### PR TITLE
polish(detail-page): align template with contributing guidelines and add interactivity

### DIFF
--- a/packages/cli/templates/detail-page/page.tsx
+++ b/packages/cli/templates/detail-page/page.tsx
@@ -3,7 +3,14 @@
 import {useState} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {XDSAppShell} from '@xds/core/AppShell';
-import {XDSSideNav, XDSSideNavItem, XDSSideNavSection} from '@xds/core/SideNav';
+import {XDSNavIcon} from '@xds/core/NavIcon';
+import {
+  XDSSideNav,
+  XDSSideNavCollapseButton,
+  XDSSideNavHeading,
+  XDSSideNavItem,
+  XDSSideNavSection,
+} from '@xds/core/SideNav';
 import {
   XDSLayout,
   XDSLayoutHeader,
@@ -18,7 +25,7 @@ import {XDSText, XDSHeading} from '@xds/core/Text';
 import {XDSBadge} from '@xds/core/Badge';
 import {XDSAvatar} from '@xds/core/Avatar';
 import {XDSButton} from '@xds/core/Button';
-import {XDSNavIcon} from '@xds/core/NavIcon';
+
 import {XDSTabList, XDSTab} from '@xds/core/TabList';
 import {XDSDivider} from '@xds/core/Divider';
 import {XDSLink} from '@xds/core/Link';
@@ -183,14 +190,9 @@ const EditIcon = (props: React.SVGProps<SVGSVGElement>) => (
   </svg>
 );
 const ShopIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth={1.5}
-    {...props}>
-    <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
-    <polyline points="9 22 9 12 15 12 15 22" />
+  <svg viewBox="0 0 24 24" fill="currentColor" {...props}>
+    <path d="M11.47 3.841a.75.75 0 0 1 1.06 0l8.69 8.69a.75.75 0 1 0 1.06-1.061l-8.689-8.69a2.25 2.25 0 0 0-3.182 0l-8.69 8.69a.75.75 0 1 0 1.061 1.06l8.69-8.689Z" />
+    <path d="m12 5.432 8.159 8.159c.03.03.06.058.091.086v6.198c0 1.035-.84 1.875-1.875 1.875H15a.75.75 0 0 1-.75-.75v-4.5a.75.75 0 0 0-.75-.75h-3a.75.75 0 0 0-.75.75V21a.75.75 0 0 1-.75.75H5.625a1.875 1.875 0 0 1-1.875-1.875v-6.198a2.29 2.29 0 0 0 .091-.086L12 5.432Z" />
   </svg>
 );
 const ArrowLeftIcon = (props: React.SVGProps<SVGSVGElement>) => (
@@ -353,10 +355,15 @@ function ShopSideNav() {
     <XDSSideNav
       collapsible
       header={
-        <XDSHStack gap={2} vAlign="center" style={{padding: '8px 12px'}}>
-          <XDSNavIcon icon={<XDSIcon icon={ShopIcon} size="sm" />} />
-          <XDSHeading level={4}>Kiln & Table</XDSHeading>
-        </XDSHStack>
+        <XDSSideNavHeading
+          icon={
+            <XDSNavIcon
+              icon={<XDSIcon icon={ShopIcon} size="sm" color="inherit" />}
+            />
+          }
+          heading="Kiln & Table"
+          headingHref="/"
+        />
       }
       footer={
         <XDSVStack gap={0} style={{padding: '8px 0'}}>
@@ -373,7 +380,8 @@ function ShopSideNav() {
             onClick={() => setActive('help')}
           />
         </XDSVStack>
-      }>
+      }
+      footerIcons={<XDSSideNavCollapseButton />}>
       <XDSSideNavSection title="Main" isHeaderHidden>
         <XDSSideNavItem
           label="Home"
@@ -438,92 +446,84 @@ function PageHeader({
   return (
     <XDSLayoutHeader hasDivider padding={4}>
       <XDSCenter axis="horizontal">
-        <XDSHStack
-          gap={4}
-          style={{
-            width: '100%',
-            justifyContent: 'space-between',
-            alignItems: 'stretch',
-          }}>
-          <XDSVStack gap={0} style={{flex: 1, minWidth: 0}}>
-            {/* Back link */}
-            <XDSLink href="#" label="All orders" color="secondary">
-              <XDSHStack gap={1} vAlign="center">
-                <XDSIcon icon={ArrowLeftIcon} size="sm" color="inherit" />
-                All orders
-              </XDSHStack>
-            </XDSLink>
-            {/* Title + metadata */}
-            <XDSVStack gap={0}>
-              <XDSHeading level={1}>#1001</XDSHeading>
-              {/* Metadata row */}
-              <XDSHStack
-                gap={1}
-                vAlign="center"
-                style={{overflow: 'hidden', whiteSpace: 'nowrap'}}>
-                <XDSText type="body" style={{flexShrink: 0}}>
-                  {PRODUCTS.length} ordered items
-                </XDSText>
-                <Bullet />
-                <XDSHStack gap={1} vAlign="center" style={{flexShrink: 0}}>
-                  <XDSAvatar name="Jane Doe" size="xsmall" />
-                  <XDSText type="body">Jane Doe</XDSText>
+        <XDSVStack gap={0} style={{width: '100%'}}>
+          <XDSHStack
+            gap={4}
+            vAlign="start"
+            style={{justifyContent: 'space-between'}}>
+            <XDSVStack gap={0} style={{flex: 1, minWidth: 0}}>
+              {/* Back link */}
+              <XDSLink href="#" label="All orders" color="secondary">
+                <XDSHStack gap={1} vAlign="center">
+                  <XDSIcon icon={ArrowLeftIcon} size="sm" color="inherit" />
+                  All orders
                 </XDSHStack>
-                <Bullet />
-                <span style={{flexShrink: 0}}>
-                  <XDSBadge variant="warning" label="Unfulfilled" />
-                </span>
-                <Bullet />
-                <XDSHStack gap={1} vAlign="center" style={{flexShrink: 0}}>
-                  <XDSIcon icon={CalendarIcon} size="sm" color="secondary" />
-                  <XDSText type="body">02/23/2026</XDSText>
+              </XDSLink>
+              {/* Title + metadata */}
+              <XDSVStack gap={0}>
+                <XDSHeading level={1}>#1001</XDSHeading>
+                {/* Metadata row */}
+                <XDSHStack
+                  gap={1}
+                  vAlign="center"
+                  style={{overflow: 'hidden', whiteSpace: 'nowrap'}}>
+                  <XDSText type="body" style={{flexShrink: 0}}>
+                    {PRODUCTS.length} ordered items
+                  </XDSText>
+                  <Bullet />
+                  <XDSHStack gap={1} vAlign="center" style={{flexShrink: 0}}>
+                    <XDSAvatar name="Jane Doe" size="xsmall" />
+                    <XDSText type="body">Jane Doe</XDSText>
+                  </XDSHStack>
+                  <Bullet />
+                  <span style={{flexShrink: 0}}>
+                    <XDSBadge variant="warning" label="Unfulfilled" />
+                  </span>
+                  <Bullet />
+                  <XDSHStack gap={1} vAlign="center" style={{flexShrink: 0}}>
+                    <XDSIcon icon={CalendarIcon} size="sm" color="secondary" />
+                    <XDSText type="body">02/23/2026</XDSText>
+                  </XDSHStack>
+                  <Bullet />
+                  <XDSHStack gap={1} vAlign="center" style={{flexShrink: 0}}>
+                    <XDSIcon icon={FlagIcon} size="sm" color="secondary" />
+                    <XDSText type="body">Needs attention</XDSText>
+                  </XDSHStack>
+                  <Bullet />
+                  <XDSLink
+                    href="#"
+                    label="See all"
+                    color="secondary"
+                    style={{flexShrink: 0}}>
+                    See all
+                  </XDSLink>
                 </XDSHStack>
-                <Bullet />
-                <XDSHStack gap={1} vAlign="center" style={{flexShrink: 0}}>
-                  <XDSIcon icon={FlagIcon} size="sm" color="secondary" />
-                  <XDSText type="body">Needs attention</XDSText>
-                </XDSHStack>
-                <Bullet />
-                <XDSLink
-                  href="#"
-                  label="See all"
-                  color="secondary"
-                  style={{flexShrink: 0}}>
-                  See all
-                </XDSLink>
-              </XDSHStack>
+              </XDSVStack>
             </XDSVStack>
 
-            {/* Tabs */}
-            <XDSHStack
-              vAlign="center"
-              style={{
-                justifyContent: 'space-between',
-                marginInline: -12,
-                marginBottom: -16,
-                marginTop: 12,
-              }}>
-              <XDSTabList value={activeTab} onChange={onTabChange} size="lg">
-                <XDSTab value="details" label="Details" />
-                <XDSTab value="invoices" label="Invoices" />
-                <XDSTab value="timeline" label="Timeline" />
-                <XDSTab value="customer" label="Customer" />
-                <XDSTab value="analysis" label="Analysis" />
-              </XDSTabList>
-            </XDSHStack>
-          </XDSVStack>
-
-          {/* Actions — top-aligned */}
-          <XDSVStack
-            style={{
-              flexShrink: 0,
-              justifyContent: 'space-between',
-              alignItems: 'flex-end',
-            }}>
-            <XDSHStack gap={2}>
+            {/* Actions — top-aligned */}
+            <XDSHStack gap={2} style={{flexShrink: 0}}>
               <XDSButton label="Restock" variant="secondary" />
               <XDSButton label="Edit" variant="secondary" />
             </XDSHStack>
+          </XDSHStack>
+
+          {/* Tabs — full width */}
+          <XDSHStack
+            vAlign="center"
+            style={{
+              justifyContent: 'space-between',
+              marginInline: -12,
+              marginBottom: -16,
+              marginTop: 12,
+            }}>
+            <XDSTabList value={activeTab} onChange={onTabChange} size="lg">
+              <XDSTab value="details" label="Details" />
+              <XDSTab value="invoices" label="Invoices" />
+              <XDSTab value="timeline" label="Timeline" />
+              <XDSTab value="customer" label="Customer" />
+              <XDSTab value="analysis" label="Analysis" />
+            </XDSTabList>
             <XDSButton
               label={isPanelOpen ? 'Hide panel' : 'Show panel'}
               variant="ghost"
@@ -534,8 +534,8 @@ function PageHeader({
               isIconOnly
               onClick={onTogglePanel}
             />
-          </XDSVStack>
-        </XDSHStack>
+          </XDSHStack>
+        </XDSVStack>
       </XDSCenter>
     </XDSLayoutHeader>
   );
@@ -738,70 +738,91 @@ function TimelineSection() {
 }
 
 // ─── Right Panel ────────────────────────────────────────────────────────────
-function RightPanel() {
+function RightPanel({isOpen}: {isOpen: boolean}) {
   return (
-    <XDSLayoutPanel hasDivider width={320} padding={0} role="complementary">
-      <XDSVStack gap={4}>
-        {/* Notes */}
-        <div
-          {...stylex.props(pageStyles.panelSection)}
-          style={{padding: '8px 16px'}}>
-          <XDSCollapsible trigger={<XDSHeading level={4}>Notes</XDSHeading>}>
-            <XDSText type="body">
-              Customer is a repeat buyer — 3rd order this quarter. Prefers snow
-              and oat glazes. Requested gift wrapping for the mug set. Ships to
-              a residential address in CA.{' '}
-              <XDSLink href="#" label="Show more" color="secondary">
-                Show more
-              </XDSLink>
-            </XDSText>
-          </XDSCollapsible>
-        </div>
-
-        {/* Customer */}
-        <div
-          {...stylex.props(pageStyles.panelSection)}
-          style={{padding: '8px 16px'}}>
-          <XDSCollapsible trigger={<XDSHeading level={4}>Customer</XDSHeading>}>
-            <XDSMetadataList>
-              <XDSMetadataListItem label="Name">Jane Doe</XDSMetadataListItem>
-              <XDSMetadataListItem label="Address">
-                321 Smith Road, CA 38238
-              </XDSMetadataListItem>
-              <XDSMetadataListItem label="Phone">234-</XDSMetadataListItem>
-              <XDSMetadataListItem label="Email">
-                janedoe@email.com
-              </XDSMetadataListItem>
-              <XDSMetadataListItem label="Billing Address">
-                Same as shipping address
-              </XDSMetadataListItem>
-            </XDSMetadataList>
-          </XDSCollapsible>
-        </div>
-
-        {/* Fraud Analysis */}
-        <div
-          {...stylex.props(pageStyles.panelSection)}
-          style={{padding: '8px 16px'}}>
-          <XDSCollapsible
-            trigger={<XDSHeading level={4}>Fraud Analysis</XDSHeading>}>
-            <XDSVStack gap={1}>
-              <XDSProgressBar
-                label="Risk level"
-                value={15}
-                variant="positive"
-                isLabelHidden
-              />
-              <XDSText type="body">Recommendation: Fulfill order</XDSText>
+    <div
+      style={{
+        width: isOpen ? 320 : 0,
+        minWidth: isOpen ? 320 : 0,
+        overflow: 'hidden',
+        transition:
+          'width var(--duration-medium, 410ms) var(--ease-standard, cubic-bezier(0.24, 1, 0.4, 1)), min-width var(--duration-medium, 410ms) var(--ease-standard, cubic-bezier(0.24, 1, 0.4, 1))',
+        flexShrink: 0,
+      }}>
+      <XDSLayoutPanel
+        hasDivider
+        width={320}
+        padding={0}
+        role="complementary"
+        style={{
+          opacity: isOpen ? 1 : 0,
+          transition:
+            'opacity var(--duration-fast, 175ms) var(--ease-standard, cubic-bezier(0.24, 1, 0.4, 1))',
+          transitionDelay: isOpen ? 'var(--duration-fast, 175ms)' : '0ms',
+        }}>
+        <XDSVStack gap={4}>
+          {/* Notes */}
+          <div
+            {...stylex.props(pageStyles.panelSection)}
+            style={{padding: '8px 16px'}}>
+            <XDSCollapsible trigger={<XDSHeading level={4}>Notes</XDSHeading>}>
               <XDSText type="body">
-                There is a low chance that you will receive a chargeback on this
-                order.
+                Customer is a repeat buyer — 3rd order this quarter. Prefers
+                snow and oat glazes. Requested gift wrapping for the mug set.
+                Ships to a residential address in CA.{' '}
+                <XDSLink href="#" label="Show more" color="secondary">
+                  Show more
+                </XDSLink>
               </XDSText>
-            </XDSVStack>
-          </XDSCollapsible>
-        </div>
-      </XDSVStack>
-    </XDSLayoutPanel>
+            </XDSCollapsible>
+          </div>
+
+          {/* Customer */}
+          <div
+            {...stylex.props(pageStyles.panelSection)}
+            style={{padding: '8px 16px'}}>
+            <XDSCollapsible
+              trigger={<XDSHeading level={4}>Customer</XDSHeading>}>
+              <XDSMetadataList>
+                <XDSMetadataListItem label="Name">Jane Doe</XDSMetadataListItem>
+                <XDSMetadataListItem label="Address">
+                  321 Smith Road, CA 38238
+                </XDSMetadataListItem>
+                <XDSMetadataListItem label="Phone">234-</XDSMetadataListItem>
+                <XDSMetadataListItem label="Email">
+                  janedoe@email.com
+                </XDSMetadataListItem>
+                <XDSMetadataListItem label="Billing Address">
+                  Same as shipping address
+                </XDSMetadataListItem>
+              </XDSMetadataList>
+            </XDSCollapsible>
+          </div>
+
+          {/* Fraud Analysis */}
+          <div
+            {...stylex.props(pageStyles.panelSection)}
+            style={{padding: '8px 16px'}}>
+            <XDSCollapsible
+              trigger={<XDSHeading level={4}>Fraud Analysis</XDSHeading>}>
+              <XDSVStack gap={1}>
+                <XDSProgressBar
+                  label="Risk level"
+                  value={15}
+                  variant="positive"
+                  isLabelHidden
+                />
+                <XDSText type="body">Recommendation: Fulfill order</XDSText>
+                <XDSText type="body">
+                  There is a low chance that you will receive a chargeback on
+                  this order.
+                </XDSText>
+              </XDSVStack>
+            </XDSCollapsible>
+          </div>
+        </XDSVStack>
+      </XDSLayoutPanel>
+    </div>
   );
 }
 
@@ -836,7 +857,7 @@ export default function DetailPage2Template() {
             </XDSVStack>
           </XDSLayoutContent>
         }
-        end={isPanelOpen ? <RightPanel /> : undefined}
+        end={<RightPanel isOpen={isPanelOpen} />}
       />
     </XDSAppShell>
   );

--- a/packages/cli/templates/detail-page/page.tsx
+++ b/packages/cli/templates/detail-page/page.tsx
@@ -27,6 +27,7 @@ import {XDSMetadataList, XDSMetadataListItem} from '@xds/core/MetadataList';
 import {XDSProgressBar} from '@xds/core/ProgressBar';
 import {XDSCollapsible} from '@xds/core/Collapsible';
 import {XDSCenter} from '@xds/core/Center';
+import {XDSIcon} from '@xds/core/Icon';
 
 // ─── Icons ──────────────────────────────────────────────────────────────────
 const HomeIcon = (props: React.SVGProps<SVGSVGElement>) => (
@@ -206,6 +207,17 @@ const ArrowLeftIcon = (props: React.SVGProps<SVGSVGElement>) => (
     />
   </svg>
 );
+const PanelRightIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    {...props}>
+    <rect x="3" y="3" width="18" height="18" rx="2" />
+    <line x1="15" y1="3" x2="15" y2="21" />
+  </svg>
+);
 
 // ─── Styles ─────────────────────────────────────────────────────────────────
 const pageStyles = stylex.create({
@@ -214,11 +226,6 @@ const pageStyles = stylex.create({
     lineHeight: '16px',
     color: 'var(--color-text-secondary, #666)',
     userSelect: 'none',
-  },
-  metaIcon: {
-    width: 14,
-    height: 14,
-    color: 'var(--color-text-secondary, #666)',
     flexShrink: 0,
   },
   productImage: {
@@ -226,22 +233,6 @@ const pageStyles = stylex.create({
     height: '100%',
     objectFit: 'cover',
     borderRadius: 'var(--radius-content, 4px)',
-  },
-  productPlaceholder: {
-    position: 'absolute',
-    inset: 0,
-    backgroundColor: 'var(--color-background-deemphasized, #e5e5e5)',
-    borderRadius: 'var(--radius-content, 4px)',
-  },
-  productImageWrap: {
-    width: 80,
-    height: 80,
-    flexShrink: 0,
-  },
-  activityDot: {
-    width: 32,
-    height: 32,
-    flexShrink: 0,
   },
   reactionBar: {
     display: 'flex',
@@ -258,70 +249,57 @@ const pageStyles = stylex.create({
   panelSection: {
     paddingBlock: 4,
   },
-  calloutCard: {
-    backgroundColor: 'var(--color-bg-wash, rgba(5,54,89,0.06))',
-    borderRadius: 'var(--radius-container, 12px)',
-    padding: 16,
-  },
-  meterBar: {
-    height: 8,
-    flex: 1,
-    backgroundColor: 'var(--color-bg-deemphasized, #e5e5e5)',
-    borderRadius: 4,
-    overflow: 'hidden',
-  },
-  meterFill: {
-    height: '100%',
-    width: '35%',
-    backgroundColor: 'var(--color-accent, #0866ff)',
-    borderRadius: 4,
-  },
-  learnMoreBtn: {
-    backgroundColor: 'rgba(255,255,255,0.5)',
-    borderRadius: 'var(--radius-element, 8px)',
-    padding: '8px 12px',
-    border: 'none',
-    cursor: 'pointer',
-    fontSize: 14,
-    textAlign: 'center',
-    width: '100%',
-  },
-  selectorLabel: {
-    padding: '4px 0',
+  contentFlushEnd: {
+    paddingInlineEnd: 0,
   },
 });
 
 // ─── Product data ───────────────────────────────────────────────────────────
+// Light product photography from the xds_oss asset set (ceramics collection)
+// Source: meta assets.file list -s xds_oss -g light-product-{1..5}
+const PRODUCT_IMAGES = [
+  'https://scontent.xx.fbcdn.net/v/t39.6806-6/671222955_2145727732941085_520241325832272863_n.png?_nc_cat=102&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=nPid9vxWiAAQ7kNvwEn9zAk&_nc_oc=Adpvs8c0_OPaD3OBM2-RuvQhsq_ZIQCuI4MIYJDHog2g0wbDnnKsQY18ujPRPRsUsCQaE3gnHXhybHYdgHyTPGcy&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=ydKBqwA5klQRsF7pHyaL9Q&_nc_ss=7a30f&oh=00_Af1MWCNR4BSpKvDiJrg4I7hrhPhvwUkpwRMPpGkexhKxpg&oe=69E5F2F2',
+  'https://scontent.xx.fbcdn.net/v/t39.6806-6/673826432_1199625442080268_2235614826141527510_n.png?_nc_cat=101&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=7sfupHwtMWoQ7kNvwHq-oll&_nc_oc=AdorjEzWeonV_cTC82CQcP_97bhPEFri4gRyJuRCTm5tm4RrSHqZHinwq3cpLIVwwDqJGdLCeaezQOL1pCTdEurA&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=dhQMbNPZ6a4O8tvuG-zaQQ&_nc_ss=7a30f&oh=00_Af0jFaeYAmFWPUXPDLAx1wHlwVkoTPaVfUQircvONREAew&oe=69E5DFF1',
+  'https://scontent.xx.fbcdn.net/v/t39.6806-6/672681263_1894137684571541_8624778644609428792_n.png?_nc_cat=109&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=O9FpOzmcuhIQ7kNvwHJc_5e&_nc_oc=AdohCQROsW1HA9oyV_P08xW-PZ7aRBaxKQDouJQeLqWBRg4s_diiKocTCXKFW6MrH29i-qmdKX4F1XacD-ZBr1aI&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=4Ho2VwbJyUMPRPg1_pYYXQ&_nc_ss=7a30f&oh=00_Af3rTWfTt78ZVlhHCjbjcvEMAmyt_Y5UApS2ezLwTSVDdw&oe=69E5F643',
+  'https://scontent.xx.fbcdn.net/v/t39.6806-6/670399674_3883527348446559_364118105607949641_n.png?_nc_cat=103&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=qjhrCslvBhEQ7kNvwGIRrYU&_nc_oc=AdqjfEPZizLmq2xSVhncfdeilisr9iS4xyW6xvESla6s72ctRLyjAdz_aUhs0_7GlT2wLRjFqotzo6mCRpj_zoev&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=p5rjWn-ZxsbEF4l-xiDkoA&_nc_ss=7a30f&oh=00_Af0dfW78AWBoDni-ydDYmjYYnu6TcBty9hI97oewb6OFfw&oe=69E5EB2D',
+  'https://scontent.xx.fbcdn.net/v/t39.6806-6/671457944_4516505268571219_6833232903201599778_n.png?_nc_cat=101&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=2LiO931mC78Q7kNvwEClCGO&_nc_oc=AdoxCLopOX1C45nJksLqWaffKTeqizJ7joW-P2gbmknrVE5KqvaVXRzof8YTOZNW0OMuPUSnUEX0aQ32RhRv6xeF&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=AXiNN0rtQ-RZnfzDQS5AjA&_nc_ss=7a30f&oh=00_Af3DYuG7fKdv_a6uNNcfTO5iIV16d_65o0-9FZnZp4jQfg&oe=69E5E555',
+];
+
 const PRODUCTS = [
   {
-    name: 'Custom Notebook',
-    details: 'Color: Brown\nSize: B5',
-    price: 20.0,
+    name: 'Solstice Mug & Plate Set',
+    details: 'Glaze: Snow\nFinish: Matte',
+    price: 89.0,
     qty: 1,
+    image: PRODUCT_IMAGES[0],
   },
   {
-    name: 'Custom Notebook',
-    details: 'Color: Brown\nSize: B5',
-    price: 20.0,
-    qty: 1,
-  },
-  {
-    name: 'Leather Pen Case',
-    details: 'Color: Black\nMaterial: Full-grain leather',
-    price: 35.0,
+    name: 'Ember Bowl',
+    details: 'Glaze: Sage\nSize: 6 in',
+    price: 42.0,
     qty: 2,
+    image: PRODUCT_IMAGES[1],
   },
   {
-    name: 'Fountain Pen',
-    details: 'Nib: Fine\nInk: Blue-black',
-    price: 45.0,
+    name: 'Terra Serving Platter',
+    details: 'Glaze: Oat\nSize: 14 in',
+    price: 65.0,
     qty: 1,
+    image: PRODUCT_IMAGES[2],
   },
   {
-    name: 'Washi Tape Set',
-    details: 'Pack: 6 rolls\nPattern: Floral',
-    price: 12.0,
+    name: 'Dawn Espresso Cup',
+    details: 'Glaze: Charcoal\nCapacity: 3 oz',
+    price: 34.0,
     qty: 3,
+    image: PRODUCT_IMAGES[3],
+  },
+  {
+    name: 'Kiln Vase',
+    details: 'Glaze: Snow\nHeight: 8 in',
+    price: 78.0,
+    qty: 1,
+    image: PRODUCT_IMAGES[4],
   },
 ];
 
@@ -345,7 +323,7 @@ const ACTIVITY = [
   {
     type: 'comment' as const,
     user: 'Alex Rivera',
-    text: "Customer requested gift wrapping for the notebooks. I've added a note to the packing slip — warehouse team should see it before fulfillment.",
+    text: "Customer requested gift wrapping for the mug & plate set. I've added a note to the packing slip — warehouse team should wrap in recycled kraft paper.",
     reactions: 3,
     time: 'Feb 23 at 10:45 AM',
   },
@@ -376,8 +354,8 @@ function ShopSideNav() {
       collapsible
       header={
         <XDSHStack gap={2} vAlign="center" style={{padding: '8px 12px'}}>
-          <XDSNavIcon icon={<ShopIcon style={{width: 16, height: 16}} />} />
-          <XDSHeading level={4}>Acme</XDSHeading>
+          <XDSNavIcon icon={<XDSIcon icon={ShopIcon} size="sm" />} />
+          <XDSHeading level={4}>Kiln & Table</XDSHeading>
         </XDSHStack>
       }
       footer={
@@ -449,84 +427,115 @@ function Bullet() {
 function PageHeader({
   activeTab,
   onTabChange,
+  isPanelOpen,
+  onTogglePanel,
 }: {
   activeTab: string;
   onTabChange: (v: string) => void;
+  isPanelOpen: boolean;
+  onTogglePanel: () => void;
 }) {
   return (
     <XDSLayoutHeader hasDivider padding={4}>
       <XDSCenter axis="horizontal">
-        <XDSVStack gap={0}>
-          {/* Back link */}
-          <XDSLink href="#" label="All orders" color="secondary">
-            <XDSHStack gap={1} vAlign="center">
-              <ArrowLeftIcon style={{width: 16, height: 16}} />
-              All orders
-            </XDSHStack>
-          </XDSLink>
-          {/* Title + metadata */}
-          <XDSVStack gap={0}>
-            {/* Title row */}
-            <XDSHStack
-              gap={2}
-              vAlign="center"
-              style={{justifyContent: 'space-between'}}>
-              <XDSHStack gap={2} vAlign="center">
-                <XDSHeading level={1}>#1001</XDSHeading>
+        <XDSHStack
+          gap={4}
+          style={{
+            width: '100%',
+            justifyContent: 'space-between',
+            alignItems: 'stretch',
+          }}>
+          <XDSVStack gap={0} style={{flex: 1, minWidth: 0}}>
+            {/* Back link */}
+            <XDSLink href="#" label="All orders" color="secondary">
+              <XDSHStack gap={1} vAlign="center">
+                <XDSIcon icon={ArrowLeftIcon} size="sm" color="inherit" />
+                All orders
               </XDSHStack>
-              <XDSHStack gap={2} vAlign="start">
-                <XDSButton label="← 2/9 →" variant="ghost" />
-                <XDSButton label="Restock" variant="secondary" />
-                <XDSButton label="Edit" variant="secondary" />
+            </XDSLink>
+            {/* Title + metadata */}
+            <XDSVStack gap={0}>
+              <XDSHeading level={1}>#1001</XDSHeading>
+              {/* Metadata row */}
+              <XDSHStack
+                gap={1}
+                vAlign="center"
+                style={{overflow: 'hidden', whiteSpace: 'nowrap'}}>
+                <XDSText type="body" style={{flexShrink: 0}}>
+                  {PRODUCTS.length} ordered items
+                </XDSText>
+                <Bullet />
+                <XDSHStack gap={1} vAlign="center" style={{flexShrink: 0}}>
+                  <XDSAvatar name="Jane Doe" size="xsmall" />
+                  <XDSText type="body">Jane Doe</XDSText>
+                </XDSHStack>
+                <Bullet />
+                <span style={{flexShrink: 0}}>
+                  <XDSBadge variant="warning" label="Unfulfilled" />
+                </span>
+                <Bullet />
+                <XDSHStack gap={1} vAlign="center" style={{flexShrink: 0}}>
+                  <XDSIcon icon={CalendarIcon} size="sm" color="secondary" />
+                  <XDSText type="body">02/23/2026</XDSText>
+                </XDSHStack>
+                <Bullet />
+                <XDSHStack gap={1} vAlign="center" style={{flexShrink: 0}}>
+                  <XDSIcon icon={FlagIcon} size="sm" color="secondary" />
+                  <XDSText type="body">Needs attention</XDSText>
+                </XDSHStack>
+                <Bullet />
+                <XDSLink
+                  href="#"
+                  label="See all"
+                  color="secondary"
+                  style={{flexShrink: 0}}>
+                  See all
+                </XDSLink>
               </XDSHStack>
-            </XDSHStack>
+            </XDSVStack>
 
-            {/* Metadata row */}
-            <XDSHStack gap={1} vAlign="center" style={{flexWrap: 'wrap'}}>
-              <XDSText type="body">{PRODUCTS.length} ordered items</XDSText>
-              <Bullet />
-              <XDSHStack gap={1} vAlign="center">
-                <XDSAvatar name="Jane Doe" size="xsmall" />
-                <XDSText type="body">Jane Doe</XDSText>
-              </XDSHStack>
-              <Bullet />
-              <XDSBadge variant="warning" label="Unfulfilled" />
-              <Bullet />
-              <XDSHStack gap={1} vAlign="center">
-                <CalendarIcon {...stylex.props(pageStyles.metaIcon)} />
-                <XDSText type="body">02/23/2026</XDSText>
-              </XDSHStack>
-              <Bullet />
-              <XDSHStack gap={1} vAlign="center">
-                <FlagIcon {...stylex.props(pageStyles.metaIcon)} />
-                <XDSText type="body">Needs attention</XDSText>
-              </XDSHStack>
-              <Bullet />
-              <XDSLink href="#" label="See all" color="secondary">
-                See all
-              </XDSLink>
+            {/* Tabs */}
+            <XDSHStack
+              vAlign="center"
+              style={{
+                justifyContent: 'space-between',
+                marginInline: -12,
+                marginBottom: -16,
+                marginTop: 12,
+              }}>
+              <XDSTabList value={activeTab} onChange={onTabChange} size="lg">
+                <XDSTab value="details" label="Details" />
+                <XDSTab value="invoices" label="Invoices" />
+                <XDSTab value="timeline" label="Timeline" />
+                <XDSTab value="customer" label="Customer" />
+                <XDSTab value="analysis" label="Analysis" />
+              </XDSTabList>
             </XDSHStack>
           </XDSVStack>
 
-          {/* Tabs */}
-          <XDSHStack
-            vAlign="center"
+          {/* Actions — top-aligned */}
+          <XDSVStack
             style={{
+              flexShrink: 0,
               justifyContent: 'space-between',
-              marginInline: -12,
-              marginBottom: -16,
-              marginTop: 12,
+              alignItems: 'flex-end',
             }}>
-            <XDSTabList value={activeTab} onChange={onTabChange} size="lg">
-              <XDSTab value="details" label="Details" />
-              <XDSTab value="invoices" label="Invoices" />
-              <XDSTab value="timeline" label="Timeline" />
-              <XDSTab value="customer" label="Customer" />
-              <XDSTab value="analysis" label="Analysis" />
-            </XDSTabList>
-            <XDSButton label="View options" variant="ghost" size="md" />
-          </XDSHStack>
-        </XDSVStack>
+            <XDSHStack gap={2}>
+              <XDSButton label="Restock" variant="secondary" />
+              <XDSButton label="Edit" variant="secondary" />
+            </XDSHStack>
+            <XDSButton
+              label={isPanelOpen ? 'Hide panel' : 'Show panel'}
+              variant="ghost"
+              size="md"
+              icon={
+                <XDSIcon icon={PanelRightIcon} size="sm" color="secondary" />
+              }
+              isIconOnly
+              onClick={onTogglePanel}
+            />
+          </XDSVStack>
+        </XDSHStack>
       </XDSCenter>
     </XDSLayoutHeader>
   );
@@ -565,14 +574,10 @@ function ItemsCard() {
               onClick={() => {}}
               startContent={
                 <div style={{width: 100, height: 66, flexShrink: 0}}>
-                  <div
-                    style={{
-                      width: '100%',
-                      height: '100%',
-                      backgroundColor:
-                        'var(--color-background-deemphasized, #e5e5e5)',
-                      borderRadius: 'var(--radius-element, 8px)',
-                    }}
+                  <img
+                    src={product.image}
+                    alt={product.name}
+                    {...stylex.props(pageStyles.productImage)}
                   />
                 </div>
               }
@@ -666,7 +671,7 @@ function TimelineSection() {
           <XDSButton
             label="Filters"
             variant="ghost"
-            icon={<FilterIcon style={{width: 14, height: 14}} />}
+            icon={<XDSIcon icon={FilterIcon} />}
             isIconOnly
           />
         </XDSHStack>
@@ -688,12 +693,10 @@ function TimelineSection() {
                           <XDSVStack gap={1} style={{marginTop: 4}}>
                             {item.changes.map((change, j) => (
                               <XDSHStack key={j} gap={2} vAlign="center">
-                                <EditIcon
-                                  style={{
-                                    width: 14,
-                                    height: 14,
-                                    color: 'var(--color-text-secondary, #888)',
-                                  }}
+                                <XDSIcon
+                                  icon={EditIcon}
+                                  size="sm"
+                                  color="secondary"
                                 />
                                 <XDSText type="supporting" color="secondary">
                                   {change}
@@ -706,8 +709,12 @@ function TimelineSection() {
                     </div>
                     <div {...stylex.props(pageStyles.reactionBar)}>
                       <XDSHStack gap={1} vAlign="center">
-                        <ThumbUpIcon style={{width: 12, height: 12}} />
-                        <HeartIcon style={{width: 12, height: 12}} />
+                        <XDSIcon
+                          icon={ThumbUpIcon}
+                          size="xsm"
+                          color="inherit"
+                        />
+                        <XDSIcon icon={HeartIcon} size="xsm" color="inherit" />
                         <span>{item.reactions}</span>
                       </XDSHStack>
                       <span>Like</span>
@@ -741,9 +748,9 @@ function RightPanel() {
           style={{padding: '8px 16px'}}>
           <XDSCollapsible trigger={<XDSHeading level={4}>Notes</XDSHeading>}>
             <XDSText type="body">
-              Customer is a repeat buyer — 3rd order this quarter. Prefers brown
-              leather goods and grid-format notebooks. Requested gift wrapping
-              for this order. Ships to a residential address in CA.{' '}
+              Customer is a repeat buyer — 3rd order this quarter. Prefers snow
+              and oat glazes. Requested gift wrapping for the mug set. Ships to
+              a residential address in CA.{' '}
               <XDSLink href="#" label="Show more" color="secondary">
                 Show more
               </XDSLink>
@@ -778,24 +785,19 @@ function RightPanel() {
           style={{padding: '8px 16px'}}>
           <XDSCollapsible
             trigger={<XDSHeading level={4}>Fraud Analysis</XDSHeading>}>
-            <XDSCard>
-              <XDSSection variant="wash">
-                <XDSVStack gap={3}>
-                  <XDSText type="body">Recommendation: Fulfill order</XDSText>
-                  <XDSProgressBar
-                    label="Risk level"
-                    value={15}
-                    variant="positive"
-                    isLabelHidden
-                  />
-                  <XDSText type="body">
-                    There is a low chance that you will receive a chargeback on
-                    this order.
-                  </XDSText>
-                  <XDSButton label="Learn more" variant="secondary" />
-                </XDSVStack>
-              </XDSSection>
-            </XDSCard>
+            <XDSVStack gap={1}>
+              <XDSProgressBar
+                label="Risk level"
+                value={15}
+                variant="positive"
+                isLabelHidden
+              />
+              <XDSText type="body">Recommendation: Fulfill order</XDSText>
+              <XDSText type="body">
+                There is a low chance that you will receive a chargeback on this
+                order.
+              </XDSText>
+            </XDSVStack>
           </XDSCollapsible>
         </div>
       </XDSVStack>
@@ -806,6 +808,7 @@ function RightPanel() {
 // ─── Main Page ──────────────────────────────────────────────────────────────
 export default function DetailPage2Template() {
   const [activeTab, setActiveTab] = useState('details');
+  const [isPanelOpen, setIsPanelOpen] = useState(true);
 
   return (
     <XDSAppShell
@@ -816,9 +819,16 @@ export default function DetailPage2Template() {
         height="fill"
         contentWidth={1000}
         defaultHasDividers
-        header={<PageHeader activeTab={activeTab} onTabChange={setActiveTab} />}
+        header={
+          <PageHeader
+            activeTab={activeTab}
+            onTabChange={setActiveTab}
+            isPanelOpen={isPanelOpen}
+            onTogglePanel={() => setIsPanelOpen(prev => !prev)}
+          />
+        }
         content={
-          <XDSLayoutContent role="main">
+          <XDSLayoutContent role="main" xstyle={pageStyles.contentFlushEnd}>
             <XDSVStack gap={4}>
               <ItemsCard />
               <InvoiceCard />
@@ -826,7 +836,7 @@ export default function DetailPage2Template() {
             </XDSVStack>
           </XDSLayoutContent>
         }
-        end={<RightPanel />}
+        end={isPanelOpen ? <RightPanel /> : undefined}
       />
     </XDSAppShell>
   );

--- a/packages/cli/templates/detail-page/template.doc.mjs
+++ b/packages/cli/templates/detail-page/template.doc.mjs
@@ -1,5 +1,6 @@
 /** @type {import('../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
+  type: 'page',
   name: 'Detail Page',
   description: 'Order detail page with timeline and line items',
   isReady: true,


### PR DESCRIPTION
## Summary

- Align the detail-page template with [Contributing Templates](https://github.com/facebookexperimental/xds/wiki/Contributing-Templates) guidelines
- Rebrand to "Kiln & Table" ceramics store matching the product-detail template from PR #1394
- Add interactive collapsible right panel with animated open/close

## Changes

### Contributing guidelines compliance
- Replace all raw SVG icons with `XDSIcon` for consistent sizing and color tokens
- Replace manual SideNav header with `XDSSideNavHeading` + `XDSNavIcon` (filled icon, white color)
- Add `XDSSideNavCollapseButton` for collapsible sidebar
- Add `type: 'page'` to `template.doc.mjs`
- Remove unused StyleX styles (8 dead declarations)
- Use `XDSIcon` inside `XDSButton` icon props

### Content & branding
- Rebrand from "Acme" to "Kiln & Table" ceramics store
- Update products to ceramics items (mugs, bowls, platters, cups, vases)
- Use `light-product-*` CDN images from `xds_oss` asset set (matching PR #1394)
- Update activity timeline and customer notes for ceramics context

### Layout & interaction
- Restructure header: actions pinned top-right, tabs span full width
- Make metadata row single-line with overflow clipping (`flexShrink: 0` on items)
- Add collapsible right panel toggle (PanelRightIcon) at end of tab row
- Animate panel open/close with XDS motion tokens (`--duration-medium`, `--ease-standard`)
- Two-layer animation: outer width collapse + inner content fade with staggered timing

## Test plan
- [ ] Verify sidebar collapses and expands via the collapse button
- [ ] Verify right panel toggles with animation when clicking the panel icon
- [ ] Verify metadata row clips on narrow widths without wrapping
- [ ] Verify product images load from CDN URLs
- [ ] Verify template renders correctly in sandbox at `/templates/detail-page/`


Made with [Cursor](https://cursor.com)