### PR TITLE
docs(DropdownMenu): fix @example for Storybook autodocs compatibility

### DIFF
--- a/packages/core/src/DropdownMenu/XDSDropdownMenu.tsx
+++ b/packages/core/src/DropdownMenu/XDSDropdownMenu.tsx
@@ -149,7 +149,6 @@ export type XDSDropdownMenuProps =
  *
  * @example
  * ```
- * // Data-driven (great for static menus)
  * <XDSDropdownMenu
  *   button={{ label: 'Actions' }}
  *   items={[
@@ -157,15 +156,6 @@ export type XDSDropdownMenuProps =
  *     { label: 'Delete', onClick: () => handleDelete() },
  *   ]}
  * />
- *
- * // Compound-component (for dynamic/stateful items)
- * <XDSDropdownMenu button={{ label: 'Actions' }}>
- *   <XDSDropdownMenuItem icon={PencilIcon} label="Edit" onClick={handleEdit} />
- *   <XDSDivider />
- *   <Suspense fallback={<XDSSkeleton />}>
- *     <LazyLoadedItems />
- *   </Suspense>
- * </XDSDropdownMenu>
  * ```
  */
 export function XDSDropdownMenu({


### PR DESCRIPTION
## What

XDSDropdownMenu's `@example` JSDoc block had two issues that break Storybook autodocs:

1. **JS comments** inside the code block (`// Data-driven`, `// Compound-component`) — Storybook's markdown parser can interpret these incorrectly
2. **Blank line** inside the code block — Storybook interprets blank lines as ending the code fence, causing the rest to render as raw text

Consolidated to a single data-driven example. The compound-component mode is already well-documented in the description text above the example.

## Night Watch Doc Review — April 16 2026

Full audit findings logged. This PR addresses the only Storybook-breaking issue found.

### Other findings (informational, no PR):
- 10 components missing `@example` blocks (sub-components mostly)
- 74 components missing `showcase` field in .doc.mjs
- 75 components missing block templates
- 68 blocks with `componentsUsed` drift (module path vs component name mismatch)
- 30 theming sections with visualProps drift
- 37 components with undocumented `xstyle` prop
- 26 components with general prop documentation drift (88 props total)

---
*Found during Night Watch doc review*