### PR TITLE
feat(chart): brush highlight + kitchen sink interaction demo

### DIFF
--- a/apps/storybook/stories/ChartInteractions.stories.tsx
+++ b/apps/storybook/stories/ChartInteractions.stories.tsx
@@ -314,3 +314,65 @@ export const ReferenceLines: StoryObj = {
     );
   },
 };
+
+/** Kitchen sink: brush highlight + zoom/pan + tooltip + click select */
+export const KitchenSink: StoryObj = {
+  render: () => {
+    const colors = useXDSChartColors();
+    const [raw] = useDataset<Car>('cars.json');
+    const data = useMemo(
+      () =>
+        raw
+          .filter(d => d.Horsepower != null && d.Miles_per_Gallon != null)
+          .map(d => ({hp: d.Horsepower, mpg: d.Miles_per_Gallon})),
+      [raw],
+    );
+    const [xDomain, setXDomain] = useState<[number, number]>([40, 230]);
+    const [yDomain, setYDomain] = useState<[number, number]>([8, 47]);
+    const [selected, setSelected] = useState<number[]>([]);
+    const [brushCount, setBrushCount] = useState<number | null>(null);
+
+    if (!data.length) return <XDSText type="supporting">Loading…</XDSText>;
+
+    return (
+      <XDSStack direction="vertical" gap={4}>
+        <XDSHeading level={3}>Kitchen Sink</XDSHeading>
+        <XDSText type="supporting" color="secondary">
+          Scroll to zoom. Drag to pan. Brush (shift+drag) to highlight. Click a
+          point to select. Hover for tooltip + crosshair.
+          {brushCount != null && ` ${brushCount} points brushed.`}
+          {selected.length > 0 && ` ${selected.length} points selected.`}
+        </XDSText>
+        <XDSChart
+          data={data}
+          xKey="hp"
+          yKeys={['mpg']}
+          xDomain={xDomain}
+          yDomain={yDomain}
+          interactive
+          height={450}>
+          <XDSChartGrid horizontal vertical />
+          <XDSChartAxis position="bottom" />
+          <XDSChartAxis position="left" />
+          <XDSChartDot
+            dataKey="mpg"
+            color={colors.categorical(1)[0]}
+            radius={4}
+          />
+          <XDSChartTooltip crosshair="xy" />
+          <XDSChartBrush
+            mode="xy"
+            onBrush={(_, sel) => setBrushCount(sel.length)}
+            onClear={() => setBrushCount(null)}
+          />
+          <XDSChartSelect selected={selected} onSelectionChange={setSelected} />
+          <XDSChartZoom
+            onXDomainChange={setXDomain}
+            onYDomainChange={setYDomain}
+            toolbar="top-right"
+          />
+        </XDSChart>
+      </XDSStack>
+    );
+  },
+};

--- a/packages/lab/src/Chart/BrushContext.ts
+++ b/packages/lab/src/Chart/BrushContext.ts
@@ -1,0 +1,23 @@
+/**
+ * @file BrushContext.ts
+ * @output React context for active brush range
+ * @position Provided by XDSChart; written by XDSChartBrush, read by marks via useBrush()
+ */
+
+import {createContext, useContext} from 'react';
+import type {BrushState} from './types';
+
+const BrushCtx = createContext<BrushState>({
+  range: null,
+  setRange: () => {},
+});
+
+export const BrushProvider = BrushCtx.Provider;
+
+/**
+ * Read the active brush state.
+ * When range is null, no brush is active — nothing should be muted.
+ */
+export function useBrush(): BrushState {
+  return useContext(BrushCtx);
+}

