### PR TITLE
Improve ChatSystemMessage docs page and block examples

### DIFF
--- a/packages/cli/templates/blocks/components/ChatSystemMessage/ChatSystemMessageShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatSystemMessage/ChatSystemMessageShowcase.doc.mjs
@@ -2,9 +2,9 @@
 export const doc = {
   type: 'block',
   name: 'ChatSystemMessage',
-  description: 'System messages for date dividers, status updates, and informational notices.',
+  description: 'System messages for date dividers, status updates, and informational notices. Shows both default and divider variants in a realistic conversation flow.',
   isReady: true,
   isShowcase: true,
   aspectRatio: 16 / 9,
-  componentsUsed: ['Chat', 'ChatSystemMessage'],
+  componentsUsed: ['Chat'],
 };

--- a/packages/cli/templates/blocks/components/ChatSystemMessage/ChatSystemMessageShowcase.tsx
+++ b/packages/cli/templates/blocks/components/ChatSystemMessage/ChatSystemMessageShowcase.tsx
@@ -1,9 +1,6 @@
 'use client';
 
-import {
-  XDSChatMessageList,
-  XDSChatSystemMessage,
-} from '@xds/core/Chat';
+import {XDSChatMessageList, XDSChatSystemMessage} from '@xds/core/Chat';
 
 export default function ChatSystemMessageShowcase() {
   return (
@@ -12,17 +9,11 @@ export default function ChatSystemMessageShowcase() {
         March 15, 2026
       </XDSChatSystemMessage>
 
-      <XDSChatSystemMessage>
-        Alex joined the conversation
-      </XDSChatSystemMessage>
+      <XDSChatSystemMessage>Alex joined the conversation</XDSChatSystemMessage>
 
-      <XDSChatSystemMessage>
-        Navi is thinking…
-      </XDSChatSystemMessage>
+      <XDSChatSystemMessage>Agent is thinking…</XDSChatSystemMessage>
 
-      <XDSChatSystemMessage variant="divider">
-        Today
-      </XDSChatSystemMessage>
+      <XDSChatSystemMessage variant="divider">Today</XDSChatSystemMessage>
 
       <XDSChatSystemMessage>
         Conversation marked as resolved

--- a/packages/cli/templates/blocks/components/ChatSystemMessage/ChatSystemMessageStatusUpdates.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatSystemMessage/ChatSystemMessageStatusUpdates.doc.mjs
@@ -4,6 +4,6 @@ export const doc = {
   name: 'ChatSystemMessage — Status Updates',
   description: 'Realistic status messages in a conversation flow showing membership changes, timestamps, and resolution notices.',
   isReady: true,
-  aspectRatio: 3 / 4,
+  aspectRatio: 4 / 3,
   componentsUsed: ['Chat', 'Icon'],
 };

--- a/packages/cli/templates/blocks/components/ChatSystemMessage/ChatSystemMessageStatusUpdates.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatSystemMessage/ChatSystemMessageStatusUpdates.doc.mjs
@@ -1,0 +1,9 @@
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  name: 'ChatSystemMessage — Status Updates',
+  description: 'Realistic status messages in a conversation flow showing membership changes, timestamps, and resolution notices.',
+  isReady: true,
+  aspectRatio: 3 / 4,
+  componentsUsed: ['Chat', 'Icon'],
+};

--- a/packages/cli/templates/blocks/components/ChatSystemMessage/ChatSystemMessageStatusUpdates.tsx
+++ b/packages/cli/templates/blocks/components/ChatSystemMessage/ChatSystemMessageStatusUpdates.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import {XDSChatMessageList, XDSChatSystemMessage} from '@xds/core/Chat';
+import {XDSIcon} from '@xds/core/Icon';
+import {
+  CheckCircleIcon,
+  UserMinusIcon,
+  UserPlusIcon,
+} from '@heroicons/react/24/outline';
+
+export default function ChatSystemMessageStatusUpdates() {
+  return (
+    <XDSChatMessageList>
+      <XDSChatSystemMessage variant="divider">
+        March 14, 2026
+      </XDSChatSystemMessage>
+
+      <XDSChatSystemMessage icon={<XDSIcon icon={UserPlusIcon} />}>
+        Sarah Chen joined the conversation
+      </XDSChatSystemMessage>
+
+      <XDSChatSystemMessage>
+        Topic changed to "Q2 Launch Planning"
+      </XDSChatSystemMessage>
+
+      <XDSChatSystemMessage variant="divider">
+        March 15, 2026
+      </XDSChatSystemMessage>
+
+      <XDSChatSystemMessage icon={<XDSIcon icon={UserMinusIcon} />}>
+        Alex Rivera left the conversation
+      </XDSChatSystemMessage>
+
+      <XDSChatSystemMessage variant="divider">Today</XDSChatSystemMessage>
+
+      <XDSChatSystemMessage icon={<XDSIcon icon={CheckCircleIcon} />}>
+        Conversation marked as resolved
+      </XDSChatSystemMessage>
+    </XDSChatMessageList>
+  );
+}

--- a/packages/cli/templates/blocks/components/ChatSystemMessage/ChatSystemMessageVariants.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatSystemMessage/ChatSystemMessageVariants.doc.mjs
@@ -1,0 +1,9 @@
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  name: 'ChatSystemMessage — Variants',
+  description: 'Default and divider variants side by side. Use default for inline status updates and divider for date separators or section breaks.',
+  isReady: true,
+  aspectRatio: 16 / 9,
+  componentsUsed: ['Chat', 'Layout', 'Text'],
+};

--- a/packages/cli/templates/blocks/components/ChatSystemMessage/ChatSystemMessageVariants.tsx
+++ b/packages/cli/templates/blocks/components/ChatSystemMessage/ChatSystemMessageVariants.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import {XDSChatMessageList, XDSChatSystemMessage} from '@xds/core/Chat';
+import {XDSStack} from '@xds/core/Layout';
+import {XDSText} from '@xds/core/Text';
+
+export default function ChatSystemMessageVariants() {
+  return (
+    <XDSStack direction="vertical" gap={4}>
+      <XDSStack direction="vertical" gap={1}>
+        <XDSText type="supporting" color="secondary">
+          Default
+        </XDSText>
+        <XDSChatMessageList>
+          <XDSChatSystemMessage>
+            Alex joined the conversation
+          </XDSChatSystemMessage>
+          <XDSChatSystemMessage>
+            Conversation marked as resolved
+          </XDSChatSystemMessage>
+        </XDSChatMessageList>
+      </XDSStack>
+      <XDSStack direction="vertical" gap={1}>
+        <XDSText type="supporting" color="secondary">
+          Divider
+        </XDSText>
+        <XDSChatMessageList>
+          <XDSChatSystemMessage variant="divider">
+            March 15, 2026
+          </XDSChatSystemMessage>
+          <XDSChatSystemMessage variant="divider">Today</XDSChatSystemMessage>
+        </XDSChatMessageList>
+      </XDSStack>
+    </XDSStack>
+  );
+}

--- a/packages/cli/templates/blocks/components/ChatSystemMessage/ChatSystemMessageWithIcon.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatSystemMessage/ChatSystemMessageWithIcon.doc.mjs
@@ -1,0 +1,9 @@
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  name: 'ChatSystemMessage — Icon',
+  description: 'System messages with a leading icon that reinforces the message type. Use icons to help users scan and identify message categories at a glance.',
+  isReady: true,
+  aspectRatio: 16 / 9,
+  componentsUsed: ['Chat', 'Icon', 'Layout', 'Text'],
+};

