### PR TITLE
feat(templates): add showcase blocks for navigation sub-components

### DIFF
--- a/packages/cli/templates/blocks/components/HStack/HStackShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/HStack/HStackShowcase.doc.mjs
@@ -1,0 +1,10 @@
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  name: 'HStack',
+  description: 'Demonstrates XDSHStack arranging items horizontally with different gaps and alignments.',
+  isReady: true,
+  isShowcase: true,
+  aspectRatio: 16 / 9,
+  componentsUsed: ['Layout', 'Badge', 'Text'],
+};

--- a/packages/cli/templates/blocks/components/HStack/HStackShowcase.tsx
+++ b/packages/cli/templates/blocks/components/HStack/HStackShowcase.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import {XDSHStack, XDSVStack} from '@xds/core/Layout';
+import {XDSBadge} from '@xds/core/Badge';
+import {XDSText} from '@xds/core/Text';
+
+export default function HStackShowcase() {
+  return (
+    <XDSVStack gap={6}>
+      <XDSVStack gap={2}>
+        <XDSText type="supporting" color="secondary">gap=2, start-aligned</XDSText>
+        <XDSHStack gap={2}>
+          <XDSBadge label="React" />
+          <XDSBadge label="TypeScript" />
+          <XDSBadge label="Node.js" />
+        </XDSHStack>
+      </XDSVStack>
+      <XDSVStack gap={2}>
+        <XDSText type="supporting" color="secondary">gap=4, center-aligned</XDSText>
+        <XDSHStack gap={4} hAlign="center">
+          <XDSBadge label="Design" />
+          <XDSBadge label="Engineering" />
+          <XDSBadge label="Product" />
+        </XDSHStack>
+      </XDSVStack>
+      <XDSVStack gap={2}>
+        <XDSText type="supporting" color="secondary">gap=2, space-between</XDSText>
+        <XDSHStack gap={2} hAlign="between">
+          <XDSBadge label="Start" />
+          <XDSBadge label="Middle" />
+          <XDSBadge label="End" />
+        </XDSHStack>
+      </XDSVStack>
+    </XDSVStack>
+  );
+}

--- a/packages/cli/templates/blocks/components/MobileNavToggle/MobileNavToggleShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/MobileNavToggle/MobileNavToggleShowcase.doc.mjs
@@ -1,0 +1,10 @@
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  name: 'MobileNavToggle',
+  description: 'Demonstrates XDSMobileNavToggle as a standalone hamburger button for opening the mobile navigation drawer.',
+  isReady: true,
+  isShowcase: true,
+  aspectRatio: 1,
+  componentsUsed: ['MobileNav', 'Button', 'SideNav'],
+};

--- a/packages/cli/templates/blocks/components/MobileNavToggle/MobileNavToggleShowcase.tsx
+++ b/packages/cli/templates/blocks/components/MobileNavToggle/MobileNavToggleShowcase.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import {useState} from 'react';
+import {XDSMobileNav} from '@xds/core/MobileNav';
+import {XDSSideNavItem, XDSSideNavSection} from '@xds/core/SideNav';
+import {XDSButton} from '@xds/core/Button';
+
+export default function MobileNavToggleShowcase() {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <div style={{display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 24}}>
+      <XDSButton
+        label="Open navigation"
+        variant="ghost"
+        icon={
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
+          </svg>
+        }
+        isIconOnly
+        onClick={() => setIsOpen(true)}
+      />
+      <XDSMobileNav isOpen={isOpen} onOpenChange={setIsOpen} title="Navigation">
+        <XDSSideNavSection title="Pages">
+          <XDSSideNavItem label="Home" isSelected href="#" />
+          <XDSSideNavItem label="Settings" href="#" />
+        </XDSSideNavSection>
+      </XDSMobileNav>
+    </div>
+  );
+}

--- a/packages/cli/templates/blocks/components/MobileNavToggle/MobileNavToggleShowcase.tsx
+++ b/packages/cli/templates/blocks/components/MobileNavToggle/MobileNavToggleShowcase.tsx
@@ -1,31 +1,38 @@
 'use client';
 
-import {XDSAppShell} from '@xds/core/AppShell';
-import {XDSMobileNav, XDSMobileNavToggle} from '@xds/core/MobileNav';
+import {useState} from 'react';
+import {XDSMobileNav} from '@xds/core/MobileNav';
 import {XDSSideNavItem, XDSSideNavSection} from '@xds/core/SideNav';
+import {XDSButton} from '@xds/core/Button';
+import {XDSIcon} from '@xds/core/Icon';
 import {XDSCenter} from '@xds/core/Center';
-import {XDSText} from '@xds/core/Text';
 import {XDSVStack} from '@xds/core/Layout';
+import {XDSText} from '@xds/core/Text';
 
 export default function MobileNavToggleShowcase() {
+  const [isOpen, setIsOpen] = useState(false);
+
   return (
-    <XDSAppShell
-      mobileNav={
-        <XDSMobileNav header="Navigation">
+    <XDSCenter>
+      <XDSVStack gap={3} hAlign="center">
+        <XDSButton
+          label="Open navigation"
+          variant="ghost"
+          icon={<XDSIcon icon="menu" color="inherit" />}
+          isIconOnly
+          onClick={() => setIsOpen(true)}
+        />
+        <XDSText type="supporting" color="secondary">
+          XDSMobileNavToggle renders this hamburger button automatically inside
+          an AppShell at mobile breakpoints.
+        </XDSText>
+        <XDSMobileNav isOpen={isOpen} onOpenChange={setIsOpen} header="Navigation">
           <XDSSideNavSection title="Pages">
             <XDSSideNavItem label="Home" isSelected href="#" />
             <XDSSideNavItem label="Settings" href="#" />
           </XDSSideNavSection>
         </XDSMobileNav>
-      }>
-      <XDSCenter>
-        <XDSVStack gap={3} hAlign="center">
-          <XDSMobileNavToggle />
-          <XDSText type="supporting" color="secondary">
-            Resize to mobile width to see the toggle
-          </XDSText>
-        </XDSVStack>
-      </XDSCenter>
-    </XDSAppShell>
+      </XDSVStack>
+    </XDSCenter>
   );
 }

