### PR TITLE
fix(theme): fix specificity overrides and missing CSS for Meta and WhatsApp themes

### DIFF
--- a/apps/sandbox/src/app/layout.tsx
+++ b/apps/sandbox/src/app/layout.tsx
@@ -10,6 +10,7 @@ import type {Metadata} from 'next';
  *   4. @xds/theme-neutral/theme.css   → @layer xds-theme  (neutral theme)
  *   5. @xds/theme-brutalist/theme.css → @layer xds-theme  (brutalist theme)
  *   6. @xds/theme-meta/theme.css      → @layer xds-theme  (meta theme)
+ *   7. @xds/theme-whatsapp/theme.css  → @layer xds-theme  (whatsapp theme)
  *
  * All theme CSS files are in @layer xds-theme and scoped via
  * @scope ([data-xds-theme="name"]), so only the active theme's rules apply.
@@ -23,6 +24,7 @@ import '@xds/theme-default/theme.css';
 import '@xds/theme-neutral/theme.css';
 import '@xds/theme-brutalist/theme.css';
 import '@xds/theme-meta/theme.css';
+import '@xds/theme-whatsapp/theme.css';
 import './globals.css';
 import {Providers} from './providers';
 

--- a/packages/themes/meta/src/icons.tsx
+++ b/packages/themes/meta/src/icons.tsx
@@ -33,16 +33,13 @@ import {
   ClipboardDocumentIcon,
   WrenchScrewdriverIcon,
   MicrophoneIcon,
-} from '@heroicons/react/24/outline';
-
-import {
   CheckCircleIcon,
   XCircleIcon,
   ExclamationTriangleIcon,
   ArrowTopRightOnSquareIcon,
   StopIcon,
   StopCircleIcon,
-} from '@heroicons/react/24/solid';
+} from '@heroicons/react/24/outline';
 
 const iconProps = {
   width: '1em',

--- a/packages/themes/meta/src/metaTheme.ts
+++ b/packages/themes/meta/src/metaTheme.ts
@@ -451,15 +451,19 @@ export const metaTheme = defineTheme({
     // =========================================================================
     radio: {
       base: {
-        borderWidth: '1.5px !important',
+        borderWidth: '2.5px !important',
         '--color-border-emphasized': '#8F9296',
+      },
+      checked: {
+        backgroundColor: 'var(--color-background-surface) !important',
+        borderColor: 'var(--color-accent) !important',
       },
     },
     'radio-dot': {
       base: {
         backgroundColor: 'var(--color-accent) !important',
-        width: '14px !important',
-        height: '14px !important',
+        width: '12px !important',
+        height: '12px !important',
       },
     },
 

--- a/packages/themes/meta/src/metaTheme.ts
+++ b/packages/themes/meta/src/metaTheme.ts
@@ -253,73 +253,73 @@ export const metaTheme = defineTheme({
     button: {
       base: {
         borderRadius: '9999px !important',
-        gap: '4px',
+        gap: '4px !important',
       },
       'size:sm': {
-        paddingInline: '12px',
+        paddingInline: '12px !important',
       },
       'size:md': {
-        paddingInline: '16px',
+        paddingInline: '16px !important',
       },
       'size:lg': {
-        paddingInline: '20px',
+        paddingInline: '20px !important',
       },
-      'variant:primary': {fontWeight: '500'},
-      'variant:secondary': {fontWeight: '500'},
-      'variant:destructive': {fontWeight: '500'},
-      'variant:ghost': {fontWeight: '500'},
+      'variant:primary': {fontWeight: '500 !important'},
+      'variant:secondary': {fontWeight: '500 !important'},
+      'variant:destructive': {fontWeight: '500 !important'},
+      'variant:ghost': {fontWeight: '500 !important'},
       'variant:primary-muted': {
-        backgroundColor: 'light-dark(#ECF5FF, #182849)',
-        color: 'light-dark(#0457CB, #78BEFF)',
-        fontWeight: '500',
-        ':hover': {opacity: '0.85'},
-        ':active': {opacity: '0.7'},
+        backgroundColor: 'light-dark(#ECF5FF, #182849) !important',
+        color: 'light-dark(#0457CB, #78BEFF) !important',
+        fontWeight: '500 !important',
+        ':hover': {opacity: '0.85 !important'},
+        ':active': {opacity: '0.7 !important'},
       },
       'variant:destructive-muted': {
-        backgroundColor: 'light-dark(#FFF0F2, #471B1A)',
-        color: 'light-dark(var(--color-error), #FE9DA6)',
-        fontWeight: '500',
-        ':hover': {opacity: '0.85'},
-        ':active': {opacity: '0.7'},
+        backgroundColor: 'light-dark(#FFF0F2, #471B1A) !important',
+        color: 'light-dark(var(--color-error), #FE9DA6) !important',
+        fontWeight: '500 !important',
+        ':hover': {opacity: '0.85 !important'},
+        ':active': {opacity: '0.7 !important'},
       },
       'variant:primary-outline': {
-        backgroundColor: 'transparent',
-        borderWidth: '1px',
-        borderStyle: 'solid',
-        borderColor: 'light-dark(var(--color-accent), #4BA9FE)',
-        color: 'light-dark(var(--color-accent), #4BA9FE)',
-        fontWeight: '500',
+        backgroundColor: 'transparent !important',
+        borderWidth: '1px !important',
+        borderStyle: 'solid !important',
+        borderColor: 'light-dark(var(--color-accent), #4BA9FE) !important',
+        color: 'light-dark(var(--color-accent), #4BA9FE) !important',
+        fontWeight: '500 !important',
         ':hover': {
           backgroundColor:
-            'light-dark(rgba(0,100,224,0.06), rgba(75,169,254,0.1))',
+            'light-dark(rgba(0,100,224,0.06), rgba(75,169,254,0.1)) !important',
         },
-        ':active': {opacity: '0.7'},
+        ':active': {opacity: '0.7 !important'},
       },
       'variant:secondary-outline': {
-        backgroundColor: 'transparent',
-        borderWidth: '1px',
-        borderStyle: 'solid',
-        borderColor: 'light-dark(var(--color-border), #525456)',
-        color: 'light-dark(var(--color-text-primary), #F3F4F5)',
-        fontWeight: '500',
+        backgroundColor: 'transparent !important',
+        borderWidth: '1px !important',
+        borderStyle: 'solid !important',
+        borderColor: 'light-dark(var(--color-border), #525456) !important',
+        color: 'light-dark(var(--color-text-primary), #F3F4F5) !important',
+        fontWeight: '500 !important',
         ':hover': {
           backgroundColor:
-            'light-dark(rgba(0,0,0,0.04), rgba(255,255,255,0.06))',
+            'light-dark(rgba(0,0,0,0.04), rgba(255,255,255,0.06)) !important',
         },
-        ':active': {opacity: '0.7'},
+        ':active': {opacity: '0.7 !important'},
       },
       'variant:destructive-outline': {
-        backgroundColor: 'transparent',
-        borderWidth: '1px',
-        borderStyle: 'solid',
-        borderColor: 'light-dark(var(--color-error), #FB7D87)',
-        color: 'light-dark(var(--color-error), #FB7D87)',
-        fontWeight: '500',
+        backgroundColor: 'transparent !important',
+        borderWidth: '1px !important',
+        borderStyle: 'solid !important',
+        borderColor: 'light-dark(var(--color-error), #FB7D87) !important',
+        color: 'light-dark(var(--color-error), #FB7D87) !important',
+        fontWeight: '500 !important',
         ':hover': {
           backgroundColor:
-            'light-dark(rgba(211,17,48,0.06), rgba(251,125,135,0.1))',
+            'light-dark(rgba(211,17,48,0.06), rgba(251,125,135,0.1)) !important',
         },
-        ':active': {opacity: '0.7'},
+        ':active': {opacity: '0.7 !important'},
       },
     },
 
@@ -345,12 +345,13 @@ export const metaTheme = defineTheme({
         borderRadius: '8px !important',
         paddingInline: '12px !important',
         paddingBlock: '12px !important',
-        minHeight: '44px',
-        borderColor: 'light-dark(#CCD3DB, #494D53)',
+        minHeight: '44px !important',
+        '--color-success': '#686A6E',
+        '--color-warning': '#686A6E',
       },
       'variant:search': {
-        backgroundColor: 'light-dark(#F3F4F5, #28292C)',
-        borderColor: 'transparent',
+        backgroundColor: 'light-dark(#F3F4F5, #28292C) !important',
+        borderColor: 'transparent !important',
         borderRadius: '9999px !important',
       },
     },
@@ -377,7 +378,7 @@ export const metaTheme = defineTheme({
         borderRadius: '8px !important',
         paddingInline: '12px !important',
         paddingBlock: '12px !important',
-        minHeight: '44px',
+        minHeight: '44px !important',
       },
     },
 
@@ -386,8 +387,8 @@ export const metaTheme = defineTheme({
     // =========================================================================
     'slider-track': {
       base: {
-        backgroundColor: '#8F9296',
-        height: '2px',
+        backgroundColor: '#8F9296 !important',
+        height: '2px !important',
       },
     },
 
@@ -398,13 +399,23 @@ export const metaTheme = defineTheme({
       base: {
         '--banner-radius': '16px',
       },
-      'status:info': {backgroundColor: 'var(--color-background-card)'},
-      'status:warning': {backgroundColor: 'var(--color-background-card)'},
-      'status:error': {backgroundColor: 'var(--color-background-card)'},
-      'status:success': {backgroundColor: 'var(--color-background-card)'},
+      'status:info': {backgroundColor: 'var(--color-background-card) !important'},
+      'status:warning': {backgroundColor: 'var(--color-background-card) !important'},
+      'status:error': {backgroundColor: 'var(--color-background-card) !important'},
+      'status:success': {backgroundColor: 'var(--color-background-card) !important'},
     },
     'banner-icon': {
-      base: {color: 'var(--color-icon-primary)'},
+      base: {color: 'var(--color-icon-primary) !important'},
+    },
+
+    // =========================================================================
+    // Icon — restore success/warning colors overridden on text-input
+    // =========================================================================
+    icon: {
+      base: {
+        '--color-success': 'light-dark(#147B29, #3CBC22)',
+        '--color-warning': 'light-dark(#965E03, #D69804)',
+      },
     },
 
     // =========================================================================
@@ -412,26 +423,26 @@ export const metaTheme = defineTheme({
     // =========================================================================
     badge: {
       base: {
-        fontWeight: '500',
-        borderRadius: '20px',
-        paddingInline: '8px',
-        paddingBlock: '6px',
+        fontWeight: '500 !important',
+        borderRadius: '20px !important',
+        paddingInline: '8px !important',
+        paddingBlock: '6px !important',
       },
       'variant:info': {
-        backgroundColor: 'light-dark(#DBECFF, #14367E)',
-        color: 'var(--color-text-primary)',
+        backgroundColor: 'light-dark(#DBECFF, #14367E) !important',
+        color: 'var(--color-text-primary) !important',
       },
       'variant:success': {
-        backgroundColor: 'light-dark(#DAF0D4, #154321)',
-        color: 'var(--color-text-primary)',
+        backgroundColor: 'light-dark(#DAF0D4, #154321) !important',
+        color: 'var(--color-text-primary) !important',
       },
       'variant:warning': {
-        backgroundColor: 'light-dark(#FAEBA4, #5B2F05)',
-        color: 'var(--color-text-primary)',
+        backgroundColor: 'light-dark(#FAEBA4, #5B2F05) !important',
+        color: 'var(--color-text-primary) !important',
       },
       'variant:error': {
-        backgroundColor: 'light-dark(#FEE4E6, #73161A)',
-        color: 'var(--color-text-primary)',
+        backgroundColor: 'light-dark(#FEE4E6, #73161A) !important',
+        color: 'var(--color-text-primary) !important',
       },
     },
 
@@ -440,15 +451,15 @@ export const metaTheme = defineTheme({
     // =========================================================================
     radio: {
       base: {
-        borderWidth: '1.5px',
+        borderWidth: '1.5px !important',
         '--color-border-emphasized': '#8F9296',
       },
     },
     'radio-dot': {
       base: {
-        backgroundColor: 'var(--color-accent)',
-        width: '14px',
-        height: '14px',
+        backgroundColor: 'var(--color-accent) !important',
+        width: '14px !important',
+        height: '14px !important',
       },
     },
 
@@ -457,8 +468,8 @@ export const metaTheme = defineTheme({
     // =========================================================================
     checkbox: {
       base: {
-        borderWidth: '2px',
-        borderRadius: '7px',
+        borderWidth: '2px !important',
+        borderRadius: '7px !important',
         '--color-border-emphasized': '#8F9296',
       },
     },
@@ -474,7 +485,7 @@ export const metaTheme = defineTheme({
     },
     'switch-thumb': {
       base: {
-        boxShadow: '0 1px 3px rgba(0,0,0,0.2), 0 1px 2px rgba(0,0,0,0.15)',
+        boxShadow: '0 1px 3px rgba(0,0,0,0.2), 0 1px 2px rgba(0,0,0,0.15) !important',
       },
     },
 
@@ -483,7 +494,7 @@ export const metaTheme = defineTheme({
     // =========================================================================
     divider: {
       base: {
-        backgroundColor: 'light-dark(#DDE2E8, #3E4042)',
+        backgroundColor: 'light-dark(#DDE2E8, #3E4042) !important',
       },
     },
 
@@ -492,7 +503,7 @@ export const metaTheme = defineTheme({
     // =========================================================================
     tab: {
       base: {
-        paddingInline: '12px',
+        paddingInline: '12px !important',
       },
     },
 
@@ -500,14 +511,14 @@ export const metaTheme = defineTheme({
     // Calendar — selected date via state class (#763)
     // =========================================================================
     'calendar-day': {
-      selected: {backgroundColor: 'var(--color-accent)'},
+      selected: {backgroundColor: 'var(--color-accent) !important'},
     },
 
     // =========================================================================
     // Empty state — heading 1 size
     // =========================================================================
     'emptystate-title': {
-      base: {fontSize: '1.75rem'},
+      base: {fontSize: '1.75rem !important'},
     },
 
     // =========================================================================
@@ -515,7 +526,7 @@ export const metaTheme = defineTheme({
     // =========================================================================
     dialog: {
       base: {
-        backgroundColor: 'light-dark(var(--color-background-surface), #1F1F20)',
+        backgroundColor: 'light-dark(var(--color-background-surface), #1F1F20) !important',
         '--dialog-radius': '32px',
       },
     },
@@ -524,13 +535,13 @@ export const metaTheme = defineTheme({
     // Layout — dialog internals: no borders, no body padding
     // =========================================================================
     'layout-header': {
-      base: {borderBlockEndWidth: '0'},
+      base: {borderBlockEndWidth: '0 !important'},
     },
     'layout-content': {
-      base: {paddingBlockStart: '0', paddingBlockEnd: '0'},
+      base: {paddingBlockStart: '0 !important', paddingBlockEnd: '0 !important'},
     },
     'layout-footer': {
-      base: {borderBlockStartWidth: '0'},
+      base: {borderBlockStartWidth: '0 !important'},
     },
 
     // =========================================================================
@@ -538,7 +549,7 @@ export const metaTheme = defineTheme({
     // =========================================================================
     popover: {
       base: {
-        borderRadius: '16px',
+        borderRadius: '16px !important',
         padding: '16px !important',
       },
     },
@@ -551,12 +562,12 @@ export const metaTheme = defineTheme({
     },
     'more-menu': {
       base: {
-        borderRadius: '16px',
+        borderRadius: '16px !important',
         padding: '8px !important',
       },
     },
     tooltip: {
-      base: {borderRadius: '16px'},
+      base: {borderRadius: '16px !important'},
     },
   },
 

--- a/packages/themes/meta/src/metaTheme.ts
+++ b/packages/themes/meta/src/metaTheme.ts
@@ -266,7 +266,11 @@ export const metaTheme = defineTheme({
       },
       'variant:primary': {fontWeight: '500 !important'},
       'variant:secondary': {fontWeight: '500 !important'},
-      'variant:destructive': {fontWeight: '500 !important'},
+      'variant:destructive': {
+        backgroundColor: 'light-dark(#D31130, #DA2A3E) !important',
+        color: '#FFFFFF !important',
+        fontWeight: '500 !important',
+      },
       'variant:ghost': {fontWeight: '500 !important'},
       'variant:primary-muted': {
         backgroundColor: 'light-dark(#ECF5FF, #182849) !important',

--- a/packages/themes/whatsapp/src/whatsappTheme.ts
+++ b/packages/themes/whatsapp/src/whatsappTheme.ts
@@ -47,14 +47,8 @@ export const whatsappTheme = defineTheme({
     },
   },
 
-  // Radius: WDS scale (0/4/8/12/28/9999) matches XDS defaults exactly.
-  //   borderRadiusNone=0 → --radius-none=0
-  //   borderRadiusHalf=4 → --radius-inner=4
-  //   borderRadiusSingle=8 → --radius-element=8 (inputs, cards)
-  //   borderRadiusSinglePlus=12 → --radius-container=12
-  //   borderRadiusTriplePlus=28 → --radius-page=28
-  //   borderRadiusCircle=9999 → --radius-full=9999 (buttons)
-  // No radius override needed — multiplier=1 (default) is correct.
+  // Radius: WhatsApp uses generously rounded surfaces — doubled radius scale.
+  radius: {base: 4, multiplier: 2},
 
   // Motion: WhatsApp feels snappy but not jarring.
   // Slightly faster than XDS default, with ease-out for natural deceleration.
@@ -297,17 +291,17 @@ export const whatsappTheme = defineTheme({
       //   - Size-specific padding: sm=16px, md=24px, lg=28px
       // =======================================================================
       base: {
-        borderRadius: '9999px',
-        fontWeight: '500',
-        paddingInline: '24px',
+        borderRadius: '9999px !important',
+        fontWeight: '500 !important',
+        paddingInline: '24px !important',
         transition:
-          'background-image 150ms cubic-bezier(0.175, 0.885, 0.32, 1.275), transform 150ms cubic-bezier(0.175, 0.885, 0.32, 1.275)',
+          'background-image 150ms cubic-bezier(0.175, 0.885, 0.32, 1.275), transform 150ms cubic-bezier(0.175, 0.885, 0.32, 1.275) !important',
       },
       'size:sm': {
-        paddingInline: '16px',
+        paddingInline: '16px !important',
       },
       'size:lg': {
-        paddingInline: '28px',
+        paddingInline: '28px !important',
       },
 
       // =======================================================================
@@ -315,8 +309,8 @@ export const whatsappTheme = defineTheme({
       //   bg: accent, text: on-accent, scale hover/press
       // =======================================================================
       'variant:primary': {
-        ':hover': {transform: 'scale(1.04)'},
-        ':active': {transform: 'scale(0.97)'},
+        ':hover': {transform: 'scale(1.04) !important'},
+        ':active': {transform: 'scale(0.97) !important'},
       },
 
       // =======================================================================
@@ -325,8 +319,8 @@ export const whatsappTheme = defineTheme({
       //   text: accent-emphasized (green700/green100)
       // =======================================================================
       'variant:secondary': {
-        backgroundColor: 'light-dark(#D9FDD3, #103529)',
-        color: 'light-dark(#15603E, #D9FDD3)',
+        backgroundColor: 'light-dark(#D9FDD3, #103529) !important',
+        color: 'light-dark(#15603E, #D9FDD3) !important',
       },
 
       // =======================================================================
@@ -334,7 +328,7 @@ export const whatsappTheme = defineTheme({
       //   bg: transparent, text: content-action-emphasized (green600/green450)
       // =======================================================================
       'variant:ghost': {
-        color: 'light-dark(#1B8755, #21C063)',
+        color: 'light-dark(#1B8755, #21C063) !important',
       },
 
       // =======================================================================
@@ -342,8 +336,8 @@ export const whatsappTheme = defineTheme({
       //   bg: secondary-negative (red400/red300), text: on-accent, scale hover/press
       // =======================================================================
       'variant:destructive': {
-        ':hover': {transform: 'scale(1.04)'},
-        ':active': {transform: 'scale(0.97)'},
+        ':hover': {transform: 'scale(1.04) !important'},
+        ':active': {transform: 'scale(0.97) !important'},
       },
 
       // =======================================================================
@@ -352,11 +346,11 @@ export const whatsappTheme = defineTheme({
       //   text: content-action-emphasized (green600/green450)
       // =======================================================================
       'variant:outline': {
-        backgroundColor: 'transparent',
-        borderWidth: '1px',
-        borderStyle: 'solid',
-        borderColor: 'light-dark(rgba(0, 0, 0, 0.2), rgba(255, 255, 255, 0.1))',
-        color: 'light-dark(#1B8755, #21C063)',
+        backgroundColor: 'transparent !important',
+        borderWidth: '1px !important',
+        borderStyle: 'solid !important',
+        borderColor: 'light-dark(rgba(0, 0, 0, 0.2), rgba(255, 255, 255, 0.1)) !important',
+        color: 'light-dark(#1B8755, #21C063) !important',
       },
 
       // =======================================================================
@@ -365,8 +359,8 @@ export const whatsappTheme = defineTheme({
       //   text: secondary-negative-emphasized (red500/red200)
       // =======================================================================
       'variant:tonal-destructive': {
-        backgroundColor: 'light-dark(#FDE8EB, #321622)',
-        color: 'light-dark(#B80531, #FA99A4)',
+        backgroundColor: 'light-dark(#FDE8EB, #321622) !important',
+        color: 'light-dark(#B80531, #FA99A4) !important',
       },
 
       // =======================================================================
@@ -375,11 +369,11 @@ export const whatsappTheme = defineTheme({
       //   text: secondary-negative-emphasized (red500/red200)
       // =======================================================================
       'variant:outline-destructive': {
-        backgroundColor: 'transparent',
-        borderWidth: '1px',
-        borderStyle: 'solid',
-        borderColor: 'light-dark(rgba(0, 0, 0, 0.2), rgba(255, 255, 255, 0.1))',
-        color: 'light-dark(#B80531, #FA99A4)',
+        backgroundColor: 'transparent !important',
+        borderWidth: '1px !important',
+        borderStyle: 'solid !important',
+        borderColor: 'light-dark(rgba(0, 0, 0, 0.2), rgba(255, 255, 255, 0.1)) !important',
+        color: 'light-dark(#B80531, #FA99A4) !important',
       },
 
       // =======================================================================
@@ -387,8 +381,8 @@ export const whatsappTheme = defineTheme({
       //   bg: transparent, text: secondary-negative-emphasized (red500/red200)
       // =======================================================================
       'variant:ghost-destructive': {
-        backgroundColor: 'transparent',
-        color: 'light-dark(#B80531, #FA99A4)',
+        backgroundColor: 'transparent !important',
+        color: 'light-dark(#B80531, #FA99A4) !important',
       },
     },
 
@@ -397,7 +391,7 @@ export const whatsappTheme = defineTheme({
     // =========================================================================
     badge: {
       base: {
-        fontWeight: '500',
+        fontWeight: '500 !important',
       },
     },
 
@@ -407,7 +401,7 @@ export const whatsappTheme = defineTheme({
     card: {
       base: {
         borderColor:
-          'light-dark(rgba(0, 0, 0, 0.06), rgba(255, 255, 255, 0.06))',
+          'light-dark(rgba(0, 0, 0, 0.06), rgba(255, 255, 255, 0.06)) !important',
       },
     },
 
@@ -417,7 +411,7 @@ export const whatsappTheme = defineTheme({
     divider: {
       base: {
         borderTopColor:
-          'light-dark(rgba(0, 0, 0, 0.1), rgba(255, 255, 255, 0.1))',
+          'light-dark(rgba(0, 0, 0, 0.1), rgba(255, 255, 255, 0.1)) !important',
       },
     },
 
@@ -437,11 +431,11 @@ export const whatsappTheme = defineTheme({
     // =========================================================================
     'text-input': {
       base: {
-        borderColor: 'light-dark(#959393, #757778)',
-        paddingInline: '12px',
-        caretColor: 'light-dark(#1DAA61, #21C063)',
+        borderColor: 'light-dark(#959393, #757778) !important',
+        paddingInline: '12px !important',
+        caretColor: 'light-dark(#1DAA61, #21C063) !important',
         ':focus-within': {
-          outlineColor: 'light-dark(#1DAA61, #21C063)',
+          outlineColor: 'light-dark(#1DAA61, #21C063) !important',
         },
       },
     },


### PR DESCRIPTION
## Summary

- **Fix theme override specificity**: StyleX's `:not(#\#)` specificity hack causes theme component overrides in `@layer xds-theme` to silently fail. Added `!important` to all visual CSS properties in both Meta (68+ properties across 20 components) and WhatsApp (32+ properties across 5 components) theme overrides.
- **Fix missing WhatsApp theme CSS**: Added `import '@xds/theme-whatsapp/theme.css'` to `layout.tsx` — the WhatsApp theme was imported in `providers.tsx` but its CSS file was never loaded, so switching to it had no visual effect.
- **Restore WhatsApp radius multiplier**: Re-added `radius: {base: 4, multiplier: 2}` which was incorrectly removed in #921, giving WhatsApp its signature rounded surfaces.
- **Meta input status colors**: Success and warning text inputs now use neutral gray (`#686A6E`) borders instead of green/yellow, matching CDS design. Error inputs keep their red border. Icon colors are restored to their original green/yellow via scoped `--color-success`/`--color-warning` on `.xds-icon`.
- **Meta outline icons**: Switched all Meta theme icons from solid to outline style.

## Test plan

- [ ] Switch to WhatsApp theme on `/pages/example-cards/` — buttons should be pill-shaped, cards/inputs should have doubled radius
- [ ] Switch to Meta theme — badges should show pastel backgrounds with dark text
- [ ] Meta theme text inputs: success state shows gray border + green icon, error state shows red border + red icon
- [ ] Meta theme buttons: pill-shaped, custom variants (primary-muted, outline variants) render correctly
- [ ] Both themes: all component overrides (slider, banner, dialog, popover, tabs, etc.) apply visually


Made with [Cursor](https://cursor.com)