### PR TITLE
feat(storybook): add FollowUpQuestion story to ChatComposer

### DIFF
--- a/apps/storybook/stories/ChatComposer.stories.tsx
+++ b/apps/storybook/stories/ChatComposer.stories.tsx
@@ -366,26 +366,34 @@ export const FollowUpQuestion: Story = {
   render: () => {
     const questions = [
       {
-        question: 'What would you like to work on?',
+        question: 'Which environment should this deploy to?',
         options: [
-          {key: 'A', label: 'Build out the new inbox page template'},
-          {key: 'B', label: 'Fix existing templates for rubric compliance'},
-          {key: 'C', label: 'Work on the Button component'},
-          {key: 'D', label: 'Explore or understand the codebase'},
+          {key: 'A', label: 'Production (requires approval)'},
+          {key: 'B', label: 'Staging'},
+          {key: 'C', label: 'Local development only'},
         ],
       },
       {
-        question: 'How familiar are you with the codebase?',
+        question:
+          'This will modify 12 files. How should I handle breaking changes?',
         options: [
-          {key: 'A', label: 'Brand new \u2014 never seen it'},
-          {key: 'B', label: 'Somewhat familiar \u2014 browsed a few files'},
+          {key: 'A', label: 'Add a migration and keep backward compatibility'},
+          {
+            key: 'B',
+            label: 'Breaking change is fine \u2014 bump the major version',
+          },
         ],
       },
       {
-        question: 'Do you want a guided walkthrough or just the answer?',
+        question:
+          'I found 3 existing implementations. Which one should I extend?',
         options: [
-          {key: 'A', label: 'Guided walkthrough with explanations'},
-          {key: 'B', label: 'Just give me the answer'},
+          {key: 'A', label: 'UserService in src/services/ (most recent)'},
+          {
+            key: 'B',
+            label: 'UserManager in src/legacy/ (has more test coverage)',
+          },
+          {key: 'C', label: 'Neither \u2014 start fresh'},
         ],
       },
     ];
@@ -403,7 +411,7 @@ export const FollowUpQuestion: Story = {
             `Sent: "${value}"\nAnswers: ${JSON.stringify(answers, null, 2)}`,
           );
         }}
