### PR TITLE
feat(cli): discover showcases from external packages

### DIFF
--- a/packages/cli/src/api/component.mjs
+++ b/packages/cli/src/api/component.mjs
@@ -192,7 +192,7 @@ export async function component(name, options = {}) {
   }
 
   if (showcase) {
-    const match = await findShowcase(dirName);
+    const match = await findShowcase(dirName, cwd);
     if (!match) {
       throw new XDSError(`No showcase found for "${name}"`);
     }

--- a/packages/cli/src/api/component.mjs
+++ b/packages/cli/src/api/component.mjs
@@ -10,6 +10,7 @@ import {findCoreDir, discoverExternalPackages} from '../utils/paths.mjs';
 import {
   discoverComponents,
   discoverExternalComponents,
+  discoverExternalComponentsGrouped,
   findComponentReadme,
   findComponentSource,
   findExternalComponentDoc,
@@ -21,11 +22,23 @@ import {XDSError} from './error.mjs';
 import {findShowcase, findRelatedBlocks} from './template.mjs';
 
 /**
+ * Resolve an external package by name from the discovered externals list.
+ * @param {string} packageName - e.g. '@nest/xds-common'
+ * @param {string} cwd
+ * @returns {{ name: string, category: string, docsDir: string } | null}
+ */
+function resolveExternalPackage(packageName, cwd) {
+  const externals = discoverExternalPackages(cwd);
+  return externals.find(ext => ext.name === packageName) ?? null;
+}
+
+/**
  * @param {string} [name]
  * @param {object} [options]
  * @param {string} [options.cwd]
  * @param {boolean} [options.list]
  * @param {string} [options.category]
+ * @param {string} [options.package] - Scope to a specific external package (e.g. '@nest/xds-common')
  * @param {boolean} [options.props]
  * @param {boolean} [options.source]
  * @param {boolean} [options.showcase]
@@ -41,6 +54,7 @@ export async function component(name, options = {}) {
     cwd = process.cwd(),
     list = false,
     category,
+    package: packageScope,
     props = false,
     source = false,
     showcase = false,
@@ -93,7 +107,7 @@ export async function component(name, options = {}) {
       return {type: 'component.list', data: {[match[0]]: match[1]}};
     }
 
-    // All components
+    // All components — merge core + external packages with grouped subcategories
     if (detail === 'brief') {
       /** @type {Record<string, Array<import('../types/component').ComponentBriefEntry>>} */
       const result = {};
@@ -118,9 +132,26 @@ export async function component(name, options = {}) {
 
     const externals = discoverExternalPackages(cwd);
     for (const ext of externals) {
-      const extComps = discoverExternalComponents(ext.docsDir);
-      if (extComps.length > 0) {
-        components[`${ext.category} (${ext.name})`] = extComps;
+      const grouped = discoverExternalComponentsGrouped(ext.docsDir);
+      const groupKeys = Object.keys(grouped);
+      if (groupKeys.length === 0) continue;
+
+      // If the package has subcategories (groups), emit each as a separate key.
+      // If no groups exist, fall back to the flat list under one key.
+      const hasGroups = groupKeys.some(
+        k => grouped[k].length > 1 || grouped[k][0] !== k,
+      );
+
+      if (hasGroups) {
+        for (const [group, members] of Object.entries(grouped)) {
+          components[`${group} (${ext.name})`] = members;
+        }
+      } else {
+        // All ungrouped — single flat list under the package category
+        const allComps = Object.values(grouped).flat().sort();
+        if (allComps.length > 0) {
+          components[`${ext.category} (${ext.name})`] = allComps;
+        }
       }
     }
     return {type: 'component.list', data: components};
@@ -129,6 +160,28 @@ export async function component(name, options = {}) {
   // ── Single component ───────────────────────────────────────────
 
   const dirName = name.replace(/^XDS/, '');
+
+  // When scoped to a specific package, search that package first.
+  // This is critical for components that exist in both core and an external
+  // package (e.g. AppShell, Button, SideNav) — the package scope ensures
+  // the external package's docs are returned, not core's.
+  if (packageScope) {
+    const ext = resolveExternalPackage(packageScope, cwd);
+    if (!ext) {
+      throw new XDSError(`External package "${packageScope}" not found`);
+    }
+    const extDocPath = findExternalComponentDoc(ext.docsDir, dirName);
+    if (extDocPath && extDocPath.endsWith('.doc.mjs')) {
+      const docs = await loadDocs(extDocPath, {zh, dense, lang});
+
+      if (props) {
+        const p = docs.props || (docs.components ? docs.components.flatMap(c => c.props || []) : []);
+        return {type: 'component.detail.props', data: p};
+      }
+      return {type: 'component.detail', data: docs};
+    }
+    throw new XDSError(`No component "${name}" in package "${packageScope}"`);
+  }
 
   if (source) {
     const sourcePath = findComponentSource(coreDir, dirName);

--- a/packages/cli/src/api/template.mjs
+++ b/packages/cli/src/api/template.mjs
@@ -4,7 +4,7 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import {CLI_ROOT} from '../utils/paths.mjs';
+import {CLI_ROOT, discoverExternalPackages} from '../utils/paths.mjs';
 import {XDSError} from './error.mjs';
 import {loadConfig} from '../lib/config.mjs';
 
@@ -91,16 +91,67 @@ async function discoverBlocks() {
   return blocks;
 }
 
+/**
+ * Discover blocks from external packages that declare `xds.showcases`.
+ * Same shape as discoverBlocks() output.
+ *
+ * @param {string} [cwd]
+ */
+async function discoverExternalBlocks(cwd = process.cwd()) {
+  const externals = discoverExternalPackages(cwd);
+  const blocks = [];
+
+  for (const ext of externals) {
+    if (!ext.showcasesDir || !fs.existsSync(ext.showcasesDir)) continue;
+    const docFiles = findDocFiles(ext.showcasesDir, /\.doc\.mjs$/);
+    for (const docPath of docFiles) {
+      const basename = path.basename(docPath, '.doc.mjs');
+      const tsxPath = path.join(path.dirname(docPath), basename + '.tsx');
+      if (!fs.existsSync(tsxPath)) continue;
+      const doc = await loadDocModule(docPath);
+      const relPath = path.relative(ext.showcasesDir, path.dirname(docPath));
+      blocks.push({
+        type: 'block',
+        dirName: basename,
+        name: doc?.name || basename,
+        description: doc?.description || '',
+        isReady: doc?.isReady ?? true,
+        aspectRatio: doc?.aspectRatio ?? 1,
+        componentsUsed: doc?.componentsUsed ?? [],
+        isShowcase: doc?.isShowcase ?? false,
+        filePath: tsxPath,
+        docPath,
+        category: relPath,
+        package: ext.name,
+      });
+    }
+  }
+
+  return blocks;
+}
+
+/**
+ * Discover all blocks — core + external packages.
+ * @param {string} [cwd]
+ */
+async function discoverAllBlocks(cwd = process.cwd()) {
+  const [core, external] = await Promise.all([
+    discoverBlocks(),
+    discoverExternalBlocks(cwd),
+  ]);
+  return [...core, ...external];
+}
+
 async function discoverAll() {
   const [pages, blocks] = await Promise.all([
     discoverPages(),
-    discoverBlocks(),
+    discoverAllBlocks(),
   ]);
   return [...pages, ...blocks].sort((a, b) => a.name.localeCompare(b.name));
 }
 
-export async function findRelatedBlocks(componentName) {
-  const blocks = await discoverBlocks();
+export async function findRelatedBlocks(componentName, cwd) {
+  const blocks = await discoverAllBlocks(cwd);
   return blocks.filter(b =>
     b.componentsUsed.some(c =>
       c.toLowerCase() === componentName.toLowerCase(),
@@ -108,8 +159,8 @@ export async function findRelatedBlocks(componentName) {
   );
 }
 
-export async function findShowcase(componentName) {
-  const blocks = await discoverBlocks();
+export async function findShowcase(componentName, cwd) {
+  const blocks = await discoverAllBlocks(cwd);
   const lc = componentName.toLowerCase();
   const showcases = blocks.filter(b => b.isShowcase);
 

--- a/packages/cli/src/api/template.mjs
+++ b/packages/cli/src/api/template.mjs
@@ -92,7 +92,7 @@ async function discoverBlocks() {
 }
 
 /**
- * Discover blocks from external packages that declare `xds.showcases`.
+ * Discover blocks from external packages that declare `xds.blocks`.
  * Same shape as discoverBlocks() output.
  *
  * @param {string} [cwd]
@@ -102,14 +102,14 @@ async function discoverExternalBlocks(cwd = process.cwd()) {
   const blocks = [];
 
   for (const ext of externals) {
-    if (!ext.showcasesDir || !fs.existsSync(ext.showcasesDir)) continue;
-    const docFiles = findDocFiles(ext.showcasesDir, /\.doc\.mjs$/);
+    if (!ext.blocksDir || !fs.existsSync(ext.blocksDir)) continue;
+    const docFiles = findDocFiles(ext.blocksDir, /\.doc\.mjs$/);
     for (const docPath of docFiles) {
       const basename = path.basename(docPath, '.doc.mjs');
       const tsxPath = path.join(path.dirname(docPath), basename + '.tsx');
       if (!fs.existsSync(tsxPath)) continue;
       const doc = await loadDocModule(docPath);
-      const relPath = path.relative(ext.showcasesDir, path.dirname(docPath));
+      const relPath = path.relative(ext.blocksDir, path.dirname(docPath));
       blocks.push({
         type: 'block',
         dirName: basename,

--- a/packages/cli/src/commands/component-package.test.mjs
+++ b/packages/cli/src/commands/component-package.test.mjs
@@ -1,0 +1,95 @@
+import {describe, it, expect, beforeEach, afterEach} from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import {component} from '../api/component.mjs';
+
+// These tests create a minimal monorepo fixture with:
+// - packages/core (symlinked to real @xds/core for loadDocs compatibility)
+// - node_modules/@test/ext with a Button + Employee component (external package)
+//
+// This tests the --package option for disambiguating overlapping component names.
+
+let tmpDir;
+
+function createFixture() {
+  // Symlink real core package so loadDocs (dynamic import) works with Vite
+  const realCoreDir = path.resolve(import.meta.dirname, '..', '..', '..', 'core');
+  const coreDir = path.join(tmpDir, 'packages', 'core');
+  fs.mkdirSync(path.dirname(coreDir), {recursive: true});
+  fs.symlinkSync(realCoreDir, coreDir);
+
+  // External package with Button (different docs) + Employee (unique)
+  const extDir = path.join(tmpDir, 'node_modules', '@test', 'ext');
+  const extSrc = path.join(extDir, 'src');
+  fs.mkdirSync(path.join(extSrc, 'Button'), {recursive: true});
+  fs.mkdirSync(path.join(extSrc, 'Employee'), {recursive: true});
+  fs.writeFileSync(path.join(extDir, 'package.json'), JSON.stringify({
+    name: '@test/ext',
+    xds: {docs: './src', category: 'Common'},
+  }));
+  fs.writeFileSync(path.join(extSrc, 'Button', 'Button.doc.mjs'), `
+export const docs = {
+  name: 'XDSCommonButton',
+  usage: { description: 'Common button with platform features.' },
+  props: [{ name: 'label', type: 'string', description: 'Button label' }, { name: 'isLoading', type: 'boolean', description: 'Shows spinner' }],
+};
+`);
+  fs.writeFileSync(path.join(extSrc, 'Employee', 'Employee.doc.mjs'), `
+export const docs = {
+  name: 'XDSCommonEmployee',
+  usage: { description: 'Employee profile component.' },
+  props: [{ name: 'employeeId', type: 'string', description: 'Employee FBID' }],
+};
+`);
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'xds-pkg-test-'));
+  createFixture();
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, {recursive: true, force: true});
+});
+
+describe('component() with --package option', () => {
+  it('returns external package docs when --package is specified', async () => {
+    const result = await component('Button', {cwd: tmpDir, package: '@test/ext'});
+    expect(result.type).toBe('component.detail');
+    expect(result.data.name).toBe('XDSCommonButton');
+    expect(result.data.usage.description).toContain('platform features');
+  });
+
+  it('returns core docs when no --package is specified (default behavior)', async () => {
+    const result = await component('Button', {cwd: tmpDir});
+    expect(result.type).toBe('component.detail');
+    // Core's Button doc has name 'Button', not 'XDSCommonButton'
+    expect(result.data.name).toBe('Button');
+  });
+
+  it('resolves unique external components without --package', async () => {
+    const result = await component('Employee', {cwd: tmpDir});
+    expect(result.type).toBe('component.detail');
+    expect(result.data.name).toBe('XDSCommonEmployee');
+  });
+
+  it('returns props for package-scoped component', async () => {
+    const result = await component('Button', {cwd: tmpDir, package: '@test/ext', props: true});
+    expect(result.type).toBe('component.detail.props');
+    expect(result.data).toHaveLength(2);
+    expect(result.data.some(p => p.name === 'isLoading')).toBe(true);
+  });
+
+  it('throws for unknown package name', async () => {
+    await expect(
+      component('Button', {cwd: tmpDir, package: '@test/nonexistent'}),
+    ).rejects.toThrow('not found');
+  });
+
+  it('throws for component not in the specified package', async () => {
+    await expect(
+      component('Avatar', {cwd: tmpDir, package: '@test/ext'}),
+    ).rejects.toThrow('No component "Avatar" in package');
+  });
+});

--- a/packages/cli/src/commands/component.test.mjs
+++ b/packages/cli/src/commands/component.test.mjs
@@ -5,6 +5,7 @@ import * as os from 'node:os';
 import {
   discoverComponents,
   discoverExternalComponents,
+  discoverExternalComponentsGrouped,
   findExternalComponentDoc,
   findComponentReadme,
   findComponentSource,
@@ -332,6 +333,79 @@ describe('discoverExternalComponents', () => {
 
     const result = discoverExternalComponents(docsDir);
     expect(result).toEqual(['Alpha', 'Middle', 'Zebra']);
+  });
+});
+
+describe('discoverExternalComponentsGrouped', () => {
+  it('reads group: from doc files and groups components', () => {
+    const docsDir = path.join(tmpDir, 'src');
+
+    // AppShell with group
+    const shellDir = path.join(docsDir, 'AppShell');
+    fs.mkdirSync(shellDir, {recursive: true});
+    fs.writeFileSync(path.join(shellDir, 'AppShell.doc.mjs'),
+      "export const docs = {\n  name: 'AppShell',\n  group: 'App Chrome',\n};");
+
+    // SideNav with same group
+    const navDir = path.join(docsDir, 'SideNav');
+    fs.mkdirSync(navDir, {recursive: true});
+    fs.writeFileSync(path.join(navDir, 'SideNav.doc.mjs'),
+      "export const docs = {\n  name: 'SideNav',\n  group: 'App Chrome',\n};");
+
+    // Diff with no group
+    const diffDir = path.join(docsDir, 'Diff');
+    fs.mkdirSync(diffDir, {recursive: true});
+    fs.writeFileSync(path.join(diffDir, 'Diff.doc.mjs'),
+      "export const docs = {\n  name: 'Diff',\n};");
+
+    const result = discoverExternalComponentsGrouped(docsDir);
+    expect(result).toEqual({
+      'App Chrome': ['AppShell', 'SideNav'],
+      'Diff': ['Diff'],
+    });
+  });
+
+  it('returns empty object for nonexistent directory', () => {
+    const result = discoverExternalComponentsGrouped(path.join(tmpDir, 'nope'));
+    expect(result).toEqual({});
+  });
+
+  it('skips hidden components', () => {
+    const docsDir = path.join(tmpDir, 'src');
+    const compDir = path.join(docsDir, 'Internal');
+    fs.mkdirSync(compDir, {recursive: true});
+    fs.writeFileSync(path.join(compDir, 'Internal.doc.mjs'),
+      "export const docs = {\n  name: 'Internal',\n  hidden: true,\n};");
+
+    fs.writeFileSync(path.join(docsDir, 'Visible.doc.mjs'),
+      "export const docs = {\n  name: 'Visible',\n};");
+
+    const result = discoverExternalComponentsGrouped(docsDir);
+    expect(result).toEqual({'Visible': ['Visible']});
+  });
+
+  it('sorts groups and ungrouped alphabetically', () => {
+    const docsDir = path.join(tmpDir, 'src');
+
+    const zDir = path.join(docsDir, 'Zebra');
+    fs.mkdirSync(zDir, {recursive: true});
+    fs.writeFileSync(path.join(zDir, 'Zebra.doc.mjs'),
+      "export const docs = {\n  name: 'Zebra',\n  group: 'Animals',\n};");
+
+    const aDir = path.join(docsDir, 'Alpha');
+    fs.mkdirSync(aDir, {recursive: true});
+    fs.writeFileSync(path.join(aDir, 'Alpha.doc.mjs'),
+      "export const docs = {\n  name: 'Alpha',\n};");
+
+    const bDir = path.join(docsDir, 'Bear');
+    fs.mkdirSync(bDir, {recursive: true});
+    fs.writeFileSync(path.join(bDir, 'Bear.doc.mjs'),
+      "export const docs = {\n  name: 'Bear',\n  group: 'Animals',\n};");
+
+    const result = discoverExternalComponentsGrouped(docsDir);
+    const keys = Object.keys(result);
+    expect(keys).toEqual(['Alpha', 'Animals']);
+    expect(result['Animals']).toEqual(['Bear', 'Zebra']);
   });
 });
 

--- a/packages/cli/src/commands/component/index.mjs
+++ b/packages/cli/src/commands/component/index.mjs
@@ -35,6 +35,7 @@ export function registerComponent(program) {
     .option('--source', 'Print component source code')
     .option('--showcase', 'Print showcase source code')
     .option('--blocks', 'List example blocks: showcase, examples, and related')
+    .option('--package <name>', 'Scope lookup to an external package (e.g. @nest/xds-common)')
     .action(async (name, options) => {
       const run = getRunPrefix();
       const zh = program.opts().zh || false;
@@ -57,6 +58,7 @@ export function registerComponent(program) {
           cwd: process.cwd(),
           list: options.list,
           category: options.category,
+          package: options.package,
           props: options.props,
           source: options.source,
           showcase: options.showcase,
@@ -191,7 +193,7 @@ export function registerComponent(program) {
 
 // Re-export lib functions for backward compatibility
 // (agent-docs.mjs, tests, and generate-skill-doc.sh import from here)
-export {discoverComponents, discoverExternalComponents, findComponentReadme, findComponentSource, findExternalComponentDoc, resolveImportPath} from '../../lib/component-discovery.mjs';
+export {discoverComponents, discoverExternalComponents, discoverExternalComponentsGrouped, findComponentReadme, findComponentSource, findExternalComponentDoc, resolveImportPath} from '../../lib/component-discovery.mjs';
 export {discoverExternalPackages} from '../../utils/paths.mjs';
 export {loadDocs} from '../../lib/component-loader.mjs';
 export {formatFull, formatCompact, formatBrief, formatProps, formatBriefAll} from '../../lib/component-format.mjs';

--- a/packages/cli/src/commands/external-showcase.test.mjs
+++ b/packages/cli/src/commands/external-showcase.test.mjs
@@ -1,0 +1,119 @@
+import {describe, it, expect, beforeEach, afterEach} from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import {findShowcase, findRelatedBlocks} from '../api/template.mjs';
+
+// These tests verify that findShowcase and findRelatedBlocks can discover
+// blocks from external packages that declare xds.showcases in package.json.
+
+let tmpDir;
+
+function createFixture() {
+  // Symlink real core package (needed for findCoreDir)
+  const realCoreDir = path.resolve(import.meta.dirname, '..', '..', '..', 'core');
+  const coreDir = path.join(tmpDir, 'packages', 'core');
+  fs.mkdirSync(path.dirname(coreDir), {recursive: true});
+  fs.symlinkSync(realCoreDir, coreDir);
+
+  // External package with showcases
+  const extDir = path.join(tmpDir, 'node_modules', '@test', 'ext');
+  const showcasesDir = path.join(extDir, 'showcases');
+
+  // Employee showcase
+  const employeeDir = path.join(showcasesDir, 'Employee');
+  fs.mkdirSync(employeeDir, {recursive: true});
+  fs.writeFileSync(path.join(employeeDir, 'EmployeeShowcase.doc.mjs'), `
+export const doc = {
+  type: 'block',
+  name: 'Employee — Profile Card',
+  description: 'Employee profile card with hover preview.',
+  isReady: true,
+  isShowcase: true,
+  aspectRatio: 16 / 9,
+  componentsUsed: ['Employee'],
+};
+`);
+  fs.writeFileSync(path.join(employeeDir, 'EmployeeShowcase.tsx'),
+    "'use client';\nexport default function EmployeeShowcase() { return <div>Employee</div>; }");
+
+  // Diff showcase + example
+  const diffDir = path.join(showcasesDir, 'Diff');
+  fs.mkdirSync(diffDir, {recursive: true});
+  fs.writeFileSync(path.join(diffDir, 'DiffShowcase.doc.mjs'), `
+export const doc = {
+  type: 'block',
+  name: 'Diff — Link with Hover Card',
+  description: 'Diff link with automatic hover card preview.',
+  isReady: true,
+  isShowcase: true,
+  aspectRatio: 4 / 3,
+  componentsUsed: ['Diff'],
+};
+`);
+  fs.writeFileSync(path.join(diffDir, 'DiffShowcase.tsx'),
+    "'use client';\nexport default function DiffShowcase() { return <div>Diff</div>; }");
+  fs.writeFileSync(path.join(diffDir, 'DiffStatusBadges.doc.mjs'), `
+export const doc = {
+  type: 'block',
+  name: 'Diff — Status Badges',
+  description: 'Shows diff status badge variants.',
+  isReady: true,
+  aspectRatio: 1,
+  componentsUsed: ['Diff', 'Badge'],
+};
+`);
+  fs.writeFileSync(path.join(diffDir, 'DiffStatusBadges.tsx'),
+    "'use client';\nexport default function DiffStatusBadges() { return <div>Diff</div>; }");
+
+  fs.writeFileSync(path.join(extDir, 'package.json'), JSON.stringify({
+    name: '@test/ext',
+    xds: {docs: './src', category: 'Common', showcases: './showcases'},
+  }));
+
+  // Need src dir for docs (even if empty) since discoverExternalPackages checks it
+  fs.mkdirSync(path.join(extDir, 'src'), {recursive: true});
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'xds-showcase-test-'));
+  createFixture();
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, {recursive: true, force: true});
+});
+
+describe('findShowcase() with external packages', () => {
+  it('finds showcase from external package by directory name', async () => {
+    const result = await findShowcase('Employee', tmpDir);
+    expect(result).not.toBeNull();
+    expect(result.name).toBe('Employee — Profile Card');
+    expect(result.filePath).toContain('EmployeeShowcase.tsx');
+  });
+
+  it('finds showcase from external package by componentsUsed', async () => {
+    const result = await findShowcase('Diff', tmpDir);
+    expect(result).not.toBeNull();
+    expect(result.name).toBe('Diff — Link with Hover Card');
+  });
+
+  it('returns null for component with no showcase', async () => {
+    const result = await findShowcase('NonExistent', tmpDir);
+    expect(result).toBeNull();
+  });
+});
+
+describe('findRelatedBlocks() with external packages', () => {
+  it('finds related blocks from external package', async () => {
+    const result = await findRelatedBlocks('Diff', tmpDir);
+    expect(result).toHaveLength(2);
+    const names = result.map(b => b.dirName).sort();
+    expect(names).toEqual(['DiffShowcase', 'DiffStatusBadges']);
+  });
+
+  it('finds cross-package component references', async () => {
+    const result = await findRelatedBlocks('Badge', tmpDir);
+    expect(result.some(b => b.dirName === 'DiffStatusBadges')).toBe(true);
+  });
+});

--- a/packages/cli/src/commands/external-showcase.test.mjs
+++ b/packages/cli/src/commands/external-showcase.test.mjs
@@ -5,7 +5,7 @@ import * as os from 'node:os';
 import {findShowcase, findRelatedBlocks} from '../api/template.mjs';
 
 // These tests verify that findShowcase and findRelatedBlocks can discover
-// blocks from external packages that declare xds.showcases in package.json.
+// blocks from external packages that declare xds.blocks in package.json.
 
 let tmpDir;
 
@@ -16,12 +16,12 @@ function createFixture() {
   fs.mkdirSync(path.dirname(coreDir), {recursive: true});
   fs.symlinkSync(realCoreDir, coreDir);
 
-  // External package with showcases
+  // External package with blocks
   const extDir = path.join(tmpDir, 'node_modules', '@test', 'ext');
-  const showcasesDir = path.join(extDir, 'showcases');
+  const blocksDir = path.join(extDir, 'blocks', 'components');
 
   // Employee showcase
-  const employeeDir = path.join(showcasesDir, 'Employee');
+  const employeeDir = path.join(blocksDir, 'Employee');
   fs.mkdirSync(employeeDir, {recursive: true});
   fs.writeFileSync(path.join(employeeDir, 'EmployeeShowcase.doc.mjs'), `
 export const doc = {
@@ -38,7 +38,7 @@ export const doc = {
     "'use client';\nexport default function EmployeeShowcase() { return <div>Employee</div>; }");
 
   // Diff showcase + example
-  const diffDir = path.join(showcasesDir, 'Diff');
+  const diffDir = path.join(blocksDir, 'Diff');
   fs.mkdirSync(diffDir, {recursive: true});
   fs.writeFileSync(path.join(diffDir, 'DiffShowcase.doc.mjs'), `
 export const doc = {
@@ -68,7 +68,7 @@ export const doc = {
 
   fs.writeFileSync(path.join(extDir, 'package.json'), JSON.stringify({
     name: '@test/ext',
-    xds: {docs: './src', category: 'Common', showcases: './showcases'},
+    xds: {docs: './src', category: 'Common', blocks: './blocks/components'},
   }));
 
   // Need src dir for docs (even if empty) since discoverExternalPackages checks it

--- a/packages/cli/src/lib/component-discovery.mjs
+++ b/packages/cli/src/lib/component-discovery.mjs
@@ -285,7 +285,9 @@ export function resolveImportPath(coreDir, componentName) {
 
 /**
  * Discover components from an external package's docs directory.
- * Scans for *.doc.mjs files and returns their names.
+ * Scans for *.doc.mjs files and returns their names as a flat array.
+ *
+ * @deprecated Use discoverExternalComponentsGrouped for group-aware discovery.
  */
 export function discoverExternalComponents(docsDir) {
   if (!fs.existsSync(docsDir)) return [];
@@ -306,6 +308,77 @@ export function discoverExternalComponents(docsDir) {
 
   scanDir(docsDir);
   return components.sort();
+}
+
+/**
+ * Discover components from an external package's docs directory,
+ * reading `group:` fields from each .doc.mjs for subcategories.
+ *
+ * Returns a Record<string, string[]> matching the shape of discoverComponents():
+ * - Grouped components: `{ 'App Chrome': ['AppShell', 'SideNav', 'TopNav'] }`
+ * - Ungrouped components: `{ 'Diff': ['Diff'] }`
+ */
+export function discoverExternalComponentsGrouped(docsDir) {
+  if (!fs.existsSync(docsDir)) return {};
+
+  /** @type {Map<string, string|null>} componentName → group */
+  const componentGroups = new Map();
+
+  function scanDir(dirPath) {
+    const entries = fs.readdirSync(dirPath, {withFileTypes: true});
+    for (const entry of entries) {
+      if (entry.name === 'node_modules' || entry.name === '__tests__') continue;
+      const fullPath = path.join(dirPath, entry.name);
+      if (entry.isDirectory()) {
+        scanDir(fullPath);
+      } else if (entry.name.endsWith('.doc.mjs')) {
+        const name = entry.name.replace('.doc.mjs', '');
+        const {group, hidden} = readDocMeta(fullPath);
+        if (!hidden) {
+          componentGroups.set(name, group);
+        }
+      }
+    }
+  }
+
+  scanDir(docsDir);
+
+  // Build grouped result (same algorithm as discoverComponents)
+  /** @type {Map<string, string[]>} */
+  const groups = new Map();
+  /** @type {string[]} */
+  const ungrouped = [];
+
+  for (const [name, group] of componentGroups) {
+    if (group) {
+      if (!groups.has(group)) groups.set(group, []);
+      groups.get(group).push(name);
+    } else {
+      ungrouped.push(name);
+    }
+  }
+
+  for (const members of groups.values()) {
+    members.sort();
+  }
+
+  /** @type {Array<{key: string, values: string[]}>} */
+  const entries = [];
+  for (const [groupName, members] of groups) {
+    entries.push({key: groupName, values: members});
+  }
+  for (const name of ungrouped) {
+    entries.push({key: name, values: [name]});
+  }
+  entries.sort((a, b) => a.key.localeCompare(b.key));
+
+  /** @type {Record<string, string[]>} */
+  const ordered = {};
+  for (const {key, values} of entries) {
+    ordered[key] = values;
+  }
+
+  return ordered;
 }
 
 /**

--- a/packages/cli/src/utils/paths.mjs
+++ b/packages/cli/src/utils/paths.mjs
@@ -71,9 +71,9 @@ export function findProjectRoot(startDir = process.cwd()) {
  * Discover external XDS-compatible packages from node_modules.
  * Scans for packages with an "xds" field in their package.json:
  *
- *   { "xds": { "docs": "./src", "category": "Common" } }
+ *   { "xds": { "docs": "./src", "category": "Common", "showcases": "./showcases" } }
  *
- * Returns array of { name, category, docsDir }.
+ * Returns array of { name, category, docsDir, showcasesDir }.
  */
 export function discoverExternalPackages(startDir = process.cwd()) {
   const externals = [];
@@ -121,6 +121,9 @@ export function discoverExternalPackages(startDir = process.cwd()) {
             name: pkg.name,
             category: pkg.xds.category || pkg.name,
             docsDir: path.resolve(fullPath, pkg.xds.docs),
+            showcasesDir: pkg.xds.showcases
+              ? path.resolve(fullPath, pkg.xds.showcases)
+              : null,
           });
         }
       } catch {

--- a/packages/cli/src/utils/paths.mjs
+++ b/packages/cli/src/utils/paths.mjs
@@ -71,9 +71,9 @@ export function findProjectRoot(startDir = process.cwd()) {
  * Discover external XDS-compatible packages from node_modules.
  * Scans for packages with an "xds" field in their package.json:
  *
- *   { "xds": { "docs": "./src", "category": "Common", "showcases": "./showcases" } }
+ *   { "xds": { "docs": "./src", "category": "Common", "blocks": "./blocks/components" } }
  *
- * Returns array of { name, category, docsDir, showcasesDir }.
+ * Returns array of { name, category, docsDir, blocksDir }.
  */
 export function discoverExternalPackages(startDir = process.cwd()) {
   const externals = [];
@@ -121,8 +121,8 @@ export function discoverExternalPackages(startDir = process.cwd()) {
             name: pkg.name,
             category: pkg.xds.category || pkg.name,
             docsDir: path.resolve(fullPath, pkg.xds.docs),
-            showcasesDir: pkg.xds.showcases
-              ? path.resolve(fullPath, pkg.xds.showcases)
+            blocksDir: pkg.xds.blocks
+              ? path.resolve(fullPath, pkg.xds.blocks)
               : null,
           });
         }

--- a/packages/cli/src/utils/paths.test.mjs
+++ b/packages/cli/src/utils/paths.test.mjs
@@ -83,7 +83,7 @@ describe('discoverExternalPackages', () => {
         name: 'xds-charts',
         category: 'Data Viz',
         docsDir: path.join(extDir, 'src'),
-        showcasesDir: null,
+        blocksDir: null,
       },
     ]);
   });
@@ -106,7 +106,7 @@ describe('discoverExternalPackages', () => {
         name: '@acme/xds-widgets',
         category: 'Widgets',
         docsDir: path.join(scopedDir, 'lib'),
-        showcasesDir: null,
+        blocksDir: null,
       },
     ]);
   });

--- a/packages/cli/src/utils/paths.test.mjs
+++ b/packages/cli/src/utils/paths.test.mjs
@@ -83,6 +83,7 @@ describe('discoverExternalPackages', () => {
         name: 'xds-charts',
         category: 'Data Viz',
         docsDir: path.join(extDir, 'src'),
+        showcasesDir: null,
       },
     ]);
   });
@@ -105,6 +106,7 @@ describe('discoverExternalPackages', () => {
         name: '@acme/xds-widgets',
         category: 'Widgets',
         docsDir: path.join(scopedDir, 'lib'),
+        showcasesDir: null,
       },
     ]);
   });


