### PR TITLE
feat: add 4 gallery templates

### DIFF
--- a/packages/cli/templates/pages/classic-gallery/page.tsx
+++ b/packages/cli/templates/pages/classic-gallery/page.tsx
@@ -1,0 +1,165 @@
+'use client';
+
+import {useState} from 'react';
+import {XDSAppShell} from '@xds/core/AppShell';
+import {XDSVStack} from '@xds/core/Layout';
+import {XDSCenter} from '@xds/core/Center';
+import {XDSText, XDSHeading} from '@xds/core/Text';
+import {XDSGrid} from '@xds/core/Grid';
+import {XDSAspectRatio} from '@xds/core/AspectRatio';
+import {XDSSection} from '@xds/core/Section';
+
+import {XDSTabList, XDSTab} from '@xds/core/TabList';
+import * as stylex from '@stylexjs/stylex';
+
+// ─── Styles ─────────────────────────────────────────────────────────────────
+
+const styles = stylex.create({
+  outer: {
+    maxWidth: 1200,
+    width: '100%',
+    paddingInline: 'var(--spacing-6)',
+    paddingBlock: 'var(--spacing-8)',
+  },
+  imageWrapper: {
+    borderRadius: 'var(--radius-container)',
+    overflow: 'clip',
+  },
+  textCenter: {
+    textAlign: 'center',
+  },
+  imgFill: {
+    width: '100%',
+    height: '100%',
+    objectFit: 'cover',
+    display: 'block',
+  },
+});
+
+// ─── Gallery Data ───────────────────────────────────────────────────────────
+
+type Category = 'all' | 'lifestyle' | 'scene' | 'home';
+
+interface GalleryImage {
+  src: string;
+  alt: string;
+  category: Category;
+}
+
+const GALLERY_IMAGES: GalleryImage[] = [
+  {
+    src: 'https://scontent.xx.fbcdn.net/v/t39.6806-6/672863405_1398068472358179_8859473259447111379_n.png?_nc_cat=100&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=-wV2jHO2HVUQ7kNvwHGzCzr&_nc_oc=AdrxH65fOWB9AYbTJt499HTYmTlEoQ2-Gq4v0HixJT92Mz5awWgcZNSxSTRZJPypWIDapoCWcQ2JcNruqRd9ovzp&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=ak5CKQPy-Mq6Vm7qld0MTw&_nc_ss=7a30f&oh=00_Af03yc18QziUpPjAs6EJMXwjb9gx2bfazL1ccL5840WQdw&oe=69E8390A',
+    alt: 'Moody scene landscape',
+    category: 'scene',
+  },
+  {
+    src: 'https://scontent.xx.fbcdn.net/v/t39.6806-6/674064782_1780208822692052_3795473963216992279_n.png?_nc_cat=108&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=78Zl6OnaJ3gQ7kNvwHrbidO&_nc_oc=AdoPCiVZCbUF3lzrCI0jEGC2uYR14gHlJTZxVejhFyKoN1SctaHmMe-PlVXCoEmGEn01g05n2-Qai4TDHfCanT2r&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=5Ca_Vp6JYkgtj8PkyMQGcA&_nc_ss=7a30f&oh=00_Af15tUTHSdnlHE7qjvC28Kvf_GLUtkAyLxVfRO5eAY3kLQ&oe=69E84C07',
+    alt: 'Moody lifestyle portrait',
+    category: 'lifestyle',
+  },
+  {
+    src: 'https://scontent.xx.fbcdn.net/v/t39.6806-6/671154433_1690063268839561_5090150051169696390_n.png?_nc_cat=104&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=Qq_R2DdWkjAQ7kNvwGoG6Gb&_nc_oc=AdpiIJkdZLHlCgoUTVQqq3ycMBrIC4BKwSNUVNqZMc27LaY_d_YZQmJCylhNOAqJXTZ1Xt95cEOcoBO4oqzdcDMW&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=rJE1zfBfSoNXYSp-jSwoDw&_nc_ss=7a30f&oh=00_Af3yobNIzECbq2tstiOFEMVnGnQE0wzgksyOhJKjNLMR9g&oe=69E83356',
+    alt: 'Moody home interior',
+    category: 'home',
+  },
+  {
+    src: 'https://scontent.xx.fbcdn.net/v/t39.6806-6/670453429_1910969922884172_3094228467578042834_n.png?_nc_cat=108&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=YeICz52KdJEQ7kNvwFEVEr-&_nc_oc=Adr3iASjbPaVCp4m5c33SzEajLNl_Arj-XOaaxFda0aUdsJ9A-YhyrHnmM6DbvJMdy0SRu-IObUInYMtFT14AwId&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=Gh4mkg0GJh1nwlefERHleA&_nc_ss=7a30f&oh=00_Af19f_-e0ThVN5TfOrqSp3WkAVXX1eBsw5CvVBpEQg_0mw&oe=69E82DE6',
+    alt: 'Moody scene vista',
+    category: 'scene',
+  },
+  {
+    src: 'https://scontent.xx.fbcdn.net/v/t39.6806-6/673866328_1278679930533651_9097451673261932422_n.png?_nc_cat=103&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=Icfd6-HDesIQ7kNvwEtOBIG&_nc_oc=Adoc6yPpfMZ3OlVJaqmMWGPwPgVfFN-D8-MLx4cMXtbmD2sc1fMurTEO2IQzYEOGV-tLIGEZ1bL9LqWKyOkecgYA&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=HBNKvpHT-ht2OXVWFqr1Hg&_nc_ss=7a30f&oh=00_Af1hHVggQoGf6bucCuuDoPnQyj1S-TUA3kQMJVH535ZSQQ&oe=69E839B9',
+    alt: 'Moody lifestyle scene',
+    category: 'lifestyle',
+  },
+  {
+    src: 'https://scontent.xx.fbcdn.net/v/t39.6806-6/672246966_2022228332030059_1486026254113745156_n.png?_nc_cat=102&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=Db-kiXIpRagQ7kNvwEiuVls&_nc_oc=AdoOEVy32V7Oo1HAW4UIdu5zb6PRPViEHbk30rht43aVQP5lGl0NuWw71BhUPQvwdyplL2rVnXPLqsNStkejzAM9&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=VGciYJh11wjMyAWCDlqOkg&_nc_ss=7a30f&oh=00_Af2wuIbroUrp1bHYcHSviFfFpTSzDz7ylfw4_fNuEuCxXw&oe=69E82F15',
+    alt: 'Moody lifestyle horizontal',
+    category: 'lifestyle',
+  },
+  {
+    src: 'https://scontent.xx.fbcdn.net/v/t39.6806-6/670668456_1850168808990410_1567515430860525015_n.png?_nc_cat=106&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=1r2TneN1xTIQ7kNvwFLqH4K&_nc_oc=AdpLJqj5zly7Z1RW9hkAPFSu6VM1smu-8ewfVZjBFgWnJiKsVcJgtdsOsi5DVY-pzYdpgAwNGq_3oF0ORDd1HXLl&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=S6P1v66QtL_kRxpiOn-UwQ&_nc_ss=7a30f&oh=00_Af0OdPMnIboqpeiIGi371xb5Wz-MYfVf8sGficMBkXdw9g&oe=69E84C2C',
+    alt: 'Moody scene vertical',
+    category: 'scene',
+  },
+  {
+    src: 'https://scontent.xx.fbcdn.net/v/t39.6806-6/672681252_1712972356395547_4336697191547122977_n.png?_nc_cat=101&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=4ETrTLj0vK8Q7kNvwGLM0xl&_nc_oc=AdqkzIHYZxzOwoMZMwoA7yLWXTYym_tCwQ4FQbOym2Tp7Imv9xKmq3nCyf1DGql6iJ_4TzH8g5EPwdPjYPwzuSxt&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=_6B4sVgLj-zcDPPv_Br-jA&_nc_ss=7a30f&oh=00_Af1E_0XE2gOCpcBWDE-FmhmIRqzE9DQrCMvILT07KlVvgA&oe=69E82FA1',
+    alt: 'Moody home vertical',
+    category: 'home',
+  },
+  {
+    src: 'https://scontent.xx.fbcdn.net/v/t39.6806-6/671420383_1473260394292788_982123928249290692_n.png?_nc_cat=106&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=zEGSNskdaZQQ7kNvwGbl9p3&_nc_oc=AdoBiMOc96dRnGJ0HNcPHsYglrop_BOmld856Nwo3dfatPreBpZMDwQyDf6djFkYW3Puo2CPINBhj6v8UQt5y0y0&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=LLHD2zOCqVKQysCimaPwRw&_nc_ss=7a30f&oh=00_Af1dQWMptFS2tFyIpHkxUxyV0EzDBhGfRAD8JvJC1VId9g&oe=69E863BA',
+    alt: 'Moody home horizontal',
+    category: 'home',
+  },
+  {
+    src: 'https://scontent.xx.fbcdn.net/v/t39.6806-6/672683360_1484439649702521_3027582698795094818_n.png?_nc_cat=101&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=fJchBtIPlwMQ7kNvwGBKiAv&_nc_oc=AdqXyJ0W9AGsWYfpM0AaKwY9T4PVz0VAuZeKvRrKomtCrpk7D23PfL-zy-FN3cHwIkD-Ecessz0Gqu06t-uUAxYq&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=vu_KBIgBGT_4jn2B7cQWIg&_nc_ss=7a30f&oh=00_Af0AOLyC3ksPoOv7SeZLT3aT-uMSiUfzfYSOs6TUdk2H6A&oe=69E847BB',
+    alt: 'Moody scene vertical',
+    category: 'scene',
+  },
+];
+
+// ─── Main Page ──────────────────────────────────────────────────────────────
+
+export default function ClassicGalleryTemplate() {
+  const [filter, setFilter] = useState<Category>('all');
+
+  const filteredImages =
+    filter === 'all'
+      ? GALLERY_IMAGES
+      : GALLERY_IMAGES.filter(img => img.category === filter);
+
+  return (
+    <XDSAppShell height="auto" contentPadding={0} variant="surface">
+      <XDSCenter axis="horizontal">
+        <div {...stylex.props(styles.outer)}>
+          <XDSVStack gap={8}>
+            {/* Header */}
+            <XDSCenter axis="horizontal">
+              <XDSSection variant="transparent" maxWidth={680} padding={0}>
+                <XDSVStack gap={4} hAlign="center" xstyle={styles.textCenter}>
+                  <XDSVStack gap={2} hAlign="center">
+                    <XDSHeading level={1}>
+                      Make every day a little more delightful, one detail at a
+                      time.
+                    </XDSHeading>
+                    <XDSText type="body" color="secondary">
+                      We believe the smallest details are the ones that matter
+                      most. A little color, a thoughtful touch, a moment that
+                      catches your eye and makes you pause; that&apos;s what
+                      turns an ordinary day into something worth remembering.
+                    </XDSText>
+                  </XDSVStack>
+
+                  <XDSTabList
+                    value={filter}
+                    onChange={v => setFilter(v as Category)}>
+                    <XDSTab value="all" label="All" />
+                    <XDSTab value="lifestyle" label="Lifestyle" />
+                    <XDSTab value="scene" label="Scenery" />
+                    <XDSTab value="home" label="Home" />
+                  </XDSTabList>
+                </XDSVStack>
+              </XDSSection>
+            </XDSCenter>
+
+            {/* Gallery Grid */}
+            <XDSGrid minChildWidth={400} gap={4}>
+              {filteredImages.map((image, i) => (
+                <a key={i} href="#">
+                  <XDSAspectRatio ratio={3 / 2} xstyle={styles.imageWrapper}>
+                    <img
+                      src={image.src}
+                      alt={image.alt}
+                      {...stylex.props(styles.imgFill)}
+                    />
+                  </XDSAspectRatio>
+                </a>
+              ))}
+            </XDSGrid>
+          </XDSVStack>
+        </div>
+      </XDSCenter>
+    </XDSAppShell>
+  );
+}

