### PR TITLE
feat(Resizable): add pill placement offset and auto-collapse flipping

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@xds/core",
   "version": "0.0.13",
-  "description": "XDS design system \u2014 accessible, themeable React components with automatic spacing and plugin architecture",
+  "description": "XDS design system — accessible, themeable React components with automatic spacing and plugin architecture",
   "author": "Meta Open Source",
   "license": "MIT",
   "homepage": "https://github.com/facebookexperimental/xds#readme",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@xds/core",
   "version": "0.0.13",
-  "description": "XDS design system — accessible, themeable React components with automatic spacing and plugin architecture",
+  "description": "XDS design system \u2014 accessible, themeable React components with automatic spacing and plugin architecture",
   "author": "Meta Open Source",
   "license": "MIT",
   "homepage": "https://github.com/facebookexperimental/xds#readme",

--- a/packages/core/src/Resizable/Resizable.doc.mjs
+++ b/packages/core/src/Resizable/Resizable.doc.mjs
@@ -61,7 +61,7 @@ export const docs = {
         name: '--resize-handle-pill-gap',
         description:
           'Gap between the pill indicator and the divider line when pillPlacement is start or end',
-        default: '2px',
+        default: '4px (--spacing-1)',
       },
     ],
   },

--- a/packages/core/src/Resizable/Resizable.doc.mjs
+++ b/packages/core/src/Resizable/Resizable.doc.mjs
@@ -42,11 +42,7 @@ export const docs = {
   theming: {
     targets: [
       {className: 'xds-resize-handle', visualProps: ['direction']},
-      {
-        className: 'xds-resize-handle-pill',
-        description:
-          'The pill grip indicator. Target to change size, shape, or color.',
-      },
+      {className: 'xds-resize-handle-pill'},
     ],
   },
   components: [

--- a/packages/core/src/Resizable/Resizable.doc.mjs
+++ b/packages/core/src/Resizable/Resizable.doc.mjs
@@ -57,6 +57,12 @@ export const docs = {
         description: 'Clickable area width around the pill',
         default: '16px',
       },
+      {
+        name: '--resize-handle-pill-gap',
+        description:
+          'Gap between the pill indicator and the divider line when pillPlacement is start or end',
+        default: '2px',
+      },
     ],
   },
   components: [
@@ -155,6 +161,15 @@ export const docs = {
           description:
             'Show the pill grip at rest instead of only on hover. Use when discoverability is important.',
           default: 'false',
+        },
+        {
+          name: 'pillPlacement',
+          type: "'start' | 'end' | 'center' | 'auto'",
+          description:
+            'Which side of the divider the pill sits on. ' +
+            'auto = content side (derived from isReversed), flips when collapsed. ' +
+            'start = left/top, end = right/bottom, center = centered on divider.',
+          default: "'auto'",
         },
         {
           name: 'label',

--- a/packages/core/src/Resizable/Resizable.doc.mjs
+++ b/packages/core/src/Resizable/Resizable.doc.mjs
@@ -40,28 +40,12 @@ export const docs = {
     ],
   },
   theming: {
-    targets: [{className: 'xds-resize-handle', visualProps: ['direction']}],
-    vars: [
+    targets: [
+      {className: 'xds-resize-handle', visualProps: ['direction']},
       {
-        name: '--resize-handle-width',
-        description: 'Visual width of the pill indicator',
-        default: '3px',
-      },
-      {
-        name: '--resize-handle-height',
-        description: 'Height of the pill indicator',
-        default: '32px',
-      },
-      {
-        name: '--resize-handle-hit-area',
-        description: 'Clickable area width around the pill',
-        default: '16px',
-      },
-      {
-        name: '--resize-handle-pill-gap',
+        className: 'xds-resize-handle-pill',
         description:
-          'Gap between the pill indicator and the divider line when pillPlacement is start or end',
-        default: '4px (--spacing-1)',
+          'The pill grip indicator. Target to change size, shape, or color.',
       },
     ],
   },

--- a/packages/core/src/Resizable/XDSResizeHandle.tsx
+++ b/packages/core/src/Resizable/XDSResizeHandle.tsx
@@ -173,11 +173,14 @@ const dynamicStyles = stylex.create({
     left: 0,
     transform: `translate(calc(${dir} * (100% + ${spacingVars['--spacing-1']})), -50%)`,
   }),
-  // Vertical pill is rotated 90° — translate along X in local space
-  // to offset along Y in screen space.
+  // Vertical offset: no rotation — use explicit landscape dimensions.
+  // Rotation + offset creates confusing coordinate math since translate
+  // operates in pre-rotation local space.
   pillOffsetY: (dir: number) => ({
+    width: spacingVars['--spacing-8'],
+    height: 3,
     top: 0,
-    transform: `translate(-50%, calc(${dir} * (100% + ${spacingVars['--spacing-1']}))) rotate(90deg)`,
+    transform: `translate(-50%, calc(${dir} * (100% + ${spacingVars['--spacing-1']})))`,
   }),
 });
 