--- a/packages/cli/templates/blocks/components/MobileNavToggle/MobileNavToggleShowcase.tsx
+++ b/packages/cli/templates/blocks/components/MobileNavToggle/MobileNavToggleShowcase.tsx
@@ -21,7 +21,7 @@ export default function MobileNavToggleShowcase() {
         isIconOnly
         onClick={() => setIsOpen(true)}
       />
-      <XDSMobileNav isOpen={isOpen} onOpenChange={setIsOpen} title="Navigation">
+      <XDSMobileNav isOpen={isOpen} onOpenChange={setIsOpen} header="Navigation">
         <XDSSideNavSection title="Pages">
           <XDSSideNavItem label="Home" isSelected href="#" />
           <XDSSideNavItem label="Settings" href="#" />

--- a/packages/cli/templates/blocks/components/MobileNavToggle/MobileNavToggleShowcase.tsx
+++ b/packages/cli/templates/blocks/components/MobileNavToggle/MobileNavToggleShowcase.tsx
@@ -4,14 +4,14 @@ import {useState} from 'react';
 import {XDSMobileNav} from '@xds/core/MobileNav';
 import {XDSSideNavItem, XDSSideNavSection} from '@xds/core/SideNav';
 import {XDSButton} from '@xds/core/Button';
-import {XDSCenter} from '@xds/core/Center';
 import {XDSIcon} from '@xds/core/Icon';
+import {XDSSection} from '@xds/core/Layout';
 
 export default function MobileNavToggleShowcase() {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
-    <XDSCenter padding={6}>
+    <XDSSection>
       <XDSButton
         label="Open navigation"
         variant="ghost"
@@ -25,6 +25,6 @@ export default function MobileNavToggleShowcase() {
           <XDSSideNavItem label="Settings" href="#" />
         </XDSSideNavSection>
       </XDSMobileNav>
-    </XDSCenter>
+    </XDSSection>
   );
 }

--- a/packages/cli/templates/blocks/components/MobileNavToggle/MobileNavToggleShowcase.tsx
+++ b/packages/cli/templates/blocks/components/MobileNavToggle/MobileNavToggleShowcase.tsx
@@ -4,20 +4,18 @@ import {useState} from 'react';
 import {XDSMobileNav} from '@xds/core/MobileNav';
 import {XDSSideNavItem, XDSSideNavSection} from '@xds/core/SideNav';
 import {XDSButton} from '@xds/core/Button';
+import {XDSCenter} from '@xds/core/Center';
+import {XDSIcon} from '@xds/core/Icon';
 
 export default function MobileNavToggleShowcase() {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
-    <div style={{display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 24}}>
+    <XDSCenter padding={6}>
       <XDSButton
         label="Open navigation"
         variant="ghost"
-        icon={
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
-            <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
-          </svg>
-        }
+        icon={<XDSIcon icon="menu" color="inherit" />}
         isIconOnly
         onClick={() => setIsOpen(true)}
       />
@@ -27,6 +25,6 @@ export default function MobileNavToggleShowcase() {
           <XDSSideNavItem label="Settings" href="#" />
         </XDSSideNavSection>
       </XDSMobileNav>
-    </div>
+    </XDSCenter>
   );
 }

--- a/packages/cli/templates/blocks/components/MobileNavToggle/MobileNavToggleShowcase.tsx
+++ b/packages/cli/templates/blocks/components/MobileNavToggle/MobileNavToggleShowcase.tsx
@@ -1,30 +1,31 @@
 'use client';
 
-import {useState} from 'react';
-import {XDSMobileNav} from '@xds/core/MobileNav';
+import {XDSAppShell} from '@xds/core/AppShell';
+import {XDSMobileNav, XDSMobileNavToggle} from '@xds/core/MobileNav';
 import {XDSSideNavItem, XDSSideNavSection} from '@xds/core/SideNav';
-import {XDSButton} from '@xds/core/Button';
-import {XDSIcon} from '@xds/core/Icon';
-import {XDSSection} from '@xds/core/Layout';
+import {XDSCenter} from '@xds/core/Center';
+import {XDSText} from '@xds/core/Text';
+import {XDSVStack} from '@xds/core/Layout';
 
 export default function MobileNavToggleShowcase() {
-  const [isOpen, setIsOpen] = useState(false);
-
   return (
-    <XDSSection>
-      <XDSButton
-        label="Open navigation"
-        variant="ghost"
-        icon={<XDSIcon icon="menu" color="inherit" />}
-        isIconOnly
-        onClick={() => setIsOpen(true)}
-      />
-      <XDSMobileNav isOpen={isOpen} onOpenChange={setIsOpen} header="Navigation">
-        <XDSSideNavSection title="Pages">
-          <XDSSideNavItem label="Home" isSelected href="#" />
-          <XDSSideNavItem label="Settings" href="#" />
-        </XDSSideNavSection>
-      </XDSMobileNav>
-    </XDSSection>
+    <XDSAppShell
+      mobileNav={
+        <XDSMobileNav header="Navigation">
+          <XDSSideNavSection title="Pages">
+            <XDSSideNavItem label="Home" isSelected href="#" />
+            <XDSSideNavItem label="Settings" href="#" />
+          </XDSSideNavSection>
+        </XDSMobileNav>
+      }>
+      <XDSCenter>
+        <XDSVStack gap={3} hAlign="center">
+          <XDSMobileNavToggle />
+          <XDSText type="supporting" color="secondary">
+            Resize to mobile width to see the toggle
+          </XDSText>
+        </XDSVStack>
+      </XDSCenter>
+    </XDSAppShell>
   );
 }

--- a/packages/cli/templates/blocks/components/MobileNavToggle/MobileNavToggleShowcase.tsx
+++ b/packages/cli/templates/blocks/components/MobileNavToggle/MobileNavToggleShowcase.tsx
@@ -1,38 +1,30 @@
 'use client';
 
-import {useState} from 'react';
-import {XDSMobileNav} from '@xds/core/MobileNav';
+import {XDSAppShell} from '@xds/core/AppShell';
+import {XDSMobileNavToggle} from '@xds/core/MobileNav';
 import {XDSSideNavItem, XDSSideNavSection} from '@xds/core/SideNav';
-import {XDSButton} from '@xds/core/Button';
-import {XDSIcon} from '@xds/core/Icon';
 import {XDSCenter} from '@xds/core/Center';
 import {XDSVStack} from '@xds/core/Layout';
 import {XDSText} from '@xds/core/Text';
 
 export default function MobileNavToggleShowcase() {
-  const [isOpen, setIsOpen] = useState(false);
-
   return (
-    <XDSCenter>
-      <XDSVStack gap={3} hAlign="center">
-        <XDSButton
-          label="Open navigation"
-          variant="ghost"
-          icon={<XDSIcon icon="menu" color="inherit" />}
-          isIconOnly
-          onClick={() => setIsOpen(true)}
-        />
-        <XDSText type="supporting" color="secondary">
-          XDSMobileNavToggle renders this hamburger button automatically inside
-          an AppShell at mobile breakpoints.
-        </XDSText>
-        <XDSMobileNav isOpen={isOpen} onOpenChange={setIsOpen} header="Navigation">
-          <XDSSideNavSection title="Pages">
-            <XDSSideNavItem label="Home" isSelected href="#" />
-            <XDSSideNavItem label="Settings" href="#" />
-          </XDSSideNavSection>
-        </XDSMobileNav>
-      </XDSVStack>
-    </XDSCenter>
+    <XDSAppShell
+      mobileNav={{hasToggle: false, breakpoint: 'lg'}}
+      sideNav={
+        <XDSSideNavSection title="Pages">
+          <XDSSideNavItem label="Home" isSelected href="#" />
+          <XDSSideNavItem label="Settings" href="#" />
+        </XDSSideNavSection>
+      }>
+      <XDSCenter>
+        <XDSVStack gap={3} hAlign="center">
+          <XDSMobileNavToggle />
+          <XDSText type="supporting" color="secondary">
+            Resize below the large breakpoint to see the toggle
+          </XDSText>
+        </XDSVStack>
+      </XDSCenter>
+    </XDSAppShell>
   );
 }

--- a/packages/cli/templates/blocks/components/SideNav/SideNavEndContent.tsx
+++ b/packages/cli/templates/blocks/components/SideNav/SideNavEndContent.tsx
@@ -45,49 +45,47 @@ function UserGroupIcon(props: ComponentProps<'svg'>) {
 
 export default function SideNavEndContent() {
   return (
-    <div style={{height: 400}}>
-      <XDSSideNav
-        header={<XDSSideNavHeading heading="My App" headingHref="/" />}>
-        <XDSSideNavSection title="Navigation" isHeaderHidden>
-          <XDSSideNavItem
-            label="Dashboard"
-            icon={HomeIcon}
-            isSelected
-            href="/dashboard"
-            endContent={
-              <XDSMoreMenu
-                size="sm"
-                items={[
-                  {label: 'Pin to top', onClick: () => {}},
-                  {label: 'Rename', onClick: () => {}},
-                ]}
-              />
-            }
-          />
-          <XDSSideNavItem
-            label="Projects"
-            icon={FolderIcon}
-            href="/projects"
-            endContent={<XDSBadge label={12} />}
-          />
-          <XDSSideNavItem
-            label="Analytics"
-            icon={ChartBarIcon}
-            href="/analytics"
-            endContent={<XDSBadge label="New" />}
-          />
-          <XDSSideNavItem
-            label="Team"
-            icon={UserGroupIcon}
-            href="/team"
-            endContent={
-              <XDSText type="supporting" color="secondary">
-                8 members
-              </XDSText>
-            }
-          />
-        </XDSSideNavSection>
-      </XDSSideNav>
-    </div>
+    <XDSSideNav
+      header={<XDSSideNavHeading heading="My App" headingHref="/" />}>
+      <XDSSideNavSection title="Navigation" isHeaderHidden>
+        <XDSSideNavItem
+          label="Dashboard"
+          icon={HomeIcon}
+          isSelected
+          href="/dashboard"
+          endContent={
+            <XDSMoreMenu
+              size="sm"
+              items={[
+                {label: 'Pin to top', onClick: () => {}},
+                {label: 'Rename', onClick: () => {}},
+              ]}
+            />
+          }
+        />
+        <XDSSideNavItem
+          label="Projects"
+          icon={FolderIcon}
+          href="/projects"
+          endContent={<XDSBadge label={12} />}
+        />
+        <XDSSideNavItem
+          label="Analytics"
+          icon={ChartBarIcon}
+          href="/analytics"
+          endContent={<XDSBadge label="New" />}
+        />
+        <XDSSideNavItem
+          label="Team"
+          icon={UserGroupIcon}
+          href="/team"
+          endContent={
+            <XDSText type="supporting" color="secondary">
+              8 members
+            </XDSText>
+          }
+        />
+      </XDSSideNavSection>
+    </XDSSideNav>
   );
 }

--- a/packages/cli/templates/blocks/components/SideNav/SideNavNestedItems.tsx
+++ b/packages/cli/templates/blocks/components/SideNav/SideNavNestedItems.tsx
@@ -27,20 +27,18 @@ function CogIcon(props: ComponentProps<'svg'>) {
 
 export default function SideNavNestedItems() {
   return (
-    <div style={{height: 400}}>
-      <XDSSideNav header={<XDSSideNavHeading heading="My App" />}>
-        <XDSSideNavSection title="Main">
-          <XDSSideNavItem label="Dashboard" icon={HomeIcon} isSelected />
-          <XDSSideNavItem label="Settings" icon={CogIcon}>
-            <XDSSideNavItem label="General" href="/settings/general" />
-            <XDSSideNavItem label="Security" href="/settings/security" />
-            <XDSSideNavItem
-              label="Notifications"
-              href="/settings/notifications"
-            />
-          </XDSSideNavItem>
-        </XDSSideNavSection>
-      </XDSSideNav>
-    </div>
+    <XDSSideNav header={<XDSSideNavHeading heading="My App" />}>
+      <XDSSideNavSection title="Main">
+        <XDSSideNavItem label="Dashboard" icon={HomeIcon} isSelected />
+        <XDSSideNavItem label="Settings" icon={CogIcon}>
+          <XDSSideNavItem label="General" href="/settings/general" />
+          <XDSSideNavItem label="Security" href="/settings/security" />
+          <XDSSideNavItem
+            label="Notifications"
+            href="/settings/notifications"
+          />
+        </XDSSideNavItem>
+      </XDSSideNavSection>
+    </XDSSideNav>
   );
 }

--- a/packages/cli/templates/blocks/components/SideNav/SideNavWithHeaderMenu.tsx
+++ b/packages/cli/templates/blocks/components/SideNav/SideNavWithHeaderMenu.tsx
@@ -29,45 +29,43 @@ function CogIcon(props: ComponentProps<'svg'>) {
 
 export default function SideNavWithHeaderMenu() {
   return (
-    <div style={{height: 400}}>
-      <XDSSideNav
-        header={
-          <XDSSideNavHeading
-            icon={
-              <XDSNavIcon
-                icon={
-                  <svg
-                    style={{width: 16, height: 16}}
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    strokeWidth={1.5}
-                    stroke="currentColor">
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      d="M21 7.5l-9-5.25L3 7.5m18 0l-9 5.25m9-5.25v9l-9 5.25M3 7.5l9 5.25M3 7.5v9l9 5.25m0-9v9"
-                    />
-                  </svg>
-                }
-              />
-            }
-            heading="Product Name"
-            subheading="Business Account"
-            menu={
-              <>
-                <XDSListItem label="Personal Account" href="#" />
-                <XDSListItem label="Acme Corp" href="#" />
-                <XDSListItem label="Add account" href="#" />
-                <XDSListItem label="Sign out" href="#" />
-              </>
-            }
-          />
-        }>
-        <XDSSideNavSection title="Navigation">
-          <XDSSideNavItem label="Dashboard" icon={HomeIcon} isSelected />
-          <XDSSideNavItem label="Settings" icon={CogIcon} />
-        </XDSSideNavSection>
-      </XDSSideNav>
-    </div>
+    <XDSSideNav
+      header={
+        <XDSSideNavHeading
+          icon={
+            <XDSNavIcon
+              icon={
+                <svg
+                  style={{width: 16, height: 16}}
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  strokeWidth={1.5}
+                  stroke="currentColor">
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M21 7.5l-9-5.25L3 7.5m18 0l-9 5.25m9-5.25v9l-9 5.25M3 7.5l9 5.25M3 7.5v9l9 5.25m0-9v9"
+                  />
+                </svg>
+              }
+            />
+          }
+          heading="Product Name"
+          subheading="Business Account"
+          menu={
+            <>
+              <XDSListItem label="Personal Account" href="#" />
+              <XDSListItem label="Acme Corp" href="#" />
+              <XDSListItem label="Add account" href="#" />
+              <XDSListItem label="Sign out" href="#" />
+            </>
+          }
+        />
+      }>
+      <XDSSideNavSection title="Navigation">
+        <XDSSideNavItem label="Dashboard" icon={HomeIcon} isSelected />
+        <XDSSideNavItem label="Settings" icon={CogIcon} />
+      </XDSSideNavSection>
+    </XDSSideNav>
   );
 }

--- a/packages/cli/templates/blocks/components/SideNavCollapseButton/SideNavCollapseButtonShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/SideNavCollapseButton/SideNavCollapseButtonShowcase.doc.mjs
@@ -1,0 +1,10 @@
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  name: 'SideNavCollapseButton',
+  description: 'Demonstrates XDSSideNavCollapseButton inside a collapsible SideNav.',
+  isReady: true,
+  isShowcase: true,
+  aspectRatio: 4 / 3,
+  componentsUsed: ['SideNav', 'SideNavCollapseButton', 'SideNavItem', 'SideNavSection'],
+};

--- a/packages/cli/templates/blocks/components/SideNavCollapseButton/SideNavCollapseButtonShowcase.tsx
+++ b/packages/cli/templates/blocks/components/SideNavCollapseButton/SideNavCollapseButtonShowcase.tsx
@@ -30,7 +30,7 @@ export default function SideNavCollapseButtonShowcase() {
     <XDSSideNav
       collapsible={{hasButton: false}}
       header={<XDSSideNavHeading heading="Workspace" />}
-      footer={<XDSSideNavCollapseButton />}
+      footerIcons={<XDSSideNavCollapseButton />}
     >
       <XDSSideNavSection title="Main">
         <XDSSideNavItem label="Home" icon={HomeIcon} isSelected href="#" />

--- a/packages/cli/templates/blocks/components/SideNavCollapseButton/SideNavCollapseButtonShowcase.tsx
+++ b/packages/cli/templates/blocks/components/SideNavCollapseButton/SideNavCollapseButtonShowcase.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import type {ComponentProps} from 'react';
+import {
+  XDSSideNav,
+  XDSSideNavCollapseButton,
+  XDSSideNavHeading,
+  XDSSideNavItem,
+  XDSSideNavSection,
+} from '@xds/core/SideNav';
+
+function HomeIcon(props: ComponentProps<'svg'>) {
+  return (
+    <svg fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="m2.25 12 8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25" />
+    </svg>
+  );
+}
+
+function FolderIcon(props: ComponentProps<'svg'>) {
+  return (
+    <svg fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 12.75V12A2.25 2.25 0 0 1 4.5 9.75h15A2.25 2.25 0 0 1 21.75 12v.75m-8.69-6.44-2.12-2.12a1.5 1.5 0 0 0-1.061-.44H4.5A2.25 2.25 0 0 0 2.25 6v12a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18V9a2.25 2.25 0 0 0-2.25-2.25h-5.379a1.5 1.5 0 0 1-1.06-.44Z" />
+    </svg>
+  );
+}
+
+export default function SideNavCollapseButtonShowcase() {
+  return (
+    <div style={{height: 320}}>
+      <XDSSideNav
+        collapsible
+        header={<XDSSideNavHeading heading="Workspace" />}
+        footer={<XDSSideNavCollapseButton />}
+      >
+        <XDSSideNavSection title="Main">
+          <XDSSideNavItem label="Home" icon={HomeIcon} isSelected href="#" />
+          <XDSSideNavItem label="Projects" icon={FolderIcon} href="#" />
+        </XDSSideNavSection>
+      </XDSSideNav>
+    </div>
+  );
+}

--- a/packages/cli/templates/blocks/components/SideNavCollapseButton/SideNavCollapseButtonShowcase.tsx
+++ b/packages/cli/templates/blocks/components/SideNavCollapseButton/SideNavCollapseButtonShowcase.tsx
@@ -28,7 +28,7 @@ function FolderIcon(props: ComponentProps<'svg'>) {
 export default function SideNavCollapseButtonShowcase() {
   return (
     <XDSSideNav
-      collapsible
+      collapsible={{hasButton: false}}
       header={<XDSSideNavHeading heading="Workspace" />}
       footer={<XDSSideNavCollapseButton />}
     >

--- a/packages/cli/templates/blocks/components/SideNavCollapseButton/SideNavCollapseButtonShowcase.tsx
+++ b/packages/cli/templates/blocks/components/SideNavCollapseButton/SideNavCollapseButtonShowcase.tsx
@@ -27,17 +27,15 @@ function FolderIcon(props: ComponentProps<'svg'>) {
 
 export default function SideNavCollapseButtonShowcase() {
   return (
-    <div style={{height: 320}}>
-      <XDSSideNav
-        collapsible
-        header={<XDSSideNavHeading heading="Workspace" />}
-        footer={<XDSSideNavCollapseButton />}
-      >
-        <XDSSideNavSection title="Main">
-          <XDSSideNavItem label="Home" icon={HomeIcon} isSelected href="#" />
-          <XDSSideNavItem label="Projects" icon={FolderIcon} href="#" />
-        </XDSSideNavSection>
-      </XDSSideNav>
-    </div>
+    <XDSSideNav
+      collapsible
+      header={<XDSSideNavHeading heading="Workspace" />}
+      footer={<XDSSideNavCollapseButton />}
+    >
+      <XDSSideNavSection title="Main">
+        <XDSSideNavItem label="Home" icon={HomeIcon} isSelected href="#" />
+        <XDSSideNavItem label="Projects" icon={FolderIcon} href="#" />
+      </XDSSideNavSection>
+    </XDSSideNav>
   );
 }

--- a/packages/cli/templates/blocks/components/SideNavHeading/SideNavHeadingShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/SideNavHeading/SideNavHeadingShowcase.doc.mjs
@@ -1,0 +1,10 @@
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  name: 'SideNavHeading',
+  description: 'Demonstrates XDSSideNavHeading with an app name, logo icon, superheading, and subheading.',
+  isReady: true,
+  isShowcase: true,
+  aspectRatio: 4 / 3,
+  componentsUsed: ['SideNav', 'SideNavHeading'],
+};

--- a/packages/cli/templates/blocks/components/SideNavHeading/SideNavHeadingShowcase.tsx
+++ b/packages/cli/templates/blocks/components/SideNavHeading/SideNavHeadingShowcase.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import {XDSSideNav, XDSSideNavHeading} from '@xds/core/SideNav';
+import {XDSHStack} from '@xds/core/Layout';
 
 function AppIcon() {
   return (
@@ -12,7 +13,7 @@ function AppIcon() {
 
 export default function SideNavHeadingShowcase() {
   return (
-    <div style={{display: 'flex', gap: 24}}>
+    <XDSHStack gap={6}>
       <XDSSideNav
         header={
           <XDSSideNavHeading
@@ -33,6 +34,6 @@ export default function SideNavHeadingShowcase() {
           />
         }
       />
-    </div>
+    </XDSHStack>
   );
 }

--- a/packages/cli/templates/blocks/components/SideNavHeading/SideNavHeadingShowcase.tsx
+++ b/packages/cli/templates/blocks/components/SideNavHeading/SideNavHeadingShowcase.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import {XDSSideNav, XDSSideNavHeading, XDSSideNavItem, XDSSideNavSection} from '@xds/core/SideNav';
+import {XDSSideNav, XDSSideNavHeading} from '@xds/core/SideNav';
 import {XDSHStack} from '@xds/core/Layout';
 
 function AppIcon() {
@@ -22,9 +22,7 @@ export default function SideNavHeadingShowcase() {
             headingHref="/"
           />
         }>
-        <XDSSideNavSection title="Menu">
-          <XDSSideNavItem label="Overview" href="#" isSelected />
-        </XDSSideNavSection>
+        {null}
       </XDSSideNav>
       <XDSSideNav
         header={
@@ -36,9 +34,7 @@ export default function SideNavHeadingShowcase() {
             headingHref="/"
           />
         }>
-        <XDSSideNavSection title="Menu">
-          <XDSSideNavItem label="Overview" href="#" isSelected />
-        </XDSSideNavSection>
+        {null}
       </XDSSideNav>
     </XDSHStack>
   );

--- a/packages/cli/templates/blocks/components/SideNavHeading/SideNavHeadingShowcase.tsx
+++ b/packages/cli/templates/blocks/components/SideNavHeading/SideNavHeadingShowcase.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import {XDSSideNav, XDSSideNavHeading} from '@xds/core/SideNav';
+import {XDSSideNav, XDSSideNavHeading, XDSSideNavItem, XDSSideNavSection} from '@xds/core/SideNav';
 import {XDSHStack} from '@xds/core/Layout';
 
 function AppIcon() {
@@ -21,8 +21,11 @@ export default function SideNavHeadingShowcase() {
             icon={<AppIcon />}
             headingHref="/"
           />
-        }
-      />
+        }>
+        <XDSSideNavSection title="Menu">
+          <XDSSideNavItem label="Overview" href="#" isSelected />
+        </XDSSideNavSection>
+      </XDSSideNav>
       <XDSSideNav
         header={
           <XDSSideNavHeading
@@ -32,8 +35,11 @@ export default function SideNavHeadingShowcase() {
             subheading="Production"
             headingHref="/"
           />
-        }
-      />
+        }>
+        <XDSSideNavSection title="Menu">
+          <XDSSideNavItem label="Overview" href="#" isSelected />
+        </XDSSideNavSection>
+      </XDSSideNav>
     </XDSHStack>
   );
 }

--- a/packages/cli/templates/blocks/components/SideNavHeading/SideNavHeadingShowcase.tsx
+++ b/packages/cli/templates/blocks/components/SideNavHeading/SideNavHeadingShowcase.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import {XDSSideNav, XDSSideNavHeading} from '@xds/core/SideNav';
+
+function AppIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6A2.25 2.25 0 0 1 6 3.75h2.25A2.25 2.25 0 0 1 10.5 6v2.25a2.25 2.25 0 0 1-2.25 2.25H6a2.25 2.25 0 0 1-2.25-2.25V6ZM3.75 15.75A2.25 2.25 0 0 1 6 13.5h2.25a2.25 2.25 0 0 1 2.25 2.25V18a2.25 2.25 0 0 1-2.25 2.25H6A2.25 2.25 0 0 1 3.75 18v-2.25ZM13.5 6a2.25 2.25 0 0 1 2.25-2.25H18A2.25 2.25 0 0 1 20.25 6v2.25A2.25 2.25 0 0 1 18 10.5h-2.25a2.25 2.25 0 0 1-2.25-2.25V6ZM13.5 15.75a2.25 2.25 0 0 1 2.25-2.25H18a2.25 2.25 0 0 1 2.25 2.25V18A2.25 2.25 0 0 1 18 20.25h-2.25a2.25 2.25 0 0 1-2.25-2.25v-2.25Z" />
+    </svg>
+  );
+}
+
+export default function SideNavHeadingShowcase() {
+  return (
+    <div style={{display: 'flex', gap: 24}}>
+      <XDSSideNav
+        header={
+          <XDSSideNavHeading
+            heading="Analytics"
+            icon={<AppIcon />}
+            headingHref="/"
+          />
+        }
+      />
+      <XDSSideNav
+        header={
+          <XDSSideNavHeading
+            heading="Analytics"
+            icon={<AppIcon />}
+            superheading="Acme Corp"
+            subheading="Production"
+            headingHref="/"
+          />
+        }
+      />
+    </div>
+  );
+}

--- a/packages/cli/templates/blocks/components/SideNavItem/SideNavItemShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/SideNavItem/SideNavItemShowcase.doc.mjs
@@ -1,0 +1,10 @@
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  name: 'SideNavItem',
+  description: 'Demonstrates XDSSideNavItem with selected, icon, disabled, and nested states.',
+  isReady: true,
+  isShowcase: true,
+  aspectRatio: 4 / 3,
+  componentsUsed: ['SideNav', 'SideNavItem', 'SideNavSection'],
+};

--- a/packages/cli/templates/blocks/components/SideNavItem/SideNavItemShowcase.tsx
+++ b/packages/cli/templates/blocks/components/SideNavItem/SideNavItemShowcase.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import type {ComponentProps} from 'react';
+import {
+  XDSSideNav,
+  XDSSideNavItem,
+  XDSSideNavSection,
+} from '@xds/core/SideNav';
+import {XDSBadge} from '@xds/core/Badge';
+
+function InboxIcon(props: ComponentProps<'svg'>) {
+  return (
+    <svg fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 13.5h3.86a2.25 2.25 0 0 1 2.012 1.244l.256.512a2.25 2.25 0 0 0 2.013 1.244h3.218a2.25 2.25 0 0 0 2.013-1.244l.256-.512a2.25 2.25 0 0 1 2.013-1.244h3.859m-19.5.338V18a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18v-4.162c0-.224-.034-.447-.1-.661L19.24 5.338a2.25 2.25 0 0 0-2.15-1.588H6.911a2.25 2.25 0 0 0-2.15 1.588L2.35 13.177a2.25 2.25 0 0 0-.1.661Z" />
+    </svg>
+  );
+}
+
+function DocumentIcon(props: ComponentProps<'svg'>) {
+  return (
+    <svg fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" />
+    </svg>
+  );
+}
+
+function CogIcon(props: ComponentProps<'svg'>) {
+  return (
+    <svg fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 0 1 1.37.49l1.296 2.247a1.125 1.125 0 0 1-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.723 7.723 0 0 1 0 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.247a1.125 1.125 0 0 1-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 0 1-.22.128c-.331.183-.581.495-.644.869l-.213 1.281c-.09.543-.56.94-1.11.94h-2.594c-.55 0-1.019-.398-1.11-.94l-.212-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 0 1-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 0 1-1.369-.49l-1.297-2.247a1.125 1.125 0 0 1 .26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 0 1 0-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 0 1-.26-1.43l1.297-2.247a1.125 1.125 0 0 1 1.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869l.214-1.28Z" />
+      <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
+    </svg>
+  );
+}
+
+export default function SideNavItemShowcase() {
+  return (
+    <div style={{height: 360}}>
+      <XDSSideNav>
+        <XDSSideNavSection title="Navigation">
+          <XDSSideNavItem
+            label="Inbox"
+            icon={InboxIcon}
+            isSelected
+            href="#"
+            endContent={<XDSBadge label="12" />}
+          />
+          <XDSSideNavItem
+            label="Documents"
+            icon={DocumentIcon}
+            href="#"
+          />
+          <XDSSideNavItem
+            label="Settings"
+            icon={CogIcon}
+            href="#"
+            isDisabled
+          />
+        </XDSSideNavSection>
+      </XDSSideNav>
+    </div>
+  );
+}

--- a/packages/cli/templates/blocks/components/SideNavItem/SideNavItemShowcase.tsx
+++ b/packages/cli/templates/blocks/components/SideNavItem/SideNavItemShowcase.tsx
@@ -1,11 +1,7 @@
 'use client';
 
 import type {ComponentProps} from 'react';
-import {
-  XDSSideNav,
-  XDSSideNavItem,
-  XDSSideNavSection,
-} from '@xds/core/SideNav';
+import {XDSSideNav, XDSSideNavItem} from '@xds/core/SideNav';
 import {XDSBadge} from '@xds/core/Badge';
 
 function InboxIcon(props: ComponentProps<'svg'>) {
@@ -36,26 +32,24 @@ function CogIcon(props: ComponentProps<'svg'>) {
 export default function SideNavItemShowcase() {
   return (
     <XDSSideNav>
-      <XDSSideNavSection title="Navigation">
-        <XDSSideNavItem
-          label="Inbox"
-          icon={InboxIcon}
-          isSelected
-          href="#"
-          endContent={<XDSBadge label="12" />}
-        />
-        <XDSSideNavItem
-          label="Documents"
-          icon={DocumentIcon}
-          href="#"
-        />
-        <XDSSideNavItem
-          label="Settings"
-          icon={CogIcon}
-          href="#"
-          isDisabled
-        />
-      </XDSSideNavSection>
+      <XDSSideNavItem
+        label="Inbox"
+        icon={InboxIcon}
+        isSelected
+        href="#"
+        endContent={<XDSBadge label="12" />}
+      />
+      <XDSSideNavItem
+        label="Documents"
+        icon={DocumentIcon}
+        href="#"
+      />
+      <XDSSideNavItem
+        label="Settings"
+        icon={CogIcon}
+        href="#"
+        isDisabled
+      />
     </XDSSideNav>
   );
 }

--- a/packages/cli/templates/blocks/components/SideNavItem/SideNavItemShowcase.tsx
+++ b/packages/cli/templates/blocks/components/SideNavItem/SideNavItemShowcase.tsx
@@ -35,29 +35,27 @@ function CogIcon(props: ComponentProps<'svg'>) {
 
 export default function SideNavItemShowcase() {
   return (
-    <div style={{height: 360}}>
-      <XDSSideNav>
-        <XDSSideNavSection title="Navigation">
-          <XDSSideNavItem
-            label="Inbox"
-            icon={InboxIcon}
-            isSelected
-            href="#"
-            endContent={<XDSBadge label="12" />}
-          />
-          <XDSSideNavItem
-            label="Documents"
-            icon={DocumentIcon}
-            href="#"
-          />
-          <XDSSideNavItem
-            label="Settings"
-            icon={CogIcon}
-            href="#"
-            isDisabled
-          />
-        </XDSSideNavSection>
-      </XDSSideNav>
-    </div>
+    <XDSSideNav>
+      <XDSSideNavSection title="Navigation">
+        <XDSSideNavItem
+          label="Inbox"
+          icon={InboxIcon}
+          isSelected
+          href="#"
+          endContent={<XDSBadge label="12" />}
+        />
+        <XDSSideNavItem
+          label="Documents"
+          icon={DocumentIcon}
+          href="#"
+        />
+        <XDSSideNavItem
+          label="Settings"
+          icon={CogIcon}
+          href="#"
+          isDisabled
+        />
+      </XDSSideNavSection>
+    </XDSSideNav>
   );
 }

--- a/packages/cli/templates/blocks/components/SideNavSection/SideNavSectionShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/SideNavSection/SideNavSectionShowcase.doc.mjs
@@ -1,0 +1,10 @@
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  name: 'SideNavSection',
+  description: 'Demonstrates XDSSideNavSection with titled groups of navigation items.',
+  isReady: true,
+  isShowcase: true,
+  aspectRatio: 4 / 3,
+  componentsUsed: ['SideNav', 'SideNavSection', 'SideNavItem'],
+};

--- a/packages/cli/templates/blocks/components/SideNavSection/SideNavSectionShowcase.tsx
+++ b/packages/cli/templates/blocks/components/SideNavSection/SideNavSectionShowcase.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import type {ComponentProps} from 'react';
+import {
+  XDSSideNav,
+  XDSSideNavItem,
+  XDSSideNavSection,
+} from '@xds/core/SideNav';
+
+function HomeIcon(props: ComponentProps<'svg'>) {
+  return (
+    <svg fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="m2.25 12 8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25" />
+    </svg>
+  );
+}
+
+function ChartIcon(props: ComponentProps<'svg'>) {
+  return (
+    <svg fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z" />
+    </svg>
+  );
+}
+
+function UserIcon(props: ComponentProps<'svg'>) {
+  return (
+    <svg fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.501 20.118a7.5 7.5 0 0 1 14.998 0A17.933 17.933 0 0 1 12 21.75c-2.676 0-5.216-.584-7.499-1.632Z" />
+    </svg>
+  );
+}
+
+function CogIcon(props: ComponentProps<'svg'>) {
+  return (
+    <svg fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 0 1 1.37.49l1.296 2.247a1.125 1.125 0 0 1-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.723 7.723 0 0 1 0 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.247a1.125 1.125 0 0 1-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 0 1-.22.128c-.331.183-.581.495-.644.869l-.213 1.281c-.09.543-.56.94-1.11.94h-2.594c-.55 0-1.019-.398-1.11-.94l-.212-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 0 1-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 0 1-1.369-.49l-1.297-2.247a1.125 1.125 0 0 1 .26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 0 1 0-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 0 1-.26-1.43l1.297-2.247a1.125 1.125 0 0 1 1.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869l.214-1.28Z" />
+      <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
+    </svg>
+  );
+}
+
+export default function SideNavSectionShowcase() {
+  return (
+    <div style={{height: 400}}>
+      <XDSSideNav>
+        <XDSSideNavSection title="Overview">
+          <XDSSideNavItem label="Dashboard" icon={HomeIcon} isSelected href="#" />
+          <XDSSideNavItem label="Analytics" icon={ChartIcon} href="#" />
+        </XDSSideNavSection>
+        <XDSSideNavSection title="Account">
+          <XDSSideNavItem label="Profile" icon={UserIcon} href="#" />
+          <XDSSideNavItem label="Settings" icon={CogIcon} href="#" />
+        </XDSSideNavSection>
+      </XDSSideNav>
+    </div>
+  );
+}

--- a/packages/cli/templates/blocks/components/SideNavSection/SideNavSectionShowcase.tsx
+++ b/packages/cli/templates/blocks/components/SideNavSection/SideNavSectionShowcase.tsx
@@ -42,17 +42,15 @@ function CogIcon(props: ComponentProps<'svg'>) {
 
 export default function SideNavSectionShowcase() {
   return (
-    <div style={{height: 400}}>
-      <XDSSideNav>
-        <XDSSideNavSection title="Overview">
-          <XDSSideNavItem label="Dashboard" icon={HomeIcon} isSelected href="#" />
-          <XDSSideNavItem label="Analytics" icon={ChartIcon} href="#" />
-        </XDSSideNavSection>
-        <XDSSideNavSection title="Account">
-          <XDSSideNavItem label="Profile" icon={UserIcon} href="#" />
-          <XDSSideNavItem label="Settings" icon={CogIcon} href="#" />
-        </XDSSideNavSection>
-      </XDSSideNav>
-    </div>
+    <XDSSideNav>
+      <XDSSideNavSection title="Overview">
+        <XDSSideNavItem label="Dashboard" icon={HomeIcon} isSelected href="#" />
+        <XDSSideNavItem label="Analytics" icon={ChartIcon} href="#" />
+      </XDSSideNavSection>
+      <XDSSideNavSection title="Account">
+        <XDSSideNavItem label="Profile" icon={UserIcon} href="#" />
+        <XDSSideNavItem label="Settings" icon={CogIcon} href="#" />
+      </XDSSideNavSection>
+    </XDSSideNav>
   );
 }

--- a/packages/cli/templates/blocks/components/TopNav/TopNavCenteredNavigation.tsx
+++ b/packages/cli/templates/blocks/components/TopNav/TopNavCenteredNavigation.tsx
@@ -3,20 +3,13 @@
 import {XDSTopNav, XDSTopNavHeading, XDSTopNavItem} from '@xds/core/TopNav';
 import {XDSNavIcon} from '@xds/core/NavIcon';
 import {XDSButton} from '@xds/core/Button';
+import {XDSIcon} from '@xds/core/Icon';
 
 function CubeIcon() {
   return (
     <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
       <path strokeLinecap="round" strokeLinejoin="round" d="M21 16.5V7.914a1.5 1.5 0 0 0-.75-1.299l-7.5-4.329a1.5 1.5 0 0 0-1.5 0l-7.5 4.33A1.5 1.5 0 0 0 3 7.913V16.5a1.5 1.5 0 0 0 .75 1.3l7.5 4.328a1.5 1.5 0 0 0 1.5 0l7.5-4.329A1.5 1.5 0 0 0 21 16.5Z" />
       <path strokeLinecap="round" strokeLinejoin="round" d="m3.75 7.5 8.25 4.764 8.25-4.764M12 22.089V12.264" />
-    </svg>
-  );
-}
-
-function SearchIcon() {
-  return (
-    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
-      <path strokeLinecap="round" strokeLinejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z" />
     </svg>
   );
 }
@@ -52,7 +45,7 @@ export default function TopNavCenteredNavigation() {
           <XDSButton
             label="Search"
             variant="ghost"
-            icon={<SearchIcon />}
+            icon={<XDSIcon icon="search" color="inherit" />}
             isIconOnly
           />
           <XDSButton

--- a/packages/cli/templates/blocks/components/TopNav/TopNavEnterpriseDashboard.tsx
+++ b/packages/cli/templates/blocks/components/TopNav/TopNavEnterpriseDashboard.tsx
@@ -3,6 +3,7 @@
 import {XDSTopNav, XDSTopNavHeading, XDSTopNavItem} from '@xds/core/TopNav';
 import {XDSNavIcon} from '@xds/core/NavIcon';
 import {XDSButton} from '@xds/core/Button';
+import {XDSIcon} from '@xds/core/Icon';
 
 function ChartIcon() {
   return (
@@ -33,14 +34,6 @@ function CogIcon() {
     <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
       <path strokeLinecap="round" strokeLinejoin="round" d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.646.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 0 1 1.37.49l1.296 2.247a1.125 1.125 0 0 1-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.723 7.723 0 0 1 0 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.247a1.125 1.125 0 0 1-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 0 1-.22.128c-.333.183-.582.495-.644.869l-.213 1.281c-.09.543-.56.94-1.11.94h-2.594c-.55 0-1.019-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 0 1-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 0 1-1.369-.49l-1.297-2.247a1.125 1.125 0 0 1 .26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 0 1 0-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 0 1-.26-1.43l1.297-2.247a1.125 1.125 0 0 1 1.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869l.214-1.28Z" />
       <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
-    </svg>
-  );
-}
-
-function SearchIcon() {
-  return (
-    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
-      <path strokeLinecap="round" strokeLinejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z" />
     </svg>
   );
 }
@@ -94,7 +87,7 @@ export default function TopNavEnterpriseDashboard() {
           <XDSButton
             label="Search"
             variant="ghost"
-            icon={<SearchIcon />}
+            icon={<XDSIcon icon="search" color="inherit" />}
             isIconOnly
           />
           <XDSButton

--- a/packages/cli/templates/blocks/components/TopNav/TopNavMegaMenu.tsx
+++ b/packages/cli/templates/blocks/components/TopNav/TopNavMegaMenu.tsx
@@ -62,76 +62,74 @@ function GlobeIcon() {
 
 export default function TopNavMegaMenu() {
   return (
-    <div style={{position: 'relative'}}>
-      <XDSTopNav
-        label="Marketing navigation"
-        heading={
-          <XDSTopNavHeading
-            heading="Acme"
-            logo={<XDSNavIcon icon={<CubeIcon />} />}
-            href="#"
-          />
-        }
-        startContent={
-          <>
-            <XDSTopNavMegaMenu
-              label="Products"
-              items={
-                <>
-                  <XDSTopNavMegaMenuItem
-                    title="Analytics"
-                    description="Track and analyze user behavior across your apps"
-                    icon={<ChartIcon />}
-                    href="#analytics"
-                  />
-                  <XDSTopNavMegaMenuItem
-                    title="Security"
-                    description="Enterprise-grade protection for your data"
-                    icon={<ShieldIcon />}
-                    href="#security"
-                  />
-                  <XDSTopNavMegaMenuItem
-                    title="Automation"
-                    description="Streamline workflows with intelligent tools"
-                    icon={<BoltIcon />}
-                    href="#automation"
-                  />
-                  <XDSTopNavMegaMenuItem
-                    title="Developer Tools"
-                    description="APIs, SDKs, and CLI for integration"
-                    icon={<CodeIcon />}
-                    href="#dev-tools"
-                  />
-                  <XDSTopNavMegaMenuItem
-                    title="Global Network"
-                    description="Low-latency edge infra in 40+ regions"
-                    icon={<GlobeIcon />}
-                    href="#network"
-                  />
-                </>
-              }
-              featured={
-                <XDSTopNavMegaMenuFeaturedCard
-                  title="What's new in v4.0"
-                  description="AI-powered analytics and real-time collaboration."
-                  image="https://images.unsplash.com/photo-1551434678-e076c223a692?w=560&h=280&fit=crop"
-                  imageAlt="Team collaboration"
-                  linkLabel="Read the announcement"
-                  linkHref="#announcement"
+    <XDSTopNav
+      label="Marketing navigation"
+      heading={
+        <XDSTopNavHeading
+          heading="Acme"
+          logo={<XDSNavIcon icon={<CubeIcon />} />}
+          href="#"
+        />
+      }
+      startContent={
+        <>
+          <XDSTopNavMegaMenu
+            label="Products"
+            items={
+              <>
+                <XDSTopNavMegaMenuItem
+                  title="Analytics"
+                  description="Track and analyze user behavior across your apps"
+                  icon={<ChartIcon />}
+                  href="#analytics"
                 />
-              }
-            />
-            <XDSTopNavItem label="Pricing" href="#" />
-            <XDSTopNavItem label="Docs" href="#" />
-          </>
-        }
-        endContent={
-          <>
-            <XDSButton label="Sign in" variant="ghost" />
-            <XDSButton label="Get started" variant="primary" />
-          </>
-        }
-      />
-    </div>
+                <XDSTopNavMegaMenuItem
+                  title="Security"
+                  description="Enterprise-grade protection for your data"
+                  icon={<ShieldIcon />}
+                  href="#security"
+                />
+                <XDSTopNavMegaMenuItem
+                  title="Automation"
+                  description="Streamline workflows with intelligent tools"
+                  icon={<BoltIcon />}
+                  href="#automation"
+                />
+                <XDSTopNavMegaMenuItem
+                  title="Developer Tools"
+                  description="APIs, SDKs, and CLI for integration"
+                  icon={<CodeIcon />}
+                  href="#dev-tools"
+                />
+                <XDSTopNavMegaMenuItem
+                  title="Global Network"
+                  description="Low-latency edge infra in 40+ regions"
+                  icon={<GlobeIcon />}
+                  href="#network"
+                />
+              </>
+            }
+            featured={
+              <XDSTopNavMegaMenuFeaturedCard
+                title="What's new in v4.0"
+                description="AI-powered analytics and real-time collaboration."
+                image="https://images.unsplash.com/photo-1551434678-e076c223a692?w=560&h=280&fit=crop"
+                imageAlt="Team collaboration"
+                linkLabel="Read the announcement"
+                linkHref="#announcement"
+              />
+            }
+          />
+          <XDSTopNavItem label="Pricing" href="#" />
+          <XDSTopNavItem label="Docs" href="#" />
+        </>
+      }
+      endContent={
+        <>
+          <XDSButton label="Sign in" variant="ghost" />
+          <XDSButton label="Get started" variant="primary" />
+        </>
+      }
+    />
   );
 }

--- a/packages/cli/templates/blocks/components/TopNav/TopNavShowcase.tsx
+++ b/packages/cli/templates/blocks/components/TopNav/TopNavShowcase.tsx
@@ -2,14 +2,7 @@
 
 import {XDSTopNav, XDSTopNavHeading, XDSTopNavItem} from '@xds/core/TopNav';
 import {XDSButton} from '@xds/core/Button';
-
-function SearchIcon() {
-  return (
-    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
-      <path strokeLinecap="round" strokeLinejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z" />
-    </svg>
-  );
-}
+import {XDSIcon} from '@xds/core/Icon';
 
 function BellIcon() {
   return (
@@ -44,7 +37,7 @@ export default function TopNavShowcase() {
           <XDSButton
             label="Search"
             variant="ghost"
-            icon={<SearchIcon />}
+            icon={<XDSIcon icon="search" color="inherit" />}
             isIconOnly
           />
           <XDSButton

--- a/packages/cli/templates/blocks/components/TopNavHeading/TopNavHeadingShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/TopNavHeading/TopNavHeadingShowcase.doc.mjs
@@ -1,0 +1,10 @@
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  name: 'TopNavHeading',
+  description: 'Demonstrates XDSTopNavHeading with a logo and text, both as a plain display and as a clickable link.',
+  isReady: true,
+  isShowcase: true,
+  aspectRatio: 3,
+  componentsUsed: ['TopNav', 'TopNavHeading'],
+};

--- a/packages/cli/templates/blocks/components/TopNavHeading/TopNavHeadingShowcase.tsx
+++ b/packages/cli/templates/blocks/components/TopNavHeading/TopNavHeadingShowcase.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import {XDSTopNav, XDSTopNavHeading} from '@xds/core/TopNav';
+
+function LogoIcon() {
+  return (
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M21 7.5l-2.25-1.313M21 7.5v2.25m0-2.25l-2.25 1.313M3 7.5l2.25-1.313M3 7.5l2.25 1.313M3 7.5v2.25m9 3l2.25-1.313M12 12.75l-2.25-1.313M12 12.75V15m0 6.75l2.25-1.313M12 21.75V15m0 0l-2.25-1.313" />
+    </svg>
+  );
+}
+
+export default function TopNavHeadingShowcase() {
+  return (
+    <div style={{display: 'flex', flexDirection: 'column', gap: 16}}>
+      <XDSTopNav
+        label="Plain heading example"
+        heading={
+          <XDSTopNavHeading
+            heading="Acme Platform"
+            logo={<LogoIcon />}
+          />
+        }
+      />
+      <XDSTopNav
+        label="Linked heading example"
+        heading={
+          <XDSTopNavHeading
+            heading="Acme Platform"
+            logo={<LogoIcon />}
+            href="/"
+          />
+        }
+      />
+    </div>
+  );
+}

--- a/packages/cli/templates/blocks/components/TopNavHeading/TopNavHeadingShowcase.tsx
+++ b/packages/cli/templates/blocks/components/TopNavHeading/TopNavHeadingShowcase.tsx
@@ -3,10 +3,10 @@
 import {XDSTopNav, XDSTopNavHeading} from '@xds/core/TopNav';
 import {XDSVStack} from '@xds/core/Layout';
 
-function LogoIcon() {
+function AppIcon() {
   return (
-    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
-      <path strokeLinecap="round" strokeLinejoin="round" d="M21 7.5l-2.25-1.313M21 7.5v2.25m0-2.25l-2.25 1.313M3 7.5l2.25-1.313M3 7.5l2.25 1.313M3 7.5v2.25m9 3l2.25-1.313M12 12.75l-2.25-1.313M12 12.75V15m0 6.75l2.25-1.313M12 21.75V15m0 0l-2.25-1.313" />
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6A2.25 2.25 0 0 1 6 3.75h2.25A2.25 2.25 0 0 1 10.5 6v2.25a2.25 2.25 0 0 1-2.25 2.25H6a2.25 2.25 0 0 1-2.25-2.25V6ZM3.75 15.75A2.25 2.25 0 0 1 6 13.5h2.25a2.25 2.25 0 0 1 2.25 2.25V18a2.25 2.25 0 0 1-2.25 2.25H6A2.25 2.25 0 0 1 3.75 18v-2.25ZM13.5 6a2.25 2.25 0 0 1 2.25-2.25H18A2.25 2.25 0 0 1 20.25 6v2.25A2.25 2.25 0 0 1 18 10.5h-2.25a2.25 2.25 0 0 1-2.25-2.25V6ZM13.5 15.75a2.25 2.25 0 0 1 2.25-2.25H18a2.25 2.25 0 0 1 2.25 2.25V18A2.25 2.25 0 0 1 18 20.25h-2.25a2.25 2.25 0 0 1-2.25-2.25v-2.25Z" />
     </svg>
   );
 }
@@ -19,7 +19,7 @@ export default function TopNavHeadingShowcase() {
         heading={
           <XDSTopNavHeading
             heading="Acme Platform"
-            logo={<LogoIcon />}
+            logo={<AppIcon />}
           />
         }
       />
@@ -28,7 +28,7 @@ export default function TopNavHeadingShowcase() {
         heading={
           <XDSTopNavHeading
             heading="Acme Platform"
-            logo={<LogoIcon />}
+            logo={<AppIcon />}
             href="/"
           />
         }

--- a/packages/cli/templates/blocks/components/TopNavHeading/TopNavHeadingShowcase.tsx
+++ b/packages/cli/templates/blocks/components/TopNavHeading/TopNavHeadingShowcase.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import {XDSTopNav, XDSTopNavHeading} from '@xds/core/TopNav';
+import {XDSVStack} from '@xds/core/Layout';
 
 function LogoIcon() {
   return (
@@ -12,7 +13,7 @@ function LogoIcon() {
 
 export default function TopNavHeadingShowcase() {
   return (
-    <div style={{display: 'flex', flexDirection: 'column', gap: 16}}>
+    <XDSVStack gap={4}>
       <XDSTopNav
         label="Plain heading example"
         heading={
@@ -32,6 +33,6 @@ export default function TopNavHeadingShowcase() {
           />
         }
       />
-    </div>
+    </XDSVStack>
   );
 }

--- a/packages/cli/templates/blocks/components/TopNavItem/TopNavItemShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/TopNavItem/TopNavItemShowcase.doc.mjs
@@ -1,0 +1,10 @@
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  name: 'TopNavItem',
+  description: 'Demonstrates XDSTopNavItem with selected, icon, disabled, and default states.',
+  isReady: true,
+  isShowcase: true,
+  aspectRatio: 3,
+  componentsUsed: ['TopNav', 'TopNavItem'],
+};

--- a/packages/cli/templates/blocks/components/TopNavItem/TopNavItemShowcase.tsx
+++ b/packages/cli/templates/blocks/components/TopNavItem/TopNavItemShowcase.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import {XDSTopNav, XDSTopNavHeading, XDSTopNavItem} from '@xds/core/TopNav';
+
+function HomeIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <path strokeLinecap="round" strokeLinejoin="round" d="m2.25 12 8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25" />
+    </svg>
+  );
+}
+
+export default function TopNavItemShowcase() {
+  return (
+    <XDSTopNav
+      label="Navigation items demo"
+      heading={<XDSTopNavHeading heading="App" />}
+      startContent={
+        <>
+          <XDSTopNavItem label="Dashboard" href="#" isSelected icon={<HomeIcon />} />
+          <XDSTopNavItem label="Projects" href="#" />
+          <XDSTopNavItem label="Reports" href="#" />
+          <XDSTopNavItem label="Archived" href="#" isDisabled />
+        </>
+      }
+    />
+  );
+}

--- a/packages/cli/templates/blocks/components/TopNavMegaMenu/TopNavMegaMenuShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/TopNavMegaMenu/TopNavMegaMenuShowcase.doc.mjs
@@ -1,0 +1,10 @@
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  name: 'TopNavMegaMenu',
+  description: 'Demonstrates XDSTopNavMegaMenu with items and a featured card in the mega menu panel.',
+  isReady: true,
+  isShowcase: true,
+  aspectRatio: 16 / 9,
+  componentsUsed: ['TopNav', 'TopNavMegaMenu', 'TopNavMegaMenuItem', 'TopNavMegaMenuFeaturedCard'],
+};

--- a/packages/cli/templates/blocks/components/TopNavMegaMenu/TopNavMegaMenuShowcase.tsx
+++ b/packages/cli/templates/blocks/components/TopNavMegaMenu/TopNavMegaMenuShowcase.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import {
+  XDSTopNav,
+  XDSTopNavHeading,
+  XDSTopNavItem,
+  XDSTopNavMegaMenu,
+  XDSTopNavMegaMenuItem,
+  XDSTopNavMegaMenuFeaturedCard,
+} from '@xds/core/TopNav';
+
+function RocketIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M15.59 14.37a6 6 0 0 1-5.84 7.38v-4.8m5.84-2.58a14.98 14.98 0 0 0 6.16-12.12A14.98 14.98 0 0 0 9.631 8.41m5.96 5.96a14.926 14.926 0 0 1-5.841 2.58m-.119-8.54a6 6 0 0 0-7.381 5.84h4.8m2.58-5.84a14.927 14.927 0 0 0-2.58 5.84m2.699 2.7c-.103.021-.207.041-.311.06a15.09 15.09 0 0 1-2.448-2.448 14.9 14.9 0 0 1 .06-.312m-2.24 2.39a4.493 4.493 0 0 0-1.757 4.306 4.493 4.493 0 0 0 4.306-1.758M16.5 9a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0Z" />
+    </svg>
+  );
+}
+
+function BookIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M12 6.042A8.967 8.967 0 0 0 6 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 0 1 6 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 0 1 6-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0 0 18 18a8.967 8.967 0 0 0-6 2.292m0-14.25v14.25" />
+    </svg>
+  );
+}
+
+function CodeIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M17.25 6.75 22.5 12l-5.25 5.25m-10.5 0L1.5 12l5.25-5.25m7.5-3-4.5 16.5" />
+    </svg>
+  );
+}
+
+function ShieldIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75 11.25 15 15 9.75m-3-7.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285Z" />
+    </svg>
+  );
+}
+
+export default function TopNavMegaMenuShowcase() {
+  return (
+    <XDSTopNav
+      label="Mega menu demo"
+      heading={<XDSTopNavHeading heading="DevTools" />}
+      startContent={
+        <>
+          <XDSTopNavItem label="Overview" href="#" isSelected />
+          <XDSTopNavMegaMenu
+            label="Products"
+            items={
+              <>
+                <XDSTopNavMegaMenuItem
+                  title="Deploy"
+                  description="Ship to production in seconds"
+                  icon={<RocketIcon />}
+                  href="#deploy"
+                />
+                <XDSTopNavMegaMenuItem
+                  title="Documentation"
+                  description="Guides, references, and tutorials"
+                  icon={<BookIcon />}
+                  href="#docs"
+                />
+                <XDSTopNavMegaMenuItem
+                  title="API"
+                  description="Programmatic access to all features"
+                  icon={<CodeIcon />}
+                  href="#api"
+                />
+                <XDSTopNavMegaMenuItem
+                  title="Security"
+                  description="Enterprise-grade protection"
+                  icon={<ShieldIcon />}
+                  href="#security"
+                />
+              </>
+            }
+            featured={
+              <XDSTopNavMegaMenuFeaturedCard
+                title="What's New"
+                description="Check out our latest features and improvements in the Q2 release."
+                linkLabel="Read the changelog"
+                linkHref="#changelog"
+              />
+            }
+          />
+        </>
+      }
+    />
+  );
+}

--- a/packages/cli/templates/blocks/components/TopNavMegaMenuFeaturedCard/TopNavMegaMenuFeaturedCardShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/TopNavMegaMenuFeaturedCard/TopNavMegaMenuFeaturedCardShowcase.doc.mjs
@@ -1,0 +1,10 @@
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  name: 'TopNavMegaMenuFeaturedCard',
+  description: 'Demonstrates XDSTopNavMegaMenuFeaturedCard with a title, description, and CTA link inside a mega menu.',
+  isReady: true,
+  isShowcase: true,
+  aspectRatio: 16 / 9,
+  componentsUsed: ['TopNav', 'TopNavMegaMenu', 'TopNavMegaMenuFeaturedCard', 'TopNavMegaMenuItem'],
+};

--- a/packages/cli/templates/blocks/components/TopNavMegaMenuFeaturedCard/TopNavMegaMenuFeaturedCardShowcase.tsx
+++ b/packages/cli/templates/blocks/components/TopNavMegaMenuFeaturedCard/TopNavMegaMenuFeaturedCardShowcase.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import {
+  XDSTopNav,
+  XDSTopNavHeading,
+  XDSTopNavMegaMenu,
+  XDSTopNavMegaMenuItem,
+  XDSTopNavMegaMenuFeaturedCard,
+} from '@xds/core/TopNav';
+
+function StarIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M11.48 3.499a.562.562 0 0 1 1.04 0l2.125 5.111a.563.563 0 0 0 .475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 0 0-.182.557l1.285 5.385a.562.562 0 0 1-.84.61l-4.725-2.885a.562.562 0 0 0-.586 0L6.982 20.54a.562.562 0 0 1-.84-.61l1.285-5.386a.562.562 0 0 0-.182-.557l-4.204-3.602a.562.562 0 0 1 .321-.988l5.518-.442a.563.563 0 0 0 .475-.345L11.48 3.5Z" />
+    </svg>
+  );
+}
+
+export default function TopNavMegaMenuFeaturedCardShowcase() {
+  return (
+    <XDSTopNav
+      label="Featured card demo"
+      heading={<XDSTopNavHeading heading="Platform" />}
+      startContent={
+        <XDSTopNavMegaMenu
+          label="Resources"
+          items={
+            <XDSTopNavMegaMenuItem
+              title="Showcase"
+              description="See what others have built"
+              icon={<StarIcon />}
+              href="#showcase"
+            />
+          }
+          featured={
+            <XDSTopNavMegaMenuFeaturedCard
+              title="Introducing v2.0"
+              description="Our biggest release yet with new components, faster builds, and a refreshed design language."
+              linkLabel="Explore the release"
+              linkHref="#release"
+            />
+          }
+        />
+      }
+    />
+  );
+}

--- a/packages/cli/templates/blocks/components/TopNavMegaMenuFeaturedCard/TopNavMegaMenuFeaturedCardShowcase.tsx
+++ b/packages/cli/templates/blocks/components/TopNavMegaMenuFeaturedCard/TopNavMegaMenuFeaturedCardShowcase.tsx
@@ -1,47 +1,14 @@
 'use client';
 
-import {
-  XDSTopNav,
-  XDSTopNavHeading,
-  XDSTopNavMegaMenu,
-  XDSTopNavMegaMenuItem,
-  XDSTopNavMegaMenuFeaturedCard,
-} from '@xds/core/TopNav';
-
-function StarIcon() {
-  return (
-    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
-      <path strokeLinecap="round" strokeLinejoin="round" d="M11.48 3.499a.562.562 0 0 1 1.04 0l2.125 5.111a.563.563 0 0 0 .475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 0 0-.182.557l1.285 5.385a.562.562 0 0 1-.84.61l-4.725-2.885a.562.562 0 0 0-.586 0L6.982 20.54a.562.562 0 0 1-.84-.61l1.285-5.386a.562.562 0 0 0-.182-.557l-4.204-3.602a.562.562 0 0 1 .321-.988l5.518-.442a.563.563 0 0 0 .475-.345L11.48 3.5Z" />
-    </svg>
-  );
-}
+import {XDSTopNavMegaMenuFeaturedCard} from '@xds/core/TopNav';
 
 export default function TopNavMegaMenuFeaturedCardShowcase() {
   return (
-    <XDSTopNav
-      label="Featured card demo"
-      heading={<XDSTopNavHeading heading="Platform" />}
-      startContent={
-        <XDSTopNavMegaMenu
-          label="Resources"
-          items={
-            <XDSTopNavMegaMenuItem
-              title="Showcase"
-              description="See what others have built"
-              icon={<StarIcon />}
-              href="#showcase"
-            />
-          }
-          featured={
-            <XDSTopNavMegaMenuFeaturedCard
-              title="Introducing v2.0"
-              description="Our biggest release yet with new components, faster builds, and a refreshed design language."
-              linkLabel="Explore the release"
-              linkHref="#release"
-            />
-          }
-        />
-      }
+    <XDSTopNavMegaMenuFeaturedCard
+      title="Introducing v2.0"
+      description="Our biggest release yet with new components, faster builds, and a refreshed design language."
+      linkLabel="Explore the release"
+      linkHref="#release"
     />
   );
 }

--- a/packages/cli/templates/blocks/components/TopNavMegaMenuItem/TopNavMegaMenuItemShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/TopNavMegaMenuItem/TopNavMegaMenuItemShowcase.doc.mjs
@@ -1,0 +1,10 @@
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  name: 'TopNavMegaMenuItem',
+  description: 'Demonstrates XDSTopNavMegaMenuItem with icons, titles, and descriptions inside a mega menu.',
+  isReady: true,
+  isShowcase: true,
+  aspectRatio: 16 / 9,
+  componentsUsed: ['TopNav', 'TopNavMegaMenu', 'TopNavMegaMenuItem'],
+};

--- a/packages/cli/templates/blocks/components/TopNavMegaMenuItem/TopNavMegaMenuItemShowcase.tsx
+++ b/packages/cli/templates/blocks/components/TopNavMegaMenuItem/TopNavMegaMenuItemShowcase.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import {
+  XDSTopNav,
+  XDSTopNavHeading,
+  XDSTopNavMegaMenu,
+  XDSTopNavMegaMenuItem,
+} from '@xds/core/TopNav';
+
+function BoltIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <path strokeLinecap="round" strokeLinejoin="round" d="m3.75 13.5 10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75Z" />
+    </svg>
+  );
+}
+
+function CubeIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <path strokeLinecap="round" strokeLinejoin="round" d="m21 7.5-9-5.25L3 7.5m18 0-9 5.25m9-5.25v9l-9 5.25M3 7.5l9 5.25M3 7.5v9l9 5.25m0-9v9" />
+    </svg>
+  );
+}
+
+function GlobeIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M12 21a9.004 9.004 0 0 0 8.716-6.747M12 21a9.004 9.004 0 0 1-8.716-6.747M12 21c2.485 0 4.5-4.03 4.5-9S14.485 3 12 3m0 18c-2.485 0-4.5-4.03-4.5-9S9.515 3 12 3m0 0a8.997 8.997 0 0 1 7.843 4.582M12 3a8.997 8.997 0 0 0-7.843 4.582m15.686 0A11.953 11.953 0 0 1 12 10.5c-2.998 0-5.74-1.1-7.843-2.918m15.686 0A8.959 8.959 0 0 1 21 12c0 .778-.099 1.533-.284 2.253m0 0A17.919 17.919 0 0 1 12 16.5a17.92 17.92 0 0 1-8.716-2.247m0 0A8.966 8.966 0 0 1 3 12c0-1.264.26-2.466.732-3.558" />
+    </svg>
+  );
+}
+
+function WrenchIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M11.42 15.17 17.25 21A2.652 2.652 0 0 0 21 17.25l-5.877-5.877M11.42 15.17l2.496-3.03c.317-.384.74-.626 1.208-.766M11.42 15.17l-4.655 5.653a2.548 2.548 0 1 1-3.586-3.586l6.837-5.63m5.108-.233c.55-.164 1.163-.188 1.743-.14a4.5 4.5 0 0 0 4.486-6.336l-3.276 3.277a3.004 3.004 0 0 1-2.25-2.25l3.276-3.276a4.5 4.5 0 0 0-6.336 4.486c.049.58.025 1.192-.14 1.743" />
+    </svg>
+  );
+}
+
+export default function TopNavMegaMenuItemShowcase() {
+  return (
+    <XDSTopNav
+      label="Mega menu items demo"
+      heading={<XDSTopNavHeading heading="Suite" />}
+      startContent={
+        <XDSTopNavMegaMenu
+          label="Services"
+          items={
+            <>
+              <XDSTopNavMegaMenuItem
+                title="Edge Functions"
+                description="Run serverless code at the network edge"
+                icon={<BoltIcon />}
+                href="#edge"
+              />
+              <XDSTopNavMegaMenuItem
+                title="Storage"
+                description="Object and file storage for your application"
+                icon={<CubeIcon />}
+                href="#storage"
+              />
+              <XDSTopNavMegaMenuItem
+                title="CDN"
+                description="Global content delivery with instant purging"
+                icon={<GlobeIcon />}
+                href="#cdn"
+              />
+              <XDSTopNavMegaMenuItem
+                title="Build Tools"
+                description="Optimized bundling and compilation pipeline"
+                icon={<WrenchIcon />}
+                href="#build"
+              />
+            </>
+          }
+        />
+      }
+    />
+  );
+}

