### PR TITLE
fix: component audit — AppShell, AspectRatio, Badge

### DIFF
--- a/packages/core/src/AppShell/XDSAppShell.tsx
+++ b/packages/core/src/AppShell/XDSAppShell.tsx
@@ -27,7 +27,6 @@ import {
   type ReactNode,
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
-import type {StyleXStyles} from '@stylexjs/stylex';
 import {
   colorVars,
   fontWeightVars,
@@ -48,6 +47,7 @@ import {XDSAppShellMobileContext} from './XDSAppShellMobileContext';
 import {useXDSSlotPresence} from './useXDSSlotPresence';
 import type {XDSAppShellMobileContextValue} from './XDSAppShellMobileContext';
 import type {SpacingStep} from '../utils/types';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import {xdsClassName, mergeProps} from '../utils';
 
 const HasActivity = typeof React.Activity !== 'undefined';
@@ -157,7 +157,7 @@ export interface XDSMobileNavConfig {
   breakpoint?: XDSAppShellBreakpoint;
 }
 
-export interface XDSAppShellProps {
+export interface XDSAppShellProps extends XDSBaseProps<HTMLDivElement> {
   /** Ref forwarded to the root element */
   ref?: React.Ref<HTMLDivElement>;
   /**
@@ -190,11 +190,6 @@ export interface XDSAppShellProps {
    * Accepts numeric spacing steps: 0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10.
    */
   contentPadding?: SpacingStep;
-
-  /**
-   * Test ID for the root element.
-   */
-  'data-testid'?: string;
 
   /**
    * Height behavior:
@@ -237,28 +232,6 @@ export interface XDSAppShellProps {
    * Top navigation — typically an XDSTopNav.
    */
   topNav?: ReactNode;
-
-  /**
-   * StyleX styles created via `stylex.create()`. Merged with the component's
-   * base styles inside a single `stylex.props()` call for optimal deduplication.
-   *
-   * @example
-   * ```
-   * const overrides = stylex.create({ root: { marginBottom: 8 } });
-   * <Component xstyle={overrides.root} />
-   * ```
-   */
-  xstyle?: StyleXStyles;
-  /**
-   * CSS class name(s) appended to the root element.
-   * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
-   */
-  className?: string;
-  /**
-   * Inline styles to apply to the root element. Spread after StyleX
-   * inline styles, so these values take priority.
-   */
-  style?: React.CSSProperties;
 }
 
 // =============================================================================

--- a/packages/core/src/AspectRatio/XDSAspectRatio.tsx
+++ b/packages/core/src/AspectRatio/XDSAspectRatio.tsx
@@ -12,7 +12,6 @@
  * - /apps/storybook/stories/AspectRatio.stories.tsx
  */
 
-
 import {type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
@@ -64,7 +63,7 @@ const styles = stylex.create({
   child: {
     position: 'absolute',
     top: 0,
-    left: 0,
+    insetInlineStart: 0,
     width: '100%',
     height: '100%',
   },

--- a/packages/core/src/Badge/index.ts
+++ b/packages/core/src/Badge/index.ts
@@ -1,7 +1,12 @@
 'use client';
 
 /**
- * @file Badge component barrel export
+ * @file index.ts
+ * @input Imports XDSBadge component and types from XDSBadge.tsx
+ * @output Exports XDSBadge, XDSBadgeProps, XDSBadgeVariant, XDSBadgeVariantMap
+ * @position Component entry point; re-exported by /packages/core/src/index.ts
+ *
+ * SYNC: When modified, update this header and /packages/core/src/Badge/Badge.doc.mjs
  */
 
 export {XDSBadge} from './XDSBadge';


### PR DESCRIPTION
## Night Watch Component Auditor — 2026-04-24

### Components Audited
- **AlertDialog** — ✅ All checks pass (theming, API, a11y, exports)
- **AppShell** — 1 finding (fixed)
- **AspectRatio** — 1 finding (fixed)
- **Avatar** — 1 finding (flagged, see Needs Review below)
- **Badge** — 1 finding (fixed)

### Fixes
1. **AppShell: Extend XDSBaseProps** — `XDSAppShellProps` was manually defining `xstyle`, `className`, `style`, and `data-testid` instead of extending `XDSBaseProps<HTMLDivElement>`. This inconsistency meant AppShell missed any future additions to XDSBaseProps (e.g. new escape hatches, data-* pattern). Now extends the shared base like all other components.

2. **AspectRatio: RTL-safe positioning** — Inner child used `left: 0` for absolute positioning. Changed to `insetInlineStart: 0` for proper RTL support. No visual change in LTR layouts.

3. **Badge: Structured file header** — `index.ts` had a minimal one-line comment. Added the standard `@file`, `@input`, `@output`, `@position` tags matching every other component barrel file.

### Needs Review
- **Avatar: Inline SVG fallback** — `DefaultIcon` uses an inline SVG for the person silhouette instead of `XDSIcon` with the icon registry. This may be intentional since the icon is tightly coupled to avatar sizing and avoids a registry dependency for the fallback state. Flagging for a human decision on whether to migrate.

---
