### PR TITLE
feat(docsite): overview page + frosted glass topnav

### DIFF
--- a/apps/docsite/src/app/globals.css
+++ b/apps/docsite/src/app/globals.css
@@ -5,3 +5,14 @@
 /* StyleX app styles injected here. useCSSLayers.before declares
    reset, xds-base, xds-theme so product styles always win. */
 @stylex;
+
+/* Translucent top nav — frosted glass effect */
+.xds-layout-header,
+:has(> .xds-layout-header) {
+  background: transparent !important;
+}
+
+.xds-top-nav {
+  background: color-mix(in srgb, var(--color-background-surface) 80%, transparent);
+  backdrop-filter: blur(12px);
+}

--- a/apps/docsite/src/app/page.tsx
+++ b/apps/docsite/src/app/page.tsx
@@ -1,90 +1,215 @@
 /**
  * Page type: overview
- * The home page — stats, package cards, quick links.
+ * Home page — hero, libraries, foundations.
+ * All data from pipeline registries.
  */
 
+import * as stylex from '@stylexjs/stylex';
+import Link from 'next/link';
 import {XDSHeading, XDSText} from '@xds/core/Text';
 import {XDSVStack, XDSHStack} from '@xds/core/Layout';
-import {XDSCard} from '@xds/core/Card';
-import {XDSClickableCard} from '@xds/core/ClickableCard';
 import {XDSGrid} from '@xds/core/Grid';
 import {XDSSection} from '@xds/core/Section';
-import {XDSButton} from '@xds/core/Button';
 import {XDSBadge} from '@xds/core/Badge';
+import {XDSButton} from '@xds/core/Button';
 import {packages} from '../generated/packageRegistry';
 import {componentCount} from '../generated/componentRegistry';
-import {blockCount, showcaseCount} from '../generated/blockRegistry';
-import {templateCount} from '../generated/templateRegistry';
+import {docTopics} from '../generated/docsRegistry';
+
+const styles = stylex.create({
+  pageContainer: {
+    maxWidth: 1200,
+    marginInline: 'auto',
+    paddingInline: {
+      default: 16,
+      '@media (min-width: 768px)': 40,
+    },
+    paddingBlockStart: 0,
+    paddingBlockEnd: 32,
+  },
+  heroContainer: {
+    position: 'relative',
+    borderRadius: 16,
+    overflow: 'hidden',
+    backgroundColor: 'var(--color-background-card)',
+    minHeight: 300,
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: {
+      default: '48px 24px',
+      '@media (min-width: 768px)': 48,
+    },
+  },
+  heroTitle: {
+    textAlign: 'center' as const,
+  },
+  heroSubtitle: {
+    textAlign: 'center' as const,
+    marginTop: 8,
+  },
+  heroDescription: {
+    maxWidth: 480,
+    marginTop: 4,
+    fontSize: 16,
+    lineHeight: 1.5,
+    textAlign: 'center' as const,
+  },
+  heroButtons: {
+    marginTop: 24,
+  },
+  foundationImage: {
+    display: 'block',
+    width: '100%',
+    aspectRatio: '2/1',
+    objectFit: 'cover' as const,
+    borderRadius: 12,
+    marginBottom: 12,
+    backgroundColor: 'var(--color-background-card)',
+  },
+  packageImageWrapper: {
+    aspectRatio: '2/1',
+    borderRadius: 12,
+    position: 'relative' as const,
+    marginBottom: 12,
+    backgroundColor: 'var(--color-background-card)',
+  },
+  monoText: {
+    fontFamily: 'monospace',
+  },
+  versionText: {
+    marginLeft: 8,
+  },
+  linkReset: {
+    textDecoration: 'none',
+    color: 'inherit',
+    cursor: 'pointer',
+  },
+});
+
+const isThemePkg = (name: string) => name.includes('theme-');
+
+const foundationTopics = docTopics
+  .filter(d => d.category === 'foundations')
+  .sort((a, b) => {
+    if (a.topic === 'tokens') return -1;
+    if (b.topic === 'tokens') return 1;
+    return a.title.localeCompare(b.title);
+  });
 
 export default function HomePage() {
+  const coreCount = componentCount;
+  const libraryPackages = packages.filter(p => !isThemePkg(p.name));
+  const themePackages = packages.filter(p => isThemePkg(p.name));
+  const allPackages = [...libraryPackages, ...themePackages];
+
   return (
-    <XDSSection maxWidth="lg" padding={6}>
-      <XDSVStack gap={8}>
-        <XDSVStack gap={3}>
-          <XDSHeading level={1}>XDS</XDSHeading>
-          <XDSText type="large" color="secondary">
-            Open-source design system for building internal tools and products.
-          </XDSText>
-          <XDSHStack gap={3}>
-            <XDSButton
-              label="Getting Started"
-              variant="primary"
-              href="/docs/getting-started"
-            />
-            <XDSButton
-              label="Components"
-              variant="secondary"
-              href="/packages/core"
-            />
-            <XDSButton label="Changelog" variant="ghost" href="/changelog" />
-          </XDSHStack>
-        </XDSVStack>
+    <div {...stylex.props(styles.pageContainer)}>
+      <XDSSection padding={0}>
+        <XDSVStack gap={10} style={{rowGap: 60}}>
+          {/* Hero */}
+          <div {...stylex.props(styles.heroContainer)}>
+            <XDSText type="large" weight="semibold" xstyle={styles.heroTitle}>
+              XDS Open Source
+            </XDSText>
+            <XDSText type="display-1" xstyle={styles.heroSubtitle}>
+              Build with AI
+            </XDSText>
+            <XDSText
+              type="body"
+              color="secondary"
+              xstyle={styles.heroDescription}>
+              An open design system for building internal tools with AI-powered
+              development. Ship faster with {coreCount} accessible, themeable
+              components.
+            </XDSText>
+            <XDSHStack gap={3} xstyle={styles.heroButtons}>
+              <XDSButton
+                variant="primary"
+                label="Get started"
+                href="/docs/getting-started"
+              />
+              <XDSButton
+                variant="secondary"
+                label="Browse components"
+                href="/packages/core"
+              />
+            </XDSHStack>
+          </div>
 
-        <XDSGrid columns={4} gap={4} minChildWidth={140}>
-          <StatCard n={componentCount} label="Components" />
-          <StatCard n={blockCount} label="Blocks" />
-          <StatCard n={showcaseCount} label="Showcases" />
-          <StatCard n={templateCount} label="Templates" />
-        </XDSGrid>
-
-        <XDSVStack gap={4}>
-          <XDSHeading level={2}>Packages</XDSHeading>
-          <XDSGrid columns={2} gap={4} minChildWidth={280}>
-            {packages.map(p => (
-              <XDSClickableCard
-                key={p.name}
-                label={p.name}
-                href={`/packages/${p.name.replace('@xds/', '')}`}
-                padding={5}>
-                <XDSVStack gap={2}>
-                  <XDSHStack gap={2} vAlign="center">
-                    <XDSText type="body" weight="bold">
-                      {p.name}
+          {/* Libraries & Packages */}
+          <XDSVStack gap={5}>
+            <XDSVStack gap={1}>
+              <XDSHeading level={2}>Libraries &amp; Packages</XDSHeading>
+              <XDSText type="body" color="secondary">
+                Install what you need. All packages are published under the @xds
+                scope.
+              </XDSText>
+            </XDSVStack>
+            <XDSGrid
+              columns={{minWidth: 260, repeat: 'fit'}}
+              gap={4}
+              rowGap={8}>
+              {allPackages.map(pkg => (
+                <Link
+                  key={pkg.name}
+                  href={`/packages/${pkg.name.replace('@xds/', '')}`}
+                  {...stylex.props(styles.linkReset)}>
+                  <div {...stylex.props(styles.packageImageWrapper)} />
+                  <XDSVStack gap={0.5}>
+                    <span {...stylex.props(styles.monoText)}>
+                      <XDSText type="body" weight="bold">
+                        {pkg.name}
+                      </XDSText>
+                      <span {...stylex.props(styles.versionText)}>
+                        <XDSText type="supporting" color="secondary">
+                          v{pkg.version}
+                        </XDSText>
+                      </span>
+                    </span>
+                    <XDSText type="supporting" color="secondary">
+                      {pkg.description}
                     </XDSText>
-                    <XDSBadge label={`v${p.version}`} variant="info" />
-                  </XDSHStack>
-                  <XDSText type="supporting" color="secondary">
-                    {p.description}
-                  </XDSText>
-                </XDSVStack>
-              </XDSClickableCard>
-            ))}
-          </XDSGrid>
-        </XDSVStack>
-      </XDSVStack>
-    </XDSSection>
-  );
-}
+                  </XDSVStack>
+                </Link>
+              ))}
+            </XDSGrid>
+          </XDSVStack>
 
