### PR TITLE
fix(templates): use accent color for all toolbar buttons in ToggleButton Color example

### DIFF
--- a/packages/cli/templates/blocks/components/ToggleButton/ToggleButtonColor.tsx
+++ b/packages/cli/templates/blocks/components/ToggleButton/ToggleButtonColor.tsx
@@ -87,7 +87,7 @@ export default function ToggleButtonColor() {
           <XDSToggleButton
             label="Link"
             icon={<XDSIcon icon={LinkIcon} color="secondary" />}
-            pressedIcon={<XDSIcon icon={LinkIcon} color="positive" />}
+            pressedIcon={<XDSIcon icon={LinkIcon} color="accent" />}
             isPressed={toolbar.link}
             onPressedChange={() => toggleToolbar('link')}
             isIconOnly


### PR DESCRIPTION
The Link toggle button in the toolbar section was using `color="positive"` (green) while all other toolbar buttons use `color="accent"`. This changes it to `accent` for consistency.