### PR TITLE
Improve Tooltip docs page and block examples

### DIFF
--- a/packages/cli/templates/blocks/components/Tooltip/TooltipActionBarTooltips.doc.mjs
+++ b/packages/cli/templates/blocks/components/Tooltip/TooltipActionBarTooltips.doc.mjs
@@ -3,8 +3,8 @@ export const doc = {
   type: 'block',
   name: 'Tooltip — Action Bar',
   description:
-    'Multiple tooltips on an action button bar with contextual descriptions.',
+    'Tooltips on an action button bar with contextual descriptions.',
   isReady: true,
   aspectRatio: 4 / 3,
-  componentsUsed: ['Tooltip', 'Button', 'HStack'],
+  componentsUsed: ['Tooltip', 'Button', 'HStack', 'Center'],
 };

--- a/packages/cli/templates/blocks/components/Tooltip/TooltipActionBarTooltips.tsx
+++ b/packages/cli/templates/blocks/components/Tooltip/TooltipActionBarTooltips.tsx
@@ -3,19 +3,22 @@
 import {XDSTooltip} from '@xds/core/Tooltip';
 import {XDSButton} from '@xds/core/Button';
 import {XDSHStack} from '@xds/core/Layout';
+import {XDSCenter} from '@xds/core/Center';
 
 export default function TooltipActionBarTooltips() {
   return (
-    <XDSHStack gap={4}>
-      <XDSTooltip content="Save your changes" placement="above">
-        <XDSButton label="Save" />
-      </XDSTooltip>
-      <XDSTooltip content="Discard changes" placement="above">
-        <XDSButton label="Cancel" />
-      </XDSTooltip>
-      <XDSTooltip content="Delete permanently" placement="above">
-        <XDSButton label="Delete" variant="destructive" />
-      </XDSTooltip>
-    </XDSHStack>
+    <XDSCenter>
+      <XDSHStack gap={4}>
+        <XDSTooltip content="Save your changes" placement="above">
+          <XDSButton label="Save" />
+        </XDSTooltip>
+        <XDSTooltip content="Discard changes" placement="above">
+          <XDSButton label="Cancel" />
+        </XDSTooltip>
+        <XDSTooltip content="Delete permanently" placement="above">
+          <XDSButton label="Delete" variant="destructive" />
+        </XDSTooltip>
+      </XDSHStack>
+    </XDSCenter>
   );
 }

--- a/packages/cli/templates/blocks/components/Tooltip/TooltipHookUsage.doc.mjs
+++ b/packages/cli/templates/blocks/components/Tooltip/TooltipHookUsage.doc.mjs
@@ -3,8 +3,8 @@ export const doc = {
   type: 'block',
   name: 'Tooltip — Hook Usage',
   description:
-    'Programmatic tooltip using the useXDSTooltip hook for direct ref control.',
+    'Tooltip using the useXDSTooltip hook for programmatic control.',
   isReady: true,
   aspectRatio: 4 / 3,
-  componentsUsed: ['Tooltip', 'Button'],
+  componentsUsed: ['Tooltip', 'Button', 'Center'],
 };

--- a/packages/cli/templates/blocks/components/Tooltip/TooltipHookUsage.tsx
+++ b/packages/cli/templates/blocks/components/Tooltip/TooltipHookUsage.tsx
@@ -2,6 +2,7 @@
 
 import {useXDSTooltip} from '@xds/core/Tooltip';
 import {XDSButton} from '@xds/core/Button';
