### PR TITLE
feat(templates): add Timestamp — Colors block example

### DIFF
--- a/packages/cli/templates/blocks/components/Timestamp/TimestampColors.doc.mjs
+++ b/packages/cli/templates/blocks/components/Timestamp/TimestampColors.doc.mjs
@@ -1,0 +1,10 @@
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  name: 'Timestamp \u2014 Colors',
+  description:
+    'Timestamp rendered in each available color variant: primary, secondary, disabled, and active.',
+  isReady: true,
+  aspectRatio: 4 / 3,
+  componentsUsed: ['Timestamp', 'Text'],
+};

--- a/packages/cli/templates/blocks/components/Timestamp/TimestampColors.doc.mjs
+++ b/packages/cli/templates/blocks/components/Timestamp/TimestampColors.doc.mjs
@@ -5,6 +5,6 @@ export const doc = {
   description:
     'Timestamp rendered in each available color variant: primary, secondary, disabled, and active.',
   isReady: true,
-  aspectRatio: 4 / 3,
+  aspectRatio: 16 / 9,
   componentsUsed: ['Timestamp', 'Stack', 'Text'],
 };

--- a/packages/cli/templates/blocks/components/Timestamp/TimestampColors.doc.mjs
+++ b/packages/cli/templates/blocks/components/Timestamp/TimestampColors.doc.mjs
@@ -6,5 +6,5 @@ export const doc = {
     'Timestamp rendered in each available color variant: primary, secondary, disabled, and active.',
   isReady: true,
   aspectRatio: 4 / 3,
-  componentsUsed: ['Timestamp', 'Text'],
+  componentsUsed: ['Timestamp', 'Stack', 'Text'],
 };

--- a/packages/cli/templates/blocks/components/Timestamp/TimestampColors.tsx
+++ b/packages/cli/templates/blocks/components/Timestamp/TimestampColors.tsx
@@ -11,25 +11,25 @@ export default function TimestampColors() {
     <XDSStack direction="vertical" gap={4}>
       <XDSStack direction="vertical" gap={1}>
         <XDSText type="supporting" color="secondary">
-          primary
+          Primary
         </XDSText>
         <XDSTimestamp value={DATE} format="date_time" color="primary" />
       </XDSStack>
       <XDSStack direction="vertical" gap={1}>
         <XDSText type="supporting" color="secondary">
-          secondary
+          Secondary
         </XDSText>
         <XDSTimestamp value={DATE} format="date_time" color="secondary" />
       </XDSStack>
       <XDSStack direction="vertical" gap={1}>
         <XDSText type="supporting" color="secondary">
-          disabled
+          Disabled
         </XDSText>
         <XDSTimestamp value={DATE} format="date_time" color="disabled" />
       </XDSStack>
       <XDSStack direction="vertical" gap={1}>
         <XDSText type="supporting" color="secondary">
-          active
+          Active
         </XDSText>
         <XDSTimestamp value={DATE} format="date_time" color="active" />
       </XDSStack>

--- a/packages/cli/templates/blocks/components/Timestamp/TimestampColors.tsx
+++ b/packages/cli/templates/blocks/components/Timestamp/TimestampColors.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import {XDSTimestamp} from '@xds/core/Timestamp';
+import {XDSText} from '@xds/core/Text';
+
+export default function TimestampColors() {
+  return (
+    <div style={{display: 'flex', flexDirection: 'column', gap: 8}}>
+      <div>
+        <XDSText type="label" color="secondary">
+          primary:{' '}
+        </XDSText>
+        <XDSTimestamp
+          value="2026-02-19T17:00:00Z"
+          format="date_time"
+          color="primary"
+        />
+      </div>
+      <div>
+        <XDSText type="label" color="secondary">
+          secondary:{' '}
+        </XDSText>
+        <XDSTimestamp
+          value="2026-02-19T17:00:00Z"
+          format="date_time"
+          color="secondary"
+        />
+      </div>
+      <div>
+        <XDSText type="label" color="secondary">
+          disabled:{' '}
+        </XDSText>
+        <XDSTimestamp
+          value="2026-02-19T17:00:00Z"
+          format="date_time"
+          color="disabled"
+        />
+      </div>
+      <div>
+        <XDSText type="label" color="secondary">
+          active:{' '}
+        </XDSText>
+        <XDSTimestamp
+          value="2026-02-19T17:00:00Z"
+          format="date_time"
+          color="active"
+        />
+      </div>
+    </div>
+  );
+}

--- a/packages/cli/templates/blocks/components/Timestamp/TimestampColors.tsx
+++ b/packages/cli/templates/blocks/components/Timestamp/TimestampColors.tsx
@@ -1,51 +1,38 @@
 'use client';
 
 import {XDSTimestamp} from '@xds/core/Timestamp';
+import {XDSStack} from '@xds/core/Layout';
 import {XDSText} from '@xds/core/Text';
+
+const DATE = '2026-02-19T17:00:00Z';
 
 export default function TimestampColors() {
   return (
-    <div style={{display: 'flex', flexDirection: 'column', gap: 8}}>
-      <div>
-        <XDSText type="label" color="secondary">
-          primary:{' '}
+    <XDSStack direction="vertical" gap={4}>
+      <XDSStack direction="vertical" gap={1}>
+        <XDSText type="supporting" color="secondary">
+          primary
         </XDSText>
-        <XDSTimestamp
-          value="2026-02-19T17:00:00Z"
-          format="date_time"
-          color="primary"
-        />
-      </div>
-      <div>
-        <XDSText type="label" color="secondary">
-          secondary:{' '}
+        <XDSTimestamp value={DATE} format="date_time" color="primary" />
+      </XDSStack>
+      <XDSStack direction="vertical" gap={1}>
+        <XDSText type="supporting" color="secondary">
+          secondary
         </XDSText>
-        <XDSTimestamp
-          value="2026-02-19T17:00:00Z"
-          format="date_time"
-          color="secondary"
-        />
-      </div>
-      <div>
-        <XDSText type="label" color="secondary">
-          disabled:{' '}
+        <XDSTimestamp value={DATE} format="date_time" color="secondary" />
+      </XDSStack>
+      <XDSStack direction="vertical" gap={1}>
+        <XDSText type="supporting" color="secondary">
+          disabled
         </XDSText>
-        <XDSTimestamp
-          value="2026-02-19T17:00:00Z"
-          format="date_time"
-          color="disabled"
-        />
-      </div>
-      <div>
-        <XDSText type="label" color="secondary">
-          active:{' '}
+        <XDSTimestamp value={DATE} format="date_time" color="disabled" />
+      </XDSStack>
+      <XDSStack direction="vertical" gap={1}>
+        <XDSText type="supporting" color="secondary">
+          active
         </XDSText>
-        <XDSTimestamp
-          value="2026-02-19T17:00:00Z"
-          format="date_time"
-          color="active"
-        />
-      </div>
-    </div>
+        <XDSTimestamp value={DATE} format="date_time" color="active" />
+      </XDSStack>
+    </XDSStack>
   );
 }


### PR DESCRIPTION
Adds a new sandbox template block showing `XDSTimestamp` rendered with each available `color` variant: **primary**, **secondary**, **disabled**, and **active**.

Mirrors the pattern of the existing Timestamp — Auto Format block, with labeled rows for each color value.

**New files:**
- `packages/cli/templates/blocks/components/Timestamp/TimestampColors.tsx`
- `packages/cli/templates/blocks/components/Timestamp/TimestampColors.doc.mjs`