### PR TITLE
fix(docsite): add browser back/forward navigation

### DIFF
--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/DocsView.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/DocsView.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, {useState, useEffect, useMemo} from 'react';
-import {useSearchParams} from 'next/navigation';
+
 import * as stylex from '@stylexjs/stylex';
 import {XDSAppShell} from '@xds/core/AppShell';
 import {XDSTopNav, XDSTopNavHeading} from '@xds/core/TopNav';
@@ -5076,52 +5076,25 @@ function ComponentDetailPage({
 }
 
 export function DocsView({
-  activeView: _activeView,
   setActiveView,
+  selectedComponent,
+  onComponentChange,
 }: {
-  activeView: 'craft' | 'explore' | 'docs' | 'profile' | 'theme';
   setActiveView: (
     v: 'craft' | 'explore' | 'docs' | 'profile' | 'theme',
   ) => void;
+  selectedComponent: string | null;
+  onComponentChange: (key: string | null) => void;
 }) {
-  const searchParams = useSearchParams();
-
-  const [activeNav, setActiveNav] = useState(() => {
-    const tab = searchParams.get('tab');
-    const component = searchParams.get('component');
-    if (tab === 'whats-new' || tab === 'getting-started') return tab;
-    if (component) return component;
-    return 'button';
-  });
+  const [activeNav, setActiveNav] = useState(selectedComponent ?? 'button');
   const [_showCode, _setShowCode] = useState(true);
   const [_activeRightNav, _setActiveRightNav] = useState('usage');
-  const [selectedComponent, setSelectedComponent] = useState<string | null>(
-    () => {
-      const tab = searchParams.get('tab');
-      const component = searchParams.get('component');
-      if (tab === 'whats-new' || tab === 'getting-started') return tab;
-      if (component) return component;
-      return null;
-    },
-  );
   const [isSearchOpen, setIsSearchOpen] = useState(false);
 
   useEffect(() => {
-    const params = new URLSearchParams();
-    params.set('page', 'docs');
-
-    if (selectedComponent === 'whats-new') {
-      params.set('tab', 'whats-new');
-    } else if (selectedComponent === 'getting-started') {
-      params.set('tab', 'getting-started');
-    } else if (selectedComponent !== null) {
-      params.set('component', selectedComponent);
+    if (selectedComponent !== null) {
+      setActiveNav(selectedComponent);
     }
-
-    const qs = params.toString();
-    if (qs === window.location.search.slice(1)) return;
-    const url = `${basePath}/pages/docsite/?${qs}`;
-    window.history.replaceState(window.history.state, '', url);
   }, [selectedComponent]);
 
   const headingMenu = (
@@ -5174,7 +5147,7 @@ export function DocsView({
               <XDSSideNavItem
                 label="Home"
                 isSelected={selectedComponent === null}
-                onClick={() => setSelectedComponent(null)}
+                onClick={() => onComponentChange(null)}
               />
             </XDSSideNavSection>
             <XDSSideNavSection title="Overview" isHeaderHidden>
@@ -5186,7 +5159,7 @@ export function DocsView({
                     activeNav === 'getting-started'
                   }
                   onClick={() => {
-                    setSelectedComponent('getting-started');
+                    onComponentChange('getting-started');
                     setActiveNav('getting-started');
                   }}
                 />
@@ -5194,7 +5167,7 @@ export function DocsView({
                   label="What's New"
                   isSelected={selectedComponent === 'whats-new'}
                   onClick={() => {
-                    setSelectedComponent('whats-new');
+                    onComponentChange('whats-new');
                     setActiveNav('whats-new');
                   }}
                 />
@@ -5207,7 +5180,7 @@ export function DocsView({
                         selectedComponent !== null && activeNav === item.key
                       }
                       onClick={() => {
-                        setSelectedComponent(item.key);
+                        onComponentChange(item.key);
                         setActiveNav(item.key);
                       }}
                     />
@@ -5222,7 +5195,7 @@ export function DocsView({
                         selectedComponent !== null && activeNav === pkg.key
                       }
                       onClick={() => {
-                        setSelectedComponent(pkg.key);
+                        onComponentChange(pkg.key);
                         setActiveNav(pkg.key);
                       }}
                     />
@@ -5241,7 +5214,7 @@ export function DocsView({
                       selectedComponent !== null && activeNav === item.key
                     }
                     onClick={() => {
-                      setSelectedComponent(item.key);
+                      onComponentChange(item.key);
                       setActiveNav(item.key);
                     }}
                   />
@@ -5254,11 +5227,11 @@ export function DocsView({
         {selectedComponent === null ? (
           <LibraryOverview
             onGetStarted={() => {
-              setSelectedComponent('getting-started');
+              onComponentChange('getting-started');
               setActiveNav('getting-started');
             }}
             onSelectComponent={(key: string) => {
-              setSelectedComponent(key);
+              onComponentChange(key);
               setActiveNav(key);
             }}
             onCraft={() => setActiveView('craft')}
@@ -5273,7 +5246,7 @@ export function DocsView({
           <LibraryPackagePage
             packageKey={selectedComponent}
             onSelectComponent={(key: string) => {
-              setSelectedComponent(key);
+              onComponentChange(key);
               setActiveNav(key);
             }}
             onCraft={() => setActiveView('craft')}

--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
@@ -428,6 +428,16 @@ function DocsiteLandingTemplate() {
     const CRAFT_TABS = ['all', 'templates', 'components'];
     const isCraftTab = page !== null && CRAFT_TABS.includes(page);
 
+    const component = searchParams.get('component');
+    let docsComponent: string | null = null;
+    if (page === 'docs') {
+      if (tab === 'whats-new' || tab === 'getting-started') {
+        docsComponent = tab;
+      } else if (component) {
+        docsComponent = component;
+      }
+    }
+
     return {
       view: v,
       templateIdx: isNaN(templateIdx as number) ? null : templateIdx,
@@ -444,6 +454,7 @@ function DocsiteLandingTemplate() {
       used,
       settings: settings === '1',
       collection,
+      docsComponent,
     };
   }, [searchParams]);
 
@@ -454,6 +465,9 @@ function DocsiteLandingTemplate() {
       | 'docs'
       | 'profile'
       | 'theme',
+  );
+  const [docsComponent, setDocsComponent] = useState<string | null>(
+    initialView.docsComponent,
   );
   const [profileTab, setProfileTab] = useState<
     'Crafted' | 'Used' | 'Bookmarks'
@@ -605,6 +619,9 @@ function DocsiteLandingTemplate() {
     [editorPanelWidth],
   );
 
+  const isPopstateRef = useRef(false);
+  const prevUrlRef = useRef('');
+
   // Sync URL when view state changes
   useEffect(() => {
     const params = new URLSearchParams();
@@ -621,7 +638,16 @@ function DocsiteLandingTemplate() {
       params.set('page', activeTab);
     } else if (activeView !== 'craft') {
       params.set('page', activeView);
-      if (activeView === 'profile') {
+      if (activeView === 'docs') {
+        if (
+          docsComponent === 'whats-new' ||
+          docsComponent === 'getting-started'
+        ) {
+          params.set('tab', docsComponent);
+        } else if (docsComponent !== null) {
+          params.set('component', docsComponent);
+        }
+      } else if (activeView === 'profile') {
         if (profileCraftName) {
           params.set('tab', 'Crafted');
           params.set('craft', profileCraftName);
@@ -643,19 +669,98 @@ function DocsiteLandingTemplate() {
     const qs = params.toString();
     if (qs === window.location.search.slice(1)) return;
     const url = `${basePath}/pages/docsite/${qs ? '?' + qs : ''}`;
-    window.history.replaceState(window.history.state, '', url);
+
+    if (isPopstateRef.current) {
+      isPopstateRef.current = false;
+      prevUrlRef.current = qs;
+      return;
+    }
+
+    const prevParams = new URLSearchParams(prevUrlRef.current);
+    const prevPage = prevParams.get('page');
+    const prevComponent = prevParams.get('component');
+    const prevTab = prevParams.get('tab');
+    const prevView = prevParams.get('view');
+    const curPage = params.get('page');
+    const curComponent = params.get('component');
+    const curTab = params.get('tab');
+    const curView = params.get('view');
+
+    const isSignificant =
+      curView !== prevView ||
+      curPage !== prevPage ||
+      curComponent !== prevComponent ||
+      (curPage === 'docs' && curTab !== prevTab);
+
+    if (isSignificant) {
+      window.history.pushState(null, '', url);
+    } else {
+      window.history.replaceState(window.history.state, '', url);
+    }
+    prevUrlRef.current = qs;
   }, [
     previewTarget,
     useTarget,
     craftTitle,
     activeView,
     activeTab,
+    docsComponent,
     profileTab,
     profileCraftName,
     profileUsedName,
     profileSettingsOpen,
     profileCollectionName,
   ]);
+
+  useEffect(() => {
+    const onPopState = () => {
+      isPopstateRef.current = true;
+      const params = new URLSearchParams(window.location.search);
+      const page = params.get('page');
+      const view = params.get('view');
+      const template = params.get('template');
+      const q = params.get('q');
+
+      if (view === 'preview' && template !== null) {
+        setPreviewTarget(parseInt(template, 10));
+        setUseTarget(null);
+      } else if (view === 'editor' && template !== null) {
+        setUseTarget(parseInt(template, 10));
+        setPreviewTarget(null);
+      } else if (q) {
+        setCraftTitle(q);
+        setPreviewTarget(null);
+        setUseTarget(null);
+      } else {
+        setPreviewTarget(null);
+        setUseTarget(null);
+        setCraftTitle(null);
+        const CRAFT_TABS = ['all', 'templates', 'components'];
+        if (page && CRAFT_TABS.includes(page)) {
+          setActiveView('craft');
+          setActiveTab(page);
+        } else if (page === 'docs') {
+          setActiveView('docs');
+          const tab = params.get('tab');
+          const component = params.get('component');
+          if (tab === 'whats-new' || tab === 'getting-started') {
+            setDocsComponent(tab);
+          } else if (component) {
+            setDocsComponent(component);
+          } else {
+            setDocsComponent(null);
+          }
+        } else if (page === 'profile' || page === 'theme') {
+          setActiveView(page);
+        } else {
+          setActiveView('craft');
+          setActiveTab('all');
+        }
+      }
+    };
+    window.addEventListener('popstate', onPopState);
+    return () => window.removeEventListener('popstate', onPopState);
+  }, []);
 
   const prevViewRef = useRef(activeView);
   const skipViewResetRef = useRef(false);
@@ -671,6 +776,9 @@ function DocsiteLandingTemplate() {
     setChatOpen(false);
     setCraftTitle(null);
     setResultFilters(new Set());
+    if (activeView !== 'docs') {
+      setDocsComponent(null);
+    }
   }, [activeView]);
   const timerRef = useRef(null as ReturnType<typeof setTimeout> | null);
   const previewTimerRef = useRef(null as ReturnType<typeof setTimeout> | null);
@@ -1066,7 +1174,13 @@ function DocsiteLandingTemplate() {
   }
 
   if (activeView === 'docs') {
-    return <DocsView activeView={activeView} setActiveView={setActiveView} />;
+    return (
+      <DocsView
+        setActiveView={setActiveView}
+        selectedComponent={docsComponent}
+        onComponentChange={setDocsComponent}
+      />
+    );
   }
 
   if (activeView === 'profile') {

--- a/apps/sandbox/src/app/(sandbox)/pages/doc-preview/DocPreview.tsx
+++ b/apps/sandbox/src/app/(sandbox)/pages/doc-preview/DocPreview.tsx
@@ -1,0 +1,573 @@
+'use client';
+
+import {useMemo, useRef, useEffect, useState} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {XDSVStack, XDSHStack} from '@xds/core/Layout';
+import {XDSText, XDSHeading} from '@xds/core/Text';
+import {XDSCodeBlock} from '@xds/core/CodeBlock';
+import {XDSDivider} from '@xds/core/Divider';
+import {useXDSTheme} from '@xds/core/theme';
+import type {
+  ReferenceDoc,
+  ReferenceSection,
+  ContentBlock,
+  TokenPreviewType,
+} from '@xds/core';
+
+// =============================================================================
+// Styles
+// =============================================================================
+
+const styles = stylex.create({
+  root: {
+    maxWidth: 960,
+    margin: '0 auto',
+    padding: 32,
+  },
+  sectionTitle: {
+    scrollMarginTop: 80,
+  },
+  tokenTable: {
+    width: '100%',
+    borderCollapse: 'collapse',
+    fontSize: 13,
+  },
+  th: {
+    textAlign: 'start',
+    fontWeight: 600,
+    fontSize: 12,
+    paddingBlock: 8,
+    paddingInline: 12,
+    borderBottom: '1px solid var(--color-border)',
+    color: 'var(--color-text-secondary)',
+    textTransform: 'uppercase' as const,
+    letterSpacing: '0.04em',
+  },
+  td: {
+    paddingBlock: 8,
+    paddingInline: 12,
+    borderBottom: '1px solid var(--color-border)',
+    verticalAlign: 'middle',
+    fontFamily: 'var(--font-family-code)',
+    fontSize: 12,
+  },
+  tokenName: {
+    fontWeight: 500,
+    color: 'var(--color-text-primary)',
+    whiteSpace: 'nowrap' as const,
+  },
+  tokenValue: {
+    color: 'var(--color-text-secondary)',
+    maxWidth: 320,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap' as const,
+  },
+  previewCell: {
+    width: 48,
+  },
+  listItem: {
+    paddingBlock: 2,
+    color: 'var(--color-text-primary)',
+    fontSize: 14,
+    lineHeight: 1.5,
+  },
+  doIcon: {
+    color: 'var(--color-success)',
+    flexShrink: 0,
+    fontWeight: 700,
+  },
+  dontIcon: {
+    color: 'var(--color-error)',
+    flexShrink: 0,
+    fontWeight: 700,
+  },
+  prose: {
+    fontSize: 14,
+    lineHeight: 1.6,
+    color: 'var(--color-text-primary)',
+  },
+});
+
+// =============================================================================
+// Token Preview Renderers
+// =============================================================================
+
+function SwatchPreview({value}: {value: string}) {
+  return (
+    <div
+      style={{
+        width: 28,
+        height: 28,
+        borderRadius: 6,
+        backgroundColor: value,
+        border: '1px solid var(--color-border)',
+        flexShrink: 0,
+      }}
+    />
+  );
+}
+
+function ShadowBoxPreview({value}: {value: string}) {
+  return (
+    <div
+      style={{
+        width: 32,
+        height: 24,
+        borderRadius: 6,
+        backgroundColor: 'var(--color-background-surface)',
+        boxShadow: value,
+        flexShrink: 0,
+      }}
+    />
+  );
+}
+
+function RadiusBoxPreview({value}: {value: string}) {
+  return (
+    <div
+      style={{
+        width: 28,
+        height: 28,
+        borderRadius: value,
+        border: '2px solid var(--color-accent)',
+        flexShrink: 0,
+      }}
+    />
+  );
+}
+
+function SpacingBarPreview({value}: {value: string}) {
+  return (
+    <div
+      style={{
+        width: value,
+        minWidth: 2,
+        maxWidth: 64,
+        height: 12,
+        borderRadius: 2,
+        backgroundColor: 'var(--color-accent)',
+        opacity: 0.6,
+        flexShrink: 0,
+      }}
+    />
+  );
+}
+
+function SizeBarPreview({value}: {value: string}) {
+  return (
+    <div
+      style={{
+        height: value,
+        width: 40,
+        maxHeight: 48,
+        borderRadius: 4,
+        backgroundColor: 'var(--color-accent-muted)',
+        border: '1px solid var(--color-accent)',
+        flexShrink: 0,
+      }}
+    />
+  );
+}
+
+function BorderLinePreview({value}: {value: string}) {
+  return (
+    <div
+      style={{
+        width: 32,
+        height: 0,
+        borderBottom: `${value} solid var(--color-border-emphasized)`,
+        flexShrink: 0,
+      }}
+    />
+  );
+}
+
+function DurationBarPreview({value}: {value: string}) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [animate, setAnimate] = useState(false);
+
+  useEffect(() => {
+    const interval = setInterval(() => setAnimate(a => !a), 2000);
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    <div
+      style={{
+        width: 40,
+        height: 8,
+        borderRadius: 4,
+        backgroundColor: 'var(--color-neutral)',
+        overflow: 'hidden',
+        flexShrink: 0,
+      }}>
+      <div
+        ref={ref}
+        style={{
+          width: animate ? '100%' : '0%',
+          height: '100%',
+          borderRadius: 4,
+          backgroundColor: 'var(--color-accent)',
+          transition: `width ${value} ease`,
+        }}
+      />
+    </div>
+  );
+}
+
+function EasingCurvePreview({value}: {value: string}) {
+  // Parse cubic-bezier values and draw a mini SVG curve
+  const match = value.match(
+    /cubic-bezier\(\s*([\d.]+)\s*,\s*([-\d.]+)\s*,\s*([\d.]+)\s*,\s*([-\d.]+)\s*\)/,
+  );
+  if (!match) return null;
+  const [, x1, y1, x2, y2] = match.map(Number);
+  return (
+    <svg width={32} height={24} viewBox="0 0 1 1" style={{flexShrink: 0}}>
+      <path
+        d={`M 0 1 C ${x1} ${1 - y1}, ${x2} ${1 - y2}, 1 0`}
+        fill="none"
+        stroke="var(--color-accent)"
+        strokeWidth={0.06}
+      />
+    </svg>
+  );
+}
+
+function FontSamplePreview({
+  tokenName,
+  value,
+}: {
+  tokenName: string;
+  value: string;
+}) {
+  const style: React.CSSProperties = {
+    flexShrink: 0,
+    whiteSpace: 'nowrap',
+    maxWidth: 120,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+  };
+
+  if (tokenName.includes('font-family')) {
+    return <span style={{...style, fontFamily: value, fontSize: 13}}>Aa</span>;
+  }
+  if (tokenName.includes('font-size')) {
+    return <span style={{...style, fontSize: value}}>Aa</span>;
+  }
+  if (tokenName.includes('font-weight')) {
+    return <span style={{...style, fontWeight: value, fontSize: 13}}>Aa</span>;
+  }
+  if (tokenName.includes('text-') && tokenName.includes('-size')) {
+    return <span style={{...style, fontSize: value}}>Aa</span>;
+  }
+  if (tokenName.includes('text-') && tokenName.includes('-weight')) {
+    return <span style={{...style, fontWeight: value, fontSize: 13}}>Aa</span>;
+  }
+  return <span style={{...style, fontSize: 13}}>Aa</span>;
+}
+
+function TokenPreview({
+  type,
+  tokenName,
+  value,
+}: {
+  type: TokenPreviewType;
+  tokenName: string;
+  value: string;
+}) {
+  switch (type) {
+    case 'swatch':
+      return <SwatchPreview value={value} />;
+    case 'shadow-box':
+      return <ShadowBoxPreview value={value} />;
+    case 'radius-box':
+      return <RadiusBoxPreview value={value} />;
+    case 'spacing-bar':
+      return <SpacingBarPreview value={value} />;
+    case 'size-bar':
+      return <SizeBarPreview value={value} />;
+    case 'border-line':
+      return <BorderLinePreview value={value} />;
+    case 'duration-bar':
+      return <DurationBarPreview value={value} />;
+    case 'easing-curve':
+      return <EasingCurvePreview value={value} />;
+    case 'font-sample':
+      return <FontSamplePreview tokenName={tokenName} value={value} />;
+    default:
+      return null;
+  }
+}
+
+// =============================================================================
+// Block Renderers
+// =============================================================================
+
+function TokenTable({
+  headers,
+  rows,
+  previewType,
+}: {
+  headers: string[];
+  rows: string[][];
+  previewType?: TokenPreviewType;
+}) {
+  const {token} = useXDSTheme();
+
+  return (
+    <div style={{overflowX: 'auto'}}>
+      <table {...stylex.props(styles.tokenTable)}>
+        <thead>
+          <tr>
+            {previewType && (
+              <th {...stylex.props(styles.th, styles.previewCell)} />
+            )}
+            <th {...stylex.props(styles.th)}>Token</th>
+            <th {...stylex.props(styles.th)}>Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, i) => {
+            const tokenName = row[0];
+            // Resolve the live value from the current theme
+            const liveValue = token(tokenName) ?? row[1];
+            return (
+              <tr key={i}>
+                {previewType && (
+                  <td {...stylex.props(styles.td, styles.previewCell)}>
+                    <TokenPreview
+                      type={previewType}
+                      tokenName={tokenName}
+                      value={liveValue}
+                    />
+                  </td>
+                )}
+                <td {...stylex.props(styles.td, styles.tokenName)}>
+                  {tokenName}
+                </td>
+                <td {...stylex.props(styles.td, styles.tokenValue)}>
+                  {liveValue}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function ProseBlock({text}: {text: string}) {
+  return (
+    <div {...stylex.props(styles.prose)}>
+      <XDSText>{text}</XDSText>
+    </div>
+  );
+}
+
+function CodeBlockRenderer({
+  lang,
+  code,
+  label,
+}: {
+  lang: string;
+  code: string;
+  label?: string;
+}) {
+  return (
+    <XDSVStack gap={1}>
+      {label && (
+        <XDSText variant="supporting" color="secondary">
+          {label}
+        </XDSText>
+      )}
+      <XDSCodeBlock code={code} language={lang} hasCopyButton />
+    </XDSVStack>
+  );
+}
+
+function ListBlock({
+  items,
+  listStyle,
+}: {
+  items: string[];
+  listStyle: 'ordered' | 'unordered' | 'do' | 'dont';
+}) {
+  return (
+    <XDSVStack gap={1}>
+      {items.map((item, i) => (
+        <XDSHStack key={i} gap={2} align="start">
+          {listStyle === 'do' && (
+            <span {...stylex.props(styles.doIcon)}>✓</span>
+          )}
+          {listStyle === 'dont' && (
+            <span {...stylex.props(styles.dontIcon)}>✗</span>
+          )}
+          {listStyle === 'ordered' && (
+            <XDSText variant="body" color="secondary">
+              {i + 1}.
+            </XDSText>
+          )}
+          {listStyle === 'unordered' && (
+            <XDSText variant="body" color="secondary">
+              •
+            </XDSText>
+          )}
+          <div {...stylex.props(styles.listItem)}>{item}</div>
+        </XDSHStack>
+      ))}
+    </XDSVStack>
+  );
+}
+
+function ContentBlockRenderer({
+  block,
+  previewType,
+}: {
+  block: ContentBlock;
+  previewType?: TokenPreviewType;
+}) {
+  switch (block.type) {
+    case 'prose':
+      return <ProseBlock text={block.text} />;
+    case 'code':
+      return (
+        <CodeBlockRenderer
+          lang={block.lang}
+          code={block.code}
+          label={block.label}
+        />
+      );
+    case 'table':
+      return (
+        <TokenTable
+          headers={block.headers}
+          rows={block.rows}
+          previewType={previewType}
+        />
+      );
+    case 'list':
+      return <ListBlock items={block.items} listStyle={block.style} />;
+    case 'token-ref':
+      // Should already be resolved by the CLI — render nothing if unresolved
+      return null;
+    default:
+      return null;
+  }
+}
+
+// =============================================================================
+// Section Renderer
+// =============================================================================
+
+function SectionRenderer({section}: {section: ReferenceSection}) {
+  return (
+    <XDSVStack gap={4}>
+      <XDSHeading
+        level={2}
+        id={section.title.toLowerCase().replace(/\s+/g, '-')}
+        xstyle={styles.sectionTitle}>
+        {section.title}
+      </XDSHeading>
+      {section.content.map((block, i) => (
+        <ContentBlockRenderer
+          key={i}
+          block={block}
+          previewType={section.previewType}
+        />
+      ))}
+    </XDSVStack>
+  );
+}
+
+// =============================================================================
+// DocPreview
+// =============================================================================
+
+export function DocPreview({doc}: {doc: ReferenceDoc}) {
+  // Group sections into: token tables, usage/code, best practices, and other
+  const {tokenSections, usageSections, practiceSections, otherSections} =
+    useMemo(() => {
+      const token: ReferenceSection[] = [];
+      const usage: ReferenceSection[] = [];
+      const practice: ReferenceSection[] = [];
+      const other: ReferenceSection[] = [];
+
+      for (const section of doc.sections) {
+        const titleLower = section.title.toLowerCase();
+        if (
+          section.previewType ||
+          section.content.some(b => b.type === 'table')
+        ) {
+          token.push(section);
+        } else if (titleLower.includes('usage')) {
+          usage.push(section);
+        } else if (
+          titleLower.includes('best practice') ||
+          titleLower.includes('guidance')
+        ) {
+          practice.push(section);
+        } else {
+          other.push(section);
+        }
+      }
+
+      return {
+        tokenSections: token,
+        usageSections: usage,
+        practiceSections: practice,
+        otherSections: other,
+      };
+    }, [doc.sections]);
+
+  return (
+    <div {...stylex.props(styles.root)}>
+      <XDSVStack gap={8}>
+        {/* Title + Description */}
+        <XDSVStack gap={2}>
+          <XDSHeading level={1}>{doc.title}</XDSHeading>
+          <XDSText variant="large" color="secondary">
+            {doc.description}
+          </XDSText>
+        </XDSVStack>
+
+        {/* Overview / other sections first */}
+        {otherSections.map((section, i) => (
+          <SectionRenderer key={`other-${i}`} section={section} />
+        ))}
+
+        {/* Token tables */}
+        {tokenSections.length > 0 && (
+          <>
+            <XDSDivider />
+            {tokenSections.map((section, i) => (
+              <SectionRenderer key={`token-${i}`} section={section} />
+            ))}
+          </>
+        )}
+
+        {/* Usage */}
+        {usageSections.length > 0 && (
+          <>
+            <XDSDivider />
+            {usageSections.map((section, i) => (
+              <SectionRenderer key={`usage-${i}`} section={section} />
+            ))}
+          </>
+        )}
+
+        {/* Best Practices */}
+        {practiceSections.length > 0 && (
+          <>
+            <XDSDivider />
+            {practiceSections.map((section, i) => (
+              <SectionRenderer key={`practice-${i}`} section={section} />
+            ))}
+          </>
+        )}
+      </XDSVStack>
+    </div>
+  );
+}

--- a/apps/sandbox/src/app/(sandbox)/pages/doc-preview/page.tsx
+++ b/apps/sandbox/src/app/(sandbox)/pages/doc-preview/page.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import {useState, useEffect} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {XDSVStack, XDSHStack} from '@xds/core/Layout';
+import {XDSText} from '@xds/core/Text';
+import {
+  XDSSegmentedControl,
+  XDSSegmentedControlItem,
+} from '@xds/core/SegmentedControl';
+import {XDSSpinner} from '@xds/core/Spinner';
+import type {ReferenceDoc} from '@xds/core';
+import {docs as docsApi} from '@xds/cli/api';
+import {DocPreview} from './DocPreview';
+
+const styles = stylex.create({
+  page: {
+    minHeight: '100vh',
+  },
+  topBar: {
+    position: 'sticky',
+    top: 0,
+    zIndex: 10,
+    backgroundColor: 'var(--color-background-body)',
+    borderBottom: '1px solid var(--color-border)',
+    padding: '12px 32px',
+  },
+  loading: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 64,
+  },
+});
+
+/** Foundational doc topics — the section docs that have tokenCategory */
+const TOPICS = [
+  {value: 'color', label: 'Color'},
+  {value: 'spacing', label: 'Spacing'},
+  {value: 'typography', label: 'Typography'},
+  {value: 'elevation', label: 'Elevation'},
+  {value: 'shape', label: 'Shape'},
+  {value: 'motion', label: 'Motion'},
+] as const;
+
+export default function DocPreviewPage() {
+  const [topic, setTopic] = useState<string>('color');
+  const [doc, setDoc] = useState<ReferenceDoc | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    docsApi(topic).then(result => {
+      if (cancelled) return;
+      if (result.type === 'docs.detail') {
+        setDoc(result.data as ReferenceDoc);
+      }
+      setLoading(false);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [topic]);
+
+  return (
+    <div {...stylex.props(styles.page)}>
+      <div {...stylex.props(styles.topBar)}>
+        <XDSHStack gap={4} align="center">
+          <XDSText variant="label" color="secondary">
+            Foundations
+          </XDSText>
+          <XDSSegmentedControl
+            value={topic}
+            onChange={setTopic}
+            label="Doc topic"
+            size="sm">
+            {TOPICS.map(t => (
+              <XDSSegmentedControlItem
+                key={t.value}
+                value={t.value}
+                label={t.label}
+              />
+            ))}
+          </XDSSegmentedControl>
+        </XDSHStack>
+      </div>
+      {loading ? (
+        <div {...stylex.props(styles.loading)}>
+          <XDSSpinner size="md" />
+        </div>
+      ) : doc ? (
+        <DocPreview doc={doc} />
+      ) : (
+        <div {...stylex.props(styles.loading)}>
+          <XDSText color="secondary">No doc found for "{topic}"</XDSText>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/sandbox/src/app/sandboxPages.ts
+++ b/apps/sandbox/src/app/sandboxPages.ts
@@ -115,6 +115,12 @@ export const categories: SandboxCategory[] = [
         description: 'Compare highlight modes and scroll performance',
       },
       {
+        name: 'Foundations',
+        href: '/pages/doc-preview/',
+        description:
+          'Token reference docs with live theme previews — color, spacing, typography, and more',
+      },
+      {
         name: 'Docsite',
         href: '/pages/docsite/',
         description:

--- a/packages/cli/docs/color.doc.mjs
+++ b/packages/cli/docs/color.doc.mjs
@@ -1,0 +1,81 @@
+/** @type {import('../../core/src/docs-types').ReferenceDoc} */
+
+export const docs = {
+  name: 'color',
+  title: 'Color',
+  description:
+    'Semantic color tokens for surfaces, text, icons, borders, and status indicators.',
+  tokenCategory: 'color',
+
+  sections: [
+    {
+      title: 'Overview',
+      content: [
+        {
+          type: 'prose',
+          text: 'XDS colors are semantic — tokens describe purpose, not appearance. Every color adapts automatically between light and dark modes via CSS light-dark(). Themes override the resolved values, so your code never references raw hex colors.',
+        },
+      ],
+    },
+    {
+      title: 'Surface Colors',
+      content: [
+        {
+          type: 'prose',
+          text: 'Layered surface hierarchy: body → surface → card → popover. Each level sits visually above the previous one.',
+        },
+        {
+          type: 'token-ref',
+          topic: 'tokens',
+          section: 'Color Tokens',
+        },
+      ],
+    },
+    {
+      title: 'Usage',
+      content: [
+        {
+          type: 'code',
+          lang: 'tsx',
+          label: 'Applying color tokens',
+          code: `import * as stylex from '@stylexjs/stylex';
+import {colorVars} from '@xds/core';
+
+const styles = stylex.create({
+  container: {
+    backgroundColor: colorVars['--color-background-surface'],
+    color: colorVars['--color-text-primary'],
+    borderColor: colorVars['--color-border'],
+  },
+  accent: {
+    color: colorVars['--color-text-accent'],
+  },
+});`,
+        },
+      ],
+    },
+    {
+      title: 'Best Practices',
+      content: [
+        {
+          type: 'list',
+          style: 'do',
+          items: [
+            'Use semantic tokens (--color-text-primary) instead of raw hex values.',
+            'Rely on the surface hierarchy (body → surface → card → popover) for layering.',
+            'Use status colors (success, error, warning) only for their semantic meaning.',
+          ],
+        },
+        {
+          type: 'list',
+          style: 'dont',
+          items: [
+            "Hardcode hex values — they won't adapt to dark mode or custom themes.",
+            'Mix accent colors with status colors in the same context.',
+            'Use --color-on-accent on non-accent backgrounds.',
+          ],
+        },
+      ],
+    },
+  ],
+};

--- a/packages/cli/docs/elevation.doc.mjs
+++ b/packages/cli/docs/elevation.doc.mjs
@@ -1,0 +1,79 @@
+/** @type {import('../../core/src/docs-types').ReferenceDoc} */
+
+export const docs = {
+  name: 'elevation',
+  title: 'Elevation',
+  description:
+    'Shadow tokens for visual elevation and inset state rings.',
+  tokenCategory: 'shadow',
+
+  sections: [
+    {
+      title: 'Overview',
+      content: [
+        {
+          type: 'prose',
+          text: 'Elevation tokens create depth through box-shadow. Three levels (low, med, high) establish a visual hierarchy for floating elements. Inset shadows provide focus and selection rings for interactive components.',
+        },
+      ],
+    },
+    {
+      title: 'Elevation Scale',
+      content: [
+        {
+          type: 'prose',
+          text: 'Each level adds stronger offset and spread. Shadow color adapts to dark mode automatically via light-dark().',
+        },
+        {
+          type: 'token-ref',
+          topic: 'tokens',
+          section: 'Shadow Tokens',
+        },
+      ],
+    },
+    {
+      title: 'Usage',
+      content: [
+        {
+          type: 'code',
+          lang: 'tsx',
+          label: 'Applying elevation',
+          code: `import {shadowVars} from '@xds/core';
+
+const styles = stylex.create({
+  dropdown: {
+    boxShadow: shadowVars['--shadow-med'],
+  },
+  dialog: {
+    boxShadow: shadowVars['--shadow-high'],
+  },
+  inputFocused: {
+    boxShadow: shadowVars['--shadow-inset-selected'],
+  },
+});`,
+        },
+      ],
+    },
+    {
+      title: 'Best Practices',
+      content: [
+        {
+          type: 'list',
+          style: 'do',
+          items: [
+            'Match elevation to interaction context: low for tooltips, med for dropdowns, high for dialogs.',
+            'Use inset shadows for input focus/selection states — they compose better than outlines.',
+          ],
+        },
+        {
+          type: 'list',
+          style: 'dont',
+          items: [
+            'Stack multiple elevation levels on the same element.',
+            'Use elevation shadows for decorative borders — use --color-border tokens instead.',
+          ],
+        },
+      ],
+    },
+  ],
+};

--- a/packages/cli/docs/motion.doc.mjs
+++ b/packages/cli/docs/motion.doc.mjs
@@ -13,7 +13,15 @@ export const docs = {
       content: [
         {
           type: 'prose',
-          text: 'XDS motion tokens define timing in three bands: fast (micro-interactions like hover/press), medium (entrance/exit), and slow (continuous/looping). Each band has a base value with min/max variants derived from a consistent ratio.',
+          text: 'Motion serves two purposes: it makes interfaces easier to understand, and it makes them more pleasant to use. A panel animating open helps the eye track what changed and where new content sits in the layout. These moments reduce cognitive load and make the interface feel responsive.',
+        },
+        {
+          type: 'prose',
+          text: 'At the same time, well-tuned motion gives an application a sense of craft and polish that users notice, even if they can\'t name it.',
+        },
+        {
+          type: 'prose',
+          text: 'XDS provides duration and easing tokens that keep these moments consistent across your application.',
         },
       ],
     },
@@ -34,6 +42,56 @@ export const docs = {
           type: 'token-ref',
           topic: 'tokens',
           section: 'Easing Tokens',
+        },
+      ],
+    },
+    {
+      title: 'Where Motion Helps',
+      content: [
+        {
+          type: 'prose',
+          text: 'Some parts of the interface benefit from animation. Panels, dialogs, and collapsible sections are disorienting when they appear instantly — animation gives the eye something to follow. Toasts and notifications need just enough entrance to be noticed without startling. State changes like a switch flipping or a selection highlighting feel more intentional with a brief transition.',
+        },
+        {
+          type: 'prose',
+          text: 'The common thread is that these are moments where the user needs to understand what happened.',
+        },
+      ],
+    },
+    {
+      title: 'Where Motion Hurts',
+      content: [
+        {
+          type: 'prose',
+          text: 'Table row hovers. List item highlights. Anything the user does dozens of times per minute. Adding perceptible duration to these interactions makes the interface feel like it’s catching up to the cursor. Keep these fast enough that the user never notices a delay.',
+        },
+        {
+          type: 'prose',
+          text: 'Animations that block interaction are worse. If a user has to wait for a panel to finish sliding before they can click something inside it, the animation has become an obstacle. Motion should never stand between the user and their next action.',
+        },
+      ],
+    },
+    {
+      title: 'Movement Principles',
+      content: [
+        {
+          type: 'list',
+          style: 'unordered',
+          items: [
+            'Not everything needs an animated exit. Elements the user is moving away from — tooltips, hover cards, dropdown menus — can disappear instantly. The user has already shifted their attention. Animate the exit only when it helps orient the user, like a panel closing or a dialog dismissing to reveal what’s underneath.',
+            'When you do animate exit, match the entrance. A panel that slides in from the right should slide back out to the right.',
+            'Direction should match the action. Navigating deeper into content should feel like moving forward. Going back should feel like returning. This keeps the user oriented in the structure of the application.',
+            'Contextual UI should feel connected to its trigger. A dropdown should expand from the button that opened it. A popover should appear near the element it describes. This doesn’t apply to global UI like command palettes or toasts, which have their own fixed positions.',
+          ],
+        },
+      ],
+    },
+    {
+      title: 'Respecting User Preferences',
+      content: [
+        {
+          type: 'prose',
+          text: 'Some users experience motion sensitivity — animation that feels polished to one person can cause discomfort for another. XDS components should honor the operating system’s reduced motion setting. When it’s enabled, replace animations with instant state changes.',
         },
       ],
     },
@@ -68,17 +126,18 @@ const styles = stylex.create({
           type: 'list',
           style: 'do',
           items: [
-            'Use fast durations for state changes (hover, press, toggle).',
-            'Use medium durations for element entrance/exit (dialogs, dropdowns).',
-            'Use slow durations sparingly — only for continuous animations (loading spinners, progress bars).',
+            'Animate transitions that involve spatial change — panels opening, content expanding, elements entering the screen.',
+            'Use fast tokens for small, frequent interactions. Use medium tokens for larger transitions that rearrange the layout.',
+            'Honor reduced motion preferences at the OS level.',
           ],
         },
         {
           type: 'list',
           style: 'dont',
           items: [
-            'Use slow durations for interactive feedback — users will perceive lag.',
-            'Skip easing on transitions — linear motion feels robotic.',
+            'Let hover states or high-frequency interactions feel like they’re lagging behind the user.',
+            'Let animation delay when a user can interact with new content. The transition should complete before — or not block — the next action.',
+            'Move elements in ways that contradict where they came from or where they’re going.',
           ],
         },
       ],

--- a/packages/cli/docs/motion.doc.mjs
+++ b/packages/cli/docs/motion.doc.mjs
@@ -1,0 +1,87 @@
+/** @type {import('../../core/src/docs-types').ReferenceDoc} */
+
+export const docs = {
+  name: 'motion',
+  title: 'Motion',
+  description:
+    'Duration and easing tokens for animations and transitions.',
+  tokenCategory: 'duration',
+
+  sections: [
+    {
+      title: 'Overview',
+      content: [
+        {
+          type: 'prose',
+          text: 'XDS motion tokens define timing in three bands: fast (micro-interactions like hover/press), medium (entrance/exit), and slow (continuous/looping). Each band has a base value with min/max variants derived from a consistent ratio.',
+        },
+      ],
+    },
+    {
+      title: 'Duration',
+      content: [
+        {
+          type: 'token-ref',
+          topic: 'tokens',
+          section: 'Duration Tokens',
+        },
+      ],
+    },
+    {
+      title: 'Easing',
+      content: [
+        {
+          type: 'token-ref',
+          topic: 'tokens',
+          section: 'Easing Tokens',
+        },
+      ],
+    },
+    {
+      title: 'Usage',
+      content: [
+        {
+          type: 'code',
+          lang: 'tsx',
+          label: 'Applying motion tokens',
+          code: `import {durationVars, easeVars} from '@xds/core';
+
+const styles = stylex.create({
+  fadeIn: {
+    transitionProperty: 'opacity',
+    transitionDuration: durationVars['--duration-fast'],
+    transitionTimingFunction: easeVars['--ease-standard'],
+  },
+  slideUp: {
+    transitionProperty: 'transform, opacity',
+    transitionDuration: durationVars['--duration-medium'],
+    transitionTimingFunction: easeVars['--ease-standard'],
+  },
+});`,
+        },
+      ],
+    },
+    {
+      title: 'Best Practices',
+      content: [
+        {
+          type: 'list',
+          style: 'do',
+          items: [
+            'Use fast durations for state changes (hover, press, toggle).',
+            'Use medium durations for element entrance/exit (dialogs, dropdowns).',
+            'Use slow durations sparingly — only for continuous animations (loading spinners, progress bars).',
+          ],
+        },
+        {
+          type: 'list',
+          style: 'dont',
+          items: [
+            'Use slow durations for interactive feedback — users will perceive lag.',
+            'Skip easing on transitions — linear motion feels robotic.',
+          ],
+        },
+      ],
+    },
+  ],
+};

--- a/packages/cli/docs/shape.doc.mjs
+++ b/packages/cli/docs/shape.doc.mjs
@@ -1,0 +1,69 @@
+/** @type {import('../../core/src/docs-types').ReferenceDoc} */
+
+export const docs = {
+  name: 'shape',
+  title: 'Shape',
+  description:
+    'Border radius tokens for consistent component rounding — from sharp corners to full pills.',
+  tokenCategory: 'radius',
+
+  sections: [
+    {
+      title: 'Overview',
+      content: [
+        {
+          type: 'prose',
+          text: 'The radius scale uses a semantic naming system: inner → element → container → page. Each level is designed for a specific context. Themes can multiply the entire scale via a radius multiplier, with --radius-none and --radius-full as fixed anchors.',
+        },
+      ],
+    },
+    {
+      title: 'Radius Scale',
+      content: [
+        {
+          type: 'token-ref',
+          topic: 'tokens',
+          section: 'Radius Tokens',
+        },
+      ],
+    },
+    {
+      title: 'Concentric Radius',
+      content: [
+        {
+          type: 'prose',
+          text: 'When a rounded container has padding, inner elements need a smaller radius to appear concentric. XDS components like Card handle this automatically — the inner radius is computed as max(0, outerRadius - padding).',
+        },
+        {
+          type: 'code',
+          lang: 'css',
+          label: 'Concentric radius formula',
+          code: `/* Automatic in XDS Card */
+--card-concentric-radius: max(0px, calc(var(--_card-radius) - var(--card-padding)));`,
+        },
+      ],
+    },
+    {
+      title: 'Best Practices',
+      content: [
+        {
+          type: 'list',
+          style: 'do',
+          items: [
+            'Use --radius-element for interactive controls (buttons, inputs, selectors).',
+            'Use --radius-container for content containers (cards, panels, dialogs).',
+            'Use --radius-full for pill shapes (badges, tags, avatar status dots).',
+          ],
+        },
+        {
+          type: 'list',
+          style: 'dont',
+          items: [
+            "Use --radius-page for small elements — it's designed for page-level containers.",
+            "Hardcode radius values — they won't scale with theme radius multipliers.",
+          ],
+        },
+      ],
+    },
+  ],
+};

--- a/packages/cli/docs/spacing.doc.mjs
+++ b/packages/cli/docs/spacing.doc.mjs
@@ -1,0 +1,79 @@
+/** @type {import('../../core/src/docs-types').ReferenceDoc} */
+
+export const docs = {
+  name: 'spacing',
+  title: 'Spacing',
+  description:
+    'Spacing scale tokens for padding, gap, and margin — the rhythmic foundation of XDS layouts.',
+  tokenCategory: 'spacing',
+
+  sections: [
+    {
+      title: 'Overview',
+      content: [
+        {
+          type: 'prose',
+          text: 'XDS uses a 4px base-unit spacing scale. Component gap props accept step values that map to these tokens. The scale provides fine-grained control at the small end (2px, 4px, 6px) and consistent rhythm at larger sizes (multiples of 4px).',
+        },
+      ],
+    },
+    {
+      title: 'Scale',
+      content: [
+        {
+          type: 'token-ref',
+          topic: 'tokens',
+          section: 'Spacing Tokens',
+        },
+      ],
+    },
+    {
+      title: 'Usage',
+      content: [
+        {
+          type: 'prose',
+          text: 'Most components accept a `gap` prop using step values (0 through 12). For custom layouts, use the spacing tokens directly in StyleX.',
+        },
+        {
+          type: 'code',
+          lang: 'tsx',
+          label: 'Spacing via component props vs StyleX',
+          code: `// Via component props (preferred)
+<XDSStack gap={4}>{/* 16px gap */}</XDSStack>
+
+// Via StyleX tokens (custom layouts)
+import {spacingVars} from '@xds/core';
+
+const styles = stylex.create({
+  custom: {
+    padding: spacingVars['--spacing-4'],
+    gap: spacingVars['--spacing-3'],
+  },
+});`,
+        },
+      ],
+    },
+    {
+      title: 'Best Practices',
+      content: [
+        {
+          type: 'list',
+          style: 'do',
+          items: [
+            'Use component gap props when available — they handle automatic spacing compensation.',
+            "Stick to the scale for consistency. If a value isn't on the scale, reconsider the design.",
+            'Use smaller steps (0.5–2) for tight internal spacing and larger steps (4–8) for section gaps.',
+          ],
+        },
+        {
+          type: 'list',
+          style: 'dont',
+          items: [
+            'Use arbitrary pixel values outside the scale.',
+            'Mix spacing tokens with raw px/rem values in the same component.',
+          ],
+        },
+      ],
+    },
+  ],
+};

--- a/packages/cli/docs/tokens.doc.mjs
+++ b/packages/cli/docs/tokens.doc.mjs
@@ -417,7 +417,8 @@ export const docs = {
             ]
           ]
         }
-      ]
+      ],
+      "previewType": "swatch"
     },
     {
       "title": "Spacing Tokens",
@@ -495,7 +496,8 @@ export const docs = {
             ]
           ]
         }
-      ]
+      ],
+      "previewType": "spacing-bar"
     },
     {
       "title": "Size Tokens",
@@ -525,7 +527,8 @@ export const docs = {
             ]
           ]
         }
-      ]
+      ],
+      "previewType": "size-bar"
     },
     {
       "title": "Border Tokens",
@@ -547,7 +550,8 @@ export const docs = {
             ]
           ]
         }
-      ]
+      ],
+      "previewType": "border-line"
     },
     {
       "title": "Radius Tokens",
@@ -589,7 +593,8 @@ export const docs = {
             ]
           ]
         }
-      ]
+      ],
+      "previewType": "radius-box"
     },
     {
       "title": "Shadow Tokens",
@@ -639,7 +644,8 @@ export const docs = {
             ]
           ]
         }
-      ]
+      ],
+      "previewType": "shadow-box"
     },
     {
       "title": "Duration Tokens",
@@ -693,7 +699,8 @@ export const docs = {
             ]
           ]
         }
-      ]
+      ],
+      "previewType": "duration-bar"
     },
     {
       "title": "Easing Tokens",
@@ -715,7 +722,8 @@ export const docs = {
             ]
           ]
         }
