### PR TITLE
fix(Collapsible): remove trigger padding and add capsize to label

### DIFF
--- a/packages/core/src/Collapsible/XDSCollapsible.tsx
+++ b/packages/core/src/Collapsible/XDSCollapsible.tsx
@@ -52,7 +52,12 @@ const styles = stylex.create({
     fontWeight: fontWeightVars['--font-weight-semibold'],
     color: colorVars['--color-text-primary'],
     textAlign: 'start',
-    paddingBlock: spacingVars['--spacing-1'],
+    paddingBlock: 0,
+  },
+  // Capsize: trim leading from text triggers
+  triggerLabel: {
+    textBoxEdge: 'cap alphabetic',
+    textBoxTrim: 'trim-both',
   },
   // Chevron indicator
   chevron: {
@@ -200,7 +205,7 @@ export function XDSCollapsible({
         onClick={toggle}
         aria-expanded={isOpen}
         {...stylex.props(styles.trigger)}>
-        <span>{trigger}</span>
+        <span {...stylex.props(styles.triggerLabel)}>{trigger}</span>
         <span
           {...stylex.props(
             styles.chevron,


### PR DESCRIPTION
## Summary

- Remove 4px `paddingBlock` from the internal trigger button — spacing should come from the parent container (e.g. `XDSCard`), not the trigger itself.
- Apply `text-box-trim` capsize to the trigger label `<span>` so text triggers sit flush without extra leading.

## Changes

| File | Change |
|------|--------|
| `XDSCollapsible.tsx` | `paddingBlock: spacing-1` → `paddingBlock: 0`, added `triggerLabel` style with capsize |

---
