### PR TITLE
fix(detail-page): use permanent lookaside URLs for product images

### DIFF
--- a/packages/cli/templates/pages/detail-page/page.tsx
+++ b/packages/cli/templates/pages/detail-page/page.tsx
@@ -69,21 +69,21 @@ const pageStyles = stylex.create({
 // Light product photography from the xds_oss asset set (ceramics collection)
 // Source: meta assets.file list -s xds_oss -g light-product-{1..5}
 const PRODUCT_IMAGES = [
-  // light-product-1
-  'https://scontent.xx.fbcdn.net/v/t39.6806-6/671222955_2145727732941085_520241325832272863_n.png?_nc_cat=102&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=_Ch_acjT1BcQ7kNvwFADCvm&_nc_oc=AdqqylHdxZ9J4WaGETpiBq1DXGTxM7xNmhKft8oBFP39swimIWZ7AZdZ1AKvHLbY4fQmrgJ5x2ERsTFv98HzMFN8&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=EcLE5fhnvnLjNTYpUQKeXw&_nc_ss=7a30f&oh=00_Af3jxqjOZaUZaSNIGpa3Aet1Uddvdujkk7oegd-_A0bOZA&oe=69EC5232',
-  // light-product-2
-  'https://scontent.xx.fbcdn.net/v/t39.6806-6/673826432_1199625442080268_2235614826141527510_n.png?_nc_cat=101&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=_wjLv5Lhh_8Q7kNvwGWRhyt&_nc_oc=AdpFiVWrB2w5PwJdvE3h9DoYN3IzJZB9W1TTvnhK4i5q0t83dp8bbLsfNTHtktLDqMrgdp6mMWKLZ7oJO_YNqje2&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=QNknQFLa-qbjgo-aYr3B3w&_nc_ss=7a30f&oh=00_Af2pOYyfoeSW61DtYM8HQox8tAFI5lUk5aX-TiLvgr1cjQ&oe=69EC3F31',
-  // light-product-3
-  'https://scontent.xx.fbcdn.net/v/t39.6806-6/672681263_1894137684571541_8624778644609428792_n.png?_nc_cat=109&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=w9acCjHivWUQ7kNvwHr7aPX&_nc_oc=Adr2brJxtVS4X0T6nifDX4ilMvUWwNKMXZh6ZuLoyqWqe7tjHD5o7cQuzNQYrIEIb6_QIW5YLaq2CTx55-fGzg0B&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=3toqnQ2Xkolb6jv7QsUzdw&_nc_ss=7a30f&oh=00_Af2x_-4uoy7Vr0QQ1F6Fs9JENKFc2--Hv3wUfmKymSXuxA&oe=69EC5583',
-  // light-product-4
-  'https://scontent.xx.fbcdn.net/v/t39.6806-6/670399674_3883527348446559_364118105607949641_n.png?_nc_cat=103&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=o3njmHZr7gYQ7kNvwGbioqf&_nc_oc=Ado4I-fGsoF4PuhuxLx6SAboigPu9Xsdnosy866WWRM5aulLrmQRc5xh7EQJrx4YDx_pK1qvGCQd_m9WDcEbzZ-D&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=C0OA-Y0wfGERdXCxRnfkMA&_nc_ss=7a30f&oh=00_Af2mjuba1-uIEO0x8d6kQtGHcS0rxRK0FsSFULQ43xApew&oe=69EC4A6D',
-  // light-product-5
-  'https://scontent.xx.fbcdn.net/v/t39.6806-6/671457944_4516505268571219_6833232903201599778_n.png?_nc_cat=101&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=70oaCchmPvkQ7kNvwEhnyV5&_nc_oc=AdpnM83UaG_26EX-nNlHboZr9lIWze8y13UKAwTsJsDkR4zFGSk__UK8FN_f_W06xnx2eHRbElX9xyop69nEylZA&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=iolShmKEPYHkXdhBqc0ynQ&_nc_ss=7a30f&oh=00_Af22qlucAlsFv61LJs7RFu-eXP8RgSILrqeE-uLtJsthBQ&oe=69EC4495',
+  // light-product-1 from xds_oss asset set
+  'https://lookaside.facebook.com/assets/xds_oss/light-product-1.png',
+  // light-product-2 from xds_oss asset set
+  'https://lookaside.facebook.com/assets/xds_oss/light-product-2.png',
+  // light-product-3 from xds_oss asset set
+  'https://lookaside.facebook.com/assets/xds_oss/light-product-3.png',
+  // light-product-4 from xds_oss asset set
+  'https://lookaside.facebook.com/assets/xds_oss/light-product-4.png',
+  // light-product-5 from xds_oss asset set
+  'https://lookaside.facebook.com/assets/xds_oss/light-product-5.png',
 ];
 
 const PRODUCTS = [
   {
-    name: 'Solstice Mug & Plate Set',
+    name: 'Solstice Mug',
     details: 'Glaze: Snow\nFinish: Matte',
     price: 89.0,
     qty: 1,
@@ -97,21 +97,21 @@ const PRODUCTS = [
     image: PRODUCT_IMAGES[1],
   },
   {
-    name: 'Terra Serving Platter',
+    name: 'Terra Cup',
     details: 'Glaze: Oat\nSize: 14 in',
     price: 65.0,
     qty: 1,
     image: PRODUCT_IMAGES[2],
   },
   {
-    name: 'Dawn Espresso Cup',
+    name: 'Dawn Plate Set',
     details: 'Glaze: Charcoal\nCapacity: 3 oz',
     price: 34.0,
     qty: 3,
     image: PRODUCT_IMAGES[3],
   },
   {
-    name: 'Kiln Vase',
+    name: 'Kiln Salad Bowl',
     details: 'Glaze: Snow\nHeight: 8 in',
     price: 78.0,
     qty: 1,


### PR DESCRIPTION
Replace 5 expiring `scontent.xx.fbcdn.net` signed CDN URLs with permanent `lookaside.facebook.com/assets/xds_oss/` URLs (light-product-1 through light-product-5) per the Contributing Templates wiki.