### PR TITLE
fix(TextArea,TimeInput): a11y and input consistency fixes

### DIFF
--- a/packages/core/src/TextArea/XDSTextArea.test.tsx
+++ b/packages/core/src/TextArea/XDSTextArea.test.tsx
@@ -146,7 +146,7 @@ describe('XDSTextArea', () => {
     expect(screen.getByRole('textbox')).not.toBeDisabled();
   });
 
-  it('is disabled when isLoading is true (isBusy)', () => {
+  it('shows aria-busy when isLoading is true', () => {
     render(
       <XDSTextArea
         label="Description"
@@ -155,7 +155,8 @@ describe('XDSTextArea', () => {
         onChange={() => {}}
       />,
     );
-    expect(screen.getByRole('textbox')).toBeDisabled();
+    expect(screen.getByRole('textbox')).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getByRole('textbox')).not.toBeDisabled();
   });
 
   it('does not call onChange when disabled', async () => {

--- a/packages/core/src/TextArea/XDSTextArea.tsx
+++ b/packages/core/src/TextArea/XDSTextArea.tsx
@@ -378,7 +378,7 @@ export function XDSTextArea({
           onBlur={onBlur}
           placeholder={placeholder}
           rows={rows}
-          disabled={effectivelyDisabled}
+          disabled={isDisabled}
           spellCheck={hasSpellCheck}
           autoFocus={hasAutoFocus}
           data-autofocus={hasAutoFocus || undefined}

--- a/packages/core/src/TimeInput/XDSTimeInput.tsx
+++ b/packages/core/src/TimeInput/XDSTimeInput.tsx
@@ -212,6 +212,12 @@ export interface XDSTimeInputProps {
   hasClear?: boolean;
 
   /**
+   * Whether to automatically focus the input on mount.
+   * @default false
+   */
+  hasAutoFocus?: boolean;
+
+  /**
    * Hour format for display.
    * - '12h': Display as 12-hour with AM/PM (e.g., "2:30 PM")
    * - '24h': Display as 24-hour (e.g., "14:30")
@@ -303,6 +309,7 @@ export function XDSTimeInput({
   max,
   hasSeconds = false,
   hasClear = false,
+  hasAutoFocus = false,
   hourFormat = '12h',
   increment = 1,
   placeholder = 'Select a time',
@@ -552,6 +559,8 @@ export function XDSTimeInput({
           onKeyDown={handleInputKeyDown}
           placeholder={displayPlaceholder}
           disabled={isDisabled}
+          autoFocus={hasAutoFocus}
+          data-autofocus={hasAutoFocus || undefined}
           aria-describedby={ariaDescribedBy}
           aria-required={isRequired === true ? 'true' : undefined}
           aria-invalid={status?.type === 'error' ? 'true' : undefined}


### PR DESCRIPTION
## Component Audit — 2026-04-17

Nightly audit of 5 components: **Table**, **Text**, **TextArea**, **TextInput**, **TimeInput**.

### Changes

**TextArea** — a11y fix: busy state no longer sets native `disabled`
- `effectivelyDisabled` was combining `isDisabled || isBusy` and passing it to the native `disabled` attribute
- Per XDS a11y contract, busy state should use `aria-busy` only (visual treatment via CSS, not native disabled)
- This aligns TextArea with TextInput, which correctly passes only `isDisabled` to native `disabled`
- Updated test to verify `aria-busy` behavior instead of `toBeDisabled()`

**TimeInput** — add missing `hasAutoFocus` prop
- All other input components (TextInput, TextArea, DateInput, NumberInput) support `hasAutoFocus`
- TimeInput was the only one missing it
- Added prop with proper `autoFocus` + `data-autofocus` wiring (required for XDSDialog focus restoration)

### Audited Components Summary

| Component | Result |
|-----------|--------|
| Table | ✅ Clean — all checks pass |
| Text (XDSText + XDSHeading) | ✅ Clean (see Needs Review) |
| TextArea | 🔧 Fixed busy-state disabled behavior |
| TextInput | ✅ Clean |
| TimeInput | 🔧 Fixed missing hasAutoFocus prop |

### Needs Review

These findings need human judgment — not auto-fixable:

1. **XDSText and XDSHeading don't extend XDSBaseProps** — they manually declare `xstyle`, `className`, `style` props instead of inheriting from `XDSBaseProps`. This means they don't get full HTML attribute passthrough. May be intentional given Text's unique semantics (`type`, `maxLines`, etc.).

2. **XDSTextArea and XDSTimeInput don't extend XDSBaseProps** — same pattern. TextInput does extend it. Should input components follow a consistent approach?

3. **TextInput, TimeInput have `lg` size variant** — the XDS input consistency spec says inputs should use `'sm' | 'md'`. Both components also expose `lg`. Is this intentional or should it be removed?
