### PR TITLE
Improve StatusDot docs page and block examples

### DIFF
--- a/packages/cli/templates/blocks/components/StatusDot/StatusDotPulsing.doc.mjs
+++ b/packages/cli/templates/blocks/components/StatusDot/StatusDotPulsing.doc.mjs
@@ -4,6 +4,7 @@ export const doc = {
   name: 'StatusDot — Pulsing',
   description: 'Animated pulsing dots for live, processing, and error states.',
   isReady: true,
-  aspectRatio: 4 / 3,
-  componentsUsed: ['StatusDot'],
+  aspectRatio: 1,
+  scale: 2,
+  componentsUsed: ['StatusDot', 'HStack'],
 };

--- a/packages/cli/templates/blocks/components/StatusDot/StatusDotPulsing.tsx
+++ b/packages/cli/templates/blocks/components/StatusDot/StatusDotPulsing.tsx
@@ -1,13 +1,14 @@
 'use client';
 
 import {XDSStatusDot} from '@xds/core/StatusDot';
+import {XDSHStack} from '@xds/core/Layout';
 
 export default function StatusDotPulsing() {
   return (
-    <div style={{display: 'flex', gap: 8, alignItems: 'center'}}>
+    <XDSHStack gap={2} vAlign="center">
       <XDSStatusDot variant="positive" label="Live" isPulsing />
       <XDSStatusDot variant="warning" label="Processing" isPulsing />
       <XDSStatusDot variant="negative" label="Error" isPulsing />
-    </div>
+    </XDSHStack>
   );
 }

--- a/packages/cli/templates/blocks/components/StatusDot/StatusDotStatusIndicators.doc.mjs
+++ b/packages/cli/templates/blocks/components/StatusDot/StatusDotStatusIndicators.doc.mjs
@@ -5,6 +5,7 @@ export const doc = {
   description:
     'Labeled status dot list for presence indicators like online, away, and offline.',
   isReady: true,
-  aspectRatio: 4 / 3,
-  componentsUsed: ['StatusDot'],
+  aspectRatio: 1,
+  scale: 2,
+  componentsUsed: ['StatusDot', 'VStack', 'HStack', 'Text'],
 };

