### PR TITLE
fix(Selector): forward extra HTML attributes from XDSBaseProps

### DIFF
--- a/packages/core/src/Selector/XDSSelector.tsx
+++ b/packages/core/src/Selector/XDSSelector.tsx
@@ -444,8 +444,10 @@ export function XDSSelector<T extends XDSSelectorOptionType>(
     xstyle,
     className,
     style,
-  } = props;
-  const hasClear = 'hasClear' in props && props.hasClear === true;
+    hasClear: hasClearProp,
+    ...rest
+  } = props as XDSSelectorPropsClearable<T>;
+  const hasClear = hasClearProp === true;
 
   // Normalize null to undefined for internal use (null is the clear sentinel)
   const normalizedValue = value === null ? undefined : value;
@@ -667,6 +669,7 @@ export function XDSSelector<T extends XDSSelectorOptionType>(
         id={triggerId}
         type="button"
         role="combobox"
+        {...rest}
         aria-haspopup="listbox"
         aria-expanded={popover.isOpen}
         aria-controls={listboxId}


### PR DESCRIPTION
## Summary

`XDSSelector` accepts `XDSBaseProps` (which extends `React.HTMLAttributes`), but was destructuring only `xstyle`, `className`, `style`, and `data-testid` — silently dropping all other HTML attributes (`data-*`, `aria-*`, `title`, `onFocus`, `onBlur`, etc.).

## Fix

- Collect remaining props with a `...rest` spread in the destructuring
- Forward `...rest` onto the trigger `<button>` element
- Extract `hasClear` from the destructuring (was previously accessed via `'hasClear' in props`) to prevent it from leaking to the DOM

This matches the pattern used by `XDSButton` and other components that extend `XDSBaseProps`.

Fixes #1415

---
