### PR TITLE
fix: component audit — Token, TopNav naming conventions

### DIFF
--- a/packages/core/src/Token/XDSToken.tsx
+++ b/packages/core/src/Token/XDSToken.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file XDSToken.tsx
  * @input Uses React, ReactNode, StyleXStyles

--- a/packages/core/src/Token/index.ts
+++ b/packages/core/src/Token/index.ts
@@ -1,5 +1,12 @@
+'use client';
+
 /**
- * @file Token component barrel export
+ * @file index.ts
+ * @input Token component
+ * @output Exports all Token module public API
+ * @position Entry point for Token module
+ *
+ * SYNC: When adding new Token files, update exports here
  */
 
 export {XDSToken} from './XDSToken';

--- a/packages/core/src/TopNav/TopNavContext.ts
+++ b/packages/core/src/TopNav/TopNavContext.ts
@@ -2,10 +2,20 @@
 
 import {createContext, useContext} from 'react';
 
-export type TopNavSlot = 'start' | 'center' | 'end';
+export type XDSTopNavSlot = 'start' | 'center' | 'end';
 
-export const TopNavSlotContext = createContext<TopNavSlot>('start');
+/**
+ * @deprecated Use XDSTopNavSlotContext instead.
+ */
+export type TopNavSlot = XDSTopNavSlot;
 
-export function useTopNavSlot(): TopNavSlot {
-  return useContext(TopNavSlotContext);
+export const XDSTopNavSlotContext = createContext<XDSTopNavSlot>('start');
+
+/**
+ * @deprecated Use XDSTopNavSlotContext instead.
+ */
+export const TopNavSlotContext = XDSTopNavSlotContext;
+
+export function useTopNavSlot(): XDSTopNavSlot {
+  return useContext(XDSTopNavSlotContext);
 }

--- a/packages/core/src/TopNav/XDSTopNav.tsx
+++ b/packages/core/src/TopNav/XDSTopNav.tsx
@@ -19,7 +19,7 @@ import * as stylex from '@stylexjs/stylex';
 import {colorVars, spacingVars} from '../theme/tokens.stylex';
 import {edgeSignals} from '../Layout/edgeCompensation.stylex';
 import {xdsClassName, mergeProps} from '../utils';
-import {TopNavSlotContext} from './TopNavContext';
+import {XDSTopNavSlotContext} from './TopNavContext';
 import {useXDSTopNavRenderMode} from './XDSTopNavRenderContext';
 import {useXDSTopNavMobileContent} from './XDSTopNavMobileContentContext';
 import {XDSDivider} from '../Divider/XDSDivider';
@@ -259,24 +259,26 @@ export function XDSTopNav({
       <div {...stylex.props(styles.leftSection, edgeSignals.start)}>
         {heading && <div {...stylex.props(styles.heading)}>{heading}</div>}
         {startContent && (
-          <TopNavSlotContext value="start">
+          <XDSTopNavSlotContext value="start">
             <div {...stylex.props(styles.startContent)}>{startContent}</div>
-          </TopNavSlotContext>
+          </XDSTopNavSlotContext>
         )}
       </div>
       {hasCenterContent && (
-        <TopNavSlotContext value="center">
+        <XDSTopNavSlotContext value="center">
           <div {...stylex.props(styles.centerContent)}>{centerContent}</div>
-        </TopNavSlotContext>
+        </XDSTopNavSlotContext>
       )}
       {hasCenterContent ? (
         <div {...stylex.props(styles.rightSection, edgeSignals.end)}>
-          <TopNavSlotContext value="end">{endContent}</TopNavSlotContext>
+          <XDSTopNavSlotContext value="end">{endContent}</XDSTopNavSlotContext>
         </div>
       ) : (
         endContent && (
           <div {...stylex.props(styles.endContent, edgeSignals.end)}>
-            <TopNavSlotContext value="end">{endContent}</TopNavSlotContext>
+            <XDSTopNavSlotContext value="end">
+              {endContent}
+            </XDSTopNavSlotContext>
           </div>
         )
       )}


### PR DESCRIPTION
## Component Audit — 2026-04-18

Audited 5 components: **Timestamp**, **Token**, **Tokenizer**, **Tooltip**, **TopNav**

### Fixes in this PR

| Component | Category | Fix |
|-----------|----------|-----|
| Token | `structure-issue` | Add missing `'use client'` directive to `XDSToken.tsx` |
| Token | `structure-issue` | Add missing `'use client'` directive + file header to `index.ts` |
| TopNav | `naming-violation` | Rename internal `TopNavSlotContext` → `XDSTopNavSlotContext` (with deprecated alias) |

### Clean components (no issues)

- **Timestamp** — all checks pass. Good use of XDSText composition, correct xdsClassName, proper a11y with aria-label for relative format.
- **Tokenizer** — all checks pass. Well-composed using XDSField, XDSToken, XDSBaseTypeahead. Correct input field props.

### Needs Review

These findings require human judgment — not fixed in this PR:

1. **`TooltipFocusTrigger` missing XDS prefix** (Tooltip/useXDSTooltip.tsx)
   - Public type exported as `TooltipFocusTrigger`, convention says `XDSTooltipFocusTrigger`
   - This is a **breaking change** on a public type — needs the breaking change process with a codemod
   - Recommend: batch with next breaking change release

2. **`XDSTokenProps` / `XDSTokenizerProps` / `XDSTopNavHeadingProps` don't extend `XDSBaseProps`**
   - These define `xstyle`, `className`, `style` manually instead of inheriting from `XDSBaseProps`
   - Functionally correct but not conformant — extending XDSBaseProps would inherit HTMLAttributes which may cause type conflicts with component-specific props like `onClick`
   - Recommend: evaluate case-by-case whether extending XDSBaseProps is safe for each

3. **`XDSTopNavMegaMenuProps` missing escape hatches** (`xstyle`/`className`/`style`)
   - Sub-component in a composed pattern — may intentionally not expose escape hatches
   - Same applies to `XDSTopNavMegaMenuItemProps` and `XDSTopNavMegaMenuFeaturedCardProps`
   - Recommend: decide if sub-components in composed patterns need escape hatches

---
