### PR TITLE
ci: cache Next.js build + drop redundant theme transpilation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,15 +1,7 @@
 # PR CI: test, build, analyze, a11y audit, and comment
 # Everything runs in parallel where possible
 #
-# Pipeline:
-#   test ─────────────────────────────────────────────────────┐
-#   check-components ────────────────────────────────────────┐│
-#   build (core) ─┬─ build-storybook ─┬─ deploy-preview ────┤├─ (merge)
-#                  ├─ build-sandbox ───┘                     ││
-#                  └─ analyze ─ pr-comment                   ││
-#                       └─ pr-a11y ─ pr-comment-update ──────┘│
-#
-# Merge queue: test + build run on merge_group events so the
+# Merge queue: test + build also run on merge_group events so the
 # merge queue can gate on them before landing a PR.
 name: CI
 
@@ -68,8 +60,8 @@ jobs:
 
       - run: yarn test
 
-  # Build core packages, verify, typecheck, analyze.
-  # Storybook and Sandbox build in parallel after this (separate jobs).
+  # Build storybook + analyze components (parallel with test)
+  # Uploads storybook preview and analysis artifacts for downstream jobs
   build:
     runs-on: ubuntu-latest
     outputs:
@@ -106,6 +98,9 @@ jobs:
       - name: Typecheck template docs
         run: yarn workspace @xds/cli typecheck:template-docs
 
+      - name: Build Storybook
+        run: yarn workspace @xds/storybook build
+
       - name: Compute PR preview path
         if: github.event_name == 'pull_request'
         id: urls
@@ -120,6 +115,28 @@ jobs:
           echo "pr_number=${PR_NUMBER}" >> $GITHUB_OUTPUT
           echo "storybook_url=https://${REPO_OWNER}.github.io/${REPO_NAME}/pr/${PR_NUMBER}/" >> $GITHUB_OUTPUT
           echo "sandbox_url=https://${REPO_OWNER}.github.io/${REPO_NAME}/pr/${PR_NUMBER}/sandbox/" >> $GITHUB_OUTPUT
+
+      - name: Build Sandbox
+        if: github.event_name == 'pull_request'
+        run: yarn workspace @xds/sandbox build
+        env:
+          SANDBOX_BASE_PATH: /pr/${{ steps.urls.outputs.pr_number }}/sandbox
+
+      - name: Upload Storybook artifact
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v7
+        with:
+          name: storybook-${{ steps.urls.outputs.short_hash }}
+          path: apps/storybook/dist/
+          retention-days: 30
+
+      - name: Upload Sandbox artifact
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v7
+        with:
+          name: sandbox-${{ steps.urls.outputs.short_hash }}
+          path: apps/sandbox/out/
+          retention-days: 30
 
       - name: Analyze components
         if: github.event_name == 'pull_request'
@@ -137,75 +154,13 @@ jobs:
           path: analysis.json
           retention-days: 1
 
-  # Build Storybook (parallel with Sandbox after core build)
-  build-storybook:
-    if: github.event_name == 'pull_request'
-    needs: [build]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 20
-          cache: 'yarn'
-
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
-
-      - name: Build core package
-        run: yarn build
-
-      - name: Build Storybook
-        run: yarn workspace @xds/storybook build
-
-      - name: Upload Storybook artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: storybook-${{ needs.build.outputs.short_hash }}
-          path: apps/storybook/dist/
-          retention-days: 30
-
-  # Build Sandbox (parallel with Storybook after core build)
-  build-sandbox:
-    if: github.event_name == 'pull_request'
-    needs: [build]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 20
-          cache: 'yarn'
-
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
-
-      - name: Build core package
-        run: yarn build
-
-      - name: Build Sandbox
-        run: yarn workspace @xds/sandbox build
-        env:
-          SANDBOX_BASE_PATH: /pr/${{ needs.build.outputs.pr_number }}/sandbox
-
-      - name: Upload Sandbox artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: sandbox-${{ needs.build.outputs.short_hash }}
-          path: apps/sandbox/out/
-          retention-days: 30
-
   # Deploy PR preview to GitHub Pages.
