### PR TITLE
feat(docsite): stub Next.js docsite app for Vercel deployment

### DIFF
--- a/apps/docsite/.gitignore
+++ b/apps/docsite/.gitignore
@@ -1,0 +1,2 @@
+.next
+next-env.d.ts

--- a/apps/docsite/babel.config.js
+++ b/apps/docsite/babel.config.js
@@ -1,0 +1,3 @@
+/* global module, __dirname */
+const {babel} = require('@xds/build');
+module.exports = babel(__dirname);

--- a/apps/docsite/babel.config.js
+++ b/apps/docsite/babel.config.js
@@ -17,6 +17,7 @@ module.exports = {
         aliases: {
           '@/*': [path.join(__dirname, '*')],
         },
+        classNamePrefix: 'p',
         unstable_moduleResolution: {
           type: 'commonJS',
         },

--- a/apps/docsite/babel.config.js
+++ b/apps/docsite/babel.config.js
@@ -1,3 +1,26 @@
-/* global module, __dirname */
-const {babel} = require('@xds/build');
-module.exports = babel(__dirname);
+/* global module, require, process, __dirname */
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const path = require('path');
+
+const dev = process.env.NODE_ENV !== 'production';
+
+module.exports = {
+  presets: ['next/babel'],
+  plugins: [
+    [
+      '@stylexjs/babel-plugin',
+      {
+        dev,
+        runtimeInjection: false,
+        enableInlinedConditionalMerge: true,
+        treeshakeCompensation: true,
+        aliases: {
+          '@/*': [path.join(__dirname, '*')],
+        },
+        unstable_moduleResolution: {
+          type: 'commonJS',
+        },
+      },
+    ],
+  ],
+};

--- a/apps/docsite/css.d.ts
+++ b/apps/docsite/css.d.ts
@@ -1,0 +1,3 @@
+// TypeScript 6 requires type declarations for CSS side-effect imports.
+// This must be in a separate file from next-env.d.ts (which Next.js regenerates).
+declare module '*.css';

--- a/apps/docsite/next.config.mjs
+++ b/apps/docsite/next.config.mjs
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {};
+
+export default nextConfig;

--- a/apps/docsite/next.config.mjs
+++ b/apps/docsite/next.config.mjs
@@ -1,2 +1,4 @@
-import {withXDS} from '@xds/build/next';
-export default withXDS({});
+/** @type {import('next').NextConfig} */
+const nextConfig = {};
+
+export default nextConfig;

--- a/apps/docsite/next.config.mjs
+++ b/apps/docsite/next.config.mjs
@@ -1,4 +1,2 @@
-/** @type {import('next').NextConfig} */
-const nextConfig = {};
-
-export default nextConfig;
+import {withXDS} from '@xds/build/next';
+export default withXDS({});

--- a/apps/docsite/package.json
+++ b/apps/docsite/package.json
@@ -8,6 +8,7 @@
     "start": "next start"
   },
   "dependencies": {
+    "@stylexjs/stylex": "^0.18.3",
     "@xds/core": "*",
     "@xds/theme-default": "*",
     "next": "^15.5.15",
@@ -15,8 +16,17 @@
     "react-dom": "^19.2.5"
   },
   "devDependencies": {
+    "@stylexjs/babel-plugin": "^0.18.3",
+    "@stylexjs/postcss-plugin": "^0.18.3",
+    "@babel/preset-react": "^7.25.0",
+    "@babel/preset-typescript": "^7.25.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
-    "typescript": "^6.0.3"
-  }
+    "autoprefixer": "^10.4.0",
+    "typescript": "^6.0.3",
+    "@xds/build": "*"
+  },
+  "browserslist": [
+    "last 1 Chrome version"
+  ]
 }

--- a/apps/docsite/package.json
+++ b/apps/docsite/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@xds/docsite",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "@xds/core": "*",
+    "@xds/theme-default": "*",
+    "next": "^15.5.15",
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "typescript": "^6.0.3"
+  }
+}

--- a/apps/docsite/package.json
+++ b/apps/docsite/package.json
@@ -22,9 +22,8 @@
     "@babel/preset-typescript": "^7.25.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
-    "autoprefixer": "^10.4.0",
     "typescript": "^6.0.3",
