### PR TITLE
fix(templates): replace hardcoded token values with proper imports

### DIFF
--- a/packages/cli/templates/pages/documentation/page.tsx
+++ b/packages/cli/templates/pages/documentation/page.tsx
@@ -30,6 +30,7 @@ import {XDSIcon} from '@xds/core/Icon';
 import {XDSSection} from '@xds/core/Section';
 import {XDSCenter} from '@xds/core/Center';
 import {XDSGrid} from '@xds/core/Grid';
+import {radiusVars} from '@xds/core/theme/tokens.stylex';
 import {
   ArrowTopRightOnSquareIcon,
   ArrowsPointingOutIcon,
@@ -42,7 +43,7 @@ import {
 const styles = stylex.create({
   tabListFlush: {marginInlineStart: '-12px'},
   previewCard: {
-    borderRadius: 12,
+    borderRadius: radiusVars['--radius-container'],
     cursor: 'pointer',
   },
 });

--- a/packages/cli/templates/pages/editor/page.tsx
+++ b/packages/cli/templates/pages/editor/page.tsx
@@ -2,7 +2,7 @@
 
 import {useState, useCallback} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {colorVars, radiusVars, shadowVars} from '@xds/core/theme/tokens.stylex';
+import {colorVars, radiusVars, shadowVars, spacingVars} from '@xds/core/theme/tokens.stylex';
 import {XDSButton} from '@xds/core/Button';
 import {XDSCard} from '@xds/core/Card';
 import {XDSCenter} from '@xds/core/Center';
@@ -262,9 +262,9 @@ const editorStyles = stylex.create({
   },
   floatingPanel: {
     position: 'absolute',
-    top: 16,
-    left: 16,
-    bottom: 16,
+    top: spacingVars['--spacing-4'],
+    left: spacingVars['--spacing-4'],
+    bottom: spacingVars['--spacing-4'],
     width: 320,
     zIndex: 10,
     backgroundColor: colorVars['--color-background-card'],
@@ -273,21 +273,21 @@ const editorStyles = stylex.create({
     overflow: 'hidden',
   },
   headerPadding: {
-    paddingInline: 16,
+    paddingInline: spacingVars['--spacing-4'],
   },
   floatingPanelCollapsed: {
     bottom: 'auto',
-    paddingBlockEnd: 16,
+    paddingBlockEnd: spacingVars['--spacing-4'],
   },
   panelScroll: {
     overflowY: 'auto',
   },
   tabListWrapper: {
-    paddingInline: 4,
+    paddingInline: spacingVars['--spacing-1'],
   },
   panelContentPadding: {
-    paddingInline: 8,
-    paddingBlockEnd: 16,
+    paddingInline: spacingVars['--spacing-2'],
+    paddingBlockEnd: spacingVars['--spacing-4'],
   },
   collapseButtonEdgeComp: {
     marginInlineEnd: -8,
@@ -295,7 +295,7 @@ const editorStyles = stylex.create({
   previewArea: {
     flex: 1,
     overflowY: 'auto',
-    padding: 32,
+    padding: spacingVars['--spacing-8'],
     paddingLeft: 368,
   },
   canvas: (maxWidth: number) => ({

--- a/packages/cli/templates/pages/login-card/page.tsx
+++ b/packages/cli/templates/pages/login-card/page.tsx
@@ -50,6 +50,20 @@ export default function LoginSimple() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [loginFailed, setLoginFailed] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleLogin = () => {
+    if (!email || !password) {
+      setLoginFailed(true);
+      return;
+    }
+    setIsLoading(true);
+    setLoginFailed(false);
+    setTimeout(() => {
+      setIsLoading(false);
+      setLoginFailed(true);
+    }, 2000);
+  };
 
   return (
     <XDSCenter axis="both" xstyle={styles.page}>
@@ -121,11 +135,12 @@ export default function LoginSimple() {
 
             {/* Login button */}
             <XDSButton
-              label="Login"
+              label={isLoading ? 'Signing in…' : 'Login'}
               variant="primary"
               size="lg"
+              isDisabled={isLoading}
               xstyle={styles.fullWidth}
-              onClick={() => setLoginFailed(true)}
+              onClick={handleLogin}
             />
 
             {/* Divider */}

--- a/packages/cli/templates/pages/login-card/page.tsx
+++ b/packages/cli/templates/pages/login-card/page.tsx
@@ -17,13 +17,13 @@ import {colorVars, spacingVars} from '@xds/core/theme/tokens.stylex';
 // Brand icons — no heroicons equivalent
 
 const AppleIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg viewBox="0 0 24 24" fill="currentColor" width={16} height={16} {...props}>
+  <svg viewBox="0 0 24 24" fill="currentColor" width={16} height={16} aria-hidden="true" {...props}>
     <path d="M17.05 20.28c-.98.95-2.05.88-3.08.4-1.09-.5-2.08-.48-3.24 0-1.44.62-2.2.44-3.06-.4C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z" />
   </svg>
 );
 
 const GoogleIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg viewBox="0 0 24 24" fill="currentColor" width={16} height={16} {...props}>
+  <svg viewBox="0 0 24 24" fill="currentColor" width={16} height={16} aria-hidden="true" {...props}>
     <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 01-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" fill="#4285F4" />
     <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853" />
     <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05" />

--- a/packages/cli/templates/pages/login-card/page.tsx
+++ b/packages/cli/templates/pages/login-card/page.tsx
@@ -135,10 +135,10 @@ export default function LoginSimple() {
 
             {/* Login button */}
             <XDSButton
-              label={isLoading ? 'Signing in…' : 'Login'}
+              label="Login"
               variant="primary"
               size="lg"
-              isDisabled={isLoading}
+              isLoading={isLoading}
               xstyle={styles.fullWidth}
               onClick={handleLogin}
             />

--- a/packages/cli/templates/pages/login-split/page.tsx
+++ b/packages/cli/templates/pages/login-split/page.tsx
@@ -8,7 +8,8 @@ import {XDSCenter} from '@xds/core/Center';
 import {XDSCard} from '@xds/core/Card';
 import {XDSText} from '@xds/core/Text';
 import {XDSIcon} from '@xds/core/Icon';
-import {SquaresPlusIcon} from '@heroicons/react/24/outline';
+import {XDSEmptyState} from '@xds/core/EmptyState';
+import {SquaresPlusIcon, CheckCircleIcon} from '@heroicons/react/24/outline';
 import {XDSTextInput} from '@xds/core/TextInput';
 import {XDSButton} from '@xds/core/Button';
 import {XDSLink} from '@xds/core/Link';
@@ -65,6 +66,7 @@ export default function LoginTwoColumn() {
   const [password, setPassword] = useState('');
   const [loginFailed, setLoginFailed] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
+  const [isSuccess, setIsSuccess] = useState(false);
 
   const handleLogin = () => {
     if (!email || !password) {
@@ -75,7 +77,7 @@ export default function LoginTwoColumn() {
     setLoginFailed(false);
     setTimeout(() => {
       setIsLoading(false);
-      setLoginFailed(true);
+      setIsSuccess(true);
     }, 2000);
   };
 
@@ -94,6 +96,13 @@ export default function LoginTwoColumn() {
 
               <XDSStackItem size="fill">
                 <XDSCenter axis="vertical" height="100%">
+                  {isSuccess ? (
+                    <XDSEmptyState
+                      title="You're signed in"
+                      description="Redirecting to your dashboard…"
+                      icon={<XDSIcon icon={CheckCircleIcon} />}
+                    />
+                  ) : (
                   <XDSVStack gap={4} xstyle={styles.fullWidth}>
                     <XDSVStack gap={1}>
                       <XDSText type="display-1" as="h2">Welcome back</XDSText>
@@ -180,15 +189,18 @@ export default function LoginTwoColumn() {
                       </XDSStackItem>
                     </XDSHStack>
                   </XDSVStack>
+                  )}
                 </XDSCenter>
               </XDSStackItem>
 
+              {!isSuccess && (
               <XDSText type="supporting" color="secondary">
                 Don&apos;t have an account?{' '}
                 <XDSLink label="Sign up" href="#" type="supporting">
                   Sign up
                 </XDSLink>
               </XDSText>
+              )}
             </XDSVStack>
 
             {/* Right — Cover image */}

--- a/packages/cli/templates/pages/login-split/page.tsx
+++ b/packages/cli/templates/pages/login-split/page.tsx
@@ -86,7 +86,7 @@ export default function LoginTwoColumn() {
       <XDSVStack gap={4} hAlign="center">
         {/* Card */}
         <XDSCard padding={0} maxWidth={1000} width="100%">
-          <XDSGrid minChildWidth={360} align="stretch">
+          <XDSGrid columns={2} align="stretch">
             {/* Left — Form */}
             <XDSVStack xstyle={styles.formColumn}>
               <XDSHStack gap={2} vAlign="center">

--- a/packages/cli/templates/pages/login-split/page.tsx
+++ b/packages/cli/templates/pages/login-split/page.tsx
@@ -24,13 +24,13 @@ const COVER_IMAGE_URL =
   'https://scontent.xx.fbcdn.net/v/t39.6806-6/671925666_4495480327349179_31826850576590602_n.png?_nc_cat=108&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=nHeGVeCH7wIQ7kNvwEe_ed5&_nc_oc=AdrmcEXVuygkqWh3Gd9ap9XNslAE4LphVAtWeNXNglbrdryrAnVn7b1pI489fHosZUwgNv1UWgRTizw-6x0E48MI&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=soyKpwlpum27aTB16xwsWg&_nc_ss=7a30f&oh=00_Af2VtQRME3fzALwgGvOuScpGMWsY5hpgmGN1E4nGG6hhWQ&oe=69EC2E2B';
 
 const AppleIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg viewBox="0 0 24 24" fill="currentColor" width={16} height={16} {...props}>
+  <svg viewBox="0 0 24 24" fill="currentColor" width={16} height={16} aria-hidden="true" {...props}>
     <path d="M17.05 20.28c-.98.95-2.05.88-3.08.4-1.09-.5-2.08-.48-3.24 0-1.44.62-2.2.44-3.06-.4C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z" />
   </svg>
 );
 
 const GoogleIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg viewBox="0 0 24 24" fill="currentColor" width={16} height={16} {...props}>
+  <svg viewBox="0 0 24 24" fill="currentColor" width={16} height={16} aria-hidden="true" {...props}>
     <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 01-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" fill="#4285F4" />
     <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853" />
     <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05" />
@@ -64,6 +64,20 @@ export default function LoginTwoColumn() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [loginFailed, setLoginFailed] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleLogin = () => {
+    if (!email || !password) {
+      setLoginFailed(true);
+      return;
+    }
+    setIsLoading(true);
+    setLoginFailed(false);
+    setTimeout(() => {
+      setIsLoading(false);
+      setLoginFailed(true);
+    }, 2000);
+  };
 
   return (
     <XDSCenter axis="both" height="100dvh" xstyle={styles.page}>
@@ -138,8 +152,9 @@ export default function LoginTwoColumn() {
                       label="Login"
                       variant="primary"
                       size="lg"
+                      isLoading={isLoading}
                       xstyle={styles.fullWidth}
-                      onClick={() => setLoginFailed(true)}
+                      onClick={handleLogin}
                     />
 
                     <XDSDivider label="Or continue with" />

--- a/packages/cli/templates/pages/login-split/page.tsx
+++ b/packages/cli/templates/pages/login-split/page.tsx
@@ -100,7 +100,7 @@ export default function LoginTwoColumn() {
                     <XDSEmptyState
                       title="You're signed in"
                       description="Redirecting to your dashboard…"
-                      icon={<XDSIcon icon={CheckCircleIcon} size="xl" />}
+                      icon={<CheckCircleIcon width={48} height={48} />}
                     />
                   ) : (
                   <XDSVStack gap={4} xstyle={styles.fullWidth}>

--- a/packages/cli/templates/pages/login-split/page.tsx
+++ b/packages/cli/templates/pages/login-split/page.tsx
@@ -86,7 +86,7 @@ export default function LoginTwoColumn() {
       <XDSVStack gap={4} hAlign="center">
         {/* Card */}
         <XDSCard padding={0} maxWidth={1000} width="100%">
-          <XDSGrid columns={2} align="stretch">
+          <XDSGrid minChildWidth={360} align="stretch">
             {/* Left — Form */}
             <XDSVStack xstyle={styles.formColumn}>
               <XDSHStack gap={2} vAlign="center">

--- a/packages/cli/templates/pages/login-split/page.tsx
+++ b/packages/cli/templates/pages/login-split/page.tsx
@@ -20,9 +20,8 @@ import {
   radiusVars,
 } from '@xds/core/theme/tokens.stylex';
 
-// light-working-vertical-1 from xds_oss asset set
 const COVER_IMAGE_URL =
-  'https://scontent.xx.fbcdn.net/v/t39.6806-6/671925666_4495480327349179_31826850576590602_n.png?_nc_cat=108&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=nHeGVeCH7wIQ7kNvwEe_ed5&_nc_oc=AdrmcEXVuygkqWh3Gd9ap9XNslAE4LphVAtWeNXNglbrdryrAnVn7b1pI489fHosZUwgNv1UWgRTizw-6x0E48MI&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=soyKpwlpum27aTB16xwsWg&_nc_ss=7a30f&oh=00_Af2VtQRME3fzALwgGvOuScpGMWsY5hpgmGN1E4nGG6hhWQ&oe=69EC2E2B';
+  'https://images.unsplash.com/photo-1497366216548-37526070297c?w=800&q=80';
 
 const AppleIcon = (props: React.SVGProps<SVGSVGElement>) => (
   <svg viewBox="0 0 24 24" fill="currentColor" width={16} height={16} aria-hidden="true" {...props}>

--- a/packages/cli/templates/pages/login-split/page.tsx
+++ b/packages/cli/templates/pages/login-split/page.tsx
@@ -100,7 +100,7 @@ export default function LoginTwoColumn() {
                     <XDSEmptyState
                       title="You're signed in"
                       description="Redirecting to your dashboard…"
-                      icon={<XDSIcon icon={CheckCircleIcon} />}
+                      icon={<XDSIcon icon={CheckCircleIcon} size="xl" />}
                     />
                   ) : (
                   <XDSVStack gap={4} xstyle={styles.fullWidth}>

--- a/packages/cli/templates/pages/login-split/page.tsx
+++ b/packages/cli/templates/pages/login-split/page.tsx
@@ -20,8 +20,9 @@ import {
   radiusVars,
 } from '@xds/core/theme/tokens.stylex';
 
+// light-working-vertical-1 from xds_oss asset set
 const COVER_IMAGE_URL =
-  'https://images.unsplash.com/photo-1497366216548-37526070297c?w=800&q=80';
+  'https://scontent.xx.fbcdn.net/v/t39.6806-6/671925666_4495480327349179_31826850576590602_n.png?_nc_cat=108&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=nHeGVeCH7wIQ7kNvwEe_ed5&_nc_oc=AdrmcEXVuygkqWh3Gd9ap9XNslAE4LphVAtWeNXNglbrdryrAnVn7b1pI489fHosZUwgNv1UWgRTizw-6x0E48MI&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=soyKpwlpum27aTB16xwsWg&_nc_ss=7a30f&oh=00_Af2VtQRME3fzALwgGvOuScpGMWsY5hpgmGN1E4nGG6hhWQ&oe=69EC2E2B';
 
 const AppleIcon = (props: React.SVGProps<SVGSVGElement>) => (
   <svg viewBox="0 0 24 24" fill="currentColor" width={16} height={16} aria-hidden="true" {...props}>

--- a/packages/cli/templates/pages/login-sso/page.tsx
+++ b/packages/cli/templates/pages/login-sso/page.tsx
@@ -72,6 +72,7 @@ export default function LoginSSO() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [loginFailed, setLoginFailed] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
 
   const provider = getProvider(email);
   const emailValid = isValidEmail(email);
@@ -85,7 +86,24 @@ export default function LoginSSO() {
     }
   };
 
-  const handleBack = () => setStep('email');
+  const handleBack = () => {
+    setStep('email');
+    setLoginFailed(false);
+    setIsLoading(false);
+  };
+
+  const handleSignIn = () => {
+    if (!password) {
+      setLoginFailed(true);
+      return;
+    }
+    setIsLoading(true);
+    setLoginFailed(false);
+    setTimeout(() => {
+      setIsLoading(false);
+      setLoginFailed(true);
+    }, 2000);
+  };
 
   return (
     <XDSCenter axis="both" xstyle={styles.page}>
@@ -195,7 +213,9 @@ export default function LoginSSO() {
                         label={`Continue with ${provider.name}`}
                         variant="primary"
                         size="lg"
+                        isLoading={isLoading}
                         xstyle={styles.fullWidth}
+                        onClick={() => setIsLoading(true)}
                       />
                       <XDSButton
                         label="Use a different email"
@@ -256,8 +276,9 @@ export default function LoginSSO() {
                         label="Sign in"
                         variant="primary"
                         size="lg"
+                        isLoading={isLoading}
                         xstyle={styles.fullWidth}
-                        onClick={() => setLoginFailed(true)}
+                        onClick={handleSignIn}
                       />
                       <XDSButton
                         label="Use a different email"

--- a/packages/cli/templates/pages/login-sso/page.tsx
+++ b/packages/cli/templates/pages/login-sso/page.tsx
@@ -20,9 +20,8 @@ import {shadowVars} from '@xds/core/theme/tokens.stylex';
 // Styles
 // ---------------------------------------------------------------------------
 
-// building from xds_oss asset set
 const BG_URL =
-  'https://scontent.xx.fbcdn.net/v/t39.6806-6/673946116_928438936673086_7955596512102197644_n.jpg?_nc_cat=103&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=PVl7FEhjCusQ7kNvwEIGngs&_nc_oc=AdpqpGsFv2Z4UswEve2B2ZCHTKIXDjyDvMT-4Z3wfkVRnE3bKLbU4_DLcVEg3Z1ZVLDKyB3qEi1_KDcmHVsxDFWV&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=rUsd40W1gpadk3EzTZm5Tw&_nc_ss=7a30f&oh=00_Af1sx6n6V2eu3whVV18i5CYuQkQb_Ry2BN-V-2_DWlcWgw&oe=69EC4058';
+  'https://images.unsplash.com/photo-1486406146926-c627a92ad1ab?w=1920&q=80';
 
 const styles = stylex.create({
   page: {

--- a/packages/cli/templates/pages/login-sso/page.tsx
+++ b/packages/cli/templates/pages/login-sso/page.tsx
@@ -20,8 +20,9 @@ import {shadowVars} from '@xds/core/theme/tokens.stylex';
 // Styles
 // ---------------------------------------------------------------------------
 
+// building from xds_oss asset set
 const BG_URL =
-  'https://images.unsplash.com/photo-1486406146926-c627a92ad1ab?w=1920&q=80';
+  'https://scontent.xx.fbcdn.net/v/t39.6806-6/673946116_928438936673086_7955596512102197644_n.jpg?_nc_cat=103&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=PVl7FEhjCusQ7kNvwEIGngs&_nc_oc=AdpqpGsFv2Z4UswEve2B2ZCHTKIXDjyDvMT-4Z3wfkVRnE3bKLbU4_DLcVEg3Z1ZVLDKyB3qEi1_KDcmHVsxDFWV&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=rUsd40W1gpadk3EzTZm5Tw&_nc_ss=7a30f&oh=00_Af1sx6n6V2eu3whVV18i5CYuQkQb_Ry2BN-V-2_DWlcWgw&oe=69EC4058';
 
 const styles = stylex.create({
   page: {

--- a/packages/cli/templates/pages/login/page.tsx
+++ b/packages/cli/templates/pages/login/page.tsx
@@ -9,6 +9,7 @@ import {XDSTextInput} from '@xds/core/TextInput';
 import {XDSButton} from '@xds/core/Button';
 import {XDSCard} from '@xds/core/Card';
 import {XDSIcon} from '@xds/core/Icon';
+import {XDSBanner} from '@xds/core/Banner';
 import {CubeIcon} from '@heroicons/react/24/outline';
 import {colorVars, spacingVars} from '@xds/core/theme/tokens.stylex';
 
@@ -64,9 +65,7 @@ export default function LoginPage() {
             </XDSVStack>
 
             {error && (
-              <XDSText type="body" color="error" size="sm">
-                {error}
-              </XDSText>
+              <XDSBanner status="error" title={error} container="card" />
             )}
 
             <XDSTextInput

--- a/packages/cli/templates/pages/login/page.tsx
+++ b/packages/cli/templates/pages/login/page.tsx
@@ -27,6 +27,18 @@ const styles = stylex.create({
 export default function LoginPage() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const handleSignIn = () => {
+    setError('');
+    if (!email || !password) {
+      setError('Please enter both email and password.');
+      return;
+    }
+    setIsLoading(true);
+    setTimeout(() => setIsLoading(false), 2000);
+  };
 
   return (
     <XDSCenter axis="both" xstyle={styles.page}>
@@ -51,6 +63,12 @@ export default function LoginPage() {
               </XDSVStack>
             </XDSVStack>
 
+            {error && (
+              <XDSText type="body" color="error" size="sm">
+                {error}
+              </XDSText>
+            )}
+
             <XDSTextInput
               label="Email"
               value={email}
@@ -70,9 +88,11 @@ export default function LoginPage() {
             />
 
             <XDSButton
-              label="Sign in"
+              label={isLoading ? 'Signing in…' : 'Sign in'}
               variant="primary"
               size="lg"
+              isDisabled={isLoading}
+              onClick={handleSignIn}
               xstyle={styles.fullWidth}
             />
           </XDSVStack>

--- a/packages/cli/templates/pages/login/page.tsx
+++ b/packages/cli/templates/pages/login/page.tsx
@@ -88,10 +88,10 @@ export default function LoginPage() {
             />
 
             <XDSButton
-              label={isLoading ? 'Signing in…' : 'Sign in'}
+              label="Sign in"
               variant="primary"
               size="lg"
-              isDisabled={isLoading}
+              isLoading={isLoading}
               onClick={handleSignIn}
               xstyle={styles.fullWidth}
             />

--- a/packages/cli/templates/pages/settings-dialog/page.tsx
+++ b/packages/cli/templates/pages/settings-dialog/page.tsx
@@ -24,6 +24,7 @@ import {XDSTabList, XDSTab} from '@xds/core/TabList';
 import {XDSBadge} from '@xds/core/Badge';
 import {XDSIcon} from '@xds/core/Icon';
 import {XDSCenter} from '@xds/core/Center';
+import {colorVars, radiusVars} from '@xds/core/theme/tokens.stylex';
 import {
   UserIcon,
   LockClosedIcon,
@@ -41,8 +42,8 @@ import {
 
 const styles = stylex.create({
   iconBox: {
-    borderRadius: 12,
-    backgroundColor: 'var(--xds-color-background-surface, #fff)',
+    borderRadius: radiusVars['--radius-container'],
+    backgroundColor: colorVars['--color-background-surface'],
     flexShrink: 0,
   },
   rowPadding: {
@@ -56,7 +57,7 @@ const styles = stylex.create({
     paddingBlock: 24,
     position: 'sticky',
     top: 0,
-    backgroundColor: 'var(--xds-color-background-surface, #fff)',
+    backgroundColor: colorVars['--color-background-surface'],
     zIndex: 1,
   },
   contentHPadding: {

--- a/packages/cli/templates/pages/settings-dialog/page.tsx
+++ b/packages/cli/templates/pages/settings-dialog/page.tsx
@@ -17,6 +17,7 @@ import {XDSDialog, XDSDialogHeader} from '@xds/core/Dialog';
 import {XDSList, XDSListItem} from '@xds/core/List';
 import {XDSDivider} from '@xds/core/Divider';
 import {XDSSelector} from '@xds/core/Selector';
+import {XDSTextInput} from '@xds/core/TextInput';
 import {XDSCard} from '@xds/core/Card';
 import {XDSSwitch} from '@xds/core/Switch';
 import {XDSLink} from '@xds/core/Link';
@@ -24,7 +25,7 @@ import {XDSTabList, XDSTab} from '@xds/core/TabList';
 import {XDSBadge} from '@xds/core/Badge';
 import {XDSIcon} from '@xds/core/Icon';
 import {XDSCenter} from '@xds/core/Center';
-import {colorVars, radiusVars} from '@xds/core/theme/tokens.stylex';
+import {colorVars, radiusVars, spacingVars} from '@xds/core/theme/tokens.stylex';
 import {
   UserIcon,
   LockClosedIcon,
@@ -47,33 +48,33 @@ const styles = stylex.create({
     flexShrink: 0,
   },
   rowPadding: {
-    paddingBlock: 16,
+    paddingBlock: spacingVars['--spacing-4'],
   },
   cardContentPadding: {
-    paddingInline: 16,
+    paddingInline: spacingVars['--spacing-4'],
   },
   headerPadding: {
-    paddingInline: 24,
-    paddingBlock: 24,
+    paddingInline: spacingVars['--spacing-6'],
+    paddingBlock: spacingVars['--spacing-6'],
     position: 'sticky',
     top: 0,
     backgroundColor: colorVars['--color-background-surface'],
     zIndex: 1,
   },
   contentHPadding: {
-    paddingInline: 24,
-    paddingBlockEnd: 24,
+    paddingInline: spacingVars['--spacing-6'],
+    paddingBlockEnd: spacingVars['--spacing-6'],
     maxWidth: 680,
   },
   sideNavPadding: {
-    paddingBlock: 16,
-    paddingInline: 12,
+    paddingBlock: spacingVars['--spacing-4'],
+    paddingInline: spacingVars['--spacing-3'],
   },
   sectionHeading: {
-    paddingBlockEnd: 8,
+    paddingBlockEnd: spacingVars['--spacing-2'],
   },
   sideNavHeading: {
-    marginInline: 16,
+    marginInline: spacingVars['--spacing-4'],
   },
   dialogHeight: {
     height: '85vh',
@@ -249,6 +250,14 @@ export default function SettingsDialogTemplate() {
   const [currency, setCurrency] = useState('CAD');
   const [timezone, setTimezone] = useState('ET');
   const [activeTab, setActiveTab] = useState('login');
+
+  const [legalName, setLegalName] = useState('Alex Johnson');
+  const [preferredName, setPreferredName] = useState('');
+  const [email, setEmail] = useState('a***n@example.com');
+  const [phone, setPhone] = useState('+1 ***-***-0123');
+  const [address, setAddress] = useState('');
+  const [mailingAddress, setMailingAddress] = useState('');
+  const [emergencyContact, setEmergencyContact] = useState('Provided');
   const [readReceipts, setReadReceipts] = useState(true);
   const [searchEngines, setSearchEngines] = useState(true);
   const [showCity, setShowCity] = useState(true);
@@ -329,46 +338,109 @@ export default function SettingsDialogTemplate() {
                 {activeNav === 'Personal information' && (
                   <XDSVStack gap={6}>
                     <XDSVStack gap={0}>
-                      <InfoRowItem
+                      <ExpandableRow
                         label="Legal name"
-                        value="Alex Johnson"
-                        action="Edit"
-                      />
-                      <InfoRowItem
+                        value={legalName}
+                        isExpanded={expandedRow === 'legalName'}
+                        onEdit={() => handleEdit('legalName')}
+                        onCancel={handleCancel}
+                        onSave={handleSave}>
+                        <XDSTextInput
+                          label="Legal name"
+                          isLabelHidden
+                          value={legalName}
+                          onChange={setLegalName}
+                        />
+                      </ExpandableRow>
+                      <ExpandableRow
                         label="Preferred first name"
-                        value="Not provided"
-                        action="Add"
-                      />
-                      <InfoRowItem
+                        value={preferredName || 'Not provided'}
+                        isExpanded={expandedRow === 'preferredName'}
+                        onEdit={() => handleEdit('preferredName')}
+                        onCancel={handleCancel}
+                        onSave={handleSave}>
+                        <XDSTextInput
+                          label="Preferred first name"
+                          isLabelHidden
+                          value={preferredName}
+                          onChange={setPreferredName}
+                        />
+                      </ExpandableRow>
+                      <ExpandableRow
                         label="Email address"
-                        value="a***n@example.com"
-                        action="Edit"
-                      />
-                      <InfoRowItem
+                        value={email}
+                        isExpanded={expandedRow === 'email'}
+                        onEdit={() => handleEdit('email')}
+                        onCancel={handleCancel}
+                        onSave={handleSave}>
+                        <XDSTextInput
+                          label="Email address"
+                          isLabelHidden
+                          value={email}
+                          onChange={setEmail}
+                        />
+                      </ExpandableRow>
+                      <ExpandableRow
                         label="Phone number"
-                        value="+1 ***-***-0123"
-                        action="Edit"
-                      />
+                        value={phone}
+                        isExpanded={expandedRow === 'phone'}
+                        onEdit={() => handleEdit('phone')}
+                        onCancel={handleCancel}
+                        onSave={handleSave}>
+                        <XDSTextInput
+                          label="Phone number"
+                          isLabelHidden
+                          value={phone}
+                          onChange={setPhone}
+                        />
+                      </ExpandableRow>
                       <InfoRowItem
                         label="Identity verification"
                         value="Verified"
                         action=""
                       />
-                      <InfoRowItem
+                      <ExpandableRow
                         label="Residential address"
-                        value="Not provided"
-                        action="Add"
-                      />
-                      <InfoRowItem
+                        value={address || 'Not provided'}
+                        isExpanded={expandedRow === 'address'}
+                        onEdit={() => handleEdit('address')}
+                        onCancel={handleCancel}
+                        onSave={handleSave}>
+                        <XDSTextInput
+                          label="Residential address"
+                          isLabelHidden
+                          value={address}
+                          onChange={setAddress}
+                        />
+                      </ExpandableRow>
+                      <ExpandableRow
                         label="Mailing address"
-                        value="Not provided"
-                        action="Add"
-                      />
-                      <InfoRowItem
+                        value={mailingAddress || 'Not provided'}
+                        isExpanded={expandedRow === 'mailingAddress'}
+                        onEdit={() => handleEdit('mailingAddress')}
+                        onCancel={handleCancel}
+                        onSave={handleSave}>
+                        <XDSTextInput
+                          label="Mailing address"
+                          isLabelHidden
+                          value={mailingAddress}
+                          onChange={setMailingAddress}
+                        />
+                      </ExpandableRow>
+                      <ExpandableRow
                         label="Emergency contact"
-                        value="Provided"
-                        action="Edit"
-                      />
+                        value={emergencyContact}
+                        isExpanded={expandedRow === 'emergencyContact'}
+                        onEdit={() => handleEdit('emergencyContact')}
+                        onCancel={handleCancel}
+                        onSave={handleSave}>
+                        <XDSTextInput
+                          label="Emergency contact"
+                          isLabelHidden
+                          value={emergencyContact}
+                          onChange={setEmergencyContact}
+                        />
+                      </ExpandableRow>
                     </XDSVStack>
 
                     <XDSCard padding={0}>

--- a/packages/cli/templates/pages/settings-sidebar/page.tsx
+++ b/packages/cli/templates/pages/settings-sidebar/page.tsx
@@ -9,6 +9,7 @@ import {XDSText, XDSHeading} from '@xds/core/Text';
 import {XDSLink} from '@xds/core/Link';
 import {XDSButton} from '@xds/core/Button';
 import {XDSSelector} from '@xds/core/Selector';
+import {XDSTextInput} from '@xds/core/TextInput';
 import {XDSCard} from '@xds/core/Card';
 import {XDSSwitch} from '@xds/core/Switch';
 import {XDSDivider} from '@xds/core/Divider';
@@ -231,6 +232,14 @@ export default function SettingsSecurityTemplate() {
   const [language, setLanguage] = useState('en-CA');
   const [currency, setCurrency] = useState('CAD');
   const [timezone, setTimezone] = useState('ET');
+
+  const [legalName, setLegalName] = useState('Alex Johnson');
+  const [preferredName, setPreferredName] = useState('');
+  const [email, setEmail] = useState('a***n@example.com');
+  const [phone, setPhone] = useState('+1 ***-***-0123');
+  const [address, setAddress] = useState('');
+  const [mailingAddress, setMailingAddress] = useState('');
+  const [emergencyContact, setEmergencyContact] = useState('Provided');
 
   return (
     <XDSAppShell
@@ -461,46 +470,109 @@ export default function SettingsSecurityTemplate() {
           <XDSVStack gap={6}>
             <XDSHeading level={2}>Personal info</XDSHeading>
             <XDSVStack gap={0}>
-              <InfoRowItem
+              <ExpandableRow
                 label="Legal name"
-                value="Alex Johnson"
-                action="Edit"
-              />
-              <InfoRowItem
+                value={legalName}
+                isExpanded={expandedRow === 'legalName'}
+                onEdit={() => setExpandedRow('legalName')}
+                onCancel={() => setExpandedRow(null)}
+                onSave={() => setExpandedRow(null)}>
+                <XDSTextInput
+                  label="Legal name"
+                  isLabelHidden
+                  value={legalName}
+                  onChange={setLegalName}
+                />
+              </ExpandableRow>
+              <ExpandableRow
                 label="Preferred first name"
-                value="Not provided"
-                action="Add"
-              />
-              <InfoRowItem
+                value={preferredName || 'Not provided'}
+                isExpanded={expandedRow === 'preferredName'}
+                onEdit={() => setExpandedRow('preferredName')}
+                onCancel={() => setExpandedRow(null)}
+                onSave={() => setExpandedRow(null)}>
+                <XDSTextInput
+                  label="Preferred first name"
+                  isLabelHidden
+                  value={preferredName}
+                  onChange={setPreferredName}
+                />
+              </ExpandableRow>
+              <ExpandableRow
                 label="Email address"
-                value="a***n@example.com"
-                action="Edit"
-              />
-              <InfoRowItem
+                value={email}
+                isExpanded={expandedRow === 'email'}
+                onEdit={() => setExpandedRow('email')}
+                onCancel={() => setExpandedRow(null)}
+                onSave={() => setExpandedRow(null)}>
+                <XDSTextInput
+                  label="Email address"
+                  isLabelHidden
+                  value={email}
+                  onChange={setEmail}
+                />
+              </ExpandableRow>
+              <ExpandableRow
                 label="Phone number"
-                value="+1 ***-***-0123"
-                action="Edit"
-              />
+                value={phone}
+                isExpanded={expandedRow === 'phone'}
+                onEdit={() => setExpandedRow('phone')}
+                onCancel={() => setExpandedRow(null)}
+                onSave={() => setExpandedRow(null)}>
+                <XDSTextInput
+                  label="Phone number"
+                  isLabelHidden
+                  value={phone}
+                  onChange={setPhone}
+                />
+              </ExpandableRow>
               <InfoRowItem
                 label="Identity verification"
                 value="Verified"
                 action=""
               />
-              <InfoRowItem
+              <ExpandableRow
                 label="Residential address"
-                value="Not provided"
-                action="Add"
-              />
-              <InfoRowItem
+                value={address || 'Not provided'}
+                isExpanded={expandedRow === 'address'}
+                onEdit={() => setExpandedRow('address')}
+                onCancel={() => setExpandedRow(null)}
+                onSave={() => setExpandedRow(null)}>
+                <XDSTextInput
+                  label="Residential address"
+                  isLabelHidden
+                  value={address}
+                  onChange={setAddress}
+                />
+              </ExpandableRow>
+              <ExpandableRow
                 label="Mailing address"
-                value="Not provided"
-                action="Add"
-              />
-              <InfoRowItem
+                value={mailingAddress || 'Not provided'}
+                isExpanded={expandedRow === 'mailingAddress'}
+                onEdit={() => setExpandedRow('mailingAddress')}
+                onCancel={() => setExpandedRow(null)}
+                onSave={() => setExpandedRow(null)}>
+                <XDSTextInput
+                  label="Mailing address"
+                  isLabelHidden
+                  value={mailingAddress}
+                  onChange={setMailingAddress}
+                />
+              </ExpandableRow>
+              <ExpandableRow
                 label="Emergency contact"
-                value="Provided"
-                action="Edit"
-              />
+                value={emergencyContact}
+                isExpanded={expandedRow === 'emergencyContact'}
+                onEdit={() => setExpandedRow('emergencyContact')}
+                onCancel={() => setExpandedRow(null)}
+                onSave={() => setExpandedRow(null)}>
+                <XDSTextInput
+                  label="Emergency contact"
+                  isLabelHidden
+                  value={emergencyContact}
+                  onChange={setEmergencyContact}
+                />
+              </ExpandableRow>
             </XDSVStack>
 
             <XDSCard padding={0}>

--- a/packages/cli/templates/pages/settings-sidebar/page.tsx
+++ b/packages/cli/templates/pages/settings-sidebar/page.tsx
@@ -16,6 +16,7 @@ import {XDSTabList, XDSTab} from '@xds/core/TabList';
 import {XDSBadge} from '@xds/core/Badge';
 import {XDSIcon} from '@xds/core/Icon';
 import {XDSCenter} from '@xds/core/Center';
+import {colorVars, radiusVars} from '@xds/core/theme/tokens.stylex';
 import {
   UserIcon,
   LockClosedIcon,
@@ -33,8 +34,8 @@ import {
 
 const styles = stylex.create({
   iconBox: {
-    borderRadius: 12,
-    backgroundColor: 'var(--xds-color-background-surface, #fff)',
+    borderRadius: radiusVars['--radius-container'],
+    backgroundColor: colorVars['--color-background-surface'],
     flexShrink: 0,
   },
   rowPadding: {

--- a/packages/cli/templates/pages/settings-sidebar/page.tsx
+++ b/packages/cli/templates/pages/settings-sidebar/page.tsx
@@ -17,7 +17,7 @@ import {XDSTabList, XDSTab} from '@xds/core/TabList';
 import {XDSBadge} from '@xds/core/Badge';
 import {XDSIcon} from '@xds/core/Icon';
 import {XDSCenter} from '@xds/core/Center';
-import {colorVars, radiusVars} from '@xds/core/theme/tokens.stylex';
+import {colorVars, radiusVars, spacingVars} from '@xds/core/theme/tokens.stylex';
 import {
   UserIcon,
   LockClosedIcon,
@@ -40,29 +40,23 @@ const styles = stylex.create({
     flexShrink: 0,
   },
   rowPadding: {
-    paddingTop: 16,
-    paddingBottom: 16,
+    paddingBlock: spacingVars['--spacing-4'],
   },
   cardContentPadding: {
-    paddingLeft: 16,
-    paddingRight: 16,
+    paddingInline: spacingVars['--spacing-4'],
   },
   contentCenter: {
     maxWidth: 700,
-    marginLeft: 'auto',
-    marginRight: 'auto',
-    paddingLeft: 48,
-    paddingRight: 48,
+    minWidth: 0,
+    width: '100%',
+    paddingInline: spacingVars['--spacing-12'],
   },
   sideNavPadding: {
-    paddingTop: 16,
-    paddingBottom: 16,
-    paddingLeft: 12,
-    paddingRight: 12,
+    paddingBlock: spacingVars['--spacing-4'],
+    paddingInline: spacingVars['--spacing-3'],
   },
   sideNavHeading: {
-    marginLeft: 16,
-    marginRight: 16,
+    marginInline: spacingVars['--spacing-4'],
   },
 });
 
@@ -270,6 +264,7 @@ export default function SettingsSecurityTemplate() {
             </XDSList>
         </XDSVStack>
       }>
+      <XDSCenter axis="horizontal">
       <XDSVStack gap={0} xstyle={styles.contentCenter}>
         {activeNav === 'Login & security' && (
           <XDSVStack gap={6}>
@@ -796,6 +791,7 @@ export default function SettingsSecurityTemplate() {
           </XDSVStack>
         )}
       </XDSVStack>
+      </XDSCenter>
     </XDSAppShell>
   );
 }

--- a/packages/cli/templates/pages/settings/page.tsx
+++ b/packages/cli/templates/pages/settings/page.tsx
@@ -13,19 +13,20 @@ import {XDSCheckboxInput} from '@xds/core/CheckboxInput';
 import {XDSSection} from '@xds/core/Section';
 import {XDSTypeahead} from '@xds/core/Typeahead';
 import * as stylex from '@stylexjs/stylex';
+import {spacingVars} from '@xds/core/theme/tokens.stylex';
 import {MagnifyingGlassIcon} from '@heroicons/react/24/outline';
 import type {XDSSearchableItem, XDSSearchSource} from '@xds/core/Typeahead';
 
 const styles = stylex.create({
   constrainedShell: {
-    maxWidth: 1100,
+    maxWidth: 1440,
     marginInline: 'auto',
   },
   headerPadding: {
-    padding: 16,
+    padding: spacingVars['--spacing-4'],
   },
   sideNavWidth: {
-    minWidth: 240,
+    minWidth: 260,
   },
 });
 


### PR DESCRIPTION
## Summary

Token usage, interactivity, CSS reduction, and accessibility fixes across 9 templates, flagged in #1507.

### Settings (basic)
- Replace hardcoded `padding: 16` with `spacingVars['--spacing-4']`
- Update `maxWidth` from 1100 → 1440 and `minWidth` from 240 → 260 to match AppShell default

### Settings (sidebar)
- Replace raw CSS variable `var(--xds-color-background-surface, #fff)` with `colorVars` and hardcoded `borderRadius: 12` with `radiusVars`
- Make Personal Info rows editable using existing ExpandableRow pattern with XDSTextInput
- Reduce CSS declarations using shorthand properties, spacing tokens, and `XDSCenter`

### Settings (dialog)
- Replace all hardcoded px padding/margin values with `spacingVars` tokens
- Make Personal Info rows editable using existing ExpandableRow pattern with XDSTextInput

### Login (base)
- Add form validation (XDSBanner on empty submit) and loading state via `XDSButton isLoading`

### Login (card)
- Add form validation and loading state via `XDSButton isLoading`
- Add `aria-hidden="true"` to decorative Apple/Google SVG icons

### Login (split)
- Add form validation and loading state via `XDSButton isLoading`
- Add `aria-hidden="true"` to decorative Apple/Google SVG icons
- Add success/redirect state with `XDSEmptyState` + `CheckCircleIcon` after login

### Login (SSO)
- Add loading state via `XDSButton isLoading` on SSO confirm and password fallback buttons
- Add validation on empty password submit

### Editor
- Replace 9 hardcoded px spacing values with `spacingVars` tokens (top, left, bottom positioning, paddingInline, paddingBlockEnd, preview area padding)

### Documentation
- Replace hardcoded `borderRadius: 12` with `radiusVars['--radius-container']`

## Test plan

- [ ] Verify settings-basic renders with wider max-width (1440px) and 260px side nav
- [ ] Verify settings-sidebar Personal Info rows expand/collapse with edit, save, cancel
- [ ] Verify settings-dialog Personal Info rows expand/collapse with edit, save, cancel
- [ ] Verify login shows `XDSBanner` error on empty submit and spinner on sign in
- [ ] Verify login-card shows error, spinner, and decorative SVGs are aria-hidden
- [ ] Verify login-split shows spinner, then success state with checkmark after login
- [ ] Verify login-sso shows spinner on both SSO confirm and password fallback sign-in
- [ ] Verify editor floating panel uses theme-aware spacing
- [ ] Verify documentation preview cards render with rounded corners