-        placeholder="Add context or just pick an option above\u2026"
+        placeholder="Or describe what you need in your own words\u2026"
         drawer={
           <XDSChatComposerDrawer count={questions.length} label="Questions">
             <div style={{width: '100%'}}>

--- a/apps/storybook/stories/ChatComposer.stories.tsx
+++ b/apps/storybook/stories/ChatComposer.stories.tsx
@@ -56,6 +56,33 @@ const MicIcon = (
   </svg>
 );
 
+const ChevronLeftIcon = (
+  <svg
+    width="1em"
+    height="1em"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round">
+    <path d="m15 18-6-6 6-6" />
+  </svg>
+);
+const ChevronRightIcon = (
+  <svg
+    width="1em"
+    height="1em"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round">
+    <path d="m9 18 6-6-6-6" />
+  </svg>
+);
+
 const meta: Meta<typeof XDSChatComposer> = {
   title: 'Core/Chat/Composer',
   component: XDSChatComposer,
@@ -334,56 +361,108 @@ export const SendStopToggle: Story = {
   },
 };
 
-/** Drawer with a follow-up question and selectable options (A–F) */
+/** Drawer with follow-up questions, selectable options, and prev/next navigation */
 export const FollowUpQuestion: Story = {
   render: () => {
-    const [selected, setSelected] = useState<string | null>('B');
-
-    const options = [
-      {key: 'A', label: 'Build out the new inbox page template'},
-      {key: 'B', label: 'Fix existing templates for rubric compliance'},
-      {key: 'C', label: 'Work on the Button component'},
-      {key: 'D', label: 'Explore or understand the codebase'},
-      {key: 'E', label: 'Something else entirely'},
-      {key: 'F', label: 'Other...'},
+    const questions = [
+      {
+        question: 'What would you like to work on?',
+        options: [
+          {key: 'A', label: 'Build out the new inbox page template'},
+          {key: 'B', label: 'Fix existing templates for rubric compliance'},
+          {key: 'C', label: 'Work on the Button component'},
+          {key: 'D', label: 'Explore or understand the codebase'},
+        ],
+      },
+      {
+        question: 'How familiar are you with the codebase?',
+        options: [
+          {key: 'A', label: 'Brand new \u2014 never seen it'},
+          {key: 'B', label: 'Somewhat familiar \u2014 browsed a few files'},
+        ],
+      },
+      {
+        question: 'Do you want a guided walkthrough or just the answer?',
+        options: [
+          {key: 'A', label: 'Guided walkthrough with explanations'},
+          {key: 'B', label: 'Just give me the answer'},
+        ],
+      },
     ];
+
+    const [currentQ, setCurrentQ] = useState(0);
+    const [answers, setAnswers] = useState<Record<number, string>>({});
+    const q = questions[currentQ];
+    const selected = answers[currentQ] ?? null;
 
     return (
       <XDSChatComposer
         onSubmit={value => {
-          const answer = selected ?? 'none';
-          console.log('Submit:', value, '| Selected:', answer);
-          alert(`Sent: "${value}" with option ${answer}`);
+          console.log('Submit:', value, '| Answers:', answers);
+          alert(
+            `Sent: "${value}"\nAnswers: ${JSON.stringify(answers, null, 2)}`,
+          );
         }}
-        placeholder="Add more optional details"
+        placeholder="Add context or just pick an option above\u2026"
         drawer={
-          <XDSChatComposerDrawer count={1} label="Questions">
-            <XDSList density="compact">
-              <XDSListItem
-                label={
-                  <XDSText weight="bold">
-                    1. What would you like to work on?
-                  </XDSText>
-                }
-              />
-              {options.map(opt => (
+          <XDSChatComposerDrawer count={questions.length} label="Questions">
+            <div style={{width: '100%'}}>
+              <XDSList>
                 <XDSListItem
-                  key={opt.key}
-                  label={opt.label}
-                  startContent={
-                    <XDSBadge
-                      variant={selected === opt.key ? 'info' : 'neutral'}
-                      label={opt.key}
-                    />
+                  label={
+                    <XDSText weight="bold">
+                      {currentQ + 1}. {q.question}
+                    </XDSText>
                   }
-                  isSelected={selected === opt.key}
-                  onClick={() => setSelected(opt.key)}
                 />
-              ))}
-            </XDSList>
+                {q.options.map(opt => (
+                  <XDSListItem
+                    key={opt.key}
+                    label={opt.label}
+                    startContent={
+                      <XDSBadge
+                        variant={selected === opt.key ? 'info' : 'neutral'}
+                        label={opt.key}
+                      />
+                    }
+                    isSelected={selected === opt.key}
+                    onClick={() =>
+                      setAnswers(prev => ({...prev, [currentQ]: opt.key}))
+                    }
+                  />
+                ))}
+              </XDSList>
+            </div>
           </XDSChatComposerDrawer>
         }
-        footerActions={<XDSButton label="Skip" variant="ghost" size="md" />}
+        headerActions={
+          <>
+            <XDSButton
+              label="Previous question"
+              variant="ghost"
+              size="sm"
+              icon={ChevronLeftIcon}
+              isIconOnly
+              isDisabled={currentQ === 0}
+              onClick={() => setCurrentQ(i => i - 1)}
+            />
+            <XDSButton
+              label="Next question"
+              variant="ghost"
+              size="sm"
+              icon={ChevronRightIcon}
+              isIconOnly
+              isDisabled={currentQ === questions.length - 1}
+              onClick={() => setCurrentQ(i => i + 1)}
+            />
+          </>
+        }
+        headerContext={
+          <XDSText color="secondary">
+            {currentQ + 1} of {questions.length}
+          </XDSText>
+        }
+        footerActions={<XDSButton label="Skip all" variant="ghost" size="md" />}
       />
     );
   },

--- a/apps/storybook/stories/ChatComposer.stories.tsx
+++ b/apps/storybook/stories/ChatComposer.stories.tsx
@@ -7,6 +7,9 @@ import {
 import {XDSToken} from '@xds/core/Token';
 import {XDSButton} from '@xds/core/Button';
 import {XDSProgressBar} from '@xds/core/ProgressBar';
+import {XDSList, XDSListItem} from '@xds/core/List';
+import {XDSText} from '@xds/core/Text';
+import {XDSBadge} from '@xds/core/Badge';
 import {useState} from 'react';
 
 // Inline icons for story demos (not in the default icon registry)
@@ -326,6 +329,61 @@ export const SendStopToggle: Story = {
           setIsStreaming(false);
         }}
         placeholder="Send a message to start streaming..."
+      />
+    );
+  },
+};
+
+/** Drawer with a follow-up question and selectable options (A–F) */
+export const FollowUpQuestion: Story = {
+  render: () => {
+    const [selected, setSelected] = useState<string | null>('B');
+
+    const options = [
+      {key: 'A', label: 'Build out the new inbox page template'},
+      {key: 'B', label: 'Fix existing templates for rubric compliance'},
+      {key: 'C', label: 'Work on the Button component'},
+      {key: 'D', label: 'Explore or understand the codebase'},
+      {key: 'E', label: 'Something else entirely'},
+      {key: 'F', label: 'Other...'},
+    ];
+
+    return (
+      <XDSChatComposer
+        onSubmit={value => {
+          const answer = selected ?? 'none';
+          console.log('Submit:', value, '| Selected:', answer);
+          alert(`Sent: "${value}" with option ${answer}`);
+        }}
+        placeholder="Add more optional details"
+        drawer={
+          <XDSChatComposerDrawer count={1} label="Questions">
+            <XDSList density="compact">
+              <XDSListItem
+                label={
+                  <XDSText weight="bold">
+                    1. What would you like to work on?
+                  </XDSText>
+                }
+              />
+              {options.map(opt => (
+                <XDSListItem
+                  key={opt.key}
+                  label={opt.label}
+                  startContent={
+                    <XDSBadge
+                      variant={selected === opt.key ? 'info' : 'neutral'}
+                      label={opt.key}
+                    />
+                  }
+                  isSelected={selected === opt.key}
+                  onClick={() => setSelected(opt.key)}
+                />
+              ))}
+            </XDSList>
+          </XDSChatComposerDrawer>
+        }
+        footerActions={<XDSButton label="Skip" variant="ghost" size="md" />}
       />
     );
   },

--- a/apps/storybook/stories/ChatComposer.stories.tsx
+++ b/apps/storybook/stories/ChatComposer.stories.tsx
@@ -407,6 +407,35 @@ export const FollowUpQuestion: Story = {
         drawer={
           <XDSChatComposerDrawer count={questions.length} label="Questions">
             <div style={{width: '100%'}}>
+              <div
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  marginBlockEnd: 4,
+                }}>
+                <XDSButton
+                  label="Previous question"
+                  variant="ghost"
+                  size="sm"
+                  icon={ChevronLeftIcon}
+                  isIconOnly
+                  isDisabled={currentQ === 0}
+                  onClick={() => setCurrentQ(i => i - 1)}
+                />
+                <XDSText color="secondary">
+                  {currentQ + 1} of {questions.length}
+                </XDSText>
+                <XDSButton
+                  label="Next question"
+                  variant="ghost"
+                  size="sm"
+                  icon={ChevronRightIcon}
+                  isIconOnly
+                  isDisabled={currentQ === questions.length - 1}
+                  onClick={() => setCurrentQ(i => i + 1)}
+                />
+              </div>
               <XDSList>
                 <XDSListItem
                   label={
@@ -434,33 +463,6 @@ export const FollowUpQuestion: Story = {
               </XDSList>
             </div>
           </XDSChatComposerDrawer>
-        }
-        headerActions={
-          <>
-            <XDSButton
-              label="Previous question"
-              variant="ghost"
-              size="sm"
-              icon={ChevronLeftIcon}
-              isIconOnly
-              isDisabled={currentQ === 0}
-              onClick={() => setCurrentQ(i => i - 1)}
-            />
-            <XDSButton
-              label="Next question"
-              variant="ghost"
-              size="sm"
-              icon={ChevronRightIcon}
-              isIconOnly
-              isDisabled={currentQ === questions.length - 1}
-              onClick={() => setCurrentQ(i => i + 1)}
-            />
-          </>
-        }
-        headerContext={
-          <XDSText color="secondary">
-            {currentQ + 1} of {questions.length}
-          </XDSText>
         }
         footerActions={<XDSButton label="Skip all" variant="ghost" size="md" />}
       />

--- a/packages/cli/templates/blocks/components/ChatComposer/ChatComposerFollowUpQuestions.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatComposer/ChatComposerFollowUpQuestions.doc.mjs
@@ -1,0 +1,10 @@
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  name: 'ChatComposer — Follow-Up Questions',
+  description:
+    'Chat composer with a collapsible drawer containing navigable follow-up questions and selectable lettered options.',
+  isReady: true,
+  aspectRatio: 4 / 3,
+  componentsUsed: ['ChatComposer', 'List', 'Badge', 'Text', 'Button'],
+};

--- a/packages/cli/templates/blocks/components/ChatComposer/ChatComposerFollowUpQuestions.tsx
+++ b/packages/cli/templates/blocks/components/ChatComposer/ChatComposerFollowUpQuestions.tsx
@@ -36,26 +36,30 @@ const ChevronRightIcon = (
 
 const questions = [
   {
-    question: 'What would you like to work on?',
+    question: 'Which environment should this deploy to?',
     options: [
-      {key: 'A', label: 'Build out the new inbox page template'},
-      {key: 'B', label: 'Fix existing templates for rubric compliance'},
-      {key: 'C', label: 'Work on the Button component'},
-      {key: 'D', label: 'Explore or understand the codebase'},
+      {key: 'A', label: 'Production (requires approval)'},
+      {key: 'B', label: 'Staging'},
+      {key: 'C', label: 'Local development only'},
     ],
   },
   {
-    question: 'How familiar are you with the codebase?',
+    question:
+      'This will modify 12 files. How should I handle breaking changes?',
     options: [
-      {key: 'A', label: 'Brand new \u2014 never seen it'},
-      {key: 'B', label: 'Somewhat familiar \u2014 browsed a few files'},
+      {key: 'A', label: 'Add a migration and keep backward compatibility'},
+      {
+        key: 'B',
+        label: 'Breaking change is fine \u2014 bump the major version',
+      },
     ],
   },
   {
-    question: 'Do you want a guided walkthrough or just the answer?',
+    question: 'I found 3 existing implementations. Which one should I extend?',
     options: [
-      {key: 'A', label: 'Guided walkthrough with explanations'},
-      {key: 'B', label: 'Just give me the answer'},
+      {key: 'A', label: 'UserService in src/services/ (most recent)'},
+      {key: 'B', label: 'UserManager in src/legacy/ (has more test coverage)'},
+      {key: 'C', label: 'Neither \u2014 start fresh'},
     ],
   },
 ];
@@ -71,7 +75,7 @@ export default function ChatComposerFollowUpQuestions() {
       onSubmit={value => {
         console.log('Submit:', value, '| Answers:', answers);
       }}
-      placeholder="Add context or just pick an option above\u2026"
+      placeholder="Or describe what you need in your own words\u2026"
       drawer={
         <XDSChatComposerDrawer count={questions.length} label="Questions">
           <div style={{width: '100%'}}>

--- a/packages/cli/templates/blocks/components/ChatComposer/ChatComposerFollowUpQuestions.tsx
+++ b/packages/cli/templates/blocks/components/ChatComposer/ChatComposerFollowUpQuestions.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import {useState} from 'react';
+import {XDSChatComposer, XDSChatComposerDrawer} from '@xds/core/Chat';
+import {XDSButton} from '@xds/core/Button';
+import {XDSList, XDSListItem} from '@xds/core/List';
+import {XDSText} from '@xds/core/Text';
+import {XDSBadge} from '@xds/core/Badge';
+
+const ChevronLeftIcon = (
+  <svg
+    width="1em"
+    height="1em"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round">
+    <path d="m15 18-6-6 6-6" />
+  </svg>
+);
+const ChevronRightIcon = (
+  <svg
+    width="1em"
+    height="1em"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round">
+    <path d="m9 18 6-6-6-6" />
+  </svg>
+);
+
+const questions = [
+  {
+    question: 'What would you like to work on?',
+    options: [
+      {key: 'A', label: 'Build out the new inbox page template'},
+      {key: 'B', label: 'Fix existing templates for rubric compliance'},
+      {key: 'C', label: 'Work on the Button component'},
+      {key: 'D', label: 'Explore or understand the codebase'},
+    ],
+  },
+  {
+    question: 'How familiar are you with the codebase?',
+    options: [
+      {key: 'A', label: 'Brand new \u2014 never seen it'},
+      {key: 'B', label: 'Somewhat familiar \u2014 browsed a few files'},
+    ],
+  },
+  {
+    question: 'Do you want a guided walkthrough or just the answer?',
+    options: [
+      {key: 'A', label: 'Guided walkthrough with explanations'},
+      {key: 'B', label: 'Just give me the answer'},
+    ],
+  },
+];
+
+export default function ChatComposerFollowUpQuestions() {
+  const [currentQ, setCurrentQ] = useState(0);
+  const [answers, setAnswers] = useState<Record<number, string>>({});
+  const q = questions[currentQ];
+  const selected = answers[currentQ] ?? null;
+
+  return (
+    <XDSChatComposer
+      onSubmit={value => {
+        console.log('Submit:', value, '| Answers:', answers);
+      }}
+      placeholder="Add context or just pick an option above\u2026"
+      drawer={
+        <XDSChatComposerDrawer count={questions.length} label="Questions">
+          <div style={{width: '100%'}}>
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                marginBlockEnd: 4,
+              }}>
+              <XDSButton
+                label="Previous question"
+                variant="ghost"
+                size="sm"
+                icon={ChevronLeftIcon}
+                isIconOnly
+                isDisabled={currentQ === 0}
+                onClick={() => setCurrentQ(i => i - 1)}
+              />
+              <XDSText color="secondary">
+                {currentQ + 1} of {questions.length}
+              </XDSText>
+              <XDSButton
+                label="Next question"
+                variant="ghost"
+                size="sm"
+                icon={ChevronRightIcon}
+                isIconOnly
+                isDisabled={currentQ === questions.length - 1}
+                onClick={() => setCurrentQ(i => i + 1)}
+              />
+            </div>
+            <XDSList>
+              <XDSListItem
+                label={
+                  <XDSText weight="bold">
+                    {currentQ + 1}. {q.question}
+                  </XDSText>
+                }
+              />
+              {q.options.map(opt => (
+                <XDSListItem
+                  key={opt.key}
+                  label={opt.label}
+                  startContent={
+                    <XDSBadge
+                      variant={selected === opt.key ? 'info' : 'neutral'}
+                      label={opt.key}
+                    />
+                  }
+                  isSelected={selected === opt.key}
+                  onClick={() =>
+                    setAnswers(prev => ({...prev, [currentQ]: opt.key}))
+                  }
+                />
+              ))}
+            </XDSList>
+          </div>
+        </XDSChatComposerDrawer>
+      }
+      footerActions={<XDSButton label="Skip all" variant="ghost" size="md" />}
+    />
+  );
+}


### PR DESCRIPTION
Adds a new **FollowUpQuestion** story to the ChatComposer Storybook page, demonstrating the drawer slot with a follow-up question and selectable lettered options (A–F).

## What it shows

- **Drawer as a question picker** — uses `XDSChatComposerDrawer` with `count={1} label="Questions"` to present a collapsible follow-up prompt above the input
- **Selectable options** — `XDSListItem` with `onClick`, `isSelected`, and a `XDSBadge` letter marker (A–F)
- **Composable slots** — combines drawer + footerActions (`Skip` button) + placeholder text for optional details
- **State management** — single `useState` for the selected option, wired into both visual feedback and submit output

## Components used

`XDSChatComposer`, `XDSChatComposerDrawer`, `XDSList`, `XDSListItem`, `XDSText`, `XDSBadge`, `XDSButton`