### PR TITLE
refactor(theme): remove cssProperties, clean up derived/vars, migrate meta theme

### DIFF
--- a/packages/cli/src/lib/component-format.mjs
+++ b/packages/cli/src/lib/component-format.mjs
@@ -212,19 +212,18 @@ export function formatFull(docs, options = {}) {
       sections.push(`Component key: \`${docs.theming.componentKey}\`\n`);
     }
 
-    // Public CSS custom properties
-    if (docs.theming?.cssProperties?.length) {
-      const propLines = [];
-      propLines.push('| CSS Property | Description | Default |');
-      propLines.push('|-------------|-------------|---------|');
-      for (const p of docs.theming.cssProperties) {
-        propLines.push(`| \`${p.name}\` | ${p.description} | ${p.default || '—'} |`);
-      }
-      sections.push(propLines.join('\n') + '\n');
-    }
-
-    // Component CSS vars
+    // Component CSS vars — additional themeable properties
     if (docs.theming?.vars?.length) {
+      sections.push('**Themeable CSS variables** — additional properties that can be overridden in `defineTheme` component overrides.\n');
+
+      // Build a set of vars that are derived from standard CSS properties
+      const derivedVarNames = new Set();
+      if (docs.theming?.derived?.length) {
+        for (const d of docs.theming.derived) {
+          if (d.vars) d.vars.forEach(v => derivedVarNames.add(v));
+        }
+      }
+
       const varLines = [];
       varLines.push('| CSS Variable | Default | Description |');
       varLines.push('|-------------|---------|-------------|');
@@ -232,17 +231,35 @@ export function formatFull(docs, options = {}) {
         if (v.derived) {
           varLines.push(`| \`${v.name}\` | _(derived)_ | ${v.description} |`);
         } else {
-          varLines.push(`| \`${v.name}\` | \`${v.default}\` | ${v.description} |`);
+          const derivedNote = derivedVarNames.has(v.name) ? ' _(set via standard CSS property)_' : '';
+          varLines.push(`| \`${v.name}\` | \`${v.default}\` | ${v.description}${derivedNote} |`);
         }
       }
       sections.push(varLines.join('\n') + '\n');
 
-      // Show var override example
-      const overridableVars = docs.theming.vars.filter(v => !v.derived);
-      if (overridableVars.length > 0) {
-        const exampleVar = overridableVars[0];
+      // Show derived property examples if available
+      if (docs.theming?.derived?.length) {
         const varsKey = docs.theming.targets?.length ? targetKey(docs.theming.targets[0]) : docs.theming.componentKey || '';
-        sections.push('Override CSS vars in defineTheme:\n```ts\ncomponents: {\n  ' + varsKey + ': {\n    base: { \'' + exampleVar.name + '\': \'...\' },\n  },\n}\n```\n');
+        const derivedExamples = docs.theming.derived
+          .filter(d => d.vars?.length)
+          .map(d => `      ${d.property}: '...',  // also sets ${d.vars.join(', ')}`)
+          .join('\n');
+        const expandExamples = docs.theming.derived
+          .filter(d => d.expand === 'container')
+          .map(d => `      ${d.property}: '...',  // expands to container layout tokens`)
+          .join('\n');
+        const allExamples = [derivedExamples, expandExamples].filter(Boolean).join('\n');
+        if (allExamples) {
+          sections.push('Some vars can be set by writing standard CSS properties:\n```ts\ncomponents: {\n  ' + varsKey + ': {\n    base: {\n' + allExamples + '\n    },\n  },\n}\n```\n');
+        }
+      } else {
+        // Fallback: show raw var override example
+        const overridableVars = docs.theming.vars.filter(v => !v.derived);
+        if (overridableVars.length > 0) {
+          const exampleVar = overridableVars[0];
+          const varsKey = docs.theming.targets?.length ? targetKey(docs.theming.targets[0]) : docs.theming.componentKey || '';
+          sections.push('Override CSS vars in defineTheme:\n```ts\ncomponents: {\n  ' + varsKey + ': {\n    base: { \'' + exampleVar.name + '\': \'...\' },\n  },\n}\n```\n');
+        }
       }
     }
   }
