### PR TITLE
feat(ci): allow design owners to merge .doc.mjs changes

### DIFF
--- a/.github/workflows/codeowner-gate.yml
+++ b/.github/workflows/codeowner-gate.yml
@@ -62,6 +62,12 @@ jobs:
               'packages/cli/templates/',
             ];
 
+            // File patterns that design owners can also merge (glob-style)
+            // .doc.mjs files are doc metadata, not component logic
+            const DESIGN_FILE_PATTERNS = [
+              /\.doc\.mjs$/,
+            ];
+
             // --- Resolve PR context ---
             const pr = context.payload.pull_request;
             const prNumber = pr.number;
@@ -83,9 +89,10 @@ jobs:
               f.previous_filename ? [f.filename, f.previous_filename] : [f.filename]
             );
             const changedFiles = files.map(f => f.filename);
-            const onlyDesignPaths = allPaths.length > 0 && allPaths.every(
-              p => DESIGN_PATHS.some(prefix => p.startsWith(prefix))
-            );
+            const isDesignOwned = (p) =>
+              DESIGN_PATHS.some(prefix => p.startsWith(prefix)) ||
+              DESIGN_FILE_PATTERNS.some(re => re.test(p));
+            const onlyDesignPaths = allPaths.length > 0 && allPaths.every(isDesignOwned);
 
             // --- Determine result ---
             let conclusion = 'failure';

