### PR TITLE
fix(codemod): handle ternary/logical expressions in icon-name-deprecations

### DIFF
--- a/packages/cli/src/codemods/transforms/v0.0.13/__tests__/icon-name-deprecations.test.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.13/__tests__/icon-name-deprecations.test.mjs
@@ -1,0 +1,79 @@
+import {describe, expect, test} from 'vitest';
+
+async function run(source) {
+  const {default: transform} = await import('../icon-name-deprecations.mjs');
+  const jscodeshift = (await import('jscodeshift')).default;
+  const j = jscodeshift.withParser('tsx');
+  const api = {jscodeshift: j, stats: () => {}, report: () => {}};
+  return transform({source, path: 'test.tsx'}, api) ?? source;
+}
+
+describe('icon-name-deprecations', () => {
+  test('renames JSX string literal: icon="checkCircle"', async () => {
+    const input = `<XDSIcon icon="checkCircle" />`;
+    const output = await run(input);
+    expect(output).toContain('success');
+    expect(output).not.toContain('checkCircle');
+  });
+
+  test('renames xCircle to error', async () => {
+    const input = `<XDSIcon icon="xCircle" />`;
+    const output = await run(input);
+    expect(output).toContain('error');
+    expect(output).not.toContain('xCircle');
+  });
+
+  test('renames inside ternary expression', async () => {
+    const input = `<XDSIcon icon={copied ? 'checkCircle' : 'copy'} />`;
+    const output = await run(input);
+    expect(output).toContain('success');
+    expect(output).not.toContain('checkCircle');
+    expect(output).toContain('copy');
+  });
+
+  test('renames both branches of ternary if both deprecated', async () => {
+    const input = `<XDSIcon icon={isOk ? 'checkCircle' : 'xCircle'} />`;
+    const output = await run(input);
+    expect(output).toContain('success');
+    expect(output).toContain('error');
+    expect(output).not.toContain('checkCircle');
+    expect(output).not.toContain('xCircle');
+  });
+
+  test('renames inside logical expression', async () => {
+    const input = `<XDSIcon icon={valid && 'checkCircle'} />`;
+    const output = await run(input);
+    expect(output).toContain('success');
+    expect(output).not.toContain('checkCircle');
+  });
+
+  test('renames in object property value', async () => {
+    const input = `const nav = [{ label: 'Done', icon: 'checkCircle' }];`;
+    const output = await run(input);
+    expect(output).toContain('success');
+    expect(output).not.toContain('checkCircle');
+  });
+
+  test('renames icon registry keys', async () => {
+    const input = `import type {XDSIconRegistry} from '@xds/core/Icon';\nconst icons = { checkCircle: <Svg />, xCircle: <X /> };`;
+    const output = await run(input);
+    expect(output).toContain('success');
+    expect(output).toContain('error');
+    expect(output).not.toContain('checkCircle');
+    expect(output).not.toContain('xCircle');
+  });
+
+  test('does not rename unrelated props', async () => {
+    const input = `<div title="checkCircle" />`;
+    const output = await run(input);
+    expect(output).toContain('checkCircle');
+  });
+
+  test('handles real-world pattern: ternary with color prop', async () => {
+    const input = `<XDSIcon icon={copied ? 'checkCircle' : 'copy'} color="inherit" />`;
+    const output = await run(input);
+    expect(output).toContain('success');
+    expect(output).toContain('copy');
+    expect(output).not.toContain('checkCircle');
+  });
+});

--- a/packages/cli/src/codemods/transforms/v0.0.13/icon-name-deprecations.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.13/icon-name-deprecations.mjs
@@ -7,6 +7,7 @@
  *
  * Handles:
  *   - JSX string literals: icon="checkCircle" → icon="success"
+ *   - JSX expressions: icon={cond ? 'checkCircle' : 'copy'} → icon={cond ? 'success' : 'copy'}
  *   - Object properties: { icon: "checkCircle" } → { icon: "success" }
  *   - String assignments: const x = "checkCircle" (when assigned to icon-typed vars)
  *   - Icon registry objects: { checkCircle: <Svg /> } → { success: <Svg /> }
@@ -33,16 +34,48 @@ export default function transformer(file, api) {
   const root = j(file.source);
   let hasChanges = false;
 
-  // 1. JSX attributes: icon="checkCircle" → icon="success"
+  // Helper: rename a string literal node if it matches a deprecated name
+  function renameStringLiteral(node) {
+    if (!node) return false;
+    if (node.type === 'StringLiteral' || node.type === 'Literal') {
+      const newName = RENAMES[node.value];
+      if (newName) {
+        node.value = newName;
+        if (node.raw) node.raw = `'${newName}'`;
+        return true;
+      }
+    }
+    return false;
+  }
+
+  // Helper: recursively rename deprecated icon strings inside an expression
+  function renameInExpression(node) {
+    if (!node) return false;
+    let changed = false;
+    if (node.type === 'StringLiteral' || node.type === 'Literal') {
+      changed = renameStringLiteral(node);
+    } else if (node.type === 'ConditionalExpression') {
+      changed = renameInExpression(node.consequent) || changed;
+      changed = renameInExpression(node.alternate) || changed;
+    } else if (node.type === 'LogicalExpression') {
+      changed = renameInExpression(node.left) || changed;
+      changed = renameInExpression(node.right) || changed;
+    }
+    return changed;
+  }
+
+  // 1. JSX attributes: icon="checkCircle" or icon={cond ? 'checkCircle' : 'copy'}
   root.find(j.JSXAttribute).forEach((path) => {
     const attrName = path.node.name?.name;
     if (!ICON_PROPS.has(attrName)) return;
 
     const value = path.node.value;
     if (value && (value.type === 'StringLiteral' || value.type === 'Literal')) {
-      const newName = RENAMES[value.value];
-      if (newName) {
-        path.node.value = j.stringLiteral(newName);
+      if (renameStringLiteral(value)) {
+        hasChanges = true;
+      }
+    } else if (value && value.type === 'JSXExpressionContainer') {
+      if (renameInExpression(value.expression)) {
         hasChanges = true;
       }
     }


### PR DESCRIPTION
## Summary

The `icon-name-deprecations` codemod only handled direct string literal props:
```tsx
<XDSIcon icon="checkCircle" />  // ✅ transformed
```

But missed expressions containing deprecated strings:
```tsx
<XDSIcon icon={copied ? 'checkCircle' : 'copy'} />  // ❌ missed
<XDSIcon icon={valid && 'checkCircle'} />            // ❌ missed
```

## Fix

Adds `renameInExpression()` helper that recursively traverses `ConditionalExpression` and `LogicalExpression` nodes within `JSXExpressionContainer` values on icon props.

## Found during canary testing

`xds_docs_app/CopyAgentPrompt.tsx` has:
```tsx
icon={<XDSIcon icon={copied ? 'checkCircle' : 'copy'} color="inherit" />}
```

This was not transformed by the codemod, confirmed by running `xds upgrade` against it.

## Test plan

- 9 new tests covering ternaries, logical expressions, both-branches, and non-icon props
- All 467 CLI tests pass

---
