### PR TITLE
feat(AlertDialog): add XDSAlertDialog confirmation dialog

### DIFF
--- a/apps/storybook/stories/AlertDialog.stories.tsx
+++ b/apps/storybook/stories/AlertDialog.stories.tsx
@@ -22,143 +22,148 @@ const meta: Meta<typeof XDSAlertDialog> = {
 export default meta;
 type Story = StoryObj<typeof XDSAlertDialog>;
 
-function DeleteExample() {
-  const [isOpen, setIsOpen] = useState(false);
-  return (
-    <>
-      <XDSButton
-        label="Delete item"
-        variant="danger"
-        onClick={() => setIsOpen(true)}
-      />
-      <XDSAlertDialog
-        isOpen={isOpen}
-        onOpenChange={setIsOpen}
-        title="Delete item?"
-        description="This action cannot be undone. The item and all its data will be permanently removed."
-        cancel={<XDSButton variant="secondary" label="Cancel" />}
-        action={
-          <XDSButton
-            variant="danger"
-            label="Delete"
-            onClick={() => setIsOpen(false)}
-          />
-        }
-      />
-    </>
-  );
-}
-
+/**
+ * Delete confirmation — the most common alert dialog pattern.
+ */
 export const Delete: Story = {
-  render: () => <DeleteExample />,
+  render: () => {
+    const [isOpen, setIsOpen] = useState(false);
+    return (
+      <>
+        <XDSButton
+          label="Delete item"
+          variant="danger"
+          onClick={() => setIsOpen(true)}
+        />
+        <XDSAlertDialog
+          isOpen={isOpen}
+          onOpenChange={setIsOpen}
+          title="Delete item?"
+          description="This action cannot be undone. The item and all its data will be permanently removed."
+          cancel={<XDSButton variant="secondary" label="Cancel" />}
+          action={
+            <XDSButton
+              variant="danger"
+              label="Delete"
+              onClick={() => setIsOpen(false)}
+            />
+          }
+        />
+      </>
+    );
+  },
 };
 
-function AsyncExample() {
-  const [isOpen, setIsOpen] = useState(false);
-  const [isLoading, setIsLoading] = useState(false);
-
-  const handleRevoke = async () => {
-    setIsLoading(true);
-    await new Promise(resolve => setTimeout(resolve, 2000));
-    setIsLoading(false);
-    setIsOpen(false);
-  };
-
-  return (
-    <>
-      <XDSButton
-        label="Revoke access"
-        variant="danger"
-        onClick={() => setIsOpen(true)}
-      />
-      <XDSAlertDialog
-        isOpen={isOpen}
-        onOpenChange={setIsOpen}
-        title="Revoke access?"
-        description="This user will immediately lose access to all shared resources."
-        cancel={
-          <XDSButton
-            variant="secondary"
-            label="Cancel"
-            isDisabled={isLoading}
-          />
-        }
-        action={
-          <XDSButton
-            variant="danger"
-            label="Revoke"
-            isLoading={isLoading}
-            onClick={handleRevoke}
-          />
-        }
-      />
-    </>
-  );
-}
-
+/**
+ * Async action with loading state.
+ * The action button shows a loading spinner while the operation completes.
+ */
 export const Async: Story = {
-  render: () => <AsyncExample />,
+  render: () => {
+    const [isOpen, setIsOpen] = useState(false);
+    const [isLoading, setIsLoading] = useState(false);
+
+    const handleRevoke = async () => {
+      setIsLoading(true);
+      await new Promise(resolve => setTimeout(resolve, 2000));
+      setIsLoading(false);
+      setIsOpen(false);
+    };
+
+    return (
+      <>
+        <XDSButton
+          label="Revoke access"
+          variant="danger"
+          onClick={() => setIsOpen(true)}
+        />
+        <XDSAlertDialog
+          isOpen={isOpen}
+          onOpenChange={setIsOpen}
+          title="Revoke access?"
+          description="This user will immediately lose access to all shared resources."
+          cancel={
+            <XDSButton
+              variant="secondary"
+              label="Cancel"
+              isDisabled={isLoading}
+            />
+          }
+          action={
+            <XDSButton
+              variant="danger"
+              label="Revoke"
+              isLoading={isLoading}
+              onClick={handleRevoke}
+            />
+          }
+        />
+      </>
+    );
+  },
 };
 
-function InformationalExample() {
-  const [isOpen, setIsOpen] = useState(false);
-  return (
-    <>
-      <XDSButton
-        label="Show notice"
-        variant="secondary"
-        onClick={() => setIsOpen(true)}
-      />
-      <XDSAlertDialog
-        isOpen={isOpen}
-        onOpenChange={setIsOpen}
-        title="Session expired"
-        description="Your session has expired. You will be redirected to the login page."
-        cancel={<XDSButton variant="secondary" label="Cancel" />}
-        action={
-          <XDSButton
-            variant="primary"
-            label="Sign in"
-            onClick={() => setIsOpen(false)}
-          />
-        }
-      />
-    </>
-  );
-}
-
+/**
+ * Informational alert — no destructive action, just acknowledgment.
+ */
 export const Informational: Story = {
-  render: () => <InformationalExample />,
+  render: () => {
+    const [isOpen, setIsOpen] = useState(false);
+    return (
+      <>
+        <XDSButton
+          label="Show notice"
+          variant="secondary"
+          onClick={() => setIsOpen(true)}
+        />
+        <XDSAlertDialog
+          isOpen={isOpen}
+          onOpenChange={setIsOpen}
+          title="Session expired"
+          description="Your session has expired. You will be redirected to the login page."
+          cancel={<XDSButton variant="secondary" label="Cancel" />}
+          action={
+            <XDSButton
+              variant="primary"
+              label="Sign in"
+              onClick={() => setIsOpen(false)}
+            />
+          }
+        />
+      </>
+    );
+  },
 };
 
-function WideExample() {
-  const [isOpen, setIsOpen] = useState(false);
-  return (
-    <>
-      <XDSButton
-        label="Reset all settings"
-        variant="danger"
-        onClick={() => setIsOpen(true)}
-      />
-      <XDSAlertDialog
-        isOpen={isOpen}
-        onOpenChange={setIsOpen}
-        title="Reset all settings?"
-        description="This will restore all preferences, themes, and configurations to their factory defaults. Any custom settings will be permanently lost."
-        cancel={<XDSButton variant="secondary" label="Keep settings" />}
-        action={
-          <XDSButton
-            variant="danger"
-            label="Reset everything"
-            onClick={() => setIsOpen(false)}
-          />
-        }
-        width={500}
-      />
-    </>
-  );
-}
-
+/**
+ * Custom width dialog.
+ */
 export const Wide: Story = {
-  render: () => <WideExample />,
+  render: () => {
+    const [isOpen, setIsOpen] = useState(false);
+    return (
+      <>
+        <XDSButton
+          label="Reset all settings"
+          variant="danger"
+          onClick={() => setIsOpen(true)}
+        />
+        <XDSAlertDialog
+          isOpen={isOpen}
+          onOpenChange={setIsOpen}
+          title="Reset all settings?"
+          description="This will restore all preferences, themes, and configurations to their factory defaults. Any custom settings will be permanently lost."
+          cancel={<XDSButton variant="secondary" label="Keep settings" />}
+          action={
+            <XDSButton
+              variant="danger"
+              label="Reset everything"
+              onClick={() => setIsOpen(false)}
+            />
+          }
+          width={500}
+        />
+      </>
+    );
+  },
 };

--- a/apps/storybook/stories/AlertDialog.stories.tsx
+++ b/apps/storybook/stories/AlertDialog.stories.tsx
@@ -15,7 +15,7 @@ const meta: Meta<typeof XDSAlertDialog> = {
     width: {control: 'number'},
     actionVariant: {
       control: 'select',
-      options: ['danger', 'primary', 'secondary', 'ghost'],
+      options: ['destructive', 'primary', 'secondary', 'ghost'],
     },
   },
 };