--- a/packages/cli/templates/pages/classic-gallery/template.doc.mjs
+++ b/packages/cli/templates/pages/classic-gallery/template.doc.mjs
@@ -1,0 +1,7 @@
+/** @type {import('../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  name: 'Classic Gallery',
+  description: 'Clean 2×2 image grid with uniform sizing',
+  type: 'page',
+  isReady: true,
+};

--- a/packages/cli/templates/pages/mixed-gallery/page.tsx
+++ b/packages/cli/templates/pages/mixed-gallery/page.tsx
@@ -1,0 +1,228 @@
+'use client';
+
+import {XDSAppShell} from '@xds/core/AppShell';
+import {XDSVStack, XDSStackItem} from '@xds/core/Layout';
+import {XDSCenter} from '@xds/core/Center';
+import {XDSText, XDSHeading} from '@xds/core/Text';
+import {XDSSection} from '@xds/core/Section';
+import {XDSGrid} from '@xds/core/Grid';
+import {XDSButton} from '@xds/core/Button';
+import {XDSAspectRatio} from '@xds/core/AspectRatio';
+import {XDSIcon} from '@xds/core/Icon';
+import {XDSMediaTheme} from '@xds/core/theme';
+import {ArrowRightIcon} from '@heroicons/react/24/outline';
+import * as stylex from '@stylexjs/stylex';
+
+// ─── Styles ────────────────────────────────────────────────────────────────
+
+const layoutStyles = stylex.create({
+  fullHeight: {
+    height: '100%',
+  },
+  minHeightZero: {
+    minHeight: 0,
+  },
+  textCenter: {
+    textAlign: 'center',
+  },
+  desktopOnly: {
+    display: {
+      default: 'flex',
+      '@media (max-width: 767px)': 'none',
+    },
+  },
+  mobileOnly: {
+    display: {
+      default: 'none',
+      '@media (max-width: 767px)': 'flex',
+    },
+  },
+  mobileGap: {
+    gap: {
+      default: null,
+      '@media (max-width: 767px)': 'var(--spacing-3)',
+    },
+  },
+});
+
+const overlayStyles = stylex.create({
+  card: {
+    position: 'relative',
+    width: '100%',
+    height: '100%',
+    overflow: 'clip',
+    borderRadius: 'var(--radius-element)',
+  },
+  overlay: {
+    position: 'absolute',
+    inset: 0,
+    backgroundColor: 'var(--color-overlay)',
+    opacity: {
+      default: 0,
+      ':hover': 1,
+    },
+    transition: 'opacity 0.2s ease',
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'flex-end',
+    padding: 'var(--spacing-6)',
+  },
+});
+
+// ─── Gallery Data ───────────────────────────────────────────────────────────
+
+interface GalleryImage {
+  src: string;
+  title: string;
+  description: string;
+}
+
+const IMAGES: GalleryImage[] = [
+  {
+    // Column 1: illustrative-horizontal-1
+    src: 'https://scontent.xx.fbcdn.net/v/t39.6806-6/670836735_2461791954280697_1048571955964692895_n.jpg?_nc_cat=105&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=b9DqIpmzyeAQ7kNvwEuVNYV&_nc_oc=Adqx7M8RaKihjC8dSQUH_YjYNSkC7dv34yH96ndekQT74zfo2M6_DMfY-HyXDGEgXYHKMGTPSBWROmTm7oSKCaPg&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=e6YHUehLaMQde9dotUaFJw&_nc_ss=7a30f&oh=00_Af2odB5hzmvCl0lYC5CdnJjHLVeooKOjOOPItWbo1K-2tg&oe=69E6FAAB',
+    title: 'Going places',
+    description:
+      "Sometimes all it takes is one small thing to turn your whole day around. That's what good design is for.",
+  },
+  {
+    // Column 1: light-home-horizontal-1
+    src: 'https://scontent.xx.fbcdn.net/v/t39.6806-6/672683340_1522469159433922_7776167798061220106_n.png?_nc_cat=101&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=Qpd2UWP6VgEQ7kNvwE-OPni&_nc_oc=AdrBHciJphXt9BtYMnlljRItaFe9QR13GbHjolSlqWeoP37sfn-C414s177sJjM7dk8xymfEjEIkYoEd8bspGCMK&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=Lt9qRH3XlVoT53AL30YKsA&_nc_ss=7a30f&oh=00_Af0tIOpEarNFMfXkSd3D5DVXSUqIKjx9toPEqC89IupM5A&oe=69E6E494',
+    title: 'Making memories',
+    description:
+      "Sometimes all it takes is one small thing to turn your whole day around. That's what good design is for.",
+  },
+  {
+    // Column 2: light-lifestyle-vertical-3
+    src: 'https://scontent.xx.fbcdn.net/v/t39.6806-6/673630979_2366966167048970_507510466630095319_n.png?_nc_cat=103&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=hayXnp1KwWwQ7kNvwE6OwnY&_nc_oc=AdrKqob4CUU2_FrICyqd-B1NVcZ_p6oN45HC6nOs4_NJs-zvYEaj0pRdsvm5oBgVXMMQ-QIYfYEdY7NPSlkmD0VF&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=wxPGUKGIf3ihSjnc_4pFdQ&_nc_ss=7a30f&oh=00_Af3cPR8RHrFZTUPXixsgg3N4iz7847JxcTfJUbK1nisSPg&oe=69E6EAD4',
+    title: 'Seeing things',
+    description:
+      "Sometimes all it takes is one small thing to turn your whole day around. That's what good design is for.",
+  },
+  {
+    // Column 3: light-lifestyle-vertical-1
+    src: 'https://scontent.xx.fbcdn.net/v/t39.6806-6/669447541_4390219861306657_6002100073104319158_n.png?_nc_cat=108&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=sXKFHmKfCccQ7kNvwGsGpL1&_nc_oc=Adqy06LYMJsViftx1OlQnquClJHettJcc9a0z0BO_mx-979b2VldT8nPRe6J3BwPheu3AlAk6N4LlItaO3vU9xg4&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=H412Z-rQCOugLK-6ss0CDA&_nc_ss=7a30f&oh=00_Af0LKXjbNPwFyK0rA1mnGPK57ctb0rzjTS5jwzXB03oPBw&oe=69E6E58D',
+    title: 'Sharing ideas',
+    description:
+      "Sometimes all it takes is one small thing to turn your whole day around. That's what good design is for.",
+  },
+  {
+    // Column 3: light-lifestyle-horizontal-1
+    src: 'https://scontent.xx.fbcdn.net/v/t39.6806-6/673173617_1842726693762408_2908608806392112143_n.png?_nc_cat=107&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=ipqP09C42_gQ7kNvwHwibG0&_nc_oc=Ado97zfee8ejAhB0dqWyWz4lhsi0K7kf9W9wFBfqvD7cm3mh9le59yGFgbdkzIWO255x4Oe7bwc_vnSh41GvAxTk&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=1ZhYNPWwWg8iLLqOsj0aUg&_nc_ss=7a30f&oh=00_Af340jh-0cJ2G-NDCnGJNrXd-RuAXXawyADjOqNP7tOD7Q&oe=69E712D6',
+    title: 'Being free',
+    description:
+      "Sometimes all it takes is one small thing to turn your whole day around. That's what good design is for.",
+  },
+];
+
+const imgStyles = stylex.create({
+  cover: {
+    width: '100%',
+    height: '100%',
+    objectFit: 'cover',
+    display: 'block',
+    minHeight: 0,
+  },
+});
+
+// ─── Gallery Card with Hover Overlay ────────────────────────────────────────
+
+function GalleryCard({image}: {image: GalleryImage}) {
+  return (
+    <div {...stylex.props(overlayStyles.card)}>
+      <img
+        src={image.src}
+        alt={image.title}
+        {...stylex.props(imgStyles.cover)}
+      />
+      <div {...stylex.props(overlayStyles.overlay)}>
+        <XDSMediaTheme mode="dark">
+          <XDSVStack gap={3}>
+            <XDSHeading level={2}>{image.title}</XDSHeading>
+            <XDSText type="body">{image.description}</XDSText>
+            <XDSButton
+              label="Read more"
+              variant="secondary"
+              endContent={<XDSIcon icon={ArrowRightIcon} />}
+            />
+          </XDSVStack>
+        </XDSMediaTheme>
+      </div>
+    </div>
+  );
+}
+
+// ─── Main Page ──────────────────────────────────────────────────────────────
+
+export default function MixedGalleryTemplate() {
+  return (
+    <XDSAppShell height="fill" contentPadding={6} variant="surface">
+      <XDSCenter axis="horizontal" height="100%">
+        <XDSSection
+          variant="transparent"
+          maxWidth={1400}
+          width="100%"
+          height="100%"
+          padding={0}>
+          <XDSVStack
+            gap={6}
+            xstyle={[layoutStyles.fullHeight, layoutStyles.mobileGap]}>
+            {/* Header — capped with XDSSection maxWidth */}
+            <XDSCenter axis="horizontal">
+              <XDSSection variant="transparent" maxWidth={680}>
+                <XDSVStack gap={2} xstyle={layoutStyles.textCenter}>
+                  <XDSHeading level={1}>
+                    Make every day a little more delightful, one detail at a
+                    time.
+                  </XDSHeading>
+                  <XDSText type="body">
+                    We believe the smallest details are the ones that matter
+                    most. A little color, a thoughtful touch, a moment that
+                    catches your eye and makes you pause; that's what turns an
+                    ordinary day into something worth remembering.
+                  </XDSText>
+                </XDSVStack>
+              </XDSSection>
+            </XDSCenter>
+
+            {/* Gallery — desktop: 3-col masonry, mobile: single column */}
+
+            {/* Desktop layout (hidden on mobile) */}
+            <XDSStackItem size="fill" xstyle={layoutStyles.desktopOnly}>
+              <XDSGrid columns={3} gap={4} height="100%">
+                <XDSVStack gap={4} xstyle={layoutStyles.minHeightZero}>
+                  <XDSStackItem size="fill">
+                    <GalleryCard image={IMAGES[0]} />
+                  </XDSStackItem>
+                  <XDSStackItem size="fill">
+                    <GalleryCard image={IMAGES[1]} />
+                  </XDSStackItem>
+                </XDSVStack>
+
+                <GalleryCard image={IMAGES[2]} />
+
+                <XDSVStack gap={4} xstyle={layoutStyles.minHeightZero}>
+                  <XDSStackItem size="fill">
+                    <GalleryCard image={IMAGES[3]} />
+                  </XDSStackItem>
+                  <XDSStackItem size="fill">
+                    <GalleryCard image={IMAGES[4]} />
+                  </XDSStackItem>
+                </XDSVStack>
+              </XDSGrid>
+            </XDSStackItem>
+
+            {/* Mobile layout (hidden on desktop) */}
+            <XDSVStack gap={4} xstyle={layoutStyles.mobileOnly}>
+              {IMAGES.map((image, i) => (
+                <XDSAspectRatio key={i} ratio={16 / 9}>
+                  <GalleryCard image={image} />
+                </XDSAspectRatio>
+              ))}
+            </XDSVStack>
+          </XDSVStack>
+        </XDSSection>
+      </XDSCenter>
+    </XDSAppShell>
+  );
+}

