### PR TITLE
docs: break navigation components into individual groups

### DIFF
--- a/packages/core/src/MobileNav/MobileNav.doc.mjs
+++ b/packages/core/src/MobileNav/MobileNav.doc.mjs
@@ -2,7 +2,7 @@
 
 export const docs = {
   name: 'MobileNav',
-  group: 'Navigation',
+  group: 'MobileNav',
   keywords: ["mobilenav","drawer","sidebar","navigation","hamburger","menu","offcanvas","slideout","navdrawer"],
   props: [
     {

--- a/packages/core/src/NavIcon/NavIcon.doc.mjs
+++ b/packages/core/src/NavIcon/NavIcon.doc.mjs
@@ -2,7 +2,7 @@
 
 export const docs = {
   name: 'NavIcon',
-  group: 'Navigation',
+  group: 'NavIcon',
   keywords: ["navicon","iconbutton","toolbar icon","appbar icon","nav button"],
   props: [
     {

--- a/packages/core/src/NavMenu/NavMenu.doc.mjs
+++ b/packages/core/src/NavMenu/NavMenu.doc.mjs
@@ -2,7 +2,7 @@
 
 export const docs = {
   name: 'NavMenu',
-  group: 'Navigation',
+  group: 'NavMenu',
   keywords: ['nav', 'menu', 'navigation', 'menu-item'],
   usage: {
     description: 'Menu item used within navigation components like SideNav and TopNav.',

--- a/packages/core/src/SideNav/SideNav.doc.mjs
+++ b/packages/core/src/SideNav/SideNav.doc.mjs
@@ -2,7 +2,7 @@
 
 export const docs = {
   name: 'SideNav',
-  group: 'Navigation',
+  group: 'SideNav',
   keywords: ["sidenav","sidebar","navigation","drawer","menu","nav","aside","sidemenu","navmenu","sider","treeview"],
   theming: {
     targets: [

--- a/packages/core/src/TopNav/TopNav.doc.mjs
+++ b/packages/core/src/TopNav/TopNav.doc.mjs
@@ -2,7 +2,7 @@
 
 export const docs = {
   name: 'TopNav',
-  group: 'Navigation',
+  group: 'TopNav',
   keywords: ["topnav","navbar","appbar","header","toolbar","navigation","menubar","topbar"],
   theming: {
     targets: [


### PR DESCRIPTION
Split the single `Navigation` group into per-component groups: TopNav, SideNav, MobileNav, NavIcon, NavMenu.

Each navigation component now has its own group in the doc metadata, making them independent entries in the component catalog instead of all being lumped under one umbrella.