### PR TITLE
docs: add ChatPastedTextToken usage docs and block examples

### DIFF
--- a/packages/cli/templates/blocks/components/Chat/ChatPastedTextTokenExpandable.doc.mjs
+++ b/packages/cli/templates/blocks/components/Chat/ChatPastedTextTokenExpandable.doc.mjs
@@ -1,0 +1,9 @@
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  name: 'Chat — Pasted Text Token — Expandable',
+  description: 'Pasted text tokens with an Expand button in the hover card. Use onExpand to dissolve the token back into editable text when the user wants to see or edit the full content.',
+  isReady: true,
+  aspectRatio: 16 / 9,
+  componentsUsed: ['Chat', 'Layout', 'Text'],
+};

--- a/packages/cli/templates/blocks/components/Chat/ChatPastedTextTokenExpandable.tsx
+++ b/packages/cli/templates/blocks/components/Chat/ChatPastedTextTokenExpandable.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import {useState} from 'react';
+import {XDSChatPastedTextToken} from '@xds/core/Chat';
+import {XDSStack} from '@xds/core/Layout';
+import {XDSText} from '@xds/core/Text';
+
+const CONFIG_TEXT = `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "strict": true,
+    "jsx": "react-jsx",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src"]
+}`;
+
+const SQL_QUERY = `SELECT u.id, u.name, u.email, COUNT(o.id) AS order_count
+FROM users u
+LEFT JOIN orders o ON o.user_id = u.id
+WHERE u.created_at > '2025-01-01'
+GROUP BY u.id, u.name, u.email
+HAVING COUNT(o.id) > 5
+ORDER BY order_count DESC
+LIMIT 50;`;
+
+export default function ChatPastedTextTokenExpandable() {
+  const [expanded, setExpanded] = useState<string | null>(null);
+
+  return (
+    <XDSStack direction="vertical" gap={4}>
+      <XDSStack direction="vertical" gap={1}>
+        <XDSText type="supporting" color="secondary">
+          With Expand button (hover to see)
+        </XDSText>
+        <XDSStack direction="horizontal" gap={2} vAlign="center">
+          {expanded === 'config' ? (
+            <XDSText type="body">Token expanded</XDSText>
+          ) : (
+            <XDSChatPastedTextToken
+              text={CONFIG_TEXT}
+              onExpand={() => setExpanded('config')}
+            />
+          )}
+        </XDSStack>
+      </XDSStack>
+      <XDSStack direction="vertical" gap={1}>
+        <XDSText type="supporting" color="secondary">
+          Another expandable token
+        </XDSText>
+        <XDSStack direction="horizontal" gap={2} vAlign="center">
+          {expanded === 'sql' ? (
+            <XDSText type="body">Token expanded</XDSText>
+          ) : (
+            <XDSChatPastedTextToken
+              text={SQL_QUERY}
+              onExpand={() => setExpanded('sql')}
+            />
+          )}
+        </XDSStack>
+      </XDSStack>
+      <XDSStack direction="vertical" gap={1}>
+        <XDSText type="supporting" color="secondary">
+          Without Expand (read-only preview)
+        </XDSText>
+        <XDSStack direction="horizontal" gap={2} vAlign="center">
+          <XDSChatPastedTextToken text={CONFIG_TEXT} />
+        </XDSStack>
+      </XDSStack>
+    </XDSStack>
+  );
+}

--- a/packages/cli/templates/blocks/components/Chat/ChatPastedTextTokenInMessage.doc.mjs
+++ b/packages/cli/templates/blocks/components/Chat/ChatPastedTextTokenInMessage.doc.mjs
@@ -1,0 +1,9 @@
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  name: 'Chat — Pasted Text Token — In Message',
+  description: 'Pasted text token shown inside a chat message bubble alongside regular text. Use to show how pasted content appears inline within a conversation.',
+  isReady: true,
+  aspectRatio: 16 / 9,
+  componentsUsed: ['Chat', 'Layout', 'Text'],
+};

