### PR TITLE
feat(tokens): add border-hover and border-selected color tokens

### DIFF
--- a/packages/cli/docs/tokens.doc.mjs
+++ b/packages/cli/docs/tokens.doc.mjs
@@ -1,7 +1,7 @@
 // AUTO-GENERATED — do not edit manually.
 // Source: packages/core/src/theme/tokens.stylex.ts
 // Run: node scripts/generate-token-docs.mjs
-// Total: 182 tokens across 12 categories.
+// Total: 184 tokens across 12 categories.
 
 /** @type {import('../../core/src/docs-types').ReferenceDoc} */
 
@@ -199,6 +199,16 @@ export const docs = {
               "--color-border-emphasized",
               "#CCD3DB",
               "#494D53"
+            ],
+            [
+              "--color-border-hover",
+              "#0171E34D",
+              "#2694FE4D"
+            ],
+            [
+              "--color-border-selected",
+              "#0171E380",
+              "#2694FE80"
             ],
             [
               "--color-skeleton",

--- a/packages/core/src/theme/expandColorScale.test.ts
+++ b/packages/core/src/theme/expandColorScale.test.ts
@@ -29,6 +29,8 @@ describe('expandColorScale', () => {
       '--color-background-inverted',
       '--color-border',
       '--color-border-emphasized',
+      '--color-border-hover',
+      '--color-border-selected',
       '--color-skeleton',
       '--color-shadow',
       '--color-tint-hover',

--- a/packages/core/src/theme/expandColorScale.ts
+++ b/packages/core/src/theme/expandColorScale.ts
@@ -163,6 +163,14 @@ export function expandColorScale(
     // Border
     '--color-border': ld(hexWithAlpha(N[10], 0.1), hexWithAlpha(N[95], 0.1)),
     '--color-border-emphasized': ld(NV[70], NV[30]),
+    '--color-border-hover': ld(
+      hexWithAlpha(P[40], 0.3),
+      hexWithAlpha(P[80], 0.3),
+    ),
+    '--color-border-selected': ld(
+      hexWithAlpha(P[40], 0.5),
+      hexWithAlpha(P[80], 0.5),
+    ),
 
     // Effects
     '--color-skeleton': ld(NV[70], NV[30]),

--- a/packages/core/src/theme/tokens.stylex.ts
+++ b/packages/core/src/theme/tokens.stylex.ts
@@ -66,6 +66,8 @@ export const colorDefaults = {
   // Border
   '--color-border': 'light-dark(#05365919, #F2F4F619)',
   '--color-border-emphasized': 'light-dark(#CCD3DB, #494D53)',
+  '--color-border-hover': 'light-dark(#0171E34D, #2694FE4D)',
+  '--color-border-selected': 'light-dark(#0171E380, #2694FE80)',
 
   // Effects
   '--color-skeleton': 'light-dark(#CCD3DB, #5A5E66)',


### PR DESCRIPTION
## Summary
- Adds `--color-border-hover` and `--color-border-selected` to the color token set, reusing the accent-derived colors currently used by input inset shadows (`--shadow-inset-hover` / `--shadow-inset-selected`)
- Updates `expandColorScale` to generate these tokens from the seed accent color so custom themes get matching values
- Regenerates token docs

## Motivation
Selectable cards need hover and selected border states. Rather than creating new token categories, this extends the existing `--color-border-*` group with interactive state variants that match the visual language already established by input components.

### Token values (default theme)
| Token | Light | Dark |
|---|---|---|
| `--color-border-hover` | `#0171E34D` (accent @ 30%) | `#2694FE4D` |
| `--color-border-selected` | `#0171E380` (accent @ 50%) | `#2694FE80` |

## Test plan
- [x] `expandColorScale` tests pass (5/5)
- [ ] Verify tokens render correctly in Storybook theme editor
- [ ] Verify custom themes generate correct hover/selected border colors


Made with [Cursor](https://cursor.com)