-function StatCard({n, label}: {n: number; label: string}) {
-  return (
-    <XDSCard padding={4}>
-      <XDSVStack gap={1} hAlign="center">
-        <XDSText type="display-2">{n}</XDSText>
-        <XDSText type="supporting" color="secondary">
-          {label}
-        </XDSText>
-      </XDSVStack>
-    </XDSCard>
+          {/* Foundations */}
+          <XDSVStack gap={5}>
+            <XDSVStack gap={1}>
+              <XDSHeading level={2}>Foundations</XDSHeading>
+              <XDSText type="body" color="secondary">
+                The design tokens and primitives that every component is built
+                on.
+              </XDSText>
+            </XDSVStack>
+            <XDSGrid
+              columns={{minWidth: 300, repeat: 'fit'}}
+              gap={4}
+              rowGap={8}>
+              {foundationTopics.map(topic => (
+                <Link
+                  key={topic.topic}
+                  href={`/docs/${topic.topic}`}
+                  {...stylex.props(styles.linkReset)}>
+                  <div {...stylex.props(styles.foundationImage)} />
+                  <XDSVStack gap={1}>
+                    <XDSText type="body" weight="bold">
+                      {topic.title}
+                    </XDSText>
+                    <XDSText type="supporting" color="secondary">
+                      {topic.description}
+                    </XDSText>
+                  </XDSVStack>
+                </Link>
+              ))}
+            </XDSGrid>
+          </XDSVStack>
+        </XDSVStack>
+      </XDSSection>
+    </div>
   );
 }


### PR DESCRIPTION
Overview page ported from Nest docsite design, all data from pipeline.

## Overview page
- Hero section with component count from registry
- Libraries & Packages grid from `packageRegistry`
- Foundations grid from `docsRegistry` (category=foundations)
- No 'Where to use' section (internal-specific in Nest)

## CSS
- Frosted glass top nav: `backdrop-filter: blur(12px)` on `.xds-top-nav`
- Layout header made transparent so blur shows through

Placeholder images for cards — real assets will be added as created.