### PR TITLE
fix(template): improve mixed-gallery rubric score

### DIFF
--- a/packages/cli/templates/pages/mixed-gallery/page.tsx
+++ b/packages/cli/templates/pages/mixed-gallery/page.tsx
@@ -103,9 +103,9 @@ function GalleryCard({image}: {image: GalleryImage}) {
 
 export default function MixedGalleryTemplate() {
   return (
-    <XDSAppShell height="auto" contentPadding={6} variant="surface">
+    <XDSAppShell height="auto" contentPadding={8} variant="surface">
       <XDSCenter axis="horizontal">
-        <XDSSection variant="transparent" maxWidth={1400} width="100%" padding={6}>
+        <XDSSection variant="transparent" maxWidth={1400} width="100%" padding={0}>
           <XDSVStack gap={6}>
             {/* Header — capped with XDSSection maxWidth */}
             <XDSCenter axis="horizontal">

--- a/packages/cli/templates/pages/mixed-gallery/page.tsx
+++ b/packages/cli/templates/pages/mixed-gallery/page.tsx
@@ -105,7 +105,7 @@ export default function MixedGalleryTemplate() {
   return (
     <XDSAppShell height="auto" contentPadding={6} variant="surface">
       <XDSCenter axis="horizontal">
-        <XDSSection variant="transparent" maxWidth={1400} width="100%" padding={0}>
+        <XDSSection variant="transparent" maxWidth={1400} width="100%" padding={6}>
           <XDSVStack gap={6}>
             {/* Header — capped with XDSSection maxWidth */}
             <XDSCenter axis="horizontal">

--- a/packages/cli/templates/pages/mixed-gallery/page.tsx
+++ b/packages/cli/templates/pages/mixed-gallery/page.tsx
@@ -6,10 +6,6 @@ import {XDSCenter} from '@xds/core/Center';
 import {XDSText, XDSHeading} from '@xds/core/Text';
 import {XDSSection} from '@xds/core/Section';
 import {XDSGrid, XDSGridSpan} from '@xds/core/Grid';
-import {XDSButton} from '@xds/core/Button';
-import {XDSIcon} from '@xds/core/Icon';
-import {XDSMediaTheme} from '@xds/core/theme';
-import {ArrowRightIcon} from '@heroicons/react/24/outline';
 import * as stylex from '@stylexjs/stylex';
 
 // ─── Styles ────────────────────────────────────────────────────────────────
@@ -31,20 +27,11 @@ const styles = stylex.create({
     width: '100%',
     height: '100%',
     objectFit: 'cover',
-  },
-  overlay: {
-    position: 'absolute',
-    inset: 0,
-    backgroundColor: 'var(--color-overlay)',
-    opacity: {
-      default: 0,
-      ':hover': 1,
+    transition: 'transform 0.3s ease',
+    transform: {
+      default: 'scale(1)',
+      ':hover': 'scale(1.05)',
     },
-    transition: 'opacity 0.2s ease',
-    display: 'flex',
-    flexDirection: 'column',
-    justifyContent: 'flex-end',
-    padding: 'var(--spacing-6)',
   },
 });
 
@@ -53,7 +40,6 @@ const styles = stylex.create({
 interface GalleryImage {
   src: string;
   title: string;
-  description: string;
 }
 
 const IMAGES: GalleryImage[] = [
@@ -61,36 +47,26 @@ const IMAGES: GalleryImage[] = [
     // illustrative-horizontal-1 from xds_oss asset set
     src: 'https://lookaside.facebook.com/assets/xds_oss/illustrative-horizontal-1.jpg',
     title: 'Going places',
-    description:
-      "Sometimes all it takes is one small thing to turn your whole day around. That's what good design is for.",
   },
   {
     // light-home-horizontal-1 from xds_oss asset set
     src: 'https://lookaside.facebook.com/assets/xds_oss/light-home-horizontal-1.png',
     title: 'Making memories',
-    description:
-      "Sometimes all it takes is one small thing to turn your whole day around. That's what good design is for.",
   },
   {
     // light-lifestyle-vertical-3 from xds_oss asset set
     src: 'https://lookaside.facebook.com/assets/xds_oss/light-lifestyle-vertical-3.png',
     title: 'Seeing things',
-    description:
-      "Sometimes all it takes is one small thing to turn your whole day around. That's what good design is for.",
   },
   {
     // light-lifestyle-vertical-1 from xds_oss asset set
     src: 'https://lookaside.facebook.com/assets/xds_oss/light-lifestyle-vertical-1.png',
     title: 'Sharing ideas',
-    description:
-      "Sometimes all it takes is one small thing to turn your whole day around. That's what good design is for.",
   },
   {
     // light-lifestyle-horizontal-1 from xds_oss asset set
     src: 'https://lookaside.facebook.com/assets/xds_oss/light-lifestyle-horizontal-1.png',
     title: 'Being free',
-    description:
-      "Sometimes all it takes is one small thing to turn your whole day around. That's what good design is for.",
   },
 ];
 
@@ -104,22 +80,6 @@ function GalleryCard({image}: {image: GalleryImage}) {
         alt={image.title}
         {...stylex.props(styles.img)}
       />
-      <div {...stylex.props(styles.overlay)}>
-        <XDSMediaTheme mode="dark">
-          <XDSVStack gap={2}>
-            <XDSHeading level={3}>{image.title}</XDSHeading>
-            <XDSText type="body">
-              One small thing to turn your day around.
-            </XDSText>
-            <XDSButton
-              label="Read more"
-              variant="secondary"
-              size="sm"
-              endContent={<XDSIcon icon={ArrowRightIcon} />}
-            />
-          </XDSVStack>
-        </XDSMediaTheme>
-      </div>
     </div>
   );
 }

--- a/packages/cli/templates/pages/mixed-gallery/page.tsx
+++ b/packages/cli/templates/pages/mixed-gallery/page.tsx
@@ -79,36 +79,36 @@ interface GalleryImage {
 
 const IMAGES: GalleryImage[] = [
   {
-    // Column 1: illustrative-horizontal-1
-    src: 'https://scontent.xx.fbcdn.net/v/t39.6806-6/670836735_2461791954280697_1048571955964692895_n.jpg?_nc_cat=105&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=b9DqIpmzyeAQ7kNvwEuVNYV&_nc_oc=Adqx7M8RaKihjC8dSQUH_YjYNSkC7dv34yH96ndekQT74zfo2M6_DMfY-HyXDGEgXYHKMGTPSBWROmTm7oSKCaPg&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=e6YHUehLaMQde9dotUaFJw&_nc_ss=7a30f&oh=00_Af2odB5hzmvCl0lYC5CdnJjHLVeooKOjOOPItWbo1K-2tg&oe=69E6FAAB',
+    // illustrative-horizontal-1 from xds_oss asset set
+    src: 'https://lookaside.facebook.com/assets/xds_oss/illustrative-horizontal-1.jpg',
     title: 'Going places',
     description:
       "Sometimes all it takes is one small thing to turn your whole day around. That's what good design is for.",
   },
   {
-    // Column 1: light-home-horizontal-1
-    src: 'https://scontent.xx.fbcdn.net/v/t39.6806-6/672683340_1522469159433922_7776167798061220106_n.png?_nc_cat=101&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=Qpd2UWP6VgEQ7kNvwE-OPni&_nc_oc=AdrBHciJphXt9BtYMnlljRItaFe9QR13GbHjolSlqWeoP37sfn-C414s177sJjM7dk8xymfEjEIkYoEd8bspGCMK&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=Lt9qRH3XlVoT53AL30YKsA&_nc_ss=7a30f&oh=00_Af0tIOpEarNFMfXkSd3D5DVXSUqIKjx9toPEqC89IupM5A&oe=69E6E494',
+    // light-home-horizontal-1 from xds_oss asset set
+    src: 'https://lookaside.facebook.com/assets/xds_oss/light-home-horizontal-1.png',
     title: 'Making memories',
     description:
       "Sometimes all it takes is one small thing to turn your whole day around. That's what good design is for.",
   },
   {
-    // Column 2: light-lifestyle-vertical-3
-    src: 'https://scontent.xx.fbcdn.net/v/t39.6806-6/673630979_2366966167048970_507510466630095319_n.png?_nc_cat=103&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=hayXnp1KwWwQ7kNvwE6OwnY&_nc_oc=AdrKqob4CUU2_FrICyqd-B1NVcZ_p6oN45HC6nOs4_NJs-zvYEaj0pRdsvm5oBgVXMMQ-QIYfYEdY7NPSlkmD0VF&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=wxPGUKGIf3ihSjnc_4pFdQ&_nc_ss=7a30f&oh=00_Af3cPR8RHrFZTUPXixsgg3N4iz7847JxcTfJUbK1nisSPg&oe=69E6EAD4',
+    // light-lifestyle-vertical-3 from xds_oss asset set
+    src: 'https://lookaside.facebook.com/assets/xds_oss/light-lifestyle-vertical-3.png',
     title: 'Seeing things',
     description:
       "Sometimes all it takes is one small thing to turn your whole day around. That's what good design is for.",
   },
   {
-    // Column 3: light-lifestyle-vertical-1
-    src: 'https://scontent.xx.fbcdn.net/v/t39.6806-6/669447541_4390219861306657_6002100073104319158_n.png?_nc_cat=108&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=sXKFHmKfCccQ7kNvwGsGpL1&_nc_oc=Adqy06LYMJsViftx1OlQnquClJHettJcc9a0z0BO_mx-979b2VldT8nPRe6J3BwPheu3AlAk6N4LlItaO3vU9xg4&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=H412Z-rQCOugLK-6ss0CDA&_nc_ss=7a30f&oh=00_Af0LKXjbNPwFyK0rA1mnGPK57ctb0rzjTS5jwzXB03oPBw&oe=69E6E58D',
+    // light-lifestyle-vertical-1 from xds_oss asset set
+    src: 'https://lookaside.facebook.com/assets/xds_oss/light-lifestyle-vertical-1.png',
     title: 'Sharing ideas',
     description:
       "Sometimes all it takes is one small thing to turn your whole day around. That's what good design is for.",
   },
   {
-    // Column 3: light-lifestyle-horizontal-1
-    src: 'https://scontent.xx.fbcdn.net/v/t39.6806-6/673173617_1842726693762408_2908608806392112143_n.png?_nc_cat=107&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=ipqP09C42_gQ7kNvwHwibG0&_nc_oc=Ado97zfee8ejAhB0dqWyWz4lhsi0K7kf9W9wFBfqvD7cm3mh9le59yGFgbdkzIWO255x4Oe7bwc_vnSh41GvAxTk&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=1ZhYNPWwWg8iLLqOsj0aUg&_nc_ss=7a30f&oh=00_Af340jh-0cJ2G-NDCnGJNrXd-RuAXXawyADjOqNP7tOD7Q&oe=69E712D6',
+    // light-lifestyle-horizontal-1 from xds_oss asset set
+    src: 'https://lookaside.facebook.com/assets/xds_oss/light-lifestyle-horizontal-1.png',
     title: 'Being free',
     description:
       "Sometimes all it takes is one small thing to turn your whole day around. That's what good design is for.",

--- a/packages/cli/templates/pages/mixed-gallery/page.tsx
+++ b/packages/cli/templates/pages/mixed-gallery/page.tsx
@@ -26,6 +26,8 @@ const styles = stylex.create({
     borderRadius: 'var(--radius-element)',
   },
   img: {
+    position: 'absolute',
+    inset: 0,
     width: '100%',
     height: '100%',
     objectFit: 'cover',

--- a/packages/cli/templates/pages/mixed-gallery/page.tsx
+++ b/packages/cli/templates/pages/mixed-gallery/page.tsx
@@ -106,12 +106,15 @@ function GalleryCard({image}: {image: GalleryImage}) {
       />
       <div {...stylex.props(styles.overlay)}>
         <XDSMediaTheme mode="dark">
-          <XDSVStack gap={3}>
-            <XDSHeading level={2}>{image.title}</XDSHeading>
-            <XDSText type="body">{image.description}</XDSText>
+          <XDSVStack gap={2}>
+            <XDSHeading level={3}>{image.title}</XDSHeading>
+            <XDSText type="body">
+              One small thing to turn your day around.
+            </XDSText>
             <XDSButton
               label="Read more"
               variant="secondary"
+              size="sm"
               endContent={<XDSIcon icon={ArrowRightIcon} />}
             />
           </XDSVStack>

--- a/packages/cli/templates/pages/mixed-gallery/page.tsx
+++ b/packages/cli/templates/pages/mixed-gallery/page.tsx
@@ -117,9 +117,8 @@ export default function MixedGalleryTemplate() {
                   </XDSHeading>
                   <XDSText type="body">
                     We believe the smallest details are the ones that matter
-                    most. A little color, a thoughtful touch, a moment that
-                    catches your eye and makes you pause; that&apos;s what turns
-                    an ordinary day into something worth remembering.
+                    most. That&apos;s what turns an ordinary day into something
+                    worth remembering.
                   </XDSText>
                 </XDSVStack>
               </XDSSection>

--- a/packages/cli/templates/pages/mixed-gallery/page.tsx
+++ b/packages/cli/templates/pages/mixed-gallery/page.tsx
@@ -78,6 +78,11 @@ const IMAGES: GalleryImage[] = [
     src: 'https://lookaside.facebook.com/assets/xds_oss/light-lifestyle-vertical-4.png',
     title: 'Taking it easy',
   },
+  {
+    // light-working-horizontal-2 from xds_oss asset set
+    src: 'https://lookaside.facebook.com/assets/xds_oss/light-working-horizontal-2.png',
+    title: 'Getting things done',
+  },
 ];
 
 // ─── Gallery Card with Hover Overlay ────────────────────────────────────────
@@ -143,12 +148,15 @@ export default function MixedGalleryTemplate() {
                 <GalleryCard image={IMAGES[1]} />
               </XDSGridSpan>
 
-              {/* Flipped row — small + large */}
-              <XDSGridSpan rows={5}>
+              {/* Second bottom row — 3 equal items */}
+              <XDSGridSpan rows={3}>
                 <GalleryCard image={IMAGES[5]} />
               </XDSGridSpan>
-              <XDSGridSpan columns={2} rows={5}>
+              <XDSGridSpan rows={3}>
                 <GalleryCard image={IMAGES[6]} />
+              </XDSGridSpan>
+              <XDSGridSpan rows={3}>
+                <GalleryCard image={IMAGES[7]} />
               </XDSGridSpan>
             </XDSGrid>
           </XDSVStack>

--- a/packages/cli/templates/pages/mixed-gallery/page.tsx
+++ b/packages/cli/templates/pages/mixed-gallery/page.tsx
@@ -103,7 +103,7 @@ function GalleryCard({image}: {image: GalleryImage}) {
 
 export default function MixedGalleryTemplate() {
   return (
-    <XDSAppShell height="auto" contentPadding={6} variant="surface">
+    <XDSAppShell height="auto" contentPadding={8} variant="surface">
       <XDSCenter axis="horizontal">
         <XDSSection variant="transparent" maxWidth={1400} width="100%" padding={0}>
           <XDSVStack gap={6}>

--- a/packages/cli/templates/pages/mixed-gallery/page.tsx
+++ b/packages/cli/templates/pages/mixed-gallery/page.tsx
@@ -126,7 +126,7 @@ export default function MixedGalleryTemplate() {
             </XDSCenter>
 
             {/* Featured masonry — hero + sidebar + bottom row */}
-            <XDSGrid columns={3} rowHeight={70} gap={3}>
+            <XDSGrid columns={3} rowHeight={90} gap={3}>
               {/* Hero — 2 cols × 5 rows */}
               <XDSGridSpan columns={2} rows={5}>
                 <GalleryCard image={IMAGES[0]} />
@@ -146,17 +146,6 @@ export default function MixedGalleryTemplate() {
               </XDSGridSpan>
               <XDSGridSpan rows={3}>
                 <GalleryCard image={IMAGES[1]} />
-              </XDSGridSpan>
-
-              {/* Second bottom row — 3 equal items */}
-              <XDSGridSpan rows={3}>
-                <GalleryCard image={IMAGES[5]} />
-              </XDSGridSpan>
-              <XDSGridSpan rows={3}>
-                <GalleryCard image={IMAGES[6]} />
-              </XDSGridSpan>
-              <XDSGridSpan rows={3}>
-                <GalleryCard image={IMAGES[7]} />
               </XDSGridSpan>
             </XDSGrid>
           </XDSVStack>

--- a/packages/cli/templates/pages/mixed-gallery/page.tsx
+++ b/packages/cli/templates/pages/mixed-gallery/page.tsx
@@ -103,7 +103,7 @@ function GalleryCard({image}: {image: GalleryImage}) {
 
 export default function MixedGalleryTemplate() {
   return (
-    <XDSAppShell height="auto" contentPadding={8} variant="surface">
+    <XDSAppShell height="auto" contentPadding={6} variant="surface">
       <XDSCenter axis="horizontal">
         <XDSSection variant="transparent" maxWidth={1400} width="100%" padding={0}>
           <XDSVStack gap={6}>

--- a/packages/cli/templates/pages/mixed-gallery/page.tsx
+++ b/packages/cli/templates/pages/mixed-gallery/page.tsx
@@ -105,7 +105,7 @@ export default function MixedGalleryTemplate() {
   return (
     <XDSAppShell height="auto" contentPadding={8} variant="surface">
       <XDSCenter axis="horizontal">
-        <XDSSection variant="transparent" maxWidth={1400} width="100%" padding={0}>
+        <XDSSection variant="transparent" maxWidth={1400} width="100%" padding={6}>
           <XDSVStack gap={6}>
             {/* Header — capped with XDSSection maxWidth */}
             <XDSCenter axis="horizontal">

--- a/packages/cli/templates/pages/mixed-gallery/page.tsx
+++ b/packages/cli/templates/pages/mixed-gallery/page.tsx
@@ -154,12 +154,9 @@ export default function MixedGalleryTemplate() {
                 <GalleryCard image={IMAGES[0]} />
               </XDSGridSpan>
 
-              {/* Sidebar items */}
-              <XDSGridSpan rows={3}>
+              {/* Sidebar — full height */}
+              <XDSGridSpan rows={5}>
                 <GalleryCard image={IMAGES[2]} />
-              </XDSGridSpan>
-              <XDSGridSpan rows={2}>
-                <GalleryCard image={IMAGES[1]} />
               </XDSGridSpan>
 
               {/* Bottom row */}

--- a/packages/cli/templates/pages/mixed-gallery/page.tsx
+++ b/packages/cli/templates/pages/mixed-gallery/page.tsx
@@ -1,13 +1,12 @@
 'use client';
 
 import {XDSAppShell} from '@xds/core/AppShell';
-import {XDSVStack, XDSStackItem} from '@xds/core/Layout';
+import {XDSVStack} from '@xds/core/Layout';
 import {XDSCenter} from '@xds/core/Center';
 import {XDSText, XDSHeading} from '@xds/core/Text';
 import {XDSSection} from '@xds/core/Section';
-import {XDSGrid} from '@xds/core/Grid';
+import {XDSGrid, XDSGridSpan} from '@xds/core/Grid';
 import {XDSButton} from '@xds/core/Button';
-import {XDSAspectRatio} from '@xds/core/AspectRatio';
 import {XDSIcon} from '@xds/core/Icon';
 import {XDSMediaTheme} from '@xds/core/theme';
 import {ArrowRightIcon} from '@heroicons/react/24/outline';
@@ -15,43 +14,21 @@ import * as stylex from '@stylexjs/stylex';
 
 // ─── Styles ────────────────────────────────────────────────────────────────
 
-const layoutStyles = stylex.create({
-  fullHeight: {
-    height: '100%',
-  },
-  minHeightZero: {
-    minHeight: 0,
-  },
+const styles = stylex.create({
   textCenter: {
     textAlign: 'center',
   },
-  desktopOnly: {
-    display: {
-      default: 'flex',
-      '@media (max-width: 767px)': 'none',
-    },
-  },
-  mobileOnly: {
-    display: {
-      default: 'none',
-      '@media (max-width: 767px)': 'flex',
-    },
-  },
-  mobileGap: {
-    gap: {
-      default: null,
-      '@media (max-width: 767px)': 'var(--spacing-3)',
-    },
-  },
-});
-
-const overlayStyles = stylex.create({
   card: {
     position: 'relative',
     width: '100%',
     height: '100%',
     overflow: 'clip',
     borderRadius: 'var(--radius-element)',
+  },
+  img: {
+    width: '100%',
+    height: '100%',
+    objectFit: 'cover',
   },
   overlay: {
     position: 'absolute',
@@ -115,27 +92,17 @@ const IMAGES: GalleryImage[] = [
   },
 ];
 
-const imgStyles = stylex.create({
-  cover: {
-    width: '100%',
-    height: '100%',
-    objectFit: 'cover',
-    display: 'block',
-    minHeight: 0,
-  },
-});
-
 // ─── Gallery Card with Hover Overlay ────────────────────────────────────────
 
 function GalleryCard({image}: {image: GalleryImage}) {
   return (
-    <div {...stylex.props(overlayStyles.card)}>
+    <div {...stylex.props(styles.card)}>
       <img
         src={image.src}
         alt={image.title}
-        {...stylex.props(imgStyles.cover)}
+        {...stylex.props(styles.img)}
       />
-      <div {...stylex.props(overlayStyles.overlay)}>
+      <div {...stylex.props(styles.overlay)}>
         <XDSMediaTheme mode="dark">
           <XDSVStack gap={3}>
             <XDSHeading level={2}>{image.title}</XDSHeading>
@@ -156,21 +123,14 @@ function GalleryCard({image}: {image: GalleryImage}) {
 
 export default function MixedGalleryTemplate() {
   return (
-    <XDSAppShell height="fill" contentPadding={6} variant="surface">
-      <XDSCenter axis="horizontal" height="100%">
-        <XDSSection
-          variant="transparent"
-          maxWidth={1400}
-          width="100%"
-          height="100%"
-          padding={0}>
-          <XDSVStack
-            gap={6}
-            xstyle={[layoutStyles.fullHeight, layoutStyles.mobileGap]}>
+    <XDSAppShell height="auto" contentPadding={6} variant="surface">
+      <XDSCenter axis="horizontal">
+        <XDSSection variant="transparent" maxWidth={1400} padding={0}>
+          <XDSVStack gap={6}>
             {/* Header — capped with XDSSection maxWidth */}
             <XDSCenter axis="horizontal">
               <XDSSection variant="transparent" maxWidth={680}>
-                <XDSVStack gap={2} xstyle={layoutStyles.textCenter}>
+                <XDSVStack gap={2} xstyle={styles.textCenter}>
                   <XDSHeading level={1}>
                     Make every day a little more delightful, one detail at a
                     time.
@@ -178,48 +138,36 @@ export default function MixedGalleryTemplate() {
                   <XDSText type="body">
                     We believe the smallest details are the ones that matter
                     most. A little color, a thoughtful touch, a moment that
-                    catches your eye and makes you pause; that's what turns an
-                    ordinary day into something worth remembering.
+                    catches your eye and makes you pause; that&apos;s what turns
+                    an ordinary day into something worth remembering.
                   </XDSText>
                 </XDSVStack>
               </XDSSection>
             </XDSCenter>
 
-            {/* Gallery — desktop: 3-col masonry, mobile: single column */}
+            {/* Masonry gallery — 3 cols with row spans */}
+            <XDSGrid columns={3} rowHeight={80} gap={4}>
+              {/* Column 1: 3 + 3 = 6 rows */}
+              <XDSGridSpan rows={3}>
+                <GalleryCard image={IMAGES[0]} />
+              </XDSGridSpan>
+              <XDSGridSpan rows={3}>
+                <GalleryCard image={IMAGES[1]} />
+              </XDSGridSpan>
 
-            {/* Desktop layout (hidden on mobile) */}
-            <XDSStackItem size="fill" xstyle={layoutStyles.desktopOnly}>
-              <XDSGrid columns={3} gap={4} height="100%">
-                <XDSVStack gap={4} xstyle={layoutStyles.minHeightZero}>
-                  <XDSStackItem size="fill">
-                    <GalleryCard image={IMAGES[0]} />
-                  </XDSStackItem>
-                  <XDSStackItem size="fill">
-                    <GalleryCard image={IMAGES[1]} />
-                  </XDSStackItem>
-                </XDSVStack>
-
+              {/* Column 2: 6 rows (tall center) */}
+              <XDSGridSpan rows={6}>
                 <GalleryCard image={IMAGES[2]} />
+              </XDSGridSpan>
 
-                <XDSVStack gap={4} xstyle={layoutStyles.minHeightZero}>
-                  <XDSStackItem size="fill">
-                    <GalleryCard image={IMAGES[3]} />
-                  </XDSStackItem>
-                  <XDSStackItem size="fill">
-                    <GalleryCard image={IMAGES[4]} />
-                  </XDSStackItem>
-                </XDSVStack>
-              </XDSGrid>
-            </XDSStackItem>
-
-            {/* Mobile layout (hidden on desktop) */}
-            <XDSVStack gap={4} xstyle={layoutStyles.mobileOnly}>
-              {IMAGES.map((image, i) => (
-                <XDSAspectRatio key={i} ratio={16 / 9}>
-                  <GalleryCard image={image} />
-                </XDSAspectRatio>
-              ))}
-            </XDSVStack>
+              {/* Column 3: 3 + 3 = 6 rows */}
+              <XDSGridSpan rows={3}>
+                <GalleryCard image={IMAGES[3]} />
+              </XDSGridSpan>
+              <XDSGridSpan rows={3}>
+                <GalleryCard image={IMAGES[4]} />
+              </XDSGridSpan>
+            </XDSGrid>
           </XDSVStack>
         </XDSSection>
       </XDSCenter>

--- a/packages/cli/templates/pages/mixed-gallery/page.tsx
+++ b/packages/cli/templates/pages/mixed-gallery/page.tsx
@@ -68,6 +68,16 @@ const IMAGES: GalleryImage[] = [
     src: 'https://lookaside.facebook.com/assets/xds_oss/light-lifestyle-horizontal-1.png',
     title: 'Being free',
   },
+  {
+    // light-home-square-2 from xds_oss asset set
+    src: 'https://lookaside.facebook.com/assets/xds_oss/light-home-square-2.png',
+    title: 'Feeling at home',
+  },
+  {
+    // light-lifestyle-vertical-4 from xds_oss asset set
+    src: 'https://lookaside.facebook.com/assets/xds_oss/light-lifestyle-vertical-4.png',
+    title: 'Taking it easy',
+  },
 ];
 
 // ─── Gallery Card with Hover Overlay ────────────────────────────────────────
@@ -131,6 +141,14 @@ export default function MixedGalleryTemplate() {
               </XDSGridSpan>
               <XDSGridSpan rows={3}>
                 <GalleryCard image={IMAGES[1]} />
+              </XDSGridSpan>
+
+              {/* Flipped row — small + large */}
+              <XDSGridSpan rows={5}>
+                <GalleryCard image={IMAGES[5]} />
+              </XDSGridSpan>
+              <XDSGridSpan columns={2} rows={5}>
+                <GalleryCard image={IMAGES[6]} />
               </XDSGridSpan>
             </XDSGrid>
           </XDSVStack>

--- a/packages/cli/templates/pages/mixed-gallery/page.tsx
+++ b/packages/cli/templates/pages/mixed-gallery/page.tsx
@@ -103,9 +103,9 @@ function GalleryCard({image}: {image: GalleryImage}) {
 
 export default function MixedGalleryTemplate() {
   return (
-    <XDSAppShell height="auto" contentPadding={8} variant="surface">
+    <XDSAppShell height="auto" contentPadding={6} variant="surface">
       <XDSCenter axis="horizontal">
-        <XDSSection variant="transparent" maxWidth={1400} width="100%" padding={6}>
+        <XDSSection variant="transparent" maxWidth={1400} width="100%" padding={0}>
           <XDSVStack gap={6}>
             {/* Header — capped with XDSSection maxWidth */}
             <XDSCenter axis="horizontal">

--- a/packages/cli/templates/pages/mixed-gallery/page.tsx
+++ b/packages/cli/templates/pages/mixed-gallery/page.tsx
@@ -145,27 +145,30 @@ export default function MixedGalleryTemplate() {
               </XDSSection>
             </XDSCenter>
 
-            {/* Masonry gallery — 3 cols with row spans */}
-            <XDSGrid columns={3} rowHeight={80} gap={4}>
-              {/* Column 1: 3 + 3 = 6 rows */}
-              <XDSGridSpan rows={3}>
+            {/* Featured masonry — hero + sidebar + bottom row */}
+            <XDSGrid columns={3} rowHeight={70} gap={3}>
+              {/* Hero — 2 cols × 5 rows */}
+              <XDSGridSpan columns={2} rows={5}>
                 <GalleryCard image={IMAGES[0]} />
               </XDSGridSpan>
+
+              {/* Sidebar items */}
               <XDSGridSpan rows={3}>
+                <GalleryCard image={IMAGES[2]} />
+              </XDSGridSpan>
+              <XDSGridSpan rows={2}>
                 <GalleryCard image={IMAGES[1]} />
               </XDSGridSpan>
 
-              {/* Column 2: 6 rows (tall center) */}
-              <XDSGridSpan rows={6}>
-                <GalleryCard image={IMAGES[2]} />
-              </XDSGridSpan>
-
-              {/* Column 3: 3 + 3 = 6 rows */}
+              {/* Bottom row */}
               <XDSGridSpan rows={3}>
                 <GalleryCard image={IMAGES[3]} />
               </XDSGridSpan>
               <XDSGridSpan rows={3}>
                 <GalleryCard image={IMAGES[4]} />
+              </XDSGridSpan>
+              <XDSGridSpan rows={3}>
+                <GalleryCard image={IMAGES[1]} />
               </XDSGridSpan>
             </XDSGrid>
           </XDSVStack>

--- a/packages/cli/templates/pages/mixed-gallery/page.tsx
+++ b/packages/cli/templates/pages/mixed-gallery/page.tsx
@@ -127,7 +127,7 @@ export default function MixedGalleryTemplate() {
   return (
     <XDSAppShell height="auto" contentPadding={6} variant="surface">
       <XDSCenter axis="horizontal">
-        <XDSSection variant="transparent" maxWidth={1400} padding={0}>
+        <XDSSection variant="transparent" maxWidth={1400} width="100%" padding={0}>
           <XDSVStack gap={6}>
             {/* Header — capped with XDSSection maxWidth */}
             <XDSCenter axis="horizontal">


### PR DESCRIPTION
## Summary

Improves the mixed-gallery template grading rubric score from **46/100 (D)** to **77/100 (B)**.

### TL;DR

- Replaced dual desktop/mobile layout with single XDSGrid + XDSGridSpan masonry ([masonry docs](https://studious-broccoli-o7e61n3.pages.github.io/storybook/index.html?path=/docs/layout-xdsgrid-masonry-gallery--docs))
- Featured masonry layout: hero (2 cols × 5 rows) + sidebar + bottom row
- Replaced overlay with hover zoom on images
- Switched all images to permanent `lookaside.facebook.com` URLs
- Shortened description text

### Rubric Score

| Category | Before | After |
|----------|--------|-------|
| XDS Component Purity | 15/30 | 20/30 |
| Icon Purity | 15/15 | 15/15 |
| Custom CSS | 0/15 | 2/15 |
| Layout & Structure | 8/15 | 15/15 |
| Doc Metadata | 10/10 | 10/10 |
| Image Handling | 5/5 | 5/5 |
| Code Quality | 8/10 | 10/10 |
| **Total** | **46/100 (D)** | **77/100 (B)** |

### Future improvements

- **Bottom padding** — XDSSection auto-escapes parent container padding, so bottom spacing can't be added without a custom CSS declaration. Would need a core fix or a `noEscape` prop on Section.
- **Responsive stacking** — The 3-column masonry grid doesn't collapse on mobile. XDSGrid with fixed `columns` + `rowHeight` doesn't support responsive reflow. Would need a responsive masonry solution in core.
- **Hover overlay** — We originally had a hover overlay that displayed text and was clickable in the design. We could not do that without it being super expensive apparently. Would love to be able to do that in the future.