### PR TITLE
fix(docsite): remove double basePath in router.replace

### DIFF
--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
@@ -17,7 +17,6 @@ import {
   XDS_DESIGN_AVATAR,
   FILTER_COLUMNS,
   PROFILE_CRAFT_ITEMS,
-  basePath,
 } from './constants';
 import {TemplateCard} from './TemplateCard';
 import {AIComposer} from './AIComposer';
@@ -382,7 +381,7 @@ function DocsiteLandingTemplate() {
 
     const qs = params.toString();
     router.replace(
-      `${basePath}/pages/docsite/${qs ? '?' + qs : ''}`,
+      `/pages/docsite/${qs ? '?' + qs : ''}`,
       {scroll: false},
     );
   }, [


### PR DESCRIPTION
## Summary
- Next.js App Router `router.replace()` auto-prepends `basePath`, but the docsite page was also manually including it, causing navigation to `/sandbox/sandbox/pages/docsite/` (404).
- Removed the manual `basePath` prefix from the `router.replace()` call so the URL resolves correctly.

## Test plan
- [ ] Deploy preview: navigate to `/sandbox/pages/docsite/`, confirm the URL stays correct after the `useEffect` syncs state
- [ ] Verify clicking between views doesn't produce doubled `/sandbox/sandbox/` in the URL


Made with [Cursor](https://cursor.com)