### PR TITLE
Improve Slider docs page and block examples

### DIFF
--- a/packages/cli/templates/blocks/components/Slider/SliderFormattedValue.doc.mjs
+++ b/packages/cli/templates/blocks/components/Slider/SliderFormattedValue.doc.mjs
@@ -3,7 +3,7 @@ export const doc = {
   type: 'block',
   name: 'Slider — Formatted Value',
   description:
-    'Slider with a custom value formatter displaying the current value as text with units.',
+    'Slider with custom formatting showing temperature in Fahrenheit.',
   isReady: true,
   aspectRatio: 4 / 3,
   componentsUsed: ['Slider'],

--- a/packages/cli/templates/blocks/components/Slider/SliderRangeSlider.doc.mjs
+++ b/packages/cli/templates/blocks/components/Slider/SliderRangeSlider.doc.mjs
@@ -3,7 +3,7 @@ export const doc = {
   type: 'block',
   name: 'Slider — Range',
   description:
-    'Dual-thumb range slider for selecting a value range like price or date bounds.',
+    'Range slider for selecting a value range like price bounds.',
   isReady: true,
   aspectRatio: 4 / 3,
   componentsUsed: ['Slider'],

--- a/packages/cli/templates/blocks/components/Slider/SliderWithMarks.doc.mjs
+++ b/packages/cli/templates/blocks/components/Slider/SliderWithMarks.doc.mjs
@@ -3,7 +3,7 @@ export const doc = {
   type: 'block',
   name: 'Slider — With Marks',
   description:
-    'Slider with labeled tick marks at fixed intervals for guided value selection.',
+    'Slider with labeled tick marks at fixed intervals.',
   isReady: true,
   aspectRatio: 4 / 3,
   componentsUsed: ['Slider'],

--- a/packages/cli/templates/blocks/components/Slider/SliderWithStatus.doc.mjs
+++ b/packages/cli/templates/blocks/components/Slider/SliderWithStatus.doc.mjs
@@ -3,8 +3,8 @@ export const doc = {
   type: 'block',
   name: 'Slider — Validation States',
   description:
-    'Sliders with error, warning, and success status messages for system monitoring.',
+    'Sliders with error, warning, and success validation states.',
   isReady: true,
   aspectRatio: 4 / 3,
-  componentsUsed: ['Slider'],
+  componentsUsed: ['Slider', 'VStack', 'Center'],
 };

--- a/packages/cli/templates/blocks/components/Slider/SliderWithStatus.tsx
+++ b/packages/cli/templates/blocks/components/Slider/SliderWithStatus.tsx
@@ -2,37 +2,35 @@
 
 import {useState} from 'react';
 import {XDSSlider} from '@xds/core/Slider';
+import {XDSVStack} from '@xds/core/Layout';
+import {XDSCenter} from '@xds/core/Center';
 
 export default function SliderWithStatus() {
   const [value1, setValue1] = useState(95);
   const [value2, setValue2] = useState(50);
   const [value3, setValue3] = useState(75);
   return (
-    <div
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-        gap: 24,
-        maxWidth: 400,
-      }}>
-      <XDSSlider
-        label="CPU Usage"
-        value={value1}
-        onChange={setValue1}
-        status={{type: 'error', message: 'CPU usage is critically high'}}
-      />
-      <XDSSlider
-        label="Memory"
-        value={value2}
-        onChange={setValue2}
-        status={{type: 'warning', message: 'Memory usage is moderate'}}
-      />
-      <XDSSlider
-        label="Disk"
-        value={value3}
-        onChange={setValue3}
-        status={{type: 'success', message: 'Disk usage is healthy'}}
-      />
-    </div>
+    <XDSCenter width={400}>
+      <XDSVStack gap={6}>
+        <XDSSlider
+          label="CPU Usage"
+          value={value1}
+          onChange={setValue1}
+          status={{type: 'error', message: 'CPU usage is critically high'}}
+        />
+        <XDSSlider
+          label="Memory"
+          value={value2}
+          onChange={setValue2}
+          status={{type: 'warning', message: 'Memory usage is moderate'}}
+        />
+        <XDSSlider
+          label="Disk"
+          value={value3}
+          onChange={setValue3}
+          status={{type: 'success', message: 'Disk usage is healthy'}}
+        />
+      </XDSVStack>
+    </XDSCenter>
   );
 }

--- a/packages/core/src/Slider/Slider.doc.mjs
+++ b/packages/core/src/Slider/Slider.doc.mjs
@@ -131,11 +131,11 @@ export const docs = {
   },
   usage: {
     description:
-      'A slider component for selecting a numeric value or range within defined bounds. Use Slider when users need to explore and choose from a continuous range, such as volume, price, or percentage values.',
+      'A draggable control for selecting a numeric value or range within defined bounds. Supports single value and range selection, tick marks, custom value formatting, and vertical orientation. Use it when users need to explore a continuous range, such as volume, price, or percentage.',
     bestPractices: [
       {guidance: true, description: 'Always provide a label, even if visually hidden, so the slider is accessible to screen readers.'},
-      {guidance: true, description: 'Use formatValue to display meaningful units such as "$50" or "75%" instead of raw numbers.'},
-      {guidance: false, description: 'Use for precise numeric entry — pair with a text input or use TextInput alone instead.'},
+      {guidance: true, description: 'Format values with meaningful units like "$50" or "75%" instead of raw numbers.'},
+      {guidance: false, description: 'Use for precise numeric entry — pair with a text input or use NumberInput instead.'},
       {guidance: false, description: 'Set a step size so large that only a few positions are possible — use SegmentedControl or radio buttons instead.'},
     ],
   },
@@ -272,11 +272,11 @@ export const docsZh = {
   },
   usage: {
     description:
-      'A slider component for selecting a numeric value or range within defined bounds. Use Slider when users need to explore and choose from a continuous range, such as volume, price, or percentage values.',
+      'A draggable control for selecting a numeric value or range within defined bounds. Supports single value and range selection, tick marks, custom value formatting, and vertical orientation. Use it when users need to explore a continuous range, such as volume, price, or percentage.',
     bestPractices: [
       {guidance: true, description: 'Always provide a label, even if visually hidden, so the slider is accessible to screen readers.'},
-      {guidance: true, description: 'Use formatValue to display meaningful units such as "$50" or "75%" instead of raw numbers.'},
-      {guidance: false, description: 'Use for precise numeric entry — pair with a text input or use TextInput alone instead.'},
+      {guidance: true, description: 'Format values with meaningful units like "$50" or "75%" instead of raw numbers.'},
+      {guidance: false, description: 'Use for precise numeric entry — pair with a text input or use NumberInput instead.'},
       {guidance: false, description: 'Set a step size so large that only a few positions are possible — use SegmentedControl or radio buttons instead.'},
     ],
   },
@@ -286,11 +286,11 @@ export const docsZh = {
 export const docsDense = {
   usage: {
     description:
-      'A slider component for selecting a numeric value or range within defined bounds. Use Slider when users need to explore and choose from a continuous range, such as volume, price, or percentage values.',
+      'A draggable control for selecting a numeric value or range within defined bounds. Supports single value and range selection, tick marks, custom value formatting, and vertical orientation. Use it when users need to explore a continuous range, such as volume, price, or percentage.',
     bestPractices: [
       {guidance: true, description: 'Always provide a label, even if visually hidden, so the slider is accessible to screen readers.'},
-      {guidance: true, description: 'Use formatValue to display meaningful units such as "$50" or "75%" instead of raw numbers.'},
-      {guidance: false, description: 'Use for precise numeric entry — pair with a text input or use TextInput alone instead.'},
+      {guidance: true, description: 'Format values with meaningful units like "$50" or "75%" instead of raw numbers.'},
+      {guidance: false, description: 'Use for precise numeric entry — pair with a text input or use NumberInput instead.'},
       {guidance: false, description: 'Set a step size so large that only a few positions are possible — use SegmentedControl or radio buttons instead.'},
     ],
   },


### PR DESCRIPTION
## Summary
- Rewrite usage description to highlight range selection, tick marks, and custom formatting
- Simplify best practices: drop prop name references, fix NumberInput reference
- Replace raw HTML `<div>` wrapper with `XDSVStack` and `XDSCenter` in WithStatus block
- Tighten block descriptions
- Update `componentsUsed` in doc metadata

## Test plan
- [ ] Verify `npx xds component Slider` output reflects updated usage and best practices
- [ ] Verify all 4 Slider blocks render correctly in the sandbox