### PR TITLE
fix: remove all unused import/variable lint warnings in storybook

### DIFF
--- a/apps/storybook/stories/AnalyticsDashboard.stories.tsx
+++ b/apps/storybook/stories/AnalyticsDashboard.stories.tsx
@@ -3,8 +3,7 @@ import type {Meta, StoryObj} from '@storybook/react';
 import * as stylex from '@stylexjs/stylex';
 import {XDSCard} from '@xds/core/Card';
 import {XDSVStack, XDSHStack} from '@xds/core/Layout';
-import {XDSText, XDSHeading} from '@xds/core/Text';
-import {XDSLink} from '@xds/core/Link';
+import {XDSText} from '@xds/core/Text';
 import {XDSTabList, XDSTab} from '@xds/core/TabList';
 import {XDSTopNav, XDSTopNavHeading} from '@xds/core/TopNav';
 import {XDSButton} from '@xds/core/Button';
@@ -79,7 +78,7 @@ import {XDSDropdownMenu} from '@xds/core/DropdownMenu';
 import {XDSMoreMenu} from '@xds/core/MoreMenu';
 import {XDSDialog, XDSDialogHeader} from '@xds/core/Dialog';
 import {XDSLayout, XDSLayoutContent, XDSLayoutFooter} from '@xds/core/Layout';
