### PR TITLE
Improve MetadataList docs page and block examples

### DIFF
--- a/packages/cli/templates/blocks/components/MetadataList/MetadataListBasicMetadata.doc.mjs
+++ b/packages/cli/templates/blocks/components/MetadataList/MetadataListBasicMetadata.doc.mjs
@@ -2,7 +2,7 @@
 export const doc = {
   type: 'block',
   name: 'MetadataList — Basic',
-  description: 'Simple single-column key-value metadata list.',
+  description: 'Single-column key-value metadata list.',
   isReady: true,
   aspectRatio: 4 / 3,
   componentsUsed: ['MetadataList'],

--- a/packages/cli/templates/blocks/components/MetadataList/MetadataListCollapsibleMetadata.doc.mjs
+++ b/packages/cli/templates/blocks/components/MetadataList/MetadataListCollapsibleMetadata.doc.mjs
@@ -3,7 +3,7 @@ export const doc = {
   type: 'block',
   name: 'MetadataList — Collapsible',
   description:
-    'Metadata list that truncates after a set number of items with a show-more toggle.',
+    'Metadata list with a show-more toggle after a set number of items.',
   isReady: true,
   aspectRatio: 4 / 3,
   componentsUsed: ['MetadataList'],

--- a/packages/cli/templates/blocks/components/MetadataList/MetadataListHorizontalMetadata.doc.mjs
+++ b/packages/cli/templates/blocks/components/MetadataList/MetadataListHorizontalMetadata.doc.mjs
@@ -3,7 +3,7 @@ export const doc = {
   type: 'block',
   name: 'MetadataList — Horizontal',
   description:
-    'Horizontally-oriented metadata items for compact inline display.',
+    'Horizontal metadata items for compact inline display.',
   isReady: true,
   aspectRatio: 4 / 3,
   componentsUsed: ['MetadataList'],

--- a/packages/cli/templates/blocks/components/MetadataList/MetadataListMultiColumnMetadata.doc.mjs
+++ b/packages/cli/templates/blocks/components/MetadataList/MetadataListMultiColumnMetadata.doc.mjs
@@ -3,8 +3,8 @@ export const doc = {
   type: 'block',
   name: 'MetadataList — Multi-Column',
   description:
-    'Multi-column metadata grid with token tags for dense information display.',
+    'Multi-column metadata grid with token tags.',
   isReady: true,
   aspectRatio: 4 / 3,
-  componentsUsed: ['MetadataList', 'Token'],
+  componentsUsed: ['MetadataList', 'Token', 'HStack'],
 };

--- a/packages/cli/templates/blocks/components/MetadataList/MetadataListMultiColumnMetadata.tsx
+++ b/packages/cli/templates/blocks/components/MetadataList/MetadataListMultiColumnMetadata.tsx
@@ -2,6 +2,7 @@
 
 import {XDSMetadataList, XDSMetadataListItem} from '@xds/core/MetadataList';
 import {XDSToken} from '@xds/core/Token';
+import {XDSHStack} from '@xds/core/Layout';
 
 export default function MetadataListMultiColumnMetadata() {
   return (
@@ -11,10 +12,10 @@ export default function MetadataListMultiColumnMetadata() {
       <XDSMetadataListItem label="Owner">Joey</XDSMetadataListItem>
       <XDSMetadataListItem label="Created">Jan 15, 2026</XDSMetadataListItem>
       <XDSMetadataListItem label="Tags">
-        <span style={{display: 'flex', gap: 4}}>
+        <XDSHStack gap={1}>
           <XDSToken label="component" />
           <XDSToken label="xds" />
-        </span>
+        </XDSHStack>
       </XDSMetadataListItem>
       <XDSMetadataListItem label="Priority">Tier 1</XDSMetadataListItem>
     </XDSMetadataList>

--- a/packages/core/src/MetadataList/MetadataList.doc.mjs
+++ b/packages/core/src/MetadataList/MetadataList.doc.mjs
@@ -88,12 +88,12 @@ export const docs = {
   ],
   usage: {
     description:
-      'MetadataList displays key-value pairs of metadata using semantic definition list markup. Use it in detail panels, summary sections, or anywhere an object\'s attributes need a structured overview.',
+      'MetadataList displays key-value pairs for object attributes like quality, condition, and status, in a structured layout. Use it for detail panels, settings summaries, and record information.',
     bestPractices: [
-      { guidance: true, description: 'Choose label position based on content length — use \'start\' for short values and \'top\' for long or complex values.' },
-      { guidance: true, description: 'Use maxNumOfItems to collapse long lists and keep the page scannable.' },
-      { guidance: false, description: 'Use MetadataList for tabular data with multiple columns of values — use a table component instead.' },
-      { guidance: false, description: 'Mix unrelated metadata items within the same list — group related attributes together.' },
+      { guidance: true, description: 'Choose label position based on content — "start" for short values, "top" for long or complex values.' },
+      { guidance: true, description: 'Collapse long lists with `maxNumOfItems` to keep the page scannable.' },
+      { guidance: false, description: 'Use for extensive form input — use a form layout instead.' },
+      { guidance: false, description: "Use for data that doesn't have a clear key-value structure." },
     ],
     anatomy: [
       {name: 'Title', required: false, description: 'Optional title for the metadata list.'},
@@ -132,12 +132,12 @@ export const docsZh = {
   ],
   usage: {
     description:
-      'MetadataList displays key-value pairs of metadata using semantic definition list markup. Use it in detail panels, summary sections, or anywhere an object\'s attributes need a structured overview.',
+      'MetadataList displays key-value pairs for object attributes like quality, condition, and status, in a structured layout. Use it for detail panels, settings summaries, and record information.',
     bestPractices: [
-      { guidance: true, description: 'Choose label position based on content length — use \'start\' for short values and \'top\' for long or complex values.' },
-      { guidance: true, description: 'Use maxNumOfItems to collapse long lists and keep the page scannable.' },
-      { guidance: false, description: 'Use MetadataList for tabular data with multiple columns of values — use a table component instead.' },
-      { guidance: false, description: 'Mix unrelated metadata items within the same list — group related attributes together.' },
+      { guidance: true, description: 'Choose label position based on content — "start" for short values, "top" for long or complex values.' },
+      { guidance: true, description: 'Collapse long lists with `maxNumOfItems` to keep the page scannable.' },
+      { guidance: false, description: 'Use for extensive form input — use a form layout instead.' },
+      { guidance: false, description: "Use for data that doesn't have a clear key-value structure." },
     ],
     anatomy: [
       {name: 'Title', required: false, description: 'Optional title for the metadata list.'},
@@ -153,12 +153,12 @@ export const docsDense = {
   description: 'label/value metadata display; column layout, collapse, orientation variants',
   usage: {
     description:
-      'MetadataList displays key-value pairs of metadata using semantic definition list markup. Use it in detail panels, summary sections, or anywhere an object\'s attributes need a structured overview.',
+      'MetadataList displays key-value pairs for object attributes like quality, condition, and status, in a structured layout. Use it for detail panels, settings summaries, and record information.',
     bestPractices: [
-      { guidance: true, description: 'Choose label position based on content length — use \'start\' for short values and \'top\' for long or complex values.' },
-      { guidance: true, description: 'Use maxNumOfItems to collapse long lists and keep the page scannable.' },
-      { guidance: false, description: 'Use MetadataList for tabular data with multiple columns of values — use a table component instead.' },
-      { guidance: false, description: 'Mix unrelated metadata items within the same list — group related attributes together.' },
+      { guidance: true, description: 'Choose label position based on content — "start" for short values, "top" for long or complex values.' },
+      { guidance: true, description: 'Collapse long lists with `maxNumOfItems` to keep the page scannable.' },
+      { guidance: false, description: 'Use for extensive form input — use a form layout instead.' },
+      { guidance: false, description: "Use for data that doesn't have a clear key-value structure." },
     ],
     anatomy: [
       {name: 'Title', required: false, description: 'Optional title for the metadata list.'},


### PR DESCRIPTION
## Summary
- Rewrite usage description to highlight practical use cases (detail panels, settings summaries, record info)
- Replace best practices with actionable guidance: label position, collapse, form input don't
- Replace raw `<span>` with `XDSHStack` in Multi-Column block
- Tighten block descriptions
- Update `componentsUsed` in doc metadata

## Test plan
- [ ] Verify `npx xds component MetadataList` output reflects updated usage and best practices
- [ ] Verify all 4 MetadataList blocks render correctly in the sandbox