### PR TITLE
feat(types): add data-* index signature to XDSBaseProps

### DIFF
--- a/packages/core/src/XDSBaseProps.ts
+++ b/packages/core/src/XDSBaseProps.ts
@@ -38,4 +38,7 @@ export interface XDSBaseProps<T extends HTMLElement = HTMLElement> extends Omit<
    * ```
    */
   xstyle?: StyleXStyles;
+
+  /** Allow data-* attributes in object literals (not just JSX). */
+  [key: `data-${string}`]: string | undefined;
 }


### PR DESCRIPTION
## Summary

Adds a `[key: \`data-${string}\`]: string | undefined` index signature to `XDSBaseProps`, allowing `data-*` attributes in object literal prop spreads — not just direct JSX usage.

## Problem

TypeScript's JSX transform has special handling for `data-*` attributes, but when constructing props as an object literal (e.g. passing the `button` prop to `XDSDropdownMenu`), TS rejects `data-*` keys with TS2353 (excess property check).

## Fix

Narrow index signature that only allows `data-` prefixed keys — no arbitrary props leak through.

Closes #1392

---