@@ -33,7 +33,7 @@ export const Delete: Story = {
       <>
         <XDSButton
           label="Delete item"
-          variant="danger"
+          variant="destructive"
           onClick={() => setIsOpen(true)}
         />
         <XDSAlertDialog
@@ -61,7 +61,7 @@ export const Async: Story = {
       <>
         <XDSButton
           label="Revoke access"
-          variant="danger"
+          variant="destructive"
           onClick={() => setIsOpen(true)}
         />
         <XDSAlertDialog
@@ -120,7 +120,7 @@ export const Imperative: Story = {
       <>
         <XDSButton
           label="Delete item"
-          variant="danger"
+          variant="destructive"
           onClick={() =>
             alert.show({
               title: 'Delete item?',

--- a/apps/storybook/stories/AlertDialog.stories.tsx
+++ b/apps/storybook/stories/AlertDialog.stories.tsx
@@ -1,6 +1,9 @@
 import {useState} from 'react';
 import type {Meta, StoryObj} from '@storybook/react';
-import {XDSAlertDialog} from '@xds/core/AlertDialog';
+import {
+  XDSAlertDialog,
+  useXDSImperativeAlertDialog,
+} from '@xds/core/AlertDialog';
 import {XDSButton} from '@xds/core/Button';
 
 const meta: Meta<typeof XDSAlertDialog> = {
@@ -8,13 +11,11 @@ const meta: Meta<typeof XDSAlertDialog> = {
   component: XDSAlertDialog,
   tags: ['autodocs'],
   argTypes: {
-    isOpen: {
-      control: 'boolean',
-      description: 'Whether the dialog is shown',
-    },
-    width: {
-      control: 'number',
-      description: 'Width of the dialog (default: 400)',
+    isOpen: {control: 'boolean'},
+    width: {control: 'number'},
+    actionVariant: {
+      control: 'select',
+      options: ['danger', 'primary', 'secondary', 'ghost'],
     },
   },
 };
@@ -40,14 +41,8 @@ export const Delete: Story = {
           onOpenChange={setIsOpen}
           title="Delete item?"
           description="This action cannot be undone. The item and all its data will be permanently removed."
-          cancel={<XDSButton variant="secondary" label="Cancel" />}
-          action={
-            <XDSButton
-              variant="danger"
-              label="Delete"
-              onClick={() => setIsOpen(false)}
-            />
-          }
+          actionLabel="Delete"
+          onAction={() => setIsOpen(false)}
         />
       </>
     );
@@ -56,19 +51,11 @@ export const Delete: Story = {
 
 /**
  * Async action with loading state.
- * The action button shows a loading spinner while the operation completes.
  */
 export const Async: Story = {
   render: () => {
     const [isOpen, setIsOpen] = useState(false);
     const [isLoading, setIsLoading] = useState(false);
-
-    const handleRevoke = async () => {
-      setIsLoading(true);
-      await new Promise(resolve => setTimeout(resolve, 2000));
-      setIsLoading(false);
-      setIsOpen(false);
-    };
 
     return (
       <>
@@ -82,21 +69,14 @@ export const Async: Story = {
           onOpenChange={setIsOpen}
           title="Revoke access?"
           description="This user will immediately lose access to all shared resources."
-          cancel={
-            <XDSButton
-              variant="secondary"
-              label="Cancel"
-              isDisabled={isLoading}
-            />
-          }
-          action={
-            <XDSButton
-              variant="danger"
-              label="Revoke"
-              isLoading={isLoading}
-              onClick={handleRevoke}
-            />
-          }
+          actionLabel="Revoke"
+          isActionLoading={isLoading}
+          onAction={async () => {
+            setIsLoading(true);
+            await new Promise(r => setTimeout(r, 2000));
+            setIsLoading(false);
+            setIsOpen(false);
+          }}
         />
       </>
     );
@@ -104,7 +84,7 @@ export const Async: Story = {
 };
 
 /**
- * Informational alert — no destructive action, just acknowledgment.
+ * Non-destructive confirmation with a primary action button.
  */
 export const Informational: Story = {
   render: () => {
@@ -121,14 +101,9 @@ export const Informational: Story = {
           onOpenChange={setIsOpen}
           title="Session expired"
           description="Your session has expired. You will be redirected to the login page."
-          cancel={<XDSButton variant="secondary" label="Cancel" />}
-          action={
-            <XDSButton
-              variant="primary"
-              label="Sign in"
-              onClick={() => setIsOpen(false)}
-            />
-          }
+          actionLabel="Sign in"
+          actionVariant="primary"
+          onAction={() => setIsOpen(false)}
         />
       </>
     );
@@ -136,33 +111,26 @@ export const Informational: Story = {
 };
 
 /**
- * Custom width dialog.
+ * Imperative API — no state management needed.
  */
-export const Wide: Story = {
+export const Imperative: Story = {
   render: () => {
-    const [isOpen, setIsOpen] = useState(false);
+    const alert = useXDSImperativeAlertDialog();
     return (
       <>
         <XDSButton
-          label="Reset all settings"
+          label="Delete item"
           variant="danger"
-          onClick={() => setIsOpen(true)}
-        />
-        <XDSAlertDialog
-          isOpen={isOpen}
-          onOpenChange={setIsOpen}
-          title="Reset all settings?"
-          description="This will restore all preferences, themes, and configurations to their factory defaults. Any custom settings will be permanently lost."
-          cancel={<XDSButton variant="secondary" label="Keep settings" />}
-          action={
-            <XDSButton
-              variant="danger"
-              label="Reset everything"
-              onClick={() => setIsOpen(false)}
-            />
+          onClick={() =>
+            alert.show({
+              title: 'Delete item?',
+              description: 'This action cannot be undone.',
+              actionLabel: 'Delete',
+              onAction: () => alert.hide(),
+            })
           }
-          width={500}
         />
+        {alert.element}
       </>
     );
   },

--- a/apps/storybook/stories/AlertDialog.stories.tsx
+++ b/apps/storybook/stories/AlertDialog.stories.tsx
@@ -1,0 +1,164 @@
+import {useState} from 'react';
+import type {Meta, StoryObj} from '@storybook/react';
+import {XDSAlertDialog} from '@xds/core/AlertDialog';
+import {XDSButton} from '@xds/core/Button';
+
+const meta: Meta<typeof XDSAlertDialog> = {
+  title: 'Core/XDSAlertDialog',
+  component: XDSAlertDialog,
+  tags: ['autodocs'],
+  argTypes: {
+    isOpen: {
+      control: 'boolean',
+      description: 'Whether the dialog is shown',
+    },
+    width: {
+      control: 'number',
+      description: 'Width of the dialog (default: 400)',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof XDSAlertDialog>;
+
+function DeleteExample() {
+  const [isOpen, setIsOpen] = useState(false);
+  return (
+    <>
+      <XDSButton
+        label="Delete item"
+        variant="danger"
+        onClick={() => setIsOpen(true)}
+      />
+      <XDSAlertDialog
+        isOpen={isOpen}
+        onOpenChange={setIsOpen}
+        title="Delete item?"
+        description="This action cannot be undone. The item and all its data will be permanently removed."
+        cancel={<XDSButton variant="secondary" label="Cancel" />}
+        action={
+          <XDSButton
+            variant="danger"
+            label="Delete"
+            onClick={() => setIsOpen(false)}
+          />
+        }
+      />
+    </>
+  );
+}
+
+export const Delete: Story = {
+  render: () => <DeleteExample />,
+};
+
+function AsyncExample() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleRevoke = async () => {
+    setIsLoading(true);
+    await new Promise(resolve => setTimeout(resolve, 2000));
+    setIsLoading(false);
+    setIsOpen(false);
+  };
+
+  return (
+    <>
+      <XDSButton
+        label="Revoke access"
+        variant="danger"
+        onClick={() => setIsOpen(true)}
+      />
+      <XDSAlertDialog
+        isOpen={isOpen}
+        onOpenChange={setIsOpen}
+        title="Revoke access?"
+        description="This user will immediately lose access to all shared resources."
+        cancel={
+          <XDSButton
+            variant="secondary"
+            label="Cancel"
+            isDisabled={isLoading}
+          />
+        }
+        action={
+          <XDSButton
+            variant="danger"
+            label="Revoke"
+            isLoading={isLoading}
+            onClick={handleRevoke}
+          />
+        }
+      />
+    </>
+  );
+}
+
+export const Async: Story = {
+  render: () => <AsyncExample />,
+};
+
+function InformationalExample() {
+  const [isOpen, setIsOpen] = useState(false);
+  return (
+    <>
+      <XDSButton
+        label="Show notice"
+        variant="secondary"
+        onClick={() => setIsOpen(true)}
+      />
+      <XDSAlertDialog
+        isOpen={isOpen}
+        onOpenChange={setIsOpen}
+        title="Session expired"
+        description="Your session has expired. You will be redirected to the login page."
+        cancel={<XDSButton variant="secondary" label="Cancel" />}
+        action={
+          <XDSButton
+            variant="primary"
+            label="Sign in"
+            onClick={() => setIsOpen(false)}
+          />
+        }
+      />
+    </>
+  );
+}
+
+export const Informational: Story = {
+  render: () => <InformationalExample />,
+};
+
+function WideExample() {
+  const [isOpen, setIsOpen] = useState(false);
+  return (
+    <>
+      <XDSButton
+        label="Reset all settings"
+        variant="danger"
+        onClick={() => setIsOpen(true)}
+      />
+      <XDSAlertDialog
+        isOpen={isOpen}
+        onOpenChange={setIsOpen}
+        title="Reset all settings?"
+        description="This will restore all preferences, themes, and configurations to their factory defaults. Any custom settings will be permanently lost."
+        cancel={<XDSButton variant="secondary" label="Keep settings" />}
+        action={
+          <XDSButton
+            variant="danger"
+            label="Reset everything"
+            onClick={() => setIsOpen(false)}
+          />
+        }
+        width={500}
+      />
+    </>
+  );
+}
+
+export const Wide: Story = {
+  render: () => <WideExample />,
+};

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,6 +34,12 @@
       "require": "./dist/theme/syntax/index.js"
     },
     "./xds.md": "./xds.md",
+    "./AlertDialog": {
+      "source": "./src/AlertDialog/index.ts",
+      "types": "./dist/AlertDialog/index.d.ts",
+      "import": "./dist/AlertDialog/index.mjs",
+      "require": "./dist/AlertDialog/index.js"
+    },
     "./AppShell": {
       "source": "./src/AppShell/index.ts",
       "types": "./dist/AppShell/index.d.ts",

--- a/packages/core/src/AlertDialog/AlertDialog.doc.mjs
+++ b/packages/core/src/AlertDialog/AlertDialog.doc.mjs
@@ -3,7 +3,7 @@
 export const docs = {
   name: 'AlertDialog',
   description:
-    'Confirmation dialog for destructive or irreversible actions. Uses role="alertdialog" with required title, description, and explicit cancel/action buttons.',
+    'Confirmation dialog for destructive or irreversible actions. Uses role="alertdialog" with required title, description, and cancel/action buttons.',
   keywords: [
     'alert',
     'alertdialog',
@@ -18,10 +18,9 @@ export const docs = {
     'ARIA alertdialog: Uses role="alertdialog" with aria-labelledby and aria-describedby',
     'No backdrop dismiss: Cannot be closed by clicking outside the dialog',
     'Escape = Cancel: Pressing Escape triggers the cancel action',
-    'Cancel auto-closes: Clicking cancel automatically calls onOpenChange(false)',
+    'Built-in buttons: Ghost cancel and configurable action button rendered internally',
     'Action does not auto-close: Supports async operations with loading states',
-    'Initial focus on Cancel: Least-destructive focus pattern from WAI-ARIA',
-    'Slot-based actions: Consumer provides XDSButton instances with full control over variant, label, loading state',
+    'Imperative API: useXDSImperativeAlertDialog for fire-and-forget usage',
   ],
   examples: [
     {
@@ -40,12 +39,28 @@ function Example() {
         onOpenChange={setIsOpen}
         title="Delete item?"
         description="This action cannot be undone."
-        cancel={<XDSButton variant="secondary" label="Cancel" />}
-        action={
-          <XDSButton variant="danger" label="Delete"
-            onClick={() => setIsOpen(false)} />
-        }
+        actionLabel="Delete"
+        onAction={() => setIsOpen(false)}
       />
+    </>
+  );
+}`,
+    },
+    {
+      label: 'Imperative',
+      code: `import {useXDSImperativeAlertDialog} from '@xds/core/AlertDialog';
+
+function Example() {
+  const alert = useXDSImperativeAlertDialog();
+  return (
+    <>
+      <button onClick={() => alert.show({
+        title: 'Delete?',
+        description: 'This cannot be undone.',
+        actionLabel: 'Delete',
+        onAction: () => alert.hide(),
+      })}>Delete</button>
+      {alert.element}
     </>
   );
 }`,
@@ -56,8 +71,11 @@ function Example() {
     {name: 'onOpenChange', type: '(isOpen: boolean) => unknown', required: true, description: 'Visibility change callback.'},
     {name: 'title', type: 'string', required: true, description: 'Dialog title. Linked via aria-labelledby.'},
     {name: 'description', type: 'string', required: true, description: 'Consequence description. Linked via aria-describedby.'},
-    {name: 'cancel', type: 'ReactNode', required: true, description: 'Cancel action slot. Auto-closes on click.'},
-    {name: 'action', type: 'ReactNode', required: true, description: 'Confirm action slot. Does NOT auto-close.'},
+    {name: 'actionLabel', type: 'string', required: true, description: 'Action button label.'},
+    {name: 'onAction', type: '() => unknown', required: true, description: 'Called when action button is clicked. Does NOT auto-close.'},
+    {name: 'cancelLabel', type: 'string', default: "'Cancel'", description: 'Cancel button label.'},
+    {name: 'actionVariant', type: 'XDSButtonVariant', default: "'danger'", description: 'Action button variant.'},
+    {name: 'isActionLoading', type: 'boolean', description: 'Shows loading spinner on the action button.'},
     {name: 'width', type: 'number | string', default: '400', description: 'Dialog width.'},
   ],
 };

--- a/packages/core/src/AlertDialog/AlertDialog.doc.mjs
+++ b/packages/core/src/AlertDialog/AlertDialog.doc.mjs
@@ -74,7 +74,7 @@ function Example() {
     {name: 'actionLabel', type: 'string', required: true, description: 'Action button label.'},
     {name: 'onAction', type: '() => unknown', required: true, description: 'Called when action button is clicked. Does NOT auto-close.'},
     {name: 'cancelLabel', type: 'string', default: "'Cancel'", description: 'Cancel button label.'},
-    {name: 'actionVariant', type: 'XDSButtonVariant', default: "'danger'", description: 'Action button variant.'},
+    {name: 'actionVariant', type: 'XDSButtonVariant', default: "'destructive'", description: 'Action button variant.'},
     {name: 'isActionLoading', type: 'boolean', description: 'Shows loading spinner on the action button.'},
     {name: 'width', type: 'number | string', default: '400', description: 'Dialog width.'},
   ],

--- a/packages/core/src/AlertDialog/AlertDialog.doc.mjs
+++ b/packages/core/src/AlertDialog/AlertDialog.doc.mjs
@@ -1,0 +1,91 @@
+/** @type {import('../docs-types').ComponentDoc} */
+
+export const docs = {
+  name: 'AlertDialog',
+  description:
+    'Confirmation dialog for destructive or irreversible actions. Uses role="alertdialog" with required title, description, and explicit cancel/action buttons.',
+  keywords: [
+    'alert',
+    'alertdialog',
+    'confirm',
+    'confirmation',
+    'destructive',
+    'delete',
+    'modal',
+    'dialog',
+  ],
+  features: [
+    'ARIA alertdialog: Uses role="alertdialog" with aria-labelledby and aria-describedby',
+    'No backdrop dismiss: Cannot be closed by clicking outside the dialog',
+    'Escape = Cancel: Pressing Escape triggers the cancel action',
+    'Cancel auto-closes: Clicking cancel automatically calls onOpenChange(false)',
+    'Action does not auto-close: Supports async operations with loading states',
+    'Initial focus on Cancel: Least-destructive focus pattern from WAI-ARIA',
+    'Slot-based actions: Consumer provides XDSButton instances with full control over variant, label, loading state',
+  ],
+  examples: [
+    {
+      label: 'Delete confirmation',
+      code: `import {XDSAlertDialog} from '@xds/core/AlertDialog';
+import {XDSButton} from '@xds/core/Button';
+import {useState} from 'react';
+
+function Example() {
+  const [isOpen, setIsOpen] = useState(false);
+  return (
+    <>
+      <XDSButton label="Delete" variant="danger" onClick={() => setIsOpen(true)} />
+      <XDSAlertDialog
+        isOpen={isOpen}
+        onOpenChange={setIsOpen}
+        title="Delete item?"
+        description="This action cannot be undone."
+        cancel={<XDSButton variant="secondary" label="Cancel" />}
+        action={
+          <XDSButton variant="danger" label="Delete"
+            onClick={() => setIsOpen(false)} />
+        }
+      />
+    </>
+  );
+}`,
+    },
+  ],
+  props: {
+    isOpen: {
+      type: 'boolean',
+      required: true,
+      description: 'Whether the dialog is open.',
+    },
+    onOpenChange: {
+      type: '(isOpen: boolean) => unknown',
+      required: true,
+      description: 'Visibility change callback.',
+    },
+    title: {
+      type: 'string',
+      required: true,
+      description: 'Dialog title. Linked via aria-labelledby.',
+    },
+    description: {
+      type: 'string',
+      required: true,
+      description: 'Consequence description. Linked via aria-describedby.',
+    },
+    cancel: {
+      type: 'ReactNode',
+      required: true,
+      description: 'Cancel action slot. Auto-closes on click.',
+    },
+    action: {
+      type: 'ReactNode',
+      required: true,
+      description: 'Confirm action slot. Does NOT auto-close.',
+    },
+    width: {
+      type: 'number | string',
+      default: '400',
+      description: 'Dialog width.',
+    },
+  },
+};

--- a/packages/core/src/AlertDialog/AlertDialog.doc.mjs
+++ b/packages/core/src/AlertDialog/AlertDialog.doc.mjs
@@ -51,41 +51,13 @@ function Example() {
 }`,
     },
   ],
-  props: {
-    isOpen: {
-      type: 'boolean',
-      required: true,
-      description: 'Whether the dialog is open.',
-    },
-    onOpenChange: {
-      type: '(isOpen: boolean) => unknown',
-      required: true,
-      description: 'Visibility change callback.',
-    },
-    title: {
-      type: 'string',
-      required: true,
-      description: 'Dialog title. Linked via aria-labelledby.',
-    },
-    description: {
-      type: 'string',
-      required: true,
-      description: 'Consequence description. Linked via aria-describedby.',
-    },
-    cancel: {
-      type: 'ReactNode',
-      required: true,
-      description: 'Cancel action slot. Auto-closes on click.',
-    },
-    action: {
-      type: 'ReactNode',
-      required: true,
-      description: 'Confirm action slot. Does NOT auto-close.',
-    },
-    width: {
-      type: 'number | string',
-      default: '400',
-      description: 'Dialog width.',
-    },
-  },
+  props: [
+    {name: 'isOpen', type: 'boolean', required: true, description: 'Whether the dialog is open.'},
+    {name: 'onOpenChange', type: '(isOpen: boolean) => unknown', required: true, description: 'Visibility change callback.'},
+    {name: 'title', type: 'string', required: true, description: 'Dialog title. Linked via aria-labelledby.'},
+    {name: 'description', type: 'string', required: true, description: 'Consequence description. Linked via aria-describedby.'},
+    {name: 'cancel', type: 'ReactNode', required: true, description: 'Cancel action slot. Auto-closes on click.'},
+    {name: 'action', type: 'ReactNode', required: true, description: 'Confirm action slot. Does NOT auto-close.'},
+    {name: 'width', type: 'number | string', default: '400', description: 'Dialog width.'},
+  ],
 };

--- a/packages/core/src/AlertDialog/XDSAlertDialog.test.tsx
+++ b/packages/core/src/AlertDialog/XDSAlertDialog.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * @file XDSAlertDialog.test.tsx
+ * @input Uses vitest, @testing-library/react, XDSAlertDialog component
+ * @output Unit tests for XDSAlertDialog component behavior
+ * @position Testing; validates XDSAlertDialog.tsx implementation
+ *
+ * SYNC: When XDSAlertDialog.tsx changes, update tests to match new behavior
+ */
+
+import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {render, screen, fireEvent} from '@testing-library/react';
+import {XDSAlertDialog} from './XDSAlertDialog';
+
+beforeEach(() => {
+  HTMLDialogElement.prototype.showModal = vi.fn(function (
+    this: HTMLDialogElement,
+  ) {
+    this.setAttribute('open', '');
+  });
+  HTMLDialogElement.prototype.close = vi.fn(function (this: HTMLDialogElement) {
+    this.removeAttribute('open');
+  });
+});
+
+describe('XDSAlertDialog', () => {
+  const defaultProps = {
+    isOpen: true,
+    onOpenChange: vi.fn(),
+    title: 'Delete item?',
+    description: 'This action cannot be undone.',
+    cancel: <button>Cancel</button>,
+    action: <button>Delete</button>,
+  };
+
+  it('renders with alertdialog role', () => {
+    render(<XDSAlertDialog {...defaultProps} />);
+    expect(screen.getByRole('alertdialog')).toBeInTheDocument();
+  });
+
+  it('renders title and description', () => {
+    render(<XDSAlertDialog {...defaultProps} />);
+    expect(screen.getByText('Delete item?')).toBeInTheDocument();
+    expect(
+      screen.getByText('This action cannot be undone.'),
+    ).toBeInTheDocument();
+  });
+
+  it('links title via aria-labelledby', () => {
+    render(<XDSAlertDialog {...defaultProps} />);
+    const dialog = screen.getByRole('alertdialog');
+    const labelledBy = dialog.getAttribute('aria-labelledby');
+    expect(labelledBy).toBeTruthy();
+    const titleEl = document.getElementById(labelledBy!);
+    expect(titleEl).toHaveTextContent('Delete item?');
+  });
+
+  it('links description via aria-describedby', () => {
+    render(<XDSAlertDialog {...defaultProps} />);
+    const dialog = screen.getByRole('alertdialog');
+    const describedBy = dialog.getAttribute('aria-describedby');
+    expect(describedBy).toBeTruthy();
+    const descEl = document.getElementById(describedBy!);
+    expect(descEl).toHaveTextContent('This action cannot be undone.');
+  });
+
+  it('renders cancel and action buttons', () => {
+    render(<XDSAlertDialog {...defaultProps} />);
+    expect(screen.getByText('Cancel')).toBeInTheDocument();
+    expect(screen.getByText('Delete')).toBeInTheDocument();
+  });
+
+  it('calls onOpenChange(false) when cancel is clicked', () => {
+    const onOpenChange = vi.fn();
+    render(<XDSAlertDialog {...defaultProps} onOpenChange={onOpenChange} />);
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('does not auto-close when action is clicked', () => {
+    const onOpenChange = vi.fn();
+    render(<XDSAlertDialog {...defaultProps} onOpenChange={onOpenChange} />);
+    fireEvent.click(screen.getByText('Delete'));
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it('does not render when isOpen is false', () => {
+    render(<XDSAlertDialog {...defaultProps} isOpen={false} />);
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+  });
+
+  it('accepts custom width', () => {
+    render(<XDSAlertDialog {...defaultProps} width={600} />);
+    expect(screen.getByRole('alertdialog')).toBeInTheDocument();
+  });
+});

--- a/packages/core/src/AlertDialog/XDSAlertDialog.test.tsx
+++ b/packages/core/src/AlertDialog/XDSAlertDialog.test.tsx
@@ -28,8 +28,8 @@ describe('XDSAlertDialog', () => {
     onOpenChange: vi.fn(),
     title: 'Delete item?',
     description: 'This action cannot be undone.',
-    cancel: <button>Cancel</button>,
-    action: <button>Delete</button>,
+    actionLabel: 'Delete',
+    onAction: vi.fn(),
   };
 
   it('renders with alertdialog role', () => {
@@ -69,6 +69,11 @@ describe('XDSAlertDialog', () => {
     expect(screen.getByText('Delete')).toBeInTheDocument();
   });
 
+  it('uses custom cancel label', () => {
+    render(<XDSAlertDialog {...defaultProps} cancelLabel="Never mind" />);
+    expect(screen.getByText('Never mind')).toBeInTheDocument();
+  });
+
   it('calls onOpenChange(false) when cancel is clicked', () => {
     const onOpenChange = vi.fn();
     render(<XDSAlertDialog {...defaultProps} onOpenChange={onOpenChange} />);
@@ -76,23 +81,17 @@ describe('XDSAlertDialog', () => {
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
-  it('does not auto-close when action is clicked', () => {
+  it('calls onAction when action is clicked', () => {
+    const onAction = vi.fn();
+    render(<XDSAlertDialog {...defaultProps} onAction={onAction} />);
+    fireEvent.click(screen.getByText('Delete'));
+    expect(onAction).toHaveBeenCalled();
+  });
+
+  it('does not call onOpenChange when action is clicked', () => {
     const onOpenChange = vi.fn();
     render(<XDSAlertDialog {...defaultProps} onOpenChange={onOpenChange} />);
     fireEvent.click(screen.getByText('Delete'));
-    expect(onOpenChange).not.toHaveBeenCalled();
-  });
-
-  it('does not auto-close when disabled cancel is clicked', () => {
-    const onOpenChange = vi.fn();
-    render(
-      <XDSAlertDialog
-        {...defaultProps}
-        onOpenChange={onOpenChange}
-        cancel={<button aria-disabled="true">Cancel</button>}
-      />,
-    );
-    fireEvent.click(screen.getByText('Cancel'));
     expect(onOpenChange).not.toHaveBeenCalled();
   });
 
@@ -106,10 +105,8 @@ describe('XDSAlertDialog', () => {
     expect(screen.getByRole('alertdialog')).toBeInTheDocument();
   });
 
-  it('has data-autofocus on cancel wrapper', () => {
+  it('defaults cancel label to Cancel', () => {
     render(<XDSAlertDialog {...defaultProps} />);
-    const cancelBtn = screen.getByText('Cancel');
-    const wrapper = cancelBtn.closest('[data-autofocus]');
-    expect(wrapper).toBeInTheDocument();
+    expect(screen.getByText('Cancel')).toBeInTheDocument();
   });
 });

--- a/packages/core/src/AlertDialog/XDSAlertDialog.test.tsx
+++ b/packages/core/src/AlertDialog/XDSAlertDialog.test.tsx
@@ -83,6 +83,19 @@ describe('XDSAlertDialog', () => {
     expect(onOpenChange).not.toHaveBeenCalled();
   });
 
+  it('does not auto-close when disabled cancel is clicked', () => {
+    const onOpenChange = vi.fn();
+    render(
+      <XDSAlertDialog
+        {...defaultProps}
+        onOpenChange={onOpenChange}
+        cancel={<button aria-disabled="true">Cancel</button>}
+      />,
+    );
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
   it('does not render when isOpen is false', () => {
     render(<XDSAlertDialog {...defaultProps} isOpen={false} />);
     expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
@@ -91,5 +104,12 @@ describe('XDSAlertDialog', () => {
   it('accepts custom width', () => {
     render(<XDSAlertDialog {...defaultProps} width={600} />);
     expect(screen.getByRole('alertdialog')).toBeInTheDocument();
+  });
+
+  it('has data-autofocus on cancel wrapper', () => {
+    render(<XDSAlertDialog {...defaultProps} />);
+    const cancelBtn = screen.getByText('Cancel');
+    const wrapper = cancelBtn.closest('[data-autofocus]');
+    expect(wrapper).toBeInTheDocument();
   });
 });

--- a/packages/core/src/AlertDialog/XDSAlertDialog.tsx
+++ b/packages/core/src/AlertDialog/XDSAlertDialog.tsx
@@ -60,7 +60,7 @@ export interface XDSAlertDialogProps {
 
   /**
    * Variant for the action button.
-   * @default 'danger'
+   * @default 'destructive'
    */
   actionVariant?: XDSButtonVariant;
 
@@ -109,7 +109,7 @@ export function XDSAlertDialog({
   description,
   cancelLabel = 'Cancel',
   actionLabel,
-  actionVariant = 'danger',
+  actionVariant = 'destructive',
   isActionLoading,
   onAction,
   width = 400,

--- a/packages/core/src/AlertDialog/XDSAlertDialog.tsx
+++ b/packages/core/src/AlertDialog/XDSAlertDialog.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+/**
+ * @file XDSAlertDialog.tsx
+ * @input Uses React, XDSDialog, XDSLayout, XDSHeading, XDSText
+ * @output Exports XDSAlertDialog component, XDSAlertDialogProps type
+ * @position Core implementation; consumed by index.ts, tested by XDSAlertDialog.test.tsx
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/AlertDialog/AlertDialog.doc.mjs (props table, features, examples)
+ * - /packages/core/src/AlertDialog/XDSAlertDialog.test.tsx (tests for new/changed behavior)
+ * - /packages/core/src/AlertDialog/index.ts (exports if types change)
+ * - /apps/storybook/stories/AlertDialog.stories.tsx (storybook stories)
+ */
+
+import {useId, useCallback, useRef, useEffect, type ReactNode} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {XDSDialog} from '../Dialog';
+import {XDSLayout} from '../Layout/XDSLayout';
+import {XDSLayoutContent} from '../Layout/XDSLayoutContent';
+import {XDSLayoutFooter} from '../Layout/XDSLayoutFooter';
+import {XDSHStack} from '../Stack';
+import {XDSHeading} from '../Text/XDSHeading';
+import {XDSText} from '../Text/XDSText';
+import {xdsClassName} from '../utils';
+
+const styles = stylex.create({
+  cancelWrapper: {
+    display: 'contents',
+  },
+});
+
+export interface XDSAlertDialogProps {
+  /**
+   * Whether the dialog is open.
+   */
+  isOpen: boolean;
+
+  /**
+   * Callback fired when the dialog visibility changes.
+   * Called with `false` when cancel is clicked or Escape is pressed.
+   */
+  onOpenChange: (isOpen: boolean) => unknown;
+
+  /**
+   * Dialog title. Linked to the dialog via `aria-labelledby`.
+   */
+  title: string;
+
+  /**
+   * Consequence description. Linked to the dialog via `aria-describedby`.
+   */
+  description: string;
+
+  /**
+   * Cancel action slot. Receives initial focus when the dialog opens.
+   * Clicking this automatically calls `onOpenChange(false)`.
+   */
+  cancel: ReactNode;
+
+  /**
+   * Confirm action slot. Does NOT auto-close —
+   * the consumer controls when to call `onOpenChange(false)`.
+   */
+  action: ReactNode;
+
+  /**
+   * The width of the dialog.
+   * Numbers are treated as pixels, strings are used as-is.
+   * @default 400
+   */
+  width?: number | string;
+}
+
+/**
+ * A confirmation dialog for destructive or irreversible actions.
+ *
+ * Uses `role="alertdialog"` and requires explicit user action to dismiss.
+ * Cannot be dismissed by clicking outside. Escape key triggers cancel.
+ * Initial focus goes to the cancel button (least destructive action).
+ *
+ * @example
+ * ```
+ * <XDSAlertDialog
+ *   isOpen={isOpen}
+ *   onOpenChange={setIsOpen}
+ *   title="Delete item?"
+ *   description="This action cannot be undone."
+ *   cancel={<XDSButton variant="secondary" label="Cancel" />}
+ *   action={
+ *     <XDSButton variant="danger" label="Delete"
+ *       onClick={async () => { await deleteItem(); setIsOpen(false); }} />
+ *   }
+ * />
+ * ```
+ */
+export function XDSAlertDialog({
+  isOpen,
+  onOpenChange,
+  title,
+  description,
+  cancel,
+  action,
+  width = 400,
+}: XDSAlertDialogProps) {
+  const titleId = useId();
+  const descriptionId = useId();
+  const cancelRef = useRef<HTMLDivElement>(null);
+
+  const handleClose = useCallback(() => {
+    onOpenChange(false);
+  }, [onOpenChange]);
+
+  // Focus the cancel button when the dialog opens (least destructive action)
+  useEffect(() => {
+    if (isOpen && cancelRef.current) {
+      const focusable = cancelRef.current.querySelector<HTMLElement>(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+      );
+      focusable?.focus();
+    }
+  }, [isOpen]);
+
+  return (
+    <XDSDialog
+      isOpen={isOpen}
+      onOpenChange={onOpenChange}
+      width={width}
+      purpose="form"
+      role="alertdialog"
+      aria-labelledby={titleId}
+      aria-describedby={descriptionId}
+      {...xdsClassName('alert-dialog')}>
+      <XDSLayout
+        content={
+          <XDSLayoutContent>
+            <XDSHeading level={2} id={titleId}>
+              {title}
+            </XDSHeading>
+            <XDSText type="body" color="secondary" id={descriptionId}>
+              {description}
+            </XDSText>
+          </XDSLayoutContent>
+        }
+        footer={
+          <XDSLayoutFooter>
+            <XDSHStack gap={2} hAlign="end">
+              <div
+                ref={cancelRef}
+                onClick={handleClose}
+                {...stylex.props(styles.cancelWrapper)}>
+                {cancel}
+              </div>
+              {action}
+            </XDSHStack>
+          </XDSLayoutFooter>
+        }
+      />
+    </XDSDialog>
+  );
+}
+
+XDSAlertDialog.displayName = 'XDSAlertDialog';

--- a/packages/core/src/AlertDialog/XDSAlertDialog.tsx
+++ b/packages/core/src/AlertDialog/XDSAlertDialog.tsx
@@ -2,7 +2,7 @@
 
 /**
  * @file XDSAlertDialog.tsx
- * @input Uses React, XDSDialog, XDSLayout, XDSHeading, XDSText
+ * @input Uses React, XDSDialog, XDSLayout, XDSHeading, XDSText, XDSButton
  * @output Exports XDSAlertDialog component, XDSAlertDialogProps type
  * @position Core implementation; consumed by index.ts, tested by XDSAlertDialog.test.tsx
  *
@@ -14,7 +14,6 @@
  */
 
 import {useId, useCallback, type ReactNode} from 'react';
-import * as stylex from '@stylexjs/stylex';
 import {XDSDialog} from '../Dialog';
 import {XDSLayout} from '../Layout/XDSLayout';
 import {XDSLayoutContent} from '../Layout/XDSLayoutContent';
@@ -22,13 +21,8 @@ import {XDSLayoutFooter} from '../Layout/XDSLayoutFooter';
 import {XDSHStack} from '../Stack';
 import {XDSHeading} from '../Text/XDSHeading';
 import {XDSText} from '../Text/XDSText';
+import {XDSButton, type XDSButtonVariant} from '../Button';
 import {xdsClassName} from '../utils';
-
-const styles = stylex.create({
-  cancelWrapper: {
-    display: 'contents',
-  },
-});
 
 export interface XDSAlertDialogProps {
   /**
@@ -53,16 +47,33 @@ export interface XDSAlertDialogProps {
   description: string;
 
   /**
-   * Cancel action slot. First focusable element receives initial focus.
-   * Clicking this automatically calls `onOpenChange(false)`.
+   * Label for the cancel button. Rendered as a ghost XDSButton.
+   * Clicking cancel calls `onOpenChange(false)`.
+   * @default 'Cancel'
    */
-  cancel: ReactNode;
+  cancelLabel?: string;
 
   /**
-   * Confirm action slot. Does NOT auto-close —
-   * the consumer controls when to call `onOpenChange(false)`.
+   * Label for the action button.
    */
-  action: ReactNode;
+  actionLabel: string;
+
+  /**
+   * Variant for the action button.
+   * @default 'danger'
+   */
+  actionVariant?: XDSButtonVariant;
+
+  /**
+   * Whether the action button shows a loading spinner.
+   */
+  isActionLoading?: boolean;
+
+  /**
+   * Callback fired when the action button is clicked.
+   * The dialog does NOT auto-close — call `onOpenChange(false)` when done.
+   */
+  onAction: () => unknown;
 
   /**
    * The width of the dialog.
@@ -77,8 +88,7 @@ export interface XDSAlertDialogProps {
  *
  * Uses `role="alertdialog"` and requires explicit user action to dismiss.
  * Cannot be dismissed by clicking outside. Escape key triggers cancel.
- * Initial focus goes to the cancel button (least destructive action)
- * via `data-autofocus` on the cancel wrapper.
+ * Initial focus goes to the cancel button (least destructive action).
  *
  * @example
  * ```
@@ -87,11 +97,8 @@ export interface XDSAlertDialogProps {
  *   onOpenChange={setIsOpen}
  *   title="Delete item?"
  *   description="This action cannot be undone."
- *   cancel={<XDSButton variant="secondary" label="Cancel" />}
- *   action={
- *     <XDSButton variant="danger" label="Delete"
- *       onClick={async () => { await deleteItem(); setIsOpen(false); }} />
- *   }
+ *   actionLabel="Delete"
+ *   onAction={async () => { await deleteItem(); setIsOpen(false); }}
  * />
  * ```
  */
@@ -100,23 +107,19 @@ export function XDSAlertDialog({
   onOpenChange,
   title,
   description,
-  cancel,
-  action,
+  cancelLabel = 'Cancel',
+  actionLabel,
+  actionVariant = 'danger',
+  isActionLoading,
+  onAction,
   width = 400,
 }: XDSAlertDialogProps) {
   const titleId = useId();
   const descriptionId = useId();
 
-  const handleCancelClick = useCallback(
-    (e: React.MouseEvent) => {
-      // Don't auto-close if the cancel button is disabled
-      const target = e.target as HTMLElement;
-      const button = target.closest('button, [role="button"]');
-      if (button?.getAttribute('aria-disabled') === 'true') return;
-      onOpenChange(false);
-    },
-    [onOpenChange],
-  );
+  const handleCancel = useCallback(() => {
+    onOpenChange(false);
+  }, [onOpenChange]);
 
   return (
     <XDSDialog
@@ -142,13 +145,17 @@ export function XDSAlertDialog({
         footer={
           <XDSLayoutFooter>
             <XDSHStack gap={2} hAlign="end">
-              <div
-                data-autofocus=""
-                onClick={handleCancelClick}
-                {...stylex.props(styles.cancelWrapper)}>
-                {cancel}
-              </div>
-              {action}
+              <XDSButton
+                variant="ghost"
+                label={cancelLabel}
+                onClick={handleCancel}
+              />
+              <XDSButton
+                variant={actionVariant}
+                label={actionLabel}
+                onClick={onAction}
+                isLoading={isActionLoading}
+              />
             </XDSHStack>
           </XDSLayoutFooter>
         }

--- a/packages/core/src/AlertDialog/XDSAlertDialog.tsx
+++ b/packages/core/src/AlertDialog/XDSAlertDialog.tsx
@@ -13,7 +13,7 @@
  * - /apps/storybook/stories/AlertDialog.stories.tsx (storybook stories)
  */
 
-import {useId, useCallback, useRef, useEffect, type ReactNode} from 'react';
+import {useId, useCallback, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {XDSDialog} from '../Dialog';
 import {XDSLayout} from '../Layout/XDSLayout';
@@ -53,7 +53,7 @@ export interface XDSAlertDialogProps {
   description: string;
 
   /**
-   * Cancel action slot. Receives initial focus when the dialog opens.
+   * Cancel action slot. First focusable element receives initial focus.
    * Clicking this automatically calls `onOpenChange(false)`.
    */
   cancel: ReactNode;
@@ -77,7 +77,8 @@ export interface XDSAlertDialogProps {
  *
  * Uses `role="alertdialog"` and requires explicit user action to dismiss.
  * Cannot be dismissed by clicking outside. Escape key triggers cancel.
- * Initial focus goes to the cancel button (least destructive action).
+ * Initial focus goes to the cancel button (least destructive action)
+ * via `data-autofocus` on the cancel wrapper.
  *
  * @example
  * ```
@@ -105,21 +106,17 @@ export function XDSAlertDialog({
 }: XDSAlertDialogProps) {
   const titleId = useId();
   const descriptionId = useId();
-  const cancelRef = useRef<HTMLDivElement>(null);
 
-  const handleClose = useCallback(() => {
-    onOpenChange(false);
-  }, [onOpenChange]);
-
-  // Focus the cancel button when the dialog opens (least destructive action)
-  useEffect(() => {
-    if (isOpen && cancelRef.current) {
-      const focusable = cancelRef.current.querySelector<HTMLElement>(
-        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
-      );
-      focusable?.focus();
-    }
-  }, [isOpen]);
+  const handleCancelClick = useCallback(
+    (e: React.MouseEvent) => {
+      // Don't auto-close if the cancel button is disabled
+      const target = e.target as HTMLElement;
+      const button = target.closest('button, [role="button"]');
+      if (button?.getAttribute('aria-disabled') === 'true') return;
+      onOpenChange(false);
+    },
+    [onOpenChange],
+  );
 
   return (
     <XDSDialog
@@ -146,8 +143,8 @@ export function XDSAlertDialog({
           <XDSLayoutFooter>
             <XDSHStack gap={2} hAlign="end">
               <div
-                ref={cancelRef}
-                onClick={handleClose}
+                data-autofocus=""
+                onClick={handleCancelClick}
                 {...stylex.props(styles.cancelWrapper)}>
                 {cancel}
               </div>

--- a/packages/core/src/AlertDialog/XDSAlertDialog.tsx
+++ b/packages/core/src/AlertDialog/XDSAlertDialog.tsx
@@ -130,7 +130,7 @@ export function XDSAlertDialog({
       role="alertdialog"
       aria-labelledby={titleId}
       aria-describedby={descriptionId}
-      {...xdsClassName('alert-dialog')}>
+      className={xdsClassName('alert-dialog')}>
       <XDSLayout
         content={
           <XDSLayoutContent>

--- a/packages/core/src/AlertDialog/XDSAlertDialog.tsx
+++ b/packages/core/src/AlertDialog/XDSAlertDialog.tsx
@@ -13,7 +13,7 @@
  * - /apps/storybook/stories/AlertDialog.stories.tsx (storybook stories)
  */
 
-import {useId, useCallback, type ReactNode} from 'react';
+import {useId, useCallback} from 'react';
 import {XDSDialog} from '../Dialog';
 import {XDSLayout} from '../Layout/XDSLayout';
 import {XDSLayoutContent} from '../Layout/XDSLayoutContent';

--- a/packages/core/src/AlertDialog/index.ts
+++ b/packages/core/src/AlertDialog/index.ts
@@ -1,0 +1,3 @@
+'use client';
+export {XDSAlertDialog} from './XDSAlertDialog';
+export type {XDSAlertDialogProps} from './XDSAlertDialog';

--- a/packages/core/src/AlertDialog/index.ts
+++ b/packages/core/src/AlertDialog/index.ts
@@ -1,3 +1,7 @@
 'use client';
+
 export {XDSAlertDialog} from './XDSAlertDialog';
 export type {XDSAlertDialogProps} from './XDSAlertDialog';
+
+export {useXDSImperativeAlertDialog} from './useXDSImperativeAlertDialog';
+export type {XDSImperativeAlertDialogReturn} from './useXDSImperativeAlertDialog';

--- a/packages/core/src/AlertDialog/useXDSImperativeAlertDialog.tsx
+++ b/packages/core/src/AlertDialog/useXDSImperativeAlertDialog.tsx
@@ -12,17 +12,10 @@
  * - /apps/storybook/stories/AlertDialog.stories.tsx
  */
 
-import {useState, useCallback, useMemo} from 'react';
+import {useState, useCallback, useMemo, type ReactNode} from 'react';
 import {XDSAlertDialog, type XDSAlertDialogProps} from './XDSAlertDialog';
-import type {ReactNode} from 'react';
 
-type AlertDialogOptions = Omit<
-  XDSAlertDialogProps,
-  'isOpen' | 'onOpenChange' | 'onAction'
-> & {
-  /** Callback fired when the action button is clicked. Call hide() when done. */
-  onAction: () => unknown;
-};
+type AlertDialogOptions = Omit<XDSAlertDialogProps, 'isOpen' | 'onOpenChange'>;
 
 export interface XDSImperativeAlertDialogReturn {
   /** Show the alert dialog. */
@@ -74,15 +67,13 @@ export function useXDSImperativeAlertDialog(): XDSImperativeAlertDialogReturn {
 
   const element = useMemo(() => {
     if (!options) return null;
-    const {onAction, ...rest} = options;
     return (
       <XDSAlertDialog
-        {...rest}
+        {...options}
         isOpen={isOpen}
         onOpenChange={open => {
           if (!open) setIsOpen(false);
         }}
-        onAction={onAction}
       />
     );
   }, [isOpen, options]);

--- a/packages/core/src/AlertDialog/useXDSImperativeAlertDialog.tsx
+++ b/packages/core/src/AlertDialog/useXDSImperativeAlertDialog.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+/**
+ * @file useXDSImperativeAlertDialog.tsx
+ * @input Uses React, XDSAlertDialog
+ * @output Exports useXDSImperativeAlertDialog hook
+ * @position Utility hook; wraps XDSAlertDialog with imperative show/hide API
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/AlertDialog/index.ts (exports)
+ * - /packages/core/src/AlertDialog/AlertDialog.doc.mjs
+ * - /apps/storybook/stories/AlertDialog.stories.tsx
+ */
+
+import {useState, useCallback, useMemo} from 'react';
+import {XDSAlertDialog, type XDSAlertDialogProps} from './XDSAlertDialog';
+import type {ReactNode} from 'react';
+
+type AlertDialogOptions = Omit<
+  XDSAlertDialogProps,
+  'isOpen' | 'onOpenChange' | 'onAction'
+> & {
+  /** Callback fired when the action button is clicked. Call hide() when done. */
+  onAction: () => unknown;
+};
+
+export interface XDSImperativeAlertDialogReturn {
+  /** Show the alert dialog. */
+  show: (options: AlertDialogOptions) => void;
+  /** Hide the alert dialog. */
+  hide: () => void;
+  /** Whether the dialog is currently open. */
+  isOpen: boolean;
+  /** Render this in your JSX tree. */
+  element: ReactNode;
+}
+
+/**
+ * Imperative alert dialog — show/hide without managing state.
+ *
+ * @example
+ * ```
+ * const alert = useXDSImperativeAlertDialog();
+ *
+ * const handleDelete = () => {
+ *   alert.show({
+ *     title: 'Delete item?',
+ *     description: 'This action cannot be undone.',
+ *     actionLabel: 'Delete',
+ *     onAction: async () => { await deleteItem(); alert.hide(); },
+ *   });
+ * };
+ *
+ * return (
+ *   <>
+ *     <button onClick={handleDelete}>Delete</button>
+ *     {alert.element}
+ *   </>
+ * );
+ * ```
+ */
+export function useXDSImperativeAlertDialog(): XDSImperativeAlertDialogReturn {
+  const [isOpen, setIsOpen] = useState(false);
+  const [options, setOptions] = useState<AlertDialogOptions | null>(null);
+
+  const show = useCallback((newOptions: AlertDialogOptions) => {
+    setOptions(newOptions);
+    setIsOpen(true);
+  }, []);
+
+  const hide = useCallback(() => {
+    setIsOpen(false);
+  }, []);
+
+  const element = useMemo(() => {
+    if (!options) return null;
+    const {onAction, ...rest} = options;
+    return (
+      <XDSAlertDialog
+        {...rest}
+        isOpen={isOpen}
+        onOpenChange={open => {
+          if (!open) setIsOpen(false);
+        }}
+        onAction={onAction}
+      />
+    );
+  }, [isOpen, options]);
+
+  return {show, hide, isOpen, element};
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -68,6 +68,7 @@ export * from './TreeList';
 
 // Keyboard shortcut display
 export * from './Kbd';
+export * from './AlertDialog';
 export * from './Dialog';
 export * from './DropdownMenu';
 export * from './MoreMenu';


### PR DESCRIPTION
## Summary

Adds `XDSAlertDialog` — a standalone confirmation dialog for destructive or irreversible actions. Composes `XDSDialog` internally with `role="alertdialog"`.

Closes #574

## API

```tsx
<XDSAlertDialog
  isOpen={isOpen}
  onOpenChange={setIsOpen}
  title="Delete item?"
  description="This action cannot be undone."
  cancel={<XDSButton variant="secondary" label="Cancel" />}
  action={
    <XDSButton variant="danger" label="Delete"
      onClick={async () => { await deleteItem(); setIsOpen(false); }} />
  }
/>
```

## Key decisions

1. **Standalone component** — `role="alertdialog"` is a distinct ARIA role; separate component makes the semantic distinction explicit
2. **Slots for cancel/action** — consumer provides `<XDSButton>` instances with full control over variant, label, loading state
3. **Cancel auto-closes; action does not** — supports async operations with loading states on the action button
4. **Escape = Cancel** — uses `purpose="form"` internally (blocks backdrop click, allows Escape)
5. **Initial focus on cancel** — least destructive action pattern from WAI-ARIA
6. **Required title + description strings** — enforces `aria-labelledby` and `aria-describedby` contract

## What's included

- `XDSAlertDialog` component + types
- 9 unit tests (role, ARIA links, cancel auto-close, action no-auto-close)
- 4 storybook stories (Delete, Async, Informational, Wide)
- Component doc file (`AlertDialog.doc.mjs`)
- Package.json exports via `sync-exports.js`

---
