### PR TITLE
Improve MobileNav docs page and block examples

### DIFF
--- a/packages/cli/templates/blocks/components/MobileNav/MobileNavBasicMobileNav.doc.mjs
+++ b/packages/cli/templates/blocks/components/MobileNav/MobileNavBasicMobileNav.doc.mjs
@@ -2,8 +2,7 @@
 export const doc = {
   type: 'block',
   name: 'MobileNav — Basic Drawer',
-  description:
-    'Standard mobile navigation drawer triggered by a menu button, with sectioned nav items.',
+  description: 'Mobile navigation drawer with sectioned nav items triggered by a menu button',
   isReady: true,
   aspectRatio: 4 / 3,
   componentsUsed: ['MobileNav', 'SideNav', 'Button', 'Icon'],

--- a/packages/cli/templates/blocks/components/MobileNav/MobileNavBasicMobileNav.tsx
+++ b/packages/cli/templates/blocks/components/MobileNav/MobileNavBasicMobileNav.tsx
@@ -1,45 +1,17 @@
 'use client';
 
 import {useState} from 'react';
-import type {SVGProps} from 'react';
 import {XDSMobileNav} from '@xds/core/MobileNav';
 import {XDSSideNavSection, XDSSideNavItem} from '@xds/core/SideNav';
 import {XDSButton} from '@xds/core/Button';
 import {XDSIcon} from '@xds/core/Icon';
-
-const HomeIcon = (p: SVGProps<SVGSVGElement>) => (
-  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round" {...p}>
-    <path d="M3 9.5L12 3l9 6.5V20a1 1 0 01-1 1H4a1 1 0 01-1-1V9.5z" />
-    <path d="M9 21V12h6v9" />
-  </svg>
-);
-
-const FolderIcon = (p: SVGProps<SVGSVGElement>) => (
-  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round" {...p}>
-    <path d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
-  </svg>
-);
-
-const ChartIcon = (p: SVGProps<SVGSVGElement>) => (
-  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round" {...p}>
-    <path d="M18 20V10M12 20V4M6 20v-6" />
-  </svg>
-);
-
-const SettingsIcon = (p: SVGProps<SVGSVGElement>) => (
-  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round" {...p}>
-    <circle cx="12" cy="12" r="3" />
-    <path d="M12 1v2m0 18v2M4.22 4.22l1.42 1.42m12.73 12.73l1.42 1.42M1 12h2m18 0h2M4.22 19.78l1.42-1.42m12.73-12.73l1.42-1.42" />
-  </svg>
-);
-
-const UsersIcon = (p: SVGProps<SVGSVGElement>) => (
-  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round" {...p}>
-    <path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2" />
-    <circle cx="9" cy="7" r="4" />
-    <path d="M23 21v-2a4 4 0 00-3-3.87M16 3.13a4 4 0 010 7.75" />
-  </svg>
-);
+import {
+  HomeIcon,
+  FolderIcon,
+  ChartBarIcon,
+  Cog6ToothIcon,
+  UsersIcon,
+} from '@heroicons/react/24/outline';
 
 export default function MobileNavBasicMobileNav() {
   const [isOpen, setIsOpen] = useState(false);
@@ -63,21 +35,17 @@ export default function MobileNavBasicMobileNav() {
             isSelected
             href="/dashboard"
           />
-          <XDSSideNavItem
-            label="Projects"
-            icon={FolderIcon}
-            href="/projects"
-          />
+          <XDSSideNavItem label="Projects" icon={FolderIcon} href="/projects" />
           <XDSSideNavItem
             label="Analytics"
-            icon={ChartIcon}
+            icon={ChartBarIcon}
             href="/analytics"
           />
         </XDSSideNavSection>
         <XDSSideNavSection title="Settings">
           <XDSSideNavItem
             label="General"
-            icon={SettingsIcon}
+            icon={Cog6ToothIcon}
             href="/settings"
           />
           <XDSSideNavItem label="Team" icon={UsersIcon} href="/team" />

--- a/packages/cli/templates/blocks/components/MobileNav/MobileNavEndSideMobileNav.doc.mjs
+++ b/packages/cli/templates/blocks/components/MobileNav/MobileNavEndSideMobileNav.doc.mjs
@@ -2,8 +2,7 @@
 export const doc = {
   type: 'block',
   name: 'MobileNav — End Side Drawer',
-  description:
-    'Mobile navigation drawer that slides in from the right edge of the screen.',
+  description: 'Navigation drawer that slides in from the right side of the screen',
   isReady: true,
   aspectRatio: 4 / 3,
   componentsUsed: ['MobileNav', 'SideNav', 'Button'],

--- a/packages/cli/templates/blocks/components/MobileNav/MobileNavEndSideMobileNav.tsx
+++ b/packages/cli/templates/blocks/components/MobileNav/MobileNavEndSideMobileNav.tsx
@@ -1,25 +1,10 @@
 'use client';
 
 import {useState} from 'react';
-import type {SVGProps} from 'react';
 import {XDSMobileNav} from '@xds/core/MobileNav';
 import {XDSSideNavSection, XDSSideNavItem} from '@xds/core/SideNav';
 import {XDSButton} from '@xds/core/Button';
-
-const SettingsIcon = (p: SVGProps<SVGSVGElement>) => (
-  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round" {...p}>
-    <circle cx="12" cy="12" r="3" />
-    <path d="M12 1v2m0 18v2M4.22 4.22l1.42 1.42m12.73 12.73l1.42 1.42M1 12h2m18 0h2M4.22 19.78l1.42-1.42m12.73-12.73l1.42-1.42" />
-  </svg>
-);
-
-const UsersIcon = (p: SVGProps<SVGSVGElement>) => (
-  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round" {...p}>
-    <path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2" />
-    <circle cx="9" cy="7" r="4" />
-    <path d="M23 21v-2a4 4 0 00-3-3.87M16 3.13a4 4 0 010 7.75" />
-  </svg>
-);
+import {Cog6ToothIcon, UsersIcon} from '@heroicons/react/24/outline';
 
 export default function MobileNavEndSideMobileNav() {
   const [isOpen, setIsOpen] = useState(false);
@@ -34,7 +19,7 @@ export default function MobileNavEndSideMobileNav() {
         <XDSSideNavSection title="Settings">
           <XDSSideNavItem
             label="General"
-            icon={SettingsIcon}
+            icon={Cog6ToothIcon}
             href="/settings"
           />
           <XDSSideNavItem label="Team" icon={UsersIcon} href="/team" />

--- a/packages/cli/templates/blocks/components/MobileNav/MobileNavShowcase.tsx
+++ b/packages/cli/templates/blocks/components/MobileNav/MobileNavShowcase.tsx
@@ -1,23 +1,33 @@
 'use client';
 
+import {useState} from 'react';
 import {XDSMobileNav} from '@xds/core/MobileNav';
 import {XDSSideNavSection, XDSSideNavItem} from '@xds/core/SideNav';
+import {XDSButton} from '@xds/core/Button';
+import {XDSIcon} from '@xds/core/Icon';
 
 export default function MobileNavShowcase() {
+  const [isOpen, setIsOpen] = useState(false);
   return (
-    <XDSMobileNav
-      isOpen={true}
-      onOpenChange={() => {}}
-      header="Navigation">
-      <XDSSideNavSection title="Main">
-        <XDSSideNavItem label="Dashboard" isSelected href="/dashboard" />
-        <XDSSideNavItem label="Projects" href="/projects" />
-        <XDSSideNavItem label="Analytics" href="/analytics" />
-      </XDSSideNavSection>
-      <XDSSideNavSection title="Settings">
-        <XDSSideNavItem label="General" href="/settings" />
-        <XDSSideNavItem label="Team" href="/team" />
-      </XDSSideNavSection>
-    </XDSMobileNav>
+    <>
+      <XDSButton
+        label="Open Navigation"
+        icon={<XDSIcon icon="menu" color="inherit" />}
+        variant="ghost"
+        onClick={() => setIsOpen(true)}
+        isIconOnly
+      />
+      <XDSMobileNav isOpen={isOpen} onOpenChange={setIsOpen} title="Navigation">
+        <XDSSideNavSection title="Main">
+          <XDSSideNavItem label="Dashboard" isSelected href="/dashboard" />
+          <XDSSideNavItem label="Projects" href="/projects" />
+          <XDSSideNavItem label="Analytics" href="/analytics" />
+        </XDSSideNavSection>
+        <XDSSideNavSection title="Settings">
+          <XDSSideNavItem label="General" href="/settings" />
+          <XDSSideNavItem label="Team" href="/team" />
+        </XDSSideNavSection>
+      </XDSMobileNav>
+    </>
   );
 }

--- a/packages/cli/templates/blocks/components/MobileNav/MobileNavShowcase.tsx
+++ b/packages/cli/templates/blocks/components/MobileNav/MobileNavShowcase.tsx
@@ -17,7 +17,10 @@ export default function MobileNavShowcase() {
         onClick={() => setIsOpen(true)}
         isIconOnly
       />
-      <XDSMobileNav isOpen={isOpen} onOpenChange={setIsOpen} title="Navigation">
+      <XDSMobileNav
+        isOpen={isOpen}
+        onOpenChange={setIsOpen}
+        header="Navigation">
         <XDSSideNavSection title="Main">
           <XDSSideNavItem label="Dashboard" isSelected href="/dashboard" />
           <XDSSideNavItem label="Projects" href="/projects" />

--- a/packages/cli/templates/blocks/components/MobileNav/MobileNavWithoutTitleMobileNav.doc.mjs
+++ b/packages/cli/templates/blocks/components/MobileNav/MobileNavWithoutTitleMobileNav.doc.mjs
@@ -2,8 +2,7 @@
 export const doc = {
   type: 'block',
   name: 'MobileNav — Without Title',
-  description:
-    'Minimal mobile navigation drawer without a title bar header.',
+  description: 'Mobile navigation drawer without a title header',
   isReady: true,
   aspectRatio: 4 / 3,
   componentsUsed: ['MobileNav', 'SideNav', 'Button', 'Icon'],

--- a/packages/cli/templates/blocks/components/MobileNav/MobileNavWithoutTitleMobileNav.tsx
+++ b/packages/cli/templates/blocks/components/MobileNav/MobileNavWithoutTitleMobileNav.tsx
@@ -1,24 +1,11 @@
 'use client';
 
 import {useState} from 'react';
-import type {SVGProps} from 'react';
 import {XDSMobileNav} from '@xds/core/MobileNav';
 import {XDSSideNavSection, XDSSideNavItem} from '@xds/core/SideNav';
 import {XDSButton} from '@xds/core/Button';
 import {XDSIcon} from '@xds/core/Icon';
-
-const HomeIcon = (p: SVGProps<SVGSVGElement>) => (
-  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round" {...p}>
-    <path d="M3 9.5L12 3l9 6.5V20a1 1 0 01-1 1H4a1 1 0 01-1-1V9.5z" />
-    <path d="M9 21V12h6v9" />
-  </svg>
-);
-
-const FolderIcon = (p: SVGProps<SVGSVGElement>) => (
-  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round" {...p}>
-    <path d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
-  </svg>
-);
+import {HomeIcon, FolderIcon} from '@heroicons/react/24/outline';
 
 export default function MobileNavWithoutTitleMobileNav() {
   const [isOpen, setIsOpen] = useState(false);
@@ -39,11 +26,7 @@ export default function MobileNavWithoutTitleMobileNav() {
             isSelected
             href="/dashboard"
           />
-          <XDSSideNavItem
-            label="Projects"
-            icon={FolderIcon}
-            href="/projects"
-          />
+          <XDSSideNavItem label="Projects" icon={FolderIcon} href="/projects" />
         </XDSSideNavSection>
       </XDSMobileNav>
     </>

--- a/packages/core/src/MobileNav/MobileNav.doc.mjs
+++ b/packages/core/src/MobileNav/MobileNav.doc.mjs
@@ -52,11 +52,11 @@ export const docs = {
   },
   usage: {
     description:
-      'MobileNav is a slide-out drawer overlay for mobile navigation. It serves as the mobile counterpart to SideNav and accepts the same children. Use it on mobile viewports where a persistent side navigation is not practical.',
+      'A slide-out drawer for mobile navigation. MobileNav is the mobile counterpart to SideNav and accepts the same children. Use it on narrow viewports where a persistent sidebar is not practical.',
     bestPractices: [
-      { guidance: true, description: 'Share the same navigation children between MobileNav and SideNav by extracting them into a variable.' },
-      { guidance: true, description: 'Provide a descriptive title to improve context and screen reader clarity.' },
-      { guidance: false, description: 'Use MobileNav on desktop viewports where a persistent SideNav would be more appropriate.' },
+      { guidance: true, description: 'Share the same nav items between MobileNav and SideNav by extracting them into a variable.' },
+      { guidance: true, description: 'Provide a title when the drawer\'s purpose is not obvious from its content.' },
+      { guidance: false, description: 'Use MobileNav on desktop — use a persistent SideNav instead.' },
     ],
   },
 };
@@ -111,11 +111,11 @@ export const docsZh = {
   },
   usage: {
     description:
-      'MobileNav is a slide-out drawer overlay for mobile navigation. It serves as the mobile counterpart to SideNav and accepts the same children. Use it on mobile viewports where a persistent side navigation is not practical.',
+      'A slide-out drawer for mobile navigation. MobileNav is the mobile counterpart to SideNav and accepts the same children. Use it on narrow viewports where a persistent sidebar is not practical.',
     bestPractices: [
-      { guidance: true, description: 'Share the same navigation children between MobileNav and SideNav by extracting them into a variable.' },
-      { guidance: true, description: 'Provide a descriptive title to improve context and screen reader clarity.' },
-      { guidance: false, description: 'Use MobileNav on desktop viewports where a persistent SideNav would be more appropriate.' },
+      { guidance: true, description: 'Share the same nav items between MobileNav and SideNav by extracting them into a variable.' },
+      { guidance: true, description: 'Provide a title when the drawer\'s purpose is not obvious from its content.' },
+      { guidance: false, description: 'Use MobileNav on desktop — use a persistent SideNav instead.' },
     ],
   },
 };
@@ -126,11 +126,11 @@ export const docsDense = {
     'Slide-out drawer overlay for mobile navigation. Mobile counterpart to XDSSideNav; accepts same children (XDSSideNavSection, XDSSideNavItem, or any ReactNode).',
   usage: {
     description:
-      'MobileNav is a slide-out drawer overlay for mobile navigation. It serves as the mobile counterpart to SideNav and accepts the same children. Use it on mobile viewports where a persistent side navigation is not practical.',
+      'A slide-out drawer for mobile navigation. MobileNav is the mobile counterpart to SideNav and accepts the same children. Use it on narrow viewports where a persistent sidebar is not practical.',
     bestPractices: [
-      { guidance: true, description: 'Share the same navigation children between MobileNav and SideNav by extracting them into a variable.' },
-      { guidance: true, description: 'Provide a descriptive title to improve context and screen reader clarity.' },
-      { guidance: false, description: 'Use MobileNav on desktop viewports where a persistent SideNav would be more appropriate.' },
+      { guidance: true, description: 'Share the same nav items between MobileNav and SideNav by extracting them into a variable.' },
+      { guidance: true, description: 'Provide a title when the drawer\'s purpose is not obvious from its content.' },
+      { guidance: false, description: 'Use MobileNav on desktop — use a persistent SideNav instead.' },
     ],
   },
   propDescriptions: {


### PR DESCRIPTION
## Summary
- Tighten usage description and best practices language
- Replace inline SVG icon components with Heroicon imports in all 3 blocks (fixes icon purity)
- Tighten block descriptions

## Test plan
- [ ] Verify `npx xds component MobileNav` output reflects updated usage and best practices
- [ ] Verify all 3 MobileNav blocks render correctly in the sandbox
- [ ] Check icons render correctly after switching from inline SVG to Heroicons