### PR TITLE
Improve AspectRatio docs page and block examples

### DIFF
--- a/packages/cli/templates/blocks/components/AspectRatio/AspectRatioImageGallery.doc.mjs
+++ b/packages/cli/templates/blocks/components/AspectRatio/AspectRatioImageGallery.doc.mjs
@@ -2,7 +2,7 @@
 export const doc = {
   type: 'block',
   name: 'AspectRatio — Image Gallery',
-  description: 'Grid of images with consistent 4:3 aspect ratios for a uniform gallery layout.',
+  description: 'Grid of images with consistent 4:3 aspect ratios.',
   isReady: true,
   aspectRatio: 4 / 3,
   componentsUsed: ['AspectRatio', 'Grid'],

--- a/packages/cli/templates/blocks/components/AspectRatio/AspectRatioSquareImage.doc.mjs
+++ b/packages/cli/templates/blocks/components/AspectRatio/AspectRatioSquareImage.doc.mjs
@@ -5,5 +5,5 @@ export const doc = {
   description: '1:1 square aspect ratio, ideal for avatars and Instagram-style images.',
   isReady: true,
   aspectRatio: 1,
-  componentsUsed: ['AspectRatio'],
+  componentsUsed: ['AspectRatio', 'Center'],
 };

--- a/packages/cli/templates/blocks/components/AspectRatio/AspectRatioSquareImage.tsx
+++ b/packages/cli/templates/blocks/components/AspectRatio/AspectRatioSquareImage.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import {XDSAspectRatio} from '@xds/core/AspectRatio';
+import {XDSCenter} from '@xds/core/Center';
 
 export default function AspectRatioSquareImage() {
   return (
-    <div style={{maxWidth: 300}}>
+    <XDSCenter width={300}>
       <XDSAspectRatio ratio={1}>
         <img
           src="https://picsum.photos/400/400"
@@ -13,10 +14,9 @@ export default function AspectRatioSquareImage() {
             width: '100%',
             height: '100%',
             objectFit: 'cover',
-            borderRadius: 8,
           }}
         />
       </XDSAspectRatio>
-    </div>
+    </XDSCenter>
   );
 }

--- a/packages/cli/templates/blocks/components/AspectRatio/AspectRatioWidescreen.doc.mjs
+++ b/packages/cli/templates/blocks/components/AspectRatio/AspectRatioWidescreen.doc.mjs
@@ -2,8 +2,8 @@
 export const doc = {
   type: 'block',
   name: 'AspectRatio — 16:9 Widescreen Image',
-  description: 'Standard 16:9 widescreen aspect ratio wrapping an image.',
+  description: '16:9 widescreen aspect ratio wrapping an image.',
   isReady: true,
   aspectRatio: 4 / 3,
-  componentsUsed: ['AspectRatio'],
+  componentsUsed: ['AspectRatio', 'Center'],
 };

--- a/packages/cli/templates/blocks/components/AspectRatio/AspectRatioWidescreen.tsx
+++ b/packages/cli/templates/blocks/components/AspectRatio/AspectRatioWidescreen.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import {XDSAspectRatio} from '@xds/core/AspectRatio';
+import {XDSCenter} from '@xds/core/Center';
 
 export default function AspectRatioWidescreen() {
   return (
-    <div style={{maxWidth: 600}}>
+    <XDSCenter width={600}>
       <XDSAspectRatio ratio={16 / 9}>
         <img
           src="https://picsum.photos/800/450"
@@ -13,10 +14,9 @@ export default function AspectRatioWidescreen() {
             width: '100%',
             height: '100%',
             objectFit: 'cover',
-            borderRadius: 8,
           }}
         />
       </XDSAspectRatio>
-    </div>
+    </XDSCenter>
   );
 }

--- a/packages/cli/templates/blocks/components/AspectRatio/AspectRatioWithSkeleton.doc.mjs
+++ b/packages/cli/templates/blocks/components/AspectRatio/AspectRatioWithSkeleton.doc.mjs
@@ -2,8 +2,8 @@
 export const doc = {
   type: 'block',
   name: 'AspectRatio — Loading Skeleton',
-  description: 'Aspect ratio container with a skeleton placeholder for loading states.',
+  description: 'Aspect ratio container with a skeleton loading placeholder.',
   isReady: true,
   aspectRatio: 4 / 3,
-  componentsUsed: ['AspectRatio', 'Skeleton'],
+  componentsUsed: ['AspectRatio', 'Skeleton', 'Center'],
 };

--- a/packages/cli/templates/blocks/components/AspectRatio/AspectRatioWithSkeleton.tsx
+++ b/packages/cli/templates/blocks/components/AspectRatio/AspectRatioWithSkeleton.tsx
@@ -2,13 +2,14 @@
 
 import {XDSAspectRatio} from '@xds/core/AspectRatio';
 import {XDSSkeleton} from '@xds/core/Skeleton';
