### PR TITLE
fix(SegmentedControl): include layout prop in xdsClassName

### DIFF
--- a/packages/core/src/SegmentedControl/XDSSegmentedControl.tsx
+++ b/packages/core/src/SegmentedControl/XDSSegmentedControl.tsx
@@ -195,7 +195,7 @@ export function XDSSegmentedControl({
         aria-disabled={isDisabled || undefined}
         onKeyDown={handleKeyDown}
         {...mergeProps(
-          xdsClassName('segmented-control', {size}),
+          xdsClassName('segmented-control', {size, layout}),
           stylex.props(
             styles.container,
             sizeStyles[size],


### PR DESCRIPTION
## Component Audit — Queue Round (2026-04-27)

### Audited Components

| Component | Result |
|-----------|--------|
| **SegmentedControl** | 🔧 1 finding, fixed below |
| **Selector** | ✅ Clean — all conventions met |
| **SideNav** | ✅ Clean — all conventions met |
| **Skeleton** | ✅ Clean — all conventions met |
| **Slider** | ✅ Clean — all conventions met |

### Fixes

#### SegmentedControl — layout prop missing from xdsClassName
- **The layout prop was not included in the xdsClassName variant map** — it drives the styles.fill visual style but themes could not target .xds-segmented-control.fill because the variant class was never applied.

### Needs Review
- SegmentedControl uses --color-neutral for its background. The semantic token guide specifies --color-secondary for self-contained elements. Flagging for human review.