### PR TITLE
fix(TabList): add escape hatches to XDSTabMenu

### DIFF
--- a/packages/core/src/TabList/XDSTabMenu.tsx
+++ b/packages/core/src/TabList/XDSTabMenu.tsx
@@ -33,6 +33,7 @@ import {useXDSTabListContext} from './XDSTabListContext';
 import type {XDSTabListSize} from './XDSTabListContext';
 import {tabScope} from './tab.markers.stylex';
 import {xdsClassName, mergeProps} from '../utils';
+import type {XDSBaseProps} from '../XDSBaseProps';
 
 export interface XDSTabMenuOption {
   value: string;
@@ -43,7 +44,10 @@ export interface XDSTabMenuOption {
   icon?: ReactNode | XDSIconType;
 }
 
-export interface XDSTabMenuProps {
+export interface XDSTabMenuProps extends Pick<
+  XDSBaseProps<HTMLButtonElement>,
+  'xstyle' | 'className' | 'style'
+> {
   /**
    * Label for the trigger button and dropdown heading.
    * Displayed as trigger text when no option is selected.
@@ -243,7 +247,13 @@ const hoverSizeStyles = stylex.create({
  * </XDSTabList>
  * ```
  */
-export function XDSTabMenu({label, options}: XDSTabMenuProps) {
+export function XDSTabMenu({
+  label,
+  options,
+  xstyle,
+  className,
+  style,
+}: XDSTabMenuProps) {
   const tabListCtx = useXDSTabListContext();
   const menuId = useId();
 
@@ -295,7 +305,10 @@ export function XDSTabMenu({label, options}: XDSTabMenuProps) {
             sizeStyles[size],
             hasSelectedOption && styles.triggerSelected,
             tabScope,
+            xstyle,
           ),
+          className,
+          style,
         )}>
         <span
           aria-hidden="true"


### PR DESCRIPTION
XDSTabMenu was missing XDSBaseProps extension — no xstyle, className, or style escape hatches. XDSTab already extends XDSBaseProps, making this an inconsistency within the TabList module.

## Changes

- Add `Pick<XDSBaseProps, 'xstyle' | 'className' | 'style'>` to `XDSTabMenuProps`
- Wire escape hatches into the trigger button's `mergeProps` call
- All 21 TabList tests pass, no type errors in the component

## Audit Summary

Component Auditor nightly run (2026-05-02) — 6 components audited:

**Pass 1 — Hardening:**
| Component | Issue | Result |
|-----------|-------|--------|
| Overlay | #1930 | Clean — all tokens, xdsClassName, a11y (inert), exports correct |

**Pass 2 — Queue:**
| Component | Result | Notes |
|-----------|--------|-------|
| TabList | **Fix** | XDSTabMenu missing XDSBaseProps (this PR) |
| Text | Clean | Semantic type system, truncation with tooltip, all conventions met |
| TextArea | Clean | Field integration, status wiring, data-autofocus, a11y correct |
| TextInput | Clean | Field integration, clear button a11y, data-autofocus correct |
| TimeInput | Clean | Keyboard nav (arrow keys), ISO parsing, range validation, all conventions met |

*Night Watch — Component Auditor*