### PR TITLE
docs(cli): expand typography foundational doc

### DIFF
--- a/packages/cli/docs/typography.doc.mjs
+++ b/packages/cli/docs/typography.doc.mjs
@@ -4,22 +4,33 @@ export const docs = {
   name: 'typography',
   title: 'Typography',
   description:
-    'Font family, size, weight, and type scale tokens for consistent text styling.',
+    'Font families, geometric type scale, weight, line-height, and semantic text tokens for consistent, accessible text styling.',
   tokenCategory: 'typography',
 
   sections: [
+    // ── Overview ────────────────────────────────────────────────────────────
     {
       title: 'Overview',
       content: [
         {
           type: 'prose',
-          text: 'XDS typography uses a geometric type scale based on 14px × 1.2^step. Semantic type scale tokens (heading, body, label, code, supporting, display) compose font size, weight, and line-height into ready-to-use combinations. The XDSText component is the primary way to apply these scales.',
+          text: 'XDS typography is built on a geometric type scale: base size × ratio^step, with 14px and 1.2 as defaults. Every text style is a semantic token that composes font size, weight, and line-height — so components express intent (heading, body, label) rather than raw values.',
+        },
+        {
+          type: 'prose',
+          text: 'Two layers work together: raw size tokens (--font-size-xs … --font-size-5xl) form the geometric scale, and semantic type scale tokens (--text-heading-1-size, --text-body-leading, etc.) reference them by var(). Themes override the entire scale by adjusting base and ratio in defineTheme — all semantic tokens recompute automatically.',
         },
       ],
     },
+
+    // ── Font Families ───────────────────────────────────────────────────────
     {
       title: 'Font Families',
       content: [
+        {
+          type: 'prose',
+          text: 'Three font roles: body (UI text), heading (titles and headings), and code (monospace). By default, body and heading share the same system font stack; code uses a monospace stack. Custom themes can assign different families per role — heading inherits from body when not explicitly set.',
+        },
         {
           type: 'token-ref',
           topic: 'tokens',
@@ -27,12 +38,14 @@ export const docs = {
         },
       ],
     },
+
+    // ── Font Sizes ──────────────────────────────────────────────────────────
     {
       title: 'Font Sizes',
       content: [
         {
           type: 'prose',
-          text: 'Geometric scale with 14px base. Each step multiplies by 1.2 and rounds to the nearest 0.0625rem.',
+          text: 'Geometric scale: round(base × ratio^step), expressed in rem. The default scale is 14px × 1.2, producing 12 steps from 4xs (6px) to 5xl (42px). Adjusting base and ratio in defineTheme regenerates every size token while preserving proportional relationships.',
         },
         {
           type: 'token-ref',
@@ -41,9 +54,15 @@ export const docs = {
         },
       ],
     },
+
+    // ── Font Weights ────────────────────────────────────────────────────────
     {
       title: 'Font Weights',
       content: [
+        {
+          type: 'prose',
+          text: 'Four semantic weights: normal (400, body/code), medium (500, labels/data), semibold (600, headings/titles), bold (700, strong emphasis). Type scale tokens reference these by var() so themes can remap numeric values.',
+        },
         {
           type: 'token-ref',
           topic: 'tokens',
@@ -51,12 +70,29 @@ export const docs = {
         },
       ],
     },
+
+    // ── Line Height ─────────────────────────────────────────────────────────
+    {
+      title: 'Line Height',
+      content: [
+        {
+          type: 'prose',
+          text: 'Line heights are computed from a tiered target ratio and snapped to a 4px vertical grid. Small text (<20px) targets 1.5, medium text (20–31px) targets 1.4, and large text (≥32px) targets 1.25. A minimum gap of fontSize + 4px is enforced. The result is a unitless ratio stored in each --text-*-leading token.',
+        },
+        {
+          type: 'prose',
+          text: 'The 4px grid is critical: every line box aligns to 4px increments, which keeps baselines, spacing, and component heights predictable. The expandTypeScale utility computes these automatically when you provide a base and ratio — you should never need to set line-height manually.',
+        },
+      ],
+    },
+
+    // ── Type Scale ──────────────────────────────────────────────────────────
     {
       title: 'Type Scale',
       content: [
         {
           type: 'prose',
-          text: 'Semantic tokens that combine size, weight, and line-height. Use these via XDSText variant prop rather than composing raw font tokens.',
+          text: 'Semantic tokens that combine size, weight, and line-height into a single type style. Each token triplet (--text-*-size, --text-*-weight, --text-*-leading) is consumed by XDSText and XDSHeading. Use the component props rather than composing raw font tokens.',
         },
         {
           type: 'token-ref',
@@ -65,23 +101,86 @@ export const docs = {
         },
       ],
     },
+
+    // ── Display Text ────────────────────────────────────────────────────────
+    {
+      title: 'Display Text',
+      content: [
+        {
+          type: 'prose',
+          text: 'Display variants (display-1, display-2, display-3) continue the geometric progression above heading-1, at steps +6, +5, and +4. They use normal weight (400) instead of semibold, and tighter line-heights (~1.2) — large text reads better with less leading. Use display types for hero banners, marketing headlines, and data callouts — not for document headings.',
+        },
+        {
+          type: 'prose',
+          text: 'Display text often needs heading semantics for accessibility. Use the as prop on XDSText to render the correct HTML element: <XDSText type="display-1" as="h1"> gives you display-1 styling with an <h1> tag, so screen readers see the correct document outline.',
+        },
+      ],
+    },
+
+    // ── Usage ────────────────────────────────────────────────────────────────
     {
       title: 'Usage',
       content: [
         {
           type: 'code',
           lang: 'tsx',
-          label: 'Using XDSText for type scale',
+          label: 'XDSHeading for document structure',
+          code: `import {XDSHeading} from '@xds/core';
+
+// Heading levels map to semantic tokens: level 1 → --text-heading-1-*
+<XDSHeading level={1}>Page Title</XDSHeading>
+<XDSHeading level={2}>Section</XDSHeading>
+<XDSHeading level={3}>Subsection</XDSHeading>
+
+// Override the accessibility level when visual ≠ document hierarchy
+<XDSHeading level={2} accessibilityLevel={3}>
+  Sidebar Section
+</XDSHeading>`,
+        },
+        {
+          type: 'code',
+          lang: 'tsx',
+          label: 'XDSText for body, label, and display text',
           code: `import {XDSText} from '@xds/core';
 
-// Preferred: XDSText component applies the full type scale
-<XDSText variant="heading1">Page Title</XDSText>
-<XDSText variant="body">Body text at the base scale.</XDSText>
-<XDSText variant="supporting">Smaller supporting text.</XDSText>
-<XDSText variant="code">Monospace code text.</XDSText>`,
+<XDSText type="body">Body text at the base scale.</XDSText>
+<XDSText type="large">Emphasized body text.</XDSText>
+<XDSText type="label">Form label</XDSText>
+<XDSText type="supporting">Helper text, timestamps, metadata.</XDSText>
+<XDSText type="code">{'const x = 1;'}</XDSText>
+
+// Display with heading semantics for accessibility
+<XDSText type="display-1" as="h1">Hero Title</XDSText>
+<XDSText type="display-2" as="h2">$1.2M Revenue</XDSText>`,
+        },
+        {
+          type: 'code',
+          lang: 'tsx',
+          label: 'Customizing the type scale via defineTheme',
+          code: `import {defineTheme} from '@xds/core';
+
+// Adjust the entire ramp holistically with base and ratio
+const editorialTheme = defineTheme({
+  name: 'editorial',
+  typography: {
+    scale: { base: 16, ratio: 1.25 },          // airy / article feel
+    body: { family: 'Geist', fallbacks: '-apple-system, sans-serif' },
+    heading: { weight: 'bold' },
+    code: { family: 'Geist Mono', fallbacks: '"SF Mono", monospace' },
+  },
+});
+
+const denseTheme = defineTheme({
+  name: 'dense',
+  typography: {
+    scale: { base: 12, ratio: 1.125 },          // compact / data-dense UI
+  },
+});`,
         },
       ],
     },
+
+    // ── Best Practices ──────────────────────────────────────────────────────
     {
       title: 'Best Practices',
       content: [
@@ -89,17 +188,23 @@ export const docs = {
           type: 'list',
           style: 'do',
           items: [
-            'Use XDSText variant prop instead of manually composing font tokens.',
-            'Use the heading scale (1–6) for document hierarchy, not visual sizing.',
-            'Use the supporting variant for helper text, timestamps, and metadata.',
+            'Use XDSHeading for document headings and XDSText for everything else — they apply the full type scale automatically.',
+            'Adjust typography holistically: change base and ratio in defineTheme to shift the entire ramp (e.g. { base: 16, ratio: 1.25 } for editorial, { base: 12, ratio: 1.125 } for dense UI).',
+            'Use display types with as="h1" (or h2/h3) when display text is a page heading — this preserves accessibility while giving you display-level sizing.',
+            'Let line-height snap to the 4px grid via the type scale — expandTypeScale computes leading automatically from base and ratio.',
+            'Use the supporting type for secondary information: timestamps, helper text, metadata, captions.',
+            'Use accessibilityLevel on XDSHeading when the visual hierarchy doesn\u2019t match the document outline (e.g. sidebar or card headings).',
           ],
         },
         {
           type: 'list',
           style: 'dont',
           items: [
-            'Skip heading levels (e.g. heading1 → heading3) — screen readers rely on the hierarchy.',
-            "Use display variants for body content — they're designed for hero/marketing text.",
+            'Set font-size or line-height manually — use the semantic type scale tokens so the full ramp stays consistent and 4px-grid-aligned.',
+            'Skip heading levels (e.g. h1 \u2192 h3) — screen readers rely on an unbroken hierarchy. Use accessibilityLevel to decouple visual from semantic level.',
+            'Use display types for body content or in-page sections — they\u2019re designed for hero/marketing/data-callout contexts only.',
+            'Override individual size tokens (--font-size-lg) to "tweak" a heading — adjust base/ratio instead so proportions remain coherent across the entire scale.',
+            'Use raw numeric font-weight values (400, 600) — reference the semantic weight tokens so themes can remap them.',
           ],
         },
       ],


### PR DESCRIPTION
Expands `typography.doc.mjs` from the foundational docs PR (#1825) with missing sections and deeper guidance.

## What changed

### New sections
- **Line Height** — tiered target ratios (<20px → 1.5, 20–31px → 1.4, ≥32px → 1.25), 4px grid snapping, minimum gap rule, and why manual line-height is unnecessary
- **Display Text** — separates display-1/2/3 from the type scale; explains weight/leading differences and the `as="h1"` pattern for accessible display headings

### Expanded sections
- **Overview** — two-layer architecture (raw tokens → semantic tokens via var())
- **Font Families** — three-role system (body/heading/code) and heading inheritance
- **Font Weights** — maps each weight to its semantic purpose
- **Font Sizes** — explains how base/ratio regenerates the full scale
- **Type Scale** — describes the token triplet pattern (size/weight/leading)
- **Usage** — 3 code blocks: `XDSHeading` (was missing), `XDSText` (fixed props from `variant` → `type`), and `defineTheme` typography customization with editorial/dense examples
- **Best Practices** — 6 do's and 5 don'ts (was 3+2): holistic base/ratio adjustment, `as="h1"` for display headings, 4px grid leading, `accessibilityLevel`, avoiding individual token overrides

### Bug fixed
- Usage examples used `variant="heading1"` which doesn't exist on XDSText — corrected to `type="body"` etc.

## Stacks on
#1825