### PR TITLE
Improve SegmentedControl docs page and block examples

### DIFF
--- a/packages/cli/templates/blocks/components/SegmentedControl/SegmentedControlFillLayout.doc.mjs
+++ b/packages/cli/templates/blocks/components/SegmentedControl/SegmentedControlFillLayout.doc.mjs
@@ -1,0 +1,10 @@
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  name: 'SegmentedControl \u2014 Fill Layout',
+  description:
+    'Segmented control that stretches segments equally to fill the available width, useful for fixed-width containers.',
+  isReady: true,
+  aspectRatio: 4 / 3,
+  componentsUsed: ['SegmentedControl'],
+};

--- a/packages/cli/templates/blocks/components/SegmentedControl/SegmentedControlFillLayout.tsx
+++ b/packages/cli/templates/blocks/components/SegmentedControl/SegmentedControlFillLayout.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import {useState} from 'react';
+import {
+  XDSSegmentedControl,
+  XDSSegmentedControlItem,
+} from '@xds/core/SegmentedControl';
+
+export default function SegmentedControlFillLayout() {
+  const [value, setValue] = useState('weekly');
+  return (
+    <div style={{width: 400}}>
+      <XDSSegmentedControl
+        value={value}
+        onChange={setValue}
+        label="Time range"
+        layout="fill">
+        <XDSSegmentedControlItem value="daily" label="Daily" />
+        <XDSSegmentedControlItem value="weekly" label="Weekly" />
+        <XDSSegmentedControlItem value="monthly" label="Monthly" />
+      </XDSSegmentedControl>
+    </div>
+  );
+}

--- a/packages/core/src/SegmentedControl/SegmentedControl.doc.mjs
+++ b/packages/core/src/SegmentedControl/SegmentedControl.doc.mjs
@@ -50,6 +50,12 @@ export const docs = {
           default: "'md'",
         },
         {
+          name: 'layout',
+          type: "'hug' | 'fill'",
+          description: 'Layout mode. hug (default) sizes segments to content; fill stretches them equally to fill the container.',
+          default: "'hug'",
+        },
+        {
           name: 'isDisabled',
           type: 'boolean',
           description: 'Whether the entire control is disabled.',
@@ -113,8 +119,8 @@ export const docs = {
     bestPractices: [
       {guidance: true, description: 'Use for switching between 2–5 mutually exclusive views or modes where all options should be visible.'},
       {guidance: true, description: 'Provide a descriptive label for the control to ensure the group is accessible to screen readers.'},
-      {guidance: false, description: 'Use for page-level navigation — use Tabs instead.'},
-      {guidance: false, description: 'Use for simple on/off states — use ToggleButton instead.'},
+      {guidance: false, description: 'Use for page-level navigation — use XDSTabList instead. TabList is a navigation component, while SegmentedControl is an input that always has exactly one selected option.'},
+      {guidance: false, description: 'Use for simple on/off states — use XDSToggleButton instead. ToggleButton can be toggled on or off independently, while SegmentedControl enforces a single selection from a group.'},
     ],
   },
 };
@@ -131,6 +137,7 @@ export const docsZh = {
         onChange: '选中分段时触发的回调。',
         label: '单选组的无障碍标签（用作 aria-label，不会渲染为可见内容）。',
         size: '控件的尺寸变体。',
+        layout: '布局模式。hug（默认）根据内容调整分段宽度；fill 将分段等宽拉伸以填满容器。',
         isDisabled: '是否禁用整个控件。',
         children: 'XDSSegmentedControlItem 子组件。',
         xstyle: '容器的额外 StyleX 样式。',
@@ -155,8 +162,8 @@ export const docsZh = {
     bestPractices: [
       {guidance: true, description: 'Use for switching between 2–5 mutually exclusive views or modes where all options should be visible.'},
       {guidance: true, description: 'Provide a descriptive label for the control to ensure the group is accessible to screen readers.'},
-      {guidance: false, description: 'Use for page-level navigation — use Tabs instead.'},
-      {guidance: false, description: 'Use for simple on/off states — use ToggleButton instead.'},
+      {guidance: false, description: 'Use for page-level navigation — use XDSTabList instead. TabList is a navigation component, while SegmentedControl is an input that always has exactly one selected option.'},
+      {guidance: false, description: 'Use for simple on/off states — use XDSToggleButton instead. ToggleButton can be toggled on or off independently, while SegmentedControl enforces a single selection from a group.'},
     ],
   },
 };