+import {XDSCenter} from '@xds/core/Center';
 
 export default function AspectRatioWithSkeleton() {
   return (
-    <div style={{maxWidth: 600}}>
+    <XDSCenter width={600}>
       <XDSAspectRatio ratio={16 / 9}>
         <XDSSkeleton width="100%" height="100%" />
       </XDSAspectRatio>
-    </div>
+    </XDSCenter>
   );
 }

--- a/packages/core/src/AspectRatio/AspectRatio.doc.mjs
+++ b/packages/core/src/AspectRatio/AspectRatio.doc.mjs
@@ -5,11 +5,12 @@ export const docs = {
   keywords: ["aspect-ratio","ratio","proportion","responsive","embed","container","widescreen","thumbnail","letterbox","crop"],
   usage: {
     description:
-      'AspectRatio maintains a specific width-to-height ratio for its children. Use it for responsive media containers like embedded videos, images, or thumbnails that need consistent proportions.',
+      'Maintains a fixed width-to-height ratio for its children, regardless of screen size. Use it for media containers like videos, images, thumbnails, or any content that needs consistent proportions.',
     bestPractices: [
-      {guidance: true, description: 'Express the ratio as a width/height fraction such as 16/9 or 4/3 for readability.'},
-      {guidance: true, description: 'Use for media containers like videos and images where consistent proportions are critical across screen sizes.'},
-      {guidance: false, description: 'Use AspectRatio for general layout containers that don\'t require a fixed proportion — use standard layout components instead.'},
+      {guidance: true, description: 'Express the ratio as a fraction like `16/9` or `4/3` for readability.'},
+      {guidance: true, description: 'Use for media that needs consistent proportions across screen sizes.'},
+      {guidance: false, description: 'Use for general layout containers — use standard layout components instead.'},
+      {guidance: false, description: 'Nest AspectRatio containers — one level is sufficient.'},
     ],
   },
   props: [
@@ -44,11 +45,12 @@ export const docsZh = {
   name: 'AspectRatio',
   usage: {
     description:
-      'AspectRatio maintains a specific width-to-height ratio for its children. Use it for responsive media containers like embedded videos, images, or thumbnails that need consistent proportions.',
+      'Maintains a fixed width-to-height ratio for its children, regardless of screen size. Use it for media containers like videos, images, thumbnails, or any content that needs consistent proportions.',
     bestPractices: [
-      {guidance: true, description: 'Express the ratio as a width/height fraction such as 16/9 or 4/3 for readability.'},
-      {guidance: true, description: 'Use for media containers like videos and images where consistent proportions are critical across screen sizes.'},
-      {guidance: false, description: 'Use AspectRatio for general layout containers that don\'t require a fixed proportion — use standard layout components instead.'},
+      {guidance: true, description: 'Express the ratio as a fraction like `16/9` or `4/3` for readability.'},
+      {guidance: true, description: 'Use for media that needs consistent proportions across screen sizes.'},
+      {guidance: false, description: 'Use for general layout containers — use standard layout components instead.'},
+      {guidance: false, description: 'Nest AspectRatio containers — one level is sufficient.'},
     ],
   },
   props: [
@@ -73,11 +75,12 @@ export const docsDense = {
   description: 'maintains specific aspect ratio for children',
   usage: {
     description:
-      'AspectRatio maintains a specific width-to-height ratio for its children. Use it for responsive media containers like embedded videos, images, or thumbnails that need consistent proportions.',
+      'Maintains a fixed width-to-height ratio for its children, regardless of screen size. Use it for media containers like videos, images, thumbnails, or any content that needs consistent proportions.',
     bestPractices: [
-      {guidance: true, description: 'Express the ratio as a width/height fraction such as 16/9 or 4/3 for readability.'},
-      {guidance: true, description: 'Use for media containers like videos and images where consistent proportions are critical across screen sizes.'},
-      {guidance: false, description: 'Use AspectRatio for general layout containers that don\'t require a fixed proportion — use standard layout components instead.'},
+      {guidance: true, description: 'Express the ratio as a fraction like `16/9` or `4/3` for readability.'},
+      {guidance: true, description: 'Use for media that needs consistent proportions across screen sizes.'},
+      {guidance: false, description: 'Use for general layout containers — use standard layout components instead.'},
+      {guidance: false, description: 'Nest AspectRatio containers — one level is sufficient.'},
     ],
   },
   propDescriptions: {


### PR DESCRIPTION
## Summary
- Rewrite usage description for clarity
- Simplify best practices, add nesting don't
- Replace raw `<div style={{maxWidth}}>` wrappers with `XDSCenter` in 3 blocks
- Remove unnecessary `borderRadius` from `<img>` inline styles
- Tighten block descriptions
- Update `componentsUsed` in doc metadata

## Test plan
- [ ] Verify `npx xds component AspectRatio` output reflects updated usage and best practices
- [ ] Verify all 4 AspectRatio blocks render correctly in the sandbox