@@ -311,14 +328,16 @@ export function formatCompact(docs, componentName, importHint) {
     }
   }
 
-  // CSS custom properties (compact includes these for theme consumers)
-  if (docs.theming?.cssProperties?.length) {
-    sections.push('## CSS Properties\n');
+  // Derived theming properties (compact includes these for theme consumers)
+  if (docs.theming?.derived?.length) {
+    sections.push('## Derived Theme Properties\n');
+    sections.push('Standard CSS properties that also set internal vars:\n');
     const propLines = [];
-    propLines.push('| CSS Property | Description | Default |');
-    propLines.push('|-------------|-------------|---------|');
-    for (const p of docs.theming.cssProperties) {
-      propLines.push(`| \`${p.name}\` | ${p.description} | ${p.default || '—'} |`);
+    propLines.push('| CSS Property | Sets |');
+    propLines.push('|-------------|------|');
+    for (const d of docs.theming.derived) {
+      const target = d.expand === 'container' ? 'container layout tokens' : (d.vars || []).map(v => `\`${v}\``).join(', ');
+      propLines.push(`| \`${d.property}\` | ${target} |`);
     }
     sections.push(propLines.join('\n') + '\n');
   }
@@ -404,12 +423,12 @@ export function formatBrief(docs, componentName, importHint, options = {}) {
     }
   }
 
-  // CSS custom properties (if any)
-  if (docs.theming?.cssProperties?.length) {
-    const cssPropNames = docs.theming.cssProperties
-      .map(p => `${p.name} (${p.default || '—'})`)
-      .join(', ');
-    output.push(`  CSS Props: ${cssPropNames}`);
+  // Derived properties (if any)
+  if (docs.theming?.derived?.length) {
+    const derivedNames = docs.theming.derived
+      .map(d => d.expand === 'container' ? `${d.property} → container tokens` : `${d.property} → ${(d.vars || []).join(', ')}`)
+      .join('; ');
+    output.push(`  Derived: ${derivedNames}`);
   }
 
 // Theme targets (class names, variants, states) with theme variant merging

--- a/packages/core/src/Banner/Banner.doc.mjs
+++ b/packages/core/src/Banner/Banner.doc.mjs
@@ -94,7 +94,7 @@ export const docs = {
       {name: '--banner-radius', description: 'Border radius (card container only)', default: 'var(--radius-container)'},
     ],
     derived: [
-      {property: 'borderRadius', description: 'Border radius of the banner', default: 'var(--radius-container)', vars: ['--banner-radius']},
+      {property: 'borderRadius', vars: ['--banner-radius']},
     ],
   },
 };
@@ -158,7 +158,7 @@ export const docsZh = {
       {name: '--banner-radius', description: 'Border radius (card container only)', default: 'var(--radius-container)'},
     ],
     derived: [
-      {property: 'borderRadius', description: 'Border radius of the banner', default: 'var(--radius-container)', vars: ['--banner-radius']},
+      {property: 'borderRadius', vars: ['--banner-radius']},
     ],
   },
 };

--- a/packages/core/src/Button/Button.doc.mjs
+++ b/packages/core/src/Button/Button.doc.mjs
@@ -130,7 +130,7 @@ export const docs = {
       {name: '--button-icon-only-aspect', description: 'Aspect ratio for icon-only buttons', default: '1 / 1'},
     ],
     derived: [
-      {property: 'borderRadius', description: 'Border radius of buttons', default: 'var(--radius-element)', vars: ['--button-radius']},
+      {property: 'borderRadius', vars: ['--button-radius']},
     ],
   },
 };
