### PR TITLE
refactor(TabList): keep size prop, remove density

### DIFF
--- a/apps/storybook/stories/TabList.stories.tsx
+++ b/apps/storybook/stories/TabList.stories.tsx
@@ -12,10 +12,15 @@ const meta: Meta<typeof XDSTabList> = {
   component: XDSTabList,
   tags: ['autodocs'],
   argTypes: {
+    density: {
+      control: 'select',
+      options: ['compact', 'balanced', 'spacious'],
+      description: 'Density variant controlling vertical spacing',
+    },
     size: {
       control: 'select',
       options: ['sm', 'md', 'lg'],
-      description: 'Size variant for tabs',
+      description: '(Deprecated) Size variant — use density instead',
     },
   },
 };
@@ -25,12 +30,12 @@ type Story = StoryObj<typeof XDSTabList>;
 
 export const Default: Story = {
   args: {
-    size: 'md',
+    density: 'balanced',
   },
   render: args => {
     const [value, setValue] = useState('home');
     return (
-      <XDSTabList value={value} onChange={setValue} size={args.size}>
+      <XDSTabList value={value} onChange={setValue} density={args.density}>
         <XDSTab value="home" label="Home" />
         <XDSTab value="projects" label="Projects" />
         <XDSTab value="settings" label="Settings" />
@@ -41,12 +46,12 @@ export const Default: Story = {
 
 export const WithMenu: Story = {
   args: {
-    size: 'md',
+    density: 'balanced',
   },
   render: args => {
     const [value, setValue] = useState('home');
     return (
-      <XDSTabList value={value} onChange={setValue} size={args.size}>
+      <XDSTabList value={value} onChange={setValue} density={args.density}>
         <XDSTab value="home" label="Home" />
         <XDSTab value="projects" label="Projects" />
         <XDSTabMenu
@@ -64,12 +69,12 @@ export const WithMenu: Story = {
 
 export const MenuWithSelectedChild: Story = {
   args: {
-    size: 'md',
+    density: 'balanced',
   },
   render: args => {
     const [value, setValue] = useState('analytics');
     return (
-      <XDSTabList value={value} onChange={setValue} size={args.size}>
+      <XDSTabList value={value} onChange={setValue} density={args.density}>
         <XDSTab value="home" label="Home" />
         <XDSTab value="projects" label="Projects" />
         <XDSTabMenu
@@ -84,14 +89,65 @@ export const MenuWithSelectedChild: Story = {
   },
 };
 
-export const SizeVariants: Story = {
+export const DensityVariants: Story = {
   render: () => {
     const [value, setValue] = useState('home');
     return (
       <div style={{display: 'flex', flexDirection: 'column', gap: '24px'}}>
         <div>
           <div style={{marginBottom: '8px', fontSize: '12px', color: '#666'}}>
-            Small
+            Compact — sm hover target + 4px padding (36px total)
+          </div>
+          <div style={{border: '1px dashed #ccc'}}>
+            <XDSTabList value={value} onChange={setValue} density="compact">
+              <XDSTab value="home" label="Home" />
+              <XDSTab value="projects" label="Projects" />
+              <XDSTab value="settings" label="Settings" />
+            </XDSTabList>
+          </div>
+        </div>
+        <div>
+          <div style={{marginBottom: '8px', fontSize: '12px', color: '#666'}}>
+            Balanced — md hover target + 4px padding (40px total)
+          </div>
+          <div style={{border: '1px dashed #ccc'}}>
+            <XDSTabList value={value} onChange={setValue} density="balanced">
+              <XDSTab value="home" label="Home" />
+              <XDSTab value="projects" label="Projects" />
+              <XDSTab value="settings" label="Settings" />
+            </XDSTabList>
+          </div>
+        </div>
+        <div>
+          <div style={{marginBottom: '8px', fontSize: '12px', color: '#666'}}>
+            Spacious — lg hover target + 4px padding (44px total)
+          </div>
+          <div style={{border: '1px dashed #ccc'}}>
+            <XDSTabList value={value} onChange={setValue} density="spacious">
+              <XDSTab value="home" label="Home" />
+              <XDSTab value="projects" label="Projects" />
+              <XDSTab value="settings" label="Settings" />
+            </XDSTabList>
+          </div>
+        </div>
+      </div>
+    );
+  },
+};
+
+/**
+ * Backward compatibility: the old `size` prop still works and maps
+ * to the equivalent density (sm→compact, md→balanced, lg→spacious).
+ */
+export const SizeVariantsLegacy: Story = {
+  name: 'Size Variants (Legacy)',
+  render: () => {
+    const [value, setValue] = useState('home');
+    return (
+      <div style={{display: 'flex', flexDirection: 'column', gap: '24px'}}>
+        <div>
+          <div style={{marginBottom: '8px', fontSize: '12px', color: '#666'}}>
+            size=\"sm\" (maps to compact)
           </div>
           <XDSTabList value={value} onChange={setValue} size="sm">
             <XDSTab value="home" label="Home" />
@@ -101,7 +157,7 @@ export const SizeVariants: Story = {
         </div>
         <div>
           <div style={{marginBottom: '8px', fontSize: '12px', color: '#666'}}>
-            Medium (default)
+            size=\"md\" (maps to balanced)
           </div>
           <XDSTabList value={value} onChange={setValue} size="md">
             <XDSTab value="home" label="Home" />
@@ -111,7 +167,7 @@ export const SizeVariants: Story = {
         </div>
         <div>
           <div style={{marginBottom: '8px', fontSize: '12px', color: '#666'}}>
-            Large
+            size=\"lg\" (maps to spacious)
           </div>
           <XDSTabList value={value} onChange={setValue} size="lg">
             <XDSTab value="home" label="Home" />
@@ -126,7 +182,7 @@ export const SizeVariants: Story = {
 
 export const WithIcons: Story = {
   args: {
-    size: 'md',
+    density: 'balanced',
   },
   render: args => {
     const [value, setValue] = useState('home');
@@ -148,7 +204,7 @@ export const WithIcons: Story = {
     );
 
     return (
-      <XDSTabList value={value} onChange={setValue} size={args.size}>
+      <XDSTabList value={value} onChange={setValue} density={args.density}>
         <XDSTab value="home" label="Home" icon={HomeIcon} />
         <XDSTab value="settings" label="Settings" icon={CogIcon} />
       </XDSTabList>
@@ -167,11 +223,21 @@ export const WithActions: Story = {
   render: () => {
     const [value, setValue] = useState('all');
     return (
-      <XDSTabList value={value} onChange={setValue} size="lg" hasDivider>
+      <XDSTabList
+        value={value}
+        onChange={setValue}
+        density="spacious"
+        hasDivider>
         <XDSTab value="all" label="All items" />
         <XDSTab value="active" label="Active" />
         <XDSTab value="archived" label="Archived" />
-        <div style={{marginInlineStart: 'auto', display: 'flex', alignItems: 'center', gap: '4px'}}>
+        <div
+          style={{
+            marginInlineStart: 'auto',
+            display: 'flex',
+            alignItems: 'center',
+            gap: '4px',
+          }}>
           <XDSButton
             label="Filter"
             variant="ghost"
@@ -201,6 +267,44 @@ export const FillLayout: Story = {
           <XDSTab value="projects" label="Projects" />
           <XDSTab value="settings" label="Settings" />
         </XDSTabList>
+      </div>
+    );
+  },
+};
+
+/**
+ * Side-by-side comparison of all three densities with a dashed border
+ * to visualize the total height of each tab strip.
+ */
+export const DensityComparison: Story = {
+  render: () => {
+    const [value, setValue] = useState('home');
+    return (
+      <div style={{display: 'flex', flexDirection: 'column', gap: '32px'}}>
+        {(['compact', 'balanced', 'spacious'] as const).map(density => (
+          <div key={density}>
+            <div
+              style={{
+                marginBottom: '8px',
+                fontSize: '12px',
+                color: '#666',
+                fontFamily: 'monospace',
+              }}>
+              density=\"{density}\"
+            </div>
+            <div style={{border: '1px dashed #ccc', display: 'inline-flex'}}>
+              <XDSTabList
+                value={value}
+                onChange={setValue}
+                density={density}
+                hasDivider>
+                <XDSTab value="home" label="Home" />
+                <XDSTab value="projects" label="Projects" />
+                <XDSTab value="settings" label="Settings" />
+              </XDSTabList>
+            </div>
+          </div>
+        ))}
       </div>
     );
   },

--- a/apps/storybook/stories/TabList.stories.tsx
+++ b/apps/storybook/stories/TabList.stories.tsx
@@ -12,15 +12,10 @@ const meta: Meta<typeof XDSTabList> = {
   component: XDSTabList,
   tags: ['autodocs'],
   argTypes: {
-    density: {
-      control: 'select',
-      options: ['compact', 'balanced', 'spacious'],
-      description: 'Density variant controlling vertical spacing',
-    },
     size: {
       control: 'select',
       options: ['sm', 'md', 'lg'],
-      description: '(Deprecated) Size variant — use density instead',
+      description: 'Size of the tab hover targets',
     },
   },
 };
@@ -30,12 +25,12 @@ type Story = StoryObj<typeof XDSTabList>;
 
 export const Default: Story = {
   args: {
-    density: 'balanced',
+    size: 'md',
   },
   render: args => {
     const [value, setValue] = useState('home');
     return (
-      <XDSTabList value={value} onChange={setValue} density={args.density}>
+      <XDSTabList value={value} onChange={setValue} size={args.size}>
         <XDSTab value="home" label="Home" />
         <XDSTab value="projects" label="Projects" />
         <XDSTab value="settings" label="Settings" />
@@ -46,12 +41,12 @@ export const Default: Story = {
 
 export const WithMenu: Story = {
   args: {
-    density: 'balanced',
+    size: 'md',
   },
   render: args => {
     const [value, setValue] = useState('home');
     return (
-      <XDSTabList value={value} onChange={setValue} density={args.density}>
+      <XDSTabList value={value} onChange={setValue} size={args.size}>
         <XDSTab value="home" label="Home" />
         <XDSTab value="projects" label="Projects" />
         <XDSTabMenu
@@ -69,12 +64,12 @@ export const WithMenu: Story = {
 
 export const MenuWithSelectedChild: Story = {
   args: {
-    density: 'balanced',
+    size: 'md',
   },
   render: args => {
     const [value, setValue] = useState('analytics');
     return (
-      <XDSTabList value={value} onChange={setValue} density={args.density}>
+      <XDSTabList value={value} onChange={setValue} size={args.size}>
         <XDSTab value="home" label="Home" />
         <XDSTab value="projects" label="Projects" />
         <XDSTabMenu
@@ -89,92 +84,31 @@ export const MenuWithSelectedChild: Story = {
   },
 };
 
-export const DensityVariants: Story = {
+export const SizeVariants: Story = {
   render: () => {
     const [value, setValue] = useState('home');
     return (
       <div style={{display: 'flex', flexDirection: 'column', gap: '24px'}}>
-        <div>
-          <div style={{marginBottom: '8px', fontSize: '12px', color: '#666'}}>
-            Compact — sm hover target + 4px padding (36px total)
+        {(['sm', 'md', 'lg'] as const).map(size => (
+          <div key={size}>
+            <div
+              style={{
+                marginBottom: '8px',
+                fontSize: '12px',
+                color: '#666',
+                fontFamily: 'monospace',
+              }}>
+              size=\"{size}\"
+            </div>
+            <div style={{border: '1px dashed #ccc', display: 'inline-flex'}}>
+              <XDSTabList value={value} onChange={setValue} size={size}>
+                <XDSTab value="home" label="Home" />
+                <XDSTab value="projects" label="Projects" />
+                <XDSTab value="settings" label="Settings" />
+              </XDSTabList>
+            </div>
           </div>
-          <div style={{border: '1px dashed #ccc'}}>
-            <XDSTabList value={value} onChange={setValue} density="compact">
-              <XDSTab value="home" label="Home" />
-              <XDSTab value="projects" label="Projects" />
-              <XDSTab value="settings" label="Settings" />
-            </XDSTabList>
-          </div>
-        </div>
-        <div>
-          <div style={{marginBottom: '8px', fontSize: '12px', color: '#666'}}>
-            Balanced — md hover target + 4px padding (40px total)
-          </div>
-          <div style={{border: '1px dashed #ccc'}}>
-            <XDSTabList value={value} onChange={setValue} density="balanced">
-              <XDSTab value="home" label="Home" />
-              <XDSTab value="projects" label="Projects" />
-              <XDSTab value="settings" label="Settings" />
-            </XDSTabList>
-          </div>
-        </div>
-        <div>
-          <div style={{marginBottom: '8px', fontSize: '12px', color: '#666'}}>
-            Spacious — lg hover target + 4px padding (44px total)
-          </div>
-          <div style={{border: '1px dashed #ccc'}}>
-            <XDSTabList value={value} onChange={setValue} density="spacious">
-              <XDSTab value="home" label="Home" />
-              <XDSTab value="projects" label="Projects" />
-              <XDSTab value="settings" label="Settings" />
-            </XDSTabList>
-          </div>
-        </div>
-      </div>
-    );
-  },
-};
-
-/**
- * Backward compatibility: the old `size` prop still works and maps
- * to the equivalent density (sm→compact, md→balanced, lg→spacious).
- */
-export const SizeVariantsLegacy: Story = {
-  name: 'Size Variants (Legacy)',
-  render: () => {
-    const [value, setValue] = useState('home');
-    return (
-      <div style={{display: 'flex', flexDirection: 'column', gap: '24px'}}>
-        <div>
-          <div style={{marginBottom: '8px', fontSize: '12px', color: '#666'}}>
-            size=\"sm\" (maps to compact)
-          </div>
-          <XDSTabList value={value} onChange={setValue} size="sm">
-            <XDSTab value="home" label="Home" />
-            <XDSTab value="projects" label="Projects" />
-            <XDSTab value="settings" label="Settings" />
-          </XDSTabList>
-        </div>
-        <div>
-          <div style={{marginBottom: '8px', fontSize: '12px', color: '#666'}}>
-            size=\"md\" (maps to balanced)
-          </div>
-          <XDSTabList value={value} onChange={setValue} size="md">
-            <XDSTab value="home" label="Home" />
-            <XDSTab value="projects" label="Projects" />
-            <XDSTab value="settings" label="Settings" />
-          </XDSTabList>
-        </div>
-        <div>
-          <div style={{marginBottom: '8px', fontSize: '12px', color: '#666'}}>
-            size=\"lg\" (maps to spacious)
-          </div>
-          <XDSTabList value={value} onChange={setValue} size="lg">
-            <XDSTab value="home" label="Home" />
-            <XDSTab value="projects" label="Projects" />
-            <XDSTab value="settings" label="Settings" />
-          </XDSTabList>
-        </div>
+        ))}
       </div>
     );
   },
@@ -182,7 +116,7 @@ export const SizeVariantsLegacy: Story = {
 
 export const WithIcons: Story = {
   args: {
-    density: 'balanced',
+    size: 'md',
   },
   render: args => {
     const [value, setValue] = useState('home');
@@ -204,7 +138,7 @@ export const WithIcons: Story = {
     );
 
     return (
-      <XDSTabList value={value} onChange={setValue} density={args.density}>
+      <XDSTabList value={value} onChange={setValue} size={args.size}>
         <XDSTab value="home" label="Home" icon={HomeIcon} />
         <XDSTab value="settings" label="Settings" icon={CogIcon} />
       </XDSTabList>
@@ -215,19 +149,12 @@ export const WithIcons: Story = {
 /**
  * Demonstrates a common page header pattern: large tab list items on the left
  * with action buttons on the right, separated by a full-width divider underneath.
- *
- * Uses hasDivider on the TabList for a full-width divider that sits behind
- * the active tab's underline indicator.
  */
 export const WithActions: Story = {
   render: () => {
     const [value, setValue] = useState('all');
     return (
-      <XDSTabList
-        value={value}
-        onChange={setValue}
-        density="spacious"
-        hasDivider>
+      <XDSTabList value={value} onChange={setValue} size="lg" hasDivider>
         <XDSTab value="all" label="All items" />
         <XDSTab value="active" label="Active" />
         <XDSTab value="archived" label="Archived" />
@@ -267,44 +194,6 @@ export const FillLayout: Story = {
           <XDSTab value="projects" label="Projects" />
           <XDSTab value="settings" label="Settings" />
         </XDSTabList>
-      </div>
-    );
-  },
-};
-
-/**
- * Side-by-side comparison of all three densities with a dashed border
- * to visualize the total height of each tab strip.
- */
-export const DensityComparison: Story = {
-  render: () => {
-    const [value, setValue] = useState('home');
-    return (
-      <div style={{display: 'flex', flexDirection: 'column', gap: '32px'}}>
-        {(['compact', 'balanced', 'spacious'] as const).map(density => (
-          <div key={density}>
-            <div
-              style={{
-                marginBottom: '8px',
-                fontSize: '12px',
-                color: '#666',
-                fontFamily: 'monospace',
-              }}>
-              density=\"{density}\"
-            </div>
-            <div style={{border: '1px dashed #ccc', display: 'inline-flex'}}>
-              <XDSTabList
-                value={value}
-                onChange={setValue}
-                density={density}
-                hasDivider>
-                <XDSTab value="home" label="Home" />
-                <XDSTab value="projects" label="Projects" />
-                <XDSTab value="settings" label="Settings" />
-              </XDSTabList>
-            </div>
-          </div>
-        ))}
       </div>
     );
   },

--- a/apps/storybook/stories/Toolbar.stories.tsx
+++ b/apps/storybook/stories/Toolbar.stories.tsx
@@ -1,5 +1,7 @@
+import {useState} from 'react';
 import type {Meta, StoryObj} from '@storybook/react';
 import {XDSToolbar} from '@xds/core/Toolbar';
+import {XDSTabList, XDSTab} from '@xds/core/TabList';
 import {XDSButton} from '@xds/core/Button';
 import {XDSCard} from '@xds/core/Card';
 import {XDSSection} from '@xds/core/Section';
@@ -389,4 +391,46 @@ export const InsideLayout: Story = {
       />
     </div>
   ),
+};
+
+/** Toolbar with tab navigation on the left and action buttons on the right. Tests that tab hover targets align with buttons at each size. */
+export const WithTabNavigation: Story = {
+  name: 'Composition: Tab Navigation',
+  render: () => {
+    const [tab, setTab] = useState('overview');
+    return (
+      <div style={{display: 'flex', flexDirection: 'column', gap: 24}}>
+        {(['sm', 'md', 'lg'] as const).map(size => (
+          <XDSCard key={size}>
+            <XDSToolbar
+              label={`Tab navigation (${size})`}
+              dividers={['bottom']}
+              startContent={
+                <XDSTabList value={tab} onChange={setTab} size={size}>
+                  <XDSTab value="overview" label="Overview" />
+                  <XDSTab value="analytics" label="Analytics" />
+                  <XDSTab value="settings" label="Settings" />
+                </XDSTabList>
+              }
+              endContent={
+                <>
+                  <XDSButton
+                    label="Export"
+                    variant="ghost"
+                    size={size}
+                    icon={<ArrowDownTrayIcon style={{width: 16, height: 16}} />}
+                    isIconOnly
+                  />
+                  <XDSButton label="New item" size={size} />
+                </>
+              }
+            />
+            <XDSSection>
+              <XDSText>Content for {size} size variant</XDSText>
+            </XDSSection>
+          </XDSCard>
+        ))}
+      </div>
+    );
+  },
 };

--- a/packages/core/src/TabList/XDSTab.tsx
+++ b/packages/core/src/TabList/XDSTab.tsx
@@ -119,8 +119,7 @@ const styles = stylex.create({
   },
   indicator: {
     position: 'absolute',
-    // Extend past the tab's bottom edge to reach the nav's bottom edge (accounting for nav paddingBlock)
-    bottom: `calc(-1 * ${spacingVars['--spacing-1']})`,
+    bottom: '-2px',
     left: spacingVars['--spacing-3'],
     right: spacingVars['--spacing-3'],
     height: '2px',

--- a/packages/core/src/TabList/XDSTab.tsx
+++ b/packages/core/src/TabList/XDSTab.tsx
@@ -119,7 +119,8 @@ const styles = stylex.create({
   },
   indicator: {
     position: 'absolute',
-    bottom: 0,
+    // Extend past the tab's bottom edge to reach the nav's bottom edge (accounting for nav paddingBlock)
+    bottom: `calc(-1 * ${spacingVars['--spacing-1']})`,
     left: spacingVars['--spacing-3'],
     right: spacingVars['--spacing-3'],
     height: '2px',

--- a/packages/core/src/TabList/XDSTabList.tsx
+++ b/packages/core/src/TabList/XDSTabList.tsx
@@ -16,8 +16,8 @@ import {useMemo, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {borderVars, colorVars, spacingVars} from '../theme/tokens.stylex';
 import {XDSBaseProps} from '../XDSBaseProps';
-import {XDSTabListContext} from './XDSTabListContext';
-import type {XDSTabListSize} from './XDSTabListContext';
+import {XDSTabListContext, DENSITY_TO_SIZE} from './XDSTabListContext';
+import type {XDSTabListSize, XDSTabListDensity} from './XDSTabListContext';
 import {xdsClassName, mergeProps} from '../utils';
 
 export interface XDSTabListProps extends Omit<
@@ -33,7 +33,16 @@ export interface XDSTabListProps extends Omit<
    */
   onChange: (value: string) => void;
   /**
+   * Density variant controlling vertical spacing of the tab strip.
+   * - `'compact'`: sm hover target + 4px block padding (total 36px)
+   * - `'balanced'`: md hover target + 4px block padding (total 40px)
+   * - `'spacious'`: lg hover target + 4px block padding (total 44px)
+   * @default 'balanced'
+   */
+  density?: XDSTabListDensity;
+  /**
    * Size variant for all tabs.
+   * @deprecated Use `density` instead. Maps: sm→compact, md→balanced, lg→spacious.
    * @default 'md'
    */
   size?: XDSTabListSize;
@@ -60,6 +69,7 @@ const styles = stylex.create({
     display: 'flex',
     alignItems: 'stretch',
     gap: spacingVars['--spacing-0-5'],
+    paddingBlock: spacingVars['--spacing-1'],
   },
   fill: {
     width: '100%',
@@ -90,7 +100,8 @@ const styles = stylex.create({
 export function XDSTabList({
   value,
   onChange,
-  size = 'md',
+  density: densityProp,
+  size: sizeProp,
   layout = 'hug',
   hasDivider = false,
   xstyle,
@@ -99,9 +110,19 @@ export function XDSTabList({
   children,
   ...restProps
 }: XDSTabListProps) {
+  // Resolve density: explicit density prop wins, then map size→density, then default
+  const SIZE_TO_DENSITY: Record<XDSTabListSize, XDSTabListDensity> = {
+    sm: 'compact',
+    md: 'balanced',
+    lg: 'spacious',
+  };
+  const density: XDSTabListDensity =
+    densityProp ?? (sizeProp ? SIZE_TO_DENSITY[sizeProp] : 'balanced');
+  const size: XDSTabListSize = DENSITY_TO_SIZE[density];
+
   const contextValue = useMemo(
-    () => ({value, onChange, size, layout}),
-    [value, onChange, size, layout],
+    () => ({value, onChange, size, density, layout}),
+    [value, onChange, size, density, layout],
   );
 
   return (
@@ -110,7 +131,7 @@ export function XDSTabList({
         aria-label="Tabs"
         {...restProps}
         {...mergeProps(
-          xdsClassName('tab-list', {size}),
+          xdsClassName('tab-list', {density}),
           stylex.props(
             styles.nav,
             layout === 'fill' && styles.fill,

--- a/packages/core/src/TabList/XDSTabList.tsx
+++ b/packages/core/src/TabList/XDSTabList.tsx
@@ -70,6 +70,8 @@ const styles = stylex.create({
     alignItems: 'stretch',
     gap: spacingVars['--spacing-0-5'],
     paddingBlock: spacingVars['--spacing-1'],
+    // Compensate for first/last tab's paddingInline so text aligns with surrounding content
+    marginInline: `calc(-1 * ${spacingVars['--spacing-3']})`,
   },
   fill: {
     width: '100%',

--- a/packages/core/src/TabList/XDSTabList.tsx
+++ b/packages/core/src/TabList/XDSTabList.tsx
@@ -16,8 +16,8 @@ import {useMemo, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {borderVars, colorVars, spacingVars} from '../theme/tokens.stylex';
 import {XDSBaseProps} from '../XDSBaseProps';
-import {XDSTabListContext, DENSITY_TO_SIZE} from './XDSTabListContext';
-import type {XDSTabListSize, XDSTabListDensity} from './XDSTabListContext';
+import {XDSTabListContext} from './XDSTabListContext';
+import type {XDSTabListSize} from './XDSTabListContext';
 import {xdsClassName, mergeProps} from '../utils';
 
 export interface XDSTabListProps extends Omit<
@@ -33,16 +33,8 @@ export interface XDSTabListProps extends Omit<
    */
   onChange: (value: string) => void;
   /**
-   * Density variant controlling vertical spacing of the tab strip.
-   * - `'compact'`: sm hover target + 4px block padding (total 36px)
-   * - `'balanced'`: md hover target + 4px block padding (total 40px)
-   * - `'spacious'`: lg hover target + 4px block padding (total 44px)
-   * @default 'balanced'
-   */
-  density?: XDSTabListDensity;
-  /**
-   * Size variant for all tabs.
-   * @deprecated Use `density` instead. Maps: sm→compact, md→balanced, lg→spacious.
+   * Size of the tab hover targets. Uses the same element size tokens
+   * as Button and TextInput (`sm` = 28px, `md` = 32px, `lg` = 36px).
    * @default 'md'
    */
   size?: XDSTabListSize;
@@ -69,9 +61,6 @@ const styles = stylex.create({
     display: 'flex',
     alignItems: 'stretch',
     gap: spacingVars['--spacing-0-5'],
-    paddingBlock: spacingVars['--spacing-1'],
-    // Compensate for first/last tab's paddingInline so text aligns with surrounding content
-    marginInline: `calc(-1 * ${spacingVars['--spacing-3']})`,
   },
   fill: {
     width: '100%',
@@ -102,8 +91,7 @@ const styles = stylex.create({
 export function XDSTabList({
   value,
   onChange,
-  density: densityProp,
-  size: sizeProp,
+  size = 'md',
   layout = 'hug',
   hasDivider = false,
   xstyle,
@@ -112,19 +100,9 @@ export function XDSTabList({
   children,
   ...restProps
 }: XDSTabListProps) {
-  // Resolve density: explicit density prop wins, then map size→density, then default
-  const SIZE_TO_DENSITY: Record<XDSTabListSize, XDSTabListDensity> = {
-    sm: 'compact',
-    md: 'balanced',
-    lg: 'spacious',
-  };
-  const density: XDSTabListDensity =
-    densityProp ?? (sizeProp ? SIZE_TO_DENSITY[sizeProp] : 'balanced');
-  const size: XDSTabListSize = DENSITY_TO_SIZE[density];
-
   const contextValue = useMemo(
-    () => ({value, onChange, size, density, layout}),
-    [value, onChange, size, density, layout],
+    () => ({value, onChange, size, layout}),
+    [value, onChange, size, layout],
   );
 
   return (
@@ -133,7 +111,7 @@ export function XDSTabList({
         aria-label="Tabs"
         {...restProps}
         {...mergeProps(
-          xdsClassName('tab-list', {density}),
+          xdsClassName('tab-list', {size}),
           stylex.props(
             styles.nav,
             layout === 'fill' && styles.fill,

--- a/packages/core/src/TabList/XDSTabListContext.ts
+++ b/packages/core/src/TabList/XDSTabListContext.ts
@@ -13,18 +13,9 @@ import {createContext, useContext} from 'react';
 
 /**
  * Size variants for tab list items.
- * @deprecated Use `XDSTabListDensity` instead. Kept for backward compatibility.
+ * Uses hardcoded px values (sizeVars not available on this branch).
  */
 export type XDSTabListSize = 'sm' | 'md' | 'lg';
-
-/**
- * Density variants for tab list spacing.
- * Controls the vertical breathing room of the tab strip:
- * - `'compact'`: Tight spacing for dense UIs. Uses sm button hover target + 4px block padding.
- * - `'balanced'`: Standard spacing. Uses md button hover target + 4px block padding.
- * - `'spacious'`: Extra spacing for readability. Uses lg button hover target + 4px block padding.
- */
-export type XDSTabListDensity = 'compact' | 'balanced' | 'spacious';
 
 /**
  * Layout mode for tab sizing.
@@ -34,23 +25,12 @@ export type XDSTabListDensity = 'compact' | 'balanced' | 'spacious';
 export type XDSTabListLayout = 'hug' | 'fill';
 
 /**
- * Maps density values to their corresponding button size for hover targets.
- */
-export const DENSITY_TO_SIZE: Record<XDSTabListDensity, XDSTabListSize> = {
-  compact: 'sm',
-  balanced: 'md',
-  spacious: 'lg',
-};
-
-/**
- * Context for communicating value/onChange/density/layout from XDSTabList to children.
+ * Context for communicating value/onChange/size/layout from XDSTabList to children.
  */
 export interface XDSTabListContextValue {
   value: string;
   onChange: (value: string) => void;
-  /** @deprecated Use `density` instead */
   size: XDSTabListSize;
-  density: XDSTabListDensity;
   layout: XDSTabListLayout;
 }
 

--- a/packages/core/src/TabList/XDSTabListContext.ts
+++ b/packages/core/src/TabList/XDSTabListContext.ts
@@ -9,14 +9,22 @@
  * SYNC: When modified, update /packages/core/src/TabList/TabList.doc.mjs
  */
 
-
 import {createContext, useContext} from 'react';
 
 /**
  * Size variants for tab list items.
- * Uses hardcoded px values (sizeVars not available on this branch).
+ * @deprecated Use `XDSTabListDensity` instead. Kept for backward compatibility.
  */
 export type XDSTabListSize = 'sm' | 'md' | 'lg';
+
+/**
+ * Density variants for tab list spacing.
+ * Controls the vertical breathing room of the tab strip:
+ * - `'compact'`: Tight spacing for dense UIs. Uses sm button hover target + 4px block padding.
+ * - `'balanced'`: Standard spacing. Uses md button hover target + 4px block padding.
+ * - `'spacious'`: Extra spacing for readability. Uses lg button hover target + 4px block padding.
+ */
+export type XDSTabListDensity = 'compact' | 'balanced' | 'spacious';
 
 /**
  * Layout mode for tab sizing.
@@ -26,12 +34,23 @@ export type XDSTabListSize = 'sm' | 'md' | 'lg';
 export type XDSTabListLayout = 'hug' | 'fill';
 
 /**
- * Context for communicating value/onChange/size/layout from XDSTabList to children.
+ * Maps density values to their corresponding button size for hover targets.
+ */
+export const DENSITY_TO_SIZE: Record<XDSTabListDensity, XDSTabListSize> = {
+  compact: 'sm',
+  balanced: 'md',
+  spacious: 'lg',
+};
+
+/**
+ * Context for communicating value/onChange/density/layout from XDSTabList to children.
  */
 export interface XDSTabListContextValue {
   value: string;
   onChange: (value: string) => void;
+  /** @deprecated Use `density` instead */
   size: XDSTabListSize;
+  density: XDSTabListDensity;
   layout: XDSTabListLayout;
 }
 

--- a/packages/core/src/TabList/XDSTabMenu.tsx
+++ b/packages/core/src/TabList/XDSTabMenu.tsx
@@ -112,7 +112,7 @@ const styles = stylex.create({
   },
   indicator: {
     position: 'absolute',
-    bottom: `calc(-1 * ${spacingVars['--spacing-1']})`,
+    bottom: '-2px',
     left: spacingVars['--spacing-3'],
     right: spacingVars['--spacing-3'],
     height: '2px',

--- a/packages/core/src/TabList/XDSTabMenu.tsx
+++ b/packages/core/src/TabList/XDSTabMenu.tsx
@@ -112,7 +112,7 @@ const styles = stylex.create({
   },
   indicator: {
     position: 'absolute',
-    bottom: 0,
+    bottom: `calc(-1 * ${spacingVars['--spacing-1']})`,
     left: spacingVars['--spacing-3'],
     right: spacingVars['--spacing-3'],
     height: '2px',

--- a/packages/core/src/TabList/index.ts
+++ b/packages/core/src/TabList/index.ts
@@ -19,4 +19,8 @@ export {XDSTabMenu} from './XDSTabMenu';
 export type {XDSTabMenuProps, XDSTabMenuOption} from './XDSTabMenu';
 
 export {useXDSTabListContext} from './XDSTabListContext';
-export type {XDSTabListSize, XDSTabListLayout} from './XDSTabListContext';
+export type {
+  XDSTabListSize,
+  XDSTabListDensity,
+  XDSTabListLayout,
+} from './XDSTabListContext';

--- a/packages/core/src/TabList/index.ts
+++ b/packages/core/src/TabList/index.ts
@@ -19,8 +19,4 @@ export {XDSTabMenu} from './XDSTabMenu';
 export type {XDSTabMenuProps, XDSTabMenuOption} from './XDSTabMenu';
 
 export {useXDSTabListContext} from './XDSTabListContext';
-export type {
-  XDSTabListSize,
-  XDSTabListDensity,
-  XDSTabListLayout,
-} from './XDSTabListContext';
+export type {XDSTabListSize, XDSTabListLayout} from './XDSTabListContext';

--- a/yarn.lock
+++ b/yarn.lock
@@ -5122,12 +5122,7 @@ prelude-ls@^1.2.1:
   resolved "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
-prettier@^2.7.1:
-  version "2.8.8"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
-  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
-
-prettier@^3.8.2:
+prettier@^2.7.1, prettier@^3.8.2:
   version "3.8.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.8.2.tgz#4f52e502193c9aa5b384c3d00852003e551bbd9f"
   integrity sha512-8c3mgTe0ASwWAJK+78dpviD+A8EqhndQPUBpNUIPt6+xWlIigCwfN01lWr9MAede4uqXGTEKeQWTvzb3vjia0Q==


### PR DESCRIPTION
## What

Reworks the TabList changes from the original PR based on review feedback.

### Keep `size`, drop `density`

`size` (`sm | md | lg`) maps to `--size-element-*` tokens — the same scale Button and TextInput use. These are interactive element heights that need to align when placed side-by-side (e.g. tabs next to buttons in a toolbar). `density` controls padding/spacing within containers of repeated items (List rows, Table cells) — a different axis.

### Indicator positioning

The active tab indicator now overflows 2px below the tab button via `bottom: -2px`. No extra padding or margin on the nav — the tab strip height equals the button size, and the underline subtly peeks out underneath.

### No edge compensation

Removed the negative `marginInline` that was baked into the nav. If a container needs tab labels to align flush with surrounding content, that's the container's responsibility.

## Changes

- Revert density prop — `size` is the only prop
- Remove `paddingBlock` and negative `marginInline` from nav
- Indicator `bottom: -2px` on XDSTab and XDSTabMenu
- Clean up stories: remove density variants, keep size variants with dashed boundary demo
- Add Toolbar + TabList composition story