### PR TITLE
fix(input): focus input when clicking anywhere on field wrapper

### DIFF
--- a/packages/core/src/NumberInput/XDSNumberInput.test.tsx
+++ b/packages/core/src/NumberInput/XDSNumberInput.test.tsx
@@ -8,7 +8,7 @@
  */
 
 import {describe, it, expect, vi} from 'vitest';
-import {render, screen} from '@testing-library/react';
+import {render, screen, fireEvent} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {HashtagIcon} from '@heroicons/react/24/outline';
 import {XDSNumberInput} from './XDSNumberInput';
@@ -630,6 +630,36 @@ describe('XDSNumberInput', () => {
       );
       await user.click(screen.getByRole('button', {name: 'Clear Qty'}));
       expect(onChange).toHaveBeenCalledWith(null);
+    });
+  });
+
+  describe('click-to-focus', () => {
+    it('focuses input when clicking the start icon', () => {
+      render(
+        <XDSNumberInput
+          label="Qty"
+          value={0}
+          onChange={() => {}}
+          startIcon={<HashtagIcon />}
+        />,
+      );
+
+      const input = screen.getByRole('spinbutton');
+      const wrapper = input.parentElement!;
+      const iconElement = wrapper.querySelector('svg')!;
+
+      fireEvent.click(iconElement);
+      expect(input).toHaveFocus();
+    });
+
+    it('focuses input when clicking the wrapper padding', () => {
+      render(<XDSNumberInput label="Qty" value={0} onChange={() => {}} />);
+
+      const input = screen.getByRole('spinbutton');
+      const wrapper = input.parentElement!;
+
+      fireEvent.click(wrapper);
+      expect(input).toHaveFocus();
     });
   });
 });

--- a/packages/core/src/NumberInput/XDSNumberInput.tsx
+++ b/packages/core/src/NumberInput/XDSNumberInput.tsx
@@ -45,6 +45,7 @@ import {
 } from '../Field';
 import {XDSIcon, renderIconSlot, type XDSIconType} from '../Icon';
 import {useXDSSize} from '../SizeContext/XDSSizeContext';