@@ -208,7 +208,7 @@ export const docsZh = {
       {name: '--button-icon-only-aspect', description: '纯图标按钮的宽高比', default: '1 / 1'},
     ],
     derived: [
-      {property: 'borderRadius', description: 'Border radius of buttons', default: 'var(--radius-element)', vars: ['--button-radius']},
+      {property: 'borderRadius', vars: ['--button-radius']},
     ],
   },
 };

--- a/packages/core/src/Card/Card.doc.mjs
+++ b/packages/core/src/Card/Card.doc.mjs
@@ -65,17 +65,9 @@ export const docs = {
     vars: [
       {name: '--card-radius', description: 'Border radius of the card', default: 'var(--radius-container)'},
     ],
-    cssProperties: [
-      {
-        name: 'padding',
-        description:
-          "Controls Card container padding. Accepts standard CSS padding shorthand (e.g. '16px 20px'). Automatically mapped to container tokens for layout integration. Supports paddingBlock/paddingInline for axis-specific control.",
-        default: 'var(--spacing-4)',
-      },
-    ],
     derived: [
-      {property: 'borderRadius', description: 'Border radius of the card', default: 'var(--radius-container)', vars: ['--card-radius']},
-      {property: 'padding', description: 'Container padding of the card', default: 'var(--spacing-4)', expand: 'container'},
+      {property: 'borderRadius', vars: ['--card-radius']},
+      {property: 'padding', expand: 'container'},
     ],
   },
 };
@@ -113,17 +105,9 @@ export const docsZh = {
     vars: [
       {name: '--card-radius', description: 'Border radius of the card', default: 'var(--radius-container)'},
     ],
-    cssProperties: [
-      {
-        name: 'padding',
-        description:
-          "Controls Card container padding. Accepts standard CSS padding shorthand (e.g. '16px 20px'). Automatically mapped to container tokens for layout integration. Supports paddingBlock/paddingInline for axis-specific control.",
-        default: 'var(--spacing-4)',
-      },
-    ],
     derived: [
-      {property: 'borderRadius', description: 'Border radius of the card', default: 'var(--radius-container)', vars: ['--card-radius']},
-      {property: 'padding', description: 'Container padding of the card', default: 'var(--spacing-4)', expand: 'container'},
+      {property: 'borderRadius', vars: ['--card-radius']},
+      {property: 'padding', expand: 'container'},
     ],
   },
 };

