### PR TITLE
fix(SideNav): use design tokens for drag handle transition, rename collapse state type

### DIFF
--- a/packages/core/src/SideNav/XDSSideNav.tsx
+++ b/packages/core/src/SideNav/XDSSideNav.tsx
@@ -22,7 +22,7 @@ import {useCallback, useState, type ReactNode} from 'react';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
-import {borderVars, colorVars, spacingVars} from '../theme/tokens.stylex';
+import {borderVars, colorVars, durationVars, easeVars, spacingVars} from '../theme/tokens.stylex';
 import {xdsClassName, mergeProps} from '../utils';
 import {XDSSideNavCollapseContext} from './XDSSideNavCollapseContext';
 import {XDSSideNavCollapseButton} from './XDSSideNavCollapseButton';
@@ -154,7 +154,9 @@ const styles = stylex.create({
     zIndex: 2,
     // Invisible by default; visible on hover
     backgroundColor: 'transparent',
-    transition: 'background-color 0.15s ease',
+    transitionProperty: 'background-color',
+    transitionDuration: durationVars['--duration-fast'],
+    transitionTimingFunction: easeVars['--ease-standard'],
     touchAction: 'none',
   },
   dragHandleHover: {

--- a/packages/core/src/SideNav/XDSSideNavCollapseContext.ts
+++ b/packages/core/src/SideNav/XDSSideNavCollapseContext.ts
@@ -12,7 +12,7 @@
 
 import {createContext, useContext} from 'react';
 
-export interface SideNavCollapseState {
+export interface XDSSideNavCollapseState {
   /** Whether the sidenav is currently collapsed */
   isCollapsed: boolean;
   /** Toggle collapse state */
@@ -21,17 +21,23 @@ export interface SideNavCollapseState {
   isCollapsible: boolean;
 }
 
-export const XDSSideNavCollapseContext = createContext<SideNavCollapseState>({
-  isCollapsed: false,
-  toggle: () => {},
-  isCollapsible: false,
-});
+/**
+ * @deprecated Use XDSSideNavCollapseState instead.
+ */
+export type SideNavCollapseState = XDSSideNavCollapseState;
+
+export const XDSSideNavCollapseContext =
+  createContext<XDSSideNavCollapseState>({
+    isCollapsed: false,
+    toggle: () => {},
+    isCollapsible: false,
+  });
 
 /**
  * Read the sidenav collapse state from context.
  * Returns { isCollapsed, toggle, isCollapsible }.
  * When used outside a sidenav with isCollapsible, isCollapsible is false.
  */
-export function useXDSSideNavCollapse(): SideNavCollapseState {
+export function useXDSSideNavCollapse(): XDSSideNavCollapseState {
   return useContext(XDSSideNavCollapseContext);
 }

--- a/packages/core/src/SideNav/index.ts
+++ b/packages/core/src/SideNav/index.ts
@@ -25,6 +25,7 @@ export {XDSSideNavCollapseButton} from './XDSSideNavCollapseButton';
 export type {XDSSideNavCollapseButtonProps} from './XDSSideNavCollapseButton';
 
 export {useXDSSideNavCollapse} from './XDSSideNavCollapseContext';
+export type {XDSSideNavCollapseState} from './XDSSideNavCollapseContext';
 
 export {
   XDSSideNavRenderContext,


### PR DESCRIPTION
## Component Audit — 2026-04-15

Nightly audit of **SegmentedControl**, **Selector**, **SideNav**, **Skeleton**, and **Slider**.

### Changes

1. **SideNav: Replace hardcoded transition with design tokens** (`XDSSideNav.tsx`)
   - The drag handle used a hardcoded `transition: 'background-color 0.15s ease'` string
   - Replaced with `durationVars['--duration-fast']` and `easeVars['--ease-standard']` for theme consistency

2. **SideNav: Rename `SideNavCollapseState` → `XDSSideNavCollapseState`** (`XDSSideNavCollapseContext.ts`)
   - Context value interface was missing the `XDS` prefix required by naming conventions
   - Added deprecated type alias for backward compatibility
   - Exported the new type from `index.ts`

### Needs Review

These findings require human judgment — the auditor flagged them but did not auto-fix:

| Component | File | Category | Finding |
|---|---|---|---|
| SegmentedControl | XDSSegmentedControl.tsx | token-semantics | Uses `--color-neutral` for container background. Not in the standard gray token set (secondary/muted/overlay-hover). Is this a distinct semantic token or should it align? |
| SegmentedControl | XDSSegmentedControl.tsx | structure | Props don't extend `XDSBaseProps` — defines xstyle/className/style manually |
| SegmentedControl | XDSSegmentedControlItem.tsx | structure | Missing xstyle/className/style escape hatches on sub-component |
| Selector | XDSSelector.tsx | input-consistency | Size includes 'lg' variant. Convention says 'sm' \| 'md' for inputs. Intentional? |
| SideNav | XDSSideNavItem.tsx | structure | Missing XDSBaseProps extension — no xstyle/className/style escape hatches |
| SideNav | XDSSideNavSection.tsx | structure | Missing XDSBaseProps extension — no xstyle/className/style escape hatches |
| Slider | XDSSlider.tsx | token-semantics | Track uses `--color-background-muted` — convention says slider tracks should use `--color-muted`. Same token? |
| Slider | XDSSlider.tsx | structure | `XDSSliderBaseProps` doesn't extend `XDSBaseProps` |

### Clean Components

- **Skeleton** — No issues found. All conventions followed.

---
