### PR TITLE
feat(Selector,Typeahead,Tokenizer): cascade size to dropdown list items

### DIFF
--- a/packages/core/src/Selector/XDSSelector.tsx
+++ b/packages/core/src/Selector/XDSSelector.tsx
@@ -243,6 +243,21 @@ const sizeStyles = stylex.create({
   },
 });
 
+/**
+ * Size-specific overrides for dropdown list items.
+ * Matches the pattern used by XDSDropdownMenuItem so that
+ * an `sm` selector renders compact list items, `md`/`lg` use
+ * the base padding defined in `styles.item`.
+ */
+const itemSizeStyles = stylex.create({
+  sm: {
+    paddingBlock: spacingVars['--spacing-1'],
+    paddingInline: spacingVars['--spacing-2'],
+  },
+  md: {},
+  lg: {},
+});
+
 const STATUS_ICON_MAP: Record<XDSSelectorStatusType, XDSIconName> = {
   warning: 'warning',
   error: 'xCircle',
@@ -574,6 +589,7 @@ export function XDSSelector<T extends XDSSelectorOptionType>(
           onMouseEnter={() => onItemMouseEnter(item, flatIndex)}
           {...stylex.props(
             styles.item,
+            itemSizeStyles[size],
             isHighlighted && styles.itemHighlighted,
             isSelected && styles.itemSelected,
             item.disabled && styles.itemDisabled,
@@ -588,6 +604,7 @@ export function XDSSelector<T extends XDSSelectorOptionType>(
     [
       children,
       highlightedIndex,
+      size,
       value,
       getItemId,
       onItemSelect,

--- a/packages/core/src/Tokenizer/XDSTokenizer.tsx
+++ b/packages/core/src/Tokenizer/XDSTokenizer.tsx
@@ -708,6 +708,7 @@ export function XDSTokenizer<T extends XDSSearchableItem>({
               debounceMs={debounceMs}
               onKeyDown={handleKeyDown}
               anchorRef={wrapperRef}
+              size={size}
               inputXStyle={
                 isAtMax || isTruncated
                   ? styles.inputAtMax

--- a/packages/core/src/Typeahead/XDSBaseTypeahead.tsx
+++ b/packages/core/src/Typeahead/XDSBaseTypeahead.tsx
@@ -144,6 +144,13 @@ export interface XDSBaseTypeaheadProps<T extends XDSSearchableItem> {
    * If the handler calls `e.preventDefault()`, internal handling is skipped.
    */
   onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+
+  /**
+   * Size of the typeahead, used to scale dropdown item padding.
+   * When 'sm', items get compact padding to match the trigger size.
+   * @default 'md'
+   */
+  size?: 'sm' | 'md';
 }
 
 // =============================================================================
@@ -222,6 +229,19 @@ const styles = stylex.create({
   },
 });
 
+/**
+ * Size-specific overrides for dropdown list items.
+ * Matches the pattern used by XDSDropdownMenuItem / XDSSelector so that
+ * an `sm` typeahead renders compact list items.
+ */
+const itemSizeStyles = stylex.create({
+  sm: {
+    paddingBlock: spacingVars['--spacing-1'],
+    paddingInline: spacingVars['--spacing-2'],
+  },
+  md: {},
+});
+
 // =============================================================================
 // Component
 // =============================================================================
@@ -266,6 +286,7 @@ export const XDSBaseTypeahead = function XDSBaseTypeahead<
   anchorRef,
   onKeyDown: externalOnKeyDown,
   debounceMs = 150,
+  size = 'md',
   ref,
 }: XDSBaseTypeaheadProps<T> & {ref?: React.Ref<HTMLInputElement>}) {
   const generatedId = useId();
@@ -629,6 +650,7 @@ export const XDSBaseTypeahead = function XDSBaseTypeahead<
                 onMouseEnter={() => setHighlightedIndex(index)}
                 {...stylex.props(
                   styles.item,
+                  itemSizeStyles[size],
                   index === highlightedIndex && styles.itemHighlighted,
                   value?.id === item.id && styles.itemSelected,
                 )}>

--- a/packages/core/src/Typeahead/XDSTypeahead.tsx
+++ b/packages/core/src/Typeahead/XDSTypeahead.tsx
@@ -421,6 +421,7 @@ export function XDSTypeahead<T extends XDSSearchableItem>({
           anchorRef={wrapperRef}
           onKeyDown={handleKeyDown}
           inputXStyle={showToken ? styles.inputHidden : undefined}
+          size={size}
         />
         {hasClear && value && !isDisabled && isEditing && (
           <button


### PR DESCRIPTION
## What

Selector, Typeahead, and Tokenizer had a `size` prop that only controlled the trigger/input height — the dropdown list items always rendered with the same fixed padding regardless of size. This was inconsistent with `XDSDropdownMenu` and `XDSMultiSelector`, which already cascaded size to their menu items.

## Why

When you use a `sm` Selector, the compact trigger should produce compact dropdown items. A `sm` trigger paired with `md`-padded items looks visually mismatched. DropdownMenu already gets this right — its `menuSize` flows through context and `XDSDropdownMenuItem` applies `itemSizeStyles[menuSize]`. This PR brings the other popover-based inputs in line.

## How

Adds `itemSizeStyles` to Selector and XDSBaseTypeahead following the same pattern as DropdownMenuItem:

- **`sm`**: `paddingBlock: spacing-1`, `paddingInline: spacing-2` (compact)
- **`md`/`lg`**: no override — uses the base `padding: spacing-2` from `styles.item`

### Files changed

| File | Change |
|------|--------|
| `Selector/XDSSelector.tsx` | Add `itemSizeStyles`, apply in `renderItem`, add `size` to deps |
| `Typeahead/XDSBaseTypeahead.tsx` | Accept `size` prop, add `itemSizeStyles`, apply to items |
| `Typeahead/XDSTypeahead.tsx` | Pass `size` through to `XDSBaseTypeahead` |
| `Tokenizer/XDSTokenizer.tsx` | Pass `size` through to `XDSBaseTypeahead` |

### Already consistent (no changes needed)
- **XDSDropdownMenu / XDSDropdownMenuItem** — already cascades `menuSize` via context
- **XDSMultiSelector** — already has `itemSizeStyles[size]` applied to items

## Testing

All 123 existing tests pass (Selector, MultiSelector, DropdownMenu, Typeahead, Tokenizer).