### PR TITLE
fix(templates): prefix image/link paths with basePath for GitHub Pages

### DIFF
--- a/packages/cli/templates/pages/docsite-landing/page.tsx
+++ b/packages/cli/templates/pages/docsite-landing/page.tsx
@@ -453,7 +453,9 @@ function BoidsCanvas({
 // Template data — real images from /public/templates/
 // ---------------------------------------------------------------------------
 
-const DUMMY_IMAGE = '/templates/dummy-placeholder.png';
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
+
+const DUMMY_IMAGE = `${basePath}/templates/dummy-placeholder.png`;
 
 const TEMPLATE_IMAGES = [DUMMY_IMAGE, DUMMY_IMAGE, DUMMY_IMAGE, DUMMY_IMAGE];
 
@@ -1529,7 +1531,7 @@ function AppTopNav() {
             heading=""
             logo={
               <img
-                src="/templates/xds-logo.svg"
+                src={`${basePath}/templates/xds-logo.svg`}
                 alt="XDS"
                 style={{height: 36, width: 48}}
               />
@@ -1759,7 +1761,7 @@ export default function DocsiteLandingTemplate() {
                 <XDSSideNavHeading
                   icon={
                     <img
-                      src="/templates/xds-logo.svg"
+                      src={`${basePath}/templates/xds-logo.svg`}
                       alt="XDS"
                       style={{
                         width: 48,

--- a/packages/cli/templates/pages/library/page.tsx
+++ b/packages/cli/templates/pages/library/page.tsx
@@ -399,7 +399,7 @@ function LibraryNav() {
         />
         <XDSSideNavItem
           label="Library"
-          href="/templates/library/"
+          href={`${basePath}/templates/library/`}
           icon={BookOpenIcon}
           selectedIcon={BookOpenIconSolid}
           isSelected
@@ -413,7 +413,7 @@ function LibraryNav() {
         />
         <XDSSideNavItem
           label="Templates"
-          href="/templates/"
+          href={`${basePath}/templates/`}
           icon={WrenchScrewdriverIcon}
         />
       </XDSSideNavSection>


### PR DESCRIPTION
## Summary
- Template image URLs and nav hrefs were hardcoded as `/templates/...`, which breaks on GitHub Pages where the sandbox is deployed at `/sandbox`.
- Prefixed all static asset paths with `process.env.NEXT_PUBLIC_BASE_PATH` in `docsite-landing` and `library` templates, matching the existing pattern.

## Test plan
- [ ] Verify images load on the deployed GitHub Pages preview (e.g. `/sandbox/templates/docsite-landing/`)
- [ ] Verify images still load in local dev (`localhost:3000/templates/...`)
- [ ] Verify library nav links navigate correctly on GitHub Pages

Made with [Cursor](https://cursor.com)