### PR TITLE
feat(cli): add displayName and metadata to discover API

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@xds/cli",
   "version": "0.0.13",
-  "description": "XDS design system CLI — init, swizzle, theme, templates, and agent docs",
+  "displayName": "CLI",
+  "description": "Scaffold projects, browse templates, generate themes, and get agent-ready docs from the command line.",
   "author": "Meta Open Source",
   "license": "MIT",
   "homepage": "https://github.com/facebookexperimental/xds#readme",

--- a/packages/cli/src/api/discover.mjs
+++ b/packages/cli/src/api/discover.mjs
@@ -29,7 +29,14 @@ function validateDocs(docs) {
 export async function discover(query, options = {}) {
   const {lang = null, zh = false} = options;
   const config = await loadConfig();
-  const toEntry = (pkg) => ({name: pkg.name, category: pkg.category, components: pkg.components});
+  const toEntry = (pkg) => ({
+    name: pkg.name,
+    category: pkg.category,
+    components: pkg.components,
+    version: pkg.version,
+    description: pkg.description,
+    displayName: pkg.displayName,
+  });
 
   if (config.packages.length === 0) {
     return {type: 'discover.list', data: []};

--- a/packages/cli/src/commands/discover.mjs
+++ b/packages/cli/src/commands/discover.mjs
@@ -73,7 +73,11 @@ export function registerDiscover(program) {
             for (const pkg of result.data) {
               const count = pkg.components.length;
               const label = count === 1 ? 'component' : 'components';
-              console.log(pkg.name + ' (' + count + ' ' + label + ')');
+              const heading = pkg.displayName
+                ? pkg.displayName + '  ' + pkg.name + ' (' + count + ' ' + label + ')'
+                : pkg.name + ' (' + count + ' ' + label + ')';
+              console.log(heading);
+              if (pkg.description) console.log('  ' + pkg.description);
 
               if (options.components) {
                 for (const comp of pkg.components) console.log('  ' + comp);
@@ -97,7 +101,12 @@ export function registerDiscover(program) {
 
         case 'discover.detail': {
           console.log('');
-          console.log(result.data.name + ' (' + result.data.components.length + ' components)');
+          const d = result.data;
+          const detailHeading = d.displayName
+            ? d.displayName + '  ' + d.name + ' (' + d.components.length + ' components)'
+            : d.name + ' (' + d.components.length + ' components)';
+          console.log(detailHeading);
+          if (d.description) console.log('  ' + d.description);
           console.log('');
           for (const comp of result.data.components) console.log('  ' + comp);
           console.log('');

--- a/packages/cli/src/lib/package-scanner.mjs
+++ b/packages/cli/src/lib/package-scanner.mjs
@@ -21,6 +21,9 @@ export function scanDirectory(scanDir) {
     if (components.length === 0) continue;
     packages.push({
       name: pkg.name || entry.name,
+      version: pkg.version,
+      description: pkg.description,
+      displayName: pkg.displayName,
       dir: pkgDir,
       xds: pkg.xds,
       category: pkg.xds.category || pkg.name || entry.name,

--- a/packages/cli/src/types/discover.d.ts
+++ b/packages/cli/src/types/discover.d.ts
@@ -23,6 +23,9 @@ export interface DiscoverListEntry {
   name: string;
   category: string;
   components: string[];
+  version?: string;
+  description?: string;
+  displayName?: string;
 }
 
 /** xds --json discover @scope/name */

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@xds/core",
   "version": "0.0.13",
-  "description": "XDS design system — accessible, themeable React components with automatic spacing and plugin architecture",
+  "displayName": "XDS Core",
+  "description": "The component library. Accessible, themeable React components with built-in spacing, dark mode, and StyleX styling.",
   "author": "Meta Open Source",
   "license": "MIT",
   "homepage": "https://github.com/facebookexperimental/xds#readme",

--- a/packages/themes/default/package.json
+++ b/packages/themes/default/package.json
@@ -1,8 +1,9 @@
 {
   "name": "@xds/theme-default",
   "version": "0.0.13",
+  "displayName": "Default Theme",
   "private": false,
-  "description": "Default theme for XDS — clean neutrals with Heroicons icon set",
+  "description": "Clean neutrals with a blue accent. Pairs with Heroicons for a polished, professional look.",
   "author": "Meta Open Source",
   "license": "MIT",
   "homepage": "https://github.com/facebookexperimental/xds#readme",

--- a/packages/themes/neutral/package.json
+++ b/packages/themes/neutral/package.json
@@ -1,8 +1,9 @@
 {
   "name": "@xds/theme-neutral",
   "version": "0.0.13",
+  "displayName": "Neutral Theme",
   "private": false,
-  "description": "Neutral theme for XDS — understated palette with Lucide icon set",
+  "description": "Understated warm grays with a subtle palette. Pairs with Lucide icons for a minimal, quiet aesthetic.",
   "author": "Meta Open Source",
   "license": "MIT",
   "homepage": "https://github.com/facebookexperimental/xds#readme",


### PR DESCRIPTION
## Summary

- Extend the `discover` command to surface `version`, `description`, and `displayName` from each scanned package's `package.json`
- Add `displayName` field to `@xds/cli`, `@xds/core`, `@xds/theme-default`, and `@xds/theme-neutral`
- Update human-friendly descriptions for all packages

## Test plan

- [ ] `xds discover --json` returns metadata fields for external packages
- [ ] `xds discover` terminal output shows displayName when present
- [ ] Existing discover functionality unchanged