-import {XDSTable, proportional, pixel} from '@xds/core/Table';
+import {XDSTable, proportional} from '@xds/core/Table';
 import type {XDSTableColumn} from '@xds/core/Table';
 import {XDSPagination} from '@xds/core/Pagination';
 import {

--- a/apps/storybook/stories/ChartStreamGL.stories.tsx
+++ b/apps/storybook/stories/ChartStreamGL.stories.tsx
@@ -1,5 +1,5 @@
 import type {Meta, StoryObj} from '@storybook/react';
-import {useRef, useEffect, useState, useCallback} from 'react';
+import {useRef, useEffect, useState} from 'react';
 import {
   XDSChart,
   XDSChartAxis,

--- a/apps/storybook/stories/ChartStreamPerf.stories.tsx
+++ b/apps/storybook/stories/ChartStreamPerf.stories.tsx
@@ -1,5 +1,5 @@
 import type {Meta, StoryObj} from '@storybook/react';
-import {useRef, useEffect, useState, useCallback} from 'react';
+import {useRef, useEffect, useState} from 'react';
 import {
   XDSChart,
   XDSChartAxis,

--- a/apps/storybook/stories/ChartV2.stories.tsx
+++ b/apps/storybook/stories/ChartV2.stories.tsx
@@ -1,5 +1,5 @@
 import type {Meta, StoryObj} from '@storybook/react';
-import {XDSChartV2 as XDSChart, bar, line, dot, area, band} from '@xds/lab';
+import {XDSChartV2 as XDSChart, bar, line, area} from '@xds/lab';
 import {XDSChartGrid, XDSChartAxis} from '@xds/lab';
 
 const meta: Meta<typeof XDSChart> = {

--- a/apps/storybook/stories/ChartV2Advanced.stories.tsx
+++ b/apps/storybook/stories/ChartV2Advanced.stories.tsx
@@ -4,8 +4,6 @@ import {
   XDSChartV2 as XDSChart,
   bar,
   line,
-  dot,
-  area,
   band,
   candlestick,
   errorBar,
@@ -15,7 +13,6 @@ import {
   streamGL,
 } from '@xds/lab';
 import {XDSChartGrid, XDSChartAxis} from '@xds/lab';
-import {XDSText} from '@xds/core';
 
 const meta: Meta<typeof XDSChart> = {
   title: 'Lab/XDSChart v2/Advanced',
@@ -61,7 +58,7 @@ const salesData = [
   {month: 'Jun', sales: 70, target: 50, errorHigh: 76, errorLow: 64},
 ];
 
-const scatterData = Array.from({length: 200}, (_, i) => ({
+const scatterData = Array.from({length: 200}, (_) => ({
   x: Math.random() * 100,
   y: Math.random() * 100,
 }));

--- a/apps/storybook/stories/ChatComposer.stories.tsx
+++ b/apps/storybook/stories/ChatComposer.stories.tsx
@@ -2,7 +2,6 @@ import type {Meta, StoryObj} from '@storybook/react';
 import {
   XDSChatComposer,
   XDSChatComposerDrawer,
-  XDSChatComposerInput,
   XDSChatSendButton,
 } from '@xds/core/Chat';
 import {XDSToken} from '@xds/core/Token';

--- a/apps/storybook/stories/ChatDictation.stories.tsx
+++ b/apps/storybook/stories/ChatDictation.stories.tsx
@@ -7,7 +7,7 @@ import {
 } from '@xds/core/Chat';
 import type {XDSChatComposerInputHandle} from '@xds/core/Chat';
 import type {UseSpeechRecognitionReturn} from '@xds/core/Chat';
-import {useState, useRef} from 'react';
+import {useRef} from 'react';
 
 // =============================================================================
 // Mock dictation values for non-interactive stories

--- a/apps/storybook/stories/ChatLayout.stories.tsx
+++ b/apps/storybook/stories/ChatLayout.stories.tsx
@@ -24,7 +24,6 @@ import {HandThumbUpIcon, HandThumbDownIcon} from '@heroicons/react/24/outline';
 import {ClipboardDocumentIcon} from '@heroicons/react/24/outline';
 import {XDSCodeBlock} from '@xds/core/CodeBlock';
 import {XDSProgressBar} from '@xds/core/ProgressBar';
-import {XDSAvatar} from '@xds/core/Avatar';
 import {useXDSTooltip} from '@xds/core/Tooltip';
 import {createStaticSource} from '@xds/core/Typeahead';
 import {XDSEmptyState} from '@xds/core/EmptyState';

--- a/apps/storybook/stories/CodeEditorTheme.stories.tsx
+++ b/apps/storybook/stories/CodeEditorTheme.stories.tsx
@@ -62,11 +62,11 @@ const sampleCode = [
 
 function ThemedEditor({
   theme,
-  title,
+  _title,
   initialCode = sampleCode,
 }: {
   theme: Parameters<typeof SyntaxThemeProvider>[0]['theme'];
-  title?: string;
+  _title?: string;
   initialCode?: string;
 }) {
   const [value, setValue] = useState(initialCode);

--- a/apps/storybook/stories/CommandPalette.stories.tsx
+++ b/apps/storybook/stories/CommandPalette.stories.tsx
@@ -10,8 +10,6 @@ import type {Meta, StoryObj} from '@storybook/react';
 import {
   XDSCommandPalette,
   XDSCommandPaletteInput,
-  XDSCommandPaletteItem,
-  XDSCommandPaletteGroup,
   XDSCommandPaletteFooter,
 } from '@xds/core/CommandPalette';
 import {XDSButton} from '@xds/core/Button';

--- a/apps/storybook/stories/PowerSearch.stories.tsx
+++ b/apps/storybook/stories/PowerSearch.stories.tsx
@@ -4,7 +4,6 @@ import {XDSPowerSearch} from '@xds/core/PowerSearch';
 import type {
   PowerSearchConfig,
   PowerSearchFilter,
-  PowerSearchChangeType,
 } from '@xds/core/PowerSearch';
 import type {XDSSearchSource, XDSSearchableItem} from '@xds/core/Typeahead';
 import {XDSButton} from '@xds/core/Button';
@@ -351,7 +350,7 @@ export const FullFeatured: Story = {
           {...args}
           config={fullConfig}
           filters={filters}
-          onChange={(newFilters, changeType, index) => {
+          onChange={(newFilters, _changeType, _index) => {
             setFilters([...newFilters]);
           }}
         />
@@ -717,7 +716,7 @@ export const WithOnChangeTracking: Story = {
           {...args}
           config={basicConfig}
           filters={filters}
-          onChange={(newFilters, changeType, index) => {
+          onChange={(newFilters, _changeType, _index) => {
             setFilters([...newFilters]);
             setLog(prev => [
               ...prev,

--- a/apps/storybook/stories/RadialChart.stories.tsx
+++ b/apps/storybook/stories/RadialChart.stories.tsx
@@ -8,7 +8,7 @@ import {
   XDSChartLegend,
   useXDSChartColors,
 } from '@xds/lab';
-import {XDSStack, XDSText} from '@xds/core';
+import {XDSStack} from '@xds/core';
 import {XDSHeading} from '@xds/core/Text';
 
 const meta: Meta = {

--- a/apps/storybook/stories/SVGIcon.stories.tsx
+++ b/apps/storybook/stories/SVGIcon.stories.tsx
@@ -14,7 +14,6 @@ import {
   searchIcon,
   mailIcon,
   lockIcon,
-  iconVars,
 } from '@xds/lab';
 import {XDSStack, XDSText, XDSDivider} from '@xds/core';
 

--- a/apps/storybook/stories/SVGIconRegistry.stories.tsx
+++ b/apps/storybook/stories/SVGIconRegistry.stories.tsx
@@ -75,7 +75,7 @@ function jsxSvgToIconDef(name: string, element: ReactElement): SVGIconDef | null
     const type = child.type as string;
     if (!['path', 'circle', 'rect', 'line', 'polyline', 'polygon'].includes(type)) continue;
     
-    const {key, children: _, ...rawAttrs} = child.props as Record<string, unknown>;
+    const {key: _key, children: _, ...rawAttrs} = child.props as Record<string, unknown>;
     
     // Clean attrs
     const attrs: Record<string, string> = {};

--- a/apps/storybook/stories/TabList.stories.tsx
+++ b/apps/storybook/stories/TabList.stories.tsx
@@ -2,9 +2,6 @@ import {useState} from 'react';
 import type {Meta, StoryObj} from '@storybook/react';
 import {XDSTabList, XDSTab, XDSTabMenu} from '@xds/core/TabList';
 import {XDSButton} from '@xds/core/Button';
-import {XDSDivider} from '@xds/core/Divider';
-import {XDSHStack} from '@xds/core/Stack';
-import {XDSStackItem} from '@xds/core/Stack';
 import {PlusIcon, FunnelIcon} from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof XDSTabList> = {

--- a/apps/storybook/stories/TableColumnResize.stories.tsx
+++ b/apps/storybook/stories/TableColumnResize.stories.tsx
@@ -5,7 +5,6 @@ import {
   useXDSTableColumnResize,
   useXDSTableSelection,
   useXDSTableSelectionState,
-  proportional,
   pixel,
 } from '@xds/core/Table';
 import type {XDSTableColumn} from '@xds/core/Table';

--- a/apps/storybook/stories/TableFiltering.stories.tsx
+++ b/apps/storybook/stories/TableFiltering.stories.tsx
@@ -332,7 +332,7 @@ export const WithSorting: Story = {
     const {filters, onFilterChange} = useXDSTableFilterState();
     const {
       sortedData: _unused,
-      sort,
+      sort: _sort,
       sortConfig,
       applySort,
     } = useXDSTableSortableState<Employee>({

--- a/apps/storybook/stories/ThreeD-Backdrop.stories.tsx
+++ b/apps/storybook/stories/ThreeD-Backdrop.stories.tsx
@@ -1,6 +1,6 @@
 import type {Meta, StoryObj} from '@storybook/react';
 import {useMemo} from 'react';
-import {XDS3DChart, XDS3DScatter, use3D, useXDSChartColors} from '@xds/lab';
+import {XDS3DChart, use3D} from '@xds/lab';
 
 const meta: Meta = {title: 'Lab/3DChart/Backdrop'};
 export default meta;

--- a/apps/storybook/stories/ThreeD-Showcase.stories.tsx
+++ b/apps/storybook/stories/ThreeD-Showcase.stories.tsx
@@ -4,7 +4,6 @@ import {
   XDS3DChart,
   XDS3DScatter,
   XDS3DScatterGL,
-  useXDSChartColors,
 } from '@xds/lab';
 import {XDSMediaTheme} from '@xds/core/theme';
 

--- a/apps/storybook/stories/ThreeDChart.stories.tsx
+++ b/apps/storybook/stories/ThreeDChart.stories.tsx
@@ -6,7 +6,6 @@ import {
   XDS3DGrid,
   XDS3DAxis,
   XDS3DSurface,
-  XDSChartLegend,
   useXDSChartColors,
 } from '@xds/lab';
 import {XDSStack, XDSText} from '@xds/core';

--- a/apps/storybook/stories/Tokenizer.stories.tsx
+++ b/apps/storybook/stories/Tokenizer.stories.tsx
@@ -310,7 +310,7 @@ export const Creatable: Story = {
           {...args}
           searchSource={emptySource}
           value={tags}
-          onChange={(items, change) => {
+          onChange={(items, _change) => {
             setTags(items);
           }}
           hasCreate
@@ -336,7 +336,7 @@ export const CreatableWithSearch: Story = {
         {...args}
         searchSource={userSource}
         value={value}
-        onChange={(items, change) => {
+        onChange={(items, _change) => {
           setValue(items);
         }}
         hasCreate

--- a/apps/storybook/stories/Toolbar.stories.tsx
+++ b/apps/storybook/stories/Toolbar.stories.tsx
@@ -17,7 +17,6 @@ import {XDSHeading} from '@xds/core/Text';
 import {
   Cog6ToothIcon,
   FunnelIcon,
-  MagnifyingGlassIcon,
   PlusIcon,
   ArrowDownTrayIcon,
   ArrowPathIcon,


### PR DESCRIPTION
## Summary

Cleans up all 35 `@typescript-eslint/no-unused-vars` warnings across 22 storybook story files.

### Changes

- **Removed unused imports** — `XDSHeading`, `XDSLink`, `useCallback`, `dot`, `band`, `area`, `XDSText`, `XDSChatComposerInput`, `useState`, `XDSAvatar`, `XDSCommandPaletteItem`, `XDSCommandPaletteGroup`, `PowerSearchChangeType`, `iconVars`, `XDSDivider`, `XDSHStack`, `XDSStackItem`, `proportional`, `XDS3DScatter`, `useXDSChartColors`, `XDSChartLegend`, `MagnifyingGlassIcon`, `pixel`
- **Prefixed unused params with `_`** — `change` → `_change`, `changeType` → `_changeType`, `index` → `_index`, `title` → `_title`
- **Renamed unused destructured vars** — `key` → `_key`, `sort` → `_sort`

### Result

```
npx eslint "apps/storybook/**/*.{ts,tsx}"
# ✨ 0 problems
```

---
