### PR TITLE
feat(Stack): add width and height props

### DIFF
--- a/packages/core/src/Stack/Stack.doc.mjs
+++ b/packages/core/src/Stack/Stack.doc.mjs
@@ -23,6 +23,16 @@ export const docs = {
             'Numeric spacing step controlling the gap between items: 0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10.',
         },
         {
+          name: 'width',
+          type: 'SizeValue',
+          description: "Width of the stack container. Numbers are treated as pixels, strings are used as-is (e.g., '100%').",
+        },
+        {
+          name: 'height',
+          type: 'SizeValue',
+          description: "Height of the stack container. Numbers are treated as pixels, strings are used as-is (e.g., '100%').",
+        },
+        {
           name: 'hAlign',
           type: "'start' | 'center' | 'end' | 'between' | 'around' | 'evenly'",
           description: 'Horizontal (main-axis) alignment of items.',
@@ -77,6 +87,16 @@ export const docs = {
           type: 'SpacingStep',
           description:
             'Numeric spacing step controlling the gap between items: 0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10.',
+        },
+        {
+          name: 'width',
+          type: 'SizeValue',
+          description: "Width of the stack container. Numbers are treated as pixels, strings are used as-is (e.g., '100%').",
+        },
+        {
+          name: 'height',
+          type: 'SizeValue',
+          description: "Height of the stack container. Numbers are treated as pixels, strings are used as-is (e.g., '100%').",
         },
         {
           name: 'hAlign',
@@ -234,6 +254,16 @@ export const docsZh = {
             '控制元素间距的数值间距步进：0、0.5、1、1.5、2、3、4、5、6、8、10。',
         },
         {
+          name: 'width',
+          type: 'SizeValue',
+          description: '堆叠容器的宽度。数字按像素处理，字符串原样使用（如 \'100%\'）。',
+        },
+        {
+          name: 'height',
+          type: 'SizeValue',
+          description: '堆叠容器的高度。数字按像素处理，字符串原样使用（如 \'100%\'）。',
+        },
+        {
           name: 'hAlign',
           type: "'start' | 'center' | 'end' | 'between' | 'around' | 'evenly'",
           description: '水平（主轴）对齐方式。',
@@ -289,6 +319,16 @@ export const docsZh = {
           type: 'SpacingStep',
           description:
             '控制元素间距的数值间距步进：0、0.5、1、1.5、2、3、4、5、6、8、10。',
+        },
+        {
+          name: 'width',
+          type: 'SizeValue',
+          description: '堆叠容器的宽度。数字按像素处理，字符串原样使用（如 \'100%\'）。',
+        },
+        {
+          name: 'height',
+          type: 'SizeValue',
+          description: '堆叠容器的高度。数字按像素处理，字符串原样使用（如 \'100%\'）。',
         },
         {
           name: 'hAlign',
@@ -441,6 +481,8 @@ export const docsDense = {
       description: 'Horizontal stack; left-to-right, polymorphic rendering.',
       propDescriptions: {
         gap: 'Numeric spacing step for gap: 0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10.',
+        width: "Width of container. Numbers=pixels, strings=as-is (e.g. '100%').",
+        height: "Height of container. Numbers=pixels, strings=as-is (e.g. '100%').",
         hAlign: 'Horizontal (main-axis) alignment.',
         vAlign: 'Vertical (cross-axis) alignment.',
         justify: 'Main-axis alignment alias for hAlign. Mirrors CSS justify-content.',
@@ -456,6 +498,8 @@ export const docsDense = {
       description: 'Vertical stack; top-to-bottom, polymorphic rendering.',
       propDescriptions: {
         gap: 'Numeric spacing step for gap: 0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10.',
+        width: "Width of container. Numbers=pixels, strings=as-is (e.g. '100%').",
+        height: "Height of container. Numbers=pixels, strings=as-is (e.g. '100%').",
         hAlign: 'Horizontal (cross-axis) alignment.',
         vAlign: 'Vertical (main-axis) alignment.',
         justify: 'Main-axis alignment alias for vAlign. Mirrors CSS justify-content.',

--- a/packages/core/src/Stack/XDSStack.test.tsx
+++ b/packages/core/src/Stack/XDSStack.test.tsx
@@ -202,4 +202,54 @@ describe('XDSStack', () => {
     );
     expect(container.firstChild).toBeInTheDocument();
   });
+
+  it('applies numeric width as pixels', () => {
+    render(
+      <XDSStack direction="vertical" width={300} data-testid="stack">
+        <div>Item</div>
+      </XDSStack>,
+    );
+    expect(screen.getByTestId('stack')).toHaveStyle({width: '300px'});
+  });
+
+  it('applies string width as-is', () => {
+    render(
+      <XDSStack direction="vertical" width="100%" data-testid="stack">
+        <div>Item</div>
+      </XDSStack>,
+    );
+    expect(screen.getByTestId('stack')).toHaveStyle({width: '100%'});
+  });
+
+  it('applies numeric height as pixels', () => {
+    render(
+      <XDSStack direction="horizontal" height={200} data-testid="stack">
+        <div>Item</div>
+      </XDSStack>,
+    );
+    expect(screen.getByTestId('stack')).toHaveStyle({height: '200px'});
+  });
+
+  it('applies string height as-is', () => {
+    render(
+      <XDSStack direction="horizontal" height="50vh" data-testid="stack">
+        <div>Item</div>
+      </XDSStack>,
+    );
+    expect(screen.getByTestId('stack')).toHaveStyle({height: '50vh'});
+  });
+
+  it('applies both width and height together', () => {
+    render(
+      <XDSStack
+        direction="vertical"
+        width={400}
+        height="100%"
+        data-testid="stack">
+        <div>Item</div>
+      </XDSStack>,
+    );
+    const el = screen.getByTestId('stack');
+    expect(el).toHaveStyle({width: '400px', height: '100%'});
+  });
 });

--- a/packages/core/src/Stack/XDSStack.tsx
+++ b/packages/core/src/Stack/XDSStack.tsx
@@ -28,6 +28,7 @@ import {
   type StackWrap,
   type SpacingStep,
 } from './stack.stylex';
+import type {SizeValue} from '../utils/types';
 import {xdsClassName, mergeProps} from '../utils';
 
 /**
@@ -90,6 +91,18 @@ export interface XDSStackProps extends XDSBaseProps<HTMLDivElement> {
    * Mirrors CSS `align-items` / Tailwind `items-*`.
    */
   align?: StackCrossAlignment;
+
+  /**
+   * Width of the stack container.
+   * Numbers are treated as pixels, strings are used as-is (e.g., '100%').
+   */
+  width?: SizeValue;
+
+  /**
+   * Height of the stack container.
+   * Numbers are treated as pixels, strings are used as-is (e.g., '100%').
+   */
+  height?: SizeValue;
 
   /**
    * Spacing between items.
@@ -170,6 +183,8 @@ export function XDSStack({
   justify,
   align,
   gap,
+  width,
+  height,
   wrap,
   element = 'div',
   xstyle,
@@ -212,6 +227,16 @@ export function XDSStack({
     xstyle,
   );
 
+  // Build inline style for dynamic sizing values
+  const sizingStyle: React.CSSProperties = {
+    ...(width != null && {
+      width: typeof width === 'number' ? `${width}px` : width,
+    }),
+    ...(height != null && {
+      height: typeof height === 'number' ? `${height}px` : height,
+    }),
+  };
+
   return createElement(
     element,
     {
@@ -220,7 +245,7 @@ export function XDSStack({
         xdsClassName('stack', {direction, gap, wrap}),
         stylexProps,
         className,
-        style,
+        {...style, ...sizingStyle},
       ),
       ...props,
     },


### PR DESCRIPTION
Add `width` and `height` sizing props to `XDSStack`, matching the pattern already used by `XDSCenter` and `XDSGrid`. Numbers are treated as pixels, strings are used as-is (e.g. `'100%'`).

`XDSHStack` and `XDSVStack` inherit these props automatically since they spread through to `XDSStack`.

### Changes
- **`XDSStack.tsx`** — Added `width?: SizeValue` and `height?: SizeValue` props, applied via inline style
- **`XDSStack.test.tsx`** — 5 new tests covering numeric px, string %, string vh, and combined usage
- **`Stack.doc.mjs`** — Updated English, Chinese, and dense docs for HStack and VStack

---
