### PR TITLE
Improve Selector docs page and block examples

### DIFF
--- a/packages/cli/templates/blocks/components/Selector/SelectorClearable.doc.mjs
+++ b/packages/cli/templates/blocks/components/Selector/SelectorClearable.doc.mjs
@@ -3,8 +3,8 @@ export const doc = {
   type: 'block',
   name: 'Selector — Clearable',
   description:
-    'Selector with a clear button to reset the selection back to empty.',
+    'Selector with a clear button to reset the selected value.',
   isReady: true,
   aspectRatio: 4 / 3,
-  componentsUsed: ['Selector'],
+  componentsUsed: ['Selector', 'Center'],
 };

--- a/packages/cli/templates/blocks/components/Selector/SelectorClearable.tsx
+++ b/packages/cli/templates/blocks/components/Selector/SelectorClearable.tsx
@@ -2,19 +2,25 @@
 
 import {useState} from 'react';
 import {XDSSelector} from '@xds/core/Selector';
+import {XDSCenter} from '@xds/core/Center';
 
 export default function SelectorClearable() {
-  const [value, setValue] = useState<string | null>('Banana');
+  const [value, setValue] = useState<string | null>('engineering');
   return (
-    <div style={{width: 250}}>
+    <XDSCenter width={250}>
       <XDSSelector
-        label="Fruit"
-        options={['Apple', 'Banana', 'Cherry', 'Date']}
+        label="Department"
+        options={[
+          {value: 'engineering', label: 'Engineering'},
+          {value: 'design', label: 'Design'},
+          {value: 'marketing', label: 'Marketing'},
+          {value: 'sales', label: 'Sales'},
+        ]}
         value={value}
         onChange={setValue}
-        placeholder="Select a fruit..."
+        placeholder="Choose a department..."
         hasClear
       />
-    </div>
+    </XDSCenter>
   );
 }

--- a/packages/cli/templates/blocks/components/Selector/SelectorWithSections.doc.mjs
+++ b/packages/cli/templates/blocks/components/Selector/SelectorWithSections.doc.mjs
@@ -3,8 +3,8 @@ export const doc = {
   type: 'block',
   name: 'Selector — Grouped Sections',
   description:
-    'Selector with options organized into labeled sections for categorized choices.',
+    'Selector with options grouped into labeled sections.',
   isReady: true,
   aspectRatio: 4 / 3,
-  componentsUsed: ['Selector'],
+  componentsUsed: ['Selector', 'Center'],
 };

--- a/packages/cli/templates/blocks/components/Selector/SelectorWithSections.tsx
+++ b/packages/cli/templates/blocks/components/Selector/SelectorWithSections.tsx
@@ -2,38 +2,45 @@
 
 import {useState} from 'react';
 import {XDSSelector} from '@xds/core/Selector';
+import {XDSCenter} from '@xds/core/Center';
 
 export default function SelectorWithSections() {
   const [value, setValue] = useState<string | undefined>();
   return (
-    <div style={{width: 250}}>
+    <XDSCenter width={250}>
       <XDSSelector
-        label="Fruit"
+        label="Office"
         options={[
-          {value: 'apple', label: 'Apple'},
-          {value: 'banana', label: 'Banana'},
           {
             type: 'section',
-            title: 'Citrus',
+            title: 'North America',
             options: [
-              {value: 'orange', label: 'Orange'},
-              {value: 'lemon', label: 'Lemon'},
-              {value: 'lime', label: 'Lime'},
+              {value: 'nyc', label: 'New York'},
+              {value: 'sf', label: 'San Francisco'},
+              {value: 'sea', label: 'Seattle'},
             ],
           },
           {
             type: 'section',
-            title: 'Tropical',
+            title: 'Europe',
             options: [
-              {value: 'mango', label: 'Mango'},
-              {value: 'pineapple', label: 'Pineapple'},
+              {value: 'ldn', label: 'London'},
+              {value: 'ber', label: 'Berlin'},
+            ],
+          },
+          {
+            type: 'section',
+            title: 'Asia Pacific',
+            options: [
+              {value: 'tyo', label: 'Tokyo'},
+              {value: 'sgp', label: 'Singapore'},
             ],
           },
         ]}
         value={value}
         onChange={setValue}
-        placeholder="Select a fruit..."
+        placeholder="Choose an office..."
       />
-    </div>
+    </XDSCenter>
   );
 }