--- a/packages/cli/templates/pages/mixed-gallery/template.doc.mjs
+++ b/packages/cli/templates/pages/mixed-gallery/template.doc.mjs
@@ -1,0 +1,7 @@
+/** @type {import('../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  name: 'Mixed Gallery',
+  description: 'Masonry-style image gallery with varying image sizes',
+  type: 'page',
+  isReady: true,
+};

--- a/packages/cli/templates/pages/product-gallery/page.tsx
+++ b/packages/cli/templates/pages/product-gallery/page.tsx
@@ -1,0 +1,174 @@
+'use client';
+
+import {XDSAppShell} from '@xds/core/AppShell';
+import {XDSVStack} from '@xds/core/Layout';
+import {XDSCenter} from '@xds/core/Center';
+import {XDSText, XDSHeading} from '@xds/core/Text';
+import {XDSButton} from '@xds/core/Button';
+import {XDSGrid} from '@xds/core/Grid';
+import {XDSAspectRatio} from '@xds/core/AspectRatio';
+import {XDSIcon} from '@xds/core/Icon';
+import {XDSSection} from '@xds/core/Section';
+import {ArrowRightIcon} from '@heroicons/react/24/outline';
+import * as stylex from '@stylexjs/stylex';
+
+// ─── Styles ─────────────────────────────────────────────────────────────────
+
+const styles = stylex.create({
+  link: {
+    textDecoration: 'none',
+    color: 'inherit',
+    cursor: 'pointer',
+  },
+  imageWrapper: {
+    borderRadius: 'var(--radius-container)',
+    overflow: 'clip',
+  },
+  image: {
+    width: '100%',
+    height: '100%',
+    objectFit: 'cover',
+    objectPosition: 'center',
+    display: 'block',
+  },
+});
+
+// ─── Product Data ───────────────────────────────────────────────────────────
+
+interface Product {
+  id: number;
+  name: string;
+  description: string;
+  price: number;
+  image: string;
+}
+
+const PRODUCTS: Product[] = [
+  {
+    id: 1,
+    name: 'Going places',
+    description:
+      "Sometimes all it takes is one small thing to turn your whole day around. That's what good design is for.",
+    price: 75.0,
+    image:
+      'https://scontent.xx.fbcdn.net/v/t39.6806-6/670836735_2461791954280697_1048571955964692895_n.jpg?_nc_cat=105&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=b9DqIpmzyeAQ7kNvwEuVNYV&_nc_oc=Adqx7M8RaKihjC8dSQUH_YjYNSkC7dv34yH96ndekQT74zfo2M6_DMfY-HyXDGEgXYHKMGTPSBWROmTm7oSKCaPg&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=JpoMwvOmI8EiEnZqKv1pTA&_nc_ss=7a30f&oh=00_Af2OVKepznOQZ3IX-zLvEo2kLnuG7__tVGUrZjjgcrbRgA&oe=69E5E16B',
+  },
+  {
+    id: 2,
+    name: 'Meeting people',
+    description:
+      "Sometimes all it takes is one small thing to turn your whole day around. That's what good design is for.",
+    price: 80.0,
+    image:
+      'https://scontent.xx.fbcdn.net/v/t39.6806-6/672442902_1640784437230723_4677249872577324579_n.jpg?_nc_cat=111&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=FTogKwiBg4oQ7kNvwG66g5l&_nc_oc=AdohfcFkqsXQ69dg4wisn1PklAF79fF9Nj8yv2VzbjdQCjdzvseKVPSke0RP0IjpniAdOiiK9NJv4Q1c85oXpxiK&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=J_KnD2I4RCz2o8AuLodUDQ&_nc_ss=7a30f&oh=00_Af28cM8LnHy_7WY3GWshof2Lb0LUOYTYGWcs6WJLZtn3Mw&oe=69E5DCC2',
+  },
+  {
+    id: 3,
+    name: 'Seeing things',
+    description:
+      "Sometimes all it takes is one small thing to turn your whole day around. That's what good design is for.",
+    price: 75.0,
+    image:
+      'https://scontent.xx.fbcdn.net/v/t39.6806-6/670491006_1228594285764183_1722506701323274836_n.jpg?_nc_cat=100&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=unkJDFgu-GIQ7kNvwHLBAsx&_nc_oc=AdriBiJflVanSL6euivARP6MqUkFisc5WqVoVdfnRLLC53mlQfqwIy13-ln2C-WURNmWQVwPWOS208aVNzXS-J03&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=PQDl1TKYJb3bDU1ul7KbxA&_nc_ss=7a30f&oh=00_Af3_j3JztXbZajrbUT0DvW6pDWu9ROyhHtoaYUewnVcirA&oe=69E5D9EE',
+  },
+  {
+    id: 4,
+    name: 'Sharing ideas',
+    description:
+      "Sometimes all it takes is one small thing to turn your whole day around. That's what good design is for.",
+    price: 75.0,
+    image:
+      'https://scontent.xx.fbcdn.net/v/t39.6806-6/670453426_1629772308172392_7338648760044721206_n.jpg?_nc_cat=104&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=w119t9ZcjqYQ7kNvwE2Tf7P&_nc_oc=AdojAepj9rmCVIeFNbEdopGIZbjSHlIf5nbxtyXI2GaOf5Nz8Gj23ajgGK--vzCyDLpCBHvRoGSNE2ioGSs11DTR&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=mUz5o8bLcOK-Q6fv8PeCIQ&_nc_ss=7a30f&oh=00_Af2_T8BE3gFLoT-wOHJ3ZC0Zafkan4APWs5SDWDmW2fQwQ&oe=69E5F2BC',
+  },
+  {
+    id: 5,
+    name: 'Making memories',
+    description:
+      "Sometimes all it takes is one small thing to turn your whole day around. That's what good design is for.",
+    price: 60.0,
+    image:
+      'https://scontent.xx.fbcdn.net/v/t39.6806-6/670440654_2425466027902111_441009769495615664_n.jpg?_nc_cat=100&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=sEujXUMcS0AQ7kNvwGotqx9&_nc_oc=AdoICPhh8wzKOuVjHhY4bDHG1GenjycImIsts9g2YwfUJfRhfqGiQ_v5I3l-HB7blzgW0OaXVo6R9Wy0O17WTrcR&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=gsRqlN0CNh8pEJrGowBt2A&_nc_ss=7a30f&oh=00_Af36QSneAf3QMV7wSsWXsheMX3vnv33kwsu79LnL0v5d0Q&oe=69E5EF77',
+  },
+  {
+    id: 6,
+    name: 'Being free',
+    description:
+      "Sometimes all it takes is one small thing to turn your whole day around. That's what good design is for.",
+    price: 80.0,
+    image:
+      'https://scontent.xx.fbcdn.net/v/t39.6806-6/673819168_896838673380430_7926069171483718115_n.jpg?_nc_cat=102&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=rhw65II8BL4Q7kNvwEQ_jcH&_nc_oc=AdpJgUbr24uDH4r8oWwxa54NQJ3z5y51tdL-gxZLR6UL9NAerKcrB4M6gl2qiXpe0H3yPqazZkot7IHWfyXqWdq4&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=SpweIC6Bhmp65LIJsM5o0g&_nc_ss=7a30f&oh=00_Af0umasO4WHA_M84DFsegtIr3laVMxdz3t-TRVTBHoy-6A&oe=69E5DFB7',
+  },
+];
+
+const fmt = (n: number) => `$${n.toFixed(2)}`;
+
+// ─── Product Card ───────────────────────────────────────────────────────────
+
+function ProductCard({product}: {product: Product}) {
+  return (
+    <a
+      href="#"
+      onClick={e => e.preventDefault()}
+      {...stylex.props(styles.link)}>
+      <XDSVStack gap={3}>
+        <XDSAspectRatio ratio={1} xstyle={styles.imageWrapper}>
+          <img
+            src={product.image}
+            alt={product.name}
+            {...stylex.props(styles.image)}
+          />
+        </XDSAspectRatio>
+
+        <XDSVStack gap={1}>
+          <XDSHeading level={2}>{product.name}</XDSHeading>
+          <XDSText type="body" color="secondary" maxLines={2}>
+            {product.description}
+          </XDSText>
+          <XDSHeading level={2}>{fmt(product.price)}</XDSHeading>
+        </XDSVStack>
+      </XDSVStack>
+    </a>
+  );
+}
+
+// ─── Main Page ──────────────────────────────────────────────────────────────
+
+export default function ProductGalleryTemplate() {
+  return (
+    <XDSAppShell height="auto" contentPadding={0} variant="surface">
+      <XDSCenter axis="horizontal">
+        <XDSSection variant="transparent" maxWidth={1200} padding={6}>
+          <XDSVStack gap={6}>
+            {/* Header — XDSGrid handles responsive stacking */}
+            <XDSGrid minChildWidth={280} gap={4} align="start">
+              <XDSHeading level={1}>
+                Make every day a little more delightful, one small detail at a
+                time.
+              </XDSHeading>
+              <XDSVStack gap={3} hAlign="start">
+                <XDSText type="body">
+                  We believe the smallest details are the ones that matter most.
+                  A little color, a thoughtful touch, a moment that catches your
+                  eye and makes you pause; that&apos;s what turns an ordinary
+                  day into something worth remembering.
+                </XDSText>
+                <XDSButton
+                  label="Get started"
+                  variant="primary"
+                  endContent={<XDSIcon icon={ArrowRightIcon} color="inherit" />}
+                />
+              </XDSVStack>
+            </XDSGrid>
+
+            {/* Product Grid — 3 cols desktop, wraps to 2→1 on smaller screens */}
+            <XDSGrid minChildWidth={300} gap={6}>
+              {PRODUCTS.map(product => (
+                <ProductCard key={product.id} product={product} />
+              ))}
+            </XDSGrid>
+          </XDSVStack>
+        </XDSSection>
+      </XDSCenter>
+    </XDSAppShell>
+  );
+}

