### PR TITLE
feat(cli): add missing component showcases

### DIFF
--- a/packages/cli/templates/blocks/components/AppShell/AppShellShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/AppShell/AppShellShowcase.doc.mjs
@@ -5,4 +5,7 @@ export const doc = {
   isReady: true,
   aspectRatio: 4 / 3,
   isShowcase: true,
+  description:
+    'A basic app shell with content padding.',
+  componentsUsed: ['AppShell', 'Text'],
 };

--- a/packages/cli/templates/blocks/components/AspectRatio/AspectRatioShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/AspectRatio/AspectRatioShowcase.doc.mjs
@@ -5,4 +5,7 @@ export const doc = {
   isReady: true,
   aspectRatio: 4 / 3,
   isShowcase: true,
+  description:
+    'Three aspect ratio containers: 1:1, 4:3, and 16:9.',
+  componentsUsed: ['AspectRatio', 'Center', 'Layout', 'Text'],
 };

--- a/packages/cli/templates/blocks/components/AspectRatio/AspectRatioShowcase.tsx
+++ b/packages/cli/templates/blocks/components/AspectRatio/AspectRatioShowcase.tsx
@@ -1,22 +1,47 @@
 'use client';
 
+import * as stylex from '@stylexjs/stylex';
 import {XDSAspectRatio} from '@xds/core/AspectRatio';
+import {XDSCenter} from '@xds/core/Center';
+import {XDSHStack} from '@xds/core/Layout';
+import {XDSText} from '@xds/core/Text';
+import {colorVars, radiusVars} from '@xds/core/theme/tokens.stylex';
+
+const s = stylex.create({
+  square: {width: 120},
+  fourThree: {width: 160},
+  widescreen: {width: 200},
+  box: {
+    backgroundColor: colorVars['--color-background-muted'],
+    border: `1px solid ${colorVars['--color-border']}`,
+    borderRadius: radiusVars['--radius-container'],
+  },
+});
 
 export default function AspectRatioShowcase() {
   return (
-    <XDSAspectRatio ratio={16 / 9}>
-      <div
-        style={{
-          width: '100%',
-          height: '100%',
-          backgroundColor: '#e5e7eb',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          borderRadius: 8,
-        }}>
-        16:9
-      </div>
-    </XDSAspectRatio>
+    <XDSHStack gap={4} vAlign="start">
+      <XDSAspectRatio ratio={1} xstyle={[s.square, s.box]}>
+        <XDSCenter width="100%" height="100%">
+          <XDSText type="supporting" color="secondary">
+            1 : 1
+          </XDSText>
+        </XDSCenter>
+      </XDSAspectRatio>
+      <XDSAspectRatio ratio={4 / 3} xstyle={[s.fourThree, s.box]}>
+        <XDSCenter width="100%" height="100%">
+          <XDSText type="supporting" color="secondary">
+            4 : 3
+          </XDSText>
+        </XDSCenter>
+      </XDSAspectRatio>
+      <XDSAspectRatio ratio={16 / 9} xstyle={[s.widescreen, s.box]}>
+        <XDSCenter width="100%" height="100%">
+          <XDSText type="supporting" color="secondary">
+            16 : 9
+          </XDSText>
+        </XDSCenter>
+      </XDSAspectRatio>
+    </XDSHStack>
   );
 }

--- a/packages/cli/templates/blocks/components/FormLayout/FormLayoutShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/FormLayout/FormLayoutShowcase.doc.mjs
@@ -5,4 +5,7 @@ export const doc = {
   isReady: true,
   aspectRatio: 1,
   isShowcase: true,
+  description:
+    'A vertical form layout with text input fields.',
+  componentsUsed: ['FormLayout', 'TextInput'],
 };

--- a/packages/cli/templates/blocks/components/IconButton/IconButtonShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/IconButton/IconButtonShowcase.doc.mjs
@@ -5,4 +5,7 @@ export const doc = {
   isReady: true,
   aspectRatio: 1,
   isShowcase: true,
+  description:
+    'An icon button with a wrench icon.',
+  componentsUsed: ['IconButton', 'Icon'],
 };

