### PR TITLE
docs(storybook): add missing @example blocks to 5 exported components

### DIFF
--- a/packages/core/src/Chat/XDSChatComposer.tsx
+++ b/packages/core/src/Chat/XDSChatComposer.tsx
@@ -249,6 +249,18 @@ const styles = stylex.create({
 // Component
 // =============================================================================
 
+/**
+ * Layout shell for a chat composer with slots for attachments, input,
+ * actions, and a send button.
+ *
+ * @example
+ * ```
+ * <XDSChatComposer
+ *   onSubmit={(value) => console.log(value)}
+ *   placeholder="Type a message..."
+ * />
+ * ```
+ */
 export function XDSChatComposer(props: XDSChatComposerProps) {
   const {
     onSubmit,

--- a/packages/core/src/Chat/XDSChatComposerAttachments.tsx
+++ b/packages/core/src/Chat/XDSChatComposerAttachments.tsx
@@ -188,6 +188,18 @@ const styles = stylex.create({
   },
 });
 
+/**
+ * Container for attachment previews inside a chat composer.
+ * Supports collapsible behavior with a count badge.
+ *
+ * @example
+ * ```
+ * <XDSChatComposerAttachments count={3}>
+ *   <AttachmentThumbnail />
+ *   <AttachmentThumbnail />
+ * </XDSChatComposerAttachments>
+ * ```
+ */
 export function XDSChatComposerAttachments({
   ref,
   children,

--- a/packages/core/src/Chat/XDSChatDictationButton.tsx
+++ b/packages/core/src/Chat/XDSChatDictationButton.tsx
@@ -84,6 +84,15 @@ const SIZE_CONFIG = {
 // Component
 // =============================================================================
 
+/**
+ * Microphone button for voice input in a chat composer.
+ * Requires the return value of useXDSChatDictation.
+ *
+ * @example
+ * ```
+ * <XDSChatDictationButton dictation={dictation} />
+ * ```
+ */
 export function XDSChatDictationButton({
   dictation,
   size = 'md',
@@ -117,18 +126,22 @@ export function XDSChatDictationButton({
       {isListening && (
         <span
           aria-hidden
-          {...mergeProps(stylex.props(styles.barsContainer), {style: {gap: barGap, height: barMaxHeight}})}>
+          {...mergeProps(stylex.props(styles.barsContainer), {
+            style: {gap: barGap, height: barMaxHeight},
+          })}>
           {boostedBands.slice(0, BAR_COUNT).map((level, i) => {
             const scale = BAR_MIN_SCALE + level * (1 - BAR_MIN_SCALE);
             return (
               <span
                 key={i}
-                {...mergeProps(stylex.props(styles.bar), {style: {
-                  width: barWidth,
-                  height: '100%',
-                  backgroundColor: barColor,
-                  transform: `scaleY(${scale})`,
-                }})}
+                {...mergeProps(stylex.props(styles.bar), {
+                  style: {
+                    width: barWidth,
+                    height: '100%',
+                    backgroundColor: barColor,
+                    transform: `scaleY(${scale})`,
+                  },
+                })}
               />
             );
           })}

--- a/packages/core/src/Chat/XDSChatLayoutScrollButton.tsx
+++ b/packages/core/src/Chat/XDSChatLayoutScrollButton.tsx
@@ -86,6 +86,14 @@ const styles = stylex.create({
 // Component
 // =============================================================================
 
+/**
+ * Floating scroll-to-bottom button for use inside XDSChatLayout.
+ *
+ * @example
+ * ```
+ * <XDSChatLayoutScrollButton isVisible={!isAtBottom} onClick={scrollToBottom} />
+ * ```
+ */
 export function XDSChatLayoutScrollButton({
   isVisible,
   label,

--- a/packages/core/src/CodeBlock/XDSCodeBlock.tsx
+++ b/packages/core/src/CodeBlock/XDSCodeBlock.tsx
@@ -511,6 +511,15 @@ function RangeCodeContent({
 // Main component
 // ---------------------------------------------------------------------------
 
+/**
+ * Read-only code display with syntax highlighting, line numbers,
+ * and optional copy button.
+ *
+ * @example
+ * ```
+ * <XDSCodeBlock code="const x = 42;" language="javascript" />
+ * ```
+ */
 export function XDSCodeBlock({
   code,
   language = 'plaintext',


### PR DESCRIPTION
## What

Added JSDoc `@example` blocks to 5 exported components that were missing them. Without these, Storybook autodocs shows no preview for these components.

### Components fixed:
- **XDSChatComposer** — chat composer layout shell
- **XDSChatComposerAttachments** — attachment container with collapse
- **XDSChatDictationButton** — voice input button
- **XDSChatLayoutScrollButton** — scroll-to-bottom button
- **XDSCodeBlock** — syntax-highlighted code display

### Intentionally skipped:
- XDSSelectorItem (deprecated re-export of XDSSelectorOption)
- XDSTreeListItem (internal, consumed only by XDSTreeList)
- XDSAppShellSlotPresence, XDSChatPastedTextToken, XDSTreeListBranches (not exported)

### Format
All examples follow the Storybook-compatible format:
- Bare ``` fences (no `tsx` tag)
- No blank lines inside code blocks
- No JS comments inside code blocks
- Single concise example per component

---
*Night Watch Doc Reviewer*