### PR TITLE
fix: map ?page=theme to craft view with theme tab pre-selected

### DIFF
--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
@@ -198,11 +198,21 @@ function DocsiteLandingTemplate() {
     const settings = searchParams.get('settings');
     const collection = searchParams.get('collection');
     const templateIdx = t !== null ? parseInt(t, 10) : null;
+
+    // Tab values like "theme", "components", "templates" are tabs within the
+    // craft view, not standalone pages. Map them so ?page=theme opens the craft
+    // view with the correct tab pre-selected.
+    const CRAFT_TABS = ['all', 'templates', 'theme', 'components'];
+    const isCraftTab = page !== null && CRAFT_TABS.includes(page);
+
     return {
       view: v,
       templateIdx: isNaN(templateIdx as number) ? null : templateIdx,
       query: q,
-      page: page as 'craft' | 'explore' | 'docs' | 'profile' | 'theme' | null,
+      page: isCraftTab
+        ? ('craft' as const)
+        : (page as 'craft' | 'explore' | 'docs' | 'profile' | null),
+      craftTab: isCraftTab ? page : null,
       tab:
         tab && ['Crafted', 'Used', 'Bookmarks'].includes(tab)
           ? (tab as 'Crafted' | 'Used' | 'Bookmarks')
@@ -293,7 +303,7 @@ function DocsiteLandingTemplate() {
   const [sortOption, setSortOption] = useState('trending');
   const [isFilterOpen, setIsFilterOpen] = useState(false);
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
-  const [activeTab, setActiveTab] = useState('all');
+  const [activeTab, setActiveTab] = useState(initialView.craftTab ?? 'all');
   const [isMobile, setIsMobile] = useState(false);
   const [isTablet, setIsTablet] = useState(false);
   const [generatingSource, setGeneratingSource] = useState(
@@ -363,6 +373,8 @@ function DocsiteLandingTemplate() {
       params.set('template', String(useTarget));
     } else if (craftTitle) {
       params.set('q', craftTitle);
+    } else if (activeView === 'craft' && activeTab !== 'all') {
+      params.set('page', activeTab);
     } else if (activeView !== 'craft') {
       params.set('page', activeView);
       if (activeView === 'profile') {
@@ -391,6 +403,7 @@ function DocsiteLandingTemplate() {
     useTarget,
     craftTitle,
     activeView,
+    activeTab,
     profileTab,
     profileCraftName,
     profileUsedName,


### PR DESCRIPTION
## Problem

`?page=theme` sets `activeView` to `"theme"`, but the valid view values are `'craft' | 'explore' | 'docs' | 'profile'`. Since `"theme"` doesn't match any dedicated view branch (`docs` or `profile`), the page falls through to the default craft layout — but with `activeView` stuck on an invalid value that the URL sync effect keeps writing back, so the state never self-corrects.

`theme`, `components`, and `templates` are **tabs within the craft view**, not standalone pages.

## Fix

- Detect tab values (`all`, `templates`, `theme`, `components`) in `initialView` and remap `?page=theme` → `activeView='craft'` + `activeTab='theme'`
- Initialize `activeTab` from the URL param
- Update URL sync to write tab values back as `?page=theme` so the URLs remain shareable
- Add `activeTab` to the URL sync effect's dependency array