### PR TITLE
docs(blocks): fix componentsUsed to match @xds/core imports

### DIFF
--- a/packages/cli/templates/blocks/components/AppShell/AppShellFullBleedWithPadded.doc.mjs
+++ b/packages/cli/templates/blocks/components/AppShell/AppShellFullBleedWithPadded.doc.mjs
@@ -5,5 +5,5 @@ export const doc = {
   description: 'Full-bleed layout with a padded details section below.',
   isReady: true,
   aspectRatio: 4 / 3,
-  componentsUsed: ['AppShell', 'TopNav', 'Heading', 'Text', 'Section'],
+  componentsUsed: ['AppShell', 'Section', 'Text', 'TopNav'],
 };

--- a/packages/cli/templates/blocks/components/AppShell/AppShellPaddedContent.doc.mjs
+++ b/packages/cli/templates/blocks/components/AppShell/AppShellPaddedContent.doc.mjs
@@ -5,5 +5,5 @@ export const doc = {
   description: 'Settings page layout with contentPadding for form-style content.',
   isReady: true,
   aspectRatio: 4 / 3,
-  componentsUsed: ['AppShell', 'TopNav', 'SideNav', 'Heading', 'TextInput'],
+  componentsUsed: ['AppShell', 'SideNav', 'Text', 'TextInput', 'TopNav'],
 };

--- a/packages/cli/templates/blocks/components/AppShell/AppShellPaddedWithFullBleed.doc.mjs
+++ b/packages/cli/templates/blocks/components/AppShell/AppShellPaddedWithFullBleed.doc.mjs
@@ -5,5 +5,5 @@ export const doc = {
   description: 'Padded layout with a full-bleed chart section using XDSSection padding override.',
   isReady: true,
   aspectRatio: 4 / 3,
-  componentsUsed: ['AppShell', 'TopNav', 'Heading', 'Section', 'Card'],
+  componentsUsed: ['AppShell', 'Card', 'Section', 'Text', 'TopNav'],
 };

--- a/packages/cli/templates/blocks/components/Card/CardAccordion.doc.mjs
+++ b/packages/cli/templates/blocks/components/Card/CardAccordion.doc.mjs
@@ -5,5 +5,5 @@ export const doc = {
   description: 'Accordion of collapsible cards using XDSCollapsibleGroup.',
   isReady: true,
   aspectRatio: 4 / 3,
-  componentsUsed: ['Card', 'Collapsible', 'VStack'],
+  componentsUsed: ['Card', 'Collapsible', 'Stack'],
 };

--- a/packages/cli/templates/blocks/components/Collapsible/CollapsibleMultipleMode.doc.mjs
+++ b/packages/cli/templates/blocks/components/Collapsible/CollapsibleMultipleMode.doc.mjs
@@ -5,5 +5,5 @@ export const doc = {
   description: 'Coordinated group where multiple sections can be open simultaneously.',
   isReady: true,
   aspectRatio: 4 / 3,
-  componentsUsed: ['Collapsible', 'Card', 'VStack'],
+  componentsUsed: ['Card', 'Collapsible', 'Stack'],
 };

--- a/packages/cli/templates/blocks/components/Collapsible/CollapsibleSingleModeAccordion.doc.mjs
+++ b/packages/cli/templates/blocks/components/Collapsible/CollapsibleSingleModeAccordion.doc.mjs
@@ -5,5 +5,5 @@ export const doc = {
   description: 'Coordinated group where only one section can be open at a time.',
   isReady: true,
   aspectRatio: 4 / 3,
-  componentsUsed: ['Collapsible', 'Card', 'VStack'],
+  componentsUsed: ['Card', 'Collapsible', 'Stack'],
 };

--- a/packages/cli/templates/blocks/components/CommandPalette/CommandPaletteGroupedItems.doc.mjs
+++ b/packages/cli/templates/blocks/components/CommandPalette/CommandPaletteGroupedItems.doc.mjs
@@ -5,5 +5,5 @@ export const doc = {
   description: 'Command palette with auto-grouped items and custom item rendering.',
   isReady: true,
   aspectRatio: 4 / 3,
-  componentsUsed: ['CommandPalette', 'Button'],
+  componentsUsed: ['Button', 'CommandPalette', 'Typeahead'],
 };

