### PR TITLE
fix(sandbox): render desktop templates in iframe to fix sideNav visibility

### DIFF
--- a/apps/sandbox/src/app/(fullscreen)/PreviewShell.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/PreviewShell.tsx
@@ -910,7 +910,23 @@ export function PreviewShell({children}: {children: React.ReactNode}) {
         {view === 'preview' ? (
           isBlock ? (
             children
-          ) : viewport !== 'desktop' ? (
+          ) : viewport === 'desktop' ? (
+            <div
+              style={{
+                flex: 1,
+                overflow: 'hidden',
+              }}>
+              <iframe
+                src={`${basePath}${pathname}?embed=1`}
+                title={`${pageName} — ${viewport}`}
+                style={{
+                  width: '100%',
+                  height: '100%',
+                  border: 'none',
+                }}
+              />
+            </div>
+          ) : (
             <div
               style={{
                 flex: 1,
@@ -932,14 +948,6 @@ export function PreviewShell({children}: {children: React.ReactNode}) {
                   backgroundColor: '#fff',
                 }}
               />
-            </div>
-          ) : (
-            <div
-              style={{
-                flex: 1,
-                overflow: 'auto',
-              }}>
-              {children}
             </div>
           )
         ) : (


### PR DESCRIPTION
## Problem

When viewing templates in the XDS sandbox PreviewShell, the sideNav was not rendering at desktop viewport size. The desktop viewport was the only size that rendered templates inline (directly as React children) rather than in an iframe.

## Root Cause

Templates rendered inline had two issues:

1. **Viewport mismatch** — The template's `XDSAppShell` uses `window.matchMedia` to detect the breakpoint, but when rendered inline, the `100dvh` height created a nested scroll context within the PreviewShell's `overflow: auto` container, interfering with the AppShell's layout assumptions.

2. **Inconsistent rendering model** — Tablet and mobile viewports already used iframes (with `?embed=1`), giving templates their own isolated viewport. Desktop was the outlier, rendering inline and inheriting the PreviewShell's scroll context.

## Fix

Render desktop templates in a full-bleed iframe, matching the approach already used for tablet and mobile viewports. The iframe fills the container with `width: 100%; height: 100%; border: none`, so the template gets its own isolated viewport where:

- `window.matchMedia` checks the iframe's viewport width (not the outer window)
- `100dvh` resolves to the iframe's viewport height
- The sideNav renders correctly at desktop widths

## Before / After

| Viewport | Before | After |
|----------|--------|-------|
| Desktop | Inline render — sideNav missing | iframe — sideNav renders correctly |
| Tablet | iframe ✓ | iframe ✓ (unchanged) |
| Mobile | iframe ✓ | iframe ✓ (unchanged) |