### PR TITLE
fix(Table): scope row border removal to parent tr via marker

### DIFF
--- a/packages/core/src/Table/XDSTableCell.tsx
+++ b/packages/core/src/Table/XDSTableCell.tsx
@@ -22,7 +22,11 @@ import {
   typeScaleVars,
 } from '../theme/tokens.stylex';
 import type {StyleXStyles} from '../theme/types';
-import {overflowStyles, containerEdgeStyles} from './table.stylex';
+import {
+  overflowStyles,
+  containerEdgeStyles,
+  tableRowMarker,
+} from './table.stylex';
 import {
   useTableContext,
   buildDividerStyles,
@@ -73,7 +77,10 @@ const dividerRowStyles = stylex.create({
       default: borderVars['--border-width'],
       // Skip border on cells in the last body row to avoid a
       // redundant line at the bottom of the table.
-      [stylex.when.ancestor(':last-child')]: '0',
+      // Scoped to tableRowMarker so only the parent <tr> is checked —
+      // without the scope, <tbody> (also a :last-child) would match
+      // and suppress borders on every row.
+      [stylex.when.ancestor(':last-child', tableRowMarker)]: '0',
     },
     borderBottomStyle: 'solid',
     borderBottomColor: colorVars['--color-border'],

--- a/packages/core/src/Table/XDSTableRow.tsx
+++ b/packages/core/src/Table/XDSTableRow.tsx
@@ -17,6 +17,7 @@ import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars, durationVars, easeVars} from '../theme/tokens.stylex';
 import type {StyleXStyles} from '../theme/types';
+import {tableRowMarker} from './table.stylex';
 import {XDSTableContext} from './XDSTableContext';
 import {xdsClassName, mergeProps} from '../utils';
 
@@ -99,7 +100,10 @@ export function XDSTableRow({
       <tr
         ref={ref}
         {...props}
-        {...mergeProps(xdsClassName('table-row'), stylex.props(xstyle))}>
+        {...mergeProps(
+          xdsClassName('table-row'),
+          stylex.props(tableRowMarker, xstyle),
+        )}>
         {children}
       </tr>
     );
@@ -129,7 +133,10 @@ export function XDSTableRow({
     <tr
       ref={ref}
       {...props}
-      {...mergeProps(xdsClassName('table-row'), stylex.props(...rowStyles))}>
+      {...mergeProps(
+        xdsClassName('table-row'),
+        stylex.props(tableRowMarker, ...rowStyles),
+      )}>
       {children}
     </tr>
   );

--- a/packages/core/src/Table/table.stylex.ts
+++ b/packages/core/src/Table/table.stylex.ts
@@ -1,16 +1,27 @@
 /**
  * @file table.stylex.ts
  * @input StyleX, theme tokens
- * @output Shared table styles used by XDSTableCell and XDSTableHeaderCell
- * @position Utility styles; consumed by cell components
+ * @output Shared table styles used by XDSTableCell, XDSTableHeaderCell, XDSTableRow
+ * @position Utility styles; consumed by cell and row components
  *
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/Table/XDSTableCell.tsx
  * - /packages/core/src/Table/XDSTableHeaderCell.tsx
+ * - /packages/core/src/Table/XDSTableRow.tsx
  */
 
 import * as stylex from '@stylexjs/stylex';
 import {spacingVars} from '../theme/tokens.stylex';
+
+/**
+ * Scoped marker for table row ancestor selectors.
+ *
+ * Applied to each `<tr>` via XDSTableRow so that cell-level
+ * `stylex.when.ancestor(':last-child', tableRowMarker)` only matches
+ * the parent row — not other ancestors like `<tbody>` or `<table>`.
+ */
+export const tableRowMarker: ReturnType<typeof stylex.defineMarker> =
+  stylex.defineMarker();
 
 /**
  * Overflow truncation for table cells.


### PR DESCRIPTION
## Problem

The `dividerRowStyles` in `XDSTableCell` used an unscoped `stylex.when.ancestor(':last-child')` to suppress the bottom border on the last body row. Because `<tbody>` is typically the last child of `<table>`, the rule matched **every** row — removing all row divider borders.

## Fix

Add a `tableRowMarker` (`stylex.defineMarker()`) applied to each `<tr>` in `XDSTableRow`, and scope the ancestor selector to it:

```ts
// Before (broken — matches <tbody> too)
[stylex.when.ancestor(':last-child')]: '0',

// After (scoped to parent <tr> only)
[stylex.when.ancestor(':last-child', tableRowMarker)]: '0',
```

Now only cells whose direct `<tr>` parent is `:last-child` have their border removed. This follows the same scoped marker pattern used elsewhere in XDS (e.g. `carouselScope` in Carousel).

## Changes

- **`table.stylex.ts`** — Added `tableRowMarker` via `stylex.defineMarker()`
- **`XDSTableRow.tsx`** — Applied `tableRowMarker` to all rendered `<tr>` elements
- **`XDSTableCell.tsx`** — Scoped ancestor selector to `tableRowMarker`

## Test

All 305 existing table tests pass.