### PR TITLE
Improve ChatLayoutScrollButton docs and block examples

### DIFF
--- a/packages/cli/templates/blocks/components/ChatLayoutScrollButton/ChatLayoutScrollButtonLabels.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatLayoutScrollButton/ChatLayoutScrollButtonLabels.doc.mjs
@@ -1,0 +1,9 @@
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  name: 'ChatLayoutScrollButton — Labels',
+  description: 'Scroll button with different labels for context-specific notifications like new messages, unread replies, or a generic scroll prompt.',
+  isReady: true,
+  aspectRatio: 16 / 9,
+  componentsUsed: ['Chat', 'Layout', 'Text'],
+};

--- a/packages/cli/templates/blocks/components/ChatLayoutScrollButton/ChatLayoutScrollButtonLabels.tsx
+++ b/packages/cli/templates/blocks/components/ChatLayoutScrollButton/ChatLayoutScrollButtonLabels.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import {XDSChatLayoutScrollButton} from '@xds/core/Chat';
+import {XDSStack} from '@xds/core/Layout';
+import {XDSText} from '@xds/core/Text';
+
+export default function ChatLayoutScrollButtonLabels() {
+  return (
+    <XDSStack direction="vertical" gap={4}>
+      <XDSText type="supporting" color="secondary">
+        Labels expand the button to give context
+      </XDSText>
+      <XDSStack direction="vertical" gap={3}>
+        <XDSChatLayoutScrollButton
+          isVisible={true}
+          onClick={() => {}}
+        />
+        <XDSChatLayoutScrollButton
+          isVisible={true}
+          label="New messages"
+          onClick={() => {}}
+        />
+        <XDSChatLayoutScrollButton
+          isVisible={true}
+          label="3 unread replies"
+          onClick={() => {}}
+        />
+      </XDSStack>
+    </XDSStack>
+  );
+}

--- a/packages/cli/templates/blocks/components/ChatLayoutScrollButton/ChatLayoutScrollButtonStates.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatLayoutScrollButton/ChatLayoutScrollButtonStates.doc.mjs
@@ -1,0 +1,10 @@
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  name: 'ChatLayoutScrollButton',
+  description: 'Scroll button in hidden, visible, and expanded (with label) states. The button fades in when the user scrolls up and expands when new messages arrive.',
+  isReady: true,
+  isShowcase: true,
+  aspectRatio: 16 / 9,
+  componentsUsed: ['Chat', 'Layout', 'Text'],
+};

--- a/packages/cli/templates/blocks/components/ChatLayoutScrollButton/ChatLayoutScrollButtonStates.tsx
+++ b/packages/cli/templates/blocks/components/ChatLayoutScrollButton/ChatLayoutScrollButtonStates.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import {XDSChatLayoutScrollButton} from '@xds/core/Chat';
+import {XDSStack} from '@xds/core/Layout';
+import {XDSText} from '@xds/core/Text';
+
+export default function ChatLayoutScrollButtonStates() {
+  return (
+    <XDSStack direction="vertical" gap={4}>
+      <XDSStack direction="vertical" gap={1}>
+        <XDSText type="supporting" color="secondary">
+          Hidden (user is at bottom)
+        </XDSText>
+        <XDSChatLayoutScrollButton
+          isVisible={false}
+          onClick={() => {}}
+        />
+      </XDSStack>
+      <XDSStack direction="vertical" gap={1}>
+        <XDSText type="supporting" color="secondary">
+          Visible (user scrolled up)
+        </XDSText>
+        <XDSChatLayoutScrollButton
+          isVisible={true}
+          onClick={() => {}}
+        />
+      </XDSStack>
+      <XDSStack direction="vertical" gap={1}>
+        <XDSText type="supporting" color="secondary">
+          Expanded with label (new messages arrived)
+        </XDSText>
+        <XDSChatLayoutScrollButton
+          isVisible={true}
+          label="New messages"
+          onClick={() => {}}
+        />
+      </XDSStack>
+    </XDSStack>
+  );
+}

