### PR TITLE
chore: add complete package metadata to all packages

### DIFF
--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -1,8 +1,26 @@
 {
   "name": "@xds/build",
   "version": "0.0.1",
+  "private": true,
   "description": "Build plugins for XDS source builds — babel, PostCSS, and Vite integrations",
+  "author": "Meta Open Source",
   "license": "MIT",
+  "homepage": "https://github.com/facebookexperimental/xds#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/facebookexperimental/xds.git",
+    "directory": "packages/build"
+  },
+  "bugs": {
+    "url": "https://github.com/facebookexperimental/xds/issues"
+  },
+  "keywords": [
+    "xds",
+    "postcss",
+    "stylex",
+    "css-layers",
+    "design-system"
+  ],
   "main": "./src/config.js",
   "exports": {
     ".": "./src/config.js",
@@ -13,13 +31,6 @@
   },
   "files": [
     "src"
-  ],
-  "keywords": [
-    "xds",
-    "postcss",
-    "stylex",
-    "css-layers",
-    "design-system"
   ],
   "peerDependencies": {
     "@stylexjs/babel-plugin": ">=0.18.0",
@@ -39,6 +50,5 @@
     "vite": {
       "optional": true
     }
-  },
-  "private": true
+  }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,28 @@
 {
   "name": "@xds/cli",
   "version": "0.0.12",
-  "description": "XDS design system CLI \u2014 init, swizzle, theme, templates, and agent docs",
+  "description": "XDS design system CLI — init, swizzle, theme, templates, and agent docs",
+  "author": "Meta Open Source",
+  "license": "MIT",
+  "homepage": "https://github.com/facebookexperimental/xds#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/facebookexperimental/xds.git",
+    "directory": "packages/cli"
+  },
+  "bugs": {
+    "url": "https://github.com/facebookexperimental/xds/issues"
+  },
+  "keywords": [
+    "xds",
+    "cli",
+    "design-system",
+    "init",
+    "swizzle",
+    "scaffolding",
+    "theme",
+    "agent-docs"
+  ],
   "type": "module",
   "bin": {
     "xds": "./bin/xds.mjs"
@@ -32,13 +53,5 @@
     "@clack/prompts": "^1.2.0",
     "commander": "^12.1.0",
     "jiti": "^2.6.1"
-  },
-  "keywords": [
-    "xds",
-    "cli",
-    "design-system",
-    "init",
-    "swizzle"
-  ],
-  "license": "MIT"
+  }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,8 +1,28 @@
 {
   "name": "@xds/core",
   "version": "0.0.12",
-  "description": "Core XDS components",
+  "description": "XDS design system — accessible, themeable React components with automatic spacing and plugin architecture",
+  "author": "Meta Open Source",
   "license": "MIT",
+  "homepage": "https://github.com/facebookexperimental/xds#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/facebookexperimental/xds.git",
+    "directory": "packages/core"
+  },
+  "bugs": {
+    "url": "https://github.com/facebookexperimental/xds/issues"
+  },
+  "keywords": [
+    "xds",
+    "design-system",
+    "react",
+    "components",
+    "ui",
+    "accessible",
+    "themeable",
+    "stylex"
+  ],
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/lab/package.json
+++ b/packages/lab/package.json
@@ -3,7 +3,23 @@
   "version": "0.0.12",
   "private": true,
   "description": "Experimental XDS components — not published, available in storybook and sandbox for testing",
+  "author": "Meta Open Source",
   "license": "MIT",
+  "homepage": "https://github.com/facebookexperimental/xds#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/facebookexperimental/xds.git",
+    "directory": "packages/lab"
+  },
+  "bugs": {
+    "url": "https://github.com/facebookexperimental/xds/issues"
+  },
+  "keywords": [
+    "xds",
+    "lab",
+    "experimental",
+    "design-system"
+  ],
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "sideEffects": false,

--- a/packages/themes/brutalist/package.json
+++ b/packages/themes/brutalist/package.json
@@ -2,8 +2,25 @@
   "name": "@xds/theme-brutalist",
   "version": "0.0.12",
   "private": true,