--- a/packages/cli/templates/blocks/components/Link/LinkShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/Link/LinkShowcase.doc.mjs
@@ -5,4 +5,7 @@ export const doc = {
   isReady: true,
   aspectRatio: 1,
   isShowcase: true,
+  description:
+    'A standalone link.',
+  componentsUsed: ['Link'],
 };

--- a/packages/cli/templates/blocks/components/Markdown/MarkdownShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/Markdown/MarkdownShowcase.doc.mjs
@@ -5,4 +5,7 @@ export const doc = {
   isReady: true,
   aspectRatio: 1,
   isShowcase: true,
+  description:
+    'Rich markdown content with headings, lists, and formatting.',
+  componentsUsed: ['Markdown'],
 };

--- a/packages/cli/templates/blocks/components/NumberInput/NumberInputShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/NumberInput/NumberInputShowcase.doc.mjs
@@ -5,4 +5,7 @@ export const doc = {
   isReady: true,
   aspectRatio: 1,
   isShowcase: true,
+  description:
+    'A number input for quantity entry.',
+  componentsUsed: ['NumberInput'],
 };

--- a/packages/cli/templates/blocks/components/OverflowList/OverflowListShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/OverflowList/OverflowListShowcase.doc.mjs
@@ -5,4 +5,7 @@ export const doc = {
   isReady: true,
   aspectRatio: 1,
   isShowcase: true,
+  description:
+    'A list of buttons that collapses overflowing items into a +N indicator.',
+  componentsUsed: ['OverflowList', 'Button'],
 };

--- a/packages/cli/templates/blocks/components/ProgressBar/ProgressBarShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/ProgressBar/ProgressBarShowcase.doc.mjs
@@ -5,4 +5,7 @@ export const doc = {
   isReady: true,
   aspectRatio: 1,
   isShowcase: true,
+  description:
+    'A progress bar filled to 60%.',
+  componentsUsed: ['ProgressBar'],
 };

--- a/packages/cli/templates/blocks/components/Resizable/ResizableShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/Resizable/ResizableShowcase.doc.mjs
@@ -1,0 +1,11 @@
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  name: 'Resizable',
+  description:
+    'Horizontal resizable split with a draggable handle between two panels.',
+  isReady: true,
+  isShowcase: true,
+  aspectRatio: 16 / 9,
+  componentsUsed: ['Resizable', 'Card', 'Layout', 'Text'],
+};

--- a/packages/cli/templates/blocks/components/Resizable/ResizableShowcase.tsx
+++ b/packages/cli/templates/blocks/components/Resizable/ResizableShowcase.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import {useXDSResizable, XDSResizeHandle} from '@xds/core/Resizable';
+import {
+  XDSCard,
+  XDSLayout,
+  XDSLayoutContent,
+  XDSLayoutPanel,
+  XDSVStack,
+} from '@xds/core/Layout';
+import {XDSText, XDSHeading} from '@xds/core/Text';
+
+export default function ResizableShowcase() {
+  const sidebar = useXDSResizable({
+    defaultSize: 200,
+    minSizePx: 120,
+    maxSizePx: 400,
+  });
+
+  return (
+    <XDSCard variant="muted" height={280}>
+      <XDSLayout
+        height="fill"
+        start={
+          <>
+            <XDSLayoutPanel width={sidebar.size} hasDivider={false}>
+              <XDSVStack gap={2}>
+                <XDSHeading level={4}>Sidebar</XDSHeading>
+                <XDSText color="secondary">
+                  {Math.round(sidebar.size)}px wide
+                </XDSText>
+              </XDSVStack>
+            </XDSLayoutPanel>
+            <XDSResizeHandle
+              direction="horizontal"
+              hasDivider
+              resizable={sidebar.props}
+              label="Resize sidebar"
+            />
+          </>
+        }
+        content={
+          <XDSLayoutContent>
+            <XDSVStack gap={2}>
+              <XDSHeading level={4}>Content</XDSHeading>
+              <XDSText color="secondary">
+                Drag the handle to resize the sidebar.
+              </XDSText>
+            </XDSVStack>
+          </XDSLayoutContent>
+        }
+      />
+    </XDSCard>
+  );
+}

