### PR TITLE
feat(vibe-tests): add xds-tailwind as 4th vibe test target

### DIFF
--- a/internal/vibe-tests/README.md
+++ b/internal/vibe-tests/README.md
@@ -23,64 +23,38 @@ Prompts live in [`test-sets/default.json`](test-sets/default.json). Each prompt 
 
 ## Sub-Agent Prompts
 
-Each target gets an equivalent prompt. The only thing that varies is the design system and where to find its docs.
+Each target gets an equivalent prompt. The only thing that varies is the design system name and the project environment.
 
-**XDS agent sees:**
+**All library targets see the same structure:**
 
 ```
-You are generating React/TSX code using the XDS design system.
-
-Read the package README at node_modules/@xds/core/README.md for how to look up
-component docs. Use what you find there to discover the components you need.
+You are generating React/TSX code using <system name>.
+Your project is at <project dir>. Explore it to find available components.
 
 ## Task
 
-Build a shipping method selector with three options: Standard (free, 5-7 days),
-Express ($9.99, 2-3 days), Overnight ($19.99, next day)
-
-## Output
-
-Write the TSX code to: internal/vibe-tests/results/<id>/results/fwc-6.tsx
-Write metadata to: internal/vibe-tests/results/<id>/results/fwc-6.json
-
-Metadata: {"completedAt": "<ISO timestamp>", "docsRead": [<component names you looked up>]}
-Write ONLY valid TSX. No markdown fences, no explanation.
-```
-
-**Baseline (shadcn) agent sees:**
-
-```
-You are generating React/TSX code using shadcn/ui components with Tailwind CSS.
-
-Read the baseline docs at internal/vibe-tests/.baseline-docs/
-and AGENTS.baseline.md for component guidance.
-
-## Task
-
-Build a shipping method selector with three options: Standard (free, 5-7 days),
-Express ($9.99, 2-3 days), Overnight ($19.99, next day)
+<prompt text>
 
 ## Output
 ...same format...
 ```
 
-**HTML agent sees:**
+**HTML target sees:**
 
 ```
 You are generating React/TSX code using ONLY plain HTML elements and inline CSS.
-Do NOT use any component library. Use standard HTML elements (div, button, input, etc.)
-with inline styles or a styles object.
+Your project is at <project dir>. Do NOT use any component library.
+Use standard HTML elements (div, button, input, etc.) with inline styles or a styles object.
 
 ## Task
 
-Build a shipping method selector with three options: Standard (free, 5-7 days),
-Express ($9.99, 2-3 days), Overnight ($19.99, next day)
+<prompt text>
 
 ## Output
 ...same format...
 ```
 
-Note: no system-specific rules, no expected components, no pre-built commands. The agent discovers what it needs through the system's own docs.
+Note: no system-specific rules, no expected components, no pre-built commands. The agent discovers what it needs through the project's own files (README, package.json, symlinked sources).
 
 ## Checker Protocol
 
@@ -151,6 +125,7 @@ These are intentional and documented — they slightly favor baseline, making XD
 
 - **Efficiency:** Tailwind's single-line `className` gets a lower styling-ratio than XDS's multi-line `stylex.create` blocks, despite encoding more decisions
 - **Maintainability:** Tailwind scale values (`p-4`, `text-sm`) count as semantic, which is generous compared to how raw `16px` is counted for HTML
+- **XDS+Tailwind scoring:** The hybrid target counts styling decisions from both XDS props and Tailwind classes. This may inflate its decision count relative to pure XDS, but accurately reflects the code's actual styling surface area
 
 ## Directory Structure
 
@@ -159,7 +134,7 @@ internal/vibe-tests/
 ├── test-sets/           # Prompt batteries (JSON)
 ├── src/                 # Runner scripts and evaluation
 │   ├── setup-iteration.mjs   # Single-target iteration setup
-│   ├── setup-nightly.mjs     # 3-target nightly setup
+│   ├── setup-nightly.mjs     # 4-target nightly setup
 │   ├── universal-eval.ts     # Static analysis scoring (5 dimensions)
 │   ├── universal-aggregate.ts # Score aggregation
 │   ├── universal-compare.ts  # Cross-target comparison

