### PR TITLE
fix: component audit — add xdsClassName to PowerSearch

### DIFF
--- a/packages/core/src/PowerSearch/XDSPowerSearch.tsx
+++ b/packages/core/src/PowerSearch/XDSPowerSearch.tsx
@@ -40,6 +40,7 @@ import {
   typeScaleVars,
   fontWeightVars,
 } from '../theme/tokens.stylex';
+import {xdsClassName} from '../utils';
 import {useInternalConfig} from './useInternalConfig';
 import {usePowerSearchSource} from './usePowerSearchSource';
 import {formatFilterValue} from './formatFilterValue';
@@ -822,7 +823,7 @@ export function XDSPowerSearch({
 
   return (
     <>
-      <div ref={popover.triggerRef}>
+      <div ref={popover.triggerRef} className={xdsClassName('power-search')}>
         <XDSTokenizer
           ref={tokenizerRef}
           label={label}


### PR DESCRIPTION
## Component Audit — Queue Round (2026-04-26)

Night Watch Component Auditor queue pass. Audited 5 components from the regular queue.

### Audited Components

| Component | Result |
|-----------|--------|
| **Popover** | ✅ Clean — all conventions met |
| **PowerSearch** | 🔧 Missing xdsClassName — fixed |
| **ProgressBar** | ✅ Clean — all conventions met |
| **RadioList** | ✅ Clean — all conventions met |
| **Section** | ✅ Clean — all conventions met |

### Fix

**XDSPowerSearch** — Added `xdsClassName('power-search')` to the wrapper element. Without this, theme packages had no way to target PowerSearch with component overrides.

### Needs Review
None — objective convention fix.

---