-  "description": "Brutalist theme for XDS \u2014 zero radius, monospace, heavy borders",
+  "description": "Brutalist theme for XDS — zero radius, monospace, heavy borders",
+  "author": "Meta Open Source",
   "license": "MIT",
+  "homepage": "https://github.com/facebookexperimental/xds#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/facebookexperimental/xds.git",
+    "directory": "packages/themes/brutalist"
+  },
+  "bugs": {
+    "url": "https://github.com/facebookexperimental/xds/issues"
+  },
+  "keywords": [
+    "xds",
+    "theme",
+    "brutalist",
+    "design-system",
+    "design-tokens"
+  ],
   "sideEffects": false,
   "main": "./dist/source.js",
   "module": "./dist/source.mjs",

--- a/packages/themes/daily/package.json
+++ b/packages/themes/daily/package.json
@@ -2,8 +2,25 @@
   "name": "@xds/theme-daily",
   "version": "0.0.12",
   "private": false,
-  "description": "Daily theme for XDS components \u2014 warm, productivity-focused (Lucide icons)",
+  "description": "Daily theme for XDS — warm, productivity-focused palette with Lucide icon set",
+  "author": "Meta Open Source",
   "license": "MIT",
+  "homepage": "https://github.com/facebookexperimental/xds#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/facebookexperimental/xds.git",
+    "directory": "packages/themes/daily"
+  },
+  "bugs": {
+    "url": "https://github.com/facebookexperimental/xds/issues"
+  },
+  "keywords": [
+    "xds",
+    "theme",
+    "design-system",
+    "lucide",
+    "design-tokens"
+  ],
   "sideEffects": false,
   "main": "./dist/source.js",
   "types": "./dist/source.d.ts",

--- a/packages/themes/default/package.json
+++ b/packages/themes/default/package.json
@@ -2,8 +2,25 @@
   "name": "@xds/theme-default",
   "version": "0.0.12",
   "private": false,
-  "description": "Default theme for XDS components (Heroicons)",
+  "description": "Default theme for XDS — clean neutrals with Heroicons icon set",
+  "author": "Meta Open Source",
   "license": "MIT",
+  "homepage": "https://github.com/facebookexperimental/xds#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/facebookexperimental/xds.git",
+    "directory": "packages/themes/default"
+  },
+  "bugs": {
+    "url": "https://github.com/facebookexperimental/xds/issues"
+  },
+  "keywords": [
+    "xds",
+    "theme",
+    "design-system",
+    "heroicons",
+    "design-tokens"
+  ],
   "sideEffects": false,
   "main": "./dist/source.js",
   "types": "./dist/source.d.ts",

--- a/packages/themes/meta/package.json
+++ b/packages/themes/meta/package.json
@@ -2,8 +2,25 @@
   "name": "@xds/theme-meta",
   "version": "0.0.12",
   "private": true,
-  "description": "Meta theme for XDS components \u2014 Meta's brand identity with blue accent and clean aesthetics",
+  "description": "Meta theme for XDS components — Meta's brand identity with blue accent and clean aesthetics",
+  "author": "Meta Open Source",
   "license": "MIT",
+  "homepage": "https://github.com/facebookexperimental/xds#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/facebookexperimental/xds.git",
+    "directory": "packages/themes/meta"
+  },
+  "bugs": {
+    "url": "https://github.com/facebookexperimental/xds/issues"
+  },
+  "keywords": [
+    "xds",
+    "theme",
+    "meta",
+    "design-system",
+    "design-tokens"
+  ],
   "sideEffects": false,
   "main": "./dist/source.js",
   "types": "./dist/source.d.ts",

--- a/packages/themes/neutral/package.json
+++ b/packages/themes/neutral/package.json
@@ -2,8 +2,25 @@
   "name": "@xds/theme-neutral",
   "version": "0.0.12",
   "private": false,
-  "description": "Neutral theme for XDS components (Lucide icons)",
+  "description": "Neutral theme for XDS — understated palette with Lucide icon set",
+  "author": "Meta Open Source",
   "license": "MIT",
