### PR TITLE
fix(gallery-hero): use permanent lookaside URLs and rename heading

### DIFF
--- a/packages/cli/templates/pages/gallery-hero/page.tsx
+++ b/packages/cli/templates/pages/gallery-hero/page.tsx
@@ -14,15 +14,18 @@ import {ArrowRightIcon} from '@heroicons/react/20/solid';
 
 const IMAGES = [
   {
-    src: 'https://scontent.xx.fbcdn.net/v/t39.6806-6/670260643_4371306203125531_1093895092404715068_n.png?_nc_cat=108&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=8DNDqYQ-HlAQ7kNvwFixzqd&_nc_oc=AdqWUbYPtoQiiTtUkVvRaqCz1Vb8xpArrNiG9wrvYQeGn1_ZoIwBbbnDsVy5W06HmMJ33Jw5Zi-v-0jxpETqCObL&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=5qc5alnBasgOfCv0qggnCQ&_nc_ss=7a30f&oh=00_Af3UnG6pajsU4ngTWofPYySbruvxaxKAupExLHtjA0GRaw&oe=69E9886B',
+    // colorful-home-horizontal-1 from xds_oss asset set
+    src: 'https://lookaside.facebook.com/assets/xds_oss/colorful-home-horizontal-1.png',
     alt: 'Colorful home interior with vibrant decor',
   },
   {
-    src: 'https://scontent.xx.fbcdn.net/v/t39.6806-6/670422313_1309114328024296_2325112857517486215_n.png?_nc_cat=106&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=UcKaimmopFkQ7kNvwG5cFp3&_nc_oc=AdrU7QvF-jKlYmG-Lfo9IvCucGfOpeRGaLeWPNgkhGtvMbcXnepY-eRF18hQmyWprjg8MJ3PX48peAKEsOs6oYOE&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=hWd-diGpmNdwV7EQs9TH4g&_nc_ss=7a30f&oh=00_Af14lXSPHUE34ePZGZkbZhSOYmIaLxrbclohokIfGF947g&oe=69E99A02',
+    // colorful-lifestyle-horizontal-1 from xds_oss asset set
+    src: 'https://lookaside.facebook.com/assets/xds_oss/colorful-lifestyle-horizontal-1.png',
     alt: 'Colorful lifestyle portrait with natural lighting',
   },
   {
-    src: 'https://scontent.xx.fbcdn.net/v/t39.6806-6/670480937_2502078110200666_6842204180822201520_n.png?_nc_cat=100&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=CkjsPqmDibQQ7kNvwHkqI35&_nc_oc=AdqCBagwocUt6pKl8FbB6mA-pmWSnum8-IQw1wk74AP-3vg7MxyzT9i0Gi8RSPeFDr1hFOJr19eqJAwwb4Evq_Az&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=irTVHgrA3MGqSILwcAjgfA&_nc_ss=7a30f&oh=00_Af3X_3VEp3lYvRpCV3S2jRGKstnQiL2MOac3lwcs2Y2y0g&oe=69E9A474',
+    // colorful-lifestyle-horizontal-2 from xds_oss asset set
+    src: 'https://lookaside.facebook.com/assets/xds_oss/colorful-lifestyle-horizontal-2.png',
     alt: 'Colorful lifestyle scene with warm tones',
   },
 ];
@@ -57,7 +60,7 @@ export default function GalleryHero() {
       topNav={
         <XDSTopNav
           label="Main navigation"
-          heading={<XDSTopNavHeading heading="DAIILY" />}
+          heading={<XDSTopNavHeading heading="GALLERY" />}
           endContent={
             <>
               <XDSTopNavItem label="Products" href="#" />


### PR DESCRIPTION
Replace 3 expiring `scontent.xx.fbcdn.net` signed CDN URLs with permanent `lookaside.facebook.com/assets/xds_oss/` URLs per the [Contributing Templates](https://github.com/facebookexperimental/xds/wiki/Contributing-Templates#how-to-use-images-in-templates) wiki. Also rename nav heading to GALLERY.