### PR TITLE
fix: use basePath for all docsite URLs in sandbox deployment

### DIFF
--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/AppTopNav.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/AppTopNav.tsx
@@ -10,7 +10,7 @@ import {XDSDropdownMenu} from '@xds/core/DropdownMenu';
 import {XDSCommandPalette} from '@xds/core/CommandPalette';
 
 import {SearchIcon, ProfileIcon, FilterIcon} from './docsite-icons';
-import {SEARCH_COMMANDS} from './constants';
+import {SEARCH_COMMANDS, basePath} from './constants';
 
 const XDS_WORDMARK = (
   <svg
@@ -107,7 +107,7 @@ export function AppTopNav({
         heading={
           <XDSTopNavHeading
             logo={XDS_WORDMARK}
-            headingHref="/pages/docsite/"
+            headingHref={`${basePath}/pages/docsite/`}
             menu={headingMenu}
           />
         }

--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/DocsView.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/DocsView.tsx
@@ -1771,7 +1771,7 @@ export function DocsView({
 
     const qs = params.toString();
     if (qs === window.location.search.slice(1)) return;
-    const url = `/pages/docsite/?${qs}`;
+    const url = `${basePath}/pages/docsite/?${qs}`;
     window.history.replaceState(window.history.state, '', url);
   }, [selectedComponent]);
 

--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
@@ -642,7 +642,7 @@ function DocsiteLandingTemplate() {
 
     const qs = params.toString();
     if (qs === window.location.search.slice(1)) return;
-    const url = `/pages/docsite/${qs ? '?' + qs : ''}`;
+    const url = `${basePath}/pages/docsite/${qs ? '?' + qs : ''}`;
     window.history.replaceState(window.history.state, '', url);
   }, [
     previewTarget,


### PR DESCRIPTION
## Summary
Fixed three hardcoded URL paths that were missing `basePath`, causing broken navigation on the deployed sandbox.

- `DocsView.tsx` — `replaceState` URL for docsite nav
- `AppTopNav.tsx` — heading logo href  
- `page.tsx` — `replaceState` URL for craft/explore nav

## Test plan
- [ ] Navigate between docsite pages on deployed sandbox
- [ ] Verify logo link works on deployed sandbox
- [ ] Verify craft/explore URL updates correctly


Made with [Cursor](https://cursor.com)