--- a/packages/cli/templates/blocks/components/CommandPalette/CommandPaletteStaticSource.doc.mjs
+++ b/packages/cli/templates/blocks/components/CommandPalette/CommandPaletteStaticSource.doc.mjs
@@ -5,5 +5,5 @@ export const doc = {
   description: 'Command palette with a static list of searchable items.',
   isReady: true,
   aspectRatio: 4 / 3,
-  componentsUsed: ['CommandPalette', 'Button'],
+  componentsUsed: ['Button', 'CommandPalette', 'Typeahead'],
 };

--- a/packages/cli/templates/blocks/components/DateInput/DateInputBasic.doc.mjs
+++ b/packages/cli/templates/blocks/components/DateInput/DateInputBasic.doc.mjs
@@ -5,5 +5,5 @@ export const doc = {
   description: 'Simple date input with text entry and calendar popover.',
   isReady: true,
   aspectRatio: 4 / 3,
-  componentsUsed: ['DateInput'],
+  componentsUsed: ['Calendar', 'DateInput'],
 };

--- a/packages/cli/templates/blocks/components/DateInput/DateInputTwoMonthCalendar.doc.mjs
+++ b/packages/cli/templates/blocks/components/DateInput/DateInputTwoMonthCalendar.doc.mjs
@@ -5,5 +5,5 @@ export const doc = {
   description: 'Date input displaying two months simultaneously in the calendar popover.',
   isReady: true,
   aspectRatio: 4 / 3,
-  componentsUsed: ['DateInput'],
+  componentsUsed: ['Calendar', 'DateInput'],
 };

--- a/packages/cli/templates/blocks/components/DateInput/DateInputWithConstraints.doc.mjs
+++ b/packages/cli/templates/blocks/components/DateInput/DateInputWithConstraints.doc.mjs
@@ -5,5 +5,5 @@ export const doc = {
   description: 'Date input restricted to a min/max date range with custom placeholder.',
   isReady: true,
   aspectRatio: 4 / 3,
-  componentsUsed: ['DateInput'],
+  componentsUsed: ['Calendar', 'DateInput'],
 };

--- a/packages/cli/templates/blocks/components/DateInput/DateInputWithDescriptionAndRequired.doc.mjs
+++ b/packages/cli/templates/blocks/components/DateInput/DateInputWithDescriptionAndRequired.doc.mjs
@@ -5,5 +5,5 @@ export const doc = {
   description: 'Required date input with helper description text below the label.',
   isReady: true,
   aspectRatio: 4 / 3,
-  componentsUsed: ['DateInput'],
+  componentsUsed: ['Calendar', 'DateInput'],
 };

--- a/packages/cli/templates/blocks/components/DateInput/DateInputWithErrorStatus.doc.mjs
+++ b/packages/cli/templates/blocks/components/DateInput/DateInputWithErrorStatus.doc.mjs
@@ -5,5 +5,5 @@ export const doc = {
   description: 'Date input displaying an error validation message.',
   isReady: true,
   aspectRatio: 4 / 3,
-  componentsUsed: ['DateInput'],
+  componentsUsed: ['Calendar', 'DateInput'],
 };

--- a/packages/cli/templates/blocks/components/FormLayout/FormLayoutDialogComposition.doc.mjs
+++ b/packages/cli/templates/blocks/components/FormLayout/FormLayoutDialogComposition.doc.mjs
@@ -5,5 +5,5 @@ export const doc = {
   description: 'Form layout inside a dialog using HTML form attribute for submit button.',
   isReady: true,
   aspectRatio: 4 / 3,
-  componentsUsed: ['FormLayout', 'Dialog', 'TextInput', 'Button'],
+  componentsUsed: ['Button', 'Dialog', 'FormLayout', 'Layout', 'TextInput'],
 };

--- a/packages/cli/templates/blocks/components/MetadataList/MetadataListWithTitleAndShowMore.doc.mjs
+++ b/packages/cli/templates/blocks/components/MetadataList/MetadataListWithTitleAndShowMore.doc.mjs
@@ -5,5 +5,5 @@ export const doc = {
   description: 'Metadata list with a heading title and collapsible show more toggle.',
   isReady: true,
   aspectRatio: 4 / 3,
-  componentsUsed: ['MetadataList', 'Heading'],
+  componentsUsed: ['MetadataList', 'Text'],
 };

