### PR TITLE
cleanup: remove examples, showcase from doc types

### DIFF
--- a/packages/cli/src/api/component.mjs
+++ b/packages/cli/src/api/component.mjs
@@ -18,6 +18,7 @@ import {
 import {loadDocs} from '../lib/component-loader.mjs';
 import {searchComponents} from '../lib/string-utils.mjs';
 import {XDSError} from './error.mjs';
+import {findShowcase} from './template.mjs';
 
 /**
  * @param {string} [name]
@@ -27,6 +28,7 @@ import {XDSError} from './error.mjs';
  * @param {string} [options.category]
  * @param {boolean} [options.props]
  * @param {boolean} [options.source]
+ * @param {boolean} [options.showcase]
  * @param {'full'|'compact'|'brief'} [options.detail]
  * @param {string} [options.lang]
  * @param {boolean} [options.zh]
@@ -40,6 +42,7 @@ export async function component(name, options = {}) {
     category,
     props = false,
     source = false,
+    showcase = false,
     detail = 'full',
     lang = null,
     zh = false,
@@ -131,6 +134,21 @@ export async function component(name, options = {}) {
       throw new XDSError(`Source for "${name}" not found`);
     }
     return {type: 'component.detail.source', data: {component: dirName, source: fs.readFileSync(sourcePath, 'utf-8')}};
+  }
+
+  if (showcase) {
+    const match = await findShowcase(dirName);
+    if (!match) {
+      throw new XDSError(`No showcase found for "${name}"`);
+    }
+    return {
+      type: 'component.detail.showcase',
+      data: {
+        component: dirName,
+        aspectRatio: match.aspectRatio,
+        source: fs.readFileSync(match.filePath, 'utf-8'),
+      },
+    };
   }
 
   let readmePath = findComponentReadme(coreDir, dirName);

--- a/packages/cli/src/api/template.mjs
+++ b/packages/cli/src/api/template.mjs
@@ -11,6 +11,7 @@ import {loadConfig} from '../lib/config.mjs';
 const TEMPLATES_DIR = path.join(CLI_ROOT, 'templates');
 const PAGES_DIR = path.join(TEMPLATES_DIR, 'pages');
 const BLOCKS_DIR = path.join(TEMPLATES_DIR, 'blocks');
+const SHOWCASE_DIR = path.join(TEMPLATES_DIR, 'showcase');
 
 async function loadDocModule(docPath) {
   if (!fs.existsSync(docPath)) return null;
@@ -106,6 +107,33 @@ export async function findRelatedBlocks(componentName) {
       c.toLowerCase() === componentName.toLowerCase(),
     ),
   );
+}
+
+async function discoverShowcases() {
+  if (!fs.existsSync(SHOWCASE_DIR)) return [];
+  const docFiles = fs.readdirSync(SHOWCASE_DIR).filter(f => f.endsWith('.doc.mjs'));
+  const showcases = [];
+  for (const docFile of docFiles) {
+    const basename = path.basename(docFile, '.doc.mjs');
+    const tsxPath = path.join(SHOWCASE_DIR, basename + '.tsx');
+    if (!fs.existsSync(tsxPath)) continue;
+    const docPath = path.join(SHOWCASE_DIR, docFile);
+    const doc = await loadDocModule(docPath);
+    showcases.push({
+      name: doc?.name || basename,
+      aspectRatio: doc?.aspectRatio ?? 1,
+      filePath: tsxPath,
+      docPath,
+    });
+  }
+  return showcases;
+}
+
+export async function findShowcase(componentName) {
+  const showcases = await discoverShowcases();
+  return showcases.find(s =>
+    s.name.toLowerCase() === componentName.toLowerCase(),
+  ) ?? null;
 }
 
 const UBIQUITOUS = new Set([

--- a/packages/cli/src/commands/component/index.mjs
+++ b/packages/cli/src/commands/component/index.mjs
@@ -33,6 +33,7 @@ export function registerComponent(program) {
     .option('--category <category>', 'List components in a specific category')
     .option('--props', 'Print only the props table')
     .option('--source', 'Print component source code')
+    .option('--showcase', 'Print showcase source code')
     .action(async (name, options) => {
       const run = getRunPrefix();
       const zh = program.opts().zh || false;
@@ -57,6 +58,7 @@ export function registerComponent(program) {
           category: options.category,
           props: options.props,
           source: options.source,
+          showcase: options.showcase,
           detail,
           lang, zh, dense,
         });
@@ -141,6 +143,11 @@ export function registerComponent(program) {
         }
 
         case 'component.detail.source': {
+          console.log(result.data.source);
+          break;
+        }
+
+        case 'component.detail.showcase': {
           console.log(result.data.source);
           break;
         }

--- a/packages/cli/src/types/api.d.ts
+++ b/packages/cli/src/types/api.d.ts
@@ -11,6 +11,7 @@ import type {
   ComponentDetailResponse,
   ComponentDetailPropsResponse,
   ComponentDetailSourceResponse,
+  ComponentDetailShowcaseResponse,
 } from './component';
 import type {
   DocsListResponse,
@@ -48,6 +49,7 @@ export interface ComponentOptions {
   category?: string;
   props?: boolean;
   source?: boolean;
+  showcase?: boolean;
   detail?: 'full' | 'compact' | 'brief';
   lang?: string;
   zh?: boolean;
@@ -59,7 +61,8 @@ type ComponentResult =
   | ComponentBriefResponse
   | ComponentDetailResponse
   | ComponentDetailPropsResponse
-  | ComponentDetailSourceResponse;
+  | ComponentDetailSourceResponse
+  | ComponentDetailShowcaseResponse;
 
 export declare function component(
   name?: string,

--- a/packages/cli/src/types/base.d.ts
+++ b/packages/cli/src/types/base.d.ts
@@ -12,6 +12,7 @@ import type {
   ComponentDetailResponse,
   ComponentDetailPropsResponse,
   ComponentDetailSourceResponse,
+  ComponentDetailShowcaseResponse,
 } from './component';
 import type {
   DiscoverListResponse,
@@ -60,6 +61,7 @@ export type CLIAnyResponse =
   | ComponentDetailResponse
   | ComponentDetailPropsResponse
   | ComponentDetailSourceResponse
+  | ComponentDetailShowcaseResponse
   | DiscoverListResponse
   | DiscoverDetailResponse
   | DiscoverDetailDocResponse

--- a/packages/cli/src/types/component.d.ts
+++ b/packages/cli/src/types/component.d.ts
@@ -10,6 +10,7 @@
  * xds --json component Button               -> component.detail
  * xds --json component Button --props       -> component.detail.props
  * xds --json component Button --source      -> component.detail.source
+ * xds --json component Button --showcase    -> component.detail.showcase
  * (not found)                               -> CLIError
  */
 
@@ -49,4 +50,10 @@ export interface ComponentDetailPropsResponse {
 export interface ComponentDetailSourceResponse {
   type: 'component.detail.source';
   data: {component: string; source: string};
+}
+
+/** xds --json component <name> --showcase */
+export interface ComponentDetailShowcaseResponse {
+  type: 'component.detail.showcase';
+  data: {component: string; aspectRatio: number; source: string};
 }

--- a/packages/cli/templates/showcase/AlertDialog.doc.mjs
+++ b/packages/cli/templates/showcase/AlertDialog.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'AlertDialog', aspectRatio: 4 / 3};

--- a/packages/cli/templates/showcase/AlertDialog.tsx
+++ b/packages/cli/templates/showcase/AlertDialog.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import {XDSAlertDialog} from '@xds/core/AlertDialog';
+
+export default function AlertDialogShowcase() {
+  return <XDSAlertDialog title="Confirm" description="Are you sure?" />;
+}

--- a/packages/cli/templates/showcase/AppShell.doc.mjs
+++ b/packages/cli/templates/showcase/AppShell.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'AppShell', aspectRatio: 16 / 9};

--- a/packages/cli/templates/showcase/AppShell.tsx
+++ b/packages/cli/templates/showcase/AppShell.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import {XDSAppShell} from '@xds/core/AppShell';
+
+export default function AppShellShowcase() {
+  return (
+    <XDSAppShell>
+      <div>Content</div>
+    </XDSAppShell>
+  );
+}

--- a/packages/cli/templates/showcase/AspectRatio.doc.mjs
+++ b/packages/cli/templates/showcase/AspectRatio.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'AspectRatio', aspectRatio: 16 / 9};

--- a/packages/cli/templates/showcase/AspectRatio.tsx
+++ b/packages/cli/templates/showcase/AspectRatio.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import {XDSAspectRatio} from '@xds/core/AspectRatio';
+
+export default function AspectRatioShowcase() {
+  return (
+    <XDSAspectRatio ratio={16 / 9}>
+      <div style={{background: '#eee', height: '100%'}} />
+    </XDSAspectRatio>
+  );
+}

--- a/packages/cli/templates/showcase/Avatar.doc.mjs
+++ b/packages/cli/templates/showcase/Avatar.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'Avatar', aspectRatio: 1};

--- a/packages/cli/templates/showcase/Avatar.tsx
+++ b/packages/cli/templates/showcase/Avatar.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import {XDSAvatar} from '@xds/core/Avatar';
+
+export default function AvatarShowcase() {
+  return <XDSAvatar name="Jane Doe" />;
+}

--- a/packages/cli/templates/showcase/Badge.doc.mjs
+++ b/packages/cli/templates/showcase/Badge.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'Badge', aspectRatio: 1};

--- a/packages/cli/templates/showcase/Badge.tsx
+++ b/packages/cli/templates/showcase/Badge.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import {XDSBadge} from '@xds/core/Badge';
+
+export default function BadgeShowcase() {
+  return <XDSBadge label="New" />;
+}

--- a/packages/cli/templates/showcase/Banner.doc.mjs
+++ b/packages/cli/templates/showcase/Banner.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'Banner', aspectRatio: 16 / 4};

--- a/packages/cli/templates/showcase/Banner.tsx
+++ b/packages/cli/templates/showcase/Banner.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import {XDSBanner} from '@xds/core/Banner';
+
+export default function BannerShowcase() {
+  return <XDSBanner variant="info">Important update</XDSBanner>;
+}

--- a/packages/cli/templates/showcase/Breadcrumbs.doc.mjs
+++ b/packages/cli/templates/showcase/Breadcrumbs.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'Breadcrumbs', aspectRatio: 16 / 4};

--- a/packages/cli/templates/showcase/Breadcrumbs.tsx
+++ b/packages/cli/templates/showcase/Breadcrumbs.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import {XDSBreadcrumbs} from '@xds/core/Breadcrumbs';
+
+export default function BreadcrumbsShowcase() {
+  return <XDSBreadcrumbs items={[{label: 'Home'}, {label: 'Settings'}]} />;
+}

--- a/packages/cli/templates/showcase/Button.doc.mjs
+++ b/packages/cli/templates/showcase/Button.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'Button', aspectRatio: 1};

--- a/packages/cli/templates/showcase/Button.tsx
+++ b/packages/cli/templates/showcase/Button.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import {XDSButton} from '@xds/core/Button';
+
+export default function ButtonShowcase() {
+  return <XDSButton label="Click me" variant="primary" />;
+}

--- a/packages/cli/templates/showcase/Calendar.doc.mjs
+++ b/packages/cli/templates/showcase/Calendar.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'Calendar', aspectRatio: 3 / 4};

--- a/packages/cli/templates/showcase/Calendar.tsx
+++ b/packages/cli/templates/showcase/Calendar.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import {XDSCalendar} from '@xds/core/Calendar';
+
+export default function CalendarShowcase() {
+  return <XDSCalendar />;
+}

--- a/packages/cli/templates/showcase/Card.doc.mjs
+++ b/packages/cli/templates/showcase/Card.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'Card', aspectRatio: 4 / 3};

--- a/packages/cli/templates/showcase/Card.tsx
+++ b/packages/cli/templates/showcase/Card.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import {XDSCard} from '@xds/core/Card';
+
+export default function CardShowcase() {
+  return <XDSCard>Card content</XDSCard>;
+}

--- a/packages/cli/templates/showcase/Carousel.doc.mjs
+++ b/packages/cli/templates/showcase/Carousel.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'Carousel', aspectRatio: 16 / 9};

--- a/packages/cli/templates/showcase/Carousel.tsx
+++ b/packages/cli/templates/showcase/Carousel.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import {XDSCarousel} from '@xds/core/Carousel';
+
+export default function CarouselShowcase() {
+  return (
+    <XDSCarousel>
+      <div>Slide 1</div>
+    </XDSCarousel>
+  );
+}

--- a/packages/cli/templates/showcase/Center.doc.mjs
+++ b/packages/cli/templates/showcase/Center.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'Center', aspectRatio: 1};

--- a/packages/cli/templates/showcase/Center.tsx
+++ b/packages/cli/templates/showcase/Center.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import {XDSCenter} from '@xds/core/Center';
+
+export default function CenterShowcase() {
+  return <XDSCenter>Centered</XDSCenter>;
+}

--- a/packages/cli/templates/showcase/Chat.doc.mjs
+++ b/packages/cli/templates/showcase/Chat.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'Chat', aspectRatio: 4 / 3};

--- a/packages/cli/templates/showcase/Chat.tsx
+++ b/packages/cli/templates/showcase/Chat.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import {
+  XDSChatMessageList,
+  XDSChatMessage,
+  XDSChatBubble,
+} from '@xds/core/Chat';
+
+export default function ChatShowcase() {
+  return (
+    <XDSChatMessageList>
+      <XDSChatMessage sender="user">
+        <XDSChatBubble>Hello</XDSChatBubble>
+      </XDSChatMessage>
+    </XDSChatMessageList>
+  );
+}

--- a/packages/cli/templates/showcase/CheckboxInput.doc.mjs
+++ b/packages/cli/templates/showcase/CheckboxInput.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'CheckboxInput', aspectRatio: 4 / 3};

