### PR TITLE
chore: trigger canary publish

### DIFF
--- a/.canary-trigger
+++ b/.canary-trigger
@@ -1,0 +1,1 @@
+# Canary trigger — 2026-04-27T16:31:08Z


### PR DESCRIPTION
Trigger CI canary publish from latest main for nest/apps/xds update. Will close after canary is published.