### PR TITLE
fix: add missing use client directives and file headers

### DIFF
--- a/packages/core/src/Spinner/index.ts
+++ b/packages/core/src/Spinner/index.ts
@@ -1,5 +1,14 @@
 'use client';
 
+/**
+ * @file index.ts
+ * @input Imports from XDSSpinner component
+ * @output Exports XDSSpinner component and related types
+ * @position Entry point for Spinner; re-exported by /packages/core/src/index.ts
+ *
+ * SYNC: When modified, update this header and /packages/core/src/Spinner/Spinner.doc.mjs
+ */
+
 export {XDSSpinner} from './XDSSpinner';
 export type {
   XDSSpinnerProps,

--- a/packages/core/src/StatusDot/XDSStatusDot.tsx
+++ b/packages/core/src/StatusDot/XDSStatusDot.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file XDSStatusDot.tsx
  * @input Uses React

--- a/packages/core/src/StatusDot/index.ts
+++ b/packages/core/src/StatusDot/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file index.ts
  * @input Imports from XDSStatusDot component

--- a/packages/core/src/Toast/XDSToastContext.ts
+++ b/packages/core/src/Toast/XDSToastContext.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import {createContext} from 'react';
 import type {XDSToastEntry, XDSToastDismissReason} from './types';
 

--- a/packages/core/src/hooks/useIsomorphicLayoutEffect.ts
+++ b/packages/core/src/hooks/useIsomorphicLayoutEffect.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file useIsomorphicLayoutEffect.ts
  * @input React useLayoutEffect, useEffect


### PR DESCRIPTION
## Component Audit — Queue Round (2026-04-28)

### Audited Components

| Component | Result |
|-----------|--------|
| **Spinner** | 🔧 1 finding, fixed below |
| **StatusDot** | 🔧 1 finding, fixed below |
| **Switch** | ✅ Clean — all conventions met |
| **Text** | ✅ Clean — all conventions met |
| **TextArea** | ✅ Clean — all conventions met |

### Fixes

#### StatusDot — missing `'use client'` directive
- Added `'use client'` to `XDSStatusDot.tsx` and `index.ts`. While StatusDot doesn't use React client APIs directly, every other component in the codebase includes the directive for consistency.

#### Spinner — missing file header on index.ts
- Added standard `@file`, `@input`, `@output`, `@position`, `SYNC` header to `packages/core/src/Spinner/index.ts`.

#### Bonus: `check-use-client.mjs` fixes
- `XDSToastContext.ts` — added missing `'use client'` (uses `createContext`)
- `useIsomorphicLayoutEffect.ts` — added missing `'use client'` (uses `useLayoutEffect`)

### Needs Review
None