### PR TITLE
fix(cli): findShowcase matches by directory name and componentsUsed

### DIFF
--- a/.claude/commands/create-component.md
+++ b/.claude/commands/create-component.md
@@ -24,6 +24,9 @@ Follow the full component lifecycle documented on the XDS wiki:
   - `{ComponentName}.doc.mjs` — typed docs (ComponentDoc)
   - `index.ts` — public exports
 - Create `apps/storybook/stories/{ComponentName}.stories.tsx`
+- Create showcase block in `packages/cli/templates/blocks/components/{ComponentName}/`:
+  - `{ComponentName}Showcase.tsx` — visual preview (renders the component in a representative state)
+  - `{ComponentName}Showcase.doc.mjs` — must set `isShowcase: true` and `componentsUsed: ['{ComponentName}']`
 - Wire up: add to `packages/core/src/index.ts`
 - Run `node scripts/sync-exports.js` to update package.json exports
 - Run `yarn build && yarn test && yarn lint`

--- a/packages/cli/src/api/template.mjs
+++ b/packages/cli/src/api/template.mjs
@@ -110,9 +110,17 @@ export async function findRelatedBlocks(componentName) {
 
 export async function findShowcase(componentName) {
   const blocks = await discoverBlocks();
-  const match = blocks.find(b =>
-    b.isShowcase && b.name.toLowerCase() === componentName.toLowerCase(),
-  );
+  const lc = componentName.toLowerCase();
+  // Match by directory name (category is "components/Badge" → ends with "/Badge"),
+  // by componentsUsed, or by exact display name.
+  const match = blocks.find(b => {
+    if (!b.isShowcase) return false;
+    const catDir = b.category.split('/').pop()?.toLowerCase();
+    if (catDir === lc) return true;
+    if (b.componentsUsed.some(c => c.toLowerCase() === lc)) return true;
+    if (b.name.toLowerCase() === lc) return true;
+    return false;
+  });
   if (!match) return null;
   return {
     name: match.name,


### PR DESCRIPTION
The previous logic compared the showcase's display name (e.g. `'Badge — Variants'`) against the component name (`'Badge'`), which never matched when the display name included a suffix.

Now matches by:
1. Directory name (category path's last segment)
2. `componentsUsed` array
3. Exact display name (backwards compat)

Fixes broken showcases for Badge, Banner, Divider, Button, TabList, and others in the docsite preview grid.

---