--- a/packages/core/src/Chat/Chat.doc.mjs
+++ b/packages/core/src/Chat/Chat.doc.mjs
@@ -210,6 +210,8 @@ export const docs = {
       { guidance: true, description: 'Pass a scrollRef when embedding the chat inside a page that already has its own scroll container, so auto-scroll targets the correct element.' },
       { guidance: false, description: 'Don\'t build your own scroll-to-bottom logic or density breakpoints — XDSChatLayout handles both via container width observation and spring-based auto-scroll.' },
       { guidance: false, description: 'Don\'t apply a fixed height directly on XDSChatLayout — wrap it in a sized container and let the layout fill with flex: 1.' },
+      { guidance: true, description: 'Show a label on XDSChatLayoutScrollButton (e.g. "New messages") when unread content arrives below the fold so the user knows there is something to see.' },
+      { guidance: false, description: 'Don\'t rebuild the scroll-to-bottom button from scratch — use XDSChatLayoutScrollButton or pass a custom element to XDSChatLayout\'s scrollButton prop.' },
 ],
     anatomy: [
       { name: 'Message area', required: true, description: 'Scrollable region for messages. Renders children (typically XDSChatMessageList) in a flex column that pushes content to the bottom when the list is short.' },
@@ -241,11 +243,11 @@ docs.components.push(chatLayoutComponent);
 
 const chatLayoutScrollButtonComponent = {
   name: 'XDSChatLayoutScrollButton',
-  description: 'Composable scroll-to-bottom button for use inside XDSChatLayout. Fades in when visible, expands to show a label (e.g. "New messages"). Used as the default scrollButton in XDSChatLayout; override via the scrollButton prop.',
+  description: 'Floating scroll-to-bottom button that appears when the user scrolls away from the latest messages. It fades in as a compact icon button and expands to show a label when new messages arrive. XDSChatLayout renders this by default — pass a custom element to the scrollButton prop to override, or null to hide it entirely.',
   props: [
-    {name: 'isVisible', type: 'boolean', description: 'Whether the button is visible.', required: true},
-    {name: 'label', type: 'string', description: 'Optional label — expands the button (e.g. "New messages").'},
-    {name: 'onClick', type: '() => void', description: 'Click handler — typically scrolls to bottom and dismisses new message indicator.', required: true},
+    {name: 'isVisible', type: 'boolean', description: 'Whether the button is visible. Bind to a scroll-position check so the button only appears when the user has scrolled up.', required: true},
+    {name: 'label', type: 'string', description: 'Optional label that expands the button (e.g. "New messages"). Use to signal unread content below the fold.'},
+    {name: 'onClick', type: '() => void', description: 'Click handler — typically scrolls to bottom and dismisses the new message indicator.', required: true},
   ],
 };
 docs.components.push(chatLayoutScrollButtonComponent);
@@ -285,6 +287,8 @@ export const docsZh = {
       { guidance: true, description: 'Pass a scrollRef when embedding the chat inside a page that already has its own scroll container, so auto-scroll targets the correct element.' },
       { guidance: false, description: 'Don\'t build your own scroll-to-bottom logic or density breakpoints — XDSChatLayout handles both via container width observation and spring-based auto-scroll.' },
       { guidance: false, description: 'Don\'t apply a fixed height directly on XDSChatLayout — wrap it in a sized container and let the layout fill with flex: 1.' },
+      { guidance: true, description: 'Show a label on XDSChatLayoutScrollButton (e.g. "New messages") when unread content arrives below the fold so the user knows there is something to see.' },
+      { guidance: false, description: 'Don\'t rebuild the scroll-to-bottom button from scratch — use XDSChatLayoutScrollButton or pass a custom element to XDSChatLayout\'s scrollButton prop.' },
 ],
     anatomy: [
       { name: 'Message area', required: true, description: 'Scrollable region for messages. Renders children (typically XDSChatMessageList) in a flex column that pushes content to the bottom when the list is short.' },
@@ -478,6 +482,8 @@ export const docsDense = {
       { guidance: true, description: 'Pass scrollRef when the chat is inside a parent scroll container.' },
       { guidance: false, description: 'Custom scroll-to-bottom or density breakpoints — layout handles both.' },
       { guidance: false, description: 'Fixed height on XDSChatLayout directly — wrap in a sized container, let flex: 1 fill.' },
+      { guidance: true, description: 'Show a label on XDSChatLayoutScrollButton when unread content arrives below the fold.' },
+      { guidance: false, description: 'Don\'t rebuild the scroll-to-bottom button — use XDSChatLayoutScrollButton or pass a custom element to scrollButton.' },
 ],
   },
   components: [
@@ -637,9 +643,9 @@ export const docsDense = {
     },
     {
       name: 'XDSChatLayoutScrollButton',
-      description: 'composable scroll-to-bottom btn; fades in when visible, expands w/ label',
+      description: 'floating scroll-to-bottom btn; fades in when scrolled up, expands w/ label for new msgs. Default in XDSChatLayout; override via scrollButton prop.',
       propDescriptions: {
-        isVisible: 'btn visibility',
+        isVisible: 'btn visibility — bind to scroll-position check',
         label: 'optional label; expands btn (e.g. "New messages")',
         onClick: 'click handler',
       },


### PR DESCRIPTION
## Summary

- **Update ChatLayoutScrollButton description** in `Chat.doc.mjs`: plain language explanation of what it does, when it appears, and how to override it (3 sentences)
- **Add 2 new best practices** (1 do, 1 don't) for the scroll button across all doc variants (docs, docsZh, docsDense)
- **Improve prop descriptions** with usage guidance (e.g. "Bind to a scroll-position check" for isVisible)
- **Add 3 new block templates** with when-to-use descriptions:
  - ChatLayoutScrollButton — States: "Scroll button in hidden, visible, and expanded (with label) states."
  - ChatLayoutScrollButton — Labels: "Scroll button with different labels for context-specific notifications."
  - ChatLayoutScrollButton — In Chat: "Scroll button used inside XDSChatLayout with messages and a composer."

## Template grades

All blocks graded against the [wiki rubric](https://github.com/facebookexperimental/xds/wiki/Contributing-Templates#template-grading-rubric):

| Block | Score | Grade | Notes |
|-------|-------|-------|-------|
| ChatLayoutScrollButton — States | 100 | A | Pure XDS components, no raw HTML, no custom CSS |
| ChatLayoutScrollButton — Labels | 100 | A | Pure XDS components, no raw HTML, no custom CSS |
| ChatLayoutScrollButton — In Chat | 87 | B | 1 necessary raw `<div>` for height constraint + 3 justified style declarations (same pattern as ChatLayoutShowcase.tsx) |

## Best practices added

| Guidance | Practice |
|----------|----------|
| ✅ Do | Show a label on XDSChatLayoutScrollButton (e.g. "New messages") when unread content arrives below the fold so the user knows there is something to see. |
| ❌ Don't | Don't rebuild the scroll-to-bottom button from scratch — use XDSChatLayoutScrollButton or pass a custom element to XDSChatLayout's scrollButton prop. |

## Test plan

- [ ] `xds component ChatLayoutScrollButton` shows all 3 block templates in "Related block templates"
- [ ] Block previews render without clipping
- [ ] Chat docs page shows updated best practices (8 total, up from 6)
- [ ] No raw HTML or inline styles in States or Labels blocks