### PR TITLE
fix(AppShell): match flex layout properties on sticky sidenav container

### DIFF
--- a/packages/core/src/AppShell/XDSAppShell.tsx
+++ b/packages/core/src/AppShell/XDSAppShell.tsx
@@ -379,20 +379,27 @@ const styles = stylex.create({
     top: 0,
     zIndex: 1,
   },
-  // Sticky sideNav for auto height mode — sticks within the wrapper
+  // Sticky sideNav for auto height mode — sticks within the wrapper.
+  // This div replaces the panel as the direct flex child of the middle
+  // (horizontal) container, so it needs the same flex properties that
+  // XDSLayoutPanel applies: flexShrink: 0 prevents the flex container
+  // from collapsing the sidenav, and overflow: clip matches the panel's
+  // default so content doesn't bleed horizontally.
   sideNavSticky: {
-    alignSelf: 'stretch',
+    flexShrink: 0,
+    overflow: 'clip',
     position: 'sticky',
     top: 'var(--appshell-header-height, 0px)',
     height: 'calc(100dvh - var(--appshell-header-height, 0px))',
-    overflow: 'auto',
     // Ensure children (XDSLayoutPanel → XDSSideNav) fill the sticky container
     display: 'flex',
     flexDirection: 'column',
   },
   // Panel fill for auto mode — panel fills the sticky container vertically
+  // and scrolls independently since the page (not the panel) owns the scroll
   panelAutoFill: {
     flex: 1,
+    overflow: 'auto',
   },
 });
 


### PR DESCRIPTION
When `height='auto'`, the sidenav panel is wrapped in a sticky `<div>` that becomes the direct flex child of the middle (horizontal) container. This wrapper was missing the flex properties that `XDSLayoutPanel` applies (`flexShrink: 0`, `overflow: clip`), causing the flex container to potentially collapse the sidenav width.

**Changes:**
- Add `flexShrink: 0` and `overflow: clip` to `sideNavSticky` (matching panel defaults)
- Remove `alignSelf: 'stretch'` (unnecessary — sticky height is explicit via `height: calc(...)`)
- Move `overflow: auto` from the sticky wrapper to `panelAutoFill` so the panel itself scrolls within the fixed-height sticky container