### PR TITLE
Improve OverflowList docs page and block examples

### DIFF
--- a/packages/cli/templates/blocks/components/OverflowList/OverflowListCollapseFromStartList.doc.mjs
+++ b/packages/cli/templates/blocks/components/OverflowList/OverflowListCollapseFromStartList.doc.mjs
@@ -2,9 +2,8 @@
 export const doc = {
   type: 'block',
   name: 'OverflowList — Collapse From Start',
-  description:
-    'Overflow list that hides items from the beginning, keeping the latest items visible.',
+  description: 'Overflow list that hides items from the start, keeping the latest visible',
   isReady: true,
   aspectRatio: 4 / 3,
-  componentsUsed: ['OverflowList', 'Button'],
+  componentsUsed: ['OverflowList', 'Button', 'Card', 'Center'],
 };

--- a/packages/cli/templates/blocks/components/OverflowList/OverflowListCollapseFromStartList.tsx
+++ b/packages/cli/templates/blocks/components/OverflowList/OverflowListCollapseFromStartList.tsx
@@ -2,26 +2,30 @@
 
 import {XDSOverflowList} from '@xds/core/OverflowList';
 import {XDSButton} from '@xds/core/Button';
+import {XDSCard} from '@xds/core/Card';
+import {XDSCenter} from '@xds/core/Center';
 
 export default function OverflowListCollapseFromStartList() {
   return (
-    <div style={{maxWidth: 300, border: '1px dashed #ccc', padding: 8}}>
-      <XDSOverflowList
-        gap={2}
-        collapseFrom="start"
-        overflowRenderer={overflowItems => (
-          <XDSButton
-            label={`+${overflowItems.length} more`}
-            variant="ghost"
-            size="sm"
-          />
-        )}>
-        <XDSButton label="Step 1" size="sm" />
-        <XDSButton label="Step 2" size="sm" />
-        <XDSButton label="Step 3" size="sm" />
-        <XDSButton label="Step 4" size="sm" />
-        <XDSButton label="Step 5" size="sm" />
-      </XDSOverflowList>
-    </div>
+    <XDSCenter width={300}>
+      <XDSCard padding={2}>
+        <XDSOverflowList
+          gap={2}
+          collapseFrom="start"
+          overflowRenderer={overflowItems => (
+            <XDSButton
+              label={`+${overflowItems.length} more`}
+              variant="ghost"
+              size="sm"
+            />
+          )}>
+          <XDSButton label="Step 1" size="sm" />
+          <XDSButton label="Step 2" size="sm" />
+          <XDSButton label="Step 3" size="sm" />
+          <XDSButton label="Step 4" size="sm" />
+          <XDSButton label="Step 5" size="sm" />
+        </XDSOverflowList>
+      </XDSCard>
+    </XDSCenter>
   );
 }

--- a/packages/cli/templates/blocks/components/OverflowList/OverflowListOverflowBadges.doc.mjs
+++ b/packages/cli/templates/blocks/components/OverflowList/OverflowListOverflowBadges.doc.mjs
@@ -2,9 +2,8 @@
 export const doc = {
   type: 'block',
   name: 'OverflowList — Badge Tags',
-  description:
-    'Resizable container of badges that collapses into a count badge on overflow.',
+  description: 'Resizable row of badges that collapses into a count badge on overflow',
   isReady: true,
   aspectRatio: 4 / 3,
-  componentsUsed: ['OverflowList', 'Badge'],
+  componentsUsed: ['OverflowList', 'Badge', 'Card'],
 };

--- a/packages/cli/templates/blocks/components/OverflowList/OverflowListOverflowBadges.tsx
+++ b/packages/cli/templates/blocks/components/OverflowList/OverflowListOverflowBadges.tsx
@@ -1,19 +1,22 @@
 'use client';
 
+import * as stylex from '@stylexjs/stylex';
 import {XDSOverflowList} from '@xds/core/OverflowList';
 import {XDSBadge} from '@xds/core/Badge';
