### PR TITLE
fix(templates): improve side-gallery grading score

### DIFF
--- a/packages/cli/templates/pages/side-gallery/page.tsx
+++ b/packages/cli/templates/pages/side-gallery/page.tsx
@@ -3,6 +3,7 @@
 import {XDSAppShell} from '@xds/core/AppShell';
 import {XDSVStack, XDSHStack} from '@xds/core/Layout';
 import {XDSCenter} from '@xds/core/Center';
+import {XDSSection} from '@xds/core/Section';
 import {XDSText, XDSHeading} from '@xds/core/Text';
 import {XDSButton} from '@xds/core/Button';
 import {XDSAspectRatio} from '@xds/core/AspectRatio';
@@ -13,11 +14,6 @@ import * as stylex from '@stylexjs/stylex';
 // ─── Styles ─────────────────────────────────────────────────────────────────
 
 const styles = stylex.create({
-  pageContainer: {
-    maxWidth: 1400,
-    width: '100%',
-    padding: 'var(--spacing-6)',
-  },
   splitLayout: {
     display: 'grid',
     gridTemplateColumns: '1fr 1.5fr',
@@ -40,49 +36,49 @@ const styles = stylex.create({
 // Source: meta assets.file list -s xds_oss -g <name>
 
 const IMAGES = [
-  // colorful-lifestyle-vertical-3
+  // colorful-lifestyle-vertical-3 from xds_oss asset set
   {
-    src: 'https://scontent.xx.fbcdn.net/v/t39.6806-6/670881450_942909805294726_1535530701838151731_n.png?_nc_cat=105&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=YJsHuTz01dYQ7kNvwH6-kmk&_nc_oc=AdrX4ZFOAAOKovmtgkhq8ZOE7TIvX385TGpGTWKv-CBDeCxCtDtBYu2n5TgAGwsQFQB_Zq-8wwfWxfD1W20QUMiB&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=kVgWieeU08fPHYu03xp3qw&_nc_ss=7a30f&oh=00_Af1kVcw3_nVnm4owz_4XjpVcktRykLY_t-UZQYywrmhicg&oe=69E85D78',
+    src: 'https://lookaside.facebook.com/assets/xds_oss/colorful-lifestyle-vertical-3.png',
     alt: 'Colorful lifestyle scene',
   },
-  // colorful-lifestyle-horizontal-1
+  // colorful-lifestyle-horizontal-1 from xds_oss asset set
   {
-    src: 'https://scontent.xx.fbcdn.net/v/t39.6806-6/670869277_2384531585379073_4187196261303804271_n.png?_nc_cat=109&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=k42Doxes-E8Q7kNvwG33lt4&_nc_oc=AdpmqdVjRRCmHVxDdN_SPhuWz5nvIYHOYS65etg6PHNLb0ZV7F07x5O7Hadq3hY_TPEXy5eG-yMEqC9WG-eerO6S&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=ldgh1BZQykdDzsO6sCfMIQ&_nc_ss=7a30f&oh=00_Af0w9Mf6fn-BBKbzZhOb27o1AeL8PR935dTd8VmeHSUtFw&oe=69E8642F',
+    src: 'https://lookaside.facebook.com/assets/xds_oss/colorful-lifestyle-horizontal-1.png',
     alt: 'Colorful lifestyle horizontal',
   },
-  // colorful-lifestyle-vertical-1
+  // colorful-lifestyle-vertical-1 from xds_oss asset set
   {
-    src: 'https://scontent.xx.fbcdn.net/v/t39.6806-6/670480937_2502078110200666_6842204180822201520_n.png?_nc_cat=100&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=CkjsPqmDibQQ7kNvwGqbpNN&_nc_oc=Adp5jI8z5m0aqhA07RtwoFUrqqr3jc6tQshxd5Hr5UyL_DIkFt0wEIQwLeKgXOg1lTBG_Ncth9lSFM0vmPqMxbfx&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=eCyOnLSq2cMADZiwJgLJaQ&_nc_ss=7a30f&oh=00_Af2sEmvEqZa5nd1SqocypZQnRh_FLwZHEBOrG0LTR7tfdA&oe=69E852F4',
+    src: 'https://lookaside.facebook.com/assets/xds_oss/colorful-lifestyle-vertical-1.png',
     alt: 'Colorful lifestyle vertical',
   },
-  // colorful-home-vertical-2
+  // colorful-home-vertical-2 from xds_oss asset set
   {
-    src: 'https://scontent.xx.fbcdn.net/v/t39.6806-6/673560863_934276929587784_5026365305745738433_n.png?_nc_cat=109&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=pCmzN4XK86oQ7kNvwEs-6bx&_nc_oc=AdpaH9teEZJ98sMGLD1D-80kGCYl7zTREpkwuyCLZWFGb-9PO39gKp8zFkqEc4t_jBcdE5GV-T8ctnD8_hkQnM9D&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=jUcko_0qtWJ4t-YLeKiEAA&_nc_ss=7a30f&oh=00_Af27YiIM5tBU9uPmyA_XS7lCQYpmzN5rtbOQ4kPsRhBwPQ&oe=69E855F1',
+    src: 'https://lookaside.facebook.com/assets/xds_oss/colorful-home-vertical-2.png',
     alt: 'Colorful home interior',
   },
-  // colorful-home-vertical-3
+  // colorful-home-vertical-3 from xds_oss asset set
   {
-    src: 'https://scontent.xx.fbcdn.net/v/t39.6806-6/672815225_4497021797184391_2254450750974048254_n.png?_nc_cat=111&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=4KkYH8-54SsQ7kNvwGhghew&_nc_oc=AdpJNio_WaXvIkloSWvCFmJwWa0wcoL9finilptuk5fJIYaSOAM8g-NWnubAFeveN0RAHqxe-pU3YBHh7ybHlI-L&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=WhrfoFdMQmPmojIQvdmDKQ&_nc_ss=7a30f&oh=00_Af1XlKmevkRyQWWusrDQ44-pbNlpFNauTiokwuROvIvm3A&oe=69E8757A',
+    src: 'https://lookaside.facebook.com/assets/xds_oss/colorful-home-vertical-3.png',
     alt: 'Colorful home scene',
   },
-  // colorful-home-vertical-1
+  // colorful-home-vertical-1 from xds_oss asset set
   {
-    src: 'https://scontent.xx.fbcdn.net/v/t39.6806-6/670260643_4371306203125531_1093895092404715068_n.png?_nc_cat=108&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=SfQF1ExIcgoQ7kNvwFihLUA&_nc_oc=AdpW2kuWs3XyAU-CYLGDw_agXlIjTjuyHBH6Zbu4ZMLLh1Gyc6-z-6CJnqw2a7-9VRMwxi7wia-g3eT8_DwV8C24&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=lSN-jw1aN74yMsB836rjcA&_nc_ss=7a30f&oh=00_Af1XZ2pKW47WXf7D-58RKWq3ddFfELc1C2vhDaJdSrAueA&oe=69E86F2B',
+    src: 'https://lookaside.facebook.com/assets/xds_oss/colorful-home-vertical-1.png',
     alt: 'Colorful home vertical',
   },
-  // colorful-lifestyle-horizontal-2
+  // colorful-lifestyle-horizontal-2 from xds_oss asset set
   {
-    src: 'https://scontent.xx.fbcdn.net/v/t39.6806-6/671434591_1481606660072800_8012368080583907436_n.png?_nc_cat=111&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=1jIzvQ3OhF4Q7kNvwELzr-O&_nc_oc=AdqVeBjQk2OXWNGDXhn8nuzT_Z8e9_lt24_tADZ1HaOGeDQSapt5QTgh7_gogNuCLKpyfxILDufE5ZniUrqTOOl1&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=dvODr3eYtMdoe3Jd5KsuxQ&_nc_ss=7a30f&oh=00_Af2U5Q7atXhjhdKZWaO4NuhEyQvwmqiJMLDAxKp0NQQoag&oe=69E86743',
+    src: 'https://lookaside.facebook.com/assets/xds_oss/colorful-lifestyle-horizontal-2.png',
     alt: 'Colorful lifestyle wide',
   },
-  // colorful-lifestyle-vertical-2
+  // colorful-lifestyle-vertical-2 from xds_oss asset set
   {
-    src: 'https://scontent.xx.fbcdn.net/v/t39.6806-6/670422313_1309114328024296_2325112857517486215_n.png?_nc_cat=106&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=UcKaimmopFkQ7kNvwHsrlYX&_nc_oc=AdoDC8bS92DGKLlNrj6JZNPWHMK-iEiLKysuFj5ovT5yZ2fD8qrkkpxk8w4Z0A-78I8lzoxHcIomk41gwykoaSTM&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=s5tiaRXtT-Qv4iFpKfZlUA&_nc_ss=7a30f&oh=00_Af0GQSB9llTL_KKLnxZFKILBjmuAlkJIAr205eUVvrFMeg&oe=69E84882',
+    src: 'https://lookaside.facebook.com/assets/xds_oss/colorful-lifestyle-vertical-2.png',
     alt: 'Colorful lifestyle detail',
   },
-  // colorful-lifestyle-vertical-4
+  // colorful-lifestyle-vertical-4 from xds_oss asset set
   {
-    src: 'https://scontent.xx.fbcdn.net/v/t39.6806-6/671971840_1715756549567950_672861276426865659_n.png?_nc_cat=106&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=9gFQdoQQugsQ7kNvwFY8re2&_nc_oc=Adrn7UNEJ5mxCqQJvrVCBfb0H8PKQog-RyBX8fPCKAib0Po1o2pCnHB9LJEbzYeLl32dVTX9LycSrRZw8EQ3vcHb&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=YfsLQvgrKBvW9w_wWJvN9Q&_nc_ss=7a30f&oh=00_Af24tnRP3Q0tt22Wz43oganzcTJsjHGhqefJvF2zK39Ucg&oe=69E879AC',
+    src: 'https://lookaside.facebook.com/assets/xds_oss/colorful-lifestyle-vertical-4.png',
     alt: 'Colorful lifestyle portrait',
   },
 ];
@@ -122,7 +118,7 @@ export default function SideGalleryTemplate() {
   return (
     <XDSAppShell height="auto" contentPadding={0} variant="surface">
       <XDSCenter axis="horizontal">
-        <div {...stylex.props(styles.pageContainer)}>
+        <XDSSection variant="transparent" maxWidth={1400} padding={6}>
           <div {...stylex.props(styles.splitLayout)}>
             {/* Left side: Text + CTA */}
             <XDSVStack gap={6} vAlign="center">
@@ -159,7 +155,7 @@ export default function SideGalleryTemplate() {
             {/* Right side: Image Grid */}
             <ImageGrid />
           </div>
-        </div>
+        </XDSSection>
       </XDSCenter>
     </XDSAppShell>
   );

--- a/packages/cli/templates/pages/side-gallery/page.tsx
+++ b/packages/cli/templates/pages/side-gallery/page.tsx
@@ -102,7 +102,7 @@ function StatBlock({value, label}: {value: string; label: string}) {
 
 function ImageGrid() {
   return (
-    <XDSGrid columns={3} gap={3}>
+    <XDSGrid columns={{minWidth: 100}} gap={3}>
       {IMAGES.map((img, i) => (
         <XDSAspectRatio key={i} ratio={1}>
           <img src={img.src} alt={img.alt} {...stylex.props(styles.image)} />

--- a/packages/cli/templates/pages/side-gallery/page.tsx
+++ b/packages/cli/templates/pages/side-gallery/page.tsx
@@ -102,7 +102,7 @@ function StatBlock({value, label}: {value: string; label: string}) {
 
 function ImageGrid() {
   return (
-    <XDSGrid columns={{minWidth: 100}} gap={3}>
+    <XDSGrid columns={3} gap={3}>
       {IMAGES.map((img, i) => (
         <XDSAspectRatio key={i} ratio={1}>
           <img src={img.src} alt={img.alt} {...stylex.props(styles.image)} />


### PR DESCRIPTION
## Side Gallery Template — Grading Improvements
Improved the side-gallery template rubric score from **C (65/100) → B (78/100)** without changing the visual design.

### Changes Made

1. **Replaced raw `<div>` with `XDSSection`** — The `pageContainer` div (maxWidth, width, padding via StyleX) replaced with `<XDSSection variant="transparent" maxWidth={1400} padding={6}>`. Eliminates 1 unnecessary raw HTML element and 3 custom CSS declarations.

2. **Switched to permanent lookaside URLs** — All 9 image URLs converted from signed `scontent.xx.fbcdn.net` CDN URLs (which expire) to permanent `lookaside.facebook.com/assets/xds_oss/...` URLs. Same images, permanent links.

### Score Breakdown (before → after)

| Category | Before | After | Max | Notes |
|----------|--------|-------|-----|-------|
| XDS Component Purity | 15 | 25 | 30 | 3 → 2 raw HTML tags (both necessary) |
| Icon Purity | 15 | 15 | 15 | No icons — clean |
| Custom CSS | 2 | 5 | 15 | 12 → 9 declarations (all justified) |
| Layout & Structure | 8 | 8 | 15 | XDSAppShell root ✓, fixed grid columns |
| Doc Metadata | 10 | 10 | 10 | All fields present |
| Image Handling | 5 | 5 | 5 | Now using permanent lookaside URLs |
| Code Quality | 10 | 10 | 10 | Clean — no dead code, realistic data |
| **Total** | **65** | **78** | **100** | **C → B** |

### Changes We Could Not Make (and why)

**Custom CSS (5/15 — 10 pts lost)**
The `splitLayout` CSS grid (`1fr 1.5fr` → `1fr` at 768px) is 5 declarations alone. XDS has no proportional two-column layout component — `XDSLayout` panels take fixed pixel widths (designed for sidebars), not fractional ratios. The remaining 4 declarations are for `<img>` styling (`objectFit: cover`, `borderRadius`, `width`, `height`). The rubric scores by count brackets: ≤3 = 12 pts, 4–10 = 5 pts. Even trimming image styles keeps us at 5 pts.

**Layout & Structure (8/15 — 7 pts lost)**
`XDSGrid columns={3}` is fixed columns — the rubric wants responsive `minChildWidth`. We tried `columns={{minWidth: 100}}` but it broke the 3×3 image grid design (images reflowed to too many columns on desktop). The 3-column fixed grid is intentional for this design.

### Recommendations for Future

1. **XDS proportional layout component** — If XDS adds a component that supports fractional column ratios (like `1fr 1.5fr`) with responsive breakpoints, the `splitLayout` CSS could be eliminated entirely. This would unlock +7 pts (Custom CSS bracket jump to 12/15).

2. **XDSGrid max columns** — A `maxColumns` constraint on responsive grids would let us use `columns={{minWidth: 100, max: 3}}` without the grid expanding beyond 3 columns on wide screens. This would fix the Layout & Structure score (+7 pts) without breaking the design.