--- a/packages/cli/templates/blocks/components/MoreMenu/MoreMenuCardHeaderWithOverflowMenu.doc.mjs
+++ b/packages/cli/templates/blocks/components/MoreMenu/MoreMenuCardHeaderWithOverflowMenu.doc.mjs
@@ -5,5 +5,5 @@ export const doc = {
   description: 'Card header layout with a title and three-dot overflow menu.',
   isReady: true,
   aspectRatio: 4 / 3,
-  componentsUsed: ['MoreMenu', 'Layout', 'Heading'],
+  componentsUsed: ['Layout', 'MoreMenu', 'Text'],
 };

--- a/packages/cli/templates/blocks/components/NavIcon/NavIconInSideNavigation.doc.mjs
+++ b/packages/cli/templates/blocks/components/NavIcon/NavIconInSideNavigation.doc.mjs
@@ -5,5 +5,5 @@ export const doc = {
   description: 'Circular accent icon used in a page navigation header.',
   isReady: true,
   aspectRatio: 16 / 4,
-  componentsUsed: ['NavIcon', 'PageNav'],
+  componentsUsed: ['NavIcon', 'SideNav'],
 };

--- a/packages/cli/templates/blocks/components/SideNav/SideNavCollapsibleSidebar.doc.mjs
+++ b/packages/cli/templates/blocks/components/SideNav/SideNavCollapsibleSidebar.doc.mjs
@@ -5,5 +5,5 @@ export const doc = {
   description: 'Collapsible sidebar',
   isReady: true,
   aspectRatio: 3 / 4,
-  componentsUsed: ['AppShell', 'SideNav', 'SideNavHeading', 'SideNavCollapseButton', 'SideNavSection', 'SideNavItem'],
+  componentsUsed: ['AppShell', 'SideNav'],
 };

--- a/packages/cli/templates/blocks/components/SideNav/SideNavStandaloneNoTopNav.doc.mjs
+++ b/packages/cli/templates/blocks/components/SideNav/SideNavStandaloneNoTopNav.doc.mjs
@@ -5,5 +5,5 @@ export const doc = {
   description: 'Standalone (no TopNav)',
   isReady: true,
   aspectRatio: 3 / 4,
-  componentsUsed: ['AppShell', 'SideNav', 'SideNavHeading', 'Button', 'SideNavSection', 'SideNavItem', 'Badge'],
+  componentsUsed: ['AppShell', 'Badge', 'SideNav'],
 };

--- a/packages/cli/templates/blocks/components/SideNav/SideNavWithXDSAppShellTopNavNoHeader.doc.mjs
+++ b/packages/cli/templates/blocks/components/SideNav/SideNavWithXDSAppShellTopNavNoHeader.doc.mjs
@@ -5,5 +5,5 @@ export const doc = {
   description: 'With XDSAppShell + TopNav (no header)',
   isReady: true,
   aspectRatio: 3 / 4,
-  componentsUsed: ['AppShell', 'TopNav', 'TopNavHeading', 'SideNav', 'SideNavSection', 'SideNavItem'],
+  componentsUsed: ['AppShell', 'SideNav', 'TopNav'],
 };

--- a/packages/cli/templates/blocks/components/Spinner/SpinnerRichLabelWithComposition.doc.mjs
+++ b/packages/cli/templates/blocks/components/Spinner/SpinnerRichLabelWithComposition.doc.mjs
@@ -5,5 +5,5 @@ export const doc = {
   description: 'Rich label with composition',
   isReady: true,
   aspectRatio: 1,
-  componentsUsed: ['Spinner', 'VStack', 'Text'],
+  componentsUsed: ['Layout', 'Spinner', 'Text'],
 };

--- a/packages/cli/templates/blocks/components/Stack/StackHeaderLayout.doc.mjs
+++ b/packages/cli/templates/blocks/components/Stack/StackHeaderLayout.doc.mjs
@@ -5,5 +5,5 @@ export const doc = {
   description: 'Header layout',
   isReady: true,
   aspectRatio: 1,
-  componentsUsed: ['Stack', 'HStack', 'StackItem'],
+  componentsUsed: ['Layout'],
 };