+import {XDSCard} from '@xds/core/Card';
+
+const styles = stylex.create({
+  resizable: {
+    resize: 'horizontal',
+    overflow: 'hidden',
+    minWidth: 80,
+    width: 300,
+  },
+});
 
 export default function OverflowListOverflowBadges() {
   return (
-    <div
-      style={{
-        resize: 'horizontal',
-        overflow: 'hidden',
-        border: '1px dashed #ccc',
-        padding: 8,
-        width: 300,
-        minWidth: 80,
-      }}>
+    <XDSCard padding={2} xstyle={styles.resizable}>
       <XDSOverflowList
         gap={1}
         overflowRenderer={overflowItems => (
@@ -25,6 +28,6 @@ export default function OverflowListOverflowBadges() {
         <XDSBadge variant="neutral" label="Storybook" />
         <XDSBadge variant="error" label="Vitest" />
       </XDSOverflowList>
-    </div>
+    </XDSCard>
   );
 }

--- a/packages/cli/templates/blocks/components/OverflowList/OverflowListOverflowDropdownActions.doc.mjs
+++ b/packages/cli/templates/blocks/components/OverflowList/OverflowListOverflowDropdownActions.doc.mjs
@@ -2,9 +2,8 @@
 export const doc = {
   type: 'block',
   name: 'OverflowList — Dropdown Actions',
-  description:
-    'Action toolbar that collapses overflow buttons into a dropdown menu.',
+  description: 'Action toolbar that collapses overflow buttons into a dropdown menu',
   isReady: true,
   aspectRatio: 4 / 3,
-  componentsUsed: ['OverflowList', 'Button', 'DropdownMenu'],
+  componentsUsed: ['OverflowList', 'Button', 'DropdownMenu', 'Card'],
 };

--- a/packages/cli/templates/blocks/components/OverflowList/OverflowListOverflowDropdownActions.tsx
+++ b/packages/cli/templates/blocks/components/OverflowList/OverflowListOverflowDropdownActions.tsx
@@ -1,23 +1,26 @@
 'use client';
 
+import * as stylex from '@stylexjs/stylex';
 import {XDSOverflowList} from '@xds/core/OverflowList';
 import {XDSButton} from '@xds/core/Button';
 import {XDSDropdownMenu} from '@xds/core/DropdownMenu';
+import {XDSCard} from '@xds/core/Card';
 
 const actions = ['Save', 'Edit', 'Duplicate', 'Share', 'Archive', 'Delete'];
 
+const styles = stylex.create({
+  resizable: {
+    resize: 'horizontal',
+    overflow: 'hidden',
+    minWidth: 100,
+    width: 350,
+    maxWidth: '100%',
+  },
+});
+
 export default function OverflowListOverflowDropdownActions() {
   return (
-    <div
-      style={{
-        resize: 'horizontal',
-        overflow: 'hidden',
-        border: '1px dashed #ccc',
-        padding: 8,
-        width: 350,
-        minWidth: 100,
-        maxWidth: '100%',
-      }}>
+    <XDSCard padding={2} xstyle={styles.resizable}>
       <XDSOverflowList
         gap={2}
         overflowRenderer={overflowItems => (
@@ -40,6 +43,6 @@ export default function OverflowListOverflowDropdownActions() {
         <XDSButton label="Archive" size="sm" />
         <XDSButton label="Delete" size="sm" variant="destructive" />
       </XDSOverflowList>
-    </div>
+    </XDSCard>
   );
 }

--- a/packages/core/src/OverflowList/OverflowList.doc.mjs
+++ b/packages/core/src/OverflowList/OverflowList.doc.mjs
@@ -67,11 +67,11 @@ export const docs = {
   },
   usage: {
     description:
-      'OverflowList is a horizontal list that automatically hides items exceeding the available width and shows a custom overflow indicator. Use it for breadcrumbs, toolbars, tag lists, or any row of items that needs to collapse gracefully at smaller widths.',
+      'A horizontal list that automatically hides items when they exceed the available width. Use OverflowList for breadcrumbs, toolbars, tag lists, or any row that needs to collapse gracefully at smaller sizes.',
     bestPractices: [
-      { guidance: true, description: 'Provide a meaningful overflow indicator via overflowRenderer, such as a "+N more" badge or dropdown.' },
-      { guidance: true, description: 'Set minVisibleItems to guarantee key items remain visible regardless of container size.' },
-      { guidance: false, description: 'Use OverflowList for vertical layouts — it is designed exclusively for horizontal item rows.' },
+      { guidance: true, description: 'Provide a meaningful overflowRenderer — a "+N more" badge, a dropdown, or a count indicator.' },
+      { guidance: true, description: 'Set minVisibleItems to keep key items visible regardless of container size.' },
+      { guidance: false, description: 'Use OverflowList for vertical layouts — it only works with horizontal rows.' },
     ],
   },
 };
@@ -127,11 +127,11 @@ export const docsZh = {
   ],
   usage: {
     description:
-      'OverflowList is a horizontal list that automatically hides items exceeding the available width and shows a custom overflow indicator. Use it for breadcrumbs, toolbars, tag lists, or any row of items that needs to collapse gracefully at smaller widths.',
+      'A horizontal list that automatically hides items when they exceed the available width. Use OverflowList for breadcrumbs, toolbars, tag lists, or any row that needs to collapse gracefully at smaller sizes.',
     bestPractices: [
-      { guidance: true, description: 'Provide a meaningful overflow indicator via overflowRenderer, such as a "+N more" badge or dropdown.' },
-      { guidance: true, description: 'Set minVisibleItems to guarantee key items remain visible regardless of container size.' },
-      { guidance: false, description: 'Use OverflowList for vertical layouts — it is designed exclusively for horizontal item rows.' },
+      { guidance: true, description: 'Provide a meaningful overflowRenderer — a "+N more" badge, a dropdown, or a count indicator.' },
+      { guidance: true, description: 'Set minVisibleItems to keep key items visible regardless of container size.' },
+      { guidance: false, description: 'Use OverflowList for vertical layouts — it only works with horizontal rows.' },
     ],
   },
 };
@@ -141,11 +141,11 @@ export const docsDense = {
   description: 'horizontal list w/ overflow indicator — hides items beyond container width',
   usage: {
     description:
-      'OverflowList is a horizontal list that automatically hides items exceeding the available width and shows a custom overflow indicator. Use it for breadcrumbs, toolbars, tag lists, or any row of items that needs to collapse gracefully at smaller widths.',
+      'A horizontal list that automatically hides items when they exceed the available width. Use OverflowList for breadcrumbs, toolbars, tag lists, or any row that needs to collapse gracefully at smaller sizes.',
     bestPractices: [
-      { guidance: true, description: 'Provide a meaningful overflow indicator via overflowRenderer, such as a "+N more" badge or dropdown.' },
-      { guidance: true, description: 'Set minVisibleItems to guarantee key items remain visible regardless of container size.' },
-      { guidance: false, description: 'Use OverflowList for vertical layouts — it is designed exclusively for horizontal item rows.' },
+      { guidance: true, description: 'Provide a meaningful overflowRenderer — a "+N more" badge, a dropdown, or a count indicator.' },
+      { guidance: true, description: 'Set minVisibleItems to keep key items visible regardless of container size.' },
+      { guidance: false, description: 'Use OverflowList for vertical layouts — it only works with horizontal rows.' },
     ],
   },
   propDescriptions: {


### PR DESCRIPTION
## Summary
- Tighten usage description and best practices language
- Replace raw `<div>` wrappers with `XDSCard` and `XDSCenter` in all 3 blocks
- Move resize styles from inline `style={{}}` to `stylex.create` in resizable blocks
- Remove hardcoded `#ccc` border colors (XDSCard provides themed borders)
- Tighten block descriptions
- Update `componentsUsed` in doc metadata

## Test plan
- [ ] Verify `npx xds component OverflowList` output reflects updated usage and best practices
- [ ] Verify all 3 OverflowList blocks render correctly in the sandbox
- [ ] Check resizable blocks still support drag-to-resize