### PR TITLE
fix: extend XDSBaseProps in Banner and Breadcrumbs

### DIFF
--- a/packages/core/src/Banner/XDSBanner.tsx
+++ b/packages/core/src/Banner/XDSBanner.tsx
@@ -22,7 +22,7 @@
 
 import {useState, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import type {StyleXStyles} from '@stylexjs/stylex';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import {XDSButton} from '../Button';
 import {XDSIcon} from '../Icon';
 import type {XDSIconName} from '../Icon';
@@ -92,7 +92,7 @@ export interface XDSBannerContainerMap {
  */
 export type XDSBannerContainer = keyof XDSBannerContainerMap;
 
-export interface XDSBannerProps {
+export interface XDSBannerProps extends XDSBaseProps<HTMLDivElement> {
   /** Ref forwarded to the root element */
   ref?: React.Ref<HTMLDivElement>;
   /**
@@ -152,31 +152,6 @@ export interface XDSBannerProps {
    * When provided, a collapse/expand toggle button appears in the header.
    */
   children?: ReactNode;
-  /**
-   * StyleX styles created via `stylex.create()`. Merged with the component's
-   * base styles inside a single `stylex.props()` call for optimal deduplication.
-   *
-   * @example
-   * ```
-   * const overrides = stylex.create({ root: { marginBottom: 8 } });
-   * <Component xstyle={overrides.root} />
-   * ```
-   */
-  xstyle?: StyleXStyles;
-  /**
-   * CSS class name(s) appended to the root element.
-   * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
-   */
-  className?: string;
-  /**
-   * Inline styles to apply to the root element. Spread after StyleX
-   * inline styles, so these values take priority.
-   */
-  style?: React.CSSProperties;
-  /**
-   * Test ID for the root element.
-   */
-  'data-testid'?: string;
 }
 
 // =============================================================================
@@ -385,8 +360,8 @@ export function XDSBanner({
   xstyle,
   className,
   style,
-  'data-testid': testId,
   ref,
+  ...rest
 }: XDSBannerProps) {
   const [isDismissed, setIsDismissed] = useState(false);
   const [isExpanded, setIsExpanded] = useState(defaultIsExpanded);
@@ -419,7 +394,6 @@ export function XDSBanner({
     <div
       ref={ref}
       role={role}
-      data-testid={testId}
       {...mergeProps(
         xdsClassName('banner', {container, status}),
         stylex.props(
@@ -430,7 +404,8 @@ export function XDSBanner({
         ),
         className,
         style,
-      )}>
+      )}
+      {...rest}>
       {/* Header: colored status background */}
       <div
         {...stylex.props(

--- a/packages/core/src/Breadcrumbs/XDSBreadcrumbs.tsx
+++ b/packages/core/src/Breadcrumbs/XDSBreadcrumbs.tsx
@@ -16,9 +16,9 @@
 
 import {createContext, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import type {StyleXStyles} from '@stylexjs/stylex';
 import {spacingVars} from '../theme/tokens.stylex';
 import {xdsClassName, mergeProps} from '../utils';
+import type {XDSBaseProps} from '../XDSBaseProps';
 
 // =============================================================================
 // Variant type
@@ -70,7 +70,7 @@ export const BreadcrumbCtx = createContext<BreadcrumbContextValue>({
 // Props
 // =============================================================================
 
-export interface XDSBreadcrumbsProps {
+export interface XDSBreadcrumbsProps extends XDSBaseProps<HTMLElement> {
   /** Ref forwarded to the root element */
   ref?: React.Ref<HTMLElement>;
   /**
@@ -90,35 +90,10 @@ export interface XDSBreadcrumbsProps {
    */
   variant?: XDSBreadcrumbsVariant;
   /**
-   * StyleX styles created via `stylex.create()`. Merged with the component's
-   * base styles inside a single `stylex.props()` call for optimal deduplication.
-   *
-   * @example
-   * ```
-   * const overrides = stylex.create({ root: { marginBottom: 8 } });
-   * <Component xstyle={overrides.root} />
-   * ```
-   */
-  xstyle?: StyleXStyles;
-  /**
-   * CSS class name(s) appended to the root element.
-   * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
-   */
-  className?: string;
-  /**
-   * Inline styles to apply to the root element. Spread after StyleX
-   * inline styles, so these values take priority.
-   */
-  style?: React.CSSProperties;
-  /**
    * Accessible label for the nav landmark.
    * @default 'Breadcrumb'
    */
   label?: string;
-  /**
-   * Test ID for the nav element.
-   */
-  'data-testid'?: string;
 }
 
 // =============================================================================
@@ -172,8 +147,8 @@ export function XDSBreadcrumbs({
   className,
   style,
   label = 'Breadcrumb',
-  'data-testid': testId,
   ref,
+  ...rest
 }: XDSBreadcrumbsProps) {
   const ctxValue: BreadcrumbContextValue = {variant, separator};
 
@@ -182,13 +157,13 @@ export function XDSBreadcrumbs({
       <nav
         ref={ref}
         aria-label={label}
-        data-testid={testId}
         {...mergeProps(
           xdsClassName('breadcrumbs', {variant}),
           stylex.props(navStyles.root, xstyle),
           className,
           style,
-        )}>
+        )}
+        {...rest}>
         <ol {...stylex.props(listStyles.root)}>{children}</ol>
       </nav>
     </BreadcrumbCtx.Provider>


### PR DESCRIPTION
## Night Watch — Component Auditor (2026-04-25)

### Audit Summary

**Pass 1 — Hardening Issues** (Stack, ToggleButton, DropdownMenu, Card, ChatComposer):
All 5 components clean — no findings.

**Pass 2 — Queue** (Banner, Breadcrumbs, Button, Calendar, Carousel):
- **Banner**: `XDSBannerProps` did not extend `XDSBaseProps` — missing event handlers, `id`, `aria-*`, and `data-*` pattern support
- **Breadcrumbs**: `XDSBreadcrumbsProps` did not extend `XDSBaseProps` — same gaps
- **Button**: Clean ✅
- **Calendar**: Clean ✅
- **Carousel**: Clean ✅

### Changes

- `XDSBannerProps` now extends `XDSBaseProps<HTMLDivElement>`
- `XDSBreadcrumbsProps` now extends `XDSBaseProps<HTMLElement>`
- Removed redundant manual `xstyle`/`className`/`style`/`data-testid` declarations (now inherited)
- Added `...rest` spread to root elements for prop passthrough

### Needs Review

- **XDSBreadcrumbItemProps** does not extend `XDSBaseProps` and lacks `xstyle`/`className`/`style` escape hatches. This is a compound item with complex rendering (link/button/span), so extending BaseProps needs human judgment on where to apply the spread.

### Tests
All 54 existing tests pass (30 Banner, 24 Breadcrumbs).
