### PR TITLE
fix: use XDSLinkProvider for rendering links in XDSMarkdown

### DIFF
--- a/packages/core/src/Markdown/XDSMarkdown.test.tsx
+++ b/packages/core/src/Markdown/XDSMarkdown.test.tsx
@@ -1,6 +1,8 @@
 import {describe, it, expect, vi} from 'vitest';
 import {render, screen, fireEvent} from '@testing-library/react';
 import {XDSMarkdown} from './XDSMarkdown';
+import {XDSLinkProvider} from '../Link/XDSLinkProvider';
+import type React from 'react';
 
 describe('XDSMarkdown', () => {
   it('renders with role="document"', () => {
@@ -198,5 +200,126 @@ describe('XDSMarkdown', () => {
     expect(links).toHaveLength(2);
     expect(links[0].getAttribute('href')).toBe('https://example.com');
     expect(links[1].getAttribute('href')).toBe('/page');
+  });
+
+  // ---------------------------------------------------------------------------
+  // XDSLinkProvider integration
+  // ---------------------------------------------------------------------------
+
+  describe('XDSLinkProvider integration', () => {
+    it('renders relative links with the provider component', () => {
+      const CustomLink = ({
+        children,
+        ...props
+      }: React.ComponentPropsWithoutRef<'a'>) => (
+        <a data-custom-link {...props}>
+          {children}
+        </a>
+      );
+
+      const {container} = render(
+        <XDSLinkProvider component={CustomLink}>
+          <XDSMarkdown>{'[docs](/docs/dialog)'}</XDSMarkdown>
+        </XDSLinkProvider>,
+      );
+
+      const link = container.querySelector('[data-custom-link]');
+      expect(link).toBeInTheDocument();
+      expect(link!.getAttribute('href')).toBe('/docs/dialog');
+      expect(link!.textContent).toBe('docs');
+    });
+
+    it('renders external links as native <a> even with provider', () => {
+      const CustomLink = ({
+        children,
+        ...props
+      }: React.ComponentPropsWithoutRef<'a'>) => (
+        <a data-custom-link {...props}>
+          {children}
+        </a>
+      );
+
+      const {container} = render(
+        <XDSLinkProvider component={CustomLink}>
+          <XDSMarkdown>{'[GitHub](https://github.com)'}</XDSMarkdown>
+        </XDSLinkProvider>,
+      );
+
+      // External link should NOT use the custom component
+      const customLink = container.querySelector('[data-custom-link]');
+      expect(customLink).toBeNull();
+
+      // Should be a regular <a> with target="_blank"
+      const link = screen.getByText('GitHub');
+      expect(link.tagName).toBe('A');
+      expect(link.getAttribute('target')).toBe('_blank');
+      expect(link.getAttribute('rel')).toBe('noopener noreferrer');
+    });
+
+    it('falls back to native <a> when no provider is set', () => {
+      render(<XDSMarkdown>{'[page](/about)'}</XDSMarkdown>);
+      const link = screen.getByText('page');
+      expect(link.tagName).toBe('A');
+      expect(link.getAttribute('href')).toBe('/about');
+      // No target="_blank" for relative links
+      expect(link.getAttribute('target')).toBeNull();
+    });
+
+    it('provider component receives onClick from onLinkClick prop', () => {
+      const handleClick = vi.fn();
+      const CustomLink = ({
+        children,
+        ...props
+      }: React.ComponentPropsWithoutRef<'a'>) => (
+        <a data-custom-link {...props}>
+          {children}
+        </a>
+      );
+
+      const {container} = render(
+        <XDSLinkProvider component={CustomLink}>
+          <XDSMarkdown onLinkClick={handleClick}>
+            {'[settings](/settings)'}
+          </XDSMarkdown>
+        </XDSLinkProvider>,
+      );
+
+      const link = container.querySelector('[data-custom-link]')!;
+      fireEvent.click(link);
+      expect(handleClick).toHaveBeenCalledWith(
+        '/settings',
+        expect.any(Object),
+      );
+    });
+
+    it('renders mixed internal and external links correctly', () => {
+      const CustomLink = ({
+        children,
+        ...props
+      }: React.ComponentPropsWithoutRef<'a'>) => (
+        <a data-custom-link {...props}>
+          {children}
+        </a>
+      );
+
+      const {container} = render(
+        <XDSLinkProvider component={CustomLink}>
+          <XDSMarkdown>
+            {'[internal](/docs) and [external](https://example.com)'}
+          </XDSMarkdown>
+        </XDSLinkProvider>,
+      );
+
+      // Internal link uses custom component
+      const customLinks = container.querySelectorAll('[data-custom-link]');
+      expect(customLinks).toHaveLength(1);
+      expect(customLinks[0].getAttribute('href')).toBe('/docs');
+
+      // External link is native <a>
+      const externalLink = screen.getByText('external');
+      expect(externalLink.tagName).toBe('A');
+      expect(externalLink.getAttribute('target')).toBe('_blank');
+      expect(externalLink).not.toHaveAttribute('data-custom-link');
+    });
   });
 });

--- a/packages/core/src/Markdown/XDSMarkdown.tsx
+++ b/packages/core/src/Markdown/XDSMarkdown.tsx
@@ -29,6 +29,8 @@ import {XDSCheckboxListItem} from '../CheckboxList/XDSCheckboxListItem';
 import {XDSList} from '../List/XDSList';
 import {XDSListItem} from '../List/XDSListItem';
 import {xdsClassName, mergeProps} from '../utils';
+import {useXDSLinkComponent} from '../Link/useXDSLinkComponent';
+import type {XDSLinkComponentType} from '../Link/types';
 import {useXDSStreamingText} from '../hooks/useXDSStreamingText';
 import {
   parseMarkdown,
@@ -611,6 +613,7 @@ function renderInline(
   onLinkClick: XDSMarkdownProps['onLinkClick'] | undefined,
   cursor: StreamingCursor,
   citationCtx: CitationContext | null,
+  LinkComponent: XDSLinkComponentType,
 ): React.ReactNode {
   switch (node.type) {
     case 'text':
@@ -619,7 +622,7 @@ function renderInline(
       return (
         <strong key={index} {...stylex.props(styles.bold)}>
           {node.children.map((c, i) =>
-            renderInline(c, i, onLinkClick, cursor, citationCtx),
+            renderInline(c, i, onLinkClick, cursor, citationCtx, LinkComponent),
           )}
         </strong>
       );
@@ -627,7 +630,7 @@ function renderInline(
       return (
         <em key={index}>
           {node.children.map((c, i) =>
-            renderInline(c, i, onLinkClick, cursor, citationCtx),
+            renderInline(c, i, onLinkClick, cursor, citationCtx, LinkComponent),
           )}
         </em>
       );
@@ -635,7 +638,7 @@ function renderInline(
       return (
         <del key={index} {...stylex.props(styles.strikethrough)}>
           {node.children.map((c, i) =>
-            renderInline(c, i, onLinkClick, cursor, citationCtx),
+            renderInline(c, i, onLinkClick, cursor, citationCtx, LinkComponent),
           )}
         </del>
       );
@@ -661,7 +664,7 @@ function renderInline(
         return (
           <span key={index}>
             {node.children.map((c, i) =>
-              renderInline(c, i, onLinkClick, cursor, citationCtx),
+              renderInline(c, i, onLinkClick, cursor, citationCtx, LinkComponent),
             )}
           </span>
         );
@@ -675,8 +678,12 @@ function renderInline(
             }
           }
         : undefined;
+      // Use the provider link component for non-external links so that
+      // framework routers (Next.js Link, React Router, etc.) can handle
+      // client-side navigation. External links keep target="_blank".
+      const Tag = isExternal ? 'a' : LinkComponent;
       return (
-        <a
+        <Tag
           key={index}
           href={safeHref}
           onClick={handleClick}
@@ -685,9 +692,9 @@ function renderInline(
             : {})}
           {...stylex.props(styles.link)}>
           {node.children.map((c, i) =>
-            renderInline(c, i, onLinkClick, cursor, citationCtx),
+            renderInline(c, i, onLinkClick, cursor, citationCtx, LinkComponent),
           )}
-        </a>
+        </Tag>
       );
     }
     case 'image': {
@@ -835,6 +842,7 @@ function renderBlock(
   citationCtx: CitationContext | null,
   contentWidthValue: string | null,
   contentAlign: 'start' | 'center',
+  LinkComponent: XDSLinkComponentType,
 ): React.ReactNode {
   const spacing = getElementSpacing(node, density);
   const isFirst = index === 0;
@@ -867,7 +875,7 @@ function renderBlock(
             isLast && styles.noMarginBlockEnd,
           )}>
           {node.children.map((c, i) =>
-            renderInline(c, i, onLinkClick, cursor, citationCtx),
+            renderInline(c, i, onLinkClick, cursor, citationCtx, LinkComponent),
           )}
         </Tag>
       );
@@ -888,7 +896,7 @@ function renderBlock(
             isLast && styles.noMarginBlockEnd,
           )}>
           {node.children.map((c, i) =>
-            renderInline(c, i, onLinkClick, cursor, citationCtx),
+            renderInline(c, i, onLinkClick, cursor, citationCtx, LinkComponent),
           )}
         </p>
       );
@@ -948,6 +956,7 @@ function renderBlock(
               citationCtx,
               contentWidthValue,
               contentAlign,
+              LinkComponent,
             ),
           )}
         </blockquote>
@@ -991,7 +1000,7 @@ function renderBlock(
                 const label = isInline ? (
                   <>
                     {firstChild.children.map((c, j) =>
-                      renderInline(c, j, onLinkClick, cursor, citationCtx),
+                      renderInline(c, j, onLinkClick, cursor, citationCtx, LinkComponent),
                     )}
                   </>
                 ) : (
@@ -1008,6 +1017,7 @@ function renderBlock(
                         citationCtx,
                         contentWidthValue,
                         contentAlign,
+                        LinkComponent,
                       ),
                     )}
                   </>
@@ -1070,7 +1080,7 @@ function renderBlock(
               const label = isInline ? (
                 <>
                   {firstChild.children.map((c, j) =>
-                    renderInline(c, j, onLinkClick, cursor, citationCtx),
+                    renderInline(c, j, onLinkClick, cursor, citationCtx, LinkComponent),
                   )}
                 </>
               ) : (
@@ -1087,6 +1097,7 @@ function renderBlock(
                       citationCtx,
                       contentWidthValue,
                       contentAlign,
+                      LinkComponent,
                     ),
                   )}
                 </>
@@ -1145,7 +1156,7 @@ function renderBlock(
                       alignStyle(node.alignments[i]),
                     )}>
                     {h.children.map((c, j) =>
-                      renderInline(c, j, onLinkClick, cursor, citationCtx),
+                      renderInline(c, j, onLinkClick, cursor, citationCtx, LinkComponent),
                     )}
                   </th>
                 ))}
