### PR TITLE
fix(sandbox): fix component card name and description running together

### DIFF
--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/DocsView.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/DocsView.tsx
@@ -233,10 +233,16 @@ export function DocsView({
                         xstyle={localStyles.previewCard}
                       />
                       <div style={{paddingTop: 12}}>
-                        <XDSText type="body" style={{fontWeight: 700}}>
+                        <XDSText
+                          type="body"
+                          style={{
+                            fontWeight: 700,
+                            display: 'block',
+                            marginBottom: 4,
+                          }}>
                           {item.name}
                         </XDSText>
-                        <XDSText type="body" color="secondary">
+                        <XDSText type="supporting" color="secondary">
                           {item.desc}
                         </XDSText>
                       </div>


### PR DESCRIPTION
## Summary

- Fix component name and description text rendering on the same line without separation in the Library/Docs view
- Component name now displays as a block element with a 4px bottom margin
- Description uses `supporting` text type (smaller, secondary) for clear visual hierarchy

## Test plan

- [ ] Open Library view and verify component cards show name on its own line above the description


Made with [Cursor](https://cursor.com)