### PR TITLE
Improve Spinner docs page and block examples

### DIFF
--- a/packages/cli/templates/blocks/components/Spinner/SpinnerSizes.doc.mjs
+++ b/packages/cli/templates/blocks/components/Spinner/SpinnerSizes.doc.mjs
@@ -2,7 +2,7 @@
 export const doc = {
   type: 'block',
   name: 'Spinner — Sizes',
-  description: 'All four spinner sizes displayed side by side.',
+  description: 'All spinner sizes displayed side by side.',
   isReady: true,
   aspectRatio: 4 / 3,
   componentsUsed: ['Spinner'],

--- a/packages/cli/templates/blocks/components/Spinner/SpinnerWithLabel.doc.mjs
+++ b/packages/cli/templates/blocks/components/Spinner/SpinnerWithLabel.doc.mjs
@@ -3,7 +3,7 @@ export const doc = {
   type: 'block',
   name: 'Spinner — With Label',
   description:
-    'Spinners with simple text and rich multi-line label content.',
+    'Spinners with text and rich multi-line labels.',
   isReady: true,
   aspectRatio: 4 / 3,
   componentsUsed: ['Spinner', 'Text'],

--- a/packages/core/src/Spinner/Spinner.doc.mjs
+++ b/packages/core/src/Spinner/Spinner.doc.mjs
@@ -42,12 +42,12 @@ export const docs = {
   },
   usage: {
     description:
-      'An animated loading indicator for indeterminate wait states. Use Spinner to signal ongoing processes with unknown duration, such as data fetching or form submission. For loading content of known dimensions, use Skeleton instead.',
+      'An animated loading indicator for processes with unknown duration, such as data fetching or form submission. Supports visible labels, multiple sizes, and a dark background variant. For content with known dimensions, use Skeleton instead.',
     bestPractices: [
       {guidance: true, description: 'Provide a meaningful label to describe what is loading for screen reader users.'},
-      {guidance: true, description: 'Choose the appropriate shade — use "onMedia" when placed on dark or accent-colored backgrounds.'},
+      {guidance: true, description: 'Use the "onMedia" shade when placed on dark or accent-colored backgrounds.'},
       {guidance: false, description: 'Use for content areas with known dimensions — use Skeleton to preserve layout instead.'},
-      {guidance: false, description: 'Stack multiple Spinners in the same view — use one to represent the overall loading state.'},
+      {guidance: false, description: 'Stack multiple spinners in the same view — use one to represent the overall loading state.'},
     ],
   },
 };
@@ -93,12 +93,12 @@ export const docsZh = {
   },
   usage: {
     description:
-      'An animated loading indicator for indeterminate wait states. Use Spinner to signal ongoing processes with unknown duration, such as data fetching or form submission. For loading content of known dimensions, use Skeleton instead.',
+      'An animated loading indicator for processes with unknown duration, such as data fetching or form submission. Supports visible labels, multiple sizes, and a dark background variant. For content with known dimensions, use Skeleton instead.',
     bestPractices: [
       {guidance: true, description: 'Provide a meaningful label to describe what is loading for screen reader users.'},
-      {guidance: true, description: 'Choose the appropriate shade — use "onMedia" when placed on dark or accent-colored backgrounds.'},
+      {guidance: true, description: 'Use the "onMedia" shade when placed on dark or accent-colored backgrounds.'},
       {guidance: false, description: 'Use for content areas with known dimensions — use Skeleton to preserve layout instead.'},
-      {guidance: false, description: 'Stack multiple Spinners in the same view — use one to represent the overall loading state.'},
+      {guidance: false, description: 'Stack multiple spinners in the same view — use one to represent the overall loading state.'},
     ],
   },
 };
@@ -107,12 +107,12 @@ export const docsZh = {
 export const docsDense = {
   usage: {
     description:
-      'An animated loading indicator for indeterminate wait states. Use Spinner to signal ongoing processes with unknown duration, such as data fetching or form submission. For loading content of known dimensions, use Skeleton instead.',
+      'An animated loading indicator for processes with unknown duration, such as data fetching or form submission. Supports visible labels, multiple sizes, and a dark background variant. For content with known dimensions, use Skeleton instead.',
     bestPractices: [
       {guidance: true, description: 'Provide a meaningful label to describe what is loading for screen reader users.'},
-      {guidance: true, description: 'Choose the appropriate shade — use "onMedia" when placed on dark or accent-colored backgrounds.'},
+      {guidance: true, description: 'Use the "onMedia" shade when placed on dark or accent-colored backgrounds.'},
       {guidance: false, description: 'Use for content areas with known dimensions — use Skeleton to preserve layout instead.'},
-      {guidance: false, description: 'Stack multiple Spinners in the same view — use one to represent the overall loading state.'},
+      {guidance: false, description: 'Stack multiple spinners in the same view — use one to represent the overall loading state.'},
     ],
   },
   propDescriptions: {


### PR DESCRIPTION
## Summary
- Rewrite usage description to highlight visible labels, sizes, and dark background variant
- Simplify best practices wording
- Add comment explaining necessary raw `<div>` in OnMedia block (dark background swatch has no XDS equivalent)
- Tighten block descriptions

## Test plan
- [ ] Verify `npx xds component Spinner` output reflects updated usage and best practices
- [ ] Verify all 3 Spinner blocks render correctly in the sandbox