### PR TITLE
feat(docsite): live token tables for foundation docs

### DIFF
--- a/apps/docsite/src/app/docs/[topic]/page.tsx
+++ b/apps/docsite/src/app/docs/[topic]/page.tsx
@@ -2,12 +2,24 @@
  * Page type: long-form-doc
  * Renders guide and foundation docs from the pipeline.
  * Content blocks (prose, code, table, list) rendered via ContentBlockRenderer.
+ * Token topics (foundations category) render TokensDocView with live token tables.
  */
 
 import {notFound} from 'next/navigation';
 import {XDSSection} from '@xds/core/Section';
 import {docTopics} from '../../../generated/docsRegistry';
 import {ReferenceDocView} from '../../../components/docs/ReferenceDocView';
+import {TokensDocView} from '../../../components/docs/TokensDocView';
+
+const TOKEN_TOPICS = new Set([
+  'tokens',
+  'color',
+  'elevation',
+  'motion',
+  'shape',
+  'spacing',
+  'typography',
+]);
 
 export function generateStaticParams() {
   return docTopics.map(d => ({topic: d.topic}));
@@ -22,13 +34,25 @@ export default async function DocPage({
   const topic = docTopics.find(d => d.topic === slug);
   if (!topic) notFound();
 
+  const isTokenTopic =
+    topic.category === 'foundations' && TOKEN_TOPICS.has(topic.topic);
+
   return (
     <XDSSection maxWidth="lg" padding={6}>
-      <ReferenceDocView
-        title={topic.title}
-        description={topic.description}
-        sections={topic.sections}
-      />
+      {isTokenTopic ? (
+        <TokensDocView
+          title={topic.title}
+          description={topic.description}
+          sections={topic.sections}
+          topic={topic.topic}
+        />
+      ) : (
+        <ReferenceDocView
+          title={topic.title}
+          description={topic.description}
+          sections={topic.sections}
+        />
+      )}
     </XDSSection>
   );
 }

--- a/apps/docsite/src/components/docs/TokensDocView.tsx
+++ b/apps/docsite/src/components/docs/TokensDocView.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import {XDSVStack} from '@xds/core/Layout';
+import {XDSText} from '@xds/core/Text';
+import {useXDSTheme} from '@xds/core/theme';
+import {
+  ColorTokenTable,
+  SpacingTokenTable,
+  RadiusTokenTable,
+  BorderTokenTable,
+  ElevationTokenTable,
+  DurationTokenTable,
+  EasingTokenTable,
+  TypographyTokenTable,
+  FontFamilyTokenTable,
+  FontWeightTokenTable,
+  FontSizeTokenTable,
+} from '../tokens';
+import {ReferenceDocView} from './ReferenceDocView';
+import {ContentBlockRenderer} from './ContentBlockRenderer';
+import type {DocSection} from '../../generated/docsRegistry';
+import type {TokenTableProps} from '../tokens';
+import type {ComponentType} from 'react';
+
+// ---------------------------------------------------------------------------
+// Map section titles to token table components per topic
+// ---------------------------------------------------------------------------
+
+type TableComponent = ComponentType<TokenTableProps>;
+
+const TOPIC_SECTION_OVERRIDES: Record<
+  string,
+  Record<string, TableComponent>
+> = {
+  tokens: {
+    'Color Tokens': ColorTokenTable,
+    'Spacing Tokens': SpacingTokenTable,
+    'Size Tokens': SpacingTokenTable,
+    'Border Tokens': BorderTokenTable,
+    'Radius Tokens': RadiusTokenTable,
+    'Shadow Tokens': ElevationTokenTable,
+    'Duration Tokens': DurationTokenTable,
+    'Easing Tokens': EasingTokenTable,
+    'Font Family Tokens': FontFamilyTokenTable,
+    'Font Size Tokens': FontSizeTokenTable,
+    'Font Weight Tokens': FontWeightTokenTable,
+    'Type Scale Tokens': TypographyTokenTable,
+  },
+  color: {
+    'Surface Colors': ColorTokenTable,
+  },
+  elevation: {
+    'Elevation Scale': ElevationTokenTable,
+  },
+  motion: {
+    Duration: DurationTokenTable,
+    Easing: EasingTokenTable,
+  },
+  shape: {
+    'Radius Scale': RadiusTokenTable,
+  },
+  spacing: {
+    Scale: SpacingTokenTable,
+  },
+  typography: {
+    'Font Families': FontFamilyTokenTable,
+    'Font Sizes': FontSizeTokenTable,
+    'Font Weights': FontWeightTokenTable,
+    'Type Scale': TypographyTokenTable,
+  },
+};
+
+// ---------------------------------------------------------------------------
+// TokenSection — renders prose blocks from the section + the table component
+// ---------------------------------------------------------------------------
+
+function TokenSection({
+  section,
+  Table,
+  theme,
+}: {
+  section: DocSection;
+  Table: TableComponent;
+  theme: TokenTableProps['theme'];
+}) {
+  return (
+    <XDSVStack gap={4}>
+      <XDSText type="display-3">{section.title}</XDSText>
+      {section.content.map((block, i) => (
+        <ContentBlockRenderer key={i} block={block} />
+      ))}
+      <Table theme={theme} />
+    </XDSVStack>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// TokensDocView
+// ---------------------------------------------------------------------------
+
+export function TokensDocView({
+  title,
+  description,
+  sections,
+  topic,
+}: {
+  title: string;
+  description: string;
+  sections: DocSection[];
+  topic: string;
+}) {
+  const theme = useXDSTheme();
+  const overrideMap = TOPIC_SECTION_OVERRIDES[topic] ?? {};
+
+  const sectionOverrides: Record<
+    string,
+    (section: DocSection) => React.ReactNode
+  > = {};
+  for (const [sectionTitle, Table] of Object.entries(overrideMap)) {
+    sectionOverrides[sectionTitle] = (section: DocSection) => (
+      <TokenSection section={section} Table={Table} theme={theme} />
+    );
+  }
+
+  return (
+    <ReferenceDocView
+      title={title}
+      description={description}
+      sections={sections}
+      sectionOverrides={sectionOverrides}
+    />
+  );
+}

--- a/apps/docsite/src/components/tokens/ColorTokenTable.tsx
+++ b/apps/docsite/src/components/tokens/ColorTokenTable.tsx
@@ -1,0 +1,144 @@
+'use client';
+
+import * as stylex from '@stylexjs/stylex';
+import {XDSHStack} from '@xds/core/Layout';
+import {XDSText} from '@xds/core/Text';
+import {XDSTable, pixel} from '@xds/core/Table';
+import type {TokenTableProps} from './types';
+import {resolveTokenForMode, hasDualMode, getTokensByPrefix} from './helpers';
+
+const styles = stylex.create({
+  swatch: {
+    width: 28,
+    height: 28,
+    borderRadius: 'var(--radius-element)',
+    flexShrink: 0,
+    border: '1px solid var(--color-border)',
+  },
+  contextLight: {
+    width: 28,
+    height: 28,
+    borderRadius: 'var(--radius-element)',
+    backgroundColor: '#FFFFFF',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+    border: '1px solid var(--color-border)',
+  },
+  contextDark: {
+    width: 28,
+    height: 28,
+    borderRadius: 'var(--radius-element)',
+    backgroundColor: '#1C1C1E',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+    border: '1px solid var(--color-border)',
+  },
+  swatchInner: {
+    width: 20,
+    height: 20,
+    borderRadius: 'var(--radius-inner)',
+  },
+});
+
+function ContextSwatch({
+  value,
+  surface,
+}: {
+  value: string;
+  surface: 'light' | 'dark';
+}) {
+  return (
+    <div
+      {...stylex.props(
+        surface === 'light' ? styles.contextLight : styles.contextDark,
+      )}>
+      <div
+        {...stylex.props(styles.swatchInner)}
+        style={{backgroundColor: value}}
+      />
+    </div>
+  );
+}
+
+function Swatch({value}: {value: string}) {
+  return (
+    <div {...stylex.props(styles.swatch)} style={{backgroundColor: value}} />
+  );
+}
+
+export function ColorTokenTable({theme}: TokenTableProps) {
+  const tokens = getTokensByPrefix(theme, '--color-');
+  const isDual = hasDualMode(theme);
+
+  const data = tokens.map(name => ({
+    tokenName: name,
+    light: resolveTokenForMode(theme, name, 'light'),
+    dark: resolveTokenForMode(theme, name, 'dark'),
+  }));
+
+  if (isDual) {
+    return (
+      <XDSTable
+        data={data as Record<string, unknown>[]}
+        columns={[
+          {key: 'tokenName', header: 'Token', width: pixel(300)},
+          {
+            key: 'light',
+            header: 'Light',
+            renderCell: (item: Record<string, unknown>) => (
+              <XDSHStack gap={2} vAlign="center">
+                <ContextSwatch value={item.light as string} surface="light" />
+                <XDSText type="code" color="secondary">
+                  {item.light as string}
+                </XDSText>
+              </XDSHStack>
+            ),
+          },
+          {
+            key: 'dark',
+            header: 'Dark',
+            renderCell: (item: Record<string, unknown>) => (
+              <XDSHStack gap={2} vAlign="center">
+                <ContextSwatch value={item.dark as string} surface="dark" />
+                <XDSText type="code" color="secondary">
+                  {item.dark as string}
+                </XDSText>
+              </XDSHStack>
+            ),
+          },
+        ]}
+        density="spacious"
+        dividers="rows"
+        hasHover
+      />
+    );
+  }
+
+  return (
+    <XDSTable
+      data={data as Record<string, unknown>[]}
+      columns={[
+        {key: 'tokenName', header: 'Token', width: pixel(300)},
+        {
+          key: 'light',
+          header: 'Value',
+          renderCell: (item: Record<string, unknown>) => (
+            <XDSHStack gap={2} vAlign="center">
+              <Swatch value={item.light as string} />
+              <XDSText type="code" color="secondary">
+                {item.light as string}
+              </XDSText>
+            </XDSHStack>
+          ),
+        },
+      ]}
+      density="spacious"
+      dividers="rows"
+      hasHover
+    />
+  );
+}

--- a/apps/docsite/src/components/tokens/ElevationTokenTable.tsx
+++ b/apps/docsite/src/components/tokens/ElevationTokenTable.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import * as stylex from '@stylexjs/stylex';
+import {XDSHStack} from '@xds/core/Layout';
+import {XDSText} from '@xds/core/Text';
+import {XDSTable, pixel} from '@xds/core/Table';
+import type {TokenTableProps} from './types';
+import {resolveToken, getTokensByPrefix} from './helpers';
+
+const styles = stylex.create({
+  shadowBox: {
+    width: 32,
+    height: 24,
+    borderRadius: 'var(--radius-element)',
+    backgroundColor: 'var(--color-background-surface)',
+    flexShrink: 0,
+  },
+});
+
+const SHADOW_ORDER = ['--shadow-low', '--shadow-medium', '--shadow-high'];
+
+export function ElevationTokenTable({theme}: TokenTableProps) {
+  const allTokens = getTokensByPrefix(theme, '--shadow-');
+  // Sort by low/medium/high order, then alphabetical for any others
+  const orderMap = new Map(SHADOW_ORDER.map((k, i) => [k, i]));
+  const tokens = [...allTokens].sort((a, b) => {
+    const ai = orderMap.get(a) ?? 99;
+    const bi = orderMap.get(b) ?? 99;
+    if (ai !== bi) return ai - bi;
+    return a.localeCompare(b);
+  });
+
+  const data = tokens.map(name => ({
+    tokenName: name,
+    value: resolveToken(theme, name),
+  }));
+
+  return (
+    <XDSTable
+      data={data as Record<string, unknown>[]}
+      columns={[
+        {key: 'tokenName', header: 'Token', width: pixel(300)},
+        {
+          key: 'value',
+          header: 'Value',
+          renderCell: (item: Record<string, unknown>) => (
+            <XDSHStack gap={2} vAlign="center">
+              <div
+                {...stylex.props(styles.shadowBox)}
+                style={{boxShadow: item.value as string}}
+              />
+              <XDSText type="code" color="secondary">
+                {item.value as string}
+              </XDSText>
+            </XDSHStack>
+          ),
+        },
+      ]}
+      density="spacious"
+      dividers="rows"
+      hasHover
+    />
+  );
+}

--- a/apps/docsite/src/components/tokens/FontTokenTables.tsx
+++ b/apps/docsite/src/components/tokens/FontTokenTables.tsx
@@ -1,0 +1,145 @@
+'use client';
+
+import * as stylex from '@stylexjs/stylex';
+import {XDSHStack} from '@xds/core/Layout';
+import {XDSText} from '@xds/core/Text';
+import {XDSTable, pixel} from '@xds/core/Table';
+import type {TokenTableProps} from './types';
+import {resolveToken, getTokensByPrefix} from './helpers';
+
+const FONT_SAMPLE = 'The quick brown fox jumps over the lazy dog';
+
+const styles = stylex.create({
+  fontSample: {
+    overflow: 'hidden',
+    whiteSpace: 'nowrap',
+    textOverflow: 'ellipsis',
+    maxWidth: 200,
+  },
+  weightSwatch: {
+    flex: 1,
+    overflow: 'hidden',
+    whiteSpace: 'nowrap',
+    textOverflow: 'ellipsis',
+  },
+  valueLabel: {
+    flexShrink: 0,
+    width: 40,
+  },
+});
+
+export function FontFamilyTokenTable({theme}: TokenTableProps) {
+  const tokens = getTokensByPrefix(theme, '--font-family-');
+  const data = tokens.map(name => ({
+    tokenName: name,
+    value: resolveToken(theme, name),
+  }));
+
+  return (
+    <XDSTable
+      data={data as Record<string, unknown>[]}
+      columns={[
+        {key: 'tokenName', header: 'Token', width: pixel(300)},
+        {
+          key: 'value',
+          header: 'Value',
+          renderCell: (item: Record<string, unknown>) => (
+            <XDSHStack gap={3} vAlign="center">
+              <XDSText type="code" color="secondary">
+                {(item.value as string)?.split(',')[0]?.trim()}
+              </XDSText>
+              <span
+                {...stylex.props(styles.fontSample)}
+                style={{
+                  fontFamily: item.value as string,
+                  flex: 1,
+                  maxWidth: 'none',
+                }}>
+                {FONT_SAMPLE}
+              </span>
+            </XDSHStack>
+          ),
+        },
+      ]}
+      density="spacious"
+      dividers="rows"
+      hasHover
+    />
+  );
+}
+
+export function FontWeightTokenTable({theme}: TokenTableProps) {
+  const tokens = getTokensByPrefix(theme, '--font-weight-');
+  const data = tokens.map(name => ({
+    tokenName: name,
+    value: resolveToken(theme, name),
+  }));
+
+  return (
+    <XDSTable
+      data={data as Record<string, unknown>[]}
+      columns={[
+        {key: 'tokenName', header: 'Token', width: pixel(300)},
+        {
+          key: 'value',
+          header: 'Value',
+          renderCell: (item: Record<string, unknown>) => (
+            <XDSHStack gap={3} vAlign="center">
+              <XDSText type="code" color="secondary">
+                {item.value as string}
+              </XDSText>
+              <span
+                {...stylex.props(styles.weightSwatch)}
+                style={{fontWeight: item.value as string}}>
+                {FONT_SAMPLE}
+              </span>
+            </XDSHStack>
+          ),
+        },
+      ]}
+      density="spacious"
+      dividers="rows"
+      hasHover
+    />
+  );
+}
+
+export function FontSizeTokenTable({theme}: TokenTableProps) {
+  const tokens = getTokensByPrefix(theme, '--font-size-');
+  const data = tokens.map(name => ({
+    tokenName: name,
+    value: resolveToken(theme, name),
+  }));
+
+  return (
+    <XDSTable
+      data={data as Record<string, unknown>[]}
+      columns={[
+        {key: 'tokenName', header: 'Token', width: pixel(300)},
+        {
+          key: 'value',
+          header: 'Value',
+          renderCell: (item: Record<string, unknown>) => (
+            <XDSHStack gap={3} vAlign="center">
+              <XDSText type="code" color="secondary">
+                {item.value as string}
+              </XDSText>
+              <span
+                {...stylex.props(styles.fontSample)}
+                style={{
+                  fontSize: item.value as string,
+                  flex: 1,
+                  maxWidth: 'none',
+                }}>
+                {FONT_SAMPLE}
+              </span>
+            </XDSHStack>
+          ),
+        },
+      ]}
+      density="spacious"
+      dividers="rows"
+      hasHover
+    />
+  );
+}

--- a/apps/docsite/src/components/tokens/MotionTokenTable.tsx
+++ b/apps/docsite/src/components/tokens/MotionTokenTable.tsx
@@ -1,0 +1,263 @@
+'use client';
+
+import {useState, useEffect, useRef} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {XDSVStack, XDSHStack} from '@xds/core/Layout';
+import {XDSText, XDSHeading} from '@xds/core/Text';
+import {XDSTable, pixel} from '@xds/core/Table';
+import type {TokenTableProps} from './types';
+import {resolveToken, getTokensByPrefix} from './helpers';
+
+const styles = stylex.create({
+  durationTrack: {
+    width: 40,
+    height: 8,
+    borderRadius: 'var(--radius-element)',
+    backgroundColor: 'var(--color-neutral)',
+    overflow: 'hidden',
+    flexShrink: 0,
+  },
+  durationFill: {
+    height: '100%',
+    borderRadius: 'var(--radius-element)',
+    backgroundColor: 'var(--color-accent)',
+  },
+  easingTrack: {
+    width: 40,
+    height: 8,
+    borderRadius: 'var(--radius-element)',
+    backgroundColor: 'var(--color-neutral)',
+    position: 'relative' as const,
+    overflow: 'visible',
+    flexShrink: 0,
+  },
+  easingDot: {
+    position: 'absolute' as const,
+    top: 0,
+    width: 8,
+    height: 8,
+    borderRadius: 'var(--radius-full)',
+    backgroundColor: 'var(--color-accent)',
+    transform: 'translateX(-50%)',
+  },
+});
+
+const DURATION_ORDER = [
+  '--duration-fast-min',
+  '--duration-fast',
+  '--duration-fast-max',
+  '--duration-medium-min',
+  '--duration-medium',
+  '--duration-medium-max',
+  '--duration-slow-min',
+  '--duration-slow',
+  '--duration-slow-max',
+];
+
+function sortDurationTokens(tokens: string[]): string[] {
+  const orderMap = new Map(DURATION_ORDER.map((k, i) => [k, i]));
+  return [...tokens].sort((a, b) => {
+    const ai = orderMap.get(a) ?? 99;
+    const bi = orderMap.get(b) ?? 99;
+    return ai - bi;
+  });
+}
+
+function DurationBar({value}: {value: string}) {
+  const [animate, setAnimate] = useState(false);
+  useEffect(() => {
+    const interval = setInterval(() => setAnimate(a => !a), 2000);
+    return () => clearInterval(interval);
+  }, []);
+  return (
+    <div {...stylex.props(styles.durationTrack)}>
+      <div
+        {...stylex.props(styles.durationFill)}
+        style={{
+          width: animate ? '100%' : '0%',
+          transition: `width ${value} ease`,
+        }}
+      />
+    </div>
+  );
+}
+
+function evaluateBezier(
+  x1: number,
+  y1: number,
+  x2: number,
+  y2: number,
+  t: number,
+): number {
+  const cx = 3 * x1,
+    bx = 3 * (x2 - x1) - cx,
+    ax = 1 - cx - bx;
+  const cy = 3 * y1,
+    by = 3 * (y2 - y1) - cy,
+    ay = 1 - cy - by;
+  const sampleX = (s: number) => ((ax * s + bx) * s + cx) * s;
+  const sampleY = (s: number) => ((ay * s + by) * s + cy) * s;
+  const sampleXDeriv = (s: number) => (3 * ax * s + 2 * bx) * s + cx;
+  let g = t;
+  for (let i = 0; i < 8; i++) {
+    const cur = sampleX(g) - t;
+    if (Math.abs(cur) < 1e-6) break;
+    const d = sampleXDeriv(g);
+    if (Math.abs(d) < 1e-6) break;
+    g -= cur / d;
+  }
+  return sampleY(Math.max(0, Math.min(1, g)));
+}
+
+function EasingCurve({value}: {value: string}) {
+  const [progress, setProgress] = useState(0);
+  const animRef = useRef<number | null>(null);
+  const startRef = useRef<number>(0);
+  const match = value.match(
+    /cubic-bezier\(\s*([\d.]+)\s*,\s*([-\d.]+)\s*,\s*([\d.]+)\s*,\s*([-\d.]+)\s*\)/,
+  );
+
+  useEffect(() => {
+    if (!match) return;
+    let running = true;
+    const duration = 1200,
+      pause = 800,
+      cycle = duration + pause;
+    function tick(ts: number) {
+      if (!running) return;
+      if (!startRef.current) startRef.current = ts;
+      const inCycle = (ts - startRef.current) % cycle;
+      setProgress(inCycle < duration ? inCycle / duration : 1);
+      if ((ts - startRef.current) % (cycle * 2) >= cycle * 2 - 16)
+        startRef.current = ts;
+      animRef.current = requestAnimationFrame(tick);
+    }
+    animRef.current = requestAnimationFrame(tick);
+    return () => {
+      running = false;
+      if (animRef.current) cancelAnimationFrame(animRef.current);
+    };
+  }, [match]);
+
+  if (!match) return null;
+  const [, x1, y1, x2, y2] = match.map(Number);
+  const easedY = evaluateBezier(x1, y1, x2, y2, progress);
+  const pad = 0.12;
+
+  return (
+    <XDSHStack gap={2} vAlign="center">
+      <svg
+        width={32}
+        height={24}
+        viewBox={`${-pad} ${-pad} ${1 + pad * 2} ${1 + pad * 2}`}
+        style={{flexShrink: 0}}>
+        <path
+          d={`M 0 1 C ${x1} ${1 - y1}, ${x2} ${1 - y2}, 1 0`}
+          fill="none"
+          stroke="var(--color-neutral)"
+          strokeWidth={0.04}
+        />
+        <path
+          d={`M 0 1 C ${x1} ${1 - y1}, ${x2} ${1 - y2}, 1 0`}
+          fill="none"
+          stroke="var(--color-accent)"
+          strokeWidth={0.06}
+          strokeDasharray="1"
+          strokeDashoffset={1 - progress}
+          pathLength={1}
+        />
+        <circle
+          cx={progress}
+          cy={1 - easedY}
+          r={0.06}
+          fill="var(--color-accent)"
+        />
+      </svg>
+      <div {...stylex.props(styles.easingTrack)}>
+        <div
+          {...stylex.props(styles.easingDot)}
+          style={{left: `${easedY * 100}%`}}
+        />
+      </div>
+    </XDSHStack>
+  );
+}
+
+export function DurationTokenTable({theme}: TokenTableProps) {
+  const tokens = sortDurationTokens(getTokensByPrefix(theme, '--duration-'));
+  const data = tokens.map(name => ({
+    tokenName: name,
+    value: resolveToken(theme, name),
+  }));
+
+  return (
+    <XDSTable
+      data={data as Record<string, unknown>[]}
+      columns={[
+        {key: 'tokenName', header: 'Token', width: pixel(300)},
+        {
+          key: 'value',
+          header: 'Value',
+          renderCell: (item: Record<string, unknown>) => (
+            <XDSHStack gap={2} vAlign="center">
+              <DurationBar value={item.value as string} />
+              <XDSText type="code" color="secondary">
+                {item.value as string}
+              </XDSText>
+            </XDSHStack>
+          ),
+        },
+      ]}
+      density="spacious"
+      dividers="rows"
+      hasHover
+    />
+  );
+}
+
+export function EasingTokenTable({theme}: TokenTableProps) {
+  const tokens = getTokensByPrefix(theme, '--ease-');
+  const data = tokens.map(name => ({
+    tokenName: name,
+    value: resolveToken(theme, name),
+  }));
+
+  return (
+    <XDSTable
+      data={data as Record<string, unknown>[]}
+      columns={[
+        {key: 'tokenName', header: 'Token', width: pixel(300)},
+        {
+          key: 'value',
+          header: 'Value',
+          renderCell: (item: Record<string, unknown>) => (
+            <XDSHStack gap={2} vAlign="center">
+              <EasingCurve value={item.value as string} />
+              <XDSText type="code" color="secondary">
+                {item.value as string}
+              </XDSText>
+            </XDSHStack>
+          ),
+        },
+      ]}
+      density="spacious"
+      dividers="rows"
+      hasHover
+    />
+  );
+}
+
+export function MotionTokenTable({theme}: TokenTableProps) {
+  return (
+    <XDSVStack gap={6}>
+      <XDSVStack gap={3}>
+        <XDSHeading level={3}>Duration</XDSHeading>
+        <DurationTokenTable theme={theme} />
+      </XDSVStack>
+      <XDSVStack gap={3}>
+        <XDSHeading level={3}>Easing</XDSHeading>
+        <EasingTokenTable theme={theme} />
+      </XDSVStack>
+    </XDSVStack>
+  );
+}

--- a/apps/docsite/src/components/tokens/ShapeTokenTable.tsx
+++ b/apps/docsite/src/components/tokens/ShapeTokenTable.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import * as stylex from '@stylexjs/stylex';
+import {XDSVStack, XDSHStack} from '@xds/core/Layout';
+import {XDSText, XDSHeading} from '@xds/core/Text';
+import {XDSTable, pixel} from '@xds/core/Table';
+import type {TokenTableProps} from './types';
+import {resolveToken, getTokensByPrefix} from './helpers';
+
+const styles = stylex.create({
+  radiusBox: {
+    width: 32,
+    height: 32,
+    backgroundColor: 'var(--color-accent-muted)',
+    border: '2px solid var(--color-accent)',
+    flexShrink: 0,
+  },
+  borderLine: {
+    width: 32,
+    height: 0,
+    borderBottomStyle: 'solid',
+    borderBottomColor: 'var(--color-border-emphasized)',
+    flexShrink: 0,
+  },
+});
+
+const RADIUS_ORDER = [
+  '--radius-none',
+  '--radius-inner',
+  '--radius-element',
+  '--radius-container',
+  '--radius-page',
+  '--radius-full',
+];
+
+function sortByOrder(tokens: string[], order: string[]): string[] {
+  const orderMap = new Map(order.map((k, i) => [k, i]));
+  return [...tokens].sort((a, b) => {
+    const ai = orderMap.get(a) ?? 99;
+    const bi = orderMap.get(b) ?? 99;
+    return ai - bi;
+  });
+}
+
+export function RadiusTokenTable({theme}: TokenTableProps) {
+  const tokens = sortByOrder(
+    getTokensByPrefix(theme, '--radius-'),
+    RADIUS_ORDER,
+  );
+  const data = tokens.map(name => ({
+    tokenName: name,
+    value: resolveToken(theme, name),
+  }));
+
+  return (
+    <XDSTable
+      data={data as Record<string, unknown>[]}
+      columns={[
+        {key: 'tokenName', header: 'Token', width: pixel(300)},
+        {
+          key: 'value',
+          header: 'Value',
+          renderCell: (item: Record<string, unknown>) => (
+            <XDSHStack gap={2} vAlign="center">
+              <div
+                {...stylex.props(styles.radiusBox)}
+                style={{borderRadius: item.value as string}}
+              />
+              <XDSText type="code" color="secondary">
+                {item.value as string}
+              </XDSText>
+            </XDSHStack>
+          ),
+        },
+      ]}
+      density="spacious"
+      dividers="rows"
+      hasHover
+    />
+  );
+}
+
+export function BorderTokenTable({theme}: TokenTableProps) {
+  const tokens = getTokensByPrefix(theme, '--border-');
+  if (tokens.length === 0) return null;
+
+  const data = tokens.map(name => ({
+    tokenName: name,
+    value: resolveToken(theme, name),
+  }));
+
+  return (
+    <XDSTable
+      data={data as Record<string, unknown>[]}
+      columns={[
+        {key: 'tokenName', header: 'Token', width: pixel(300)},
+        {
+          key: 'value',
+          header: 'Value',
+          renderCell: (item: Record<string, unknown>) => (
+            <XDSHStack gap={2} vAlign="center">
+              <div
+                {...stylex.props(styles.borderLine)}
+                style={{borderBottomWidth: item.value as string}}
+              />
+              <XDSText type="code" color="secondary">
+                {item.value as string}
+              </XDSText>
+            </XDSHStack>
+          ),
+        },
+      ]}
+      density="spacious"
+      dividers="rows"
+      hasHover
+    />
+  );
+}
+
+export function ShapeTokenTable({theme}: TokenTableProps) {
+  return (
+    <XDSVStack gap={6}>
+      <XDSVStack gap={3}>
+        <XDSHeading level={3}>Radius</XDSHeading>
+        <RadiusTokenTable theme={theme} />
+      </XDSVStack>
+      <XDSVStack gap={3}>
+        <XDSHeading level={3}>Border</XDSHeading>
+        <BorderTokenTable theme={theme} />
+      </XDSVStack>
+    </XDSVStack>
+  );
+}

--- a/apps/docsite/src/components/tokens/SpacingTokenTable.tsx
+++ b/apps/docsite/src/components/tokens/SpacingTokenTable.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import * as stylex from '@stylexjs/stylex';
+import {XDSHStack} from '@xds/core/Layout';
+import {XDSText} from '@xds/core/Text';
+import {XDSTable, pixel} from '@xds/core/Table';
+import type {TokenTableProps} from './types';
+import {resolveToken, getTokensByPrefix} from './helpers';
+
+const styles = stylex.create({
+  bar: {
+    minWidth: 2,
+    maxWidth: 64,
+    height: 12,
+    borderRadius: 'var(--radius-element)',
+    backgroundColor: 'var(--color-accent)',
+    opacity: 0.6,
+    flexShrink: 0,
+  },
+});
+
+export function SpacingTokenTable({theme}: TokenTableProps) {
+  const tokens = getTokensByPrefix(theme, '--spacing-');
+  const data = tokens.map(name => ({
+    tokenName: name,
+    value: resolveToken(theme, name),
+  }));
+
+  return (
+    <XDSTable
+      data={data as Record<string, unknown>[]}
+      columns={[
+        {key: 'tokenName', header: 'Token', width: pixel(300)},
+        {
+          key: 'value',
+          header: 'Value',
+          renderCell: (item: Record<string, unknown>) => (
+            <XDSHStack gap={2} vAlign="center">
+              <div
+                {...stylex.props(styles.bar)}
+                style={{width: item.value as string}}
+              />
+              <XDSText type="code" color="secondary">
+                {item.value as string}
+              </XDSText>
+            </XDSHStack>
+          ),
+        },
+      ]}
+      density="spacious"
+      dividers="rows"
+      hasHover
+    />
+  );
+}

--- a/apps/docsite/src/components/tokens/TypographyTokenTable.tsx
+++ b/apps/docsite/src/components/tokens/TypographyTokenTable.tsx
@@ -1,0 +1,152 @@
+'use client';
+
+import * as stylex from '@stylexjs/stylex';
+import {XDSTable, proportional} from '@xds/core/Table';
+import type {XDSTextType} from '@xds/core';
+import type {XDSHeadingLevel} from '@xds/core/Text';
+import type {TokenTableProps} from './types';
+import {resolveToken} from './helpers';
+
+const styles = stylex.create({
+  sample: {
+    overflow: 'hidden',
+    whiteSpace: 'nowrap' as const,
+    textOverflow: 'ellipsis',
+    display: 'block',
+  },
+});
+
+const HEADING_LEVELS: XDSHeadingLevel[] = [1, 2, 3, 4, 5, 6];
+const TEXT_TYPES: XDSTextType[] = [
+  'display-1',
+  'display-2',
+  'display-3',
+  'large',
+  'body',
+  'label',
+  'code',
+  'supporting',
+];
+
+const STYLE_LABEL: Record<string, string> = {
+  'display-1': 'Display 1',
+  'display-2': 'Display 2',
+  'display-3': 'Display 3',
+  'heading-1': 'H1',
+  'heading-2': 'H2',
+  'heading-3': 'H3',
+  'heading-4': 'H4',
+  'heading-5': 'H5',
+  'heading-6': 'H6',
+  body: 'Body',
+  large: 'Large',
+  label: 'Label',
+  code: 'Code',
+  supporting: 'Supporting',
+};
+
+const SAMPLE_TEXT: Record<string, string> = {
+  'display-1': '$12,450',
+  'display-2': '98.7%',
+  'display-3': 'Welcome',
+  'heading-1': 'Page Title',
+  'heading-2': 'Section Title',
+  'heading-3': 'Card Heading',
+  'heading-4': 'Subsection',
+  'heading-5': 'Group Label',
+  'heading-6': 'Overline',
+  body: 'Body text for reading',
+  large: 'Intro paragraph',
+  label: 'Form Label',
+  code: 'const x = 42;',
+  supporting: 'Helper text',
+};
+
+const FONT_FAMILY_MAP: Record<string, string> = {
+  'heading-1': '--font-family-heading',
+  'heading-2': '--font-family-heading',
+  'heading-3': '--font-family-heading',
+  'heading-4': '--font-family-heading',
+  'heading-5': '--font-family-heading',
+  'heading-6': '--font-family-heading',
+  body: '--font-family-body',
+  large: '--font-family-body',
+  label: '--font-family-body',
+  supporting: '--font-family-body',
+  code: '--font-family-code',
+  'display-1': '--font-family-heading',
+  'display-2': '--font-family-heading',
+  'display-3': '--font-family-heading',
+};
+
+export function TypographyTokenTable({theme}: TokenTableProps) {
+  const entries = [
+    ...HEADING_LEVELS.map(level => `heading-${level}`),
+    ...TEXT_TYPES,
+  ];
+
+  const data = entries.map(name => {
+    const sizeToken = `--text-${name}-size`;
+    const weightToken = `--text-${name}-weight`;
+    const leadingToken = `--text-${name}-leading`;
+    const fontFamilyToken = FONT_FAMILY_MAP[name] ?? '--font-family-body';
+
+    const fontSize = resolveToken(theme, sizeToken);
+    const fontWeight = resolveToken(theme, weightToken);
+    const leading = resolveToken(theme, leadingToken);
+    const fontFamily = resolveToken(theme, fontFamilyToken);
+
+    const px =
+      fontSize && leading
+        ? Math.round(parseFloat(leading) * parseFloat(fontSize))
+        : null;
+
+    return {
+      name,
+      label: STYLE_LABEL[name] ?? name,
+      sampleText: SAMPLE_TEXT[name] ?? name,
+      fontFamily,
+      fontSize,
+      fontWeight,
+      leading: px ? `${leading} (${px}px)` : leading,
+    };
+  });
+
+  return (
+    <XDSTable
+      data={data as Record<string, unknown>[]}
+      columns={[
+        {
+          key: 'label',
+          header: 'Style',
+          width: proportional(2),
+          renderCell: (item: Record<string, unknown>) => (
+            <span
+              {...stylex.props(styles.sample)}
+              style={{
+                fontFamily: item.fontFamily as string,
+                fontSize: item.fontSize as string,
+                fontWeight: item.fontWeight as string,
+                lineHeight: (item.leading as string)?.split(' ')[0],
+              }}>
+              {item.label as string}
+            </span>
+          ),
+        },
+        {
+          key: 'fontFamily',
+          header: 'Font',
+          renderCell: (item: Record<string, unknown>) => (
+            <>{(item.fontFamily as string)?.split(',')[0]?.trim()}</>
+          ),
+        },
+        {key: 'fontSize', header: 'Size'},
+        {key: 'fontWeight', header: 'Weight'},
+        {key: 'leading', header: 'Leading'},
+      ]}
+      density="spacious"
+      dividers="rows"
+      hasHover
+    />
+  );
+}

--- a/apps/docsite/src/components/tokens/helpers.ts
+++ b/apps/docsite/src/components/tokens/helpers.ts
@@ -1,0 +1,33 @@
+import type {UseXDSThemeReturn} from '@xds/core/theme';
+import {borderDefaults} from '@xds/core/theme';
+
+const extraDefaults: Record<string, string> = {
+  ...borderDefaults,
+};
+
+export function resolveToken(theme: UseXDSThemeReturn, name: string): string {
+  return theme.token(name) || extraDefaults[name] || '';
+}
+
+export function resolveTokenForMode(
+  theme: UseXDSThemeReturn,
+  name: string,
+  _mode: 'light' | 'dark',
+): string {
+  return theme.token(name) || extraDefaults[name] || '';
+}
+
+export function hasDualMode(_theme: UseXDSThemeReturn): boolean {
+  return true;
+}
+
+export function getTokensByPrefix(
+  theme: UseXDSThemeReturn,
+  prefix: string,
+): string[] {
+  const allKeys = new Set([
+    ...Object.keys(theme.tokens),
+    ...Object.keys(extraDefaults),
+  ]);
+  return [...allKeys].filter(k => k.startsWith(prefix));
+}

--- a/apps/docsite/src/components/tokens/index.ts
+++ b/apps/docsite/src/components/tokens/index.ts
@@ -1,0 +1,20 @@
+export {ColorTokenTable} from './ColorTokenTable';
+export {SpacingTokenTable} from './SpacingTokenTable';
+export {
+  ShapeTokenTable,
+  RadiusTokenTable,
+  BorderTokenTable,
+} from './ShapeTokenTable';
+export {ElevationTokenTable} from './ElevationTokenTable';
+export {
+  MotionTokenTable,
+  DurationTokenTable,
+  EasingTokenTable,
+} from './MotionTokenTable';
+export {TypographyTokenTable} from './TypographyTokenTable';
+export {
+  FontFamilyTokenTable,
+  FontWeightTokenTable,
+  FontSizeTokenTable,
+} from './FontTokenTables';
+export type {TokenTableProps} from './types';

--- a/apps/docsite/src/components/tokens/types.ts
+++ b/apps/docsite/src/components/tokens/types.ts
@@ -1,0 +1,5 @@
+import type {UseXDSThemeReturn} from '@xds/core/theme';
+
+export interface TokenTableProps {
+  theme: UseXDSThemeReturn;
+}


### PR DESCRIPTION
Token table components ported from Nest docsite — render live theme values with visual previews.

## Token Tables
| Component | Tokens | Preview |
|-----------|--------|---------|
| ColorTokenTable | `--color-*` | Light/dark swatches with context backgrounds |
| SpacingTokenTable | `--spacing-*` | Accent-colored bars |
| ShapeTokenTable | `--radius-*`, `--border-*` | Radius boxes + border lines |
| ElevationTokenTable | `--shadow-*` | Box-shadow preview |
| MotionTokenTable | `--duration-*`, `--ease-*` | Animated bars + SVG easing curves |
| TypographyTokenTable | `--text-*-size/weight/leading` | Live type scale samples |
| FontTokenTables | `--font-family/weight/size-*` | Font samples |

## Integration
`TokensDocView` wraps `ReferenceDocView` with per-topic section overrides. Foundation pages automatically get token tables where the doc section title matches.

All data from `useXDSTheme` — tables read live computed token values from the active theme.