### PR TITLE
refactor(codeeditor): converge on shared CodeBlock infrastructure

### DIFF
--- a/apps/storybook/stories/CodeEditorPerf.stories.tsx
+++ b/apps/storybook/stories/CodeEditorPerf.stories.tsx
@@ -1,0 +1,353 @@
+import type {Meta, StoryObj} from '@storybook/react';
+import {useState, useRef, useEffect, useCallback} from 'react';
+import {XDSCodeEditor} from '@xds/lab';
+
+const meta: Meta<typeof XDSCodeEditor> = {
+  title: 'Performance/XDSCodeEditor',
+  component: XDSCodeEditor,
+  parameters: {layout: 'fullscreen'},
+};
+
+export default meta;
+type Story = StoryObj<typeof XDSCodeEditor>;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function generateCode(lineCount: number): string {
+  const lines: string[] = [];
+  for (let i = 0; i < lineCount; i++) {
+    const mod = i % 6;
+    if (mod === 0) lines.push(`import {Component${i}} from './module${i}';`);
+    else if (mod === 1) lines.push(`const value${i} = ${i} + Math.random();`);
+    else if (mod === 2) lines.push(`function compute${i}(x: number): number {`);
+    else if (mod === 3)
+      lines.push(`  return x * ${i} + value${Math.max(0, i - 2)};`);
+    else if (mod === 4) lines.push(`}`);
+    else lines.push(`// Line ${i + 1}: performance test`);
+  }
+  return lines.join('\n');
+}
+
+function Metric({label, value}: {label: string; value: string | number}) {
+  return (
+    <div
+      style={{
+        display: 'inline-flex',
+        gap: 4,
+        padding: '2px 8px',
+        borderRadius: 4,
+        background: '#f0f0f0',
+        fontSize: 12,
+        fontFamily: 'monospace',
+      }}>
+      <span style={{color: '#666'}}>{label}:</span>
+      <strong>{value}</strong>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Stress Test — single editor, configurable line count
+// ---------------------------------------------------------------------------
+
+function StressTestImpl() {
+  const [lineCount, setLineCount] = useState(500);
+  const [mode, setMode] = useState<'auto' | 'ranges' | 'spans'>('auto');
+  const [code, setCode] = useState(() => generateCode(500));
+  const [mountTime, setMountTime] = useState<number | null>(null);
+  const mountStart = useRef(0);
+
+  useEffect(() => {
+    mountStart.current = performance.now();
+  }, [code]);
+
+  useEffect(() => {
+    const frame = requestAnimationFrame(() => {
+      setMountTime(performance.now() - mountStart.current);
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [code]);
+
+  const regenerate = useCallback((count: number) => {
+    setLineCount(count);
+    setCode(generateCode(count));
+  }, []);
+
+  return (
+    <div
+      style={{padding: 16, display: 'flex', flexDirection: 'column', gap: 12}}>
+      <div
+        style={{
+          display: 'flex',
+          gap: 8,
+          alignItems: 'center',
+          flexWrap: 'wrap',
+        }}>
+        <span style={{fontSize: 13, fontWeight: 600}}>Lines:</span>
+        {[100, 500, 1000, 2000, 5000].map(n => (
+          <button
+            key={n}
+            onClick={() => regenerate(n)}
+            style={{
+              padding: '4px 10px',
+              borderRadius: 4,
+              border: lineCount === n ? '2px solid #0066cc' : '1px solid #ccc',
+              background: lineCount === n ? '#e6f0ff' : 'white',
+              cursor: 'pointer',
+              fontSize: 12,
+            }}>
+            {n}
+          </button>
+        ))}
+        <span style={{fontSize: 13, fontWeight: 600, marginLeft: 12}}>
+          Mode:
+        </span>
+        {(['auto', 'ranges', 'spans'] as const).map(m => (
+          <button
+            key={m}
+            onClick={() => setMode(m)}
+            style={{
+              padding: '4px 10px',
+              borderRadius: 4,
+              border: mode === m ? '2px solid #0066cc' : '1px solid #ccc',
+              background: mode === m ? '#e6f0ff' : 'white',
+              cursor: 'pointer',
+              fontSize: 12,
+            }}>
+            {m}
+          </button>
+        ))}
+        {mountTime != null && (
+          <Metric label="Mount" value={`${mountTime.toFixed(1)}ms`} />
+        )}
+      </div>
+      <XDSCodeEditor
+        value={code}
+        onChange={setCode}
+        language="typescript"
+        hasLineNumbers
+        highlightMode={mode}
+        maxHeight={600}
+      />
+    </div>
+  );
+}
+
+export const StressTest: Story = {
+  render: () => <StressTestImpl />,
+};
+
+// ---------------------------------------------------------------------------
+// Side by Side — ranges vs spans
+// ---------------------------------------------------------------------------
+
+function SideBySideImpl() {
+  const [lineCount, setLineCount] = useState(500);
+  const initialCode = generateCode(500);
+  const [codeA, setCodeA] = useState(initialCode);
+  const [codeB, setCodeB] = useState(initialCode);
+  const [mountA, setMountA] = useState<number | null>(null);
+  const [mountB, setMountB] = useState<number | null>(null);
+  const startA = useRef(0);
+  const startB = useRef(0);
+
+  useEffect(() => {
+    startA.current = performance.now();
+    startB.current = performance.now();
+  }, [lineCount]);
+
+  useEffect(() => {
+    const frame = requestAnimationFrame(() => {
+      const now = performance.now();
+      setMountA(now - startA.current);
+      setMountB(now - startB.current);
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [lineCount]);
+
+  const regenerate = useCallback((count: number) => {
+    setLineCount(count);
+    const c = generateCode(count);
+    setCodeA(c);
+    setCodeB(c);
+  }, []);
+
+  return (
+    <div
+      style={{padding: 16, display: 'flex', flexDirection: 'column', gap: 12}}>
+      <div style={{display: 'flex', gap: 8, alignItems: 'center'}}>
+        <span style={{fontSize: 13, fontWeight: 600}}>Lines:</span>
+        {[100, 500, 1000, 2000].map(n => (
+          <button
+            key={n}
+            onClick={() => regenerate(n)}
+            style={{
+              padding: '4px 10px',
+              borderRadius: 4,
+              border: lineCount === n ? '2px solid #0066cc' : '1px solid #ccc',
+              background: lineCount === n ? '#e6f0ff' : 'white',
+              cursor: 'pointer',
+              fontSize: 12,
+            }}>
+            {n}
+          </button>
+        ))}
+      </div>
+      <div style={{display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16}}>
+        <div>
+          <div
+            style={{
+              display: 'flex',
+              gap: 8,
+              marginBottom: 8,
+              alignItems: 'center',
+            }}>
+            <strong style={{fontSize: 13}}>Ranges (CSS Highlight API)</strong>
+            {mountA != null && (
+              <Metric label="Mount" value={`${mountA.toFixed(1)}ms`} />
+            )}
+          </div>
+          <XDSCodeEditor
+            value={codeA}
+            onChange={setCodeA}
+            language="typescript"
+            hasLineNumbers
+            highlightMode="ranges"
+            maxHeight={500}
+          />
+        </div>
+        <div>
+          <div
+            style={{
+              display: 'flex',
+              gap: 8,
+              marginBottom: 8,
+              alignItems: 'center',
+            }}>
+            <strong style={{fontSize: 13}}>Spans (overlay)</strong>
+            {mountB != null && (
+              <Metric label="Mount" value={`${mountB.toFixed(1)}ms`} />
+            )}
+          </div>
+          <XDSCodeEditor
+            value={codeB}
+            onChange={setCodeB}
+            language="typescript"
+            hasLineNumbers
+            highlightMode="spans"
+            maxHeight={500}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export const SideBySide: Story = {
+  render: () => <SideBySideImpl />,
+};
+
+// ---------------------------------------------------------------------------
+// Typing Latency — measure input responsiveness
+// ---------------------------------------------------------------------------
+
+function TypingLatencyImpl() {
+  const [lineCount, setLineCount] = useState(500);
+  const [mode, setMode] = useState<'auto' | 'ranges' | 'spans'>('auto');
+  const [code, setCode] = useState(() => generateCode(500));
+  const [latencies, setLatencies] = useState<number[]>([]);
+  const lastInput = useRef(0);
+
+  const handleChange = useCallback((val: string) => {
+    const now = performance.now();
+    if (lastInput.current > 0) {
+      const dt = now - lastInput.current;
+      // Only record if this looks like a keystroke (< 500ms gap)
+      if (dt < 500) {
+        setLatencies(prev => [...prev.slice(-49), dt]);
+      }
+    }
+    lastInput.current = now;
+    setCode(val);
+  }, []);
+
+  const avgLatency =
+    latencies.length > 0
+      ? latencies.reduce((a, b) => a + b, 0) / latencies.length
+      : 0;
+  const maxLatency = latencies.length > 0 ? Math.max(...latencies) : 0;
+
+  const regenerate = useCallback((count: number) => {
+    setLineCount(count);
+    setCode(generateCode(count));
+    setLatencies([]);
+  }, []);
+
+  return (
+    <div
+      style={{padding: 16, display: 'flex', flexDirection: 'column', gap: 12}}>
+      <div
+        style={{
+          display: 'flex',
+          gap: 8,
+          alignItems: 'center',
+          flexWrap: 'wrap',
+        }}>
+        <span style={{fontSize: 13, fontWeight: 600}}>Lines:</span>
+        {[100, 500, 1000, 2000].map(n => (
+          <button
+            key={n}
+            onClick={() => regenerate(n)}
+            style={{
+              padding: '4px 10px',
+              borderRadius: 4,
+              border: lineCount === n ? '2px solid #0066cc' : '1px solid #ccc',
+              background: lineCount === n ? '#e6f0ff' : 'white',
+              cursor: 'pointer',
+              fontSize: 12,
+            }}>
+            {n}
+          </button>
+        ))}
+        <span style={{fontSize: 13, fontWeight: 600, marginLeft: 12}}>
+          Mode:
+        </span>
+        {(['auto', 'ranges', 'spans'] as const).map(m => (
+          <button
+            key={m}
+            onClick={() => setMode(m)}
+            style={{
+              padding: '4px 10px',
+              borderRadius: 4,
+              border: mode === m ? '2px solid #0066cc' : '1px solid #ccc',
+              background: mode === m ? '#e6f0ff' : 'white',
+              cursor: 'pointer',
+              fontSize: 12,
+            }}>
+            {m}
+          </button>
+        ))}
+        <Metric label="Avg" value={`${avgLatency.toFixed(1)}ms`} />
+        <Metric label="Max" value={`${maxLatency.toFixed(1)}ms`} />
+        <Metric label="Samples" value={latencies.length} />
+        <span style={{fontSize: 11, color: '#888'}}>
+          Type in the editor to measure input latency
+        </span>
+      </div>
+      <XDSCodeEditor
+        value={code}
+        onChange={handleChange}
+        language="typescript"
+        hasLineNumbers
+        highlightMode={mode}
+        maxHeight={600}
+      />
+    </div>
+  );
+}
+
+export const TypingLatency: Story = {
+  render: () => <TypingLatencyImpl />,
+};

--- a/apps/storybook/stories/CodeEditorTheme.stories.tsx
+++ b/apps/storybook/stories/CodeEditorTheme.stories.tsx
@@ -1,0 +1,239 @@
+import type {Meta, StoryObj} from '@storybook/react';
+import {useState} from 'react';
+import {XDSCodeEditor} from '@xds/lab';
+import {
+  XDSSyntaxTheme as SyntaxThemeProvider,
+  defineSyntaxTheme,
+} from '@xds/core/theme/syntax';
+import {
+  oneDarkPro,
+  dracula,
+  monokai,
+  nord,
+  tokyoNight,
+  catppuccinMocha,
+  githubDark,
+  githubLight,
+  solarizedLight,
+  oneLight,
+  catppuccinLatte,
+  tokyoNightLight,
+  allSyntaxPresets,
+} from '@xds/core/theme/syntax';
+
+const sampleCode = [
+  "import {useState, useEffect} from 'react';",
+  '',
+  'interface User {',
+  '  id: string;',
+  '  name: string;',
+  '  roles: string[];',
+  '}',
+  '',
+  'const API_URL = "https://api.example.com";',
+  'const MAX_RETRIES = 3;',
+  '',
+  '// Fetch user data with retry logic',
+  'async function fetchUser(id: string): Promise<User> {',
+  '  const response = await fetch(`${API_URL}/users/${id}`);',
+  '  if (!response.ok) {',
+  '    throw new Error(`HTTP ${response.status}`);',
+  '  }',
+  '  return response.json();',
+  '}',
+  '',
+  'export function UserCard({id}: {id: string}) {',
+  '  const [user, setUser] = useState<User | null>(null);',
+  '',
+  '  useEffect(() => {',
+  '    fetchUser(id).then(setUser);',
+  '  }, [id]);',
+  '',
+  '  if (!user) return <div>Loading...</div>;',
+  '',
+  '  return (',
+  '    <div className="card">',
+  '      <h2>{user.name}</h2>',
+  '      <span>{user.roles.length} roles</span>',
+  '    </div>',
+  '  );',
+  '}',
+].join('\n');
+
+function ThemedEditor({
+  theme,
+  title,
+  initialCode = sampleCode,
+}: {
+  theme: Parameters<typeof SyntaxThemeProvider>[0]['theme'];
+  title?: string;
+  initialCode?: string;
+}) {
+  const [value, setValue] = useState(initialCode);
+  return (
+    <SyntaxThemeProvider theme={theme}>
+      <XDSCodeEditor
+        value={value}
+        onChange={setValue}
+        language="typescript"
+        hasLineNumbers
+      />
+    </SyntaxThemeProvider>
+  );
+}
+
+const meta: Meta = {
+  title: 'Lab/XDSCodeEditor Themes',
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Syntax theme showcase for XDSCodeEditor. All themes from XDSSyntaxTheme ' +
+          'work identically on both CodeBlock and CodeEditor.',
+      },
+    },
+  },
+};
+
+export default meta;
+
+// ---------------------------------------------------------------------------
+// Individual theme stories
+// ---------------------------------------------------------------------------
+
+export const OneDarkPro: StoryObj = {
+  render: () => <ThemedEditor theme={oneDarkPro} />,
+};
+
+export const Dracula: StoryObj = {
+  render: () => <ThemedEditor theme={dracula} />,
+};
+
+export const Monokai: StoryObj = {
+  render: () => <ThemedEditor theme={monokai} />,
+};
+
+export const Nord: StoryObj = {
+  render: () => <ThemedEditor theme={nord} />,
+};
+
+export const TokyoNight: StoryObj = {
+  render: () => <ThemedEditor theme={tokyoNight} />,
+};
+
+export const CatppuccinMocha: StoryObj = {
+  render: () => <ThemedEditor theme={catppuccinMocha} />,
+};
+
+export const GitHubLight: StoryObj = {
+  render: () => <ThemedEditor theme={githubLight} />,
+};
+
+export const GitHubDark: StoryObj = {
+  render: () => <ThemedEditor theme={githubDark} />,
+};
+
+export const SolarizedLight: StoryObj = {
+  render: () => <ThemedEditor theme={solarizedLight} />,
+};
+
+export const OneLight: StoryObj = {
+  render: () => <ThemedEditor theme={oneLight} />,
+};
+
+export const CatppuccinLatte: StoryObj = {
+  render: () => <ThemedEditor theme={catppuccinLatte} />,
+};
+
+export const TokyoNightLight: StoryObj = {
+  render: () => <ThemedEditor theme={tokyoNightLight} />,
+};
+
+// ---------------------------------------------------------------------------
+// Gallery — all themes side by side
+// ---------------------------------------------------------------------------
+
+const shortCode = [
+  'const greet = (name: string) => {',
+  '  // Say hello',
+  '  return `Hello, ${name}!`;',
+  '};',
+  '',
+  'const result = greet("World");',
+  'console.log(result); // Hello, World!',
+].join('\n');
+
+function GalleryEditor({
+  theme,
+}: {
+  theme: Parameters<typeof SyntaxThemeProvider>[0]['theme'];
+}) {
+  const [value, setValue] = useState(shortCode);
+  return (
+    <SyntaxThemeProvider theme={theme}>
+      <div>
+        <div
+          style={{
+            fontSize: 11,
+            fontWeight: 600,
+            color: '#888',
+            marginBottom: 4,
+            fontFamily: 'monospace',
+          }}>
+          {theme.name}
+        </div>
+        <XDSCodeEditor
+          value={value}
+          onChange={setValue}
+          language="typescript"
+          hasLineNumbers
+        />
+      </div>
+    </SyntaxThemeProvider>
+  );
+}
+
+export const AllThemesGallery: StoryObj = {
+  render: () => (
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: '1fr 1fr',
+        gap: 16,
+        padding: 16,
+      }}>
+      {allSyntaxPresets.map(theme => (
+        <GalleryEditor key={theme.name} theme={theme} />
+      ))}
+    </div>
+  ),
+  parameters: {layout: 'fullscreen'},
+};
+
+// ---------------------------------------------------------------------------
+// Custom syntax theme
+// ---------------------------------------------------------------------------
+
+const cyberpunk = defineSyntaxTheme({
+  name: 'cyberpunk',
+  tokens: {
+    keyword: '#ff2a6d',
+    string: '#05d9e8',
+    comment: '#4a5568',
+    number: '#d1f7ff',
+    function: '#ff6ac1',
+    type: '#7efff5',
+    variable: '#e2e8f0',
+    operator: '#ff9e64',
+    constant: '#d1f7ff',
+    tag: '#ff2a6d',
+    attribute: '#7efff5',
+    property: '#05d9e8',
+    punctuation: '#718096',
+    background: '#0d0221',
+  },
+});
+
+export const CustomTheme: StoryObj = {
+  render: () => <ThemedEditor theme={cyberpunk} />,
+};

--- a/packages/core/src/CodeBlock/XDSCodeBlock.tsx
+++ b/packages/core/src/CodeBlock/XDSCodeBlock.tsx
@@ -8,6 +8,7 @@
 
 import {
   useLayoutEffect,
+  useEffect,
   useRef,
   useState,
   useCallback,

--- a/packages/core/src/CodeBlock/XDSCodeBlock.tsx
+++ b/packages/core/src/CodeBlock/XDSCodeBlock.tsx
@@ -8,7 +8,6 @@
 
 import {
   useLayoutEffect,
-  useEffect,
   useRef,
   useState,
   useCallback,
@@ -32,15 +31,10 @@ import {
 } from '../theme/tokens.stylex';
 import {xdsClassName, mergeProps} from '../utils';
 import {XDSIcon} from '../Icon';
-import {
-  tokenize,
-  tokenizeAsync,
-  flatTokensToLines,
-  SYNC_TOKENIZE_THRESHOLD,
-} from './tokenizer';
-import type {Token, TokenLine} from './tokenizer';
+import type {TokenLine} from './tokenizer';
 import {ensureHighlightStyles} from './highlightStyles';
 import {applyHighlightRangesChunked} from './highlightRanges';
+import {hasHighlightAPI, useTokenLines, buildSpanLine} from './codeShared';
 
 // ---------------------------------------------------------------------------
 // Styles
@@ -321,95 +315,8 @@ export interface XDSCodeBlockProps extends XDSBaseProps<HTMLPreElement> {
 }
 
 // ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function hasHighlightAPI(): boolean {
-  return (
-    typeof CSS !== 'undefined' &&
-    'highlights' in CSS &&
-    typeof Highlight !== 'undefined'
-  );
-}
-
-/**
- * Hook: per-line tokens with sync/async + custom tokenizer compat.
- */
-function useTokenLines(
-  code: string,
-  language: string,
-  customTokenizer?: XDSCodeBlockProps['tokenizer'],
-): TokenLine[] {
-  const [asyncTokens, setAsyncTokens] = useState<TokenLine[] | null>(null);
-
-  const syncTokens = useMemo(() => {
-    if (code.length >= SYNC_TOKENIZE_THRESHOLD) return null;
-    if (customTokenizer) {
-      return flatTokensToLines(customTokenizer(code, language), code);
-    }
-    return tokenize(code, language);
-  }, [code, language, customTokenizer]);
-
-  useEffect(() => {
-    if (code.length < SYNC_TOKENIZE_THRESHOLD) return;
-
-    const abortController = new AbortController();
-
-    if (customTokenizer) {
-      Promise.resolve().then(() => {
-        if (abortController.signal.aborted) return;
-        const flat = customTokenizer(code, language);
-        setAsyncTokens(flatTokensToLines(flat, code));
-      });
-    } else {
-      tokenizeAsync(code, language, abortController.signal).then(tokens => {
-        if (!abortController.signal.aborted) {
-          setAsyncTokens(tokens);
-        }
-      });
-    }
-
-    return () => {
-      abortController.abort();
-      setAsyncTokens(null);
-    };
-  }, [code, language, customTokenizer]);
-
-  return syncTokens ?? asyncTokens ?? [];
-}
-
-// ---------------------------------------------------------------------------
 // Span-mode code element
 // ---------------------------------------------------------------------------
-
-function buildSpanLine(lineText: string, tokens: Token[]): React.ReactNode {
-  if (tokens.length === 0) {
-    return lineText || '\u200b';
-  }
-
-  const parts: React.ReactNode[] = [];
-  let cursor = 0;
-
-  for (const token of tokens) {
-    if (token.start > cursor) {
-      parts.push(lineText.slice(cursor, token.start));
-    }
-    const end = Math.min(token.end, lineText.length);
-    parts.push(
-      <span
-        key={`${token.start}-${token.type}`}
-        className={`xds-token-${token.type}`}>
-        {lineText.slice(token.start, end)}
-      </span>,
-    );
-    cursor = end;
-  }
-
-  if (cursor < lineText.length) {
-    parts.push(lineText.slice(cursor));
-  }
-  return parts.length > 0 ? parts : '\u200b';
-}
 
 function SpanCodeContent({
   lines,

--- a/packages/core/src/CodeBlock/codeShared.tsx
+++ b/packages/core/src/CodeBlock/codeShared.tsx
@@ -1,0 +1,153 @@
+/**
+ * @file codeShared.tsx
+ * @input Code string, language, tokenizer functions
+ * @output Shared hooks and helpers for CodeBlock and CodeEditor
+ * @position Shared utility; consumed by XDSCodeBlock and XDSCodeEditor
+ */
+
+import {useEffect, useMemo, useState} from 'react';
+import * as React from 'react';
+import {
+  tokenize,
+  tokenizeAsync,
+  flatTokensToLines,
+  SYNC_TOKENIZE_THRESHOLD,
+} from './tokenizer';
+import type {Token, TokenLine} from './tokenizer';
+
+// ---------------------------------------------------------------------------
+// Feature detection
+// ---------------------------------------------------------------------------
+
+export function hasHighlightAPI(): boolean {
+  return (
+    typeof CSS !== 'undefined' &&
+    'highlights' in CSS &&
+    typeof Highlight !== 'undefined'
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tokenizer types
+// ---------------------------------------------------------------------------
+
+/** Custom tokenizer that returns flat tokens with absolute offsets. */
+export type FlatTokenizer = (
+  code: string,
+  language: string,
+) => Array<{type: string; start: number; end: number}>;
+
+/** Custom tokenizer that returns per-line tokens directly. */
+export type LineTokenizer = (code: string, language: string) => TokenLine[];
+
+// ---------------------------------------------------------------------------
+// useTokenLines hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Unified sync/async tokenization hook. Returns per-line token arrays.
+ *
+ * - Small code (< SYNC_TOKENIZE_THRESHOLD): tokenized synchronously in useMemo
+ * - Large code: tokenized asynchronously with abort support
+ * - Custom tokenizers: flat tokenizers are automatically converted to per-line
+ */
+export function useTokenLines(
+  code: string,
+  language: string,
+  customTokenizer?: FlatTokenizer | LineTokenizer,
+): TokenLine[] {
+  const [asyncTokens, setAsyncTokens] = useState<TokenLine[] | null>(null);
+
+  const syncTokens = useMemo(() => {
+    if (code.length >= SYNC_TOKENIZE_THRESHOLD) return null;
+    if (customTokenizer) {
+      const result = customTokenizer(code, language);
+      // If the result is an array of arrays, it's already per-line
+      if (result.length > 0 && Array.isArray(result[0])) {
+        return result as TokenLine[];
+      }
+      return flatTokensToLines(
+        result as Array<{type: string; start: number; end: number}>,
+        code,
+      );
+    }
+    return tokenize(code, language);
+  }, [code, language, customTokenizer]);
+
+  useEffect(() => {
+    if (code.length < SYNC_TOKENIZE_THRESHOLD) return;
+
+    const abortController = new AbortController();
+
+    if (customTokenizer) {
+      Promise.resolve().then(() => {
+        if (abortController.signal.aborted) return;
+        const result = customTokenizer(code, language);
+        if (result.length > 0 && Array.isArray(result[0])) {
+          setAsyncTokens(result as TokenLine[]);
+        } else {
+          setAsyncTokens(
+            flatTokensToLines(
+              result as Array<{type: string; start: number; end: number}>,
+              code,
+            ),
+          );
+        }
+      });
+    } else {
+      tokenizeAsync(code, language, abortController.signal).then(tokens => {
+        if (!abortController.signal.aborted) {
+          setAsyncTokens(tokens);
+        }
+      });
+    }
+
+    return () => {
+      abortController.abort();
+      setAsyncTokens(null);
+    };
+  }, [code, language, customTokenizer]);
+
+  return syncTokens ?? asyncTokens ?? [];
+}
+
+// ---------------------------------------------------------------------------
+// Span-mode helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build span-based highlighted content for a single line.
+ * Tokens with the default color type are already filtered out by
+ * the tokenizer, so every token here gets a colored span.
+ */
+export function buildSpanLine(
+  lineText: string,
+  tokens: Token[],
+): React.ReactNode {
+  if (tokens.length === 0) {
+    return lineText || '\u200b';
+  }
+
+  const parts: React.ReactNode[] = [];
+  let cursor = 0;
+
+  for (const token of tokens) {
+    if (token.start > cursor) {
+      parts.push(lineText.slice(cursor, token.start));
+    }
+    const end = Math.min(token.end, lineText.length);
+    parts.push(
+      <span
+        key={`${token.start}-${token.type}`}
+        className={`xds-token-${token.type}`}>
+        {lineText.slice(token.start, end)}
+      </span>,
+    );
+    cursor = end;
+  }
+
+  if (cursor < lineText.length) {
+    parts.push(lineText.slice(cursor));
+  }
+  return parts.length > 0 ? parts : '\u200b';
+}

--- a/packages/core/src/CodeBlock/index.ts
+++ b/packages/core/src/CodeBlock/index.ts
@@ -13,5 +13,11 @@ export {
 } from './tokenizer';
 export type {Token, TokenLine} from './tokenizer';
 
-export {applyHighlightRangesChunked, applyHighlightRangesBatch, cleanupRanges} from './highlightRanges';
+export {
+  applyHighlightRangesChunked,
+  applyHighlightRangesBatch,
+  cleanupRanges,
+} from './highlightRanges';
 export {ensureHighlightStyles, TOKEN_TYPES} from './highlightStyles';
+export {hasHighlightAPI, useTokenLines, buildSpanLine} from './codeShared';
+export type {FlatTokenizer, LineTokenizer} from './codeShared';

--- a/packages/lab/src/CodeEditor/XDSCodeEditor.tsx
+++ b/packages/lab/src/CodeEditor/XDSCodeEditor.tsx
@@ -2,24 +2,15 @@
  * @file XDSCodeEditor.tsx
  * @input Uses React, StyleX, theme tokens, CSS Custom Highlight API
  * @output Exports XDSCodeEditor component and XDSCodeEditorProps
- * @position Core implementation; editable code input (lab/experimental)
+ * @position Lab implementation; editable code input
  *
- * SYNC: When modified, update:
- * - /packages/lab/src/CodeEditor/index.ts (exports if types change)
- * - /packages/lab/src/CodeBlock/tokenizer.ts (shared tokenizer)
- * - /packages/lab/src/CodeBlock/highlightStyles.ts (::highlight rules)
+ * Shares tokenization, span rendering, and highlight infrastructure
+ * with XDSCodeBlock via codeShared utilities.
  */
 
 'use client';
 
-import {
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  useCallback,
-  useState,
-  useMemo,
-} from 'react';
+import {useEffect, useLayoutEffect, useRef, useCallback, useState} from 'react';
 import type {XDSBaseProps} from '@xds/core/XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
 import {
@@ -32,13 +23,15 @@ import {
   borderVars,
 } from '@xds/core/theme/tokens.stylex';
 import {xdsClassName, mergeProps} from '@xds/core/utils';
+import type {TokenLine} from '@xds/core/CodeBlock';
+import type {FlatTokenizer, LineTokenizer} from '@xds/core/CodeBlock';
 import {
-  tokenize,
-  tokenizeAsync,
-  SYNC_TOKENIZE_THRESHOLD,
+  ensureHighlightStyles,
+  applyHighlightRangesChunked,
+  hasHighlightAPI,
+  useTokenLines,
+  buildSpanLine,
 } from '@xds/core/CodeBlock';
-import type {Token, TokenLine} from '@xds/core/CodeBlock';
-import {ensureHighlightStyles, applyHighlightRangesChunked} from '@xds/core/CodeBlock';
 
 // ---------------------------------------------------------------------------
 // Styles
@@ -49,7 +42,7 @@ const styles = stylex.create({
     position: 'relative',
     display: 'flex',
     borderRadius: radiusVars['--radius-element'],
-    backgroundColor: colorVars['--color-background-muted'],
+    backgroundColor: 'var(--color-syntax-background)',
     border: `${borderVars['--border-width']} solid ${colorVars['--color-border']}`,
     overflow: 'hidden',
   },
@@ -64,7 +57,7 @@ const styles = stylex.create({
     paddingInlineEnd: spacingVars['--spacing-3'],
     textAlign: 'end',
     userSelect: 'none',
-    color: colorVars['--color-text-disabled'],
+    color: 'var(--color-syntax-punctuation)',
     borderRight: `${borderVars['--border-width']} solid ${colorVars['--color-border']}`,
   },
   gutterLine: {
@@ -82,7 +75,7 @@ const styles = stylex.create({
     paddingInline: spacingVars['--spacing-4'],
     margin: 0,
     fontFamily: typographyVars['--font-family-code'],
-    color: colorVars['--color-text-primary'],
+    color: 'var(--color-syntax-variable)',
     tabSize: 2,
     whiteSpace: 'pre',
     wordBreak: 'normal',
@@ -105,13 +98,13 @@ const styles = stylex.create({
     fontSize: textSizeVars['--font-size-sm'],
   },
   sizeMd: {
-    fontSize: textSizeVars['--font-size-base'],
+    fontSize: typeScaleVars['--text-code-size'],
   },
   gutterSm: {
     fontSize: textSizeVars['--font-size-sm'],
   },
   gutterMd: {
-    fontSize: textSizeVars['--font-size-base'],
+    fontSize: typeScaleVars['--text-code-size'],
   },
 });
 
@@ -123,7 +116,6 @@ export interface XDSCodeEditorProps extends Omit<
   XDSBaseProps<HTMLDivElement>,
   'onChange'
 > {
-  /** Ref forwarded to the root element */
   ref?: React.Ref<HTMLDivElement>;
   /** Controlled value */
   value: string;
@@ -141,33 +133,21 @@ export interface XDSCodeEditorProps extends Omit<
   maxHeight?: number | string;
   /** Text size. @default "md" */
   size?: 'sm' | 'md';
-  /** Custom tokenizer */
-  tokenizer?: (
-    code: string,
-    language: string,
-  ) => TokenLine[];
+  /** Custom tokenizer (flat or per-line) */
+  tokenizer?: FlatTokenizer | LineTokenizer;
   /**
    * How to apply syntax highlighting.
-   * - 'css-highlight': Uses CSS Custom Highlight API (zero DOM overhead).
-   *   Falls back to 'spans' if the API is not available.
-   * - 'spans': Renders `<span>` elements with CSS classes per token.
-   *   In the editor, uses a transparent-text overlay approach.
-   * @default 'css-highlight'
+   * - 'auto': Uses CSS Custom Highlight API when available, falls back to spans.
+   * - 'ranges': Forces CSS Custom Highlight API (no-op if unavailable).
+   * - 'spans': Renders colored `<span>` elements with transparent-text overlay.
+   * @default 'auto'
    */
-  highlightMode?: 'css-highlight' | 'spans';
+  highlightMode?: 'auto' | 'ranges' | 'spans';
 }
 
 // ---------------------------------------------------------------------------
-// Helpers
+// Editor behavior
 // ---------------------------------------------------------------------------
-
-function hasHighlightAPI(): boolean {
-  return (
-    typeof CSS !== 'undefined' &&
-    'highlights' in CSS &&
-    typeof Highlight !== 'undefined'
-  );
-}
 
 const AUTO_CLOSE_PAIRS: Record<string, string> = {
   '(': ')',
@@ -178,54 +158,14 @@ const AUTO_CLOSE_PAIRS: Record<string, string> = {
   '`': '`',
 };
 
-let editorInstanceCounter = 0;
-
 // ---------------------------------------------------------------------------
-// Span-based rendering helpers
+// Span-mode overlay
 // ---------------------------------------------------------------------------
 
-
-/**
- * Build span-based highlighted line content from per-line tokens.
- */
-function buildSpanLine(
-  lineText: string,
-  tokens: Token[],
+function buildSpanContent(
+  lines: string[],
+  tokenLines: TokenLine[],
 ): React.ReactNode {
-  if (!lineText) return '\u200b';
-  if (tokens.length === 0) return lineText;
-
-  const parts: React.ReactNode[] = [];
-  let cursor = 0;
-
-  for (const token of tokens) {
-    if (token.start > cursor) {
-      parts.push(lineText.slice(cursor, token.start));
-    }
-
-    const end = Math.min(token.end, lineText.length);
-    parts.push(
-      <span
-        key={`${token.start}-${token.type}`}
-        className={`xds-token-${token.type}`}>
-        {lineText.slice(token.start, end)}
-      </span>,
-    );
-
-    cursor = end;
-  }
-
-  if (cursor < lineText.length) {
-    parts.push(lineText.slice(cursor));
-  }
-
-  return parts.length > 0 ? parts : lineText;
-}
-
-/**
- * Build span-based content for all lines.
- */
-function buildSpanContent(lines: string[], tokenLines: TokenLine[]): React.ReactNode {
   return lines.map((line, i) => (
     <div key={i}>
       {buildSpanLine(line, tokenLines[i] ?? [])}
@@ -241,10 +181,8 @@ function buildSpanContent(lines: string[], tokenLines: TokenLine[]): React.React
 /**
  * An editable code input using contentEditable="plaintext-only".
  *
- * Uses CSS Custom Highlight API for syntax coloring. Supports
- * auto-indent, tab insertion, and bracket auto-closing.
- * Falls back to span-based rendering when the API is unavailable
- * or `highlightMode="spans"` is set.
+ * Uses the same tokenization and highlight infrastructure as XDSCodeBlock.
+ * Supports auto-indent, tab insertion, and bracket auto-closing.
  *
  * @example
  * ```tsx
@@ -267,7 +205,7 @@ export function XDSCodeEditor({
   maxHeight,
   size = 'md',
   tokenizer: customTokenizer,
-  highlightMode: highlightModeProp = 'css-highlight',
+  highlightMode = 'auto',
   xstyle,
   className,
   style,
@@ -275,17 +213,16 @@ export function XDSCodeEditor({
   ...props
 }: XDSCodeEditorProps) {
   const editorRef = useRef<HTMLDivElement>(null);
-  const [instanceId] = useState(() => ++editorInstanceCounter);
   const [focused, setFocused] = useState(false);
   const isComposingRef = useRef(false);
 
-  // Resolve effective highlight mode
-  const useSpans = highlightModeProp === 'spans' || !hasHighlightAPI();
-
-  // Async tokens for span mode overlay
-  const [asyncTokens, setAsyncTokens] = useState<TokenLine[] | null>(null);
+  const useSpans =
+    highlightMode === 'spans' ||
+    (highlightMode === 'auto' && !hasHighlightAPI());
 
   const lines = value.split('\n');
+  const tokenLines = useTokenLines(value, language, customTokenizer);
+  const hasTokens = tokenLines.some(line => line.length > 0);
 
   // Sync textContent with controlled value
   useLayoutEffect(() => {
@@ -296,86 +233,27 @@ export function XDSCodeEditor({
     }
   }, [value]);
 
-  // Compute sync tokens for span mode (small code)
-  const syncTokens = useMemo(() => {
-    if (!useSpans) return null;
-    if (value.length >= SYNC_TOKENIZE_THRESHOLD) return null;
-    const tok = customTokenizer ?? tokenize;
-    return tok(value, language);
-  }, [useSpans, value, language, customTokenizer]);
-
-  // Async tokenization for span mode with large code
-  useEffect(() => {
-    if (!useSpans) return;
-    if (value.length < SYNC_TOKENIZE_THRESHOLD) return;
-
-    const abortController = new AbortController();
-
-    tokenizeAsync(value, language, abortController.signal).then(tokens => {
-      if (!abortController.signal.aborted) {
-        setAsyncTokens(tokens);
-      }
-    });
-
-    return () => {
-      abortController.abort();
-      setAsyncTokens(null);
-    };
-  }, [useSpans, value, language, customTokenizer]);
-
-  const spanTokens: TokenLine[] = syncTokens ?? asyncTokens ?? [];
-
-  // Ensure styles are always injected
+  // Ensure highlight styles are injected
   useLayoutEffect(() => {
     ensureHighlightStyles();
   }, []);
 
-  // Apply CSS Custom Highlight API ranges — small code
-  useLayoutEffect(() => {
-    if (useSpans) return;
-    if (value.length >= SYNC_TOKENIZE_THRESHOLD) return;
-    if (!hasHighlightAPI()) return;
-
-    const el = editorRef.current;
-    if (!el) return;
-
-    const tok = customTokenizer ?? tokenize;
-    const tokens = tok(value, language);
-    if (tokens.length === 0) return;
-
-    return applyHighlightRangesChunked(el, tokens);
-  }, [useSpans, value, language, customTokenizer, instanceId]);
-
-  // Apply CSS Custom Highlight API ranges — large code (async)
+  // Apply CSS Custom Highlight API ranges
   useEffect(() => {
     if (useSpans) return;
-    if (value.length < SYNC_TOKENIZE_THRESHOLD) return;
     if (!hasHighlightAPI()) return;
 
     const el = editorRef.current;
-    if (!el) return;
+    if (!el || tokenLines.length === 0) return;
 
-    const abortController = new AbortController();
-    let cleanup: (() => void) | undefined;
-
-    tokenizeAsync(value, language, abortController.signal).then(tokens => {
-      if (abortController.signal.aborted) return;
-      if (tokens.length === 0) return;
-      cleanup = applyHighlightRangesChunked(el, tokens);
-    });
-
-    return () => {
-      abortController.abort();
-      cleanup?.();
-    };
-  }, [useSpans, value, language, customTokenizer, instanceId]);
+    return applyHighlightRangesChunked(el, tokenLines);
+  }, [useSpans, tokenLines]);
 
   const handleInput = useCallback(() => {
     if (isComposingRef.current) return;
     const el = editorRef.current;
     if (!el) return;
-    const newValue = el.textContent ?? '';
-    onChange(newValue);
+    onChange(el.textContent ?? '');
   }, [onChange]);
 
   const handleKeyDown = useCallback(
@@ -410,20 +288,17 @@ export function XDSCodeEditor({
         if (!el) return;
         const fullText = el.textContent ?? '';
 
-        // Find cursor offset
         const range = sel.getRangeAt(0);
         const preCaretRange = range.cloneRange();
         preCaretRange.selectNodeContents(el);
         preCaretRange.setEnd(range.startContainer, range.startOffset);
         const cursorOffset = preCaretRange.toString().length;
 
-        // Find current line and its indentation
         const beforeCursor = fullText.slice(0, cursorOffset);
         const lastNewline = beforeCursor.lastIndexOf('\n');
         const currentLine = beforeCursor.slice(lastNewline + 1);
         const indent = currentLine.match(/^(\s*)/)?.[1] ?? '';
 
-        // Insert newline + indent
         const insertText = '\n' + indent;
         range.deleteContents();
         const textNode = document.createTextNode(insertText);
@@ -442,15 +317,12 @@ export function XDSCodeEditor({
         const sel = window.getSelection();
         if (!sel || sel.rangeCount === 0) return;
         const range = sel.getRangeAt(0);
-
-        // Only auto-close if no text is selected
         if (!range.collapsed) return;
 
         e.preventDefault();
         const textNode = document.createTextNode(e.key + closeChar);
         range.deleteContents();
         range.insertNode(textNode);
-        // Place cursor between the pair
         range.setStart(textNode, 1);
         range.setEnd(textNode, 1);
         sel.removeAllRanges();
@@ -476,15 +348,13 @@ export function XDSCodeEditor({
   const showPlaceholder = placeholder && value === '';
 
   const containerStyle: React.CSSProperties | undefined = maxHeight
-    ? {maxHeight: typeof maxHeight === 'number' ? `${maxHeight}px` : maxHeight}
+    ? {
+        maxHeight: typeof maxHeight === 'number' ? `${maxHeight}px` : maxHeight,
+      }
     : undefined;
 
-  // For span mode in the editor, we render a non-interactive overlay with
-  // colored spans on top of the contentEditable. The contentEditable text
-  // is made transparent so the overlay provides the visual coloring while
-  // the contentEditable handles input/caret.
   const spanOverlay =
-    useSpans && spanTokens.some(line => line.length > 0) ? (
+    useSpans && hasTokens ? (
       <div
         aria-hidden="true"
         style={{
@@ -499,7 +369,7 @@ export function XDSCodeEditor({
           overflowWrap: 'normal',
         }}
         {...stylex.props(styles.editor, sizeStyle)}>
-        {buildSpanContent(lines, spanTokens)}
+        {buildSpanContent(lines, tokenLines)}
       </div>
     ) : null;
 
@@ -548,7 +418,7 @@ export function XDSCodeEditor({
           onCompositionEnd={handleCompositionEnd}
           {...stylex.props(styles.editor, sizeStyle)}
           style={
-            useSpans && spanTokens.some(line => line.length > 0)
+            useSpans && hasTokens
               ? {color: 'transparent', caretColor: 'inherit'}
               : undefined
           }


### PR DESCRIPTION
Extracts shared code from XDSCodeBlock into `codeShared.tsx` so both CodeBlock and CodeEditor use the same tokenization and rendering infrastructure.

## Shared module (`codeShared.tsx`)
- `useTokenLines()` — unified sync/async tokenization hook with abort handling
- `buildSpanLine()` — span-based highlighted line rendering
- `hasHighlightAPI()` — CSS Custom Highlight API feature detection
- `FlatTokenizer` / `LineTokenizer` types

## CodeEditor convergence
- Replaces ~80 lines of manual sync/async tokenization with one `useTokenLines()` call
- Replaces duplicate `buildSpanLine` with the shared version
- Aligns `highlightMode` prop to `'auto' | 'ranges' | 'spans'` (matching CodeBlock)
- Uses syntax-aware color tokens (`--color-syntax-*`) instead of generic `--color-text-*`
- Gets lazy `contentvisibilityautostatechange` highlight ranges for free via shared `applyHighlightRangesChunked`

## Perf stories (`Performance/XDSCodeEditor`)
- **StressTest** — configurable line count (100–5000) + mode toggle, shows mount time
- **SideBySide** — ranges vs spans comparison, editable
- **TypingLatency** — measures avg/max input latency under load

Keeping CodeEditor in lab until perf is validated via these stories.