### PR TITLE
fix(Card): preserve border width across variants to prevent jitter

### DIFF
--- a/packages/core/src/Card/XDSCard.tsx
+++ b/packages/core/src/Card/XDSCard.tsx
@@ -64,10 +64,13 @@ const styles = stylex.create({
     '--_card-radius': radiusVars['--radius-container'],
     borderRadius: 'var(--_card-radius)',
     overflow: 'clip',
-  },
-  withBorder: {
+    // Border width/style always present to prevent layout jitter when
+    // switching between default and colored variants.
     borderWidth: borderVars['--border-width'],
     borderStyle: 'solid',
+    borderColor: 'transparent',
+  },
+  withBorder: {
     borderColor: colorVars['--color-border-emphasized'],
   },
   // Fixed-height cards scroll content; overflow: auto also clips to border-radius


### PR DESCRIPTION
## Problem

Switching a card's `variant` between `default` and any colored variant (e.g. `blue`, `muted`) causes a 1px layout shift. The default variant applies `borderWidth` + `borderStyle` + `borderColor`, while all other variants have no border at all — different box models.

## Fix

Move `borderWidth` and `borderStyle` to the base `card` style with `borderColor: 'transparent'`. The `withBorder` style now only overrides `borderColor` to make it visible for the `default` variant.

The box model is now identical across all variants — colored cards have the same border width, just transparent.

```diff
  card: {
    borderRadius: 'var(--_card-radius)',
    overflow: 'clip',
+   borderWidth: borderVars['--border-width'],
+   borderStyle: 'solid',
+   borderColor: 'transparent',
  },
  withBorder: {
-   borderWidth: borderVars['--border-width'],
-   borderStyle: 'solid',
    borderColor: colorVars['--color-border-emphasized'],
  },
```

---
