### PR TITLE
chore: bump all packages to v0.0.13

### DIFF
--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xds/build",
-  "version": "0.0.1",
+  "version": "0.0.13",
   "private": true,
   "description": "Build plugins for XDS source builds — babel, PostCSS, and Vite integrations",
   "author": "Meta Open Source",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xds/cli",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "XDS design system CLI — init, swizzle, theme, templates, and agent docs",
   "author": "Meta Open Source",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xds/core",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "XDS design system — accessible, themeable React components with automatic spacing and plugin architecture",
   "author": "Meta Open Source",
   "license": "MIT",

--- a/packages/lab/package.json
+++ b/packages/lab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xds/lab",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "private": true,
   "description": "Experimental XDS components — not published, available in storybook and sandbox for testing",
   "author": "Meta Open Source",
@@ -25,7 +25,7 @@
   "sideEffects": false,
   "peerDependencies": {
     "@stylexjs/stylex": ">=0.10.0",
-    "@xds/core": "*",
+    "@xds/core": "0.0.13",
     "react": ">=19.0.0",
     "react-dom": ">=19.0.0"
   },

--- a/packages/themes/brutalist/package.json
+++ b/packages/themes/brutalist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xds/theme-brutalist",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "private": true,
   "description": "Brutalist theme for XDS — zero radius, monospace, heavy borders",
   "author": "Meta Open Source",
@@ -49,9 +49,9 @@
     "build": "xds theme build src/brutalistTheme.ts -o dist/theme.css && tsup && tsc --project tsconfig.build.json"
   },
   "peerDependencies": {
-    "@xds/core": "*"
+    "@xds/core": "0.0.13"
   },
   "devDependencies": {
-    "@xds/cli": "*"
+    "@xds/cli": "0.0.13"
   }
 }

--- a/packages/themes/daily/package.json
+++ b/packages/themes/daily/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xds/theme-daily",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "private": false,
   "description": "Daily theme for XDS — warm, productivity-focused palette with Lucide icon set",
   "author": "Meta Open Source",
@@ -51,11 +51,11 @@
     "lucide-react": "^1.11.0"
   },
   "peerDependencies": {
-    "@xds/core": "*",
+    "@xds/core": "0.0.13",
     "react": ">=19"
   },
   "devDependencies": {
-    "@xds/cli": "*"
+    "@xds/cli": "0.0.13"
   },
   "module": "./dist/source.mjs"
 }

--- a/packages/themes/default/package.json
+++ b/packages/themes/default/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xds/theme-default",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "private": false,
   "description": "Default theme for XDS — clean neutrals with Heroicons icon set",
   "author": "Meta Open Source",
@@ -51,11 +51,11 @@
     "@heroicons/react": "^2.2.0"
   },
   "peerDependencies": {
-    "@xds/core": "*",
+    "@xds/core": "0.0.13",
     "react": ">=19"
   },
   "devDependencies": {
-    "@xds/cli": "*"
+    "@xds/cli": "0.0.13"
   },
   "module": "./dist/source.mjs"
 }

--- a/packages/themes/matcha/package.json
+++ b/packages/themes/matcha/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xds/theme-matcha",
-  "version": "0.0.1",
+  "version": "0.0.13",
   "private": false,
   "description": "Matcha theme for XDS — earthy green palette with Figtree typography and Lucide icons",
   "author": "Meta Open Source",
@@ -51,11 +51,11 @@
     "lucide-react": "^1.11.0"
   },
   "peerDependencies": {
-    "@xds/core": "*",
+    "@xds/core": "0.0.13",
     "react": ">=19"
   },
   "devDependencies": {
-    "@xds/cli": "*"
+    "@xds/cli": "0.0.13"
   },
   "module": "./dist/source.mjs"
 }

--- a/packages/themes/meta/package.json
+++ b/packages/themes/meta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xds/theme-meta",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "private": true,
   "description": "Meta theme for XDS components — Meta's brand identity with blue accent and clean aesthetics",
   "author": "Meta Open Source",
@@ -51,11 +51,11 @@
     "@heroicons/react": "^2.2.0"
   },
   "peerDependencies": {
-    "@xds/core": "*",
+    "@xds/core": "0.0.13",
     "react": ">=19"
   },
   "devDependencies": {
-    "@xds/cli": "*"
+    "@xds/cli": "0.0.13"
   },
   "module": "./dist/source.mjs"
 }

--- a/packages/themes/neutral/package.json
+++ b/packages/themes/neutral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xds/theme-neutral",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "private": false,
   "description": "Neutral theme for XDS — understated palette with Lucide icon set",
   "author": "Meta Open Source",
@@ -51,11 +51,11 @@
     "lucide-react": "^1.11.0"
   },
   "peerDependencies": {
-    "@xds/core": "*",
+    "@xds/core": "0.0.13",
     "react": ">=19"
   },
   "devDependencies": {
-    "@xds/cli": "*"
+    "@xds/cli": "0.0.13"
   },
   "module": "./dist/source.mjs"
 }

--- a/packages/themes/whatsapp/package.json
+++ b/packages/themes/whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xds/theme-whatsapp",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "private": true,
   "description": "WhatsApp theme for XDS — green accent, warm grays, Roboto, rounded surfaces",
   "author": "Meta Open Source",
@@ -49,10 +49,10 @@
     "build": "xds theme build src/whatsappTheme.ts -o dist/theme.css && tsup && tsc --project tsconfig.build.json"
   },
   "peerDependencies": {
-    "@xds/core": "*",
+    "@xds/core": "0.0.13",
     "react": ">=19"
   },
   "devDependencies": {
-    "@xds/cli": "*"
+    "@xds/cli": "0.0.13"
   }
 }

--- a/packages/vega/package.json
+++ b/packages/vega/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xds/vega",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "private": true,
   "description": "XDS Vega wrapper — chart and data visualization components",
   "author": "Meta Open Source",


### PR DESCRIPTION
Bump all @xds/* packages to v0.0.13.

Once merged, CI will publish to Metaccio automatically via `changeset publish`.