### PR TITLE
fix(hardening): extend XDSBaseProps in Text, TextArea, TimeInput

### DIFF
--- a/packages/core/src/Text/XDSHeading.tsx
+++ b/packages/core/src/Text/XDSHeading.tsx
@@ -16,7 +16,6 @@
 
 import {lazy, Suspense, useCallback, useRef, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import type {StyleXStyles} from '@stylexjs/stylex';
 import type {
   XDSTextColor,
   XDSTextDisplay,
@@ -36,6 +35,7 @@ import {
 import {useTruncation} from './useTruncation';
 import type {LayerPlacement} from '../Layer';
 import {xdsClassName, mergeProps} from '../utils';
+import type {XDSBaseProps} from '../XDSBaseProps';
 
 const LazyXDSTooltip = lazy(() =>
   import('../Tooltip/XDSTooltip').then(mod => ({default: mod.XDSTooltip})),
@@ -46,7 +46,7 @@ const LazyXDSTooltip = lazy(() =>
  */
 export type XDSHeadingLevel = 1 | 2 | 3 | 4 | 5 | 6;
 
-export interface XDSHeadingProps {
+export interface XDSHeadingProps extends Omit<XDSBaseProps<HTMLHeadingElement>, 'children'> {
   /** Ref forwarded to the root element */
   ref?: React.Ref<HTMLHeadingElement>;
   /**
@@ -123,34 +123,9 @@ export interface XDSHeadingProps {
   hasStrikethrough?: boolean;
 
   /**
-   * StyleX styles created via `stylex.create()`. Merged with the component's
-   * base styles inside a single `stylex.props()` call for optimal deduplication.
-   *
-   * @example
-   * ```
-   * const overrides = stylex.create({ root: { marginBottom: 8 } });
-   * <Component xstyle={overrides.root} />
-   * ```
-   */
-  xstyle?: StyleXStyles;
-  /**
-   * CSS class name(s) appended to the root element.
-   * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
-   */
-  className?: string;
-  /**
-   * Inline styles to apply to the root element. Spread after StyleX
-   * inline styles, so these values take priority.
-   */
-  style?: React.CSSProperties;
-
-  /**
    * Heading content
    */
   children: ReactNode;
-
-  'data-testid'?: string;
-  id?: string;
 }
 
 const levelToTag = {

--- a/packages/core/src/Text/XDSText.tsx
+++ b/packages/core/src/Text/XDSText.tsx
@@ -15,7 +15,6 @@
 
 import {lazy, Suspense, useCallback, useRef, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import type {StyleXStyles} from '@stylexjs/stylex';
 import type {
   XDSTextType,
   XDSTextSize,
@@ -41,6 +40,7 @@ import {
 import {useTruncation} from './useTruncation';
 import type {LayerPlacement} from '../Layer';
 import {xdsClassName, mergeProps} from '../utils';
+import type {XDSBaseProps} from '../XDSBaseProps';
 
 const LazyXDSTooltip = lazy(() =>
   import('../Tooltip/XDSTooltip').then(mod => ({default: mod.XDSTooltip})),
@@ -48,7 +48,7 @@ const LazyXDSTooltip = lazy(() =>
 
 export type {XDSTextType, XDSTextSize};
 
-export interface XDSTextProps {
+export interface XDSTextProps extends Omit<XDSBaseProps, 'children'> {
   /** Ref forwarded to the root element */
   ref?: React.Ref<HTMLElement>;
   /**
@@ -132,28 +132,6 @@ export interface XDSTextProps {
   hasTabularNumbers?: boolean;
 
   /**
-   * StyleX styles created via `stylex.create()`. Merged with the component's
-   * base styles inside a single `stylex.props()` call for optimal deduplication.
-   *
-   * @example
-   * ```
-   * const overrides = stylex.create({ root: { marginBottom: 8 } });
-   * <Component xstyle={overrides.root} />
-   * ```
-   */
-  xstyle?: StyleXStyles;
-  /**
-   * CSS class name(s) appended to the root element.
-   * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
-   */
-  className?: string;
-  /**
-   * Inline styles to apply to the root element. Spread after StyleX
-   * inline styles, so these values take priority.
-   */
-  style?: React.CSSProperties;
-
-  /**
    * Text content
    */
   children: ReactNode;
@@ -164,9 +142,6 @@ export interface XDSTextProps {
    * @default 'span'
    */
   as?: 'span' | 'p' | 'div' | 'label' | 'h1' | 'h2' | 'h3';
-
-  'data-testid'?: string;
-  id?: string;
 }
 
 // Default color by text type

--- a/packages/core/src/TextArea/XDSTextArea.tsx
+++ b/packages/core/src/TextArea/XDSTextArea.tsx
@@ -39,7 +39,7 @@ import {
 import {XDSIcon, type XDSIconType} from '../Icon';
 import {XDSSpinner} from '../Spinner';
 import {xdsClassName, mergeProps} from '../utils';
-import type {StyleXStyles} from '@stylexjs/stylex';
+import type {XDSBaseProps} from '../XDSBaseProps';
 
 const COUNTER_WARNING_THRESHOLD = 0.8;
 
@@ -122,7 +122,10 @@ export interface XDSTextAreaStatus {
   message?: string;
 }
 
-export interface XDSTextAreaProps {
+export interface XDSTextAreaProps extends Omit<
+  XDSBaseProps,
+  'onChange' | 'defaultValue'
+> {
   /** Ref forwarded to the root element */
   ref?: React.Ref<HTMLTextAreaElement>;
   /**
@@ -226,27 +229,6 @@ export interface XDSTextAreaProps {
    * Callback fired when the textarea loses focus.
    */
   onBlur?: (e: FocusEvent<HTMLTextAreaElement>) => void;
-  /**
-   * StyleX styles created via `stylex.create()`. Merged with the component's
-   * base styles inside a single `stylex.props()` call for optimal deduplication.
-   *
-   * @example
-   * ```
-   * const overrides = stylex.create({ root: { marginBottom: 8 } });
-   * <Component xstyle={overrides.root} />
-   * ```
-   */
-  xstyle?: StyleXStyles;
-  /**
-   * CSS class name(s) appended to the root element.
-   * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
-   */
-  className?: string;
-  /**
-   * Inline styles to apply to the root element. Spread after StyleX
-   * inline styles, so these values take priority.
-   */
-  style?: React.CSSProperties;
 }
 
 /**

--- a/packages/core/src/TimeInput/XDSTimeInput.test.tsx
+++ b/packages/core/src/TimeInput/XDSTimeInput.test.tsx
@@ -101,14 +101,14 @@ describe('XDSTimeInput', () => {
       />,
     );
     expect(
-      screen.getByRole('button', {name: 'Clear time'}),
+      screen.getByRole('button', {name: 'Clear Time'}),
     ).toBeInTheDocument();
   });
 
   it('does not show clear button when value is empty', () => {
     render(<XDSTimeInput label="Time" onChange={() => {}} hasClear />);
     expect(
-      screen.queryByRole('button', {name: 'Clear time'}),
+      screen.queryByRole('button', {name: 'Clear Time'}),
     ).not.toBeInTheDocument();
   });
 
@@ -124,7 +124,7 @@ describe('XDSTimeInput', () => {
       />,
     );
 
-    await user.click(screen.getByRole('button', {name: 'Clear time'}));
+    await user.click(screen.getByRole('button', {name: 'Clear Time'}));
     expect(onChange).toHaveBeenCalledWith(undefined);
   });
 

--- a/packages/core/src/TimeInput/XDSTimeInput.tsx
+++ b/packages/core/src/TimeInput/XDSTimeInput.tsx
@@ -25,7 +25,6 @@ import {
   type FocusEvent,
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
-import type {StyleXStyles} from '@stylexjs/stylex';
 import type {XDSIconName} from '../Icon';
 import {
   colorVars,
@@ -57,6 +56,8 @@ import {
   xdsClassName,
   mergeProps,
 } from '../utils';
+import type {XDSBaseProps} from '../XDSBaseProps';
+import {useXDSSize} from '../SizeContext/XDSSizeContext';
 
 const styles = stylex.create({
   icon: {
@@ -133,7 +134,10 @@ export type {
   XDSInputStatusType as XDSTimeInputStatusType,
 } from '../Field';
 
-export interface XDSTimeInputProps {
+export interface XDSTimeInputProps extends Omit<
+  XDSBaseProps,
+  'onChange' | 'defaultValue'
+> {
   /** Ref forwarded to the root element */
   ref?: React.Ref<HTMLInputElement>;
   /**
@@ -259,28 +263,6 @@ export interface XDSTimeInputProps {
    * Tooltip text to display in an info icon at the end of the label.
    */
   labelTooltip?: string;
-
-  /**
-   * StyleX styles created via `stylex.create()`. Merged with the component's
-   * base styles inside a single `stylex.props()` call for optimal deduplication.
-   *
-   * @example
-   * ```
-   * const overrides = stylex.create({ root: { marginBottom: 8 } });
-   * <Component xstyle={overrides.root} />
-   * ```
-   */
-  xstyle?: StyleXStyles;
-  /**
-   * CSS class name(s) appended to the root element.
-   * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
-   */
-  className?: string;
-  /**
-   * Inline styles to apply to the root element. Spread after StyleX
-   * inline styles, so these values take priority.
-   */
-  style?: React.CSSProperties;
 }
 
 /**
@@ -316,7 +298,7 @@ export function XDSTimeInput({
   hourFormat = '12h',
   increment = 1,
   placeholder = 'Select a time',
-  size = 'md',
+  size: sizeProp,
   status,
   labelTooltip,
   xstyle,
@@ -324,6 +306,8 @@ export function XDSTimeInput({
   style,
   ref,
 }: XDSTimeInputProps) {
+  const size = useXDSSize(sizeProp, 'md');
+
   const id = useId();
   const descriptionID = useId();
   const statusMessageID = useId();
@@ -579,7 +563,7 @@ export function XDSTimeInput({
           <button
             type="button"
             onClick={handleClear}
-            aria-label="Clear time"
+            aria-label={`Clear ${label}`}
             {...stylex.props(styles.clearButton)}>
             <XDSIcon icon="close" size="sm" color="secondary" />
           </button>


### PR DESCRIPTION
## Component Audit — April 22, 2026

Audited 5 components: **Text**, **TextArea**, **TextInput**, **TimeInput**, **Timestamp**

### Findings & Fixes

| Component | Finding | Fix |
|-----------|---------|-----|
| **XDSText** | Props don't extend XDSBaseProps | Now extends `Omit<XDSBaseProps, 'children'>` |
| **XDSHeading** | Props don't extend XDSBaseProps | Now extends `Omit<XDSBaseProps<HTMLHeadingElement>, 'children'>` |
| **XDSTextArea** | Props don't extend XDSBaseProps | Now extends `Omit<XDSBaseProps, 'onChange' \| 'defaultValue'>` |
| **XDSTimeInput** | Props don't extend XDSBaseProps | Now extends `Omit<XDSBaseProps, 'onChange' \| 'defaultValue'>` |
| **XDSTimeInput** | No SizeContext inheritance | Uses `useXDSSize(sizeProp, 'md')` (consistent with TextInput) |
| **XDSTimeInput** | Clear button a11y: generic aria-label | Changed from "Clear time" to `Clear ${label}` (matches TextInput) |
| **XDSTextInput** | — | Clean ✅ |
| **XDSTimestamp** | — | Clean ✅ |

### What Changed

- **XDSBaseProps inheritance**: Text, Heading, TextArea, and TimeInput now extend XDSBaseProps instead of manually declaring xstyle/className/style. This gives them automatic support for data-* attributes and standardizes the escape hatch surface.
- **SizeContext**: TimeInput now participates in SizeContext (via `useXDSSize`), matching TextInput behavior.
- **A11y**: TimeInput clear button aria-label now includes the field label for screen reader context.

### Removed (redundant with XDSBaseProps)

- Manual `xstyle?: StyleXStyles` declarations (4 files)
- Manual `className?: string` declarations (4 files)  
- Manual `style?: React.CSSProperties` declarations (4 files)
- Manual `data-testid?: string` and `id?: string` declarations (2 files — now covered by XDSBaseProps's data-* support and inherited id)