### PR TITLE
fix: add pull-requests:read permission to prune workflow

### DIFF
--- a/.github/workflows/prune-branches.yml
+++ b/.github/workflows/prune-branches.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: read
 
 jobs:
   prune:


### PR DESCRIPTION
## Problem

The `prune-branches` workflow runs daily and reports "Nothing to prune 🎉" every time — while 435+ stale branches accumulated.

## Root Cause

The workflow declares:
```yaml
permissions:
  contents: write
```

When you explicitly set `permissions` in a GitHub Actions workflow, it **overrides all defaults** — including `pull-requests: read`. This means `gh pr list` silently fails (`2>/dev/null` swallows the error), every branch gets state `error`, falls through to the commit-date stale check, and since the repo is only ~4 months old, nothing exceeds the 60-day threshold.

Result: every branch is classified as "keep (open PR or recent)" and nothing is ever deleted.

## Fix

Add `pull-requests: read` so the script can actually query PR status.

## Testing

Verified locally that `gh pr list --state all --head <branch>` correctly returns `MERGED`/`CLOSED` for branches with closed PRs. The script logic is fine — it just needs the permission to read PR data.

After merging, trigger the workflow manually via `workflow_dispatch` to verify it prunes correctly.

---