--- a/packages/core/src/Chat/XDSChatComposer.tsx
+++ b/packages/core/src/Chat/XDSChatComposer.tsx
@@ -249,6 +249,18 @@ const styles = stylex.create({
 // Component
 // =============================================================================
 
+/**
+ * Layout shell for a chat composer with slots for attachments, input,
+ * actions, and a send button.
+ *
+ * @example
+ * ```
+ * <XDSChatComposer
+ *   onSubmit={(value) => console.log(value)}
+ *   placeholder="Type a message..."
+ * />
+ * ```
+ */
 export function XDSChatComposer(props: XDSChatComposerProps) {
   const {
     onSubmit,

--- a/packages/core/src/Chat/XDSChatComposerAttachments.tsx
+++ b/packages/core/src/Chat/XDSChatComposerAttachments.tsx
@@ -188,6 +188,18 @@ const styles = stylex.create({
   },
 });
 
+/**
+ * Container for attachment previews inside a chat composer.
+ * Supports collapsible behavior with a count badge.
+ *
+ * @example
+ * ```
+ * <XDSChatComposerAttachments count={3}>
+ *   <AttachmentThumbnail />
+ *   <AttachmentThumbnail />
+ * </XDSChatComposerAttachments>
+ * ```
+ */
 export function XDSChatComposerAttachments({
   ref,
   children,

--- a/packages/core/src/Chat/XDSChatDictationButton.tsx
+++ b/packages/core/src/Chat/XDSChatDictationButton.tsx
@@ -84,6 +84,15 @@ const SIZE_CONFIG = {
 // Component
 // =============================================================================
 
+/**
+ * Microphone button for voice input in a chat composer.
+ * Requires the return value of useXDSChatDictation.
+ *
+ * @example
+ * ```
+ * <XDSChatDictationButton dictation={dictation} />
+ * ```
+ */
 export function XDSChatDictationButton({
   dictation,
   size = 'md',
@@ -117,18 +126,22 @@ export function XDSChatDictationButton({
       {isListening && (
         <span
           aria-hidden
-          {...mergeProps(stylex.props(styles.barsContainer), {style: {gap: barGap, height: barMaxHeight}})}>
+          {...mergeProps(stylex.props(styles.barsContainer), {
+            style: {gap: barGap, height: barMaxHeight},
+          })}>
           {boostedBands.slice(0, BAR_COUNT).map((level, i) => {
             const scale = BAR_MIN_SCALE + level * (1 - BAR_MIN_SCALE);
             return (
               <span
                 key={i}
-                {...mergeProps(stylex.props(styles.bar), {style: {
-                  width: barWidth,
-                  height: '100%',
-                  backgroundColor: barColor,
-                  transform: `scaleY(${scale})`,
-                }})}
+                {...mergeProps(stylex.props(styles.bar), {
+                  style: {
+                    width: barWidth,
+                    height: '100%',
+                    backgroundColor: barColor,
+                    transform: `scaleY(${scale})`,
+                  },
+                })}
               />
             );
           })}

--- a/packages/core/src/Chat/XDSChatLayoutScrollButton.tsx
+++ b/packages/core/src/Chat/XDSChatLayoutScrollButton.tsx
@@ -86,6 +86,14 @@ const styles = stylex.create({
 // Component
 // =============================================================================
 
+/**
+ * Floating scroll-to-bottom button for use inside XDSChatLayout.
+ *
+ * @example
+ * ```
+ * <XDSChatLayoutScrollButton isVisible={!isAtBottom} onClick={scrollToBottom} />
+ * ```
+ */
 export function XDSChatLayoutScrollButton({
   isVisible,
   label,

--- a/packages/core/src/CodeBlock/XDSCodeBlock.tsx
+++ b/packages/core/src/CodeBlock/XDSCodeBlock.tsx
@@ -511,6 +511,15 @@ function RangeCodeContent({
 // Main component
 // ---------------------------------------------------------------------------
 
+/**
+ * Read-only code display with syntax highlighting, line numbers,
+ * and optional copy button.
+ *
+ * @example
+ * ```
+ * <XDSCodeBlock code="const x = 42;" language="javascript" />
+ * ```
+ */
 export function XDSCodeBlock({
   code,
   language = 'plaintext',

--- a/packages/core/src/Layout/index.ts
+++ b/packages/core/src/Layout/index.ts
@@ -42,6 +42,7 @@ export type {
 export {XDSStack, XDSHStack, XDSVStack, XDSStackItem} from '../Stack';
 export type {
   XDSStackProps,
+  XDSStackAlignment,
   StackAlignment,
   XDSHStackProps,
   XDSVStackProps,

--- a/packages/core/src/Stack/XDSStack.tsx
+++ b/packages/core/src/Stack/XDSStack.tsx
@@ -40,7 +40,10 @@ import {xdsClassName, mergeProps} from '../utils';
  * - Cross axis (vAlign for horizontal, hAlign for vertical):
  *   `'start' | 'center' | 'end' | 'stretch'`
  */
-export type StackAlignment = StackMainAlignment | StackCrossAlignment;
+export type XDSStackAlignment = StackMainAlignment | StackCrossAlignment;
+
+/** @deprecated Use `XDSStackAlignment` instead. */
+export type StackAlignment = XDSStackAlignment;
 
 export interface XDSStackProps extends XDSBaseProps<HTMLDivElement> {
   /** Ref forwarded to the root element */
@@ -59,7 +62,7 @@ export interface XDSStackProps extends XDSBaseProps<HTMLDivElement> {
    * - When `direction='vertical'`: controls cross-axis (align-items).
    *   Accepts: `'start' | 'center' | 'end' | 'stretch'`
    */
-  hAlign?: StackAlignment;
+  hAlign?: XDSStackAlignment;
 
   /**
    * Vertical alignment of items.
@@ -68,7 +71,7 @@ export interface XDSStackProps extends XDSBaseProps<HTMLDivElement> {
    * - When `direction='vertical'`: controls main-axis (justify-content).
    *   Accepts: `'start' | 'center' | 'end' | 'between' | 'around' | 'evenly'`
    */
-  vAlign?: StackAlignment;
+  vAlign?: XDSStackAlignment;
 
   /**
    * Spacing between items.

--- a/packages/core/src/Stack/index.ts
+++ b/packages/core/src/Stack/index.ts
@@ -9,7 +9,11 @@
 
 // Unified stack component
 export {XDSStack} from './XDSStack';
-export type {XDSStackProps, StackAlignment} from './XDSStack';
+export type {
+  XDSStackProps,
+  XDSStackAlignment,
+  StackAlignment,
+} from './XDSStack';
 
 // Convenience wrappers
 export {XDSHStack} from './XDSHStack';

--- a/packages/core/src/StatusDot/index.ts
+++ b/packages/core/src/StatusDot/index.ts
@@ -1,5 +1,8 @@
 /**
- * @file StatusDot component barrel export
+ * @file index.ts
+ * @input Imports from XDSStatusDot component
+ * @output Exports XDSStatusDot component and related types
+ * @position Entry point for StatusDot; re-exported by /packages/core/src/index.ts
  */
 
 export {XDSStatusDot} from './XDSStatusDot';


### PR DESCRIPTION
Adds `.doc.mjs` files to the Code Owner Gate's design-owned paths. These are doc metadata files (usage guidelines, prop descriptions, best practices) — not component logic.

This means design owners listed in `.github/DESIGNOWNERS` can merge PRs that update block examples + doc metadata without waiting for code owner approval.

**What changed:**
- Added `DESIGN_FILE_PATTERNS` array with `/\.doc\.mjs$/` regex
- Updated `onlyDesignPaths` check to also match file patterns