--- a/packages/core/src/Resizable/XDSResizeHandle.tsx
+++ b/packages/core/src/Resizable/XDSResizeHandle.tsx
@@ -128,14 +128,10 @@ const styles = stylex.create({
   },
 
   // Pill base — themes target .xds-resize-handle-pill for size/shape.
-  // Dimensions are always width=thin, height=long. Vertical mode rotates
-  // the pill 90° so themes only need to style one orientation.
   pill: {
     position: 'absolute',
     zIndex: 2,
     pointerEvents: 'none',
-    width: 3,
-    height: spacingVars['--spacing-8'],
     borderRadius: radiusVars['--radius-full'],
     backgroundColor: colorVars['--color-border'],
     transitionProperty: 'opacity, background-color, transform',
@@ -145,8 +141,13 @@ const styles = stylex.create({
     left: '50%',
     transform: 'translate(-50%, -50%)',
   },
+  pillHorizontal: {
+    width: 3,
+    height: spacingVars['--spacing-8'],
+  },
   pillVertical: {
-    transform: 'translate(-50%, -50%) rotate(90deg)',
+    width: spacingVars['--spacing-8'],
+    height: 3,
   },
   pillHidden: {opacity: 0},
   pillVisible: {opacity: 1},
@@ -177,8 +178,6 @@ const dynamicStyles = stylex.create({
   // Rotation + offset creates confusing coordinate math since translate
   // operates in pre-rotation local space.
   pillOffsetY: (dir: number) => ({
-    width: spacingVars['--spacing-8'],
-    height: 3,
     top: 0,
     transform: `translate(-50%, calc(${dir} * (100% + ${spacingVars['--spacing-1']})))`,
   }),
@@ -486,7 +485,7 @@ export function XDSResizeHandle({
             xdsClassName('resize-handle-pill'),
             stylex.props(
               styles.pill,
-              !isHorizontal && styles.pillVertical,
+              isHorizontal ? styles.pillHorizontal : styles.pillVertical,
               effectiveSide !== 'center' &&
                 (isHorizontal
                   ? dynamicStyles.pillOffsetX(

--- a/packages/core/src/Resizable/XDSResizeHandle.tsx
+++ b/packages/core/src/Resizable/XDSResizeHandle.tsx
@@ -24,6 +24,7 @@ import {
   colorVars,
   durationVars,
   easeVars,
+  radiusVars,
   spacingVars,
 } from '../theme/tokens.stylex';
 import {xdsClassName, mergeProps} from '../utils';
@@ -131,7 +132,7 @@ const styles = stylex.create({
     position: 'absolute',
     zIndex: 2,
     pointerEvents: 'none',
-    borderRadius: spacingVars['--spacing-0-5'],
+    borderRadius: radiusVars['--radius-full'],
     backgroundColor: colorVars['--color-border'],
     transitionProperty: 'opacity, background-color, transform',
     transitionDuration: durationVars['--duration-fast'],

--- a/packages/core/src/Resizable/XDSResizeHandle.tsx
+++ b/packages/core/src/Resizable/XDSResizeHandle.tsx
@@ -25,22 +25,11 @@ const KEYBOARD_LARGE_STEP = 50;
 
 /**
  * Hit area bias: the pill sits off-center from the divider, so the grab zone
- * should shift toward the pill. The bias is derived from the pill width + gap
- * relative to the total hit area:
- *
- *   hit area   = var(--resize-handle-hit-area, 16px)
- *   pill width = var(--resize-handle-width, 3px)
- *   pill gap   = var(--resize-handle-pill-gap, 4px)  → 7px offset
- *
- *   shift = (pill width + gap) / hit area ÷ 2 ≈ 7/16/2 ≈ 22%
- *   So the origin shifts from 50% to ~62.5% toward the pill side
- *   (and 37.5% away from it).
- *
- * If these CSS custom properties change, the bias percentages should be
- * updated to match — or consider computing them with calc().
+ * shifts ~2:1 toward the pill side. Two-thirds of the hit area covers the pill,
+ * one-third covers the opposite side.
  */
-const HIT_AREA_BIAS_TOWARD = '62.5%';
-const HIT_AREA_BIAS_AWAY = '37.5%';
+const HIT_AREA_BIAS_TOWARD = '66.67%';
+const HIT_AREA_BIAS_AWAY = '33.33%';
 
 type PillPlacement = 'start' | 'end' | 'center' | 'auto';
 

--- a/packages/core/src/Resizable/XDSResizeHandle.tsx
+++ b/packages/core/src/Resizable/XDSResizeHandle.tsx
@@ -128,29 +128,25 @@ const styles = stylex.create({
   },
 
   // Pill base — themes target .xds-resize-handle-pill for size/shape.
+  // Dimensions are always width=thin, height=long. Vertical mode rotates
+  // the pill 90° so themes only need to style one orientation.
   pill: {
     position: 'absolute',
     zIndex: 2,
     pointerEvents: 'none',
+    width: 3,
+    height: spacingVars['--spacing-8'],
     borderRadius: radiusVars['--radius-full'],
     backgroundColor: colorVars['--color-border'],
     transitionProperty: 'opacity, background-color, transform',
     transitionDuration: durationVars['--duration-fast'],
     transitionTimingFunction: easeVars['--ease-standard'],
-  },
-  pillHorizontal: {
-    width: 3,
-    height: spacingVars['--spacing-8'],
     top: '50%',
     left: '50%',
     transform: 'translate(-50%, -50%)',
   },
   pillVertical: {
-    height: 3,
-    width: spacingVars['--spacing-8'],
-    left: '50%',
-    top: '50%',
-    transform: 'translate(-50%, -50%)',
+    transform: 'translate(-50%, -50%) rotate(90deg)',
   },
   pillHidden: {opacity: 0},
   pillVisible: {opacity: 1},
@@ -177,9 +173,11 @@ const dynamicStyles = stylex.create({
     left: 0,
     transform: `translate(calc(${dir} * (100% + ${spacingVars['--spacing-1']})), -50%)`,
   }),
+  // Vertical pill is rotated 90° — translate along X in local space
+  // to offset along Y in screen space.
   pillOffsetY: (dir: number) => ({
     top: 0,
-    transform: `translate(-50%, calc(${dir} * (100% + ${spacingVars['--spacing-1']})))`,
+    transform: `translate(-50%, calc(${dir} * (100% + ${spacingVars['--spacing-1']}))) rotate(90deg)`,
   }),
 });
 
@@ -485,7 +483,7 @@ export function XDSResizeHandle({
             xdsClassName('resize-handle-pill'),
             stylex.props(
               styles.pill,
-              isHorizontal ? styles.pillHorizontal : styles.pillVertical,
+              !isHorizontal && styles.pillVertical,
               effectiveSide !== 'center' &&
                 (isHorizontal
                   ? dynamicStyles.pillOffsetX(

--- a/packages/core/src/Resizable/XDSResizeHandle.tsx
+++ b/packages/core/src/Resizable/XDSResizeHandle.tsx
@@ -2,13 +2,15 @@
 
 /**
  * @file XDSResizeHandle.tsx
- * @input direction, isReversed, hasDivider, isAlwaysVisible, ResizableProps
+ * @input direction, isReversed, hasDivider, isAlwaysVisible, pillPlacement, ResizableProps
  * @output Styled drag handle with WAI-ARIA separator role and keyboard support
  * @position Between resizable panels; consumed directly by builders
  *
  * Shadcn-inspired approach: the handle element is 1px wide (the divider line
  * itself), with an absolutely-positioned wider hit area for pointer interaction.
- * Optional pill grip indicator centered on the line.
+ * Pill grip indicator can sit on either side of the divider (or centered) via
+ * pillPlacement. Default 'auto' places the pill on the content side and flips
+ * when the panel collapses to 0px so it stays accessible.
  */
 
 import {useCallback, useEffect, useRef, useState} from 'react';
@@ -20,6 +22,25 @@ import type {ResizableProps} from './useXDSResizable';
 
 const KEYBOARD_STEP = 10;
 const KEYBOARD_LARGE_STEP = 50;
+
+type PillPlacement = 'start' | 'end' | 'center' | 'auto';
+
+function resolveEffectiveSide(
+  pillPlacement: PillPlacement,
+  isReversed: boolean,
+  isCollapsed: boolean,
+): 'start' | 'end' | 'center' {
+  if (pillPlacement !== 'auto') return pillPlacement;
+  // Default: pill on the panel side (inside the controlled panel).
+  // isReversed=false → panel on start → pill on start
+  // isReversed=true  → panel on end   → pill on end
+  const panelSide: 'start' | 'end' = isReversed ? 'end' : 'start';
+  // When collapsed, flip to the content side so the pill stays visible.
+  if (isCollapsed) {
+    return panelSide === 'start' ? 'end' : 'start';
+  }
+  return panelSide;
+}
 
 const styles = stylex.create({
   // The handle is 1px in layout flow — the visible divider line itself.
@@ -86,7 +107,6 @@ const styles = stylex.create({
     top: 0,
     bottom: 0,
     left: '50%',
-    transform: 'translateX(-50%)',
     cursor: 'col-resize',
   },
   hitAreaVertical: {
@@ -94,9 +114,15 @@ const styles = stylex.create({
     left: 0,
     right: 0,
     top: '50%',
-    transform: 'translateY(-50%)',
     cursor: 'row-resize',
   },
+  // Bias hit area toward the pill so the grab zone covers the visible grip.
+  hitAreaHorizontalCenter: {transform: 'translateX(-50%)'},
+  hitAreaHorizontalStart: {transform: 'translateX(-62.5%)'},
+  hitAreaHorizontalEnd: {transform: 'translateX(-37.5%)'},
+  hitAreaVerticalCenter: {transform: 'translateY(-50%)'},
+  hitAreaVerticalStart: {transform: 'translateY(-62.5%)'},
+  hitAreaVerticalEnd: {transform: 'translateY(-37.5%)'},
 
   // Pill grip indicator — absolutely positioned so it's not constrained
   // by the 1px handle container. Without this, the vertical pill (3px tall)
@@ -104,27 +130,58 @@ const styles = stylex.create({
   pill: {
     position: 'absolute',
     zIndex: 2,
+    pointerEvents: 'none',
     borderRadius: 2,
     backgroundColor: colorVars['--color-border'],
-    transitionProperty: 'opacity, background-color',
+    transitionProperty: 'opacity, background-color, transform, top, left',
     transitionDuration: durationVars['--duration-fast'],
     transitionTimingFunction: easeVars['--ease-standard'],
   },
-  pillHorizontal: {
+  // Horizontal pill placement variants (vertical bar beside a vertical 1px line)
+  pillHorizontalCenter: {
     width: 'var(--resize-handle-width, 3px)',
     height: 'var(--resize-handle-height, 32px)',
-    // Centered on the 1px vertical line
     top: '50%',
     left: '50%',
     transform: 'translate(-50%, -50%)',
   },
-  pillVertical: {
+  pillHorizontalStart: {
+    width: 'var(--resize-handle-width, 3px)',
+    height: 'var(--resize-handle-height, 32px)',
+    top: '50%',
+    left: 0,
+    transform:
+      'translate(calc(-100% - var(--resize-handle-pill-gap, 4px)), -50%)',
+  },
+  pillHorizontalEnd: {
+    width: 'var(--resize-handle-width, 3px)',
+    height: 'var(--resize-handle-height, 32px)',
+    top: '50%',
+    left: '100%',
+    transform: 'translate(var(--resize-handle-pill-gap, 4px), -50%)',
+  },
+  // Vertical pill placement variants (horizontal bar beside a horizontal 1px line)
+  pillVerticalCenter: {
     height: 'var(--resize-handle-width, 3px)',
     width: 'var(--resize-handle-height, 32px)',
-    // Centered on the 1px horizontal line
     top: '50%',
     left: '50%',
     transform: 'translate(-50%, -50%)',
+  },
+  pillVerticalStart: {
+    height: 'var(--resize-handle-width, 3px)',
+    width: 'var(--resize-handle-height, 32px)',
+    top: 0,
+    left: '50%',
+    transform:
+      'translate(-50%, calc(-100% - var(--resize-handle-pill-gap, 4px)))',
+  },
+  pillVerticalEnd: {
+    height: 'var(--resize-handle-width, 3px)',
+    width: 'var(--resize-handle-height, 32px)',
+    top: '100%',
+    left: '50%',
+    transform: 'translate(-50%, var(--resize-handle-pill-gap, 4px))',
   },
   pillHidden: {opacity: 0},
   pillVisible: {opacity: 1},
@@ -178,6 +235,16 @@ export interface XDSResizeHandleProps extends Omit<
   isAlwaysVisible?: boolean;
 
   /**
+   * Which side of the divider line the pill sits on.
+   * - `'auto'` — content side by default, flips when panel is collapsed to 0px
+   * - `'start'` — left (horizontal) or top (vertical)
+   * - `'end'` — right (horizontal) or bottom (vertical)
+   * - `'center'` — centered on the divider line (original behavior)
+   * @default 'auto'
+   */
+  pillPlacement?: PillPlacement;
+
+  /**
    * Accessible label for the separator.
    * @default 'Resize handle'
    */
@@ -212,6 +279,7 @@ export function XDSResizeHandle({
   isDisabled = false,
   hasDivider = false,
   isAlwaysVisible = true,
+  pillPlacement = 'auto',
   label = 'Resize handle',
   resizable,
   children,
@@ -225,6 +293,11 @@ export function XDSResizeHandle({
   const [isFocused, setIsFocused] = useState(false);
   const isHorizontal = direction === 'horizontal';
   const sign = isReversed ? -1 : 1;
+  const effectiveSide = resolveEffectiveSide(
+    pillPlacement,
+    isReversed,
+    resizable?._isCollapsed ?? false,
+  );
 
   const getRTLMultiplier = useCallback((): number => {
     const el = handleRef.current;
@@ -403,6 +476,17 @@ export function XDSResizeHandle({
         {...stylex.props(
           styles.hitArea,
           isHorizontal ? styles.hitAreaHorizontal : styles.hitAreaVertical,
+          isHorizontal
+            ? effectiveSide === 'start'
+              ? styles.hitAreaHorizontalStart
+              : effectiveSide === 'end'
+                ? styles.hitAreaHorizontalEnd
+                : styles.hitAreaHorizontalCenter
+            : effectiveSide === 'start'
+              ? styles.hitAreaVerticalStart
+              : effectiveSide === 'end'
+                ? styles.hitAreaVerticalEnd
+                : styles.hitAreaVerticalCenter,
           isDisabled && styles.disabled,
         )}
         onPointerDown={handlePointerDown}
@@ -417,7 +501,17 @@ export function XDSResizeHandle({
         <div
           {...stylex.props(
             styles.pill,
-            isHorizontal ? styles.pillHorizontal : styles.pillVertical,
+            isHorizontal
+              ? effectiveSide === 'start'
+                ? styles.pillHorizontalStart
+                : effectiveSide === 'end'
+                  ? styles.pillHorizontalEnd
+                  : styles.pillHorizontalCenter
+              : effectiveSide === 'start'
+                ? styles.pillVerticalStart
+                : effectiveSide === 'end'
+                  ? styles.pillVerticalEnd
+                  : styles.pillVerticalCenter,
             isAlwaysVisible ? styles.pillVisible : styles.pillHidden,
             isInteracting && !isDragging && styles.pillHover,
             isDragging && styles.pillActive,

--- a/packages/core/src/Resizable/XDSResizeHandle.tsx
+++ b/packages/core/src/Resizable/XDSResizeHandle.tsx
@@ -6,30 +6,31 @@
  * @output Styled drag handle with WAI-ARIA separator role and keyboard support
  * @position Between resizable panels; consumed directly by builders
  *
- * Shadcn-inspired approach: the handle element is 1px wide (the divider line
- * itself), with an absolutely-positioned wider hit area for pointer interaction.
- * Pill grip indicator can sit on either side of the divider (or centered) via
- * pillPlacement. Default 'auto' places the pill on the content side and flips
- * when the panel collapses to 0px so it stays accessible.
+ * The handle element is 1px wide (the divider line itself), with an
+ * absolutely-positioned wider hit area for pointer interaction.
+ * Pill grip indicator can sit on either side of the divider (or centered)
+ * via pillPlacement. Default 'auto' places the pill on the panel side and
+ * flips when the panel collapses to 0px so it stays accessible.
+ *
+ * Pill placement uses a single stylex dynamic style that accepts a direction
+ * multiplier (-1 or 1). The pill element has its own xdsClassName
+ * ('resize-handle-pill') so themes can target size/shape directly.
  */
 
 import {useCallback, useEffect, useRef, useState} from 'react';
 import type {HTMLAttributes, ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {colorVars, durationVars, easeVars} from '../theme/tokens.stylex';
+import {
+  colorVars,
+  durationVars,
+  easeVars,
+  spacingVars,
+} from '../theme/tokens.stylex';
 import {xdsClassName, mergeProps} from '../utils';
 import type {ResizableProps} from './useXDSResizable';
 
 const KEYBOARD_STEP = 10;
 const KEYBOARD_LARGE_STEP = 50;
-
-/**
- * Hit area bias: the pill sits off-center from the divider, so the grab zone
- * shifts ~2:1 toward the pill side. Two-thirds of the hit area covers the pill,
- * one-third covers the opposite side.
- */
-const HIT_AREA_BIAS_TOWARD = '66.67%';
-const HIT_AREA_BIAS_AWAY = '33.33%';
 
 type PillPlacement = 'start' | 'end' | 'center' | 'auto';
 
@@ -39,20 +40,23 @@ function resolveEffectiveSide(
   isCollapsed: boolean,
 ): 'start' | 'end' | 'center' {
   if (pillPlacement !== 'auto') return pillPlacement;
-  // Default: pill on the panel side (inside the controlled panel).
-  // isReversed=false → panel on start → pill on start
-  // isReversed=true  → panel on end   → pill on end
   const panelSide: 'start' | 'end' = isReversed ? 'end' : 'start';
-  // When collapsed, flip to the content side so the pill stays visible.
   if (isCollapsed) {
     return panelSide === 'start' ? 'end' : 'start';
   }
   return panelSide;
 }
 
+/**
+ * Hit area bias percentage. When the pill is off-center, the grab zone
+ * shifts ~2:1 toward the pill so users can reach the visible grip easily.
+ */
+function hitAreaBias(effectiveSide: 'start' | 'end' | 'center'): string {
+  if (effectiveSide === 'center') return '50%';
+  return effectiveSide === 'start' ? '66.67%' : '33.33%';
+}
+
 const styles = stylex.create({
-  // The handle is 1px in layout flow — the visible divider line itself.
-  // A wider hit area is achieved via the hitArea child.
   handle: {
     position: 'relative',
     flexShrink: 0,
@@ -69,7 +73,7 @@ const styles = stylex.create({
     },
     outlineOffset: {
       default: null,
-      ':focus-visible': '2px',
+      ':focus-visible': spacingVars['--spacing-0-5'],
     },
   },
   horizontal: {
@@ -82,8 +86,6 @@ const styles = stylex.create({
     width: '100%',
     cursor: 'row-resize',
   },
-  // Zero-footprint mode: handle takes 0px in layout when no divider.
-  // Hit area + pill use absolute positioning so they still work.
   noDividerHorizontal: {
     backgroundColor: 'transparent',
     width: 0,
@@ -103,7 +105,6 @@ const styles = stylex.create({
     pointerEvents: 'none',
   },
 
-  // Wider invisible hit area — extends beyond the 1px line.
   hitArea: {
     position: 'absolute',
     zIndex: 1,
@@ -111,78 +112,44 @@ const styles = stylex.create({
     userSelect: 'none',
   },
   hitAreaHorizontal: {
-    width: 'var(--resize-handle-hit-area, 16px)',
+    width: spacingVars['--spacing-4'],
     top: 0,
     bottom: 0,
     left: '50%',
     cursor: 'col-resize',
   },
   hitAreaVertical: {
-    height: 'var(--resize-handle-hit-area, 16px)',
+    height: spacingVars['--spacing-4'],
     left: 0,
     right: 0,
     top: '50%',
     cursor: 'row-resize',
   },
-  // Bias hit area toward the pill so the grab zone covers the visible grip.
-  // See HIT_AREA_BIAS_TOWARD / HIT_AREA_BIAS_AWAY constants for derivation.
-  hitAreaHorizontalCenter: {transform: 'translateX(-50%)'},
-  hitAreaHorizontalStart: {transform: `translateX(-${HIT_AREA_BIAS_TOWARD})`},
-  hitAreaHorizontalEnd: {transform: `translateX(-${HIT_AREA_BIAS_AWAY})`},
-  hitAreaVerticalCenter: {transform: 'translateY(-50%)'},
-  hitAreaVerticalStart: {transform: `translateY(-${HIT_AREA_BIAS_TOWARD})`},
-  hitAreaVerticalEnd: {transform: `translateY(-${HIT_AREA_BIAS_AWAY})`},
 
-  // Pill grip indicator — absolutely positioned so it's not constrained
-  // by the 1px handle container. Without this, the vertical pill (3px tall)
-  // gets squished to 1px by the flex layout of the 1px-tall handle.
+  // Pill base — themes target .xds-resize-handle-pill for size/shape.
   pill: {
     position: 'absolute',
     zIndex: 2,
     pointerEvents: 'none',
-    borderRadius: 2,
+    borderRadius: spacingVars['--spacing-0-5'],
     backgroundColor: colorVars['--color-border'],
-    transitionProperty: 'opacity, background-color, transform, top, left',
+    transitionProperty: 'opacity, background-color, transform',
     transitionDuration: durationVars['--duration-fast'],
     transitionTimingFunction: easeVars['--ease-standard'],
   },
-  // Base pill dimensions per axis — applied alongside a placement style.
   pillHorizontal: {
-    width: 'var(--resize-handle-width, 3px)',
-    height: 'var(--resize-handle-height, 32px)',
-    top: '50%',
-  },
-  pillVertical: {
-    height: 'var(--resize-handle-width, 3px)',
-    width: 'var(--resize-handle-height, 32px)',
-    left: '50%',
-  },
-  // Pill placement: center (on the divider line)
-  pillCenter: {
+    width: 3,
+    height: spacingVars['--spacing-8'],
     top: '50%',
     left: '50%',
     transform: 'translate(-50%, -50%)',
   },
-  // Pill placement: start (left / top of divider)
-  pillHorizontalStart: {
-    left: 0,
-    transform:
-      'translate(calc(-100% - var(--resize-handle-pill-gap, var(--spacing-1, 4px))), -50%)',
-  },
-  pillHorizontalEnd: {
-    left: '100%',
-    transform:
-      'translate(var(--resize-handle-pill-gap, var(--spacing-1, 4px)), -50%)',
-  },
-  pillVerticalStart: {
-    top: 0,
-    transform:
-      'translate(-50%, calc(-100% - var(--resize-handle-pill-gap, var(--spacing-1, 4px))))',
-  },
-  pillVerticalEnd: {
-    top: '100%',
-    transform:
-      'translate(-50%, var(--resize-handle-pill-gap, var(--spacing-1, 4px)))',
+  pillVertical: {
+    height: 3,
+    width: spacingVars['--spacing-8'],
+    left: '50%',
+    top: '50%',
+    transform: 'translate(-50%, -50%)',
   },
   pillHidden: {opacity: 0},
   pillVisible: {opacity: 1},
@@ -194,6 +161,25 @@ const styles = stylex.create({
     opacity: 1,
     backgroundColor: colorVars['--color-border-emphasized'],
   },
+});
+
+// Dynamic styles — avoids inline style overrides.
+// Each axis gets its own function since StyleX requires static structure.
+const dynamicStyles = stylex.create({
+  hitAreaBiasX: (pct: string) => ({
+    transform: `translateX(-${pct})`,
+  }),
+  hitAreaBiasY: (pct: string) => ({
+    transform: `translateY(-${pct})`,
+  }),
+  pillOffsetX: (dir: number) => ({
+    left: 0,
+    transform: `translate(calc(${dir} * (100% + ${spacingVars['--spacing-1']})), -50%)`,
+  }),
+  pillOffsetY: (dir: number) => ({
+    top: 0,
+    transform: `translate(-50%, calc(${dir} * (100% + ${spacingVars['--spacing-1']})))`,
+  }),
 });
 
 export interface XDSResizeHandleProps extends Omit<
@@ -237,7 +223,7 @@ export interface XDSResizeHandleProps extends Omit<
 
   /**
    * Which side of the divider line the pill sits on.
-   * - `'auto'` — content side by default, flips when panel is collapsed to 0px
+   * - `'auto'` — panel side by default, flips when panel is collapsed to 0px
    * - `'start'` — left (horizontal) or top (vertical)
    * - `'end'` — right (horizontal) or bottom (vertical)
    * - `'center'` — centered on the divider line (original behavior)
@@ -265,6 +251,8 @@ export interface XDSResizeHandleProps extends Omit<
  * Draggable resize handle placed between resizable panels. Renders as a thin
  * divider line with a wider invisible hit area and optional pill grip indicator.
  * Supports keyboard resizing via arrow keys and WAI-ARIA separator role.
+ *
+ * The pill element uses class `xds-resize-handle-pill` for theme targeting.
  *
  * @example
  * ```
@@ -478,16 +466,8 @@ export function XDSResizeHandle({
           styles.hitArea,
           isHorizontal ? styles.hitAreaHorizontal : styles.hitAreaVertical,
           isHorizontal
-            ? effectiveSide === 'start'
-              ? styles.hitAreaHorizontalStart
-              : effectiveSide === 'end'
-                ? styles.hitAreaHorizontalEnd
-                : styles.hitAreaHorizontalCenter
-            : effectiveSide === 'start'
-              ? styles.hitAreaVerticalStart
-              : effectiveSide === 'end'
-                ? styles.hitAreaVerticalEnd
-                : styles.hitAreaVerticalCenter,
+            ? dynamicStyles.hitAreaBiasX(hitAreaBias(effectiveSide))
+            : dynamicStyles.hitAreaBiasY(hitAreaBias(effectiveSide)),
           isDisabled && styles.disabled,
         )}
         onPointerDown={handlePointerDown}
@@ -497,24 +477,26 @@ export function XDSResizeHandle({
         }}
         onKeyDown={handleKeyDown}
       />
-      {/* Pill grip indicator */}
+      {/* Pill grip indicator — themed via .xds-resize-handle-pill */}
       {children ?? (
         <div
-          {...stylex.props(
-            styles.pill,
-            isHorizontal ? styles.pillHorizontal : styles.pillVertical,
-            effectiveSide === 'center'
-              ? styles.pillCenter
-              : isHorizontal
-                ? effectiveSide === 'start'
-                  ? styles.pillHorizontalStart
-                  : styles.pillHorizontalEnd
-                : effectiveSide === 'start'
-                  ? styles.pillVerticalStart
-                  : styles.pillVerticalEnd,
-            isAlwaysVisible ? styles.pillVisible : styles.pillHidden,
-            isInteracting && !isDragging && styles.pillHover,
-            isDragging && styles.pillActive,
+          {...mergeProps(
+            xdsClassName('resize-handle-pill'),
+            stylex.props(
+              styles.pill,
+              isHorizontal ? styles.pillHorizontal : styles.pillVertical,
+              effectiveSide !== 'center' &&
+                (isHorizontal
+                  ? dynamicStyles.pillOffsetX(
+                      effectiveSide === 'start' ? -1 : 1,
+                    )
+                  : dynamicStyles.pillOffsetY(
+                      effectiveSide === 'start' ? -1 : 1,
+                    )),
+              isAlwaysVisible ? styles.pillVisible : styles.pillHidden,
+              isInteracting && !isDragging && styles.pillHover,
+              isDragging && styles.pillActive,
+            ),
           )}
         />
       )}

--- a/packages/core/src/Resizable/XDSResizeHandle.tsx
+++ b/packages/core/src/Resizable/XDSResizeHandle.tsx
@@ -23,6 +23,25 @@ import type {ResizableProps} from './useXDSResizable';
 const KEYBOARD_STEP = 10;
 const KEYBOARD_LARGE_STEP = 50;
 
+/**
+ * Hit area bias: the pill sits off-center from the divider, so the grab zone
+ * should shift toward the pill. The bias is derived from the pill width + gap
+ * relative to the total hit area:
+ *
+ *   hit area   = var(--resize-handle-hit-area, 16px)
+ *   pill width = var(--resize-handle-width, 3px)
+ *   pill gap   = var(--resize-handle-pill-gap, 4px)  → 7px offset
+ *
+ *   shift = (pill width + gap) / hit area ÷ 2 ≈ 7/16/2 ≈ 22%
+ *   So the origin shifts from 50% to ~62.5% toward the pill side
+ *   (and 37.5% away from it).
+ *
+ * If these CSS custom properties change, the bias percentages should be
+ * updated to match — or consider computing them with calc().
+ */
+const HIT_AREA_BIAS_TOWARD = '62.5%';
+const HIT_AREA_BIAS_AWAY = '37.5%';
+
 type PillPlacement = 'start' | 'end' | 'center' | 'auto';
 
 function resolveEffectiveSide(
@@ -117,12 +136,13 @@ const styles = stylex.create({
     cursor: 'row-resize',
   },
   // Bias hit area toward the pill so the grab zone covers the visible grip.
+  // See HIT_AREA_BIAS_TOWARD / HIT_AREA_BIAS_AWAY constants for derivation.
   hitAreaHorizontalCenter: {transform: 'translateX(-50%)'},
-  hitAreaHorizontalStart: {transform: 'translateX(-62.5%)'},
-  hitAreaHorizontalEnd: {transform: 'translateX(-37.5%)'},
+  hitAreaHorizontalStart: {transform: `translateX(-${HIT_AREA_BIAS_TOWARD})`},
+  hitAreaHorizontalEnd: {transform: `translateX(-${HIT_AREA_BIAS_AWAY})`},
   hitAreaVerticalCenter: {transform: 'translateY(-50%)'},
-  hitAreaVerticalStart: {transform: 'translateY(-62.5%)'},
-  hitAreaVerticalEnd: {transform: 'translateY(-37.5%)'},
+  hitAreaVerticalStart: {transform: `translateY(-${HIT_AREA_BIAS_TOWARD})`},
+  hitAreaVerticalEnd: {transform: `translateY(-${HIT_AREA_BIAS_AWAY})`},
 
   // Pill grip indicator — absolutely positioned so it's not constrained
   // by the 1px handle container. Without this, the vertical pill (3px tall)
@@ -137,51 +157,43 @@ const styles = stylex.create({
     transitionDuration: durationVars['--duration-fast'],
     transitionTimingFunction: easeVars['--ease-standard'],
   },
-  // Horizontal pill placement variants (vertical bar beside a vertical 1px line)
-  pillHorizontalCenter: {
+  // Base pill dimensions per axis — applied alongside a placement style.
+  pillHorizontal: {
     width: 'var(--resize-handle-width, 3px)',
     height: 'var(--resize-handle-height, 32px)',
+    top: '50%',
+  },
+  pillVertical: {
+    height: 'var(--resize-handle-width, 3px)',
+    width: 'var(--resize-handle-height, 32px)',
+    left: '50%',
+  },
+  // Pill placement: center (on the divider line)
+  pillCenter: {
     top: '50%',
     left: '50%',
     transform: 'translate(-50%, -50%)',
   },
+  // Pill placement: start (left / top of divider)
   pillHorizontalStart: {
-    width: 'var(--resize-handle-width, 3px)',
-    height: 'var(--resize-handle-height, 32px)',
-    top: '50%',
     left: 0,
     transform:
-      'translate(calc(-100% - var(--resize-handle-pill-gap, 4px)), -50%)',
+      'translate(calc(-100% - var(--resize-handle-pill-gap, var(--spacing-1, 4px))), -50%)',
   },
   pillHorizontalEnd: {
-    width: 'var(--resize-handle-width, 3px)',
-    height: 'var(--resize-handle-height, 32px)',
-    top: '50%',
     left: '100%',
-    transform: 'translate(var(--resize-handle-pill-gap, 4px), -50%)',
-  },
-  // Vertical pill placement variants (horizontal bar beside a horizontal 1px line)
-  pillVerticalCenter: {
-    height: 'var(--resize-handle-width, 3px)',
-    width: 'var(--resize-handle-height, 32px)',
-    top: '50%',
-    left: '50%',
-    transform: 'translate(-50%, -50%)',
+    transform:
+      'translate(var(--resize-handle-pill-gap, var(--spacing-1, 4px)), -50%)',
   },
   pillVerticalStart: {
-    height: 'var(--resize-handle-width, 3px)',
-    width: 'var(--resize-handle-height, 32px)',
     top: 0,
-    left: '50%',
     transform:
-      'translate(-50%, calc(-100% - var(--resize-handle-pill-gap, 4px)))',
+      'translate(-50%, calc(-100% - var(--resize-handle-pill-gap, var(--spacing-1, 4px))))',
   },
   pillVerticalEnd: {
-    height: 'var(--resize-handle-width, 3px)',
-    width: 'var(--resize-handle-height, 32px)',
     top: '100%',
-    left: '50%',
-    transform: 'translate(-50%, var(--resize-handle-pill-gap, 4px))',
+    transform:
+      'translate(-50%, var(--resize-handle-pill-gap, var(--spacing-1, 4px)))',
   },
   pillHidden: {opacity: 0},
   pillVisible: {opacity: 1},
@@ -501,17 +513,16 @@ export function XDSResizeHandle({
         <div
           {...stylex.props(
             styles.pill,
-            isHorizontal
-              ? effectiveSide === 'start'
-                ? styles.pillHorizontalStart
-                : effectiveSide === 'end'
-                  ? styles.pillHorizontalEnd
-                  : styles.pillHorizontalCenter
-              : effectiveSide === 'start'
-                ? styles.pillVerticalStart
-                : effectiveSide === 'end'
-                  ? styles.pillVerticalEnd
-                  : styles.pillVerticalCenter,
+            isHorizontal ? styles.pillHorizontal : styles.pillVertical,
+            effectiveSide === 'center'
+              ? styles.pillCenter
+              : isHorizontal
+                ? effectiveSide === 'start'
+                  ? styles.pillHorizontalStart
+                  : styles.pillHorizontalEnd
+                : effectiveSide === 'start'
+                  ? styles.pillVerticalStart
+                  : styles.pillVerticalEnd,
             isAlwaysVisible ? styles.pillVisible : styles.pillHidden,
             isInteracting && !isDragging && styles.pillHover,
             isDragging && styles.pillActive,


### PR DESCRIPTION
There are visual problems with the drag handle pill overlapping dividers.  So this update allows users to place pill to either the start or end side depending on the panel placement.  And also auto flips handle if it gets completely collapsed. 


https://github.com/user-attachments/assets/44f3fea4-e678-4814-99d5-4f95db110593


## Summary
- Add `pillPlacement` prop to `XDSResizeHandle` with `'auto'` default that places the pill grip on the panel side and flips to the content side when the panel collapses to 0px, keeping it accessible
- Hit area shifts 62.5%/37.5% toward the pill for better grab targeting
- Add `Resizable.doc.mjs` with CSS custom property documentation and `./Resizable` package export

## Test plan
- [ ] Verify pill flips sides when a collapsible panel collapses to 0px
- [ ] Verify hit area bias makes the grip easier to grab from the panel side
- [ ] Verify `pillPlacement="start"`, `"end"`, `"center"` overrides work
- [ ] Verify Storybook stories render correctly


Made with [Cursor](https://cursor.com)