### PR TITLE
Improve TreeList docs page and block examples

### DIFF
--- a/packages/cli/templates/blocks/components/TreeList/TreeListFileTreeWithIcons.tsx
+++ b/packages/cli/templates/blocks/components/TreeList/TreeListFileTreeWithIcons.tsx
@@ -2,24 +2,7 @@
 
 import {XDSTreeList} from '@xds/core/TreeList';
 import {XDSIcon} from '@xds/core/Icon';
-
-function FolderIcon() {
-  return (
-    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
-      <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 12.75V12A2.25 2.25 0 0 1 4.5 9.75h15A2.25 2.25 0 0 1 21.75 12v.75m-8.69-6.44-2.12-2.12a1.5 1.5 0 0 0-1.061-.44H4.5A2.25 2.25 0 0 0 2.25 6v12a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18V9a2.25 2.25 0 0 0-2.25-2.25h-5.379a1.5 1.5 0 0 1-1.06-.44Z" />
-    </svg>
-  );
-}
-
-function DocumentIcon() {
-  return (
-    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
-      <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" />
-    </svg>
-  );
-}
-
-const noop = () => {};
+import {FolderIcon, DocumentIcon} from '@heroicons/react/24/outline';
 
 export default function TreeListFileTreeWithIcons() {
   return (
@@ -29,27 +12,27 @@ export default function TreeListFileTreeWithIcons() {
           id: 'src',
           label: 'src',
           isExpanded: true,
-          startContent: <XDSIcon icon={FolderIcon} />,
+          startContent: <XDSIcon icon={FolderIcon} size="sm" />,
           children: [
             {
               id: 'app',
               label: 'App.tsx',
-              onClick: noop,
-              startContent: <XDSIcon icon={DocumentIcon} />,
+              onClick: () => {},
+              startContent: <XDSIcon icon={DocumentIcon} size="sm" />,
             },
             {
               id: 'index',
               label: 'index.tsx',
-              onClick: noop,
-              startContent: <XDSIcon icon={DocumentIcon} />,
+              onClick: () => {},
+              startContent: <XDSIcon icon={DocumentIcon} size="sm" />,
             },
           ],
         },
         {
           id: 'pkg',
           label: 'package.json',
-          onClick: noop,
-          startContent: <XDSIcon icon={DocumentIcon} />,
+          onClick: () => {},
+          startContent: <XDSIcon icon={DocumentIcon} size="sm" />,
         },
       ]}
     />