-  # Waits for both Storybook and Sandbox builds.
+  # Uses a per-PR concurrency group so multiple PRs deploy in parallel.
+  # Instead of peaceiris/actions-gh-pages (which can conflict with main's
+  # force-push), we do a manual git push with retry-on-conflict.
   deploy-preview:
     if: github.event_name == 'pull_request'
-    needs: [build, build-storybook, build-sandbox]
+    needs: [build]
     runs-on: ubuntu-latest
     concurrency:
       group: "pr-preview-${{ needs.build.outputs.pr_number }}"
@@ -267,7 +222,7 @@ jobs:
           exit 1
 
   # Post PR comment with preview links + analysis as soon as build finishes
-  # Does NOT wait for Storybook/Sandbox — those deploy later
+  # Does NOT wait for test or a11y — those update the comment later
   pr-comment:
     if: github.event_name == 'pull_request'
     needs: [build]
@@ -338,10 +293,10 @@ jobs:
               });
             }
 
-  # Accessibility audit — needs Storybook build
+  # Accessibility audit
   # Skipped when no components changed.
   pr-a11y:
-    needs: [build, build-storybook, check-components]
+    needs: [build, check-components]
     if: github.event_name == 'pull_request' && needs.check-components.outputs.has_components == 'true'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
       - run: yarn test
 
   # Build core packages, verify, typecheck, analyze.
-  # Uploads core dist for parallel Storybook + Sandbox builds.
+  # Storybook and Sandbox build in parallel after this (separate jobs).
   build:
     runs-on: ubuntu-latest
     outputs:
@@ -137,17 +137,6 @@ jobs:
           path: analysis.json
           retention-days: 1
 
