### PR TITLE
fix(cli): support hyphenated filenames in docs topic discovery

### DIFF
--- a/packages/cli/src/api/docs.mjs
+++ b/packages/cli/src/api/docs.mjs
@@ -14,7 +14,7 @@ function discoverTopics() {
   const topics = {};
   if (!fs.existsSync(DOCS_DIR)) return topics;
   for (const file of fs.readdirSync(DOCS_DIR)) {
-    const match = file.match(/^(\w+)\.doc\.mjs$/);
+    const match = file.match(/^([\w-]+)\.doc\.mjs$/);
     if (match) topics[match[1]] = path.join(DOCS_DIR, file);
   }
   return topics;

--- a/packages/cli/src/commands/docs.test.mjs
+++ b/packages/cli/src/commands/docs.test.mjs
@@ -49,3 +49,32 @@ describe('registerDocs', () => {
     expect(errorOutput).toContain('Unknown topic');
   });
 });
+
+describe('hyphenated doc filenames', () => {
+  it('lists hyphenated topics like cli-reference', async () => {
+    const program = createProgram();
+    await program.parseAsync(['node', 'xds', 'docs']);
+
+    const output = console.log.mock.calls.map(c => c[0]).join('\n');
+    expect(output).toContain('cli-reference');
+    expect(output).toContain('getting-started');
+  });
+
+  it('loads a hyphenated topic by name', async () => {
+    const program = createProgram();
+    await program.parseAsync(['node', 'xds', 'docs', 'cli-reference']);
+
+    const output = console.log.mock.calls.map(c => c[0]).join('\n');
+    // cli-reference doc should have real content, not an error
+    expect(output.length).toBeGreaterThan(0);
+    expect(console.error).not.toHaveBeenCalled();
+  });
+
+  it('returns docs.detail via API for hyphenated topic', async () => {
+    const {docs: docsApi} = await import('../api/docs.mjs');
+    const result = await docsApi('cli-reference');
+    expect(result.type).toBe('docs.detail');
+    expect(result.data).toBeDefined();
+    expect(result.data.description).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Problem

`discoverTopics()` in `packages/cli/src/api/docs.mjs` uses `\w+` to match doc filenames, which only covers `[a-zA-Z0-9_]`. Any `.doc.mjs` file with a hyphen in its name is silently skipped.

Two existing docs are affected:
- `cli-reference.doc.mjs`
- `getting-started.doc.mjs`

## Fix

One-character regex change on line 17:

```diff
- const match = file.match(/^(\w+)\.doc\.mjs$/);
+ const match = file.match(/^([\w-]+)\.doc\.mjs$/);
```

## Test Plan

### 1. Before/after: `npx xds docs` topic listing

**Before** (on `main`, with `\w+`) — 11 topics, both hyphenated files missing:

```
Available docs:

  color          Semantic color tokens for surfaces, text, icons, borders, and status indicators.
  elevation      Shadow tokens for visual elevation and inset state rings.
  icons          Semantic icon names available in XDS. These adapt to the active theme icon registry.
  motion         Duration and easing tokens for animations and transitions.
  principles     Design principles, rules, and anti-patterns for XDS.
  shape          Border radius tokens for consistent component rounding — from sharp corners to full pills.
  spacing        Spacing scale tokens for padding, gap, and margin — the rhythmic foundation of XDS layouts.
  styling        How to customize component appearance: xstyle prop, className, rest props, compound component patterns, and theming hooks.
  theme          XDSTheme provider, custom themes, theme build for production/SSR, light/dark mode, and component style overrides.
  tokens         Complete reference for spacing, color, radius, typography, shadow, motion, and size tokens.
  typography     Font families, geometric type scale, weight, line-height, and semantic text tokens for consistent, accessible text styling.
```

**After** (with `[\w-]+`) — 13 topics, `cli-reference` and `getting-started` now appear:

```
Available docs:

  cli-reference  Complete command reference for the XDS CLI — every command, flag, and argument.
  color          Semantic color tokens for surfaces, text, icons, borders, and status indicators.
  elevation      Shadow tokens for visual elevation and inset state rings.
  getting-started Go from zero to a working XDS app in five steps.
  icons          Semantic icon names available in XDS. These adapt to the active theme icon registry.
  motion         Duration and easing tokens for animations and transitions.
  principles     Design principles, rules, and anti-patterns for XDS.
  shape          Border radius tokens for consistent component rounding — from sharp corners to full pills.
  spacing        Spacing scale tokens for padding, gap, and margin — the rhythmic foundation of XDS layouts.
  styling        How to customize component appearance: xstyle prop, className, rest props, compound component patterns, and theming hooks.
  theme          XDSTheme provider, custom themes, theme build for production/SSR, light/dark mode, and component style overrides.
  tokens         Complete reference for spacing, color, radius, typography, shadow, motion, and size tokens.
  typography     Font families, geometric type scale, weight, line-height, and semantic text tokens for consistent, accessible text styling.
```

### 2. `npx xds docs cli-reference` — loads full content

```
# CLI Reference

Complete command reference for the XDS CLI — every command, flag, and argument.

## Overview

The XDS CLI (`npx xds` or `npx @xds/cli`) provides tools for scaffolding, theming,
component discovery, documentation, upgrades, and gap reporting. All commands support
`--help` for inline usage.

## Global Options

These flags apply to any command that outputs documentation or reference content.

- `--zh` — Output docs in Chinese Simplified
- `--dense` — Output docs in compressed dense format (token-efficient)
- `--lang <locale>` — Output docs in specified language/format (en, zh, dense)
- `--detail <level>` — Output detail level: full, compact, or brief (default: full)
- `--json` — Output as typed JSON envelope: `{ type, data }`

## init

Initialize XDS in your project. Installs packages, sets up theming, and optionally
adds AI agent docs for Claude, Cursor, or Codex.

...
```

### 3. `npx xds docs getting-started` — loads full content

```
# Getting Started

Go from zero to a working XDS app in five steps.

## Install the CLI

Use the XDS CLI to scaffold a new app. It wires up Next.js, the design system,
and a working theme out of the box.

## Pick a theme

Choose between the default theme and the neutral theme...

## Add your first component

XDS components are imported from per-category subpath entrypoints...

...
```

### 4. Existing topics still work: `npx xds docs tokens`

```
# XDS Design Tokens

Complete reference for spacing, color, radius, typography, shadow, motion, and size tokens.

## Color Tokens

Semantic colors for consistent theming. All colors use light-dark() for automatic mode switching.

Token                             | Light       | Dark
--------------------------------- | ----------- | -----------
--color-accent                    | #0064E0     | #2694FE
--color-accent-muted              | #0082FB33   | #0082FB3F
--color-on-accent                 | #FFFFFF     | #FFFFFF
...
```

### 5. Unit tests (all 5 pass — 2 existing + 3 new)

```
$ npx vitest run packages/cli/src/commands/docs.test.mjs --no-coverage

✓ packages/cli/src/commands/docs.test.mjs (5 tests) 105ms

 Test Files  1 passed (1)
      Tests  5 passed (5)
```

New tests:
- **lists hyphenated topics** — asserts `cli-reference` and `getting-started` appear in `xds docs` output
- **loads hyphenated topic by name** — `xds docs cli-reference` produces output, no errors
- **API returns valid envelope** — `docs("cli-reference")` returns `{type: "docs.detail", data: {description: ...}}`