### PR TITLE
feat(AppShell): add defaultIsMobile to MobileNavConfig for SSR

### DIFF
--- a/packages/core/src/AppShell/XDSAppShell.test.tsx
+++ b/packages/core/src/AppShell/XDSAppShell.test.tsx
@@ -292,6 +292,26 @@ describe('XDSAppShell', () => {
     expect(screen.getByRole('dialog', {hidden: true})).toBeInTheDocument();
   });
 
+  it('renders mobile layout on first render when defaultIsMobile is true', () => {
+    // matchMedia says mobile too — simulates correct SSR hint
+    mockMql = createMockMatchMedia(true);
+    vi.stubGlobal('matchMedia', vi.fn().mockReturnValue(mockMql));
+
+    const {container} = render(
+      <XDSAppShell
+        sideNav={<TestSideNav />}
+        mobileNav={{defaultIsMobile: true}}>
+        <div>Content</div>
+      </XDSAppShell>,
+    );
+
+    // SideNav should NOT be rendered inline — it's in the mobile drawer
+    const inlinePanel = container.querySelector(
+      '.xds-app-shell > .xds-layout .xds-layout-panel',
+    );
+    expect(inlinePanel).toBeNull();
+  });
+
   // ===========================================================================
   // Height modes
   // ===========================================================================

--- a/packages/core/src/AppShell/XDSAppShell.tsx
+++ b/packages/core/src/AppShell/XDSAppShell.tsx
@@ -155,6 +155,18 @@ export interface XDSMobileNavConfig {
    * @default 'md'
    */
   breakpoint?: XDSAppShellBreakpoint;
+
+  /**
+   * SSR hint: whether the initial render should assume mobile layout.
+   * Seeds the breakpoint state so the server-rendered HTML matches
+   * the client on mobile devices, avoiding a layout flash.
+   *
+   * Derive from the User-Agent header or a device-detection cookie
+   * in a server component, then pass down.
+   *
+   * @default false
+   */
+  defaultIsMobile?: boolean;
 }
 
 export interface XDSAppShellProps {
@@ -478,6 +490,7 @@ export function XDSAppShell({
   const mobileNavConfigContent: ReactNode | null =
     mobileNavConfig?.content ?? null;
   const mobileNavHasToggle = mobileNavConfig?.hasToggle !== false;
+  const mobileNavDefaultIsMobile = mobileNavConfig?.defaultIsMobile ?? false;
   const mobileNavIsControlled = mobileNavConfig?.isOpen !== undefined;
 
   // =========================================================================
@@ -495,7 +508,9 @@ export function XDSAppShell({
   // =========================================================================
   // Mobile nav open state (controlled + uncontrolled)
   // =========================================================================
-  const [isBelowBreakpoint, setIsBelowBreakpoint] = useState(false);
+  const [isBelowBreakpoint, setIsBelowBreakpoint] = useState(
+    mobileNavDefaultIsMobile,
+  );
   const [uncontrolledMobileOpen, setUncontrolledMobileOpen] = useState(false);
   const isMobileNavOpen = mobileNavIsControlled
     ? mobileNavConfig!.isOpen!


### PR DESCRIPTION
## Problem

Server-rendered pages using `XDSAppShell` always assume desktop layout on first paint (`isBelowBreakpoint` starts as `false`). On mobile devices, the `useEffect` fires after hydration and switches to mobile layout — causing a visible flash where the inline sidenav briefly appears then disappears.

## Solution

Adds `defaultIsMobile?: boolean` to `XDSMobileNavConfig`. When `true`, it seeds the initial `isBelowBreakpoint` state so the server-rendered HTML already has the mobile layout — no flash.

### Usage

```tsx
// In a server component, detect mobile from UA
const isMobile = headers().get('user-agent')?.includes('Mobile') ?? false;

// Pass to client layout
<XDSAppShell
  mobileNav={{ defaultIsMobile: isMobile }}
  sideNav={<MySideNav />}
  topNav={<MyTopNav />}
>
  {children}
</XDSAppShell>
```

## Changes

- Added `defaultIsMobile` to `XDSMobileNavConfig` interface
- Seeds `useState(mobileNavDefaultIsMobile)` instead of `useState(false)`
- Added test verifying inline sidenav is hidden when `defaultIsMobile` is true

---
