### PR TITLE
Improve Dialog docs page and block examples

### DIFF
--- a/packages/cli/templates/blocks/components/Dialog/DialogConfirmationDialog.doc.mjs
+++ b/packages/cli/templates/blocks/components/Dialog/DialogConfirmationDialog.doc.mjs
@@ -6,5 +6,5 @@ export const doc = {
     'Destructive action confirmation with cancel and delete buttons. Use before permanently deleting data or revoking access.',
   isReady: true,
   aspectRatio: 16 / 9,
-  componentsUsed: ['Dialog', 'Layout', 'Button', 'Text'],
+  componentsUsed: ['Dialog', 'Layout', 'Button', 'Text', 'Card'],
 };

--- a/packages/cli/templates/blocks/components/Dialog/DialogConfirmationDialog.doc.mjs
+++ b/packages/cli/templates/blocks/components/Dialog/DialogConfirmationDialog.doc.mjs
@@ -1,9 +1,9 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
-  name: 'Dialog — Confirmation Dialog',
+  name: 'Dialog — Confirmation',
   description:
-    'Destructive action confirmation with cancel and delete buttons.',
+    'Destructive action confirmation with cancel and delete buttons. Use before permanently deleting data or revoking access.',
   isReady: true,
   aspectRatio: 4 / 3,
   componentsUsed: ['Dialog', 'Layout', 'Button', 'Text'],

