### PR TITLE
fix(sandbox): migrate to @xds/build for proper CSS layer isolation

### DIFF
--- a/apps/sandbox/babel.config.js
+++ b/apps/sandbox/babel.config.js
@@ -1,28 +1,4 @@
-/* global module, process, __dirname */
+/* global module, __dirname */
 const path = require('path');
-
-const rootDir = path.resolve(__dirname, '../..');
-
-module.exports = {
-  presets: ['next/babel'],
-  plugins: [
-    [
-      '@stylexjs/babel-plugin',
-      {
-        dev: process.env.NODE_ENV === 'development',
-        runtimeInjection: false,
-        genConditionalClasses: true,
-        treeshakeCompensation: true,
-        unstable_moduleResolution: {
-          type: 'commonJS',
-          rootDir,
-        },
-      },
-    ],
-  ],
-  // Don't run StyleX babel plugin on pre-built dist files —
-  // their CSS is already compiled and shipped via xds.css imports.
-  ignore: [
-    '**/packages/core/dist/**',
-  ],
-};
+const {babel} = require('@xds/build');
+module.exports = babel(path.resolve(__dirname, '../..'));

--- a/apps/sandbox/next.config.mjs
+++ b/apps/sandbox/next.config.mjs
@@ -1,19 +1,4 @@
-/**
- * @file next.config.mjs
- * @description Next.js configuration for the XDS sandbox app.
- *
- * Supports two dev modes controlled by the XDS_SOURCE env var:
- *
- * - **Default** (XDS_SOURCE unset): Resolves @xds/core from dist/.
- *   CSS layers and theming work correctly. Pair with `yarn workspace @xds/core dev`
- *   in a second terminal for near-hot-reload via incremental dist rebuilds.
- *
- * - **Source mode** (XDS_SOURCE=1): Resolves @xds/core from TypeScript source.
- *   Instant hot reload (~200ms), but CSS layer separation is lost — theming
- *   won't work. Best for layout and behavior iteration.
- */
-
-const useSource = process.env.XDS_SOURCE === '1';
+import {withXDS} from '@xds/build/next';
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
@@ -24,46 +9,12 @@ const nextConfig = {
   env: {
     NEXT_PUBLIC_BASE_PATH: process.env.SANDBOX_BASE_PATH || '',
   },
-  transpilePackages: [
-    // Only transpile @xds/core in source mode — in dist mode, it's pre-built.
-    // Theme packages are NOT listed here — their exports already resolve to
-    // pre-compiled dist/ files (ESM + CSS), so re-transpilation is wasted work.
-    ...(useSource ? ['@xds/core'] : []),
-  ],
   images: {
     unoptimized: true,
   },
   typescript: {
     ignoreBuildErrors: false,
   },
-  webpack: useSource
-    ? (config) => {
-        // Prefer "source" exports condition so @xds/core resolves to src/ TypeScript.
-        // This enables hot reload when editing packages/core/src/ files.
-        config.resolve.conditionNames = [
-          'source',
-          'import',
-          'require',
-          'default',
-        ];
-
-        // Remove packages/core from snapshot managedPaths so webpack
-        // doesn't treat it as an immutable dependency.
-        config.snapshot = {
-          ...config.snapshot,
-          managedPaths: [],
-        };
-
-        // Poll as fallback — FSEvents can miss changes through symlinks.
-        config.watchOptions = {
-          ...config.watchOptions,
-          poll: 1000,
-          followSymlinks: true,
-        };
-
-        return config;
-      }
-    : undefined,
 };
 
-export default nextConfig;
+export default withXDS(nextConfig);

--- a/apps/sandbox/package.json
+++ b/apps/sandbox/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "build:deps": "yarn workspace @xds/core build && yarn workspace @xds/theme-default build && yarn workspace @xds/theme-neutral build && yarn workspace @xds/theme-brutalist build && yarn workspace @xds/theme-meta build && yarn workspace @xds/theme-whatsapp build && yarn workspace @xds/theme-daily build",
+    "build:deps": "yarn workspace @xds/theme-default build && yarn workspace @xds/theme-neutral build && yarn workspace @xds/theme-brutalist build && yarn workspace @xds/theme-meta build && yarn workspace @xds/theme-whatsapp build && yarn workspace @xds/theme-daily build",
     "generate:versions": "node scripts/generate-versions.js",
     "predev": "node ../../scripts/sync-templates.js && yarn generate:versions",
     "dev": "node ../../scripts/sync-templates.js --watch & next dev",
@@ -37,6 +37,7 @@
     "@types/node": "^25.6.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "@xds/build": "*"
   }
 }

--- a/apps/sandbox/postcss.config.js
+++ b/apps/sandbox/postcss.config.js
@@ -1,33 +1,10 @@
 /* global module, __dirname */
 const path = require('path');
-const babelConfig = require('./babel.config');
+const {postcss} = require('@xds/build');
 
 const rootDir = path.resolve(__dirname, '../..');
 
