### PR TITLE
fix: privatize leaked internal exports

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -280,12 +280,6 @@
       "import": "./dist/NavIcon/index.mjs",
       "require": "./dist/NavIcon/index.js"
     },
-    "./NavItem": {
-      "source": "./src/NavItem/index.ts",
-      "types": "./dist/NavItem/index.d.ts",
-      "import": "./dist/NavItem/index.mjs",
-      "require": "./dist/NavItem/index.js"
-    },
     "./NavMenu": {
       "source": "./src/NavMenu/index.ts",
       "types": "./dist/NavMenu/index.d.ts",

--- a/packages/core/src/Calendar/index.ts
+++ b/packages/core/src/Calendar/index.ts
@@ -46,4 +46,4 @@ export {
 } from './utils';
 
 // Re-export theme styles for customization
-export {dayCellTheme} from './styles';
+

--- a/packages/core/src/Selector/index.ts
+++ b/packages/core/src/Selector/index.ts
@@ -20,11 +20,4 @@ export type {
   XDSSelectorDivider,
   XDSSelectorSection,
 } from './types';
-export {
-  isOptionData,
-  isDivider,
-  isSection,
-  normalizeOption,
-  getSelectableOptions,
-} from './utils';
 export {useCombobox, useSelectedItemOffset} from './hooks';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -38,7 +38,7 @@ export * from './Link';
 export * from './List';
 export * from './MetadataList';
 export * from './NavIcon';
-export * from './NavItem';
+// NavItem (navItemStyles) is internal — shared styles consumed by SideNav/TopNav/MobileNav
 export * from './NavMenu';
 export * from './Slider';
 export * from './Stack';

--- a/packages/core/src/theme/index.ts
+++ b/packages/core/src/theme/index.ts
@@ -51,7 +51,7 @@ export {
 } from './domainTokens';
 
 // Syntax theme API
-export {defineSyntaxTheme, syntaxThemeStyle, syntaxThemeToCSS} from './syntax';
+export {defineSyntaxTheme} from './syntax';
 export type {
   SyntaxTheme,
   SyntaxThemeInput,
@@ -133,12 +133,7 @@ export type {
 export {useXDSTheme} from './useXDSTheme';
 export type {UseXDSThemeReturn} from './useXDSTheme';
 
-export {
-  defaultOnDarkTokens,
-  defaultOnLightTokens,
-  resolveOnMedia,
-} from './onMediaTokens';
-export type {OnMediaOverrides, ResolvedOnMedia} from './onMediaTokens';
+
 
 export type {
   ThemeMode,
@@ -153,8 +148,4 @@ export type {
   FontWeight,
 } from './types';
 
-export {
-  derivedVarRegistry,
-  getDerivedVars,
-  type DerivedVarEntry,
-} from './derivedVarRegistry';
+

--- a/scripts/sync-exports.js
+++ b/scripts/sync-exports.js
@@ -38,6 +38,13 @@ const CHECK_MODE = process.argv.includes('--check');
 const UTILITY_DIRS = new Set(['hooks', 'theme', 'utils']);
 
 /**
+ * Internal directories that have an index.ts but should NOT be
+ * publicly exported. These are shared implementation details
+ * consumed by other components via relative imports.
+ */
+const INTERNAL_DIRS = new Set(['NavItem']);
+
+/**
  * Additional exports that can't be auto-discovered from directory structure.
  * These are maintained manually here as the single source of truth.
  */
@@ -75,6 +82,7 @@ function discoverExportDirs() {
 
   for (const entry of entries) {
     if (!entry.isDirectory()) continue;
+    if (INTERNAL_DIRS.has(entry.name)) continue;
 
     const indexPath = path.join(SRC_DIR, entry.name, 'index.ts');
     if (fs.existsSync(indexPath)) {


### PR DESCRIPTION
## What

Remove internal-only exports from the `@xds/core` public API. All removals verified to have zero external usage via internal code search search across internal apps.

## Removed

| Module | Export | Reason |
|--------|--------|--------|
| **NavItem** | `navItemStyles`, `NavItemSize` | Raw shared StyleX styles — internal to SideNav/TopNav/MobileNav |
| **Selector** | `isOptionData`, `isDivider`, `isSection`, `normalizeOption`, `getSelectableOptions` | Internal type guard utils |
| **Calendar** | `dayCellTheme` | Leaked internal StyleX theme |
| **Theme** | `derivedVarRegistry`, `getDerivedVars` | Internal theme pipeline infrastructure |
| **Theme** | `defaultOnDarkTokens`, `defaultOnLightTokens`, `resolveOnMedia` | Internal MediaTheme implementation |
| **Theme** | `syntaxThemeStyle`, `syntaxThemeToCSS` | Internal — public API is `defineSyntaxTheme` |

## Not removed

Everything else stays. Theme generation APIs (`generateThemeCSS`, scale expanders, etc.) are used by the sandbox theme editor. CodeBlock highlight utils are used by lab CodeEditor. These are legitimate consumer-facing APIs.

## Changes

- Remove exports from 3 module barrels (Selector, Calendar, Theme)
- Remove NavItem from `index.ts` barrel and `package.json` exports
- Add `INTERNAL_DIRS` to `sync-exports.js` to skip NavItem directory

Refs #1598