### PR TITLE
fix: component audit — Spinner, Stack, StatusDot, Switch, TabList

### DIFF
--- a/packages/core/src/Layout/index.ts
+++ b/packages/core/src/Layout/index.ts
@@ -42,6 +42,7 @@ export type {
 export {XDSStack, XDSHStack, XDSVStack, XDSStackItem} from '../Stack';
 export type {
   XDSStackProps,
+  XDSStackAlignment,
   StackAlignment,
   XDSHStackProps,
   XDSVStackProps,

--- a/packages/core/src/Stack/XDSStack.tsx
+++ b/packages/core/src/Stack/XDSStack.tsx
@@ -40,7 +40,10 @@ import {xdsClassName, mergeProps} from '../utils';
  * - Cross axis (vAlign for horizontal, hAlign for vertical):
  *   `'start' | 'center' | 'end' | 'stretch'`
  */
-export type StackAlignment = StackMainAlignment | StackCrossAlignment;
+export type XDSStackAlignment = StackMainAlignment | StackCrossAlignment;
+
+/** @deprecated Use `XDSStackAlignment` instead. */
+export type StackAlignment = XDSStackAlignment;
 
 export interface XDSStackProps extends XDSBaseProps<HTMLDivElement> {
   /** Ref forwarded to the root element */
@@ -59,7 +62,7 @@ export interface XDSStackProps extends XDSBaseProps<HTMLDivElement> {
    * - When `direction='vertical'`: controls cross-axis (align-items).
    *   Accepts: `'start' | 'center' | 'end' | 'stretch'`
    */
-  hAlign?: StackAlignment;
+  hAlign?: XDSStackAlignment;
 
   /**
    * Vertical alignment of items.
@@ -68,7 +71,7 @@ export interface XDSStackProps extends XDSBaseProps<HTMLDivElement> {
    * - When `direction='vertical'`: controls main-axis (justify-content).
    *   Accepts: `'start' | 'center' | 'end' | 'between' | 'around' | 'evenly'`
    */
-  vAlign?: StackAlignment;
+  vAlign?: XDSStackAlignment;
 
   /**
    * Spacing between items.

--- a/packages/core/src/Stack/index.ts
+++ b/packages/core/src/Stack/index.ts
@@ -9,7 +9,11 @@
 
 // Unified stack component
 export {XDSStack} from './XDSStack';
-export type {XDSStackProps, StackAlignment} from './XDSStack';
+export type {
+  XDSStackProps,
+  XDSStackAlignment,
+  StackAlignment,
+} from './XDSStack';
 
 // Convenience wrappers
 export {XDSHStack} from './XDSHStack';

--- a/packages/core/src/StatusDot/index.ts
+++ b/packages/core/src/StatusDot/index.ts
@@ -1,5 +1,8 @@
 /**
- * @file StatusDot component barrel export
+ * @file index.ts
+ * @input Imports from XDSStatusDot component
+ * @output Exports XDSStatusDot component and related types
+ * @position Entry point for StatusDot; re-exported by /packages/core/src/index.ts
  */
 
 export {XDSStatusDot} from './XDSStatusDot';


### PR DESCRIPTION
## Component Audit (2026-04-21)

Night Watch Component Auditor — Queue Round.

### Components Audited
- **Spinner** — All 10 checks pass
- **Stack** — 1 finding: StackAlignment type missing XDS prefix
- **StatusDot** — 1 finding: index.ts missing full file header
- **Switch** — All 10 checks pass
- **TabList** — All 10 checks pass

### Changes
- Rename StackAlignment to XDSStackAlignment (public type naming convention). Backwards-compatible deprecated alias kept.
- Add full structured file header to StatusDot/index.ts

### Checks Run
All 10 audit dimensions checked per component (CSS vars, xdsClassName, component reuse, prop naming, type naming, structure, input consistency, a11y, export hygiene).