### PR TITLE
chore: add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Meta Platforms, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "xds",
   "version": "0.0.0",
   "private": true,
+  "license": "MIT",
   "workspaces": [
     "apps/*",
     "packages/*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,6 +2,7 @@
   "name": "@xds/core",
   "version": "0.0.12",
   "description": "Core XDS components",
+  "license": "MIT",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/lab/package.json
+++ b/packages/lab/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.12",
   "private": true,
   "description": "Experimental XDS components — not published, available in storybook and sandbox for testing",
+  "license": "MIT",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "sideEffects": false,

--- a/packages/vega/package.json
+++ b/packages/vega/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.0.12",
   "description": "XDS Vega wrapper \u2014 chart and data visualization components",
+  "license": "MIT",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Adds an MIT LICENSE file to the repo root and adds the `"license": "MIT"` field to packages that were missing it.

**Added:**
- `LICENSE` — MIT license, copyright Meta Platforms, Inc.

**Updated `package.json` license field:**
- Root `package.json`
- `packages/core`
- `packages/lab`
- `packages/vega`

(build, cli, and all theme packages already had it.)