### PR TITLE
fix(templates): open selector showcases by default

### DIFF
--- a/packages/cli/templates/blocks/components/MultiSelector/MultiSelectorShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/MultiSelector/MultiSelectorShowcase.doc.mjs
@@ -5,4 +5,5 @@ export const doc = {
   isReady: true,
   aspectRatio: 1,
   isShowcase: true,
+  componentsUsed: ['MultiSelector'],
 };

--- a/packages/cli/templates/blocks/components/MultiSelector/MultiSelectorShowcase.tsx
+++ b/packages/cli/templates/blocks/components/MultiSelector/MultiSelectorShowcase.tsx
@@ -5,6 +5,7 @@ export default function MultiSelectorShowcase() {
     <div style={{width: 300}}>
       <XDSMultiSelector
         label="Columns"
+        defaultOpen
         options={['Name', 'Email', 'Role', 'Status', 'Created']}
         value={[]}
         onChange={() => {}}

--- a/packages/cli/templates/blocks/components/MultiSelector/MultiSelectorShowcase.tsx
+++ b/packages/cli/templates/blocks/components/MultiSelector/MultiSelectorShowcase.tsx
@@ -5,7 +5,7 @@ export default function MultiSelectorShowcase() {
     <div style={{width: 300}}>
       <XDSMultiSelector
         label="Columns"
-        defaultOpen
+        isDefaultOpen
         options={['Name', 'Email', 'Role', 'Status', 'Created']}
         value={[]}
         onChange={() => {}}

--- a/packages/cli/templates/blocks/components/Selector/SelectorShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/Selector/SelectorShowcase.doc.mjs
@@ -5,4 +5,5 @@ export const doc = {
   isReady: true,
   aspectRatio: 1,
   isShowcase: true,
+  componentsUsed: ['Selector'],
 };

--- a/packages/cli/templates/blocks/components/Selector/SelectorShowcase.tsx
+++ b/packages/cli/templates/blocks/components/Selector/SelectorShowcase.tsx
@@ -6,6 +6,7 @@ export default function SelectorShowcase() {
   return (
     <XDSSelector
       label="Fruit"
+      defaultOpen
       options={['Apple', 'Banana', 'Orange', 'Mango', 'Pineapple']}
       placeholder="Select a fruit..."
       onChange={() => {}}

--- a/packages/cli/templates/blocks/components/Selector/SelectorShowcase.tsx
+++ b/packages/cli/templates/blocks/components/Selector/SelectorShowcase.tsx
@@ -6,7 +6,7 @@ export default function SelectorShowcase() {
   return (
     <XDSSelector
       label="Fruit"
-      defaultOpen
+      isDefaultOpen
       options={['Apple', 'Banana', 'Orange', 'Mango', 'Pineapple']}
       placeholder="Select a fruit..."
       onChange={() => {}}

--- a/packages/core/src/MultiSelector/XDSMultiSelector.tsx
+++ b/packages/core/src/MultiSelector/XDSMultiSelector.tsx
@@ -496,7 +496,7 @@ export interface XDSMultiSelectorProps<
    * Useful for showcases and previews.
    * @default false
    */
-  defaultOpen?: boolean;
+  isDefaultOpen?: boolean;
 
   /**
    * Test ID for testing frameworks.
@@ -543,7 +543,7 @@ export function XDSMultiSelector<T extends XDSMultiSelectorOptionType>({
   triggerDisplay = 'count',
   maxBadges = 3,
   children,
-  defaultOpen = false,
+  isDefaultOpen = false,
   'data-testid': testId,
   xstyle,
   className,
@@ -673,12 +673,11 @@ export function XDSMultiSelector<T extends XDSMultiSelectorOptionType>({
     dialogLabel: `${label} options`,
   });
 
-  // Open dropdown on mount when defaultOpen is true
+  // Open dropdown on mount when isDefaultOpen is true
   useEffect(() => {
-    if (defaultOpen) {
+    if (isDefaultOpen) {
       popover.show();
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Handle toggle

--- a/packages/core/src/MultiSelector/XDSMultiSelector.tsx
+++ b/packages/core/src/MultiSelector/XDSMultiSelector.tsx
@@ -13,6 +13,7 @@
 
 import React, {
   useCallback,
+  useEffect,
   useId,
   useMemo,
   useOptimistic,
@@ -491,6 +492,13 @@ export interface XDSMultiSelectorProps<
   children?: (option: XDSMultiSelectorOptionData) => ReactNode;
 
   /**
+   * Whether the dropdown starts open on mount.
+   * Useful for showcases and previews.
+   * @default false
+   */
+  defaultOpen?: boolean;
+
+  /**
    * Test ID for testing frameworks.
    */
   'data-testid'?: string;
@@ -535,6 +543,7 @@ export function XDSMultiSelector<T extends XDSMultiSelectorOptionType>({
   triggerDisplay = 'count',
   maxBadges = 3,
   children,
+  defaultOpen = false,
   'data-testid': testId,
   xstyle,
   className,
@@ -663,6 +672,14 @@ export function XDSMultiSelector<T extends XDSMultiSelectorOptionType>({
     hasAutoFocus: false,
     dialogLabel: `${label} options`,
   });
+
+  // Open dropdown on mount when defaultOpen is true
+  useEffect(() => {
+    if (defaultOpen) {
+      popover.show();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Handle toggle
   // Handle clear button click

--- a/packages/core/src/Selector/XDSSelector.tsx
+++ b/packages/core/src/Selector/XDSSelector.tsx
@@ -381,7 +381,7 @@ interface XDSSelectorPropsBase<
    * Useful for showcases and previews.
    * @default false
    */
-  defaultOpen?: boolean;
+  isDefaultOpen?: boolean;
 
   /**
    * Test ID for testing frameworks.
@@ -467,7 +467,7 @@ export function XDSSelector<T extends XDSSelectorOptionType>(
     status,
     labelTooltip,
     children,
-    defaultOpen = false,
+    isDefaultOpen = false,
     'data-testid': testId,
     xstyle,
     className,
@@ -531,12 +531,11 @@ export function XDSSelector<T extends XDSSelectorOptionType>(
     hasAutoFocus: false,
   });
 
-  // Open dropdown on mount when defaultOpen is true
+  // Open dropdown on mount when isDefaultOpen is true
   useEffect(() => {
-    if (defaultOpen) {
+    if (isDefaultOpen) {
       popover.show();
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Calculate offset to position selected item over trigger

--- a/packages/core/src/Selector/XDSSelector.tsx
+++ b/packages/core/src/Selector/XDSSelector.tsx
@@ -13,6 +13,7 @@
 
 import React, {
   useCallback,
+  useEffect,
   useId,
   useMemo,
   useOptimistic,
@@ -376,6 +377,13 @@ interface XDSSelectorPropsBase<
   children?: (option: XDSSelectorOptionData) => ReactNode;
 
   /**
+   * Whether the dropdown starts open on mount.
+   * Useful for showcases and previews.
+   * @default false
+   */
+  defaultOpen?: boolean;
+
+  /**
    * Test ID for testing frameworks.
    */
   'data-testid'?: string;
@@ -459,6 +467,7 @@ export function XDSSelector<T extends XDSSelectorOptionType>(
     status,
     labelTooltip,
     children,
+    defaultOpen = false,
     'data-testid': testId,
     xstyle,
     className,
@@ -521,6 +530,14 @@ export function XDSSelector<T extends XDSSelectorOptionType>(
     hasCloseButton: false,
     hasAutoFocus: false,
   });
+
+  // Open dropdown on mount when defaultOpen is true
+  useEffect(() => {
+    if (defaultOpen) {
+      popover.show();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Calculate offset to position selected item over trigger
   const {offset: selectedItemOffset, isPositioned} = useSelectedItemOffset({


### PR DESCRIPTION
Same pattern as #1670 for Popover/DropdownMenu/MoreMenu — add `defaultOpen` prop to `XDSSelector` and `XDSMultiSelector` so their dropdown renders open on mount. Update showcase blocks to use it.

### Changes
- **XDSSelector**: Add `defaultOpen` prop → calls `popover.show()` on mount
- **XDSMultiSelector**: Same
- **SelectorShowcase**: Add `defaultOpen`
- **MultiSelectorShowcase**: Add `defaultOpen`
- **doc.mjs**: Add `componentsUsed` to both showcases
