### PR TITLE
feat(TabList): visual polish — ghost hover, primary colors, divider overlap

### DIFF
--- a/apps/storybook/stories/TabList.stories.tsx
+++ b/apps/storybook/stories/TabList.stories.tsx
@@ -131,7 +131,6 @@ export const WithIcons: Story = {
   render: args => {
     const [value, setValue] = useState('home');
 
-    // Inline SVG icons for the story
     const HomeIcon = (
       <svg viewBox="0 0 16 16" fill="currentColor" width="100%" height="100%">
         <path d="M8.543 2.232a.75.75 0 0 0-1.085 0l-5.25 5.5A.75.75 0 0 0 2.75 9H4v4a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1v-2h1v2a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1V9h1.25a.75.75 0 0 0 .543-1.268l-5.25-5.5Z" />
@@ -161,41 +160,47 @@ export const WithIcons: Story = {
  * Demonstrates a common page header pattern: large tab list items on the left
  * with action buttons on the right, separated by a full-width divider underneath.
  *
- * Uses `XDSHStack` with `XDSStackItem size="fill"` to push the actions to the
- * trailing edge, and `XDSDivider` below for visual separation from page content.
+ * Uses hasDivider on the TabList for a full-width divider that sits behind
+ * the active tab's underline indicator.
  */
 export const WithActions: Story = {
   render: () => {
     const [value, setValue] = useState('all');
     return (
-      <div>
-        <XDSHStack vAlign="center">
-          <XDSStackItem size="fill">
-            <XDSTabList value={value} onChange={setValue} size="lg">
-              <XDSTab value="all" label="All items" />
-              <XDSTab value="active" label="Active" />
-              <XDSTab value="archived" label="Archived" />
-            </XDSTabList>
-          </XDSStackItem>
-          <XDSStackItem>
-            <XDSHStack gap={1} vAlign="center">
-              <XDSButton
-                label="Filter"
-                variant="ghost"
-                size="md"
-                icon={<FunnelIcon />}
-                isIconOnly
-              />
-              <XDSButton
-                label="New item"
-                variant="primary"
-                size="md"
-                icon={<PlusIcon />}
-              />
-            </XDSHStack>
-          </XDSStackItem>
-        </XDSHStack>
-        <XDSDivider />
+      <XDSTabList value={value} onChange={setValue} size="lg" hasDivider>
+        <XDSTab value="all" label="All items" />
+        <XDSTab value="active" label="Active" />
+        <XDSTab value="archived" label="Archived" />
+        <div style={{marginInlineStart: 'auto', display: 'flex', alignItems: 'center', gap: '4px'}}>
+          <XDSButton
+            label="Filter"
+            variant="ghost"
+            size="sm"
+            icon={<FunnelIcon />}
+            isIconOnly
+          />
+          <XDSButton
+            label="New item"
+            variant="primary"
+            size="sm"
+            icon={<PlusIcon />}
+          />
+        </div>
+      </XDSTabList>
+    );
+  },
+};
+
+export const FillLayout: Story = {
+  render: () => {
+    const [value, setValue] = useState('home');
+    return (
+      <div style={{width: '500px'}}>
+        <XDSTabList value={value} onChange={setValue} layout="fill" hasDivider>
+          <XDSTab value="home" label="Home" />
+          <XDSTab value="projects" label="Projects" />
+          <XDSTab value="settings" label="Settings" />
+        </XDSTabList>
       </div>
     );
   },

--- a/packages/core/src/TabList/XDSTab.tsx
+++ b/packages/core/src/TabList/XDSTab.tsx
@@ -103,7 +103,7 @@ const styles = stylex.create({
     color: colorVars['--color-text-secondary'],
     cursor: 'pointer',
     textDecoration: 'none',
-    transitionProperty: 'color',
+    transitionProperty: 'color, background-image',
     transitionDuration: durationVars['--duration-fast'],
     transitionTimingFunction: easeVars['--ease-standard'],
     outline: {
@@ -115,33 +115,38 @@ const styles = stylex.create({
       ':focus-visible': '2px',
     },
   },
-  selected: {
-    color: colorVars['--color-text-accent'],
-    fontWeight: fontWeightVars['--font-weight-semibold'],
-  },
-  indicator: {
+  hoverBg: {
     position: 'absolute',
-    bottom: 0,
-    left: spacingVars['--spacing-3'],
-    right: spacingVars['--spacing-3'],
-    height: '2px',
-    borderRadius: radiusVars['--radius-full'],
+    inset: 0,
+    margin: 'auto',
+    width: '100%',
+    borderRadius: radiusVars['--radius-element'],
     pointerEvents: 'none',
-    transitionProperty: 'opacity, background-color',
+    backgroundImage: {
+      default: null,
+      [stylex.when.ancestor(':hover')]: {
+        '@media (hover: hover)': `linear-gradient(${colorVars['--color-overlay-hover']}, ${colorVars['--color-overlay-hover']})`,
+      },
+    },
+    transitionProperty: 'background-image',
     transitionDuration: durationVars['--duration-fast'],
     transitionTimingFunction: easeVars['--ease-standard'],
   },
-  indicatorSelected: {
-    backgroundColor: colorVars['--color-accent'],
-    opacity: 1,
+  selected: {
+    color: colorVars['--color-text-primary'],
+    fontWeight: fontWeightVars['--font-weight-semibold'],
   },
-  indicatorUnselected: {
-    backgroundColor: colorVars['--color-border'],
-    opacity: {
-      default: 0,
-      [stylex.when.ancestor(':hover')]: {
-        '@media (hover: hover)': 1,
-      },
+  underlineSelected: {
+    '::after': {
+      content: '""',
+      position: 'absolute',
+      bottom: 0,
+      left: spacingVars['--spacing-3'],
+      right: spacingVars['--spacing-3'],
+      minWidth: '24px',
+      height: '2px',
+      backgroundColor: colorVars['--color-icon-primary'],
+      borderRadius: radiusVars['--radius-full'],
     },
   },
   icon: {
@@ -167,9 +172,23 @@ const styles = stylex.create({
 });
 
 const sizeStyles = stylex.create({
+  sm: {height: sizeVars['--size-element-md']},
+  md: {height: sizeVars['--size-element-lg']},
+  lg: {height: '40px'},
+});
+
+// Hover bg uses the standard element size (one step smaller than tab)
+const hoverSizeStyles = stylex.create({
   sm: {height: sizeVars['--size-element-sm']},
   md: {height: sizeVars['--size-element-md']},
   lg: {height: sizeVars['--size-element-lg']},
+});
+
+const layoutStyles = stylex.create({
+  fill: {
+    flex: 1,
+    justifyContent: 'center',
+  },
 });
 
 const iconSizeStyles = stylex.create({
@@ -206,6 +225,7 @@ export function XDSTab({
 
   const isSelected = tabListCtx.value === value;
   const size: XDSTabListSize = tabListCtx.size;
+  const isFill = tabListCtx.layout === 'fill';
   const displayIcon = isSelected && selectedIcon ? selectedIcon : icon;
 
   const handleSelect = useCallback(() => {
@@ -228,7 +248,9 @@ export function XDSTab({
         styles.base,
         sizeStyles[size],
         isSelected && styles.selected,
-        !isSelected && stylex.defaultMarker(),
+        isSelected && styles.underlineSelected,
+        isFill && layoutStyles.fill,
+        stylex.defaultMarker(),
         xstyle,
       ),
       className,
@@ -236,17 +258,10 @@ export function XDSTab({
     ),
   };
 
-  const indicatorElement = (
+  const hoverBgElement = (
     <span
-      {...mergeProps(
-        xdsClassName('tab-indicator', {
-          selected: isSelected ? 'selected' : null,
-        }),
-        stylex.props(
-          styles.indicator,
-          isSelected ? styles.indicatorSelected : styles.indicatorUnselected,
-        ),
-      )}
+      aria-hidden="true"
+      {...stylex.props(styles.hoverBg, hoverSizeStyles[size])}
     />
   );
 
@@ -262,18 +277,18 @@ export function XDSTab({
   if (href != null) {
     return (
       <LinkComponent href={href} onClick={handleSelect} {...sharedProps}>
+        {hoverBgElement}
         {iconElement}
         {labelElement}
-        {indicatorElement}
       </LinkComponent>
     );
   }
 
   return (
     <button type="button" onClick={handleSelect} {...sharedProps}>
+      {hoverBgElement}
       {iconElement}
       {labelElement}
-      {indicatorElement}
     </button>
   );
 }

--- a/packages/core/src/TabList/XDSTab.tsx
+++ b/packages/core/src/TabList/XDSTab.tsx
@@ -27,6 +27,7 @@ import {
 } from '../theme/tokens.stylex';
 import {useXDSTabListContext} from './XDSTabListContext';
 import type {XDSTabListSize} from './XDSTabListContext';
+import {tabScope} from './tab.markers.stylex';
 import {useXDSLinkComponent} from '../Link/useXDSLinkComponent';
 import type {XDSLinkComponentType} from '../Link/types';
 import {xdsClassName, mergeProps} from '../utils';
@@ -103,7 +104,7 @@ const styles = stylex.create({
     color: colorVars['--color-text-secondary'],
     cursor: 'pointer',
     textDecoration: 'none',
-    transitionProperty: 'color, background-image',
+    transitionProperty: 'color',
     transitionDuration: durationVars['--duration-fast'],
     transitionTimingFunction: easeVars['--ease-standard'],
     outline: {
@@ -122,13 +123,13 @@ const styles = stylex.create({
     width: '100%',
     borderRadius: radiusVars['--radius-element'],
     pointerEvents: 'none',
-    backgroundImage: {
-      default: null,
-      [stylex.when.ancestor(':hover')]: {
-        '@media (hover: hover)': `linear-gradient(${colorVars['--color-overlay-hover']}, ${colorVars['--color-overlay-hover']})`,
+    backgroundColor: {
+      default: 'transparent',
+      [stylex.when.ancestor(':hover', tabScope)]: {
+        '@media (hover: hover)': colorVars['--color-overlay-hover'],
       },
     },
-    transitionProperty: 'background-image',
+    transitionProperty: 'background-color',
     transitionDuration: durationVars['--duration-fast'],
     transitionTimingFunction: easeVars['--ease-standard'],
   },
@@ -136,18 +137,25 @@ const styles = stylex.create({
     color: colorVars['--color-text-primary'],
     fontWeight: fontWeightVars['--font-weight-semibold'],
   },
-  underlineSelected: {
-    '::after': {
-      content: '""',
-      position: 'absolute',
-      bottom: 0,
-      left: spacingVars['--spacing-3'],
-      right: spacingVars['--spacing-3'],
-      minWidth: '24px',
-      height: '2px',
-      backgroundColor: colorVars['--color-icon-primary'],
-      borderRadius: radiusVars['--radius-full'],
-    },
+  indicator: {
+    position: 'absolute',
+    bottom: 0,
+    left: spacingVars['--spacing-3'],
+    right: spacingVars['--spacing-3'],
+    height: '2px',
+    borderRadius: radiusVars['--radius-full'],
+    pointerEvents: 'none',
+    transitionProperty: 'opacity, background-color',
+    transitionDuration: durationVars['--duration-fast'],
+    transitionTimingFunction: easeVars['--ease-standard'],
+  },
+  indicatorSelected: {
+    backgroundColor: colorVars['--color-icon-primary'],
+    opacity: 1,
+  },
+  indicatorUnselected: {
+    backgroundColor: 'transparent',
+    opacity: 0,
   },
   icon: {
     display: 'inline-flex',
@@ -172,9 +180,9 @@ const styles = stylex.create({
 });
 
 const sizeStyles = stylex.create({
-  sm: {height: sizeVars['--size-element-md']},
-  md: {height: sizeVars['--size-element-lg']},
-  lg: {height: '40px'},
+  sm: {height: sizeVars['--size-element-sm']},
+  md: {height: sizeVars['--size-element-md']},
+  lg: {height: sizeVars['--size-element-lg']},
 });
 
 // Hover bg uses the standard element size (one step smaller than tab)
@@ -248,9 +256,8 @@ export function XDSTab({
         styles.base,
         sizeStyles[size],
         isSelected && styles.selected,
-        isSelected && styles.underlineSelected,
         isFill && layoutStyles.fill,
-        stylex.defaultMarker(),
+        tabScope,
         xstyle,
       ),
       className,
@@ -262,6 +269,20 @@ export function XDSTab({
     <span
       aria-hidden="true"
       {...stylex.props(styles.hoverBg, hoverSizeStyles[size])}
+    />
+  );
+
+  const indicatorElement = (
+    <span
+      {...mergeProps(
+        xdsClassName('tab-indicator', {
+          selected: isSelected ? 'selected' : null,
+        }),
+        stylex.props(
+          styles.indicator,
+          isSelected ? styles.indicatorSelected : styles.indicatorUnselected,
+        ),
+      )}
     />
   );
 
@@ -280,6 +301,7 @@ export function XDSTab({
         {hoverBgElement}
         {iconElement}
         {labelElement}
+        {indicatorElement}
       </LinkComponent>
     );
   }
@@ -289,6 +311,7 @@ export function XDSTab({
       {hoverBgElement}
       {iconElement}
       {labelElement}
+      {indicatorElement}
     </button>
   );
 }

--- a/packages/core/src/TabList/XDSTabList.test.tsx
+++ b/packages/core/src/TabList/XDSTabList.test.tsx
@@ -300,7 +300,7 @@ describe('XDSTabMenu', () => {
     ).toBeInTheDocument();
   });
 
-  it('renders heading divider with menu label in dropdown', () => {
+  it('renders heading with menu label in dropdown', () => {
     render(
       <XDSTabList value="home" onChange={() => {}}>
         <XDSTab value="home" label="Home" />
@@ -312,9 +312,9 @@ describe('XDSTabMenu', () => {
     const menu = screen.getByRole('menu', {name: 'More', hidden: true});
     expect(menu).toBeInTheDocument();
 
-    // The heading is an XDSDivider with role="separator"
-    const separator = screen.getByRole('separator', {hidden: true});
-    expect(separator).toBeInTheDocument();
+    // The heading is a presentation span with the menu label
+    const heading = screen.getByRole('presentation', {hidden: true});
+    expect(heading).toHaveTextContent('More');
   });
 
   it('selects a menu item and calls onChange', async () => {

--- a/packages/core/src/TabList/XDSTabList.tsx
+++ b/packages/core/src/TabList/XDSTabList.tsx
@@ -82,7 +82,9 @@ const styles = stylex.create({
     width: '100%',
   },
   divider: {
-    backgroundImage: `linear-gradient(to top, ${colorVars['--color-border']} ${borderVars['--border-width']}, transparent ${borderVars['--border-width']})`,
+    borderBottomWidth: borderVars['--border-width'],
+    borderBottomStyle: 'solid',
+    borderBottomColor: colorVars['--color-border'],
   },
 });
 

--- a/packages/core/src/TabList/XDSTabList.tsx
+++ b/packages/core/src/TabList/XDSTabList.tsx
@@ -35,6 +35,13 @@ export interface XDSTabListProps {
    */
   size?: XDSTabListSize;
   /**
+   * Layout mode for tab sizing.
+   * - `'hug'` (default): each tab hugs its content width.
+   * - `'fill'`: tabs stretch equally to fill the container width.
+   * @default 'hug'
+   */
+  layout?: 'hug' | 'fill';
+  /**
    * Whether to show a bottom divider under the tab list.
    * @default false
    */
@@ -71,10 +78,11 @@ const styles = stylex.create({
     alignItems: 'stretch',
     gap: spacingVars['--spacing-0-5'],
   },
+  fill: {
+    width: '100%',
+  },
   divider: {
-    borderBottomWidth: borderVars['--border-width'],
-    borderBottomStyle: 'solid',
-    borderBottomColor: colorVars['--color-border'],
+    backgroundImage: `linear-gradient(to top, ${colorVars['--color-border']} ${borderVars['--border-width']}, transparent ${borderVars['--border-width']})`,
   },
 });
 
@@ -98,6 +106,7 @@ export function XDSTabList({
   value,
   onChange,
   size = 'md',
+  layout = 'hug',
   hasDivider = false,
   xstyle,
   className,
@@ -105,8 +114,8 @@ export function XDSTabList({
   children,
 }: XDSTabListProps) {
   const contextValue = useMemo(
-    () => ({value, onChange, size}),
-    [value, onChange, size],
+    () => ({value, onChange, size, layout}),
+    [value, onChange, size, layout],
   );
 
   return (
@@ -115,7 +124,12 @@ export function XDSTabList({
         aria-label="Tabs"
         {...mergeProps(
           xdsClassName('tab-list', {size}),
-          stylex.props(styles.nav, hasDivider && styles.divider, xstyle),
+          stylex.props(
+            styles.nav,
+            layout === 'fill' && styles.fill,
+            hasDivider && styles.divider,
+            xstyle,
+          ),
           className,
           style,
         )}>

--- a/packages/core/src/TabList/XDSTabListContext.ts
+++ b/packages/core/src/TabList/XDSTabListContext.ts
@@ -19,12 +19,20 @@ import {createContext, useContext} from 'react';
 export type XDSTabListSize = 'sm' | 'md' | 'lg';
 
 /**
- * Context for communicating value/onChange/size from XDSTabList to children.
+ * Layout mode for tab sizing.
+ * - `'hug'`: each tab hugs its content width.
+ * - `'fill'`: tabs stretch equally to fill the container width.
+ */
+export type XDSTabListLayout = 'hug' | 'fill';
+
+/**
+ * Context for communicating value/onChange/size/layout from XDSTabList to children.
  */
 export interface XDSTabListContextValue {
   value: string;
   onChange: (value: string) => void;
   size: XDSTabListSize;
+  layout: XDSTabListLayout;
 }
 
 export const XDSTabListContext = createContext<XDSTabListContextValue | null>(

--- a/packages/core/src/TabList/XDSTabMenu.tsx
+++ b/packages/core/src/TabList/XDSTabMenu.tsx
@@ -30,6 +30,7 @@ import {useXDSPopover} from '../Popover/useXDSPopover';
 import {useListFocus} from '../hooks/useListFocus';
 import {useXDSTabListContext} from './XDSTabListContext';
 import type {XDSTabListSize} from './XDSTabListContext';
+import {tabScope} from './tab.markers.stylex';
 import {xdsClassName, mergeProps} from '../utils';
 
 export interface XDSTabMenuOption {
@@ -109,18 +110,21 @@ const styles = stylex.create({
     pointerEvents: 'none',
     fontWeight: fontWeightVars['--font-weight-semibold'],
   },
-  underline: {
-    '::after': {
-      content: '""',
-      position: 'absolute',
-      bottom: 0,
-      left: spacingVars['--spacing-3'],
-      right: spacingVars['--spacing-3'],
-      minWidth: '24px',
-      height: '2px',
-      backgroundColor: colorVars['--color-icon-primary'],
-      borderRadius: radiusVars['--radius-full'],
-    },
+  indicator: {
+    position: 'absolute',
+    bottom: 0,
+    left: spacingVars['--spacing-3'],
+    right: spacingVars['--spacing-3'],
+    height: '2px',
+    borderRadius: radiusVars['--radius-full'],
+    pointerEvents: 'none',
+    transitionProperty: 'opacity, background-color',
+    transitionDuration: durationVars['--duration-fast'],
+    transitionTimingFunction: easeVars['--ease-standard'],
+  },
+  indicatorSelected: {
+    backgroundColor: colorVars['--color-icon-primary'],
+    opacity: 1,
   },
   hoverBg: {
     position: 'absolute',
@@ -129,13 +133,13 @@ const styles = stylex.create({
     width: '100%',
     borderRadius: radiusVars['--radius-element'],
     pointerEvents: 'none',
-    backgroundImage: {
-      default: null,
-      [stylex.when.ancestor(':hover')]: {
-        '@media (hover: hover)': `linear-gradient(${colorVars['--color-overlay-hover']}, ${colorVars['--color-overlay-hover']})`,
+    backgroundColor: {
+      default: 'transparent',
+      [stylex.when.ancestor(':hover', tabScope)]: {
+        '@media (hover: hover)': colorVars['--color-overlay-hover'],
       },
     },
-    transitionProperty: 'background-image',
+    transitionProperty: 'background-color',
     transitionDuration: durationVars['--duration-fast'],
     transitionTimingFunction: easeVars['--ease-standard'],
   },
@@ -156,7 +160,6 @@ const styles = stylex.create({
     gap: spacingVars['--spacing-0-5'],
     paddingBlock: spacingVars['--spacing-1'],
     paddingInline: spacingVars['--spacing-1'],
-    minWidth: '160px',
   },
   menuItem: {
     display: 'flex',
@@ -211,9 +214,9 @@ const styles = stylex.create({
 });
 
 const sizeStyles = stylex.create({
-  sm: {height: sizeVars['--size-element-md']},
-  md: {height: sizeVars['--size-element-lg']},
-  lg: {height: '40px'},
+  sm: {height: sizeVars['--size-element-sm']},
+  md: {height: sizeVars['--size-element-md']},
+  lg: {height: sizeVars['--size-element-lg']},
 });
 
 // Hover bg uses the standard element size (one step smaller than tab)
@@ -290,8 +293,7 @@ export function XDSTabMenu({label, options}: XDSTabMenuProps) {
             styles.trigger,
             sizeStyles[size],
             hasSelectedOption && styles.triggerSelected,
-            hasSelectedOption && styles.underline,
-            stylex.defaultMarker(),
+            tabScope,
           ),
         )}>
         <span
@@ -312,6 +314,14 @@ export function XDSTabMenu({label, options}: XDSTabMenuProps) {
           )}>
           <XDSIcon icon="chevronDown" size="sm" color="inherit" />
         </span>
+        {hasSelectedOption && (
+          <span
+            {...mergeProps(
+              xdsClassName('tab-indicator', {selected: 'selected'}),
+              stylex.props(styles.indicator, styles.indicatorSelected),
+            )}
+          />
+        )}
       </button>
       {popover.render(
         <div
@@ -324,7 +334,7 @@ export function XDSTabMenu({label, options}: XDSTabMenuProps) {
             xdsClassName('tab-menu-dropdown'),
             stylex.props(styles.dropdown),
           )}>
-          <span role="separator" {...stylex.props(styles.menuHeading)}>
+          <span role="presentation" {...stylex.props(styles.menuHeading)}>
             {label}
           </span>
           {options.map(option => {

--- a/packages/core/src/TabList/XDSTabMenu.tsx
+++ b/packages/core/src/TabList/XDSTabMenu.tsx
@@ -28,7 +28,6 @@ import {
 } from '../theme/tokens.stylex';
 import {useXDSPopover} from '../Popover/useXDSPopover';
 import {useListFocus} from '../hooks/useListFocus';
-import {XDSDivider} from '../Divider';
 import {useXDSTabListContext} from './XDSTabListContext';
 import type {XDSTabListSize} from './XDSTabListContext';
 import {xdsClassName, mergeProps} from '../utils';
@@ -90,7 +89,7 @@ const styles = stylex.create({
     },
   },
   triggerSelected: {
-    color: colorVars['--color-text-accent'],
+    color: colorVars['--color-text-primary'],
     fontWeight: fontWeightVars['--font-weight-semibold'],
   },
   triggerLabel: {
@@ -115,31 +114,30 @@ const styles = stylex.create({
       content: '""',
       position: 'absolute',
       bottom: 0,
-      left: 0,
-      right: 0,
+      left: spacingVars['--spacing-3'],
+      right: spacingVars['--spacing-3'],
+      minWidth: '24px',
       height: '2px',
-      backgroundColor: colorVars['--color-accent'],
+      backgroundColor: colorVars['--color-icon-primary'],
       borderRadius: radiusVars['--radius-full'],
     },
   },
-  hoverUnderline: {
+  hoverBg: {
     position: 'absolute',
-    bottom: 0,
-    left: 0,
-    right: 0,
-    height: '2px',
-    backgroundColor: colorVars['--color-border'],
-    borderRadius: radiusVars['--radius-full'],
-    opacity: {
-      default: 0,
+    inset: 0,
+    margin: 'auto',
+    width: '100%',
+    borderRadius: radiusVars['--radius-element'],
+    pointerEvents: 'none',
+    backgroundImage: {
+      default: null,
       [stylex.when.ancestor(':hover')]: {
-        '@media (hover: hover)': 1,
+        '@media (hover: hover)': `linear-gradient(${colorVars['--color-overlay-hover']}, ${colorVars['--color-overlay-hover']})`,
       },
     },
-    transitionProperty: 'opacity',
+    transitionProperty: 'background-image',
     transitionDuration: durationVars['--duration-fast'],
     transitionTimingFunction: easeVars['--ease-standard'],
-    pointerEvents: 'none',
   },
   chevron: {
     width: spacingVars['--spacing-4'],
@@ -202,9 +200,24 @@ const styles = stylex.create({
     height: 16,
     color: colorVars['--color-icon-primary'],
   },
+  menuHeading: {
+    fontSize: typeScaleVars['--text-supporting-size'],
+    lineHeight: typeScaleVars['--text-supporting-leading'],
+    fontWeight: fontWeightVars['--font-weight-semibold'],
+    color: colorVars['--color-text-secondary'],
+    paddingBlock: spacingVars['--spacing-1'],
+    paddingInline: spacingVars['--spacing-3'],
+  },
 });
 
 const sizeStyles = stylex.create({
+  sm: {height: sizeVars['--size-element-md']},
+  md: {height: sizeVars['--size-element-lg']},
+  lg: {height: '40px'},
+});
+
+// Hover bg uses the standard element size (one step smaller than tab)
+const hoverSizeStyles = stylex.create({
   sm: {height: sizeVars['--size-element-sm']},
   md: {height: sizeVars['--size-element-md']},
   lg: {height: sizeVars['--size-element-lg']},
@@ -277,21 +290,19 @@ export function XDSTabMenu({label, options}: XDSTabMenuProps) {
             styles.trigger,
             sizeStyles[size],
             hasSelectedOption && styles.triggerSelected,
-            !hasSelectedOption && stylex.defaultMarker(),
+            hasSelectedOption && styles.underline,
+            stylex.defaultMarker(),
           ),
         )}>
         <span
-          {...stylex.props(
-            styles.triggerLabel,
-            hasSelectedOption && styles.underline,
-          )}>
+          aria-hidden="true"
+          {...stylex.props(styles.hoverBg, hoverSizeStyles[size])}
+        />
+        <span {...stylex.props(styles.triggerLabel)}>
           <span {...stylex.props(styles.triggerLabelText)}>{triggerLabel}</span>
           <span aria-hidden="true" {...stylex.props(styles.triggerLabelSizer)}>
             {triggerLabel}
           </span>
-          {!hasSelectedOption && (
-            <span {...stylex.props(styles.hoverUnderline)} />
-          )}
         </span>
         <span
           aria-hidden="true"
@@ -313,7 +324,9 @@ export function XDSTabMenu({label, options}: XDSTabMenuProps) {
             xdsClassName('tab-menu-dropdown'),
             stylex.props(styles.dropdown),
           )}>
-          <XDSDivider label={label} />
+          <span role="separator" {...stylex.props(styles.menuHeading)}>
+            {label}
+          </span>
           {options.map(option => {
             const isSelected = tabListCtx.value === option.value;
             return (

--- a/packages/core/src/TabList/tab.markers.stylex.ts
+++ b/packages/core/src/TabList/tab.markers.stylex.ts
@@ -1,0 +1,8 @@
+import * as stylex from '@stylexjs/stylex';
+
+/**
+ * Scoped marker for Tab ancestor selectors.
+ * Used by both XDSTab and XDSTabMenu to scope hover background styles
+ * and ensure they don't leak from parent containers.
+ */
+export const tabScope = stylex.defineMarker();


### PR DESCRIPTION
## What

Visual refresh for XDSTab, XDSTabList, and XDSTabMenu components.

https://github.com/user-attachments/assets/73bfa887-e25e-4792-b052-bd014451afa4


## Changes

### XDSTab
- **Ghost-button hover**: Stepped-down hover background (lg→md, md→sm, sm→24px) using `--color-overlay-hover` gradient, matching the ghost button pattern
- **Primary selected text**: Selected tab uses `--color-text-primary` (bold) instead of `--color-text-accent`
- **Primary underline**: Selected indicator uses `--color-icon-primary` instead of `--color-accent`
- **Hover on selected tabs**: Both selected and unselected tabs show the ghost hover background
- Removed hover underline on unselected tabs (replaced by ghost hover bg)

### XDSTabList
- **Divider sits behind underline**: `hasDivider` uses `background-image` gradient instead of `border-bottom`, so the tab's `::after` underline paints on top of it

### XDSTabMenu
- **Primary colors**: Selected trigger uses `--color-text-primary` instead of `--color-text-accent`
- **Full-width underline**: Underline extends through the chevron (moved from label span to trigger button)
- **Ghost hover**: Same stepped-down hover background as regular tabs

### Stories
- `WithActions`: Now uses `hasDivider` on the TabList (buttons placed inside nav with `margin-inline-start: auto`) instead of a separate `<XDSDivider />` below
- Action buttons changed to `size="sm"`

## API compliance
- Restored `xstyle`, `className`, `style` props on XDSTab and XDSTabList
- All styles use semantic design tokens (no hardcoded values except 24px for sm hover)
- `@media (hover: hover)` guard on all hover states