### PR TITLE
fix(templates): TextInputStates aspect ratio → 0.85

### DIFF
--- a/packages/cli/templates/blocks/components/TextInput/TextInputStates.doc.mjs
+++ b/packages/cli/templates/blocks/components/TextInput/TextInputStates.doc.mjs
@@ -4,6 +4,6 @@ export const doc = {
   name: 'TextInput — States',
   description: 'Error, warning, and success validation states with status messages. Use to show users what went wrong and how to fix it.',
   isReady: true,
-  aspectRatio: 9 / 16,
+  aspectRatio: 0.85,
   componentsUsed: ['TextInput', 'Layout'],
 };


### PR DESCRIPTION
Updates the TextInputStates block aspect ratio from `9/16` (0.5625) to `0.85` for a better fit in the preview card.