### PR TITLE
feat(sandbox): add ThemeDocPreview — auto-generated theme docs from definedTheme

### DIFF
--- a/apps/sandbox/src/app/(sandbox)/pages/doc-preview/DocPreview.tsx
+++ b/apps/sandbox/src/app/(sandbox)/pages/doc-preview/DocPreview.tsx
@@ -5,7 +5,12 @@ import * as stylex from '@stylexjs/stylex';
 import {XDSVStack, XDSHStack} from '@xds/core/Layout';
 import {XDSText, XDSHeading} from '@xds/core/Text';
 import {XDSCodeBlock} from '@xds/core/CodeBlock';
+import {XDSBadge} from '@xds/core/Badge';
+import {XDSCard} from '@xds/core/Card';
 import {XDSDivider} from '@xds/core/Divider';
+import {XDSSection} from '@xds/core/Section';
+import {XDSTable, pixel, proportional} from '@xds/core/Table';
+import {XDSTooltip} from '@xds/core/Tooltip';
 import {useXDSTheme} from '@xds/core/theme';
 import type {
   ReferenceDoc,
@@ -36,25 +41,46 @@ const styles = stylex.create({
     textAlign: 'start',
     fontWeight: 600,
     fontSize: 12,
-    paddingBlock: 8,
-    paddingInline: 12,
+    paddingBlock: 12,
+    paddingInline: 16,
     borderBottom: '1px solid var(--color-border)',
     color: 'var(--color-text-secondary)',
     textTransform: 'uppercase' as const,
     letterSpacing: '0.04em',
   },
   td: {
-    paddingBlock: 8,
-    paddingInline: 12,
+    paddingBlock: 12,
+    paddingInline: 16,
     borderBottom: '1px solid var(--color-border)',
     verticalAlign: 'middle',
     fontFamily: 'var(--font-family-code)',
     fontSize: 12,
   },
+  tokenRow: {
+    borderRadius: 8,
+    transition: 'background-color 0.15s ease',
+    ':hover': {
+      backgroundColor: 'var(--color-background-wash)',
+    },
+  },
   tokenName: {
     fontWeight: 500,
     color: 'var(--color-text-primary)',
     whiteSpace: 'nowrap' as const,
+  },
+  tokenLink: {
+    cursor: 'pointer',
+    color: 'var(--color-text-primary)',
+    textDecoration: {
+      default: 'none',
+      ':hover': 'underline',
+    },
+    background: 'none',
+    border: 'none',
+    padding: 0,
+    fontFamily: 'var(--font-family-code)',
+    fontSize: 12,
+    fontWeight: 500,
   },
   tokenValue: {
     color: 'var(--color-text-secondary)',
@@ -63,8 +89,35 @@ const styles = stylex.create({
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap' as const,
   },
-  previewCell: {
-    width: 48,
+  valueWithPreview: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 8,
+  },
+  typeScalePreview: {
+    overflow: 'hidden',
+    whiteSpace: 'nowrap' as const,
+    textOverflow: 'ellipsis',
+    display: 'block',
+    fontFamily: 'inherit',
+  },
+  tokenDetail: {
+    display: 'flex',
+    flexDirection: 'column' as const,
+    gap: 2,
+  },
+  tokenDetailName: {
+    fontFamily: 'var(--font-family-code)',
+    fontSize: 11,
+    fontWeight: 500,
+    color: 'var(--color-text-primary)',
+    whiteSpace: 'nowrap' as const,
+  },
+  tokenDetailValue: {
+    fontFamily: 'var(--font-family-code)',
+    fontSize: 11,
+    color: 'var(--color-text-secondary)',
+    whiteSpace: 'nowrap' as const,
   },
   listItem: {
     paddingBlock: 2,
@@ -72,20 +125,19 @@ const styles = stylex.create({
     fontSize: 14,
     lineHeight: 1.5,
   },
-  doIcon: {
-    color: 'var(--color-success)',
-    flexShrink: 0,
-    fontWeight: 700,
+  fullWidth: {
+    width: '100%',
   },
-  dontIcon: {
-    color: 'var(--color-error)',
-    flexShrink: 0,
-    fontWeight: 700,
+  codeBlockEmbed: {
+    width: '100%',
   },
   prose: {
     fontSize: 14,
     lineHeight: 1.6,
     color: 'var(--color-text-primary)',
+  },
+  version: {
+    fontFamily: 'var(--font-family-code)',
   },
 });
 
@@ -302,10 +354,302 @@ function TokenPreview({
 }
 
 // =============================================================================
+// Typescale Table
+// =============================================================================
+
+const FONT_FAMILY_MAP: Record<string, string> = {
+  'heading-1': '--font-family-heading',
+  'heading-2': '--font-family-heading',
+  'heading-3': '--font-family-heading',
+  'heading-4': '--font-family-heading',
+  'heading-5': '--font-family-heading',
+  'heading-6': '--font-family-heading',
+  body: '--font-family-body',
+  large: '--font-family-body',
+  label: '--font-family-body',
+  supporting: '--font-family-body',
+  code: '--font-family-code',
+  'display-1': '--font-family-heading',
+  'display-2': '--font-family-heading',
+  'display-3': '--font-family-heading',
+};
+
+const STYLE_LABEL: Record<string, string> = {
+  'display-1': 'Display 1',
+  'display-2': 'Display 2',
+  'display-3': 'Display 3',
+  'heading-1': 'H1',
+  'heading-2': 'H2',
+  'heading-3': 'H3',
+  'heading-4': 'H4',
+  'heading-5': 'H5',
+  'heading-6': 'H6',
+  body: 'Body',
+  large: 'Large',
+  label: 'Label',
+  code: 'Code',
+  supporting: 'Supporting',
+};
+
+const DUMMY_TEXT: Record<string, string> = {
+  'display-1': '$12,450',
+  'display-2': '98.7%',
+  'display-3': 'Welcome',
+  'heading-1': 'Page Title',
+  'heading-2': 'Section Title',
+  'heading-3': 'Card Heading',
+  'heading-4': 'Subsection',
+  'heading-5': 'Group Label',
+  'heading-6': 'Overline',
+  body: 'Body text for reading',
+  large: 'Intro paragraph',
+  label: 'Form Label',
+  code: 'const x = 42;',
+  supporting: 'Helper text',
+};
+
+interface TypeScaleStyle {
+  name: string;
+  sizeToken: string;
+  sizeValue: string;
+  weightToken: string;
+  weightValue: string;
+  leadingToken: string;
+  leadingValue: string;
+  fontFamilyToken: string;
+}
+
+function isTypeScaleTable(rows: string[][], previewType?: string): boolean {
+  if (previewType !== 'font-sample') return false;
+  if (rows.length < 3) return false;
+  return (
+    rows[0]?.[0]?.endsWith('-size') &&
+    rows[1]?.[0]?.endsWith('-weight') &&
+    rows[2]?.[0]?.endsWith('-leading')
+  );
+}
+
+function groupTypeScaleRows(rows: string[][]): TypeScaleStyle[] {
+  const grouped: TypeScaleStyle[] = [];
+  for (let i = 0; i + 2 < rows.length; i += 3) {
+    const sizeToken = rows[i][0];
+    const name = sizeToken.replace('--text-', '').replace('-size', '');
+    grouped.push({
+      name,
+      sizeToken,
+      sizeValue: rows[i][1],
+      weightToken: rows[i + 1][0],
+      weightValue: rows[i + 1][1],
+      leadingToken: rows[i + 2][0],
+      leadingValue: rows[i + 2][1],
+      fontFamilyToken: FONT_FAMILY_MAP[name] ?? '--font-family-body',
+    });
+  }
+  return grouped;
+}
+
+const TYPE_SCALE_ORDER = [
+  'display-1',
+  'display-2',
+  'display-3',
+  'heading-1',
+  'heading-2',
+  'heading-3',
+  'heading-4',
+  'heading-5',
+  'heading-6',
+  'large',
+  'body',
+  'label',
+  'code',
+  'supporting',
+];
+
+function TypeScaleTable({rows}: {rows: string[][]}) {
+  const {token} = useXDSTheme();
+  const grouped = useMemo(() => {
+    const items = groupTypeScaleRows(rows);
+    const orderMap = new Map(TYPE_SCALE_ORDER.map((k, i) => [k, i]));
+    return items.sort(
+      (a, b) => (orderMap.get(a.name) ?? 99) - (orderMap.get(b.name) ?? 99),
+    );
+  }, [rows]);
+
+  const data = grouped.map(s => {
+    const leading = token(s.leadingToken) ?? s.leadingValue;
+    const size = token(s.sizeToken);
+    const px = size ? Math.round(parseFloat(leading) * parseFloat(size)) : null;
+    return {
+      name: s.name,
+      preview: STYLE_LABEL[s.name] ?? s.name,
+      fontFamily: token(s.fontFamilyToken),
+      fontSize: token(s.sizeToken) ?? s.sizeValue,
+      fontWeight: token(s.weightToken) ?? s.weightValue,
+      leading: px ? `${leading} (${px}px)` : leading,
+      fontFamilyToken: s.fontFamilyToken,
+      sizeToken: s.sizeToken,
+      weightToken: s.weightToken,
+      leadingToken: s.leadingToken,
+    };
+  });
+
+  return (
+    <XDSTable
+      data={data as Record<string, unknown>[]}
+      columns={[
+        {
+          key: 'preview',
+          header: 'Style',
+          width: proportional(2),
+          renderCell: (item: Record<string, unknown>) => (
+            <span
+              {...stylex.props(styles.typeScalePreview)}
+              style={{
+                fontFamily: item.fontFamily as string,
+                fontSize: item.fontSize as string,
+                fontWeight: item.fontWeight as string,
+                lineHeight: (item.leading as string)?.split(' ')[0],
+              }}>
+              {item.preview as string}
+            </span>
+          ),
+        },
+        {
+          key: 'fontFamily',
+          header: 'Font',
+          renderCell: (item: Record<string, unknown>) => (
+            <>{(item.fontFamily as string)?.split(',')[0]?.trim()}</>
+          ),
+        },
+        {
+          key: 'fontSize',
+          header: 'Size',
+        },
+        {
+          key: 'fontWeight',
+          header: 'Weight',
+        },
+        {
+          key: 'leading',
+          header: 'Leading',
+        },
+      ]}
+      density="spacious"
+      dividers="rows"
+      hasHover
+    />
+  );
+}
+
+function CopyableTokenName({name}: {name: string}) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <XDSTooltip content={copied ? 'Copied!' : 'Click to copy'}>
+      <button
+        {...stylex.props(styles.tokenLink)}
+        onClick={e => {
+          e.stopPropagation();
+          navigator.clipboard.writeText(name);
+          setCopied(true);
+          setTimeout(() => setCopied(false), 1500);
+        }}>
+        {name}
+      </button>
+    </XDSTooltip>
+  );
+}
+
+// =============================================================================
 // Block Renderers
 // =============================================================================
 
+function TokenTableInner({
+  rows,
+  previewType,
+  isDualColor,
+}: {
+  rows: string[][];
+  previewType?: TokenPreviewType;
+  isDualColor: boolean;
+}) {
+  const {token} = useXDSTheme();
+  const data = rows.map((row, i) => ({
+    _idx: i,
+    tokenName: row[0],
+    light: row[1],
+    dark: row[2],
+    value: token(row[0]) ?? row[1],
+  }));
+
+  const columns = isDualColor
+    ? [
+        {
+          key: 'tokenName' as const,
+          header: 'Token',
+          renderCell: (item: Record<string, unknown>) => (
+            <CopyableTokenName name={item.tokenName as string} />
+          ),
+        },
+        {
+          key: 'light' as const,
+          header: 'Light',
+          renderCell: (item: Record<string, unknown>) => (
+            <div {...stylex.props(styles.valueWithPreview)}>
+              <SwatchPreview value={item.light as string} />
+              {item.light as string}
+            </div>
+          ),
+        },
+        {
+          key: 'dark' as const,
+          header: 'Dark',
+          renderCell: (item: Record<string, unknown>) => (
+            <div {...stylex.props(styles.valueWithPreview)}>
+              <SwatchPreview value={item.dark as string} />
+              {item.dark as string}
+            </div>
+          ),
+        },
+      ]
+    : [
+        {
+          key: 'tokenName' as const,
+          header: 'Token',
+          renderCell: (item: Record<string, unknown>) => (
+            <CopyableTokenName name={item.tokenName as string} />
+          ),
+        },
+        {
+          key: 'value' as const,
+          header: 'Value',
+          renderCell: (item: Record<string, unknown>) => {
+            const name = item.tokenName as string;
+            const val = item.value as string;
+            return previewType ? (
+              <div {...stylex.props(styles.valueWithPreview)}>
+                <TokenPreview type={previewType} tokenName={name} value={val} />
+                {val}
+              </div>
+            ) : (
+              <>{val}</>
+            );
+          },
+        },
+      ];
+
+  return (
+    <XDSTable
+      data={data as Record<string, unknown>[]}
+      columns={columns}
+      density="spacious"
+      dividers="rows"
+      hasHover
+    />
+  );
+}
+
 function TokenTable({
+  headers,
   rows,
   previewType,
 }: {
@@ -313,48 +657,18 @@ function TokenTable({
   rows: string[][];
   previewType?: TokenPreviewType;
 }) {
-  const {token} = useXDSTheme();
+  if (isTypeScaleTable(rows, previewType)) {
+    return <TypeScaleTable rows={rows} />;
+  }
+
+  const isDualColor = headers.length === 3 && previewType === 'swatch';
 
   return (
-    <div style={{overflowX: 'auto'}}>
-      <table {...stylex.props(styles.tokenTable)}>
-        <thead>
-          <tr>
-            {previewType && (
-              <th {...stylex.props(styles.th, styles.previewCell)} />
-            )}
-            <th {...stylex.props(styles.th)}>Token</th>
-            <th {...stylex.props(styles.th)}>Value</th>
-          </tr>
-        </thead>
-        <tbody>
-          {rows.map((row, i) => {
-            const tokenName = row[0];
-            // Resolve the live value from the current theme
-            const liveValue = token(tokenName) ?? row[1];
-            return (
-              <tr key={i}>
-                {previewType && (
-                  <td {...stylex.props(styles.td, styles.previewCell)}>
-                    <TokenPreview
-                      type={previewType}
-                      tokenName={tokenName}
-                      value={liveValue}
-                    />
-                  </td>
-                )}
-                <td {...stylex.props(styles.td, styles.tokenName)}>
-                  {tokenName}
-                </td>
-                <td {...stylex.props(styles.td, styles.tokenValue)}>
-                  {liveValue}
-                </td>
-              </tr>
-            );
-          })}
-        </tbody>
-      </table>
-    </div>
+    <TokenTableInner
+      rows={rows}
+      previewType={previewType}
+      isDualColor={isDualColor}
+    />
   );
 }
 
@@ -376,14 +690,29 @@ function CodeBlockRenderer({
   label?: string;
 }) {
   return (
-    <XDSVStack gap={1}>
-      {label && (
-        <XDSText type="supporting" color="secondary">
-          {label}
-        </XDSText>
-      )}
-      <XDSCodeBlock code={code} language={lang} hasCopyButton />
-    </XDSVStack>
+    <div {...stylex.props(styles.fullWidth)}>
+      <XDSVStack gap={1}>
+        {label && (
+          <XDSText type="body" color="primary">
+            {label}
+          </XDSText>
+        )}
+        <XDSCard variant="muted" padding={0}>
+          <XDSCodeBlock
+            code={code}
+            language={lang}
+            hasCopyButton
+            size="sm"
+            xstyle={styles.codeBlockEmbed}
+            style={
+              {
+                '--color-syntax-background': 'transparent',
+              } as React.CSSProperties
+            }
+          />
+        </XDSCard>
+      </XDSVStack>
+    </div>
   );
 }
 
@@ -394,16 +723,54 @@ function ListBlock({
   items: string[];
   listStyle: 'ordered' | 'unordered' | 'do' | 'dont';
 }) {
+  if (
+    listStyle === 'do' ||
+    listStyle === 'dont' ||
+    listStyle === ('do-dont-merged' as string)
+  ) {
+    const data =
+      listStyle === ('do-dont-merged' as string)
+        ? items.map(item => {
+            const isdo = item.startsWith('do:');
+            return {
+              type: isdo ? 'do' : 'dont',
+              text: item.slice(item.indexOf(':') + 1),
+            };
+          })
+        : items.map(text => ({type: listStyle as string, text}));
+    return (
+      <XDSTable
+        data={data as Record<string, unknown>[]}
+        columns={[
+          {
+            key: 'type',
+            header: 'Guidance',
+            width: pixel(100),
+            renderCell: (item: Record<string, unknown>) => (
+              <XDSBadge
+                label={item.type === 'do' ? 'Do' : "Don't"}
+                variant={item.type === 'do' ? 'success' : 'error'}
+              />
+            ),
+          },
+          {
+            key: 'text',
+            header: 'Practices',
+            renderCell: (item: Record<string, unknown>) => (
+              <XDSText type="body">{item.text as string}</XDSText>
+            ),
+          },
+        ]}
+        density="spacious"
+        dividers="rows"
+      />
+    );
+  }
+
   return (
     <XDSVStack gap={1}>
       {items.map((item, i) => (
-        <XDSHStack key={i} gap={2} align="start">
-          {listStyle === 'do' && (
-            <span {...stylex.props(styles.doIcon)}>✓</span>
-          )}
-          {listStyle === 'dont' && (
-            <span {...stylex.props(styles.dontIcon)}>✗</span>
-          )}
+        <XDSHStack key={i} gap={2} vAlign="center">
           {listStyle === 'ordered' && (
             <XDSText type="body" color="secondary">
               {i + 1}.
@@ -461,7 +828,46 @@ function ContentBlockRenderer({
 // Section Renderer
 // =============================================================================
 
+function mergeDosDonts(blocks: ContentBlock[]): ContentBlock[] {
+  const merged: ContentBlock[] = [];
+  let pendingDo: string[] = [];
+  let pendingDont: string[] = [];
+
+  const flush = () => {
+    if (pendingDo.length > 0 || pendingDont.length > 0) {
+      merged.push({
+        type: 'list' as const,
+        style: 'do-dont-merged' as 'do',
+        items: [
+          ...pendingDo.map(text => `do:${text}`),
+          ...pendingDont.map(text => `dont:${text}`),
+        ],
+      });
+      pendingDo = [];
+      pendingDont = [];
+    }
+  };
+
+  for (const block of blocks) {
+    if (block.type === 'list' && block.style === 'do') {
+      pendingDo.push(...block.items);
+    } else if (block.type === 'list' && block.style === 'dont') {
+      pendingDont.push(...block.items);
+    } else {
+      flush();
+      merged.push(block);
+    }
+  }
+  flush();
+  return merged;
+}
+
 function SectionRenderer({section}: {section: ReferenceSection}) {
+  const mergedContent = useMemo(
+    () => mergeDosDonts(section.content),
+    [section.content],
+  );
+
   return (
     <XDSVStack gap={4}>
       <XDSHeading
@@ -470,7 +876,7 @@ function SectionRenderer({section}: {section: ReferenceSection}) {
         xstyle={styles.sectionTitle}>
         {section.title}
       </XDSHeading>
-      {section.content.map((block, i) => (
+      {mergedContent.map((block, i) => (
         <ContentBlockRenderer
           key={i}
           block={block}
@@ -485,9 +891,15 @@ function SectionRenderer({section}: {section: ReferenceSection}) {
 // DocPreview
 // =============================================================================
 
-export function DocPreview({doc}: {doc: ReferenceDoc}) {
+export function DocPreview({
+  doc,
+  version,
+}: {
+  doc: ReferenceDoc;
+  version?: string;
+}) {
   // Group sections into: token tables, usage/code, best practices, and other
-  const {tokenSections, usageSections, practiceSections, otherSections} =
+  const {tokenSections, usageSections, practiceSections, overviewSections} =
     useMemo(() => {
       const token: ReferenceSection[] = [];
       const usage: ReferenceSection[] = [];
@@ -513,39 +925,59 @@ export function DocPreview({doc}: {doc: ReferenceDoc}) {
         }
       }
 
+      // Prepend the doc description into the first overview section
+      const overview = [...other];
+      if (overview.length > 0) {
+        overview[0] = {
+          ...overview[0],
+          content: [
+            {type: 'prose' as const, text: doc.description},
+            ...overview[0].content,
+          ],
+        };
+      } else {
+        overview.push({
+          title: 'Overview',
+          content: [{type: 'prose' as const, text: doc.description}],
+        });
+      }
+
+      const sortedTokens = [...token].sort((a, b) => {
+        const aIsScale = a.title.toLowerCase().includes('type scale') ? 0 : 1;
+        const bIsScale = b.title.toLowerCase().includes('type scale') ? 0 : 1;
+        return aIsScale - bIsScale;
+      });
+
       return {
-        tokenSections: token,
+        tokenSections: sortedTokens,
         usageSections: usage,
         practiceSections: practice,
-        otherSections: other,
+        overviewSections: overview,
       };
-    }, [doc.sections]);
+    }, [doc.sections, doc.description]);
 
   return (
     <div {...stylex.props(styles.root)}>
       <XDSVStack gap={8}>
-        {/* Title + Description */}
-        <XDSVStack gap={2}>
-          <XDSHeading level={1}>{doc.title}</XDSHeading>
-          <XDSText type="large" color="secondary">
-            {doc.description}
+        {/* Title + Version */}
+        <XDSVStack gap={1}>
+          <XDSText type="display-1" as="h1">
+            {doc.title}
           </XDSText>
+          {version && (
+            <XDSText
+              type="supporting"
+              color="secondary"
+              xstyle={styles.version}>
+              v{version}
+            </XDSText>
+          )}
         </XDSVStack>
 
-        {/* Overview / other sections first */}
-        {otherSections.map((section, i) => (
+        {/* Overview */}
+        {overviewSections.map((section, i) => (
           <SectionRenderer key={`other-${i}`} section={section} />
         ))}
-
-        {/* Token tables */}
-        {tokenSections.length > 0 && (
-          <>
-            <XDSDivider />
-            {tokenSections.map((section, i) => (
-              <SectionRenderer key={`token-${i}`} section={section} />
-            ))}
-          </>
-        )}
 
         {/* Usage */}
         {usageSections.length > 0 && (
@@ -563,6 +995,16 @@ export function DocPreview({doc}: {doc: ReferenceDoc}) {
             <XDSDivider />
             {practiceSections.map((section, i) => (
               <SectionRenderer key={`practice-${i}`} section={section} />
+            ))}
+          </>
+        )}
+
+        {/* Token tables */}
+        {tokenSections.length > 0 && (
+          <>
+            <XDSDivider />
+            {tokenSections.map((section, i) => (
+              <SectionRenderer key={`token-${i}`} section={section} />
             ))}
           </>
         )}

--- a/apps/sandbox/src/app/(sandbox)/pages/theme-doc-preview/ThemeDocPreview.tsx
+++ b/apps/sandbox/src/app/(sandbox)/pages/theme-doc-preview/ThemeDocPreview.tsx
@@ -1,0 +1,886 @@
+'use client';
+
+/**
+ * ThemeDocPreview — Auto-generated theme documentation from a definedTheme object.
+ *
+ * Takes an XDSDefinedTheme and renders a full documentation page by introspecting
+ * the theme's tokens, components, variants, typography, motion, and icons.
+ *
+ * No hand-written .doc.mjs files needed — everything comes from the theme itself.
+ */
+
+import {useMemo} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {XDSVStack, XDSHStack} from '@xds/core/Layout';
+import {XDSText, XDSHeading} from '@xds/core/Text';
+import type {XDSTextType, XDSHeadingLevel} from '@xds/core/Text';
+import {XDSCard} from '@xds/core/Card';
+import {XDSCodeBlock} from '@xds/core/CodeBlock';
+import {XDSDivider} from '@xds/core/Divider';
+import {XDSBadge} from '@xds/core/Badge';
+import {XDSTable, pixel, proportional} from '@xds/core/Table';
+import {XDSTheme, useXDSTheme} from '@xds/core/theme';
+import type {XDSDefinedTheme, XDSComponentStyleMap} from '@xds/core/theme';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface ThemeDocPreviewProps {
+  /** The theme to document */
+  theme: XDSDefinedTheme;
+  /** Brief description — typically from package.json `description` */
+  description?: string;
+  /** Package name — e.g. '@xds/theme-neutral' */
+  packageName?: string;
+  /** Package version */
+  version?: string;
+}
+
+// =============================================================================
+// Token categorization
+// =============================================================================
+
+interface TokenCategory {
+  label: string;
+  prefixes: string[];
+  preview: 'swatch' | 'radius' | 'shadow' | 'spacing' | 'none';
+}
+
+const TOKEN_CATEGORIES: TokenCategory[] = [
+  {label: 'Colors', prefixes: ['--color-'], preview: 'swatch'},
+  {label: 'Radius', prefixes: ['--radius-'], preview: 'radius'},
+  {label: 'Shadows', prefixes: ['--shadow-'], preview: 'shadow'},
+  {label: 'Spacing', prefixes: ['--spacing-'], preview: 'spacing'},
+  {label: 'Sizes', prefixes: ['--size-'], preview: 'spacing'},
+  {label: 'Typography', prefixes: ['--font-', '--text-'], preview: 'none'},
+  {
+    label: 'Motion',
+    prefixes: ['--duration-', '--ease-', '--transition-'],
+    preview: 'none',
+  },
+];
+
+interface TokenEntry {
+  name: string;
+  value: string;
+  lightValue: string;
+  darkValue: string;
+  isOverride: boolean;
+}
+
+function categorizeTokens(theme: XDSDefinedTheme): Map<string, TokenEntry[]> {
+  const result = new Map<string, TokenEntry[]>();
+  const allTokens = theme.tokens;
+  const inputTokens = theme.__inputTokens;
+
+  const overrideKeys = new Set(inputTokens ? Object.keys(inputTokens) : []);
+
+  for (const category of TOKEN_CATEGORIES) {
+    const entries: TokenEntry[] = [];
+
+    for (const [name, value] of Object.entries(allTokens)) {
+      if (!category.prefixes.some(p => name.startsWith(p))) continue;
+
+      let lightValue = value;
+      let darkValue = value;
+      const ldMatch = value.match(/^light-dark\(\s*(.+?)\s*,\s*(.+?)\s*\)$/);
+      if (ldMatch) {
+        lightValue = ldMatch[1];
+        darkValue = ldMatch[2];
+      }
+
+      if (inputTokens?.[name] && Array.isArray(inputTokens[name])) {
+        const tuple = inputTokens[name] as [string, string];
+        lightValue = tuple[0];
+        darkValue = tuple[1];
+      }
+
+      entries.push({
+        name,
+        value,
+        lightValue,
+        darkValue,
+        isOverride: overrideKeys.has(name),
+      });
+    }
+
+    entries.sort((a, b) => {
+      if (a.isOverride !== b.isOverride) return a.isOverride ? -1 : 1;
+      return a.name.localeCompare(b.name);
+    });
+
+    if (entries.length > 0) {
+      result.set(category.label, entries);
+    }
+  }
+
+  return result;
+}
+
+// =============================================================================
+// Component override analysis
+// =============================================================================
+
+interface VariantOverride {
+  key: string;
+  label: string;
+  properties: Array<{property: string; value: string}>;
+}
+
+interface ComponentOverride {
+  component: string;
+  variants: VariantOverride[];
+}
+
+function analyzeComponents(
+  components?: XDSComponentStyleMap,
+): ComponentOverride[] {
+  if (!components) return [];
+
+  const result: ComponentOverride[] = [];
+
+  for (const [component, rules] of Object.entries(components)) {
+    const variants: VariantOverride[] = [];
+
+    for (const [key, overrides] of Object.entries(rules)) {
+      const properties: Array<{property: string; value: string}> = [];
+
+      for (const [prop, val] of Object.entries(overrides)) {
+        if (typeof val === 'string') {
+          properties.push({property: prop, value: val});
+        } else if (typeof val === 'object') {
+          for (const [pseudoProp, pseudoVal] of Object.entries(val)) {
+            properties.push({
+              property: `${prop} \u2192 ${pseudoProp}`,
+              value: pseudoVal,
+            });
+          }
+        }
+      }
+
+      if (properties.length > 0) {
+        const label =
+          key === 'base'
+            ? 'Base'
+            : key
+                .split('+')
+                .map(part => {
+                  const [p, v] = part.split(':');
+                  return `${p}: ${v}`;
+                })
+                .join(', ');
+
+        variants.push({key, label, properties});
+      }
+    }
+
+    if (variants.length > 0) {
+      result.push({component, variants});
+    }
+  }
+
+  return result.sort((a, b) => a.component.localeCompare(b.component));
+}
+
+// =============================================================================
+// Styles
+// =============================================================================
+
+const styles = stylex.create({
+  root: {
+    maxWidth: 960,
+    margin: '0 auto',
+    padding: 32,
+  },
+  header: {
+    paddingBottom: 8,
+  },
+  overrideIndicator: {
+    display: 'inline-block',
+    width: 6,
+    height: 6,
+    borderRadius: '50%',
+    backgroundColor: 'var(--color-accent)',
+    marginInlineStart: 6,
+    verticalAlign: 'middle',
+  },
+  tokenName: {
+    fontFamily: 'var(--font-family-code)',
+    fontSize: 12,
+    fontWeight: 500,
+  },
+  tokenValue: {
+    fontFamily: 'var(--font-family-code)',
+    fontSize: 12,
+    color: 'var(--color-text-secondary)',
+    maxWidth: 280,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap' as const,
+  },
+  swatchPair: {
+    display: 'flex',
+    gap: 4,
+  },
+  swatchLight: {
+    width: 28,
+    height: 28,
+    borderRadius: 6,
+    backgroundColor: '#FFFFFF',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    border: '1px solid rgba(0, 0, 0, 0.08)',
+  },
+  swatchDark: {
+    width: 28,
+    height: 28,
+    borderRadius: 6,
+    backgroundColor: '#1C1C1E',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    border: '1px solid rgba(255, 255, 255, 0.08)',
+  },
+  swatchInner: {
+    width: 20,
+    height: 20,
+    borderRadius: 4,
+  },
+  singleSwatch: {
+    width: 28,
+    height: 28,
+    borderRadius: 6,
+    border: '1px solid var(--color-border)',
+  },
+  radiusBox: {
+    width: 28,
+    height: 28,
+    border: '2px solid var(--color-accent)',
+  },
+  shadowBox: {
+    width: 32,
+    height: 24,
+    borderRadius: 6,
+    backgroundColor: 'var(--color-background-surface)',
+  },
+  spacingBar: {
+    minWidth: 2,
+    maxWidth: 64,
+    height: 12,
+    borderRadius: 2,
+    backgroundColor: 'var(--color-accent)',
+    opacity: 0.6,
+  },
+  propName: {
+    fontFamily: 'var(--font-family-code)',
+    fontSize: 12,
+  },
+  propValue: {
+    fontFamily: 'var(--font-family-code)',
+    fontSize: 12,
+    color: 'var(--color-text-secondary)',
+  },
+  iconGrid: {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(auto-fill, minmax(140px, 1fr))',
+    gap: 8,
+  },
+  iconItem: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 8,
+    padding: '6px 8px',
+    borderRadius: 6,
+    fontSize: 12,
+    fontFamily: 'var(--font-family-code)',
+    color: 'var(--color-text-secondary)',
+    backgroundColor: 'var(--color-background-surface)',
+    border: '1px solid var(--color-border)',
+  },
+  statsGrid: {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(auto-fit, minmax(140px, 1fr))',
+    gap: 12,
+  },
+  statNumber: {
+    fontSize: 28,
+    fontWeight: 700,
+    color: 'var(--color-text-primary)',
+    lineHeight: 1,
+  },
+});
+
+// =============================================================================
+// Preview renderers
+// =============================================================================
+
+function ColorPreview({entry}: {entry: TokenEntry}) {
+  if (entry.lightValue !== entry.darkValue) {
+    return (
+      <div {...stylex.props(styles.swatchPair)}>
+        <div {...stylex.props(styles.swatchLight)}>
+          <div
+            {...stylex.props(styles.swatchInner)}
+            style={{backgroundColor: entry.lightValue}}
+          />
+        </div>
+        <div {...stylex.props(styles.swatchDark)}>
+          <div
+            {...stylex.props(styles.swatchInner)}
+            style={{backgroundColor: entry.darkValue}}
+          />
+        </div>
+      </div>
+    );
+  }
+  return (
+    <div
+      {...stylex.props(styles.singleSwatch)}
+      style={{backgroundColor: entry.value}}
+    />
+  );
+}
+
+function RadiusPreview({value}: {value: string}) {
+  return (
+    <div {...stylex.props(styles.radiusBox)} style={{borderRadius: value}} />
+  );
+}
+
+function ShadowPreview({value}: {value: string}) {
+  return <div {...stylex.props(styles.shadowBox)} style={{boxShadow: value}} />;
+}
+
+function SpacingPreview({value}: {value: string}) {
+  return <div {...stylex.props(styles.spacingBar)} style={{width: value}} />;
+}
+
+// =============================================================================
+// Type scale preview — rendered live within the theme
+// =============================================================================
+
+const HEADING_LEVELS: XDSHeadingLevel[] = [1, 2, 3, 4, 5, 6];
+const TEXT_TYPES: XDSTextType[] = [
+  'display-1',
+  'display-2',
+  'display-3',
+  'large',
+  'body',
+  'label',
+  'code',
+  'supporting',
+];
+
+type TypeRow = Record<string, unknown> & {
+  variant: string;
+  size: string;
+  weight: string;
+  leading: string;
+  sample: React.ReactNode;
+};
+
+function TypeScalePreview() {
+  const {token} = useXDSTheme();
+
+  const headingRows: TypeRow[] = HEADING_LEVELS.map(level => ({
+    variant: `Heading ${level}`,
+    size: token(`--text-heading-${level}-size`) ?? '\u2013',
+    weight: token(`--text-heading-${level}-weight`) ?? '\u2013',
+    leading: token(`--text-heading-${level}-leading`) ?? '\u2013',
+    sample: <XDSHeading level={level}>The quick brown fox</XDSHeading>,
+  }));
+
+  const textRows: TypeRow[] = TEXT_TYPES.map(type => ({
+    variant: type,
+    size: token(`--text-${type}-size`) ?? '\u2013',
+    weight: token(`--text-${type}-weight`) ?? '\u2013',
+    leading: token(`--text-${type}-leading`) ?? '\u2013',
+    sample: (
+      <XDSText type={type}>The quick brown fox jumps over the lazy dog</XDSText>
+    ),
+  }));
+
+  const typeColumns = [
+    {
+      key: 'variant',
+      header: 'Variant',
+      width: pixel(100),
+      renderCell: (item: Record<string, unknown>) => (
+        <XDSText type="code">{String(item.variant)}</XDSText>
+      ),
+    },
+    {
+      key: 'sample',
+      header: 'Sample',
+      width: proportional(1),
+      renderCell: (item: Record<string, unknown>) =>
+        (item as unknown as TypeRow).sample,
+    },
+    {
+      key: 'size',
+      header: 'Size',
+      width: pixel(80),
+      renderCell: (item: Record<string, unknown>) => (
+        <XDSText type="code" color="secondary">
+          {String(item.size)}
+        </XDSText>
+      ),
+    },
+    {
+      key: 'weight',
+      header: 'Weight',
+      width: pixel(80),
+      renderCell: (item: Record<string, unknown>) => (
+        <XDSText type="code" color="secondary">
+          {String(item.weight)}
+        </XDSText>
+      ),
+    },
+  ];
+
+  return (
+    <XDSVStack gap={4}>
+      <XDSText type="label" color="secondary">
+        Headings
+      </XDSText>
+      <XDSTable
+        data={headingRows as Record<string, unknown>[]}
+        columns={typeColumns}
+      />
+      <XDSText type="label" color="secondary">
+        Text
+      </XDSText>
+      <XDSTable
+        data={textRows as Record<string, unknown>[]}
+        columns={typeColumns}
+      />
+    </XDSVStack>
+  );
+}
+
+// =============================================================================
+// Token section
+// =============================================================================
+
+function TokenSection({
+  category,
+  entries,
+  preview,
+}: {
+  category: string;
+  entries: TokenEntry[];
+  preview: TokenCategory['preview'];
+}) {
+  const {token} = useXDSTheme();
+  const hasPreview = preview !== 'none';
+  const hasDualMode = entries.some(e => e.lightValue !== e.darkValue);
+  const overrideCount = entries.filter(e => e.isOverride).length;
+
+  const data = entries as unknown as Record<string, unknown>[];
+
+  const previewColumn = hasPreview
+    ? [
+        {
+          key: '_preview',
+          header: '',
+          width: pixel(hasDualMode && category === 'Colors' ? 72 : 40),
+          renderCell: (item: Record<string, unknown>) => {
+            const entry = item as unknown as TokenEntry;
+            const liveValue = token(entry.name) ?? entry.value;
+            switch (preview) {
+              case 'swatch':
+                return <ColorPreview entry={entry} />;
+              case 'radius':
+                return <RadiusPreview value={liveValue} />;
+              case 'shadow':
+                return <ShadowPreview value={liveValue} />;
+              case 'spacing':
+                return <SpacingPreview value={liveValue} />;
+              default:
+                return null;
+            }
+          },
+        },
+      ]
+    : [];
+
+  const nameColumn = {
+    key: 'name',
+    header: 'Token',
+    width: proportional(1),
+    renderCell: (item: Record<string, unknown>) => {
+      const entry = item as unknown as TokenEntry;
+      return (
+        <XDSHStack gap={1} align="center">
+          <span {...stylex.props(styles.tokenName)}>{entry.name}</span>
+          {entry.isOverride && (
+            <span {...stylex.props(styles.overrideIndicator)} />
+          )}
+        </XDSHStack>
+      );
+    },
+  };
+
+  const valueColumns =
+    hasDualMode && category === 'Colors'
+      ? [
+          {
+            key: 'lightValue',
+            header: 'Light',
+            width: pixel(200),
+            renderCell: (item: Record<string, unknown>) => (
+              <span {...stylex.props(styles.tokenValue)}>
+                {String(item.lightValue ?? item.value)}
+              </span>
+            ),
+          },
+          {
+            key: 'darkValue',
+            header: 'Dark',
+            width: pixel(200),
+            renderCell: (item: Record<string, unknown>) => (
+              <span {...stylex.props(styles.tokenValue)}>
+                {String(item.darkValue ?? item.value)}
+              </span>
+            ),
+          },
+        ]
+      : [
+          {
+            key: 'value',
+            header: 'Value',
+            width: pixel(280),
+            renderCell: (item: Record<string, unknown>) => (
+              <span {...stylex.props(styles.tokenValue)}>
+                {String(item.value)}
+              </span>
+            ),
+          },
+        ];
+
+  return (
+    <XDSVStack gap={3}>
+      <XDSHStack gap={2} align="center">
+        <XDSHeading level={3}>{category}</XDSHeading>
+        <XDSBadge label={`${entries.length}`} />
+        {overrideCount > 0 && overrideCount < entries.length && (
+          <XDSText type="supporting" color="secondary">
+            {overrideCount} custom
+          </XDSText>
+        )}
+      </XDSHStack>
+      <XDSTable
+        data={data}
+        columns={[...previewColumn, nameColumn, ...valueColumns]}
+        density="compact"
+      />
+    </XDSVStack>
+  );
+}
+
+// =============================================================================
+// Component overrides section
+// =============================================================================
+
+function ComponentOverridesSection({
+  overrides,
+}: {
+  overrides: ComponentOverride[];
+}) {
+  if (overrides.length === 0) return null;
+
+  return (
+    <XDSVStack gap={4}>
+      <XDSHStack gap={2} align="center">
+        <XDSHeading level={2}>Component Overrides</XDSHeading>
+        <XDSBadge label={`${overrides.length}`} />
+      </XDSHStack>
+      <XDSText color="secondary">
+        Components with custom styling applied by this theme.
+      </XDSText>
+
+      {overrides.map(comp => (
+        <XDSCard key={comp.component}>
+          <XDSVStack gap={3}>
+            <XDSHeading level={4}>{comp.component}</XDSHeading>
+            {comp.variants.map(variant => (
+              <XDSVStack key={variant.key} gap={2}>
+                <XDSBadge label={variant.label} variant="neutral" />
+                <XDSTable
+                  data={
+                    variant.properties as unknown as Record<string, unknown>[]
+                  }
+                  columns={[
+                    {
+                      key: 'property',
+                      header: 'Property',
+                      width: pixel(200),
+                      renderCell: (item: Record<string, unknown>) => (
+                        <span {...stylex.props(styles.propName)}>
+                          {String(item.property)}
+                        </span>
+                      ),
+                    },
+                    {
+                      key: 'value',
+                      header: 'Value',
+                      width: proportional(1),
+                      renderCell: (item: Record<string, unknown>) => (
+                        <span {...stylex.props(styles.propValue)}>
+                          {String(item.value)}
+                        </span>
+                      ),
+                    },
+                  ]}
+                />
+              </XDSVStack>
+            ))}
+          </XDSVStack>
+        </XDSCard>
+      ))}
+    </XDSVStack>
+  );
+}
+
+// =============================================================================
+// Icons section
+// =============================================================================
+
+function IconRegistrySection({
+  icons,
+}: {
+  icons?: Partial<Record<string, unknown>>;
+}) {
+  if (!icons) return null;
+  const iconNames = Object.keys(icons).sort();
+  if (iconNames.length === 0) return null;
+
+  return (
+    <XDSVStack gap={3}>
+      <XDSHStack gap={2} align="center">
+        <XDSHeading level={2}>Icon Registry</XDSHeading>
+        <XDSBadge label={`${iconNames.length}`} />
+      </XDSHStack>
+      <XDSText color="secondary">
+        Icons registered by this theme, available via{' '}
+        <XDSText type="code">{'<XDSIcon name="..." />'}</XDSText>.
+      </XDSText>
+      <div {...stylex.props(styles.iconGrid)}>
+        {iconNames.map(name => (
+          <div key={name} {...stylex.props(styles.iconItem)}>
+            {name}
+          </div>
+        ))}
+      </div>
+    </XDSVStack>
+  );
+}
+
+// =============================================================================
+// Summary stats
+// =============================================================================
+
+function ThemeStats({
+  tokensByCategory,
+  overrides,
+  iconCount,
+  fontCount,
+}: {
+  tokensByCategory: Map<string, TokenEntry[]>;
+  overrides: ComponentOverride[];
+  iconCount: number;
+  fontCount: number;
+}) {
+  let totalTokens = 0;
+  let customTokens = 0;
+  for (const entries of tokensByCategory.values()) {
+    totalTokens += entries.length;
+    customTokens += entries.filter(e => e.isOverride).length;
+  }
+
+  const stats = [
+    {label: 'Tokens', value: totalTokens},
+    {label: 'Custom', value: customTokens},
+    {label: 'Components', value: overrides.length},
+    {label: 'Icons', value: iconCount},
+    ...(fontCount > 0 ? [{label: 'Fonts', value: fontCount}] : []),
+  ];
+
+  return (
+    <div {...stylex.props(styles.statsGrid)}>
+      {stats.map(stat => (
+        <XDSCard key={stat.label}>
+          <XDSVStack gap={1}>
+            <div {...stylex.props(styles.statNumber)}>{stat.value}</div>
+            <XDSText type="supporting" color="secondary">
+              {stat.label}
+            </XDSText>
+          </XDSVStack>
+        </XDSCard>
+      ))}
+    </div>
+  );
+}
+
+// =============================================================================
+// Usage code block
+// =============================================================================
+
+function UsageSection({
+  theme,
+  packageName,
+}: {
+  theme: XDSDefinedTheme;
+  packageName?: string;
+}) {
+  const pkg = packageName ?? `@xds/theme-${theme.name}`;
+  const exportName = `${theme.name}Theme`;
+
+  const code = `import {XDSTheme} from '@xds/core';
+import {${exportName}} from '${pkg}';
+
+function App() {
+  return (
+    <XDSTheme theme={${exportName}}>
+      <YourApp />
+    </XDSTheme>
+  );
+}`;
+
+  return (
+    <XDSVStack gap={2}>
+      <XDSHeading level={2}>Usage</XDSHeading>
+      <XDSCodeBlock code={code} language="tsx" hasCopyButton />
+    </XDSVStack>
+  );
+}
+
+// =============================================================================
+// Fonts section
+// =============================================================================
+
+function FontsSection({theme}: {theme: XDSDefinedTheme}) {
+  if (!theme.fonts || theme.fonts.length === 0) return null;
+
+  return (
+    <XDSVStack gap={3}>
+      <XDSHeading level={2}>Fonts</XDSHeading>
+      <XDSTable
+        data={theme.fonts as unknown as Record<string, unknown>[]}
+        columns={[
+          {
+            key: 'family',
+            header: 'Family',
+            width: pixel(200),
+            renderCell: (item: Record<string, unknown>) => (
+              <XDSText type="code">{String(item.family)}</XDSText>
+            ),
+          },
+          {
+            key: 'url',
+            header: 'URL',
+            width: proportional(1),
+            renderCell: (item: Record<string, unknown>) => (
+              <span {...stylex.props(styles.tokenValue)}>
+                {String(item.url)}
+              </span>
+            ),
+          },
+        ]}
+      />
+    </XDSVStack>
+  );
+}
+
+// =============================================================================
+// Main component
+// =============================================================================
+
+export function ThemeDocPreview({
+  theme,
+  description,
+  packageName,
+  version,
+}: ThemeDocPreviewProps) {
+  const tokensByCategory = useMemo(() => categorizeTokens(theme), [theme]);
+  const overrides = useMemo(() => analyzeComponents(theme.components), [theme]);
+  const iconCount = theme.icons ? Object.keys(theme.icons).length : 0;
+  const fontCount = theme.fonts?.length ?? 0;
+
+  const pkg = packageName ?? `@xds/theme-${theme.name}`;
+
+  return (
+    <XDSTheme theme={theme}>
+      <div {...stylex.props(styles.root)}>
+        <XDSVStack gap={8}>
+          {/* Header */}
+          <XDSVStack gap={2} xstyle={styles.header}>
+            <XDSHStack gap={2} align="center">
+              <XDSHeading level={1}>{theme.name} theme</XDSHeading>
+              {version && <XDSBadge label={`v${version}`} variant="neutral" />}
+            </XDSHStack>
+            {description && (
+              <XDSText type="large" color="secondary">
+                {description}
+              </XDSText>
+            )}
+            <XDSText type="code" color="secondary">
+              {pkg}
+            </XDSText>
+          </XDSVStack>
+
+          {/* Stats */}
+          <ThemeStats
+            tokensByCategory={tokensByCategory}
+            overrides={overrides}
+            iconCount={iconCount}
+            fontCount={fontCount}
+          />
+
+          {/* Usage */}
+          <UsageSection theme={theme} packageName={packageName} />
+
+          <XDSDivider />
+
+          {/* Typography rendered live */}
+          <XDSVStack gap={3}>
+            <XDSHeading level={2}>Type Scale</XDSHeading>
+            <XDSText color="secondary">
+              Live type scale rendered within this theme.
+            </XDSText>
+            <TypeScalePreview />
+          </XDSVStack>
+
+          <XDSDivider />
+
+          {/* Token sections */}
+          {TOKEN_CATEGORIES.map(cat => {
+            const entries = tokensByCategory.get(cat.label);
+            if (!entries) return null;
+            return (
+              <TokenSection
+                key={cat.label}
+                category={cat.label}
+                entries={entries}
+                preview={cat.preview}
+              />
+            );
+          })}
+
+          <XDSDivider />
+
+          {/* Component overrides */}
+          <ComponentOverridesSection overrides={overrides} />
+
+          {/* Fonts */}
+          <FontsSection theme={theme} />
+
+          {/* Icons */}
+          <IconRegistrySection icons={theme.icons} />
+        </XDSVStack>
+      </div>
+    </XDSTheme>
+  );
+}

--- a/apps/sandbox/src/app/(sandbox)/pages/theme-doc-preview/page.tsx
+++ b/apps/sandbox/src/app/(sandbox)/pages/theme-doc-preview/page.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import {useState} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {XDSHStack} from '@xds/core/Layout';
+import {XDSText} from '@xds/core/Text';
+import {
+  XDSSegmentedControl,
+  XDSSegmentedControlItem,
+} from '@xds/core/SegmentedControl';
+import {defaultTheme} from '@xds/theme-default';
+import {neutralTheme} from '@xds/theme-neutral';
+import {brutalistTheme} from '@xds/theme-brutalist';
+import type {XDSDefinedTheme} from '@xds/core/theme';
+import {ThemeDocPreview} from './ThemeDocPreview';
+
+const styles = stylex.create({
+  page: {
+    minHeight: '100vh',
+  },
+  topBar: {
+    position: 'sticky',
+    top: 0,
+    zIndex: 10,
+    backgroundColor: 'var(--color-background-body)',
+    borderBottom: '1px solid var(--color-border)',
+    padding: '12px 32px',
+  },
+});
+
+interface ThemeOption {
+  value: string;
+  label: string;
+  theme: XDSDefinedTheme;
+  packageName: string;
+  description: string;
+  version: string;
+}
+
+const THEMES: ThemeOption[] = [
+  {
+    value: 'default',
+    label: 'Default',
+    theme: defaultTheme,
+    packageName: '@xds/theme-default',
+    description:
+      'Default theme for XDS \u2014 clean neutrals with Heroicons icon set',
+    version: '0.0.13',
+  },
+  {
+    value: 'neutral',
+    label: 'Neutral',
+    theme: neutralTheme,
+    packageName: '@xds/theme-neutral',
+    description:
+      'Neutral theme for XDS \u2014 understated palette with Lucide icon set',
+    version: '0.0.13',
+  },
+  {
+    value: 'brutalist',
+    label: 'Brutalist',
+    theme: brutalistTheme,
+    packageName: '@xds/theme-brutalist',
+    description:
+      'Bold brutalist theme for XDS \u2014 high contrast, sharp edges, expressive typography',
+    version: '0.0.13',
+  },
+];
+
+export default function ThemeDocPreviewPage() {
+  const [selected, setSelected] = useState('default');
+  const current = THEMES.find(t => t.value === selected) ?? THEMES[0];
+
+  return (
+    <div {...stylex.props(styles.page)}>
+      <div {...stylex.props(styles.topBar)}>
+        <XDSHStack gap={4} align="center">
+          <XDSText type="label" color="secondary">
+            Theme
+          </XDSText>
+          <XDSSegmentedControl
+            value={selected}
+            onChange={setSelected}
+            label="Theme selector"
+            size="sm">
+            {THEMES.map(t => (
+              <XDSSegmentedControlItem
+                key={t.value}
+                value={t.value}
+                label={t.label}
+              />
+            ))}
+          </XDSSegmentedControl>
+        </XDSHStack>
+      </div>
+      <ThemeDocPreview
+        theme={current.theme}
+        description={current.description}
+        packageName={current.packageName}
+        version={current.version}
+      />
+    </div>
+  );
+}

--- a/apps/sandbox/src/app/sandboxPages.ts
+++ b/apps/sandbox/src/app/sandboxPages.ts
@@ -121,6 +121,12 @@ export const categories: SandboxCategory[] = [
           'Token reference docs with live theme previews — color, spacing, typography, and more',
       },
       {
+        name: 'Theme Docs',
+        href: '/pages/theme-doc-preview/',
+        description:
+          'Auto-generated theme documentation — tokens, components, variants, and icons',
+      },
+      {
         name: 'Docsite',
         href: '/pages/docsite/',
         description:

--- a/packages/core/src/theme/index.ts
+++ b/packages/core/src/theme/index.ts
@@ -130,10 +130,8 @@ export type {
   TypeScaleVarName,
 } from './tokens.stylex';
 
-export {useXDSTheme} from './useXDSTheme';
-export type {UseXDSThemeReturn} from './useXDSTheme';
-
-
+export {useXDSTheme, XDSThemeContext} from './useXDSTheme';
+export type {UseXDSThemeReturn, XDSThemeContextValue} from './useXDSTheme';
 
 export type {
   ThemeMode,
@@ -147,5 +145,3 @@ export type {
   TypographyRole,
   FontWeight,
 } from './types';
-
-


### PR DESCRIPTION
## Summary

Adds a `ThemeDocPreview` component that takes an `XDSDefinedTheme` object and renders complete documentation by introspecting it at runtime. No hand-written `.doc.mjs` files needed — everything comes from the theme object itself.

### What it renders

- **Header** — theme name, description (from `package.json`), version badge, package name
- **Stats cards** — total tokens, custom overrides, component count, icon count, font count
- **Usage** — code block with correct import paths
- **Live type scale** — headings + text rendered within the theme (Heading 1–6, display/body/label/code/supporting)
- **Token tables** by category — Colors, Radius, Shadows, Spacing, Sizes, Typography, Motion
  - Visual previews: dual light/dark swatches, radius boxes, shadow boxes, spacing bars
  - Override indicators (accent dot) for tokens explicitly set by the theme vs inherited defaults
  - Split Light/Dark columns for color tokens with mode-specific values
- **Component overrides** — per-component, per-variant CSS property tables
- **Fonts** — declared font families and URLs
- **Icon registry** — grid of all registered icon names

### Theme picker page

The sandbox page includes a segmented control to switch between Default, Neutral, and Brutalist themes. The entire page re-renders with the selected theme's data.

### Motivation

Related to 9aa7e29 (Ruby's theme reference docs). Theme docs should live close to the theme package and derive from the source of truth — the `definedTheme` object — rather than hand-maintained `.doc.mjs` files that can drift.

This component is distributable: pass it any `XDSDefinedTheme` + optional metadata and it renders a full doc page. Future: could power package README generation or be embedded in the docsite.

---

*This PR was authored by Navi on behalf of @cixzhang.*