--- a/packages/lab/src/Chart/EventLayer.tsx
+++ b/packages/lab/src/Chart/EventLayer.tsx
@@ -1,0 +1,186 @@
+/**
+ * @file EventLayer.tsx
+ * @output Single event capture rect that dispatches to registered interactions
+ * @position Last child inside XDSChart's plot area <g>
+ *
+ * Solves the overlapping-rect problem: tooltip, brush, zoom, and select
+ * all need pointer events but can't each have their own capture rect.
+ * This component renders one rect and routes gestures by type:
+ *
+ *   - pointerMove (no button) → tooltip/crosshair
+ *   - pointerDown + drag → brush OR pan (based on which is registered)
+ *   - wheel / pinch → zoom
+ *   - click (no drag) → select
+ */
+
+import {useCallback, useRef} from 'react';
+import {useChart} from './ChartContext';
+
+export interface GestureHandlers {
+  /** Hover / touch scrub — tooltip + crosshair */
+  onHover?: (e: React.PointerEvent<SVGRectElement>) => void;
+  onHoverEnd?: () => void;
+
+  /** Drag gesture — brush selection */
+  onDragStart?: (e: React.PointerEvent<SVGRectElement>) => void;
+  onDragMove?: (e: React.PointerEvent<SVGRectElement>) => void;
+  onDragEnd?: (e: React.PointerEvent<SVGRectElement>) => void;
+
+  /** Wheel / pinch — zoom */
+  onWheel?: (e: React.WheelEvent<SVGRectElement>) => void;
+  onPinchStart?: (e: React.PointerEvent<SVGRectElement>) => void;
+  onPinchMove?: (e: React.PointerEvent<SVGRectElement>) => void;
+  onPinchEnd?: (e: React.PointerEvent<SVGRectElement>) => void;
+
+  /** Click (no drag) — select */
+  onClick?: (e: React.PointerEvent<SVGRectElement>) => void;
+}
+
+const DRAG_THRESHOLD = 4; // px — below this it's a click, not a drag
+
+export function EventLayer({handlers}: {handlers: GestureHandlers}) {
+  const {width, height} = useChart();
+
+  const dragging = useRef(false);
+  const dragStartPos = useRef({x: 0, y: 0});
+  const pointerDown = useRef(false);
+  const pointersRef = useRef<Map<number, {x: number; y: number}>>(new Map());
+  const pinching = useRef(false);
+  const touchActive = useRef(false);
+
+  const handlePointerDown = useCallback(
+    (e: React.PointerEvent<SVGRectElement>) => {
+      e.preventDefault(); // prevent text selection on touch
+
+      pointersRef.current.set(e.pointerId, {x: e.clientX, y: e.clientY});
+
+      // Two fingers → pinch
+      if (pointersRef.current.size === 2) {
+        pinching.current = true;
+        dragging.current = false;
+        pointerDown.current = false;
+        handlers.onPinchStart?.(e);
+        return;
+      }
+
+      // Single pointer
+      pointerDown.current = true;
+      dragging.current = false;
+      dragStartPos.current = {x: e.clientX, y: e.clientY};
+
+      if (e.pointerType !== 'mouse') {
+        touchActive.current = true;
+        // Touch: show tooltip immediately on tap
+        handlers.onHover?.(e);
+      }
+    },
+    [handlers],
+  );
+
+  const handlePointerMove = useCallback(
+    (e: React.PointerEvent<SVGRectElement>) => {
+      pointersRef.current.set(e.pointerId, {x: e.clientX, y: e.clientY});
+
+      // Pinch zoom
+      if (pinching.current && pointersRef.current.size === 2) {
+        handlers.onPinchMove?.(e);
+        return;
+      }
+
+      // Check if we've exceeded drag threshold
+      if (pointerDown.current && !dragging.current) {
+        const dx = Math.abs(e.clientX - dragStartPos.current.x);
+        const dy = Math.abs(e.clientY - dragStartPos.current.y);
+        if (dx > DRAG_THRESHOLD || dy > DRAG_THRESHOLD) {
+          dragging.current = true;
+          handlers.onDragStart?.(e);
+        }
+      }
+
+      // Active drag
+      if (dragging.current) {
+        handlers.onDragMove?.(e);
+        // Also update tooltip during drag (for brush + crosshair combo)
+        handlers.onHover?.(e);
+        return;
+      }
+
+      // Plain hover (mouse) or touch scrub (after tap)
+      if (e.pointerType === 'mouse' || touchActive.current) {
+        handlers.onHover?.(e);
+      }
+    },
+    [handlers],
+  );
+
+  const handlePointerUp = useCallback(
+    (e: React.PointerEvent<SVGRectElement>) => {
+      pointersRef.current.delete(e.pointerId);
+
+      if (pinching.current) {
+        if (pointersRef.current.size < 2) {
+          pinching.current = false;
+          handlers.onPinchEnd?.(e);
+        }
+        return;
+      }
+
+      if (dragging.current) {
+        dragging.current = false;
+        pointerDown.current = false;
+        handlers.onDragEnd?.(e);
+      } else if (pointerDown.current) {
+        // No drag happened → it's a click
+        pointerDown.current = false;
+        handlers.onClick?.(e);
+      }
+
+      // Touch: dismiss tooltip on lift
+      if (e.pointerType !== 'mouse') {
+        touchActive.current = false;
+        handlers.onHoverEnd?.();
+      }
+    },
+    [handlers],
+  );
+
+  const handlePointerLeave = useCallback(
+    (_e: React.PointerEvent<SVGRectElement>) => {
+      if (!pointerDown.current && !touchActive.current) {
+        handlers.onHoverEnd?.();
+      }
+    },
+    [handlers],
+  );
+
+  const handleWheel = useCallback(
+    (e: React.WheelEvent<SVGRectElement>) => {
+      e.preventDefault();
+      handlers.onWheel?.(e);
+    },
+    [handlers],
+  );
+
+  return (
+    <rect
+      x={0}
+      y={0}
+      width={width}
+      height={height}
+      fill="transparent"
+      style={
+        {
+          touchAction: 'none',
+          userSelect: 'none',
+          cursor: 'crosshair',
+        } as React.CSSProperties
+      }
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerUp}
+      onPointerCancel={handlePointerUp}
+      onPointerLeave={handlePointerLeave}
+      onWheel={handleWheel}
+    />
+  );
+}

--- a/packages/lab/src/Chart/InteractionContext.ts
+++ b/packages/lab/src/Chart/InteractionContext.ts
@@ -1,0 +1,77 @@
+/**
+ * @file InteractionContext.ts
+ * @output Shared gesture dispatch for chart interactions
+ * @position Provided by XDSChart; interaction components register handlers
+ *
+ * Solves the overlapping-rect problem: one EventLayer rect dispatches
+ * gestures to all registered handlers based on gesture type.
+ */
+
+import {createContext, useContext, useCallback, useRef} from 'react';
+import type {GestureHandlers} from './EventLayer';
+
+export interface InteractionRegistry {
+  /** Register a set of gesture handlers. Returns unregister function. */
+  register: (id: string, handlers: Partial<GestureHandlers>) => () => void;
+  /** Get merged handlers for the EventLayer */
+  getHandlers: () => GestureHandlers;
+}
+
+/**
+ * Create an interaction registry. Called once in XDSChart.
+ */
+export function useInteractionRegistry(): InteractionRegistry {
+  const handlersMap = useRef(new Map<string, Partial<GestureHandlers>>());
+
+  const register = useCallback(
+    (id: string, handlers: Partial<GestureHandlers>) => {
+      handlersMap.current.set(id, handlers);
+      return () => {
+        handlersMap.current.delete(id);
+      };
+    },
+    [],
+  );
+
+  const getHandlers = useCallback((): GestureHandlers => {
+    const all = [...handlersMap.current.values()];
+
+    // Merge: each gesture type calls all registered handlers
+    const merge = <K extends keyof GestureHandlers>(key: K) => {
+      const fns = all
+        .map(h => h[key])
+        .filter((f): f is NonNullable<GestureHandlers[K]> => f != null);
+      if (fns.length === 0) return undefined;
+      return ((...args: unknown[]) => {
+        for (const fn of fns) (fn as (...a: unknown[]) => void)(...args);
+      }) as GestureHandlers[K];
+    };
+
+    return {
+      onHover: merge('onHover'),
+      onHoverEnd: merge('onHoverEnd'),
+      onDragStart: merge('onDragStart'),
+      onDragMove: merge('onDragMove'),
+      onDragEnd: merge('onDragEnd'),
+      onWheel: merge('onWheel'),
+      onPinchStart: merge('onPinchStart'),
+      onPinchMove: merge('onPinchMove'),
+      onPinchEnd: merge('onPinchEnd'),
+      onClick: merge('onClick'),
+    };
+  }, []);
+
+  return {register, getHandlers};
+}
+
+const InteractionCtx = createContext<InteractionRegistry | null>(null);
+
+export const InteractionProvider = InteractionCtx.Provider;
+
+export function useInteraction(): InteractionRegistry {
+  const ctx = useContext(InteractionCtx);
+  if (!ctx) {
+    throw new Error('Interaction components must be inside <XDSChart>');
+  }
+  return ctx;
+}

