### PR TITLE
feat: include CHANGELOG.md in @xds/core and @xds/cli published files

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -42,7 +42,8 @@
     "bin",
     "src",
     "templates",
-    "docs"
+    "docs",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "xds": "node bin/xds.mjs",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -564,7 +564,8 @@
     "src",
     "docs.mjs",
     "groups.doc.mjs",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "prepack": "yarn build",


### PR DESCRIPTION
## What

Adds `CHANGELOG.md` to the `files` field in `@xds/core` and `@xds/cli` `package.json` so changelogs are included in the published npm packages.

## Why

Consumers (like the internal doc site) need access to changelog content at build time. Currently `CHANGELOG.md` exists in the repo but isn't shipped with the packages, so consumers have to either duplicate the content or maintain separate generator scripts.

With this change, consumers can simply read `CHANGELOG.md` from `node_modules/@xds/core/CHANGELOG.md` and render it directly with `XDSMarkdown`.

The theme packages (brutalist, default, neutral, whatsapp) already include `CHANGELOG.md` in their `files` — this brings core and cli in line.

## Changes

- `packages/core/package.json`: added `CHANGELOG.md` to `files`
- `packages/cli/package.json`: added `CHANGELOG.md` to `files`