### PR TITLE
fix: component audit — data-autofocus on BaseTypeahead, displayName on TreeListBranches

### DIFF
--- a/packages/core/src/TreeList/XDSTreeListBranches.tsx
+++ b/packages/core/src/TreeList/XDSTreeListBranches.tsx
@@ -107,3 +107,5 @@ export function XDSTreeListBranches({
   );
 }
 
+
+XDSTreeListBranches.displayName = 'XDSTreeListBranches';

--- a/packages/core/src/Typeahead/XDSBaseTypeahead.tsx
+++ b/packages/core/src/Typeahead/XDSBaseTypeahead.tsx
@@ -612,6 +612,7 @@ export const XDSBaseTypeahead = function XDSBaseTypeahead<
         placeholder={placeholder}
         disabled={isDisabled}
         autoFocus={hasAutoFocus}
+        data-autofocus={hasAutoFocus || undefined}
         autoComplete="off"
         {...stylex.props(
           styles.input,


### PR DESCRIPTION
## Night Watch — Component Auditor (2026-04-23)

### Components Audited
Token, Tokenizer, Tooltip, TopNav, TreeList

### Fixes

**1. XDSBaseTypeahead: add `data-autofocus` attribute** (`a11y-gap`)
- **File:** `packages/core/src/Typeahead/XDSBaseTypeahead.tsx`
- Sets `autoFocus={hasAutoFocus}` but was missing `data-autofocus={hasAutoFocus || undefined}` on the same input element
- XDSDialog uses `data-autofocus` to re-focus elements after `showModal()` — without it, React's `autoFocus` fires before the dialog is visible and silently fails (see PR #1044)
- Affects both XDSTokenizer and XDSTypeahead (both pass `hasAutoFocus` to BaseTypeahead)

**2. XDSTreeListBranches: add missing `displayName`** (`structure-issue`)
- **File:** `packages/core/src/TreeList/XDSTreeListBranches.tsx`
- Internal component but still best practice for React DevTools

### Needs Review (not fixed in this PR)

**Token & Tokenizer props don't extend `XDSBaseProps`** — both manually declare `xstyle`, `className`, `style`, `data-testid` instead of extending the shared base interface. This means they're missing standard event handler and aria attribute passthroughs. Flagging for human review since extending XDSBaseProps would change the public API surface (Token has special onClick behavior).

### Audit Summary

| Component | CSS Vars | xdsClassName | Reuse | Naming | Types | Structure | Input | A11y | Exports |
|-----------|----------|-------------|-------|--------|-------|-----------|-------|------|---------|
| Token | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️ BaseProps | — | ✅ | ✅ |
| Tokenizer | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️ BaseProps | ✅ | ⚠️ data-autofocus | ✅ |
| Tooltip | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | — | ✅ | ✅ |
| TopNav | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | — | ✅ | ✅ |
| TreeList | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️ displayName | — | ✅ | ✅ |

---