--- a/internal/vibe-tests/environments/project-xds-tailwind/README.md
+++ b/internal/vibe-tests/environments/project-xds-tailwind/README.md
@@ -1,0 +1,55 @@
+# XDS + Tailwind CSS
+
+This project uses XDS components for structured UI (cards, buttons, inputs, etc.)
+and Tailwind CSS utilities for layout, spacing, and custom styling.
+
+## Usage Pattern
+
+Use XDS components for interactive/semantic elements:
+
+```tsx
+import {XDSCard, XDSButton, XDSVStack, XDSHeading, XDSText} from '@xds/core';
+```
+
+Use Tailwind utility classes for layout and customization:
+
+```tsx
+<main className="flex min-h-screen items-center p-8">
+  <XDSCard className="max-w-md">
+    <XDSVStack gap={4}>
+      <XDSHeading level={2}>Dashboard</XDSHeading>
+      <XDSButton label="Save" variant="primary" />
+    </XDSVStack>
+  </XDSCard>
+</main>
+```
+
+## XDS Tailwind Bridge
+
+XDS tokens are available as native Tailwind utilities. Instead of:
+
+```tsx
+<div className="bg-[var(--color-background-surface)]">
+```
+
+Write:
+
+```tsx
+<div className="bg-surface text-primary rounded-lg p-4">
+```
+
+Available token utilities include: `text-primary`, `text-secondary`, `bg-surface`,
+`bg-card`, `bg-muted`, `border-default`, `text-error`, `bg-success`, and many more.
+
+## Component Docs
+
+Run `npx xds component <Name>` to look up component props and usage.
+Run `npx xds component --list` to see all available components.
+
+## Key Rules
+
+- XDS components accept `className` — Tailwind utilities override XDS styles
+- Use XDS components for semantic UI (buttons, cards, inputs, headings, text)
+- Use Tailwind for layout (`flex`, `grid`, `gap-*`, `p-*`, `m-*`)
+- Use bridge tokens (`bg-surface`, `text-primary`) instead of raw CSS variables
+- All XDS components are imported from `@xds/core`

--- a/internal/vibe-tests/environments/project-xds-tailwind/globals.css
+++ b/internal/vibe-tests/environments/project-xds-tailwind/globals.css
@@ -1,0 +1,9 @@
+@layer reset, theme, base, xds-base, xds-theme, components, utilities;
+
+@import "tailwindcss/theme.css" layer(theme);
+@import "tailwindcss/preflight.css" layer(base);
+@import "@xds/core/reset.css";
+@import "@xds/core/xds.css";
+@import "@xds/theme-default/theme.css";
+@import "@xds/core/tailwind-theme.css";
+@import "tailwindcss/utilities.css" layer(utilities);

--- a/internal/vibe-tests/environments/project-xds-tailwind/package.json
+++ b/internal/vibe-tests/environments/project-xds-tailwind/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "my-app",
+  "private": true,
+  "dependencies": {
+    "@xds/core": "*",
+    "@xds/theme-default": "*",
+    "react": "^19",
+    "react-dom": "^19",
+    "tailwindcss": "^4"
+  },
+  "devDependencies": {
+    "@xds/cli": "*",
+    "@tailwindcss/postcss": "^4"
+  }
+}

