### PR TITLE
fix(Dialog,MobileNav): replace :where([open]) with prop-driven open styles

### DIFF
--- a/packages/core/src/Dialog/XDSDialog.tsx
+++ b/packages/core/src/Dialog/XDSDialog.tsx
@@ -123,21 +123,11 @@ const styles = stylex.create({
     '--_dialog-radius': radiusVars['--radius-container'],
     borderRadius: 'var(--_dialog-radius)',
     boxShadow: shadowVars['--shadow-high'],
-    display: {
-      default: 'none',
-      ':where([open])': 'flex',
-    },
+    display: 'none',
     flexDirection: 'column',
     height: 'fit-content',
     overscrollBehavior: 'contain',
-    opacity: {
-      default: 0,
-      ':where([open])': 1,
-    },
-    animationName: {
-      default: 'none',
-      ':where([open])': enterDirectional,
-    },
+    opacity: 0,
     animationDuration: durationVars['--duration-medium-max'],
     animationTimingFunction: easeVars['--ease-standard'],
     animationFillMode: 'backwards' as const,
@@ -149,6 +139,14 @@ const styles = stylex.create({
       default: '0',
       ':focus-visible': '2px',
     },
+  },
+  // Applied via isOpen prop — avoids :where([open]) attribute selectors
+  // which have zero specificity and can lose to default styles depending
+  // on CSS source order in the build output.
+  open: {
+    display: 'flex',
+    opacity: 1,
+    animationName: enterDirectional,
   },
   // Backdrop using ::backdrop pseudo-element
   backdrop: {
@@ -453,6 +451,7 @@ export function XDSDialog({
         xdsClassName('dialog', {variant}),
         stylex.props(
           styles.dialog,
+          isOpen && styles.open,
           styles.backdrop,
           styles.isolateEdgeSignals,
           !isFullscreen && dynamicStyles.sizing(width, maxHeight),

--- a/packages/core/src/MobileNav/XDSMobileNav.tsx
+++ b/packages/core/src/MobileNav/XDSMobileNav.tsx
@@ -62,13 +62,12 @@ const styles = stylex.create({
     // Prevent touch gestures (pull-to-refresh, background scroll) passing through
     touchAction: 'none',
     outline: 'none',
-    // Native <dialog> uses display:none when closed — we preserve that
-    // by only setting display when [open] via :where() selector.
-    // This prevents the dialog from blocking pointer events when closed.
-    display: {
-      default: 'none',
-      ':where([open])': 'flex',
-    },
+    // Native <dialog> uses display:none when closed.
+    // Open state applied via isOpen prop to avoid :where([open]) specificity issues.
+    display: 'none',
+  },
+  open: {
+    display: 'flex',
   },
   // ::backdrop is provided by the browser's top layer
   backdrop: {
@@ -399,6 +398,7 @@ export function XDSMobileNav({
         xdsClassName('mobile-nav', {side: resolvedSide}),
         stylex.props(
           styles.dialog,
+          isOpen && styles.open,
           styles.backdrop,
           isOpen && styles.backdropOpen,
           xstyle,


### PR DESCRIPTION
## Problem

`XDSDialog` and `XDSMobileNav` use `:where([open])` selectors for their open state styles:

```tsx
display: { default: 'none', ':where([open])': 'flex' }
opacity: { default: 0, ':where([open])': 1 }
```

The `:where()` pseudo-class has **zero specificity**, so both the default and conditional rules end up with identical specificity (just the atomic class selector). CSS uses source order as the tiebreaker — and depending on how the build outputs the atomic classes, `display: none` can silently win over `display: flex` even when the dialog has the `[open]` attribute.

This was reported as a debugging nightmare in a internal apps where the dialog was in the DOM with `[open]` set, but completely invisible.

## Fix

Replace all `:where([open])` selectors with a `styles.open` block toggled via the `isOpen` prop:

```tsx
// Before — specificity depends on build output order
display: { default: 'none', ':where([open])': 'flex' }

// After — deterministic, later in stylex.props() always wins
const styles = stylex.create({
  dialog: { display: 'none', opacity: 0 },
  open: { display: 'flex', opacity: 1, animationName: enterDirectional },
});

// In render:
stylex.props(styles.dialog, isOpen && styles.open, ...)
```

Both components already have `isOpen` as a prop, so this is a clean swap with no API change.

## Changes

- **XDSDialog**: Remove `:where([open])` from `display`, `opacity`, and `animationName`. Add `styles.open` toggled by `isOpen`.
- **XDSMobileNav**: Remove `:where([open])` from `display`. Add `styles.open` toggled by `isOpen`.
- All 69 existing tests pass unchanged.

---
