### PR TITLE
fix(Breadcrumbs): onClick-only items now match link color

### DIFF
--- a/packages/core/src/Breadcrumbs/XDSBreadcrumbItem.tsx
+++ b/packages/core/src/Breadcrumbs/XDSBreadcrumbItem.tsx
@@ -107,6 +107,14 @@ const itemStyles = stylex.create({
     },
     cursor: 'pointer',
   },
+  // Reset native button styles so onClick-only items match link appearance
+  buttonReset: {
+    background: 'none',
+    border: 'none',
+    padding: 0,
+    margin: 0,
+    font: 'inherit',
+  },
   defaultLink: {
     color: colorVars['--color-text-secondary'],
   },
@@ -259,6 +267,17 @@ export function XDSBreadcrumbItem({
           )}>
           {content}
         </LinkComponent>
+      ) : onClick != null ? (
+        <button
+          type="button"
+          onClick={onClick}
+          {...stylex.props(
+            itemStyles.link,
+            itemStyles.buttonReset,
+            isSupporting ? itemStyles.supportingLink : itemStyles.defaultLink,
+          )}>
+          {content}
+        </button>
       ) : (
         <span
           {...stylex.props(

--- a/packages/core/src/Breadcrumbs/XDSBreadcrumbs.test.tsx
+++ b/packages/core/src/Breadcrumbs/XDSBreadcrumbs.test.tsx
@@ -201,7 +201,7 @@ describe('XDSBreadcrumbItem', () => {
     expect(screen.getByText('Third').tagName).toBe('A');
   });
 
-  it('handles onClick', async () => {
+  it('handles onClick on link items', async () => {
     const handleClick = vi.fn();
     render(
       <XDSBreadcrumbs>
@@ -213,6 +213,21 @@ describe('XDSBreadcrumbItem', () => {
     );
     const link = screen.getByRole('link', {name: 'Home'});
     await userEvent.click(link);
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders onClick-only items as buttons with link styling', async () => {
+    const handleClick = vi.fn();
+    render(
+      <XDSBreadcrumbs>
+        <XDSBreadcrumbItem onClick={handleClick}>Home</XDSBreadcrumbItem>
+        <XDSBreadcrumbItem isCurrent>Current</XDSBreadcrumbItem>
+      </XDSBreadcrumbs>,
+    );
+    const button = screen.getByRole('button', {name: 'Home'});
+    expect(button.tagName).toBe('BUTTON');
+    expect(button).toHaveAttribute('type', 'button');
+    await userEvent.click(button);
     expect(handleClick).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
## Problem

`XDSBreadcrumbItem` with `onClick` (no `href`) rendered with **primary** text color, while items with `href` rendered with **secondary** text color. The two should look identical — the navigation mechanism shouldn't affect appearance.

### Root cause

The non-`isCurrent` render path had two branches:
- `href` → `<LinkComponent>` with `link` + `defaultLink` styles (secondary color ✓)
- no `href` → `<span>` with `current` + `defaultCurrent` styles (primary color ✗)

The fallback `else` branch was styled as a current-page item, so any `onClick`-only item got primary color + no pointer cursor.

## Fix

Added a middle branch: when `onClick` is present without `href`, render a `<button type="button">` with:
- Same link styles as href items (secondary color, pointer, hover underline)
- A `buttonReset` style to strip native button chrome

This is semantically correct too — a clickable non-link should be a button, not a span.

## Test

Added test: `renders onClick-only items as buttons with link styling`

---
