### PR TITLE
fix(Resizable): use radius-full for pill border-radius

### DIFF
--- a/packages/core/src/Resizable/XDSResizeHandle.tsx
+++ b/packages/core/src/Resizable/XDSResizeHandle.tsx
@@ -24,6 +24,7 @@ import {
   colorVars,
   durationVars,
   easeVars,
+  radiusVars,
   spacingVars,
 } from '../theme/tokens.stylex';
 import {xdsClassName, mergeProps} from '../utils';
@@ -131,7 +132,7 @@ const styles = stylex.create({
     position: 'absolute',
     zIndex: 2,
     pointerEvents: 'none',
-    borderRadius: spacingVars['--spacing-0-5'],
+    borderRadius: radiusVars['--radius-full'],
     backgroundColor: colorVars['--color-border'],
     transitionProperty: 'opacity, background-color, transform',
     transitionDuration: durationVars['--duration-fast'],


### PR DESCRIPTION
The pill is a fully-rounded shape — `radius-full` (9999px) is the correct semantic token, not `spacing-0-5` which only happened to look rounded at small sizes.