### PR TITLE
fix(cli): handle prerelease suffixes in semverCompare

### DIFF
--- a/packages/cli/src/codemods/__tests__/registry.test.mjs
+++ b/packages/cli/src/codemods/__tests__/registry.test.mjs
@@ -32,5 +32,15 @@ describe('registry', () => {
       const results = await getTransformsBetween('0.0.8', '0.0.2');
       expect(results).toEqual([]);
     });
+
+    test('handles prerelease suffixes in --to (canary versions)', async () => {
+      const results = await getTransformsBetween('0.0.12', '0.0.13-canary.21d98fa');
+      expect(results.map((r) => r.version)).toEqual(['0.0.13']);
+    });
+
+    test('handles prerelease suffixes in --from', async () => {
+      const results = await getTransformsBetween('0.0.12-canary.abc1234', '0.0.13');
+      expect(results.map((r) => r.version)).toEqual(['0.0.13']);
+    });
   });
 });

--- a/packages/cli/src/codemods/registry.mjs
+++ b/packages/cli/src/codemods/registry.mjs
@@ -24,8 +24,8 @@ const registry = new Map([
  * @returns {number}
  */
 function semverCompare(a, b) {
-  const pa = a.split('.').map(Number);
-  const pb = b.split('.').map(Number);
+  const pa = a.split('-')[0].split('.').map(Number);
+  const pb = b.split('-')[0].split('.').map(Number);
   for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
     const na = pa[i] ?? 0;
     const nb = pb[i] ?? 0;


### PR DESCRIPTION
## Summary

Fixes `semverCompare` in the codemod registry to strip prerelease suffixes before numeric comparison.

## Problem

`semverCompare('0.0.13', '0.0.13-canary.21d98fa')` was returning `NaN` because `'13-canary'` parsed to `NaN` via `Number()`. This caused `getTransformsBetween('0.0.12', '0.0.13-canary.X')` to filter out the `v0.0.13` codemods entirely.

Impact: `xds-upgrade-apps.mjs` (the Nest batch upgrader) passes the canary version as `--to`, so all codemods were silently skipped during canary testing.

## Fix

Strip everything after the first `-` before splitting on `.`:
```js
const pa = a.split('-')[0].split('.').map(Number);
```

## Test plan

- Added tests for prerelease suffixes in both `--from` and `--to`
- All 7 registry tests pass

---
