### PR TITLE
fix: use Range API for multi-line truncation detection

### DIFF
--- a/apps/storybook/stories/Text.stories.tsx
+++ b/apps/storybook/stories/Text.stories.tsx
@@ -315,6 +315,74 @@ export const TruncationVariants: Story = {
 };
 
 // =============================================================================
+// Multi-Line Truncation Tooltip (fix for #1710)
+// =============================================================================
+
+/**
+ * Demonstrates the fix for #1710: multi-line truncation tooltip now works.
+ * Previously, hovering over clamped multi-line text never showed a tooltip
+ * because `-webkit-line-clamp` caused `scrollHeight === offsetHeight`.
+ */
+export const MultiLineTruncationTooltip: Story = {
+  render: () => (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '24px',
+        maxWidth: '280px',
+      }}>
+      <div>
+        <XDSText type="label" display="block">
+          maxLines=1 (always worked):
+        </XDSText>
+        <div style={{border: '1px solid #ccc', padding: '8px'}}>
+          <XDSText type="body" maxLines={1}>
+            This single-line text is long enough to be truncated with an
+            ellipsis. Hover to see the full content in a tooltip.
+          </XDSText>
+        </div>
+      </div>
+      <div>
+        <XDSText type="label" display="block">
+          maxLines=2 (was broken, now fixed):
+        </XDSText>
+        <div style={{border: '1px solid #ccc', padding: '8px'}}>
+          <XDSText type="body" maxLines={2}>
+            This two-line text should show a tooltip on hover when it overflows
+            past two lines. Previously the tooltip never appeared because
+            truncation was not detected. Now it works correctly.
+          </XDSText>
+        </div>
+      </div>
+      <div>
+        <XDSText type="label" display="block">
+          maxLines=3 (was broken, now fixed):
+        </XDSText>
+        <div style={{border: '1px solid #ccc', padding: '8px'}}>
+          <XDSText type="body" maxLines={3}>
+            This three-line text has even more content to demonstrate that the
+            fix works for any maxLines value greater than one. The tooltip
+            should appear on hover showing the full untruncated text. Previously
+            this was broken because the browser reported clamped dimensions.
+          </XDSText>
+        </div>
+      </div>
+      <div>
+        <XDSText type="label" display="block">
+          maxLines=2, short text (no tooltip expected):
+        </XDSText>
+        <div style={{border: '1px solid #ccc', padding: '8px'}}>
+          <XDSText type="body" maxLines={2}>
+            Short text. No tooltip.
+          </XDSText>
+        </div>
+      </div>
+    </div>
+  ),
+};
+
+// =============================================================================
 // Word Break
 // =============================================================================
 

--- a/packages/core/src/Text/useTruncation.ts
+++ b/packages/core/src/Text/useTruncation.ts
@@ -10,7 +10,6 @@
  * - /packages/core/src/Text/Text.doc.mjs
  */
 
-
 import {useCallback, useRef, useState, type RefCallback} from 'react';
 
 export interface UseTruncationOptions {
@@ -43,7 +42,8 @@ export interface UseTruncationReturn {
  *
  * Uses ResizeObserver for efficient detection when content or container changes.
  * - Single-line: compares scrollWidth > offsetWidth
- * - Multi-line: compares scrollHeight > offsetHeight
+ * - Multi-line: uses Range.getBoundingClientRect() to measure actual content
+ *   height, bypassing -webkit-line-clamp's clamped scrollHeight
  *
  * @example
  * ```
@@ -80,8 +80,21 @@ export function useTruncation(
         // Single-line: check horizontal overflow
         setIsTruncated(element.scrollWidth > element.offsetWidth);
       } else {
-        // Multi-line: check vertical overflow
-        setIsTruncated(element.scrollHeight > element.offsetHeight);
+        // Multi-line: use Range to measure actual content height.
+        // When -webkit-line-clamp is active, browsers may report
+        // scrollHeight === offsetHeight (the clamped size), so the
+        // naive scrollHeight check fails. Range.getBoundingClientRect()
+        // measures the real text content regardless of clamping.
+        let contentHeight = element.scrollHeight;
+        try {
+          const range = document.createRange();
+          range.selectNodeContents(element);
+          contentHeight = range.getBoundingClientRect().height;
+          range.detach();
+        } catch {
+          // Fallback to scrollHeight (e.g. jsdom in tests)
+        }
+        setIsTruncated(contentHeight > element.offsetHeight);
       }
     },
     [maxLines],


### PR DESCRIPTION
## Summary

Fixes #1710 — `XDSText` with `maxLines >= 2` and `hasTruncateTooltip` never showed the truncation tooltip, even when text was visually clamped.

## Root Cause

When `-webkit-line-clamp` is active, browsers may report `scrollHeight === offsetHeight` for the clamped element. The existing check in `useTruncation.ts`:

```ts
setIsTruncated(element.scrollHeight > element.offsetHeight);
```

...always evaluated to `false`, so truncation was never detected for multi-line text.

Single-line (`maxLines === 1`) was unaffected because it uses `scrollWidth > offsetWidth` with `text-overflow: ellipsis` instead of line clamping.

## Fix

Replace the `scrollHeight` comparison with `Range.getBoundingClientRect().height`, which measures the actual content height regardless of `-webkit-line-clamp`:

```ts
const range = document.createRange();
range.selectNodeContents(element);
const contentHeight = range.getBoundingClientRect().height;
range.detach();
setIsTruncated(contentHeight > element.offsetHeight);
```

Falls back to `scrollHeight` in environments where `Range.getBoundingClientRect` is unavailable (e.g. jsdom in tests).

## Testing

- All existing tests pass (43/43)
- Added `MultiLineTruncationTooltip` story demonstrating the fix across maxLines 1, 2, and 3, plus a short-text case where no tooltip is expected
- Lint clean (0 errors)

## Stories

The new `MultiLineTruncationTooltip` story shows:
1. **maxLines=1** — always worked (baseline)
2. **maxLines=2** — was broken, now fixed
3. **maxLines=3** — was broken, now fixed
4. **maxLines=2 with short text** — correctly shows no tooltip when content fits