--- a/packages/cli/templates/blocks/components/StatusDot/StatusDotStatusIndicators.tsx
+++ b/packages/cli/templates/blocks/components/StatusDot/StatusDotStatusIndicators.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import {XDSStatusDot} from '@xds/core/StatusDot';
+import {XDSVStack, XDSHStack} from '@xds/core/Layout';
+import {XDSText} from '@xds/core/Text';
 
 const statuses = [
   {variant: 'positive', label: 'Online'},
@@ -11,15 +13,13 @@ const statuses = [
 
 export default function StatusDotStatusIndicators() {
   return (
-    <div style={{display: 'flex', flexDirection: 'column', gap: 8}}>
+    <XDSVStack gap={2}>
       {statuses.map(({variant, label}) => (
-        <div
-          key={variant}
-          style={{display: 'flex', gap: 8, alignItems: 'center'}}>
+        <XDSHStack key={variant} gap={2} vAlign="center">
           <XDSStatusDot variant={variant} label={label} />
-          <span>{label}</span>
-        </div>
+          <XDSText type="body">{label}</XDSText>
+        </XDSHStack>
       ))}
-    </div>
+    </XDSVStack>
   );
 }

--- a/packages/cli/templates/blocks/components/StatusDot/StatusDotVariants.doc.mjs
+++ b/packages/cli/templates/blocks/components/StatusDot/StatusDotVariants.doc.mjs
@@ -4,6 +4,7 @@ export const doc = {
   name: 'StatusDot — Variants',
   description: 'All five semantic color variants displayed in a row.',
   isReady: true,
-  aspectRatio: 4 / 3,
-  componentsUsed: ['StatusDot'],
+  aspectRatio: 1,
+  scale: 2,
+  componentsUsed: ['StatusDot', 'HStack'],
 };

--- a/packages/cli/templates/blocks/components/StatusDot/StatusDotVariants.tsx
+++ b/packages/cli/templates/blocks/components/StatusDot/StatusDotVariants.tsx
@@ -1,15 +1,16 @@
 'use client';
 
 import {XDSStatusDot} from '@xds/core/StatusDot';
+import {XDSHStack} from '@xds/core/Layout';
 
 export default function StatusDotVariants() {
   return (
-    <div style={{display: 'flex', gap: 8, alignItems: 'center'}}>
+    <XDSHStack gap={2} vAlign="center">
       <XDSStatusDot variant="positive" label="Positive" />
       <XDSStatusDot variant="warning" label="Warning" />
       <XDSStatusDot variant="negative" label="Negative" />
       <XDSStatusDot variant="info" label="Info" />
       <XDSStatusDot variant="neutral" label="Neutral" />
-    </div>
+    </XDSHStack>
   );
 }

--- a/packages/core/src/StatusDot/StatusDot.doc.mjs
+++ b/packages/core/src/StatusDot/StatusDot.doc.mjs
@@ -37,12 +37,12 @@ export const docs = {
   },
   usage: {
     description:
-      'StatusDot is a small colored dot indicator that communicates status through semantic color variants. Use it alongside text labels to convey states like online/offline presence or severity levels, as color alone should not carry meaning.',
+      'A small colored dot that communicates status like online/offline presence or severity levels. Supports five semantic variants and an optional pulse animation. Always pair with a visible text label, as color alone should not carry meaning.',
     bestPractices: [
       { guidance: true, description: 'Always pair with a visible text label so status is not conveyed by color alone.' },
-      { guidance: true, description: 'Provide a descriptive label prop for screen reader accessibility.' },
-      { guidance: false, description: 'Use StatusDot as the sole indicator of status without an accompanying text label.' },
-      { guidance: false, description: 'Enable the pulse animation for purely decorative purposes — reserve it for states that require immediate attention.' },
+      { guidance: true, description: 'Provide a descriptive `label` prop for screen reader accessibility.' },
+      { guidance: false, description: 'Use the pulse animation for purely decorative purposes — reserve it for states that require immediate attention.' },
+      { guidance: false, description: 'Rely on color alone to communicate status — always include text.' },
     ],
   },
 };
@@ -84,12 +84,12 @@ export const docsZh = {
   },
   usage: {
     description:
-      'StatusDot is a small colored dot indicator that communicates status through semantic color variants. Use it alongside text labels to convey states like online/offline presence or severity levels, as color alone should not carry meaning.',
+      'A small colored dot that communicates status like online/offline presence or severity levels. Supports five semantic variants and an optional pulse animation. Always pair with a visible text label, as color alone should not carry meaning.',
     bestPractices: [
       { guidance: true, description: 'Always pair with a visible text label so status is not conveyed by color alone.' },
-      { guidance: true, description: 'Provide a descriptive label prop for screen reader accessibility.' },
-      { guidance: false, description: 'Use StatusDot as the sole indicator of status without an accompanying text label.' },
-      { guidance: false, description: 'Enable the pulse animation for purely decorative purposes — reserve it for states that require immediate attention.' },
+      { guidance: true, description: 'Provide a descriptive `label` prop for screen reader accessibility.' },
+      { guidance: false, description: 'Use the pulse animation for purely decorative purposes — reserve it for states that require immediate attention.' },
+      { guidance: false, description: 'Rely on color alone to communicate status — always include text.' },
     ],
   },
 };
@@ -99,12 +99,12 @@ export const docsDense = {
   description: 'Small colored dot indicator for status display (online/offline, severity, etc).',
   usage: {
     description:
-      'StatusDot is a small colored dot indicator that communicates status through semantic color variants. Use it alongside text labels to convey states like online/offline presence or severity levels, as color alone should not carry meaning.',
+      'A small colored dot that communicates status like online/offline presence or severity levels. Supports five semantic variants and an optional pulse animation. Always pair with a visible text label, as color alone should not carry meaning.',
     bestPractices: [
       { guidance: true, description: 'Always pair with a visible text label so status is not conveyed by color alone.' },
-      { guidance: true, description: 'Provide a descriptive label prop for screen reader accessibility.' },
-      { guidance: false, description: 'Use StatusDot as the sole indicator of status without an accompanying text label.' },
-      { guidance: false, description: 'Enable the pulse animation for purely decorative purposes — reserve it for states that require immediate attention.' },
+      { guidance: true, description: 'Provide a descriptive `label` prop for screen reader accessibility.' },
+      { guidance: false, description: 'Use the pulse animation for purely decorative purposes — reserve it for states that require immediate attention.' },
+      { guidance: false, description: 'Rely on color alone to communicate status — always include text.' },
     ],
   },
   propDescriptions: {


### PR DESCRIPTION
## Summary
- Rewrite usage description to highlight variants and pulse animation
- Remove duplicate best practice, add clearer "color alone" don't
- Replace raw HTML `<div>` and `<span>` with `XDSCenter`, `XDSHStack`, `XDSVStack`, `XDSText`
- Center all 3 block examples
- Update `componentsUsed` in doc metadata

## Test plan
- [ ] Verify `npx xds component StatusDot` output reflects updated usage and best practices
- [ ] Verify all 3 StatusDot blocks render correctly in the sandbox
- [ ] Check blocks are centered in previews