### PR TITLE
docs(ChatReasoning): add usage docs and block examples

### DIFF
--- a/packages/cli/templates/blocks/components/ChatReasoning/ChatReasoningCollapsed.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatReasoning/ChatReasoningCollapsed.doc.mjs
@@ -1,0 +1,9 @@
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  name: 'ChatReasoning — Collapsed',
+  description: 'Default collapsed state showing the label, duration, and an ellipsized preview of the reasoning content. Click to expand.',
+  isReady: true,
+  aspectRatio: 16 / 9,
+  componentsUsed: ['ChatReasoning', 'Layout', 'Text'],
+};

--- a/packages/cli/templates/blocks/components/ChatReasoning/ChatReasoningCollapsed.tsx
+++ b/packages/cli/templates/blocks/components/ChatReasoning/ChatReasoningCollapsed.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import {XDSChatReasoning} from '@xds/lab';
+import {XDSStack} from '@xds/core/Layout';
+import {XDSText} from '@xds/core/Text';
+
+export default function ChatReasoningCollapsed() {
+  return (
+    <XDSStack direction="vertical" gap={4}>
+      <XDSStack direction="vertical" gap={1}>
+        <XDSText type="supporting" color="secondary">
+          Default label with duration
+        </XDSText>
+        <XDSChatReasoning duration="12s">
+          Let me work through the constraints systematically. The farmer has 3
+          fields and rotates wheat, corn, soy. No same crop in adjacent fields
+          and no same crop in the same field two years in a row.
+        </XDSChatReasoning>
+      </XDSStack>
+      <XDSStack direction="vertical" gap={1}>
+        <XDSText type="supporting" color="secondary">
+          Custom label with duration
+        </XDSText>
+        <XDSChatReasoning label="Analyzing" duration="3s">
+          Checking the codebase for similar patterns and reviewing the test
+          coverage to identify any gaps in the current implementation.
+        </XDSChatReasoning>
+      </XDSStack>
+    </XDSStack>
+  );
+}

--- a/packages/cli/templates/blocks/components/ChatReasoning/ChatReasoningCollapsed.tsx
+++ b/packages/cli/templates/blocks/components/ChatReasoning/ChatReasoningCollapsed.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import {XDSChatReasoning} from '@xds/lab';
+import {XDSChatReasoning} from '../../../../../lab/src/ChatReasoning/XDSChatReasoning';
 import {XDSStack} from '@xds/core/Layout';
 import {XDSText} from '@xds/core/Text';
 

--- a/packages/cli/templates/blocks/components/ChatReasoning/ChatReasoningCollapsed.tsx
+++ b/packages/cli/templates/blocks/components/ChatReasoning/ChatReasoningCollapsed.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import {XDSChatReasoning} from '../../../../../lab/src/ChatReasoning/XDSChatReasoning';
+import {XDSChatReasoning} from '@xds/lab/ChatReasoning';
 import {XDSStack} from '@xds/core/Layout';
 import {XDSText} from '@xds/core/Text';
 

--- a/packages/cli/templates/blocks/components/ChatReasoning/ChatReasoningExpanded.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatReasoning/ChatReasoningExpanded.doc.mjs
@@ -1,0 +1,9 @@
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  name: 'ChatReasoning — Expanded',
+  description: 'Expanded state revealing the full reasoning content. Use defaultIsExpanded or controlled isExpanded to show reasoning open by default.',
+  isReady: true,
+  aspectRatio: 4 / 3,
+  componentsUsed: ['ChatReasoning', 'Markdown', 'Layout', 'Text'],
+};

--- a/packages/cli/templates/blocks/components/ChatReasoning/ChatReasoningExpanded.tsx
+++ b/packages/cli/templates/blocks/components/ChatReasoning/ChatReasoningExpanded.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import {XDSChatReasoning} from '../../../../../lab/src/ChatReasoning/XDSChatReasoning';
+import {XDSChatReasoning} from '@xds/lab/ChatReasoning';
 import {XDSMarkdown} from '@xds/core/Markdown';
 import {XDSStack} from '@xds/core/Layout';
 import {XDSText} from '@xds/core/Text';

