### PR TITLE
chore(templates): remove unused XDSSection import from settings-sidebar

### DIFF
--- a/packages/cli/templates/pages/settings-sidebar/page.tsx
+++ b/packages/cli/templates/pages/settings-sidebar/page.tsx
@@ -10,7 +10,6 @@ import {XDSLink} from '@xds/core/Link';
 import {XDSButton} from '@xds/core/Button';
 import {XDSSelector} from '@xds/core/Selector';
 import {XDSCard} from '@xds/core/Card';
-import {XDSSection} from '@xds/core/Section';
 import {XDSSwitch} from '@xds/core/Switch';
 import {XDSDivider} from '@xds/core/Divider';
 import {XDSTabList, XDSTab} from '@xds/core/TabList';


### PR DESCRIPTION
## Summary
- Remove unused `XDSSection` import from `settings-sidebar/page.tsx` — imported but never referenced

Identified during the dead code audit in #1507.

## Test plan
- [ ] Verify settings-sidebar template still renders correctly
- [ ] Confirm no other references to `XDSSection` exist in the file

Made with [Cursor](https://cursor.com)