--- a/packages/cli/templates/showcase/CheckboxInput.tsx
+++ b/packages/cli/templates/showcase/CheckboxInput.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import {XDSCheckboxInput} from '@xds/core/CheckboxInput';
+
+export default function CheckboxInputShowcase() {
+  return <XDSCheckboxInput label="Accept terms" />;
+}

--- a/packages/cli/templates/showcase/CheckboxList.doc.mjs
+++ b/packages/cli/templates/showcase/CheckboxList.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'CheckboxList', aspectRatio: 4 / 3};

--- a/packages/cli/templates/showcase/CheckboxList.tsx
+++ b/packages/cli/templates/showcase/CheckboxList.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import {XDSCheckboxList} from '@xds/core/CheckboxList';
+
+export default function CheckboxListShowcase() {
+  return (
+    <XDSCheckboxList
+      label="Options"
+      items={[{label: 'Option A', value: 'a'}]}
+    />
+  );
+}

--- a/packages/cli/templates/showcase/Collapsible.doc.mjs
+++ b/packages/cli/templates/showcase/Collapsible.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'Collapsible', aspectRatio: 4 / 3};

--- a/packages/cli/templates/showcase/Collapsible.tsx
+++ b/packages/cli/templates/showcase/Collapsible.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import {XDSCollapsible} from '@xds/core/Collapsible';
+
+export default function CollapsibleShowcase() {
+  return <XDSCollapsible trigger="Details">Hidden content</XDSCollapsible>;
+}

--- a/packages/cli/templates/showcase/DateInput.doc.mjs
+++ b/packages/cli/templates/showcase/DateInput.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'DateInput', aspectRatio: 4 / 3};

--- a/packages/cli/templates/showcase/DateInput.tsx
+++ b/packages/cli/templates/showcase/DateInput.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import {XDSDateInput} from '@xds/core/DateInput';
+
+export default function DateInputShowcase() {
+  return <XDSDateInput label="Date" />;
+}

--- a/packages/cli/templates/showcase/Dialog.doc.mjs
+++ b/packages/cli/templates/showcase/Dialog.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'Dialog', aspectRatio: 4 / 3};

--- a/packages/cli/templates/showcase/Dialog.tsx
+++ b/packages/cli/templates/showcase/Dialog.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import {XDSDialog} from '@xds/core/Dialog';
+
+export default function DialogShowcase() {
+  return (
+    <XDSDialog isOpen={true} onOpenChange={() => {}}>
+      Dialog content
+    </XDSDialog>
+  );
+}

--- a/packages/cli/templates/showcase/Divider.doc.mjs
+++ b/packages/cli/templates/showcase/Divider.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'Divider', aspectRatio: 16 / 4};

--- a/packages/cli/templates/showcase/Divider.tsx
+++ b/packages/cli/templates/showcase/Divider.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import {XDSDivider} from '@xds/core/Divider';
+
+export default function DividerShowcase() {
+  return <XDSDivider />;
+}

--- a/packages/cli/templates/showcase/DropdownMenu.doc.mjs
+++ b/packages/cli/templates/showcase/DropdownMenu.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'DropdownMenu', aspectRatio: 4 / 3};

--- a/packages/cli/templates/showcase/DropdownMenu.tsx
+++ b/packages/cli/templates/showcase/DropdownMenu.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import {XDSDropdownMenu} from '@xds/core/DropdownMenu';
+
+export default function DropdownMenuShowcase() {
+  return (
+    <XDSDropdownMenu
+      trigger={<button>Menu</button>}
+      items={[{label: 'Edit'}]}
+    />
+  );
+}

--- a/packages/cli/templates/showcase/EmptyState.doc.mjs
+++ b/packages/cli/templates/showcase/EmptyState.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'EmptyState', aspectRatio: 4 / 3};

--- a/packages/cli/templates/showcase/EmptyState.tsx
+++ b/packages/cli/templates/showcase/EmptyState.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import {XDSEmptyState} from '@xds/core/EmptyState';
+
+export default function EmptyStateShowcase() {
+  return <XDSEmptyState title="No results" />;
+}

--- a/packages/cli/templates/showcase/Field.doc.mjs
+++ b/packages/cli/templates/showcase/Field.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'Field', aspectRatio: 4 / 3};

--- a/packages/cli/templates/showcase/Field.tsx
+++ b/packages/cli/templates/showcase/Field.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import {XDSField} from '@xds/core/Field';
+
+export default function FieldShowcase() {
+  return (
+    <XDSField label="Name">
+      <input />
+    </XDSField>
+  );
+}

--- a/packages/cli/templates/showcase/FormLayout.doc.mjs
+++ b/packages/cli/templates/showcase/FormLayout.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'FormLayout', aspectRatio: 4 / 3};

--- a/packages/cli/templates/showcase/FormLayout.tsx
+++ b/packages/cli/templates/showcase/FormLayout.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import {XDSFormLayout} from '@xds/core/FormLayout';
+
+export default function FormLayoutShowcase() {
+  return <XDSFormLayout>Form fields</XDSFormLayout>;
+}

--- a/packages/cli/templates/showcase/Grid.doc.mjs
+++ b/packages/cli/templates/showcase/Grid.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'Grid', aspectRatio: 4 / 3};

--- a/packages/cli/templates/showcase/Grid.tsx
+++ b/packages/cli/templates/showcase/Grid.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import {XDSGrid} from '@xds/core/Grid';
+
+export default function GridShowcase() {
+  return (
+    <XDSGrid columns={3}>
+      <div>1</div>
+      <div>2</div>
+      <div>3</div>
+    </XDSGrid>
+  );
+}

--- a/packages/cli/templates/showcase/HoverCard.doc.mjs
+++ b/packages/cli/templates/showcase/HoverCard.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'HoverCard', aspectRatio: 1};

--- a/packages/cli/templates/showcase/HoverCard.tsx
+++ b/packages/cli/templates/showcase/HoverCard.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import {XDSHoverCard} from '@xds/core/HoverCard';
+
+export default function HoverCardShowcase() {
+  return <XDSHoverCard trigger={<span>Hover</span>}>Details</XDSHoverCard>;
+}

--- a/packages/cli/templates/showcase/Icon.doc.mjs
+++ b/packages/cli/templates/showcase/Icon.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'Icon', aspectRatio: 1};

--- a/packages/cli/templates/showcase/Icon.tsx
+++ b/packages/cli/templates/showcase/Icon.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import {XDSIcon} from '@xds/core/Icon';
+
+export default function IconShowcase() {
+  return <XDSIcon name="star" />;
+}

--- a/packages/cli/templates/showcase/IconButton.doc.mjs
+++ b/packages/cli/templates/showcase/IconButton.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'IconButton', aspectRatio: 1};

--- a/packages/cli/templates/showcase/IconButton.tsx
+++ b/packages/cli/templates/showcase/IconButton.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import {XDSIconButton} from '@xds/core/IconButton';
+
+export default function IconButtonShowcase() {
+  return <XDSIconButton label="Settings" icon="gear" />;
+}

--- a/packages/cli/templates/showcase/Kbd.doc.mjs
+++ b/packages/cli/templates/showcase/Kbd.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'Kbd', aspectRatio: 1};

--- a/packages/cli/templates/showcase/Kbd.tsx
+++ b/packages/cli/templates/showcase/Kbd.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import {XDSKbd} from '@xds/core/Kbd';
+
+export default function KbdShowcase() {
+  return <XDSKbd>⌘K</XDSKbd>;
+}

--- a/packages/cli/templates/showcase/Layer.doc.mjs
+++ b/packages/cli/templates/showcase/Layer.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'Layer', aspectRatio: 1};

--- a/packages/cli/templates/showcase/Layer.tsx
+++ b/packages/cli/templates/showcase/Layer.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import {XDSLayer} from '@xds/core/Layer';
+
+export default function LayerShowcase() {
+  return <XDSLayer>Layer content</XDSLayer>;
+}

--- a/packages/cli/templates/showcase/Layout.doc.mjs
+++ b/packages/cli/templates/showcase/Layout.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'Layout', aspectRatio: 16 / 9};

--- a/packages/cli/templates/showcase/Layout.tsx
+++ b/packages/cli/templates/showcase/Layout.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import {XDSLayout} from '@xds/core/Layout';
+
+export default function LayoutShowcase() {
+  return <XDSLayout>Layout content</XDSLayout>;
+}

--- a/packages/cli/templates/showcase/Link.doc.mjs
+++ b/packages/cli/templates/showcase/Link.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'Link', aspectRatio: 1};

--- a/packages/cli/templates/showcase/Link.tsx
+++ b/packages/cli/templates/showcase/Link.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import {XDSLink} from '@xds/core/Link';
+
+export default function LinkShowcase() {
+  return <XDSLink href="#">Link text</XDSLink>;
+}

--- a/packages/cli/templates/showcase/List.doc.mjs
+++ b/packages/cli/templates/showcase/List.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'List', aspectRatio: 3 / 4};

--- a/packages/cli/templates/showcase/List.tsx
+++ b/packages/cli/templates/showcase/List.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import {XDSList, XDSListItem} from '@xds/core/List';
+
+export default function ListShowcase() {
+  return (
+    <XDSList>
+      <XDSListItem>Item 1</XDSListItem>
+    </XDSList>
+  );
+}

--- a/packages/cli/templates/showcase/Markdown.doc.mjs
+++ b/packages/cli/templates/showcase/Markdown.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'Markdown', aspectRatio: 4 / 3};

--- a/packages/cli/templates/showcase/Markdown.tsx
+++ b/packages/cli/templates/showcase/Markdown.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import {XDSMarkdown} from '@xds/core/Markdown';
+
+export default function MarkdownShowcase() {
+  return <XDSMarkdown content="# Hello" />;
+}

--- a/packages/cli/templates/showcase/MetadataList.doc.mjs
+++ b/packages/cli/templates/showcase/MetadataList.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'MetadataList', aspectRatio: 4 / 3};

--- a/packages/cli/templates/showcase/MetadataList.tsx
+++ b/packages/cli/templates/showcase/MetadataList.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import {XDSMetadataList} from '@xds/core/MetadataList';
+
+export default function MetadataListShowcase() {
+  return <XDSMetadataList items={[{label: 'Status', value: 'Active'}]} />;
+}

--- a/packages/cli/templates/showcase/MobileNav.doc.mjs
+++ b/packages/cli/templates/showcase/MobileNav.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'MobileNav', aspectRatio: 3 / 4};

--- a/packages/cli/templates/showcase/MobileNav.tsx
+++ b/packages/cli/templates/showcase/MobileNav.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import {XDSMobileNav} from '@xds/core/MobileNav';
+
+export default function MobileNavShowcase() {
+  return <XDSMobileNav>Nav items</XDSMobileNav>;
+}

--- a/packages/cli/templates/showcase/MoreMenu.doc.mjs
+++ b/packages/cli/templates/showcase/MoreMenu.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'MoreMenu', aspectRatio: 4 / 3};

--- a/packages/cli/templates/showcase/MoreMenu.tsx
+++ b/packages/cli/templates/showcase/MoreMenu.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import {XDSMoreMenu} from '@xds/core/MoreMenu';
+
+export default function MoreMenuShowcase() {
+  return <XDSMoreMenu items={[{label: 'Edit'}]} />;
+}

--- a/packages/cli/templates/showcase/MultiSelector.doc.mjs
+++ b/packages/cli/templates/showcase/MultiSelector.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'MultiSelector', aspectRatio: 4 / 3};

--- a/packages/cli/templates/showcase/MultiSelector.tsx
+++ b/packages/cli/templates/showcase/MultiSelector.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import {XDSMultiSelector} from '@xds/core/MultiSelector';
+
+export default function MultiSelectorShowcase() {
+  return <XDSMultiSelector label="Tags" items={[]} />;
+}

--- a/packages/cli/templates/showcase/NavIcon.doc.mjs
+++ b/packages/cli/templates/showcase/NavIcon.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'NavIcon', aspectRatio: 16 / 4};

--- a/packages/cli/templates/showcase/NavIcon.tsx
+++ b/packages/cli/templates/showcase/NavIcon.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import {XDSNavIcon} from '@xds/core/NavIcon';
+
+export default function NavIconShowcase() {
+  return <XDSNavIcon label="Home" />;
+}

--- a/packages/cli/templates/showcase/NumberInput.doc.mjs
+++ b/packages/cli/templates/showcase/NumberInput.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'NumberInput', aspectRatio: 4 / 3};

--- a/packages/cli/templates/showcase/NumberInput.tsx
+++ b/packages/cli/templates/showcase/NumberInput.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import {XDSNumberInput} from '@xds/core/NumberInput';
+
+export default function NumberInputShowcase() {
+  return <XDSNumberInput label="Amount" value={0} onChange={() => {}} />;
+}

--- a/packages/cli/templates/showcase/OverflowList.doc.mjs
+++ b/packages/cli/templates/showcase/OverflowList.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'OverflowList', aspectRatio: 16 / 4};

--- a/packages/cli/templates/showcase/OverflowList.tsx
+++ b/packages/cli/templates/showcase/OverflowList.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import {XDSOverflowList} from '@xds/core/OverflowList';
+
+export default function OverflowListShowcase() {
+  return (
+    <XDSOverflowList
+      items={[]}
+      renderItem={() => null}
+      renderOverflow={() => null}
+    />
+  );
+}

--- a/packages/cli/templates/showcase/Pagination.doc.mjs
+++ b/packages/cli/templates/showcase/Pagination.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'Pagination', aspectRatio: 16 / 4};

--- a/packages/cli/templates/showcase/Pagination.tsx
+++ b/packages/cli/templates/showcase/Pagination.tsx
@@ -1,0 +1,9 @@
+'use client';
+
+import {XDSPagination} from '@xds/core/Pagination';
+
+export default function PaginationShowcase() {
+  return (
+    <XDSPagination totalPages={10} currentPage={1} onPageChange={() => {}} />
+  );
+}

