### PR TITLE
feat(templates): split Documentation into three focused templates

### DIFF
--- a/packages/cli/templates/pages/documentation-design/page.tsx
+++ b/packages/cli/templates/pages/documentation-design/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import {useState} from 'react';
+import {useState, useMemo} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {XDSAppShell} from '@xds/core/AppShell';
 import {
@@ -9,20 +9,61 @@ import {
   XDSSideNavItem,
   XDSSideNavSection,
 } from '@xds/core/SideNav';
-import {XDSText} from '@xds/core/Text';
+import {XDSHeading, XDSText} from '@xds/core/Text';
 import {XDSButton} from '@xds/core/Button';
+import {XDSIconButton} from '@xds/core/IconButton';
 import {XDSCard} from '@xds/core/Card';
+import {XDSAvatar} from '@xds/core/Avatar';
+import {XDSBadge} from '@xds/core/Badge';
+import {XDSToken} from '@xds/core/Token';
+import {XDSBanner} from '@xds/core/Banner';
+import {XDSCodeBlock} from '@xds/core/CodeBlock';
+import {XDSTabList, XDSTab} from '@xds/core/TabList';
 import {XDSHStack, XDSVStack, XDSStackItem} from '@xds/core/Stack';
 import {XDSLayout, XDSLayoutContent} from '@xds/core/Layout';
-import {XDSGrid} from '@xds/core/Grid';
-import {radiusVars} from '@xds/core/theme/tokens.stylex';
+import {XDSDialog, XDSDialogHeader} from '@xds/core/Dialog';
+import {XDSDivider} from '@xds/core/Divider';
+import {XDSTooltip} from '@xds/core/Tooltip';
+import {XDSTable, pixel} from '@xds/core/Table';
+import {XDSIcon} from '@xds/core/Icon';
+import {XDSSection} from '@xds/core/Section';
+import {XDSCenter} from '@xds/core/Center';
+import {
+  ArrowTopRightOnSquareIcon,
+  ArrowsPointingOutIcon,
+  PlusIcon,
+} from '@heroicons/react/24/outline';
 
 const styles = stylex.create({
-  previewCard: {
-    borderRadius: radiusVars['--radius-container'],
-    cursor: 'pointer',
-  },
+  tabListFlush: {marginInlineStart: '-12px'},
 });
+
+// ---------------------------------------------------------------------------
+// DialogPreview — stateful dialog preview for component previews
+// ---------------------------------------------------------------------------
+
+function DialogPreview() {
+  const [isOpen, setIsOpen] = useState(false);
+  return (
+    <XDSVStack gap={3}>
+      <XDSHeading level={3}>Dialog</XDSHeading>
+      <XDSButton
+        label="Open Dialog"
+        variant="primary"
+        onClick={() => setIsOpen(true)}
+      />
+      <XDSDialog isOpen={isOpen} onOpenChange={setIsOpen}>
+        <XDSDialogHeader title="Example Dialog" onOpenChange={setIsOpen} />
+        <XDSSection padding={4}>
+          <XDSText type="body">
+            This is an example dialog. Dialogs are used to require user action
+            or display important information that needs acknowledgment.
+          </XDSText>
+        </XDSSection>
+      </XDSDialog>
+    </XDSVStack>
+  );
+}
 
 // ---------------------------------------------------------------------------
 // Data
@@ -46,106 +87,234 @@ const COMPONENT_CATEGORIES = [
       {key: 'kbd', name: 'Kbd', desc: 'Kbd renders keyboard shortcut hints in a styled inline element. Use it to show users which key combinations perform specific actions.'},
       {key: 'link', name: 'Link', desc: 'Links provide navigation between pages or to external resources. They follow accessible anchor semantics with visual affordance.'},
       {key: 'list', name: 'List', desc: 'List displays a vertical set of related items. It supports selection, icons, and metadata for building menus, nav lists, and more.'},
+      {key: 'metadatalist', name: 'MetadataList', desc: 'MetadataList displays key-value pairs in a structured layout. Use it for detail panels, settings summaries, and record information.'},
+      {key: 'moremenu', name: 'MoreMenu', desc: 'MoreMenu provides an overflow menu triggered by an icon button. It collects secondary actions that do not fit in the primary toolbar.'},
+      {key: 'overflowlist', name: 'OverflowList', desc: 'OverflowList renders as many items as fit in the available space and collapses the rest into an overflow menu automatically.'},
+      {key: 'pagination', name: 'Pagination', desc: 'Pagination lets users navigate through pages of content. It supports page numbers, previous/next controls, and page-size selection.'},
       {key: 'popover', name: 'Popover', desc: 'Popover displays rich content in a floating panel anchored to a trigger element. It is used for forms, filters, and contextual tools.'},
+      {key: 'progressbar', name: 'ProgressBar', desc: 'ProgressBar shows the completion status of a task or process. It provides visual feedback for uploads, installations, and multi-step flows.'},
+      {key: 'skeleton', name: 'Skeleton', desc: 'Skeleton renders placeholder shapes that mimic content layout while loading. It reduces perceived wait time and prevents layout shifts.'},
+      {key: 'spinner', name: 'Spinner', desc: 'Spinner indicates that a process is in progress when the duration is unknown. It draws attention without blocking the interface.'},
+      {key: 'statusdot', name: 'StatusDot', desc: 'StatusDot shows a small colored indicator for online, offline, busy, or custom statuses. It is often paired with avatars or list items.'},
       {key: 'table', name: 'Table', desc: 'Table displays structured data in rows and columns with support for sorting, selection, and custom cell rendering.'},
+      {key: 'thumbnail', name: 'Thumbnail', desc: 'Thumbnail renders a small image preview with consistent sizing and optional rounded corners. It is used in media lists, cards, and galleries.'},
+      {key: 'timestamp', name: 'Timestamp', desc: 'Timestamp formats and displays dates and times with relative or absolute labels. It updates automatically to stay current.'},
+      {key: 'toast', name: 'Toast', desc: 'Toasts display brief, non-blocking notifications at the edge of the screen. They auto-dismiss and are used for success, error, or info messages.'},
+      {key: 'togglebutton', name: 'ToggleButton', desc: 'ToggleButton is a button that switches between an on and off state. Use it for binary options like bookmarking, favoriting, or muting.'},
       {key: 'token', name: 'Token', desc: 'Tokens display compact metadata labels such as tags, categories, or filters. They can be dismissible and support selection state.'},
       {key: 'tooltip', name: 'Tooltip', desc: 'Tooltips show concise helper text when users hover over or focus an element. They clarify icons, truncated labels, and controls.'},
+      {key: 'treelist', name: 'TreeList', desc: 'TreeList renders hierarchical data in an expandable tree structure. It supports multi-level nesting, selection, and lazy loading.'},
     ],
   },
-  {
-    label: 'Layout',
-    items: [
-      {key: 'card', name: 'Card', desc: 'Cards group related content and actions in a contained surface. They can include headers, media, body text, and action bars.'},
-      {key: 'divider', name: 'Divider', desc: 'Dividers separate content into distinct sections with a subtle or strong horizontal line. They can optionally include a label.'},
-      {key: 'grid', name: 'Grid', desc: 'Grid provides a CSS grid-based layout container with configurable columns, rows, and gap. It simplifies responsive multi-column designs.'},
-      {key: 'stack', name: 'Stack', desc: 'Stack arranges child elements in a row or column with consistent gap spacing. It is the primary tool for one-dimensional layout composition.'},
-    ],
-  },
-  {
-    label: 'Navigation',
-    items: [
-      {key: 'breadcrumbs', name: 'Breadcrumbs', desc: "Breadcrumbs show the user's current location within a navigation hierarchy. They provide quick links back to parent pages."},
-      {key: 'sidenav', name: 'SideNav', desc: 'SideNav renders a vertical navigation panel with links, sections, and collapsible groups. It is used as the primary nav in dashboard layouts.'},
-      {key: 'tablist', name: 'TabList', desc: 'TabList switches between content views using a horizontal row of tabs. Only one tab is active at a time, and content changes without a page reload.'},
-      {key: 'topnav', name: 'TopNav', desc: 'TopNav provides an app-level navigation bar across the top of the page. It holds branding, primary links, search, and user actions.'},
-    ],
-  },
-  {
-    label: 'Form',
-    items: [
-      {key: 'checkboxinput', name: 'CheckboxInput', desc: 'CheckboxInput renders a single checkbox with a label. It is used for boolean opt-in choices like terms acceptance or feature toggles.'},
-      {key: 'selector', name: 'Selector', desc: 'Selector lets users pick a single item from a dropdown list. It supports search, grouping, and custom option rendering.'},
-      {key: 'switch', name: 'Switch', desc: 'Switch toggles a setting between on and off states with immediate effect. It is used for preferences, feature flags, and real-time controls.'},
-      {key: 'textinput', name: 'TextInput', desc: 'TextInput is a single-line text field for short user input like names, emails, and search queries. It supports icons, prefixes, and validation.'},
-      {key: 'typeahead', name: 'Typeahead', desc: 'Typeahead provides an autocomplete search input that suggests results as the user types. It supports async data sources and custom rendering.'},
-    ],
-  },
+  {label: 'Typography', items: [
+    {key: 'heading', name: 'Heading', desc: 'Heading renders semantic section titles from h1 through h6. It establishes visual hierarchy and supports multiple weight and size options.'},
+    {key: 'text', name: 'Text', desc: 'Text renders body copy, labels, and supporting content with consistent typography. It supports sizes from display down to caption.'},
+  ]},
+  {label: 'Layout', items: [
+    {key: 'aspectratio', name: 'AspectRatio', desc: 'AspectRatio constrains its child to a specified width-to-height ratio. Use it for responsive images, videos, and embedded media.'},
+    {key: 'card', name: 'Card', desc: 'Cards group related content and actions in a contained surface. They can include headers, media, body text, and action bars.'},
+    {key: 'center', name: 'Center', desc: 'Center aligns its child horizontally and vertically within the available space. It is useful for empty states, loading screens, and hero sections.'},
+    {key: 'divider', name: 'Divider', desc: 'Dividers separate content into distinct sections with a subtle or strong horizontal line. They can optionally include a label.'},
+    {key: 'grid', name: 'Grid', desc: 'Grid provides a CSS grid-based layout container with configurable columns, rows, and gap. It simplifies responsive multi-column designs.'},
+    {key: 'layout', name: 'Layout', desc: 'Layout provides foundational page-level primitives for header, sidebar, and content regions. It establishes consistent spacing and structure.'},
+    {key: 'section', name: 'Section', desc: 'Section wraps a block of content with consistent vertical spacing and an optional heading. It structures pages into logical groups.'},
+    {key: 'stack', name: 'Stack', desc: 'Stack arranges child elements in a row or column with consistent gap spacing. It is the primary tool for one-dimensional layout composition.'},
+    {key: 'toolbar', name: 'Toolbar', desc: 'Toolbar arranges a row of action buttons and controls in a compact, aligned strip. It is used at the top of panels, editors, and cards.'},
+  ]},
+  {label: 'Navigation', items: [
+    {key: 'breadcrumbs', name: 'Breadcrumbs', desc: "Breadcrumbs show the user's current location within a navigation hierarchy. They provide quick links back to parent pages."},
+    {key: 'mobilenav', name: 'MobileNav', desc: 'MobileNav provides a responsive navigation menu optimized for small screens. It typically slides in from the edge of the viewport.'},
+    {key: 'sidenav', name: 'SideNav', desc: 'SideNav renders a vertical navigation panel with links, sections, and collapsible groups. It is used as the primary nav in dashboard layouts.'},
+    {key: 'tablist', name: 'TabList', desc: 'TabList switches between content views using a horizontal row of tabs. Only one tab is active at a time, and content changes without a page reload.'},
+    {key: 'topnav', name: 'TopNav', desc: 'TopNav provides an app-level navigation bar across the top of the page. It holds branding, primary links, search, and user actions.'},
+  ]},
+  {label: 'Form', items: [
+    {key: 'checkboxinput', name: 'CheckboxInput', desc: 'CheckboxInput renders a single checkbox with a label. It is used for boolean opt-in choices like terms acceptance or feature toggles.'},
+    {key: 'selector', name: 'Selector', desc: 'Selector lets users pick a single item from a dropdown list. It supports search, grouping, and custom option rendering.'},
+    {key: 'switch', name: 'Switch', desc: 'Switch toggles a setting between on and off states with immediate effect. It is used for preferences, feature flags, and real-time controls.'},
+    {key: 'textinput', name: 'TextInput', desc: 'TextInput is a single-line text field for short user input like names, emails, and search queries. It supports icons, prefixes, and validation.'},
+    {key: 'typeahead', name: 'Typeahead', desc: 'Typeahead provides an autocomplete search input that suggests results as the user types. It supports async data sources and custom rendering.'},
+  ]},
+  {label: 'Components', items: [
+    {key: 'codeblock', name: 'CodeBlock', desc: 'CodeBlock displays formatted, syntax-highlighted source code. It supports line numbers, copy-to-clipboard, and language detection.'},
+    {key: 'collapsible', name: 'Collapsible', desc: 'Collapsible wraps content that can be expanded or collapsed with a trigger. It is used for FAQs, advanced settings, and progressive disclosure.'},
+    {key: 'markdown', name: 'Markdown', desc: 'Markdown renders markdown-formatted text into styled HTML. It supports headings, lists, links, code blocks, and inline formatting.'},
+  ]},
+  {label: 'Chat', items: [
+    {key: 'chat', name: 'Chat', desc: 'Chat provides a conversational message interface with message bubbles, input, and thread support. It is used for AI assistants and messaging UIs.'},
+  ]},
+  {label: 'CommandPalette', items: [
+    {key: 'commandpalette', name: 'CommandPalette', desc: 'CommandPalette is a keyboard-driven command menu for quick navigation and actions. It is opened with a hotkey and supports fuzzy search.'},
+  ]},
 ];
 
+const COMPONENT_DOCS: Record<string, {
+  usage: string;
+  bestPractices: {type: 'do' | 'dont'; text: string}[];
+  examples: {title: string; description: string; code: string}[];
+}> = {
+  button: {
+    usage: 'Buttons provide visual cues for actions and events. These fundamental components allow users to commit actions and navigate a page flow. Use a Button when a user needs to submit a form, start a new task or action, or trigger a new UI element to appear on the page.',
+    bestPractices: [
+      {type: 'do', text: 'Convey clear action hierarchy: Each surface should only have 1 primary button. A majority of buttons should be in default or flat style.'},
+      {type: 'do', text: 'Promote clarity: Consider labels alongside icons where appropriate.'},
+      {type: 'dont', text: 'Overuse primary or special buttons: Overusing colored buttons will result in a page with less intentionality, create visual confusion and a lack of page hierarchy.'},
+    ],
+    examples: [
+      {title: 'Semantics', description: 'We have four semantic buttons types: flat, default, primary, and destructive. Flat buttons are used to limit visual prominence, whereas primary emphasizes a single action. Use destructive for deletions that trigger dialog confirmations.',
+        code: `<XDSButton label="Flat" variant="ghost" />\n<XDSButton label="Default" variant="secondary" />\n<XDSButton label="Primary" variant="primary" />\n<XDSButton label="Destructive" variant="destructive" />`},
+      {title: 'Default button with badge', description: 'Buttons can include a badge to highlight new or updated actions.',
+        code: `<XDSButton\n  label="Button"\n  variant="default"\n/>`},
+    ],
+  },
+};
+
+function getComponentName(key: string): string {
+  for (const cat of COMPONENT_CATEGORIES) {
+    const item = cat.items.find(i => i.key === key);
+    if (item) return item.name;
+  }
+  return key;
+}
+
+function getComponentDocs(key: string) {
+  if (COMPONENT_DOCS[key]) return COMPONENT_DOCS[key];
+  const name = getComponentName(key);
+  let desc = '';
+  for (const cat of COMPONENT_CATEGORIES) {
+    const item = cat.items.find(i => i.key === key);
+    if (item) { desc = item.desc; break; }
+  }
+  return {
+    usage: desc,
+    bestPractices: [
+      {type: 'do' as const, text: `Use ${name} in the appropriate context to provide the functionality described above.`},
+      {type: 'do' as const, text: `Pair ${name} with related components to create cohesive, accessible interfaces.`},
+      {type: 'dont' as const, text: `Use ${name} when a simpler alternative achieves the same goal with less complexity.`},
+    ],
+    examples: [{title: `Basic ${name}`, description: `A simple example of the ${name} component with default settings.`, code: `<XDS${name} />`}],
+  };
+}
+
 // ---------------------------------------------------------------------------
-// Sub-views
+// ComponentDetailView
 // ---------------------------------------------------------------------------
 
-function OverviewView({
-  onSelectComponent,
-}: {
-  onSelectComponent: (key: string) => void;
-}) {
+function ComponentDetailView({activeNav}: {activeNav: string}) {
+  const [exampleTabs, setExampleTabs] = useState<Record<string, string>>({});
+
+  const EXAMPLE_PREVIEWS: Record<string, React.ReactNode[]> = {
+    button: [
+      <XDSHStack key="semantics" gap={3} vAlign="center">
+        <XDSButton label="Flat" variant="ghost" />
+        <XDSButton label="Default" variant="secondary" />
+        <XDSButton label="Primary" variant="primary" />
+        <XDSButton label="Destructive" variant="destructive" />
+      </XDSHStack>,
+      <XDSButton key="badge" label="Button" variant="secondary" />,
+    ],
+  };
+
+  const COMPONENT_PREVIEWS: Record<string, React.ReactNode> = {
+    button: (
+      <XDSButton label="Button" variant="secondary" icon={<XDSIcon icon={PlusIcon} />} endContent={<XDSBadge label="New" variant="info" />} />
+    ),
+    avatar: <XDSAvatar name="Alice" size="medium" />,
+    badge: <XDSBadge label="Success" variant="success" />,
+    card: (<XDSCard><XDSVStack gap={2}><XDSHeading level={4}>Card Title</XDSHeading><XDSText type="body" color="secondary">Cards group related content and actions.</XDSText></XDSVStack></XDSCard>),
+    banner: (<XDSBanner status="info" title="Information"><XDSText type="body">This is an informational banner message.</XDSText></XDSBanner>),
+    dialog: <DialogPreview />,
+    text: <XDSText type="body">Body text</XDSText>,
+    divider: <XDSDivider />,
+    token: <XDSToken label="Design" />,
+    tooltip: (<XDSTooltip content="Primary action"><XDSButton label="Hover me" variant="primary" /></XDSTooltip>),
+  };
+
+  const docs = useMemo(() => getComponentDocs(activeNav), [activeNav]);
+  const previews = EXAMPLE_PREVIEWS[activeNav] ?? [];
+
   return (
-    <XDSLayout contentWidth={1200} content={
+    <XDSLayout contentWidth={960} content={
       <XDSLayoutContent padding={8}>
-        <XDSVStack gap={10}>
-          {/* Hero banner */}
-          <XDSCard variant="cyan" padding={10}>
-            <XDSHStack gap={8} vAlign="center">
-              <XDSStackItem size="fill">
-                <XDSVStack gap={4}>
-                  <XDSText type="display-1">Web overview</XDSText>
-                  <XDSText type="large" weight="normal" color="secondary">
-                    An open-source UI library to help developers quickly build
-                    beautiful, accessible products.
-                  </XDSText>
-                  <XDSHStack>
-                    <XDSButton
-                      label="Get started"
-                      variant="primary"
-                      size="lg"
-                      onClick={() => onSelectComponent('getting-started')}
-                    />
-                  </XDSHStack>
-                </XDSVStack>
-              </XDSStackItem>
-              <XDSStackItem size="fill" />
-            </XDSHStack>
+        <XDSVStack gap={8}>
+          <XDSVStack gap={2}>
+            <XDSText type="display-1">{getComponentName(activeNav)}</XDSText>
+            <XDSText type="supporting" color="secondary">March 30, 2026 · Updated 5:40 p.m. PST</XDSText>
+          </XDSVStack>
+
+          <XDSDivider />
+
+          <XDSCard variant="muted" padding={0}>
+            <XDSCenter height={360}>
+              {COMPONENT_PREVIEWS[activeNav] ?? (<XDSText type="supporting" color="secondary">Preview coming soon</XDSText>)}
+            </XDSCenter>
           </XDSCard>
 
-          {/* Category sections */}
-          {COMPONENT_CATEGORIES.map(category => (
-            <XDSVStack key={category.label} gap={4}>
-              <XDSText type="display-2">{category.label}</XDSText>
-              <XDSGrid columns={{minWidth: 260}} gap={8}>
-                {category.items.map(item => (
-                  <XDSVStack key={item.key} gap={3}>
-                    <XDSCard
-                      variant="muted"
-                      padding={0}
-                      minHeight={160}
-                      xstyle={styles.previewCard}
-                      onClick={() => onSelectComponent(item.key)}
-                    />
-                    <XDSVStack gap={0.5}>
-                      <XDSText type="body" weight="bold">
-                        {item.name}
-                      </XDSText>
-                      <XDSText type="body" color="secondary">
-                        {item.desc}
-                      </XDSText>
-                    </XDSVStack>
+          <XDSVStack gap={4}>
+            <XDSHeading level={2}>Usage</XDSHeading>
+            <XDSText type="large" weight="normal">{docs.usage}</XDSText>
+            <XDSHeading level={3}>Best practices</XDSHeading>
+            <XDSTable
+              data={docs.bestPractices as Record<string, unknown>[]}
+              columns={[
+                {key: 'type', header: 'Guidance', width: pixel(125), renderCell: (item: Record<string, unknown>) => (
+                  <XDSBadge label={item.type === 'do' ? 'Do' : 'Dont'} variant={item.type === 'do' ? 'success' : 'error'} />
+                )},
+                {key: 'text', header: 'Practices', renderCell: (item: Record<string, unknown>) => (
+                  <XDSText type="body" textWrap="wrap">{item.text as string}</XDSText>
+                )},
+              ]}
+              density="spacious"
+              dividers="rows"
+            />
+          </XDSVStack>
+
+          <XDSDivider />
+
+          <XDSVStack gap={4}>
+            <XDSHeading level={2}>Examples</XDSHeading>
+            <XDSText type="large" weight="normal">
+              Explore common configurations, variations, and states for this component.
+            </XDSText>
+          </XDSVStack>
+          <XDSVStack gap={8}>
+          {docs.examples.map((example, i) => {
+            const tabKey = `${activeNav}-${i}`;
+            const activeTab = exampleTabs[tabKey] ?? 'description';
+            return (
+              <XDSCard key={i} padding={0}>
+                <XDSSection padding={3} variant="transparent">
+                  <XDSHStack gap={3} vAlign="center">
+                    <XDSStackItem size="fill">
+                      <XDSText type="body" weight="medium">{example.title}</XDSText>
+                    </XDSStackItem>
+                    <XDSHStack gap={1} vAlign="center">
+                      <XDSButton label="Open in Craft" variant="ghost" size="sm" icon={<XDSIcon icon={ArrowTopRightOnSquareIcon} />} />
+                      <XDSButton label="Send to CLI" variant="ghost" size="sm" />
+                      <XDSIconButton label="Fullscreen" variant="ghost" size="sm" icon={<XDSIcon icon={ArrowsPointingOutIcon} />} />
+                    </XDSHStack>
+                  </XDSHStack>
+                </XDSSection>
+                <XDSCenter height={280}>
+                  {previews[i] ?? (<XDSText type="supporting" color="secondary">Preview coming soon</XDSText>)}
+                </XDSCenter>
+                <XDSSection variant="wash" padding={3} dividers={['top']}>
+                  <XDSVStack gap={3}>
+                    <XDSTabList value={activeTab} onChange={value => setExampleTabs(prev => ({...prev, [tabKey]: value}))} size="sm" xstyle={styles.tabListFlush}>
+                      <XDSTab value="description" label="Description" />
+                      <XDSTab value="code" label="Code" />
+                    </XDSTabList>
+                    {activeTab === 'description' ? (
+                      <XDSText type="body">{example.description}</XDSText>
+                    ) : (
+                      <XDSCodeBlock code={example.code} language="tsx" />
+                    )}
                   </XDSVStack>
-                ))}
-              </XDSGrid>
-            </XDSVStack>
-          ))}
+                </XDSSection>
+              </XDSCard>
+            );
+          })}
+          </XDSVStack>
         </XDSVStack>
       </XDSLayoutContent>
     } />
@@ -157,35 +326,34 @@ function OverviewView({
 // ---------------------------------------------------------------------------
 
 export default function DesignDocumentationPage() {
+  const [activePage, setActivePage] = useState<string>('button');
+
   return (
     <XDSAppShell
       variant="section"
       height="fill"
       sideNav={
         <XDSSideNav
-          header={
-            <XDSSideNavHeading heading="Product Name" />
-          }>
-          <XDSSideNavSection title="Navigation" isHeaderHidden>
-            <XDSSideNavItem
-              label="Home"
-              isSelected
-            />
-          </XDSSideNavSection>
-
+          header={<XDSSideNavHeading heading="Product Name" />}>
           {COMPONENT_CATEGORIES.map(category => (
             <XDSSideNavSection key={category.label} title={category.label}>
               {category.items.map(item => (
                 <XDSSideNavItem
                   key={item.key}
                   label={item.name}
+                  isSelected={activePage === item.key}
+                  onClick={
+                    item.key === 'button'
+                      ? () => setActivePage(item.key)
+                      : undefined
+                  }
                 />
               ))}
             </XDSSideNavSection>
           ))}
         </XDSSideNav>
       }>
-      <OverviewView onSelectComponent={() => {}} />
+      <ComponentDetailView activeNav={activePage} />
     </XDSAppShell>
   );
 }

--- a/packages/cli/templates/pages/documentation-design/page.tsx
+++ b/packages/cli/templates/pages/documentation-design/page.tsx
@@ -1,0 +1,638 @@
+'use client';
+
+import {useState} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {XDSAppShell} from '@xds/core/AppShell';
+import {
+  XDSSideNav,
+  XDSSideNavHeading,
+  XDSSideNavItem,
+  XDSSideNavSection,
+} from '@xds/core/SideNav';
+import {XDSHeading, XDSText} from '@xds/core/Text';
+import {XDSButton} from '@xds/core/Button';
+import {XDSCard} from '@xds/core/Card';
+import {XDSBadge} from '@xds/core/Badge';
+import {XDSList, XDSListItem} from '@xds/core/List';
+import {XDSCodeBlock} from '@xds/core/CodeBlock';
+import {XDSHStack, XDSVStack, XDSStackItem} from '@xds/core/Stack';
+import {XDSLayout, XDSLayoutContent} from '@xds/core/Layout';
+import {XDSDivider} from '@xds/core/Divider';
+import {XDSTable, pixel} from '@xds/core/Table';
+import {XDSGrid} from '@xds/core/Grid';
+import {XDSSection} from '@xds/core/Section';
+
+// ---------------------------------------------------------------------------
+// Data — design foundation sections
+// ---------------------------------------------------------------------------
+
+const NAV_SECTIONS = [
+  {
+    label: 'Foundations',
+    items: [
+      {key: 'overview', name: 'Overview'},
+      {key: 'typography', name: 'Typography'},
+      {key: 'colors', name: 'Colors'},
+      {key: 'spacing', name: 'Spacing'},
+      {key: 'shape', name: 'Shape'},
+      {key: 'elevation', name: 'Elevation'},
+      {key: 'icons', name: 'Icons'},
+    ],
+  },
+  {
+    label: 'Patterns',
+    items: [
+      {key: 'layout-patterns', name: 'Layout Patterns'},
+      {key: 'responsive', name: 'Responsive Design'},
+      {key: 'motion', name: 'Motion & Animation'},
+      {key: 'accessibility', name: 'Accessibility'},
+    ],
+  },
+  {
+    label: 'Theming',
+    items: [
+      {key: 'theme-overview', name: 'Theme System'},
+      {key: 'custom-themes', name: 'Custom Themes'},
+      {key: 'dark-mode', name: 'Dark Mode'},
+    ],
+  },
+];
+
+const TYPE_SCALE: {
+  name: string;
+  token: string;
+  size: string;
+  weight: string;
+  lineHeight: string;
+  usage: string;
+}[] = [
+  {name: 'Display 1', token: 'display-1', size: '36px', weight: '700', lineHeight: '1.2', usage: 'Page titles and hero headings'},
+  {name: 'Display 2', token: 'display-2', size: '28px', weight: '700', lineHeight: '1.25', usage: 'Section headings'},
+  {name: 'Large', token: 'large', size: '20px', weight: '400', lineHeight: '1.4', usage: 'Lead paragraphs and introductions'},
+  {name: 'Body', token: 'body', size: '15px', weight: '400', lineHeight: '1.5', usage: 'Default body text'},
+  {name: 'Label', token: 'label', size: '13px', weight: '600', lineHeight: '1.4', usage: 'Form labels and small headings'},
+  {name: 'Supporting', token: 'supporting', size: '12px', weight: '400', lineHeight: '1.4', usage: 'Captions, timestamps, metadata'},
+];
+
+const COLOR_TOKENS: {
+  name: string;
+  token: string;
+  value: string;
+  usage: string;
+}[] = [
+  {name: 'Accent', token: '--color-accent', value: '#0066FF', usage: 'Primary actions, links, active states'},
+  {name: 'Accent Muted', token: '--color-accent-muted', value: '#DBEAFE', usage: 'Accent backgrounds, hover highlights'},
+  {name: 'Background', token: '--color-background', value: '#FFFFFF', usage: 'Page background'},
+  {name: 'Surface', token: '--color-surface', value: '#F9FAFB', usage: 'Card backgrounds, elevated containers'},
+  {name: 'Muted', token: '--color-muted', value: '#F3F4F6', usage: 'Subtle backgrounds, disabled states'},
+  {name: 'Text Primary', token: '--color-text-primary', value: '#111827', usage: 'Primary text content'},
+  {name: 'Text Secondary', token: '--color-text-secondary', value: '#6B7280', usage: 'Supporting text, labels, metadata'},
+  {name: 'Border', token: '--color-border', value: '#E5E7EB', usage: 'Card borders, dividers, input outlines'},
+  {name: 'Success', token: '--color-success', value: '#059669', usage: 'Success states, confirmations'},
+  {name: 'Warning', token: '--color-warning', value: '#D97706', usage: 'Warning states, caution indicators'},
+  {name: 'Error', token: '--color-error', value: '#DC2626', usage: 'Error states, destructive actions'},
+];
+
+const SPACING_SCALE: {
+  step: string;
+  value: string;
+  px: string;
+  usage: string;
+}[] = [
+  {step: '0', value: '0px', px: '0', usage: 'No spacing'},
+  {step: '0.5', value: '2px', px: '2', usage: 'Tight inline spacing'},
+  {step: '1', value: '4px', px: '4', usage: 'Compact gaps, icon margins'},
+  {step: '2', value: '8px', px: '8', usage: 'Default inline spacing, small gaps'},
+  {step: '3', value: '12px', px: '12', usage: 'Component padding, stack gaps'},
+  {step: '4', value: '16px', px: '16', usage: 'Card padding, section margins'},
+  {step: '5', value: '20px', px: '20', usage: 'Generous padding'},
+  {step: '6', value: '24px', px: '24', usage: 'Section spacing'},
+  {step: '8', value: '32px', px: '32', usage: 'Large section gaps'},
+  {step: '10', value: '40px', px: '40', usage: 'Page-level spacing'},
+];
+
+const RADIUS_TOKENS: {
+  name: string;
+  token: string;
+  value: string;
+  usage: string;
+}[] = [
+  {name: 'None', token: '--radius-none', value: '0px', usage: 'Sharp corners for full-bleed elements'},
+  {name: 'Small', token: '--radius-sm', value: '4px', usage: 'Badges, tokens, compact controls'},
+  {name: 'Control', token: '--radius-control', value: '8px', usage: 'Buttons, inputs, selectors'},
+  {name: 'Container', token: '--radius-container', value: '12px', usage: 'Cards, dialogs, panels'},
+  {name: 'Large', token: '--radius-lg', value: '16px', usage: 'Hero sections, feature cards'},
+  {name: 'Pill', token: '--radius-pill', value: '9999px', usage: 'Fully rounded pills, avatars'},
+];
+
+const ELEVATION_LEVELS: {
+  name: string;
+  token: string;
+  value: string;
+  usage: string;
+}[] = [
+  {name: 'None', token: '--elevation-0', value: 'none', usage: 'Flat elements on the surface'},
+  {name: 'Low', token: '--elevation-1', value: '0 1px 3px rgba(0,0,0,0.08)', usage: 'Cards, subtle lift on hover'},
+  {name: 'Medium', token: '--elevation-2', value: '0 4px 12px rgba(0,0,0,0.12)', usage: 'Dropdowns, popovers'},
+  {name: 'High', token: '--elevation-3', value: '0 8px 24px rgba(0,0,0,0.16)', usage: 'Dialogs, modals'},
+];
+
+// ---------------------------------------------------------------------------
+// Page content views
+// ---------------------------------------------------------------------------
+
+function OverviewPage() {
+  return (
+    <XDSLayout contentWidth={960} content={
+      <XDSLayoutContent padding={8}>
+        <XDSVStack gap={8}>
+          <XDSVStack gap={2}>
+            <XDSText type="display-1">Design Foundations</XDSText>
+            <XDSText type="large" weight="normal" color="secondary">
+              The design tokens and primitives that every component is built on.
+              Use these foundations to create consistent, accessible interfaces.
+            </XDSText>
+          </XDSVStack>
+
+          <XDSGrid columns={{minWidth: 280}} gap={4}>
+            {[
+              {title: 'Typography', desc: 'A type scale from display-1 down to supporting text, with weight and color options.', key: 'typography'},
+              {title: 'Colors', desc: 'A semantic palette that adapts across themes. Surface, text, border, and accent tokens.', key: 'colors'},
+              {title: 'Spacing', desc: 'A 4px-based scale for padding, margins, and gaps. Consistent rhythm across layouts.', key: 'spacing'},
+              {title: 'Shape', desc: 'Border radius tokens from sharp (0px) to fully rounded (pill). Intentional corner rounding.', key: 'shape'},
+              {title: 'Elevation', desc: 'Shadow tokens from flat to high elevation. Visual depth for layered interfaces.', key: 'elevation'},
+              {title: 'Icons', desc: 'Consistent icon set with semantic and non-semantic color options in multiple sizes.', key: 'icons'},
+            ].map(item => (
+              <XDSCard key={item.key} padding={5}>
+                <XDSVStack gap={1}>
+                  <XDSText type="body" weight="bold">{item.title}</XDSText>
+                  <XDSText type="body" color="secondary">{item.desc}</XDSText>
+                </XDSVStack>
+              </XDSCard>
+            ))}
+          </XDSGrid>
+
+          <XDSDivider />
+
+          <XDSVStack gap={4}>
+            <XDSHeading level={2}>Design Principles</XDSHeading>
+            <XDSList density="spacious" listStyle="disc">
+              <XDSListItem label="Consistency — Use tokens instead of raw values. Components inherit from the theme automatically." />
+              <XDSListItem label="Accessibility — WCAG AA contrast ratios. Keyboard navigable. Screen reader friendly." />
+              <XDSListItem label="Composability — Small, focused components that combine into complex interfaces." />
+              <XDSListItem label="Themeable — Every visual decision flows from tokens. Swap an entire look with one theme." />
+            </XDSList>
+          </XDSVStack>
+        </XDSVStack>
+      </XDSLayoutContent>
+    } />
+  );
+}
+
+function TypographyPage() {
+  return (
+    <XDSLayout contentWidth={960} content={
+      <XDSLayoutContent padding={8}>
+        <XDSVStack gap={8}>
+          <XDSVStack gap={2}>
+            <XDSText type="display-1">Typography</XDSText>
+            <XDSText type="body" color="secondary">
+              A type scale from display headings down to supporting text. Establishes
+              visual hierarchy without guessing font sizes.
+            </XDSText>
+          </XDSVStack>
+
+          {/* Visual preview */}
+          <XDSCard variant="muted" padding={8}>
+            <XDSVStack gap={6}>
+              <XDSText type="display-1">Display 1</XDSText>
+              <XDSText type="display-2">Display 2</XDSText>
+              <XDSText type="large">Large text</XDSText>
+              <XDSText type="body">Body text — the default for reading content.</XDSText>
+              <XDSText type="label">Label text</XDSText>
+              <XDSText type="supporting">Supporting text</XDSText>
+            </XDSVStack>
+          </XDSCard>
+
+          {/* Scale table */}
+          <XDSVStack gap={4}>
+            <XDSHeading level={2}>Type Scale</XDSHeading>
+            <XDSTable
+              data={TYPE_SCALE as Record<string, unknown>[]}
+              columns={[
+                {key: 'name', header: 'Name', width: pixel(130)},
+                {key: 'token', header: 'Token', width: pixel(120), renderCell: (item: Record<string, unknown>) => (
+                  <XDSText type="supporting" style={{fontFamily: 'monospace', fontSize: 12}}>{item.token as string}</XDSText>
+                )},
+                {key: 'size', header: 'Size', width: pixel(80)},
+                {key: 'weight', header: 'Weight', width: pixel(80)},
+                {key: 'lineHeight', header: 'Line Height', width: pixel(100)},
+                {key: 'usage', header: 'Usage'},
+              ]}
+              density="spacious"
+              dividers="rows"
+            />
+          </XDSVStack>
+
+          <XDSDivider />
+
+          {/* Usage example */}
+          <XDSVStack gap={4}>
+            <XDSHeading level={2}>Usage</XDSHeading>
+            <XDSCard padding={0}>
+              <XDSCodeBlock
+                code={`import { XDSHeading, XDSText } from '@xds/core/Text';
+
+<XDSHeading level={1}>Page Title</XDSHeading>
+<XDSText type="body" color="secondary">
+  Supporting description text.
+</XDSText>
+<XDSText type="supporting">Metadata · Timestamp</XDSText>`}
+                language="tsx"
+              />
+            </XDSCard>
+          </XDSVStack>
+
+          <XDSDivider />
+
+          <XDSVStack gap={4}>
+            <XDSHeading level={2}>Guidelines</XDSHeading>
+            <XDSList density="spacious" listStyle="disc">
+              <XDSListItem label="Use display-1 for page titles. Only one per page." />
+              <XDSListItem label="Use display-2 for section headings within a page." />
+              <XDSListItem label="Body text is the default. Use it for paragraphs and content." />
+              <XDSListItem label="Supporting text for timestamps, captions, and metadata." />
+              <XDSListItem label="Don't skip heading levels — go from h1 to h2, not h1 to h3." />
+            </XDSList>
+          </XDSVStack>
+        </XDSVStack>
+      </XDSLayoutContent>
+    } />
+  );
+}
+
+function ColorsPage() {
+  return (
+    <XDSLayout contentWidth={960} content={
+      <XDSLayoutContent padding={8}>
+        <XDSVStack gap={8}>
+          <XDSVStack gap={2}>
+            <XDSText type="display-1">Colors</XDSText>
+            <XDSText type="body" color="secondary">
+              A semantic palette that adapts across themes. Use surface, text,
+              border, and accent tokens instead of raw hex values.
+            </XDSText>
+          </XDSVStack>
+
+          {/* Color swatches */}
+          <XDSGrid columns={{minWidth: 160}} gap={4}>
+            {COLOR_TOKENS.map(color => (
+              <XDSCard key={color.token} padding={0}>
+                <div
+                  style={{
+                    height: 80,
+                    backgroundColor: color.value,
+                    borderRadius: '12px 12px 0 0',
+                    border: color.value === '#FFFFFF' ? '1px solid #E5E7EB' : 'none',
+                    borderBottom: 'none',
+                  }}
+                />
+                <XDSSection padding={3}>
+                  <XDSVStack gap={0.5}>
+                    <XDSText type="body" weight="bold">{color.name}</XDSText>
+                    <XDSText type="supporting" color="secondary" style={{fontFamily: 'monospace', fontSize: 11}}>
+                      {color.value}
+                    </XDSText>
+                  </XDSVStack>
+                </XDSSection>
+              </XDSCard>
+            ))}
+          </XDSGrid>
+
+          {/* Token reference table */}
+          <XDSVStack gap={4}>
+            <XDSHeading level={2}>Token Reference</XDSHeading>
+            <XDSTable
+              data={COLOR_TOKENS as Record<string, unknown>[]}
+              columns={[
+                {key: 'name', header: 'Name', width: pixel(140)},
+                {key: 'token', header: 'Token', width: pixel(200), renderCell: (item: Record<string, unknown>) => (
+                  <XDSText type="supporting" style={{fontFamily: 'monospace', fontSize: 12}}>{item.token as string}</XDSText>
+                )},
+                {key: 'value', header: 'Default', width: pixel(100), renderCell: (item: Record<string, unknown>) => (
+                  <XDSHStack gap={2} vAlign="center">
+                    <div style={{width: 16, height: 16, borderRadius: 4, backgroundColor: item.value as string, border: '1px solid rgba(0,0,0,0.1)', flexShrink: 0}} />
+                    <XDSText type="supporting" style={{fontFamily: 'monospace', fontSize: 11}}>{item.value as string}</XDSText>
+                  </XDSHStack>
+                )},
+                {key: 'usage', header: 'Usage'},
+              ]}
+              density="spacious"
+              dividers="rows"
+            />
+          </XDSVStack>
+
+          <XDSDivider />
+
+          <XDSVStack gap={4}>
+            <XDSHeading level={2}>Usage</XDSHeading>
+            <XDSCard padding={0}>
+              <XDSCodeBlock
+                code={`// Use semantic tokens — they adapt across themes
+<XDSText color="secondary">Muted text</XDSText>
+<XDSButton variant="primary">Accent color</XDSButton>
+<XDSCard variant="muted">Surface background</XDSCard>
+
+// Never use raw hex values in component code
+// ❌ style={{ color: '#6B7280' }}
+// ✅ <XDSText color="secondary">`}
+                language="tsx"
+              />
+            </XDSCard>
+          </XDSVStack>
+        </XDSVStack>
+      </XDSLayoutContent>
+    } />
+  );
+}
+
+function SpacingPage() {
+  return (
+    <XDSLayout contentWidth={960} content={
+      <XDSLayoutContent padding={8}>
+        <XDSVStack gap={8}>
+          <XDSVStack gap={2}>
+            <XDSText type="display-1">Spacing</XDSText>
+            <XDSText type="body" color="secondary">
+              A 4px-based scale used for padding, margins, and gaps. Keeps
+              layouts aligned to a consistent rhythm across every component.
+            </XDSText>
+          </XDSVStack>
+
+          {/* Visual scale */}
+          <XDSCard variant="muted" padding={6}>
+            <XDSVStack gap={3}>
+              {SPACING_SCALE.filter(s => parseInt(s.px) > 0).map(space => (
+                <XDSHStack key={space.step} gap={4} vAlign="center">
+                  <XDSText type="supporting" color="secondary" style={{fontFamily: 'monospace', width: 40, textAlign: 'right', flexShrink: 0}}>
+                    {space.step}
+                  </XDSText>
+                  <div
+                    style={{
+                      width: parseInt(space.px),
+                      height: 24,
+                      backgroundColor: 'var(--color-accent, #0066FF)',
+                      borderRadius: 4,
+                      opacity: 0.7,
+                      flexShrink: 0,
+                    }}
+                  />
+                  <XDSText type="supporting" color="secondary">{space.value}</XDSText>
+                </XDSHStack>
+              ))}
+            </XDSVStack>
+          </XDSCard>
+
+          {/* Table */}
+          <XDSVStack gap={4}>
+            <XDSHeading level={2}>Scale Reference</XDSHeading>
+            <XDSTable
+              data={SPACING_SCALE as Record<string, unknown>[]}
+              columns={[
+                {key: 'step', header: 'Step', width: pixel(80)},
+                {key: 'value', header: 'Value', width: pixel(100)},
+                {key: 'usage', header: 'Usage'},
+              ]}
+              density="spacious"
+              dividers="rows"
+            />
+          </XDSVStack>
+
+          <XDSDivider />
+
+          <XDSVStack gap={4}>
+            <XDSHeading level={2}>Usage</XDSHeading>
+            <XDSCard padding={0}>
+              <XDSCodeBlock
+                code={`// Use the gap prop on Stack and Grid components
+<XDSVStack gap={4}>  {/* 16px gap */}
+  <XDSHeading level={2}>Section</XDSHeading>
+  <XDSText type="body">Content</XDSText>
+</XDSVStack>
+
+// Use the padding prop on Card and Section
+<XDSCard padding={6}>  {/* 24px padding */}
+  <XDSText type="body">Card content</XDSText>
+</XDSCard>`}
+                language="tsx"
+              />
+            </XDSCard>
+          </XDSVStack>
+        </XDSVStack>
+      </XDSLayoutContent>
+    } />
+  );
+}
+
+function ShapePage() {
+  return (
+    <XDSLayout contentWidth={960} content={
+      <XDSLayoutContent padding={8}>
+        <XDSVStack gap={8}>
+          <XDSVStack gap={2}>
+            <XDSText type="display-1">Shape</XDSText>
+            <XDSText type="body" color="secondary">
+              Border radius tokens from sharp to fully rounded. Controls, cards,
+              and containers each have a designated radius so shapes feel intentional.
+            </XDSText>
+          </XDSVStack>
+
+          {/* Visual preview */}
+          <XDSCard variant="muted" padding={8}>
+            <XDSHStack gap={6} vAlign="end" style={{justifyContent: 'center'}}>
+              {RADIUS_TOKENS.map(radius => (
+                <XDSVStack key={radius.token} gap={2} hAlign="center">
+                  <div
+                    style={{
+                      width: 64,
+                      height: 64,
+                      borderRadius: radius.value === '9999px' ? 9999 : parseInt(radius.value),
+                      backgroundColor: 'var(--color-accent, #0066FF)',
+                      opacity: 0.8,
+                    }}
+                  />
+                  <XDSText type="supporting" weight="semibold">{radius.name}</XDSText>
+                  <XDSText type="supporting" color="secondary" style={{fontFamily: 'monospace', fontSize: 11}}>
+                    {radius.value}
+                  </XDSText>
+                </XDSVStack>
+              ))}
+            </XDSHStack>
+          </XDSCard>
+
+          {/* Table */}
+          <XDSVStack gap={4}>
+            <XDSHeading level={2}>Radius Tokens</XDSHeading>
+            <XDSTable
+              data={RADIUS_TOKENS as Record<string, unknown>[]}
+              columns={[
+                {key: 'name', header: 'Name', width: pixel(120)},
+                {key: 'token', header: 'Token', width: pixel(200), renderCell: (item: Record<string, unknown>) => (
+                  <XDSText type="supporting" style={{fontFamily: 'monospace', fontSize: 12}}>{item.token as string}</XDSText>
+                )},
+                {key: 'value', header: 'Value', width: pixel(100)},
+                {key: 'usage', header: 'Usage'},
+              ]}
+              density="spacious"
+              dividers="rows"
+            />
+          </XDSVStack>
+        </XDSVStack>
+      </XDSLayoutContent>
+    } />
+  );
+}
+
+function ElevationPage() {
+  return (
+    <XDSLayout contentWidth={960} content={
+      <XDSLayoutContent padding={8}>
+        <XDSVStack gap={8}>
+          <XDSVStack gap={2}>
+            <XDSText type="display-1">Elevation</XDSText>
+            <XDSText type="body" color="secondary">
+              Shadow tokens that create visual depth. Higher elevation = more
+              prominence. Use sparingly to maintain visual clarity.
+            </XDSText>
+          </XDSVStack>
+
+          {/* Visual preview */}
+          <XDSCard variant="muted" padding={8}>
+            <XDSHStack gap={8} vAlign="center" style={{justifyContent: 'center'}}>
+              {ELEVATION_LEVELS.map(level => (
+                <XDSVStack key={level.token} gap={3} hAlign="center">
+                  <div
+                    style={{
+                      width: 96,
+                      height: 96,
+                      borderRadius: 12,
+                      backgroundColor: 'var(--color-background, #fff)',
+                      boxShadow: level.value,
+                      border: level.value === 'none' ? '1px solid var(--color-border, #E5E7EB)' : 'none',
+                    }}
+                  />
+                  <XDSText type="supporting" weight="semibold">{level.name}</XDSText>
+                </XDSVStack>
+              ))}
+            </XDSHStack>
+          </XDSCard>
+
+          {/* Table */}
+          <XDSVStack gap={4}>
+            <XDSHeading level={2}>Elevation Tokens</XDSHeading>
+            <XDSTable
+              data={ELEVATION_LEVELS as Record<string, unknown>[]}
+              columns={[
+                {key: 'name', header: 'Level', width: pixel(100)},
+                {key: 'token', header: 'Token', width: pixel(160), renderCell: (item: Record<string, unknown>) => (
+                  <XDSText type="supporting" style={{fontFamily: 'monospace', fontSize: 12}}>{item.token as string}</XDSText>
+                )},
+                {key: 'value', header: 'Value', width: pixel(260), renderCell: (item: Record<string, unknown>) => (
+                  <XDSText type="supporting" style={{fontFamily: 'monospace', fontSize: 12}}>{item.value as string}</XDSText>
+                )},
+                {key: 'usage', header: 'Usage'},
+              ]}
+              density="spacious"
+              dividers="rows"
+            />
+          </XDSVStack>
+        </XDSVStack>
+      </XDSLayoutContent>
+    } />
+  );
+}
+
+function PlaceholderPage({title, description}: {title: string; description: string}) {
+  return (
+    <XDSLayout contentWidth={960} content={
+      <XDSLayoutContent padding={8}>
+        <XDSVStack gap={8}>
+          <XDSVStack gap={2}>
+            <XDSText type="display-1">{title}</XDSText>
+            <XDSText type="body" color="secondary">{description}</XDSText>
+          </XDSVStack>
+          <XDSCard variant="muted" padding={10}>
+            <XDSVStack gap={3} hAlign="center" style={{textAlign: 'center'}}>
+              <XDSText type="body" color="secondary">Documentation coming soon</XDSText>
+              <XDSBadge label="In Progress" variant="info" />
+            </XDSVStack>
+          </XDSCard>
+        </XDSVStack>
+      </XDSLayoutContent>
+    } />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Page content router
+// ---------------------------------------------------------------------------
+
+const PAGE_CONTENT: Record<string, {title: string; description: string}> = {
+  icons: {title: 'Icons', description: 'Consistent icon set with semantic and non-semantic color options in multiple sizes.'},
+  'layout-patterns': {title: 'Layout Patterns', description: 'Common layout compositions using Stack, Grid, AppShell, and responsive breakpoints.'},
+  responsive: {title: 'Responsive Design', description: 'Breakpoint system, container queries, and mobile-first design patterns.'},
+  motion: {title: 'Motion & Animation', description: 'Transition tokens, keyframes, and animation patterns for smooth, purposeful motion.'},
+  accessibility: {title: 'Accessibility', description: 'WCAG AA compliance, keyboard navigation, screen reader support, and ARIA patterns.'},
+  'theme-overview': {title: 'Theme System', description: 'How theming works: providers, tokens, and runtime theme switching.'},
+  'custom-themes': {title: 'Custom Themes', description: 'Create and publish custom themes with your own colors, typography, and radius.'},
+  'dark-mode': {title: 'Dark Mode', description: 'Implementing dark mode with theme switching and system preference detection.'},
+};
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export default function DesignDocumentationPage() {
+  const [activePage, setActivePage] = useState<string>('overview');
+
+  const renderContent = () => {
+    switch (activePage) {
+      case 'overview': return <OverviewPage />;
+      case 'typography': return <TypographyPage />;
+      case 'colors': return <ColorsPage />;
+      case 'spacing': return <SpacingPage />;
+      case 'shape': return <ShapePage />;
+      case 'elevation': return <ElevationPage />;
+      default: {
+        const info = PAGE_CONTENT[activePage];
+        if (info) return <PlaceholderPage title={info.title} description={info.description} />;
+        return <OverviewPage />;
+      }
+    }
+  };
+
+  return (
+    <XDSAppShell
+      variant="section"
+      height="fill"
+      sideNav={
+        <XDSSideNav
+          header={<XDSSideNavHeading heading="Design System" />}>
+          {NAV_SECTIONS.map(section => (
+            <XDSSideNavSection key={section.label} title={section.label}>
+              {section.items.map(item => (
+                <XDSSideNavItem
+                  key={item.key}
+                  label={item.name}
+                  isSelected={activePage === item.key}
+                  onClick={() => setActivePage(item.key)}
+                />
+              ))}
+            </XDSSideNavSection>
+          ))}
+        </XDSSideNav>
+      }>
+      {renderContent()}
+    </XDSAppShell>
+  );
+}

--- a/packages/cli/templates/pages/documentation-design/page.tsx
+++ b/packages/cli/templates/pages/documentation-design/page.tsx
@@ -10,561 +10,110 @@ import {
   XDSSideNavSection,
 } from '@xds/core/SideNav';
 import {XDSHeading, XDSText} from '@xds/core/Text';
-import {XDSButton} from '@xds/core/Button';
 import {XDSCard} from '@xds/core/Card';
-import {XDSBadge} from '@xds/core/Badge';
-import {XDSList, XDSListItem} from '@xds/core/List';
 import {XDSCodeBlock} from '@xds/core/CodeBlock';
 import {XDSHStack, XDSVStack, XDSStackItem} from '@xds/core/Stack';
 import {XDSLayout, XDSLayoutContent} from '@xds/core/Layout';
 import {XDSDivider} from '@xds/core/Divider';
 import {XDSTable, pixel} from '@xds/core/Table';
 import {XDSGrid} from '@xds/core/Grid';
-import {XDSSection} from '@xds/core/Section';
+import {radiusVars} from '@xds/core/theme/tokens.stylex';
 
-// ---------------------------------------------------------------------------
-// Data — design foundation sections
-// ---------------------------------------------------------------------------
-
-const NAV_SECTIONS = [
-  {
-    label: 'Foundations',
-    items: [
-      {key: 'overview', name: 'Overview'},
-      {key: 'typography', name: 'Typography'},
-      {key: 'colors', name: 'Colors'},
-      {key: 'spacing', name: 'Spacing'},
-      {key: 'shape', name: 'Shape'},
-      {key: 'elevation', name: 'Elevation'},
-      {key: 'icons', name: 'Icons'},
-    ],
+const styles = stylex.create({
+  previewCard: {
+    borderRadius: radiusVars['--radius-container'],
+    cursor: 'pointer',
   },
-  {
-    label: 'Patterns',
-    items: [
-      {key: 'layout-patterns', name: 'Layout Patterns'},
-      {key: 'responsive', name: 'Responsive Design'},
-      {key: 'motion', name: 'Motion & Animation'},
-      {key: 'accessibility', name: 'Accessibility'},
-    ],
-  },
-  {
-    label: 'Theming',
-    items: [
-      {key: 'theme-overview', name: 'Theme System'},
-      {key: 'custom-themes', name: 'Custom Themes'},
-      {key: 'dark-mode', name: 'Dark Mode'},
-    ],
-  },
-];
+});
 
-const TYPE_SCALE: {
-  name: string;
-  token: string;
-  size: string;
-  weight: string;
-  lineHeight: string;
-  usage: string;
-}[] = [
-  {name: 'Display 1', token: 'display-1', size: '36px', weight: '700', lineHeight: '1.2', usage: 'Page titles and hero headings'},
-  {name: 'Display 2', token: 'display-2', size: '28px', weight: '700', lineHeight: '1.25', usage: 'Section headings'},
-  {name: 'Large', token: 'large', size: '20px', weight: '400', lineHeight: '1.4', usage: 'Lead paragraphs and introductions'},
-  {name: 'Body', token: 'body', size: '15px', weight: '400', lineHeight: '1.5', usage: 'Default body text'},
-  {name: 'Label', token: 'label', size: '13px', weight: '600', lineHeight: '1.4', usage: 'Form labels and small headings'},
-  {name: 'Supporting', token: 'supporting', size: '12px', weight: '400', lineHeight: '1.4', usage: 'Captions, timestamps, metadata'},
-];
+// ---------------------------------------------------------------------------
+// Data
+// ---------------------------------------------------------------------------
 
-const COLOR_TOKENS: {
-  name: string;
-  token: string;
-  value: string;
-  usage: string;
-}[] = [
-  {name: 'Accent', token: '--color-accent', value: '#0066FF', usage: 'Primary actions, links, active states'},
-  {name: 'Accent Muted', token: '--color-accent-muted', value: '#DBEAFE', usage: 'Accent backgrounds, hover highlights'},
-  {name: 'Background', token: '--color-background', value: '#FFFFFF', usage: 'Page background'},
-  {name: 'Surface', token: '--color-surface', value: '#F9FAFB', usage: 'Card backgrounds, elevated containers'},
-  {name: 'Muted', token: '--color-muted', value: '#F3F4F6', usage: 'Subtle backgrounds, disabled states'},
-  {name: 'Text Primary', token: '--color-text-primary', value: '#111827', usage: 'Primary text content'},
-  {name: 'Text Secondary', token: '--color-text-secondary', value: '#6B7280', usage: 'Supporting text, labels, metadata'},
-  {name: 'Border', token: '--color-border', value: '#E5E7EB', usage: 'Card borders, dividers, input outlines'},
-  {name: 'Success', token: '--color-success', value: '#059669', usage: 'Success states, confirmations'},
-  {name: 'Warning', token: '--color-warning', value: '#D97706', usage: 'Warning states, caution indicators'},
-  {name: 'Error', token: '--color-error', value: '#DC2626', usage: 'Error states, destructive actions'},
-];
-
-const SPACING_SCALE: {
-  step: string;
-  value: string;
-  px: string;
-  usage: string;
-}[] = [
-  {step: '0', value: '0px', px: '0', usage: 'No spacing'},
-  {step: '0.5', value: '2px', px: '2', usage: 'Tight inline spacing'},
-  {step: '1', value: '4px', px: '4', usage: 'Compact gaps, icon margins'},
-  {step: '2', value: '8px', px: '8', usage: 'Default inline spacing, small gaps'},
-  {step: '3', value: '12px', px: '12', usage: 'Component padding, stack gaps'},
-  {step: '4', value: '16px', px: '16', usage: 'Card padding, section margins'},
-  {step: '5', value: '20px', px: '20', usage: 'Generous padding'},
-  {step: '6', value: '24px', px: '24', usage: 'Section spacing'},
-  {step: '8', value: '32px', px: '32', usage: 'Large section gaps'},
-  {step: '10', value: '40px', px: '40', usage: 'Page-level spacing'},
-];
-
-const RADIUS_TOKENS: {
-  name: string;
-  token: string;
-  value: string;
-  usage: string;
-}[] = [
-  {name: 'None', token: '--radius-none', value: '0px', usage: 'Sharp corners for full-bleed elements'},
-  {name: 'Small', token: '--radius-sm', value: '4px', usage: 'Badges, tokens, compact controls'},
-  {name: 'Control', token: '--radius-control', value: '8px', usage: 'Buttons, inputs, selectors'},
-  {name: 'Container', token: '--radius-container', value: '12px', usage: 'Cards, dialogs, panels'},
-  {name: 'Large', token: '--radius-lg', value: '16px', usage: 'Hero sections, feature cards'},
-  {name: 'Pill', token: '--radius-pill', value: '9999px', usage: 'Fully rounded pills, avatars'},
-];
-
-const ELEVATION_LEVELS: {
-  name: string;
-  token: string;
-  value: string;
-  usage: string;
-}[] = [
-  {name: 'None', token: '--elevation-0', value: 'none', usage: 'Flat elements on the surface'},
-  {name: 'Low', token: '--elevation-1', value: '0 1px 3px rgba(0,0,0,0.08)', usage: 'Cards, subtle lift on hover'},
-  {name: 'Medium', token: '--elevation-2', value: '0 4px 12px rgba(0,0,0,0.12)', usage: 'Dropdowns, popovers'},
-  {name: 'High', token: '--elevation-3', value: '0 8px 24px rgba(0,0,0,0.16)', usage: 'Dialogs, modals'},
+const FOUNDATION_SECTIONS = [
+  {key: 'typography', name: 'Typography', desc: 'A type scale from display-1 down to supporting text, with weight and color options. Establishes visual hierarchy without guessing font sizes.'},
+  {key: 'colors', name: 'Colors', desc: 'A semantic palette that adapts across themes. Use surface, text, border, and accent tokens instead of raw hex values so your UI stays consistent.'},
+  {key: 'spacing', name: 'Spacing', desc: 'A 4px-based scale (0–10) used for padding, margins, and gaps. Keeps layouts aligned to a consistent rhythm across every component and page.'},
+  {key: 'shape', name: 'Shape', desc: 'Border radius tokens from sharp (2px) to fully rounded (pill). Controls, cards, and containers each have a designated radius so shapes feel intentional.'},
+  {key: 'icons', name: 'Icons', desc: 'A consistent icon set built for XDS components. Semantic and non-semantic color options with multiple sizes.'},
 ];
 
 // ---------------------------------------------------------------------------
-// Page content views
+// Sub-views
 // ---------------------------------------------------------------------------
 
-function OverviewPage() {
+function OverviewView({
+  onSelectSection,
+}: {
+  onSelectSection: (key: string) => void;
+}) {
   return (
-    <XDSLayout contentWidth={960} content={
+    <XDSLayout contentWidth={1200} content={
       <XDSLayoutContent padding={8}>
-        <XDSVStack gap={8}>
-          <XDSVStack gap={2}>
-            <XDSText type="display-1">Design Foundations</XDSText>
-            <XDSText type="large" weight="normal" color="secondary">
-              The design tokens and primitives that every component is built on.
-              Use these foundations to create consistent, accessible interfaces.
-            </XDSText>
-          </XDSVStack>
-
-          <XDSGrid columns={{minWidth: 280}} gap={4}>
-            {[
-              {title: 'Typography', desc: 'A type scale from display-1 down to supporting text, with weight and color options.', key: 'typography'},
-              {title: 'Colors', desc: 'A semantic palette that adapts across themes. Surface, text, border, and accent tokens.', key: 'colors'},
-              {title: 'Spacing', desc: 'A 4px-based scale for padding, margins, and gaps. Consistent rhythm across layouts.', key: 'spacing'},
-              {title: 'Shape', desc: 'Border radius tokens from sharp (0px) to fully rounded (pill). Intentional corner rounding.', key: 'shape'},
-              {title: 'Elevation', desc: 'Shadow tokens from flat to high elevation. Visual depth for layered interfaces.', key: 'elevation'},
-              {title: 'Icons', desc: 'Consistent icon set with semantic and non-semantic color options in multiple sizes.', key: 'icons'},
-            ].map(item => (
-              <XDSCard key={item.key} padding={5}>
-                <XDSVStack gap={1}>
-                  <XDSText type="body" weight="bold">{item.title}</XDSText>
-                  <XDSText type="body" color="secondary">{item.desc}</XDSText>
+        <XDSVStack gap={10}>
+          <XDSCard variant="cyan" padding={10}>
+            <XDSHStack gap={8} vAlign="center">
+              <XDSStackItem size="fill">
+                <XDSVStack gap={4}>
+                  <XDSText type="display-1">Design foundations</XDSText>
+                  <XDSText type="large" weight="normal" color="secondary">
+                    The design tokens and primitives that every component is
+                    built on. Use these foundations to create consistent,
+                    accessible interfaces.
+                  </XDSText>
                 </XDSVStack>
-              </XDSCard>
-            ))}
-          </XDSGrid>
-
-          <XDSDivider />
-
-          <XDSVStack gap={4}>
-            <XDSHeading level={2}>Design Principles</XDSHeading>
-            <XDSList density="spacious" listStyle="disc">
-              <XDSListItem label="Consistency — Use tokens instead of raw values. Components inherit from the theme automatically." />
-              <XDSListItem label="Accessibility — WCAG AA contrast ratios. Keyboard navigable. Screen reader friendly." />
-              <XDSListItem label="Composability — Small, focused components that combine into complex interfaces." />
-              <XDSListItem label="Themeable — Every visual decision flows from tokens. Swap an entire look with one theme." />
-            </XDSList>
-          </XDSVStack>
-        </XDSVStack>
-      </XDSLayoutContent>
-    } />
-  );
-}
-
-function TypographyPage() {
-  return (
-    <XDSLayout contentWidth={960} content={
-      <XDSLayoutContent padding={8}>
-        <XDSVStack gap={8}>
-          <XDSVStack gap={2}>
-            <XDSText type="display-1">Typography</XDSText>
-            <XDSText type="body" color="secondary">
-              A type scale from display headings down to supporting text. Establishes
-              visual hierarchy without guessing font sizes.
-            </XDSText>
-          </XDSVStack>
-
-          {/* Visual preview */}
-          <XDSCard variant="muted" padding={8}>
-            <XDSVStack gap={6}>
-              <XDSText type="display-1">Display 1</XDSText>
-              <XDSText type="display-2">Display 2</XDSText>
-              <XDSText type="large">Large text</XDSText>
-              <XDSText type="body">Body text — the default for reading content.</XDSText>
-              <XDSText type="label">Label text</XDSText>
-              <XDSText type="supporting">Supporting text</XDSText>
-            </XDSVStack>
+              </XDSStackItem>
+              <XDSStackItem size="fill" />
+            </XDSHStack>
           </XDSCard>
 
-          {/* Scale table */}
-          <XDSVStack gap={4}>
-            <XDSHeading level={2}>Type Scale</XDSHeading>
-            <XDSTable
-              data={TYPE_SCALE as Record<string, unknown>[]}
-              columns={[
-                {key: 'name', header: 'Name', width: pixel(130)},
-                {key: 'token', header: 'Token', width: pixel(120), renderCell: (item: Record<string, unknown>) => (
-                  <XDSText type="supporting" style={{fontFamily: 'monospace', fontSize: 12}}>{item.token as string}</XDSText>
-                )},
-                {key: 'size', header: 'Size', width: pixel(80)},
-                {key: 'weight', header: 'Weight', width: pixel(80)},
-                {key: 'lineHeight', header: 'Line Height', width: pixel(100)},
-                {key: 'usage', header: 'Usage'},
-              ]}
-              density="spacious"
-              dividers="rows"
-            />
-          </XDSVStack>
-
-          <XDSDivider />
-
-          {/* Usage example */}
-          <XDSVStack gap={4}>
-            <XDSHeading level={2}>Usage</XDSHeading>
-            <XDSCard padding={0}>
-              <XDSCodeBlock
-                code={`import { XDSHeading, XDSText } from '@xds/core/Text';
-
-<XDSHeading level={1}>Page Title</XDSHeading>
-<XDSText type="body" color="secondary">
-  Supporting description text.
-</XDSText>
-<XDSText type="supporting">Metadata · Timestamp</XDSText>`}
-                language="tsx"
-              />
-            </XDSCard>
-          </XDSVStack>
-
-          <XDSDivider />
-
-          <XDSVStack gap={4}>
-            <XDSHeading level={2}>Guidelines</XDSHeading>
-            <XDSList density="spacious" listStyle="disc">
-              <XDSListItem label="Use display-1 for page titles. Only one per page." />
-              <XDSListItem label="Use display-2 for section headings within a page." />
-              <XDSListItem label="Body text is the default. Use it for paragraphs and content." />
-              <XDSListItem label="Supporting text for timestamps, captions, and metadata." />
-              <XDSListItem label="Don't skip heading levels — go from h1 to h2, not h1 to h3." />
-            </XDSList>
-          </XDSVStack>
-        </XDSVStack>
-      </XDSLayoutContent>
-    } />
-  );
-}
-
-function ColorsPage() {
-  return (
-    <XDSLayout contentWidth={960} content={
-      <XDSLayoutContent padding={8}>
-        <XDSVStack gap={8}>
-          <XDSVStack gap={2}>
-            <XDSText type="display-1">Colors</XDSText>
-            <XDSText type="body" color="secondary">
-              A semantic palette that adapts across themes. Use surface, text,
-              border, and accent tokens instead of raw hex values.
-            </XDSText>
-          </XDSVStack>
-
-          {/* Color swatches */}
-          <XDSGrid columns={{minWidth: 160}} gap={4}>
-            {COLOR_TOKENS.map(color => (
-              <XDSCard key={color.token} padding={0}>
-                <div
-                  style={{
-                    height: 80,
-                    backgroundColor: color.value,
-                    borderRadius: '12px 12px 0 0',
-                    border: color.value === '#FFFFFF' ? '1px solid #E5E7EB' : 'none',
-                    borderBottom: 'none',
-                  }}
+          <XDSGrid columns={{minWidth: 260}} gap={8}>
+            {FOUNDATION_SECTIONS.map(item => (
+              <XDSVStack key={item.key} gap={3}>
+                <XDSCard
+                  variant="muted"
+                  padding={0}
+                  minHeight={160}
+                  xstyle={styles.previewCard}
+                  onClick={() => onSelectSection(item.key)}
                 />
-                <XDSSection padding={3}>
-                  <XDSVStack gap={0.5}>
-                    <XDSText type="body" weight="bold">{color.name}</XDSText>
-                    <XDSText type="supporting" color="secondary" style={{fontFamily: 'monospace', fontSize: 11}}>
-                      {color.value}
-                    </XDSText>
-                  </XDSVStack>
-                </XDSSection>
-              </XDSCard>
+                <XDSVStack gap={0.5}>
+                  <XDSText type="body" weight="bold">
+                    {item.name}
+                  </XDSText>
+                  <XDSText type="body" color="secondary">
+                    {item.desc}
+                  </XDSText>
+                </XDSVStack>
+              </XDSVStack>
             ))}
           </XDSGrid>
+        </XDSVStack>
+      </XDSLayoutContent>
+    } />
+  );
+}
 
-          {/* Token reference table */}
-          <XDSVStack gap={4}>
-            <XDSHeading level={2}>Token Reference</XDSHeading>
-            <XDSTable
-              data={COLOR_TOKENS as Record<string, unknown>[]}
-              columns={[
-                {key: 'name', header: 'Name', width: pixel(140)},
-                {key: 'token', header: 'Token', width: pixel(200), renderCell: (item: Record<string, unknown>) => (
-                  <XDSText type="supporting" style={{fontFamily: 'monospace', fontSize: 12}}>{item.token as string}</XDSText>
-                )},
-                {key: 'value', header: 'Default', width: pixel(100), renderCell: (item: Record<string, unknown>) => (
-                  <XDSHStack gap={2} vAlign="center">
-                    <div style={{width: 16, height: 16, borderRadius: 4, backgroundColor: item.value as string, border: '1px solid rgba(0,0,0,0.1)', flexShrink: 0}} />
-                    <XDSText type="supporting" style={{fontFamily: 'monospace', fontSize: 11}}>{item.value as string}</XDSText>
-                  </XDSHStack>
-                )},
-                {key: 'usage', header: 'Usage'},
-              ]}
-              density="spacious"
-              dividers="rows"
-            />
+function FoundationDetailView({activeNav}: {activeNav: string}) {
+  const item = FOUNDATION_SECTIONS.find(s => s.key === activeNav);
+  if (!item) return null;
+
+  return (
+    <XDSLayout contentWidth={960} content={
+      <XDSLayoutContent padding={8}>
+        <XDSVStack gap={8}>
+          <XDSVStack gap={2}>
+            <XDSText type="display-1">{item.name}</XDSText>
+            <XDSText type="body" color="secondary">{item.desc}</XDSText>
           </XDSVStack>
 
           <XDSDivider />
 
-          <XDSVStack gap={4}>
-            <XDSHeading level={2}>Usage</XDSHeading>
-            <XDSCard padding={0}>
-              <XDSCodeBlock
-                code={`// Use semantic tokens — they adapt across themes
-<XDSText color="secondary">Muted text</XDSText>
-<XDSButton variant="primary">Accent color</XDSButton>
-<XDSCard variant="muted">Surface background</XDSCard>
-
-// Never use raw hex values in component code
-// ❌ style={{ color: '#6B7280' }}
-// ✅ <XDSText color="secondary">`}
-                language="tsx"
-              />
-            </XDSCard>
-          </XDSVStack>
-        </XDSVStack>
-      </XDSLayoutContent>
-    } />
-  );
-}
-
-function SpacingPage() {
-  return (
-    <XDSLayout contentWidth={960} content={
-      <XDSLayoutContent padding={8}>
-        <XDSVStack gap={8}>
-          <XDSVStack gap={2}>
-            <XDSText type="display-1">Spacing</XDSText>
-            <XDSText type="body" color="secondary">
-              A 4px-based scale used for padding, margins, and gaps. Keeps
-              layouts aligned to a consistent rhythm across every component.
-            </XDSText>
-          </XDSVStack>
-
-          {/* Visual scale */}
-          <XDSCard variant="muted" padding={6}>
-            <XDSVStack gap={3}>
-              {SPACING_SCALE.filter(s => parseInt(s.px) > 0).map(space => (
-                <XDSHStack key={space.step} gap={4} vAlign="center">
-                  <XDSText type="supporting" color="secondary" style={{fontFamily: 'monospace', width: 40, textAlign: 'right', flexShrink: 0}}>
-                    {space.step}
-                  </XDSText>
-                  <div
-                    style={{
-                      width: parseInt(space.px),
-                      height: 24,
-                      backgroundColor: 'var(--color-accent, #0066FF)',
-                      borderRadius: 4,
-                      opacity: 0.7,
-                      flexShrink: 0,
-                    }}
-                  />
-                  <XDSText type="supporting" color="secondary">{space.value}</XDSText>
-                </XDSHStack>
-              ))}
-            </XDSVStack>
-          </XDSCard>
-
-          {/* Table */}
-          <XDSVStack gap={4}>
-            <XDSHeading level={2}>Scale Reference</XDSHeading>
-            <XDSTable
-              data={SPACING_SCALE as Record<string, unknown>[]}
-              columns={[
-                {key: 'step', header: 'Step', width: pixel(80)},
-                {key: 'value', header: 'Value', width: pixel(100)},
-                {key: 'usage', header: 'Usage'},
-              ]}
-              density="spacious"
-              dividers="rows"
-            />
-          </XDSVStack>
-
-          <XDSDivider />
-
-          <XDSVStack gap={4}>
-            <XDSHeading level={2}>Usage</XDSHeading>
-            <XDSCard padding={0}>
-              <XDSCodeBlock
-                code={`// Use the gap prop on Stack and Grid components
-<XDSVStack gap={4}>  {/* 16px gap */}
-  <XDSHeading level={2}>Section</XDSHeading>
-  <XDSText type="body">Content</XDSText>
-</XDSVStack>
-
-// Use the padding prop on Card and Section
-<XDSCard padding={6}>  {/* 24px padding */}
-  <XDSText type="body">Card content</XDSText>
-</XDSCard>`}
-                language="tsx"
-              />
-            </XDSCard>
-          </XDSVStack>
-        </XDSVStack>
-      </XDSLayoutContent>
-    } />
-  );
-}
-
-function ShapePage() {
-  return (
-    <XDSLayout contentWidth={960} content={
-      <XDSLayoutContent padding={8}>
-        <XDSVStack gap={8}>
-          <XDSVStack gap={2}>
-            <XDSText type="display-1">Shape</XDSText>
-            <XDSText type="body" color="secondary">
-              Border radius tokens from sharp to fully rounded. Controls, cards,
-              and containers each have a designated radius so shapes feel intentional.
-            </XDSText>
-          </XDSVStack>
-
-          {/* Visual preview */}
-          <XDSCard variant="muted" padding={8}>
-            <XDSHStack gap={6} vAlign="end" style={{justifyContent: 'center'}}>
-              {RADIUS_TOKENS.map(radius => (
-                <XDSVStack key={radius.token} gap={2} hAlign="center">
-                  <div
-                    style={{
-                      width: 64,
-                      height: 64,
-                      borderRadius: radius.value === '9999px' ? 9999 : parseInt(radius.value),
-                      backgroundColor: 'var(--color-accent, #0066FF)',
-                      opacity: 0.8,
-                    }}
-                  />
-                  <XDSText type="supporting" weight="semibold">{radius.name}</XDSText>
-                  <XDSText type="supporting" color="secondary" style={{fontFamily: 'monospace', fontSize: 11}}>
-                    {radius.value}
-                  </XDSText>
-                </XDSVStack>
-              ))}
-            </XDSHStack>
-          </XDSCard>
-
-          {/* Table */}
-          <XDSVStack gap={4}>
-            <XDSHeading level={2}>Radius Tokens</XDSHeading>
-            <XDSTable
-              data={RADIUS_TOKENS as Record<string, unknown>[]}
-              columns={[
-                {key: 'name', header: 'Name', width: pixel(120)},
-                {key: 'token', header: 'Token', width: pixel(200), renderCell: (item: Record<string, unknown>) => (
-                  <XDSText type="supporting" style={{fontFamily: 'monospace', fontSize: 12}}>{item.token as string}</XDSText>
-                )},
-                {key: 'value', header: 'Value', width: pixel(100)},
-                {key: 'usage', header: 'Usage'},
-              ]}
-              density="spacious"
-              dividers="rows"
-            />
-          </XDSVStack>
-        </XDSVStack>
-      </XDSLayoutContent>
-    } />
-  );
-}
-
-function ElevationPage() {
-  return (
-    <XDSLayout contentWidth={960} content={
-      <XDSLayoutContent padding={8}>
-        <XDSVStack gap={8}>
-          <XDSVStack gap={2}>
-            <XDSText type="display-1">Elevation</XDSText>
-            <XDSText type="body" color="secondary">
-              Shadow tokens that create visual depth. Higher elevation = more
-              prominence. Use sparingly to maintain visual clarity.
-            </XDSText>
-          </XDSVStack>
-
-          {/* Visual preview */}
-          <XDSCard variant="muted" padding={8}>
-            <XDSHStack gap={8} vAlign="center" style={{justifyContent: 'center'}}>
-              {ELEVATION_LEVELS.map(level => (
-                <XDSVStack key={level.token} gap={3} hAlign="center">
-                  <div
-                    style={{
-                      width: 96,
-                      height: 96,
-                      borderRadius: 12,
-                      backgroundColor: 'var(--color-background, #fff)',
-                      boxShadow: level.value,
-                      border: level.value === 'none' ? '1px solid var(--color-border, #E5E7EB)' : 'none',
-                    }}
-                  />
-                  <XDSText type="supporting" weight="semibold">{level.name}</XDSText>
-                </XDSVStack>
-              ))}
-            </XDSHStack>
-          </XDSCard>
-
-          {/* Table */}
-          <XDSVStack gap={4}>
-            <XDSHeading level={2}>Elevation Tokens</XDSHeading>
-            <XDSTable
-              data={ELEVATION_LEVELS as Record<string, unknown>[]}
-              columns={[
-                {key: 'name', header: 'Level', width: pixel(100)},
-                {key: 'token', header: 'Token', width: pixel(160), renderCell: (item: Record<string, unknown>) => (
-                  <XDSText type="supporting" style={{fontFamily: 'monospace', fontSize: 12}}>{item.token as string}</XDSText>
-                )},
-                {key: 'value', header: 'Value', width: pixel(260), renderCell: (item: Record<string, unknown>) => (
-                  <XDSText type="supporting" style={{fontFamily: 'monospace', fontSize: 12}}>{item.value as string}</XDSText>
-                )},
-                {key: 'usage', header: 'Usage'},
-              ]}
-              density="spacious"
-              dividers="rows"
-            />
-          </XDSVStack>
-        </XDSVStack>
-      </XDSLayoutContent>
-    } />
-  );
-}
-
-function PlaceholderPage({title, description}: {title: string; description: string}) {
-  return (
-    <XDSLayout contentWidth={960} content={
-      <XDSLayoutContent padding={8}>
-        <XDSVStack gap={8}>
-          <XDSVStack gap={2}>
-            <XDSText type="display-1">{title}</XDSText>
-            <XDSText type="body" color="secondary">{description}</XDSText>
-          </XDSVStack>
           <XDSCard variant="muted" padding={10}>
             <XDSVStack gap={3} hAlign="center" style={{textAlign: 'center'}}>
-              <XDSText type="body" color="secondary">Documentation coming soon</XDSText>
-              <XDSBadge label="In Progress" variant="info" />
+              <XDSText type="body" color="secondary">
+                Documentation coming soon
+              </XDSText>
             </XDSVStack>
           </XDSCard>
         </XDSVStack>
@@ -572,44 +121,13 @@ function PlaceholderPage({title, description}: {title: string; description: stri
     } />
   );
 }
-
-// ---------------------------------------------------------------------------
-// Page content router
-// ---------------------------------------------------------------------------
-
-const PAGE_CONTENT: Record<string, {title: string; description: string}> = {
-  icons: {title: 'Icons', description: 'Consistent icon set with semantic and non-semantic color options in multiple sizes.'},
-  'layout-patterns': {title: 'Layout Patterns', description: 'Common layout compositions using Stack, Grid, AppShell, and responsive breakpoints.'},
-  responsive: {title: 'Responsive Design', description: 'Breakpoint system, container queries, and mobile-first design patterns.'},
-  motion: {title: 'Motion & Animation', description: 'Transition tokens, keyframes, and animation patterns for smooth, purposeful motion.'},
-  accessibility: {title: 'Accessibility', description: 'WCAG AA compliance, keyboard navigation, screen reader support, and ARIA patterns.'},
-  'theme-overview': {title: 'Theme System', description: 'How theming works: providers, tokens, and runtime theme switching.'},
-  'custom-themes': {title: 'Custom Themes', description: 'Create and publish custom themes with your own colors, typography, and radius.'},
-  'dark-mode': {title: 'Dark Mode', description: 'Implementing dark mode with theme switching and system preference detection.'},
-};
 
 // ---------------------------------------------------------------------------
 // Main component
 // ---------------------------------------------------------------------------
 
 export default function DesignDocumentationPage() {
-  const [activePage, setActivePage] = useState<string>('overview');
-
-  const renderContent = () => {
-    switch (activePage) {
-      case 'overview': return <OverviewPage />;
-      case 'typography': return <TypographyPage />;
-      case 'colors': return <ColorsPage />;
-      case 'spacing': return <SpacingPage />;
-      case 'shape': return <ShapePage />;
-      case 'elevation': return <ElevationPage />;
-      default: {
-        const info = PAGE_CONTENT[activePage];
-        if (info) return <PlaceholderPage title={info.title} description={info.description} />;
-        return <OverviewPage />;
-      }
-    }
-  };
+  const [activePage, setActivePage] = useState<string>('home');
 
   return (
     <XDSAppShell
@@ -617,22 +135,33 @@ export default function DesignDocumentationPage() {
       height="fill"
       sideNav={
         <XDSSideNav
-          header={<XDSSideNavHeading heading="Design System" />}>
-          {NAV_SECTIONS.map(section => (
-            <XDSSideNavSection key={section.label} title={section.label}>
-              {section.items.map(item => (
-                <XDSSideNavItem
-                  key={item.key}
-                  label={item.name}
-                  isSelected={activePage === item.key}
-                  onClick={() => setActivePage(item.key)}
-                />
-              ))}
-            </XDSSideNavSection>
-          ))}
+          header={
+            <XDSSideNavHeading heading="Product Name" />
+          }>
+          <XDSSideNavSection title="Navigation" isHeaderHidden>
+            <XDSSideNavItem
+              label="Home"
+              isSelected={activePage === 'home'}
+              onClick={() => setActivePage('home')}
+            />
+          </XDSSideNavSection>
+          <XDSSideNavSection title="Foundations">
+            {FOUNDATION_SECTIONS.map(item => (
+              <XDSSideNavItem
+                key={item.key}
+                label={item.name}
+                isSelected={activePage === item.key}
+                onClick={() => setActivePage(item.key)}
+              />
+            ))}
+          </XDSSideNavSection>
         </XDSSideNav>
       }>
-      {renderContent()}
+      {activePage === 'home' ? (
+        <OverviewView onSelectSection={setActivePage} />
+      ) : (
+        <FoundationDetailView activeNav={activePage} />
+      )}
     </XDSAppShell>
   );
 }

--- a/packages/cli/templates/pages/documentation-design/page.tsx
+++ b/packages/cli/templates/pages/documentation-design/page.tsx
@@ -9,13 +9,11 @@ import {
   XDSSideNavItem,
   XDSSideNavSection,
 } from '@xds/core/SideNav';
-import {XDSHeading, XDSText} from '@xds/core/Text';
+import {XDSText} from '@xds/core/Text';
+import {XDSButton} from '@xds/core/Button';
 import {XDSCard} from '@xds/core/Card';
-import {XDSCodeBlock} from '@xds/core/CodeBlock';
 import {XDSHStack, XDSVStack, XDSStackItem} from '@xds/core/Stack';
 import {XDSLayout, XDSLayoutContent} from '@xds/core/Layout';
-import {XDSDivider} from '@xds/core/Divider';
-import {XDSTable, pixel} from '@xds/core/Table';
 import {XDSGrid} from '@xds/core/Grid';
 import {radiusVars} from '@xds/core/theme/tokens.stylex';
 
@@ -30,12 +28,58 @@ const styles = stylex.create({
 // Data
 // ---------------------------------------------------------------------------
 
-const FOUNDATION_SECTIONS = [
-  {key: 'typography', name: 'Typography', desc: 'A type scale from display-1 down to supporting text, with weight and color options. Establishes visual hierarchy without guessing font sizes.'},
-  {key: 'colors', name: 'Colors', desc: 'A semantic palette that adapts across themes. Use surface, text, border, and accent tokens instead of raw hex values so your UI stays consistent.'},
-  {key: 'spacing', name: 'Spacing', desc: 'A 4px-based scale (0–10) used for padding, margins, and gaps. Keeps layouts aligned to a consistent rhythm across every component and page.'},
-  {key: 'shape', name: 'Shape', desc: 'Border radius tokens from sharp (2px) to fully rounded (pill). Controls, cards, and containers each have a designated radius so shapes feel intentional.'},
-  {key: 'icons', name: 'Icons', desc: 'A consistent icon set built for XDS components. Semantic and non-semantic color options with multiple sizes.'},
+const COMPONENT_CATEGORIES = [
+  {
+    label: 'Core',
+    items: [
+      {key: 'appshell', name: 'AppShell', desc: 'AppShell provides a foundational page layout with header, sidebar, and content regions. Use it to establish consistent structure across your application.'},
+      {key: 'avatar', name: 'Avatar', desc: 'Avatars represent a person or entity with an image, initials, or icon. They are commonly used in user profiles, comments, and contact lists.'},
+      {key: 'badge', name: 'Badge', desc: 'Badges display small counts or status labels. They can be attached to icons, buttons, or list items to surface key information at a glance.'},
+      {key: 'banner', name: 'Banner', desc: 'Banners show important, non-modal messages at the top of a page or section. They communicate status, warnings, or promotional information.'},
+      {key: 'button', name: 'Button', desc: 'Buttons let people take action. They can be used in forms, dialogs, and toolbars, or as standalone links.'},
+      {key: 'calendar', name: 'Calendar', desc: 'Calendar provides a date-picking grid for selecting single dates or date ranges. It integrates with form fields for date input.'},
+      {key: 'dialog', name: 'Dialog', desc: 'Dialogs are modal overlays that require user attention or action before continuing. They are used for confirmations, forms, and critical decisions.'},
+      {key: 'dropdownmenu', name: 'DropdownMenu', desc: 'DropdownMenu presents a list of actions or options in a floating overlay. It is triggered by a button and supports nested submenus.'},
+      {key: 'emptystate', name: 'EmptyState', desc: 'EmptyState provides a placeholder when there is no content to display. It guides users with a message, illustration, and optional call-to-action.'},
+      {key: 'hovercard', name: 'HoverCard', desc: 'HoverCard shows a rich preview of content when users hover over a trigger element. It is ideal for previewing profiles, links, or details.'},
+      {key: 'icon', name: 'Icon', desc: 'Icons are small visual symbols that represent actions, objects, or concepts. They improve scannability and reinforce meaning alongside text.'},
+      {key: 'kbd', name: 'Kbd', desc: 'Kbd renders keyboard shortcut hints in a styled inline element. Use it to show users which key combinations perform specific actions.'},
+      {key: 'link', name: 'Link', desc: 'Links provide navigation between pages or to external resources. They follow accessible anchor semantics with visual affordance.'},
+      {key: 'list', name: 'List', desc: 'List displays a vertical set of related items. It supports selection, icons, and metadata for building menus, nav lists, and more.'},
+      {key: 'popover', name: 'Popover', desc: 'Popover displays rich content in a floating panel anchored to a trigger element. It is used for forms, filters, and contextual tools.'},
+      {key: 'table', name: 'Table', desc: 'Table displays structured data in rows and columns with support for sorting, selection, and custom cell rendering.'},
+      {key: 'token', name: 'Token', desc: 'Tokens display compact metadata labels such as tags, categories, or filters. They can be dismissible and support selection state.'},
+      {key: 'tooltip', name: 'Tooltip', desc: 'Tooltips show concise helper text when users hover over or focus an element. They clarify icons, truncated labels, and controls.'},
+    ],
+  },
+  {
+    label: 'Layout',
+    items: [
+      {key: 'card', name: 'Card', desc: 'Cards group related content and actions in a contained surface. They can include headers, media, body text, and action bars.'},
+      {key: 'divider', name: 'Divider', desc: 'Dividers separate content into distinct sections with a subtle or strong horizontal line. They can optionally include a label.'},
+      {key: 'grid', name: 'Grid', desc: 'Grid provides a CSS grid-based layout container with configurable columns, rows, and gap. It simplifies responsive multi-column designs.'},
+      {key: 'stack', name: 'Stack', desc: 'Stack arranges child elements in a row or column with consistent gap spacing. It is the primary tool for one-dimensional layout composition.'},
+    ],
+  },
+  {
+    label: 'Navigation',
+    items: [
+      {key: 'breadcrumbs', name: 'Breadcrumbs', desc: "Breadcrumbs show the user's current location within a navigation hierarchy. They provide quick links back to parent pages."},
+      {key: 'sidenav', name: 'SideNav', desc: 'SideNav renders a vertical navigation panel with links, sections, and collapsible groups. It is used as the primary nav in dashboard layouts.'},
+      {key: 'tablist', name: 'TabList', desc: 'TabList switches between content views using a horizontal row of tabs. Only one tab is active at a time, and content changes without a page reload.'},
+      {key: 'topnav', name: 'TopNav', desc: 'TopNav provides an app-level navigation bar across the top of the page. It holds branding, primary links, search, and user actions.'},
+    ],
+  },
+  {
+    label: 'Form',
+    items: [
+      {key: 'checkboxinput', name: 'CheckboxInput', desc: 'CheckboxInput renders a single checkbox with a label. It is used for boolean opt-in choices like terms acceptance or feature toggles.'},
+      {key: 'selector', name: 'Selector', desc: 'Selector lets users pick a single item from a dropdown list. It supports search, grouping, and custom option rendering.'},
+      {key: 'switch', name: 'Switch', desc: 'Switch toggles a setting between on and off states with immediate effect. It is used for preferences, feature flags, and real-time controls.'},
+      {key: 'textinput', name: 'TextInput', desc: 'TextInput is a single-line text field for short user input like names, emails, and search queries. It supports icons, prefixes, and validation.'},
+      {key: 'typeahead', name: 'Typeahead', desc: 'Typeahead provides an autocomplete search input that suggests results as the user types. It supports async data sources and custom rendering.'},
+    ],
+  },
 ];
 
 // ---------------------------------------------------------------------------
@@ -43,79 +87,65 @@ const FOUNDATION_SECTIONS = [
 // ---------------------------------------------------------------------------
 
 function OverviewView({
-  onSelectSection,
+  onSelectComponent,
 }: {
-  onSelectSection: (key: string) => void;
+  onSelectComponent: (key: string) => void;
 }) {
   return (
     <XDSLayout contentWidth={1200} content={
       <XDSLayoutContent padding={8}>
         <XDSVStack gap={10}>
+          {/* Hero banner */}
           <XDSCard variant="cyan" padding={10}>
             <XDSHStack gap={8} vAlign="center">
               <XDSStackItem size="fill">
                 <XDSVStack gap={4}>
-                  <XDSText type="display-1">Design foundations</XDSText>
+                  <XDSText type="display-1">Web overview</XDSText>
                   <XDSText type="large" weight="normal" color="secondary">
-                    The design tokens and primitives that every component is
-                    built on. Use these foundations to create consistent,
-                    accessible interfaces.
+                    An open-source UI library to help developers quickly build
+                    beautiful, accessible products.
                   </XDSText>
+                  <XDSHStack>
+                    <XDSButton
+                      label="Get started"
+                      variant="primary"
+                      size="lg"
+                      onClick={() => onSelectComponent('getting-started')}
+                    />
+                  </XDSHStack>
                 </XDSVStack>
               </XDSStackItem>
               <XDSStackItem size="fill" />
             </XDSHStack>
           </XDSCard>
 
-          <XDSGrid columns={{minWidth: 260}} gap={8}>
-            {FOUNDATION_SECTIONS.map(item => (
-              <XDSVStack key={item.key} gap={3}>
-                <XDSCard
-                  variant="muted"
-                  padding={0}
-                  minHeight={160}
-                  xstyle={styles.previewCard}
-                  onClick={() => onSelectSection(item.key)}
-                />
-                <XDSVStack gap={0.5}>
-                  <XDSText type="body" weight="bold">
-                    {item.name}
-                  </XDSText>
-                  <XDSText type="body" color="secondary">
-                    {item.desc}
-                  </XDSText>
-                </XDSVStack>
-              </XDSVStack>
-            ))}
-          </XDSGrid>
-        </XDSVStack>
-      </XDSLayoutContent>
-    } />
-  );
-}
-
-function FoundationDetailView({activeNav}: {activeNav: string}) {
-  const item = FOUNDATION_SECTIONS.find(s => s.key === activeNav);
-  if (!item) return null;
-
-  return (
-    <XDSLayout contentWidth={960} content={
-      <XDSLayoutContent padding={8}>
-        <XDSVStack gap={8}>
-          <XDSVStack gap={2}>
-            <XDSText type="display-1">{item.name}</XDSText>
-            <XDSText type="body" color="secondary">{item.desc}</XDSText>
-          </XDSVStack>
-
-          <XDSDivider />
-
-          <XDSCard variant="muted" padding={10}>
-            <XDSVStack gap={3} hAlign="center" style={{textAlign: 'center'}}>
-              <XDSText type="body" color="secondary">
-                Documentation coming soon
-              </XDSText>
+          {/* Category sections */}
+          {COMPONENT_CATEGORIES.map(category => (
+            <XDSVStack key={category.label} gap={4}>
+              <XDSText type="display-2">{category.label}</XDSText>
+              <XDSGrid columns={{minWidth: 260}} gap={8}>
+                {category.items.map(item => (
+                  <XDSVStack key={item.key} gap={3}>
+                    <XDSCard
+                      variant="muted"
+                      padding={0}
+                      minHeight={160}
+                      xstyle={styles.previewCard}
+                      onClick={() => onSelectComponent(item.key)}
+                    />
+                    <XDSVStack gap={0.5}>
+                      <XDSText type="body" weight="bold">
+                        {item.name}
+                      </XDSText>
+                      <XDSText type="body" color="secondary">
+                        {item.desc}
+                      </XDSText>
+                    </XDSVStack>
+                  </XDSVStack>
+                ))}
+              </XDSGrid>
             </XDSVStack>
-          </XDSCard>
+          ))}
         </XDSVStack>
       </XDSLayoutContent>
     } />
@@ -127,8 +157,6 @@ function FoundationDetailView({activeNav}: {activeNav: string}) {
 // ---------------------------------------------------------------------------
 
 export default function DesignDocumentationPage() {
-  const [activePage, setActivePage] = useState<string>('home');
-
   return (
     <XDSAppShell
       variant="section"
@@ -141,27 +169,23 @@ export default function DesignDocumentationPage() {
           <XDSSideNavSection title="Navigation" isHeaderHidden>
             <XDSSideNavItem
               label="Home"
-              isSelected={activePage === 'home'}
-              onClick={() => setActivePage('home')}
+              isSelected
             />
           </XDSSideNavSection>
-          <XDSSideNavSection title="Foundations">
-            {FOUNDATION_SECTIONS.map(item => (
-              <XDSSideNavItem
-                key={item.key}
-                label={item.name}
-                isSelected={activePage === item.key}
-                onClick={() => setActivePage(item.key)}
-              />
-            ))}
-          </XDSSideNavSection>
+
+          {COMPONENT_CATEGORIES.map(category => (
+            <XDSSideNavSection key={category.label} title={category.label}>
+              {category.items.map(item => (
+                <XDSSideNavItem
+                  key={item.key}
+                  label={item.name}
+                />
+              ))}
+            </XDSSideNavSection>
+          ))}
         </XDSSideNav>
       }>
-      {activePage === 'home' ? (
-        <OverviewView onSelectSection={setActivePage} />
-      ) : (
-        <FoundationDetailView activeNav={activePage} />
-      )}
+      <OverviewView onSelectComponent={() => {}} />
     </XDSAppShell>
   );
 }

--- a/packages/cli/templates/pages/documentation-design/template.doc.mjs
+++ b/packages/cli/templates/pages/documentation-design/template.doc.mjs
@@ -1,0 +1,7 @@
+/** @type {import('../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'page',
+  name: 'Design Documentation',
+  description: 'Design system foundations with typography scale, color palette, spacing tokens, shape reference, and usage guidelines.',
+  isReady: true,
+};

--- a/packages/cli/templates/pages/documentation-design/template.doc.mjs
+++ b/packages/cli/templates/pages/documentation-design/template.doc.mjs
@@ -1,7 +1,7 @@
 /** @type {import('../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'page',
-  name: 'Component Page',
+  name: 'Component Reference',
   description: 'Component documentation page with live preview, usage guide, best practices table, and code examples.',
   isReady: true,
 };

--- a/packages/cli/templates/pages/documentation-design/template.doc.mjs
+++ b/packages/cli/templates/pages/documentation-design/template.doc.mjs
@@ -1,7 +1,7 @@
 /** @type {import('../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'page',
-  name: 'Design Documentation',
-  description: 'Design system foundations with typography scale, color palette, spacing tokens, shape reference, and usage guidelines.',
+  name: 'Component Page',
+  description: 'Component documentation page with live preview, usage guide, best practices table, and code examples.',
   isReady: true,
 };

--- a/packages/cli/templates/pages/documentation-technical/page.tsx
+++ b/packages/cli/templates/pages/documentation-technical/page.tsx
@@ -1,0 +1,465 @@
+'use client';
+
+import {useState, useMemo} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {XDSAppShell} from '@xds/core/AppShell';
+import {
+  XDSSideNav,
+  XDSSideNavHeading,
+  XDSSideNavItem,
+  XDSSideNavSection,
+} from '@xds/core/SideNav';
+import {XDSHeading, XDSText} from '@xds/core/Text';
+import {XDSButton} from '@xds/core/Button';
+import {XDSIconButton} from '@xds/core/IconButton';
+import {XDSCard} from '@xds/core/Card';
+import {XDSAvatar} from '@xds/core/Avatar';
+import {XDSBadge} from '@xds/core/Badge';
+import {XDSToken} from '@xds/core/Token';
+import {XDSList, XDSListItem} from '@xds/core/List';
+import {XDSBanner} from '@xds/core/Banner';
+import {XDSCodeBlock} from '@xds/core/CodeBlock';
+import {XDSTabList, XDSTab} from '@xds/core/TabList';
+import {XDSHStack, XDSVStack, XDSStackItem} from '@xds/core/Stack';
+import {XDSLayout, XDSLayoutContent} from '@xds/core/Layout';
+import {XDSDialog, XDSDialogHeader} from '@xds/core/Dialog';
+import {XDSDivider} from '@xds/core/Divider';
+import {XDSTooltip} from '@xds/core/Tooltip';
+import {XDSTable, pixel} from '@xds/core/Table';
+import {XDSIcon} from '@xds/core/Icon';
+import {XDSSection} from '@xds/core/Section';
+import {XDSCenter} from '@xds/core/Center';
+import {
+  ArrowTopRightOnSquareIcon,
+  ArrowsPointingOutIcon,
+  PlusIcon,
+} from '@heroicons/react/24/outline';
+
+const styles = stylex.create({
+  tabListFlush: {marginInlineStart: '-12px'},
+});
+
+// ---------------------------------------------------------------------------
+// DialogPreview
+// ---------------------------------------------------------------------------
+
+function DialogPreview() {
+  const [isOpen, setIsOpen] = useState(false);
+  return (
+    <XDSVStack gap={3}>
+      <XDSHeading level={3}>Dialog</XDSHeading>
+      <XDSButton
+        label="Open Dialog"
+        variant="primary"
+        onClick={() => setIsOpen(true)}
+      />
+      <XDSDialog isOpen={isOpen} onOpenChange={setIsOpen}>
+        <XDSDialogHeader title="Example Dialog" onOpenChange={setIsOpen} />
+        <XDSSection padding={4}>
+          <XDSText type="body">
+            This is an example dialog. Dialogs are used to require user action
+            or display important information that needs acknowledgment.
+          </XDSText>
+        </XDSSection>
+      </XDSDialog>
+    </XDSVStack>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Data
+// ---------------------------------------------------------------------------
+
+const COMPONENT_CATEGORIES = [
+  {
+    label: 'Core',
+    items: [
+      {key: 'appshell', name: 'AppShell', desc: 'Foundational page layout with header, sidebar, and content regions.'},
+      {key: 'avatar', name: 'Avatar', desc: 'Represents a person or entity with an image, initials, or icon.'},
+      {key: 'badge', name: 'Badge', desc: 'Small counts or status labels attached to icons, buttons, or list items.'},
+      {key: 'banner', name: 'Banner', desc: 'Important, non-modal messages at the top of a page or section.'},
+      {key: 'button', name: 'Button', desc: 'Buttons let people take action in forms, dialogs, and toolbars.'},
+      {key: 'card', name: 'Card', desc: 'Cards group related content and actions in a contained surface.'},
+      {key: 'dialog', name: 'Dialog', desc: 'Modal overlays that require user attention or action before continuing.'},
+      {key: 'dropdownmenu', name: 'DropdownMenu', desc: 'List of actions or options in a floating overlay triggered by a button.'},
+      {key: 'icon', name: 'Icon', desc: 'Small visual symbols that represent actions, objects, or concepts.'},
+      {key: 'link', name: 'Link', desc: 'Navigation between pages or to external resources with visual affordance.'},
+      {key: 'list', name: 'List', desc: 'Vertical set of related items with selection, icons, and metadata.'},
+      {key: 'popover', name: 'Popover', desc: 'Rich content in a floating panel anchored to a trigger element.'},
+      {key: 'table', name: 'Table', desc: 'Structured data in rows and columns with sorting, selection, and custom cells.'},
+      {key: 'token', name: 'Token', desc: 'Compact metadata labels such as tags, categories, or filters.'},
+      {key: 'tooltip', name: 'Tooltip', desc: 'Concise helper text when users hover over or focus an element.'},
+    ],
+  },
+  {
+    label: 'Layout',
+    items: [
+      {key: 'stack', name: 'Stack', desc: 'Arranges children in a row or column with consistent gap spacing.'},
+      {key: 'grid', name: 'Grid', desc: 'CSS grid-based layout container with configurable columns and gap.'},
+      {key: 'divider', name: 'Divider', desc: 'Separates content into distinct sections with a subtle line.'},
+      {key: 'section', name: 'Section', desc: 'Wraps content with consistent vertical spacing and optional heading.'},
+      {key: 'center', name: 'Center', desc: 'Centers its child horizontally and vertically within available space.'},
+    ],
+  },
+  {
+    label: 'Navigation',
+    items: [
+      {key: 'sidenav', name: 'SideNav', desc: 'Vertical navigation panel with links, sections, and collapsible groups.'},
+      {key: 'topnav', name: 'TopNav', desc: 'App-level navigation bar with branding, links, and user actions.'},
+      {key: 'tablist', name: 'TabList', desc: 'Switches between content views using a horizontal row of tabs.'},
+      {key: 'breadcrumbs', name: 'Breadcrumbs', desc: "Shows user's current location within a navigation hierarchy."},
+    ],
+  },
+  {
+    label: 'Form',
+    items: [
+      {key: 'textinput', name: 'TextInput', desc: 'Single-line text field for names, emails, and search queries.'},
+      {key: 'selector', name: 'Selector', desc: 'Pick a single item from a dropdown list with search and grouping.'},
+      {key: 'switch', name: 'Switch', desc: 'Toggles a setting between on and off states with immediate effect.'},
+      {key: 'checkboxinput', name: 'CheckboxInput', desc: 'Single checkbox with a label for boolean opt-in choices.'},
+      {key: 'radiolist', name: 'RadioList', desc: 'Group of mutually exclusive options for settings and preferences.'},
+      {key: 'slider', name: 'Slider', desc: 'Select a value or range by dragging a handle along a track.'},
+    ],
+  },
+];
+
+const COMPONENT_DOCS: Record<
+  string,
+  {
+    usage: string;
+    bestPractices: {type: 'do' | 'dont'; text: string}[];
+    props: {name: string; type: string; default: string; description: string}[];
+    examples: {title: string; description: string; code: string}[];
+  }
+> = {
+  button: {
+    usage:
+      'Buttons provide visual cues for actions and events. These fundamental components allow users to commit actions and navigate a page flow. Use a Button when a user needs to submit a form, start a new task or action, or trigger a new UI element to appear on the page.',
+    bestPractices: [
+      {type: 'do', text: 'Convey clear action hierarchy: Each surface should only have 1 primary button.'},
+      {type: 'do', text: 'Promote clarity: Consider labels alongside icons where appropriate.'},
+      {type: 'dont', text: 'Overuse primary buttons: Overusing colored buttons creates visual confusion.'},
+      {type: 'dont', text: 'Use a button for navigation: Use Link instead for page transitions.'},
+    ],
+    props: [
+      {name: 'label', type: 'string', default: '—', description: 'Accessible label text for the button.'},
+      {name: 'variant', type: "'primary' | 'secondary' | 'ghost' | 'destructive'", default: "'secondary'", description: 'Visual style variant.'},
+      {name: 'size', type: "'sm' | 'md' | 'lg'", default: "'md'", description: 'Size of the button.'},
+      {name: 'icon', type: 'ReactNode', default: '—', description: 'Icon element displayed before the label.'},
+      {name: 'isIconOnly', type: 'boolean', default: 'false', description: 'Render only the icon, hiding the label visually.'},
+      {name: 'isDisabled', type: 'boolean', default: 'false', description: 'Prevents interaction and dims the button.'},
+      {name: 'isLoading', type: 'boolean', default: 'false', description: 'Shows a spinner and disables interaction.'},
+      {name: 'onClick', type: '() => void', default: '—', description: 'Callback fired when the button is clicked.'},
+    ],
+    examples: [
+      {
+        title: 'Variants',
+        description: 'Four semantic button types: ghost, secondary, primary, and destructive.',
+        code: `<XDSButton label="Ghost" variant="ghost" />
+<XDSButton label="Secondary" variant="secondary" />
+<XDSButton label="Primary" variant="primary" />
+<XDSButton label="Destructive" variant="destructive" />`,
+      },
+      {
+        title: 'With icon',
+        description: 'Buttons can include a leading icon for visual reinforcement.',
+        code: `<XDSButton
+  label="Add item"
+  variant="primary"
+  icon={<PlusIcon />}
+/>`,
+      },
+      {
+        title: 'Icon only',
+        description: 'Icon-only buttons for compact toolbars. Always provide a label for accessibility.',
+        code: `<XDSButton
+  label="Settings"
+  variant="ghost"
+  icon={<CogIcon />}
+  isIconOnly
+/>`,
+      },
+    ],
+  },
+};
+
+function getComponentName(key: string): string {
+  for (const cat of COMPONENT_CATEGORIES) {
+    const item = cat.items.find(i => i.key === key);
+    if (item) return item.name;
+  }
+  return key;
+}
+
+function getComponentDesc(key: string): string {
+  for (const cat of COMPONENT_CATEGORIES) {
+    const item = cat.items.find(i => i.key === key);
+    if (item) return item.desc;
+  }
+  return '';
+}
+
+function getComponentDocs(key: string) {
+  if (COMPONENT_DOCS[key]) return COMPONENT_DOCS[key];
+  const name = getComponentName(key);
+  const desc = getComponentDesc(key);
+  return {
+    usage: desc,
+    bestPractices: [
+      {type: 'do' as const, text: `Use ${name} in the appropriate context to provide the described functionality.`},
+      {type: 'do' as const, text: `Pair ${name} with related components to create cohesive, accessible interfaces.`},
+      {type: 'dont' as const, text: `Use ${name} when a simpler alternative achieves the same goal with less complexity.`},
+    ],
+    props: [
+      {name: 'label', type: 'string', default: '—', description: `Accessible label for the ${name} component.`},
+      {name: 'children', type: 'ReactNode', default: '—', description: `Content rendered inside the ${name}.`},
+      {name: 'className', type: 'string', default: '—', description: 'Additional CSS class name.'},
+    ],
+    examples: [
+      {
+        title: `Basic ${name}`,
+        description: `A simple example of the ${name} component with default settings.`,
+        code: `<XDS${name} />`,
+      },
+    ],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Sub-views
+// ---------------------------------------------------------------------------
+
+function ComponentDetailView({activeNav}: {activeNav: string}) {
+  const [exampleTabs, setExampleTabs] = useState<Record<string, string>>({});
+
+  const EXAMPLE_PREVIEWS: Record<string, React.ReactNode[]> = {
+    button: [
+      <XDSHStack key="variants" gap={3} vAlign="center">
+        <XDSButton label="Ghost" variant="ghost" />
+        <XDSButton label="Secondary" variant="secondary" />
+        <XDSButton label="Primary" variant="primary" />
+        <XDSButton label="Destructive" variant="destructive" />
+      </XDSHStack>,
+      <XDSButton key="icon" label="Add item" variant="primary" icon={<XDSIcon icon={PlusIcon} />} />,
+      <XDSButton key="icononly" label="Settings" variant="ghost" icon={<XDSIcon icon={PlusIcon} />} isIconOnly />,
+    ],
+  };
+
+  const COMPONENT_PREVIEWS: Record<string, React.ReactNode> = {
+    button: (
+      <XDSButton
+        label="Button"
+        variant="secondary"
+        icon={<XDSIcon icon={PlusIcon} />}
+        endContent={<XDSBadge label="New" variant="info" />}
+      />
+    ),
+    avatar: <XDSAvatar name="Alice" size="medium" />,
+    badge: <XDSBadge label="Success" variant="success" />,
+    card: (
+      <XDSCard>
+        <XDSVStack gap={2}>
+          <XDSHeading level={4}>Card Title</XDSHeading>
+          <XDSText type="body" color="secondary">Cards group related content and actions.</XDSText>
+        </XDSVStack>
+      </XDSCard>
+    ),
+    banner: (
+      <XDSBanner status="info" title="Information">
+        <XDSText type="body">This is an informational banner message.</XDSText>
+      </XDSBanner>
+    ),
+    dialog: <DialogPreview />,
+    token: <XDSToken label="Design" />,
+    tooltip: (
+      <XDSTooltip content="Primary action">
+        <XDSButton label="Hover me" variant="primary" />
+      </XDSTooltip>
+    ),
+  };
+
+  const docs = useMemo(() => getComponentDocs(activeNav), [activeNav]);
+  const previews = EXAMPLE_PREVIEWS[activeNav] ?? [];
+
+  return (
+    <XDSLayout contentWidth={960} content={
+      <XDSLayoutContent padding={8}>
+        <XDSVStack gap={8}>
+          {/* Header */}
+          <XDSVStack gap={2}>
+            <XDSText type="display-1">{getComponentName(activeNav)}</XDSText>
+            <XDSText type="supporting" color="secondary">
+              March 30, 2026 · Updated 5:40 p.m. PST
+            </XDSText>
+          </XDSVStack>
+
+          <XDSDivider />
+
+          {/* Live Preview */}
+          <XDSCard variant="muted" padding={0}>
+            <XDSCenter height={360}>
+              {COMPONENT_PREVIEWS[activeNav] ?? (
+                <XDSText type="supporting" color="secondary">Preview coming soon</XDSText>
+              )}
+            </XDSCenter>
+          </XDSCard>
+
+          {/* Usage & Best Practices */}
+          <XDSVStack gap={4}>
+            <XDSHeading level={2}>Usage</XDSHeading>
+            <XDSText type="large" weight="normal">{docs.usage}</XDSText>
+            <XDSHeading level={3}>Best practices</XDSHeading>
+            <XDSTable
+              data={docs.bestPractices as Record<string, unknown>[]}
+              columns={[
+                {
+                  key: 'type',
+                  header: 'Guidance',
+                  width: pixel(125),
+                  renderCell: (item: Record<string, unknown>) => (
+                    <XDSBadge
+                      label={item.type === 'do' ? 'Do' : 'Dont'}
+                      variant={item.type === 'do' ? 'success' : 'error'}
+                    />
+                  ),
+                },
+                {
+                  key: 'text',
+                  header: 'Practices',
+                  renderCell: (item: Record<string, unknown>) => (
+                    <XDSText type="body" textWrap="wrap">{item.text as string}</XDSText>
+                  ),
+                },
+              ]}
+              density="spacious"
+              dividers="rows"
+            />
+          </XDSVStack>
+
+          <XDSDivider />
+
+          {/* Props table */}
+          <XDSVStack gap={4}>
+            <XDSHeading level={2}>Props</XDSHeading>
+            <XDSText type="body" color="secondary">
+              All available props for the {getComponentName(activeNav)} component.
+            </XDSText>
+            <XDSTable
+              data={docs.props as Record<string, unknown>[]}
+              columns={[
+                {key: 'name', header: 'Prop', width: pixel(140), renderCell: (item: Record<string, unknown>) => (
+                  <XDSText type="body" weight="bold" style={{fontFamily: 'monospace', fontSize: 13}}>{item.name as string}</XDSText>
+                )},
+                {key: 'type', header: 'Type', width: pixel(200), renderCell: (item: Record<string, unknown>) => (
+                  <XDSText type="supporting" style={{fontFamily: 'monospace', fontSize: 12}}>{item.type as string}</XDSText>
+                )},
+                {key: 'default', header: 'Default', width: pixel(100), renderCell: (item: Record<string, unknown>) => (
+                  <XDSText type="supporting" color="secondary" style={{fontFamily: 'monospace', fontSize: 12}}>{item.default as string}</XDSText>
+                )},
+                {key: 'description', header: 'Description'},
+              ]}
+              density="spacious"
+              dividers="rows"
+            />
+          </XDSVStack>
+
+          <XDSDivider />
+
+          {/* Examples */}
+          <XDSVStack gap={4}>
+            <XDSHeading level={2}>Examples</XDSHeading>
+            <XDSText type="large" weight="normal">
+              Explore common configurations, variations, and states.
+            </XDSText>
+          </XDSVStack>
+          <XDSVStack gap={8}>
+            {docs.examples.map((example, i) => {
+              const tabKey = `${activeNav}-${i}`;
+              const activeTab = exampleTabs[tabKey] ?? 'description';
+              return (
+                <XDSCard key={i} padding={0}>
+                  <XDSSection padding={3} variant="transparent">
+                    <XDSHStack gap={3} vAlign="center">
+                      <XDSStackItem size="fill">
+                        <XDSText type="body" weight="medium">{example.title}</XDSText>
+                      </XDSStackItem>
+                      <XDSHStack gap={1} vAlign="center">
+                        <XDSButton
+                          label="Open in Craft"
+                          variant="ghost"
+                          size="sm"
+                          icon={<XDSIcon icon={ArrowTopRightOnSquareIcon} />}
+                        />
+                        <XDSIconButton
+                          label="Fullscreen"
+                          variant="ghost"
+                          size="sm"
+                          icon={<XDSIcon icon={ArrowsPointingOutIcon} />}
+                        />
+                      </XDSHStack>
+                    </XDSHStack>
+                  </XDSSection>
+                  <XDSCenter height={280}>
+                    {previews[i] ?? (
+                      <XDSText type="supporting" color="secondary">Preview coming soon</XDSText>
+                    )}
+                  </XDSCenter>
+                  <XDSSection variant="wash" padding={3} dividers={['top']}>
+                    <XDSVStack gap={3}>
+                      <XDSTabList
+                        value={activeTab}
+                        onChange={value => setExampleTabs(prev => ({...prev, [tabKey]: value}))}
+                        size="sm"
+                        xstyle={styles.tabListFlush}>
+                        <XDSTab value="description" label="Description" />
+                        <XDSTab value="code" label="Code" />
+                      </XDSTabList>
+                      {activeTab === 'description' ? (
+                        <XDSText type="body">{example.description}</XDSText>
+                      ) : (
+                        <XDSCodeBlock code={example.code} language="tsx" />
+                      )}
+                    </XDSVStack>
+                  </XDSSection>
+                </XDSCard>
+              );
+            })}
+          </XDSVStack>
+        </XDSVStack>
+      </XDSLayoutContent>
+    } />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export default function TechnicalDocumentationPage() {
+  const [activePage, setActivePage] = useState<string>('button');
+
+  return (
+    <XDSAppShell
+      variant="section"
+      height="fill"
+      sideNav={
+        <XDSSideNav
+          header={<XDSSideNavHeading heading="API Reference" />}>
+          {COMPONENT_CATEGORIES.map(category => (
+            <XDSSideNavSection key={category.label} title={category.label}>
+              {category.items.map(item => (
+                <XDSSideNavItem
+                  key={item.key}
+                  label={item.name}
+                  isSelected={activePage === item.key}
+                  onClick={() => setActivePage(item.key)}
+                />
+              ))}
+            </XDSSideNavSection>
+          ))}
+        </XDSSideNav>
+      }>
+      <ComponentDetailView activeNav={activePage} />
+    </XDSAppShell>
+  );
+}

--- a/packages/cli/templates/pages/documentation-technical/page.tsx
+++ b/packages/cli/templates/pages/documentation-technical/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import {useState, useMemo} from 'react';
+import {useState} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {XDSAppShell} from '@xds/core/AppShell';
 import {
@@ -11,64 +11,28 @@ import {
 } from '@xds/core/SideNav';
 import {XDSHeading, XDSText} from '@xds/core/Text';
 import {XDSButton} from '@xds/core/Button';
-import {XDSIconButton} from '@xds/core/IconButton';
 import {XDSCard} from '@xds/core/Card';
 import {XDSDropdownMenu} from '@xds/core/DropdownMenu';
-import {XDSAvatar} from '@xds/core/Avatar';
-import {XDSBadge} from '@xds/core/Badge';
-import {XDSToken} from '@xds/core/Token';
 import {XDSList, XDSListItem} from '@xds/core/List';
-import {XDSBanner} from '@xds/core/Banner';
 import {XDSCodeBlock} from '@xds/core/CodeBlock';
-import {XDSTabList, XDSTab} from '@xds/core/TabList';
 import {XDSHStack, XDSVStack, XDSStackItem} from '@xds/core/Stack';
 import {XDSLayout, XDSLayoutContent} from '@xds/core/Layout';
-import {XDSDialog, XDSDialogHeader} from '@xds/core/Dialog';
 import {XDSDivider} from '@xds/core/Divider';
-import {XDSTooltip} from '@xds/core/Tooltip';
-import {XDSTable, pixel} from '@xds/core/Table';
 import {XDSIcon} from '@xds/core/Icon';
-import {XDSSection} from '@xds/core/Section';
-import {XDSCenter} from '@xds/core/Center';
+import {XDSGrid} from '@xds/core/Grid';
+import {radiusVars} from '@xds/core/theme/tokens.stylex';
 import {
-  ArrowTopRightOnSquareIcon,
-  ArrowsPointingOutIcon,
   SparklesIcon,
   ClipboardDocumentIcon,
-  PlusIcon,
   ChevronDownIcon,
 } from '@heroicons/react/24/outline';
 
 const styles = stylex.create({
-  tabListFlush: {marginInlineStart: '-12px'},
+  previewCard: {
+    borderRadius: radiusVars['--radius-container'],
+    cursor: 'pointer',
+  },
 });
-
-// ---------------------------------------------------------------------------
-// DialogPreview — stateful dialog preview for component previews
-// ---------------------------------------------------------------------------
-
-function DialogPreview() {
-  const [isOpen, setIsOpen] = useState(false);
-  return (
-    <XDSVStack gap={3}>
-      <XDSHeading level={3}>Dialog</XDSHeading>
-      <XDSButton
-        label="Open Dialog"
-        variant="primary"
-        onClick={() => setIsOpen(true)}
-      />
-      <XDSDialog isOpen={isOpen} onOpenChange={setIsOpen}>
-        <XDSDialogHeader title="Example Dialog" onOpenChange={setIsOpen} />
-        <XDSSection padding={4}>
-          <XDSText type="body">
-            This is an example dialog. Dialogs are used to require user action
-            or display important information that needs acknowledgment.
-          </XDSText>
-        </XDSSection>
-      </XDSDialog>
-    </XDSVStack>
-  );
-}
 
 // ---------------------------------------------------------------------------
 // Data
@@ -92,51 +56,25 @@ const COMPONENT_CATEGORIES = [
       {key: 'kbd', name: 'Kbd', desc: 'Kbd renders keyboard shortcut hints in a styled inline element. Use it to show users which key combinations perform specific actions.'},
       {key: 'link', name: 'Link', desc: 'Links provide navigation between pages or to external resources. They follow accessible anchor semantics with visual affordance.'},
       {key: 'list', name: 'List', desc: 'List displays a vertical set of related items. It supports selection, icons, and metadata for building menus, nav lists, and more.'},
-      {key: 'metadatalist', name: 'MetadataList', desc: 'MetadataList displays key-value pairs in a structured layout. Use it for detail panels, settings summaries, and record information.'},
-      {key: 'moremenu', name: 'MoreMenu', desc: 'MoreMenu provides an overflow menu triggered by an icon button. It collects secondary actions that do not fit in the primary toolbar.'},
-      {key: 'overflowlist', name: 'OverflowList', desc: 'OverflowList renders as many items as fit in the available space and collapses the rest into an overflow menu automatically.'},
-      {key: 'pagination', name: 'Pagination', desc: 'Pagination lets users navigate through pages of content. It supports page numbers, previous/next controls, and page-size selection.'},
       {key: 'popover', name: 'Popover', desc: 'Popover displays rich content in a floating panel anchored to a trigger element. It is used for forms, filters, and contextual tools.'},
-      {key: 'progressbar', name: 'ProgressBar', desc: 'ProgressBar shows the completion status of a task or process. It provides visual feedback for uploads, installations, and multi-step flows.'},
-      {key: 'skeleton', name: 'Skeleton', desc: 'Skeleton renders placeholder shapes that mimic content layout while loading. It reduces perceived wait time and prevents layout shifts.'},
-      {key: 'spinner', name: 'Spinner', desc: 'Spinner indicates that a process is in progress when the duration is unknown. It draws attention without blocking the interface.'},
-      {key: 'statusdot', name: 'StatusDot', desc: 'StatusDot shows a small colored indicator for online, offline, busy, or custom statuses. It is often paired with avatars or list items.'},
       {key: 'table', name: 'Table', desc: 'Table displays structured data in rows and columns with support for sorting, selection, and custom cell rendering.'},
-      {key: 'thumbnail', name: 'Thumbnail', desc: 'Thumbnail renders a small image preview with consistent sizing and optional rounded corners. It is used in media lists, cards, and galleries.'},
-      {key: 'timestamp', name: 'Timestamp', desc: 'Timestamp formats and displays dates and times with relative or absolute labels. It updates automatically to stay current.'},
-      {key: 'toast', name: 'Toast', desc: 'Toasts display brief, non-blocking notifications at the edge of the screen. They auto-dismiss and are used for success, error, or info messages.'},
-      {key: 'togglebutton', name: 'ToggleButton', desc: 'ToggleButton is a button that switches between an on and off state. Use it for binary options like bookmarking, favoriting, or muting.'},
       {key: 'token', name: 'Token', desc: 'Tokens display compact metadata labels such as tags, categories, or filters. They can be dismissible and support selection state.'},
       {key: 'tooltip', name: 'Tooltip', desc: 'Tooltips show concise helper text when users hover over or focus an element. They clarify icons, truncated labels, and controls.'},
-      {key: 'treelist', name: 'TreeList', desc: 'TreeList renders hierarchical data in an expandable tree structure. It supports multi-level nesting, selection, and lazy loading.'},
-    ],
-  },
-  {
-    label: 'Typography',
-    items: [
-      {key: 'heading', name: 'Heading', desc: 'Heading renders semantic section titles from h1 through h6. It establishes visual hierarchy and supports multiple weight and size options.'},
-      {key: 'text', name: 'Text', desc: 'Text renders body copy, labels, and supporting content with consistent typography. It supports sizes from display down to caption.'},
     ],
   },
   {
     label: 'Layout',
     items: [
-      {key: 'aspectratio', name: 'AspectRatio', desc: 'AspectRatio constrains its child to a specified width-to-height ratio. Use it for responsive images, videos, and embedded media.'},
       {key: 'card', name: 'Card', desc: 'Cards group related content and actions in a contained surface. They can include headers, media, body text, and action bars.'},
-      {key: 'center', name: 'Center', desc: 'Center aligns its child horizontally and vertically within the available space. It is useful for empty states, loading screens, and hero sections.'},
       {key: 'divider', name: 'Divider', desc: 'Dividers separate content into distinct sections with a subtle or strong horizontal line. They can optionally include a label.'},
       {key: 'grid', name: 'Grid', desc: 'Grid provides a CSS grid-based layout container with configurable columns, rows, and gap. It simplifies responsive multi-column designs.'},
-      {key: 'layout', name: 'Layout', desc: 'Layout provides foundational page-level primitives for header, sidebar, and content regions. It establishes consistent spacing and structure.'},
-      {key: 'section', name: 'Section', desc: 'Section wraps a block of content with consistent vertical spacing and an optional heading. It structures pages into logical groups.'},
       {key: 'stack', name: 'Stack', desc: 'Stack arranges child elements in a row or column with consistent gap spacing. It is the primary tool for one-dimensional layout composition.'},
-      {key: 'toolbar', name: 'Toolbar', desc: 'Toolbar arranges a row of action buttons and controls in a compact, aligned strip. It is used at the top of panels, editors, and cards.'},
     ],
   },
   {
     label: 'Navigation',
     items: [
       {key: 'breadcrumbs', name: 'Breadcrumbs', desc: "Breadcrumbs show the user's current location within a navigation hierarchy. They provide quick links back to parent pages."},
-      {key: 'mobilenav', name: 'MobileNav', desc: 'MobileNav provides a responsive navigation menu optimized for small screens. It typically slides in from the edge of the viewport.'},
       {key: 'sidenav', name: 'SideNav', desc: 'SideNav renders a vertical navigation panel with links, sections, and collapsible groups. It is used as the primary nav in dashboard layouts.'},
       {key: 'tablist', name: 'TabList', desc: 'TabList switches between content views using a horizontal row of tabs. Only one tab is active at a time, and content changes without a page reload.'},
       {key: 'topnav', name: 'TopNav', desc: 'TopNav provides an app-level navigation bar across the top of the page. It holds branding, primary links, search, and user actions.'},
@@ -146,144 +84,77 @@ const COMPONENT_CATEGORIES = [
     label: 'Form',
     items: [
       {key: 'checkboxinput', name: 'CheckboxInput', desc: 'CheckboxInput renders a single checkbox with a label. It is used for boolean opt-in choices like terms acceptance or feature toggles.'},
-      {key: 'checkboxlist', name: 'CheckboxList', desc: 'CheckboxList displays a group of checkboxes for selecting multiple options. It manages shared state and supports select-all behavior.'},
-      {key: 'dateinput', name: 'DateInput', desc: 'DateInput provides a text field with calendar picker for entering dates. It validates format and supports min/max date constraints.'},
-      {key: 'field', name: 'Field', desc: 'Field wraps a form control with a label, helper text, and error message. It ensures consistent layout and accessibility across all form inputs.'},
-      {key: 'formlayout', name: 'FormLayout', desc: 'FormLayout arranges form fields in a structured vertical or horizontal layout with consistent spacing and alignment.'},
-      {key: 'multiselector', name: 'MultiSelector', desc: 'MultiSelector lets users pick multiple items from a searchable list with tokenized selections. It is ideal for assigning tags, teams, or categories.'},
-      {key: 'numberinput', name: 'NumberInput', desc: 'NumberInput provides a text field for numeric values with optional increment/decrement controls. It supports min, max, and step constraints.'},
-      {key: 'powersearch', name: 'PowerSearch', desc: 'PowerSearch provides an advanced search interface with filters, suggestions, and structured query support for complex data exploration.'},
-      {key: 'radiolist', name: 'RadioList', desc: 'RadioList presents a group of mutually exclusive options. Only one option can be selected at a time, making it ideal for settings and preferences.'},
       {key: 'selector', name: 'Selector', desc: 'Selector lets users pick a single item from a dropdown list. It supports search, grouping, and custom option rendering.'},
-      {key: 'slider', name: 'Slider', desc: 'Slider lets users select a value or range by dragging a handle along a track. It is used for volume, brightness, and numeric range inputs.'},
       {key: 'switch', name: 'Switch', desc: 'Switch toggles a setting between on and off states with immediate effect. It is used for preferences, feature flags, and real-time controls.'},
-      {key: 'textarea', name: 'TextArea', desc: 'TextArea provides a multi-line text field for longer-form content like comments, descriptions, and messages. It supports auto-resize.'},
       {key: 'textinput', name: 'TextInput', desc: 'TextInput is a single-line text field for short user input like names, emails, and search queries. It supports icons, prefixes, and validation.'},
-      {key: 'timeinput', name: 'TimeInput', desc: 'TimeInput provides a field for entering times with optional picker support. It validates format and supports 12- and 24-hour modes.'},
-      {key: 'tokenizer', name: 'Tokenizer', desc: 'Tokenizer is a text input that converts entries into removable tokens. It is used for multi-value fields like email recipients and tags.'},
       {key: 'typeahead', name: 'Typeahead', desc: 'Typeahead provides an autocomplete search input that suggests results as the user types. It supports async data sources and custom rendering.'},
-    ],
-  },
-  {
-    label: 'Inputs',
-    items: [
-      {key: 'segmentedcontrol', name: 'SegmentedControl', desc: 'SegmentedControl lets users toggle between a small set of mutually exclusive options displayed as connected segments. It works like a visual radio group.'},
-    ],
-  },
-  {
-    label: 'Components',
-    items: [
-      {key: 'codeblock', name: 'CodeBlock', desc: 'CodeBlock displays formatted, syntax-highlighted source code. It supports line numbers, copy-to-clipboard, and language detection.'},
-      {key: 'collapsible', name: 'Collapsible', desc: 'Collapsible wraps content that can be expanded or collapsed with a trigger. It is used for FAQs, advanced settings, and progressive disclosure.'},
-      {key: 'markdown', name: 'Markdown', desc: 'Markdown renders markdown-formatted text into styled HTML. It supports headings, lists, links, code blocks, and inline formatting.'},
-    ],
-  },
-  {
-    label: 'Chat',
-    items: [
-      {key: 'chat', name: 'Chat', desc: 'Chat provides a conversational message interface with message bubbles, input, and thread support. It is used for AI assistants and messaging UIs.'},
-    ],
-  },
-  {
-    label: 'CommandPalette',
-    items: [
-      {key: 'commandpalette', name: 'CommandPalette', desc: 'CommandPalette is a keyboard-driven command menu for quick navigation and actions. It is opened with a hotkey and supports fuzzy search.'},
     ],
   },
 ];
 
-const COMPONENT_DOCS: Record<
-  string,
-  {
-    usage: string;
-    bestPractices: {type: 'do' | 'dont'; text: string}[];
-    examples: {
-      title: string;
-      description: string;
-      code: string;
-    }[];
-  }
-> = {
-  button: {
-    usage:
-      'Buttons provide visual cues for actions and events. These fundamental components allow users to commit actions and navigate a page flow. Use a Button when a user needs to submit a form, start a new task or action, or trigger a new UI element to appear on the page.',
-    bestPractices: [
-      {
-        type: 'do',
-        text: 'Convey clear action hierarchy: Each surface should only have 1 primary button. A majority of buttons should be in default or flat style.',
-      },
-      {
-        type: 'do',
-        text: 'Promote clarity: Consider labels alongside icons where appropriate.',
-      },
-      {
-        type: 'dont',
-        text: 'Overuse primary or special buttons: Overusing colored buttons will result in a page with less intentionality, create visual confusion and a lack of page hierarchy.',
-      },
-    ],
-    examples: [
-      {
-        title: 'Semantics',
-        description:
-          'We have four semantic buttons types: flat, default, primary, and destructive. Flat buttons are used to limit visual prominence, whereas primary emphasizes a single action. Use destructive for deletions that trigger dialog confirmations.',
-        code: `<XDSButton label="Flat" variant="ghost" />
-<XDSButton label="Default" variant="secondary" />
-<XDSButton label="Primary" variant="primary" />
-<XDSButton label="Destructive" variant="destructive" />`,
-      },
-      {
-        title: 'Default button with badge',
-        description:
-          'Buttons can include a badge to highlight new or updated actions.',
-        code: `<XDSButton
-  label="Button"
-  variant="default"
-/>`,
-      },
-    ],
-  },
-};
-
-function getComponentName(key: string): string {
-  for (const cat of COMPONENT_CATEGORIES) {
-    const item = cat.items.find(i => i.key === key);
-    if (item) return item.name;
-  }
-  return key;
-}
-
-function getComponentDesc(key: string): string {
-  for (const cat of COMPONENT_CATEGORIES) {
-    const item = cat.items.find(i => i.key === key);
-    if (item) return item.desc;
-  }
-  return '';
-}
-
-function getComponentDocs(key: string) {
-  if (COMPONENT_DOCS[key]) return COMPONENT_DOCS[key];
-  const name = getComponentName(key);
-  const desc = getComponentDesc(key);
-  return {
-    usage: desc,
-    bestPractices: [
-      {type: 'do' as const, text: `Use ${name} in the appropriate context to provide the functionality described above.`},
-      {type: 'do' as const, text: `Pair ${name} with related components to create cohesive, accessible interfaces.`},
-      {type: 'dont' as const, text: `Use ${name} when a simpler alternative achieves the same goal with less complexity.`},
-    ],
-    examples: [
-      {
-        title: `Basic ${name}`,
-        description: `A simple example of the ${name} component with default settings.`,
-        code: `<XDS${name} />`,
-      },
-    ],
-  };
-}
-
 // ---------------------------------------------------------------------------
-// GettingStartedView
+// Sub-views
 // ---------------------------------------------------------------------------
+
+function OverviewView({
+  onSelectComponent,
+}: {
+  onSelectComponent: (key: string) => void;
+}) {
+  return (
+    <XDSLayout contentWidth={1200} content={
+      <XDSLayoutContent padding={8}>
+        <XDSVStack gap={10}>
+          <XDSCard variant="cyan" padding={10}>
+            <XDSHStack gap={8} vAlign="center">
+              <XDSStackItem size="fill">
+                <XDSVStack gap={4}>
+                  <XDSText type="display-1">Web overview</XDSText>
+                  <XDSText type="large" weight="normal" color="secondary">
+                    An open-source UI library to help developers quickly build
+                    beautiful, accessible products.
+                  </XDSText>
+                  <XDSHStack>
+                    <XDSButton
+                      label="Get started"
+                      variant="primary"
+                      size="lg"
+                      onClick={() => onSelectComponent('getting-started')}
+                    />
+                  </XDSHStack>
+                </XDSVStack>
+              </XDSStackItem>
+              <XDSStackItem size="fill" />
+            </XDSHStack>
+          </XDSCard>
+
+          {COMPONENT_CATEGORIES.map(category => (
+            <XDSVStack key={category.label} gap={4}>
+              <XDSText type="display-2">{category.label}</XDSText>
+              <XDSGrid columns={{minWidth: 260}} gap={8}>
+                {category.items.map(item => (
+                  <XDSVStack key={item.key} gap={3}>
+                    <XDSCard
+                      variant="muted"
+                      padding={0}
+                      minHeight={160}
+                      xstyle={styles.previewCard}
+                      onClick={() => onSelectComponent(item.key)}
+                    />
+                    <XDSVStack gap={0.5}>
+                      <XDSText type="body" weight="bold">{item.name}</XDSText>
+                      <XDSText type="body" color="secondary">{item.desc}</XDSText>
+                    </XDSVStack>
+                  </XDSVStack>
+                ))}
+              </XDSGrid>
+            </XDSVStack>
+          ))}
+        </XDSVStack>
+      </XDSLayoutContent>
+    } />
+  );
+}
 
 function GettingStartedView() {
   return (
@@ -309,9 +180,7 @@ function GettingStartedView() {
               <XDSStackItem size="fill">
                 <XDSHStack gap={2} vAlign="center">
                   <XDSIcon icon={SparklesIcon} size="sm" color="secondary" />
-                  <XDSText type="body" weight="semibold">
-                    AI Assistance
-                  </XDSText>
+                  <XDSText type="body" weight="semibold">AI Assistance</XDSText>
                 </XDSHStack>
               </XDSStackItem>
               <XDSButton
@@ -326,13 +195,7 @@ function GettingStartedView() {
                 }}
               />
               <XDSDropdownMenu
-                button={{
-                  label: 'More options',
-                  variant: 'ghost',
-                  size: 'sm',
-                  isIconOnly: true,
-                  icon: <XDSIcon icon={ChevronDownIcon} />,
-                }}
+                button={{label: 'More options', variant: 'ghost', size: 'sm', isIconOnly: true, icon: <XDSIcon icon={ChevronDownIcon} />}}
                 items={[
                   {label: 'Open in v0', onClick: () => {}},
                   {label: 'Open in Claude', onClick: () => {}},
@@ -367,36 +230,23 @@ function GettingStartedView() {
             Every project starts with installing the core package. This gives
             you access to all components, tokens, and utilities.
           </XDSText>
-
           <XDSVStack gap={2}>
-            <XDSText type="body" weight="bold">
-              Step 1: Install the core package
-            </XDSText>
+            <XDSText type="body" weight="bold">Step 1: Install the core package</XDSText>
             <XDSCard padding={0}>
               <XDSCodeBlock code="npm install @xds/core" language="bash" />
             </XDSCard>
           </XDSVStack>
-
           <XDSVStack gap={2}>
-            <XDSText type="body" weight="bold">
-              Step 2: Add the StyleX compiler
-            </XDSText>
+            <XDSText type="body" weight="bold">Step 2: Add the StyleX compiler</XDSText>
             <XDSText type="body" color="secondary">
-              XDS uses StyleX for styling. Add the compiler plugin to your build
-              configuration.
+              XDS uses StyleX for styling. Add the compiler plugin to your build configuration.
             </XDSText>
             <XDSCard padding={0}>
-              <XDSCodeBlock
-                code="npm install @stylexjs/babel-plugin"
-                language="bash"
-              />
+              <XDSCodeBlock code="npm install @stylexjs/babel-plugin" language="bash" />
             </XDSCard>
           </XDSVStack>
-
           <XDSVStack gap={2}>
-            <XDSText type="body" weight="bold">
-              Step 3: Import your first component
-            </XDSText>
+            <XDSText type="body" weight="bold">Step 3: Import your first component</XDSText>
             <XDSCard padding={0}>
               <XDSCodeBlock
                 code={`import { XDSButton } from '@xds/core/Button';
@@ -416,8 +266,7 @@ export default function App() {
           <XDSHeading level={2}>Configure theming</XDSHeading>
           <XDSText type="body">
             XDS ships with a default theme that works out of the box. To
-            customize colors, typography, and spacing, wrap your app in a theme
-            provider.
+            customize colors, typography, and spacing, wrap your app in a theme provider.
           </XDSText>
           <XDSCard padding={0}>
             <XDSCodeBlock
@@ -457,217 +306,11 @@ export default function App({ children }) {
 }
 
 // ---------------------------------------------------------------------------
-// ComponentDetailView
-// ---------------------------------------------------------------------------
-
-function ComponentDetailView({activeNav}: {activeNav: string}) {
-  const [exampleTabs, setExampleTabs] = useState<Record<string, string>>({});
-
-  const EXAMPLE_PREVIEWS: Record<string, React.ReactNode[]> = {
-    button: [
-      <XDSHStack key="semantics" gap={3} vAlign="center">
-        <XDSButton label="Flat" variant="ghost" />
-        <XDSButton label="Default" variant="secondary" />
-        <XDSButton label="Primary" variant="primary" />
-        <XDSButton label="Destructive" variant="destructive" />
-      </XDSHStack>,
-      <XDSButton key="badge" label="Button" variant="secondary" />,
-    ],
-  };
-
-  const COMPONENT_PREVIEWS: Record<string, React.ReactNode> = {
-    button: (
-      <XDSButton
-        label="Button"
-        variant="secondary"
-        icon={<XDSIcon icon={PlusIcon} />}
-        endContent={<XDSBadge label="New" variant="info" />}
-      />
-    ),
-    avatar: <XDSAvatar name="Alice" size="medium" />,
-    badge: <XDSBadge label="Success" variant="success" />,
-    card: (
-      <XDSCard>
-        <XDSVStack gap={2}>
-          <XDSHeading level={4}>Card Title</XDSHeading>
-          <XDSText type="body" color="secondary">
-            Cards group related content and actions.
-          </XDSText>
-        </XDSVStack>
-      </XDSCard>
-    ),
-    banner: (
-      <XDSBanner status="info" title="Information">
-        <XDSText type="body">This is an informational banner message.</XDSText>
-      </XDSBanner>
-    ),
-    dialog: <DialogPreview />,
-    text: <XDSText type="body">Body text</XDSText>,
-    divider: <XDSDivider />,
-    token: <XDSToken label="Design" />,
-    tooltip: (
-      <XDSTooltip content="Primary action">
-        <XDSButton label="Hover me" variant="primary" />
-      </XDSTooltip>
-    ),
-  };
-
-  const docs = useMemo(() => getComponentDocs(activeNav), [activeNav]);
-  const previews = EXAMPLE_PREVIEWS[activeNav] ?? [];
-
-  return (
-    <XDSLayout contentWidth={960} content={
-      <XDSLayoutContent padding={8}>
-        <XDSVStack gap={8}>
-          {/* Header */}
-          <XDSVStack gap={2}>
-            <XDSText type="display-1">{getComponentName(activeNav)}</XDSText>
-            <XDSText type="supporting" color="secondary">
-              March 30, 2026 · Updated 5:40 p.m. PST
-            </XDSText>
-          </XDSVStack>
-
-          <XDSDivider />
-
-          {/* Live Preview Card */}
-          <XDSCard variant="muted" padding={0}>
-            <XDSCenter height={360}>
-              {COMPONENT_PREVIEWS[activeNav] ?? (
-                <XDSText type="supporting" color="secondary">
-                  Preview coming soon
-                </XDSText>
-              )}
-            </XDSCenter>
-          </XDSCard>
-
-          {/* Usage & Best Practices */}
-          <XDSVStack gap={4}>
-            <XDSHeading level={2}>Usage</XDSHeading>
-            <XDSText type="large" weight="normal">
-              {docs.usage}
-            </XDSText>
-            <XDSHeading level={3}>Best practices</XDSHeading>
-            <XDSTable
-              data={docs.bestPractices as Record<string, unknown>[]}
-              columns={[
-                {
-                  key: 'type',
-                  header: 'Guidance',
-                  width: pixel(125),
-                  renderCell: (item: Record<string, unknown>) => (
-                    <XDSBadge
-                      label={item.type === 'do' ? 'Do' : 'Dont'}
-                      variant={item.type === 'do' ? 'success' : 'error'}
-                    />
-                  ),
-                },
-                {
-                  key: 'text',
-                  header: 'Practices',
-                  renderCell: (item: Record<string, unknown>) => (
-                    <XDSText type="body" textWrap="wrap">
-                      {item.text as string}
-                    </XDSText>
-                  ),
-                },
-              ]}
-              density="spacious"
-              dividers="rows"
-            />
-          </XDSVStack>
-
-          <XDSDivider />
-
-          {/* Examples */}
-          <XDSVStack gap={4}>
-            <XDSHeading level={2}>Examples</XDSHeading>
-            <XDSText type="large" weight="normal">
-              Explore common configurations, variations, and states for this
-              component.
-            </XDSText>
-          </XDSVStack>
-          <XDSVStack gap={8}>
-          {docs.examples.map((example, i) => {
-            const tabKey = `${activeNav}-${i}`;
-            const activeTab = exampleTabs[tabKey] ?? 'description';
-            return (
-              <XDSCard key={i} padding={0}>
-                {/* Header */}
-                <XDSSection padding={3} variant="transparent">
-                  <XDSHStack gap={3} vAlign="center">
-                    <XDSStackItem size="fill">
-                      <XDSText type="body" weight="medium">
-                        {example.title}
-                      </XDSText>
-                    </XDSStackItem>
-                    <XDSHStack gap={1} vAlign="center">
-                      <XDSButton
-                        label="Open in Craft"
-                        variant="ghost"
-                        size="sm"
-                        icon={<XDSIcon icon={ArrowTopRightOnSquareIcon} />}
-                      />
-                      <XDSButton
-                        label="Send to CLI"
-                        variant="ghost"
-                        size="sm"
-                      />
-                      <XDSIconButton
-                        label="Fullscreen"
-                        variant="ghost"
-                        size="sm"
-                        icon={<XDSIcon icon={ArrowsPointingOutIcon} />}
-                      />
-                    </XDSHStack>
-                  </XDSHStack>
-                </XDSSection>
-                {/* Preview */}
-                <XDSCenter height={280}>
-                  {previews[i] ?? (
-                    <XDSText type="supporting" color="secondary">
-                      Preview coming soon
-                    </XDSText>
-                  )}
-                </XDSCenter>
-                {/* Tabs + content */}
-                <XDSSection variant="wash" padding={3} dividers={['top']}>
-                  <XDSVStack gap={3}>
-                    <XDSTabList
-                      value={activeTab}
-                      onChange={value =>
-                        setExampleTabs(prev => ({
-                          ...prev,
-                          [tabKey]: value,
-                        }))
-                      }
-                      size="sm"
-                      xstyle={styles.tabListFlush}>
-                      <XDSTab value="description" label="Description" />
-                      <XDSTab value="code" label="Code" />
-                    </XDSTabList>
-                    {activeTab === 'description' ? (
-                      <XDSText type="body">{example.description}</XDSText>
-                    ) : (
-                      <XDSCodeBlock code={example.code} language="tsx" />
-                    )}
-                  </XDSVStack>
-                </XDSSection>
-              </XDSCard>
-            );
-          })}
-          </XDSVStack>
-        </XDSVStack>
-      </XDSLayoutContent>
-    } />
-  );
-}
-
-// ---------------------------------------------------------------------------
 // Main component
 // ---------------------------------------------------------------------------
 
 export default function TechnicalDocumentationPage() {
-  const [activePage, setActivePage] = useState<string>('getting-started');
+  const [activePage, setActivePage] = useState<string>('home');
 
   return (
     <XDSAppShell
@@ -675,10 +318,13 @@ export default function TechnicalDocumentationPage() {
       height="fill"
       sideNav={
         <XDSSideNav
-          header={
-            <XDSSideNavHeading heading="Product Name" />
-          }>
+          header={<XDSSideNavHeading heading="Product Name" />}>
           <XDSSideNavSection title="Navigation" isHeaderHidden>
+            <XDSSideNavItem
+              label="Home"
+              isSelected={activePage === 'home'}
+              onClick={() => setActivePage('home')}
+            />
             <XDSSideNavItem
               label="Getting started"
               isSelected={activePage === 'getting-started'}
@@ -692,22 +338,16 @@ export default function TechnicalDocumentationPage() {
                 <XDSSideNavItem
                   key={item.key}
                   label={item.name}
-                  isSelected={activePage === item.key}
-                  onClick={
-                    item.key === 'button'
-                      ? () => setActivePage(item.key)
-                      : undefined
-                  }
                 />
               ))}
             </XDSSideNavSection>
           ))}
         </XDSSideNav>
       }>
-      {activePage === 'getting-started' ? (
-        <GettingStartedView />
+      {activePage === 'home' ? (
+        <OverviewView onSelectComponent={setActivePage} />
       ) : (
-        <ComponentDetailView activeNav={activePage} />
+        <GettingStartedView />
       )}
     </XDSAppShell>
   );

--- a/packages/cli/templates/pages/documentation-technical/page.tsx
+++ b/packages/cli/templates/pages/documentation-technical/page.tsx
@@ -16,7 +16,6 @@ import {XDSCard} from '@xds/core/Card';
 import {XDSAvatar} from '@xds/core/Avatar';
 import {XDSBadge} from '@xds/core/Badge';
 import {XDSToken} from '@xds/core/Token';
-import {XDSList, XDSListItem} from '@xds/core/List';
 import {XDSBanner} from '@xds/core/Banner';
 import {XDSCodeBlock} from '@xds/core/CodeBlock';
 import {XDSTabList, XDSTab} from '@xds/core/TabList';
@@ -40,7 +39,7 @@ const styles = stylex.create({
 });
 
 // ---------------------------------------------------------------------------
-// DialogPreview
+// DialogPreview — stateful dialog preview for component previews
 // ---------------------------------------------------------------------------
 
 function DialogPreview() {
@@ -74,51 +73,116 @@ const COMPONENT_CATEGORIES = [
   {
     label: 'Core',
     items: [
-      {key: 'appshell', name: 'AppShell', desc: 'Foundational page layout with header, sidebar, and content regions.'},
-      {key: 'avatar', name: 'Avatar', desc: 'Represents a person or entity with an image, initials, or icon.'},
-      {key: 'badge', name: 'Badge', desc: 'Small counts or status labels attached to icons, buttons, or list items.'},
-      {key: 'banner', name: 'Banner', desc: 'Important, non-modal messages at the top of a page or section.'},
-      {key: 'button', name: 'Button', desc: 'Buttons let people take action in forms, dialogs, and toolbars.'},
-      {key: 'card', name: 'Card', desc: 'Cards group related content and actions in a contained surface.'},
-      {key: 'dialog', name: 'Dialog', desc: 'Modal overlays that require user attention or action before continuing.'},
-      {key: 'dropdownmenu', name: 'DropdownMenu', desc: 'List of actions or options in a floating overlay triggered by a button.'},
-      {key: 'icon', name: 'Icon', desc: 'Small visual symbols that represent actions, objects, or concepts.'},
-      {key: 'link', name: 'Link', desc: 'Navigation between pages or to external resources with visual affordance.'},
-      {key: 'list', name: 'List', desc: 'Vertical set of related items with selection, icons, and metadata.'},
-      {key: 'popover', name: 'Popover', desc: 'Rich content in a floating panel anchored to a trigger element.'},
-      {key: 'table', name: 'Table', desc: 'Structured data in rows and columns with sorting, selection, and custom cells.'},
-      {key: 'token', name: 'Token', desc: 'Compact metadata labels such as tags, categories, or filters.'},
-      {key: 'tooltip', name: 'Tooltip', desc: 'Concise helper text when users hover over or focus an element.'},
+      {key: 'appshell', name: 'AppShell', desc: 'AppShell provides a foundational page layout with header, sidebar, and content regions. Use it to establish consistent structure across your application.'},
+      {key: 'avatar', name: 'Avatar', desc: 'Avatars represent a person or entity with an image, initials, or icon. They are commonly used in user profiles, comments, and contact lists.'},
+      {key: 'badge', name: 'Badge', desc: 'Badges display small counts or status labels. They can be attached to icons, buttons, or list items to surface key information at a glance.'},
+      {key: 'banner', name: 'Banner', desc: 'Banners show important, non-modal messages at the top of a page or section. They communicate status, warnings, or promotional information.'},
+      {key: 'button', name: 'Button', desc: 'Buttons let people take action. They can be used in forms, dialogs, and toolbars, or as standalone links.'},
+      {key: 'calendar', name: 'Calendar', desc: 'Calendar provides a date-picking grid for selecting single dates or date ranges. It integrates with form fields for date input.'},
+      {key: 'dialog', name: 'Dialog', desc: 'Dialogs are modal overlays that require user attention or action before continuing. They are used for confirmations, forms, and critical decisions.'},
+      {key: 'dropdownmenu', name: 'DropdownMenu', desc: 'DropdownMenu presents a list of actions or options in a floating overlay. It is triggered by a button and supports nested submenus.'},
+      {key: 'emptystate', name: 'EmptyState', desc: 'EmptyState provides a placeholder when there is no content to display. It guides users with a message, illustration, and optional call-to-action.'},
+      {key: 'hovercard', name: 'HoverCard', desc: 'HoverCard shows a rich preview of content when users hover over a trigger element. It is ideal for previewing profiles, links, or details.'},
+      {key: 'icon', name: 'Icon', desc: 'Icons are small visual symbols that represent actions, objects, or concepts. They improve scannability and reinforce meaning alongside text.'},
+      {key: 'kbd', name: 'Kbd', desc: 'Kbd renders keyboard shortcut hints in a styled inline element. Use it to show users which key combinations perform specific actions.'},
+      {key: 'link', name: 'Link', desc: 'Links provide navigation between pages or to external resources. They follow accessible anchor semantics with visual affordance.'},
+      {key: 'list', name: 'List', desc: 'List displays a vertical set of related items. It supports selection, icons, and metadata for building menus, nav lists, and more.'},
+      {key: 'metadatalist', name: 'MetadataList', desc: 'MetadataList displays key-value pairs in a structured layout. Use it for detail panels, settings summaries, and record information.'},
+      {key: 'moremenu', name: 'MoreMenu', desc: 'MoreMenu provides an overflow menu triggered by an icon button. It collects secondary actions that do not fit in the primary toolbar.'},
+      {key: 'overflowlist', name: 'OverflowList', desc: 'OverflowList renders as many items as fit in the available space and collapses the rest into an overflow menu automatically.'},
+      {key: 'pagination', name: 'Pagination', desc: 'Pagination lets users navigate through pages of content. It supports page numbers, previous/next controls, and page-size selection.'},
+      {key: 'popover', name: 'Popover', desc: 'Popover displays rich content in a floating panel anchored to a trigger element. It is used for forms, filters, and contextual tools.'},
+      {key: 'progressbar', name: 'ProgressBar', desc: 'ProgressBar shows the completion status of a task or process. It provides visual feedback for uploads, installations, and multi-step flows.'},
+      {key: 'skeleton', name: 'Skeleton', desc: 'Skeleton renders placeholder shapes that mimic content layout while loading. It reduces perceived wait time and prevents layout shifts.'},
+      {key: 'spinner', name: 'Spinner', desc: 'Spinner indicates that a process is in progress when the duration is unknown. It draws attention without blocking the interface.'},
+      {key: 'statusdot', name: 'StatusDot', desc: 'StatusDot shows a small colored indicator for online, offline, busy, or custom statuses. It is often paired with avatars or list items.'},
+      {key: 'table', name: 'Table', desc: 'Table displays structured data in rows and columns with support for sorting, selection, and custom cell rendering.'},
+      {key: 'thumbnail', name: 'Thumbnail', desc: 'Thumbnail renders a small image preview with consistent sizing and optional rounded corners. It is used in media lists, cards, and galleries.'},
+      {key: 'timestamp', name: 'Timestamp', desc: 'Timestamp formats and displays dates and times with relative or absolute labels. It updates automatically to stay current.'},
+      {key: 'toast', name: 'Toast', desc: 'Toasts display brief, non-blocking notifications at the edge of the screen. They auto-dismiss and are used for success, error, or info messages.'},
+      {key: 'togglebutton', name: 'ToggleButton', desc: 'ToggleButton is a button that switches between an on and off state. Use it for binary options like bookmarking, favoriting, or muting.'},
+      {key: 'token', name: 'Token', desc: 'Tokens display compact metadata labels such as tags, categories, or filters. They can be dismissible and support selection state.'},
+      {key: 'tooltip', name: 'Tooltip', desc: 'Tooltips show concise helper text when users hover over or focus an element. They clarify icons, truncated labels, and controls.'},
+      {key: 'treelist', name: 'TreeList', desc: 'TreeList renders hierarchical data in an expandable tree structure. It supports multi-level nesting, selection, and lazy loading.'},
+    ],
+  },
+  {
+    label: 'Typography',
+    items: [
+      {key: 'heading', name: 'Heading', desc: 'Heading renders semantic section titles from h1 through h6. It establishes visual hierarchy and supports multiple weight and size options.'},
+      {key: 'text', name: 'Text', desc: 'Text renders body copy, labels, and supporting content with consistent typography. It supports sizes from display down to caption.'},
     ],
   },
   {
     label: 'Layout',
     items: [
-      {key: 'stack', name: 'Stack', desc: 'Arranges children in a row or column with consistent gap spacing.'},
-      {key: 'grid', name: 'Grid', desc: 'CSS grid-based layout container with configurable columns and gap.'},
-      {key: 'divider', name: 'Divider', desc: 'Separates content into distinct sections with a subtle line.'},
-      {key: 'section', name: 'Section', desc: 'Wraps content with consistent vertical spacing and optional heading.'},
-      {key: 'center', name: 'Center', desc: 'Centers its child horizontally and vertically within available space.'},
+      {key: 'aspectratio', name: 'AspectRatio', desc: 'AspectRatio constrains its child to a specified width-to-height ratio. Use it for responsive images, videos, and embedded media.'},
+      {key: 'card', name: 'Card', desc: 'Cards group related content and actions in a contained surface. They can include headers, media, body text, and action bars.'},
+      {key: 'center', name: 'Center', desc: 'Center aligns its child horizontally and vertically within the available space. It is useful for empty states, loading screens, and hero sections.'},
+      {key: 'divider', name: 'Divider', desc: 'Dividers separate content into distinct sections with a subtle or strong horizontal line. They can optionally include a label.'},
+      {key: 'grid', name: 'Grid', desc: 'Grid provides a CSS grid-based layout container with configurable columns, rows, and gap. It simplifies responsive multi-column designs.'},
+      {key: 'layout', name: 'Layout', desc: 'Layout provides foundational page-level primitives for header, sidebar, and content regions. It establishes consistent spacing and structure.'},
+      {key: 'section', name: 'Section', desc: 'Section wraps a block of content with consistent vertical spacing and an optional heading. It structures pages into logical groups.'},
+      {key: 'stack', name: 'Stack', desc: 'Stack arranges child elements in a row or column with consistent gap spacing. It is the primary tool for one-dimensional layout composition.'},
+      {key: 'toolbar', name: 'Toolbar', desc: 'Toolbar arranges a row of action buttons and controls in a compact, aligned strip. It is used at the top of panels, editors, and cards.'},
     ],
   },
   {
     label: 'Navigation',
     items: [
-      {key: 'sidenav', name: 'SideNav', desc: 'Vertical navigation panel with links, sections, and collapsible groups.'},
-      {key: 'topnav', name: 'TopNav', desc: 'App-level navigation bar with branding, links, and user actions.'},
-      {key: 'tablist', name: 'TabList', desc: 'Switches between content views using a horizontal row of tabs.'},
-      {key: 'breadcrumbs', name: 'Breadcrumbs', desc: "Shows user's current location within a navigation hierarchy."},
+      {key: 'breadcrumbs', name: 'Breadcrumbs', desc: "Breadcrumbs show the user's current location within a navigation hierarchy. They provide quick links back to parent pages."},
+      {key: 'mobilenav', name: 'MobileNav', desc: 'MobileNav provides a responsive navigation menu optimized for small screens. It typically slides in from the edge of the viewport.'},
+      {key: 'sidenav', name: 'SideNav', desc: 'SideNav renders a vertical navigation panel with links, sections, and collapsible groups. It is used as the primary nav in dashboard layouts.'},
+      {key: 'tablist', name: 'TabList', desc: 'TabList switches between content views using a horizontal row of tabs. Only one tab is active at a time, and content changes without a page reload.'},
+      {key: 'topnav', name: 'TopNav', desc: 'TopNav provides an app-level navigation bar across the top of the page. It holds branding, primary links, search, and user actions.'},
     ],
   },
   {
     label: 'Form',
     items: [
-      {key: 'textinput', name: 'TextInput', desc: 'Single-line text field for names, emails, and search queries.'},
-      {key: 'selector', name: 'Selector', desc: 'Pick a single item from a dropdown list with search and grouping.'},
-      {key: 'switch', name: 'Switch', desc: 'Toggles a setting between on and off states with immediate effect.'},
-      {key: 'checkboxinput', name: 'CheckboxInput', desc: 'Single checkbox with a label for boolean opt-in choices.'},
-      {key: 'radiolist', name: 'RadioList', desc: 'Group of mutually exclusive options for settings and preferences.'},
-      {key: 'slider', name: 'Slider', desc: 'Select a value or range by dragging a handle along a track.'},
+      {key: 'checkboxinput', name: 'CheckboxInput', desc: 'CheckboxInput renders a single checkbox with a label. It is used for boolean opt-in choices like terms acceptance or feature toggles.'},
+      {key: 'checkboxlist', name: 'CheckboxList', desc: 'CheckboxList displays a group of checkboxes for selecting multiple options. It manages shared state and supports select-all behavior.'},
+      {key: 'dateinput', name: 'DateInput', desc: 'DateInput provides a text field with calendar picker for entering dates. It validates format and supports min/max date constraints.'},
+      {key: 'field', name: 'Field', desc: 'Field wraps a form control with a label, helper text, and error message. It ensures consistent layout and accessibility across all form inputs.'},
+      {key: 'formlayout', name: 'FormLayout', desc: 'FormLayout arranges form fields in a structured vertical or horizontal layout with consistent spacing and alignment.'},
+      {key: 'multiselector', name: 'MultiSelector', desc: 'MultiSelector lets users pick multiple items from a searchable list with tokenized selections. It is ideal for assigning tags, teams, or categories.'},
+      {key: 'numberinput', name: 'NumberInput', desc: 'NumberInput provides a text field for numeric values with optional increment/decrement controls. It supports min, max, and step constraints.'},
+      {key: 'powersearch', name: 'PowerSearch', desc: 'PowerSearch provides an advanced search interface with filters, suggestions, and structured query support for complex data exploration.'},
+      {key: 'radiolist', name: 'RadioList', desc: 'RadioList presents a group of mutually exclusive options. Only one option can be selected at a time, making it ideal for settings and preferences.'},
+      {key: 'selector', name: 'Selector', desc: 'Selector lets users pick a single item from a dropdown list. It supports search, grouping, and custom option rendering.'},
+      {key: 'slider', name: 'Slider', desc: 'Slider lets users select a value or range by dragging a handle along a track. It is used for volume, brightness, and numeric range inputs.'},
+      {key: 'switch', name: 'Switch', desc: 'Switch toggles a setting between on and off states with immediate effect. It is used for preferences, feature flags, and real-time controls.'},
+      {key: 'textarea', name: 'TextArea', desc: 'TextArea provides a multi-line text field for longer-form content like comments, descriptions, and messages. It supports auto-resize.'},
+      {key: 'textinput', name: 'TextInput', desc: 'TextInput is a single-line text field for short user input like names, emails, and search queries. It supports icons, prefixes, and validation.'},
+      {key: 'timeinput', name: 'TimeInput', desc: 'TimeInput provides a field for entering times with optional picker support. It validates format and supports 12- and 24-hour modes.'},
+      {key: 'tokenizer', name: 'Tokenizer', desc: 'Tokenizer is a text input that converts entries into removable tokens. It is used for multi-value fields like email recipients and tags.'},
+      {key: 'typeahead', name: 'Typeahead', desc: 'Typeahead provides an autocomplete search input that suggests results as the user types. It supports async data sources and custom rendering.'},
+    ],
+  },
+  {
+    label: 'Inputs',
+    items: [
+      {key: 'segmentedcontrol', name: 'SegmentedControl', desc: 'SegmentedControl lets users toggle between a small set of mutually exclusive options displayed as connected segments. It works like a visual radio group.'},
+    ],
+  },
+  {
+    label: 'Components',
+    items: [
+      {key: 'codeblock', name: 'CodeBlock', desc: 'CodeBlock displays formatted, syntax-highlighted source code. It supports line numbers, copy-to-clipboard, and language detection.'},
+      {key: 'collapsible', name: 'Collapsible', desc: 'Collapsible wraps content that can be expanded or collapsed with a trigger. It is used for FAQs, advanced settings, and progressive disclosure.'},
+      {key: 'markdown', name: 'Markdown', desc: 'Markdown renders markdown-formatted text into styled HTML. It supports headings, lists, links, code blocks, and inline formatting.'},
+    ],
+  },
+  {
+    label: 'Chat',
+    items: [
+      {key: 'chat', name: 'Chat', desc: 'Chat provides a conversational message interface with message bubbles, input, and thread support. It is used for AI assistants and messaging UIs.'},
+    ],
+  },
+  {
+    label: 'CommandPalette',
+    items: [
+      {key: 'commandpalette', name: 'CommandPalette', desc: 'CommandPalette is a keyboard-driven command menu for quick navigation and actions. It is opened with a hotkey and supports fuzzy search.'},
     ],
   },
 ];
@@ -128,55 +192,47 @@ const COMPONENT_DOCS: Record<
   {
     usage: string;
     bestPractices: {type: 'do' | 'dont'; text: string}[];
-    props: {name: string; type: string; default: string; description: string}[];
-    examples: {title: string; description: string; code: string}[];
+    examples: {
+      title: string;
+      description: string;
+      code: string;
+    }[];
   }
 > = {
   button: {
     usage:
       'Buttons provide visual cues for actions and events. These fundamental components allow users to commit actions and navigate a page flow. Use a Button when a user needs to submit a form, start a new task or action, or trigger a new UI element to appear on the page.',
     bestPractices: [
-      {type: 'do', text: 'Convey clear action hierarchy: Each surface should only have 1 primary button.'},
-      {type: 'do', text: 'Promote clarity: Consider labels alongside icons where appropriate.'},
-      {type: 'dont', text: 'Overuse primary buttons: Overusing colored buttons creates visual confusion.'},
-      {type: 'dont', text: 'Use a button for navigation: Use Link instead for page transitions.'},
-    ],
-    props: [
-      {name: 'label', type: 'string', default: '—', description: 'Accessible label text for the button.'},
-      {name: 'variant', type: "'primary' | 'secondary' | 'ghost' | 'destructive'", default: "'secondary'", description: 'Visual style variant.'},
-      {name: 'size', type: "'sm' | 'md' | 'lg'", default: "'md'", description: 'Size of the button.'},
-      {name: 'icon', type: 'ReactNode', default: '—', description: 'Icon element displayed before the label.'},
-      {name: 'isIconOnly', type: 'boolean', default: 'false', description: 'Render only the icon, hiding the label visually.'},
-      {name: 'isDisabled', type: 'boolean', default: 'false', description: 'Prevents interaction and dims the button.'},
-      {name: 'isLoading', type: 'boolean', default: 'false', description: 'Shows a spinner and disables interaction.'},
-      {name: 'onClick', type: '() => void', default: '—', description: 'Callback fired when the button is clicked.'},
+      {
+        type: 'do',
+        text: 'Convey clear action hierarchy: Each surface should only have 1 primary button. A majority of buttons should be in default or flat style.',
+      },
+      {
+        type: 'do',
+        text: 'Promote clarity: Consider labels alongside icons where appropriate.',
+      },
+      {
+        type: 'dont',
+        text: 'Overuse primary or special buttons: Overusing colored buttons will result in a page with less intentionality, create visual confusion and a lack of page hierarchy.',
+      },
     ],
     examples: [
       {
-        title: 'Variants',
-        description: 'Four semantic button types: ghost, secondary, primary, and destructive.',
-        code: `<XDSButton label="Ghost" variant="ghost" />
-<XDSButton label="Secondary" variant="secondary" />
+        title: 'Semantics',
+        description:
+          'We have four semantic buttons types: flat, default, primary, and destructive. Flat buttons are used to limit visual prominence, whereas primary emphasizes a single action. Use destructive for deletions that trigger dialog confirmations.',
+        code: `<XDSButton label="Flat" variant="ghost" />
+<XDSButton label="Default" variant="secondary" />
 <XDSButton label="Primary" variant="primary" />
 <XDSButton label="Destructive" variant="destructive" />`,
       },
       {
-        title: 'With icon',
-        description: 'Buttons can include a leading icon for visual reinforcement.',
+        title: 'Default button with badge',
+        description:
+          'Buttons can include a badge to highlight new or updated actions.',
         code: `<XDSButton
-  label="Add item"
-  variant="primary"
-  icon={<PlusIcon />}
-/>`,
-      },
-      {
-        title: 'Icon only',
-        description: 'Icon-only buttons for compact toolbars. Always provide a label for accessibility.',
-        code: `<XDSButton
-  label="Settings"
-  variant="ghost"
-  icon={<CogIcon />}
-  isIconOnly
+  label="Button"
+  variant="default"
 />`,
       },
     ],
@@ -206,14 +262,9 @@ function getComponentDocs(key: string) {
   return {
     usage: desc,
     bestPractices: [
-      {type: 'do' as const, text: `Use ${name} in the appropriate context to provide the described functionality.`},
+      {type: 'do' as const, text: `Use ${name} in the appropriate context to provide the functionality described above.`},
       {type: 'do' as const, text: `Pair ${name} with related components to create cohesive, accessible interfaces.`},
       {type: 'dont' as const, text: `Use ${name} when a simpler alternative achieves the same goal with less complexity.`},
-    ],
-    props: [
-      {name: 'label', type: 'string', default: '—', description: `Accessible label for the ${name} component.`},
-      {name: 'children', type: 'ReactNode', default: '—', description: `Content rendered inside the ${name}.`},
-      {name: 'className', type: 'string', default: '—', description: 'Additional CSS class name.'},
     ],
     examples: [
       {
@@ -226,7 +277,7 @@ function getComponentDocs(key: string) {
 }
 
 // ---------------------------------------------------------------------------
-// Sub-views
+// ComponentDetailView
 // ---------------------------------------------------------------------------
 
 function ComponentDetailView({activeNav}: {activeNav: string}) {
@@ -234,14 +285,13 @@ function ComponentDetailView({activeNav}: {activeNav: string}) {
 
   const EXAMPLE_PREVIEWS: Record<string, React.ReactNode[]> = {
     button: [
-      <XDSHStack key="variants" gap={3} vAlign="center">
-        <XDSButton label="Ghost" variant="ghost" />
-        <XDSButton label="Secondary" variant="secondary" />
+      <XDSHStack key="semantics" gap={3} vAlign="center">
+        <XDSButton label="Flat" variant="ghost" />
+        <XDSButton label="Default" variant="secondary" />
         <XDSButton label="Primary" variant="primary" />
         <XDSButton label="Destructive" variant="destructive" />
       </XDSHStack>,
-      <XDSButton key="icon" label="Add item" variant="primary" icon={<XDSIcon icon={PlusIcon} />} />,
-      <XDSButton key="icononly" label="Settings" variant="ghost" icon={<XDSIcon icon={PlusIcon} />} isIconOnly />,
+      <XDSButton key="badge" label="Button" variant="secondary" />,
     ],
   };
 
@@ -260,7 +310,9 @@ function ComponentDetailView({activeNav}: {activeNav: string}) {
       <XDSCard>
         <XDSVStack gap={2}>
           <XDSHeading level={4}>Card Title</XDSHeading>
-          <XDSText type="body" color="secondary">Cards group related content and actions.</XDSText>
+          <XDSText type="body" color="secondary">
+            Cards group related content and actions.
+          </XDSText>
         </XDSVStack>
       </XDSCard>
     ),
@@ -270,6 +322,8 @@ function ComponentDetailView({activeNav}: {activeNav: string}) {
       </XDSBanner>
     ),
     dialog: <DialogPreview />,
+    text: <XDSText type="body">Body text</XDSText>,
+    divider: <XDSDivider />,
     token: <XDSToken label="Design" />,
     tooltip: (
       <XDSTooltip content="Primary action">
@@ -295,11 +349,13 @@ function ComponentDetailView({activeNav}: {activeNav: string}) {
 
           <XDSDivider />
 
-          {/* Live Preview */}
+          {/* Live Preview Card */}
           <XDSCard variant="muted" padding={0}>
             <XDSCenter height={360}>
               {COMPONENT_PREVIEWS[activeNav] ?? (
-                <XDSText type="supporting" color="secondary">Preview coming soon</XDSText>
+                <XDSText type="supporting" color="secondary">
+                  Preview coming soon
+                </XDSText>
               )}
             </XDSCenter>
           </XDSCard>
@@ -307,7 +363,9 @@ function ComponentDetailView({activeNav}: {activeNav: string}) {
           {/* Usage & Best Practices */}
           <XDSVStack gap={4}>
             <XDSHeading level={2}>Usage</XDSHeading>
-            <XDSText type="large" weight="normal">{docs.usage}</XDSText>
+            <XDSText type="large" weight="normal">
+              {docs.usage}
+            </XDSText>
             <XDSHeading level={3}>Best practices</XDSHeading>
             <XDSTable
               data={docs.bestPractices as Record<string, unknown>[]}
@@ -327,36 +385,11 @@ function ComponentDetailView({activeNav}: {activeNav: string}) {
                   key: 'text',
                   header: 'Practices',
                   renderCell: (item: Record<string, unknown>) => (
-                    <XDSText type="body" textWrap="wrap">{item.text as string}</XDSText>
+                    <XDSText type="body" textWrap="wrap">
+                      {item.text as string}
+                    </XDSText>
                   ),
                 },
-              ]}
-              density="spacious"
-              dividers="rows"
-            />
-          </XDSVStack>
-
-          <XDSDivider />
-
-          {/* Props table */}
-          <XDSVStack gap={4}>
-            <XDSHeading level={2}>Props</XDSHeading>
-            <XDSText type="body" color="secondary">
-              All available props for the {getComponentName(activeNav)} component.
-            </XDSText>
-            <XDSTable
-              data={docs.props as Record<string, unknown>[]}
-              columns={[
-                {key: 'name', header: 'Prop', width: pixel(140), renderCell: (item: Record<string, unknown>) => (
-                  <XDSText type="body" weight="bold" style={{fontFamily: 'monospace', fontSize: 13}}>{item.name as string}</XDSText>
-                )},
-                {key: 'type', header: 'Type', width: pixel(200), renderCell: (item: Record<string, unknown>) => (
-                  <XDSText type="supporting" style={{fontFamily: 'monospace', fontSize: 12}}>{item.type as string}</XDSText>
-                )},
-                {key: 'default', header: 'Default', width: pixel(100), renderCell: (item: Record<string, unknown>) => (
-                  <XDSText type="supporting" color="secondary" style={{fontFamily: 'monospace', fontSize: 12}}>{item.default as string}</XDSText>
-                )},
-                {key: 'description', header: 'Description'},
               ]}
               density="spacious"
               dividers="rows"
@@ -369,61 +402,79 @@ function ComponentDetailView({activeNav}: {activeNav: string}) {
           <XDSVStack gap={4}>
             <XDSHeading level={2}>Examples</XDSHeading>
             <XDSText type="large" weight="normal">
-              Explore common configurations, variations, and states.
+              Explore common configurations, variations, and states for this
+              component.
             </XDSText>
           </XDSVStack>
           <XDSVStack gap={8}>
-            {docs.examples.map((example, i) => {
-              const tabKey = `${activeNav}-${i}`;
-              const activeTab = exampleTabs[tabKey] ?? 'description';
-              return (
-                <XDSCard key={i} padding={0}>
-                  <XDSSection padding={3} variant="transparent">
-                    <XDSHStack gap={3} vAlign="center">
-                      <XDSStackItem size="fill">
-                        <XDSText type="body" weight="medium">{example.title}</XDSText>
-                      </XDSStackItem>
-                      <XDSHStack gap={1} vAlign="center">
-                        <XDSButton
-                          label="Open in Craft"
-                          variant="ghost"
-                          size="sm"
-                          icon={<XDSIcon icon={ArrowTopRightOnSquareIcon} />}
-                        />
-                        <XDSIconButton
-                          label="Fullscreen"
-                          variant="ghost"
-                          size="sm"
-                          icon={<XDSIcon icon={ArrowsPointingOutIcon} />}
-                        />
-                      </XDSHStack>
-                    </XDSHStack>
-                  </XDSSection>
-                  <XDSCenter height={280}>
-                    {previews[i] ?? (
-                      <XDSText type="supporting" color="secondary">Preview coming soon</XDSText>
-                    )}
-                  </XDSCenter>
-                  <XDSSection variant="wash" padding={3} dividers={['top']}>
-                    <XDSVStack gap={3}>
-                      <XDSTabList
-                        value={activeTab}
-                        onChange={value => setExampleTabs(prev => ({...prev, [tabKey]: value}))}
+          {docs.examples.map((example, i) => {
+            const tabKey = `${activeNav}-${i}`;
+            const activeTab = exampleTabs[tabKey] ?? 'description';
+            return (
+              <XDSCard key={i} padding={0}>
+                {/* Header */}
+                <XDSSection padding={3} variant="transparent">
+                  <XDSHStack gap={3} vAlign="center">
+                    <XDSStackItem size="fill">
+                      <XDSText type="body" weight="medium">
+                        {example.title}
+                      </XDSText>
+                    </XDSStackItem>
+                    <XDSHStack gap={1} vAlign="center">
+                      <XDSButton
+                        label="Open in Craft"
+                        variant="ghost"
                         size="sm"
-                        xstyle={styles.tabListFlush}>
-                        <XDSTab value="description" label="Description" />
-                        <XDSTab value="code" label="Code" />
-                      </XDSTabList>
-                      {activeTab === 'description' ? (
-                        <XDSText type="body">{example.description}</XDSText>
-                      ) : (
-                        <XDSCodeBlock code={example.code} language="tsx" />
-                      )}
-                    </XDSVStack>
-                  </XDSSection>
-                </XDSCard>
-              );
-            })}
+                        icon={<XDSIcon icon={ArrowTopRightOnSquareIcon} />}
+                      />
+                      <XDSButton
+                        label="Send to CLI"
+                        variant="ghost"
+                        size="sm"
+                      />
+                      <XDSIconButton
+                        label="Fullscreen"
+                        variant="ghost"
+                        size="sm"
+                        icon={<XDSIcon icon={ArrowsPointingOutIcon} />}
+                      />
+                    </XDSHStack>
+                  </XDSHStack>
+                </XDSSection>
+                {/* Preview */}
+                <XDSCenter height={280}>
+                  {previews[i] ?? (
+                    <XDSText type="supporting" color="secondary">
+                      Preview coming soon
+                    </XDSText>
+                  )}
+                </XDSCenter>
+                {/* Tabs + content */}
+                <XDSSection variant="wash" padding={3} dividers={['top']}>
+                  <XDSVStack gap={3}>
+                    <XDSTabList
+                      value={activeTab}
+                      onChange={value =>
+                        setExampleTabs(prev => ({
+                          ...prev,
+                          [tabKey]: value,
+                        }))
+                      }
+                      size="sm"
+                      xstyle={styles.tabListFlush}>
+                      <XDSTab value="description" label="Description" />
+                      <XDSTab value="code" label="Code" />
+                    </XDSTabList>
+                    {activeTab === 'description' ? (
+                      <XDSText type="body">{example.description}</XDSText>
+                    ) : (
+                      <XDSCodeBlock code={example.code} language="tsx" />
+                    )}
+                  </XDSVStack>
+                </XDSSection>
+              </XDSCard>
+            );
+          })}
           </XDSVStack>
         </XDSVStack>
       </XDSLayoutContent>
@@ -444,7 +495,9 @@ export default function TechnicalDocumentationPage() {
       height="fill"
       sideNav={
         <XDSSideNav
-          header={<XDSSideNavHeading heading="API Reference" />}>
+          header={
+            <XDSSideNavHeading heading="Product Name" />
+          }>
           {COMPONENT_CATEGORIES.map(category => (
             <XDSSideNavSection key={category.label} title={category.label}>
               {category.items.map(item => (
@@ -452,7 +505,11 @@ export default function TechnicalDocumentationPage() {
                   key={item.key}
                   label={item.name}
                   isSelected={activePage === item.key}
-                  onClick={() => setActivePage(item.key)}
+                  onClick={
+                    item.key === 'button'
+                      ? () => setActivePage(item.key)
+                      : undefined
+                  }
                 />
               ))}
             </XDSSideNavSection>

--- a/packages/cli/templates/pages/documentation-technical/page.tsx
+++ b/packages/cli/templates/pages/documentation-technical/page.tsx
@@ -13,9 +13,11 @@ import {XDSHeading, XDSText} from '@xds/core/Text';
 import {XDSButton} from '@xds/core/Button';
 import {XDSIconButton} from '@xds/core/IconButton';
 import {XDSCard} from '@xds/core/Card';
+import {XDSDropdownMenu} from '@xds/core/DropdownMenu';
 import {XDSAvatar} from '@xds/core/Avatar';
 import {XDSBadge} from '@xds/core/Badge';
 import {XDSToken} from '@xds/core/Token';
+import {XDSList, XDSListItem} from '@xds/core/List';
 import {XDSBanner} from '@xds/core/Banner';
 import {XDSCodeBlock} from '@xds/core/CodeBlock';
 import {XDSTabList, XDSTab} from '@xds/core/TabList';
@@ -31,7 +33,10 @@ import {XDSCenter} from '@xds/core/Center';
 import {
   ArrowTopRightOnSquareIcon,
   ArrowsPointingOutIcon,
+  SparklesIcon,
+  ClipboardDocumentIcon,
   PlusIcon,
+  ChevronDownIcon,
 } from '@heroicons/react/24/outline';
 
 const styles = stylex.create({
@@ -277,6 +282,181 @@ function getComponentDocs(key: string) {
 }
 
 // ---------------------------------------------------------------------------
+// GettingStartedView
+// ---------------------------------------------------------------------------
+
+function GettingStartedView() {
+  return (
+    <XDSLayout contentWidth={960} content={
+      <XDSLayoutContent padding={8}>
+        <XDSVStack gap={8}>
+        <XDSVStack gap={2}>
+          <XDSText type="display-1">
+            Getting started with Product Name
+          </XDSText>
+          <XDSText type="supporting" color="secondary">
+            Last updated March 30, 2026
+          </XDSText>
+          <XDSText type="body">
+            Install the package, configure your theme, and build your first
+            component in three steps.
+          </XDSText>
+        </XDSVStack>
+
+        <XDSCard>
+          <XDSVStack gap={3}>
+            <XDSHStack gap={2} vAlign="center">
+              <XDSStackItem size="fill">
+                <XDSHStack gap={2} vAlign="center">
+                  <XDSIcon icon={SparklesIcon} size="sm" color="secondary" />
+                  <XDSText type="body" weight="semibold">
+                    AI Assistance
+                  </XDSText>
+                </XDSHStack>
+              </XDSStackItem>
+              <XDSButton
+                label="Copy prompt"
+                variant="ghost"
+                size="sm"
+                icon={<XDSIcon icon={ClipboardDocumentIcon} />}
+                onClick={() => {
+                  void navigator.clipboard.writeText(
+                    'Help me get set up with Product Name. Based on my project, do the following: 1. Install @xds/core and the StyleX compiler. 2. Wrap my app in XDSThemeProvider. 3. Replace one existing component with an XDS equivalent. After setup, suggest relevant next steps based on my project.',
+                  );
+                }}
+              />
+              <XDSDropdownMenu
+                button={{
+                  label: 'More options',
+                  variant: 'ghost',
+                  size: 'sm',
+                  isIconOnly: true,
+                  icon: <XDSIcon icon={ChevronDownIcon} />,
+                }}
+                items={[
+                  {label: 'Open in v0', onClick: () => {}},
+                  {label: 'Open in Claude', onClick: () => {}},
+                  {label: 'Open in ChatGPT', onClick: () => {}},
+                  {label: 'Open in Cursor', onClick: () => {}},
+                ]}
+              />
+            </XDSHStack>
+            <XDSText type="body" color="secondary">
+              Help me get set up with Product Name. Based on my project, do the
+              following: 1. Install @xds/core and the StyleX compiler. 2. Wrap
+              my app in XDSThemeProvider. 3. Replace one existing component with
+              an XDS equivalent.
+            </XDSText>
+          </XDSVStack>
+        </XDSCard>
+
+        <XDSVStack gap={4}>
+          <XDSHeading level={2}>Prerequisites</XDSHeading>
+          <XDSList density="compact" listStyle="disc">
+            <XDSListItem label="Node.js 18+" />
+            <XDSListItem label="React 18 or 19" />
+            <XDSListItem label="A package manager (npm, yarn, or pnpm)" />
+          </XDSList>
+        </XDSVStack>
+
+        <XDSDivider />
+
+        <XDSVStack gap={4}>
+          <XDSHeading level={2}>Install the package</XDSHeading>
+          <XDSText type="body">
+            Every project starts with installing the core package. This gives
+            you access to all components, tokens, and utilities.
+          </XDSText>
+
+          <XDSVStack gap={2}>
+            <XDSText type="body" weight="bold">
+              Step 1: Install the core package
+            </XDSText>
+            <XDSCard padding={0}>
+              <XDSCodeBlock code="npm install @xds/core" language="bash" />
+            </XDSCard>
+          </XDSVStack>
+
+          <XDSVStack gap={2}>
+            <XDSText type="body" weight="bold">
+              Step 2: Add the StyleX compiler
+            </XDSText>
+            <XDSText type="body" color="secondary">
+              XDS uses StyleX for styling. Add the compiler plugin to your build
+              configuration.
+            </XDSText>
+            <XDSCard padding={0}>
+              <XDSCodeBlock
+                code="npm install @stylexjs/babel-plugin"
+                language="bash"
+              />
+            </XDSCard>
+          </XDSVStack>
+
+          <XDSVStack gap={2}>
+            <XDSText type="body" weight="bold">
+              Step 3: Import your first component
+            </XDSText>
+            <XDSCard padding={0}>
+              <XDSCodeBlock
+                code={`import { XDSButton } from '@xds/core/Button';
+
+export default function App() {
+  return <XDSButton label="Hello XDS" variant="primary" />;
+}`}
+                language="tsx"
+              />
+            </XDSCard>
+          </XDSVStack>
+        </XDSVStack>
+
+        <XDSDivider />
+
+        <XDSVStack gap={4}>
+          <XDSHeading level={2}>Configure theming</XDSHeading>
+          <XDSText type="body">
+            XDS ships with a default theme that works out of the box. To
+            customize colors, typography, and spacing, wrap your app in a theme
+            provider.
+          </XDSText>
+          <XDSCard padding={0}>
+            <XDSCodeBlock
+              code={`import { XDSThemeProvider } from '@xds/core/Theme';
+
+export default function App({ children }) {
+  return (
+    <XDSThemeProvider theme="default">
+      {children}
+    </XDSThemeProvider>
+  );
+}`}
+              language="tsx"
+            />
+          </XDSCard>
+          <XDSText type="body" color="secondary">
+            See the theming guide for the full list of customizable tokens.
+          </XDSText>
+        </XDSVStack>
+
+        <XDSDivider />
+
+        <XDSVStack gap={4}>
+          <XDSHeading level={2}>Next steps</XDSHeading>
+          <XDSList density="compact" listStyle="disc">
+            <XDSListItem label="Fundamental concepts — How theming, layout, and composition work" />
+            <XDSListItem label="Component API reference — Props, variants, and examples for every component" />
+            <XDSListItem label="Accessibility — Built-in a11y features and ARIA patterns" />
+            <XDSListItem label="CLI tools — Scaffold projects and manage templates" />
+            <XDSListItem label="Design tokens — Colors, spacing, typography, and sizing" />
+          </XDSList>
+        </XDSVStack>
+      </XDSVStack>
+      </XDSLayoutContent>
+    } />
+  );
+}
+
+// ---------------------------------------------------------------------------
 // ComponentDetailView
 // ---------------------------------------------------------------------------
 
@@ -487,7 +667,7 @@ function ComponentDetailView({activeNav}: {activeNav: string}) {
 // ---------------------------------------------------------------------------
 
 export default function TechnicalDocumentationPage() {
-  const [activePage, setActivePage] = useState<string>('button');
+  const [activePage, setActivePage] = useState<string>('getting-started');
 
   return (
     <XDSAppShell
@@ -498,6 +678,14 @@ export default function TechnicalDocumentationPage() {
           header={
             <XDSSideNavHeading heading="Product Name" />
           }>
+          <XDSSideNavSection title="Navigation" isHeaderHidden>
+            <XDSSideNavItem
+              label="Getting started"
+              isSelected={activePage === 'getting-started'}
+              onClick={() => setActivePage('getting-started')}
+            />
+          </XDSSideNavSection>
+
           {COMPONENT_CATEGORIES.map(category => (
             <XDSSideNavSection key={category.label} title={category.label}>
               {category.items.map(item => (
@@ -516,7 +704,11 @@ export default function TechnicalDocumentationPage() {
           ))}
         </XDSSideNav>
       }>
-      <ComponentDetailView activeNav={activePage} />
+      {activePage === 'getting-started' ? (
+        <GettingStartedView />
+      ) : (
+        <ComponentDetailView activeNav={activePage} />
+      )}
     </XDSAppShell>
   );
 }

--- a/packages/cli/templates/pages/documentation-technical/page.tsx
+++ b/packages/cli/templates/pages/documentation-technical/page.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import {useState} from 'react';
-import * as stylex from '@stylexjs/stylex';
 import {XDSAppShell} from '@xds/core/AppShell';
 import {
   XDSSideNav,
@@ -19,299 +17,17 @@ import {XDSHStack, XDSVStack, XDSStackItem} from '@xds/core/Stack';
 import {XDSLayout, XDSLayoutContent} from '@xds/core/Layout';
 import {XDSDivider} from '@xds/core/Divider';
 import {XDSIcon} from '@xds/core/Icon';
-import {XDSGrid} from '@xds/core/Grid';
-import {radiusVars} from '@xds/core/theme/tokens.stylex';
 import {
   SparklesIcon,
   ClipboardDocumentIcon,
   ChevronDownIcon,
 } from '@heroicons/react/24/outline';
 
-const styles = stylex.create({
-  previewCard: {
-    borderRadius: radiusVars['--radius-container'],
-    cursor: 'pointer',
-  },
-});
-
-// ---------------------------------------------------------------------------
-// Data
-// ---------------------------------------------------------------------------
-
-const COMPONENT_CATEGORIES = [
-  {
-    label: 'Core',
-    items: [
-      {key: 'appshell', name: 'AppShell', desc: 'AppShell provides a foundational page layout with header, sidebar, and content regions. Use it to establish consistent structure across your application.'},
-      {key: 'avatar', name: 'Avatar', desc: 'Avatars represent a person or entity with an image, initials, or icon. They are commonly used in user profiles, comments, and contact lists.'},
-      {key: 'badge', name: 'Badge', desc: 'Badges display small counts or status labels. They can be attached to icons, buttons, or list items to surface key information at a glance.'},
-      {key: 'banner', name: 'Banner', desc: 'Banners show important, non-modal messages at the top of a page or section. They communicate status, warnings, or promotional information.'},
-      {key: 'button', name: 'Button', desc: 'Buttons let people take action. They can be used in forms, dialogs, and toolbars, or as standalone links.'},
-      {key: 'calendar', name: 'Calendar', desc: 'Calendar provides a date-picking grid for selecting single dates or date ranges. It integrates with form fields for date input.'},
-      {key: 'dialog', name: 'Dialog', desc: 'Dialogs are modal overlays that require user attention or action before continuing. They are used for confirmations, forms, and critical decisions.'},
-      {key: 'dropdownmenu', name: 'DropdownMenu', desc: 'DropdownMenu presents a list of actions or options in a floating overlay. It is triggered by a button and supports nested submenus.'},
-      {key: 'emptystate', name: 'EmptyState', desc: 'EmptyState provides a placeholder when there is no content to display. It guides users with a message, illustration, and optional call-to-action.'},
-      {key: 'hovercard', name: 'HoverCard', desc: 'HoverCard shows a rich preview of content when users hover over a trigger element. It is ideal for previewing profiles, links, or details.'},
-      {key: 'icon', name: 'Icon', desc: 'Icons are small visual symbols that represent actions, objects, or concepts. They improve scannability and reinforce meaning alongside text.'},
-      {key: 'kbd', name: 'Kbd', desc: 'Kbd renders keyboard shortcut hints in a styled inline element. Use it to show users which key combinations perform specific actions.'},
-      {key: 'link', name: 'Link', desc: 'Links provide navigation between pages or to external resources. They follow accessible anchor semantics with visual affordance.'},
-      {key: 'list', name: 'List', desc: 'List displays a vertical set of related items. It supports selection, icons, and metadata for building menus, nav lists, and more.'},
-      {key: 'popover', name: 'Popover', desc: 'Popover displays rich content in a floating panel anchored to a trigger element. It is used for forms, filters, and contextual tools.'},
-      {key: 'table', name: 'Table', desc: 'Table displays structured data in rows and columns with support for sorting, selection, and custom cell rendering.'},
-      {key: 'token', name: 'Token', desc: 'Tokens display compact metadata labels such as tags, categories, or filters. They can be dismissible and support selection state.'},
-      {key: 'tooltip', name: 'Tooltip', desc: 'Tooltips show concise helper text when users hover over or focus an element. They clarify icons, truncated labels, and controls.'},
-    ],
-  },
-  {
-    label: 'Layout',
-    items: [
-      {key: 'card', name: 'Card', desc: 'Cards group related content and actions in a contained surface. They can include headers, media, body text, and action bars.'},
-      {key: 'divider', name: 'Divider', desc: 'Dividers separate content into distinct sections with a subtle or strong horizontal line. They can optionally include a label.'},
-      {key: 'grid', name: 'Grid', desc: 'Grid provides a CSS grid-based layout container with configurable columns, rows, and gap. It simplifies responsive multi-column designs.'},
-      {key: 'stack', name: 'Stack', desc: 'Stack arranges child elements in a row or column with consistent gap spacing. It is the primary tool for one-dimensional layout composition.'},
-    ],
-  },
-  {
-    label: 'Navigation',
-    items: [
-      {key: 'breadcrumbs', name: 'Breadcrumbs', desc: "Breadcrumbs show the user's current location within a navigation hierarchy. They provide quick links back to parent pages."},
-      {key: 'sidenav', name: 'SideNav', desc: 'SideNav renders a vertical navigation panel with links, sections, and collapsible groups. It is used as the primary nav in dashboard layouts.'},
-      {key: 'tablist', name: 'TabList', desc: 'TabList switches between content views using a horizontal row of tabs. Only one tab is active at a time, and content changes without a page reload.'},
-      {key: 'topnav', name: 'TopNav', desc: 'TopNav provides an app-level navigation bar across the top of the page. It holds branding, primary links, search, and user actions.'},
-    ],
-  },
-  {
-    label: 'Form',
-    items: [
-      {key: 'checkboxinput', name: 'CheckboxInput', desc: 'CheckboxInput renders a single checkbox with a label. It is used for boolean opt-in choices like terms acceptance or feature toggles.'},
-      {key: 'selector', name: 'Selector', desc: 'Selector lets users pick a single item from a dropdown list. It supports search, grouping, and custom option rendering.'},
-      {key: 'switch', name: 'Switch', desc: 'Switch toggles a setting between on and off states with immediate effect. It is used for preferences, feature flags, and real-time controls.'},
-      {key: 'textinput', name: 'TextInput', desc: 'TextInput is a single-line text field for short user input like names, emails, and search queries. It supports icons, prefixes, and validation.'},
-      {key: 'typeahead', name: 'Typeahead', desc: 'Typeahead provides an autocomplete search input that suggests results as the user types. It supports async data sources and custom rendering.'},
-    ],
-  },
-];
-
-// ---------------------------------------------------------------------------
-// Sub-views
-// ---------------------------------------------------------------------------
-
-function OverviewView({
-  onSelectComponent,
-}: {
-  onSelectComponent: (key: string) => void;
-}) {
-  return (
-    <XDSLayout contentWidth={1200} content={
-      <XDSLayoutContent padding={8}>
-        <XDSVStack gap={10}>
-          <XDSCard variant="cyan" padding={10}>
-            <XDSHStack gap={8} vAlign="center">
-              <XDSStackItem size="fill">
-                <XDSVStack gap={4}>
-                  <XDSText type="display-1">Web overview</XDSText>
-                  <XDSText type="large" weight="normal" color="secondary">
-                    An open-source UI library to help developers quickly build
-                    beautiful, accessible products.
-                  </XDSText>
-                  <XDSHStack>
-                    <XDSButton
-                      label="Get started"
-                      variant="primary"
-                      size="lg"
-                      onClick={() => onSelectComponent('getting-started')}
-                    />
-                  </XDSHStack>
-                </XDSVStack>
-              </XDSStackItem>
-              <XDSStackItem size="fill" />
-            </XDSHStack>
-          </XDSCard>
-
-          {COMPONENT_CATEGORIES.map(category => (
-            <XDSVStack key={category.label} gap={4}>
-              <XDSText type="display-2">{category.label}</XDSText>
-              <XDSGrid columns={{minWidth: 260}} gap={8}>
-                {category.items.map(item => (
-                  <XDSVStack key={item.key} gap={3}>
-                    <XDSCard
-                      variant="muted"
-                      padding={0}
-                      minHeight={160}
-                      xstyle={styles.previewCard}
-                      onClick={() => onSelectComponent(item.key)}
-                    />
-                    <XDSVStack gap={0.5}>
-                      <XDSText type="body" weight="bold">{item.name}</XDSText>
-                      <XDSText type="body" color="secondary">{item.desc}</XDSText>
-                    </XDSVStack>
-                  </XDSVStack>
-                ))}
-              </XDSGrid>
-            </XDSVStack>
-          ))}
-        </XDSVStack>
-      </XDSLayoutContent>
-    } />
-  );
-}
-
-function GettingStartedView() {
-  return (
-    <XDSLayout contentWidth={960} content={
-      <XDSLayoutContent padding={8}>
-        <XDSVStack gap={8}>
-        <XDSVStack gap={2}>
-          <XDSText type="display-1">
-            Getting started with Product Name
-          </XDSText>
-          <XDSText type="supporting" color="secondary">
-            Last updated March 30, 2026
-          </XDSText>
-          <XDSText type="body">
-            Install the package, configure your theme, and build your first
-            component in three steps.
-          </XDSText>
-        </XDSVStack>
-
-        <XDSCard>
-          <XDSVStack gap={3}>
-            <XDSHStack gap={2} vAlign="center">
-              <XDSStackItem size="fill">
-                <XDSHStack gap={2} vAlign="center">
-                  <XDSIcon icon={SparklesIcon} size="sm" color="secondary" />
-                  <XDSText type="body" weight="semibold">AI Assistance</XDSText>
-                </XDSHStack>
-              </XDSStackItem>
-              <XDSButton
-                label="Copy prompt"
-                variant="ghost"
-                size="sm"
-                icon={<XDSIcon icon={ClipboardDocumentIcon} />}
-                onClick={() => {
-                  void navigator.clipboard.writeText(
-                    'Help me get set up with Product Name. Based on my project, do the following: 1. Install @xds/core and the StyleX compiler. 2. Wrap my app in XDSThemeProvider. 3. Replace one existing component with an XDS equivalent. After setup, suggest relevant next steps based on my project.',
-                  );
-                }}
-              />
-              <XDSDropdownMenu
-                button={{label: 'More options', variant: 'ghost', size: 'sm', isIconOnly: true, icon: <XDSIcon icon={ChevronDownIcon} />}}
-                items={[
-                  {label: 'Open in v0', onClick: () => {}},
-                  {label: 'Open in Claude', onClick: () => {}},
-                  {label: 'Open in ChatGPT', onClick: () => {}},
-                  {label: 'Open in Cursor', onClick: () => {}},
-                ]}
-              />
-            </XDSHStack>
-            <XDSText type="body" color="secondary">
-              Help me get set up with Product Name. Based on my project, do the
-              following: 1. Install @xds/core and the StyleX compiler. 2. Wrap
-              my app in XDSThemeProvider. 3. Replace one existing component with
-              an XDS equivalent.
-            </XDSText>
-          </XDSVStack>
-        </XDSCard>
-
-        <XDSVStack gap={4}>
-          <XDSHeading level={2}>Prerequisites</XDSHeading>
-          <XDSList density="compact" listStyle="disc">
-            <XDSListItem label="Node.js 18+" />
-            <XDSListItem label="React 18 or 19" />
-            <XDSListItem label="A package manager (npm, yarn, or pnpm)" />
-          </XDSList>
-        </XDSVStack>
-
-        <XDSDivider />
-
-        <XDSVStack gap={4}>
-          <XDSHeading level={2}>Install the package</XDSHeading>
-          <XDSText type="body">
-            Every project starts with installing the core package. This gives
-            you access to all components, tokens, and utilities.
-          </XDSText>
-          <XDSVStack gap={2}>
-            <XDSText type="body" weight="bold">Step 1: Install the core package</XDSText>
-            <XDSCard padding={0}>
-              <XDSCodeBlock code="npm install @xds/core" language="bash" />
-            </XDSCard>
-          </XDSVStack>
-          <XDSVStack gap={2}>
-            <XDSText type="body" weight="bold">Step 2: Add the StyleX compiler</XDSText>
-            <XDSText type="body" color="secondary">
-              XDS uses StyleX for styling. Add the compiler plugin to your build configuration.
-            </XDSText>
-            <XDSCard padding={0}>
-              <XDSCodeBlock code="npm install @stylexjs/babel-plugin" language="bash" />
-            </XDSCard>
-          </XDSVStack>
-          <XDSVStack gap={2}>
-            <XDSText type="body" weight="bold">Step 3: Import your first component</XDSText>
-            <XDSCard padding={0}>
-              <XDSCodeBlock
-                code={`import { XDSButton } from '@xds/core/Button';
-
-export default function App() {
-  return <XDSButton label="Hello XDS" variant="primary" />;
-}`}
-                language="tsx"
-              />
-            </XDSCard>
-          </XDSVStack>
-        </XDSVStack>
-
-        <XDSDivider />
-
-        <XDSVStack gap={4}>
-          <XDSHeading level={2}>Configure theming</XDSHeading>
-          <XDSText type="body">
-            XDS ships with a default theme that works out of the box. To
-            customize colors, typography, and spacing, wrap your app in a theme provider.
-          </XDSText>
-          <XDSCard padding={0}>
-            <XDSCodeBlock
-              code={`import { XDSThemeProvider } from '@xds/core/Theme';
-
-export default function App({ children }) {
-  return (
-    <XDSThemeProvider theme="default">
-      {children}
-    </XDSThemeProvider>
-  );
-}`}
-              language="tsx"
-            />
-          </XDSCard>
-          <XDSText type="body" color="secondary">
-            See the theming guide for the full list of customizable tokens.
-          </XDSText>
-        </XDSVStack>
-
-        <XDSDivider />
-
-        <XDSVStack gap={4}>
-          <XDSHeading level={2}>Next steps</XDSHeading>
-          <XDSList density="compact" listStyle="disc">
-            <XDSListItem label="Fundamental concepts — How theming, layout, and composition work" />
-            <XDSListItem label="Component API reference — Props, variants, and examples for every component" />
-            <XDSListItem label="Accessibility — Built-in a11y features and ARIA patterns" />
-            <XDSListItem label="CLI tools — Scaffold projects and manage templates" />
-            <XDSListItem label="Design tokens — Colors, spacing, typography, and sizing" />
-          </XDSList>
-        </XDSVStack>
-      </XDSVStack>
-      </XDSLayoutContent>
-    } />
-  );
-}
-
 // ---------------------------------------------------------------------------
 // Main component
 // ---------------------------------------------------------------------------
 
 export default function TechnicalDocumentationPage() {
-  const [activePage, setActivePage] = useState<string>('home');
-
   return (
     <XDSAppShell
       variant="section"
@@ -320,35 +36,155 @@ export default function TechnicalDocumentationPage() {
         <XDSSideNav
           header={<XDSSideNavHeading heading="Product Name" />}>
           <XDSSideNavSection title="Navigation" isHeaderHidden>
-            <XDSSideNavItem
-              label="Home"
-              isSelected={activePage === 'home'}
-              onClick={() => setActivePage('home')}
-            />
-            <XDSSideNavItem
-              label="Getting started"
-              isSelected={activePage === 'getting-started'}
-              onClick={() => setActivePage('getting-started')}
-            />
+            <XDSSideNavItem label="Home" />
+            <XDSSideNavItem label="Getting started" isSelected />
           </XDSSideNavSection>
-
-          {COMPONENT_CATEGORIES.map(category => (
-            <XDSSideNavSection key={category.label} title={category.label}>
-              {category.items.map(item => (
-                <XDSSideNavItem
-                  key={item.key}
-                  label={item.name}
-                />
-              ))}
-            </XDSSideNavSection>
-          ))}
         </XDSSideNav>
       }>
-      {activePage === 'home' ? (
-        <OverviewView onSelectComponent={setActivePage} />
-      ) : (
-        <GettingStartedView />
-      )}
+      <XDSLayout contentWidth={960} content={
+        <XDSLayoutContent padding={8}>
+          <XDSVStack gap={8}>
+          <XDSVStack gap={2}>
+            <XDSText type="display-1">
+              Getting started with Product Name
+            </XDSText>
+            <XDSText type="supporting" color="secondary">
+              Last updated March 30, 2026
+            </XDSText>
+            <XDSText type="body">
+              Install the package, configure your theme, and build your first
+              component in three steps.
+            </XDSText>
+          </XDSVStack>
+
+          <XDSCard>
+            <XDSVStack gap={3}>
+              <XDSHStack gap={2} vAlign="center">
+                <XDSStackItem size="fill">
+                  <XDSHStack gap={2} vAlign="center">
+                    <XDSIcon icon={SparklesIcon} size="sm" color="secondary" />
+                    <XDSText type="body" weight="semibold">AI Assistance</XDSText>
+                  </XDSHStack>
+                </XDSStackItem>
+                <XDSButton
+                  label="Copy prompt"
+                  variant="ghost"
+                  size="sm"
+                  icon={<XDSIcon icon={ClipboardDocumentIcon} />}
+                  onClick={() => {
+                    void navigator.clipboard.writeText(
+                      'Help me get set up with Product Name. Based on my project, do the following: 1. Install @xds/core and the StyleX compiler. 2. Wrap my app in XDSThemeProvider. 3. Replace one existing component with an XDS equivalent. After setup, suggest relevant next steps based on my project.',
+                    );
+                  }}
+                />
+                <XDSDropdownMenu
+                  button={{label: 'More options', variant: 'ghost', size: 'sm', isIconOnly: true, icon: <XDSIcon icon={ChevronDownIcon} />}}
+                  items={[
+                    {label: 'Open in v0', onClick: () => {}},
+                    {label: 'Open in Claude', onClick: () => {}},
+                    {label: 'Open in ChatGPT', onClick: () => {}},
+                    {label: 'Open in Cursor', onClick: () => {}},
+                  ]}
+                />
+              </XDSHStack>
+              <XDSText type="body" color="secondary">
+                Help me get set up with Product Name. Based on my project, do the
+                following: 1. Install @xds/core and the StyleX compiler. 2. Wrap
+                my app in XDSThemeProvider. 3. Replace one existing component with
+                an XDS equivalent.
+              </XDSText>
+            </XDSVStack>
+          </XDSCard>
+
+          <XDSVStack gap={4}>
+            <XDSHeading level={2}>Prerequisites</XDSHeading>
+            <XDSList density="compact" listStyle="disc">
+              <XDSListItem label="Node.js 18+" />
+              <XDSListItem label="React 18 or 19" />
+              <XDSListItem label="A package manager (npm, yarn, or pnpm)" />
+            </XDSList>
+          </XDSVStack>
+
+          <XDSDivider />
+
+          <XDSVStack gap={4}>
+            <XDSHeading level={2}>Install the package</XDSHeading>
+            <XDSText type="body">
+              Every project starts with installing the core package. This gives
+              you access to all components, tokens, and utilities.
+            </XDSText>
+            <XDSVStack gap={2}>
+              <XDSText type="body" weight="bold">Step 1: Install the core package</XDSText>
+              <XDSCard padding={0}>
+                <XDSCodeBlock code="npm install @xds/core" language="bash" />
+              </XDSCard>
+            </XDSVStack>
+            <XDSVStack gap={2}>
+              <XDSText type="body" weight="bold">Step 2: Add the StyleX compiler</XDSText>
+              <XDSText type="body" color="secondary">
+                XDS uses StyleX for styling. Add the compiler plugin to your build configuration.
+              </XDSText>
+              <XDSCard padding={0}>
+                <XDSCodeBlock code="npm install @stylexjs/babel-plugin" language="bash" />
+              </XDSCard>
+            </XDSVStack>
+            <XDSVStack gap={2}>
+              <XDSText type="body" weight="bold">Step 3: Import your first component</XDSText>
+              <XDSCard padding={0}>
+                <XDSCodeBlock
+                  code={`import { XDSButton } from '@xds/core/Button';
+
+export default function App() {
+  return <XDSButton label="Hello XDS" variant="primary" />;
+}`}
+                  language="tsx"
+                />
+              </XDSCard>
+            </XDSVStack>
+          </XDSVStack>
+
+          <XDSDivider />
+
+          <XDSVStack gap={4}>
+            <XDSHeading level={2}>Configure theming</XDSHeading>
+            <XDSText type="body">
+              XDS ships with a default theme that works out of the box. To
+              customize colors, typography, and spacing, wrap your app in a theme provider.
+            </XDSText>
+            <XDSCard padding={0}>
+              <XDSCodeBlock
+                code={`import { XDSThemeProvider } from '@xds/core/Theme';
+
+export default function App({ children }) {
+  return (
+    <XDSThemeProvider theme="default">
+      {children}
+    </XDSThemeProvider>
+  );
+}`}
+                language="tsx"
+              />
+            </XDSCard>
+            <XDSText type="body" color="secondary">
+              See the theming guide for the full list of customizable tokens.
+            </XDSText>
+          </XDSVStack>
+
+          <XDSDivider />
+
+          <XDSVStack gap={4}>
+            <XDSHeading level={2}>Next steps</XDSHeading>
+            <XDSList density="compact" listStyle="disc">
+              <XDSListItem label="Fundamental concepts — How theming, layout, and composition work" />
+              <XDSListItem label="Component API reference — Props, variants, and examples for every component" />
+              <XDSListItem label="Accessibility — Built-in a11y features and ARIA patterns" />
+              <XDSListItem label="CLI tools — Scaffold projects and manage templates" />
+              <XDSListItem label="Design tokens — Colors, spacing, typography, and sizing" />
+            </XDSList>
+          </XDSVStack>
+        </XDSVStack>
+        </XDSLayoutContent>
+      } />
     </XDSAppShell>
   );
 }

--- a/packages/cli/templates/pages/documentation-technical/template.doc.mjs
+++ b/packages/cli/templates/pages/documentation-technical/template.doc.mjs
@@ -1,7 +1,7 @@
 /** @type {import('../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'page',
-  name: 'Getting Started',
+  name: 'Setup Guide',
   description: 'Getting started guide with install steps, AI assistance prompt card, theming setup, and next steps.',
   isReady: true,
 };

--- a/packages/cli/templates/pages/documentation-technical/template.doc.mjs
+++ b/packages/cli/templates/pages/documentation-technical/template.doc.mjs
@@ -1,7 +1,7 @@
 /** @type {import('../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'page',
-  name: 'Technical Documentation',
-  description: 'API reference docs with live previews, props tables, code examples, and best practice guidance.',
+  name: 'Getting Started',
+  description: 'Getting started guide with install steps, AI assistance prompt card, theming setup, and next steps.',
   isReady: true,
 };

--- a/packages/cli/templates/pages/documentation-technical/template.doc.mjs
+++ b/packages/cli/templates/pages/documentation-technical/template.doc.mjs
@@ -1,0 +1,7 @@
+/** @type {import('../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'page',
+  name: 'Technical Documentation',
+  description: 'API reference docs with live previews, props tables, code examples, and best practice guidance.',
+  isReady: true,
+};

--- a/packages/cli/templates/pages/documentation/page.tsx
+++ b/packages/cli/templates/pages/documentation/page.tsx
@@ -12,20 +12,10 @@ import {
 import {XDSHeading, XDSText} from '@xds/core/Text';
 import {XDSButton} from '@xds/core/Button';
 import {XDSCard} from '@xds/core/Card';
-import {XDSDropdownMenu} from '@xds/core/DropdownMenu';
-import {XDSList, XDSListItem} from '@xds/core/List';
-import {XDSCodeBlock} from '@xds/core/CodeBlock';
 import {XDSHStack, XDSVStack, XDSStackItem} from '@xds/core/Stack';
 import {XDSLayout, XDSLayoutContent} from '@xds/core/Layout';
-import {XDSDivider} from '@xds/core/Divider';
-import {XDSIcon} from '@xds/core/Icon';
 import {XDSGrid} from '@xds/core/Grid';
 import {radiusVars} from '@xds/core/theme/tokens.stylex';
-import {
-  SparklesIcon,
-  ClipboardDocumentIcon,
-  ChevronDownIcon,
-} from '@heroicons/react/24/outline';
 
 const styles = stylex.create({
   previewCard: {
@@ -162,190 +152,11 @@ function OverviewView({
   );
 }
 
-function GettingStartedView() {
-  return (
-    <XDSLayout contentWidth={960} content={
-      <XDSLayoutContent padding={8}>
-        <XDSVStack gap={8}>
-        {/* Header */}
-        <XDSVStack gap={2}>
-          <XDSText type="display-1">
-            Getting started with Product Name
-          </XDSText>
-          <XDSText type="supporting" color="secondary">
-            Last updated March 30, 2026
-          </XDSText>
-          <XDSText type="body">
-            Install the package, configure your theme, and build your first
-            component in three steps.
-          </XDSText>
-        </XDSVStack>
-
-        {/* AI Assistance prompt card */}
-        <XDSCard>
-          <XDSVStack gap={3}>
-            <XDSHStack gap={2} vAlign="center">
-              <XDSStackItem size="fill">
-                <XDSHStack gap={2} vAlign="center">
-                  <XDSIcon icon={SparklesIcon} size="sm" color="secondary" />
-                  <XDSText type="body" weight="semibold">
-                    AI Assistance
-                  </XDSText>
-                </XDSHStack>
-              </XDSStackItem>
-              <XDSButton
-                label="Copy prompt"
-                variant="ghost"
-                size="sm"
-                icon={<XDSIcon icon={ClipboardDocumentIcon} />}
-                onClick={() => {
-                  void navigator.clipboard.writeText(
-                    'Help me get set up with Product Name. Based on my project, do the following: 1. Install @xds/core and the StyleX compiler. 2. Wrap my app in XDSThemeProvider. 3. Replace one existing component with an XDS equivalent. After setup, suggest relevant next steps based on my project.',
-                  );
-                }}
-              />
-              <XDSDropdownMenu
-                button={{
-                  label: 'More options',
-                  variant: 'ghost',
-                  size: 'sm',
-                  isIconOnly: true,
-                  icon: <XDSIcon icon={ChevronDownIcon} />,
-                }}
-                items={[
-                  {label: 'Open in v0', onClick: () => {}},
-                  {label: 'Open in Claude', onClick: () => {}},
-                  {label: 'Open in ChatGPT', onClick: () => {}},
-                  {label: 'Open in Cursor', onClick: () => {}},
-                ]}
-              />
-            </XDSHStack>
-            <XDSText type="body" color="secondary">
-              Help me get set up with Product Name. Based on my project, do the
-              following: 1. Install @xds/core and the StyleX compiler. 2. Wrap
-              my app in XDSThemeProvider. 3. Replace one existing component with
-              an XDS equivalent.
-            </XDSText>
-          </XDSVStack>
-        </XDSCard>
-
-        {/* Prerequisites */}
-        <XDSVStack gap={4}>
-          <XDSHeading level={2}>Prerequisites</XDSHeading>
-          <XDSList density="compact" listStyle="disc">
-            <XDSListItem label="Node.js 18+" />
-            <XDSListItem label="React 18 or 19" />
-            <XDSListItem label="A package manager (npm, yarn, or pnpm)" />
-          </XDSList>
-        </XDSVStack>
-
-        <XDSDivider />
-
-        {/* Install the package */}
-        <XDSVStack gap={4}>
-          <XDSHeading level={2}>Install the package</XDSHeading>
-          <XDSText type="body">
-            Every project starts with installing the core package. This gives
-            you access to all components, tokens, and utilities.
-          </XDSText>
-
-          <XDSVStack gap={2}>
-            <XDSText type="body" weight="bold">
-              Step 1: Install the core package
-            </XDSText>
-            <XDSCard padding={0}>
-              <XDSCodeBlock code="npm install @xds/core" language="bash" />
-            </XDSCard>
-          </XDSVStack>
-
-          <XDSVStack gap={2}>
-            <XDSText type="body" weight="bold">
-              Step 2: Add the StyleX compiler
-            </XDSText>
-            <XDSText type="body" color="secondary">
-              XDS uses StyleX for styling. Add the compiler plugin to your build
-              configuration.
-            </XDSText>
-            <XDSCard padding={0}>
-              <XDSCodeBlock
-                code="npm install @stylexjs/babel-plugin"
-                language="bash"
-              />
-            </XDSCard>
-          </XDSVStack>
-
-          <XDSVStack gap={2}>
-            <XDSText type="body" weight="bold">
-              Step 3: Import your first component
-            </XDSText>
-            <XDSCard padding={0}>
-              <XDSCodeBlock
-                code={`import { XDSButton } from '@xds/core/Button';
-
-export default function App() {
-  return <XDSButton label="Hello XDS" variant="primary" />;
-}`}
-                language="tsx"
-              />
-            </XDSCard>
-          </XDSVStack>
-        </XDSVStack>
-
-        <XDSDivider />
-
-        {/* Configure theming */}
-        <XDSVStack gap={4}>
-          <XDSHeading level={2}>Configure theming</XDSHeading>
-          <XDSText type="body">
-            XDS ships with a default theme that works out of the box. To
-            customize colors, typography, and spacing, wrap your app in a theme
-            provider.
-          </XDSText>
-          <XDSCard padding={0}>
-            <XDSCodeBlock
-              code={`import { XDSThemeProvider } from '@xds/core/Theme';
-
-export default function App({ children }) {
-  return (
-    <XDSThemeProvider theme="default">
-      {children}
-    </XDSThemeProvider>
-  );
-}`}
-              language="tsx"
-            />
-          </XDSCard>
-          <XDSText type="body" color="secondary">
-            See the theming guide for the full list of customizable tokens.
-          </XDSText>
-        </XDSVStack>
-
-        <XDSDivider />
-
-        {/* Next steps */}
-        <XDSVStack gap={4}>
-          <XDSHeading level={2}>Next steps</XDSHeading>
-          <XDSList density="compact" listStyle="disc">
-            <XDSListItem label="Fundamental concepts — How theming, layout, and composition work" />
-            <XDSListItem label="Component API reference — Props, variants, and examples for every component" />
-            <XDSListItem label="Accessibility — Built-in a11y features and ARIA patterns" />
-            <XDSListItem label="CLI tools — Scaffold projects and manage templates" />
-            <XDSListItem label="Design tokens — Colors, spacing, typography, and sizing" />
-          </XDSList>
-        </XDSVStack>
-      </XDSVStack>
-      </XDSLayoutContent>
-    } />
-  );
-}
-
 // ---------------------------------------------------------------------------
 // Main component
 // ---------------------------------------------------------------------------
 
 export default function DocumentationOverviewPage() {
-  const [activePage, setActivePage] = useState<string>('home');
-
   return (
     <XDSAppShell
       variant="section"
@@ -358,13 +169,7 @@ export default function DocumentationOverviewPage() {
           <XDSSideNavSection title="Navigation" isHeaderHidden>
             <XDSSideNavItem
               label="Home"
-              isSelected={activePage === 'home'}
-              onClick={() => setActivePage('home')}
-            />
-            <XDSSideNavItem
-              label="Getting started"
-              isSelected={activePage === 'getting-started'}
-              onClick={() => setActivePage('getting-started')}
+              isSelected
             />
           </XDSSideNavSection>
 
@@ -380,11 +185,7 @@ export default function DocumentationOverviewPage() {
           ))}
         </XDSSideNav>
       }>
-      {activePage === 'home' ? (
-        <OverviewView onSelectComponent={setActivePage} />
-      ) : (
-        <GettingStartedView />
-      )}
+      <OverviewView onSelectComponent={() => {}} />
     </XDSAppShell>
   );
 }

--- a/packages/cli/templates/pages/documentation/page.tsx
+++ b/packages/cli/templates/pages/documentation/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import * as stylex from '@stylexjs/stylex';
 import {XDSAppShell} from '@xds/core/AppShell';
 import {
   XDSSideNav,
@@ -12,6 +13,73 @@ import {XDSButton} from '@xds/core/Button';
 import {XDSCard} from '@xds/core/Card';
 import {XDSHStack, XDSVStack, XDSStackItem} from '@xds/core/Stack';
 import {XDSLayout, XDSLayoutContent} from '@xds/core/Layout';
+import {XDSGrid} from '@xds/core/Grid';
+import {radiusVars} from '@xds/core/theme/tokens.stylex';
+
+const styles = stylex.create({
+  previewCard: {
+    borderRadius: radiusVars['--radius-container'],
+    cursor: 'pointer',
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Data
+// ---------------------------------------------------------------------------
+
+const COMPONENT_CATEGORIES = [
+  {
+    label: 'Core',
+    items: [
+      {key: 'appshell', name: 'AppShell', desc: 'AppShell provides a foundational page layout with header, sidebar, and content regions. Use it to establish consistent structure across your application.'},
+      {key: 'avatar', name: 'Avatar', desc: 'Avatars represent a person or entity with an image, initials, or icon. They are commonly used in user profiles, comments, and contact lists.'},
+      {key: 'badge', name: 'Badge', desc: 'Badges display small counts or status labels. They can be attached to icons, buttons, or list items to surface key information at a glance.'},
+      {key: 'banner', name: 'Banner', desc: 'Banners show important, non-modal messages at the top of a page or section. They communicate status, warnings, or promotional information.'},
+      {key: 'button', name: 'Button', desc: 'Buttons let people take action. They can be used in forms, dialogs, and toolbars, or as standalone links.'},
+      {key: 'calendar', name: 'Calendar', desc: 'Calendar provides a date-picking grid for selecting single dates or date ranges. It integrates with form fields for date input.'},
+      {key: 'dialog', name: 'Dialog', desc: 'Dialogs are modal overlays that require user attention or action before continuing. They are used for confirmations, forms, and critical decisions.'},
+      {key: 'dropdownmenu', name: 'DropdownMenu', desc: 'DropdownMenu presents a list of actions or options in a floating overlay. It is triggered by a button and supports nested submenus.'},
+      {key: 'emptystate', name: 'EmptyState', desc: 'EmptyState provides a placeholder when there is no content to display. It guides users with a message, illustration, and optional call-to-action.'},
+      {key: 'hovercard', name: 'HoverCard', desc: 'HoverCard shows a rich preview of content when users hover over a trigger element. It is ideal for previewing profiles, links, or details.'},
+      {key: 'icon', name: 'Icon', desc: 'Icons are small visual symbols that represent actions, objects, or concepts. They improve scannability and reinforce meaning alongside text.'},
+      {key: 'kbd', name: 'Kbd', desc: 'Kbd renders keyboard shortcut hints in a styled inline element. Use it to show users which key combinations perform specific actions.'},
+      {key: 'link', name: 'Link', desc: 'Links provide navigation between pages or to external resources. They follow accessible anchor semantics with visual affordance.'},
+      {key: 'list', name: 'List', desc: 'List displays a vertical set of related items. It supports selection, icons, and metadata for building menus, nav lists, and more.'},
+      {key: 'popover', name: 'Popover', desc: 'Popover displays rich content in a floating panel anchored to a trigger element. It is used for forms, filters, and contextual tools.'},
+      {key: 'table', name: 'Table', desc: 'Table displays structured data in rows and columns with support for sorting, selection, and custom cell rendering.'},
+      {key: 'token', name: 'Token', desc: 'Tokens display compact metadata labels such as tags, categories, or filters. They can be dismissible and support selection state.'},
+      {key: 'tooltip', name: 'Tooltip', desc: 'Tooltips show concise helper text when users hover over or focus an element. They clarify icons, truncated labels, and controls.'},
+    ],
+  },
+  {
+    label: 'Layout',
+    items: [
+      {key: 'card', name: 'Card', desc: 'Cards group related content and actions in a contained surface. They can include headers, media, body text, and action bars.'},
+      {key: 'divider', name: 'Divider', desc: 'Dividers separate content into distinct sections with a subtle or strong horizontal line. They can optionally include a label.'},
+      {key: 'grid', name: 'Grid', desc: 'Grid provides a CSS grid-based layout container with configurable columns, rows, and gap. It simplifies responsive multi-column designs.'},
+      {key: 'stack', name: 'Stack', desc: 'Stack arranges child elements in a row or column with consistent gap spacing. It is the primary tool for one-dimensional layout composition.'},
+    ],
+  },
+  {
+    label: 'Navigation',
+    items: [
+      {key: 'breadcrumbs', name: 'Breadcrumbs', desc: "Breadcrumbs show the user's current location within a navigation hierarchy. They provide quick links back to parent pages."},
+      {key: 'sidenav', name: 'SideNav', desc: 'SideNav renders a vertical navigation panel with links, sections, and collapsible groups. It is used as the primary nav in dashboard layouts.'},
+      {key: 'tablist', name: 'TabList', desc: 'TabList switches between content views using a horizontal row of tabs. Only one tab is active at a time, and content changes without a page reload.'},
+      {key: 'topnav', name: 'TopNav', desc: 'TopNav provides an app-level navigation bar across the top of the page. It holds branding, primary links, search, and user actions.'},
+    ],
+  },
+  {
+    label: 'Form',
+    items: [
+      {key: 'checkboxinput', name: 'CheckboxInput', desc: 'CheckboxInput renders a single checkbox with a label. It is used for boolean opt-in choices like terms acceptance or feature toggles.'},
+      {key: 'selector', name: 'Selector', desc: 'Selector lets users pick a single item from a dropdown list. It supports search, grouping, and custom option rendering.'},
+      {key: 'switch', name: 'Switch', desc: 'Switch toggles a setting between on and off states with immediate effect. It is used for preferences, feature flags, and real-time controls.'},
+      {key: 'textinput', name: 'TextInput', desc: 'TextInput is a single-line text field for short user input like names, emails, and search queries. It supports icons, prefixes, and validation.'},
+      {key: 'typeahead', name: 'Typeahead', desc: 'Typeahead provides an autocomplete search input that suggests results as the user types. It supports async data sources and custom rendering.'},
+    ],
+  },
+];
 
 // ---------------------------------------------------------------------------
 // Main component
@@ -24,14 +92,19 @@ export default function DocumentationOverviewPage() {
       height="fill"
       sideNav={
         <XDSSideNav
-          header={
-            <XDSSideNavHeading heading="Product Name" />
-          }>
+          header={<XDSSideNavHeading heading="Product Name" />}>
           <XDSSideNavSection title="Navigation" isHeaderHidden>
             <XDSSideNavItem label="Home" isSelected />
             <XDSSideNavItem label="Getting started" />
-            <XDSSideNavItem label="Components" />
           </XDSSideNavSection>
+
+          {COMPONENT_CATEGORIES.map(category => (
+            <XDSSideNavSection key={category.label} title={category.label}>
+              {category.items.map(item => (
+                <XDSSideNavItem key={item.key} label={item.name} />
+              ))}
+            </XDSSideNavSection>
+          ))}
         </XDSSideNav>
       }>
       <XDSLayout contentWidth={1200} content={
@@ -58,6 +131,28 @@ export default function DocumentationOverviewPage() {
                 <XDSStackItem size="fill" />
               </XDSHStack>
             </XDSCard>
+
+            {COMPONENT_CATEGORIES.map(category => (
+              <XDSVStack key={category.label} gap={4}>
+                <XDSText type="display-2">{category.label}</XDSText>
+                <XDSGrid columns={{minWidth: 260}} gap={8}>
+                  {category.items.map(item => (
+                    <XDSVStack key={item.key} gap={3}>
+                      <XDSCard
+                        variant="muted"
+                        padding={0}
+                        minHeight={160}
+                        xstyle={styles.previewCard}
+                      />
+                      <XDSVStack gap={0.5}>
+                        <XDSText type="body" weight="bold">{item.name}</XDSText>
+                        <XDSText type="body" color="secondary">{item.desc}</XDSText>
+                      </XDSVStack>
+                    </XDSVStack>
+                  ))}
+                </XDSGrid>
+              </XDSVStack>
+            ))}
           </XDSVStack>
         </XDSLayoutContent>
       } />

--- a/packages/cli/templates/pages/documentation/page.tsx
+++ b/packages/cli/templates/pages/documentation/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import {useState, useMemo} from 'react';
+import {useState} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {XDSAppShell} from '@xds/core/AppShell';
 import {
@@ -11,38 +11,25 @@ import {
 } from '@xds/core/SideNav';
 import {XDSHeading, XDSText} from '@xds/core/Text';
 import {XDSButton} from '@xds/core/Button';
-import {XDSIconButton} from '@xds/core/IconButton';
 import {XDSCard} from '@xds/core/Card';
 import {XDSDropdownMenu} from '@xds/core/DropdownMenu';
-import {XDSAvatar} from '@xds/core/Avatar';
 import {XDSBadge} from '@xds/core/Badge';
-import {XDSToken} from '@xds/core/Token';
 import {XDSList, XDSListItem} from '@xds/core/List';
 import {XDSBanner} from '@xds/core/Banner';
 import {XDSCodeBlock} from '@xds/core/CodeBlock';
-import {XDSTabList, XDSTab} from '@xds/core/TabList';
 import {XDSHStack, XDSVStack, XDSStackItem} from '@xds/core/Stack';
 import {XDSLayout, XDSLayoutContent} from '@xds/core/Layout';
-import {XDSDialog, XDSDialogHeader} from '@xds/core/Dialog';
 import {XDSDivider} from '@xds/core/Divider';
-import {XDSTooltip} from '@xds/core/Tooltip';
-import {XDSTable, pixel} from '@xds/core/Table';
 import {XDSIcon} from '@xds/core/Icon';
-import {XDSSection} from '@xds/core/Section';
-import {XDSCenter} from '@xds/core/Center';
 import {XDSGrid} from '@xds/core/Grid';
 import {radiusVars} from '@xds/core/theme/tokens.stylex';
 import {
-  ArrowTopRightOnSquareIcon,
-  ArrowsPointingOutIcon,
   SparklesIcon,
   ClipboardDocumentIcon,
-  PlusIcon,
   ChevronDownIcon,
 } from '@heroicons/react/24/outline';
 
 const styles = stylex.create({
-  tabListFlush: {marginInlineStart: '-12px'},
   previewCard: {
     borderRadius: radiusVars['--radius-container'],
     cursor: 'pointer',
@@ -50,540 +37,75 @@ const styles = stylex.create({
 });
 
 // ---------------------------------------------------------------------------
-// DialogPreview — stateful dialog preview for component previews
-// ---------------------------------------------------------------------------
-
-function DialogPreview() {
-  const [isOpen, setIsOpen] = useState(false);
-  return (
-    <XDSVStack gap={3}>
-      <XDSHeading level={3}>Dialog</XDSHeading>
-      <XDSButton
-        label="Open Dialog"
-        variant="primary"
-        onClick={() => setIsOpen(true)}
-      />
-      <XDSDialog isOpen={isOpen} onOpenChange={setIsOpen}>
-        <XDSDialogHeader title="Example Dialog" onOpenChange={setIsOpen} />
-        <XDSSection padding={4}>
-          <XDSText type="body">
-            This is an example dialog. Dialogs are used to require user action
-            or display important information that needs acknowledgment.
-          </XDSText>
-        </XDSSection>
-      </XDSDialog>
-    </XDSVStack>
-  );
-}
-
-// ---------------------------------------------------------------------------
 // Data
 // ---------------------------------------------------------------------------
 
-const COMPONENT_CATEGORIES = [
+const OVERVIEW_SECTIONS = [
   {
     label: 'Core',
     items: [
-      {
-        key: 'appshell',
-        name: 'AppShell',
-        desc: 'AppShell provides a foundational page layout with header, sidebar, and content regions. Use it to establish consistent structure across your application.',
-      },
-      {
-        key: 'avatar',
-        name: 'Avatar',
-        desc: 'Avatars represent a person or entity with an image, initials, or icon. They are commonly used in user profiles, comments, and contact lists.',
-      },
-      {
-        key: 'badge',
-        name: 'Badge',
-        desc: 'Badges display small counts or status labels. They can be attached to icons, buttons, or list items to surface key information at a glance.',
-      },
-      {
-        key: 'banner',
-        name: 'Banner',
-        desc: 'Banners show important, non-modal messages at the top of a page or section. They communicate status, warnings, or promotional information.',
-      },
-      {
-        key: 'button',
-        name: 'Button',
-        desc: 'Buttons let people take action. They can be used in forms, dialogs, and toolbars, or as standalone links.',
-      },
-      {
-        key: 'calendar',
-        name: 'Calendar',
-        desc: 'Calendar provides a date-picking grid for selecting single dates or date ranges. It integrates with form fields for date input.',
-      },
-      {
-        key: 'dialog',
-        name: 'Dialog',
-        desc: 'Dialogs are modal overlays that require user attention or action before continuing. They are used for confirmations, forms, and critical decisions.',
-      },
-      {
-        key: 'dropdownmenu',
-        name: 'DropdownMenu',
-        desc: 'DropdownMenu presents a list of actions or options in a floating overlay. It is triggered by a button and supports nested submenus.',
-      },
-      {
-        key: 'emptystate',
-        name: 'EmptyState',
-        desc: 'EmptyState provides a placeholder when there is no content to display. It guides users with a message, illustration, and optional call-to-action.',
-      },
-      {
-        key: 'hovercard',
-        name: 'HoverCard',
-        desc: 'HoverCard shows a rich preview of content when users hover over a trigger element. It is ideal for previewing profiles, links, or details.',
-      },
-      {
-        key: 'icon',
-        name: 'Icon',
-        desc: 'Icons are small visual symbols that represent actions, objects, or concepts. They improve scannability and reinforce meaning alongside text.',
-      },
-      {
-        key: 'kbd',
-        name: 'Kbd',
-        desc: 'Kbd renders keyboard shortcut hints in a styled inline element. Use it to show users which key combinations perform specific actions.',
-      },
-      {
-        key: 'link',
-        name: 'Link',
-        desc: 'Links provide navigation between pages or to external resources. They follow accessible anchor semantics with visual affordance.',
-      },
-      {
-        key: 'list',
-        name: 'List',
-        desc: 'List displays a vertical set of related items. It supports selection, icons, and metadata for building menus, nav lists, and more.',
-      },
-      {
-        key: 'metadatalist',
-        name: 'MetadataList',
-        desc: 'MetadataList displays key-value pairs in a structured layout. Use it for detail panels, settings summaries, and record information.',
-      },
-      {
-        key: 'moremenu',
-        name: 'MoreMenu',
-        desc: 'MoreMenu provides an overflow menu triggered by an icon button. It collects secondary actions that do not fit in the primary toolbar.',
-      },
-      {
-        key: 'overflowlist',
-        name: 'OverflowList',
-        desc: 'OverflowList renders as many items as fit in the available space and collapses the rest into an overflow menu automatically.',
-      },
-      {
-        key: 'pagination',
-        name: 'Pagination',
-        desc: 'Pagination lets users navigate through pages of content. It supports page numbers, previous/next controls, and page-size selection.',
-      },
-      {
-        key: 'popover',
-        name: 'Popover',
-        desc: 'Popover displays rich content in a floating panel anchored to a trigger element. It is used for forms, filters, and contextual tools.',
-      },
-      {
-        key: 'progressbar',
-        name: 'ProgressBar',
-        desc: 'ProgressBar shows the completion status of a task or process. It provides visual feedback for uploads, installations, and multi-step flows.',
-      },
-      {
-        key: 'skeleton',
-        name: 'Skeleton',
-        desc: 'Skeleton renders placeholder shapes that mimic content layout while loading. It reduces perceived wait time and prevents layout shifts.',
-      },
-      {
-        key: 'spinner',
-        name: 'Spinner',
-        desc: 'Spinner indicates that a process is in progress when the duration is unknown. It draws attention without blocking the interface.',
-      },
-      {
-        key: 'statusdot',
-        name: 'StatusDot',
-        desc: 'StatusDot shows a small colored indicator for online, offline, busy, or custom statuses. It is often paired with avatars or list items.',
-      },
-      {
-        key: 'table',
-        name: 'Table',
-        desc: 'Table displays structured data in rows and columns with support for sorting, selection, and custom cell rendering.',
-      },
-      {
-        key: 'thumbnail',
-        name: 'Thumbnail',
-        desc: 'Thumbnail renders a small image preview with consistent sizing and optional rounded corners. It is used in media lists, cards, and galleries.',
-      },
-      {
-        key: 'timestamp',
-        name: 'Timestamp',
-        desc: 'Timestamp formats and displays dates and times with relative or absolute labels. It updates automatically to stay current.',
-      },
-      {
-        key: 'toast',
-        name: 'Toast',
-        desc: 'Toasts display brief, non-blocking notifications at the edge of the screen. They auto-dismiss and are used for success, error, or info messages.',
-      },
-      {
-        key: 'togglebutton',
-        name: 'ToggleButton',
-        desc: 'ToggleButton is a button that switches between an on and off state. Use it for binary options like bookmarking, favoriting, or muting.',
-      },
-      {
-        key: 'token',
-        name: 'Token',
-        desc: 'Tokens display compact metadata labels such as tags, categories, or filters. They can be dismissible and support selection state.',
-      },
-      {
-        key: 'tooltip',
-        name: 'Tooltip',
-        desc: 'Tooltips show concise helper text when users hover over or focus an element. They clarify icons, truncated labels, and controls.',
-      },
-      {
-        key: 'treelist',
-        name: 'TreeList',
-        desc: 'TreeList renders hierarchical data in an expandable tree structure. It supports multi-level nesting, selection, and lazy loading.',
-      },
-    ],
-  },
-  {
-    label: 'Typography',
-    items: [
-      {
-        key: 'heading',
-        name: 'Heading',
-        desc: 'Heading renders semantic section titles from h1 through h6. It establishes visual hierarchy and supports multiple weight and size options.',
-      },
-      {
-        key: 'text',
-        name: 'Text',
-        desc: 'Text renders body copy, labels, and supporting content with consistent typography. It supports sizes from display down to caption.',
-      },
+      {key: 'appshell', name: 'AppShell', desc: 'Foundational page layout with header, sidebar, and content regions.'},
+      {key: 'button', name: 'Button', desc: 'Buttons let people take action. Used in forms, dialogs, and toolbars.'},
+      {key: 'card', name: 'Card', desc: 'Cards group related content and actions in a contained surface.'},
+      {key: 'dialog', name: 'Dialog', desc: 'Modal overlays that require user attention or action before continuing.'},
+      {key: 'badge', name: 'Badge', desc: 'Small counts or status labels attached to icons, buttons, or list items.'},
+      {key: 'banner', name: 'Banner', desc: 'Important, non-modal messages at the top of a page or section.'},
+      {key: 'avatar', name: 'Avatar', desc: 'Represents a person or entity with an image, initials, or icon.'},
+      {key: 'table', name: 'Table', desc: 'Structured data in rows and columns with sorting and selection.'},
     ],
   },
   {
     label: 'Layout',
     items: [
-      {
-        key: 'aspectratio',
-        name: 'AspectRatio',
-        desc: 'AspectRatio constrains its child to a specified width-to-height ratio. Use it for responsive images, videos, and embedded media.',
-      },
-      {
-        key: 'card',
-        name: 'Card',
-        desc: 'Cards group related content and actions in a contained surface. They can include headers, media, body text, and action bars.',
-      },
-      {
-        key: 'center',
-        name: 'Center',
-        desc: 'Center aligns its child horizontally and vertically within the available space. It is useful for empty states, loading screens, and hero sections.',
-      },
-      {
-        key: 'divider',
-        name: 'Divider',
-        desc: 'Dividers separate content into distinct sections with a subtle or strong horizontal line. They can optionally include a label.',
-      },
-      {
-        key: 'grid',
-        name: 'Grid',
-        desc: 'Grid provides a CSS grid-based layout container with configurable columns, rows, and gap. It simplifies responsive multi-column designs.',
-      },
-      {
-        key: 'layout',
-        name: 'Layout',
-        desc: 'Layout provides foundational page-level primitives for header, sidebar, and content regions. It establishes consistent spacing and structure.',
-      },
-      {
-        key: 'section',
-        name: 'Section',
-        desc: 'Section wraps a block of content with consistent vertical spacing and an optional heading. It structures pages into logical groups.',
-      },
-      {
-        key: 'stack',
-        name: 'Stack',
-        desc: 'Stack arranges child elements in a row or column with consistent gap spacing. It is the primary tool for one-dimensional layout composition.',
-      },
-      {
-        key: 'toolbar',
-        name: 'Toolbar',
-        desc: 'Toolbar arranges a row of action buttons and controls in a compact, aligned strip. It is used at the top of panels, editors, and cards.',
-      },
+      {key: 'stack', name: 'Stack', desc: 'Arranges child elements in a row or column with consistent gap spacing.'},
+      {key: 'grid', name: 'Grid', desc: 'CSS grid-based layout container with configurable columns and gap.'},
+      {key: 'divider', name: 'Divider', desc: 'Separates content into distinct sections with a subtle line.'},
+      {key: 'section', name: 'Section', desc: 'Wraps a block of content with consistent vertical spacing.'},
     ],
   },
   {
     label: 'Navigation',
     items: [
-      {
-        key: 'breadcrumbs',
-        name: 'Breadcrumbs',
-        desc: "Breadcrumbs show the user's current location within a navigation hierarchy. They provide quick links back to parent pages.",
-      },
-      {
-        key: 'mobilenav',
-        name: 'MobileNav',
-        desc: 'MobileNav provides a responsive navigation menu optimized for small screens. It typically slides in from the edge of the viewport.',
-      },
-      {
-        key: 'sidenav',
-        name: 'SideNav',
-        desc: 'SideNav renders a vertical navigation panel with links, sections, and collapsible groups. It is used as the primary nav in dashboard layouts.',
-      },
-      {
-        key: 'tablist',
-        name: 'TabList',
-        desc: 'TabList switches between content views using a horizontal row of tabs. Only one tab is active at a time, and content changes without a page reload.',
-      },
-      {
-        key: 'topnav',
-        name: 'TopNav',
-        desc: 'TopNav provides an app-level navigation bar across the top of the page. It holds branding, primary links, search, and user actions.',
-      },
+      {key: 'sidenav', name: 'SideNav', desc: 'Vertical navigation panel with links, sections, and collapsible groups.'},
+      {key: 'topnav', name: 'TopNav', desc: 'App-level navigation bar with branding, links, search, and user actions.'},
+      {key: 'tablist', name: 'TabList', desc: 'Switches between content views using a horizontal row of tabs.'},
+      {key: 'breadcrumbs', name: 'Breadcrumbs', desc: "Shows the user's current location within a navigation hierarchy."},
     ],
   },
   {
     label: 'Form',
     items: [
-      {
-        key: 'checkboxinput',
-        name: 'CheckboxInput',
-        desc: 'CheckboxInput renders a single checkbox with a label. It is used for boolean opt-in choices like terms acceptance or feature toggles.',
-      },
-      {
-        key: 'checkboxlist',
-        name: 'CheckboxList',
-        desc: 'CheckboxList displays a group of checkboxes for selecting multiple options. It manages shared state and supports select-all behavior.',
-      },
-      {
-        key: 'dateinput',
-        name: 'DateInput',
-        desc: 'DateInput provides a text field with calendar picker for entering dates. It validates format and supports min/max date constraints.',
-      },
-      {
-        key: 'field',
-        name: 'Field',
-        desc: 'Field wraps a form control with a label, helper text, and error message. It ensures consistent layout and accessibility across all form inputs.',
-      },
-      {
-        key: 'formlayout',
-        name: 'FormLayout',
-        desc: 'FormLayout arranges form fields in a structured vertical or horizontal layout with consistent spacing and alignment.',
-      },
-      {
-        key: 'multiselector',
-        name: 'MultiSelector',
-        desc: 'MultiSelector lets users pick multiple items from a searchable list with tokenized selections. It is ideal for assigning tags, teams, or categories.',
-      },
-      {
-        key: 'numberinput',
-        name: 'NumberInput',
-        desc: 'NumberInput provides a text field for numeric values with optional increment/decrement controls. It supports min, max, and step constraints.',
-      },
-      {
-        key: 'powersearch',
-        name: 'PowerSearch',
-        desc: 'PowerSearch provides an advanced search interface with filters, suggestions, and structured query support for complex data exploration.',
-      },
-      {
-        key: 'radiolist',
-        name: 'RadioList',
-        desc: 'RadioList presents a group of mutually exclusive options. Only one option can be selected at a time, making it ideal for settings and preferences.',
-      },
-      {
-        key: 'selector',
-        name: 'Selector',
-        desc: 'Selector lets users pick a single item from a dropdown list. It supports search, grouping, and custom option rendering.',
-      },
-      {
-        key: 'slider',
-        name: 'Slider',
-        desc: 'Slider lets users select a value or range by dragging a handle along a track. It is used for volume, brightness, and numeric range inputs.',
-      },
-      {
-        key: 'switch',
-        name: 'Switch',
-        desc: 'Switch toggles a setting between on and off states with immediate effect. It is used for preferences, feature flags, and real-time controls.',
-      },
-      {
-        key: 'textarea',
-        name: 'TextArea',
-        desc: 'TextArea provides a multi-line text field for longer-form content like comments, descriptions, and messages. It supports auto-resize.',
-      },
-      {
-        key: 'textinput',
-        name: 'TextInput',
-        desc: 'TextInput is a single-line text field for short user input like names, emails, and search queries. It supports icons, prefixes, and validation.',
-      },
-      {
-        key: 'timeinput',
-        name: 'TimeInput',
-        desc: 'TimeInput provides a field for entering times with optional picker support. It validates format and supports 12- and 24-hour modes.',
-      },
-      {
-        key: 'tokenizer',
-        name: 'Tokenizer',
-        desc: 'Tokenizer is a text input that converts entries into removable tokens. It is used for multi-value fields like email recipients and tags.',
-      },
-      {
-        key: 'typeahead',
-        name: 'Typeahead',
-        desc: 'Typeahead provides an autocomplete search input that suggests results as the user types. It supports async data sources and custom rendering.',
-      },
-    ],
-  },
-  {
-    label: 'Inputs',
-    items: [
-      {
-        key: 'segmentedcontrol',
-        name: 'SegmentedControl',
-        desc: 'SegmentedControl lets users toggle between a small set of mutually exclusive options displayed as connected segments. It works like a visual radio group.',
-      },
-    ],
-  },
-  {
-    label: 'Components',
-    items: [
-      {
-        key: 'codeblock',
-        name: 'CodeBlock',
-        desc: 'CodeBlock displays formatted, syntax-highlighted source code. It supports line numbers, copy-to-clipboard, and language detection.',
-      },
-      {
-        key: 'collapsible',
-        name: 'Collapsible',
-        desc: 'Collapsible wraps content that can be expanded or collapsed with a trigger. It is used for FAQs, advanced settings, and progressive disclosure.',
-      },
-      {
-        key: 'markdown',
-        name: 'Markdown',
-        desc: 'Markdown renders markdown-formatted text into styled HTML. It supports headings, lists, links, code blocks, and inline formatting.',
-      },
-    ],
-  },
-  {
-    label: 'Chat',
-    items: [
-      {
-        key: 'chat',
-        name: 'Chat',
-        desc: 'Chat provides a conversational message interface with message bubbles, input, and thread support. It is used for AI assistants and messaging UIs.',
-      },
-    ],
-  },
-  {
-    label: 'CommandPalette',
-    items: [
-      {
-        key: 'commandpalette',
-        name: 'CommandPalette',
-        desc: 'CommandPalette is a keyboard-driven command menu for quick navigation and actions. It is opened with a hotkey and supports fuzzy search.',
-      },
+      {key: 'textinput', name: 'TextInput', desc: 'Single-line text field for names, emails, and search queries.'},
+      {key: 'selector', name: 'Selector', desc: 'Pick a single item from a dropdown list with search and grouping.'},
+      {key: 'switch', name: 'Switch', desc: 'Toggles a setting between on and off states with immediate effect.'},
+      {key: 'checkboxinput', name: 'CheckboxInput', desc: 'Single checkbox with a label for boolean opt-in choices.'},
     ],
   },
 ];
 
-const COMPONENT_DOCS: Record<
-  string,
-  {
-    usage: string;
-    bestPractices: {type: 'do' | 'dont'; text: string}[];
-    examples: {
-      title: string;
-      description: string;
-      code: string;
-    }[];
-  }
-> = {
-  button: {
-    usage:
-      'Buttons provide visual cues for actions and events. These fundamental components allow users to commit actions and navigate a page flow. Use a Button when a user needs to submit a form, start a new task or action, or trigger a new UI element to appear on the page.',
-    bestPractices: [
-      {
-        type: 'do',
-        text: 'Convey clear action hierarchy: Each surface should only have 1 primary button. A majority of buttons should be in default or flat style.',
-      },
-      {
-        type: 'do',
-        text: 'Promote clarity: Consider labels alongside icons where appropriate.',
-      },
-      {
-        type: 'dont',
-        text: 'Overuse primary or special buttons: Overusing colored buttons will result in a page with less intentionality, create visual confusion and a lack of page hierarchy.',
-      },
-    ],
-    examples: [
-      {
-        title: 'Semantics',
-        description:
-          'We have four semantic buttons types: flat, default, primary, and destructive. Flat buttons are used to limit visual prominence, whereas primary emphasizes a single action. Use destructive for deletions that trigger dialog confirmations.',
-        code: `<XDSButton label="Flat" variant="ghost" />
-<XDSButton label="Default" variant="secondary" />
-<XDSButton label="Primary" variant="primary" />
-<XDSButton label="Destructive" variant="destructive" />`,
-      },
-      {
-        title: 'Default button with badge',
-        description:
-          'Buttons can include a badge to highlight new or updated actions.',
-        code: `<XDSButton
-  label="Button"
-  variant="default"
-/>`,
-      },
-    ],
-  },
-};
+const QUICK_LINKS = [
+  {title: 'Getting Started', desc: 'Install, configure theming, and build your first component.', key: 'getting-started'},
+  {title: 'What\'s New', desc: 'Latest updates, new components, and breaking changes.', key: 'whats-new'},
+  {title: 'Principles', desc: 'Design rules, anti-patterns, and best practices.', key: 'principles'},
+  {title: 'Accessibility', desc: 'Built-in a11y features and ARIA patterns.', key: 'accessibility'},
+];
 
-function getComponentName(key: string): string {
-  for (const cat of COMPONENT_CATEGORIES) {
-    const item = cat.items.find(i => i.key === key);
-    if (item) return item.name;
-  }
-  return key;
-}
-
-function getComponentDesc(key: string): string {
-  for (const cat of COMPONENT_CATEGORIES) {
-    const item = cat.items.find(i => i.key === key);
-    if (item) return item.desc;
-  }
-  return '';
-}
-
-function getComponentDocs(key: string) {
-  if (COMPONENT_DOCS[key]) return COMPONENT_DOCS[key];
-  const name = getComponentName(key);
-  const desc = getComponentDesc(key);
-  return {
-    usage: desc,
-    bestPractices: [
-      {
-        type: 'do' as const,
-        text: `Use ${name} in the appropriate context to provide the functionality described above.`,
-      },
-      {
-        type: 'do' as const,
-        text: `Pair ${name} with related components to create cohesive, accessible interfaces.`,
-      },
-      {
-        type: 'dont' as const,
-        text: `Use ${name} when a simpler alternative achieves the same goal with less complexity.`,
-      },
-    ],
-    examples: [
-      {
-        title: `Basic ${name}`,
-        description: `A simple example of the ${name} component with default settings.`,
-        code: `<XDS${name} />`,
-      },
-    ],
-  };
-}
+const CHANGELOG_ENTRIES = [
+  {date: 'Apr.18', type: 'Release' as const, title: '@xds/chat package with message bubbles, thread view, and AI composer'},
+  {date: 'Apr.18', type: 'Release' as const, title: 'Calendar component with single date and date range selection'},
+  {date: 'Apr.16', type: 'Improvement' as const, title: 'Dialog entry animations now use @starting-style instead of JS state'},
+  {date: 'Apr.14', type: 'Fix' as const, title: 'Popover focus trap no longer breaks with nested popovers'},
+  {date: 'Apr.10', type: 'Improvement' as const, title: 'Button loading state preserves width to prevent layout shift'},
+];
 
 // ---------------------------------------------------------------------------
 // Sub-views
 // ---------------------------------------------------------------------------
 
 function OverviewView({
-  onSelectComponent,
+  onSelectPage,
 }: {
-  onSelectComponent: (key: string) => void;
+  onSelectPage: (key: string) => void;
 }) {
   return (
     <XDSLayout contentWidth={1200} content={
@@ -594,17 +116,23 @@ function OverviewView({
             <XDSHStack gap={8} vAlign="center">
               <XDSStackItem size="fill">
                 <XDSVStack gap={4}>
-                  <XDSText type="display-1">Web overview</XDSText>
+                  <XDSText type="display-1">Documentation</XDSText>
                   <XDSText type="large" weight="normal" color="secondary">
-                    An open-source UI library to help developers quickly build
-                    beautiful, accessible products.
+                    Everything you need to build beautiful, accessible products
+                    with our component library.
                   </XDSText>
-                  <XDSHStack>
+                  <XDSHStack gap={3}>
                     <XDSButton
                       label="Get started"
                       variant="primary"
                       size="lg"
-                      onClick={() => onSelectComponent('getting-started')}
+                      onClick={() => onSelectPage('getting-started')}
+                    />
+                    <XDSButton
+                      label="What's new"
+                      variant="secondary"
+                      size="lg"
+                      onClick={() => onSelectPage('whats-new')}
                     />
                   </XDSHStack>
                 </XDSVStack>
@@ -613,8 +141,27 @@ function OverviewView({
             </XDSHStack>
           </XDSCard>
 
-          {/* Category sections */}
-          {COMPONENT_CATEGORIES.map(category => (
+          {/* Quick links */}
+          <XDSVStack gap={4}>
+            <XDSText type="display-2">Quick Links</XDSText>
+            <XDSGrid columns={{minWidth: 260}} gap={4}>
+              {QUICK_LINKS.map(link => (
+                <XDSCard
+                  key={link.key}
+                  padding={5}
+                  onClick={() => onSelectPage(link.key)}
+                  xstyle={styles.previewCard}>
+                  <XDSVStack gap={1}>
+                    <XDSText type="body" weight="bold">{link.title}</XDSText>
+                    <XDSText type="body" color="secondary">{link.desc}</XDSText>
+                  </XDSVStack>
+                </XDSCard>
+              ))}
+            </XDSGrid>
+          </XDSVStack>
+
+          {/* Component categories */}
+          {OVERVIEW_SECTIONS.map(category => (
             <XDSVStack key={category.label} gap={4}>
               <XDSText type="display-2">{category.label}</XDSText>
               <XDSGrid columns={{minWidth: 260}} gap={8}>
@@ -625,21 +172,49 @@ function OverviewView({
                       padding={0}
                       minHeight={160}
                       xstyle={styles.previewCard}
-                      onClick={() => onSelectComponent(item.key)}
+                      onClick={() => onSelectPage(item.key)}
                     />
                     <XDSVStack gap={0.5}>
-                      <XDSText type="body" weight="bold">
-                        {item.name}
-                      </XDSText>
-                      <XDSText type="body" color="secondary">
-                        {item.desc}
-                      </XDSText>
+                      <XDSText type="body" weight="bold">{item.name}</XDSText>
+                      <XDSText type="body" color="secondary">{item.desc}</XDSText>
                     </XDSVStack>
                   </XDSVStack>
                 ))}
               </XDSGrid>
             </XDSVStack>
           ))}
+
+          {/* What's new */}
+          <XDSVStack gap={4}>
+            <XDSHStack vAlign="center">
+              <XDSStackItem size="fill">
+                <XDSText type="display-2">What&#39;s New</XDSText>
+              </XDSStackItem>
+              <XDSButton
+                label="View all"
+                variant="ghost"
+                onClick={() => onSelectPage('whats-new')}
+              />
+            </XDSHStack>
+            {CHANGELOG_ENTRIES.map((entry, i) => (
+              <div key={i}>
+                <XDSHStack gap={3} vAlign="center">
+                  <XDSText
+                    type="supporting"
+                    color="secondary"
+                    style={{fontFamily: 'monospace', fontSize: 12, width: 50, flexShrink: 0}}>
+                    {entry.date}
+                  </XDSText>
+                  <XDSBadge
+                    label={entry.type}
+                    variant={entry.type === 'Release' ? 'green' : entry.type === 'Improvement' ? 'blue' : 'orange'}
+                  />
+                  <XDSText type="body" style={{flex: 1}}>{entry.title}</XDSText>
+                </XDSHStack>
+                {i < CHANGELOG_ENTRIES.length - 1 && <XDSDivider style={{marginTop: 12}} />}
+              </div>
+            ))}
+          </XDSVStack>
         </XDSVStack>
       </XDSLayoutContent>
     } />
@@ -651,146 +226,114 @@ function GettingStartedView() {
     <XDSLayout contentWidth={960} content={
       <XDSLayoutContent padding={8}>
         <XDSVStack gap={8}>
-        {/* Header */}
-        <XDSVStack gap={2}>
-          <XDSText type="display-1">
-            Getting started with Product Name
-          </XDSText>
-          <XDSText type="supporting" color="secondary">
-            Last updated March 30, 2026
-          </XDSText>
-          <XDSText type="body">
-            Install the package, configure your theme, and build your first
-            component in three steps.
-          </XDSText>
-        </XDSVStack>
-
-        {/* AI Assistance prompt card */}
-        <XDSCard>
-          <XDSVStack gap={3}>
-            <XDSHStack gap={2} vAlign="center">
-              <XDSStackItem size="fill">
-                <XDSHStack gap={2} vAlign="center">
-                  <XDSIcon icon={SparklesIcon} size="sm" color="secondary" />
-                  <XDSText type="body" weight="semibold">
-                    AI Assistance
-                  </XDSText>
-                </XDSHStack>
-              </XDSStackItem>
-              <XDSButton
-                label="Copy prompt"
-                variant="ghost"
-                size="sm"
-                icon={<XDSIcon icon={ClipboardDocumentIcon} />}
-                onClick={() => {
-                  void navigator.clipboard.writeText(
-                    'Help me get set up with Product Name. Based on my project, do the following: 1. Install @xds/core and the StyleX compiler. 2. Wrap my app in XDSThemeProvider. 3. Replace one existing component with an XDS equivalent. After setup, suggest relevant next steps based on my project.',
-                  );
-                }}
-              />
-              <XDSDropdownMenu
-                button={{
-                  label: 'More options',
-                  variant: 'ghost',
-                  size: 'sm',
-                  isIconOnly: true,
-                  icon: <XDSIcon icon={ChevronDownIcon} />,
-                }}
-                items={[
-                  {label: 'Open in v0', onClick: () => {}},
-                  {label: 'Open in Claude', onClick: () => {}},
-                  {label: 'Open in ChatGPT', onClick: () => {}},
-                  {label: 'Open in Cursor', onClick: () => {}},
-                ]}
-              />
-            </XDSHStack>
-            <XDSText type="body" color="secondary">
-              Help me get set up with Product Name. Based on my project, do the
-              following: 1. Install @xds/core and the StyleX compiler. 2. Wrap
-              my app in XDSThemeProvider. 3. Replace one existing component with
-              an XDS equivalent.
+          <XDSVStack gap={2}>
+            <XDSText type="display-1">Getting started</XDSText>
+            <XDSText type="supporting" color="secondary">
+              Last updated March 30, 2026
+            </XDSText>
+            <XDSText type="body">
+              Install the package, configure your theme, and build your first
+              component in three steps.
             </XDSText>
           </XDSVStack>
-        </XDSCard>
 
-        {/* Prerequisites */}
-        <XDSVStack gap={4}>
-          <XDSHeading level={2}>Prerequisites</XDSHeading>
-          <XDSList density="compact" listStyle="disc">
-            <XDSListItem label="Node.js 18+" />
-            <XDSListItem label="React 18 or 19" />
-            <XDSListItem label="A package manager (npm, yarn, or pnpm)" />
-          </XDSList>
-        </XDSVStack>
+          <XDSCard>
+            <XDSVStack gap={3}>
+              <XDSHStack gap={2} vAlign="center">
+                <XDSStackItem size="fill">
+                  <XDSHStack gap={2} vAlign="center">
+                    <XDSIcon icon={SparklesIcon} size="sm" color="secondary" />
+                    <XDSText type="body" weight="semibold">AI Assistance</XDSText>
+                  </XDSHStack>
+                </XDSStackItem>
+                <XDSButton
+                  label="Copy prompt"
+                  variant="ghost"
+                  size="sm"
+                  icon={<XDSIcon icon={ClipboardDocumentIcon} />}
+                  onClick={() => {
+                    void navigator.clipboard.writeText(
+                      'Help me get set up with Product Name. Install @xds/core and the StyleX compiler, wrap my app in XDSThemeProvider, and replace one existing component with an XDS equivalent.',
+                    );
+                  }}
+                />
+                <XDSDropdownMenu
+                  button={{
+                    label: 'More options',
+                    variant: 'ghost',
+                    size: 'sm',
+                    isIconOnly: true,
+                    icon: <XDSIcon icon={ChevronDownIcon} />,
+                  }}
+                  items={[
+                    {label: 'Open in Cursor', onClick: () => {}},
+                    {label: 'Open in Claude', onClick: () => {}},
+                  ]}
+                />
+              </XDSHStack>
+              <XDSText type="body" color="secondary">
+                Help me get set up with Product Name. Install @xds/core and the
+                StyleX compiler, wrap my app in XDSThemeProvider, and replace
+                one existing component with an XDS equivalent.
+              </XDSText>
+            </XDSVStack>
+          </XDSCard>
 
-        <XDSDivider />
-
-        {/* Install the package */}
-        <XDSVStack gap={4}>
-          <XDSHeading level={2}>Install the package</XDSHeading>
-          <XDSText type="body">
-            Every project starts with installing the core package. This gives
-            you access to all components, tokens, and utilities.
-          </XDSText>
-
-          {/* Step 1 */}
-          <XDSVStack gap={2}>
-            <XDSText type="body" weight="bold">
-              Step 1: Install the core package
-            </XDSText>
-            <XDSCard padding={0}>
-              <XDSCodeBlock code="npm install @xds/core" language="bash" />
-            </XDSCard>
+          <XDSVStack gap={4}>
+            <XDSHeading level={2}>Prerequisites</XDSHeading>
+            <XDSList density="compact" listStyle="disc">
+              <XDSListItem label="Node.js 18+" />
+              <XDSListItem label="React 18 or 19" />
+              <XDSListItem label="A package manager (npm, yarn, or pnpm)" />
+            </XDSList>
           </XDSVStack>
 
-          {/* Step 2 */}
-          <XDSVStack gap={2}>
-            <XDSText type="body" weight="bold">
-              Step 2: Add the StyleX compiler
-            </XDSText>
-            <XDSText type="body" color="secondary">
-              XDS uses StyleX for styling. Add the compiler plugin to your build
-              configuration.
-            </XDSText>
-            <XDSCard padding={0}>
-              <XDSCodeBlock
-                code="npm install @stylexjs/babel-plugin"
-                language="bash"
-              />
-            </XDSCard>
-          </XDSVStack>
+          <XDSDivider />
 
-          {/* Step 3 */}
-          <XDSVStack gap={2}>
-            <XDSText type="body" weight="bold">
-              Step 3: Import your first component
+          <XDSVStack gap={4}>
+            <XDSHeading level={2}>Install the package</XDSHeading>
+            <XDSText type="body">
+              Every project starts with installing the core package. This gives
+              you access to all components, tokens, and utilities.
             </XDSText>
-            <XDSCard padding={0}>
-              <XDSCodeBlock
-                code={`import { XDSButton } from '@xds/core/Button';
+            <XDSVStack gap={2}>
+              <XDSText type="body" weight="bold">Step 1: Install the core package</XDSText>
+              <XDSCard padding={0}>
+                <XDSCodeBlock code="npm install @xds/core" language="bash" />
+              </XDSCard>
+            </XDSVStack>
+            <XDSVStack gap={2}>
+              <XDSText type="body" weight="bold">Step 2: Add the StyleX compiler</XDSText>
+              <XDSCard padding={0}>
+                <XDSCodeBlock code="npm install @stylexjs/babel-plugin" language="bash" />
+              </XDSCard>
+            </XDSVStack>
+            <XDSVStack gap={2}>
+              <XDSText type="body" weight="bold">Step 3: Import your first component</XDSText>
+              <XDSCard padding={0}>
+                <XDSCodeBlock
+                  code={`import { XDSButton } from '@xds/core/Button';
 
 export default function App() {
   return <XDSButton label="Hello XDS" variant="primary" />;
 }`}
-                language="tsx"
-              />
-            </XDSCard>
+                  language="tsx"
+                />
+              </XDSCard>
+            </XDSVStack>
           </XDSVStack>
-        </XDSVStack>
 
-        <XDSDivider />
+          <XDSDivider />
 
-        {/* Configure theming */}
-        <XDSVStack gap={4}>
-          <XDSHeading level={2}>Configure theming</XDSHeading>
-          <XDSText type="body">
-            XDS ships with a default theme that works out of the box. To
-            customize colors, typography, and spacing, wrap your app in a theme
-            provider.
-          </XDSText>
-          <XDSCard padding={0}>
-            <XDSCodeBlock
-              code={`import { XDSThemeProvider } from '@xds/core/Theme';
+          <XDSVStack gap={4}>
+            <XDSHeading level={2}>Configure theming</XDSHeading>
+            <XDSText type="body">
+              XDS ships with a default theme that works out of the box. To
+              customize colors, typography, and spacing, wrap your app in a theme provider.
+            </XDSText>
+            <XDSCard padding={0}>
+              <XDSCodeBlock
+                code={`import { XDSThemeProvider } from '@xds/core/Theme';
 
 export default function App({ children }) {
   return (
@@ -799,229 +342,65 @@ export default function App({ children }) {
     </XDSThemeProvider>
   );
 }`}
-              language="tsx"
-            />
-          </XDSCard>
-          <XDSText type="body" color="secondary">
-            See the theming guide for the full list of customizable tokens.
-          </XDSText>
-        </XDSVStack>
+                language="tsx"
+              />
+            </XDSCard>
+          </XDSVStack>
 
-        <XDSDivider />
+          <XDSDivider />
 
-        {/* Next steps */}
-        <XDSVStack gap={4}>
-          <XDSHeading level={2}>Next steps</XDSHeading>
-          <XDSList density="compact" listStyle="disc">
-            <XDSListItem label="Fundamental concepts — How theming, layout, and composition work" />
-            <XDSListItem label="Component API reference — Props, variants, and examples for every component" />
-            <XDSListItem label="Accessibility — Built-in a11y features and ARIA patterns" />
-            <XDSListItem label="CLI tools — Scaffold projects and manage templates" />
-            <XDSListItem label="Design tokens — Colors, spacing, typography, and sizing" />
-          </XDSList>
+          <XDSVStack gap={4}>
+            <XDSHeading level={2}>Next steps</XDSHeading>
+            <XDSList density="compact" listStyle="disc">
+              <XDSListItem label="Fundamental concepts — How theming, layout, and composition work" />
+              <XDSListItem label="Component API reference — Props, variants, and examples for every component" />
+              <XDSListItem label="Accessibility — Built-in a11y features and ARIA patterns" />
+              <XDSListItem label="CLI tools — Scaffold projects and manage templates" />
+              <XDSListItem label="Design tokens — Colors, spacing, typography, and sizing" />
+            </XDSList>
+          </XDSVStack>
         </XDSVStack>
-      </XDSVStack>
       </XDSLayoutContent>
     } />
   );
 }
 
-function ComponentDetailView({activeNav}: {activeNav: string}) {
-  const [exampleTabs, setExampleTabs] = useState<Record<string, string>>({});
-
-  const EXAMPLE_PREVIEWS: Record<string, React.ReactNode[]> = {
-    button: [
-      <XDSHStack key="semantics" gap={3} vAlign="center">
-        <XDSButton label="Flat" variant="ghost" />
-        <XDSButton label="Default" variant="secondary" />
-        <XDSButton label="Primary" variant="primary" />
-        <XDSButton label="Destructive" variant="destructive" />
-      </XDSHStack>,
-      <XDSButton key="badge" label="Button" variant="secondary" />,
-    ],
-  };
-
-  const COMPONENT_PREVIEWS: Record<string, React.ReactNode> = {
-    button: (
-      <XDSButton
-        label="Button"
-        variant="secondary"
-        icon={<XDSIcon icon={PlusIcon} />}
-        endContent={<XDSBadge label="New" variant="info" />}
-      />
-    ),
-    avatar: <XDSAvatar name="Alice" size="medium" />,
-    badge: <XDSBadge label="Success" variant="success" />,
-    card: (
-      <XDSCard>
-        <XDSVStack gap={2}>
-          <XDSHeading level={4}>Card Title</XDSHeading>
-          <XDSText type="body" color="secondary">
-            Cards group related content and actions.
-          </XDSText>
-        </XDSVStack>
-      </XDSCard>
-    ),
-    banner: (
-      <XDSBanner status="info" title="Information">
-        <XDSText type="body">This is an informational banner message.</XDSText>
-      </XDSBanner>
-    ),
-    dialog: <DialogPreview />,
-    text: <XDSText type="body">Body text</XDSText>,
-    divider: <XDSDivider />,
-    token: <XDSToken label="Design" />,
-    tooltip: (
-      <XDSTooltip content="Primary action">
-        <XDSButton label="Hover me" variant="primary" />
-      </XDSTooltip>
-    ),
-  };
-
-  const docs = useMemo(() => getComponentDocs(activeNav), [activeNav]);
-  const previews = EXAMPLE_PREVIEWS[activeNav] ?? [];
-
+function WhatsNewView() {
   return (
     <XDSLayout contentWidth={960} content={
       <XDSLayoutContent padding={8}>
         <XDSVStack gap={8}>
-          {/* Header */}
           <XDSVStack gap={2}>
-            <XDSText type="display-1">{getComponentName(activeNav)}</XDSText>
-            <XDSText type="supporting" color="secondary">
-              March 30, 2026 · Updated 5:40 p.m. PST
+            <XDSText type="display-1">What&#39;s New</XDSText>
+            <XDSText type="body" color="secondary">
+              Latest updates, new components, improvements, and breaking changes.
             </XDSText>
           </XDSVStack>
 
-          <XDSDivider />
+          <XDSBanner status="info" title="Latest Release">
+            <XDSText type="body">
+              @xds/chat v0.0.12 is now available with message bubbles, thread view, and AI composer.
+            </XDSText>
+          </XDSBanner>
 
-          {/* Live Preview Card */}
-          <XDSCard variant="muted" padding={0}>
-            <XDSCenter height={360}>
-              {COMPONENT_PREVIEWS[activeNav] ?? (
-                <XDSText type="supporting" color="secondary">
-                  Preview coming soon
+          {CHANGELOG_ENTRIES.map((entry, i) => (
+            <div key={i}>
+              <XDSHStack gap={3} vAlign="center" style={{padding: '12px 0'}}>
+                <XDSText
+                  type="supporting"
+                  color="secondary"
+                  style={{fontFamily: 'monospace', fontSize: 12, width: 50, flexShrink: 0}}>
+                  {entry.date}
                 </XDSText>
-              )}
-            </XDSCenter>
-          </XDSCard>
-
-          {/* Usage & Best Practices */}
-          <XDSVStack gap={4}>
-            <XDSHeading level={2}>Usage</XDSHeading>
-            <XDSText type="large" weight="normal">
-              {docs.usage}
-            </XDSText>
-            <XDSHeading level={3}>Best practices</XDSHeading>
-            <XDSTable
-              data={docs.bestPractices as Record<string, unknown>[]}
-              columns={[
-                {
-                  key: 'type',
-                  header: 'Guidance',
-                  width: pixel(125),
-                  renderCell: (item: Record<string, unknown>) => (
-                    <XDSBadge
-                      label={item.type === 'do' ? 'Do' : 'Dont'}
-                      variant={item.type === 'do' ? 'success' : 'error'}
-                    />
-                  ),
-                },
-                {
-                  key: 'text',
-                  header: 'Practices',
-                  renderCell: (item: Record<string, unknown>) => (
-                    <XDSText type="body" textWrap="wrap">
-                      {item.text as string}
-                    </XDSText>
-                  ),
-                },
-              ]}
-              density="spacious"
-              dividers="rows"
-            />
-          </XDSVStack>
-
-          <XDSDivider />
-
-          {/* Examples */}
-          <XDSVStack gap={4}>
-            <XDSHeading level={2}>Examples</XDSHeading>
-            <XDSText type="large" weight="normal">
-              Explore common configurations, variations, and states for this
-              component.
-            </XDSText>
-          </XDSVStack>
-          <XDSVStack gap={8}>
-          {docs.examples.map((example, i) => {
-            const tabKey = `${activeNav}-${i}`;
-            const activeTab = exampleTabs[tabKey] ?? 'description';
-            return (
-              <XDSCard key={i} padding={0}>
-                {/* Header */}
-                <XDSSection padding={3} variant="transparent">
-                  <XDSHStack gap={3} vAlign="center">
-                    <XDSStackItem size="fill">
-                      <XDSText type="body" weight="medium">
-                        {example.title}
-                      </XDSText>
-                    </XDSStackItem>
-                    <XDSHStack gap={1} vAlign="center">
-                      <XDSButton
-                        label="Open in Craft"
-                        variant="ghost"
-                        size="sm"
-                        icon={<XDSIcon icon={ArrowTopRightOnSquareIcon} />}
-                      />
-                      <XDSButton
-                        label="Send to CLI"
-                        variant="ghost"
-                        size="sm"
-                      />
-                      <XDSIconButton
-                        label="Fullscreen"
-                        variant="ghost"
-                        size="sm"
-                        icon={<XDSIcon icon={ArrowsPointingOutIcon} />}
-                      />
-                    </XDSHStack>
-                  </XDSHStack>
-                </XDSSection>
-                {/* Preview */}
-                <XDSCenter height={280}>
-                  {previews[i] ?? (
-                    <XDSText type="supporting" color="secondary">
-                      Preview coming soon
-                    </XDSText>
-                  )}
-                </XDSCenter>
-                {/* Tabs + content */}
-                <XDSSection variant="wash" padding={3} dividers={['top']}>
-                  <XDSVStack gap={3}>
-                    <XDSTabList
-                      value={activeTab}
-                      onChange={value =>
-                        setExampleTabs(prev => ({
-                          ...prev,
-                          [tabKey]: value,
-                        }))
-                      }
-                      size="sm"
-                      xstyle={styles.tabListFlush}>
-                      <XDSTab value="description" label="Description" />
-                      <XDSTab value="code" label="Code" />
-                    </XDSTabList>
-                    {activeTab === 'description' ? (
-                      <XDSText type="body">{example.description}</XDSText>
-                    ) : (
-                      <XDSCodeBlock code={example.code} language="tsx" />
-                    )}
-                  </XDSVStack>
-                </XDSSection>
-              </XDSCard>
-            );
-          })}
-          </XDSVStack>
+                <XDSBadge
+                  label={entry.type}
+                  variant={entry.type === 'Release' ? 'green' : entry.type === 'Improvement' ? 'blue' : 'orange'}
+                />
+                <XDSText type="body" weight="bold" style={{flex: 1}}>{entry.title}</XDSText>
+              </XDSHStack>
+              {i < CHANGELOG_ENTRIES.length - 1 && <XDSDivider />}
+            </div>
+          ))}
         </XDSVStack>
       </XDSLayoutContent>
     } />
@@ -1032,7 +411,7 @@ function ComponentDetailView({activeNav}: {activeNav: string}) {
 // Main component
 // ---------------------------------------------------------------------------
 
-export default function DocumentationPage() {
+export default function DocumentationOverviewPage() {
   const [activePage, setActivePage] = useState<string>('home');
 
   return (
@@ -1041,9 +420,7 @@ export default function DocumentationPage() {
       height="fill"
       sideNav={
         <XDSSideNav
-          header={
-            <XDSSideNavHeading heading="Product Name" />
-          }>
+          header={<XDSSideNavHeading heading="Product Name" />}>
           <XDSSideNavSection title="Navigation" isHeaderHidden>
             <XDSSideNavItem
               label="Home"
@@ -1051,24 +428,30 @@ export default function DocumentationPage() {
               onClick={() => setActivePage('home')}
             />
             <XDSSideNavItem
-              label="Getting started"
+              label="Getting Started"
               isSelected={activePage === 'getting-started'}
               onClick={() => setActivePage('getting-started')}
             />
+            <XDSSideNavItem
+              label="What's New"
+              isSelected={activePage === 'whats-new'}
+              onClick={() => setActivePage('whats-new')}
+            />
           </XDSSideNavSection>
 
-          {COMPONENT_CATEGORIES.map(category => (
+          <XDSSideNavSection title="Guides">
+            <XDSSideNavItem label="Principles" />
+            <XDSSideNavItem label="Accessibility" />
+            <XDSSideNavItem label="Theming" />
+            <XDSSideNavItem label="CLI Tools" />
+          </XDSSideNavSection>
+
+          {OVERVIEW_SECTIONS.map(category => (
             <XDSSideNavSection key={category.label} title={category.label}>
               {category.items.map(item => (
                 <XDSSideNavItem
                   key={item.key}
                   label={item.name}
-                  isSelected={activePage === item.key}
-                  onClick={
-                    item.key === 'button'
-                      ? () => setActivePage(item.key)
-                      : undefined
-                  }
                 />
               ))}
             </XDSSideNavSection>
@@ -1076,11 +459,13 @@ export default function DocumentationPage() {
         </XDSSideNav>
       }>
       {activePage === 'home' ? (
-        <OverviewView onSelectComponent={setActivePage} />
+        <OverviewView onSelectPage={setActivePage} />
       ) : activePage === 'getting-started' ? (
         <GettingStartedView />
+      ) : activePage === 'whats-new' ? (
+        <WhatsNewView />
       ) : (
-        <ComponentDetailView activeNav={activePage} />
+        <OverviewView onSelectPage={setActivePage} />
       )}
     </XDSAppShell>
   );

--- a/packages/cli/templates/pages/documentation/page.tsx
+++ b/packages/cli/templates/pages/documentation/page.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import {useState} from 'react';
-import * as stylex from '@stylexjs/stylex';
 import {XDSAppShell} from '@xds/core/AppShell';
 import {
   XDSSideNav,
@@ -9,148 +7,11 @@ import {
   XDSSideNavItem,
   XDSSideNavSection,
 } from '@xds/core/SideNav';
-import {XDSHeading, XDSText} from '@xds/core/Text';
+import {XDSText} from '@xds/core/Text';
 import {XDSButton} from '@xds/core/Button';
 import {XDSCard} from '@xds/core/Card';
 import {XDSHStack, XDSVStack, XDSStackItem} from '@xds/core/Stack';
 import {XDSLayout, XDSLayoutContent} from '@xds/core/Layout';
-import {XDSGrid} from '@xds/core/Grid';
-import {radiusVars} from '@xds/core/theme/tokens.stylex';
-
-const styles = stylex.create({
-  previewCard: {
-    borderRadius: radiusVars['--radius-container'],
-    cursor: 'pointer',
-  },
-});
-
-// ---------------------------------------------------------------------------
-// Data
-// ---------------------------------------------------------------------------
-
-const COMPONENT_CATEGORIES = [
-  {
-    label: 'Core',
-    items: [
-      {key: 'appshell', name: 'AppShell', desc: 'AppShell provides a foundational page layout with header, sidebar, and content regions. Use it to establish consistent structure across your application.'},
-      {key: 'avatar', name: 'Avatar', desc: 'Avatars represent a person or entity with an image, initials, or icon. They are commonly used in user profiles, comments, and contact lists.'},
-      {key: 'badge', name: 'Badge', desc: 'Badges display small counts or status labels. They can be attached to icons, buttons, or list items to surface key information at a glance.'},
-      {key: 'banner', name: 'Banner', desc: 'Banners show important, non-modal messages at the top of a page or section. They communicate status, warnings, or promotional information.'},
-      {key: 'button', name: 'Button', desc: 'Buttons let people take action. They can be used in forms, dialogs, and toolbars, or as standalone links.'},
-      {key: 'calendar', name: 'Calendar', desc: 'Calendar provides a date-picking grid for selecting single dates or date ranges. It integrates with form fields for date input.'},
-      {key: 'dialog', name: 'Dialog', desc: 'Dialogs are modal overlays that require user attention or action before continuing. They are used for confirmations, forms, and critical decisions.'},
-      {key: 'dropdownmenu', name: 'DropdownMenu', desc: 'DropdownMenu presents a list of actions or options in a floating overlay. It is triggered by a button and supports nested submenus.'},
-      {key: 'emptystate', name: 'EmptyState', desc: 'EmptyState provides a placeholder when there is no content to display. It guides users with a message, illustration, and optional call-to-action.'},
-      {key: 'hovercard', name: 'HoverCard', desc: 'HoverCard shows a rich preview of content when users hover over a trigger element. It is ideal for previewing profiles, links, or details.'},
-      {key: 'icon', name: 'Icon', desc: 'Icons are small visual symbols that represent actions, objects, or concepts. They improve scannability and reinforce meaning alongside text.'},
-      {key: 'kbd', name: 'Kbd', desc: 'Kbd renders keyboard shortcut hints in a styled inline element. Use it to show users which key combinations perform specific actions.'},
-      {key: 'link', name: 'Link', desc: 'Links provide navigation between pages or to external resources. They follow accessible anchor semantics with visual affordance.'},
-      {key: 'list', name: 'List', desc: 'List displays a vertical set of related items. It supports selection, icons, and metadata for building menus, nav lists, and more.'},
-      {key: 'popover', name: 'Popover', desc: 'Popover displays rich content in a floating panel anchored to a trigger element. It is used for forms, filters, and contextual tools.'},
-      {key: 'table', name: 'Table', desc: 'Table displays structured data in rows and columns with support for sorting, selection, and custom cell rendering.'},
-      {key: 'token', name: 'Token', desc: 'Tokens display compact metadata labels such as tags, categories, or filters. They can be dismissible and support selection state.'},
-      {key: 'tooltip', name: 'Tooltip', desc: 'Tooltips show concise helper text when users hover over or focus an element. They clarify icons, truncated labels, and controls.'},
-    ],
-  },
-  {
-    label: 'Layout',
-    items: [
-      {key: 'card', name: 'Card', desc: 'Cards group related content and actions in a contained surface. They can include headers, media, body text, and action bars.'},
-      {key: 'divider', name: 'Divider', desc: 'Dividers separate content into distinct sections with a subtle or strong horizontal line. They can optionally include a label.'},
-      {key: 'grid', name: 'Grid', desc: 'Grid provides a CSS grid-based layout container with configurable columns, rows, and gap. It simplifies responsive multi-column designs.'},
-      {key: 'stack', name: 'Stack', desc: 'Stack arranges child elements in a row or column with consistent gap spacing. It is the primary tool for one-dimensional layout composition.'},
-    ],
-  },
-  {
-    label: 'Navigation',
-    items: [
-      {key: 'breadcrumbs', name: 'Breadcrumbs', desc: "Breadcrumbs show the user's current location within a navigation hierarchy. They provide quick links back to parent pages."},
-      {key: 'sidenav', name: 'SideNav', desc: 'SideNav renders a vertical navigation panel with links, sections, and collapsible groups. It is used as the primary nav in dashboard layouts.'},
-      {key: 'tablist', name: 'TabList', desc: 'TabList switches between content views using a horizontal row of tabs. Only one tab is active at a time, and content changes without a page reload.'},
-      {key: 'topnav', name: 'TopNav', desc: 'TopNav provides an app-level navigation bar across the top of the page. It holds branding, primary links, search, and user actions.'},
-    ],
-  },
-  {
-    label: 'Form',
-    items: [
-      {key: 'checkboxinput', name: 'CheckboxInput', desc: 'CheckboxInput renders a single checkbox with a label. It is used for boolean opt-in choices like terms acceptance or feature toggles.'},
-      {key: 'selector', name: 'Selector', desc: 'Selector lets users pick a single item from a dropdown list. It supports search, grouping, and custom option rendering.'},
-      {key: 'switch', name: 'Switch', desc: 'Switch toggles a setting between on and off states with immediate effect. It is used for preferences, feature flags, and real-time controls.'},
-      {key: 'textinput', name: 'TextInput', desc: 'TextInput is a single-line text field for short user input like names, emails, and search queries. It supports icons, prefixes, and validation.'},
-      {key: 'typeahead', name: 'Typeahead', desc: 'Typeahead provides an autocomplete search input that suggests results as the user types. It supports async data sources and custom rendering.'},
-    ],
-  },
-];
-
-// ---------------------------------------------------------------------------
-// Sub-views
-// ---------------------------------------------------------------------------
-
-function OverviewView({
-  onSelectComponent,
-}: {
-  onSelectComponent: (key: string) => void;
-}) {
-  return (
-    <XDSLayout contentWidth={1200} content={
-      <XDSLayoutContent padding={8}>
-        <XDSVStack gap={10}>
-          {/* Hero banner */}
-          <XDSCard variant="cyan" padding={10}>
-            <XDSHStack gap={8} vAlign="center">
-              <XDSStackItem size="fill">
-                <XDSVStack gap={4}>
-                  <XDSText type="display-1">Web overview</XDSText>
-                  <XDSText type="large" weight="normal" color="secondary">
-                    An open-source UI library to help developers quickly build
-                    beautiful, accessible products.
-                  </XDSText>
-                  <XDSHStack>
-                    <XDSButton
-                      label="Get started"
-                      variant="primary"
-                      size="lg"
-                      onClick={() => onSelectComponent('getting-started')}
-                    />
-                  </XDSHStack>
-                </XDSVStack>
-              </XDSStackItem>
-              <XDSStackItem size="fill" />
-            </XDSHStack>
-          </XDSCard>
-
-          {/* Category sections */}
-          {COMPONENT_CATEGORIES.map(category => (
-            <XDSVStack key={category.label} gap={4}>
-              <XDSText type="display-2">{category.label}</XDSText>
-              <XDSGrid columns={{minWidth: 260}} gap={8}>
-                {category.items.map(item => (
-                  <XDSVStack key={item.key} gap={3}>
-                    <XDSCard
-                      variant="muted"
-                      padding={0}
-                      minHeight={160}
-                      xstyle={styles.previewCard}
-                      onClick={() => onSelectComponent(item.key)}
-                    />
-                    <XDSVStack gap={0.5}>
-                      <XDSText type="body" weight="bold">
-                        {item.name}
-                      </XDSText>
-                      <XDSText type="body" color="secondary">
-                        {item.desc}
-                      </XDSText>
-                    </XDSVStack>
-                  </XDSVStack>
-                ))}
-              </XDSGrid>
-            </XDSVStack>
-          ))}
-        </XDSVStack>
-      </XDSLayoutContent>
-    } />
-  );
-}
 
 // ---------------------------------------------------------------------------
 // Main component
@@ -167,25 +28,39 @@ export default function DocumentationOverviewPage() {
             <XDSSideNavHeading heading="Product Name" />
           }>
           <XDSSideNavSection title="Navigation" isHeaderHidden>
-            <XDSSideNavItem
-              label="Home"
-              isSelected
-            />
+            <XDSSideNavItem label="Home" isSelected />
+            <XDSSideNavItem label="Getting started" />
+            <XDSSideNavItem label="Components" />
           </XDSSideNavSection>
-
-          {COMPONENT_CATEGORIES.map(category => (
-            <XDSSideNavSection key={category.label} title={category.label}>
-              {category.items.map(item => (
-                <XDSSideNavItem
-                  key={item.key}
-                  label={item.name}
-                />
-              ))}
-            </XDSSideNavSection>
-          ))}
         </XDSSideNav>
       }>
-      <OverviewView onSelectComponent={() => {}} />
+      <XDSLayout contentWidth={1200} content={
+        <XDSLayoutContent padding={8}>
+          <XDSVStack gap={10}>
+            <XDSCard variant="cyan" padding={10}>
+              <XDSHStack gap={8} vAlign="center">
+                <XDSStackItem size="fill">
+                  <XDSVStack gap={4}>
+                    <XDSText type="display-1">Web overview</XDSText>
+                    <XDSText type="large" weight="normal" color="secondary">
+                      An open-source UI library to help developers quickly build
+                      beautiful, accessible products.
+                    </XDSText>
+                    <XDSHStack>
+                      <XDSButton
+                        label="Get started"
+                        variant="primary"
+                        size="lg"
+                      />
+                    </XDSHStack>
+                  </XDSVStack>
+                </XDSStackItem>
+                <XDSStackItem size="fill" />
+              </XDSHStack>
+            </XDSCard>
+          </XDSVStack>
+        </XDSLayoutContent>
+      } />
     </XDSAppShell>
   );
 }

--- a/packages/cli/templates/pages/documentation/page.tsx
+++ b/packages/cli/templates/pages/documentation/page.tsx
@@ -13,9 +13,7 @@ import {XDSHeading, XDSText} from '@xds/core/Text';
 import {XDSButton} from '@xds/core/Button';
 import {XDSCard} from '@xds/core/Card';
 import {XDSDropdownMenu} from '@xds/core/DropdownMenu';
-import {XDSBadge} from '@xds/core/Badge';
 import {XDSList, XDSListItem} from '@xds/core/List';
-import {XDSBanner} from '@xds/core/Banner';
 import {XDSCodeBlock} from '@xds/core/CodeBlock';
 import {XDSHStack, XDSVStack, XDSStackItem} from '@xds/core/Stack';
 import {XDSLayout, XDSLayoutContent} from '@xds/core/Layout';
@@ -40,62 +38,58 @@ const styles = stylex.create({
 // Data
 // ---------------------------------------------------------------------------
 
-const OVERVIEW_SECTIONS = [
+const COMPONENT_CATEGORIES = [
   {
     label: 'Core',
     items: [
-      {key: 'appshell', name: 'AppShell', desc: 'Foundational page layout with header, sidebar, and content regions.'},
-      {key: 'button', name: 'Button', desc: 'Buttons let people take action. Used in forms, dialogs, and toolbars.'},
-      {key: 'card', name: 'Card', desc: 'Cards group related content and actions in a contained surface.'},
-      {key: 'dialog', name: 'Dialog', desc: 'Modal overlays that require user attention or action before continuing.'},
-      {key: 'badge', name: 'Badge', desc: 'Small counts or status labels attached to icons, buttons, or list items.'},
-      {key: 'banner', name: 'Banner', desc: 'Important, non-modal messages at the top of a page or section.'},
-      {key: 'avatar', name: 'Avatar', desc: 'Represents a person or entity with an image, initials, or icon.'},
-      {key: 'table', name: 'Table', desc: 'Structured data in rows and columns with sorting and selection.'},
+      {key: 'appshell', name: 'AppShell', desc: 'AppShell provides a foundational page layout with header, sidebar, and content regions. Use it to establish consistent structure across your application.'},
+      {key: 'avatar', name: 'Avatar', desc: 'Avatars represent a person or entity with an image, initials, or icon. They are commonly used in user profiles, comments, and contact lists.'},
+      {key: 'badge', name: 'Badge', desc: 'Badges display small counts or status labels. They can be attached to icons, buttons, or list items to surface key information at a glance.'},
+      {key: 'banner', name: 'Banner', desc: 'Banners show important, non-modal messages at the top of a page or section. They communicate status, warnings, or promotional information.'},
+      {key: 'button', name: 'Button', desc: 'Buttons let people take action. They can be used in forms, dialogs, and toolbars, or as standalone links.'},
+      {key: 'calendar', name: 'Calendar', desc: 'Calendar provides a date-picking grid for selecting single dates or date ranges. It integrates with form fields for date input.'},
+      {key: 'dialog', name: 'Dialog', desc: 'Dialogs are modal overlays that require user attention or action before continuing. They are used for confirmations, forms, and critical decisions.'},
+      {key: 'dropdownmenu', name: 'DropdownMenu', desc: 'DropdownMenu presents a list of actions or options in a floating overlay. It is triggered by a button and supports nested submenus.'},
+      {key: 'emptystate', name: 'EmptyState', desc: 'EmptyState provides a placeholder when there is no content to display. It guides users with a message, illustration, and optional call-to-action.'},
+      {key: 'hovercard', name: 'HoverCard', desc: 'HoverCard shows a rich preview of content when users hover over a trigger element. It is ideal for previewing profiles, links, or details.'},
+      {key: 'icon', name: 'Icon', desc: 'Icons are small visual symbols that represent actions, objects, or concepts. They improve scannability and reinforce meaning alongside text.'},
+      {key: 'kbd', name: 'Kbd', desc: 'Kbd renders keyboard shortcut hints in a styled inline element. Use it to show users which key combinations perform specific actions.'},
+      {key: 'link', name: 'Link', desc: 'Links provide navigation between pages or to external resources. They follow accessible anchor semantics with visual affordance.'},
+      {key: 'list', name: 'List', desc: 'List displays a vertical set of related items. It supports selection, icons, and metadata for building menus, nav lists, and more.'},
+      {key: 'popover', name: 'Popover', desc: 'Popover displays rich content in a floating panel anchored to a trigger element. It is used for forms, filters, and contextual tools.'},
+      {key: 'table', name: 'Table', desc: 'Table displays structured data in rows and columns with support for sorting, selection, and custom cell rendering.'},
+      {key: 'token', name: 'Token', desc: 'Tokens display compact metadata labels such as tags, categories, or filters. They can be dismissible and support selection state.'},
+      {key: 'tooltip', name: 'Tooltip', desc: 'Tooltips show concise helper text when users hover over or focus an element. They clarify icons, truncated labels, and controls.'},
     ],
   },
   {
     label: 'Layout',
     items: [
-      {key: 'stack', name: 'Stack', desc: 'Arranges child elements in a row or column with consistent gap spacing.'},
-      {key: 'grid', name: 'Grid', desc: 'CSS grid-based layout container with configurable columns and gap.'},
-      {key: 'divider', name: 'Divider', desc: 'Separates content into distinct sections with a subtle line.'},
-      {key: 'section', name: 'Section', desc: 'Wraps a block of content with consistent vertical spacing.'},
+      {key: 'card', name: 'Card', desc: 'Cards group related content and actions in a contained surface. They can include headers, media, body text, and action bars.'},
+      {key: 'divider', name: 'Divider', desc: 'Dividers separate content into distinct sections with a subtle or strong horizontal line. They can optionally include a label.'},
+      {key: 'grid', name: 'Grid', desc: 'Grid provides a CSS grid-based layout container with configurable columns, rows, and gap. It simplifies responsive multi-column designs.'},
+      {key: 'stack', name: 'Stack', desc: 'Stack arranges child elements in a row or column with consistent gap spacing. It is the primary tool for one-dimensional layout composition.'},
     ],
   },
   {
     label: 'Navigation',
     items: [
-      {key: 'sidenav', name: 'SideNav', desc: 'Vertical navigation panel with links, sections, and collapsible groups.'},
-      {key: 'topnav', name: 'TopNav', desc: 'App-level navigation bar with branding, links, search, and user actions.'},
-      {key: 'tablist', name: 'TabList', desc: 'Switches between content views using a horizontal row of tabs.'},
-      {key: 'breadcrumbs', name: 'Breadcrumbs', desc: "Shows the user's current location within a navigation hierarchy."},
+      {key: 'breadcrumbs', name: 'Breadcrumbs', desc: "Breadcrumbs show the user's current location within a navigation hierarchy. They provide quick links back to parent pages."},
+      {key: 'sidenav', name: 'SideNav', desc: 'SideNav renders a vertical navigation panel with links, sections, and collapsible groups. It is used as the primary nav in dashboard layouts.'},
+      {key: 'tablist', name: 'TabList', desc: 'TabList switches between content views using a horizontal row of tabs. Only one tab is active at a time, and content changes without a page reload.'},
+      {key: 'topnav', name: 'TopNav', desc: 'TopNav provides an app-level navigation bar across the top of the page. It holds branding, primary links, search, and user actions.'},
     ],
   },
   {
     label: 'Form',
     items: [
-      {key: 'textinput', name: 'TextInput', desc: 'Single-line text field for names, emails, and search queries.'},
-      {key: 'selector', name: 'Selector', desc: 'Pick a single item from a dropdown list with search and grouping.'},
-      {key: 'switch', name: 'Switch', desc: 'Toggles a setting between on and off states with immediate effect.'},
-      {key: 'checkboxinput', name: 'CheckboxInput', desc: 'Single checkbox with a label for boolean opt-in choices.'},
+      {key: 'checkboxinput', name: 'CheckboxInput', desc: 'CheckboxInput renders a single checkbox with a label. It is used for boolean opt-in choices like terms acceptance or feature toggles.'},
+      {key: 'selector', name: 'Selector', desc: 'Selector lets users pick a single item from a dropdown list. It supports search, grouping, and custom option rendering.'},
+      {key: 'switch', name: 'Switch', desc: 'Switch toggles a setting between on and off states with immediate effect. It is used for preferences, feature flags, and real-time controls.'},
+      {key: 'textinput', name: 'TextInput', desc: 'TextInput is a single-line text field for short user input like names, emails, and search queries. It supports icons, prefixes, and validation.'},
+      {key: 'typeahead', name: 'Typeahead', desc: 'Typeahead provides an autocomplete search input that suggests results as the user types. It supports async data sources and custom rendering.'},
     ],
   },
-];
-
-const QUICK_LINKS = [
-  {title: 'Getting Started', desc: 'Install, configure theming, and build your first component.', key: 'getting-started'},
-  {title: 'What\'s New', desc: 'Latest updates, new components, and breaking changes.', key: 'whats-new'},
-  {title: 'Principles', desc: 'Design rules, anti-patterns, and best practices.', key: 'principles'},
-  {title: 'Accessibility', desc: 'Built-in a11y features and ARIA patterns.', key: 'accessibility'},
-];
-
-const CHANGELOG_ENTRIES = [
-  {date: 'Apr.18', type: 'Release' as const, title: '@xds/chat package with message bubbles, thread view, and AI composer'},
-  {date: 'Apr.18', type: 'Release' as const, title: 'Calendar component with single date and date range selection'},
-  {date: 'Apr.16', type: 'Improvement' as const, title: 'Dialog entry animations now use @starting-style instead of JS state'},
-  {date: 'Apr.14', type: 'Fix' as const, title: 'Popover focus trap no longer breaks with nested popovers'},
-  {date: 'Apr.10', type: 'Improvement' as const, title: 'Button loading state preserves width to prevent layout shift'},
 ];
 
 // ---------------------------------------------------------------------------
@@ -103,9 +97,9 @@ const CHANGELOG_ENTRIES = [
 // ---------------------------------------------------------------------------
 
 function OverviewView({
-  onSelectPage,
+  onSelectComponent,
 }: {
-  onSelectPage: (key: string) => void;
+  onSelectComponent: (key: string) => void;
 }) {
   return (
     <XDSLayout contentWidth={1200} content={
@@ -116,23 +110,17 @@ function OverviewView({
             <XDSHStack gap={8} vAlign="center">
               <XDSStackItem size="fill">
                 <XDSVStack gap={4}>
-                  <XDSText type="display-1">Documentation</XDSText>
+                  <XDSText type="display-1">Web overview</XDSText>
                   <XDSText type="large" weight="normal" color="secondary">
-                    Everything you need to build beautiful, accessible products
-                    with our component library.
+                    An open-source UI library to help developers quickly build
+                    beautiful, accessible products.
                   </XDSText>
-                  <XDSHStack gap={3}>
+                  <XDSHStack>
                     <XDSButton
                       label="Get started"
                       variant="primary"
                       size="lg"
-                      onClick={() => onSelectPage('getting-started')}
-                    />
-                    <XDSButton
-                      label="What's new"
-                      variant="secondary"
-                      size="lg"
-                      onClick={() => onSelectPage('whats-new')}
+                      onClick={() => onSelectComponent('getting-started')}
                     />
                   </XDSHStack>
                 </XDSVStack>
@@ -141,27 +129,8 @@ function OverviewView({
             </XDSHStack>
           </XDSCard>
 
-          {/* Quick links */}
-          <XDSVStack gap={4}>
-            <XDSText type="display-2">Quick Links</XDSText>
-            <XDSGrid columns={{minWidth: 260}} gap={4}>
-              {QUICK_LINKS.map(link => (
-                <XDSCard
-                  key={link.key}
-                  padding={5}
-                  onClick={() => onSelectPage(link.key)}
-                  xstyle={styles.previewCard}>
-                  <XDSVStack gap={1}>
-                    <XDSText type="body" weight="bold">{link.title}</XDSText>
-                    <XDSText type="body" color="secondary">{link.desc}</XDSText>
-                  </XDSVStack>
-                </XDSCard>
-              ))}
-            </XDSGrid>
-          </XDSVStack>
-
-          {/* Component categories */}
-          {OVERVIEW_SECTIONS.map(category => (
+          {/* Category sections */}
+          {COMPONENT_CATEGORIES.map(category => (
             <XDSVStack key={category.label} gap={4}>
               <XDSText type="display-2">{category.label}</XDSText>
               <XDSGrid columns={{minWidth: 260}} gap={8}>
@@ -172,49 +141,21 @@ function OverviewView({
                       padding={0}
                       minHeight={160}
                       xstyle={styles.previewCard}
-                      onClick={() => onSelectPage(item.key)}
+                      onClick={() => onSelectComponent(item.key)}
                     />
                     <XDSVStack gap={0.5}>
-                      <XDSText type="body" weight="bold">{item.name}</XDSText>
-                      <XDSText type="body" color="secondary">{item.desc}</XDSText>
+                      <XDSText type="body" weight="bold">
+                        {item.name}
+                      </XDSText>
+                      <XDSText type="body" color="secondary">
+                        {item.desc}
+                      </XDSText>
                     </XDSVStack>
                   </XDSVStack>
                 ))}
               </XDSGrid>
             </XDSVStack>
           ))}
-
-          {/* What's new */}
-          <XDSVStack gap={4}>
-            <XDSHStack vAlign="center">
-              <XDSStackItem size="fill">
-                <XDSText type="display-2">What&#39;s New</XDSText>
-              </XDSStackItem>
-              <XDSButton
-                label="View all"
-                variant="ghost"
-                onClick={() => onSelectPage('whats-new')}
-              />
-            </XDSHStack>
-            {CHANGELOG_ENTRIES.map((entry, i) => (
-              <div key={i}>
-                <XDSHStack gap={3} vAlign="center">
-                  <XDSText
-                    type="supporting"
-                    color="secondary"
-                    style={{fontFamily: 'monospace', fontSize: 12, width: 50, flexShrink: 0}}>
-                    {entry.date}
-                  </XDSText>
-                  <XDSBadge
-                    label={entry.type}
-                    variant={entry.type === 'Release' ? 'green' : entry.type === 'Improvement' ? 'blue' : 'orange'}
-                  />
-                  <XDSText type="body" style={{flex: 1}}>{entry.title}</XDSText>
-                </XDSHStack>
-                {i < CHANGELOG_ENTRIES.length - 1 && <XDSDivider style={{marginTop: 12}} />}
-              </div>
-            ))}
-          </XDSVStack>
         </XDSVStack>
       </XDSLayoutContent>
     } />
@@ -226,114 +167,143 @@ function GettingStartedView() {
     <XDSLayout contentWidth={960} content={
       <XDSLayoutContent padding={8}>
         <XDSVStack gap={8}>
+        {/* Header */}
+        <XDSVStack gap={2}>
+          <XDSText type="display-1">
+            Getting started with Product Name
+          </XDSText>
+          <XDSText type="supporting" color="secondary">
+            Last updated March 30, 2026
+          </XDSText>
+          <XDSText type="body">
+            Install the package, configure your theme, and build your first
+            component in three steps.
+          </XDSText>
+        </XDSVStack>
+
+        {/* AI Assistance prompt card */}
+        <XDSCard>
+          <XDSVStack gap={3}>
+            <XDSHStack gap={2} vAlign="center">
+              <XDSStackItem size="fill">
+                <XDSHStack gap={2} vAlign="center">
+                  <XDSIcon icon={SparklesIcon} size="sm" color="secondary" />
+                  <XDSText type="body" weight="semibold">
+                    AI Assistance
+                  </XDSText>
+                </XDSHStack>
+              </XDSStackItem>
+              <XDSButton
+                label="Copy prompt"
+                variant="ghost"
+                size="sm"
+                icon={<XDSIcon icon={ClipboardDocumentIcon} />}
+                onClick={() => {
+                  void navigator.clipboard.writeText(
+                    'Help me get set up with Product Name. Based on my project, do the following: 1. Install @xds/core and the StyleX compiler. 2. Wrap my app in XDSThemeProvider. 3. Replace one existing component with an XDS equivalent. After setup, suggest relevant next steps based on my project.',
+                  );
+                }}
+              />
+              <XDSDropdownMenu
+                button={{
+                  label: 'More options',
+                  variant: 'ghost',
+                  size: 'sm',
+                  isIconOnly: true,
+                  icon: <XDSIcon icon={ChevronDownIcon} />,
+                }}
+                items={[
+                  {label: 'Open in v0', onClick: () => {}},
+                  {label: 'Open in Claude', onClick: () => {}},
+                  {label: 'Open in ChatGPT', onClick: () => {}},
+                  {label: 'Open in Cursor', onClick: () => {}},
+                ]}
+              />
+            </XDSHStack>
+            <XDSText type="body" color="secondary">
+              Help me get set up with Product Name. Based on my project, do the
+              following: 1. Install @xds/core and the StyleX compiler. 2. Wrap
+              my app in XDSThemeProvider. 3. Replace one existing component with
+              an XDS equivalent.
+            </XDSText>
+          </XDSVStack>
+        </XDSCard>
+
+        {/* Prerequisites */}
+        <XDSVStack gap={4}>
+          <XDSHeading level={2}>Prerequisites</XDSHeading>
+          <XDSList density="compact" listStyle="disc">
+            <XDSListItem label="Node.js 18+" />
+            <XDSListItem label="React 18 or 19" />
+            <XDSListItem label="A package manager (npm, yarn, or pnpm)" />
+          </XDSList>
+        </XDSVStack>
+
+        <XDSDivider />
+
+        {/* Install the package */}
+        <XDSVStack gap={4}>
+          <XDSHeading level={2}>Install the package</XDSHeading>
+          <XDSText type="body">
+            Every project starts with installing the core package. This gives
+            you access to all components, tokens, and utilities.
+          </XDSText>
+
           <XDSVStack gap={2}>
-            <XDSText type="display-1">Getting started</XDSText>
-            <XDSText type="supporting" color="secondary">
-              Last updated March 30, 2026
+            <XDSText type="body" weight="bold">
+              Step 1: Install the core package
             </XDSText>
-            <XDSText type="body">
-              Install the package, configure your theme, and build your first
-              component in three steps.
-            </XDSText>
+            <XDSCard padding={0}>
+              <XDSCodeBlock code="npm install @xds/core" language="bash" />
+            </XDSCard>
           </XDSVStack>
 
-          <XDSCard>
-            <XDSVStack gap={3}>
-              <XDSHStack gap={2} vAlign="center">
-                <XDSStackItem size="fill">
-                  <XDSHStack gap={2} vAlign="center">
-                    <XDSIcon icon={SparklesIcon} size="sm" color="secondary" />
-                    <XDSText type="body" weight="semibold">AI Assistance</XDSText>
-                  </XDSHStack>
-                </XDSStackItem>
-                <XDSButton
-                  label="Copy prompt"
-                  variant="ghost"
-                  size="sm"
-                  icon={<XDSIcon icon={ClipboardDocumentIcon} />}
-                  onClick={() => {
-                    void navigator.clipboard.writeText(
-                      'Help me get set up with Product Name. Install @xds/core and the StyleX compiler, wrap my app in XDSThemeProvider, and replace one existing component with an XDS equivalent.',
-                    );
-                  }}
-                />
-                <XDSDropdownMenu
-                  button={{
-                    label: 'More options',
-                    variant: 'ghost',
-                    size: 'sm',
-                    isIconOnly: true,
-                    icon: <XDSIcon icon={ChevronDownIcon} />,
-                  }}
-                  items={[
-                    {label: 'Open in Cursor', onClick: () => {}},
-                    {label: 'Open in Claude', onClick: () => {}},
-                  ]}
-                />
-              </XDSHStack>
-              <XDSText type="body" color="secondary">
-                Help me get set up with Product Name. Install @xds/core and the
-                StyleX compiler, wrap my app in XDSThemeProvider, and replace
-                one existing component with an XDS equivalent.
-              </XDSText>
-            </XDSVStack>
-          </XDSCard>
-
-          <XDSVStack gap={4}>
-            <XDSHeading level={2}>Prerequisites</XDSHeading>
-            <XDSList density="compact" listStyle="disc">
-              <XDSListItem label="Node.js 18+" />
-              <XDSListItem label="React 18 or 19" />
-              <XDSListItem label="A package manager (npm, yarn, or pnpm)" />
-            </XDSList>
+          <XDSVStack gap={2}>
+            <XDSText type="body" weight="bold">
+              Step 2: Add the StyleX compiler
+            </XDSText>
+            <XDSText type="body" color="secondary">
+              XDS uses StyleX for styling. Add the compiler plugin to your build
+              configuration.
+            </XDSText>
+            <XDSCard padding={0}>
+              <XDSCodeBlock
+                code="npm install @stylexjs/babel-plugin"
+                language="bash"
+              />
+            </XDSCard>
           </XDSVStack>
 
-          <XDSDivider />
-
-          <XDSVStack gap={4}>
-            <XDSHeading level={2}>Install the package</XDSHeading>
-            <XDSText type="body">
-              Every project starts with installing the core package. This gives
-              you access to all components, tokens, and utilities.
+          <XDSVStack gap={2}>
+            <XDSText type="body" weight="bold">
+              Step 3: Import your first component
             </XDSText>
-            <XDSVStack gap={2}>
-              <XDSText type="body" weight="bold">Step 1: Install the core package</XDSText>
-              <XDSCard padding={0}>
-                <XDSCodeBlock code="npm install @xds/core" language="bash" />
-              </XDSCard>
-            </XDSVStack>
-            <XDSVStack gap={2}>
-              <XDSText type="body" weight="bold">Step 2: Add the StyleX compiler</XDSText>
-              <XDSCard padding={0}>
-                <XDSCodeBlock code="npm install @stylexjs/babel-plugin" language="bash" />
-              </XDSCard>
-            </XDSVStack>
-            <XDSVStack gap={2}>
-              <XDSText type="body" weight="bold">Step 3: Import your first component</XDSText>
-              <XDSCard padding={0}>
-                <XDSCodeBlock
-                  code={`import { XDSButton } from '@xds/core/Button';
+            <XDSCard padding={0}>
+              <XDSCodeBlock
+                code={`import { XDSButton } from '@xds/core/Button';
 
 export default function App() {
   return <XDSButton label="Hello XDS" variant="primary" />;
 }`}
-                  language="tsx"
-                />
-              </XDSCard>
-            </XDSVStack>
+                language="tsx"
+              />
+            </XDSCard>
           </XDSVStack>
+        </XDSVStack>
 
-          <XDSDivider />
+        <XDSDivider />
 
-          <XDSVStack gap={4}>
-            <XDSHeading level={2}>Configure theming</XDSHeading>
-            <XDSText type="body">
-              XDS ships with a default theme that works out of the box. To
-              customize colors, typography, and spacing, wrap your app in a theme provider.
-            </XDSText>
-            <XDSCard padding={0}>
-              <XDSCodeBlock
-                code={`import { XDSThemeProvider } from '@xds/core/Theme';
+        {/* Configure theming */}
+        <XDSVStack gap={4}>
+          <XDSHeading level={2}>Configure theming</XDSHeading>
+          <XDSText type="body">
+            XDS ships with a default theme that works out of the box. To
+            customize colors, typography, and spacing, wrap your app in a theme
+            provider.
+          </XDSText>
+          <XDSCard padding={0}>
+            <XDSCodeBlock
+              code={`import { XDSThemeProvider } from '@xds/core/Theme';
 
 export default function App({ children }) {
   return (
@@ -342,66 +312,28 @@ export default function App({ children }) {
     </XDSThemeProvider>
   );
 }`}
-                language="tsx"
-              />
-            </XDSCard>
-          </XDSVStack>
-
-          <XDSDivider />
-
-          <XDSVStack gap={4}>
-            <XDSHeading level={2}>Next steps</XDSHeading>
-            <XDSList density="compact" listStyle="disc">
-              <XDSListItem label="Fundamental concepts — How theming, layout, and composition work" />
-              <XDSListItem label="Component API reference — Props, variants, and examples for every component" />
-              <XDSListItem label="Accessibility — Built-in a11y features and ARIA patterns" />
-              <XDSListItem label="CLI tools — Scaffold projects and manage templates" />
-              <XDSListItem label="Design tokens — Colors, spacing, typography, and sizing" />
-            </XDSList>
-          </XDSVStack>
+              language="tsx"
+            />
+          </XDSCard>
+          <XDSText type="body" color="secondary">
+            See the theming guide for the full list of customizable tokens.
+          </XDSText>
         </XDSVStack>
-      </XDSLayoutContent>
-    } />
-  );
-}
 
-function WhatsNewView() {
-  return (
-    <XDSLayout contentWidth={960} content={
-      <XDSLayoutContent padding={8}>
-        <XDSVStack gap={8}>
-          <XDSVStack gap={2}>
-            <XDSText type="display-1">What&#39;s New</XDSText>
-            <XDSText type="body" color="secondary">
-              Latest updates, new components, improvements, and breaking changes.
-            </XDSText>
-          </XDSVStack>
+        <XDSDivider />
 
-          <XDSBanner status="info" title="Latest Release">
-            <XDSText type="body">
-              @xds/chat v0.0.12 is now available with message bubbles, thread view, and AI composer.
-            </XDSText>
-          </XDSBanner>
-
-          {CHANGELOG_ENTRIES.map((entry, i) => (
-            <div key={i}>
-              <XDSHStack gap={3} vAlign="center" style={{padding: '12px 0'}}>
-                <XDSText
-                  type="supporting"
-                  color="secondary"
-                  style={{fontFamily: 'monospace', fontSize: 12, width: 50, flexShrink: 0}}>
-                  {entry.date}
-                </XDSText>
-                <XDSBadge
-                  label={entry.type}
-                  variant={entry.type === 'Release' ? 'green' : entry.type === 'Improvement' ? 'blue' : 'orange'}
-                />
-                <XDSText type="body" weight="bold" style={{flex: 1}}>{entry.title}</XDSText>
-              </XDSHStack>
-              {i < CHANGELOG_ENTRIES.length - 1 && <XDSDivider />}
-            </div>
-          ))}
+        {/* Next steps */}
+        <XDSVStack gap={4}>
+          <XDSHeading level={2}>Next steps</XDSHeading>
+          <XDSList density="compact" listStyle="disc">
+            <XDSListItem label="Fundamental concepts — How theming, layout, and composition work" />
+            <XDSListItem label="Component API reference — Props, variants, and examples for every component" />
+            <XDSListItem label="Accessibility — Built-in a11y features and ARIA patterns" />
+            <XDSListItem label="CLI tools — Scaffold projects and manage templates" />
+            <XDSListItem label="Design tokens — Colors, spacing, typography, and sizing" />
+          </XDSList>
         </XDSVStack>
+      </XDSVStack>
       </XDSLayoutContent>
     } />
   );
@@ -420,7 +352,9 @@ export default function DocumentationOverviewPage() {
       height="fill"
       sideNav={
         <XDSSideNav
-          header={<XDSSideNavHeading heading="Product Name" />}>
+          header={
+            <XDSSideNavHeading heading="Product Name" />
+          }>
           <XDSSideNavSection title="Navigation" isHeaderHidden>
             <XDSSideNavItem
               label="Home"
@@ -428,25 +362,13 @@ export default function DocumentationOverviewPage() {
               onClick={() => setActivePage('home')}
             />
             <XDSSideNavItem
-              label="Getting Started"
+              label="Getting started"
               isSelected={activePage === 'getting-started'}
               onClick={() => setActivePage('getting-started')}
             />
-            <XDSSideNavItem
-              label="What's New"
-              isSelected={activePage === 'whats-new'}
-              onClick={() => setActivePage('whats-new')}
-            />
           </XDSSideNavSection>
 
-          <XDSSideNavSection title="Guides">
-            <XDSSideNavItem label="Principles" />
-            <XDSSideNavItem label="Accessibility" />
-            <XDSSideNavItem label="Theming" />
-            <XDSSideNavItem label="CLI Tools" />
-          </XDSSideNavSection>
-
-          {OVERVIEW_SECTIONS.map(category => (
+          {COMPONENT_CATEGORIES.map(category => (
             <XDSSideNavSection key={category.label} title={category.label}>
               {category.items.map(item => (
                 <XDSSideNavItem
@@ -459,13 +381,9 @@ export default function DocumentationOverviewPage() {
         </XDSSideNav>
       }>
       {activePage === 'home' ? (
-        <OverviewView onSelectPage={setActivePage} />
-      ) : activePage === 'getting-started' ? (
-        <GettingStartedView />
-      ) : activePage === 'whats-new' ? (
-        <WhatsNewView />
+        <OverviewView onSelectComponent={setActivePage} />
       ) : (
-        <OverviewView onSelectPage={setActivePage} />
+        <GettingStartedView />
       )}
     </XDSAppShell>
   );

--- a/packages/cli/templates/pages/documentation/template.doc.mjs
+++ b/packages/cli/templates/pages/documentation/template.doc.mjs
@@ -1,7 +1,7 @@
 /** @type {import('../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'page',
-  name: 'Documentation',
-  description: 'Component documentation page with sidebar navigation, live previews, and anatomy tables.',
+  name: 'Documentation Overview',
+  description: 'Documentation landing page with component category grid, quick links, changelog, and getting started guide.',
   isReady: true,
 };

--- a/packages/cli/templates/pages/documentation/template.doc.mjs
+++ b/packages/cli/templates/pages/documentation/template.doc.mjs
@@ -1,7 +1,7 @@
 /** @type {import('../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'page',
-  name: 'Documentation Overview',
+  name: 'Documentation Home',
   description: 'Documentation landing page with hero banner and component category grid organized by Core, Layout, Navigation, and Form.',
   isReady: true,
 };

--- a/packages/cli/templates/pages/documentation/template.doc.mjs
+++ b/packages/cli/templates/pages/documentation/template.doc.mjs
@@ -2,6 +2,6 @@
 export const doc = {
   type: 'page',
   name: 'Documentation Overview',
-  description: 'Documentation landing page with component category grid, quick links, changelog, and getting started guide.',
+  description: 'Documentation landing page with hero banner and component category grid organized by Core, Layout, Navigation, and Form.',
   isReady: true,
 };


### PR DESCRIPTION
## Summary

- Split the single `Documentation` template into three purpose-built templates so each can be used independently:
  - **Documentation Overview** (`/templates/documentation/`) — landing page with component category grid, quick links, changelog, and getting started guide
  - **Technical Documentation** (`/templates/documentation-technical/`) — API reference with live previews, props tables, code examples, and best practice guidance
  - **Design Documentation** (`/templates/documentation-design/`) — design foundations with typography scale, color palette, spacing tokens, shape/radius reference, and elevation system
- The original `documentation` slug is preserved for the overview template so existing links still work

## Test plan

- [ ] Visit `/templates/documentation/` and verify the overview landing page renders with hero banner, quick links, component category grid, changelog, and getting started/what's new sub-pages
- [ ] Visit `/templates/documentation-technical/` and verify the API reference renders with sidebar navigation, component detail pages (try Button), props table, best practices table, and code examples
- [ ] Visit `/templates/documentation-design/` and verify the design docs render with sidebar navigation and content pages for Typography, Colors, Spacing, Shape, and Elevation
- [ ] Run `node scripts/sync-templates.js` and confirm all three templates appear in the generated registry
- [ ] Verify the templates table at `/templates/` lists all three documentation templates


Made with [Cursor](https://cursor.com)