-      ]
+      ],
+      "previewType": "easing-curve"
     },
     {
       "title": "Font Family Tokens",
@@ -745,7 +753,8 @@ export const docs = {
             ]
           ]
         }
-      ]
+      ],
+      "previewType": "font-sample"
     },
     {
       "title": "Font Size Tokens",
@@ -811,7 +820,8 @@ export const docs = {
             ]
           ]
         }
-      ]
+      ],
+      "previewType": "font-sample"
     },
     {
       "title": "Font Weight Tokens",
@@ -845,7 +855,8 @@ export const docs = {
             ]
           ]
         }
-      ]
+      ],
+      "previewType": "font-sample"
     },
     {
       "title": "Type Scale Tokens",
@@ -1031,7 +1042,8 @@ export const docs = {
             ]
           ]
         }
-      ]
+      ],
+      "previewType": "font-sample"
     },
     {
       "title": "Usage in StyleX",

--- a/packages/cli/docs/typography.doc.mjs
+++ b/packages/cli/docs/typography.doc.mjs
@@ -1,0 +1,108 @@
+/** @type {import('../../core/src/docs-types').ReferenceDoc} */
+
+export const docs = {
+  name: 'typography',
+  title: 'Typography',
+  description:
+    'Font family, size, weight, and type scale tokens for consistent text styling.',
+  tokenCategory: 'typography',
+
+  sections: [
+    {
+      title: 'Overview',
+      content: [
+        {
+          type: 'prose',
+          text: 'XDS typography uses a geometric type scale based on 14px × 1.2^step. Semantic type scale tokens (heading, body, label, code, supporting, display) compose font size, weight, and line-height into ready-to-use combinations. The XDSText component is the primary way to apply these scales.',
+        },
+      ],
+    },
+    {
+      title: 'Font Families',
+      content: [
+        {
+          type: 'token-ref',
+          topic: 'tokens',
+          section: 'Font Family Tokens',
+        },
+      ],
+    },
+    {
+      title: 'Font Sizes',
+      content: [
+        {
+          type: 'prose',
+          text: 'Geometric scale with 14px base. Each step multiplies by 1.2 and rounds to the nearest 0.0625rem.',
+        },
+        {
+          type: 'token-ref',
+          topic: 'tokens',
+          section: 'Font Size Tokens',
+        },
+      ],
+    },
+    {
+      title: 'Font Weights',
+      content: [
+        {
+          type: 'token-ref',
+          topic: 'tokens',
+          section: 'Font Weight Tokens',
+        },
+      ],
+    },
+    {
+      title: 'Type Scale',
+      content: [
+        {
+          type: 'prose',
+          text: 'Semantic tokens that combine size, weight, and line-height. Use these via XDSText variant prop rather than composing raw font tokens.',
+        },
+        {
+          type: 'token-ref',
+          topic: 'tokens',
+          section: 'Type Scale Tokens',
+        },
+      ],
+    },
+    {
+      title: 'Usage',
+      content: [
+        {
+          type: 'code',
+          lang: 'tsx',
+          label: 'Using XDSText for type scale',
+          code: `import {XDSText} from '@xds/core';
+
+// Preferred: XDSText component applies the full type scale
+<XDSText variant="heading1">Page Title</XDSText>
+<XDSText variant="body">Body text at the base scale.</XDSText>
+<XDSText variant="supporting">Smaller supporting text.</XDSText>
+<XDSText variant="code">Monospace code text.</XDSText>`,
+        },
+      ],
+    },
+    {
+      title: 'Best Practices',
+      content: [
+        {
+          type: 'list',
+          style: 'do',
+          items: [
+            'Use XDSText variant prop instead of manually composing font tokens.',
+            'Use the heading scale (1–6) for document hierarchy, not visual sizing.',
+            'Use the supporting variant for helper text, timestamps, and metadata.',
+          ],
+        },
+        {
+          type: 'list',
+          style: 'dont',
+          items: [
+            'Skip heading levels (e.g. heading1 → heading3) — screen readers rely on the hierarchy.',
+            "Use display variants for body content — they're designed for hero/marketing text.",
+          ],
+        },
+      ],
+    },
+  ],
+};

--- a/packages/cli/src/api/docs.mjs
+++ b/packages/cli/src/api/docs.mjs
@@ -57,6 +57,53 @@ async function loadReferenceDocs(docPath, {lang} = {}) {
 }
 
 /**
+ * Resolve token-ref blocks by inlining the referenced section's table.
+ * This allows section docs to reference token tables without duplicating data.
+ */
+async function resolveTokenRefs(docsData, topics) {
+  const resolved = {...docsData, sections: [...docsData.sections]};
+  for (let si = 0; si < resolved.sections.length; si++) {
+    const section = resolved.sections[si];
+    const newContent = [];
+    for (const block of section.content) {
+      if (block.type === 'token-ref') {
+        const refPath = topics[block.topic];
+        if (!refPath) {
+          newContent.push({type: 'prose', text: `[token-ref: unknown topic "${block.topic}"]`});
+          continue;
+        }
+        const refMod = await import(pathToFileURL(refPath).href);
+        const refDocs = refMod.docs;
+        const refSection = refDocs.sections.find(
+          s => s.title.toLowerCase() === block.section.toLowerCase(),
+        );
+        if (!refSection) {
+          newContent.push({type: 'prose', text: `[token-ref: section "${block.section}" not found in "${block.topic}"]`});
+          continue;
+        }
+        // Inline the referenced section's content blocks (tables, prose, etc.)
+        // and carry over the previewType
+        for (const refBlock of refSection.content) {
+          newContent.push(refBlock);
+        }
+        // If the referenced section has a previewType, attach it to our section
+        if (refSection.previewType && !section.previewType) {
+          resolved.sections[si] = {...section, previewType: refSection.previewType, content: newContent};
+        }
+      } else {
+        newContent.push(block);
+      }
+    }
+    if (resolved.sections[si] === section) {
+      resolved.sections[si] = {...section, content: newContent};
+    } else {
+      resolved.sections[si].content = newContent;
+    }
+  }
+  return resolved;
+}
+
+/**
  * @param {string} [topic]
  * @param {string} [section]
  * @param {object} [options]
@@ -106,5 +153,6 @@ export async function docs(topic, section, options = {}) {
     return {type: 'docs.detail.section', data: match};
   }
 
-  return {type: 'docs.detail', data: docsData};
+  const resolved = await resolveTokenRefs(docsData, topics);
+  return {type: 'docs.detail', data: resolved};
 }

--- a/packages/core/src/docs-types.ts
+++ b/packages/core/src/docs-types.ts
@@ -421,6 +421,7 @@ export interface TranslationDoc {
  * { type: 'code', lang: 'tsx', code: 'padding: spacingVars[...]' }
  * { type: 'table', headers: ['Token', 'Value'], rows: [['--spacing-4', '16px']] }
  * { type: 'list', style: 'do', items: ['Use semantic tokens'] }
+ * { type: 'token-ref', topic: 'tokens', section: 'Color Tokens' }
  * ```
  */
 export type ContentBlock =
@@ -431,7 +432,43 @@ export type ContentBlock =
       type: 'list';
       style: 'ordered' | 'unordered' | 'do' | 'dont';
       items: string[];
+    }
+  | {
+      /** Reference to a token table in another doc topic.
+       *  The CLI resolves this at read time and inlines the referenced
+       *  section's table. The docsite can render it with live theme values
+       *  and type-specific previews instead of static strings. */
+      type: 'token-ref';
+      /** Doc topic name containing the tokens. e.g. `'tokens'` */
+      topic: string;
+      /** Section title to pull from that topic. e.g. `'Color Tokens'` */
+      section: string;
     };
