### PR TITLE
fix(ClickableCard): merge caller xstyle with internal interactive styles

### DIFF
--- a/packages/core/src/ClickableCard/XDSClickableCard.tsx
+++ b/packages/core/src/ClickableCard/XDSClickableCard.tsx
@@ -210,6 +210,7 @@ export interface XDSClickableCardProps extends XDSBaseProps {
 export function XDSClickableCard({
   label,
   onClick: onClickProp,
+  onMouseUp: _onMouseUp,
   href,
   target,
   isDisabled = false,
@@ -221,6 +222,7 @@ export function XDSClickableCard({
   maxWidth,
   ref,
   xstyle: callerXstyle,
+  className: _className,
   ...props
 }: XDSClickableCardProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);

--- a/packages/core/src/ClickableCard/XDSClickableCard.tsx
+++ b/packages/core/src/ClickableCard/XDSClickableCard.tsx
@@ -210,7 +210,7 @@ export interface XDSClickableCardProps extends XDSBaseProps {
 export function XDSClickableCard({
   label,
   onClick: onClickProp,
-  onMouseUp: callerOnMouseUp,
+  onMouseUp: onMouseUpProp,
   href,
   target,
   isDisabled = false,
@@ -221,8 +221,8 @@ export function XDSClickableCard({
   height,
   maxWidth,
   ref,
-  xstyle: callerXstyle,
-  className: callerClassName,
+  xstyle: xstyleProp,
+  className: classNameProp,
   style,
   ...props
 }: XDSClickableCardProps) {
@@ -238,10 +238,10 @@ export function XDSClickableCard({
     disabled: isDisabled,
   });
 
-  const handleMouseUp = callerOnMouseUp
+  const handleMouseUp = onMouseUpProp
     ? (e: MouseEvent<HTMLElement>) => {
         onMouseUp(e);
-        callerOnMouseUp(e);
+        onMouseUpProp(e);
       }
     : onMouseUp;
 
@@ -261,8 +261,8 @@ export function XDSClickableCard({
       padding={padding}
       variant={variant}
       className={
-        callerClassName
-          ? `${xdsClassName('clickable-card', {variant})} ${callerClassName}`
+        classNameProp
+          ? `${xdsClassName('clickable-card', {variant})} ${classNameProp}`
           : xdsClassName('clickable-card', {variant})
       }
       xstyle={
@@ -272,7 +272,7 @@ export function XDSClickableCard({
           !isDisabled && styles.overlay,
           !isDisabled && styles.hoverOnPointer,
           isDisabled && styles.disabled,
-          callerXstyle,
+          xstyleProp,
         ] as unknown as StyleXStyles
       }
       style={style}

--- a/packages/core/src/ClickableCard/XDSClickableCard.tsx
+++ b/packages/core/src/ClickableCard/XDSClickableCard.tsx
@@ -210,7 +210,7 @@ export interface XDSClickableCardProps extends XDSBaseProps {
 export function XDSClickableCard({
   label,
   onClick: onClickProp,
-  onMouseUp: _onMouseUp,
+  onMouseUp: callerOnMouseUp,
   href,
   target,
   isDisabled = false,
@@ -222,7 +222,8 @@ export function XDSClickableCard({
   maxWidth,
   ref,
   xstyle: callerXstyle,
-  className: _className,
+  className: callerClassName,
+  style,
   ...props
 }: XDSClickableCardProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -236,6 +237,13 @@ export function XDSClickableCard({
     target,
     disabled: isDisabled,
   });
+
+  const handleMouseUp = callerOnMouseUp
+    ? (e: MouseEvent<HTMLElement>) => {
+        onMouseUp(e);
+        callerOnMouseUp(e);
+      }
+    : onMouseUp;
 
   const isLink = href != null;
 
@@ -252,7 +260,11 @@ export function XDSClickableCard({
       maxWidth={maxWidth}
       padding={padding}
       variant={variant}
-      className={xdsClassName('clickable-card', {variant})}
+      className={
+        callerClassName
+          ? `${xdsClassName('clickable-card', {variant})} ${callerClassName}`
+          : xdsClassName('clickable-card', {variant})
+      }
       xstyle={
         [
           styles.interactive,
@@ -263,8 +275,9 @@ export function XDSClickableCard({
           callerXstyle,
         ] as unknown as StyleXStyles
       }
+      style={style}
       onClick={!isDisabled ? onClick : undefined}
-      onMouseUp={!isDisabled ? onMouseUp : undefined}
+      onMouseUp={!isDisabled ? handleMouseUp : undefined}
       {...props}>
       {isLink ? (
         <a

--- a/packages/core/src/ClickableCard/XDSClickableCard.tsx
+++ b/packages/core/src/ClickableCard/XDSClickableCard.tsx
@@ -169,7 +169,6 @@ export interface XDSClickableCardProps extends XDSBaseProps {
 
   /** Maximum width of the card. */
   maxWidth?: SizeValue;
-
 }
 
 // =============================================================================
@@ -221,6 +220,7 @@ export function XDSClickableCard({
   height,
   maxWidth,
   ref,
+  xstyle: callerXstyle,
   ...props
 }: XDSClickableCardProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -251,13 +251,16 @@ export function XDSClickableCard({
       padding={padding}
       variant={variant}
       className={xdsClassName('clickable-card', {variant})}
-      xstyle={[
-        styles.interactive,
-        styles.focusWithin,
-        !isDisabled && styles.overlay,
-        !isDisabled && styles.hoverOnPointer,
-        isDisabled && styles.disabled,
-      ] as unknown as StyleXStyles}
+      xstyle={
+        [
+          styles.interactive,
+          styles.focusWithin,
+          !isDisabled && styles.overlay,
+          !isDisabled && styles.hoverOnPointer,
+          isDisabled && styles.disabled,
+          callerXstyle,
+        ] as unknown as StyleXStyles
+      }
       onClick={!isDisabled ? onClick : undefined}
       onMouseUp={!isDisabled ? onMouseUp : undefined}
       {...props}>

--- a/packages/core/src/SelectableCard/XDSSelectableCard.tsx
+++ b/packages/core/src/SelectableCard/XDSSelectableCard.tsx
@@ -264,8 +264,8 @@ export function XDSSelectableCard({
   label,
   isSelected,
   onChange,
-  onClick: callerOnClick,
-  onMouseUp: callerOnMouseUp,
+  onClick: onClickProp,
+  onMouseUp: onMouseUpProp,
   isDisabled = false,
   children,
   padding,
@@ -274,8 +274,8 @@ export function XDSSelectableCard({
   height,
   maxWidth,
   ref,
-  xstyle: callerXstyle,
-  className: callerClassName,
+  xstyle: xstyleProp,
+  className: classNameProp,
   style,
   ...props
 }: XDSSelectableCardProps) {
@@ -298,17 +298,17 @@ export function XDSSelectableCard({
     disabled: isDisabled,
   });
 
-  const composedOnClick = callerOnClick
+  const composedOnClick = onClickProp
     ? (e: MouseEvent<HTMLElement>) => {
         onClick(e);
-        callerOnClick(e);
+        onClickProp(e);
       }
     : onClick;
 
-  const composedOnMouseUp = callerOnMouseUp
+  const composedOnMouseUp = onMouseUpProp
     ? (e: MouseEvent<HTMLElement>) => {
         onMouseUp(e);
-        callerOnMouseUp(e);
+        onMouseUpProp(e);
       }
     : onMouseUp;
 
@@ -326,11 +326,11 @@ export function XDSSelectableCard({
       padding={padding}
       variant={variant}
       className={
-        callerClassName
+        classNameProp
           ? `${xdsClassName('selectable-card', {
               variant,
               selected: isSelected ? 'true' : 'false',
-            })} ${callerClassName}`
+            })} ${classNameProp}`
           : xdsClassName('selectable-card', {
               variant,
               selected: isSelected ? 'true' : 'false',
@@ -344,7 +344,7 @@ export function XDSSelectableCard({
           !isDisabled && styles.overlay,
           !isDisabled && styles.hoverOnPointer,
           isDisabled && styles.disabled,
-          callerXstyle,
+          xstyleProp,
         ] as unknown as StyleXStyles
       }
       style={style}

--- a/packages/core/src/SelectableCard/XDSSelectableCard.tsx
+++ b/packages/core/src/SelectableCard/XDSSelectableCard.tsx
@@ -264,6 +264,8 @@ export function XDSSelectableCard({
   label,
   isSelected,
   onChange,
+  onClick: callerOnClick,
+  onMouseUp: callerOnMouseUp,
   isDisabled = false,
   children,
   padding,
@@ -272,6 +274,9 @@ export function XDSSelectableCard({
   height,
   maxWidth,
   ref,
+  xstyle: callerXstyle,
+  className: callerClassName,
+  style,
   ...props
 }: XDSSelectableCardProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -293,6 +298,20 @@ export function XDSSelectableCard({
     disabled: isDisabled,
   });
 
+  const composedOnClick = callerOnClick
+    ? (e: MouseEvent<HTMLElement>) => {
+        onClick(e);
+        callerOnClick(e);
+      }
+    : onClick;
+
+  const composedOnMouseUp = callerOnMouseUp
+    ? (e: MouseEvent<HTMLElement>) => {
+        onMouseUp(e);
+        callerOnMouseUp(e);
+      }
+    : onMouseUp;
+
   return (
     <XDSCard
       ref={(node: HTMLDivElement | null) => {
@@ -306,10 +325,17 @@ export function XDSSelectableCard({
       maxWidth={maxWidth}
       padding={padding}
       variant={variant}
-      className={xdsClassName('selectable-card', {
-        variant,
-        selected: isSelected ? 'true' : 'false',
-      })}
+      className={
+        callerClassName
+          ? `${xdsClassName('selectable-card', {
+              variant,
+              selected: isSelected ? 'true' : 'false',
+            })} ${callerClassName}`
+          : xdsClassName('selectable-card', {
+              variant,
+              selected: isSelected ? 'true' : 'false',
+            })
+      }
       xstyle={
         [
           styles.interactive,
@@ -318,10 +344,12 @@ export function XDSSelectableCard({
           !isDisabled && styles.overlay,
           !isDisabled && styles.hoverOnPointer,
           isDisabled && styles.disabled,
+          callerXstyle,
         ] as unknown as StyleXStyles
       }
-      onClick={!isDisabled ? onClick : undefined}
-      onMouseUp={!isDisabled ? onMouseUp : undefined}
+      style={style}
+      onClick={!isDisabled ? composedOnClick : undefined}
+      onMouseUp={!isDisabled ? composedOnMouseUp : undefined}
       {...props}>
       <input
         ref={interactiveRef}


### PR DESCRIPTION
Fixes #1872

`XDSClickableCard` spreads `{...props}` after setting its own `xstyle`, so any caller-provided `xstyle` completely overwrites the internal interactive styles (cursor, hover overlay, focus ring).

Destructures `xstyle` from props and merges it into the style array, preserving the full interactive style chain while allowing callers to layer on additional styles.