### PR DESCRIPTION
Extends the CLI to find blocks (.tsx + .doc.mjs) from external XDS-compatible packages, not just the built-in `@xds/cli/templates/blocks` directory.

### The problem

`findShowcase()` and `findRelatedBlocks()` only search `@xds/cli/templates/blocks/`. External packages like `@nest/xds-common` have no way to provide showcase previews or example blocks for their components.

### The fix

External packages can now declare a `blocks` directory in their `xds` config:

```json
{
  "xds": {
    "docs": "./src",
    "category": "Common",
    "blocks": "./blocks/components"
  }
}
```

The blocks directory uses the same structure as core:
```
blocks/
  components/
    Employee/
      EmployeeShowcase.doc.mjs   # isShowcase: true
      EmployeeShowcase.tsx
      EmployeeProfileCard.doc.mjs  # example block
      EmployeeProfileCard.tsx
    Diff/
      DiffShowcase.doc.mjs
      DiffShowcase.tsx
```

Same `TemplateDoc` type, same naming conventions, same `componentsUsed`/`isShowcase`/`aspectRatio` metadata as core blocks.

### Changes

- **`paths.mjs`**: `discoverExternalPackages()` now returns `blocksDir` when `xds.blocks` is set
- **`template.mjs`**: New `discoverExternalBlocks()` scans external package block dirs; `discoverAllBlocks()` merges core + external. External blocks get a `package` field for attribution.
- **`findShowcase()`** and **`findRelatedBlocks()`** now accept optional `cwd` and search both core and external package blocks
- **`component.mjs`**: Passes `cwd` through to `findShowcase()`

### Depends on

- #1919 (package-scoped component resolution)

### Tests

5 new tests + 2 updated expectations.