--- a/packages/cli/templates/blocks/components/Skeleton/SkeletonShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/Skeleton/SkeletonShowcase.doc.mjs
@@ -5,4 +5,7 @@ export const doc = {
   isReady: true,
   aspectRatio: 1,
   isShowcase: true,
+  description:
+    'A skeleton loading placeholder.',
+  componentsUsed: ['Skeleton'],
 };

--- a/packages/cli/templates/blocks/components/Slider/SliderShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/Slider/SliderShowcase.doc.mjs
@@ -5,4 +5,7 @@ export const doc = {
   isReady: true,
   aspectRatio: 1,
   isShowcase: true,
+  description:
+    'A slider control set to 50%.',
+  componentsUsed: ['Slider'],
 };

--- a/packages/cli/templates/blocks/components/Spinner/SpinnerShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/Spinner/SpinnerShowcase.doc.mjs
@@ -5,4 +5,7 @@ export const doc = {
   isReady: true,
   aspectRatio: 1,
   isShowcase: true,
+  description:
+    'A large spinner indicator.',
+  componentsUsed: ['Spinner'],
 };

--- a/packages/cli/templates/blocks/components/StatusDot/StatusDotShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/StatusDot/StatusDotShowcase.doc.mjs
@@ -5,4 +5,7 @@ export const doc = {
   isReady: true,
   aspectRatio: 1,
   isShowcase: true,
+  description:
+    'A positive status dot indicator.',
+  componentsUsed: ['StatusDot'],
 };

--- a/packages/cli/templates/blocks/components/Switch/SwitchShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/Switch/SwitchShowcase.doc.mjs
@@ -5,4 +5,7 @@ export const doc = {
   isReady: true,
   aspectRatio: 1,
   isShowcase: true,
+  description:
+    'A toggle switch for enabling notifications.',
+  componentsUsed: ['Switch'],
 };

--- a/packages/cli/templates/blocks/components/TextArea/TextAreaShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/TextArea/TextAreaShowcase.doc.mjs
@@ -5,4 +5,7 @@ export const doc = {
   isReady: true,
   aspectRatio: 1,
   isShowcase: true,
+  description:
+    'A text area with placeholder text.',
+  componentsUsed: ['TextArea'],
 };

--- a/packages/cli/templates/blocks/components/Thumbnail/ThumbnailShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/Thumbnail/ThumbnailShowcase.doc.mjs
@@ -5,4 +5,7 @@ export const doc = {
   isReady: true,
   aspectRatio: 16 / 9,
   isShowcase: true,
+  description:
+    'A thumbnail with an image and label.',
+  componentsUsed: ['Thumbnail'],
 };

--- a/packages/cli/templates/blocks/components/TimeInput/TimeInputShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/TimeInput/TimeInputShowcase.doc.mjs
@@ -5,4 +5,7 @@ export const doc = {
   isReady: true,
   aspectRatio: 16 / 9,
   isShowcase: true,
+  description:
+    'A time input field.',
+  componentsUsed: ['TimeInput'],
 };

--- a/packages/cli/templates/blocks/components/Tokenizer/TokenizerShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/Tokenizer/TokenizerShowcase.doc.mjs
@@ -5,4 +5,7 @@ export const doc = {
   isReady: true,
   aspectRatio: 4 / 3,
   isShowcase: true,
+  description:
+    'A tokenizer with preset tags and search source.',
+  componentsUsed: ['Tokenizer'],
 };


### PR DESCRIPTION
Adds the Resizable showcase block (the only component completely missing a showcase) and adds `componentsUsed` + `description` metadata to 18 existing showcase doc.mjs files that were missing them.

## Components
AppShell, AspectRatio, FormLayout, IconButton, Link, Markdown, NumberInput, OverflowList, ProgressBar, Resizable, Skeleton, Slider, Spinner, StatusDot, Switch, TextArea, Thumbnail, TimeInput, Tokenizer

## What changed
- Created `ResizableShowcase.tsx` + `ResizableShowcase.doc.mjs` (new directory)
- Added `componentsUsed` and `description` to 18 existing showcase doc.mjs files
- All follow the existing showcase pattern (isShowcase: true, componentsUsed, aspectRatio)
- Verified all 19 doc.mjs files parse correctly