--- a/packages/lab/src/Chart/XDSChart.tsx
+++ b/packages/lab/src/Chart/XDSChart.tsx
@@ -19,7 +19,8 @@ import {scaleLinear, scaleBand} from 'd3-scale';
 import type {ScaleLinear} from 'd3-scale';
 import {isBandScale} from './utils';
 import {ChartProvider} from './ChartContext';
-import type {ChartMargin, ChartScale} from './types';
+import {BrushProvider} from './BrushContext';
+import type {ChartMargin, ChartScale, BrushRange} from './types';
 
 /**
  * Controls how the y-axis domain is computed:
@@ -205,7 +206,10 @@ export function XDSChart({
       if (isBandScale(xScale)) {
         const domain = xScale.domain();
         const step = xScale.step();
-        const idx = Math.min(domain.length - 1, Math.max(0, Math.floor(px / step)));
+        const idx = Math.min(
+          domain.length - 1,
+          Math.max(0, Math.floor(px / step)),
+        );
         x = domain[idx];
       } else {
         x = (xScale as ScaleLinear<number, number>).invert(px);
@@ -244,20 +248,51 @@ export function XDSChart({
       pointerToData,
       pixelToData,
     }),
-    [innerWidth, innerHeight, margin, xKey, data, xScale, yScale, pointerToData, pixelToData],
+    [
+      innerWidth,
+      innerHeight,
+      margin,
+      xKey,
+      data,
+      xScale,
+      yScale,
+      pointerToData,
+      pixelToData,
+    ],
+  );
+
+  // Brush highlight state — shared with mark components via BrushContext
+  const [brushRange, setBrushRange] = useState<BrushRange | null>(null);
+  const brushState = useMemo(
+    () => ({range: brushRange, setRange: setBrushRange}),
+    [brushRange],
   );
 
   return (
-    <div ref={containerRef} style={{width: '100%', touchAction: interactive ? 'none' : undefined, userSelect: interactive ? 'none' : undefined} as React.CSSProperties}>
+    <div
+      ref={containerRef}
+      style={
+        {
+          width: '100%',
+          touchAction: interactive ? 'none' : undefined,
+          userSelect: interactive ? 'none' : undefined,
+        } as React.CSSProperties
+      }>
       {containerWidth > 0 && (
-        <svg ref={svgRef} width={containerWidth} height={height} style={interactive ? {touchAction: 'none'} : undefined}>
+        <svg
+          ref={svgRef}
+          width={containerWidth}
+          height={height}
+          style={interactive ? {touchAction: 'none'} : undefined}>
           <defs>
             <clipPath id="xds-chart-plot">
               <rect x={0} y={0} width={innerWidth} height={innerHeight} />
             </clipPath>
           </defs>
           <g transform={`translate(${margin.left},${margin.top})`}>
-            <ChartProvider value={ctx}>{children}</ChartProvider>
+            <BrushProvider value={brushState}>
+              <ChartProvider value={ctx}>{children}</ChartProvider>
+            </BrushProvider>
           </g>
         </svg>
       )}

--- a/packages/lab/src/Chart/XDSChart.tsx
+++ b/packages/lab/src/Chart/XDSChart.tsx
@@ -20,6 +20,11 @@ import type {ScaleLinear} from 'd3-scale';
 import {isBandScale} from './utils';
 import {ChartProvider} from './ChartContext';
 import {BrushProvider} from './BrushContext';
+import {
+  InteractionProvider,
+  useInteractionRegistry,
+} from './InteractionContext';
+import {EventLayer} from './EventLayer';
 import type {ChartMargin, ChartScale, BrushRange} from './types';
 
 /**
@@ -268,12 +273,16 @@ export function XDSChart({
     [brushRange],
   );
 
+  // Interaction registry — one EventLayer dispatches to all registered handlers
+  const interactionRegistry = useInteractionRegistry();
+
   return (
     <div
       ref={containerRef}
       style={
         {
           width: '100%',
+          position: 'relative',
           touchAction: interactive ? 'none' : undefined,
           userSelect: interactive ? 'none' : undefined,
         } as React.CSSProperties
@@ -290,9 +299,14 @@ export function XDSChart({
             </clipPath>
           </defs>
           <g transform={`translate(${margin.left},${margin.top})`}>
-            <BrushProvider value={brushState}>
-              <ChartProvider value={ctx}>{children}</ChartProvider>
-            </BrushProvider>
+            <InteractionProvider value={interactionRegistry}>
+              <BrushProvider value={brushState}>
+                <ChartProvider value={ctx}>
+                  {children}
+                  <EventLayer handlers={interactionRegistry.getHandlers()} />
+                </ChartProvider>
+              </BrushProvider>
+            </InteractionProvider>
           </g>
         </svg>
       )}

--- a/packages/lab/src/Chart/XDSChartBar.tsx
+++ b/packages/lab/src/Chart/XDSChartBar.tsx
@@ -5,6 +5,7 @@
  */
 
 import {useChart} from './ChartContext';