--- a/packages/cli/templates/blocks/components/Dialog/DialogConfirmationDialog.doc.mjs
+++ b/packages/cli/templates/blocks/components/Dialog/DialogConfirmationDialog.doc.mjs
@@ -3,7 +3,7 @@ export const doc = {
   type: 'block',
   name: 'Dialog — Confirmation',
   description:
-    'Destructive action confirmation with cancel and delete buttons. Use before permanently deleting data or revoking access.',
+    'Asks the user to confirm a destructive action before it happens. Use before deleting projects, removing team members, revoking API keys, or any irreversible operation.',
   isReady: true,
   aspectRatio: 16 / 9,
   componentsUsed: ['Dialog', 'Layout', 'Button', 'Text', 'Card'],

--- a/packages/cli/templates/blocks/components/Dialog/DialogConfirmationDialog.doc.mjs
+++ b/packages/cli/templates/blocks/components/Dialog/DialogConfirmationDialog.doc.mjs
@@ -5,6 +5,6 @@ export const doc = {
   description:
     'Destructive action confirmation with cancel and delete buttons. Use before permanently deleting data or revoking access.',
   isReady: true,
-  aspectRatio: 4 / 3,
+  aspectRatio: 16 / 9,
   componentsUsed: ['Dialog', 'Layout', 'Button', 'Text'],
 };

--- a/packages/cli/templates/blocks/components/Dialog/DialogConfirmationDialog.tsx
+++ b/packages/cli/templates/blocks/components/Dialog/DialogConfirmationDialog.tsx
@@ -24,7 +24,7 @@ export default function DialogConfirmationDialog() {
     <XDSCard>
       <XDSVStack gap={3}>
         <XDSVStack gap={1}>
-          <XDSText type="bodyBold">Marketing Dashboard</XDSText>
+          <XDSText type="body" weight="bold">Marketing Dashboard</XDSText>
           <XDSText type="supporting" color="secondary">
             Created Jan 12, 2026 · 14 pages · 3 collaborators
           </XDSText>

--- a/packages/cli/templates/blocks/components/Dialog/DialogConfirmationDialog.tsx
+++ b/packages/cli/templates/blocks/components/Dialog/DialogConfirmationDialog.tsx
@@ -7,6 +7,7 @@ import {
   XDSLayoutContent,
   XDSLayoutFooter,
   XDSHStack,
+  XDSVStack,
 } from '@xds/core/Layout';
 import {XDSButton} from '@xds/core/Button';
 import {XDSText} from '@xds/core/Text';
@@ -21,34 +22,31 @@ export default function DialogConfirmationDialog() {
   };
 
   return (
-    <div style={{display: 'flex', flexDirection: 'column', gap: 12}}>
+    <XDSVStack gap={3}>
       <XDSButton
-        label="Delete Item"
+        label="Delete project"
         variant="destructive"
         onClick={() => setIsOpen(true)}
       />
       {deleted && (
         <XDSText type="body" color="primary">
-          Item deleted (demo)
+          Project deleted (demo)
         </XDSText>
       )}
       <XDSDialog
         isOpen={isOpen}
         onOpenChange={setIsOpen}
-        width={350}
+        width={400}
         purpose="form">
         <XDSLayout
           header={
-            <XDSDialogHeader
-              title="Confirm Delete"
-              onOpenChange={setIsOpen}
-            />
+            <XDSDialogHeader title="Delete project?" onOpenChange={setIsOpen} />
           }
           content={
             <XDSLayoutContent>
               <XDSText type="body">
-                Are you sure you want to delete this item? This action cannot be
-                undone.
+                This will permanently delete &quot;Marketing Dashboard&quot; and
+                all of its data. This action cannot be undone.
               </XDSText>
             </XDSLayoutContent>
           }
@@ -70,6 +68,6 @@ export default function DialogConfirmationDialog() {
           }
         />
       </XDSDialog>
-    </div>
+    </XDSVStack>
   );
 }

--- a/packages/cli/templates/blocks/components/Dialog/DialogConfirmationDialog.tsx
+++ b/packages/cli/templates/blocks/components/Dialog/DialogConfirmationDialog.tsx
@@ -11,28 +11,33 @@ import {
 } from '@xds/core/Layout';
 import {XDSButton} from '@xds/core/Button';
 import {XDSText} from '@xds/core/Text';
+import {XDSCard} from '@xds/core/Card';
 
 export default function DialogConfirmationDialog() {
   const [isOpen, setIsOpen] = useState(false);
-  const [deleted, setDeleted] = useState(false);
 
   const handleDelete = () => {
-    setDeleted(true);
     setIsOpen(false);
   };
 
   return (
-    <XDSVStack gap={3}>
-      <XDSButton
-        label="Delete project"
-        variant="destructive"
-        onClick={() => setIsOpen(true)}
-      />
-      {deleted && (
-        <XDSText type="body" color="primary">
-          Project deleted (demo)
-        </XDSText>
-      )}
+    <XDSCard>
+      <XDSVStack gap={3}>
+        <XDSVStack gap={1}>
+          <XDSText type="bodyBold">Marketing Dashboard</XDSText>
+          <XDSText type="supporting" color="secondary">
+            Created Jan 12, 2026 · 14 pages · 3 collaborators
+          </XDSText>
+        </XDSVStack>
+        <XDSHStack gap={2}>
+          <XDSButton label="Edit" variant="secondary" onClick={() => {}} />
+          <XDSButton
+            label="Delete project"
+            variant="destructive"
+            onClick={() => setIsOpen(true)}
+          />
+        </XDSHStack>
+      </XDSVStack>
       <XDSDialog
         isOpen={isOpen}
         onOpenChange={setIsOpen}
@@ -68,6 +73,6 @@ export default function DialogConfirmationDialog() {
           }
         />
       </XDSDialog>
-    </XDSVStack>
+    </XDSCard>
   );
 }

--- a/packages/cli/templates/blocks/components/Dialog/DialogFormDialog.doc.mjs
+++ b/packages/cli/templates/blocks/components/Dialog/DialogFormDialog.doc.mjs
@@ -6,5 +6,5 @@ export const doc = {
     'Form-purpose dialog that prevents backdrop dismissal to protect unsaved data. Use for editing profiles, settings, or any dialog with inputs.',
   isReady: true,
   aspectRatio: 16 / 9,
-  componentsUsed: ['Dialog', 'Layout', 'Button', 'Text'],
+  componentsUsed: ['Dialog', 'Layout', 'Button', 'Text', 'Card'],
 };

--- a/packages/cli/templates/blocks/components/Dialog/DialogFormDialog.doc.mjs
+++ b/packages/cli/templates/blocks/components/Dialog/DialogFormDialog.doc.mjs
@@ -5,6 +5,6 @@ export const doc = {
   description:
     'Form-purpose dialog that prevents backdrop dismissal to protect unsaved data. Use for editing profiles, settings, or any dialog with inputs.',
   isReady: true,
-  aspectRatio: 4 / 3,
+  aspectRatio: 16 / 9,
   componentsUsed: ['Dialog', 'Layout', 'Button', 'Text'],
 };

--- a/packages/cli/templates/blocks/components/Dialog/DialogFormDialog.doc.mjs
+++ b/packages/cli/templates/blocks/components/Dialog/DialogFormDialog.doc.mjs
@@ -3,7 +3,7 @@ export const doc = {
   type: 'block',
   name: 'Dialog — Form',
   description:
-    'Form-purpose dialog that prevents backdrop dismissal to protect unsaved data. Use for editing profiles, settings, or any dialog with inputs.',
+    'Collects user input without navigating away from the page. Uses purpose="form" so clicking the backdrop won\'t close it. Use for editing profiles, creating items, or updating settings inline.',
   isReady: true,
   aspectRatio: 16 / 9,
   componentsUsed: ['Dialog', 'Layout', 'Button', 'Text', 'Card'],

--- a/packages/cli/templates/blocks/components/Dialog/DialogFormDialog.doc.mjs
+++ b/packages/cli/templates/blocks/components/Dialog/DialogFormDialog.doc.mjs
@@ -6,5 +6,5 @@ export const doc = {
     'Collects user input without navigating away from the page. Uses purpose="form" so clicking the backdrop won\'t close it. Use for editing profiles, creating items, or updating settings inline.',
   isReady: true,
   aspectRatio: 16 / 9,
-  componentsUsed: ['Dialog', 'Layout', 'Button', 'Text', 'Card'],
+  componentsUsed: ['Dialog', 'Layout', 'Button', 'Text', 'TextInput', 'TextArea', 'Card'],
 };

--- a/packages/cli/templates/blocks/components/Dialog/DialogFormDialog.doc.mjs
+++ b/packages/cli/templates/blocks/components/Dialog/DialogFormDialog.doc.mjs
@@ -1,9 +1,9 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
-  name: 'Dialog — Form Dialog',
+  name: 'Dialog — Form',
   description:
-    'Form-purpose dialog that prevents backdrop dismissal to protect unsaved data.',
+    'Form-purpose dialog that prevents backdrop dismissal to protect unsaved data. Use for editing profiles, settings, or any dialog with inputs.',
   isReady: true,
   aspectRatio: 4 / 3,
   componentsUsed: ['Dialog', 'Layout', 'Button', 'Text'],

--- a/packages/cli/templates/blocks/components/Dialog/DialogFormDialog.tsx
+++ b/packages/cli/templates/blocks/components/Dialog/DialogFormDialog.tsx
@@ -11,10 +11,14 @@ import {
 } from '@xds/core/Layout';
 import {XDSButton} from '@xds/core/Button';
 import {XDSText} from '@xds/core/Text';
+import {XDSTextInput} from '@xds/core/TextInput';
+import {XDSTextArea} from '@xds/core/TextArea';
 import {XDSCard} from '@xds/core/Card';
 
 export default function DialogFormDialog() {
   const [isOpen, setIsOpen] = useState(false);
+  const [name, setName] = useState('Ruby Cheung');
+  const [bio, setBio] = useState('Design systems engineer');
 
   return (
     <XDSCard>
@@ -46,15 +50,19 @@ export default function DialogFormDialog() {
           }
           content={
             <XDSLayoutContent>
-              <XDSVStack gap={3}>
-                <XDSText type="body">
-                  This dialog uses purpose=&quot;form&quot;. Clicking the
-                  backdrop will not close it, preventing accidental data loss.
-                  Escape still works.
-                </XDSText>
-                <XDSText type="supporting" color="secondary">
-                  Form fields would go here — TextInput, TextArea, etc.
-                </XDSText>
+              <XDSVStack gap={4}>
+                <XDSTextInput
+                  label="Display name"
+                  value={name}
+                  onChange={setName}
+                  placeholder="Enter your name"
+                />
+                <XDSTextArea
+                  label="Bio"
+                  value={bio}
+                  onChange={setBio}
+                  placeholder="Tell us about yourself"
+                />
               </XDSVStack>
             </XDSLayoutContent>
           }

--- a/packages/cli/templates/blocks/components/Dialog/DialogFormDialog.tsx
+++ b/packages/cli/templates/blocks/components/Dialog/DialogFormDialog.tsx
@@ -24,7 +24,7 @@ export default function DialogFormDialog() {
     <XDSCard>
       <XDSVStack gap={3}>
         <XDSVStack gap={1}>
-          <XDSText type="bodyBold">Profile Settings</XDSText>
+          <XDSText type="body" weight="bold">Profile Settings</XDSText>
           <XDSText type="supporting" color="secondary">
             Display name, bio, and avatar
           </XDSText>

--- a/packages/cli/templates/blocks/components/Dialog/DialogFormDialog.tsx
+++ b/packages/cli/templates/blocks/components/Dialog/DialogFormDialog.tsx
@@ -7,6 +7,7 @@ import {
   XDSLayoutContent,
   XDSLayoutFooter,
   XDSHStack,
+  XDSVStack,
 } from '@xds/core/Layout';
 import {XDSButton} from '@xds/core/Button';
 import {XDSText} from '@xds/core/Text';
@@ -15,9 +16,9 @@ export default function DialogFormDialog() {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
-    <>
+    <XDSVStack gap={3}>
       <XDSButton
-        label="Open Form Modal"
+        label="Edit profile"
         variant="secondary"
         onClick={() => setIsOpen(true)}
       />
@@ -25,21 +26,27 @@ export default function DialogFormDialog() {
         isOpen={isOpen}
         onOpenChange={setIsOpen}
         purpose="form"
-        width={500}>
+        width={480}>
         <XDSLayout
           header={
             <XDSDialogHeader
-              title="Edit Profile"
+              title="Edit profile"
+              subtitle="Update your display name and bio"
               onOpenChange={setIsOpen}
             />
           }
           content={
             <XDSLayoutContent>
-              <XDSText type="body">
-                This modal uses purpose=&quot;form&quot;. Clicking outside
-                won&apos;t close it to prevent accidental data loss, but you can
-                still press Escape.
-              </XDSText>
+              <XDSVStack gap={3}>
+                <XDSText type="body">
+                  This dialog uses purpose=&quot;form&quot;. Clicking the
+                  backdrop will not close it, preventing accidental data loss.
+                  Escape still works.
+                </XDSText>
+                <XDSText type="supporting" color="secondary">
+                  Form fields would go here — TextInput, TextArea, etc.
+                </XDSText>
+              </XDSVStack>
             </XDSLayoutContent>
           }
           footer={
@@ -60,6 +67,6 @@ export default function DialogFormDialog() {
           }
         />
       </XDSDialog>
-    </>
+    </XDSVStack>
   );
 }

--- a/packages/cli/templates/blocks/components/Dialog/DialogFormDialog.tsx
+++ b/packages/cli/templates/blocks/components/Dialog/DialogFormDialog.tsx
@@ -11,17 +11,26 @@ import {
 } from '@xds/core/Layout';
 import {XDSButton} from '@xds/core/Button';
 import {XDSText} from '@xds/core/Text';
+import {XDSCard} from '@xds/core/Card';
 
 export default function DialogFormDialog() {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
-    <XDSVStack gap={3}>
-      <XDSButton
-        label="Edit profile"
-        variant="secondary"
-        onClick={() => setIsOpen(true)}
-      />
+    <XDSCard>
+      <XDSVStack gap={3}>
+        <XDSVStack gap={1}>
+          <XDSText type="bodyBold">Profile Settings</XDSText>
+          <XDSText type="supporting" color="secondary">
+            Display name, bio, and avatar
+          </XDSText>
+        </XDSVStack>
+        <XDSButton
+          label="Edit profile"
+          variant="secondary"
+          onClick={() => setIsOpen(true)}
+        />
+      </XDSVStack>
       <XDSDialog
         isOpen={isOpen}
         onOpenChange={setIsOpen}
@@ -67,6 +76,6 @@ export default function DialogFormDialog() {
           }
         />
       </XDSDialog>
-    </XDSVStack>
+    </XDSCard>
   );
 }

--- a/packages/cli/templates/blocks/components/Dialog/DialogFullscreenDialog.doc.mjs
+++ b/packages/cli/templates/blocks/components/Dialog/DialogFullscreenDialog.doc.mjs
@@ -1,8 +1,9 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
-  name: 'Dialog — Fullscreen Dialog',
-  description: 'Full-viewport dialog variant with scrollable content.',
+  name: 'Dialog — Fullscreen',
+  description:
+    'Full-viewport dialog for complex content like documentation, editors, or multi-section forms that need more space.',
   isReady: true,
   aspectRatio: 4 / 3,
   componentsUsed: ['Dialog', 'Layout', 'Button', 'Text'],

--- a/packages/cli/templates/blocks/components/Dialog/DialogFullscreenDialog.doc.mjs
+++ b/packages/cli/templates/blocks/components/Dialog/DialogFullscreenDialog.doc.mjs
@@ -5,6 +5,6 @@ export const doc = {
   description:
     'Full-viewport dialog for complex content like documentation, editors, or multi-section forms that need more space.',
   isReady: true,
-  aspectRatio: 4 / 3,
+  aspectRatio: 16 / 9,
   componentsUsed: ['Dialog', 'Layout', 'Button', 'Text'],
 };

--- a/packages/cli/templates/blocks/components/Dialog/DialogFullscreenDialog.doc.mjs
+++ b/packages/cli/templates/blocks/components/Dialog/DialogFullscreenDialog.doc.mjs
@@ -6,5 +6,5 @@ export const doc = {
     'Full-viewport dialog for complex content like documentation, editors, or multi-section forms that need more space.',
   isReady: true,
   aspectRatio: 16 / 9,
-  componentsUsed: ['Dialog', 'Layout', 'Button', 'Text'],
+  componentsUsed: ['Dialog', 'Layout', 'Button', 'Text', 'Card'],
 };

--- a/packages/cli/templates/blocks/components/Dialog/DialogFullscreenDialog.doc.mjs
+++ b/packages/cli/templates/blocks/components/Dialog/DialogFullscreenDialog.doc.mjs
@@ -3,7 +3,7 @@ export const doc = {
   type: 'block',
   name: 'Dialog — Fullscreen',
   description:
-    'Full-viewport dialog for complex content like documentation, editors, or multi-section forms that need more space.',
+    'Takes over the entire viewport for content that needs maximum space. Use for documentation viewers, rich text editors, multi-step wizards, or media previews where the standard dialog width is too narrow.',
   isReady: true,
   aspectRatio: 16 / 9,
   componentsUsed: ['Dialog', 'Layout', 'Button', 'Text', 'Card'],

--- a/packages/cli/templates/blocks/components/Dialog/DialogFullscreenDialog.tsx
+++ b/packages/cli/templates/blocks/components/Dialog/DialogFullscreenDialog.tsx
@@ -7,17 +7,41 @@ import {
   XDSLayoutContent,
   XDSLayoutFooter,
   XDSHStack,
+  XDSVStack,
 } from '@xds/core/Layout';
 import {XDSButton} from '@xds/core/Button';
 import {XDSText} from '@xds/core/Text';
+
+const SECTIONS = [
+  {
+    title: 'Getting started',
+    body: 'Create your first project by clicking New Project in the sidebar. Choose a template or start from scratch.',
+  },
+  {
+    title: 'Team members',
+    body: 'Invite collaborators from Settings > Team. Each member can have Admin, Editor, or Viewer permissions.',
+  },
+  {
+    title: 'Billing',
+    body: 'Free plans include up to 3 projects. Upgrade to Pro for unlimited projects and priority support.',
+  },
+  {
+    title: 'API access',
+    body: 'Generate API keys from Settings > Developer. Rate limits are 1,000 requests per minute on free plans.',
+  },
+  {
+    title: 'Data export',
+    body: 'Export your data anytime from Settings > Data. Exports are available as CSV or JSON within 24 hours.',
+  },
+];
 
 export default function DialogFullscreenDialog() {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
-    <>
+    <XDSVStack gap={3}>
       <XDSButton
-        label="Open Fullscreen Modal"
+        label="Open documentation"
         variant="secondary"
         onClick={() => setIsOpen(true)}
       />
@@ -25,26 +49,21 @@ export default function DialogFullscreenDialog() {
         <XDSLayout
           header={
             <XDSDialogHeader
-              title="Fullscreen Modal"
+              title="Documentation"
+              subtitle="Everything you need to get started"
               onOpenChange={setIsOpen}
             />
           }
           content={
             <XDSLayoutContent>
-              <div
-                style={{display: 'flex', flexDirection: 'column', gap: 12}}>
-                <XDSText type="body">
-                  This modal takes up the entire viewport. The width, maxHeight,
-                  and position props are ignored in fullscreen mode.
-                </XDSText>
-                {Array.from({length: 10}, (_, i) => (
-                  <XDSText type="body" key={i}>
-                    {i + 1}. Lorem ipsum dolor sit amet, consectetur adipiscing
-                    elit. Sed do eiusmod tempor incididunt ut labore et dolore
-                    magna aliqua.
-                  </XDSText>
+              <XDSVStack gap={4}>
+                {SECTIONS.map(({title, body}) => (
+                  <XDSVStack key={title} gap={1}>
+                    <XDSText type="bodyBold">{title}</XDSText>
+                    <XDSText type="body">{body}</XDSText>
+                  </XDSVStack>
                 ))}
-              </div>
+              </XDSVStack>
             </XDSLayoutContent>
           }
           footer={
@@ -60,6 +79,6 @@ export default function DialogFullscreenDialog() {
           }
         />
       </XDSDialog>
-    </>
+    </XDSVStack>
   );
 }

--- a/packages/cli/templates/blocks/components/Dialog/DialogFullscreenDialog.tsx
+++ b/packages/cli/templates/blocks/components/Dialog/DialogFullscreenDialog.tsx
@@ -43,7 +43,7 @@ export default function DialogFullscreenDialog() {
     <XDSCard>
       <XDSVStack gap={3}>
         <XDSVStack gap={1}>
-          <XDSText type="bodyBold">Help &amp; Documentation</XDSText>
+          <XDSText type="body" weight="bold">Help &amp; Documentation</XDSText>
           <XDSText type="supporting" color="secondary">
             5 articles · Last updated Apr 2026
           </XDSText>
@@ -68,7 +68,7 @@ export default function DialogFullscreenDialog() {
               <XDSVStack gap={4}>
                 {SECTIONS.map(({title, body}) => (
                   <XDSVStack key={title} gap={1}>
-                    <XDSText type="bodyBold">{title}</XDSText>
+                    <XDSText type="body" weight="bold">{title}</XDSText>
                     <XDSText type="body">{body}</XDSText>
                   </XDSVStack>
                 ))}

--- a/packages/cli/templates/blocks/components/Dialog/DialogFullscreenDialog.tsx
+++ b/packages/cli/templates/blocks/components/Dialog/DialogFullscreenDialog.tsx
@@ -11,6 +11,7 @@ import {
 } from '@xds/core/Layout';
 import {XDSButton} from '@xds/core/Button';
 import {XDSText} from '@xds/core/Text';
+import {XDSCard} from '@xds/core/Card';
 
 const SECTIONS = [
   {
@@ -39,12 +40,20 @@ export default function DialogFullscreenDialog() {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
-    <XDSVStack gap={3}>
-      <XDSButton
-        label="Open documentation"
-        variant="secondary"
-        onClick={() => setIsOpen(true)}
-      />
+    <XDSCard>
+      <XDSVStack gap={3}>
+        <XDSVStack gap={1}>
+          <XDSText type="bodyBold">Help &amp; Documentation</XDSText>
+          <XDSText type="supporting" color="secondary">
+            5 articles · Last updated Apr 2026
+          </XDSText>
+        </XDSVStack>
+        <XDSButton
+          label="Open documentation"
+          variant="secondary"
+          onClick={() => setIsOpen(true)}
+        />
+      </XDSVStack>
       <XDSDialog isOpen={isOpen} onOpenChange={setIsOpen} variant="fullscreen">
         <XDSLayout
           header={
@@ -79,6 +88,6 @@ export default function DialogFullscreenDialog() {
           }
         />
       </XDSDialog>
-    </XDSVStack>
+    </XDSCard>
   );
 }

--- a/packages/cli/templates/blocks/components/Dialog/DialogScrollingContent.doc.mjs
+++ b/packages/cli/templates/blocks/components/Dialog/DialogScrollingContent.doc.mjs
@@ -3,7 +3,7 @@ export const doc = {
   type: 'block',
   name: 'Dialog — Scrollable',
   description:
-    'Dialog with constrained max height and scrollable body. Use for terms and conditions, long lists, or any content that overflows.',
+    'Constrains the dialog height and scrolls the body when content overflows. Use for terms and conditions, license agreements, changelogs, or any long-form content the user needs to review before accepting.',
   isReady: true,
   aspectRatio: 16 / 9,
   componentsUsed: ['Dialog', 'Layout', 'Button', 'Text', 'Card'],

--- a/packages/cli/templates/blocks/components/Dialog/DialogScrollingContent.doc.mjs
+++ b/packages/cli/templates/blocks/components/Dialog/DialogScrollingContent.doc.mjs
@@ -1,9 +1,9 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
-  name: 'Dialog — Scrolling Content',
+  name: 'Dialog — Scrollable',
   description:
-    'Dialog with constrained max height and scrollable body content.',
+    'Dialog with constrained max height and scrollable body. Use for terms and conditions, long lists, or any content that overflows.',
   isReady: true,
   aspectRatio: 4 / 3,
   componentsUsed: ['Dialog', 'Layout', 'Button', 'Text'],

--- a/packages/cli/templates/blocks/components/Dialog/DialogScrollingContent.doc.mjs
+++ b/packages/cli/templates/blocks/components/Dialog/DialogScrollingContent.doc.mjs
@@ -5,6 +5,6 @@ export const doc = {
   description:
     'Dialog with constrained max height and scrollable body. Use for terms and conditions, long lists, or any content that overflows.',
   isReady: true,
-  aspectRatio: 4 / 3,
+  aspectRatio: 16 / 9,
   componentsUsed: ['Dialog', 'Layout', 'Button', 'Text'],
 };

--- a/packages/cli/templates/blocks/components/Dialog/DialogScrollingContent.doc.mjs
+++ b/packages/cli/templates/blocks/components/Dialog/DialogScrollingContent.doc.mjs
@@ -6,5 +6,5 @@ export const doc = {
     'Dialog with constrained max height and scrollable body. Use for terms and conditions, long lists, or any content that overflows.',
   isReady: true,
   aspectRatio: 16 / 9,
-  componentsUsed: ['Dialog', 'Layout', 'Button', 'Text'],
+  componentsUsed: ['Dialog', 'Layout', 'Button', 'Text', 'Card'],
 };

--- a/packages/cli/templates/blocks/components/Dialog/DialogScrollingContent.tsx
+++ b/packages/cli/templates/blocks/components/Dialog/DialogScrollingContent.tsx
@@ -31,7 +31,7 @@ export default function DialogScrollingContent() {
     <XDSCard>
       <XDSVStack gap={3}>
         <XDSVStack gap={1}>
-          <XDSText type="bodyBold">Terms and Conditions</XDSText>
+          <XDSText type="body" weight="bold">Terms and Conditions</XDSText>
           <XDSText type="supporting" color="secondary">
             Last updated March 2026 · 8 clauses
           </XDSText>

--- a/packages/cli/templates/blocks/components/Dialog/DialogScrollingContent.tsx
+++ b/packages/cli/templates/blocks/components/Dialog/DialogScrollingContent.tsx
@@ -7,17 +7,29 @@ import {
   XDSLayoutContent,
   XDSLayoutFooter,
   XDSHStack,
+  XDSVStack,
 } from '@xds/core/Layout';
 import {XDSButton} from '@xds/core/Button';
 import {XDSText} from '@xds/core/Text';
+
+const TERMS = [
+  'You agree to use the service only for lawful purposes and in compliance with all applicable laws.',
+  'Your account credentials are your responsibility. Notify us immediately if you suspect unauthorized access.',
+  'We reserve the right to suspend accounts that violate these terms or engage in abusive behavior.',
+  'Content you upload remains your property. You grant us a license to host and display it within the service.',
+  'We may update these terms at any time. Continued use after changes constitutes acceptance.',
+  'The service is provided as-is without warranties. We are not liable for data loss or service interruptions.',
+  'You may cancel your account at any time. Your data will be deleted within 30 days of cancellation.',
+  'Disputes will be resolved through binding arbitration in accordance with applicable regulations.',
+];
 
 export default function DialogScrollingContent() {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
-    <>
+    <XDSVStack gap={3}>
       <XDSButton
-        label="Open Scrolling Modal"
+        label="Review terms"
         variant="secondary"
         onClick={() => setIsOpen(true)}
       />
@@ -31,18 +43,13 @@ export default function DialogScrollingContent() {
           }
           content={
             <XDSLayoutContent>
-              <div
-                style={{display: 'flex', flexDirection: 'column', gap: 12}}>
-                {Array.from({length: 20}, (_, i) => (
+              <XDSVStack gap={3}>
+                {TERMS.map((term, i) => (
                   <XDSText type="body" key={i}>
-                    {i + 1}. Lorem ipsum dolor sit amet, consectetur adipiscing
-                    elit. Sed do eiusmod tempor incididunt ut labore et dolore
-                    magna aliqua. Ut enim ad minim veniam, quis nostrud
-                    exercitation ullamco laboris nisi ut aliquip ex ea commodo
-                    consequat.
+                    {i + 1}. {term}
                   </XDSText>
                 ))}
-              </div>
+              </XDSVStack>
             </XDSLayoutContent>
           }
           footer={
@@ -63,6 +70,6 @@ export default function DialogScrollingContent() {
           }
         />
       </XDSDialog>
-    </>
+    </XDSVStack>
   );
 }

--- a/packages/cli/templates/blocks/components/Dialog/DialogScrollingContent.tsx
+++ b/packages/cli/templates/blocks/components/Dialog/DialogScrollingContent.tsx
@@ -11,6 +11,7 @@ import {
 } from '@xds/core/Layout';
 import {XDSButton} from '@xds/core/Button';
 import {XDSText} from '@xds/core/Text';
+import {XDSCard} from '@xds/core/Card';
 
 const TERMS = [
   'You agree to use the service only for lawful purposes and in compliance with all applicable laws.',
@@ -27,12 +28,20 @@ export default function DialogScrollingContent() {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
-    <XDSVStack gap={3}>
-      <XDSButton
-        label="Review terms"
-        variant="secondary"
-        onClick={() => setIsOpen(true)}
-      />
+    <XDSCard>
+      <XDSVStack gap={3}>
+        <XDSVStack gap={1}>
+          <XDSText type="bodyBold">Terms and Conditions</XDSText>
+          <XDSText type="supporting" color="secondary">
+            Last updated March 2026 · 8 clauses
+          </XDSText>
+        </XDSVStack>
+        <XDSButton
+          label="Review terms"
+          variant="secondary"
+          onClick={() => setIsOpen(true)}
+        />
+      </XDSVStack>
       <XDSDialog isOpen={isOpen} onOpenChange={setIsOpen} maxHeight="50vh">
         <XDSLayout
           header={
@@ -70,6 +79,6 @@ export default function DialogScrollingContent() {
           }
         />
       </XDSDialog>
-    </XDSVStack>
+    </XDSCard>
   );
 }

--- a/packages/cli/templates/blocks/components/Dialog/DialogWithSubtitle.doc.mjs
+++ b/packages/cli/templates/blocks/components/Dialog/DialogWithSubtitle.doc.mjs
@@ -1,8 +1,9 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
-  name: 'Dialog — With Subtitle',
-  description: 'Modal dialog with a title and subtitle in the header.',
+  name: 'Dialog — Required',
+  description:
+    'Required-purpose dialog that cannot be dismissed by Escape or backdrop click. Use when the user must explicitly choose an action, like ownership transfers.',
   isReady: true,
   aspectRatio: 4 / 3,
   componentsUsed: ['Dialog', 'Layout', 'Button', 'Text'],

--- a/packages/cli/templates/blocks/components/Dialog/DialogWithSubtitle.doc.mjs
+++ b/packages/cli/templates/blocks/components/Dialog/DialogWithSubtitle.doc.mjs
@@ -5,6 +5,6 @@ export const doc = {
   description:
     'Required-purpose dialog that cannot be dismissed by Escape or backdrop click. Use when the user must explicitly choose an action, like ownership transfers.',
   isReady: true,
-  aspectRatio: 4 / 3,
+  aspectRatio: 16 / 9,
   componentsUsed: ['Dialog', 'Layout', 'Button', 'Text'],
 };

--- a/packages/cli/templates/blocks/components/Dialog/DialogWithSubtitle.doc.mjs
+++ b/packages/cli/templates/blocks/components/Dialog/DialogWithSubtitle.doc.mjs
@@ -3,7 +3,7 @@ export const doc = {
   type: 'block',
   name: 'Dialog — Required',
   description:
-    'Required-purpose dialog that cannot be dismissed by Escape or backdrop click. Use when the user must explicitly choose an action, like ownership transfers.',
+    'Cannot be dismissed by Escape or backdrop click — the user must explicitly choose an action. Uses purpose="required". Use for ownership transfers, legal acknowledgements, or critical decisions where skipping is not an option.',
   isReady: true,
   aspectRatio: 16 / 9,
   componentsUsed: ['Dialog', 'Layout', 'Button', 'Text', 'Card'],

--- a/packages/cli/templates/blocks/components/Dialog/DialogWithSubtitle.doc.mjs
+++ b/packages/cli/templates/blocks/components/Dialog/DialogWithSubtitle.doc.mjs
@@ -6,5 +6,5 @@ export const doc = {
     'Required-purpose dialog that cannot be dismissed by Escape or backdrop click. Use when the user must explicitly choose an action, like ownership transfers.',
   isReady: true,
   aspectRatio: 16 / 9,
-  componentsUsed: ['Dialog', 'Layout', 'Button', 'Text'],
+  componentsUsed: ['Dialog', 'Layout', 'Button', 'Text', 'Card'],
 };

--- a/packages/cli/templates/blocks/components/Dialog/DialogWithSubtitle.tsx
+++ b/packages/cli/templates/blocks/components/Dialog/DialogWithSubtitle.tsx
@@ -20,7 +20,7 @@ export default function DialogWithSubtitle() {
     <XDSCard>
       <XDSVStack gap={3}>
         <XDSVStack gap={1}>
-          <XDSText type="bodyBold">Project Ownership</XDSText>
+          <XDSText type="body" weight="bold">Project Ownership</XDSText>
           <XDSText type="supporting" color="secondary">
             Marketing Dashboard · Owner: You
           </XDSText>

--- a/packages/cli/templates/blocks/components/Dialog/DialogWithSubtitle.tsx
+++ b/packages/cli/templates/blocks/components/Dialog/DialogWithSubtitle.tsx
@@ -11,17 +11,26 @@ import {
 } from '@xds/core/Layout';
 import {XDSButton} from '@xds/core/Button';
 import {XDSText} from '@xds/core/Text';
+import {XDSCard} from '@xds/core/Card';
 
 export default function DialogWithSubtitle() {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
-    <XDSVStack gap={3}>
-      <XDSButton
-        label="Transfer ownership"
-        variant="secondary"
-        onClick={() => setIsOpen(true)}
-      />
+    <XDSCard>
+      <XDSVStack gap={3}>
+        <XDSVStack gap={1}>
+          <XDSText type="bodyBold">Project Ownership</XDSText>
+          <XDSText type="supporting" color="secondary">
+            Marketing Dashboard · Owner: You
+          </XDSText>
+        </XDSVStack>
+        <XDSButton
+          label="Transfer ownership"
+          variant="secondary"
+          onClick={() => setIsOpen(true)}
+        />
+      </XDSVStack>
       <XDSDialog isOpen={isOpen} onOpenChange={setIsOpen} purpose="required">
         <XDSLayout
           header={
@@ -63,6 +72,6 @@ export default function DialogWithSubtitle() {
           }
         />
       </XDSDialog>
-    </XDSVStack>
+    </XDSCard>
   );
 }

--- a/packages/cli/templates/blocks/components/Dialog/DialogWithSubtitle.tsx
+++ b/packages/cli/templates/blocks/components/Dialog/DialogWithSubtitle.tsx
@@ -41,17 +41,10 @@ export default function DialogWithSubtitle() {
           }
           content={
             <XDSLayoutContent>
-              <XDSVStack gap={2}>
-                <XDSText type="body">
-                  You are about to transfer &quot;Marketing Dashboard&quot; to
-                  Sarah Chen. Once accepted, you will lose admin access.
-                </XDSText>
-                <XDSText type="supporting" color="secondary">
-                  This dialog uses purpose=&quot;required&quot; — neither Escape
-                  nor the backdrop can dismiss it. The user must choose an
-                  action.
-                </XDSText>
-              </XDSVStack>
+              <XDSText type="body">
+                You are about to transfer &quot;Marketing Dashboard&quot; to
+                Sarah Chen. Once accepted, you will lose admin access.
+              </XDSText>
             </XDSLayoutContent>
           }
           footer={

--- a/packages/cli/templates/blocks/components/Dialog/DialogWithSubtitle.tsx
+++ b/packages/cli/templates/blocks/components/Dialog/DialogWithSubtitle.tsx
@@ -7,6 +7,7 @@ import {
   XDSLayoutContent,
   XDSLayoutFooter,
   XDSHStack,
+  XDSVStack,
 } from '@xds/core/Layout';
 import {XDSButton} from '@xds/core/Button';
 import {XDSText} from '@xds/core/Text';
@@ -15,27 +16,33 @@ export default function DialogWithSubtitle() {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
-    <>
+    <XDSVStack gap={3}>
       <XDSButton
-        label="Open Modal with Subtitle"
+        label="Transfer ownership"
         variant="secondary"
         onClick={() => setIsOpen(true)}
       />
-      <XDSDialog isOpen={isOpen} onOpenChange={setIsOpen}>
+      <XDSDialog isOpen={isOpen} onOpenChange={setIsOpen} purpose="required">
         <XDSLayout
           header={
             <XDSDialogHeader
-              title="Edit User Profile"
-              subtitle="Make changes to your account settings"
-              onOpenChange={setIsOpen}
+              title="Transfer project ownership"
+              subtitle="This action requires confirmation from the new owner"
             />
           }
           content={
             <XDSLayoutContent>
-              <XDSText type="body">
-                The subtitle appears below the title in smaller, secondary text.
-                It provides additional context about the dialog&apos;s purpose.
-              </XDSText>
+              <XDSVStack gap={2}>
+                <XDSText type="body">
+                  You are about to transfer &quot;Marketing Dashboard&quot; to
+                  Sarah Chen. Once accepted, you will lose admin access.
+                </XDSText>
+                <XDSText type="supporting" color="secondary">
+                  This dialog uses purpose=&quot;required&quot; — neither Escape
+                  nor the backdrop can dismiss it. The user must choose an
+                  action.
+                </XDSText>
+              </XDSVStack>
             </XDSLayoutContent>
           }
           footer={
@@ -47,7 +54,7 @@ export default function DialogWithSubtitle() {
                   onClick={() => setIsOpen(false)}
                 />
                 <XDSButton
-                  label="Save Changes"
+                  label="Transfer"
                   variant="primary"
                   onClick={() => setIsOpen(false)}
                 />
@@ -56,6 +63,6 @@ export default function DialogWithSubtitle() {
           }
         />
       </XDSDialog>
-    </>
+    </XDSVStack>
   );
 }

--- a/packages/core/src/Dialog/Dialog.doc.mjs
+++ b/packages/core/src/Dialog/Dialog.doc.mjs
@@ -115,19 +115,21 @@ export const docs = {
     },
   ],
   usage: {
-    description: 'A modal dialog that interrupts the user workflow to communicate important information or request a decision. Use for confirmations before destructive actions, multi-step workflows, or content that requires acknowledgement before proceeding.',
+    description: 'Dialog displays a modal overlay that blocks interaction with the page until the user responds. Use it for delete confirmations, edit forms, terms acceptance, or any decision that should not be skipped.',
     bestPractices: [
-      { guidance: true, description: 'Choose the right purpose (required, form, info) to match the importance of the content.' },
-      { guidance: true, description: 'Include a clear title in the header so users immediately understand the dialog context.' },
+      { guidance: true, description: 'Choose the right purpose: info for dismissable content, form to prevent accidental backdrop dismissal, required when the user must respond.' },
+      { guidance: true, description: 'Include a clear title in the header so users immediately understand what the dialog is asking.' },
+      { guidance: true, description: 'Use purpose="form" for dialogs with inputs so the user can\'t accidentally lose data by clicking the backdrop.' },
+      { guidance: true, description: 'Keep dialogs focused on a single task — if the content grows beyond what fits, consider a full page instead.' },
       { guidance: false, description: 'Use a dialog for simple messages that could be shown inline or as a toast notification.' },
       { guidance: false, description: 'Nest dialogs inside other dialogs — restructure the flow into steps within a single dialog instead.' },
+      { guidance: false, description: 'Use the fullscreen variant for simple confirmations — it is meant for complex content like editors or long forms.' },
     ],
     anatomy: [
-      {name: 'Body', required: true, description: 'The main content area of the dialog.'},
-      {name: 'Header', required: true, description: 'Contains the title, actions, and close button.'},
-      {name: 'Footer', required: true, description: 'Contains action buttons, links, and page count.'},
-      {name: 'Left Panel', required: false, description: 'Used for navigation or completion stages.'},
-      {name: 'Right Panel', required: false, description: 'Used for supplementary information.'},
+      {name: 'Header', required: true, description: 'Title, optional subtitle, and close button. The title receives focus on open for accessibility.'},
+      {name: 'Body', required: true, description: 'The main content area — text, forms, lists, or any layout.'},
+      {name: 'Footer', required: false, description: 'Action buttons like Save/Cancel or Accept/Decline, aligned to the end.'},
+      {name: 'Backdrop', required: true, description: 'Semi-transparent overlay behind the dialog that blocks page interaction.'},
     ],
   },
 };
@@ -248,40 +250,35 @@ export const docsZh = {
     },
   ],
   usage: {
-    description: 'A modal dialog that interrupts the user workflow to communicate important information or request a decision. Use for confirmations before destructive actions, multi-step workflows, or content that requires acknowledgement before proceeding.',
+    description: 'Dialog displays a modal overlay that blocks interaction with the page until the user responds. Use it for delete confirmations, edit forms, terms acceptance, or any decision that should not be skipped.',
     bestPractices: [
-      { guidance: true, description: 'Choose the right purpose (required, form, info) to match the importance of the content.' },
-      { guidance: true, description: 'Include a clear title in the header so users immediately understand the dialog context.' },
+      { guidance: true, description: 'Choose the right purpose: info for dismissable content, form to prevent accidental backdrop dismissal, required when the user must respond.' },
+      { guidance: true, description: 'Include a clear title in the header so users immediately understand what the dialog is asking.' },
+      { guidance: true, description: 'Use purpose="form" for dialogs with inputs so the user can\'t accidentally lose data by clicking the backdrop.' },
+      { guidance: true, description: 'Keep dialogs focused on a single task — if the content grows beyond what fits, consider a full page instead.' },
       { guidance: false, description: 'Use a dialog for simple messages that could be shown inline or as a toast notification.' },
       { guidance: false, description: 'Nest dialogs inside other dialogs — restructure the flow into steps within a single dialog instead.' },
+      { guidance: false, description: 'Use the fullscreen variant for simple confirmations — it is meant for complex content like editors or long forms.' },
     ],
     anatomy: [
-      {name: 'Body', required: true, description: 'The main content area of the dialog.'},
-      {name: 'Header', required: true, description: 'Contains the title, actions, and close button.'},
-      {name: 'Footer', required: true, description: 'Contains action buttons, links, and page count.'},
-      {name: 'Left Panel', required: false, description: 'Used for navigation or completion stages.'},
-      {name: 'Right Panel', required: false, description: 'Used for supplementary information.'},
+      {name: 'Header', required: true, description: 'Title, optional subtitle, and close button. The title receives focus on open for accessibility.'},
+      {name: 'Body', required: true, description: 'The main content area — text, forms, lists, or any layout.'},
+      {name: 'Footer', required: false, description: 'Action buttons like Save/Cancel or Accept/Decline, aligned to the end.'},
+      {name: 'Backdrop', required: true, description: 'Semi-transparent overlay behind the dialog that blocks page interaction.'},
     ],
   },
 };
 
 /** @type {import('../docs-types').TranslationDoc} */
 export const docsDense = {
-  description: 'modal dialog using native <dialog> w/ auto focus trapping, backdrop, purpose-based dismissal',
+  description: 'modal overlay that blocks page interaction until the user responds',
   usage: {
-    description: 'A modal dialog that interrupts the user workflow to communicate important information or request a decision. Use for confirmations before destructive actions, multi-step workflows, or content that requires acknowledgement before proceeding.',
+    description: 'Dialog displays a modal overlay that blocks page interaction. Use for delete confirmations, edit forms, terms acceptance.',
     bestPractices: [
-      { guidance: true, description: 'Choose the right purpose (required, form, info) to match the importance of the content.' },
-      { guidance: true, description: 'Include a clear title in the header so users immediately understand the dialog context.' },
-      { guidance: false, description: 'Use a dialog for simple messages that could be shown inline or as a toast notification.' },
-      { guidance: false, description: 'Nest dialogs inside other dialogs — restructure the flow into steps within a single dialog instead.' },
-    ],
-    anatomy: [
-      {name: 'Body', required: true, description: 'The main content area of the dialog.'},
-      {name: 'Header', required: true, description: 'Contains the title, actions, and close button.'},
-      {name: 'Footer', required: true, description: 'Contains action buttons, links, and page count.'},
-      {name: 'Left Panel', required: false, description: 'Used for navigation or completion stages.'},
-      {name: 'Right Panel', required: false, description: 'Used for supplementary information.'},
+      { guidance: true, description: 'Pick the right purpose: info=dismissable, form=no backdrop dismiss, required=must respond.' },
+      { guidance: true, description: 'Clear title in header. Use purpose="form" for dialogs with inputs.' },
+      { guidance: false, description: 'Use for simple messages — use inline or toast instead. Don\'t nest dialogs.' },
+      { guidance: false, description: 'Fullscreen for simple confirmations — it\'s for complex content like editors.' },
     ],
   },
   components: [


### PR DESCRIPTION
## Summary

- **Rewrite Dialog usage docs** in `Dialog.doc.mjs`: plain language description with concrete use cases (delete confirmations, edit forms, terms acceptance), expanded from 4 to 7 best practices (added form purpose, single task, and fullscreen guidance), simplified anatomy to 4 elements (Header, Body, Footer, Backdrop)
- **Replace raw HTML** — all `<div style={{...}}>` replaced with `XDSVStack`/`XDSHStack`
- **Replace lorem ipsum** — realistic content in all blocks (terms of service, documentation sections, project data)
- **Wrap triggers in Cards** — each block shows a contextual card with title, metadata, and trigger button instead of a lonely button
- **Add real form fields** — Form dialog uses `XDSTextInput` and `XDSTextArea` with prefilled data instead of placeholder text
- **Repurpose WithSubtitle** into Required purpose demo with ownership transfer scenario
- **Shorten block names**, add concrete when-to-use guidance with specific scenarios
- **Switch all blocks to 16/9 aspect ratio**

### Blocks

| Block | Description |
|-------|-------------|
| Dialog — Confirmation | Asks the user to confirm a destructive action. Use before deleting projects, removing team members, or revoking API keys. |
| Dialog — Form | Collects user input without navigating away. Uses purpose="form" so the backdrop won't close it. Use for editing profiles, creating items, or updating settings. |
| Dialog — Fullscreen | Takes over the entire viewport. Use for documentation viewers, rich text editors, multi-step wizards, or media previews. |
| Dialog — Scrollable | Constrains dialog height and scrolls the body. Use for terms and conditions, license agreements, changelogs, or long-form review content. |
| Dialog — Required | Cannot be dismissed by Escape or backdrop. Uses purpose="required". Use for ownership transfers, legal acknowledgements, or critical decisions. |

## Template grades

All blocks graded against the [wiki rubric](https://github.com/facebookexperimental/xds/wiki/Contributing-Templates#template-grading-rubric):

| Block | Score | Grade |
|-------|-------|-------|
| Dialog — Confirmation | 97 | A |
| Dialog — Form | 97 | A |
| Dialog — Fullscreen | 97 | A |
| Dialog — Scrollable | 97 | A |
| Dialog — Required | 97 | A |

All blocks score 97 because they use `16/9` instead of the wiki-recommended `4/3` (Content/form). All other criteria: 0 raw HTML, 0 SVG, 0 custom CSS, 0 lorem ipsum, 20+ lines, self-contained imports, realistic data.

## Test plan

- [ ] `xds component Dialog` shows all 5 block templates in "Related block templates"
- [ ] Block previews show contextual cards with trigger buttons at 16/9 aspect ratio
- [ ] Dialog docs page shows updated usage with 7 best practices and anatomy table
- [ ] Clicking buttons in each block opens the correct dialog type
- [ ] Form dialog contains actual TextInput and TextArea fields
- [ ] No raw HTML, inline styles, or lorem ipsum in any block