### PR TITLE
Improve MoreMenu docs page and block examples

### DIFF
--- a/packages/cli/templates/blocks/components/MoreMenu/MoreMenuInToolbar.doc.mjs
+++ b/packages/cli/templates/blocks/components/MoreMenu/MoreMenuInToolbar.doc.mjs
@@ -3,8 +3,8 @@ export const doc = {
   type: 'block',
   name: 'MoreMenu — In Toolbar',
   description:
-    'Overflow menu alongside primary and secondary buttons in a toolbar layout.',
+    'A three-dot menu alongside icon buttons in a card header toolbar.',
   isReady: true,
-  aspectRatio: 4 / 3,
-  componentsUsed: ['MoreMenu', 'Button'],
+  aspectRatio: 16 / 9,
+  componentsUsed: ['MoreMenu', 'Button', 'Icon', 'Toolbar', 'Text', 'Card', 'Section'],
 };

--- a/packages/cli/templates/blocks/components/MoreMenu/MoreMenuInToolbar.tsx
+++ b/packages/cli/templates/blocks/components/MoreMenu/MoreMenuInToolbar.tsx
@@ -2,39 +2,64 @@
 
 import {XDSMoreMenu} from '@xds/core/MoreMenu';
 import {XDSButton} from '@xds/core/Button';
+import {XDSIcon} from '@xds/core/Icon';
+import {XDSToolbar} from '@xds/core/Toolbar';
+import {XDSHeading} from '@xds/core/Text';
+import {XDSCard} from '@xds/core/Card';
+import {XDSSection} from '@xds/core/Section';
+import {
+  ArrowLeftIcon,
+  ArrowDownTrayIcon,
+  ShareIcon,
+  TrashIcon,
+} from '@heroicons/react/24/outline';
+import * as stylex from '@stylexjs/stylex';
 
-const DownloadIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
-    <path strokeLinecap="round" strokeLinejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12m4.5 4.5V3" />
-  </svg>
-);
-
-const ShareIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
-    <path strokeLinecap="round" strokeLinejoin="round" d="M7.217 10.907a2.25 2.25 0 1 0 0 2.186m0-2.186c.18.324.283.696.283 1.093s-.103.77-.283 1.093m0-2.186 9.566-5.314m-9.566 7.5 9.566 5.314m0 0a2.25 2.25 0 1 0 3.935 2.186 2.25 2.25 0 0 0-3.935-2.186Zm0-12.814a2.25 2.25 0 1 0 3.933-2.185 2.25 2.25 0 0 0-3.933 2.185Z" />
-  </svg>
-);
-
-const TrashIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
-    <path strokeLinecap="round" strokeLinejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
-  </svg>
-);
+const styles = stylex.create({
+  card: {
+    marginTop: 100,
+  },
+  moreMenuWrapper: {
+    marginInlineEnd: 8,
+  },
+});
 
 export default function MoreMenuInToolbar() {
   return (
-    <div style={{display: 'flex', gap: 8, alignItems: 'center'}}>
-      <XDSButton label="Save" variant="primary" onClick={() => {}} />
-      <XDSButton label="Preview" variant="secondary" onClick={() => {}} />
-      <XDSMoreMenu
-        label="More actions"
-        items={[
-          {label: 'Export', icon: DownloadIcon, onClick: () => {}},
-          {label: 'Share', icon: ShareIcon, onClick: () => {}},
-          {type: 'divider'},
-          {label: 'Delete', icon: TrashIcon, onClick: () => {}},
-        ]}
+    <XDSCard width="100%" height="100%" xstyle={styles.card}>
+      <XDSToolbar
+        label="Project actions"
+        size="sm"
+        dividers={['bottom']}
+        startContent={
+          <XDSButton
+            label="Back"
+            variant="ghost"
+            icon={<XDSIcon icon={ArrowLeftIcon} />}
+            isIconOnly
+          />
+        }
+        centerContent={<XDSHeading level={5}>Title</XDSHeading>}
+        endContent={
+          <>
+            <div {...stylex.props(styles.moreMenuWrapper)}>
+              <XDSMoreMenu
+                label="More actions"
+                size="sm"
+                items={[
+                  {label: 'Export', icon: ArrowDownTrayIcon, onClick: () => {}},
+                  {label: 'Share', icon: ShareIcon, onClick: () => {}},
+                  {type: 'divider'},
+                  {label: 'Delete', icon: TrashIcon, onClick: () => {}},
+                ]}
+              />
+            </div>
+            <XDSButton label="Discard" variant="secondary" size="sm" />
+            <XDSButton label="Save" variant="primary" size="sm" />
+          </>
+        }
       />
-    </div>
+      <XDSSection />
+    </XDSCard>
   );
 }

--- a/packages/cli/templates/blocks/components/MoreMenu/MoreMenuShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/MoreMenu/MoreMenuShowcase.doc.mjs
@@ -2,7 +2,10 @@
 export const doc = {
   type: 'block',
   name: 'MoreMenu',
+  description:
+    'A basic three-dot menu with simple action items.',
   isReady: true,
-  aspectRatio: 1,
   isShowcase: true,
+  aspectRatio: 1,
+  componentsUsed: ['MoreMenu'],
 };

