### PR TITLE
feat(sandbox): theme editor entry points and docsite double-loading fix

### DIFF
--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/AIComposer.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/AIComposer.tsx
@@ -2,16 +2,19 @@
 
 import React, {useState} from 'react';
 import {XDSChatComposer, XDSChatComposerInput} from '@xds/core/Chat';
-import {
-  XDSSegmentedControl,
-  XDSSegmentedControlItem,
-} from '@xds/core/SegmentedControl';
+import {XDSDropdownMenu} from '@xds/core/DropdownMenu';
+import {GridIcon, PaletteIcon} from './docsite-icons';
 
 export type ComposerMode = 'template' | 'theme';
 
 const PLACEHOLDER: Record<ComposerMode, string> = {
   template: 'What should we build?',
   theme: 'Describe your brand or style...',
+};
+
+const MODE_ICON: Record<ComposerMode, React.ReactNode> = {
+  template: <GridIcon width={16} height={16} />,
+  theme: <PaletteIcon width={16} height={16} />,
 };
 
 export function AIComposer({
@@ -63,13 +66,28 @@ export function AIComposer({
           onChange={setPrompt}
           placeholder={PLACEHOLDER[mode]}
           footerActions={
-            <XDSSegmentedControl
-              value={mode}
-              onChange={v => onModeChange(v as ComposerMode)}
-              size="sm">
-              <XDSSegmentedControlItem value="template" label="Template" />
-              <XDSSegmentedControlItem value="theme" label="Theme" />
-            </XDSSegmentedControl>
+            <XDSDropdownMenu
+              button={{
+                label: mode === 'template' ? 'Template' : 'Theme',
+                icon: MODE_ICON[mode],
+                variant: 'ghost',
+                size: 'sm',
+                isIconOnly: true,
+              }}
+              hasChevron={false}
+              items={[
+                {
+                  label: 'Template',
+                  icon: <GridIcon width={16} height={16} />,
+                  onClick: () => onModeChange('template'),
+                },
+                {
+                  label: 'Theme',
+                  icon: <PaletteIcon width={16} height={16} />,
+                  onClick: () => onModeChange('theme'),
+                },
+              ]}
+            />
           }
           input={<XDSChatComposerInput placeholder={PLACEHOLDER[mode]} />}
         />

--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/AIComposer.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/AIComposer.tsx
@@ -7,16 +7,23 @@ import {
   XDSSegmentedControlItem,
 } from '@xds/core/SegmentedControl';
 
-type ComposerMode = 'template' | 'theme';
+export type ComposerMode = 'template' | 'theme';
 
 const PLACEHOLDER: Record<ComposerMode, string> = {
   template: 'What should we build?',
   theme: 'Describe your brand or style...',
 };
 
-export function AIComposer({onThemeMode}: {onThemeMode?: () => void}) {
+export function AIComposer({
+  mode,
+  onModeChange,
+  onThemeMode,
+}: {
+  mode: ComposerMode;
+  onModeChange: (mode: ComposerMode) => void;
+  onThemeMode?: () => void;
+}) {
   const [prompt, setPrompt] = useState('');
-  const [mode, setMode] = useState<ComposerMode>('template');
 
   const handleSubmit = () => {
     if (mode === 'theme' && onThemeMode) {
@@ -58,7 +65,7 @@ export function AIComposer({onThemeMode}: {onThemeMode?: () => void}) {
           headerActions={
             <XDSSegmentedControl
               value={mode}
-              onChange={v => setMode(v as ComposerMode)}
+              onChange={v => onModeChange(v as ComposerMode)}
               size="sm">
               <XDSSegmentedControlItem value="template" label="Template" />
               <XDSSegmentedControlItem value="theme" label="Theme" />

--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/AIComposer.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/AIComposer.tsx
@@ -2,9 +2,28 @@
 
 import React, {useState} from 'react';
 import {XDSChatComposer, XDSChatComposerInput} from '@xds/core/Chat';
+import {
+  XDSSegmentedControl,
+  XDSSegmentedControlItem,
+} from '@xds/core/SegmentedControl';
 
-export function AIComposer() {
+type ComposerMode = 'template' | 'theme';
+
+const PLACEHOLDER: Record<ComposerMode, string> = {
+  template: 'What should we build?',
+  theme: 'Describe your brand or style...',
+};
+
+export function AIComposer({onThemeMode}: {onThemeMode?: () => void}) {
   const [prompt, setPrompt] = useState('');
+  const [mode, setMode] = useState<ComposerMode>('template');
+
+  const handleSubmit = () => {
+    if (mode === 'theme' && onThemeMode) {
+      onThemeMode();
+    }
+    setPrompt('');
+  };
 
   return (
     <>
@@ -32,11 +51,20 @@ export function AIComposer() {
           zIndex: 100,
         }}>
         <XDSChatComposer
-          onSubmit={() => setPrompt('')}
+          onSubmit={handleSubmit}
           value={prompt}
           onChange={setPrompt}
-          placeholder="What should we build?"
-          input={<XDSChatComposerInput placeholder="What should we build?" />}
+          placeholder={PLACEHOLDER[mode]}
+          headerActions={
+            <XDSSegmentedControl
+              value={mode}
+              onChange={v => setMode(v as ComposerMode)}
+              size="sm">
+              <XDSSegmentedControlItem value="template" label="Template" />
+              <XDSSegmentedControlItem value="theme" label="Theme" />
+            </XDSSegmentedControl>
+          }
+          input={<XDSChatComposerInput placeholder={PLACEHOLDER[mode]} />}
         />
       </div>
     </>

--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/AIComposer.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/AIComposer.tsx
@@ -54,41 +54,49 @@ export function AIComposer({
         style={{
           position: 'fixed',
           bottom: 24,
-          left: '50%',
-          transform: 'translateX(-50%)',
-          width: 680,
-          maxWidth: 'calc(100% - 48px)',
+          left: 0,
+          right: 0,
+          display: 'flex',
+          justifyContent: 'center',
+          pointerEvents: 'none',
           zIndex: 100,
         }}>
-        <XDSChatComposer
-          onSubmit={handleSubmit}
-          value={prompt}
-          onChange={setPrompt}
-          placeholder={PLACEHOLDER[mode]}
-          footerActions={
-            <XDSDropdownMenu
-              button={{
-                label: mode === 'template' ? 'Template' : 'Theme',
-                icon: MODE_ICON[mode],
-                variant: 'ghost',
-                size: 'sm',
-              }}
-              items={[
-                {
-                  label: 'Template',
-                  icon: GridIcon,
-                  onClick: () => onModeChange('template'),
-                },
-                {
-                  label: 'Theme',
-                  icon: PaletteIcon,
-                  onClick: () => onModeChange('theme'),
-                },
-              ]}
-            />
-          }
-          input={<XDSChatComposerInput placeholder={PLACEHOLDER[mode]} />}
-        />
+        <div
+          style={{
+            width: 680,
+            maxWidth: 'calc(100% - 48px)',
+            pointerEvents: 'auto',
+          }}>
+          <XDSChatComposer
+            onSubmit={handleSubmit}
+            value={prompt}
+            onChange={setPrompt}
+            placeholder={PLACEHOLDER[mode]}
+            footerActions={
+              <XDSDropdownMenu
+                button={{
+                  label: mode === 'template' ? 'Template' : 'Theme',
+                  icon: MODE_ICON[mode],
+                  variant: 'ghost',
+                  size: 'sm',
+                }}
+                items={[
+                  {
+                    label: 'Template',
+                    icon: GridIcon,
+                    onClick: () => onModeChange('template'),
+                  },
+                  {
+                    label: 'Theme',
+                    icon: PaletteIcon,
+                    onClick: () => onModeChange('theme'),
+                  },
+                ]}
+              />
+            }
+            input={<XDSChatComposerInput placeholder={PLACEHOLDER[mode]} />}
+          />
+        </div>
       </div>
     </>
   );

--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/AIComposer.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/AIComposer.tsx
@@ -78,12 +78,12 @@ export function AIComposer({
               items={[
                 {
                   label: 'Template',
-                  icon: <GridIcon width={16} height={16} />,
+                  icon: GridIcon,
                   onClick: () => onModeChange('template'),
                 },
                 {
                   label: 'Theme',
-                  icon: <PaletteIcon width={16} height={16} />,
+                  icon: PaletteIcon,
                   onClick: () => onModeChange('theme'),
                 },
               ]}

--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/AIComposer.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/AIComposer.tsx
@@ -62,7 +62,7 @@ export function AIComposer({
           value={prompt}
           onChange={setPrompt}
           placeholder={PLACEHOLDER[mode]}
-          headerActions={
+          footerActions={
             <XDSSegmentedControl
               value={mode}
               onChange={v => onModeChange(v as ComposerMode)}

--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/AIComposer.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/AIComposer.tsx
@@ -2,7 +2,7 @@
 
 import React, {useState} from 'react';
 import {XDSChatComposer, XDSChatComposerInput} from '@xds/core/Chat';
-import {XDSDropdownMenu} from '@xds/core/DropdownMenu';
+import {XDSButton} from '@xds/core/Button';
 import {GridIcon, PaletteIcon} from './docsite-icons';
 
 export type ComposerMode = 'template' | 'theme';
@@ -19,11 +19,9 @@ const MODE_ICON: Record<ComposerMode, React.ReactNode> = {
 
 export function AIComposer({
   mode,
-  onModeChange,
   onThemeMode,
 }: {
   mode: ComposerMode;
-  onModeChange: (mode: ComposerMode) => void;
   onThemeMode?: () => void;
 }) {
   const [prompt, setPrompt] = useState('');
@@ -73,25 +71,12 @@ export function AIComposer({
             onChange={setPrompt}
             placeholder={PLACEHOLDER[mode]}
             footerActions={
-              <XDSDropdownMenu
-                button={{
-                  label: mode === 'template' ? 'Template' : 'Theme',
-                  icon: MODE_ICON[mode],
-                  variant: 'ghost',
-                  size: 'sm',
-                }}
-                items={[
-                  {
-                    label: 'Template',
-                    icon: GridIcon,
-                    onClick: () => onModeChange('template'),
-                  },
-                  {
-                    label: 'Theme',
-                    icon: PaletteIcon,
-                    onClick: () => onModeChange('theme'),
-                  },
-                ]}
+              <XDSButton
+                label={mode === 'template' ? 'Template' : 'Theme'}
+                icon={MODE_ICON[mode]}
+                variant="ghost"
+                size="sm"
+                isDisabled
               />
             }
             input={<XDSChatComposerInput placeholder={PLACEHOLDER[mode]} />}

--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/AIComposer.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/AIComposer.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import React, {useState} from 'react';
+import React, {useState, useEffect} from 'react';
 import {XDSChatComposer, XDSChatComposerInput} from '@xds/core/Chat';
-import {XDSButton} from '@xds/core/Button';
+import {XDSDropdownMenu} from '@xds/core/DropdownMenu';
 import {GridIcon, PaletteIcon} from './docsite-icons';
 
 export type ComposerMode = 'template' | 'theme';
@@ -18,13 +18,18 @@ const MODE_ICON: Record<ComposerMode, React.ReactNode> = {
 };
 
 export function AIComposer({
-  mode,
+  tabMode,
   onThemeMode,
 }: {
-  mode: ComposerMode;
+  tabMode: ComposerMode;
   onThemeMode?: () => void;
 }) {
   const [prompt, setPrompt] = useState('');
+  const [mode, setMode] = useState<ComposerMode>(tabMode);
+
+  useEffect(() => {
+    setMode(tabMode);
+  }, [tabMode]);
 
   const handleSubmit = () => {
     if (mode === 'theme' && onThemeMode) {
@@ -71,12 +76,25 @@ export function AIComposer({
             onChange={setPrompt}
             placeholder={PLACEHOLDER[mode]}
             footerActions={
-              <XDSButton
-                label={mode === 'template' ? 'Template' : 'Theme'}
-                icon={MODE_ICON[mode]}
-                variant="ghost"
-                size="sm"
-                isDisabled
+              <XDSDropdownMenu
+                button={{
+                  label: mode === 'template' ? 'Template' : 'Theme',
+                  icon: MODE_ICON[mode],
+                  variant: 'ghost',
+                  size: 'sm',
+                }}
+                items={[
+                  {
+                    label: 'Template',
+                    icon: GridIcon,
+                    onClick: () => setMode('template'),
+                  },
+                  {
+                    label: 'Theme',
+                    icon: PaletteIcon,
+                    onClick: () => setMode('theme'),
+                  },
+                ]}
               />
             }
             input={<XDSChatComposerInput placeholder={PLACEHOLDER[mode]} />}

--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/AIComposer.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/AIComposer.tsx
@@ -72,9 +72,7 @@ export function AIComposer({
                 icon: MODE_ICON[mode],
                 variant: 'ghost',
                 size: 'sm',
-                isIconOnly: true,
               }}
-              hasChevron={false}
               items={[
                 {
                   label: 'Template',

--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/AppTopNav.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/AppTopNav.tsx
@@ -8,7 +8,7 @@ import {XDSStack} from '@xds/core/Layout';
 import {XDSList, XDSListItem} from '@xds/core/List';
 import {XDSDropdownMenu} from '@xds/core/DropdownMenu';
 import {XDSCommandPalette} from '@xds/core/CommandPalette';
-import {XDSText} from '@xds/core/Text';
+
 import {SearchIcon, ProfileIcon, FilterIcon} from './docsite-icons';
 import {SEARCH_COMMANDS} from './constants';
 
@@ -92,11 +92,6 @@ export function AppTopNav({
       <XDSListItem
         label="Theme Editor"
         onClick={() => setActiveView('theme')}
-        endContent={
-          <XDSText type="label" color="secondary" size="sm">
-            Temporary
-          </XDSText>
-        }
       />
     </XDSList>
   );

--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/AppTopNav.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/AppTopNav.tsx
@@ -89,10 +89,6 @@ export function AppTopNav({
     <XDSList density="spacious" style={{minWidth: 240}}>
       <XDSListItem label="Craft" onClick={() => setActiveView('craft')} />
       <XDSListItem label="Library" onClick={() => setActiveView('docs')} />
-      <XDSListItem
-        label="Theme Editor"
-        onClick={() => setActiveView('theme')}
-      />
     </XDSList>
   );
 

--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/constants.ts
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/constants.ts
@@ -185,22 +185,120 @@ export const TEMPLATES: {
   author: string;
   isOfficial: boolean;
 }[] = [
-  {name: 'Contact Form', src: FIRST_CARD_IMAGE, size: 'large', author: 'Andrea Anderson', isOfficial: true},
-  {name: 'Shopping Details', src: SHOPPING_DETAILS_IMAGE, size: 'small', author: 'Andrea Anderson', isOfficial: true},
-  {name: 'Button Component', src: SCREENSHOT_3_IMAGE, size: 'small', author: 'XDS Design', isOfficial: true},
-  {name: 'Settings Page', src: `${basePath}/templates/card4-preview.png`, size: 'small', author: 'XDS Design', isOfficial: true},
-  {name: 'Login (SSO)', src: DUMMY_IMAGE, slug: 'login-sso', size: 'large', author: 'XDS Design', isOfficial: true},
-  {name: 'Login (Split)', src: DUMMY_IMAGE, slug: 'login-split', size: 'large', author: 'XDS Design', isOfficial: true},
-  {name: 'Dashboard', src: DUMMY_IMAGE, size: 'large', author: 'Marcus Chen', isOfficial: false},
-  {name: 'Data Table', src: DUMMY_IMAGE, size: 'small', author: 'XDS Design', isOfficial: true},
-  {name: 'File Explorer', src: DUMMY_IMAGE, size: 'small', author: 'Sarah Kim', isOfficial: false},
-  {name: 'Contact Form', src: DUMMY_IMAGE, size: 'small', author: 'Sarah Kim', isOfficial: false},
-  {name: 'Editor', src: DUMMY_IMAGE, size: 'xlarge', author: 'Andrea Anderson', isOfficial: true},
-  {name: 'Analytics', src: DUMMY_IMAGE, size: 'large', author: 'Marcus Chen', isOfficial: false},
-  {name: 'User Profile', src: DUMMY_IMAGE, size: 'small', author: 'Sarah Kim', isOfficial: false},
-  {name: 'Notifications', src: DUMMY_IMAGE, size: 'small', author: 'XDS Design', isOfficial: true},
-  {name: 'Calendar', src: DUMMY_IMAGE, size: 'small', author: 'Andrea Anderson', isOfficial: false},
-  {name: 'Onboarding', src: DUMMY_IMAGE, size: 'xlarge', author: 'XDS Design', isOfficial: true},
+  {
+    name: 'Contact Form',
+    src: FIRST_CARD_IMAGE,
+    size: 'large',
+    author: 'Andrea Anderson',
+    isOfficial: true,
+  },
+  {
+    name: 'Shopping Details',
+    src: SHOPPING_DETAILS_IMAGE,
+    size: 'small',
+    author: 'Andrea Anderson',
+    isOfficial: true,
+  },
+  {
+    name: 'Button Component',
+    src: SCREENSHOT_3_IMAGE,
+    size: 'small',
+    author: 'XDS Design',
+    isOfficial: true,
+  },
+  {
+    name: 'Settings Page',
+    src: `${basePath}/templates/card4-preview.png`,
+    size: 'small',
+    author: 'XDS Design',
+    isOfficial: true,
+  },
+  {
+    name: 'Login (SSO)',
+    src: DUMMY_IMAGE,
+    slug: 'login-sso',
+    size: 'large',
+    author: 'XDS Design',
+    isOfficial: true,
+  },
+  {
+    name: 'Login (Split)',
+    src: DUMMY_IMAGE,
+    slug: 'login-split',
+    size: 'large',
+    author: 'XDS Design',
+    isOfficial: true,
+  },
+  {
+    name: 'Dashboard',
+    src: DUMMY_IMAGE,
+    size: 'large',
+    author: 'Marcus Chen',
+    isOfficial: false,
+  },
+  {
+    name: 'Data Table',
+    src: DUMMY_IMAGE,
+    size: 'small',
+    author: 'XDS Design',
+    isOfficial: true,
+  },
+  {
+    name: 'File Explorer',
+    src: DUMMY_IMAGE,
+    size: 'small',
+    author: 'Sarah Kim',
+    isOfficial: false,
+  },
+  {
+    name: 'Contact Form',
+    src: DUMMY_IMAGE,
+    size: 'small',
+    author: 'Sarah Kim',
+    isOfficial: false,
+  },
+  {
+    name: 'Editor',
+    src: DUMMY_IMAGE,
+    size: 'xlarge',
+    author: 'Andrea Anderson',
+    isOfficial: true,
+  },
+  {
+    name: 'Analytics',
+    src: DUMMY_IMAGE,
+    size: 'large',
+    author: 'Marcus Chen',
+    isOfficial: false,
+  },
+  {
+    name: 'User Profile',
+    src: DUMMY_IMAGE,
+    size: 'small',
+    author: 'Sarah Kim',
+    isOfficial: false,
+  },
+  {
+    name: 'Notifications',
+    src: DUMMY_IMAGE,
+    size: 'small',
+    author: 'XDS Design',
+    isOfficial: true,
+  },
+  {
+    name: 'Calendar',
+    src: DUMMY_IMAGE,
+    size: 'small',
+    author: 'Andrea Anderson',
+    isOfficial: false,
+  },
+  {
+    name: 'Onboarding',
+    src: DUMMY_IMAGE,
+    size: 'xlarge',
+    author: 'XDS Design',
+    isOfficial: true,
+  },
 ];
 
 // ---------------------------------------------------------------------------
@@ -214,11 +312,23 @@ export const FILTER_COLUMNS: {heading: string; items: string[]}[] = [
   },
   {
     heading: 'Templates',
-    items: ['My Account & Profile', 'Charts', 'Login', 'Filter & Sort', 'Signup'],
+    items: [
+      'My Account & Profile',
+      'Charts',
+      'Login',
+      'Filter & Sort',
+      'Signup',
+    ],
   },
   {
     heading: 'Components',
-    items: ['Dropdown Menu', 'Side Navigation', 'Stepper', 'Text Field', 'Navigation Menu'],
+    items: [
+      'Dropdown Menu',
+      'Side Navigation',
+      'Stepper',
+      'Text Field',
+      'Navigation Menu',
+    ],
   },
 ];
 
@@ -234,18 +344,110 @@ export const PROFILE_USED_ITEMS: {
   usageCount: number;
   img: string;
 }[] = [
-  {name: 'Admin Dashboard', type: 'Template', description: 'Full admin panel with sidebar nav, KPI cards, and data tables.', lastUsed: '2026-04-15T09:00:00Z', usageCount: 7, img: SCREENSHOT_3_IMAGE},
-  {name: 'AppShell', type: 'Component', description: 'Foundational page layout with header, sidebar, and content regions.', lastUsed: '2026-04-14T10:30:00Z', usageCount: 12, img: FIRST_CARD_IMAGE},
-  {name: 'Meta Theme', type: 'Theme', description: 'Meta brand colors with Figtree typography and blue accents.', lastUsed: '2026-04-14T08:00:00Z', usageCount: 9, img: SHOPPING_DETAILS_IMAGE},
-  {name: 'Button', type: 'Component', description: 'Primary action element for forms, dialogs, and toolbars.', lastUsed: '2026-04-14T16:00:00Z', usageCount: 24, img: FIRST_CARD_IMAGE},
-  {name: 'Contact Form', type: 'Template', description: 'Responsive contact form with validation, file upload, and success state.', lastUsed: '2026-04-13T11:00:00Z', usageCount: 4, img: `${basePath}/templates/card4-preview.png`},
-  {name: 'Badge', type: 'Component', description: 'Displays small counts or status labels on icons, buttons, or list items.', lastUsed: '2026-04-12T09:20:00Z', usageCount: 15, img: SCREENSHOT_3_IMAGE},
-  {name: 'Dark Mode Palette', type: 'Theme', description: 'High-contrast dark theme with WCAG AA compliant color ratios.', lastUsed: '2026-04-11T18:30:00Z', usageCount: 3, img: DUMMY_IMAGE},
-  {name: 'Avatar', type: 'Component', description: 'Represents a person or entity with an image, initials, or icon.', lastUsed: '2026-04-13T15:45:00Z', usageCount: 8, img: SHOPPING_DETAILS_IMAGE},
-  {name: 'Settings Page', type: 'Template', description: 'Sidebar settings layout with inline editing and expandable rows.', lastUsed: '2026-04-10T14:00:00Z', usageCount: 5, img: `${basePath}/templates/card4-preview.png`},
-  {name: 'Dialog', type: 'Component', description: 'Modal overlays that require user attention or action.', lastUsed: '2026-04-11T13:15:00Z', usageCount: 6, img: DUMMY_IMAGE},
-  {name: 'WhatsApp Theme', type: 'Theme', description: 'WhatsApp brand greens and warm grays with rounded components.', lastUsed: '2026-04-09T10:00:00Z', usageCount: 2, img: DUMMY_IMAGE},
-  {name: 'DropdownMenu', type: 'Component', description: 'Presents actions or options in a floating overlay.', lastUsed: '2026-04-09T16:45:00Z', usageCount: 5, img: DUMMY_IMAGE},
+  {
+    name: 'Admin Dashboard',
+    type: 'Template',
+    description:
+      'Full admin panel with sidebar nav, KPI cards, and data tables.',
+    lastUsed: '2026-04-15T09:00:00Z',
+    usageCount: 7,
+    img: SCREENSHOT_3_IMAGE,
+  },
+  {
+    name: 'AppShell',
+    type: 'Component',
+    description:
+      'Foundational page layout with header, sidebar, and content regions.',
+    lastUsed: '2026-04-14T10:30:00Z',
+    usageCount: 12,
+    img: FIRST_CARD_IMAGE,
+  },
+  {
+    name: 'Meta Theme',
+    type: 'Theme',
+    description: 'Meta brand colors with Figtree typography and blue accents.',
+    lastUsed: '2026-04-14T08:00:00Z',
+    usageCount: 9,
+    img: SHOPPING_DETAILS_IMAGE,
+  },
+  {
+    name: 'Button',
+    type: 'Component',
+    description: 'Primary action element for forms, dialogs, and toolbars.',
+    lastUsed: '2026-04-14T16:00:00Z',
+    usageCount: 24,
+    img: FIRST_CARD_IMAGE,
+  },
+  {
+    name: 'Contact Form',
+    type: 'Template',
+    description:
+      'Responsive contact form with validation, file upload, and success state.',
+    lastUsed: '2026-04-13T11:00:00Z',
+    usageCount: 4,
+    img: `${basePath}/templates/card4-preview.png`,
+  },
+  {
+    name: 'Badge',
+    type: 'Component',
+    description:
+      'Displays small counts or status labels on icons, buttons, or list items.',
+    lastUsed: '2026-04-12T09:20:00Z',
+    usageCount: 15,
+    img: SCREENSHOT_3_IMAGE,
+  },
+  {
+    name: 'Dark Mode Palette',
+    type: 'Theme',
+    description:
+      'High-contrast dark theme with WCAG AA compliant color ratios.',
+    lastUsed: '2026-04-11T18:30:00Z',
+    usageCount: 3,
+    img: DUMMY_IMAGE,
+  },
+  {
+    name: 'Avatar',
+    type: 'Component',
+    description:
+      'Represents a person or entity with an image, initials, or icon.',
+    lastUsed: '2026-04-13T15:45:00Z',
+    usageCount: 8,
+    img: SHOPPING_DETAILS_IMAGE,
+  },
+  {
+    name: 'Settings Page',
+    type: 'Template',
+    description:
+      'Sidebar settings layout with inline editing and expandable rows.',
+    lastUsed: '2026-04-10T14:00:00Z',
+    usageCount: 5,
+    img: `${basePath}/templates/card4-preview.png`,
+  },
+  {
+    name: 'Dialog',
+    type: 'Component',
+    description: 'Modal overlays that require user attention or action.',
+    lastUsed: '2026-04-11T13:15:00Z',
+    usageCount: 6,
+    img: DUMMY_IMAGE,
+  },
+  {
+    name: 'WhatsApp Theme',
+    type: 'Theme',
+    description:
+      'WhatsApp brand greens and warm grays with rounded components.',
+    lastUsed: '2026-04-09T10:00:00Z',
+    usageCount: 2,
+    img: DUMMY_IMAGE,
+  },
+  {
+    name: 'DropdownMenu',
+    type: 'Component',
+    description: 'Presents actions or options in a floating overlay.',
+    lastUsed: '2026-04-09T16:45:00Z',
+    usageCount: 5,
+    img: DUMMY_IMAGE,
+  },
 ];
 
 export const PROFILE_LIKED_ITEMS: {
@@ -256,12 +458,55 @@ export const PROFILE_LIKED_ITEMS: {
   img: string;
   author: string;
 }[] = [
-  {name: 'Meta Theme', type: 'Theme', bookmarkedAt: '2026-04-13T08:00:00Z', description: 'Meta brand colors with Figtree typography.', img: FIRST_CARD_IMAGE, author: 'XDS Design'},
-  {name: 'Brutalist Theme', type: 'Theme', bookmarkedAt: '2026-04-11T10:30:00Z', description: 'Bold, raw aesthetic with heavy borders and sharp angles.', img: SHOPPING_DETAILS_IMAGE, author: 'Andrea Anderson'},
-  {name: 'Admin Dashboard', type: 'Template', bookmarkedAt: '2026-04-10T14:20:00Z', description: 'Full admin panel with sidebar nav, KPI cards, and data tables.', img: SCREENSHOT_3_IMAGE, author: 'Andrea Anderson'},
-  {name: 'Product Detail', type: 'Template', bookmarkedAt: '2026-04-07T09:00:00Z', description: 'E-commerce product page with image gallery and reviews.', img: `${basePath}/templates/card4-preview.png`, author: 'XDS Design'},
-  {name: 'Toast Notification', type: 'Component', bookmarkedAt: '2026-04-05T11:00:00Z', description: 'Stackable toast with auto-dismiss and action support.', img: DUMMY_IMAGE, author: 'Andrea Anderson'},
-  {name: 'Kanban Board', type: 'Template', bookmarkedAt: '2026-04-02T16:30:00Z', description: 'Drag-and-drop board with swimlanes and card detail drawers.', img: DUMMY_IMAGE, author: 'XDS Design'},
+  {
+    name: 'Meta Theme',
+    type: 'Theme',
+    bookmarkedAt: '2026-04-13T08:00:00Z',
+    description: 'Meta brand colors with Figtree typography.',
+    img: FIRST_CARD_IMAGE,
+    author: 'XDS Design',
+  },
+  {
+    name: 'Brutalist Theme',
+    type: 'Theme',
+    bookmarkedAt: '2026-04-11T10:30:00Z',
+    description: 'Bold, raw aesthetic with heavy borders and sharp angles.',
+    img: SHOPPING_DETAILS_IMAGE,
+    author: 'Andrea Anderson',
+  },
+  {
+    name: 'Admin Dashboard',
+    type: 'Template',
+    bookmarkedAt: '2026-04-10T14:20:00Z',
+    description:
+      'Full admin panel with sidebar nav, KPI cards, and data tables.',
+    img: SCREENSHOT_3_IMAGE,
+    author: 'Andrea Anderson',
+  },
+  {
+    name: 'Product Detail',
+    type: 'Template',
+    bookmarkedAt: '2026-04-07T09:00:00Z',
+    description: 'E-commerce product page with image gallery and reviews.',
+    img: `${basePath}/templates/card4-preview.png`,
+    author: 'XDS Design',
+  },
+  {
+    name: 'Toast Notification',
+    type: 'Component',
+    bookmarkedAt: '2026-04-05T11:00:00Z',
+    description: 'Stackable toast with auto-dismiss and action support.',
+    img: DUMMY_IMAGE,
+    author: 'Andrea Anderson',
+  },
+  {
+    name: 'Kanban Board',
+    type: 'Template',
+    bookmarkedAt: '2026-04-02T16:30:00Z',
+    description: 'Drag-and-drop board with swimlanes and card detail drawers.',
+    img: DUMMY_IMAGE,
+    author: 'XDS Design',
+  },
 ];
 
 export const PROFILE_COLLECTIONS: {
@@ -270,11 +515,63 @@ export const PROFILE_COLLECTIONS: {
   color: string;
   items: string[];
 }[] = [
-  {name: 'Work Projects', count: 4, color: '#3B82F6', items: ['Admin Dashboard', 'Meta Theme', 'Toast Notification', 'Kanban Board']},
-  {name: 'Design Inspiration', count: 6, color: '#8B5CF6', items: ['Meta Theme', 'Brutalist Theme', 'Admin Dashboard', 'Product Detail', 'Toast Notification', 'Kanban Board']},
-  {name: 'Client Templates', count: 3, color: '#F59E0B', items: ['Admin Dashboard', 'Product Detail', 'Kanban Board']},
-  {name: 'Dashboard Ideas', count: 5, color: '#10B981', items: ['Admin Dashboard', 'Meta Theme', 'Brutalist Theme', 'Product Detail', 'Kanban Board']},
-  {name: 'Landing Pages', count: 8, color: '#EF4444', items: ['Meta Theme', 'Brutalist Theme', 'Admin Dashboard', 'Product Detail', 'Toast Notification', 'Kanban Board', 'Meta Theme', 'Brutalist Theme']},
+  {
+    name: 'Work Projects',
+    count: 4,
+    color: '#3B82F6',
+    items: [
+      'Admin Dashboard',
+      'Meta Theme',
+      'Toast Notification',
+      'Kanban Board',
+    ],
+  },
+  {
+    name: 'Design Inspiration',
+    count: 6,
+    color: '#8B5CF6',
+    items: [
+      'Meta Theme',
+      'Brutalist Theme',
+      'Admin Dashboard',
+      'Product Detail',
+      'Toast Notification',
+      'Kanban Board',
+    ],
+  },
+  {
+    name: 'Client Templates',
+    count: 3,
+    color: '#F59E0B',
+    items: ['Admin Dashboard', 'Product Detail', 'Kanban Board'],
+  },
+  {
+    name: 'Dashboard Ideas',
+    count: 5,
+    color: '#10B981',
+    items: [
+      'Admin Dashboard',
+      'Meta Theme',
+      'Brutalist Theme',
+      'Product Detail',
+      'Kanban Board',
+    ],
+  },
+  {
+    name: 'Landing Pages',
+    count: 8,
+    color: '#EF4444',
+    items: [
+      'Meta Theme',
+      'Brutalist Theme',
+      'Admin Dashboard',
+      'Product Detail',
+      'Toast Notification',
+      'Kanban Board',
+      'Meta Theme',
+      'Brutalist Theme',
+    ],
+  },
 ];
 
 export const PROFILE_CRAFT_ITEMS: {
@@ -289,19 +586,175 @@ export const PROFILE_CRAFT_ITEMS: {
   description: string;
   tags: string[];
 }[] = [
-  {name: 'My Dashboard Theme', type: 'Theme', status: 'Published', used: 342, views: 1205, bookmarks: 89, img: FIRST_CARD_IMAGE, lastUpdated: '2026-03-01T10:00:00Z', description: 'Dark-mode friendly theme with custom color tokens and typography overrides.', tags: ['Dashboard', 'Dark Mode', 'SaaS']},
-  {name: 'Custom Login Template', type: 'Template', status: 'Published', used: 128, views: 580, bookmarks: 34, img: SHOPPING_DETAILS_IMAGE, lastUpdated: '2026-03-15T14:30:00Z', description: 'Branded login page with social auth buttons and form validation.', tags: ['Login', 'Authentication', 'Form']},
-  {name: 'Data Visualization Kit', type: 'Template', status: 'Published', used: 89, views: 312, bookmarks: 27, img: SCREENSHOT_3_IMAGE, lastUpdated: '2026-04-02T11:00:00Z', description: 'Charts, graphs, and data table layouts for analytics dashboards.', tags: ['Dashboard', 'Charts', 'Analytics']},
-  {name: 'Settings Page', type: 'Template', status: 'Published', used: 67, views: 248, bookmarks: 18, img: `${basePath}/templates/card4-preview.png`, lastUpdated: '2026-02-20T08:00:00Z', description: 'Sidebar settings layout with inline editing and expandable rows.', tags: ['Settings', 'SaaS', 'Admin']},
-  {name: 'Product Detail Page', type: 'Template', status: 'Published', used: 54, views: 190, bookmarks: 15, img: DUMMY_IMAGE, lastUpdated: '2026-03-28T12:00:00Z', description: 'E-commerce product page with image gallery, reviews, and add-to-cart.', tags: ['E-commerce', 'Shopping', 'Product']},
-  {name: 'Custom Notification Card', type: 'Component', status: 'Published', used: 203, views: 870, bookmarks: 62, img: DUMMY_IMAGE, lastUpdated: '2026-01-15T09:00:00Z', description: 'Toast-style notification card with dismiss, action buttons, and auto-hide.', tags: ['Notification', 'Toast', 'Feedback']},
-  {name: 'Metric Summary Card', type: 'Component', status: 'Published', used: 156, views: 620, bookmarks: 41, img: DUMMY_IMAGE, lastUpdated: '2026-02-10T14:00:00Z', description: 'KPI card with sparkline, trend indicator, and comparison period.', tags: ['Dashboard', 'KPI', 'Analytics']},
-  {name: 'Analytics Dashboard', type: 'Template', status: 'In Review', used: 0, views: 45, bookmarks: 0, img: DUMMY_IMAGE, lastUpdated: '2026-04-12T09:00:00Z', description: 'Full-page analytics dashboard with filters, charts, and data tables.', tags: ['Dashboard', 'Analytics', 'Data Table']},
-  {name: 'Team Directory', type: 'Template', status: 'In Review', used: 0, views: 32, bookmarks: 0, img: DUMMY_IMAGE, lastUpdated: '2026-04-10T16:30:00Z', description: 'Searchable team roster with profile cards, org chart, and role filters.', tags: ['Directory', 'Team', 'Admin']},
-  {name: 'Checkout Flow', type: 'Template', status: 'Needs Fixes', used: 0, views: 18, bookmarks: 0, img: DUMMY_IMAGE, lastUpdated: '2026-04-11T14:00:00Z', description: 'Multi-step checkout with cart summary, address form, and payment integration.', tags: ['E-commerce', 'Checkout', 'Form']},
-  {name: 'Onboarding Flow', type: 'Template', status: 'Draft', used: 0, views: 12, bookmarks: 0, img: DUMMY_IMAGE, lastUpdated: '2026-04-14T16:00:00Z', description: 'Multi-step onboarding wizard with progress bar and skip logic.', tags: ['Onboarding', 'Wizard', 'Form']},
-  {name: 'Dark Mode Palette', type: 'Theme', status: 'Draft', used: 0, views: 8, bookmarks: 0, img: DUMMY_IMAGE, lastUpdated: '2026-04-13T11:30:00Z', description: 'High-contrast dark theme with WCAG AA compliant color ratios.', tags: ['Dark Mode', 'Accessibility', 'Theme']},
-  {name: 'File Upload Dropzone', type: 'Component', status: 'Draft', used: 0, views: 5, bookmarks: 0, img: DUMMY_IMAGE, lastUpdated: '2026-04-15T10:00:00Z', description: 'Drag-and-drop file uploader with preview thumbnails and progress bars.', tags: ['Upload', 'Form', 'File']},
+  {
+    name: 'My Dashboard Theme',
+    type: 'Theme',
+    status: 'Published',
+    used: 342,
+    views: 1205,
+    bookmarks: 89,
+    img: FIRST_CARD_IMAGE,
+    lastUpdated: '2026-03-01T10:00:00Z',
+    description:
+      'Dark-mode friendly theme with custom color tokens and typography overrides.',
+    tags: ['Dashboard', 'Dark Mode', 'SaaS'],
+  },
+  {
+    name: 'Custom Login Template',
+    type: 'Template',
+    status: 'Published',
+    used: 128,
+    views: 580,
+    bookmarks: 34,
+    img: SHOPPING_DETAILS_IMAGE,
+    lastUpdated: '2026-03-15T14:30:00Z',
+    description:
+      'Branded login page with social auth buttons and form validation.',
+    tags: ['Login', 'Authentication', 'Form'],
+  },
+  {
+    name: 'Data Visualization Kit',
+    type: 'Template',
+    status: 'Published',
+    used: 89,
+    views: 312,
+    bookmarks: 27,
+    img: SCREENSHOT_3_IMAGE,
+    lastUpdated: '2026-04-02T11:00:00Z',
+    description:
+      'Charts, graphs, and data table layouts for analytics dashboards.',
+    tags: ['Dashboard', 'Charts', 'Analytics'],
+  },
+  {
+    name: 'Settings Page',
+    type: 'Template',
+    status: 'Published',
+    used: 67,
+    views: 248,
+    bookmarks: 18,
+    img: `${basePath}/templates/card4-preview.png`,
+    lastUpdated: '2026-02-20T08:00:00Z',
+    description:
+      'Sidebar settings layout with inline editing and expandable rows.',
+    tags: ['Settings', 'SaaS', 'Admin'],
+  },
+  {
+    name: 'Product Detail Page',
+    type: 'Template',
+    status: 'Published',
+    used: 54,
+    views: 190,
+    bookmarks: 15,
+    img: DUMMY_IMAGE,
+    lastUpdated: '2026-03-28T12:00:00Z',
+    description:
+      'E-commerce product page with image gallery, reviews, and add-to-cart.',
+    tags: ['E-commerce', 'Shopping', 'Product'],
+  },
+  {
+    name: 'Custom Notification Card',
+    type: 'Component',
+    status: 'Published',
+    used: 203,
+    views: 870,
+    bookmarks: 62,
+    img: DUMMY_IMAGE,
+    lastUpdated: '2026-01-15T09:00:00Z',
+    description:
+      'Toast-style notification card with dismiss, action buttons, and auto-hide.',
+    tags: ['Notification', 'Toast', 'Feedback'],
+  },
+  {
+    name: 'Metric Summary Card',
+    type: 'Component',
+    status: 'Published',
+    used: 156,
+    views: 620,
+    bookmarks: 41,
+    img: DUMMY_IMAGE,
+    lastUpdated: '2026-02-10T14:00:00Z',
+    description:
+      'KPI card with sparkline, trend indicator, and comparison period.',
+    tags: ['Dashboard', 'KPI', 'Analytics'],
+  },
+  {
+    name: 'Analytics Dashboard',
+    type: 'Template',
+    status: 'In Review',
+    used: 0,
+    views: 45,
+    bookmarks: 0,
+    img: DUMMY_IMAGE,
+    lastUpdated: '2026-04-12T09:00:00Z',
+    description:
+      'Full-page analytics dashboard with filters, charts, and data tables.',
+    tags: ['Dashboard', 'Analytics', 'Data Table'],
+  },
+  {
+    name: 'Team Directory',
+    type: 'Template',
+    status: 'In Review',
+    used: 0,
+    views: 32,
+    bookmarks: 0,
+    img: DUMMY_IMAGE,
+    lastUpdated: '2026-04-10T16:30:00Z',
+    description:
+      'Searchable team roster with profile cards, org chart, and role filters.',
+    tags: ['Directory', 'Team', 'Admin'],
+  },
+  {
+    name: 'Checkout Flow',
+    type: 'Template',
+    status: 'Needs Fixes',
+    used: 0,
+    views: 18,
+    bookmarks: 0,
+    img: DUMMY_IMAGE,
+    lastUpdated: '2026-04-11T14:00:00Z',
+    description:
+      'Multi-step checkout with cart summary, address form, and payment integration.',
+    tags: ['E-commerce', 'Checkout', 'Form'],
+  },
+  {
+    name: 'Onboarding Flow',
+    type: 'Template',
+    status: 'Draft',
+    used: 0,
+    views: 12,
+    bookmarks: 0,
+    img: DUMMY_IMAGE,
+    lastUpdated: '2026-04-14T16:00:00Z',
+    description:
+      'Multi-step onboarding wizard with progress bar and skip logic.',
+    tags: ['Onboarding', 'Wizard', 'Form'],
+  },
+  {
+    name: 'Dark Mode Palette',
+    type: 'Theme',
+    status: 'Draft',
+    used: 0,
+    views: 8,
+    bookmarks: 0,
+    img: DUMMY_IMAGE,
+    lastUpdated: '2026-04-13T11:30:00Z',
+    description:
+      'High-contrast dark theme with WCAG AA compliant color ratios.',
+    tags: ['Dark Mode', 'Accessibility', 'Theme'],
+  },
+  {
+    name: 'File Upload Dropzone',
+    type: 'Component',
+    status: 'Draft',
+    used: 0,
+    views: 5,
+    bookmarks: 0,
+    img: DUMMY_IMAGE,
+    lastUpdated: '2026-04-15T10:00:00Z',
+    description:
+      'Drag-and-drop file uploader with preview thumbnails and progress bars.',
+    tags: ['Upload', 'Form', 'File'],
+  },
 ];
 
 // ---------------------------------------------------------------------------
@@ -328,20 +781,131 @@ export type ThemePickerEntry = {
   accent: string;
   description?: string;
   isPinnedByDefault?: boolean;
-  preview: {bg: string; surface: string; accent: string; text: string};
+  preview: {
+    bg: string;
+    surface: string;
+    accent: string;
+    text: string;
+    radius?: number;
+  };
 };
 
 export const THEME_PICKER_ENTRIES: ThemePickerEntry[] = [
   // Official — shipped theme packages
-  {key: 'default', name: 'Default', category: 'official', accent: '#0066FF', isPinnedByDefault: true, description: 'Clean blue accent with neutral grays', preview: {bg: '#FFFFFF', surface: '#F5F5F5', accent: '#0066FF', text: '#111111'}},
-  {key: 'meta', name: 'Meta', category: 'official', accent: '#0064E0', description: 'Meta brand with Figtree typography', preview: {bg: '#FFFFFF', surface: '#F2F4F6', accent: '#0064E0', text: '#111112'}},
-  {key: 'whatsapp', name: 'WhatsApp', category: 'official', accent: '#1DAA61', description: 'WhatsApp brand greens and warm grays', preview: {bg: '#FFFFFF', surface: '#F7F5F3', accent: '#1DAA61', text: '#111B21'}},
-  {key: 'threads', name: 'Threads', category: 'official', accent: '#000000', description: 'Threads brand with clean monochrome palette', preview: {bg: '#FFFFFF', surface: '#F5F5F5', accent: '#000000', text: '#111111'}},
-  {key: 'facebook', name: 'Facebook', category: 'official', accent: '#1877F2', description: 'Classic Facebook blue brand colors', preview: {bg: '#FFFFFF', surface: '#F0F2F5', accent: '#1877F2', text: '#1C1E21'}},
+  {
+    key: 'default',
+    name: 'Default',
+    category: 'official',
+    accent: '#0066FF',
+    isPinnedByDefault: true,
+    description: 'Clean blue accent with neutral grays',
+    preview: {
+      bg: '#FFFFFF',
+      surface: '#F5F5F5',
+      accent: '#0066FF',
+      text: '#111111',
+      radius: 8,
+    },
+  },
+  {
+    key: 'meta',
+    name: 'Meta',
+    category: 'official',
+    accent: '#0064E0',
+    description: 'Meta brand with Figtree typography',
+    preview: {
+      bg: '#FFFFFF',
+      surface: '#F2F4F6',
+      accent: '#0064E0',
+      text: '#111112',
+      radius: 10,
+    },
+  },
+  {
+    key: 'whatsapp',
+    name: 'WhatsApp',
+    category: 'official',
+    accent: '#1DAA61',
+    description: 'WhatsApp brand greens and warm grays',
+    preview: {
+      bg: '#FFFFFF',
+      surface: '#F7F5F3',
+      accent: '#1DAA61',
+      text: '#111B21',
+      radius: 12,
+    },
+  },
+  {
+    key: 'threads',
+    name: 'Threads',
+    category: 'official',
+    accent: '#000000',
+    description: 'Threads brand with clean monochrome palette',
+    preview: {
+      bg: '#FFFFFF',
+      surface: '#F5F5F5',
+      accent: '#000000',
+      text: '#111111',
+      radius: 16,
+    },
+  },
+  {
+    key: 'facebook',
+    name: 'Facebook',
+    category: 'official',
+    accent: '#1877F2',
+    description: 'Classic Facebook blue brand colors',
+    preview: {
+      bg: '#FFFFFF',
+      surface: '#F0F2F5',
+      accent: '#1877F2',
+      text: '#1C1E21',
+      radius: 8,
+    },
+  },
   // Community — future user-contributed themes
-  {key: 'forest', name: 'Forest', category: 'community', accent: '#2D8A4E', description: 'Earthy greens and warm browns', preview: {bg: '#F4F7F4', surface: '#E8EDE8', accent: '#2D8A4E', text: '#1A2E1A'}},
-  {key: 'sunset', name: 'Sunset', category: 'community', accent: '#E5484D', description: 'Warm reds and golden highlights', preview: {bg: '#FFF5F5', surface: '#FDE8E8', accent: '#E5484D', text: '#2D1515'}},
-  {key: 'midnight', name: 'Midnight', category: 'community', accent: '#818CF8', description: 'Deep blues with soft violet accents', preview: {bg: '#0F172A', surface: '#1E293B', accent: '#818CF8', text: '#E2E8F0'}},
+  {
+    key: 'forest',
+    name: 'Forest',
+    category: 'community',
+    accent: '#2D8A4E',
+    description: 'Earthy greens and warm browns',
+    preview: {
+      bg: '#F4F7F4',
+      surface: '#E8EDE8',
+      accent: '#2D8A4E',
+      text: '#1A2E1A',
+      radius: 6,
+    },
+  },
+  {
+    key: 'sunset',
+    name: 'Sunset',
+    category: 'community',
+    accent: '#E5484D',
+    description: 'Warm reds and golden highlights',
+    preview: {
+      bg: '#FFF5F5',
+      surface: '#FDE8E8',
+      accent: '#E5484D',
+      text: '#2D1515',
+      radius: 12,
+    },
+  },
+  {
+    key: 'midnight',
+    name: 'Midnight',
+    category: 'community',
+    accent: '#818CF8',
+    description: 'Deep blues with soft violet accents',
+    preview: {
+      bg: '#0F172A',
+      surface: '#1E293B',
+      accent: '#818CF8',
+      text: '#E2E8F0',
+      radius: 4,
+    },
+  },
 ];
 
 // ---------------------------------------------------------------------------

--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/constants.ts
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/constants.ts
@@ -787,6 +787,7 @@ export type ThemePickerEntry = {
     accent: string;
     text: string;
     radius?: number;
+    font?: string;
   };
 };
 
@@ -805,6 +806,7 @@ export const THEME_PICKER_ENTRIES: ThemePickerEntry[] = [
       accent: '#0066FF',
       text: '#111111',
       radius: 8,
+      font: 'system-ui, sans-serif',
     },
   },
   {
@@ -819,6 +821,7 @@ export const THEME_PICKER_ENTRIES: ThemePickerEntry[] = [
       accent: '#0064E0',
       text: '#111112',
       radius: 10,
+      font: 'Figtree, sans-serif',
     },
   },
   {
@@ -833,6 +836,7 @@ export const THEME_PICKER_ENTRIES: ThemePickerEntry[] = [
       accent: '#1DAA61',
       text: '#111B21',
       radius: 12,
+      font: 'Helvetica Neue, sans-serif',
     },
   },
   {
@@ -847,6 +851,7 @@ export const THEME_PICKER_ENTRIES: ThemePickerEntry[] = [
       accent: '#000000',
       text: '#111111',
       radius: 16,
+      font: 'system-ui, sans-serif',
     },
   },
   {
@@ -861,6 +866,7 @@ export const THEME_PICKER_ENTRIES: ThemePickerEntry[] = [
       accent: '#1877F2',
       text: '#1C1E21',
       radius: 8,
+      font: 'Helvetica, Arial, sans-serif',
     },
   },
   // Community — future user-contributed themes
@@ -876,6 +882,7 @@ export const THEME_PICKER_ENTRIES: ThemePickerEntry[] = [
       accent: '#2D8A4E',
       text: '#1A2E1A',
       radius: 6,
+      font: 'Georgia, serif',
     },
   },
   {
@@ -890,6 +897,7 @@ export const THEME_PICKER_ENTRIES: ThemePickerEntry[] = [
       accent: '#E5484D',
       text: '#2D1515',
       radius: 12,
+      font: 'Avenir Next, sans-serif',
     },
   },
   {
@@ -904,6 +912,7 @@ export const THEME_PICKER_ENTRIES: ThemePickerEntry[] = [
       accent: '#818CF8',
       text: '#E2E8F0',
       radius: 4,
+      font: 'SF Mono, monospace',
     },
   },
 ];

--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
@@ -1855,7 +1855,9 @@ function DocsiteLandingTemplate() {
                       ];
                       if (activeTab === 'all' && i === 2) {
                         items.push(
-                          ...THEME_PICKER_ENTRIES.slice(0, 2).map((t, ti) => (
+                          ...THEME_PICKER_ENTRIES.filter(
+                            t => t.key === 'forest' || t.key === 'midnight',
+                          ).map((t, ti) => (
                             <ThemeCard
                               key={`theme-${t.key}`}
                               theme={t}

--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
@@ -21,7 +21,7 @@ import {
 } from './constants';
 import {TemplateCard} from './TemplateCard';
 import {AIComposer} from './AIComposer';
-import type {ComposerMode} from './AIComposer';
+
 import {ChatPanel} from './ChatPanel';
 import type {PanelTab, PointedElement} from './ChatPanel';
 import {InlinePublishPanel} from './InlinePublishPanel';
@@ -1794,9 +1794,6 @@ function DocsiteLandingTemplate() {
       {!chatOpen && (
         <AIComposer
           mode={activeTab === 'theme' ? 'theme' : 'template'}
-          onModeChange={(m: ComposerMode) =>
-            setActiveTab(m === 'theme' ? 'theme' : 'all')
-          }
           onThemeMode={() => setActiveView('theme')}
         />
       )}

--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
@@ -188,14 +188,151 @@ function ThemeCard({
           <div
             style={{
               aspectRatio: '1920 / 1205',
-              display: 'grid',
-              gridTemplateColumns: '1fr 1fr',
-              gridTemplateRows: '1fr 1fr',
+              backgroundColor: theme.preview.bg,
+              display: 'flex',
+              flexDirection: 'column',
+              overflow: 'hidden',
             }}>
-            <div style={{backgroundColor: theme.preview.bg}} />
-            <div style={{backgroundColor: theme.preview.surface}} />
-            <div style={{backgroundColor: theme.preview.accent}} />
-            <div style={{backgroundColor: theme.preview.text}} />
+            {/* Top nav bar */}
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: '3%',
+                padding: '3% 4%',
+                borderBottom: `1px solid ${theme.preview.surface}`,
+              }}>
+              <div
+                style={{
+                  width: '5%',
+                  height: 0,
+                  paddingBottom: '5%',
+                  borderRadius: '50%',
+                  backgroundColor: theme.preview.accent,
+                  flexShrink: 0,
+                }}
+              />
+              <div
+                style={{
+                  flex: 1,
+                  height: 0,
+                  paddingBottom: '4%',
+                  borderRadius: 999,
+                  backgroundColor: theme.preview.surface,
+                }}
+              />
+              <div
+                style={{
+                  width: '5%',
+                  height: 0,
+                  paddingBottom: '5%',
+                  borderRadius: '50%',
+                  backgroundColor: theme.preview.surface,
+                  flexShrink: 0,
+                }}
+              />
+            </div>
+            {/* Body: sidebar + content */}
+            <div style={{flex: 1, display: 'flex', minHeight: 0}}>
+              {/* Sidebar */}
+              <div
+                style={{
+                  width: '22%',
+                  padding: '4% 3%',
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: '6%',
+                  borderRight: `1px solid ${theme.preview.surface}`,
+                }}>
+                {[true, false, false, false].map((active, j) => (
+                  <div
+                    key={j}
+                    style={{
+                      height: 0,
+                      paddingBottom: '16%',
+                      borderRadius: 3,
+                      backgroundColor: active
+                        ? theme.preview.accent
+                        : theme.preview.text,
+                      opacity: active ? 1 : 0.15,
+                    }}
+                  />
+                ))}
+              </div>
+              {/* Content area */}
+              <div
+                style={{
+                  flex: 1,
+                  padding: '4%',
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: '4%',
+                }}>
+                {/* Content cards 2x2 */}
+                <div
+                  style={{
+                    flex: 1,
+                    display: 'grid',
+                    gridTemplateColumns: '1fr 1fr',
+                    gridTemplateRows: '1fr 1fr',
+                    gap: '4%',
+                  }}>
+                  {[0, 1, 2, 3].map(j => (
+                    <div
+                      key={j}
+                      style={{
+                        backgroundColor: theme.preview.surface,
+                        borderRadius: 4,
+                        padding: '10%',
+                        display: 'flex',
+                        flexDirection: 'column',
+                        gap: '8%',
+                      }}>
+                      <div
+                        style={{
+                          height: 0,
+                          paddingBottom: '12%',
+                          width: '60%',
+                          borderRadius: 2,
+                          backgroundColor: theme.preview.text,
+                          opacity: 0.7,
+                        }}
+                      />
+                      <div
+                        style={{
+                          height: 0,
+                          paddingBottom: '8%',
+                          width: '90%',
+                          borderRadius: 2,
+                          backgroundColor: theme.preview.text,
+                          opacity: 0.15,
+                        }}
+                      />
+                      <div
+                        style={{
+                          height: 0,
+                          paddingBottom: '8%',
+                          width: '70%',
+                          borderRadius: 2,
+                          backgroundColor: theme.preview.text,
+                          opacity: 0.15,
+                        }}
+                      />
+                    </div>
+                  ))}
+                </div>
+                {/* CTA button */}
+                <div
+                  style={{
+                    height: 0,
+                    paddingBottom: '5%',
+                    width: '30%',
+                    borderRadius: 4,
+                    backgroundColor: theme.preview.accent,
+                  }}
+                />
+              </div>
+            </div>
           </div>
           <div
             style={{

--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
@@ -19,6 +19,7 @@ import {
   PROFILE_CRAFT_ITEMS,
   THEME_PICKER_ENTRIES,
 } from './constants';
+import type {ThemePickerEntry} from './constants';
 import {TemplateCard} from './TemplateCard';
 import {AIComposer} from './AIComposer';
 
@@ -151,6 +152,120 @@ function SearchableFilterDropdown({
         endContent={<XDSIcon icon="chevronDown" size="sm" color="inherit" />}
       />
     </XDSPopover>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ThemeCard — mirrors TemplateCard layout for visual consistency
+// ---------------------------------------------------------------------------
+
+function ThemeCard({
+  theme,
+  index,
+  onCustomize,
+}: {
+  theme: ThemePickerEntry;
+  index: number;
+  onCustomize: () => void;
+}) {
+  const [hovered, setHovered] = useState(false);
+
+  return (
+    <div
+      style={{
+        animation: `craftCardFadeIn 400ms ${index * 60}ms cubic-bezier(0.16, 1, 0.3, 1) both`,
+      }}>
+      <XDSCard padding={0}>
+        <div
+          style={{
+            position: 'relative',
+            cursor: 'pointer',
+            overflow: 'hidden',
+          }}
+          onMouseEnter={() => setHovered(true)}
+          onMouseLeave={() => setHovered(false)}
+          onClick={onCustomize}>
+          <div
+            style={{
+              aspectRatio: '1920 / 1205',
+              display: 'grid',
+              gridTemplateColumns: '1fr 1fr',
+              gridTemplateRows: '1fr 1fr',
+            }}>
+            <div style={{backgroundColor: theme.preview.bg}} />
+            <div style={{backgroundColor: theme.preview.surface}} />
+            <div style={{backgroundColor: theme.preview.accent}} />
+            <div style={{backgroundColor: theme.preview.text}} />
+          </div>
+          <div
+            style={{
+              position: 'absolute',
+              inset: 0,
+              backgroundColor: 'var(--color-overlay, rgba(0,0,0,0.5))',
+              opacity: hovered ? 1 : 0,
+              transition: 'opacity 300ms ease',
+            }}>
+            <div
+              style={{
+                position: 'absolute',
+                top: 12,
+                right: 12,
+              }}>
+              <span
+                style={{
+                  fontSize: 11,
+                  fontWeight: 600,
+                  padding: '2px 8px',
+                  borderRadius: 9999,
+                  backgroundColor: 'rgba(255,255,255,0.9)',
+                  color: '#333',
+                }}>
+                {theme.category === 'official' ? 'Official' : 'Community'}
+              </span>
+            </div>
+            <div
+              style={{
+                position: 'absolute',
+                bottom: 0,
+                left: 0,
+                right: 0,
+                padding: 16,
+                background:
+                  'linear-gradient(to top, rgba(0,0,0,0.6), transparent)',
+                display: 'flex',
+                alignItems: 'flex-end',
+                justifyContent: 'space-between',
+              }}>
+              <XDSStack direction="vertical" gap={0}>
+                <XDSHeading level={3} style={{color: '#fff'}}>
+                  {theme.name}
+                </XDSHeading>
+                {theme.description && (
+                  <XDSText
+                    type="supporting"
+                    style={{color: 'rgba(255,255,255,0.7)'}}>
+                    {theme.description}
+                  </XDSText>
+                )}
+              </XDSStack>
+              <XDSButton
+                label="Customize"
+                variant="secondary"
+                size="sm"
+                style={{
+                  backgroundColor: 'var(--color-background-surface)',
+                  flexShrink: 0,
+                }}
+                onClick={e => {
+                  e.stopPropagation();
+                  onCustomize();
+                }}
+              />
+            </div>
+          </div>
+        </div>
+      </XDSCard>
+    </div>
   );
 }
 
@@ -1331,211 +1446,22 @@ function DocsiteLandingTemplate() {
                   style={{
                     maxWidth: 2000,
                     margin: '0 auto',
+                    display: 'grid',
+                    gridTemplateColumns: isMobile
+                      ? '1fr'
+                      : isTablet
+                        ? 'repeat(2, 1fr)'
+                        : 'repeat(3, 1fr)',
+                    gap: 16,
                   }}>
-                  <XDSCard
-                    padding={0}
-                    style={{
-                      marginBottom: 32,
-                      overflow: 'hidden',
-                    }}>
-                    <div
-                      style={{
-                        display: 'flex',
-                        alignItems: 'center',
-                        gap: 32,
-                        padding: '40px 48px',
-                        background:
-                          'linear-gradient(135deg, var(--color-background-surface, #f5f5f5) 0%, var(--color-background-muted, #e8e8e8) 100%)',
-                      }}>
-                      <div style={{flex: 1}}>
-                        <XDSHeading level={2}>Make it yours</XDSHeading>
-                        <XDSText
-                          type="body"
-                          color="secondary"
-                          style={{marginTop: 8, maxWidth: 480}}>
-                          Customize colors, typography, spacing, and more to
-                          match your brand. Start from an official theme or
-                          build one from scratch.
-                        </XDSText>
-                        <div style={{marginTop: 20}}>
-                          <XDSButton
-                            label="Open Theme Editor"
-                            icon={<PaletteIcon />}
-                            onClick={() => setActiveView('theme')}
-                          />
-                        </div>
-                      </div>
-                      <div
-                        style={{
-                          display: 'flex',
-                          gap: 6,
-                          flexShrink: 0,
-                        }}>
-                        {['#0066FF', '#1DAA61', '#E5484D', '#818CF8'].map(
-                          color => (
-                            <div
-                              key={color}
-                              style={{
-                                width: 32,
-                                height: 64,
-                                borderRadius: 8,
-                                backgroundColor: color,
-                              }}
-                            />
-                          ),
-                        )}
-                      </div>
-                    </div>
-                  </XDSCard>
-
-                  <div style={{marginBottom: 16}}>
-                    <XDSText type="label" color="secondary">
-                      Official
-                    </XDSText>
-                  </div>
-                  <div
-                    style={{
-                      display: 'grid',
-                      gridTemplateColumns: isMobile
-                        ? '1fr'
-                        : isTablet
-                          ? 'repeat(2, 1fr)'
-                          : 'repeat(3, 1fr)',
-                      gap: 16,
-                      marginBottom: 32,
-                    }}>
-                    {THEME_PICKER_ENTRIES.filter(
-                      t => t.category === 'official',
-                    ).map((theme, i) => (
-                      <XDSCard
-                        key={theme.key}
-                        padding={0}
-                        style={{
-                          overflow: 'hidden',
-                          cursor: 'pointer',
-                          animation: `craftCardFadeIn 400ms ${i * 60}ms cubic-bezier(0.16, 1, 0.3, 1) both`,
-                        }}
-                        onClick={() => setActiveView('theme')}>
-                        <div
-                          style={{
-                            height: 80,
-                            display: 'flex',
-                          }}>
-                          <div
-                            style={{
-                              flex: 1,
-                              backgroundColor: theme.preview.bg,
-                            }}
-                          />
-                          <div
-                            style={{
-                              flex: 1,
-                              backgroundColor: theme.preview.surface,
-                            }}
-                          />
-                          <div
-                            style={{
-                              flex: 1,
-                              backgroundColor: theme.preview.accent,
-                            }}
-                          />
-                          <div
-                            style={{
-                              flex: 1,
-                              backgroundColor: theme.preview.text,
-                            }}
-                          />
-                        </div>
-                        <div style={{padding: '12px 16px'}}>
-                          <XDSText type="body" weight="bold">
-                            {theme.name}
-                          </XDSText>
-                          {theme.description && (
-                            <XDSText
-                              type="supporting"
-                              color="secondary"
-                              style={{marginTop: 2}}>
-                              {theme.description}
-                            </XDSText>
-                          )}
-                        </div>
-                      </XDSCard>
-                    ))}
-                  </div>
-
-                  <div style={{marginBottom: 16}}>
-                    <XDSText type="label" color="secondary">
-                      Community
-                    </XDSText>
-                  </div>
-                  <div
-                    style={{
-                      display: 'grid',
-                      gridTemplateColumns: isMobile
-                        ? '1fr'
-                        : isTablet
-                          ? 'repeat(2, 1fr)'
-                          : 'repeat(3, 1fr)',
-                      gap: 16,
-                    }}>
-                    {THEME_PICKER_ENTRIES.filter(
-                      t => t.category === 'community',
-                    ).map((theme, i) => (
-                      <XDSCard
-                        key={theme.key}
-                        padding={0}
-                        style={{
-                          overflow: 'hidden',
-                          cursor: 'pointer',
-                          animation: `craftCardFadeIn 400ms ${i * 60}ms cubic-bezier(0.16, 1, 0.3, 1) both`,
-                        }}
-                        onClick={() => setActiveView('theme')}>
-                        <div
-                          style={{
-                            height: 80,
-                            display: 'flex',
-                          }}>
-                          <div
-                            style={{
-                              flex: 1,
-                              backgroundColor: theme.preview.bg,
-                            }}
-                          />
-                          <div
-                            style={{
-                              flex: 1,
-                              backgroundColor: theme.preview.surface,
-                            }}
-                          />
-                          <div
-                            style={{
-                              flex: 1,
-                              backgroundColor: theme.preview.accent,
-                            }}
-                          />
-                          <div
-                            style={{
-                              flex: 1,
-                              backgroundColor: theme.preview.text,
-                            }}
-                          />
-                        </div>
-                        <div style={{padding: '12px 16px'}}>
-                          <XDSText type="body" weight="bold">
-                            {theme.name}
-                          </XDSText>
-                          {theme.description && (
-                            <XDSText
-                              type="supporting"
-                              color="secondary"
-                              style={{marginTop: 2}}>
-                              {theme.description}
-                            </XDSText>
-                          )}
-                        </div>
-                      </XDSCard>
-                    ))}
-                  </div>
+                  {THEME_PICKER_ENTRIES.map((theme, i) => (
+                    <ThemeCard
+                      key={theme.key}
+                      theme={theme}
+                      index={i}
+                      onCustomize={() => setActiveView('theme')}
+                    />
+                  ))}
                 </div>
               )}
 

--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
@@ -208,6 +208,7 @@ function ThemeCard({
                   fontSize: 18,
                   fontWeight: 700,
                   letterSpacing: '0.04em',
+                  fontFamily: theme.preview.font ?? 'system-ui, sans-serif',
                   color: theme.preview.text,
                   opacity: 0.7,
                   flexShrink: 0,

--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
@@ -202,16 +202,18 @@ function ThemeCard({
                 padding: '3% 4%',
                 borderBottom: `1px solid ${theme.preview.surface}`,
               }}>
-              <div
+              <span
                 style={{
-                  width: '5%',
-                  height: 0,
-                  paddingBottom: '5%',
-                  borderRadius: '50%',
-                  backgroundColor: theme.preview.accent,
+                  fontSize: 9,
+                  fontWeight: 700,
+                  letterSpacing: '0.04em',
+                  color: theme.preview.text,
+                  opacity: 0.7,
                   flexShrink: 0,
-                }}
-              />
+                  lineHeight: 1,
+                }}>
+                {theme.name}
+              </span>
               <div
                 style={{
                   flex: 1,

--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
@@ -1790,7 +1790,7 @@ function DocsiteLandingTemplate() {
           </div>
         </div>
       </div>
-      {!chatOpen && <AIComposer />}
+      {!chatOpen && <AIComposer onThemeMode={() => setActiveView('theme')} />}
       {/* Bottom drawer overlay */}
       {previewTarget !== null &&
         (() => {

--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
@@ -17,6 +17,7 @@ import {
   XDS_DESIGN_AVATAR,
   FILTER_COLUMNS,
   PROFILE_CRAFT_ITEMS,
+  THEME_PICKER_ENTRIES,
 } from './constants';
 import {TemplateCard} from './TemplateCard';
 import {AIComposer} from './AIComposer';
@@ -1178,46 +1179,50 @@ function DocsiteLandingTemplate() {
                     <XDSTab value="components" label="Components" />
                   </XDSTabList>
                   <div style={{justifySelf: 'end', display: 'flex', gap: 4}}>
-                    <XDSButton
-                      label="Filter"
-                      variant="ghost"
-                      size="sm"
-                      isIconOnly
-                      icon={<FilterIcon />}
-                      onClick={() => setIsFilterOpen(!isFilterOpen)}
-                    />
-                    <XDSDropdownMenu
-                      button={{
-                        label:
-                          sortOption === 'trending'
-                            ? 'Trending'
-                            : sortOption === 'newest'
-                              ? 'Newest first'
-                              : 'Oldest first',
-                        variant: 'ghost',
-                        size: 'sm',
-                      }}
-                      items={[
-                        {
-                          label: 'Trending',
-                          onClick: () => setSortOption('trending'),
-                        },
-                        {
-                          label: 'Newest first',
-                          onClick: () => setSortOption('newest'),
-                        },
-                        {
-                          label: 'Oldest first',
-                          onClick: () => setSortOption('oldest'),
-                        },
-                      ]}
-                    />
+                    {activeTab !== 'theme' && (
+                      <>
+                        <XDSButton
+                          label="Filter"
+                          variant="ghost"
+                          size="sm"
+                          isIconOnly
+                          icon={<FilterIcon />}
+                          onClick={() => setIsFilterOpen(!isFilterOpen)}
+                        />
+                        <XDSDropdownMenu
+                          button={{
+                            label:
+                              sortOption === 'trending'
+                                ? 'Trending'
+                                : sortOption === 'newest'
+                                  ? 'Newest first'
+                                  : 'Oldest first',
+                            variant: 'ghost',
+                            size: 'sm',
+                          }}
+                          items={[
+                            {
+                              label: 'Trending',
+                              onClick: () => setSortOption('trending'),
+                            },
+                            {
+                              label: 'Newest first',
+                              onClick: () => setSortOption('newest'),
+                            },
+                            {
+                              label: 'Oldest first',
+                              onClick: () => setSortOption('oldest'),
+                            },
+                          ]}
+                        />
+                      </>
+                    )}
                   </div>
                 </div>
               )}
 
               {/* Filter panel — sticky, independent of tab row */}
-              {!craftTitle && isFilterOpen && (
+              {!craftTitle && isFilterOpen && activeTab !== 'theme' && (
                 <div
                   style={{
                     position: 'sticky',
@@ -1289,277 +1294,498 @@ function DocsiteLandingTemplate() {
               )}
 
               {/* Active filter chips */}
-              {!craftTitle && activeFilters.size > 0 && (
+              {!craftTitle &&
+                activeFilters.size > 0 &&
+                activeTab !== 'theme' && (
+                  <div
+                    style={{
+                      maxWidth: 2000,
+                      margin: '0 auto 16px',
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 8,
+                      flexWrap: 'wrap',
+                    }}>
+                    {Array.from(activeFilters).map(filter => (
+                      <XDSToken
+                        key={filter}
+                        label={filter}
+                        onRemove={() => handleToggleFilter(filter)}
+                      />
+                    ))}
+                    <XDSText type="supporting">
+                      <XDSLink
+                        label="Clear all"
+                        color="secondary"
+                        onClick={handleClearFilters}>
+                        Clear all
+                      </XDSLink>
+                    </XDSText>
+                  </div>
+                )}
+
+              {/* Theme tab content */}
+              {!craftTitle && activeTab === 'theme' && (
                 <div
                   style={{
                     maxWidth: 2000,
-                    margin: '0 auto 16px',
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: 8,
-                    flexWrap: 'wrap',
+                    margin: '0 auto',
                   }}>
-                  {Array.from(activeFilters).map(filter => (
-                    <XDSToken
-                      key={filter}
-                      label={filter}
-                      onRemove={() => handleToggleFilter(filter)}
-                    />
-                  ))}
-                  <XDSText type="supporting">
-                    <XDSLink
-                      label="Clear all"
-                      color="secondary"
-                      onClick={handleClearFilters}>
-                      Clear all
-                    </XDSLink>
-                  </XDSText>
+                  <XDSCard
+                    padding={0}
+                    style={{
+                      marginBottom: 32,
+                      overflow: 'hidden',
+                    }}>
+                    <div
+                      style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 32,
+                        padding: '40px 48px',
+                        background:
+                          'linear-gradient(135deg, var(--color-background-surface, #f5f5f5) 0%, var(--color-background-muted, #e8e8e8) 100%)',
+                      }}>
+                      <div style={{flex: 1}}>
+                        <XDSHeading level={2}>Make it yours</XDSHeading>
+                        <XDSText
+                          type="body"
+                          color="secondary"
+                          style={{marginTop: 8, maxWidth: 480}}>
+                          Customize colors, typography, spacing, and more to
+                          match your brand. Start from an official theme or
+                          build one from scratch.
+                        </XDSText>
+                        <div style={{marginTop: 20}}>
+                          <XDSButton
+                            label="Open Theme Editor"
+                            icon={<PaletteIcon />}
+                            onClick={() => setActiveView('theme')}
+                          />
+                        </div>
+                      </div>
+                      <div
+                        style={{
+                          display: 'flex',
+                          gap: 6,
+                          flexShrink: 0,
+                        }}>
+                        {['#0066FF', '#1DAA61', '#E5484D', '#818CF8'].map(
+                          color => (
+                            <div
+                              key={color}
+                              style={{
+                                width: 32,
+                                height: 64,
+                                borderRadius: 8,
+                                backgroundColor: color,
+                              }}
+                            />
+                          ),
+                        )}
+                      </div>
+                    </div>
+                  </XDSCard>
+
+                  <div style={{marginBottom: 16}}>
+                    <XDSText type="label" color="secondary">
+                      Official
+                    </XDSText>
+                  </div>
+                  <div
+                    style={{
+                      display: 'grid',
+                      gridTemplateColumns: isMobile
+                        ? '1fr'
+                        : isTablet
+                          ? 'repeat(2, 1fr)'
+                          : 'repeat(3, 1fr)',
+                      gap: 16,
+                      marginBottom: 32,
+                    }}>
+                    {THEME_PICKER_ENTRIES.filter(
+                      t => t.category === 'official',
+                    ).map((theme, i) => (
+                      <XDSCard
+                        key={theme.key}
+                        padding={0}
+                        style={{
+                          overflow: 'hidden',
+                          cursor: 'pointer',
+                          animation: `craftCardFadeIn 400ms ${i * 60}ms cubic-bezier(0.16, 1, 0.3, 1) both`,
+                        }}
+                        onClick={() => setActiveView('theme')}>
+                        <div
+                          style={{
+                            height: 80,
+                            display: 'flex',
+                          }}>
+                          <div
+                            style={{
+                              flex: 1,
+                              backgroundColor: theme.preview.bg,
+                            }}
+                          />
+                          <div
+                            style={{
+                              flex: 1,
+                              backgroundColor: theme.preview.surface,
+                            }}
+                          />
+                          <div
+                            style={{
+                              flex: 1,
+                              backgroundColor: theme.preview.accent,
+                            }}
+                          />
+                          <div
+                            style={{
+                              flex: 1,
+                              backgroundColor: theme.preview.text,
+                            }}
+                          />
+                        </div>
+                        <div style={{padding: '12px 16px'}}>
+                          <XDSText type="body" weight="bold">
+                            {theme.name}
+                          </XDSText>
+                          {theme.description && (
+                            <XDSText
+                              type="supporting"
+                              color="secondary"
+                              style={{marginTop: 2}}>
+                              {theme.description}
+                            </XDSText>
+                          )}
+                        </div>
+                      </XDSCard>
+                    ))}
+                  </div>
+
+                  <div style={{marginBottom: 16}}>
+                    <XDSText type="label" color="secondary">
+                      Community
+                    </XDSText>
+                  </div>
+                  <div
+                    style={{
+                      display: 'grid',
+                      gridTemplateColumns: isMobile
+                        ? '1fr'
+                        : isTablet
+                          ? 'repeat(2, 1fr)'
+                          : 'repeat(3, 1fr)',
+                      gap: 16,
+                    }}>
+                    {THEME_PICKER_ENTRIES.filter(
+                      t => t.category === 'community',
+                    ).map((theme, i) => (
+                      <XDSCard
+                        key={theme.key}
+                        padding={0}
+                        style={{
+                          overflow: 'hidden',
+                          cursor: 'pointer',
+                          animation: `craftCardFadeIn 400ms ${i * 60}ms cubic-bezier(0.16, 1, 0.3, 1) both`,
+                        }}
+                        onClick={() => setActiveView('theme')}>
+                        <div
+                          style={{
+                            height: 80,
+                            display: 'flex',
+                          }}>
+                          <div
+                            style={{
+                              flex: 1,
+                              backgroundColor: theme.preview.bg,
+                            }}
+                          />
+                          <div
+                            style={{
+                              flex: 1,
+                              backgroundColor: theme.preview.surface,
+                            }}
+                          />
+                          <div
+                            style={{
+                              flex: 1,
+                              backgroundColor: theme.preview.accent,
+                            }}
+                          />
+                          <div
+                            style={{
+                              flex: 1,
+                              backgroundColor: theme.preview.text,
+                            }}
+                          />
+                        </div>
+                        <div style={{padding: '12px 16px'}}>
+                          <XDSText type="body" weight="bold">
+                            {theme.name}
+                          </XDSText>
+                          {theme.description && (
+                            <XDSText
+                              type="supporting"
+                              color="secondary"
+                              style={{marginTop: 2}}>
+                              {theme.description}
+                            </XDSText>
+                          )}
+                        </div>
+                      </XDSCard>
+                    ))}
+                  </div>
                 </div>
               )}
 
               {/* Template grid */}
-              {craftLoading ? (
-                <div
-                  style={{
-                    maxWidth: 2000,
-                    margin: '0 auto',
-                    display: 'grid',
-                    gridTemplateColumns: isMobile
-                      ? '1fr'
-                      : isTablet
-                        ? 'repeat(2, 1fr)'
-                        : 'repeat(3, 1fr)',
-                    gap: 16,
-                  }}>
-                  {Array.from({length: 8}).map((_, i) => (
-                    <div
-                      key={i}
-                      style={{
-                        borderRadius: 16,
-                        overflow: 'hidden',
-                        animation: `craftCardFadeIn 400ms ${i * 60}ms cubic-bezier(0.16, 1, 0.3, 1) both`,
-                      }}>
+              {(craftTitle || activeTab !== 'theme') &&
+                (craftLoading ? (
+                  <div
+                    style={{
+                      maxWidth: 2000,
+                      margin: '0 auto',
+                      display: 'grid',
+                      gridTemplateColumns: isMobile
+                        ? '1fr'
+                        : isTablet
+                          ? 'repeat(2, 1fr)'
+                          : 'repeat(3, 1fr)',
+                      gap: 16,
+                    }}>
+                    {Array.from({length: 8}).map((_, i) => (
                       <div
+                        key={i}
                         style={{
-                          aspectRatio: '4 / 3',
-                          background:
-                            'linear-gradient(90deg, var(--color-background-muted, #f0f0f0) 0%, var(--color-background-surface, #fafafa) 50%, var(--color-background-muted, #f0f0f0) 100%)',
-                          backgroundSize: '800px 100%',
-                          animation: 'craftShimmer 1.6s ease-in-out infinite',
-                          borderRadius: '16px 16px 0 0',
-                        }}
-                      />
-                      <div
-                        style={{
-                          padding: 16,
-                          display: 'flex',
-                          flexDirection: 'column',
-                          gap: 10,
-                        }}>
-                        <div
-                          style={{
-                            height: 14,
-                            width: '60%',
-                            borderRadius: 6,
-                            background:
-                              'linear-gradient(90deg, var(--color-background-muted, #f0f0f0) 0%, var(--color-background-surface, #fafafa) 50%, var(--color-background-muted, #f0f0f0) 100%)',
-                            backgroundSize: '800px 100%',
-                            animation: 'craftShimmer 1.6s ease-in-out infinite',
-                          }}
-                        />
-                        <div
-                          style={{
-                            height: 10,
-                            width: '40%',
-                            borderRadius: 6,
-                            background:
-                              'linear-gradient(90deg, var(--color-background-muted, #f0f0f0) 0%, var(--color-background-surface, #fafafa) 50%, var(--color-background-muted, #f0f0f0) 100%)',
-                            backgroundSize: '800px 100%',
-                            animation: 'craftShimmer 1.6s ease-in-out infinite',
-                          }}
-                        />
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              ) : isCraftResults ? (
-                <div
-                  style={{
-                    maxWidth: 2000,
-                    margin: '0 auto',
-                    display: 'grid',
-                    gridTemplateColumns: isMobile
-                      ? '1fr'
-                      : isTablet
-                        ? 'repeat(2, 1fr)'
-                        : 'repeat(3, 1fr)',
-                    gap: 16,
-                  }}>
-                  {filteredCraftItems.map((item, i) => (
-                    <XDSCard
-                      key={item.name}
-                      padding={0}
-                      style={{
-                        overflow: 'hidden',
-                        animation: `craftCardFadeIn 400ms ${i * 60}ms cubic-bezier(0.16, 1, 0.3, 1) both`,
-                      }}>
-                      <div
-                        style={{
-                          aspectRatio: '16 / 9',
+                          borderRadius: 16,
                           overflow: 'hidden',
-                          backgroundColor:
-                            'var(--color-background-muted, #f0f0f0)',
+                          animation: `craftCardFadeIn 400ms ${i * 60}ms cubic-bezier(0.16, 1, 0.3, 1) both`,
                         }}>
-                        <img
-                          src={item.img}
-                          alt={item.name}
+                        <div
                           style={{
-                            width: '100%',
-                            height: '100%',
-                            objectFit: 'cover',
-                            objectPosition: 'top',
-                            display: 'block',
+                            aspectRatio: '4 / 3',
+                            background:
+                              'linear-gradient(90deg, var(--color-background-muted, #f0f0f0) 0%, var(--color-background-surface, #fafafa) 50%, var(--color-background-muted, #f0f0f0) 100%)',
+                            backgroundSize: '800px 100%',
+                            animation: 'craftShimmer 1.6s ease-in-out infinite',
+                            borderRadius: '16px 16px 0 0',
                           }}
                         />
-                      </div>
-                      <div style={{padding: 16}}>
                         <div
                           style={{
+                            padding: 16,
                             display: 'flex',
-                            alignItems: 'center',
-                            justifyContent: 'space-between',
-                            gap: 8,
+                            flexDirection: 'column',
+                            gap: 10,
                           }}>
-                          <XDSText type="body" weight="bold">
-                            {item.name}
-                          </XDSText>
-                          <span
+                          <div
                             style={{
-                              fontSize: 11,
-                              fontWeight: 600,
-                              padding: '2px 8px',
-                              borderRadius: 9999,
-                              whiteSpace: 'nowrap' as const,
-                              flexShrink: 0,
-                              backgroundColor:
-                                item.status === 'Published'
-                                  ? '#ECFDF3'
-                                  : item.status === 'In Review'
-                                    ? '#FFFAEB'
-                                    : '#F2F4F7',
-                              color:
-                                item.status === 'Published'
-                                  ? '#027A48'
-                                  : item.status === 'In Review'
-                                    ? '#B54708'
-                                    : '#667085',
-                            }}>
-                            {item.status}
-                          </span>
-                        </div>
-                        <div style={{marginTop: 4}}>
-                          <XDSText type="supporting" color="secondary">
-                            {item.type}
-                          </XDSText>
-                        </div>
-                        <div
-                          style={{
-                            display: 'flex',
-                            alignItems: 'center',
-                            gap: 16,
-                            marginTop: 12,
-                          }}>
-                          <div>
-                            <XDSText type="supporting" color="secondary">
-                              {item.used} uses
-                            </XDSText>
-                          </div>
-                          <div>
-                            <XDSText type="supporting" color="secondary">
-                              {item.views} views
-                            </XDSText>
-                          </div>
-                          <div style={{marginLeft: 'auto'}}>
-                            <XDSText type="supporting" color="secondary">
-                              {new Date(item.lastUpdated).toLocaleDateString(
-                                'en-US',
-                                {month: 'short', day: 'numeric'},
-                              )}
-                            </XDSText>
-                          </div>
+                              height: 14,
+                              width: '60%',
+                              borderRadius: 6,
+                              background:
+                                'linear-gradient(90deg, var(--color-background-muted, #f0f0f0) 0%, var(--color-background-surface, #fafafa) 50%, var(--color-background-muted, #f0f0f0) 100%)',
+                              backgroundSize: '800px 100%',
+                              animation:
+                                'craftShimmer 1.6s ease-in-out infinite',
+                            }}
+                          />
+                          <div
+                            style={{
+                              height: 10,
+                              width: '40%',
+                              borderRadius: 6,
+                              background:
+                                'linear-gradient(90deg, var(--color-background-muted, #f0f0f0) 0%, var(--color-background-surface, #fafafa) 50%, var(--color-background-muted, #f0f0f0) 100%)',
+                              backgroundSize: '800px 100%',
+                              animation:
+                                'craftShimmer 1.6s ease-in-out infinite',
+                            }}
+                          />
                         </div>
                       </div>
-                    </XDSCard>
-                  ))}
-                  {filteredCraftItems.length === 0 && (
-                    <div
-                      style={{
-                        gridColumn: '1 / -1',
-                        padding: 32,
-                        textAlign: 'center' as const,
-                      }}>
-                      <XDSText type="body" color="secondary">
-                        No items match this filter.
-                      </XDSText>
-                    </div>
-                  )}
-                </div>
-              ) : (
-                <div
-                  style={{
-                    maxWidth: 2000,
-                    margin: '0 auto',
-                    display: 'grid',
-                    gridTemplateColumns: isMobile
-                      ? '1fr'
-                      : isTablet
-                        ? 'repeat(2, 1fr)'
-                        : 'repeat(3, 1fr)',
-                    gap: 16,
-                  }}>
-                  {filteredTemplates.map((template, i) => (
-                    <div
-                      key={`${template.name}-${template.originalIndex}`}
-                      style={{
-                        ...(craftTitle
-                          ? {
-                              animation: `craftCardFadeIn 400ms ${i * 50}ms cubic-bezier(0.16, 1, 0.3, 1) both`,
-                            }
-                          : undefined),
-                        filter: previewImageFilter,
-                        transition: 'filter 300ms ease',
-                      }}>
-                      <TemplateCard
-                        src={template.src}
-                        slug={template.slug}
-                        name={template.name}
-                        isSelected={selected.has(template.originalIndex)}
-                        isGenerating={
-                          isGenerating &&
-                          generatingSource !== template.originalIndex
-                        }
-                        cardSize={template.size}
-                        onSelect={() =>
-                          setSelected(prev => {
-                            const next = new Set(prev);
-                            if (next.has(template.originalIndex)) {
-                              next.delete(template.originalIndex);
-                            } else {
-                              next.add(template.originalIndex);
-                            }
-                            return next;
-                          })
-                        }
-                        onMoreLikeThis={() =>
-                          handleMoreLikeThis(template.originalIndex)
-                        }
-                        onUse={() => handleUse(template.originalIndex)}
-                        onPreview={() => handlePreview(template.originalIndex)}
-                      />
-                    </div>
-                  ))}
-                </div>
-              )}
+                    ))}
+                  </div>
+                ) : isCraftResults ? (
+                  <div
+                    style={{
+                      maxWidth: 2000,
+                      margin: '0 auto',
+                      display: 'grid',
+                      gridTemplateColumns: isMobile
+                        ? '1fr'
+                        : isTablet
+                          ? 'repeat(2, 1fr)'
+                          : 'repeat(3, 1fr)',
+                      gap: 16,
+                    }}>
+                    {filteredCraftItems.map((item, i) => (
+                      <XDSCard
+                        key={item.name}
+                        padding={0}
+                        style={{
+                          overflow: 'hidden',
+                          animation: `craftCardFadeIn 400ms ${i * 60}ms cubic-bezier(0.16, 1, 0.3, 1) both`,
+                        }}>
+                        <div
+                          style={{
+                            aspectRatio: '16 / 9',
+                            overflow: 'hidden',
+                            backgroundColor:
+                              'var(--color-background-muted, #f0f0f0)',
+                          }}>
+                          <img
+                            src={item.img}
+                            alt={item.name}
+                            style={{
+                              width: '100%',
+                              height: '100%',
+                              objectFit: 'cover',
+                              objectPosition: 'top',
+                              display: 'block',
+                            }}
+                          />
+                        </div>
+                        <div style={{padding: 16}}>
+                          <div
+                            style={{
+                              display: 'flex',
+                              alignItems: 'center',
+                              justifyContent: 'space-between',
+                              gap: 8,
+                            }}>
+                            <XDSText type="body" weight="bold">
+                              {item.name}
+                            </XDSText>
+                            <span
+                              style={{
+                                fontSize: 11,
+                                fontWeight: 600,
+                                padding: '2px 8px',
+                                borderRadius: 9999,
+                                whiteSpace: 'nowrap' as const,
+                                flexShrink: 0,
+                                backgroundColor:
+                                  item.status === 'Published'
+                                    ? '#ECFDF3'
+                                    : item.status === 'In Review'
+                                      ? '#FFFAEB'
+                                      : '#F2F4F7',
+                                color:
+                                  item.status === 'Published'
+                                    ? '#027A48'
+                                    : item.status === 'In Review'
+                                      ? '#B54708'
+                                      : '#667085',
+                              }}>
+                              {item.status}
+                            </span>
+                          </div>
+                          <div style={{marginTop: 4}}>
+                            <XDSText type="supporting" color="secondary">
+                              {item.type}
+                            </XDSText>
+                          </div>
+                          <div
+                            style={{
+                              display: 'flex',
+                              alignItems: 'center',
+                              gap: 16,
+                              marginTop: 12,
+                            }}>
+                            <div>
+                              <XDSText type="supporting" color="secondary">
+                                {item.used} uses
+                              </XDSText>
+                            </div>
+                            <div>
+                              <XDSText type="supporting" color="secondary">
+                                {item.views} views
+                              </XDSText>
+                            </div>
+                            <div style={{marginLeft: 'auto'}}>
+                              <XDSText type="supporting" color="secondary">
+                                {new Date(item.lastUpdated).toLocaleDateString(
+                                  'en-US',
+                                  {month: 'short', day: 'numeric'},
+                                )}
+                              </XDSText>
+                            </div>
+                          </div>
+                        </div>
+                      </XDSCard>
+                    ))}
+                    {filteredCraftItems.length === 0 && (
+                      <div
+                        style={{
+                          gridColumn: '1 / -1',
+                          padding: 32,
+                          textAlign: 'center' as const,
+                        }}>
+                        <XDSText type="body" color="secondary">
+                          No items match this filter.
+                        </XDSText>
+                      </div>
+                    )}
+                  </div>
+                ) : (
+                  <div
+                    style={{
+                      maxWidth: 2000,
+                      margin: '0 auto',
+                      display: 'grid',
+                      gridTemplateColumns: isMobile
+                        ? '1fr'
+                        : isTablet
+                          ? 'repeat(2, 1fr)'
+                          : 'repeat(3, 1fr)',
+                      gap: 16,
+                    }}>
+                    {filteredTemplates.map((template, i) => (
+                      <div
+                        key={`${template.name}-${template.originalIndex}`}
+                        style={{
+                          ...(craftTitle
+                            ? {
+                                animation: `craftCardFadeIn 400ms ${i * 50}ms cubic-bezier(0.16, 1, 0.3, 1) both`,
+                              }
+                            : undefined),
+                          filter: previewImageFilter,
+                          transition: 'filter 300ms ease',
+                        }}>
+                        <TemplateCard
+                          src={template.src}
+                          slug={template.slug}
+                          name={template.name}
+                          isSelected={selected.has(template.originalIndex)}
+                          isGenerating={
+                            isGenerating &&
+                            generatingSource !== template.originalIndex
+                          }
+                          cardSize={template.size}
+                          onSelect={() =>
+                            setSelected(prev => {
+                              const next = new Set(prev);
+                              if (next.has(template.originalIndex)) {
+                                next.delete(template.originalIndex);
+                              } else {
+                                next.add(template.originalIndex);
+                              }
+                              return next;
+                            })
+                          }
+                          onMoreLikeThis={() =>
+                            handleMoreLikeThis(template.originalIndex)
+                          }
+                          onUse={() => handleUse(template.originalIndex)}
+                          onPreview={() =>
+                            handlePreview(template.originalIndex)
+                          }
+                        />
+                      </div>
+                    ))}
+                  </div>
+                ))}
             </div>
           </div>
         </div>

--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
@@ -158,7 +158,7 @@ function SearchableFilterDropdown({
 
 export default function DocsiteLandingPage() {
   return (
-    <Suspense>
+    <Suspense fallback={null}>
       <DocsiteLandingTemplate />
     </Suspense>
   );
@@ -398,6 +398,7 @@ function DocsiteLandingTemplate() {
     }
 
     const qs = params.toString();
+    if (qs === window.location.search.slice(1)) return;
     router.replace(`/pages/docsite/${qs ? '?' + qs : ''}`, {scroll: false});
   }, [
     previewTarget,

--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
@@ -204,7 +204,7 @@ function ThemeCard({
               }}>
               <span
                 style={{
-                  fontSize: 9,
+                  fontSize: 18,
                   fontWeight: 700,
                   letterSpacing: '0.04em',
                   color: theme.preview.text,

--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
@@ -169,6 +169,7 @@ function ThemeCard({
   onCustomize: () => void;
 }) {
   const [hovered, setHovered] = useState(false);
+  const r = theme.preview.radius ?? 8;
 
   return (
     <div
@@ -252,7 +253,7 @@ function ThemeCard({
                     style={{
                       height: 0,
                       paddingBottom: '16%',
-                      borderRadius: 3,
+                      borderRadius: Math.max(r * 0.4, 2),
                       backgroundColor: active
                         ? theme.preview.accent
                         : theme.preview.text,
@@ -284,7 +285,7 @@ function ThemeCard({
                       key={j}
                       style={{
                         backgroundColor: theme.preview.surface,
-                        borderRadius: 4,
+                        borderRadius: r,
                         padding: '10%',
                         display: 'flex',
                         flexDirection: 'column',
@@ -295,7 +296,7 @@ function ThemeCard({
                           height: 0,
                           paddingBottom: '12%',
                           width: '60%',
-                          borderRadius: 2,
+                          borderRadius: Math.max(r * 0.25, 1),
                           backgroundColor: theme.preview.text,
                           opacity: 0.7,
                         }}
@@ -305,7 +306,7 @@ function ThemeCard({
                           height: 0,
                           paddingBottom: '8%',
                           width: '90%',
-                          borderRadius: 2,
+                          borderRadius: Math.max(r * 0.25, 1),
                           backgroundColor: theme.preview.text,
                           opacity: 0.15,
                         }}
@@ -315,7 +316,7 @@ function ThemeCard({
                           height: 0,
                           paddingBottom: '8%',
                           width: '70%',
-                          borderRadius: 2,
+                          borderRadius: Math.max(r * 0.25, 1),
                           backgroundColor: theme.preview.text,
                           opacity: 0.15,
                         }}
@@ -329,7 +330,7 @@ function ThemeCard({
                     height: 0,
                     paddingBottom: '5%',
                     width: '30%',
-                    borderRadius: 4,
+                    borderRadius: Math.max(r * 0.5, 2),
                     backgroundColor: theme.preview.accent,
                   }}
                 />

--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
@@ -1809,49 +1809,64 @@ function DocsiteLandingTemplate() {
                           : 'repeat(3, 1fr)',
                       gap: 16,
                     }}>
-                    {filteredTemplates.map((template, i) => (
-                      <div
-                        key={`${template.name}-${template.originalIndex}`}
-                        style={{
-                          ...(craftTitle
-                            ? {
-                                animation: `craftCardFadeIn 400ms ${i * 50}ms cubic-bezier(0.16, 1, 0.3, 1) both`,
-                              }
-                            : undefined),
-                          filter: previewImageFilter,
-                          transition: 'filter 300ms ease',
-                        }}>
-                        <TemplateCard
-                          src={template.src}
-                          slug={template.slug}
-                          name={template.name}
-                          isSelected={selected.has(template.originalIndex)}
-                          isGenerating={
-                            isGenerating &&
-                            generatingSource !== template.originalIndex
-                          }
-                          cardSize={template.size}
-                          onSelect={() =>
-                            setSelected(prev => {
-                              const next = new Set(prev);
-                              if (next.has(template.originalIndex)) {
-                                next.delete(template.originalIndex);
-                              } else {
-                                next.add(template.originalIndex);
-                              }
-                              return next;
-                            })
-                          }
-                          onMoreLikeThis={() =>
-                            handleMoreLikeThis(template.originalIndex)
-                          }
-                          onUse={() => handleUse(template.originalIndex)}
-                          onPreview={() =>
-                            handlePreview(template.originalIndex)
-                          }
-                        />
-                      </div>
-                    ))}
+                    {filteredTemplates.flatMap((template, i) => {
+                      const items = [
+                        <div
+                          key={`${template.name}-${template.originalIndex}`}
+                          style={{
+                            ...(craftTitle
+                              ? {
+                                  animation: `craftCardFadeIn 400ms ${i * 50}ms cubic-bezier(0.16, 1, 0.3, 1) both`,
+                                }
+                              : undefined),
+                            filter: previewImageFilter,
+                            transition: 'filter 300ms ease',
+                          }}>
+                          <TemplateCard
+                            src={template.src}
+                            slug={template.slug}
+                            name={template.name}
+                            isSelected={selected.has(template.originalIndex)}
+                            isGenerating={
+                              isGenerating &&
+                              generatingSource !== template.originalIndex
+                            }
+                            cardSize={template.size}
+                            onSelect={() =>
+                              setSelected(prev => {
+                                const next = new Set(prev);
+                                if (next.has(template.originalIndex)) {
+                                  next.delete(template.originalIndex);
+                                } else {
+                                  next.add(template.originalIndex);
+                                }
+                                return next;
+                              })
+                            }
+                            onMoreLikeThis={() =>
+                              handleMoreLikeThis(template.originalIndex)
+                            }
+                            onUse={() => handleUse(template.originalIndex)}
+                            onPreview={() =>
+                              handlePreview(template.originalIndex)
+                            }
+                          />
+                        </div>,
+                      ];
+                      if (activeTab === 'all' && i === 2) {
+                        items.push(
+                          ...THEME_PICKER_ENTRIES.slice(0, 2).map((t, ti) => (
+                            <ThemeCard
+                              key={`theme-${t.key}`}
+                              theme={t}
+                              index={i + ti + 1}
+                              onCustomize={() => setActiveView('theme')}
+                            />
+                          )),
+                        );
+                      }
+                      return items;
+                    })}
                   </div>
                 ))}
             </div>

--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
@@ -1793,7 +1793,7 @@ function DocsiteLandingTemplate() {
       </div>
       {!chatOpen && (
         <AIComposer
-          mode={activeTab === 'theme' ? 'theme' : 'template'}
+          tabMode={activeTab === 'theme' ? 'theme' : 'template'}
           onThemeMode={() => setActiveView('theme')}
         />
       )}

--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
@@ -21,6 +21,7 @@ import {
 } from './constants';
 import {TemplateCard} from './TemplateCard';
 import {AIComposer} from './AIComposer';
+import type {ComposerMode} from './AIComposer';
 import {ChatPanel} from './ChatPanel';
 import type {PanelTab, PointedElement} from './ChatPanel';
 import {InlinePublishPanel} from './InlinePublishPanel';
@@ -1790,7 +1791,15 @@ function DocsiteLandingTemplate() {
           </div>
         </div>
       </div>
-      {!chatOpen && <AIComposer onThemeMode={() => setActiveView('theme')} />}
+      {!chatOpen && (
+        <AIComposer
+          mode={activeTab === 'theme' ? 'theme' : 'template'}
+          onModeChange={(m: ComposerMode) =>
+            setActiveTab(m === 'theme' ? 'theme' : 'all')
+          }
+          onThemeMode={() => setActiveView('theme')}
+        />
+      )}
       {/* Bottom drawer overlay */}
       {previewTarget !== null &&
         (() => {


### PR DESCRIPTION
## Summary

- **Fix double loading on docsite page**: The URL-sync `useEffect` was calling `router.replace()` on mount with the same query string already in the URL, causing `useSearchParams()` to return a new reference and re-render the entire page. Added a guard to skip the replace when the URL already matches.

- **Theme editor entry from craft "Theme" tab**: When the Theme tab is selected, a grid of theme preview cards replaces the template grid. Each card shows a design preview image tinted with the theme's accent color, the theme name in the theme's font, and a hover overlay with description and "Customize" button.

- **Composer mode switcher**: Added a dropdown menu in the composer footer that lets users toggle between Template and Theme mode. The craft tabs drive the composer mode (switching to Theme tab auto-toggles the composer), but users can also toggle it independently.

- **Theme cards on the All tab**: Forest and Midnight theme cards are mixed into the All tab template grid after the 3rd card for discoverability.

- **Removed Theme Editor from nav dropdown**: Now that there are proper entry points (tab + composer), the "Temporary" dropdown item is removed.

## Test plan

- [ ] Visit `/pages/docsite/?page=docs` — confirm no visible double-render flash
- [ ] Click the "Theme" tab — confirm theme cards appear with tinted preview images
- [ ] Hover a theme card — confirm overlay shows name, description, category badge, and Customize button
- [ ] Click "Customize" — confirm it opens the ThemeEditorView
- [ ] Switch back to "All" tab — confirm Forest and Midnight theme cards appear in the grid
- [ ] Check the composer dropdown at bottom-left — confirm it shows Template/Theme toggle
- [ ] Switch composer to Theme mode — confirm placeholder changes to "Describe your brand or style..."
- [ ] Submit in Theme mode — confirm it navigates to ThemeEditorView
- [ ] Switch between tabs — confirm composer mode syncs with the active tab
- [ ] Open the XDS logo dropdown — confirm "Theme Editor" item is removed