### PR TITLE
fix(sandbox): constrain TextArea examples to 400px and add error-without-message

### DIFF
--- a/packages/cli/templates/blocks/components/TextArea/TextAreaCharacterCount.tsx
+++ b/packages/cli/templates/blocks/components/TextArea/TextAreaCharacterCount.tsx
@@ -9,13 +9,15 @@ export default function TextAreaCharacterCount() {
   );
 
   return (
-    <XDSTextArea
-      label="Status update"
-      value={value}
-      onChange={setValue}
-      placeholder="What's on your mind?"
-      maxLength={280}
-      rows={3}
-    />
+    <div style={{width: 400}}>
+      <XDSTextArea
+        label="Status update"
+        value={value}
+        onChange={setValue}
+        placeholder="What's on your mind?"
+        maxLength={280}
+        rows={3}
+      />
+    </div>
   );
 }

--- a/packages/cli/templates/blocks/components/TextArea/TextAreaShowcase.tsx
+++ b/packages/cli/templates/blocks/components/TextArea/TextAreaShowcase.tsx
@@ -4,11 +4,13 @@ import {XDSTextArea} from '@xds/core/TextArea';
 
 export default function TextAreaShowcase() {
   return (
-    <XDSTextArea
-      label="Description"
-      value=""
-      onChange={() => {}}
-      placeholder="Enter a description..."
-    />
+    <div style={{width: 400}}>
+      <XDSTextArea
+        label="Description"
+        value=""
+        onChange={() => {}}
+        placeholder="Enter a description..."
+      />
+    </div>
   );
 }

--- a/packages/cli/templates/blocks/components/TextArea/TextAreaStates.tsx
+++ b/packages/cli/templates/blocks/components/TextArea/TextAreaStates.tsx
@@ -8,7 +8,7 @@ export default function TextAreaStates() {
   const [requiredValue, setRequiredValue] = useState('');
 
   return (
-    <XDSStack direction="vertical" gap={4}>
+    <XDSStack direction="vertical" gap={4} style={{width: 400}}>
       <XDSTextArea
         label="Required field"
         value={requiredValue}

--- a/packages/cli/templates/blocks/components/TextArea/TextAreaValidation.doc.mjs
+++ b/packages/cli/templates/blocks/components/TextArea/TextAreaValidation.doc.mjs
@@ -2,8 +2,8 @@
 export const doc = {
   type: 'block',
   name: 'TextArea — Validation',
-  description: 'All three status variants — error, warning, and success — with status messages. Use to show inline validation feedback as the user types.',
+  description: 'All three status variants — error, warning, and success — with status messages, plus error without a message. Use to show inline validation feedback as the user types.',
   isReady: true,
-  aspectRatio: 1,
+  aspectRatio: 3 / 4,
   componentsUsed: ['TextArea', 'Layout'],
 };

--- a/packages/cli/templates/blocks/components/TextArea/TextAreaValidation.tsx
+++ b/packages/cli/templates/blocks/components/TextArea/TextAreaValidation.tsx
@@ -10,9 +10,10 @@ export default function TextAreaValidation() {
   const [successValue, setSuccessValue] = useState(
     'Redesign the onboarding flow to reduce drop-off by 15% in Q3. Focus on simplifying the account creation step and adding a progress indicator.',
   );
+  const [errorNoMsgValue, setErrorNoMsgValue] = useState('Invalid content');
 
   return (
-    <XDSStack direction="vertical" gap={4}>
+    <XDSStack direction="vertical" gap={4} style={{width: 400}}>
       <XDSTextArea
         label="Error message"
         value={errorValue}
@@ -39,6 +40,12 @@ export default function TextAreaValidation() {
           type: 'success',
           message: 'Looks good — clear and actionable.',
         }}
+      />
+      <XDSTextArea
+        label="Error without message"
+        value={errorNoMsgValue}
+        onChange={setErrorNoMsgValue}
+        status={{type: 'error'}}
       />
     </XDSStack>
   );

--- a/packages/cli/templates/blocks/components/TextArea/TextAreaWithIcon.tsx
+++ b/packages/cli/templates/blocks/components/TextArea/TextAreaWithIcon.tsx
@@ -8,13 +8,15 @@ export default function TextAreaWithIcon() {
   const [value, setValue] = useState('');
 
   return (
-    <XDSTextArea
-      label="Meeting notes"
-      description="Capture key decisions and action items."
-      value={value}
-      onChange={setValue}
-      placeholder="What was discussed?"
-      startIcon={PencilSquareIcon}
-    />
+    <div style={{width: 400}}>
+      <XDSTextArea
+        label="Meeting notes"
+        description="Capture key decisions and action items."
+        value={value}
+        onChange={setValue}
+        placeholder="What was discussed?"
+        startIcon={PencilSquareIcon}
+      />
+    </div>
   );
 }


### PR DESCRIPTION
## What

- All TextArea sandbox templates now render at a fixed 400px width — they no longer grow or shrink with content.
- Added an "error without message" example to TextAreaValidation (matching the storybook StatusWithoutMessage story).
- Bumped TextAreaValidation aspect ratio from 1:1 to 3:4 so the additional item doesn't overflow.

## Files changed

| File | Change |
|------|--------|
| `TextAreaShowcase.tsx` | Wrapped in `<div style={{width: 400}}>` |
| `TextAreaCharacterCount.tsx` | Wrapped in `<div style={{width: 400}}>` |
| `TextAreaStates.tsx` | Added `style={{width: 400}}` to XDSStack |
| `TextAreaWithIcon.tsx` | Wrapped in `<div style={{width: 400}}>` |
| `TextAreaValidation.tsx` | Added `style={{width: 400}}` to XDSStack + error-without-message variant |
| `TextAreaValidation.doc.mjs` | aspectRatio: 1 → 3/4, updated description |