### PR TITLE
fix: increase vitest worker heap to prevent OOM flakes

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -45,7 +45,7 @@ export default defineConfig({
       // Map @xds/core subpath imports to source for lab package tests.
       // Must use regex to match subpaths like @xds/core/Dialog, @xds/core/theme/tokens.stylex
       // while not breaking core's own relative imports.
-      { find: /^@xds\/core\/(.*)$/, replacement: path.join(coreSrc, '$1') },
+      {find: /^@xds\/core\/(.*)$/, replacement: path.join(coreSrc, '$1')},
     ],
   },
   test: {
@@ -63,5 +63,12 @@ export default defineConfig({
       exclude: ['**/*.test.{ts,tsx}', '**/*.stories.{ts,tsx}', '**/index.ts'],
     },
     setupFiles: ['./internal/test-utils/src/setup.ts'],
+    // Increase worker heap to prevent OOM crashes on memory-heavy test files
+    // (e.g. Chat composer tests with contentEditable + popover portals in jsdom).
+    poolOptions: {
+      forks: {
+        execArgv: ['--max-old-space-size=4096'],
+      },
+    },
   },
 });


### PR DESCRIPTION
## Problem

Tests intermittently fail with worker OOM crashes in CI and locally:

```
1: 0xb78db3 node::OOMErrorHandler(char const*, v8::OOMDetails const&)
Error: Worker exited unexpectedly
```

The crash originates from memory-heavy test files (e.g. Chat composer tests with contentEditable, selection ranges, popover portals in jsdom). Not deterministic — sometimes passes, sometimes OOMs.

## Root Cause

No `poolOptions` configured in vitest. The default V8 heap limit for fork workers is too small when jsdom + React + StyleX Babel transforms are all loaded into the same worker process.

## Fix

Set `--max-old-space-size=4096` on vitest fork workers via `poolOptions.forks.execArgv`. One line in `vitest.config.ts`.

All 168 test files (2939 tests) pass locally with this change.

---
