### PR TITLE
fix(templates): render CommandPalette blocks inline

### DIFF
--- a/packages/cli/templates/blocks/components/CommandPalette/CommandPaletteAsyncSearch.doc.mjs
+++ b/packages/cli/templates/blocks/components/CommandPalette/CommandPaletteAsyncSearch.doc.mjs
@@ -6,5 +6,5 @@ export const doc = {
     'Server-side search with loading spinner and custom empty states.',
   isReady: true,
   aspectRatio: 4 / 3,
-  componentsUsed: ['CommandPalette', 'CommandPaletteInput', 'Button'],
+  componentsUsed: ['CommandPalette', 'CommandPaletteInput'],
 };

--- a/packages/cli/templates/blocks/components/CommandPalette/CommandPaletteAsyncSearch.tsx
+++ b/packages/cli/templates/blocks/components/CommandPalette/CommandPaletteAsyncSearch.tsx
@@ -1,8 +1,7 @@
 'use client';
 
-import {useState, useMemo} from 'react';
+import {useMemo} from 'react';
 import {XDSCommandPalette, XDSCommandPaletteInput} from '@xds/core/CommandPalette';
-import {XDSButton} from '@xds/core/Button';
 import type {XDSSearchSource} from '@xds/core/Typeahead';
 
 const allFiles = [
@@ -13,8 +12,8 @@ const allFiles = [
   {id: 'app', label: 'src/App.tsx'},
 ];
 
+// Remove isInline for production — command palettes should be modal.
 export default function CommandPaletteAsyncSearch() {
-  const [isOpen, setIsOpen] = useState(false);
   const source = useMemo<XDSSearchSource>(
     () => ({
       async search(query: string) {
@@ -31,16 +30,14 @@ export default function CommandPaletteAsyncSearch() {
   );
 
   return (
-    <>
-      <XDSButton label="Open File Search" onClick={() => setIsOpen(true)} />
-      <XDSCommandPalette
-        isOpen={isOpen}
-        onOpenChange={setIsOpen}
-        searchSource={source}
-        input={<XDSCommandPaletteInput placeholder="Search files..." />}
-        emptyBootstrapText="Type a filename to search"
-        emptySearchText="No files found"
-      />
-    </>
+    <XDSCommandPalette
+      isOpen
+      isInline
+      onOpenChange={() => {}}
+      searchSource={source}
+      input={<XDSCommandPaletteInput placeholder="Search files..." />}
+      emptyBootstrapText="Type a filename to search"
+      emptySearchText="No files found"
+    />
   );
 }

--- a/packages/cli/templates/blocks/components/CommandPalette/CommandPaletteAutoGrouped.doc.mjs
+++ b/packages/cli/templates/blocks/components/CommandPalette/CommandPaletteAutoGrouped.doc.mjs
@@ -6,5 +6,5 @@ export const doc = {
     'Command palette with items grouped via auxiliaryData.group.',
   isReady: true,
   aspectRatio: 4 / 3,
-  componentsUsed: ['CommandPalette', 'Button'],
+  componentsUsed: ['CommandPalette'],
 };

--- a/packages/cli/templates/blocks/components/CommandPalette/CommandPaletteAutoGrouped.tsx
+++ b/packages/cli/templates/blocks/components/CommandPalette/CommandPaletteAutoGrouped.tsx
@@ -1,12 +1,11 @@
 'use client';
 
-import {useState, useMemo} from 'react';
+import {useMemo} from 'react';
 import {XDSCommandPalette} from '@xds/core/CommandPalette';
-import {XDSButton} from '@xds/core/Button';
 import {createStaticSource} from '@xds/core/Typeahead';
 
+// Remove isInline for production — command palettes should be modal.
 export default function CommandPaletteAutoGrouped() {
-  const [isOpen, setIsOpen] = useState(false);
   const source = useMemo(
     () =>
       createStaticSource([
@@ -33,13 +32,11 @@ export default function CommandPaletteAutoGrouped() {
   );
 
   return (
-    <>
-      <XDSButton label="Open Grouped" onClick={() => setIsOpen(true)} />
-      <XDSCommandPalette
-        isOpen={isOpen}
-        onOpenChange={setIsOpen}
-        searchSource={source}
-      />
-    </>
+    <XDSCommandPalette
+      isOpen
+      isInline
+      onOpenChange={() => {}}
+      searchSource={source}
+    />
   );
 }

--- a/packages/cli/templates/blocks/components/CommandPalette/CommandPaletteCustomFooter.doc.mjs
+++ b/packages/cli/templates/blocks/components/CommandPalette/CommandPaletteCustomFooter.doc.mjs
@@ -5,5 +5,5 @@ export const doc = {
   description: 'Command palette with a custom footer tip message.',
   isReady: true,
   aspectRatio: 4 / 3,
-  componentsUsed: ['CommandPalette', 'CommandPaletteFooter', 'Button', 'Text'],
+  componentsUsed: ['CommandPalette', 'CommandPaletteFooter', 'Text'],
 };

--- a/packages/cli/templates/blocks/components/CommandPalette/CommandPaletteCustomFooter.tsx
+++ b/packages/cli/templates/blocks/components/CommandPalette/CommandPaletteCustomFooter.tsx
@@ -1,16 +1,15 @@
 'use client';
 
-import {useState, useMemo} from 'react';
+import {useMemo} from 'react';
 import {
   XDSCommandPalette,
   XDSCommandPaletteFooter,
 } from '@xds/core/CommandPalette';
-import {XDSButton} from '@xds/core/Button';
 import {XDSText} from '@xds/core/Text';
 import {createStaticSource} from '@xds/core/Typeahead';
 
+// Remove isInline for production — command palettes should be modal.
 export default function CommandPaletteCustomFooter() {
-  const [isOpen, setIsOpen] = useState(false);
   const source = useMemo(
     () =>
       createStaticSource([
@@ -21,18 +20,16 @@ export default function CommandPaletteCustomFooter() {
   );
 
   return (
-    <>
-      <XDSButton label="Open" onClick={() => setIsOpen(true)} />
-      <XDSCommandPalette
-        isOpen={isOpen}
-        onOpenChange={setIsOpen}
-        searchSource={source}
-        footer={
-          <XDSCommandPaletteFooter>
-            <XDSText type="supporting">Pro tip: use ⌘K to open anywhere</XDSText>
-          </XDSCommandPaletteFooter>
-        }
-      />
-    </>
+    <XDSCommandPalette
+      isOpen
+      isInline
+      onOpenChange={() => {}}
+      searchSource={source}
+      footer={
+        <XDSCommandPaletteFooter>
+          <XDSText type="supporting">Pro tip: use ⌘K to open anywhere</XDSText>
+        </XDSCommandPaletteFooter>
+      }
+    />
   );
 }

--- a/packages/cli/templates/blocks/components/CommandPalette/CommandPalettePickerMode.doc.mjs
+++ b/packages/cli/templates/blocks/components/CommandPalette/CommandPalettePickerMode.doc.mjs
@@ -6,5 +6,5 @@ export const doc = {
     'Single-value picker with persistent selection and check indicator.',
   isReady: true,
   aspectRatio: 4 / 3,
-  componentsUsed: ['CommandPalette', 'Button', 'Text', 'Icon'],
+  componentsUsed: ['CommandPalette', 'Text', 'Icon'],
 };

--- a/packages/cli/templates/blocks/components/CommandPalette/CommandPalettePickerMode.tsx
+++ b/packages/cli/templates/blocks/components/CommandPalette/CommandPalettePickerMode.tsx
@@ -2,13 +2,12 @@
 
 import {useState, useMemo} from 'react';
 import {XDSCommandPalette} from '@xds/core/CommandPalette';
-import {XDSButton} from '@xds/core/Button';
 import {XDSText} from '@xds/core/Text';
 import {XDSIcon} from '@xds/core/Icon';
 import {createStaticSource} from '@xds/core/Typeahead';
 
+// Remove isInline for production — command palettes should be modal.
 export default function CommandPalettePickerMode() {
-  const [isOpen, setIsOpen] = useState(false);
   const [theme, setTheme] = useState('light');
   const source = useMemo(
     () =>
@@ -21,26 +20,21 @@ export default function CommandPalettePickerMode() {
   );
 
   return (
-    <>
-      <XDSButton label={`Theme: ${theme}`} onClick={() => setIsOpen(true)} />
-      <XDSCommandPalette
-        isOpen={isOpen}
-        onOpenChange={setIsOpen}
-        searchSource={source}
-        value={theme}
-        onValueChange={v => {
-          setTheme(v);
-          setIsOpen(false);
-        }}
-        renderItem={(item, isSelected) => (
-          <>
-            <XDSText type="body" style={{flex: 1}}>
-              {item.label}
-            </XDSText>
-            {isSelected && <XDSIcon icon="check" size="sm" />}
-          </>
-        )}
-      />
-    </>
+    <XDSCommandPalette
+      isOpen
+      isInline
+      onOpenChange={() => {}}
+      searchSource={source}
+      value={theme}
+      onValueChange={setTheme}
+      renderItem={(item, isSelected) => (
+        <>
+          <XDSText type="body" style={{flex: 1}}>
+            {item.label}
+          </XDSText>
+          {isSelected && <XDSIcon icon="check" size="sm" />}
+        </>
+      )}
+    />
   );
 }

--- a/packages/cli/templates/blocks/components/CommandPalette/CommandPaletteRichItems.doc.mjs
+++ b/packages/cli/templates/blocks/components/CommandPalette/CommandPaletteRichItems.doc.mjs
@@ -6,5 +6,5 @@ export const doc = {
     'Custom item rendering with icons, keyboard shortcuts, and keyword search.',
   isReady: true,
   aspectRatio: 4 / 3,
-  componentsUsed: ['CommandPalette', 'Button', 'Text', 'Kbd'],
+  componentsUsed: ['CommandPalette', 'Text', 'Kbd'],
 };

--- a/packages/cli/templates/blocks/components/CommandPalette/CommandPaletteRichItems.tsx
+++ b/packages/cli/templates/blocks/components/CommandPalette/CommandPaletteRichItems.tsx
@@ -1,8 +1,7 @@
 'use client';
 
-import {useState, useMemo} from 'react';
+import {useMemo} from 'react';
 import {XDSCommandPalette} from '@xds/core/CommandPalette';
-import {XDSButton} from '@xds/core/Button';
 import {XDSText} from '@xds/core/Text';
 import {XDSKbd} from '@xds/core/Kbd';
 import {createStaticSource} from '@xds/core/Typeahead';
@@ -46,28 +45,26 @@ const commands: RichCommand[] = [
   },
 ];
 
+// Remove isInline for production — command palettes should be modal.
 export default function CommandPaletteRichItems() {
-  const [isOpen, setIsOpen] = useState(false);
   const source = useMemo(() => createStaticSource(commands), []);
 
   return (
-    <>
-      <XDSButton label="Open Rich Palette" onClick={() => setIsOpen(true)} />
-      <XDSCommandPalette
-        isOpen={isOpen}
-        onOpenChange={setIsOpen}
-        searchSource={source}
-        renderItem={(item: RichCommand) => (
-          <>
-            <XDSText type="body" style={{flex: 1}}>
-              {item.label}
-            </XDSText>
-            {item.auxiliaryData?.shortcut && (
-              <XDSKbd keys={item.auxiliaryData.shortcut} />
-            )}
-          </>
-        )}
-      />
-    </>
+    <XDSCommandPalette
+      isOpen
+      isInline
+      onOpenChange={() => {}}
+      searchSource={source}
+      renderItem={(item: RichCommand) => (
+        <>
+          <XDSText type="body" style={{flex: 1}}>
+            {item.label}
+          </XDSText>
+          {item.auxiliaryData?.shortcut && (
+            <XDSKbd keys={item.auxiliaryData.shortcut} />
+          )}
+        </>
+      )}
+    />
   );
 }


### PR DESCRIPTION
## Summary

Updates all 6 CommandPalette template blocks to use `isInline` (from #1676) so the palette renders inline in block previews instead of requiring a button click to open.

### Changes
- All blocks now use `isOpen isInline` on XDSCommandPalette
- Removed trigger buttons and isOpen state from all blocks
- Updated doc.mjs `componentsUsed` arrays

Depends on #1676.

---
