### PR TITLE
fix(vibe-tests): resolve theme alias to source.ts in all Vite configs

### DIFF
--- a/internal/vibe-tests/app/vite.config.preview.ts
+++ b/internal/vibe-tests/app/vite.config.preview.ts
@@ -70,11 +70,11 @@ export default defineConfig({
       '@xds/core': path.resolve(repoRoot, 'packages/core/src'),
       '@xds/theme-default': path.resolve(
         repoRoot,
-        'packages/themes/default/src',
+        'packages/themes/default/src/source.ts',
       ),
       '@xds/theme/default': path.resolve(
         repoRoot,
-        'packages/themes/default/src',
+        'packages/themes/default/src/source.ts',
       ),
       '@xds/theme-neutral': path.resolve(
         repoRoot,

--- a/internal/vibe-tests/app/vite.config.report.ts
+++ b/internal/vibe-tests/app/vite.config.report.ts
@@ -84,11 +84,11 @@ export default defineConfig({
       // Theme: resolve to source (no StyleX usage, just defineTheme + icons).
       {
         find: '@xds/theme-default',
-        replacement: path.resolve(repoRoot, 'packages/themes/default/src'),
+        replacement: path.resolve(repoRoot, 'packages/themes/default/src/source.ts'),
       },
       {
         find: '@xds/theme/default',
-        replacement: path.resolve(repoRoot, 'packages/themes/default/src'),
+        replacement: path.resolve(repoRoot, 'packages/themes/default/src/source.ts'),
       },
     ],
   },

--- a/internal/vibe-tests/app/vite.config.ts
+++ b/internal/vibe-tests/app/vite.config.ts
@@ -60,11 +60,11 @@ export default defineConfig({
       '@xds/core': path.resolve(repoRoot, 'packages/core/src'),
       '@xds/theme-default': path.resolve(
         repoRoot,
-        'packages/themes/default/src',
+        'packages/themes/default/src/source.ts',
       ),
       '@xds/theme/default': path.resolve(
         repoRoot,
-        'packages/themes/default/src',
+        'packages/themes/default/src/source.ts',
       ),
       '@xds/theme-neutral': path.resolve(
         repoRoot,


### PR DESCRIPTION
PR #1368 fixed `build-previews.ts` but missed the three `app/` Vite configs that also alias `@xds/theme-default` to a directory instead of `source.ts`. Same EISDIR error.

**Files fixed:**
- `vite.config.report.ts` — report build
- `vite.config.preview.ts` — preview dev server
- `vite.config.ts` — main dev server

**Also adds missing baseline shims** for shadcn components that agents commonly import:
- `tooltip` — TooltipProvider, Tooltip, TooltipTrigger, TooltipContent
- `command` — Command, CommandInput, CommandList, CommandEmpty, CommandGroup, CommandItem
- `scroll-area` — ScrollArea, ScrollBar
- `popover` — Popover, PopoverTrigger, PopoverContent

These were causing ENOENT failures when building baseline previews (4/10 failed in tonight's run).

---