--- a/packages/cli/templates/blocks/components/Chat/ChatPastedTextTokenInMessage.tsx
+++ b/packages/cli/templates/blocks/components/Chat/ChatPastedTextTokenInMessage.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import {
+  XDSChatPastedTextToken,
+  XDSChatMessage,
+  XDSChatMessageBubble,
+  XDSChatMessageList,
+} from '@xds/core/Chat';
+import {XDSStack} from '@xds/core/Layout';
+import {XDSText} from '@xds/core/Text';
+
+const PASTED_CODE = `import {useState} from 'react';
+
+export function Counter() {
+  const [count, setCount] = useState(0);
+  return <button onClick={() => setCount(c => c + 1)}>{count}</button>;
+}`;
+
+const PASTED_ERROR = `TypeError: Cannot read properties of undefined (reading 'map')
+    at UserList (UserList.tsx:14:22)
+    at renderWithHooks (react-dom.js:16305:18)
+    at mountIndeterminateComponent (react-dom.js:20069:13)`;
+
+export default function ChatPastedTextTokenInMessage() {
+  return (
+    <XDSStack direction="vertical" gap={4}>
+      <XDSStack direction="vertical" gap={1}>
+        <XDSText type="supporting" color="secondary">
+          User shares a code snippet
+        </XDSText>
+        <XDSChatMessageList>
+          <XDSChatMessage sender="user">
+            <XDSChatMessageBubble>
+              <XDSStack direction="vertical" gap={2}>
+                <XDSText type="body">Can you review this component?</XDSText>
+                <XDSChatPastedTextToken text={PASTED_CODE} />
+              </XDSStack>
+            </XDSChatMessageBubble>
+          </XDSChatMessage>
+        </XDSChatMessageList>
+      </XDSStack>
+      <XDSStack direction="vertical" gap={1}>
+        <XDSText type="supporting" color="secondary">
+          User shares an error log
+        </XDSText>
+        <XDSChatMessageList>
+          <XDSChatMessage sender="user">
+            <XDSChatMessageBubble>
+              <XDSStack direction="vertical" gap={2}>
+                <XDSText type="body">
+                  I'm getting this error in production:
+                </XDSText>
+                <XDSChatPastedTextToken text={PASTED_ERROR} />
+              </XDSStack>
+            </XDSChatMessageBubble>
+          </XDSChatMessage>
+        </XDSChatMessageList>
+      </XDSStack>
+    </XDSStack>
+  );
+}

--- a/packages/cli/templates/blocks/components/Chat/ChatPastedTextTokenPreviews.doc.mjs
+++ b/packages/cli/templates/blocks/components/Chat/ChatPastedTextTokenPreviews.doc.mjs
@@ -1,0 +1,9 @@
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  name: 'Chat — Pasted Text Token — Previews',
+  description: 'Pasted text tokens for short, multi-line, and long text. The badge auto-formats a character and line count. Hover to see a truncated preview of the full text.',
+  isReady: true,
+  aspectRatio: 16 / 9,
+  componentsUsed: ['Chat', 'Layout', 'Text'],
+};