-      - name: Upload build artifact
-        if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v7
-        with:
-          name: core-build
-          path: |
-            packages/core/dist/
-            packages/vega/dist/
-            packages/themes/*/dist/
-          retention-days: 1
-
   # Build Storybook (parallel with Sandbox after core build)
   build-storybook:
     if: github.event_name == 'pull_request'
@@ -166,10 +155,8 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
-      - name: Download core build
-        uses: actions/download-artifact@v8
-        with:
-          name: core-build
+      - name: Build core package
+        run: yarn build
 
       - name: Build Storybook
         run: yarn workspace @xds/storybook build
@@ -199,10 +186,8 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
-      - name: Download core build
-        uses: actions/download-artifact@v8
-        with:
-          name: core-build
+      - name: Build core package
+        run: yarn build
 
       - name: Build Sandbox
         run: yarn workspace @xds/sandbox build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,16 @@ jobs:
       - name: Typecheck template docs
         run: yarn workspace @xds/cli typecheck:template-docs
 
+      - name: Cache Next.js build
+        if: github.event_name == 'pull_request'
+        uses: actions/cache@v4
+        with:
+          path: apps/sandbox/.next/cache
+          key: nextjs-sandbox-${{ hashFiles('yarn.lock') }}-${{ hashFiles('packages/core/dist/**') }}
+          restore-keys: |
+            nextjs-sandbox-${{ hashFiles('yarn.lock') }}-
+            nextjs-sandbox-
+
       - name: Build Storybook
         run: yarn workspace @xds/storybook build
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,15 @@
 # PR CI: test, build, analyze, a11y audit, and comment
 # Everything runs in parallel where possible
 #
-# Merge queue: test + build also run on merge_group events so the
+# Pipeline:
+#   test ─────────────────────────────────────────────────────┐
+#   check-components ────────────────────────────────────────┐│
+#   build (core) ─┬─ build-storybook ─┬─ deploy-preview ────┤├─ (merge)
+#                  ├─ build-sandbox ───┘                     ││
+#                  └─ analyze ─ pr-comment                   ││
+#                       └─ pr-a11y ─ pr-comment-update ──────┘│
+#
+# Merge queue: test + build run on merge_group events so the
 # merge queue can gate on them before landing a PR.
 name: CI
 
@@ -60,8 +68,8 @@ jobs:
 
       - run: yarn test
 
-  # Build storybook + analyze components (parallel with test)
-  # Uploads storybook preview and analysis artifacts for downstream jobs
+  # Build core packages, verify, typecheck, analyze.
+  # Uploads core dist for parallel Storybook + Sandbox builds.
   build:
     runs-on: ubuntu-latest
     outputs:
@@ -98,9 +106,6 @@ jobs:
       - name: Typecheck template docs
         run: yarn workspace @xds/cli typecheck:template-docs
 
-      - name: Build Storybook
-        run: yarn workspace @xds/storybook build
-
       - name: Compute PR preview path
         if: github.event_name == 'pull_request'
         id: urls
@@ -115,28 +120,6 @@ jobs:
           echo "pr_number=${PR_NUMBER}" >> $GITHUB_OUTPUT
           echo "storybook_url=https://${REPO_OWNER}.github.io/${REPO_NAME}/pr/${PR_NUMBER}/" >> $GITHUB_OUTPUT
           echo "sandbox_url=https://${REPO_OWNER}.github.io/${REPO_NAME}/pr/${PR_NUMBER}/sandbox/" >> $GITHUB_OUTPUT
-
-      - name: Build Sandbox
-        if: github.event_name == 'pull_request'
-        run: yarn workspace @xds/sandbox build
-        env:
-          SANDBOX_BASE_PATH: /pr/${{ steps.urls.outputs.pr_number }}/sandbox
-
-      - name: Upload Storybook artifact
-        if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v7
-        with:
-          name: storybook-${{ steps.urls.outputs.short_hash }}
-          path: apps/storybook/dist/
-          retention-days: 30
-
-      - name: Upload Sandbox artifact
-        if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v7
-        with:
-          name: sandbox-${{ steps.urls.outputs.short_hash }}
-          path: apps/sandbox/out/
-          retention-days: 30
 
       - name: Analyze components
         if: github.event_name == 'pull_request'
@@ -154,13 +137,90 @@ jobs:
           path: analysis.json
           retention-days: 1
 
-  # Deploy PR preview to GitHub Pages.
-  # Uses a per-PR concurrency group so multiple PRs deploy in parallel.
-  # Instead of peaceiris/actions-gh-pages (which can conflict with main's
-  # force-push), we do a manual git push with retry-on-conflict.
-  deploy-preview:
+      - name: Upload build artifact
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v7
+        with:
+          name: core-build
+          path: |
+            packages/core/dist/
+            packages/vega/dist/
+            packages/themes/*/dist/
+          retention-days: 1
+
+  # Build Storybook (parallel with Sandbox after core build)
+  build-storybook:
     if: github.event_name == 'pull_request'
     needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Download core build
+        uses: actions/download-artifact@v8
+        with:
+          name: core-build
+
+      - name: Build Storybook
+        run: yarn workspace @xds/storybook build
+
+      - name: Upload Storybook artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: storybook-${{ needs.build.outputs.short_hash }}
+          path: apps/storybook/dist/
+          retention-days: 30
+
+  # Build Sandbox (parallel with Storybook after core build)
+  build-sandbox:
+    if: github.event_name == 'pull_request'
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Download core build
+        uses: actions/download-artifact@v8
+        with:
+          name: core-build
+
+      - name: Build Sandbox
+        run: yarn workspace @xds/sandbox build
+        env:
+          SANDBOX_BASE_PATH: /pr/${{ needs.build.outputs.pr_number }}/sandbox
+
+      - name: Upload Sandbox artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: sandbox-${{ needs.build.outputs.short_hash }}
+          path: apps/sandbox/out/
+          retention-days: 30
+
+  # Deploy PR preview to GitHub Pages.
+  # Waits for both Storybook and Sandbox builds.
+  deploy-preview:
+    if: github.event_name == 'pull_request'
+    needs: [build, build-storybook, build-sandbox]
     runs-on: ubuntu-latest
     concurrency:
       group: "pr-preview-${{ needs.build.outputs.pr_number }}"
