### PR TITLE
Improve IconButton docs page and block examples

### DIFF
--- a/packages/cli/templates/blocks/components/IconButton/IconButtonActionBar.doc.mjs
+++ b/packages/cli/templates/blocks/components/IconButton/IconButtonActionBar.doc.mjs
@@ -2,8 +2,7 @@
 export const doc = {
   type: 'block',
   name: 'IconButton — Action Bar',
-  description:
-    'A toolbar row of ghost icon buttons for common actions like search, copy, info, and close.',
+  description: 'Row of ghost icon buttons for a compact action toolbar',
   isReady: true,
   aspectRatio: 4 / 3,
   componentsUsed: ['IconButton', 'Icon', 'HStack'],

--- a/packages/cli/templates/blocks/components/IconButton/IconButtonActionBar.tsx
+++ b/packages/cli/templates/blocks/components/IconButton/IconButtonActionBar.tsx
@@ -2,7 +2,7 @@
 
 import {XDSIconButton} from '@xds/core/IconButton';
 import {XDSIcon} from '@xds/core/Icon';
-import {XDSHStack} from '@xds/core/Layout';
+import {XDSHStack} from '@xds/core/Stack';
 
 export default function IconButtonActionBar() {
   return (

--- a/packages/cli/templates/blocks/components/IconButton/IconButtonLoadingToggle.doc.mjs
+++ b/packages/cli/templates/blocks/components/IconButton/IconButtonLoadingToggle.doc.mjs
@@ -2,8 +2,7 @@
 export const doc = {
   type: 'block',
   name: 'IconButton — Loading State',
-  description:
-    'Icon buttons that show a loading spinner on click, demonstrating async action feedback.',
+  description: 'Icon buttons that show a loading spinner on click for async feedback',
   isReady: true,
   aspectRatio: 4 / 3,
   componentsUsed: ['IconButton', 'Icon', 'HStack'],

--- a/packages/cli/templates/blocks/components/IconButton/IconButtonLoadingToggle.tsx
+++ b/packages/cli/templates/blocks/components/IconButton/IconButtonLoadingToggle.tsx
@@ -3,7 +3,7 @@
 import {useState} from 'react';
 import {XDSIconButton} from '@xds/core/IconButton';
 import {XDSIcon} from '@xds/core/Icon';
-import {XDSHStack} from '@xds/core/Layout';
+import {XDSHStack} from '@xds/core/Stack';
 
 export default function IconButtonLoadingToggle() {
   const [loadingId, setLoadingId] = useState<string | null>(null);

--- a/packages/cli/templates/blocks/components/IconButton/IconButtonTooltipIconButton.doc.mjs
+++ b/packages/cli/templates/blocks/components/IconButton/IconButtonTooltipIconButton.doc.mjs
@@ -2,8 +2,7 @@
 export const doc = {
   type: 'block',
   name: 'IconButton — With Tooltips',
-  description:
-    'Icon buttons with tooltip hints that appear on hover, providing context for icon-only controls.',
+  description: 'Icon buttons with tooltips that explain each action on hover',
   isReady: true,
   aspectRatio: 4 / 3,
   componentsUsed: ['IconButton', 'Icon', 'HStack'],

--- a/packages/cli/templates/blocks/components/IconButton/IconButtonTooltipIconButton.tsx
+++ b/packages/cli/templates/blocks/components/IconButton/IconButtonTooltipIconButton.tsx
@@ -2,7 +2,7 @@
 
 import {XDSIconButton} from '@xds/core/IconButton';
 import {XDSIcon} from '@xds/core/Icon';
-import {XDSHStack} from '@xds/core/Layout';
+import {XDSHStack} from '@xds/core/Stack';
 
 export default function IconButtonTooltipIconButton() {
   return (

--- a/packages/core/src/IconButton/IconButton.doc.mjs
+++ b/packages/core/src/IconButton/IconButton.doc.mjs
@@ -60,11 +60,13 @@ export const docs = {
   ],
 
   usage: {
-    description: 'An icon-only button for compact actions that can be clearly represented by a single icon. Use IconButton in toolbars, table rows, and dense UI areas where space is limited and the icon meaning is universally understood.',
+    description: 'A button that shows only an icon with no visible text. Use IconButton in toolbars, table rows, and compact UI where space is tight and the icon is universally understood.',
     bestPractices: [
-      { guidance: true, description: 'Always provide a descriptive label prop — it becomes the aria-label for screen reader users.' },
-      { guidance: true, description: 'Add a tooltip to clarify the action for sighted users who may not recognize the icon.' },
-      { guidance: false, description: 'Use an icon-only button when the action is ambiguous — add visible text or use a standard Button instead.' },
+      { guidance: true, description: 'Make the aria-label specific — a trash icon labeled "Delete conversation" is clearer than just "Delete" for screen readers.' },
+      { guidance: true, description: 'Add a tooltip — even a gear icon can mean Settings, Preferences, or Configure.' },
+      { guidance: true, description: 'Use ghost in toolbars and dense areas to reduce visual clutter.' },
+      { guidance: false, description: 'Use IconButton if the action isn\'t obvious from the icon alone — use Button with text.' },
+      { guidance: false, description: 'Skip the tooltip — label only reaches screen readers, sighted users need the hover hint.' },
     ],
   },
 };


### PR DESCRIPTION
## Summary
- Rewrite usage description to focus on when to reach for IconButton
- Expand best practices from 3 to 5 entries covering aria-label quality, tooltips, ghost variant, and when to use Button instead
- Fix imports in all 3 blocks: `@xds/core/Layout` → `@xds/core/Stack` (canonical path)
- Tighten block descriptions

## Test plan
- [ ] Verify `npx xds component IconButton` output reflects updated usage and best practices
- [ ] Verify all 3 IconButton blocks render correctly in the sandbox