+  "homepage": "https://github.com/facebookexperimental/xds#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/facebookexperimental/xds.git",
+    "directory": "packages/themes/neutral"
+  },
+  "bugs": {
+    "url": "https://github.com/facebookexperimental/xds/issues"
+  },
+  "keywords": [
+    "xds",
+    "theme",
+    "design-system",
+    "lucide",
+    "design-tokens"
+  ],
   "sideEffects": false,
   "main": "./dist/source.js",
   "types": "./dist/source.d.ts",

--- a/packages/themes/whatsapp/package.json
+++ b/packages/themes/whatsapp/package.json
@@ -2,8 +2,25 @@
   "name": "@xds/theme-whatsapp",
   "version": "0.0.12",
   "private": true,
-  "description": "WhatsApp theme for XDS \u2014 green accent, warm grays, Roboto, rounded surfaces",
+  "description": "WhatsApp theme for XDS — green accent, warm grays, Roboto, rounded surfaces",
+  "author": "Meta Open Source",
   "license": "MIT",
+  "homepage": "https://github.com/facebookexperimental/xds#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/facebookexperimental/xds.git",
+    "directory": "packages/themes/whatsapp"
+  },
+  "bugs": {
+    "url": "https://github.com/facebookexperimental/xds/issues"
+  },
+  "keywords": [
+    "xds",
+    "theme",
+    "whatsapp",
+    "design-system",
+    "design-tokens"
+  ],
   "sideEffects": false,
   "main": "./dist/source.js",
   "module": "./dist/source.mjs",

--- a/packages/vega/package.json
+++ b/packages/vega/package.json
@@ -1,9 +1,26 @@
 {
   "name": "@xds/vega",
-  "private": true,
   "version": "0.0.12",
-  "description": "XDS Vega wrapper \u2014 chart and data visualization components",
+  "private": true,
+  "description": "XDS Vega wrapper — chart and data visualization components",
+  "author": "Meta Open Source",
   "license": "MIT",
+  "homepage": "https://github.com/facebookexperimental/xds#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/facebookexperimental/xds.git",
+    "directory": "packages/vega"
+  },
+  "bugs": {
+    "url": "https://github.com/facebookexperimental/xds/issues"
+  },
+  "keywords": [
+    "xds",
+    "vega",
+    "charts",
+    "data-visualization",
+    "design-system"
+  ],
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary

All 11 XDS packages were missing standard npm metadata fields. The CLI had keywords but nothing else; core had a one-liner description and nothing else. This adds complete, high-quality metadata to every package.

## Changes

### All packages (published + private)
- **`repository`** — points to monorepo with correct `directory` field
- **`homepage`** — links to repo README
- **`bugs`** — links to GitHub Issues
- **`author`** — `Meta Open Source`
- **`keywords`** — tailored per package for npm discoverability
- **Field ordering** normalized to standard convention

### Description improvements
| Package | Before | After |
|---------|--------|-------|
| `@xds/core` | "Core XDS components" | "XDS design system — accessible, themeable React components with automatic spacing and plugin architecture" |
| `@xds/theme-default` | "Default theme for XDS components (Heroicons)" | "Default theme for XDS — clean neutrals with Heroicons icon set" |
| `@xds/theme-neutral` | "Neutral theme for XDS components (Lucide icons)" | "Neutral theme for XDS — understated palette with Lucide icon set" |
| `@xds/theme-daily` | "Daily theme for XDS components — warm, productivity-focused (Lucide icons)" | "Daily theme for XDS — warm, productivity-focused palette with Lucide icon set" |

### Keywords added
- **core:** xds, design-system, react, components, ui, accessible, themeable, stylex
- **cli:** +scaffolding, theme, agent-docs
- **themes:** xds, theme, design-system, design-tokens, + icon library name
- **lab/vega/build:** category-appropriate tags

## Why
npm pages, IDE tooltips, and `npm search` all surface this metadata. Having it complete and consistent makes the packages look professional and discoverable.

---
