### PR TITLE
fix(build): remove turbopack key to fix broken styles in static export

### DIFF
--- a/packages/build/src/next.js
+++ b/packages/build/src/next.js
@@ -32,15 +32,15 @@ function withXDS(nextConfig = {}) {
   const merged = Array.from(new Set([...existingTranspile, ...xdsPackages]));
 
   const existingWebpack = nextConfig.webpack;
-  const existingTurbopack = nextConfig.turbopack;
-
   return {
     ...nextConfig,
     transpilePackages: merged,
-    // Next.js 16+ defaults to Turbopack and errors if only webpack config
-    // is present. An empty turbopack config silences the check, and
-    // transpilePackages handles @xds/* source resolution for both bundlers.
-    turbopack: existingTurbopack || {},
+    // Do NOT add a `turbopack` key here. The @xds/build babel plugin uses
+    // dual class-name prefixes (xds/x) that require webpack's Babel pipeline.
+    // Adding turbopack: {} forces Next.js 16+ to use Turbopack, which skips
+    // the Babel plugin and causes class-name mismatches in the compiled CSS.
+    // Without a turbopack key, Next.js 16 auto-detects babel.config.js and
+    // falls back to webpack.
     webpack: (config, context) => {
       // Resolve to source exports
       config.resolve.conditionNames = [


### PR DESCRIPTION
## Problem

The sandbox deployment on GitHub Pages has completely broken styles — giant sidebar icons, no backgrounds, no spacing, unstyled buttons. This affects **all** sandbox pages, not just the mega menu.

## Root Cause

PR #1807 (Next.js 15→16 upgrade) added a fix to `withXDS()` that included `turbopack: {}` in the Next.js config to "silence" a Next.js 16 compatibility check. However, this **forces** Next.js 16 to use Turbopack for production builds.

The `@xds/build` babel plugin uses **dual class-name prefixes**:
- `xds` prefix for library code (`packages/core/`, `packages/themes/`)
- `x` prefix for product/app code

This splitting only works with webpack's Babel transform pipeline. Turbopack uses SWC and **skips the Babel plugin entirely**, but the PostCSS plugin still compiles CSS with the `xds` prefix. Result:

| | HTML classes | CSS selectors | Match? |
|---|---|---|---|
| **Webpack (Babel)** | `.x78zum5` + `.xds78zum5` | `.x78zum5` + `.xds78zum5` | ✅ |
| **Turbopack (SWC)** | `.x78zum5` only | `.xds78zum5` | ❌ |

## Fix

Remove the `turbopack: {}` key from `withXDS()`. Without it, Next.js 16 auto-detects `babel.config.js` and falls back to webpack — which is the correct behavior for any app using the XDS Babel plugin.

## Verification

Built the sandbox static export locally and served it — styles render correctly with the fix applied.

**Before (Turbopack — broken):**
![broken](https://github.com/user-attachments/assets/placeholder-broken)

**After (webpack — fixed):**
![fixed](https://github.com/user-attachments/assets/placeholder-fixed)