### PR TITLE
fix: use :focus-visible instead of :focus-within for focus outlines

### DIFF
--- a/packages/core/src/CheckboxInput/XDSCheckboxInput.tsx
+++ b/packages/core/src/CheckboxInput/XDSCheckboxInput.tsx
@@ -86,12 +86,12 @@ const styles = stylex.create({
   checkboxFocus: {
     outline: {
       default: 'none',
-      [stylex.when.ancestor(':focus-within', checkboxScope)]:
+      [stylex.when.ancestor(':has(:focus-visible)', checkboxScope)]:
         `2px solid ${colorVars['--color-accent']}`,
     },
     outlineOffset: {
       default: null,
-      [stylex.when.ancestor(':focus-within', checkboxScope)]: '2px',
+      [stylex.when.ancestor(':has(:focus-visible)', checkboxScope)]: '2px',
     },
   },
   // State-dependent colors with ancestor hover behavior

--- a/packages/core/src/List/XDSListItem.tsx
+++ b/packages/core/src/List/XDSListItem.tsx
@@ -141,14 +141,14 @@ const styles = stylex.create({
       ':active': colorVars['--color-overlay-pressed'],
     },
   },
-  focusWithinOutline: {
+  focusVisibleOutline: {
     outline: {
       default: 'none',
-      ':focus-within': `2px solid ${colorVars['--color-accent']}`,
+      ':has(:focus-visible)': `2px solid ${colorVars['--color-accent']}`,
     },
     outlineOffset: {
       default: '0',
-      ':focus-within': '2px',
+      ':has(:focus-visible)': '2px',
     },
   },
   disabled: {
@@ -453,7 +453,7 @@ export function XDSListItem({
           hasDividers ? styles.noRadius : styles.withRadius,
           hasDividers && styles.withDivider,
           isInteractive && styles.interactive,
-          isInteractive && styles.focusWithinOutline,
+          isInteractive && styles.focusVisibleOutline,
           isDisabled && styles.disabled,
           isSelected && styles.selected,
           xstyle,

--- a/packages/core/src/List/XDSListItem.tsx
+++ b/packages/core/src/List/XDSListItem.tsx
@@ -171,6 +171,8 @@ const styles = stylex.create({
     flex: 1,
     minWidth: 0,
     textAlign: 'start',
+    // Suppress inner focus ring — the parent <li> handles it via :has(:focus-visible)
+    outline: 'none',
   },
   invisibleAnchor: {
     all: 'unset',
@@ -183,6 +185,8 @@ const styles = stylex.create({
     minWidth: 0,
     textAlign: 'start',
     textDecoration: 'none',
+    // Suppress inner focus ring — the parent <li> handles it via :has(:focus-visible)
+    outline: 'none',
   },
   content: {
     display: 'flex',

--- a/packages/core/src/RadioList/XDSRadioListItem.tsx
+++ b/packages/core/src/RadioList/XDSRadioListItem.tsx
@@ -96,11 +96,11 @@ const styles = stylex.create({
   radioWrapperFocus: {
     outline: {
       default: 'none',
-      ':focus-within': `2px solid ${colorVars['--color-accent']}`,
+      ':has(:focus-visible)': `2px solid ${colorVars['--color-accent']}`,
     },
     outlineOffset: {
       default: '0',
-      ':focus-within': '2px',
+      ':has(:focus-visible)': '2px',
     },
     borderRadius: '50%',
   },

--- a/packages/core/src/Switch/XDSSwitch.tsx
+++ b/packages/core/src/Switch/XDSSwitch.tsx
@@ -106,12 +106,12 @@ const styles = stylex.create({
   trackFocus: {
     outline: {
       default: 'none',
-      [stylex.when.ancestor(':focus-within', switchScope)]:
+      [stylex.when.ancestor(':has(:focus-visible)', switchScope)]:
         `2px solid ${colorVars['--color-accent']}`,
     },
     outlineOffset: {
       default: null,
-      [stylex.when.ancestor(':focus-within', switchScope)]: '2px',
+      [stylex.when.ancestor(':has(:focus-visible)', switchScope)]: '2px',
     },
   },
   // State-dependent colors with ancestor hover behavior

--- a/packages/core/src/Token/XDSToken.test.tsx
+++ b/packages/core/src/Token/XDSToken.test.tsx
@@ -354,7 +354,7 @@ describe('XDSToken focus outline', () => {
     const button = screen.getByRole('button', {name: 'Focusable'});
     await user.tab();
     expect(button).toHaveFocus();
-    // The container should handle focus outline via :focus-within,
+    // The container should handle focus outline via :has(:focus-visible),
     // not the button itself
     const container = screen.getByTestId('focus-token');
     expect(container.tagName).toBe('SPAN');

--- a/packages/core/src/Token/XDSToken.tsx
+++ b/packages/core/src/Token/XDSToken.tsx
@@ -205,14 +205,14 @@ const styles = stylex.create({
     overflow: 'hidden',
     minWidth: 0,
   },
-  focusWithinOutline: {
+  focusVisibleOutline: {
     outline: {
       default: null,
-      ':focus-within': `2px solid ${colorVars['--color-accent']}`,
+      ':has(:focus-visible)': `2px solid ${colorVars['--color-accent']}`,
     },
     outlineOffset: {
       default: '0',
-      ':focus-within': '2px',
+      ':has(:focus-visible)': '2px',
     },
   },
   removeButton: {
@@ -413,7 +413,7 @@ export function XDSToken({
             sizeStyles[size],
             colorStyles[color],
             styles.interactive,
-            styles.focusWithinOutline,
+            styles.focusVisibleOutline,
             isDisabled && styles.disabled,
             xstyle,
           ),

--- a/packages/core/src/TreeList/XDSTreeListItem.tsx
+++ b/packages/core/src/TreeList/XDSTreeListItem.tsx
@@ -74,14 +74,14 @@ const styles = stylex.create({
       ':active': `linear-gradient(${colorVars['--color-overlay-pressed']}, ${colorVars['--color-overlay-pressed']})`,
     },
   },
-  focusWithinOutline: {
+  focusVisibleOutline: {
     outline: {
       default: 'none',
-      ':focus-within': `2px solid ${colorVars['--color-accent']}`,
+      ':has(:focus-visible)': `2px solid ${colorVars['--color-accent']}`,
     },
     outlineOffset: {
       default: '0',
-      ':focus-within': '2px',
+      ':has(:focus-visible)': '2px',
     },
   },
   disabled: {
@@ -408,7 +408,7 @@ export function XDSTreeListItem({
               (isInteractive || (hasChildren && onClick == null)) &&
                 styles.interactive,
               (isInteractive || (hasChildren && onClick == null)) &&
-                styles.focusWithinOutline,
+                styles.focusVisibleOutline,
               isDisabled && styles.disabled,
               isSelected && styles.selected,
             ),

--- a/packages/core/src/TreeList/XDSTreeListItem.tsx
+++ b/packages/core/src/TreeList/XDSTreeListItem.tsx
@@ -102,6 +102,8 @@ const styles = stylex.create({
     flex: 1,
     minWidth: 0,
     textAlign: 'start',
+    // Suppress inner focus ring — the parent <li> handles it via :has(:focus-visible)
+    outline: 'none',
   },
   invisibleAnchor: {
     all: 'unset',
@@ -114,6 +116,8 @@ const styles = stylex.create({
     minWidth: 0,
     textAlign: 'start',
     textDecoration: 'none',
+    // Suppress inner focus ring — the parent <li> handles it via :has(:focus-visible)
+    outline: 'none',
   },
   content: {
     display: 'flex',


### PR DESCRIPTION
## Problem

Clicking on interactive list items (and other components with container focus outlines) would show the focus ring on mouse click. Focus outlines should only appear during keyboard navigation.

## Fix

Replaces `:focus-within` with `:has(:focus-visible)` across all components that render focus outlines on a container element wrapping an inner interactive element (button/anchor/input).

### Affected components
- **XDSListItem** — settings template nav items
- **XDSToken** — removable tokens
- **XDSTreeListItem** — tree navigation items
- **XDSRadioListItem** — radio option wrapper
- **XDSCheckboxInput** — checkbox indicator
- **XDSSwitch** — switch track

### Not changed (legitimate `:focus-within`)
- `Field/inputStyles` — text input border should highlight on any focus
- `Popover` — visibility/layout logic
- `ChatComposer` — input container border

---