--- a/packages/cli/templates/blocks/components/Stack/StackOverrideAlignmentPerItem.doc.mjs
+++ b/packages/cli/templates/blocks/components/Stack/StackOverrideAlignmentPerItem.doc.mjs
@@ -5,5 +5,5 @@ export const doc = {
   description: 'Override alignment per item',
   isReady: true,
   aspectRatio: 1,
-  componentsUsed: ['Stack', 'HStack', 'StackItem'],
+  componentsUsed: ['Layout'],
 };

--- a/packages/cli/templates/blocks/components/Stack/StackPageLayout.doc.mjs
+++ b/packages/cli/templates/blocks/components/Stack/StackPageLayout.doc.mjs
@@ -5,5 +5,5 @@ export const doc = {
   description: 'Page layout',
   isReady: true,
   aspectRatio: 1,
-  componentsUsed: ['Stack', 'VStack', 'StackItem'],
+  componentsUsed: ['Layout'],
 };

--- a/packages/cli/templates/blocks/components/Stack/StackSidebarLayout.doc.mjs
+++ b/packages/cli/templates/blocks/components/Stack/StackSidebarLayout.doc.mjs
@@ -5,5 +5,5 @@ export const doc = {
   description: 'Sidebar layout',
   isReady: true,
   aspectRatio: 1,
-  componentsUsed: ['Stack', 'HStack', 'StackItem'],
+  componentsUsed: ['Layout'],
 };

--- a/packages/cli/templates/blocks/components/Stack/StackStyleXUtilityAdvancedUse.doc.mjs
+++ b/packages/cli/templates/blocks/components/Stack/StackStyleXUtilityAdvancedUse.doc.mjs
@@ -5,5 +5,5 @@ export const doc = {
   description: 'StyleX utility — advanced use',
   isReady: true,
   aspectRatio: 1,
-  componentsUsed: ['Stack'],
+  componentsUsed: ['Layout'],
 };

--- a/packages/cli/templates/blocks/components/TabList/TabListBasic.doc.mjs
+++ b/packages/cli/templates/blocks/components/TabList/TabListBasic.doc.mjs
@@ -5,5 +5,5 @@ export const doc = {
   description: 'Basic',
   isReady: true,
   aspectRatio: 16 / 4,
-  componentsUsed: ['TabList', 'Tab'],
+  componentsUsed: ['TabList'],
 };

--- a/packages/cli/templates/blocks/components/TabList/TabListWithBottomDivider.doc.mjs
+++ b/packages/cli/templates/blocks/components/TabList/TabListWithBottomDivider.doc.mjs
@@ -5,5 +5,5 @@ export const doc = {
   description: 'With bottom divider',
   isReady: true,
   aspectRatio: 16 / 4,
-  componentsUsed: ['TabList', 'Tab'],
+  componentsUsed: ['TabList'],
 };

--- a/packages/cli/templates/blocks/components/TabList/TabListWithIcons.doc.mjs
+++ b/packages/cli/templates/blocks/components/TabList/TabListWithIcons.doc.mjs
@@ -5,5 +5,5 @@ export const doc = {
   description: 'With icons',
   isReady: true,
   aspectRatio: 16 / 4,
-  componentsUsed: ['TabList', 'Tab'],
+  componentsUsed: ['TabList'],
 };

--- a/packages/cli/templates/blocks/components/TabList/TabListWithLinks.doc.mjs
+++ b/packages/cli/templates/blocks/components/TabList/TabListWithLinks.doc.mjs
@@ -5,5 +5,5 @@ export const doc = {
   description: 'With links',
   isReady: true,
   aspectRatio: 16 / 4,
-  componentsUsed: ['TabList', 'Tab'],
+  componentsUsed: ['TabList'],
 };

--- a/packages/cli/templates/blocks/components/TabList/TabListWithOverflowMenu.doc.mjs
+++ b/packages/cli/templates/blocks/components/TabList/TabListWithOverflowMenu.doc.mjs
@@ -5,5 +5,5 @@ export const doc = {
   description: 'With overflow menu',
   isReady: true,
   aspectRatio: 16 / 4,
-  componentsUsed: ['TabList', 'Tab', 'TabMenu'],
+  componentsUsed: ['TabList'],
 };