--- a/packages/cli/templates/pages/product-gallery/template.doc.mjs
+++ b/packages/cli/templates/pages/product-gallery/template.doc.mjs
@@ -1,0 +1,7 @@
+/** @type {import('../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  name: 'Product Gallery',
+  description: 'Card grid of products with images, titles, descriptions, and prices',
+  type: 'page',
+  isReady: true,
+};

--- a/packages/cli/templates/pages/side-gallery/page.tsx
+++ b/packages/cli/templates/pages/side-gallery/page.tsx
@@ -1,0 +1,166 @@
+'use client';
+
+import {XDSAppShell} from '@xds/core/AppShell';
+import {XDSVStack, XDSHStack} from '@xds/core/Layout';
+import {XDSCenter} from '@xds/core/Center';
+import {XDSText, XDSHeading} from '@xds/core/Text';
+import {XDSButton} from '@xds/core/Button';
+import {XDSAspectRatio} from '@xds/core/AspectRatio';
+import {XDSGrid} from '@xds/core/Grid';
+import {XDSDivider} from '@xds/core/Divider';
+import * as stylex from '@stylexjs/stylex';
+
+// ─── Styles ─────────────────────────────────────────────────────────────────
+
+const styles = stylex.create({
+  pageContainer: {
+    maxWidth: 1400,
+    width: '100%',
+    padding: 'var(--spacing-6)',
+  },
+  splitLayout: {
+    display: 'grid',
+    gridTemplateColumns: '1fr 1.5fr',
+    gap: 'var(--spacing-7)',
+    alignItems: 'center',
+    '@media (max-width: 768px)': {
+      gridTemplateColumns: '1fr',
+    },
+  },
+  image: {
+    width: '100%',
+    height: '100%',
+    objectFit: 'cover',
+    borderRadius: 'var(--radius-element)',
+  },
+});
+
+// ─── Image Data ─────────────────────────────────────────────────────────────
+// From the xds_oss asset set (colorful home + lifestyle collection)
+// Source: meta assets.file list -s xds_oss -g <name>
+
+const IMAGES = [
+  // colorful-lifestyle-vertical-3
+  {
+    src: 'https://scontent.xx.fbcdn.net/v/t39.6806-6/670881450_942909805294726_1535530701838151731_n.png?_nc_cat=105&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=YJsHuTz01dYQ7kNvwH6-kmk&_nc_oc=AdrX4ZFOAAOKovmtgkhq8ZOE7TIvX385TGpGTWKv-CBDeCxCtDtBYu2n5TgAGwsQFQB_Zq-8wwfWxfD1W20QUMiB&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=kVgWieeU08fPHYu03xp3qw&_nc_ss=7a30f&oh=00_Af1kVcw3_nVnm4owz_4XjpVcktRykLY_t-UZQYywrmhicg&oe=69E85D78',
+    alt: 'Colorful lifestyle scene',
+  },
+  // colorful-lifestyle-horizontal-1
+  {
+    src: 'https://scontent.xx.fbcdn.net/v/t39.6806-6/670869277_2384531585379073_4187196261303804271_n.png?_nc_cat=109&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=k42Doxes-E8Q7kNvwG33lt4&_nc_oc=AdpmqdVjRRCmHVxDdN_SPhuWz5nvIYHOYS65etg6PHNLb0ZV7F07x5O7Hadq3hY_TPEXy5eG-yMEqC9WG-eerO6S&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=ldgh1BZQykdDzsO6sCfMIQ&_nc_ss=7a30f&oh=00_Af0w9Mf6fn-BBKbzZhOb27o1AeL8PR935dTd8VmeHSUtFw&oe=69E8642F',
+    alt: 'Colorful lifestyle horizontal',
+  },
+  // colorful-lifestyle-vertical-1
+  {
+    src: 'https://scontent.xx.fbcdn.net/v/t39.6806-6/670480937_2502078110200666_6842204180822201520_n.png?_nc_cat=100&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=CkjsPqmDibQQ7kNvwGqbpNN&_nc_oc=Adp5jI8z5m0aqhA07RtwoFUrqqr3jc6tQshxd5Hr5UyL_DIkFt0wEIQwLeKgXOg1lTBG_Ncth9lSFM0vmPqMxbfx&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=eCyOnLSq2cMADZiwJgLJaQ&_nc_ss=7a30f&oh=00_Af2sEmvEqZa5nd1SqocypZQnRh_FLwZHEBOrG0LTR7tfdA&oe=69E852F4',
+    alt: 'Colorful lifestyle vertical',
+  },
+  // colorful-home-vertical-2
+  {
+    src: 'https://scontent.xx.fbcdn.net/v/t39.6806-6/673560863_934276929587784_5026365305745738433_n.png?_nc_cat=109&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=pCmzN4XK86oQ7kNvwEs-6bx&_nc_oc=AdpaH9teEZJ98sMGLD1D-80kGCYl7zTREpkwuyCLZWFGb-9PO39gKp8zFkqEc4t_jBcdE5GV-T8ctnD8_hkQnM9D&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=jUcko_0qtWJ4t-YLeKiEAA&_nc_ss=7a30f&oh=00_Af27YiIM5tBU9uPmyA_XS7lCQYpmzN5rtbOQ4kPsRhBwPQ&oe=69E855F1',
+    alt: 'Colorful home interior',
+  },
+  // colorful-home-vertical-3
+  {
+    src: 'https://scontent.xx.fbcdn.net/v/t39.6806-6/672815225_4497021797184391_2254450750974048254_n.png?_nc_cat=111&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=4KkYH8-54SsQ7kNvwGhghew&_nc_oc=AdpJNio_WaXvIkloSWvCFmJwWa0wcoL9finilptuk5fJIYaSOAM8g-NWnubAFeveN0RAHqxe-pU3YBHh7ybHlI-L&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=WhrfoFdMQmPmojIQvdmDKQ&_nc_ss=7a30f&oh=00_Af1XlKmevkRyQWWusrDQ44-pbNlpFNauTiokwuROvIvm3A&oe=69E8757A',
+    alt: 'Colorful home scene',
+  },
+  // colorful-home-vertical-1
+  {
+    src: 'https://scontent.xx.fbcdn.net/v/t39.6806-6/670260643_4371306203125531_1093895092404715068_n.png?_nc_cat=108&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=SfQF1ExIcgoQ7kNvwFihLUA&_nc_oc=AdpW2kuWs3XyAU-CYLGDw_agXlIjTjuyHBH6Zbu4ZMLLh1Gyc6-z-6CJnqw2a7-9VRMwxi7wia-g3eT8_DwV8C24&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=lSN-jw1aN74yMsB836rjcA&_nc_ss=7a30f&oh=00_Af1XZ2pKW47WXf7D-58RKWq3ddFfELc1C2vhDaJdSrAueA&oe=69E86F2B',
+    alt: 'Colorful home vertical',
+  },
+  // colorful-lifestyle-horizontal-2
+  {
+    src: 'https://scontent.xx.fbcdn.net/v/t39.6806-6/671434591_1481606660072800_8012368080583907436_n.png?_nc_cat=111&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=1jIzvQ3OhF4Q7kNvwELzr-O&_nc_oc=AdqVeBjQk2OXWNGDXhn8nuzT_Z8e9_lt24_tADZ1HaOGeDQSapt5QTgh7_gogNuCLKpyfxILDufE5ZniUrqTOOl1&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=dvODr3eYtMdoe3Jd5KsuxQ&_nc_ss=7a30f&oh=00_Af2U5Q7atXhjhdKZWaO4NuhEyQvwmqiJMLDAxKp0NQQoag&oe=69E86743',
+    alt: 'Colorful lifestyle wide',
+  },
+  // colorful-lifestyle-vertical-2
+  {
+    src: 'https://scontent.xx.fbcdn.net/v/t39.6806-6/670422313_1309114328024296_2325112857517486215_n.png?_nc_cat=106&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=UcKaimmopFkQ7kNvwHsrlYX&_nc_oc=AdoDC8bS92DGKLlNrj6JZNPWHMK-iEiLKysuFj5ovT5yZ2fD8qrkkpxk8w4Z0A-78I8lzoxHcIomk41gwykoaSTM&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=s5tiaRXtT-Qv4iFpKfZlUA&_nc_ss=7a30f&oh=00_Af0GQSB9llTL_KKLnxZFKILBjmuAlkJIAr205eUVvrFMeg&oe=69E84882',
+    alt: 'Colorful lifestyle detail',
+  },
+  // colorful-lifestyle-vertical-4
+  {
+    src: 'https://scontent.xx.fbcdn.net/v/t39.6806-6/671971840_1715756549567950_672861276426865659_n.png?_nc_cat=106&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=9gFQdoQQugsQ7kNvwFY8re2&_nc_oc=Adrn7UNEJ5mxCqQJvrVCBfb0H8PKQog-RyBX8fPCKAib0Po1o2pCnHB9LJEbzYeLl32dVTX9LycSrRZw8EQ3vcHb&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=YfsLQvgrKBvW9w_wWJvN9Q&_nc_ss=7a30f&oh=00_Af24tnRP3Q0tt22Wz43oganzcTJsjHGhqefJvF2zK39Ucg&oe=69E879AC',
+    alt: 'Colorful lifestyle portrait',
+  },
+];
+
+// ─── Stat Block ─────────────────────────────────────────────────────────────
+
+function StatBlock({value, label}: {value: string; label: string}) {
+  return (
+    <XDSVStack gap={0}>
+      <XDSText type="large" weight="bold">
+        {value}
+      </XDSText>
+      <XDSText type="supporting" color="secondary">
+        {label}
+      </XDSText>
+    </XDSVStack>
+  );
+}
+
+// ─── Image Grid ─────────────────────────────────────────────────────────────
+
+function ImageGrid() {
+  return (
+    <XDSGrid columns={3} gap={3}>
+      {IMAGES.map((img, i) => (
+        <XDSAspectRatio key={i} ratio={1}>
+          <img src={img.src} alt={img.alt} {...stylex.props(styles.image)} />
+        </XDSAspectRatio>
+      ))}
+    </XDSGrid>
+  );
+}
+
+// ─── Main Page ──────────────────────────────────────────────────────────────
+
+export default function SideGalleryTemplate() {
+  return (
+    <XDSAppShell height="auto" contentPadding={0} variant="surface">
+      <XDSCenter axis="horizontal">
+        <div {...stylex.props(styles.pageContainer)}>
+          <div {...stylex.props(styles.splitLayout)}>
+            {/* Left side: Text + CTA */}
+            <XDSVStack gap={6} vAlign="center">
+              <XDSVStack gap={3}>
+                <XDSText type="supporting" color="secondary" weight="semibold">
+                  DAIILY
+                </XDSText>
+                <XDSHeading level={1}>
+                  Make every day a little more delightful, one small detail at a
+                  time.
+                </XDSHeading>
+                <XDSText type="body" color="secondary">
+                  We believe the smallest details are the ones that matter most.
+                  A little color, a thoughtful touch, a moment that catches your
+                  eye and makes you pause; that&apos;s what turns an ordinary
+                  day into something worth remembering.
+                </XDSText>
+              </XDSVStack>
+
+              <XDSHStack gap={3} vAlign="center">
+                <XDSButton label="Explore" variant="primary" />
+              </XDSHStack>
+
+              <XDSVStack gap={4}>
+                <XDSDivider />
+                <XDSHStack gap={6}>
+                  <StatBlock value="12k+" label="Photos" />
+                  <StatBlock value="350+" label="Projects" />
+                  <StatBlock value="8yrs" label="Experience" />
+                </XDSHStack>
+              </XDSVStack>
+            </XDSVStack>
+
+            {/* Right side: Image Grid */}
+            <ImageGrid />
+          </div>
+        </div>
+      </XDSCenter>
+    </XDSAppShell>
+  );
+}