--- a/packages/cli/templates/blocks/components/TopNavMegaMenuItem/TopNavMegaMenuItemShowcase.tsx
+++ b/packages/cli/templates/blocks/components/TopNavMegaMenuItem/TopNavMegaMenuItemShowcase.tsx
@@ -1,11 +1,7 @@
 'use client';
 
-import {
-  XDSTopNav,
-  XDSTopNavHeading,
-  XDSTopNavMegaMenu,
-  XDSTopNavMegaMenuItem,
-} from '@xds/core/TopNav';
+import {XDSTopNavMegaMenuItem} from '@xds/core/TopNav';
+import {XDSGrid} from '@xds/core/Grid';
 
 function BoltIcon() {
   return (
@@ -41,42 +37,31 @@ function WrenchIcon() {
 
 export default function TopNavMegaMenuItemShowcase() {
   return (
-    <XDSTopNav
-      label="Mega menu items demo"
-      heading={<XDSTopNavHeading heading="Suite" />}
-      startContent={
-        <XDSTopNavMegaMenu
-          label="Services"
-          items={
-            <>
-              <XDSTopNavMegaMenuItem
-                title="Edge Functions"
-                description="Run serverless code at the network edge"
-                icon={<BoltIcon />}
-                href="#edge"
-              />
-              <XDSTopNavMegaMenuItem
-                title="Storage"
-                description="Object and file storage for your application"
-                icon={<CubeIcon />}
-                href="#storage"
-              />
-              <XDSTopNavMegaMenuItem
-                title="CDN"
-                description="Global content delivery with instant purging"
-                icon={<GlobeIcon />}
-                href="#cdn"
-              />
-              <XDSTopNavMegaMenuItem
-                title="Build Tools"
-                description="Optimized bundling and compilation pipeline"
-                icon={<WrenchIcon />}
-                href="#build"
-              />
-            </>
-          }
-        />
-      }
-    />
+    <XDSGrid columns={2} gap={2}>
+      <XDSTopNavMegaMenuItem
+        title="Edge Functions"
+        description="Run serverless code at the network edge"
+        icon={<BoltIcon />}
+        href="#edge"
+      />
+      <XDSTopNavMegaMenuItem
+        title="Storage"
+        description="Object and file storage for your application"
+        icon={<CubeIcon />}
+        href="#storage"
+      />
+      <XDSTopNavMegaMenuItem
+        title="CDN"
+        description="Global content delivery with instant purging"
+        icon={<GlobeIcon />}
+        href="#cdn"
+      />
+      <XDSTopNavMegaMenuItem
+        title="Build Tools"
+        description="Optimized bundling and compilation pipeline"
+        icon={<WrenchIcon />}
+        href="#build"
+      />
+    </XDSGrid>
   );
 }

--- a/packages/cli/templates/blocks/components/TopNavMenu/TopNavMenuShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/TopNavMenu/TopNavMenuShowcase.doc.mjs
@@ -1,0 +1,10 @@
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  name: 'TopNavMenu',
+  description: 'Demonstrates XDSTopNavMenu with a hover-triggered dropdown containing items with icons and descriptions.',
+  isReady: true,
+  isShowcase: true,
+  aspectRatio: 16 / 9,
+  componentsUsed: ['TopNav', 'TopNavMenu', 'TopNavItem'],
+};

--- a/packages/cli/templates/blocks/components/TopNavMenu/TopNavMenuShowcase.tsx
+++ b/packages/cli/templates/blocks/components/TopNavMenu/TopNavMenuShowcase.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import {
+  XDSTopNav,
+  XDSTopNavHeading,
+  XDSTopNavItem,
+  XDSTopNavMenu,
+} from '@xds/core/TopNav';
+
+function ChartIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z" />
+    </svg>
+  );
+}
+
+function UsersIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M15 19.128a9.38 9.38 0 0 0 2.625.372 9.337 9.337 0 0 0 4.121-.952 4.125 4.125 0 0 0-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 0 1 8.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0 1 11.964-3.07M12 6.375a3.375 3.375 0 1 1-6.75 0 3.375 3.375 0 0 1 6.75 0Zm8.25 2.25a2.625 2.625 0 1 1-5.25 0 2.625 2.625 0 0 1 5.25 0Z" />
+    </svg>
+  );
+}
+
+function CogIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 0 1 1.37.49l1.296 2.247a1.125 1.125 0 0 1-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.723 7.723 0 0 1 0 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.247a1.125 1.125 0 0 1-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 0 1-.22.128c-.331.183-.581.495-.644.869l-.213 1.281c-.09.543-.56.94-1.11.94h-2.594c-.55 0-1.019-.398-1.11-.94l-.212-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 0 1-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 0 1-1.369-.49l-1.297-2.247a1.125 1.125 0 0 1 .26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 0 1 0-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 0 1-.26-1.43l1.297-2.247a1.125 1.125 0 0 1 1.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869l.214-1.28Z" />
+      <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
+    </svg>
+  );
+}
+
+export default function TopNavMenuShowcase() {
+  return (
+    <XDSTopNav
+      label="Menu demo"
+      heading={<XDSTopNavHeading heading="Platform" />}
+      startContent={
+        <>
+          <XDSTopNavItem label="Home" href="#" isSelected />
+          <XDSTopNavMenu
+            label="Tools"
+            items={[
+              {
+                title: 'Analytics',
+                description: 'View traffic and engagement metrics',
+                icon: <ChartIcon />,
+                href: '#analytics',
+              },
+              {
+                title: 'Team Members',
+                description: 'Manage your team and permissions',
+                icon: <UsersIcon />,
+                href: '#team',
+              },
+              {
+                title: 'Settings',
+                description: 'Configure your workspace',
+                icon: <CogIcon />,
+                href: '#settings',
+              },
+            ]}
+          />
+        </>
+      }
+    />
+  );
+}