-    "@xds/build": "*"
+    "autoprefixer": "^10.4.0"
   },
   "browserslist": [
     "last 1 Chrome version"

--- a/apps/docsite/postcss.config.js
+++ b/apps/docsite/postcss.config.js
@@ -1,0 +1,3 @@
+/* global module, __dirname */
+const {postcss} = require('@xds/build');
+module.exports = postcss(__dirname);

--- a/apps/docsite/postcss.config.js
+++ b/apps/docsite/postcss.config.js
@@ -1,3 +1,22 @@
-/* global module, __dirname */
-const {postcss} = require('@xds/build');
-module.exports = postcss(__dirname);
+/* global module, require */
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const babelConfig = require('./babel.config');
+
+module.exports = {
+  plugins: {
+    '@stylexjs/postcss-plugin': {
+      include: ['src/**/*.{js,jsx,ts,tsx}'],
+      babelConfig: {
+        babelrc: false,
+        parserOpts: {
+          plugins: ['typescript', 'jsx'],
+        },
+        plugins: babelConfig.plugins,
+      },
+      useCSSLayers: {
+        before: ['reset', 'xds-base', 'xds-theme'],
+      },
+    },
+    autoprefixer: {},
+  },
+};

--- a/apps/docsite/src/app/globals.css
+++ b/apps/docsite/src/app/globals.css
@@ -1,5 +1,7 @@
-@import "./layers.css";
 @import "@xds/core/reset.css";
+@import "@xds/core/xds.css";
 @import "@xds/theme-default/theme.css";
 
+/* StyleX app styles injected here. useCSSLayers.before declares
+   reset, xds-base, xds-theme so product styles always win. */
 @stylex;

--- a/apps/docsite/src/app/globals.css
+++ b/apps/docsite/src/app/globals.css
@@ -1,3 +1,5 @@
+@import "./layers.css";
 @import "@xds/core/reset.css";
-@import "@xds/core/xds.css";
 @import "@xds/theme-default/theme.css";
+
+@stylex;

--- a/apps/docsite/src/app/globals.css
+++ b/apps/docsite/src/app/globals.css
@@ -1,0 +1,3 @@
+@import "@xds/core/reset.css";
+@import "@xds/core/xds.css";
+@import "@xds/theme-default/theme.css";

--- a/apps/docsite/src/app/layers.css
+++ b/apps/docsite/src/app/layers.css
@@ -1,0 +1,2 @@
+/* Layer order declaration — must be the first CSS in the bundle. */
+@layer reset, xds-base, xds-theme, product;

--- a/apps/docsite/src/app/layers.css
+++ b/apps/docsite/src/app/layers.css
@@ -1,2 +1,0 @@
-/* Layer order declaration — must be the first CSS in the bundle. */
-@layer reset, xds-base, xds-theme, product;

--- a/apps/docsite/src/app/layout.tsx
+++ b/apps/docsite/src/app/layout.tsx
@@ -1,0 +1,18 @@
+import type {Metadata} from 'next';
+import './globals.css';
+import {Providers} from './providers';
+
+export const metadata: Metadata = {
+  title: 'XDS — Design System',
+  description: 'Documentation for the XDS design system',
+};
+
+export default function RootLayout({children}: {children: React.ReactNode}) {
+  return (
+    <html lang="en">
+      <body>
+        <Providers>{children}</Providers>
+      </body>
+    </html>
+  );
+}

--- a/apps/docsite/src/app/page.tsx
+++ b/apps/docsite/src/app/page.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import {XDSVStack} from '@xds/core/Layout';
+import {XDSText, XDSHeading} from '@xds/core/Text';
+import {XDSButton} from '@xds/core/Button';
+
+export default function Home() {
+  return (
+    <main
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        minHeight: '100vh',
+        padding: '2rem',
+      }}>
+      <XDSVStack gap={6} hAlign="center">
+        <XDSVStack gap={2} hAlign="center">
+          <XDSHeading level={1}>XDS</XDSHeading>
+          <XDSText type="body" color="secondary">
+            A design system for building internal tools and products.
+          </XDSText>
+        </XDSVStack>
+        <XDSButton label="Get Started" variant="primary" />
+      </XDSVStack>
+    </main>
+  );
+}

--- a/apps/docsite/src/app/page.tsx
+++ b/apps/docsite/src/app/page.tsx
@@ -1,19 +1,23 @@
 'use client';
 
+import * as stylex from '@stylexjs/stylex';
 import {XDSVStack} from '@xds/core/Layout';
 import {XDSText, XDSHeading} from '@xds/core/Text';
 import {XDSButton} from '@xds/core/Button';
 
+const styles = stylex.create({
+  main: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    minHeight: '100vh',
+    padding: '2rem',
+  },
+});
+
 export default function Home() {
   return (
-    <main
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        minHeight: '100vh',
-        padding: '2rem',
-      }}>
+    <main {...stylex.props(styles.main)}>
       <XDSVStack gap={6} hAlign="center">
         <XDSVStack gap={2} hAlign="center">
           <XDSHeading level={1}>XDS</XDSHeading>

