### PR TITLE
fix(MobileNav): close drawer when nav item is activated

### DIFF
--- a/packages/core/src/SideNav/XDSSideNav.test.tsx
+++ b/packages/core/src/SideNav/XDSSideNav.test.tsx
@@ -846,3 +846,88 @@ describe('XDSSideNavItem (collapsed)', () => {
     expect(screen.getByRole('group')).toBeInTheDocument();
   });
 });
+
+// =============================================================================
+// Mobile nav close-on-activate
+// =============================================================================
+
+import {XDSSideNavRenderContext} from './XDSSideNavRenderContext';
+import {XDSAppShellMobileContext} from '../AppShell/XDSAppShellMobileContext';
+
+describe('XDSSideNavItem — mobile drawer close-on-activate', () => {
+  function renderInDrawer(ui: ReactNode, closeMobileNav = vi.fn()) {
+    return {
+      closeMobileNav,
+      ...render(
+        <XDSAppShellMobileContext.Provider
+          value={{
+            isMobile: true,
+            isMobileNavOpen: true,
+            toggleMobileNav: vi.fn(),
+            openMobileNav: vi.fn(),
+            closeMobileNav,
+            isMobileNavEnabled: true,
+            hasAutoToggle: true,
+          }}>
+          <XDSSideNavRenderContext value="drawer">{ui}</XDSSideNavRenderContext>
+        </XDSAppShellMobileContext.Provider>,
+      ),
+    };
+  }
+
+  it('closes the mobile nav when a link item is clicked', async () => {
+    const user = userEvent.setup();
+    const {closeMobileNav} = renderInDrawer(
+      <XDSSideNavItem label="Home" href="/" data-testid="item" />,
+    );
+    await user.click(screen.getByTestId('item'));
+    expect(closeMobileNav).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes the mobile nav when a button item is clicked', async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    const {closeMobileNav} = renderInDrawer(
+      <XDSSideNavItem label="Action" onClick={onClick} data-testid="item" />,
+    );
+    await user.click(screen.getByTestId('item'));
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(closeMobileNav).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT close when a collapsible parent is toggled', async () => {
+    const user = userEvent.setup();
+    const {closeMobileNav} = renderInDrawer(
+      <XDSSideNavItem
+        label="Settings"
+        icon={StubIcon}
+        collapsible
+        data-testid="parent">
+        <XDSSideNavItem label="General" href="/settings/general" />
+      </XDSSideNavItem>,
+    );
+    await user.click(screen.getByTestId('parent'));
+    expect(closeMobileNav).not.toHaveBeenCalled();
+  });
+
+  it('does NOT close when not inside a drawer', async () => {
+    const user = userEvent.setup();
+    const closeMobileNav = vi.fn();
+    render(
+      <XDSAppShellMobileContext.Provider
+        value={{
+          isMobile: false,
+          isMobileNavOpen: false,
+          toggleMobileNav: vi.fn(),
+          openMobileNav: vi.fn(),
+          closeMobileNav,
+          isMobileNavEnabled: false,
+          hasAutoToggle: true,
+        }}>
+        <XDSSideNavItem label="Home" href="/" data-testid="item" />
+      </XDSAppShellMobileContext.Provider>,
+    );
+    await user.click(screen.getByTestId('item'));
+    expect(closeMobileNav).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/SideNav/XDSSideNavItem.tsx
+++ b/packages/core/src/SideNav/XDSSideNavItem.tsx
@@ -40,6 +40,8 @@ import {
   XDSSideNavCollapseContext,
 } from './XDSSideNavCollapseContext';
 import {getIcon} from '../Icon/globalIconRegistry';
+import {useXDSSideNavRenderMode} from './XDSSideNavRenderContext';
+import {useXDSAppShellMobile} from '../AppShell/XDSAppShellMobileContext';
 
 // =============================================================================
 // Styles
@@ -247,6 +249,9 @@ export function XDSSideNavItem({
   ref,
 }: XDSSideNavItemProps) {
   const {isCollapsed} = useXDSSideNavCollapse();
+  const renderMode = useXDSSideNavRenderMode();
+  const {closeMobileNav} = useXDSAppShellMobile();
+  const isInDrawer = renderMode === 'drawer' || renderMode === 'drawer-content';
   const id = useId();
   const hasChildren = !!children;
   const LinkComponent = useXDSLinkComponent(as);
@@ -294,6 +299,10 @@ export function XDSSideNavItem({
       return;
     }
     onClick?.(e);
+    // Close the mobile nav when a nav item is activated inside the drawer
+    if (isInDrawer) {
+      closeMobileNav();
+    }
   };
 
   // Hover handlers for collapsed popover (mirrors TopNavMenu pattern)

--- a/packages/core/src/TopNav/XDSTopNavItem.tsx
+++ b/packages/core/src/TopNav/XDSTopNavItem.tsx
@@ -30,6 +30,7 @@ import type {XDSLinkComponentType} from '../Link/types';
 import {useXDSTopNavRenderMode} from './XDSTopNavRenderContext';
 import {navItemStyles, type NavItemSize} from '../NavItem/navItemStyles.stylex';
 import {xdsClassName, mergeProps} from '../utils';
+import {useXDSAppShellMobile} from '../AppShell/XDSAppShellMobileContext';
 
 /**
  * NavItem styles with hover/selected states
@@ -188,11 +189,19 @@ export function XDSTopNavItem({
 }: XDSTopNavItemProps) {
   const LinkComponent = useXDSLinkComponent(as);
   const renderMode = useXDSTopNavRenderMode();
+  const {closeMobileNav} = useXDSAppShellMobile();
 
   // =========================================================================
   // Drawer mode — render as a SideNavItem-style vertical list element
   // =========================================================================
   if (renderMode === 'drawer') {
+    const handleDrawerClick = (e: React.MouseEvent) => {
+      if (isDisabled) return;
+      // Forward the original onClick if present
+      (props as {onClick?: (e: React.MouseEvent) => void}).onClick?.(e);
+      closeMobileNav();
+    };
+
     return (
       <LinkComponent
         ref={ref}
@@ -213,7 +222,8 @@ export function XDSTopNavItem({
           className,
           style,
         )}
-        {...props}>
+        {...props}
+        onClick={handleDrawerClick}>
         {icon}
         {!isIconOnly && (children ?? label)}
       </LinkComponent>

--- a/packages/core/src/TopNav/XDSTopNavMegaMenuItem.tsx
+++ b/packages/core/src/TopNav/XDSTopNavMegaMenuItem.tsx
@@ -28,6 +28,7 @@ import {useXDSLinkComponent} from '../Link/useXDSLinkComponent';
 import type {XDSLinkComponentType} from '../Link/types';
 import {useXDSTopNavRenderMode} from './XDSTopNavRenderContext';
 import {xdsClassName, mergeProps} from '../utils';
+import {useXDSAppShellMobile} from '../AppShell/XDSAppShellMobileContext';
 
 // =============================================================================
 // Styles
@@ -196,6 +197,7 @@ export function XDSTopNavMegaMenuItem({
 }: XDSTopNavMegaMenuItemProps) {
   const renderMode = useXDSTopNavRenderMode();
   const LinkComponent = useXDSLinkComponent(as);
+  const {closeMobileNav} = useXDSAppShellMobile();
 
   // =========================================================================
   // Drawer mode — matches SideNavItem / TopNavMenu drawer appearance
@@ -203,10 +205,14 @@ export function XDSTopNavMegaMenuItem({
   if (renderMode === 'drawer') {
     const Element = href ? LinkComponent : 'button';
     const elementProps = Element === 'button' ? {type: 'button' as const} : {};
+    const handleDrawerClick = () => {
+      onClick?.();
+      closeMobileNav();
+    };
     return (
       <Element
         href={href}
-        onClick={onClick}
+        onClick={handleDrawerClick}
         {...elementProps}
         {...mergeProps(
           xdsClassName('top-nav-mega-menu-item', {mode: 'drawer'}),

--- a/packages/core/src/TopNav/XDSTopNavMenu.tsx
+++ b/packages/core/src/TopNav/XDSTopNavMenu.tsx
@@ -28,6 +28,7 @@ import {xdsClassName, mergeProps} from '../utils';
 import {navItemStyles} from '../NavItem/navItemStyles.stylex';
 import {useTopNavSlot} from './TopNavContext';
 import {useXDSTopNavRenderMode} from './XDSTopNavRenderContext';
+import {useXDSAppShellMobile} from '../AppShell/XDSAppShellMobileContext';
 import {
   colorVars,
   spacingVars,
@@ -317,6 +318,7 @@ export function XDSTopNavMenu({
   hideDelay = 200,
 }: XDSTopNavMenuProps) {
   const renderMode = useXDSTopNavRenderMode();
+  const {closeMobileNav} = useXDSAppShellMobile();
   const [drawerExpanded, setDrawerExpanded] = useState(false);
   const menuId = useId();
 
@@ -355,7 +357,10 @@ export function XDSTopNavMenu({
               <a
                 key={i}
                 href={item.href}
-                onClick={item.onClick}
+                onClick={e => {
+                  item.onClick?.();
+                  closeMobileNav();
+                }}
                 {...stylex.props(navItemStyles.item, drawerStyles.item)}>
                 {item.icon && (
                   <span {...stylex.props(drawerStyles.itemIcon)}>


### PR DESCRIPTION
## Summary

When a nav item is activated (clicked) inside the mobile nav drawer, the drawer now automatically closes. Previously, navigating from the mobile drawer left it open — the user had to manually dismiss it.

## Changes

- **SideNavItem** — detects drawer context via `useXDSSideNavRenderMode()` and calls `closeMobileNav()` on activation. Collapsible parent toggles are excluded (they just expand/collapse children, not navigate).
- **TopNavItem** — same behavior in drawer mode via `useXDSTopNavRenderMode()`.
- **TopNavMenu** — drawer-mode menu items close the drawer on click.
- **TopNavMegaMenuItem** — same treatment in drawer mode.

All components read `closeMobileNav()` from the existing `AppShellMobileContext`. Outside of an AppShell (or when not in a drawer), the default context is a no-op — no behavioral change.

## Tests

Added 4 tests covering:
- Link item click closes mobile nav ✓
- Button item click closes mobile nav ✓  
- Collapsible parent toggle does NOT close ✓
- Items outside a drawer do NOT trigger close ✓

---
