### PR TITLE
feat(sandbox): apply library design to sandbox landing page

### DIFF
--- a/apps/sandbox/src/app/(sandbox)/[category]/CategoryContent.tsx
+++ b/apps/sandbox/src/app/(sandbox)/[category]/CategoryContent.tsx
@@ -1,41 +1,94 @@
 'use client';
 
+import {useState, useMemo} from 'react';
+import * as stylex from '@stylexjs/stylex';
 import {XDSHeading, XDSText} from '@xds/core/Text';
+import {XDSLayout, XDSLayoutHeader, XDSLayoutContent} from '@xds/core/Layout';
+import {XDSTextInput} from '@xds/core/TextInput';
+import {XDSGrid} from '@xds/core/Grid';
+import {XDSVStack} from '@xds/core/Stack';
+import {spacingVars} from '@xds/core/theme/tokens.stylex';
 import {categories} from '../../sandboxPages';
 import {ProjectCard} from '../../ProjectCard';
+import {SearchIcon} from '../../icons';
+
+const styles = stylex.create({
+  emptyState: {
+    padding: spacingVars['--spacing-12'],
+    textAlign: 'center',
+  },
+});
 
 export function CategoryContent({slug}: {slug: string}) {
   const category = categories.find(c => c.slug === slug);
+  const [search, setSearch] = useState('');
+
+  const filtered = useMemo(() => {
+    if (!category) return [];
+    if (!search.trim()) return category.pages;
+    const q = search.toLowerCase();
+    return category.pages.filter(
+      p =>
+        p.name.toLowerCase().includes(q) ||
+        p.description.toLowerCase().includes(q),
+    );
+  }, [category, search]);
 
   if (!category) {
     return (
-      <div>
-        <XDSHeading level={1}>Not Found</XDSHeading>
-        <XDSText type="body" color="secondary">
-          Category &quot;{slug}&quot; doesn&apos;t exist.
-        </XDSText>
-      </div>
+      <XDSLayout
+        header={
+          <XDSLayoutHeader hasDivider padding={6}>
+            <XDSHeading level={1}>Not Found</XDSHeading>
+          </XDSLayoutHeader>
+        }
+        content={
+          <XDSLayoutContent padding={6}>
+            <XDSText type="body" color="secondary">
+              Category &quot;{slug}&quot; doesn&apos;t exist.
+            </XDSText>
+          </XDSLayoutContent>
+        }
+      />
     );
   }
 
   return (
-    <div style={{display: 'flex', flexDirection: 'column', gap: 24}}>
-      <div style={{display: 'flex', flexDirection: 'column', gap: 4}}>
-        <XDSHeading level={1}>{category.label}</XDSHeading>
-        <XDSText type="body" color="secondary">
-          {category.description}
-        </XDSText>
-      </div>
-      <div
-        style={{
-          display: 'grid',
-          gridTemplateColumns: 'repeat(4, 1fr)',
-          gap: 20,
-        }}>
-        {category.pages.map(page => (
-          <ProjectCard key={page.href} page={page} />
-        ))}
-      </div>
-    </div>
+    <XDSLayout
+      header={
+        <XDSLayoutHeader hasDivider padding={6}>
+          <XDSHeading level={1}>{category.label}</XDSHeading>
+        </XDSLayoutHeader>
+      }
+      content={
+        <XDSLayoutContent padding={6}>
+          <XDSVStack gap={6}>
+            <XDSTextInput
+              label="Search"
+              isLabelHidden
+              placeholder="Search..."
+              value={search}
+              onChange={setSearch}
+              startIcon={SearchIcon}
+              size="lg"
+            />
+
+            {filtered.length === 0 ? (
+              <div {...stylex.props(styles.emptyState)}>
+                <XDSText type="supporting" color="secondary">
+                  No results found.
+                </XDSText>
+              </div>
+            ) : (
+              <XDSGrid minChildWidth={280} gap={4}>
+                {filtered.map(page => (
+                  <ProjectCard key={page.href} page={page} />
+                ))}
+              </XDSGrid>
+            )}
+          </XDSVStack>
+        </XDSLayoutContent>
+      }
+    />
   );
 }