--- a/packages/cli/templates/blocks/components/Selector/SelectorWithStatus.doc.mjs
+++ b/packages/cli/templates/blocks/components/Selector/SelectorWithStatus.doc.mjs
@@ -3,8 +3,8 @@ export const doc = {
   type: 'block',
   name: 'Selector — Validation States',
   description:
-    'Selector fields showing error, warning, and success validation states with messages.',
+    'Selector showing error, warning, and success validation states.',
   isReady: true,
   aspectRatio: 4 / 3,
-  componentsUsed: ['Selector'],
+  componentsUsed: ['Selector', 'Center', 'VStack'],
 };

--- a/packages/cli/templates/blocks/components/Selector/SelectorWithStatus.tsx
+++ b/packages/cli/templates/blocks/components/Selector/SelectorWithStatus.tsx
@@ -2,45 +2,51 @@
 
 import {useState} from 'react';
 import {XDSSelector} from '@xds/core/Selector';
+import {XDSVStack} from '@xds/core/Layout';
+import {XDSCenter} from '@xds/core/Center';
 
 export default function SelectorWithStatus() {
   const [value1, setValue1] = useState<string | undefined>();
-  const [value2, setValue2] = useState<string | undefined>('banana');
-  const [value3, setValue3] = useState<string | undefined>('apple');
+  const [value2, setValue2] = useState<string | undefined>('viewer');
+  const [value3, setValue3] = useState<string | undefined>('admin');
   return (
-    <div
-      style={{display: 'flex', flexDirection: 'column', gap: 16, width: 250}}>
-      <XDSSelector
-        label="Error status"
-        options={[
-          {value: 'apple', label: 'Apple'},
-          {value: 'banana', label: 'Banana'},
-        ]}
-        value={value1}
-        onChange={setValue1}
-        placeholder="Select a fruit..."
-        status={{type: 'error', message: 'Please select a fruit'}}
-      />
-      <XDSSelector
-        label="Warning status"
-        options={[
-          {value: 'apple', label: 'Apple'},
-          {value: 'banana', label: 'Banana'},
-        ]}
-        value={value2}
-        onChange={setValue2}
-        status={{type: 'warning', message: 'Banana is out of season'}}
-      />
-      <XDSSelector
-        label="Success status"
-        options={[
-          {value: 'apple', label: 'Apple'},
-          {value: 'banana', label: 'Banana'},
-        ]}
-        value={value3}
-        onChange={setValue3}
-        status={{type: 'success'}}
-      />
-    </div>
+    <XDSCenter width={250}>
+      <XDSVStack gap={4}>
+        <XDSSelector
+          label="Role"
+          options={[
+            {value: 'admin', label: 'Admin'},
+            {value: 'editor', label: 'Editor'},
+            {value: 'viewer', label: 'Viewer'},
+          ]}
+          value={value1}
+          onChange={setValue1}
+          placeholder="Choose a role..."
+          status={{type: 'error', message: 'Please select a role'}}
+        />
+        <XDSSelector
+          label="Role"
+          options={[
+            {value: 'admin', label: 'Admin'},
+            {value: 'editor', label: 'Editor'},
+            {value: 'viewer', label: 'Viewer'},
+          ]}
+          value={value2}
+          onChange={setValue2}
+          status={{type: 'warning', message: 'Viewer has limited access'}}
+        />
+        <XDSSelector
+          label="Role"
+          options={[
+            {value: 'admin', label: 'Admin'},
+            {value: 'editor', label: 'Editor'},
+            {value: 'viewer', label: 'Viewer'},
+          ]}
+          value={value3}
+          onChange={setValue3}
+          status={{type: 'success'}}
+        />
+      </XDSVStack>
+    </XDSCenter>
   );
 }

