### PR TITLE
fix(editor): minor changes

### DIFF
--- a/packages/cli/templates/pages/editor/page.tsx
+++ b/packages/cli/templates/pages/editor/page.tsx
@@ -293,8 +293,7 @@ function defaultProps(type: BlockType): Record<string, unknown> {
 
 const editorStyles = stylex.create({
   shell: {
-    position: 'fixed',
-    inset: 0,
+    height: '100%',
     display: 'flex',
     flexDirection: 'column',
     backgroundColor: colorVars['--color-background-body'],

--- a/packages/cli/templates/pages/editor/page.tsx
+++ b/packages/cli/templates/pages/editor/page.tsx
@@ -40,7 +40,6 @@ import {
   DevicePhoneMobileIcon,
   EyeIcon,
   PlusCircleIcon,
-  ArrowLeftEndOnRectangleIcon,
   ShoppingBagIcon,
   ShoppingCartIcon,
   BanknotesIcon,
@@ -858,7 +857,7 @@ export default function EditorPage() {
                   <XDSButton
                     label={isPanelCollapsed ? 'Expand panel' : 'Collapse panel'}
                     icon={
-                      <XDSIcon icon={ArrowLeftEndOnRectangleIcon} size="sm" />
+                      <XDSIcon icon={isPanelCollapsed ? ChevronDownIcon : ChevronUpIcon} size="sm" />
                     }
                     variant="ghost"
                     size="sm"


### PR DESCRIPTION
Two fixes for the editor template:

1. *Top content cutoff* — The editor used `position: fixed; inset: 0` which made it cover the entire viewport, hiding content behind the sandbox preview toolbar. Replaced with `height: 100%` so it fills its parent container instead.

2. *Panel collapse icon* — Replaced the `ArrowLeftEndOnRectangleIcon` with chevron icons that indicate panel state: ChevronUpIcon when open, ChevronDownIcon when collapsed.