### PR TITLE
fix (Sandbox): Sandbox Crashing on Node.js 24

### DIFF
--- a/apps/sandbox/next-env.d.ts
+++ b/apps/sandbox/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/sandbox/next-env.d.ts
+++ b/apps/sandbox/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/build/src/next.js
+++ b/packages/build/src/next.js
@@ -13,9 +13,47 @@
  */
 
 /**
+ * Build-in replacement for webpack's default `output.hashFunction`.
+ *
+ * Wraps Node's `crypto.createHash('sha256')` but tolerates `undefined` inputs
+ * to `update()`. This works around a webpack 5 bug that surfaces on Node.js 24:
+ * `FileSystemInfo._resolveContextTimestamp` occasionally passes an unresolved
+ * context's `timestampHash` (which can be `undefined`) straight into
+ * `hash.update()`, which crashes the dev server with either
+ *   `TypeError: Cannot read properties of undefined (reading 'length')`
+ *     (inside WasmHash, the default hash)
+ * or
+ *   `TypeError: The "data" argument must be of type string or an instance of
+ *   Buffer, TypedArray, or DataView. Received undefined`
+ *     (with a plain Node crypto hash).
+ *
+ * Treating `undefined` as an empty string is safe here because webpack is only
+ * producing opaque cache/snapshot hashes; missing values simply collapse to a
+ * stable empty hash contribution.
+ */
+function createSafeHash() {
+  const crypto = require('node:crypto');
+  const hash = crypto.createHash('sha256');
+  return {
+    update(data, inputEncoding) {
+      if (data == null) {
+        data = '';
+      }
+      return inputEncoding !== undefined
+        ? hash.update(data, inputEncoding)
+        : hash.update(data);
+    },
+    digest(encoding) {
+      return hash.digest(encoding);
+    },
+  };
+}
+
+/**
  * Wraps a Next.js config to enable XDS source builds.
  * - Adds transpilePackages for @xds/* packages
  * - Sets conditionNames to resolve source exports
+ * - Installs a Node 24-safe webpack `output.hashFunction`
  */
 function withXDS(nextConfig = {}) {
   const xdsPackages = [
@@ -45,6 +83,12 @@ function withXDS(nextConfig = {}) {
         'require',
         'default',
       ];
+
+      // Swap webpack's default WasmHash-based hasher for a Node-crypto hasher
+      // that tolerates `undefined` inputs. See `createSafeHash` above.
+      if (config.output) {
+        config.output.hashFunction = createSafeHash;
+      }
 
       // Call user's webpack config if provided
       if (existingWebpack) {


### PR DESCRIPTION
Sandbox was crashing on localhost. This fix description was generated in Cursor:

# Fix dev server crash on Node.js 24

`TypeError: Cannot read properties of undefined (reading 'length')`

## Problem

Running `yarn dev:sandbox` on Node.js 24 crashes the Next.js dev server as soon
as it tries to compile the first route (e.g. `/_not-found`,
`/templates/library/`). The terminal shows:

```
⨯ uncaughtException: [TypeError: Cannot read properties of undefined (reading 'length')]
```

and the browser hangs with a **"Failed to fetch"** overlay.

## Root cause

The crash originates in the webpack 5 bundled with Next.js 15.5.15, inside
`FileSystemInfo._resolveContextTimestamp`:

```
TypeError: Cannot read properties of undefined (reading 'length')
    at WasmHash._updateWithBuffer   (next/dist/compiled/webpack/bundle5.js)
    at WasmHash.update
    at BatchedHash.update
    at _resolveContextTimestamp     (FileSystemInfo)
```

When webpack resolves a symlinked context — we have a yarn-workspace self-link
(`node_modules/@xds/sandbox → apps/sandbox`) — the resolved entry's
`timestampHash` can come back as `undefined`, and that `undefined` is fed
straight into `hash.update(...)`. On Node 24, webpack's default
WebAssembly-based xxhash64 hasher (`WasmHash`) crashes when it tries to read
`.length` on that `undefined`.

`next build` doesn't use the same snapshot/context-hash path, which is why
builds passed while `next dev` was broken.

## Fix

In `packages/build/src/next.js` (`withXDS`), install a safe
`output.hashFunction` — a tiny wrapper around `crypto.createHash('sha256')`
that coerces `null`/`undefined` inputs to `""` before delegating to Node's
hash. These hashes are only used for opaque cache/snapshot keys, so collapsing
missing values to a stable empty contribution is safe and deterministic.

```js
function createSafeHash() {
  const crypto = require('node:crypto');
  const hash = crypto.createHash('sha256');
  return {
    update(data, inputEncoding) {
      if (data == null) data = '';
      return inputEncoding !== undefined
        ? hash.update(data, inputEncoding)
        : hash.update(data);
    },
    digest(encoding) {
      return hash.digest(encoding);
    },
  };
}

// inside withXDS's webpack(config) { ... }
if (config.output) {
  config.output.hashFunction = createSafeHash;
}
```

This benefits every XDS-built Next.js app (sandbox, examples, etc.) with a
single change.

## Verification

With the fix, cold `yarn dev:sandbox` against `/templates/library/`:

- `✓ Compiled /templates/library in 2.7s (5753 modules)`
- `GET /templates/library/ 200 in 3209ms` (cold) / `200 in 149ms` (warm)
- Library page serves ~172 KB of HTML
- 0 `uncaughtException` entries

## Scope

One-file change: `packages/build/src/next.js`. No config, lockfile, or
dependency changes required.