### PR TITLE
fix(vibe-tests): report label props + baseline preview shims

### DIFF
--- a/internal/vibe-tests/app/src/report/PromptDetailCard.tsx
+++ b/internal/vibe-tests/app/src/report/PromptDetailCard.tsx
@@ -75,9 +75,9 @@ function Findings({score}: {score: UniversalScore}) {
                 : f.severity === 'moderate'
                   ? 'warning'
                   : 'neutral'
-            }>
-            {f.severity ?? 'info'}
-          </XDSBadge>
+            }
+            label={f.severity ?? 'info'}
+          />
           <XDSText key={`text-${i}`} type="body">
             <strong>{f.dimension}</strong> — {f.detail}
           </XDSText>
@@ -144,49 +144,49 @@ export function PromptDetailCard({
                   <XDSButton
                     variant="secondary"
                     size="sm"
-                    onClick={() => window.open(previewUrls.xds, '_blank')}>
-                    XDS Preview
-                  </XDSButton>
+                    onClick={() => window.open(previewUrls.xds, '_blank')}
+                    label="XDS Preview"
+                  />
                 )}
                 {previewUrls?.baseline && (
                   <XDSButton
                     variant="secondary"
                     size="sm"
-                    onClick={() => window.open(previewUrls.baseline, '_blank')}>
-                    Baseline Preview
-                  </XDSButton>
+                    onClick={() => window.open(previewUrls.baseline, '_blank')}
+                    label="Baseline Preview"
+                  />
                 )}
                 {previewUrls?.html && (
                   <XDSButton
                     variant="secondary"
                     size="sm"
-                    onClick={() => window.open(previewUrls.html, '_blank')}>
-                    HTML Preview
-                  </XDSButton>
+                    onClick={() => window.open(previewUrls.html, '_blank')}
+                    label="HTML Preview"
+                  />
                 )}
                 {hasXdsCode && (
                   <XDSButton
                     variant="ghost"
                     size="sm"
-                    onClick={() => onViewCode('xds')}>
-                    XDS Code
-                  </XDSButton>
+                    onClick={() => onViewCode('xds')}
+                    label="XDS Code"
+                  />
                 )}
                 {hasBaselineCode && (
                   <XDSButton
                     variant="ghost"
                     size="sm"
-                    onClick={() => onViewCode('baseline')}>
-                    Baseline Code
-                  </XDSButton>
+                    onClick={() => onViewCode('baseline')}
+                    label="Baseline Code"
+                  />
                 )}
                 {hasHtmlCode && (
                   <XDSButton
                     variant="ghost"
                     size="sm"
-                    onClick={() => onViewCode('html')}>
-                    HTML Code
-                  </XDSButton>
+                    onClick={() => onViewCode('html')}
+                    label="HTML Code"
+                  />
                 )}
               </div>
             )}

--- a/internal/vibe-tests/app/src/report/Report.tsx
+++ b/internal/vibe-tests/app/src/report/Report.tsx
@@ -212,9 +212,9 @@ export function Report() {
                   variant="secondary"
                   onClick={() =>
                     setThemeMode(m => (m === 'light' ? 'dark' : 'light'))
-                  }>
-                  {themeMode === 'light' ? '🌙 Dark' : '☀️ Light'}
-                </XDSButton>
+                  }
+                  label={themeMode === 'light' ? '🌙 Dark' : '☀️ Light'}
+                />
               </XDSHStack>
             </div>
 

