### PR TITLE
feat(Text): default type to 'body' instead of requiring it

### DIFF
--- a/packages/core/src/Text/Text.doc.mjs
+++ b/packages/core/src/Text/Text.doc.mjs
@@ -19,7 +19,7 @@ export const docs = {
           type: "'body' | 'large' | 'label' | 'supporting' | 'code'",
           description:
             'Semantic text type. Determines size, weight, and line-height from the theme.',
-          required: true,
+          default: "'body'",
         },
         {
           name: 'children',
@@ -233,7 +233,7 @@ export const docsZh = {
           type: "'body' | 'large' | 'label' | 'supporting' | 'code'",
           description:
             '语义化文本类型。从主题中确定大小、字重和行高。',
-          required: true,
+          default: "'body'",
         },
         {
           name: 'children',

--- a/packages/core/src/Text/XDSText.test.tsx
+++ b/packages/core/src/Text/XDSText.test.tsx
@@ -9,6 +9,11 @@ import {XDSText} from './XDSText';
 
 describe('XDSText', () => {
   describe('rendering', () => {
+    it('renders without type prop (defaults to body)', () => {
+      render(<XDSText>Default body text</XDSText>);
+      expect(screen.getByText('Default body text')).toBeInTheDocument();
+    });
+
     it('renders children correctly', () => {
       render(<XDSText type="body">Hello World</XDSText>);
       expect(screen.getByText('Hello World')).toBeInTheDocument();

--- a/packages/core/src/Text/XDSText.tsx
+++ b/packages/core/src/Text/XDSText.tsx
@@ -53,9 +53,9 @@ export interface XDSTextProps extends Omit<XDSBaseProps, 'children'> {
   ref?: React.Ref<HTMLElement>;
   /**
    * Semantic text type. Determines size, weight, and line-height from theme.
-   * Required to ensure semantic usage.
+   * @default 'body'
    */
-  type: XDSTextType;
+  type?: XDSTextType;
 
   /**
    * Explicit font size override. When set, overrides the size from `type`
@@ -172,7 +172,7 @@ const defaultColorByType: Record<XDSTextType, XDSTextColor> = {
  * ```
  */
 export function XDSText({
-  type,
+  type = 'body',
   size: _size,
   color,
   weight,


### PR DESCRIPTION
Closes #1700

## Problem

`type` is the most common tsc error in vibe tests. Agents (and likely humans) consistently write `<XDSText>content</XDSText>` — the natural pattern from every other text component. The required prop generates friction on the happy path without adding safety.

## Change

`type` is now optional, defaults to `'body'`.

```tsx
// Before (tsc error):
<XDSText>Hello</XDSText>

// After (renders as body):
<XDSText>Hello</XDSText>

// Explicit still works:
<XDSText type="label">Label</XDSText>
```

## Files changed

| File | Change |
|------|--------|
| `XDSText.tsx` | `type` optional, default `'body'` |
| `Text.doc.mjs` | Updated both locales: required → default |
| `XDSText.test.tsx` | Added test for default behavior |

## Evidence

From vibe test runs (4-way: XDS / XDS+TW / Baseline / HTML):
- Missing `type` on XDSText appeared in both XDS and XDS+Tailwind iterations
- 4 instances in the XDS TodoTracker, 5 in XDS+TW
- Both agents read the docs but still omitted it — the pattern is too ingrained

---
