### PR TITLE
feat(text): support custom theme-defined text types

### DIFF
--- a/packages/core/src/Text/XDSText.test.tsx
+++ b/packages/core/src/Text/XDSText.test.tsx
@@ -6,6 +6,7 @@
 import {render, screen} from '@testing-library/react';
 import {describe, it, expect} from 'vitest';
 import {XDSText} from './XDSText';
+import type {XDSTextType} from './XDSText';
 
 describe('XDSText', () => {
   describe('rendering', () => {
@@ -193,5 +194,29 @@ describe('XDSText', () => {
     const element = screen.getByText('Themed Text');
     expect(element.className).toContain('xds-text');
     expect(element.className).toContain('body');
+  });
+});
+
+describe('XDSText custom types', () => {
+  it('renders custom text types with body fallback styles', () => {
+    render(<XDSText type={'hero' as XDSTextType}>Custom</XDSText>);
+    const el = screen.getByText('Custom');
+    expect(el).toBeInTheDocument();
+    expect(el.className).toContain('xds-text');
+    expect(el.className).toContain('hero');
+  });
+
+  it('applies primary color to custom types by default', () => {
+    render(<XDSText type={'caption' as XDSTextType}>Caption</XDSText>);
+    expect(screen.getByText('Caption').className).toContain('primary');
+  });
+
+  it('allows color override on custom types', () => {
+    render(
+      <XDSText type={'hero' as XDSTextType} color="secondary">
+        Muted
+      </XDSText>,
+    );
+    expect(screen.getByText('Muted').className).toContain('secondary');
   });
 });

--- a/packages/core/src/Text/XDSText.tsx
+++ b/packages/core/src/Text/XDSText.tsx
@@ -18,6 +18,7 @@ import {lazy, Suspense, useCallback, useRef, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {
   XDSTextType,
+  XDSBuiltinTextType,
   XDSTextSize,
   XDSTextColor,
   XDSTextWeight,
@@ -146,8 +147,8 @@ export interface XDSTextProps extends Omit<XDSBaseProps, 'children'> {
   as?: 'span' | 'p' | 'div' | 'label' | 'h1' | 'h2' | 'h3';
 }
 
-// Default color by text type
-const defaultColorByType: Record<XDSTextType, XDSTextColor> = {
+// Default color by text type — custom types fall back to 'primary'
+const defaultColorByType: Record<string, XDSTextColor> = {
   body: 'primary',
   large: 'primary',
   label: 'primary',
@@ -157,6 +158,16 @@ const defaultColorByType: Record<XDSTextType, XDSTextColor> = {
   'display-2': 'primary',
   'display-3': 'primary',
 };
+
+/**
+ * Resolve the StyleX style key for a text type.
+ * Custom (theme-defined) types fall back to 'body' for baseline StyleX styles;
+ * their visual treatment comes from theme CSS overrides (.xds-text.<type>).
+ */
+function resolveStyleType(type: XDSTextType): XDSBuiltinTextType {
+  if (type in sizeByTypeStyles) return type as XDSBuiltinTextType;
+  return 'body';
+}
 
 /**
  * Semantic text component. Renders text with type-based styling from the theme.
@@ -195,7 +206,10 @@ export function XDSText({
   ...props
 }: XDSTextProps) {
   // Resolve color with type-based default
-  const resolvedColor = color ?? defaultColorByType[type];
+  const resolvedColor = color ?? defaultColorByType[type] ?? 'primary';
+
+  // Resolve style type — custom types fall back to 'body' for StyleX baseline
+  const styleType = resolveStyleType(type);
 
   // Resolve wordBreak with smart default
   const resolvedWordBreak =
@@ -244,8 +258,8 @@ export function XDSText({
           xdsClassName('text', {type, color: resolvedColor}),
           stylex.props(
             colorStyles[resolvedColor],
-            sizeByTypeStyles[type],
-            defaultWeightByTypeStyles[type],
+            sizeByTypeStyles[styleType],
+            defaultWeightByTypeStyles[styleType],
             weight && weightStyles[weight],
             // Display: use truncation styles when maxLines > 0
             maxLines === 1

--- a/packages/core/src/theme/expandTypeScale.ts
+++ b/packages/core/src/theme/expandTypeScale.ts
@@ -62,7 +62,8 @@ export type HeadingWeightOverrides = Partial<
 
 /**
  * Weight overrides for text types.
- * Keys are text type names, values are CSS font-weight values.
+ * Keys are built-in text type names, values are CSS font-weight values.
+ * Accepts additional string keys for custom theme-defined text types.
  */
 export type TextWeightOverrides = Partial<
   Record<
@@ -73,7 +74,8 @@ export type TextWeightOverrides = Partial<
     | 'supporting'
     | 'display-1'
     | 'display-2'
-    | 'display-3',
+    | 'display-3'
+    | (string & {}),
     FontWeightValue
   >
 >;

--- a/packages/core/src/theme/index.ts
+++ b/packages/core/src/theme/index.ts
@@ -133,12 +133,12 @@ export type {
 export {useXDSTheme} from './useXDSTheme';
 export type {UseXDSThemeReturn} from './useXDSTheme';
 
-
-
 export type {
   ThemeMode,
   HeadingLevel,
   XDSTextType,
+  XDSBuiltinTextType,
+  XDSCustomTextTypes,
   XDSTextSize,
   XDSTextWeight,
   XDSTextColor,
@@ -147,5 +147,3 @@ export type {
   TypographyRole,
   FontWeight,
 } from './types';
-
-

--- a/packages/core/src/theme/types.ts
+++ b/packages/core/src/theme/types.ts
@@ -109,9 +109,9 @@ export type ThemeMode = 'system' | 'light' | 'dark';
 export type HeadingLevel = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 
 /**
- * Semantic text types for XDSText
+ * Built-in semantic text types for XDSText.
  */
-export type XDSTextType =
+export type XDSBuiltinTextType =
   | 'body'
   | 'large'
   | 'label'
@@ -120,6 +120,33 @@ export type XDSTextType =
   | 'display-1'
   | 'display-2'
   | 'display-3';
+
+/**
+ * Semantic text types for XDSText.
+ *
+ * Themes can define custom text types via component overrides in defineTheme.
+ * Custom types render with `body` baseline styles and receive their visual
+ * treatment from theme CSS (`.xds-text.<custom-type> { ... }`).
+ *
+ * To add type-safe custom types, use module augmentation:
+ * ```ts
+ * declare module '@xds/core/theme' {
+ *   interface XDSCustomTextTypes {
+ *     hero: true;
+ *     caption: true;
+ *   }
+ * }
+ * ```
+ *
+ * `xds theme build` generates these augmentations automatically when it
+ * detects new `type:*` values in a theme's component overrides.
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface XDSCustomTextTypes {}
+
+export type XDSTextType =
+  | XDSBuiltinTextType
+  | (keyof XDSCustomTextTypes & string);
 
 /**
  * Text size scale for XDSText size prop override


### PR DESCRIPTION
## Summary

Themes can now define custom text types via `defineTheme` component overrides. Previously, `XDSTextType` was a closed union — passing a custom type like `'hero'` would produce a TypeScript error and crash at runtime when looking up static StyleX style maps.

## Changes

**`types.ts`** — Extensible type system
- Split `XDSTextType` into `XDSBuiltinTextType` (the 8 built-in types) and `XDSCustomTextTypes` (augmentation interface)
- `XDSTextType = XDSBuiltinTextType | (keyof XDSCustomTextTypes & string)`
- Consumers add type-safe custom types via module augmentation — or `xds theme build` generates them automatically

**`XDSText.tsx`** — Graceful runtime fallback
- `resolveStyleType()` maps unknown types to `'body'` for baseline StyleX styles
- `defaultColorByType` uses `Record<string, ...>` with `'primary'` fallback
- `xdsClassName('text', {type})` passes through any type value as a CSS class — theme CSS handles the rest

**`expandTypeScale.ts`** — Accepts custom type keys
- `TextWeightOverrides` now uses `(string & {})` in the key union

## How it works

```ts
// Theme defines a custom text type
defineTheme({
  components: {
    text: {
      'type:hero': {
        fontSize: '3rem',
        fontWeight: '900',
        textTransform: 'uppercase',
      },
    },
  },
});
```

```tsx
// XDSText renders with body baseline + theme CSS overrides
<XDSText type="hero">Welcome</XDSText>
// → <span class="xds-text hero primary ...">
```

```ts
// Type safety via augmentation
declare module '@xds/core/theme' {
  interface XDSCustomTextTypes {
    hero: true;
  }
}
```

## Tests

3 new tests — custom types render, default to primary color, accept color overrides. All 26 pass.