--- a/packages/core/src/Chat/Chat.doc.mjs
+++ b/packages/core/src/Chat/Chat.doc.mjs
@@ -25,8 +25,8 @@ export const docs = {
       {name: '--button-radius', description: 'Concentric button radius inside the composer.', default: 'max(var(--radius-element), calc(var(--composer-radius) - var(--composer-padding)))', derived: true, formula: 'max(var(--radius-element), calc(var(--composer-radius) - var(--composer-padding)))'},
     ],
     derived: [
-      {property: 'borderRadius', description: 'Border radius of the composer. Inner elements derive their radius concentrically.', default: 'var(--radius-page)', vars: ['--composer-radius']},
-      {property: 'padding', description: 'Padding of the composer. Used in the concentric radius calculation.', default: 'var(--spacing-3)', vars: ['--composer-padding']},
+      {property: 'borderRadius', vars: ['--composer-radius']},
+      {property: 'padding', vars: ['--composer-padding']},
     ],
   },
   components: [

--- a/packages/core/src/Dialog/Dialog.doc.mjs
+++ b/packages/core/src/Dialog/Dialog.doc.mjs
@@ -11,17 +11,9 @@ export const docs = {
     vars: [
       {name: '--dialog-radius', description: 'Border radius of the dialog', default: 'var(--radius-container)'},
     ],
-    cssProperties: [
-      {
-        name: 'padding',
-        description:
-          "Controls Dialog container padding. Accepts standard CSS padding shorthand (e.g. '16px 20px'). Automatically mapped to container tokens for layout integration.",
-        default: 'var(--spacing-4)',
-      },
-    ],
     derived: [
-      {property: 'borderRadius', description: 'Border radius of the dialog', default: 'var(--radius-container)', vars: ['--dialog-radius']},
-      {property: 'padding', description: 'Container padding of the dialog', default: 'var(--spacing-4)', expand: 'container'},
+      {property: 'borderRadius', vars: ['--dialog-radius']},
+      {property: 'padding', expand: 'container'},
     ],
   },
   components: [
@@ -151,17 +143,9 @@ export const docsZh = {
     vars: [
       {name: '--dialog-radius', description: 'Border radius of the dialog', default: 'var(--radius-container)'},
     ],
-    cssProperties: [
-      {
-        name: 'padding',
-        description:
-          "Controls Dialog container padding. Accepts standard CSS padding shorthand (e.g. '16px 20px'). Automatically mapped to container tokens for layout integration.",
-        default: 'var(--spacing-4)',
-      },
-    ],
     derived: [
-      {property: 'borderRadius', description: 'Border radius of the dialog', default: 'var(--radius-container)', vars: ['--dialog-radius']},
-      {property: 'padding', description: 'Container padding of the dialog', default: 'var(--spacing-4)', expand: 'container'},
+      {property: 'borderRadius', vars: ['--dialog-radius']},
+      {property: 'padding', expand: 'container'},
     ],
   },
   components: [

--- a/packages/core/src/DropdownMenu/DropdownMenu.doc.mjs
+++ b/packages/core/src/DropdownMenu/DropdownMenu.doc.mjs
@@ -13,8 +13,8 @@ export const docs = {
       {name: '--dropdown-padding', description: 'Inner padding of the menu popup', default: 'var(--spacing-1)'},
     ],
     derived: [
-      {property: 'borderRadius', description: 'Border radius of the menu popup', default: 'var(--radius-element)', vars: ['--dropdown-radius']},
-      {property: 'padding', description: 'Inner padding of the menu popup', default: 'var(--spacing-1)', vars: ['--dropdown-padding']},
+      {property: 'borderRadius', vars: ['--dropdown-radius']},
+      {property: 'padding', vars: ['--dropdown-padding']},
     ],
   },
   components: [
@@ -198,8 +198,8 @@ export const docsZh = {
       {name: '--dropdown-padding', description: 'Inner padding of the menu popup', default: 'var(--spacing-1)'},
     ],
     derived: [
-      {property: 'borderRadius', description: 'Border radius of the menu popup', default: 'var(--radius-element)', vars: ['--dropdown-radius']},
-      {property: 'padding', description: 'Inner padding of the menu popup', default: 'var(--spacing-1)', vars: ['--dropdown-padding']},
+      {property: 'borderRadius', vars: ['--dropdown-radius']},
+      {property: 'padding', vars: ['--dropdown-padding']},
     ],
   },
   components: [

--- a/packages/core/src/Field/Field.doc.mjs
+++ b/packages/core/src/Field/Field.doc.mjs
@@ -13,7 +13,7 @@ export const docs = {
       {name: '--input-radius', description: 'Border radius of input fields', default: 'var(--radius-element)'},
     ],
     derived: [
-      {property: 'borderRadius', description: 'Border radius of input fields', default: 'var(--radius-element)', vars: ['--input-radius']},
+      {property: 'borderRadius', vars: ['--input-radius']},
     ],
   },
   components: [
@@ -239,7 +239,7 @@ export const docsZh = {
       {name: '--input-radius', description: 'Border radius of input fields', default: 'var(--radius-element)'},
     ],
     derived: [
-      {property: 'borderRadius', description: 'Border radius of input fields', default: 'var(--radius-element)', vars: ['--input-radius']},
+      {property: 'borderRadius', vars: ['--input-radius']},
     ],
   },
   components: [

--- a/packages/core/src/HoverCard/HoverCard.doc.mjs
+++ b/packages/core/src/HoverCard/HoverCard.doc.mjs
@@ -11,7 +11,7 @@ export const docs = {
       {name: '--hovercard-radius', description: 'Border radius of the hover card', default: 'var(--radius-container)'},
     ],
     derived: [
-      {property: 'borderRadius', description: 'Border radius of the hover card', default: 'var(--radius-container)', vars: ['--hovercard-radius']},
+      {property: 'borderRadius', vars: ['--hovercard-radius']},
     ],
   },
   components: [
@@ -161,7 +161,7 @@ export const docsZh = {
       {name: '--hovercard-radius', description: 'Border radius of the hover card', default: 'var(--radius-container)'},
     ],
     derived: [
-      {property: 'borderRadius', description: 'Border radius of the hover card', default: 'var(--radius-container)', vars: ['--hovercard-radius']},
+      {property: 'borderRadius', vars: ['--hovercard-radius']},
     ],
   },
   components: [

--- a/packages/core/src/Popover/Popover.doc.mjs
+++ b/packages/core/src/Popover/Popover.doc.mjs
@@ -139,7 +139,7 @@ export const docs = {
       {name: '--popover-radius', description: 'Border radius of the popover', default: 'var(--radius-element)'},
     ],
     derived: [
-      {property: 'borderRadius', description: 'Border radius of the popover', default: 'var(--radius-element)', vars: ['--popover-radius']},
+      {property: 'borderRadius', vars: ['--popover-radius']},
     ],
   },
   usage: {
@@ -294,7 +294,7 @@ export const docsZh = {
       {name: '--popover-radius', description: 'Border radius of the popover', default: 'var(--radius-element)'},
     ],
     derived: [
-      {property: 'borderRadius', description: 'Border radius of the popover', default: 'var(--radius-element)', vars: ['--popover-radius']},
+      {property: 'borderRadius', vars: ['--popover-radius']},
     ],
   },
   usage: {

--- a/packages/core/src/Section/Section.doc.mjs
+++ b/packages/core/src/Section/Section.doc.mjs
@@ -59,16 +59,8 @@ export const docs = {
     targets: [
       {className: 'xds-section', visualProps: ['variant']},
     ],
-    cssProperties: [
-      {
-        name: 'padding',
-        description:
-          "Controls Section container padding. Accepts standard CSS padding shorthand (e.g. '16px 20px'). Automatically mapped to container tokens for layout integration. Supports paddingBlock/paddingInline for axis-specific control.",
-        default: 'var(--spacing-4)',
-      },
-    ],
     derived: [
-      {property: 'padding', description: 'Container padding of the section', default: 'var(--spacing-4)', expand: 'container'},
+      {property: 'padding', expand: 'container'},
     ],
   },
   usage: {
@@ -141,16 +133,8 @@ export const docsZh = {
     targets: [
       {className: 'xds-section', visualProps: ['variant']},
     ],
-    cssProperties: [
-      {
-        name: 'padding',
-        description:
-          "Controls Section container padding. Accepts standard CSS padding shorthand (e.g. '16px 20px'). Automatically mapped to container tokens for layout integration. Supports paddingBlock/paddingInline for axis-specific control.",
-        default: 'var(--spacing-4)',
-      },
-    ],
     derived: [
-      {property: 'padding', description: 'Container padding of the section', default: 'var(--spacing-4)', expand: 'container'},
+      {property: 'padding', expand: 'container'},
     ],
   },
   usage: {

--- a/packages/core/src/SegmentedControl/SegmentedControl.doc.mjs
+++ b/packages/core/src/SegmentedControl/SegmentedControl.doc.mjs
@@ -13,8 +13,8 @@ export const docs = {
       {name: '--segmented-padding', description: 'Inner padding of the segmented control', default: 'var(--spacing-0-5)'},
     ],
     derived: [
-      {property: 'borderRadius', description: 'Border radius of the segmented control', default: 'var(--radius-element)', vars: ['--segmented-radius']},
-      {property: 'padding', description: 'Inner padding of the segmented control', default: 'var(--spacing-0-5)', vars: ['--segmented-padding']},
+      {property: 'borderRadius', vars: ['--segmented-radius']},
+      {property: 'padding', vars: ['--segmented-padding']},
     ],
   },
   components: [

--- a/packages/core/src/docs-types.ts
+++ b/packages/core/src/docs-types.ts
@@ -78,24 +78,6 @@ export interface ThemingTarget {
 }
 
 /**
- * Documents a public CSS custom property that themes can set on a component
- * via component style overrides in `defineTheme`.
- *
- * @example
- * ```
- * {name: 'padding', description: 'Controls Card container padding. Mapped to container tokens automatically.', default: 'var(--spacing-4)'}
- * ```
- */
-export interface CSSPropertyDoc {
-  /** The CSS custom property name. Always starts with `--xds-`. */
-  name: string;
-  /** What this property controls, in 1-2 sentences. */
-  description: string;
-  /** Default value if not set by theme. e.g. `"var(--spacing-4)"` */
-  default?: string;
-}
-
-/**
  * Maps a standard CSS property to one or more internal CSS custom properties.
  *
  * Theme authors write standard CSS (e.g. `borderRadius: '32px'`). The theme
@@ -128,11 +110,6 @@ export interface DerivedVar {
   /** The standard CSS property name (camelCase) that theme authors write.
    *  e.g. `'borderRadius'`, `'padding'`, `'paddingBlock'` */
   property: string;
-  /** What this derived mapping controls, in 1-2 sentences. */
-  description?: string;
-  /** Default value as a CSS expression if not set by theme.
-   *  e.g. `'var(--radius-container)'`, `'var(--spacing-4)'` */
-  default?: string;
   /** Internal CSS custom property names to set when this property appears
    *  in a theme's component overrides. Omit when using `expand`. */
   vars?: string[];
@@ -155,7 +132,9 @@ export interface DerivedVar {
 export interface ComponentVar {
   /** CSS custom property name, e.g. '--card-radius' */
   name: string;
-  /** What this var controls */
+  /** What this var controls. For derived vars, describe what the CSS property
+   *  expands into (e.g. "Border radius of the card. Theme authors write
+   *  `borderRadius`; the pipeline also sets this var.") */
   description: string;
   /** Default value as a CSS expression, e.g. 'var(--radius-container)' */
   default: string;
@@ -163,6 +142,21 @@ export interface ComponentVar {
   derived?: boolean;
   /** CSS expression showing how derived vars are computed */
   formula?: string;
+  /**
+   * The standard CSS property (camelCase) that theme authors write to set
+   * this var. When present, the pipeline intercepts this property in
+   * component overrides and emits the internal var alongside the CSS.
+   *
+   * e.g. `'borderRadius'` — writing `borderRadius: '32px'` in defineTheme
+   * emits both `border-radius: 32px` and `--card-radius: 32px`.
+   */
+  property?: string;
+  /**
+   * Named expansion strategy instead of setting the var directly.
+   * `'container'` — the pipeline expands padding values into 7 container
+   * layout tokens (--xds-<component>-padding, -inline, -block-start, etc.).
+   */
+  expand?: 'container';
 }
 
 /**
@@ -298,14 +292,10 @@ interface BaseDoc {
     targets: ThemingTarget[];
     /** CSS custom properties exposed for theming. */
     vars?: ComponentVar[];
-    /** Public CSS custom properties that themes can set on this component
-     *  via component overrides. Only document supported public properties —
-     *  internal variables must not be listed here. */
-    cssProperties?: CSSPropertyDoc[];
     /** Maps standard CSS properties to internal vars for theme pipeline
      *  expansion. Ordered by priority — earlier entries emit first.
      *  The pipeline reads this to know: when a theme sets `borderRadius`
-     *  on this component, also emit `--_card-radius`.
+     *  on this component, also emit the internal var.
      *  @see DerivedVar */
     derived?: DerivedVar[];
   };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -153,8 +153,8 @@ export type {
   PropDoc,
   ComponentEntry,
   ThemingTarget,
-  CSSPropertyDoc,
   ComponentVar,
+  DerivedVar,
   TranslationDoc,
   ComponentShowcaseDoc,
 } from './docs-types';

--- a/packages/core/src/theme/derivedVarRegistry.ts
+++ b/packages/core/src/theme/derivedVarRegistry.ts
@@ -19,10 +19,6 @@
 export interface DerivedVarEntry {
   /** The standard CSS property name (camelCase) that theme authors write. */
   property: string;
-  /** What this derived mapping controls. */
-  description?: string;
-  /** Default value as a CSS expression. */
-  default?: string;
   /** Internal CSS custom property names to set. Omit when using `expand`. */
   vars?: string[];
   /** Named expansion strategy. 'container' expands padding to container tokens. */
@@ -38,42 +34,42 @@ export interface DerivedVarEntry {
  */
 export const derivedVarRegistry: Record<string, DerivedVarEntry[]> = {
   banner: [
-    {property: 'borderRadius', description: 'Border radius of the banner', default: 'var(--radius-container)', vars: ['--banner-radius']},
+    {property: 'borderRadius', vars: ['--banner-radius']},
   ],
   button: [
-    {property: 'borderRadius', description: 'Border radius of buttons', default: 'var(--radius-element)', vars: ['--button-radius']},
+    {property: 'borderRadius', vars: ['--button-radius']},
   ],
   card: [
-    {property: 'borderRadius', description: 'Border radius of the card', default: 'var(--radius-container)', vars: ['--card-radius']},
-    {property: 'padding', description: 'Container padding of the card', default: 'var(--spacing-4)', expand: 'container'},
+    {property: 'borderRadius', vars: ['--card-radius']},
+    {property: 'padding', expand: 'container'},
   ],
   chat: [
-    {property: 'borderRadius', description: 'Border radius of the composer. Inner elements derive their radius concentrically.', default: 'var(--radius-page)', vars: ['--composer-radius']},
-    {property: 'padding', description: 'Padding of the composer. Used in the concentric radius calculation.', default: 'var(--spacing-3)', vars: ['--composer-padding']},
+    {property: 'borderRadius', vars: ['--composer-radius']},
+    {property: 'padding', vars: ['--composer-padding']},
   ],
   dialog: [
-    {property: 'borderRadius', description: 'Border radius of the dialog', default: 'var(--radius-container)', vars: ['--dialog-radius']},
-    {property: 'padding', description: 'Container padding of the dialog', default: 'var(--spacing-4)', expand: 'container'},
+    {property: 'borderRadius', vars: ['--dialog-radius']},
+    {property: 'padding', expand: 'container'},
   ],
   'dropdown-menu': [
-    {property: 'borderRadius', description: 'Border radius of the menu popup', default: 'var(--radius-element)', vars: ['--dropdown-radius']},
-    {property: 'padding', description: 'Inner padding of the menu popup', default: 'var(--spacing-1)', vars: ['--dropdown-padding']},
+    {property: 'borderRadius', vars: ['--dropdown-radius']},
+    {property: 'padding', vars: ['--dropdown-padding']},
   ],
   field: [
-    {property: 'borderRadius', description: 'Border radius of input fields', default: 'var(--radius-element)', vars: ['--input-radius']},
+    {property: 'borderRadius', vars: ['--input-radius']},
   ],
   hovercard: [
-    {property: 'borderRadius', description: 'Border radius of the hover card', default: 'var(--radius-container)', vars: ['--hovercard-radius']},
+    {property: 'borderRadius', vars: ['--hovercard-radius']},
   ],
   popover: [
-    {property: 'borderRadius', description: 'Border radius of the popover', default: 'var(--radius-element)', vars: ['--popover-radius']},
+    {property: 'borderRadius', vars: ['--popover-radius']},
   ],
   section: [
-    {property: 'padding', description: 'Container padding of the section', default: 'var(--spacing-4)', expand: 'container'},
+    {property: 'padding', expand: 'container'},
   ],
   'segmented-control': [
-    {property: 'borderRadius', description: 'Border radius of the segmented control', default: 'var(--radius-element)', vars: ['--segmented-radius']},
-    {property: 'padding', description: 'Inner padding of the segmented control', default: 'var(--spacing-0-5)', vars: ['--segmented-padding']},
+    {property: 'borderRadius', vars: ['--segmented-radius']},
+    {property: 'padding', vars: ['--segmented-padding']},
   ],
 };
 

--- a/packages/themes/meta/src/metaTheme.ts
+++ b/packages/themes/meta/src/metaTheme.ts
@@ -329,7 +329,7 @@ export const metaTheme = defineTheme({
     card: {
       base: {
         padding: '20px',
-        '--card-radius': '32px',
+        borderRadius: '32px',
       },
     },
 
@@ -396,7 +396,7 @@ export const metaTheme = defineTheme({
     // =========================================================================
     banner: {
       base: {
-        '--banner-radius': '16px',
+        borderRadius: '16px',
       },
       'status:info': {backgroundColor: 'var(--color-background-card)'},
       'status:warning': {backgroundColor: 'var(--color-background-card)'},
@@ -516,7 +516,7 @@ export const metaTheme = defineTheme({
     dialog: {
       base: {
         backgroundColor: 'light-dark(var(--color-background-surface), #1F1F20)',
-        '--dialog-radius': '32px',
+        borderRadius: '32px',
       },
     },
 
@@ -544,9 +544,8 @@ export const metaTheme = defineTheme({
     },
     'dropdown-menu': {
       base: {
-        '--dropdown-radius': '16px',
-        '--dropdown-padding': '8px',
-        padding: '8px !important',
+        borderRadius: '16px',
+        padding: '8px',
       },
     },
     'more-menu': {


### PR DESCRIPTION
## Summary

Follow-up to #1467. Cleans up the theming doc system and migrates the meta theme to use derived var expansion.

### Changes

**Remove `cssProperties`** — fully replaced by `derived`
- Remove `CSSPropertyDoc` type from docs-types.ts
- Remove `cssProperties` field from BaseDoc theming section
- Remove `cssProperties` from Card, Dialog, Section doc files
- Replace `CSSPropertyDoc` export with `DerivedVar` in index.ts

**Clean up `derived` entries** — strip `description`/`default` since that info lives on `vars`
- `vars` documents what internal vars exist (name, description, default)
- `derived` documents the expansion rules (which CSS property triggers which vars)
- No duplication between the two

**Update CLI** — explain derived vars properly
- Vars section: "Themeable CSS variables — additional properties that can be overridden"
- Vars with derived mappings get annotated: _(set via standard CSS property)_
- Show expansion examples: `borderRadius: '...',  // also sets --card-radius`
- Compact/brief formats show derived mappings instead of removed cssProperties

**Migrate meta theme** — raw CSS vars → standard CSS properties
- `'--card-radius': '32px'` → `borderRadius: '32px'`
- `'--banner-radius': '16px'` → `borderRadius: '16px'`
- `'--dialog-radius': '32px'` → `borderRadius: '32px'`
- `'--dropdown-radius': '16px'` + `'--dropdown-padding': '8px'` → `borderRadius: '16px'` + `padding: '8px'`
- Removed `!important` on dropdown padding (derived expansion handles it now)

### Net result

-162 lines, +118 lines. Cleaner doc system, one less type, meta theme reads like standard CSS.

Refs #1244

---
