### PR TITLE
fix(icon): use secondary color for input startIcon slots

### DIFF
--- a/packages/core/src/NumberInput/XDSNumberInput.tsx
+++ b/packages/core/src/NumberInput/XDSNumberInput.tsx
@@ -544,7 +544,8 @@ export function XDSNumberInput({
           className,
           style,
         )}>
-        {startIcon && renderIconSlot(startIcon, {size: 'sm', color: 'primary'})}
+        {startIcon &&
+          renderIconSlot(startIcon, {size: 'sm', color: 'secondary'})}
         <input
           {...rest}
           ref={setRefs}

--- a/packages/core/src/TextArea/XDSTextArea.tsx
+++ b/packages/core/src/TextArea/XDSTextArea.tsx
@@ -351,7 +351,8 @@ export function XDSTextArea({
           className,
           style,
         )}>
-        {startIcon && renderIconSlot(startIcon, {size: 'sm', color: 'primary'})}
+        {startIcon &&
+          renderIconSlot(startIcon, {size: 'sm', color: 'secondary'})}
         <textarea
           {...rest}
           ref={ref}

--- a/packages/core/src/TextInput/XDSTextInput.tsx
+++ b/packages/core/src/TextInput/XDSTextInput.tsx
@@ -360,7 +360,8 @@ export function XDSTextInput({
           className,
           style,
         )}>
-        {startIcon && renderIconSlot(startIcon, {size: 'sm', color: 'primary'})}
+        {startIcon &&
+          renderIconSlot(startIcon, {size: 'sm', color: 'secondary'})}
         <input
           {...rest}
           ref={setRefs}

--- a/packages/core/src/Tokenizer/XDSTokenizer.tsx
+++ b/packages/core/src/Tokenizer/XDSTokenizer.tsx
@@ -669,7 +669,7 @@ export function XDSTokenizer<T extends XDSSearchableItem>({
               ),
             )}>
             {startIcon &&
-              renderIconSlot(startIcon, {size: 'sm', color: 'primary'})}
+              renderIconSlot(startIcon, {size: 'sm', color: 'secondary'})}
             {isTruncated ? (
               <XDSOverflowList
                 gap={1}
@@ -768,7 +768,10 @@ export function XDSTokenizer<T extends XDSSearchableItem>({
                 {isTruncated && (
                   <>
                     {startIcon &&
-                      renderIconSlot(startIcon, {size: 'sm', color: 'primary'})}
+                      renderIconSlot(startIcon, {
+                        size: 'sm',
+                        color: 'secondary',
+                      })}
                     <XDSOverflowList
                       gap={1}
                       behavior="observeParent"

--- a/packages/core/src/Typeahead/XDSTypeahead.tsx
+++ b/packages/core/src/Typeahead/XDSTypeahead.tsx
@@ -396,7 +396,8 @@ export function XDSTypeahead<T extends XDSSearchableItem>({
             isDisabled && inputWrapperStyles.disabled,
           ),
         )}>
-        {startIcon && renderIconSlot(startIcon, {size: 'sm', color: 'primary'})}
+        {startIcon &&
+          renderIconSlot(startIcon, {size: 'sm', color: 'secondary'})}
         {showToken && (
           <XDSToken
             ref={tokenRef}


### PR DESCRIPTION
The `startIcon` in TextInput, TextArea, NumberInput, Typeahead, and Tokenizer was using `primary` color. Input icons should be `secondary` to match the visual weight of other icon slots (DropdownMenuItem, SelectorOption, NavMenuItem all use `secondary`).

5 files, 1-line change each — `primary` → `secondary` in `renderIconSlot` calls.