### PR TITLE
fix: chart Tier 1 correctness — xKey in context, bars from zero, shared utils

### DIFF
--- a/packages/lab/src/Chart/XDSChart.tsx
+++ b/packages/lab/src/Chart/XDSChart.tsx
@@ -157,11 +157,12 @@ export function XDSChart({
       width: innerWidth,
       height: innerHeight,
       margin,
+      xKey,
       data,
       xScale,
       yScale,
     }),
-    [innerWidth, innerHeight, margin, data, xScale, yScale],
+    [innerWidth, innerHeight, margin, xKey, data, xScale, yScale],
   );
 
   return (

--- a/packages/lab/src/Chart/XDSChartArea.tsx
+++ b/packages/lab/src/Chart/XDSChartArea.tsx
@@ -7,17 +7,14 @@
 import {useMemo} from 'react';
 import {area, curveMonotoneX} from 'd3-shape';
 import {useChart} from './ChartContext';
-import type {ScaleBand} from 'd3-scale';
+import {xPixel} from './utils';
 
 export interface XDSChartAreaProps {
   /** Data key for the upper bound. If omitted, uses `baseline`. */
   yUpper?: string;
   /** Data key for the lower bound. If omitted, uses `baseline`. */
   yLower?: string;
-  /**
-   * Fallback data key when only one bound is specified.
-   * Acts as the other edge of the band.
-   */
+  /** Fallback data key when only one bound is specified. */
   baseline?: string;
   /** Fill color */
   color: string;
@@ -29,26 +26,14 @@ export interface XDSChartAreaProps {
   strokeWidth?: number;
 }
 
-function isBandScale(scale: unknown): scale is ScaleBand<string> {
-  return typeof scale === 'function' && 'bandwidth' in scale;
-}
-
 /**
  * Area band between two y-values. Use for confidence intervals, error ranges,
  * or any min/max band around a line.
  *
- * Supports full band (both bounds), upper-only, or lower-only:
- *
  * @example
  * ```
- * // Full band
  * <XDSChartArea yUpper="upper95" yLower="lower95" color={colors[0]} />
- *
- * // Upper confidence only — shades from mean up to upper bound
  * <XDSChartArea yUpper="upper95" baseline="mean" color={colors[0]} />
- *
- * // Lower confidence only — shades from lower bound up to mean
- * <XDSChartArea yLower="lower95" baseline="mean" color={colors[0]} />
  * ```
  */
 export function XDSChartArea({
@@ -60,24 +45,15 @@ export function XDSChartArea({
   stroke = false,
   strokeWidth = 1,
 }: XDSChartAreaProps) {
-  const {data, xScale, yScale} = useChart();
+  const {data, xKey, xScale, yScale} = useChart();
 
-  // Resolve which keys to use for upper and lower edges
   const upperKey = yUpper ?? baseline;
   const lowerKey = yLower ?? baseline;
 
   const pathD = useMemo(() => {
     if (!upperKey || !lowerKey) return '';
-
     const generator = area<Record<string, unknown>>()
-      .x(d => {
-        if (isBandScale(xScale)) {
-          return (
-            (xScale(String(Object.values(d)[0])) ?? 0) + xScale.bandwidth() / 2
-          );
-        }
-        return (xScale as (v: number) => number)(Object.values(d)[0] as number);
-      })
+      .x(d => xPixel(d, xKey, xScale))
       .y0(d => {
         const v = typeof d[lowerKey] === 'number' ? (d[lowerKey] as number) : 0;
         return yScale(v);
@@ -88,7 +64,7 @@ export function XDSChartArea({
       })
       .curve(curveMonotoneX);
     return generator(data) ?? '';
-  }, [data, xScale, yScale, upperKey, lowerKey]);
+  }, [data, xKey, xScale, yScale, upperKey, lowerKey]);
 
   if (!pathD) return null;
 

--- a/packages/lab/src/Chart/XDSChartAxis.tsx
+++ b/packages/lab/src/Chart/XDSChartAxis.tsx
@@ -6,7 +6,8 @@
 
 import {useMemo} from 'react';
 import {useChart} from './ChartContext';
-import type {ScaleBand, ScaleLinear, ScaleTime} from 'd3-scale';
+import {isBandScale} from './utils';
+import type {ScaleLinear, ScaleTime} from 'd3-scale';
 
 export interface XDSChartAxisProps {
   /** Which edge to render the axis on */
@@ -15,10 +16,6 @@ export interface XDSChartAxisProps {
   tickCount?: number;
   /** Custom tick formatter */
   tickFormat?: (value: unknown) => string;
-}
-
-function isBandScale(scale: unknown): scale is ScaleBand<string> {
-  return typeof scale === 'function' && 'bandwidth' in scale;
 }
 
 /**

--- a/packages/lab/src/Chart/XDSChartBar.tsx
+++ b/packages/lab/src/Chart/XDSChartBar.tsx
@@ -5,7 +5,7 @@
  */
 
 import {useChart} from './ChartContext';
-import type {ScaleBand} from 'd3-scale';
+import {isBandScale} from './utils';
 
 export interface XDSChartBarProps {
   /** Which data key to visualize */
@@ -16,12 +16,9 @@ export interface XDSChartBarProps {
   radius?: number;
 }
 
-function isBandScale(scale: unknown): scale is ScaleBand<string> {
-  return typeof scale === 'function' && 'bandwidth' in scale;
-}
-
 /**
  * Bar marks. Requires a band xScale (categorical x-axis).
+ * Bars grow from the zero line — handles both positive and negative values.
  *
  * @example
  * ```
@@ -29,20 +26,26 @@ function isBandScale(scale: unknown): scale is ScaleBand<string> {
  * ```
  */
 export function XDSChartBar({dataKey, color, radius = 4}: XDSChartBarProps) {
-  const {data, xScale, yScale, height} = useChart();
+  const {data, xKey, xScale, yScale} = useChart();
 
   if (!isBandScale(xScale)) return null;
+
+  // Zero line position — bars grow from here
+  const zeroY = yScale(0);
 
   return (
     <g>
       {data.map((d, i) => {
-        const xVal = xScale(String(Object.values(d)[0]));
+        const xVal = xScale(String(d[xKey]));
         if (xVal == null) return null;
 
         const yVal =
           typeof d[dataKey] === 'number' ? (d[dataKey] as number) : 0;
-        const barHeight = height - yScale(yVal);
-        const barY = yScale(yVal);
+        const yPos = yScale(yVal);
+
+        // Bar grows from zero line toward the value
+        const barY = Math.min(yPos, zeroY);
+        const barHeight = Math.abs(yPos - zeroY);
 
         return (
           <rect

--- a/packages/lab/src/Chart/XDSChartCandlestick.tsx
+++ b/packages/lab/src/Chart/XDSChartCandlestick.tsx
@@ -9,7 +9,7 @@
  */
 
 import {useChart} from './ChartContext';
-import type {ScaleBand} from 'd3-scale';
+import {isBandScale} from './utils';
 
 export interface XDSChartCandlestickProps {
   /** Data key for the high/max value (top of whisker) */
@@ -40,10 +40,6 @@ export interface XDSChartCandlestickProps {
   radius?: number;
   /** Dot radius (unused in bar variant, kept for future variants) */
   dotRadius?: number;
-}
-
-function isBandScale(scale: unknown): scale is ScaleBand<string> {
-  return typeof scale === 'function' && 'bandwidth' in scale;
 }
 
 /**
@@ -80,7 +76,7 @@ export function XDSChartCandlestick({
   radius = 2,
   dotRadius = 3,
 }: XDSChartCandlestickProps) {
-  const {data, xScale, yScale} = useChart();
+  const {data, xKey, xScale, yScale} = useChart();
 
   if (!isBandScale(xScale)) return null;
   const bw = xScale.bandwidth();
@@ -88,7 +84,7 @@ export function XDSChartCandlestick({
   return (
     <g>
       {data.map((d, i) => {
-        const xVal = xScale(String(Object.values(d)[0]));
+        const xVal = xScale(String(d[xKey]));
         if (xVal == null) return null;
 
         const hVal = typeof d[high] === 'number' ? (d[high] as number) : 0;

--- a/packages/lab/src/Chart/XDSChartDot.tsx
+++ b/packages/lab/src/Chart/XDSChartDot.tsx
@@ -1,11 +1,11 @@
 /**
  * @file XDSChartDot.tsx
- * @output Renders scatter dots for a pair of data keys
+ * @output Renders scatter dots for a data key
  * @position Child of XDSChart; reads scales from context
  */
 
 import {useChart} from './ChartContext';
-import type {ScaleBand} from 'd3-scale';
+import {xPixel} from './utils';
 
 export interface XDSChartDotProps {
   /** Which data key for the y values */
@@ -14,10 +14,6 @@ export interface XDSChartDotProps {
   color: string;
   /** Dot radius */
   radius?: number;
-}
-
-function isBandScale(scale: unknown): scale is ScaleBand<string> {
-  return typeof scale === 'function' && 'bandwidth' in scale;
 }
 
 /**
@@ -29,19 +25,12 @@ function isBandScale(scale: unknown): scale is ScaleBand<string> {
  * ```
  */
 export function XDSChartDot({dataKey, color, radius = 4}: XDSChartDotProps) {
-  const {data, xScale, yScale} = useChart();
+  const {data, xKey, xScale, yScale} = useChart();
 
   return (
     <g>
       {data.map((d, i) => {
-        let x: number;
-        if (isBandScale(xScale)) {
-          x =
-            (xScale(String(Object.values(d)[0])) ?? 0) + xScale.bandwidth() / 2;
-        } else {
-          const xVal = Object.values(d)[0];
-          x = (xScale as (v: number) => number)(xVal as number);
-        }
+        const x = xPixel(d, xKey, xScale);
         const yVal =
           typeof d[dataKey] === 'number' ? (d[dataKey] as number) : 0;
         return (

--- a/packages/lab/src/Chart/XDSChartDotGL.tsx
+++ b/packages/lab/src/Chart/XDSChartDotGL.tsx
@@ -6,7 +6,7 @@
 
 import {useRef, useEffect, useCallback} from 'react';
 import {useChart} from './ChartContext';
-import type {ScaleBand} from 'd3-scale';
+import {xPixel} from './utils';
 
 export interface XDSChartDotGLProps {
   /** Which data key for the y values */
@@ -17,10 +17,6 @@ export interface XDSChartDotGLProps {
   size?: number;
   /** Opacity 0-1 */
   opacity?: number;
-}
-
-function isBandScale(scale: unknown): scale is ScaleBand<string> {
-  return typeof scale === 'function' && 'bandwidth' in scale;
 }
 
 /** Parse hex color to [r, g, b] floats 0-1 */
@@ -102,7 +98,7 @@ export function XDSChartDotGL({
   size = 6,
   opacity = 0.8,
 }: XDSChartDotGLProps) {
-  const {data, xScale, yScale, width, height} = useChart();
+  const {data, xKey, xScale, yScale, width, height} = useChart();
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const glRef = useRef<WebGLRenderingContext | null>(null);
   const programRef = useRef<WebGLProgram | null>(null);
@@ -111,18 +107,12 @@ export function XDSChartDotGL({
   const getPositions = useCallback((): Float32Array => {
     const positions: number[] = [];
     for (const d of data) {
-      let x: number;
-      if (isBandScale(xScale)) {
-        x = (xScale(String(Object.values(d)[0])) ?? 0) + xScale.bandwidth() / 2;
-      } else {
-        const xVal = Object.values(d)[0];
-        x = (xScale as (v: number) => number)(xVal as number);
-      }
+      const x = xPixel(d, xKey, xScale);
       const yVal = typeof d[dataKey] === 'number' ? (d[dataKey] as number) : 0;
       positions.push(x, yScale(yVal));
     }
     return new Float32Array(positions);
-  }, [data, dataKey, xScale, yScale]);
+  }, [data, xKey, dataKey, xScale, yScale]);
 
   useEffect(() => {
     const canvas = canvasRef.current;

--- a/packages/lab/src/Chart/XDSChartDotGLInteractive.tsx
+++ b/packages/lab/src/Chart/XDSChartDotGLInteractive.tsx
@@ -17,7 +17,7 @@ import {
   type ReactNode,
 } from 'react';
 import {useChart} from './ChartContext';
-import type {ScaleBand} from 'd3-scale';
+import {xPixel} from './utils';
 
 export interface XDSChartDotGLInteractiveProps {
   /** Which data key for the y values */
@@ -33,10 +33,6 @@ export interface XDSChartDotGLInteractiveProps {
    * If omitted, a default tooltip is rendered.
    */
   renderTooltip?: (datum: Record<string, unknown>, index: number) => ReactNode;
-}
-
-function isBandScale(scale: unknown): scale is ScaleBand<string> {
-  return typeof scale === 'function' && 'bandwidth' in scale;
 }
 
 function hexToGL(hex: string): [number, number, number] {
@@ -166,7 +162,7 @@ export function XDSChartDotGLInteractive({
   opacity = 0.8,
   renderTooltip,
 }: XDSChartDotGLInteractiveProps) {
-  const {data, xScale, yScale, width, height} = useChart();
+  const {data, xKey, xScale, yScale, width, height} = useChart();
   const visCanvasRef = useRef<HTMLCanvasElement>(null);
   const pickCanvasRef = useRef<HTMLCanvasElement>(null);
   const [hoverIndex, setHoverIndex] = useState<number>(-1);
@@ -188,17 +184,12 @@ export function XDSChartDotGLInteractive({
   const positions = useMemo(() => {
     const pos: number[] = [];
     for (const d of data) {
-      let x: number;
-      if (isBandScale(xScale)) {
-        x = (xScale(String(Object.values(d)[0])) ?? 0) + xScale.bandwidth() / 2;
-      } else {
-        x = (xScale as (v: number) => number)(Object.values(d)[0] as number);
-      }
+      const x = xPixel(d, xKey, xScale);
       const yVal = typeof d[dataKey] === 'number' ? (d[dataKey] as number) : 0;
       pos.push(x, yScale(yVal));
     }
     return new Float32Array(pos);
-  }, [data, dataKey, xScale, yScale]);
+  }, [data, xKey, dataKey, xScale, yScale]);
 
   // Pick colors — one unique color per point
   const pickColors = useMemo(() => {

--- a/packages/lab/src/Chart/XDSChartErrorBar.tsx
+++ b/packages/lab/src/Chart/XDSChartErrorBar.tsx
@@ -5,7 +5,7 @@
  */
 
 import {useChart} from './ChartContext';
-import type {ScaleBand} from 'd3-scale';
+import {xPixel} from './utils';
 
 export interface XDSChartErrorBarProps {
   /** Data key for the upper bound */
@@ -18,10 +18,6 @@ export interface XDSChartErrorBarProps {
   strokeWidth?: number;
   /** Width of the whisker caps in pixels */
   capWidth?: number;
-}
-
-function isBandScale(scale: unknown): scale is ScaleBand<string> {
-  return typeof scale === 'function' && 'bandwidth' in scale;
 }
 
 /**
@@ -40,19 +36,12 @@ export function XDSChartErrorBar({
   strokeWidth = 1.5,
   capWidth = 8,
 }: XDSChartErrorBarProps) {
-  const {data, xScale, yScale} = useChart();
+  const {data, xKey, xScale, yScale} = useChart();
 
   return (
     <g>
       {data.map((d, i) => {
-        let x: number;
-        if (isBandScale(xScale)) {
-          x =
-            (xScale(String(Object.values(d)[0])) ?? 0) + xScale.bandwidth() / 2;
-        } else {
-          x = (xScale as (v: number) => number)(Object.values(d)[0] as number);
-        }
-
+        const x = xPixel(d, xKey, xScale);
         const upper = typeof d[yUpper] === 'number' ? (d[yUpper] as number) : 0;
         const lower = typeof d[yLower] === 'number' ? (d[yLower] as number) : 0;
         const yTop = yScale(upper);
@@ -61,7 +50,6 @@ export function XDSChartErrorBar({
 
         return (
           <g key={i}>
-            {/* Vertical stem */}
             <line
               x1={x}
               x2={x}
@@ -70,7 +58,6 @@ export function XDSChartErrorBar({
               stroke={color}
               strokeWidth={strokeWidth}
             />
-            {/* Top cap */}
             <line
               x1={x - half}
               x2={x + half}
@@ -79,7 +66,6 @@ export function XDSChartErrorBar({
               stroke={color}
               strokeWidth={strokeWidth}
             />
-            {/* Bottom cap */}
             <line
               x1={x - half}
               x2={x + half}

--- a/packages/lab/src/Chart/XDSChartGrid.tsx
+++ b/packages/lab/src/Chart/XDSChartGrid.tsx
@@ -6,17 +6,14 @@
 
 import {useMemo} from 'react';
 import {useChart} from './ChartContext';
-import type {ScaleBand, ScaleLinear, ScaleTime} from 'd3-scale';
+import {isBandScale} from './utils';
+import type {ScaleLinear, ScaleTime} from 'd3-scale';
 
 export interface XDSChartGridProps {
   /** Show horizontal grid lines (default: true) */
   horizontal?: boolean;
   /** Show vertical grid lines */
   vertical?: boolean;
-}
-
-function isBandScale(scale: unknown): scale is ScaleBand<string> {
-  return typeof scale === 'function' && 'bandwidth' in scale;
 }
 
 /**

--- a/packages/lab/src/Chart/XDSChartHeatmapGL.tsx
+++ b/packages/lab/src/Chart/XDSChartHeatmapGL.tsx
@@ -11,6 +11,7 @@
 import {useRef, useEffect, useMemo} from 'react';
 import {scaleBand} from 'd3-scale';
 import {useChart} from './ChartContext';
+import {isBandScale} from './utils';
 import type {ScaleBand} from 'd3-scale';
 
 export interface XDSChartHeatmapGLProps {
@@ -29,10 +30,6 @@ export interface XDSChartHeatmapGLProps {
   domain?: [number, number];
   /** Gap between cells in pixels (default: 1) */
   cellGap?: number;
-}
-
-function isBandScale(scale: unknown): scale is ScaleBand<string> {
-  return typeof scale === 'function' && 'bandwidth' in scale;
 }
 
 function hexToGL(hex: string): [number, number, number] {

--- a/packages/lab/src/Chart/XDSChartLine.tsx
+++ b/packages/lab/src/Chart/XDSChartLine.tsx
@@ -7,7 +7,7 @@
 import {useMemo} from 'react';
 import {line, curveMonotoneX} from 'd3-shape';
 import {useChart} from './ChartContext';
-import type {ScaleBand} from 'd3-scale';
+import {xPixel} from './utils';
 
 export interface XDSChartLineProps {
   /** Which data key to visualize */
@@ -20,10 +20,6 @@ export interface XDSChartLineProps {
   dots?: boolean;
   /** Dot radius */
   dotRadius?: number;
-}
-
-function isBandScale(scale: unknown): scale is ScaleBand<string> {
-  return typeof scale === 'function' && 'bandwidth' in scale;
 }
 
 /**
@@ -42,21 +38,15 @@ export function XDSChartLine({
   dots = false,
   dotRadius = 3,
 }: XDSChartLineProps) {
-  const {data, xScale, yScale} = useChart();
+  const {data, xKey, xScale, yScale} = useChart();
 
   const points = useMemo(() => {
     return data.map((d, i) => {
-      let x: number;
-      if (isBandScale(xScale)) {
-        x = (xScale(String(Object.values(d)[0])) ?? 0) + xScale.bandwidth() / 2;
-      } else {
-        const xVal = Object.values(d)[0];
-        x = (xScale as (v: number) => number)(xVal as number);
-      }
+      const x = xPixel(d, xKey, xScale);
       const yVal = typeof d[dataKey] === 'number' ? (d[dataKey] as number) : 0;
       return {x, y: yScale(yVal), index: i};
     });
-  }, [data, dataKey, xScale, yScale]);
+  }, [data, xKey, dataKey, xScale, yScale]);
 
   const pathD = useMemo(() => {
     const generator = line<{x: number; y: number}>()

--- a/packages/lab/src/Chart/XDSChartTooltip.tsx
+++ b/packages/lab/src/Chart/XDSChartTooltip.tsx
@@ -6,7 +6,7 @@
 
 import {useState, useCallback, type ReactNode} from 'react';
 import {useChart} from './ChartContext';
-import type {ScaleBand} from 'd3-scale';
+import {isBandScale, xPixel} from './utils';
 
 export interface XDSChartTooltipProps {
   /**
@@ -15,10 +15,6 @@ export interface XDSChartTooltipProps {
    * Default: renders all yKeys as "key: value" lines.
    */
   render?: (datum: Record<string, unknown>, index: number) => ReactNode;
-}
-
-function isBandScale(scale: unknown): scale is ScaleBand<string> {
-  return typeof scale === 'function' && 'bandwidth' in scale;
 }
 
 /**
@@ -32,7 +28,7 @@ function isBandScale(scale: unknown): scale is ScaleBand<string> {
  * ```
  */
 export function XDSChartTooltip({render}: XDSChartTooltipProps) {
-  const {data, xScale, yScale, width, height} = useChart();
+  const {data, xKey, xScale, yScale, width, height} = useChart();
   const [hoverIndex, setHoverIndex] = useState<number | null>(null);
 
   const handleMouseMove = useCallback(
@@ -61,8 +57,7 @@ export function XDSChartTooltip({render}: XDSChartTooltipProps) {
         let closest = 0;
         let minDist = Infinity;
         data.forEach((d, i) => {
-          const xVal = Object.values(d)[0] as number;
-          const dist = Math.abs(linearScale(xVal) - cursor.x);
+          const dist = Math.abs(xPixel(d, xKey, xScale) - cursor.x);
           if (dist < minDist) {
             minDist = dist;
             closest = i;
@@ -83,12 +78,9 @@ export function XDSChartTooltip({render}: XDSChartTooltipProps) {
   let tooltipY = 0;
   if (datum && hoverIndex !== null) {
     if (isBandScale(xScale)) {
-      tooltipX =
-        (xScale(String(Object.values(datum)[0])) ?? 0) + xScale.bandwidth() / 2;
+      tooltipX = xPixel(datum, xKey, xScale);
     } else {
-      tooltipX = (xScale as (v: number) => number)(
-        Object.values(datum)[0] as number,
-      );
+      tooltipX = xPixel(datum, xKey, xScale);
     }
     // Find the max y value across all numeric keys for positioning
     const yVals = Object.values(datum).filter(

--- a/packages/lab/src/Chart/index.ts
+++ b/packages/lab/src/Chart/index.ts
@@ -33,6 +33,7 @@ export {
 export {useChart} from './ChartContext';
 export type {ChartContext, ChartMargin, ChartScale} from './types';
 export {m4Reduce, type M4Point} from './m4';
+export {isBandScale, xPixel} from './utils';
 export {useXDSChartColors} from './useXDSChartColors';
 export {
   getXDSChartColors,

--- a/packages/lab/src/Chart/types.ts
+++ b/packages/lab/src/Chart/types.ts
@@ -28,6 +28,8 @@ export interface ChartContext {
   height: number;
   /** Margin offsets */
   margin: ChartMargin;
+  /** The data key used for x-axis values */
+  xKey: string;
   /** The full dataset */
   data: Record<string, unknown>[];
   /** X scale — band for categorical, linear/time for continuous */

--- a/packages/lab/src/Chart/utils.ts
+++ b/packages/lab/src/Chart/utils.ts
@@ -1,0 +1,29 @@
+/**
+ * @file utils.ts
+ * @output Shared utilities for chart components
+ * @position Internal helpers; consumed by mark, axis, and interaction components
+ */
+
+import type {ScaleBand} from 'd3-scale';
+import type {ChartScale} from './types';
+
+/** Type guard for d3 band scales */
+export function isBandScale(scale: ChartScale): scale is ScaleBand<string> {
+  return typeof scale === 'function' && 'bandwidth' in scale;
+}
+
+/**
+ * Get the x pixel position for a datum using the chart's xKey and xScale.
+ * For band scales, returns the center of the band.
+ */
+export function xPixel(
+  d: Record<string, unknown>,
+  xKey: string,
+  xScale: ChartScale,
+): number {
+  const raw = d[xKey];
+  if (isBandScale(xScale)) {
+    return (xScale(String(raw)) ?? 0) + xScale.bandwidth() / 2;
+  }
+  return (xScale as (v: number) => number)(raw as number);
+}


### PR DESCRIPTION
## What

Fixes four Tier 1 correctness issues identified in the chart system audit.

### 1. xKey in chart context
All marks now use `d[xKey]` from context instead of `Object.values(d)[0]`. Object key order is not guaranteed for numeric keys — this was a correctness bug hiding behind convention.

### 2. Bars grow from zero line
`XDSChartBar` now computes bar position relative to `yScale(0)`, not the chart bottom. Positive bars grow up from zero, negative bars grow down. Previously broke with `yBaseline='zero'`.

### 3. Shared `isBandScale` + `xPixel` utilities
Extracted to `utils.ts` — eliminates 10 duplicate `isBandScale` definitions across mark components. Single source of truth for scale type detection and x-position computation.

### 4. All marks updated
Bar, Line, Dot, Area, ErrorBar, Candlestick, DotGL, DotGLInteractive, Tooltip, Grid, Axis, HeatmapGL — all now use shared utilities and read `xKey` from context.

## Why

These are Tier 1 guarantees from the [Chart System Architecture](https://github.com/facebookexperimental/xds/wiki/Chart-System-Architecture) — correctness requirements enforced by architecture, not documentation.

---
