### PR TITLE
fix(cli): handle showcase flag in package-scoped component resolution

### DIFF
--- a/packages/cli/src/api/component.mjs
+++ b/packages/cli/src/api/component.mjs
@@ -170,6 +170,22 @@ export async function component(name, options = {}) {
     if (!ext) {
       throw new XDSError(`External package "${packageScope}" not found`);
     }
+
+    if (showcase) {
+      const match = await findShowcase(dirName, cwd);
+      if (!match) {
+        throw new XDSError(`No showcase found for "${name}" in package "${packageScope}"`);
+      }
+      return {
+        type: 'component.detail.showcase',
+        data: {
+          component: dirName,
+          aspectRatio: match.aspectRatio,
+          source: fs.readFileSync(match.filePath, 'utf-8'),
+        },
+      };
+    }
+
     const extDocPath = findExternalComponentDoc(ext.docsDir, dirName);
     if (extDocPath && extDocPath.endsWith('.doc.mjs')) {
       const docs = await loadDocs(extDocPath, {zh, dense, lang});

--- a/packages/cli/src/commands/component-package.test.mjs
+++ b/packages/cli/src/commands/component-package.test.mjs
@@ -24,9 +24,27 @@ function createFixture() {
   const extSrc = path.join(extDir, 'src');
   fs.mkdirSync(path.join(extSrc, 'Button'), {recursive: true});
   fs.mkdirSync(path.join(extSrc, 'Employee'), {recursive: true});
+
+  // Blocks directory with an Employee showcase
+  const blocksDir = path.join(extDir, 'blocks', 'components', 'Employee');
+  fs.mkdirSync(blocksDir, {recursive: true});
+  fs.writeFileSync(path.join(blocksDir, 'EmployeeShowcase.doc.mjs'), `
+export const doc = {
+  type: 'block',
+  name: 'Employee — Showcase',
+  description: 'Employee showcase.',
+  isReady: true,
+  isShowcase: true,
+  aspectRatio: 16 / 9,
+  componentsUsed: ['Employee'],
+};
+`);
+  fs.writeFileSync(path.join(blocksDir, 'EmployeeShowcase.tsx'),
+    "'use client';\nexport default function EmployeeShowcase() { return <div>Employee</div>; }");
+
   fs.writeFileSync(path.join(extDir, 'package.json'), JSON.stringify({
     name: '@test/ext',
-    xds: {docs: './src', category: 'Common'},
+    xds: {docs: './src', category: 'Common', blocks: './blocks/components'},
   }));
   fs.writeFileSync(path.join(extSrc, 'Button', 'Button.doc.mjs'), `
 export const docs = {
@@ -91,5 +109,13 @@ describe('component() with --package option', () => {
     await expect(
       component('Avatar', {cwd: tmpDir, package: '@test/ext'}),
     ).rejects.toThrow('No component "Avatar" in package');
+  });
+
+  it('returns showcase from external package when --package + --showcase', async () => {
+    const result = await component('Employee', {cwd: tmpDir, package: '@test/ext', showcase: true});
+    expect(result.type).toBe('component.detail.showcase');
+    expect(result.data.component).toBe('Employee');
+    expect(result.data.source).toContain('EmployeeShowcase');
+    expect(result.data.aspectRatio).toBeCloseTo(16 / 9);
   });
 });


### PR DESCRIPTION
The package-scoped path in `component()` returned early with `component.detail` before checking the `showcase`/`source`/`blocks` flags. This meant:

```js
component('Diff', {package: '@nest/xds-common', showcase: true})
// returned: { type: 'component.detail', ... }  ← wrong
// expected: { type: 'component.detail.showcase', ... }
```

Now the `showcase` flag is checked inside the package-scoped block, calling `findShowcase()` with `cwd` so it searches external package blocks.

Regression from #1919.

### Test

New integration test: `component('Employee', {package, showcase: true})` returns `component.detail.showcase` with the correct source and aspect ratio.