### PR TITLE
feat(cli): add theme nudge to generated agent docs

### DIFF
--- a/packages/cli/src/commands/agent-docs.mjs
+++ b/packages/cli/src/commands/agent-docs.mjs
@@ -126,6 +126,7 @@ export function generateCompressedIndex(version, {coreDir, zh = false, lang, run
   lines.push('No style={{}} — use the xstyle prop on XDS components for custom styling.');
   lines.push('If a component prop does what you need, use it — never replicate with CSS/stylex.');
   lines.push(`No magic values — run \`${run} docs tokens\` for spacing/color/radius.`);
+  lines.push(`To change accent/brand colors: \`${run} theme\` — never override --xds-color-* in :root.`);
   lines.push('');
 
   // CLI quick reference

--- a/packages/cli/src/commands/agent-docs.test.mjs
+++ b/packages/cli/src/commands/agent-docs.test.mjs
@@ -34,9 +34,10 @@ describe('generateCompressedIndex', () => {
     expect(result).toContain('<!-- XDS:END -->');
   });
 
-  it('does not include theme command references', () => {
+  it('includes theme nudge rule', () => {
     const result = generateCompressedIndex('1.0.0');
-    expect(result).not.toMatch(/\bxds theme\b/);
+    expect(result).toMatch(/xds theme/);
+    expect(result).toMatch(/never override --xds-color/);
   });
 
   it('includes upgrade command and migration rule', () => {


### PR DESCRIPTION
## What

Adds a theme system nudge to the auto-generated AGENTS.md block that every XDS app gets.

## Why

The generated AGENTS.md block currently has zero mention of theming. When an LLM encounters a request like "change the accent color to purple," it defaults to overriding `--xds-color-*` tokens in `:root` because it has no signal that a theme system exists.

## How

One line added to `generateCompressedIndex()` in agent-docs.mjs:

```
To change accent/brand colors: `yarn xds theme` — never override --xds-color-* in :root.
```

## Vibe Test Results

Tested prompt 2a ("Change the app's accent color to purple #4f46e5") across three conditions:

| Condition | Approach | Theme-Aware? | Separate Theme File? |
|-----------|----------|-------------|---------------------|
| No comment, no AGENTS.md rule | `:root` override in globals.css | ❌ No | ❌ No |
| CSS comment only (internal template) | `:root` override + TODO caveat | ✅ Aware, didn't change behavior | ❌ No |
| CSS comment + AGENTS.md rule | Separate `custom-theme.css` imported after default | ✅ Primary driver | ✅ Yes |

**Key finding:** The CSS comment alone improved awareness (added TODO, knew about theme system) but didn't change the LLM's actual behavior. Adding the AGENTS.md rule flipped behavior — the LLM created a separate theme file instead of inlining in `:root`. Both signals together produced the best result.

Companion change: internal CLI template update to add a CSS comment above the theme import in globals.css (separate Phabricator diff).