### PR TITLE
fix(Resizable): fix vertical pill offset and doc typecheck

### DIFF
--- a/packages/core/src/Resizable/Resizable.doc.mjs
+++ b/packages/core/src/Resizable/Resizable.doc.mjs
@@ -42,11 +42,7 @@ export const docs = {
   theming: {
     targets: [
       {className: 'xds-resize-handle', visualProps: ['direction']},
-      {
-        className: 'xds-resize-handle-pill',
-        description:
-          'The pill grip indicator. Target to change size, shape, or color.',
-      },
+      {className: 'xds-resize-handle-pill'},
     ],
   },
   components: [

--- a/packages/core/src/Resizable/XDSResizeHandle.tsx
+++ b/packages/core/src/Resizable/XDSResizeHandle.tsx
@@ -173,11 +173,14 @@ const dynamicStyles = stylex.create({
     left: 0,
     transform: `translate(calc(${dir} * (100% + ${spacingVars['--spacing-1']})), -50%)`,
   }),
-  // Vertical pill is rotated 90° — translate along X in local space
-  // to offset along Y in screen space.
+  // Vertical offset: no rotation — use explicit landscape dimensions.
+  // Rotation + offset creates confusing coordinate math since translate
+  // operates in pre-rotation local space.
   pillOffsetY: (dir: number) => ({
+    width: spacingVars['--spacing-8'],
+    height: 3,
     top: 0,
-    transform: `translate(-50%, calc(${dir} * (100% + ${spacingVars['--spacing-1']}))) rotate(90deg)`,
+    transform: `translate(-50%, calc(${dir} * (100% + ${spacingVars['--spacing-1']})))`,
   }),
 });
 


### PR DESCRIPTION
**Vertical pill offset was broken.** The rotation approach (`rotate(90deg)`) caused the translate to operate in pre-rotation local space, producing wrong screen positions. Fix: `pillOffsetY` uses explicit landscape dimensions (width=long, height=thin) instead of rotation + offset. Rotation is still used for the centered case where the math is simple.

Also fixes the `typecheck:docs` CI failure (invalid `description` field on `ThemingTarget`).