### PR TITLE
feat(sandbox): add TimeInput — Increment block example

### DIFF
--- a/packages/cli/templates/blocks/components/TimeInput/TimeInputIncrement.doc.mjs
+++ b/packages/cli/templates/blocks/components/TimeInput/TimeInputIncrement.doc.mjs
@@ -1,0 +1,9 @@
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  name: 'TimeInput — Increment',
+  description: 'Time input with a custom step increment. Arrow keys jump by the specified interval (e.g. 15 minutes) for quick slot-based scheduling.',
+  isReady: true,
+  aspectRatio: 16 / 9,
+  componentsUsed: ['TimeInput', 'Layout'],
+};

--- a/packages/cli/templates/blocks/components/TimeInput/TimeInputIncrement.tsx
+++ b/packages/cli/templates/blocks/components/TimeInput/TimeInputIncrement.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import {useState} from 'react';
+import {XDSTimeInput} from '@xds/core/TimeInput';
+import {XDSStack} from '@xds/core/Layout';
+
+export default function TimeInputIncrement() {
+  const [slot, setSlot] = useState('09:00');
+
+  return (
+    <XDSStack direction="vertical" gap={3}>
+      <XDSTimeInput
+        label="Appointment slot"
+        increment={15}
+        description="Use arrow keys to change by 15 minutes"
+        value={slot as never}
+        onChange={setSlot as never}
+        hasClear
+      />
+    </XDSStack>
+  );
+}


### PR DESCRIPTION
Adds a new **TimeInput — Increment** block to the sandbox templates, showing the `increment` prop with 15-minute steps.

## What it does
- Arrow keys jump by 15 minutes for quick slot-based scheduling
- Mirrors the pattern from the [Storybook WithIncrement story](https://studious-broccoli-o7e61n3.pages.github.io/storybook/index.html?path=/story/core-inputs-timeinput--with-increment)
- Follows the same structure as the existing [TimeInputConstrained](https://studious-broccoli-o7e61n3.pages.github.io/sandbox/templates/TimeInputConstrained/) block

## Files added
- `packages/cli/templates/blocks/components/TimeInput/TimeInputIncrement.tsx`
- `packages/cli/templates/blocks/components/TimeInput/TimeInputIncrement.doc.mjs`

Once deployed, available at: `/sandbox/templates/TimeInputIncrement/`