--- a/packages/cli/templates/pages/side-gallery/template.doc.mjs
+++ b/packages/cli/templates/pages/side-gallery/template.doc.mjs
@@ -1,0 +1,7 @@
+/** @type {import('../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  name: 'Side Gallery',
+  description: 'Text and CTA on the left with an image collage on the right',
+  type: 'page',
+  isReady: true,
+};


### PR DESCRIPTION
Adds 4 gallery templates to the sandbox. Clean branch with 1 commit per template.

Supersedes #1348.

1. **product-gallery** — Card grid with product images, titles, descriptions, and prices
2. **classic-gallery** — Clean filterable image grid with category tabs
3. **mixed-gallery** — Masonry-style image gallery with hover overlays
4. **side-gallery** — Text and CTA on the left with 3×3 image grid on the right

### Template Grading (per [Contributing-Templates rubric](https://github.com/facebookexperimental/xds/wiki/Contributing-Templates#template-grading-rubric))

| Template | Score | Grade | Notes |
|----------|-------|-------|-------|
| product-gallery | 85 | B+ | Heroicon, XDSAppShell, XDSSection, all StyleX with tokens |
| side-gallery | 82 | B | XDSAppShell, XDSGrid for image grid, all StyleX with tokens |
| classic-gallery | 80 | B | XDSAppShell, XDSGrid minChildWidth, category tabs |
| mixed-gallery | 70 | C+ | Masonry layout + hover overlay pattern is inherently CSS-heavy |

All templates use:
- XDS components for all layout, text, and interactive elements
- StyleX with XDS token vars (`--spacing-*`, `--radius-*`) for any custom styling
- Images from `xds_oss` asset manager (CDN URLs)
- `XDSMediaTheme mode="dark"` for overlay text (mixed-gallery)
- Zero inline `style={{}}` attributes
- Zero lorem ipsum — all real copy
- Heroicons via `@heroicons/react` (no inline SVGs)