### PR TITLE
fix(file-explorer): add horizontal padding to toolbar

### DIFF
--- a/packages/cli/templates/pages/file-explorer/page.tsx
+++ b/packages/cli/templates/pages/file-explorer/page.tsx
@@ -263,6 +263,7 @@ const styles = stylex.create({
   scrollable: {overflowY: 'auto'},
   fixedColumn: {flexShrink: 0, alignSelf: 'stretch'},
   fillRemaining: {flex: 1, alignSelf: 'stretch'},
+  toolbarPadding: {paddingInline: 4},
 });
 
 function findItem(items: FileSystemItem[], id: string): FileSystemItem | null {
@@ -341,6 +342,7 @@ export default function FileExplorerPage() {
             label="File Explorer"
             size="sm"
             dividers={['bottom']}
+            xstyle={styles.toolbarPadding}
             startContent={
               <>
                 <XDSIconButton


### PR DESCRIPTION
## Summary
- Adds 4px inline (left/right) padding to the file explorer toolbar via `xstyle`

## Test plan
- [ ] Verify toolbar has visible horizontal padding in the sandbox file-explorer template


Made with [Cursor](https://cursor.com)