--- a/apps/sandbox/src/app/(sandbox)/page.tsx
+++ b/apps/sandbox/src/app/(sandbox)/page.tsx
@@ -1,46 +1,155 @@
 'use client';
 
+import {useState, useMemo} from 'react';
+import * as stylex from '@stylexjs/stylex';
 import {XDSText, XDSHeading} from '@xds/core/Text';
+import {XDSLayout, XDSLayoutHeader, XDSLayoutContent} from '@xds/core/Layout';
+import {XDSTextInput} from '@xds/core/TextInput';
+import {XDSToggleButton, XDSToggleButtonGroup} from '@xds/core/ToggleButton';
+import {XDSDropdownMenu} from '@xds/core/DropdownMenu';
+import {XDSGrid} from '@xds/core/Grid';
+import {XDSHStack, XDSVStack} from '@xds/core/Stack';
+import {XDSDivider} from '@xds/core/Divider';
+import {spacingVars} from '@xds/core/theme/tokens.stylex';
 import {categories} from '../sandboxPages';
 import {ProjectCard} from '../ProjectCard';
+import {SearchIcon} from '../icons';
+
+const CATEGORY_FILTERS = ['All', ...categories.map(c => c.label)];
+
+const allPages = categories.flatMap(c =>
+  c.pages.map(p => ({...p, category: c.label})),
+);
+
+const styles = stylex.create({
+  emptyState: {
+    padding: spacingVars['--spacing-12'],
+    textAlign: 'center',
+  },
+  hideOnSmall: {
+    display: {
+      default: 'none',
+      '@media (min-width: 840px)': 'block',
+    },
+  },
+  hideOnLarge: {
+    display: {
+      default: 'block',
+      '@media (min-width: 840px)': 'none',
+    },
+  },
+});
 
 export default function Home() {
-  return (
-    <div style={{display: 'flex', flexDirection: 'column', gap: 40}}>
-      <div style={{display: 'flex', flexDirection: 'column', gap: 8}}>
-        <XDSHeading level={1}>XDS Sandbox</XDSHeading>
-        <XDSText type="body" color="secondary">
-          A testing ground for XDS components. Explore tools and templates
-          below, or create new pages under{' '}
-          <XDSText type="body" weight="bold">
-            src/app/pages/
-          </XDSText>
-          .
-        </XDSText>
-      </div>
+  const [activeTab, setActiveTab] = useState('All');
+  const [search, setSearch] = useState('');
 
-      {categories.map(category => (
-        <div
-          key={category.slug}
-          style={{display: 'flex', flexDirection: 'column', gap: 16}}>
-          <div style={{display: 'flex', flexDirection: 'column', gap: 4}}>
-            <XDSHeading level={2}>{category.label}</XDSHeading>
-            <XDSText type="body" color="secondary">
-              {category.description}
-            </XDSText>
-          </div>
-          <div
-            style={{
-              display: 'grid',
-              gridTemplateColumns: 'repeat(4, 1fr)',
-              gap: 20,
-            }}>
-            {category.pages.map(page => (
-              <ProjectCard key={page.href} page={page} />
-            ))}
-          </div>
-        </div>
-      ))}
-    </div>
+  const filtered = useMemo(() => {
+    let items =
+      activeTab === 'All'
+        ? allPages
+        : allPages.filter(p => p.category === activeTab);
+    if (search.trim()) {
+      const q = search.toLowerCase();
+      items = items.filter(
+        p =>
+          p.name.toLowerCase().includes(q) ||
+          p.description.toLowerCase().includes(q),
+      );
+    }
+    return items;
+  }, [activeTab, search]);
+
+  const groupedSections = useMemo(() => {
+    if (activeTab !== 'All') return null;
+    const map = new Map<string, typeof allPages>();
+    for (const page of filtered) {
+      if (!map.has(page.category)) map.set(page.category, []);
+      map.get(page.category)!.push(page);
+    }
+    return categories
+      .filter(c => map.has(c.label))
+      .map(c => ({category: c.label, pages: map.get(c.label)!}));
+  }, [activeTab, filtered]);
+
+  return (
+    <XDSLayout
+      header={
+        <XDSLayoutHeader hasDivider padding={6}>
+          <XDSHeading level={1}>XDS Sandbox</XDSHeading>
+        </XDSLayoutHeader>
+      }
+      content={
+        <XDSLayoutContent padding={6}>
+          <XDSVStack gap={6}>
+            <XDSVStack gap={4}>
+              <XDSTextInput
+                label="Search"
+                isLabelHidden
+                placeholder="Search..."
+                value={search}
+                onChange={setSearch}
+                startIcon={SearchIcon}
+                size="lg"
+              />
+              <XDSHStack vAlign="center" hAlign="between">
+                <div {...stylex.props(styles.hideOnSmall)}>
+                  <XDSToggleButtonGroup
+                    label="Filter by category"
+                    value={activeTab}
+                    onChange={v => setActiveTab(v ?? 'All')}>
+                    {CATEGORY_FILTERS.map(cat => (
+                      <XDSToggleButton
+                        key={cat}
+                        label={cat}
+                        value={cat}
+                        size="lg"
+                      />
+                    ))}
+                  </XDSToggleButtonGroup>
+                </div>
+                <div {...stylex.props(styles.hideOnLarge)}>
+                  <XDSDropdownMenu
+                    button={{label: activeTab, size: 'lg'}}
+                    items={CATEGORY_FILTERS.map(cat => ({
+                      label: cat,
+                      onClick: () => setActiveTab(cat),
+                    }))}
+                  />
+                </div>
+              </XDSHStack>
+            </XDSVStack>
+
+            {filtered.length === 0 ? (
+              <div {...stylex.props(styles.emptyState)}>
+                <XDSText type="supporting" color="secondary">
+                  No results found.
+                </XDSText>
+              </div>
+            ) : groupedSections != null ? (
+              <XDSVStack gap={6}>
+                {groupedSections.flatMap(section => [
+                  <XDSDivider key={`d-${section.category}`} />,
+                  <XDSVStack gap={6} key={section.category}>
+                    <XDSHeading level={2}>{section.category}</XDSHeading>
+                    <XDSGrid minChildWidth={280} gap={4}>
+                      {section.pages.map(page => (
+                        <ProjectCard key={page.href} page={page} />
+                      ))}
+                    </XDSGrid>
+                  </XDSVStack>,
+                ])}
+              </XDSVStack>
+            ) : (
+              <XDSGrid minChildWidth={280} gap={4}>
+                {filtered.map(page => (
+                  <ProjectCard key={page.href} page={page} />
+                ))}
+              </XDSGrid>
+            )}
+          </XDSVStack>
+        </XDSLayoutContent>
+      }
+    />
   );
 }

--- a/apps/sandbox/src/app/ProjectCard.tsx
+++ b/apps/sandbox/src/app/ProjectCard.tsx
@@ -1,16 +1,11 @@
 'use client';
 
-import {useState} from 'react';
 import Link from 'next/link';
 import {XDSText} from '@xds/core/Text';
 import type {SandboxPage} from './sandboxPages';
 import {ImageIcon} from './icons';
 
-const basePath = process.env.NEXT_PUBLIC_BASE_PATH || '';
-
 export function ProjectCard({page}: {page: SandboxPage}) {
-  const [iframeError, setIframeError] = useState(false);
-
   return (
     <Link
       href={page.href}
@@ -31,32 +26,18 @@ export function ProjectCard({page}: {page: SandboxPage}) {
             height: 160,
             backgroundColor: 'var(--color-background-body)',
             overflow: 'hidden',
-            position: 'relative',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
           }}>
-          {iframeError ? (
-            <div style={{display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%'}}>
-              <ImageIcon style={{width: 48, height: 48, opacity: 0.3, color: 'var(--color-text-disabled)'}} />
-            </div>
-          ) : (
-            <iframe
-              src={`${basePath}${page.href}`}
-              title={page.name}
-              onError={() => setIframeError(true)}
-              style={{
-                width: 1280,
-                height: 800,
-                border: 'none',
-                transform: 'scale(0.2)',
-                transformOrigin: 'top left',
-                position: 'absolute',
-                top: 0,
-                left: 0,
-                pointerEvents: 'none',
-              }}
-              tabIndex={-1}
-              loading="lazy"
-            />
-          )}
+          <ImageIcon
+            style={{
+              width: 48,
+              height: 48,
+              opacity: 0.3,
+              color: 'var(--color-text-disabled)',
+            }}
+          />
         </div>
         <div
           style={{

--- a/apps/sandbox/src/app/SandboxShell.tsx
+++ b/apps/sandbox/src/app/SandboxShell.tsx
@@ -5,7 +5,7 @@ import {SandboxNav} from './SandboxNav';
 
 export function SandboxShell({children}: {children: React.ReactNode}) {
   return (
-    <XDSAppShell sideNav={<SandboxNav />} contentPadding={4}>
+    <XDSAppShell sideNav={<SandboxNav />} contentPadding={0}>
       {children}
     </XDSAppShell>
   );

--- a/apps/sandbox/src/app/icons.tsx
+++ b/apps/sandbox/src/app/icons.tsx
@@ -156,3 +156,17 @@ export const AppWindowIcon = (props: IconProps) => (
     <path d="M6 4v4" />
   </svg>
 );
+
+export const SearchIcon = (props: IconProps) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}>
+    <circle cx="11" cy="11" r="8" />
+    <line x1="21" y1="21" x2="16.65" y2="16.65" />
+  </svg>
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2807,6 +2807,17 @@ ast-types@^0.16.1:
   dependencies:
     tslib "^2.0.1"
 
+autoprefixer@^10.4.0:
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-10.5.0.tgz#33d87e443430f020a0f85319d6ff1593cb291be9"
+  integrity sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==
+  dependencies:
+    browserslist "^4.28.2"
+    caniuse-lite "^1.0.30001787"
+    fraction.js "^5.3.4"
+    picocolors "^1.1.1"
+    postcss-value-parser "^4.2.0"
+
 available-typed-arrays@^1.0.7:
   version "1.0.7"
   resolved "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz"
@@ -2835,6 +2846,11 @@ balanced-match@^4.0.2:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-4.0.4.tgz#bfb10662feed8196a2c62e7c68e17720c274179a"
   integrity sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==
+
+baseline-browser-mapping@^2.10.12:
+  version "2.10.19"
+  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.19.tgz#7697721c22f94f66195d0c34299b1a91e3299493"
+  integrity sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g==
 
 baseline-browser-mapping@^2.9.0:
   version "2.9.14"
@@ -2907,6 +2923,17 @@ browserslist@^4.24.0:
     node-releases "^2.0.27"
     update-browserslist-db "^1.2.0"
 
+browserslist@^4.28.2:
+  version "4.28.2"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.28.2.tgz#f50b65362ef48974ca9f50b3680566d786b811d2"
+  integrity sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==
+  dependencies:
+    baseline-browser-mapping "^2.10.12"
+    caniuse-lite "^1.0.30001782"
+    electron-to-chromium "^1.5.328"
+    node-releases "^2.0.36"
+    update-browserslist-db "^1.2.3"
+
 buffer-from@^1.0.0:
   version "1.1.2"
   resolved "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz"
@@ -2959,6 +2986,11 @@ caniuse-lite@^1.0.30001579, caniuse-lite@^1.0.30001759:
   version "1.0.30001769"
   resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001769.tgz"
   integrity sha512-BCfFL1sHijQlBGWBMuJyhZUhzo7wer5sVj9hqekB/7xn0Ypy+pER/edCYQm4exbXj4WiySGp40P8UuTh6w1srg==
+
+caniuse-lite@^1.0.30001782, caniuse-lite@^1.0.30001787:
+  version "1.0.30001788"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz#31e97d1bfec332b3f2d7eea7781460c97629b3bf"
+  integrity sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==
 
 chai@^5.1.1, chai@^5.1.2:
   version "5.3.3"
@@ -3387,6 +3419,11 @@ electron-to-chromium@^1.5.263:
   version "1.5.267"
   resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.267.tgz"
   integrity sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==
+
+electron-to-chromium@^1.5.328:
+  version "1.5.339"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.339.tgz#d797bf5f222a7f6241a42b43a97bf52ff43947f1"
+  integrity sha512-Is+0BBHJ4NrdpAYiperrmp53pLywG/yV/6lIMTAnhxvzj/Cmn5Q/ogSHC6AKe7X+8kPLxxFk0cs5oc/3j/fxIg==
 
 emoji-regex@^10.3.0:
   version "10.6.0"
@@ -3869,6 +3906,11 @@ foreground-child@^3.1.0:
   dependencies:
     cross-spawn "^7.0.6"
     signal-exit "^4.0.1"
+
+fraction.js@^5.3.4:
+  version "5.3.4"
+  resolved "https://registry.yarnpkg.com/fraction.js/-/fraction.js-5.3.4.tgz#8c0fcc6a9908262df4ed197427bdeef563e0699a"
+  integrity sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==
 
 fs-extra@^7.0.1:
   version "7.0.1"
@@ -4863,6 +4905,11 @@ node-releases@^2.0.27:
   resolved "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz"
   integrity sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==
 
+node-releases@^2.0.36:
+  version "2.0.37"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.37.tgz#9bd4f10b77ba39c2b9402d4e8399c482a797f671"
+  integrity sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==
+
 object-assign@^4.0.1, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
@@ -5094,7 +5141,7 @@ postcss-load-config@^6.0.1:
   dependencies:
     lilconfig "^3.1.1"
 
-postcss-value-parser@^4.1.0:
+postcss-value-parser@^4.1.0, postcss-value-parser@^4.2.0:
   version "4.2.0"
   resolved "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
@@ -5122,12 +5169,7 @@ prelude-ls@^1.2.1:
   resolved "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
-prettier@^2.7.1:
-  version "2.8.8"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
-  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
-
-prettier@^3.8.2:
+prettier@^2.7.1, prettier@^3.8.2:
   version "3.8.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.8.2.tgz#4f52e502193c9aa5b384c3d00852003e551bbd9f"
   integrity sha512-8c3mgTe0ASwWAJK+78dpviD+A8EqhndQPUBpNUIPt6+xWlIigCwfN01lWr9MAede4uqXGTEKeQWTvzb3vjia0Q==
@@ -5932,7 +5974,7 @@ unplugin@^2.3.11:
     picomatch "^4.0.3"
     webpack-virtual-modules "^0.6.2"
 
-update-browserslist-db@^1.2.0:
+update-browserslist-db@^1.2.0, update-browserslist-db@^1.2.3:
   version "1.2.3"
   resolved "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz"
   integrity sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==


### PR DESCRIPTION
## Summary

Redesigns the sandbox home page and category sub-pages to follow the same layout pattern as the library template.

### Changes

- **Header**: Page heading (`XDS Sandbox`) moved into `XDSLayoutHeader` with a divider, matching the library's header treatment
- **Search**: Added full-width search input with `SearchIcon` for filtering across all sandbox pages
- **Category toggles**: Added `XDSToggleButtonGroup` using the existing sandbox categories (`Components & Patterns`, `Templates`, `Blocks`, `Tools`) — collapses to a dropdown on mobile
- **Responsive grid**: Replaced fixed `repeat(4, 1fr)` grid with `XDSGrid minChildWidth={280}` for fluid responsiveness
- **Grouped sections**: When `All` is selected, pages are grouped by category with dividers between sections
- **Category pages**: Same `XDSLayout` + search treatment applied to individual category routes
- **Thumbnails**: Kept the existing iframe-based `ProjectCard` thumbnails (not static images)

### Layout structure

Uses `XDSLayout` → `XDSLayoutHeader` + `XDSLayoutContent` inside the existing `SandboxShell` (which provides `XDSAppShell` + `SideNav`). Updated `SandboxShell` to `contentPadding={0}` so the inner Layout manages its own padding.