+
+/**
+ * Preview type hint for token tables. Tells the docsite how to render
+ * a visual preview column for each token row.
+ *
+ * - `'swatch'` — Color circle/square showing the token value
+ * - `'shadow-box'` — Box with the shadow applied
+ * - `'radius-box'` — Box with the border-radius applied
+ * - `'spacing-bar'` — Horizontal bar at the token's width
+ * - `'size-bar'` — Horizontal bar at the token's height
+ * - `'border-line'` — Line at the token's border-width
+ * - `'duration-bar'` — Animated bar showing the timing
+ * - `'easing-curve'` — Bezier curve visualization
+ * - `'font-sample'` — Text sample in the font family/size/weight
+ */
+export type TokenPreviewType =
+  | 'swatch'
+  | 'shadow-box'
+  | 'radius-box'
+  | 'spacing-bar'
+  | 'size-bar'
+  | 'border-line'
+  | 'duration-bar'
+  | 'easing-curve'
+  | 'font-sample';
 
 /**
  * A section within a reference doc. Sections are the primary
@@ -443,6 +480,10 @@ export interface ReferenceSection {
   title: string;
   /** Ordered content blocks. Mix prose, code, tables, and lists freely. */
   content: ContentBlock[];
+  /** Preview type for token tables in this section. When set, the docsite
+   *  renders a visual preview column using the token's computed CSS value
+   *  from the current theme. Omit for non-token sections. */
+  previewType?: TokenPreviewType;
 }
 
 /**
@@ -467,6 +508,11 @@ export interface ReferenceDoc {
   description: string;
   /** Ordered sections that make up the doc. */
   sections: ReferenceSection[];
