### PR TITLE
fix(Collapsible): wrap showcase items in XDSVStack with gap

### DIFF
--- a/packages/cli/templates/blocks/components/Collapsible/CollapsibleShowcase.tsx
+++ b/packages/cli/templates/blocks/components/Collapsible/CollapsibleShowcase.tsx
@@ -3,33 +3,29 @@
 import {XDSCollapsible, XDSCollapsibleGroup} from '@xds/core/Collapsible';
 import {XDSText} from '@xds/core/Text';
 import {XDSCard} from '@xds/core/Card';
-import {XDSStack} from '@xds/core/Layout';
+import {XDSVStack} from '@xds/core/Layout';
 
 export default function CollapsibleShowcase() {
   return (
     <XDSCard width={400}>
       <XDSCollapsibleGroup type="single" defaultValue="notifications">
-        <XDSCollapsible trigger="General settings" value="general">
-          <XDSStack direction="vertical" gap={3}>
+        <XDSVStack gap={2}>
+          <XDSCollapsible trigger="General settings" value="general">
             <XDSText type="body" color="secondary">
               Configure your display name, language, and time zone preferences.
             </XDSText>
-          </XDSStack>
-        </XDSCollapsible>
-        <XDSCollapsible trigger="Notifications" value="notifications">
-          <XDSStack direction="vertical" gap={3}>
+          </XDSCollapsible>
+          <XDSCollapsible trigger="Notifications" value="notifications">
             <XDSText type="body" color="secondary">
               Choose which email and push notifications you want to receive.
             </XDSText>
-          </XDSStack>
-        </XDSCollapsible>
-        <XDSCollapsible trigger="Privacy" value="privacy">
-          <XDSStack direction="vertical" gap={3}>
+          </XDSCollapsible>
+          <XDSCollapsible trigger="Privacy" value="privacy">
             <XDSText type="body" color="secondary">
               Manage your data sharing preferences and account visibility.
             </XDSText>
-          </XDSStack>
-        </XDSCollapsible>
+          </XDSCollapsible>
+        </XDSVStack>
       </XDSCollapsibleGroup>
     </XDSCard>
   );


### PR DESCRIPTION
Wraps the collapsible items in the showcase block with `XDSVStack gap={2}` so they have consistent spacing between them — matches the pattern used in the other Collapsible blocks (SingleAccordion, MultipleAccordion, etc.).

Also swaps `XDSStack direction="vertical"` → `XDSVStack` for consistency.

---
