### PR TITLE
fix: component audit — PowerSearch token, RadioList exports

### DIFF
--- a/packages/core/src/PowerSearch/XDSPowerSearch.tsx
+++ b/packages/core/src/PowerSearch/XDSPowerSearch.tsx
@@ -33,7 +33,12 @@ import type {XDSIconType} from '../Icon';
 import type {XDSIconName} from '../Icon/globalIconRegistry';
 import type {XDSInputStatus} from '../Field';
 import {useXDSPopover} from '../Popover/useXDSPopover';
-import {spacingVars, colorVars, typeScaleVars} from '../theme/tokens.stylex';
+import {
+  spacingVars,
+  colorVars,
+  typeScaleVars,
+  fontWeightVars,
+} from '../theme/tokens.stylex';
 import {useInternalConfig} from './useInternalConfig';
 import {usePowerSearchSource} from './usePowerSearchSource';
 import {formatFilterValue} from './formatFilterValue';
@@ -78,7 +83,7 @@ const OPERATOR_VALUE_TYPE_TO_ICON: Record<string, XDSIconName> = {
 
 const tokenValueStyles = stylex.create({
   value: {
-    fontWeight: 'bold',
+    fontWeight: fontWeightVars['--font-weight-bold'],
   },
 });
 

--- a/packages/core/src/RadioList/index.ts
+++ b/packages/core/src/RadioList/index.ts
@@ -9,7 +9,11 @@
  * SYNC: When modified, update this header
  */
 
-export {XDSRadioList} from './XDSRadioList';
-export type {XDSRadioListProps, XDSRadioListSize} from './XDSRadioList';
+export {XDSRadioList, XDSRadioListContext} from './XDSRadioList';
+export type {
+  XDSRadioListProps,
+  XDSRadioListSize,
+  XDSRadioListContextValue,
+} from './XDSRadioList';
 export {XDSRadioListItem} from './XDSRadioListItem';
 export type {XDSRadioListItemProps} from './XDSRadioListItem';


### PR DESCRIPTION
## Component Audit — 2026-04-14

**Components audited:** Popover, PowerSearch, ProgressBar, RadioList, Section

### Fixes

1. **PowerSearch: hardcoded fontWeight** — replaced raw `bold` with `fontWeightVars["--font-weight-bold"]` token (line 81)
2. **RadioList: missing context exports** — exported `XDSRadioListContext` and `XDSRadioListContextValue` from index.ts for consumer extensibility

### Clean Components
- **Popover** — tokens correct, xdsClassName on content div, ARIA button+dialog pattern solid, exports complete
- **ProgressBar** — semantic type scale tokens used, xdsClassName on root + fill, a11y complete (role=meter/progressbar), exports clean  
- **Section** — tokens correct, xdsClassName on inner visual container (not outer wrapper), XDSBaseProps extended, exports clean

### Needs Review
- **ProgressBar/Section variant maps**: Both have extensible VariantMap interfaces for type augmentation, but runtime variantStyles[variant] is a hardcoded stylex.create() map. Theme-extended variants would return undefined at runtime. xdsClassName provides CSS targeting as an alternative path. Design decision needed.
- **Popover/PowerSearch/RadioList props**: Manual xstyle/className/style definition instead of extending XDSBaseProps. Functionally equivalent but diverges from convention. Low priority.

---
