### PR TITLE
fix(theme): restore --radius-page to 16px (base × 4)

### DIFF
--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/DocsView.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/DocsView.tsx
@@ -2670,7 +2670,7 @@ const SHAPE_TOKENS: {
   },
   {
     token: '--radius-page',
-    value: '28px',
+    value: '16px',
     usage: 'Modals, dialogs, chat composer',
     cssVar: 'var(--radius-page)',
   },

--- a/internal/vibe-tests/prompts/radius-evaluator.md
+++ b/internal/vibe-tests/prompts/radius-evaluator.md
@@ -18,7 +18,7 @@ You will receive:
 | Token              | Value  | Usage                    |
 | ------------------ | ------ | ------------------------ |
 | --radius-full      | 9999px | Pills, avatars           |
-| --radius-page      | 28px   | Page sections, app shell |
+| --radius-page      | 16px   | Page sections, app shell |
 | --radius-container | 12px   | Cards, modals            |
 | --radius-element   | 8px    | Buttons, inputs          |
 | --radius-inner     | 4px    | Small elements           |
@@ -29,7 +29,7 @@ You will receive:
 | Token              | Value  | Usage                           |
 | ------------------ | ------ | ------------------------------- |
 | --radius-full      | 9999px | Pills, avatars                  |
-| --radius-page      | 28px   | Page sections, large containers |
+| --radius-page      | 16px   | Page sections, large containers |
 | --radius-container | 12px   | Cards, modals                   |
 | --radius-element   | 8px    | Buttons, inputs                 |
 | --radius-inner     | 4px    | Small elements                  |