--- a/packages/cli/templates/blocks/components/Table/TableBasicDatadrivenTable.doc.mjs
+++ b/packages/cli/templates/blocks/components/Table/TableBasicDatadrivenTable.doc.mjs
@@ -5,5 +5,5 @@ export const doc = {
   description: 'Basic data-driven table',
   isReady: true,
   aspectRatio: 4 / 3,
-  componentsUsed: ['Table', 'HStack', 'Avatar', 'VStack', 'Text', 'StatusDot', 'Badge'],
+  componentsUsed: ['Avatar', 'Badge', 'Layout', 'StatusDot', 'Table', 'Text'],
 };

--- a/packages/cli/templates/blocks/components/Table/TableChildrenMode.doc.mjs
+++ b/packages/cli/templates/blocks/components/Table/TableChildrenMode.doc.mjs
@@ -5,5 +5,5 @@ export const doc = {
   description: 'Children mode',
   isReady: true,
   aspectRatio: 4 / 3,
-  componentsUsed: ['Table', 'TableRow', 'TableCell', 'HStack', 'Avatar', 'Text', 'Badge'],
+  componentsUsed: ['Avatar', 'Badge', 'Layout', 'Table', 'Text'],
 };

--- a/packages/cli/templates/blocks/components/Table/TableColumnResizePlugin.doc.mjs
+++ b/packages/cli/templates/blocks/components/Table/TableColumnResizePlugin.doc.mjs
@@ -5,5 +5,5 @@ export const doc = {
   description: 'Column resize plugin',
   isReady: true,
   aspectRatio: 4 / 3,
-  componentsUsed: ['TableColumnResize', 'Table'],
+  componentsUsed: ['Table'],
 };

--- a/packages/cli/templates/blocks/components/Table/TableRichCellContentWithRenderCell.doc.mjs
+++ b/packages/cli/templates/blocks/components/Table/TableRichCellContentWithRenderCell.doc.mjs
@@ -5,5 +5,5 @@ export const doc = {
   description: 'Rich cell content with renderCell',
   isReady: true,
   aspectRatio: 4 / 3,
-  componentsUsed: ['Table', 'VStack', 'Text', 'Badge'],
+  componentsUsed: ['Badge', 'Layout', 'Table', 'Text'],
 };

--- a/packages/cli/templates/blocks/components/Table/TableSelectionPlugin.doc.mjs
+++ b/packages/cli/templates/blocks/components/Table/TableSelectionPlugin.doc.mjs
@@ -5,5 +5,5 @@ export const doc = {
   description: 'Selection plugin',
   isReady: true,
   aspectRatio: 4 / 3,
-  componentsUsed: ['TableSelectionState', 'TableSelection', 'Table'],
+  componentsUsed: ['Table'],
 };

--- a/packages/cli/templates/blocks/components/Text/TextFontWrapperForNativeHTML.doc.mjs
+++ b/packages/cli/templates/blocks/components/Text/TextFontWrapperForNativeHTML.doc.mjs
@@ -5,5 +5,5 @@ export const doc = {
   description: 'Font wrapper for native HTML',
   isReady: true,
   aspectRatio: 1,
-  componentsUsed: ['Text'],
+  componentsUsed: [],
 };

--- a/packages/cli/templates/blocks/components/Text/TextHeading.doc.mjs
+++ b/packages/cli/templates/blocks/components/Text/TextHeading.doc.mjs
@@ -5,5 +5,5 @@ export const doc = {
   description: 'Heading',
   isReady: true,
   aspectRatio: 1,
-  componentsUsed: ['Text', 'Heading'],
+  componentsUsed: ['Text'],
 };

--- a/packages/cli/templates/blocks/components/Toast/ToastBasic.doc.mjs
+++ b/packages/cli/templates/blocks/components/Toast/ToastBasic.doc.mjs
@@ -5,5 +5,5 @@ export const doc = {
   description: 'Basic',
   isReady: true,
   aspectRatio: 1,
-  componentsUsed: ['Toast'],
+  componentsUsed: ['Button', 'Toast'],
 };