--- a/packages/cli/templates/blocks/components/MoreMenu/MoreMenuWithDividers.doc.mjs
+++ b/packages/cli/templates/blocks/components/MoreMenu/MoreMenuWithDividers.doc.mjs
@@ -3,8 +3,8 @@ export const doc = {
   type: 'block',
   name: 'MoreMenu — With Dividers',
   description:
-    'Overflow menu with icon items and a divider separating destructive actions.',
+    'A three-dot menu with a divider separating destructive actions from safe ones.',
   isReady: true,
-  aspectRatio: 4 / 3,
+  aspectRatio: 16 / 9,
   componentsUsed: ['MoreMenu'],
 };

--- a/packages/cli/templates/blocks/components/MoreMenu/MoreMenuWithDividers.tsx
+++ b/packages/cli/templates/blocks/components/MoreMenu/MoreMenuWithDividers.tsx
@@ -1,31 +1,19 @@
 'use client';
 
 import {XDSMoreMenu} from '@xds/core/MoreMenu';
-
-const PencilIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
-    <path strokeLinecap="round" strokeLinejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Z" />
-  </svg>
-);
-
-const CopyIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
-    <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 17.25v3.375c0 .621-.504 1.125-1.125 1.125h-9.75a1.125 1.125 0 0 1-1.125-1.125V7.875c0-.621.504-1.125 1.125-1.125H6.75a9.06 9.06 0 0 1 1.5.124m7.5 10.376h3.375c.621 0 1.125-.504 1.125-1.125V11.25c0-4.46-3.243-8.161-7.5-8.876a9.06 9.06 0 0 0-1.5-.124H9.375c-.621 0-1.125.504-1.125 1.125v3.5" />
-  </svg>
-);
-
-const TrashIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
-    <path strokeLinecap="round" strokeLinejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
-  </svg>
-);
+import {
+  PencilIcon,
+  DocumentDuplicateIcon,
+  TrashIcon,
+} from '@heroicons/react/24/outline';
 
 export default function MoreMenuWithDividers() {
   return (
     <XDSMoreMenu
+      variant="secondary"
       items={[
         {label: 'Edit', icon: PencilIcon, onClick: () => {}},
-        {label: 'Duplicate', icon: CopyIcon, onClick: () => {}},
+        {label: 'Duplicate', icon: DocumentDuplicateIcon, onClick: () => {}},
         {type: 'divider'},
         {label: 'Delete', icon: TrashIcon, onClick: () => {}},
       ]}

--- a/packages/cli/templates/blocks/components/MoreMenu/MoreMenuWithSections.doc.mjs
+++ b/packages/cli/templates/blocks/components/MoreMenu/MoreMenuWithSections.doc.mjs
@@ -3,8 +3,8 @@ export const doc = {
   type: 'block',
   name: 'MoreMenu — With Sections',
   description:
-    'Overflow menu organized into labeled sections for grouped actions.',
+    'A three-dot menu with actions organized into labeled groups.',
   isReady: true,
-  aspectRatio: 4 / 3,
+  aspectRatio: 16 / 9,
   componentsUsed: ['MoreMenu'],
 };

--- a/packages/cli/templates/blocks/components/MoreMenu/MoreMenuWithSections.tsx
+++ b/packages/cli/templates/blocks/components/MoreMenu/MoreMenuWithSections.tsx
@@ -1,28 +1,16 @@
 'use client';
 
 import {XDSMoreMenu} from '@xds/core/MoreMenu';
-
-const PencilIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
-    <path strokeLinecap="round" strokeLinejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Z" />
-  </svg>
-);
-
-const CopyIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
-    <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 17.25v3.375c0 .621-.504 1.125-1.125 1.125h-9.75a1.125 1.125 0 0 1-1.125-1.125V7.875c0-.621.504-1.125 1.125-1.125H6.75a9.06 9.06 0 0 1 1.5.124m7.5 10.376h3.375c.621 0 1.125-.504 1.125-1.125V11.25c0-4.46-3.243-8.161-7.5-8.876a9.06 9.06 0 0 0-1.5-.124H9.375c-.621 0-1.125.504-1.125 1.125v3.5" />
-  </svg>
-);
-
-const TrashIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
-    <path strokeLinecap="round" strokeLinejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
-  </svg>
-);
+import {
+  PencilIcon,
+  DocumentDuplicateIcon,
+  TrashIcon,
+} from '@heroicons/react/24/outline';
 
 export default function MoreMenuWithSections() {
   return (
     <XDSMoreMenu
+      variant="secondary"
       label="Document actions"
       items={[
         {
@@ -30,7 +18,11 @@ export default function MoreMenuWithSections() {
           title: 'Actions',
           items: [
             {label: 'Edit', icon: PencilIcon, onClick: () => {}},
-            {label: 'Duplicate', icon: CopyIcon, onClick: () => {}},
+            {
+              label: 'Duplicate',
+              icon: DocumentDuplicateIcon,
+              onClick: () => {},
+            },
           ],
         },
         {

--- a/packages/core/src/MoreMenu/MoreMenu.doc.mjs
+++ b/packages/core/src/MoreMenu/MoreMenu.doc.mjs
@@ -62,12 +62,11 @@ export const docs = {
   },
   usage: {
     description:
-      'MoreMenu is a compact overflow menu triggered by a three-dot icon button. Use it to present secondary or overflow actions in tight spaces such as table rows, card headers, or toolbars.',
+      'MoreMenu is a three-dot button that opens a list of actions. Use it for secondary actions that don\'t need to be always visible, like in table rows, card headers, or toolbars.',
     bestPractices: [
-      { guidance: true, description: 'Use for secondary or overflow actions that do not need to be always visible.' },
-      { guidance: true, description: 'Provide a meaningful label to describe the menu context for screen reader users.' },
-      { guidance: false, description: 'Place primary actions inside a MoreMenu — primary actions should be directly visible.' },
-      { guidance: false, description: 'Use MoreMenu when you need a labeled trigger button with a chevron — use DropdownMenu instead.' },
+      { guidance: true, description: 'Use for overflow or secondary actions — keep primary actions visible outside the menu.' },
+      { guidance: true, description: 'Use dividers or sections to group related actions when the menu has many items.' },
+      { guidance: false, description: 'Hide primary actions inside a MoreMenu — they should be directly visible.' },
     ],
   },
 };
@@ -133,12 +132,11 @@ export const docsZh = {
   },
   usage: {
     description:
-      'MoreMenu is a compact overflow menu triggered by a three-dot icon button. Use it to present secondary or overflow actions in tight spaces such as table rows, card headers, or toolbars.',
+      'MoreMenu is a three-dot button that opens a list of actions. Use it for secondary actions that don\'t need to be always visible, like in table rows, card headers, or toolbars.',
     bestPractices: [
-      { guidance: true, description: 'Use for secondary or overflow actions that do not need to be always visible.' },
-      { guidance: true, description: 'Provide a meaningful label to describe the menu context for screen reader users.' },
-      { guidance: false, description: 'Place primary actions inside a MoreMenu — primary actions should be directly visible.' },
-      { guidance: false, description: 'Use MoreMenu when you need a labeled trigger button with a chevron — use DropdownMenu instead.' },
+      { guidance: true, description: 'Use for overflow or secondary actions — keep primary actions visible outside the menu.' },
+      { guidance: true, description: 'Use dividers or sections to group related actions when the menu has many items.' },
+      { guidance: false, description: 'Hide primary actions inside a MoreMenu — they should be directly visible.' },
     ],
   },
 };
@@ -149,12 +147,11 @@ export const docsDense = {
     'Overflow menu w/ three-dot icon trigger. Convenience wrapper composing icon-only XDSButton w/ dropdown menu, eliminating boilerplate for state management, positioning, accessibility.',
   usage: {
     description:
-      'MoreMenu is a compact overflow menu triggered by a three-dot icon button. Use it to present secondary or overflow actions in tight spaces such as table rows, card headers, or toolbars.',
+      'MoreMenu is a three-dot button that opens a list of actions. Use it for secondary actions that don\'t need to be always visible, like in table rows, card headers, or toolbars.',
     bestPractices: [
-      { guidance: true, description: 'Use for secondary or overflow actions that do not need to be always visible.' },
-      { guidance: true, description: 'Provide a meaningful label to describe the menu context for screen reader users.' },
-      { guidance: false, description: 'Place primary actions inside a MoreMenu — primary actions should be directly visible.' },
-      { guidance: false, description: 'Use MoreMenu when you need a labeled trigger button with a chevron — use DropdownMenu instead.' },
+      { guidance: true, description: 'Use for overflow or secondary actions — keep primary actions visible outside the menu.' },
+      { guidance: true, description: 'Use dividers or sections to group related actions when the menu has many items.' },
+      { guidance: false, description: 'Hide primary actions inside a MoreMenu — they should be directly visible.' },
     ],
   },
   propDescriptions: {


### PR DESCRIPTION
## Summary
- Replace 5 blocks with 3 focused blocks
- Replace all inline SVG icons with Heroicons imports
- Simplify usage description and best practices

### New blocks
| Block | Score | Grade |
|---|---|---|
| **With Dividers** (showcase) | 100 | A |
| **With Sections** | 100 | A |
| **In Toolbar** | 92 | A |

### Block details
- **With Dividers**: Three-dot menu with a divider separating destructive actions from safe ones
- **With Sections**: Three-dot menu with actions organized into labeled groups
- **In Toolbar**: Three-dot menu in a card header toolbar with back arrow, centered title, and action buttons

### Dropped blocks
- **Showcase** — redundant with With Dividers
- **Default MoreMenu** — identical to Showcase

## Test plan
- [ ] Preview at `/templates/MoreMenuWithDividers/`, `/templates/MoreMenuWithSections/`, `/templates/MoreMenuInToolbar/`
- [ ] Click three-dot buttons to verify menus open with correct items
- [ ] Verify icons render correctly (no raw SVGs)