### PR TITLE
Improve RadioList docs page and block examples

### DIFF
--- a/packages/cli/templates/blocks/components/RadioList/RadioListHorizontalLayout.doc.mjs
+++ b/packages/cli/templates/blocks/components/RadioList/RadioListHorizontalLayout.doc.mjs
@@ -3,7 +3,7 @@ export const doc = {
   type: 'block',
   name: 'RadioList — Horizontal Layout',
   description:
-    'Radio list with horizontal orientation for compact inline selection like sizes.',
+    'Radio list with horizontal orientation for compact selections.',
   isReady: true,
   aspectRatio: 4 / 3,
   componentsUsed: ['RadioList'],

--- a/packages/cli/templates/blocks/components/RadioList/RadioListPricingTier.doc.mjs
+++ b/packages/cli/templates/blocks/components/RadioList/RadioListPricingTier.doc.mjs
@@ -3,8 +3,8 @@ export const doc = {
   type: 'block',
   name: 'RadioList — Pricing Tier',
   description:
-    'Radio list with end content showing pricing info, a common pattern for plan selection.',
+    'Radio list with pricing info in end content for plan selection.',
   isReady: true,
   aspectRatio: 4 / 3,
-  componentsUsed: ['RadioList'],
+  componentsUsed: ['RadioList', 'Text'],
 };

--- a/packages/cli/templates/blocks/components/RadioList/RadioListPricingTier.tsx
+++ b/packages/cli/templates/blocks/components/RadioList/RadioListPricingTier.tsx
@@ -12,17 +12,29 @@ export default function RadioListPricingTier() {
       <XDSRadioListItem
         label="Free"
         value="free"
-        endContent={<XDSText type="body" color="positive">$0/mo</XDSText>}
+        endContent={
+          <XDSText type="body" color="secondary">
+            $0/mo
+          </XDSText>
+        }
       />
       <XDSRadioListItem
         label="Pro"
         value="pro"
-        endContent={<XDSText type="body" color="accent">$9/mo</XDSText>}
+        endContent={
+          <XDSText type="body" color="secondary">
+            $9/mo
+          </XDSText>
+        }
       />
       <XDSRadioListItem
         label="Enterprise"
         value="enterprise"
-        endContent={<XDSText type="body" color="secondary">Custom</XDSText>}
+        endContent={
+          <XDSText type="body" color="secondary">
+            Custom
+          </XDSText>
+        }
       />
     </XDSRadioList>
   );

--- a/packages/cli/templates/blocks/components/RadioList/RadioListPricingTier.tsx
+++ b/packages/cli/templates/blocks/components/RadioList/RadioListPricingTier.tsx
@@ -2,6 +2,7 @@
 
 import {useState} from 'react';
 import {XDSRadioList, XDSRadioListItem} from '@xds/core/RadioList';
+import {XDSText} from '@xds/core/Text';
 
 export default function RadioListPricingTier() {
   const [value, setValue] = useState('');
@@ -11,17 +12,17 @@ export default function RadioListPricingTier() {
       <XDSRadioListItem
         label="Free"
         value="free"
-        endContent={<span style={{color: '#0D8626'}}>$0/mo</span>}
+        endContent={<XDSText type="body" color="positive">$0/mo</XDSText>}
       />
       <XDSRadioListItem
         label="Pro"
         value="pro"
-        endContent={<span style={{color: '#0064E0'}}>$9/mo</span>}
+        endContent={<XDSText type="body" color="accent">$9/mo</XDSText>}
       />
       <XDSRadioListItem
         label="Enterprise"
         value="enterprise"
-        endContent={<span style={{color: '#5B08D8'}}>Custom</span>}
+        endContent={<XDSText type="body" color="secondary">Custom</XDSText>}
       />
     </XDSRadioList>
   );

--- a/packages/cli/templates/blocks/components/RadioList/RadioListWithDescriptions.doc.mjs
+++ b/packages/cli/templates/blocks/components/RadioList/RadioListWithDescriptions.doc.mjs
@@ -3,7 +3,7 @@ export const doc = {
   type: 'block',
   name: 'RadioList — With Descriptions',
   description:
-    'Radio list with description text on both the group and each individual item.',
+    'Radio list with descriptions on the group and each item.',
   isReady: true,
   aspectRatio: 4 / 3,
   componentsUsed: ['RadioList'],

--- a/packages/cli/templates/blocks/components/RadioList/RadioListWithValidation.doc.mjs
+++ b/packages/cli/templates/blocks/components/RadioList/RadioListWithValidation.doc.mjs
@@ -3,7 +3,7 @@ export const doc = {
   type: 'block',
   name: 'RadioList — With Validation',
   description:
-    'Required radio list that shows an error message when no option is selected.',
+    'Required radio list with an error message when nothing is selected.',
   isReady: true,
   aspectRatio: 4 / 3,
   componentsUsed: ['RadioList'],

--- a/packages/core/src/RadioList/RadioList.doc.mjs
+++ b/packages/core/src/RadioList/RadioList.doc.mjs
@@ -144,12 +144,14 @@ export const docs = {
   ],
   usage: {
     description:
-      'RadioList presents a group of mutually exclusive options for single-value selection. Use it when users must choose exactly one option from a small, visible set. For multiple selections use CheckboxList; for long option lists consider Selector.',
+      'A group of options where only one can be selected at a time. All options are visible at once, making it easy to compare choices. Use it when users need to pick one option from a small set.',
     bestPractices: [
-      { guidance: true, description: 'Keep the number of options small enough to display without scrolling — typically 2 to 7 choices.' },
+      { guidance: true, description: 'Keep the number of options small — typically 2 to 7 choices.' },
       { guidance: true, description: 'Use clear, concise labels that differentiate each option at a glance.' },
-      { guidance: false, description: 'Use a RadioList when more than one selection is needed — switch to CheckboxList for multi-select scenarios.' },
-      { guidance: false, description: 'Use a RadioList for very long lists of options — use a Selector or Combobox for discoverability.' },
+      { guidance: true, description: "Pre-select a default option when there's a sensible default — don't leave the group empty unless the choice is truly optional." },
+      { guidance: false, description: 'Use when multiple selections are needed — use CheckboxList instead.' },
+      { guidance: false, description: 'Use for long lists — use Selector for better discoverability.' },
+      { guidance: false, description: 'Use horizontal layout with more than 4 options — it wraps awkwardly.' },
     ],
     anatomy: [
       {name: 'Header', required: false, description: 'Optional heading above the radio list.'},
@@ -304,12 +306,14 @@ export const docsZh = {
   ],
   usage: {
     description:
-      'RadioList presents a group of mutually exclusive options for single-value selection. Use it when users must choose exactly one option from a small, visible set. For multiple selections use CheckboxList; for long option lists consider Selector.',
+      'A group of options where only one can be selected at a time. All options are visible at once, making it easy to compare choices. Use it when users need to pick one option from a small set.',
     bestPractices: [
-      { guidance: true, description: 'Keep the number of options small enough to display without scrolling — typically 2 to 7 choices.' },
+      { guidance: true, description: 'Keep the number of options small — typically 2 to 7 choices.' },
       { guidance: true, description: 'Use clear, concise labels that differentiate each option at a glance.' },
-      { guidance: false, description: 'Use a RadioList when more than one selection is needed — switch to CheckboxList for multi-select scenarios.' },
-      { guidance: false, description: 'Use a RadioList for very long lists of options — use a Selector or Combobox for discoverability.' },
+      { guidance: true, description: "Pre-select a default option when there's a sensible default — don't leave the group empty unless the choice is truly optional." },
+      { guidance: false, description: 'Use when multiple selections are needed — use CheckboxList instead.' },
+      { guidance: false, description: 'Use for long lists — use Selector for better discoverability.' },
+      { guidance: false, description: 'Use horizontal layout with more than 4 options — it wraps awkwardly.' },
     ],
     anatomy: [
       {name: 'Header', required: false, description: 'Optional heading above the radio list.'},
@@ -325,12 +329,14 @@ export const docsDense = {
     'Radio group component for single-value selection from list of options.',
   usage: {
     description:
-      'RadioList presents a group of mutually exclusive options for single-value selection. Use it when users must choose exactly one option from a small, visible set. For multiple selections use CheckboxList; for long option lists consider Selector.',
+      'A group of options where only one can be selected at a time. All options are visible at once, making it easy to compare choices. Use it when users need to pick one option from a small set.',
     bestPractices: [
-      { guidance: true, description: 'Keep the number of options small enough to display without scrolling — typically 2 to 7 choices.' },
+      { guidance: true, description: 'Keep the number of options small — typically 2 to 7 choices.' },
       { guidance: true, description: 'Use clear, concise labels that differentiate each option at a glance.' },
-      { guidance: false, description: 'Use a RadioList when more than one selection is needed — switch to CheckboxList for multi-select scenarios.' },
-      { guidance: false, description: 'Use a RadioList for very long lists of options — use a Selector or Combobox for discoverability.' },
+      { guidance: true, description: "Pre-select a default option when there's a sensible default — don't leave the group empty unless the choice is truly optional." },
+      { guidance: false, description: 'Use when multiple selections are needed — use CheckboxList instead.' },
+      { guidance: false, description: 'Use for long lists — use Selector for better discoverability.' },
+      { guidance: false, description: 'Use horizontal layout with more than 4 options — it wraps awkwardly.' },
     ],
     anatomy: [
       {name: 'Header', required: false, description: 'Optional heading above the radio list.'},


### PR DESCRIPTION
## Summary
- Rewrite usage description in plain language
- Expand best practices: add default selection do, horizontal layout don't, simplify existing
- Replace raw `<span>` tags with `XDSText` in Pricing Tier block
- Tighten block descriptions
- Update `componentsUsed` in doc metadata

## Test plan
- [ ] Verify `npx xds component RadioList` output reflects updated usage and best practices
- [ ] Verify all 4 RadioList blocks render correctly in the sandbox
- [ ] Check Pricing Tier block renders XDSText color variants correctly