### PR TITLE
docs: reorganize component categories (Proposal B)

### DIFF
--- a/apps/storybook/stories/AlertDialog.stories.tsx
+++ b/apps/storybook/stories/AlertDialog.stories.tsx
@@ -7,7 +7,7 @@ import {
 import {XDSButton} from '@xds/core/Button';
 
 const meta: Meta<typeof XDSAlertDialog> = {
-  title: 'Core/XDSAlertDialog',
+  title: 'Core/Dialogs/AlertDialog',
   component: XDSAlertDialog,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/AnalyticsDashboard.stories.tsx
+++ b/apps/storybook/stories/AnalyticsDashboard.stories.tsx
@@ -1385,7 +1385,7 @@ function AnalyticsDashboard() {
 // =============================================================================
 
 const meta: Meta = {
-  title: 'Pages/Analytics Dashboard',
+  title: 'Patterns/Analytics Dashboard',
   parameters: {
     layout: 'fullscreen',
   },

--- a/apps/storybook/stories/AppShell.stories.tsx
+++ b/apps/storybook/stories/AppShell.stories.tsx
@@ -224,7 +224,7 @@ function SideNavWithHeader() {
 // =============================================================================
 
 const meta: Meta<typeof XDSAppShell> = {
-  title: 'Core/XDSAppShell',
+  title: 'Core/AppShell',
   component: XDSAppShell,
   tags: ['autodocs'],
   parameters: {

--- a/apps/storybook/stories/AspectRatio.stories.tsx
+++ b/apps/storybook/stories/AspectRatio.stories.tsx
@@ -65,7 +65,7 @@ const styles = stylex.create({
 });
 
 const meta: Meta<typeof XDSAspectRatio> = {
-  title: 'Layout/XDSAspectRatio',
+  title: 'Core/AspectRatio',
   component: XDSAspectRatio,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Avatar.stories.tsx
+++ b/apps/storybook/stories/Avatar.stories.tsx
@@ -23,7 +23,7 @@ const styles = stylex.create({
 });
 
 const meta: Meta<typeof XDSAvatar> = {
-  title: 'Core/XDSAvatar',
+  title: 'Core/Avatar',
   component: XDSAvatar,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Badge.stories.tsx
+++ b/apps/storybook/stories/Badge.stories.tsx
@@ -2,7 +2,7 @@ import type {Meta, StoryObj} from '@storybook/react';
 import {XDSBadge} from '@xds/core/Badge';
 
 const meta: Meta<typeof XDSBadge> = {
-  title: 'Core/XDSBadge',
+  title: 'Core/Badge',
   component: XDSBadge,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Banner.stories.tsx
+++ b/apps/storybook/stories/Banner.stories.tsx
@@ -5,7 +5,7 @@ import {XDSIcon} from '@xds/core/Icon';
 import {ShieldCheckIcon} from '@heroicons/react/24/solid';
 
 const meta: Meta<typeof XDSBanner> = {
-  title: 'Core/XDSBanner',
+  title: 'Core/Banner',
   component: XDSBanner,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Breadcrumbs.stories.tsx
+++ b/apps/storybook/stories/Breadcrumbs.stories.tsx
@@ -3,7 +3,7 @@ import {XDSBreadcrumbs, XDSBreadcrumbItem} from '@xds/core/Breadcrumbs';
 import {HomeIcon, Cog6ToothIcon, FolderIcon} from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof XDSBreadcrumbs> = {
-  title: 'Navigation/XDSBreadcrumbs',
+  title: 'Core/Navigation/Breadcrumbs',
   component: XDSBreadcrumbs,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Button.stories.tsx
+++ b/apps/storybook/stories/Button.stories.tsx
@@ -4,7 +4,7 @@ import {XDSBadge} from '@xds/core/Badge';
 import {Cog6ToothIcon, TrashIcon} from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof XDSButton> = {
-  title: 'Core/XDSButton',
+  title: 'Core/Buttons/Button',
   component: XDSButton,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Calendar.stories.tsx
+++ b/apps/storybook/stories/Calendar.stories.tsx
@@ -7,7 +7,7 @@ import {
 } from '@xds/core/Calendar';
 
 const meta: Meta<typeof XDSCalendar> = {
-  title: 'Core/XDSCalendar',
+  title: 'Core/Calendar',
   component: XDSCalendar,
   tags: ['autodocs'],
 };

--- a/apps/storybook/stories/Card.stories.tsx
+++ b/apps/storybook/stories/Card.stories.tsx
@@ -46,7 +46,7 @@ const styles = stylex.create({
 });
 
 const meta: Meta<typeof XDSCard> = {
-  title: 'Layout/XDSCard',
+  title: 'Core/Card',
   component: XDSCard,
   tags: ['autodocs'],
   decorators: [

--- a/apps/storybook/stories/Carousel.stories.tsx
+++ b/apps/storybook/stories/Carousel.stories.tsx
@@ -66,7 +66,7 @@ const IMAGES = [
 ];
 
 const meta: Meta<typeof XDSCarousel> = {
-  title: 'Core/XDSCarousel',
+  title: 'Core/Carousel',
   component: XDSCarousel,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Center.stories.tsx
+++ b/apps/storybook/stories/Center.stories.tsx
@@ -43,7 +43,7 @@ const Box = ({children}: {children: React.ReactNode}) => (
 );
 
 const meta: Meta<typeof XDSCenter> = {
-  title: 'Layout/XDSCenter',
+  title: 'Core/Center',
   component: XDSCenter,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Chart.stories.tsx
+++ b/apps/storybook/stories/Chart.stories.tsx
@@ -24,7 +24,7 @@ import {useDataset} from './useDataset';
  * Datasets from [vega-datasets](https://github.com/vega/vega-datasets) (CDN).
  */
 const meta: Meta<typeof XDSChart> = {
-  title: 'Lab/XDSChart',
+  title: 'Lab/Chart',
   component: XDSChart,
   tags: ['autodocs'],
 };

--- a/apps/storybook/stories/ChartAdvanced.stories.tsx
+++ b/apps/storybook/stories/ChartAdvanced.stories.tsx
@@ -14,7 +14,7 @@ import {
 import {XDSStack, XDSText} from '@xds/core';
 import {XDSHeading} from '@xds/core/Text';
 
-const meta: Meta = {title: 'Lab/XDSChartAdvanced'};
+const meta: Meta = {title: 'Lab/ChartAdvanced'};
 export default meta;
 
 const ciData = [

--- a/apps/storybook/stories/ChartCoordinated.stories.tsx
+++ b/apps/storybook/stories/ChartCoordinated.stories.tsx
@@ -14,7 +14,7 @@ import {XDSStack, XDSText} from '@xds/core';
 import {XDSHeading} from '@xds/core/Text';
 import {useDataset} from './useDataset';
 
-const meta: Meta = {title: 'Lab/XDSChart Interactions/Coordinated Views'};
+const meta: Meta = {title: 'Lab/Chart Interactions/Coordinated Views'};
 export default meta;
 
 type Car = {

--- a/apps/storybook/stories/ChartDotGL.stories.tsx
+++ b/apps/storybook/stories/ChartDotGL.stories.tsx
@@ -10,7 +10,7 @@ import {
 import {XDSStack, XDSText} from '@xds/core';
 import {XDSHeading} from '@xds/core/Text';
 
-const meta: Meta = {title: 'Lab/XDSChartDotGL'};
+const meta: Meta = {title: 'Lab/ChartDotGL'};
 export default meta;
 
 const smallData = Array.from({length: 30}, (_, i) => ({

--- a/apps/storybook/stories/ChartDotGLInteractive.stories.tsx
+++ b/apps/storybook/stories/ChartDotGLInteractive.stories.tsx
@@ -9,7 +9,7 @@ import {
 import {XDSStack, XDSText} from '@xds/core';
 import {XDSHeading} from '@xds/core/Text';
 
-const meta: Meta = {title: 'Lab/XDSChartDotGLInteractive'};
+const meta: Meta = {title: 'Lab/ChartDotGLInteractive'};
 export default meta;
 
 const scatterData = Array.from({length: 5000}, () => ({

--- a/apps/storybook/stories/ChartHeatmapGL.stories.tsx
+++ b/apps/storybook/stories/ChartHeatmapGL.stories.tsx
@@ -10,7 +10,7 @@ import {
 import {XDSStack, XDSText} from '@xds/core';
 import {XDSHeading} from '@xds/core/Text';
 
-const meta: Meta = {title: 'Lab/XDSChartHeatmapGL'};
+const meta: Meta = {title: 'Lab/ChartHeatmapGL'};
 export default meta;
 
 const days = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];

--- a/apps/storybook/stories/ChartInteractions.stories.tsx
+++ b/apps/storybook/stories/ChartInteractions.stories.tsx
@@ -18,7 +18,7 @@ import {XDSStack, XDSText} from '@xds/core';
 import {XDSHeading} from '@xds/core/Text';
 import {useDataset} from './useDataset';
 
-const meta: Meta = {title: 'Lab/XDSChart Interactions', tags: ['autodocs']};
+const meta: Meta = {title: 'Lab/Chart Interactions', tags: ['autodocs']};
 export default meta;
 
 type Car = {Horsepower: number; Miles_per_Gallon: number};

--- a/apps/storybook/stories/ChartStreamGL.stories.tsx
+++ b/apps/storybook/stories/ChartStreamGL.stories.tsx
@@ -12,7 +12,7 @@ import {XDSStack, XDSText} from '@xds/core';
 import {XDSHeading} from '@xds/core/Text';
 
 const meta: Meta = {
-  title: 'Lab/XDSChartStreamGL',
+  title: 'Lab/ChartStreamGL',
 };
 
 export default meta;

--- a/apps/storybook/stories/ChartStreamPerf.stories.tsx
+++ b/apps/storybook/stories/ChartStreamPerf.stories.tsx
@@ -12,7 +12,7 @@ import {XDSStack, XDSText} from '@xds/core';
 import {XDSHeading} from '@xds/core/Text';
 
 const meta: Meta = {
-  title: 'Lab/XDSChartStreamGL/Performance',
+  title: 'Lab/ChartStreamGL/Performance',
 };
 
 export default meta;

--- a/apps/storybook/stories/Chat.stories.tsx
+++ b/apps/storybook/stories/Chat.stories.tsx
@@ -17,7 +17,7 @@ import {HandThumbUpIcon, HandThumbDownIcon} from '@heroicons/react/24/outline';
 import {ClipboardDocumentIcon} from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof XDSChatMessageList> = {
-  title: 'Chat/XDSChatMessageList',
+  title: 'Core/Chat/MessageList',
   component: XDSChatMessageList,
   tags: ['autodocs'],
 };

--- a/apps/storybook/stories/ChatComposer.stories.tsx
+++ b/apps/storybook/stories/ChatComposer.stories.tsx
@@ -55,7 +55,7 @@ const MicIcon = (
 );
 
 const meta: Meta<typeof XDSChatComposer> = {
-  title: 'Chat/XDSChatComposer',
+  title: 'Core/Chat/Composer',
   component: XDSChatComposer,
   tags: ['autodocs'],
   parameters: {

--- a/apps/storybook/stories/ChatComposerInput.stories.tsx
+++ b/apps/storybook/stories/ChatComposerInput.stories.tsx
@@ -11,7 +11,7 @@ import type {XDSSearchableItem, XDSSearchSource} from '@xds/core/Typeahead';
 import {useState} from 'react';
 
 const meta: Meta = {
-  title: 'Chat/XDSChatComposerInput',
+  title: 'Core/Chat/ComposerInput',
   component: XDSChatComposerInput,
   tags: ['autodocs'],
   parameters: {

--- a/apps/storybook/stories/ChatDictation.stories.tsx
+++ b/apps/storybook/stories/ChatDictation.stories.tsx
@@ -74,7 +74,7 @@ const unsupportedDictation: UseSpeechRecognitionReturn = {
 // =============================================================================
 
 const meta: Meta<typeof XDSChatDictationButton> = {
-  title: 'Chat/XDSChatDictationButton',
+  title: 'Core/Chat/DictationButton',
   component: XDSChatDictationButton,
   tags: ['autodocs'],
   parameters: {

--- a/apps/storybook/stories/ChatLayout.stories.tsx
+++ b/apps/storybook/stories/ChatLayout.stories.tsx
@@ -32,7 +32,7 @@ import {XDSEmptyState} from '@xds/core/EmptyState';
 import {useState, useCallback, useRef} from 'react';
 
 const meta: Meta<typeof XDSChatLayout> = {
-  title: 'Chat/XDSChatLayout',
+  title: 'Core/Chat/Layout',
   component: XDSChatLayout,
   tags: ['autodocs'],
   parameters: {layout: 'fullscreen'},

--- a/apps/storybook/stories/ChatReasoning.stories.tsx
+++ b/apps/storybook/stories/ChatReasoning.stories.tsx
@@ -10,7 +10,7 @@ import {XDSMarkdown} from '@xds/core/Markdown';
 import {useState, useEffect} from 'react';
 
 const meta: Meta = {
-  title: 'Lab/XDSChatReasoning',
+  title: 'Lab/ChatReasoning',
   component: XDSChatReasoning,
   tags: ['autodocs'],
   parameters: {

--- a/apps/storybook/stories/ChatTokenizedText.stories.tsx
+++ b/apps/storybook/stories/ChatTokenizedText.stories.tsx
@@ -3,7 +3,7 @@ import {XDSChatTokenizedText} from '@xds/core/Chat';
 import {XDSChatMessage, XDSChatMessageBubble} from '@xds/core/Chat';
 
 const meta: Meta<typeof XDSChatTokenizedText> = {
-  title: 'Chat/XDSChatTokenizedText',
+  title: 'Core/Chat/TokenizedText',
   component: XDSChatTokenizedText,
   tags: ['autodocs'],
   parameters: {layout: 'centered'},

--- a/apps/storybook/stories/ChatToolCalls.stories.tsx
+++ b/apps/storybook/stories/ChatToolCalls.stories.tsx
@@ -4,7 +4,7 @@ import {useState, useCallback} from 'react';
 import {XDSCodeBlock} from '@xds/core/CodeBlock';
 
 const meta: Meta<typeof XDSChatToolCalls> = {
-  title: 'Chat/XDSChatToolCalls',
+  title: 'Core/Chat/ToolCalls',
   component: XDSChatToolCalls,
   tags: ['autodocs'],
   parameters: {

--- a/apps/storybook/stories/CheckboxInput.stories.tsx
+++ b/apps/storybook/stories/CheckboxInput.stories.tsx
@@ -8,7 +8,7 @@ import {
 } from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof XDSCheckboxInput> = {
-  title: 'Form/XDSCheckboxInput',
+  title: 'Core/Inputs/CheckboxInput',
   component: XDSCheckboxInput,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/CheckboxList.stories.tsx
+++ b/apps/storybook/stories/CheckboxList.stories.tsx
@@ -5,7 +5,7 @@ import {XDSList} from '@xds/core/List';
 import {XDSCard} from '@xds/core/Card';
 
 const meta: Meta<typeof XDSCheckboxList> = {
-  title: 'Form/XDSCheckboxList',
+  title: 'Core/Inputs/CheckboxList',
   component: XDSCheckboxList,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Code.stories.tsx
+++ b/apps/storybook/stories/Code.stories.tsx
@@ -5,7 +5,7 @@ import {XDSStack} from '@xds/core/Stack';
 import {XDSLink} from '@xds/core/Link';
 
 const meta: Meta<typeof XDSCode> = {
-  title: 'Components/XDSCode',
+  title: 'Core/Code',
   component: XDSCode,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/CodeBlock.stories.tsx
+++ b/apps/storybook/stories/CodeBlock.stories.tsx
@@ -2,7 +2,7 @@ import type {Meta, StoryObj} from '@storybook/react';
 import {XDSCodeBlock} from '@xds/core/CodeBlock';
 
 const meta: Meta<typeof XDSCodeBlock> = {
-  title: 'Components/XDSCodeBlock',
+  title: 'Core/CodeBlock',
   component: XDSCodeBlock,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/CodeEditor.stories.tsx
+++ b/apps/storybook/stories/CodeEditor.stories.tsx
@@ -3,7 +3,7 @@ import {useState} from 'react';
 import {XDSCodeEditor} from '@xds/lab';
 
 const meta: Meta<typeof XDSCodeEditor> = {
-  title: 'Lab/XDSCodeEditor',
+  title: 'Lab/CodeEditor',
   component: XDSCodeEditor,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/CodeEditorPerf.stories.tsx
+++ b/apps/storybook/stories/CodeEditorPerf.stories.tsx
@@ -3,7 +3,7 @@ import {useState, useRef, useEffect, useCallback} from 'react';
 import {XDSCodeEditor} from '@xds/lab';
 
 const meta: Meta<typeof XDSCodeEditor> = {
-  title: 'Lab/XDSCodeEditor/Performance',
+  title: 'Lab/CodeEditor/Performance',
   component: XDSCodeEditor,
   parameters: {layout: 'fullscreen'},
 };

--- a/apps/storybook/stories/CodeEditorTheme.stories.tsx
+++ b/apps/storybook/stories/CodeEditorTheme.stories.tsx
@@ -83,7 +83,7 @@ function ThemedEditor({
 }
 
 const meta: Meta = {
-  title: 'Lab/XDSCodeEditor Themes',
+  title: 'Lab/CodeEditor Themes',
   parameters: {
     docs: {
       description: {

--- a/apps/storybook/stories/CodeTheme.stories.tsx
+++ b/apps/storybook/stories/CodeTheme.stories.tsx
@@ -62,7 +62,7 @@ const sampleCode = [
 ].join('\n');
 
 const meta: Meta = {
-  title: 'Theme/XDSSyntaxTheme',
+  title: 'Core/Theme/SyntaxTheme',
   tags: ['autodocs'],
   parameters: {
     docs: {

--- a/apps/storybook/stories/Collapsible.stories.tsx
+++ b/apps/storybook/stories/Collapsible.stories.tsx
@@ -29,7 +29,7 @@ const styles = stylex.create({
 });
 
 const meta: Meta<typeof XDSCollapsibleGroup> = {
-  title: 'Components/XDSCollapsible',
+  title: 'Core/Collapsible',
   component: XDSCollapsibleGroup,
   tags: ['autodocs'],
   decorators: [

--- a/apps/storybook/stories/CommandPalette.stories.tsx
+++ b/apps/storybook/stories/CommandPalette.stories.tsx
@@ -20,7 +20,7 @@ import {createStaticSource} from '@xds/core/Typeahead';
 import type {XDSSearchSource, XDSSearchableItem} from '@xds/core/Typeahead';
 
 const meta: Meta<typeof XDSCommandPalette> = {
-  title: 'CommandPalette/XDSCommandPalette',
+  title: 'Core/CommandPalette',
   component: XDSCommandPalette,
   tags: ['autodocs'],
 };

--- a/apps/storybook/stories/DateInput.stories.tsx
+++ b/apps/storybook/stories/DateInput.stories.tsx
@@ -5,7 +5,7 @@ import type {ISODateString} from '@xds/core/Calendar';
 import {XDSLayout, XDSLayoutContent} from '@xds/core/Layout';
 
 const meta: Meta<typeof XDSDateInput> = {
-  title: 'Form/XDSDateInput',
+  title: 'Core/Inputs/DateInput',
   component: XDSDateInput,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Dialog.stories.tsx
+++ b/apps/storybook/stories/Dialog.stories.tsx
@@ -19,7 +19,7 @@ const styles = stylex.create({
 });
 
 const meta: Meta<typeof XDSDialog> = {
-  title: 'Core/XDSDialog',
+  title: 'Core/Dialogs/Dialog',
   component: XDSDialog,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Divider.stories.tsx
+++ b/apps/storybook/stories/Divider.stories.tsx
@@ -19,7 +19,7 @@ const styles = stylex.create({
 });
 
 const meta: Meta<typeof XDSDivider> = {
-  title: 'Layout/XDSDivider',
+  title: 'Core/Divider',
   component: XDSDivider,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/DropdownMenu.stories.tsx
+++ b/apps/storybook/stories/DropdownMenu.stories.tsx
@@ -17,7 +17,7 @@ import {
 } from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof XDSDropdownMenu> = {
-  title: 'Core/XDSDropdownMenu',
+  title: 'Core/DropdownMenu',
   component: XDSDropdownMenu,
   tags: ['autodocs'],
   parameters: {

--- a/apps/storybook/stories/EmptyState.stories.tsx
+++ b/apps/storybook/stories/EmptyState.stories.tsx
@@ -3,7 +3,7 @@ import {XDSEmptyState} from '@xds/core/EmptyState';
 import {XDSButton} from '@xds/core/Button';
 
 const meta: Meta<typeof XDSEmptyState> = {
-  title: 'Core/XDSEmptyState',
+  title: 'Core/EmptyState',
   component: XDSEmptyState,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Field.stories.tsx
+++ b/apps/storybook/stories/Field.stories.tsx
@@ -57,7 +57,7 @@ const NativeInput = ({
 );
 
 const meta: Meta<typeof XDSField> = {
-  title: 'Form/XDSField',
+  title: 'Core/Inputs/Field',
   component: XDSField,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/FormLayout.stories.tsx
+++ b/apps/storybook/stories/FormLayout.stories.tsx
@@ -8,7 +8,7 @@ import {XDSText} from '@xds/core/Text';
 import * as stylex from '@stylexjs/stylex';
 
 const meta: Meta<typeof XDSFormLayout> = {
-  title: 'Form/XDSFormLayout',
+  title: 'Core/Inputs/FormLayout',
   component: XDSFormLayout,
   tags: ['autodocs'],
   args: {

--- a/apps/storybook/stories/Grid.stories.tsx
+++ b/apps/storybook/stories/Grid.stories.tsx
@@ -47,7 +47,7 @@ const styles = stylex.create({
 });
 
 const meta: Meta<typeof XDSGrid> = {
-  title: 'Layout/XDSGrid',
+  title: 'Core/Grid',
   component: XDSGrid,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/GridMasonry.stories.tsx
+++ b/apps/storybook/stories/GridMasonry.stories.tsx
@@ -12,7 +12,7 @@ import {
 } from '@xds/core/theme/tokens.stylex';
 
 const meta: Meta = {
-  title: 'Layout/XDSGrid/Masonry Gallery',
+  title: 'Core/Grid/Masonry Gallery',
   tags: ['autodocs'],
 };
 

--- a/apps/storybook/stories/Heading.stories.tsx
+++ b/apps/storybook/stories/Heading.stories.tsx
@@ -3,7 +3,7 @@ import {XDSHeading} from '@xds/core/Text';
 import {XDSText} from '@xds/core/Text';
 
 const meta: Meta<typeof XDSHeading> = {
-  title: 'Typography/XDSHeading',
+  title: 'Core/Heading',
   component: XDSHeading,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/HoverCard.stories.tsx
+++ b/apps/storybook/stories/HoverCard.stories.tsx
@@ -4,7 +4,7 @@ import {XDSButton} from '@xds/core/Button';
 import {XDSVStack, XDSHStack} from '@xds/core/Layout';
 
 const meta: Meta<typeof XDSHoverCard> = {
-  title: 'Core/XDSHoverCard',
+  title: 'Core/HoverCard',
   component: XDSHoverCard,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Icon.stories.tsx
+++ b/apps/storybook/stories/Icon.stories.tsx
@@ -19,7 +19,7 @@ import {
 } from '@heroicons/react/24/solid';
 
 const meta: Meta<typeof XDSIcon> = {
-  title: 'Core/XDSIcon',
+  title: 'Core/Icon',
   component: XDSIcon,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/IconButton.stories.tsx
+++ b/apps/storybook/stories/IconButton.stories.tsx
@@ -11,7 +11,7 @@ import {
 } from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof XDSIconButton> = {
-  title: 'Core/XDSIconButton',
+  title: 'Core/Buttons/IconButton',
   component: XDSIconButton,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Kbd.stories.tsx
+++ b/apps/storybook/stories/Kbd.stories.tsx
@@ -3,7 +3,7 @@ import {XDSKbd} from '@xds/core/Kbd';
 import {XDSText} from '@xds/core/Text';
 
 const meta: Meta<typeof XDSKbd> = {
-  title: 'Core/XDSKbd',
+  title: 'Core/Kbd',
   component: XDSKbd,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Layout.stories.tsx
+++ b/apps/storybook/stories/Layout.stories.tsx
@@ -157,7 +157,7 @@ const NavItem = ({
 );
 
 const meta: Meta<typeof XDSLayout> = {
-  title: 'Layout/XDSLayout',
+  title: 'Core/Layout',
   component: XDSLayout,
   tags: ['autodocs'],
   parameters: {

--- a/apps/storybook/stories/Link.stories.tsx
+++ b/apps/storybook/stories/Link.stories.tsx
@@ -3,7 +3,7 @@ import {XDSLink} from '@xds/core/Link';
 import {XDSText} from '@xds/core/Text';
 
 const meta: Meta<typeof XDSLink> = {
-  title: 'Core/XDSLink',
+  title: 'Core/Link',
   component: XDSLink,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/List.stories.tsx
+++ b/apps/storybook/stories/List.stories.tsx
@@ -14,7 +14,7 @@ import {
 } from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof XDSList> = {
-  title: 'Core/XDSList',
+  title: 'Core/List',
   component: XDSList,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Markdown.stories.tsx
+++ b/apps/storybook/stories/Markdown.stories.tsx
@@ -4,7 +4,7 @@ import {XDSMarkdown} from '@xds/core/Markdown';
 import {XDSButton} from '@xds/core/Button';
 
 const meta: Meta<typeof XDSMarkdown> = {
-  title: 'Components/XDSMarkdown',
+  title: 'Core/Markdown',
   component: XDSMarkdown,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/MarkdownCitations.stories.tsx
+++ b/apps/storybook/stories/MarkdownCitations.stories.tsx
@@ -5,7 +5,7 @@ import type {XDSMarkdownSource} from '@xds/core/Markdown';
 import {XDSButton} from '@xds/core/Button';
 
 const meta: Meta<typeof XDSMarkdown> = {
-  title: 'Components/XDSMarkdown/Citations',
+  title: 'Core/Markdown/Citations',
   component: XDSMarkdown,
   tags: ['autodocs'],
 };

--- a/apps/storybook/stories/MetadataList.stories.tsx
+++ b/apps/storybook/stories/MetadataList.stories.tsx
@@ -9,7 +9,7 @@ import {
 } from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof XDSMetadataList> = {
-  title: 'Core/XDSMetadataList',
+  title: 'Core/MetadataList',
   component: XDSMetadataList,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/MobileNav.stories.tsx
+++ b/apps/storybook/stories/MobileNav.stories.tsx
@@ -29,7 +29,7 @@ import {
 // =============================================================================
 
 const meta: Meta<typeof XDSMobileNav> = {
-  title: 'Navigation/XDSMobileNav',
+  title: 'Core/Navigation/MobileNav',
   component: XDSMobileNav,
   tags: ['autodocs'],
   parameters: {

--- a/apps/storybook/stories/MoreMenu.stories.tsx
+++ b/apps/storybook/stories/MoreMenu.stories.tsx
@@ -12,7 +12,7 @@ import {
 } from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof XDSMoreMenu> = {
-  title: 'Core/XDSMoreMenu',
+  title: 'Core/MoreMenu',
   component: XDSMoreMenu,
   tags: ['autodocs'],
   parameters: {

--- a/apps/storybook/stories/MultiSelector.stories.tsx
+++ b/apps/storybook/stories/MultiSelector.stories.tsx
@@ -3,7 +3,7 @@ import {useState} from 'react';
 import {XDSMultiSelector} from '@xds/core/MultiSelector';
 
 const meta: Meta<typeof XDSMultiSelector> = {
-  title: 'Form/XDSMultiSelector',
+  title: 'Core/Inputs/MultiSelector',
   component: XDSMultiSelector,
   tags: ['autodocs'],
   parameters: {

--- a/apps/storybook/stories/NumberInput.stories.tsx
+++ b/apps/storybook/stories/NumberInput.stories.tsx
@@ -4,7 +4,7 @@ import {XDSNumberInput} from '@xds/core/NumberInput';
 import {HashtagIcon, CurrencyDollarIcon} from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof XDSNumberInput> = {
-  title: 'Form/XDSNumberInput',
+  title: 'Core/Inputs/NumberInput',
   component: XDSNumberInput,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/OverflowList.stories.tsx
+++ b/apps/storybook/stories/OverflowList.stories.tsx
@@ -7,7 +7,7 @@ import {XDSDropdownMenu} from '@xds/core/DropdownMenu';
 import {XDSTextInput} from '@xds/core/TextInput';
 
 const meta: Meta<typeof XDSOverflowList> = {
-  title: 'Core/XDSOverflowList',
+  title: 'Core/OverflowList',
   component: XDSOverflowList,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Pagination.stories.tsx
+++ b/apps/storybook/stories/Pagination.stories.tsx
@@ -3,7 +3,7 @@ import {useState} from 'react';
 import {XDSPagination} from '@xds/core/Pagination';
 
 const meta: Meta<typeof XDSPagination> = {
-  title: 'Core/XDSPagination',
+  title: 'Core/Pagination',
   component: XDSPagination,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Popover.stories.tsx
+++ b/apps/storybook/stories/Popover.stories.tsx
@@ -9,7 +9,7 @@ import {XDSCheckboxInput} from '@xds/core/CheckboxInput';
 import {XDSDivider} from '@xds/core/Divider';
 
 const meta: Meta<typeof XDSPopover> = {
-  title: 'Core/XDSPopover',
+  title: 'Core/Popover',
   component: XDSPopover,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/PowerSearch.stories.tsx
+++ b/apps/storybook/stories/PowerSearch.stories.tsx
@@ -273,7 +273,7 @@ const fullConfig: PowerSearchConfig = {
 // =============================================================================
 
 const meta: Meta<typeof XDSPowerSearch> = {
-  title: 'Form/XDSPowerSearch',
+  title: 'Core/Inputs/PowerSearch',
   component: XDSPowerSearch,
   tags: ['autodocs'],
   decorators: [

--- a/apps/storybook/stories/ProgressBar.stories.tsx
+++ b/apps/storybook/stories/ProgressBar.stories.tsx
@@ -2,7 +2,7 @@ import type {Meta, StoryObj} from '@storybook/react';
 import {XDSProgressBar} from '@xds/core/ProgressBar';
 
 const meta: Meta<typeof XDSProgressBar> = {
-  title: 'Core/XDSProgressBar',
+  title: 'Core/ProgressBar',
   component: XDSProgressBar,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/RadialChart.stories.tsx
+++ b/apps/storybook/stories/RadialChart.stories.tsx
@@ -12,7 +12,7 @@ import {XDSStack, XDSText} from '@xds/core';
 import {XDSHeading} from '@xds/core/Text';
 
 const meta: Meta = {
-  title: 'Lab/XDSRadialChart',
+  title: 'Lab/RadialChart',
   tags: ['autodocs'],
 };
 

--- a/apps/storybook/stories/RadioList.stories.tsx
+++ b/apps/storybook/stories/RadioList.stories.tsx
@@ -3,7 +3,7 @@ import type {Meta, StoryObj} from '@storybook/react';
 import {XDSRadioList, XDSRadioListItem} from '@xds/core/RadioList';
 
 const meta: Meta<typeof XDSRadioList> = {
-  title: 'Form/XDSRadioList',
+  title: 'Core/Inputs/RadioList',
   component: XDSRadioList,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/SVGIcon.stories.tsx
+++ b/apps/storybook/stories/SVGIcon.stories.tsx
@@ -19,7 +19,7 @@ import {
 import {XDSStack, XDSText, XDSDivider} from '@xds/core';
 
 const meta: Meta<typeof XDSSVGIcon> = {
-  title: 'Lab/XDSSVGIcon',
+  title: 'Lab/SVGIcon',
   component: XDSSVGIcon,
   argTypes: {
     variation: {

--- a/apps/storybook/stories/SVGIconRegistry.stories.tsx
+++ b/apps/storybook/stories/SVGIconRegistry.stories.tsx
@@ -154,7 +154,7 @@ function jsxSvgToIconDef(name: string, element: ReactElement): SVGIconDef | null
 // =============================================================================
 
 const meta: Meta = {
-  title: 'Lab/XDSSVGIcon/Registry Icons',
+  title: 'Lab/SVGIcon/Registry Icons',
 };
 export default meta;
 

--- a/apps/storybook/stories/SankeyChart.stories.tsx
+++ b/apps/storybook/stories/SankeyChart.stories.tsx
@@ -12,7 +12,7 @@ import {XDSStack, XDSText} from '@xds/core';
 import {XDSHeading} from '@xds/core/Text';
 
 const meta: Meta = {
-  title: 'Lab/XDSSankeyChart',
+  title: 'Lab/SankeyChart',
   tags: ['autodocs'],
 };
 

--- a/apps/storybook/stories/Section.stories.tsx
+++ b/apps/storybook/stories/Section.stories.tsx
@@ -48,7 +48,7 @@ const styles = stylex.create({
 });
 
 const meta: Meta<typeof XDSSection> = {
-  title: 'Layout/XDSSection',
+  title: 'Core/Section',
   component: XDSSection,
   tags: ['autodocs'],
   decorators: [

--- a/apps/storybook/stories/SegmentedControl.stories.tsx
+++ b/apps/storybook/stories/SegmentedControl.stories.tsx
@@ -12,7 +12,7 @@ import {
 } from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof XDSSegmentedControl> = {
-  title: 'Inputs/XDSSegmentedControl',
+  title: 'Core/Inputs/SegmentedControl',
   component: XDSSegmentedControl,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Selector.stories.tsx
+++ b/apps/storybook/stories/Selector.stories.tsx
@@ -4,7 +4,7 @@ import {XDSSelector, XDSSelectorOption} from '@xds/core/Selector';
 import {UserIcon, CogIcon, BellIcon} from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof XDSSelector> = {
-  title: 'Form/XDSSelector',
+  title: 'Core/Inputs/Selector',
   component: XDSSelector,
   tags: ['autodocs'],
   parameters: {

--- a/apps/storybook/stories/SideNav.stories.tsx
+++ b/apps/storybook/stories/SideNav.stories.tsx
@@ -29,7 +29,7 @@ import {
 } from '@heroicons/react/24/solid';
 
 const meta: Meta<typeof XDSSideNav> = {
-  title: 'Navigation/XDSSideNav',
+  title: 'Core/Navigation/SideNav',
   component: XDSSideNav,
   tags: ['autodocs'],
   parameters: {

--- a/apps/storybook/stories/Skeleton.stories.tsx
+++ b/apps/storybook/stories/Skeleton.stories.tsx
@@ -4,7 +4,7 @@ import {XDSCard} from '@xds/core/Card';
 import {XDSHStack, XDSVStack} from '@xds/core/Layout';
 
 const meta: Meta<typeof XDSSkeleton> = {
-  title: 'Core/XDSSkeleton',
+  title: 'Core/Skeleton',
   component: XDSSkeleton,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Slider.stories.tsx
+++ b/apps/storybook/stories/Slider.stories.tsx
@@ -4,7 +4,7 @@ import type {Meta, StoryObj} from '@storybook/react';
 import {XDSSlider} from '@xds/core/Slider';
 
 const meta: Meta<typeof XDSSlider> = {
-  title: 'Form/XDSSlider',
+  title: 'Core/Slider',
   component: XDSSlider,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Spinner.stories.tsx
+++ b/apps/storybook/stories/Spinner.stories.tsx
@@ -4,7 +4,7 @@ import {XDSText} from '@xds/core/Text';
 import {XDSHStack, XDSVStack} from '@xds/core/Layout';
 
 const meta: Meta<typeof XDSSpinner> = {
-  title: 'Core/XDSSpinner',
+  title: 'Core/Spinner',
   component: XDSSpinner,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Stack.stories.tsx
+++ b/apps/storybook/stories/Stack.stories.tsx
@@ -117,7 +117,7 @@ const Box = ({
 );
 
 const meta: Meta<typeof XDSStack> = {
-  title: 'Layout/XDSStack',
+  title: 'Core/Stack',
   component: XDSStack,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/StatusDot.stories.tsx
+++ b/apps/storybook/stories/StatusDot.stories.tsx
@@ -2,7 +2,7 @@ import type {Meta, StoryObj} from '@storybook/react';
 import {XDSStatusDot} from '@xds/core/StatusDot';
 
 const meta: Meta<typeof XDSStatusDot> = {
-  title: 'Core/XDSStatusDot',
+  title: 'Core/StatusDot',
   component: XDSStatusDot,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Switch.stories.tsx
+++ b/apps/storybook/stories/Switch.stories.tsx
@@ -9,7 +9,7 @@ import {
 } from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof XDSSwitch> = {
-  title: 'Form/XDSSwitch',
+  title: 'Core/Switch',
   component: XDSSwitch,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/TabList.stories.tsx
+++ b/apps/storybook/stories/TabList.stories.tsx
@@ -8,7 +8,7 @@ import {XDSStackItem} from '@xds/core/Stack';
 import {PlusIcon, FunnelIcon} from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof XDSTabList> = {
-  title: 'Navigation/XDSTabList',
+  title: 'Core/Navigation/TabList',
   component: XDSTabList,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Table.stories.tsx
+++ b/apps/storybook/stories/Table.stories.tsx
@@ -94,7 +94,7 @@ const columns: XDSTableColumn<User>[] = [
 // =============================================================================
 
 const meta: Meta<typeof XDSTable> = {
-  title: 'Core/XDSTable',
+  title: 'Core/Table',
   component: XDSTable,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/TableColumnResize.stories.tsx
+++ b/apps/storybook/stories/TableColumnResize.stories.tsx
@@ -71,7 +71,7 @@ const columns: XDSTableColumn<User>[] = [
 // =============================================================================
 
 const meta: Meta = {
-  title: 'Core/XDSTable/ColumnResize',
+  title: 'Core/Table/ColumnResize',
   tags: ['autodocs'],
 };
 

--- a/apps/storybook/stories/TableColumnSettings.stories.tsx
+++ b/apps/storybook/stories/TableColumnSettings.stories.tsx
@@ -100,7 +100,7 @@ const defaultActiveKeys: UserColumnKey[] = [
 // =============================================================================
 
 const meta: Meta = {
-  title: 'Core/XDSTable/ColumnSettings',
+  title: 'Core/Table/ColumnSettings',
   tags: ['autodocs'],
 };
 

--- a/apps/storybook/stories/TableFiltering.stories.tsx
+++ b/apps/storybook/stories/TableFiltering.stories.tsx
@@ -97,7 +97,7 @@ const fieldDefs = [
 ] as const;
 
 const meta: Meta = {
-  title: 'Core/XDSTable/Filtering',
+  title: 'Core/Table/Filtering',
   tags: ['autodocs'],
 };
 

--- a/apps/storybook/stories/TablePagination.stories.tsx
+++ b/apps/storybook/stories/TablePagination.stories.tsx
@@ -82,7 +82,7 @@ function PaginatedDemo({
 // =============================================================================
 
 const meta: Meta = {
-  title: 'Core/XDSTable/Pagination',
+  title: 'Core/Table/Pagination',
   tags: ['autodocs'],
 };
 

--- a/apps/storybook/stories/TableSelection.stories.tsx
+++ b/apps/storybook/stories/TableSelection.stories.tsx
@@ -68,7 +68,7 @@ const columns: XDSTableColumn<User>[] = [
 // =============================================================================
 
 const meta: Meta = {
-  title: 'Core/XDSTable/Selection',
+  title: 'Core/Table/Selection',
   tags: ['autodocs'],
 };
 

--- a/apps/storybook/stories/TableSortable.stories.tsx
+++ b/apps/storybook/stories/TableSortable.stories.tsx
@@ -77,7 +77,7 @@ const columns: XDSTableColumn<Employee>[] = [
 // =============================================================================
 
 const meta: Meta = {
-  title: 'Core/XDSTable/Sortable',
+  title: 'Core/Table/Sortable',
   tags: ['autodocs'],
 };
 

--- a/apps/storybook/stories/Text.stories.tsx
+++ b/apps/storybook/stories/Text.stories.tsx
@@ -2,7 +2,7 @@ import type {Meta, StoryObj} from '@storybook/react';
 import {XDSText} from '@xds/core/Text';
 
 const meta: Meta<typeof XDSText> = {
-  title: 'Typography/XDSText',
+  title: 'Core/Text',
   component: XDSText,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/TextArea.stories.tsx
+++ b/apps/storybook/stories/TextArea.stories.tsx
@@ -8,7 +8,7 @@ import {
 } from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof XDSTextArea> = {
-  title: 'Form/XDSTextArea',
+  title: 'Core/Inputs/TextArea',
   component: XDSTextArea,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/TextInput.stories.tsx
+++ b/apps/storybook/stories/TextInput.stories.tsx
@@ -8,7 +8,7 @@ import {
 } from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof XDSTextInput> = {
-  title: 'Form/XDSTextInput',
+  title: 'Core/Inputs/TextInput',
   component: XDSTextInput,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/ThemeEditor.stories.tsx
+++ b/apps/storybook/stories/ThemeEditor.stories.tsx
@@ -1961,7 +1961,7 @@ function ThemeEditorComponent() {
 // =============================================================================
 
 const meta: Meta = {
-  title: 'Theme Editor',
+  title: 'Patterns/Theme Editor',
   parameters: {
     layout: 'fullscreen',
     docs: {

--- a/apps/storybook/stories/ThreeD-Backdrop.stories.tsx
+++ b/apps/storybook/stories/ThreeD-Backdrop.stories.tsx
@@ -2,7 +2,7 @@ import type {Meta, StoryObj} from '@storybook/react';
 import {useMemo} from 'react';
 import {XDS3DChart, XDS3DScatter, use3D, useXDSChartColors} from '@xds/lab';
 
-const meta: Meta = {title: 'Lab/XDS3DChart/Backdrop'};
+const meta: Meta = {title: 'Lab/3DChart/Backdrop'};
 export default meta;
 
 /** Scatter that colors each point based on its projected screen position */

--- a/apps/storybook/stories/ThreeD-Showcase.stories.tsx
+++ b/apps/storybook/stories/ThreeD-Showcase.stories.tsx
@@ -8,7 +8,7 @@ import {
 } from '@xds/lab';
 import {XDSMediaTheme} from '@xds/core/theme';
 
-const meta: Meta = {title: 'Lab/XDS3DChart/PopArt'};
+const meta: Meta = {title: 'Lab/3DChart/PopArt'};
 export default meta;
 
 // =============================================================================

--- a/apps/storybook/stories/ThreeDChart.stories.tsx
+++ b/apps/storybook/stories/ThreeDChart.stories.tsx
@@ -13,7 +13,7 @@ import {XDSStack, XDSText} from '@xds/core';
 import {XDSHeading} from '@xds/core/Text';
 
 const meta: Meta = {
-  title: 'Lab/XDS3DChart',
+  title: 'Lab/3DChart',
   tags: ['autodocs'],
 };
 

--- a/apps/storybook/stories/Thumbnail.stories.tsx
+++ b/apps/storybook/stories/Thumbnail.stories.tsx
@@ -3,7 +3,7 @@ import type {Meta, StoryObj} from '@storybook/react';
 import {XDSThumbnail} from '@xds/core/Thumbnail';
 
 const meta: Meta<typeof XDSThumbnail> = {
-  title: 'Core/XDSThumbnail',
+  title: 'Core/Thumbnail',
   component: XDSThumbnail,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/TimeInput.stories.tsx
+++ b/apps/storybook/stories/TimeInput.stories.tsx
@@ -4,7 +4,7 @@ import {XDSTimeInput} from '@xds/core/TimeInput';
 import type {ISOTimeString} from '@xds/core';
 
 const meta: Meta<typeof XDSTimeInput> = {
-  title: 'Form/XDSTimeInput',
+  title: 'Core/Inputs/TimeInput',
   component: XDSTimeInput,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Timestamp.stories.tsx
+++ b/apps/storybook/stories/Timestamp.stories.tsx
@@ -3,7 +3,7 @@ import {XDSTimestamp} from '@xds/core/Timestamp';
 import {XDSText} from '@xds/core/Text';
 
 const meta: Meta<typeof XDSTimestamp> = {
-  title: 'Core/XDSTimestamp',
+  title: 'Core/Timestamp',
   component: XDSTimestamp,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Toast.stories.tsx
+++ b/apps/storybook/stories/Toast.stories.tsx
@@ -9,7 +9,7 @@ import {XDSStack} from '@xds/core/Stack';
 import {XDSDialog} from '@xds/core/Dialog';
 
 const meta: Meta = {
-  title: 'Core/XDSToast',
+  title: 'Core/Toast',
   tags: ['autodocs'],
   parameters: {
     docs: {

--- a/apps/storybook/stories/ToggleButton.stories.tsx
+++ b/apps/storybook/stories/ToggleButton.stories.tsx
@@ -28,7 +28,7 @@ import {XDSIcon} from '@xds/core/Icon';
 const iconSize = {width: 16, height: 16} as const;
 
 const meta: Meta<typeof XDSToggleButton> = {
-  title: 'Core/XDSToggleButton',
+  title: 'Core/Buttons/ToggleButton',
   component: XDSToggleButton,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Token.stories.tsx
+++ b/apps/storybook/stories/Token.stories.tsx
@@ -2,7 +2,7 @@ import type {Meta, StoryObj} from '@storybook/react';
 import {XDSToken, type XDSTokenColor} from '@xds/core/Token';
 
 const meta: Meta<typeof XDSToken> = {
-  title: 'Core/XDSToken',
+  title: 'Core/Token',
   component: XDSToken,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Tokenizer.stories.tsx
+++ b/apps/storybook/stories/Tokenizer.stories.tsx
@@ -24,7 +24,7 @@ const userSource: XDSSearchSource = {
 };
 
 const meta: Meta<typeof XDSTokenizer> = {
-  title: 'Form/XDSTokenizer',
+  title: 'Core/Inputs/Tokenizer',
   component: XDSTokenizer,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Toolbar.stories.tsx
+++ b/apps/storybook/stories/Toolbar.stories.tsx
@@ -27,7 +27,7 @@ import {
 } from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof XDSToolbar> = {
-  title: 'Layout/XDSToolbar',
+  title: 'Core/Toolbar',
   component: XDSToolbar,
   tags: ['autodocs'],
   parameters: {

--- a/apps/storybook/stories/ToolbarEdgeCompensation.stories.tsx
+++ b/apps/storybook/stories/ToolbarEdgeCompensation.stories.tsx
@@ -25,7 +25,7 @@ import {
 } from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof XDSToolbar> = {
-  title: 'Layout/XDSToolbar/Edge Compensation',
+  title: 'Core/Toolbar/Edge Compensation',
   component: XDSToolbar,
   parameters: {
     layout: 'padded',

--- a/apps/storybook/stories/Tooltip.stories.tsx
+++ b/apps/storybook/stories/Tooltip.stories.tsx
@@ -4,7 +4,7 @@ import {XDSButton} from '@xds/core/Button';
 import {XDSHStack} from '@xds/core/Layout';
 
 const meta: Meta<typeof XDSTooltip> = {
-  title: 'Core/XDSTooltip',
+  title: 'Core/Tooltip',
   component: XDSTooltip,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/TopNav.stories.tsx
+++ b/apps/storybook/stories/TopNav.stories.tsx
@@ -14,7 +14,7 @@ import {
 } from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof XDSTopNav> = {
-  title: 'Navigation/XDSTopNav',
+  title: 'Core/Navigation/TopNav',
   component: XDSTopNav,
   tags: ['autodocs'],
   parameters: {

--- a/apps/storybook/stories/TopNavMenu.stories.tsx
+++ b/apps/storybook/stories/TopNavMenu.stories.tsx
@@ -26,7 +26,7 @@ import {
 // =============================================================================
 
 const menuMeta: Meta<typeof XDSTopNavMenu> = {
-  title: 'Navigation/XDSTopNavMenu',
+  title: 'Core/Navigation/TopNavMenu',
   component: XDSTopNavMenu,
   tags: ['autodocs'],
   parameters: {

--- a/apps/storybook/stories/TreeList.stories.tsx
+++ b/apps/storybook/stories/TreeList.stories.tsx
@@ -13,7 +13,7 @@ import {
 const noop = () => {};
 
 const meta: Meta<typeof XDSTreeList> = {
-  title: 'Core/XDSTreeList',
+  title: 'Core/TreeList',
   component: XDSTreeList,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Typeahead.stories.tsx
+++ b/apps/storybook/stories/Typeahead.stories.tsx
@@ -23,7 +23,7 @@ const fruitSource: XDSSearchSource = {
 };
 
 const meta: Meta<typeof XDSTypeahead> = {
-  title: 'Form/XDSTypeahead',
+  title: 'Core/Inputs/Typeahead',
   component: XDSTypeahead,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/VegaChart.stories.tsx
+++ b/apps/storybook/stories/VegaChart.stories.tsx
@@ -72,7 +72,7 @@ const radialPlotSpec: AnySpec = {
 };
 
 const meta: Meta<typeof XDSVegaChart> = {
-  title: 'Vega/XDSVegaChart',
+  title: 'Vega/VegaChart',
   component: XDSVegaChart,
   tags: ['autodocs'],
   parameters: {

--- a/apps/storybook/stories/XDSMediaTheme.stories.tsx
+++ b/apps/storybook/stories/XDSMediaTheme.stories.tsx
@@ -18,7 +18,7 @@ import {XDSCard} from '@xds/core/Card';
 // =============================================================================
 
 const meta: Meta = {
-  title: 'Theme/XDSMediaTheme',
+  title: 'Core/Theme/MediaTheme',
   parameters: {
     docs: {
       description: {

--- a/apps/storybook/stories/XDSTheme.stories.tsx
+++ b/apps/storybook/stories/XDSTheme.stories.tsx
@@ -312,7 +312,7 @@ const oceanTheme = defineTheme({
 // =============================================================================
 
 const meta: Meta = {
-  title: 'Components/XDSTheme',
+  title: 'Core/Theme/Theme',
   parameters: {
     docs: {
       description: {

--- a/apps/storybook/stories/useXDSLinkify.stories.tsx
+++ b/apps/storybook/stories/useXDSLinkify.stories.tsx
@@ -66,7 +66,7 @@ function LinkifyDemo({
 // ---------------------------------------------------------------------------
 
 const meta: Meta<typeof LinkifyDemo> = {
-  title: 'Hooks/useXDSLinkify',
+  title: 'Core/Hooks/useXDSLinkify',
   component: LinkifyDemo,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/useXDSStreamingText.stories.tsx
+++ b/apps/storybook/stories/useXDSStreamingText.stories.tsx
@@ -84,7 +84,7 @@ function StreamingDemo({
 const SAMPLE_TEXT = 'Here is how you fetch a user in TypeScript:\n\nconst response = await fetch("/api/users/" + id);\nconst user = await response.json();\n\nKey points:\n- Always check response.ok before parsing\n- Use AbortController for cancellation\n- Consider a useUser hook for React apps\n\nThis approach gives you type-safe API calls with proper error handling.';
 
 const meta: Meta<typeof StreamingDemo> = {
-  title: 'Hooks/useXDSStreamingText',
+  title: 'Core/Hooks/useXDSStreamingText',
   component: StreamingDemo,
   tags: ['autodocs'],
   argTypes: {

--- a/packages/core/src/AlertDialog/AlertDialog.doc.mjs
+++ b/packages/core/src/AlertDialog/AlertDialog.doc.mjs
@@ -2,6 +2,7 @@
 
 export const docs = {
   name: 'AlertDialog',
+  group: 'Dialogs',
   keywords: [
     'alert',
     'alertdialog',

--- a/packages/core/src/Button/Button.doc.mjs
+++ b/packages/core/src/Button/Button.doc.mjs
@@ -2,6 +2,7 @@
 
 export const docs = {
   name: 'Button',
+  group: 'Buttons',
 
   keywords: ["button","btn","cta","submit","action","loading","primary","secondary","ghost","destructive","danger"],
 

--- a/packages/core/src/CheckboxInput/CheckboxInput.doc.mjs
+++ b/packages/core/src/CheckboxInput/CheckboxInput.doc.mjs
@@ -2,6 +2,7 @@
 
 export const docs = {
   name: 'CheckboxInput',
+  group: 'Inputs',
   keywords: ["checkbox","check","toggle","tick","indeterminate","boolean","tristate"],
   props: [
     {

--- a/packages/core/src/CheckboxList/CheckboxList.doc.mjs
+++ b/packages/core/src/CheckboxList/CheckboxList.doc.mjs
@@ -2,6 +2,7 @@
 
 export const docs = {
   name: 'CheckboxList',
+  group: 'Inputs',
   keywords: ["checkboxlist","checkbox","checkboxgroup","multichoice","multiselect","checklist"],
   components: [
     {

--- a/packages/core/src/DateInput/DateInput.doc.mjs
+++ b/packages/core/src/DateInput/DateInput.doc.mjs
@@ -2,6 +2,7 @@
 
 export const docs = {
   name: 'DateInput',
+  group: 'Inputs',
   keywords: ["dateinput","datepicker","datefield","calendar","dateselect","dateentry","datechooser"],
   props: [
     {

--- a/packages/core/src/Dialog/Dialog.doc.mjs
+++ b/packages/core/src/Dialog/Dialog.doc.mjs
@@ -2,6 +2,7 @@
 
 export const docs = {
   name: 'Dialog',
+  group: 'Dialogs',
   keywords: ["dialog","modal","popup","overlay","lightbox","alert","confirm","prompt","backdrop","focus trap"],
   theming: {
     container: true,

--- a/packages/core/src/Field/Field.doc.mjs
+++ b/packages/core/src/Field/Field.doc.mjs
@@ -2,6 +2,7 @@
 
 export const docs = {
   name: 'Field',
+  group: 'Inputs',
   keywords: ["field","formfield","formgroup","formcontrol","label","input","required","optional","helpertext","hint"],
   theming: {
     targets: [

--- a/packages/core/src/FormLayout/FormLayout.doc.mjs
+++ b/packages/core/src/FormLayout/FormLayout.doc.mjs
@@ -2,6 +2,7 @@
 
 export const docs = {
   name: 'FormLayout',
+  group: 'Inputs',
   keywords: ["formlayout","form","fieldset","formgroup","formcontainer","fields","vertical","horizontal"],
   props: [
     {

--- a/packages/core/src/IconButton/IconButton.doc.mjs
+++ b/packages/core/src/IconButton/IconButton.doc.mjs
@@ -2,6 +2,7 @@
 
 export const docs = {
   name: 'IconButton',
+  group: 'Buttons',
   keywords: ['icon-button', 'icon', 'button', 'toolbar', 'action', 'compact'],
 
   props: [

--- a/packages/core/src/MobileNav/MobileNav.doc.mjs
+++ b/packages/core/src/MobileNav/MobileNav.doc.mjs
@@ -2,6 +2,7 @@
 
 export const docs = {
   name: 'MobileNav',
+  group: 'Navigation',
   keywords: ["mobilenav","drawer","sidebar","navigation","hamburger","menu","offcanvas","slideout","navdrawer"],
   props: [
     {

--- a/packages/core/src/MultiSelector/MultiSelector.doc.mjs
+++ b/packages/core/src/MultiSelector/MultiSelector.doc.mjs
@@ -2,6 +2,7 @@
 
 export const docs = {
   name: 'MultiSelector',
+  group: 'Inputs',
   keywords: ['multiselect', 'checkbox', 'dropdown', 'multi', 'picker', 'checklist', 'facet', 'filter', 'select'],
   theming: {
     targets: [

--- a/packages/core/src/NavIcon/NavIcon.doc.mjs
+++ b/packages/core/src/NavIcon/NavIcon.doc.mjs
@@ -2,6 +2,7 @@
 
 export const docs = {
   name: 'NavIcon',
+  group: 'Navigation',
   keywords: ["navicon","iconbutton","toolbar icon","appbar icon","nav button"],
   props: [
     {

--- a/packages/core/src/NumberInput/NumberInput.doc.mjs
+++ b/packages/core/src/NumberInput/NumberInput.doc.mjs
@@ -2,6 +2,7 @@
 
 export const docs = {
   name: 'NumberInput',
+  group: 'Inputs',
   keywords: ["numberinput","numberfield","stepper","spinner","counter","increment","decrement","quantity","numberpicker"],
   props: [
     {

--- a/packages/core/src/PowerSearch/PowerSearch.doc.mjs
+++ b/packages/core/src/PowerSearch/PowerSearch.doc.mjs
@@ -2,6 +2,7 @@
 
 export const docs = {
   name: 'PowerSearch',
+  group: 'Inputs',
   keywords: ["powersearch","search","searchbar","filter","filterbar","faceted","querybuilder","structured","omnibar"],
   props: [
     {

--- a/packages/core/src/RadioList/RadioList.doc.mjs
+++ b/packages/core/src/RadioList/RadioList.doc.mjs
@@ -2,6 +2,7 @@
 
 export const docs = {
   name: 'RadioList',
+  group: 'Inputs',
   keywords: ["radiolist","radio","radiogroup","radiobutton","optionlist","singlechoice","choicelist"],
   theming: {
     targets: [

--- a/packages/core/src/SegmentedControl/SegmentedControl.doc.mjs
+++ b/packages/core/src/SegmentedControl/SegmentedControl.doc.mjs
@@ -2,6 +2,7 @@
 
 export const docs = {
   name: 'SegmentedControl',
+  group: 'Inputs',
   keywords: ['radio', 'tabs', 'toggle', 'toggle-group', 'pill', 'button-group', 'switch', 'segment', 'control'],
   theming: {
     targets: [

--- a/packages/core/src/Selector/Selector.doc.mjs
+++ b/packages/core/src/Selector/Selector.doc.mjs
@@ -2,6 +2,7 @@
 
 export const docs = {
   name: 'Selector',
+  group: 'Inputs',
   keywords: ["selector","select","dropdown","combobox","picker","listbox","chooser","autocomplete","option","selectmenu"],
   theming: {
     targets: [

--- a/packages/core/src/SideNav/SideNav.doc.mjs
+++ b/packages/core/src/SideNav/SideNav.doc.mjs
@@ -2,6 +2,7 @@
 
 export const docs = {
   name: 'SideNav',
+  group: 'Navigation',
   keywords: ["sidenav","sidebar","navigation","drawer","menu","nav","aside","sidemenu","navmenu","sider","treeview"],
   theming: {
     targets: [

--- a/packages/core/src/TextArea/TextArea.doc.mjs
+++ b/packages/core/src/TextArea/TextArea.doc.mjs
@@ -2,6 +2,7 @@
 
 export const docs = {
   name: 'TextArea',
+  group: 'Inputs',
   keywords: ["textarea","textfield","multiline","comment","message","autoresize","autosize","charlimit"],
   props: [
     {

--- a/packages/core/src/TextInput/TextInput.doc.mjs
+++ b/packages/core/src/TextInput/TextInput.doc.mjs
@@ -2,6 +2,7 @@
 
 export const docs = {
   name: 'TextInput',
+  group: 'Inputs',
   keywords: ["textinput","textfield","input","search","clearable","prefix","suffix","adornment","validation"],
   props: [
     {

--- a/packages/core/src/TimeInput/TimeInput.doc.mjs
+++ b/packages/core/src/TimeInput/TimeInput.doc.mjs
@@ -2,6 +2,7 @@
 
 export const docs = {
   name: 'TimeInput',
+  group: 'Inputs',
   keywords: ["timeinput","timepicker","time","clock","hour","minute","ampm","timeselect","timefield"],
   props: [
     {

--- a/packages/core/src/ToggleButton/ToggleButton.doc.mjs
+++ b/packages/core/src/ToggleButton/ToggleButton.doc.mjs
@@ -2,6 +2,7 @@
 
 export const docs = {
   name: 'ToggleButton',
+  group: 'Buttons',
   keywords: ["toggle","togglebutton","pressed","toolbar","formatting","segmented","button-group","exclusive","multi-select"],
   theming: {
     targets: [

--- a/packages/core/src/Tokenizer/Tokenizer.doc.mjs
+++ b/packages/core/src/Tokenizer/Tokenizer.doc.mjs
@@ -2,6 +2,7 @@
 
 export const docs = {
   name: 'Tokenizer',
+  group: 'Inputs',
   keywords: ["tokenizer","multiselect","multi-select","chips","tags","combobox","autocomplete","taginput","chipinput"],
   props: [
     {

--- a/packages/core/src/TopNav/TopNav.doc.mjs
+++ b/packages/core/src/TopNav/TopNav.doc.mjs
@@ -2,6 +2,7 @@
 
 export const docs = {
   name: 'TopNav',
+  group: 'Navigation',
   keywords: ["topnav","navbar","appbar","header","toolbar","navigation","menubar","topbar"],
   theming: {
     targets: [

--- a/packages/core/src/Typeahead/Typeahead.doc.mjs
+++ b/packages/core/src/Typeahead/Typeahead.doc.mjs
@@ -2,6 +2,7 @@
 
 export const docs = {
   name: 'Typeahead',
+  group: 'Inputs',
   keywords: ["typeahead","autocomplete","combobox","searchbox","autosuggest","select","dropdown","lookup","searchable","suggestion","picker"],
   components: [
     {

--- a/packages/core/src/docs-types.ts
+++ b/packages/core/src/docs-types.ts
@@ -268,6 +268,16 @@ interface BaseDoc {
    *  Lowercase only. Used by `xds component <term>` for fuzzy matching.
    *  e.g. `['accordion', 'expand', 'toggle', 'disclosure']` for Collapsible */
   keywords?: string[];
+  /** Optional group for sidebar/docs organization.
+   *  Components without a group appear flat in alphabetical order.
+   *  Groups cluster related components that are always used together
+   *  or are variants of each other. */
+  group?:
+    | 'Buttons'
+    | 'Chat'
+    | 'Dialogs'
+    | 'Inputs'
+    | 'Navigation';
   /** Theming configuration. Documents the stable CSS class names
    *  rendered by this component that themes can target via `@scope`
    *  selectors in `defineTheme`. */


### PR DESCRIPTION
## What

Implements Proposal B from #1598 — flat + grouped component organization.

## Structure

Components appear **alphabetically by default**. Groups exist only where there's clear "combination energy":

```
Components
├── AppShell
├── AspectRatio
├── Avatar
├── Badge
├── Banner
├── Breadcrumbs
├── Buttons (Button, IconButton, ToggleButton)
├── Calendar
├── Card
├── ...
├── Chat (14 sub-components)
├── Code
├── CodeBlock
├── Collapsible
├── CommandPalette
├── Dialogs (AlertDialog, Dialog)
├── Divider
├── ...
├── Inputs (18 form controls)
├── ...
├── Menus (DropdownMenu, MoreMenu)
├── MetadataList
├── Navigation (SideNav, TopNav, MobileNav, NavIcon, NavMenuItem)
├── ...
├── Table
├── Text (includes Heading)
├── ...
└── Utilities
```

## Changes

### Type system
- Added `group?` field to `BaseDoc` in `docs-types.ts`
- Union type: `'Buttons' | 'Chat' | 'Dialogs' | 'Inputs' | 'Menus' | 'Navigation'`

### doc.mjs files (29 updated)
- 3 Buttons, 2 Dialogs, 2 Menus, 4 Navigation, 18 Inputs

### Storybook titles (77 updated)
- Old categories removed: `Core/`, `Form/`, `Layout/`, `Components/`, `Typography/`
- Grouped components get group prefix: `Buttons/XDSButton`, `Inputs/XDSTextInput`
- Flat components have no prefix: `XDSAvatar`, `XDSCard`, `XDSTable`

Refs #1598