### PR TITLE
fix(cli): scope findShowcase to package when package filter is set

### DIFF
--- a/packages/cli/src/api/component.mjs
+++ b/packages/cli/src/api/component.mjs
@@ -172,7 +172,7 @@ export async function component(name, options = {}) {
     }
 
     if (showcase) {
-      const match = await findShowcase(dirName, cwd);
+      const match = await findShowcase(dirName, cwd, {package: packageScope});
       if (!match) {
         throw new XDSError(`No showcase found for "${name}" in package "${packageScope}"`);
       }

--- a/packages/cli/src/api/template.mjs
+++ b/packages/cli/src/api/template.mjs
@@ -159,10 +159,24 @@ export async function findRelatedBlocks(componentName, cwd) {
   );
 }
 
-export async function findShowcase(componentName, cwd) {
+/**
+ * @param {string} componentName
+ * @param {string} [cwd]
+ * @param {{ package?: string }} [options] - When set, only search blocks from this package.
+ *   Core blocks have no `package` field; external blocks have `package` set to the npm name.
+ */
+export async function findShowcase(componentName, cwd, options) {
   const blocks = await discoverAllBlocks(cwd);
   const lc = componentName.toLowerCase();
-  const showcases = blocks.filter(b => b.isShowcase);
+  const packageFilter = options?.package;
+
+  // When scoped to a package, only consider blocks from that package.
+  // Core blocks have no `package` field — filter them out when a package is specified.
+  const showcases = blocks.filter(b => {
+    if (!b.isShowcase) return false;
+    if (packageFilter) return b.package === packageFilter;
+    return true;
+  });
 
   const toResult = (b) => ({
     name: b.name,


### PR DESCRIPTION
For overlapping component names (CommandPalette, Button, SideNav, etc.), `findShowcase()` was returning core's showcase even when called with a package scope. Core blocks matched first on the directory-name priority check.

`findShowcase` now accepts an optional `{package}` filter. When set, only blocks from that specific package are searched — core blocks (which have no `package` field) are excluded.

```js
// Before: returns core's CommandPalette showcase
component('CommandPalette', {package: '@nest/xds-common', showcase: true})

// After: returns xds-common's CommandPalette showcase
component('CommandPalette', {package: '@nest/xds-common', showcase: true})
```

The `package` field on external blocks is already set by `discoverExternalBlocks()` from #1920.