### PR TITLE
fix: remove outline from transition to prevent black flash on focus

### DIFF
--- a/packages/core/src/Field/inputStyles.stylex.ts
+++ b/packages/core/src/Field/inputStyles.stylex.ts
@@ -48,7 +48,7 @@ export const inputWrapperStyles = stylex.create({
     '--_field-radius': radiusVars['--radius-element'],
     borderRadius: 'var(--_field-radius)',
     backgroundColor: colorVars['--color-background-surface'],
-    transitionProperty: 'border-color, outline, box-shadow',
+    transitionProperty: 'border-color, box-shadow',
     transitionDuration: {
       default: durationVars['--duration-fast'],
       '@media (prefers-reduced-motion: reduce)': '0s',

--- a/packages/core/src/MultiSelector/XDSMultiSelector.tsx
+++ b/packages/core/src/MultiSelector/XDSMultiSelector.tsx
@@ -93,7 +93,7 @@ const styles = stylex.create({
     lineHeight: typeScaleVars['--text-label-leading'],
     color: colorVars['--color-text-primary'],
     cursor: 'pointer',
-    transitionProperty: 'border-color, outline, box-shadow',
+    transitionProperty: 'border-color, box-shadow',
     transitionDuration: durationVars['--duration-fast'],
     transitionTimingFunction: easeVars['--ease-standard'],
     boxShadow: {

--- a/packages/core/src/Selector/XDSSelector.tsx
+++ b/packages/core/src/Selector/XDSSelector.tsx
@@ -89,7 +89,7 @@ const styles = stylex.create({
     lineHeight: typeScaleVars['--text-label-leading'],
     color: colorVars['--color-text-primary'],
     cursor: 'pointer',
-    transitionProperty: 'border-color, outline, box-shadow',
+    transitionProperty: 'border-color, box-shadow',
     transitionDuration: durationVars['--duration-fast'],
     transitionTimingFunction: easeVars['--ease-standard'],
     boxShadow: {


### PR DESCRIPTION
## Problem

When focusing input components, there's a brief black outline flash before the themed blue outline appears.

## Root Cause

The `transitionProperty` includes `outline`, causing the browser to animate from `outline: none` to `outline: 1px solid var(--color-accent)`. During interpolation, the browser renders its default black outline before reaching the themed color.

## Fix

Remove `outline` from `transitionProperty` in all three places:
- `inputStyles.stylex.ts` (shared input wrapper used by TextInput, TextArea, NumberInput, etc.)
- `XDSSelector.tsx`
- `XDSMultiSelector.tsx`

The outline now appears instantly on focus — which is the correct UX. Focus indicators should be immediate, not animated. The border-color and box-shadow transitions are preserved.

---
