### PR TITLE
fix(TextInput, TextArea): default value to empty string

### DIFF
--- a/packages/core/src/TextArea/XDSTextArea.tsx
+++ b/packages/core/src/TextArea/XDSTextArea.tsx
@@ -264,7 +264,7 @@ export function XDSTextArea({
   onChange,
   onChangeAction,
   isLoading = false,
-  value,
+  value = '',
   placeholder,
   rows = 3,
   isDisabled = false,

--- a/packages/core/src/TextInput/XDSTextInput.test.tsx
+++ b/packages/core/src/TextInput/XDSTextInput.test.tsx
@@ -52,6 +52,12 @@ describe('XDSTextInput', () => {
     expect(setValue).toHaveBeenCalledWith('A', expect.any(Object));
   });
 
+  it('renders empty string when value is undefined', () => {
+    // @ts-expect-error — testing runtime safety when value is omitted
+    render(<XDSTextInput label="Name" onChange={() => {}} />);
+    expect(screen.getByRole('textbox')).toHaveValue('');
+  });
+
   it('displays controlled value', () => {
     render(
       <XDSTextInput

--- a/packages/core/src/TextInput/XDSTextInput.tsx
+++ b/packages/core/src/TextInput/XDSTextInput.tsx
@@ -241,7 +241,7 @@ export function XDSTextInput({
   onChange,
   onChangeAction,
   isLoading = false,
-  value,
+  value = '',
   placeholder,
   labelTooltip,
   hasClear = false,


### PR DESCRIPTION
When `<XDSTextInput>` or `<XDSTextArea>` is rendered without a `value` prop, `String(undefined)` produces the literal text `"undefined"` in the input.

**Fix:** Default `value` to `''` in the destructuring for both components. The prop is typed as required (`value: string`), but TypeScript types don't exist at runtime — this makes the component defensive against omitted props.

**Changes:**
- `XDSTextInput.tsx` — `value = ''` default
- `XDSTextArea.tsx` — `value = ''` default
- `XDSTextInput.test.tsx` — regression test for undefined value