@@ -222,7 +282,7 @@ jobs:
           exit 1
 
   # Post PR comment with preview links + analysis as soon as build finishes
-  # Does NOT wait for test or a11y — those update the comment later
+  # Does NOT wait for Storybook/Sandbox — those deploy later
   pr-comment:
     if: github.event_name == 'pull_request'
     needs: [build]
@@ -293,10 +353,10 @@ jobs:
               });
             }
 
-  # Accessibility audit
+  # Accessibility audit — needs Storybook build
   # Skipped when no components changed.
   pr-a11y:
-    needs: [build, check-components]
+    needs: [build, build-storybook, check-components]
     if: github.event_name == 'pull_request' && needs.check-components.outputs.has_components == 'true'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,6 +83,15 @@ jobs:
       - name: Build Storybook
         run: yarn workspace @xds/storybook build
 
+      - name: Cache Next.js build
+        uses: actions/cache@v4
+        with:
+          path: apps/sandbox/.next/cache
+          key: nextjs-sandbox-${{ hashFiles('yarn.lock') }}-${{ hashFiles('packages/core/dist/**') }}
+          restore-keys: |
+            nextjs-sandbox-${{ hashFiles('yarn.lock') }}-
+            nextjs-sandbox-
+
       - name: Build Sandbox
         run: yarn workspace @xds/sandbox build
         env:

--- a/apps/sandbox/next.config.mjs
+++ b/apps/sandbox/next.config.mjs
@@ -26,12 +26,9 @@ const nextConfig = {
   },
   transpilePackages: [
     // Only transpile @xds/core in source mode — in dist mode, it's pre-built.
+    // Theme packages are NOT listed here — their exports already resolve to
+    // pre-compiled dist/ files (ESM + CSS), so re-transpilation is wasted work.
     ...(useSource ? ['@xds/core'] : []),
-    '@xds/theme-default',
-    '@xds/theme-neutral',
-    '@xds/theme-brutalist',
-    '@xds/theme-meta',
-    '@xds/theme-daily',
   ],
   images: {
     unoptimized: true,


### PR DESCRIPTION
## Summary

Two changes targeting the sandbox build, which at ~3 min is the single slowest step in CI.

### 1. Cache `.next/cache` between CI runs

Next.js stores webpack compilation cache in `.next/cache/`. Without caching, every CI run recompiles all modules from scratch (2m23s). With a warm cache, only changed modules recompile.

Cache key strategy:
- **Exact**: `yarn.lock` hash + `packages/core/dist/**` hash — matches when deps and core output are identical
- **Fallback**: `yarn.lock` hash only — partial match when core changed but deps didnt
- **Last resort**: any previous sandbox cache — stale but still useful for node_modules compilation

Most PRs change a handful of components, so the vast majority of cached modules survive.

### 2. Remove themes from `transpilePackages`

All 6 theme packages (`@xds/theme-default`, `-neutral`, `-brutalist`, `-meta`, `-daily`, `-whatsapp`) export pre-compiled ESM + CSS from `dist/`. Listing them in `transpilePackages` told webpack to re-transpile them through SWC on every build — redundant work.

Verified: all sandbox theme imports resolve to `dist/` paths:
- `@xds/theme-*/theme.css` → `dist/theme.css`
- `@xds/theme-*/built` → `dist/*.js`  
- `@xds/theme-*` (bare) → `dist/source.mjs`

### Expected impact

First run (cold cache): similar to current (~3 min sandbox)
Subsequent runs (warm cache): significantly faster webpack compilation

The cache wont help this PRs first run, but every PR after this merges will benefit.

---
