### PR TITLE
fix(Icon): default color to inherit so icons match parent context

### DIFF
--- a/packages/core/src/Icon/Icon.doc.mjs
+++ b/packages/core/src/Icon/Icon.doc.mjs
@@ -14,7 +14,7 @@ export const docs = {
       name: 'color',
       type: "'primary' | 'secondary' | 'tertiary' | 'disabled' | 'accent' | 'positive' | 'negative' | 'warning' | 'inherit'",
       description: 'Color variant mapped to XDS icon color tokens.',
-      default: "'primary'",
+      default: "'inherit'",
     },
     {
       name: 'size',
@@ -52,7 +52,7 @@ export const docsZh = {
       name: 'color',
       type: "'primary' | 'secondary' | 'tertiary' | 'disabled' | 'accent' | 'positive' | 'negative' | 'warning' | 'inherit'",
       description: '映射到 XDS 图标颜色令牌的颜色变体。',
-      default: "'primary'",
+      default: "'inherit'",
     },
     {
       name: 'size',

--- a/packages/core/src/Icon/XDSIcon.tsx
+++ b/packages/core/src/Icon/XDSIcon.tsx
@@ -185,7 +185,7 @@ export interface XDSIconProps extends Omit<
   icon: XDSIconType | XDSIconName;
   /**
    * The color variant of the icon.
-   * @default 'primary'
+   * @default 'inherit'
    */
   color?: XDSIconColor;
   /**
@@ -213,7 +213,7 @@ export interface XDSIconProps extends Omit<
  */
 export function XDSIcon({
   icon,
-  color = 'primary',
+  color = 'inherit',
   size = 'md',
   ref,
   ...props


### PR DESCRIPTION
## Problem

`XDSIcon` defaults `color` to `'primary'`, which maps to `--color-icon-primary`. When an icon is placed inside a component that sets its own CSS `color` (Button, Token, Badge, etc.), the icon ignores the parent's color and forces the primary icon color.

This means an icon inside a destructive button renders in the wrong color — it uses `--color-icon-primary` instead of inheriting `--color-on-error` from the button.

## Fix

Change the default from `'primary'` to `'inherit'`. Icons now inherit the parent's CSS `color` by default, which is the correct behavior when nested inside components.

For standalone usage, this is a no-op: `--color-icon-primary` and `--color-text-primary` resolve to the same value (`light-dark(#0A1317, #DFE2E5)`), so an icon inheriting from the page body looks the same.

Anyone who explicitly passes `color="primary"` (or any other value) is unaffected — the explicit prop still wins.

Closes #1585