### PR TITLE
fix(theme): baseline media theme rules in reset.css

### DIFF
--- a/packages/core/src/reset.css
+++ b/packages/core/src/reset.css
@@ -385,4 +385,21 @@
   :where(html:not([data-theme])) {
     color-scheme: light dark;
   }
+
+  /* ===========================================================================
+     Media Theme Baseline
+     =========================================================================== */
+
+  /*
+   * color-scheme flip for [data-xds-media] — makes light-dark() base
+   * tokens resolve correctly on inverted surfaces without a theme.
+   * Token overrides (text/icon/accent) are theme-level (generateOnMediaCSS).
+   */
+  :where([data-xds-media="dark"]) {
+    color-scheme: dark;
+  }
+
+  :where([data-xds-media="light"]) {
+    color-scheme: light;
+  }
 }

--- a/packages/core/src/theme/onMediaTokens.test.ts
+++ b/packages/core/src/theme/onMediaTokens.test.ts
@@ -168,7 +168,9 @@ describe('generateOnMediaCSS', () => {
     });
     const css = generateOnMediaCSS(theme);
     expect(css).toContain('[data-xds-media="dark"] .xds-button.secondary');
-    expect(css).toContain('background-color: color-mix(in srgb, white 20%, transparent)');
+    expect(css).toContain(
+      'background-color: color-mix(in srgb, white 20%, transparent)',
+    );
   });
 
   it('emits pseudo-class rules for on-media components', () => {
@@ -188,5 +190,50 @@ describe('generateOnMediaCSS', () => {
     const css = generateOnMediaCSS(theme);
     expect(css).toContain('.xds-button:hover');
     expect(css).toContain('color: rgba(255,255,255,0.8)');
+  });
+});
+
+describe('reset.css baseline media rules', () => {
+  /**
+   * Validates that reset.css provides the minimum baseline for
+   * XDSMediaTheme: a color-scheme flip on [data-xds-media].
+   *
+   * Token overrides (text-primary, icon-primary, accent) are a
+   * theme-level concern — themes handle those via generateOnMediaCSS.
+   */
+  let resetCSS: string;
+
+  beforeAll(async () => {
+    const fs = await import('fs');
+    const path = await import('path');
+    resetCSS = fs.readFileSync(
+      path.resolve(__dirname, '../reset.css'),
+      'utf-8',
+    );
+  });
+
+  it('flips color-scheme on [data-xds-media="dark"]', () => {
+    const darkMatch = resetCSS.match(
+      /:where\(\[data-xds-media="dark"\]\)\s*\{([^}]+)\}/,
+    );
+    expect(darkMatch).not.toBeNull();
+    expect(darkMatch![1]).toContain('color-scheme: dark');
+  });
+
+  it('flips color-scheme on [data-xds-media="light"]', () => {
+    const lightMatch = resetCSS.match(
+      /:where\(\[data-xds-media="light"\]\)\s*\{([^}]+)\}/,
+    );
+    expect(lightMatch).not.toBeNull();
+    expect(lightMatch![1]).toContain('color-scheme: light');
+  });
+
+  it('does NOT include token overrides at baseline level', () => {
+    const darkMatch = resetCSS.match(
+      /:where\(\[data-xds-media="dark"\]\)\s*\{([^}]+)\}/,
+    );
+    expect(darkMatch![1]).not.toContain('--color-text-primary');
+    expect(darkMatch![1]).not.toContain('--color-icon-primary');
+    expect(darkMatch![1]).not.toContain('--color-accent');
   });
 });


### PR DESCRIPTION
## Problem

`XDSMediaTheme` sets `data-xds-media="dark|light"` on a wrapper div, but the CSS rules targeting that attribute are generated by `generateOnMediaCSS` — which only runs when a theme is applied via `defineTheme()`.

Without a theme (base tokens only) or in the source build path (where `xds.css` isn't a separate file), there's nothing to:
1. Flip `color-scheme` so `light-dark()` base tokens resolve to the correct side
2. Override text/icon/accent to use pure on-color values on inverted surfaces

This means `<XDSMediaTheme mode="dark">` is a no-op without a theme — text stays dark on dark surfaces.

## Fix

Add baseline `[data-xds-media]` rules to `reset.css` in `@layer reset`:

```css
:where([data-xds-media="dark"]) {
  color-scheme: dark;
  --color-text-primary: var(--color-on-dark);
  --color-icon-primary: var(--color-on-dark);
  --color-accent: var(--color-on-dark);
}

:where([data-xds-media="light"]) {
  color-scheme: light;
  --color-text-primary: var(--color-on-light);
  --color-icon-primary: var(--color-on-light);
  --color-accent: var(--color-on-light);
}
```

- `color-scheme` flip makes all `light-dark()` base tokens resolve correctly
- Token overrides match the defaults in `onMediaTokens.ts`
- Lives in `@layer reset` so any theme's `@layer xds-theme` rules naturally win
- `:where()` keeps specificity at zero — consistent with the rest of the reset

## Sync test

Added a test in `onMediaTokens.test.ts` that reads `reset.css` and validates the CSS rules match the TS defaults in `defaultOnDarkTokens` / `defaultOnLightTokens`. If someone adds a new default token override in TS but forgets to update the CSS (or vice versa), the test fails.

## Why reset.css?

`reset.css` is the one file that's always imported regardless of distribution path (source via Vite/StyleX or dist via `xds.css`). It's the reliable baseline.