--- a/packages/cli/templates/showcase/Popover.doc.mjs
+++ b/packages/cli/templates/showcase/Popover.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'Popover', aspectRatio: 4 / 3};

--- a/packages/cli/templates/showcase/Popover.tsx
+++ b/packages/cli/templates/showcase/Popover.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import {XDSPopover} from '@xds/core/Popover';
+
+export default function PopoverShowcase() {
+  return <XDSPopover trigger={<button>Open</button>}>Content</XDSPopover>;
+}

--- a/packages/cli/templates/showcase/PowerSearch.doc.mjs
+++ b/packages/cli/templates/showcase/PowerSearch.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'PowerSearch', aspectRatio: 4 / 3};

--- a/packages/cli/templates/showcase/PowerSearch.tsx
+++ b/packages/cli/templates/showcase/PowerSearch.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import {XDSPowerSearch} from '@xds/core/PowerSearch';
+
+export default function PowerSearchShowcase() {
+  return <XDSPowerSearch config={{name: 'search', fields: []}} />;
+}

--- a/packages/cli/templates/showcase/ProgressBar.doc.mjs
+++ b/packages/cli/templates/showcase/ProgressBar.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'ProgressBar', aspectRatio: 16 / 4};

--- a/packages/cli/templates/showcase/ProgressBar.tsx
+++ b/packages/cli/templates/showcase/ProgressBar.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import {XDSProgressBar} from '@xds/core/ProgressBar';
+
+export default function ProgressBarShowcase() {
+  return <XDSProgressBar label="Loading" value={60} />;
+}

--- a/packages/cli/templates/showcase/RadioList.doc.mjs
+++ b/packages/cli/templates/showcase/RadioList.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'RadioList', aspectRatio: 4 / 3};

--- a/packages/cli/templates/showcase/RadioList.tsx
+++ b/packages/cli/templates/showcase/RadioList.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import {XDSRadioList} from '@xds/core/RadioList';
+
+export default function RadioListShowcase() {
+  return <XDSRadioList label="Choice" items={[{label: 'A', value: 'a'}]} />;
+}

--- a/packages/cli/templates/showcase/Section.doc.mjs
+++ b/packages/cli/templates/showcase/Section.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'Section', aspectRatio: 4 / 3};

--- a/packages/cli/templates/showcase/Section.tsx
+++ b/packages/cli/templates/showcase/Section.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import {XDSSection} from '@xds/core/Section';
+
+export default function SectionShowcase() {
+  return <XDSSection title="Section">Content</XDSSection>;
+}

--- a/packages/cli/templates/showcase/SegmentedControl.doc.mjs
+++ b/packages/cli/templates/showcase/SegmentedControl.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'SegmentedControl', aspectRatio: 4 / 3};

--- a/packages/cli/templates/showcase/SegmentedControl.tsx
+++ b/packages/cli/templates/showcase/SegmentedControl.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import {XDSSegmentedControl} from '@xds/core/SegmentedControl';
+
+export default function SegmentedControlShowcase() {
+  return <XDSSegmentedControl items={[{label: 'Tab 1', value: '1'}]} />;
+}

--- a/packages/cli/templates/showcase/Selector.doc.mjs
+++ b/packages/cli/templates/showcase/Selector.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'Selector', aspectRatio: 4 / 3};

--- a/packages/cli/templates/showcase/Selector.tsx
+++ b/packages/cli/templates/showcase/Selector.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import {XDSSelector} from '@xds/core/Selector';
+
+export default function SelectorShowcase() {
+  return <XDSSelector label="Choose" items={['Option A', 'Option B']} />;
+}

--- a/packages/cli/templates/showcase/SideNav.doc.mjs
+++ b/packages/cli/templates/showcase/SideNav.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'SideNav', aspectRatio: 3 / 4};

--- a/packages/cli/templates/showcase/SideNav.tsx
+++ b/packages/cli/templates/showcase/SideNav.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import {XDSSideNav, XDSSideNavItem} from '@xds/core/SideNav';
+
+export default function SideNavShowcase() {
+  return (
+    <XDSSideNav>
+      <XDSSideNavItem label="Dashboard" />
+    </XDSSideNav>
+  );
+}

--- a/packages/cli/templates/showcase/Skeleton.doc.mjs
+++ b/packages/cli/templates/showcase/Skeleton.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'Skeleton', aspectRatio: 4 / 3};

--- a/packages/cli/templates/showcase/Skeleton.tsx
+++ b/packages/cli/templates/showcase/Skeleton.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import {XDSSkeleton} from '@xds/core/Skeleton';
+
+export default function SkeletonShowcase() {
+  return <XDSSkeleton />;
+}

--- a/packages/cli/templates/showcase/Slider.doc.mjs
+++ b/packages/cli/templates/showcase/Slider.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'Slider', aspectRatio: 4 / 3};

--- a/packages/cli/templates/showcase/Slider.tsx
+++ b/packages/cli/templates/showcase/Slider.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import {XDSSlider} from '@xds/core/Slider';
+
+export default function SliderShowcase() {
+  return <XDSSlider label="Volume" value={50} onChange={() => {}} />;
+}

--- a/packages/cli/templates/showcase/Spinner.doc.mjs
+++ b/packages/cli/templates/showcase/Spinner.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'Spinner', aspectRatio: 1};

--- a/packages/cli/templates/showcase/Spinner.tsx
+++ b/packages/cli/templates/showcase/Spinner.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import {XDSSpinner} from '@xds/core/Spinner';
+
+export default function SpinnerShowcase() {
+  return <XDSSpinner label="Loading" />;
+}

--- a/packages/cli/templates/showcase/Stack.doc.mjs
+++ b/packages/cli/templates/showcase/Stack.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'Stack', aspectRatio: 4 / 3};

--- a/packages/cli/templates/showcase/Stack.tsx
+++ b/packages/cli/templates/showcase/Stack.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import {XDSVStack} from '@xds/core/Stack';
+
+export default function StackShowcase() {
+  return (
+    <XDSVStack gap={2}>
+      <div>Item 1</div>
+      <div>Item 2</div>
+    </XDSVStack>
+  );
+}

--- a/packages/cli/templates/showcase/StatusDot.doc.mjs
+++ b/packages/cli/templates/showcase/StatusDot.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'StatusDot', aspectRatio: 1};

--- a/packages/cli/templates/showcase/StatusDot.tsx
+++ b/packages/cli/templates/showcase/StatusDot.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import {XDSStatusDot} from '@xds/core/StatusDot';
+
+export default function StatusDotShowcase() {
+  return <XDSStatusDot variant="positive" label="Online" />;
+}

--- a/packages/cli/templates/showcase/Switch.doc.mjs
+++ b/packages/cli/templates/showcase/Switch.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'Switch', aspectRatio: 4 / 3};

--- a/packages/cli/templates/showcase/Switch.tsx
+++ b/packages/cli/templates/showcase/Switch.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import {XDSSwitch} from '@xds/core/Switch';
+
+export default function SwitchShowcase() {
+  return <XDSSwitch label="Dark mode" />;
+}

--- a/packages/cli/templates/showcase/TabList.doc.mjs
+++ b/packages/cli/templates/showcase/TabList.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'TabList', aspectRatio: 16 / 4};

--- a/packages/cli/templates/showcase/TabList.tsx
+++ b/packages/cli/templates/showcase/TabList.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import {XDSTabList} from '@xds/core/TabList';
+
+export default function TabListShowcase() {
+  return <XDSTabList tabs={[{label: 'Tab 1'}, {label: 'Tab 2'}]} />;
+}

--- a/packages/cli/templates/showcase/Table.doc.mjs
+++ b/packages/cli/templates/showcase/Table.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'Table', aspectRatio: 4 / 3};

--- a/packages/cli/templates/showcase/Table.tsx
+++ b/packages/cli/templates/showcase/Table.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import {XDSTable} from '@xds/core/Table';
+
+export default function TableShowcase() {
+  return <XDSTable data={[]} columns={[]} />;
+}

--- a/packages/cli/templates/showcase/Text.doc.mjs
+++ b/packages/cli/templates/showcase/Text.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'Text', aspectRatio: 1};

--- a/packages/cli/templates/showcase/Text.tsx
+++ b/packages/cli/templates/showcase/Text.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import {XDSText} from '@xds/core/Text';
+
+export default function TextShowcase() {
+  return <XDSText type="body">Hello world</XDSText>;
+}

--- a/packages/cli/templates/showcase/TextArea.doc.mjs
+++ b/packages/cli/templates/showcase/TextArea.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'TextArea', aspectRatio: 4 / 3};

--- a/packages/cli/templates/showcase/TextArea.tsx
+++ b/packages/cli/templates/showcase/TextArea.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import {XDSTextArea} from '@xds/core/TextArea';
+
+export default function TextAreaShowcase() {
+  return <XDSTextArea label="Description" value="" onChange={() => {}} />;
+}

--- a/packages/cli/templates/showcase/TextInput.doc.mjs
+++ b/packages/cli/templates/showcase/TextInput.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'TextInput', aspectRatio: 4 / 3};

--- a/packages/cli/templates/showcase/TextInput.tsx
+++ b/packages/cli/templates/showcase/TextInput.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import {XDSTextInput} from '@xds/core/TextInput';
+
+export default function TextInputShowcase() {
+  return <XDSTextInput label="Name" value="" onChange={() => {}} />;
+}

--- a/packages/cli/templates/showcase/Thumbnail.doc.mjs
+++ b/packages/cli/templates/showcase/Thumbnail.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'Thumbnail', aspectRatio: 1};

--- a/packages/cli/templates/showcase/Thumbnail.tsx
+++ b/packages/cli/templates/showcase/Thumbnail.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import {XDSThumbnail} from '@xds/core/Thumbnail';
+
+export default function ThumbnailShowcase() {
+  return <XDSThumbnail src="https://via.placeholder.com/80" alt="Preview" />;
+}

--- a/packages/cli/templates/showcase/TimeInput.doc.mjs
+++ b/packages/cli/templates/showcase/TimeInput.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'TimeInput', aspectRatio: 4 / 3};

--- a/packages/cli/templates/showcase/TimeInput.tsx
+++ b/packages/cli/templates/showcase/TimeInput.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import {XDSTimeInput} from '@xds/core/TimeInput';
+
+export default function TimeInputShowcase() {
+  return <XDSTimeInput label="Time" />;
+}

--- a/packages/cli/templates/showcase/Timestamp.doc.mjs
+++ b/packages/cli/templates/showcase/Timestamp.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'Timestamp', aspectRatio: 1};

--- a/packages/cli/templates/showcase/Timestamp.tsx
+++ b/packages/cli/templates/showcase/Timestamp.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import {XDSTimestamp} from '@xds/core/Timestamp';
+
+export default function TimestampShowcase() {
+  return <XDSTimestamp date={new Date()} />;
+}

--- a/packages/cli/templates/showcase/Toast.doc.mjs
+++ b/packages/cli/templates/showcase/Toast.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'Toast', aspectRatio: 4 / 3};

--- a/packages/cli/templates/showcase/Toast.tsx
+++ b/packages/cli/templates/showcase/Toast.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import {XDSToast} from '@xds/core/Toast';
+
+export default function ToastShowcase() {
+  return <XDSToast message="Saved successfully" />;
+}

--- a/packages/cli/templates/showcase/ToggleButton.doc.mjs
+++ b/packages/cli/templates/showcase/ToggleButton.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'ToggleButton', aspectRatio: 1};

--- a/packages/cli/templates/showcase/ToggleButton.tsx
+++ b/packages/cli/templates/showcase/ToggleButton.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import {XDSToggleButton} from '@xds/core/ToggleButton';
+
+export default function ToggleButtonShowcase() {
+  return <XDSToggleButton label="Bold" isIconOnly />;
+}

--- a/packages/cli/templates/showcase/Token.doc.mjs
+++ b/packages/cli/templates/showcase/Token.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'Token', aspectRatio: 1};

--- a/packages/cli/templates/showcase/Token.tsx
+++ b/packages/cli/templates/showcase/Token.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import {XDSToken} from '@xds/core/Token';
+
+export default function TokenShowcase() {
+  return <XDSToken label="Tag" />;
+}

--- a/packages/cli/templates/showcase/Tokenizer.doc.mjs
+++ b/packages/cli/templates/showcase/Tokenizer.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'Tokenizer', aspectRatio: 4 / 3};

--- a/packages/cli/templates/showcase/Tokenizer.tsx
+++ b/packages/cli/templates/showcase/Tokenizer.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import {XDSTokenizer} from '@xds/core/Tokenizer';
+
+export default function TokenizerShowcase() {
+  return <XDSTokenizer label="Tags" items={[]} />;
+}

--- a/packages/cli/templates/showcase/Toolbar.doc.mjs
+++ b/packages/cli/templates/showcase/Toolbar.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'Toolbar', aspectRatio: 16 / 4};

--- a/packages/cli/templates/showcase/Toolbar.tsx
+++ b/packages/cli/templates/showcase/Toolbar.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import {XDSToolbar} from '@xds/core/Toolbar';
+
+export default function ToolbarShowcase() {
+  return <XDSToolbar label="Actions" />;
+}

--- a/packages/cli/templates/showcase/Tooltip.doc.mjs
+++ b/packages/cli/templates/showcase/Tooltip.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'Tooltip', aspectRatio: 1};

--- a/packages/cli/templates/showcase/Tooltip.tsx
+++ b/packages/cli/templates/showcase/Tooltip.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import {XDSTooltip} from '@xds/core/Tooltip';
+
+export default function TooltipShowcase() {
+  return (
+    <XDSTooltip content="Help text">
+      <button>Hover</button>
+    </XDSTooltip>
+  );
+}

--- a/packages/cli/templates/showcase/TopNav.doc.mjs
+++ b/packages/cli/templates/showcase/TopNav.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'TopNav', aspectRatio: 16 / 4};