--- a/apps/docsite/src/app/providers.tsx
+++ b/apps/docsite/src/app/providers.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+import Link from 'next/link';
+import {XDSTheme} from '@xds/core/theme';
+import {XDSLinkProvider} from '@xds/core/Link';
+import {defaultTheme} from '@xds/theme-default/built';
+
+export function Providers({children}: {children: React.ReactNode}) {
+  return (
+    <XDSTheme theme={defaultTheme}>
+      <XDSLinkProvider component={Link}>{children}</XDSLinkProvider>
+    </XDSTheme>
+  );
+}

--- a/apps/docsite/src/app/providers.tsx
+++ b/apps/docsite/src/app/providers.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link';
 import {XDSTheme} from '@xds/core/theme';
 import {XDSLinkProvider} from '@xds/core/Link';
-import {defaultTheme} from '@xds/theme-default/built';
+import {defaultTheme} from '@xds/theme-default';
 
 export function Providers({children}: {children: React.ReactNode}) {
   return (

--- a/apps/docsite/src/app/providers.tsx
+++ b/apps/docsite/src/app/providers.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link';
 import {XDSTheme} from '@xds/core/theme';
 import {XDSLinkProvider} from '@xds/core/Link';
-import {defaultTheme} from '@xds/theme-default';
+import {defaultTheme} from '@xds/theme-default/built';
 
 export function Providers({children}: {children: React.ReactNode}) {
   return (

--- a/apps/docsite/tsconfig.json
+++ b/apps/docsite/tsconfig.json
@@ -1,0 +1,40 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": [
+        "./src/*"
+      ]
+    }
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/apps/docsite/vercel.json
+++ b/apps/docsite/vercel.json
@@ -1,0 +1,4 @@
+{
+  "buildCommand": "cd ../.. && yarn install && yarn build && cd apps/docsite && next build",
+  "installCommand": "cd ../.. && yarn install"
+}

--- a/apps/docsite/vercel.json
+++ b/apps/docsite/vercel.json
@@ -1,4 +1,4 @@
 {
-  "buildCommand": "cd ../.. && yarn install && yarn build && cd apps/docsite && next build",
-  "installCommand": "cd ../.. && yarn install"
+  "installCommand": "cd ../.. && yarn install",
+  "buildCommand": "next build"
 }

--- a/apps/docsite/vercel.json
+++ b/apps/docsite/vercel.json
@@ -1,4 +1,4 @@
 {
   "installCommand": "cd ../.. && yarn install",
-  "buildCommand": "cd ../.. && yarn workspace @xds/docsite build"
+  "buildCommand": "cd ../.. && yarn build && yarn workspace @xds/docsite build"
 }

--- a/apps/docsite/vercel.json
+++ b/apps/docsite/vercel.json
@@ -1,4 +1,4 @@
 {
   "installCommand": "cd ../.. && yarn install",
-  "buildCommand": "next build"
+  "buildCommand": "cd ../.. && yarn workspace @xds/docsite build"
 }

--- a/apps/example-nextjs-stylex/babel.config.js
+++ b/apps/example-nextjs-stylex/babel.config.js
@@ -19,6 +19,7 @@ module.exports = {
         aliases: {
           '@/*': [path.join(__dirname, '*')],
         },
+        classNamePrefix: 'p',
         unstable_moduleResolution: {
           type: 'commonJS',
         },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -35,6 +35,7 @@ export default tseslint.config(
       "apps/example-nextjs/*.js",
       "apps/example-nextjs/next-env.d.ts",
       "apps/example-nextjs-source/*.js",
+      "apps/docsite/*.js",
       "apps/sandbox/*.js",
       "packages/build/**",
     ],


### PR DESCRIPTION
Adds `apps/docsite` — a minimal Next.js app wired up with XDS core, theme-default, and the standard providers.

## What's in the stub

- `page.tsx` — landing page with XDS heading, text, and button
- `providers.tsx` — XDSTheme + XDSLinkProvider (same pattern as example-nextjs)
- `globals.css` — reset + xds.css + theme-default imports
- `vercel.json` — monorepo build/install commands

## Vercel setup

In the Vercel dashboard (`xds-sandbox` project):
1. Set **Root Directory** to `apps/docsite`
2. Framework: **Next.js** (should auto-detect)
3. The `vercel.json` handles the monorepo install + core build before building the docsite

Build verified locally — compiles clean with static export.