### PR TITLE
docs(storybook): fix @example blocks for Storybook autodocs

### DIFF
--- a/packages/core/src/Layout/XDSLayoutPanel.tsx
+++ b/packages/core/src/Layout/XDSLayoutPanel.tsx
@@ -163,7 +163,7 @@ export interface XDSLayoutPanelProps extends XDSBaseProps<HTMLDivElement> {
    * to this panel.
    *
    * @example
-   * ```tsx
+   * ```
    * const sidebar = useXDSResizable({ defaultSize: 250, minSizePx: 200 });
    * <XDSLayoutPanel resizable={sidebar.props}>
    *   <Navigation />

--- a/packages/core/src/Resizable/XDSResizeHandle.tsx
+++ b/packages/core/src/Resizable/XDSResizeHandle.tsx
@@ -193,6 +193,19 @@ export interface XDSResizeHandleProps extends Omit<
   xstyle?: stylex.StyleXStyles;
 }
 
+/**
+ * Draggable resize handle placed between resizable panels. Renders as a thin
+ * divider line with a wider invisible hit area and optional pill grip indicator.
+ * Supports keyboard resizing via arrow keys and WAI-ARIA separator role.
+ *
+ * @example
+ * ```
+ * <XDSResizeHandle
+ *   resizable={sidebar.props}
+ *   direction="horizontal"
+ *   hasDivider />
+ * ```
+ */
 export function XDSResizeHandle({
   direction = 'horizontal',
   isReversed = false,

--- a/packages/core/src/SelectableCard/XDSSelectableCard.tsx
+++ b/packages/core/src/SelectableCard/XDSSelectableCard.tsx
@@ -228,7 +228,6 @@ export interface XDSSelectableCardProps extends Omit<XDSBaseProps, 'onChange'> {
 
   /** Maximum width of the card. */
   maxWidth?: SizeValue;
-
 }
 
 // =============================================================================
@@ -253,42 +252,12 @@ export interface XDSSelectableCardProps extends Omit<XDSBaseProps, 'onChange'> {
  *
  * @example
  * ```
- * // Single select (radio behavior)
- * const [selected, setSelected] = useState<string | null>(null);
- *
- * {plans.map(plan => (
- *   <XDSSelectableCard
- *     key={plan.id}
- *     label={plan.name}
- *     isSelected={selected === plan.id}
- *     onChange={() => setSelected(plan.id)}
- *   >
- *     <XDSText type="body" weight="bold">{plan.name}</XDSText>
- *   </XDSSelectableCard>
- * ))}
- * ```
- *
- * @example
- * ```
- * // Multi-select (checkbox behavior)
- * const [selected, setSelected] = useState(new Set<string>());
- *
- * {filters.map(filter => (
- *   <XDSSelectableCard
- *     key={filter.id}
- *     label={filter.name}
- *     isSelected={selected.has(filter.id)}
- *     onChange={(isNowSelected) => {
- *       setSelected(prev => {
- *         const next = new Set(prev);
- *         isNowSelected ? next.add(filter.id) : next.delete(filter.id);
- *         return next;
- *       });
- *     }}
- *   >
- *     <XDSText type="body">{filter.name}</XDSText>
- *   </XDSSelectableCard>
- * ))}
+ * <XDSSelectableCard
+ *   label="Option A"
+ *   isSelected={selected === 'a'}
+ *   onChange={() => setSelected('a')}>
+ *   <XDSText type="body" weight="bold">Option A</XDSText>
+ * </XDSSelectableCard>
  * ```
  */
 export function XDSSelectableCard({
@@ -341,14 +310,16 @@ export function XDSSelectableCard({
         variant,
         selected: isSelected ? 'true' : 'false',
       })}
-      xstyle={[
-        styles.interactive,
-        styles.focusWithin,
-        isSelected && selectedStyleForVariant(variant),
-        !isDisabled && styles.overlay,
-        !isDisabled && styles.hoverOnPointer,
-        isDisabled && styles.disabled,
-      ] as unknown as StyleXStyles}
+      xstyle={
+        [
+          styles.interactive,
+          styles.focusWithin,
+          isSelected && selectedStyleForVariant(variant),
+          !isDisabled && styles.overlay,
+          !isDisabled && styles.hoverOnPointer,
+          isDisabled && styles.disabled,
+        ] as unknown as StyleXStyles
+      }
       onClick={!isDisabled ? onClick : undefined}
       onMouseUp={!isDisabled ? onMouseUp : undefined}
       {...props}>


### PR DESCRIPTION
## What

Fix 3 Storybook-incompatible `@example` blocks found during Night Watch doc review:

1. **XDSLayoutPanel** — Remove `````tsx`` language tag on `resizable` prop JSDoc (Storybook chokes on the `tsx` tag)
2. **XDSSelectableCard** — Consolidate 2 `@example` blocks into 1, remove JS comments (`//`), blank lines, and bare `>` inside code blocks that break Storybook's markdown parser
3. **XDSResizeHandle** — Add missing `@example` JSDoc (public 418-line component had no example)

## Why

Storybook autodocs parses JSDoc `@example` blocks as markdown. Blank lines inside code fences end the code block early, JS comments confuse the parser, and bare `>` on its own line becomes a markdown blockquote.

## Checklist
- [x] No `````tsx`` in docblocks
- [x] No blank lines, JS comments, or bare `>` inside `@example` code blocks
- [x] Single concise `@example` per component
- [x] Lint + prettier pass

---
*Night Watch Doc Reviewer*