@@ -169,8 +176,8 @@ export const docsDense = {
     bestPractices: [
       {guidance: true, description: 'Use for switching between 2–5 mutually exclusive views or modes where all options should be visible.'},
       {guidance: true, description: 'Provide a descriptive label for the control to ensure the group is accessible to screen readers.'},
-      {guidance: false, description: 'Use for page-level navigation — use Tabs instead.'},
-      {guidance: false, description: 'Use for simple on/off states — use ToggleButton instead.'},
+      {guidance: false, description: 'Use for page-level navigation — use XDSTabList instead. TabList is a navigation component, while SegmentedControl is an input that always has exactly one selected option.'},
+      {guidance: false, description: 'Use for simple on/off states — use XDSToggleButton instead. ToggleButton can be toggled on or off independently, while SegmentedControl enforces a single selection from a group.'},
     ],
   },
   propDescriptions: {
@@ -178,6 +185,7 @@ export const docsDense = {
     onChange: 'callback on segment selection',
     label: 'aria-label for radio group (never rendered)',
     size: 'size variant',
+    layout: 'hug (default) sizes to content; fill stretches equally',
     isDisabled: 'disables entire control',
     children: 'XDSSegmentedControlItem children',
     xstyle: 'additional StyleX styles for container',
@@ -185,12 +193,13 @@ export const docsDense = {
   components: [
     {
       name: 'XDSSegmentedControl',
-      description: 'container; provides context (value/onChange/size/isDisabled) to children',
+      description: 'container; provides context (value/onChange/size/layout/isDisabled) to children',
       propDescriptions: {
         value: 'selected value (controlled)',
         onChange: 'selection callback',
         label: 'aria-label for radio group (not rendered)',
         size: 'size variant',
+        layout: 'hug (default) sizes to content; fill stretches equally',
         isDisabled: 'disables entire control',
         children: 'XDSSegmentedControlItem children',
         xstyle: 'extra StyleX styles',

--- a/packages/core/src/SegmentedControl/XDSSegmentedControl.tsx
+++ b/packages/core/src/SegmentedControl/XDSSegmentedControl.tsx
@@ -16,7 +16,7 @@ import React, {useMemo, useRef, useCallback, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars, spacingVars, radiusVars} from '../theme/tokens.stylex';
 import {XDSSegmentedControlContext} from './XDSSegmentedControlContext';
-import type {XDSSegmentedControlSize} from './XDSSegmentedControlContext';
+import type {XDSSegmentedControlSize, XDSSegmentedControlLayout} from './XDSSegmentedControlContext';
 import {xdsClassName, mergeProps} from '../utils';
 import {useXDSSize} from '../SizeContext/XDSSizeContext';
 import type {XDSBaseProps} from '../XDSBaseProps';
@@ -43,6 +43,13 @@ export interface XDSSegmentedControlProps extends Omit<
    */
   size?: XDSSegmentedControlSize;
   /**
+   * Layout mode for segment sizing.
+   * - `'hug'` (default): each segment hugs its content width.
+   * - `'fill'`: segments stretch equally to fill the container width.
+   * @default 'hug'
+   */
+  layout?: XDSSegmentedControlLayout;
+  /**
    * Whether the entire control is disabled.
    * @default false
    */
@@ -65,6 +72,10 @@ const styles = stylex.create({
     '--_segmented-control-padding': spacingVars['--spacing-0-5'],
     padding: 'var(--_segmented-control-padding)',
     backgroundColor: colorVars['--color-neutral'],
+  },
+  fill: {
+    display: 'flex',
+    width: '100%',
   },
   disabled: {
     opacity: 0.5,
@@ -105,6 +116,7 @@ export function XDSSegmentedControl({
   onChange,
   label,
   size: sizeProp,
+  layout = 'hug',
   isDisabled = false,
   children,
   xstyle,
@@ -168,8 +180,8 @@ export function XDSSegmentedControl({
   );
 
   const contextValue = useMemo(
-    () => ({value, onChange, size, isDisabled}),
-    [value, onChange, size, isDisabled],
+    () => ({value, onChange, size, layout, isDisabled}),
+    [value, onChange, size, layout, isDisabled],
   );
 
   return (
@@ -185,6 +197,7 @@ export function XDSSegmentedControl({
           stylex.props(
             styles.container,
             sizeStyles[size],
+            layout === 'fill' && styles.fill,
             isDisabled && styles.disabled,
             xstyle,
           ),

--- a/packages/core/src/SegmentedControl/XDSSegmentedControlContext.ts
+++ b/packages/core/src/SegmentedControl/XDSSegmentedControlContext.ts
@@ -13,11 +13,13 @@
 import {createContext, useContext} from 'react';
 
 export type XDSSegmentedControlSize = 'sm' | 'md' | 'lg';
+export type XDSSegmentedControlLayout = 'hug' | 'fill';
 
 export interface XDSSegmentedControlContextValue {
   value: string;
   onChange: (value: string) => void;
   size: XDSSegmentedControlSize;
+  layout: XDSSegmentedControlLayout;
   isDisabled: boolean;
 }
 

--- a/packages/core/src/SegmentedControl/XDSSegmentedControlItem.tsx
+++ b/packages/core/src/SegmentedControl/XDSSegmentedControlItem.tsx
@@ -106,6 +106,10 @@ const styles = stylex.create({
     cursor: 'default',
     color: colorVars['--color-text-disabled'],
   },
+  fill: {
+    flex: 1,
+    justifyContent: 'center',
+  },
   icon: {
     display: 'inline-flex',
     alignItems: 'center',
@@ -163,6 +167,7 @@ export function XDSSegmentedControlItem({
   const isSelected = ctx.value === value;
   const isItemDisabled = isDisabled || ctx.isDisabled;
   const size: XDSSegmentedControlSize = ctx.size;
+  const isFill = ctx.layout === 'fill';
 
   const handleClick = useCallback(() => {
     if (!isItemDisabled && !isSelected) {
@@ -193,6 +198,7 @@ export function XDSSegmentedControlItem({
         stylex.props(
           styles.base,
           sizeStyles[size],
+          isFill && styles.fill,
           isSelected && styles.selected,
           !isSelected && !isItemDisabled && styles.hover,
           isItemDisabled && styles.disabled,

--- a/packages/core/src/SegmentedControl/index.ts
+++ b/packages/core/src/SegmentedControl/index.ts
@@ -15,4 +15,4 @@ export type {XDSSegmentedControlProps} from './XDSSegmentedControl';
 export {XDSSegmentedControlItem} from './XDSSegmentedControlItem';
 export type {XDSSegmentedControlItemProps} from './XDSSegmentedControlItem';
 
-export type {XDSSegmentedControlSize} from './XDSSegmentedControlContext';
+export type {XDSSegmentedControlSize, XDSSegmentedControlLayout} from './XDSSegmentedControlContext';


### PR DESCRIPTION
## Summary

Adds `layout` prop to `XDSSegmentedControl` (matching TabList's fill pattern) and improves best practice disambiguation across TabList/SegmentedControl/ToggleButton.

### Changes

**Component: XDSSegmentedControl**
- New `layout?: 'hug' | 'fill'` prop — `hug` (default) sizes segments to content, `fill` stretches them equally to fill the container width
- Layout is passed through context so `XDSSegmentedControlItem` applies `flex: 1` in fill mode
- Container switches from `inline-flex` to `flex` + `width: 100%` in fill mode
- Mirrors the same `layout` API as `XDSTabList` for consistency

**Block templates:**
- **SegmentedControl — Fill Layout**: Time range switcher (Daily/Weekly/Monthly) stretched to fill a fixed-width container

**Docs:**
- Added `layout` prop to component docs (`docs`, `docsZh`, `docsDense`)
- Improved disambiguation best practices — don'ts now reference `XDSTabList` and `XDSToggleButton` by name with clear explanations of when to use each:
  - ❌ Use for page-level navigation — use XDSTabList instead. TabList is a navigation component, while SegmentedControl is an input that always has exactly one selected option.
  - ❌ Use for simple on/off states — use XDSToggleButton instead. ToggleButton can be toggled on or off independently, while SegmentedControl enforces a single selection from a group.

**Exports:**
- `XDSSegmentedControlLayout` type exported from `@xds/core/SegmentedControl`

### Files changed
- `XDSSegmentedControl.tsx` — layout prop, fill styles, context wiring
- `XDSSegmentedControlItem.tsx` — reads layout from context, applies flex: 1
- `XDSSegmentedControlContext.ts` — layout field added to context type
- `index.ts` — exports `XDSSegmentedControlLayout` type
- `SegmentedControl.doc.mjs` — layout prop docs + disambiguation best practices
- `SegmentedControlFillLayout.tsx` + `.doc.mjs` — new block template

### Test plan
`vitest run packages/core/src/SegmentedControl/XDSSegmentedControl.test.tsx` — 19 tests pass