--- a/packages/cli/templates/blocks/components/Toast/ToastError.doc.mjs
+++ b/packages/cli/templates/blocks/components/Toast/ToastError.doc.mjs
@@ -5,5 +5,5 @@ export const doc = {
   description: 'Error',
   isReady: true,
   aspectRatio: 1,
-  componentsUsed: ['Toast'],
+  componentsUsed: ['Button', 'Toast'],
 };

--- a/packages/cli/templates/blocks/components/ToggleButton/ToggleButtonMultiselectGroup.doc.mjs
+++ b/packages/cli/templates/blocks/components/ToggleButton/ToggleButtonMultiselectGroup.doc.mjs
@@ -5,5 +5,5 @@ export const doc = {
   description: 'Multi-select group',
   isReady: true,
   aspectRatio: 1,
-  componentsUsed: ['ToggleButtonGroup', 'ToggleButton'],
+  componentsUsed: ['ToggleButton'],
 };

--- a/packages/cli/templates/blocks/components/ToggleButton/ToggleButtonSingleselectGroup.doc.mjs
+++ b/packages/cli/templates/blocks/components/ToggleButton/ToggleButtonSingleselectGroup.doc.mjs
@@ -5,5 +5,5 @@ export const doc = {
   description: 'Single-select group',
   isReady: true,
   aspectRatio: 1,
-  componentsUsed: ['ToggleButtonGroup', 'ToggleButton'],
+  componentsUsed: ['ToggleButton'],
 };

--- a/packages/cli/templates/blocks/components/Tokenizer/TokenizerBasicMultiselect.doc.mjs
+++ b/packages/cli/templates/blocks/components/Tokenizer/TokenizerBasicMultiselect.doc.mjs
@@ -5,5 +5,5 @@ export const doc = {
   description: 'Basic multi-select',
   isReady: true,
   aspectRatio: 4 / 3,
-  componentsUsed: ['Tokenizer'],
+  componentsUsed: ['Tokenizer', 'Typeahead'],
 };

--- a/packages/cli/templates/blocks/components/Tokenizer/TokenizerCustomTokenRendering.doc.mjs
+++ b/packages/cli/templates/blocks/components/Tokenizer/TokenizerCustomTokenRendering.doc.mjs
@@ -5,5 +5,5 @@ export const doc = {
   description: 'Custom token rendering',
   isReady: true,
   aspectRatio: 4 / 3,
-  componentsUsed: ['Tokenizer', 'Token'],
+  componentsUsed: ['Token', 'Tokenizer', 'Typeahead'],
 };

--- a/packages/cli/templates/blocks/components/Tokenizer/TokenizerFreetextTagsHasCreate.doc.mjs
+++ b/packages/cli/templates/blocks/components/Tokenizer/TokenizerFreetextTagsHasCreate.doc.mjs
@@ -5,5 +5,5 @@ export const doc = {
   description: 'Free-text tags (hasCreate)',
   isReady: true,
   aspectRatio: 4 / 3,
-  componentsUsed: ['Tokenizer'],
+  componentsUsed: ['Tokenizer', 'Typeahead'],
 };

--- a/packages/cli/templates/blocks/components/Tokenizer/TokenizerWithMaxEntriesAndClearAll.doc.mjs
+++ b/packages/cli/templates/blocks/components/Tokenizer/TokenizerWithMaxEntriesAndClearAll.doc.mjs
@@ -5,5 +5,5 @@ export const doc = {
   description: 'With max entries and clear all',
   isReady: true,
   aspectRatio: 4 / 3,
-  componentsUsed: ['Tokenizer'],
+  componentsUsed: ['Tokenizer', 'Typeahead'],
 };

--- a/packages/cli/templates/blocks/components/TopNav/TopNavBasicNavWithHeadingAndItems.doc.mjs
+++ b/packages/cli/templates/blocks/components/TopNav/TopNavBasicNavWithHeadingAndItems.doc.mjs
@@ -5,5 +5,5 @@ export const doc = {
   description: 'Basic nav with heading and items',
   isReady: true,
   aspectRatio: 16 / 4,
-  componentsUsed: ['TopNav', 'TopNavHeading', 'NavIcon', 'TopNavItem', 'Button'],
+  componentsUsed: ['Button', 'NavIcon', 'TopNav'],
 };

