### PR TITLE
fix(theme): include onMedia CSS in built theme output

### DIFF
--- a/packages/cli/src/commands/build-theme.mjs
+++ b/packages/cli/src/commands/build-theme.mjs
@@ -24,11 +24,13 @@ const _require = createRequire(import.meta.url);
 let _defineTheme = null;
 let _generateThemeRules = null;
 let _generateThemeRulesSplit = null;
+let _generateOnMediaCSS = null;
 try {
   const coreTheme = _require('@xds/core/theme');
   _defineTheme = coreTheme.defineTheme;
   _generateThemeRules = coreTheme.generateThemeRules;
   _generateThemeRulesSplit = coreTheme.generateThemeRulesSplit;
+  _generateOnMediaCSS = coreTheme.generateOnMediaCSS;
 } catch {
   // Core not available — fall back to legacy generation
 }
@@ -1002,6 +1004,13 @@ export function registerTheme(program) {
               : '';
             cssParts.push(`@layer xds-theme {\n${colorSchemeDecl}${componentScope}\n}`);
           }
+          // On-media rules (XDSMediaTheme dark/light surface overrides)
+          if (_generateOnMediaCSS) {
+            const onMediaCss = _generateOnMediaCSS(resolvedTheme);
+            if (onMediaCss) {
+              cssParts.push(`@layer xds-theme {\n${onMediaCss}\n}`);
+            }
+          }
           css = cssParts.join('\n\n') + '\n';
         } else {
           const rules = _generateThemeRules(resolvedTheme);
@@ -1015,6 +1024,13 @@ export function registerTheme(program) {
             ? '  :root { color-scheme: light dark; }\n\n'
             : '';
           css = `@layer xds-theme {\n${colorSchemeDecl}${scopeBlock}\n}\n`;
+          // On-media rules (legacy path)
+          if (_generateOnMediaCSS) {
+            const onMediaCss = _generateOnMediaCSS(resolvedTheme);
+            if (onMediaCss) {
+              css += `\n@layer xds-theme {\n${onMediaCss}\n}\n`;
+            }
+          }
         }
       } else {
         // Legacy fallback when core isn't built yet


### PR DESCRIPTION
## Problem

`xds theme build` called `generateThemeRulesSplit()` for component and prose rules but never called `generateOnMediaCSS()`. Built theme CSS files had no `[data-xds-media]` selector rules.

This meant `<XDSMediaTheme mode="dark">` rendered the `data-xds-media` attribute on the DOM, but the theme's CSS never targeted it — text, icons, and buttons inside media contexts kept their default colors instead of flipping to the inverted surface tokens.

## Fix

Import `generateOnMediaCSS` from core and append its output to the built CSS. The function already wraps its output in the correct `@scope` selector:

```css
@layer xds-theme {
  @scope ([data-xds-theme="default"]) to ([data-xds-theme]) {
    [data-xds-media="dark"] {
      color-scheme: dark;
      --color-text-primary: var(--color-on-dark);
      --color-icon-primary: var(--color-on-dark);
      --color-accent: var(--color-on-dark);
    }
    [data-xds-media="dark"] .xds-button.secondary {
      background-color: color-mix(in srgb, white 20%, transparent);
    }
    /* ... light surface overrides ... */
  }
}
```

Both the split path (`generateThemeRulesSplit`) and legacy path (`generateThemeRules`) are patched.

## Before / After

**Before:** `<XDSMediaTheme mode="dark">` had no effect with pre-built themes — text stayed dark on dark overlays.
**After:** Text, icons, and buttons correctly flip to their inverted-surface tokens.

---
