### PR TITLE
fix(sandbox): add @ mention and / command triggers to AI Chat template

### DIFF
--- a/packages/cli/templates/pages/ai-chat/page.tsx
+++ b/packages/cli/templates/pages/ai-chat/page.tsx
@@ -507,6 +507,12 @@ export default function AIChatTemplate() {
                             description={item.auxiliaryData?.role}
                             onClick={() => {
                               composerInputRef.current?.focus();
+                              // Move cursor to end so token is appended
+                              const sel = window.getSelection();
+                              if (sel && document.activeElement) {
+                                sel.selectAllChildren(document.activeElement);
+                                sel.collapseToEnd();
+                              }
                               composerInputRef.current?.insertToken({
                                 value: `@${item.id}`,
                                 label: item.label,
@@ -752,6 +758,12 @@ export default function AIChatTemplate() {
                     description={item.auxiliaryData?.role}
                     onClick={() => {
                       composerInputRef.current?.focus();
+                      // Move cursor to end so token is appended
+                      const sel = window.getSelection();
+                      if (sel && document.activeElement) {
+                        sel.selectAllChildren(document.activeElement);
+                        sel.collapseToEnd();
+                      }
                       composerInputRef.current?.insertToken({
                         value: `@${item.id}`,
                         label: item.label,

--- a/packages/cli/templates/pages/ai-chat/page.tsx
+++ b/packages/cli/templates/pages/ai-chat/page.tsx
@@ -41,7 +41,7 @@ import {XDSToken} from '@xds/core/Token';
 import {XDSCard} from '@xds/core/Card';
 import {XDSGrid} from '@xds/core/Grid';
 
-import {XDSDropdownMenu} from '@xds/core/DropdownMenu';
+import {XDSDropdownMenu, XDSDropdownMenuItem} from '@xds/core/DropdownMenu';
 import {
   ChatBubbleOvalLeftIcon,
   FolderIcon,
@@ -488,27 +488,42 @@ export default function AIChatTemplate() {
                   }
                   headerActions={
                     <>
-                      <XDSButton
-                        label="Reference"
-                        variant="ghost"
-                        size="sm"
-                        icon={<AtSymbolIcon style={{width: 16, height: 16}} />}
-                        isIconOnly
-                        onClick={() => {
-                          const input = composerInputRef.current;
-                          if (!input) return;
-                          input.focus();
-                          const sel = window.getSelection();
-                          if (sel) {
-                            sel.selectAllChildren(document.activeElement!);
-                            sel.collapseToEnd();
-                          }
-                          input.insertText('@');
-                          document.activeElement?.dispatchEvent(
-                            new Event('input', {bubbles: true}),
-                          );
+                      <XDSDropdownMenu
+                        button={{
+                          label: 'Reference',
+                          variant: 'ghost',
+                          size: 'sm',
+                          icon: (
+                            <AtSymbolIcon style={{width: 16, height: 16}} />
+                          ),
+                          isIconOnly: true,
                         }}
-                      />
+                        hasChevron={false}
+                        menuWidth={240}
+                        items={MENTION_ITEMS.map(item => ({
+                          label: item.label,
+                          onClick: () => {
+                            composerInputRef.current?.focus();
+                            composerInputRef.current?.insertToken({
+                              value: `@${item.id}`,
+                              label: item.label,
+                              variant: 'blue',
+                            });
+                            document.activeElement?.dispatchEvent(
+                              new Event('input', {bubbles: true}),
+                            );
+                          },
+                        }))}>
+                        {item => (
+                          <XDSDropdownMenuItem
+                            label={item.label}
+                            description={
+                              MENTION_ITEMS.find(m => m.label === item.label)
+                                ?.auxiliaryData?.role
+                            }
+                          />
+                        )}
+                      </XDSDropdownMenu>
                       <XDSButton
                         label="Attach"
                         variant="ghost"
@@ -725,27 +740,40 @@ export default function AIChatTemplate() {
           }
           headerActions={
             <>
-              <XDSButton
-                label="Reference"
-                variant="ghost"
-                size="sm"
-                icon={<AtSymbolIcon style={{width: 16, height: 16}} />}
-                isIconOnly
-                onClick={() => {
-                  const input = composerInputRef.current;
-                  if (!input) return;
-                  input.focus();
-                  const sel = window.getSelection();
-                  if (sel) {
-                    sel.selectAllChildren(document.activeElement!);
-                    sel.collapseToEnd();
-                  }
-                  input.insertText('@');
-                  document.activeElement?.dispatchEvent(
-                    new Event('input', {bubbles: true}),
-                  );
+              <XDSDropdownMenu
+                button={{
+                  label: 'Reference',
+                  variant: 'ghost',
+                  size: 'sm',
+                  icon: <AtSymbolIcon style={{width: 16, height: 16}} />,
+                  isIconOnly: true,
                 }}
-              />
+                hasChevron={false}
+                menuWidth={240}
+                items={MENTION_ITEMS.map(item => ({
+                  label: item.label,
+                  onClick: () => {
+                    composerInputRef.current?.focus();
+                    composerInputRef.current?.insertToken({
+                      value: `@${item.id}`,
+                      label: item.label,
+                      variant: 'blue',
+                    });
+                    document.activeElement?.dispatchEvent(
+                      new Event('input', {bubbles: true}),
+                    );
+                  },
+                }))}>
+                {item => (
+                  <XDSDropdownMenuItem
+                    label={item.label}
+                    description={
+                      MENTION_ITEMS.find(m => m.label === item.label)
+                        ?.auxiliaryData?.role
+                    }
+                  />
+                )}
+              </XDSDropdownMenu>
               <XDSButton
                 label="Attach"
                 variant="ghost"

--- a/packages/cli/templates/pages/ai-chat/page.tsx
+++ b/packages/cli/templates/pages/ai-chat/page.tsx
@@ -26,8 +26,14 @@ import {
   XDSChatSystemMessage,
   useXDSChatDictation,
   type XDSChatComposerInputHandle,
+  type XDSChatComposerTrigger,
 } from '@xds/core/Chat';
 import {XDSMarkdown} from '@xds/core/Markdown';
+import {
+  createStaticSource,
+  XDSTypeaheadItem,
+  type XDSSearchableItem,
+} from '@xds/core/Typeahead';
 import {XDSTimestamp} from '@xds/core/Timestamp';
 import {XDSToggleButton, XDSToggleButtonGroup} from '@xds/core/ToggleButton';
 import {XDSButton} from '@xds/core/Button';
@@ -172,6 +178,86 @@ const MODE_OPTIONS = [
   {key: 'sensitive', label: 'Sensitive', icon: LockClosedIcon},
   {key: 'deep', label: 'Deep Mode', icon: ClockIcon},
 ] as const;
+
+// ============= TRIGGER DATA =============
+
+const MENTION_ITEMS: XDSSearchableItem<{role: string}>[] = [
+  {id: 'cindy', label: 'Cindy Zhang', auxiliaryData: {role: 'Design Systems'}},
+  {id: 'alex', label: 'Alex Johnson', auxiliaryData: {role: 'Frontend'}},
+  {id: 'sam', label: 'Sam Rivera', auxiliaryData: {role: 'Backend'}},
+  {id: 'jordan', label: 'Jordan Lee', auxiliaryData: {role: 'Product'}},
+  {id: 'taylor', label: 'Taylor Kim', auxiliaryData: {role: 'Design'}},
+  {
+    id: 'morgan',
+    label: 'Morgan Chen',
+    auxiliaryData: {role: 'Infrastructure'},
+  },
+];
+
+const COMMAND_ITEMS: XDSSearchableItem<{description: string}>[] = [
+  {
+    id: 'summarize',
+    label: 'summarize',
+    auxiliaryData: {description: 'Summarize the conversation'},
+  },
+  {
+    id: 'translate',
+    label: 'translate',
+    auxiliaryData: {description: 'Translate text to another language'},
+  },
+  {
+    id: 'search',
+    label: 'search',
+    auxiliaryData: {description: 'Search the web or documents'},
+  },
+  {
+    id: 'code',
+    label: 'code',
+    auxiliaryData: {description: 'Generate or explain code'},
+  },
+  {
+    id: 'help',
+    label: 'help',
+    auxiliaryData: {description: 'Show available commands'},
+  },
+];
+
+const mentionSource = createStaticSource(MENTION_ITEMS);
+const commandSource = createStaticSource(COMMAND_ITEMS);
+
+const mentionTrigger: XDSChatComposerTrigger = {
+  character: '@',
+  searchSource: mentionSource,
+  renderItem: item => (
+    <XDSTypeaheadItem
+      item={item}
+      description={(item.auxiliaryData as {role: string})?.role}
+    />
+  ),
+  onSelect: item => ({
+    value: `@${item.id}`,
+    label: item.label,
+    variant: 'blue' as const,
+  }),
+};
+
+const commandTrigger: XDSChatComposerTrigger = {
+  character: '/',
+  searchSource: commandSource,
+  renderItem: item => (
+    <XDSTypeaheadItem
+      item={item}
+      description={(item.auxiliaryData as {description: string})?.description}
+    />
+  ),
+  onSelect: item => ({
+    value: `/${item.label}`,
+    label: `/${item.label}`,
+    variant: 'yellow' as const,
+  }),
+};
+
+const composerTriggers = [mentionTrigger, commandTrigger];
 
 // ============= MESSAGE TYPES =============
 
@@ -379,6 +465,7 @@ export default function AIChatTemplate() {
                   input={
                     <XDSChatComposerInput
                       ref={composerInputRef}
+                      triggers={composerTriggers}
                       style={{minHeight: '44px'}}
                     />
                   }
@@ -615,6 +702,7 @@ export default function AIChatTemplate() {
           input={
             <XDSChatComposerInput
               ref={composerInputRef}
+              triggers={composerTriggers}
               style={{minHeight: '44px'}}
             />
           }

--- a/packages/cli/templates/pages/ai-chat/page.tsx
+++ b/packages/cli/templates/pages/ai-chat/page.tsx
@@ -499,30 +499,25 @@ export default function AIChatTemplate() {
                           isIconOnly: true,
                         }}
                         hasChevron={false}
-                        menuWidth={240}
-                        items={MENTION_ITEMS.map(item => ({
-                          label: item.label,
-                          onClick: () => {
-                            composerInputRef.current?.focus();
-                            composerInputRef.current?.insertToken({
-                              value: `@${item.id}`,
-                              label: item.label,
-                              variant: 'blue',
-                            });
-                            document.activeElement?.dispatchEvent(
-                              new Event('input', {bubbles: true}),
-                            );
-                          },
-                        }))}>
-                        {item => (
+                        menuWidth={240}>
+                        {MENTION_ITEMS.map(item => (
                           <XDSDropdownMenuItem
+                            key={item.id}
                             label={item.label}
-                            description={
-                              MENTION_ITEMS.find(m => m.label === item.label)
-                                ?.auxiliaryData?.role
-                            }
+                            description={item.auxiliaryData?.role}
+                            onClick={() => {
+                              composerInputRef.current?.focus();
+                              composerInputRef.current?.insertToken({
+                                value: `@${item.id}`,
+                                label: item.label,
+                                variant: 'blue',
+                              });
+                              document.activeElement?.dispatchEvent(
+                                new Event('input', {bubbles: true}),
+                              );
+                            }}
                           />
-                        )}
+                        ))}
                       </XDSDropdownMenu>
                       <XDSButton
                         label="Attach"
@@ -749,30 +744,25 @@ export default function AIChatTemplate() {
                   isIconOnly: true,
                 }}
                 hasChevron={false}
-                menuWidth={240}
-                items={MENTION_ITEMS.map(item => ({
-                  label: item.label,
-                  onClick: () => {
-                    composerInputRef.current?.focus();
-                    composerInputRef.current?.insertToken({
-                      value: `@${item.id}`,
-                      label: item.label,
-                      variant: 'blue',
-                    });
-                    document.activeElement?.dispatchEvent(
-                      new Event('input', {bubbles: true}),
-                    );
-                  },
-                }))}>
-                {item => (
+                menuWidth={240}>
+                {MENTION_ITEMS.map(item => (
                   <XDSDropdownMenuItem
+                    key={item.id}
                     label={item.label}
-                    description={
-                      MENTION_ITEMS.find(m => m.label === item.label)
-                        ?.auxiliaryData?.role
-                    }
+                    description={item.auxiliaryData?.role}
+                    onClick={() => {
+                      composerInputRef.current?.focus();
+                      composerInputRef.current?.insertToken({
+                        value: `@${item.id}`,
+                        label: item.label,
+                        variant: 'blue',
+                      });
+                      document.activeElement?.dispatchEvent(
+                        new Event('input', {bubbles: true}),
+                      );
+                    }}
                   />
-                )}
+                ))}
               </XDSDropdownMenu>
               <XDSButton
                 label="Attach"


### PR DESCRIPTION
Adds `@` mention and `/` slash command typeahead triggers to the AI Chat template, and replaces the `@` header button with a dropdown menu for direct token insertion.

## What changed

### Trigger menus (typing in the composer)
- **`@` trigger** — typing `@` opens a typeahead with mock users and their roles. Selecting inserts a blue token.
- **`/` trigger** — typing `/` opens a typeahead with commands (summarize, translate, search, code, help) with descriptions. Selecting inserts a yellow token.

### @ reference button → dropdown menu
- The `@` button in the composer header bar now opens a `XDSDropdownMenu` popover instead of inserting a raw `@` character.
- Each menu item shows the person's name and role via `XDSDropdownMenuItem`.
- Selecting an item calls `composerInputRef.insertToken()` to insert a blue token at the current cursor position.
- If the textarea isn't focused, focus is restored first so the token appends at the end.
- Both composers (landing + chat view) share the same behavior.

## How

- Triggers use `XDSChatComposerTrigger` with `createStaticSource` + `XDSTypeaheadItem` (same pattern as the MultipleTriggers storybook story).
- The `@` button uses `XDSDropdownMenu` with `hasChevron={false}`, `XDSDropdownMenuItem` for custom rendering with descriptions, and the imperative `insertToken` handle for token insertion.