--- a/internal/vibe-tests/src/build-previews.ts
+++ b/internal/vibe-tests/src/build-previews.ts
@@ -146,12 +146,16 @@ function createEntryFile(
   const entryPath = path.join(tmpDir, 'entry.tsx');
 
   // For XDS and XDS+Tailwind targets, wrap in theme provider and import reset
-  if (target === 'xds') {
+  if (target === 'xds' || target === 'xds-tailwind') {
+    const tailwindImport =
+      target === 'xds-tailwind'
+        ? `\nimport '${path.join(REPO_ROOT, 'packages/core/src/tailwind-theme.css').replace(/\\/g, '/')}';`
+        : '';
     fs.writeFileSync(
       entryPath,
       `import React from 'react';
 import {createRoot} from 'react-dom/client';
-import '@xds/core/reset.css';
+import '@xds/core/reset.css';${tailwindImport}
 import {XDSTheme} from '@xds/core/theme';
 import {defaultTheme} from '@xds/theme/default';
 import Component from '${componentPath.replace(/\\/g, '/')}';
@@ -193,9 +197,9 @@ function createIndexHtml(
 ): string {
   const htmlPath = path.join(tmpDir, 'index.html');
 
-  // Baseline previews need Tailwind CSS for styling
+  // Baseline and xds-tailwind previews need Tailwind CSS for styling
   const tailwindCdn =
-    target === 'baseline'
+    target === 'baseline' || target === 'xds-tailwind'
       ? `\n  <script src="https://cdn.tailwindcss.com"></script>
   <style>
     :root {
@@ -284,7 +288,7 @@ function createViteConfig(tmpDir: string, target: string): string {
   // type casts). We use a pre-transform plugin to strip TypeScript type
   // assertions before StyleX processes the file.
   const plugins =
-    target === 'xds'
+    target === 'xds' || target === 'xds-tailwind'
       ? `
     {
       name: 'stylex-inline-vars',
@@ -356,7 +360,7 @@ function createViteConfig(tmpDir: string, target: string): string {
     viteSingleFile(),`;
 
   const imports =
-    target === 'xds'
+    target === 'xds' || target === 'xds-tailwind'
       ? `import stylex from '@stylexjs/unplugin';
 import react from '@vitejs/plugin-react';
 import {viteSingleFile} from 'vite-plugin-singlefile';`
@@ -380,7 +384,7 @@ import {viteSingleFile} from 'vite-plugin-singlefile';`;
     },`;
 
   const aliases =
-    target === 'xds'
+    target === 'xds' || target === 'xds-tailwind'
       ? xdsAliases
       : target === 'baseline'
         ? `
@@ -713,7 +717,7 @@ async function main() {
       console.log(`  📄 ${promptId} (${target})...`);
 
       // Auto-fix missing XDS imports before building
-      if (target === 'xds') {
+      if (target === 'xds' || target === 'xds-tailwind') {
         const autoImported = fixMissingXDSImports(componentPath);
         if (autoImported.length > 0) {
           console.log(`  ⚡ Auto-imported: ${autoImported.join(', ')}`);
@@ -728,7 +732,7 @@ async function main() {
       const ok = buildPreview(componentPath, target, promptId, previewPath);
       if (ok) {
         // Post-build validation: ensure no unresolved XDS references
-        if (target === 'xds') {
+        if (target === 'xds' || target === 'xds-tailwind') {
           const unresolved = validatePreviewHtml(previewPath);
           if (unresolved.length > 0) {
             console.error(

--- a/internal/vibe-tests/src/setup-environment.mjs
+++ b/internal/vibe-tests/src/setup-environment.mjs
@@ -36,7 +36,7 @@ function copyFile(src, dest) {
  * Create an isolated project directory for a single agent.
  * Returns the absolute path to the project directory.
  *
- * @param {'xds' | 'baseline' | 'html'} target
+ * @param {'xds' | 'xds-tailwind' | 'baseline' | 'html'} target
  * @param {string} iterDir - The iteration results directory
  * @param {string} promptId - The prompt ID (used to name the clone)
  */
@@ -44,17 +44,22 @@ export function createAgentProject(target, iterDir, promptId) {
   const projectDir = path.join(iterDir, 'projects', promptId);
   ensureDir(projectDir);
 
-  const templateMap = {xds: 'project-xds', baseline: 'project-baseline', html: 'project-html'};
+  const templateMap = {
+    xds: 'project-xds',
+    'xds-tailwind': 'project-xds-tailwind',
+    baseline: 'project-baseline',
+    html: 'project-html',
+  };
   const template = templateMap[target];
   if (!template) throw new Error(`Unknown target: ${target}`);
 
-  // Copy package.json from template
-  copyFile(
-    path.join(ENV_TEMPLATES, template, 'package.json'),
-    path.join(projectDir, 'package.json'),
-  );
+  // Copy template files (package.json, README, globals.css, etc.)
+  const templateDir = path.join(ENV_TEMPLATES, template);
+  for (const file of fs.readdirSync(templateDir)) {
+    copyFile(path.join(templateDir, file), path.join(projectDir, file));
+  }
 
-  if (target === 'xds') {
+  if (target === 'xds' || target === 'xds-tailwind') {
     // Symlink node_modules/@xds/core → packages/core
     const coreLink = path.join(projectDir, 'node_modules', '@xds', 'core');
     ensureDir(path.dirname(coreLink));

--- a/internal/vibe-tests/src/setup-iteration.mjs
+++ b/internal/vibe-tests/src/setup-iteration.mjs
@@ -8,6 +8,7 @@
  *
  * Usage:
  *   node internal/vibe-tests/src/setup-iteration.mjs --sample 10 --target xds
+ *   node internal/vibe-tests/src/setup-iteration.mjs --sample 10 --target xds-tailwind
  *   node internal/vibe-tests/src/setup-iteration.mjs --sample 10 --target baseline
  *   node internal/vibe-tests/src/setup-iteration.mjs --sample 10 --target html
  *   node internal/vibe-tests/src/setup-iteration.mjs --sample 10 --target xds --prompts cwm-1,dd-2,fwc-6
@@ -113,6 +114,25 @@ Metadata: {"completedAt": "<ISO timestamp>", "docsRead": [<docs you read>]}
 Write ONLY valid TSX. No markdown fences, no explanation.`;
 }
 
+function generateXdsTailwindTaskPrompt(prompt, iterDir) {
+  return `You are generating React/TSX code using the XDS design system with Tailwind CSS.
+
+Read the package README at ${path.resolve(VIBE_DIR, '../../packages/core/README.md')} for how to look up
+component docs. Use what you find there to discover the components you need.
+
+## Task
+
+${prompt.prompt}
+
+## Output
+
+Write the TSX code to: ${path.join(iterDir, 'results', `${prompt.id}.tsx`)}
+Write metadata to: ${path.join(iterDir, 'results', `${prompt.id}.json`)}
+
+Metadata: {"completedAt": "<ISO timestamp>", "docsRead": [<component names you looked up>]}
+Write ONLY valid TSX. No markdown fences, no explanation.`;
+}
+
 function generateHtmlTaskPrompt(prompt, iterDir) {
   return `You are generating React/TSX code using ONLY plain HTML elements and inline CSS.
 Do NOT use any component library. Use standard HTML elements (div, button, input, etc.)
@@ -144,6 +164,7 @@ const promptFilter = promptsIdx !== -1 ? args[promptsIdx + 1].split(',') : null;
 console.log(`\n🧪 Setup Vibe Test Iteration`);
 console.log(`   Target: ${target}, Sample: ${sample}`);
 if (target === 'xds') console.log(`   Mode: CLI-retrieval (MacBook)\n`);
+else if (target === 'xds-tailwind') console.log(`   Mode: CLI-retrieval + Tailwind (MacBook)\n`);
 else console.log(`   Mode: ${target === 'baseline' ? 'baseline-docs' : 'no docs'}\n`);
 
 // 1. Load and filter/sample prompts
@@ -173,7 +194,7 @@ const manifest = {
     persona: 'naive',
     holdout: false,
     degradation: false,
-    cliRetrieval: target === 'xds',
+    cliRetrieval: target === 'xds' || target === 'xds-tailwind',
   },
   prompts: prompts.map(p => ({
     id: p.id,
@@ -187,6 +208,7 @@ const manifest = {
 fs.writeFileSync(path.join(iterDir, 'manifest.json'), JSON.stringify(manifest, null, 2));
 
 const generateTaskPrompt = target === 'xds' ? generateXdsTaskPrompt
+  : target === 'xds-tailwind' ? generateXdsTailwindTaskPrompt
   : target === 'baseline' ? generateBaselineTaskPrompt
   : generateHtmlTaskPrompt;
 
@@ -216,8 +238,8 @@ console.log(`   Dir: ${iterDir}`);
 console.log(`   ${prompts.length} tasks created`);
 console.log(`   Prompt IDs: ${prompts.map(p => p.id).join(',')}\n`);
 
-if (target === 'xds') {
-  console.log(`## Sub-agent spawn pattern (XDS with CLI retrieval):\n`);
+if (target === 'xds' || target === 'xds-tailwind') {
+  console.log(`## Sub-agent spawn pattern (${target} with CLI retrieval):\n`);
   console.log(`Each agent needs: node "cli:MacBook-Pro-2" for CLI, workspace for file I/O\n`);
 } else if (target === 'baseline') {
   console.log(`## Sub-agent spawn pattern (baseline):\n`);

--- a/internal/vibe-tests/src/setup-nightly.mjs
+++ b/internal/vibe-tests/src/setup-nightly.mjs
@@ -2,14 +2,15 @@
 /**
  * @file setup-nightly.mjs
  * 
- * Sets up a complete nightly vibe test run: 3 iterations (xds, baseline, html)
- * using the same prompts. XDS tasks include CLI-retrieval instructions.
+ * Sets up a complete nightly vibe test run: 4 iterations
+ * (xds, xds-tailwind, baseline, html) using the same prompts.
+ * XDS and XDS+Tailwind tasks include CLI-retrieval instructions.
  *
  * Usage:
  *   node internal/vibe-tests/src/setup-nightly.mjs
  *   node internal/vibe-tests/src/setup-nightly.mjs --sample 5
  *
- * Output: prints JSON with all three iteration IDs and prompt IDs
+ * Output: prints JSON with all four iteration IDs and prompt IDs
  * for the nightly runner to use when spawning sub-agents.
  */
 
@@ -81,7 +82,24 @@ function samplePrompts(prompts, n) {
 
 function generateXdsTaskPrompt(prompt, projectDir) {
   return `You are generating React/TSX code using the XDS design system.
-Your project is at ${projectDir}. Explore it to find how to look up component docs.
+Your project is at ${projectDir}. Explore it to find available components.
+
+## Task
+
+${prompt.prompt}
+
+## Output
+
+Write the TSX code to: ${path.join(projectDir, `${prompt.id}.tsx`)}
+Write metadata to: ${path.join(projectDir, `${prompt.id}.json`)}
+
+Metadata: {"completedAt": "<ISO timestamp>", "docsRead": [<component names you looked up>]}
+Write ONLY valid TSX. No markdown fences, no explanation.`;
+}
+
+function generateXdsTailwindTaskPrompt(prompt, projectDir) {
+  return `You are generating React/TSX code using the XDS design system with Tailwind CSS.
+Your project is at ${projectDir}. Explore it to find available components.
 
 ## Task
 
@@ -131,7 +149,15 @@ Metadata: {"completedAt": "<ISO timestamp>", "docsRead": []}
 Write ONLY valid TSX. No markdown fences, no explanation.`;
 }
 
-function createIteration(target, prompts, generateFn) {
+const TARGET_CONFIG = {
+  xds: {label: 'XDS', generateFn: generateXdsTaskPrompt, cliRetrieval: true},
+  'xds-tailwind': {label: 'XDS+TW', generateFn: generateXdsTailwindTaskPrompt, cliRetrieval: true},
+  baseline: {label: 'Baseline', generateFn: generateBaselineTaskPrompt, cliRetrieval: false},
+  html: {label: 'HTML', generateFn: generateHtmlTaskPrompt, cliRetrieval: false},
+};
+
+function createIteration(target, prompts) {
+  const config = TARGET_CONFIG[target];
   const iterationId = generateId();
   const iterDir = path.join(RESULTS_DIR, iterationId);
   ensureDir(iterDir);
@@ -146,7 +172,7 @@ function createIteration(target, prompts, generateFn) {
       persona: 'naive',
       holdout: false,
       degradation: false,
-      cliRetrieval: target === 'xds',
+      cliRetrieval: config.cliRetrieval,
     },
     prompts: prompts.map(p => ({
       id: p.id,
@@ -164,7 +190,7 @@ function createIteration(target, prompts, generateFn) {
 
   for (const prompt of prompts) {
     const agentProject = createAgentProject(target, iterDir, prompt.id);
-    const taskPrompt = generateFn(prompt, agentProject);
+    const taskPrompt = config.generateFn(prompt, agentProject);
     const task = {
       promptId: prompt.id,
       category: prompt.category,
@@ -186,12 +212,13 @@ function createIteration(target, prompts, generateFn) {
 
 // ── Main ─────────────────────────────────────────────────────────────
 
+const TARGETS = ['xds', 'xds-tailwind', 'baseline', 'html'];
 const args = process.argv.slice(2);
 const sampleIdx = args.indexOf('--sample');
 const sample = sampleIdx !== -1 ? parseInt(args[sampleIdx + 1]) : 10;
 
 console.log(`\n🧪 Nightly Vibe Test Setup`);
-console.log(`   Sample: ${sample} prompts × 3 targets = ${sample * 3} total tasks\n`);
+console.log(`   Sample: ${sample} prompts × ${TARGETS.length} targets = ${sample * TARGETS.length} total tasks\n`);
 
 // 1. Sample prompts once — reuse across all targets
 const allPrompts = loadTestSet();
@@ -200,64 +227,64 @@ const promptIds = prompts.map(p => p.id);
 console.log(`📋 Selected ${prompts.length} prompts from ${allPrompts.length} total`);
 console.log(`   IDs: ${promptIds.join(', ')}\n`);
 
-// 2. Create iterations for all three targets
-const xds = createIteration('xds', prompts, generateXdsTaskPrompt);
-const baseline = createIteration('baseline', prompts, generateBaselineTaskPrompt);
-const html = createIteration('html', prompts, generateHtmlTaskPrompt);
+// 2. Create iterations for all targets
+const iterations = {};
+const dirs = {};
+for (const target of TARGETS) {
+  const result = createIteration(target, prompts);
+  iterations[target] = result.iterationId;
+  dirs[target] = result.iterDir;
+}
 
 console.log(`✅ All iterations ready:\n`);
-console.log(`   XDS:      ${xds.iterationId}  (${xds.iterDir})`);
-console.log(`   Baseline: ${baseline.iterationId}  (${baseline.iterDir})`);
-console.log(`   HTML:     ${html.iterationId}  (${html.iterDir})\n`);
+for (const target of TARGETS) {
+  const label = TARGET_CONFIG[target].label.padEnd(10);
+  console.log(`   ${label} ${iterations[target]}  (${dirs[target]})`);
+}
+console.log();
 
 // 3. Output structured data for the nightly runner
 const nightlyConfig = {
   createdAt: timestamp(),
   sample,
   promptIds,
-  iterations: {
-    xds: xds.iterationId,
-    baseline: baseline.iterationId,
-    html: html.iterationId,
-  },
-  dirs: {
-    xds: xds.iterDir,
-    baseline: baseline.iterDir,
-    html: html.iterDir,
-  },
+  iterations,
+  dirs,
 };
 
-// Write config for the runner to pick up
 const configPath = path.join(RESULTS_DIR, 'nightly-config.json');
 fs.writeFileSync(configPath, JSON.stringify(nightlyConfig, null, 2));
 console.log(`📄 Config written: ${configPath}\n`);
 
-// Print spawn instructions
-console.log(`## XDS agents (CLI retrieval on MacBook):\n`);
-for (const p of prompts) {
-  console.log(`  ${xds.iterDir}/tasks/${p.id}.json`);
-}
-console.log(`\n## Baseline agents (read .baseline-docs/):\n`);
-for (const p of prompts) {
-  console.log(`  ${baseline.iterDir}/tasks/${p.id}.json`);
-}
-console.log(`\n## HTML agents (no docs):\n`);
-for (const p of prompts) {
-  console.log(`  ${html.iterDir}/tasks/${p.id}.json`);
+// Print spawn instructions per target
+for (const target of TARGETS) {
+  const config = TARGET_CONFIG[target];
+  const hint = config.cliRetrieval ? '(CLI retrieval on MacBook)' :
+    target === 'baseline' ? '(read .baseline-docs/)' : '(no docs)';
+  console.log(`## ${config.label} agents ${hint}:\n`);
+  for (const p of prompts) {
+    console.log(`  ${dirs[target]}/tasks/${p.id}.json`);
+  }
+  console.log();
 }
 
-console.log(`\n## After all agents complete:\n`);
+// Post-run commands
+const allIds = TARGETS.map(t => iterations[t]);
+console.log(`## After all agents complete:\n`);
 console.log(`  # Collect results from agent project dirs`);
-console.log(`  node src/collect-results.mjs ${xds.iterationId}`);
-console.log(`  node src/collect-results.mjs ${baseline.iterationId}`);
-console.log(`  node src/collect-results.mjs ${html.iterationId}`);
+for (const id of allIds) {
+  console.log(`  node src/collect-results.mjs ${id}`);
+}
 console.log(``);
 console.log(`  # tsc type-checking`);
-console.log(`  npx tsx src/build-previews.ts --iterations "${xds.iterationId},${baseline.iterationId},${html.iterationId}" --tsc-only`);
+console.log(`  npx tsx src/build-previews.ts --iterations "${allIds.join(',')}" --tsc-only`);
 console.log(`\n  # Evaluation`);
-console.log(`  npx tsx src/universal-aggregate.ts --iteration ${xds.iterationId}`);
-console.log(`  npx tsx src/universal-aggregate.ts --iteration ${baseline.iterationId}`);
-console.log(`  npx tsx src/universal-aggregate.ts --iteration ${html.iterationId}`);
-console.log(`  npx tsx src/universal-compare.ts --xds ${xds.iterationId} --baseline ${baseline.iterationId} --html ${html.iterationId}`);
-console.log(`\n  # Deploy report`);
-console.log(`  npx tsx src/deploy-report.ts --iteration ${xds.iterationId} --baseline ${baseline.iterationId} --html ${html.iterationId}`);
+for (const id of allIds) {
+  console.log(`  npx tsx src/universal-aggregate.ts --iteration ${id}`);
+}
+console.log(`\n  # Compare (3-way: xds vs baseline vs html)`);
+console.log(`  npx tsx src/universal-compare.ts --xds ${iterations.xds} --baseline ${iterations.baseline} --html ${iterations.html}`);
+console.log(`\n  # Compare (xds vs xds-tailwind)`);
+console.log(`  npx tsx src/universal-compare.ts --xds ${iterations.xds} --baseline ${iterations['xds-tailwind']}`);
+console.log(`\n  # Deploy report (xds vs baseline)`);
+console.log(`  npx tsx src/deploy-report.ts --iteration ${iterations.xds} --baseline ${iterations.baseline}`);

--- a/internal/vibe-tests/src/universal-eval.ts
+++ b/internal/vibe-tests/src/universal-eval.ts
@@ -436,7 +436,7 @@ function countElements(code: string): number {
 function countStylingDecisions(code: string, target: string): number {
   let count = 0;
 
-  if (target === 'xds') {
+  if (target === 'xds' || target === 'xds-tailwind') {
     // Component props that are styling decisions: variant, size, gap, color, type
     count += (
       code.match(
@@ -448,7 +448,9 @@ function countStylingDecisions(code: string, target: string): number {
     for (const block of stylexBlocks) {
       count += (block.match(/\w+\s*:/g) || []).length;
     }
-  } else if (target === 'baseline') {
+  }
+
+  if (target === 'baseline' || target === 'xds-tailwind') {
     // Tailwind classes — each utility class is a decision
     const classNames = code.match(/className\s*=\s*["']([^"']+)["']/g) || [];
     for (const cn of classNames) {
@@ -462,9 +464,13 @@ function countStylingDecisions(code: string, target: string): number {
     for (const call of cnCalls) {
       count += (call.match(/["'][^"']+["']/g) || []).length;
     }
-    // Component variant/size props
-    count += (code.match(/\b(variant|size)\s*=\s*/g) || []).length;
-  } else {
+    // Component variant/size props (only count if not already counted above)
+    if (target === 'baseline') {
+      count += (code.match(/\b(variant|size)\s*=\s*/g) || []).length;
+    }
+  }
+
+  if (target === 'html') {
     // Raw HTML — inline style properties
     const styleBlocks = code.match(/style\s*=\s*\{\{([^}]+)\}\}/g) || [];
     for (const block of styleBlocks) {
@@ -527,14 +533,14 @@ function analyzeEfficiency(
       if (stripped === '}' || stripped === '};') inTypeBlock = false;
       continue;
     }
-    if (target === 'xds' && stripped.includes('stylex.create'))
+    if ((target === 'xds' || target === 'xds-tailwind') && stripped.includes('stylex.create'))
       inStyleBlock = true;
     if (inStyleBlock) {
       stylingLines++;
       if (stripped === '});') inStyleBlock = false;
       continue;
     }
-    if (target === 'baseline' && stripped.includes('className=')) {
+    if ((target === 'baseline' || target === 'xds-tailwind') && stripped.includes('className=')) {
       stylingLines++;
       continue;
     }
@@ -650,14 +656,16 @@ function countMagicAndSemanticValues(
   // CSS variables
   semantic += (code.match(/var\(--[\w-]+\)/g) || []).length;
 
-  if (target === 'xds') {
+  if (target === 'xds' || target === 'xds-tailwind') {
     // StyleX token references: spacingVars["--spacing-4"], colorVars["--color-*"]
     semantic += (code.match(/\w+Vars\[["']--[\w-]+["']\]/g) || []).length;
     // Component props that delegate styling: variant=, size=, gap=, color=, type=
     semantic += (
       code.match(/\b(variant|size|gap|color|type|level)\s*=\s*["']/g) || []
     ).length;
-  } else if (target === 'baseline') {
+  }
+
+  if (target === 'baseline' || target === 'xds-tailwind') {
     // Tailwind semantic tokens: bg-primary, text-muted-foreground, etc.
     semantic += (
       code.match(
@@ -670,8 +678,10 @@ function countMagicAndSemanticValues(
         /(?:^|\s)(?:p|m|gap|space|text|rounded|font|w|h)-(?:\d+|xs|sm|md|lg|xl|2xl|3xl|full|auto)(?:\s|["']|$)/g,
       ) || []
     ).length;
-    // Component variant/size props
-    semantic += (code.match(/\b(variant|size)\s*=\s*["']/g) || []).length;
+    // Component variant/size props (only count if not already counted above)
+    if (target === 'baseline') {
+      semantic += (code.match(/\b(variant|size)\s*=\s*["']/g) || []).length;
+    }
   }
 
   // --- Magic values (all targets) ---


### PR DESCRIPTION
Adds XDS + Tailwind CSS as a new nightly vibe test environment alongside xds, baseline, and html.

## What

New `xds-tailwind` target: agents get a project with XDS components + Tailwind v4 + the bridge CSS + a README explaining the setup. Same discovery-driven prompts as every other target — no coaching.

## Changes

| File | What |
|------|------|
| `environments/project-xds-tailwind/` | Template: package.json, globals.css (layer ordering), README |
| `setup-nightly.mjs` | 4 targets × N prompts (was 3) |
| `setup-environment.mjs` | Symlinks core + cli for xds-tailwind projects |
| `setup-iteration.mjs` | `--target xds-tailwind` support |
| `build-previews.ts` | Entry file + Vite config for hybrid target |
| `universal-eval.ts` | Hybrid scoring: counts both XDS props and Tailwind classes |
| `README.md` | Simplified prompt docs, new asymmetry documented |

## Fairness

All library targets get identical prompt structure: `You are generating React/TSX code using <system>. Your project is at <dir>. Explore it to find available components.` No hints about which components to use, no pre-built commands, no coaching on how to combine the systems.

The agent discovers the XDS+Tailwind integration pattern from the project's README and globals.css — same as a real consumer would.

---
