### PR TITLE
fix(button): remove automatic edge compensation from ghost buttons

### DIFF
--- a/packages/core/src/Button/XDSButton.tsx
+++ b/packages/core/src/Button/XDSButton.tsx
@@ -32,7 +32,6 @@ import {
 import {XDSTooltip} from '../Tooltip/XDSTooltip';
 import {XDSSpinner} from '../Spinner';
 
-import {edgeCompensation} from '../Layout/edgeCompensation.stylex';
 import {useXDSSize} from '../SizeContext/XDSSizeContext';
 import {xdsClassName, mergeProps} from '../utils';
 import {useXDSLinkComponent} from '../Link/useXDSLinkComponent';
@@ -488,12 +487,6 @@ export function XDSButton({
       }
     : undefined;
 
-  // Ghost buttons opt into edge compensation — they pull back at container
-  // edges via negative margin when placed as first/last child in a slot
-  // that sets --edge-inset-start/--edge-inset-end.
-  const isFlat = variant === 'ghost';
-  const edgeCompStyle = isFlat ? edgeCompensation.item : null;
-
   // Shared StyleX props for both button and link rendering
   const sharedStylexProps = stylex.props(
     styles.base,
@@ -503,7 +496,6 @@ export function XDSButton({
     buttonDisabled && styles.disabled,
     useAriaDisabled && styles.ariaDisabled,
     isLoadingState && loadingStyles.loading,
-    edgeCompStyle,
     renderAsLink && styles.link,
     xstyle,
   );


### PR DESCRIPTION
Ghost buttons were automatically applying `edgeCompensation.item`, which adds negative margins (e.g. -8px) when placed as first/last child inside containers that set `--edge-inset-start`/`--edge-inset-end` (like Toolbar).

This removes the automatic edge compensation opt-in from `XDSButton`.

**Scan results — edge compensation is NOT fully dead code:**

| Consumer | Uses `edgeCompensation.item`? | Status |
|----------|-------------------------------|--------|
| `XDSButton` (ghost) | Was applying it | Removed in this PR |
| `XDSTab` | Still applying it | Active — keeps tab edge compensation in Toolbar |
| `XDSToolbar` | Sets `--edge-inset-start/end` on slots | Active — the container side is live |

| Export | Used? |
|--------|-------|
| `edgeCompensation.item` | Yes — by XDSTab (and was by XDSButton) |
| `edgeInset` presets (start1–5, end1–5) | Unused — Toolbar uses its own dynamic `edgeInsetStyles` instead |

The `edgeInset` named presets exported from `edgeCompensation.stylex.ts` are dead code — no component imports them. Could be cleaned up in a follow-up.