### PR TITLE
Update changelog heading levels for doc site rendering

### DIFF
--- a/apps/sandbox/scripts/generate-changelog.js
+++ b/apps/sandbox/scripts/generate-changelog.js
@@ -84,8 +84,8 @@ function parseChangelog(markdown, pkg) {
       continue;
     }
 
-    // Version heading: ## 0.0.12
-    const versionMatch = line.match(/^## (\d+\.\d+\.\d+)/);
+    // Version heading: # 0.0.12 (or legacy ## 0.0.12)
+    const versionMatch = line.match(/^#{1,2} (\d+\.\d+\.\d+)/);
     if (versionMatch) {
       currentVersion = {
         version: versionMatch[1],
@@ -106,8 +106,8 @@ function parseChangelog(markdown, pkg) {
 
     if (!currentVersion) continue;
 
-    // Section heading: ### Breaking Changes
-    const sectionMatch = line.match(/^### (.+)/);
+    // Section heading: #### Breaking Changes (or legacy ### Breaking Changes)
+    const sectionMatch = line.match(/^#{3,4} (.+)/);
     if (sectionMatch) {
       const heading = sectionMatch[1].trim().toLowerCase();
       currentSection = SECTION_MAP[heading] || heading;

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,62 +1,70 @@
 # @xds/cli
 
-## 0.0.12
+# 0.0.12
 
-### Codemods
+#### Codemods
 
 - `add-is-icon-only` — Add `isIconOnly` to icon-only Button and ToggleButton usages (#1257)
 
-### Upgrade
+#### Upgrade
 
 ```sh
 npx xds upgrade --apply --to 0.0.12
 ```
 
-## 0.0.10
+---
 
-### Codemods
+# 0.0.10
+
+#### Codemods
 
 - `remove-size-props` — Remove `size` prop from StatusDot and ProgressBar (#966)
 
-### Upgrade
+#### Upgrade
 
 ```sh
 npx xds upgrade --apply --to 0.0.10
 ```
 
-## 0.0.8
+---
 
-### New Features
+# 0.0.8
+
+#### New Features
 
 - CLI: tsx parser for .ts files
 - Update hints in postAction hook
 
-### Codemods
+#### Codemods
 
 - `rename-endslot-to-endcontent` — Button `endSlot` → `endContent` (#895)
 - `migrate-token-renames` — Token name migration to v0.0.8 convention
 
-### Upgrade
+#### Upgrade
 
 ```sh
 npx xds upgrade --apply --to 0.0.8
 ```
 
-## 0.0.7
+---
 
-### Codemods
+# 0.0.7
+
+#### Codemods
 
 - `rename-banner-variant-to-container` — Banner `variant` → `container` (#814)
 
-### Upgrade
+#### Upgrade
 
 ```sh
 npx xds upgrade --apply --to 0.0.7
 ```
 
-## 0.0.6
+---
 
-### Codemods
+# 0.0.6
+
+#### Codemods
 
 - `migrate-token-names` — Design token renames per naming audit
 - `migrate-shadow-tokens` — Elevation → shadow semantic naming
@@ -65,15 +73,17 @@ npx xds upgrade --apply --to 0.0.7
 - `migrate-skeleton-radius` — Skeleton radius prop → numeric scale
 - `migrate-badge-children-to-label` — Badge children → label prop
 
-### Upgrade
+#### Upgrade
 
 ```sh
 npx xds upgrade --apply --to 0.0.6
 ```
 
-## 0.0.5
+---
 
-### New Features
+# 0.0.5
+
+#### New Features
 
 - Generate agent cheat sheet from live CLI metadata (#640)
 - `--detail` and `--lang` flags for typed `.doc.mjs` output (#636)
@@ -81,33 +91,39 @@ npx xds upgrade --apply --to 0.0.6
 
 > **Note:** Codemods for v0.0.5 breaking changes are registered under v0.0.6. Use `--to 0.0.6`.
 
-## 0.0.4
+---
 
-### Features
+# 0.0.4
+
+#### Features
 
 - **`xds theme build`** — Renamed from `build-theme` to `theme build` (#570)
 - **`--lang` flag** — TranslationDoc support for i18n/compressed docs (#611)
 - **`--zh` flag** — Chinese Simplified doc output (#567)
 
-### Refactors
+#### Refactors
 
 - Split `component.mjs` into `lib/` modules with lazy command registry (#613)
 
-## 0.0.3
+---
 
-### Patch Changes
+# 0.0.3
+
+#### Patch Changes
 
 - Sync package.json exports map
 - Add verify-exports CI check (#537)
 
-## 0.0.2
+---
 
-### New Features
+# 0.0.2
+
+#### New Features
 
 - `xds upgrade` command with codemod support
 - `xds theme build` (formerly `build-theme`)
 
-### Codemods
+#### Codemods
 
 12 codemods for the v0.0.2 breaking changes:
 - `rename-selector-items-to-options` — Selector `items` → `options`
@@ -123,12 +139,14 @@ npx xds upgrade --apply --to 0.0.6
 - `migrate-isFullBleed-to-padding` — `isFullBleed` → `padding={0}`
 - `migrate-badge-dot-to-statusdot` — Badge dot → StatusDot
 
-### Upgrade
+#### Upgrade
 
 ```sh
 npx xds upgrade --apply --to 0.0.2
 ```
 
-## 0.0.1
+---
+
+# 0.0.1
 
 - Initial release

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,12 +1,12 @@
 # @xds/core
 
-## 0.0.12
+# 0.0.12
 
-### Breaking Changes
+#### Breaking Changes
 
 - **Button `isIconOnly` required for icon-only mode** — `XDSButton` and `XDSToggleButton` now require explicit `isIconOnly` for icon-only rendering. (#1257)
 
-### New Features
+#### New Features
 
 - **XDSThumbnail** component (#1255)
 - **XDSChatLayout** with fixed composer dock and container queries (#1249)
@@ -24,7 +24,7 @@
 - **ChatComposer `headerActions` + `headerContext`** replacing `contextToolbar` (#1242)
 - **Chat trigger menu system** for ComposerInput (#1193)
 
-### Fixes
+#### Fixes
 
 - Dialog: reset inherited edge signals, prevent ghost button margin shift (#1237)
 - CodeBlock: syntax highlighting missing on scroll + perf improvements (#1221)
@@ -38,7 +38,7 @@
 - CodeBlock: use semantic `--text-code-size` token for md size (#1273)
 - Input: forward native event handlers via `...rest` spread (#1259, #1291)
 
-### Upgrade
+#### Upgrade
 
 Codemods are available for all breaking changes in this release:
 
@@ -50,25 +50,29 @@ Preview changes first (dry run): `npx xds upgrade --to 0.0.12`
 Run a specific codemod: `npx xds upgrade --apply --codemod add-is-icon-only`
 List all available codemods: `npx xds upgrade --list`
 
-## 0.0.11
+---
 
-### Patch Changes
+# 0.0.11
+
+#### Patch Changes
 
 - Version bump and publish infrastructure fixes
 - No breaking changes
 
-## 0.0.10
+---
 
-### Breaking Changes
+# 0.0.10
+
+#### Breaking Changes
 
 - **StatusDot and ProgressBar single size** — Both components now have a single fixed size (8px). The `size` prop has been removed. (#966)
 
-### New Features
+#### New Features
 
 - **Layout `defaultHasDividers`** — Container-controlled dividers via context (#969)
 - **Button `href` support** — Link-styled buttons (#935)
 
-### Fixes
+#### Fixes
 
 - Dialog: propagate `maxHeight` to layout via `--container-max-height` (#965)
 - Popover: embed surface styles in `useXDSPopover` hook (#964)
@@ -81,7 +85,7 @@ List all available codemods: `npx xds upgrade --list`
 - DialogHeader: re-add capsize with visual adjustment (#956)
 - Hardening sweep (#968)
 
-### Upgrade
+#### Upgrade
 
 Codemods are available for all breaking changes in this release:
 
@@ -93,14 +97,16 @@ Preview changes first (dry run): `npx xds upgrade --to 0.0.10`
 Run a specific codemod: `npx xds upgrade --apply --codemod remove-size-props`
 List all available codemods: `npx xds upgrade --list`
 
-## 0.0.8
+---
 
-### Breaking Changes
+# 0.0.8
+
+#### Breaking Changes
 
 - **Button `endSlot` → `endContent`** — Renamed on XDSButton and forwarded object literals (e.g. XDSDropdownMenu button prop). (#895)
 - **Token renames** — Intermediate token names from v0.0.6 renamed to final v0.0.8 convention per the token spec.
 
-### Fixes
+#### Fixes
 
 - Align cyan, pink, and yellow token colors with WWW (#907)
 - Dialog hardening (#775)
@@ -120,7 +126,7 @@ List all available codemods: `npx xds upgrade --list`
 - Correct neutral gray token semantics across components (#852)
 - Formalize container padding tokens, prevent internal var access (#847)
 
-### Upgrade
+#### Upgrade
 
 Codemods are available for all breaking changes in this release:
 
@@ -132,13 +138,15 @@ Preview changes first (dry run): `npx xds upgrade --to 0.0.8`
 Run a specific codemod: `npx xds upgrade --apply --codemod rename-endslot-to-endcontent`
 List all available codemods: `npx xds upgrade --list`
 
-## 0.0.7
+---
 
-### Breaking Changes
+# 0.0.7
+
+#### Breaking Changes
 
 - **Banner `variant` → `container`** — Renamed the `variant` prop on XDSBanner to `container`. Type references `XDSBannerVariant` → `XDSBannerContainer` and `XDSBannerVariantMap` → `XDSBannerContainerMap`. (#814)
 
-### Upgrade
+#### Upgrade
 
 Codemods are available for all breaking changes in this release:
 
@@ -150,9 +158,11 @@ Preview changes first (dry run): `npx xds upgrade --to 0.0.7`
 Run a specific codemod: `npx xds upgrade --apply --codemod rename-banner-variant-to-container`
 List all available codemods: `npx xds upgrade --list`
 
-## 0.0.6
+---
 
-### Breaking Changes
+# 0.0.6
+
+#### Breaking Changes
 
 - **Token renames** — Design tokens renamed per naming audit: `positive` → `success`, `negative` → `error`, `divider` → `border`, etc. (`migrate-token-names`)
 - **Shadow tokens** — Elevation tokens renamed to `shadow-base`/`shadow-menu`/`shadow-hover`/`shadow-dialog` + `insetshadow-border-*` (`migrate-shadow-tokens`)
@@ -160,7 +170,7 @@ List all available codemods: `npx xds upgrade --list`
 - **Radius tokens** — Semantic radius tokens renamed to numeric scale (`migrate-radius-tokens`, `migrate-skeleton-radius`)
 - **Badge `children` → `label`** — Content passed as children now uses the `label` prop (`migrate-badge-children-to-label`)
 
-### New Features
+#### New Features
 
 - **Dynamic theming primitives:** `radiusScale`, `motionScale`, `typeScale` in `defineTheme`
 - **Motion tokens:** duration, easing, and component migration to token-based transitions
@@ -173,7 +183,7 @@ List all available codemods: `npx xds upgrade --list`
 - **NavItem** component
 - Shared theme CSS generation, removed XDSFontWrapper
 
-### Fixes
+#### Fixes
 
 - Badge: hardcoded height → spacing token; add `label` prop for API consistency (#709)
 - CheckboxInput & Switch: focus rings + indeterminate aria (#723)
@@ -187,7 +197,7 @@ List all available codemods: `npx xds upgrade --list`
 - Sync package.json exports (NavItem, remove stale typography.css)
 - Type-scale: use Math.round for 4px grid snapping in computeLeading
 
-### Upgrade
+#### Upgrade
 
 Codemods are available for all breaking changes in this release:
 
@@ -198,40 +208,46 @@ npx xds upgrade --apply --to 0.0.6
 Preview changes first (dry run): `npx xds upgrade --to 0.0.6`
 List all available codemods: `npx xds upgrade --list`
 
-## 0.0.5
+---
+
+# 0.0.5
 
 > **Note:** v0.0.5 was the published version. Codemods for this release are registered under v0.0.6 in the CLI. Use `--to 0.0.6` to run them.
 
 See 0.0.6 above for breaking changes and upgrade instructions.
 
-## 0.0.4
+---
 
-### New Components
+# 0.0.4
+
+#### New Components
 
 - **XDSTreeList** — Hierarchical tree list component with expand/collapse (#609)
 - **XDSPowerSearch** — Advanced search component with result count, filtering (#561, #593)
 
-### Features
+#### Features
 
 - **AppShell variant system** — New `variant` prop (#597)
 - **AppShell contentPadding** — New `contentPadding` prop (#612)
 - **AppShell auto height mode** — Sidenav and sticky backgrounds (#615)
 - **startIcon** support (#584)
 
-### Fixes
+#### Fixes
 
 - Removed deprecated `isFullBleed` prop from Card and Section (#610, #598)
 - Layout: `padding={0}` treated as equivalent to `isFullBleed` (#595)
 - SideNav: consistent spacing (#601)
 - Nav: consistent gap and heading text sizes (#616)
 
-### Refactors
+#### Refactors
 
 - Popover, HoverCard, Tooltip moved to top-level directories (#557)
 
-## 0.0.3
+---
 
-### Patch Changes
+# 0.0.3
+
+#### Patch Changes
 
 - Bundle StyleX runtime — consumers no longer need @stylexjs/stylex as peer dependency (#545)
 - Add stable token export path at @xds/core/tokens (#544)
@@ -240,9 +256,11 @@ See 0.0.6 above for breaking changes and upgrade instructions.
 - Sync package.json exports map
 - Add verify-exports CI check (#537)
 
-## 0.0.2
+---
 
-### Breaking Changes
+# 0.0.2
+
+#### Breaking Changes
 
 - CSS-based theming replaces StyleX theme system — `defineTheme()` API
 - `className` and `style` props on all components
@@ -253,7 +271,7 @@ See 0.0.6 above for breaking changes and upgrade instructions.
 - `gap="space4"` → `gap={4}`, `isFullBleed` → `padding={0}`
 - Badge dot → StatusDot
 
-### Upgrade
+#### Upgrade
 
 Codemods are available for all breaking changes in this release:
 
@@ -278,6 +296,8 @@ List all available codemods: `npx xds upgrade --list`
 - `migrate-isFullBleed-to-padding` — `isFullBleed` → `padding={0}`
 - `migrate-badge-dot-to-statusdot` — Badge `shape="dot"` → StatusDot
 
-## 0.0.1
+---
+
+# 0.0.1
 
 - Initial release

--- a/packages/lab/CHANGELOG.md
+++ b/packages/lab/CHANGELOG.md
@@ -1,8 +1,8 @@
 # @xds/lab
 
-## 0.0.5
+# 0.0.5
 
-### Patch Changes
+#### Patch Changes
 
 - Updated dependencies
   - @xds/core@0.0.5

--- a/packages/themes/brutalist/CHANGELOG.md
+++ b/packages/themes/brutalist/CHANGELOG.md
@@ -1,14 +1,16 @@
 # @xds/theme-brutalist
 
-## 0.0.5
+# 0.0.5
 
-### Patch Changes
+#### Patch Changes
 
 - Aligned version with other packages
 
-## 0.0.4
+---
 
-### Minor Changes
+# 0.0.4
+
+#### Minor Changes
 
 - Initial release — brutalist theme with zero radius, monospace typography, heavy borders
 - Added to Storybook (#560)

--- a/packages/themes/default/CHANGELOG.md
+++ b/packages/themes/default/CHANGELOG.md
@@ -1,36 +1,44 @@
 # @xds/theme-default
 
-## 0.0.5
+# 0.0.5
 
-### Changes
+#### Changes
 
 - Updated token names to match naming audit (shadow, radius, elevation renames)
 - Motion token primitives: duration and easing values
 - Dynamic radius and type scale support via `defineTheme` config
 
-### Patch Changes
+#### Patch Changes
 
 - Updated dependencies
   - @xds/core@0.0.5
 
-## 0.0.4
+---
 
-### Patch Changes
+# 0.0.4
+
+#### Patch Changes
 
 - Updated dependencies — aligned with @xds/core@0.0.4
 
-## 0.0.3
+---
 
-### Patch Changes
+# 0.0.3
+
+#### Patch Changes
 
 - Fix theme package to produce proper JS/TS module output via tsup (#541)
 
-## 0.0.2
+---
 
-### Changes
+# 0.0.2
+
+#### Changes
 
 - Migrated to CSS-based theming with `defineTheme()`
 
-## 0.0.1
+---
+
+# 0.0.1
 
 - Initial release — default theme with Heroicons

--- a/packages/themes/neutral/CHANGELOG.md
+++ b/packages/themes/neutral/CHANGELOG.md
@@ -1,36 +1,44 @@
 # @xds/theme-neutral
 
-## 0.0.5
+# 0.0.5
 
-### Changes
+#### Changes
 
 - Updated token names to match naming audit (shadow, radius, elevation renames)
 - Motion token primitives: duration and easing values
 - Dynamic radius and type scale support via `defineTheme` config
 
-### Patch Changes
+#### Patch Changes
 
 - Updated dependencies
   - @xds/core@0.0.5
 
-## 0.0.4
+---
 
-### Patch Changes
+# 0.0.4
+
+#### Patch Changes
 
 - Updated dependencies — aligned with @xds/core@0.0.4
 
-## 0.0.3
+---
 
-### Patch Changes
+# 0.0.3
+
+#### Patch Changes
 
 - Fix theme package to produce proper JS/TS module output via tsup (#541)
 
-## 0.0.2
+---
 
-### Changes
+# 0.0.2
+
+#### Changes
 
 - Migrated to CSS-based theming with `defineTheme()`
 
-## 0.0.1
+---
+
+# 0.0.1
 
 - Initial release — neutral theme with Lucide icons


### PR DESCRIPTION
Promote version headings from ## to # (h1) and demote section headings from ### to #### (h4) across all package changelogs. Add horizontal rule dividers between version sections.

This aligns with the doc site's XDSMarkdown rendering which uses headingLevelStart={1}, giving version numbers prominent h1 sizing and section labels (Features, Fixes, etc.) a smaller h4 treatment.

Made-with: Cursor