+import {XDSCenter} from '@xds/core/Center';
 
 export default function TooltipHookUsage() {
   const tooltip = useXDSTooltip({
@@ -10,13 +11,13 @@ export default function TooltipHookUsage() {
   });
 
   return (
-    <>
+    <XDSCenter>
       <XDSButton
         label="Using hook directly"
         ref={tooltip.ref}
         aria-describedby={tooltip.describedBy}
       />
       {tooltip.renderTooltip('Tooltip via hook')}
-    </>
+    </XDSCenter>
   );
 }

--- a/packages/cli/templates/blocks/components/Tooltip/TooltipInlineTextTooltips.doc.mjs
+++ b/packages/cli/templates/blocks/components/Tooltip/TooltipInlineTextTooltips.doc.mjs
@@ -3,8 +3,8 @@ export const doc = {
   type: 'block',
   name: 'Tooltip — Inline Text',
   description:
-    'Tooltips on inline text terms within paragraph content for definitions.',
+    'Tooltips on inline text terms for definitions.',
   isReady: true,
   aspectRatio: 4 / 3,
-  componentsUsed: ['Tooltip'],
+  componentsUsed: ['Tooltip', 'Text'],
 };

--- a/packages/cli/templates/blocks/components/Tooltip/TooltipInlineTextTooltips.tsx
+++ b/packages/cli/templates/blocks/components/Tooltip/TooltipInlineTextTooltips.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import {XDSTooltip} from '@xds/core/Tooltip';
+import {XDSText} from '@xds/core/Text';
 
 export default function TooltipInlineTextTooltips() {
   return (
-    <p>
+    <XDSText type="body">
       Learn more about our{' '}
       <XDSTooltip
         content="Your data is encrypted and never shared"
@@ -16,6 +17,6 @@ export default function TooltipInlineTextTooltips() {
         terms of service
       </XDSTooltip>
       .
-    </p>
+    </XDSText>
   );
 }

--- a/packages/core/src/Tooltip/Tooltip.doc.mjs
+++ b/packages/core/src/Tooltip/Tooltip.doc.mjs
@@ -134,12 +134,12 @@ export const docs = {
   },
   usage: {
     description:
-      'Tooltip displays a short, non-interactive text hint anchored to a trigger element on hover or focus. Use Tooltip for progressive disclosure of supplementary information, such as describing an icon-only button or showing the full text of a truncated label.',
+      'A short text hint that appears on hover or focus, anchored to a trigger element. Use it to describe icon-only buttons, show the full text of truncated labels, or provide supplementary context without cluttering the UI.',
     bestPractices: [
       {guidance: true, description: 'Keep tooltip content concise — aim for under 140 characters of plain text.'},
       {guidance: true, description: 'Add a tooltip to icon-only buttons and controls that lack a visible label.'},
-      {guidance: false, description: 'Avoid placing interactive elements like links or buttons inside a tooltip — use HoverCard or Popover instead.'},
-      {guidance: false, description: 'Avoid using tooltips for essential information that users must see to complete a task.'},
+      {guidance: false, description: 'Place interactive elements like links or buttons inside a tooltip — use HoverCard or Popover instead.'},
+      {guidance: false, description: 'Use tooltips for essential information that users must see to complete a task.'},
     ],
   },
 };
@@ -279,12 +279,12 @@ export const docsZh = {
   },
   usage: {
     description:
-      'Tooltip displays a short, non-interactive text hint anchored to a trigger element on hover or focus. Use Tooltip for progressive disclosure of supplementary information, such as describing an icon-only button or showing the full text of a truncated label.',
+      'A short text hint that appears on hover or focus, anchored to a trigger element. Use it to describe icon-only buttons, show the full text of truncated labels, or provide supplementary context without cluttering the UI.',
     bestPractices: [
       {guidance: true, description: 'Keep tooltip content concise — aim for under 140 characters of plain text.'},
       {guidance: true, description: 'Add a tooltip to icon-only buttons and controls that lack a visible label.'},
-      {guidance: false, description: 'Avoid placing interactive elements like links or buttons inside a tooltip — use HoverCard or Popover instead.'},
-      {guidance: false, description: 'Avoid using tooltips for essential information that users must see to complete a task.'},
+      {guidance: false, description: 'Place interactive elements like links or buttons inside a tooltip — use HoverCard or Popover instead.'},
+      {guidance: false, description: 'Use tooltips for essential information that users must see to complete a task.'},
     ],
   },
 };
@@ -294,12 +294,12 @@ export const docsDense = {
   description: 'Hover/focus triggered tooltip for displaying short, non-interactive text anchored to trigger element.',
   usage: {
     description:
-      'Tooltip displays a short, non-interactive text hint anchored to a trigger element on hover or focus. Use Tooltip for progressive disclosure of supplementary information, such as describing an icon-only button or showing the full text of a truncated label.',
+      'A short text hint that appears on hover or focus, anchored to a trigger element. Use it to describe icon-only buttons, show the full text of truncated labels, or provide supplementary context without cluttering the UI.',
     bestPractices: [
       {guidance: true, description: 'Keep tooltip content concise — aim for under 140 characters of plain text.'},
       {guidance: true, description: 'Add a tooltip to icon-only buttons and controls that lack a visible label.'},
-      {guidance: false, description: 'Avoid placing interactive elements like links or buttons inside a tooltip — use HoverCard or Popover instead.'},
-      {guidance: false, description: 'Avoid using tooltips for essential information that users must see to complete a task.'},
+      {guidance: false, description: 'Place interactive elements like links or buttons inside a tooltip — use HoverCard or Popover instead.'},
+      {guidance: false, description: 'Use tooltips for essential information that users must see to complete a task.'},
     ],
   },
   components: [


### PR DESCRIPTION
## Summary
- Rewrite usage description to be more concrete and approachable
- Drop "Avoid" prefix from don'ts for consistency with other components
- Center Action Bar and Hook Usage block triggers with `XDSCenter`
- Replace raw `<p>` tag with `XDSText` in Inline Text block
- Tighten block descriptions
- Update `componentsUsed` in doc metadata

## Test plan
- [ ] Verify `npx xds component Tooltip` output reflects updated usage and best practices
- [ ] Verify all 3 Tooltip blocks render correctly in the sandbox
- [ ] Check Action Bar and Hook Usage triggers are centered in block previews