--- a/packages/cli/templates/showcase/TopNav.tsx
+++ b/packages/cli/templates/showcase/TopNav.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import {XDSTopNav} from '@xds/core/TopNav';
+
+export default function TopNavShowcase() {
+  return <XDSTopNav label="Navigation" />;
+}

--- a/packages/cli/templates/showcase/TreeList.doc.mjs
+++ b/packages/cli/templates/showcase/TreeList.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'TreeList', aspectRatio: 3 / 4};

--- a/packages/cli/templates/showcase/TreeList.tsx
+++ b/packages/cli/templates/showcase/TreeList.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import {XDSTreeList} from '@xds/core/TreeList';
+
+export default function TreeListShowcase() {
+  return <XDSTreeList items={[{label: 'Root'}]} />;
+}

--- a/packages/cli/templates/showcase/Typeahead.doc.mjs
+++ b/packages/cli/templates/showcase/Typeahead.doc.mjs
@@ -1,0 +1,2 @@
+/** @type {import('@xds/core').ComponentShowcaseDoc} */
+export const doc = {name: 'Typeahead', aspectRatio: 4 / 3};

--- a/packages/cli/templates/showcase/Typeahead.tsx
+++ b/packages/cli/templates/showcase/Typeahead.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import {XDSTypeahead} from '@xds/core/Typeahead';
+
+export default function TypeaheadShowcase() {
+  return <XDSTypeahead label="Search" />;
+}

