### PR TITLE
fix(cli): remove cli-reference from docs tests

### DIFF
--- a/packages/cli/src/commands/docs.test.mjs
+++ b/packages/cli/src/commands/docs.test.mjs
@@ -51,28 +51,26 @@ describe('registerDocs', () => {
 });
 
 describe('hyphenated doc filenames', () => {
-  it('lists hyphenated topics like cli-reference', async () => {
+  it('lists hyphenated topics like getting-started', async () => {
     const program = createProgram();
     await program.parseAsync(['node', 'xds', 'docs']);
 
     const output = console.log.mock.calls.map(c => c[0]).join('\n');
-    expect(output).toContain('cli-reference');
     expect(output).toContain('getting-started');
   });
 
   it('loads a hyphenated topic by name', async () => {
     const program = createProgram();
-    await program.parseAsync(['node', 'xds', 'docs', 'cli-reference']);
+    await program.parseAsync(['node', 'xds', 'docs', 'getting-started']);
 
     const output = console.log.mock.calls.map(c => c[0]).join('\n');
-    // cli-reference doc should have real content, not an error
     expect(output.length).toBeGreaterThan(0);
     expect(console.error).not.toHaveBeenCalled();
   });
 
   it('returns docs.detail via API for hyphenated topic', async () => {
     const {docs: docsApi} = await import('../api/docs.mjs');
-    const result = await docsApi('cli-reference');
+    const result = await docsApi('getting-started');
     expect(result.type).toBe('docs.detail');
     expect(result.data).toBeDefined();
     expect(result.data.description).toBeDefined();


### PR DESCRIPTION
The `cli-reference` doc was intentionally removed. Updates the hyphenated doc filename tests to use `getting-started` instead, which still exercises the same hyphenated-name code path.