--- a/packages/cli/templates/blocks/components/Chat/ChatPastedTextTokenPreviews.tsx
+++ b/packages/cli/templates/blocks/components/Chat/ChatPastedTextTokenPreviews.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import {XDSChatPastedTextToken} from '@xds/core/Chat';
+import {XDSStack} from '@xds/core/Layout';
+import {XDSText} from '@xds/core/Text';
+
+const SHORT_TEXT = 'SELECT id, name FROM users WHERE active = true;';
+
+const MULTI_LINE_TEXT = `function fibonacci(n) {
+  if (n <= 1) return n;
+  return fibonacci(n - 1) + fibonacci(n - 2);
+}
+
+console.log(fibonacci(10));`;
+
+const LONG_TEXT =
+  'The quick brown fox jumps over the lazy dog. ' +
+  'Pack my box with five dozen liquor jugs. ' +
+  'How vexingly quick daft zebras jump. ' +
+  'The five boxing wizards jump quickly. ' +
+  'Sphinx of black quartz, judge my vow.';
+
+export default function ChatPastedTextTokenPreviews() {
+  return (
+    <XDSStack direction="vertical" gap={4}>
+      <XDSStack direction="vertical" gap={1}>
+        <XDSText type="supporting" color="secondary">
+          Short single-line text
+        </XDSText>
+        <XDSStack direction="horizontal" gap={2}>
+          <XDSChatPastedTextToken text={SHORT_TEXT} />
+        </XDSStack>
+      </XDSStack>
+      <XDSStack direction="vertical" gap={1}>
+        <XDSText type="supporting" color="secondary">
+          Multi-line code snippet
+        </XDSText>
+        <XDSStack direction="horizontal" gap={2}>
+          <XDSChatPastedTextToken text={MULTI_LINE_TEXT} />
+        </XDSStack>
+      </XDSStack>
+      <XDSStack direction="vertical" gap={1}>
+        <XDSText type="supporting" color="secondary">
+          Long paragraph
+        </XDSText>
+        <XDSStack direction="horizontal" gap={2}>
+          <XDSChatPastedTextToken text={LONG_TEXT} />
+        </XDSStack>
+      </XDSStack>
+    </XDSStack>
+  );
+}

--- a/packages/core/src/Chat/Chat.doc.mjs
+++ b/packages/core/src/Chat/Chat.doc.mjs
@@ -172,6 +172,14 @@ export const docs = {
         {name: 'token', type: 'XDSChatComposerToken', description: 'The token to render. Pass a badge config ({ value, label, variant?, icon? }) for the common case, or a custom render ({ value, render }) for full control.', required: true},
       ],
     },
