### PR TITLE
fix(Divider): remove opaque background from label

### DIFF
--- a/packages/core/src/Divider/XDSDivider.tsx
+++ b/packages/core/src/Divider/XDSDivider.tsx
@@ -137,7 +137,6 @@ const labelStyles = stylex.create({
   label: {
     flexShrink: 0,
     paddingInline: spacingVars['--spacing-3'],
-    backgroundColor: colorVars['--color-background-surface'],
     // Small secondary text styling
     fontSize: typeScaleVars['--text-supporting-size'],
     lineHeight: typeScaleVars['--text-supporting-leading'],


### PR DESCRIPTION
The label had `backgroundColor` set to `--color-background-surface`, which created a visible opaque rectangle when the divider sat on non-surface backgrounds. Removing it lets the label sit transparently over the divider lines.

---
