### PR TITLE
Improve NumberInput docs page and block examples

### DIFF
--- a/packages/cli/templates/blocks/components/NumberInput/NumberInputClearableNumberInput.doc.mjs
+++ b/packages/cli/templates/blocks/components/NumberInput/NumberInputClearableNumberInput.doc.mjs
@@ -2,9 +2,8 @@
 export const doc = {
   type: 'block',
   name: 'NumberInput — Clearable',
-  description:
-    'Number input with a clear button, unit suffix, and min/max range constraint.',
+  description: 'Number input with a clear button, unit suffix, and min/max constraint',
   isReady: true,
   aspectRatio: 4 / 3,
-  componentsUsed: ['NumberInput'],
+  componentsUsed: ['NumberInput', 'Center'],
 };

--- a/packages/cli/templates/blocks/components/NumberInput/NumberInputClearableNumberInput.tsx
+++ b/packages/cli/templates/blocks/components/NumberInput/NumberInputClearableNumberInput.tsx
@@ -2,11 +2,12 @@
 
 import {useState} from 'react';
 import {XDSNumberInput} from '@xds/core/NumberInput';
+import {XDSCenter} from '@xds/core/Center';
 
 export default function NumberInputClearableNumberInput() {
   const [value, setValue] = useState<number | null>(75);
   return (
-    <div style={{maxWidth: 300}}>
+    <XDSCenter width={300}>
       <XDSNumberInput
         label="Progress"
         units="%"
@@ -16,6 +17,6 @@ export default function NumberInputClearableNumberInput() {
         onChange={setValue}
         hasClear
       />
-    </div>
+    </XDSCenter>
   );
 }

--- a/packages/cli/templates/blocks/components/NumberInput/NumberInputRangeNumberInput.doc.mjs
+++ b/packages/cli/templates/blocks/components/NumberInput/NumberInputRangeNumberInput.doc.mjs
@@ -2,9 +2,8 @@
 export const doc = {
   type: 'block',
   name: 'NumberInput — Range Constrained',
-  description:
-    'Number input with min/max boundaries and a description indicating the valid range.',
+  description: 'Number input with min/max boundaries and a helper description',
   isReady: true,
   aspectRatio: 4 / 3,
-  componentsUsed: ['NumberInput'],
+  componentsUsed: ['NumberInput', 'Center'],
 };

--- a/packages/cli/templates/blocks/components/NumberInput/NumberInputRangeNumberInput.tsx
+++ b/packages/cli/templates/blocks/components/NumberInput/NumberInputRangeNumberInput.tsx
@@ -2,20 +2,21 @@
 
 import {useState} from 'react';
 import {XDSNumberInput} from '@xds/core/NumberInput';
+import {XDSCenter} from '@xds/core/Center';
 
 export default function NumberInputRangeNumberInput() {
-  const [value, setValue] = useState<number | null>(null);
+  const [value, setValue] = useState<number | null>(3);
   return (
-    <div style={{maxWidth: 300}}>
+    <XDSCenter width={300}>
       <XDSNumberInput
-        label="Rating"
-        placeholder="1-5"
+        label="Team Size"
+        placeholder="1–50"
         min={1}
-        max={5}
-        description="Rate from 1 to 5"
+        max={50}
+        description="Number of people on the team"
         value={value}
         onChange={setValue}
       />
-    </div>
+    </XDSCenter>
   );
 }

--- a/packages/cli/templates/blocks/components/NumberInput/NumberInputStatuses.doc.mjs
+++ b/packages/cli/templates/blocks/components/NumberInput/NumberInputStatuses.doc.mjs
@@ -2,9 +2,8 @@
 export const doc = {
   type: 'block',
   name: 'NumberInput — Status Variants',
-  description:
-    'Three number inputs showing error, warning, and success validation states with messages.',
+  description: 'Number inputs showing error, warning, and success validation states',
   isReady: true,
   aspectRatio: 4 / 3,
-  componentsUsed: ['NumberInput'],
+  componentsUsed: ['NumberInput', 'VStack', 'Center'],
 };

--- a/packages/cli/templates/blocks/components/NumberInput/NumberInputStatuses.tsx
+++ b/packages/cli/templates/blocks/components/NumberInput/NumberInputStatuses.tsx
@@ -2,37 +2,36 @@
 
 import {useState} from 'react';
 import {XDSNumberInput} from '@xds/core/NumberInput';
+import {XDSVStack} from '@xds/core/Stack';
+import {XDSCenter} from '@xds/core/Center';
 
 export default function NumberInputStatuses() {
   const [error, setError] = useState<number | null>(-5);
   const [warning, setWarning] = useState<number | null>(150);
   const [success, setSuccess] = useState<number | null>(25);
   return (
-    <div
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-        gap: 16,
-        maxWidth: 300,
-      }}>
-      <XDSNumberInput
-        label="Error"
-        value={error}
-        onChange={setError}
-        status={{type: 'error', message: 'Must be positive'}}
-      />
-      <XDSNumberInput
-        label="Warning"
-        value={warning}
-        onChange={setWarning}
-        status={{type: 'warning', message: 'Value seems high'}}
-      />
-      <XDSNumberInput
-        label="Success"
-        value={success}
-        onChange={setSuccess}
-        status={{type: 'success', message: 'Looks good'}}
-      />
-    </div>
+    <XDSCenter width={300}>
+      <XDSVStack gap={4}>
+        <XDSNumberInput
+          label="Budget"
+          value={error}
+          onChange={setError}
+          status={{type: 'error', message: 'Must be a positive amount'}}
+        />
+        <XDSNumberInput
+          label="Headcount"
+          value={warning}
+          onChange={setWarning}
+          status={{type: 'warning', message: 'Exceeds typical team size'}}
+        />
+        <XDSNumberInput
+          label="Completion"
+          units="%"
+          value={success}
+          onChange={setSuccess}
+          status={{type: 'success', message: 'On track'}}
+        />
+      </XDSVStack>
+    </XDSCenter>
   );
 }