--- a/packages/cli/templates/blocks/components/ChatReasoning/ChatReasoningExpanded.tsx
+++ b/packages/cli/templates/blocks/components/ChatReasoning/ChatReasoningExpanded.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import {XDSChatReasoning} from '@xds/lab';
+import {XDSMarkdown} from '@xds/core/Markdown';
+import {XDSStack} from '@xds/core/Layout';
+import {XDSText} from '@xds/core/Text';
+
+export default function ChatReasoningExpanded() {
+  return (
+    <XDSStack direction="vertical" gap={4}>
+      <XDSStack direction="vertical" gap={1}>
+        <XDSText type="supporting" color="secondary">
+          Plain text content
+        </XDSText>
+        <XDSChatReasoning duration="8s" defaultIsExpanded>
+          First, I need to understand the constraints. Three fields, three crops
+          (wheat, corn, soy). No adjacent fields can have the same crop. No
+          field can repeat its crop from the previous year. For Year 1 there are
+          12 valid arrangements.
+        </XDSChatReasoning>
+      </XDSStack>
+      <XDSStack direction="vertical" gap={1}>
+        <XDSText type="supporting" color="secondary">
+          Rich content with Markdown
+        </XDSText>
+        <XDSChatReasoning duration="15s" defaultIsExpanded>
+          <XDSMarkdown density="compact">{`First, I need to understand the constraints:
+1. Three fields, three crops (wheat, corn, soy)
+2. No adjacent fields can have the same crop
+3. No field can repeat its crop from the previous year
+
+For **Year 1**: 3 × 2 × 2 = 12 arrangements.`}</XDSMarkdown>
+        </XDSChatReasoning>
+      </XDSStack>
+    </XDSStack>
+  );
+}

--- a/packages/cli/templates/blocks/components/ChatReasoning/ChatReasoningExpanded.tsx
+++ b/packages/cli/templates/blocks/components/ChatReasoning/ChatReasoningExpanded.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import {XDSChatReasoning} from '@xds/lab';
+import {XDSChatReasoning} from '../../../../../lab/src/ChatReasoning/XDSChatReasoning';
 import {XDSMarkdown} from '@xds/core/Markdown';
 import {XDSStack} from '@xds/core/Layout';
 import {XDSText} from '@xds/core/Text';

--- a/packages/cli/templates/blocks/components/ChatReasoning/ChatReasoningInMessage.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatReasoning/ChatReasoningInMessage.doc.mjs
@@ -1,0 +1,9 @@
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  name: 'ChatReasoning — In Message',
+  description: 'Reasoning embedded inside a chat message, appearing above the assistant response. The typical composition for AI chat interfaces.',
+  isReady: true,
+  aspectRatio: 4 / 3,
+  componentsUsed: ['ChatReasoning', 'Chat', 'Avatar', 'Markdown', 'Layout'],
+};

