### PR TITLE
fix(Field): contain z-index stacking context in inputStatusWrapper

### DIFF
--- a/packages/core/src/Field/XDSField.tsx
+++ b/packages/core/src/Field/XDSField.tsx
@@ -34,6 +34,7 @@ const styles = stylex.create({
   inputStatusWrapper: {
     display: 'flex',
     flexDirection: 'column',
+    isolation: 'isolate',
   },
 });
 

--- a/packages/core/src/TextInput/XDSTextInput.tsx
+++ b/packages/core/src/TextInput/XDSTextInput.tsx
@@ -47,9 +47,6 @@ import {XDSIcon, renderIconSlot, type XDSIconType} from '../Icon';
 import {XDSSpinner} from '../Spinner';
 
 const styles = stylex.create({
-  wrapper: {
-    zIndex: 1,
-  },
   clearButton: {
     display: 'flex',
     alignItems: 'center',
@@ -363,7 +360,6 @@ export function XDSTextInput({
           xdsClassName('text-input', {size, status: status?.type ?? null}),
           stylex.props(
             inputWrapperStyles.base,
-            styles.wrapper,
             sizeStyles[size],
             isDisabled && inputWrapperStyles.disabled,
             status && inputStatusBorderStyles[status.type],


### PR DESCRIPTION
## Problem

Input wrappers use z-index: 1 (in inputWrapperStyles.base) so they render above the attached FieldStatus message, which uses negative margin-top to tuck underneath. This z-index leaks into the parent stacking context — when inputs scroll underneath a sticky header or top nav, they paint on top of it.

## Fix

Add isolation: isolate on the inputStatusWrapper div in XDSField. This creates a local stacking context that contains the z-index: 1 so it does not escape into the page layout. The internal layering (input above status) still works, but the whole group now participates normally in the parent stacking order.

Also removes a redundant zIndex: 1 from TextInput's local styles.wrapper — it was already set in inputWrapperStyles.base.

## Changes

- packages/core/src/Field/XDSField.tsx — add isolation: isolate to inputStatusWrapper
- packages/core/src/TextInput/XDSTextInput.tsx — remove redundant styles.wrapper z-index