### PR TITLE
fix(Resizable): fix doc typecheck — remove invalid ThemingTarget field

### DIFF
--- a/packages/core/src/Resizable/Resizable.doc.mjs
+++ b/packages/core/src/Resizable/Resizable.doc.mjs
@@ -42,11 +42,7 @@ export const docs = {
   theming: {
     targets: [
       {className: 'xds-resize-handle', visualProps: ['direction']},
-      {
-        className: 'xds-resize-handle-pill',
-        description:
-          'The pill grip indicator. Target to change size, shape, or color.',
-      },
+      {className: 'xds-resize-handle-pill'},
     ],
   },
   components: [


### PR DESCRIPTION
The `description` field doesn't exist on `ThemingTarget`. Removes it from the pill theming target entry in `Resizable.doc.mjs`. Fixes the `typecheck:docs` CI step.