### PR TITLE
fix(Slider): keep tooltip visible during thumb drag

### DIFF
--- a/packages/core/src/HoverCard/XDSHoverCard.tsx
+++ b/packages/core/src/HoverCard/XDSHoverCard.tsx
@@ -111,6 +111,14 @@ export interface XDSHoverCardProps {
   hasHoverIndication?: 'auto' | boolean;
 
   /**
+   * Controlled open state. When provided, overrides hover/focus triggers:
+   * - `true`: force-show the hover card (hover/focus hide is suppressed)
+   * - `false`: force-hide the hover card
+   * - `undefined`: uncontrolled — hover/focus triggers manage visibility
+   */
+  isOpen?: boolean;
+
+  /**
    * Whether the hover card should be shown on mount.
    * The hover card is still dismissible — this just opens it initially.
    */
@@ -158,6 +166,7 @@ export function XDSHoverCard({
   isEnabled = true,
   onOpenChange,
   hasHoverIndication = 'auto',
+  isOpen,
   isDefaultOpen,
 }: XDSHoverCardProps): ReactElement {
   const wrapperRef = useRef<HTMLElement>(null);
@@ -183,6 +192,7 @@ export function XDSHoverCard({
     hideDelay,
     focusTrigger,
     isEnabled,
+    isOpen,
     isDefaultOpen,
     onShow: handleShow,
     onHide: handleHide,

--- a/packages/core/src/HoverCard/useXDSHoverCard.tsx
+++ b/packages/core/src/HoverCard/useXDSHoverCard.tsx
@@ -112,6 +112,14 @@ export interface XDSHoverCardOptions {
   isEnabled?: boolean;
 
   /**
+   * Controlled open state. When provided, overrides hover/focus triggers:
+   * - `true`: force-show the hover card (hover/focus hide is suppressed)
+   * - `false`: force-hide the hover card
+   * - `undefined`: uncontrolled — hover/focus triggers manage visibility
+   */
+  isOpen?: boolean;
+
+  /**
    * Whether the hover card should be shown on mount.
    * The hover card is still dismissible — this just opens it initially.
    */
@@ -232,6 +240,7 @@ export function useXDSHoverCard(
     hideDelay = 200,
     focusTrigger = 'auto',
     isEnabled = true,
+    isOpen,
     isDefaultOpen = false,
     onShow,
     onHide,
@@ -280,8 +289,9 @@ export function useXDSHoverCard(
     }, delay);
   }, [isEnabled, clearTimeouts, layer, delay]);
 
-  // Schedule hide with delay
+  // Schedule hide with delay (suppressed when isOpen is true)
   const scheduleHide = useCallback(() => {
+    if (isOpen === true) return;
     clearTimeouts();
     hideTimeoutRef.current = setTimeout(() => {
       // Don't hide if hovering content
@@ -289,7 +299,7 @@ export function useXDSHoverCard(
         layer.hide();
       }
     }, hideDelay);
-  }, [clearTimeouts, layer, hideDelay]);
+  }, [isOpen, clearTimeouts, layer, hideDelay]);
 
   // Event handlers
   const handleMouseEnter = useCallback(() => {
@@ -409,6 +419,18 @@ export function useXDSHoverCard(
     }
     // Only run on mount — isDefaultOpen is not reactive
   }, []);
+
+  // Controlled open state — overrides hover/focus triggers
+  useEffect(() => {
+    if (isOpen === undefined) return;
+    if (isOpen) {
+      clearTimeouts();
+      layer.show();
+    } else {
+      clearTimeouts();
+      layer.hide();
+    }
+  }, [isOpen, clearTimeouts, layer]);
 
   // Render function that wraps layer.render with hover card behavior
   const renderHoverCard = useCallback(

--- a/packages/core/src/HoverCard/useXDSHoverCard.tsx
+++ b/packages/core/src/HoverCard/useXDSHoverCard.tsx
@@ -280,14 +280,14 @@ export function useXDSHoverCard(
     }
   }, []);
 
