### PR TITLE
feat(templates): add thumbnail carousel to ChatComposerDrawer attachments

### DIFF
--- a/packages/cli/templates/blocks/components/ChatComposerDrawer/ChatComposerDrawerAttachments.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatComposerDrawer/ChatComposerDrawerAttachments.doc.mjs
@@ -2,8 +2,8 @@
 export const doc = {
   type: 'block',
   name: 'ChatComposerDrawer — Attachments',
-  description: 'Drawer with removable file tokens. Omit count to keep the drawer always expanded — use when the number of attachments is small and predictable.',
+  description: 'Drawer with two rows: a scrollable carousel of image thumbnails and a row of removable file tokens. Omit count to keep the drawer always expanded.',
   isReady: true,
   aspectRatio: 16 / 9,
-  componentsUsed: ['Chat', 'Token', 'Layout'],
+  componentsUsed: ['Chat', 'Token', 'Thumbnail', 'Carousel', 'Layout'],
 };

--- a/packages/cli/templates/blocks/components/ChatComposerDrawer/ChatComposerDrawerAttachments.tsx
+++ b/packages/cli/templates/blocks/components/ChatComposerDrawer/ChatComposerDrawerAttachments.tsx
@@ -2,7 +2,42 @@
 
 import {XDSChatComposer, XDSChatComposerDrawer} from '@xds/core/Chat';
 import {XDSToken} from '@xds/core/Token';
+import {XDSThumbnail} from '@xds/core/Thumbnail';
+import {XDSCarousel} from '@xds/core/Carousel';
 import {XDSStack} from '@xds/core/Layout';
+
+const IMAGE_ATTACHMENTS = [
+  {
+    id: '1',
+    src: 'https://picsum.photos/id/1015/200/200',
+    alt: 'River through a valley',
+    label: 'valley.jpg',
+  },
+  {
+    id: '2',
+    src: 'https://picsum.photos/id/1018/200/200',
+    alt: 'Foggy mountain peak',
+    label: 'mountain.jpg',
+  },
+  {
+    id: '3',
+    src: 'https://picsum.photos/id/1025/200/200',
+    alt: 'Golden retriever puppy',
+    label: 'puppy.jpg',
+  },
+  {
+    id: '4',
+    src: 'https://picsum.photos/id/1035/200/200',
+    alt: 'Bridge at sunset',
+    label: 'bridge.jpg',
+  },
+  {
+    id: '5',
+    src: 'https://picsum.photos/id/1040/200/200',
+    alt: 'Lakeside at dusk',
+    label: 'lakeside.jpg',
+  },
+];
 
 export default function ChatComposerDrawerAttachments() {
   return (
@@ -11,8 +46,23 @@ export default function ChatComposerDrawerAttachments() {
         onSubmit={() => {}}
         drawer={
           <XDSChatComposerDrawer>
-            <XDSToken label="quarterly-report.pdf" onRemove={() => {}} />
-            <XDSToken label="budget-forecast.xlsx" onRemove={() => {}} />
+            <XDSStack direction="vertical" gap={2} width="100%">
+              <XDSCarousel gap={1}>
+                {IMAGE_ATTACHMENTS.map(img => (
+                  <XDSThumbnail
+                    key={img.id}
+                    src={img.src}
+                    alt={img.alt}
+                    label={img.label}
+                    onRemove={() => {}}
+                  />
+                ))}
+              </XDSCarousel>
+              <XDSStack direction="horizontal" gap={1} wrap="wrap">
+                <XDSToken label="quarterly-report.pdf" onRemove={() => {}} />
+                <XDSToken label="budget-forecast.xlsx" onRemove={() => {}} />
+              </XDSStack>
+            </XDSStack>
           </XDSChatComposerDrawer>
         }
       />


### PR DESCRIPTION
Updates the `ChatComposerDrawerAttachments` template to show two distinct rows inside the drawer:

1. **Image thumbnails** — a horizontal `XDSCarousel` containing `XDSThumbnail` components with removable images
2. **File tokens** — `XDSToken` components for non-image file attachments (existing pattern)

The two rows are stacked vertically using `XDSStack` inside the drawer. The carousel enables horizontal scrolling when thumbnails overflow the drawer width.

### Components used
- `XDSChatComposer` / `XDSChatComposerDrawer`
- `XDSCarousel`
- `XDSThumbnail`
- `XDSToken`
- `XDSStack`