### PR TITLE
fix(docsite): disable mobile nav to prevent click blocking

### DIFF
--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/DocsView.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/DocsView.tsx
@@ -1283,6 +1283,7 @@ export function DocsView({
       <XDSAppShell
         variant="surface"
         height="fill"
+        mobileNav={{breakpoint: 'none'}}
         topNav={
           <XDSTopNav
             label="XDS navigation"


### PR DESCRIPTION
## Summary
- Adds `mobileNav={{breakpoint: 'none'}}` to the docsite's `XDSAppShell` to prevent the auto-generated mobile nav drawer from blocking click interactions when the docsite is rendered inside the sandbox PreviewShell wrapper.

## Test plan
- [ ] Open the sandbox docsite page and verify all sidebar items, top nav buttons, and content links are clickable
- [ ] Resize the browser below 768px and confirm the sidebar stays inline (no mobile drawer appears)


Made with [Cursor](https://cursor.com)