### PR TITLE
revert: remove xds classNamePrefix from dist build

### DIFF
--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -39,7 +39,7 @@ export default defineConfig({
               runtimeInjection: false,
               genConditionalClasses: true,
               treeshakeCompensation: true,
-              classNamePrefix: 'xds',
+
               unstable_moduleResolution: {
                 type: 'commonJS',
                 rootDir: '.',

--- a/scripts/build-css.mjs
+++ b/scripts/build-css.mjs
@@ -5,10 +5,10 @@
  *
  * Usage: node scripts/build-css.mjs
  *
- * Compiles all source files with classNamePrefix: 'xds' to match the
- * JS dist output. The resulting CSS uses xds-prefixed class names
- * (e.g. .xds78zum5) which are distinct from product-level styles
- * that use the default 'x' prefix.
+ * This script:
+ * 1. Runs Babel with the StyleX plugin over all source files
+ * 2. Collects all StyleX rules
+ * 3. Outputs a combined xds.css with all rules in @layer xds-base
  *
  * Dist consumers import the full stylesheet:
  *   import '@xds/core/xds.css';
@@ -26,7 +26,7 @@ const ROOT = path.resolve(__dirname, '..');
 const CORE_SRC = path.resolve(ROOT, 'packages/core/src');
 const CORE_DIST = path.resolve(ROOT, 'packages/core/dist');
 
-async function collectStyleXRules() {
+async function collectStyleXCSS() {
   const files = await glob('**/*.{ts,tsx}', {
     cwd: CORE_SRC,
     absolute: true,
@@ -60,7 +60,6 @@ async function collectStyleXRules() {
               runtimeInjection: false,
               genConditionalClasses: true,
               treeshakeCompensation: true,
-              classNamePrefix: 'xds',
               unstable_moduleResolution: {
                 type: 'commonJS',
                 rootDir: ROOT,
@@ -81,11 +80,12 @@ async function collectStyleXRules() {
   }
 
   console.log(`Collected ${allRules.length} StyleX rules`);
+
   return allRules;
 }
 
 async function main() {
-  const allRules = await collectStyleXRules();
+  const allRules = await collectStyleXCSS();
 
   if (allRules.length === 0) {
     console.error('No StyleX rules found!');


### PR DESCRIPTION
## Summary

Reverts #1490. The `classNamePrefix: 'xds'` in the dist build breaks internal apps where `XDS Common` source is compiled by the app's postcss plugin with the default `x` prefix.

### The problem

In internal apps:
- Dist JS outputs `xds`-prefixed class names (`.xds78zum5`)
- PostCSS compiles xds-common source (which imports `@xds/core`) with default `x` prefix (`.x78zum5`)
- CSS rules don't match the JS class names → broken styles

### The fix

Revert dist to default `x` prefix. Both tsup (JS) and build-css (CSS) now produce `x`-prefixed output, matching what the postcss plugin generates when compiling xds-common.

The `@xds/build` source path (used in the XDS sandbox/storybook) still uses `xds` prefix internally for library/product separation — that's unaffected.

### What's needed before we can bring the xds prefix back

All consumers need to stop source-compiling `@xds/core` in their postcss and use the dist CSS instead. The migration script for that is ready (#1506 follow-up).