### PR TITLE
docs(common-props): add missing xstyle prop to Spinner, TabList, TextArea, TimeInput

### DIFF
--- a/packages/core/src/Spinner/Spinner.doc.mjs
+++ b/packages/core/src/Spinner/Spinner.doc.mjs
@@ -38,6 +38,12 @@ export const docs = {
         'Accessible name for screen readers. Defaults to label (if string) or "Loading".',
       default: "'Loading'",
     },
+    {
+      name: 'xstyle',
+      type: 'StyleXStyles',
+      description:
+        'StyleX styles for layout customization (margins, positioning, sizing). Must be a stylex.create() value — not an inline style object like style={{}}.',
+    },
   ],
   examples: [
     {
@@ -128,6 +134,12 @@ export const docsZh = {
       description: '屏幕阅读器的无障碍名称。默认为 label（如果是字符串）或 "Loading"。',
       default: "'Loading'",
     },
+    {
+      name: 'xstyle',
+      type: 'StyleXStyles',
+      description:
+        'StyleX 样式，用于布局自定义（边距、定位、尺寸）。必须是 stylex.create() 的值，而非内联样式对象如 style={{}}。',
+    },
   ],
   examples: [
     {
@@ -194,5 +206,6 @@ export const docsDense = {
     shade: 'Color shade for light or dark backgrounds.',
     label: 'Visible content below spinner. String auto-sets aria-label.',
     'aria-label': 'A11y name for screen readers. Defaults to label or "Loading".',
+    xstyle: 'StyleX styles for layout customization. Must be stylex.create() value, not inline style.',
   },
 };

--- a/packages/core/src/TabList/TabList.doc.mjs
+++ b/packages/core/src/TabList/TabList.doc.mjs
@@ -128,6 +128,12 @@ export const docs = {
           description: 'XDSTab and XDSTabMenu items to render inside the nav.',
           required: true,
         },
+        {
+          name: 'xstyle',
+          type: 'StyleXStyles',
+          description:
+            'StyleX styles for layout customization (margins, positioning, sizing). Must be a stylex.create() value — not an inline style object like style={{}}.',
+        },
       ],
       examples: [
         {
@@ -186,6 +192,12 @@ export const docs = {
           type: 'ReactNode',
           description:
             'Icon element shown when the tab is selected; falls back to icon if not provided.',
+        },
+        {
+          name: 'xstyle',
+          type: 'StyleXStyles',
+          description:
+            'StyleX styles for layout customization (margins, positioning, sizing). Must be a stylex.create() value — not an inline style object like style={{}}.',
         },
       ],
       examples: [
@@ -388,6 +400,12 @@ export const docsZh = {
           description: '在 nav 内渲染的 XDSTab 和 XDSTabMenu 项。',
           required: true,
         },
+        {
+          name: 'xstyle',
+          type: 'StyleXStyles',
+          description:
+            'StyleX 样式，用于布局自定义（边距、定位、尺寸）。必须是 stylex.create() 的值，而非内联样式对象如 style={{}}。',
+        },
       ],
       examples: [
         {
@@ -446,6 +464,12 @@ export const docsZh = {
           type: 'ReactNode',
           description:
             '标签选中时显示的图标元素；未提供时回退到 icon。',
+        },
+        {
+          name: 'xstyle',
+          type: 'StyleXStyles',
+          description:
+            'StyleX 样式，用于布局自定义（边距、定位、尺寸）。必须是 stylex.create() 的值，而非内联样式对象如 style={{}}。',
         },
       ],
       examples: [
@@ -548,6 +572,7 @@ export const docsDense = {
         size: 'Size variant applied to all child tabs.',
         hasDivider: 'Show bottom border divider under tab list.',
         children: 'XDSTab + XDSTabMenu items inside nav.',
+        xstyle: 'StyleX styles for layout customization. Must be stylex.create() value, not inline style.',
       },
     },
     {
@@ -560,6 +585,7 @@ export const docsDense = {
         as: 'Custom link component overriding XDSLinkProvider; only w/ href.',
         icon: 'Icon shown when not selected.',
         selectedIcon: 'Icon shown when selected; falls back to icon.',
+        xstyle: 'StyleX styles for layout customization. Must be stylex.create() value, not inline style.',
       },
     },
     {

--- a/packages/core/src/TextArea/TextArea.doc.mjs
+++ b/packages/core/src/TextArea/TextArea.doc.mjs
@@ -195,6 +195,12 @@ export const docs = {
       type: '(e: FocusEvent<HTMLTextAreaElement>) => void',
       description: 'Callback fired when the textarea loses focus.',
     },
+    {
+      name: 'xstyle',
+      type: 'StyleXStyles',
+      description:
+        'StyleX styles for layout customization (margins, positioning, sizing). Must be a stylex.create() value — not an inline style object like style={{}}.',
+    },
   ],
   theming: {
     targets: [
@@ -426,6 +432,12 @@ export const docsZh = {
       type: '(e: FocusEvent<HTMLTextAreaElement>) => void',
       description: '文本域失去焦点时触发的回调。',
     },
+    {
+      name: 'xstyle',
+      type: 'StyleXStyles',
+      description:
+        'StyleX 样式，用于布局自定义（边距、定位、尺寸）。必须是 stylex.create() 的值，而非内联样式对象如 style={{}}。',
+    },
   ],
   theming: {
     targets: [
@@ -511,5 +523,6 @@ export const docsDense = {
     htmlName: 'HTML name attr for form submissions.',
     onFocus: 'Callback on focus.',
     onBlur: 'Callback on blur.',
+    xstyle: 'StyleX styles for layout customization. Must be stylex.create() value, not inline style.',
   },
 };

--- a/packages/core/src/TimeInput/TimeInput.doc.mjs
+++ b/packages/core/src/TimeInput/TimeInput.doc.mjs
@@ -192,6 +192,12 @@ export const docs = {
       description:
         'Tooltip text rendered as an info icon at the end of the label row.',
     },
+    {
+      name: 'xstyle',
+      type: 'StyleXStyles',
+      description:
+        'StyleX styles for layout customization (margins, positioning, sizing). Must be a stylex.create() value — not an inline style object like style={{}}.',
+    },
   ],
   accessibility: [
     'The visible label is associated with the input via htmlFor / id.',
@@ -409,6 +415,12 @@ export const docsZh = {
       description:
         '在标签行末尾以信息图标形式渲染的工具提示文本。',
     },
+    {
+      name: 'xstyle',
+      type: 'StyleXStyles',
+      description:
+        'StyleX 样式，用于布局自定义（边距、定位、尺寸）。必须是 stylex.create() 的值，而非内联样式对象如 style={{}}。',
+    },
   ],
   accessibility: [
     '可见标签通过 htmlFor / id 与输入框关联。',
@@ -472,5 +484,6 @@ export const docsDense = {
     size: 'Input element height.',
     status: 'Colored border+icon. Message rendered below input.',
     labelTooltip: 'Tooltip as info icon at label row end.',
+    xstyle: 'StyleX styles for layout customization. Must be stylex.create() value, not inline style.',
   },
 };


### PR DESCRIPTION
## What

Four components had `xstyle` in their TypeScript interface but missing from their `.doc.mjs` props arrays. LLMs consuming CLI output (via `xds component <Name> --props`) wouldn't see that these components support StyleX layout overrides — a common source of incorrect inline style usage.

### Components fixed

| Component | File | Sections updated |
|-----------|------|-----------------|
| Spinner | `Spinner.doc.mjs` | English props, Chinese props, dense propDescriptions |
| XDSTabList | `TabList.doc.mjs` | English component props, Chinese component props, dense propDescriptions |
| XDSTab | `TabList.doc.mjs` | English component props, Chinese component props, dense propDescriptions |
| TextArea | `TextArea.doc.mjs` | English props, Chinese props, dense propDescriptions |
| TimeInput | `TimeInput.doc.mjs` | English props, Chinese props, dense propDescriptions |

### Why this matters

LLMs frequently pass inline style objects to `xstyle` (e.g., `xstyle={{ marginTop: 8 }}`). The doc entry explicitly states that only `stylex.create()` values are valid, which helps LLMs generate correct code.

## Checklist
- [x] `yarn workspace @xds/core typecheck:docs` passes
- [x] CLI `--props` output verified for all 4 components
- [x] No Storybook ```tsx` in docblocks
- [x] Common props (`xstyle`) documented consistently across English, Chinese, and dense sections

---
*Night Watch Doc Reviewer*