--- a/packages/cli/templates/blocks/components/TopNav/TopNavInXDSLayoutHeaderSlot.doc.mjs
+++ b/packages/cli/templates/blocks/components/TopNav/TopNavInXDSLayoutHeaderSlot.doc.mjs
@@ -5,5 +5,5 @@ export const doc = {
   description: 'In XDSLayout header slot',
   isReady: true,
   aspectRatio: 16 / 4,
-  componentsUsed: ['Layout', 'TopNav', 'TopNavHeading', 'TopNavItem', 'LayoutContent'],
+  componentsUsed: ['Layout', 'TopNav'],
 };

--- a/packages/cli/templates/blocks/components/TopNav/TopNavWithCenteredContentThreecolumnLayout.doc.mjs
+++ b/packages/cli/templates/blocks/components/TopNav/TopNavWithCenteredContentThreecolumnLayout.doc.mjs
@@ -5,5 +5,5 @@ export const doc = {
   description: 'With centered content (three-column layout)',
   isReady: true,
   aspectRatio: 16 / 4,
-  componentsUsed: ['TopNav', 'TopNavHeading', 'TopNavItem'],
+  componentsUsed: ['TopNav'],
 };

--- a/packages/cli/templates/blocks/components/TopNav/TopNavWithHoverMenuAndMegaMenu.doc.mjs
+++ b/packages/cli/templates/blocks/components/TopNav/TopNavWithHoverMenuAndMegaMenu.doc.mjs
@@ -5,5 +5,5 @@ export const doc = {
   description: 'With hover menu and mega menu',
   isReady: true,
   aspectRatio: 16 / 4,
-  componentsUsed: ['TopNav', 'TopNavHeading', 'TopNavItem', 'TopNavMenu', 'TopNavMegaMenu', 'TopNavMegaMenuItem', 'TopNavMegaMenuFeaturedCard'],
+  componentsUsed: ['TopNav'],
 };

--- a/packages/cli/templates/blocks/components/Typeahead/TypeaheadWithCustomItemRendering.doc.mjs
+++ b/packages/cli/templates/blocks/components/Typeahead/TypeaheadWithCustomItemRendering.doc.mjs
@@ -5,5 +5,5 @@ export const doc = {
   description: 'With custom item rendering',
   isReady: true,
   aspectRatio: 4 / 3,
-  componentsUsed: ['Typeahead', 'TypeaheadItem', 'Avatar'],
+  componentsUsed: ['Avatar', 'Typeahead'],
 };


### PR DESCRIPTION
## What

51 block `.doc.mjs` files had `componentsUsed` arrays listing sub-component names (e.g. `HStack`, `TopNavItem`, `Tab`) instead of the actual `@xds/core/Module` import path names (e.g. `Layout`, `TopNav`, `TabList`).

### Pattern examples

| Block | Before | After |
|-------|--------|-------|
| StackHeaderLayout | `['Stack', 'HStack', 'StackItem']` | `['Layout']` |
| TopNavWithHoverMenuAndMegaMenu | `['TopNav', 'TopNavHeading', 'TopNavItem', ...]` | `['TopNav']` |
| TableBasicDatadrivenTable | `['Avatar', 'Badge', 'HStack', ...]` | `['Avatar', 'Badge', 'Layout', ...]` |
| DateInputBasic | `['DateInput']` | `['Calendar', 'DateInput']` |

Sub-components like `XDSHStack`, `XDSTopNavItem`, `XDSTab` are re-exported from their parent packages (`Layout`, `TopNav`, `TabList`). The `componentsUsed` field should reference the import path segment, matching `from '@xds/core/X'` in the tsx file.

## Scope
- 51 files, 1-line change each
- All changes are mechanical: old componentsUsed → new componentsUsed derived from tsx imports

## Checklist
- [x] Changes are minimal and mechanical
- [x] Each fix derived from actual `@xds/core/*` imports in the corresponding `.tsx` file
- [x] No template logic or rendering changes

---
*Night Watch Doc Reviewer*