### PR TITLE
feat(cli): add --skip-install and --force-install flags to upgrade command

### DIFF
--- a/packages/cli/src/commands/upgrade.mjs
+++ b/packages/cli/src/commands/upgrade.mjs
@@ -104,16 +104,18 @@ function bumpXdsDeps(targetVersion) {
 
 /**
  * Get the install command for the detected package manager.
+ * @param {boolean} force — pass --force to bust stale lockfile resolutions
  * @returns {string}
  */
-function getInstallCommand() {
+function getInstallCommand(force = false) {
   const pm = detectPackageManager();
+  const forceFlag = force ? ' --force' : '';
   switch (pm) {
-    case 'yarn': return 'yarn install';
-    case 'pnpm': return 'pnpm install';
-    case 'bun': return 'bun install';
+    case 'yarn': return `yarn install${forceFlag}`;
+    case 'pnpm': return `pnpm install${force ? ' --force' : ''}`;
+    case 'bun': return `bun install${force ? ' --force' : ''}`;
     case 'npm':
-    default: return 'npm install';
+    default: return `npm install${force ? ' --force' : ''}`;
   }
 }
 
@@ -141,6 +143,8 @@ export function registerUpgrade(program) {
     .option('--force', 'Run codemods even if versions appear up to date', false)
     .option('--codemod <name>', 'Run a specific transform only')
     .option('--codemod-only', 'Skip version bump and install, run codemods only', false)
+    .option('--skip-install', 'Skip package manager install after bumping deps', false)
+    .option('--force-install', 'Pass --force to package manager install (busts stale lockfile resolutions)', false)
     .option('--path <dir>', 'Source directory to scan', './src')
     .option('--install-deps', 'Auto-install jscodeshift without prompting', false)
     .option('--list', 'List available codemods', false)
@@ -261,13 +265,17 @@ export function registerUpgrade(program) {
           receipt.depsUpdated = result.bumped;
           if (!json) p.log.info(`Bumped ${result.bumped.join(', ')} → ${targetVersion}`);
 
-          const installCmd = getInstallCommand();
-          if (!json) p.log.step(`Running ${installCmd}...`);
-          try {
-            execSync(installCmd, {stdio: 'inherit', cwd: process.cwd()});
-            if (!json) p.log.success('Dependencies installed.');
-          } catch {
-            if (!json) p.log.warn('Install failed — codemods will still run against existing code.');
+          const installCmd = getInstallCommand(options.forceInstall);
+          if (options.skipInstall) {
+            if (!json) p.log.info('Skipping install (--skip-install). Run your package manager manually.');
+          } else {
+            if (!json) p.log.step(`Running ${installCmd}...`);
+            try {
+              execSync(installCmd, {stdio: 'inherit', cwd: process.cwd()});
+              if (!json) p.log.success('Dependencies installed.');
+            } catch {
+              if (!json) p.log.warn('Install failed — codemods will still run against existing code.');
+            }
           }
         }
       }


### PR DESCRIPTION
## Summary

Adds two new flags to `xds upgrade`:

- **`--skip-install`** — Skips the automatic `yarn install` after bumping deps. Use when install is handled externally (e.g. the internal libs upgrade script runs `yarn install --force` separately).

- **`--force-install`** — Passes `--force` to the package manager. Busts stale lockfile resolutions that cause duplicate `@xds/core` copies when `file:`-linked libs have pinned devDependencies.

### Why

When internal apps upgrade `@xds/core`, libs like `XDS Common` and `internal card component` can end up with a nested `node_modules/@xds/core` at the old version (from the lockfile). This produces two copies with potentially different class name hashes.

`yarn install --force` re-resolves all packages and deduplicates correctly. The `--skip-install` flag lets the internal upgrade script control when and how install happens.

### Usage

```bash
# internal libs upgrade script bumps versions, then:
xds upgrade --apply --to 0.0.13 --skip-install

# Or force a fresh install:
xds upgrade --apply --to 0.0.13 --force-install
```