### PR TITLE
feat(lab): radial charts + 3D charts + useXDSChartRange

### DIFF
--- a/apps/storybook/stories/RadialChart.stories.tsx
+++ b/apps/storybook/stories/RadialChart.stories.tsx
@@ -1,0 +1,160 @@
+import type {Meta, StoryObj} from '@storybook/react';
+import {
+  XDSRadialChart,
+  XDSRadialGrid,
+  XDSRadialArea,
+  XDSRadialAxis,
+  XDSRadialSlice,
+  XDSChartLegend,
+  useXDSChartColors,
+} from '@xds/lab';
+import {XDSStack, XDSText} from '@xds/core';
+import {XDSHeading} from '@xds/core/Text';
+
+const meta: Meta = {
+  title: 'Lab/XDSRadialChart',
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+// Spider data — each row is a "model" with values per axis
+const spiderData = [
+  {
+    model: 'Model A',
+    speed: 85,
+    handling: 70,
+    comfort: 90,
+    safety: 95,
+    efficiency: 60,
+  },
+  {
+    model: 'Model B',
+    speed: 70,
+    handling: 95,
+    comfort: 60,
+    safety: 80,
+    efficiency: 85,
+  },
+  {
+    model: 'Model C',
+    speed: 95,
+    handling: 60,
+    comfort: 75,
+    safety: 70,
+    efficiency: 90,
+  },
+];
+
+/** Spider/radar chart comparing three models across five dimensions */
+export const SpiderChart: StoryObj = {
+  render: () => {
+    const colors = useXDSChartColors();
+    const c = colors.categorical(3);
+    return (
+      <XDSStack direction="vertical" gap={4}>
+        <XDSHeading level={3}>Spider Chart</XDSHeading>
+        <XDSRadialChart
+          data={spiderData}
+          axes={['speed', 'handling', 'comfort', 'safety', 'efficiency']}
+          height={400}>
+          <XDSRadialGrid rings={5} />
+          <XDSRadialArea dataKey="Model A" color={c[0]} dots />
+          <XDSRadialArea dataKey="Model B" color={c[1]} dots />
+          <XDSRadialArea dataKey="Model C" color={c[2]} dots />
+          <XDSRadialAxis />
+          <XDSChartLegend
+            items={[
+              {label: 'Model A', color: c[0]},
+              {label: 'Model B', color: c[1]},
+              {label: 'Model C', color: c[2]},
+            ]}
+          />
+        </XDSRadialChart>
+      </XDSStack>
+    );
+  },
+};
+
+// Pie data
+const pieData = [
+  {region: 'North America', revenue: 42},
+  {region: 'Europe', revenue: 28},
+  {region: 'Asia Pacific', revenue: 18},
+  {region: 'Latin America', revenue: 8},
+  {region: 'Africa', revenue: 4},
+];
+
+/** Pie chart — revenue by region */
+export const PieChart: StoryObj = {
+  render: () => {
+    const colors = useXDSChartColors();
+    return (
+      <XDSStack direction="vertical" gap={4}>
+        <XDSHeading level={3}>Pie Chart</XDSHeading>
+        <XDSRadialChart
+          data={pieData}
+          valueKey="revenue"
+          labelKey="region"
+          height={400}>
+          <XDSRadialSlice colors={colors.categorical(5)} />
+          <XDSChartLegend
+            items={pieData.map((d, i) => ({
+              label: d.region,
+              color: colors.categorical(5)[i],
+            }))}
+          />
+        </XDSRadialChart>
+      </XDSStack>
+    );
+  },
+};
+
+/** Donut chart — same data with inner radius */
+export const DonutChart: StoryObj = {
+  render: () => {
+    const colors = useXDSChartColors();
+    return (
+      <XDSStack direction="vertical" gap={4}>
+        <XDSHeading level={3}>Donut Chart</XDSHeading>
+        <XDSRadialChart
+          data={pieData}
+          valueKey="revenue"
+          labelKey="region"
+          innerRadius={0.55}
+          height={400}>
+          <XDSRadialSlice colors={colors.categorical(5)} />
+          <XDSChartLegend
+            items={pieData.map((d, i) => ({
+              label: d.region,
+              color: colors.categorical(5)[i],
+            }))}
+          />
+        </XDSRadialChart>
+      </XDSStack>
+    );
+  },
+};
+
+/** Spider with donut center */
+export const SpiderDonut: StoryObj = {
+  render: () => {
+    const colors = useXDSChartColors();
+    const c = colors.categorical(2);
+    return (
+      <XDSStack direction="vertical" gap={4}>
+        <XDSHeading level={3}>Spider with Inner Radius</XDSHeading>
+        <XDSRadialChart
+          data={spiderData}
+          axes={['speed', 'handling', 'comfort', 'safety', 'efficiency']}
+          innerRadius={0.2}
+          height={400}>
+          <XDSRadialGrid rings={4} />
+          <XDSRadialArea dataKey="Model A" color={c[0]} dots />
+          <XDSRadialArea dataKey="Model B" color={c[1]} dots />
+          <XDSRadialAxis />
+        </XDSRadialChart>
+      </XDSStack>
+    );
+  },
+};

--- a/apps/storybook/stories/ThreeDChart.stories.tsx
+++ b/apps/storybook/stories/ThreeDChart.stories.tsx
@@ -1,0 +1,155 @@
+import type {Meta, StoryObj} from '@storybook/react';
+import {
+  XDS3DChart,
+  XDS3DScatter,
+  XDS3DBar,
+  XDS3DGrid,
+  XDS3DAxis,
+  XDS3DSurface,
+  XDSChartLegend,
+  useXDSChartColors,
+} from '@xds/lab';
+import {XDSStack, XDSText} from '@xds/core';
+import {XDSHeading} from '@xds/core/Text';
+
+const meta: Meta = {
+  title: 'Lab/XDS3DChart',
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+// Random 3D scatter data
+const scatterData = Array.from({length: 200}, () => ({
+  x: Math.random() * 100,
+  y: Math.random() * 100,
+  z: Math.random() * 100,
+}));
+
+/** 3D scatter plot — drag to rotate */
+export const Scatter3D: StoryObj = {
+  render: () => {
+    const colors = useXDSChartColors();
+    return (
+      <XDSStack direction="vertical" gap={4}>
+        <XDSHeading level={3}>3D Scatter Plot</XDSHeading>
+        <XDSText type="supporting" color="secondary">
+          200 points. Drag to rotate. Depth encoded via size and opacity.
+        </XDSText>
+        <XDS3DChart
+          data={scatterData}
+          xKey="x"
+          yKey="y"
+          zKey="z"
+          height={400}
+          interactive>
+          <XDS3DGrid />
+          <XDS3DAxis />
+          <XDS3DScatter color={colors.categorical(1)[0]} radius={4} />
+        </XDS3DChart>
+      </XDSStack>
+    );
+  },
+};
+
+// 3D bar data — sales by product and region
+const barData = [
+  {product: 0, region: 0, sales: 42},
+  {product: 1, region: 0, sales: 58},
+  {product: 2, region: 0, sales: 35},
+  {product: 0, region: 1, sales: 65},
+  {product: 1, region: 1, sales: 48},
+  {product: 2, region: 1, sales: 72},
+  {product: 0, region: 2, sales: 30},
+  {product: 1, region: 2, sales: 55},
+  {product: 2, region: 2, sales: 40},
+];
+
+/** 3D bar chart — drag to rotate */
+export const Bar3D: StoryObj = {
+  render: () => {
+    const colors = useXDSChartColors();
+    return (
+      <XDSStack direction="vertical" gap={4}>
+        <XDSHeading level={3}>3D Bar Chart</XDSHeading>
+        <XDSText type="supporting" color="secondary">
+          Sales by product x region. Drag to rotate.
+        </XDSText>
+        <XDS3DChart
+          data={barData}
+          xKey="product"
+          yKey="sales"
+          zKey="region"
+          height={400}
+          interactive>
+          <XDS3DGrid divisions={3} />
+          <XDS3DAxis />
+          <XDS3DBar
+            color={colors.categorical(1)[0]}
+            barWidth={0.12}
+            barDepth={0.12}
+          />
+        </XDS3DChart>
+      </XDSStack>
+    );
+  },
+};
+
+// Surface data — math function
+const surfaceData: Record<string, unknown>[] = [];
+for (let x = 0; x <= 20; x++) {
+  for (let z = 0; z <= 20; z++) {
+    const xn = x / 20,
+      zn = z / 20;
+    const y = Math.sin(xn * Math.PI * 2) * Math.cos(zn * Math.PI * 2) * 50 + 50;
+    surfaceData.push({x, y: Math.round(y), z});
+  }
+}
+
+/** 3D surface — height-colored mesh */
+export const Surface3D: StoryObj = {
+  render: () => {
+    const colors = useXDSChartColors();
+    return (
+      <XDSStack direction="vertical" gap={4}>
+        <XDSHeading level={3}>3D Surface</XDSHeading>
+        <XDSText type="supporting" color="secondary">
+          sin(x) * cos(z) surface. Drag to rotate. Color maps to height.
+        </XDSText>
+        <XDS3DChart
+          data={surfaceData}
+          xKey="x"
+          yKey="y"
+          zKey="z"
+          height={450}
+          interactive>
+          <XDS3DGrid />
+          <XDS3DAxis />
+          <XDS3DSurface colorRange={colors.sequential.blue(5)} />
+        </XDS3DChart>
+      </XDSStack>
+    );
+  },
+};
+
+/** 3D surface wireframe */
+export const Wireframe3D: StoryObj = {
+  render: () => {
+    const colors = useXDSChartColors();
+    return (
+      <XDSStack direction="vertical" gap={4}>
+        <XDSHeading level={3}>3D Wireframe</XDSHeading>
+        <XDS3DChart
+          data={surfaceData}
+          xKey="x"
+          yKey="y"
+          zKey="z"
+          height={450}
+          interactive>
+          <XDS3DGrid />
+          <XDS3DSurface colorRange={colors.sequential.teal(5)} wireframe />
+        </XDS3DChart>
+      </XDSStack>
+    );
+  },
+};

--- a/apps/storybook/stories/useXDSChartRange.stories.tsx
+++ b/apps/storybook/stories/useXDSChartRange.stories.tsx
@@ -1,0 +1,184 @@
+import type {Meta, StoryObj} from '@storybook/react';
+import {useRef, useEffect} from 'react';
+import {
+  XDSChart,
+  XDSChartAxis,
+  XDSChartGrid,
+  XDSChartStreamGL,
+  useXDSChartColors,
+  useXDSChartRange,
+  type XDSChartStreamGLHandle,
+} from '@xds/lab';
+import {XDSStack, XDSText} from '@xds/core';
+import {XDSHeading} from '@xds/core/Text';
+
+const meta: Meta = {
+  title: 'Lab/useXDSChartRange',
+};
+
+export default meta;
+
+/** Known y-range — useXDSChartRange just manages the sliding x window */
+export const KnownRange: StoryObj = {
+  render: () => {
+    const colors = useXDSChartColors();
+    const streamRef = useRef<XDSChartStreamGLHandle>(null);
+    const tRef = useRef(0);
+    const {xDomain, yDomain, push} = useXDSChartRange({
+      xWindow: 300,
+      yDomain: [0, 100],
+    });
+
+    useEffect(() => {
+      const id = setInterval(() => {
+        tRef.current += 1;
+        const y =
+          Math.sin(tRef.current * 0.04) * 30 + 50 + (Math.random() - 0.5) * 10;
+        push(tRef.current, y, streamRef);
+      }, 33);
+      return () => clearInterval(id);
+    }, [push]);
+
+    return (
+      <XDSStack direction="vertical" gap={4}>
+        <XDSHeading level={3}>Known Range (0-100%)</XDSHeading>
+        <XDSText type="supporting" color="secondary">
+          yDomain fixed at [0, 100]. useXDSChartRange manages xDomain sliding
+          window.
+        </XDSText>
+        <XDSChart
+          data={[]}
+          xKey="t"
+          yKeys={[]}
+          xDomain={xDomain}
+          yDomain={yDomain}
+          height={200}>
+          <XDSChartGrid horizontal />
+          <XDSChartAxis position="bottom" />
+          <XDSChartAxis position="left" />
+          <XDSChartStreamGL
+            ref={streamRef}
+            color={colors.categorical(1)[0]}
+            bufferSize={300}
+            lineWidth={1.5}
+          />
+        </XDSChart>
+      </XDSStack>
+    );
+  },
+};
+
+/** Unknown y-range — auto-tracks from data with 10% padding */
+export const UnknownRange: StoryObj = {
+  render: () => {
+    const colors = useXDSChartColors();
+    const streamRef = useRef<XDSChartStreamGLHandle>(null);
+    const tRef = useRef(0);
+    const {xDomain, yDomain, push} = useXDSChartRange({
+      xWindow: 300,
+      yPadding: 0.1,
+    });
+
+    useEffect(() => {
+      const id = setInterval(() => {
+        tRef.current += 1;
+        // Gradually increasing range to show auto-expansion
+        const amplitude = 10 + tRef.current * 0.05;
+        const y = Math.sin(tRef.current * 0.03) * amplitude + 50;
+        push(tRef.current, y, streamRef);
+      }, 33);
+      return () => clearInterval(id);
+    }, [push]);
+
+    return (
+      <XDSStack direction="vertical" gap={4}>
+        <XDSHeading level={3}>Unknown Range (auto-tracks)</XDSHeading>
+        <XDSText type="supporting" color="secondary">
+          No fixed yDomain. Range auto-expands as data reveals amplitude.
+          Currently: [{yDomain[0].toFixed(1)}, {yDomain[1].toFixed(1)}]
+        </XDSText>
+        <XDSChart
+          data={[]}
+          xKey="t"
+          yKeys={[]}
+          xDomain={xDomain}
+          yDomain={yDomain}
+          height={200}>
+          <XDSChartGrid horizontal />
+          <XDSChartAxis position="bottom" />
+          <XDSChartAxis position="left" />
+          <XDSChartStreamGL
+            ref={streamRef}
+            color={colors.categorical(2)[1]}
+            bufferSize={300}
+            lineWidth={1.5}
+          />
+        </XDSChart>
+      </XDSStack>
+    );
+  },
+};
+
+/** Zero-centered — seismograph pattern with yCenter */
+export const ZeroCentered: StoryObj = {
+  render: () => {
+    const colors = useXDSChartColors();
+    const streamRef = useRef<XDSChartStreamGLHandle>(null);
+    const tRef = useRef(0);
+    const quakeRef = useRef(0);
+    const {xDomain, yDomain, push} = useXDSChartRange({
+      xWindow: 600,
+      yCenter: true,
+      yPadding: 0.05,
+    });
+
+    useEffect(() => {
+      let raf: number;
+      const tick = () => {
+        tRef.current += 1;
+        if (Math.random() < 0.003) quakeRef.current = 30 + Math.random() * 50;
+        quakeRef.current *= 0.97;
+        const tremor = (Math.random() - 0.5) * 2;
+        const quake =
+          quakeRef.current > 0.5
+            ? Math.sin(tRef.current * 0.5) *
+              quakeRef.current *
+              (0.5 + Math.random() * 0.5)
+            : 0;
+        push(tRef.current, tremor + quake, streamRef);
+        raf = requestAnimationFrame(tick);
+      };
+      raf = requestAnimationFrame(tick);
+      return () => cancelAnimationFrame(raf);
+    }, [push]);
+
+    return (
+      <XDSStack direction="vertical" gap={4}>
+        <XDSHeading level={3}>Zero-Centered (seismograph)</XDSHeading>
+        <XDSText type="supporting" color="secondary">
+          yCenter=true keeps 0 at center. Range auto-expands on quake bursts.
+          Currently: [{yDomain[0].toFixed(1)}, {yDomain[1].toFixed(1)}]
+        </XDSText>
+        <XDSChart
+          data={[]}
+          xKey="t"
+          yKeys={[]}
+          xDomain={xDomain}
+          yDomain={yDomain}
+          yBaseline="zero"
+          height={220}>
+          <XDSChartGrid horizontal />
+          <XDSChartAxis position="bottom" />
+          <XDSChartAxis position="left" />
+          <XDSChartStreamGL
+            ref={streamRef}
+            color={colors.categorical(5)[3]}
+            bufferSize={600}
+            lineWidth={1}
+            opacity={0.9}
+          />
+        </XDSChart>
+      </XDSStack>
+    );
+  },
+};

--- a/packages/lab/src/Chart/XDSChart.tsx
+++ b/packages/lab/src/Chart/XDSChart.tsx
@@ -198,6 +198,11 @@ export function XDSChart({
     <div ref={containerRef} style={{width: '100%'}}>
       {containerWidth > 0 && (
         <svg width={containerWidth} height={height}>
+          <defs>
+            <clipPath id="xds-chart-plot">
+              <rect x={0} y={0} width={innerWidth} height={innerHeight} />
+            </clipPath>
+          </defs>
           <g transform={`translate(${margin.left},${margin.top})`}>
             <ChartProvider value={ctx}>{children}</ChartProvider>
           </g>

--- a/packages/lab/src/Chart/XDSChartAxis.tsx
+++ b/packages/lab/src/Chart/XDSChartAxis.tsx
@@ -82,7 +82,7 @@ export function XDSChartAxis({
         x2={isHorizontal ? width : 0}
         y1={isHorizontal ? 0 : 0}
         y2={isHorizontal ? 0 : height}
-        stroke="var(--color-border)"
+        stroke="var(--color-border-emphasized)"
         strokeWidth={1}
       />
       {ticks.map(({value, offset}) => {
@@ -102,7 +102,11 @@ export function XDSChartAxis({
                 transition: tickTransition,
                 opacity: isVisible ? 1 : 0,
               }}>
-              <line y2={y} stroke="var(--color-border)" strokeWidth={1} />
+              <line
+                y2={y}
+                stroke="var(--color-border-emphasized)"
+                strokeWidth={1}
+              />
               <text
                 y={position === 'bottom' ? tickSize + 12 : -(tickSize + 4)}
                 textAnchor="middle"
@@ -123,7 +127,11 @@ export function XDSChartAxis({
               transition: tickTransition,
               opacity: isVisible ? 1 : 0,
             }}>
-            <line x2={x} stroke="var(--color-border)" strokeWidth={1} />
+            <line
+              x2={x}
+              stroke="var(--color-border-emphasized)"
+              strokeWidth={1}
+            />
             <text
               x={position === 'left' ? -(tickSize + 4) : tickSize + 4}
               dy="0.32em"

--- a/packages/lab/src/Chart/XDSChartDotGL.tsx
+++ b/packages/lab/src/Chart/XDSChartDotGL.tsx
@@ -183,7 +183,12 @@ export function XDSChartDotGL({
   if (width <= 0 || height <= 0) return null;
 
   return (
-    <foreignObject x={0} y={0} width={width} height={height}>
+    <foreignObject
+      x={0}
+      y={0}
+      width={width}
+      height={height}
+      style={{overflow: 'hidden'}}>
       <canvas
         ref={canvasRef}
         style={{

--- a/packages/lab/src/Chart/XDSChartDotGLInteractive.tsx
+++ b/packages/lab/src/Chart/XDSChartDotGLInteractive.tsx
@@ -422,7 +422,12 @@ export function XDSChartDotGLInteractive({
   return (
     <g>
       {/* Visible WebGL canvas */}
-      <foreignObject x={0} y={0} width={width} height={height}>
+      <foreignObject
+        x={0}
+        y={0}
+        width={width}
+        height={height}
+        style={{overflow: 'hidden'}}>
         <canvas
           ref={visCanvasRef}
           style={{width, height, pointerEvents: 'none'}}

--- a/packages/lab/src/Chart/XDSChartHeatmapGL.tsx
+++ b/packages/lab/src/Chart/XDSChartHeatmapGL.tsx
@@ -257,7 +257,12 @@ export function XDSChartHeatmapGL({
   if (width <= 0 || height <= 0) return null;
 
   return (
-    <foreignObject x={0} y={0} width={width} height={height}>
+    <foreignObject
+      x={0}
+      y={0}
+      width={width}
+      height={height}
+      style={{overflow: 'hidden'}}>
       <canvas ref={canvasRef} style={{width, height, pointerEvents: 'none'}} />
     </foreignObject>
   );

--- a/packages/lab/src/Chart/XDSChartStreamGL.tsx
+++ b/packages/lab/src/Chart/XDSChartStreamGL.tsx
@@ -230,7 +230,12 @@ export const XDSChartStreamGL = forwardRef<
   if (width <= 0 || height <= 0) return null;
 
   return (
-    <foreignObject x={0} y={0} width={width} height={height}>
+    <foreignObject
+      x={0}
+      y={0}
+      width={width}
+      height={height}
+      style={{overflow: 'hidden'}}>
       <canvas ref={canvasRef} style={{width, height, pointerEvents: 'none'}} />
     </foreignObject>
   );

--- a/packages/lab/src/Chart/getXDSChartColors.ts
+++ b/packages/lab/src/Chart/getXDSChartColors.ts
@@ -45,6 +45,13 @@ export interface XDSChartColorsAPI {
     warning: string;
     neutral: string;
   };
+  /** Structural colors for chart chrome — axes, grid, ticks, labels */
+  structural: {
+    axis: string;
+    grid: string;
+    tick: string;
+    label: string;
+  };
   alpha(hex: string, opacity: number): string;
 }
 
@@ -169,6 +176,13 @@ export function getXDSChartColorsFromResolver(
       negative: resolve('--color-data-categorical-red'),
       warning: resolve('--color-data-categorical-orange'),
       neutral: resolve('--color-data-neutral'),
+    },
+
+    structural: {
+      axis: resolve('--color-border-emphasized'),
+      grid: resolve('--color-border'),
+      tick: resolve('--color-border-emphasized'),
+      label: resolve('--color-text-secondary'),
     },
 
     alpha: hexAlpha,

--- a/packages/lab/src/Chart/index.ts
+++ b/packages/lab/src/Chart/index.ts
@@ -42,3 +42,8 @@ export {
   type SequentialHue,
   type TokenResolver,
 } from './getXDSChartColors';
+export {
+  useXDSChartRange,
+  type UseXDSChartRangeOptions,
+  type UseXDSChartRangeReturn,
+} from './useXDSChartRange';

--- a/packages/lab/src/Chart/useXDSChartRange.test.ts
+++ b/packages/lab/src/Chart/useXDSChartRange.test.ts
@@ -1,0 +1,99 @@
+import {describe, it, expect} from 'vitest';
+import {renderHook, act} from '@testing-library/react';
+import {useXDSChartRange} from './useXDSChartRange';
+
+describe('useXDSChartRange', () => {
+  it('initializes with zero domain', () => {
+    const {result} = renderHook(() => useXDSChartRange({xWindow: 300}));
+    expect(result.current.xDomain).toEqual([0, 0]);
+    expect(result.current.yDomain).toEqual([0, 1]);
+  });
+
+  it('uses fixed yDomain when provided', () => {
+    const {result} = renderHook(() =>
+      useXDSChartRange({xWindow: 300, yDomain: [0, 100]}),
+    );
+    expect(result.current.yDomain).toEqual([0, 100]);
+  });
+
+  it('grows xDomain during warmup then slides', () => {
+    const {result} = renderHook(() => useXDSChartRange({xWindow: 100}));
+
+    // During warmup: [0, x]
+    act(() => {
+      result.current.push(50, 10);
+    });
+    expect(result.current.xDomain).toEqual([0, 50]);
+
+    // Still warmup
+    act(() => {
+      result.current.push(80, 20);
+    });
+    expect(result.current.xDomain).toEqual([0, 80]);
+
+    // Full window: slides
+    act(() => {
+      result.current.push(150, 20);
+    });
+    expect(result.current.xDomain).toEqual([50, 150]);
+  });
+
+  it('auto-tracks y range with padding', () => {
+    const {result} = renderHook(() =>
+      useXDSChartRange({xWindow: 100, yPadding: 0.1}),
+    );
+
+    act(() => {
+      result.current.push(1, 50);
+    });
+    // Single point: range=1 (fallback), pad=0.1
+    expect(result.current.yDomain[0]).toBeLessThan(50);
+    expect(result.current.yDomain[1]).toBeGreaterThan(50);
+
+    act(() => {
+      result.current.push(2, 100);
+    });
+    // Range 50-100, padding 10% = 5
+    expect(result.current.yDomain[0]).toBeCloseTo(45, 0);
+    expect(result.current.yDomain[1]).toBeCloseTo(105, 0);
+  });
+
+  it('does not auto-track y when fixed yDomain is set', () => {
+    const {result} = renderHook(() =>
+      useXDSChartRange({xWindow: 100, yDomain: [0, 100]}),
+    );
+
+    act(() => {
+      result.current.push(1, 200);
+    });
+    expect(result.current.yDomain).toEqual([0, 100]);
+  });
+
+  it('centers y around zero when yCenter is true', () => {
+    const {result} = renderHook(() =>
+      useXDSChartRange({xWindow: 100, yCenter: true, yPadding: 0}),
+    );
+
+    act(() => {
+      result.current.push(1, -30);
+      result.current.push(2, 10);
+    });
+    expect(result.current.yDomain[0]).toBe(-30);
+    expect(result.current.yDomain[1]).toBe(30);
+  });
+
+  it('resets state', () => {
+    const {result} = renderHook(() => useXDSChartRange({xWindow: 200}));
+
+    act(() => {
+      result.current.push(500, 99);
+    });
+    expect(result.current.xDomain[1]).toBe(500);
+
+    act(() => {
+      result.current.reset();
+    });
+    expect(result.current.xDomain).toEqual([0, 0]);
+    expect(result.current.yDomain).toEqual([0, 1]);
+  });
+});

--- a/packages/lab/src/Chart/useXDSChartRange.ts
+++ b/packages/lab/src/Chart/useXDSChartRange.ts
@@ -1,0 +1,144 @@
+/**
+ * @file useXDSChartRange.ts
+ * @output Hook that tracks streaming data ranges and provides domains for XDSChart
+ * @position Helper hook; sits between the data source and XDSChart props
+ *
+ * Manages xDomain/yDomain as state. Domain updates are synchronous with
+ * every push — no throttling. The chart's declared domain must always
+ * match the data being rendered (Tier 1 guarantee).
+ */
+
+import {useState, useRef, useCallback} from 'react';
+import type {XDSChartStreamGLHandle} from './XDSChartStreamGL';
+
+export interface UseXDSChartRangeOptions {
+  /** Sliding window size for x-axis (number of ticks visible). Required. */
+  xWindow: number;
+  /**
+   * Fixed y-axis domain. When provided, y auto-tracking is disabled.
+   * Use when the range is known (e.g. 0-100 for percentages).
+   */
+  yDomain?: [number, number];
+  /**
+   * Padding factor for auto-tracked y-axis (default: 0.1 = 10%).
+   * Applied symmetrically above max and below min.
+   */
+  yPadding?: number;
+  /**
+   * Anchor y=0 in the center of the y-axis (default: false).
+   * When true, y-domain is always symmetric around 0.
+   */
+  yCenter?: boolean;
+}
+
+export interface UseXDSChartRangeReturn {
+  /** Current x-axis domain — pass to XDSChart xDomain prop */
+  xDomain: [number, number];
+  /** Current y-axis domain — pass to XDSChart yDomain prop */
+  yDomain: [number, number];
+  /**
+   * Push a data point. Updates domains synchronously, then optionally
+   * forwards to a stream ref.
+   */
+  push(
+    x: number,
+    y: number,
+    streamRef?: React.RefObject<XDSChartStreamGLHandle | null>,
+  ): void;
+  /** Reset all tracking state */
+  reset(): void;
+}
+
+/**
+ * Tracks streaming data ranges and provides xDomain/yDomain for XDSChart.
+ *
+ * Domain updates are synchronous with every push — no throttling, no lag.
+ * This ensures the chart's declared domain always matches the rendered data.
+ *
+ * @example
+ * ```
+ * const {xDomain, yDomain, push} = useXDSChartRange({xWindow: 300, yPadding: 0.1});
+ *
+ * <XDSChart xDomain={xDomain} yDomain={yDomain} ...>
+ *   <XDSChartStreamGL ref={streamRef} ... />
+ * </XDSChart>
+ * ```
+ */
+export function useXDSChartRange({
+  xWindow,
+  yDomain: fixedYDomain,
+  yPadding = 0.1,
+  yCenter = false,
+}: UseXDSChartRangeOptions): UseXDSChartRangeReturn {
+  const [xDomain, setXDomain] = useState<[number, number]>([0, 0]);
+  const [yDomain, setYDomain] = useState<[number, number]>(
+    fixedYDomain ?? [0, 1],
+  );
+
+  const rangeRef = useRef({
+    yMin: fixedYDomain ? fixedYDomain[0] : Infinity,
+    yMax: fixedYDomain ? fixedYDomain[1] : -Infinity,
+  });
+
+  const push = useCallback(
+    (
+      x: number,
+      y: number,
+      streamRef?: React.RefObject<XDSChartStreamGLHandle | null>,
+    ) => {
+      // Forward to stream
+      streamRef?.current?.push(x, y);
+
+      // x domain: during warmup grow from [0, x], once full slide
+      const xMin = x >= xWindow ? x - xWindow : 0;
+      const xMax = x >= xWindow ? x : Math.max(x, 1);
+      setXDomain([xMin, xMax]);
+
+      // y domain: track min/max, update on every push
+      if (!fixedYDomain) {
+        const r = rangeRef.current;
+        let changed = false;
+        if (y < r.yMin) {
+          r.yMin = y;
+          changed = true;
+        }
+        if (y > r.yMax) {
+          r.yMax = y;
+          changed = true;
+        }
+
+        if (changed) {
+          const range = r.yMax - r.yMin || 1;
+          const pad = range * yPadding;
+          let min = r.yMin - pad;
+          let max = r.yMax + pad;
+
+          if (yCenter) {
+            const abs = Math.max(Math.abs(min), Math.abs(max));
+            min = -abs;
+            max = abs;
+          }
+
+          setYDomain([min, max]);
+        }
+      }
+    },
+    [xWindow, fixedYDomain, yPadding, yCenter],
+  );
+
+  const reset = useCallback(() => {
+    rangeRef.current = {
+      yMin: fixedYDomain ? fixedYDomain[0] : Infinity,
+      yMax: fixedYDomain ? fixedYDomain[1] : -Infinity,
+    };
+    setXDomain([0, 0]);
+    setYDomain(fixedYDomain ?? [0, 1]);
+  }, [fixedYDomain]);
+
+  return {
+    xDomain,
+    yDomain: fixedYDomain ?? yDomain,
+    push,
+    reset,
+  };
+}

--- a/packages/lab/src/Radial/RadialContext.ts
+++ b/packages/lab/src/Radial/RadialContext.ts
@@ -1,0 +1,20 @@
+/**
+ * @file RadialContext.ts
+ * @output React context for radial chart components
+ */
+
+import {createContext, useContext} from 'react';
+import type {RadialContext} from './types';
+
+const RadialCtx = createContext<RadialContext | null>(null);
+
+export const RadialProvider = RadialCtx.Provider;
+
+/** Access the radial chart context. Throws if used outside XDSRadialChart. */
+export function useRadial(): RadialContext {
+  const ctx = useContext(RadialCtx);
+  if (!ctx) {
+    throw new Error('Radial components must be used inside <XDSRadialChart>');
+  }
+  return ctx;
+}

--- a/packages/lab/src/Radial/XDSRadialArea.tsx
+++ b/packages/lab/src/Radial/XDSRadialArea.tsx
@@ -1,0 +1,92 @@
+/**
+ * @file XDSRadialArea.tsx
+ * @output Renders a spider/radar polygon for a dataset
+ */
+
+import {useMemo} from 'react';
+import {useRadial} from './RadialContext';
+
+export interface XDSRadialAreaProps {
+  /** Key identifying which dataset row to plot (matches a value in data) */
+  dataKey: string;
+  /** Fill color */
+  color: string;
+  /** Fill opacity (default: 0.2) */
+  opacity?: number;
+  /** Stroke width (default: 2) */
+  strokeWidth?: number;
+  /** Show dots at vertices */
+  dots?: boolean;
+  /** Dot radius */
+  dotRadius?: number;
+}
+
+/**
+ * Spider/radar polygon. Reads axis definitions and scales from radial context.
+ * Each axis value is normalized to [0,1] within its domain, then mapped to radius.
+ *
+ * @example
+ * ```
+ * <XDSRadialArea dataKey="modelA" color={colors[0]} dots />
+ * ```
+ */
+export function XDSRadialArea({
+  dataKey,
+  color,
+  opacity = 0.2,
+  strokeWidth = 2,
+  dots = false,
+  dotRadius = 4,
+}: XDSRadialAreaProps) {
+  const {cx, cy, data, axes, angleByAxis, radiusScale, axisDomains} =
+    useRadial();
+
+  const points = useMemo(() => {
+    if (!axes || !angleByAxis || !radiusScale || !axisDomains) return [];
+
+    // Find the data row matching this key
+    // dataKey matches a value in the first non-axis field, or we use the index
+    const datum =
+      data.find(d => {
+        // Check if any string field matches dataKey
+        return Object.values(d).some(v => v === dataKey);
+      }) ?? data[0];
+
+    if (!datum) return [];
+
+    return axes.map(key => {
+      const angle = angleByAxis.get(key)!;
+      const domain = axisDomains.get(key)!;
+      const raw = typeof datum[key] === 'number' ? (datum[key] as number) : 0;
+      const [min, max] = domain;
+      const t = max > min ? (raw - min) / (max - min) : 0;
+      const r = radiusScale(Math.max(0, Math.min(1, t)));
+      return {
+        x: cx + Math.cos(angle) * r,
+        y: cy + Math.sin(angle) * r,
+        key,
+      };
+    });
+  }, [cx, cy, data, dataKey, axes, angleByAxis, radiusScale, axisDomains]);
+
+  if (points.length === 0) return null;
+
+  const pathPoints = points.map(p => `${p.x},${p.y}`).join(' ');
+
+  return (
+    <g>
+      <polygon
+        points={pathPoints}
+        fill={color}
+        fillOpacity={opacity}
+        stroke={color}
+        strokeWidth={strokeWidth}
+        strokeLinejoin="round"
+      />
+      {dots &&
+        points.map(p => (
+          <circle key={p.key} cx={p.x} cy={p.y} r={dotRadius} fill={color} />
+        ))}
+    </g>
+  );
+}

--- a/packages/lab/src/Radial/XDSRadialAxis.tsx
+++ b/packages/lab/src/Radial/XDSRadialAxis.tsx
@@ -1,0 +1,53 @@
+/**
+ * @file XDSRadialAxis.tsx
+ * @output Renders axis labels at each spider vertex
+ */
+
+import {useRadial} from './RadialContext';
+
+export interface XDSRadialAxisProps {
+  /** Label offset from the outer ring in pixels (default: 16) */
+  labelOffset?: number;
+}
+
+/**
+ * Axis labels positioned at each spider chart vertex.
+ *
+ * @example
+ * ```
+ * <XDSRadialAxis />
+ * ```
+ */
+export function XDSRadialAxis({labelOffset = 16}: XDSRadialAxisProps) {
+  const {cx, cy, radius, axes, angleByAxis} = useRadial();
+
+  if (!axes || !angleByAxis) return null;
+
+  return (
+    <g>
+      {axes.map(key => {
+        const angle = angleByAxis.get(key)!;
+        const x = cx + Math.cos(angle) * (radius + labelOffset);
+        const y = cy + Math.sin(angle) * (radius + labelOffset);
+
+        // Determine text anchor based on position
+        const isRight = Math.cos(angle) > 0.1;
+        const isLeft = Math.cos(angle) < -0.1;
+        const anchor = isRight ? 'start' : isLeft ? 'end' : 'middle';
+
+        return (
+          <text
+            key={key}
+            x={x}
+            y={y}
+            textAnchor={anchor}
+            dominantBaseline="central"
+            fill="var(--color-text-secondary)"
+            fontSize={12}>
+            {key}
+          </text>
+        );
+      })}
+    </g>
+  );
+}

--- a/packages/lab/src/Radial/XDSRadialChart.tsx
+++ b/packages/lab/src/Radial/XDSRadialChart.tsx
@@ -1,0 +1,197 @@
+/**
+ * @file XDSRadialChart.tsx
+ * @output Root radial chart container — spider, pie, donut
+ * @position Parent component; all radial marks read from its context
+ *
+ * Owns the radial coordinate space: center, radius, angle/radius scales.
+ * Same Tier 1 guarantee as XDSChart — all children map through the same context.
+ */
+
+import {
+  type ReactNode,
+  useMemo,
+  useRef,
+  useState,
+  useLayoutEffect,
+} from 'react';
+import {RadialProvider} from './RadialContext';
+import type {RadialMode} from './types';
+
+export interface XDSRadialChartProps {
+  /** The dataset */
+  data: Record<string, unknown>[];
+  /** Chart height in pixels. Width is responsive. */
+  height?: number;
+  /**
+   * Spider mode: array of axis keys (each key is a dimension).
+   * When provided, the chart operates in spider mode.
+   */
+  axes?: string[];
+  /**
+   * Pie/donut mode: data key containing the numeric value for each slice.
+   * When provided (without axes), the chart operates in pie mode.
+   */
+  valueKey?: string;
+  /**
+   * Pie/donut mode: data key for the slice label.
+   */
+  labelKey?: string;
+  /**
+   * Inner radius as a fraction of outer radius (0-1).
+   * 0 = full pie/spider, 0.6 = donut. Default: 0.
+   */
+  innerRadius?: number;
+  /**
+   * Padding between pie slices in radians. Default: 0.02.
+   */
+  padAngle?: number;
+  /** Chart contents */
+  children: ReactNode;
+}
+
+/**
+ * Root radial chart container. Computes angular/radial scales and provides
+ * them to children via context.
+ *
+ * @example
+ * ```
+ * // Spider
+ * <XDSRadialChart data={data} axes={['speed', 'handling', 'comfort']} height={400}>
+ *   <XDSRadialGrid rings={5} />
+ *   <XDSRadialArea dataKey="modelA" color={colors[0]} />
+ *   <XDSRadialAxis />
+ * </XDSRadialChart>
+ *
+ * // Pie
+ * <XDSRadialChart data={data} valueKey="revenue" labelKey="region" height={400}>
+ *   <XDSRadialSlice />
+ * </XDSRadialChart>
+ *
+ * // Donut
+ * <XDSRadialChart data={data} valueKey="revenue" labelKey="region" innerRadius={0.6} height={400}>
+ *   <XDSRadialSlice />
+ * </XDSRadialChart>
+ * ```
+ */
+export function XDSRadialChart({
+  data,
+  height = 400,
+  axes,
+  valueKey,
+  labelKey,
+  innerRadius: innerRadiusFraction = 0,
+  padAngle = 0.02,
+  children,
+}: XDSRadialChartProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [containerWidth, setContainerWidth] = useState(0);
+
+  useLayoutEffect(() => {
+    if (!containerRef.current) return;
+    const observer = new ResizeObserver(entries => {
+      const entry = entries[0];
+      if (entry) setContainerWidth(entry.contentRect.width);
+    });
+    observer.observe(containerRef.current);
+    return () => observer.disconnect();
+  }, []);
+
+  const size = Math.min(containerWidth, height);
+  const cx = containerWidth / 2;
+  const cy = height / 2;
+  const outerRadius = size / 2 - 40; // leave room for labels
+  const innerRadiusPx = outerRadius * innerRadiusFraction;
+
+  const mode: RadialMode = axes ? 'spider' : 'pie';
+
+  // Spider: compute axis angles and domains
+  const spiderCtx = useMemo(() => {
+    if (!axes || axes.length === 0) return {};
+
+    const angleByAxis = new Map<string, number>();
+    const step = (2 * Math.PI) / axes.length;
+    axes.forEach((key, i) => {
+      // Start from top (-PI/2) and go clockwise
+      angleByAxis.set(key, -Math.PI / 2 + step * i);
+    });
+
+    // Compute domain per axis
+    const axisDomains = new Map<string, [number, number]>();
+    for (const key of axes) {
+      let min = Infinity;
+      let max = -Infinity;
+      for (const d of data) {
+        const v = d[key];
+        if (typeof v === 'number') {
+          if (v < min) min = v;
+          if (v > max) max = v;
+        }
+      }
+      // Include 0 as floor
+      if (min > 0) min = 0;
+      axisDomains.set(key, [min, max]);
+    }
+
+    const radiusScale = (t: number) =>
+      innerRadiusPx + t * (outerRadius - innerRadiusPx);
+
+    return {axes, angleByAxis, radiusScale, axisDomains};
+  }, [axes, data, outerRadius, innerRadiusPx]);
+
+  // Pie: compute slices
+  const pieCtx = useMemo(() => {
+    if (!valueKey) return {};
+
+    const total = data.reduce((sum, d) => {
+      const v = d[valueKey];
+      return sum + (typeof v === 'number' ? v : 0);
+    }, 0);
+
+    if (total === 0) return {slices: []};
+
+    const totalPad = padAngle * data.length;
+    const available = 2 * Math.PI - totalPad;
+    let currentAngle = -Math.PI / 2; // start from top
+
+    const slices = data.map(d => {
+      const v = typeof d[valueKey] === 'number' ? (d[valueKey] as number) : 0;
+      const percentage = v / total;
+      const sweep = percentage * available;
+      const slice = {
+        key: labelKey ? String(d[labelKey]) : String(v),
+        value: v,
+        startAngle: currentAngle,
+        endAngle: currentAngle + sweep,
+        percentage,
+      };
+      currentAngle += sweep + padAngle;
+      return slice;
+    });
+
+    return {slices};
+  }, [data, valueKey, labelKey, padAngle]);
+
+  const ctx = useMemo(
+    () => ({
+      cx,
+      cy,
+      radius: outerRadius,
+      innerRadius: innerRadiusPx,
+      data,
+      mode,
+      ...spiderCtx,
+      ...pieCtx,
+    }),
+    [cx, cy, outerRadius, innerRadiusPx, data, mode, spiderCtx, pieCtx],
+  );
+
+  return (
+    <div ref={containerRef} style={{width: '100%'}}>
+      {containerWidth > 0 && (
+        <svg width={containerWidth} height={height}>
+          <RadialProvider value={ctx}>{children}</RadialProvider>
+        </svg>
+      )}
+    </div>
+  );
+}

--- a/packages/lab/src/Radial/XDSRadialGrid.tsx
+++ b/packages/lab/src/Radial/XDSRadialGrid.tsx
@@ -1,0 +1,70 @@
+/**
+ * @file XDSRadialGrid.tsx
+ * @output Renders concentric grid rings and axis lines for spider charts
+ */
+
+import {useRadial} from './RadialContext';
+
+export interface XDSRadialGridProps {
+  /** Number of concentric rings (default: 5) */
+  rings?: number;
+}
+
+/**
+ * Concentric grid rings and axis lines for spider charts.
+ *
+ * @example
+ * ```
+ * <XDSRadialGrid rings={5} />
+ * ```
+ */
+export function XDSRadialGrid({rings = 5}: XDSRadialGridProps) {
+  const {cx, cy, radius, innerRadius, axes, angleByAxis, radiusScale} =
+    useRadial();
+
+  if (!axes || !angleByAxis || !radiusScale) return null;
+
+  return (
+    <g>
+      {/* Concentric rings */}
+      {Array.from({length: rings}, (_, i) => {
+        const t = (i + 1) / rings;
+        const r = radiusScale(t);
+        // Draw polygon ring connecting points at this radius
+        const points = axes
+          .map(key => {
+            const angle = angleByAxis.get(key)!;
+            return `${cx + Math.cos(angle) * r},${cy + Math.sin(angle) * r}`;
+          })
+          .join(' ');
+        return (
+          <polygon
+            key={i}
+            points={points}
+            fill="none"
+            stroke="var(--color-border)"
+            strokeOpacity={0.3}
+            strokeWidth={1}
+          />
+        );
+      })}
+
+      {/* Axis lines from center to each vertex */}
+      {axes.map(key => {
+        const angle = angleByAxis.get(key)!;
+        return (
+          <line
+            key={key}
+            x1={cx + Math.cos(angle) * innerRadius}
+            y1={cy + Math.sin(angle) * innerRadius}
+            x2={cx + Math.cos(angle) * radius}
+            y2={cy + Math.sin(angle) * radius}
+            stroke="var(--color-border)"
+            strokeOpacity={0.3}
+            strokeWidth={1}
+          />
+        );
+      })}
+    </g>
+  );
+}

--- a/packages/lab/src/Radial/XDSRadialSlice.tsx
+++ b/packages/lab/src/Radial/XDSRadialSlice.tsx
@@ -1,0 +1,126 @@
+/**
+ * @file XDSRadialSlice.tsx
+ * @output Renders pie/donut slices from radial context
+ */
+
+import {useRadial} from './RadialContext';
+
+export interface XDSRadialSliceProps {
+  /**
+   * Colors for each slice. Array of hex strings.
+   * Use useXDSChartColors().categorical(n).
+   */
+  colors: string[];
+  /** Corner radius on slice edges (default: 2) */
+  cornerRadius?: number;
+  /** Show percentage labels (default: true) */
+  labels?: boolean;
+  /** Minimum percentage to show a label (default: 5) */
+  labelThreshold?: number;
+}
+
+/** SVG arc path from angles and radii */
+function arcPath(
+  cx: number,
+  cy: number,
+  innerR: number,
+  outerR: number,
+  startAngle: number,
+  endAngle: number,
+): string {
+  const x1 = cx + Math.cos(startAngle) * outerR;
+  const y1 = cy + Math.sin(startAngle) * outerR;
+  const x2 = cx + Math.cos(endAngle) * outerR;
+  const y2 = cy + Math.sin(endAngle) * outerR;
+  const x3 = cx + Math.cos(endAngle) * innerR;
+  const y3 = cy + Math.sin(endAngle) * innerR;
+  const x4 = cx + Math.cos(startAngle) * innerR;
+  const y4 = cy + Math.sin(startAngle) * innerR;
+
+  const sweep = endAngle - startAngle;
+  const largeArc = sweep > Math.PI ? 1 : 0;
+
+  if (innerR === 0) {
+    // Pie slice (triangle-ish)
+    return [
+      `M ${cx} ${cy}`,
+      `L ${x1} ${y1}`,
+      `A ${outerR} ${outerR} 0 ${largeArc} 1 ${x2} ${y2}`,
+      'Z',
+    ].join(' ');
+  }
+
+  // Donut slice (annular sector)
+  return [
+    `M ${x1} ${y1}`,
+    `A ${outerR} ${outerR} 0 ${largeArc} 1 ${x2} ${y2}`,
+    `L ${x3} ${y3}`,
+    `A ${innerR} ${innerR} 0 ${largeArc} 0 ${x4} ${y4}`,
+    'Z',
+  ].join(' ');
+}
+
+/**
+ * Pie/donut slices. Reads slice geometry from radial context.
+ *
+ * @example
+ * ```
+ * <XDSRadialSlice colors={colors.categorical(5)} />
+ * ```
+ */
+export function XDSRadialSlice({
+  colors,
+  cornerRadius = 0,
+  labels = true,
+  labelThreshold = 5,
+}: XDSRadialSliceProps) {
+  const {cx, cy, radius, innerRadius, slices} = useRadial();
+
+  if (!slices || slices.length === 0) return null;
+
+  return (
+    <g>
+      {slices.map((slice, i) => {
+        const color = colors[i % colors.length];
+        const d = arcPath(
+          cx,
+          cy,
+          innerRadius,
+          radius,
+          slice.startAngle,
+          slice.endAngle,
+        );
+
+        // Label position at midpoint of arc, between inner and outer radius
+        const midAngle = (slice.startAngle + slice.endAngle) / 2;
+        const labelR = innerRadius + (radius - innerRadius) * 0.6;
+        const lx = cx + Math.cos(midAngle) * labelR;
+        const ly = cy + Math.sin(midAngle) * labelR;
+        const showLabel = labels && slice.percentage * 100 >= labelThreshold;
+
+        return (
+          <g key={slice.key}>
+            <path
+              d={d}
+              fill={color}
+              stroke="var(--color-background-surface)"
+              strokeWidth={cornerRadius > 0 ? 0 : 1}
+            />
+            {showLabel && (
+              <text
+                x={lx}
+                y={ly}
+                textAnchor="middle"
+                dominantBaseline="central"
+                fill="var(--color-text-primary)"
+                fontSize={12}
+                fontWeight={500}>
+                {Math.round(slice.percentage * 100)}%
+              </text>
+            )}
+          </g>
+        );
+      })}
+    </g>
+  );
+}

--- a/packages/lab/src/Radial/index.ts
+++ b/packages/lab/src/Radial/index.ts
@@ -1,0 +1,7 @@
+export {XDSRadialChart, type XDSRadialChartProps} from './XDSRadialChart';
+export {XDSRadialGrid, type XDSRadialGridProps} from './XDSRadialGrid';
+export {XDSRadialArea, type XDSRadialAreaProps} from './XDSRadialArea';
+export {XDSRadialAxis, type XDSRadialAxisProps} from './XDSRadialAxis';
+export {XDSRadialSlice, type XDSRadialSliceProps} from './XDSRadialSlice';
+export {useRadial} from './RadialContext';
+export type {RadialContext, RadialMode} from './types';

--- a/packages/lab/src/Radial/types.ts
+++ b/packages/lab/src/Radial/types.ts
@@ -1,0 +1,44 @@
+/**
+ * @file types.ts
+ * @output Radial chart types and context
+ * @position Foundation types consumed by all radial sub-components
+ */
+
+/** Radial chart mode */
+export type RadialMode = 'spider' | 'pie';
+
+/** Radial context provided by XDSRadialChart to children */
+export interface RadialContext {
+  /** Center x pixel position */
+  cx: number;
+  /** Center y pixel position */
+  cy: number;
+  /** Outer radius in pixels */
+  radius: number;
+  /** Inner radius in pixels (>0 for donut) */
+  innerRadius: number;
+  /** The full dataset */
+  data: Record<string, unknown>[];
+  /** Chart mode */
+  mode: RadialMode;
+
+  // Spider-specific
+  /** Axis keys for spider charts */
+  axes?: string[];
+  /** Angle for each axis in radians */
+  angleByAxis?: Map<string, number>;
+  /** Radius scale: maps a normalized value (0-1) to pixel distance from center */
+  radiusScale?: (t: number) => number;
+  /** Domain [min, max] per axis for spider normalization */
+  axisDomains?: Map<string, [number, number]>;
+
+  // Pie-specific
+  /** Computed slices with start/end angles */
+  slices?: Array<{
+    key: string;
+    value: number;
+    startAngle: number;
+    endAngle: number;
+    percentage: number;
+  }>;
+}

--- a/packages/lab/src/ThreeD/ThreeDContext.ts
+++ b/packages/lab/src/ThreeD/ThreeDContext.ts
@@ -1,0 +1,20 @@
+/**
+ * @file ThreeDContext.ts
+ * @output React context for 3D chart components
+ */
+
+import {createContext, useContext} from 'react';
+import type {ThreeDContext} from './types';
+
+const ThreeDCtx = createContext<ThreeDContext | null>(null);
+
+export const ThreeDProvider = ThreeDCtx.Provider;
+
+/** Access the 3D chart context. Throws if used outside XDS3DChart. */
+export function use3D(): ThreeDContext {
+  const ctx = useContext(ThreeDCtx);
+  if (!ctx) {
+    throw new Error('3D components must be used inside <XDS3DChart>');
+  }
+  return ctx;
+}

--- a/packages/lab/src/ThreeD/XDS3DAxis.tsx
+++ b/packages/lab/src/ThreeD/XDS3DAxis.tsx
@@ -1,0 +1,84 @@
+/**
+ * @file XDS3DAxis.tsx
+ * @output 3D axis lines with labels at each end
+ */
+
+import {use3D} from './ThreeDContext';
+
+export interface XDS3DAxisProps {
+  /** Show axis labels (default: true) */
+  labels?: boolean;
+}
+
+export function XDS3DAxis({labels = true}: XDS3DAxisProps) {
+  const {project, xKey, yKey, zKey, xDomain, yDomain, zDomain} = use3D();
+
+  const origin = project(0, 0, 0);
+  const xEnd = project(1, 0, 0);
+  const yEnd = project(0, 1, 0);
+  const zEnd = project(0, 0, 1);
+
+  const lineColor = 'var(--color-border-emphasized)';
+  const labelColor = 'var(--color-text-secondary)';
+
+  return (
+    <g>
+      {/* X axis */}
+      <line
+        x1={origin.px}
+        y1={origin.py}
+        x2={xEnd.px}
+        y2={xEnd.py}
+        stroke={lineColor}
+        strokeWidth={1.5}
+      />
+      {/* Y axis */}
+      <line
+        x1={origin.px}
+        y1={origin.py}
+        x2={yEnd.px}
+        y2={yEnd.py}
+        stroke={lineColor}
+        strokeWidth={1.5}
+      />
+      {/* Z axis */}
+      <line
+        x1={origin.px}
+        y1={origin.py}
+        x2={zEnd.px}
+        y2={zEnd.py}
+        stroke={lineColor}
+        strokeWidth={1.5}
+      />
+
+      {labels && (
+        <>
+          <text
+            x={xEnd.px + 8}
+            y={xEnd.py}
+            fill={labelColor}
+            fontSize={11}
+            dominantBaseline="central">
+            {xKey} [{xDomain[0]}-{xDomain[1]}]
+          </text>
+          <text
+            x={yEnd.px + 8}
+            y={yEnd.py}
+            fill={labelColor}
+            fontSize={11}
+            dominantBaseline="central">
+            {yKey} [{yDomain[0]}-{yDomain[1]}]
+          </text>
+          <text
+            x={zEnd.px + 8}
+            y={zEnd.py}
+            fill={labelColor}
+            fontSize={11}
+            dominantBaseline="central">
+            {zKey} [{zDomain[0]}-{zDomain[1]}]
+          </text>
+        </>
+      )}
+    </g>
+  );
+}

--- a/packages/lab/src/ThreeD/XDS3DBar.tsx
+++ b/packages/lab/src/ThreeD/XDS3DBar.tsx
@@ -1,0 +1,128 @@
+/**
+ * @file XDS3DBar.tsx
+ * @output 3D bar chart — projected rectangles with depth shading
+ */
+
+import {useMemo} from 'react';
+import {use3D} from './ThreeDContext';
+
+export interface XDS3DBarProps {
+  color: string;
+  barWidth?: number;
+  barDepth?: number;
+}
+
+export function XDS3DBar({
+  color,
+  barWidth = 0.06,
+  barDepth = 0.06,
+}: XDS3DBarProps) {
+  const {
+    data,
+    xKey,
+    yKey,
+    zKey,
+    project,
+    xDomain,
+    yDomain,
+    zDomain,
+    normalize,
+  } = use3D();
+
+  const bars = useMemo(() => {
+    return data
+      .map((d, i) => {
+        const nx = normalize(d[xKey] as number, xDomain);
+        const ny = normalize(d[yKey] as number, yDomain);
+        const nz = normalize(d[zKey] as number, zDomain);
+        const hw = barWidth / 2;
+        const hd = barDepth / 2;
+
+        // Bar goes from y=0 to y=ny
+        // Four top corners of the bar
+        const topFL = project(nx - hw, ny, nz - hd); // front-left
+        const topFR = project(nx + hw, ny, nz - hd); // front-right
+        const topBL = project(nx - hw, ny, nz + hd); // back-left
+        const topBR = project(nx + hw, ny, nz + hd); // back-right
+
+        // Four bottom corners (y=0)
+        const botFL = project(nx - hw, 0, nz - hd);
+        const botFR = project(nx + hw, 0, nz - hd);
+        const botBL = project(nx - hw, 0, nz + hd);
+        const botBR = project(nx + hw, 0, nz + hd);
+
+        // Average depth for sorting
+        const avgDepth =
+          (topFL.depth + topBR.depth + botFL.depth + botBR.depth) / 4;
+
+        return {
+          topFL,
+          topFR,
+          topBL,
+          topBR,
+          botFL,
+          botFR,
+          botBL,
+          botBR,
+          avgDepth,
+          index: i,
+          ny,
+        };
+      })
+      .sort((a, b) => a.avgDepth - b.avgDepth);
+  }, [
+    data,
+    xKey,
+    yKey,
+    zKey,
+    project,
+    xDomain,
+    yDomain,
+    zDomain,
+    normalize,
+    barWidth,
+    barDepth,
+  ]);
+
+  return (
+    <g>
+      {bars.map(b => {
+        const face = (pts: {px: number; py: number}[], shade: number) =>
+          pts.map(p => `${p.px},${p.py}`).join(' ');
+
+        // Front face
+        const front = [b.botFL, b.botFR, b.topFR, b.topFL];
+        // Right face
+        const right = [b.botFR, b.botBR, b.topBR, b.topFR];
+        // Top face
+        const top = [b.topFL, b.topFR, b.topBR, b.topBL];
+
+        return (
+          <g key={b.index}>
+            <polygon
+              points={face(front, 0)}
+              fill={color}
+              fillOpacity={0.9}
+              stroke={color}
+              strokeWidth={0.5}
+            />
+            <polygon
+              points={face(right, 0)}
+              fill={color}
+              fillOpacity={0.7}
+              stroke={color}
+              strokeWidth={0.5}
+            />
+            <polygon
+              points={face(top, 0)}
+              fill={color}
+              fillOpacity={1}
+              stroke={color}
+              strokeWidth={0.5}
+            />
+          </g>
+        );
+      })}
+    </g>
+  );
+}

--- a/packages/lab/src/ThreeD/XDS3DChart.tsx
+++ b/packages/lab/src/ThreeD/XDS3DChart.tsx
@@ -1,0 +1,210 @@
+/**
+ * @file XDS3DChart.tsx
+ * @output Root 3D chart container — projected SVG with depth sorting
+ * @position Parent component; all 3D marks read from its context
+ */
+
+import {
+  type ReactNode,
+  useMemo,
+  useRef,
+  useState,
+  useLayoutEffect,
+  useCallback,
+} from 'react';
+import {ThreeDProvider} from './ThreeDContext';
+import type {Camera, ProjectedPoint} from './types';
+
+export interface XDS3DChartProps {
+  data: Record<string, unknown>[];
+  xKey: string;
+  yKey: string;
+  zKey: string;
+  xDomain?: [number, number];
+  yDomain?: [number, number];
+  zDomain?: [number, number];
+  height?: number;
+  azimuth?: number;
+  elevation?: number;
+  interactive?: boolean;
+  children: ReactNode;
+}
+
+function computeDomain(
+  data: Record<string, unknown>[],
+  key: string,
+): [number, number] {
+  let min = Infinity,
+    max = -Infinity;
+  for (const d of data) {
+    const v = d[key];
+    if (typeof v === 'number') {
+      if (v < min) min = v;
+      if (v > max) max = v;
+    }
+  }
+  return [min === Infinity ? 0 : min, max === -Infinity ? 1 : max];
+}
+
+export function XDS3DChart({
+  data,
+  xKey,
+  yKey,
+  zKey,
+  xDomain: xDomainProp,
+  yDomain: yDomainProp,
+  zDomain: zDomainProp,
+  height = 400,
+  azimuth: azimuthProp = 35,
+  elevation: elevationProp = 25,
+  interactive = false,
+  children,
+}: XDS3DChartProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [containerWidth, setContainerWidth] = useState(0);
+  const [camera, setCamera] = useState<Camera>({
+    azimuth: azimuthProp,
+    elevation: elevationProp,
+  });
+  const dragRef = useRef<{
+    startX: number;
+    startY: number;
+    startAz: number;
+    startEl: number;
+  } | null>(null);
+
+  useLayoutEffect(() => {
+    if (!containerRef.current) return;
+    const obs = new ResizeObserver(e => {
+      if (e[0]) setContainerWidth(e[0].contentRect.width);
+    });
+    obs.observe(containerRef.current);
+    return () => obs.disconnect();
+  }, []);
+
+  const width = containerWidth;
+  const xDomain = xDomainProp ?? computeDomain(data, xKey);
+  const yDomain = yDomainProp ?? computeDomain(data, yKey);
+  const zDomain = zDomainProp ?? computeDomain(data, zKey);
+
+  const normalize = useCallback((value: number, domain: [number, number]) => {
+    const range = domain[1] - domain[0];
+    return range === 0 ? 0.5 : (value - domain[0]) / range;
+  }, []);
+
+  const project = useMemo(() => {
+    const azRad = (camera.azimuth * Math.PI) / 180;
+    const elRad = (camera.elevation * Math.PI) / 180;
+    const cosAz = Math.cos(azRad),
+      sinAz = Math.sin(azRad);
+    const cosEl = Math.cos(elRad),
+      sinEl = Math.sin(elRad);
+    const scale = Math.min(width, height) * 0.35;
+    const cx = width / 2,
+      cy = height / 2;
+
+    return (nx: number, ny: number, nz: number): ProjectedPoint => {
+      const x = nx - 0.5,
+        y = ny - 0.5,
+        z = nz - 0.5;
+      const x1 = x * cosAz + z * sinAz;
+      const z1 = -x * sinAz + z * cosAz;
+      const y1 = y * cosEl - z1 * sinEl;
+      const z2 = y * sinEl + z1 * cosEl;
+      return {px: cx + x1 * scale, py: cy - y1 * scale, depth: z2};
+    };
+  }, [camera.azimuth, camera.elevation, width, height]);
+
+  const handleStart = useCallback(
+    (clientX: number, clientY: number) => {
+      if (!interactive) return;
+      dragRef.current = {
+        startX: clientX,
+        startY: clientY,
+        startAz: camera.azimuth,
+        startEl: camera.elevation,
+      };
+    },
+    [interactive, camera],
+  );
+
+  const handleMove = useCallback((clientX: number, clientY: number) => {
+    if (!dragRef.current) return;
+    const dx = clientX - dragRef.current.startX;
+    const dy = clientY - dragRef.current.startY;
+    setCamera({
+      azimuth: dragRef.current.startAz + dx * 0.5,
+      elevation: Math.max(
+        -89,
+        Math.min(89, dragRef.current.startEl - dy * 0.5),
+      ),
+    });
+  }, []);
+
+  const handleEnd = useCallback(() => {
+    dragRef.current = null;
+  }, []);
+
+  const ctx = useMemo(
+    () => ({
+      width,
+      height,
+      data,
+      xKey,
+      yKey,
+      zKey,
+      project,
+      xDomain,
+      yDomain,
+      zDomain,
+      normalize,
+      camera,
+    }),
+    [
+      width,
+      height,
+      data,
+      xKey,
+      yKey,
+      zKey,
+      project,
+      xDomain,
+      yDomain,
+      zDomain,
+      normalize,
+      camera,
+    ],
+  );
+
+  return (
+    <div ref={containerRef} style={{width: '100%'}}>
+      {containerWidth > 0 && (
+        <svg
+          width={containerWidth}
+          height={height}
+          onMouseDown={e => handleStart(e.clientX, e.clientY)}
+          onMouseMove={e => handleMove(e.clientX, e.clientY)}
+          onMouseUp={handleEnd}
+          onMouseLeave={handleEnd}
+          onTouchStart={e => {
+            const t = e.touches[0];
+            if (t) handleStart(t.clientX, t.clientY);
+          }}
+          onTouchMove={e => {
+            const t = e.touches[0];
+            if (t) {
+              e.preventDefault();
+              handleMove(t.clientX, t.clientY);
+            }
+          }}
+          onTouchEnd={handleEnd}
+          style={{
+            cursor: interactive ? 'grab' : undefined,
+            touchAction: interactive ? 'none' : undefined,
+          }}>
+          <ThreeDProvider value={ctx}>{children}</ThreeDProvider>
+        </svg>
+      )}
+    </div>
+  );
+}

--- a/packages/lab/src/ThreeD/XDS3DGrid.tsx
+++ b/packages/lab/src/ThreeD/XDS3DGrid.tsx
@@ -1,0 +1,66 @@
+/**
+ * @file XDS3DGrid.tsx
+ * @output 3D wireframe grid on the floor plane (y=0)
+ */
+
+import {useMemo} from 'react';
+import {use3D} from './ThreeDContext';
+
+export interface XDS3DGridProps {
+  divisions?: number;
+}
+
+export function XDS3DGrid({divisions = 5}: XDS3DGridProps) {
+  const {project} = use3D();
+
+  const lines = useMemo(() => {
+    const result: {
+      x1: number;
+      y1: number;
+      x2: number;
+      y2: number;
+      depth: number;
+    }[] = [];
+    for (let i = 0; i <= divisions; i++) {
+      const t = i / divisions;
+      // X-parallel lines (along z)
+      const a = project(t, 0, 0);
+      const b = project(t, 0, 1);
+      result.push({
+        x1: a.px,
+        y1: a.py,
+        x2: b.px,
+        y2: b.py,
+        depth: (a.depth + b.depth) / 2,
+      });
+      // Z-parallel lines (along x)
+      const c = project(0, 0, t);
+      const d = project(1, 0, t);
+      result.push({
+        x1: c.px,
+        y1: c.py,
+        x2: d.px,
+        y2: d.py,
+        depth: (c.depth + d.depth) / 2,
+      });
+    }
+    return result.sort((a, b) => a.depth - b.depth);
+  }, [project, divisions]);
+
+  return (
+    <g>
+      {lines.map((l, i) => (
+        <line
+          key={i}
+          x1={l.x1}
+          y1={l.y1}
+          x2={l.x2}
+          y2={l.y2}
+          stroke="var(--color-border)"
+          strokeOpacity={0.3}
+          strokeWidth={1}
+        />
+      ))}
+    </g>
+  );
+}

--- a/packages/lab/src/ThreeD/XDS3DScatter.tsx
+++ b/packages/lab/src/ThreeD/XDS3DScatter.tsx
@@ -1,0 +1,61 @@
+/**
+ * @file XDS3DScatter.tsx
+ * @output 3D scatter plot — projected circles with depth-based sizing/opacity
+ */
+
+import {useMemo} from 'react';
+import {use3D} from './ThreeDContext';
+
+export interface XDS3DScatterProps {
+  color: string;
+  radius?: number;
+  opacity?: number;
+}
+
+export function XDS3DScatter({
+  color,
+  radius = 4,
+  opacity = 0.8,
+}: XDS3DScatterProps) {
+  const {
+    data,
+    xKey,
+    yKey,
+    zKey,
+    project,
+    xDomain,
+    yDomain,
+    zDomain,
+    normalize,
+  } = use3D();
+
+  const points = useMemo(() => {
+    return data
+      .map((d, i) => {
+        const nx = normalize(d[xKey] as number, xDomain);
+        const ny = normalize(d[yKey] as number, yDomain);
+        const nz = normalize(d[zKey] as number, zDomain);
+        const {px, py, depth} = project(nx, ny, nz);
+        return {px, py, depth, index: i};
+      })
+      .sort((a, b) => a.depth - b.depth); // painter's algorithm
+  }, [data, xKey, yKey, zKey, project, xDomain, yDomain, zDomain, normalize]);
+
+  return (
+    <g>
+      {points.map(p => {
+        const depthFactor = 0.5 + (p.depth + 0.5) * 0.5; // 0.5-1.0
+        return (
+          <circle
+            key={p.index}
+            cx={p.px}
+            cy={p.py}
+            r={radius * depthFactor}
+            fill={color}
+            fillOpacity={opacity * depthFactor}
+          />
+        );
+      })}
+    </g>
+  );
+}

--- a/packages/lab/src/ThreeD/XDS3DSurface.tsx
+++ b/packages/lab/src/ThreeD/XDS3DSurface.tsx
@@ -1,0 +1,130 @@
+/**
+ * @file XDS3DSurface.tsx
+ * @output 3D surface mesh — projected triangulated grid with color mapping
+ */
+
+import {useMemo} from 'react';
+import {use3D} from './ThreeDContext';
+
+export interface XDS3DSurfaceProps {
+  /**
+   * Color ramp for surface height — low to high.
+   * Use useXDSChartColors().sequential.blue(5).
+   */
+  colorRange: string[];
+  opacity?: number;
+  wireframe?: boolean;
+}
+
+function lerpColor(colors: string[], t: number): string {
+  const clamped = Math.max(0, Math.min(1, t));
+  if (colors.length === 1) return colors[0];
+  const scaled = clamped * (colors.length - 1);
+  const lo = Math.floor(scaled);
+  const hi = Math.min(lo + 1, colors.length - 1);
+  // Simple: just return the nearest
+  return scaled - lo < 0.5 ? colors[lo] : colors[hi];
+}
+
+/**
+ * 3D surface mesh. Data should be a grid of points with x, y (height), z.
+ * Points are triangulated in order and colored by y-value.
+ */
+export function XDS3DSurface({
+  colorRange,
+  opacity = 0.8,
+  wireframe = false,
+}: XDS3DSurfaceProps) {
+  const {
+    data,
+    xKey,
+    yKey,
+    zKey,
+    project,
+    xDomain,
+    yDomain,
+    zDomain,
+    normalize,
+  } = use3D();
+
+  const faces = useMemo(() => {
+    // Detect grid dimensions from unique x and z values
+    const xVals = [...new Set(data.map(d => d[xKey] as number))].sort(
+      (a, b) => a - b,
+    );
+    const zVals = [...new Set(data.map(d => d[zKey] as number))].sort(
+      (a, b) => a - b,
+    );
+    const cols = xVals.length;
+    const rows = zVals.length;
+
+    if (cols < 2 || rows < 2) return [];
+
+    // Build lookup grid
+    const grid = new Map<string, Record<string, unknown>>();
+    for (const d of data) {
+      grid.set(`${d[xKey]},${d[zKey]}`, d);
+    }
+
+    const result: {points: string; color: string; depth: number}[] = [];
+
+    for (let r = 0; r < rows - 1; r++) {
+      for (let c = 0; c < cols - 1; c++) {
+        const corners = [
+          grid.get(`${xVals[c]},${zVals[r]}`),
+          grid.get(`${xVals[c + 1]},${zVals[r]}`),
+          grid.get(`${xVals[c + 1]},${zVals[r + 1]}`),
+          grid.get(`${xVals[c]},${zVals[r + 1]}`),
+        ];
+
+        if (corners.some(c => !c)) continue;
+
+        const projected = corners.map(d => {
+          const nx = normalize(d![xKey] as number, xDomain);
+          const ny = normalize(d![yKey] as number, yDomain);
+          const nz = normalize(d![zKey] as number, zDomain);
+          return {...project(nx, ny, nz), ny};
+        });
+
+        const avgY = projected.reduce((s, p) => s + p.ny, 0) / 4;
+        const avgDepth = projected.reduce((s, p) => s + p.depth, 0) / 4;
+        const color = lerpColor(colorRange, avgY);
+
+        result.push({
+          points: projected.map(p => `${p.px},${p.py}`).join(' '),
+          color,
+          depth: avgDepth,
+        });
+      }
+    }
+
+    return result.sort((a, b) => a.depth - b.depth);
+  }, [
+    data,
+    xKey,
+    yKey,
+    zKey,
+    project,
+    xDomain,
+    yDomain,
+    zDomain,
+    normalize,
+    colorRange,
+  ]);
+
+  return (
+    <g>
+      {faces.map((f, i) => (
+        <polygon
+          key={i}
+          points={f.points}
+          fill={wireframe ? 'none' : f.color}
+          fillOpacity={opacity}
+          stroke={wireframe ? f.color : f.color}
+          strokeWidth={wireframe ? 1 : 0.5}
+          strokeOpacity={wireframe ? 0.8 : 0.3}
+        />
+      ))}
+    </g>
+  );
+}

--- a/packages/lab/src/ThreeD/index.ts
+++ b/packages/lab/src/ThreeD/index.ts
@@ -1,0 +1,8 @@
+export {XDS3DChart, type XDS3DChartProps} from './XDS3DChart';
+export {XDS3DScatter, type XDS3DScatterProps} from './XDS3DScatter';
+export {XDS3DBar, type XDS3DBarProps} from './XDS3DBar';
+export {XDS3DGrid, type XDS3DGridProps} from './XDS3DGrid';
+export {XDS3DAxis, type XDS3DAxisProps} from './XDS3DAxis';
+export {XDS3DSurface, type XDS3DSurfaceProps} from './XDS3DSurface';
+export {use3D} from './ThreeDContext';
+export type {ThreeDContext, Camera, Point3D, ProjectedPoint} from './types';

--- a/packages/lab/src/ThreeD/types.ts
+++ b/packages/lab/src/ThreeD/types.ts
@@ -1,0 +1,58 @@
+/**
+ * @file types.ts
+ * @output 3D chart types and context
+ * @position Foundation types consumed by all 3D sub-components
+ *
+ * Uses a simple perspective projection — no WebGL dependency for the
+ * coordinate system. Marks can render as projected SVG or WebGL.
+ */
+
+/** 3D point in data space */
+export interface Point3D {
+  x: number;
+  y: number;
+  z: number;
+}
+
+/** 2D projected point with depth for sorting */
+export interface ProjectedPoint {
+  px: number;
+  py: number;
+  depth: number;
+}
+
+/** Camera configuration */
+export interface Camera {
+  /** Rotation around the vertical axis in degrees (default: 30) */
+  azimuth: number;
+  /** Rotation above the horizontal plane in degrees (default: 20) */
+  elevation: number;
+  /** Distance from origin — affects perspective strength (default: 5) */
+  distance: number;
+}
+
+/** 3D context provided by XDS3DChart to children */
+export interface ThreeDContext {
+  /** Inner width in pixels */
+  width: number;
+  /** Inner height in pixels */
+  height: number;
+  /** The full dataset */
+  data: Record<string, unknown>[];
+  /** Data key for x dimension */
+  xKey: string;
+  /** Data key for y dimension (vertical) */
+  yKey: string;
+  /** Data key for z dimension (depth) */
+  zKey: string;
+  /** Project a 3D data point to 2D screen coordinates */
+  project: (x: number, y: number, z: number) => ProjectedPoint;
+  /** Domain for x axis [min, max] */
+  xDomain: [number, number];
+  /** Domain for y axis [min, max] */
+  yDomain: [number, number];
+  /** Domain for z axis [min, max] */
+  zDomain: [number, number];
+  /** Camera settings */
+  camera: Camera;
+}

--- a/packages/lab/src/index.ts
+++ b/packages/lab/src/index.ts
@@ -97,9 +97,50 @@ export {
   m4Reduce,
   type M4Point,
   useXDSChartColors,
+  useXDSChartRange,
+  type UseXDSChartRangeOptions,
+  type UseXDSChartRangeReturn,
   getXDSChartColors,
   getXDSChartColorsFromResolver,
   type XDSChartColorsAPI,
   type SequentialHue,
   type TokenResolver,
 } from './Chart';
+
+// Radial charts — spider, pie, donut
+export {
+  XDSRadialChart,
+  type XDSRadialChartProps,
+  XDSRadialGrid,
+  type XDSRadialGridProps,
+  XDSRadialArea,
+  type XDSRadialAreaProps,
+  XDSRadialAxis,
+  type XDSRadialAxisProps,
+  XDSRadialSlice,
+  type XDSRadialSliceProps,
+  useRadial,
+  type RadialContext,
+  type RadialMode,
+} from './Radial';
+
+// 3D charts — projected SVG with interactive rotation
+export {
+  XDS3DChart,
+  type XDS3DChartProps,
+  XDS3DScatter,
+  type XDS3DScatterProps,
+  XDS3DBar,
+  type XDS3DBarProps,
+  XDS3DGrid,
+  type XDS3DGridProps,
+  XDS3DAxis,
+  type XDS3DAxisProps,
+  XDS3DSurface,
+  type XDS3DSurfaceProps,
+  use3D,
+  type ThreeDContext,
+  type Camera,
+  type Point3D,
+  type ProjectedPoint,
+} from './ThreeD';


### PR DESCRIPTION
Three layout systems for XDS charts, each with its own Tier 1 context guaranteeing all children map through the same coordinate space.

## Layout Architecture

| Layout | Root Component | Coordinate System |
|---|---|---|
| Cartesian | `XDSChart` | x/y linear or band scales |
| Radial | `XDSRadialChart` | angle + radius from center |
| 3D | `XDS3DChart` | projected 3D → 2D SVG |

Shared across all layouts: `useXDSChartColors`, `XDSChartLegend`, color system, data integrity principles.

## Radial Components

```tsx
// Spider
<XDSRadialChart data={data} axes={['speed', 'handling', 'comfort']} height={400}>
  <XDSRadialGrid rings={5} />
  <XDSRadialArea dataKey="Model A" color={colors[0]} dots />
  <XDSRadialAxis />
</XDSRadialChart>

// Donut
<XDSRadialChart data={data} valueKey="revenue" labelKey="region" innerRadius={0.6}>
  <XDSRadialSlice colors={colors.categorical(5)} />
</XDSRadialChart>
```

## 3D Components

```tsx
<XDS3DChart data={data} xKey="x" yKey="y" zKey="z" height={400} interactive>
  <XDS3DGrid />
  <XDS3DAxis />
  <XDS3DScatter color={colors[0]} />
</XDS3DChart>
```

- Projected SVG — no Three.js dependency
- Interactive camera rotation (drag to orbit)
- Depth-encoded scatter, shaded 3D bars, height-colored surface mesh + wireframe
- Painter's algorithm for z-ordering

## useXDSChartRange Hook

```tsx
const {xDomain, yDomain, push} = useXDSChartRange({xWindow: 300, yPadding: 0.1});
```

Manages streaming domains as state. 7 tests.

## Stories

Spider, pie, donut, spider+inner-radius, 3D scatter (interactive), 3D bars, 3D surface, wireframe, useXDSChartRange demos.

---
