### PR TITLE
fix: component audit — SegmentedControl, Slider extend XDSBaseProps

### DIFF
--- a/packages/core/src/SegmentedControl/XDSSegmentedControl.tsx
+++ b/packages/core/src/SegmentedControl/XDSSegmentedControl.tsx
@@ -21,7 +21,10 @@ import {xdsClassName, mergeProps} from '../utils';
 import {useXDSSize} from '../SizeContext/XDSSizeContext';
 import type {XDSBaseProps} from '../XDSBaseProps';
 
-export interface XDSSegmentedControlProps extends XDSBaseProps<HTMLDivElement> {
+export interface XDSSegmentedControlProps extends Omit<
+  XDSBaseProps<HTMLDivElement>,
+  'onChange'
+> {
   /**
    * The currently selected value (controlled).
    */

--- a/packages/core/src/SegmentedControl/XDSSegmentedControl.tsx
+++ b/packages/core/src/SegmentedControl/XDSSegmentedControl.tsx
@@ -14,14 +14,14 @@
 
 import React, {useMemo, useRef, useCallback, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import type {StyleXStyles} from '@stylexjs/stylex';
 import {colorVars, spacingVars, radiusVars} from '../theme/tokens.stylex';
 import {XDSSegmentedControlContext} from './XDSSegmentedControlContext';
 import type {XDSSegmentedControlSize} from './XDSSegmentedControlContext';
 import {xdsClassName, mergeProps} from '../utils';
 import {useXDSSize} from '../SizeContext/XDSSizeContext';
+import type {XDSBaseProps} from '../XDSBaseProps';
 
-export interface XDSSegmentedControlProps {
+export interface XDSSegmentedControlProps extends XDSBaseProps<HTMLDivElement> {
   /**
    * The currently selected value (controlled).
    */
@@ -48,20 +48,6 @@ export interface XDSSegmentedControlProps {
    * XDSSegmentedControlItem children.
    */
   children: ReactNode;
-  /**
-   * Additional StyleX styles for the container.
-   */
-  xstyle?: StyleXStyles;
-  /**
-   * CSS class name(s) appended to the root element.
-   * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
-   */
-  className?: string;
-  /**
-   * Inline styles to apply to the root element. Spread after StyleX
-   * inline styles, so these values take priority.
-   */
-  style?: React.CSSProperties;
 }
 
 // =============================================================================

--- a/packages/core/src/Slider/XDSSlider.tsx
+++ b/packages/core/src/Slider/XDSSlider.tsx
@@ -21,7 +21,6 @@ import {
   type PointerEvent,
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
-import type {StyleXStyles} from '@stylexjs/stylex';
 import {
   colorVars,
   spacingVars,
@@ -35,12 +34,13 @@ import {XDSField} from '../Field/XDSField';
 import {XDSTooltip} from '../Tooltip/XDSTooltip';
 import type {XDSInputStatus} from '../Field/types';
 import {xdsClassName, mergeProps} from '../utils';
+import type {XDSBaseProps} from '../XDSBaseProps';
 
 // =============================================================================
 // Types
 // =============================================================================
 
-export interface XDSSliderBaseProps {
+export interface XDSSliderBaseProps extends XDSBaseProps<HTMLDivElement> {
   /** Ref forwarded to the root element */
   ref?: React.Ref<HTMLDivElement>;
   /** Label text for the slider (always rendered for accessibility). */
@@ -73,27 +73,6 @@ export interface XDSSliderBaseProps {
   valueDisplay?: 'tooltip' | 'text' | 'none';
   /** Tick marks at specified positions with optional labels. */
   marks?: Array<{value: number; label?: string}>;
-  /**
-   * StyleX styles created via `stylex.create()`. Merged with the component's
-   * base styles inside a single `stylex.props()` call for optimal deduplication.
-   *
-   * @example
-   * ```
-   * const overrides = stylex.create({ root: { marginBottom: 8 } });
-   * <Component xstyle={overrides.root} />
-   * ```
-   */
-  xstyle?: StyleXStyles;
-  /**
-   * CSS class name(s) appended to the root element.
-   * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
-   */
-  className?: string;
-  /**
-   * Inline styles to apply to the root element. Spread after StyleX
-   * inline styles, so these values take priority.
-   */
-  style?: React.CSSProperties;
   /** Test ID for the root element. */
   'data-testid'?: string;
 }

--- a/packages/core/src/Slider/XDSSlider.tsx
+++ b/packages/core/src/Slider/XDSSlider.tsx
@@ -40,7 +40,10 @@ import type {XDSBaseProps} from '../XDSBaseProps';
 // Types
 // =============================================================================
 
-export interface XDSSliderBaseProps extends XDSBaseProps<HTMLDivElement> {
+export interface XDSSliderBaseProps extends Omit<
+  XDSBaseProps<HTMLDivElement>,
+  'onChange'
+> {
   /** Ref forwarded to the root element */
   ref?: React.Ref<HTMLDivElement>;
   /** Label text for the slider (always rendered for accessibility). */


### PR DESCRIPTION
## Component Audit — Queue Round (2026-04-20)

Audited 5 components from the queue: SegmentedControl, Selector, SideNav, Skeleton, Slider.

### Fixes

| Component | Fix |
|-----------|-----|
| SegmentedControl | Migrate inline `xstyle`/`className`/`style` props to extend `XDSBaseProps<HTMLDivElement>` |
| Slider | Migrate inline `xstyle`/`className`/`style` props to extend `XDSBaseProps<HTMLDivElement>` |

### Clean (No Issues)

- **Selector** — already extends `XDSBaseProps`, has `xdsClassName`, proper structure
- **SideNav** — extends `XDSBaseProps`, all 4 sub-components (`Item`, `Heading`, `Section`, `CollapseButton`) have `xdsClassName` and `displayName`
- **Skeleton** — extends `XDSBaseProps`, uses `xdsClassName`, all tokens correct

### Notes

Both fixes are non-breaking — the props were already defined inline with the same types. This change improves consistency by using the shared `XDSBaseProps` interface, which ensures the escape hatch pattern stays uniform across all components.