### PR TITLE
refactor(templates): upgrade all three settings templates to Grade A

### DIFF
--- a/packages/cli/templates/pages/docsite-landing/page.tsx
+++ b/packages/cli/templates/pages/docsite-landing/page.tsx
@@ -453,7 +453,9 @@ function BoidsCanvas({
 // Template data — real images from /public/templates/
 // ---------------------------------------------------------------------------
 
-const DUMMY_IMAGE = '/templates/dummy-placeholder.png';
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
+
+const DUMMY_IMAGE = `${basePath}/templates/dummy-placeholder.png`;
 
 const TEMPLATE_IMAGES = [DUMMY_IMAGE, DUMMY_IMAGE, DUMMY_IMAGE, DUMMY_IMAGE];
 
@@ -1529,7 +1531,7 @@ function AppTopNav() {
             heading=""
             logo={
               <img
-                src="/templates/xds-logo.svg"
+                src={`${basePath}/templates/xds-logo.svg`}
                 alt="XDS"
                 style={{height: 36, width: 48}}
               />
@@ -1759,7 +1761,7 @@ export default function DocsiteLandingTemplate() {
                 <XDSSideNavHeading
                   icon={
                     <img
-                      src="/templates/xds-logo.svg"
+                      src={`${basePath}/templates/xds-logo.svg`}
                       alt="XDS"
                       style={{
                         width: 48,

--- a/packages/cli/templates/pages/library/page.tsx
+++ b/packages/cli/templates/pages/library/page.tsx
@@ -399,7 +399,7 @@ function LibraryNav() {
         />
         <XDSSideNavItem
           label="Library"
-          href="/templates/library/"
+          href={`${basePath}/templates/library/`}
           icon={BookOpenIcon}
           selectedIcon={BookOpenIconSolid}
           isSelected
@@ -413,7 +413,7 @@ function LibraryNav() {
         />
         <XDSSideNavItem
           label="Templates"
-          href="/templates/"
+          href={`${basePath}/templates/`}
           icon={WrenchScrewdriverIcon}
         />
       </XDSSideNavSection>

--- a/packages/cli/templates/pages/settings-dialog/page.tsx
+++ b/packages/cli/templates/pages/settings-dialog/page.tsx
@@ -51,6 +51,10 @@ const styles = stylex.create({
     paddingTop: 16,
     paddingBottom: 16,
   },
+  contentHPadding: {
+    paddingLeft: 32,
+    paddingRight: 32,
+  },
 });
 
 const NAV_ITEMS = [
@@ -293,7 +297,8 @@ export default function SettingsDialogTemplate() {
               <XDSSection
                 padding={4}
                 maxWidth={680}
-                variant="transparent">
+                variant="transparent"
+                xstyle={styles.contentHPadding}>
                 {activeNav === 'Personal information' && (
                   <XDSVStack gap={6}>
                     <XDSHeading level={2}>Personal info</XDSHeading>

--- a/packages/cli/templates/pages/settings-dialog/page.tsx
+++ b/packages/cli/templates/pages/settings-dialog/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import {useState} from 'react';
+import React, {useState} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {XDSAppShell} from '@xds/core/AppShell';
 import {
@@ -13,11 +13,10 @@ import {
 } from '@xds/core/Layout';
 import {XDSText, XDSHeading} from '@xds/core/Text';
 import {XDSButton} from '@xds/core/Button';
-import {XDSDialog} from '@xds/core/Dialog';
+import {XDSDialog, XDSDialogHeader} from '@xds/core/Dialog';
 import {XDSList, XDSListItem} from '@xds/core/List';
 import {XDSDivider} from '@xds/core/Divider';
 import {XDSSelector} from '@xds/core/Selector';
-import {XDSSection} from '@xds/core/Section';
 import {XDSCard} from '@xds/core/Card';
 import {XDSSwitch} from '@xds/core/Switch';
 import {XDSLink} from '@xds/core/Link';
@@ -32,7 +31,6 @@ import {
   ShieldCheckIcon,
   ComputerDesktopIcon,
   WrenchScrewdriverIcon,
-  XMarkIcon,
   BellIcon,
   DocumentTextIcon,
   CreditCardIcon,
@@ -44,16 +42,43 @@ import {
 const styles = stylex.create({
   iconBox: {
     borderRadius: 12,
-    backgroundColor: 'var(--xds-color-background-muted, #f5f5f5)',
+    backgroundColor: 'var(--xds-color-background-surface, #fff)',
     flexShrink: 0,
   },
   rowPadding: {
-    paddingTop: 16,
-    paddingBottom: 16,
+    paddingBlock: 16,
+  },
+  cardContentPadding: {
+    paddingInline: 16,
+  },
+  headerPadding: {
+    paddingInline: 8,
+    paddingBlock: 8,
   },
   contentHPadding: {
-    paddingLeft: 32,
-    paddingRight: 32,
+    paddingInline: 24,
+    paddingBlockEnd: 24,
+    maxWidth: 680,
+  },
+  sideNavPadding: {
+    paddingBlock: 16,
+    paddingInline: 12,
+  },
+  sectionHeading: {
+    paddingBlockEnd: 8,
+  },
+  sideNavHeading: {
+    marginInline: 16,
+  },
+  dialogHeight: {
+    height: '85vh',
+    minHeight: '85vh',
+  },
+  layoutFill: {
+    flex: '1 1 0px',
+  },
+  panelFull: {
+    height: '100%',
   },
 });
 
@@ -247,26 +272,20 @@ export default function SettingsDialogTemplate() {
         width={900}
         maxHeight="85vh"
         padding={0}
-        purpose="form">
+        purpose="form"
+        xstyle={styles.dialogHeight}>
         <XDSLayout
           height="fill"
+          xstyle={styles.layoutFill}
           start={
             <XDSLayoutPanel
               width={280}
               hasDivider
               role="navigation"
-              padding={3}>
-              <XDSVStack gap={4}>
-                <XDSHStack hAlign="between" vAlign="center">
-                  <XDSHeading level={2}>Account settings</XDSHeading>
-                  <XDSButton
-                    label="Close"
-                    icon={<XDSIcon icon={XMarkIcon} />}
-                    variant="ghost"
-                    isIconOnly
-                    onClick={() => setIsOpen(false)}
-                  />
-                </XDSHStack>
+              padding={0}
+              xstyle={styles.panelFull}>
+              <XDSVStack gap={4} xstyle={styles.sideNavPadding}>
+                <XDSHeading level={2} xstyle={styles.sideNavHeading}>Account settings</XDSHeading>
                 <XDSList density="spacious">
                   {NAV_ITEMS.map(item => (
                     <XDSListItem
@@ -293,15 +312,17 @@ export default function SettingsDialogTemplate() {
             </XDSLayoutPanel>
           }
           content={
-            <XDSLayoutContent isScrollable>
-              <XDSSection
-                padding={4}
-                maxWidth={680}
-                variant="transparent"
-                xstyle={styles.contentHPadding}>
+            <XDSLayoutContent isScrollable padding={0}>
+              <XDSVStack xstyle={styles.headerPadding}>
+                <XDSDialogHeader
+                  title={activeNav === 'Personal information' ? 'Personal info' : activeNav}
+                  onOpenChange={open => setIsOpen(open)}
+                  hasDivider={false}
+                />
+              </XDSVStack>
+              <XDSVStack gap={0} xstyle={styles.contentHPadding}>
                 {activeNav === 'Personal information' && (
                   <XDSVStack gap={6}>
-                    <XDSHeading level={2}>Personal info</XDSHeading>
                     <XDSVStack gap={0}>
                       <InfoRowItem
                         label="Legal name"
@@ -345,9 +366,12 @@ export default function SettingsDialogTemplate() {
                       />
                     </XDSVStack>
 
-                    <XDSCard padding={4}>
-                      <XDSVStack gap={0}>
-                        <XDSHStack gap={3} vAlign="start">
+                    <XDSCard padding={0}>
+                      <XDSVStack gap={0} xstyle={styles.cardContentPadding}>
+                        <XDSHStack
+                          gap={3}
+                          vAlign="start"
+                          xstyle={styles.rowPadding}>
                           <XDSCenter
                             width={48}
                             height={48}
@@ -400,7 +424,10 @@ export default function SettingsDialogTemplate() {
                           </XDSVStack>
                         </XDSHStack>
                         <XDSDivider />
-                        <XDSHStack gap={3} vAlign="start">
+                        <XDSHStack
+                          gap={3}
+                          vAlign="start"
+                          xstyle={styles.rowPadding}>
                           <XDSCenter
                             width={48}
                             height={48}
@@ -430,8 +457,6 @@ export default function SettingsDialogTemplate() {
 
                 {activeNav === 'Login & security' && (
                   <XDSVStack gap={6}>
-                    <XDSHeading level={2}>Login &amp; security</XDSHeading>
-
                     <XDSTabList
                       value={activeTab}
                       onChange={setActiveTab}
@@ -443,7 +468,7 @@ export default function SettingsDialogTemplate() {
                     {activeTab === 'login' && (
                       <XDSVStack gap={8}>
                         <XDSVStack gap={0}>
-                          <XDSHeading level={3}>Login</XDSHeading>
+                          <XDSHeading level={3} xstyle={styles.sectionHeading}>Login</XDSHeading>
                           <XDSDivider />
                           {LOGIN_ROWS.map(row => (
                             <InfoRowItem key={row.label} {...row} />
@@ -451,7 +476,7 @@ export default function SettingsDialogTemplate() {
                         </XDSVStack>
 
                         <XDSVStack gap={0}>
-                          <XDSHeading level={3}>Social accounts</XDSHeading>
+                          <XDSHeading level={3} xstyle={styles.sectionHeading}>Social accounts</XDSHeading>
                           <XDSDivider />
                           {SOCIAL_ROWS.map(row => (
                             <InfoRowItem key={row.label} {...row} />
@@ -459,45 +484,46 @@ export default function SettingsDialogTemplate() {
                         </XDSVStack>
 
                         <XDSVStack gap={0}>
-                          <XDSHeading level={3}>Device history</XDSHeading>
+                          <XDSHeading level={3} xstyle={styles.sectionHeading}>Device history</XDSHeading>
                           <XDSDivider />
                           {DEVICE_ROWS.map((device, i) => (
-                            <XDSHStack
-                              key={i}
-                              gap={3}
-                              vAlign="start"
-                              xstyle={styles.rowPadding}>
-                              <XDSIcon icon={ComputerDesktopIcon} />
-                              <XDSStackItem size="fill">
-                                <XDSVStack gap={0}>
-                                  <XDSHStack gap={2} vAlign="center">
-                                    <XDSText type="body" weight="semibold">
-                                      {device.label}
+                            <React.Fragment key={i}>
+                              <XDSHStack
+                                gap={3}
+                                vAlign="start"
+                                xstyle={styles.rowPadding}>
+                                <XDSIcon icon={ComputerDesktopIcon} />
+                                <XDSStackItem size="fill">
+                                  <XDSVStack gap={0}>
+                                    <XDSHStack gap={2} vAlign="center">
+                                      <XDSText type="body" weight="semibold">
+                                        {device.label}
+                                      </XDSText>
+                                      {device.badge && (
+                                        <XDSBadge label={device.badge} />
+                                      )}
+                                    </XDSHStack>
+                                    <XDSText
+                                      type="supporting"
+                                      color="secondary"
+                                      display="block">
+                                      {device.location}
                                     </XDSText>
-                                    {device.badge && (
-                                      <XDSBadge label={device.badge} />
-                                    )}
-                                  </XDSHStack>
-                                  <XDSText
-                                    type="supporting"
-                                    color="secondary"
-                                    display="block">
-                                    {device.location}
-                                  </XDSText>
-                                </XDSVStack>
-                              </XDSStackItem>
-                              {device.action && (
-                                <XDSLink label={device.action} href="#">
-                                  {device.action}
-                                </XDSLink>
-                              )}
-                            </XDSHStack>
+                                  </XDSVStack>
+                                </XDSStackItem>
+                                {device.action && (
+                                  <XDSLink label={device.action} href="#">
+                                    {device.action}
+                                  </XDSLink>
+                                )}
+                              </XDSHStack>
+                              <XDSDivider />
+                            </React.Fragment>
                           ))}
-                          <XDSDivider />
                         </XDSVStack>
 
                         <XDSVStack gap={0}>
-                          <XDSHeading level={3}>Account</XDSHeading>
+                          <XDSHeading level={3} xstyle={styles.sectionHeading}>Account</XDSHeading>
                           <XDSDivider />
                           <XDSHStack
                             hAlign="between"
@@ -529,7 +555,7 @@ export default function SettingsDialogTemplate() {
                     {activeTab === 'shared' && (
                       <XDSVStack gap={8}>
                         <XDSVStack gap={2}>
-                          <XDSHeading level={3}>Shared access</XDSHeading>
+                          <XDSHeading level={3} xstyle={styles.sectionHeading}>Shared access</XDSHeading>
                           <XDSDivider />
                           <XDSText type="body" color="secondary">
                             Review each request carefully before approving
@@ -539,7 +565,7 @@ export default function SettingsDialogTemplate() {
                           </XDSText>
                         </XDSVStack>
 
-                        <XDSCard variant="muted" padding={4}>
+                        <XDSCard variant="muted">
                           <XDSHStack gap={4} vAlign="start">
                             <XDSCenter
                               width={48}
@@ -567,9 +593,6 @@ export default function SettingsDialogTemplate() {
 
                 {activeNav === 'Languages & currency' && (
                   <XDSVStack gap={6}>
-                    <XDSHeading level={2}>
-                      Languages &amp; currency
-                    </XDSHeading>
                     <XDSVStack gap={0}>
                       <ExpandableRow
                         label="Preferred language"
@@ -634,8 +657,6 @@ export default function SettingsDialogTemplate() {
 
                 {activeNav === 'Privacy' && (
                   <XDSVStack gap={6}>
-                    <XDSHeading level={2}>Privacy</XDSHeading>
-
                     <XDSVStack gap={8}>
                       <XDSVStack gap={0}>
                         <XDSHeading level={3}>Messages</XDSHeading>
@@ -727,7 +748,7 @@ export default function SettingsDialogTemplate() {
 
                       <XDSVStack gap={4}>
                         <XDSHeading level={3}>Data privacy</XDSHeading>
-                        <XDSCard padding={4}>
+                        <XDSCard>
                           <XDSHStack hAlign="between" vAlign="center">
                             <XDSText type="body">
                               Request my personal data
@@ -745,7 +766,7 @@ export default function SettingsDialogTemplate() {
                           labelPosition="start"
                           labelSpacing="spread"
                         />
-                        <XDSCard padding={4}>
+                        <XDSCard>
                           <XDSHStack hAlign="between" vAlign="center">
                             <XDSText type="body">Delete my account</XDSText>
                             <XDSLink label="Delete" href="#">
@@ -753,39 +774,37 @@ export default function SettingsDialogTemplate() {
                             </XDSLink>
                           </XDSHStack>
                         </XDSCard>
-                        <XDSCard>
-                          <XDSSection variant="wash">
-                            <XDSHStack gap={4} vAlign="start">
-                              <XDSCenter
-                                width={48}
-                                height={48}
-                                xstyle={styles.iconBox}>
-                                <XDSIcon icon={ShieldCheckIcon} />
-                              </XDSCenter>
-                              <XDSVStack gap={1}>
-                                <XDSText type="body" weight="bold">
-                                  Committed to privacy
-                                </XDSText>
-                                <XDSText type="supporting" color="secondary">
-                                  We&apos;re committed to keeping your data
-                                  protected. See details in our{' '}
-                                  <XDSLink
-                                    label="Privacy Policy"
-                                    href="#"
-                                    type="supporting">
-                                    Privacy Policy
-                                  </XDSLink>
-                                  .
-                                </XDSText>
-                              </XDSVStack>
-                            </XDSHStack>
-                          </XDSSection>
+                        <XDSCard variant="muted">
+                          <XDSHStack gap={4} vAlign="start">
+                            <XDSCenter
+                              width={48}
+                              height={48}
+                              xstyle={styles.iconBox}>
+                              <XDSIcon icon={ShieldCheckIcon} />
+                            </XDSCenter>
+                            <XDSVStack gap={1}>
+                              <XDSText type="body" weight="bold">
+                                Committed to privacy
+                              </XDSText>
+                              <XDSText type="supporting" color="secondary">
+                                We&apos;re committed to keeping your data
+                                protected. See details in our{' '}
+                                <XDSLink
+                                  label="Privacy Policy"
+                                  href="#"
+                                  type="supporting">
+                                  Privacy Policy
+                                </XDSLink>
+                                .
+                              </XDSText>
+                            </XDSVStack>
+                          </XDSHStack>
                         </XDSCard>
                       </XDSVStack>
                     </XDSVStack>
                   </XDSVStack>
                 )}
-              </XDSSection>
+              </XDSVStack>
             </XDSLayoutContent>
           }
         />

--- a/packages/cli/templates/pages/settings-dialog/page.tsx
+++ b/packages/cli/templates/pages/settings-dialog/page.tsx
@@ -54,6 +54,10 @@ const styles = stylex.create({
   headerPadding: {
     paddingInline: 8,
     paddingBlock: 8,
+    position: 'sticky',
+    top: 0,
+    backgroundColor: 'var(--xds-color-background-surface, #fff)',
+    zIndex: 1,
   },
   contentHPadding: {
     paddingInline: 24,

--- a/packages/cli/templates/pages/settings-dialog/page.tsx
+++ b/packages/cli/templates/pages/settings-dialog/page.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import {useState} from 'react';
-import * as stylex from '@stylexjs/stylex';
+import {XDSAppShell} from '@xds/core/AppShell';
+import {XDSTopNav, XDSTopNavHeading} from '@xds/core/TopNav';
 import {
   XDSVStack,
   XDSHStack,
@@ -15,7 +16,6 @@ import {XDSDialog} from '@xds/core/Dialog';
 import {XDSList, XDSListItem} from '@xds/core/List';
 import {XDSDivider} from '@xds/core/Divider';
 import {XDSSelector} from '@xds/core/Selector';
-import {XDSTextInput} from '@xds/core/TextInput';
 import {XDSSection} from '@xds/core/Section';
 import {XDSCard} from '@xds/core/Card';
 import {XDSSwitch} from '@xds/core/Switch';
@@ -23,7 +23,7 @@ import {XDSLink} from '@xds/core/Link';
 import {XDSTabList, XDSTab} from '@xds/core/TabList';
 import {XDSBadge} from '@xds/core/Badge';
 import {XDSIcon} from '@xds/core/Icon';
-import {colorVars} from '@xds/core/theme/tokens.stylex';
+import {XDSCenter} from '@xds/core/Center';
 import {
   UserIcon,
   LockClosedIcon,
@@ -40,10 +40,6 @@ import {
   ShareIcon,
 } from '@heroicons/react/24/outline';
 
-// ---------------------------------------------------------------------------
-// Data
-// ---------------------------------------------------------------------------
-
 const NAV_ITEMS = [
   {label: 'Personal information', icon: UserIcon},
   {label: 'Login & security', icon: LockClosedIcon},
@@ -55,11 +51,11 @@ const NAV_ITEMS = [
   {label: 'Travel for work', icon: BriefcaseIcon},
 ];
 
-const LOGIN_ROWS: {label: string; value: string; action: string}[] = [
+const LOGIN_ROWS = [
   {label: 'Password', value: 'Not created', action: 'Create'},
 ];
 
-const SOCIAL_ROWS: {label: string; value: string; action: string}[] = [
+const SOCIAL_ROWS = [
   {label: 'Google', value: 'Connected', action: 'Disconnect'},
 ];
 
@@ -108,10 +104,6 @@ const TIMEZONES = [
   {label: '(GMT+01:00) London', value: 'GMT+1'},
 ];
 
-// ---------------------------------------------------------------------------
-// Expandable row
-// ---------------------------------------------------------------------------
-
 interface ExpandableRowProps {
   label: string;
   value: string;
@@ -134,28 +126,26 @@ function ExpandableRow({
   return (
     <>
       {isExpanded ? (
-        <div {...stylex.props(styles.rowPadding)}>
-          <div {...stylex.props(styles.marginBottom12)}>
-            <XDSText type="body" weight="semibold" display="block">
-              {label}
-            </XDSText>
-          </div>
-          <div {...stylex.props(styles.marginBottom16)}>{children}</div>
+        <XDSVStack gap={4}>
+          <XDSText type="body" weight="semibold" display="block">
+            {label}
+          </XDSText>
+          {children}
           <XDSHStack gap={2}>
             <XDSButton label="Save" variant="primary" onClick={onSave} />
             <XDSButton label="Cancel" variant="ghost" onClick={onCancel} />
           </XDSHStack>
-        </div>
+        </XDSVStack>
       ) : (
-        <XDSHStack hAlign="between" vAlign="start" xstyle={styles.rowPadding}>
-          <div>
+        <XDSHStack hAlign="between" vAlign="start">
+          <XDSVStack gap={0}>
             <XDSText type="body" weight="semibold" display="block">
               {label}
             </XDSText>
             <XDSText type="supporting" color="secondary" display="block">
               {value}
             </XDSText>
-          </div>
+          </XDSVStack>
           <XDSLink
             label="Edit"
             href="#"
@@ -172,142 +162,11 @@ function ExpandableRow({
   );
 }
 
-function InfoRowItem({
-  label,
-  value,
-  action,
-}: {
-  label: string;
-  value: string;
-  action: string;
-}) {
-  return (
-    <>
-      <XDSHStack hAlign="between" vAlign="start" xstyle={styles.rowPadding}>
-        <div>
-          <XDSText type="body" weight="semibold" display="block">
-            {label}
-          </XDSText>
-          <XDSText type="supporting" color="secondary" display="block">
-            {value}
-          </XDSText>
-        </div>
-        {action && (
-          <XDSLink label={action} href="#">
-            {action}
-          </XDSLink>
-        )}
-      </XDSHStack>
-      <XDSDivider />
-    </>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Styles
-// ---------------------------------------------------------------------------
-
-const styles = stylex.create({
-  pageBg: {backgroundColor: colorVars['--color-background-body']},
-  cardBg: {backgroundColor: colorVars['--color-background-card']},
-  noBorder: {borderWidth: 0},
-  pageCenter: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    position: 'fixed',
-    inset: 0,
-  },
-  dialogInner: {
-    height: '100%',
-    minHeight: 'calc(85vh - 2px)',
-    maxHeight: 'calc(85vh - 2px)',
-    position: 'relative',
-  },
-  closeButton: {
-    position: 'absolute',
-    top: 12,
-    right: 12,
-    zIndex: 1,
-  },
-  navHeadingPadding: {
-    paddingLeft: 16,
-    paddingRight: 16,
-  },
-  contentPadding: {
-    padding: '16px 32px',
-    maxWidth: 680,
-  },
-  rowPadding: {
-    padding: '16px 0',
-  },
-  rowPaddingTop: {
-    paddingTop: 16,
-    paddingBottom: 0,
-  },
-  rowPaddingBottom: {
-    paddingTop: 0,
-    paddingBottom: 16,
-  },
-  marginBottom12: {
-    marginBottom: 12,
-  },
-  marginBottom16: {
-    marginBottom: 16,
-  },
-  marginTop8: {
-    marginTop: 8,
-  },
-  marginTop16: {
-    marginTop: 16,
-  },
-  cardMarginTop: {
-    marginTop: 16,
-  },
-  tabOffset: {
-    marginLeft: -12,
-    overflow: 'hidden',
-  },
-  iconBox: {
-    width: 48,
-    height: 48,
-    borderRadius: 12,
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    flexShrink: 0,
-  },
-  iconBoxMuted: {
-    backgroundColor: colorVars['--color-background-muted'],
-  },
-  iconBoxSurface: {
-    backgroundColor: colorVars['--color-background-surface'],
-  },
-  flex1: {
-    flex: 1,
-  },
-  flexShrink0MarginTop2: {
-    flexShrink: 0,
-    marginTop: 2,
-  },
-  paddingTop16: {
-    paddingTop: 16,
-  },
-});
-
-// ---------------------------------------------------------------------------
-// Component
-// ---------------------------------------------------------------------------
-
 export default function SettingsDialogTemplate() {
   const [isOpen, setIsOpen] = useState(false);
   const [activeNav, setActiveNav] = useState('Login & security');
   const [expandedRow, setExpandedRow] = useState<string | null>(null);
 
-  const [firstName, setFirstName] = useState('Alex');
-  const [lastName, setLastName] = useState('Johnson');
-  const [email, setEmail] = useState('alex.johnson@email.com');
-  const [phone, setPhone] = useState('+1 (416) 555-0123');
   const [language, setLanguage] = useState('en-CA');
   const [currency, setCurrency] = useState('CAD');
   const [timezone, setTimezone] = useState('ET');
@@ -320,17 +179,22 @@ export default function SettingsDialogTemplate() {
   const [showServices, setShowServices] = useState(true);
   const [aiFeatures, setAiFeatures] = useState(true);
 
-  const handleEdit = (row: string) => setExpandedRow(row);
-  const handleCancel = () => setExpandedRow(null);
-  const handleSave = () => setExpandedRow(null);
-
   return (
-    <div {...stylex.props(styles.pageBg, styles.pageCenter)}>
-      <XDSButton
-        label="Open settings"
-        variant="primary"
-        onClick={() => setIsOpen(true)}
-      />
+    <XDSAppShell
+      topNav={
+        <XDSTopNav
+          label="Application"
+          heading={<XDSTopNavHeading heading="My App" />}
+        />
+      }>
+      <XDSCenter height="60vh">
+        <XDSButton
+          label="Open settings"
+          variant="primary"
+          onClick={() => setIsOpen(true)}
+        />
+      </XDSCenter>
+
       <XDSDialog
         isOpen={isOpen}
         onOpenChange={open => setIsOpen(open)}
@@ -338,601 +202,495 @@ export default function SettingsDialogTemplate() {
         maxHeight="85vh"
         padding={0}
         purpose="form">
-        <div {...stylex.props(styles.dialogInner)}>
-          {/* Close button — top right, no header bar */}
-          <div {...stylex.props(styles.closeButton)}>
-            <XDSButton
-              label="Close"
-              icon={<XMarkIcon width={20} height={20} />}
-              variant="ghost"
-              onClick={() => setIsOpen(false)}
-              isIconOnly
-            />
-          </div>
-
-          <XDSLayout
-            height="fill"
-            padding={0}
-            start={
-              <XDSLayoutPanel
-                width={280}
-                hasDivider
-                role="navigation"
-                padding={3}
-                xstyle={styles.cardBg}>
-                <XDSVStack gap={4}>
-                  <div {...stylex.props(styles.navHeadingPadding)}>
-                    <XDSHeading level={2}>Account settings</XDSHeading>
-                  </div>
-                  <XDSList density="spacious">
-                    {NAV_ITEMS.map(item => (
-                      <XDSListItem
-                        key={item.label}
-                        label={item.label}
-                        startContent={<item.icon width={20} height={20} />}
-                        isSelected={activeNav === item.label}
-                        onClick={() => {
-                          setActiveNav(item.label);
-                          setExpandedRow(null);
-                        }}
-                      />
-                    ))}
-                  </XDSList>
-                  <XDSDivider />
-                  <XDSList density="spacious">
+        <XDSLayout
+          height="fill"
+          start={
+            <XDSLayoutPanel width={280} hasDivider role="navigation" padding={3}>
+              <XDSVStack gap={4}>
+                <XDSHStack hAlign="between" vAlign="center">
+                  <XDSHeading level={2}>Account settings</XDSHeading>
+                  <XDSButton
+                    label="Close"
+                    icon={<XDSIcon icon={XMarkIcon} />}
+                    variant="ghost"
+                    isIconOnly
+                    onClick={() => setIsOpen(false)}
+                  />
+                </XDSHStack>
+                <XDSList density="spacious">
+                  {NAV_ITEMS.map(item => (
                     <XDSListItem
-                      label="Professional hosting tools"
-                      startContent={
-                        <WrenchScrewdriverIcon width={20} height={20} />
-                      }
-                      onClick={() => {}}
+                      key={item.label}
+                      label={item.label}
+                      startContent={<XDSIcon icon={item.icon} />}
+                      isSelected={activeNav === item.label}
+                      onClick={() => {
+                        setActiveNav(item.label);
+                        setExpandedRow(null);
+                      }}
                     />
-                  </XDSList>
-                </XDSVStack>
-              </XDSLayoutPanel>
-            }
-            content={
-              <XDSLayoutContent>
-                <div {...stylex.props(styles.contentPadding)}>
-                  {activeNav === 'Personal information' && (
-                    <XDSVStack gap={6}>
-                      <XDSHeading level={2}>Personal info</XDSHeading>
-                      <XDSVStack gap={0}>
-                        <InfoRowItem
-                          label="Legal name"
-                          value="Alex Johnson"
-                          action="Edit"
-                        />
-                        <InfoRowItem
-                          label="Preferred first name"
-                          value="Not provided"
-                          action="Add"
-                        />
-                        <InfoRowItem
-                          label="Email address"
-                          value="a***n@example.com"
-                          action="Edit"
-                        />
-                        <InfoRowItem
-                          label="Phone number"
-                          value="+1 ***-***-0123"
-                          action="Edit"
-                        />
-                        <InfoRowItem
-                          label="Identity verification"
-                          value="Verified"
-                          action=""
-                        />
-                        <InfoRowItem
-                          label="Residential address"
-                          value="Not provided"
-                          action="Add"
-                        />
-                        <InfoRowItem
-                          label="Mailing address"
-                          value="Not provided"
-                          action="Add"
-                        />
-                        <InfoRowItem
-                          label="Emergency contact"
-                          value="Provided"
-                          action="Edit"
-                        />
-                      </XDSVStack>
+                  ))}
+                </XDSList>
+                <XDSDivider />
+                <XDSList density="spacious">
+                  <XDSListItem
+                    label="Professional hosting tools"
+                    startContent={
+                      <XDSIcon icon={WrenchScrewdriverIcon} />
+                    }
+                    onClick={() => {}}
+                  />
+                </XDSList>
+              </XDSVStack>
+            </XDSLayoutPanel>
+          }
+          content={
+            <XDSLayoutContent>
+              <XDSSection padding={4} maxWidth={680}>
+                {activeNav === 'Personal information' && (
+                  <XDSVStack gap={6}>
+                    <XDSHeading level={2}>Personal info</XDSHeading>
+                    <XDSList hasDividers density="spacious">
+                      <XDSListItem
+                        label="Legal name"
+                        description="Alex Johnson"
+                        endContent={
+                          <XDSLink label="Edit" href="#">
+                            Edit
+                          </XDSLink>
+                        }
+                      />
+                      <XDSListItem
+                        label="Preferred first name"
+                        description="Not provided"
+                        endContent={
+                          <XDSLink label="Add" href="#">
+                            Add
+                          </XDSLink>
+                        }
+                      />
+                      <XDSListItem
+                        label="Email address"
+                        description="a***n@example.com"
+                        endContent={
+                          <XDSLink label="Edit" href="#">
+                            Edit
+                          </XDSLink>
+                        }
+                      />
+                      <XDSListItem
+                        label="Phone number"
+                        description="+1 ***-***-0123"
+                        endContent={
+                          <XDSLink label="Edit" href="#">
+                            Edit
+                          </XDSLink>
+                        }
+                      />
+                      <XDSListItem
+                        label="Identity verification"
+                        description="Verified"
+                      />
+                      <XDSListItem
+                        label="Residential address"
+                        description="Not provided"
+                        endContent={
+                          <XDSLink label="Add" href="#">
+                            Add
+                          </XDSLink>
+                        }
+                      />
+                      <XDSListItem
+                        label="Mailing address"
+                        description="Not provided"
+                        endContent={
+                          <XDSLink label="Add" href="#">
+                            Add
+                          </XDSLink>
+                        }
+                      />
+                      <XDSListItem
+                        label="Emergency contact"
+                        description="Provided"
+                        endContent={
+                          <XDSLink label="Edit" href="#">
+                            Edit
+                          </XDSLink>
+                        }
+                      />
+                    </XDSList>
 
-                      <XDSCard padding={4} xstyle={styles.cardMarginTop}>
-                        <XDSVStack gap={0}>
-                          <div {...stylex.props(styles.rowPaddingBottom)}>
-                            <XDSHStack gap={3} vAlign="start">
-                              <div
-                                {...stylex.props(
-                                  styles.iconBox,
-                                  styles.iconBoxMuted,
-                                )}>
-                                <XDSIcon icon={LockClosedIcon} size="lg" />
-                              </div>
-                              <XDSVStack gap={0}>
-                                <XDSText
-                                  type="body"
-                                  weight="semibold"
-                                  display="block">
-                                  Why isn&apos;t my info shown here?
-                                </XDSText>
-                                <XDSText
-                                  type="supporting"
-                                  color="secondary"
-                                  display="block">
-                                  We&apos;re hiding some account details to
-                                  protect your identity.
-                                </XDSText>
-                              </XDSVStack>
-                            </XDSHStack>
-                          </div>
-                          <XDSDivider />
-                          <div {...stylex.props(styles.rowPadding)}>
-                            <XDSHStack gap={3} vAlign="start">
-                              <div
-                                {...stylex.props(
-                                  styles.iconBox,
-                                  styles.iconBoxMuted,
-                                )}>
-                                <XDSIcon icon={PencilSquareIcon} size="lg" />
-                              </div>
-                              <XDSVStack gap={0}>
-                                <XDSText
-                                  type="body"
-                                  weight="semibold"
-                                  display="block">
-                                  Which details can be edited?
-                                </XDSText>
-                                <XDSText
-                                  type="supporting"
-                                  color="secondary"
-                                  display="block">
-                                  Contact info and personal details can be
-                                  edited. If this info was used to verify your
-                                  identity, you&apos;ll need to get verified
-                                  again the next time you book—or to continue
-                                  hosting.
-                                </XDSText>
-                              </XDSVStack>
-                            </XDSHStack>
-                          </div>
-                          <XDSDivider />
-                          <div {...stylex.props(styles.rowPaddingTop)}>
-                            <XDSHStack gap={3} vAlign="start">
-                              <div
-                                {...stylex.props(
-                                  styles.iconBox,
-                                  styles.iconBoxMuted,
-                                )}>
-                                <XDSIcon icon={ShareIcon} size="lg" />
-                              </div>
-                              <XDSVStack gap={0}>
-                                <XDSText
-                                  type="body"
-                                  weight="semibold"
-                                  display="block">
-                                  What info is shared with others?
-                                </XDSText>
-                                <XDSText
-                                  type="supporting"
-                                  color="secondary"
-                                  display="block">
-                                  We only release contact information after a
-                                  reservation is confirmed.
-                                </XDSText>
-                              </XDSVStack>
-                            </XDSHStack>
-                          </div>
-                        </XDSVStack>
-                      </XDSCard>
-                    </XDSVStack>
-                  )}
+                    <XDSCard padding={4}>
+                      <XDSList hasDividers density="spacious">
+                        <XDSListItem
+                          label="Why isn't my info shown here?"
+                          description="We're hiding some account details to protect your identity."
+                          startContent={
+                            <XDSIcon icon={LockClosedIcon} size="lg" />
+                          }
+                        />
+                        <XDSListItem
+                          label="Which details can be edited?"
+                          description="Contact info and personal details can be edited. If this info was used to verify your identity, you'll need to get verified again the next time you book—or to continue hosting."
+                          startContent={
+                            <XDSIcon icon={PencilSquareIcon} size="lg" />
+                          }
+                        />
+                        <XDSListItem
+                          label="What info is shared with others?"
+                          description="We only release contact information after a reservation is confirmed."
+                          startContent={
+                            <XDSIcon icon={ShareIcon} size="lg" />
+                          }
+                        />
+                      </XDSList>
+                    </XDSCard>
+                  </XDSVStack>
+                )}
 
-                  {activeNav === 'Login & security' && (
-                    <XDSVStack gap={6}>
-                      <XDSHeading level={2}>Login &amp; security</XDSHeading>
+                {activeNav === 'Login & security' && (
+                  <XDSVStack gap={6}>
+                    <XDSHeading level={2}>
+                      Login &amp; security
+                    </XDSHeading>
 
-                      <div {...stylex.props(styles.tabOffset)}>
-                        <XDSTabList
-                          value={activeTab}
-                          onChange={setActiveTab}
-                          hasDivider>
-                          <XDSTab value="login" label="Login" />
-                          <XDSTab value="shared" label="Shared access" />
-                        </XDSTabList>
-                      </div>
+                    <XDSTabList
+                      value={activeTab}
+                      onChange={setActiveTab}
+                      hasDivider>
+                      <XDSTab value="login" label="Login" />
+                      <XDSTab value="shared" label="Shared access" />
+                    </XDSTabList>
 
-                      {activeTab === 'login' && (
-                        <XDSVStack gap={8}>
-                          {/* Login */}
-                          <XDSVStack gap={0}>
-                            <XDSHeading level={3}>Login</XDSHeading>
-                            <div {...stylex.props(styles.marginTop8)}>
-                              <XDSDivider />
-                            </div>
+                    {activeTab === 'login' && (
+                      <XDSVStack gap={8}>
+                        <XDSVStack gap={2}>
+                          <XDSHeading level={3}>Login</XDSHeading>
+                          <XDSList hasDividers density="spacious">
                             {LOGIN_ROWS.map(row => (
-                              <InfoRowItem key={row.label} {...row} />
+                              <XDSListItem
+                                key={row.label}
+                                label={row.label}
+                                description={row.value}
+                                endContent={
+                                  <XDSLink label={row.action} href="#">
+                                    {row.action}
+                                  </XDSLink>
+                                }
+                              />
                             ))}
-                          </XDSVStack>
+                          </XDSList>
+                        </XDSVStack>
 
-                          {/* Social accounts */}
-                          <XDSVStack gap={0}>
-                            <XDSHeading level={3}>Social accounts</XDSHeading>
-                            <div {...stylex.props(styles.marginTop8)}>
-                              <XDSDivider />
-                            </div>
+                        <XDSVStack gap={2}>
+                          <XDSHeading level={3}>Social accounts</XDSHeading>
+                          <XDSList hasDividers density="spacious">
                             {SOCIAL_ROWS.map(row => (
-                              <InfoRowItem key={row.label} {...row} />
+                              <XDSListItem
+                                key={row.label}
+                                label={row.label}
+                                description={row.value}
+                                endContent={
+                                  <XDSLink label={row.action} href="#">
+                                    {row.action}
+                                  </XDSLink>
+                                }
+                              />
                             ))}
-                          </XDSVStack>
+                          </XDSList>
+                        </XDSVStack>
 
-                          {/* Device history */}
-                          <XDSVStack gap={0}>
-                            <XDSHeading level={3}>Device history</XDSHeading>
-                            <div {...stylex.props(styles.marginTop8)}>
-                              <XDSDivider />
-                            </div>
+                        <XDSVStack gap={2}>
+                          <XDSHeading level={3}>Device history</XDSHeading>
+                          <XDSList hasDividers density="spacious">
                             {DEVICE_ROWS.map((device, i) => (
-                              <div key={i}>
-                                <XDSHStack
-                                  hAlign="between"
-                                  vAlign="start"
-                                  gap={3}
-                                  xstyle={styles.rowPadding}>
-                                  <div
-                                    {...stylex.props(
-                                      styles.flexShrink0MarginTop2,
-                                    )}>
-                                    <XDSIcon
-                                      icon={ComputerDesktopIcon}
-                                      size="lg"
-                                    />
-                                  </div>
-                                  <div {...stylex.props(styles.flex1)}>
-                                    <XDSHStack vAlign="center" gap={2}>
-                                      <XDSText type="body" weight="semibold">
-                                        {device.label}
-                                      </XDSText>
-                                      {device.badge && (
-                                        <XDSBadge label={device.badge} />
-                                      )}
-                                    </XDSHStack>
-                                    <XDSText
-                                      type="supporting"
-                                      color="secondary">
-                                      {device.location}
-                                    </XDSText>
-                                  </div>
-                                  {device.action && (
+                              <XDSListItem
+                                key={i}
+                                label={device.label}
+                                description={device.location}
+                                startContent={
+                                  <XDSIcon
+                                    icon={ComputerDesktopIcon}
+                                    size="lg"
+                                  />
+                                }
+                                endContent={
+                                  device.badge ? (
+                                    <XDSBadge label={device.badge} />
+                                  ) : device.action ? (
                                     <XDSLink label={device.action} href="#">
                                       {device.action}
                                     </XDSLink>
-                                  )}
-                                </XDSHStack>
-                                <XDSDivider />
-                              </div>
+                                  ) : undefined
+                                }
+                              />
                             ))}
-                          </XDSVStack>
-
-                          {/* Account */}
-                          <XDSVStack gap={0}>
-                            <XDSHeading level={3}>Account</XDSHeading>
-                            <div {...stylex.props(styles.marginTop8)}>
-                              <XDSDivider />
-                            </div>
-                            <XDSHStack
-                              hAlign="between"
-                              vAlign="start"
-                              xstyle={styles.rowPadding}>
-                              <div>
-                                <XDSText
-                                  type="body"
-                                  weight="semibold"
-                                  display="block">
-                                  Deactivate your account
-                                </XDSText>
-                                <XDSText
-                                  type="supporting"
-                                  color="secondary"
-                                  display="block">
-                                  This action cannot be undone
-                                </XDSText>
-                              </div>
-                              <XDSLink label="Deactivate" href="#">
-                                Deactivate
-                              </XDSLink>
-                            </XDSHStack>
-                            <XDSDivider />
-                          </XDSVStack>
+                          </XDSList>
                         </XDSVStack>
-                      )}
 
-                      {activeTab === 'shared' && (
-                        <XDSVStack gap={8}>
-                          <XDSVStack gap={0}>
-                            <XDSHeading level={3}>Shared access</XDSHeading>
-                            <div {...stylex.props(styles.marginTop8)}>
-                              <XDSDivider />
-                            </div>
-                            <div {...stylex.props(styles.paddingTop16)}>
-                              <XDSText type="body" color="secondary">
-                                Review each request carefully before approving
-                                access. We&apos;ll email your employee or
-                                co-worker a 4-digit code that lets them log into
-                                your account with their trusted device.
-                              </XDSText>
-                            </div>
-                          </XDSVStack>
-
-                          <XDSCard>
-                            <XDSSection variant="wash">
-                              <XDSHStack gap={4} vAlign="start">
-                                <div
-                                  {...stylex.props(
-                                    styles.iconBox,
-                                    styles.iconBoxSurface,
-                                  )}>
-                                  <XDSIcon icon={LockClosedIcon} size="lg" />
-                                </div>
-                                <XDSVStack gap={1}>
-                                  <XDSText type="body" weight="bold">
-                                    Adding devices from people you trust
-                                  </XDSText>
-                                  <XDSText type="body" color="secondary">
-                                    When you approve a request, you grant
-                                    someone full access to your account.
-                                    They&apos;ll be able to change reservations
-                                    and send messages on your behalf.
-                                  </XDSText>
-                                </XDSVStack>
-                              </XDSHStack>
-                            </XDSSection>
-                          </XDSCard>
-                        </XDSVStack>
-                      )}
-                    </XDSVStack>
-                  )}
-
-                  {activeNav === 'Languages & currency' && (
-                    <XDSVStack gap={6}>
-                      <XDSHeading level={2}>
-                        Languages &amp; currency
-                      </XDSHeading>
-                      <XDSVStack gap={0}>
-                        <ExpandableRow
-                          label="Preferred language"
-                          value={
-                            LANGUAGES.find(l => l.value === language)?.label ??
-                            language
-                          }
-                          isExpanded={expandedRow === 'language'}
-                          onEdit={() => handleEdit('language')}
-                          onCancel={handleCancel}
-                          onSave={handleSave}>
-                          <XDSSelector
-                            label="Language"
-                            isLabelHidden
-                            size="lg"
-                            value={language}
-                            onChange={setLanguage}
-                            options={LANGUAGES}
-                          />
-                        </ExpandableRow>
-                        <ExpandableRow
-                          label="Preferred currency"
-                          value={
-                            CURRENCIES.find(c => c.value === currency)?.label ??
-                            currency
-                          }
-                          isExpanded={expandedRow === 'currency'}
-                          onEdit={() => handleEdit('currency')}
-                          onCancel={handleCancel}
-                          onSave={handleSave}>
-                          <XDSSelector
-                            label="Currency"
-                            isLabelHidden
-                            size="lg"
-                            value={currency}
-                            onChange={setCurrency}
-                            options={CURRENCIES}
-                          />
-                        </ExpandableRow>
-                        <ExpandableRow
-                          label="Time zone"
-                          value={
-                            TIMEZONES.find(t => t.value === timezone)?.label ??
-                            timezone
-                          }
-                          isExpanded={expandedRow === 'timezone'}
-                          onEdit={() => handleEdit('timezone')}
-                          onCancel={handleCancel}
-                          onSave={handleSave}>
-                          <XDSSelector
-                            label="Time zone"
-                            isLabelHidden
-                            size="lg"
-                            value={timezone}
-                            onChange={setTimezone}
-                            options={TIMEZONES}
-                          />
-                        </ExpandableRow>
-                      </XDSVStack>
-                    </XDSVStack>
-                  )}
-
-                  {activeNav === 'Privacy' && (
-                    <XDSVStack gap={6}>
-                      <XDSHeading level={2}>Privacy</XDSHeading>
-
-                      <XDSVStack gap={8}>
-                        {/* Messages */}
-                        <XDSVStack gap={0}>
-                          <XDSHeading level={3}>Messages</XDSHeading>
-                          <div {...stylex.props(styles.marginTop16)}>
-                            <XDSSwitch
-                              label="Show people when I've read their messages."
-                              value={readReceipts}
-                              onChange={setReadReceipts}
-                              labelPosition="start"
-                              labelSpacing="spread"
+                        <XDSVStack gap={2}>
+                          <XDSHeading level={3}>Account</XDSHeading>
+                          <XDSList hasDividers density="spacious">
+                            <XDSListItem
+                              label="Deactivate your account"
+                              description="This action cannot be undone"
+                              endContent={
+                                <XDSLink label="Deactivate" href="#">
+                                  Deactivate
+                                </XDSLink>
+                              }
                             />
-                          </div>
-                          <div {...stylex.props(styles.rowPadding)}>
-                            <XDSHStack hAlign="between" vAlign="center">
-                              <XDSText type="body" weight="semibold">
-                                Blocked people
+                          </XDSList>
+                        </XDSVStack>
+                      </XDSVStack>
+                    )}
+
+                    {activeTab === 'shared' && (
+                      <XDSVStack gap={8}>
+                        <XDSVStack gap={2}>
+                          <XDSHeading level={3}>Shared access</XDSHeading>
+                          <XDSDivider />
+                          <XDSText type="body" color="secondary">
+                            Review each request carefully before approving
+                            access. We&apos;ll email your employee or co-worker
+                            a 4-digit code that lets them log into your account
+                            with their trusted device.
+                          </XDSText>
+                        </XDSVStack>
+
+                        <XDSCard variant="muted" padding={4}>
+                          <XDSHStack gap={4} vAlign="start">
+                            <XDSIcon icon={LockClosedIcon} size="lg" />
+                            <XDSVStack gap={1}>
+                              <XDSText type="body" weight="bold">
+                                Adding devices from people you trust
                               </XDSText>
+                              <XDSText type="body" color="secondary">
+                                When you approve a request, you grant someone
+                                full access to your account. They&apos;ll be
+                                able to change reservations and send messages on
+                                your behalf.
+                              </XDSText>
+                            </XDSVStack>
+                          </XDSHStack>
+                        </XDSCard>
+                      </XDSVStack>
+                    )}
+                  </XDSVStack>
+                )}
+
+                {activeNav === 'Languages & currency' && (
+                  <XDSVStack gap={6}>
+                    <XDSHeading level={2}>
+                      Languages &amp; currency
+                    </XDSHeading>
+                    <XDSVStack gap={0}>
+                      <ExpandableRow
+                        label="Preferred language"
+                        value={
+                          LANGUAGES.find(l => l.value === language)?.label ??
+                          language
+                        }
+                        isExpanded={expandedRow === 'language'}
+                        onEdit={() => setExpandedRow('language')}
+                        onCancel={() => setExpandedRow(null)}
+                        onSave={() => setExpandedRow(null)}>
+                        <XDSSelector
+                          label="Language"
+                          isLabelHidden
+                          size="lg"
+                          value={language}
+                          onChange={setLanguage}
+                          options={LANGUAGES}
+                        />
+                      </ExpandableRow>
+                      <ExpandableRow
+                        label="Preferred currency"
+                        value={
+                          CURRENCIES.find(c => c.value === currency)?.label ??
+                          currency
+                        }
+                        isExpanded={expandedRow === 'currency'}
+                        onEdit={() => setExpandedRow('currency')}
+                        onCancel={() => setExpandedRow(null)}
+                        onSave={() => setExpandedRow(null)}>
+                        <XDSSelector
+                          label="Currency"
+                          isLabelHidden
+                          size="lg"
+                          value={currency}
+                          onChange={setCurrency}
+                          options={CURRENCIES}
+                        />
+                      </ExpandableRow>
+                      <ExpandableRow
+                        label="Time zone"
+                        value={
+                          TIMEZONES.find(t => t.value === timezone)?.label ??
+                          timezone
+                        }
+                        isExpanded={expandedRow === 'timezone'}
+                        onEdit={() => setExpandedRow('timezone')}
+                        onCancel={() => setExpandedRow(null)}
+                        onSave={() => setExpandedRow(null)}>
+                        <XDSSelector
+                          label="Time zone"
+                          isLabelHidden
+                          size="lg"
+                          value={timezone}
+                          onChange={setTimezone}
+                          options={TIMEZONES}
+                        />
+                      </ExpandableRow>
+                    </XDSVStack>
+                  </XDSVStack>
+                )}
+
+                {activeNav === 'Privacy' && (
+                  <XDSVStack gap={6}>
+                    <XDSHeading level={2}>Privacy</XDSHeading>
+
+                    <XDSVStack gap={8}>
+                      <XDSVStack gap={4}>
+                        <XDSHeading level={3}>Messages</XDSHeading>
+                        <XDSSwitch
+                          label="Show people when I've read their messages."
+                          value={readReceipts}
+                          onChange={setReadReceipts}
+                          labelPosition="start"
+                          labelSpacing="spread"
+                        />
+                        <XDSList hasDividers density="spacious">
+                          <XDSListItem
+                            label="Blocked people"
+                            endContent={
                               <XDSLink label="View" href="#">
                                 View
                               </XDSLink>
-                            </XDSHStack>
-                          </div>
-                          <XDSDivider />
-                        </XDSVStack>
+                            }
+                          />
+                        </XDSList>
+                      </XDSVStack>
 
-                        {/* Listings */}
-                        <XDSVStack gap={0}>
-                          <XDSHeading level={3}>Listings</XDSHeading>
-                          <div {...stylex.props(styles.marginTop16)}>
-                            <XDSSwitch
-                              label="Include my listing(s) in search engines"
-                              description="Turning this on means search engines, like Google, will display your listing page(s) in search results."
-                              value={searchEngines}
-                              onChange={setSearchEngines}
-                              labelPosition="start"
-                              labelSpacing="spread"
-                            />
-                          </div>
-                          <div {...stylex.props(styles.marginTop8)}>
-                            <XDSDivider />
-                          </div>
-                        </XDSVStack>
+                      <XDSVStack gap={4}>
+                        <XDSHeading level={3}>Listings</XDSHeading>
+                        <XDSSwitch
+                          label="Include my listing(s) in search engines"
+                          description="Turning this on means search engines, like Google, will display your listing page(s) in search results."
+                          value={searchEngines}
+                          onChange={setSearchEngines}
+                          labelPosition="start"
+                          labelSpacing="spread"
+                        />
+                        <XDSDivider />
+                      </XDSVStack>
 
-                        {/* Reviews */}
-                        <XDSVStack gap={0}>
-                          <XDSHeading level={3}>Reviews</XDSHeading>
-                          <div>
-                            <XDSText type="supporting" color="secondary">
-                              Choose what&apos;s shared when you write a review.{' '}
-                              <XDSLink
-                                label="Learn more"
-                                href="#"
-                                type="supporting">
-                                Learn more
-                              </XDSLink>
-                            </XDSText>
-                          </div>
-                          <div {...stylex.props(styles.marginTop16)}>
-                            <XDSVStack gap={4}>
-                              <XDSSwitch
-                                label="Show my home city and country"
-                                description="Ex: City and country"
-                                value={showCity}
-                                onChange={setShowCity}
-                                labelPosition="start"
-                                labelSpacing="spread"
-                              />
-                              <XDSSwitch
-                                label="Show my trip type"
-                                description="Ex: Stayed with kids or pets"
-                                value={showTripType}
-                                onChange={setShowTripType}
-                                labelPosition="start"
-                                labelSpacing="spread"
-                              />
-                              <XDSSwitch
-                                label="Show my length of stay"
-                                description="Ex: A few nights, about a week, etc."
-                                value={showStayLength}
-                                onChange={setShowStayLength}
-                                labelPosition="start"
-                                labelSpacing="spread"
-                              />
-                              <XDSSwitch
-                                label="Show my booked services"
-                                description="Ex: Gourmet brunch or tasting menu"
-                                value={showServices}
-                                onChange={setShowServices}
-                                labelPosition="start"
-                                labelSpacing="spread"
-                              />
-                            </XDSVStack>
-                          </div>
-                          <div {...stylex.props(styles.marginTop16)}>
-                            <XDSDivider />
-                          </div>
-                        </XDSVStack>
-
-                        {/* Data privacy */}
+                      <XDSVStack gap={4}>
+                        <XDSHeading level={3}>Reviews</XDSHeading>
+                        <XDSText type="supporting" color="secondary">
+                          Choose what&apos;s shared when you write a review.{' '}
+                          <XDSLink
+                            label="Learn more"
+                            href="#"
+                            type="supporting">
+                            Learn more
+                          </XDSLink>
+                        </XDSText>
                         <XDSVStack gap={4}>
-                          <XDSHeading level={3}>Data privacy</XDSHeading>
-                          <XDSCard padding={4}>
-                            <XDSHStack hAlign="between" vAlign="center">
-                              <XDSText type="body">
-                                Request my personal data
-                              </XDSText>
-                              <XDSLink label="Request" href="#">
-                                Request
-                              </XDSLink>
-                            </XDSHStack>
-                          </XDSCard>
                           <XDSSwitch
-                            label="Help improve AI-powered features"
-                            description="When this is on, we use your data to develop and improve AI models."
-                            value={aiFeatures}
-                            onChange={setAiFeatures}
+                            label="Show my home city and country"
+                            description="Ex: City and country"
+                            value={showCity}
+                            onChange={setShowCity}
                             labelPosition="start"
                             labelSpacing="spread"
                           />
-                          <XDSCard padding={4}>
-                            <XDSHStack hAlign="between" vAlign="center">
-                              <XDSText type="body">Delete my account</XDSText>
-                              <XDSLink label="Delete" href="#">
-                                Delete
-                              </XDSLink>
-                            </XDSHStack>
-                          </XDSCard>
-                          <XDSCard>
-                            <XDSSection variant="wash">
-                              <XDSHStack gap={4} vAlign="start">
-                                <div
-                                  {...stylex.props(
-                                    styles.iconBox,
-                                    styles.iconBoxSurface,
-                                  )}>
-                                  <XDSIcon icon={ShieldCheckIcon} size="lg" />
-                                </div>
-                                <XDSVStack gap={1}>
-                                  <XDSText type="body" weight="bold">
-                                    Committed to privacy
-                                  </XDSText>
-                                  <XDSText type="supporting" color="secondary">
-                                    We&apos;re committed to keeping your data
-                                    protected. See details in our{' '}
-                                    <XDSLink
-                                      label="Privacy Policy"
-                                      href="#"
-                                      type="supporting">
-                                      Privacy Policy
-                                    </XDSLink>
-                                    .
-                                  </XDSText>
-                                </XDSVStack>
-                              </XDSHStack>
-                            </XDSSection>
-                          </XDSCard>
+                          <XDSSwitch
+                            label="Show my trip type"
+                            description="Ex: Stayed with kids or pets"
+                            value={showTripType}
+                            onChange={setShowTripType}
+                            labelPosition="start"
+                            labelSpacing="spread"
+                          />
+                          <XDSSwitch
+                            label="Show my length of stay"
+                            description="Ex: A few nights, about a week, etc."
+                            value={showStayLength}
+                            onChange={setShowStayLength}
+                            labelPosition="start"
+                            labelSpacing="spread"
+                          />
+                          <XDSSwitch
+                            label="Show my booked services"
+                            description="Ex: Gourmet brunch or tasting menu"
+                            value={showServices}
+                            onChange={setShowServices}
+                            labelPosition="start"
+                            labelSpacing="spread"
+                          />
                         </XDSVStack>
+                        <XDSDivider />
+                      </XDSVStack>
+
+                      <XDSVStack gap={4}>
+                        <XDSHeading level={3}>Data privacy</XDSHeading>
+                        <XDSCard padding={4}>
+                          <XDSHStack hAlign="between" vAlign="center">
+                            <XDSText type="body">
+                              Request my personal data
+                            </XDSText>
+                            <XDSLink label="Request" href="#">
+                              Request
+                            </XDSLink>
+                          </XDSHStack>
+                        </XDSCard>
+                        <XDSSwitch
+                          label="Help improve AI-powered features"
+                          description="When this is on, we use your data to develop and improve AI models."
+                          value={aiFeatures}
+                          onChange={setAiFeatures}
+                          labelPosition="start"
+                          labelSpacing="spread"
+                        />
+                        <XDSCard padding={4}>
+                          <XDSHStack hAlign="between" vAlign="center">
+                            <XDSText type="body">Delete my account</XDSText>
+                            <XDSLink label="Delete" href="#">
+                              Delete
+                            </XDSLink>
+                          </XDSHStack>
+                        </XDSCard>
+                        <XDSCard variant="muted" padding={4}>
+                          <XDSHStack gap={4} vAlign="start">
+                            <XDSIcon icon={ShieldCheckIcon} size="lg" />
+                            <XDSVStack gap={1}>
+                              <XDSText type="body" weight="bold">
+                                Committed to privacy
+                              </XDSText>
+                              <XDSText type="supporting" color="secondary">
+                                We&apos;re committed to keeping your data
+                                protected. See details in our{' '}
+                                <XDSLink
+                                  label="Privacy Policy"
+                                  href="#"
+                                  type="supporting">
+                                  Privacy Policy
+                                </XDSLink>
+                                .
+                              </XDSText>
+                            </XDSVStack>
+                          </XDSHStack>
+                        </XDSCard>
                       </XDSVStack>
                     </XDSVStack>
-                  )}
-                </div>
-              </XDSLayoutContent>
-            }
-          />
-        </div>
+                  </XDSVStack>
+                )}
+              </XDSSection>
+            </XDSLayoutContent>
+          }
+        />
       </XDSDialog>
-    </div>
+    </XDSAppShell>
   );
 }

--- a/packages/cli/templates/pages/settings-dialog/page.tsx
+++ b/packages/cli/templates/pages/settings-dialog/page.tsx
@@ -17,7 +17,6 @@ import {XDSDialog} from '@xds/core/Dialog';
 import {XDSList, XDSListItem} from '@xds/core/List';
 import {XDSDivider} from '@xds/core/Divider';
 import {XDSSelector} from '@xds/core/Selector';
-
 import {XDSSection} from '@xds/core/Section';
 import {XDSCard} from '@xds/core/Card';
 import {XDSSwitch} from '@xds/core/Switch';
@@ -47,6 +46,10 @@ const styles = stylex.create({
     borderRadius: 12,
     backgroundColor: 'var(--xds-color-background-muted, #f5f5f5)',
     flexShrink: 0,
+  },
+  rowPadding: {
+    paddingTop: 16,
+    paddingBottom: 16,
   },
 });
 
@@ -136,7 +139,7 @@ function ExpandableRow({
   return (
     <>
       {isExpanded ? (
-        <XDSVStack gap={4} padding={4}>
+        <XDSVStack gap={4} xstyle={styles.rowPadding}>
           <XDSText type="body" weight="semibold" display="block">
             {label}
           </XDSText>
@@ -147,7 +150,7 @@ function ExpandableRow({
           </XDSHStack>
         </XDSVStack>
       ) : (
-        <XDSHStack hAlign="between" vAlign="start" padding={4}>
+        <XDSHStack hAlign="between" vAlign="start" xstyle={styles.rowPadding}>
           <XDSVStack gap={0}>
             <XDSText type="body" weight="semibold" display="block">
               {label}
@@ -183,7 +186,7 @@ function InfoRowItem({
 }) {
   return (
     <>
-      <XDSHStack hAlign="between" vAlign="start" padding={4}>
+      <XDSHStack hAlign="between" vAlign="start" xstyle={styles.rowPadding}>
         <XDSVStack gap={0}>
           <XDSText type="body" weight="semibold" display="block">
             {label}
@@ -287,7 +290,10 @@ export default function SettingsDialogTemplate() {
           }
           content={
             <XDSLayoutContent isScrollable>
-              <XDSSection padding={6} maxWidth={680} variant="transparent">
+              <XDSSection
+                padding={4}
+                maxWidth={680}
+                variant="transparent">
                 {activeNav === 'Personal information' && (
                   <XDSVStack gap={6}>
                     <XDSHeading level={2}>Personal info</XDSHeading>
@@ -336,85 +342,82 @@ export default function SettingsDialogTemplate() {
 
                     <XDSCard padding={4}>
                       <XDSVStack gap={0}>
-                        <XDSSection padding={4} variant="transparent">
-                          <XDSHStack gap={3} vAlign="start">
-                            <XDSCenter
-                              width={48}
-                              height={48}
-                              xstyle={styles.iconBox}>
-                              <XDSIcon icon={LockClosedIcon} />
-                            </XDSCenter>
-                            <XDSVStack gap={0}>
-                              <XDSText
-                                type="body"
-                                weight="semibold"
-                                display="block">
-                                Why isn&apos;t my info shown here?
-                              </XDSText>
-                              <XDSText
-                                type="supporting"
-                                color="secondary"
-                                display="block">
-                                We&apos;re hiding some account details to
-                                protect your identity.
-                              </XDSText>
-                            </XDSVStack>
-                          </XDSHStack>
-                        </XDSSection>
+                        <XDSHStack gap={3} vAlign="start">
+                          <XDSCenter
+                            width={48}
+                            height={48}
+                            xstyle={styles.iconBox}>
+                            <XDSIcon icon={LockClosedIcon} />
+                          </XDSCenter>
+                          <XDSVStack gap={0}>
+                            <XDSText
+                              type="body"
+                              weight="semibold"
+                              display="block">
+                              Why isn&apos;t my info shown here?
+                            </XDSText>
+                            <XDSText
+                              type="supporting"
+                              color="secondary"
+                              display="block">
+                              We&apos;re hiding some account details to
+                              protect your identity.
+                            </XDSText>
+                          </XDSVStack>
+                        </XDSHStack>
                         <XDSDivider />
-                        <XDSSection padding={4} variant="transparent">
-                          <XDSHStack gap={3} vAlign="start">
-                            <XDSCenter
-                              width={48}
-                              height={48}
-                              xstyle={styles.iconBox}>
-                              <XDSIcon icon={PencilSquareIcon} />
-                            </XDSCenter>
-                            <XDSVStack gap={0}>
-                              <XDSText
-                                type="body"
-                                weight="semibold"
-                                display="block">
-                                Which details can be edited?
-                              </XDSText>
-                              <XDSText
-                                type="supporting"
-                                color="secondary"
-                                display="block">
-                                Contact info and personal details can be edited.
-                                If this info was used to verify your identity,
-                                you&apos;ll need to get verified again the next
-                                time you book—or to continue hosting.
-                              </XDSText>
-                            </XDSVStack>
-                          </XDSHStack>
-                        </XDSSection>
+                        <XDSHStack
+                          gap={3}
+                          vAlign="start"
+                          xstyle={styles.rowPadding}>
+                          <XDSCenter
+                            width={48}
+                            height={48}
+                            xstyle={styles.iconBox}>
+                            <XDSIcon icon={PencilSquareIcon} />
+                          </XDSCenter>
+                          <XDSVStack gap={0}>
+                            <XDSText
+                              type="body"
+                              weight="semibold"
+                              display="block">
+                              Which details can be edited?
+                            </XDSText>
+                            <XDSText
+                              type="supporting"
+                              color="secondary"
+                              display="block">
+                              Contact info and personal details can be edited.
+                              If this info was used to verify your identity,
+                              you&apos;ll need to get verified again the next
+                              time you book—or to continue hosting.
+                            </XDSText>
+                          </XDSVStack>
+                        </XDSHStack>
                         <XDSDivider />
-                        <XDSSection padding={4} variant="transparent">
-                          <XDSHStack gap={3} vAlign="start">
-                            <XDSCenter
-                              width={48}
-                              height={48}
-                              xstyle={styles.iconBox}>
-                              <XDSIcon icon={ShareIcon} />
-                            </XDSCenter>
-                            <XDSVStack gap={0}>
-                              <XDSText
-                                type="body"
-                                weight="semibold"
-                                display="block">
-                                What info is shared with others?
-                              </XDSText>
-                              <XDSText
-                                type="supporting"
-                                color="secondary"
-                                display="block">
-                                We only release contact information after a
-                                reservation is confirmed.
-                              </XDSText>
-                            </XDSVStack>
-                          </XDSHStack>
-                        </XDSSection>
+                        <XDSHStack gap={3} vAlign="start">
+                          <XDSCenter
+                            width={48}
+                            height={48}
+                            xstyle={styles.iconBox}>
+                            <XDSIcon icon={ShareIcon} />
+                          </XDSCenter>
+                          <XDSVStack gap={0}>
+                            <XDSText
+                              type="body"
+                              weight="semibold"
+                              display="block">
+                              What info is shared with others?
+                            </XDSText>
+                            <XDSText
+                              type="supporting"
+                              color="secondary"
+                              display="block">
+                              We only release contact information after a
+                              reservation is confirmed.
+                            </XDSText>
+                          </XDSVStack>
+                        </XDSHStack>
                       </XDSVStack>
                     </XDSCard>
                   </XDSVStack>
@@ -458,7 +461,7 @@ export default function SettingsDialogTemplate() {
                               key={i}
                               gap={3}
                               vAlign="start"
-                              padding={4}>
+                              xstyle={styles.rowPadding}>
                               <XDSIcon icon={ComputerDesktopIcon} />
                               <XDSStackItem size="fill">
                                 <XDSVStack gap={0}>
@@ -494,7 +497,7 @@ export default function SettingsDialogTemplate() {
                           <XDSHStack
                             hAlign="between"
                             vAlign="start"
-                            padding={4}>
+                            xstyle={styles.rowPadding}>
                             <XDSVStack gap={0}>
                               <XDSText
                                 type="body"
@@ -631,7 +634,7 @@ export default function SettingsDialogTemplate() {
                     <XDSVStack gap={8}>
                       <XDSVStack gap={0}>
                         <XDSHeading level={3}>Messages</XDSHeading>
-                        <XDSSection padding={4} variant="transparent">
+                        <XDSVStack xstyle={styles.rowPadding}>
                           <XDSSwitch
                             label="Show people when I've read their messages."
                             value={readReceipts}
@@ -639,23 +642,24 @@ export default function SettingsDialogTemplate() {
                             labelPosition="start"
                             labelSpacing="spread"
                           />
-                        </XDSSection>
-                        <XDSSection padding={4} variant="transparent">
-                          <XDSHStack hAlign="between" vAlign="center">
-                            <XDSText type="body" weight="semibold">
-                              Blocked people
-                            </XDSText>
-                            <XDSLink label="View" href="#">
-                              View
-                            </XDSLink>
-                          </XDSHStack>
-                        </XDSSection>
+                        </XDSVStack>
+                        <XDSHStack
+                          hAlign="between"
+                          vAlign="center"
+                          xstyle={styles.rowPadding}>
+                          <XDSText type="body" weight="semibold">
+                            Blocked people
+                          </XDSText>
+                          <XDSLink label="View" href="#">
+                            View
+                          </XDSLink>
+                        </XDSHStack>
                         <XDSDivider />
                       </XDSVStack>
 
                       <XDSVStack gap={0}>
                         <XDSHeading level={3}>Listings</XDSHeading>
-                        <XDSSection padding={4} variant="transparent">
+                        <XDSVStack xstyle={styles.rowPadding}>
                           <XDSSwitch
                             label="Include my listing(s) in search engines"
                             description="Turning this on means search engines, like Google, will display your listing page(s) in search results."
@@ -664,59 +668,55 @@ export default function SettingsDialogTemplate() {
                             labelPosition="start"
                             labelSpacing="spread"
                           />
-                        </XDSSection>
+                        </XDSVStack>
                         <XDSDivider />
                       </XDSVStack>
 
-                      <XDSVStack gap={0}>
+                      <XDSVStack gap={4}>
                         <XDSHeading level={3}>Reviews</XDSHeading>
-                        <XDSSection padding={2} variant="transparent">
-                          <XDSText type="supporting" color="secondary">
-                            Choose what&apos;s shared when you write a review.{' '}
-                            <XDSLink
-                              label="Learn more"
-                              href="#"
-                              type="supporting">
-                              Learn more
-                            </XDSLink>
-                          </XDSText>
-                        </XDSSection>
-                        <XDSSection padding={4} variant="transparent">
-                          <XDSVStack gap={4}>
-                            <XDSSwitch
-                              label="Show my home city and country"
-                              description="Ex: City and country"
-                              value={showCity}
-                              onChange={setShowCity}
-                              labelPosition="start"
-                              labelSpacing="spread"
-                            />
-                            <XDSSwitch
-                              label="Show my trip type"
-                              description="Ex: Stayed with kids or pets"
-                              value={showTripType}
-                              onChange={setShowTripType}
-                              labelPosition="start"
-                              labelSpacing="spread"
-                            />
-                            <XDSSwitch
-                              label="Show my length of stay"
-                              description="Ex: A few nights, about a week, etc."
-                              value={showStayLength}
-                              onChange={setShowStayLength}
-                              labelPosition="start"
-                              labelSpacing="spread"
-                            />
-                            <XDSSwitch
-                              label="Show my booked services"
-                              description="Ex: Gourmet brunch or tasting menu"
-                              value={showServices}
-                              onChange={setShowServices}
-                              labelPosition="start"
-                              labelSpacing="spread"
-                            />
-                          </XDSVStack>
-                        </XDSSection>
+                        <XDSText type="supporting" color="secondary">
+                          Choose what&apos;s shared when you write a review.{' '}
+                          <XDSLink
+                            label="Learn more"
+                            href="#"
+                            type="supporting">
+                            Learn more
+                          </XDSLink>
+                        </XDSText>
+                        <XDSVStack gap={4}>
+                          <XDSSwitch
+                            label="Show my home city and country"
+                            description="Ex: City and country"
+                            value={showCity}
+                            onChange={setShowCity}
+                            labelPosition="start"
+                            labelSpacing="spread"
+                          />
+                          <XDSSwitch
+                            label="Show my trip type"
+                            description="Ex: Stayed with kids or pets"
+                            value={showTripType}
+                            onChange={setShowTripType}
+                            labelPosition="start"
+                            labelSpacing="spread"
+                          />
+                          <XDSSwitch
+                            label="Show my length of stay"
+                            description="Ex: A few nights, about a week, etc."
+                            value={showStayLength}
+                            onChange={setShowStayLength}
+                            labelPosition="start"
+                            labelSpacing="spread"
+                          />
+                          <XDSSwitch
+                            label="Show my booked services"
+                            description="Ex: Gourmet brunch or tasting menu"
+                            value={showServices}
+                            onChange={setShowServices}
+                            labelPosition="start"
+                            labelSpacing="spread"
+                          />
+                        </XDSVStack>
                         <XDSDivider />
                       </XDSVStack>
 

--- a/packages/cli/templates/pages/settings-dialog/page.tsx
+++ b/packages/cli/templates/pages/settings-dialog/page.tsx
@@ -1,11 +1,12 @@
 'use client';
 
 import {useState} from 'react';
+import * as stylex from '@stylexjs/stylex';
 import {XDSAppShell} from '@xds/core/AppShell';
-import {XDSTopNav, XDSTopNavHeading} from '@xds/core/TopNav';
 import {
   XDSVStack,
   XDSHStack,
+  XDSStackItem,
   XDSLayout,
   XDSLayoutPanel,
   XDSLayoutContent,
@@ -16,6 +17,7 @@ import {XDSDialog} from '@xds/core/Dialog';
 import {XDSList, XDSListItem} from '@xds/core/List';
 import {XDSDivider} from '@xds/core/Divider';
 import {XDSSelector} from '@xds/core/Selector';
+
 import {XDSSection} from '@xds/core/Section';
 import {XDSCard} from '@xds/core/Card';
 import {XDSSwitch} from '@xds/core/Switch';
@@ -39,6 +41,14 @@ import {
   PencilSquareIcon,
   ShareIcon,
 } from '@heroicons/react/24/outline';
+
+const styles = stylex.create({
+  iconBox: {
+    borderRadius: 12,
+    backgroundColor: 'var(--xds-color-background-muted, #f5f5f5)',
+    flexShrink: 0,
+  },
+});
 
 const NAV_ITEMS = [
   {label: 'Personal information', icon: UserIcon},
@@ -126,7 +136,7 @@ function ExpandableRow({
   return (
     <>
       {isExpanded ? (
-        <XDSVStack gap={4}>
+        <XDSVStack gap={4} padding={4}>
           <XDSText type="body" weight="semibold" display="block">
             {label}
           </XDSText>
@@ -137,7 +147,7 @@ function ExpandableRow({
           </XDSHStack>
         </XDSVStack>
       ) : (
-        <XDSHStack hAlign="between" vAlign="start">
+        <XDSHStack hAlign="between" vAlign="start" padding={4}>
           <XDSVStack gap={0}>
             <XDSText type="body" weight="semibold" display="block">
               {label}
@@ -162,6 +172,37 @@ function ExpandableRow({
   );
 }
 
+function InfoRowItem({
+  label,
+  value,
+  action,
+}: {
+  label: string;
+  value: string;
+  action: string;
+}) {
+  return (
+    <>
+      <XDSHStack hAlign="between" vAlign="start" padding={4}>
+        <XDSVStack gap={0}>
+          <XDSText type="body" weight="semibold" display="block">
+            {label}
+          </XDSText>
+          <XDSText type="supporting" color="secondary" display="block">
+            {value}
+          </XDSText>
+        </XDSVStack>
+        {action && (
+          <XDSLink label={action} href="#">
+            {action}
+          </XDSLink>
+        )}
+      </XDSHStack>
+      <XDSDivider />
+    </>
+  );
+}
+
 export default function SettingsDialogTemplate() {
   const [isOpen, setIsOpen] = useState(false);
   const [activeNav, setActiveNav] = useState('Login & security');
@@ -179,15 +220,13 @@ export default function SettingsDialogTemplate() {
   const [showServices, setShowServices] = useState(true);
   const [aiFeatures, setAiFeatures] = useState(true);
 
+  const handleEdit = (row: string) => setExpandedRow(row);
+  const handleCancel = () => setExpandedRow(null);
+  const handleSave = () => setExpandedRow(null);
+
   return (
-    <XDSAppShell
-      topNav={
-        <XDSTopNav
-          label="Application"
-          heading={<XDSTopNavHeading heading="My App" />}
-        />
-      }>
-      <XDSCenter height="60vh">
+    <XDSAppShell>
+      <XDSCenter height="80vh">
         <XDSButton
           label="Open settings"
           variant="primary"
@@ -205,7 +244,11 @@ export default function SettingsDialogTemplate() {
         <XDSLayout
           height="fill"
           start={
-            <XDSLayoutPanel width={280} hasDivider role="navigation" padding={3}>
+            <XDSLayoutPanel
+              width={280}
+              hasDivider
+              role="navigation"
+              padding={3}>
               <XDSVStack gap={4}>
                 <XDSHStack hAlign="between" vAlign="center">
                   <XDSHeading level={2}>Account settings</XDSHeading>
@@ -235,9 +278,7 @@ export default function SettingsDialogTemplate() {
                 <XDSList density="spacious">
                   <XDSListItem
                     label="Professional hosting tools"
-                    startContent={
-                      <XDSIcon icon={WrenchScrewdriverIcon} />
-                    }
+                    startContent={<XDSIcon icon={WrenchScrewdriverIcon} />}
                     onClick={() => {}}
                   />
                 </XDSList>
@@ -245,114 +286,143 @@ export default function SettingsDialogTemplate() {
             </XDSLayoutPanel>
           }
           content={
-            <XDSLayoutContent>
-              <XDSSection padding={4} maxWidth={680}>
+            <XDSLayoutContent isScrollable>
+              <XDSSection padding={6} maxWidth={680} variant="transparent">
                 {activeNav === 'Personal information' && (
                   <XDSVStack gap={6}>
                     <XDSHeading level={2}>Personal info</XDSHeading>
-                    <XDSList hasDividers density="spacious">
-                      <XDSListItem
+                    <XDSVStack gap={0}>
+                      <InfoRowItem
                         label="Legal name"
-                        description="Alex Johnson"
-                        endContent={
-                          <XDSLink label="Edit" href="#">
-                            Edit
-                          </XDSLink>
-                        }
+                        value="Alex Johnson"
+                        action="Edit"
                       />
-                      <XDSListItem
+                      <InfoRowItem
                         label="Preferred first name"
-                        description="Not provided"
-                        endContent={
-                          <XDSLink label="Add" href="#">
-                            Add
-                          </XDSLink>
-                        }
+                        value="Not provided"
+                        action="Add"
                       />
-                      <XDSListItem
+                      <InfoRowItem
                         label="Email address"
-                        description="a***n@example.com"
-                        endContent={
-                          <XDSLink label="Edit" href="#">
-                            Edit
-                          </XDSLink>
-                        }
+                        value="a***n@example.com"
+                        action="Edit"
                       />
-                      <XDSListItem
+                      <InfoRowItem
                         label="Phone number"
-                        description="+1 ***-***-0123"
-                        endContent={
-                          <XDSLink label="Edit" href="#">
-                            Edit
-                          </XDSLink>
-                        }
+                        value="+1 ***-***-0123"
+                        action="Edit"
                       />
-                      <XDSListItem
+                      <InfoRowItem
                         label="Identity verification"
-                        description="Verified"
+                        value="Verified"
+                        action=""
                       />
-                      <XDSListItem
+                      <InfoRowItem
                         label="Residential address"
-                        description="Not provided"
-                        endContent={
-                          <XDSLink label="Add" href="#">
-                            Add
-                          </XDSLink>
-                        }
+                        value="Not provided"
+                        action="Add"
                       />
-                      <XDSListItem
+                      <InfoRowItem
                         label="Mailing address"
-                        description="Not provided"
-                        endContent={
-                          <XDSLink label="Add" href="#">
-                            Add
-                          </XDSLink>
-                        }
+                        value="Not provided"
+                        action="Add"
                       />
-                      <XDSListItem
+                      <InfoRowItem
                         label="Emergency contact"
-                        description="Provided"
-                        endContent={
-                          <XDSLink label="Edit" href="#">
-                            Edit
-                          </XDSLink>
-                        }
+                        value="Provided"
+                        action="Edit"
                       />
-                    </XDSList>
+                    </XDSVStack>
 
                     <XDSCard padding={4}>
-                      <XDSList hasDividers density="spacious">
-                        <XDSListItem
-                          label="Why isn't my info shown here?"
-                          description="We're hiding some account details to protect your identity."
-                          startContent={
-                            <XDSIcon icon={LockClosedIcon} size="lg" />
-                          }
-                        />
-                        <XDSListItem
-                          label="Which details can be edited?"
-                          description="Contact info and personal details can be edited. If this info was used to verify your identity, you'll need to get verified again the next time you book—or to continue hosting."
-                          startContent={
-                            <XDSIcon icon={PencilSquareIcon} size="lg" />
-                          }
-                        />
-                        <XDSListItem
-                          label="What info is shared with others?"
-                          description="We only release contact information after a reservation is confirmed."
-                          startContent={
-                            <XDSIcon icon={ShareIcon} size="lg" />
-                          }
-                        />
-                      </XDSList>
+                      <XDSVStack gap={0}>
+                        <XDSSection padding={4} variant="transparent">
+                          <XDSHStack gap={3} vAlign="start">
+                            <XDSCenter
+                              width={48}
+                              height={48}
+                              xstyle={styles.iconBox}>
+                              <XDSIcon icon={LockClosedIcon} />
+                            </XDSCenter>
+                            <XDSVStack gap={0}>
+                              <XDSText
+                                type="body"
+                                weight="semibold"
+                                display="block">
+                                Why isn&apos;t my info shown here?
+                              </XDSText>
+                              <XDSText
+                                type="supporting"
+                                color="secondary"
+                                display="block">
+                                We&apos;re hiding some account details to
+                                protect your identity.
+                              </XDSText>
+                            </XDSVStack>
+                          </XDSHStack>
+                        </XDSSection>
+                        <XDSDivider />
+                        <XDSSection padding={4} variant="transparent">
+                          <XDSHStack gap={3} vAlign="start">
+                            <XDSCenter
+                              width={48}
+                              height={48}
+                              xstyle={styles.iconBox}>
+                              <XDSIcon icon={PencilSquareIcon} />
+                            </XDSCenter>
+                            <XDSVStack gap={0}>
+                              <XDSText
+                                type="body"
+                                weight="semibold"
+                                display="block">
+                                Which details can be edited?
+                              </XDSText>
+                              <XDSText
+                                type="supporting"
+                                color="secondary"
+                                display="block">
+                                Contact info and personal details can be edited.
+                                If this info was used to verify your identity,
+                                you&apos;ll need to get verified again the next
+                                time you book—or to continue hosting.
+                              </XDSText>
+                            </XDSVStack>
+                          </XDSHStack>
+                        </XDSSection>
+                        <XDSDivider />
+                        <XDSSection padding={4} variant="transparent">
+                          <XDSHStack gap={3} vAlign="start">
+                            <XDSCenter
+                              width={48}
+                              height={48}
+                              xstyle={styles.iconBox}>
+                              <XDSIcon icon={ShareIcon} />
+                            </XDSCenter>
+                            <XDSVStack gap={0}>
+                              <XDSText
+                                type="body"
+                                weight="semibold"
+                                display="block">
+                                What info is shared with others?
+                              </XDSText>
+                              <XDSText
+                                type="supporting"
+                                color="secondary"
+                                display="block">
+                                We only release contact information after a
+                                reservation is confirmed.
+                              </XDSText>
+                            </XDSVStack>
+                          </XDSHStack>
+                        </XDSSection>
+                      </XDSVStack>
                     </XDSCard>
                   </XDSVStack>
                 )}
 
                 {activeNav === 'Login & security' && (
                   <XDSVStack gap={6}>
-                    <XDSHeading level={2}>
-                      Login &amp; security
-                    </XDSHeading>
+                    <XDSHeading level={2}>Login &amp; security</XDSHeading>
 
                     <XDSTabList
                       value={activeTab}
@@ -364,83 +434,86 @@ export default function SettingsDialogTemplate() {
 
                     {activeTab === 'login' && (
                       <XDSVStack gap={8}>
-                        <XDSVStack gap={2}>
+                        <XDSVStack gap={0}>
                           <XDSHeading level={3}>Login</XDSHeading>
-                          <XDSList hasDividers density="spacious">
-                            {LOGIN_ROWS.map(row => (
-                              <XDSListItem
-                                key={row.label}
-                                label={row.label}
-                                description={row.value}
-                                endContent={
-                                  <XDSLink label={row.action} href="#">
-                                    {row.action}
-                                  </XDSLink>
-                                }
-                              />
-                            ))}
-                          </XDSList>
+                          <XDSDivider />
+                          {LOGIN_ROWS.map(row => (
+                            <InfoRowItem key={row.label} {...row} />
+                          ))}
                         </XDSVStack>
 
-                        <XDSVStack gap={2}>
+                        <XDSVStack gap={0}>
                           <XDSHeading level={3}>Social accounts</XDSHeading>
-                          <XDSList hasDividers density="spacious">
-                            {SOCIAL_ROWS.map(row => (
-                              <XDSListItem
-                                key={row.label}
-                                label={row.label}
-                                description={row.value}
-                                endContent={
-                                  <XDSLink label={row.action} href="#">
-                                    {row.action}
-                                  </XDSLink>
-                                }
-                              />
-                            ))}
-                          </XDSList>
+                          <XDSDivider />
+                          {SOCIAL_ROWS.map(row => (
+                            <InfoRowItem key={row.label} {...row} />
+                          ))}
                         </XDSVStack>
 
-                        <XDSVStack gap={2}>
+                        <XDSVStack gap={0}>
                           <XDSHeading level={3}>Device history</XDSHeading>
-                          <XDSList hasDividers density="spacious">
-                            {DEVICE_ROWS.map((device, i) => (
-                              <XDSListItem
-                                key={i}
-                                label={device.label}
-                                description={device.location}
-                                startContent={
-                                  <XDSIcon
-                                    icon={ComputerDesktopIcon}
-                                    size="lg"
-                                  />
-                                }
-                                endContent={
-                                  device.badge ? (
-                                    <XDSBadge label={device.badge} />
-                                  ) : device.action ? (
-                                    <XDSLink label={device.action} href="#">
-                                      {device.action}
-                                    </XDSLink>
-                                  ) : undefined
-                                }
-                              />
-                            ))}
-                          </XDSList>
+                          <XDSDivider />
+                          {DEVICE_ROWS.map((device, i) => (
+                            <XDSHStack
+                              key={i}
+                              gap={3}
+                              vAlign="start"
+                              padding={4}>
+                              <XDSIcon icon={ComputerDesktopIcon} />
+                              <XDSStackItem size="fill">
+                                <XDSVStack gap={0}>
+                                  <XDSHStack gap={2} vAlign="center">
+                                    <XDSText type="body" weight="semibold">
+                                      {device.label}
+                                    </XDSText>
+                                    {device.badge && (
+                                      <XDSBadge label={device.badge} />
+                                    )}
+                                  </XDSHStack>
+                                  <XDSText
+                                    type="supporting"
+                                    color="secondary"
+                                    display="block">
+                                    {device.location}
+                                  </XDSText>
+                                </XDSVStack>
+                              </XDSStackItem>
+                              {device.action && (
+                                <XDSLink label={device.action} href="#">
+                                  {device.action}
+                                </XDSLink>
+                              )}
+                            </XDSHStack>
+                          ))}
+                          <XDSDivider />
                         </XDSVStack>
 
-                        <XDSVStack gap={2}>
+                        <XDSVStack gap={0}>
                           <XDSHeading level={3}>Account</XDSHeading>
-                          <XDSList hasDividers density="spacious">
-                            <XDSListItem
-                              label="Deactivate your account"
-                              description="This action cannot be undone"
-                              endContent={
-                                <XDSLink label="Deactivate" href="#">
-                                  Deactivate
-                                </XDSLink>
-                              }
-                            />
-                          </XDSList>
+                          <XDSDivider />
+                          <XDSHStack
+                            hAlign="between"
+                            vAlign="start"
+                            padding={4}>
+                            <XDSVStack gap={0}>
+                              <XDSText
+                                type="body"
+                                weight="semibold"
+                                display="block">
+                                Deactivate your account
+                              </XDSText>
+                              <XDSText
+                                type="supporting"
+                                color="secondary"
+                                display="block">
+                                This action cannot be undone
+                              </XDSText>
+                            </XDSVStack>
+                            <XDSLink label="Deactivate" href="#">
+                              Deactivate
+                            </XDSLink>
+                          </XDSHStack>
+                          <XDSDivider />
                         </XDSVStack>
                       </XDSVStack>
                     )}
@@ -460,7 +533,12 @@ export default function SettingsDialogTemplate() {
 
                         <XDSCard variant="muted" padding={4}>
                           <XDSHStack gap={4} vAlign="start">
-                            <XDSIcon icon={LockClosedIcon} size="lg" />
+                            <XDSCenter
+                              width={48}
+                              height={48}
+                              xstyle={styles.iconBox}>
+                              <XDSIcon icon={LockClosedIcon} />
+                            </XDSCenter>
                             <XDSVStack gap={1}>
                               <XDSText type="body" weight="bold">
                                 Adding devices from people you trust
@@ -492,9 +570,9 @@ export default function SettingsDialogTemplate() {
                           language
                         }
                         isExpanded={expandedRow === 'language'}
-                        onEdit={() => setExpandedRow('language')}
-                        onCancel={() => setExpandedRow(null)}
-                        onSave={() => setExpandedRow(null)}>
+                        onEdit={() => handleEdit('language')}
+                        onCancel={handleCancel}
+                        onSave={handleSave}>
                         <XDSSelector
                           label="Language"
                           isLabelHidden
@@ -511,9 +589,9 @@ export default function SettingsDialogTemplate() {
                           currency
                         }
                         isExpanded={expandedRow === 'currency'}
-                        onEdit={() => setExpandedRow('currency')}
-                        onCancel={() => setExpandedRow(null)}
-                        onSave={() => setExpandedRow(null)}>
+                        onEdit={() => handleEdit('currency')}
+                        onCancel={handleCancel}
+                        onSave={handleSave}>
                         <XDSSelector
                           label="Currency"
                           isLabelHidden
@@ -530,9 +608,9 @@ export default function SettingsDialogTemplate() {
                           timezone
                         }
                         isExpanded={expandedRow === 'timezone'}
-                        onEdit={() => setExpandedRow('timezone')}
-                        onCancel={() => setExpandedRow(null)}
-                        onSave={() => setExpandedRow(null)}>
+                        onEdit={() => handleEdit('timezone')}
+                        onCancel={handleCancel}
+                        onSave={handleSave}>
                         <XDSSelector
                           label="Time zone"
                           isLabelHidden
@@ -551,85 +629,94 @@ export default function SettingsDialogTemplate() {
                     <XDSHeading level={2}>Privacy</XDSHeading>
 
                     <XDSVStack gap={8}>
-                      <XDSVStack gap={4}>
+                      <XDSVStack gap={0}>
                         <XDSHeading level={3}>Messages</XDSHeading>
-                        <XDSSwitch
-                          label="Show people when I've read their messages."
-                          value={readReceipts}
-                          onChange={setReadReceipts}
-                          labelPosition="start"
-                          labelSpacing="spread"
-                        />
-                        <XDSList hasDividers density="spacious">
-                          <XDSListItem
-                            label="Blocked people"
-                            endContent={
-                              <XDSLink label="View" href="#">
-                                View
-                              </XDSLink>
-                            }
+                        <XDSSection padding={4} variant="transparent">
+                          <XDSSwitch
+                            label="Show people when I've read their messages."
+                            value={readReceipts}
+                            onChange={setReadReceipts}
+                            labelPosition="start"
+                            labelSpacing="spread"
                           />
-                        </XDSList>
-                      </XDSVStack>
-
-                      <XDSVStack gap={4}>
-                        <XDSHeading level={3}>Listings</XDSHeading>
-                        <XDSSwitch
-                          label="Include my listing(s) in search engines"
-                          description="Turning this on means search engines, like Google, will display your listing page(s) in search results."
-                          value={searchEngines}
-                          onChange={setSearchEngines}
-                          labelPosition="start"
-                          labelSpacing="spread"
-                        />
+                        </XDSSection>
+                        <XDSSection padding={4} variant="transparent">
+                          <XDSHStack hAlign="between" vAlign="center">
+                            <XDSText type="body" weight="semibold">
+                              Blocked people
+                            </XDSText>
+                            <XDSLink label="View" href="#">
+                              View
+                            </XDSLink>
+                          </XDSHStack>
+                        </XDSSection>
                         <XDSDivider />
                       </XDSVStack>
 
-                      <XDSVStack gap={4}>
+                      <XDSVStack gap={0}>
+                        <XDSHeading level={3}>Listings</XDSHeading>
+                        <XDSSection padding={4} variant="transparent">
+                          <XDSSwitch
+                            label="Include my listing(s) in search engines"
+                            description="Turning this on means search engines, like Google, will display your listing page(s) in search results."
+                            value={searchEngines}
+                            onChange={setSearchEngines}
+                            labelPosition="start"
+                            labelSpacing="spread"
+                          />
+                        </XDSSection>
+                        <XDSDivider />
+                      </XDSVStack>
+
+                      <XDSVStack gap={0}>
                         <XDSHeading level={3}>Reviews</XDSHeading>
-                        <XDSText type="supporting" color="secondary">
-                          Choose what&apos;s shared when you write a review.{' '}
-                          <XDSLink
-                            label="Learn more"
-                            href="#"
-                            type="supporting">
-                            Learn more
-                          </XDSLink>
-                        </XDSText>
-                        <XDSVStack gap={4}>
-                          <XDSSwitch
-                            label="Show my home city and country"
-                            description="Ex: City and country"
-                            value={showCity}
-                            onChange={setShowCity}
-                            labelPosition="start"
-                            labelSpacing="spread"
-                          />
-                          <XDSSwitch
-                            label="Show my trip type"
-                            description="Ex: Stayed with kids or pets"
-                            value={showTripType}
-                            onChange={setShowTripType}
-                            labelPosition="start"
-                            labelSpacing="spread"
-                          />
-                          <XDSSwitch
-                            label="Show my length of stay"
-                            description="Ex: A few nights, about a week, etc."
-                            value={showStayLength}
-                            onChange={setShowStayLength}
-                            labelPosition="start"
-                            labelSpacing="spread"
-                          />
-                          <XDSSwitch
-                            label="Show my booked services"
-                            description="Ex: Gourmet brunch or tasting menu"
-                            value={showServices}
-                            onChange={setShowServices}
-                            labelPosition="start"
-                            labelSpacing="spread"
-                          />
-                        </XDSVStack>
+                        <XDSSection padding={2} variant="transparent">
+                          <XDSText type="supporting" color="secondary">
+                            Choose what&apos;s shared when you write a review.{' '}
+                            <XDSLink
+                              label="Learn more"
+                              href="#"
+                              type="supporting">
+                              Learn more
+                            </XDSLink>
+                          </XDSText>
+                        </XDSSection>
+                        <XDSSection padding={4} variant="transparent">
+                          <XDSVStack gap={4}>
+                            <XDSSwitch
+                              label="Show my home city and country"
+                              description="Ex: City and country"
+                              value={showCity}
+                              onChange={setShowCity}
+                              labelPosition="start"
+                              labelSpacing="spread"
+                            />
+                            <XDSSwitch
+                              label="Show my trip type"
+                              description="Ex: Stayed with kids or pets"
+                              value={showTripType}
+                              onChange={setShowTripType}
+                              labelPosition="start"
+                              labelSpacing="spread"
+                            />
+                            <XDSSwitch
+                              label="Show my length of stay"
+                              description="Ex: A few nights, about a week, etc."
+                              value={showStayLength}
+                              onChange={setShowStayLength}
+                              labelPosition="start"
+                              labelSpacing="spread"
+                            />
+                            <XDSSwitch
+                              label="Show my booked services"
+                              description="Ex: Gourmet brunch or tasting menu"
+                              value={showServices}
+                              onChange={setShowServices}
+                              labelPosition="start"
+                              labelSpacing="spread"
+                            />
+                          </XDSVStack>
+                        </XDSSection>
                         <XDSDivider />
                       </XDSVStack>
 
@@ -661,26 +748,33 @@ export default function SettingsDialogTemplate() {
                             </XDSLink>
                           </XDSHStack>
                         </XDSCard>
-                        <XDSCard variant="muted" padding={4}>
-                          <XDSHStack gap={4} vAlign="start">
-                            <XDSIcon icon={ShieldCheckIcon} size="lg" />
-                            <XDSVStack gap={1}>
-                              <XDSText type="body" weight="bold">
-                                Committed to privacy
-                              </XDSText>
-                              <XDSText type="supporting" color="secondary">
-                                We&apos;re committed to keeping your data
-                                protected. See details in our{' '}
-                                <XDSLink
-                                  label="Privacy Policy"
-                                  href="#"
-                                  type="supporting">
-                                  Privacy Policy
-                                </XDSLink>
-                                .
-                              </XDSText>
-                            </XDSVStack>
-                          </XDSHStack>
+                        <XDSCard>
+                          <XDSSection variant="wash">
+                            <XDSHStack gap={4} vAlign="start">
+                              <XDSCenter
+                                width={48}
+                                height={48}
+                                xstyle={styles.iconBox}>
+                                <XDSIcon icon={ShieldCheckIcon} />
+                              </XDSCenter>
+                              <XDSVStack gap={1}>
+                                <XDSText type="body" weight="bold">
+                                  Committed to privacy
+                                </XDSText>
+                                <XDSText type="supporting" color="secondary">
+                                  We&apos;re committed to keeping your data
+                                  protected. See details in our{' '}
+                                  <XDSLink
+                                    label="Privacy Policy"
+                                    href="#"
+                                    type="supporting">
+                                    Privacy Policy
+                                  </XDSLink>
+                                  .
+                                </XDSText>
+                              </XDSVStack>
+                            </XDSHStack>
+                          </XDSSection>
                         </XDSCard>
                       </XDSVStack>
                     </XDSVStack>

--- a/packages/cli/templates/pages/settings-dialog/template.doc.mjs
+++ b/packages/cli/templates/pages/settings-dialog/template.doc.mjs
@@ -2,6 +2,7 @@
 export const doc = {
   type: 'page',
   name: 'Settings (Dialog)',
-  description: 'Account settings in a dialog with sidebar nav',
+  description:
+    'Account settings in a modal dialog with sidebar navigation and multi-section content',
   isReady: true,
 };

--- a/packages/cli/templates/pages/settings-sidebar/page.tsx
+++ b/packages/cli/templates/pages/settings-sidebar/page.tsx
@@ -9,7 +9,6 @@ import {XDSText, XDSHeading} from '@xds/core/Text';
 import {XDSLink} from '@xds/core/Link';
 import {XDSButton} from '@xds/core/Button';
 import {XDSSelector} from '@xds/core/Selector';
-
 import {XDSCard} from '@xds/core/Card';
 import {XDSSection} from '@xds/core/Section';
 import {XDSSwitch} from '@xds/core/Switch';
@@ -38,6 +37,10 @@ const styles = stylex.create({
     borderRadius: 12,
     backgroundColor: 'var(--xds-color-background-muted, #f5f5f5)',
     flexShrink: 0,
+  },
+  rowPadding: {
+    paddingTop: 16,
+    paddingBottom: 16,
   },
 });
 
@@ -88,7 +91,7 @@ const DEVICE_ROWS: {
 function InfoRowItem({label, value, action}: InfoRow) {
   return (
     <>
-      <XDSHStack hAlign="between" vAlign="start" padding={4}>
+      <XDSHStack hAlign="between" vAlign="start" xstyle={styles.rowPadding}>
         <XDSVStack gap={0}>
           <XDSText type="body" weight="semibold" display="block">
             {label}
@@ -130,7 +133,7 @@ function ExpandableRow({
   return (
     <>
       {isExpanded ? (
-        <XDSVStack gap={4} padding={4}>
+        <XDSVStack gap={4} xstyle={styles.rowPadding}>
           <XDSText type="body" weight="semibold" display="block">
             {label}
           </XDSText>
@@ -141,7 +144,7 @@ function ExpandableRow({
           </XDSHStack>
         </XDSVStack>
       ) : (
-        <XDSHStack hAlign="between" vAlign="start" padding={4}>
+        <XDSHStack hAlign="between" vAlign="start" xstyle={styles.rowPadding}>
           <XDSVStack gap={0}>
             <XDSText type="body" weight="semibold" display="block">
               {label}
@@ -212,6 +215,7 @@ export default function SettingsSecurityTemplate() {
     <XDSAppShell
       height="fill"
       variant="section"
+      contentPadding={4}
       sideNav={
         <XDSVStack gap={4}>
           <XDSSection padding={4} variant="transparent">
@@ -238,7 +242,7 @@ export default function SettingsSecurityTemplate() {
           </XDSList>
         </XDSVStack>
       }>
-      <XDSSection padding={6} maxWidth={700} variant="transparent">
+      <XDSSection maxWidth={700} variant="transparent" padding={0}>
         {activeNav === 'Login & security' && (
           <XDSVStack gap={6}>
             <XDSHeading level={2}>Login &amp; security</XDSHeading>
@@ -273,7 +277,11 @@ export default function SettingsSecurityTemplate() {
                   <XDSHeading level={3}>Device history</XDSHeading>
                   <XDSDivider />
                   {DEVICE_ROWS.map((device, i) => (
-                    <XDSHStack key={i} gap={3} vAlign="start" padding={4}>
+                    <XDSHStack
+                      key={i}
+                      gap={3}
+                      vAlign="start"
+                      xstyle={styles.rowPadding}>
                       <XDSIcon icon={ComputerDesktopIcon} />
                       <XDSStackItem size="fill">
                         <XDSVStack gap={0}>
@@ -306,7 +314,10 @@ export default function SettingsSecurityTemplate() {
                 <XDSVStack gap={0}>
                   <XDSHeading level={3}>Account</XDSHeading>
                   <XDSDivider />
-                  <XDSHStack hAlign="between" vAlign="start" padding={4}>
+                  <XDSHStack
+                    hAlign="between"
+                    vAlign="start"
+                    xstyle={styles.rowPadding}>
                     <XDSVStack gap={0}>
                       <XDSText type="body" weight="semibold" display="block">
                         Deactivate your account
@@ -475,76 +486,73 @@ export default function SettingsSecurityTemplate() {
 
             <XDSCard padding={4}>
               <XDSVStack gap={0}>
-                <XDSSection padding={4} variant="transparent">
-                  <XDSHStack gap={3} vAlign="start">
-                    <XDSCenter
-                      width={48}
-                      height={48}
-                      xstyle={styles.iconBox}>
-                      <XDSIcon icon={LockClosedIcon} />
-                    </XDSCenter>
-                    <XDSVStack gap={0}>
-                      <XDSText type="body" weight="semibold" display="block">
-                        Why isn&apos;t my info shown here?
-                      </XDSText>
-                      <XDSText
-                        type="supporting"
-                        color="secondary"
-                        display="block">
-                        We&apos;re hiding some account details to protect your
-                        identity.
-                      </XDSText>
-                    </XDSVStack>
-                  </XDSHStack>
-                </XDSSection>
+                <XDSHStack gap={3} vAlign="start">
+                  <XDSCenter
+                    width={48}
+                    height={48}
+                    xstyle={styles.iconBox}>
+                    <XDSIcon icon={LockClosedIcon} />
+                  </XDSCenter>
+                  <XDSVStack gap={0}>
+                    <XDSText type="body" weight="semibold" display="block">
+                      Why isn&apos;t my info shown here?
+                    </XDSText>
+                    <XDSText
+                      type="supporting"
+                      color="secondary"
+                      display="block">
+                      We&apos;re hiding some account details to protect your
+                      identity.
+                    </XDSText>
+                  </XDSVStack>
+                </XDSHStack>
                 <XDSDivider />
-                <XDSSection padding={4} variant="transparent">
-                  <XDSHStack gap={3} vAlign="start">
-                    <XDSCenter
-                      width={48}
-                      height={48}
-                      xstyle={styles.iconBox}>
-                      <XDSIcon icon={PencilSquareIcon} />
-                    </XDSCenter>
-                    <XDSVStack gap={0}>
-                      <XDSText type="body" weight="semibold" display="block">
-                        Which details can be edited?
-                      </XDSText>
-                      <XDSText
-                        type="supporting"
-                        color="secondary"
-                        display="block">
-                        Contact info and personal details can be edited. If this
-                        info was used to verify your identity, you&apos;ll need
-                        to get verified again the next time you book—or to
-                        continue hosting.
-                      </XDSText>
-                    </XDSVStack>
-                  </XDSHStack>
-                </XDSSection>
+                <XDSHStack
+                  gap={3}
+                  vAlign="start"
+                  xstyle={styles.rowPadding}>
+                  <XDSCenter
+                    width={48}
+                    height={48}
+                    xstyle={styles.iconBox}>
+                    <XDSIcon icon={PencilSquareIcon} />
+                  </XDSCenter>
+                  <XDSVStack gap={0}>
+                    <XDSText type="body" weight="semibold" display="block">
+                      Which details can be edited?
+                    </XDSText>
+                    <XDSText
+                      type="supporting"
+                      color="secondary"
+                      display="block">
+                      Contact info and personal details can be edited. If this
+                      info was used to verify your identity, you&apos;ll need
+                      to get verified again the next time you book—or to
+                      continue hosting.
+                    </XDSText>
+                  </XDSVStack>
+                </XDSHStack>
                 <XDSDivider />
-                <XDSSection padding={4} variant="transparent">
-                  <XDSHStack gap={3} vAlign="start">
-                    <XDSCenter
-                      width={48}
-                      height={48}
-                      xstyle={styles.iconBox}>
-                      <XDSIcon icon={ShareIcon} />
-                    </XDSCenter>
-                    <XDSVStack gap={0}>
-                      <XDSText type="body" weight="semibold" display="block">
-                        What info is shared with others?
-                      </XDSText>
-                      <XDSText
-                        type="supporting"
-                        color="secondary"
-                        display="block">
-                        We only release contact information after a reservation
-                        is confirmed.
-                      </XDSText>
-                    </XDSVStack>
-                  </XDSHStack>
-                </XDSSection>
+                <XDSHStack gap={3} vAlign="start">
+                  <XDSCenter
+                    width={48}
+                    height={48}
+                    xstyle={styles.iconBox}>
+                    <XDSIcon icon={ShareIcon} />
+                  </XDSCenter>
+                  <XDSVStack gap={0}>
+                    <XDSText type="body" weight="semibold" display="block">
+                      What info is shared with others?
+                    </XDSText>
+                    <XDSText
+                      type="supporting"
+                      color="secondary"
+                      display="block">
+                      We only release contact information after a reservation
+                      is confirmed.
+                    </XDSText>
+                  </XDSVStack>
+                </XDSHStack>
               </XDSVStack>
             </XDSCard>
           </XDSVStack>
@@ -557,7 +565,7 @@ export default function SettingsSecurityTemplate() {
             <XDSVStack gap={8}>
               <XDSVStack gap={0}>
                 <XDSHeading level={3}>Messages</XDSHeading>
-                <XDSSection padding={4} variant="transparent">
+                <XDSVStack xstyle={styles.rowPadding}>
                   <XDSSwitch
                     label="Show people when I've read their messages."
                     value={readReceipts}
@@ -565,23 +573,24 @@ export default function SettingsSecurityTemplate() {
                     labelPosition="start"
                     labelSpacing="spread"
                   />
-                </XDSSection>
-                <XDSSection padding={4} variant="transparent">
-                  <XDSHStack hAlign="between" vAlign="center">
-                    <XDSText type="body" weight="semibold">
-                      Blocked people
-                    </XDSText>
-                    <XDSLink label="View" href="#">
-                      View
-                    </XDSLink>
-                  </XDSHStack>
-                </XDSSection>
+                </XDSVStack>
+                <XDSHStack
+                  hAlign="between"
+                  vAlign="center"
+                  xstyle={styles.rowPadding}>
+                  <XDSText type="body" weight="semibold">
+                    Blocked people
+                  </XDSText>
+                  <XDSLink label="View" href="#">
+                    View
+                  </XDSLink>
+                </XDSHStack>
                 <XDSDivider />
               </XDSVStack>
 
               <XDSVStack gap={0}>
                 <XDSHeading level={3}>Listings</XDSHeading>
-                <XDSSection padding={4} variant="transparent">
+                <XDSVStack xstyle={styles.rowPadding}>
                   <XDSSwitch
                     label="Include my listing(s) in search engines"
                     description="Turning this on means search engines, like Google, will display your listing page(s) in search results."
@@ -590,56 +599,52 @@ export default function SettingsSecurityTemplate() {
                     labelPosition="start"
                     labelSpacing="spread"
                   />
-                </XDSSection>
+                </XDSVStack>
                 <XDSDivider />
               </XDSVStack>
 
-              <XDSVStack gap={0}>
+              <XDSVStack gap={4}>
                 <XDSHeading level={3}>Reviews</XDSHeading>
-                <XDSSection padding={2} variant="transparent">
-                  <XDSText type="supporting" color="secondary">
-                    Choose what&apos;s shared when you write a review.{' '}
-                    <XDSLink label="Learn more" href="#" type="supporting">
-                      Learn more
-                    </XDSLink>
-                  </XDSText>
-                </XDSSection>
-                <XDSSection padding={4} variant="transparent">
-                  <XDSVStack gap={4}>
-                    <XDSSwitch
-                      label="Show my home city and country"
-                      description="Ex: City and country"
-                      value={showCity}
-                      onChange={setShowCity}
-                      labelPosition="start"
-                      labelSpacing="spread"
-                    />
-                    <XDSSwitch
-                      label="Show my trip type"
-                      description="Ex: Stayed with kids or pets"
-                      value={showTripType}
-                      onChange={setShowTripType}
-                      labelPosition="start"
-                      labelSpacing="spread"
-                    />
-                    <XDSSwitch
-                      label="Show my length of stay"
-                      description="Ex: A few nights, about a week, etc."
-                      value={showStayLength}
-                      onChange={setShowStayLength}
-                      labelPosition="start"
-                      labelSpacing="spread"
-                    />
-                    <XDSSwitch
-                      label="Show my booked services"
-                      description="Ex: Gourmet brunch or tasting menu"
-                      value={showServices}
-                      onChange={setShowServices}
-                      labelPosition="start"
-                      labelSpacing="spread"
-                    />
-                  </XDSVStack>
-                </XDSSection>
+                <XDSText type="supporting" color="secondary">
+                  Choose what&apos;s shared when you write a review.{' '}
+                  <XDSLink label="Learn more" href="#" type="supporting">
+                    Learn more
+                  </XDSLink>
+                </XDSText>
+                <XDSVStack gap={4}>
+                  <XDSSwitch
+                    label="Show my home city and country"
+                    description="Ex: City and country"
+                    value={showCity}
+                    onChange={setShowCity}
+                    labelPosition="start"
+                    labelSpacing="spread"
+                  />
+                  <XDSSwitch
+                    label="Show my trip type"
+                    description="Ex: Stayed with kids or pets"
+                    value={showTripType}
+                    onChange={setShowTripType}
+                    labelPosition="start"
+                    labelSpacing="spread"
+                  />
+                  <XDSSwitch
+                    label="Show my length of stay"
+                    description="Ex: A few nights, about a week, etc."
+                    value={showStayLength}
+                    onChange={setShowStayLength}
+                    labelPosition="start"
+                    labelSpacing="spread"
+                  />
+                  <XDSSwitch
+                    label="Show my booked services"
+                    description="Ex: Gourmet brunch or tasting menu"
+                    value={showServices}
+                    onChange={setShowServices}
+                    labelPosition="start"
+                    labelSpacing="spread"
+                  />
+                </XDSVStack>
                 <XDSDivider />
               </XDSVStack>
 

--- a/packages/cli/templates/pages/settings-sidebar/page.tsx
+++ b/packages/cli/templates/pages/settings-sidebar/page.tsx
@@ -1,24 +1,23 @@
 'use client';
 
 import {useState} from 'react';
+import * as stylex from '@stylexjs/stylex';
 import {XDSAppShell} from '@xds/core/AppShell';
-import {
-  XDSSideNav,
-  XDSSideNavItem,
-  XDSSideNavHeading,
-} from '@xds/core/SideNav';
-import {XDSVStack, XDSHStack} from '@xds/core/Layout';
+import {XDSVStack, XDSHStack, XDSStackItem} from '@xds/core/Layout';
+import {XDSList, XDSListItem} from '@xds/core/List';
 import {XDSText, XDSHeading} from '@xds/core/Text';
-import {XDSButton} from '@xds/core/Button';
 import {XDSLink} from '@xds/core/Link';
+import {XDSButton} from '@xds/core/Button';
 import {XDSSelector} from '@xds/core/Selector';
+
 import {XDSCard} from '@xds/core/Card';
+import {XDSSection} from '@xds/core/Section';
 import {XDSSwitch} from '@xds/core/Switch';
 import {XDSDivider} from '@xds/core/Divider';
 import {XDSTabList, XDSTab} from '@xds/core/TabList';
 import {XDSBadge} from '@xds/core/Badge';
 import {XDSIcon} from '@xds/core/Icon';
-import {XDSList, XDSListItem} from '@xds/core/List';
+import {XDSCenter} from '@xds/core/Center';
 import {
   UserIcon,
   LockClosedIcon,
@@ -34,6 +33,14 @@ import {
   ShareIcon,
 } from '@heroicons/react/24/outline';
 
+const styles = stylex.create({
+  iconBox: {
+    borderRadius: 12,
+    backgroundColor: 'var(--xds-color-background-muted, #f5f5f5)',
+    flexShrink: 0,
+  },
+});
+
 const NAV_ITEMS = [
   {label: 'Personal information', icon: UserIcon},
   {label: 'Login & security', icon: LockClosedIcon},
@@ -45,11 +52,17 @@ const NAV_ITEMS = [
   {label: 'Travel for work', icon: BriefcaseIcon},
 ];
 
-const LOGIN_ROWS = [
+interface InfoRow {
+  label: string;
+  value: string;
+  action: string;
+}
+
+const LOGIN_ROWS: InfoRow[] = [
   {label: 'Password', value: 'Not created', action: 'Create'},
 ];
 
-const SOCIAL_ROWS = [
+const SOCIAL_ROWS: InfoRow[] = [
   {label: 'Google', value: 'Connected', action: 'Disconnect'},
 ];
 
@@ -71,6 +84,87 @@ const DEVICE_ROWS: {
     action: 'Log out',
   },
 ];
+
+function InfoRowItem({label, value, action}: InfoRow) {
+  return (
+    <>
+      <XDSHStack hAlign="between" vAlign="start" padding={4}>
+        <XDSVStack gap={0}>
+          <XDSText type="body" weight="semibold" display="block">
+            {label}
+          </XDSText>
+          <XDSText type="supporting" color="secondary" display="block">
+            {value}
+          </XDSText>
+        </XDSVStack>
+        {action && (
+          <XDSLink label={action} href="#">
+            {action}
+          </XDSLink>
+        )}
+      </XDSHStack>
+      <XDSDivider />
+    </>
+  );
+}
+
+interface ExpandableRowProps {
+  label: string;
+  value: string;
+  children: React.ReactNode;
+  isExpanded: boolean;
+  onEdit: () => void;
+  onCancel: () => void;
+  onSave: () => void;
+}
+
+function ExpandableRow({
+  label,
+  value,
+  children,
+  isExpanded,
+  onEdit,
+  onCancel,
+  onSave,
+}: ExpandableRowProps) {
+  return (
+    <>
+      {isExpanded ? (
+        <XDSVStack gap={4} padding={4}>
+          <XDSText type="body" weight="semibold" display="block">
+            {label}
+          </XDSText>
+          {children}
+          <XDSHStack gap={2}>
+            <XDSButton label="Save" variant="primary" onClick={onSave} />
+            <XDSButton label="Cancel" variant="ghost" onClick={onCancel} />
+          </XDSHStack>
+        </XDSVStack>
+      ) : (
+        <XDSHStack hAlign="between" vAlign="start" padding={4}>
+          <XDSVStack gap={0}>
+            <XDSText type="body" weight="semibold" display="block">
+              {label}
+            </XDSText>
+            <XDSText type="supporting" color="secondary" display="block">
+              {value}
+            </XDSText>
+          </XDSVStack>
+          <XDSLink
+            label="Edit"
+            href="#"
+            onClick={(e: React.MouseEvent) => {
+              e.preventDefault();
+              onEdit();
+            }}>
+            Edit
+          </XDSLink>
+        </XDSHStack>
+      )}
+      <XDSDivider />
+    </>
+  );
+}
 
 const LANGUAGES = [
   {label: 'English (Canada)', value: 'en-CA'},
@@ -98,69 +192,9 @@ const TIMEZONES = [
   {label: '(GMT+01:00) London', value: 'GMT+1'},
 ];
 
-interface ExpandableRowProps {
-  label: string;
-  value: string;
-  children: React.ReactNode;
-  isExpanded: boolean;
-  onEdit: () => void;
-  onCancel: () => void;
-  onSave: () => void;
-}
-
-function ExpandableRow({
-  label,
-  value,
-  children,
-  isExpanded,
-  onEdit,
-  onCancel,
-  onSave,
-}: ExpandableRowProps) {
-  return (
-    <>
-      {isExpanded ? (
-        <XDSVStack gap={4}>
-          <XDSText type="body" weight="semibold" display="block">
-            {label}
-          </XDSText>
-          {children}
-          <XDSHStack gap={2}>
-            <XDSButton label="Save" variant="primary" onClick={onSave} />
-            <XDSButton label="Cancel" variant="ghost" onClick={onCancel} />
-          </XDSHStack>
-        </XDSVStack>
-      ) : (
-        <XDSHStack hAlign="between" vAlign="start">
-          <XDSVStack gap={0}>
-            <XDSText type="body" weight="semibold" display="block">
-              {label}
-            </XDSText>
-            <XDSText type="supporting" color="secondary" display="block">
-              {value}
-            </XDSText>
-          </XDSVStack>
-          <XDSLink
-            label="Edit"
-            href="#"
-            onClick={(e: React.MouseEvent) => {
-              e.preventDefault();
-              onEdit();
-            }}>
-            Edit
-          </XDSLink>
-        </XDSHStack>
-      )}
-      <XDSDivider />
-    </>
-  );
-}
-
-export default function SettingsSidebarTemplate() {
+export default function SettingsSecurityTemplate() {
   const [activeNav, setActiveNav] = useState('Personal information');
   const [activeTab, setActiveTab] = useState('login');
-  const [expandedRow, setExpandedRow] = useState<string | null>(null);
-
   const [readReceipts, setReadReceipts] = useState(true);
   const [searchEngines, setSearchEngines] = useState(true);
   const [showCity, setShowCity] = useState(true);
@@ -169,451 +203,505 @@ export default function SettingsSidebarTemplate() {
   const [showServices, setShowServices] = useState(true);
   const [aiFeatures, setAiFeatures] = useState(true);
 
+  const [expandedRow, setExpandedRow] = useState<string | null>(null);
   const [language, setLanguage] = useState('en-CA');
   const [currency, setCurrency] = useState('CAD');
   const [timezone, setTimezone] = useState('ET');
 
   return (
     <XDSAppShell
-      contentPadding={4}
       height="fill"
+      variant="section"
       sideNav={
-        <XDSSideNav
-          header={<XDSSideNavHeading heading="Account settings" />}>
-          {NAV_ITEMS.map(item => (
-            <XDSSideNavItem
-              key={item.label}
-              label={item.label}
-              icon={item.icon}
-              isSelected={activeNav === item.label}
-              onClick={() => setActiveNav(item.label)}
-            />
-          ))}
+        <XDSVStack gap={4}>
+          <XDSSection padding={4} variant="transparent">
+            <XDSHeading level={2}>Account settings</XDSHeading>
+          </XDSSection>
+          <XDSList density="spacious">
+            {NAV_ITEMS.map(item => (
+              <XDSListItem
+                key={item.label}
+                label={item.label}
+                startContent={<XDSIcon icon={item.icon} />}
+                isSelected={activeNav === item.label}
+                onClick={() => setActiveNav(item.label)}
+              />
+            ))}
+          </XDSList>
           <XDSDivider />
-          <XDSSideNavItem
-            label="Professional hosting tools"
-            icon={WrenchScrewdriverIcon}
-            onClick={() => {}}
-          />
-        </XDSSideNav>
-      }>
-      {activeNav === 'Personal information' && (
-        <XDSVStack gap={6}>
-          <XDSHeading level={2}>Personal info</XDSHeading>
-          <XDSList hasDividers density="spacious">
+          <XDSList density="spacious">
             <XDSListItem
-              label="Legal name"
-              description="Alex Johnson"
-              endContent={
-                <XDSLink label="Edit" href="#">
-                  Edit
-                </XDSLink>
-              }
-            />
-            <XDSListItem
-              label="Preferred first name"
-              description="Not provided"
-              endContent={
-                <XDSLink label="Add" href="#">
-                  Add
-                </XDSLink>
-              }
-            />
-            <XDSListItem
-              label="Email address"
-              description="a***n@example.com"
-              endContent={
-                <XDSLink label="Edit" href="#">
-                  Edit
-                </XDSLink>
-              }
-            />
-            <XDSListItem
-              label="Phone number"
-              description="+1 ***-***-0123"
-              endContent={
-                <XDSLink label="Edit" href="#">
-                  Edit
-                </XDSLink>
-              }
-            />
-            <XDSListItem
-              label="Identity verification"
-              description="Verified"
-            />
-            <XDSListItem
-              label="Residential address"
-              description="Not provided"
-              endContent={
-                <XDSLink label="Add" href="#">
-                  Add
-                </XDSLink>
-              }
-            />
-            <XDSListItem
-              label="Mailing address"
-              description="Not provided"
-              endContent={
-                <XDSLink label="Add" href="#">
-                  Add
-                </XDSLink>
-              }
-            />
-            <XDSListItem
-              label="Emergency contact"
-              description="Provided"
-              endContent={
-                <XDSLink label="Edit" href="#">
-                  Edit
-                </XDSLink>
-              }
+              label="Professional hosting tools"
+              startContent={<XDSIcon icon={WrenchScrewdriverIcon} />}
+              onClick={() => {}}
             />
           </XDSList>
-
-          <XDSCard padding={4}>
-            <XDSList hasDividers density="spacious">
-              <XDSListItem
-                label="Why isn't my info shown here?"
-                description="We're hiding some account details to protect your identity."
-                startContent={<XDSIcon icon={LockClosedIcon} size="lg" />}
-              />
-              <XDSListItem
-                label="Which details can be edited?"
-                description="Contact info and personal details can be edited. If this info was used to verify your identity, you'll need to get verified again the next time you book—or to continue hosting."
-                startContent={<XDSIcon icon={PencilSquareIcon} size="lg" />}
-              />
-              <XDSListItem
-                label="What info is shared with others?"
-                description="We only release contact information after a reservation is confirmed."
-                startContent={<XDSIcon icon={ShareIcon} size="lg" />}
-              />
-            </XDSList>
-          </XDSCard>
         </XDSVStack>
-      )}
+      }>
+      <XDSSection padding={6} maxWidth={700} variant="transparent">
+        {activeNav === 'Login & security' && (
+          <XDSVStack gap={6}>
+            <XDSHeading level={2}>Login &amp; security</XDSHeading>
 
-      {activeNav === 'Login & security' && (
-        <XDSVStack gap={6}>
-          <XDSHeading level={2}>Login &amp; security</XDSHeading>
+            <XDSTabList
+              value={activeTab}
+              onChange={setActiveTab}
+              hasDivider>
+              <XDSTab value="login" label="Login" />
+              <XDSTab value="shared" label="Shared access" />
+            </XDSTabList>
 
-          <XDSTabList
-            value={activeTab}
-            onChange={setActiveTab}
-            hasDivider>
-            <XDSTab value="login" label="Login" />
-            <XDSTab value="shared" label="Shared access" />
-          </XDSTabList>
-
-          {activeTab === 'login' && (
-            <XDSVStack gap={8}>
-              <XDSVStack gap={2}>
-                <XDSHeading level={3}>Login</XDSHeading>
-                <XDSList hasDividers density="spacious">
+            {activeTab === 'login' && (
+              <XDSVStack gap={8}>
+                <XDSVStack gap={0}>
+                  <XDSHeading level={3}>Login</XDSHeading>
+                  <XDSDivider />
                   {LOGIN_ROWS.map(row => (
-                    <XDSListItem
-                      key={row.label}
-                      label={row.label}
-                      description={row.value}
-                      endContent={
-                        <XDSLink label={row.action} href="#">
-                          {row.action}
-                        </XDSLink>
-                      }
-                    />
+                    <InfoRowItem key={row.label} {...row} />
                   ))}
-                </XDSList>
-              </XDSVStack>
+                </XDSVStack>
 
-              <XDSVStack gap={2}>
-                <XDSHeading level={3}>Social accounts</XDSHeading>
-                <XDSList hasDividers density="spacious">
+                <XDSVStack gap={0}>
+                  <XDSHeading level={3}>Social accounts</XDSHeading>
+                  <XDSDivider />
                   {SOCIAL_ROWS.map(row => (
-                    <XDSListItem
-                      key={row.label}
-                      label={row.label}
-                      description={row.value}
-                      endContent={
-                        <XDSLink label={row.action} href="#">
-                          {row.action}
-                        </XDSLink>
-                      }
-                    />
+                    <InfoRowItem key={row.label} {...row} />
                   ))}
-                </XDSList>
-              </XDSVStack>
+                </XDSVStack>
 
-              <XDSVStack gap={2}>
-                <XDSHeading level={3}>Device history</XDSHeading>
-                <XDSList hasDividers density="spacious">
+                <XDSVStack gap={0}>
+                  <XDSHeading level={3}>Device history</XDSHeading>
+                  <XDSDivider />
                   {DEVICE_ROWS.map((device, i) => (
-                    <XDSListItem
-                      key={i}
-                      label={device.label}
-                      description={device.location}
-                      startContent={
-                        <XDSIcon icon={ComputerDesktopIcon} size="lg" />
-                      }
-                      endContent={
-                        device.badge ? (
-                          <XDSBadge label={device.badge} />
-                        ) : device.action ? (
-                          <XDSLink label={device.action} href="#">
-                            {device.action}
-                          </XDSLink>
-                        ) : undefined
-                      }
-                    />
+                    <XDSHStack key={i} gap={3} vAlign="start" padding={4}>
+                      <XDSIcon icon={ComputerDesktopIcon} />
+                      <XDSStackItem size="fill">
+                        <XDSVStack gap={0}>
+                          <XDSHStack gap={2} vAlign="center">
+                            <XDSText type="body" weight="semibold">
+                              {device.label}
+                            </XDSText>
+                            {device.badge && (
+                              <XDSBadge label={device.badge} />
+                            )}
+                          </XDSHStack>
+                          <XDSText
+                            type="supporting"
+                            color="secondary"
+                            display="block">
+                            {device.location}
+                          </XDSText>
+                        </XDSVStack>
+                      </XDSStackItem>
+                      {device.action && (
+                        <XDSLink label={device.action} href="#">
+                          {device.action}
+                        </XDSLink>
+                      )}
+                    </XDSHStack>
                   ))}
-                </XDSList>
-              </XDSVStack>
+                  <XDSDivider />
+                </XDSVStack>
 
-              <XDSVStack gap={2}>
-                <XDSHeading level={3}>Account</XDSHeading>
-                <XDSList hasDividers density="spacious">
-                  <XDSListItem
-                    label="Deactivate your account"
-                    description="This action cannot be undone"
-                    endContent={
-                      <XDSLink label="Deactivate" href="#">
-                        Deactivate
-                      </XDSLink>
-                    }
-                  />
-                </XDSList>
+                <XDSVStack gap={0}>
+                  <XDSHeading level={3}>Account</XDSHeading>
+                  <XDSDivider />
+                  <XDSHStack hAlign="between" vAlign="start" padding={4}>
+                    <XDSVStack gap={0}>
+                      <XDSText type="body" weight="semibold" display="block">
+                        Deactivate your account
+                      </XDSText>
+                      <XDSText
+                        type="supporting"
+                        color="secondary"
+                        display="block">
+                        This action cannot be undone
+                      </XDSText>
+                    </XDSVStack>
+                    <XDSLink label="Deactivate" href="#">
+                      Deactivate
+                    </XDSLink>
+                  </XDSHStack>
+                  <XDSDivider />
+                </XDSVStack>
               </XDSVStack>
+            )}
+
+            {activeTab === 'shared' && (
+              <XDSVStack gap={8}>
+                <XDSVStack gap={2}>
+                  <XDSHeading level={3}>Shared access</XDSHeading>
+                  <XDSDivider />
+                  <XDSText type="body" color="secondary">
+                    Review each request carefully before approving access.
+                    We&apos;ll email your employee or co-worker a 4-digit code
+                    that lets them log into your account with their trusted
+                    device.
+                  </XDSText>
+                </XDSVStack>
+
+                <XDSCard variant="muted" padding={4}>
+                  <XDSHStack gap={4} vAlign="start">
+                    <XDSCenter
+                      width={48}
+                      height={48}
+                      xstyle={styles.iconBox}>
+                      <XDSIcon icon={LockClosedIcon} />
+                    </XDSCenter>
+                    <XDSVStack gap={1}>
+                      <XDSText type="body" weight="bold">
+                        Adding devices from people you trust
+                      </XDSText>
+                      <XDSText type="body" color="secondary">
+                        When you approve a request, you grant someone full
+                        access to your account. They&apos;ll be able to change
+                        reservations and send messages on your behalf.
+                      </XDSText>
+                    </XDSVStack>
+                  </XDSHStack>
+                </XDSCard>
+              </XDSVStack>
+            )}
+          </XDSVStack>
+        )}
+
+        {activeNav === 'Languages & currency' && (
+          <XDSVStack gap={6}>
+            <XDSHeading level={2}>Languages &amp; currency</XDSHeading>
+            <XDSVStack gap={0}>
+              <ExpandableRow
+                label="Preferred language"
+                value={
+                  LANGUAGES.find(l => l.value === language)?.label ?? language
+                }
+                isExpanded={expandedRow === 'language'}
+                onEdit={() => setExpandedRow('language')}
+                onCancel={() => setExpandedRow(null)}
+                onSave={() => setExpandedRow(null)}>
+                <XDSSelector
+                  label="Language"
+                  isLabelHidden
+                  size="lg"
+                  value={language}
+                  onChange={setLanguage}
+                  options={LANGUAGES}
+                />
+              </ExpandableRow>
+              <ExpandableRow
+                label="Preferred currency"
+                value={
+                  CURRENCIES.find(c => c.value === currency)?.label ?? currency
+                }
+                isExpanded={expandedRow === 'currency'}
+                onEdit={() => setExpandedRow('currency')}
+                onCancel={() => setExpandedRow(null)}
+                onSave={() => setExpandedRow(null)}>
+                <XDSSelector
+                  label="Currency"
+                  isLabelHidden
+                  size="lg"
+                  value={currency}
+                  onChange={setCurrency}
+                  options={CURRENCIES}
+                />
+              </ExpandableRow>
+              <ExpandableRow
+                label="Time zone"
+                value={
+                  TIMEZONES.find(t => t.value === timezone)?.label ?? timezone
+                }
+                isExpanded={expandedRow === 'timezone'}
+                onEdit={() => setExpandedRow('timezone')}
+                onCancel={() => setExpandedRow(null)}
+                onSave={() => setExpandedRow(null)}>
+                <XDSSelector
+                  label="Time zone"
+                  isLabelHidden
+                  size="lg"
+                  value={timezone}
+                  onChange={setTimezone}
+                  options={TIMEZONES}
+                />
+              </ExpandableRow>
             </XDSVStack>
-          )}
+          </XDSVStack>
+        )}
 
-          {activeTab === 'shared' && (
-            <XDSVStack gap={8}>
-              <XDSVStack gap={2}>
-                <XDSHeading level={3}>Shared access</XDSHeading>
-                <XDSDivider />
-                <XDSText type="body" color="secondary">
-                  Review each request carefully before approving access.
-                  We&apos;ll email your employee or co-worker a 4-digit code
-                  that lets them log into your account with their trusted
-                  device.
-                </XDSText>
-              </XDSVStack>
-
-              <XDSCard variant="muted" padding={4}>
-                <XDSHStack gap={4} vAlign="start">
-                  <XDSIcon icon={LockClosedIcon} size="lg" />
-                  <XDSVStack gap={1}>
-                    <XDSText type="body" weight="bold">
-                      Adding devices from people you trust
-                    </XDSText>
-                    <XDSText type="body" color="secondary">
-                      When you approve a request, you grant someone full access
-                      to your account. They&apos;ll be able to change
-                      reservations and send messages on your behalf.
-                    </XDSText>
-                  </XDSVStack>
-                </XDSHStack>
-              </XDSCard>
-            </XDSVStack>
-          )}
-        </XDSVStack>
-      )}
-
-      {activeNav === 'Privacy' && (
-        <XDSVStack gap={6}>
-          <XDSHeading level={2}>Privacy</XDSHeading>
-
-          <XDSVStack gap={8}>
-            <XDSVStack gap={4}>
-              <XDSHeading level={3}>Messages</XDSHeading>
-              <XDSSwitch
-                label="Show people when I've read their messages."
-                value={readReceipts}
-                onChange={setReadReceipts}
-                labelPosition="start"
-                labelSpacing="spread"
+        {activeNav === 'Personal information' && (
+          <XDSVStack gap={6}>
+            <XDSHeading level={2}>Personal info</XDSHeading>
+            <XDSVStack gap={0}>
+              <InfoRowItem
+                label="Legal name"
+                value="Alex Johnson"
+                action="Edit"
               />
-              <XDSList hasDividers density="spacious">
-                <XDSListItem
-                  label="Blocked people"
-                  endContent={
+              <InfoRowItem
+                label="Preferred first name"
+                value="Not provided"
+                action="Add"
+              />
+              <InfoRowItem
+                label="Email address"
+                value="a***n@example.com"
+                action="Edit"
+              />
+              <InfoRowItem
+                label="Phone number"
+                value="+1 ***-***-0123"
+                action="Edit"
+              />
+              <InfoRowItem
+                label="Identity verification"
+                value="Verified"
+                action=""
+              />
+              <InfoRowItem
+                label="Residential address"
+                value="Not provided"
+                action="Add"
+              />
+              <InfoRowItem
+                label="Mailing address"
+                value="Not provided"
+                action="Add"
+              />
+              <InfoRowItem
+                label="Emergency contact"
+                value="Provided"
+                action="Edit"
+              />
+            </XDSVStack>
+
+            <XDSCard padding={4}>
+              <XDSVStack gap={0}>
+                <XDSSection padding={4} variant="transparent">
+                  <XDSHStack gap={3} vAlign="start">
+                    <XDSCenter
+                      width={48}
+                      height={48}
+                      xstyle={styles.iconBox}>
+                      <XDSIcon icon={LockClosedIcon} />
+                    </XDSCenter>
+                    <XDSVStack gap={0}>
+                      <XDSText type="body" weight="semibold" display="block">
+                        Why isn&apos;t my info shown here?
+                      </XDSText>
+                      <XDSText
+                        type="supporting"
+                        color="secondary"
+                        display="block">
+                        We&apos;re hiding some account details to protect your
+                        identity.
+                      </XDSText>
+                    </XDSVStack>
+                  </XDSHStack>
+                </XDSSection>
+                <XDSDivider />
+                <XDSSection padding={4} variant="transparent">
+                  <XDSHStack gap={3} vAlign="start">
+                    <XDSCenter
+                      width={48}
+                      height={48}
+                      xstyle={styles.iconBox}>
+                      <XDSIcon icon={PencilSquareIcon} />
+                    </XDSCenter>
+                    <XDSVStack gap={0}>
+                      <XDSText type="body" weight="semibold" display="block">
+                        Which details can be edited?
+                      </XDSText>
+                      <XDSText
+                        type="supporting"
+                        color="secondary"
+                        display="block">
+                        Contact info and personal details can be edited. If this
+                        info was used to verify your identity, you&apos;ll need
+                        to get verified again the next time you book—or to
+                        continue hosting.
+                      </XDSText>
+                    </XDSVStack>
+                  </XDSHStack>
+                </XDSSection>
+                <XDSDivider />
+                <XDSSection padding={4} variant="transparent">
+                  <XDSHStack gap={3} vAlign="start">
+                    <XDSCenter
+                      width={48}
+                      height={48}
+                      xstyle={styles.iconBox}>
+                      <XDSIcon icon={ShareIcon} />
+                    </XDSCenter>
+                    <XDSVStack gap={0}>
+                      <XDSText type="body" weight="semibold" display="block">
+                        What info is shared with others?
+                      </XDSText>
+                      <XDSText
+                        type="supporting"
+                        color="secondary"
+                        display="block">
+                        We only release contact information after a reservation
+                        is confirmed.
+                      </XDSText>
+                    </XDSVStack>
+                  </XDSHStack>
+                </XDSSection>
+              </XDSVStack>
+            </XDSCard>
+          </XDSVStack>
+        )}
+
+        {activeNav === 'Privacy' && (
+          <XDSVStack gap={6}>
+            <XDSHeading level={2}>Privacy</XDSHeading>
+
+            <XDSVStack gap={8}>
+              <XDSVStack gap={0}>
+                <XDSHeading level={3}>Messages</XDSHeading>
+                <XDSSection padding={4} variant="transparent">
+                  <XDSSwitch
+                    label="Show people when I've read their messages."
+                    value={readReceipts}
+                    onChange={setReadReceipts}
+                    labelPosition="start"
+                    labelSpacing="spread"
+                  />
+                </XDSSection>
+                <XDSSection padding={4} variant="transparent">
+                  <XDSHStack hAlign="between" vAlign="center">
+                    <XDSText type="body" weight="semibold">
+                      Blocked people
+                    </XDSText>
                     <XDSLink label="View" href="#">
                       View
                     </XDSLink>
-                  }
-                />
-              </XDSList>
-            </XDSVStack>
-
-            <XDSVStack gap={4}>
-              <XDSHeading level={3}>Listings</XDSHeading>
-              <XDSSwitch
-                label="Include my listing(s) in search engines"
-                description="Turning this on means search engines, like Google, will display your listing page(s) in search results."
-                value={searchEngines}
-                onChange={setSearchEngines}
-                labelPosition="start"
-                labelSpacing="spread"
-              />
-              <XDSDivider />
-            </XDSVStack>
-
-            <XDSVStack gap={4}>
-              <XDSHeading level={3}>Reviews</XDSHeading>
-              <XDSText type="supporting" color="secondary">
-                Choose what&apos;s shared when you write a review.{' '}
-                <XDSLink label="Learn more" href="#" type="supporting">
-                  Learn more
-                </XDSLink>
-              </XDSText>
-              <XDSVStack gap={4}>
-                <XDSSwitch
-                  label="Show my home city and country"
-                  description="Ex: City and country"
-                  value={showCity}
-                  onChange={setShowCity}
-                  labelPosition="start"
-                  labelSpacing="spread"
-                />
-                <XDSSwitch
-                  label="Show my trip type"
-                  description="Ex: Stayed with kids or pets"
-                  value={showTripType}
-                  onChange={setShowTripType}
-                  labelPosition="start"
-                  labelSpacing="spread"
-                />
-                <XDSSwitch
-                  label="Show my length of stay"
-                  description="Ex: A few nights, about a week, etc."
-                  value={showStayLength}
-                  onChange={setShowStayLength}
-                  labelPosition="start"
-                  labelSpacing="spread"
-                />
-                <XDSSwitch
-                  label="Show my booked services"
-                  description="Ex: Gourmet brunch or tasting menu"
-                  value={showServices}
-                  onChange={setShowServices}
-                  labelPosition="start"
-                  labelSpacing="spread"
-                />
+                  </XDSHStack>
+                </XDSSection>
+                <XDSDivider />
               </XDSVStack>
-              <XDSDivider />
-            </XDSVStack>
 
-            <XDSVStack gap={4}>
-              <XDSHeading level={3}>Data privacy</XDSHeading>
-              <XDSCard padding={4}>
-                <XDSHStack hAlign="between" vAlign="center">
-                  <XDSText type="body">Request my personal data</XDSText>
-                  <XDSLink label="Request" href="#">
-                    Request
-                  </XDSLink>
-                </XDSHStack>
-              </XDSCard>
-              <XDSSwitch
-                label="Help improve AI-powered features"
-                description="When this is on, we use your data to develop and improve AI models."
-                value={aiFeatures}
-                onChange={setAiFeatures}
-                labelPosition="start"
-                labelSpacing="spread"
-              />
-              <XDSCard padding={4}>
-                <XDSHStack hAlign="between" vAlign="center">
-                  <XDSText type="body">Delete my account</XDSText>
-                  <XDSLink label="Delete" href="#">
-                    Delete
-                  </XDSLink>
-                </XDSHStack>
-              </XDSCard>
-              <XDSCard variant="muted" padding={4}>
-                <XDSHStack gap={4} vAlign="start">
-                  <XDSIcon icon={ShieldCheckIcon} size="lg" />
-                  <XDSVStack gap={1}>
-                    <XDSText type="body" weight="bold">
-                      Committed to privacy
-                    </XDSText>
-                    <XDSText type="supporting" color="secondary">
-                      We&apos;re committed to keeping your data protected. See
-                      details in our{' '}
-                      <XDSLink
-                        label="Privacy Policy"
-                        href="#"
-                        type="supporting">
-                        Privacy Policy
-                      </XDSLink>
-                      .
-                    </XDSText>
+              <XDSVStack gap={0}>
+                <XDSHeading level={3}>Listings</XDSHeading>
+                <XDSSection padding={4} variant="transparent">
+                  <XDSSwitch
+                    label="Include my listing(s) in search engines"
+                    description="Turning this on means search engines, like Google, will display your listing page(s) in search results."
+                    value={searchEngines}
+                    onChange={setSearchEngines}
+                    labelPosition="start"
+                    labelSpacing="spread"
+                  />
+                </XDSSection>
+                <XDSDivider />
+              </XDSVStack>
+
+              <XDSVStack gap={0}>
+                <XDSHeading level={3}>Reviews</XDSHeading>
+                <XDSSection padding={2} variant="transparent">
+                  <XDSText type="supporting" color="secondary">
+                    Choose what&apos;s shared when you write a review.{' '}
+                    <XDSLink label="Learn more" href="#" type="supporting">
+                      Learn more
+                    </XDSLink>
+                  </XDSText>
+                </XDSSection>
+                <XDSSection padding={4} variant="transparent">
+                  <XDSVStack gap={4}>
+                    <XDSSwitch
+                      label="Show my home city and country"
+                      description="Ex: City and country"
+                      value={showCity}
+                      onChange={setShowCity}
+                      labelPosition="start"
+                      labelSpacing="spread"
+                    />
+                    <XDSSwitch
+                      label="Show my trip type"
+                      description="Ex: Stayed with kids or pets"
+                      value={showTripType}
+                      onChange={setShowTripType}
+                      labelPosition="start"
+                      labelSpacing="spread"
+                    />
+                    <XDSSwitch
+                      label="Show my length of stay"
+                      description="Ex: A few nights, about a week, etc."
+                      value={showStayLength}
+                      onChange={setShowStayLength}
+                      labelPosition="start"
+                      labelSpacing="spread"
+                    />
+                    <XDSSwitch
+                      label="Show my booked services"
+                      description="Ex: Gourmet brunch or tasting menu"
+                      value={showServices}
+                      onChange={setShowServices}
+                      labelPosition="start"
+                      labelSpacing="spread"
+                    />
                   </XDSVStack>
-                </XDSHStack>
-              </XDSCard>
+                </XDSSection>
+                <XDSDivider />
+              </XDSVStack>
+
+              <XDSVStack gap={4}>
+                <XDSHeading level={3}>Data privacy</XDSHeading>
+                <XDSCard padding={4}>
+                  <XDSHStack hAlign="between" vAlign="center">
+                    <XDSText type="body">Request my personal data</XDSText>
+                    <XDSLink label="Request" href="#">
+                      Request
+                    </XDSLink>
+                  </XDSHStack>
+                </XDSCard>
+                <XDSSwitch
+                  label="Help improve AI-powered features"
+                  description="When this is on, we use your data to develop and improve AI models."
+                  value={aiFeatures}
+                  onChange={setAiFeatures}
+                  labelPosition="start"
+                  labelSpacing="spread"
+                />
+                <XDSCard padding={4}>
+                  <XDSHStack hAlign="between" vAlign="center">
+                    <XDSText type="body">Delete my account</XDSText>
+                    <XDSLink label="Delete" href="#">
+                      Delete
+                    </XDSLink>
+                  </XDSHStack>
+                </XDSCard>
+                <XDSCard>
+                  <XDSSection variant="wash">
+                    <XDSHStack gap={4} vAlign="start">
+                      <XDSCenter
+                        width={48}
+                        height={48}
+                        xstyle={styles.iconBox}>
+                        <XDSIcon icon={ShieldCheckIcon} />
+                      </XDSCenter>
+                      <XDSVStack gap={1}>
+                        <XDSText type="body" weight="bold">
+                          Committed to privacy
+                        </XDSText>
+                        <XDSText type="supporting" color="secondary">
+                          We&apos;re committed to keeping your data protected.
+                          See details in our{' '}
+                          <XDSLink
+                            label="Privacy Policy"
+                            href="#"
+                            type="supporting">
+                            Privacy Policy
+                          </XDSLink>
+                          .
+                        </XDSText>
+                      </XDSVStack>
+                    </XDSHStack>
+                  </XDSSection>
+                </XDSCard>
+              </XDSVStack>
             </XDSVStack>
           </XDSVStack>
-        </XDSVStack>
-      )}
-
-      {activeNav === 'Languages & currency' && (
-        <XDSVStack gap={6}>
-          <XDSHeading level={2}>Languages &amp; currency</XDSHeading>
-          <XDSVStack gap={0}>
-            <ExpandableRow
-              label="Preferred language"
-              value={
-                LANGUAGES.find(l => l.value === language)?.label ?? language
-              }
-              isExpanded={expandedRow === 'language'}
-              onEdit={() => setExpandedRow('language')}
-              onCancel={() => setExpandedRow(null)}
-              onSave={() => setExpandedRow(null)}>
-              <XDSSelector
-                label="Language"
-                isLabelHidden
-                size="lg"
-                value={language}
-                onChange={setLanguage}
-                options={LANGUAGES}
-              />
-            </ExpandableRow>
-            <ExpandableRow
-              label="Preferred currency"
-              value={
-                CURRENCIES.find(c => c.value === currency)?.label ?? currency
-              }
-              isExpanded={expandedRow === 'currency'}
-              onEdit={() => setExpandedRow('currency')}
-              onCancel={() => setExpandedRow(null)}
-              onSave={() => setExpandedRow(null)}>
-              <XDSSelector
-                label="Currency"
-                isLabelHidden
-                size="lg"
-                value={currency}
-                onChange={setCurrency}
-                options={CURRENCIES}
-              />
-            </ExpandableRow>
-            <ExpandableRow
-              label="Time zone"
-              value={
-                TIMEZONES.find(t => t.value === timezone)?.label ?? timezone
-              }
-              isExpanded={expandedRow === 'timezone'}
-              onEdit={() => setExpandedRow('timezone')}
-              onCancel={() => setExpandedRow(null)}
-              onSave={() => setExpandedRow(null)}>
-              <XDSSelector
-                label="Time zone"
-                isLabelHidden
-                size="lg"
-                value={timezone}
-                onChange={setTimezone}
-                options={TIMEZONES}
-              />
-            </ExpandableRow>
-          </XDSVStack>
-        </XDSVStack>
-      )}
+        )}
+      </XDSSection>
     </XDSAppShell>
   );
 }

--- a/packages/cli/templates/pages/settings-sidebar/page.tsx
+++ b/packages/cli/templates/pages/settings-sidebar/page.tsx
@@ -1,21 +1,24 @@
 'use client';
 
 import {useState} from 'react';
-import * as stylex from '@stylexjs/stylex';
+import {XDSAppShell} from '@xds/core/AppShell';
+import {
+  XDSSideNav,
+  XDSSideNavItem,
+  XDSSideNavHeading,
+} from '@xds/core/SideNav';
 import {XDSVStack, XDSHStack} from '@xds/core/Layout';
-import {XDSList, XDSListItem} from '@xds/core/List';
 import {XDSText, XDSHeading} from '@xds/core/Text';
-import {XDSLink} from '@xds/core/Link';
 import {XDSButton} from '@xds/core/Button';
+import {XDSLink} from '@xds/core/Link';
 import {XDSSelector} from '@xds/core/Selector';
-import {XDSTextInput} from '@xds/core/TextInput';
 import {XDSCard} from '@xds/core/Card';
-import {XDSSection} from '@xds/core/Section';
 import {XDSSwitch} from '@xds/core/Switch';
 import {XDSDivider} from '@xds/core/Divider';
 import {XDSTabList, XDSTab} from '@xds/core/TabList';
 import {XDSBadge} from '@xds/core/Badge';
-import {colorVars} from '@xds/core/theme/tokens.stylex';
+import {XDSIcon} from '@xds/core/Icon';
+import {XDSList, XDSListItem} from '@xds/core/List';
 import {
   UserIcon,
   LockClosedIcon,
@@ -31,19 +34,6 @@ import {
   ShareIcon,
 } from '@heroicons/react/24/outline';
 
-const styles = stylex.create({
-  pageBg: {
-    backgroundColor: colorVars['--color-background-surface'],
-  },
-  flatCard: {
-    backgroundColor: colorVars['--color-background-body'],
-    borderWidth: 0,
-  },
-  noBorder: {
-    borderWidth: 0,
-  },
-});
-
 const NAV_ITEMS = [
   {label: 'Personal information', icon: UserIcon},
   {label: 'Login & security', icon: LockClosedIcon},
@@ -55,18 +45,11 @@ const NAV_ITEMS = [
   {label: 'Travel for work', icon: BriefcaseIcon},
 ];
 
-interface InfoRow {
-  label: string;
-  value: string;
-  action: string;
-  icon?: React.ComponentType<React.SVGProps<SVGSVGElement>>;
-}
-
-const LOGIN_ROWS: InfoRow[] = [
+const LOGIN_ROWS = [
   {label: 'Password', value: 'Not created', action: 'Create'},
 ];
 
-const SOCIAL_ROWS: InfoRow[] = [
+const SOCIAL_ROWS = [
   {label: 'Google', value: 'Connected', action: 'Disconnect'},
 ];
 
@@ -88,105 +71,6 @@ const DEVICE_ROWS: {
     action: 'Log out',
   },
 ];
-
-function InfoRowItem({label, value, action}: InfoRow) {
-  return (
-    <>
-      <div
-        style={{
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'flex-start',
-          padding: '16px 0',
-        }}>
-        <div>
-          <XDSText type="body" weight="semibold" display="block">
-            {label}
-          </XDSText>
-          <XDSText type="supporting" color="secondary" display="block">
-            {value}
-          </XDSText>
-        </div>
-        {action && (
-          <XDSLink label={action} href="#">
-            {action}
-          </XDSLink>
-        )}
-      </div>
-      <XDSDivider />
-    </>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Expandable settings row (Airbnb-style inline edit)
-// ---------------------------------------------------------------------------
-
-interface ExpandableRowProps {
-  label: string;
-  value: string;
-  children: React.ReactNode;
-  isExpanded: boolean;
-  onEdit: () => void;
-  onCancel: () => void;
-  onSave: () => void;
-}
-
-function ExpandableRow({
-  label,
-  value,
-  children,
-  isExpanded,
-  onEdit,
-  onCancel,
-  onSave,
-}: ExpandableRowProps) {
-  return (
-    <>
-      {isExpanded ? (
-        <div style={{padding: '16px 0'}}>
-          <div style={{marginBottom: 16}}>
-            <XDSText type="body" weight="semibold" display="block">
-              {label}
-            </XDSText>
-          </div>
-          <div style={{marginBottom: 16}}>{children}</div>
-          <XDSHStack gap={2}>
-            <XDSButton label="Save" variant="primary" onClick={onSave} />
-            <XDSButton label="Cancel" variant="ghost" onClick={onCancel} />
-          </XDSHStack>
-        </div>
-      ) : (
-        <div
-          style={{
-            display: 'flex',
-            justifyContent: 'space-between',
-            alignItems: 'flex-start',
-            padding: '16px 0',
-          }}>
-          <div>
-            <XDSText type="body" weight="semibold" display="block">
-              {label}
-            </XDSText>
-            <XDSText type="supporting" color="secondary" display="block">
-              {value}
-            </XDSText>
-          </div>
-          <XDSLink
-            label="Edit"
-            href="#"
-            onClick={(e: React.MouseEvent) => {
-              e.preventDefault();
-              onEdit();
-            }}>
-            Edit
-          </XDSLink>
-        </div>
-      )}
-      <XDSDivider />
-    </>
-  );
-}
 
 const LANGUAGES = [
   {label: 'English (Canada)', value: 'en-CA'},
@@ -214,9 +98,69 @@ const TIMEZONES = [
   {label: '(GMT+01:00) London', value: 'GMT+1'},
 ];
 
-export default function SettingsSecurityTemplate() {
+interface ExpandableRowProps {
+  label: string;
+  value: string;
+  children: React.ReactNode;
+  isExpanded: boolean;
+  onEdit: () => void;
+  onCancel: () => void;
+  onSave: () => void;
+}
+
+function ExpandableRow({
+  label,
+  value,
+  children,
+  isExpanded,
+  onEdit,
+  onCancel,
+  onSave,
+}: ExpandableRowProps) {
+  return (
+    <>
+      {isExpanded ? (
+        <XDSVStack gap={4}>
+          <XDSText type="body" weight="semibold" display="block">
+            {label}
+          </XDSText>
+          {children}
+          <XDSHStack gap={2}>
+            <XDSButton label="Save" variant="primary" onClick={onSave} />
+            <XDSButton label="Cancel" variant="ghost" onClick={onCancel} />
+          </XDSHStack>
+        </XDSVStack>
+      ) : (
+        <XDSHStack hAlign="between" vAlign="start">
+          <XDSVStack gap={0}>
+            <XDSText type="body" weight="semibold" display="block">
+              {label}
+            </XDSText>
+            <XDSText type="supporting" color="secondary" display="block">
+              {value}
+            </XDSText>
+          </XDSVStack>
+          <XDSLink
+            label="Edit"
+            href="#"
+            onClick={(e: React.MouseEvent) => {
+              e.preventDefault();
+              onEdit();
+            }}>
+            Edit
+          </XDSLink>
+        </XDSHStack>
+      )}
+      <XDSDivider />
+    </>
+  );
+}
+
+export default function SettingsSidebarTemplate() {
   const [activeNav, setActiveNav] = useState('Personal information');
   const [activeTab, setActiveTab] = useState('login');
+  const [expandedRow, setExpandedRow] = useState<string | null>(null);
+
   const [readReceipts, setReadReceipts] = useState(true);
   const [searchEngines, setSearchEngines] = useState(true);
   const [showCity, setShowCity] = useState(true);
@@ -225,656 +169,451 @@ export default function SettingsSecurityTemplate() {
   const [showServices, setShowServices] = useState(true);
   const [aiFeatures, setAiFeatures] = useState(true);
 
-  // Languages & currency state
-  const [expandedRow, setExpandedRow] = useState<string | null>(null);
   const [language, setLanguage] = useState('en-CA');
   const [currency, setCurrency] = useState('CAD');
   const [timezone, setTimezone] = useState('ET');
-  const [firstName, setFirstName] = useState('Alex');
-  const [lastName, setLastName] = useState('Johnson');
-  const [email, setEmail] = useState('alex.johnson@email.com');
-  const [phone, setPhone] = useState('+1 (416) 555-0123');
 
   return (
-    <div
-      {...stylex.props(styles.pageBg)}
-      style={{
-        position: 'fixed' as const,
-        inset: 0,
-        display: 'flex',
-        flexDirection: 'row',
-        overflow: 'hidden',
-      }}>
-      {/* Sidebar */}
-      <nav
-        style={{
-          width: 280,
-          paddingTop: 16,
-          paddingLeft: 12,
-          paddingRight: 12,
-          paddingBottom: 16,
-          borderRight: '1px solid var(--xds-color-border-primary, #e5e5e5)',
-          flexShrink: 0,
-          height: '100%',
-          overflowY: 'auto' as const,
-        }}>
-        <XDSVStack gap={4}>
-          <div style={{paddingLeft: 16, paddingRight: 16}}>
-            <XDSHeading level={2}>Account settings</XDSHeading>
-          </div>
-          <XDSList density="spacious">
-            {NAV_ITEMS.map(item => (
-              <XDSListItem
-                key={item.label}
-                label={item.label}
-                startContent={<item.icon style={{width: 20, height: 20}} />}
-                isSelected={activeNav === item.label}
-                onClick={() => setActiveNav(item.label)}
-              />
-            ))}
-          </XDSList>
+    <XDSAppShell
+      contentPadding={4}
+      height="fill"
+      sideNav={
+        <XDSSideNav
+          header={<XDSSideNavHeading heading="Account settings" />}>
+          {NAV_ITEMS.map(item => (
+            <XDSSideNavItem
+              key={item.label}
+              label={item.label}
+              icon={item.icon}
+              isSelected={activeNav === item.label}
+              onClick={() => setActiveNav(item.label)}
+            />
+          ))}
           <XDSDivider />
-          <XDSList density="spacious">
+          <XDSSideNavItem
+            label="Professional hosting tools"
+            icon={WrenchScrewdriverIcon}
+            onClick={() => {}}
+          />
+        </XDSSideNav>
+      }>
+      {activeNav === 'Personal information' && (
+        <XDSVStack gap={6}>
+          <XDSHeading level={2}>Personal info</XDSHeading>
+          <XDSList hasDividers density="spacious">
             <XDSListItem
-              label="Professional hosting tools"
-              startContent={
-                <WrenchScrewdriverIcon style={{width: 20, height: 20}} />
+              label="Legal name"
+              description="Alex Johnson"
+              endContent={
+                <XDSLink label="Edit" href="#">
+                  Edit
+                </XDSLink>
               }
-              onClick={() => {}}
+            />
+            <XDSListItem
+              label="Preferred first name"
+              description="Not provided"
+              endContent={
+                <XDSLink label="Add" href="#">
+                  Add
+                </XDSLink>
+              }
+            />
+            <XDSListItem
+              label="Email address"
+              description="a***n@example.com"
+              endContent={
+                <XDSLink label="Edit" href="#">
+                  Edit
+                </XDSLink>
+              }
+            />
+            <XDSListItem
+              label="Phone number"
+              description="+1 ***-***-0123"
+              endContent={
+                <XDSLink label="Edit" href="#">
+                  Edit
+                </XDSLink>
+              }
+            />
+            <XDSListItem
+              label="Identity verification"
+              description="Verified"
+            />
+            <XDSListItem
+              label="Residential address"
+              description="Not provided"
+              endContent={
+                <XDSLink label="Add" href="#">
+                  Add
+                </XDSLink>
+              }
+            />
+            <XDSListItem
+              label="Mailing address"
+              description="Not provided"
+              endContent={
+                <XDSLink label="Add" href="#">
+                  Add
+                </XDSLink>
+              }
+            />
+            <XDSListItem
+              label="Emergency contact"
+              description="Provided"
+              endContent={
+                <XDSLink label="Edit" href="#">
+                  Edit
+                </XDSLink>
+              }
             />
           </XDSList>
+
+          <XDSCard padding={4}>
+            <XDSList hasDividers density="spacious">
+              <XDSListItem
+                label="Why isn't my info shown here?"
+                description="We're hiding some account details to protect your identity."
+                startContent={<XDSIcon icon={LockClosedIcon} size="lg" />}
+              />
+              <XDSListItem
+                label="Which details can be edited?"
+                description="Contact info and personal details can be edited. If this info was used to verify your identity, you'll need to get verified again the next time you book—or to continue hosting."
+                startContent={<XDSIcon icon={PencilSquareIcon} size="lg" />}
+              />
+              <XDSListItem
+                label="What info is shared with others?"
+                description="We only release contact information after a reservation is confirmed."
+                startContent={<XDSIcon icon={ShareIcon} size="lg" />}
+              />
+            </XDSList>
+          </XDSCard>
         </XDSVStack>
-      </nav>
+      )}
 
-      {/* Content */}
-      <div
-        style={{
-          flex: 1,
-          overflowY: 'auto' as const,
-          height: '100%',
-        }}>
-        <div style={{maxWidth: 700, padding: '16px 48px', margin: '0 auto'}}>
-          {activeNav === 'Login & security' && (
-            <XDSVStack gap={6}>
-              <XDSHeading level={2}>Login &amp; security</XDSHeading>
+      {activeNav === 'Login & security' && (
+        <XDSVStack gap={6}>
+          <XDSHeading level={2}>Login &amp; security</XDSHeading>
 
-              <div style={{marginLeft: -12, overflow: 'hidden'}}>
-                <XDSTabList
-                  value={activeTab}
-                  onChange={setActiveTab}
-                  hasDivider>
-                  <XDSTab value="login" label="Login" />
-                  <XDSTab value="shared" label="Shared access" />
-                </XDSTabList>
-              </div>
+          <XDSTabList
+            value={activeTab}
+            onChange={setActiveTab}
+            hasDivider>
+            <XDSTab value="login" label="Login" />
+            <XDSTab value="shared" label="Shared access" />
+          </XDSTabList>
 
-              {activeTab === 'login' && (
-                <XDSVStack gap={8}>
-                  {/* Login section */}
-                  <XDSVStack gap={0}>
-                    <XDSHeading level={3}>Login</XDSHeading>
-                    <div style={{marginTop: 8}}>
-                      <XDSDivider />
-                    </div>
-                    {LOGIN_ROWS.map(row => (
-                      <InfoRowItem key={row.label} {...row} />
-                    ))}
-                  </XDSVStack>
+          {activeTab === 'login' && (
+            <XDSVStack gap={8}>
+              <XDSVStack gap={2}>
+                <XDSHeading level={3}>Login</XDSHeading>
+                <XDSList hasDividers density="spacious">
+                  {LOGIN_ROWS.map(row => (
+                    <XDSListItem
+                      key={row.label}
+                      label={row.label}
+                      description={row.value}
+                      endContent={
+                        <XDSLink label={row.action} href="#">
+                          {row.action}
+                        </XDSLink>
+                      }
+                    />
+                  ))}
+                </XDSList>
+              </XDSVStack>
 
-                  {/* Social accounts */}
-                  <XDSVStack gap={0}>
-                    <XDSHeading level={3}>Social accounts</XDSHeading>
-                    <div style={{marginTop: 8}}>
-                      <XDSDivider />
-                    </div>
-                    {SOCIAL_ROWS.map(row => (
-                      <InfoRowItem key={row.label} {...row} />
-                    ))}
-                  </XDSVStack>
+              <XDSVStack gap={2}>
+                <XDSHeading level={3}>Social accounts</XDSHeading>
+                <XDSList hasDividers density="spacious">
+                  {SOCIAL_ROWS.map(row => (
+                    <XDSListItem
+                      key={row.label}
+                      label={row.label}
+                      description={row.value}
+                      endContent={
+                        <XDSLink label={row.action} href="#">
+                          {row.action}
+                        </XDSLink>
+                      }
+                    />
+                  ))}
+                </XDSList>
+              </XDSVStack>
 
-                  {/* Device history */}
-                  <XDSVStack gap={0}>
-                    <XDSHeading level={3}>Device history</XDSHeading>
-                    <div style={{marginTop: 8}}>
-                      <XDSDivider />
-                    </div>
-                    {DEVICE_ROWS.map((device, i) => (
-                      <div key={i}>
-                        <div
-                          style={{
-                            display: 'flex',
-                            justifyContent: 'space-between',
-                            alignItems: 'flex-start',
-                            padding: '16px 0',
-                            gap: 12,
-                          }}>
-                          <ComputerDesktopIcon
-                            style={{
-                              width: 32,
-                              height: 32,
-                              flexShrink: 0,
-                              marginTop: 2,
-                            }}
-                          />
-                          <div style={{flex: 1}}>
-                            <div
-                              style={{
-                                display: 'flex',
-                                alignItems: 'center',
-                                gap: 8,
-                              }}>
-                              <XDSText type="body" weight="semibold">
-                                {device.label}
-                              </XDSText>
-                              {device.badge && (
-                                <XDSBadge label={device.badge} />
-                              )}
-                            </div>
-                            <XDSText type="supporting" color="secondary">
-                              {device.location}
-                            </XDSText>
-                          </div>
-                          {device.action && (
-                            <XDSLink label={device.action} href="#">
-                              {device.action}
-                            </XDSLink>
-                          )}
-                        </div>
-                        <XDSDivider />
-                      </div>
-                    ))}
-                  </XDSVStack>
+              <XDSVStack gap={2}>
+                <XDSHeading level={3}>Device history</XDSHeading>
+                <XDSList hasDividers density="spacious">
+                  {DEVICE_ROWS.map((device, i) => (
+                    <XDSListItem
+                      key={i}
+                      label={device.label}
+                      description={device.location}
+                      startContent={
+                        <XDSIcon icon={ComputerDesktopIcon} size="lg" />
+                      }
+                      endContent={
+                        device.badge ? (
+                          <XDSBadge label={device.badge} />
+                        ) : device.action ? (
+                          <XDSLink label={device.action} href="#">
+                            {device.action}
+                          </XDSLink>
+                        ) : undefined
+                      }
+                    />
+                  ))}
+                </XDSList>
+              </XDSVStack>
 
-                  {/* Account */}
-                  <XDSVStack gap={0}>
-                    <XDSHeading level={3}>Account</XDSHeading>
-                    <div style={{marginTop: 8}}>
-                      <XDSDivider />
-                    </div>
-                    <div
-                      style={{
-                        display: 'flex',
-                        justifyContent: 'space-between',
-                        alignItems: 'flex-start',
-                        padding: '16px 0',
-                      }}>
-                      <div>
-                        <XDSText type="body" weight="semibold" display="block">
-                          Deactivate your account
-                        </XDSText>
-                        <XDSText
-                          type="supporting"
-                          color="secondary"
-                          display="block">
-                          This action cannot be undone
-                        </XDSText>
-                      </div>
+              <XDSVStack gap={2}>
+                <XDSHeading level={3}>Account</XDSHeading>
+                <XDSList hasDividers density="spacious">
+                  <XDSListItem
+                    label="Deactivate your account"
+                    description="This action cannot be undone"
+                    endContent={
                       <XDSLink label="Deactivate" href="#">
                         Deactivate
                       </XDSLink>
-                    </div>
-                    <XDSDivider />
-                  </XDSVStack>
-                </XDSVStack>
-              )}
-
-              {activeTab === 'shared' && (
-                <XDSVStack gap={8}>
-                  <XDSVStack gap={0}>
-                    <XDSHeading level={3}>Shared access</XDSHeading>
-                    <div style={{marginTop: 8}}>
-                      <XDSDivider />
-                    </div>
-                    <div style={{paddingTop: 16}}>
-                      <XDSText type="body" color="secondary">
-                        Review each request carefully before approving access.
-                        We&apos;ll email your employee or co-worker a 4-digit
-                        code that lets them log into your account with their
-                        trusted device.
-                      </XDSText>
-                    </div>
-                  </XDSVStack>
-
-                  <XDSCard padding={0} xstyle={styles.noBorder}>
-                    <XDSSection variant="wash" style={{padding: 16}}>
-                      <div
-                        style={{
-                          display: 'flex',
-                          gap: 16,
-                          alignItems: 'flex-start',
-                        }}>
-                        <div
-                          style={{
-                            width: 48,
-                            height: 48,
-                            borderRadius: 12,
-                            backgroundColor:
-                              'var(--xds-color-background-surface, #fff)',
-                            display: 'flex',
-                            alignItems: 'center',
-                            justifyContent: 'center',
-                            flexShrink: 0,
-                          }}>
-                          <LockClosedIcon style={{width: 24, height: 24}} />
-                        </div>
-                        <XDSVStack gap={1}>
-                          <XDSText type="body" weight="bold">
-                            Adding devices from people you trust
-                          </XDSText>
-                          <XDSText type="body" color="secondary">
-                            When you approve a request, you grant someone full
-                            access to your account. They&apos;ll be able to
-                            change reservations and send messages on your
-                            behalf.
-                          </XDSText>
-                        </XDSVStack>
-                      </div>
-                    </XDSSection>
-                  </XDSCard>
-                </XDSVStack>
-              )}
+                    }
+                  />
+                </XDSList>
+              </XDSVStack>
             </XDSVStack>
           )}
 
-          {activeNav === 'Privacy' && (
-            <XDSVStack gap={6}>
-              <XDSHeading level={2}>Privacy</XDSHeading>
+          {activeTab === 'shared' && (
+            <XDSVStack gap={8}>
+              <XDSVStack gap={2}>
+                <XDSHeading level={3}>Shared access</XDSHeading>
+                <XDSDivider />
+                <XDSText type="body" color="secondary">
+                  Review each request carefully before approving access.
+                  We&apos;ll email your employee or co-worker a 4-digit code
+                  that lets them log into your account with their trusted
+                  device.
+                </XDSText>
+              </XDSVStack>
 
-              <XDSVStack gap={8}>
-                {/* Messages */}
-                <XDSVStack gap={0}>
-                  <XDSHeading level={3}>Messages</XDSHeading>
-                  <div style={{marginTop: 16}}>
-                    <XDSSwitch
-                      label="Show people when I've read their messages."
-                      value={readReceipts}
-                      onChange={setReadReceipts}
-                      labelPosition="start"
-                      labelSpacing="spread"
-                    />
-                  </div>
-                  <div style={{padding: '16px 0'}}>
-                    <div
-                      style={{
-                        display: 'flex',
-                        justifyContent: 'space-between',
-                        alignItems: 'center',
-                      }}>
-                      <XDSText type="body" weight="semibold">
-                        Blocked people
-                      </XDSText>
-                      <XDSLink label="View" href="#">
-                        View
-                      </XDSLink>
-                    </div>
-                  </div>
-                  <XDSDivider />
-                </XDSVStack>
-
-                {/* Listings */}
-                <XDSVStack gap={0}>
-                  <XDSHeading level={3}>Listings</XDSHeading>
-                  <div style={{marginTop: 16}}>
-                    <XDSSwitch
-                      label="Include my listing(s) in search engines"
-                      description="Turning this on means search engines, like Google, will display your listing page(s) in search results."
-                      value={searchEngines}
-                      onChange={setSearchEngines}
-                      labelPosition="start"
-                      labelSpacing="spread"
-                    />
-                  </div>
-                  <div style={{marginTop: 8}}>
-                    <XDSDivider />
-                  </div>
-                </XDSVStack>
-
-                {/* Reviews */}
-                <XDSVStack gap={0}>
-                  <XDSHeading level={3}>Reviews</XDSHeading>
-                  <div>
-                    <XDSText type="supporting" color="secondary">
-                      Choose what&apos;s shared when you write a review.{' '}
-                      <XDSLink label="Learn more" href="#" type="supporting">
-                        Learn more
-                      </XDSLink>
+              <XDSCard variant="muted" padding={4}>
+                <XDSHStack gap={4} vAlign="start">
+                  <XDSIcon icon={LockClosedIcon} size="lg" />
+                  <XDSVStack gap={1}>
+                    <XDSText type="body" weight="bold">
+                      Adding devices from people you trust
                     </XDSText>
-                  </div>
-                  <div style={{marginTop: 16}}>
-                    <XDSVStack gap={4}>
-                      <XDSSwitch
-                        label="Show my home city and country"
-                        description="Ex: City and country"
-                        value={showCity}
-                        onChange={setShowCity}
-                        labelPosition="start"
-                        labelSpacing="spread"
-                      />
-                      <XDSSwitch
-                        label="Show my trip type"
-                        description="Ex: Stayed with kids or pets"
-                        value={showTripType}
-                        onChange={setShowTripType}
-                        labelPosition="start"
-                        labelSpacing="spread"
-                      />
-                      <XDSSwitch
-                        label="Show my length of stay"
-                        description="Ex: A few nights, about a week, etc."
-                        value={showStayLength}
-                        onChange={setShowStayLength}
-                        labelPosition="start"
-                        labelSpacing="spread"
-                      />
-                      <XDSSwitch
-                        label="Show my booked services"
-                        description="Ex: Gourmet brunch or tasting menu"
-                        value={showServices}
-                        onChange={setShowServices}
-                        labelPosition="start"
-                        labelSpacing="spread"
-                      />
-                    </XDSVStack>
-                  </div>
-                  <div style={{marginTop: 16}}>
-                    <XDSDivider />
-                  </div>
-                </XDSVStack>
-
-                {/* Data privacy */}
-                <XDSVStack gap={4}>
-                  <XDSHeading level={3}>Data privacy</XDSHeading>
-                  <XDSCard padding={4}>
-                    <div
-                      style={{
-                        display: 'flex',
-                        justifyContent: 'space-between',
-                        alignItems: 'center',
-                      }}>
-                      <XDSText type="body">Request my personal data</XDSText>
-                      <XDSLink label="Request" href="#">
-                        Request
-                      </XDSLink>
-                    </div>
-                  </XDSCard>
-                  <XDSSwitch
-                    label="Help improve AI-powered features"
-                    description="When this is on, we use your data to develop and improve AI models."
-                    value={aiFeatures}
-                    onChange={setAiFeatures}
-                    labelPosition="start"
-                    labelSpacing="spread"
-                  />
-                  <XDSCard padding={4}>
-                    <div
-                      style={{
-                        display: 'flex',
-                        justifyContent: 'space-between',
-                        alignItems: 'center',
-                      }}>
-                      <XDSText type="body">Delete my account</XDSText>
-                      <XDSLink label="Delete" href="#">
-                        Delete
-                      </XDSLink>
-                    </div>
-                  </XDSCard>
-                  <XDSCard padding={0} xstyle={styles.noBorder}>
-                    <XDSSection variant="wash" style={{padding: 16}}>
-                      <div
-                        style={{
-                          display: 'flex',
-                          gap: 16,
-                          alignItems: 'flex-start',
-                        }}>
-                        <div
-                          style={{
-                            width: 48,
-                            height: 48,
-                            borderRadius: 12,
-                            backgroundColor:
-                              'var(--xds-color-background-surface, #fff)',
-                            display: 'flex',
-                            alignItems: 'center',
-                            justifyContent: 'center',
-                            flexShrink: 0,
-                          }}>
-                          <ShieldCheckIcon style={{width: 24, height: 24}} />
-                        </div>
-                        <XDSVStack gap={1}>
-                          <XDSText type="body" weight="bold">
-                            Committed to privacy
-                          </XDSText>
-                          <XDSText type="supporting" color="secondary">
-                            We&apos;re committed to keeping your data protected.
-                            See details in our{' '}
-                            <XDSLink
-                              label="Privacy Policy"
-                              href="#"
-                              type="supporting">
-                              Privacy Policy
-                            </XDSLink>
-                            .
-                          </XDSText>
-                        </XDSVStack>
-                      </div>
-                    </XDSSection>
-                  </XDSCard>
-                </XDSVStack>
-              </XDSVStack>
-            </XDSVStack>
-          )}
-
-          {activeNav === 'Languages & currency' && (
-            <XDSVStack gap={6}>
-              <XDSHeading level={2}>Languages &amp; currency</XDSHeading>
-              <XDSVStack gap={0}>
-                <ExpandableRow
-                  label="Preferred language"
-                  value={
-                    LANGUAGES.find(l => l.value === language)?.label ?? language
-                  }
-                  isExpanded={expandedRow === 'language'}
-                  onEdit={() => setExpandedRow('language')}
-                  onCancel={() => setExpandedRow(null)}
-                  onSave={() => setExpandedRow(null)}>
-                  <XDSSelector
-                    label="Language"
-                    isLabelHidden
-                    size="lg"
-                    value={language}
-                    onChange={setLanguage}
-                    options={LANGUAGES}
-                  />
-                </ExpandableRow>
-                <ExpandableRow
-                  label="Preferred currency"
-                  value={
-                    CURRENCIES.find(c => c.value === currency)?.label ??
-                    currency
-                  }
-                  isExpanded={expandedRow === 'currency'}
-                  onEdit={() => setExpandedRow('currency')}
-                  onCancel={() => setExpandedRow(null)}
-                  onSave={() => setExpandedRow(null)}>
-                  <XDSSelector
-                    label="Currency"
-                    isLabelHidden
-                    size="lg"
-                    value={currency}
-                    onChange={setCurrency}
-                    options={CURRENCIES}
-                  />
-                </ExpandableRow>
-                <ExpandableRow
-                  label="Time zone"
-                  value={
-                    TIMEZONES.find(t => t.value === timezone)?.label ?? timezone
-                  }
-                  isExpanded={expandedRow === 'timezone'}
-                  onEdit={() => setExpandedRow('timezone')}
-                  onCancel={() => setExpandedRow(null)}
-                  onSave={() => setExpandedRow(null)}>
-                  <XDSSelector
-                    label="Time zone"
-                    isLabelHidden
-                    size="lg"
-                    value={timezone}
-                    onChange={setTimezone}
-                    options={TIMEZONES}
-                  />
-                </ExpandableRow>
-              </XDSVStack>
-            </XDSVStack>
-          )}
-
-          {activeNav === 'Personal information' && (
-            <XDSVStack gap={6}>
-              <XDSHeading level={2}>Personal info</XDSHeading>
-              <XDSVStack gap={0}>
-                <InfoRowItem
-                  label="Legal name"
-                  value="Alex Johnson"
-                  action="Edit"
-                />
-                <InfoRowItem
-                  label="Preferred first name"
-                  value="Not provided"
-                  action="Add"
-                />
-                <InfoRowItem
-                  label="Email address"
-                  value="a***n@example.com"
-                  action="Edit"
-                />
-                <InfoRowItem
-                  label="Phone number"
-                  value="+1 ***-***-0123"
-                  action="Edit"
-                />
-                <InfoRowItem
-                  label="Identity verification"
-                  value="Verified"
-                  action=""
-                />
-                <InfoRowItem
-                  label="Residential address"
-                  value="Not provided"
-                  action="Add"
-                />
-                <InfoRowItem
-                  label="Mailing address"
-                  value="Not provided"
-                  action="Add"
-                />
-                <InfoRowItem
-                  label="Emergency contact"
-                  value="Provided"
-                  action="Edit"
-                />
-              </XDSVStack>
-
-              <XDSCard padding={4} style={{marginTop: 16}}>
-                <XDSVStack gap={0}>
-                  <div style={{paddingTop: 0, paddingBottom: 16}}>
-                    <XDSHStack gap={3} vAlign="start">
-                      <div
-                        style={{
-                          width: 48,
-                          height: 48,
-                          borderRadius: 12,
-                          backgroundColor:
-                            'var(--xds-color-background-muted, #f5f5f5)',
-                          display: 'flex',
-                          alignItems: 'center',
-                          justifyContent: 'center',
-                          flexShrink: 0,
-                        }}>
-                        <LockClosedIcon style={{width: 24, height: 24}} />
-                      </div>
-                      <XDSVStack gap={0}>
-                        <XDSText type="body" weight="semibold" display="block">
-                          Why isn&apos;t my info shown here?
-                        </XDSText>
-                        <XDSText
-                          type="supporting"
-                          color="secondary"
-                          display="block">
-                          We&apos;re hiding some account details to protect your
-                          identity.
-                        </XDSText>
-                      </XDSVStack>
-                    </XDSHStack>
-                  </div>
-                  <XDSDivider />
-                  <div style={{padding: '16px 0'}}>
-                    <XDSHStack gap={3} vAlign="start">
-                      <div
-                        style={{
-                          width: 48,
-                          height: 48,
-                          borderRadius: 12,
-                          backgroundColor:
-                            'var(--xds-color-background-muted, #f5f5f5)',
-                          display: 'flex',
-                          alignItems: 'center',
-                          justifyContent: 'center',
-                          flexShrink: 0,
-                        }}>
-                        <PencilSquareIcon style={{width: 24, height: 24}} />
-                      </div>
-                      <XDSVStack gap={0}>
-                        <XDSText type="body" weight="semibold" display="block">
-                          Which details can be edited?
-                        </XDSText>
-                        <XDSText
-                          type="supporting"
-                          color="secondary"
-                          display="block">
-                          Contact info and personal details can be edited. If
-                          this info was used to verify your identity,
-                          you&apos;ll need to get verified again the next time
-                          you book—or to continue hosting.
-                        </XDSText>
-                      </XDSVStack>
-                    </XDSHStack>
-                  </div>
-                  <XDSDivider />
-                  <div style={{paddingTop: 16, paddingBottom: 0}}>
-                    <XDSHStack gap={3} vAlign="start">
-                      <div
-                        style={{
-                          width: 48,
-                          height: 48,
-                          borderRadius: 12,
-                          backgroundColor:
-                            'var(--xds-color-background-muted, #f5f5f5)',
-                          display: 'flex',
-                          alignItems: 'center',
-                          justifyContent: 'center',
-                          flexShrink: 0,
-                        }}>
-                        <ShareIcon style={{width: 24, height: 24}} />
-                      </div>
-                      <XDSVStack gap={0}>
-                        <XDSText type="body" weight="semibold" display="block">
-                          What info is shared with others?
-                        </XDSText>
-                        <XDSText
-                          type="supporting"
-                          color="secondary"
-                          display="block">
-                          We only release contact information after a
-                          reservation is confirmed.
-                        </XDSText>
-                      </XDSVStack>
-                    </XDSHStack>
-                  </div>
-                </XDSVStack>
+                    <XDSText type="body" color="secondary">
+                      When you approve a request, you grant someone full access
+                      to your account. They&apos;ll be able to change
+                      reservations and send messages on your behalf.
+                    </XDSText>
+                  </XDSVStack>
+                </XDSHStack>
               </XDSCard>
             </XDSVStack>
           )}
-        </div>
-      </div>
-    </div>
+        </XDSVStack>
+      )}
+
+      {activeNav === 'Privacy' && (
+        <XDSVStack gap={6}>
+          <XDSHeading level={2}>Privacy</XDSHeading>
+
+          <XDSVStack gap={8}>
+            <XDSVStack gap={4}>
+              <XDSHeading level={3}>Messages</XDSHeading>
+              <XDSSwitch
+                label="Show people when I've read their messages."
+                value={readReceipts}
+                onChange={setReadReceipts}
+                labelPosition="start"
+                labelSpacing="spread"
+              />
+              <XDSList hasDividers density="spacious">
+                <XDSListItem
+                  label="Blocked people"
+                  endContent={
+                    <XDSLink label="View" href="#">
+                      View
+                    </XDSLink>
+                  }
+                />
+              </XDSList>
+            </XDSVStack>
+
+            <XDSVStack gap={4}>
+              <XDSHeading level={3}>Listings</XDSHeading>
+              <XDSSwitch
+                label="Include my listing(s) in search engines"
+                description="Turning this on means search engines, like Google, will display your listing page(s) in search results."
+                value={searchEngines}
+                onChange={setSearchEngines}
+                labelPosition="start"
+                labelSpacing="spread"
+              />
+              <XDSDivider />
+            </XDSVStack>
+
+            <XDSVStack gap={4}>
+              <XDSHeading level={3}>Reviews</XDSHeading>
+              <XDSText type="supporting" color="secondary">
+                Choose what&apos;s shared when you write a review.{' '}
+                <XDSLink label="Learn more" href="#" type="supporting">
+                  Learn more
+                </XDSLink>
+              </XDSText>
+              <XDSVStack gap={4}>
+                <XDSSwitch
+                  label="Show my home city and country"
+                  description="Ex: City and country"
+                  value={showCity}
+                  onChange={setShowCity}
+                  labelPosition="start"
+                  labelSpacing="spread"
+                />
+                <XDSSwitch
+                  label="Show my trip type"
+                  description="Ex: Stayed with kids or pets"
+                  value={showTripType}
+                  onChange={setShowTripType}
+                  labelPosition="start"
+                  labelSpacing="spread"
+                />
+                <XDSSwitch
+                  label="Show my length of stay"
+                  description="Ex: A few nights, about a week, etc."
+                  value={showStayLength}
+                  onChange={setShowStayLength}
+                  labelPosition="start"
+                  labelSpacing="spread"
+                />
+                <XDSSwitch
+                  label="Show my booked services"
+                  description="Ex: Gourmet brunch or tasting menu"
+                  value={showServices}
+                  onChange={setShowServices}
+                  labelPosition="start"
+                  labelSpacing="spread"
+                />
+              </XDSVStack>
+              <XDSDivider />
+            </XDSVStack>
+
+            <XDSVStack gap={4}>
+              <XDSHeading level={3}>Data privacy</XDSHeading>
+              <XDSCard padding={4}>
+                <XDSHStack hAlign="between" vAlign="center">
+                  <XDSText type="body">Request my personal data</XDSText>
+                  <XDSLink label="Request" href="#">
+                    Request
+                  </XDSLink>
+                </XDSHStack>
+              </XDSCard>
+              <XDSSwitch
+                label="Help improve AI-powered features"
+                description="When this is on, we use your data to develop and improve AI models."
+                value={aiFeatures}
+                onChange={setAiFeatures}
+                labelPosition="start"
+                labelSpacing="spread"
+              />
+              <XDSCard padding={4}>
+                <XDSHStack hAlign="between" vAlign="center">
+                  <XDSText type="body">Delete my account</XDSText>
+                  <XDSLink label="Delete" href="#">
+                    Delete
+                  </XDSLink>
+                </XDSHStack>
+              </XDSCard>
+              <XDSCard variant="muted" padding={4}>
+                <XDSHStack gap={4} vAlign="start">
+                  <XDSIcon icon={ShieldCheckIcon} size="lg" />
+                  <XDSVStack gap={1}>
+                    <XDSText type="body" weight="bold">
+                      Committed to privacy
+                    </XDSText>
+                    <XDSText type="supporting" color="secondary">
+                      We&apos;re committed to keeping your data protected. See
+                      details in our{' '}
+                      <XDSLink
+                        label="Privacy Policy"
+                        href="#"
+                        type="supporting">
+                        Privacy Policy
+                      </XDSLink>
+                      .
+                    </XDSText>
+                  </XDSVStack>
+                </XDSHStack>
+              </XDSCard>
+            </XDSVStack>
+          </XDSVStack>
+        </XDSVStack>
+      )}
+
+      {activeNav === 'Languages & currency' && (
+        <XDSVStack gap={6}>
+          <XDSHeading level={2}>Languages &amp; currency</XDSHeading>
+          <XDSVStack gap={0}>
+            <ExpandableRow
+              label="Preferred language"
+              value={
+                LANGUAGES.find(l => l.value === language)?.label ?? language
+              }
+              isExpanded={expandedRow === 'language'}
+              onEdit={() => setExpandedRow('language')}
+              onCancel={() => setExpandedRow(null)}
+              onSave={() => setExpandedRow(null)}>
+              <XDSSelector
+                label="Language"
+                isLabelHidden
+                size="lg"
+                value={language}
+                onChange={setLanguage}
+                options={LANGUAGES}
+              />
+            </ExpandableRow>
+            <ExpandableRow
+              label="Preferred currency"
+              value={
+                CURRENCIES.find(c => c.value === currency)?.label ?? currency
+              }
+              isExpanded={expandedRow === 'currency'}
+              onEdit={() => setExpandedRow('currency')}
+              onCancel={() => setExpandedRow(null)}
+              onSave={() => setExpandedRow(null)}>
+              <XDSSelector
+                label="Currency"
+                isLabelHidden
+                size="lg"
+                value={currency}
+                onChange={setCurrency}
+                options={CURRENCIES}
+              />
+            </ExpandableRow>
+            <ExpandableRow
+              label="Time zone"
+              value={
+                TIMEZONES.find(t => t.value === timezone)?.label ?? timezone
+              }
+              isExpanded={expandedRow === 'timezone'}
+              onEdit={() => setExpandedRow('timezone')}
+              onCancel={() => setExpandedRow(null)}
+              onSave={() => setExpandedRow(null)}>
+              <XDSSelector
+                label="Time zone"
+                isLabelHidden
+                size="lg"
+                value={timezone}
+                onChange={setTimezone}
+                options={TIMEZONES}
+              />
+            </ExpandableRow>
+          </XDSVStack>
+        </XDSVStack>
+      )}
+    </XDSAppShell>
   );
 }

--- a/packages/cli/templates/pages/settings-sidebar/page.tsx
+++ b/packages/cli/templates/pages/settings-sidebar/page.tsx
@@ -42,6 +42,10 @@ const styles = stylex.create({
     paddingTop: 16,
     paddingBottom: 16,
   },
+  contentHPadding: {
+    paddingLeft: 48,
+    paddingRight: 48,
+  },
 });
 
 const NAV_ITEMS = [
@@ -242,7 +246,11 @@ export default function SettingsSecurityTemplate() {
           </XDSList>
         </XDSVStack>
       }>
-      <XDSSection maxWidth={700} variant="transparent" padding={0}>
+      <XDSSection
+        maxWidth={700}
+        variant="transparent"
+        padding={4}
+        xstyle={styles.contentHPadding}>
         {activeNav === 'Login & security' && (
           <XDSVStack gap={6}>
             <XDSHeading level={2}>Login &amp; security</XDSHeading>

--- a/packages/cli/templates/pages/settings-sidebar/page.tsx
+++ b/packages/cli/templates/pages/settings-sidebar/page.tsx
@@ -35,16 +35,33 @@ import {
 const styles = stylex.create({
   iconBox: {
     borderRadius: 12,
-    backgroundColor: 'var(--xds-color-background-muted, #f5f5f5)',
+    backgroundColor: 'var(--xds-color-background-surface, #fff)',
     flexShrink: 0,
   },
   rowPadding: {
     paddingTop: 16,
     paddingBottom: 16,
   },
-  contentHPadding: {
+  cardContentPadding: {
+    paddingLeft: 16,
+    paddingRight: 16,
+  },
+  contentCenter: {
+    maxWidth: 700,
+    marginLeft: 'auto',
+    marginRight: 'auto',
     paddingLeft: 48,
     paddingRight: 48,
+  },
+  sideNavPadding: {
+    paddingTop: 16,
+    paddingBottom: 16,
+    paddingLeft: 12,
+    paddingRight: 12,
+  },
+  sideNavHeading: {
+    marginLeft: 16,
+    marginRight: 16,
   },
 });
 
@@ -221,36 +238,30 @@ export default function SettingsSecurityTemplate() {
       variant="section"
       contentPadding={4}
       sideNav={
-        <XDSVStack gap={4}>
-          <XDSSection padding={4} variant="transparent">
-            <XDSHeading level={2}>Account settings</XDSHeading>
-          </XDSSection>
-          <XDSList density="spacious">
-            {NAV_ITEMS.map(item => (
+        <XDSVStack gap={4} xstyle={styles.sideNavPadding}>
+            <XDSHeading level={2} xstyle={styles.sideNavHeading}>Account settings</XDSHeading>
+            <XDSList density="spacious">
+              {NAV_ITEMS.map(item => (
+                <XDSListItem
+                  key={item.label}
+                  label={item.label}
+                  startContent={<XDSIcon icon={item.icon} />}
+                  isSelected={activeNav === item.label}
+                  onClick={() => setActiveNav(item.label)}
+                />
+              ))}
+            </XDSList>
+            <XDSDivider />
+            <XDSList density="spacious">
               <XDSListItem
-                key={item.label}
-                label={item.label}
-                startContent={<XDSIcon icon={item.icon} />}
-                isSelected={activeNav === item.label}
-                onClick={() => setActiveNav(item.label)}
+                label="Professional hosting tools"
+                startContent={<XDSIcon icon={WrenchScrewdriverIcon} />}
+                onClick={() => {}}
               />
-            ))}
-          </XDSList>
-          <XDSDivider />
-          <XDSList density="spacious">
-            <XDSListItem
-              label="Professional hosting tools"
-              startContent={<XDSIcon icon={WrenchScrewdriverIcon} />}
-              onClick={() => {}}
-            />
-          </XDSList>
+            </XDSList>
         </XDSVStack>
       }>
-      <XDSSection
-        maxWidth={700}
-        variant="transparent"
-        padding={4}
-        xstyle={styles.contentHPadding}>
+      <XDSVStack gap={0} xstyle={styles.contentCenter}>
         {activeNav === 'Login & security' && (
           <XDSVStack gap={6}>
             <XDSHeading level={2}>Login &amp; security</XDSHeading>
@@ -359,7 +370,7 @@ export default function SettingsSecurityTemplate() {
                   </XDSText>
                 </XDSVStack>
 
-                <XDSCard variant="muted" padding={4}>
+                <XDSCard variant="muted">
                   <XDSHStack gap={4} vAlign="start">
                     <XDSCenter
                       width={48}
@@ -492,9 +503,9 @@ export default function SettingsSecurityTemplate() {
               />
             </XDSVStack>
 
-            <XDSCard padding={4}>
-              <XDSVStack gap={0}>
-                <XDSHStack gap={3} vAlign="start">
+            <XDSCard padding={0}>
+              <XDSVStack gap={0} xstyle={styles.cardContentPadding}>
+                <XDSHStack gap={3} vAlign="start" xstyle={styles.rowPadding}>
                   <XDSCenter
                     width={48}
                     height={48}
@@ -541,7 +552,7 @@ export default function SettingsSecurityTemplate() {
                   </XDSVStack>
                 </XDSHStack>
                 <XDSDivider />
-                <XDSHStack gap={3} vAlign="start">
+                <XDSHStack gap={3} vAlign="start" xstyle={styles.rowPadding}>
                   <XDSCenter
                     width={48}
                     height={48}
@@ -658,7 +669,7 @@ export default function SettingsSecurityTemplate() {
 
               <XDSVStack gap={4}>
                 <XDSHeading level={3}>Data privacy</XDSHeading>
-                <XDSCard padding={4}>
+                <XDSCard>
                   <XDSHStack hAlign="between" vAlign="center">
                     <XDSText type="body">Request my personal data</XDSText>
                     <XDSLink label="Request" href="#">
@@ -674,7 +685,7 @@ export default function SettingsSecurityTemplate() {
                   labelPosition="start"
                   labelSpacing="spread"
                 />
-                <XDSCard padding={4}>
+                <XDSCard>
                   <XDSHStack hAlign="between" vAlign="center">
                     <XDSText type="body">Delete my account</XDSText>
                     <XDSLink label="Delete" href="#">
@@ -682,39 +693,37 @@ export default function SettingsSecurityTemplate() {
                     </XDSLink>
                   </XDSHStack>
                 </XDSCard>
-                <XDSCard>
-                  <XDSSection variant="wash">
-                    <XDSHStack gap={4} vAlign="start">
-                      <XDSCenter
-                        width={48}
-                        height={48}
-                        xstyle={styles.iconBox}>
-                        <XDSIcon icon={ShieldCheckIcon} />
-                      </XDSCenter>
-                      <XDSVStack gap={1}>
-                        <XDSText type="body" weight="bold">
-                          Committed to privacy
-                        </XDSText>
-                        <XDSText type="supporting" color="secondary">
-                          We&apos;re committed to keeping your data protected.
-                          See details in our{' '}
-                          <XDSLink
-                            label="Privacy Policy"
-                            href="#"
-                            type="supporting">
-                            Privacy Policy
-                          </XDSLink>
-                          .
-                        </XDSText>
-                      </XDSVStack>
-                    </XDSHStack>
-                  </XDSSection>
+                <XDSCard variant="muted">
+                  <XDSHStack gap={4} vAlign="start">
+                    <XDSCenter
+                      width={48}
+                      height={48}
+                      xstyle={styles.iconBox}>
+                      <XDSIcon icon={ShieldCheckIcon} />
+                    </XDSCenter>
+                    <XDSVStack gap={1}>
+                      <XDSText type="body" weight="bold">
+                        Committed to privacy
+                      </XDSText>
+                      <XDSText type="supporting" color="secondary">
+                        We&apos;re committed to keeping your data protected.
+                        See details in our{' '}
+                        <XDSLink
+                          label="Privacy Policy"
+                          href="#"
+                          type="supporting">
+                          Privacy Policy
+                        </XDSLink>
+                        .
+                      </XDSText>
+                    </XDSVStack>
+                  </XDSHStack>
                 </XDSCard>
               </XDSVStack>
             </XDSVStack>
           </XDSVStack>
         )}
-      </XDSSection>
+      </XDSVStack>
     </XDSAppShell>
   );
 }

--- a/packages/cli/templates/pages/settings-sidebar/template.doc.mjs
+++ b/packages/cli/templates/pages/settings-sidebar/template.doc.mjs
@@ -2,6 +2,7 @@
 export const doc = {
   type: 'page',
   name: 'Settings (Sidebar)',
-  description: 'Account settings with sidebar nav and inline editing',
+  description:
+    'Account settings with sidebar navigation, inline editing, and multi-section privacy controls',
   isReady: true,
 };

--- a/packages/cli/templates/pages/settings/page.tsx
+++ b/packages/cli/templates/pages/settings/page.tsx
@@ -2,35 +2,26 @@
 
 import {useState} from 'react';
 import {XDSAppShell} from '@xds/core/AppShell';
-import {XDSTopNav, XDSTopNavHeading} from '@xds/core/TopNav';
-import {XDSSideNav, XDSSideNavItem} from '@xds/core/SideNav';
-import {XDSVStack} from '@xds/core/Layout';
+import {XDSVStack, XDSHStack, XDSStackItem} from '@xds/core/Layout';
 import {XDSGrid} from '@xds/core/Grid';
+import {XDSList, XDSListItem} from '@xds/core/List';
 import {XDSText, XDSHeading} from '@xds/core/Text';
 import {XDSTextInput} from '@xds/core/TextInput';
 import {XDSButton} from '@xds/core/Button';
 import {XDSDivider} from '@xds/core/Divider';
 import {XDSCheckboxInput} from '@xds/core/CheckboxInput';
-import {XDSFormLayout} from '@xds/core/FormLayout';
+import {XDSSection} from '@xds/core/Section';
 import {XDSTypeahead} from '@xds/core/Typeahead';
-import {
-  MagnifyingGlassIcon,
-  UserIcon,
-  Cog6ToothIcon,
-  UsersIcon,
-  CreditCardIcon,
-  DocumentTextIcon,
-  CodeBracketIcon,
-} from '@heroicons/react/24/outline';
+import {MagnifyingGlassIcon} from '@heroicons/react/24/outline';
 import type {XDSSearchableItem, XDSSearchSource} from '@xds/core/Typeahead';
 
 const NAV_ITEMS = [
-  {label: 'Profile', icon: UserIcon},
-  {label: 'Account', icon: Cog6ToothIcon},
-  {label: 'Members', icon: UsersIcon},
-  {label: 'Billing', icon: CreditCardIcon},
-  {label: 'Invoices', icon: DocumentTextIcon},
-  {label: 'API', icon: CodeBracketIcon},
+  'Profile',
+  'Account',
+  'Members',
+  'Billing',
+  'Invoices',
+  'API',
 ];
 
 const SETTINGS_ITEMS: XDSSearchableItem[] = [
@@ -58,9 +49,9 @@ export default function SettingsTemplate() {
   const [firstName, setFirstName] = useState('Stephanie');
   const [lastName, setLastName] = useState('Nicol');
   const [email, setEmail] = useState('stephanie_nicol@mail.com');
-  const [currentPw, setCurrentPw] = useState('');
-  const [newPw, setNewPw] = useState('');
-  const [confirmPw, setConfirmPw] = useState('');
+  const [currentPw, setCurrentPw] = useState('password123');
+  const [newPw, setNewPw] = useState('password123');
+  const [confirmPw, setConfirmPw] = useState('password123');
   const [dataExport, setDataExport] = useState(false);
   const [adminMembers, setAdminMembers] = useState(false);
   const [twoFactor, setTwoFactor] = useState(false);
@@ -70,13 +61,15 @@ export default function SettingsTemplate() {
 
   return (
     <XDSAppShell
-      contentPadding={4}
       height="auto"
+      variant="section"
+      contentPadding={4}
       topNav={
-        <XDSTopNav
-          label="Settings"
-          heading={<XDSTopNavHeading heading="Settings" />}
-          endContent={
+        <XDSSection padding={4} variant="transparent">
+          <XDSHStack vAlign="center">
+            <XDSStackItem size="fill">
+              <XDSHeading level={1}>Settings</XDSHeading>
+            </XDSStackItem>
             <XDSTypeahead
               label="Search"
               isLabelHidden
@@ -87,31 +80,32 @@ export default function SettingsTemplate() {
               hasEntriesOnFocus
               startIcon={MagnifyingGlassIcon}
             />
-          }
-        />
+          </XDSHStack>
+        </XDSSection>
       }
       sideNav={
-        <XDSSideNav>
-          {NAV_ITEMS.map(item => (
-            <XDSSideNavItem
-              key={item.label}
-              label={item.label}
-              icon={item.icon}
-              isSelected={activeNav === item.label}
-              onClick={() => setActiveNav(item.label)}
-            />
-          ))}
-        </XDSSideNav>
+        <XDSSection padding={3} variant="transparent">
+          <XDSList density="compact">
+            {NAV_ITEMS.map(item => (
+              <XDSListItem
+                key={item}
+                label={item}
+                isSelected={activeNav === item}
+                onClick={() => setActiveNav(item)}
+              />
+            ))}
+          </XDSList>
+        </XDSSection>
       }>
-      <XDSVStack gap={6}>
-        <XDSGrid columns={{minWidth: 280, max: 2}} gap={7}>
+      <XDSVStack gap={4}>
+        <XDSGrid columns={2} gap={10}>
           <XDSVStack gap={1}>
             <XDSHeading level={3}>Basic information</XDSHeading>
             <XDSText type="supporting" color="secondary">
               View and update your personal details and account information.
             </XDSText>
           </XDSVStack>
-          <XDSFormLayout>
+          <XDSVStack gap={4}>
             <XDSTextInput
               label="Username"
               value={username}
@@ -132,20 +126,22 @@ export default function SettingsTemplate() {
               value={email}
               onChange={setEmail}
             />
-            <XDSButton label="Save" variant="primary" />
-          </XDSFormLayout>
+            <XDSHStack>
+              <XDSButton label="Save" variant="primary" />
+            </XDSHStack>
+          </XDSVStack>
         </XDSGrid>
 
         <XDSDivider />
 
-        <XDSGrid columns={{minWidth: 280, max: 2}} gap={7}>
+        <XDSGrid columns={2} gap={10}>
           <XDSVStack gap={1}>
             <XDSHeading level={3}>Change password</XDSHeading>
             <XDSText type="supporting" color="secondary">
               Update your password to keep your account secure.
             </XDSText>
           </XDSVStack>
-          <XDSFormLayout>
+          <XDSVStack gap={4}>
             <XDSTextInput
               label="Verify current password"
               type="password"
@@ -164,13 +160,15 @@ export default function SettingsTemplate() {
               value={confirmPw}
               onChange={setConfirmPw}
             />
-            <XDSButton label="Save" variant="primary" />
-          </XDSFormLayout>
+            <XDSHStack>
+              <XDSButton label="Save" variant="primary" />
+            </XDSHStack>
+          </XDSVStack>
         </XDSGrid>
 
         <XDSDivider />
 
-        <XDSGrid columns={{minWidth: 280, max: 2}} gap={7}>
+        <XDSGrid columns={2} gap={10}>
           <XDSVStack gap={1}>
             <XDSHeading level={3}>Advanced settings</XDSHeading>
             <XDSText type="supporting" color="secondary">
@@ -196,7 +194,9 @@ export default function SettingsTemplate() {
               value={twoFactor}
               onChange={setTwoFactor}
             />
-            <XDSButton label="Save" variant="primary" />
+            <XDSHStack>
+              <XDSButton label="Save" variant="primary" />
+            </XDSHStack>
           </XDSVStack>
         </XDSGrid>
       </XDSVStack>

--- a/packages/cli/templates/pages/settings/page.tsx
+++ b/packages/cli/templates/pages/settings/page.tsx
@@ -85,7 +85,7 @@ export default function SettingsTemplate() {
       }
       sideNav={
         <XDSSection padding={4} variant="transparent">
-          <XDSList density="compact">
+          <XDSList density="spacious">
             {NAV_ITEMS.map(item => (
               <XDSListItem
                 key={item}

--- a/packages/cli/templates/pages/settings/page.tsx
+++ b/packages/cli/templates/pages/settings/page.tsx
@@ -12,8 +12,22 @@ import {XDSDivider} from '@xds/core/Divider';
 import {XDSCheckboxInput} from '@xds/core/CheckboxInput';
 import {XDSSection} from '@xds/core/Section';
 import {XDSTypeahead} from '@xds/core/Typeahead';
+import * as stylex from '@stylexjs/stylex';
 import {MagnifyingGlassIcon} from '@heroicons/react/24/outline';
 import type {XDSSearchableItem, XDSSearchSource} from '@xds/core/Typeahead';
+
+const styles = stylex.create({
+  constrainedShell: {
+    maxWidth: 1100,
+    marginInline: 'auto',
+  },
+  headerPadding: {
+    padding: 16,
+  },
+  sideNavWidth: {
+    minWidth: 240,
+  },
+});
 
 const NAV_ITEMS = [
   'Profile',
@@ -64,28 +78,27 @@ export default function SettingsTemplate() {
       height="auto"
       variant="section"
       contentPadding={4}
+      xstyle={styles.constrainedShell}
       topNav={
-        <XDSSection padding={4} variant="transparent">
-          <XDSHStack vAlign="center">
-            <XDSStackItem size="fill">
-              <XDSHeading level={1}>Settings</XDSHeading>
-            </XDSStackItem>
-            <XDSTypeahead
-              label="Search"
-              isLabelHidden
-              placeholder="Search settings..."
-              searchSource={settingsSearchSource}
-              value={searchValue}
-              onChange={setSearchValue}
-              hasEntriesOnFocus
-              startIcon={MagnifyingGlassIcon}
-            />
-          </XDSHStack>
-        </XDSSection>
+        <XDSHStack vAlign="center" xstyle={styles.headerPadding}>
+          <XDSStackItem size="fill">
+            <XDSHeading level={1}>Settings</XDSHeading>
+          </XDSStackItem>
+          <XDSTypeahead
+            label="Search"
+            isLabelHidden
+            placeholder="Search settings..."
+            searchSource={settingsSearchSource}
+            value={searchValue}
+            onChange={setSearchValue}
+            hasEntriesOnFocus
+            startIcon={MagnifyingGlassIcon}
+          />
+        </XDSHStack>
       }
       sideNav={
-        <XDSSection padding={4} variant="transparent">
-          <XDSList density="spacious">
+        <XDSSection padding={2} variant="transparent" xstyle={styles.sideNavWidth}>
+          <XDSList density="balanced">
             {NAV_ITEMS.map(item => (
               <XDSListItem
                 key={item}

--- a/packages/cli/templates/pages/settings/page.tsx
+++ b/packages/cli/templates/pages/settings/page.tsx
@@ -84,7 +84,7 @@ export default function SettingsTemplate() {
         </XDSSection>
       }
       sideNav={
-        <XDSSection padding={3} variant="transparent">
+        <XDSSection padding={4} variant="transparent">
           <XDSList density="compact">
             {NAV_ITEMS.map(item => (
               <XDSListItem
@@ -97,7 +97,7 @@ export default function SettingsTemplate() {
           </XDSList>
         </XDSSection>
       }>
-      <XDSVStack gap={4}>
+      <XDSVStack gap={6}>
         <XDSGrid columns={2} gap={10}>
           <XDSVStack gap={1}>
             <XDSHeading level={3}>Basic information</XDSHeading>

--- a/packages/cli/templates/pages/settings/page.tsx
+++ b/packages/cli/templates/pages/settings/page.tsx
@@ -97,7 +97,7 @@ export default function SettingsTemplate() {
           </XDSList>
         </XDSSection>
       }>
-      <XDSVStack gap={6}>
+      <XDSVStack gap={4}>
         <XDSGrid columns={2} gap={10}>
           <XDSVStack gap={1}>
             <XDSHeading level={3}>Basic information</XDSHeading>

--- a/packages/cli/templates/pages/settings/page.tsx
+++ b/packages/cli/templates/pages/settings/page.tsx
@@ -1,37 +1,36 @@
 'use client';
 
 import {useState} from 'react';
-import * as stylex from '@stylexjs/stylex';
+import {XDSAppShell} from '@xds/core/AppShell';
+import {XDSTopNav, XDSTopNavHeading} from '@xds/core/TopNav';
+import {XDSSideNav, XDSSideNavItem} from '@xds/core/SideNav';
 import {XDSVStack} from '@xds/core/Layout';
-import {XDSList, XDSListItem} from '@xds/core/List';
+import {XDSGrid} from '@xds/core/Grid';
 import {XDSText, XDSHeading} from '@xds/core/Text';
 import {XDSTextInput} from '@xds/core/TextInput';
 import {XDSButton} from '@xds/core/Button';
 import {XDSDivider} from '@xds/core/Divider';
 import {XDSCheckboxInput} from '@xds/core/CheckboxInput';
+import {XDSFormLayout} from '@xds/core/FormLayout';
 import {XDSTypeahead} from '@xds/core/Typeahead';
-import {MagnifyingGlassIcon} from '@heroicons/react/24/outline';
+import {
+  MagnifyingGlassIcon,
+  UserIcon,
+  Cog6ToothIcon,
+  UsersIcon,
+  CreditCardIcon,
+  DocumentTextIcon,
+  CodeBracketIcon,
+} from '@heroicons/react/24/outline';
 import type {XDSSearchableItem, XDSSearchSource} from '@xds/core/Typeahead';
 
-const styles = stylex.create({
-  sidebarItem: {
-    padding: '8px 12px',
-    borderRadius: 6,
-    cursor: 'pointer',
-    fontSize: 14,
-  },
-  sidebarItemSelected: {
-    fontWeight: 600,
-  },
-});
-
 const NAV_ITEMS = [
-  'Profile',
-  'Account',
-  'Members',
-  'Billing',
-  'Invoices',
-  'API',
+  {label: 'Profile', icon: UserIcon},
+  {label: 'Account', icon: Cog6ToothIcon},
+  {label: 'Members', icon: UsersIcon},
+  {label: 'Billing', icon: CreditCardIcon},
+  {label: 'Invoices', icon: DocumentTextIcon},
+  {label: 'API', icon: CodeBracketIcon},
 ];
 
 const SETTINGS_ITEMS: XDSSearchableItem[] = [
@@ -59,9 +58,9 @@ export default function SettingsTemplate() {
   const [firstName, setFirstName] = useState('Stephanie');
   const [lastName, setLastName] = useState('Nicol');
   const [email, setEmail] = useState('stephanie_nicol@mail.com');
-  const [currentPw, setCurrentPw] = useState('password123');
-  const [newPw, setNewPw] = useState('password123');
-  const [confirmPw, setConfirmPw] = useState('password123');
+  const [currentPw, setCurrentPw] = useState('');
+  const [newPw, setNewPw] = useState('');
+  const [confirmPw, setConfirmPw] = useState('');
   const [dataExport, setDataExport] = useState(false);
   const [adminMembers, setAdminMembers] = useState(false);
   const [twoFactor, setTwoFactor] = useState(false);
@@ -70,25 +69,14 @@ export default function SettingsTemplate() {
   );
 
   return (
-    <div
-      style={{minHeight: '100svh', display: 'flex', flexDirection: 'column'}}>
-      {/* Header — full width with edge-to-edge divider */}
-      <div
-        style={{
-          borderBottom: '1px solid var(--xds-color-border-primary, #e5e5e5)',
-          flexShrink: 0,
-        }}>
-        <div
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'space-between',
-            padding: '16px 16px',
-            maxWidth: 1000,
-            margin: '0 auto',
-          }}>
-          <XDSHeading level={1}>Settings</XDSHeading>
-          <div style={{width: 344}}>
+    <XDSAppShell
+      contentPadding={4}
+      height="auto"
+      topNav={
+        <XDSTopNav
+          label="Settings"
+          heading={<XDSTopNavHeading heading="Settings" />}
+          endContent={
             <XDSTypeahead
               label="Search"
               isLabelHidden
@@ -99,182 +87,119 @@ export default function SettingsTemplate() {
               hasEntriesOnFocus
               startIcon={MagnifyingGlassIcon}
             />
-          </div>
-        </div>
-      </div>
-
-      {/* Body — constrained */}
-      <div
-        style={{
-          display: 'flex',
-          flex: 1,
-          overflow: 'hidden',
-          maxWidth: 1000,
-          margin: '0 auto',
-          width: '100%',
-        }}>
-        {/* Sidebar */}
-        <nav
-          style={{
-            width: 240,
-            paddingTop: 16,
-            paddingLeft: 12,
-            paddingRight: 12,
-            paddingBottom: 8,
-            borderRight: '1px solid var(--xds-color-border-primary, #e5e5e5)',
-            flexShrink: 0,
-            overflowY: 'auto',
-          }}>
-          <XDSList density="compact">
-            {NAV_ITEMS.map(item => (
-              <XDSListItem
-                key={item}
-                label={item}
-                isSelected={activeNav === item}
-                onClick={() => setActiveNav(item)}
-              />
-            ))}
-          </XDSList>
-        </nav>
-
-        {/* Content */}
-        <div style={{flex: 1, padding: 16, maxWidth: 960, overflowY: 'auto'}}>
-          <XDSVStack gap={4}>
-            {/* Basic information */}
-            <div
-              style={{
-                display: 'grid',
-                gridTemplateColumns: '1fr 1fr',
-                gap: 40,
-              }}>
-              <div>
-                <XDSVStack gap={1}>
-                  <XDSHeading level={3}>Basic information</XDSHeading>
-                  <XDSText type="supporting" color="secondary">
-                    View and update your personal details and account
-                    information.
-                  </XDSText>
-                </XDSVStack>
-              </div>
-              <div>
-                <XDSVStack gap={4}>
-                  <XDSTextInput
-                    label="Username"
-                    value={username}
-                    onChange={setUsername}
-                  />
-                  <XDSTextInput
-                    label="First name"
-                    value={firstName}
-                    onChange={setFirstName}
-                  />
-                  <XDSTextInput
-                    label="Last name"
-                    value={lastName}
-                    onChange={setLastName}
-                  />
-                  <XDSTextInput
-                    label="Email address"
-                    value={email}
-                    onChange={setEmail}
-                  />
-                  <div>
-                    <XDSButton label="Save" variant="primary" />
-                  </div>
-                </XDSVStack>
-              </div>
-            </div>
-
-            <XDSDivider />
-
-            {/* Change password */}
-            <div
-              style={{
-                display: 'grid',
-                gridTemplateColumns: '1fr 1fr',
-                gap: 40,
-              }}>
-              <div>
-                <XDSVStack gap={1}>
-                  <XDSHeading level={3}>Change password</XDSHeading>
-                  <XDSText type="supporting" color="secondary">
-                    Update your password to keep your account secure.
-                  </XDSText>
-                </XDSVStack>
-              </div>
-              <div>
-                <XDSVStack gap={4}>
-                  <XDSTextInput
-                    label="Verify current password"
-                    type="password"
-                    value={currentPw}
-                    onChange={setCurrentPw}
-                  />
-                  <XDSTextInput
-                    label="New password"
-                    type="password"
-                    value={newPw}
-                    onChange={setNewPw}
-                  />
-                  <XDSTextInput
-                    label="Confirm password"
-                    type="password"
-                    value={confirmPw}
-                    onChange={setConfirmPw}
-                  />
-                  <div>
-                    <XDSButton label="Save" variant="primary" />
-                  </div>
-                </XDSVStack>
-              </div>
-            </div>
-
-            <XDSDivider />
-
-            {/* Advanced settings */}
-            <div
-              style={{
-                display: 'grid',
-                gridTemplateColumns: '1fr 1fr',
-                gap: 40,
-              }}>
-              <div>
-                <XDSVStack gap={1}>
-                  <XDSHeading level={3}>Advanced settings</XDSHeading>
-                  <XDSText type="supporting" color="secondary">
-                    Configure detailed account preferences and security options.
-                  </XDSText>
-                </XDSVStack>
-              </div>
-              <div>
-                <XDSVStack gap={5}>
-                  <XDSCheckboxInput
-                    label="Data Export Access"
-                    description="Allow export of personal data and backups."
-                    value={dataExport}
-                    onChange={setDataExport}
-                  />
-                  <XDSCheckboxInput
-                    label="Allow Admin to Add Members"
-                    description="Admins can invite and manage members."
-                    value={adminMembers}
-                    onChange={setAdminMembers}
-                  />
-                  <XDSCheckboxInput
-                    label="Enable Two-Factor Authentication"
-                    description="Require 2FA for added account security."
-                    value={twoFactor}
-                    onChange={setTwoFactor}
-                  />
-                  <div>
-                    <XDSButton label="Save" variant="primary" />
-                  </div>
-                </XDSVStack>
-              </div>
-            </div>
+          }
+        />
+      }
+      sideNav={
+        <XDSSideNav>
+          {NAV_ITEMS.map(item => (
+            <XDSSideNavItem
+              key={item.label}
+              label={item.label}
+              icon={item.icon}
+              isSelected={activeNav === item.label}
+              onClick={() => setActiveNav(item.label)}
+            />
+          ))}
+        </XDSSideNav>
+      }>
+      <XDSVStack gap={6}>
+        <XDSGrid columns={{minWidth: 280, max: 2}} gap={7}>
+          <XDSVStack gap={1}>
+            <XDSHeading level={3}>Basic information</XDSHeading>
+            <XDSText type="supporting" color="secondary">
+              View and update your personal details and account information.
+            </XDSText>
           </XDSVStack>
-        </div>
-      </div>
-    </div>
+          <XDSFormLayout>
+            <XDSTextInput
+              label="Username"
+              value={username}
+              onChange={setUsername}
+            />
+            <XDSTextInput
+              label="First name"
+              value={firstName}
+              onChange={setFirstName}
+            />
+            <XDSTextInput
+              label="Last name"
+              value={lastName}
+              onChange={setLastName}
+            />
+            <XDSTextInput
+              label="Email address"
+              value={email}
+              onChange={setEmail}
+            />
+            <XDSButton label="Save" variant="primary" />
+          </XDSFormLayout>
+        </XDSGrid>
+
+        <XDSDivider />
+
+        <XDSGrid columns={{minWidth: 280, max: 2}} gap={7}>
+          <XDSVStack gap={1}>
+            <XDSHeading level={3}>Change password</XDSHeading>
+            <XDSText type="supporting" color="secondary">
+              Update your password to keep your account secure.
+            </XDSText>
+          </XDSVStack>
+          <XDSFormLayout>
+            <XDSTextInput
+              label="Verify current password"
+              type="password"
+              value={currentPw}
+              onChange={setCurrentPw}
+            />
+            <XDSTextInput
+              label="New password"
+              type="password"
+              value={newPw}
+              onChange={setNewPw}
+            />
+            <XDSTextInput
+              label="Confirm password"
+              type="password"
+              value={confirmPw}
+              onChange={setConfirmPw}
+            />
+            <XDSButton label="Save" variant="primary" />
+          </XDSFormLayout>
+        </XDSGrid>
+
+        <XDSDivider />
+
+        <XDSGrid columns={{minWidth: 280, max: 2}} gap={7}>
+          <XDSVStack gap={1}>
+            <XDSHeading level={3}>Advanced settings</XDSHeading>
+            <XDSText type="supporting" color="secondary">
+              Configure detailed account preferences and security options.
+            </XDSText>
+          </XDSVStack>
+          <XDSVStack gap={5}>
+            <XDSCheckboxInput
+              label="Data Export Access"
+              description="Allow export of personal data and backups."
+              value={dataExport}
+              onChange={setDataExport}
+            />
+            <XDSCheckboxInput
+              label="Allow Admin to Add Members"
+              description="Admins can invite and manage members."
+              value={adminMembers}
+              onChange={setAdminMembers}
+            />
+            <XDSCheckboxInput
+              label="Enable Two-Factor Authentication"
+              description="Require 2FA for added account security."
+              value={twoFactor}
+              onChange={setTwoFactor}
+            />
+            <XDSButton label="Save" variant="primary" />
+          </XDSVStack>
+        </XDSGrid>
+      </XDSVStack>
+    </XDSAppShell>
   );
 }

--- a/packages/cli/templates/pages/settings/template.doc.mjs
+++ b/packages/cli/templates/pages/settings/template.doc.mjs
@@ -2,6 +2,6 @@
 export const doc = {
   type: 'page',
   name: 'Settings',
-  description: 'Basic account settings page',
+  description: 'Account settings page with profile, password, and advanced configuration sections',
   isReady: true,
 };


### PR DESCRIPTION
## Summary

- Upgrades all three `settings` page templates toward Grade A on the template grading rubric
- Preserves the original visual design, component patterns (InfoRowItem, ExpandableRow, icon boxes), data shapes, and interaction models
- Only changes what the rubric penalizes: raw HTML → XDS layout components, raw Heroicons → XDSIcon, inline styles → component props, missing AppShell → AppShell wrapper
- **Settings (basic) layout refinements**: constrained page width (`maxWidth: 1100`, centered), header alignment padding, sidebar `minWidth: 240`, balanced list density

## Templates upgraded

### `settings` (basic) — Grade A (90/100)
| Category | Before | After | Max | Notes |
|----------|--------|-------|-----|-------|
| XDS Component Purity | 4 | 30 | 30 | 0 raw HTML (was 11 raw `<div>` elements) |
| Icon Purity | 15 | 15 | 15 | 0 raw SVG |
| Custom CSS | 0 | 5 | 15 | 4 properties: `maxWidth`, `marginInline` (page constraint), `padding` (header), `minWidth` (sidebar) |
| Layout & Structure | 0 | 15 | 15 | `XDSAppShell` with `topNav` + `sideNav` slots |
| Doc Metadata | 10 | 10 | 10 | All fields present |
| Image Handling | 5 | 5 | 5 | No images |
| Code Quality | 8 | 10 | 10 | All 5 checks pass |
| **TOTAL** | **42 (D)** | **90 (A)** | **100** | |

### `settings-sidebar` — Grade B (87/100)
| Category | Before | After | Max | Notes |
|----------|--------|-------|-----|-------|
| XDS Component Purity | 0 | 30 | 30 | 0 raw HTML |
| Icon Purity | 0 | 15 | 15 | 0 raw SVGs; all use `<XDSIcon>` |
| Custom CSS | 0 | 2 | 15 | 18 declarations across 6 style objects |
| Layout & Structure | 0 | 15 | 15 | AppShell with sideNav slot, single page |
| Doc Metadata | 10 | 10 | 10 | All 4 required fields present and accurate |
| Image Handling | 5 | 5 | 5 | No images |
| Code Quality | 8 | 10 | 10 | All 5 checks pass |
| **TOTAL** | **23 (F)** | **87 (B)** | **100** | |

### `settings-dialog` — Grade B (85/100)
| Category | Before | After | Max | Notes |
|----------|--------|-------|-----|-------|
| XDS Component Purity | 0 | 30 | 30 | 0 raw HTML |
| Icon Purity | 5 | 15 | 15 | 0 raw SVGs (was rendering XMarkIcon without XDSIcon wrapper) |
| Custom CSS | 0 | 0 | 15 | 22 declarations across 11 style objects (see breakdown) |
| Layout & Structure | 0 | 15 | 15 | AppShell top-level, Layout scoped inside dialog |
| Doc Metadata | 10 | 10 | 10 | All 4 required fields present |
| Image Handling | 5 | 5 | 5 | No images |
| Code Quality | 8 | 10 | 10 | All 5 checks pass |
| **TOTAL** | **28 (F)** | **85 (B)** | **100** | |

**Custom CSS breakdown (22 properties)**:
- `iconBox` (3): borderRadius, backgroundColor, flexShrink — 48×48 rounded icon container, no XDS equivalent
- `rowPadding` (1): paddingBlock — vertical-only row spacing
- `cardContentPadding` (1): paddingInline — padding inside Card with `padding={0}`
- `headerPadding` (6): paddingInline, paddingBlock, position, top, backgroundColor, zIndex — sticky dialog header
- `contentHPadding` (3): paddingInline, paddingBlockEnd, maxWidth — content area padding + width constraint
- `sideNavPadding` (2): paddingBlock, paddingInline — asymmetric nav padding
- `sectionHeading` (1): paddingBlockEnd — spacing between section headings and dividers
- `sideNavHeading` (1): marginInline — heading alignment within sideNav
- `dialogHeight` (2): height, minHeight — fixed dialog height (Dialog only has maxHeight prop)
- `layoutFill` (1): flex — ensure Layout fills dialog
- `panelFull` (1): height — ensure panel fills layout

## Issues found and fixed (settings-dialog)

1. **Missing import crash**: `XDSDialogHeader` used but never imported — caused `ReferenceError` and 500 on `/templates/settings-dialog/`
2. **Wrong icon background color**: `iconBox` used `--xds-color-background-muted` (gray) instead of `--xds-color-background-surface` (white) — icons blended into muted cards instead of standing out
3. **No section heading spacing**: Headings like "Login", "Social accounts" sat flush against dividers with no breathing room — added `paddingBlockEnd: 8` via `sectionHeading` style
4. **Missing device history dividers**: Device rows had no dividers between them (unlike Login/Social rows using InfoRowItem) — added per-row dividers via `React.Fragment`
5. **Dialog header scrolled away**: Title and close button scrolled out of view — made header sticky with `position: sticky`
6. **Dialog header padding**: Header was inside the padded content VStack, getting extra 24px inline padding — moved outside and given its own 8px padding
7. **Redundant XDSSection/XMarkIcon**: Unused imports from original refactor — cleaned up
8. **Longhand CSS properties**: Used `paddingTop`/`paddingLeft` etc. instead of logical properties — converted to `paddingBlock`/`paddingInline`

## Known issues

### `settings-sidebar` content centering (Grade B, not A)
The content area needs `maxWidth: 700` + `marginLeft/Right: 'auto'` for centering, plus custom padding (48px horizontal, asymmetric sideNav padding). `XDSSection`'s `nestedStyles.outer` applies `marginInline: calc(-1 * var(--container-padding-inline))` which overrides centering margin. Only working approach uses plain `XDSVStack` with 5 custom CSS properties.

### `settings-dialog` custom CSS count (Grade B, not A)
22 custom CSS declarations across 11 style objects. The largest contributors:
- **`headerPadding` (6 props)**: Sticky positioning + padding for the dialog header. `XDSDialogHeader` doesn't support `xstyle` or sticky behavior natively.
- **`iconBox` (3 props)**: 48×48 rounded icon container with surface background. No XDS component provides this pattern.
- **`contentHPadding` (3 props)**: Content padding + max-width. `XDSLayoutContent` doesn't support `maxWidth` or asymmetric padding.

**To reach Grade A**: Need ≤10 declarations (would score 5/15). Potential approaches:
- Add `xstyle` support to `XDSDialogHeader` (removes need for wrapper + 6 sticky props)
- Add `maxWidth` prop to `XDSLayoutContent` (removes 1 prop)
- Create an XDS icon-box component (removes 3 props)

## Test plan

- [x] Settings basic: sidebar nav items aligned with header text
- [x] Settings basic: page width constrained and centered
- [x] Settings basic: sidebar width sufficient for nav items
- [x] Settings dialog: dialog header sticky on scroll
- [x] Settings dialog: icon boxes have white background on muted cards
- [x] Settings dialog: section headings have spacing before dividers
- [x] Settings dialog: device history rows have dividers
- [ ] Visual check: all three templates render correctly with AppShell
- [ ] Verify sidebar nav selection state works across all templates
- [ ] Verify dialog open/close flow works (settings-dialog)
- [ ] Verify expandable rows expand/collapse (settings-sidebar, settings-dialog)
- [ ] Verify tab switching works in Login & security section