--- a/packages/cli/templates/blocks/components/ChatSystemMessage/ChatSystemMessageWithIcon.tsx
+++ b/packages/cli/templates/blocks/components/ChatSystemMessage/ChatSystemMessageWithIcon.tsx
@@ -25,7 +25,7 @@ export default function ChatSystemMessageWithIcon() {
           Messages are end-to-end encrypted
         </XDSChatSystemMessage>
         <XDSChatSystemMessage icon={<XDSIcon icon={SparklesIcon} />}>
-          Navi is generating a response…
+          Agent is generating a response…
         </XDSChatSystemMessage>
         <XDSChatSystemMessage icon={<XDSIcon icon={ShieldCheckIcon} />}>
           Conversation verified by admin

--- a/packages/cli/templates/blocks/components/ChatSystemMessage/ChatSystemMessageWithIcon.tsx
+++ b/packages/cli/templates/blocks/components/ChatSystemMessage/ChatSystemMessageWithIcon.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import {XDSChatMessageList, XDSChatSystemMessage} from '@xds/core/Chat';
+import {XDSIcon} from '@xds/core/Icon';
+import {XDSStack} from '@xds/core/Layout';
+import {XDSText} from '@xds/core/Text';
+import {
+  LockClosedIcon,
+  ShieldCheckIcon,
+  SparklesIcon,
+  UserPlusIcon,
+} from '@heroicons/react/24/outline';
+
+export default function ChatSystemMessageWithIcon() {
+  return (
+    <XDSStack direction="vertical" gap={4}>
+      <XDSText type="supporting" color="secondary">
+        Icons reinforce the message type
+      </XDSText>
+      <XDSChatMessageList>
+        <XDSChatSystemMessage icon={<XDSIcon icon={UserPlusIcon} />}>
+          Jordan was added to the conversation
+        </XDSChatSystemMessage>
+        <XDSChatSystemMessage icon={<XDSIcon icon={LockClosedIcon} />}>
+          Messages are end-to-end encrypted
+        </XDSChatSystemMessage>
+        <XDSChatSystemMessage icon={<XDSIcon icon={SparklesIcon} />}>
+          Navi is generating a response…
+        </XDSChatSystemMessage>
+        <XDSChatSystemMessage icon={<XDSIcon icon={ShieldCheckIcon} />}>
+          Conversation verified by admin
+        </XDSChatSystemMessage>
+      </XDSChatMessageList>
+    </XDSStack>
+  );
+}

--- a/packages/core/src/Chat/Chat.doc.mjs
+++ b/packages/core/src/Chat/Chat.doc.mjs
@@ -75,11 +75,11 @@ export const docs = {
     },
     {
       name: 'XDSChatSystemMessage',
-      description: 'Centered system/notice message for date separators, status updates, and non-sender content.',
+      description: 'Centered system message for non-sender content like date separators, membership changes, and status notices. It is not a chat bubble — it has no avatar, no alignment, and no sender context. Use the divider variant for temporal breaks and default for inline status updates.',
       props: [
-        {name: 'children', type: 'ReactNode', description: 'System message content.', required: true},
-        {name: 'variant', type: "'default' | 'divider'", description: 'Visual variant. Divider adds horizontal lines on each side (uses XDSDivider internally).', default: "'default'"},
-        {name: 'icon', type: 'ReactNode', description: 'Icon rendered before the text. Typically an XDSIcon.'},
+        {name: 'children', type: 'ReactNode', description: 'System message content — a short, factual string like a date, a join/leave notice, or a status change.', required: true},
+        {name: 'variant', type: "'default' | 'divider'", description: "Visual variant. 'default' renders centered text. 'divider' adds horizontal lines on each side via XDSDivider — use for date separators and section breaks.", default: "'default'"},
+        {name: 'icon', type: 'ReactNode', description: 'Leading icon that reinforces the message type. Wrap in XDSIcon for consistent sizing. Use for membership changes, encryption notices, or AI activity.'},
       ],
     },
     {
@@ -174,9 +174,13 @@ export const docs = {
       { guidance: true, description: 'Show the streaming state with isStreaming and provide an onStop handler so users can cancel long-running responses.' },
       { guidance: true, description: 'Put name and metadata on the bubble when the content has a visible bubble boundary. Put them on the message wrapper when the content is raw (no bubble).' },
       { guidance: true, description: 'Use XDSChatLayout for full-page chat — it handles auto-scroll, density adaptation, and composer docking automatically.' },
+      { guidance: true, description: 'Use XDSChatSystemMessage with variant="divider" for date separators and default for status notices like joins, leaves, or topic changes.' },
+      { guidance: true, description: 'Add an icon to system messages when the type is not obvious from the text alone — membership changes, encryption notices, or AI activity benefit from visual reinforcement.' },
       { guidance: false, description: 'Don\'t build custom input containers or composer chrome — XDSChatComposer handles the border radius, shadows, focus ring, and slot layout. Customise through slots, not wrapping.' },
       { guidance: false, description: 'Don\'t place metadata or names on both the bubble and the message wrapper — pick one based on whether the content has a bubble boundary.' },
       { guidance: false, description: 'Don\'t use the status prop for transient success messages — it\'s for errors and warnings that need the user\'s attention before they send another message.' },
+      { guidance: false, description: 'Don\'t use XDSChatSystemMessage for sender content — it has no avatar, alignment, or bubble. Use XDSChatMessage with a sender role instead.' },
+      { guidance: false, description: 'Don\'t put long or multi-line content in a system message — keep it to a single short sentence. If you need more, use a bubble or a card.' },
     ],
     anatomy: [
       { name: 'Drawer', required: false, description: 'Collapsible area above the input for file tokens, context chips, or other attachments. Use XDSChatComposerDrawer.' },
@@ -226,9 +230,13 @@ export const docsZh = {
       { guidance: true, description: 'Show the streaming state with isStreaming and provide an onStop handler so users can cancel long-running responses.' },
       { guidance: true, description: 'Put name and metadata on the bubble when the content has a visible bubble boundary. Put them on the message wrapper when the content is raw (no bubble).' },
       { guidance: true, description: 'Use XDSChatLayout for full-page chat — it handles auto-scroll, density adaptation, and composer docking automatically.' },
+      { guidance: true, description: 'Use XDSChatSystemMessage with variant="divider" for date separators and default for status notices like joins, leaves, or topic changes.' },
+      { guidance: true, description: 'Add an icon to system messages when the type is not obvious from the text alone — membership changes, encryption notices, or AI activity benefit from visual reinforcement.' },
       { guidance: false, description: 'Don\'t build custom input containers or composer chrome — XDSChatComposer handles the border radius, shadows, focus ring, and slot layout. Customise through slots, not wrapping.' },
       { guidance: false, description: 'Don\'t place metadata or names on both the bubble and the message wrapper — pick one based on whether the content has a bubble boundary.' },
       { guidance: false, description: 'Don\'t use the status prop for transient success messages — it\'s for errors and warnings that need the user\'s attention before they send another message.' },
+      { guidance: false, description: 'Don\'t use XDSChatSystemMessage for sender content — it has no avatar, alignment, or bubble. Use XDSChatMessage with a sender role instead.' },
+      { guidance: false, description: 'Don\'t put long or multi-line content in a system message — keep it to a single short sentence. If you need more, use a bubble or a card.' },
     ],
   },
   components: [
@@ -272,8 +280,8 @@ export const docsZh = {
     },
     {
       name: 'XDSChatSystemMessage',
-      description: '居中的系统/通知消息，用于日期分隔、状态更新和非发送者内容。',
-      propDescriptions: {children: '系统消息内容。', variant: '视觉变体。divider 在两侧添加水平线（内部使用 XDSDivider）。', icon: '文本前渲染的图标。通常是 XDSIcon。'},
+      description: '居中的系统消息，用于日期分隔、成员变更和状态通知等非发送者内容。没有头像、对齐或气泡。使用 divider 变体做时间分隔，default 做内联状态更新。',
+      propDescriptions: {children: '系统消息内容 — 简短的事实性文本，如日期、加入/离开通知或状态变更。', variant: "视觉变体。'default' 渲染居中文本。'divider' 通过 XDSDivider 在两侧添加水平线 — 用于日期分隔和段落分隔。", icon: '增强消息类型辨识度的前置图标。使用 XDSIcon 包裹以获得一致的尺寸。'},
     },
     {
       name: 'XDSChatComposer',
@@ -387,9 +395,12 @@ export const docsDense = {
       { guidance: true, description: 'isStreaming + onStop for cancelable long-running responses.' },
       { guidance: true, description: 'Name/metadata on bubble if bubble boundary, on message wrapper if raw content.' },
       { guidance: true, description: 'XDSChatLayout for full-page — auto-scroll, density adaptation, composer docking.' },
+      { guidance: true, description: 'SystemMessage: divider variant for date breaks, default for status notices. Add icon for membership/encryption/AI messages.' },
       { guidance: false, description: 'Custom composer chrome — Composer handles radius, shadows, focus ring. Use slots.' },
       { guidance: false, description: 'Metadata/names on both bubble and wrapper — pick one.' },
       { guidance: false, description: 'Status for success toasts — it\'s for errors/warnings before next send.' },
+      { guidance: false, description: 'SystemMessage for sender content — no avatar/alignment/bubble. Use ChatMessage instead.' },
+      { guidance: false, description: 'Long/multi-line system messages — keep to a single short sentence.' },
     ],
   },
   components: [
@@ -437,11 +448,11 @@ export const docsDense = {
     },
     {
       name: 'XDSChatSystemMessage',
-      description: 'centered system/notice msg for date separators+status updates',
+      description: 'centered non-sender msg; divider variant for date breaks, default for status notices; supports leading icon',
       propDescriptions: {
-        children: 'system msg content',
-        variant: 'visual variant; divider adds horizontal lines via XDSDivider',
-        icon: 'icon before text; typically XDSIcon',
+        children: 'short factual text: date, join/leave, status change',
+        variant: "default=centered text, divider=horizontal lines via XDSDivider for date/section breaks",
+        icon: 'leading icon reinforcing msg type; wrap in XDSIcon',
       },
     },
     {


### PR DESCRIPTION
## Summary

- **Improve ChatSystemMessage usage docs** in `Chat.doc.mjs`: enriched component description from one generic sentence to a clear explanation of what it is and is not (no avatar, no alignment, no sender context), expanded prop descriptions with concrete guidance, added 4 new best practices (2 do's for variant/icon selection, 2 don'ts for sender content misuse and long text)
- **Add ChatSystemMessage — Variants block**: default and divider variants side by side with section labels using XDSStack/XDSText
- **Add ChatSystemMessage — Icon block**: 4 system messages with leading icons (user join, encryption, AI activity, admin verification) using XDSIcon + heroicons
- **Add ChatSystemMessage — Status Updates block**: realistic multi-day conversation flow mixing dividers, icons, and plain text — membership changes, topic changes, and resolution notices
- **Update Showcase doc metadata**: expanded description, accurate componentsUsed

## Template grades

All blocks graded against the [wiki rubric](https://github.com/facebookexperimental/xds/wiki/Contributing-Templates#template-grading-rubric):

| Block | Score | Grade | Notes |
|-------|-------|-------|-------|
| ChatSystemMessage — Variants | 100 | A | 0 raw HTML, 0 raw SVG, 0 custom CSS, 41 lines, all doc fields correct |
| ChatSystemMessage — Icon | 100 | A | 0 raw HTML, 0 raw SVG, 0 custom CSS, 47 lines, all doc fields correct |
| ChatSystemMessage — Status Updates | 100 | A | 0 raw HTML, 0 raw SVG, 0 custom CSS, 52 lines, all doc fields correct |

### Scoring detail (identical across all 3 blocks)

| Category | Points | Max | Details |
|----------|--------|-----|---------|
| XDS Component Purity | 30 | 30 | 0 raw HTML elements — all layout via XDSStack/XDSChatMessageList |
| Icon Purity | 15 | 15 | All icons wrapped in XDSIcon |
| Custom CSS | 15 | 15 | 0 custom CSS declarations — all styling via component props |
| Layout & Structure | 15 | 15 | No AppShell, single-pattern focus, 41–52 lines |
| Doc Metadata | 10 | 10 | All fields present, aspectRatio matches shape, componentsUsed accurate |
| Image Handling | 5 | 5 | No images needed |
| Code Quality | 10 | 10 | `use client` ✓, default export ✓, self-contained imports ✓, realistic data ✓, no dead code ✓ |
| **TOTAL** | **100** | **100** | |

## Test plan

- [ ] `xds component Chat` shows all ChatSystemMessage block templates in "Related block templates"
- [ ] Block previews render without clipping
- [ ] Chat docs page shows updated usage with 10 best practices (6 do's + 4 don'ts)
- [ ] No raw HTML or inline styles in any block
