### PR TITLE
fix(docsite): enable mobile nav

### DIFF
--- a/apps/docsite/src/components/DocsShell.tsx
+++ b/apps/docsite/src/components/DocsShell.tsx
@@ -170,7 +170,6 @@ export function DocsShell({
     <XDSAppShell
       variant="surface"
       height="fill"
-      mobileNav={{breakpoint: 'none'}}
       topNav={
         <XDSTopNav
           label="XDS navigation"


### PR DESCRIPTION
Removes `mobileNav={{breakpoint: 'none'}}` from DocsShell so the app shell uses its default responsive breakpoint. This enables the mobile hamburger nav on small screens.