--- a/packages/cli/templates/blocks/components/VStack/VStackShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/VStack/VStackShowcase.doc.mjs
@@ -1,0 +1,10 @@
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  name: 'VStack',
+  description: 'Demonstrates XDSVStack arranging items vertically with different gaps.',
+  isReady: true,
+  isShowcase: true,
+  aspectRatio: 4 / 3,
+  componentsUsed: ['Layout', 'Badge', 'Text'],
+};

--- a/packages/cli/templates/blocks/components/VStack/VStackShowcase.tsx
+++ b/packages/cli/templates/blocks/components/VStack/VStackShowcase.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import {XDSHStack, XDSVStack} from '@xds/core/Layout';
+import {XDSBadge} from '@xds/core/Badge';
+import {XDSText} from '@xds/core/Text';
+
+export default function VStackShowcase() {
+  return (
+    <XDSHStack gap={10} hAlign="center">
+      <XDSVStack gap={2}>
+        <XDSText type="supporting" color="secondary">gap=2</XDSText>
+        <XDSVStack gap={2}>
+          <XDSBadge label="Step 1" />
+          <XDSBadge label="Step 2" />
+          <XDSBadge label="Step 3" />
+        </XDSVStack>
+      </XDSVStack>
+      <XDSVStack gap={2}>
+        <XDSText type="supporting" color="secondary">gap=4</XDSText>
+        <XDSVStack gap={4}>
+          <XDSBadge label="Step 1" />
+          <XDSBadge label="Step 2" />
+          <XDSBadge label="Step 3" />
+        </XDSVStack>
+      </XDSVStack>
+      <XDSVStack gap={2}>
+        <XDSText type="supporting" color="secondary">gap=6</XDSText>
+        <XDSVStack gap={6}>
+          <XDSBadge label="Step 1" />
+          <XDSBadge label="Step 2" />
+          <XDSBadge label="Step 3" />
+        </XDSVStack>
+      </XDSVStack>
+    </XDSHStack>
+  );
+}


### PR DESCRIPTION
Adds showcase block templates for 13 navigation and layout sub-components that were missing from CLI discovery.

New showcases:
- TopNavHeading, TopNavItem, TopNavMenu, TopNavMegaMenu, TopNavMegaMenuItem, TopNavMegaMenuFeaturedCard
- SideNavCollapseButton, SideNavHeading, SideNavItem, SideNavSection
- MobileNavToggle
- HStack, VStack

Each showcase follows the established pattern with a .tsx and .doc.mjs file.
