### PR TITLE
feat(storybook): iconless nested SideNav items story

### DIFF
--- a/apps/storybook/stories/SideNav.stories.tsx
+++ b/apps/storybook/stories/SideNav.stories.tsx
@@ -589,3 +589,49 @@ export const CollapsibleItems: Story = {
     </XDSSideNav>
   ),
 };
+
+// =============================================================================
+// Iconless Items with Nested Children
+// =============================================================================
+
+export const IconlessNestedItems: Story = {
+  name: 'Iconless Nested Items',
+  render: () => (
+    <XDSSideNav
+      header={
+        <XDSSideNavHeading
+          icon={
+            <XDSNavIcon icon={<CubeIcon style={{width: 16, height: 16}} />} />
+          }
+          heading="My App"
+        />
+      }>
+      <XDSSideNavSection title="Main">
+        <XDSSideNavItem
+          label="Dashboard"
+          icon={HomeIcon}
+          selectedIcon={HomeIconSolid}
+          isSelected
+          href="/dashboard"
+        />
+        <XDSSideNavItem
+          label="Settings"
+          icon={Cog6ToothIcon}
+          collapsible>
+          <XDSSideNavItem label="General" href="/settings/general" />
+          <XDSSideNavItem label="Security" href="/settings/security" />
+          <XDSSideNavItem
+            label="Notifications"
+            href="/settings/notifications"
+          />
+        </XDSSideNavItem>
+        <XDSSideNavItem label="Reports" collapsible>
+          <XDSSideNavItem label="Monthly" href="/reports/monthly" />
+          <XDSSideNavItem label="Quarterly" href="/reports/quarterly" />
+          <XDSSideNavItem label="Annual" href="/reports/annual" />
+        </XDSSideNavItem>
+        <XDSSideNavItem label="Analytics" icon={ChartBarIcon} href="/analytics" />
+      </XDSSideNavSection>
+    </XDSSideNav>
+  ),
+};


### PR DESCRIPTION
Adds a storybook example showing an iconless `XDSSideNavItem` with nested children alongside an icon-bearing parent with nested children.

**Purpose:** Evaluate whether the left indentation on nested items should be reduced when the parent has no icon — the current `spacing-6` indent may be too deep without the icon column to anchor it.

**Story layout:**
- Dashboard (icon, selected)
- Settings (icon, collapsible → 3 children)
- Reports (**no icon**, collapsible → 3 children)
- Analytics (icon)