### PR TITLE
fix(sandbox): prevent PreviewShell toolbar flash in iframe embeds

### DIFF
--- a/apps/sandbox/src/app/(fullscreen)/PreviewShell.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/PreviewShell.tsx
@@ -717,6 +717,7 @@ export function PreviewShell({children}: {children: React.ReactNode}) {
 
   return (
     <div
+      data-preview-shell
       style={{
         display: 'flex',
         flexDirection: 'column',

--- a/apps/sandbox/src/app/layout.tsx
+++ b/apps/sandbox/src/app/layout.tsx
@@ -15,6 +15,18 @@ export default function RootLayout({children}: {children: React.ReactNode}) {
           rel="stylesheet"
           href="https://fonts.googleapis.com/css2?family=Figtree:wght@400;500;600;700&display=swap"
         />
+        {/* Prevent PreviewShell toolbar flash when loaded inside an iframe.
+            Runs before paint so the toolbar is never visible in embed contexts. */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `try{if(window.self!==window.top)document.documentElement.classList.add('xds-embed')}catch(e){document.documentElement.classList.add('xds-embed')}`,
+          }}
+        />
+        <style
+          dangerouslySetInnerHTML={{
+            __html: `html.xds-embed [data-preview-shell]{display:none!important}`,
+          }}
+        />
       </head>
       <body>
         <Providers>{children}</Providers>


### PR DESCRIPTION
## Problem

When loading template pages in the sandbox (e.g. `/sandbox/templates/ai-chat-landing/`), the PreviewShell toolbar visibly stacks 2–3 times before the page settles. This happens because:

1. PR #1844 changed desktop templates to render in iframes (via `?embed=1`), matching tablet/mobile
2. The sandbox is a **static export** — the iframe receives the same pre-rendered HTML as the outer page, including the full PreviewShell toolbar
3. The `isEmbed` check reads `window.location.search`, which isn't available during static generation — so the static HTML always includes the toolbar
4. React hydration eventually detects `?embed=1` and removes the inner toolbars, but not before a visible flash

## Fix

Add a **render-blocking** inline script in `<head>` that runs before paint:

1. Detects iframe context (`window.self !== window.top`)
2. Sets an `xds-embed` class on `<html>`
3. A companion CSS rule hides `[data-preview-shell]` when that class is present

This eliminates the flash entirely — the toolbar is hidden via CSS before the browser paints, and React hydration proceeds normally afterward.

## Changes

- **`layout.tsx`** — inline `<script>` + `<style>` in `<head>` for iframe detection
- **`PreviewShell.tsx`** — `data-preview-shell` attribute on the wrapper div as a CSS hook