+  /** Token category for foundational docs that map to a token section.
+   *  When set, the docsite can link from the tokens overview page
+   *  to this doc for detailed guidance on that category.
+   *  e.g. `'color'` links tokens → color foundational doc. */
+  tokenCategory?: string;
 }
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -162,4 +162,8 @@ export type {
   DerivedVar,
   TranslationDoc,
   GroupDoc,
+  ReferenceDoc,
+  ReferenceSection,
+  ContentBlock,
+  TokenPreviewType,
 } from './docs-types';

--- a/scripts/generate-token-docs.mjs
+++ b/scripts/generate-token-docs.mjs
@@ -61,6 +61,7 @@ function extractDefaults(name) {
 const groups = [
   {
     key: 'color',
+    previewType: 'swatch',
     exportName: 'colorDefaults',
     title: 'Color Tokens',
     description:
@@ -76,6 +77,7 @@ const groups = [
   },
   {
     key: 'spacing',
+    previewType: 'spacing-bar',
     exportName: 'spacingDefaults',
     title: 'Spacing Tokens',
     description:
@@ -85,6 +87,7 @@ const groups = [
   },
   {
     key: 'size',
+    previewType: 'size-bar',
     exportName: 'sizeDefaults',
     title: 'Size Tokens',
     description:
@@ -94,6 +97,7 @@ const groups = [
   },
   {
     key: 'border',
+    previewType: 'border-line',
     exportName: 'borderDefaults',
     title: 'Border Tokens',
     description: 'Border width for card and input borders.',
@@ -102,6 +106,7 @@ const groups = [
   },
   {
     key: 'radius',
+    previewType: 'radius-box',
     exportName: 'radiusDefaults',
     title: 'Radius Tokens',
     description:
@@ -111,6 +116,7 @@ const groups = [
   },
   {
     key: 'shadow',
+    previewType: 'shadow-box',
     exportName: 'shadowDefaults',
     title: 'Shadow Tokens',
     description:
@@ -120,6 +126,7 @@ const groups = [
   },
   {
     key: 'duration',
+    previewType: 'duration-bar',
     exportName: 'durationDefaults',
     title: 'Duration Tokens',
     description:
@@ -129,6 +136,7 @@ const groups = [
   },
   {
     key: 'ease',
+    previewType: 'easing-curve',
     exportName: 'easeDefaults',
     title: 'Easing Tokens',
     description: 'Easing curves for animations and transitions.',
@@ -137,6 +145,7 @@ const groups = [
   },
   {
     key: 'typography',
+    previewType: 'font-sample',
     exportName: 'typographyDefaults',
     title: 'Font Family Tokens',
     description: 'Font family stacks for body, code, and heading text.',
@@ -145,6 +154,7 @@ const groups = [
   },
   {
     key: 'textSize',
+    previewType: 'font-sample',
     exportName: 'textSizeDefaults',
     title: 'Font Size Tokens',
     description:
@@ -154,6 +164,7 @@ const groups = [
   },
   {
     key: 'fontWeight',
+    previewType: 'font-sample',
     exportName: 'fontWeightDefaults',
     title: 'Font Weight Tokens',
     description: 'Font weight values for body, emphasis, and headings.',
@@ -162,6 +173,7 @@ const groups = [
   },
   {
     key: 'typeScale',
+    previewType: 'font-sample',
     exportName: 'typeScaleDefaults',
     title: 'Type Scale Tokens',
     description:
@@ -189,7 +201,9 @@ for (const group of groups) {
     {type: 'table', headers: group.headers, rows},
   ];
 
-  sections.push({title: group.title, content});
+  const section = {title: group.title, content};
+  if (group.previewType) section.previewType = group.previewType;
+  sections.push(section);
 }
 
 // Add a usage section at the end (hand-written, not generated)


### PR DESCRIPTION
## Summary
- Centralize all URL history management in `page.tsx` — single `pushState`/`popstate` owner
- Make `DocsView` a controlled component (`selectedComponent` prop + `onComponentChange` callback) with no direct history manipulation
- Use `pushState` only for meaningful navigations (view changes, component selection, docs tab switches) and `replaceState` for minor state (sort order, filters, profile settings) so back button isn't tedious
- Reset `docsComponent` state when leaving docs view so returning starts fresh
- Parse `?page=docs&component=button` on initial load for page refresh support

## Test plan
- [ ] Navigate to docs view, click a component (e.g. Button), press browser back — should return to docs home
- [ ] Click through several components, use back/forward — each step should restore correctly
- [ ] Navigate from docs to craft view and back — docs should start at home, not last visited component
- [ ] Refresh on `?page=docs&component=button` — should land on Button component page
- [ ] Click rapidly between components — back button should not require excessive clicks (minor state uses replaceState)
- [ ] Navigate to template preview/editor, use back — should return to previous view