--- a/packages/cli/templates/blocks/components/ChatReasoning/ChatReasoningInMessage.tsx
+++ b/packages/cli/templates/blocks/components/ChatReasoning/ChatReasoningInMessage.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import {XDSChatReasoning} from '../../../../../lab/src/ChatReasoning/XDSChatReasoning';
+import {XDSChatReasoning} from '@xds/lab/ChatReasoning';
 import {
   XDSChatMessageList,
   XDSChatMessage,

--- a/packages/cli/templates/blocks/components/ChatReasoning/ChatReasoningInMessage.tsx
+++ b/packages/cli/templates/blocks/components/ChatReasoning/ChatReasoningInMessage.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import {XDSChatReasoning} from '@xds/lab';
+import {
+  XDSChatMessageList,
+  XDSChatMessage,
+  XDSChatMessageBubble,
+} from '@xds/core/Chat';
+import {XDSAvatar} from '@xds/core/Avatar';
+import {XDSMarkdown} from '@xds/core/Markdown';
+
+export default function ChatReasoningInMessage() {
+  return (
+    <XDSChatMessageList>
+      <XDSChatMessage sender="user">
+        <XDSChatMessageBubble>
+          How many valid planting arrangements are possible over 3 years?
+        </XDSChatMessageBubble>
+      </XDSChatMessage>
+      <XDSChatMessage
+        sender="assistant"
+        avatar={<XDSAvatar name="AI" size="small" />}>
+        <XDSChatReasoning duration="12s">
+          Let me work through the constraints systematically. The farmer has 3
+          fields and rotates wheat, corn, soy.
+        </XDSChatReasoning>
+        <XDSMarkdown density="compact">
+          {`There are **42** valid planting arrangements over 3 years.`}
+        </XDSMarkdown>
+      </XDSChatMessage>
+    </XDSChatMessageList>
+  );
+}

--- a/packages/cli/templates/blocks/components/ChatReasoning/ChatReasoningInMessage.tsx
+++ b/packages/cli/templates/blocks/components/ChatReasoning/ChatReasoningInMessage.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import {XDSChatReasoning} from '@xds/lab';
+import {XDSChatReasoning} from '../../../../../lab/src/ChatReasoning/XDSChatReasoning';
 import {
   XDSChatMessageList,
   XDSChatMessage,

--- a/packages/cli/templates/blocks/components/ChatReasoning/ChatReasoningStreaming.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatReasoning/ChatReasoningStreaming.doc.mjs
@@ -1,0 +1,9 @@
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  name: 'ChatReasoning — Streaming',
+  description: 'Streaming state with a shimmer animation on the label while the model is actively thinking. Duration and preview are hidden until streaming ends.',
+  isReady: true,
+  aspectRatio: 16 / 9,
+  componentsUsed: ['ChatReasoning', 'Layout', 'Text'],
+};

--- a/packages/cli/templates/blocks/components/ChatReasoning/ChatReasoningStreaming.tsx
+++ b/packages/cli/templates/blocks/components/ChatReasoning/ChatReasoningStreaming.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import {XDSChatReasoning} from '@xds/lab';
+import {XDSChatReasoning} from '../../../../../lab/src/ChatReasoning/XDSChatReasoning';
 import {XDSStack} from '@xds/core/Layout';
 import {XDSText} from '@xds/core/Text';
 

--- a/packages/cli/templates/blocks/components/ChatReasoning/ChatReasoningStreaming.tsx
+++ b/packages/cli/templates/blocks/components/ChatReasoning/ChatReasoningStreaming.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import {XDSChatReasoning} from '../../../../../lab/src/ChatReasoning/XDSChatReasoning';
+import {XDSChatReasoning} from '@xds/lab/ChatReasoning';
 import {XDSStack} from '@xds/core/Layout';
 import {XDSText} from '@xds/core/Text';
 

--- a/packages/cli/templates/blocks/components/ChatReasoning/ChatReasoningStreaming.tsx
+++ b/packages/cli/templates/blocks/components/ChatReasoning/ChatReasoningStreaming.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import {XDSChatReasoning} from '@xds/lab';
+import {XDSStack} from '@xds/core/Layout';
+import {XDSText} from '@xds/core/Text';
+
+export default function ChatReasoningStreaming() {
+  return (
+    <XDSStack direction="vertical" gap={4}>
+      <XDSStack direction="vertical" gap={1}>
+        <XDSText type="supporting" color="secondary">
+          Default streaming label
+        </XDSText>
+        <XDSChatReasoning isStreaming>
+          Working through the combinatorial constraints and evaluating possible
+          solutions for the optimization problem.
+        </XDSChatReasoning>
+      </XDSStack>
+      <XDSStack direction="vertical" gap={1}>
+        <XDSText type="supporting" color="secondary">
+          Custom streaming label
+        </XDSText>
+        <XDSChatReasoning isStreaming label="Analyzing">
+          Reviewing the repository structure and identifying relevant files for
+          the requested changes.
+        </XDSChatReasoning>
+      </XDSStack>
+    </XDSStack>
+  );
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -540,6 +540,12 @@
       "import": "./dist/Typeahead/index.mjs",
       "require": "./dist/Typeahead/index.js"
     },
+    "./XDSBaseProps": {
+      "source": "./src/XDSBaseProps.ts",
+      "types": "./dist/XDSBaseProps.d.ts",
+      "import": "./src/XDSBaseProps.ts",
+      "require": "./src/XDSBaseProps.ts"
+    },
     "./hooks": {
       "source": "./src/hooks/index.ts",
       "types": "./dist/hooks/index.d.ts",

--- a/packages/lab/package.json
+++ b/packages/lab/package.json
@@ -22,6 +22,18 @@
   ],
   "main": "./src/index.ts",
   "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "source": "./src/index.ts",
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    },
+    "./ChatReasoning": {
+      "source": "./src/ChatReasoning/XDSChatReasoning.tsx",
+      "types": "./src/ChatReasoning/XDSChatReasoning.tsx",
+      "default": "./src/ChatReasoning/XDSChatReasoning.tsx"
+    }
+  },
   "sideEffects": false,
   "peerDependencies": {
     "@stylexjs/stylex": ">=0.10.0",

--- a/packages/lab/src/ChatReasoning/XDSChatReasoning.doc.mjs
+++ b/packages/lab/src/ChatReasoning/XDSChatReasoning.doc.mjs
@@ -1,0 +1,69 @@
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
+
+export const docs = {
+  name: 'ChatReasoning',
+  group: 'Chat',
+
+  keywords: ['chat', 'reasoning', 'thinking', 'collapsible', 'ai', 'chain-of-thought', 'shimmer', 'streaming', 'expand'],
+
+  usage: {
+    description:
+      'ChatReasoning displays model thinking or chain-of-thought content as a compact, collapsible element. It renders a single line with a label, optional duration, and an ellipsized preview that expands on click to reveal the full reasoning.',
+    bestPractices: [
+      {guidance: true, description: 'Place reasoning directly above the assistant response inside a ChatMessage so the user can see the thought process that led to the answer.'},
+      {guidance: true, description: 'Use the isStreaming prop while the model is still generating reasoning tokens. This shows a shimmer animation and hides the duration until thinking is complete.'},
+      {guidance: true, description: 'Pass a duration string (e.g. "12s") when the reasoning is finished so the user knows how long the model spent thinking.'},
+      {guidance: false, description: "Don't leave reasoning expanded by default in long conversations — collapsed is the right default so the focus stays on the response."},
+      {guidance: false, description: "Don't use ChatReasoning for general collapsible content. It is designed specifically for AI thinking displays, not arbitrary expandable sections."},
+    ],
+    anatomy: [
+      {name: 'Icon', required: false, description: 'A thinking indicator icon rendered at the start of the header row.'},
+      {name: 'Label', required: false, description: 'The header text, defaults to "Thinking". Shows a shimmer effect during streaming.'},
+      {name: 'Duration', required: false, description: 'Time string shown after the label when reasoning is complete.'},
+      {name: 'Preview', required: false, description: 'Ellipsized snippet of the reasoning content, visible only when collapsed.'},
+      {name: 'Content', required: true, description: 'The full reasoning text or rich content revealed when expanded.'},
+    ],
+  },
+
+  props: [
+    {
+      name: 'children',
+      type: 'ReactNode',
+      description: 'Reasoning content. Plain text renders as-is; pass XDSMarkdown for rich formatting.',
+      required: true,
+    },
+    {
+      name: 'label',
+      type: 'string',
+      description: 'Header label text.',
+      default: "'Thinking'",
+    },
+    {
+      name: 'duration',
+      type: 'string',
+      description: 'Duration string shown after the label when reasoning is complete (e.g. "12s").',
+    },
+    {
+      name: 'isStreaming',
+      type: 'boolean',
+      description: 'Shows a shimmer animation on the label and hides the duration and preview while the model is actively thinking.',
+      default: 'false',
+    },
+    {
+      name: 'isExpanded',
+      type: 'boolean',
+      description: 'Controlled expanded state. Use with onExpandedChange for full control.',
+    },
+    {
+      name: 'defaultIsExpanded',
+      type: 'boolean',
+      description: 'Initial expanded state for uncontrolled usage.',
+      default: 'false',
+    },
+    {
+      name: 'onExpandedChange',
+      type: '(isExpanded: boolean) => void',
+      description: 'Called when the expanded state changes via user interaction.',
+    },
+  ],
+};


### PR DESCRIPTION
## Summary

- **Add ChatReasoning usage docs** in `XDSChatReasoning.doc.mjs`: component description, 5 best practices (3 do, 2 don't), anatomy breakdown, and full prop documentation
- **Add 4 new block templates** in `packages/cli/templates/blocks/components/ChatReasoning/`:
  - **ChatReasoning — Collapsed**: default and custom label with duration and ellipsized preview
  - **ChatReasoning — Expanded**: plain text and rich Markdown content in the expanded state
  - **ChatReasoning — Streaming**: shimmer animation during active model thinking, with default and custom labels
  - **ChatReasoning — In Message**: reasoning composed inside an assistant chat message above the response

All blocks use XDS layout primitives (`XDSStack`, `XDSText`) — no raw HTML or inline styles.

## Template grades

All blocks graded against the [wiki rubric](https://github.com/facebookexperimental/xds/wiki/Contributing-Templates#template-grading-rubric):

| Block | Score | Grade |
|-------|-------|-------|
| ChatReasoning — Collapsed | 100 | A |
| ChatReasoning — Expanded | 100 | A |
| ChatReasoning — Streaming | 100 | A |
| ChatReasoning — In Message | 100 | A |

## Test plan

- [ ] Block previews render without clipping in the sandbox
- [ ] ChatReasoning docs page shows updated usage with 5 best practices and anatomy table
- [ ] No raw HTML or inline styles in any block
- [ ] Collapsed block expands on click
- [ ] Streaming block shows shimmer animation on the label