### PR TITLE
docs(ChatToolCalls): add usage section with best practices and All Statuses block

### DIFF
--- a/packages/cli/templates/blocks/components/ChatToolCalls/ChatToolCallsAllStatuses.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatToolCalls/ChatToolCallsAllStatuses.doc.mjs
@@ -1,0 +1,10 @@
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  name: 'ChatToolCalls — All Statuses',
+  description:
+    'All four tool call statuses side by side — pending, running, complete, and error — to show every visual state at a glance.',
+  isReady: true,
+  aspectRatio: 4 / 3,
+  componentsUsed: ['ChatToolCalls'],
+};

--- a/packages/cli/templates/blocks/components/ChatToolCalls/ChatToolCallsAllStatuses.tsx
+++ b/packages/cli/templates/blocks/components/ChatToolCalls/ChatToolCallsAllStatuses.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import {XDSChatToolCalls} from '@xds/core/Chat';
+
+export default function ChatToolCallsAllStatuses() {
+  return (
+    <XDSChatToolCalls
+      calls={[
+        {
+          key: 'pending',
+          name: 'bash',
+          target: 'yarn build',
+          status: 'pending',
+        },
+        {
+          key: 'running',
+          name: 'bash',
+          target: 'yarn test',
+          status: 'running',
+        },
+        {
+          key: 'complete',
+          name: 'edit',
+          target: 'XDSButton.tsx',
+          status: 'complete',
+          duration: '120ms',
+          additions: 8,
+          deletions: 2,
+        },
+        {
+          key: 'error',
+          name: 'bash',
+          target: 'yarn lint',
+          status: 'error',
+          duration: '0.8s',
+          errorMessage: '3 lint errors found',
+        },
+      ]}
+    />
+  );
+}

