### PR TITLE
fix(templates): bring detail-page and product-detail to rubric compliance

### DIFF
--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/AppTopNav.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/AppTopNav.tsx
@@ -8,8 +8,9 @@ import {XDSStack} from '@xds/core/Layout';
 import {XDSList, XDSListItem} from '@xds/core/List';
 import {XDSDropdownMenu} from '@xds/core/DropdownMenu';
 import {XDSCommandPalette} from '@xds/core/CommandPalette';
+import {XDSText} from '@xds/core/Text';
 import {SearchIcon, ProfileIcon, FilterIcon} from './docsite-icons';
-import {SEARCH_COMMANDS, basePath} from './constants';
+import {SEARCH_COMMANDS} from './constants';
 
 const XDS_WORDMARK = (
   <svg
@@ -53,8 +54,10 @@ export function AppTopNav({
   onFilterOpenChange,
   craftTitle,
 }: {
-  activeView: 'craft' | 'explore' | 'docs' | 'profile';
-  setActiveView: (view: 'craft' | 'explore' | 'docs' | 'profile') => void;
+  activeView: 'craft' | 'explore' | 'docs' | 'profile' | 'theme';
+  setActiveView: (
+    view: 'craft' | 'explore' | 'docs' | 'profile' | 'theme',
+  ) => void;
   scrollContainerRef?: React.RefObject<HTMLDivElement | null>;
   activeTab: string;
   onActiveTabChange: (tab: string) => void;
@@ -86,6 +89,15 @@ export function AppTopNav({
     <XDSList density="spacious" style={{minWidth: 240}}>
       <XDSListItem label="Craft" onClick={() => setActiveView('craft')} />
       <XDSListItem label="Library" onClick={() => setActiveView('docs')} />
+      <XDSListItem
+        label="Theme Editor"
+        onClick={() => setActiveView('theme')}
+        endContent={
+          <XDSText color="secondary" size="sm">
+            Temporary
+          </XDSText>
+        }
+      />
     </XDSList>
   );
 
@@ -104,7 +116,7 @@ export function AppTopNav({
         heading={
           <XDSTopNavHeading
             logo={XDS_WORDMARK}
-            headingHref={`${basePath}/pages/docsite/`}
+            headingHref="/pages/docsite/"
             menu={headingMenu}
           />
         }

--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/ThemeEditorView.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/ThemeEditorView.tsx
@@ -1,0 +1,5180 @@
+'use client';
+
+import * as React from 'react';
+import {XDSButton} from '@xds/core/Button';
+import {XDSToggleButton, XDSToggleButtonGroup} from '@xds/core/ToggleButton';
+import {XDSTextInput} from '@xds/core/TextInput';
+import {XDSBadge} from '@xds/core/Badge';
+import {XDSCard} from '@xds/core/Card';
+import {XDSHStack, XDSVStack, XDSStack} from '@xds/core/Stack';
+import {
+  XDSLayout,
+  XDSLayoutHeader,
+  XDSLayoutContent,
+  XDSLayoutFooter,
+} from '@xds/core/Layout';
+import {XDSText, XDSHeading} from '@xds/core/Text';
+import {XDSSwitch} from '@xds/core/Switch';
+import {XDSAvatar} from '@xds/core/Avatar';
+import {XDSBanner} from '@xds/core/Banner';
+import {XDSTabList, XDSTab} from '@xds/core/TabList';
+import {XDSDialog} from '@xds/core/Dialog';
+import {XDSToken} from '@xds/core/Token';
+import {XDSSlider} from '@xds/core/Slider';
+import {XDSSelector} from '@xds/core/Selector';
+import {XDSProgressBar} from '@xds/core/ProgressBar';
+import {XDSCheckboxInput} from '@xds/core/CheckboxInput';
+import {XDSRadioList, XDSRadioListItem} from '@xds/core/RadioList';
+import {XDSTable, proportional, pixel} from '@xds/core/Table';
+import type {XDSTableColumn} from '@xds/core/Table';
+import {XDSDivider} from '@xds/core/Divider';
+import {XDSDropdownMenu} from '@xds/core/DropdownMenu';
+import {XDSPopover} from '@xds/core/Popover';
+import {XDSHoverCard} from '@xds/core/HoverCard';
+import {XDSTooltip} from '@xds/core/Tooltip';
+import {XDSSpinner} from '@xds/core/Spinner';
+import {XDSMarkdown} from '@xds/core/Markdown';
+import {XDSCodeBlock} from '@xds/core/CodeBlock';
+import {
+  XDSSegmentedControl,
+  XDSSegmentedControlItem,
+} from '@xds/core/SegmentedControl';
+import {XDSSkeleton} from '@xds/core/Skeleton';
+import {XDSStatusDot} from '@xds/core/StatusDot';
+import {XDSIcon} from '@xds/core/Icon';
+import {XDSLink} from '@xds/core/Link';
+import {XDSBreadcrumbs, XDSBreadcrumbItem} from '@xds/core/Breadcrumbs';
+import {XDSCollapsible, XDSCollapsibleGroup} from '@xds/core/Collapsible';
+import {XDSCalendar} from '@xds/core/Calendar';
+import {XDSList, XDSListItem} from '@xds/core/List';
+import {XDSAppShell} from '@xds/core/AppShell';
+import {
+  XDSSideNav,
+  XDSSideNavItem,
+  XDSSideNavSection,
+  XDSSideNavCollapseButton,
+  XDSSideNavHeading,
+} from '@xds/core/SideNav';
+import {XDSNavIcon} from '@xds/core/NavIcon';
+import {XDSPowerSearch, usePowerSearchConfig} from '@xds/core/PowerSearch';
+import type {PowerSearchFilter} from '@xds/core/PowerSearch';
+import {
+  XDSTheme,
+  defineTheme,
+  expandTypeScale,
+  expandRadiusScale,
+  expandColorScale,
+  generateThemeCSSFlat,
+} from '@xds/core/theme';
+import type {XDSDefinedTheme} from '@xds/core/theme';
+import {templates} from '../../../../generated/templateRegistry';
+import {
+  colorDefaults,
+  spacingDefaults,
+  radiusDefaults,
+  typographyDefaults,
+  textSizeDefaults,
+  fontWeightDefaults,
+  typeScaleDefaults,
+  sizeDefaults,
+  shadowDefaults,
+  durationDefaults,
+  easeDefaults,
+  transitionDefaults,
+} from '@xds/core/theme';
+import {defaultIconRegistry} from '@xds/theme-default';
+import {
+  HomeIcon,
+  FolderIcon,
+  CubeIcon,
+  XMarkIcon,
+  ChartBarIcon,
+  UserGroupIcon,
+  DocumentTextIcon,
+  PhotoIcon,
+} from '@heroicons/react/24/outline';
+import {
+  HomeIcon as HomeIconSolid,
+  FolderIcon as FolderIconSolid,
+} from '@heroicons/react/24/solid';
+import {MoonIcon, ContrastIcon} from './docsite-icons';
+
+// =============================================================================
+// Token Groups
+// =============================================================================
+
+const TOKEN_GROUPS = {
+  colors: {
+    label: 'Colors',
+    description:
+      'Semantic color tokens for text, backgrounds, borders, and states',
+    tokens: colorDefaults,
+  },
+  spacing: {
+    label: 'Spacing',
+    description: 'Consistent spacing scale for margins, padding, and gaps',
+    tokens: spacingDefaults,
+  },
+  radius: {
+    label: 'Radius',
+    description: 'Border radius tokens for rounded corners',
+    tokens: radiusDefaults,
+  },
+  typography: {
+    label: 'Typography',
+    description: 'Font families, sizes, weights, and line heights',
+    tokens: {
+      ...typographyDefaults,
+      ...textSizeDefaults,
+      ...fontWeightDefaults,
+    },
+  },
+  size: {
+    label: 'Size',
+    description: 'Component size tokens (sm, md, lg)',
+    tokens: sizeDefaults,
+  },
+  shadow: {
+    label: 'Elevation',
+    description: 'Shadow tokens',
+    tokens: shadowDefaults,
+  },
+  duration: {
+    label: 'Duration',
+    description: 'Motion duration tokens',
+    tokens: durationDefaults,
+  },
+  easing: {
+    label: 'Easing',
+    description: 'Motion easing tokens',
+    tokens: easeDefaults,
+  },
+} as const;
+
+type TokenGroupKey = keyof typeof TOKEN_GROUPS;
+
+// =============================================================================
+// Component-Scoped CSS Custom Properties
+// =============================================================================
+
+interface ComponentVar {
+  name: string;
+  default: string;
+  description: string;
+  options: Array<{value: string; label: string}>;
+}
+
+const RADIUS_OPTIONS = [
+  {value: 'var(--radius-none)', label: 'None'},
+  {value: 'var(--radius-inner)', label: 'Inner'},
+  {value: 'var(--radius-element)', label: 'Element'},
+  {value: 'var(--radius-container)', label: 'Container'},
+  {value: 'var(--radius-page)', label: 'Page'},
+  {value: 'var(--radius-full)', label: 'Full'},
+];
+
+const SPACING_OPTIONS = [
+  {value: 'var(--spacing-0-5)', label: '0.5'},
+  {value: 'var(--spacing-1)', label: '1'},
+  {value: 'var(--spacing-2)', label: '2'},
+  {value: 'var(--spacing-3)', label: '3'},
+  {value: 'var(--spacing-4)', label: '4'},
+  {value: 'var(--spacing-6)', label: '6'},
+  {value: 'var(--spacing-8)', label: '8'},
+];
+
+const COMPONENT_VARS: Record<string, {label: string; vars: ComponentVar[]}> = {
+  button: {
+    label: 'Button',
+    vars: [
+      {
+        name: '--button-radius',
+        default: 'var(--radius-element)',
+        description: 'Border radius',
+        options: RADIUS_OPTIONS,
+      },
+      {
+        name: '--button-press-scale',
+        default: 'scale(0.98)',
+        description: 'Active press transform',
+        options: [
+          {value: 'scale(1)', label: 'None'},
+          {value: 'scale(0.99)', label: 'Subtle'},
+          {value: 'scale(0.98)', label: 'Default'},
+          {value: 'scale(0.96)', label: 'Strong'},
+          {value: 'scale(0.94)', label: 'Heavy'},
+        ],
+      },
+      {
+        name: '--button-disabled-opacity',
+        default: '0.5',
+        description: 'Opacity when disabled',
+        options: [
+          {value: '0.3', label: '0.3'},
+          {value: '0.4', label: '0.4'},
+          {value: '0.5', label: '0.5 (Default)'},
+          {value: '0.6', label: '0.6'},
+          {value: '0.7', label: '0.7'},
+          {value: '1', label: '1.0 (Opaque)'},
+        ],
+      },
+      {
+        name: '--button-focus-offset',
+        default: '3px',
+        description: 'Focus ring outline offset',
+        options: [
+          {value: '1px', label: '1px'},
+          {value: '2px', label: '2px'},
+          {value: '3px', label: '3px (Default)'},
+          {value: '4px', label: '4px'},
+          {value: '6px', label: '6px'},
+        ],
+      },
+      {
+        name: '--button-icon-only-aspect',
+        default: '1 / 1',
+        description: 'Aspect ratio for icon-only buttons',
+        options: [
+          {value: '1 / 1', label: '1:1 Square (Default)'},
+          {value: 'auto', label: 'Auto'},
+        ],
+      },
+    ],
+  },
+  card: {
+    label: 'Card',
+    vars: [
+      {
+        name: '--card-radius',
+        default: 'var(--radius-container)',
+        description: 'Border radius',
+        options: RADIUS_OPTIONS,
+      },
+    ],
+  },
+  dialog: {
+    label: 'Dialog',
+    vars: [
+      {
+        name: '--dialog-radius',
+        default: 'var(--radius-container)',
+        description: 'Border radius',
+        options: RADIUS_OPTIONS,
+      },
+    ],
+  },
+  'dropdown-menu': {
+    label: 'Dropdown Menu',
+    vars: [
+      {
+        name: '--dropdown-radius',
+        default: 'var(--radius-element)',
+        description: 'Border radius of menu popup',
+        options: RADIUS_OPTIONS,
+      },
+      {
+        name: '--dropdown-padding',
+        default: 'var(--spacing-1)',
+        description: 'Inner padding of menu popup',
+        options: SPACING_OPTIONS,
+      },
+    ],
+  },
+  popover: {
+    label: 'Popover',
+    vars: [
+      {
+        name: '--popover-radius',
+        default: 'var(--radius-element)',
+        description: 'Border radius',
+        options: RADIUS_OPTIONS,
+      },
+    ],
+  },
+  hovercard: {
+    label: 'Hover Card',
+    vars: [
+      {
+        name: '--hovercard-radius',
+        default: 'var(--radius-container)',
+        description: 'Border radius',
+        options: RADIUS_OPTIONS,
+      },
+    ],
+  },
+  field: {
+    label: 'Field / Input',
+    vars: [
+      {
+        name: '--input-radius',
+        default: 'var(--radius-element)',
+        description: 'Border radius of input fields',
+        options: RADIUS_OPTIONS,
+      },
+    ],
+  },
+  banner: {
+    label: 'Banner',
+    vars: [
+      {
+        name: '--banner-radius',
+        default: 'var(--radius-container)',
+        description: 'Border radius',
+        options: RADIUS_OPTIONS,
+      },
+    ],
+  },
+  'chat-composer': {
+    label: 'Chat Composer',
+    vars: [
+      {
+        name: '--composer-radius',
+        default: 'var(--radius-page)',
+        description: 'Border radius of composer body',
+        options: RADIUS_OPTIONS,
+      },
+      {
+        name: '--composer-padding',
+        default: 'var(--spacing-3)',
+        description: 'Padding of composer body',
+        options: SPACING_OPTIONS,
+      },
+    ],
+  },
+};
+
+const RATIO_OPTIONS = [
+  {value: 1.067, label: '1.067 — Minor Second'},
+  {value: 1.125, label: '1.125 — Major Second'},
+  {value: 1.2, label: '1.200 — Minor Third'},
+  {value: 1.25, label: '1.250 — Major Third'},
+  {value: 1.333, label: '1.333 — Perfect Fourth'},
+  {value: 1.414, label: '1.414 — Augmented Fourth'},
+  {value: 1.5, label: '1.500 — Perfect Fifth'},
+  {value: 1.618, label: '1.618 — Golden Ratio'},
+];
+
+// =============================================================================
+// Color Categories
+// =============================================================================
+
+const COLOR_CATEGORIES = {
+  'Core Semantic': [
+    '--color-accent',
+    '--color-accent-muted',
+    '--color-neutral',
+    '--color-overlay',
+  ],
+  'Interactive States': [
+    '--color-overlay-hover',
+    '--color-overlay-pressed',
+    '--color-accent',
+    '--color-error',
+    '--color-success',
+    '--color-warning',
+    '--color-background-muted',
+  ],
+  Text: [
+    '--color-text-primary',
+    '--color-text-secondary',
+    '--color-text-disabled',
+    '--color-text-accent',
+    '--color-on-dark',
+  ],
+  Icon: [
+    '--color-icon-primary',
+    '--color-icon-secondary',
+    '--color-icon-disabled',
+  ],
+  'Surface Variants': [
+    '--color-background-surface',
+    '--color-background-body',
+    '--color-background-card',
+    '--color-background-popover',
+  ],
+  'Status/Sentiment': [
+    '--color-success',
+    '--color-success-muted',
+    '--color-error',
+    '--color-error-muted',
+    '--color-warning',
+    '--color-warning-muted',
+  ],
+  Divider: ['--color-border', '--color-border-emphasized'],
+  Effects: ['--color-skeleton', '--color-shadow', '--color-tint-hover'],
+  'Palette: Blue': [
+    '--color-background-blue',
+    '--color-border-blue',
+    '--color-icon-blue',
+    '--color-text-blue',
+  ],
+  'Palette: Green': [
+    '--color-background-green',
+    '--color-border-green',
+    '--color-icon-green',
+    '--color-text-green',
+  ],
+  'Palette: Red': [
+    '--color-background-red',
+    '--color-border-red',
+    '--color-icon-red',
+    '--color-text-red',
+  ],
+  'Palette: Yellow': [
+    '--color-background-yellow',
+    '--color-border-yellow',
+    '--color-icon-yellow',
+    '--color-text-yellow',
+  ],
+  'Palette: Orange': [
+    '--color-background-orange',
+    '--color-border-orange',
+    '--color-icon-orange',
+    '--color-text-orange',
+  ],
+  'Palette: Purple': [
+    '--color-background-purple',
+    '--color-border-purple',
+    '--color-icon-purple',
+    '--color-text-purple',
+  ],
+  'Palette: Pink': [
+    '--color-background-pink',
+    '--color-border-pink',
+    '--color-icon-pink',
+    '--color-text-pink',
+  ],
+  'Palette: Teal': [
+    '--color-background-teal',
+    '--color-border-teal',
+    '--color-icon-teal',
+    '--color-text-teal',
+  ],
+  'Palette: Cyan': [
+    '--color-background-cyan',
+    '--color-border-cyan',
+    '--color-icon-cyan',
+    '--color-text-cyan',
+  ],
+  'Palette: Gray': [
+    '--color-background-gray',
+    '--color-border-gray',
+    '--color-icon-gray',
+    '--color-text-gray',
+  ],
+} as const;
+
+// =============================================================================
+// Typography Categories
+// =============================================================================
+
+const TYPOGRAPHY_CATEGORIES = {
+  'Font Families': [
+    '--font-family-body',
+    '--font-family-heading',
+    '--font-family-code',
+  ],
+  'Heading 1': {
+    description: 'Primary page title (24px default)',
+    tokens: [
+      '--text-heading-1-size',
+      '--text-heading-1-weight',
+      '--text-heading-1-leading',
+    ],
+  },
+  'Heading 2': {
+    description: 'Section title (20px default)',
+    tokens: [
+      '--text-heading-2-size',
+      '--text-heading-2-weight',
+      '--text-heading-2-leading',
+    ],
+  },
+  'Heading 3': {
+    description: 'Subsection title (17px default)',
+    tokens: [
+      '--text-heading-3-size',
+      '--text-heading-3-weight',
+      '--text-heading-3-leading',
+    ],
+  },
+  'Heading 4': {
+    description: 'Card/component title (14px — base anchor)',
+    tokens: [
+      '--text-heading-4-size',
+      '--text-heading-4-weight',
+      '--text-heading-4-leading',
+    ],
+  },
+  'Heading 5': {
+    description: 'Minor heading (12px default)',
+    tokens: [
+      '--text-heading-5-size',
+      '--text-heading-5-weight',
+      '--text-heading-5-leading',
+    ],
+  },
+  'Heading 6': {
+    description: 'Smallest heading (10px default)',
+    tokens: [
+      '--text-heading-6-size',
+      '--text-heading-6-weight',
+      '--text-heading-6-leading',
+    ],
+  },
+  'Body Text': {
+    description: 'Default paragraph text',
+    tokens: ['--text-body-size', '--text-body-weight', '--text-body-leading'],
+  },
+  'Large Text': {
+    description: 'Intro/lead paragraphs',
+    tokens: [
+      '--text-large-size',
+      '--text-large-weight',
+      '--text-large-leading',
+    ],
+  },
+  'Label Text': {
+    description: 'Form labels, UI labels',
+    tokens: [
+      '--text-label-size',
+      '--text-label-weight',
+      '--text-label-leading',
+    ],
+  },
+  'Supporting Text': {
+    description: 'Captions, helper text',
+    tokens: [
+      '--text-supporting-size',
+      '--text-supporting-weight',
+      '--text-supporting-leading',
+    ],
+  },
+  'Code Text': {
+    description: 'Inline code, code blocks',
+    tokens: ['--text-code-size', '--text-code-weight', '--text-code-leading'],
+  },
+  'All Text Sizes': [
+    '--font-size-4xs',
+    '--font-size-3xs',
+    '--font-size-2xs',
+    '--font-size-xs',
+    '--font-size-sm',
+    '--font-size-base',
+    '--font-size-lg',
+    '--font-size-xl',
+    '--font-size-2xl',
+    '--font-size-3xl',
+    '--font-size-4xl',
+  ],
+  'All Font Weights': [
+    '--font-weight-normal',
+    '--font-weight-medium',
+    '--font-weight-semibold',
+    '--font-weight-bold',
+  ],
+  'All Line Heights': [
+    '--leading-tight',
+    '--leading-snug',
+    '--leading-base',
+    '--leading-normal',
+    '--leading-relaxed',
+  ],
+} as const;
+
+type TypographyCategoryValue =
+  | string[]
+  | {description: string; tokens: string[]};
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+function parseLightDark(value: string): {light: string; dark: string} | null {
+  const match = value.match(/^light-dark\(([^,]+),\s*([^)]+)\)$/);
+  if (match) {
+    return {light: match[1].trim(), dark: match[2].trim()};
+  }
+  return null;
+}
+
+function parseColorWithAlpha(
+  value: string,
+): {hex: string; alpha: number} | null {
+  const hex8Match = value.match(/^#([0-9A-Fa-f]{8})$/);
+  if (hex8Match) {
+    const hex = '#' + hex8Match[1].slice(0, 6);
+    const alpha = parseInt(hex8Match[1].slice(6, 8), 16) / 255;
+    return {hex, alpha: Math.round(alpha * 100) / 100};
+  }
+  const hex6Match = value.match(/^#([0-9A-Fa-f]{6})$/);
+  if (hex6Match) {
+    return {hex: value, alpha: 1};
+  }
+  const hex3Match = value.match(/^#([0-9A-Fa-f]{3})$/);
+  if (hex3Match) {
+    const r = hex3Match[1][0];
+    const g = hex3Match[1][1];
+    const b = hex3Match[1][2];
+    return {hex: `#${r}${r}${g}${g}${b}${b}`, alpha: 1};
+  }
+  const rgbaMatch = value.match(
+    /rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*([\d.]+))?\)/,
+  );
+  if (rgbaMatch) {
+    const r = parseInt(rgbaMatch[1], 10).toString(16).padStart(2, '0');
+    const g = parseInt(rgbaMatch[2], 10).toString(16).padStart(2, '0');
+    const b = parseInt(rgbaMatch[3], 10).toString(16).padStart(2, '0');
+    const alpha = rgbaMatch[4] ? parseFloat(rgbaMatch[4]) : 1;
+    return {hex: `#${r}${g}${b}`, alpha};
+  }
+  return null;
+}
+
+function colorWithAlphaToString(hex: string, alpha: number): string {
+  if (alpha >= 1) {
+    return hex.toUpperCase();
+  }
+  const alphaHex = Math.round(alpha * 255)
+    .toString(16)
+    .padStart(2, '0');
+  return `${hex}${alphaHex}`.toUpperCase();
+}
+
+function getTokenLabel(tokenName: string): string {
+  return tokenName
+    .replace(/^--/, '')
+    .replace(/-/g, ' ')
+    .replace(/\b\w/g, c => c.toUpperCase());
+}
+
+// =============================================================================
+// Token Editor Components
+// =============================================================================
+
+function ColorSwatch({
+  tokenName,
+  value,
+  onChange,
+  mode,
+}: {
+  tokenName: string;
+  value: string;
+  onChange: (tokenName: string, value: string) => void;
+  mode: 'light' | 'dark';
+}) {
+  const parsed = parseLightDark(value);
+  const displayValue = parsed
+    ? mode === 'light'
+      ? parsed.light
+      : parsed.dark
+    : value;
+  const colorParsed = parseColorWithAlpha(displayValue);
+  const hasColorPicker = colorParsed !== null;
+
+  const handleColorChange = (newHex: string, newAlpha?: number) => {
+    const alpha = newAlpha ?? colorParsed?.alpha ?? 1;
+    const newColor = colorWithAlphaToString(newHex, alpha);
+    const newValue = parsed
+      ? mode === 'light'
+        ? `light-dark(${newColor}, ${parsed.dark})`
+        : `light-dark(${parsed.light}, ${newColor})`
+      : newColor;
+    onChange(tokenName, newValue);
+  };
+
+  const handleAlphaChange = (newAlpha: number) => {
+    if (colorParsed) {
+      handleColorChange(colorParsed.hex, newAlpha);
+    }
+  };
+
+  return (
+    <XDSHStack
+      gap={3}
+      vAlign="center"
+      style={{
+        padding: '8px 12px',
+        borderRadius: 8,
+        backgroundColor: 'var(--color-background-body)',
+      }}>
+      <div
+        style={{
+          width: 32,
+          height: 32,
+          borderRadius: 6,
+          backgroundColor: displayValue,
+          border: '1px solid var(--color-border-emphasized)',
+          flexShrink: 0,
+          position: 'relative',
+          cursor: hasColorPicker ? 'pointer' : undefined,
+          backgroundImage:
+            colorParsed && colorParsed.alpha < 1
+              ? `linear-gradient(45deg, #ccc 25%, transparent 25%), linear-gradient(-45deg, #ccc 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #ccc 75%), linear-gradient(-45deg, transparent 75%, #ccc 75%)`
+              : undefined,
+          backgroundSize: '8px 8px',
+          backgroundPosition: '0 0, 0 4px, 4px -4px, -4px 0px',
+        }}>
+        <div
+          style={{
+            width: '100%',
+            height: '100%',
+            borderRadius: 6,
+            backgroundColor: displayValue,
+          }}
+        />
+        {hasColorPicker && colorParsed && (
+          <input
+            type="color"
+            value={colorParsed.hex}
+            onChange={e => handleColorChange(e.target.value)}
+            style={{
+              position: 'absolute',
+              inset: 0,
+              width: '100%',
+              height: '100%',
+              opacity: 0,
+              cursor: 'pointer',
+              border: 'none',
+              padding: 0,
+            }}
+          />
+        )}
+      </div>
+      <XDSVStack gap={0} style={{flex: 1, minWidth: 0}}>
+        <XDSText type="supporting" color="primary" maxLines={1}>
+          {getTokenLabel(tokenName)}
+        </XDSText>
+        <XDSText type="supporting" color="secondary" maxLines={1}>
+          {tokenName}
+        </XDSText>
+      </XDSVStack>
+      <XDSHStack gap={1.5} vAlign="center">
+        <div style={{width: 100}}>
+          <XDSTextInput
+            label="Value"
+            isLabelHidden
+            value={displayValue}
+            onChange={val => {
+              const newValue = parsed
+                ? mode === 'light'
+                  ? `light-dark(${val}, ${parsed.dark})`
+                  : `light-dark(${parsed.light}, ${val})`
+                : val;
+              onChange(tokenName, newValue);
+            }}
+            size="sm"
+          />
+        </div>
+        {hasColorPicker && colorParsed && (
+          <>
+            <div style={{width: 50}}>
+              <XDSTextInput
+                label="Alpha"
+                isLabelHidden
+                value={String(Math.round(colorParsed.alpha * 100))}
+                onChange={val => handleAlphaChange(Number(val) / 100)}
+                size="sm"
+              />
+            </div>
+            <XDSText type="supporting" color="secondary">
+              %
+            </XDSText>
+          </>
+        )}
+      </XDSHStack>
+    </XDSHStack>
+  );
+}
+
+function SpacingEditor({
+  tokenName,
+  value,
+  onChange,
+}: {
+  tokenName: string;
+  value: string;
+  onChange: (tokenName: string, value: string) => void;
+}) {
+  const numValue = parseInt(value, 10);
+  return (
+    <XDSHStack
+      gap={3}
+      vAlign="center"
+      style={{
+        padding: '8px 12px',
+        borderRadius: 8,
+        backgroundColor: 'var(--color-background-body)',
+      }}>
+      <div
+        style={{
+          width: Math.min(numValue, 48),
+          height: 24,
+          backgroundColor: 'var(--color-accent)',
+          borderRadius: 4,
+          flexShrink: 0,
+        }}
+      />
+      <XDSVStack gap={0} style={{flex: 1, minWidth: 0}}>
+        <XDSText type="supporting" color="primary" maxLines={1}>
+          {getTokenLabel(tokenName)}
+        </XDSText>
+        <XDSText type="supporting" color="secondary" maxLines={1}>
+          {tokenName}
+        </XDSText>
+      </XDSVStack>
+      <div style={{width: 80}}>
+        <XDSTextInput
+          label="Value"
+          isLabelHidden
+          value={value}
+          onChange={val => onChange(tokenName, val)}
+          size="sm"
+        />
+      </div>
+    </XDSHStack>
+  );
+}
+
+function RadiusEditor({
+  tokenName,
+  value,
+  onChange,
+}: {
+  tokenName: string;
+  value: string;
+  onChange: (tokenName: string, value: string) => void;
+}) {
+  return (
+    <XDSHStack
+      gap={3}
+      vAlign="center"
+      style={{
+        padding: '8px 12px',
+        borderRadius: 8,
+        backgroundColor: 'var(--color-background-body)',
+      }}>
+      <div
+        style={{
+          width: 32,
+          height: 32,
+          backgroundColor: 'var(--color-accent)',
+          borderRadius: value,
+          flexShrink: 0,
+        }}
+      />
+      <XDSVStack gap={0} style={{flex: 1, minWidth: 0}}>
+        <XDSText type="supporting" color="primary" maxLines={1}>
+          {getTokenLabel(tokenName)}
+        </XDSText>
+        <XDSText type="supporting" color="secondary" maxLines={1}>
+          {tokenName}
+        </XDSText>
+      </XDSVStack>
+      <div style={{width: 80}}>
+        <XDSTextInput
+          label="Value"
+          isLabelHidden
+          value={value}
+          onChange={val => onChange(tokenName, val)}
+          size="sm"
+        />
+      </div>
+    </XDSHStack>
+  );
+}
+
+function TypographyEditor({
+  tokenName,
+  value,
+  onChange,
+}: {
+  tokenName: string;
+  value: string;
+  onChange: (tokenName: string, value: string) => void;
+}) {
+  const isFont = tokenName.includes('font-') && !tokenName.includes('weight');
+  const isSize = tokenName.includes('text-');
+  const isWeight = tokenName.includes('weight');
+  const isLeading = tokenName.includes('leading');
+
+  return (
+    <XDSHStack
+      gap={3}
+      vAlign="center"
+      style={{
+        padding: '8px 12px',
+        borderRadius: 8,
+        backgroundColor: 'var(--color-background-body)',
+      }}>
+      <div
+        style={{
+          width: 48,
+          height: 32,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontSize: isSize ? value : '14px',
+          fontWeight: isWeight ? value : 400,
+          fontFamily: isFont ? value : 'inherit',
+          lineHeight: isLeading ? value : 1.4,
+          color: 'var(--color-text-primary)',
+          flexShrink: 0,
+        }}>
+        Aa
+      </div>
+      <XDSVStack gap={0} style={{flex: 1, minWidth: 0}}>
+        <XDSText type="supporting" color="primary" maxLines={1}>
+          {getTokenLabel(tokenName)}
+        </XDSText>
+        <XDSText type="supporting" color="secondary" maxLines={1}>
+          {tokenName}
+        </XDSText>
+      </XDSVStack>
+      <div style={{width: 200}}>
+        <XDSTextInput
+          label="Value"
+          isLabelHidden
+          value={value}
+          onChange={val => onChange(tokenName, val)}
+          size="sm"
+        />
+      </div>
+    </XDSHStack>
+  );
+}
+
+// =============================================================================
+// Preview Components
+// =============================================================================
+
+interface SpacingRow extends Record<string, unknown> {
+  token: string;
+  value: string;
+  preview: React.ReactNode;
+}
+
+const spacingTableColumns: XDSTableColumn<SpacingRow>[] = [
+  {key: 'token', header: 'Token'},
+  {key: 'value', header: 'Value'},
+  {key: 'preview', header: 'Preview'},
+];
+
+const ROW: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+};
+const FULL_W: React.CSSProperties = {width: '100%'};
+const CHART: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'flex-end',
+  gap: 'var(--spacing-1)',
+  height: 80,
+};
+const BAR_BASE: React.CSSProperties = {
+  flex: 1,
+  borderRadius: 'var(--radius-inner)',
+  backgroundColor: 'var(--color-accent)',
+  minWidth: 0,
+};
+const SEC_BOX: React.CSSProperties = {
+  backgroundColor: 'var(--color-background-muted)',
+  borderRadius: 'var(--radius-container)',
+  padding: 'var(--spacing-3)',
+};
+const CARD_WRAP: React.CSSProperties = {
+  breakInside: 'avoid' as const,
+  marginBottom: 'var(--spacing-6)',
+};
+
+function Sparkline({values}: {values: number[]}) {
+  return (
+    <XDSHStack gap={0.5} vAlign="end">
+      {values.map((v, i) => (
+        <div
+          key={i}
+          style={{
+            width: 4,
+            height: v,
+            borderRadius: 2,
+            backgroundColor: 'var(--color-accent)',
+          }}
+        />
+      ))}
+    </XDSHStack>
+  );
+}
+
+function ComponentPreview() {
+  const [settingsTab, setSettingsTab] = React.useState('general');
+  const [brightness, setBrightness] = React.useState(65);
+  const [colorTemp, setColorTemp] = React.useState(45);
+  const [switch1, setSwitch1] = React.useState(false);
+  const [switch2, setSwitch2] = React.useState(true);
+  const [check1, setCheck1] = React.useState(false);
+  const [check2, setCheck2] = React.useState(true);
+  const [sliderValue, setSliderValue] = React.useState(50);
+  const [selectorValue, setSelectorValue] = React.useState('Apple');
+  const [progressValue, setProgressValue] = React.useState(65);
+  const [interactionsTab, setInteractionsTab] = React.useState('overview');
+
+  return (
+    <div
+      style={{
+        columnCount: 3,
+        columnGap: 'var(--spacing-6)',
+        minHeight: '100%',
+      }}>
+      {/* Contribution History */}
+      <div style={CARD_WRAP}>
+        <XDSCard>
+          <XDSLayout
+            height="auto"
+            header={
+              <XDSLayoutHeader>
+                <XDSVStack gap={1}>
+                  <div style={ROW}>
+                    <XDSHeading level={3}>Contribution History</XDSHeading>
+                    <XDSBadge label="+12% vs last month" variant="info" />
+                  </div>
+                  <XDSText type="supporting" color="secondary">
+                    Last 6 months of activity
+                  </XDSText>
+                </XDSVStack>
+              </XDSLayoutHeader>
+            }
+            content={
+              <XDSLayoutContent>
+                <XDSVStack gap={3}>
+                  <div style={CHART}>
+                    {[40, 55, 60, 70, 55, 65].map((h, i) => (
+                      <div key={i} style={{...BAR_BASE, height: h}} />
+                    ))}
+                  </div>
+                  <XDSHStack gap={4}>
+                    {['Dec', 'Jan', 'Feb', 'Mar', 'Apr', 'May'].map(m => (
+                      <XDSText key={m} type="supporting" color="secondary">
+                        {m}
+                      </XDSText>
+                    ))}
+                  </XDSHStack>
+                  <XDSDivider />
+                  <XDSHStack gap={3}>
+                    <div style={{...SEC_BOX, flex: 1}}>
+                      <XDSVStack gap={1}>
+                        <XDSText type="supporting" color="secondary">
+                          UPCOMING
+                        </XDSText>
+                        <XDSText type="label">May 25, 2024</XDSText>
+                        <XDSText type="supporting" color="secondary">
+                          $1,000 scheduled
+                        </XDSText>
+                      </XDSVStack>
+                    </div>
+                    <div style={{...SEC_BOX, flex: 1}}>
+                      <XDSVStack gap={1}>
+                        <XDSText type="supporting" color="secondary">
+                          AUTO-SAVE PLAN
+                        </XDSText>
+                        <XDSText type="label">Accelerated</XDSText>
+                        <XDSText type="supporting" color="secondary">
+                          Recurring weekly
+                        </XDSText>
+                      </XDSVStack>
+                    </div>
+                  </XDSHStack>
+                </XDSVStack>
+              </XDSLayoutContent>
+            }
+            footer={
+              <XDSLayoutFooter>
+                <XDSButton
+                  label="View Full Report"
+                  variant="primary"
+                  style={FULL_W}
+                />
+              </XDSLayoutFooter>
+            }
+          />
+        </XDSCard>
+      </div>
+
+      {/* Savings Targets */}
+      <div style={CARD_WRAP}>
+        <XDSCard>
+          <XDSLayout
+            height="auto"
+            header={
+              <XDSLayoutHeader>
+                <div style={ROW}>
+                  <XDSHeading level={3}>Savings Targets</XDSHeading>
+                  <XDSButton label="New Goal" size="sm" />
+                </div>
+              </XDSLayoutHeader>
+            }
+            content={
+              <XDSLayoutContent>
+                <XDSVStack gap={4}>
+                  <XDSBanner
+                    status="info"
+                    title="On Track"
+                    description="Your retirement savings are ahead of schedule by $12,000 this quarter."
+                  />
+                  <XDSText type="supporting" color="secondary">
+                    Active milestones for 2024
+                  </XDSText>
+                  <XDSVStack gap={1}>
+                    <XDSText type="supporting" color="secondary">
+                      RETIREMENT
+                    </XDSText>
+                    <XDSHeading level={2}>$420,000</XDSHeading>
+                    <XDSProgressBar label="Retirement" value={65} />
+                    <div style={ROW}>
+                      <XDSText type="supporting" color="secondary">
+                        65% achieved
+                      </XDSText>
+                      <XDSText type="supporting" color="secondary">
+                        $273,000
+                      </XDSText>
+                    </div>
+                  </XDSVStack>
+                  <XDSVStack gap={1}>
+                    <XDSText type="supporting" color="secondary">
+                      REAL ESTATE
+                    </XDSText>
+                    <XDSHeading level={2}>$85,000</XDSHeading>
+                    <XDSProgressBar label="Real Estate" value={32} />
+                    <div style={ROW}>
+                      <XDSText type="supporting" color="secondary">
+                        32% achieved
+                      </XDSText>
+                      <XDSText type="supporting" color="secondary">
+                        $27,200
+                      </XDSText>
+                    </div>
+                  </XDSVStack>
+                </XDSVStack>
+              </XDSLayoutContent>
+            }
+          />
+        </XDSCard>
+      </div>
+
+      {/* Buy Investment */}
+      <div style={CARD_WRAP}>
+        <XDSCard>
+          <XDSLayout
+            height="auto"
+            header={
+              <XDSLayoutHeader>
+                <XDSHeading level={3}>Buy Investment</XDSHeading>
+              </XDSLayoutHeader>
+            }
+            content={
+              <XDSLayoutContent>
+                <XDSVStack gap={4}>
+                  <XDSTextInput
+                    label="Amount to Invest"
+                    value="1,000.00"
+                    onChange={() => {}}
+                  />
+                  <XDSSelector
+                    label="Order Type"
+                    options={['Market Order', 'Limit Order', 'Stop Order']}
+                    value="Market Order"
+                    onChange={() => {}}
+                  />
+                  <XDSText type="supporting" color="secondary">
+                    Market orders execute at the current price.
+                  </XDSText>
+                  <XDSDivider />
+                  <div style={ROW}>
+                    <XDSText type="body">Estimated Shares</XDSText>
+                    <XDSText type="body" weight="bold">
+                      1.95
+                    </XDSText>
+                  </div>
+                  <div style={ROW}>
+                    <XDSText type="body">Buying Power</XDSText>
+                    <XDSText type="body" weight="bold">
+                      $12,450.00
+                    </XDSText>
+                  </div>
+                </XDSVStack>
+              </XDSLayoutContent>
+            }
+            footer={
+              <XDSLayoutFooter>
+                <XDSButton
+                  label="Review Order"
+                  variant="primary"
+                  style={FULL_W}
+                />
+              </XDSLayoutFooter>
+            }
+          />
+        </XDSCard>
+      </div>
+
+      {/* Recent Transactions */}
+      <div style={CARD_WRAP}>
+        <XDSCard>
+          <XDSLayout
+            height="auto"
+            header={
+              <XDSLayoutHeader>
+                <div style={ROW}>
+                  <XDSVStack gap={1}>
+                    <XDSHeading level={3}>Recent Transactions</XDSHeading>
+                    <XDSText type="supporting" color="secondary">
+                      Your latest account activity.
+                    </XDSText>
+                  </XDSVStack>
+                  <XDSLink label="View All" href="#">
+                    View All
+                  </XDSLink>
+                </div>
+              </XDSLayoutHeader>
+            }
+            content={
+              <XDSLayoutContent>
+                <XDSTable
+                  data={[
+                    {
+                      id: '1',
+                      name: 'Blue Bottle Coffee',
+                      cat: 'Food & Drink',
+                      date: 'Today, 10:24 AM',
+                      amt: '-$6.50',
+                    },
+                    {
+                      id: '2',
+                      name: 'Whole Foods Market',
+                      cat: 'Groceries',
+                      date: 'Yesterday',
+                      amt: '-$142.30',
+                    },
+                    {
+                      id: '3',
+                      name: 'Stripe Payout',
+                      cat: 'Income',
+                      date: 'Oct 12',
+                      amt: '+$4,200.00',
+                    },
+                    {
+                      id: '4',
+                      name: 'Uber Technologies',
+                      cat: 'Transport',
+                      date: 'Oct 11',
+                      amt: '-$24.10',
+                    },
+                  ]}
+                  idKey="id"
+                  density="compact"
+                  isStriped
+                  dividers="none"
+                  columns={[
+                    {
+                      key: 'name',
+                      header: '',
+                      width: proportional(2),
+                      renderCell: (txn: {name: string; cat: string}) => (
+                        <XDSHStack gap={3} vAlign="center">
+                          <XDSAvatar name={txn.name} size="small" />
+                          <XDSVStack gap={0}>
+                            <XDSText type="body" weight="bold">
+                              {txn.name}
+                            </XDSText>
+                            <XDSText type="supporting" color="secondary">
+                              {txn.cat}
+                            </XDSText>
+                          </XDSVStack>
+                        </XDSHStack>
+                      ),
+                    },
+                    {
+                      key: 'amt',
+                      header: '',
+                      width: proportional(1),
+                      renderCell: (txn: {amt: string; date: string}) => (
+                        <XDSVStack gap={0} style={{alignItems: 'flex-end'}}>
+                          <XDSText type="body" weight="bold">
+                            {txn.amt}
+                          </XDSText>
+                          <XDSText type="supporting" color="secondary">
+                            {txn.date}
+                          </XDSText>
+                        </XDSVStack>
+                      ),
+                    },
+                  ]}
+                />
+              </XDSLayoutContent>
+            }
+          />
+        </XDSCard>
+      </div>
+
+      {/* Stock Performance */}
+      <div style={CARD_WRAP}>
+        <XDSCard>
+          <XDSVStack gap={3}>
+            <XDSHeading level={3}>Stock Performance</XDSHeading>
+            <XDSText type="supporting" color="secondary">
+              6-month price history.
+            </XDSText>
+            <XDSSelector
+              label="Ticker"
+              options={['VOO', 'AAPL', 'GOOGL', 'MSFT']}
+              value="VOO"
+              onChange={() => {}}
+            />
+            <div style={CHART}>
+              {[30, 45, 38, 52, 48, 55, 42, 60, 58, 65, 50, 70].map((h, i) => (
+                <div key={i} style={{...BAR_BASE, height: h}} />
+              ))}
+            </div>
+          </XDSVStack>
+        </XDSCard>
+      </div>
+
+      {/* Card Balance */}
+      <div style={CARD_WRAP}>
+        <XDSCard>
+          <XDSVStack gap={3}>
+            <div style={ROW}>
+              <XDSVStack gap={0}>
+                <XDSText type="supporting" color="secondary">
+                  Card Balance
+                </XDSText>
+                <XDSHeading level={3}>US$12.94</XDSHeading>
+                <XDSText type="supporting" color="secondary">
+                  US$ 1,337.06 Available
+                </XDSText>
+              </XDSVStack>
+              <XDSVStack gap={0} style={{alignItems: 'flex-end'}}>
+                <XDSText type="supporting" color="secondary">
+                  Payment Due
+                </XDSText>
+                <XDSHeading level={3}>1 Apr</XDSHeading>
+                <XDSLink label="Pay Early" href="#">
+                  Pay Early
+                </XDSLink>
+              </XDSVStack>
+            </div>
+            <XDSText type="supporting" color="secondary">
+              Yearly Activity
+            </XDSText>
+            <div style={CHART}>
+              {[20, 35, 15, 45, 30, 50, 25, 40, 55, 35, 45, 30].map((h, i) => (
+                <div key={i} style={{...BAR_BASE, height: h}} />
+              ))}
+            </div>
+          </XDSVStack>
+        </XDSCard>
+      </div>
+
+      {/* Power Usage */}
+      <div style={CARD_WRAP}>
+        <XDSCard>
+          <XDSVStack gap={3}>
+            <XDSHeading level={3}>Power Usage</XDSHeading>
+            <XDSText type="supporting" color="secondary">
+              Whole Home
+            </XDSText>
+            <div style={CHART}>
+              {[60, 45, 70, 55, 40, 65, 50, 35, 55, 45, 60, 50].map((h, i) => (
+                <div key={i} style={{...BAR_BASE, height: h}} />
+              ))}
+            </div>
+            <XDSDivider />
+            <div style={ROW}>
+              <XDSVStack gap={0}>
+                <XDSText type="supporting" color="secondary">
+                  Currently Using
+                </XDSText>
+                <XDSText type="label" weight="bold">
+                  3.4 kW
+                </XDSText>
+              </XDSVStack>
+              <XDSVStack gap={0}>
+                <XDSText type="supporting" color="secondary">
+                  Solar Gen
+                </XDSText>
+                <XDSText type="label" weight="bold" color="active">
+                  +1.2 kW
+                </XDSText>
+              </XDSVStack>
+            </div>
+            <XDSVStack gap={1}>
+              <XDSText type="supporting" color="secondary">
+                Battery Level
+              </XDSText>
+              <XDSProgressBar label="Battery" value={85} hasValueLabel />
+            </XDSVStack>
+          </XDSVStack>
+        </XDSCard>
+      </div>
+
+      {/* Clearinghouse Balance */}
+      <div style={CARD_WRAP}>
+        <XDSCard>
+          <XDSVStack gap={4}>
+            <XDSText type="supporting" color="secondary">
+              Clearhouse Balance
+            </XDSText>
+            <XDSHeading level={1}>$0.00</XDSHeading>
+            <XDSHStack gap={2} vAlign="center">
+              <div
+                style={{
+                  width: 8,
+                  height: 8,
+                  borderRadius: '50%',
+                  backgroundColor: 'var(--color-success)',
+                }}
+              />
+              <XDSText type="supporting" color="secondary">
+                Pending Setup
+              </XDSText>
+            </XDSHStack>
+            <XDSDivider />
+            <div style={ROW}>
+              <XDSText type="body">Net Royalties</XDSText>
+              <XDSText type="body" weight="bold">
+                $0.00
+              </XDSText>
+            </div>
+            <div style={ROW}>
+              <XDSText type="body">Processing Fee</XDSText>
+              <XDSText type="body" weight="bold">
+                -$0.00
+              </XDSText>
+            </div>
+            <XDSDivider />
+            <div style={ROW}>
+              <XDSText type="body">Total Ready to Claim</XDSText>
+              <XDSText type="body" weight="bold">
+                $0.00 USD
+              </XDSText>
+            </div>
+            <XDSText type="supporting" color="secondary">
+              Once your bank is connected, balances over $10.00 are
+              automatically eligible for monthly distribution.
+            </XDSText>
+          </XDSVStack>
+        </XDSCard>
+      </div>
+
+      {/* Payout Preferences */}
+      <div style={CARD_WRAP}>
+        <XDSCard>
+          <XDSLayout
+            height="auto"
+            header={
+              <XDSLayoutHeader>
+                <div style={ROW}>
+                  <XDSHeading level={3}>Payout Preferences</XDSHeading>
+                  <XDSButton
+                    label="Close"
+                    icon={<XDSIcon icon="close" size="sm" />}
+                    variant="ghost"
+                    size="sm"
+                    isIconOnly
+                  />
+                </div>
+              </XDSLayoutHeader>
+            }
+            content={
+              <XDSLayoutContent>
+                <XDSVStack gap={4}>
+                  <XDSText type="supporting" color="secondary">
+                    Receiving Method
+                  </XDSText>
+                  <XDSTextInput
+                    label="Account Holder Name"
+                    value="Synthetic Horizons Music LLC"
+                    onChange={() => {}}
+                  />
+                  <XDSRadioList
+                    label="Receiving Method"
+                    value="bank"
+                    onChange={() => {}}>
+                    <XDSRadioListItem
+                      value="bank"
+                      label="Bank Transfer — SWIFT / IBAN"
+                    />
+                    <XDSRadioListItem
+                      value="paypal"
+                      label="PayPal — Instant Payout"
+                    />
+                  </XDSRadioList>
+                  <XDSTextInput
+                    label="IBAN / Account Number"
+                    value="DE89 3704 0044 ..."
+                    onChange={() => {}}
+                  />
+                </XDSVStack>
+              </XDSLayoutContent>
+            }
+            footer={
+              <XDSLayoutFooter>
+                <XDSButton
+                  label="Save Payout Settings"
+                  variant="primary"
+                  style={FULL_W}
+                />
+              </XDSLayoutFooter>
+            }
+          />
+        </XDSCard>
+      </div>
+
+      {/* Q2 Dividend Income */}
+      <div style={CARD_WRAP}>
+        <XDSCard>
+          <XDSLayout
+            height="auto"
+            header={
+              <XDSLayoutHeader>
+                <div style={ROW}>
+                  <XDSVStack gap={1}>
+                    <XDSHeading level={3}>Q2 Dividend Income</XDSHeading>
+                    <XDSText type="supporting" color="secondary">
+                      Quarterly dividend payouts across your portfolio holdings.
+                    </XDSText>
+                  </XDSVStack>
+                  <XDSButton
+                    label="Close"
+                    icon={<XDSIcon icon="close" size="sm" />}
+                    variant="ghost"
+                    size="sm"
+                    isIconOnly
+                  />
+                </div>
+              </XDSLayoutHeader>
+            }
+            content={
+              <XDSLayoutContent>
+                <XDSVStack gap={3}>
+                  {[
+                    {
+                      name: 'Vanguard VIG',
+                      shares: '450 Shares',
+                      amt: '$1,842.10',
+                    },
+                    {name: 'S&P 500 VOO', shares: '112 Shares', amt: '$928.40'},
+                    {name: 'Apple AAPL', shares: '85 Shares', amt: '$340.00'},
+                    {
+                      name: 'Realty Income',
+                      shares: '320 Shares',
+                      amt: '$1,139.50',
+                    },
+                  ].map((d, i) => (
+                    <div key={i} style={ROW}>
+                      <XDSVStack gap={0}>
+                        <XDSText type="body" weight="bold">
+                          {d.name}
+                        </XDSText>
+                        <XDSText type="supporting" color="secondary">
+                          {d.shares}
+                        </XDSText>
+                      </XDSVStack>
+                      <XDSHStack gap={2} vAlign="center">
+                        <Sparkline values={[8, 12, 6, 15, 10, 18]} />
+                        <XDSText type="body" weight="bold">
+                          {d.amt}
+                        </XDSText>
+                      </XDSHStack>
+                    </div>
+                  ))}
+                </XDSVStack>
+              </XDSLayoutContent>
+            }
+          />
+        </XDSCard>
+      </div>
+
+      {/* Payments Navigation */}
+      <div style={CARD_WRAP}>
+        <XDSCard>
+          <XDSVStack gap={4}>
+            <XDSBreadcrumbs variant="supporting">
+              <XDSBreadcrumbItem href="#">Home</XDSBreadcrumbItem>
+              <XDSBreadcrumbItem href="#">...</XDSBreadcrumbItem>
+              <XDSBreadcrumbItem isCurrent>Payments</XDSBreadcrumbItem>
+            </XDSBreadcrumbs>
+            <XDSDivider />
+            <XDSCollapsibleGroup type="single" defaultValue="0">
+              {[
+                {
+                  title: 'Change transfer limit',
+                  desc: 'Adjust how much you can send from your balance.',
+                },
+                {
+                  title: 'Scheduled transfers',
+                  desc: 'Set up a transfer to send at a later date.',
+                },
+                {
+                  title: 'Direct Debits',
+                  desc: 'Set up and manage regular payments.',
+                },
+                {
+                  title: 'Recurring card payments',
+                  desc: 'Manage your repeated card transactions.',
+                },
+              ].map((item, i) => (
+                <XDSCollapsible
+                  key={i}
+                  value={String(i)}
+                  defaultIsOpen={i === 0}
+                  trigger={
+                    <XDSText type="body" weight="bold">
+                      {item.title}
+                    </XDSText>
+                  }>
+                  <XDSText type="supporting" color="secondary">
+                    {item.desc}
+                  </XDSText>
+                </XDSCollapsible>
+              ))}
+            </XDSCollapsibleGroup>
+          </XDSVStack>
+        </XDSCard>
+      </div>
+
+      {/* FAQ / Settings Tabs */}
+      <div style={CARD_WRAP}>
+        <XDSCard>
+          <XDSLayout
+            height="auto"
+            header={
+              <XDSLayoutHeader>
+                <XDSTabList value={settingsTab} onChange={setSettingsTab}>
+                  <XDSTab value="general" label="General" />
+                  <XDSTab value="billing" label="Billing" />
+                  <XDSTab value="goals" label="Goals" />
+                </XDSTabList>
+              </XDSLayoutHeader>
+            }
+            content={
+              <XDSLayoutContent>
+                <XDSVStack gap={3}>
+                  <XDSText type="label" weight="bold">
+                    How do I set up a custom financial goal?
+                  </XDSText>
+                  <XDSText type="body" color="secondary">
+                    Click New Goal from the Savings Targets card. Choose a
+                    category, set a target amount and date, and we&apos;ll
+                    calculate the monthly contribution needed.
+                  </XDSText>
+                  <XDSDivider />
+                  <XDSText type="label" weight="bold">
+                    Can I track multiple goals at once?
+                  </XDSText>
+                  <XDSDivider />
+                  <XDSText type="label" weight="bold">
+                    How are monthly contributions calculated?
+                  </XDSText>
+                </XDSVStack>
+              </XDSLayoutContent>
+            }
+            footer={
+              <XDSLayoutFooter>
+                <XDSButton
+                  label="Contact Support"
+                  variant="secondary"
+                  style={FULL_W}
+                />
+              </XDSLayoutFooter>
+            }
+          />
+        </XDSCard>
+      </div>
+
+      {/* Savings Target Progress */}
+      <div style={CARD_WRAP}>
+        <XDSCard>
+          <XDSVStack gap={3}>
+            <XDSHeading level={2}>$24,000</XDSHeading>
+            <XDSText type="supporting" color="secondary">
+              80% of $30,000
+            </XDSText>
+            <XDSProgressBar label="Savings Progress" value={80} />
+            <XDSDivider />
+            <div style={ROW}>
+              <XDSText type="body">Projected Finish</XDSText>
+              <XDSText type="body" weight="bold">
+                October 2024
+              </XDSText>
+            </div>
+            <div style={ROW}>
+              <XDSText type="body">Monthly Average</XDSText>
+              <XDSText type="body" weight="bold">
+                $1,250
+              </XDSText>
+            </div>
+            <div style={ROW}>
+              <XDSText type="body">Top Contributor</XDSText>
+              <XDSText type="body" weight="bold">
+                Auto-Transfer
+              </XDSText>
+            </div>
+          </XDSVStack>
+        </XDSCard>
+      </div>
+
+      {/* Kitchen Island (Smart Home) */}
+      <div style={CARD_WRAP}>
+        <XDSCard>
+          <XDSLayout
+            height="auto"
+            header={
+              <XDSLayoutHeader>
+                <div style={ROW}>
+                  <XDSHeading level={3}>Kitchen Island</XDSHeading>
+                  <XDSSwitch label="On" value={true} onChange={() => {}} />
+                </div>
+              </XDSLayoutHeader>
+            }
+            content={
+              <XDSLayoutContent>
+                <XDSVStack gap={4}>
+                  <XDSText type="supporting" color="secondary">
+                    Hue Color Ambient
+                  </XDSText>
+                  <XDSHStack gap={2}>
+                    {['Cooking', 'Dining', 'Nightlight', 'Focus'].map(m => (
+                      <XDSToken key={m} label={m} />
+                    ))}
+                  </XDSHStack>
+                  <XDSSlider
+                    label="Brightness"
+                    value={brightness}
+                    onChange={(v: number) => setBrightness(v)}
+                  />
+                  <XDSSlider
+                    label="Color Temp"
+                    value={colorTemp}
+                    onChange={(v: number) => setColorTemp(v)}
+                  />
+                </XDSVStack>
+              </XDSLayoutContent>
+            }
+          />
+        </XDSCard>
+      </div>
+
+      {/* Upcoming Payments */}
+      <div style={CARD_WRAP}>
+        <XDSCard>
+          <XDSVStack gap={3}>
+            <XDSHeading level={3}>Upcoming Payments</XDSHeading>
+            <XDSText type="supporting" color="secondary">
+              Select a date to view scheduled payments.
+            </XDSText>
+            <XDSCalendar />
+            <XDSDivider />
+            {[
+              {
+                name: 'Netflix Subscription',
+                date: 'Apr 15, 2024',
+                amt: '$19.99',
+              },
+              {name: 'Rent Payment', date: 'Apr 1, 2024', amt: '$2,400.00'},
+              {name: 'Auto Insurance', date: 'Apr 22, 2024', amt: '$186.00'},
+            ].map((p, i) => (
+              <div key={i} style={ROW}>
+                <XDSVStack gap={0}>
+                  <XDSText type="body" weight="bold">
+                    {p.name}
+                  </XDSText>
+                  <XDSText type="supporting" color="secondary">
+                    {p.date}
+                  </XDSText>
+                </XDSVStack>
+                <XDSText type="body" weight="bold">
+                  {p.amt}
+                </XDSText>
+              </div>
+            ))}
+          </XDSVStack>
+        </XDSCard>
+      </div>
+
+      {/* Syncing Accounts */}
+      <div style={CARD_WRAP}>
+        <XDSCard>
+          <XDSLayout
+            height="auto"
+            content={
+              <XDSLayoutContent>
+                <XDSHStack gap={3} vAlign="center">
+                  <XDSSpinner size="sm" />
+                  <XDSVStack gap={1}>
+                    <XDSHeading level={3}>Syncing your accounts</XDSHeading>
+                    <XDSText type="supporting" color="secondary">
+                      We&apos;re pulling in your latest transactions. This
+                      usually takes a few seconds.
+                    </XDSText>
+                  </XDSVStack>
+                </XDSHStack>
+              </XDSLayoutContent>
+            }
+            footer={
+              <XDSLayoutFooter>
+                <XDSButton label="Cancel" variant="ghost" style={FULL_W} />
+              </XDSLayoutFooter>
+            }
+          />
+        </XDSCard>
+      </div>
+
+      {/* Notifications */}
+      <div style={CARD_WRAP}>
+        <XDSCard>
+          <XDSLayout
+            height="auto"
+            header={
+              <XDSLayoutHeader>
+                <XDSVStack gap={1}>
+                  <XDSHeading level={3}>Notifications</XDSHeading>
+                  <XDSText type="supporting" color="secondary">
+                    Choose what you want to be notified about.
+                  </XDSText>
+                </XDSVStack>
+              </XDSLayoutHeader>
+            }
+            content={
+              <XDSLayoutContent>
+                <XDSVStack gap={4}>
+                  <XDSCheckboxInput
+                    label="Transaction alerts"
+                    value={true}
+                    onChange={() => {}}
+                  />
+                  <XDSText type="supporting" color="secondary">
+                    Deposits, withdrawals, and transfers.
+                  </XDSText>
+                  <XDSCheckboxInput
+                    label="Security alerts"
+                    value={false}
+                    onChange={() => {}}
+                  />
+                  <XDSText type="supporting" color="secondary">
+                    Login attempts and account changes.
+                  </XDSText>
+                  <XDSCheckboxInput
+                    label="Goal milestones"
+                    value={false}
+                    onChange={() => {}}
+                  />
+                  <XDSText type="supporting" color="secondary">
+                    Updates at 25%, 50%, 75%, and 100%.
+                  </XDSText>
+                </XDSVStack>
+              </XDSLayoutContent>
+            }
+            footer={
+              <XDSLayoutFooter>
+                <XDSButton
+                  label="Save Preferences"
+                  variant="primary"
+                  style={FULL_W}
+                />
+              </XDSLayoutFooter>
+            }
+          />
+        </XDSCard>
+      </div>
+
+      {/* Dollar-Cost Averaging */}
+      <div style={CARD_WRAP}>
+        <XDSCard>
+          <XDSVStack gap={3}>
+            <XDSHeading level={3}>Dollar-Cost Averaging</XDSHeading>
+            <XDSText type="supporting" color="secondary">
+              A strategy for building wealth over time.
+            </XDSText>
+            <XDSText type="body" color="secondary">
+              Over time, this smooths out the average cost of your investments.
+              When prices drop, your fixed amount buys more shares. When prices
+              rise, you buy fewer.
+            </XDSText>
+          </XDSVStack>
+        </XDSCard>
+      </div>
+
+      {/* Buttons & Overlays */}
+      <div style={CARD_WRAP}>
+        <XDSCard>
+          <XDSVStack gap={4}>
+            <XDSHeading level={3}>Buttons & Overlays</XDSHeading>
+            <XDSHStack gap={2} wrap="wrap">
+              <XDSButton label="Primary" variant="primary" onClick={() => {}} />
+              <XDSButton
+                label="Secondary"
+                variant="secondary"
+                onClick={() => {}}
+              />
+              <XDSButton label="Ghost" variant="ghost" onClick={() => {}} />
+              <XDSDropdownMenu
+                button={{label: 'Dropdown', variant: 'secondary'}}
+                items={[
+                  {label: 'Edit', onClick: () => {}},
+                  {label: 'Duplicate', onClick: () => {}},
+                  {type: 'divider' as const},
+                  {label: 'Delete', onClick: () => {}},
+                ]}
+              />
+            </XDSHStack>
+            <XDSDivider />
+            <XDSHStack gap={2} vAlign="center" wrap="wrap">
+              <XDSPopover
+                content={<PopoverSettingsContent />}
+                placement="below">
+                <XDSButton label="Popover" variant="secondary" size="sm" />
+              </XDSPopover>
+              <XDSHoverCard
+                content={
+                  <XDSVStack gap={1} style={{padding: 12, maxWidth: 240}}>
+                    <XDSText type="label" display="block">
+                      HoverCard
+                    </XDSText>
+                    <XDSText type="supporting" color="secondary">
+                      Hover to trigger.
+                    </XDSText>
+                  </XDSVStack>
+                }
+                placement="below">
+                <XDSButton
+                  label="HoverCard"
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => {}}
+                />
+              </XDSHoverCard>
+              <XDSTooltip content="Tooltip preview">
+                <XDSButton
+                  label="Tooltip"
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => {}}
+                />
+              </XDSTooltip>
+            </XDSHStack>
+          </XDSVStack>
+        </XDSCard>
+      </div>
+
+      {/* Form Controls */}
+      <div style={CARD_WRAP}>
+        <XDSCard>
+          <XDSVStack gap={4}>
+            <XDSHeading level={3}>Form Controls</XDSHeading>
+            <XDSHStack gap={4} wrap="wrap">
+              <XDSSwitch
+                label="Switch A"
+                value={switch1}
+                onChange={setSwitch1}
+              />
+              <XDSSwitch
+                label="Switch B"
+                value={switch2}
+                onChange={setSwitch2}
+              />
+              <XDSCheckboxInput
+                label="Check A"
+                value={check1}
+                onChange={setCheck1}
+              />
+              <XDSCheckboxInput
+                label="Check B"
+                value={check2}
+                onChange={setCheck2}
+              />
+            </XDSHStack>
+            <XDSDivider />
+            <XDSHStack gap={4} vAlign="end">
+              <div style={{flex: 1, maxWidth: 200}}>
+                <XDSSlider
+                  label="Volume"
+                  value={sliderValue}
+                  onChange={setSliderValue}
+                  min={0}
+                  max={100}
+                />
+              </div>
+              <div style={{maxWidth: 160}}>
+                <XDSSelector
+                  label="Fruit"
+                  options={['Apple', 'Banana', 'Orange', 'Mango']}
+                  value={selectorValue}
+                  onChange={setSelectorValue}
+                />
+              </div>
+            </XDSHStack>
+          </XDSVStack>
+        </XDSCard>
+      </div>
+
+      {/* Loading & Status */}
+      <div style={CARD_WRAP}>
+        <XDSCard>
+          <XDSVStack gap={4}>
+            <XDSHeading level={3}>Loading & Status</XDSHeading>
+            <XDSHStack gap={4} vAlign="center">
+              <XDSSpinner size="sm" />
+              <XDSSpinner size="md" />
+              <XDSSpinner size="lg" />
+            </XDSHStack>
+            <XDSDivider />
+            <XDSVStack gap={2}>
+              <XDSHStack gap={3} vAlign="center">
+                <XDSSkeleton
+                  width={40}
+                  height={40}
+                  radius="rounded"
+                  index={0}
+                />
+                <XDSVStack gap={1} style={{flex: 1}}>
+                  <XDSSkeleton width={160} height={14} index={1} />
+                  <XDSSkeleton width={100} height={10} index={2} />
+                </XDSVStack>
+              </XDSHStack>
+              <XDSSkeleton width="100%" height={12} index={3} />
+              <XDSSkeleton width="80%" height={12} index={4} />
+            </XDSVStack>
+            <XDSDivider />
+            <XDSVStack gap={3}>
+              <XDSProgressBar
+                value={progressValue}
+                label={`${progressValue}%`}
+              />
+              <XDSHStack gap={2}>
+                {[0, 25, 50, 75, 100].map(v => (
+                  <XDSButton
+                    key={v}
+                    label={`${v}%`}
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setProgressValue(v)}
+                  />
+                ))}
+              </XDSHStack>
+            </XDSVStack>
+            <XDSDivider />
+            <XDSHStack gap={4} vAlign="center">
+              <XDSHStack gap={2} vAlign="center">
+                <XDSStatusDot variant="positive" label="Online" isPulsing />
+                <XDSText type="body">Online</XDSText>
+              </XDSHStack>
+              <XDSHStack gap={2} vAlign="center">
+                <XDSStatusDot variant="warning" label="Away" isPulsing />
+                <XDSText type="body">Away</XDSText>
+              </XDSHStack>
+              <XDSHStack gap={2} vAlign="center">
+                <XDSStatusDot variant="negative" label="Busy" isPulsing />
+                <XDSText type="body">Busy</XDSText>
+              </XDSHStack>
+            </XDSHStack>
+          </XDSVStack>
+        </XDSCard>
+      </div>
+
+      {/* Surface Interactions */}
+      <div style={CARD_WRAP}>
+        <XDSCard>
+          <XDSVStack gap={4}>
+            <XDSHeading level={3}>Surface Interactions</XDSHeading>
+            <XDSTabList value={interactionsTab} onChange={setInteractionsTab}>
+              <XDSTab value="overview" label="Overview" />
+              <XDSTab value="analytics" label="Analytics" />
+              <XDSTab value="reports" label="Reports" />
+              <XDSTab value="settings" label="Settings" />
+            </XDSTabList>
+            <XDSDivider />
+            <XDSList density="balanced" s>
+              <XDSListItem
+                label="Dashboard"
+                description="View your metrics"
+                onClick={() => {}}
+              />
+              <XDSListItem
+                label="Projects"
+                description="Manage active projects"
+                onClick={() => {}}
+              />
+              <XDSListItem
+                label="Settings"
+                description="Configure preferences"
+                onClick={() => {}}
+              />
+            </XDSList>
+          </XDSVStack>
+        </XDSCard>
+      </div>
+    </div>
+  );
+}
+
+function LandingPagePreview() {
+  return (
+    <div style={{display: 'flex', flexDirection: 'column', gap: '48px'}}>
+      <div style={{textAlign: 'center', padding: '48px 24px'}}>
+        <XDSBadge variant="info" label="New Release" />
+        <XDSHeading level={1} style={{marginTop: 16, marginBottom: 12}}>
+          Ship faster with XDS
+        </XDSHeading>
+        <XDSText
+          type="large"
+          color="secondary"
+          display="block"
+          style={{
+            marginBottom: 24,
+            maxWidth: 520,
+            marginLeft: 'auto',
+            marginRight: 'auto',
+          }}>
+          A design system for building internal tools. Open internals, plugin
+          architecture, and automatic spacing.
+        </XDSText>
+        <div style={{display: 'flex', gap: '8px', justifyContent: 'center'}}>
+          <XDSButton label="Get Started" />
+          <XDSButton label="Documentation" variant="secondary" />
+        </div>
+      </div>
+      <XDSDivider />
+      <div>
+        <XDSHeading level={2} style={{marginBottom: 16}}>
+          Features
+        </XDSHeading>
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(3, 1fr)',
+            gap: '16px',
+          }}>
+          {[
+            {
+              title: 'Open Internals',
+              desc: 'All primitives exported and composable. No black boxes.',
+            },
+            {
+              title: 'Plugin Architecture',
+              desc: 'Transform and extend components through a unified plugin system.',
+            },
+            {
+              title: 'AI-Ready',
+              desc: 'JSDoc annotations with composition hints for LLM-assisted development.',
+            },
+          ].map(f => (
+            <XDSCard key={f.title} padding={3}>
+              <XDSHeading level={3} style={{marginBottom: 8}}>
+                {f.title}
+              </XDSHeading>
+              <XDSText type="body" color="secondary">
+                {f.desc}
+              </XDSText>
+            </XDSCard>
+          ))}
+        </div>
+      </div>
+      <XDSCard padding={4}>
+        <XDSText type="large" display="block" style={{marginBottom: 12}}>
+          &ldquo;XDS cut our dev time in half. The type scale system alone saved
+          us weeks of bikeshedding.&rdquo;
+        </XDSText>
+        <div style={{display: 'flex', alignItems: 'center', gap: '8px'}}>
+          <XDSAvatar name="Alex Chen" size="small" />
+          <div>
+            <XDSText type="label">Alex Chen</XDSText>
+            <XDSText type="supporting" color="secondary">
+              {' '}
+              · Engineering Lead
+            </XDSText>
+          </div>
+        </div>
+      </XDSCard>
+      <div style={{textAlign: 'center', padding: '32px 0'}}>
+        <XDSHeading level={2} style={{marginBottom: 8}}>
+          Ready to build?
+        </XDSHeading>
+        <XDSText
+          type="body"
+          color="secondary"
+          display="block"
+          style={{marginBottom: 16}}>
+          Get started with XDS in under 5 minutes.
+        </XDSText>
+        <XDSButton label="Start Building" />
+      </div>
+    </div>
+  );
+}
+
+interface MetricRow extends Record<string, unknown> {
+  metric: string;
+  value: string;
+  change: string;
+  trend: 'up' | 'down' | 'flat';
+}
+
+const dashboardColumns: XDSTableColumn<MetricRow>[] = [
+  {key: 'metric', header: 'Metric'},
+  {key: 'value', header: 'Value'},
+  {key: 'change', header: 'Change'},
+];
+
+function DashboardPreview() {
+  const [tab, setTab] = React.useState('overview');
+  const metrics: MetricRow[] = [
+    {metric: 'Total Users', value: '12,847', change: '+12.3%', trend: 'up'},
+    {metric: 'Active Sessions', value: '3,421', change: '+8.1%', trend: 'up'},
+    {
+      metric: 'Avg Response Time',
+      value: '142ms',
+      change: '-5.2%',
+      trend: 'down',
+    },
+    {metric: 'Error Rate', value: '0.03%', change: '-18.7%', trend: 'down'},
+    {metric: 'API Calls (24h)', value: '2.4M', change: '+3.1%', trend: 'up'},
+    {metric: 'Storage Used', value: '847 GB', change: '+1.2%', trend: 'flat'},
+  ];
+
+  return (
+    <div style={{display: 'flex', flexDirection: 'column', gap: '24px'}}>
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+        }}>
+        <div>
+          <XDSHeading level={1}>Dashboard</XDSHeading>
+          <XDSText type="supporting" color="secondary">
+            Last updated 2 minutes ago
+          </XDSText>
+        </div>
+        <div style={{display: 'flex', gap: '8px'}}>
+          <XDSButton label="Export" variant="secondary" size="sm" />
+          <XDSButton label="Refresh" size="sm" />
+        </div>
+      </div>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(4, 1fr)',
+          gap: '12px',
+        }}>
+        {[
+          {label: 'Revenue', value: '$48.2K', delta: '+12%'},
+          {label: 'Users', value: '12,847', delta: '+8%'},
+          {label: 'Uptime', value: '99.97%', delta: '—'},
+          {label: 'NPS', value: '72', delta: '+3'},
+        ].map(kpi => (
+          <XDSCard key={kpi.label} padding={3}>
+            <XDSText type="supporting" color="secondary" display="block">
+              {kpi.label}
+            </XDSText>
+            <XDSHeading level={2} style={{marginTop: 4}}>
+              {kpi.value}
+            </XDSHeading>
+            <XDSText
+              type="supporting"
+              color={kpi.delta.startsWith('+') ? 'active' : 'secondary'}>
+              {kpi.delta}
+            </XDSText>
+          </XDSCard>
+        ))}
+      </div>
+      <div>
+        <XDSTabList value={tab} onChange={setTab}>
+          <XDSTab value="overview" label="Overview" />
+          <XDSTab value="performance" label="Performance" />
+          <XDSTab value="errors" label="Errors" />
+        </XDSTabList>
+        <div style={{marginTop: '16px'}}>
+          <XDSTable
+            columns={dashboardColumns}
+            data={metrics}
+            density="compact"
+          />
+        </div>
+      </div>
+      <XDSBanner
+        status="info"
+        title="System Update"
+        description="A new version of the API is available. Review the changelog for breaking changes."
+        endContent={
+          <XDSButton label="View Changelog" variant="secondary" size="sm" />
+        }
+      />
+      <div
+        style={{display: 'grid', gridTemplateColumns: '2fr 1fr', gap: '16px'}}>
+        <XDSCard padding={3}>
+          <XDSHeading level={3} style={{marginBottom: 12}}>
+            Recent Activity
+          </XDSHeading>
+          {[
+            {
+              user: 'Sarah K.',
+              action: 'deployed v2.4.1 to production',
+              time: '5 min ago',
+            },
+            {
+              user: 'Mike R.',
+              action: 'merged PR #247: fix auth flow',
+              time: '23 min ago',
+            },
+            {
+              user: 'Cindy Z.',
+              action: 'created issue #312: token audit',
+              time: '1 hr ago',
+            },
+            {
+              user: 'Alex C.',
+              action: 'updated dashboard metrics query',
+              time: '2 hr ago',
+            },
+          ].map((item, i) => (
+            <div
+              key={i}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: '8px',
+                padding: '8px 0',
+                borderBottom: i < 3 ? '1px solid var(--color-divider)' : 'none',
+              }}>
+              <XDSAvatar name={item.user} size="small" />
+              <div style={{flex: 1}}>
+                <XDSText type="label">{item.user}</XDSText>
+                <XDSText type="body" color="secondary">
+                  {' '}
+                  {item.action}
+                </XDSText>
+              </div>
+              <XDSText type="supporting" color="secondary">
+                {item.time}
+              </XDSText>
+            </div>
+          ))}
+        </XDSCard>
+        <XDSCard padding={3}>
+          <XDSHeading level={3} style={{marginBottom: 12}}>
+            Quick Stats
+          </XDSHeading>
+          <div style={{display: 'flex', flexDirection: 'column', gap: '12px'}}>
+            {[
+              {label: 'CPU Usage', value: 43},
+              {label: 'Memory', value: 67},
+              {label: 'Storage', value: 82},
+            ].map(stat => (
+              <div key={stat.label}>
+                <div
+                  style={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    marginBottom: '4px',
+                  }}>
+                  <XDSText type="supporting">{stat.label}</XDSText>
+                  <XDSText type="supporting" color="secondary">
+                    {stat.value}%
+                  </XDSText>
+                </div>
+                <XDSProgressBar
+                  value={stat.value}
+                  label={stat.label}
+                  isLabelHidden
+                />
+              </div>
+            ))}
+          </div>
+        </XDSCard>
+      </div>
+    </div>
+  );
+}
+
+// Minimal motion preview sub-components — kept compact since the full
+// MotionPreview table page provides the richest test surface.
+
+function PopoverSettingsContent() {
+  const [notifications, setNotifications] = React.useState(true);
+  const [darkMode, setDarkMode] = React.useState(false);
+  const [sounds, setSounds] = React.useState(true);
+
+  return (
+    <XDSVStack gap={3} style={{width: 240}}>
+      <XDSText type="label" display="block">
+        Settings
+      </XDSText>
+      <XDSDivider />
+      <XDSSwitch
+        label="Notifications"
+        description="Receive push notifications"
+        value={notifications}
+        onChange={setNotifications}
+      />
+      <XDSSwitch
+        label="Dark mode"
+        description="Use dark color theme"
+        value={darkMode}
+        onChange={setDarkMode}
+      />
+      <XDSSwitch
+        label="Sounds"
+        description="Play sounds for actions"
+        value={sounds}
+        onChange={setSounds}
+      />
+    </XDSVStack>
+  );
+}
+
+function MicroInteractionsPreview() {
+  const [switch1, setSwitch1] = React.useState(false);
+  const [switch2, setSwitch2] = React.useState(true);
+  const [check1, setCheck1] = React.useState(false);
+  const [check2, setCheck2] = React.useState(true);
+  const [sliderValue, setSliderValue] = React.useState(50);
+  const [selectorValue, setSelectorValue] = React.useState('Apple');
+
+  return (
+    <XDSCard>
+      <XDSVStack gap={4}>
+        <XDSText type="label" display="block">
+          Micro-Interactions
+        </XDSText>
+        <div>
+          <XDSText type="supporting" color="secondary" display="block">
+            Buttons — hover, press, focus
+          </XDSText>
+          <XDSHStack gap={2} style={{marginTop: 8}}>
+            <XDSButton label="Primary" variant="primary" onClick={() => {}} />
+            <XDSButton
+              label="Secondary"
+              variant="secondary"
+              onClick={() => {}}
+            />
+            <XDSButton label="Ghost" variant="ghost" onClick={() => {}} />
+            <XDSDropdownMenu
+              button={{label: 'Dropdown', variant: 'secondary'}}
+              items={[
+                {label: 'Edit', onClick: () => {}},
+                {label: 'Duplicate', onClick: () => {}},
+                {type: 'divider' as const},
+                {label: 'Delete', onClick: () => {}},
+              ]}
+            />
+          </XDSHStack>
+        </div>
+        <XDSDivider />
+        <div>
+          <XDSText type="supporting" color="secondary" display="block">
+            Popover / HoverCard / Tooltip
+          </XDSText>
+          <XDSHStack
+            gap={2}
+            vAlign="center"
+            style={{marginTop: 8, flexWrap: 'wrap'}}>
+            <XDSPopover content={<PopoverSettingsContent />} placement="below">
+              <XDSButton label="Popover" variant="secondary" size="sm" />
+            </XDSPopover>
+            <XDSHoverCard
+              content={
+                <div style={{padding: 12, maxWidth: 240}}>
+                  <XDSText
+                    type="label"
+                    display="block"
+                    style={{marginBottom: 4}}>
+                    HoverCard
+                  </XDSText>
+                  <XDSText type="supporting" color="secondary">
+                    Hover to trigger.
+                  </XDSText>
+                </div>
+              }
+              placement="below">
+              <XDSButton
+                label="HoverCard"
+                variant="secondary"
+                size="sm"
+                onClick={() => {}}
+              />
+            </XDSHoverCard>
+            <XDSTooltip content="Tooltip preview">
+              <XDSButton
+                label="Tooltip"
+                variant="secondary"
+                size="sm"
+                onClick={() => {}}
+              />
+            </XDSTooltip>
+          </XDSHStack>
+        </div>
+        <XDSDivider />
+        <div>
+          <XDSText type="supporting" color="secondary" display="block">
+            Switches & Checkboxes
+          </XDSText>
+          <XDSHStack gap={4} style={{marginTop: 8}}>
+            <XDSSwitch label="Switch 1" value={switch1} onChange={setSwitch1} />
+            <XDSSwitch label="Switch 2" value={switch2} onChange={setSwitch2} />
+            <XDSCheckboxInput
+              label="Check A"
+              value={check1}
+              onChange={setCheck1}
+            />
+            <XDSCheckboxInput
+              label="Check B"
+              value={check2}
+              onChange={setCheck2}
+            />
+          </XDSHStack>
+        </div>
+        <XDSDivider />
+        <div>
+          <XDSText type="supporting" color="secondary" display="block">
+            Slider & Selector
+          </XDSText>
+          <XDSHStack gap={4} vAlign="end" style={{marginTop: 8}}>
+            <div style={{flex: 1, maxWidth: 200}}>
+              <XDSSlider
+                label="Volume"
+                value={sliderValue}
+                onChange={setSliderValue}
+                min={0}
+                max={100}
+              />
+            </div>
+            <div style={{maxWidth: 160}}>
+              <XDSSelector
+                label="Fruit"
+                options={['Apple', 'Banana', 'Orange', 'Mango']}
+                value={selectorValue}
+                onChange={setSelectorValue}
+              />
+            </div>
+          </XDSHStack>
+        </div>
+      </XDSVStack>
+    </XDSCard>
+  );
+}
+
+function LoadingStatusPreview() {
+  const [progressValue, setProgressValue] = React.useState(65);
+  return (
+    <XDSCard>
+      <XDSVStack gap={4}>
+        <XDSText type="label" display="block">
+          Loading & Status
+        </XDSText>
+        <XDSHStack gap={4} vAlign="center">
+          <XDSSpinner size="sm" />
+          <XDSSpinner size="md" />
+          <XDSSpinner size="lg" />
+        </XDSHStack>
+        <XDSDivider />
+        <XDSVStack gap={2}>
+          <XDSHStack gap={3} vAlign="center">
+            <XDSSkeleton width={40} height={40} radius="rounded" index={0} />
+            <XDSVStack gap={1} style={{flex: 1}}>
+              <XDSSkeleton width={160} height={14} index={1} />
+              <XDSSkeleton width={100} height={10} index={2} />
+            </XDSVStack>
+          </XDSHStack>
+          <XDSSkeleton width="100%" height={12} index={3} />
+          <XDSSkeleton width="80%" height={12} index={4} />
+        </XDSVStack>
+        <XDSDivider />
+        <XDSVStack gap={3}>
+          <XDSProgressBar value={progressValue} label={`${progressValue}%`} />
+          <XDSHStack gap={2}>
+            {[0, 25, 50, 75, 100].map(v => (
+              <XDSButton
+                key={v}
+                label={`${v}%`}
+                variant="ghost"
+                size="sm"
+                onClick={() => setProgressValue(v)}
+              />
+            ))}
+          </XDSHStack>
+        </XDSVStack>
+        <XDSDivider />
+        <XDSHStack gap={4} vAlign="center">
+          <XDSHStack gap={2} vAlign="center">
+            <XDSStatusDot variant="positive" label="Online" isPulsing />
+            <XDSText type="body">Online</XDSText>
+          </XDSHStack>
+          <XDSHStack gap={2} vAlign="center">
+            <XDSStatusDot variant="warning" label="Away" isPulsing />
+            <XDSText type="body">Away</XDSText>
+          </XDSHStack>
+          <XDSHStack gap={2} vAlign="center">
+            <XDSStatusDot variant="negative" label="Busy" isPulsing />
+            <XDSText type="body">Busy</XDSText>
+          </XDSHStack>
+        </XDSHStack>
+      </XDSVStack>
+    </XDSCard>
+  );
+}
+
+function SurfaceInteractionsPreview() {
+  const [activeTab, setActiveTab] = React.useState('overview');
+  return (
+    <XDSCard>
+      <XDSVStack gap={4}>
+        <XDSText type="label" display="block">
+          Surface Interactions
+        </XDSText>
+        <XDSTabList value={activeTab} onChange={setActiveTab}>
+          <XDSTab value="overview" label="Overview" />
+          <XDSTab value="analytics" label="Analytics" />
+          <XDSTab value="reports" label="Reports" />
+          <XDSTab value="settings" label="Settings" />
+        </XDSTabList>
+        <XDSDivider />
+        <XDSList density="balanced" s>
+          <XDSListItem
+            label="Dashboard"
+            description="View your metrics"
+            onClick={() => {}}
+          />
+          <XDSListItem
+            label="Projects"
+            description="Manage active projects"
+            onClick={() => {}}
+          />
+          <XDSListItem
+            label="Settings"
+            description="Configure preferences"
+            onClick={() => {}}
+          />
+        </XDSList>
+      </XDSVStack>
+    </XDSCard>
+  );
+}
+
+function MotionPreview() {
+  const [sidebarCollapsed, setSidebarCollapsed] = React.useState(false);
+  const [overlayOpen, setOverlayOpen] = React.useState(false);
+  const [pushOpen, setPushOpen] = React.useState(false);
+  const [selectedUser, setSelectedUser] = React.useState<{
+    id: string;
+    name: string;
+    email: string;
+    role: string;
+  } | null>(null);
+  const [modalOpen, setModalOpen] = React.useState(false);
+  const containerRef = React.useRef<HTMLDivElement>(null);
+  const [containerWidth, setContainerWidth] = React.useState(1200);
+
+  React.useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver(entries => {
+      for (const entry of entries) setContainerWidth(entry.contentRect.width);
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  const [filters, setFilters] = React.useState<PowerSearchFilter[]>([]);
+  const fieldDefs = [
+    {key: 'name', type: 'string', label: 'Name'},
+    {key: 'email', type: 'string', label: 'Email'},
+    {
+      key: 'role',
+      type: 'enum',
+      label: 'Role',
+      enumValues: [
+        {value: 'engineer', label: 'Engineer'},
+        {value: 'designer', label: 'Designer'},
+        {value: 'pm', label: 'PM'},
+      ],
+    },
+  ] as const;
+  const {config, applyFilters} = usePowerSearchConfig(fieldDefs, 'Users');
+
+  const allUsers = [
+    {
+      id: '1',
+      name: 'Alice Johnson',
+      email: 'alice@example.com',
+      role: 'engineer',
+    },
+    {id: '2', name: 'Bob Smith', email: 'bob@example.com', role: 'designer'},
+    {id: '3', name: 'Charlie Brown', email: 'charlie@example.com', role: 'pm'},
+    {
+      id: '4',
+      name: 'Diana Prince',
+      email: 'diana@example.com',
+      role: 'engineer',
+    },
+    {id: '5', name: 'Eve Davis', email: 'eve@example.com', role: 'designer'},
+  ];
+  const filteredUsers = applyFilters(filters, allUsers);
+  const roleLabels: Record<string, string> = {
+    Engineer: 'Engineer',
+    Designer: 'Designer',
+    PM: 'PM',
+    engineer: 'Engineer',
+    designer: 'Designer',
+    pm: 'PM',
+  };
+
+  const tableColumns: XDSTableColumn<(typeof allUsers)[0]>[] = [
+    {key: 'name', header: 'Name', width: proportional(2)},
+    ...(containerWidth > 975
+      ? [{key: 'email' as const, header: 'Email', width: proportional(2)}]
+      : []),
+    {
+      key: 'role',
+      header: 'Role',
+      width: pixel(120),
+      renderCell: (user: (typeof allUsers)[0]) =>
+        roleLabels[user.role] ?? user.role,
+    },
+  ];
+
+  const dur = {
+    medMin: 'var(--duration-medium-min)',
+    med: 'var(--duration-medium)',
+  };
+  const ease = 'var(--ease-standard)';
+  const motionSlideIn = `${dur.med} ${ease}`;
+  const motionSlideOut = `${dur.medMin} ${ease}`;
+
+  return (
+    <div
+      ref={containerRef}
+      style={{
+        border: '1px solid var(--color-border)',
+        borderRadius: '12px',
+        overflow: 'hidden',
+        height: '630px',
+        position: 'relative',
+        fontFamily: 'var(--font-family-body)',
+        fontSize: 'var(--font-size-base)',
+        lineHeight: 'var(--leading-base)',
+        color: 'var(--color-text-primary)',
+      }}>
+      <XDSAppShell
+        height="fill"
+        style={{height: '100%'}}
+        variant="section"
+        contentPadding={0}
+        sideNav={
+          <XDSSideNav
+            collapsible={{
+              isCollapsed: sidebarCollapsed,
+              onCollapsedChange: setSidebarCollapsed,
+              hasButton: false,
+            }}
+            header={
+              <XDSSideNavHeading
+                icon={
+                  <XDSNavIcon
+                    icon={<CubeIcon style={{width: 16, height: 16}} />}
+                  />
+                }
+                heading="My App"
+                headingHref="/"
+              />
+            }
+            footerIcons={<XDSSideNavCollapseButton />}>
+            <XDSSideNavSection title="Main">
+              <XDSSideNavItem
+                label="Dashboard"
+                icon={HomeIcon}
+                selectedIcon={HomeIconSolid}
+                isSelected
+                onClick={() => {}}
+              />
+              <XDSSideNavItem
+                label="Projects"
+                icon={FolderIcon}
+                selectedIcon={FolderIconSolid}
+                onClick={() => {}}
+                endContent={<XDSBadge label="3" />}
+              />
+              <XDSSideNavItem
+                label="Analytics"
+                icon={ChartBarIcon}
+                onClick={() => {}}
+              />
+              <XDSSideNavItem
+                label="Team"
+                icon={UserGroupIcon}
+                onClick={() => {}}
+              />
+            </XDSSideNavSection>
+            <XDSSideNavSection title="Documents">
+              <XDSSideNavItem
+                label="All Documents"
+                icon={DocumentTextIcon}
+                onClick={() => {}}
+              />
+            </XDSSideNavSection>
+          </XDSSideNav>
+        }>
+        <div style={{display: 'flex', flexDirection: 'column', height: '100%'}}>
+          <div
+            style={{
+              padding: '12px var(--spacing-3)',
+              display: 'flex',
+              flexDirection: 'column',
+              gap: '12px',
+              borderBottom: '1px solid var(--color-border)',
+            }}>
+            <XDSHeading level={2}>Users</XDSHeading>
+            <div style={{display: 'flex', alignItems: 'center', gap: '8px'}}>
+              <div style={{flex: 1}}>
+                <XDSPowerSearch
+                  config={config}
+                  filters={filters}
+                  onChange={newFilters => setFilters([...newFilters])}
+                  placeholder="Search..."
+                  label="Filter users"
+                  resultCount={filteredUsers.length}
+                />
+              </div>
+              <XDSHStack gap={1}>
+                <XDSButton
+                  label="Modal"
+                  variant="secondary"
+                  onClick={() => setModalOpen(true)}
+                />
+                <XDSButton
+                  label="Overlay"
+                  variant={overlayOpen ? 'primary' : 'secondary'}
+                  onClick={() => setOverlayOpen(!overlayOpen)}
+                />
+                <XDSButton
+                  label="Push"
+                  variant="secondary"
+                  onClick={() => setPushOpen(!pushOpen)}
+                />
+              </XDSHStack>
+            </div>
+          </div>
+          <div
+            style={{
+              display: 'flex',
+              flex: 1,
+              overflow: 'hidden',
+              position: 'relative',
+            }}>
+            <div
+              style={{
+                flex: 1,
+                overflow: 'auto',
+                minWidth: 0,
+                cursor: 'pointer',
+              }}
+              onClick={e => {
+                const row = (e.target as HTMLElement).closest('tr');
+                if (
+                  !row ||
+                  !row.parentElement ||
+                  row.parentElement.tagName === 'THEAD'
+                )
+                  return;
+                const index = Array.from(row.parentElement.children).indexOf(
+                  row,
+                );
+                const user = filteredUsers[index];
+                if (user) {
+                  setSelectedUser(user);
+                  setPushOpen(true);
+                }
+              }}>
+              <XDSTable
+                data={filteredUsers}
+                columns={tableColumns}
+                hasHover
+                idKey="id"
+              />
+            </div>
+            <div
+              style={{
+                position: 'absolute',
+                top: 0,
+                right: 0,
+                bottom: 0,
+                width: '40%',
+                maxWidth: '480px',
+                borderLeft: '1px solid var(--color-border)',
+                backgroundColor: 'var(--color-background-surface)',
+                transform: overlayOpen ? 'translateX(0)' : 'translateX(100%)',
+                opacity: overlayOpen ? 1 : 0,
+                transition: overlayOpen
+                  ? `transform ${motionSlideIn}, opacity ${motionSlideIn}`
+                  : `transform ${motionSlideOut}, opacity ${motionSlideOut}`,
+                display: 'flex',
+                flexDirection: 'column',
+                zIndex: 5,
+              }}>
+              <div
+                style={{
+                  padding: 'var(--spacing-2) var(--spacing-3)',
+                  borderBottom: '1px solid var(--color-border)',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                }}>
+                <XDSText type="label">Details</XDSText>
+                <XDSButton
+                  label="Close"
+                  icon={<XMarkIcon style={{width: 16, height: 16}} />}
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setOverlayOpen(false)}
+                  isIconOnly
+                />
+              </div>
+            </div>
+            <div
+              style={{
+                flexShrink: 0,
+                width: pushOpen ? '40%' : '0px',
+                maxWidth: pushOpen ? '480px' : '0px',
+                overflow: 'hidden',
+                borderLeft: pushOpen ? '1px solid var(--color-border)' : 'none',
+                backgroundColor: 'var(--color-background-surface)',
+                opacity: pushOpen ? 1 : 0,
+                transition: pushOpen
+                  ? `width ${motionSlideIn}, max-width ${motionSlideIn}, opacity ${motionSlideIn}`
+                  : `width ${motionSlideOut}, max-width ${motionSlideOut}, opacity ${motionSlideOut}`,
+                display: 'flex',
+                flexDirection: 'column',
+              }}>
+              <div
+                style={{
+                  padding: 'var(--spacing-2) var(--spacing-3)',
+                  borderBottom: '1px solid var(--color-border)',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  whiteSpace: 'nowrap',
+                }}>
+                <XDSText type="label">
+                  {selectedUser?.name ?? 'Details'}
+                </XDSText>
+                <XDSButton
+                  label="Close"
+                  icon={<XMarkIcon style={{width: 16, height: 16}} />}
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setPushOpen(false)}
+                  isIconOnly
+                />
+              </div>
+              {selectedUser && (
+                <div
+                  style={{padding: 'var(--spacing-3)', whiteSpace: 'nowrap'}}>
+                  <XDSVStack gap={2}>
+                    <div>
+                      <XDSText
+                        type="supporting"
+                        color="secondary"
+                        display="block">
+                        Email
+                      </XDSText>
+                      <XDSText type="body">{selectedUser.email}</XDSText>
+                    </div>
+                    <div>
+                      <XDSText
+                        type="supporting"
+                        color="secondary"
+                        display="block">
+                        Role
+                      </XDSText>
+                      <XDSText type="body">
+                        {roleLabels[selectedUser.role] ?? selectedUser.role}
+                      </XDSText>
+                    </div>
+                  </XDSVStack>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </XDSAppShell>
+      <XDSDialog isOpen={modalOpen} onOpenChange={setModalOpen}>
+        <div style={{padding: 'var(--spacing-3)', flex: 1}}>
+          <XDSText type="body" color="secondary">
+            Modal dialog with directional entry animation.
+          </XDSText>
+        </div>
+        <div
+          style={{
+            padding: 'var(--spacing-2) var(--spacing-3)',
+            borderTop: '1px solid var(--color-border)',
+            display: 'flex',
+            justifyContent: 'flex-end',
+            gap: 'var(--spacing-2)',
+          }}>
+          <XDSButton
+            label="Cancel"
+            variant="secondary"
+            onClick={() => setModalOpen(false)}
+          />
+          <XDSButton
+            label="Confirm"
+            variant="primary"
+            onClick={() => setModalOpen(false)}
+          />
+        </div>
+      </XDSDialog>
+    </div>
+  );
+}
+
+// =============================================================================
+// Token Scale Preview
+// =============================================================================
+
+const SECTION_STYLE: React.CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 12,
+};
+
+const SECTION_TITLE: React.CSSProperties = {
+  fontSize: 11,
+  fontWeight: 600,
+  textTransform: 'uppercase',
+  letterSpacing: '0.05em',
+  color: '#888',
+};
+
+const SCALE_ROW: React.CSSProperties = {
+  display: 'grid',
+  gridTemplateColumns: '1fr 200px 200px',
+  alignItems: 'center',
+  gap: 8,
+};
+
+const CODE_LABEL: React.CSSProperties = {
+  fontSize: 12,
+  fontFamily: 'monospace',
+  color: '#888',
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+};
+
+function TokenScalePreview({tokens}: {tokens: Record<string, string>}) {
+  const resolveSize = (raw: string) => {
+    if (!raw) return raw;
+    const resolved = raw.startsWith('var(')
+      ? tokens[raw.slice(4, -1)] || raw
+      : raw;
+    return resolved;
+  };
+  const toPx = (raw: string) => {
+    const resolved = resolveSize(raw);
+    if (resolved.endsWith('rem'))
+      return `${Math.round(parseFloat(resolved) * 16)}px`;
+    return resolved;
+  };
+
+  const colorsSection = (
+    <div style={SECTION_STYLE}>
+      <span style={SECTION_TITLE}>Colors</span>
+      <div style={{display: 'flex', flexDirection: 'column', gap: 4}}>
+        {[
+          {token: '--color-accent', label: 'accent'},
+          {token: '--color-accent-muted', label: 'accent-muted'},
+          {token: '--color-neutral', label: 'neutral'},
+          {token: '--color-background-card', label: 'card'},
+          {token: '--color-background-surface', label: 'surface'},
+          {token: '--color-text-primary', label: 'text'},
+          {token: '--color-text-secondary', label: 'text-secondary'},
+          {token: '--color-border', label: 'border'},
+        ].map(({token, label}) => {
+          const raw = tokens[token] || '';
+          const parsed = parseLightDark(raw);
+          const displayVal = parsed ? parsed.light : raw;
+          return (
+            <div key={token} style={SCALE_ROW}>
+              <div
+                style={{
+                  width: 48,
+                  height: 48,
+                  borderRadius: 8,
+                  backgroundColor: `var(${token})`,
+                  border: '1px solid #ddd',
+                  flexShrink: 0,
+                }}
+              />
+              <span style={CODE_LABEL}>{label}</span>
+              <span style={CODE_LABEL}>{displayVal}</span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+
+  const typographySection = (
+    <div style={SECTION_STYLE}>
+      <span style={SECTION_TITLE}>Typography</span>
+      <div style={{display: 'flex', flexDirection: 'column', gap: 8}}>
+        {(['display-1', 'display-2', 'display-3'] as const).map(type => (
+          <div key={type} style={SCALE_ROW}>
+            <div style={{overflow: 'hidden'}}>
+              <XDSText type={type} maxLines={1}>
+                Display
+              </XDSText>
+            </div>
+            <span style={CODE_LABEL}>{type}</span>
+            <span style={CODE_LABEL}>
+              {toPx(tokens[`--text-${type}-size`] || '')}
+            </span>
+          </div>
+        ))}
+        {([1, 2, 3, 4] as const).map(level => (
+          <div key={level} style={SCALE_ROW}>
+            <div style={{overflow: 'hidden'}}>
+              <XDSHeading level={level} maxLines={1}>
+                Heading {level}
+              </XDSHeading>
+            </div>
+            <span style={CODE_LABEL}>h{level}</span>
+            <span style={CODE_LABEL}>
+              {toPx(tokens[`--text-heading-${level}-size`] || '')}
+            </span>
+          </div>
+        ))}
+        {(['large', 'body', 'label', 'supporting', 'code'] as const).map(
+          type => (
+            <div key={type} style={SCALE_ROW}>
+              <div style={{overflow: 'hidden'}}>
+                <XDSText type={type} maxLines={1}>
+                  {type === 'code'
+                    ? 'const theme = defineTheme()'
+                    : 'The quick brown fox'}
+                </XDSText>
+              </div>
+              <span style={CODE_LABEL}>{type}</span>
+              <span style={CODE_LABEL}>
+                {toPx(tokens[`--text-${type}-size`] || '')}
+              </span>
+            </div>
+          ),
+        )}
+      </div>
+    </div>
+  );
+
+  const spacingSection = (
+    <div style={SECTION_STYLE}>
+      <span style={SECTION_TITLE}>Spacing</span>
+      <div style={{display: 'flex', flexDirection: 'column', gap: 4}}>
+        {[0.5, 1, 2, 3, 4, 6, 8, 12].map(step => {
+          const key = String(step).replace('.', '-');
+          const val = tokens[`--spacing-${key}`] || '0px';
+          return (
+            <div key={step} style={SCALE_ROW}>
+              <div style={{display: 'flex', alignItems: 'center'}}>
+                <div
+                  style={{
+                    width: val,
+                    height: val,
+                    backgroundColor: 'var(--color-accent-muted)',
+                    border: '1px dashed var(--color-accent)',
+                    transition: 'width 200ms ease, height 200ms ease',
+                  }}
+                />
+              </div>
+              <span style={CODE_LABEL}>{step}</span>
+              <span style={CODE_LABEL}>{val}</span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+
+  const radiusSection = (
+    <div style={SECTION_STYLE}>
+      <span style={SECTION_TITLE}>Corner Radius</span>
+      <div style={{display: 'flex', flexDirection: 'column', gap: 8}}>
+        {(['none', 'inner', 'element', 'container', 'page'] as const).map(
+          name => {
+            const val = tokens[`--radius-${name}`] || '0px';
+            return (
+              <div key={name} style={SCALE_ROW}>
+                <div
+                  style={{
+                    width: 48,
+                    height: 48,
+                    backgroundColor: 'var(--color-accent-muted)',
+                    border: '1px dashed var(--color-accent)',
+                    borderRadius: val,
+                    flexShrink: 0,
+                    transition: 'border-radius 200ms ease',
+                  }}
+                />
+                <span style={CODE_LABEL}>{name}</span>
+                <span style={CODE_LABEL}>{val}</span>
+              </div>
+            );
+          },
+        )}
+      </div>
+    </div>
+  );
+
+  const sizeSection = (
+    <div style={SECTION_STYLE}>
+      <span style={SECTION_TITLE}>Element Size</span>
+      <div style={{display: 'flex', flexDirection: 'column', gap: 8}}>
+        {(['sm', 'md', 'lg'] as const).map(size => {
+          const val = tokens[`--size-element-${size}`] || '32px';
+          return (
+            <div key={size} style={SCALE_ROW}>
+              <div
+                style={{
+                  width: `calc(${val} * 2.4)`,
+                  height: val,
+                  backgroundColor: 'var(--color-accent-muted)',
+                  border: '1px dashed var(--color-accent)',
+                  borderRadius: 8,
+                  flexShrink: 0,
+                  transition: 'width 200ms ease, height 200ms ease',
+                }}
+              />
+              <span style={CODE_LABEL}>{size}</span>
+              <span style={CODE_LABEL}>{val}</span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+
+  return (
+    <div style={{containerType: 'inline-size'}}>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: '1fr',
+          gap: 32,
+        }}>
+        <style>{`@container (min-width: 720px) { .token-scale-grid { grid-template-columns: 1fr auto 1fr !important; } }`}</style>
+        <div
+          className="token-scale-grid"
+          style={{display: 'grid', gridTemplateColumns: '1fr', gap: 32}}>
+          <div style={{display: 'flex', flexDirection: 'column', gap: 32}}>
+            {colorsSection}
+            {spacingSection}
+            {sizeSection}
+          </div>
+          <div
+            className="token-scale-divider"
+            style={{width: 1, backgroundColor: 'var(--color-border)'}}
+          />
+          <div style={{display: 'flex', flexDirection: 'column', gap: 32}}>
+            {typographySection}
+            {radiusSection}
+          </div>
+        </div>
+        <style>{`@container (max-width: 719px) { .token-scale-divider { display: none !important; } }`}</style>
+      </div>
+    </div>
+  );
+}
+
+// =============================================================================
+// Preview Tabs
+// =============================================================================
+
+function TemplateIframePreview({
+  slug,
+  theme,
+  mode,
+}: {
+  slug: string;
+  theme: XDSDefinedTheme;
+  mode: 'light' | 'dark';
+}) {
+  const iframeRef = React.useRef<HTMLIFrameElement>(null);
+  const href =
+    templates.find(t => t.slug === slug)?.href ?? `/templates/${slug}/`;
+
+  React.useEffect(() => {
+    const iframe = iframeRef.current;
+    if (!iframe) return;
+    const inject = () => {
+      const doc = iframe.contentDocument;
+      if (!doc) return;
+      doc.documentElement.setAttribute('data-xds-theme', theme.name);
+      doc.documentElement.setAttribute('data-color-scheme', mode);
+      doc.documentElement.style.colorScheme = mode;
+
+      // Hide the PreviewShell toolbar inside the iframe
+      const root = doc.body?.firstElementChild as HTMLElement | null;
+      if (root) {
+        const toolbar = root.firstElementChild as HTMLElement | null;
+        if (toolbar) toolbar.style.display = 'none';
+      }
+
+      let styleEl = doc.querySelector<HTMLStyleElement>(
+        'style[data-xds-editor-theme]',
+      );
+      if (!styleEl) {
+        styleEl = doc.createElement('style');
+        styleEl.setAttribute('data-xds-editor-theme', 'true');
+        doc.head.appendChild(styleEl);
+      }
+      styleEl.textContent = generateThemeCSSFlat(theme);
+    };
+    iframe.addEventListener('load', inject);
+    inject();
+    return () => iframe.removeEventListener('load', inject);
+  }, [theme, mode, slug]);
+
+  return (
+    <iframe
+      ref={iframeRef}
+      src={href}
+      style={{
+        width: '100%',
+        height: '100%',
+        border: 'none',
+        borderRadius: 'var(--radius-container)',
+      }}
+    />
+  );
+}
+
+function PreviewContent({
+  activePreview,
+  tokens,
+  theme,
+  mode,
+}: {
+  activePreview: string;
+  tokens?: Record<string, string>;
+  theme?: XDSDefinedTheme;
+  mode?: 'light' | 'dark';
+}) {
+  return (
+    <div
+      style={
+        activePreview.startsWith('template:') ? {height: '100%'} : undefined
+      }>
+      {activePreview === 'preview' && <ComponentPreview />}
+      {activePreview === 'landing' && <LandingPagePreview />}
+      {activePreview === 'dashboard' && <DashboardPreview />}
+      {activePreview === 'table' && <MotionPreview />}
+      {activePreview === 'tokens' && tokens && (
+        <TokenScalePreview tokens={tokens} />
+      )}
+      {activePreview.startsWith('template:') && theme && mode && (
+        <TemplateIframePreview
+          slug={activePreview.slice(9)}
+          theme={theme}
+          mode={mode}
+        />
+      )}
+    </div>
+  );
+}
+
+// =============================================================================
+// Code Generator
+// =============================================================================
+
+function generateThemeCode(
+  themeName: string,
+  tokens: Record<string, string>,
+  defaults: Record<string, string>,
+  typeScaleBase?: number,
+  typeScaleRatio?: number,
+): string {
+  const changedTokens: Record<string, string> = {};
+  const hasCustomTypeScale =
+    typeScaleBase !== undefined &&
+    typeScaleRatio !== undefined &&
+    (typeScaleBase !== 14 || typeScaleRatio !== 1.2);
+  const typeScaleTokenKeys = new Set(Object.keys(typeScaleDefaults));
+
+  for (const [key, value] of Object.entries(tokens)) {
+    if (value !== defaults[key]) {
+      if (hasCustomTypeScale && typeScaleTokenKeys.has(key)) continue;
+      changedTokens[key] = value;
+    }
+  }
+
+  const hasTokenOverrides = Object.keys(changedTokens).length > 0;
+
+  if (!hasTokenOverrides && !hasCustomTypeScale) {
+    return `import { defineTheme } from '@xds/core/theme';\n\nexport const ${themeName}Theme = defineTheme({\n  name: '${themeName}',\n  tokens: {},\n});`;
+  }
+
+  const parts: string[] = [];
+  if (hasCustomTypeScale) {
+    parts.push(
+      `  typography: { scale: { base: ${typeScaleBase}, ratio: ${typeScaleRatio} } },`,
+    );
+  }
+  if (hasTokenOverrides) {
+    const tokenEntries = Object.entries(changedTokens)
+      .map(([key, value]) => {
+        const parsed = parseLightDark(value);
+        if (parsed)
+          return `    '${key}': ['${parsed.light}', '${parsed.dark}'],`;
+        return `    '${key}': '${value}',`;
+      })
+      .join('\n');
+    parts.push(`  tokens: {\n${tokenEntries}\n  },`);
+  } else {
+    parts.push(`  tokens: {},`);
+  }
+
+  return `import { defineTheme } from '@xds/core/theme';\n\nexport const ${themeName}Theme = defineTheme({\n  name: '${themeName}',\n${parts.join('\n')}\n});`;
+}
+
+// =============================================================================
+// Main ThemeEditorView Component
+// =============================================================================
+
+export function ThemeEditorView({
+  activeView,
+  setActiveView,
+}: {
+  activeView: string;
+  setActiveView: (view: 'craft' | 'explore' | 'docs' | 'profile') => void;
+}) {
+  // Token editing state
+  const [activeGroup, setActiveGroup] = React.useState<TokenGroupKey>('colors');
+  const [activeColorCategory, setActiveColorCategory] =
+    React.useState<string>('Core Semantic');
+  const [activeTypographyCategory, setActiveTypographyCategory] =
+    React.useState<string>('Heading 1');
+  const [themeName] = React.useState('custom');
+  const [mode, setMode] = React.useState<'light' | 'dark'>('light');
+  const [showCode, setShowCode] = React.useState(false);
+  const [pushPanelOpen, setPushPanelOpen] = React.useState(false);
+  const [overlayPanelOpen, setOverlayPanelOpen] = React.useState(false);
+  const [activePreview, setActivePreview] = React.useState('preview');
+
+  const isMotionGroup = activeGroup === 'duration' || activeGroup === 'easing';
+
+  React.useEffect(() => {
+    if (panelMode === 'editor') setActivePreview('tokens');
+    if (panelMode === 'target') setActivePreview('preview');
+  }, [panelMode]);
+  const [typeScaleBase, setTypeScaleBase] = React.useState(14);
+  const [typeScaleRatio, setTypeScaleRatio] = React.useState(1.2);
+  const [panelMode, setPanelMode] = React.useState<'editor' | 'target' | 'raw'>(
+    'editor',
+  );
+  const [targetComponent, setTargetComponent] = React.useState<string | null>(
+    null,
+  );
+  const [flashComponent, setFlashComponent] = React.useState<string | null>(
+    null,
+  );
+  const [customVars, setCustomVars] = React.useState<Set<string>>(new Set());
+  const previewRef = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    if (!flashComponent || !previewRef.current) return;
+    const container = previewRef.current;
+    const selector = `.xds-${flashComponent}`;
+    const elements = container.querySelectorAll<HTMLElement>(selector);
+    if (elements.length === 0) {
+      setFlashComponent(null);
+      return;
+    }
+    elements.forEach(el => el.classList.add('xds-target-flash'));
+    const timer = setTimeout(() => {
+      elements.forEach(el => el.classList.remove('xds-target-flash'));
+      setFlashComponent(null);
+    }, 3000);
+    return () => {
+      clearTimeout(timer);
+      elements.forEach(el => el.classList.remove('xds-target-flash'));
+    };
+  }, [flashComponent]);
+
+  const [radiusBase, setRadiusBase] = React.useState(4);
+  const [spacingBase, setSpacingBase] = React.useState(4);
+  const [sizeBase, setSizeBase] = React.useState(32);
+  const [durationStep, setDurationStep] = React.useState(1);
+  const [activePreset, setActivePreset] = React.useState<string | null>(
+    'default',
+  );
+  const [autoPickColors, setAutoPickColors] = React.useState(false);
+
+  const [aiImagePreview, setAiImagePreview] = React.useState<string | null>(
+    null,
+  );
+  const [aiAnalyzing, setAiAnalyzing] = React.useState(false);
+  const [aiError, setAiError] = React.useState<string | null>(null);
+
+  const UNIFIED_PRESETS = React.useMemo(
+    () => ({
+      compact: {
+        typeBase: 12,
+        typeRatio: 1.125,
+        spacing: 2,
+        radius: 2,
+        sizeMd: 28,
+      },
+      default: {
+        typeBase: 14,
+        typeRatio: 1.2,
+        spacing: 4,
+        radius: 4,
+        sizeMd: 32,
+      },
+      comfortable: {
+        typeBase: 16,
+        typeRatio: 1.25,
+        spacing: 6,
+        radius: 8,
+        sizeMd: 44,
+      },
+      gigantic: {
+        typeBase: 18,
+        typeRatio: 1.414,
+        spacing: 8,
+        radius: 12,
+        sizeMd: 48,
+      },
+    }),
+    [],
+  );
+
+  const applyTypeScale = React.useCallback((base: number, ratio: number) => {
+    setActivePreset(null);
+    setTypeScaleBase(base);
+    setTypeScaleRatio(ratio);
+    setTokens(prev => ({...prev, ...expandTypeScale({base, ratio})}));
+  }, []);
+
+  const applySpacingScale = React.useCallback((base: number) => {
+    setActivePreset(null);
+    setSpacingBase(base);
+    const steps = [0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+    const keys = [
+      '0',
+      '0-5',
+      '1',
+      '1-5',
+      '2',
+      '3',
+      '4',
+      '5',
+      '6',
+      '7',
+      '8',
+      '9',
+      '10',
+      '11',
+      '12',
+    ];
+    const patch: Record<string, string> = {};
+    steps.forEach((step, i) => {
+      patch[`--spacing-${keys[i]}`] = `${Math.round(base * step)}px`;
+    });
+    setTokens(prev => ({...prev, ...patch}));
+  }, []);
+
+  const applySizeScale = React.useCallback((base: number) => {
+    setActivePreset(null);
+    setSizeBase(base);
+    setTokens(prev => ({
+      ...prev,
+      '--size-element-sm': `${base - 4}px`,
+      '--size-element-md': `${base}px`,
+      '--size-element-lg': `${base + 4}px`,
+    }));
+  }, []);
+
+  const applyRadiusScale = React.useCallback((base: number) => {
+    setActivePreset(null);
+    setRadiusBase(base);
+    setTokens(prev => ({
+      ...prev,
+      ...expandRadiusScale({base, multiplier: 1}),
+    }));
+  }, []);
+
+  const applyDurationScale = React.useCallback((multiplier: number) => {
+    setDurationStep(multiplier);
+    const defaults = {
+      '--duration-fast-min': 130,
+      '--duration-fast': 175,
+      '--duration-fast-max': 230,
+      '--duration-medium-min': 310,
+      '--duration-medium': 410,
+      '--duration-medium-max': 550,
+      '--duration-slow-min': 730,
+      '--duration-slow': 975,
+      '--duration-slow-max': 1300,
+    };
+    const patch: Record<string, string> = {};
+    for (const [key, base] of Object.entries(defaults)) {
+      patch[key] = `${Math.round(base / multiplier)}ms`;
+    }
+    setTokens(prev => ({...prev, ...patch}));
+  }, []);
+
+  const applyUnifiedPreset = React.useCallback(
+    (presetKey: string) => {
+      const p = UNIFIED_PRESETS[presetKey as keyof typeof UNIFIED_PRESETS];
+      if (!p) return;
+      setActivePreset(presetKey);
+      setTypeScaleBase(p.typeBase);
+      setTypeScaleRatio(p.typeRatio);
+      setSpacingBase(p.spacing);
+      setRadiusBase(p.radius);
+      setSizeBase(p.sizeMd);
+      setTokens(prev => {
+        const spacingSteps = [
+          0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
+        ];
+        const spacingKeys = [
+          '0',
+          '0-5',
+          '1',
+          '1-5',
+          '2',
+          '3',
+          '4',
+          '5',
+          '6',
+          '7',
+          '8',
+          '9',
+          '10',
+          '11',
+          '12',
+        ];
+        const spacingPatch: Record<string, string> = {};
+        spacingSteps.forEach((step, i) => {
+          spacingPatch[`--spacing-${spacingKeys[i]}`] =
+            `${Math.round(p.spacing * step)}px`;
+        });
+        return {
+          ...prev,
+          ...expandTypeScale({base: p.typeBase, ratio: p.typeRatio}),
+          ...spacingPatch,
+          ...expandRadiusScale({base: p.radius, multiplier: 1}),
+          '--size-element-sm': `${p.sizeMd - p.spacing}px`,
+          '--size-element-md': `${p.sizeMd}px`,
+          '--size-element-lg': `${p.sizeMd + p.spacing}px`,
+        };
+      });
+    },
+    [UNIFIED_PRESETS],
+  );
+
+  const FONT_LABEL_TO_VALUE: Record<string, string> = React.useMemo(
+    () => ({
+      System:
+        '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
+      Inter: '"Inter", -apple-system, sans-serif',
+      Roboto: '"Roboto", -apple-system, sans-serif',
+      'DM Sans': '"DM Sans", -apple-system, sans-serif',
+      Figtree: '"Figtree", -apple-system, sans-serif',
+      Poppins: '"Poppins", -apple-system, sans-serif',
+      'IBM Plex Sans': '"IBM Plex Sans", -apple-system, sans-serif',
+      'Source Sans': '"Source Sans 3", -apple-system, sans-serif',
+      'Noto Sans': '"Noto Sans", -apple-system, sans-serif',
+      Georgia: 'Georgia, "Times New Roman", serif',
+    }),
+    [],
+  );
+
+  const applyAITheme = React.useCallback(
+    (result: {
+      accentColor: string;
+      headingFont: string;
+      bodyFont: string;
+      spacingBase: number;
+      radiusBase: number;
+      typeScaleBase: number;
+      typeScaleRatio: number;
+      sizeBase: number;
+    }) => {
+      const clampedSpacing = Math.max(
+        2,
+        Math.min(16, Math.round(result.spacingBase / 2) * 2),
+      );
+      const clampedRadius = Math.max(
+        0,
+        Math.min(18, Math.round(result.radiusBase / 2) * 2),
+      );
+      const clampedTypeBase = Math.max(
+        10,
+        Math.min(24, Math.round(result.typeScaleBase)),
+      );
+      const clampedSize = Math.max(
+        24,
+        Math.min(56, Math.round(result.sizeBase / 2) * 2),
+      );
+
+      const validRatios = [1.067, 1.125, 1.2, 1.25, 1.333, 1.414, 1.5, 1.618];
+      const closestRatio = validRatios.reduce((best, r) =>
+        Math.abs(r - result.typeScaleRatio) <
+        Math.abs(best - result.typeScaleRatio)
+          ? r
+          : best,
+      );
+
+      setActivePreset(null);
+      setTypeScaleBase(clampedTypeBase);
+      setTypeScaleRatio(closestRatio);
+      setSpacingBase(clampedSpacing);
+      setRadiusBase(clampedRadius);
+      setSizeBase(clampedSize);
+      setAutoPickColors(true);
+
+      const headingValue =
+        FONT_LABEL_TO_VALUE[result.headingFont] ||
+        FONT_LABEL_TO_VALUE['System'];
+      const bodyValue =
+        FONT_LABEL_TO_VALUE[result.bodyFont] || FONT_LABEL_TO_VALUE['System'];
+
+      const spacingSteps = [0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+      const spacingKeys = [
+        '0',
+        '0-5',
+        '1',
+        '1-5',
+        '2',
+        '3',
+        '4',
+        '5',
+        '6',
+        '7',
+        '8',
+        '9',
+        '10',
+        '11',
+        '12',
+      ];
+      const spacingPatch: Record<string, string> = {};
+      spacingSteps.forEach((step, i) => {
+        spacingPatch[`--spacing-${spacingKeys[i]}`] =
+          `${Math.round(clampedSpacing * step)}px`;
+      });
+
+      const accentHex = result.accentColor?.startsWith('#')
+        ? result.accentColor
+        : '#0066FF';
+      const colorPatch = expandColorScale({accent: accentHex});
+
+      setTokens(prev => ({
+        ...prev,
+        ...expandTypeScale({base: clampedTypeBase, ratio: closestRatio}),
+        ...spacingPatch,
+        ...expandRadiusScale({base: clampedRadius, multiplier: 1}),
+        ...colorPatch,
+        '--color-accent': accentHex,
+        '--font-family-heading': headingValue,
+        '--font-family-body': bodyValue,
+        '--size-element-sm': `${clampedSize - 4}px`,
+        '--size-element-md': `${clampedSize}px`,
+        '--size-element-lg': `${clampedSize + 4}px`,
+      }));
+    },
+    [FONT_LABEL_TO_VALUE],
+  );
+
+  const handleImageUpload = React.useCallback(
+    async (file: File) => {
+      setAiError(null);
+      setAiAnalyzing(true);
+
+      const previewUrl = URL.createObjectURL(file);
+      setAiImagePreview(previewUrl);
+
+      try {
+        const buffer = await file.arrayBuffer();
+        const base64 = btoa(
+          new Uint8Array(buffer).reduce(
+            (data, byte) => data + String.fromCharCode(byte),
+            '',
+          ),
+        );
+
+        const resp = await fetch('/api/analyze-theme', {
+          method: 'POST',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({image: base64, mimeType: file.type}),
+        });
+
+        const data = await resp.json();
+        if (!resp.ok) {
+          throw new Error(data.error || `HTTP ${resp.status}`);
+        }
+
+        applyAITheme(data);
+      } catch (err) {
+        setAiError(err instanceof Error ? err.message : String(err));
+      } finally {
+        setAiAnalyzing(false);
+      }
+    },
+    [applyAITheme],
+  );
+
+  // Resize state (docsite layout pattern)
+  const [editorPanelWidth, setEditorPanelWidth] = React.useState(400);
+  const [isEditorResizing, setIsEditorResizing] = React.useState(false);
+
+  const allDefaults: Record<string, string> = React.useMemo(
+    () => ({
+      ...colorDefaults,
+      ...spacingDefaults,
+      ...radiusDefaults,
+      ...typographyDefaults,
+      ...textSizeDefaults,
+      ...fontWeightDefaults,
+      ...typeScaleDefaults,
+      ...sizeDefaults,
+      ...shadowDefaults,
+      ...durationDefaults,
+      ...easeDefaults,
+      ...transitionDefaults,
+    }),
+    [],
+  );
+
+  const [tokens, setTokens] =
+    React.useState<Record<string, string>>(allDefaults);
+
+  const handleTokenChange = React.useCallback(
+    (tokenName: string, value: string) => {
+      setTokens(prev => ({...prev, [tokenName]: value}));
+    },
+    [],
+  );
+
+  const handleReset = React.useCallback(() => {
+    setTokens(allDefaults);
+    setTypeScaleBase(14);
+    setTypeScaleRatio(1.2);
+    setRadiusBase(4);
+    setSpacingBase(4);
+    setSizeBase(32);
+    setDurationStep(1);
+    setActivePreset('default');
+  }, [allDefaults]);
+
+  const typeScaleKeys = React.useMemo(
+    () => new Set(Object.keys(typeScaleDefaults)),
+    [],
+  );
+
+  const currentTheme = React.useMemo(() => {
+    const tokenOverrides: Record<string, string> = {};
+    for (const [key, value] of Object.entries(tokens)) {
+      if (typeScaleKeys.has(key) || value !== allDefaults[key]) {
+        tokenOverrides[key] = value;
+      }
+    }
+    return defineTheme({
+      name: themeName,
+      typography: {scale: {base: typeScaleBase, ratio: typeScaleRatio}},
+      tokens: tokenOverrides as Partial<Record<string, string>>,
+      icons: defaultIconRegistry,
+    });
+  }, [
+    tokens,
+    themeName,
+    allDefaults,
+    typeScaleBase,
+    typeScaleRatio,
+    typeScaleKeys,
+  ]);
+
+  const handleEditorResizeStart = React.useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      setIsEditorResizing(true);
+      const startX = e.clientX;
+      const startWidth = editorPanelWidth;
+      const onMouseMove = (ev: MouseEvent) => {
+        const maxWidth = Math.floor(window.innerWidth / 2);
+        const newWidth = Math.min(
+          Math.max(startWidth + (ev.clientX - startX), 280),
+          maxWidth,
+        );
+        setEditorPanelWidth(newWidth);
+      };
+      const onMouseUp = () => {
+        setIsEditorResizing(false);
+        document.removeEventListener('mousemove', onMouseMove);
+        document.removeEventListener('mouseup', onMouseUp);
+        document.body.style.cursor = '';
+        document.body.style.userSelect = '';
+      };
+      document.body.style.cursor = 'col-resize';
+      document.body.style.userSelect = 'none';
+      document.addEventListener('mousemove', onMouseMove);
+      document.addEventListener('mouseup', onMouseUp);
+    },
+    [editorPanelWidth],
+  );
+
+  // ---------------------------------------------------------------------------
+  // Token Editor Renderer
+  // ---------------------------------------------------------------------------
+
+  const renderTokenEditor = () => {
+    const group = TOKEN_GROUPS[activeGroup];
+
+    if (activeGroup === 'colors') {
+      const seen = new Set<string>();
+      return (
+        <div style={{display: 'flex', flexDirection: 'column', gap: '4px'}}>
+          {Object.entries(COLOR_CATEGORIES).map(([category, tokenNames]) => {
+            const uniqueTokens = tokenNames.filter(t => {
+              if (seen.has(t)) return false;
+              seen.add(t);
+              return true;
+            });
+            if (uniqueTokens.length === 0) return null;
+            return (
+              <React.Fragment key={category}>
+                <XDSText
+                  type="supporting"
+                  color="secondary"
+                  style={{marginTop: 8, marginBottom: 2}}>
+                  {category}
+                </XDSText>
+                {uniqueTokens.map(tokenName => (
+                  <ColorSwatch
+                    key={tokenName}
+                    tokenName={tokenName}
+                    value={tokens[tokenName] || ''}
+                    onChange={handleTokenChange}
+                    mode={mode}
+                  />
+                ))}
+              </React.Fragment>
+            );
+          })}
+        </div>
+      );
+    }
+
+    if (activeGroup === 'spacing' || activeGroup === 'size') {
+      return (
+        <div style={{display: 'flex', flexDirection: 'column', gap: '8px'}}>
+          {Object.keys(group.tokens).map(tokenName => (
+            <SpacingEditor
+              key={tokenName}
+              tokenName={tokenName}
+              value={tokens[tokenName] || ''}
+              onChange={handleTokenChange}
+            />
+          ))}
+        </div>
+      );
+    }
+
+    if (activeGroup === 'radius') {
+      return (
+        <div style={{display: 'flex', flexDirection: 'column', gap: '8px'}}>
+          {Object.keys(group.tokens).map(tokenName => (
+            <RadiusEditor
+              key={tokenName}
+              tokenName={tokenName}
+              value={tokens[tokenName] || ''}
+              onChange={handleTokenChange}
+            />
+          ))}
+        </div>
+      );
+    }
+
+    if (activeGroup === 'typography') {
+      const seen = new Set<string>();
+      return (
+        <div style={{display: 'flex', flexDirection: 'column', gap: '4px'}}>
+          {Object.entries(TYPOGRAPHY_CATEGORIES).map(
+            ([category, categoryValue]) => {
+              const catTokens: string[] = Array.isArray(categoryValue)
+                ? categoryValue
+                : categoryValue.tokens;
+              const uniqueTokens = catTokens.filter(t => {
+                if (seen.has(t)) return false;
+                seen.add(t);
+                return true;
+              });
+              if (uniqueTokens.length === 0) return null;
+              return (
+                <React.Fragment key={category}>
+                  <XDSText
+                    type="supporting"
+                    color="secondary"
+                    style={{marginTop: 8, marginBottom: 2}}>
+                    {category}
+                  </XDSText>
+                  {uniqueTokens.map(tokenName => (
+                    <TypographyEditor
+                      key={tokenName}
+                      tokenName={tokenName}
+                      value={tokens[tokenName] || ''}
+                      onChange={handleTokenChange}
+                    />
+                  ))}
+                </React.Fragment>
+              );
+            },
+          )}
+        </div>
+      );
+    }
+
+    return (
+      <XDSVStack gap={2}>
+        {Object.keys(group.tokens).map(tokenName => (
+          <XDSHStack
+            key={tokenName}
+            gap={3}
+            vAlign="center"
+            style={{
+              padding: '8px 12px',
+              borderRadius: 8,
+              backgroundColor: 'var(--color-background-body)',
+            }}>
+            <XDSVStack gap={0} style={{flex: 1, minWidth: 0}}>
+              <XDSText type="supporting" color="primary" maxLines={1}>
+                {getTokenLabel(tokenName)}
+              </XDSText>
+              <XDSText type="supporting" color="secondary" maxLines={1}>
+                {tokenName}
+              </XDSText>
+            </XDSVStack>
+            <div style={{width: 200}}>
+              <XDSTextInput
+                label="Value"
+                isLabelHidden
+                value={tokens[tokenName] || ''}
+                onChange={val => handleTokenChange(tokenName, val)}
+                size="sm"
+              />
+            </div>
+          </XDSHStack>
+        ))}
+      </XDSVStack>
+    );
+  };
+
+  // ---------------------------------------------------------------------------
+  // Layout — docsite split-panel pattern
+  // ---------------------------------------------------------------------------
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        height: '100vh',
+        overflow: 'hidden',
+        backgroundColor: 'var(--color-background-surface, #fff)',
+      }}>
+      <style>
+        {'@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Roboto:wght@400;500;700&family=DM+Sans:wght@400;500;600;700&family=Figtree:wght@400;500;600;700&family=Poppins:wght@400;500;600;700&family=IBM+Plex+Sans:wght@400;500;600;700&family=Source+Sans+3:wght@400;500;600;700&family=Noto+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&family=Fira+Code:wght@400;500;600;700&family=Source+Code+Pro:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600;700&display=swap");' +
+          '.xds-editor-resize-handle { opacity: 0; transition: opacity 150ms ease, background-color 150ms ease; }' +
+          '.xds-editor-resize-grip:hover .xds-editor-resize-handle { opacity: 0.6; }' +
+          '.xds-editor-resize-grip[data-resizing="true"] .xds-editor-resize-handle { opacity: 1; }' +
+          '@keyframes xds-flash-fade { 0% { outline: 2px solid var(--color-accent); outline-offset: 2px; } 100% { outline: 2px solid transparent; outline-offset: 2px; } }' +
+          '.xds-target-flash { animation: xds-flash-fade 3s ease-out forwards; }'}
+      </style>
+
+      {/* Left Panel — Token Editor */}
+      <div
+        style={{
+          width: editorPanelWidth,
+          minWidth: 280,
+          maxWidth: '50vw',
+          flexShrink: 0,
+          padding: 16,
+          paddingRight: 0,
+          display: 'flex',
+        }}>
+        <div
+          style={{
+            flex: 1,
+            backgroundColor: 'var(--color-background-card, #fff)',
+            borderRadius: 16,
+            border: '1px solid var(--color-divider, #e0e0e0)',
+            overflow: 'hidden',
+            display: 'flex',
+            flexDirection: 'column' as const,
+          }}>
+          {/* Token group tabs */}
+          <div
+            style={{
+              padding: '12px 16px 12px',
+              borderBottom: '1px solid var(--color-border)',
+              display: 'flex',
+              alignItems: 'center',
+              gap: 8,
+              overflowX: 'auto',
+              overflowY: 'hidden',
+              scrollbarWidth: 'none',
+            }}>
+            <XDSButton
+              label="Back"
+              variant="ghost"
+              size="sm"
+              onClick={() => setActiveView('craft')}
+              icon={<span style={{fontSize: 14}}>&#8592;</span>}
+              isIconOnly
+              style={{flexShrink: 0}}
+            />
+            <XDSToggleButtonGroup
+              label="Panel mode"
+              type="single"
+              value={
+                panelMode === 'target'
+                  ? 'target'
+                  : panelMode === 'editor'
+                    ? 'editor'
+                    : activeGroup
+              }
+              onChange={v => {
+                if (v === null) return;
+                if (v === 'editor') {
+                  setPanelMode('editor');
+                } else if (v === 'target') {
+                  setPanelMode('target');
+                  setActivePreview('preview');
+                } else if (v === 'raw') {
+                  setPanelMode('raw');
+                } else {
+                  setActiveGroup(v as TokenGroupKey);
+                }
+              }}
+              size="sm">
+              <XDSToggleButton value="editor" label="Editor" />
+              <XDSToggleButton value="target" label="Component" />
+              {panelMode === 'editor' || panelMode === 'target' ? (
+                <XDSToggleButton value="raw" label="Raw Tokens" />
+              ) : (
+                (Object.keys(TOKEN_GROUPS) as TokenGroupKey[]).map(groupKey => (
+                  <XDSToggleButton
+                    key={groupKey}
+                    value={groupKey}
+                    label={TOKEN_GROUPS[groupKey].label}
+                  />
+                ))
+              )}
+            </XDSToggleButtonGroup>
+          </div>
+
+          {/* Scrollable token editors */}
+          <div style={{flex: 1, overflow: 'auto', padding: '16px'}}>
+            {panelMode === 'editor' ? (
+              <XDSVStack gap={4}>
+                {/* Core Colors */}
+                <div>
+                  <XDSHStack
+                    vAlign="center"
+                    style={{marginBottom: 8, justifyContent: 'space-between'}}>
+                    <XDSText type="label" color="secondary">
+                      Core Colors
+                    </XDSText>
+                    <XDSSwitch
+                      label="Auto Pick"
+                      value={autoPickColors}
+                      onChange={val => {
+                        setAutoPickColors(val);
+                        if (val) {
+                          const accentRaw = tokens['--color-accent'] || '';
+                          const parsed = parseLightDark(accentRaw);
+                          const accentHex = parsed ? parsed.light : accentRaw;
+                          if (accentHex && accentHex.startsWith('#')) {
+                            const derived = expandColorScale({
+                              accent: accentHex,
+                            });
+                            setTokens(prev => ({...prev, ...derived}));
+                          }
+                        }
+                      }}
+                    />
+                  </XDSHStack>
+                  <XDSVStack gap={1}>
+                    {autoPickColors ? (
+                      <ColorSwatch
+                        tokenName="--color-accent"
+                        value={tokens['--color-accent'] || ''}
+                        onChange={(name, value) => {
+                          handleTokenChange(name, value);
+                          const parsed = parseLightDark(value);
+                          const hex = parsed ? parsed.light : value;
+                          if (hex && hex.startsWith('#') && hex.length >= 7) {
+                            const derived = expandColorScale({accent: hex});
+                            setTokens(prev => ({
+                              ...prev,
+                              [name]: value,
+                              ...derived,
+                            }));
+                          }
+                        }}
+                        mode={mode}
+                      />
+                    ) : (
+                      [
+                        '--color-accent',
+                        '--color-neutral',
+                        '--color-background-card',
+                        '--color-background-surface',
+                        '--color-text-primary',
+                      ].map(tokenName => (
+                        <ColorSwatch
+                          key={tokenName}
+                          tokenName={tokenName}
+                          value={tokens[tokenName] || ''}
+                          onChange={handleTokenChange}
+                          mode={mode}
+                        />
+                      ))
+                    )}
+                  </XDSVStack>
+                </div>
+
+                {/* Font Families */}
+                <div>
+                  <XDSVStack gap={2}>
+                    {[
+                      {
+                        token: '--font-family-body',
+                        label: 'Body Font',
+                        options: [
+                          {
+                            value:
+                              '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
+                            label: 'System (Default)',
+                          },
+                          {
+                            value: '"Inter", -apple-system, sans-serif',
+                            label: 'Inter',
+                          },
+                          {
+                            value: '"Roboto", -apple-system, sans-serif',
+                            label: 'Roboto',
+                          },
+                          {
+                            value: '"DM Sans", -apple-system, sans-serif',
+                            label: 'DM Sans',
+                          },
+                          {
+                            value: '"Figtree", -apple-system, sans-serif',
+                            label: 'Figtree',
+                          },
+                          {
+                            value: '"Poppins", -apple-system, sans-serif',
+                            label: 'Poppins',
+                          },
+                          {
+                            value: '"IBM Plex Sans", -apple-system, sans-serif',
+                            label: 'IBM Plex Sans',
+                          },
+                          {
+                            value: '"Source Sans 3", -apple-system, sans-serif',
+                            label: 'Source Sans',
+                          },
+                          {
+                            value: '"Noto Sans", -apple-system, sans-serif',
+                            label: 'Noto Sans',
+                          },
+                          {
+                            value: 'Georgia, "Times New Roman", serif',
+                            label: 'Georgia (Serif)',
+                          },
+                        ],
+                      },
+                      {
+                        token: '--font-family-heading',
+                        label: 'Heading Font',
+                        options: [
+                          {
+                            value:
+                              '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
+                            label: 'System (Default)',
+                          },
+                          {
+                            value: '"Inter", -apple-system, sans-serif',
+                            label: 'Inter',
+                          },
+                          {
+                            value: '"Roboto", -apple-system, sans-serif',
+                            label: 'Roboto',
+                          },
+                          {
+                            value: '"DM Sans", -apple-system, sans-serif',
+                            label: 'DM Sans',
+                          },
+                          {
+                            value: '"Figtree", -apple-system, sans-serif',
+                            label: 'Figtree',
+                          },
+                          {
+                            value: '"Poppins", -apple-system, sans-serif',
+                            label: 'Poppins',
+                          },
+                          {
+                            value: '"IBM Plex Sans", -apple-system, sans-serif',
+                            label: 'IBM Plex Sans',
+                          },
+                          {
+                            value: '"Source Sans 3", -apple-system, sans-serif',
+                            label: 'Source Sans',
+                          },
+                          {
+                            value: '"Noto Sans", -apple-system, sans-serif',
+                            label: 'Noto Sans',
+                          },
+                          {
+                            value: 'Georgia, "Times New Roman", serif',
+                            label: 'Georgia (Serif)',
+                          },
+                        ],
+                      },
+                    ].map(({token, label, options}) => (
+                      <div key={token}>
+                        <XDSText
+                          type="label"
+                          color="secondary"
+                          style={{marginBottom: 4, display: 'block'}}>
+                          {label}
+                        </XDSText>
+                        <XDSSelector
+                          label={label}
+                          isLabelHidden
+                          options={options}
+                          value={tokens[token] || options[0].value}
+                          onChange={(val: string) =>
+                            handleTokenChange(token, val)
+                          }
+                        />
+                      </div>
+                    ))}
+                  </XDSVStack>
+                </div>
+
+                {/* Unified Presets */}
+                <div>
+                  <XDSText
+                    type="label"
+                    color="secondary"
+                    style={{marginBottom: 8, display: 'block'}}>
+                    Master Preset
+                  </XDSText>
+                  <div
+                    style={{display: 'flex', flexDirection: 'column', gap: 8}}>
+                    {Object.entries(UNIFIED_PRESETS).map(([key, p]) => {
+                      const isSelected = activePreset === key;
+                      const ratioLabel =
+                        RATIO_OPTIONS.find(
+                          o => Math.abs(o.value - p.typeRatio) < 0.001,
+                        )?.label.split(' — ')[1] || p.typeRatio.toFixed(3);
+                      return (
+                        <div
+                          key={key}
+                          onClick={() => applyUnifiedPreset(key)}
+                          style={{
+                            padding: 12,
+                            borderRadius: 10,
+                            border: isSelected
+                              ? '2px solid var(--color-accent)'
+                              : '1px solid var(--color-border-emphasized)',
+                            backgroundColor: isSelected
+                              ? 'var(--color-accent-muted)'
+                              : 'transparent',
+                            cursor: 'pointer',
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'space-between',
+                            gap: 12,
+                            transition:
+                              'border-color 0.15s ease, background-color 0.15s ease',
+                          }}>
+                          <XDSText type="label" weight="semibold">
+                            {key.charAt(0).toUpperCase() + key.slice(1)}
+                          </XDSText>
+                          <XDSText
+                            type="supporting"
+                            color="secondary"
+                            style={{textAlign: 'end'}}>
+                            Type {p.typeBase}px · {ratioLabel} · Grid{' '}
+                            {p.spacing}px · Radius {p.radius}px · Size{' '}
+                            {p.sizeMd}px
+                          </XDSText>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+
+                {/* Spacing */}
+                <XDSVStack gap={3}>
+                  <XDSHStack gap={1} vAlign="center">
+                    <XDSText type="label" color="secondary">
+                      Spacing
+                    </XDSText>
+                    <XDSTooltip
+                      content={`Linear scale: step N = ${spacingBase}px × N. All spacing tokens are multiples of the base unit.`}>
+                      <XDSIcon icon="info" size="sm" color="secondary" />
+                    </XDSTooltip>
+                  </XDSHStack>
+                  <div style={{paddingBottom: 24, overflow: 'visible'}}>
+                    <XDSSlider
+                      label="Base Unit"
+                      isLabelHidden
+                      min={0}
+                      max={16}
+                      step={2}
+                      value={spacingBase}
+                      onChange={(v: number) => applySpacingScale(v)}
+                      formatValue={(v: number) => `${v}px`}
+                      valueDisplay="text"
+                      marks={[
+                        {value: 2, label: 'S'},
+                        {value: 4, label: 'M'},
+                        {value: 6, label: 'L'},
+                        {value: 8, label: 'XL'},
+                      ]}
+                    />
+                  </div>
+                </XDSVStack>
+
+                {/* Radius */}
+                <XDSVStack gap={3}>
+                  <XDSHStack gap={1} vAlign="center">
+                    <XDSText type="label" color="secondary">
+                      Corner Radius
+                    </XDSText>
+                    <XDSTooltip
+                      content={`Linear scale: inner = ${radiusBase}px (1×), element = ${radiusBase * 2}px (2×), container = ${radiusBase * 3}px (3×), page = ${Math.round(radiusBase * 7)}px (7×).`}>
+                      <XDSIcon icon="info" size="sm" color="secondary" />
+                    </XDSTooltip>
+                  </XDSHStack>
+                  <div style={{paddingBottom: 24, overflow: 'visible'}}>
+                    <XDSSlider
+                      label="Base Radius"
+                      isLabelHidden
+                      min={0}
+                      max={18}
+                      step={2}
+                      value={radiusBase}
+                      onChange={(v: number) => applyRadiusScale(v)}
+                      formatValue={(v: number) => `${v}px`}
+                      valueDisplay="text"
+                      marks={[
+                        {value: 2, label: 'S'},
+                        {value: 4, label: 'M'},
+                        {value: 8, label: 'L'},
+                        {value: 12, label: 'XL'},
+                      ]}
+                    />
+                  </div>
+                </XDSVStack>
+
+                {/* Size */}
+                <XDSVStack gap={3}>
+                  <XDSHStack gap={1} vAlign="center">
+                    <XDSText type="label" color="secondary">
+                      Element Size
+                    </XDSText>
+                    <XDSTooltip
+                      content={`Step scale: sm = ${sizeBase - 4}px (md − grid), md = ${sizeBase}px (base), lg = ${sizeBase + 4}px (md + grid).`}>
+                      <XDSIcon icon="info" size="sm" color="secondary" />
+                    </XDSTooltip>
+                  </XDSHStack>
+                  <div style={{paddingBottom: 24, overflow: 'visible'}}>
+                    <XDSSlider
+                      label="Base Size (md)"
+                      isLabelHidden
+                      min={24}
+                      max={56}
+                      step={2}
+                      value={sizeBase}
+                      onChange={(v: number) => applySizeScale(v)}
+                      formatValue={(v: number) => `${v}px`}
+                      valueDisplay="text"
+                      marks={[
+                        {value: 28, label: 'S'},
+                        {value: 32, label: 'M'},
+                        {value: 44, label: 'L'},
+                        {value: 48, label: 'XL'},
+                      ]}
+                    />
+                  </div>
+                </XDSVStack>
+
+                {/* Type Scale */}
+                <XDSVStack gap={3}>
+                  <XDSHStack gap={1} vAlign="center">
+                    <XDSText type="label" color="secondary">
+                      Type Size
+                    </XDSText>
+                    <XDSTooltip
+                      content={`Geometric scale: size = round(base × ratio^step). Base = ${typeScaleBase}px, ratio = ${typeScaleRatio.toFixed(3)}. h4 is the anchor (step 0).`}>
+                      <XDSIcon icon="info" size="sm" color="secondary" />
+                    </XDSTooltip>
+                  </XDSHStack>
+                  <div style={{paddingBottom: 24, overflow: 'visible'}}>
+                    <XDSSlider
+                      label="Base Size"
+                      isLabelHidden
+                      min={10}
+                      max={24}
+                      step={1}
+                      value={typeScaleBase}
+                      onChange={(v: number) =>
+                        applyTypeScale(v, typeScaleRatio)
+                      }
+                      formatValue={(v: number) => `${v}px`}
+                      valueDisplay="text"
+                      marks={[
+                        {value: 12, label: 'S'},
+                        {value: 14, label: 'M'},
+                        {value: 16, label: 'L'},
+                        {value: 18, label: 'XL'},
+                      ]}
+                    />
+                  </div>
+                  <div
+                    style={{display: 'flex', flexDirection: 'column', gap: 4}}>
+                    <XDSText type="label" color="secondary">
+                      Type Scale
+                    </XDSText>
+                    <XDSSelector
+                      label="Type Scale"
+                      isLabelHidden
+                      options={[
+                        ...RATIO_OPTIONS.map(opt => ({
+                          value: String(opt.value),
+                          label: opt.label,
+                        })),
+                        {
+                          value: 'custom',
+                          label: !RATIO_OPTIONS.some(
+                            o => Math.abs(o.value - typeScaleRatio) < 0.001,
+                          )
+                            ? `Custom — ${typeScaleRatio.toFixed(3)}`
+                            : 'Custom...',
+                        },
+                      ]}
+                      value={
+                        !RATIO_OPTIONS.some(
+                          o => Math.abs(o.value - typeScaleRatio) < 0.001,
+                        )
+                          ? 'custom'
+                          : String(typeScaleRatio)
+                      }
+                      onChange={(v: string) => {
+                        if (v !== 'custom')
+                          applyTypeScale(typeScaleBase, Number(v));
+                      }}
+                    />
+                  </div>
+                </XDSVStack>
+
+                {/* Duration */}
+                <XDSVStack gap={3}>
+                  <XDSHStack gap={1} vAlign="center">
+                    <XDSText type="label" color="secondary">
+                      Duration
+                    </XDSText>
+                    <XDSTooltip
+                      content={`Speed multiplier for all motion. Current: ${durationStep}× (e.g. medium = ${Math.round(410 / durationStep)}ms).`}>
+                      <XDSIcon icon="info" size="sm" color="secondary" />
+                    </XDSTooltip>
+                  </XDSHStack>
+                  <div style={{paddingBottom: 24, overflow: 'visible'}}>
+                    <XDSSlider
+                      label="Duration Scale"
+                      isLabelHidden
+                      min={0.5}
+                      max={2}
+                      step={0.1}
+                      value={durationStep}
+                      onChange={(v: number) =>
+                        applyDurationScale(Math.round(v * 10) / 10)
+                      }
+                      formatValue={(v: number) => `${v.toFixed(1)}×`}
+                      valueDisplay="text"
+                      marks={[
+                        {value: 0.5, label: '0.5×'},
+                        {value: 1, label: '1×'},
+                        {value: 1.5, label: '1.5×'},
+                        {value: 2, label: '2×'},
+                      ]}
+                    />
+                  </div>
+                </XDSVStack>
+
+                {/* AI Theme Extraction */}
+                <div>
+                  <XDSText
+                    type="label"
+                    color="secondary"
+                    style={{marginBottom: 8, display: 'block'}}>
+                    Extract from Screenshot
+                  </XDSText>
+                  <div
+                    onClick={() => {
+                      if (!aiAnalyzing) {
+                        const input = document.createElement('input');
+                        input.type = 'file';
+                        input.accept = 'image/png,image/jpeg,image/webp';
+                        input.onchange = () => {
+                          const file = input.files?.[0];
+                          if (file) handleImageUpload(file);
+                        };
+                        input.click();
+                      }
+                    }}
+                    onDragOver={e => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                    }}
+                    onDrop={e => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      if (aiAnalyzing) return;
+                      const file = e.dataTransfer.files[0];
+                      if (file && file.type.startsWith('image/'))
+                        handleImageUpload(file);
+                    }}
+                    style={{
+                      border: '2px dashed var(--color-border-emphasized)',
+                      borderRadius: 10,
+                      padding: aiImagePreview ? 0 : 20,
+                      textAlign: 'center',
+                      cursor: aiAnalyzing ? 'wait' : 'pointer',
+                      transition:
+                        'border-color 0.15s ease, background-color 0.15s ease',
+                      backgroundColor: 'var(--color-background-surface)',
+                      position: 'relative',
+                      overflow: 'hidden',
+                    }}>
+                    {aiAnalyzing ? (
+                      <XDSVStack
+                        gap={2}
+                        hAlign="center"
+                        style={{padding: aiImagePreview ? 20 : 0}}>
+                        {aiImagePreview && (
+                          <img
+                            src={aiImagePreview}
+                            alt="Uploaded screenshot"
+                            style={{
+                              position: 'absolute',
+                              inset: 0,
+                              width: '100%',
+                              height: '100%',
+                              objectFit: 'cover',
+                              opacity: 0.15,
+                            }}
+                          />
+                        )}
+                        <div style={{position: 'relative'}}>
+                          <XDSSpinner size="md" />
+                        </div>
+                        <XDSText
+                          type="supporting"
+                          color="secondary"
+                          style={{position: 'relative'}}>
+                          Analyzing with Gemini...
+                        </XDSText>
+                      </XDSVStack>
+                    ) : aiImagePreview ? (
+                      <div style={{position: 'relative'}}>
+                        <img
+                          src={aiImagePreview}
+                          alt="Uploaded screenshot"
+                          style={{
+                            width: '100%',
+                            height: 120,
+                            objectFit: 'cover',
+                            display: 'block',
+                            borderRadius: 8,
+                          }}
+                        />
+                        <div
+                          style={{
+                            position: 'absolute',
+                            inset: 0,
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            background: 'rgba(0,0,0,0.4)',
+                            borderRadius: 8,
+                            opacity: 0,
+                            transition: 'opacity 0.15s ease',
+                          }}
+                          onMouseEnter={e => {
+                            (e.currentTarget as HTMLElement).style.opacity =
+                              '1';
+                          }}
+                          onMouseLeave={e => {
+                            (e.currentTarget as HTMLElement).style.opacity =
+                              '0';
+                          }}>
+                          <XDSText type="supporting" style={{color: '#fff'}}>
+                            Click to replace
+                          </XDSText>
+                        </div>
+                      </div>
+                    ) : (
+                      <XDSVStack gap={2} hAlign="center">
+                        <PhotoIcon
+                          style={{
+                            width: 32,
+                            height: 32,
+                            color: 'var(--color-icon-secondary)',
+                          }}
+                        />
+                        <XDSText type="supporting" color="secondary">
+                          Upload a UI screenshot or brand guideline
+                        </XDSText>
+                      </XDSVStack>
+                    )}
+                  </div>
+                  {aiError && (
+                    <XDSBanner
+                      status="negative"
+                      description={aiError}
+                      action={
+                        aiImagePreview
+                          ? {
+                              label: 'Retry',
+                              onClick: () => {
+                                fetch(aiImagePreview)
+                                  .then(r => r.blob())
+                                  .then(blob =>
+                                    handleImageUpload(
+                                      new File([blob], 'retry.png', {
+                                        type: blob.type,
+                                      }),
+                                    ),
+                                  );
+                              },
+                            }
+                          : undefined
+                      }
+                      onDismiss={() => setAiError(null)}
+                      style={{marginTop: 8}}
+                    />
+                  )}
+                </div>
+              </XDSVStack>
+            ) : panelMode === 'target' ? (
+              <XDSVStack gap={4}>
+                <XDSSelector
+                  label="Target component"
+                  isLabelHidden
+                  size="lg"
+                  options={Object.entries(COMPONENT_VARS).map(
+                    ([key, comp]) => ({
+                      value: key,
+                      label: comp.label,
+                      icon: CubeIcon,
+                    }),
+                  )}
+                  value={targetComponent || ''}
+                  onChange={(v: string) => {
+                    setTargetComponent(v);
+                    setFlashComponent(v);
+                  }}
+                />
+
+                {targetComponent && COMPONENT_VARS[targetComponent] && (
+                  <XDSVStack gap={1}>
+                    {COMPONENT_VARS[targetComponent].vars.map(v => {
+                      const currentValue = tokens[v.name] || '';
+                      const isCustom = customVars.has(v.name);
+                      const isPresetValue =
+                        !isCustom &&
+                        (!currentValue ||
+                          v.options.some(o => o.value === currentValue));
+
+                      return (
+                        <div
+                          key={v.name}
+                          style={{
+                            padding: '10px 12px',
+                            borderRadius: 8,
+                            backgroundColor: 'var(--color-background-body)',
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'space-between',
+                            gap: 12,
+                          }}>
+                          <div style={{flex: 1, minWidth: 0}}>
+                            <XDSText
+                              type="supporting"
+                              color="primary"
+                              maxLines={1}>
+                              {v.name}
+                            </XDSText>
+                            <XDSText
+                              type="supporting"
+                              color="secondary"
+                              maxLines={1}>
+                              {v.description}
+                            </XDSText>
+                          </div>
+                          <div style={{flexShrink: 0, width: 140}}>
+                            {!isPresetValue ? (
+                              <XDSTextInput
+                                label={v.name}
+                                isLabelHidden
+                                size="sm"
+                                value={currentValue}
+                                placeholder={v.default}
+                                onChange={(val: string) => {
+                                  if (val.trim() === '') {
+                                    setTokens(prev => {
+                                      const next = {...prev};
+                                      delete next[v.name];
+                                      return next;
+                                    });
+                                    setCustomVars(prev => {
+                                      const next = new Set(prev);
+                                      next.delete(v.name);
+                                      return next;
+                                    });
+                                  } else {
+                                    handleTokenChange(v.name, val);
+                                  }
+                                }}
+                              />
+                            ) : (
+                              <XDSSelector
+                                label={v.name}
+                                isLabelHidden
+                                size="sm"
+                                options={[
+                                  ...v.options,
+                                  {value: '__custom__', label: 'Custom...'},
+                                ]}
+                                value={currentValue || v.default}
+                                onChange={(val: string) => {
+                                  if (val === '__custom__') {
+                                    setCustomVars(prev =>
+                                      new Set(prev).add(v.name),
+                                    );
+                                  } else {
+                                    handleTokenChange(v.name, val);
+                                  }
+                                }}
+                              />
+                            )}
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </XDSVStack>
+                )}
+              </XDSVStack>
+            ) : (
+              renderTokenEditor()
+            )}
+          </div>
+
+          {/* Action bar */}
+          <div
+            style={{
+              padding: '16px',
+              borderTop: '1px solid var(--color-border)',
+              display: 'flex',
+              gap: '8px',
+            }}>
+            <XDSButton
+              label="Reset All"
+              variant="ghost"
+              onClick={handleReset}
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Resize Handle */}
+      <div
+        onMouseDown={handleEditorResizeStart}
+        data-resizing={isEditorResizing}
+        className="xds-editor-resize-grip"
+        style={{
+          width: 16,
+          flexShrink: 0,
+          cursor: 'col-resize',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          zIndex: 10,
+          backgroundColor: 'transparent',
+        }}>
+        <div
+          className="xds-editor-resize-handle"
+          style={{
+            width: 3,
+            height: 32,
+            borderRadius: 2,
+            backgroundColor: isEditorResizing
+              ? 'var(--color-icon-primary, #111)'
+              : 'var(--color-border-strong, #ccc)',
+          }}
+        />
+      </div>
+
+      {/* Right Panel — Preview */}
+      <div
+        style={{
+          flex: 1,
+          display: 'flex',
+          flexDirection: 'column' as const,
+          minWidth: 0,
+          overflow: 'hidden',
+          marginLeft: -16,
+          paddingLeft: 16,
+        }}>
+        {/* Preview toolbar */}
+        <div
+          style={{
+            padding: '16px',
+            backgroundColor: 'var(--color-background-surface)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+          }}>
+          <div style={{display: 'flex', alignItems: 'center', gap: 12}}>
+            <XDSDropdownMenu
+              button={{
+                label: activePreview.startsWith('template:')
+                  ? (templates.find(t => t.slug === activePreview.slice(9))
+                      ?.name ?? 'Template')
+                  : ((
+                      {
+                        preview: 'Component Preview',
+                        landing: 'Landing Page',
+                        dashboard: 'Dashboard',
+                        tokens: 'Token Preview',
+                        table: 'Table Page',
+                      } as Record<string, string>
+                    )[activePreview] ?? activePreview),
+                variant: 'ghost',
+                size: 'md',
+              }}
+              items={[
+                {
+                  label: 'Token Preview',
+                  onClick: () => setActivePreview('tokens'),
+                },
+                {
+                  label: 'Component Preview',
+                  onClick: () => setActivePreview('preview'),
+                },
+                {
+                  label: 'Landing Page',
+                  onClick: () => setActivePreview('landing'),
+                },
+                {
+                  label: 'Dashboard',
+                  onClick: () => setActivePreview('dashboard'),
+                },
+                {label: 'Table Page', onClick: () => setActivePreview('table')},
+                {type: 'divider' as const},
+                ...templates
+                  .filter(t => t.isReady)
+                  .map(t => ({
+                    label: t.name,
+                    onClick: () => setActivePreview(`template:${t.slug}`),
+                  })),
+              ]}
+            />
+          </div>
+          <XDSSegmentedControl
+            label="Color mode"
+            value={mode}
+            onChange={v => setMode(v as 'light' | 'dark')}
+            size="sm">
+            <XDSSegmentedControlItem
+              value="light"
+              label="Light"
+              icon={<ContrastIcon />}
+              isLabelHidden
+            />
+            <XDSSegmentedControlItem
+              value="dark"
+              label="Dark"
+              icon={<MoonIcon />}
+              isLabelHidden
+            />
+          </XDSSegmentedControl>
+          <XDSButton
+            label={showCode ? 'Hide Code' : 'Export Theme'}
+            variant="secondary"
+            size="sm"
+            onClick={() => setShowCode(!showCode)}
+          />
+        </div>
+
+        {/* Code panel (collapsible) */}
+        {showCode && (
+          <div
+            style={{
+              borderBottom: '1px solid var(--color-border)',
+              backgroundColor: 'var(--color-background-body)',
+              maxHeight: '300px',
+              overflow: 'auto',
+            }}>
+            <XDSCodeBlock
+              code={generateThemeCode(
+                themeName,
+                tokens,
+                allDefaults,
+                typeScaleBase,
+                typeScaleRatio,
+              )}
+              language="typescript"
+              size="sm"
+            />
+          </div>
+        )}
+
+        {/* Preview content wrapped in theme */}
+        <div
+          style={{
+            flex: 1,
+            display: 'flex',
+            flexDirection: 'column',
+            minHeight: 0,
+          }}>
+          <XDSTheme theme={currentTheme} mode={mode}>
+            <div
+              ref={previewRef}
+              style={{
+                flex: 1,
+                overflow: 'auto',
+                position: 'relative',
+                padding: 24,
+                backgroundColor: 'var(--color-background-surface)',
+                borderRadius: 'var(--radius-container)',
+              }}>
+              <PreviewContent
+                activePreview={activePreview}
+                tokens={tokens}
+                theme={currentTheme}
+                mode={mode}
+              />
+
+              {/* Overlay panel */}
+              <div
+                style={{
+                  position: 'absolute',
+                  top: 0,
+                  right: 0,
+                  bottom: 0,
+                  width: '40%',
+                  maxWidth: 480,
+                  borderLeft: '1px solid var(--color-border)',
+                  backgroundColor: mode === 'dark' ? '#1F1F22' : '#FFFFFF',
+                  transform: overlayPanelOpen
+                    ? 'translateX(0)'
+                    : 'translateX(100%)',
+                  opacity: overlayPanelOpen ? 1 : 0,
+                  transition:
+                    'transform var(--duration-medium) var(--ease-standard), opacity var(--duration-medium) var(--ease-standard)',
+                  display: 'flex',
+                  flexDirection: 'column',
+                  zIndex: 10,
+                  boxShadow: overlayPanelOpen ? 'var(--shadow-high)' : 'none',
+                }}>
+                <div
+                  style={{
+                    padding: 'var(--spacing-2) var(--spacing-3)',
+                    borderBottom: '1px solid var(--color-border)',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                  }}>
+                  <XDSText type="label">Overlay Panel</XDSText>
+                  <XDSButton
+                    label="Close"
+                    icon={<XMarkIcon style={{width: 16, height: 16}} />}
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setOverlayPanelOpen(false)}
+                    isIconOnly
+                  />
+                </div>
+                <div style={{padding: 'var(--spacing-3)'}}>
+                  <XDSText type="supporting" color="secondary">
+                    Slides over content without resizing it.
+                  </XDSText>
+                </div>
+              </div>
+
+              {/* Push panel */}
+              <div
+                style={{
+                  flexShrink: 0,
+                  width: pushPanelOpen ? '40%' : '0px',
+                  maxWidth: pushPanelOpen ? 480 : 0,
+                  overflow: 'hidden',
+                  borderLeft: pushPanelOpen
+                    ? '1px solid var(--color-border)'
+                    : 'none',
+                  backgroundColor: mode === 'dark' ? '#1F1F22' : '#FFFFFF',
+                  opacity: pushPanelOpen ? 1 : 0,
+                  transition:
+                    'width var(--duration-medium) var(--ease-standard), max-width var(--duration-medium) var(--ease-standard), opacity var(--duration-medium) var(--ease-standard)',
+                  display: 'flex',
+                  flexDirection: 'column',
+                }}>
+                <div
+                  style={{
+                    padding: 'var(--spacing-2) var(--spacing-3)',
+                    borderBottom: '1px solid var(--color-border)',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                    whiteSpace: 'nowrap',
+                  }}>
+                  <XDSText type="label">Push Panel</XDSText>
+                  <XDSButton
+                    label="Close"
+                    icon={<XMarkIcon style={{width: 16, height: 16}} />}
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setPushPanelOpen(false)}
+                    isIconOnly
+                  />
+                </div>
+                <div
+                  style={{padding: 'var(--spacing-3)', whiteSpace: 'nowrap'}}>
+                  <XDSText type="supporting" color="secondary">
+                    Pushes content to make room.
+                  </XDSText>
+                </div>
+              </div>
+            </div>
+          </XDSTheme>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
@@ -15,6 +15,7 @@ import {
   TEMPLATES,
   AVATAR_IMAGE,
   XDS_DESIGN_AVATAR,
+  THEME_PICKER_ENTRIES,
   FILTER_COLUMNS,
   PROFILE_CRAFT_ITEMS,
   basePath,
@@ -26,10 +27,10 @@ import type {PanelTab, PointedElement} from './ChatPanel';
 import {InlinePublishPanel} from './InlinePublishPanel';
 import {TemplatePreview} from './TemplatePreview';
 import {SharePopoverContent} from './SharePopover';
-import {TemplatePreviewModal} from './TemplatePreviewModal';
 import {AppTopNav} from './AppTopNav';
 import {DocsView} from './DocsView';
 import {ProfileView} from './ProfileView';
+import {ThemeEditorView} from './ThemeEditorView';
 import {XDSAppShell} from '@xds/core/AppShell';
 import {XDSAvatar} from '@xds/core/Avatar';
 import {XDSStack} from '@xds/core/Layout';
@@ -46,19 +47,62 @@ import {XDSList, XDSListItem} from '@xds/core/List';
 import {XDSPopover} from '@xds/core/Popover';
 import {XDSTextInput} from '@xds/core/TextInput';
 import {XDSToolbar} from '@xds/core/Toolbar';
-
+import {XDSTooltip} from '@xds/core/Tooltip';
 import {XDSDropdownMenu} from '@xds/core/DropdownMenu';
 import {
   ArrowLeftIcon,
+  BookmarkIcon,
+  BookmarkFilledIcon,
+  StarIcon,
+  StarFilledIcon,
   SearchIcon,
   PaletteIcon,
   ContrastIcon,
   MoonIcon,
   VerifiedIcon,
+  MetaLogo,
+  WhatsAppLogo,
+  ThreadsLogo,
+  FacebookLogo,
+  DefaultThemeIcon,
+  ForestThemeIcon,
+  SunsetThemeIcon,
   FilterIcon,
+  MidnightThemeIcon,
 } from './docsite-icons';
 
+const BRAND_LOGOS: Record<
+  string,
+  React.ComponentType<React.SVGProps<SVGSVGElement>>
+> = {
+  default: DefaultThemeIcon,
+  meta: MetaLogo,
+  whatsapp: WhatsAppLogo,
+  threads: ThreadsLogo,
+  facebook: FacebookLogo,
+  forest: ForestThemeIcon,
+  sunset: SunsetThemeIcon,
+  midnight: MidnightThemeIcon,
+};
+
+const tokenStyles = stylex.create({
+  outline: {
+    borderWidth: 1,
+    borderStyle: 'solid',
+    borderColor: 'var(--color-border-emphasized)',
+  },
+  pill: {
+    borderWidth: 1,
+    borderStyle: 'solid',
+    borderColor: 'var(--color-border-emphasized)',
+    borderRadius: 9999,
+  },
+});
+
 const popoverStyles = stylex.create({
+  themeBrowse: {
+    padding: 16,
+  },
   filterDropdown: {
     padding: 8,
   },
@@ -192,47 +236,17 @@ function DocsiteLandingTemplate() {
     const v = searchParams.get('view');
     const t = searchParams.get('template');
     const q = searchParams.get('q');
-    const page = searchParams.get('page');
-    const tab = searchParams.get('tab');
-    const craft = searchParams.get('craft');
-    const used = searchParams.get('used');
-    const settings = searchParams.get('settings');
-    const collection = searchParams.get('collection');
     const templateIdx = t !== null ? parseInt(t, 10) : null;
     return {
       view: v,
       templateIdx: isNaN(templateIdx as number) ? null : templateIdx,
       query: q,
-      page: page as 'craft' | 'explore' | 'docs' | 'profile' | null,
-      tab:
-        tab && ['Crafted', 'Used', 'Bookmarks'].includes(tab)
-          ? (tab as 'Crafted' | 'Used' | 'Bookmarks')
-          : null,
-      craft,
-      used,
-      settings: settings === '1',
-      collection,
     };
   }, [searchParams]);
 
   const [activeView, setActiveView] = useState(
-    (initialView.page ?? 'craft') as 'craft' | 'explore' | 'docs' | 'profile',
+    'craft' as 'craft' | 'explore' | 'docs' | 'profile' | 'theme',
   );
-  const [profileTab, setProfileTab] = useState<
-    'Crafted' | 'Used' | 'Bookmarks'
-  >(initialView.tab ?? 'Crafted');
-  const [profileCraftName, setProfileCraftName] = useState<string | null>(
-    initialView.craft,
-  );
-  const [profileUsedName, setProfileUsedName] = useState<string | null>(
-    initialView.used,
-  );
-  const [profileSettingsOpen, setProfileSettingsOpen] = useState(
-    initialView.settings,
-  );
-  const [profileCollectionName, setProfileCollectionName] = useState<
-    string | null
-  >(initialView.collection);
   const [craftTitle, setCraftTitle] = useState<string | null>(
     initialView.query,
   );
@@ -303,6 +317,7 @@ function DocsiteLandingTemplate() {
     initialView.view === 'editor' ? initialView.templateIdx : null,
   );
   const [previewGenerating, setPreviewGenerating] = useState(false);
+  const [previewTransitioning, setPreviewTransitioning] = useState(false);
   const [showPublishCard1, setShowPublishCard1] = useState(false);
   const [panelTab, setPanelTab] = useState<PanelTab>('configure');
   const [isPointing, setIsPointing] = useState(false);
@@ -314,7 +329,26 @@ function DocsiteLandingTemplate() {
 
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const [isHeaderCollapsed, setIsHeaderCollapsed] = useState(false);
+  const [card4SelectedOption, setCard4SelectedOption] = useState('default');
+  const [card4ThemeBrowse, setCard4ThemeBrowse] = useState(false);
   const [card4Bookmarked, setCard4Bookmarked] = useState(false);
+  const [card4ShowAddPopover, setCard4ShowAddPopover] = useState(false);
+  const card4ScrollRef = useRef<HTMLDivElement>(null);
+  const [card4ThemeSearch, setCard4ThemeSearch] = useState('');
+  const [card4PinnedThemes, setCard4PinnedThemes] = useState(
+    () =>
+      new Set(
+        THEME_PICKER_ENTRIES.filter(t => t.isPinnedByDefault).map(t => t.key),
+      ),
+  );
+  const toggleCard4Pin = useCallback((key: string) => {
+    setCard4PinnedThemes(prev => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }, []);
 
   const handleEditorResizeStart = useCallback(
     (e: React.MouseEvent) => {
@@ -349,64 +383,21 @@ function DocsiteLandingTemplate() {
 
   // Sync URL when view state changes
   useEffect(() => {
-    const params = new URLSearchParams();
-
+    let path = '/pages/docsite/';
     if (previewTarget !== null) {
-      params.set('view', 'preview');
-      params.set('template', String(previewTarget));
+      path += '?view=preview&template=' + previewTarget;
     } else if (useTarget !== null) {
-      params.set('view', 'editor');
-      params.set('template', String(useTarget));
+      path += '?view=editor&template=' + useTarget;
     } else if (craftTitle) {
-      params.set('q', craftTitle);
-    } else if (activeView !== 'craft') {
-      params.set('page', activeView);
-      if (activeView === 'profile') {
-        if (profileCraftName) {
-          params.set('tab', 'Crafted');
-          params.set('craft', profileCraftName);
-        } else if (profileUsedName) {
-          params.set('tab', 'Used');
-          params.set('used', profileUsedName);
-        } else if (profileCollectionName) {
-          params.set('tab', 'Bookmarks');
-          params.set('collection', profileCollectionName);
-        } else if (profileTab !== 'Crafted') {
-          params.set('tab', profileTab);
-        }
-        if (profileSettingsOpen) {
-          params.set('settings', '1');
-        }
-      }
+      path += '?q=' + encodeURIComponent(craftTitle);
     }
-
-    const qs = params.toString();
-    router.replace(
-      `${basePath}/pages/docsite/${qs ? '?' + qs : ''}`,
-      {scroll: false},
-    );
-  }, [
-    previewTarget,
-    useTarget,
-    craftTitle,
-    activeView,
-    profileTab,
-    profileCraftName,
-    profileUsedName,
-    profileSettingsOpen,
-    profileCollectionName,
-    router,
-  ]);
+    router.replace(path, {scroll: false});
+  }, [previewTarget, useTarget, craftTitle, router]);
 
   const prevViewRef = useRef(activeView);
-  const skipViewResetRef = useRef(false);
   useEffect(() => {
     if (prevViewRef.current === activeView) return;
     prevViewRef.current = activeView;
-    if (skipViewResetRef.current) {
-      skipViewResetRef.current = false;
-      return;
-    }
     setPreviewTarget(null);
     setUseTarget(null);
     setChatOpen(false);
@@ -457,23 +448,16 @@ function DocsiteLandingTemplate() {
   );
 
   const handleUse = useCallback((index: number) => {
-    viewBeforeEditorRef.current = activeView;
     setPreviewTarget(null);
     setUseTarget(index);
     setPanelTab('configure');
     setChatOpen(true);
-  }, [activeView]);
+  }, []);
 
-  const viewBeforeEditorRef = useRef<'craft' | 'explore' | 'docs' | 'profile'>('craft');
   const handleBackFromUse = useCallback(() => {
     setUseTarget(null);
     setChatOpen(false);
     setShowPublishCard1(false);
-    const returnTo = viewBeforeEditorRef.current;
-    if (returnTo !== 'craft') {
-      skipViewResetRef.current = true;
-      setActiveView(returnTo);
-    }
   }, []);
 
   const handlePreview = useCallback((index: number) => {
@@ -521,35 +505,38 @@ function DocsiteLandingTemplate() {
     setActiveFilters(new Set());
   }, []);
 
-  const handleProfileAction = useCallback((action: 'craft' | 'bookmarked' | 'used' | 'settings') => {
-    if (action === 'settings') {
-      setIsSettingsOpen(true);
-    } else if (action === 'craft') {
-      setPreviewTarget(null);
-      setCraftTitle('My Craft');
-      setIsCraftResults(true);
-      setIsProfileResults(true);
-      setCraftStatusFilter('all');
-      setCraftLoading(true);
-      if (craftLoadingTimer.current) clearTimeout(craftLoadingTimer.current);
-      craftLoadingTimer.current = setTimeout(() => {
-        setCraftLoading(false);
-        craftLoadingTimer.current = null;
-      }, 900);
-    } else {
-      const label = action === 'bookmarked' ? 'Bookmarked' : 'Used';
-      setPreviewTarget(null);
-      setCraftTitle(label);
-      setIsProfileResults(true);
-      setIsCraftResults(false);
-      setCraftLoading(true);
-      if (craftLoadingTimer.current) clearTimeout(craftLoadingTimer.current);
-      craftLoadingTimer.current = setTimeout(() => {
-        setCraftLoading(false);
-        craftLoadingTimer.current = null;
-      }, 900);
-    }
-  }, []);
+  const handleProfileAction = useCallback(
+    (action: 'craft' | 'bookmarked' | 'used' | 'settings') => {
+      if (action === 'settings') {
+        setIsSettingsOpen(true);
+      } else if (action === 'craft') {
+        setPreviewTarget(null);
+        setCraftTitle('My Craft');
+        setIsCraftResults(true);
+        setIsProfileResults(true);
+        setCraftStatusFilter('all');
+        setCraftLoading(true);
+        if (craftLoadingTimer.current) clearTimeout(craftLoadingTimer.current);
+        craftLoadingTimer.current = setTimeout(() => {
+          setCraftLoading(false);
+          craftLoadingTimer.current = null;
+        }, 900);
+      } else {
+        const label = action === 'bookmarked' ? 'Bookmarked' : 'Used';
+        setPreviewTarget(null);
+        setCraftTitle(label);
+        setIsProfileResults(true);
+        setIsCraftResults(false);
+        setCraftLoading(true);
+        if (craftLoadingTimer.current) clearTimeout(craftLoadingTimer.current);
+        craftLoadingTimer.current = setTimeout(() => {
+          setCraftLoading(false);
+          craftLoadingTimer.current = null;
+        }, 900);
+      }
+    },
+    [],
+  );
 
   const filteredTemplates = useMemo(() => {
     return TEMPLATES.map((t, i) => ({...t, originalIndex: i})).filter(t => {
@@ -559,23 +546,26 @@ function DocsiteLandingTemplate() {
     });
   }, [templateFilter]);
 
-  const craftStatusCounts = useMemo(() => ({
-    published: PROFILE_CRAFT_ITEMS.filter(i => i.status === 'Published').length,
-    draft: PROFILE_CRAFT_ITEMS.filter(i => i.status === 'Draft').length,
-    review: PROFILE_CRAFT_ITEMS.filter(i => i.status === 'In Review').length,
-  }), []);
+  const craftStatusCounts = useMemo(
+    () => ({
+      published: PROFILE_CRAFT_ITEMS.filter(i => i.status === 'Published')
+        .length,
+      draft: PROFILE_CRAFT_ITEMS.filter(i => i.status === 'Draft').length,
+      review: PROFILE_CRAFT_ITEMS.filter(i => i.status === 'In Review').length,
+    }),
+    [],
+  );
 
   const filteredCraftItems = useMemo(() => {
     if (craftStatusFilter === 'all') return PROFILE_CRAFT_ITEMS;
-    return PROFILE_CRAFT_ITEMS.filter(item => item.status === craftStatusFilter);
+    return PROFILE_CRAFT_ITEMS.filter(
+      item => item.status === craftStatusFilter,
+    );
   }, [craftStatusFilter]);
 
   // Editor flow — same layout for all cards
   if (useTarget !== null && activeView === 'craft') {
-    const isBlankCanvas = useTarget === -1;
-    const t = isBlankCanvas
-      ? {name: 'Untitled', src: '', size: 'medium' as const, author: '', isOfficial: false}
-      : TEMPLATES[useTarget % TEMPLATES.length];
+    const t = TEMPLATES[useTarget % TEMPLATES.length];
     return (
       <div
         style={{
@@ -742,28 +732,13 @@ function DocsiteLandingTemplate() {
 
   if (activeView === 'profile') {
     return (
-      <ProfileView
-        activeView={activeView}
-        setActiveView={setActiveView}
-        onStartCrafting={() => {
-          viewBeforeEditorRef.current = 'profile';
-          skipViewResetRef.current = true;
-          setActiveView('craft');
-          setUseTarget(-1);
-          setPanelTab('configure');
-          setChatOpen(true);
-        }}
-        profileTab={profileTab}
-        onTabChange={setProfileTab}
-        profileCraftName={profileCraftName}
-        onCraftPreviewChange={setProfileCraftName}
-        profileUsedName={profileUsedName}
-        onUsedPreviewChange={setProfileUsedName}
-        profileSettingsOpen={profileSettingsOpen}
-        onSettingsChange={setProfileSettingsOpen}
-        profileCollectionName={profileCollectionName}
-        onCollectionChange={setProfileCollectionName}
-      />
+      <ProfileView activeView={activeView} setActiveView={setActiveView} />
+    );
+  }
+
+  if (activeView === 'theme') {
+    return (
+      <ThemeEditorView activeView={activeView} setActiveView={setActiveView} />
     );
   }
 
@@ -900,15 +875,31 @@ function DocsiteLandingTemplate() {
                       'craftTitleSlideIn 400ms 100ms cubic-bezier(0.16, 1, 0.3, 1) both',
                   }}>
                   {[
-                    {value: 'all', label: `All (${PROFILE_CRAFT_ITEMS.length})`},
-                    {value: 'Published', label: `Published (${craftStatusCounts.published})`},
-                    {value: 'Draft', label: `Draft (${craftStatusCounts.draft})`},
-                    {value: 'In Review', label: `In Review (${craftStatusCounts.review})`},
+                    {
+                      value: 'all',
+                      label: `All (${PROFILE_CRAFT_ITEMS.length})`,
+                    },
+                    {
+                      value: 'Published',
+                      label: `Published (${craftStatusCounts.published})`,
+                    },
+                    {
+                      value: 'Draft',
+                      label: `Draft (${craftStatusCounts.draft})`,
+                    },
+                    {
+                      value: 'In Review',
+                      label: `In Review (${craftStatusCounts.review})`,
+                    },
                   ].map(tab => (
                     <XDSButton
                       key={tab.value}
                       label={tab.label}
-                      variant={craftStatusFilter === tab.value ? 'primary' : 'secondary'}
+                      variant={
+                        craftStatusFilter === tab.value
+                          ? 'primary'
+                          : 'secondary'
+                      }
                       size="sm"
                       onClick={() => setCraftStatusFilter(tab.value)}
                     />
@@ -1286,8 +1277,7 @@ function DocsiteLandingTemplate() {
                           background:
                             'linear-gradient(90deg, var(--color-background-muted, #f0f0f0) 0%, var(--color-background-surface, #fafafa) 50%, var(--color-background-muted, #f0f0f0) 100%)',
                           backgroundSize: '800px 100%',
-                          animation:
-                            'craftShimmer 1.6s ease-in-out infinite',
+                          animation: 'craftShimmer 1.6s ease-in-out infinite',
                           borderRadius: '16px 16px 0 0',
                         }}
                       />
@@ -1306,8 +1296,7 @@ function DocsiteLandingTemplate() {
                             background:
                               'linear-gradient(90deg, var(--color-background-muted, #f0f0f0) 0%, var(--color-background-surface, #fafafa) 50%, var(--color-background-muted, #f0f0f0) 100%)',
                             backgroundSize: '800px 100%',
-                            animation:
-                              'craftShimmer 1.6s ease-in-out infinite',
+                            animation: 'craftShimmer 1.6s ease-in-out infinite',
                           }}
                         />
                         <div
@@ -1318,8 +1307,7 @@ function DocsiteLandingTemplate() {
                             background:
                               'linear-gradient(90deg, var(--color-background-muted, #f0f0f0) 0%, var(--color-background-surface, #fafafa) 50%, var(--color-background-muted, #f0f0f0) 100%)',
                             backgroundSize: '800px 100%',
-                            animation:
-                              'craftShimmer 1.6s ease-in-out infinite',
+                            animation: 'craftShimmer 1.6s ease-in-out infinite',
                           }}
                         />
                       </div>
@@ -1351,7 +1339,8 @@ function DocsiteLandingTemplate() {
                         style={{
                           aspectRatio: '16 / 9',
                           overflow: 'hidden',
-                          backgroundColor: 'var(--color-background-muted, #f0f0f0)',
+                          backgroundColor:
+                            'var(--color-background-muted, #f0f0f0)',
                         }}>
                         <img
                           src={item.img}
@@ -1424,7 +1413,10 @@ function DocsiteLandingTemplate() {
                           </div>
                           <div style={{marginLeft: 'auto'}}>
                             <XDSText type="supporting" color="secondary">
-                              {new Date(item.lastUpdated).toLocaleDateString('en-US', {month: 'short', day: 'numeric'})}
+                              {new Date(item.lastUpdated).toLocaleDateString(
+                                'en-US',
+                                {month: 'short', day: 'numeric'},
+                              )}
                             </XDSText>
                           </div>
                         </div>
@@ -1432,7 +1424,12 @@ function DocsiteLandingTemplate() {
                     </XDSCard>
                   ))}
                   {filteredCraftItems.length === 0 && (
-                    <div style={{gridColumn: '1 / -1', padding: 32, textAlign: 'center' as const}}>
+                    <div
+                      style={{
+                        gridColumn: '1 / -1',
+                        padding: 32,
+                        textAlign: 'center' as const,
+                      }}>
                       <XDSText type="body" color="secondary">
                         No items match this filter.
                       </XDSText>
@@ -1440,59 +1437,59 @@ function DocsiteLandingTemplate() {
                   )}
                 </div>
               ) : (
-              <div
-                style={{
-                  maxWidth: 2000,
-                  margin: '0 auto',
-                  display: 'grid',
-                  gridTemplateColumns: isMobile
-                    ? '1fr'
-                    : isTablet
-                      ? 'repeat(2, 1fr)'
-                      : 'repeat(3, 1fr)',
-                  gap: 16,
-                }}>
-                {filteredTemplates.map((template, i) => (
-                  <div
-                    key={`${template.name}-${template.originalIndex}`}
-                    style={{
-                      ...(craftTitle
-                        ? {
-                            animation: `craftCardFadeIn 400ms ${i * 50}ms cubic-bezier(0.16, 1, 0.3, 1) both`,
-                          }
-                        : undefined),
-                      filter: previewImageFilter,
-                      transition: 'filter 300ms ease',
-                    }}>
-                    <TemplateCard
-                      src={template.src}
-                      name={template.name}
-                      isSelected={selected.has(template.originalIndex)}
-                      isGenerating={
-                        isGenerating &&
-                        generatingSource !== template.originalIndex
-                      }
-                      cardSize={template.size}
-                      onSelect={() =>
-                        setSelected(prev => {
-                          const next = new Set(prev);
-                          if (next.has(template.originalIndex)) {
-                            next.delete(template.originalIndex);
-                          } else {
-                            next.add(template.originalIndex);
-                          }
-                          return next;
-                        })
-                      }
-                      onMoreLikeThis={() =>
-                        handleMoreLikeThis(template.originalIndex)
-                      }
-                      onUse={() => handleUse(template.originalIndex)}
-                      onPreview={() => handlePreview(template.originalIndex)}
-                    />
-                  </div>
-                ))}
-              </div>
+                <div
+                  style={{
+                    maxWidth: 2000,
+                    margin: '0 auto',
+                    display: 'grid',
+                    gridTemplateColumns: isMobile
+                      ? '1fr'
+                      : isTablet
+                        ? 'repeat(2, 1fr)'
+                        : 'repeat(3, 1fr)',
+                    gap: 16,
+                  }}>
+                  {filteredTemplates.map((template, i) => (
+                    <div
+                      key={`${template.name}-${template.originalIndex}`}
+                      style={{
+                        ...(craftTitle
+                          ? {
+                              animation: `craftCardFadeIn 400ms ${i * 50}ms cubic-bezier(0.16, 1, 0.3, 1) both`,
+                            }
+                          : undefined),
+                        filter: previewImageFilter,
+                        transition: 'filter 300ms ease',
+                      }}>
+                      <TemplateCard
+                        src={template.src}
+                        name={template.name}
+                        isSelected={selected.has(template.originalIndex)}
+                        isGenerating={
+                          isGenerating &&
+                          generatingSource !== template.originalIndex
+                        }
+                        cardSize={template.size}
+                        onSelect={() =>
+                          setSelected(prev => {
+                            const next = new Set(prev);
+                            if (next.has(template.originalIndex)) {
+                              next.delete(template.originalIndex);
+                            } else {
+                              next.add(template.originalIndex);
+                            }
+                            return next;
+                          })
+                        }
+                        onMoreLikeThis={() =>
+                          handleMoreLikeThis(template.originalIndex)
+                        }
+                        onUse={() => handleUse(template.originalIndex)}
+                        onPreview={() => handlePreview(template.originalIndex)}
+                      />
+                    </div>
+                  ))}
+                </div>
               )}
             </div>
           </div>
@@ -1505,45 +1502,668 @@ function DocsiteLandingTemplate() {
       {previewTarget !== null &&
         (() => {
           const t = TEMPLATES[previewTarget % TEMPLATES.length];
+          const isMeta = previewTarget === 3 && card4SelectedOption === 'meta';
           const moreLikeThisImages = TEMPLATES.map((tmpl, i) => ({
-            img: tmpl.src,
+            src: tmpl.src,
             name: tmpl.name,
-            key: i,
+            description: `${tmpl.name} template`,
+            originalIndex: i,
           }))
-            .filter(item => item.key !== previewTarget)
+            .filter(item => item.originalIndex !== previewTarget)
             .slice(0, 4);
           return (
-            <TemplatePreviewModal
+            <XDSDialog
               isOpen={true}
-              onClose={() => setPreviewTarget(null)}
-              item={{
-                name: t.name,
-                img: t.src,
-                author: t.author,
+              onOpenChange={open => {
+                if (!open) setPreviewTarget(null);
               }}
-              onStartCrafting={() => {
-                viewBeforeEditorRef.current = activeView;
-                setUseTarget(previewTarget);
-                setPanelTab('configure');
-                setChatOpen(true);
-              }}
-              isBookmarked={card4Bookmarked}
-              onBookmarkToggle={() => setCard4Bookmarked(prev => !prev)}
-              moreLikeThis={moreLikeThisImages}
-              onMoreLikeThisClick={(mlItem) => setPreviewTarget(mlItem.key as number)}
-              exploreTags={[
-                'website', 'dashboard', 'admin panel', 'settings',
-                'form layout', 'data table', 'sidebar nav', 'landing page',
-                'e-commerce', 'documentation', 'profile page',
-              ]}
-              onExploreTagClick={handleTokenClick}
-              componentTags={[
-                'XDSAppShell', 'XDSTopNav', 'XDSVStack', 'XDSHStack',
-                'XDSHeading', 'XDSText', 'XDSButton', 'XDSCard',
-                'XDSBadge', 'XDSAvatar',
-              ]}
-              onComponentTagClick={handleTokenClick}
-            />
+              width="90vw"
+              maxHeight="90vh"
+              purpose="info"
+              style={
+                {
+                  padding: 0,
+                  overflow: 'visible',
+                  maxWidth: 1600,
+                  '--xds-dialog-padding': '0px',
+                } as React.CSSProperties
+              }>
+              <div
+                style={{position: 'absolute', top: 0, right: -40, zIndex: 1}}>
+                <XDSCard padding={0} style={{borderRadius: '50%'}}>
+                  <XDSButton
+                    label="Close"
+                    variant="ghost"
+                    size="sm"
+                    isIconOnly
+                    icon={<span style={{fontSize: 16, lineHeight: 1}}>✕</span>}
+                    onClick={() => setPreviewTarget(null)}
+                  />
+                </XDSCard>
+              </div>
+              <div ref={card4ScrollRef} style={{overflowY: 'auto'}}>
+                {/* Main content: image left + details right */}
+                <div style={{display: 'flex', minHeight: 0, padding: '0 32px'}}>
+                  {/* Left — Preview image + thumbnails */}
+                  <XDSStack
+                    direction="vertical"
+                    gap={3}
+                    style={{flex: 1, minWidth: 0, padding: '32px 32px 32px 0'}}>
+                    <div
+                      style={{
+                        flex: 1,
+                        aspectRatio: '16 / 10',
+                        backgroundColor:
+                          'var(--color-background-muted, #f9f9f9)',
+                        borderRadius: 12,
+                        overflowY: 'auto',
+                        overflowX: 'hidden',
+                        border: '1px solid var(--color-border, #e0e0e0)',
+                      }}>
+                      <img
+                        src={
+                          isMeta
+                            ? `${basePath}/templates/card4-preview-meta.png`
+                            : t.src
+                        }
+                        alt={t.name}
+                        style={{
+                          width: '100%',
+                          display: 'block',
+                          opacity: previewTransitioning ? 0 : 1,
+                          transition: 'opacity 250ms ease',
+                          animation: previewTransitioning
+                            ? 'none'
+                            : 'previewFadeIn 300ms ease',
+                        }}
+                      />
+                    </div>
+                  </XDSStack>
+
+                  {/* Right — Details panel */}
+                  <XDSStack
+                    direction="vertical"
+                    style={{width: 360, flexShrink: 0, padding: '32px 0'}}>
+                    <div
+                      style={{
+                        opacity: previewTransitioning ? 0 : 1,
+                        transition: 'opacity 250ms ease',
+                        animation: previewTransitioning
+                          ? 'none'
+                          : 'previewFadeIn 300ms ease',
+                      }}>
+                      {/* Title */}
+                      <XDSText type="display-2">{t.name}</XDSText>
+
+                      {/* Description */}
+                      <div style={{marginTop: 8}}>
+                        <XDSText type="body" color="secondary">
+                          A ready-to-use {t.name.toLowerCase()} template built
+                          with XDS components. Customize it with your own
+                          content and theme to match your brand.
+                        </XDSText>
+                      </div>
+
+                      {/* Author */}
+                      <XDSStack
+                        direction="horizontal"
+                        gap={3}
+                        vAlign="center"
+                        style={{marginTop: 16}}>
+                        <XDSAvatar
+                          name={t.author}
+                          size={36}
+                          src={
+                            t.author === 'XDS Design'
+                              ? XDS_DESIGN_AVATAR
+                              : AVATAR_IMAGE
+                          }
+                        />
+                        <XDSStack direction="vertical">
+                          <XDSText type="supporting" color="secondary">
+                            Crafted by
+                          </XDSText>
+                          <XDSText
+                            type="body"
+                            style={{fontWeight: 600, fontSize: 16}}>
+                            {t.author}
+                          </XDSText>
+                        </XDSStack>
+                      </XDSStack>
+                    </div>
+
+                    {/* CTA buttons */}
+                    <XDSStack
+                      direction="vertical"
+                      gap={2}
+                      style={{marginTop: 32, position: 'relative'}}>
+                      <XDSButton
+                        variant="primary"
+                        label="Start crafting"
+                        size="lg"
+                        style={{width: '100%'}}
+                        onClick={() => {
+                          setUseTarget(previewTarget);
+                          setPreviewTarget(null);
+                          setPanelTab('configure');
+                          setChatOpen(true);
+                        }}
+                      />
+                      <div
+                        style={{
+                          display: 'flex',
+                          gap: 8,
+                          width: '100%',
+                        }}>
+                        <XDSButton
+                          variant="secondary"
+                          label="Use in your product"
+                          size="lg"
+                          style={{flex: 1}}
+                          onClick={() =>
+                            setCard4ShowAddPopover(!card4ShowAddPopover)
+                          }
+                        />
+                        <XDSTooltip content="Bookmark">
+                          <XDSButton
+                            label={card4Bookmarked ? '893' : '892'}
+                            variant="secondary"
+                            size="lg"
+                            isIconOnly
+                            icon={
+                              card4Bookmarked ? (
+                                <BookmarkFilledIcon />
+                              ) : (
+                                <BookmarkIcon />
+                              )
+                            }
+                            onClick={() => setCard4Bookmarked(prev => !prev)}
+                          />
+                        </XDSTooltip>
+                      </div>
+                      {card4ShowAddPopover && (
+                        <XDSCard
+                          style={{
+                            position: 'absolute',
+                            top: '100%',
+                            left: 0,
+                            right: 0,
+                            marginTop: 8,
+                            zIndex: 10,
+                          }}>
+                          <SharePopoverContent
+                            cliCommand={`npx xds template ${t.name.toLowerCase().replace(/\s+/g, '-')} ./my-project`}
+                            onClose={() => setCard4ShowAddPopover(false)}
+                          />
+                        </XDSCard>
+                      )}
+                    </XDSStack>
+
+                    {/* Themes — pinned grid */}
+                    <div style={{marginTop: 24}}>
+                      <div
+                        style={{
+                          display: 'flex',
+                          alignItems: 'center',
+                          justifyContent: 'space-between',
+                        }}>
+                        <XDSText type="body" style={{fontWeight: 600}}>
+                          Apply your themes
+                        </XDSText>
+                        <XDSPopover
+                          label="Browse themes"
+                          placement="below"
+                          alignment="end"
+                          width={480}
+                          isOpen={card4ThemeBrowse}
+                          onOpenChange={open => {
+                            setCard4ThemeBrowse(open);
+                            if (!open) setCard4ThemeSearch('');
+                          }}
+                          xstyle={popoverStyles.themeBrowse}
+                          content={
+                            <div
+                              style={{
+                                display: 'flex',
+                                flexDirection: 'column',
+                                gap: 16,
+                              }}>
+                              <div
+                                tabIndex={0}
+                                style={{
+                                  position: 'absolute',
+                                  opacity: 0,
+                                  width: 0,
+                                  height: 0,
+                                  overflow: 'hidden',
+                                }}
+                              />
+                              <XDSTextInput
+                                label="Search"
+                                isLabelHidden
+                                placeholder="Search themes..."
+                                value={card4ThemeSearch}
+                                onChange={setCard4ThemeSearch}
+                                size="lg"
+                                startIcon={SearchIcon}
+                              />
+                              <div
+                                style={{
+                                  maxHeight: 560,
+                                  overflowY: 'auto',
+                                  display: 'flex',
+                                  flexDirection: 'column',
+                                  gap: 16,
+                                }}>
+                                {(['official', 'community'] as const).map(
+                                  category => {
+                                    const entries = THEME_PICKER_ENTRIES.filter(
+                                      e =>
+                                        e.category === category &&
+                                        e.name
+                                          .toLowerCase()
+                                          .includes(
+                                            card4ThemeSearch.toLowerCase(),
+                                          ),
+                                    );
+                                    if (entries.length === 0) return null;
+                                    return (
+                                      <div key={category}>
+                                        <div style={{marginBottom: 8}}>
+                                          <XDSText
+                                            type="supporting"
+                                            color="secondary">
+                                            {category.charAt(0).toUpperCase() +
+                                              category.slice(1)}
+                                          </XDSText>
+                                        </div>
+                                        <div
+                                          style={{
+                                            display: 'grid',
+                                            gridTemplateColumns: '1fr 1fr 1fr',
+                                            gap: 8,
+                                          }}>
+                                          {entries.map(entry => {
+                                            const isSelected =
+                                              card4SelectedOption === entry.key;
+                                            const isPinned =
+                                              card4PinnedThemes.has(entry.key);
+                                            const p = entry.preview;
+                                            return (
+                                              <div
+                                                key={entry.key}
+                                                style={{
+                                                  borderRadius: 12,
+                                                  overflow: 'hidden',
+                                                  cursor: 'pointer',
+                                                  border: isSelected
+                                                    ? '1.5px solid var(--color-accent)'
+                                                    : '1px solid var(--color-border-emphasized)',
+                                                  transition:
+                                                    'border-color 0.15s ease',
+                                                }}>
+                                                <div
+                                                  onClick={() => {
+                                                    setCard4SelectedOption(
+                                                      entry.key,
+                                                    );
+                                                    setCard4ThemeBrowse(false);
+                                                    setCard4ThemeSearch('');
+                                                  }}
+                                                  style={{
+                                                    height: 100,
+                                                    backgroundColor: p.bg,
+                                                    display: 'flex',
+                                                    flexDirection: 'column',
+                                                    overflow: 'hidden',
+                                                  }}>
+                                                  <div
+                                                    style={{
+                                                      height: 14,
+                                                      backgroundColor:
+                                                        p.surface,
+                                                      borderBottom: `1px solid ${p.text}1A`,
+                                                      display: 'flex',
+                                                      alignItems: 'center',
+                                                      paddingInline: 8,
+                                                      gap: 4,
+                                                    }}>
+                                                    <div
+                                                      style={{
+                                                        width: 5,
+                                                        height: 5,
+                                                        borderRadius: '50%',
+                                                        backgroundColor:
+                                                          p.accent,
+                                                      }}
+                                                    />
+                                                    <div
+                                                      style={{
+                                                        width: 16,
+                                                        height: 2,
+                                                        borderRadius: 1,
+                                                        backgroundColor: p.text,
+                                                        opacity: 0.3,
+                                                      }}
+                                                    />
+                                                  </div>
+                                                  <div
+                                                    style={{
+                                                      flex: 1,
+                                                      padding: 8,
+                                                      display: 'flex',
+                                                      flexDirection: 'column',
+                                                      gap: 5,
+                                                    }}>
+                                                    <div
+                                                      style={{
+                                                        width: '65%',
+                                                        height: 4,
+                                                        borderRadius: 2,
+                                                        backgroundColor: p.text,
+                                                        opacity: 0.6,
+                                                      }}
+                                                    />
+                                                    <div
+                                                      style={{
+                                                        width: '45%',
+                                                        height: 3,
+                                                        borderRadius: 1.5,
+                                                        backgroundColor: p.text,
+                                                        opacity: 0.25,
+                                                      }}
+                                                    />
+                                                    <div
+                                                      style={{
+                                                        width: 28,
+                                                        height: 10,
+                                                        borderRadius: 4,
+                                                        backgroundColor:
+                                                          p.accent,
+                                                        marginTop: 'auto',
+                                                      }}
+                                                    />
+                                                  </div>
+                                                </div>
+                                                <div
+                                                  style={{
+                                                    display: 'flex',
+                                                    alignItems: 'center',
+                                                    justifyContent:
+                                                      'space-between',
+                                                    padding: '6px 8px',
+                                                    backgroundColor:
+                                                      'var(--color-surface, #f5f5f5)',
+                                                  }}>
+                                                  <div
+                                                    style={{
+                                                      display: 'flex',
+                                                      alignItems: 'center',
+                                                      gap: 6,
+                                                    }}>
+                                                    {(() => {
+                                                      const Logo =
+                                                        BRAND_LOGOS[entry.key];
+                                                      return Logo ? (
+                                                        <Logo
+                                                          width={14}
+                                                          height={14}
+                                                        />
+                                                      ) : (
+                                                        <div
+                                                          style={{
+                                                            width: 14,
+                                                            height: 14,
+                                                            borderRadius: '50%',
+                                                            backgroundColor:
+                                                              entry.accent,
+                                                          }}
+                                                        />
+                                                      );
+                                                    })()}
+                                                    <XDSText
+                                                      type="supporting"
+                                                      style={{
+                                                        fontWeight: isSelected
+                                                          ? 600
+                                                          : 400,
+                                                      }}>
+                                                      {entry.name}
+                                                    </XDSText>
+                                                  </div>
+                                                  <div
+                                                    onClick={e => {
+                                                      e.stopPropagation();
+                                                      toggleCard4Pin(entry.key);
+                                                    }}
+                                                    style={{
+                                                      cursor: 'pointer',
+                                                      display: 'flex',
+                                                      padding: 2,
+                                                    }}>
+                                                    {isPinned ? (
+                                                      <StarFilledIcon
+                                                        width={14}
+                                                        height={14}
+                                                        style={{
+                                                          color:
+                                                            'var(--color-text-primary, #111)',
+                                                        }}
+                                                      />
+                                                    ) : (
+                                                      <StarIcon
+                                                        width={14}
+                                                        height={14}
+                                                        style={{
+                                                          color:
+                                                            'var(--color-secondary, #999)',
+                                                        }}
+                                                      />
+                                                    )}
+                                                  </div>
+                                                </div>
+                                              </div>
+                                            );
+                                          })}
+                                        </div>
+                                      </div>
+                                    );
+                                  },
+                                )}
+                              </div>
+                            </div>
+                          }>
+                          <XDSButton label="Browse" variant="ghost" size="sm" />
+                        </XDSPopover>
+                      </div>
+                      <div
+                        style={{
+                          display: 'grid',
+                          gridTemplateColumns: 'repeat(auto-fill, 44px)',
+                          gap: 8,
+                          marginTop: 16,
+                        }}>
+                        {THEME_PICKER_ENTRIES.filter(e =>
+                          card4PinnedThemes.has(e.key),
+                        ).map(entry => {
+                          const isSelected = card4SelectedOption === entry.key;
+                          const BrandLogo = BRAND_LOGOS[entry.key];
+                          return (
+                            <XDSTooltip key={entry.key} content={entry.name}>
+                              <div
+                                onClick={() =>
+                                  setCard4SelectedOption(entry.key)
+                                }
+                                style={{
+                                  width: 44,
+                                  height: 44,
+                                  borderRadius: 10,
+                                  display: 'flex',
+                                  alignItems: 'center',
+                                  justifyContent: 'center',
+                                  cursor: 'pointer',
+                                  border: isSelected
+                                    ? '1.5px solid var(--color-accent)'
+                                    : '1px solid var(--color-border-emphasized)',
+                                  backgroundColor: '#fff',
+                                  transition: 'border-color 0.15s ease',
+                                }}>
+                                {BrandLogo ? (
+                                  <BrandLogo width={28} height={28} />
+                                ) : (
+                                  <div
+                                    style={{
+                                      width: 24,
+                                      height: 24,
+                                      borderRadius: '50%',
+                                      backgroundColor: entry.accent,
+                                    }}
+                                  />
+                                )}
+                              </div>
+                            </XDSTooltip>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  </XDSStack>
+                </div>
+
+                {/* More like this */}
+                <div style={{padding: '0 32px'}}>
+                  <XDSHeading level={3}>More like this</XDSHeading>
+                  <div
+                    style={{
+                      display: 'grid',
+                      gridTemplateColumns: 'repeat(4, 1fr)',
+                      gap: 12,
+                      marginTop: 16,
+                    }}>
+                    {moreLikeThisImages.map(img => (
+                      <XDSCard
+                        key={img.originalIndex}
+                        padding={0}
+                        onClick={() => {
+                          setPreviewTransitioning(true);
+                          setTimeout(() => {
+                            setPreviewTarget(img.originalIndex);
+                            card4ScrollRef.current?.scrollTo({top: 0});
+                            setTimeout(
+                              () => setPreviewTransitioning(false),
+                              50,
+                            );
+                          }, 250);
+                        }}
+                        style={{
+                          cursor: 'pointer',
+                          aspectRatio: '16/10',
+                          overflow: 'hidden',
+                        }}>
+                        <img
+                          src={img.src}
+                          alt={img.name}
+                          style={{
+                            width: '100%',
+                            height: '100%',
+                            objectFit: 'cover',
+                            objectPosition: 'top',
+                            display: 'block',
+                            opacity: previewTransitioning ? 0 : 1,
+                            transition: 'opacity 250ms ease',
+                            animation: previewTransitioning
+                              ? 'none'
+                              : 'previewFadeIn 300ms ease',
+                          }}
+                        />
+                      </XDSCard>
+                    ))}
+                  </div>
+                </div>
+
+                {/* Explore more */}
+                <div style={{padding: '32px 32px 0'}}>
+                  <XDSHeading level={3}>Explore more</XDSHeading>
+                  <div
+                    style={{
+                      display: 'flex',
+                      flexWrap: 'wrap',
+                      gap: 8,
+                      marginTop: 16,
+                      opacity: previewTransitioning ? 0 : 1,
+                      transition: 'opacity 250ms ease',
+                      animation: previewTransitioning
+                        ? 'none'
+                        : 'previewFadeIn 300ms ease',
+                    }}>
+                    {[
+                      'website',
+                      'dashboard',
+                      'admin panel',
+                      'settings',
+                      'form layout',
+                      'data table',
+                      'sidebar nav',
+                      'landing page',
+                      'e-commerce',
+                      'documentation',
+                      'profile page',
+                    ].map(tag => (
+                      <XDSToken
+                        key={tag}
+                        label={tag}
+                        xstyle={tokenStyles.pill}
+                        style={{
+                          backgroundColor: 'transparent',
+                          cursor: 'pointer',
+                        }}
+                        onClick={() => handleTokenClick(tag)}
+                      />
+                    ))}
+                  </div>
+                </div>
+
+                {/* Component used */}
+                <div style={{padding: '32px 32px 32px'}}>
+                  <XDSHeading level={3}>Component used</XDSHeading>
+                  <div
+                    style={{
+                      display: 'flex',
+                      flexWrap: 'wrap',
+                      gap: 8,
+                      marginTop: 16,
+                      opacity: previewTransitioning ? 0 : 1,
+                      transition: 'opacity 250ms ease',
+                      animation: previewTransitioning
+                        ? 'none'
+                        : 'previewFadeIn 300ms ease',
+                    }}>
+                    {[
+                      'XDSAppShell',
+                      'XDSTopNav',
+                      'XDSVStack',
+                      'XDSHStack',
+                      'XDSHeading',
+                      'XDSText',
+                      'XDSButton',
+                      'XDSCard',
+                      'XDSBadge',
+                      'XDSAvatar',
+                    ].map(c => (
+                      <XDSToken
+                        key={c}
+                        label={c}
+                        xstyle={tokenStyles.outline}
+                        style={{
+                          backgroundColor: 'transparent',
+                          cursor: 'pointer',
+                        }}
+                        onClick={() => handleTokenClick(c)}
+                      />
+                    ))}
+                  </div>
+                </div>
+              </div>
+            </XDSDialog>
           );
         })()}
 
@@ -1557,28 +2177,46 @@ function DocsiteLandingTemplate() {
         <XDSStack direction="vertical" gap={4} style={{padding: '8px 0'}}>
           <XDSStack direction="horizontal" hAlign="between" vAlign="center">
             <XDSStack direction="vertical" gap={1}>
-              <XDSText type="body" style={{fontWeight: 600}}>Dark mode</XDSText>
-              <XDSText type="supporting" color="secondary">Switch between light and dark appearance</XDSText>
+              <XDSText type="body" style={{fontWeight: 600}}>
+                Dark mode
+              </XDSText>
+              <XDSText type="supporting" color="secondary">
+                Switch between light and dark appearance
+              </XDSText>
             </XDSStack>
             <XDSButton
               label={previewMode === 'dark' ? 'On' : 'Off'}
               variant="secondary"
               size="sm"
-              onClick={() => setPreviewMode(previewMode === 'dark' ? 'light' : 'dark')}
+              onClick={() =>
+                setPreviewMode(previewMode === 'dark' ? 'light' : 'dark')
+              }
             />
           </XDSStack>
           <XDSDivider />
           <XDSStack direction="horizontal" hAlign="between" vAlign="center">
             <XDSStack direction="vertical" gap={1}>
-              <XDSText type="body" style={{fontWeight: 600}}>Theme</XDSText>
-              <XDSText type="supporting" color="secondary">Choose a visual theme for previews</XDSText>
+              <XDSText type="body" style={{fontWeight: 600}}>
+                Theme
+              </XDSText>
+              <XDSText type="supporting" color="secondary">
+                Choose a visual theme for previews
+              </XDSText>
             </XDSStack>
             <XDSDropdownMenu
-              button={{label: previewTheme.charAt(0).toUpperCase() + previewTheme.slice(1), variant: 'secondary', size: 'sm'}}
+              button={{
+                label:
+                  previewTheme.charAt(0).toUpperCase() + previewTheme.slice(1),
+                variant: 'secondary',
+                size: 'sm',
+              }}
               items={[
                 {label: 'Default', onClick: () => setPreviewTheme('default')},
                 {label: 'Neutral', onClick: () => setPreviewTheme('neutral')},
-                {label: 'Brutalist', onClick: () => setPreviewTheme('brutalist')},
+                {
+                  label: 'Brutalist',
+                  onClick: () => setPreviewTheme('brutalist'),
+                },
                 {label: 'Meta', onClick: () => setPreviewTheme('meta')},
                 {label: 'WhatsApp', onClick: () => setPreviewTheme('whatsapp')},
               ]}
@@ -1587,12 +2225,21 @@ function DocsiteLandingTemplate() {
           <XDSDivider />
           <XDSStack direction="horizontal" hAlign="between" vAlign="center">
             <XDSStack direction="vertical" gap={1}>
-              <XDSText type="body" style={{fontWeight: 600}}>Default sort</XDSText>
-              <XDSText type="supporting" color="secondary">How templates are ordered by default</XDSText>
+              <XDSText type="body" style={{fontWeight: 600}}>
+                Default sort
+              </XDSText>
+              <XDSText type="supporting" color="secondary">
+                How templates are ordered by default
+              </XDSText>
             </XDSStack>
             <XDSDropdownMenu
               button={{
-                label: sortOption === 'trending' ? 'Trending' : sortOption === 'newest' ? 'Newest first' : 'Oldest first',
+                label:
+                  sortOption === 'trending'
+                    ? 'Trending'
+                    : sortOption === 'newest'
+                      ? 'Newest first'
+                      : 'Oldest first',
                 variant: 'secondary',
                 size: 'sm',
               }}

--- a/apps/sandbox/src/app/api/analyze-theme/route.ts
+++ b/apps/sandbox/src/app/api/analyze-theme/route.ts
@@ -1,0 +1,225 @@
+/**
+ * @input  POST { image: string (base64, no data-URI prefix), mimeType: string }
+ * @output JSON ThemeExtraction — accent color, fonts, spacing, radius, type scale, size
+ * @position apps/sandbox API · Plugboard (devvm) or direct Gemini API (local)
+ *
+ * Two transport modes:
+ *  1. Plugboard mTLS — used on Meta devvm/devgpu (certs at /var/facebook/...)
+ *  2. Direct Gemini API — used locally when GEMINI_API_KEY env var is set
+ */
+import {NextRequest, NextResponse} from 'next/server';
+import {execSync} from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const CERT = '/var/facebook/x509_identities/server.pem';
+const CA = '/var/facebook/rootcanal/ca.pem';
+const MODEL = 'gemini-2.5-pro-preview';
+const PLUGBOARD_BASE = 'https://plugboard.x2p.facebook.net/v1beta/models';
+const PLUGBOARD_KEY = 'sk-plugboard-dummy-1234567890';
+const GEMINI_BASE = 'https://generativelanguage.googleapis.com/v1beta/models';
+
+export interface ThemeExtraction {
+  accentColor: string;
+  headingFont: string;
+  bodyFont: string;
+  spacingBase: number;
+  radiusBase: number;
+  typeScaleBase: number;
+  typeScaleRatio: number;
+  sizeBase: number;
+  density: 'compact' | 'default' | 'comfortable' | 'spacious';
+  notes: string;
+}
+
+const ANALYSIS_PROMPT = `You are a UI design system expert. Analyze this screenshot and extract theme parameters.
+
+Return a JSON object with these fields — pick values ONLY from the allowed options listed:
+
+1. "accentColor": The primary accent / brand color as a hex string (e.g. "#0066FF").
+   Look for the most prominent colored button, link, or interactive element. Ignore neutral grays.
+
+2. "headingFont": The closest match for heading text. Pick ONE of:
+   "System", "Inter", "Roboto", "DM Sans", "Figtree", "Poppins", "IBM Plex Sans", "Source Sans", "Noto Sans", "Georgia"
+
+3. "bodyFont": The closest match for body/paragraph text. Pick ONE of:
+   "System", "Inter", "Roboto", "DM Sans", "Figtree", "Poppins", "IBM Plex Sans", "Source Sans", "Noto Sans", "Georgia"
+
+4. "spacingBase": The base spacing grid in px. Pick ONE of: 2, 4, 6, 8
+   - 2 = very tight/compact UI
+   - 4 = standard density (most common)
+   - 6 = comfortable/relaxed
+   - 8 = very spacious
+
+5. "radiusBase": Corner radius base in px. Pick an even number from 0 to 18.
+   - 0 = fully sharp corners
+   - 2-4 = subtle rounding
+   - 6-8 = moderate rounding
+   - 10-12 = heavily rounded
+   - 14-18 = pill-like
+
+6. "typeScaleBase": The base body text size in px. Pick a whole number from 10 to 24.
+   Look at the main paragraph/body text size.
+
+7. "typeScaleRatio": The ratio between type scale steps. Pick ONE of:
+   1.067, 1.125, 1.2, 1.25, 1.333, 1.414, 1.5, 1.618
+   Compare heading sizes to body text to infer the multiplier.
+
+8. "sizeBase": The height of primary interactive elements (buttons, inputs) in px.
+   Pick an even number from 24 to 56.
+   - 28 = compact controls
+   - 32 = standard
+   - 36-44 = comfortable/large
+   - 48+ = very large touch targets
+
+9. "density": Overall UI density. Pick ONE of: "compact", "default", "comfortable", "spacious"
+
+10. "notes": A 1-2 sentence description of the UI's visual style.
+
+Respond with ONLY the JSON object. No explanation, no markdown fences.`;
+
+function parseGeminiResponse(responseBody: string): ThemeExtraction {
+  const resp = JSON.parse(responseBody);
+  if (resp.error) {
+    throw new Error(`Gemini API error: ${JSON.stringify(resp.error)}`);
+  }
+
+  let text = resp.candidates?.[0]?.content?.parts?.[0]?.text?.trim();
+  if (!text) {
+    throw new Error('No content in Gemini response');
+  }
+
+  text = text
+    .replace(/```json\s*/g, '')
+    .replace(/```\s*/g, '')
+    .trim();
+  return JSON.parse(text);
+}
+
+function buildPayload(image: string, mimeType: string) {
+  return {
+    contents: [
+      {
+        role: 'user',
+        parts: [{inlineData: {mimeType, data: image}}, {text: ANALYSIS_PROMPT}],
+      },
+    ],
+    generationConfig: {
+      temperature: 0.1,
+      maxOutputTokens: 4096,
+      responseMimeType: 'application/json',
+    },
+  };
+}
+
+async function callViaPlugboard(
+  image: string,
+  mimeType: string,
+): Promise<ThemeExtraction> {
+  const payload = buildPayload(image, mimeType);
+  const tmpFile = path.join(
+    os.tmpdir(),
+    `xds-theme-analyze-${Date.now()}.json`,
+  );
+  fs.writeFileSync(tmpFile, JSON.stringify(payload));
+
+  try {
+    const result = execSync(
+      [
+        'curl',
+        '-s',
+        '-w',
+        '\\n%{http_code}',
+        '--cert',
+        CERT,
+        '--cacert',
+        CA,
+        '--noproxy',
+        'x2p.facebook.net',
+        '-H',
+        'Content-Type: application/json',
+        '-H',
+        `x-goog-api-key: ${PLUGBOARD_KEY}`,
+        '-d',
+        `@${tmpFile}`,
+        `${PLUGBOARD_BASE}/${MODEL}:generateContent`,
+      ].join(' '),
+      {encoding: 'utf-8', timeout: 120_000},
+    );
+
+    const lines = result.trim().split('\n');
+    const httpCode = lines[lines.length - 1];
+    const body = lines.slice(0, -1).join('\n');
+
+    if (httpCode !== '200') {
+      throw new Error(
+        `Plugboard returned HTTP ${httpCode}: ${body.slice(0, 300)}`,
+      );
+    }
+
+    return parseGeminiResponse(body);
+  } finally {
+    if (fs.existsSync(tmpFile)) fs.unlinkSync(tmpFile);
+  }
+}
+
+async function callViaDirect(
+  apiKey: string,
+  image: string,
+  mimeType: string,
+): Promise<ThemeExtraction> {
+  const payload = buildPayload(image, mimeType);
+  const url = `${GEMINI_BASE}/${MODEL}:generateContent?key=${apiKey}`;
+
+  const resp = await fetch(url, {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify(payload),
+  });
+
+  const body = await resp.text();
+  if (!resp.ok) {
+    throw new Error(
+      `Gemini API returned HTTP ${resp.status}: ${body.slice(0, 300)}`,
+    );
+  }
+
+  return parseGeminiResponse(body);
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const reqBody = await request.json();
+    const {image, mimeType} = reqBody as {image: string; mimeType: string};
+
+    if (!image || !mimeType) {
+      return NextResponse.json(
+        {error: 'Missing required fields: image (base64), mimeType'},
+        {status: 400},
+      );
+    }
+
+    const hasPlugboard = fs.existsSync(CERT);
+    const directKey = process.env.GEMINI_API_KEY;
+
+    if (!hasPlugboard && !directKey) {
+      return NextResponse.json(
+        {
+          error:
+            'No Gemini access configured. Either run on a Meta devvm (Plugboard mTLS) or set GEMINI_API_KEY environment variable.',
+        },
+        {status: 503},
+      );
+    }
+
+    const extraction = hasPlugboard
+      ? await callViaPlugboard(image, mimeType)
+      : await callViaDirect(directKey!, image, mimeType);
+
+    return NextResponse.json(extraction);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({error: message}, {status: 500});
+  }
+}

--- a/packages/cli/templates/pages/detail-page/page.tsx
+++ b/packages/cli/templates/pages/detail-page/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import {useState} from 'react';
-import * as stylex from '@stylexjs/stylex';
 import {XDSAppShell} from '@xds/core/AppShell';
 import {XDSNavIcon} from '@xds/core/NavIcon';
 import {
@@ -18,6 +17,7 @@ import {
   XDSLayoutPanel,
   XDSVStack,
   XDSHStack,
+  XDSStackItem,
   XDSCard,
   XDSSection,
 } from '@xds/core/Layout';
@@ -25,7 +25,6 @@ import {XDSText, XDSHeading} from '@xds/core/Text';
 import {XDSBadge} from '@xds/core/Badge';
 import {XDSAvatar} from '@xds/core/Avatar';
 import {XDSButton} from '@xds/core/Button';
-
 import {XDSTabList, XDSTab} from '@xds/core/TabList';
 import {XDSDivider} from '@xds/core/Divider';
 import {XDSLink} from '@xds/core/Link';
@@ -35,224 +34,51 @@ import {XDSProgressBar} from '@xds/core/ProgressBar';
 import {XDSCollapsible} from '@xds/core/Collapsible';
 import {XDSCenter} from '@xds/core/Center';
 import {XDSIcon} from '@xds/core/Icon';
-
-// ─── Icons ──────────────────────────────────────────────────────────────────
-const HomeIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth={1.5}
-    {...props}>
-    <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
-    <polyline points="9 22 9 12 15 12 15 22" />
-  </svg>
-);
-const OrdersIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth={1.5}
-    {...props}>
-    <rect x="2" y="3" width="20" height="18" rx="2" />
-    <path d="M8 7h8M8 11h5M8 15h3" />
-  </svg>
-);
-const ProductsIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth={1.5}
-    {...props}>
-    <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z" />
-    <polyline points="3.27 6.96 12 12.01 20.73 6.96" />
-    <line x1="12" y1="22.08" x2="12" y2="12" />
-  </svg>
-);
-const CustomersIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth={1.5}
-    {...props}>
-    <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
-    <circle cx="9" cy="7" r="4" />
-    <path d="M22 21v-2a4 4 0 0 0-3-3.87M16 3.13a4 4 0 0 1 0 7.75" />
-  </svg>
-);
-const ContentIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth={1.5}
-    {...props}>
-    <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
-    <path d="M14 2v6h6M16 13H8M16 17H8M10 9H8" />
-  </svg>
-);
-const AnalyticsIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth={1.5}
-    {...props}>
-    <path d="M18 20V10M12 20V4M6 20v-6" />
-  </svg>
-);
-const SettingsIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth={1.5}
-    {...props}>
-    <circle cx="12" cy="12" r="3" />
-    <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z" />
-  </svg>
-);
-const HelpIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth={1.5}
-    {...props}>
-    <circle cx="12" cy="12" r="10" />
-    <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3M12 17h.01" />
-  </svg>
-);
-const CalendarIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth={1.5}
-    {...props}>
-    <rect x="3" y="4" width="18" height="18" rx="2" />
-    <line x1="16" y1="2" x2="16" y2="6" />
-    <line x1="8" y1="2" x2="8" y2="6" />
-    <line x1="3" y1="10" x2="21" y2="10" />
-  </svg>
-);
-const FlagIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth={1.5}
-    {...props}>
-    <path d="M4 15s1-1 4-1 5 2 8 2 4-1 4-1V3s-1 1-4 1-5-2-8-2-4 1-4 1zM4 22v-7" />
-  </svg>
-);
-const FilterIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth={1.5}
-    {...props}>
-    <polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3" />
-  </svg>
-);
-const ThumbUpIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth={1.5}
-    {...props}>
-    <path d="M14 9V5a3 3 0 0 0-3-3l-4 9v11h11.28a2 2 0 0 0 2-1.7l1.38-9a2 2 0 0 0-2-2.3zM7 22H4a2 2 0 0 1-2-2v-7a2 2 0 0 1 2-2h3" />
-  </svg>
-);
-const HeartIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth={1.5}
-    {...props}>
-    <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
-  </svg>
-);
-const EditIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth={1.5}
-    {...props}>
-    <path d="M12 20h9M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z" />
-  </svg>
-);
-const ShopIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg viewBox="0 0 24 24" fill="currentColor" {...props}>
-    <path d="M11.47 3.841a.75.75 0 0 1 1.06 0l8.69 8.69a.75.75 0 1 0 1.06-1.061l-8.689-8.69a2.25 2.25 0 0 0-3.182 0l-8.69 8.69a.75.75 0 1 0 1.061 1.06l8.69-8.689Z" />
-    <path d="m12 5.432 8.159 8.159c.03.03.06.058.091.086v6.198c0 1.035-.84 1.875-1.875 1.875H15a.75.75 0 0 1-.75-.75v-4.5a.75.75 0 0 0-.75-.75h-3a.75.75 0 0 0-.75.75V21a.75.75 0 0 1-.75.75H5.625a1.875 1.875 0 0 1-1.875-1.875v-6.198a2.29 2.29 0 0 0 .091-.086L12 5.432Z" />
-  </svg>
-);
-const ArrowLeftIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth={1.5}
-    {...props}>
-    <path
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18"
-    />
-  </svg>
-);
-const PanelRightIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth={1.5}
-    {...props}>
-    <rect x="3" y="3" width="18" height="18" rx="2" />
-    <line x1="15" y1="3" x2="15" y2="21" />
-  </svg>
-);
+import {
+  HomeIcon,
+  ClipboardDocumentListIcon,
+  CubeIcon,
+  UserGroupIcon,
+  DocumentTextIcon,
+  ChartBarIcon,
+  Cog6ToothIcon,
+  QuestionMarkCircleIcon,
+  CalendarIcon,
+  FlagIcon,
+  FunnelIcon,
+  HandThumbUpIcon,
+  HeartIcon,
+  PencilSquareIcon,
+  ArrowLeftIcon,
+  ViewColumnsIcon,
+} from '@heroicons/react/24/outline';
+import {BuildingStorefrontIcon} from '@heroicons/react/24/solid';
 
 // ─── Styles ─────────────────────────────────────────────────────────────────
+import * as stylex from '@stylexjs/stylex';
+
 const pageStyles = stylex.create({
-  bulletSeparator: {
-    fontSize: 12,
-    lineHeight: '16px',
-    color: 'var(--color-text-secondary, #666)',
-    userSelect: 'none',
-    flexShrink: 0,
-  },
-  productImage: {
-    width: '100%',
-    height: '100%',
-    objectFit: 'cover',
-    borderRadius: 'var(--radius-content, 4px)',
-  },
-  reactionBar: {
-    display: 'flex',
-    gap: 12,
-    alignItems: 'center',
-    fontSize: 12,
-    color: 'var(--color-text-secondary, #666)',
-  },
-  commentBubble: {
-    backgroundColor: 'var(--color-bg-wash, #f5f5f5)',
-    borderRadius: 'var(--radius-container, 12px)',
-    padding: 12,
-  },
-  panelSection: {
-    paddingBlock: 4,
-  },
   contentFlushEnd: {
     paddingInlineEnd: 0,
+  },
+  panelAnimationWrapper: {
+    overflow: 'hidden',
+    flexShrink: 0,
+    transition:
+      'width var(--duration-medium, 410ms) var(--ease-standard, cubic-bezier(0.24, 1, 0.4, 1)), min-width var(--duration-medium, 410ms) var(--ease-standard, cubic-bezier(0.24, 1, 0.4, 1))',
+  },
+  panelContent: {
+    transition:
+      'opacity var(--duration-fast, 175ms) var(--ease-standard, cubic-bezier(0.24, 1, 0.4, 1))',
+  },
+  tabsRow: {
+    marginInline: -12,
+    marginBottom: -16,
+    marginTop: 12,
+  },
+  metadataRow: {
+    overflow: 'hidden',
+    whiteSpace: 'nowrap',
   },
 });
 
@@ -358,7 +184,9 @@ function ShopSideNav() {
         <XDSSideNavHeading
           icon={
             <XDSNavIcon
-              icon={<XDSIcon icon={ShopIcon} size="sm" color="inherit" />}
+              icon={
+                <XDSIcon icon={BuildingStorefrontIcon} size="sm" color="inherit" />
+              }
             />
           }
           heading="Kiln & Table"
@@ -366,16 +194,16 @@ function ShopSideNav() {
         />
       }
       footer={
-        <XDSVStack gap={0} style={{padding: '8px 0'}}>
+        <XDSVStack gap={0}>
           <XDSSideNavItem
             label="Settings"
-            icon={SettingsIcon}
+            icon={Cog6ToothIcon}
             isSelected={active === 'settings'}
             onClick={() => setActive('settings')}
           />
           <XDSSideNavItem
             label="Help Center"
-            icon={HelpIcon}
+            icon={QuestionMarkCircleIcon}
             isSelected={active === 'help'}
             onClick={() => setActive('help')}
           />
@@ -391,13 +219,13 @@ function ShopSideNav() {
         />
         <XDSSideNavItem
           label="Orders"
-          icon={OrdersIcon}
+          icon={ClipboardDocumentListIcon}
           isSelected={active === 'orders'}
           onClick={() => setActive('orders')}
         />
         <XDSSideNavItem
           label="Products"
-          icon={ProductsIcon}
+          icon={CubeIcon}
           isSelected={active === 'products'}
           onClick={() => setActive('products')}
         />
@@ -405,19 +233,19 @@ function ShopSideNav() {
       <XDSSideNavSection title="Sales channels">
         <XDSSideNavItem
           label="Customers"
-          icon={CustomersIcon}
+          icon={UserGroupIcon}
           isSelected={active === 'customers'}
           onClick={() => setActive('customers')}
         />
         <XDSSideNavItem
           label="Content"
-          icon={ContentIcon}
+          icon={DocumentTextIcon}
           isSelected={active === 'content'}
           onClick={() => setActive('content')}
         />
         <XDSSideNavItem
           label="Analytics"
-          icon={AnalyticsIcon}
+          icon={ChartBarIcon}
           isSelected={active === 'analytics'}
           onClick={() => setActive('analytics')}
         />
@@ -428,7 +256,11 @@ function ShopSideNav() {
 
 // ─── Bullet separator ───────────────────────────────────────────────────────
 function Bullet() {
-  return <span {...stylex.props(pageStyles.bulletSeparator)}>{'・'}</span>;
+  return (
+    <XDSText type="supporting" color="secondary">
+      {'・'}
+    </XDSText>
+  );
 }
 
 // ─── Page Header ────────────────────────────────────────────────────────────
@@ -446,91 +278,69 @@ function PageHeader({
   return (
     <XDSLayoutHeader hasDivider padding={4}>
       <XDSCenter axis="horizontal">
-        <XDSVStack gap={0} style={{width: '100%'}}>
-          <XDSHStack
-            gap={4}
-            vAlign="start"
-            style={{justifyContent: 'space-between'}}>
-            <XDSVStack gap={0} style={{flex: 1, minWidth: 0}}>
-              {/* Back link */}
-              <XDSLink href="#" label="All orders" color="secondary">
-                <XDSHStack gap={1} vAlign="center">
-                  <XDSIcon icon={ArrowLeftIcon} size="sm" color="inherit" />
-                  All orders
-                </XDSHStack>
-              </XDSLink>
-              {/* Title + metadata */}
+        <XDSVStack gap={0}>
+          <XDSHStack gap={4} vAlign="start">
+            <XDSStackItem size="fill">
               <XDSVStack gap={0}>
-                <XDSHeading level={1}>#1001</XDSHeading>
-                {/* Metadata row */}
-                <XDSHStack
-                  gap={1}
-                  vAlign="center"
-                  style={{overflow: 'hidden', whiteSpace: 'nowrap'}}>
-                  <XDSText type="body" style={{flexShrink: 0}}>
-                    {PRODUCTS.length} ordered items
-                  </XDSText>
-                  <Bullet />
-                  <XDSHStack gap={1} vAlign="center" style={{flexShrink: 0}}>
-                    <XDSAvatar name="Jane Doe" size="xsmall" />
-                    <XDSText type="body">Jane Doe</XDSText>
+                <XDSLink href="#" label="All orders" color="secondary">
+                  <XDSHStack gap={1} vAlign="center">
+                    <XDSIcon icon={ArrowLeftIcon} size="sm" color="inherit" />
+                    All orders
                   </XDSHStack>
-                  <Bullet />
-                  <span style={{flexShrink: 0}}>
+                </XDSLink>
+                <XDSVStack gap={0}>
+                  <XDSHeading level={1}>#1001</XDSHeading>
+                  <XDSHStack
+                    gap={1}
+                    vAlign="center"
+                    xstyle={pageStyles.metadataRow}>
+                    <XDSText type="body">{PRODUCTS.length} ordered items</XDSText>
+                    <Bullet />
+                    <XDSHStack gap={1} vAlign="center">
+                      <XDSAvatar name="Jane Doe" size="xsmall" />
+                      <XDSText type="body">Jane Doe</XDSText>
+                    </XDSHStack>
+                    <Bullet />
                     <XDSBadge variant="warning" label="Unfulfilled" />
-                  </span>
-                  <Bullet />
-                  <XDSHStack gap={1} vAlign="center" style={{flexShrink: 0}}>
-                    <XDSIcon icon={CalendarIcon} size="sm" color="secondary" />
-                    <XDSText type="body">02/23/2026</XDSText>
+                    <Bullet />
+                    <XDSHStack gap={1} vAlign="center">
+                      <XDSIcon icon={CalendarIcon} size="sm" color="secondary" />
+                      <XDSText type="body">02/23/2026</XDSText>
+                    </XDSHStack>
+                    <Bullet />
+                    <XDSHStack gap={1} vAlign="center">
+                      <XDSIcon icon={FlagIcon} size="sm" color="secondary" />
+                      <XDSText type="body">Needs attention</XDSText>
+                    </XDSHStack>
+                    <Bullet />
+                    <XDSLink href="#" label="See all" color="secondary">
+                      See all
+                    </XDSLink>
                   </XDSHStack>
-                  <Bullet />
-                  <XDSHStack gap={1} vAlign="center" style={{flexShrink: 0}}>
-                    <XDSIcon icon={FlagIcon} size="sm" color="secondary" />
-                    <XDSText type="body">Needs attention</XDSText>
-                  </XDSHStack>
-                  <Bullet />
-                  <XDSLink
-                    href="#"
-                    label="See all"
-                    color="secondary"
-                    style={{flexShrink: 0}}>
-                    See all
-                  </XDSLink>
-                </XDSHStack>
+                </XDSVStack>
               </XDSVStack>
-            </XDSVStack>
-
-            {/* Actions — top-aligned */}
-            <XDSHStack gap={2} style={{flexShrink: 0}}>
+            </XDSStackItem>
+            <XDSHStack gap={2}>
               <XDSButton label="Restock" variant="secondary" />
               <XDSButton label="Edit" variant="secondary" />
             </XDSHStack>
           </XDSHStack>
 
-          {/* Tabs — full width */}
-          <XDSHStack
-            vAlign="center"
-            style={{
-              justifyContent: 'space-between',
-              marginInline: -12,
-              marginBottom: -16,
-              marginTop: 12,
-            }}>
-            <XDSTabList value={activeTab} onChange={onTabChange} size="lg">
-              <XDSTab value="details" label="Details" />
-              <XDSTab value="invoices" label="Invoices" />
-              <XDSTab value="timeline" label="Timeline" />
-              <XDSTab value="customer" label="Customer" />
-              <XDSTab value="analysis" label="Analysis" />
-            </XDSTabList>
+          <XDSHStack vAlign="center" xstyle={pageStyles.tabsRow}>
+            <XDSStackItem size="fill">
+              <XDSTabList value={activeTab} onChange={onTabChange} size="lg">
+                <XDSTab value="details" label="Details" />
+                <XDSTab value="invoices" label="Invoices" />
+                <XDSTab value="timeline" label="Timeline" />
+                <XDSTab value="customer" label="Customer" />
+                <XDSTab value="analysis" label="Analysis" />
+              </XDSTabList>
+            </XDSStackItem>
             <XDSButton
               label={isPanelOpen ? 'Hide panel' : 'Show panel'}
               variant="ghost"
               size="md"
-              icon={
-                <XDSIcon icon={PanelRightIcon} size="sm" color="secondary" />
-              }
+              icon={<XDSIcon icon={ViewColumnsIcon} size="sm" />}
               isIconOnly
               onClick={onTogglePanel}
             />
@@ -546,18 +356,20 @@ function ItemsCard() {
   return (
     <XDSSection>
       <XDSVStack gap={4}>
-        <XDSHStack vAlign="center" style={{justifyContent: 'space-between'}}>
-          <XDSHStack gap={2} vAlign="center">
-            <XDSHeading level={2}>Items</XDSHeading>
-            <XDSBadge variant="warning" label="Unfulfilled" />
-          </XDSHStack>
+        <XDSHStack vAlign="center">
+          <XDSStackItem size="fill">
+            <XDSHStack gap={2} vAlign="center">
+              <XDSHeading level={2}>Items</XDSHeading>
+              <XDSBadge variant="warning" label="Unfulfilled" />
+            </XDSHStack>
+          </XDSStackItem>
           <XDSHStack gap={2}>
             <XDSButton label="Fulfill item" variant="ghost" />
             <XDSButton label="Create shipping label" variant="secondary" />
           </XDSHStack>
         </XDSHStack>
 
-        <XDSList density="spacious" style={{marginInline: -12}}>
+        <XDSList density="spacious">
           {PRODUCTS.map((product, i) => (
             <XDSListItem
               key={i}
@@ -573,13 +385,16 @@ function ItemsCard() {
               }
               onClick={() => {}}
               startContent={
-                <div style={{width: 100, height: 66, flexShrink: 0}}>
-                  <img
-                    src={product.image}
-                    alt={product.name}
-                    {...stylex.props(pageStyles.productImage)}
-                  />
-                </div>
+                <img
+                  src={product.image}
+                  alt={product.name}
+                  style={{
+                    width: 100,
+                    height: 66,
+                    objectFit: 'cover',
+                    borderRadius: 'var(--radius-content, 4px)',
+                  }}
+                />
               }
               endContent={
                 <XDSText type="body" color="secondary">
@@ -601,11 +416,13 @@ function InvoiceCard() {
   return (
     <XDSSection>
       <XDSVStack gap={4}>
-        <XDSHStack vAlign="center" style={{justifyContent: 'space-between'}}>
-          <XDSHStack gap={2} vAlign="center">
-            <XDSHeading level={2}>Invoice</XDSHeading>
-            <XDSBadge variant="success" label="Paid" />
-          </XDSHStack>
+        <XDSHStack vAlign="center">
+          <XDSStackItem size="fill">
+            <XDSHStack gap={2} vAlign="center">
+              <XDSHeading level={2}>Invoice</XDSHeading>
+              <XDSBadge variant="success" label="Paid" />
+            </XDSHStack>
+          </XDSStackItem>
           <XDSHStack gap={2}>
             <XDSButton label="Refund" variant="ghost" />
             <XDSButton label="Send Invoice" variant="secondary" />
@@ -614,31 +431,40 @@ function InvoiceCard() {
 
         <XDSMetadataList>
           <XDSMetadataListItem label="Subtotal">
-            <XDSHStack style={{justifyContent: 'space-between', width: '100%'}}>
-              <span>{PRODUCTS.length} items</span>
-              <span>{fmt(SUBTOTAL)}</span>
+            <XDSHStack>
+              <XDSStackItem size="fill">
+                <XDSText type="body">{PRODUCTS.length} items</XDSText>
+              </XDSStackItem>
+              <XDSText type="body">{fmt(SUBTOTAL)}</XDSText>
             </XDSHStack>
           </XDSMetadataListItem>
           <XDSMetadataListItem label="Discount">
-            <XDSHStack style={{justifyContent: 'space-between', width: '100%'}}>
-              <span>New customer code: NEW15</span>
-              <span>– {fmt(DISCOUNT)}</span>
+            <XDSHStack>
+              <XDSStackItem size="fill">
+                <XDSText type="body">New customer code: NEW15</XDSText>
+              </XDSStackItem>
+              <XDSText type="body">– {fmt(DISCOUNT)}</XDSText>
             </XDSHStack>
           </XDSMetadataListItem>
           <XDSMetadataListItem label="Shipping">
-            <XDSHStack style={{justifyContent: 'space-between', width: '100%'}}>
-              <span>Free shipping (0.0lbs) USPS</span>
-              <span>{fmt(SHIPPING)}</span>
+            <XDSHStack>
+              <XDSStackItem size="fill">
+                <XDSText type="body">Free shipping (0.0lbs) USPS</XDSText>
+              </XDSStackItem>
+              <XDSText type="body">{fmt(SHIPPING)}</XDSText>
             </XDSHStack>
           </XDSMetadataListItem>
           <XDSMetadataListItem label="Tax">
-            <XDSHStack style={{justifyContent: 'space-between', width: '100%'}}>
-              <span>Sales tax (8.25%)</span>
-              <span>{fmt(TAX)}</span>
+            <XDSHStack>
+              <XDSStackItem size="fill">
+                <XDSText type="body">Sales tax (8.25%)</XDSText>
+              </XDSStackItem>
+              <XDSText type="body">{fmt(TAX)}</XDSText>
             </XDSHStack>
           </XDSMetadataListItem>
           <XDSMetadataListItem label="Total">
-            <XDSHStack style={{justifyContent: 'flex-end', width: '100%'}}>
+            <XDSHStack>
+              <XDSStackItem size="fill" />
               <XDSText type="body" weight="bold">
                 {fmt(TOTAL)}
               </XDSText>
@@ -650,9 +476,11 @@ function InvoiceCard() {
 
         <XDSMetadataList>
           <XDSMetadataListItem label="Paid by customer">
-            <XDSHStack style={{justifyContent: 'space-between', width: '100%'}}>
-              <span>Visa ...7482</span>
-              <span>{fmt(TOTAL)}</span>
+            <XDSHStack>
+              <XDSStackItem size="fill">
+                <XDSText type="body">Visa ...7482</XDSText>
+              </XDSStackItem>
+              <XDSText type="body">{fmt(TOTAL)}</XDSText>
             </XDSHStack>
           </XDSMetadataListItem>
         </XDSMetadataList>
@@ -666,35 +494,37 @@ function TimelineSection() {
   return (
     <XDSSection>
       <XDSVStack gap={4}>
-        <XDSHStack vAlign="center" style={{justifyContent: 'space-between'}}>
-          <XDSHeading level={2}>Timeline</XDSHeading>
+        <XDSHStack vAlign="center">
+          <XDSStackItem size="fill">
+            <XDSHeading level={2}>Timeline</XDSHeading>
+          </XDSStackItem>
           <XDSButton
             label="Filters"
             variant="ghost"
-            icon={<XDSIcon icon={FilterIcon} />}
+            icon={<XDSIcon icon={FunnelIcon} />}
             isIconOnly
           />
         </XDSHStack>
 
         <XDSVStack gap={4}>
           {ACTIVITY.map((item, i) => (
-            <div key={i}>
-              <XDSVStack gap={2}>
-                <XDSHStack gap={3} vAlign="start">
-                  <XDSAvatar name={item.user} size="small" />
-                  <XDSVStack gap={2} style={{flex: 1}}>
-                    <div {...stylex.props(pageStyles.commentBubble)}>
+            <XDSVStack key={i} gap={2}>
+              <XDSHStack gap={3} vAlign="start">
+                <XDSAvatar name={item.user} size="small" />
+                <XDSStackItem size="fill">
+                  <XDSVStack gap={2}>
+                    <XDSCard variant="muted" padding={3}>
                       <XDSVStack gap={1}>
                         <XDSText type="body" weight="bold">
                           {item.user}
                         </XDSText>
                         <XDSText type="body">{item.text}</XDSText>
                         {item.changes && (
-                          <XDSVStack gap={1} style={{marginTop: 4}}>
+                          <XDSVStack gap={1}>
                             {item.changes.map((change, j) => (
                               <XDSHStack key={j} gap={2} vAlign="center">
                                 <XDSIcon
-                                  icon={EditIcon}
+                                  icon={PencilSquareIcon}
                                   size="sm"
                                   color="secondary"
                                 />
@@ -706,30 +536,40 @@ function TimelineSection() {
                           </XDSVStack>
                         )}
                       </XDSVStack>
-                    </div>
-                    <div {...stylex.props(pageStyles.reactionBar)}>
+                    </XDSCard>
+                    <XDSHStack gap={3} vAlign="center">
                       <XDSHStack gap={1} vAlign="center">
                         <XDSIcon
-                          icon={ThumbUpIcon}
+                          icon={HandThumbUpIcon}
                           size="xsm"
-                          color="inherit"
+                          color="secondary"
                         />
-                        <XDSIcon icon={HeartIcon} size="xsm" color="inherit" />
-                        <span>{item.reactions}</span>
+                        <XDSIcon
+                          icon={HeartIcon}
+                          size="xsm"
+                          color="secondary"
+                        />
+                        <XDSText type="supporting" color="secondary">
+                          {item.reactions}
+                        </XDSText>
                       </XDSHStack>
-                      <span>Like</span>
+                      <XDSText type="supporting" color="secondary">
+                        Like
+                      </XDSText>
                       <Bullet />
-                      <span>Reply</span>
+                      <XDSText type="supporting" color="secondary">
+                        Reply
+                      </XDSText>
                       <Bullet />
-                      <span>{item.time}</span>
-                    </div>
+                      <XDSText type="supporting" color="secondary">
+                        {item.time}
+                      </XDSText>
+                    </XDSHStack>
                   </XDSVStack>
-                </XDSHStack>
-              </XDSVStack>
-              {i < ACTIVITY.length - 1 && (
-                <XDSDivider style={{marginTop: 12}} />
-              )}
-            </div>
+                </XDSStackItem>
+              </XDSHStack>
+              {i < ACTIVITY.length - 1 && <XDSDivider />}
+            </XDSVStack>
           ))}
         </XDSVStack>
       </XDSVStack>
@@ -741,85 +581,66 @@ function TimelineSection() {
 function RightPanel({isOpen}: {isOpen: boolean}) {
   return (
     <div
+      {...stylex.props(pageStyles.panelAnimationWrapper)}
       style={{
         width: isOpen ? 320 : 0,
         minWidth: isOpen ? 320 : 0,
-        overflow: 'hidden',
-        transition:
-          'width var(--duration-medium, 410ms) var(--ease-standard, cubic-bezier(0.24, 1, 0.4, 1)), min-width var(--duration-medium, 410ms) var(--ease-standard, cubic-bezier(0.24, 1, 0.4, 1))',
-        flexShrink: 0,
       }}>
       <XDSLayoutPanel
         hasDivider
         width={320}
-        padding={0}
+        padding={4}
         role="complementary"
         style={{
           opacity: isOpen ? 1 : 0,
-          transition:
-            'opacity var(--duration-fast, 175ms) var(--ease-standard, cubic-bezier(0.24, 1, 0.4, 1))',
           transitionDelay: isOpen ? 'var(--duration-fast, 175ms)' : '0ms',
-        }}>
+        }}
+        xstyle={pageStyles.panelContent}>
         <XDSVStack gap={4}>
-          {/* Notes */}
-          <div
-            {...stylex.props(pageStyles.panelSection)}
-            style={{padding: '8px 16px'}}>
-            <XDSCollapsible trigger={<XDSHeading level={4}>Notes</XDSHeading>}>
+          <XDSCollapsible trigger={<XDSHeading level={4}>Notes</XDSHeading>}>
+            <XDSText type="body">
+              Customer is a repeat buyer — 3rd order this quarter. Prefers snow
+              and oat glazes. Requested gift wrapping for the mug set. Ships to
+              a residential address in CA.{' '}
+              <XDSLink href="#" label="Show more" color="secondary">
+                Show more
+              </XDSLink>
+            </XDSText>
+          </XDSCollapsible>
+
+          <XDSCollapsible
+            trigger={<XDSHeading level={4}>Customer</XDSHeading>}>
+            <XDSMetadataList>
+              <XDSMetadataListItem label="Name">Jane Doe</XDSMetadataListItem>
+              <XDSMetadataListItem label="Address">
+                321 Smith Road, CA 38238
+              </XDSMetadataListItem>
+              <XDSMetadataListItem label="Phone">234-</XDSMetadataListItem>
+              <XDSMetadataListItem label="Email">
+                janedoe@email.com
+              </XDSMetadataListItem>
+              <XDSMetadataListItem label="Billing Address">
+                Same as shipping address
+              </XDSMetadataListItem>
+            </XDSMetadataList>
+          </XDSCollapsible>
+
+          <XDSCollapsible
+            trigger={<XDSHeading level={4}>Fraud Analysis</XDSHeading>}>
+            <XDSVStack gap={1}>
+              <XDSProgressBar
+                label="Risk level"
+                value={15}
+                variant="positive"
+                isLabelHidden
+              />
+              <XDSText type="body">Recommendation: Fulfill order</XDSText>
               <XDSText type="body">
-                Customer is a repeat buyer — 3rd order this quarter. Prefers
-                snow and oat glazes. Requested gift wrapping for the mug set.
-                Ships to a residential address in CA.{' '}
-                <XDSLink href="#" label="Show more" color="secondary">
-                  Show more
-                </XDSLink>
+                There is a low chance that you will receive a chargeback on this
+                order.
               </XDSText>
-            </XDSCollapsible>
-          </div>
-
-          {/* Customer */}
-          <div
-            {...stylex.props(pageStyles.panelSection)}
-            style={{padding: '8px 16px'}}>
-            <XDSCollapsible
-              trigger={<XDSHeading level={4}>Customer</XDSHeading>}>
-              <XDSMetadataList>
-                <XDSMetadataListItem label="Name">Jane Doe</XDSMetadataListItem>
-                <XDSMetadataListItem label="Address">
-                  321 Smith Road, CA 38238
-                </XDSMetadataListItem>
-                <XDSMetadataListItem label="Phone">234-</XDSMetadataListItem>
-                <XDSMetadataListItem label="Email">
-                  janedoe@email.com
-                </XDSMetadataListItem>
-                <XDSMetadataListItem label="Billing Address">
-                  Same as shipping address
-                </XDSMetadataListItem>
-              </XDSMetadataList>
-            </XDSCollapsible>
-          </div>
-
-          {/* Fraud Analysis */}
-          <div
-            {...stylex.props(pageStyles.panelSection)}
-            style={{padding: '8px 16px'}}>
-            <XDSCollapsible
-              trigger={<XDSHeading level={4}>Fraud Analysis</XDSHeading>}>
-              <XDSVStack gap={1}>
-                <XDSProgressBar
-                  label="Risk level"
-                  value={15}
-                  variant="positive"
-                  isLabelHidden
-                />
-                <XDSText type="body">Recommendation: Fulfill order</XDSText>
-                <XDSText type="body">
-                  There is a low chance that you will receive a chargeback on
-                  this order.
-                </XDSText>
-              </XDSVStack>
-            </XDSCollapsible>
-          </div>
+            </XDSVStack>
+          </XDSCollapsible>
         </XDSVStack>
       </XDSLayoutPanel>
     </div>

--- a/packages/cli/templates/pages/product-detail/page.tsx
+++ b/packages/cli/templates/pages/product-detail/page.tsx
@@ -3,7 +3,7 @@
 import {useState} from 'react';
 import {XDSAppShell} from '@xds/core/AppShell';
 import {XDSTopNav, XDSTopNavHeading, XDSTopNavItem} from '@xds/core/TopNav';
-import {XDSVStack, XDSHStack} from '@xds/core/Layout';
+import {XDSVStack, XDSHStack, XDSStackItem} from '@xds/core/Layout';
 import {XDSCenter} from '@xds/core/Center';
 import {XDSGrid} from '@xds/core/Grid';
 import {XDSText, XDSHeading} from '@xds/core/Text';
@@ -18,139 +18,48 @@ import {XDSBadge} from '@xds/core/Badge';
 import {XDSDivider} from '@xds/core/Divider';
 import {XDSCollapsible, XDSCollapsibleGroup} from '@xds/core/Collapsible';
 import {XDSNavIcon} from '@xds/core/NavIcon';
-
-// ─── Icons ──────────────────────────────────────────────────────────────────
-const BagIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth={1.5}
-    {...props}>
-    <path d="M6 2L3 6v14a2 2 0 002 2h14a2 2 0 002-2V6l-3-4zM3 6h18M16 10a4 4 0 01-8 0" />
-  </svg>
-);
-
-const UserIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth={1.5}
-    {...props}>
-    <path d="M20 21v-2a4 4 0 00-4-4H8a4 4 0 00-4 4v2" />
-    <circle cx="12" cy="7" r="4" />
-  </svg>
-);
-
-const SearchIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth={1.5}
-    {...props}>
-    <circle cx="11" cy="11" r="8" />
-    <path d="M21 21l-4.35-4.35" />
-  </svg>
-);
-
-const HeartIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth={1.5}
-    {...props}>
-    <path d="M20.84 4.61a5.5 5.5 0 00-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 00-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 000-7.78z" />
-  </svg>
-);
-
-const MinusIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth={2}
-    strokeLinecap="round"
-    {...props}>
-    <line x1="5" y1="12" x2="19" y2="12" />
-  </svg>
-);
-
-const PlusIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth={2}
-    strokeLinecap="round"
-    {...props}>
-    <line x1="12" y1="5" x2="12" y2="19" />
-    <line x1="5" y1="12" x2="19" y2="12" />
-  </svg>
-);
+import {
+  ShoppingBagIcon,
+  UserIcon,
+  MagnifyingGlassIcon,
+  HeartIcon,
+  MinusIcon,
+  PlusIcon,
+  StarIcon,
+} from '@heroicons/react/24/outline';
+import {StarIcon as StarIconSolid} from '@heroicons/react/24/solid';
 
 // ─── Star Rating ─────────────────────────────────────────────────────────────
 function StarRating({rating, count}: {rating: number; count: number}) {
   const full = Math.floor(rating);
   const partial = rating - full;
   const empty = 5 - full - (partial > 0 ? 1 : 0);
-  const starSize = 16;
 
   return (
-    <div style={{display: 'flex', alignItems: 'center', gap: 4}}>
+    <XDSHStack gap={1} vAlign="center">
       {Array.from({length: full}, (_, i) => (
-        <svg
-          key={`full-${i}`}
-          viewBox="0 0 24 24"
-          fill="currentColor"
-          style={{
-            width: starSize,
-            height: starSize,
-            color: 'var(--color-icon-primary)',
-          }}>
-          <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" />
-        </svg>
+        <XDSIcon key={`full-${i}`} icon={StarIconSolid} size="sm" />
       ))}
       {partial > 0 && (
-        <svg
-          key="partial"
-          viewBox="0 0 24 24"
-          style={{width: starSize, height: starSize}}>
-          <defs>
-            <clipPath id="star-clip">
-              <rect x="0" y="0" width={24 * partial} height="24" />
-            </clipPath>
-          </defs>
-          <path
-            d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"
-            fill="var(--color-icon-primary)"
-            clipPath="url(#star-clip)"
-          />
-          <path
-            d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"
-            fill="none"
-            stroke="var(--color-icon-primary)"
-            strokeWidth={1.5}
-          />
-        </svg>
+        <XDSHStack style={{position: 'relative'}}>
+          <XDSIcon icon={StarIcon} size="sm" />
+          <XDSHStack
+            style={{
+              position: 'absolute',
+              inset: 0,
+              clipPath: `inset(0 ${Math.round((1 - partial) * 100)}% 0 0)`,
+            }}>
+            <XDSIcon icon={StarIconSolid} size="sm" />
+          </XDSHStack>
+        </XDSHStack>
       )}
       {Array.from({length: empty}, (_, i) => (
-        <svg
-          key={`empty-${i}`}
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="var(--color-icon-primary)"
-          strokeWidth={1.5}
-          style={{width: starSize, height: starSize}}>
-          <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" />
-        </svg>
+        <XDSIcon key={`empty-${i}`} icon={StarIcon} size="sm" />
       ))}
       <XDSText type="body" color="secondary">
         {rating} ({count})
       </XDSText>
-    </div>
+    </XDSHStack>
   );
 }
 
@@ -174,11 +83,11 @@ const PRODUCT = {
   price: 89.0,
   originalPrice: 119.0,
   description:
-    'A hand-thrown mug and plate set that brings quiet warmth to every meal. The mug sits easy in the hand with a generous 12 oz capacity, while the 8-inch plate works for everything from toast to tapas. Each piece is kiln-fired at 2,300°F for a finish that resists chips and stains. Subtle variations in the reactive glaze mean no two sets are exactly alike. Dishwasher and microwave safe.',
+    'A hand-thrown mug and plate set that brings quiet warmth to every meal. The mug sits easy in the hand with a generous 12 oz capacity, while the 8-inch plate works for everything from toast to tapas. Each piece is kiln-fired at 2,300\u00B0F for a finish that resists chips and stains. Subtle variations in the reactive glaze mean no two sets are exactly alike. Dishwasher and microwave safe.',
   composition:
-    'High-fire stoneware clay, wheel-thrown and trimmed by hand. Reactive glaze applied by dipping — color pools and breaks naturally over the clay body. Lead-free and food-safe. Unglazed foot ring reveals the raw clay underneath. Each piece is bisque-fired, glazed, then fired again to cone 10 in a gas reduction kiln.',
+    'High-fire stoneware clay, wheel-thrown and trimmed by hand. Reactive glaze applied by dipping \u2014 color pools and breaks naturally over the clay body. Lead-free and food-safe. Unglazed foot ring reveals the raw clay underneath. Each piece is bisque-fired, glazed, then fired again to cone 10 in a gas reduction kiln.',
   deliveryReturns:
-    'Free shipping on all ceramics orders over $75. Each piece is individually wrapped in recycled kraft paper and cushioned for transit. Returns accepted within 30 days — items must be unused and in original packaging. Replacement pieces available individually.',
+    'Free shipping on all ceramics orders over $75. Each piece is individually wrapped in recycled kraft paper and cushioned for transit. Returns accepted within 30 days \u2014 items must be unused and in original packaging. Replacement pieces available individually.',
   dimensions:
     'Mug height: 9.5 cm / 3.75 in. Mug diameter: 8.5 cm / 3.35 in. Capacity: 350 ml / 12 oz. Plate diameter: 20 cm / 8 in. Plate height: 2 cm / 0.75 in. Weight: 680 g / 1.5 lb (set).',
 };
@@ -207,7 +116,9 @@ function StoreTopNav() {
         <XDSTopNavHeading
           heading="Kiln & Table"
           logo={
-            <XDSNavIcon icon={<XDSIcon icon={BagIcon} size="sm" />} />
+            <XDSNavIcon
+              icon={<XDSIcon icon={ShoppingBagIcon} size="sm" />}
+            />
           }
           href="#"
         />
@@ -226,7 +137,7 @@ function StoreTopNav() {
           <XDSButton
             label="Search"
             variant="ghost"
-            icon={<XDSIcon icon={SearchIcon} size="sm" />}
+            icon={<XDSIcon icon={MagnifyingGlassIcon} size="sm" />}
             isIconOnly
           />
           <XDSButton
@@ -244,7 +155,7 @@ function StoreTopNav() {
           <XDSButton
             label="Cart"
             variant="ghost"
-            icon={<XDSIcon icon={BagIcon} size="sm" />}
+            icon={<XDSIcon icon={ShoppingBagIcon} size="sm" />}
             isIconOnly
           />
         </>
@@ -265,8 +176,7 @@ function ImageGallery({
   const thumbnails = IMAGES.slice(1);
 
   return (
-    <div style={{display: 'flex', flexDirection: 'column', gap: 12}}>
-      {/* Hero image */}
+    <XDSVStack gap={3}>
       <img
         src={heroSrc}
         alt={PRODUCT.name}
@@ -275,10 +185,8 @@ function ImageGallery({
           aspectRatio: '4 / 5',
           objectFit: 'cover',
           borderRadius: 'var(--radius-container, 12px)',
-          backgroundColor: 'var(--color-surface-secondary)',
         }}
       />
-      {/* Thumbnail grid */}
       <XDSGrid columns={3} gap={2}>
         {thumbnails.map((src, i) => (
           <img
@@ -289,7 +197,6 @@ function ImageGallery({
               width: '100%',
               aspectRatio: '1 / 1',
               objectFit: 'cover',
-              cursor: 'pointer',
               borderRadius: 'var(--radius-element, 8px)',
               outline:
                 selected === i
@@ -309,7 +216,7 @@ function ImageGallery({
           />
         ))}
       </XDSGrid>
-    </div>
+    </XDSVStack>
   );
 }
 
@@ -324,11 +231,10 @@ function ProductInfo() {
 
   return (
     <XDSVStack gap={5}>
-      {/* Title & Rating */}
       <XDSVStack gap={2}>
         <XDSHeading level={1}>{PRODUCT.name}</XDSHeading>
         <StarRating rating={4.3} count={128} />
-        <XDSHStack gap={2} style={{alignItems: 'center'}}>
+        <XDSHStack gap={2} vAlign="center">
           <XDSText type="large" weight="bold">
             {fmt(PRODUCT.price)}
           </XDSText>
@@ -338,10 +244,10 @@ function ProductInfo() {
           <XDSBadge variant="error" label="Sale" />
         </XDSHStack>
       </XDSVStack>
-      {/* Glaze Selector */}
+
       <XDSVStack gap={2}>
         <XDSText type="label">Glaze</XDSText>
-        <div style={{width: 'fit-content'}}>
+        <XDSVStack hAlign="start">
           <XDSSegmentedControl value={color} onChange={setColor} label="Glaze">
             {COLORS.map(c => (
               <XDSSegmentedControlItem
@@ -351,12 +257,12 @@ function ProductInfo() {
               />
             ))}
           </XDSSegmentedControl>
-        </div>
+        </XDSVStack>
       </XDSVStack>
-      {/* Finish Selector */}
+
       <XDSVStack gap={2}>
         <XDSText type="label">Finish</XDSText>
-        <div style={{width: 'fit-content'}}>
+        <XDSVStack hAlign="start">
           <XDSSegmentedControl
             value={finish}
             onChange={setFinish}
@@ -369,9 +275,9 @@ function ProductInfo() {
               />
             ))}
           </XDSSegmentedControl>
-        </div>
+        </XDSVStack>
       </XDSVStack>
-      {/* Quantity */}
+
       <XDSHStack gap={1} vAlign="center">
         <XDSButton
           label="Decrease quantity"
@@ -381,7 +287,7 @@ function ProductInfo() {
           isDisabled={(quantity ?? 1) <= 1}
           isIconOnly
         />
-        <div style={{width: 100}}>
+        <XDSCenter width={100}>
           <XDSNumberInput
             label="Quantity"
             isLabelHidden
@@ -391,7 +297,7 @@ function ProductInfo() {
             max={10}
             isIntegerOnly
           />
-        </div>
+        </XDSCenter>
         <XDSButton
           label="Increase quantity"
           variant="ghost"
@@ -401,25 +307,13 @@ function ProductInfo() {
           isIconOnly
         />
       </XDSHStack>
-      {/* Add to Cart + Buy it now (8px gap between them) */}
-      <XDSVStack gap={2}>
-        <XDSButton
-          label="Add to Cart"
-          variant="primary"
-          size="lg"
-          style={{display: 'flex', width: '100%'}}>
-          Add to Cart
-        </XDSButton>
 
-        {/* Buy it now + Wishlist */}
+      <XDSVStack gap={2}>
+        <XDSButton label="Add to Cart" variant="primary" size="lg" />
         <XDSHStack gap={2}>
-          <XDSButton
-            label="Buy it now"
-            variant="secondary"
-            size="lg"
-            style={{display: 'flex', flex: 1}}>
-            Buy it now
-          </XDSButton>
+          <XDSStackItem size="fill">
+            <XDSButton label="Buy it now" variant="secondary" size="lg" />
+          </XDSStackItem>
           <XDSButton
             label="Add to wishlist"
             variant="ghost"
@@ -429,9 +323,9 @@ function ProductInfo() {
           />
         </XDSHStack>
       </XDSVStack>
-      {/* Description */}
+
       <XDSText type="body">{PRODUCT.description}</XDSText>
-      {/* Collapsible Sections */}
+
       <XDSCollapsibleGroup type="multiple" defaultValue={['composition']}>
         <XDSDivider />
         <XDSCollapsible
@@ -443,7 +337,9 @@ function ProductInfo() {
         <XDSCollapsible
           value="delivery"
           defaultIsOpen={false}
-          trigger={<XDSHeading level={3}>Delivery &amp; Returns</XDSHeading>}>
+          trigger={
+            <XDSHeading level={3}>Delivery &amp; Returns</XDSHeading>
+          }>
           <XDSText type="body">{PRODUCT.deliveryReturns}</XDSText>
         </XDSCollapsible>
         <XDSDivider />
@@ -470,30 +366,21 @@ export default function ProductDetailTemplate() {
       contentPadding={0}
       variant="surface">
       <XDSCenter axis="horizontal">
-        <div
-          style={{
-            maxWidth: 1200,
-            width: '100%',
-            padding: '32px 24px',
-          }}>
-          <XDSGrid columns={2} gap={5}>
-            <div style={{minWidth: 0}}>
-              <ImageGallery
-                selected={selectedThumb}
-                onSelect={setSelectedThumb}
-              />
-            </div>
-            <div
-              style={{
-                minWidth: 0,
-                position: 'sticky',
-                top: 64,
-                alignSelf: 'start',
-              }}>
+        <XDSVStack
+          gap={0}
+          style={{maxWidth: 1200, width: '100%', padding: '32px 24px'}}>
+          <XDSGrid minChildWidth={400} gap={5}>
+            <ImageGallery
+              selected={selectedThumb}
+              onSelect={setSelectedThumb}
+            />
+            <XDSVStack
+              gap={0}
+              style={{position: 'sticky', top: 64, alignSelf: 'start'}}>
               <ProductInfo />
-            </div>
+            </XDSVStack>
           </XDSGrid>
-        </div>
+        </XDSVStack>
       </XDSCenter>
     </XDSAppShell>
   );

--- a/packages/core/src/theme/defineTheme.ts
+++ b/packages/core/src/theme/defineTheme.ts
@@ -63,6 +63,7 @@ import {
   expandRadiusScale,
   type XDSRadiusScaleConfig,
 } from './expandRadiusScale';
+import {expandColorScale, type XDSColorScaleConfig} from './expandColorScale';
 
 import type {DomainTokenName} from './domainTokens';
 import {domainTokenDefaults} from './domainTokens';
@@ -214,6 +215,20 @@ export interface XDSDefineThemeInput {
    * ```
    */
   radius?: XDSRadiusScaleConfig;
+  /**
+   * Color scale configuration. Generates color token overrides from a
+   * single accent color using the HCT perceptual color model.
+   *
+   * Only generates tokens derivable from the accent — status colors,
+   * categorical hues, and fixed tokens (on-dark/on-light) use defaults.
+   * Explicit `tokens` entries always take precedence.
+   *
+   * @example
+   * ```tsx
+   * color: { accent: '#0064E0', neutralStyle: 'cool', contrast: 'standard' }
+   * ```
+   */
+  color?: XDSColorScaleConfig;
   /** Token overrides — flat map of CSS custom property names to values.
    *  Values can be a string or [light, dark] tuple.
    *  Only include tokens you want to override; defaults fill the rest. */
@@ -481,7 +496,15 @@ export function defineTheme(input: XDSDefineThemeInput): XDSDefinedTheme {
     };
   }
 
-  // 1. Apply typeScale-generated tokens first (lowest precedence)
+  // 1. Apply color-generated tokens (lowest precedence for colors)
+  if (input.color) {
+    const colorTokens = expandColorScale(input.color);
+    for (const [key, value] of Object.entries(colorTokens)) {
+      tokens[key] = value;
+    }
+  }
+
+  // 1a. Apply typeScale-generated tokens (lowest precedence for type)
   if (typeScaleConfig) {
     const typeScaleTokens = expandTypeScale(typeScaleConfig);
     for (const [key, value] of Object.entries(typeScaleTokens)) {

--- a/packages/core/src/theme/expandColorScale.ts
+++ b/packages/core/src/theme/expandColorScale.ts
@@ -1,0 +1,176 @@
+/**
+ * @file expandColorScale.ts
+ * @input Color scale configuration { accent, neutralStyle?, contrast? }
+ * @output Token overrides for derivable color tokens
+ * @position Theme utility; consumed by defineTheme.ts
+ *
+ * Generates color token overrides from a single accent color using the
+ * HCT perceptual color model. Only produces tokens that meaningfully
+ * derive from the accent — status colors, categorical hues, and fixed
+ * tokens (on-dark/on-light) fall through to colorDefaults.
+ *
+ * SYNC: When modified, update:
+ * - /packages/core/src/theme/defineTheme.ts
+ */
+
+import {hexToHct, tonalPalette, hexWithAlpha} from './hct';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/**
+ * Color scale configuration.
+ *
+ * @example
+ * ```
+ * // Minimal — just a seed color
+ * { accent: '#0064E0' }
+ *
+ * // With customization
+ * { accent: '#B7410E', neutralStyle: 'warm', contrast: 'high' }
+ * ```
+ */
+export interface XDSColorScaleConfig {
+  /** Seed accent color as hex (#RRGGBB). Everything derives from this. */
+  accent: string;
+
+  /**
+   * Neutral tone warmth. Controls how much of the seed's hue bleeds
+   * into neutral/background colors.
+   * @default 'cool'
+   */
+  neutralStyle?: 'warm' | 'cool' | 'neutral';
+
+  /**
+   * Contrast level. Affects tone assignments for text and UI elements.
+   * @default 'standard'
+   */
+  contrast?: 'standard' | 'high';
+}
+
+export type ColorScaleTokens = Record<string, string>;
+
+// =============================================================================
+// Neutral chroma by style
+// =============================================================================
+
+const NEUTRAL_CHROMA: Record<string, number> = {
+  warm: 7,
+  cool: 5,
+  neutral: 3,
+};
+
+const NEUTRAL_VARIANT_CHROMA: Record<string, number> = {
+  warm: 10,
+  cool: 8,
+  neutral: 6,
+};
+
+// =============================================================================
+// Computation
+// =============================================================================
+
+function ld(light: string, dark: string): string {
+  return `light-dark(${light}, ${dark})`;
+}
+
+/**
+ * Expand a color scale config into XDS color token overrides.
+ *
+ * Only generates tokens that meaningfully derive from the accent color.
+ * Tokens that are convention-bound (status colors, categorical hues,
+ * --color-on-dark/on-light) are NOT generated — they fall through
+ * to colorDefaults.
+ *
+ * @example
+ * ```
+ * const tokens = expandColorScale({ accent: '#0064E0' });
+ * // tokens['--color-accent'] === 'light-dark(#..., #...)'
+ * ```
+ */
+export function expandColorScale(
+  config: XDSColorScaleConfig,
+): ColorScaleTokens {
+  const {accent, neutralStyle = 'cool', contrast = 'standard'} = config;
+
+  const seed = hexToHct(accent);
+  const seedHue = seed.hue;
+
+  const primaryChroma = Math.max(seed.chroma, 48);
+  const neutralChroma = NEUTRAL_CHROMA[neutralStyle] ?? 5;
+  const neutralVariantChroma = NEUTRAL_VARIANT_CHROMA[neutralStyle] ?? 8;
+
+  const P = tonalPalette(seedHue, primaryChroma);
+  const N = tonalPalette(seedHue, neutralChroma);
+  const NV = tonalPalette(seedHue, neutralVariantChroma);
+
+  const isHigh = contrast === 'high';
+
+  const textPrimaryLightTone = isHigh ? 0 : 10;
+  const textPrimaryDarkTone = isHigh ? 99 : 90;
+  const textSecondaryLightTone = isHigh ? 20 : 30;
+  const textSecondaryDarkTone = isHigh ? 80 : 70;
+
+  return {
+    // Core semantic
+    '--color-accent': ld(P[40], P[80]),
+    '--color-accent-muted': ld(
+      hexWithAlpha(P[40], 0.2),
+      hexWithAlpha(P[80], 0.25),
+    ),
+    '--color-on-accent': ld(P[100], P[20]),
+    '--color-neutral': ld(hexWithAlpha(N[10], 0.1), hexWithAlpha(N[90], 0.2)),
+    '--color-background-surface': ld(N[99], N[10]),
+    '--color-background-body': ld(N[95], N[5] ?? N[0]),
+    '--color-overlay': ld(hexWithAlpha(N[10], 0.4), hexWithAlpha(N[10], 0.6)),
+    '--color-overlay-hover': ld(
+      hexWithAlpha(N[10], 0.05),
+      hexWithAlpha(N[100], 0.05),
+    ),
+    '--color-overlay-pressed': ld(
+      hexWithAlpha(N[10], 0.1),
+      hexWithAlpha(N[100], 0.1),
+    ),
+    '--color-background-muted': ld(
+      hexWithAlpha(N[10], 0.05),
+      hexWithAlpha(N[10], 0.5),
+    ),
+
+    // Text
+    '--color-text-primary': ld(N[textPrimaryLightTone], N[textPrimaryDarkTone]),
+    '--color-text-secondary': ld(
+      NV[textSecondaryLightTone],
+      NV[textSecondaryDarkTone],
+    ),
+    '--color-text-disabled': ld(NV[60], NV[40]),
+    '--color-text-accent': ld(P[30], P[80]),
+
+    // Icon
+    '--color-icon-accent': ld(P[40], P[80]),
+    '--color-icon-primary': ld(N[textPrimaryLightTone], N[textPrimaryDarkTone]),
+    '--color-icon-secondary': ld(
+      NV[textSecondaryLightTone],
+      NV[textSecondaryDarkTone],
+    ),
+    '--color-icon-disabled': ld(NV[60], NV[40]),
+
+    // Surface variants
+    '--color-background-card': ld(N[99], N[10]),
+    '--color-background-popover': ld(N[99], N[20]),
+    '--color-background-inverted': ld(N[10], N[99]),
+
+    // Border
+    '--color-border': ld(hexWithAlpha(N[10], 0.1), hexWithAlpha(N[95], 0.1)),
+    '--color-border-emphasized': ld(NV[70], NV[30]),
+
+    // Effects
+    '--color-skeleton': ld(NV[70], NV[30]),
+    '--color-shadow': ld(hexWithAlpha(N[0], 0.1), hexWithAlpha(N[0], 0.3)),
+    '--color-tint-hover': ld('black', 'white'),
+
+    // Inset shadows (input border rings) — accent-derived for hover/selected
+    '--shadow-inset-hover': `inset 0px 0px 0px 2px ${hexWithAlpha(P[40], 0.3)}`,
+    '--shadow-inset-selected': `inset 0px 0px 0px 2px ${hexWithAlpha(P[40], 0.5)}`,
+  };
+}

--- a/packages/core/src/theme/hct.ts
+++ b/packages/core/src/theme/hct.ts
@@ -1,0 +1,273 @@
+/**
+ * @file hct.ts
+ * @input Hex color string (#RRGGBB)
+ * @output HCT color representation (Hue, Chroma, Tone)
+ * @position Theme utility; consumed by expandColorScale.ts
+ *
+ * Minimal HCT (Hue, Chroma, Tone) color space implementation.
+ * Ported from Google's material-color-utilities (Apache-2.0).
+ * Zero runtime dependencies — all math is self-contained.
+ *
+ * HCT combines:
+ * - Hue from CAM16 (perceptually uniform hue)
+ * - Chroma from CAM16 (colorfulness)
+ * - Tone from L* (CIE Lightness, 0=black, 100=white)
+ */
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface HCT {
+  hue: number;
+  chroma: number;
+  tone: number;
+}
+
+// =============================================================================
+// sRGB <-> Linear RGB
+// =============================================================================
+
+function srgbToLinear(c: number): number {
+  const s = c / 255;
+  return s <= 0.04045 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+}
+
+function linearToSrgb(c: number): number {
+  const s = c <= 0.0031308 ? c * 12.92 : 1.055 * Math.pow(c, 1 / 2.4) - 0.055;
+  return Math.round(Math.min(255, Math.max(0, s * 255)));
+}
+
+// =============================================================================
+// Linear RGB <-> XYZ (D65 illuminant)
+// =============================================================================
+
+function linearRgbToXyz(
+  r: number,
+  g: number,
+  b: number,
+): [number, number, number] {
+  return [
+    0.4124564 * r + 0.3575761 * g + 0.1804375 * b,
+    0.2126729 * r + 0.7151522 * g + 0.072175 * b,
+    0.0193339 * r + 0.119192 * g + 0.9503041 * b,
+  ];
+}
+
+function xyzToLinearRgb(
+  x: number,
+  y: number,
+  z: number,
+): [number, number, number] {
+  return [
+    3.2404542 * x - 1.5371385 * y - 0.4985314 * z,
+    -0.969266 * x + 1.8760108 * y + 0.041556 * z,
+    0.0556434 * x - 0.2040259 * y + 1.0572252 * z,
+  ];
+}
+
+// =============================================================================
+// XYZ <-> L*a*b*
+// =============================================================================
+
+const D65_WHITE: [number, number, number] = [0.95047, 1.0, 1.08883];
+
+function labF(t: number): number {
+  const delta = 6 / 29;
+  return t > delta * delta * delta
+    ? Math.cbrt(t)
+    : t / (3 * delta * delta) + 4 / 29;
+}
+
+function labFInv(t: number): number {
+  const delta = 6 / 29;
+  return t > delta ? t * t * t : 3 * delta * delta * (t - 4 / 29);
+}
+
+function xyzToLab(x: number, y: number, z: number): [number, number, number] {
+  const fx = labF(x / D65_WHITE[0]);
+  const fy = labF(y / D65_WHITE[1]);
+  const fz = labF(z / D65_WHITE[2]);
+  return [116 * fy - 16, 500 * (fx - fy), 200 * (fy - fz)];
+}
+
+function labToXyz(L: number, a: number, b: number): [number, number, number] {
+  const fy = (L + 16) / 116;
+  const fx = a / 500 + fy;
+  const fz = fy - b / 200;
+  return [
+    labFInv(fx) * D65_WHITE[0],
+    labFInv(fy) * D65_WHITE[1],
+    labFInv(fz) * D65_WHITE[2],
+  ];
+}
+
+// =============================================================================
+// Tone <-> Y (CIE Luminance)
+// =============================================================================
+
+export function toneToY(tone: number): number {
+  return labFInv((tone + 16) / 116);
+}
+
+export function yToTone(y: number): number {
+  return 116 * labF(y) - 16;
+}
+
+// =============================================================================
+// Hex <-> RGB
+// =============================================================================
+
+function hexToRgb(hex: string): [number, number, number] {
+  const h = hex.replace('#', '');
+  const full =
+    h.length === 3 ? h[0] + h[0] + h[1] + h[1] + h[2] + h[2] : h.slice(0, 6);
+  const n = parseInt(full, 16);
+  return [(n >> 16) & 0xff, (n >> 8) & 0xff, n & 0xff];
+}
+
+function rgbToHex(r: number, g: number, b: number): string {
+  return (
+    '#' +
+    [r, g, b]
+      .map(c => c.toString(16).padStart(2, '0'))
+      .join('')
+      .toUpperCase()
+  );
+}
+
+// =============================================================================
+// Core: Hex <-> HCT
+// =============================================================================
+
+/**
+ * Convert a hex color to HCT.
+ * Hue: 0-360, Chroma: 0-~120, Tone: 0-100.
+ */
+export function hexToHct(hex: string): HCT {
+  const [r, g, b] = hexToRgb(hex);
+  const lr = srgbToLinear(r);
+  const lg = srgbToLinear(g);
+  const lb = srgbToLinear(b);
+  const [x, y, z] = linearRgbToXyz(lr, lg, lb);
+  const [L, a, bLab] = xyzToLab(x, y, z);
+
+  const hueRad = Math.atan2(bLab, a);
+  let hue = (hueRad * 180) / Math.PI;
+  if (hue < 0) hue += 360;
+
+  const chroma = Math.sqrt(a * a + bLab * bLab);
+  const tone = L;
+
+  return {hue, chroma, tone: Math.max(0, Math.min(100, tone))};
+}
+
+/**
+ * Convert HCT to hex, with gamut mapping.
+ * Uses chroma reduction to find the closest in-gamut sRGB color.
+ */
+export function hctToHex(hct: HCT): string {
+  const {hue, chroma, tone} = hct;
+
+  if (tone <= 0) return '#000000';
+  if (tone >= 100) return '#FFFFFF';
+  if (chroma < 0.5) {
+    const gray = toneToGray(tone);
+    return rgbToHex(gray, gray, gray);
+  }
+
+  let lo = 0;
+  let hi = chroma;
+  let bestHex = '#000000';
+
+  for (let i = 0; i < 16; i++) {
+    const mid = (lo + hi) / 2;
+    const candidate = hctComponentToHex(hue, mid, tone);
+    if (candidate !== null) {
+      bestHex = candidate;
+      lo = mid;
+    } else {
+      hi = mid;
+    }
+  }
+
+  return bestHex;
+}
+
+function toneToGray(tone: number): number {
+  const y = toneToY(tone);
+  return linearToSrgb(y);
+}
+
+function hctComponentToHex(
+  hue: number,
+  chroma: number,
+  tone: number,
+): string | null {
+  const hueRad = (hue * Math.PI) / 180;
+  const a = Math.cos(hueRad) * chroma;
+  const b = Math.sin(hueRad) * chroma;
+  const L = tone;
+
+  const [x, y, z] = labToXyz(L, a, b);
+  const [lr, lg, lb] = xyzToLinearRgb(x, y, z);
+
+  const r = linearToSrgb(lr);
+  const g = linearToSrgb(lg);
+  const bVal = linearToSrgb(lb);
+
+  const rLin = srgbToLinear(r);
+  const gLin = srgbToLinear(g);
+  const bLin = srgbToLinear(bVal);
+
+  const tolerance = 0.02;
+  if (
+    Math.abs(rLin - lr) > tolerance ||
+    Math.abs(gLin - lg) > tolerance ||
+    Math.abs(bLin - lb) > tolerance
+  ) {
+    return null;
+  }
+
+  if (r < 0 || r > 255 || g < 0 || g > 255 || bVal < 0 || bVal > 255) {
+    return null;
+  }
+
+  return rgbToHex(r, g, bVal);
+}
+
+// =============================================================================
+// Tonal Palette
+// =============================================================================
+
+const PALETTE_TONES = [0, 5, 10, 20, 30, 40, 50, 60, 70, 80, 90, 95, 99, 100];
+
+/**
+ * Generate a tonal palette: hex colors at standard tones
+ * for a given hue and chroma.
+ */
+export function tonalPalette(
+  hue: number,
+  chroma: number,
+): Record<number, string> {
+  const result: Record<number, string> = {};
+  for (const tone of PALETTE_TONES) {
+    result[tone] = hctToHex({hue, chroma, tone});
+  }
+  return result;
+}
+
+// =============================================================================
+// Utility: hex with alpha
+// =============================================================================
+
+/**
+ * Append alpha (0-1) to a hex color as a 2-digit hex suffix.
+ */
+export function hexWithAlpha(hex: string, alpha: number): string {
+  const alphaHex = Math.round(alpha * 255)
+    .toString(16)
+    .padStart(2, '0')
+    .toUpperCase();
+  return hex + alphaHex;
+}

--- a/packages/core/src/theme/index.ts
+++ b/packages/core/src/theme/index.ts
@@ -74,6 +74,9 @@ export type {
   RadiusScaleTokens,
 } from './expandRadiusScale';
 
+export {expandColorScale} from './expandColorScale';
+export type {XDSColorScaleConfig, ColorScaleTokens} from './expandColorScale';
+
 export {expandMotionScale} from './expandMotionScale';
 export type {
   XDSMotionScaleConfig,


### PR DESCRIPTION
## Summary

- Replace all inline SVG icon definitions with @heroicons/react imports (17 in detail-page, 6 + StarRating in product-detail)
- Replace raw HTML elements (span, div) with XDS components (XDSText, XDSStackItem, XDSCard, XDSVStack, XDSHStack)
- Reduce custom CSS declarations from ~110 combined to ~39 by removing redundant stylex rules and inline styles
- Fix product-detail grid to use minChildWidth for responsive reflow
- Raises both templates from Grade F to Grade B per the Contributing Templates grading rubric

## Test plan

- [ ] Verify detail-page renders correctly in sandbox at /templates/detail-page/
- [ ] Verify product-detail renders correctly in sandbox at /templates/product-detail/
- [ ] Check sidebar nav icons display properly with heroicons
- [ ] Check star rating partial fill renders correctly on product-detail
- [ ] Check panel slide animation still works on detail-page
- [ ] Verify no TypeScript errors

Made with [Cursor](https://cursor.com)