### PR TITLE
fix(templates): use correct xds_oss CDN images for login templates

### DIFF
--- a/packages/cli/templates/pages/login-split/page.tsx
+++ b/packages/cli/templates/pages/login-split/page.tsx
@@ -19,9 +19,9 @@ import {
   radiusVars,
 } from '@xds/core/theme/tokens.stylex';
 
-// colorful-lifestyle-vertical-1 from xds_oss asset set
+// light-working-vertical-1 from xds_oss asset set
 const COVER_IMAGE_URL =
-  'https://scontent.xx.fbcdn.net/v/t39.6806-6/670480937_2502078110200666_6842204180822201520_n.png?_nc_cat=100&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=CkjsPqmDibQQ7kNvwGqbpNN&_nc_oc=Adp5jI8z5m0aqhA07RtwoFUrqqr3jc6tQshxd5Hr5UyL_DIkFt0wEIQwLeKgXOg1lTBG_Ncth9lSFM0vmPqMxbfx&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=eCyOnLSq2cMADZiwJgLJaQ&_nc_ss=7a30f&oh=00_Af2sEmvEqZa5nd1SqocypZQnRh_FLwZHEBOrG0LTR7tfdA&oe=69E852F4';
+  'https://scontent.xx.fbcdn.net/v/t39.6806-6/671925666_4495480327349179_31826850576590602_n.png?_nc_cat=108&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=nHeGVeCH7wIQ7kNvwEe_ed5&_nc_oc=AdrmcEXVuygkqWh3Gd9ap9XNslAE4LphVAtWeNXNglbrdryrAnVn7b1pI489fHosZUwgNv1UWgRTizw-6x0E48MI&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=soyKpwlpum27aTB16xwsWg&_nc_ss=7a30f&oh=00_Af2VtQRME3fzALwgGvOuScpGMWsY5hpgmGN1E4nGG6hhWQ&oe=69EC2E2B';
 
 const AppleIcon = (props: React.SVGProps<SVGSVGElement>) => (
   <svg viewBox="0 0 24 24" fill="currentColor" width={16} height={16} {...props}>

--- a/packages/cli/templates/pages/login-sso/page.tsx
+++ b/packages/cli/templates/pages/login-sso/page.tsx
@@ -20,9 +20,9 @@ import {shadowVars} from '@xds/core/theme/tokens.stylex';
 // Styles
 // ---------------------------------------------------------------------------
 
-// moody-scene-horizontal-1 from xds_oss asset set
+// building from xds_oss asset set
 const BG_URL =
-  'https://scontent.xx.fbcdn.net/v/t39.6806-6/672863405_1398068472358179_8859473259447111379_n.png?_nc_cat=100&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=-wV2jHO2HVUQ7kNvwHGzCzr&_nc_oc=AdrxH65fOWB9AYbTJt499HTYmTlEoQ2-Gq4v0HixJT92Mz5awWgcZNSxSTRZJPypWIDapoCWcQ2JcNruqRd9ovzp&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=ak5CKQPy-Mq6Vm7qld0MTw&_nc_ss=7a30f&oh=00_Af03yc18QziUpPjAs6EJMXwjb9gx2bfazL1ccL5840WQdw&oe=69E8390A';
+  'https://scontent.xx.fbcdn.net/v/t39.6806-6/673946116_928438936673086_7955596512102197644_n.jpg?_nc_cat=103&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=PVl7FEhjCusQ7kNvwEIGngs&_nc_oc=AdpqpGsFv2Z4UswEve2B2ZCHTKIXDjyDvMT-4Z3wfkVRnE3bKLbU4_DLcVEg3Z1ZVLDKyB3qEi1_KDcmHVsxDFWV&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=rUsd40W1gpadk3EzTZm5Tw&_nc_ss=7a30f&oh=00_Af1sx6n6V2eu3whVV18i5CYuQkQb_Ry2BN-V-2_DWlcWgw&oe=69EC4058';
 
 const styles = stylex.create({
   page: {


### PR DESCRIPTION
## Summary
- **login-split**: Replaced wrong CDN image (`colorful-lifestyle-vertical-1`) with the correct `light-working-vertical-1` from xds_oss
- **login-sso**: Replaced wrong CDN image (`moody-scene-horizontal-1`) with the correct `building` from xds_oss

The previous PR (#1524) swapped local image paths to CDN URLs but picked the wrong xds_oss assets. This fixes both to match the original images.

## Test plan
- [ ] Verify login-split cover image matches the original `light-working-vertical-1.png`
- [ ] Verify login-sso background image matches the original `login-sso-bg.jpg` (architectural building photo)
- [ ] Check deployed preview at `/templates/login-split/` and `/templates/login-sso/`

Made with [Cursor](https://cursor.com)