### PR TITLE
fix: hardening audit — AlertDialog, CheckboxList, Table, Carousel, Thumbnail

### DIFF
--- a/packages/core/src/AlertDialog/XDSAlertDialog.tsx
+++ b/packages/core/src/AlertDialog/XDSAlertDialog.tsx
@@ -22,9 +22,10 @@ import {XDSHStack} from '../Stack';
 import {XDSHeading} from '../Text/XDSHeading';
 import {XDSText} from '../Text/XDSText';
 import {XDSButton, type XDSButtonVariant} from '../Button';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import {xdsClassName} from '../utils';
 
-export interface XDSAlertDialogProps {
+export interface XDSAlertDialogProps extends XDSBaseProps<HTMLDivElement> {
   /**
    * Whether the dialog is open.
    */
@@ -113,6 +114,10 @@ export function XDSAlertDialog({
   isActionLoading,
   onAction,
   width = 400,
+  xstyle,
+  className,
+  style,
+  'data-testid': testId,
 }: XDSAlertDialogProps) {
   const titleId = useId();
   const descriptionId = useId();
@@ -130,7 +135,12 @@ export function XDSAlertDialog({
       role="alertdialog"
       aria-labelledby={titleId}
       aria-describedby={descriptionId}
-      className={xdsClassName('alert-dialog')}>
+      className={
+        xdsClassName('alert-dialog') + (className ? ` ${className}` : '')
+      }
+      xstyle={xstyle}
+      style={style}
+      data-testid={testId}>
       <XDSLayout
         content={
           <XDSLayoutContent>

--- a/packages/core/src/Carousel/index.ts
+++ b/packages/core/src/Carousel/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file index.ts
  * @input XDSCarousel component

--- a/packages/core/src/CheckboxList/XDSCheckboxList.tsx
+++ b/packages/core/src/CheckboxList/XDSCheckboxList.tsx
@@ -19,6 +19,7 @@ import {XDSField} from '../Field/XDSField';
 import type {XDSInputStatus} from '../Field/types';
 import {XDSList} from '../List/XDSList';
 import type {XDSListDensity} from '../List/XDSListContext';
+import {xdsClassName} from '../utils';
 import {
   XDSCheckboxListContext,
   type XDSCheckboxListContextValue,
@@ -205,7 +206,9 @@ export function XDSCheckboxList({
       }
       statusVariant="detached"
       xstyle={xstyle}
-      className={className}
+      className={
+        xdsClassName('checkbox-list') + (className ? ` ${className}` : '')
+      }
       style={style}>
       <XDSCheckboxListContext.Provider value={contextValue}>
         <XDSList density={density} hasDividers={hasDividers}>

--- a/packages/core/src/Table/XDSBaseTable.tsx
+++ b/packages/core/src/Table/XDSBaseTable.tsx
@@ -396,7 +396,10 @@ function XDSBaseTableInner<T extends Record<string, unknown>>({
       ref={ref}
       {...tableRenderProps.htmlProps}
       {...mergeProps(
-        xdsClassName('base-table'),
+        xdsClassName('base-table') +
+          (tableRenderProps.htmlProps.className
+            ? ` ${tableRenderProps.htmlProps.className}`
+            : ''),
         stylex.props(...tableRenderProps.styles),
       )}
       style={tableStyle}>

--- a/packages/core/src/Table/XDSTable.tsx
+++ b/packages/core/src/Table/XDSTable.tsx
@@ -22,6 +22,7 @@ import {XDSTableCell} from './XDSTableCell';
 import {XDSTableHeaderCell} from './XDSTableHeaderCell';
 import {XDSTableContext} from './XDSTableContext';
 import {useXDSBaseTablePlugins} from './useXDSBaseTablePlugins';
+import {xdsClassName} from '../utils';
 import type {
   XDSBaseTableProps,
   XDSTableVerticalAlign,
@@ -120,8 +121,16 @@ function buildTableStylePlugin<
 >(): TablePlugin<T> {
   return {
     transformTable(props: TableRenderProps): TableRenderProps {
+      const existingClass = props.htmlProps.className ?? '';
+      const tableClass = xdsClassName('table');
       return {
         ...props,
+        htmlProps: {
+          ...props.htmlProps,
+          className: existingClass
+            ? `${existingClass} ${tableClass}`
+            : tableClass,
+        },
         styles: [...props.styles, tableStyles.base, tableStyles.containerBleed],
       };
     },

--- a/packages/core/src/Thumbnail/index.ts
+++ b/packages/core/src/Thumbnail/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file Thumbnail component barrel export
  */


### PR DESCRIPTION
## Hardening Audit — 2026-04-20

Component audit addressing open hardening issues.

### Fixes

| Component | Issue | Fix |
|-----------|-------|-----|
| AlertDialog | `XDSAlertDialogProps` missing escape hatches | Extend `XDSBaseProps` — adds `xstyle`, `className`, `style`, `data-testid` |
| CheckboxList | No `xdsClassName` targeting surface | Add `xdsClassName('checkbox-list')` to root |
| Table | `XDSTable` indistinguishable from `XDSBaseTable` for theming | Add `xdsClassName('table')` via style plugin; preserve `htmlProps.className` in `XDSBaseTable` |
| Carousel | Missing `'use client'` on index.ts | Add directive |
| Thumbnail | Missing `'use client'` on index.ts | Add directive |

### Also Audited (Clean)

Toast, Markdown, Toolbar, MultiSelector — all pass CSS variable usage, xdsClassName placement, prop naming, type naming, structure, accessibility, and export hygiene checks.

### Needs Review

- **Table xdsClassName approach**: The plugin pipeline approach adds `'xds-table'` to the table element's class list alongside `'xds-base-table'`. This preserves backward compatibility — existing `@scope .xds-base-table` selectors still work, while themes can now also target `.xds-table` for styled-specific overrides.

---

Addresses: #1385, #1307, #1288, #1227, #1142, #1141, #1018, #1017, #909