+    {
+      name: 'XDSChatPastedTextToken',
+      description: 'Inline token that represents pasted text inside the chat composer. Renders a neutral badge showing a character and line count. On hover, a card previews the full text with an optional Expand button to dissolve the token back into editable text.',
+      props: [
+        {name: 'text', type: 'string', description: 'The full pasted text. The badge label auto-formats as "N chars" or "N lines, N chars" based on content.', required: true},
+        {name: 'onExpand', type: '() => void', description: 'Called when the user clicks Expand in the hover card. Dissolves the token into editable text in the composer.'},
+      ],
+    },
   ],
   usage: {
     description: 'Chat components provide layout primitives and a message composer for building AI chat interfaces. XDSChatComposer is the input shell — compose it using named slots (drawer, headerActions, footerActions, sendActions) to assemble features like file attachments, model selectors, and context indicators without building custom layout. Use Chat components when building conversational UIs that need message display, sender-aware styling, and rich input with trigger menus and attachments.',
@@ -388,6 +396,11 @@ export const docsZh = {
       propDescriptions: {token: '徽章配置或自定义渲染。'},
     },
     {
+      name: 'XDSChatPastedTextToken',
+      description: '聊天编辑器中粘贴文本的内联标记。渲染一个中性徽章，显示字符和行数。悬停时显示完整文本预览卡片，带有可选的展开按钮。',
+      propDescriptions: {text: '完整的粘贴文本。徽章标签根据内容自动格式化为"N 个字符"或"N 行，N 个字符"。', onExpand: '用户在悬停卡片中点击展开时调用。将标记溶解为编辑器中的可编辑文本。'},
+    },
+    {
       name: 'XDSChatLayout',
       description: '完整聊天界面的布局外壳。消息在页面中自然流动，编写器固定在底部，带有毛玻璃效果。通过容器宽度自动适配密度。',
       propDescriptions: {
@@ -570,6 +583,14 @@ export const docsDense = {
       name: 'XDSChatComposerTokenElement',
       description: 'token chip outside contentEditable; badge config or custom render in data-xds-token span',
       propDescriptions: {token: 'badge config or custom render'},
+    },
+    {
+      name: 'XDSChatPastedTextToken',
+      description: 'inline pasted-text token in composer; neutral badge w/ char+line count; hover card previews full text w/ optional Expand to dissolve back to editable text',
+      propDescriptions: {
+        text: 'full pasted text; badge auto-formats count label',
+        onExpand: 'expand click handler; dissolves token into editable text',
+      },
     },
     {
       name: 'XDSChatLayout',

--- a/packages/core/src/Chat/index.ts
+++ b/packages/core/src/Chat/index.ts
@@ -34,6 +34,9 @@ export type {
 export {XDSChatTokenizedText} from './XDSChatTokenizedText';
 export type {XDSChatTokenizedTextProps} from './XDSChatTokenizedText';
 
+export {XDSChatPastedTextToken} from './XDSChatPastedTextToken';
+export type {XDSChatPastedTextTokenProps} from './XDSChatPastedTextToken';
+
 export {XDSChatMessageList} from './XDSChatMessageList';
 export type {XDSChatMessageListProps} from './XDSChatMessageList';
 


### PR DESCRIPTION
## Summary

- **Export XDSChatPastedTextToken** from the Chat barrel (`index.ts`) so block templates can import it from `@xds/core/Chat`
- **Add component entry to Chat.doc.mjs** across all three doc variants (docs, docsZh, docsDense) with props, description, and types
- **Add 3 new block templates**:
  - Chat — Pasted Text Token — Previews: short single-line, multi-line code snippet, and long paragraph tokens showing auto-formatted badge labels
  - Chat — Pasted Text Token — In Message: tokens in context inside chat message bubbles (code snippet and error log use cases)
  - Chat — Pasted Text Token — Expandable: tokens with expand/dissolve interaction plus read-only comparison

### Usage section

**Description:** XDSChatPastedTextToken is an inline token for large pasted text inside the chat composer. It collapses the pasted content into a compact badge showing a character and line count, with a hover card that previews the full text and an optional Expand button to dissolve the token back into editable text.

**Best practices:**
| Guidance | Practice |
|----------|----------|
| ✅ Do | Use the token for pasted text that exceeds ~200 characters to keep the composer compact and scannable. |
| ✅ Do | Provide an `onExpand` callback so users can dissolve the token back into editable text when they need to modify the pasted content. |
| ❌ Don't | Use the token for short pasted text — if the content is under a few lines, let it render as plain text in the composer. |
| ❌ Don't | Omit the `onExpand` prop in editable contexts — users need a way to get back to the full text for editing. Read-only contexts (message display) can omit it. |

## Template grades

All blocks graded against the [wiki rubric](https://github.com/facebookexperimental/xds/wiki/Contributing-Templates#template-grading-rubric):

| Block | XDS Purity (30) | Icons (15) | CSS (15) | Layout (15) | Doc Meta (10) | Images (5) | Code Quality (10) | Total | Grade |
|-------|---------|-------|-----|--------|----------|--------|--------------|-------|-------|
| Previews | 30 (0 raw HTML) | 15 (no icons) | 15 (0 custom CSS) | 15 (no AppShell, single-focus, 52 lines) | 10 (all fields, 16/9, componentsUsed accurate) | 5 (no images) | 10 (use client ✓, default export ✓, self-contained ✓, realistic data ✓, no dead code ✓) | **100** | **A** |
| In Message | 30 (0 raw HTML) | 15 (no icons) | 15 (0 custom CSS) | 15 (no AppShell, single-focus, 63 lines) | 10 (all fields, 16/9, componentsUsed accurate) | 5 (no images) | 10 (use client ✓, default export ✓, self-contained ✓, realistic data ✓, no dead code ✓) | **100** | **A** |
| Expandable | 30 (0 raw HTML) | 15 (no icons) | 15 (0 custom CSS) | 15 (no AppShell, single-focus, 75 lines) | 10 (all fields, 16/9, componentsUsed accurate) | 5 (no images) | 10 (use client ✓, default export ✓, self-contained ✓, realistic data ✓, no dead code ✓) | **100** | **A** |

## Test plan

- [ ] `xds component Chat` shows the 3 new block templates in "Related block templates"
- [ ] Block previews render without clipping
- [ ] Chat docs page shows XDSChatPastedTextToken in the component list with props and description
- [ ] No raw HTML or inline styles in any block