--- a/packages/core/src/theme/defineTheme.test.ts
+++ b/packages/core/src/theme/defineTheme.test.ts
@@ -78,7 +78,6 @@ describe('defineTheme', () => {
   });
 
   it('includes icons in the theme', () => {
-     
     const icons = {close: 'X'} as Partial<XDSIconRegistry>;
     const theme = defineTheme({name: 'icons', icons});
     expect(theme.icons).toBe(icons);
@@ -411,7 +410,7 @@ describe('radius', () => {
     expect(theme.tokens['--radius-inner']).toBe('6px');
     expect(theme.tokens['--radius-element']).toBe('12px');
     expect(theme.tokens['--radius-container']).toBe('18px');
-    expect(theme.tokens['--radius-page']).toBe('42px');
+    expect(theme.tokens['--radius-page']).toBe('24px');
     expect(theme.tokens['--radius-none']).toBe('0px');
     expect(theme.tokens['--radius-full']).toBe('9999px');
   });

--- a/packages/core/src/theme/expandRadiusScale.test.ts
+++ b/packages/core/src/theme/expandRadiusScale.test.ts
@@ -8,7 +8,7 @@ describe('expandRadiusScale', () => {
     expect(tokens['--radius-inner']).toBe('4px');
     expect(tokens['--radius-element']).toBe('8px');
     expect(tokens['--radius-container']).toBe('12px');
-    expect(tokens['--radius-page']).toBe('28px');
+    expect(tokens['--radius-page']).toBe('16px');
     expect(tokens['--radius-full']).toBe('9999px');
   });
 
@@ -17,7 +17,7 @@ describe('expandRadiusScale', () => {
     expect(tokens['--radius-inner']).toBe('6px');
     expect(tokens['--radius-element']).toBe('12px');
     expect(tokens['--radius-container']).toBe('18px');
-    expect(tokens['--radius-page']).toBe('42px');
+    expect(tokens['--radius-page']).toBe('24px');
   });
 
   it('multiplier 0 produces all zeros', () => {
@@ -49,6 +49,6 @@ describe('expandRadiusScale', () => {
     expect(tokens['--radius-inner']).toBe('6px');
     expect(tokens['--radius-element']).toBe('12px');
     expect(tokens['--radius-container']).toBe('18px');
-    expect(tokens['--radius-page']).toBe('42px');
+    expect(tokens['--radius-page']).toBe('24px');
   });
 });

--- a/packages/core/src/theme/expandRadiusScale.ts
+++ b/packages/core/src/theme/expandRadiusScale.ts
@@ -13,7 +13,7 @@
  *   --radius-inner     → base × 1 × multiplier (internal corners)
  *   --radius-element   → base × 2 × multiplier (buttons, inputs)
  *   --radius-container → base × 3 × multiplier (cards, panels)
- *   --radius-page      → base × 7 × multiplier (page-level containers)
+ *   --radius-page      → base × 4 × multiplier (page-level containers)
  *   --radius-full      → 9999px (fixed, pill shapes)
  *
  * SYNC: When modified, update:
@@ -70,7 +70,7 @@ export type RadiusScaleTokens = Record<string, string>;
  * // tokens['--radius-inner'] === '4px'       (4 × 1 × 1)
  * // tokens['--radius-element'] === '8px'     (4 × 2 × 1)
  * // tokens['--radius-container'] === '12px'  (4 × 3 × 1)
- * // tokens['--radius-page'] === '28px'       (4 × 7 × 1)
+ * // tokens['--radius-page'] === '16px'       (4 × 4 × 1)
  * // tokens['--radius-full'] === '9999px'
  *
  * const sharp = expandRadiusScale({ base: 4, multiplier: 0 });
@@ -86,7 +86,7 @@ export function expandRadiusScale(
     '--radius-inner': `${Math.round(base * 1 * multiplier)}px`,
     '--radius-element': `${Math.round(base * 2 * multiplier)}px`,
     '--radius-container': `${Math.round(base * 3 * multiplier)}px`,
-    '--radius-page': `${Math.round(base * 7 * multiplier)}px`,
+    '--radius-page': `${Math.round(base * 4 * multiplier)}px`,
     '--radius-full': '9999px',
   };
 }

--- a/packages/core/src/theme/tokens.stylex.ts
+++ b/packages/core/src/theme/tokens.stylex.ts
@@ -75,43 +75,43 @@ export const colorDefaults = {
 
   // Blue
   '--color-background-blue': 'light-dark(#0171E333, #0171E333)',
-  '--color-border-blue': 'light-dark(#0064E0, #2694FE)',  // Blue 650 / 500
+  '--color-border-blue': 'light-dark(#0064E0, #2694FE)', // Blue 650 / 500
   '--color-icon-blue': 'light-dark(#0064E0, #2694FE)',
   '--color-text-blue': 'light-dark(#042F97, #AFD7FF)',
 
   // Cyan
   '--color-background-cyan': 'light-dark(#03A7D733, #03A7D733)',
-  '--color-border-cyan': 'light-dark(#089DD0, #0171A4)',  // Cyan 500 / 650
+  '--color-border-cyan': 'light-dark(#089DD0, #0171A4)', // Cyan 500 / 650
   '--color-icon-cyan': 'light-dark(#00ACC1, #26C6DA)',
   '--color-text-cyan': 'light-dark(#014975, #A1EEF9)',
 
   // Gray
   '--color-background-gray': 'light-dark(#0A131733, #666A724C)',
-  '--color-border-gray': 'light-dark(#647685, #748695)',  // Gray 600 / 550
+  '--color-border-gray': 'light-dark(#647685, #748695)', // Gray 600 / 550
   '--color-icon-gray': 'light-dark(#4E606F, #AAAFB5)',
   '--color-text-gray': 'light-dark(#0A1317, #E7EAED)',
 
   // Green
   '--color-background-green': 'light-dark(#24BB5E33, #24BB5E33)',
-  '--color-border-green': 'light-dark(#0D8626, #0B991F)',  // Green 600 / 550
+  '--color-border-green': 'light-dark(#0D8626, #0B991F)', // Green 600 / 550
   '--color-icon-green': 'light-dark(#0D8626, #26A756)',
   '--color-text-green': 'light-dark(#09441F, #A5F690)',
 
   // Orange
   '--color-background-orange': 'light-dark(#F2790233, #F2790233)',
-  '--color-border-orange': 'light-dark(#EB6E00, #B34A01)',  // Orange 500 / 650
+  '--color-border-orange': 'light-dark(#EB6E00, #B34A01)', // Orange 500 / 650
   '--color-icon-orange': 'light-dark(#E9690B, #FB8C00)',
   '--color-text-orange': 'light-dark(#6B2203, #FDB876)',
 
   // Pink
   '--color-background-pink': 'light-dark(#E638B333, #E638B333)',
-  '--color-border-pink': 'light-dark(#F351C0, #C02294)',  // Pink 500 / 650
+  '--color-border-pink': 'light-dark(#F351C0, #C02294)', // Pink 500 / 650
   '--color-icon-pink': 'light-dark(#C2185B, #EC407A)',
   '--color-text-pink': 'light-dark(#650053, #FEADE3)',
 
   // Purple
   '--color-background-purple': 'light-dark(#7952FF33, #7952FF33)',
-  '--color-border-purple': 'light-dark(#9081FF, #7340FE)',  // Purple 500 / 650
+  '--color-border-purple': 'light-dark(#9081FF, #7340FE)', // Purple 500 / 650
   '--color-icon-purple': 'light-dark(#5B08D8, #7952FF)',
   '--color-text-purple': 'light-dark(#3E0697, #B3B0FE)',
 
@@ -123,13 +123,13 @@ export const colorDefaults = {
 
   // Teal
   '--color-background-teal': 'light-dark(#0DB7AF33, #0DB7AF33)',
-  '--color-border-teal': 'light-dark(#08A3A3, #08767D)',  // Teal 500 / 650
+  '--color-border-teal': 'light-dark(#08A3A3, #08767D)', // Teal 500 / 650
   '--color-icon-teal': 'light-dark(#009688, #26A69A)',
   '--color-text-teal': 'light-dark(#083943, #40DCCD)',
 
   // Yellow
   '--color-background-yellow': 'light-dark(#E2A40033, #E2A40033)',
-  '--color-border-yellow': 'light-dark(#C58600, #B47700)',  // Yellow 500 / 550
+  '--color-border-yellow': 'light-dark(#C58600, #B47700)', // Yellow 500 / 550
   '--color-icon-yellow': 'light-dark(#FBC02D, #FFEE58)',
   '--color-text-yellow': 'light-dark(#753F07, #FBCE03)',
 
@@ -204,7 +204,7 @@ export const radiusDefaults = {
   '--radius-inner': '4px',
   '--radius-element': '8px',
   '--radius-container': '12px',
-  '--radius-page': '28px',
+  '--radius-page': '16px',
   '--radius-full': '9999px',
 } as const;
 


### PR DESCRIPTION
## Summary

Reverts `--radius-page` from 28px (`base × 7`) back to 16px (`base × 4`), restoring the original value and concentric radius math.

## History

- **PR #686** introduced `--radius-page` at `base × 4 = 16px` with a clear design rationale:
  > *page radius (16px) = card radius (12px) + page padding (4px gap)*
  
  This supported concentric corner radii when cards are nested inside page-level containers.

- **PR #894** (the big token rename refactor — 142 files, ~2k line changes) changed the step multiplier from `4` to `7`, bumping the default to 28px. The commit message doesn't explain this change — it was bundled into the large rename and appears to be unintentional scope creep. The `ThemeEditorView.tsx` in the same codebase still labels the token as "Page — 16px", further suggesting the bump was accidental.

## Changes

| File | Change |
|------|--------|
| `expandRadiusScale.ts` | step `7` → `4` |
| `tokens.stylex.ts` | default `28px` → `16px` |
| `expandRadiusScale.test.ts` | Updated assertions |
| `defineTheme.test.ts` | Updated assertion |
| `DocsView.tsx` | Updated token table value |
| `radius-evaluator.md` | Updated vibe test reference |

Theme overrides (daily, meta, neutral, matcha) are left unchanged — those are explicit per-theme design choices.

## Test plan

`yarn test` — all 86 theme tests pass. `yarn build` — clean.