--- a/packages/cli/templates/blocks/components/TreeList/TreeListInteractiveSettings.doc.mjs
+++ b/packages/cli/templates/blocks/components/TreeList/TreeListInteractiveSettings.doc.mjs
@@ -3,7 +3,7 @@ export const doc = {
   type: 'block',
   name: 'TreeList — Interactive Settings',
   description:
-    'Settings panel tree with clickable items, a gear icon, and a documentation link with a chevron indicator.',
+    'Settings tree with clickable items and a documentation link.',
   isReady: true,
   aspectRatio: 4 / 3,
   componentsUsed: ['TreeList', 'Icon'],

--- a/packages/cli/templates/blocks/components/TreeList/TreeListInteractiveSettings.tsx
+++ b/packages/cli/templates/blocks/components/TreeList/TreeListInteractiveSettings.tsx
@@ -2,23 +2,7 @@
 
 import {XDSTreeList} from '@xds/core/TreeList';
 import {XDSIcon} from '@xds/core/Icon';
-
-function CogIcon() {
-  return (
-    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
-      <path strokeLinecap="round" strokeLinejoin="round" d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.646.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 0 1 1.37.49l1.296 2.247a1.125 1.125 0 0 1-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.723 7.723 0 0 1 0 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.247a1.125 1.125 0 0 1-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 0 1-.22.128c-.333.183-.582.495-.644.869l-.213 1.281c-.09.543-.56.94-1.11.94h-2.594c-.55 0-1.019-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 0 1-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 0 1-1.369-.49l-1.297-2.247a1.125 1.125 0 0 1 .26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 0 1 0-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 0 1-.26-1.43l1.297-2.247a1.125 1.125 0 0 1 1.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869l.214-1.28Z" />
-      <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
-    </svg>
-  );
-}
-
-function ChevronIcon() {
-  return (
-    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
-      <path strokeLinecap="round" strokeLinejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" />
-    </svg>
-  );
-}
+import {Cog6ToothIcon, ChevronRightIcon} from '@heroicons/react/24/outline';
 
 export default function TreeListInteractiveSettings() {
   return (
@@ -28,7 +12,7 @@ export default function TreeListInteractiveSettings() {
           id: 'settings',
           label: 'Settings',
           isExpanded: true,
-          startContent: <XDSIcon icon={CogIcon} />,
+          startContent: <XDSIcon icon={Cog6ToothIcon} size="sm" />,
           children: [
             {
               id: 'general',
@@ -46,7 +30,7 @@ export default function TreeListInteractiveSettings() {
           id: 'docs',
           label: 'Documentation',
           href: '#',
-          endContent: <XDSIcon icon={ChevronIcon} />,
+          endContent: <XDSIcon icon={ChevronRightIcon} size="sm" />,
         },
       ]}
     />

--- a/packages/cli/templates/blocks/components/TreeList/TreeListMailboxTree.doc.mjs
+++ b/packages/cli/templates/blocks/components/TreeList/TreeListMailboxTree.doc.mjs
@@ -3,7 +3,7 @@ export const doc = {
   type: 'block',
   name: 'TreeList — Mailbox Tree',
   description:
-    'Email folder hierarchy with badge counts showing unread messages per folder.',
+    'Email folder tree with unread badge counts.',
   isReady: true,
   aspectRatio: 4 / 3,
   componentsUsed: ['TreeList', 'Badge'],

--- a/packages/cli/templates/blocks/components/TreeList/TreeListNavigationTree.doc.mjs
+++ b/packages/cli/templates/blocks/components/TreeList/TreeListNavigationTree.doc.mjs
@@ -3,7 +3,7 @@ export const doc = {
   type: 'block',
   name: 'TreeList — Navigation Tree',
   description:
-    'Simple section-based navigation tree with a selected item highlighting the current page.',
+    'Navigation tree with a selected item for the current page.',
   isReady: true,
   aspectRatio: 4 / 3,
   componentsUsed: ['TreeList'],

--- a/packages/core/src/TreeList/TreeList.doc.mjs
+++ b/packages/core/src/TreeList/TreeList.doc.mjs
@@ -44,11 +44,12 @@ export const docs = {
   ],
   usage: {
     description:
-      'TreeList displays hierarchical data as an expandable and collapsible tree structure with branch connector lines. Use TreeList for file explorers, nested category browsers, or any interface that visualizes parent-child relationships.',
+      'An expandable tree structure for displaying hierarchical data with branch connector lines. Use it for file explorers, nested category browsers, or any interface that visualizes parent-child relationships.',
     bestPractices: [
       {guidance: true, description: 'Provide meaningful labels and icons for each node to make the hierarchy easy to scan.'},
-      {guidance: true, description: 'Pre-expand important branches using isExpanded so users see key content immediately.'},
-      {guidance: false, description: 'Avoid deeply nesting more than 4-5 levels — flatten the structure or use a different pattern for very deep hierarchies.'},
+      {guidance: true, description: 'Pre-expand important branches so users see key content immediately.'},
+      {guidance: false, description: 'Nest more than 4–5 levels deep — flatten the structure or use a different pattern.'},
+      {guidance: false, description: 'Use a tree for flat, non-hierarchical data — use a List instead.'},
     ],
   },
 };
@@ -104,11 +105,12 @@ export const docsZh = {
   ],
   usage: {
     description:
-      'TreeList displays hierarchical data as an expandable and collapsible tree structure with branch connector lines. Use TreeList for file explorers, nested category browsers, or any interface that visualizes parent-child relationships.',
+      'An expandable tree structure for displaying hierarchical data with branch connector lines. Use it for file explorers, nested category browsers, or any interface that visualizes parent-child relationships.',
     bestPractices: [
       {guidance: true, description: 'Provide meaningful labels and icons for each node to make the hierarchy easy to scan.'},
-      {guidance: true, description: 'Pre-expand important branches using isExpanded so users see key content immediately.'},
-      {guidance: false, description: 'Avoid deeply nesting more than 4-5 levels — flatten the structure or use a different pattern for very deep hierarchies.'},
+      {guidance: true, description: 'Pre-expand important branches so users see key content immediately.'},
+      {guidance: false, description: 'Nest more than 4–5 levels deep — flatten the structure or use a different pattern.'},
+      {guidance: false, description: 'Use a tree for flat, non-hierarchical data — use a List instead.'},
     ],
   },
 };
@@ -119,11 +121,12 @@ export const docsDense = {
     'Data-driven tree list for hierarchical data w/ expand/collapse, branch lines, interactive items. Flat items array w/ recursive children, no composition, no cloneElement.',
   usage: {
     description:
-      'TreeList displays hierarchical data as an expandable and collapsible tree structure with branch connector lines. Use TreeList for file explorers, nested category browsers, or any interface that visualizes parent-child relationships.',
+      'An expandable tree structure for displaying hierarchical data with branch connector lines. Use it for file explorers, nested category browsers, or any interface that visualizes parent-child relationships.',
     bestPractices: [
       {guidance: true, description: 'Provide meaningful labels and icons for each node to make the hierarchy easy to scan.'},
-      {guidance: true, description: 'Pre-expand important branches using isExpanded so users see key content immediately.'},
-      {guidance: false, description: 'Avoid deeply nesting more than 4-5 levels — flatten the structure or use a different pattern for very deep hierarchies.'},
+      {guidance: true, description: 'Pre-expand important branches so users see key content immediately.'},
+      {guidance: false, description: 'Nest more than 4–5 levels deep — flatten the structure or use a different pattern.'},
+      {guidance: false, description: 'Use a tree for flat, non-hierarchical data — use a List instead.'},
     ],
   },
   propDescriptions: {


### PR DESCRIPTION
## Summary
- Rewrite usage description for clarity
- Simplify best practices: drop `isExpanded` jargon, add flat data don't
- Replace inline SVG icons with Heroicons in File Tree and Interactive Settings blocks
- Tighten block descriptions

## Test plan
- [ ] Verify `npx xds component TreeList` output reflects updated usage and best practices
- [ ] Verify all 4 TreeList blocks render correctly in the sandbox
- [ ] Check File Tree and Interactive Settings blocks render Heroicons correctly