--- a/packages/core/src/Chat/Chat.doc.mjs
+++ b/packages/core/src/Chat/Chat.doc.mjs
@@ -152,7 +152,18 @@ export const docs = {
     },
     {
       name: 'XDSChatToolCalls',
-      description: 'Displays tool/function call invocations from an LLM response. Accepts a `calls` array matching the shape LLM APIs return. Single call renders inline; multiple calls get a collapsible summary with the latest call visible at the surface.',
+      description: 'Displays tool/function call invocations from an LLM response. Pass a `calls` array matching the shape LLM APIs already return — the component handles single-call inline rendering, multi-call collapsible groups, status indicators, node badges, diff stats, and expandable result details automatically.',
+      usage: {
+        description: 'ChatToolCalls renders a compact, scannable summary of tool invocations in an AI chat message. Use it inside XDSChatMessage to show which tools the assistant called, their status, and optional result details like diffs or command output.',
+        bestPractices: [
+          {guidance: true, description: 'Map your LLM SDK\'s tool call array directly to the calls prop — the component is designed to accept the shape that Vercel AI SDK, Anthropic, and OpenAI return.'},
+          {guidance: true, description: 'Provide a `resultDetail` with XDSCodeBlock for tool calls that produce visible output like diffs, command results, or search results so users can inspect what happened.'},
+          {guidance: true, description: 'Include `node` badges when tool calls run across different sandboxes or environments so users can tell where each action executed.'},
+          {guidance: false, description: "Don't build your own tool call list with custom styling — ChatToolCalls handles status icons, collapsible groups, diff stats, and error states consistently."},
+          {guidance: false, description: "Don't set `defaultIsExpanded={true}` for large call groups (>5 calls) — the collapsed summary keeps the chat scannable."},
+          {guidance: false, description: "Don't omit `status` on calls that are still in progress — the running spinner gives users confidence that work is happening."},
+        ],
+      },
       props: [
         {name: 'calls', type: 'XDSChatToolCallItem[]', description: 'Array of tool call data. Each item has name, status, target, duration, node, additions, deletions, stats, resultDetail.', required: true},
         {name: 'label', type: 'string', description: 'Custom summary label for groups. Auto-generated from count if omitted.'},

--- a/packages/core/src/docs-types.ts
+++ b/packages/core/src/docs-types.ts
@@ -168,6 +168,10 @@ export interface ComponentEntry {
   description: string;
   /** All public props for this component. */
   props: PropDoc[];
+  /** Optional usage documentation for this sub-component. Use when a
+   *  sub-component is significant enough to warrant its own usage guidance
+   *  beyond the parent group's usage section. */
+  usage?: UsageDoc;
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds usage documentation for `XDSChatToolCalls`, following the pattern from #1554.

### What changed

**`packages/core/src/Chat/Chat.doc.mjs`** — XDSChatToolCalls sub-component entry now includes:

- **Description** (2 sentences): What the component is and when to use it
- **Best practices** — 3 do's and 3 don'ts:
  - ✅ Map your LLM SDK tool call array directly to the `calls` prop
  - ✅ Provide `resultDetail` with XDSCodeBlock for inspectable output
  - ✅ Include `node` badges for cross-environment tool calls
  - ❌ Don't build your own tool call list — ChatToolCalls handles it all
  - ❌ Don't set `defaultIsExpanded={true}` for large groups
  - ❌ Don't omit `status` on in-progress calls

**New block: `ChatToolCalls — All Statuses`** — Shows all four statuses (pending, running, complete, error) side by side.

### Existing blocks (unchanged)

| Block | Description | Storybook equivalent |
|-------|-------------|---------------------|
| Showcase | Single inline tool call | SingleCall |
| Multiple Calls | Collapsible group with durations and diff stats | MultipleCalls |
| With Nodes | Node badges per sandbox/environment | WithNodes |
| With Errors | Failed call with error detail in CodeBlock | ErrorWithDetail |
| Interactive | Expandable result details (diffs, test output) | Interactive |
| **All Statuses** (new) | All 4 statuses at a glance | AllStatuses |

---

## Block Grading

All blocks graded per the [Contributing Templates rubric](https://github.com/facebookexperimental/xds/wiki/Contributing-Templates#template-grading-rubric).

### ChatToolCalls — Showcase (A · 95/100)

| Category | Pts | Max | Notes |
|----------|-----|-----|-------|
| XDS Component Purity | 30 | 30 | 0 raw HTML |
| Icon Purity | 15 | 15 | 0 raw SVG |
| Custom CSS | 15 | 15 | 0 declarations |
| Layout & Structure | 13 | 15 | 18 lines (slightly under 20 min) |
| Doc Metadata | 10 | 10 | isShowcase=true, 4/3 ratio |
| Image Handling | 5 | 5 | None |
| Code Quality | 7 | 10 | Thin but valid showcase |

### ChatToolCalls — Multiple Calls (A · 98/100)

| Category | Pts | Max | Notes |
|----------|-----|-----|-------|
| XDS Component Purity | 30 | 30 | 0 raw HTML |
| Icon Purity | 15 | 15 | 0 raw SVG |
| Custom CSS | 15 | 15 | 0 declarations |
| Layout & Structure | 15 | 15 | 32 lines, focused |
| Doc Metadata | 10 | 10 | All fields accurate |
| Image Handling | 5 | 5 | None |
| Code Quality | 8 | 10 | Realistic tool names/durations |

### ChatToolCalls — With Nodes (A · 98/100)

| Category | Pts | Max | Notes |
|----------|-----|-----|-------|
| XDS Component Purity | 30 | 30 | 0 raw HTML |
| Icon Purity | 15 | 15 | 0 raw SVG |
| Custom CSS | 15 | 15 | 0 declarations |
| Layout & Structure | 15 | 15 | 39 lines, focused |
| Doc Metadata | 10 | 10 | All fields accurate |
| Image Handling | 5 | 5 | None |
| Code Quality | 8 | 10 | Realistic node names |

### ChatToolCalls — With Errors (A · 96/100)

| Category | Pts | Max | Notes |
|----------|-----|-----|-------|
| XDS Component Purity | 30 | 30 | 0 raw HTML |
| Icon Purity | 15 | 15 | 0 raw SVG |
| Custom CSS | 15 | 15 | 0 declarations |
| Layout & Structure | 15 | 15 | 54 lines, focused |
| Doc Metadata | 10 | 10 | componentsUsed accurate |
| Image Handling | 5 | 5 | None |
| Code Quality | 6 | 10 | Realistic test error output |

### ChatToolCalls — Interactive (A · 96/100)

| Category | Pts | Max | Notes |
|----------|-----|-----|-------|
| XDS Component Purity | 30 | 30 | 0 raw HTML |
| Icon Purity | 15 | 15 | 0 raw SVG |
| Custom CSS | 15 | 15 | 0 declarations |
| Layout & Structure | 15 | 15 | 68 lines, focused |
| Doc Metadata | 10 | 10 | componentsUsed accurate |
| Image Handling | 5 | 5 | None |
| Code Quality | 6 | 10 | Realistic diff/test output |

### ChatToolCalls — All Statuses ✨ new (A · 98/100)

| Category | Pts | Max | Notes |
|----------|-----|-----|-------|
| XDS Component Purity | 30 | 30 | 0 raw HTML |
| Icon Purity | 15 | 15 | 0 raw SVG |
| Custom CSS | 15 | 15 | 0 declarations |
| Layout & Structure | 15 | 15 | 41 lines, focused |
| Doc Metadata | 10 | 10 | All fields accurate |
| Image Handling | 5 | 5 | None |
| Code Quality | 8 | 10 | All 4 statuses with realistic data |
