### PR TITLE
refactor: redesign edge compensation model for toolbars

### DIFF
--- a/apps/storybook/stories/Toolbar.stories.tsx
+++ b/apps/storybook/stories/Toolbar.stories.tsx
@@ -98,11 +98,12 @@ export const ThreeSlot: Story = {
 export const StartOnly: Story = {
   args: {
     label: 'Bulk actions',
+    size: 'sm',
     startContent: (
       <>
         <XDSBadge label="3 selected" />
-        <XDSButton label="Delete" variant="ghost" size="sm" />
-        <XDSButton label="Archive" variant="ghost" size="sm" />
+        <XDSButton label="Delete" variant="ghost" />
+        <XDSButton label="Archive" variant="ghost" />
       </>
     ),
   },
@@ -126,16 +127,15 @@ export const Compact: Story = {
     size: 'sm',
     startContent: (
       <>
-        <XDSButton label="Cut" variant="ghost" size="sm" />
-        <XDSButton label="Copy" variant="ghost" size="sm" />
-        <XDSButton label="Paste" variant="ghost" size="sm" />
+        <XDSButton label="Cut" variant="ghost" />
+        <XDSButton label="Copy" variant="ghost" />
+        <XDSButton label="Paste" variant="ghost" />
       </>
     ),
     endContent: (
       <XDSButton
         label="Settings"
         variant="ghost"
-        size="sm"
         icon={<Cog6ToothIcon style={{width: 14, height: 14}} />}
         isIconOnly
       />
@@ -147,7 +147,7 @@ export const WashVariant: Story = {
   args: {
     label: 'Highlighted toolbar',
     variant: 'wash',
-    startContent: <XDSText>3 items selected</XDSText>,
+    startContent: <XDSText type="body">3 items selected</XDSText>,
     endContent: (
       <>
         <XDSButton label="Delete" variant="ghost" />
@@ -161,7 +161,7 @@ export const WashVariant: Story = {
 // Composition patterns — real-world layouts
 // ---------------------------------------------------------------------------
 
-/** Toolbar as a Card header. Full-bleed via XDSSection, compact density for card context. */
+/** Toolbar as a Card header. Compact density for card context. */
 export const InsideCard: Story = {
   name: 'Composition: Card Header',
   render: () => (
@@ -176,13 +176,11 @@ export const InsideCard: Story = {
             <XDSButton
               label="Filter"
               variant="ghost"
-              size="sm"
               icon={<FunnelIcon style={{width: 16, height: 16}} />}
               isIconOnly
             />
             <XDSButton
               label="Add user"
-              size="sm"
               icon={<PlusIcon style={{width: 16, height: 16}} />}
               isIconOnly
             />
@@ -190,7 +188,7 @@ export const InsideCard: Story = {
         }
       />
       <XDSSection>
-        <XDSText>Table rows go here...</XDSText>
+        <XDSText type="body">Table rows go here...</XDSText>
       </XDSSection>
     </XDSCard>
   ),
@@ -203,12 +201,19 @@ export const TableToolbar: Story = {
     <div style={{width: 700}}>
       <XDSToolbar
         label="Table filters"
+        size="sm"
         startContent={
           <>
-            <XDSTextInput label="Search" isLabelHidden placeholder="Search..." size="sm" />
-            <XDSButton label="Status" variant="outline" size="sm" />
-            <XDSButton label="Priority" variant="outline" size="sm" />
-            <XDSButton label="Assignee" variant="outline" size="sm" />
+            <XDSTextInput
+              label="Search"
+              isLabelHidden
+              placeholder="Search..."
+              value=""
+              onChange={() => {}}
+            />
+            <XDSButton label="Status" variant="secondary" />
+            <XDSButton label="Priority" variant="secondary" />
+            <XDSButton label="Assignee" variant="secondary" />
           </>
         }
         endContent={
@@ -237,7 +242,7 @@ export const TableToolbar: Story = {
   ),
 };
 
-/** Page-level toolbar with breadcrumbs-like back nav, centered title, and actions. */
+/** Page-level toolbar with back nav, centered title, and actions. */
 export const PageHeader: Story = {
   name: 'Composition: Page Header',
   render: () => (
@@ -262,18 +267,19 @@ export const PageHeader: Story = {
         }
       />
       <XDSSection>
-        <XDSText>Settings form content...</XDSText>
+        <XDSText type="body">Settings form content...</XDSText>
       </XDSSection>
     </XDSCard>
   ),
 };
 
-/** Bulk selection toolbar with badge count + action buttons. Appears contextually when items are selected. */
+/** Bulk selection toolbar with badge count + action buttons. */
 export const BulkActions: Story = {
   name: 'Composition: Bulk Selection',
   render: () => (
     <XDSToolbar
       label="Bulk actions"
+      size="sm"
       variant="wash"
       startContent={
         <>
@@ -281,20 +287,18 @@ export const BulkActions: Story = {
           <XDSButton
             label="Delete"
             variant="ghost"
-            size="sm"
             icon={<TrashIcon style={{width: 16, height: 16}} />}
             isIconOnly
           />
           <XDSButton
             label="Archive"
             variant="ghost"
-            size="sm"
             icon={<ArchiveBoxIcon style={{width: 16, height: 16}} />}
             isIconOnly
           />
         </>
       }
-      endContent={<XDSButton label="Deselect all" variant="ghost" size="sm" />}
+      endContent={<XDSButton label="Deselect all" variant="ghost" />}
     />
   ),
 };
@@ -314,18 +318,16 @@ export const StackedToolbars: Story = {
             <XDSButton
               label="Refresh"
               variant="ghost"
-              size="sm"
               icon={<ArrowPathIcon style={{width: 16, height: 16}} />}
               isIconOnly
             />
             <XDSButton
               label="Export"
               variant="ghost"
-              size="sm"
               icon={<ArrowDownTrayIcon style={{width: 16, height: 16}} />}
               isIconOnly
             />
-            <XDSButton label="New order" size="sm" />
+            <XDSButton label="New order" />
           </>
         }
       />
@@ -335,18 +337,22 @@ export const StackedToolbars: Story = {
         variant="wash"
         startContent={
           <>
-            <XDSTextInput label="Search orders" isLabelHidden placeholder="Search orders..." size="sm" />
-            <XDSButton label="Status" variant="outline" size="sm" />
-            <XDSButton label="Date range" variant="outline" size="sm" />
-            <XDSButton label="Customer" variant="outline" size="sm" />
+            <XDSTextInput
+              label="Search orders"
+              isLabelHidden
+              placeholder="Search orders..."
+              value=""
+              onChange={() => {}}
+            />
+            <XDSButton label="Status" variant="secondary" />
+            <XDSButton label="Date range" variant="secondary" />
+            <XDSButton label="Customer" variant="secondary" />
           </>
         }
-        endContent={
-          <XDSButton label="Clear filters" variant="ghost" size="sm" />
-        }
+        endContent={<XDSButton label="Clear filters" variant="ghost" />}
       />
       <XDSSection>
-        <XDSText>Order table rows...</XDSText>
+        <XDSText type="body">Order table rows...</XDSText>
       </XDSSection>
     </XDSCard>
   ),
@@ -370,7 +376,7 @@ export const InsideLayout: Story = {
               }
               endContent={
                 <>
-                  <XDSButton label="Notifications" variant="ghost" size="sm" />
+                  <XDSButton label="Notifications" variant="ghost" />
                   <XDSMoreMenu
                     items={[
                       {label: 'Profile'},
@@ -385,7 +391,7 @@ export const InsideLayout: Story = {
         }
         content={
           <XDSLayoutContent>
-            <XDSText>Dashboard content...</XDSText>
+            <XDSText type="body">Dashboard content...</XDSText>
           </XDSLayoutContent>
         }
       />
@@ -393,7 +399,7 @@ export const InsideLayout: Story = {
   ),
 };
 
-/** Toolbar with tab navigation on the left and action buttons on the right. Tests that tab hover targets align with buttons at each size. */
+/** Toolbar with tab navigation. Size cascades from toolbar to tabs and buttons. */
 export const WithTabNavigation: Story = {
   name: 'Composition: Tab Navigation',
   render: () => {
@@ -404,9 +410,10 @@ export const WithTabNavigation: Story = {
           <XDSCard key={size}>
             <XDSToolbar
               label={`Tab navigation (${size})`}
+              size={size}
               dividers={['bottom']}
               startContent={
-                <XDSTabList value={tab} onChange={setTab} size={size}>
+                <XDSTabList value={tab} onChange={setTab}>
                   <XDSTab value="overview" label="Overview" />
                   <XDSTab value="analytics" label="Analytics" />
                   <XDSTab value="settings" label="Settings" />
@@ -417,16 +424,15 @@ export const WithTabNavigation: Story = {
                   <XDSButton
                     label="Export"
                     variant="ghost"
-                    size={size}
                     icon={<ArrowDownTrayIcon style={{width: 16, height: 16}} />}
                     isIconOnly
                   />
-                  <XDSButton label="New item" size={size} />
+                  <XDSButton label="New item" />
                 </>
               }
             />
             <XDSSection>
-              <XDSText>Content for {size} size variant</XDSText>
+              <XDSText type="body">Content for {size} size variant</XDSText>
             </XDSSection>
           </XDSCard>
         ))}

--- a/apps/storybook/stories/ToolbarEdgeCompensation.stories.tsx
+++ b/apps/storybook/stories/ToolbarEdgeCompensation.stories.tsx
@@ -1,0 +1,1177 @@
+import {useState} from 'react';
+import type {Meta, StoryObj} from '@storybook/react';
+import {XDSToolbar} from '@xds/core/Toolbar';
+import {XDSButton} from '@xds/core/Button';
+import {XDSCard} from '@xds/core/Card';
+import {XDSSection} from '@xds/core/Section';
+import {XDSText, XDSHeading} from '@xds/core/Text';
+import {XDSTabList, XDSTab} from '@xds/core/TabList';
+import {XDSLayout} from '@xds/core/Layout';
+import {XDSLayoutHeader} from '@xds/core/Layout';
+import {XDSLayoutContent} from '@xds/core/Layout';
+import {XDSVStack} from '@xds/core/Layout';
+import {
+  Cog6ToothIcon,
+  FunnelIcon,
+  PlusIcon,
+  ArrowLeftIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  ShareIcon,
+  EllipsisHorizontalIcon,
+  MagnifyingGlassIcon,
+  BellIcon,
+  Squares2X2Icon,
+} from '@heroicons/react/24/outline';
+
+const meta: Meta<typeof XDSToolbar> = {
+  title: 'Layout/XDSToolbar/Edge Compensation',
+  component: XDSToolbar,
+  parameters: {
+    layout: 'padded',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof XDSToolbar>;
+
+function AlignmentGuide({
+  children,
+  label,
+}: {
+  children: React.ReactNode;
+  label: string;
+}) {
+  return (
+    <div>
+      <div style={{marginBottom: 8, fontSize: 12, color: '#666'}}>{label}</div>
+      {children}
+    </div>
+  );
+}
+
+function BodyContent({lines = 3}: {lines?: number}) {
+  return (
+    <XDSVStack gap={2}>
+      {Array.from({length: lines}, (_, i) => (
+        <XDSText type="body" key={i}>
+          {i === 0
+            ? 'Body content should align with the toolbar text or button labels above.'
+            : 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore.'}
+        </XDSText>
+      ))}
+    </XDSVStack>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 1. Ghost buttons at edges
+// ---------------------------------------------------------------------------
+
+/** Ghost buttons in start and end slots across all three sizes. The button text/icon should align flush with the container edge. */
+export const GhostButtonsBothEdges: Story = {
+  name: 'Ghost buttons: start + end',
+  render: () => (
+    <XDSVStack gap={4}>
+      {(['sm', 'md', 'lg'] as const).map(size => (
+        <AlignmentGuide key={size} label={`size="${size}"`}>
+          <XDSCard width={600}>
+            <XDSToolbar
+              label={`Ghost buttons ${size}`}
+              size={size}
+              dividers={['bottom']}
+              startContent={
+                <>
+                  <XDSButton
+                    label="Back"
+                    variant="ghost"
+                    icon={<ArrowLeftIcon />}
+                    isIconOnly
+                  />
+                  <XDSButton label="Edit" variant="ghost" />
+                  <XDSButton label="Share" variant="ghost" />
+                </>
+              }
+              endContent={
+                <>
+                  <XDSButton
+                    label="Filter"
+                    variant="ghost"
+                    icon={<FunnelIcon />}
+                    isIconOnly
+                  />
+                  <XDSButton
+                    label="Settings"
+                    variant="ghost"
+                    icon={<Cog6ToothIcon />}
+                    isIconOnly
+                  />
+                </>
+              }
+            />
+            <XDSSection>
+              <BodyContent />
+            </XDSSection>
+          </XDSCard>
+        </AlignmentGuide>
+      ))}
+    </XDSVStack>
+  ),
+};
+
+// ---------------------------------------------------------------------------
+// 2. Solid buttons at edges — no compensation needed
+// ---------------------------------------------------------------------------
+
+/** Solid (default) buttons at edges. These should NOT compensate — their padding is visually filled. */
+export const SolidButtonsBothEdges: Story = {
+  name: 'Solid buttons: start + end',
+  render: () => (
+    <XDSVStack gap={4}>
+      {(['sm', 'md', 'lg'] as const).map(size => (
+        <AlignmentGuide key={size} label={`size="${size}"`}>
+          <XDSCard width={600}>
+            <XDSToolbar
+              label={`Solid buttons ${size}`}
+              size={size}
+              dividers={['bottom']}
+              startContent={<XDSButton label="New item" icon={<PlusIcon />} />}
+              endContent={<XDSButton label="Save" />}
+            />
+            <XDSSection>
+              <BodyContent />
+            </XDSSection>
+          </XDSCard>
+        </AlignmentGuide>
+      ))}
+    </XDSVStack>
+  ),
+};
+
+// ---------------------------------------------------------------------------
+// 3. Mixed: ghost start, solid end
+// ---------------------------------------------------------------------------
+
+/** Ghost on start edge, solid on end. Only the start should compensate. */
+export const GhostStartSolidEnd: Story = {
+  name: 'Mixed: ghost start, solid end',
+  render: () => (
+    <XDSVStack gap={4}>
+      {(['sm', 'md', 'lg'] as const).map(size => (
+        <AlignmentGuide key={size} label={`size="${size}"`}>
+          <XDSCard width={600}>
+            <XDSToolbar
+              label={`Mixed ${size}`}
+              size={size}
+              dividers={['bottom']}
+              startContent={
+                <>
+                  <XDSButton
+                    label="Back"
+                    variant="ghost"
+                    icon={<ArrowLeftIcon />}
+                    isIconOnly
+                  />
+                  <XDSButton label="Edit" variant="ghost" />
+                </>
+              }
+              endContent={<XDSButton label="Save" />}
+            />
+            <XDSSection>
+              <BodyContent />
+            </XDSSection>
+          </XDSCard>
+        </AlignmentGuide>
+      ))}
+    </XDSVStack>
+  ),
+};
+
+// ---------------------------------------------------------------------------
+// 4. Mixed: solid start, ghost end
+// ---------------------------------------------------------------------------
+
+/** Solid on start edge, ghost on end. Only the end should compensate. */
+export const SolidStartGhostEnd: Story = {
+  name: 'Mixed: solid start, ghost end',
+  render: () => (
+    <XDSVStack gap={4}>
+      {(['sm', 'md', 'lg'] as const).map(size => (
+        <AlignmentGuide key={size} label={`size="${size}"`}>
+          <XDSCard width={600}>
+            <XDSToolbar
+              label={`Mixed ${size}`}
+              size={size}
+              dividers={['bottom']}
+              startContent={<XDSButton label="New item" icon={<PlusIcon />} />}
+              endContent={
+                <>
+                  <XDSButton
+                    label="Filter"
+                    variant="ghost"
+                    icon={<FunnelIcon />}
+                    isIconOnly
+                  />
+                  <XDSButton
+                    label="More"
+                    variant="ghost"
+                    icon={<EllipsisHorizontalIcon />}
+                    isIconOnly
+                  />
+                </>
+              }
+            />
+            <XDSSection>
+              <BodyContent />
+            </XDSSection>
+          </XDSCard>
+        </AlignmentGuide>
+      ))}
+    </XDSVStack>
+  ),
+};
+
+// ---------------------------------------------------------------------------
+// 5. Heading as start content + ghost end
+// ---------------------------------------------------------------------------
+
+/** Heading in start slot with ghost buttons at end. Check heading alignment with body text below. */
+export const HeadingStartGhostEnd: Story = {
+  name: 'Heading start + ghost end',
+  render: () => (
+    <XDSVStack gap={4}>
+      {(['sm', 'md', 'lg'] as const).map(size => (
+        <AlignmentGuide key={size} label={`size="${size}"`}>
+          <XDSCard width={600}>
+            <XDSToolbar
+              label={`Heading ${size}`}
+              size={size}
+              dividers={['bottom']}
+              startContent={<XDSHeading level={4}>Section Title</XDSHeading>}
+              endContent={
+                <>
+                  <XDSButton
+                    label="Filter"
+                    variant="ghost"
+                    icon={<FunnelIcon />}
+                    isIconOnly
+                  />
+                  <XDSButton
+                    label="Add"
+                    variant="ghost"
+                    icon={<PlusIcon />}
+                    isIconOnly
+                  />
+                </>
+              }
+            />
+            <XDSSection>
+              <BodyContent />
+            </XDSSection>
+          </XDSCard>
+        </AlignmentGuide>
+      ))}
+    </XDSVStack>
+  ),
+};
+
+// ---------------------------------------------------------------------------
+// 6. Text as start content + ghost end
+// ---------------------------------------------------------------------------
+
+/** Text (not heading) in start slot with ghost buttons. */
+export const TextStartGhostEnd: Story = {
+  name: 'Text start + ghost end',
+  render: () => (
+    <XDSCard width={600}>
+      <XDSToolbar
+        label="Text start"
+        dividers={['bottom']}
+        startContent={
+          <XDSText type="body" weight="bold">
+            3 items selected
+          </XDSText>
+        }
+        endContent={
+          <>
+            <XDSButton label="Delete" variant="ghost" />
+            <XDSButton label="Archive" variant="ghost" />
+          </>
+        }
+      />
+      <XDSSection>
+        <BodyContent />
+      </XDSSection>
+    </XDSCard>
+  ),
+};
+
+// ---------------------------------------------------------------------------
+// 7. Heading start + solid end
+// ---------------------------------------------------------------------------
+
+/** Heading on start, solid on end. No edge compensation on buttons — check heading vs body alignment. */
+export const HeadingStartSolidEnd: Story = {
+  name: 'Heading start + solid end',
+  render: () => (
+    <XDSCard width={600}>
+      <XDSToolbar
+        label="Heading solid"
+        dividers={['bottom']}
+        startContent={<XDSHeading level={4}>Project Settings</XDSHeading>}
+        endContent={<XDSButton label="Save changes" />}
+      />
+      <XDSSection>
+        <BodyContent />
+      </XDSSection>
+    </XDSCard>
+  ),
+};
+
+// ---------------------------------------------------------------------------
+// 8. Layout WITHOUT contentWidth — toolbar full bleed
+// ---------------------------------------------------------------------------
+
+/** Toolbar in XDSLayout header, no contentWidth. Full-width toolbar, edge compensation normal. */
+export const LayoutNoContentWidth: Story = {
+  name: 'Layout: no contentWidth, ghost buttons',
+  render: () => (
+    <div style={{height: 400, border: '1px solid #e0e0e0', borderRadius: 8}}>
+      <XDSLayout
+        header={
+          <XDSLayoutHeader hasDivider padding={0}>
+            <XDSToolbar
+              label="App header"
+              startContent={
+                <>
+                  <XDSButton
+                    label="Menu"
+                    variant="ghost"
+                    icon={<Squares2X2Icon />}
+                    isIconOnly
+                  />
+                  <XDSHeading level={4}>Dashboard</XDSHeading>
+                </>
+              }
+              endContent={
+                <>
+                  <XDSButton
+                    label="Search"
+                    variant="ghost"
+                    icon={<MagnifyingGlassIcon />}
+                    isIconOnly
+                  />
+                  <XDSButton
+                    label="Notifications"
+                    variant="ghost"
+                    icon={<BellIcon />}
+                    isIconOnly
+                  />
+                  <XDSButton
+                    label="Settings"
+                    variant="ghost"
+                    icon={<Cog6ToothIcon />}
+                    isIconOnly
+                  />
+                </>
+              }
+            />
+          </XDSLayoutHeader>
+        }
+        content={
+          <XDSLayoutContent>
+            <BodyContent lines={6} />
+          </XDSLayoutContent>
+        }
+      />
+    </div>
+  ),
+};
+
+/** Same without contentWidth but solid buttons for baseline comparison. */
+export const LayoutNoContentWidthSolid: Story = {
+  name: 'Layout: no contentWidth, solid buttons',
+  render: () => (
+    <div style={{height: 400, border: '1px solid #e0e0e0', borderRadius: 8}}>
+      <XDSLayout
+        header={
+          <XDSLayoutHeader hasDivider padding={0}>
+            <XDSToolbar
+              label="App header"
+              startContent={<XDSHeading level={4}>Dashboard</XDSHeading>}
+              endContent={
+                <>
+                  <XDSButton label="Cancel" variant="secondary" />
+                  <XDSButton label="Save" />
+                </>
+              }
+            />
+          </XDSLayoutHeader>
+        }
+        content={
+          <XDSLayoutContent>
+            <BodyContent lines={6} />
+          </XDSLayoutContent>
+        }
+      />
+    </div>
+  ),
+};
+
+// ---------------------------------------------------------------------------
+// 9. Layout WITH contentWidth — the critical case
+// ---------------------------------------------------------------------------
+
+/** Toolbar in XDSLayout with contentWidth=640. Header is full bleed, body is constrained. Ghost buttons should still align flush. */
+export const LayoutWithContentWidth: Story = {
+  name: 'Layout: contentWidth=640, ghost buttons',
+  render: () => (
+    <div style={{height: 400, border: '1px solid #e0e0e0', borderRadius: 8}}>
+      <XDSLayout
+        contentWidth={640}
+        header={
+          <XDSLayoutHeader hasDivider padding={0}>
+            <XDSToolbar
+              label="Page header"
+              startContent={
+                <>
+                  <XDSButton
+                    label="Back"
+                    variant="ghost"
+                    icon={<ArrowLeftIcon />}
+                    isIconOnly
+                  />
+                  <XDSHeading level={4}>Settings</XDSHeading>
+                </>
+              }
+              endContent={
+                <>
+                  <XDSButton
+                    label="Search"
+                    variant="ghost"
+                    icon={<MagnifyingGlassIcon />}
+                    isIconOnly
+                  />
+                  <XDSButton
+                    label="More"
+                    variant="ghost"
+                    icon={<EllipsisHorizontalIcon />}
+                    isIconOnly
+                  />
+                </>
+              }
+            />
+          </XDSLayoutHeader>
+        }
+        content={
+          <XDSLayoutContent>
+            <BodyContent lines={6} />
+          </XDSLayoutContent>
+        }
+      />
+    </div>
+  ),
+};
+
+/** Same with contentWidth but solid buttons for comparison. */
+export const LayoutWithContentWidthSolid: Story = {
+  name: 'Layout: contentWidth=640, solid buttons',
+  render: () => (
+    <div style={{height: 400, border: '1px solid #e0e0e0', borderRadius: 8}}>
+      <XDSLayout
+        contentWidth={640}
+        header={
+          <XDSLayoutHeader hasDivider padding={0}>
+            <XDSToolbar
+              label="Page header"
+              startContent={<XDSHeading level={4}>Settings</XDSHeading>}
+              endContent={
+                <>
+                  <XDSButton label="Cancel" variant="secondary" />
+                  <XDSButton label="Save" />
+                </>
+              }
+            />
+          </XDSLayoutHeader>
+        }
+        content={
+          <XDSLayoutContent>
+            <BodyContent lines={6} />
+          </XDSLayoutContent>
+        }
+      />
+    </div>
+  ),
+};
+
+/** Mixed ghost/solid with contentWidth — ghost start, solid end. */
+export const LayoutWithContentWidthMixed: Story = {
+  name: 'Layout: contentWidth=640, mixed',
+  render: () => (
+    <div style={{height: 400, border: '1px solid #e0e0e0', borderRadius: 8}}>
+      <XDSLayout
+        contentWidth={640}
+        header={
+          <XDSLayoutHeader hasDivider padding={0}>
+            <XDSToolbar
+              label="Page header"
+              startContent={
+                <>
+                  <XDSButton
+                    label="Back"
+                    variant="ghost"
+                    icon={<ArrowLeftIcon />}
+                    isIconOnly
+                  />
+                  <XDSHeading level={4}>Edit Project</XDSHeading>
+                </>
+              }
+              endContent={<XDSButton label="Save changes" />}
+            />
+          </XDSLayoutHeader>
+        }
+        content={
+          <XDSLayoutContent>
+            <BodyContent lines={6} />
+          </XDSLayoutContent>
+        }
+      />
+    </div>
+  ),
+};
+
+// ---------------------------------------------------------------------------
+// 10. Wider contentWidth
+// ---------------------------------------------------------------------------
+
+/** contentWidth=960, ghost buttons. Common for dashboards. */
+export const LayoutContentWidth960: Story = {
+  name: 'Layout: contentWidth=960, ghost buttons',
+  render: () => (
+    <div style={{height: 400, border: '1px solid #e0e0e0', borderRadius: 8}}>
+      <XDSLayout
+        contentWidth={960}
+        header={
+          <XDSLayoutHeader hasDivider padding={0}>
+            <XDSToolbar
+              label="Dashboard header"
+              startContent={
+                <>
+                  <XDSButton
+                    label="Back"
+                    variant="ghost"
+                    icon={<ChevronLeftIcon />}
+                    isIconOnly
+                  />
+                  <XDSHeading level={4}>Analytics Dashboard</XDSHeading>
+                </>
+              }
+              endContent={
+                <>
+                  <XDSButton
+                    label="Share"
+                    variant="ghost"
+                    icon={<ShareIcon />}
+                    isIconOnly
+                  />
+                  <XDSButton
+                    label="Settings"
+                    variant="ghost"
+                    icon={<Cog6ToothIcon />}
+                    isIconOnly
+                  />
+                </>
+              }
+            />
+          </XDSLayoutHeader>
+        }
+        content={
+          <XDSLayoutContent>
+            <BodyContent lines={6} />
+          </XDSLayoutContent>
+        }
+      />
+    </div>
+  ),
+};
+
+// ---------------------------------------------------------------------------
+// 11. Layout with padding prop
+// ---------------------------------------------------------------------------
+
+/** Layout with padding=4 and ghost toolbar. Layout outer padding interacts with toolbar edge compensation. */
+export const LayoutWithPadding: Story = {
+  name: 'Layout: padding=4, ghost buttons',
+  render: () => (
+    <div style={{height: 400, border: '1px solid #e0e0e0', borderRadius: 8}}>
+      <XDSLayout
+        padding={4}
+        header={
+          <XDSLayoutHeader hasDivider padding={0}>
+            <XDSToolbar
+              label="Padded layout header"
+              startContent={
+                <>
+                  <XDSButton
+                    label="Back"
+                    variant="ghost"
+                    icon={<ArrowLeftIcon />}
+                    isIconOnly
+                  />
+                  <XDSHeading level={4}>Padded Layout</XDSHeading>
+                </>
+              }
+              endContent={
+                <XDSButton
+                  label="Settings"
+                  variant="ghost"
+                  icon={<Cog6ToothIcon />}
+                  isIconOnly
+                />
+              }
+            />
+          </XDSLayoutHeader>
+        }
+        content={
+          <XDSLayoutContent>
+            <BodyContent lines={6} />
+          </XDSLayoutContent>
+        }
+      />
+    </div>
+  ),
+};
+
+/** Layout with padding + contentWidth together. Both constraints active. */
+export const LayoutWithPaddingAndContentWidth: Story = {
+  name: 'Layout: padding=4 + contentWidth=640',
+  render: () => (
+    <div style={{height: 400, border: '1px solid #e0e0e0', borderRadius: 8}}>
+      <XDSLayout
+        padding={4}
+        contentWidth={640}
+        header={
+          <XDSLayoutHeader hasDivider padding={0}>
+            <XDSToolbar
+              label="Padded constrained header"
+              startContent={
+                <>
+                  <XDSButton
+                    label="Back"
+                    variant="ghost"
+                    icon={<ArrowLeftIcon />}
+                    isIconOnly
+                  />
+                  <XDSHeading level={4}>Constrained + Padded</XDSHeading>
+                </>
+              }
+              endContent={
+                <>
+                  <XDSButton
+                    label="Share"
+                    variant="ghost"
+                    icon={<ShareIcon />}
+                    isIconOnly
+                  />
+                  <XDSButton
+                    label="Settings"
+                    variant="ghost"
+                    icon={<Cog6ToothIcon />}
+                    isIconOnly
+                  />
+                </>
+              }
+            />
+          </XDSLayoutHeader>
+        }
+        content={
+          <XDSLayoutContent>
+            <BodyContent lines={6} />
+          </XDSLayoutContent>
+        }
+      />
+    </div>
+  ),
+};
+
+// ---------------------------------------------------------------------------
+// 12. LayoutHeader with default padding (not padding={0}) — double padding?
+// ---------------------------------------------------------------------------
+
+/** Toolbar inside LayoutHeader using the header's default padding (not padding={0}). Potential double-padding issue. */
+export const LayoutHeaderDefaultPadding: Story = {
+  name: 'Layout: header default padding + toolbar',
+  render: () => (
+    <div style={{height: 400, border: '1px solid #e0e0e0', borderRadius: 8}}>
+      <XDSLayout
+        header={
+          <XDSLayoutHeader hasDivider>
+            <XDSToolbar
+              label="Double padded?"
+              startContent={
+                <>
+                  <XDSButton
+                    label="Back"
+                    variant="ghost"
+                    icon={<ArrowLeftIcon />}
+                    isIconOnly
+                  />
+                  <XDSHeading level={4}>Double Padding Check</XDSHeading>
+                </>
+              }
+              endContent={
+                <XDSButton
+                  label="Settings"
+                  variant="ghost"
+                  icon={<Cog6ToothIcon />}
+                  isIconOnly
+                />
+              }
+            />
+          </XDSLayoutHeader>
+        }
+        content={
+          <XDSLayoutContent>
+            <BodyContent lines={4} />
+          </XDSLayoutContent>
+        }
+      />
+    </div>
+  ),
+};
+
+// ---------------------------------------------------------------------------
+// 13. Side-by-side comparison
+// ---------------------------------------------------------------------------
+
+/** Direct visual comparison: ghost vs solid, with body content for alignment reference. */
+export const SideBySideComparison: Story = {
+  name: 'Comparison: ghost vs solid alignment',
+  render: () => (
+    <div style={{display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 24}}>
+      <AlignmentGuide label="Ghost buttons (should align flush)">
+        <XDSCard>
+          <XDSToolbar
+            label="Ghost"
+            dividers={['bottom']}
+            startContent={
+              <>
+                <XDSButton
+                  label="Back"
+                  variant="ghost"
+                  icon={<ArrowLeftIcon />}
+                  isIconOnly
+                />
+                <XDSButton label="Edit" variant="ghost" />
+              </>
+            }
+            endContent={
+              <XDSButton
+                label="More"
+                variant="ghost"
+                icon={<EllipsisHorizontalIcon />}
+                isIconOnly
+              />
+            }
+          />
+          <XDSSection>
+            <BodyContent />
+          </XDSSection>
+        </XDSCard>
+      </AlignmentGuide>
+      <AlignmentGuide label="Solid buttons (natural padding)">
+        <XDSCard>
+          <XDSToolbar
+            label="Solid"
+            dividers={['bottom']}
+            startContent={<XDSButton label="New" icon={<PlusIcon />} />}
+            endContent={<XDSButton label="Save" />}
+          />
+          <XDSSection>
+            <BodyContent />
+          </XDSSection>
+        </XDSCard>
+      </AlignmentGuide>
+    </div>
+  ),
+};
+
+// ---------------------------------------------------------------------------
+// 14. Three-slot with ghost edges
+// ---------------------------------------------------------------------------
+
+/** Three-slot (center content) with ghost buttons at both edges. Center stays centered. */
+export const ThreeSlotGhostEdges: Story = {
+  name: 'Three-slot: ghost edges + center heading',
+  render: () => (
+    <XDSVStack gap={4}>
+      {(['sm', 'md', 'lg'] as const).map(size => (
+        <AlignmentGuide key={size} label={`size="${size}"`}>
+          <XDSCard width={700}>
+            <XDSToolbar
+              label={`Three slot ${size}`}
+              size={size}
+              dividers={['bottom']}
+              startContent={
+                <XDSButton
+                  label="Back"
+                  variant="ghost"
+                  icon={<ChevronLeftIcon />}
+                  isIconOnly
+                />
+              }
+              centerContent={<XDSHeading level={4}>Document Title</XDSHeading>}
+              endContent={
+                <>
+                  <XDSButton
+                    label="Share"
+                    variant="ghost"
+                    icon={<ShareIcon />}
+                    isIconOnly
+                  />
+                  <XDSButton
+                    label="More"
+                    variant="ghost"
+                    icon={<EllipsisHorizontalIcon />}
+                    isIconOnly
+                  />
+                </>
+              }
+            />
+            <XDSSection>
+              <BodyContent />
+            </XDSSection>
+          </XDSCard>
+        </AlignmentGuide>
+      ))}
+    </XDSVStack>
+  ),
+};
+
+// ---------------------------------------------------------------------------
+// 15. Three-slot with mixed ghost/solid
+// ---------------------------------------------------------------------------
+
+/** Three-slot: ghost start, center heading, solid end. */
+export const ThreeSlotMixed: Story = {
+  name: 'Three-slot: ghost start, solid end',
+  render: () => (
+    <XDSCard width={700}>
+      <XDSToolbar
+        label="Mixed three slot"
+        dividers={['bottom']}
+        startContent={
+          <XDSButton
+            label="Back"
+            variant="ghost"
+            icon={<ChevronLeftIcon />}
+            isIconOnly
+          />
+        }
+        centerContent={<XDSHeading level={4}>Page Title</XDSHeading>}
+        endContent={
+          <>
+            <XDSButton label="Cancel" variant="secondary" />
+            <XDSButton label="Publish" />
+          </>
+        }
+      />
+      <XDSSection>
+        <BodyContent />
+      </XDSSection>
+    </XDSCard>
+  ),
+};
+
+// ---------------------------------------------------------------------------
+// 16. Stress test: stacked variants
+// ---------------------------------------------------------------------------
+
+/** Multiple toolbars stacked — checks edge compensation consistency across adjacent toolbars with different content types. */
+export const StackedVariants: Story = {
+  name: 'Stress: stacked toolbar variants',
+  render: () => (
+    <XDSCard width={700}>
+      <XDSToolbar
+        label="Ghost both"
+        size="sm"
+        dividers={['bottom']}
+        startContent={
+          <>
+            <XDSButton
+              label="Back"
+              variant="ghost"
+              icon={<ArrowLeftIcon />}
+              isIconOnly
+            />
+            <XDSHeading level={4}>Ghost + Heading</XDSHeading>
+          </>
+        }
+        endContent={
+          <XDSButton
+            label="Settings"
+            variant="ghost"
+            icon={<Cog6ToothIcon />}
+            isIconOnly
+          />
+        }
+      />
+      <XDSToolbar
+        label="Solid both"
+        size="sm"
+        dividers={['bottom']}
+        startContent={<XDSButton label="Add" size="sm" icon={<PlusIcon />} />}
+        endContent={<XDSButton label="Save" size="sm" />}
+      />
+      <XDSToolbar
+        label="Ghost start solid end"
+        size="sm"
+        dividers={['bottom']}
+        startContent={
+          <XDSButton
+            label="Back"
+            variant="ghost"
+            icon={<ChevronLeftIcon />}
+            isIconOnly
+          />
+        }
+        endContent={
+          <XDSButton label="Next" size="sm" icon={<ChevronRightIcon />} />
+        }
+      />
+      <XDSToolbar
+        label="Text start ghost end"
+        size="sm"
+        dividers={['bottom']}
+        startContent={
+          <XDSText type="body" weight="bold">
+            Selection mode
+          </XDSText>
+        }
+        endContent={<XDSButton label="Done" variant="ghost" />}
+      />
+      <XDSSection>
+        <BodyContent lines={2} />
+      </XDSSection>
+    </XDSCard>
+  ),
+};
+
+// ---------------------------------------------------------------------------
+// 17. Card > Layout with contentWidth > toolbar as header
+// ---------------------------------------------------------------------------
+
+/** Card wrapping a Layout with contentWidth. Toolbar lives in the LayoutHeader. Tests the full nesting chain: Card padding → Layout bleed → contentWidth constraint → toolbar edge compensation. */
+export const CardLayoutContentWidthToolbar: Story = {
+  name: 'Card > Layout(contentWidth) > Toolbar header',
+  render: () => (
+    <XDSVStack gap={4}>
+      <AlignmentGuide label="contentWidth=640, ghost buttons">
+        <XDSCard width={900}>
+          <XDSLayout
+            contentWidth={640}
+            header={
+              <XDSLayoutHeader hasDivider padding={0}>
+                <XDSToolbar
+                  label="Card layout header"
+                  startContent={
+                    <>
+                      <XDSButton
+                        label="Back"
+                        variant="ghost"
+                        icon={<ArrowLeftIcon />}
+                        isIconOnly
+                      />
+                      <XDSHeading level={4}>Project Settings</XDSHeading>
+                    </>
+                  }
+                  endContent={
+                    <>
+                      <XDSButton
+                        label="Search"
+                        variant="ghost"
+                        icon={<MagnifyingGlassIcon />}
+                        isIconOnly
+                      />
+                      <XDSButton
+                        label="Settings"
+                        variant="ghost"
+                        icon={<Cog6ToothIcon />}
+                        isIconOnly
+                      />
+                    </>
+                  }
+                />
+              </XDSLayoutHeader>
+            }
+            content={
+              <XDSLayoutContent>
+                <BodyContent lines={4} />
+              </XDSLayoutContent>
+            }
+          />
+        </XDSCard>
+      </AlignmentGuide>
+      <AlignmentGuide label="contentWidth=640, mixed (ghost start, solid end)">
+        <XDSCard width={900}>
+          <XDSLayout
+            contentWidth={640}
+            header={
+              <XDSLayoutHeader hasDivider padding={0}>
+                <XDSToolbar
+                  label="Card layout header"
+                  startContent={
+                    <>
+                      <XDSButton
+                        label="Back"
+                        variant="ghost"
+                        icon={<ArrowLeftIcon />}
+                        isIconOnly
+                      />
+                      <XDSHeading level={4}>Edit Document</XDSHeading>
+                    </>
+                  }
+                  endContent={<XDSButton label="Save changes" />}
+                />
+              </XDSLayoutHeader>
+            }
+            content={
+              <XDSLayoutContent>
+                <BodyContent lines={4} />
+              </XDSLayoutContent>
+            }
+          />
+        </XDSCard>
+      </AlignmentGuide>
+      <AlignmentGuide label="contentWidth=640, heading start, no end">
+        <XDSCard width={900}>
+          <XDSLayout
+            contentWidth={640}
+            header={
+              <XDSLayoutHeader hasDivider padding={0}>
+                <XDSToolbar
+                  label="Card layout header"
+                  startContent={
+                    <XDSHeading level={4}>Notifications</XDSHeading>
+                  }
+                />
+              </XDSLayoutHeader>
+            }
+            content={
+              <XDSLayoutContent>
+                <BodyContent lines={4} />
+              </XDSLayoutContent>
+            }
+          />
+        </XDSCard>
+      </AlignmentGuide>
+    </XDSVStack>
+  ),
+};
+
+// ---------------------------------------------------------------------------
+// 18. Card(padding=3/12px) > Layout > toolbar header + body text
+// ---------------------------------------------------------------------------
+
+/** Card with 12px padding wrapping a Layout. Toolbar in header, body text in content. Tests that toolbar edge compensation aligns with body text when the card has non-default (smaller) padding. */
+export const CardSmallPaddingLayoutToolbar: Story = {
+  name: 'Card(12px) > Layout > Toolbar + body',
+  render: () => (
+    <XDSCard width={700} padding={3}>
+      <XDSLayout
+        header={
+          <XDSLayoutHeader hasDivider padding={0}>
+            <XDSToolbar
+              label="Card header"
+              startContent={
+                <>
+                  <XDSButton
+                    label="Back"
+                    variant="ghost"
+                    icon={<ArrowLeftIcon />}
+                    isIconOnly
+                  />
+                  <XDSHeading level={4}>Project Settings</XDSHeading>
+                </>
+              }
+              endContent={
+                <>
+                  <XDSButton
+                    label="Search"
+                    variant="ghost"
+                    icon={<MagnifyingGlassIcon />}
+                    isIconOnly
+                  />
+                  <XDSButton
+                    label="Settings"
+                    variant="ghost"
+                    icon={<Cog6ToothIcon />}
+                    isIconOnly
+                  />
+                </>
+              }
+            />
+          </XDSLayoutHeader>
+        }
+        content={
+          <XDSLayoutContent>
+            <BodyContent lines={4} />
+          </XDSLayoutContent>
+        }
+      />
+    </XDSCard>
+  ),
+};
+
+// ---------------------------------------------------------------------------
+// 19. Toolbar with TabList — size cascades from toolbar
+// ---------------------------------------------------------------------------
+
+/** Toolbar with tab navigation. Size prop on toolbar cascades to tabs and buttons via XDSSizeContext. */
+export const WithTabs: Story = {
+  name: 'Tabs in toolbar (all sizes)',
+  render: () => {
+    const [tab, setTab] = useState('overview');
+    return (
+      <XDSVStack gap={4}>
+        {(['sm', 'md', 'lg'] as const).map(size => (
+          <AlignmentGuide key={size} label={`size="${size}"`}>
+            <XDSCard width={700}>
+              <XDSToolbar
+                label={`Tab toolbar ${size}`}
+                size={size}
+                dividers={['bottom']}
+                startContent={
+                  <XDSTabList value={tab} onChange={setTab}>
+                    <XDSTab value="overview" label="Overview" />
+                    <XDSTab value="analytics" label="Analytics" />
+                    <XDSTab value="settings" label="Settings" />
+                  </XDSTabList>
+                }
+                endContent={
+                  <>
+                    <XDSButton
+                      label="Filter"
+                      variant="ghost"
+                      icon={<FunnelIcon />}
+                      isIconOnly
+                    />
+                    <XDSButton
+                      label="Add"
+                      variant="ghost"
+                      icon={<PlusIcon />}
+                      isIconOnly
+                    />
+                  </>
+                }
+              />
+              <XDSSection>
+                <BodyContent />
+              </XDSSection>
+            </XDSCard>
+          </AlignmentGuide>
+        ))}
+      </XDSVStack>
+    );
+  },
+};

--- a/packages/cli/templates/pages/editor/page.tsx
+++ b/packages/cli/templates/pages/editor/page.tsx
@@ -2,19 +2,13 @@
 
 import {useState, useCallback} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {colorVars, radiusVars, shadowVars, spacingVars} from '@xds/core/theme/tokens.stylex';
+import {colorVars, radiusVars, shadowVars} from '@xds/core/theme/tokens.stylex';
 import {XDSButton} from '@xds/core/Button';
 import {XDSCard} from '@xds/core/Card';
 import {XDSCenter} from '@xds/core/Center';
 import {XDSDivider} from '@xds/core/Divider';
 import {XDSEmptyState} from '@xds/core/EmptyState';
-import {
-  XDSHStack,
-  XDSVStack,
-  XDSStackItem,
-  XDSLayout,
-  XDSLayoutContent,
-} from '@xds/core/Layout';
+import {XDSHStack, XDSVStack} from '@xds/core/Layout';
 import {XDSIcon} from '@xds/core/Icon';
 import {XDSList, XDSListItem} from '@xds/core/List';
 import {XDSTable} from '@xds/core/Table';
@@ -110,12 +104,14 @@ const TRANSACTION_COLUMNS: XDSTableColumn<Transaction>[] = [
     header: 'Transaction',
     renderCell: (item: Transaction) => (
       <XDSHStack gap={3} vAlign="center">
-        <XDSIcon
-          icon={CATEGORY_ICONS[item.category] || SparklesIcon}
-        />
+        <XDSIcon icon={CATEGORY_ICONS[item.category] || SparklesIcon} />
         <XDSVStack gap={0}>
-          <XDSText type="label" weight="semibold">{item.name}</XDSText>
-          <XDSText type="supporting" color="secondary">{item.category}</XDSText>
+          <XDSText type="label" weight="semibold">
+            {item.name}
+          </XDSText>
+          <XDSText type="supporting" color="secondary">
+            {item.category}
+          </XDSText>
         </XDSVStack>
       </XDSHStack>
     ),
@@ -124,7 +120,9 @@ const TRANSACTION_COLUMNS: XDSTableColumn<Transaction>[] = [
     key: 'date',
     header: 'Date',
     renderCell: (item: Transaction) => (
-      <XDSText type="body" color="secondary">{item.date}</XDSText>
+      <XDSText type="body" color="secondary">
+        {item.date}
+      </XDSText>
     ),
   },
   {
@@ -175,11 +173,42 @@ const DEFAULT_BLOCKS: Block[] = [
       heading: 'Recent Transactions',
       description: 'Your latest account activity.',
       items: [
-        {id: 't1', name: 'Blue Bottle Coffee', category: 'Food & Drink', date: 'Today, 10:24 AM', amount: '-$6.50'},
-        {id: 't2', name: 'Whole Foods Market', category: 'Groceries', date: 'Yesterday', amount: '-$142.30'},
-        {id: 't3', name: 'Stripe Payout', category: 'Income', date: 'Oct 12', amount: '+$4,200.00', isPositive: true},
-        {id: 't4', name: 'Uber Technologies', category: 'Transport', date: 'Oct 11', amount: '-$24.10'},
-        {id: 't5', name: 'Netflix Subscription', category: 'Entertainment', date: 'Oct 10', amount: '-$19.99'},
+        {
+          id: 't1',
+          name: 'Blue Bottle Coffee',
+          category: 'Food & Drink',
+          date: 'Today, 10:24 AM',
+          amount: '-$6.50',
+        },
+        {
+          id: 't2',
+          name: 'Whole Foods Market',
+          category: 'Groceries',
+          date: 'Yesterday',
+          amount: '-$142.30',
+        },
+        {
+          id: 't3',
+          name: 'Stripe Payout',
+          category: 'Income',
+          date: 'Oct 12',
+          amount: '+$4,200.00',
+          isPositive: true,
+        },
+        {
+          id: 't4',
+          name: 'Uber Technologies',
+          category: 'Transport',
+          date: 'Oct 11',
+          amount: '-$24.10',
+        },
+        {
+          id: 't5',
+          name: 'Netflix Subscription',
+          category: 'Entertainment',
+          date: 'Oct 10',
+          amount: '-$19.99',
+        },
       ],
     },
   },
@@ -239,7 +268,13 @@ function defaultProps(type: BlockType): Record<string, unknown> {
         heading: 'Activity',
         description: '',
         items: [
-          {id: 't1', name: 'New Item', category: 'General', date: 'Today', amount: '$0.00'},
+          {
+            id: 't1',
+            name: 'New Item',
+            category: 'General',
+            date: 'Today',
+            amount: '$0.00',
+          },
         ],
       };
     case 'cta':
@@ -257,14 +292,24 @@ function defaultProps(type: BlockType): Record<string, unknown> {
 // ---------------------------------------------------------------------------
 
 const editorStyles = stylex.create({
-  contentRelative: {
+  shell: {
+    position: 'fixed',
+    inset: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    backgroundColor: colorVars['--color-background-body'],
+  },
+  bodyRow: {
+    display: 'flex',
+    flex: 1,
+    overflow: 'hidden',
     position: 'relative',
   },
   floatingPanel: {
     position: 'absolute',
-    top: spacingVars['--spacing-4'],
-    left: spacingVars['--spacing-4'],
-    bottom: spacingVars['--spacing-4'],
+    top: 16,
+    left: 16,
+    bottom: 16,
     width: 320,
     zIndex: 10,
     backgroundColor: colorVars['--color-background-card'],
@@ -272,35 +317,24 @@ const editorStyles = stylex.create({
     boxShadow: shadowVars['--shadow-low'],
     overflow: 'hidden',
   },
-  headerPadding: {
-    paddingInline: spacingVars['--spacing-4'],
-  },
   floatingPanelCollapsed: {
     bottom: 'auto',
-    paddingBlockEnd: spacingVars['--spacing-4'],
+    paddingBlockEnd: 16,
   },
   panelScroll: {
+    flex: 1,
     overflowY: 'auto',
-  },
-  tabListWrapper: {
-    paddingInline: spacingVars['--spacing-1'],
-  },
-  panelContentPadding: {
-    paddingInline: spacingVars['--spacing-2'],
-    paddingBlockEnd: spacingVars['--spacing-4'],
-  },
-  collapseButtonEdgeComp: {
-    marginInlineEnd: -8,
   },
   previewArea: {
     flex: 1,
     overflowY: 'auto',
-    padding: spacingVars['--spacing-8'],
+    padding: 32,
     paddingLeft: 368,
   },
   canvas: (maxWidth: number) => ({
     maxWidth,
     width: '100%',
+    marginInline: 'auto',
     transition: 'max-width 0.3s ease',
   }),
   clickable: {
@@ -310,6 +344,33 @@ const editorStyles = stylex.create({
     outline: '2px solid',
     outlineColor: colorVars['--color-border-blue'],
     outlineOffset: -2,
+  },
+  flex1: {
+    flex: 1,
+  },
+  sectionHeadingInline: {
+    paddingInline: 0,
+  },
+  iconCircle: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: 40,
+    height: 40,
+    borderRadius: '50%',
+    backgroundColor: colorVars['--color-background-muted'],
+    flexShrink: 0,
+  },
+  tabListWrapper: {
+    paddingInline: 4,
+  },
+  panelContentPadding: {
+    paddingInline: 16,
+    paddingBlockEnd: 16,
+  },
+  tabFill: {
+    flex: 1,
+    textAlign: 'center',
   },
 });
 
@@ -454,10 +515,7 @@ function BlockPreview({
   switch (type) {
     case 'hero':
       return (
-        <XDSCard
-          padding={6}
-          xstyle={cardXstyle}
-          onClick={onSelect}>
+        <XDSCard padding={6} xstyle={cardXstyle} onClick={onSelect}>
           <XDSVStack gap={4}>
             <XDSHeading level={2}>
               {(props.heading as string) || 'Hero Heading'}
@@ -475,10 +533,7 @@ function BlockPreview({
     case 'text':
       if (props.heading) {
         return (
-          <XDSCard
-            padding={6}
-            xstyle={cardXstyle}
-            onClick={onSelect}>
+          <XDSCard padding={6} xstyle={cardXstyle} onClick={onSelect}>
             <XDSEmptyState
               title={props.heading as string}
               description={props.description as string}
@@ -496,9 +551,7 @@ function BlockPreview({
         );
       }
       return (
-        <XDSCard
-          xstyle={cardXstyle}
-          onClick={onSelect}>
+        <XDSCard xstyle={cardXstyle} onClick={onSelect}>
           <XDSText type="body">
             {(props.content as string) || 'Text content goes here'}
           </XDSText>
@@ -507,9 +560,7 @@ function BlockPreview({
 
     case 'image':
       return (
-        <XDSCard
-          xstyle={cardXstyle}
-          onClick={onSelect}>
+        <XDSCard xstyle={cardXstyle} onClick={onSelect}>
           <XDSEmptyState
             title="Image Block"
             description="Drop an image or enter a URL"
@@ -521,15 +572,13 @@ function BlockPreview({
 
     case 'button':
       return (
-        <XDSCard
-          padding={6}
-          xstyle={cardXstyle}
-          onClick={onSelect}>
+        <XDSCard padding={6} xstyle={cardXstyle} onClick={onSelect}>
           <XDSCenter>
             <XDSButton
               label={(props.label as string) || 'Button'}
               variant={
-                (props.variant as 'primary' | 'secondary' | 'ghost') || 'primary'
+                (props.variant as 'primary' | 'secondary' | 'ghost') ||
+                'primary'
               }
               size={(props.size as 'sm' | 'md' | 'lg') || 'md'}
             />
@@ -540,24 +589,19 @@ function BlockPreview({
     case 'features': {
       const items = (props.items as Transaction[]) || [];
       return (
-        <XDSCard
-          padding={6}
-          xstyle={cardXstyle}
-          onClick={onSelect}>
+        <XDSCard padding={6} xstyle={cardXstyle} onClick={onSelect}>
           <XDSVStack gap={4}>
             <XDSHStack gap={3} vAlign="start">
-              <XDSStackItem size="fill">
-                <XDSVStack gap={1}>
-                  <XDSHeading level={3}>
-                    {(props.heading as string) || 'Features'}
-                  </XDSHeading>
-                  {(props.description as string) && (
-                    <XDSText type="supporting" color="secondary">
-                      {props.description as string}
-                    </XDSText>
-                  )}
-                </XDSVStack>
-              </XDSStackItem>
+              <XDSVStack gap={1} xstyle={editorStyles.flex1}>
+                <XDSHeading level={3}>
+                  {(props.heading as string) || 'Features'}
+                </XDSHeading>
+                {(props.description as string) && (
+                  <XDSText type="supporting" color="secondary">
+                    {props.description as string}
+                  </XDSText>
+                )}
+              </XDSVStack>
               <XDSButton label="View All" variant="secondary" size="sm" />
             </XDSHStack>
             <XDSTable
@@ -575,9 +619,7 @@ function BlockPreview({
       const cardItems =
         (props.cards as Array<{title: string; description: string}>) || [];
       return (
-        <XDSCard
-          xstyle={cardXstyle}
-          onClick={onSelect}>
+        <XDSCard xstyle={cardXstyle} onClick={onSelect}>
           <XDSVStack gap={4}>
             <XDSHeading level={3}>Cards</XDSHeading>
             <XDSDivider />
@@ -597,12 +639,11 @@ function BlockPreview({
 
     case 'cta':
       return (
-        <XDSCard
-          padding={6}
-          xstyle={cardXstyle}
-          onClick={onSelect}>
+        <XDSCard padding={6} xstyle={cardXstyle} onClick={onSelect}>
           <XDSHStack gap={4} vAlign="start">
-            <XDSIcon icon={LockClosedIcon} color="secondary" size="lg" />
+            <div {...stylex.props(editorStyles.iconCircle)}>
+              <XDSIcon icon={LockClosedIcon} color="secondary" />
+            </div>
             <XDSVStack gap={1}>
               <XDSText type="label" weight="semibold">
                 {(props.heading as string) || 'Notice'}
@@ -689,7 +730,10 @@ export default function EditorPage() {
   const blocksTabContent = (
     <XDSVStack gap={2}>
       <XDSVStack gap={1}>
-        <XDSSection variant="transparent" padding={2}>
+        <XDSSection
+          variant="transparent"
+          padding={2}
+          xstyle={editorStyles.sectionHeadingInline}>
           <XDSHeading level={4}>Add Block</XDSHeading>
         </XDSSection>
         <XDSList density="balanced" hasDividers={false}>
@@ -707,7 +751,10 @@ export default function EditorPage() {
       </XDSVStack>
 
       <XDSVStack gap={1}>
-        <XDSSection variant="transparent" padding={2}>
+        <XDSSection
+          variant="transparent"
+          padding={2}
+          xstyle={editorStyles.sectionHeadingInline}>
           <XDSHeading level={4}>Layers</XDSHeading>
         </XDSSection>
         <XDSList density="balanced" hasDividers={false}>
@@ -718,10 +765,7 @@ export default function EditorPage() {
               isSelected={block.id === selectedId}
               onClick={() => selectBlock(block.id)}
               startContent={
-                <XDSIcon
-                  icon={BLOCK_META[block.type].icon}
-                  color="secondary"
-                />
+                <XDSIcon icon={BLOCK_META[block.type].icon} color="secondary" />
               }
               endContent={
                 <XDSHStack gap={1}>
@@ -770,9 +814,7 @@ export default function EditorPage() {
   const propertiesTabContent = selectedBlock ? (
     <PropertiesForm
       block={selectedBlock}
-      onUpdate={(key, value) =>
-        updateBlockProp(selectedBlock.id, key, value)
-      }
+      onUpdate={(key, value) => updateBlockProp(selectedBlock.id, key, value)}
     />
   ) : (
     <XDSEmptyState
@@ -783,116 +825,108 @@ export default function EditorPage() {
   );
 
   return (
-    <XDSLayout
-      height="fill"
-      content={
-        <XDSLayoutContent
-          padding={0}
-          isScrollable={false}
-          xstyle={editorStyles.contentRelative}>
-          {/* Floating Sidebar */}
-          <XDSVStack
-            gap={4}
-            xstyle={[
-              editorStyles.floatingPanel,
-              isPanelCollapsed && editorStyles.floatingPanelCollapsed,
-            ]}>
-            <XDSSection variant="transparent" padding={4} xstyle={editorStyles.headerPadding}>
-              <XDSVStack gap={4}>
-                <XDSHStack gap={3} vAlign="center">
-                  <XDSStackItem size="fill">
-                    {isEditingTitle ? (
-                      <XDSTextInput
-                        label="Page title"
-                        isLabelHidden
-                        value={pageTitle}
-                        onChange={setPageTitle}
-                        onKeyDown={(e: React.KeyboardEvent) => {
-                          if (e.key === 'Enter') setIsEditingTitle(false);
-                        }}
-                        hasAutoFocus
-                        onBlur={() => setIsEditingTitle(false)}
-                      />
-                    ) : (
-                      <XDSHeading level={2}>{pageTitle}</XDSHeading>
-                    )}
-                  </XDSStackItem>
+    <XDSVStack xstyle={editorStyles.shell}>
+      <XDSHStack xstyle={editorStyles.bodyRow}>
+        {/* Floating Sidebar */}
+        <XDSVStack
+          gap={4}
+          xstyle={[
+            editorStyles.floatingPanel,
+            isPanelCollapsed && editorStyles.floatingPanelCollapsed,
+          ]}>
+          {/* Panel Header */}
+          <XDSSection variant="transparent" padding={4}>
+            <XDSVStack gap={4}>
+              <XDSHStack gap={3} vAlign="center">
+                <XDSVStack gap={0} xstyle={editorStyles.flex1}>
+                  {isEditingTitle ? (
+                    <XDSTextInput
+                      label="Page title"
+                      isLabelHidden
+                      value={pageTitle}
+                      onChange={setPageTitle}
+                      onKeyDown={(e: React.KeyboardEvent) => {
+                        if (e.key === 'Enter') setIsEditingTitle(false);
+                      }}
+                      hasAutoFocus
+                      onBlur={() => setIsEditingTitle(false)}
+                    />
+                  ) : (
+                    <XDSHeading level={2}>{pageTitle}</XDSHeading>
+                  )}
+                </XDSVStack>
+                <XDSHStack gap={1}>
                   <XDSButton
-                    label={
-                      isPanelCollapsed ? 'Expand panel' : 'Collapse panel'
-                    }
+                    label={isPanelCollapsed ? 'Expand panel' : 'Collapse panel'}
                     icon={
-                      <XDSIcon
-                        icon={ArrowLeftEndOnRectangleIcon}
-                        size="sm"
-                      />
+                      <XDSIcon icon={ArrowLeftEndOnRectangleIcon} size="sm" />
                     }
                     variant="ghost"
                     size="sm"
                     onClick={() => setIsPanelCollapsed(v => !v)}
                     isIconOnly
-                    xstyle={editorStyles.collapseButtonEdgeComp}
                   />
                 </XDSHStack>
+              </XDSHStack>
 
-                <XDSToolbar
-                  label="Viewport and actions"
-                  padding={0}
-                  startContent={
-                    <XDSSegmentedControl
-                      label="Viewport size"
-                      value={viewport}
-                      onChange={(v: string) =>
-                        setViewport(v as ViewportSize)
-                      }>
-                      <XDSSegmentedControlItem
-                        value="desktop"
-                        label="Desktop"
-                        icon={
-                          <XDSIcon icon={ComputerDesktopIcon} size="sm" />
-                        }
-                        isLabelHidden
-                      />
-                      <XDSSegmentedControlItem
-                        value="tablet"
-                        label="Tablet"
-                        icon={<XDSIcon icon={DeviceTabletIcon} size="sm" />}
-                        isLabelHidden
-                      />
-                      <XDSSegmentedControlItem
-                        value="phone"
-                        label="Phone"
-                        icon={
-                          <XDSIcon icon={DevicePhoneMobileIcon} size="sm" />
-                        }
-                        isLabelHidden
-                      />
-                    </XDSSegmentedControl>
-                  }
-                  endContent={
-                    <XDSHStack gap={2}>
-                      <XDSButton
-                        label="Preview"
-                        icon={<XDSIcon icon={EyeIcon} size="sm" />}
-                        variant="ghost"
-                        isIconOnly
-                      />
-                      <XDSButton label="Publish" variant="primary" />
-                    </XDSHStack>
-                  }
-                />
-              </XDSVStack>
-            </XDSSection>
+              <XDSToolbar
+                label="Viewport and actions"
+                startContent={
+                  <XDSSegmentedControl
+                    label="Viewport size"
+                    value={viewport}
+                    onChange={(v: string) => setViewport(v as ViewportSize)}>
+                    <XDSSegmentedControlItem
+                      value="desktop"
+                      label="Desktop"
+                      icon={<XDSIcon icon={ComputerDesktopIcon} size="sm" />}
+                      isLabelHidden
+                    />
+                    <XDSSegmentedControlItem
+                      value="tablet"
+                      label="Tablet"
+                      icon={<XDSIcon icon={DeviceTabletIcon} size="sm" />}
+                      isLabelHidden
+                    />
+                    <XDSSegmentedControlItem
+                      value="phone"
+                      label="Phone"
+                      icon={<XDSIcon icon={DevicePhoneMobileIcon} size="sm" />}
+                      isLabelHidden
+                    />
+                  </XDSSegmentedControl>
+                }
+                endContent={
+                  <XDSHStack gap={2}>
+                    <XDSButton
+                      label="Preview"
+                      icon={<XDSIcon icon={EyeIcon} size="sm" />}
+                      variant="ghost"
+                      isIconOnly
+                    />
+                    <XDSButton label="Publish" variant="primary" />
+                  </XDSHStack>
+                }
+              />
+            </XDSVStack>
+          </XDSSection>
 
-            {!isPanelCollapsed && (
-              <>
+          {!isPanelCollapsed && (
+            <>
               <XDSVStack gap={0} xstyle={editorStyles.tabListWrapper}>
                 <XDSTabList
                   value={sidebarTab}
-                  onChange={(v: string) => setSidebarTab(v as SidebarTab)}
-                  layout="fill">
-                  <XDSTab value="blocks" label="Blocks" />
-                  <XDSTab value="properties" label="Properties" />
+                  onChange={(v: string) => setSidebarTab(v as SidebarTab)}>
+                  <XDSTab
+                    value="blocks"
+                    label="Blocks"
+                    xstyle={editorStyles.tabFill}
+                  />
+                  <XDSTab
+                    value="properties"
+                    label="Properties"
+                    xstyle={editorStyles.tabFill}
+                  />
                 </XDSTabList>
                 <XDSDivider />
               </XDSVStack>
@@ -907,37 +941,34 @@ export default function EditorPage() {
                   ? blocksTabContent
                   : propertiesTabContent}
               </XDSSection>
-              </>
+            </>
+          )}
+        </XDSVStack>
+
+        {/* Preview Canvas */}
+        <XDSVStack xstyle={editorStyles.previewArea}>
+          <XDSVStack
+            gap={4}
+            xstyle={editorStyles.canvas(VIEWPORT_MAX[viewport])}>
+            {blocks.length > 0 ? (
+              blocks.map(block => (
+                <BlockPreview
+                  key={block.id}
+                  block={block}
+                  isSelected={block.id === selectedId}
+                  onSelect={() => selectBlock(block.id)}
+                />
+              ))
+            ) : (
+              <XDSEmptyState
+                title="No blocks yet"
+                description="Add blocks from the sidebar to start building your page"
+                icon={<XDSIcon icon={PlusCircleIcon} />}
+              />
             )}
           </XDSVStack>
-
-          {/* Preview Canvas */}
-          <XDSVStack xstyle={editorStyles.previewArea}>
-            <XDSCenter axis="horizontal">
-              <XDSVStack
-                gap={4}
-                xstyle={editorStyles.canvas(VIEWPORT_MAX[viewport])}>
-                {blocks.length > 0 ? (
-                  blocks.map(block => (
-                    <BlockPreview
-                      key={block.id}
-                      block={block}
-                      isSelected={block.id === selectedId}
-                      onSelect={() => selectBlock(block.id)}
-                    />
-                  ))
-                ) : (
-                  <XDSEmptyState
-                    title="No blocks yet"
-                    description="Add blocks from the sidebar to start building your page"
-                    icon={<XDSIcon icon={PlusCircleIcon} />}
-                  />
-                )}
-              </XDSVStack>
-            </XDSCenter>
-          </XDSVStack>
-        </XDSLayoutContent>
-      }
-    />
+        </XDSVStack>
+      </XDSHStack>
+    </XDSVStack>
   );
 }

--- a/packages/core/src/Banner/XDSBanner.tsx
+++ b/packages/core/src/Banner/XDSBanner.tsx
@@ -235,9 +235,6 @@ const styles = stylex.create({
     gap: spacingVars['--spacing-2'],
     paddingBlock: spacingVars['--spacing-3'],
     paddingInline: spacingVars['--spacing-4'],
-    // Publish inline padding for edge compensation (ghost buttons at edges).
-    // Banner has different block padding (spacing-3) vs inline padding (spacing-4).
-    '--container-padding-inline': spacingVars['--spacing-4'],
   },
   // When there's only a title (no description) and actions, center everything vertically
   headerCentered: {

--- a/packages/core/src/Button/XDSButton.tsx
+++ b/packages/core/src/Button/XDSButton.tsx
@@ -390,21 +390,6 @@ const loadingStyles = stylex.create({
 });
 
 /**
- * Edge compensation: publish the component's own inline padding so the
- * compensation formula can read it. This is separate from the base padding
- * styles so themes can override button padding independently and
- * compensation stays in sync.
- */
-const edgeCompStyles = stylex.create({
-  paddingInline2: {
-    '--component-padding-inline': spacingVars['--spacing-2'],
-  },
-  paddingInline3: {
-    '--component-padding-inline': spacingVars['--spacing-3'],
-  },
-});
-
-/**
  * A versatile button component with multiple variants.
  *
  * Styles use XDS theme tokens via StyleX.
@@ -502,17 +487,11 @@ export function XDSButton({
       }
     : undefined;
 
-  // Ghost buttons opt into edge compensation — they self-adjust margins
-  // when placed at container edges (e.g., TopNav endContent).
-  // The component publishes its own inline padding via --component-padding-inline
-  // so the compensation formula stays theme-safe.
+  // Ghost buttons opt into edge compensation — they pull back at container
+  // edges via negative margin when placed as first/last child in a slot
+  // that sets --edge-inset-start/--edge-inset-end.
   const isFlat = variant === 'ghost';
-  const edgeCompStyle = isFlat ? edgeCompensation.self : null;
-  const edgePaddingSignal = isFlat
-    ? isIconOnly
-      ? edgeCompStyles.paddingInline2
-      : edgeCompStyles.paddingInline3
-    : null;
+  const edgeCompStyle = isFlat ? edgeCompensation.item : null;
 
   // Shared StyleX props for both button and link rendering
   const sharedStylexProps = stylex.props(
@@ -523,7 +502,6 @@ export function XDSButton({
     buttonDisabled && styles.disabled,
     useAriaDisabled && styles.ariaDisabled,
     isLoadingState && loadingStyles.loading,
-    edgePaddingSignal,
     edgeCompStyle,
     renderAsLink && styles.link,
     xstyle,

--- a/packages/core/src/Button/XDSButton.tsx
+++ b/packages/core/src/Button/XDSButton.tsx
@@ -489,7 +489,7 @@ export function XDSButton({
 
   // Ghost buttons opt into edge compensation — they pull back at container
   // edges via negative margin when placed as first/last child in a slot
-  // that sets --edge-inset-start/--edge-inset-end.
+  // that sets --_edge-inset-start/--_edge-inset-end.
   const isFlat = variant === 'ghost';
   const edgeCompStyle = isFlat ? edgeCompensation.item : null;
 

--- a/packages/core/src/Button/XDSButton.tsx
+++ b/packages/core/src/Button/XDSButton.tsx
@@ -489,7 +489,7 @@ export function XDSButton({
 
   // Ghost buttons opt into edge compensation — they pull back at container
   // edges via negative margin when placed as first/last child in a slot
-  // that sets --_edge-inset-start/--_edge-inset-end.
+  // that sets --edge-inset-start/--edge-inset-end.
   const isFlat = variant === 'ghost';
   const edgeCompStyle = isFlat ? edgeCompensation.item : null;
 

--- a/packages/core/src/Layout/edgeCompensation.stylex.ts
+++ b/packages/core/src/Layout/edgeCompensation.stylex.ts
@@ -2,86 +2,80 @@
  * @file edgeCompensation.stylex.ts
  * @input Uses @stylexjs/stylex
  * @output StyleX utilities for automatic edge padding compensation
- * @position Layout utility; used by containers (TopNav, LayoutHeader, Banner, etc.)
- *   and components with transparent variants (Button ghost/tertiary)
+ * @position Layout utility; used by containers (TopNav, Toolbar, etc.)
+ *   and components with transparent variants (Button ghost, Tab)
  *
- * ## Edge Compensation Pattern
+ * ## Edge Inset Pattern
  *
- * Interactive components with transparent padding (ghost buttons, tertiary buttons)
+ * Interactive components with transparent padding (ghost buttons, tabs)
  * create excess visual space at container edges. The container's padding + the
- * component's own transparent padding doubles up. Solid buttons don't have this
- * problem — their padding is visually filled.
+ * component's own transparent padding doubles up.
  *
  * This module provides a two-layer solution:
  *
- * 1. **Containers** set spatial signals via CSS custom properties:
- *    - `--edge-start: 1` / `--edge-end: 1` on edge-adjacent slots
- *    - `--container-padding-inline` on the container root (the inline padding value)
+ * 1. **Containers** set the inset budget via CSS custom properties on slot wrappers:
+ *    - `--edge-inset-start: <px>` — how much to pull back at the start edge
+ *    - `--edge-inset-end: <px>` — how much to pull back at the end edge
  *
- * 2. **Components** with flat/transparent variants read these signals and
- *    self-adjust their margins, clamped to `min(own-padding, container-padding-inline)`.
+ * 2. **Components** opt in by applying `edgeCompensation.item` which uses
+ *    `:first-child` / `:last-child` selectors to only compensate items
+ *    actually at the edge.
  *
- * The compensation formula:
- * ```
- * margin = var(--edge-*, 0) * -1 * min(own-padding, var(--container-padding-inline, 0px))
- * ```
- *
- * - When not at an edge: `--edge-*` is 0, so margin is 0 (no effect)
- * - When at an edge: margin pulls the component toward the edge by the smaller
- *   of its own padding or the container's inline padding
- *
- * ### Why --container-padding-inline?
- *
- * Edge compensation is always an inline (horizontal) adjustment. Many containers
- * have different inline vs block padding (e.g., Banner: paddingInline=spacing-4,
- * paddingBlock=spacing-3; TopNav: paddingInline=spacing-4, no block padding).
- * The container system uses two directional vars: --container-padding-inline for
- * horizontal padding and --container-padding-block-start/end for vertical. Edge compensation
- * only reads the inline var since it only adjusts horizontal margins.
+ * The container decides the amount. The component decides whether to participate.
  *
  * SYNC: When modified, update /packages/core/src/Layout/Layout.doc.mjs
  */
 
 import * as stylex from '@stylexjs/stylex';
+import {spacingVars} from '../theme/tokens.stylex';
 
 // =============================================================================
-// Container-side: Edge signal styles
+// Container-side: Edge inset styles
 // =============================================================================
 
 /**
- * Styles for containers to mark slots at their edges.
+ * Styles for containers to set the edge inset budget on slot wrappers.
  *
- * Apply these to wrapper divs around slot content (startContent, endContent, etc.)
- * so child components know they're at a container boundary.
- *
- * The container must also set `--container-padding-inline` on its root element
- * so components know how much inline room is available for compensation.
+ * Apply to wrapper divs around slot content (startContent, endContent, etc.).
+ * The value is the amount of negative margin that edge-adjacent components
+ * will apply to pull themselves toward the container edge.
  *
  * @example
  * ```tsx
- * // In TopNav:
- * <div {...stylex.props(edgeSignals.start)}>
+ * // Toolbar sets inset equal to its slot padding:
+ * <div {...stylex.props(edgeInset.start4)}>
  *   {startContent}
  * </div>
- * <div {...stylex.props(edgeSignals.end)}>
+ * <div {...stylex.props(edgeInset.end4)}>
  *   {endContent}
  * </div>
  * ```
  */
-export const edgeSignals = stylex.create({
-  /** Mark slot as being at the inline-start edge of the container */
-  start: {
-    '--edge-start': '1',
-  },
-  /** Mark slot as being at the inline-end edge of the container */
-  end: {
-    '--edge-end': '1',
-  },
-  /** Mark slot as being at both edges (e.g., a single-slot container) */
-  both: {
-    '--edge-start': '1',
-    '--edge-end': '1',
-  },
+export const edgeInset = stylex.create({
+  /** Start edge inset: spacing-1 (4px) */
+  start1: {'--edge-inset-start': spacingVars['--spacing-1']},
+  /** Start edge inset: spacing-1.5 (6px) */
+  start1_5: {'--edge-inset-start': spacingVars['--spacing-1-5']},
+  /** Start edge inset: spacing-2 (8px) */
+  start2: {'--edge-inset-start': spacingVars['--spacing-2']},
+  /** Start edge inset: spacing-3 (12px) */
+  start3: {'--edge-inset-start': spacingVars['--spacing-3']},
+  /** Start edge inset: spacing-4 (16px) */
+  start4: {'--edge-inset-start': spacingVars['--spacing-4']},
+  /** Start edge inset: spacing-5 (20px) */
+  start5: {'--edge-inset-start': spacingVars['--spacing-5']},
+  /** End edge inset: spacing-1 (4px) */
+  end1: {'--edge-inset-end': spacingVars['--spacing-1']},
+  /** End edge inset: spacing-1.5 (6px) */
+  end1_5: {'--edge-inset-end': spacingVars['--spacing-1-5']},
+  /** End edge inset: spacing-2 (8px) */
+  end2: {'--edge-inset-end': spacingVars['--spacing-2']},
+  /** End edge inset: spacing-3 (12px) */
+  end3: {'--edge-inset-end': spacingVars['--spacing-3']},
+  /** End edge inset: spacing-4 (16px) */
+  end4: {'--edge-inset-end': spacingVars['--spacing-4']},
+  /** End edge inset: spacing-5 (20px) */
+  end5: {'--edge-inset-end': spacingVars['--spacing-5']},
 });
 
 // =============================================================================
@@ -91,44 +85,58 @@ export const edgeSignals = stylex.create({
 /**
  * Styles for components to self-adjust at container edges.
  *
- * Components with transparent/flat variants (ghost buttons, tertiary buttons,
- * icon-only buttons) should apply these styles to compensate for doubled padding
- * at container edges.
+ * Components with transparent/flat padding (ghost buttons, tabs) apply
+ * `edgeCompensation.item` to participate in edge compensation.
  *
- * The compensation is `min(own-padding, container-padding-inline)` — never more
- * than either value. When not at an edge (signals default to 0), no compensation
- * is applied.
- *
- * Components must set `--component-padding-inline` on themselves so the
- * compensation formula knows the component's own inline padding. This makes
- * edge compensation theme-safe — if a theme changes the button's internal
- * padding, the compensation adjusts automatically.
+ * Only the first child in a slot gets start compensation, and only the
+ * last child gets end compensation — via `:first-child` / `:last-child`.
  *
  * @example
  * ```tsx
  * // In XDSButton, for ghost variant:
- * const styles = stylex.create({
- *   ghost: {
- *     paddingInline: spacingVars['--spacing-3'],
- *     '--component-padding-inline': spacingVars['--spacing-3'],
- *   },
- * });
- *
  * {...stylex.props(
  *   styles.base,
  *   styles.ghost,
- *   edgeCompensation.self,
+ *   edgeCompensation.item,
  * )}
  * ```
  */
 export const edgeCompensation = stylex.create({
   /**
-   * Self-compensating edge style. Reads --component-padding-inline from the
-   * component itself. The component must set this variable to its own inline
-   * padding value (typically via the same spacing token used for paddingInline).
+   * Edge-compensating item. Applies negative margin at container edges
+   * using the inset budget set by the parent container.
+   * Only activates when the component is :first-child (start) or :last-child (end).
    */
-  self: {
-    marginInlineStart: `calc(var(--edge-start, 0) * -1 * min(var(--component-padding-inline, 0px), var(--container-padding-inline, 0px)))`,
-    marginInlineEnd: `calc(var(--edge-end, 0) * -1 * min(var(--component-padding-inline, 0px), var(--container-padding-inline, 0px)))`,
+  item: {
+    marginInlineStart: {
+      default: null,
+      ':first-child': 'calc(-1 * var(--edge-inset-start, 0px))',
+    },
+    marginInlineEnd: {
+      default: null,
+      ':last-child': 'calc(-1 * var(--edge-inset-end, 0px))',
+    },
+  },
+});
+
+// =============================================================================
+// Legacy API (deprecated — migrate to edgeInset + edgeCompensation.item)
+// =============================================================================
+
+/**
+ * @deprecated Use `edgeInset` instead. These set --edge-start/--edge-end
+ * multiplier signals which are no longer used by the new compensation model.
+ * Kept temporarily for backwards compatibility during migration.
+ */
+export const edgeSignals = stylex.create({
+  start: {
+    '--edge-start': '1',
+  },
+  end: {
+    '--edge-end': '1',
+  },
+  both: {
+    '--edge-start': '1',
+    '--edge-end': '1',
   },
 });

--- a/packages/core/src/Layout/edgeCompensation.stylex.ts
+++ b/packages/core/src/Layout/edgeCompensation.stylex.ts
@@ -14,8 +14,8 @@
  * This module provides a two-layer solution:
  *
  * 1. **Containers** set the inset budget via CSS custom properties on slot wrappers:
- *    - `--edge-inset-start: <px>` — how much to pull back at the start edge
- *    - `--edge-inset-end: <px>` — how much to pull back at the end edge
+ *    - `--_edge-inset-start: <px>` — how much to pull back at the start edge
+ *    - `--_edge-inset-end: <px>` — how much to pull back at the end edge
  *
  * 2. **Components** opt in by applying `edgeCompensation.item` which uses
  *    `:first-child` / `:last-child` selectors to only compensate items
@@ -53,29 +53,29 @@ import {spacingVars} from '../theme/tokens.stylex';
  */
 export const edgeInset = stylex.create({
   /** Start edge inset: spacing-1 (4px) */
-  start1: {'--edge-inset-start': spacingVars['--spacing-1']},
+  start1: {'--_edge-inset-start': spacingVars['--spacing-1']},
   /** Start edge inset: spacing-1.5 (6px) */
-  start1_5: {'--edge-inset-start': spacingVars['--spacing-1-5']},
+  start1_5: {'--_edge-inset-start': spacingVars['--spacing-1-5']},
   /** Start edge inset: spacing-2 (8px) */
-  start2: {'--edge-inset-start': spacingVars['--spacing-2']},
+  start2: {'--_edge-inset-start': spacingVars['--spacing-2']},
   /** Start edge inset: spacing-3 (12px) */
-  start3: {'--edge-inset-start': spacingVars['--spacing-3']},
+  start3: {'--_edge-inset-start': spacingVars['--spacing-3']},
   /** Start edge inset: spacing-4 (16px) */
-  start4: {'--edge-inset-start': spacingVars['--spacing-4']},
+  start4: {'--_edge-inset-start': spacingVars['--spacing-4']},
   /** Start edge inset: spacing-5 (20px) */
-  start5: {'--edge-inset-start': spacingVars['--spacing-5']},
+  start5: {'--_edge-inset-start': spacingVars['--spacing-5']},
   /** End edge inset: spacing-1 (4px) */
-  end1: {'--edge-inset-end': spacingVars['--spacing-1']},
+  end1: {'--_edge-inset-end': spacingVars['--spacing-1']},
   /** End edge inset: spacing-1.5 (6px) */
-  end1_5: {'--edge-inset-end': spacingVars['--spacing-1-5']},
+  end1_5: {'--_edge-inset-end': spacingVars['--spacing-1-5']},
   /** End edge inset: spacing-2 (8px) */
-  end2: {'--edge-inset-end': spacingVars['--spacing-2']},
+  end2: {'--_edge-inset-end': spacingVars['--spacing-2']},
   /** End edge inset: spacing-3 (12px) */
-  end3: {'--edge-inset-end': spacingVars['--spacing-3']},
+  end3: {'--_edge-inset-end': spacingVars['--spacing-3']},
   /** End edge inset: spacing-4 (16px) */
-  end4: {'--edge-inset-end': spacingVars['--spacing-4']},
+  end4: {'--_edge-inset-end': spacingVars['--spacing-4']},
   /** End edge inset: spacing-5 (20px) */
-  end5: {'--edge-inset-end': spacingVars['--spacing-5']},
+  end5: {'--_edge-inset-end': spacingVars['--spacing-5']},
 });
 
 // =============================================================================
@@ -110,33 +110,11 @@ export const edgeCompensation = stylex.create({
   item: {
     marginInlineStart: {
       default: null,
-      ':first-child': 'calc(-1 * var(--edge-inset-start, 0px))',
+      ':first-child': 'calc(-1 * var(--_edge-inset-start, 0px))',
     },
     marginInlineEnd: {
       default: null,
-      ':last-child': 'calc(-1 * var(--edge-inset-end, 0px))',
+      ':last-child': 'calc(-1 * var(--_edge-inset-end, 0px))',
     },
-  },
-});
-
-// =============================================================================
-// Legacy API (deprecated — migrate to edgeInset + edgeCompensation.item)
-// =============================================================================
-
-/**
- * @deprecated Use `edgeInset` instead. These set --edge-start/--edge-end
- * multiplier signals which are no longer used by the new compensation model.
- * Kept temporarily for backwards compatibility during migration.
- */
-export const edgeSignals = stylex.create({
-  start: {
-    '--edge-start': '1',
-  },
-  end: {
-    '--edge-end': '1',
-  },
-  both: {
-    '--edge-start': '1',
-    '--edge-end': '1',
   },
 });

--- a/packages/core/src/Layout/edgeCompensation.stylex.ts
+++ b/packages/core/src/Layout/edgeCompensation.stylex.ts
@@ -14,8 +14,8 @@
  * This module provides a two-layer solution:
  *
  * 1. **Containers** set the inset budget via CSS custom properties on slot wrappers:
- *    - `--_edge-inset-start: <px>` — how much to pull back at the start edge
- *    - `--_edge-inset-end: <px>` — how much to pull back at the end edge
+ *    - `--edge-inset-start: <px>` — how much to pull back at the start edge
+ *    - `--edge-inset-end: <px>` — how much to pull back at the end edge
  *
  * 2. **Components** opt in by applying `edgeCompensation.item` which uses
  *    `:first-child` / `:last-child` selectors to only compensate items
@@ -53,29 +53,29 @@ import {spacingVars} from '../theme/tokens.stylex';
  */
 export const edgeInset = stylex.create({
   /** Start edge inset: spacing-1 (4px) */
-  start1: {'--_edge-inset-start': spacingVars['--spacing-1']},
+  start1: {'--edge-inset-start': spacingVars['--spacing-1']},
   /** Start edge inset: spacing-1.5 (6px) */
-  start1_5: {'--_edge-inset-start': spacingVars['--spacing-1-5']},
+  start1_5: {'--edge-inset-start': spacingVars['--spacing-1-5']},
   /** Start edge inset: spacing-2 (8px) */
-  start2: {'--_edge-inset-start': spacingVars['--spacing-2']},
+  start2: {'--edge-inset-start': spacingVars['--spacing-2']},
   /** Start edge inset: spacing-3 (12px) */
-  start3: {'--_edge-inset-start': spacingVars['--spacing-3']},
+  start3: {'--edge-inset-start': spacingVars['--spacing-3']},
   /** Start edge inset: spacing-4 (16px) */
-  start4: {'--_edge-inset-start': spacingVars['--spacing-4']},
+  start4: {'--edge-inset-start': spacingVars['--spacing-4']},
   /** Start edge inset: spacing-5 (20px) */
-  start5: {'--_edge-inset-start': spacingVars['--spacing-5']},
+  start5: {'--edge-inset-start': spacingVars['--spacing-5']},
   /** End edge inset: spacing-1 (4px) */
-  end1: {'--_edge-inset-end': spacingVars['--spacing-1']},
+  end1: {'--edge-inset-end': spacingVars['--spacing-1']},
   /** End edge inset: spacing-1.5 (6px) */
-  end1_5: {'--_edge-inset-end': spacingVars['--spacing-1-5']},
+  end1_5: {'--edge-inset-end': spacingVars['--spacing-1-5']},
   /** End edge inset: spacing-2 (8px) */
-  end2: {'--_edge-inset-end': spacingVars['--spacing-2']},
+  end2: {'--edge-inset-end': spacingVars['--spacing-2']},
   /** End edge inset: spacing-3 (12px) */
-  end3: {'--_edge-inset-end': spacingVars['--spacing-3']},
+  end3: {'--edge-inset-end': spacingVars['--spacing-3']},
   /** End edge inset: spacing-4 (16px) */
-  end4: {'--_edge-inset-end': spacingVars['--spacing-4']},
+  end4: {'--edge-inset-end': spacingVars['--spacing-4']},
   /** End edge inset: spacing-5 (20px) */
-  end5: {'--_edge-inset-end': spacingVars['--spacing-5']},
+  end5: {'--edge-inset-end': spacingVars['--spacing-5']},
 });
 
 // =============================================================================
@@ -110,11 +110,11 @@ export const edgeCompensation = stylex.create({
   item: {
     marginInlineStart: {
       default: null,
-      ':first-child': 'calc(-1 * var(--_edge-inset-start, 0px))',
+      ':first-child': 'calc(-1 * var(--edge-inset-start, 0px))',
     },
     marginInlineEnd: {
       default: null,
-      ':last-child': 'calc(-1 * var(--_edge-inset-end, 0px))',
+      ':last-child': 'calc(-1 * var(--edge-inset-end, 0px))',
     },
   },
 });

--- a/packages/core/src/Layout/index.ts
+++ b/packages/core/src/Layout/index.ts
@@ -18,7 +18,11 @@ export type {
 } from './container.stylex';
 
 // Edge compensation utility
-export {edgeSignals, edgeCompensation} from './edgeCompensation.stylex';
+export {
+  edgeInset,
+  edgeCompensation,
+  edgeSignals,
+} from './edgeCompensation.stylex';
 
 // Stack utilities (re-exported from Stack module)
 export {stack} from '../Stack/stack.stylex';

--- a/packages/core/src/Layout/index.ts
+++ b/packages/core/src/Layout/index.ts
@@ -18,11 +18,7 @@ export type {
 } from './container.stylex';
 
 // Edge compensation utility
-export {
-  edgeInset,
-  edgeCompensation,
-  edgeSignals,
-} from './edgeCompensation.stylex';
+export {edgeInset, edgeCompensation} from './edgeCompensation.stylex';
 
 // Stack utilities (re-exported from Stack module)
 export {stack} from '../Stack/stack.stylex';

--- a/packages/core/src/Layout/padding.stylex.ts
+++ b/packages/core/src/Layout/padding.stylex.ts
@@ -184,3 +184,56 @@ export const layoutPaddingOuterYVarStyles = stylex.create({
   8: {'--layout-padding-outer-y': spacingVars['--spacing-8']},
   10: {'--layout-padding-outer-y': spacingVars['--spacing-10']},
 });
+
+/**
+ * Block-only padding override styles.
+ * Use when a component needs to override block padding independently
+ * of inline padding (e.g., Toolbar sets tight block padding while
+ * inheriting inline padding from its container).
+ */
+export const paddingBlockStyles = stylex.create({
+  0: {
+    paddingBlockStart: spacingVars['--spacing-0'],
+    paddingBlockEnd: spacingVars['--spacing-0'],
+  },
+  0.5: {
+    paddingBlockStart: spacingVars['--spacing-0-5'],
+    paddingBlockEnd: spacingVars['--spacing-0-5'],
+  },
+  1: {
+    paddingBlockStart: spacingVars['--spacing-1'],
+    paddingBlockEnd: spacingVars['--spacing-1'],
+  },
+  1.5: {
+    paddingBlockStart: spacingVars['--spacing-1-5'],
+    paddingBlockEnd: spacingVars['--spacing-1-5'],
+  },
+  2: {
+    paddingBlockStart: spacingVars['--spacing-2'],
+    paddingBlockEnd: spacingVars['--spacing-2'],
+  },
+  3: {
+    paddingBlockStart: spacingVars['--spacing-3'],
+    paddingBlockEnd: spacingVars['--spacing-3'],
+  },
+  4: {
+    paddingBlockStart: spacingVars['--spacing-4'],
+    paddingBlockEnd: spacingVars['--spacing-4'],
+  },
+  5: {
+    paddingBlockStart: spacingVars['--spacing-5'],
+    paddingBlockEnd: spacingVars['--spacing-5'],
+  },
+  6: {
+    paddingBlockStart: spacingVars['--spacing-6'],
+    paddingBlockEnd: spacingVars['--spacing-6'],
+  },
+  8: {
+    paddingBlockStart: spacingVars['--spacing-8'],
+    paddingBlockEnd: spacingVars['--spacing-8'],
+  },
+  10: {
+    paddingBlockStart: spacingVars['--spacing-10'],
+    paddingBlockEnd: spacingVars['--spacing-10'],
+  },
+});

--- a/packages/core/src/Section/XDSSection.tsx
+++ b/packages/core/src/Section/XDSSection.tsx
@@ -20,6 +20,7 @@ import {container} from '../Layout/container.stylex';
 import type {SpacingToken} from '../Layout/container.stylex';
 import {
   paddingStyles,
+  paddingBlockStyles,
   containerPaddingInlineVarStyles,
   containerPaddingBlockStartVarStyles,
   containerPaddingBlockEndVarStyles,
@@ -69,8 +70,11 @@ const variantStyles = stylex.create({
 const nestedStyles = stylex.create({
   // Outer wrapper escapes parent's container padding
   outer: {
-    // Always escape horizontal padding
-    marginInline: 'calc(-1 * var(--container-padding-inline, 0px))',
+    // Escape horizontal padding using directional vars with shorthand fallback
+    marginInlineStart:
+      'calc(-1 * var(--container-padding-inline-start, var(--container-padding-inline, 0px)))',
+    marginInlineEnd:
+      'calc(-1 * var(--container-padding-inline-end, var(--container-padding-inline, 0px)))',
     // Escape top padding only if first child
     marginTop: {
       default: null,
@@ -85,6 +89,8 @@ const nestedStyles = stylex.create({
   // Inner wrapper resets container padding for descendants
   inner: {
     '--container-padding-inline': '0px',
+    '--container-padding-inline-start': '0px',
+    '--container-padding-inline-end': '0px',
     '--container-padding-block-start': '0px',
     '--container-padding-block-end': '0px',
     height: '100%',
@@ -187,6 +193,13 @@ export interface XDSSectionProps extends XDSBaseProps<HTMLElement> {
    * @default 4 (16px)
    */
   padding?: SpacingStep;
+  /**
+   * Block (vertical) padding override. When set, overrides only the block
+   * axis padding while preserving inline padding from `padding` or the
+   * container theme default.
+   * Accepts numeric spacing steps: 0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10.
+   */
+  paddingBlock?: SpacingStep;
 }
 
 /**
@@ -216,6 +229,7 @@ export function XDSSection({
   children,
   dividers,
   padding,
+  paddingBlock,
   xstyle,
   className,
   style,
@@ -277,6 +291,11 @@ export function XDSSection({
             !useThemeDefault &&
               effectivePadding !== 4 &&
               containerPaddingBlockEndVarStyles[effectivePadding],
+            paddingBlock != null && paddingBlockStyles[paddingBlock],
+            paddingBlock != null &&
+              containerPaddingBlockStartVarStyles[paddingBlock],
+            paddingBlock != null &&
+              containerPaddingBlockEndVarStyles[paddingBlock],
             variantStyles[variant],
             dividers?.includes('top') && dividerStyles.top,
             dividers?.includes('bottom') && dividerStyles.bottom,

--- a/packages/core/src/TabList/XDSTab.tsx
+++ b/packages/core/src/TabList/XDSTab.tsx
@@ -31,6 +31,7 @@ import {tabScope} from './tab.markers.stylex';
 import {useXDSLinkComponent} from '../Link/useXDSLinkComponent';
 import type {XDSLinkComponentType} from '../Link/types';
 import {xdsClassName, mergeProps} from '../utils';
+import {edgeCompensation} from '../Layout/edgeCompensation.stylex';
 
 export interface XDSTabProps extends XDSBaseProps<HTMLButtonElement> {
   /**
@@ -119,7 +120,7 @@ const styles = stylex.create({
   },
   indicator: {
     position: 'absolute',
-    bottom: '-2px',
+    bottom: 'var(--_tab-indicator-bottom, -2px)',
     left: spacingVars['--spacing-3'],
     right: spacingVars['--spacing-3'],
     height: '2px',
@@ -239,6 +240,7 @@ export function XDSTab({
         sizeStyles[size],
         isSelected && styles.selected,
         isFill && layoutStyles.fill,
+        edgeCompensation.item,
         tabScope,
         xstyle,
       ),

--- a/packages/core/src/Toolbar/XDSToolbar.tsx
+++ b/packages/core/src/Toolbar/XDSToolbar.tsx
@@ -127,8 +127,8 @@ const blockPaddingVarForSize: Record<XDSElementSize, string> = {
  */
 const edgeInsetStyles = stylex.create({
   inset: (blockPadding: string) => ({
-    '--_edge-inset-start': `calc(var(--container-padding-inline-start, var(--container-padding-inline, ${spacingVars['--spacing-4']})) - ${blockPadding})`,
-    '--_edge-inset-end': `calc(var(--container-padding-inline-end, var(--container-padding-inline, ${spacingVars['--spacing-4']})) - ${blockPadding})`,
+    '--edge-inset-start': `calc(var(--container-padding-inline-start, var(--container-padding-inline, ${spacingVars['--spacing-4']})) - ${blockPadding})`,
+    '--edge-inset-end': `calc(var(--container-padding-inline-end, var(--container-padding-inline, ${spacingVars['--spacing-4']})) - ${blockPadding})`,
   }),
 });
 

--- a/packages/core/src/Toolbar/XDSToolbar.tsx
+++ b/packages/core/src/Toolbar/XDSToolbar.tsx
@@ -127,8 +127,8 @@ const blockPaddingVarForSize: Record<XDSElementSize, string> = {
  */
 const edgeInsetStyles = stylex.create({
   inset: (blockPadding: string) => ({
-    '--edge-inset-start': `calc(var(--container-padding-inline-start, var(--container-padding-inline, ${spacingVars['--spacing-4']})) - ${blockPadding})`,
-    '--edge-inset-end': `calc(var(--container-padding-inline-end, var(--container-padding-inline, ${spacingVars['--spacing-4']})) - ${blockPadding})`,
+    '--_edge-inset-start': `calc(var(--container-padding-inline-start, var(--container-padding-inline, ${spacingVars['--spacing-4']})) - ${blockPadding})`,
+    '--_edge-inset-end': `calc(var(--container-padding-inline-end, var(--container-padding-inline, ${spacingVars['--spacing-4']})) - ${blockPadding})`,
   }),
 });
 

--- a/packages/core/src/Toolbar/XDSToolbar.tsx
+++ b/packages/core/src/Toolbar/XDSToolbar.tsx
@@ -111,13 +111,13 @@ const dynamicStyles = stylex.create({
 const defaultBlockPaddingForSize: Record<XDSElementSize, SpacingStep> = {
   sm: 2,
   md: 2,
-  lg: 3,
+  lg: 2,
 };
 
 const blockPaddingVarForSize: Record<XDSElementSize, string> = {
   sm: spacingVars['--spacing-2'] as string,
   md: spacingVars['--spacing-2'] as string,
-  lg: spacingVars['--spacing-3'] as string,
+  lg: spacingVars['--spacing-2'] as string,
 };
 
 /**

--- a/packages/core/src/Toolbar/XDSToolbar.tsx
+++ b/packages/core/src/Toolbar/XDSToolbar.tsx
@@ -2,7 +2,7 @@
 
 /**
  * @file XDSToolbar.tsx
- * @input Uses XDSSection, XDSSizeContext, useListFocus, edgeSignals, StyleX, spacingVars, sizeVars
+ * @input Uses XDSSection, XDSSizeContext, useListFocus, StyleX, spacingVars, sizeVars
  * @output Exports XDSToolbar component and XDSToolbarProps
  * @position Core implementation; consumed by index.ts
  *
@@ -24,7 +24,6 @@ import {xdsClassName, mergeProps} from '../utils';
 import {XDSSection} from '../Section/XDSSection';
 import {useListFocus} from '../hooks/useListFocus';
 import {XDSSizeProvider} from '../SizeContext/XDSSizeContext';
-import {edgeSignals} from '../Layout/edgeCompensation.stylex';
 
 /**
  * Map SpacingStep values to spacingVars keys.
@@ -65,7 +64,6 @@ const styles = stylex.create({
   startSlot: {
     display: 'flex',
     alignItems: 'center',
-    paddingInlineStart: spacingVars['--spacing-2'],
   },
   centerSlot: {
     display: 'flex',
@@ -78,7 +76,6 @@ const styles = stylex.create({
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'flex-end',
-    paddingInlineEnd: spacingVars['--spacing-2'],
   },
   // When only startContent is present, let it fill
   startOnly: {
@@ -90,48 +87,50 @@ const styles = stylex.create({
   },
 });
 
-/**
- * Size-specific styles. Each size sets:
- * - minHeight: element token + vertical breathing room
- * - --container-padding-inline: so ghost buttons auto-compensate at edges
- */
 const sizeStyles = stylex.create({
-  sm: {
+  base: {
     minHeight: sizeVars['--size-element-sm'],
-  },
-  md: {
-    minHeight: sizeVars['--size-element-md'],
-  },
-  lg: {
-    minHeight: sizeVars['--size-element-lg'],
   },
 });
 
-/**
- * Container padding value per size for edge compensation.
- * Maps to the same spacing tokens used for the Section padding.
- */
-const containerPaddingValue: Record<XDSElementSize, string> = {
-  sm: '4px',
-  md: '8px',
-  lg: '12px',
-};
-
-// Dynamic styles for configurable gap
+// Dynamic styles for configurable gap and tab indicator offset
 const dynamicStyles = stylex.create({
   gap: (gapValue: string) => ({
     gap: gapValue,
   }),
+  tabIndicatorBottom: (offset: string) => ({
+    '--_tab-indicator-bottom': offset,
+  }),
 });
 
 /**
- * Default padding per toolbar size.
+ * Default block padding per toolbar size. Inline padding comes from the
+ * parent container (Card, Section, LayoutHeader) via the Section's
+ * theme default — the toolbar only controls its vertical tightness.
  */
-const defaultPaddingForSize: Record<XDSElementSize, SpacingStep> = {
-  sm: 1,
+const defaultBlockPaddingForSize: Record<XDSElementSize, SpacingStep> = {
+  sm: 2,
   md: 2,
   lg: 3,
 };
+
+const blockPaddingVarForSize: Record<XDSElementSize, string> = {
+  sm: spacingVars['--spacing-2'] as string,
+  md: spacingVars['--spacing-2'] as string,
+  lg: spacingVars['--spacing-3'] as string,
+};
+
+/**
+ * Dynamic edge inset style. The inset equals container-inline-padding minus
+ * the toolbar's block padding, creating even spacing around edge-compensated
+ * items (ghost buttons, tabs).
+ */
+const edgeInsetStyles = stylex.create({
+  inset: (blockPadding: string) => ({
+    '--edge-inset-start': `calc(var(--container-padding-inline-start, var(--container-padding-inline, ${spacingVars['--spacing-4']})) - ${blockPadding})`,
+    '--edge-inset-end': `calc(var(--container-padding-inline-end, var(--container-padding-inline, ${spacingVars['--spacing-4']})) - ${blockPadding})`,
+  }),
+});
 
 export type XDSToolbarSize = XDSElementSize;
 
@@ -168,7 +167,7 @@ export interface XDSToolbarProps extends XDSBaseProps<HTMLDivElement> {
   size?: XDSToolbarSize;
   /**
    * Gap between items within each slot, using the spacing scale.
-   * @default 2
+   * @default 1
    */
   gap?: SpacingStep;
   /**
@@ -182,11 +181,7 @@ export interface XDSToolbarProps extends XDSBaseProps<HTMLDivElement> {
    * @default 'transparent'
    */
   variant?: XDSSectionVariant;
-  /**
-   * Internal padding using the spacing scale.
-   * Passed through to XDSSection. Defaults based on size (sm=1/4px, md=2/8px, lg=3/12px).
-   */
-  padding?: SpacingStep;
+
   /**
    * Which sides should have divider borders.
    * Passed through to XDSSection.
@@ -220,10 +215,9 @@ export function XDSToolbar({
   endContent,
   label,
   size = 'md',
-  gap = 2,
+  gap = 1,
   orientation = 'horizontal',
   variant = 'transparent',
-  padding,
   dividers,
   xstyle,
   className,
@@ -236,7 +230,6 @@ export function XDSToolbar({
   const hasEndContent = endContent != null;
 
   const gapVar = spacingVars[spacingStepToVar[gap]] as string;
-  const resolvedPadding = padding ?? defaultPaddingForSize[size];
 
   const {listRef, handleKeyDown} = useListFocus({
     itemSelector: 'button, input, [tabindex="0"]',
@@ -248,16 +241,11 @@ export function XDSToolbar({
       <XDSSection
         ref={ref}
         variant={variant}
-        padding={resolvedPadding}
+        paddingBlock={defaultBlockPaddingForSize[size]}
         dividers={dividers}
         xstyle={xstyle}
         className={className}
-        style={
-          {
-            ...style,
-            '--container-padding-inline': containerPaddingValue[size],
-          } as React.CSSProperties
-        }>
+        style={style}>
         <div
           ref={listRef as React.RefObject<HTMLDivElement>}
           role="toolbar"
@@ -269,8 +257,11 @@ export function XDSToolbar({
             stylex.props(
               hasCenterContent ? styles.baseGrid : styles.baseFlex,
               orientation === 'vertical' && styles.vertical,
-              sizeStyles[size],
+              sizeStyles.base,
               dynamicStyles.gap(gapVar),
+              dynamicStyles.tabIndicatorBottom(
+                `calc(-1 * (${blockPaddingVarForSize[size]}${dividers?.includes('bottom') ? ' + 1px' : ''}))`,
+              ),
             ),
           )}
           {...props}>
@@ -280,7 +271,7 @@ export function XDSToolbar({
               <div
                 {...stylex.props(
                   styles.startSlot,
-                  edgeSignals.start,
+                  edgeInsetStyles.inset(blockPaddingVarForSize[size]),
                   dynamicStyles.gap(gapVar),
                 )}>
                 {startContent}
@@ -292,7 +283,7 @@ export function XDSToolbar({
               <div
                 {...stylex.props(
                   styles.endSlot,
-                  edgeSignals.end,
+                  edgeInsetStyles.inset(blockPaddingVarForSize[size]),
                   dynamicStyles.gap(gapVar),
                 )}>
                 {endContent}
@@ -306,9 +297,7 @@ export function XDSToolbar({
                   {...stylex.props(
                     styles.startSlot,
                     !hasEndContent && styles.startOnly,
-                    // Edge signal: start slot is at the start edge;
-                    // if no end content, it's also at the end edge.
-                    !hasEndContent ? edgeSignals.both : edgeSignals.start,
+                    edgeInsetStyles.inset(blockPaddingVarForSize[size]),
                     dynamicStyles.gap(gapVar),
                   )}>
                   {startContent}
@@ -319,7 +308,7 @@ export function XDSToolbar({
                   {...stylex.props(
                     styles.endSlot,
                     !hasStartContent && styles.endOnly,
-                    !hasStartContent ? edgeSignals.both : edgeSignals.end,
+                    edgeInsetStyles.inset(blockPaddingVarForSize[size]),
                     dynamicStyles.gap(gapVar),
                   )}>
                   {endContent}

--- a/packages/core/src/TopNav/XDSTopNav.tsx
+++ b/packages/core/src/TopNav/XDSTopNav.tsx
@@ -17,7 +17,7 @@ import {type ReactNode} from 'react';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars, spacingVars} from '../theme/tokens.stylex';
-import {edgeSignals} from '../Layout/edgeCompensation.stylex';
+import {edgeInset} from '../Layout/edgeCompensation.stylex';
 import {xdsClassName, mergeProps} from '../utils';
 import {XDSTopNavSlotContext} from './TopNavContext';
 import {useXDSTopNavRenderMode} from './XDSTopNavRenderContext';
@@ -36,8 +36,6 @@ const styles = stylex.create({
     width: '100%',
     padding: spacingVars['--spacing-2'],
     boxSizing: 'border-box',
-    // Publish inline padding for edge compensation (ghost buttons at edges).
-    '--container-padding-inline': spacingVars['--spacing-2'],
   },
   // Flex layout (default, used when no centerContent)
   baseFlex: {
@@ -256,7 +254,7 @@ export function XDSTopNav({
         style,
       )}
       {...props}>
-      <div {...stylex.props(styles.leftSection, edgeSignals.start)}>
+      <div {...stylex.props(styles.leftSection, edgeInset.start2)}>
         {heading && <div {...stylex.props(styles.heading)}>{heading}</div>}
         {startContent && (
           <XDSTopNavSlotContext value="start">
@@ -270,12 +268,12 @@ export function XDSTopNav({
         </XDSTopNavSlotContext>
       )}
       {hasCenterContent ? (
-        <div {...stylex.props(styles.rightSection, edgeSignals.end)}>
+        <div {...stylex.props(styles.rightSection, edgeInset.end2)}>
           <XDSTopNavSlotContext value="end">{endContent}</XDSTopNavSlotContext>
         </div>
       ) : (
         endContent && (
-          <div {...stylex.props(styles.endContent, edgeSignals.end)}>
+          <div {...stylex.props(styles.endContent, edgeInset.end2)}>
             <XDSTopNavSlotContext value="end">
               {endContent}
             </XDSTopNavSlotContext>

--- a/packages/core/src/TopNav/XDSTopNav.tsx
+++ b/packages/core/src/TopNav/XDSTopNav.tsx
@@ -254,7 +254,7 @@ export function XDSTopNav({
         style,
       )}
       {...props}>
-      <div {...stylex.props(styles.leftSection, edgeInset.start2)}>
+      <div {...stylex.props(styles.leftSection, edgeInset.start1)}>
         {heading && <div {...stylex.props(styles.heading)}>{heading}</div>}
         {startContent && (
           <XDSTopNavSlotContext value="start">
@@ -268,12 +268,12 @@ export function XDSTopNav({
         </XDSTopNavSlotContext>
       )}
       {hasCenterContent ? (
-        <div {...stylex.props(styles.rightSection, edgeInset.end2)}>
+        <div {...stylex.props(styles.rightSection)}>
           <XDSTopNavSlotContext value="end">{endContent}</XDSTopNavSlotContext>
         </div>
       ) : (
         endContent && (
-          <div {...stylex.props(styles.endContent, edgeInset.end2)}>
+          <div {...stylex.props(styles.endContent)}>
             <XDSTopNavSlotContext value="end">
               {endContent}
             </XDSTopNavSlotContext>

--- a/packages/core/src/TopNav/XDSTopNav.tsx
+++ b/packages/core/src/TopNav/XDSTopNav.tsx
@@ -17,7 +17,6 @@ import {type ReactNode} from 'react';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars, spacingVars} from '../theme/tokens.stylex';
-import {edgeInset} from '../Layout/edgeCompensation.stylex';
 import {xdsClassName, mergeProps} from '../utils';
 import {XDSTopNavSlotContext} from './TopNavContext';
 import {useXDSTopNavRenderMode} from './XDSTopNavRenderContext';
@@ -254,7 +253,7 @@ export function XDSTopNav({
         style,
       )}
       {...props}>
-      <div {...stylex.props(styles.leftSection, edgeInset.start1)}>
+      <div {...stylex.props(styles.leftSection)}>
         {heading && <div {...stylex.props(styles.heading)}>{heading}</div>}
         {startContent && (
           <XDSTopNavSlotContext value="start">

--- a/packages/core/src/theme/derivedVarRegistry.test.ts
+++ b/packages/core/src/theme/derivedVarRegistry.test.ts
@@ -31,6 +31,8 @@ const STRUCTURAL_VARS = new Set([
   '--container-padding-inline',
   '--container-padding-inline-start',
   '--container-padding-inline-end',
+  '--edge-inset-start',
+  '--edge-inset-end',
   '--container-padding-block-start',
   '--container-padding-block-end',
   '--container-max-height',

--- a/packages/core/src/theme/derivedVarRegistry.test.ts
+++ b/packages/core/src/theme/derivedVarRegistry.test.ts
@@ -39,9 +39,6 @@ const STRUCTURAL_VARS = new Set([
   '--layout-padding-outer-x',
   '--layout-padding-outer-y',
   '--layout-content-width',
-  '--edge-start',
-  '--edge-end',
-  '--component-padding-inline',
   '--appshell-header-height',
   '--dialog-dir-x',
   '--dialog-dir-y',
@@ -65,11 +62,18 @@ function extractComponentVars(filePath: string): string[] {
   while ((match = varPattern.exec(content)) !== null) {
     const varName = match[1];
     // Skip token vars (--color-*, --spacing-*, --radius-*, etc.)
-    if (/^--(color|spacing|radius|shadow|duration|ease|transition|font|text|size)-/.test(varName)) continue;
+    if (
+      /^--(color|spacing|radius|shadow|duration|ease|transition|font|text|size)-/.test(
+        varName,
+      )
+    )
+      continue;
     // Skip structural vars
     if (STRUCTURAL_VARS.has(varName)) continue;
     // Skip vars that start with structural prefixes
     if (/^--(container-|layout-|edge-|component-)/.test(varName)) continue;
+    // Skip private vars (--_ prefix = internal, not themeable)
+    if (varName.startsWith('--_')) continue;
     vars.add(varName);
   }
   return [...vars];
@@ -96,7 +100,13 @@ function discoverComponents(): ComponentInfo[] {
     const dirPath = join(SRC_DIR, dir);
     // Find source files with component vars (.tsx and .ts, excluding tests/docs)
     const sourceFiles = readdirSync(dirPath)
-      .filter(f => (f.endsWith('.tsx') || f.endsWith('.ts')) && !f.includes('.test.') && !f.endsWith('.doc.mjs') && !f.endsWith('.d.ts'))
+      .filter(
+        f =>
+          (f.endsWith('.tsx') || f.endsWith('.ts')) &&
+          !f.includes('.test.') &&
+          !f.endsWith('.doc.mjs') &&
+          !f.endsWith('.d.ts'),
+      )
       .map(f => join(dirPath, f));
 
     const allVars = new Set<string>();
@@ -117,7 +127,9 @@ function discoverComponents(): ComponentInfo[] {
       const mod = require(docPath);
       docVars = (mod.docs?.theming?.vars || []).map((v: any) => v.name);
       docDerived = mod.docs?.theming?.derived || [];
-    } catch { /* skip */ }
+    } catch {
+      /* skip */
+    }
 
     results.push({
       dir,
@@ -178,8 +190,8 @@ describe('component CSS vars are documented and themeable', () => {
       expect(
         undocumented,
         `${dir} has undocumented CSS vars in source: ${undocumented.join(', ')}. ` +
-        `Add them to ${dir}.doc.mjs theming.vars[] and add a derived[] ` +
-        `entry mapping the standard CSS property to the internal var.`,
+          `Add them to ${dir}.doc.mjs theming.vars[] and add a derived[] ` +
+          `entry mapping the standard CSS property to the internal var.`,
       ).toEqual([]);
     });
 
@@ -215,8 +227,8 @@ describe('component CSS vars are documented and themeable', () => {
       expect(
         themeableVars,
         `${dir} has vars that should be themeable via derived[]: ${themeableVars.join(', ')}. ` +
-        `Add derived[] entries in ${dir}.doc.mjs mapping standard CSS ` +
-        `properties (borderRadius, padding) to these internal vars.`,
+          `Add derived[] entries in ${dir}.doc.mjs mapping standard CSS ` +
+          `properties (borderRadius, padding) to these internal vars.`,
       ).toEqual([]);
     });
   }
@@ -245,7 +257,7 @@ describe('derivedVarRegistry ↔ doc file consistency', () => {
       if (!key) {
         missing.push(
           `${dir}: has theming.derived but no DIR_TO_REGISTRY_KEY mapping. ` +
-          `Add the mapping and a derivedVarRegistry entry.`,
+            `Add the mapping and a derivedVarRegistry entry.`,
         );
       } else if (!derivedVarRegistry[key]) {
         missing.push(
@@ -258,7 +270,9 @@ describe('derivedVarRegistry ↔ doc file consistency', () => {
 
   it('registry has no orphan entries', () => {
     const validKeys = new Set(Object.values(DIR_TO_REGISTRY_KEY));
-    const orphans = Object.keys(derivedVarRegistry).filter(k => !validKeys.has(k));
+    const orphans = Object.keys(derivedVarRegistry).filter(
+      k => !validKeys.has(k),
+    );
     expect(orphans).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

Redesigns the edge compensation system to be simpler and more correct.

### New model

**Container-side:** `edgeInset` styles set `--edge-inset-start`/`--edge-inset-end` on slot wrappers — the actual px amount to compensate. The container decides the budget.

**Component-side:** `edgeCompensation.item` uses `:first-child`/`:last-child` selectors to apply negative margin only on edge-adjacent items. Components opt in.

### Toolbar changes

- **Inline padding** now comes from the parent container (Section theme default) — the toolbar no longer manages its own inline padding
- **Block padding** is the only axis the toolbar controls (8px for all sizes)
- **Edge inset** = `container-inline-padding - block-padding` (creates even spacing around ghost buttons/tabs)
- **Gap** default changed from `spacing-2` to `spacing-1`
- **Min-height** is always `--size-element-sm` — content sizes itself naturally
- **Tab indicator** offset via `--_tab-indicator-bottom` private CSS var (includes divider width when present)
- **Removed** `padding` prop (no longer needed)

### Section changes

- Added `paddingBlock` prop for independent block axis override
- Fixed `nestedStyles.outer` to use directional `--container-padding-inline-start/end` vars
- Inner wrapper now resets directional vars alongside the shorthand

### TopNav changes

- **Removed edge compensation entirely.** TopNav doesn't place ghost buttons at its edges — the heading is at the start and utility buttons at the end don't need inset adjustment. The old system was compensating unnecessarily (and too aggressively since #878 halved the inline padding from 16px to 8px without updating the compensation).

### Other changes

- **Button:** simplified to `edgeCompensation.item` (removed `--component-padding-inline`)
- **Tab:** added `edgeCompensation.item` + indicator reads `--_tab-indicator-bottom`
- **Banner:** removed unused `--container-padding-inline` (dead code)
- **Stories:** rewrote Toolbar.stories.tsx to use size cascading properly; added 20+ edge compensation test stories
- **derivedVar test:** skip `--_` prefixed private vars; added `--edge-inset-*` to structural vars

### Old vs New

| Aspect | Old | New |
|--------|-----|-----|
| Container signal | `--edge-start: 1` multiplier | `--edge-inset-start: 12px` direct value |
| Component formula | `min(own-padding, container-padding)` | `var(--edge-inset-start, 0px)` |
| Position detection | Wrapper div with signal | `:first-child`/`:last-child` on component |
| Amount decided by | Component + container together | Container alone |

## Test plan

- [x] 158 unit tests pass (Toolbar, Tab, Button, TopNav, Banner, Section, EdgeComp)
- [x] Zero type errors
- [x] Storybook renders all edge compensation examples
- [ ] Visual verification of even spacing in all toolbar size variants