-module.exports = {
-  plugins: {
-    '@stylexjs/postcss-plugin': {
-      include: [
-        'src/**/*.{js,jsx,ts,tsx}',
-        path.join(rootDir, 'packages/core/src/**/*.{ts,tsx}'),
-        path.join(rootDir, 'packages/cli/templates/**/*.{ts,tsx}'),
-        path.join(rootDir, 'packages/themes/default/src/**/*.{ts,tsx}'),
-        path.join(rootDir, 'packages/themes/neutral/src/**/*.{ts,tsx}'),
-      ],
-      babelConfig: {
-        babelrc: false,
-        parserOpts: {
-          plugins: ['typescript', 'jsx'],
-        },
-        presets: [
-          ['@babel/preset-react', {runtime: 'automatic'}],
-          // Must come after preset-react (runs first due to reverse order)
-          // to strip TypeScript type assertions before StyleX evaluates them.
-          '@babel/preset-typescript',
-        ],
-        plugins: babelConfig.plugins,
-      },
-      useCSSLayers: true,
-    },
-  },
-};
+module.exports = postcss(rootDir, {
+  appDir: path.relative(rootDir, path.resolve(__dirname, 'src')),
+  extraInclude: ['packages/cli/templates/**/*.{ts,tsx}'],
+});

--- a/apps/sandbox/src/app/globals.css
+++ b/apps/sandbox/src/app/globals.css
@@ -1,1 +1,10 @@
+@import "./layers.css";
+@import "@xds/core/reset.css";
+@import "@xds/theme-default/theme.css";
+@import "@xds/theme-neutral/theme.css";
+@import "@xds/theme-brutalist/theme.css";
+@import "@xds/theme-meta/theme.css";
+@import "@xds/theme-whatsapp/theme.css";
+@import "@xds/theme-daily/theme.css";
+
 @stylex;

--- a/apps/sandbox/src/app/layers.css
+++ b/apps/sandbox/src/app/layers.css
@@ -1,0 +1,5 @@
+/* Layer order declaration — must be the first CSS in the bundle.
+   Separate file because webpack hoists @import content above inline
+   CSS, so an inline @layer statement in globals.css would appear
+   after reset.css and theme.css content in the output. */
+@layer reset, xds-base, xds-theme, product;

--- a/apps/sandbox/src/app/layout.tsx
+++ b/apps/sandbox/src/app/layout.tsx
@@ -1,28 +1,4 @@
 import type {Metadata} from 'next';
-
-/**
- * XDS CSS Layer Model (dist path)
- *
- * Import order establishes CSS layer priority (lowest → highest):
- *   1. @xds/core/reset.css            → @layer reset  (reset styles)
- *   2. @xds/core/xds.css              → @layer xds-base   (component base styles)
- *   3. @xds/theme-default/theme.css   → @layer xds-theme  (default theme)
- *   4. @xds/theme-neutral/theme.css   → @layer xds-theme  (neutral theme)
- *   5. @xds/theme-brutalist/theme.css → @layer xds-theme  (brutalist theme)
- *   6. @xds/theme-meta/theme.css      → @layer xds-theme  (meta theme)
- *
- * All theme CSS files are in @layer xds-theme and scoped via
- * @scope ([data-xds-theme="name"]), so only the active theme's rules apply.
- *
- * Product/consumer styles sit unlayered (outside layers) and naturally
- * win over all XDS layers without needing !important.
- */
-import '@xds/core/reset.css';
-import '@xds/core/xds.css';
-import '@xds/theme-default/theme.css';
-import '@xds/theme-neutral/theme.css';
-import '@xds/theme-brutalist/theme.css';
-import '@xds/theme-meta/theme.css';
 import './globals.css';
 import {Providers} from './providers';
 

--- a/packages/build/src/config.js
+++ b/packages/build/src/config.js
@@ -75,6 +75,7 @@ function postcss(rootDir, overrides = {}) {
   return {
     plugins: {
       [require.resolve('./index.js')]: {
+        cwd: rootDir,
         appDir,
         babelPlugins: [
           ['@stylexjs/babel-plugin', stylexOptions(rootDir, rest)],


### PR DESCRIPTION
## Summary

Migrates the sandbox app from the raw `@stylexjs/postcss-plugin` to `@xds/build`, fixing a CSS layer leak where 21KB of styles escaped layer containment.

### The bug

The sandbox used `@stylexjs/postcss-plugin` with `useCSSLayers: true` — StyleX's native layer support. This leaked content outside all layers:
- **18 `@property` declarations** — unlayered
- **15 `@keyframes`** — unlayered
- **169 atomic CSS rules** — unlayered

Unlayered rules beat everything inside layers, which broke theme overrides and cascade ordering.

### The fix

Replace with `@xds/build`, which:
1. Compiles library and product StyleX in **separate passes** with different class name prefixes (`xds` vs `x`)
2. **Wraps each in its own CSS layer** — library in `@layer xds-base`, product in `@layer product`
3. Declares layer order upfront: `reset → xds-base → xds-theme → product`

### Before → After

| | Before | After |
|---|---|---|
| Content outside layers | 21,543 chars | **0** |
| Library/product separation | None | 1,591 `xds`-prefixed + 1,836 `x`-prefixed |
| Layer structure | Bare `priority1-9` at top level | Proper `reset → xds-base → xds-theme → product` |

### Other changes

- **Removes dist/source dual-mode** — sandbox is now purely source-mode via `withXDS()`, matching `example-nextjs-source`
- **`build:deps` no longer builds `@xds/core`** — unnecessary in source mode
- **`@xds/build` config.js** — passes `cwd: rootDir` so the postcss plugin globs from the monorepo root (fixes hoisted `node_modules/@xds` symlinks)
