### PR TITLE
fix: prevent pagination controls from jumping when table row count changes

### DIFF
--- a/packages/core/src/Table/plugins/pagination/useXDSTablePagination.test.tsx
+++ b/packages/core/src/Table/plugins/pagination/useXDSTablePagination.test.tsx
@@ -599,4 +599,47 @@ describe('useXDSTablePagination', () => {
       expect(prevButton).toBeDisabled();
     });
   });
+
+  // ===========================================================================
+  // Stable height wrapper
+  // ===========================================================================
+
+  describe('stable height wrapper', () => {
+    it('wraps the table in a div for stable height when pagination is below', () => {
+      render(<PaginatedTable data={generateItems(30)} pageSize={10} />);
+      const table = screen.getByRole('table');
+      // The table should be inside a wrapper div (not a direct child of the fragment)
+      const wrapper = table.parentElement;
+      expect(wrapper).toBeInstanceOf(HTMLDivElement);
+      expect(wrapper?.tagName).toBe('DIV');
+    });
+
+    it('wraps the table in a div for stable height when pagination is above', () => {
+      render(
+        <PaginatedTable
+          data={generateItems(30)}
+          pageSize={10}
+          position="above"
+        />,
+      );
+      const table = screen.getByRole('table');
+      const wrapper = table.parentElement;
+      expect(wrapper).toBeInstanceOf(HTMLDivElement);
+      expect(wrapper?.tagName).toBe('DIV');
+    });
+
+    it('does not add wrapper when position is none', () => {
+      const {container} = render(
+        <PaginatedTable
+          data={generateItems(30)}
+          pageSize={10}
+          position="none"
+        />,
+      );
+      const table = screen.getByRole('table');
+      // When position is 'none', the table should not have an extra wrapper
+      // (it's returned directly, so its parent is whatever the test container provides)
+      expect(table.parentElement).toBe(container);
+    });
+  });
 });

--- a/packages/core/src/Table/plugins/pagination/useXDSTablePagination.tsx
+++ b/packages/core/src/Table/plugins/pagination/useXDSTablePagination.tsx
@@ -14,7 +14,7 @@
  * - /packages/core/src/Table/index.ts (exports)
  */
 
-import {useMemo, useRef, type ReactNode} from 'react';
+import {useMemo, useRef, useLayoutEffect, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {spacingVars} from '../../../theme/tokens.stylex';
 import {XDSPagination} from '../../../Pagination';
@@ -231,6 +231,34 @@ export function useXDSTablePagination<T extends Record<string, unknown>>(
   const configRef = useRef({paginationProps, position, align});
   configRef.current = {paginationProps, position, align};
 
+  // Track the maximum observed table height to prevent layout jumping
+  // when the last page has fewer rows than a full page. The wrapper
+  // applies this as minHeight so the pagination controls stay put.
+  const maxHeightRef = useRef(0);
+  const tableWrapperRef = useRef<HTMLDivElement>(null);
+
+  // Reset tracked height when pageSize changes since row count differs.
+  const lastPageSizeRef = useRef(pageSize);
+  if (lastPageSizeRef.current !== pageSize) {
+    lastPageSizeRef.current = pageSize;
+    maxHeightRef.current = 0;
+  }
+
+  // After every page change, measure the table and maintain minHeight.
+  // useLayoutEffect runs before paint, preventing a visual flash when
+  // temporarily clearing minHeight to measure natural content height.
+  useLayoutEffect(() => {
+    const node = tableWrapperRef.current;
+    if (node == null) return;
+    // Temporarily remove minHeight to measure natural height
+    node.style.minHeight = '';
+    const height = node.scrollHeight;
+    if (height > maxHeightRef.current) {
+      maxHeightRef.current = height;
+    }
+    node.style.minHeight = `${maxHeightRef.current}px`;
+  });
+
   // Stable plugin object \u2014 created once, reads config via ref.
   return useMemo(
     (): TablePlugin<T> => ({
@@ -268,7 +296,7 @@ export function useXDSTablePagination<T extends Record<string, unknown>>(
         return (
           <>
             {(pos === 'above' || pos === 'both') && makeWrapper('above')}
-            {children}
+            <div ref={tableWrapperRef}>{children}</div>
             {(pos === 'below' || pos === 'both') && makeWrapper('below')}
           </>
         );


### PR DESCRIPTION
## Problem

When navigating a paginated table, the last page often has fewer rows than a full page. This causes the table to shrink in height, making the pagination controls jump upward. Clicking "Previous" then restores a full page, causing them to jump back down — making repeated navigation annoying since the buttons are a moving target.

Demo of the issue: https://pxl.cl/9wZNM

## Solution

Wrap the table in a stable-height container that tracks the maximum observed height. The container's `minHeight` ratchets up to the tallest page seen, keeping the pagination controls in a fixed position regardless of row count changes.

**Key details:**
- Uses `useLayoutEffect` (not `useEffect`) to measure and apply `minHeight` before the browser paints, avoiding any visual flash
- Tracked max height resets when `pageSize` changes (since different page sizes produce different natural heights)
- Zero impact when all pages have the same number of rows — the wrapper is a plain `<div>` with no forced height
- Applied only when pagination controls are rendered (`position !== 'none'`)

## Testing

- All 40 existing pagination plugin tests pass
- All 299 Table tests pass across 13 test files  
- Added 3 new tests verifying the wrapper div exists for `below`, `above`, and `none` positions
- Build passes clean, no lint errors