### PR TITLE
refactor(sandbox): simplify ProjectCard — remove thumbnail, use XDS components

### DIFF
--- a/apps/sandbox/src/app/ProjectCard.tsx
+++ b/apps/sandbox/src/app/ProjectCard.tsx
@@ -2,58 +2,25 @@
 
 import Link from 'next/link';
 import {XDSText} from '@xds/core/Text';
+import {XDSCard} from '@xds/core/Card';
+import {XDSVStack} from '@xds/core/Stack';
 import type {SandboxPage} from './sandboxPages';
-import {ImageIcon} from './icons';
 
 export function ProjectCard({page}: {page: SandboxPage}) {
   return (
     <Link
       href={page.href}
       style={{textDecoration: 'none', color: 'inherit', display: 'flex'}}>
-      <div
-        style={{
-          display: 'flex',
-          flexDirection: 'column',
-          width: '100%',
-          borderRadius: 12,
-          border: '1px solid var(--color-border-emphasized)',
-          backgroundColor: 'var(--color-background-card)',
-          overflow: 'hidden',
-        }}>
-        <div
-          style={{
-            width: '100%',
-            height: 160,
-            backgroundColor: 'var(--color-background-body)',
-            overflow: 'hidden',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-          }}>
-          <ImageIcon
-            style={{
-              width: 48,
-              height: 48,
-              opacity: 0.3,
-              color: 'var(--color-text-disabled)',
-            }}
-          />
-        </div>
-        <div
-          style={{
-            display: 'flex',
-            flexDirection: 'column',
-            gap: 4,
-            padding: '12px 16px',
-          }}>
+      <XDSCard padding={4} style={{width: '100%'}}>
+        <XDSVStack gap={1}>
           <XDSText type="body" weight="semibold" maxLines={1}>
             {page.name}
           </XDSText>
           <XDSText type="body" size="sm" color="secondary" maxLines={2}>
             {page.description}
           </XDSText>
-        </div>
-      </div>
+        </XDSVStack>
+      </XDSCard>
     </Link>
   );
 }


### PR DESCRIPTION
## Summary

Removes the placeholder thumbnail area from sandbox ProjectCards and replaces generic div wrappers with proper XDS components.

### Before
- Thumbnail placeholder with `ImageIcon` taking up 160px of height
- Hand-rolled `div` wrappers with inline styles for card layout

### After
- No thumbnail — cards show just name and description
- Uses `XDSCard` and `XDSVStack` instead of generic divs

### Why
The iframe thumbnails were removed in #1409 for performance, but the placeholder icon area was kept. It adds visual noise without value — removing it makes the cards cleaner and more compact.