--- a/packages/core/src/Selector/Selector.doc.mjs
+++ b/packages/core/src/Selector/Selector.doc.mjs
@@ -125,12 +125,16 @@ export const docs = {
   ],
   usage: {
     description:
-      'A dropdown selector for choosing a single option from a list. Use Selector in forms or settings when presenting 3–20 options. For triggering actions instead of selecting values, use a Dropdown Menu.',
+      'A dropdown selector for choosing a single value from a list of options. Supports labels, validation, descriptions, and required/optional states. Use it in forms and settings when presenting a moderate number of options.',
     bestPractices: [
       {guidance: true, description: 'Provide a visible label so users understand what they are selecting.'},
-      {guidance: true, description: 'Use sections and dividers to organize long lists of related options.'},
+      {guidance: true, description: 'Use sections and dividers to organize options when the list exceeds ~8 items.'},
+      {guidance: true, description: 'Set a meaningful placeholder that hints at the expected selection (e.g. "Choose a country" not "Select...").'},
       {guidance: false, description: 'Use for action menus — use Dropdown Menu for triggering commands or navigation.'},
       {guidance: false, description: 'Use when there are only two options — use a SegmentedControl or radio buttons instead.'},
+      {guidance: false, description: 'Use Selector for navigation — links should be links, not dropdown options.'},
+      {guidance: false, description: 'Use for yes/no or on/off choices — use Switch or CheckboxInput instead.'},
+      {guidance: false, description: 'Put more than ~20 options without sections — consider Typeahead for large lists.'},
     ],
     anatomy: [
       {name: 'Label', required: false, description: 'Text label displayed above the selector.'},
@@ -267,12 +271,16 @@ export const docsZh = {
   ],
   usage: {
     description:
-      'A dropdown selector for choosing a single option from a list. Use Selector in forms or settings when presenting 3–20 options. For triggering actions instead of selecting values, use a Dropdown Menu.',
+      'A dropdown selector for choosing a single value from a list of options. Supports labels, validation, descriptions, and required/optional states. Use it in forms and settings when presenting a moderate number of options.',
     bestPractices: [
       {guidance: true, description: 'Provide a visible label so users understand what they are selecting.'},
-      {guidance: true, description: 'Use sections and dividers to organize long lists of related options.'},
+      {guidance: true, description: 'Use sections and dividers to organize options when the list exceeds ~8 items.'},
+      {guidance: true, description: 'Set a meaningful placeholder that hints at the expected selection (e.g. "Choose a country" not "Select...").'},
       {guidance: false, description: 'Use for action menus — use Dropdown Menu for triggering commands or navigation.'},
       {guidance: false, description: 'Use when there are only two options — use a SegmentedControl or radio buttons instead.'},
+      {guidance: false, description: 'Use Selector for navigation — links should be links, not dropdown options.'},
+      {guidance: false, description: 'Use for yes/no or on/off choices — use Switch or CheckboxInput instead.'},
+      {guidance: false, description: 'Put more than ~20 options without sections — consider Typeahead for large lists.'},
     ],
     anatomy: [
       {name: 'Label', required: false, description: 'Text label displayed above the selector.'},
@@ -289,12 +297,16 @@ export const docsZh = {
 export const docsDense = {
   usage: {
     description:
-      'A dropdown selector for choosing a single option from a list. Use Selector in forms or settings when presenting 3–20 options. For triggering actions instead of selecting values, use a Dropdown Menu.',
+      'A dropdown selector for choosing a single value from a list of options. Supports labels, validation, descriptions, and required/optional states. Use it in forms and settings when presenting a moderate number of options.',
     bestPractices: [
       {guidance: true, description: 'Provide a visible label so users understand what they are selecting.'},
-      {guidance: true, description: 'Use sections and dividers to organize long lists of related options.'},
+      {guidance: true, description: 'Use sections and dividers to organize options when the list exceeds ~8 items.'},
+      {guidance: true, description: 'Set a meaningful placeholder that hints at the expected selection (e.g. "Choose a country" not "Select...").'},
       {guidance: false, description: 'Use for action menus — use Dropdown Menu for triggering commands or navigation.'},
       {guidance: false, description: 'Use when there are only two options — use a SegmentedControl or radio buttons instead.'},
+      {guidance: false, description: 'Use Selector for navigation — links should be links, not dropdown options.'},
+      {guidance: false, description: 'Use for yes/no or on/off choices — use Switch or CheckboxInput instead.'},
+      {guidance: false, description: 'Put more than ~20 options without sections — consider Typeahead for large lists.'},
     ],
     anatomy: [
       {name: 'Label', required: false, description: 'Text label displayed above the selector.'},


### PR DESCRIPTION
## Summary
- Rewrite usage description to highlight form integration and drop overly specific option-count guidance
- Expand best practices with 4 new entries: placeholder guidance, navigation warning, Switch/CheckboxInput alternative, Typeahead suggestion for large lists
- Rewrite all 3 block examples to use realistic mock data (departments, offices, roles) instead of generic fruits
- Replace raw HTML `<div>` wrappers with `XDSCenter` and `XDSVStack` to score A on the template rubric
- Tighten block descriptions
- Update `componentsUsed` in doc metadata

## Test plan
- [ ] Verify `npx xds component Selector` output reflects updated usage and best practices
- [ ] Verify all 3 Selector blocks render correctly in the sandbox
- [ ] Check block previews display properly with `XDSCenter` width constraint