+import {useBrush} from './BrushContext';
 import {isBandScale} from './utils';
 
 export interface XDSChartBarProps {
@@ -27,6 +28,7 @@ export interface XDSChartBarProps {
  */
 export function XDSChartBar({dataKey, color, radius = 4}: XDSChartBarProps) {
   const {data, xKey, xScale, yScale} = useChart();
+  const {range} = useBrush();
 
   if (!isBandScale(xScale)) return null;
 
@@ -47,6 +49,19 @@ export function XDSChartBar({dataKey, color, radius = 4}: XDSChartBarProps) {
         const barY = Math.min(yPos, zeroY);
         const barHeight = Math.abs(yPos - zeroY);
 
+        // Dim bars outside brush (band scale: use index-based x range check)
+        let opacity = 1;
+        if (range) {
+          const idx = i;
+          const domainLen = xScale.domain().length;
+          const normalizedX =
+            range.x[0] + (idx / domainLen) * (range.x[1] - range.x[0]);
+          // For band scales, check if bar index falls within brush pixel range
+          const barMidPx = xVal + xScale.bandwidth() / 2;
+          const inX = barMidPx >= range.x[0] && barMidPx <= range.x[1];
+          opacity = inX ? 1 : 0.15;
+        }
+
         return (
           <rect
             key={i}
@@ -55,6 +70,7 @@ export function XDSChartBar({dataKey, color, radius = 4}: XDSChartBarProps) {
             width={xScale.bandwidth()}
             height={Math.max(0, barHeight)}
             fill={color}
+            opacity={opacity}
             rx={radius}
             ry={radius}
           />

--- a/packages/lab/src/Chart/XDSChartBrush.tsx
+++ b/packages/lab/src/Chart/XDSChartBrush.tsx
@@ -4,9 +4,10 @@
  * @position Child of XDSChart; reads scales from context
  */
 
-import React, {useState, useCallback, useRef} from 'react';
+import React, {useState, useCallback, useRef, useEffect} from 'react';
 import {useChart} from './ChartContext';
 import {useBrush} from './BrushContext';
+import {useInteraction} from './InteractionContext';
 import {isBandScale} from './utils';
 import type {ScaleLinear} from 'd3-scale';
 import type {BrushMode, BrushRange} from './types';
@@ -79,7 +80,7 @@ export function XDSChartBrush({
   color = 'var(--color-accent)',
   opacity = 0.15,
 }: XDSChartBrushProps) {
-  const {width, height, data, xKey, xScale, yScale} = useChart();
+  const {height, data, xKey, xScale, yScale} = useChart();
   const {setRange} = useBrush();
   const [brush, setBrush] = useState<{
     x0: number;
@@ -89,8 +90,9 @@ export function XDSChartBrush({
   } | null>(null);
   const dragging = useRef(false);
   const startRef = useRef({x: 0, y: 0});
+  const {register} = useInteraction();
 
-  const onPointerDown = useCallback((e: React.PointerEvent<SVGRectElement>) => {
+  const onDragStart = useCallback((e: React.PointerEvent<SVGRectElement>) => {
     (e.target as Element).setPointerCapture(e.pointerId);
     dragging.current = true;
     const {x, y} = localCoords(e);
@@ -98,7 +100,7 @@ export function XDSChartBrush({
     setBrush({x0: x, y0: y, x1: x, y1: y});
   }, []);
 
-  const onPointerMove = useCallback(
+  const onDragMove = useCallback(
     (e: React.PointerEvent<SVGRectElement>) => {
       if (!dragging.current) return;
       const {x, y} = localCoords(e);
@@ -123,7 +125,7 @@ export function XDSChartBrush({
     [mode, height],
   );
 
-  const onPointerUp = useCallback(() => {
+  const onDragEnd = useCallback(() => {
     dragging.current = false;
     if (!brush) return;
 
@@ -176,6 +178,17 @@ export function XDSChartBrush({
     onBrush?.(range, selected);
   }, [brush, mode, xScale, yScale, data, xKey, onBrush, onClear, setRange]);
 
+  // Register with shared event layer
+  useEffect(
+    () =>
+      register('brush', {
+        onDragStart: onDragStart,
+        onDragMove: onDragMove,
+        onDragEnd: onDragEnd,
+      }),
+    [register, onDragStart, onDragMove, onDragEnd],
+  );
+
   const rectX = brush ? brush.x0 : 0;
   const rectY = brush ? brush.y0 : 0;
   const rectW = brush ? brush.x1 - brush.x0 : 0;
@@ -183,24 +196,6 @@ export function XDSChartBrush({
 
   return (
     <g>
-      <rect
-        x={0}
-        y={0}
-        width={width}
-        height={height}
-        fill="transparent"
-        style={
-          {
-            cursor: 'crosshair',
-            touchAction: 'none',
-            userSelect: 'none',
-          } as React.CSSProperties
-        }
-        onPointerDown={onPointerDown}
-        onPointerMove={onPointerMove}
-        onPointerUp={onPointerUp}
-        onPointerCancel={onPointerUp}
-      />
       {brush && (rectW > 1 || rectH > 1) && (
         <rect
           x={rectX}

--- a/packages/lab/src/Chart/XDSChartBrush.tsx
+++ b/packages/lab/src/Chart/XDSChartBrush.tsx
@@ -6,20 +6,12 @@
 
 import React, {useState, useCallback, useRef} from 'react';
 import {useChart} from './ChartContext';
+import {useBrush} from './BrushContext';
 import {isBandScale} from './utils';
 import type {ScaleLinear} from 'd3-scale';
+import type {BrushMode, BrushRange} from './types';
 
-/**
- * Brush direction mode:
- * - `'x'` — horizontal range selection (default)
- * - `'xy'` — 2D rectangular selection
- */
-export type BrushMode = 'x' | 'xy';
-
-export interface BrushRange {
-  x: [number, number];
-  y?: [number, number];
-}
+export type {BrushMode, BrushRange};
 
 export interface XDSChartBrushProps {
   /**
@@ -88,6 +80,7 @@ export function XDSChartBrush({
   opacity = 0.15,
 }: XDSChartBrushProps) {
   const {width, height, data, xKey, xScale, yScale} = useChart();
+  const {setRange} = useBrush();
   const [brush, setBrush] = useState<{
     x0: number;
     y0: number;
@@ -140,13 +133,14 @@ export function XDSChartBrush({
     // Too small — treat as click (clear)
     if (dx < 3 && (mode === 'x' || dy < 3)) {
       setBrush(null);
+      setRange(null);
       onClear?.();
       return;
     }
 
     if (isBandScale(xScale)) {
-      // Band scale — can't invert meaningfully for range
       setBrush(null);
+      setRange(null);
       return;
     }
 
@@ -166,7 +160,6 @@ export function XDSChartBrush({
       selected = data.filter(d => {
         const xv = d[xKey];
         if (typeof xv !== 'number' || xv < xMin || xv > xMax) return false;
-        // Check all numeric values against y range
         return Object.entries(d).some(
           ([k, v]) =>
             k !== xKey && typeof v === 'number' && v >= yMin && v <= yMax,
@@ -179,8 +172,9 @@ export function XDSChartBrush({
       });
     }
 
+    setRange(range);
     onBrush?.(range, selected);
-  }, [brush, mode, xScale, yScale, data, xKey, onBrush, onClear]);
+  }, [brush, mode, xScale, yScale, data, xKey, onBrush, onClear, setRange]);
 
   const rectX = brush ? brush.x0 : 0;
   const rectY = brush ? brush.y0 : 0;

--- a/packages/lab/src/Chart/XDSChartDot.tsx
+++ b/packages/lab/src/Chart/XDSChartDot.tsx
@@ -5,6 +5,7 @@
  */
 
 import {useChart} from './ChartContext';
+import {useBrush} from './BrushContext';
 import {xPixel} from './utils';
 
 export interface XDSChartDotProps {
@@ -26,6 +27,7 @@ export interface XDSChartDotProps {
  */
 export function XDSChartDot({dataKey, color, radius = 4}: XDSChartDotProps) {
   const {data, xKey, xScale, yScale} = useChart();
+  const {range} = useBrush();
 
   return (
     <g>
@@ -33,8 +35,26 @@ export function XDSChartDot({dataKey, color, radius = 4}: XDSChartDotProps) {
         const x = xPixel(d, xKey, xScale);
         const yVal =
           typeof d[dataKey] === 'number' ? (d[dataKey] as number) : 0;
+
+        // Dim points outside the brush range
+        let opacity = 1;
+        if (range) {
+          const xv = d[xKey];
+          const inX =
+            typeof xv === 'number' && xv >= range.x[0] && xv <= range.x[1];
+          const inY = !range.y || (yVal >= range.y[0] && yVal <= range.y[1]);
+          opacity = inX && inY ? 1 : 0.15;
+        }
+
         return (
-          <circle key={i} cx={x} cy={yScale(yVal)} r={radius} fill={color} />
+          <circle
+            key={i}
+            cx={x}
+            cy={yScale(yVal)}
+            r={radius}
+            fill={color}
+            opacity={opacity}
+          />
         );
       })}
     </g>

--- a/packages/lab/src/Chart/XDSChartLine.tsx
+++ b/packages/lab/src/Chart/XDSChartLine.tsx
@@ -7,6 +7,7 @@
 import {useMemo} from 'react';
 import {line, curveMonotoneX} from 'd3-shape';
 import {useChart} from './ChartContext';
+import {useBrush} from './BrushContext';
 import {xPixel} from './utils';
 
 export interface XDSChartLineProps {
@@ -39,14 +40,19 @@ export function XDSChartLine({
   dotRadius = 3,
 }: XDSChartLineProps) {
   const {data, xKey, xScale, yScale} = useChart();
+  const {range} = useBrush();
 
   const points = useMemo(() => {
     return data.map((d, i) => {
       const x = xPixel(d, xKey, xScale);
       const yVal = typeof d[dataKey] === 'number' ? (d[dataKey] as number) : 0;
-      return {x, y: yScale(yVal), index: i};
+      const xv = d[xKey];
+      const inBrush =
+        !range ||
+        (typeof xv === 'number' && xv >= range.x[0] && xv <= range.x[1]);
+      return {x, y: yScale(yVal), index: i, inBrush};
     });
-  }, [data, xKey, dataKey, xScale, yScale]);
+  }, [data, xKey, dataKey, xScale, yScale, range]);
 
   const pathD = useMemo(() => {
     const generator = line<{x: number; y: number}>()
@@ -56,12 +62,47 @@ export function XDSChartLine({
     return generator(points) ?? '';
   }, [points]);
 
+  // When brush is active, draw the full line muted and overlay the selected segment
+  const hasActiveBrush = range != null;
+
   return (
     <g>
-      <path d={pathD} fill="none" stroke={color} strokeWidth={strokeWidth} />
+      <path
+        d={pathD}
+        fill="none"
+        stroke={color}
+        strokeWidth={strokeWidth}
+        opacity={hasActiveBrush ? 0.2 : 1}
+      />
+      {hasActiveBrush &&
+        (() => {
+          // Draw highlighted segment
+          const selectedPoints = points.filter(p => p.inBrush);
+          if (selectedPoints.length < 2) return null;
+          const gen = line<{x: number; y: number}>()
+            .x(d => d.x)
+            .y(d => d.y)
+            .curve(curveMonotoneX);
+          const highlightPath = gen(selectedPoints) ?? '';
+          return (
+            <path
+              d={highlightPath}
+              fill="none"
+              stroke={color}
+              strokeWidth={strokeWidth + 0.5}
+            />
+          );
+        })()}
       {dots &&
         points.map(p => (
-          <circle key={p.index} cx={p.x} cy={p.y} r={dotRadius} fill={color} />
+          <circle
+            key={p.index}
+            cx={p.x}
+            cy={p.y}
+            r={dotRadius}
+            fill={color}
+            opacity={p.inBrush ? 1 : 0.15}
+          />
         ))}
     </g>
   );

--- a/packages/lab/src/Chart/XDSChartSelect.tsx
+++ b/packages/lab/src/Chart/XDSChartSelect.tsx
@@ -3,8 +3,9 @@
  * @output Click/tap to select data points. Pointer events.
  */
 
-import {useCallback} from 'react';
+import {useCallback, useEffect} from 'react';
 import {useChart} from './ChartContext';
+import {useInteraction} from './InteractionContext';
 import {xPixel} from './utils';
 
 export interface XDSChartSelectProps {
@@ -22,9 +23,11 @@ export function XDSChartSelect({
   color = 'var(--color-accent)',
   radius = 6,
 }: XDSChartSelectProps) {
-  const {width, height, data, xKey, xScale, yScale} = useChart();
+  const {data, xKey, xScale, yScale} = useChart();
 
-  const handlePointerUp = useCallback(
+  const {register} = useInteraction();
+
+  const handleClick = useCallback(
     (e: React.PointerEvent<SVGRectElement>) => {
       const svg = e.currentTarget.ownerSVGElement;
       if (!svg) return;
@@ -66,17 +69,13 @@ export function XDSChartSelect({
     [data, xKey, xScale, yScale, selected, onSelect, onSelectionChange],
   );
 
+  useEffect(
+    () => register('select', {onClick: handleClick}),
+    [register, handleClick],
+  );
+
   return (
     <g>
-      <rect
-        x={0}
-        y={0}
-        width={width}
-        height={height}
-        fill="transparent"
-        style={{cursor: 'pointer'}}
-        onPointerUp={handlePointerUp}
-      />
       {selected.map(idx => {
         if (idx < 0 || idx >= data.length) return null;
         const d = data[idx];

--- a/packages/lab/src/Chart/XDSChartTooltip.tsx
+++ b/packages/lab/src/Chart/XDSChartTooltip.tsx
@@ -10,10 +10,11 @@
 
 'use client';
 
-import {useState, useCallback, useRef, type ReactNode} from 'react';
+import {useState, useCallback, useRef, useEffect, type ReactNode} from 'react';
 import {createPortal} from 'react-dom';
 import {useXDSLayer} from '@xds/core/Layer';
 import {useChart} from './ChartContext';
+import {useInteraction} from './InteractionContext';
 import {xPixel} from './utils';
 import type {DataPoint, ChartCrosshairMode} from './types';
 
@@ -150,7 +151,6 @@ export function XDSChartTooltip({
 
         // For each y key, compute distance to that point
         let bestDistForDatum = Infinity;
-        let bestYKey = yKeys[0];
 
         for (const yk of yKeys) {
           const yv = datum[yk];
@@ -160,7 +160,6 @@ export function XDSChartTooltip({
           const dist = dx * dx + dy * dy; // squared euclidean
           if (dist < bestDistForDatum) {
             bestDistForDatum = dist;
-            bestYKey = yk;
           }
         }
 
@@ -230,42 +229,23 @@ export function XDSChartTooltip({
     [pointerToData, findNearest, snap, layer, svgRef],
   );
 
-  // Touch: tap to show, drag to scrub
-  const handlePointerDown = useCallback(
-    (e: React.PointerEvent<SVGRectElement>) => {
-      if (e.pointerType !== 'mouse') {
-        e.preventDefault(); // blocks text selection on touch
-        active.current = true;
-        updateTooltip(e);
-      }
-    },
-    [updateTooltip],
-  );
-
-  // Mouse: hover to show. Touch: drag to scrub (only if active).
-  const handlePointerMove = useCallback(
-    (e: React.PointerEvent<SVGRectElement>) => {
-      if (e.pointerType !== 'mouse' && !active.current) return;
-      updateTooltip(e);
-    },
-    [updateTooltip],
-  );
-
-  // Touch: lift to dismiss
-  const handlePointerUp = useCallback(() => {
-    if (active.current) {
-      active.current = false;
-      setHoverState(null);
-      layer.hide();
-    }
-  }, [layer]);
-
   const handlePointerLeave = useCallback(() => {
     if (!active.current) {
       setHoverState(null);
       layer.hide();
     }
   }, [layer]);
+
+  // Register with shared event layer
+  const {register} = useInteraction();
+  useEffect(
+    () =>
+      register('tooltip', {
+        onHover: updateTooltip,
+        onHoverEnd: handlePointerLeave,
+      }),
+    [register, updateTooltip, handlePointerLeave],
+  );
 
   const fmtX =
     xFormat ??
@@ -298,21 +278,6 @@ export function XDSChartTooltip({
   return (
     <>
       <g>
-        {/* Event capture rect — pointer events only, no capture/selection */}
-        <rect
-          x={0}
-          y={0}
-          width={width}
-          height={height}
-          fill="transparent"
-          style={{touchAction: 'none'}}
-          onPointerDown={handlePointerDown}
-          onPointerMove={handlePointerMove}
-          onPointerUp={handlePointerUp}
-          onPointerCancel={handlePointerUp}
-          onPointerLeave={handlePointerLeave}
-        />
-
         {point && (
           <>
             {/* Vertical crosshair line */}

--- a/packages/lab/src/Chart/XDSChartTooltip.tsx
+++ b/packages/lab/src/Chart/XDSChartTooltip.tsx
@@ -15,16 +15,9 @@ import {createPortal} from 'react-dom';
 import {useXDSLayer} from '@xds/core/Layer';
 import {useChart} from './ChartContext';
 import {xPixel} from './utils';
-import type {DataPoint} from './types';
+import type {DataPoint, ChartCrosshairMode} from './types';
 
-/**
- * Crosshair mode:
- * - `'x'` — vertical line only (most common for time series)
- * - `'y'` — horizontal line only
- * - `'xy'` — both axes
- * - `false` — no crosshair lines
- */
-export type ChartCrosshairMode = 'x' | 'y' | 'xy' | false;
+export type {ChartCrosshairMode};
 
 export interface XDSChartTooltipProps {
   /**

--- a/packages/lab/src/Chart/XDSChartZoom.tsx
+++ b/packages/lab/src/Chart/XDSChartZoom.tsx
@@ -12,6 +12,7 @@ import {useCallback, useRef, useState, useEffect} from 'react';
 import {createPortal} from 'react-dom';
 import {XDSIconButton} from '@xds/core/IconButton';
 import {useChart} from './ChartContext';
+import {useInteraction} from './InteractionContext';
 import {isBandScale} from './utils';
 import type {ScaleLinear} from 'd3-scale';
 import type {ZoomToolbarPosition} from './types';
@@ -97,6 +98,7 @@ export function XDSChartZoom({
   toolbar = 'top-right',
 }: XDSChartZoomProps) {
   const {width, height, xScale, yScale, svgRef} = useChart();
+  const {register} = useInteraction();
 
   // Capture initial domains on mount for reset
   const initialDomainsRef = useRef<{
@@ -112,31 +114,6 @@ export function XDSChartZoom({
     const yDomain = yScale.domain() as [number, number];
     initialDomainsRef.current = {x: xDomain, y: yDomain};
   }, [xScale, yScale]);
-
-  const dragRef = useRef<{
-    startX: number;
-    startY: number;
-    xDomain: [number, number];
-    yDomain: [number, number];
-  } | null>(null);
-
-  const pointersRef = useRef<Map<number, {x: number; y: number}>>(new Map());
-  const pinchRef = useRef<{
-    dist: number;
-    xDomain: [number, number];
-    yDomain: [number, number];
-  } | null>(null);
-
-  const getXDomain = useCallback(
-    (): [number, number] =>
-      isBandScale(xScale)
-        ? [0, 0]
-        : ((xScale as ScaleLinear<number, number>).domain() as [
-            number,
-            number,
-          ]),
-    [xScale],
-  );
 
   // Zoom a single axis around a pivot point by a factor.
   // factor > 1 = zoom out, factor < 1 = zoom in.
@@ -220,76 +197,11 @@ export function XDSChartZoom({
     ],
   );
 
-  const onPointerDown = useCallback(
-    (e: React.PointerEvent<SVGRectElement>) => {
-      (e.target as Element).setPointerCapture(e.pointerId);
-      e.preventDefault(); // prevent selection on touch
-      pointersRef.current.set(e.pointerId, {x: e.clientX, y: e.clientY});
-
-      if (pointersRef.current.size === 2) {
-        const pts = [...pointersRef.current.values()];
-        const dist = Math.hypot(pts[1].x - pts[0].x, pts[1].y - pts[0].y);
-        pinchRef.current = {
-          dist,
-          xDomain: getXDomain(),
-          yDomain: yScale.domain() as [number, number],
-        };
-        dragRef.current = null;
-      } else if (pointersRef.current.size === 1) {
-        dragRef.current = {
-          startX: e.clientX,
-          startY: e.clientY,
-          xDomain: getXDomain(),
-          yDomain: yScale.domain() as [number, number],
-        };
-      }
-    },
-    [getXDomain, yScale],
+  // Register with shared event layer
+  useEffect(
+    () => register('zoom', {onWheel: handleWheel}),
+    [register, handleWheel],
   );
-
-  const onPointerMove = useCallback(
-    (e: React.PointerEvent<SVGRectElement>) => {
-      pointersRef.current.set(e.pointerId, {x: e.clientX, y: e.clientY});
-
-      if (pointersRef.current.size === 2 && pinchRef.current) {
-        const pts = [...pointersRef.current.values()];
-        const dist = Math.hypot(pts[1].x - pts[0].x, pts[1].y - pts[0].y);
-        const ratio = pinchRef.current.dist / dist;
-        if (!yOnly && !isBandScale(xScale)) {
-          const [xMin, xMax] = pinchRef.current.xDomain;
-          const mid = (xMin + xMax) / 2;
-          const half = ((xMax - xMin) / 2) * ratio;
-          onXDomainChange?.([mid - half, mid + half]);
-        }
-        if (!xOnly) {
-          const [yMin, yMax] = pinchRef.current.yDomain;
-          const mid = (yMin + yMax) / 2;
-          const half = ((yMax - yMin) / 2) * ratio;
-          onYDomainChange?.([mid - half, mid + half]);
-        }
-      } else if (dragRef.current) {
-        const dx = e.clientX - dragRef.current.startX;
-        const dy = e.clientY - dragRef.current.startY;
-        if (!yOnly && !isBandScale(xScale)) {
-          const [xMin, xMax] = dragRef.current.xDomain;
-          const xShift = -(dx / width) * (xMax - xMin);
-          onXDomainChange?.([xMin + xShift, xMax + xShift]);
-        }
-        if (!xOnly) {
-          const [yMin, yMax] = dragRef.current.yDomain;
-          const yShift = (dy / height) * (yMax - yMin);
-          onYDomainChange?.([yMin + yShift, yMax + yShift]);
-        }
-      }
-    },
-    [xScale, width, height, onXDomainChange, onYDomainChange, xOnly, yOnly],
-  );
-
-  const onPointerUp = useCallback((e: React.PointerEvent<SVGRectElement>) => {
-    pointersRef.current.delete(e.pointerId);
-    if (pointersRef.current.size < 2) pinchRef.current = null;
-    if (pointersRef.current.size === 0) dragRef.current = null;
-  }, []);
 
   const handleReset = useCallback(() => {
     const init = initialDomainsRef.current;
@@ -326,28 +238,6 @@ export function XDSChartZoom({
 
   return (
     <>
-      <g>
-        <rect
-          x={0}
-          y={0}
-          width={width}
-          height={height}
-          fill="transparent"
-          style={
-            {
-              cursor: 'grab',
-              touchAction: 'none',
-              userSelect: 'none',
-            } as React.CSSProperties
-          }
-          onWheel={handleWheel}
-          onPointerDown={onPointerDown}
-          onPointerMove={onPointerMove}
-          onPointerUp={onPointerUp}
-          onPointerCancel={onPointerUp}
-        />
-      </g>
-
       {/* Toolbar — portaled to chart container for proper positioning */}
       {toolbar &&
         portalTarget &&

--- a/packages/lab/src/Chart/XDSChartZoom.tsx
+++ b/packages/lab/src/Chart/XDSChartZoom.tsx
@@ -14,13 +14,9 @@ import {XDSIconButton} from '@xds/core/IconButton';
 import {useChart} from './ChartContext';
 import {isBandScale} from './utils';
 import type {ScaleLinear} from 'd3-scale';
+import type {ZoomToolbarPosition} from './types';
 
-/** Toolbar position relative to the chart */
-export type ZoomToolbarPosition =
-  | 'top-right'
-  | 'top-left'
-  | 'bottom-right'
-  | 'bottom-left';
+export type {ZoomToolbarPosition};
 
 export interface XDSChartZoomProps {
   onXDomainChange?: (domain: [number, number]) => void;

--- a/packages/lab/src/Chart/index.ts
+++ b/packages/lab/src/Chart/index.ts
@@ -24,18 +24,25 @@ export {
   type XDSChartStreamGLProps,
   type XDSChartStreamGLHandle,
 } from './XDSChartStreamGL';
-export {
-  XDSChartTooltip,
-  type XDSChartTooltipProps,
-  type ChartCrosshairMode,
-} from './XDSChartTooltip';
+export {XDSChartTooltip, type XDSChartTooltipProps} from './XDSChartTooltip';
 export {
   XDSChartLegend,
   type XDSChartLegendProps,
   type XDSChartLegendItem,
 } from './XDSChartLegend';
 export {useChart} from './ChartContext';
-export type {ChartContext, ChartMargin, ChartScale, DataPoint} from './types';
+export {useBrush} from './BrushContext';
+export type {
+  ChartContext,
+  ChartMargin,
+  ChartScale,
+  DataPoint,
+  BrushRange,
+  BrushMode,
+  BrushState,
+  ChartCrosshairMode,
+  ZoomToolbarPosition,
+} from './types';
 export {m4Reduce, type M4Point} from './m4';
 export {isBandScale, xPixel} from './utils';
 export {useXDSChartColors} from './useXDSChartColors';
@@ -63,13 +70,8 @@ export {
   CIRCLE_FRAG_BODY,
   POINT_SIZE_COMPENSATION,
 } from './webgl';
-export {
-  XDSChartBrush,
-  type XDSChartBrushProps,
-  type BrushMode,
-  type BrushRange,
-} from './XDSChartBrush';
-export {XDSChartZoom, type XDSChartZoomProps, type ZoomToolbarPosition} from './XDSChartZoom';
+export {XDSChartBrush, type XDSChartBrushProps} from './XDSChartBrush';
+export {XDSChartZoom, type XDSChartZoomProps} from './XDSChartZoom';
 export {XDSChartSelect, type XDSChartSelectProps} from './XDSChartSelect';
 export {
   XDSChartReferenceLine,

--- a/packages/lab/src/Chart/index.ts
+++ b/packages/lab/src/Chart/index.ts
@@ -32,6 +32,8 @@ export {
 } from './XDSChartLegend';
 export {useChart} from './ChartContext';
 export {useBrush} from './BrushContext';
+export {useInteraction} from './InteractionContext';
+export {EventLayer, type GestureHandlers} from './EventLayer';
 export type {
   ChartContext,
   ChartMargin,

--- a/packages/lab/src/Chart/types.ts
+++ b/packages/lab/src/Chart/types.ts
@@ -60,3 +60,36 @@ export interface ChartContext {
    */
   pixelToData: (px: number, py: number) => DataPoint;
 }
+
+/** Brush selection range in data coordinates */
+export interface BrushRange {
+  x: [number, number];
+  y?: [number, number];
+}
+
+/** Brush direction mode */
+export type BrushMode = 'x' | 'xy';
+
+/** Active brush state shared via BrushContext */
+export interface BrushState {
+  /** The active brush range in data coordinates, or null if no brush */
+  range: BrushRange | null;
+  /** Update the brush range (called by XDSChartBrush) */
+  setRange: (range: BrushRange | null) => void;
+}
+
+/**
+ * Crosshair mode for tooltips:
+ * - `'x'` — vertical line only
+ * - `'y'` — horizontal line only
+ * - `'xy'` — both axes
+ * - `false` — no crosshair lines
+ */
+export type ChartCrosshairMode = 'x' | 'y' | 'xy' | false;
+
+/** Toolbar position relative to the chart */
+export type ZoomToolbarPosition =
+  | 'top-right'
+  | 'top-left'
+  | 'bottom-right'
+  | 'bottom-left';


### PR DESCRIPTION
## Summary

Adds brush highlight that dims unselected marks across all chart mark types, plus a kitchen sink story demonstrating all interactions layered together.

## BrushContext System

- `BrushContext` — shared state for active brush range, provided by `XDSChart`
- `XDSChartBrush` writes active range to context on brush, clears on click
- Mark components read from `useBrush()` and dim items outside the range:
  - **XDSChartDot** — opacity 0.15 for unselected points
  - **XDSChartBar** — opacity 0.15 for unselected bars
  - **XDSChartLine** — full line drawn muted (0.2), selected segment overlaid bold

## Kitchen Sink Story

One scatter plot with every interaction layered:
- Scroll to zoom, drag to pan (`XDSChartZoom`)
- 2D brush with highlight (`XDSChartBrush mode='xy'`)
- Tooltip with crosshair (`XDSChartTooltip crosshair='xy'`)
- Click to select points (`XDSChartSelect`)
- Zoom toolbar (top-right)

---
