### PR TITLE
fix(templates): use defaultOpen in Tooltip and HoverCard showcases

### DIFF
--- a/packages/cli/templates/blocks/components/HoverCard/HoverCardShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/HoverCard/HoverCardShowcase.doc.mjs
@@ -5,4 +5,5 @@ export const doc = {
   isReady: true,
   aspectRatio: 1,
   isShowcase: true,
+  componentsUsed: ['HoverCard', 'Button', 'Layout', 'Text'],
 };

--- a/packages/cli/templates/blocks/components/HoverCard/HoverCardShowcase.tsx
+++ b/packages/cli/templates/blocks/components/HoverCard/HoverCardShowcase.tsx
@@ -3,25 +3,21 @@
 import {XDSHoverCard} from '@xds/core/HoverCard';
 import {XDSButton} from '@xds/core/Button';
 import {XDSVStack} from '@xds/core/Layout';
+import {XDSText, XDSHeading} from '@xds/core/Text';
 
 export default function HoverCardShowcase() {
   return (
-    <div style={{padding: 80}}>
-      <XDSHoverCard
-        placement="above"
-        content={
-          <div style={{width: 200}}>
-            <XDSVStack gap={2}>
-              <div style={{fontWeight: 600}}>Jane Doe</div>
-              <div style={{fontSize: 14, opacity: 0.7}}>Software Engineer</div>
-              <div style={{fontSize: 13}}>
-                Building great products with great people.
-              </div>
-            </XDSVStack>
-          </div>
-        }>
-        <XDSButton label="Hover me">Hover me</XDSButton>
-      </XDSHoverCard>
-    </div>
+    <XDSHoverCard
+      placement="above"
+      isDefaultOpen
+      content={
+        <XDSVStack gap={1} style={{width: 200}}>
+          <XDSHeading level={5}>Jane Doe</XDSHeading>
+          <XDSText type="supporting" color="secondary">Software Engineer</XDSText>
+          <XDSText type="body">Building great products with great people.</XDSText>
+        </XDSVStack>
+      }>
+      <XDSButton label="Hover me" />
+    </XDSHoverCard>
   );
 }

--- a/packages/cli/templates/blocks/components/Tooltip/TooltipShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/Tooltip/TooltipShowcase.doc.mjs
@@ -5,4 +5,5 @@ export const doc = {
   isReady: true,
   aspectRatio: 1,
   isShowcase: true,
+  componentsUsed: ['Tooltip', 'Button'],
 };

--- a/packages/cli/templates/blocks/components/Tooltip/TooltipShowcase.tsx
+++ b/packages/cli/templates/blocks/components/Tooltip/TooltipShowcase.tsx
@@ -5,7 +5,7 @@ import {XDSButton} from '@xds/core/Button';
 
 export default function TooltipShowcase() {
   return (
-    <XDSTooltip content="This is a helpful tooltip" placement="above">
+    <XDSTooltip content="This is a helpful tooltip" placement="above" isDefaultOpen>
       <XDSButton label="Hover me" />
     </XDSTooltip>
   );


### PR DESCRIPTION
## Summary

Updates Tooltip and HoverCard showcase blocks to use the `defaultOpen` prop (from #1672) so the layer content is visible in block previews.

### Changes

- **TooltipShowcase**: Added `defaultOpen` so tooltip renders open
- **HoverCardShowcase**: Added `defaultOpen`, replaced raw `<div>` with XDS components (XDSText, XDSHeading, XDSVStack), removed unnecessary padding wrapper
- Updated doc.mjs `componentsUsed` arrays

Depends on #1672.

---