--- a/packages/cli/templates/blocks/components/NumberInput/NumberInputWithUnits.doc.mjs
+++ b/packages/cli/templates/blocks/components/NumberInput/NumberInputWithUnits.doc.mjs
@@ -2,9 +2,8 @@
 export const doc = {
   type: 'block',
   name: 'NumberInput — With Units',
-  description:
-    'Number input displaying a unit suffix like percentage, constrained to a valid range.',
+  description: 'Number input with a percentage unit suffix and valid range',
   isReady: true,
   aspectRatio: 4 / 3,
-  componentsUsed: ['NumberInput'],
+  componentsUsed: ['NumberInput', 'Center'],
 };

--- a/packages/cli/templates/blocks/components/NumberInput/NumberInputWithUnits.tsx
+++ b/packages/cli/templates/blocks/components/NumberInput/NumberInputWithUnits.tsx
@@ -2,11 +2,12 @@
 
 import {useState} from 'react';
 import {XDSNumberInput} from '@xds/core/NumberInput';
+import {XDSCenter} from '@xds/core/Center';
 
 export default function NumberInputWithUnits() {
   const [value, setValue] = useState<number | null>(50);
   return (
-    <div style={{maxWidth: 300}}>
+    <XDSCenter width={300}>
       <XDSNumberInput
         label="Discount"
         placeholder="Enter discount"
@@ -16,6 +17,6 @@ export default function NumberInputWithUnits() {
         value={value}
         onChange={setValue}
       />
-    </div>
+    </XDSCenter>
   );
 }

--- a/packages/core/src/NumberInput/NumberInput.doc.mjs
+++ b/packages/core/src/NumberInput/NumberInput.doc.mjs
@@ -156,10 +156,10 @@ export const docs = {
   },
   usage: {
     description:
-      'NumberInput is a form input for collecting and editing numeric values with built-in validation. Use it when users need to enter quantities, measurements, or other constrained numeric data with optional min, max, and step controls.',
+      'A form input for numeric values with built-in validation, min/max constraints, and step controls. Use NumberInput for quantities, measurements, percentages, and similar inputs.',
     bestPractices: [
-      { guidance: true, description: 'Set appropriate min, max, and step constraints to guide users toward valid values.' },
-      { guidance: true, description: 'Display units (e.g. "%" or "GB") to clarify what the number represents.' },
+      { guidance: true, description: 'Set min, max, and step to guide users toward valid values.' },
+      { guidance: true, description: 'Show units (e.g. "%" or "GB") so users know what the number represents.' },
       { guidance: false, description: 'Use NumberInput for free-form text that happens to contain numbers — use TextInput instead.' },
       { guidance: false, description: 'Set both isOptional and isRequired on the same field.' },
     ],
@@ -328,10 +328,10 @@ export const docsZh = {
   },
   usage: {
     description:
-      'NumberInput is a form input for collecting and editing numeric values with built-in validation. Use it when users need to enter quantities, measurements, or other constrained numeric data with optional min, max, and step controls.',
+      'A form input for numeric values with built-in validation, min/max constraints, and step controls. Use NumberInput for quantities, measurements, percentages, and similar inputs.',
     bestPractices: [
-      { guidance: true, description: 'Set appropriate min, max, and step constraints to guide users toward valid values.' },
-      { guidance: true, description: 'Display units (e.g. "%" or "GB") to clarify what the number represents.' },
+      { guidance: true, description: 'Set min, max, and step to guide users toward valid values.' },
+      { guidance: true, description: 'Show units (e.g. "%" or "GB") so users know what the number represents.' },
       { guidance: false, description: 'Use NumberInput for free-form text that happens to contain numbers — use TextInput instead.' },
       { guidance: false, description: 'Set both isOptional and isRequired on the same field.' },
     ],
@@ -350,10 +350,10 @@ export const docsDense = {
   description: 'Number input component for collecting numeric user input w/ validation.',
   usage: {
     description:
-      'NumberInput is a form input for collecting and editing numeric values with built-in validation. Use it when users need to enter quantities, measurements, or other constrained numeric data with optional min, max, and step controls.',
+      'A form input for numeric values with built-in validation, min/max constraints, and step controls. Use NumberInput for quantities, measurements, percentages, and similar inputs.',
     bestPractices: [
-      { guidance: true, description: 'Set appropriate min, max, and step constraints to guide users toward valid values.' },
-      { guidance: true, description: 'Display units (e.g. "%" or "GB") to clarify what the number represents.' },
+      { guidance: true, description: 'Set min, max, and step to guide users toward valid values.' },
+      { guidance: true, description: 'Show units (e.g. "%" or "GB") so users know what the number represents.' },
       { guidance: false, description: 'Use NumberInput for free-form text that happens to contain numbers — use TextInput instead.' },
       { guidance: false, description: 'Set both isOptional and isRequired on the same field.' },
     ],


### PR DESCRIPTION
## Summary
- Rewrite usage description to be more concise
- Tighten best practices language
- Replace raw `<div>` wrappers with `XDSCenter` in all 4 blocks
- Replace `<div>` flex layout with `XDSVStack` in Statuses block
- Add realistic mock data to RangeConstrained and Statuses blocks
- Tighten block descriptions
- Update `componentsUsed` in doc metadata

## Test plan
- [ ] Verify `npx xds component NumberInput` output reflects updated usage and best practices
- [ ] Verify all 4 NumberInput blocks render correctly in the sandbox