### PR TITLE
docs: reorganize component categories (Proposal A)

### DIFF
--- a/apps/storybook/stories/AlertDialog.stories.tsx
+++ b/apps/storybook/stories/AlertDialog.stories.tsx
@@ -7,7 +7,7 @@ import {
 import {XDSButton} from '@xds/core/Button';
 
 const meta: Meta<typeof XDSAlertDialog> = {
-  title: 'Core/XDSAlertDialog',
+  title: 'Overlays/AlertDialog',
   component: XDSAlertDialog,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/AnalyticsDashboard.stories.tsx
+++ b/apps/storybook/stories/AnalyticsDashboard.stories.tsx
@@ -1385,7 +1385,7 @@ function AnalyticsDashboard() {
 // =============================================================================
 
 const meta: Meta = {
-  title: 'Pages/Analytics Dashboard',
+  title: 'Patterns/Analytics Dashboard',
   parameters: {
     layout: 'fullscreen',
   },

--- a/apps/storybook/stories/AppShell.stories.tsx
+++ b/apps/storybook/stories/AppShell.stories.tsx
@@ -224,7 +224,7 @@ function SideNavWithHeader() {
 // =============================================================================
 
 const meta: Meta<typeof XDSAppShell> = {
-  title: 'Core/XDSAppShell',
+  title: 'Layout/AppShell',
   component: XDSAppShell,
   tags: ['autodocs'],
   parameters: {

--- a/apps/storybook/stories/AspectRatio.stories.tsx
+++ b/apps/storybook/stories/AspectRatio.stories.tsx
@@ -65,7 +65,7 @@ const styles = stylex.create({
 });
 
 const meta: Meta<typeof XDSAspectRatio> = {
-  title: 'Layout/XDSAspectRatio',
+  title: 'Layout/AspectRatio',
   component: XDSAspectRatio,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Avatar.stories.tsx
+++ b/apps/storybook/stories/Avatar.stories.tsx
@@ -23,7 +23,7 @@ const styles = stylex.create({
 });
 
 const meta: Meta<typeof XDSAvatar> = {
-  title: 'Core/XDSAvatar',
+  title: 'Display/Avatar',
   component: XDSAvatar,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Badge.stories.tsx
+++ b/apps/storybook/stories/Badge.stories.tsx
@@ -2,7 +2,7 @@ import type {Meta, StoryObj} from '@storybook/react';
 import {XDSBadge} from '@xds/core/Badge';
 
 const meta: Meta<typeof XDSBadge> = {
-  title: 'Core/XDSBadge',
+  title: 'Display/Badge',
   component: XDSBadge,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Banner.stories.tsx
+++ b/apps/storybook/stories/Banner.stories.tsx
@@ -5,7 +5,7 @@ import {XDSIcon} from '@xds/core/Icon';
 import {ShieldCheckIcon} from '@heroicons/react/24/solid';
 
 const meta: Meta<typeof XDSBanner> = {
-  title: 'Core/XDSBanner',
+  title: 'Display/Banner',
   component: XDSBanner,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Breadcrumbs.stories.tsx
+++ b/apps/storybook/stories/Breadcrumbs.stories.tsx
@@ -3,7 +3,7 @@ import {XDSBreadcrumbs, XDSBreadcrumbItem} from '@xds/core/Breadcrumbs';
 import {HomeIcon, Cog6ToothIcon, FolderIcon} from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof XDSBreadcrumbs> = {
-  title: 'Navigation/XDSBreadcrumbs',
+  title: 'Navigation/Breadcrumbs',
   component: XDSBreadcrumbs,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Button.stories.tsx
+++ b/apps/storybook/stories/Button.stories.tsx
@@ -4,7 +4,7 @@ import {XDSBadge} from '@xds/core/Badge';
 import {Cog6ToothIcon, TrashIcon} from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof XDSButton> = {
-  title: 'Core/XDSButton',
+  title: 'Actions/Button',
   component: XDSButton,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Calendar.stories.tsx
+++ b/apps/storybook/stories/Calendar.stories.tsx
@@ -7,7 +7,7 @@ import {
 } from '@xds/core/Calendar';
 
 const meta: Meta<typeof XDSCalendar> = {
-  title: 'Core/XDSCalendar',
+  title: 'Display/Calendar',
   component: XDSCalendar,
   tags: ['autodocs'],
 };

--- a/apps/storybook/stories/Card.stories.tsx
+++ b/apps/storybook/stories/Card.stories.tsx
@@ -46,7 +46,7 @@ const styles = stylex.create({
 });
 
 const meta: Meta<typeof XDSCard> = {
-  title: 'Layout/XDSCard',
+  title: 'Layout/Card',
   component: XDSCard,
   tags: ['autodocs'],
   decorators: [

--- a/apps/storybook/stories/Carousel.stories.tsx
+++ b/apps/storybook/stories/Carousel.stories.tsx
@@ -66,7 +66,7 @@ const IMAGES = [
 ];
 
 const meta: Meta<typeof XDSCarousel> = {
-  title: 'Core/XDSCarousel',
+  title: 'Display/Carousel',
   component: XDSCarousel,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Center.stories.tsx
+++ b/apps/storybook/stories/Center.stories.tsx
@@ -43,7 +43,7 @@ const Box = ({children}: {children: React.ReactNode}) => (
 );
 
 const meta: Meta<typeof XDSCenter> = {
-  title: 'Layout/XDSCenter',
+  title: 'Layout/Center',
   component: XDSCenter,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Chart.stories.tsx
+++ b/apps/storybook/stories/Chart.stories.tsx
@@ -24,7 +24,7 @@ import {useDataset} from './useDataset';
  * Datasets from [vega-datasets](https://github.com/vega/vega-datasets) (CDN).
  */
 const meta: Meta<typeof XDSChart> = {
-  title: 'Lab/XDSChart',
+  title: 'Lab/Chart',
   component: XDSChart,
   tags: ['autodocs'],
 };

--- a/apps/storybook/stories/ChartAdvanced.stories.tsx
+++ b/apps/storybook/stories/ChartAdvanced.stories.tsx
@@ -14,7 +14,7 @@ import {
 import {XDSStack, XDSText} from '@xds/core';
 import {XDSHeading} from '@xds/core/Text';
 
-const meta: Meta = {title: 'Lab/XDSChartAdvanced'};
+const meta: Meta = {title: 'Lab/ChartAdvanced'};
 export default meta;
 
 const ciData = [

--- a/apps/storybook/stories/ChartCoordinated.stories.tsx
+++ b/apps/storybook/stories/ChartCoordinated.stories.tsx
@@ -14,7 +14,7 @@ import {XDSStack, XDSText} from '@xds/core';
 import {XDSHeading} from '@xds/core/Text';
 import {useDataset} from './useDataset';
 
-const meta: Meta = {title: 'Lab/XDSChart Interactions/Coordinated Views'};
+const meta: Meta = {title: 'Lab/Chart Interactions/Coordinated Views'};
 export default meta;
 
 type Car = {

--- a/apps/storybook/stories/ChartDotGL.stories.tsx
+++ b/apps/storybook/stories/ChartDotGL.stories.tsx
@@ -10,7 +10,7 @@ import {
 import {XDSStack, XDSText} from '@xds/core';
 import {XDSHeading} from '@xds/core/Text';
 
-const meta: Meta = {title: 'Lab/XDSChartDotGL'};
+const meta: Meta = {title: 'Lab/ChartDotGL'};
 export default meta;
 
 const smallData = Array.from({length: 30}, (_, i) => ({

--- a/apps/storybook/stories/ChartDotGLInteractive.stories.tsx
+++ b/apps/storybook/stories/ChartDotGLInteractive.stories.tsx
@@ -9,7 +9,7 @@ import {
 import {XDSStack, XDSText} from '@xds/core';
 import {XDSHeading} from '@xds/core/Text';
 
-const meta: Meta = {title: 'Lab/XDSChartDotGLInteractive'};
+const meta: Meta = {title: 'Lab/ChartDotGLInteractive'};
 export default meta;
 
 const scatterData = Array.from({length: 5000}, () => ({

--- a/apps/storybook/stories/ChartHeatmapGL.stories.tsx
+++ b/apps/storybook/stories/ChartHeatmapGL.stories.tsx
@@ -10,7 +10,7 @@ import {
 import {XDSStack, XDSText} from '@xds/core';
 import {XDSHeading} from '@xds/core/Text';
 
-const meta: Meta = {title: 'Lab/XDSChartHeatmapGL'};
+const meta: Meta = {title: 'Lab/ChartHeatmapGL'};
 export default meta;
 
 const days = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];

--- a/apps/storybook/stories/ChartInteractions.stories.tsx
+++ b/apps/storybook/stories/ChartInteractions.stories.tsx
@@ -18,7 +18,7 @@ import {XDSStack, XDSText} from '@xds/core';
 import {XDSHeading} from '@xds/core/Text';
 import {useDataset} from './useDataset';
 
-const meta: Meta = {title: 'Lab/XDSChart Interactions', tags: ['autodocs']};
+const meta: Meta = {title: 'Lab/Chart Interactions', tags: ['autodocs']};
 export default meta;
 
 type Car = {Horsepower: number; Miles_per_Gallon: number};

--- a/apps/storybook/stories/ChartStreamGL.stories.tsx
+++ b/apps/storybook/stories/ChartStreamGL.stories.tsx
@@ -12,7 +12,7 @@ import {XDSStack, XDSText} from '@xds/core';
 import {XDSHeading} from '@xds/core/Text';
 
 const meta: Meta = {
-  title: 'Lab/XDSChartStreamGL',
+  title: 'Lab/ChartStreamGL',
 };
 
 export default meta;

--- a/apps/storybook/stories/ChartStreamPerf.stories.tsx
+++ b/apps/storybook/stories/ChartStreamPerf.stories.tsx
@@ -12,7 +12,7 @@ import {XDSStack, XDSText} from '@xds/core';
 import {XDSHeading} from '@xds/core/Text';
 
 const meta: Meta = {
-  title: 'Lab/XDSChartStreamGL/Performance',
+  title: 'Lab/ChartStreamGL/Performance',
 };
 
 export default meta;

--- a/apps/storybook/stories/Chat.stories.tsx
+++ b/apps/storybook/stories/Chat.stories.tsx
@@ -17,7 +17,7 @@ import {HandThumbUpIcon, HandThumbDownIcon} from '@heroicons/react/24/outline';
 import {ClipboardDocumentIcon} from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof XDSChatMessageList> = {
-  title: 'Chat/XDSChatMessageList',
+  title: 'Chat/MessageList',
   component: XDSChatMessageList,
   tags: ['autodocs'],
 };

--- a/apps/storybook/stories/ChatComposer.stories.tsx
+++ b/apps/storybook/stories/ChatComposer.stories.tsx
@@ -55,7 +55,7 @@ const MicIcon = (
 );
 
 const meta: Meta<typeof XDSChatComposer> = {
-  title: 'Chat/XDSChatComposer',
+  title: 'Chat/Composer',
   component: XDSChatComposer,
   tags: ['autodocs'],
   parameters: {

--- a/apps/storybook/stories/ChatComposerInput.stories.tsx
+++ b/apps/storybook/stories/ChatComposerInput.stories.tsx
@@ -11,7 +11,7 @@ import type {XDSSearchableItem, XDSSearchSource} from '@xds/core/Typeahead';
 import {useState} from 'react';
 
 const meta: Meta = {
-  title: 'Chat/XDSChatComposerInput',
+  title: 'Chat/ComposerInput',
   component: XDSChatComposerInput,
   tags: ['autodocs'],
   parameters: {

--- a/apps/storybook/stories/ChatDictation.stories.tsx
+++ b/apps/storybook/stories/ChatDictation.stories.tsx
@@ -74,7 +74,7 @@ const unsupportedDictation: UseSpeechRecognitionReturn = {
 // =============================================================================
 
 const meta: Meta<typeof XDSChatDictationButton> = {
-  title: 'Chat/XDSChatDictationButton',
+  title: 'Chat/DictationButton',
   component: XDSChatDictationButton,
   tags: ['autodocs'],
   parameters: {

--- a/apps/storybook/stories/ChatLayout.stories.tsx
+++ b/apps/storybook/stories/ChatLayout.stories.tsx
@@ -32,7 +32,7 @@ import {XDSEmptyState} from '@xds/core/EmptyState';
 import {useState, useCallback, useRef} from 'react';
 
 const meta: Meta<typeof XDSChatLayout> = {
-  title: 'Chat/XDSChatLayout',
+  title: 'Chat/Layout',
   component: XDSChatLayout,
   tags: ['autodocs'],
   parameters: {layout: 'fullscreen'},

--- a/apps/storybook/stories/ChatReasoning.stories.tsx
+++ b/apps/storybook/stories/ChatReasoning.stories.tsx
@@ -10,7 +10,7 @@ import {XDSMarkdown} from '@xds/core/Markdown';
 import {useState, useEffect} from 'react';
 
 const meta: Meta = {
-  title: 'Lab/XDSChatReasoning',
+  title: 'Lab/ChatReasoning',
   component: XDSChatReasoning,
   tags: ['autodocs'],
   parameters: {

--- a/apps/storybook/stories/ChatTokenizedText.stories.tsx
+++ b/apps/storybook/stories/ChatTokenizedText.stories.tsx
@@ -3,7 +3,7 @@ import {XDSChatTokenizedText} from '@xds/core/Chat';
 import {XDSChatMessage, XDSChatMessageBubble} from '@xds/core/Chat';
 
 const meta: Meta<typeof XDSChatTokenizedText> = {
-  title: 'Chat/XDSChatTokenizedText',
+  title: 'Chat/TokenizedText',
   component: XDSChatTokenizedText,
   tags: ['autodocs'],
   parameters: {layout: 'centered'},

--- a/apps/storybook/stories/ChatToolCalls.stories.tsx
+++ b/apps/storybook/stories/ChatToolCalls.stories.tsx
@@ -4,7 +4,7 @@ import {useState, useCallback} from 'react';
 import {XDSCodeBlock} from '@xds/core/CodeBlock';
 
 const meta: Meta<typeof XDSChatToolCalls> = {
-  title: 'Chat/XDSChatToolCalls',
+  title: 'Chat/ToolCalls',
   component: XDSChatToolCalls,
   tags: ['autodocs'],
   parameters: {

--- a/apps/storybook/stories/CheckboxInput.stories.tsx
+++ b/apps/storybook/stories/CheckboxInput.stories.tsx
@@ -8,7 +8,7 @@ import {
 } from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof XDSCheckboxInput> = {
-  title: 'Form/XDSCheckboxInput',
+  title: 'Inputs/CheckboxInput',
   component: XDSCheckboxInput,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/CheckboxList.stories.tsx
+++ b/apps/storybook/stories/CheckboxList.stories.tsx
@@ -5,7 +5,7 @@ import {XDSList} from '@xds/core/List';
 import {XDSCard} from '@xds/core/Card';
 
 const meta: Meta<typeof XDSCheckboxList> = {
-  title: 'Form/XDSCheckboxList',
+  title: 'Inputs/CheckboxList',
   component: XDSCheckboxList,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Code.stories.tsx
+++ b/apps/storybook/stories/Code.stories.tsx
@@ -5,7 +5,7 @@ import {XDSStack} from '@xds/core/Stack';
 import {XDSLink} from '@xds/core/Link';
 
 const meta: Meta<typeof XDSCode> = {
-  title: 'Components/XDSCode',
+  title: 'Display/Code',
   component: XDSCode,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/CodeBlock.stories.tsx
+++ b/apps/storybook/stories/CodeBlock.stories.tsx
@@ -2,7 +2,7 @@ import type {Meta, StoryObj} from '@storybook/react';
 import {XDSCodeBlock} from '@xds/core/CodeBlock';
 
 const meta: Meta<typeof XDSCodeBlock> = {
-  title: 'Components/XDSCodeBlock',
+  title: 'Display/CodeBlock',
   component: XDSCodeBlock,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/CodeEditor.stories.tsx
+++ b/apps/storybook/stories/CodeEditor.stories.tsx
@@ -3,7 +3,7 @@ import {useState} from 'react';
 import {XDSCodeEditor} from '@xds/lab';
 
 const meta: Meta<typeof XDSCodeEditor> = {
-  title: 'Lab/XDSCodeEditor',
+  title: 'Lab/CodeEditor',
   component: XDSCodeEditor,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/CodeEditorPerf.stories.tsx
+++ b/apps/storybook/stories/CodeEditorPerf.stories.tsx
@@ -3,7 +3,7 @@ import {useState, useRef, useEffect, useCallback} from 'react';
 import {XDSCodeEditor} from '@xds/lab';
 
 const meta: Meta<typeof XDSCodeEditor> = {
-  title: 'Lab/XDSCodeEditor/Performance',
+  title: 'Lab/CodeEditor/Performance',
   component: XDSCodeEditor,
   parameters: {layout: 'fullscreen'},
 };

--- a/apps/storybook/stories/CodeEditorTheme.stories.tsx
+++ b/apps/storybook/stories/CodeEditorTheme.stories.tsx
@@ -83,7 +83,7 @@ function ThemedEditor({
 }
 
 const meta: Meta = {
-  title: 'Lab/XDSCodeEditor Themes',
+  title: 'Lab/CodeEditor Themes',
   parameters: {
     docs: {
       description: {

--- a/apps/storybook/stories/CodeTheme.stories.tsx
+++ b/apps/storybook/stories/CodeTheme.stories.tsx
@@ -62,7 +62,7 @@ const sampleCode = [
 ].join('\n');
 
 const meta: Meta = {
-  title: 'Theme/XDSSyntaxTheme',
+  title: 'Theme/SyntaxTheme',
   tags: ['autodocs'],
   parameters: {
     docs: {

--- a/apps/storybook/stories/Collapsible.stories.tsx
+++ b/apps/storybook/stories/Collapsible.stories.tsx
@@ -29,7 +29,7 @@ const styles = stylex.create({
 });
 
 const meta: Meta<typeof XDSCollapsibleGroup> = {
-  title: 'Components/XDSCollapsible',
+  title: 'Layout/Collapsible',
   component: XDSCollapsibleGroup,
   tags: ['autodocs'],
   decorators: [

--- a/apps/storybook/stories/CommandPalette.stories.tsx
+++ b/apps/storybook/stories/CommandPalette.stories.tsx
@@ -20,7 +20,7 @@ import {createStaticSource} from '@xds/core/Typeahead';
 import type {XDSSearchSource, XDSSearchableItem} from '@xds/core/Typeahead';
 
 const meta: Meta<typeof XDSCommandPalette> = {
-  title: 'CommandPalette/XDSCommandPalette',
+  title: 'Actions/CommandPalette',
   component: XDSCommandPalette,
   tags: ['autodocs'],
 };

--- a/apps/storybook/stories/DateInput.stories.tsx
+++ b/apps/storybook/stories/DateInput.stories.tsx
@@ -5,7 +5,7 @@ import type {ISODateString} from '@xds/core/Calendar';
 import {XDSLayout, XDSLayoutContent} from '@xds/core/Layout';
 
 const meta: Meta<typeof XDSDateInput> = {
-  title: 'Form/XDSDateInput',
+  title: 'Inputs/DateInput',
   component: XDSDateInput,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Dialog.stories.tsx
+++ b/apps/storybook/stories/Dialog.stories.tsx
@@ -19,7 +19,7 @@ const styles = stylex.create({
 });
 
 const meta: Meta<typeof XDSDialog> = {
-  title: 'Core/XDSDialog',
+  title: 'Overlays/Dialog',
   component: XDSDialog,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Divider.stories.tsx
+++ b/apps/storybook/stories/Divider.stories.tsx
@@ -19,7 +19,7 @@ const styles = stylex.create({
 });
 
 const meta: Meta<typeof XDSDivider> = {
-  title: 'Layout/XDSDivider',
+  title: 'Layout/Divider',
   component: XDSDivider,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/DropdownMenu.stories.tsx
+++ b/apps/storybook/stories/DropdownMenu.stories.tsx
@@ -17,7 +17,7 @@ import {
 } from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof XDSDropdownMenu> = {
-  title: 'Core/XDSDropdownMenu',
+  title: 'Actions/DropdownMenu',
   component: XDSDropdownMenu,
   tags: ['autodocs'],
   parameters: {

--- a/apps/storybook/stories/EmptyState.stories.tsx
+++ b/apps/storybook/stories/EmptyState.stories.tsx
@@ -3,7 +3,7 @@ import {XDSEmptyState} from '@xds/core/EmptyState';
 import {XDSButton} from '@xds/core/Button';
 
 const meta: Meta<typeof XDSEmptyState> = {
-  title: 'Core/XDSEmptyState',
+  title: 'Display/EmptyState',
   component: XDSEmptyState,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Field.stories.tsx
+++ b/apps/storybook/stories/Field.stories.tsx
@@ -57,7 +57,7 @@ const NativeInput = ({
 );
 
 const meta: Meta<typeof XDSField> = {
-  title: 'Form/XDSField',
+  title: 'Inputs/Field',
   component: XDSField,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/FormLayout.stories.tsx
+++ b/apps/storybook/stories/FormLayout.stories.tsx
@@ -8,7 +8,7 @@ import {XDSText} from '@xds/core/Text';
 import * as stylex from '@stylexjs/stylex';
 
 const meta: Meta<typeof XDSFormLayout> = {
-  title: 'Form/XDSFormLayout',
+  title: 'Inputs/FormLayout',
   component: XDSFormLayout,
   tags: ['autodocs'],
   args: {

--- a/apps/storybook/stories/Grid.stories.tsx
+++ b/apps/storybook/stories/Grid.stories.tsx
@@ -47,7 +47,7 @@ const styles = stylex.create({
 });
 
 const meta: Meta<typeof XDSGrid> = {
-  title: 'Layout/XDSGrid',
+  title: 'Layout/Grid',
   component: XDSGrid,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/GridMasonry.stories.tsx
+++ b/apps/storybook/stories/GridMasonry.stories.tsx
@@ -12,7 +12,7 @@ import {
 } from '@xds/core/theme/tokens.stylex';
 
 const meta: Meta = {
-  title: 'Layout/XDSGrid/Masonry Gallery',
+  title: 'Layout/Grid/Masonry Gallery',
   tags: ['autodocs'],
 };
 

--- a/apps/storybook/stories/Heading.stories.tsx
+++ b/apps/storybook/stories/Heading.stories.tsx
@@ -3,7 +3,7 @@ import {XDSHeading} from '@xds/core/Text';
 import {XDSText} from '@xds/core/Text';
 
 const meta: Meta<typeof XDSHeading> = {
-  title: 'Typography/XDSHeading',
+  title: 'Display/Heading',
   component: XDSHeading,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/HoverCard.stories.tsx
+++ b/apps/storybook/stories/HoverCard.stories.tsx
@@ -4,7 +4,7 @@ import {XDSButton} from '@xds/core/Button';
 import {XDSVStack, XDSHStack} from '@xds/core/Layout';
 
 const meta: Meta<typeof XDSHoverCard> = {
-  title: 'Core/XDSHoverCard',
+  title: 'Overlays/HoverCard',
   component: XDSHoverCard,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Icon.stories.tsx
+++ b/apps/storybook/stories/Icon.stories.tsx
@@ -19,7 +19,7 @@ import {
 } from '@heroicons/react/24/solid';
 
 const meta: Meta<typeof XDSIcon> = {
-  title: 'Core/XDSIcon',
+  title: 'Display/Icon',
   component: XDSIcon,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/IconButton.stories.tsx
+++ b/apps/storybook/stories/IconButton.stories.tsx
@@ -11,7 +11,7 @@ import {
 } from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof XDSIconButton> = {
-  title: 'Core/XDSIconButton',
+  title: 'Actions/IconButton',
   component: XDSIconButton,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Kbd.stories.tsx
+++ b/apps/storybook/stories/Kbd.stories.tsx
@@ -3,7 +3,7 @@ import {XDSKbd} from '@xds/core/Kbd';
 import {XDSText} from '@xds/core/Text';
 
 const meta: Meta<typeof XDSKbd> = {
-  title: 'Core/XDSKbd',
+  title: 'Display/Kbd',
   component: XDSKbd,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Layout.stories.tsx
+++ b/apps/storybook/stories/Layout.stories.tsx
@@ -157,7 +157,7 @@ const NavItem = ({
 );
 
 const meta: Meta<typeof XDSLayout> = {
-  title: 'Layout/XDSLayout',
+  title: 'Layout/Layout',
   component: XDSLayout,
   tags: ['autodocs'],
   parameters: {

--- a/apps/storybook/stories/Link.stories.tsx
+++ b/apps/storybook/stories/Link.stories.tsx
@@ -3,7 +3,7 @@ import {XDSLink} from '@xds/core/Link';
 import {XDSText} from '@xds/core/Text';
 
 const meta: Meta<typeof XDSLink> = {
-  title: 'Core/XDSLink',
+  title: 'Display/Link',
   component: XDSLink,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/List.stories.tsx
+++ b/apps/storybook/stories/List.stories.tsx
@@ -14,7 +14,7 @@ import {
 } from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof XDSList> = {
-  title: 'Core/XDSList',
+  title: 'Collections/List',
   component: XDSList,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Markdown.stories.tsx
+++ b/apps/storybook/stories/Markdown.stories.tsx
@@ -4,7 +4,7 @@ import {XDSMarkdown} from '@xds/core/Markdown';
 import {XDSButton} from '@xds/core/Button';
 
 const meta: Meta<typeof XDSMarkdown> = {
-  title: 'Components/XDSMarkdown',
+  title: 'Display/Markdown',
   component: XDSMarkdown,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/MarkdownCitations.stories.tsx
+++ b/apps/storybook/stories/MarkdownCitations.stories.tsx
@@ -5,7 +5,7 @@ import type {XDSMarkdownSource} from '@xds/core/Markdown';
 import {XDSButton} from '@xds/core/Button';
 
 const meta: Meta<typeof XDSMarkdown> = {
-  title: 'Components/XDSMarkdown/Citations',
+  title: 'Display/Markdown/Citations',
   component: XDSMarkdown,
   tags: ['autodocs'],
 };

--- a/apps/storybook/stories/MetadataList.stories.tsx
+++ b/apps/storybook/stories/MetadataList.stories.tsx
@@ -9,7 +9,7 @@ import {
 } from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof XDSMetadataList> = {
-  title: 'Core/XDSMetadataList',
+  title: 'Collections/MetadataList',
   component: XDSMetadataList,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/MobileNav.stories.tsx
+++ b/apps/storybook/stories/MobileNav.stories.tsx
@@ -29,7 +29,7 @@ import {
 // =============================================================================
 
 const meta: Meta<typeof XDSMobileNav> = {
-  title: 'Navigation/XDSMobileNav',
+  title: 'Navigation/MobileNav',
   component: XDSMobileNav,
   tags: ['autodocs'],
   parameters: {

--- a/apps/storybook/stories/MoreMenu.stories.tsx
+++ b/apps/storybook/stories/MoreMenu.stories.tsx
@@ -12,7 +12,7 @@ import {
 } from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof XDSMoreMenu> = {
-  title: 'Core/XDSMoreMenu',
+  title: 'Actions/MoreMenu',
   component: XDSMoreMenu,
   tags: ['autodocs'],
   parameters: {

--- a/apps/storybook/stories/MultiSelector.stories.tsx
+++ b/apps/storybook/stories/MultiSelector.stories.tsx
@@ -3,7 +3,7 @@ import {useState} from 'react';
 import {XDSMultiSelector} from '@xds/core/MultiSelector';
 
 const meta: Meta<typeof XDSMultiSelector> = {
-  title: 'Form/XDSMultiSelector',
+  title: 'Inputs/MultiSelector',
   component: XDSMultiSelector,
   tags: ['autodocs'],
   parameters: {

--- a/apps/storybook/stories/NumberInput.stories.tsx
+++ b/apps/storybook/stories/NumberInput.stories.tsx
@@ -4,7 +4,7 @@ import {XDSNumberInput} from '@xds/core/NumberInput';
 import {HashtagIcon, CurrencyDollarIcon} from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof XDSNumberInput> = {
-  title: 'Form/XDSNumberInput',
+  title: 'Inputs/NumberInput',
   component: XDSNumberInput,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/OverflowList.stories.tsx
+++ b/apps/storybook/stories/OverflowList.stories.tsx
@@ -7,7 +7,7 @@ import {XDSDropdownMenu} from '@xds/core/DropdownMenu';
 import {XDSTextInput} from '@xds/core/TextInput';
 
 const meta: Meta<typeof XDSOverflowList> = {
-  title: 'Core/XDSOverflowList',
+  title: 'Layout/OverflowList',
   component: XDSOverflowList,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Pagination.stories.tsx
+++ b/apps/storybook/stories/Pagination.stories.tsx
@@ -3,7 +3,7 @@ import {useState} from 'react';
 import {XDSPagination} from '@xds/core/Pagination';
 
 const meta: Meta<typeof XDSPagination> = {
-  title: 'Core/XDSPagination',
+  title: 'Display/Pagination',
   component: XDSPagination,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Popover.stories.tsx
+++ b/apps/storybook/stories/Popover.stories.tsx
@@ -9,7 +9,7 @@ import {XDSCheckboxInput} from '@xds/core/CheckboxInput';
 import {XDSDivider} from '@xds/core/Divider';
 
 const meta: Meta<typeof XDSPopover> = {
-  title: 'Core/XDSPopover',
+  title: 'Overlays/Popover',
   component: XDSPopover,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/PowerSearch.stories.tsx
+++ b/apps/storybook/stories/PowerSearch.stories.tsx
@@ -273,7 +273,7 @@ const fullConfig: PowerSearchConfig = {
 // =============================================================================
 
 const meta: Meta<typeof XDSPowerSearch> = {
-  title: 'Form/XDSPowerSearch',
+  title: 'Inputs/PowerSearch',
   component: XDSPowerSearch,
   tags: ['autodocs'],
   decorators: [

--- a/apps/storybook/stories/ProgressBar.stories.tsx
+++ b/apps/storybook/stories/ProgressBar.stories.tsx
@@ -2,7 +2,7 @@ import type {Meta, StoryObj} from '@storybook/react';
 import {XDSProgressBar} from '@xds/core/ProgressBar';
 
 const meta: Meta<typeof XDSProgressBar> = {
-  title: 'Core/XDSProgressBar',
+  title: 'Display/ProgressBar',
   component: XDSProgressBar,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/RadialChart.stories.tsx
+++ b/apps/storybook/stories/RadialChart.stories.tsx
@@ -12,7 +12,7 @@ import {XDSStack, XDSText} from '@xds/core';
 import {XDSHeading} from '@xds/core/Text';
 
 const meta: Meta = {
-  title: 'Lab/XDSRadialChart',
+  title: 'Lab/RadialChart',
   tags: ['autodocs'],
 };
 

--- a/apps/storybook/stories/RadioList.stories.tsx
+++ b/apps/storybook/stories/RadioList.stories.tsx
@@ -3,7 +3,7 @@ import type {Meta, StoryObj} from '@storybook/react';
 import {XDSRadioList, XDSRadioListItem} from '@xds/core/RadioList';
 
 const meta: Meta<typeof XDSRadioList> = {
-  title: 'Form/XDSRadioList',
+  title: 'Inputs/RadioList',
   component: XDSRadioList,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/SVGIcon.stories.tsx
+++ b/apps/storybook/stories/SVGIcon.stories.tsx
@@ -19,7 +19,7 @@ import {
 import {XDSStack, XDSText, XDSDivider} from '@xds/core';
 
 const meta: Meta<typeof XDSSVGIcon> = {
-  title: 'Lab/XDSSVGIcon',
+  title: 'Lab/SVGIcon',
   component: XDSSVGIcon,
   argTypes: {
     variation: {

--- a/apps/storybook/stories/SVGIconRegistry.stories.tsx
+++ b/apps/storybook/stories/SVGIconRegistry.stories.tsx
@@ -154,7 +154,7 @@ function jsxSvgToIconDef(name: string, element: ReactElement): SVGIconDef | null
 // =============================================================================
 
 const meta: Meta = {
-  title: 'Lab/XDSSVGIcon/Registry Icons',
+  title: 'Lab/SVGIcon/Registry Icons',
 };
 export default meta;
 

--- a/apps/storybook/stories/SankeyChart.stories.tsx
+++ b/apps/storybook/stories/SankeyChart.stories.tsx
@@ -12,7 +12,7 @@ import {XDSStack, XDSText} from '@xds/core';
 import {XDSHeading} from '@xds/core/Text';
 
 const meta: Meta = {
-  title: 'Lab/XDSSankeyChart',
+  title: 'Lab/SankeyChart',
   tags: ['autodocs'],
 };
 

--- a/apps/storybook/stories/Section.stories.tsx
+++ b/apps/storybook/stories/Section.stories.tsx
@@ -48,7 +48,7 @@ const styles = stylex.create({
 });
 
 const meta: Meta<typeof XDSSection> = {
-  title: 'Layout/XDSSection',
+  title: 'Layout/Section',
   component: XDSSection,
   tags: ['autodocs'],
   decorators: [

--- a/apps/storybook/stories/SegmentedControl.stories.tsx
+++ b/apps/storybook/stories/SegmentedControl.stories.tsx
@@ -12,7 +12,7 @@ import {
 } from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof XDSSegmentedControl> = {
-  title: 'Inputs/XDSSegmentedControl',
+  title: 'Inputs/SegmentedControl',
   component: XDSSegmentedControl,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Selector.stories.tsx
+++ b/apps/storybook/stories/Selector.stories.tsx
@@ -4,7 +4,7 @@ import {XDSSelector, XDSSelectorOption} from '@xds/core/Selector';
 import {UserIcon, CogIcon, BellIcon} from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof XDSSelector> = {
-  title: 'Form/XDSSelector',
+  title: 'Inputs/Selector',
   component: XDSSelector,
   tags: ['autodocs'],
   parameters: {

--- a/apps/storybook/stories/SideNav.stories.tsx
+++ b/apps/storybook/stories/SideNav.stories.tsx
@@ -29,7 +29,7 @@ import {
 } from '@heroicons/react/24/solid';
 
 const meta: Meta<typeof XDSSideNav> = {
-  title: 'Navigation/XDSSideNav',
+  title: 'Navigation/SideNav',
   component: XDSSideNav,
   tags: ['autodocs'],
   parameters: {

--- a/apps/storybook/stories/Skeleton.stories.tsx
+++ b/apps/storybook/stories/Skeleton.stories.tsx
@@ -4,7 +4,7 @@ import {XDSCard} from '@xds/core/Card';
 import {XDSHStack, XDSVStack} from '@xds/core/Layout';
 
 const meta: Meta<typeof XDSSkeleton> = {
-  title: 'Core/XDSSkeleton',
+  title: 'Display/Skeleton',
   component: XDSSkeleton,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Slider.stories.tsx
+++ b/apps/storybook/stories/Slider.stories.tsx
@@ -4,7 +4,7 @@ import type {Meta, StoryObj} from '@storybook/react';
 import {XDSSlider} from '@xds/core/Slider';
 
 const meta: Meta<typeof XDSSlider> = {
-  title: 'Form/XDSSlider',
+  title: 'Inputs/Slider',
   component: XDSSlider,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Spinner.stories.tsx
+++ b/apps/storybook/stories/Spinner.stories.tsx
@@ -4,7 +4,7 @@ import {XDSText} from '@xds/core/Text';
 import {XDSHStack, XDSVStack} from '@xds/core/Layout';
 
 const meta: Meta<typeof XDSSpinner> = {
-  title: 'Core/XDSSpinner',
+  title: 'Display/Spinner',
   component: XDSSpinner,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Stack.stories.tsx
+++ b/apps/storybook/stories/Stack.stories.tsx
@@ -117,7 +117,7 @@ const Box = ({
 );
 
 const meta: Meta<typeof XDSStack> = {
-  title: 'Layout/XDSStack',
+  title: 'Layout/Stack',
   component: XDSStack,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/StatusDot.stories.tsx
+++ b/apps/storybook/stories/StatusDot.stories.tsx
@@ -2,7 +2,7 @@ import type {Meta, StoryObj} from '@storybook/react';
 import {XDSStatusDot} from '@xds/core/StatusDot';
 
 const meta: Meta<typeof XDSStatusDot> = {
-  title: 'Core/XDSStatusDot',
+  title: 'Display/StatusDot',
   component: XDSStatusDot,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Switch.stories.tsx
+++ b/apps/storybook/stories/Switch.stories.tsx
@@ -9,7 +9,7 @@ import {
 } from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof XDSSwitch> = {
-  title: 'Form/XDSSwitch',
+  title: 'Inputs/Switch',
   component: XDSSwitch,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/TabList.stories.tsx
+++ b/apps/storybook/stories/TabList.stories.tsx
@@ -8,7 +8,7 @@ import {XDSStackItem} from '@xds/core/Stack';
 import {PlusIcon, FunnelIcon} from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof XDSTabList> = {
-  title: 'Navigation/XDSTabList',
+  title: 'Navigation/TabList',
   component: XDSTabList,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Table.stories.tsx
+++ b/apps/storybook/stories/Table.stories.tsx
@@ -94,7 +94,7 @@ const columns: XDSTableColumn<User>[] = [
 // =============================================================================
 
 const meta: Meta<typeof XDSTable> = {
-  title: 'Core/XDSTable',
+  title: 'Collections/Table',
   component: XDSTable,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/TableColumnResize.stories.tsx
+++ b/apps/storybook/stories/TableColumnResize.stories.tsx
@@ -71,7 +71,7 @@ const columns: XDSTableColumn<User>[] = [
 // =============================================================================
 
 const meta: Meta = {
-  title: 'Core/XDSTable/ColumnResize',
+  title: 'Collections/Table/ColumnResize',
   tags: ['autodocs'],
 };
 

--- a/apps/storybook/stories/TableColumnSettings.stories.tsx
+++ b/apps/storybook/stories/TableColumnSettings.stories.tsx
@@ -100,7 +100,7 @@ const defaultActiveKeys: UserColumnKey[] = [
 // =============================================================================
 
 const meta: Meta = {
-  title: 'Core/XDSTable/ColumnSettings',
+  title: 'Collections/Table/ColumnSettings',
   tags: ['autodocs'],
 };
 

--- a/apps/storybook/stories/TableFiltering.stories.tsx
+++ b/apps/storybook/stories/TableFiltering.stories.tsx
@@ -97,7 +97,7 @@ const fieldDefs = [
 ] as const;
 
 const meta: Meta = {
-  title: 'Core/XDSTable/Filtering',
+  title: 'Collections/Table/Filtering',
   tags: ['autodocs'],
 };
 

--- a/apps/storybook/stories/TablePagination.stories.tsx
+++ b/apps/storybook/stories/TablePagination.stories.tsx
@@ -82,7 +82,7 @@ function PaginatedDemo({
 // =============================================================================
 
 const meta: Meta = {
-  title: 'Core/XDSTable/Pagination',
+  title: 'Collections/Table/Pagination',
   tags: ['autodocs'],
 };
 

--- a/apps/storybook/stories/TableSelection.stories.tsx
+++ b/apps/storybook/stories/TableSelection.stories.tsx
@@ -68,7 +68,7 @@ const columns: XDSTableColumn<User>[] = [
 // =============================================================================
 
 const meta: Meta = {
-  title: 'Core/XDSTable/Selection',
+  title: 'Collections/Table/Selection',
   tags: ['autodocs'],
 };
 

--- a/apps/storybook/stories/TableSortable.stories.tsx
+++ b/apps/storybook/stories/TableSortable.stories.tsx
@@ -77,7 +77,7 @@ const columns: XDSTableColumn<Employee>[] = [
 // =============================================================================
 
 const meta: Meta = {
-  title: 'Core/XDSTable/Sortable',
+  title: 'Collections/Table/Sortable',
   tags: ['autodocs'],
 };
 

--- a/apps/storybook/stories/Text.stories.tsx
+++ b/apps/storybook/stories/Text.stories.tsx
@@ -2,7 +2,7 @@ import type {Meta, StoryObj} from '@storybook/react';
 import {XDSText} from '@xds/core/Text';
 
 const meta: Meta<typeof XDSText> = {
-  title: 'Typography/XDSText',
+  title: 'Display/Text',
   component: XDSText,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/TextArea.stories.tsx
+++ b/apps/storybook/stories/TextArea.stories.tsx
@@ -8,7 +8,7 @@ import {
 } from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof XDSTextArea> = {
-  title: 'Form/XDSTextArea',
+  title: 'Inputs/TextArea',
   component: XDSTextArea,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/TextInput.stories.tsx
+++ b/apps/storybook/stories/TextInput.stories.tsx
@@ -8,7 +8,7 @@ import {
 } from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof XDSTextInput> = {
-  title: 'Form/XDSTextInput',
+  title: 'Inputs/TextInput',
   component: XDSTextInput,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/ThemeEditor.stories.tsx
+++ b/apps/storybook/stories/ThemeEditor.stories.tsx
@@ -1961,7 +1961,7 @@ function ThemeEditorComponent() {
 // =============================================================================
 
 const meta: Meta = {
-  title: 'Theme Editor',
+  title: 'Patterns/Theme Editor',
   parameters: {
     layout: 'fullscreen',
     docs: {

--- a/apps/storybook/stories/ThreeD-Backdrop.stories.tsx
+++ b/apps/storybook/stories/ThreeD-Backdrop.stories.tsx
@@ -2,7 +2,7 @@ import type {Meta, StoryObj} from '@storybook/react';
 import {useMemo} from 'react';
 import {XDS3DChart, XDS3DScatter, use3D, useXDSChartColors} from '@xds/lab';
 
-const meta: Meta = {title: 'Lab/XDS3DChart/Backdrop'};
+const meta: Meta = {title: 'Lab/3DChart/Backdrop'};
 export default meta;
 
 /** Scatter that colors each point based on its projected screen position */

--- a/apps/storybook/stories/ThreeD-Showcase.stories.tsx
+++ b/apps/storybook/stories/ThreeD-Showcase.stories.tsx
@@ -8,7 +8,7 @@ import {
 } from '@xds/lab';
 import {XDSMediaTheme} from '@xds/core/theme';
 
-const meta: Meta = {title: 'Lab/XDS3DChart/PopArt'};
+const meta: Meta = {title: 'Lab/3DChart/PopArt'};
 export default meta;
 
 // =============================================================================

--- a/apps/storybook/stories/ThreeDChart.stories.tsx
+++ b/apps/storybook/stories/ThreeDChart.stories.tsx
@@ -13,7 +13,7 @@ import {XDSStack, XDSText} from '@xds/core';
 import {XDSHeading} from '@xds/core/Text';
 
 const meta: Meta = {
-  title: 'Lab/XDS3DChart',
+  title: 'Lab/3DChart',
   tags: ['autodocs'],
 };
 

--- a/apps/storybook/stories/Thumbnail.stories.tsx
+++ b/apps/storybook/stories/Thumbnail.stories.tsx
@@ -3,7 +3,7 @@ import type {Meta, StoryObj} from '@storybook/react';
 import {XDSThumbnail} from '@xds/core/Thumbnail';
 
 const meta: Meta<typeof XDSThumbnail> = {
-  title: 'Core/XDSThumbnail',
+  title: 'Display/Thumbnail',
   component: XDSThumbnail,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/TimeInput.stories.tsx
+++ b/apps/storybook/stories/TimeInput.stories.tsx
@@ -4,7 +4,7 @@ import {XDSTimeInput} from '@xds/core/TimeInput';
 import type {ISOTimeString} from '@xds/core';
 
 const meta: Meta<typeof XDSTimeInput> = {
-  title: 'Form/XDSTimeInput',
+  title: 'Inputs/TimeInput',
   component: XDSTimeInput,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Timestamp.stories.tsx
+++ b/apps/storybook/stories/Timestamp.stories.tsx
@@ -3,7 +3,7 @@ import {XDSTimestamp} from '@xds/core/Timestamp';
 import {XDSText} from '@xds/core/Text';
 
 const meta: Meta<typeof XDSTimestamp> = {
-  title: 'Core/XDSTimestamp',
+  title: 'Display/Timestamp',
   component: XDSTimestamp,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Toast.stories.tsx
+++ b/apps/storybook/stories/Toast.stories.tsx
@@ -9,7 +9,7 @@ import {XDSStack} from '@xds/core/Stack';
 import {XDSDialog} from '@xds/core/Dialog';
 
 const meta: Meta = {
-  title: 'Core/XDSToast',
+  title: 'Overlays/Toast',
   tags: ['autodocs'],
   parameters: {
     docs: {

--- a/apps/storybook/stories/ToggleButton.stories.tsx
+++ b/apps/storybook/stories/ToggleButton.stories.tsx
@@ -28,7 +28,7 @@ import {XDSIcon} from '@xds/core/Icon';
 const iconSize = {width: 16, height: 16} as const;
 
 const meta: Meta<typeof XDSToggleButton> = {
-  title: 'Core/XDSToggleButton',
+  title: 'Actions/ToggleButton',
   component: XDSToggleButton,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Token.stories.tsx
+++ b/apps/storybook/stories/Token.stories.tsx
@@ -2,7 +2,7 @@ import type {Meta, StoryObj} from '@storybook/react';
 import {XDSToken, type XDSTokenColor} from '@xds/core/Token';
 
 const meta: Meta<typeof XDSToken> = {
-  title: 'Core/XDSToken',
+  title: 'Display/Token',
   component: XDSToken,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Tokenizer.stories.tsx
+++ b/apps/storybook/stories/Tokenizer.stories.tsx
@@ -24,7 +24,7 @@ const userSource: XDSSearchSource = {
 };
 
 const meta: Meta<typeof XDSTokenizer> = {
-  title: 'Form/XDSTokenizer',
+  title: 'Inputs/Tokenizer',
   component: XDSTokenizer,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Toolbar.stories.tsx
+++ b/apps/storybook/stories/Toolbar.stories.tsx
@@ -27,7 +27,7 @@ import {
 } from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof XDSToolbar> = {
-  title: 'Layout/XDSToolbar',
+  title: 'Layout/Toolbar',
   component: XDSToolbar,
   tags: ['autodocs'],
   parameters: {

--- a/apps/storybook/stories/ToolbarEdgeCompensation.stories.tsx
+++ b/apps/storybook/stories/ToolbarEdgeCompensation.stories.tsx
@@ -25,7 +25,7 @@ import {
 } from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof XDSToolbar> = {
-  title: 'Layout/XDSToolbar/Edge Compensation',
+  title: 'Layout/Toolbar/Edge Compensation',
   component: XDSToolbar,
   parameters: {
     layout: 'padded',

--- a/apps/storybook/stories/Tooltip.stories.tsx
+++ b/apps/storybook/stories/Tooltip.stories.tsx
@@ -4,7 +4,7 @@ import {XDSButton} from '@xds/core/Button';
 import {XDSHStack} from '@xds/core/Layout';
 
 const meta: Meta<typeof XDSTooltip> = {
-  title: 'Core/XDSTooltip',
+  title: 'Overlays/Tooltip',
   component: XDSTooltip,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/TopNav.stories.tsx
+++ b/apps/storybook/stories/TopNav.stories.tsx
@@ -14,7 +14,7 @@ import {
 } from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof XDSTopNav> = {
-  title: 'Navigation/XDSTopNav',
+  title: 'Navigation/TopNav',
   component: XDSTopNav,
   tags: ['autodocs'],
   parameters: {

--- a/apps/storybook/stories/TopNavMenu.stories.tsx
+++ b/apps/storybook/stories/TopNavMenu.stories.tsx
@@ -26,7 +26,7 @@ import {
 // =============================================================================
 
 const menuMeta: Meta<typeof XDSTopNavMenu> = {
-  title: 'Navigation/XDSTopNavMenu',
+  title: 'Navigation/TopNavMenu',
   component: XDSTopNavMenu,
   tags: ['autodocs'],
   parameters: {

--- a/apps/storybook/stories/TreeList.stories.tsx
+++ b/apps/storybook/stories/TreeList.stories.tsx
@@ -13,7 +13,7 @@ import {
 const noop = () => {};
 
 const meta: Meta<typeof XDSTreeList> = {
-  title: 'Core/XDSTreeList',
+  title: 'Collections/TreeList',
   component: XDSTreeList,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Typeahead.stories.tsx
+++ b/apps/storybook/stories/Typeahead.stories.tsx
@@ -23,7 +23,7 @@ const fruitSource: XDSSearchSource = {
 };
 
 const meta: Meta<typeof XDSTypeahead> = {
-  title: 'Form/XDSTypeahead',
+  title: 'Inputs/Typeahead',
   component: XDSTypeahead,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/VegaChart.stories.tsx
+++ b/apps/storybook/stories/VegaChart.stories.tsx
@@ -72,7 +72,7 @@ const radialPlotSpec: AnySpec = {
 };
 
 const meta: Meta<typeof XDSVegaChart> = {
-  title: 'Vega/XDSVegaChart',
+  title: 'Vega/VegaChart',
   component: XDSVegaChart,
   tags: ['autodocs'],
   parameters: {

--- a/apps/storybook/stories/XDSMediaTheme.stories.tsx
+++ b/apps/storybook/stories/XDSMediaTheme.stories.tsx
@@ -18,7 +18,7 @@ import {XDSCard} from '@xds/core/Card';
 // =============================================================================
 
 const meta: Meta = {
-  title: 'Theme/XDSMediaTheme',
+  title: 'Theme/MediaTheme',
   parameters: {
     docs: {
       description: {

--- a/apps/storybook/stories/XDSTheme.stories.tsx
+++ b/apps/storybook/stories/XDSTheme.stories.tsx
@@ -312,7 +312,7 @@ const oceanTheme = defineTheme({
 // =============================================================================
 
 const meta: Meta = {
-  title: 'Components/XDSTheme',
+  title: 'Theme',
   parameters: {
     docs: {
       description: {


### PR DESCRIPTION
## What

Alternative to #1605. Traditional categorical structure — every component belongs to exactly one category.

## Structure

| Category | Components | Count |
|----------|-----------|-------|
| **Actions** | Button, CommandPalette, DropdownMenu, IconButton, MoreMenu, ToggleButton | 6 |
| **Chat** | Composer, ComposerInput, DictationButton, Layout, MessageList, TokenizedText, ToolCalls | 7 |
| **Collections** | List, MetadataList, Table, TreeList | 4 |
| **Display** | Avatar, Badge, Banner, Calendar, Carousel, Code, CodeBlock, EmptyState, Heading, Icon, Kbd, Link, Markdown, Pagination, ProgressBar, Skeleton, Spinner, StatusDot, Text, Thumbnail, Timestamp, Token | 22 |
| **Inputs** | CheckboxInput, CheckboxList, DateInput, Field, FormLayout, MultiSelector, NumberInput, PowerSearch, RadioList, SegmentedControl, Selector, Slider, Switch, TextArea, TextInput, TimeInput, Tokenizer, Typeahead | 18 |
| **Layout** | AppShell, AspectRatio, Card, Center, Collapsible, Divider, Grid, Layout, OverflowList, Section, Stack, Toolbar | 12 |
| **Navigation** | Breadcrumbs, MobileNav, SideNav, TabList, TopNav, TopNavMenu | 6 |
| **Overlays** | AlertDialog, Dialog, HoverCard, Popover, Toast, Tooltip | 6 |

Plus: **Lab**, **Theme**, **Hooks**, **Patterns**, **Vega**

## Compare with

- **#1605** (Proposal B) — Flat + grouped. Components alphabetical by default, groups only where there's combination energy.
- This PR (Proposal A) — Every component categorized. Easier to browse by concept, harder to find a specific component.

## Changes

- Update all storybook story titles to new categorical structure
- Strip XDS prefix from all titles
- Move Analytics Dashboard and Theme Editor to Patterns/

Refs #1598