@@ -1163,7 +1174,7 @@ function renderBlock(
                       alignStyle(node.alignments[j]),
                     )}>
                     {cell.children.map((c, k) =>
-                      renderInline(c, k, onLinkClick, cursor, citationCtx),
+                      renderInline(c, k, onLinkClick, cursor, citationCtx, LinkComponent),
                     )}
                   </td>
                 ));
@@ -1295,6 +1306,11 @@ export function XDSMarkdown({
 
   // Build citation context — numbers are assigned in encounter order during rendering.
   // This is recreated each render so numbering stays consistent with the AST.
+  // Resolve the link component from XDSLinkProvider context.
+  // Non-external links rendered inside markdown will use this component,
+  // enabling client-side navigation in Next.js, React Router, etc.
+  const LinkComponent = useXDSLinkComponent();
+
   const citationCtx: CitationContext | null = sources
     ? {sources, numberMap: new Map(), nextNumber: 1, style: citationStyle}
     : null;
@@ -1326,6 +1342,7 @@ export function XDSMarkdown({
               : contentWidth
             : null,
           contentAlign,
+          LinkComponent,
         ),
       )}
     </div>


### PR DESCRIPTION
## Summary

`XDSMarkdown` rendered all links as raw `<a>` tags, which meant internal links caused full page reloads instead of using client-side navigation — even in apps that wrap with `XDSLinkProvider` (e.g., Next.js `Link`).

This change makes `XDSMarkdown` respect `XDSLinkProvider` context for non-external links, matching the behavior of other XDS components like `XDSLink`, `XDSSideNavItem`, `XDSBreadcrumbItem`, and `XDSTab`.

## Changes

**`XDSMarkdown.tsx`**
- Import `useXDSLinkComponent` hook and `XDSLinkComponentType`
- Call `useXDSLinkComponent()` in the component to resolve the provider link component
- Thread the resolved `LinkComponent` through `renderBlock` → `renderInline`
- For non-external links: render with `LinkComponent` (from provider or native `<a>`)
- For external links (`http://...`): continue using native `<a>` with `target="_blank"`

**`XDSMarkdown.test.tsx`**
- 5 new tests covering `XDSLinkProvider` integration:
  - Relative links use the provider component
  - External links bypass the provider (still native `<a>` with `target="_blank"`)
  - Falls back to native `<a>` when no provider is set
  - Provider component receives `onClick` from `onLinkClick` prop
  - Mixed internal/external links in same paragraph

## Test Plan

### 1. Unit Tests — Vitest (all 145 pass)

```
$ npx vitest run packages/core/src/Markdown/ --no-coverage

✓ packages/core/src/Markdown/XDSMarkdown.test.tsx (34 tests) 468ms
✓ packages/core/src/Markdown/parser.test.ts (100 tests) 195ms
✓ packages/core/src/Markdown/incremental.test.ts (23 tests) 134ms
✓ packages/core/src/Markdown/parser.perf.test.ts (11 tests) 4492ms

 Test Files  4 passed (4)
      Tests  145 passed (145)
```

Link provider tests (all 36 pass):

```
$ npx vitest run packages/core/src/Link/ --no-coverage

✓ packages/core/src/Link/useXDSLinkComponent.test.tsx (6 tests)
✓ packages/core/src/Link/useXDSLinkify.test.tsx (13 tests)
✓ packages/core/src/Link/XDSLink.test.tsx (17 tests)

 Test Files  3 passed (3)
      Tests  36 passed (36)
```

### 2. E2E Browser Test — Playwright + Chromium

A Vite test app renders `XDSMarkdown` with identical markdown content in two sections:
1. **Without `XDSLinkProvider`** — baseline (native `<a>`)
2. **With `XDSLinkProvider`** wrapping a `MockRouterLink` that simulates Next.js `Link` behavior: renders `<a>`, adds `data-router-link="true"`, and intercepts clicks with `preventDefault()` + console log

```
$ npx playwright test --reporter=list

✓ internal links use provider component, external links stay native (693ms)
✓ clicking internal link does client-side nav, not full page reload (1.1s)

2 passed (3.0s)
```

### 3. DOM Evidence — Actual rendered HTML captured by Playwright

**Without provider — internal link (native `<a>`, no router):**

```html
<a href="/docs/dialog" class="XDSMarkdown__styles.link ...">internal link</a>
```

→ No `data-router-link` attribute. No `target="_blank"`. Plain native `<a>`.

**Without provider — external link:**

```html
<a href="https://github.com" target="_blank" rel="noopener noreferrer" class="XDSMarkdown__styles.link ...">external link</a>
```

→ Has `target="_blank"` + `rel="noopener noreferrer"` as expected.

**With provider — internal link (uses MockRouterLink):**

```html
<a href="/docs/dialog" data-router-link="true" class="XDSMarkdown__styles.link ...">internal link</a>
```

→ `data-router-link="true"` proves the provider component was used.
→ No `target="_blank"` — this link will use client-side navigation.

**With provider — external link (still native `<a>`):**

```html
<a href="https://github.com" target="_blank" rel="noopener noreferrer" class="XDSMarkdown__styles.link ...">external link</a>
```

→ No `data-router-link`. External links bypass the provider and remain native `<a>` with `target="_blank"`.

### 4. Network/Navigation Evidence — No full page reload

```
URL before click:  http://localhost:5199/
URL after click:   http://localhost:5199/
URL changed:       false ✓

Router console logs: 1
  [ROUTER] Client-side navigation to: /docs/dialog ✓

Document-level navigation requests: 0 ✓
  → No full page reload occurred
```

Clicking the internal link inside the provider-wrapped `XDSMarkdown`:
- **Did NOT** change the page URL (no full navigation)
- **Did NOT** trigger any document-level HTTP requests
- **Did** log `[ROUTER] Client-side navigation to: /docs/dialog` via the mock router

This proves the custom link component intercepted the click and would perform client-side routing (just like Next.js `Link`), without a full page reload.

Closes #1907