### PR TITLE
fix(templates): improve two-column contact form rubric score

### DIFF
--- a/packages/cli/templates/pages/form-two-column/page.tsx
+++ b/packages/cli/templates/pages/form-two-column/page.tsx
@@ -56,7 +56,6 @@ const CONTACT_COLUMNS = [
 const styles = stylex.create({
   page: {
     backgroundColor: colorVars['--color-background-surface'],
-    minHeight: '100svh',
     padding: 48,
   },
   inner: {
@@ -64,10 +63,7 @@ const styles = stylex.create({
     width: '100%',
   },
   topGrid: {
-    display: 'grid',
-    gridTemplateColumns: '1fr 1fr',
     gap: 80,
-    alignItems: 'center',
   },
   imagePlaceholder: {
     borderRadius: radiusVars['--radius-container'],
@@ -118,7 +114,7 @@ export default function FormTwoColumnPage() {
     <XDSCenter height="100svh" xstyle={styles.page}>
       <XDSVStack gap={10} xstyle={styles.inner}>
         {/* ── Top: two-column ── */}
-        <div {...stylex.props(styles.topGrid)}>
+        <XDSGrid columns={2} align="center" xstyle={styles.topGrid}>
           {/* Left: headline + description + illustration */}
           <XDSVStack gap={6}>
             <XDSVStack gap={3}>
@@ -235,7 +231,7 @@ export default function FormTwoColumnPage() {
               />
             </XDSVStack>
           </XDSCard>
-        </div>
+        </XDSGrid>
 
         {/* ── Bottom: contact strip ── */}
         <XDSVStack gap={6}>

--- a/packages/cli/templates/pages/form-two-column/page.tsx
+++ b/packages/cli/templates/pages/form-two-column/page.tsx
@@ -70,15 +70,10 @@ const styles = stylex.create({
     alignItems: 'center',
   },
   imagePlaceholder: {
-    backgroundColor: colorVars['--color-background-surface'],
     borderRadius: radiusVars['--radius-container'],
-    overflow: 'hidden',
-    alignSelf: 'flex-start',
     width: '85%',
     aspectRatio: '4 / 3',
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
+    objectFit: 'contain',
   },
   fullWidth: {
     width: '100%',
@@ -135,13 +130,11 @@ export default function FormTwoColumnPage() {
                 figure out the best path forward.
               </XDSText>
             </XDSVStack>
-            <div {...stylex.props(styles.imagePlaceholder)}>
-              <img
-                src={ILLUSTRATION_URL}
-                alt="Illustration"
-                style={{width: '100%', height: '100%', objectFit: 'contain'}}
-              />
-            </div>
+            <img
+              {...stylex.props(styles.imagePlaceholder)}
+              src={ILLUSTRATION_URL}
+              alt="Illustration"
+            />
           </XDSVStack>
 
           {/* Right: form on a card */}

--- a/packages/cli/templates/pages/form-two-column/page.tsx
+++ b/packages/cli/templates/pages/form-two-column/page.tsx
@@ -20,7 +20,7 @@ import {
 
 // illustration-horizontal-1 from xds_oss asset set
 const ILLUSTRATION_URL =
-  'https://lookaside.facebook.com/assets/xds_oss/illustration-horizontal-1.jpg';
+  'https://lookaside.facebook.com/assets/xds_oss/illustration-horizontal-1.png';
 
 // ─────────────────────────────────────────────────────────────
 // Constants

--- a/packages/cli/templates/pages/form-two-column/page.tsx
+++ b/packages/cli/templates/pages/form-two-column/page.tsx
@@ -3,6 +3,8 @@
 import {useState} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {XDSVStack, XDSHStack} from '@xds/core/Layout';
+import {XDSCenter} from '@xds/core/Center';
+import {XDSGrid} from '@xds/core/Grid';
 import {XDSButton} from '@xds/core/Button';
 import {XDSText} from '@xds/core/Text';
 import {XDSTextInput} from '@xds/core/TextInput';
@@ -54,18 +56,12 @@ const CONTACT_COLUMNS = [
 const styles = stylex.create({
   page: {
     backgroundColor: colorVars['--color-background-surface'],
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
     minHeight: '100svh',
     padding: 48,
   },
   inner: {
     maxWidth: 1100,
     width: '100%',
-    display: 'flex',
-    flexDirection: 'column',
-    gap: 56,
   },
   topGrid: {
     display: 'grid',
@@ -83,18 +79,6 @@ const styles = stylex.create({
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
-  },
-  inlineGrid: {
-    display: 'grid',
-    gridTemplateColumns: '1fr 1fr',
-    gap: 12,
-  },
-  footerGrid: {
-    display: 'grid',
-    gridTemplateColumns: '1fr 1fr 1fr',
-    gap: 32,
-    paddingTop: 32,
-    textAlign: 'center',
   },
   fullWidth: {
     width: '100%',
@@ -136,8 +120,8 @@ export default function FormTwoColumnPage() {
   const handleSubmit = () => setSubmitted(true);
 
   return (
-    <div {...stylex.props(styles.page)}>
-      <div {...stylex.props(styles.inner)}>
+    <XDSCenter height="100svh" xstyle={styles.page}>
+      <XDSVStack gap={10} xstyle={styles.inner}>
         {/* ── Top: two-column ── */}
         <div {...stylex.props(styles.topGrid)}>
           {/* Left: headline + description + illustration */}
@@ -176,7 +160,7 @@ export default function FormTwoColumnPage() {
                     : undefined
                 }
               />
-              <div {...stylex.props(styles.inlineGrid)}>
+              <XDSGrid columns={2} gap={3}>
                 <XDSTextInput
                   label="Email"
                   isLabelHidden
@@ -196,8 +180,8 @@ export default function FormTwoColumnPage() {
                   value={company}
                   onChange={setCompany}
                 />
-              </div>
-              <div {...stylex.props(styles.inlineGrid)}>
+              </XDSGrid>
+              <XDSGrid columns={2} gap={3}>
                 <XDSTextInput
                   label="Job title"
                   isLabelHidden
@@ -212,7 +196,7 @@ export default function FormTwoColumnPage() {
                   value={phone}
                   onChange={setPhone}
                 />
-              </div>
+              </XDSGrid>
 
               <XDSVStack gap={2}>
                 <XDSText type="label">What are you reaching out about?</XDSText>
@@ -263,7 +247,7 @@ export default function FormTwoColumnPage() {
         {/* ── Bottom: contact strip ── */}
         <XDSVStack gap={6}>
           <XDSDivider />
-          <div {...stylex.props(styles.footerGrid)}>
+          <XDSGrid columns={3} gap={6}>
             {CONTACT_COLUMNS.map(col => (
               <XDSVStack key={col.label} gap={1} hAlign="center">
                 <XDSText type="supporting" color="secondary">
@@ -278,9 +262,9 @@ export default function FormTwoColumnPage() {
                 </XDSLink>
               </XDSVStack>
             ))}
-          </div>
+          </XDSGrid>
         </XDSVStack>
-      </div>
-    </div>
+      </XDSVStack>
+    </XDSCenter>
   );
 }

--- a/packages/cli/templates/pages/form-two-column/page.tsx
+++ b/packages/cli/templates/pages/form-two-column/page.tsx
@@ -5,6 +5,7 @@ import * as stylex from '@stylexjs/stylex';
 import {XDSVStack, XDSHStack} from '@xds/core/Layout';
 import {XDSCenter} from '@xds/core/Center';
 import {XDSGrid} from '@xds/core/Grid';
+import {XDSAspectRatio} from '@xds/core/AspectRatio';
 import {XDSButton} from '@xds/core/Button';
 import {XDSText} from '@xds/core/Text';
 import {XDSTextInput} from '@xds/core/TextInput';
@@ -14,7 +15,7 @@ import {XDSLink} from '@xds/core/Link';
 import {XDSDivider} from '@xds/core/Divider';
 import {XDSCard} from '@xds/core/Card';
 import {XDSSelector} from '@xds/core/Selector';
-import {colorVars, radiusVars} from '@xds/core/theme/tokens.stylex';
+import {colorVars} from '@xds/core/theme/tokens.stylex';
 
 // illustration-horizontal-1 from xds_oss asset set
 const ILLUSTRATION_URL =
@@ -62,14 +63,8 @@ const styles = stylex.create({
     maxWidth: 1100,
     width: '100%',
   },
-  topGrid: {
-    gap: 80,
-  },
   imagePlaceholder: {
-    borderRadius: radiusVars['--radius-container'],
     width: '85%',
-    aspectRatio: '4 / 3',
-    objectFit: 'contain',
   },
   fullWidth: {
     width: '100%',
@@ -114,7 +109,7 @@ export default function FormTwoColumnPage() {
     <XDSCenter height="100svh" xstyle={styles.page}>
       <XDSVStack gap={10} xstyle={styles.inner}>
         {/* ── Top: two-column ── */}
-        <XDSGrid columns={2} align="center" xstyle={styles.topGrid}>
+        <XDSGrid columns={2} align="center" gap={10}>
           {/* Left: headline + description + illustration */}
           <XDSVStack gap={6}>
             <XDSVStack gap={3}>
@@ -126,11 +121,9 @@ export default function FormTwoColumnPage() {
                 figure out the best path forward.
               </XDSText>
             </XDSVStack>
-            <img
-              {...stylex.props(styles.imagePlaceholder)}
-              src={ILLUSTRATION_URL}
-              alt="Illustration"
-            />
+            <XDSAspectRatio ratio={4 / 3} xstyle={styles.imagePlaceholder}>
+              <img src={ILLUSTRATION_URL} alt="Illustration" />
+            </XDSAspectRatio>
           </XDSVStack>
 
           {/* Right: form on a card */}

--- a/packages/cli/templates/pages/form-two-column/page.tsx
+++ b/packages/cli/templates/pages/form-two-column/page.tsx
@@ -106,7 +106,7 @@ export default function FormTwoColumnPage() {
       <XDSSection
         maxWidth={1100}
         width="100%"
-        padding={12}
+        padding={10}
         variant="transparent">
         <XDSVStack gap={10}>
           {/* ── Top: two-column ── */}

--- a/packages/cli/templates/pages/form-two-column/page.tsx
+++ b/packages/cli/templates/pages/form-two-column/page.tsx
@@ -18,8 +18,9 @@ import {
   radiusVars,
 } from '@xds/core/theme/tokens.stylex';
 
+// illustration-horizontal-1 from xds_oss asset set
 const ILLUSTRATION_URL =
-  'https://images.unsplash.com/photo-1618005182384-a83a8bd57fbe?w=800&q=80';
+  'https://lookaside.facebook.com/assets/xds_oss/illustrative-horizontal-1.jpg';
 
 // ─────────────────────────────────────────────────────────────
 // Constants

--- a/packages/cli/templates/pages/form-two-column/page.tsx
+++ b/packages/cli/templates/pages/form-two-column/page.tsx
@@ -4,6 +4,7 @@ import {useState} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {XDSVStack, XDSHStack} from '@xds/core/Layout';
 import {XDSCenter} from '@xds/core/Center';
+import {XDSSection} from '@xds/core/Section';
 import {XDSGrid} from '@xds/core/Grid';
 import {XDSAspectRatio} from '@xds/core/AspectRatio';
 import {XDSButton} from '@xds/core/Button';
@@ -57,11 +58,6 @@ const CONTACT_COLUMNS = [
 const styles = stylex.create({
   page: {
     backgroundColor: colorVars['--color-background-surface'],
-    padding: 48,
-  },
-  inner: {
-    maxWidth: 1100,
-    width: '100%',
   },
   imagePlaceholder: {
     width: '85%',
@@ -107,146 +103,154 @@ export default function FormTwoColumnPage() {
 
   return (
     <XDSCenter height="100svh" xstyle={styles.page}>
-      <XDSVStack gap={10} xstyle={styles.inner}>
-        {/* ── Top: two-column ── */}
-        <XDSGrid columns={2} align="center" gap={10}>
-          {/* Left: headline + description + illustration */}
-          <XDSVStack gap={6}>
-            <XDSVStack gap={3}>
-              <XDSText type="display-1" as="h1">
-                Let&apos;s work together
-              </XDSText>
-              <XDSText type="body" color="secondary">
-                Tell us what you&apos;re working on and we&apos;ll help you
-                figure out the best path forward.
-              </XDSText>
+      <XDSSection
+        maxWidth={1100}
+        width="100%"
+        padding={12}
+        variant="transparent">
+        <XDSVStack gap={10}>
+          {/* ── Top: two-column ── */}
+          <XDSGrid columns={2} align="center" gap={10}>
+            {/* Left: headline + description + illustration */}
+            <XDSVStack gap={6}>
+              <XDSVStack gap={3}>
+                <XDSText type="display-1" as="h1">
+                  Let&apos;s work together
+                </XDSText>
+                <XDSText type="body" color="secondary">
+                  Tell us what you&apos;re working on and we&apos;ll help you
+                  figure out the best path forward.
+                </XDSText>
+              </XDSVStack>
+              <XDSAspectRatio ratio={4 / 3} xstyle={styles.imagePlaceholder}>
+                <img src={ILLUSTRATION_URL} alt="Illustration" />
+              </XDSAspectRatio>
             </XDSVStack>
-            <XDSAspectRatio ratio={4 / 3} xstyle={styles.imagePlaceholder}>
-              <img src={ILLUSTRATION_URL} alt="Illustration" />
-            </XDSAspectRatio>
-          </XDSVStack>
 
-          {/* Right: form on a card */}
-          <XDSCard padding={8}>
-            <XDSVStack gap={4}>
-              <XDSText type="label">Your details</XDSText>
-              <XDSTextInput
-                label="Full name"
-                isLabelHidden
-                placeholder="Full name*"
-                value={fullName}
-                onChange={setFullName}
-                status={
-                  errors.fullName
-                    ? {type: 'error', message: errors.fullName}
-                    : undefined
-                }
-              />
-              <XDSGrid columns={2} gap={3}>
+            {/* Right: form on a card */}
+            <XDSCard padding={8}>
+              <XDSVStack gap={4}>
+                <XDSText type="label">Your details</XDSText>
                 <XDSTextInput
-                  label="Email"
+                  label="Full name"
                   isLabelHidden
-                  placeholder="Email*"
-                  value={email}
-                  onChange={setEmail}
+                  placeholder="Full name*"
+                  value={fullName}
+                  onChange={setFullName}
                   status={
-                    errors.email
-                      ? {type: 'error', message: errors.email}
+                    errors.fullName
+                      ? {type: 'error', message: errors.fullName}
                       : undefined
                   }
                 />
-                <XDSTextInput
-                  label="Company name"
-                  isLabelHidden
-                  placeholder="Company name"
-                  value={company}
-                  onChange={setCompany}
-                />
-              </XDSGrid>
-              <XDSGrid columns={2} gap={3}>
-                <XDSTextInput
-                  label="Job title"
-                  isLabelHidden
-                  placeholder="Job title"
-                  value={jobTitle}
-                  onChange={setJobTitle}
-                />
-                <XDSTextInput
-                  label="Phone number"
-                  isLabelHidden
-                  placeholder="Phone number"
-                  value={phone}
-                  onChange={setPhone}
-                />
-              </XDSGrid>
+                <XDSGrid columns={2} gap={3}>
+                  <XDSTextInput
+                    label="Email"
+                    isLabelHidden
+                    placeholder="Email*"
+                    value={email}
+                    onChange={setEmail}
+                    status={
+                      errors.email
+                        ? {type: 'error', message: errors.email}
+                        : undefined
+                    }
+                  />
+                  <XDSTextInput
+                    label="Company name"
+                    isLabelHidden
+                    placeholder="Company name"
+                    value={company}
+                    onChange={setCompany}
+                  />
+                </XDSGrid>
+                <XDSGrid columns={2} gap={3}>
+                  <XDSTextInput
+                    label="Job title"
+                    isLabelHidden
+                    placeholder="Job title"
+                    value={jobTitle}
+                    onChange={setJobTitle}
+                  />
+                  <XDSTextInput
+                    label="Phone number"
+                    isLabelHidden
+                    placeholder="Phone number"
+                    value={phone}
+                    onChange={setPhone}
+                  />
+                </XDSGrid>
 
-              <XDSVStack gap={2}>
-                <XDSText type="label">What are you reaching out about?</XDSText>
-                <XDSHStack gap={2} wrap="wrap">
-                  {INQUIRY_REASONS.map(reason => (
-                    <XDSToken
-                      key={reason}
-                      label={reason}
-                      color={inquiryReason === reason ? 'blue' : 'default'}
-                      onClick={() =>
-                        setInquiryReason(prev =>
-                          prev === reason ? '' : reason,
-                        )
-                      }
-                    />
-                  ))}
-                </XDSHStack>
+                <XDSVStack gap={2}>
+                  <XDSText type="label">
+                    What are you reaching out about?
+                  </XDSText>
+                  <XDSHStack gap={2} wrap="wrap">
+                    {INQUIRY_REASONS.map(reason => (
+                      <XDSToken
+                        key={reason}
+                        label={reason}
+                        color={inquiryReason === reason ? 'blue' : 'default'}
+                        onClick={() =>
+                          setInquiryReason(prev =>
+                            prev === reason ? '' : reason,
+                          )
+                        }
+                      />
+                    ))}
+                  </XDSHStack>
+                </XDSVStack>
+                <XDSSelector
+                  label="Budget range"
+                  options={BUDGET_OPTIONS}
+                  value={budget}
+                  onChange={setBudget}
+                  placeholder="Select a budget range..."
+                />
+                <XDSTextArea
+                  label="Project details"
+                  isLabelHidden
+                  placeholder="Project details*"
+                  value={details}
+                  onChange={setDetails}
+                  status={
+                    errors.details
+                      ? {type: 'error', message: errors.details}
+                      : undefined
+                  }
+                />
+                <XDSButton
+                  label="Let's connect"
+                  variant="primary"
+                  xstyle={styles.fullWidth}
+                  onClick={handleSubmit}
+                />
               </XDSVStack>
-              <XDSSelector
-                label="Budget range"
-                options={BUDGET_OPTIONS}
-                value={budget}
-                onChange={setBudget}
-                placeholder="Select a budget range..."
-              />
-              <XDSTextArea
-                label="Project details"
-                isLabelHidden
-                placeholder="Project details*"
-                value={details}
-                onChange={setDetails}
-                status={
-                  errors.details
-                    ? {type: 'error', message: errors.details}
-                    : undefined
-                }
-              />
-              <XDSButton
-                label="Let's connect"
-                variant="primary"
-                xstyle={styles.fullWidth}
-                onClick={handleSubmit}
-              />
-            </XDSVStack>
-          </XDSCard>
-        </XDSGrid>
-
-        {/* ── Bottom: contact strip ── */}
-        <XDSVStack gap={6}>
-          <XDSDivider />
-          <XDSGrid columns={3} gap={6}>
-            {CONTACT_COLUMNS.map(col => (
-              <XDSVStack key={col.label} gap={1} hAlign="center">
-                <XDSText type="supporting" color="secondary">
-                  {col.label}
-                </XDSText>
-                <XDSLink
-                  label={col.email}
-                  href={`mailto:${col.email}`}
-                  type="body"
-                  size="sm">
-                  {col.email}
-                </XDSLink>
-              </XDSVStack>
-            ))}
+            </XDSCard>
           </XDSGrid>
+
+          {/* ── Bottom: contact strip ── */}
+          <XDSVStack gap={6}>
+            <XDSDivider />
+            <XDSGrid columns={3} gap={6}>
+              {CONTACT_COLUMNS.map(col => (
+                <XDSVStack key={col.label} gap={1} hAlign="center">
+                  <XDSText type="supporting" color="secondary">
+                    {col.label}
+                  </XDSText>
+                  <XDSLink
+                    label={col.email}
+                    href={`mailto:${col.email}`}
+                    type="body"
+                    size="sm">
+                    {col.email}
+                  </XDSLink>
+                </XDSVStack>
+              ))}
+            </XDSGrid>
+          </XDSVStack>
         </XDSVStack>
-      </XDSVStack>
+      </XDSSection>
     </XDSCenter>
   );
 }

--- a/packages/cli/templates/pages/form-two-column/page.tsx
+++ b/packages/cli/templates/pages/form-two-column/page.tsx
@@ -20,7 +20,7 @@ import {
 
 // illustration-horizontal-1 from xds_oss asset set
 const ILLUSTRATION_URL =
-  'https://lookaside.facebook.com/assets/xds_oss/illustrative-horizontal-1.jpg';
+  'https://lookaside.facebook.com/assets/xds_oss/illustration-horizontal-1.jpg';
 
 // ─────────────────────────────────────────────────────────────
 // Constants

--- a/packages/cli/templates/pages/form-two-column/page.tsx
+++ b/packages/cli/templates/pages/form-two-column/page.tsx
@@ -2,7 +2,7 @@
 
 import {useState} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {XDSVStack} from '@xds/core/Layout';
+import {XDSVStack, XDSHStack} from '@xds/core/Layout';
 import {XDSButton} from '@xds/core/Button';
 import {XDSText} from '@xds/core/Text';
 import {XDSTextInput} from '@xds/core/TextInput';
@@ -12,11 +12,7 @@ import {XDSLink} from '@xds/core/Link';
 import {XDSDivider} from '@xds/core/Divider';
 import {XDSCard} from '@xds/core/Card';
 import {XDSSelector} from '@xds/core/Selector';
-import {
-  colorVars,
-  spacingVars,
-  radiusVars,
-} from '@xds/core/theme/tokens.stylex';
+import {colorVars, radiusVars} from '@xds/core/theme/tokens.stylex';
 
 // illustration-horizontal-1 from xds_oss asset set
 const ILLUSTRATION_URL =
@@ -77,13 +73,6 @@ const styles = stylex.create({
     gap: 80,
     alignItems: 'center',
   },
-  headline: {
-    fontSize: 48,
-    fontWeight: 700,
-    lineHeight: 1.05,
-    letterSpacing: '-0.03em',
-    margin: 0,
-  },
   imagePlaceholder: {
     backgroundColor: colorVars['--color-background-surface'],
     borderRadius: radiusVars['--radius-container'],
@@ -107,42 +96,10 @@ const styles = stylex.create({
     paddingTop: 32,
     textAlign: 'center',
   },
-  footerLabel: {
-    textTransform: 'uppercase',
-    letterSpacing: '0.08em',
-  },
-  tokenWrap: {
-    display: 'flex',
-    flexWrap: 'wrap',
-    gap: spacingVars['--spacing-2'],
-  },
   fullWidth: {
     width: '100%',
   },
 });
-
-const mobileStyles = stylex.create({
-  page: {
-    padding: 20,
-    alignItems: 'flex-start',
-  },
-  topGrid: {
-    gridTemplateColumns: '1fr',
-    gap: 32,
-  },
-  image: {
-    width: '100%',
-  },
-  footerGrid: {
-    gridTemplateColumns: '1fr',
-    textAlign: 'left',
-  },
-  inlineGrid: {
-    gridTemplateColumns: '1fr',
-  },
-});
-
-const MOBILE = '@media (max-width: 767px)' as const;
 
 // ─────────────────────────────────────────────────────────────
 // Page
@@ -186,9 +143,9 @@ export default function FormTwoColumnPage() {
           {/* Left: headline + description + illustration */}
           <XDSVStack gap={6}>
             <XDSVStack gap={3}>
-              <div {...stylex.props(styles.headline)}>
+              <XDSText type="display-1" as="h1">
                 Let&apos;s work together
-              </div>
+              </XDSText>
               <XDSText type="body" color="secondary">
                 Tell us what you&apos;re working on and we&apos;ll help you
                 figure out the best path forward.
@@ -259,7 +216,7 @@ export default function FormTwoColumnPage() {
 
               <XDSVStack gap={2}>
                 <XDSText type="label">What are you reaching out about?</XDSText>
-                <div {...stylex.props(styles.tokenWrap)}>
+                <XDSHStack gap={2} wrap="wrap">
                   {INQUIRY_REASONS.map(reason => (
                     <XDSToken
                       key={reason}
@@ -272,7 +229,7 @@ export default function FormTwoColumnPage() {
                       }
                     />
                   ))}
-                </div>
+                </XDSHStack>
               </XDSVStack>
               <XDSSelector
                 label="Budget range"
@@ -304,13 +261,13 @@ export default function FormTwoColumnPage() {
         </div>
 
         {/* ── Bottom: contact strip ── */}
-        <div>
+        <XDSVStack gap={6}>
           <XDSDivider />
           <div {...stylex.props(styles.footerGrid)}>
             {CONTACT_COLUMNS.map(col => (
               <XDSVStack key={col.label} gap={1} hAlign="center">
                 <XDSText type="supporting" color="secondary">
-                  <span {...stylex.props(styles.footerLabel)}>{col.label}</span>
+                  {col.label}
                 </XDSText>
                 <XDSLink
                   label={col.email}
@@ -322,7 +279,7 @@ export default function FormTwoColumnPage() {
               </XDSVStack>
             ))}
           </div>
-        </div>
+        </XDSVStack>
       </div>
     </div>
   );


### PR DESCRIPTION
## TL;DR

Improve the form-two-column template from **F (37/100)** to **A (92/100)** on the [template grading rubric](https://github.com/facebookexperimental/xds/wiki/Contributing-Templates#template-grading-rubric). 

## What changed

- **Image**: Replaced external Unsplash URL with permanent `xds_oss` asset (`illustration-horizontal-1`)
- **Page root**: Raw `<div>` → `XDSCenter`
- **Inner wrapper**: Raw `<div>` with custom flexbox → `XDSSection` (maxWidth, width, padding props) + `XDSVStack`
- **Headline**: Raw `<div>` with 5 custom CSS declarations → `XDSText type="display-1"` (42px token)
- **Form field grids**: Raw `<div>` with CSS grid → `XDSGrid columns={2}`
- **Footer grid**: Raw `<div>` with CSS grid → `XDSGrid columns={3}`
- **Token chips wrap**: Raw `<div>` with flexbox → `XDSHStack wrap="wrap"`
- **Footer wrapper**: Raw `<div>` → `XDSVStack`
- **Footer label**: Raw `<span>` with custom uppercase styling → inline text in `XDSText`
- **Image container**: Wrapper `<div>` with 9 CSS declarations → `XDSAspectRatio ratio={4/3}`
- **Dead code**: Removed unused `mobileStyles`, `MOBILE` const, and unused token imports

## What did not change

- **Two-column layout**: Still the same left-content / right-form split
- **Form fields and behavior**: All inputs, validation, tokens, selectors untouched
- **Footer contact strip**: Same three-column layout
- **Overall visual design**: Layout structure preserved throughout

## Why some things remain as custom CSS

3 justified CSS declarations remain (no XDS alternative exists):
1. `page.backgroundColor` — `XDSCenter` has no `variant` or `background` prop
2. `imagePlaceholder.width: 85%` — no width prop on `<img>` or `XDSAspectRatio`
3. `fullWidth.width: 100%` — `XDSButton` has no `isFullWidth` prop; `xstyle` is the intended pattern

## Grading comparison

| Category | Before | After | Max |
|----------|--------|-------|-----|
| XDS Component Purity | 4 | 25 | 30 |
| Icon Purity | 15 | 15 | 15 |
| Custom CSS | 0 | 12 | 15 |
| Layout & Structure | 0 | 15 | 15 |
| Doc Metadata | 10 | 10 | 10 |
| Image Handling | 0 | 5 | 5 |
| Code Quality | 8 | 10 | 10 |
| **Total** | **37 (F)** | **92 (A)** | **100** |

## Recommendations

- **`XDSCenter` could benefit from a `variant` prop** (like Section has) to handle page background colors without xstyle
- **`XDSButton` could benefit from an `isFullWidth` prop** — full-width submit buttons are extremely common in form templates
- **`XDSAspectRatio` + `<img>` is a common pattern** — a first-party `XDSImage` component with `ratio`, `objectFit`, `radius`, and `width` props would eliminate the last necessary raw HTML element in image-heavy templates

## Preview

https://studious-broccoli-o7e61n3.pages.github.io/pr/1622/sandbox/templates/form-two-column/