### PR TITLE
fix(docs): update Chat canonical component to ChatComposer

### DIFF
--- a/packages/core/groups.doc.mjs
+++ b/packages/core/groups.doc.mjs
@@ -18,7 +18,7 @@
 export const GROUP_DOCS = {
   Chat: {
     name: 'Chat',
-    canonical: 'ChatMessageList',
+    canonical: 'ChatComposer',
     description:
       'Conversational messaging primitives for building chat UIs, AI assistants, and threaded conversations.',
   },


### PR DESCRIPTION
Updates the Chat group's canonical component from `ChatMessageList` to `ChatComposer` in `groups.doc.mjs`.