--- a/packages/core/src/AlertDialog/AlertDialog.doc.mjs
+++ b/packages/core/src/AlertDialog/AlertDialog.doc.mjs
@@ -4,10 +4,6 @@ export const docs = {
   name: 'AlertDialog',
   description:
     'Confirmation dialog for destructive or irreversible actions. Uses role="alertdialog" with required title, description, and cancel/action buttons.',
-  showcase: {
-    aspectRatio: 4 / 3,
-    code: '<XDSAlertDialog title="Confirm" description="Are you sure?" />',
-  },
   keywords: [
     'alert',
     'alertdialog',

--- a/packages/core/src/AppShell/AppShell.doc.mjs
+++ b/packages/core/src/AppShell/AppShell.doc.mjs
@@ -4,10 +4,6 @@ export const docs = {
   name: 'AppShell',
   description:
     'Application-level layout shell providing header, side navigation, and main content area — composes XDSLayout internally and replaces the XDSPage + XDSPageLayout pattern.',
-  showcase: {
-    aspectRatio: 16 / 9,
-    code: '<XDSAppShell><div>Content</div></XDSAppShell>',
-  },
   keywords: ["appshell","layout","scaffold","sidebar","sidenav","topnav","header","navigation","dashboard","shell","page","frame"],
   features: [
     'Two navigation slots: topNav (horizontal bar) and sideNav (vertical sidebar)',

--- a/packages/core/src/AspectRatio/AspectRatio.doc.mjs
+++ b/packages/core/src/AspectRatio/AspectRatio.doc.mjs
@@ -2,12 +2,7 @@
 
 export const docs = {
   name: 'AspectRatio',
-  description: 'Maintains a specific aspect ratio for its children.',
-  showcase: {
-    aspectRatio: 16 / 9,
-    code: '<XDSAspectRatio ratio={16/9}><div style={{background: "#eee", height: "100%"}} /></XDSAspectRatio>',
-  },
-  keywords: ["aspect-ratio","ratio","proportion","responsive","embed","container","widescreen","thumbnail","letterbox","crop"],
+  description: 'Maintains a specific aspect ratio for its children.',  keywords: ["aspect-ratio","ratio","proportion","responsive","embed","container","widescreen","thumbnail","letterbox","crop"],
   features: [
     'Accepts any numeric ratio expressed as width/height (e.g. 16/9, 4/3, 1)',
     'Children are positioned absolutely to fill the container',

--- a/packages/core/src/Avatar/Avatar.doc.mjs
+++ b/packages/core/src/Avatar/Avatar.doc.mjs
@@ -4,10 +4,6 @@ export const docs = {
   name: 'Avatar',
   description:
     'Avatar component for displaying user profile pictures with fallback support.',
-  showcase: {
-    aspectRatio: 1,
-    code: '<XDSAvatar name="Jane Doe" />',
-  },
   keywords: ["avatar","profile","user","photo","thumbnail","initials","gravatar","pfp","userpic"],
   features: [
     'Image loading: Primary and fallback image sources',

--- a/packages/core/src/Badge/Badge.doc.mjs
+++ b/packages/core/src/Badge/Badge.doc.mjs
@@ -4,10 +4,6 @@ export const docs = {
   name: 'Badge',
   description:
     'A badge component for displaying status indicators, counts, or labels.',
-  showcase: {
-    aspectRatio: 1,
-    code: '<XDSBadge label="New" />',
-  },
   keywords: ["badge","tag","chip","label","status","indicator","count","counter","pill","notification","marker"],
   props: [
     {

--- a/packages/core/src/Banner/Banner.doc.mjs
+++ b/packages/core/src/Banner/Banner.doc.mjs
@@ -4,10 +4,6 @@ export const docs = {
   name: 'Banner',
   description:
     'Persistent status notification for info, warning, error, or success messages.',
-  showcase: {
-    aspectRatio: 16 / 4,
-    code: '<XDSBanner variant="info">Important update</XDSBanner>',
-  },
 
   keywords: ["banner","alert","notification","callout","notice","status","message","info","warning","error","success","toast"],
   features: [

--- a/packages/core/src/Breadcrumbs/Breadcrumbs.doc.mjs
+++ b/packages/core/src/Breadcrumbs/Breadcrumbs.doc.mjs
@@ -2,12 +2,7 @@
 
 export const docs = {
   name: 'Breadcrumbs',
-  description: 'A navigation breadcrumb trail with semantic HTML.',
-  showcase: {
-    aspectRatio: 16 / 4,
-    code: '<XDSBreadcrumbs items={[{label: "Home"}, {label: "Settings"}]} />',
-  },
-  keywords: ["breadcrumbs","breadcrumb","navigation","nav","crumbs","trail","path","hierarchy","wayfinding","steps"],
+  description: 'A navigation breadcrumb trail with semantic HTML.',  keywords: ["breadcrumbs","breadcrumb","navigation","nav","crumbs","trail","path","hierarchy","wayfinding","steps"],
   features: [
     'Renders a <nav> landmark with an ordered list of breadcrumb items',
     'Configurable separator between items (defaults to /)',

--- a/packages/core/src/Button/Button.doc.mjs
+++ b/packages/core/src/Button/Button.doc.mjs
@@ -4,10 +4,6 @@ export const docs = {
   name: 'Button',
   description:
     'XDSButton component with multiple variants, sizes, and isLoading state support.',
-  showcase: {
-    aspectRatio: 1,
-    code: '<XDSButton label="Click me" variant="primary" />',
-  },
 
   keywords: ["button","btn","cta","submit","action","loading","primary","secondary","ghost","destructive","danger"],
   features: [

--- a/packages/core/src/Calendar/Calendar.doc.mjs
+++ b/packages/core/src/Calendar/Calendar.doc.mjs
@@ -4,10 +4,6 @@ export const docs = {
   name: 'Calendar',
   description:
     'XDSCalendar component for date selection with single and range modes.',
-  showcase: {
-    aspectRatio: 3 / 4,
-    code: '<XDSCalendar />',
-  },
   keywords: ["calendar","datepicker","date picker","rangepicker","date range","monthview","daypicker"],
   features: [
     "Selection Modes: 'single' (default) and 'range'",

--- a/packages/core/src/Card/Card.doc.mjs
+++ b/packages/core/src/Card/Card.doc.mjs
@@ -3,10 +3,6 @@
 export const docs = {
   name: 'Card',
   description: 'Card container component with shadow and themed styling.',
-  showcase: {
-    aspectRatio: 4 / 3,
-    code: '<XDSCard>Card content</XDSCard>',
-  },
   keywords: ["card","surface","panel","container","elevated","shadow","box","paper","tile","well"],
   features: [
     'Top-level container for elevated content',

--- a/packages/core/src/Carousel/Carousel.doc.mjs
+++ b/packages/core/src/Carousel/Carousel.doc.mjs
@@ -4,10 +4,6 @@ export const docs = {
   name: 'Carousel',
   description:
     'Horizontal scroll container with fade-edge overflow indication, optional navigation buttons, and scroll-snap support.',
-  showcase: {
-    aspectRatio: 16 / 9,
-    code: '<XDSCarousel><div>Slide 1</div></XDSCarousel>',
-  },
   keywords: ['carousel', 'slider', 'scroll', 'gallery', 'filmstrip', 'swiper', 'horizontal', 'overflow', 'snap'],
   features: [
     'Overflow Detection: Gradient fades appear at edges when content overflows, signaling more items',

--- a/packages/core/src/Center/Center.doc.mjs
+++ b/packages/core/src/Center/Center.doc.mjs
@@ -3,10 +3,6 @@
 export const docs = {
   name: 'Center',
   description: 'Centers children horizontally and/or vertically using flexbox.',
-  showcase: {
-    aspectRatio: 1,
-    code: '<XDSCenter>Centered</XDSCenter>',
-  },
   keywords: ["center","centered","centering","align","alignment","justify","flexbox","middle"],
   features: [
     'Supports centering on both axes, horizontal only, or vertical only',

--- a/packages/core/src/Chat/Chat.doc.mjs
+++ b/packages/core/src/Chat/Chat.doc.mjs
@@ -4,10 +4,6 @@ export const docs = {
   name: 'Chat',
   description:
     'Chat components for AI chat interfaces. Layout (MessageList, Message, Bubble, SystemMessage) + Composer (Composer, ComposerInput with trigger menus, ComposerAttachments).',
-  showcase: {
-    aspectRatio: 4 / 3,
-    code: '<XDSChatMessageList><XDSChatMessage sender="user"><XDSChatBubble>Hello</XDSChatBubble></XDSChatMessage></XDSChatMessageList>',
-  },
   keywords: ['chat', 'message', 'bubble', 'conversation', 'ai', 'assistant', 'thread', 'system-message', 'composer', 'mention', 'trigger', 'typeahead', 'token', 'imperative', 'tokenized-text'],
   features: [
     'Composition model — MessageList > Message > Bubble',

--- a/packages/core/src/CheckboxInput/CheckboxInput.doc.mjs
+++ b/packages/core/src/CheckboxInput/CheckboxInput.doc.mjs
@@ -3,10 +3,6 @@
 export const docs = {
   name: 'CheckboxInput',
   description: 'A checkbox input component for toggling boolean values.',
-  showcase: {
-    aspectRatio: 4 / 3,
-    code: '<XDSCheckboxInput label="Accept terms" />',
-  },
   keywords: ["checkbox","check","toggle","tick","indeterminate","boolean","tristate"],
   features: [
     'Accessible — always includes a label (can be visually hidden)',

--- a/packages/core/src/CheckboxList/CheckboxList.doc.mjs
+++ b/packages/core/src/CheckboxList/CheckboxList.doc.mjs
@@ -3,12 +3,7 @@
 export const docs = {
   name: 'CheckboxList',
   description:
-    'A checkbox group component for multi-value selection from a list of options. Supports collection mode (parent-managed state) and standalone mode (per-item state).',
-  showcase: {
-    aspectRatio: 4 / 3,
-    code: '<XDSCheckboxList label="Options" items={[{label: "Option A", value: "a"}]} />',
-  },
-  keywords: ["checkboxlist","checkbox","checkboxgroup","multichoice","multiselect","checklist"],
+    'A checkbox group component for multi-value selection from a list of options. Supports collection mode (parent-managed state) and standalone mode (per-item state).',  keywords: ["checkboxlist","checkbox","checkboxgroup","multichoice","multiselect","checklist"],
   features: [
     'Accessible — uses native <input type="checkbox"> with proper ARIA attributes',
     'Collection mode — parent manages selected values as string[], items derive checked state',

--- a/packages/core/src/CodeBlock/XDSCodeBlock.doc.mjs
+++ b/packages/core/src/CodeBlock/XDSCodeBlock.doc.mjs
@@ -42,10 +42,6 @@ export const docs = {
         {name: 'style', type: 'CSSProperties', description: 'Inline styles. Prefer xstyle for StyleX-optimized styling.'},
         {name: 'data-testid', type: 'string', description: 'Test selector for automated testing frameworks.'},
       ],
-      examples: [
-        {label: 'Basic usage', code: '<XDSCodeBlock\n  code={`const x = 42;`}\n  language="typescript"\n  hasLineNumbers\n/>'},
-        {label: 'With title and line highlighting', code: '<XDSCodeBlock\n  code={snippetCode}\n  language="typescript"\n  title="utils.ts"\n  highlightLines={[3, 4, 5]}\n/>'},
-      ],
     },
     {
       name: 'XDSCode',
@@ -57,14 +53,7 @@ export const docs = {
         {name: 'style', type: 'CSSProperties', description: 'Inline styles. Prefer xstyle for StyleX-optimized styling.'},
         {name: 'data-testid', type: 'string', description: 'Test selector for automated testing frameworks.'},
       ],
-      examples: [
-        {label: 'Inline in prose', code: '<XDSText type="body">\n  Pass <XDSCode>xstyle</XDSCode> a <XDSCode>stylex.create()</XDSCode> value.\n</XDSText>'},
-      ],
     },
-  ],
-  examples: [
-    {label: 'TypeScript with line numbers', code: '<XDSCodeBlock\n  code={`function greet(name: string) { return name; }`}\n  language="typescript"\n  hasLineNumbers\n  title="greet.ts"\n/>'},
-    {label: 'Inline code in text', code: '<XDSText type="body">\n  Use <XDSCode>const</XDSCode> for block-scoped declarations.\n</XDSText>'},
   ],
   theming: {
     targets: [

--- a/packages/core/src/Collapsible/Collapsible.doc.mjs
+++ b/packages/core/src/Collapsible/Collapsible.doc.mjs
@@ -3,10 +3,6 @@
 export const docs = {
   name: 'Collapsible',
   description: 'Collapsible content primitive and group coordination.',
-  showcase: {
-    aspectRatio: 4 / 3,
-    code: '<XDSCollapsible trigger="Details">Hidden content</XDSCollapsible>',
-  },
   keywords: ["accordion","collapse","expandable","disclosure","toggle","panel","foldable","expander","expand"],
   features: [
     'XDSCollapsible makes any content collapsible — a trigger toggles visibility of the content area',

--- a/packages/core/src/CommandPalette/XDSCommandPalette.doc.mjs
+++ b/packages/core/src/CommandPalette/XDSCommandPalette.doc.mjs
@@ -113,21 +113,6 @@ export const docs = {
           default: '480',
         },
       ],
-      examples: [
-        {
-          label: 'Static source',
-          code: `const source = createStaticSource([
-  {id: 'home', label: 'Home'},
-  {id: 'settings', label: 'Settings'},
-]);
-
-<XDSCommandPalette
-  isOpen={isOpen}
-  onOpenChange={setIsOpen}
-  searchSource={source}
-/>`,
-        },
-      ],
     },
     {
       name: 'XDSCommandPaletteInput',
@@ -171,14 +156,6 @@ export const docs = {
             'StyleX styles for layout customization. Must be a stylex.create() value.',
         },
       ],
-      examples: [
-        {
-          label: 'Custom placeholder',
-          code: `<XDSCommandPalette isOpen={isOpen} onOpenChange={setIsOpen} searchSource={source}
-  input={<XDSCommandPaletteInput placeholder="Search commands..." />}
-/>`,
-        },
-      ],
     },
     {
       name: 'XDSCommandPaletteList',
@@ -202,16 +179,6 @@ export const docs = {
           type: 'StyleXStyles',
           description:
             'StyleX styles for layout customization. Must be a stylex.create() value.',
-        },
-      ],
-      examples: [
-        {
-          label: 'Basic',
-          code: `<XDSCommandPaletteList>
-  <XDSCommandPaletteItem value="home" onSelect={goHome}>
-    Go Home
-  </XDSCommandPaletteItem>
-</XDSCommandPaletteList>`,
         },
       ],
     },
@@ -264,16 +231,6 @@ export const docs = {
             'StyleX styles for layout customization. Must be a stylex.create() value.',
         },
       ],
-      examples: [
-        {
-          label: 'With icon and shortcut',
-          code: `<XDSCommandPaletteItem value="settings" onSelect={() => navigate('/settings')}>
-  <XDSIcon name="settings" size="sm" />
-  Settings
-  <XDSKbd keys={['⌘', ',']} />
-</XDSCommandPaletteItem>`,
-        },
-      ],
     },
     {
       name: 'XDSCommandPaletteGroup',
@@ -298,15 +255,6 @@ export const docs = {
             'StyleX styles for layout customization. Must be a stylex.create() value.',
         },
       ],
-      examples: [
-        {
-          label: 'Basic',
-          code: `<XDSCommandPaletteGroup heading="Navigation">
-  <XDSCommandPaletteItem value="home" onSelect={goHome}>Home</XDSCommandPaletteItem>
-  <XDSCommandPaletteItem value="settings" onSelect={goSettings}>Settings</XDSCommandPaletteItem>
-</XDSCommandPaletteGroup>`,
-        },
-      ],
     },
     {
       name: 'XDSCommandPaletteFooter',
@@ -326,14 +274,6 @@ export const docs = {
             'StyleX styles for layout customization. Must be a stylex.create() value.',
         },
       ],
-      examples: [
-        {
-          label: 'Default hints',
-          code: `<XDSCommandPalette isOpen={isOpen} onOpenChange={setIsOpen} searchSource={source}
-  footer={<XDSCommandPaletteFooter />}
-/>`,
-        },
-      ],
     },
     {
       name: 'XDSCommandPaletteEmpty',
@@ -347,54 +287,6 @@ export const docs = {
           required: true,
         },
       ],
-      examples: [
-        {
-          label: 'Custom empty state',
-          code: `<XDSCommandPalette
-  isOpen={isOpen}
-  onOpenChange={setIsOpen}
-  searchSource={source}
-  emptySearchText={
-    <XDSCommandPaletteEmpty>No commands found</XDSCommandPaletteEmpty>
-  }
-/>`,
-        },
-      ],
-    },
-  ],
-  examples: [
-    {
-      label: 'Static source with createStaticSource',
-      code: `const source = createStaticSource([
-  {id: 'home', label: 'Home'},
-  {id: 'settings', label: 'Settings'},
-  {id: 'logout', label: 'Sign out'},
-]);
-
-function MyCommandPalette() {
-  const [isOpen, setIsOpen] = useState(false);
-  return (
-    <XDSCommandPalette
-      isOpen={isOpen}
-      onOpenChange={setIsOpen}
-      searchSource={source}
-    />
-  );
-}`,
-    },
-    {
-      label: 'Grouped items with renderItem',
-      code: `<XDSCommandPalette
-  isOpen={isOpen}
-  onOpenChange={setIsOpen}
-  searchSource={source}
-  renderItem={(item) => (
-    <>
-      <XDSIcon name={item.auxiliaryData.icon} size="sm" />
-      {item.label}
-    </>
-  )}
-/>`,
     },
   ],
   theming: {

--- a/packages/core/src/DateInput/DateInput.doc.mjs
+++ b/packages/core/src/DateInput/DateInput.doc.mjs
@@ -4,10 +4,6 @@ export const docs = {
   name: 'DateInput',
   description:
     'XDSDateInput component combining a text input with a calendar popover for date selection.',
-  showcase: {
-    aspectRatio: 4 / 3,
-    code: '<XDSDateInput label="Date" />',
-  },
   keywords: ["dateinput","datepicker","datefield","calendar","dateselect","dateentry","datechooser"],
   features: [
     'Text Input — manual date entry with flexible parsing (supports various formats)',

--- a/packages/core/src/Dialog/Dialog.doc.mjs
+++ b/packages/core/src/Dialog/Dialog.doc.mjs
@@ -3,12 +3,7 @@
 export const docs = {
   name: 'Dialog',
   description:
-    'Modal dialog using the native <dialog> element with automatic focus trapping, backdrop, and purpose-based dismissal control.',
-  showcase: {
-    aspectRatio: 4 / 3,
-    code: '<XDSDialog isOpen={true} onOpenChange={() => {}}>Dialog content</XDSDialog>',
-  },
-  keywords: ["dialog","modal","popup","overlay","lightbox","alert","confirm","prompt","backdrop","focus trap"],
+    'Modal dialog using the native <dialog> element with automatic focus trapping, backdrop, and purpose-based dismissal control.',  keywords: ["dialog","modal","popup","overlay","lightbox","alert","confirm","prompt","backdrop","focus trap"],
   features: [
     "Native <dialog>: Uses the browser's built-in modal behavior via showModal()",
     'Automatic focus trap: Focus is trapped within the dialog when open (browser-native)',

--- a/packages/core/src/Divider/Divider.doc.mjs
+++ b/packages/core/src/Divider/Divider.doc.mjs
@@ -5,10 +5,6 @@
 export const docs = {
   name: 'Divider',
   description: 'Visual separator with optional label, using XDS design tokens.',
-  showcase: {
-    aspectRatio: 16 / 4,
-    code: '<XDSDivider />',
-  },
   keywords: ["divider","separator","hr","rule","line","border","spacer","horizontal rule"],
   features: [
     'Supports horizontal and vertical orientations',

--- a/packages/core/src/DropdownMenu/DropdownMenu.doc.mjs
+++ b/packages/core/src/DropdownMenu/DropdownMenu.doc.mjs
@@ -3,12 +3,7 @@
 export const docs = {
   name: 'DropdownMenu',
   description:
-    'A dropdown menu component for displaying actionable items in a popup menu.',
-  showcase: {
-    aspectRatio: 4 / 3,
-    code: '<XDSDropdownMenu trigger={<button>Menu</button>} items={[{label: "Edit"}]} />',
-  },
-  keywords: ["dropdown","menu","popover","select","actions","contextmenu","overflow","kebab","menubutton"],
+    'A dropdown menu component for displaying actionable items in a popup menu.',  keywords: ["dropdown","menu","popover","select","actions","contextmenu","overflow","kebab","menubutton"],
   features: [
     'Button customization: Customize the trigger button via the `button` prop (supports all XDSButton props)',
     'Data-driven items: Pass items via the `items` prop with support for sections and dividers',

--- a/packages/core/src/EmptyState/EmptyState.doc.mjs
+++ b/packages/core/src/EmptyState/EmptyState.doc.mjs
@@ -4,10 +4,6 @@ export const docs = {
   name: 'EmptyState',
   description:
     'An empty state placeholder for content areas with no data. Displays an icon or illustration, title, optional description, and action buttons.',
-  showcase: {
-    aspectRatio: 4 / 3,
-    code: '<XDSEmptyState title="No results" />',
-  },
   keywords: ["emptystate","empty","placeholder","nodata","blank","noresults","illustration","blankslate"],
   features: [
     'Uses role="status" so screen readers announce the empty state automatically',

--- a/packages/core/src/Field/Field.doc.mjs
+++ b/packages/core/src/Field/Field.doc.mjs
@@ -4,10 +4,6 @@ export const docs = {
   name: 'Field',
   description:
     'A form field wrapper component that provides label, description, and optional/required indicators.',
-  showcase: {
-    aspectRatio: 4 / 3,
-    code: '<XDSField label="Name"><input /></XDSField>',
-  },
   keywords: ["field","formfield","formgroup","formcontrol","label","input","required","optional","helpertext","hint"],
   features: [
     'Label Support — required label for accessibility (can be visually hidden)',

--- a/packages/core/src/FormLayout/FormLayout.doc.mjs
+++ b/packages/core/src/FormLayout/FormLayout.doc.mjs
@@ -4,10 +4,6 @@ export const docs = {
   name: 'FormLayout',
   description:
     'A spatial layout container for arranging form fields with consistent spacing and direction.',
-  showcase: {
-    aspectRatio: 4 / 3,
-    code: '<XDSFormLayout>Form fields</XDSFormLayout>',
-  },
   keywords: ["formlayout","form","fieldset","formgroup","formcontainer","fields","vertical","horizontal"],
   props: [
     {

--- a/packages/core/src/Grid/Grid.doc.mjs
+++ b/packages/core/src/Grid/Grid.doc.mjs
@@ -2,12 +2,7 @@
 
 export const docs = {
   name: 'Grid',
-  description: 'CSS Grid-based layout with responsive auto-fit support.',
-  showcase: {
-    aspectRatio: 4 / 3,
-    code: '<XDSGrid columns={3}><div>1</div><div>2</div><div>3</div></XDSGrid>',
-  },
-  keywords: ["grid","columns","responsive","auto-fit","masonry","tiles","row","col","simplegrid"],
+  description: 'CSS Grid-based layout with responsive auto-fit support.',  keywords: ["grid","columns","responsive","auto-fit","masonry","tiles","row","col","simplegrid"],
   features: [
     'Fixed-column grids via the `columns` prop',
     'Responsive auto-fit columns via `minChildWidth` — items wrap based on available space',

--- a/packages/core/src/HoverCard/HoverCard.doc.mjs
+++ b/packages/core/src/HoverCard/HoverCard.doc.mjs
@@ -3,12 +3,7 @@
 export const docs = {
   name: 'HoverCard',
   description:
-    'A hover/focus triggered overlay for displaying rich, interactive content anchored to a trigger element.',
-  showcase: {
-    aspectRatio: 1,
-    code: '<XDSHoverCard trigger={<span>Hover</span>}>Details</XDSHoverCard>',
-  },
-  keywords: ["hovercard","hover card","popover","tooltip","preview card","flyout","overlay","hover popup"],
+    'A hover/focus triggered overlay for displaying rich, interactive content anchored to a trigger element.',  keywords: ["hovercard","hover card","popover","tooltip","preview card","flyout","overlay","hover popup"],
   features: [
     'CSS Anchor Positioning for automatic placement relative to trigger elements',
     'Popover API for top-layer rendering — no React portals needed',

--- a/packages/core/src/Icon/Icon.doc.mjs
+++ b/packages/core/src/Icon/Icon.doc.mjs
@@ -4,10 +4,6 @@ export const docs = {
   name: 'Icon',
   description:
     'Renders icons with XDS design system colors and sizes. Supports both direct SVG icon components and semantic icon names that adapt to the active theme.',
-  showcase: {
-    aspectRatio: 1,
-    code: '<XDSIcon name="star" />',
-  },
   keywords: ["icon","svg","glyph","symbol","pictogram","graphic","vector"],
   features: [
     "Semantic Icon Names: Use names like 'close' or 'chevronDown' — resolved from the theme's icon registry",

--- a/packages/core/src/IconButton/IconButton.doc.mjs
+++ b/packages/core/src/IconButton/IconButton.doc.mjs
@@ -4,10 +4,6 @@ export const docs = {
   name: 'IconButton',
   description:
     'An icon-only button. Thin wrapper around XDSButton with isIconOnly always true.',
-  showcase: {
-    aspectRatio: 1,
-    code: '<XDSIconButton label="Settings" icon="gear" />',
-  },
 
   keywords: ['icon-button', 'icon', 'button', 'toolbar', 'action', 'compact'],
   features: [

--- a/packages/core/src/Kbd/Kbd.doc.mjs
+++ b/packages/core/src/Kbd/Kbd.doc.mjs
@@ -4,10 +4,6 @@ export const docs = {
   name: 'Kbd',
   description:
     'Displays a keyboard shortcut as styled <kbd> elements. Use in tooltips, menus, and documentation to show key combinations.',
-  showcase: {
-    aspectRatio: 1,
-    code: '<XDSKbd>⌘K</XDSKbd>',
-  },
   keywords: ["kbd","keyboard","shortcut","hotkey","keybinding","keystroke","keycombo","modifier","accelerator"],
   features: [
     'Key parsing — splits "mod+k" into individual styled <kbd> elements',

--- a/packages/core/src/Layer/Layer.doc.mjs
+++ b/packages/core/src/Layer/Layer.doc.mjs
@@ -4,10 +4,6 @@ export const docs = {
   name: 'Layer',
   description:
     'Core hook for overlay positioning using CSS Anchor Positioning and the Popover API — no React portals needed. Popover, HoverCard, and Tooltip build on this foundation and live in their own directories.',
-  showcase: {
-    aspectRatio: 1,
-    code: '<XDSLayer>Layer content</XDSLayer>',
-  },
   keywords: ["layer","overlay","popover","positioning","anchor","floating","dropdown","popper","popup","portal"],
   features: [
     'CSS Anchor Positioning for automatic placement relative to trigger elements',

--- a/packages/core/src/Layout/Layout.doc.mjs
+++ b/packages/core/src/Layout/Layout.doc.mjs
@@ -4,10 +4,6 @@ export const docs = {
   name: 'Layout',
   description:
     'Composable utilities and components for building structured layouts with a container/content separation pattern.',
-  showcase: {
-    aspectRatio: 16 / 9,
-    code: '<XDSLayout>Layout content</XDSLayout>',
-  },
   keywords: ["layout","container","content","flex","box","wrapper","scaffold","page","shell"],
   features: [
     'Primitive + higher-order architecture — XDSLayoutContainer is a primitive; XDSCard, XDSSection are higher-order',

--- a/packages/core/src/Link/Link.doc.mjs
+++ b/packages/core/src/Link/Link.doc.mjs
@@ -4,10 +4,6 @@ export const docs = {
   name: 'Link',
   description:
     'XDSLink component for styled anchor links with multiple variants and features, plus polymorphic link infrastructure for rendering custom link components (Next.js Link, React Router Link, etc.).',
-  showcase: {
-    aspectRatio: 1,
-    code: '<XDSLink href="#">Link text</XDSLink>',
-  },
   keywords: ["link","anchor","href","hyperlink","navigation","url","external","textlink"],
   features: [
     "Color control: Uses XDSText color prop ('active' default, 'secondary', 'inherit', etc.)",

--- a/packages/core/src/List/List.doc.mjs
+++ b/packages/core/src/List/List.doc.mjs
@@ -4,10 +4,6 @@ export const docs = {
   name: 'List',
   description:
     'Vertical list component for rendering collections of items with consistent spacing, dividers, and marker styles. Uses a composition model: XDSList wraps XDSListItem sub-components.',
-  showcase: {
-    aspectRatio: 3 / 4,
-    code: '<XDSList><XDSListItem>Item 1</XDSListItem></XDSList>',
-  },
   keywords: ["list","listitem","listbox","menu","collection","items","ul","navlist"],
   features: [
     'Composition model — XDSList wraps XDSListItem sub-components',

--- a/packages/core/src/Markdown/Markdown.doc.mjs
+++ b/packages/core/src/Markdown/Markdown.doc.mjs
@@ -4,10 +4,6 @@ export const docs = {
   name: 'Markdown',
   description:
     'Renders a markdown string as XDS components. Supports headings, paragraphs, bold, italic, code, lists, tables, links, images, blockquotes, horizontal rules, and task lists. Handles streaming text with a smooth fade-in animation.',
-  showcase: {
-    aspectRatio: 4 / 3,
-    code: '<XDSMarkdown content="# Hello" />',
-  },
   keywords: [
     'markdown',
     'rich text',

--- a/packages/core/src/MetadataList/MetadataList.doc.mjs
+++ b/packages/core/src/MetadataList/MetadataList.doc.mjs
@@ -3,12 +3,7 @@
 export const docs = {
   name: 'MetadataList',
   description:
-    'A read-only labeled list for displaying key-value metadata. Semantic equivalent of HTML <dl>/<dt>/<dd> with layout control, column modes, and consistent styling. Uses a composition model: XDSMetadataList wraps XDSMetadataListItem sub-components.',
-  showcase: {
-    aspectRatio: 4 / 3,
-    code: '<XDSMetadataList items={[{label: "Status", value: "Active"}]} />',
-  },
-  keywords: ["metadata","description","definition","keyvalue","properties","details","attributes","summary"],
+    'A read-only labeled list for displaying key-value metadata. Semantic equivalent of HTML <dl>/<dt>/<dd> with layout control, column modes, and consistent styling. Uses a composition model: XDSMetadataList wraps XDSMetadataListItem sub-components.',  keywords: ["metadata","description","definition","keyvalue","properties","details","attributes","summary"],
   features: [
     'Composition model — XDSMetadataList wraps XDSMetadataListItem sub-components',
     'Column modes: single, multi (auto-fill), or fixed number',

--- a/packages/core/src/MobileNav/MobileNav.doc.mjs
+++ b/packages/core/src/MobileNav/MobileNav.doc.mjs
@@ -4,10 +4,6 @@ export const docs = {
   name: 'MobileNav',
   description:
     'Slide-out drawer overlay for mobile navigation. The mobile counterpart to XDSSideNav — accepts the same children (XDSSideNavSection, XDSSideNavItem, or any ReactNode).',
-  showcase: {
-    aspectRatio: 3 / 4,
-    code: '<XDSMobileNav>Nav items</XDSMobileNav>',
-  },
   keywords: ["mobilenav","drawer","sidebar","navigation","hamburger","menu","offcanvas","slideout","navdrawer"],
   props: [
     {

--- a/packages/core/src/MoreMenu/MoreMenu.doc.mjs
+++ b/packages/core/src/MoreMenu/MoreMenu.doc.mjs
@@ -3,12 +3,7 @@
 export const docs = {
   name: 'MoreMenu',
   description:
-    'Overflow menu with a three-dot icon trigger. A convenience wrapper that composes an icon-only XDSButton with a dropdown menu, eliminating the boilerplate of wiring up state management, positioning, and accessibility attributes.',
-  showcase: {
-    aspectRatio: 4 / 3,
-    code: '<XDSMoreMenu items={[{label: "Edit"}]} />',
-  },
-  keywords: ["moremenu","overflow","kebab","dotmenu","threedot","ellipsis","dropdown","contextmenu","actionmenu"],
+    'Overflow menu with a three-dot icon trigger. A convenience wrapper that composes an icon-only XDSButton with a dropdown menu, eliminating the boilerplate of wiring up state management, positioning, and accessibility attributes.',  keywords: ["moremenu","overflow","kebab","dotmenu","threedot","ellipsis","dropdown","contextmenu","actionmenu"],
   props: [
     {
       name: 'items',

--- a/packages/core/src/MultiSelector/MultiSelector.doc.mjs
+++ b/packages/core/src/MultiSelector/MultiSelector.doc.mjs
@@ -3,12 +3,7 @@
 export const docs = {
   name: 'MultiSelector',
   description:
-    'Multi-select dropdown with checkboxes for choosing multiple items from a list. For small, finite sets like column toggles or filter facets — not a replacement for XDSTokenizer.',
-  showcase: {
-    aspectRatio: 4 / 3,
-    code: '<XDSMultiSelector label="Tags" items={[]} />',
-  },
-  keywords: ['multiselect', 'checkbox', 'dropdown', 'multi', 'picker', 'checklist', 'facet', 'filter', 'select'],
+    'Multi-select dropdown with checkboxes for choosing multiple items from a list. For small, finite sets like column toggles or filter facets — not a replacement for XDSTokenizer.',  keywords: ['multiselect', 'checkbox', 'dropdown', 'multi', 'picker', 'checklist', 'facet', 'filter', 'select'],
   features: [
     'Checkbox-based multi-select — dropdown stays open on toggle',
     'Supports string items, object items with optional icon and disabled state, dividers, and labeled sections',

--- a/packages/core/src/NavIcon/NavIcon.doc.mjs
+++ b/packages/core/src/NavIcon/NavIcon.doc.mjs
@@ -4,10 +4,6 @@ export const docs = {
   name: 'NavIcon',
   description:
     'Circular icon container with accent background for navigation headers.',
-  showcase: {
-    aspectRatio: 16 / 4,
-    code: '<XDSNavIcon label="Home" />',
-  },
   keywords: ["navicon","iconbutton","toolbar icon","appbar icon","nav button"],
   features: [
     'Shared — used in both XDSTopNavHeading and XDSPageNavHeader',

--- a/packages/core/src/NumberInput/NumberInput.doc.mjs
+++ b/packages/core/src/NumberInput/NumberInput.doc.mjs
@@ -3,12 +3,7 @@
 export const docs = {
   name: 'NumberInput',
   description:
-    'A number input component for collecting numeric user input with validation.',
-  showcase: {
-    aspectRatio: 4 / 3,
-    code: '<XDSNumberInput label="Amount" value={0} onChange={() => {}} />',
-  },
-  keywords: ["numberinput","numberfield","stepper","spinner","counter","increment","decrement","quantity","numberpicker"],
+    'A number input component for collecting numeric user input with validation.',  keywords: ["numberinput","numberfield","stepper","spinner","counter","increment","decrement","quantity","numberpicker"],
   features: [
     'Label Support — required label for accessibility (can be visually hidden)',
     'Description — optional description text displayed between the label and input',

--- a/packages/core/src/OverflowList/OverflowList.doc.mjs
+++ b/packages/core/src/OverflowList/OverflowList.doc.mjs
@@ -3,12 +3,7 @@
 export const docs = {
   name: 'OverflowList',
   description:
-    'Horizontal list that hides items that overflow the available width and shows a custom indicator. Uses a hidden measurement container to avoid layout flicker.',
-  showcase: {
-    aspectRatio: 16 / 4,
-    code: '<XDSOverflowList items={[]} renderItem={() => null} renderOverflow={() => null} />',
-  },
-  keywords: [
+    'Horizontal list that hides items that overflow the available width and shows a custom indicator. Uses a hidden measurement container to avoid layout flicker.',  keywords: [
     'overflow',
     'truncate',
     'collapse',

--- a/packages/core/src/Pagination/Pagination.doc.mjs
+++ b/packages/core/src/Pagination/Pagination.doc.mjs
@@ -3,12 +3,7 @@
 export const docs = {
   name: 'Pagination',
   description:
-    'Standalone pagination controls for navigating through pages of content. Supports multiple display variants and works with known totals or cursor-based pagination.',
-  showcase: {
-    aspectRatio: 16 / 4,
-    code: '<XDSPagination totalPages={10} currentPage={1} onPageChange={() => {}} />',
-  },
-  keywords: ["pagination","pager","paginator","pagenavigation","paging","paginate","pages","pagecontrol"],
+    'Standalone pagination controls for navigating through pages of content. Supports multiple display variants and works with known totals or cursor-based pagination.',  keywords: ["pagination","pager","paginator","pagenavigation","paging","paginate","pages","pagecontrol"],
   props: [
     {
       name: 'page',

--- a/packages/core/src/Popover/Popover.doc.mjs
+++ b/packages/core/src/Popover/Popover.doc.mjs
@@ -3,12 +3,7 @@
 export const docs = {
   name: 'Popover',
   description:
-    'A click-triggered popover for displaying interactive content anchored to a trigger element, implementing the button + dialog ARIA pattern.',
-  showcase: {
-    aspectRatio: 4 / 3,
-    code: '<XDSPopover trigger={<button>Open</button>}>Content</XDSPopover>',
-  },
-  keywords: ["popover","popup","dropdown","tooltip","overlay","flyout","callout","popper","anchor","floating","bubble"],
+    'A click-triggered popover for displaying interactive content anchored to a trigger element, implementing the button + dialog ARIA pattern.',  keywords: ["popover","popup","dropdown","tooltip","overlay","flyout","callout","popper","anchor","floating","bubble"],
   features: [
     'CSS Anchor Positioning for automatic placement relative to trigger elements',
     'Popover API for top-layer rendering — no React portals needed',

--- a/packages/core/src/PowerSearch/PowerSearch.doc.mjs
+++ b/packages/core/src/PowerSearch/PowerSearch.doc.mjs
@@ -3,12 +3,7 @@
 export const docs = {
   name: 'PowerSearch',
   description:
-    'Structured filter bar where each token represents a filter (field + operator + value). Users select fields from a typeahead dropdown, configure operators and values in an edit popover, and manage filters as removable tokens.',
-  showcase: {
-    aspectRatio: 4 / 3,
-    code: '<XDSPowerSearch config={{name: "search", fields: []}} />',
-  },
-  keywords: ["powersearch","search","searchbar","filter","filterbar","faceted","querybuilder","structured","omnibar"],
+    'Structured filter bar where each token represents a filter (field + operator + value). Users select fields from a typeahead dropdown, configure operators and values in an edit popover, and manage filters as removable tokens.',  keywords: ["powersearch","search","searchbar","filter","filterbar","faceted","querybuilder","structured","omnibar"],
   props: [
     {
       name: 'config',

--- a/packages/core/src/ProgressBar/ProgressBar.doc.mjs
+++ b/packages/core/src/ProgressBar/ProgressBar.doc.mjs
@@ -3,12 +3,7 @@
 export const docs = {
   name: 'ProgressBar',
   description:
-    'A progress bar for displaying determinate or indeterminate progress.',
-  showcase: {
-    aspectRatio: 16 / 4,
-    code: '<XDSProgressBar label="Loading" value={60} />',
-  },
-  keywords: ["progressbar","progress","loader","loading","linear","determinate","indeterminate","meter"],
+    'A progress bar for displaying determinate or indeterminate progress.',  keywords: ["progressbar","progress","loader","loading","linear","determinate","indeterminate","meter"],
   features: [
     'Determinate mode uses role="meter" with aria-valuenow, aria-valuemin, and aria-valuemax',
     'Indeterminate mode uses role="progressbar" without value attributes',

--- a/packages/core/src/RadioList/RadioList.doc.mjs
+++ b/packages/core/src/RadioList/RadioList.doc.mjs
@@ -3,12 +3,7 @@
 export const docs = {
   name: 'RadioList',
   description:
-    'A radio group component for single-value selection from a list of options.',
-  showcase: {
-    aspectRatio: 4 / 3,
-    code: '<XDSRadioList label="Choice" items={[{label: "A", value: "a"}]} />',
-  },
-  keywords: ["radiolist","radio","radiogroup","radiobutton","optionlist","singlechoice","choicelist"],
+    'A radio group component for single-value selection from a list of options.',  keywords: ["radiolist","radio","radiogroup","radiobutton","optionlist","singlechoice","choicelist"],
   features: [
     'Accessible — uses native <input type="radio"> with proper role="radiogroup" and ARIA attributes',
     'Orientation — supports vertical and horizontal layouts',

--- a/packages/core/src/Section/Section.doc.mjs
+++ b/packages/core/src/Section/Section.doc.mjs
@@ -4,10 +4,6 @@ export const docs = {
   name: 'Section',
   description:
     'Container with background variants for creating visually distinct regions that automatically escape parent container padding for edge-to-edge fills.',
-  showcase: {
-    aspectRatio: 4 / 3,
-    code: '<XDSSection title="Section">Content</XDSSection>',
-  },
   keywords: ["section","panel","container","group","fieldset","region","block"],
   features: [
     'Background variants: section, transparent, and wash',

--- a/packages/core/src/SegmentedControl/SegmentedControl.doc.mjs
+++ b/packages/core/src/SegmentedControl/SegmentedControl.doc.mjs
@@ -3,12 +3,7 @@
 export const docs = {
   name: 'SegmentedControl',
   description:
-    'Segmented button group for single selection with radio group semantics. Visually resembles a tab bar but controls a value, not a view.',
-  showcase: {
-    aspectRatio: 4 / 3,
-    code: '<XDSSegmentedControl items={[{label: "Tab 1", value: "1"}]} />',
-  },
-  keywords: ['radio', 'tabs', 'toggle', 'toggle-group', 'pill', 'button-group', 'switch', 'segment', 'control'],
+    'Segmented button group for single selection with radio group semantics. Visually resembles a tab bar but controls a value, not a view.',  keywords: ['radio', 'tabs', 'toggle', 'toggle-group', 'pill', 'button-group', 'switch', 'segment', 'control'],
   features: [
     'Context-based communication: XDSSegmentedControlContext passes value/onChange/size/isDisabled from parent to children',
     'Radio group semantics: role="radiogroup" with role="radio" items and aria-checked',

--- a/packages/core/src/Selector/Selector.doc.mjs
+++ b/packages/core/src/Selector/Selector.doc.mjs
@@ -3,12 +3,7 @@
 export const docs = {
   name: 'Selector',
   description:
-    'Dropdown selector for choosing from a list of options. Follows XDS input conventions with label, status, and field props.',
-  showcase: {
-    aspectRatio: 4 / 3,
-    code: '<XDSSelector label="Choose" items={["Option A", "Option B"]} />',
-  },
-  keywords: ["selector","select","dropdown","combobox","picker","listbox","chooser","autocomplete","option","selectmenu"],
+    'Dropdown selector for choosing from a list of options. Follows XDS input conventions with label, status, and field props.',  keywords: ["selector","select","dropdown","combobox","picker","listbox","chooser","autocomplete","option","selectmenu"],
   features: [
     'Supports string items (auto-converted to {value, label}), object items with optional icon and disabled state, dividers, and labeled sections',
     'Custom item rendering via children render prop and XDSSelectorItem helper',

--- a/packages/core/src/SideNav/SideNav.doc.mjs
+++ b/packages/core/src/SideNav/SideNav.doc.mjs
@@ -4,10 +4,6 @@ export const docs = {
   name: 'SideNav',
   description:
     'Sidebar navigation component for application pages. Supports sections, nested items, selected state, icons, and collapsible sidebar.',
-  showcase: {
-    aspectRatio: 3 / 4,
-    code: '<XDSSideNav><XDSSideNavItem label="Dashboard" /></XDSSideNav>',
-  },
   keywords: ["sidenav","sidebar","navigation","drawer","menu","nav","aside","sidemenu","navmenu","sider","treeview"],
   features: [
     'Five-zone layout: header, topContent, children (scrollable), footer, footerIcons',

--- a/packages/core/src/Skeleton/Skeleton.doc.mjs
+++ b/packages/core/src/Skeleton/Skeleton.doc.mjs
@@ -4,10 +4,6 @@ export const docs = {
   name: 'Skeleton',
   description:
     'A placeholder loading component that displays an animated pulsing effect while content is loading.',
-  showcase: {
-    aspectRatio: 4 / 3,
-    code: '<XDSSkeleton />',
-  },
   keywords: ["skeleton","placeholder","loading","shimmer","pulse","loader","bone","ghost","preloader"],
   features: [
     'Pulsing Animation: Smooth opacity animation using stepped timing for a subtle shimmer effect',

--- a/packages/core/src/Slider/Slider.doc.mjs
+++ b/packages/core/src/Slider/Slider.doc.mjs
@@ -3,12 +3,7 @@
 export const docs = {
   name: 'Slider',
   description:
-    'A slider component for selecting numeric values or ranges with full keyboard and pointer support.',
-  showcase: {
-    aspectRatio: 4 / 3,
-    code: '<XDSSlider label="Volume" value={50} onChange={() => {}} />',
-  },
-  keywords: ["slider","range","slidebar","trackbar","scrubber","knob","thumb","rangeslider"],
+    'A slider component for selecting numeric values or ranges with full keyboard and pointer support.',  keywords: ["slider","range","slidebar","trackbar","scrubber","knob","thumb","rangeslider"],
   features: [
     'Single & range modes: Pass a `number` for single thumb, `[number, number]` for range',
     'Orientation: Supports `horizontal` and `vertical` layouts',

--- a/packages/core/src/Spinner/Spinner.doc.mjs
+++ b/packages/core/src/Spinner/Spinner.doc.mjs
@@ -4,10 +4,6 @@ export const docs = {
   name: 'Spinner',
   description:
     'An animated loading indicator with optional visible label.',
-  showcase: {
-    aspectRatio: 1,
-    code: '<XDSSpinner label="Loading" />',
-  },
   keywords: ["spinner","loader","loading","circular","progress","spin","activity","busy","indeterminate"],
   features: [
     'Canvas Animation: Lightweight canvas-based spinner with smooth 360° rotation',

--- a/packages/core/src/Stack/Stack.doc.mjs
+++ b/packages/core/src/Stack/Stack.doc.mjs
@@ -3,12 +3,7 @@
 export const docs = {
   name: 'Stack',
   description:
-    'Stack layout primitives for arranging items in horizontal or vertical sequences using flexbox-based layout with themed spacing tokens.',
-  showcase: {
-    aspectRatio: 4 / 3,
-    code: '<XDSVStack gap={2}><div>Item 1</div><div>Item 2</div></XDSVStack>',
-  },
-  keywords: ["stack","hstack","vstack","flexbox","flex","spacing","gap","horizontal","vertical","row","column"],
+    'Stack layout primitives for arranging items in horizontal or vertical sequences using flexbox-based layout with themed spacing tokens.',  keywords: ["stack","hstack","vstack","flexbox","flex","spacing","gap","horizontal","vertical","row","column"],
   features: [
     'Horizontal (XDSHStack) and vertical (XDSVStack) stacking',
     'Themed spacing via gap tokens from the design system spacing scale',

--- a/packages/core/src/StatusDot/StatusDot.doc.mjs
+++ b/packages/core/src/StatusDot/StatusDot.doc.mjs
@@ -4,10 +4,6 @@ export const docs = {
   name: 'StatusDot',
   description:
     'A small colored dot indicator for status display (online/offline, severity, etc).',
-  showcase: {
-    aspectRatio: 1,
-    code: '<XDSStatusDot variant="positive" label="Online" />',
-  },
   keywords: ["statusdot","dot","indicator","status","signal","presence","availability","online","pip"],
   features: [
     'Five semantic color variants: positive, warning, negative, info, neutral',

--- a/packages/core/src/Switch/Switch.doc.mjs
+++ b/packages/core/src/Switch/Switch.doc.mjs
@@ -4,10 +4,6 @@ export const docs = {
   name: 'Switch',
   description:
     'A toggle switch component for boolean values with integrated label support.',
-  showcase: {
-    aspectRatio: 4 / 3,
-    code: '<XDSSwitch label="Dark mode" />',
-  },
   keywords: ["switch","toggle","onoff","flipswitch","boolean","toggleswitch"],
   features: [
     'Boolean toggle — fixed 40x24px track with animated 16px (off) / 20px (on) thumb',

--- a/packages/core/src/TabList/TabList.doc.mjs
+++ b/packages/core/src/TabList/TabList.doc.mjs
@@ -3,12 +3,7 @@
 export const docs = {
   name: 'TabList',
   description:
-    'Tab navigation components with overflow menu support, rendering as a semantic nav landmark with button or anchor tab items.',
-  showcase: {
-    aspectRatio: 16 / 4,
-    code: '<XDSTabList tabs={[{label: "Tab 1"}, {label: "Tab 2"}]} />',
-  },
-  keywords: ["tabs","tabbar","tabstrip","navigation","tabpanel","tabgroup","segmented","navtabs","tab"],
+    'Tab navigation components with overflow menu support, rendering as a semantic nav landmark with button or anchor tab items.',  keywords: ["tabs","tabbar","tabstrip","navigation","tabpanel","tabgroup","segmented","navtabs","tab"],
   features: [
     'Context-based communication: XDSTabListContext passes value/onChange/size from XDSTabList to children',
     'Single-responsibility XDSTab: renders as <button> or <a> (when href is provided) in the nav',

--- a/packages/core/src/Table/Table.doc.mjs
+++ b/packages/core/src/Table/Table.doc.mjs
@@ -3,12 +3,7 @@
 export const docs = {
   name: 'Table',
   description:
-    'Data-driven table with rich cell content via renderCell. Compose cells with XDSBadge, XDSStatusDot, XDSText, XDSAvatar, and layout primitives. XDSBaseTable provides the unstyled structural core with a composable plugin pipeline.',
-  showcase: {
-    aspectRatio: 4 / 3,
-    code: '<XDSTable data={[]} columns={[]} />',
-  },
-  keywords: ["table","datatable","datagrid","spreadsheet","sorting","virtualized","columns","rows","selection","pinning"],
+    'Data-driven table with rich cell content via renderCell. Compose cells with XDSBadge, XDSStatusDot, XDSText, XDSAvatar, and layout primitives. XDSBaseTable provides the unstyled structural core with a composable plugin pipeline.',  keywords: ["table","datatable","datagrid","spreadsheet","sorting","virtualized","columns","rows","selection","pinning"],
   features: [
     'Data-driven rendering — pass data + columns, rows render automatically',
     'Rich cell content via renderCell — compose XDS components (XDSBadge, XDSStatusDot, XDSText, XDSAvatar) inside table cells',

--- a/packages/core/src/Text/Text.doc.mjs
+++ b/packages/core/src/Text/Text.doc.mjs
@@ -4,10 +4,6 @@ export const docs = {
   name: 'Text',
   description:
     'Typography components for the XDS design system, including semantic body text, headings, and a wrapper for applying typography styles to native HTML.',
-  showcase: {
-    aspectRatio: 1,
-    code: '<XDSText type="body">Hello world</XDSText>',
-  },
   keywords: ["text","typography","label","paragraph","heading","caption","font","body","subtitle"],  features: [
     'Semantic text types (body, large, label, supporting, code) driven by theme tokens',
     'Headings use native h1–h6 elements with optional aria-level override for decoupled visual vs document hierarchy',

--- a/packages/core/src/TextArea/TextArea.doc.mjs
+++ b/packages/core/src/TextArea/TextArea.doc.mjs
@@ -3,12 +3,7 @@
 export const docs = {
   name: 'TextArea',
   description:
-    'A multi-line text input component for collecting longer user input.',
-  showcase: {
-    aspectRatio: 4 / 3,
-    code: '<XDSTextArea label="Description" value="" onChange={() => {}} />',
-  },
-  keywords: ["textarea","textfield","multiline","comment","message","autoresize","autosize","charlimit"],
+    'A multi-line text input component for collecting longer user input.',  keywords: ["textarea","textfield","multiline","comment","message","autoresize","autosize","charlimit"],
   features: [
     'Label support — required label for accessibility, can be visually hidden',
     'Description — optional text displayed between the label and textarea',

--- a/packages/core/src/TextInput/TextInput.doc.mjs
+++ b/packages/core/src/TextInput/TextInput.doc.mjs
@@ -3,12 +3,7 @@
 export const docs = {
   name: 'TextInput',
   description:
-    'A text input component for collecting user text input, with label, description, validation status, and optional/required indicators.',
-  showcase: {
-    aspectRatio: 4 / 3,
-    code: '<XDSTextInput label="Name" value="" onChange={() => {}} />',
-  },
-  keywords: ["textinput","textfield","input","search","clearable","prefix","suffix","adornment","validation"],
+    'A text input component for collecting user text input, with label, description, validation status, and optional/required indicators.',  keywords: ["textinput","textfield","input","search","clearable","prefix","suffix","adornment","validation"],
   features: [
     'Label support — required label for accessibility (can be visually hidden)',
     'Description — optional text displayed between the label and input',

--- a/packages/core/src/Thumbnail/Thumbnail.doc.mjs
+++ b/packages/core/src/Thumbnail/Thumbnail.doc.mjs
@@ -4,10 +4,6 @@ export const docs = {
   name: 'Thumbnail',
   description:
     'A square preview card for image attachments. Shows a skeleton shimmer while uploading, the image on success, or a placeholder icon when no source is provided.',
-  showcase: {
-    aspectRatio: 1,
-    code: '<XDSThumbnail src="https://via.placeholder.com/80" alt="Preview" />',
-  },
   keywords: ["thumbnail","attachment","preview","image","upload","dismiss","remove","loading"],
   features: [
     'Square 1:1 aspect ratio via CSS aspect-ratio',

--- a/packages/core/src/TimeInput/TimeInput.doc.mjs
+++ b/packages/core/src/TimeInput/TimeInput.doc.mjs
@@ -4,10 +4,6 @@ export const docs = {
   name: 'TimeInput',
   description:
     'Time input with free-text entry, text parsing, and arrow-key navigation.',
-  showcase: {
-    aspectRatio: 4 / 3,
-    code: '<XDSTimeInput label="Time" />',
-  },
   keywords: ["timeinput","timepicker","time","clock","hour","minute","ampm","timeselect","timefield"],
   features: [
     'Accepts free-text time entry and parses common formats (e.g. "2:30 PM", "14:30")',

--- a/packages/core/src/Timestamp/Timestamp.doc.mjs
+++ b/packages/core/src/Timestamp/Timestamp.doc.mjs
@@ -3,12 +3,7 @@
 export const docs = {
   name: 'Timestamp',
   description:
-    'Displays a formatted timestamp as human-readable text with optional tooltip and live updates. Renders via XDSText for consistent typography.',
-  showcase: {
-    aspectRatio: 1,
-    code: '<XDSTimestamp date={new Date()} />',
-  },
-  keywords: ['date', 'time', 'datetime', 'relative', 'ago', 'clock', 'format', 'duration'],
+    'Displays a formatted timestamp as human-readable text with optional tooltip and live updates. Renders via XDSText for consistent typography.',  keywords: ['date', 'time', 'datetime', 'relative', 'ago', 'clock', 'format', 'duration'],
   props: [
     {
       name: 'value',

--- a/packages/core/src/Toast/Toast.doc.mjs
+++ b/packages/core/src/Toast/Toast.doc.mjs
@@ -4,10 +4,6 @@ export const docs = {
   name: 'Toast',
   description:
     'Toast notification system with auto-dismiss, stacking, deduplication, and smooth animations. Uses XDSMediaTheme for inverted surface theming.',
-  showcase: {
-    aspectRatio: 4 / 3,
-    code: '<XDSToast message="Saved successfully" />',
-  },
 
   keywords: ["toast","notification","snackbar","alert","message","feedback","status"],
   features: [

--- a/packages/core/src/ToggleButton/ToggleButton.doc.mjs
+++ b/packages/core/src/ToggleButton/ToggleButton.doc.mjs
@@ -4,10 +4,6 @@ export const docs = {
   name: 'ToggleButton',
   description:
     'A button that toggles between pressed and unpressed states, with optional icon swap and group integration for single or multi-select behavior.',
-  showcase: {
-    aspectRatio: 1,
-    code: '<XDSToggleButton label="Bold" isIconOnly />',
-  },
   keywords: ["toggle","togglebutton","pressed","toolbar","formatting","segmented","button-group","exclusive","multi-select"],
   features: [
     'Controlled toggle via isPressed/onPressedChange',

--- a/packages/core/src/Token/Token.doc.mjs
+++ b/packages/core/src/Token/Token.doc.mjs
@@ -4,10 +4,6 @@ export const docs = {
   name: 'Token',
   description:
     'A chip/tag component for displaying entities inline. Renders as a <span> by default, <a> when href is provided, or a <span> with an invisible <button> inside when onClick is provided.',
-  showcase: {
-    aspectRatio: 1,
-    code: '<XDSToken label="Tag" />',
-  },
   keywords: ["token","chip","tag","pill","label","removable","dismissible","filter chip","closable"],
   features: [
     'Polymorphic — renders as <span>, <a>, or interactive <span>+<button> based on props',

--- a/packages/core/src/Tokenizer/Tokenizer.doc.mjs
+++ b/packages/core/src/Tokenizer/Tokenizer.doc.mjs
@@ -3,12 +3,7 @@
 export const docs = {
   name: 'Tokenizer',
   description:
-    'Multi-select typeahead with token chips for selected items. Composes XDSBaseTypeahead for search and XDSToken for chips.',
-  showcase: {
-    aspectRatio: 4 / 3,
-    code: '<XDSTokenizer label="Tags" items={[]} />',
-  },
-  keywords: ["tokenizer","multiselect","multi-select","chips","tags","combobox","autocomplete","taginput","chipinput"],
+    'Multi-select typeahead with token chips for selected items. Composes XDSBaseTypeahead for search and XDSToken for chips.',  keywords: ["tokenizer","multiselect","multi-select","chips","tags","combobox","autocomplete","taginput","chipinput"],
   props: [
     {
       name: 'label',

--- a/packages/core/src/Toolbar/Toolbar.doc.mjs
+++ b/packages/core/src/Toolbar/Toolbar.doc.mjs
@@ -4,10 +4,6 @@ export const docs = {
   name: 'Toolbar',
   description:
     'General-purpose toolbar with start, center, and end content slots. Built on XDSSection with roving tabindex keyboard navigation.',
-  showcase: {
-    aspectRatio: 16 / 4,
-    code: '<XDSToolbar label="Actions" />',
-  },
   keywords: ['toolbar', 'nav', 'bar', 'actions', 'buttonbar', 'header', 'footer', 'action-bar', 'control-bar'],
   features: [
     'Slot-based layout — startContent, centerContent, and endContent for flexible organization',

--- a/packages/core/src/Tooltip/Tooltip.doc.mjs
+++ b/packages/core/src/Tooltip/Tooltip.doc.mjs
@@ -4,10 +4,6 @@ export const docs = {
   name: 'Tooltip',
   description:
     'A hover/focus triggered tooltip for displaying short, non-interactive text anchored to a trigger element.',
-  showcase: {
-    aspectRatio: 1,
-    code: '<XDSTooltip content="Help text"><button>Hover</button></XDSTooltip>',
-  },
   keywords: ["tooltip","hint","infotip","title","hover","flyout","balloon","helpertext"],
   features: [
     'CSS Anchor Positioning for automatic placement relative to trigger elements',

--- a/packages/core/src/TopNav/TopNav.doc.mjs
+++ b/packages/core/src/TopNav/TopNav.doc.mjs
@@ -4,10 +4,6 @@ export const docs = {
   name: 'TopNav',
   description:
     'Top navigation bar component for application headers with slot-based layout and companion nav item components.',
-  showcase: {
-    aspectRatio: 16 / 4,
-    code: '<XDSTopNav label="Navigation" />',
-  },
   keywords: ["topnav","navbar","appbar","header","toolbar","navigation","menubar","topbar"],
   features: [
     'Slot-based layout — heading, startContent, centerContent, and endContent slots for flexible organization',

--- a/packages/core/src/TreeList/TreeList.doc.mjs
+++ b/packages/core/src/TreeList/TreeList.doc.mjs
@@ -3,12 +3,7 @@
 export const docs = {
   name: 'TreeList',
   description:
-    'Data-driven tree list component for rendering hierarchical data with expand/collapse, branch lines, and interactive items. Uses a flat items array with recursive children — no composition, no cloneElement.',
-  showcase: {
-    aspectRatio: 3 / 4,
-    code: '<XDSTreeList items={[{label: "Root"}]} />',
-  },
-  keywords: ['tree', 'hierarchy', 'nested', 'accordion', 'folder', 'expand', 'collapse', 'treeview', 'outline'],
+    'Data-driven tree list component for rendering hierarchical data with expand/collapse, branch lines, and interactive items. Uses a flat items array with recursive children — no composition, no cloneElement.',  keywords: ['tree', 'hierarchy', 'nested', 'accordion', 'folder', 'expand', 'collapse', 'treeview', 'outline'],
   features: [
     'Data-driven API — items array with recursive children',
     'Internal expansion state — seed via isExpanded on each item',

--- a/packages/core/src/Typeahead/Typeahead.doc.mjs
+++ b/packages/core/src/Typeahead/Typeahead.doc.mjs
@@ -4,10 +4,6 @@ export const docs = {
   name: 'Typeahead',
   description:
     'Searchable dropdown components for single-item selection with keyboard navigation. Supports async and sync search via a searchSource interface.',
-  showcase: {
-    aspectRatio: 4 / 3,
-    code: '<XDSTypeahead label="Search" />',
-  },
   keywords: ["typeahead","autocomplete","combobox","searchbox","autosuggest","select","dropdown","lookup","searchable","suggestion","picker"],
   features: [
     'Async and sync search via a searchSource interface with search() and bootstrap() methods',

--- a/packages/core/src/docs-types.ts
+++ b/packages/core/src/docs-types.ts
@@ -48,28 +48,6 @@ export interface PropDoc {
 }
 
 /**
- * A usage example showing the component in JSX. Examples should progress
- * from basic to advanced. Include 2-5 examples per component (complex
- * components like Table or Layer may justify more).
- *
- * @example
- * ```
- * {label: 'Basic', code: '<XDSButton variant="primary">Save</XDSButton>'}
- * {label: 'With icon', code: '<XDSButton icon={PlusIcon} variant="secondary">Add</XDSButton>'}
- * ```
- */
-export interface Example {
-  /** Short descriptive title in sentence case, 2-8 words.
-   *  e.g. `"Basic"`, `"With icon"`, `"Rich cell content with renderCell"`.
-   *  Omit only for trivial single-example sub-components. */
-  label?: string;
-  /** JSX code string. Use regular strings for single-line snippets and
-   *  template literals for multi-line code. Prefer realistic variable names
-   *  (`users`, `transactions`) over generic ones (`data`, `value1`). */
-  code: string;
-}
-
-/**
  * A theming target — a stable CSS class name that `defineTheme` can target
  * via `@scope` selectors. Each component renders one or more class names
  * via `xdsClassName()`, and themes can override styles for each.
@@ -159,8 +137,6 @@ export interface ComponentEntry {
   description: string;
   /** All public props for this component. */
   props: PropDoc[];
-  /** Usage examples for this component. */
-  examples?: Example[];
 }
 
 /**
@@ -227,20 +203,6 @@ interface BaseDoc {
    *  Be specific enough to differentiate from similar components.
    *  e.g. `"Data-driven table with rich cell content via renderCell."` */
   description: string;
-  /** Top-level usage examples showing the component in real scenarios.
-   *  For multi-component dirs, these show how the components work together.
-   *  Start with the most common usage pattern, then progress to advanced.
-   *  Include 2-5 examples (complex components may justify more). */
-  examples?: Example[];
-  /** Minimal JSX code string showing the component in its simplest valid
-   *  form. Used as the live preview "cover image" in gallery views.
-   *  e.g. `'<XDSButton label="Click" variant="primary" />'` */
-  showcase?: {
-    /** Width-to-height ratio for the preview container. */
-    aspectRatio: number;
-    /** JSX code string of the component in minimal form. */
-    code: string;
-  };
   /** Search keywords for CLI discovery. Terms a developer might type when
    *  looking for this component: synonyms, related UI concepts, and common
    *  names from other design systems (MUI, Chakra, Radix, shadcn).
@@ -335,7 +297,7 @@ export type ComponentDoc = SingleComponentDoc | MultiComponentDoc;
  * Translation overlay for component documentation.
  *
  * Contains only the prose fields that change between languages/formats.
- * The CLI merges this onto the base `docs` at read time — props, examples,
+ * The CLI merges this onto the base `docs` at read time — props,
  * types, defaults, and code all come from `docs`.
  *
  * Used by both `docsZh` (Chinese translation) and `docsDense` (compressed format).

--- a/packages/core/src/docs-types.ts
+++ b/packages/core/src/docs-types.ts
@@ -467,3 +467,21 @@ export interface BlockTemplateDoc extends BaseTemplateDoc {
 }
 
 export type TemplateDoc = PageTemplateDoc | BlockTemplateDoc;
+
+/**
+ * Showcase metadata for a component.
+ *
+ * Each component can have a showcase file in `packages/cli/templates/showcase/`
+ * consisting of a `{Name}.doc.mjs` (this type) and a `{Name}.tsx` (the component).
+ *
+ *   /\*\* \@type \{import('@xds/core').ComponentShowcaseDoc\} *\/
+ *   export const doc = \{ name: 'Button', aspectRatio: 1 \};
+ */
+export interface ComponentShowcaseDoc {
+  /** Component name (matches the directory name).
+   *  e.g. `"Button"`, `"Layout"`, `"Dialog"` */
+  name: string;
+  /** Width-to-height ratio for the preview container.
+   *  e.g. `1`, `16 / 9`, `4 / 3` */
+  aspectRatio: number;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -155,4 +155,5 @@ export type {
   CSSPropertyDoc,
   ComponentVar,
   TranslationDoc,
+  ComponentShowcaseDoc,
 } from './docs-types';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -150,7 +150,6 @@ export type {
   SingleComponentDoc,
   MultiComponentDoc,
   PropDoc,
-  Example,
   ComponentEntry,
   ThemingTarget,
   CSSPropertyDoc,


### PR DESCRIPTION
## Summary
- Remove `Example` interface and `examples` field from `ComponentDoc`, `ComponentEntry`, and `BaseDoc` — block templates in `templates/blocks/components/` already provide real executable examples
- Remove `showcase` from `BaseDoc` — block templates serve this role too
- Strip leftover `examples` data from CommandPalette and CodeBlock doc files

## Plan
We'll add more commits to this PR to continue cleaning up the doc types:
- [ ] Remove `showcase` data from all ~70 doc.mjs files
- [ ] Restructure prose fields (description, features, accessibility, notes, keyboard)


Made with [Cursor](https://cursor.com)