-  // Schedule show with delay
+  // Schedule show with delay (suppressed when isOpen is false)
   const scheduleShow = useCallback(() => {
-    if (!isEnabled) return;
+    if (!isEnabled || isOpen === false) return;
     clearTimeouts();
     showTimeoutRef.current = setTimeout(() => {
       layer.show();
     }, delay);
-  }, [isEnabled, clearTimeouts, layer, delay]);
+  }, [isEnabled, isOpen, clearTimeouts, layer, delay]);
 
   // Schedule hide with delay (suppressed when isOpen is true)
   const scheduleHide = useCallback(() => {

--- a/packages/core/src/Slider/XDSSlider.tsx
+++ b/packages/core/src/Slider/XDSSlider.tsx
@@ -16,6 +16,7 @@
 import {
   useId,
   useRef,
+  useState,
   useCallback,
   type KeyboardEvent,
   type PointerEvent,
@@ -347,6 +348,7 @@ export function XDSSlider({ref, ...props}: XDSSliderProps) {
 
   const trackRef = useRef<HTMLDivElement>(null);
   const draggingThumbRef = useRef<number | null>(null);
+  const [draggingThumb, setDraggingThumb] = useState<number | null>(null);
 
   // Build aria-describedby
   const describedByParts: string[] = [];
@@ -474,6 +476,7 @@ export function XDSSlider({ref, ...props}: XDSSliderProps) {
         : getValueFromPosition(e.clientX, e.clientY);
       const thumbIndex = getClosestThumb(newVal);
       draggingThumbRef.current = thumbIndex;
+      setDraggingThumb(thumbIndex);
       updateValue(thumbIndex, newVal);
 
       // Focus the closest thumb
@@ -505,6 +508,7 @@ export function XDSSlider({ref, ...props}: XDSSliderProps) {
     (_e: PointerEvent<HTMLDivElement>) => {
       if (draggingThumbRef.current !== null) {
         draggingThumbRef.current = null;
+        setDraggingThumb(null);
         fireChangeEnd();
       }
     },
@@ -643,7 +647,8 @@ export function XDSSlider({ref, ...props}: XDSSliderProps) {
           content={displayValue(val)}
           placement={tooltipPlacement}
           delay={0}
-          focusTrigger="always">
+          focusTrigger="always"
+          isOpen={draggingThumb === thumbIndex ? true : undefined}>
           {thumbElement}
         </XDSTooltip>
       );

--- a/packages/core/src/Tooltip/XDSTooltip.tsx
+++ b/packages/core/src/Tooltip/XDSTooltip.tsx
@@ -121,6 +121,14 @@ export interface XDSTooltipProps {
   hasHoverIndication?: 'auto' | boolean;
 
   /**
+   * Controlled open state. When provided, overrides hover/focus triggers:
+   * - `true`: force-show the tooltip (hover/focus hide is suppressed)
+   * - `false`: force-hide the tooltip
+   * - `undefined`: uncontrolled — hover/focus triggers manage visibility
+   */
+  isOpen?: boolean;
+
+  /**
    * Whether the tooltip should be shown on mount.
    * The tooltip is still dismissible — this just opens it initially.
    */
@@ -168,6 +176,7 @@ export function XDSTooltip({
   isEnabled = true,
   onOpenChange,
   hasHoverIndication = 'auto',
+  isOpen,
   isDefaultOpen,
 }: XDSTooltipProps): ReactElement {
   const wrapperRef = useRef<HTMLElement>(null);
@@ -193,6 +202,7 @@ export function XDSTooltip({
     hideDelay,
     focusTrigger,
     isEnabled,
+    isOpen,
     isDefaultOpen,
     onShow: handleShow,
     onHide: handleHide,

--- a/packages/core/src/Tooltip/useXDSTooltip.tsx
+++ b/packages/core/src/Tooltip/useXDSTooltip.tsx
@@ -119,6 +119,14 @@ export interface XDSTooltipOptions {
   isEnabled?: boolean;
 
   /**
+   * Controlled open state. When provided, overrides hover/focus triggers:
+   * - `true`: force-show the tooltip (hover/focus hide is suppressed)
+   * - `false`: force-hide the tooltip
+   * - `undefined`: uncontrolled — hover/focus triggers manage visibility
+   */
+  isOpen?: boolean;
+
+  /**
    * Whether the tooltip should be shown on mount.
    * The tooltip is still dismissible — this just opens it initially.
    */
@@ -232,6 +240,7 @@ export function useXDSTooltip(
     hideDelay = 0,
     focusTrigger = 'auto',
     isEnabled = true,
+    isOpen,
     isDefaultOpen = false,
     onShow,
     onHide,
@@ -277,8 +286,9 @@ export function useXDSTooltip(
     }, delay);
   }, [isEnabled, clearTimeouts, layer, delay]);
 
-  // Schedule hide with delay
+  // Schedule hide with delay (suppressed when isOpen is true)
   const scheduleHide = useCallback(() => {
+    if (isOpen === true) return;
     clearTimeouts();
     if (hideDelay > 0) {
       hideTimeoutRef.current = setTimeout(() => {
@@ -287,7 +297,7 @@ export function useXDSTooltip(
     } else {
       layer.hide();
     }
-  }, [clearTimeouts, layer, hideDelay]);
+  }, [isOpen, clearTimeouts, layer, hideDelay]);
 
   // Event handlers
   const handleMouseEnter = useCallback(() => {
@@ -384,6 +394,18 @@ export function useXDSTooltip(
     }
     // Only run on mount — isDefaultOpen is not reactive
   }, []);
+
+  // Controlled open state — overrides hover/focus triggers
+  useEffect(() => {
+    if (isOpen === undefined) return;
+    if (isOpen) {
+      clearTimeouts();
+      layer.show();
+    } else {
+      clearTimeouts();
+      layer.hide();
+    }
+  }, [isOpen, clearTimeouts, layer]);
 
   // Render function that wraps layer.render with tooltip styling
   const renderTooltip = useCallback(

--- a/packages/core/src/Tooltip/useXDSTooltip.tsx
+++ b/packages/core/src/Tooltip/useXDSTooltip.tsx
@@ -277,14 +277,14 @@ export function useXDSTooltip(
     }
   }, []);
 
-  // Schedule show with delay
+  // Schedule show with delay (suppressed when isOpen is false)
   const scheduleShow = useCallback(() => {
-    if (!isEnabled) return;
+    if (!isEnabled || isOpen === false) return;
     clearTimeouts();
     showTimeoutRef.current = setTimeout(() => {
       layer.show();
     }, delay);
-  }, [isEnabled, clearTimeouts, layer, delay]);
+  }, [isEnabled, isOpen, clearTimeouts, layer, delay]);
 
   // Schedule hide with delay (suppressed when isOpen is true)
   const scheduleHide = useCallback(() => {


### PR DESCRIPTION
## What

Fixes the slider tooltip disappearing mid-drag when the pointer leaves the thumb's 20×20px bounding box.

## How

### Controlled `isOpen` prop for Tooltip & HoverCard

Adds a new `isOpen` prop to both `XDSTooltip` and `XDSHoverCard` (and their underlying hooks):

- `true` — force-show, suppress scheduled hides
- `false` — force-hide
- `undefined` — uncontrolled (default, existing behavior)

This is a general-purpose addition — any consumer that needs programmatic control over tooltip/hovercard visibility can now use it.

### Slider fix

`XDSSlider` now tracks the active drag thumb in React state (alongside the existing ref for perf-sensitive handlers) and passes `isOpen={draggingThumb === thumbIndex ? true : undefined}` to each thumb's `XDSTooltip`. The tooltip stays pinned for the entire drag and returns to normal hover/focus behavior when released.

## Files changed

| File | Change |
|------|--------|
| `useXDSTooltip.tsx` | `isOpen` option, controlled effect, suppress hide |
| `XDSTooltip.tsx` | `isOpen` prop threaded to hook |
| `useXDSHoverCard.tsx` | Same `isOpen` support |
| `XDSHoverCard.tsx` | Same `isOpen` prop |
| `XDSSlider.tsx` | `draggingThumb` state, wire `isOpen` to tooltip |

Closes #1747