### PR TITLE
fix(tokens): update palette border colors from DSP color ramp

### DIFF
--- a/packages/cli/docs/tokens.doc.mjs
+++ b/packages/cli/docs/tokens.doc.mjs
@@ -222,8 +222,8 @@ export const docs = {
             ],
             [
               "--color-border-blue",
-              "#0171E3",
-              "#4BA9FE"
+              "#0064E0",
+              "#2694FE"
             ],
             [
               "--color-icon-blue",
@@ -242,8 +242,8 @@ export const docs = {
             ],
             [
               "--color-border-cyan",
-              "#00BCD4",
-              "#4DD0E1"
+              "#089DD0",
+              "#0171A4"
             ],
             [
               "--color-icon-cyan",
@@ -263,7 +263,7 @@ export const docs = {
             [
               "--color-border-gray",
               "#647685",
-              "#8C939B"
+              "#748695"
             ],
             [
               "--color-icon-gray",
@@ -282,8 +282,8 @@ export const docs = {
             ],
             [
               "--color-border-green",
-              "#24BB5E",
-              "#4CD964"
+              "#0D8626",
+              "#0B991F"
             ],
             [
               "--color-icon-green",
@@ -302,8 +302,8 @@ export const docs = {
             ],
             [
               "--color-border-orange",
-              "#F27902",
-              "#FFA040"
+              "#EB6E00",
+              "#B34A01"
             ],
             [
               "--color-icon-orange",
@@ -322,8 +322,8 @@ export const docs = {
             ],
             [
               "--color-border-pink",
-              "#E91E63",
-              "#F48FB1"
+              "#F351C0",
+              "#C02294"
             ],
             [
               "--color-icon-pink",
@@ -342,8 +342,8 @@ export const docs = {
             ],
             [
               "--color-border-purple",
-              "#7952FF",
-              "#9575CD"
+              "#9081FF",
+              "#7340FE"
             ],
             [
               "--color-icon-purple",
@@ -382,8 +382,8 @@ export const docs = {
             ],
             [
               "--color-border-teal",
-              "#0DB7AF",
-              "#4DB6AC"
+              "#08A3A3",
+              "#08767D"
             ],
             [
               "--color-icon-teal",
@@ -402,8 +402,8 @@ export const docs = {
             ],
             [
               "--color-border-yellow",
-              "#FFEB3B",
-              "#FFF176"
+              "#C58600",
+              "#B47700"
             ],
             [
               "--color-icon-yellow",

--- a/packages/core/src/theme/tokens.stylex.ts
+++ b/packages/core/src/theme/tokens.stylex.ts
@@ -129,7 +129,7 @@ export const colorDefaults = {
 
   // Yellow
   '--color-background-yellow': 'light-dark(#E2A40033, #E2A40033)',
-  '--color-border-yellow': 'light-dark(#C58600, #965E03)',  // Yellow 500 / 650
+  '--color-border-yellow': 'light-dark(#C58600, #B47700)',  // Yellow 500 / 550
   '--color-icon-yellow': 'light-dark(#FBC02D, #FFEE58)',
   '--color-text-yellow': 'light-dark(#753F07, #FBCE03)',
 

--- a/packages/core/src/theme/tokens.stylex.ts
+++ b/packages/core/src/theme/tokens.stylex.ts
@@ -75,43 +75,43 @@ export const colorDefaults = {
 
   // Blue
   '--color-background-blue': 'light-dark(#0171E333, #0171E333)',
-  '--color-border-blue': 'light-dark(#0171E3, #4BA9FE)',
+  '--color-border-blue': 'light-dark(#0064E0, #2694FE)',  // Blue 650 / 500
   '--color-icon-blue': 'light-dark(#0064E0, #2694FE)',
   '--color-text-blue': 'light-dark(#042F97, #AFD7FF)',
 
   // Cyan
   '--color-background-cyan': 'light-dark(#03A7D733, #03A7D733)',
-  '--color-border-cyan': 'light-dark(#00BCD4, #4DD0E1)',
+  '--color-border-cyan': 'light-dark(#089DD0, #0171A4)',  // Cyan 500 / 650
   '--color-icon-cyan': 'light-dark(#00ACC1, #26C6DA)',
   '--color-text-cyan': 'light-dark(#014975, #A1EEF9)',
 
   // Gray
   '--color-background-gray': 'light-dark(#0A131733, #666A724C)',
-  '--color-border-gray': 'light-dark(#647685, #8C939B)',
+  '--color-border-gray': 'light-dark(#647685, #748695)',  // Gray 600 / 550
   '--color-icon-gray': 'light-dark(#4E606F, #AAAFB5)',
   '--color-text-gray': 'light-dark(#0A1317, #E7EAED)',
 
   // Green
   '--color-background-green': 'light-dark(#24BB5E33, #24BB5E33)',
-  '--color-border-green': 'light-dark(#24BB5E, #4CD964)',
+  '--color-border-green': 'light-dark(#0D8626, #0B991F)',  // Green 600 / 550
   '--color-icon-green': 'light-dark(#0D8626, #26A756)',
   '--color-text-green': 'light-dark(#09441F, #A5F690)',
 
   // Orange
   '--color-background-orange': 'light-dark(#F2790233, #F2790233)',
-  '--color-border-orange': 'light-dark(#F27902, #FFA040)',
+  '--color-border-orange': 'light-dark(#EB6E00, #B34A01)',  // Orange 500 / 650
   '--color-icon-orange': 'light-dark(#E9690B, #FB8C00)',
   '--color-text-orange': 'light-dark(#6B2203, #FDB876)',
 
   // Pink
   '--color-background-pink': 'light-dark(#E638B333, #E638B333)',
-  '--color-border-pink': 'light-dark(#E91E63, #F48FB1)',
+  '--color-border-pink': 'light-dark(#F351C0, #C02294)',  // Pink 500 / 650
   '--color-icon-pink': 'light-dark(#C2185B, #EC407A)',
   '--color-text-pink': 'light-dark(#650053, #FEADE3)',
 
   // Purple
   '--color-background-purple': 'light-dark(#7952FF33, #7952FF33)',
-  '--color-border-purple': 'light-dark(#7952FF, #9575CD)',
+  '--color-border-purple': 'light-dark(#9081FF, #7340FE)',  // Purple 500 / 650
   '--color-icon-purple': 'light-dark(#5B08D8, #7952FF)',
   '--color-text-purple': 'light-dark(#3E0697, #B3B0FE)',
 
@@ -123,13 +123,13 @@ export const colorDefaults = {
 
   // Teal
   '--color-background-teal': 'light-dark(#0DB7AF33, #0DB7AF33)',
-  '--color-border-teal': 'light-dark(#0DB7AF, #4DB6AC)',
+  '--color-border-teal': 'light-dark(#08A3A3, #08767D)',  // Teal 500 / 650
   '--color-icon-teal': 'light-dark(#009688, #26A69A)',
   '--color-text-teal': 'light-dark(#083943, #40DCCD)',
 
   // Yellow
   '--color-background-yellow': 'light-dark(#E2A40033, #E2A40033)',
-  '--color-border-yellow': 'light-dark(#FFEB3B, #FFF176)',
+  '--color-border-yellow': 'light-dark(#C58600, #965E03)',  // Yellow 500 / 650
   '--color-icon-yellow': 'light-dark(#FBC02D, #FFEE58)',
   '--color-text-yellow': 'light-dark(#753F07, #FBCE03)',
 


### PR DESCRIPTION
## What

Update all 10 `--color-border-{color}` tokens to use values from the XDS DSP color palette ramp, with contrast-matched light/dark pairs.

## Why

The existing border colors were set in the initial theme (Jan 2026) and never updated to match the DSP palette. Light and dark mode contrast ratios were mismatched — some dark values had 2-3x the contrast of their light counterparts.

## Changes

All hex values sourced from `XDS DSP Tokens - 0. Color Palette: Base`.

| Color | Old (light/dark) | New (light/dark) | Palette steps | CR (L/D) |
|-------|-----------------|------------------|---------------|----------|
| Blue | `#0171E3` / `#4BA9FE` | `#0064E0` / `#2694FE` | 650 / 500 | 5.39 / 5.48 |
| Cyan | `#00BCD4` / `#4DD0E1` | `#089DD0` / `#0171A4` | 500 / 650 | 3.11 / 3.17 |
| Gray | `#647685` / `#8C939B` | `#647685` / `#748695` | 600 / 550 | 4.70 / 4.54 |
| Green | `#24BB5E` / `#4CD964` | `#0D8626` / `#0B991F` | 600 / 550 | 4.71 / 4.54 |
| Orange | `#F27902` / `#FFA040` | `#EB6E00` / `#B34A01` | 500 / 650 | 3.11 / 3.17 |
| Pink | `#E91E63` / `#F48FB1` | `#F351C0` / `#C02294` | 500 / 650 | 3.11 / 3.17 |
| Purple | `#7952FF` / `#9575CD` | `#9081FF` / `#7340FE` | 500 / 650 | 3.10 / 3.16 |
| Red | `#E3193B` / `#F5394F` | unchanged | 600 / 550 | 4.70 / 4.53 |
| Teal | `#0DB7AF` / `#4DB6AC` | `#08A3A3` / `#08767D` | 500 / 650 | 3.10 / 3.17 |
| Yellow | `#FFEB3B` / `#FFF176` | `#C58600` / `#965E03` | 500 / 650 | 3.10 / 3.17 |

## Context

These border tokens are currently unused in core components but will be needed for selectable card states. This PR aligns the values before that work begins.


<img width="2880" height="4822" alt="image" src="https://github.com/user-attachments/assets/3fda0660-03fa-4284-a808-7bee666adda6" />