+import {useInputContainer} from '../hooks/useInputContainer';
 
 const styles = stylex.create({
   wrapper: {
@@ -364,6 +365,7 @@ export function XDSNumberInput({
   const descriptionID = useId();
   const statusMessageID = useId();
   const inputRef = useRef<HTMLInputElement | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
 
   // Pending input while user is typing (null = show formatted value)
   const [pendingInput, setPendingInput] = useState<string | null>(null);
@@ -508,6 +510,14 @@ export function XDSNumberInput({
     inputRef.current?.focus();
   }, [hasClear, onChange]);
 
+  // Focus input when clicking anywhere on the wrapper (icons, padding, etc.)
+  const {onClick: handleWrapperClick, onMouseUp: handleWrapperMouseUp} =
+    useInputContainer({
+      containerRef,
+      inputRef,
+      disabled: isDisabled,
+    });
+
   return (
     <XDSField
       label={label}
@@ -530,6 +540,9 @@ export function XDSNumberInput({
       }
       labelTooltip={labelTooltip}>
       <div
+        ref={containerRef}
+        onClick={handleWrapperClick}
+        onMouseUp={handleWrapperMouseUp}
         {...mergeProps(
           xdsClassName('number-input', {size, status: status?.type ?? null}),
           stylex.props(

--- a/packages/core/src/TextArea/XDSTextArea.test.tsx
+++ b/packages/core/src/TextArea/XDSTextArea.test.tsx
@@ -551,4 +551,34 @@ describe('XDSTextArea', () => {
       expect(screen.getByRole('textbox')).not.toHaveAttribute('name');
     });
   });
+
+  describe('click-to-focus', () => {
+    it('focuses textarea when clicking the start icon', () => {
+      render(
+        <XDSTextArea
+          label="Notes"
+          value=""
+          onChange={() => {}}
+          startIcon={<MagnifyingGlassIcon />}
+        />,
+      );
+
+      const textarea = screen.getByRole('textbox');
+      const wrapper = textarea.parentElement!;
+      const iconElement = wrapper.querySelector('svg')!;
+
+      fireEvent.click(iconElement);
+      expect(textarea).toHaveFocus();
+    });
+
+    it('focuses textarea when clicking the wrapper padding', () => {
+      render(<XDSTextArea label="Notes" value="" onChange={() => {}} />);
+
+      const textarea = screen.getByRole('textbox');
+      const wrapper = textarea.parentElement!;
+
+      fireEvent.click(wrapper);
+      expect(textarea).toHaveFocus();
+    });
+  });
 });

--- a/packages/core/src/TextArea/XDSTextArea.tsx
+++ b/packages/core/src/TextArea/XDSTextArea.tsx
@@ -18,6 +18,8 @@ import {
   useId,
   useOptimistic,
   useTransition,
+  useCallback,
+  useRef,
   type ChangeEvent,
   type ClipboardEvent,
   type FocusEvent,
@@ -42,6 +44,7 @@ import {XDSIcon, renderIconSlot, type XDSIconType} from '../Icon';
 import {XDSSpinner} from '../Spinner';
 import {xdsClassName, mergeProps} from '../utils';
 import type {XDSBaseProps} from '../XDSBaseProps';
+import {useInputContainer} from '../hooks/useInputContainer';
 
 const COUNTER_WARNING_THRESHOLD = 0.8;
 
@@ -275,6 +278,8 @@ export function XDSTextArea({
   const descriptionID = useId();
   const statusMessageID = useId();
   const counterID = useId();
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
 
   const [, startTransition] = useTransition();
   const [optimisticValue, setOptimisticValue] = useOptimistic(value);
@@ -317,6 +322,28 @@ export function XDSTextArea({
 
   const effectivelyDisabled = isDisabled || isBusy;
 
+  // Combine refs
+  const setRefs = useCallback(
+    (el: HTMLTextAreaElement | null) => {
+      textareaRef.current = el;
+      if (typeof ref === 'function') {
+        ref(el);
+      } else if (ref) {
+        (ref as React.MutableRefObject<HTMLTextAreaElement | null>).current =
+          el;
+      }
+    },
+    [ref],
+  );
+
+  // Focus textarea when clicking anywhere on the wrapper (icons, padding, etc.)
+  const {onClick: handleWrapperClick, onMouseUp: handleWrapperMouseUp} =
+    useInputContainer({
+      containerRef,
+      inputRef: textareaRef,
+      disabled: effectivelyDisabled,
+    });
+
   return (
     <XDSField
       label={label}
@@ -338,6 +365,9 @@ export function XDSTextArea({
       }
       labelTooltip={labelTooltip}>
       <div
+        ref={containerRef}
+        onClick={handleWrapperClick}
+        onMouseUp={handleWrapperMouseUp}
         {...mergeProps(
           xdsClassName('textarea', {status: status?.type ?? null}),
           stylex.props(
@@ -356,7 +386,7 @@ export function XDSTextArea({
           renderIconSlot(startIcon, {size: 'sm', color: 'secondary'})}
         <textarea
           {...rest}
-          ref={ref}
+          ref={setRefs}
           id={id}
           name={htmlName}
           value={String(optimisticValue)}

--- a/packages/core/src/TextInput/XDSTextInput.test.tsx
+++ b/packages/core/src/TextInput/XDSTextInput.test.tsx
@@ -8,7 +8,7 @@
  */
 
 import {describe, it, expect, vi} from 'vitest';
-import {render, screen} from '@testing-library/react';
+import {render, screen, fireEvent} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {MagnifyingGlassIcon} from '@heroicons/react/24/outline';
 import {XDSTextInput} from './XDSTextInput';
@@ -464,6 +464,37 @@ describe('XDSTextInput', () => {
       );
       await user.click(screen.getByRole('button', {name: 'Clear Name'}));
       expect(onChange).toHaveBeenCalledWith('', null);
+    });
+  });
+
+  describe('click-to-focus', () => {
+    it('focuses input when clicking the start icon', () => {
+      render(
+        <XDSTextInput
+          label="Search"
+          value=""
+          onChange={() => {}}
+          startIcon={<MagnifyingGlassIcon />}
+        />,
+      );
+
+      const input = screen.getByRole('textbox');
+      const wrapper = input.parentElement!;
+      // The icon is rendered before the input; grab the first non-input child
+      const iconElement = wrapper.querySelector('svg')!;
+
+      fireEvent.click(iconElement);
+      expect(input).toHaveFocus();
+    });
+
+    it('focuses input when clicking the wrapper padding', () => {
+      render(<XDSTextInput label="Name" value="" onChange={() => {}} />);
+
+      const input = screen.getByRole('textbox');
+      const wrapper = input.parentElement!;
+
+      fireEvent.click(wrapper);
+      expect(input).toHaveFocus();
     });
   });
 });

--- a/packages/core/src/TextInput/XDSTextInput.tsx
+++ b/packages/core/src/TextInput/XDSTextInput.tsx
@@ -114,6 +114,7 @@ export type {
 } from '../Field';
 import {xdsClassName, mergeProps} from '../utils';
 import {useXDSSize} from '../SizeContext/XDSSizeContext';
+import {useInputContainer} from '../hooks/useInputContainer';
 import {XDSBaseProps} from '../XDSBaseProps';
 
 export type XDSTextInputType = 'text' | 'password' | 'email';
@@ -267,6 +268,7 @@ export function XDSTextInput({
   const descriptionID = useId();
   const statusMessageID = useId();
   const inputRef = useRef<HTMLInputElement | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
 
   const [, startTransition] = useTransition();
   const [optimisticValue, setOptimisticValue] = useOptimistic(value);
@@ -325,6 +327,14 @@ export function XDSTextInput({
     [ref],
   );
 
+  // Focus input when clicking anywhere on the wrapper (icons, padding, etc.)
+  const {onClick: handleWrapperClick, onMouseUp: handleWrapperMouseUp} =
+    useInputContainer({
+      containerRef,
+      inputRef,
+      disabled: isDisabled,
+    });
+
   return (
     <XDSField
       label={label}
@@ -346,6 +356,9 @@ export function XDSTextInput({
       }
       labelTooltip={labelTooltip}>
       <div
+        ref={containerRef}
+        onClick={handleWrapperClick}
+        onMouseUp={handleWrapperMouseUp}
         {...mergeProps(
           xdsClassName('text-input', {size, status: status?.type ?? null}),
           stylex.props(

--- a/packages/core/src/TimeInput/XDSTimeInput.test.tsx
+++ b/packages/core/src/TimeInput/XDSTimeInput.test.tsx
@@ -8,7 +8,7 @@
  */
 
 import {describe, it, expect, vi} from 'vitest';
-import {render, screen} from '@testing-library/react';
+import {render, screen, fireEvent} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {XDSTimeInput} from './XDSTimeInput';
 import type {ISOTimeString} from '../utils';
@@ -183,5 +183,29 @@ describe('XDSTimeInput', () => {
 
     // onChange should be called immediately when input is valid, not waiting for blur
     expect(onChange).toHaveBeenCalledWith('15:45');
+  });
+
+  it('focuses input when clicking the clock icon', () => {
+    render(<XDSTimeInput label="Time" onChange={() => {}} />);
+
+    const input = screen.getByRole('textbox');
+    const wrapper = input.parentElement!;
+    // The icon container is the first child div (before the input)
+    const iconContainer = wrapper.querySelector(':scope > div') as HTMLElement;
+
+    fireEvent.click(iconContainer);
+    expect(input).toHaveFocus();
+  });
+
+  it('focuses input when clicking the wrapper padding', () => {
+    render(<XDSTimeInput label="Time" onChange={() => {}} />);
+
+    const input = screen.getByRole('textbox');
+    const wrapper = input.parentElement!;
+
+    // Simulate clicking padding area by dispatching click directly on wrapper
+    // with wrapper as both target and currentTarget
+    fireEvent.click(wrapper);
+    expect(input).toHaveFocus();
   });
 });

--- a/packages/core/src/TimeInput/XDSTimeInput.tsx
+++ b/packages/core/src/TimeInput/XDSTimeInput.tsx
@@ -59,6 +59,7 @@ import {
 } from '../utils';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import {useXDSSize} from '../SizeContext/XDSSizeContext';
+import {useInputContainer} from '../hooks/useInputContainer';
 
 const styles = stylex.create({
   icon: {
@@ -313,6 +314,7 @@ export function XDSTimeInput({
   const descriptionID = useId();
   const statusMessageID = useId();
   const inputRef = useRef<HTMLInputElement | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
 
   const [, startTransition] = useTransition();
   const [optimisticValue, setOptimisticValue] = useOptimistic(value);
@@ -498,6 +500,14 @@ export function XDSTimeInput({
     [ref],
   );
 
+  // Focus input when clicking anywhere on the wrapper (icons, padding, etc.)
+  const {onClick: handleWrapperClick, onMouseUp: handleWrapperMouseUp} =
+    useInputContainer({
+      containerRef,
+      inputRef,
+      disabled: isDisabled,
+    });
+
   return (
     <XDSField
       label={label}
@@ -519,6 +529,9 @@ export function XDSTimeInput({
       }
       labelTooltip={labelTooltip}>
       <div
+        ref={containerRef}
+        onClick={handleWrapperClick}
+        onMouseUp={handleWrapperMouseUp}
         {...mergeProps(
           xdsClassName('time-input', {size, status: status?.type ?? null}),
           stylex.props(

--- a/packages/core/src/hooks/index.ts
+++ b/packages/core/src/hooks/index.ts
@@ -44,3 +44,6 @@ export type {
   UseClickableContainerOptions,
   ClickableContainerResult,
 } from './useClickableContainer';
+
+export {useInputContainer} from './useInputContainer';
+export type {UseInputContainerOptions} from './useInputContainer';

--- a/packages/core/src/hooks/useInputContainer.ts
+++ b/packages/core/src/hooks/useInputContainer.ts
@@ -1,0 +1,102 @@
+'use client';
+
+/**
+ * @file useInputContainer.ts
+ * @input Container ref, input ref
+ * @output onClick and onMouseUp handlers for the input container wrapper
+ * @position Hook for input wrapper containers that delegate focus to the inner input/textarea
+ *
+ * Uses useClickableContainer to safely handle nested interactive elements
+ * (clear buttons, calendar toggles, etc.) while focusing the input when
+ * clicking non-interactive areas (icons, padding, status indicators).
+ */
+
+import {useCallback, type RefObject} from 'react';
+import {useClickableContainer} from './useClickableContainer';
+
+/**
+ * Input types that should receive `.focus()` when the container is clicked.
+ * Other input types (e.g. checkbox, radio, file) use `.click()` instead.
+ */
+const FOCUS_INPUT_TYPES = new Set([
+  'text',
+  'password',
+  'email',
+  'number',
+  'search',
+  'tel',
+  'url',
+  'date',
+  'datetime-local',
+  'month',
+  'time',
+  'week',
+]);
+
+export interface UseInputContainerOptions {
+  /** Ref to the outer container/wrapper element */
+  containerRef: RefObject<HTMLElement | null>;
+  /** Ref to the inner input or textarea element */
+  inputRef: RefObject<
+    HTMLInputElement | HTMLTextAreaElement | HTMLElement | null
+  >;
+  /** Whether the input is disabled */
+  disabled?: boolean;
+}
+
+/**
+ * Hook that makes an input container wrapper clickable, delegating focus
+ * to the inner input/textarea when the user clicks non-interactive areas
+ * (icons, padding, status indicators).
+ *
+ * Nested interactive elements (clear buttons, links) are handled safely
+ * via useClickableContainer — clicking them does NOT steal focus.
+ *
+ * @compositionHint Use inside input wrapper components (XDSTextInput,
+ * XDSNumberInput, XDSTimeInput, XDSTextArea, etc.).
+ *
+ * @example
+ * ```
+ * const containerRef = useRef<HTMLDivElement>(null);
+ * const inputRef = useRef<HTMLInputElement>(null);
+ * const { onClick, onMouseUp } = useInputContainer({
+ *   containerRef,
+ *   inputRef,
+ * });
+ * return (
+ *   <div ref={containerRef} onClick={onClick} onMouseUp={onMouseUp}>
+ *     <XDSIcon icon="search" />
+ *     <input ref={inputRef} />
+ *   </div>
+ * );
+ * ```
+ */
+export function useInputContainer({
+  containerRef,
+  inputRef,
+  disabled = false,
+}: UseInputContainerOptions) {
+  const onClick = useCallback(() => {
+    const input = inputRef.current;
+    if (input == null) return;
+    if (
+      input instanceof HTMLInputElement &&
+      FOCUS_INPUT_TYPES.has(input.type)
+    ) {
+      input.focus();
+    } else if (input instanceof HTMLTextAreaElement) {
+      input.focus();
+    } else if (input instanceof HTMLElement) {
+      input.click();
+    } else if ('focus' in input) {
+      (input as unknown as {focus: () => void}).focus();
+    }
+  }, [inputRef]);
+
+  return useClickableContainer({
+    containerRef,
+    interactiveRef: inputRef,
+    onClick,
+    disabled,
+  });
+}


### PR DESCRIPTION
## Summary

Clicking on icons, status indicators, or padding within input field wrappers now correctly focuses the underlying input/textarea element.

## Problem

Previously, only clicking directly on the text portion of an input field would focus it. Non-interactive elements within the field wrapper — like the clock icon in `XDSTimeInput`, start icons in `XDSTextInput`/`XDSNumberInput`/`XDSTextArea`, and status icons — were dead zones that didn't delegate focus to the input.

This is a common usability issue: users expect the entire input field to be clickable.

## Solution

Added an `onClick` handler to each input component's wrapper `<div>` that calls `focus()` on the internal input ref. The handler includes a guard clause that skips interactive child elements (buttons, inputs, links) so clear buttons, calendar toggles, etc. continue to work as expected.

## Affected Components

- **XDSTimeInput** — clock icon, status icons
- **XDSTextInput** — startIcon, status icons
- **XDSNumberInput** — startIcon, units label, status icons
- **XDSTextArea** — startIcon, status icons

**XDSDateInput** was not affected since its icons are already interactive buttons.

## Tests

Added click-to-focus tests for all 4 components (8 new tests total), covering both icon clicks and wrapper padding clicks.