--- a/internal/vibe-tests/src/build-previews.ts
+++ b/internal/vibe-tests/src/build-previews.ts
@@ -593,6 +593,47 @@ export function DialogTitle({className, children, ...props}: any) { return <h2 c
 export function DialogDescription({className, children, ...props}: any) { return <p className={cn('text-sm text-gray-500', className)} {...props}>{children}</p>; }
 export function DialogFooter({className, children, ...props}: any) { return <div className={cn('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', className)} {...props}>{children}</div>; }
 `,
+    tooltip: `import React, {useState, useRef, useEffect} from 'react';
+import {cn} from '@/lib/utils';
+export function TooltipProvider({children}: any) { return <>{children}</>; }
+export function Tooltip({children, open, onOpenChange, delayDuration}: any) { return <>{children}</>; }
+export function TooltipTrigger({children, asChild, ...props}: any) { return <>{children}</>; }
+export function TooltipContent({className, children, side, sideOffset, ...props}: any) {
+  return <div className={cn('z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md', className)} {...props}>{children}</div>;
+}
+`,
+    command: `import React, {useState, createContext, useContext} from 'react';
+import {cn} from '@/lib/utils';
+const CmdCtx = createContext<{search: string; setSearch: (s: string) => void}>({search: '', setSearch: () => {}});
+export function Command({className, children, ...props}: any) {
+  const [search, setSearch] = useState('');
+  return <CmdCtx.Provider value={{search, setSearch}}><div className={cn('flex h-full w-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground', className)} {...props}>{children}</div></CmdCtx.Provider>;
+}
+export function CommandInput({className, placeholder, value, onValueChange, ...props}: any) {
+  const ctx = useContext(CmdCtx);
+  return <input className={cn('flex h-11 w-full rounded-md bg-transparent py-3 px-3 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50 border-b', className)} placeholder={placeholder} value={value ?? ctx.search} onChange={e => { ctx.setSearch(e.target.value); onValueChange?.(e.target.value); }} {...props} />;
+}
+export function CommandList({className, children, ...props}: any) { return <div className={cn('max-h-[300px] overflow-y-auto overflow-x-hidden', className)} {...props}>{children}</div>; }
+export function CommandEmpty({children, ...props}: any) { const ctx = useContext(CmdCtx); return <div className="py-6 text-center text-sm" {...props}>{children}</div>; }
+export function CommandGroup({className, heading, children, ...props}: any) { return <div className={cn('overflow-hidden p-1 text-foreground', className)} {...props}>{heading && <div className="px-2 py-1.5 text-xs font-medium text-muted-foreground">{heading}</div>}{children}</div>; }
+export function CommandItem({className, children, onSelect, value, ...props}: any) { return <div className={cn('relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none hover:bg-accent hover:text-accent-foreground', className)} onClick={() => onSelect?.(value)} {...props}>{children}</div>; }
+export function CommandSeparator({className, ...props}: any) { return <div className={cn('-mx-1 h-px bg-border', className)} {...props} />; }
+`,
+    'scroll-area': `import React from 'react';
+import {cn} from '@/lib/utils';
+export function ScrollArea({className, children, ...props}: any) {
+  return <div className={cn('relative overflow-auto', className)} {...props}>{children}</div>;
+}
+export function ScrollBar({orientation, ...props}: any) { return null; }
+`,
+    popover: `import React, {useState} from 'react';
+import {cn} from '@/lib/utils';
+export function Popover({children, open, onOpenChange}: any) { return <div className="relative inline-block">{children}</div>; }
+export function PopoverTrigger({children, asChild, ...props}: any) { return <>{children}</>; }
+export function PopoverContent({className, children, align, sideOffset, ...props}: any) {
+  return <div className={cn('z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none', className)} {...props}>{children}</div>;
+}
+`,
   };
 
   for (const [name, content] of Object.entries(components)) {


### PR DESCRIPTION
Two fixes for the vibe test report pipeline:

## Report template — label prop migration

`XDSBadge` and `XDSButton` use the `label` prop, not children. The report template was using the old children pattern:

```diff
- <XDSBadge variant="error">{text}</XDSBadge>
+ <XDSBadge variant="error" label={text} />

- <XDSButton variant="secondary">Click me</XDSButton>
+ <XDSButton variant="secondary" label="Click me" />
```

**Files:** `PromptDetailCard.tsx`, `Report.tsx`

## Baseline preview shims

4/10 baseline previews failed in tonight's run because the generated code imported shadcn components that had no stub shim. Added:

- `tooltip` — TooltipProvider, Tooltip, TooltipTrigger, TooltipContent
- `command` — Command, CommandInput, CommandList, CommandEmpty, CommandGroup, CommandItem
- `scroll-area` — ScrollArea, ScrollBar
- `popover` — Popover, PopoverTrigger, PopoverContent

**File:** `build-previews.ts`

---
