### PR TITLE
fix(Dialog): use target-based backdrop detection for native popup compat

### DIFF
--- a/packages/core/src/Dialog/XDSDialog.tsx
+++ b/packages/core/src/Dialog/XDSDialog.tsx
@@ -436,20 +436,13 @@ export function XDSDialog({
     return () => dialog.removeEventListener('keydown', handleKeyDown);
   }, [isOpen, isInline, allowEscape, onOpenChange]);
 
-  // Handle backdrop click
+  // Handle backdrop click — when the user clicks the ::backdrop pseudo-element,
+  // the event target is the <dialog> element itself; clicks on child content
+  // always target the child. This avoids false positives from native browser
+  // popups (date pickers, selects, color pickers) that render outside the
+  // dialog's bounding rect.
   const handleClick = (event: React.MouseEvent<HTMLDialogElement>) => {
-    const dialog = dialogRef.current;
-    if (!dialog) return;
-
-    // Check if click was on the backdrop (dialog element itself, not content)
-    const rect = dialog.getBoundingClientRect();
-    const isBackdropClick =
-      event.clientX < rect.left ||
-      event.clientX > rect.right ||
-      event.clientY < rect.top ||
-      event.clientY > rect.bottom;
-
-    if (isBackdropClick && allowBackdropClick) {
+    if (event.target === event.currentTarget && allowBackdropClick) {
       onOpenChange(false);
     }
   };


### PR DESCRIPTION
Fixes #1734

Native browser popups (date picker, select, color picker) render outside the dialog's bounding rect in a separate browser compositing layer. The coordinate-based backdrop click detection incorrectly treats these as backdrop clicks and dismisses the dialog.

Replaces `getBoundingClientRect()` coordinate comparison with `event.target === event.currentTarget` — the standard `<dialog>` backdrop detection pattern. When clicking the `::backdrop` pseudo-element, the event target is the `<dialog>` element itself; child clicks always target the child element.

This is the same pattern used by MDN's dialog examples and works correctly with native popups since popup clicks never target the `<dialog>` element directly.