### PR TITLE
feat(Card): add transparent variant, fix border jitter across variants

### DIFF
--- a/packages/core/src/Card/XDSCard.test.tsx
+++ b/packages/core/src/Card/XDSCard.test.tsx
@@ -13,4 +13,13 @@ describe('XDSCard', () => {
     const root = container.firstElementChild!;
     expect(root.className).toContain('xds-card');
   });
+
+  it('renders transparent variant with variant class', () => {
+    const {container} = render(
+      <XDSCard variant="transparent">Content</XDSCard>,
+    );
+    const root = container.firstElementChild!;
+    expect(root.className).toContain('xds-card');
+    expect(root.className).toContain('transparent');
+  });
 });

--- a/packages/core/src/Card/XDSCard.tsx
+++ b/packages/core/src/Card/XDSCard.tsx
@@ -34,15 +34,18 @@ import type {XDSBaseProps} from '../XDSBaseProps';
 
 /**
  * Background color variant for XDSCard.
- * - `default`: the standard card background (`--color-background-card`)
- * - `muted`: subtle muted background (`--color-background-muted`) for de-emphasised cards
+ * - `default`: standard card background with visible border
+ * - `transparent`: no background, no visible border — for grouping content without visual weight
+ * - `muted`: subtle muted background for de-emphasised cards
  * - Non-semantic palette: `blue | cyan | gray | green | orange | pink | purple | red | teal | yellow`
  *   Each uses the corresponding `--color-background-<name>` token (20% opacity tint).
  *
- * Non-default variants have no border — the background provides its own visual separation.
+ * All variants include a transparent border to prevent layout jitter
+ * when switching variants. Themes can override borderWidth/borderColor.
  */
 export type XDSCardVariant =
   | 'default'
+  | 'transparent'
   | 'muted'
   | 'blue'
   | 'cyan'
@@ -64,10 +67,11 @@ const styles = stylex.create({
     '--_card-radius': radiusVars['--radius-container'],
     borderRadius: 'var(--_card-radius)',
     overflow: 'clip',
-  },
-  withBorder: {
     borderWidth: borderVars['--border-width'],
     borderStyle: 'solid',
+    borderColor: 'transparent',
+  },
+  withBorder: {
     borderColor: colorVars['--color-border-emphasized'],
   },
   // Fixed-height cards scroll content; overflow: auto also clips to border-radius
@@ -80,6 +84,9 @@ const styles = stylex.create({
 const variantStyles = stylex.create({
   default: {
     backgroundColor: colorVars['--color-background-card'],
+  },
+  transparent: {
+    backgroundColor: 'transparent',
   },
   muted: {
     backgroundColor: colorVars['--color-background-muted'],
@@ -182,9 +189,10 @@ export interface XDSCardProps extends XDSBaseProps<HTMLDivElement> {
 
   /**
    * Background color variant.
-   * - `default`: standard card background with border
-   * - `muted`: subtle muted background for de-emphasised cards (no border)
-   * - Non-semantic: `blue`, `cyan`, `gray`, `green`, `orange`, `pink`, `purple`, `red`, `teal`, `yellow` (no border)
+   * - `default`: standard card background with visible border
+   * - `transparent`: no background, no visible border — for grouping without visual weight
+   * - `muted`: subtle muted background for de-emphasised cards
+   * - Non-semantic: `blue`, `cyan`, `gray`, `green`, `orange`, `pink`, `purple`, `red`, `teal`, `yellow`
    * @default 'default'
    */
   variant?: XDSCardVariant;


### PR DESCRIPTION
## Changes

### 1. New `transparent` variant

`variant="transparent"` — no background, no visible border. For grouping content that needs card padding/radius semantics without visual weight.

### 2. Border jitter fix

Border width/style always present on the base card style with `borderColor: transparent`. Only `default` overrides the color to make it visible. All variants share the same box model — no 1px shift when switching.

Keeps real CSS border properties so themes that override `borderWidth`/`borderColor` (e.g. brutalist with `3px solid`) continue to work.

---
