### PR TITLE
fix(templates): show Dialog and AlertDialog blocks inline

### DIFF
--- a/packages/cli/templates/blocks/components/AlertDialog/AlertDialogAsyncAction.doc.mjs
+++ b/packages/cli/templates/blocks/components/AlertDialog/AlertDialogAsyncAction.doc.mjs
@@ -6,5 +6,5 @@ export const doc = {
     'Alert dialog with an async action that shows a loading state while processing.',
   isReady: true,
   aspectRatio: 4 / 3,
-  componentsUsed: ['AlertDialog', 'Button'],
+  componentsUsed: ['AlertDialog', 'Button', 'Layout'],
 };

--- a/packages/cli/templates/blocks/components/AlertDialog/AlertDialogAsyncAction.tsx
+++ b/packages/cli/templates/blocks/components/AlertDialog/AlertDialogAsyncAction.tsx
@@ -3,13 +3,28 @@
 import {useState} from 'react';
 import {XDSAlertDialog} from '@xds/core/AlertDialog';
 import {XDSButton} from '@xds/core/Button';
+import {XDSVStack} from '@xds/core/Layout';
 
 export default function AlertDialogAsyncAction() {
   const [isOpen, setIsOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
 
+  const alertProps = {
+    title: 'Revoke access?',
+    description:
+      'This user will immediately lose access to all shared resources.',
+    actionLabel: 'Revoke',
+  } as const;
+
   return (
-    <>
+    <XDSVStack gap={3}>
+      <XDSAlertDialog
+        isOpen
+        isInline
+        onOpenChange={() => {}}
+        {...alertProps}
+        onAction={() => {}}
+      />
       <XDSButton
         label="Revoke access"
         variant="destructive"
@@ -18,9 +33,7 @@ export default function AlertDialogAsyncAction() {
       <XDSAlertDialog
         isOpen={isOpen}
         onOpenChange={setIsOpen}
-        title="Revoke access?"
-        description="This user will immediately lose access to all shared resources."
-        actionLabel="Revoke"
+        {...alertProps}
         isActionLoading={isLoading}
         onAction={async () => {
           setIsLoading(true);
@@ -29,6 +42,6 @@ export default function AlertDialogAsyncAction() {
           setIsOpen(false);
         }}
       />
-    </>
+    </XDSVStack>
   );
 }

--- a/packages/cli/templates/blocks/components/AlertDialog/AlertDialogDeleteConfirmation.doc.mjs
+++ b/packages/cli/templates/blocks/components/AlertDialog/AlertDialogDeleteConfirmation.doc.mjs
@@ -6,5 +6,5 @@ export const doc = {
     'Destructive confirmation dialog triggered by a button, the most common alert dialog pattern.',
   isReady: true,
   aspectRatio: 4 / 3,
-  componentsUsed: ['AlertDialog', 'Button'],
+  componentsUsed: ['AlertDialog', 'Button', 'Layout'],
 };

--- a/packages/cli/templates/blocks/components/AlertDialog/AlertDialogDeleteConfirmation.tsx
+++ b/packages/cli/templates/blocks/components/AlertDialog/AlertDialogDeleteConfirmation.tsx
@@ -3,11 +3,27 @@
 import {useState} from 'react';
 import {XDSAlertDialog} from '@xds/core/AlertDialog';
 import {XDSButton} from '@xds/core/Button';
+import {XDSVStack} from '@xds/core/Layout';
 
 export default function AlertDialogDeleteConfirmation() {
   const [isOpen, setIsOpen] = useState(false);
+
+  const alertProps = {
+    title: 'Delete item?',
+    description:
+      'This action cannot be undone. The item and all its data will be permanently removed.',
+    actionLabel: 'Delete',
+  } as const;
+
   return (
-    <>
+    <XDSVStack gap={3}>
+      <XDSAlertDialog
+        isOpen
+        isInline
+        onOpenChange={() => {}}
+        {...alertProps}
+        onAction={() => {}}
+      />
       <XDSButton
         label="Delete item"
         variant="destructive"
@@ -16,11 +32,9 @@ export default function AlertDialogDeleteConfirmation() {
       <XDSAlertDialog
         isOpen={isOpen}
         onOpenChange={setIsOpen}
-        title="Delete item?"
-        description="This action cannot be undone. The item and all its data will be permanently removed."
-        actionLabel="Delete"
+        {...alertProps}
         onAction={() => setIsOpen(false)}
       />
-    </>
+    </XDSVStack>
   );
 }

--- a/packages/cli/templates/blocks/components/AlertDialog/AlertDialogInformationalAlert.doc.mjs
+++ b/packages/cli/templates/blocks/components/AlertDialog/AlertDialogInformationalAlert.doc.mjs
@@ -6,5 +6,5 @@ export const doc = {
     'Non-destructive confirmation dialog with a primary action button for informational notices.',
   isReady: true,
   aspectRatio: 4 / 3,
-  componentsUsed: ['AlertDialog', 'Button'],
+  componentsUsed: ['AlertDialog', 'Button', 'Layout'],
 };

--- a/packages/cli/templates/blocks/components/AlertDialog/AlertDialogInformationalAlert.tsx
+++ b/packages/cli/templates/blocks/components/AlertDialog/AlertDialogInformationalAlert.tsx
@@ -3,11 +3,28 @@
 import {useState} from 'react';
 import {XDSAlertDialog} from '@xds/core/AlertDialog';
 import {XDSButton} from '@xds/core/Button';
+import {XDSVStack} from '@xds/core/Layout';
 
 export default function AlertDialogInformationalAlert() {
   const [isOpen, setIsOpen] = useState(false);
+
+  const alertProps = {
+    title: 'Session expired',
+    description:
+      'Your session has expired. You will be redirected to the login page.',
+    actionLabel: 'Sign in',
+    actionVariant: 'primary',
+  } as const;
+
   return (
-    <>
+    <XDSVStack gap={3}>
+      <XDSAlertDialog
+        isOpen
+        isInline
+        onOpenChange={() => {}}
+        {...alertProps}
+        onAction={() => {}}
+      />
       <XDSButton
         label="Show notice"
         variant="secondary"
@@ -16,12 +33,9 @@ export default function AlertDialogInformationalAlert() {
       <XDSAlertDialog
         isOpen={isOpen}
         onOpenChange={setIsOpen}
-        title="Session expired"
-        description="Your session has expired. You will be redirected to the login page."
-        actionLabel="Sign in"
-        actionVariant="primary"
+        {...alertProps}
         onAction={() => setIsOpen(false)}
       />
-    </>
+    </XDSVStack>
   );
 }

--- a/packages/cli/templates/blocks/components/Dialog/DialogConfirmationDialog.doc.mjs
+++ b/packages/cli/templates/blocks/components/Dialog/DialogConfirmationDialog.doc.mjs
@@ -6,5 +6,5 @@ export const doc = {
     'Asks the user to confirm a destructive action before it happens. Use before deleting projects, removing team members, revoking API keys, or any irreversible operation.',
   isReady: true,
   aspectRatio: 16 / 9,
-  componentsUsed: ['Dialog', 'Layout', 'Button', 'Text', 'Card'],
+  componentsUsed: ['Dialog', 'Layout', 'Button', 'Text'],
 };

--- a/packages/cli/templates/blocks/components/Dialog/DialogConfirmationDialog.tsx
+++ b/packages/cli/templates/blocks/components/Dialog/DialogConfirmationDialog.tsx
@@ -11,7 +11,6 @@ import {
 } from '@xds/core/Layout';
 import {XDSButton} from '@xds/core/Button';
 import {XDSText} from '@xds/core/Text';
-import {XDSCard} from '@xds/core/Card';
 
 export default function DialogConfirmationDialog() {
   const [isOpen, setIsOpen] = useState(false);
@@ -20,61 +19,56 @@ export default function DialogConfirmationDialog() {
     setIsOpen(false);
   };
 
+  const dialogContent = (onClose: (open: boolean) => void) => (
+    <XDSLayout
+      header={
+        <XDSDialogHeader title="Delete project?" onOpenChange={onClose} />
+      }
+      content={
+        <XDSLayoutContent>
+          <XDSText type="body">
+            This will permanently delete &quot;Marketing Dashboard&quot; and all
+            of its data. This action cannot be undone.
+          </XDSText>
+        </XDSLayoutContent>
+      }
+      footer={
+        <XDSLayoutFooter>
+          <XDSHStack gap={2} hAlign="end">
+            <XDSButton
+              label="Cancel"
+              variant="secondary"
+              onClick={() => onClose(false)}
+            />
+            <XDSButton
+              label="Delete"
+              variant="destructive"
+              onClick={handleDelete}
+            />
+          </XDSHStack>
+        </XDSLayoutFooter>
+      }
+    />
+  );
+
   return (
-    <XDSCard>
-      <XDSVStack gap={3}>
-        <XDSVStack gap={1}>
-          <XDSText type="body" weight="bold">
-            Marketing Dashboard
-          </XDSText>
-          <XDSText type="supporting" color="secondary">
-            Created Jan 12, 2026 · 14 pages · 3 collaborators
-          </XDSText>
-        </XDSVStack>
-        <XDSHStack gap={2}>
-          <XDSButton label="Edit" variant="secondary" onClick={() => {}} />
-          <XDSButton
-            label="Delete project"
-            variant="destructive"
-            onClick={() => setIsOpen(true)}
-          />
-        </XDSHStack>
-      </XDSVStack>
+    <XDSVStack gap={3}>
+      <XDSDialog isOpen isInline onOpenChange={() => {}} width={400} purpose="form">
+        {dialogContent(() => {})}
+      </XDSDialog>
+      <XDSButton
+        label="Open dialog"
+        variant="secondary"
+        size="sm"
+        onClick={() => setIsOpen(true)}
+      />
       <XDSDialog
         isOpen={isOpen}
         onOpenChange={setIsOpen}
         width={400}
         purpose="form">
-        <XDSLayout
-          header={
-            <XDSDialogHeader title="Delete project?" onOpenChange={setIsOpen} />
-          }
-          content={
-            <XDSLayoutContent>
-              <XDSText type="body">
-                This will permanently delete &quot;Marketing Dashboard&quot; and
-                all of its data. This action cannot be undone.
-              </XDSText>
-            </XDSLayoutContent>
-          }
-          footer={
-            <XDSLayoutFooter>
-              <XDSHStack gap={2} hAlign="end">
-                <XDSButton
-                  label="Cancel"
-                  variant="secondary"
-                  onClick={() => setIsOpen(false)}
-                />
-                <XDSButton
-                  label="Delete"
-                  variant="destructive"
-                  onClick={handleDelete}
-                />
-              </XDSHStack>
-            </XDSLayoutFooter>
-          }
-        />
+        {dialogContent(setIsOpen)}
       </XDSDialog>
-    </XDSCard>
+    </XDSVStack>
   );
 }

--- a/packages/cli/templates/blocks/components/Dialog/DialogFormDialog.doc.mjs
+++ b/packages/cli/templates/blocks/components/Dialog/DialogFormDialog.doc.mjs
@@ -6,5 +6,5 @@ export const doc = {
     'Collects user input without navigating away from the page. Uses purpose="form" so clicking the backdrop won\'t close it. Use for editing profiles, creating items, or updating settings inline.',
   isReady: true,
   aspectRatio: 16 / 9,
-  componentsUsed: ['Dialog', 'Layout', 'Button', 'Text', 'TextInput', 'TextArea', 'Card'],
+  componentsUsed: ['Dialog', 'Layout', 'Button', 'TextInput', 'TextArea'],
 };

--- a/packages/cli/templates/blocks/components/Dialog/DialogFormDialog.tsx
+++ b/packages/cli/templates/blocks/components/Dialog/DialogFormDialog.tsx
@@ -10,82 +10,83 @@ import {
   XDSVStack,
 } from '@xds/core/Layout';
 import {XDSButton} from '@xds/core/Button';
-import {XDSText} from '@xds/core/Text';
 import {XDSTextInput} from '@xds/core/TextInput';
 import {XDSTextArea} from '@xds/core/TextArea';
-import {XDSCard} from '@xds/core/Card';
 
 export default function DialogFormDialog() {
   const [isOpen, setIsOpen] = useState(false);
   const [name, setName] = useState('Ruby Cheung');
   const [bio, setBio] = useState('Design systems engineer');
 
-  return (
-    <XDSCard>
-      <XDSVStack gap={3}>
-        <XDSVStack gap={1}>
-          <XDSText type="body" weight="bold">
-            Profile Settings
-          </XDSText>
-          <XDSText type="supporting" color="secondary">
-            Display name, bio, and avatar
-          </XDSText>
-        </XDSVStack>
-        <XDSButton
-          label="Edit profile"
-          variant="secondary"
-          onClick={() => setIsOpen(true)}
+  const dialogContent = (onClose: (open: boolean) => void) => (
+    <XDSLayout
+      header={
+        <XDSDialogHeader
+          title="Edit profile"
+          subtitle="Update your display name and bio"
+          onOpenChange={onClose}
         />
-      </XDSVStack>
+      }
+      content={
+        <XDSLayoutContent>
+          <XDSVStack gap={4}>
+            <XDSTextInput
+              label="Display name"
+              value={name}
+              onChange={setName}
+              placeholder="Enter your name"
+            />
+            <XDSTextArea
+              label="Bio"
+              value={bio}
+              onChange={setBio}
+              placeholder="Tell us about yourself"
+            />
+          </XDSVStack>
+        </XDSLayoutContent>
+      }
+      footer={
+        <XDSLayoutFooter>
+          <XDSHStack gap={2} hAlign="end">
+            <XDSButton
+              label="Cancel"
+              variant="secondary"
+              onClick={() => onClose(false)}
+            />
+            <XDSButton
+              label="Save"
+              variant="primary"
+              onClick={() => onClose(false)}
+            />
+          </XDSHStack>
+        </XDSLayoutFooter>
+      }
+    />
+  );
+
+  return (
+    <XDSVStack gap={3}>
+      <XDSDialog
+        isOpen
+        isInline
+        onOpenChange={() => {}}
+        purpose="form"
+        width={480}>
+        {dialogContent(() => {})}
+      </XDSDialog>
+      <XDSButton
+        label="Open dialog"
+        variant="secondary"
+        size="sm"
+        onClick={() => setIsOpen(true)}
+      />
       <XDSDialog
         isOpen={isOpen}
         onOpenChange={setIsOpen}
         purpose="form"
         width={480}>
-        <XDSLayout
-          header={
-            <XDSDialogHeader
-              title="Edit profile"
-              subtitle="Update your display name and bio"
-              onOpenChange={setIsOpen}
-            />
-          }
-          content={
-            <XDSLayoutContent>
-              <XDSVStack gap={4}>
-                <XDSTextInput
-                  label="Display name"
-                  value={name}
-                  onChange={setName}
-                  placeholder="Enter your name"
-                />
-                <XDSTextArea
-                  label="Bio"
-                  value={bio}
-                  onChange={setBio}
-                  placeholder="Tell us about yourself"
-                />
-              </XDSVStack>
-            </XDSLayoutContent>
-          }
-          footer={
-            <XDSLayoutFooter>
-              <XDSHStack gap={2} hAlign="end">
-                <XDSButton
-                  label="Cancel"
-                  variant="secondary"
-                  onClick={() => setIsOpen(false)}
-                />
-                <XDSButton
-                  label="Save"
-                  variant="primary"
-                  onClick={() => setIsOpen(false)}
-                />
-              </XDSHStack>
-            </XDSLayoutFooter>
-          }
-        />
+        {dialogContent(setIsOpen)}
       </XDSDialog>
-    </XDSCard>
+    </XDSVStack>
   );
 }

--- a/packages/cli/templates/blocks/components/Dialog/DialogScrollingContent.doc.mjs
+++ b/packages/cli/templates/blocks/components/Dialog/DialogScrollingContent.doc.mjs
@@ -6,5 +6,5 @@ export const doc = {
     'Constrains the dialog height and scrolls the body when content overflows. Use for terms and conditions, license agreements, changelogs, or any long-form content the user needs to review before accepting.',
   isReady: true,
   aspectRatio: 16 / 9,
-  componentsUsed: ['Dialog', 'Layout', 'Button', 'Text', 'Card'],
+  componentsUsed: ['Dialog', 'Layout', 'Button', 'Text'],
 };

--- a/packages/cli/templates/blocks/components/Dialog/DialogScrollingContent.tsx
+++ b/packages/cli/templates/blocks/components/Dialog/DialogScrollingContent.tsx
@@ -11,76 +11,80 @@ import {
 } from '@xds/core/Layout';
 import {XDSButton} from '@xds/core/Button';
 import {XDSText} from '@xds/core/Text';
-import {XDSCard} from '@xds/core/Card';
 
 const TERMS = [
-  'You agree to use the service only for lawful purposes and in compliance with all applicable laws.',
-  'Your account credentials are your responsibility. Notify us immediately if you suspect unauthorized access.',
-  'We reserve the right to suspend accounts that violate these terms or engage in abusive behavior.',
+  'You agree to use the service only for lawful purposes and in compliance with all applicable laws and regulations in your jurisdiction.',
+  'Your account credentials are your responsibility. Notify us immediately if you suspect unauthorized access to your account.',
+  'We reserve the right to suspend accounts that violate these terms or engage in abusive behavior toward other users.',
   'Content you upload remains your property. You grant us a license to host and display it within the service.',
-  'We may update these terms at any time. Continued use after changes constitutes acceptance.',
-  'The service is provided as-is without warranties. We are not liable for data loss or service interruptions.',
+  'We may update these terms at any time. Continued use after changes constitutes acceptance of the updated terms.',
+  'The service is provided as-is without warranties of any kind. We are not liable for data loss or service interruptions.',
   'You may cancel your account at any time. Your data will be deleted within 30 days of cancellation.',
   'Disputes will be resolved through binding arbitration in accordance with applicable regulations.',
+  'You agree not to reverse-engineer, decompile, or disassemble any part of the service or its underlying technology.',
+  'We may collect anonymized usage data to improve the service. Personal data is handled per our Privacy Policy.',
+  'Third-party integrations are governed by their own terms. We are not responsible for third-party service outages.',
+  'You are responsible for maintaining backups of your data. We provide export tools but do not guarantee data recovery.',
+  'Commercial use requires a Business plan. Free accounts are limited to personal and non-commercial projects.',
+  'We may introduce new features or discontinue existing ones with 30 days notice via email or in-app notification.',
+  'Violation of these terms may result in immediate termination of your account without prior notice or refund.',
 ];
 
 export default function DialogScrollingContent() {
   const [isOpen, setIsOpen] = useState(false);
 
-  return (
-    <XDSCard>
-      <XDSVStack gap={3}>
-        <XDSVStack gap={1}>
-          <XDSText type="body" weight="bold">
-            Terms and Conditions
-          </XDSText>
-          <XDSText type="supporting" color="secondary">
-            Last updated March 2026 · 8 clauses
-          </XDSText>
-        </XDSVStack>
-        <XDSButton
-          label="Review terms"
-          variant="secondary"
-          onClick={() => setIsOpen(true)}
+  const dialogContent = (onClose: (open: boolean) => void) => (
+    <XDSLayout
+      header={
+        <XDSDialogHeader
+          title="Terms and Conditions"
+          onOpenChange={onClose}
         />
-      </XDSVStack>
-      <XDSDialog isOpen={isOpen} onOpenChange={setIsOpen} maxHeight="50vh">
-        <XDSLayout
-          header={
-            <XDSDialogHeader
-              title="Terms and Conditions"
-              onOpenChange={setIsOpen}
+      }
+      content={
+        <XDSLayoutContent>
+          <XDSVStack gap={3}>
+            {TERMS.map((term, i) => (
+              <XDSText type="body" key={i}>
+                {i + 1}. {term}
+              </XDSText>
+            ))}
+          </XDSVStack>
+        </XDSLayoutContent>
+      }
+      footer={
+        <XDSLayoutFooter>
+          <XDSHStack gap={2} hAlign="end">
+            <XDSButton
+              label="Decline"
+              variant="secondary"
+              onClick={() => onClose(false)}
             />
-          }
-          content={
-            <XDSLayoutContent>
-              <XDSVStack gap={3}>
-                {TERMS.map((term, i) => (
-                  <XDSText type="body" key={i}>
-                    {i + 1}. {term}
-                  </XDSText>
-                ))}
-              </XDSVStack>
-            </XDSLayoutContent>
-          }
-          footer={
-            <XDSLayoutFooter>
-              <XDSHStack gap={2} hAlign="end">
-                <XDSButton
-                  label="Decline"
-                  variant="secondary"
-                  onClick={() => setIsOpen(false)}
-                />
-                <XDSButton
-                  label="Accept"
-                  variant="primary"
-                  onClick={() => setIsOpen(false)}
-                />
-              </XDSHStack>
-            </XDSLayoutFooter>
-          }
-        />
+            <XDSButton
+              label="Accept"
+              variant="primary"
+              onClick={() => onClose(false)}
+            />
+          </XDSHStack>
+        </XDSLayoutFooter>
+      }
+    />
+  );
+
+  return (
+    <XDSVStack gap={3}>
+      <XDSDialog isOpen isInline onOpenChange={() => {}} maxHeight="50vh">
+        {dialogContent(() => {})}
       </XDSDialog>
-    </XDSCard>
+      <XDSButton
+        label="Open dialog"
+        variant="secondary"
+        size="sm"
+        onClick={() => setIsOpen(true)}
+      />
+      <XDSDialog isOpen={isOpen} onOpenChange={setIsOpen} maxHeight="50vh">
+        {dialogContent(setIsOpen)}
+      </XDSDialog>
+    </XDSVStack>
   );
 }

--- a/packages/cli/templates/blocks/components/Dialog/DialogWithSubtitle.doc.mjs
+++ b/packages/cli/templates/blocks/components/Dialog/DialogWithSubtitle.doc.mjs
@@ -6,5 +6,5 @@ export const doc = {
     'Cannot be dismissed by Escape or backdrop click — the user must explicitly choose an action. Uses purpose="required". Use for ownership transfers, legal acknowledgements, or critical decisions where skipping is not an option.',
   isReady: true,
   aspectRatio: 16 / 9,
-  componentsUsed: ['Dialog', 'Layout', 'Button', 'Text', 'Card'],
+  componentsUsed: ['Dialog', 'Layout', 'Button', 'Text'],
 };

--- a/packages/cli/templates/blocks/components/Dialog/DialogWithSubtitle.tsx
+++ b/packages/cli/templates/blocks/components/Dialog/DialogWithSubtitle.tsx
@@ -11,62 +11,59 @@ import {
 } from '@xds/core/Layout';
 import {XDSButton} from '@xds/core/Button';
 import {XDSText} from '@xds/core/Text';
-import {XDSCard} from '@xds/core/Card';
 
 export default function DialogWithSubtitle() {
   const [isOpen, setIsOpen] = useState(false);
 
-  return (
-    <XDSCard>
-      <XDSVStack gap={3}>
-        <XDSVStack gap={1}>
-          <XDSText type="body" weight="bold">
-            Project Ownership
-          </XDSText>
-          <XDSText type="supporting" color="secondary">
-            Marketing Dashboard · Owner: You
-          </XDSText>
-        </XDSVStack>
-        <XDSButton
-          label="Transfer ownership"
-          variant="secondary"
-          onClick={() => setIsOpen(true)}
+  const dialogContent = (onClose: (open: boolean) => void) => (
+    <XDSLayout
+      header={
+        <XDSDialogHeader
+          title="Transfer project ownership"
+          subtitle="This action requires confirmation from the new owner"
         />
-      </XDSVStack>
-      <XDSDialog isOpen={isOpen} onOpenChange={setIsOpen} purpose="required">
-        <XDSLayout
-          header={
-            <XDSDialogHeader
-              title="Transfer project ownership"
-              subtitle="This action requires confirmation from the new owner"
+      }
+      content={
+        <XDSLayoutContent>
+          <XDSText type="body">
+            You are about to transfer &quot;Marketing Dashboard&quot; to Sarah
+            Chen. Once accepted, you will lose admin access.
+          </XDSText>
+        </XDSLayoutContent>
+      }
+      footer={
+        <XDSLayoutFooter>
+          <XDSHStack gap={2} hAlign="end">
+            <XDSButton
+              label="Cancel"
+              variant="secondary"
+              onClick={() => onClose(false)}
             />
-          }
-          content={
-            <XDSLayoutContent>
-              <XDSText type="body">
-                You are about to transfer &quot;Marketing Dashboard&quot; to
-                Sarah Chen. Once accepted, you will lose admin access.
-              </XDSText>
-            </XDSLayoutContent>
-          }
-          footer={
-            <XDSLayoutFooter>
-              <XDSHStack gap={2} hAlign="end">
-                <XDSButton
-                  label="Cancel"
-                  variant="secondary"
-                  onClick={() => setIsOpen(false)}
-                />
-                <XDSButton
-                  label="Transfer"
-                  variant="primary"
-                  onClick={() => setIsOpen(false)}
-                />
-              </XDSHStack>
-            </XDSLayoutFooter>
-          }
-        />
+            <XDSButton
+              label="Transfer"
+              variant="primary"
+              onClick={() => onClose(false)}
+            />
+          </XDSHStack>
+        </XDSLayoutFooter>
+      }
+    />
+  );
+
+  return (
+    <XDSVStack gap={3}>
+      <XDSDialog isOpen isInline onOpenChange={() => {}} purpose="required">
+        {dialogContent(() => {})}
       </XDSDialog>
-    </XDSCard>
+      <XDSButton
+        label="Open dialog"
+        variant="secondary"
+        size="sm"
+        onClick={() => setIsOpen(true)}
+      />
+      <XDSDialog isOpen={isOpen} onOpenChange={setIsOpen} purpose="required">
+        {dialogContent(setIsOpen)}
+      </XDSDialog>
+    </XDSVStack>
   );
 }


### PR DESCRIPTION
## Summary

Updates Dialog and AlertDialog template blocks to render dialog content inline using `isInline` (from #1676), while keeping a button to open the real modal dialog for testing.

### Pattern
Each block now shows:
1. The dialog content rendered inline (always visible in the block preview)
2. An "Open dialog" button that launches the real modal version

### Updated blocks
- DialogConfirmationDialog, DialogScrollingContent, DialogWithSubtitle, DialogFormDialog
- AlertDialogDeleteConfirmation, AlertDialogInformationalAlert, AlertDialogAsyncAction

### Skipped
- DialogFullscreenDialog — fullscreen variant doesn't make sense inline
- AlertDialogImperativeAlert — demonstrates hook pattern, not direct rendering

Depends on #1676.

---
