### PR TITLE
fix: improve mock data and example placeholders across codebase

### DIFF
--- a/apps/sandbox/src/app/(sandbox)/pages/table-overview/page.tsx
+++ b/apps/sandbox/src/app/(sandbox)/pages/table-overview/page.tsx
@@ -27,7 +27,7 @@ import * as stylex from '@stylexjs/stylex';
 interface ReviewRow extends Record<string, unknown> {
   id: string;
   title: string;
-  diffId: string;
+  prId: string;
   lines: number;
   reviewTime: string;
   authorName: string;
@@ -45,8 +45,8 @@ interface ReviewRow extends Record<string, unknown> {
 const waitingForAWhile: ReviewRow[] = [
   {
     id: '1',
-    title: '[xds][XDSCommonFilterTokenList]: Promote out of beta',
-    diffId: 'D93462457',
+    title: '[xds][FilterTokenList]: Promote out of beta',
+    prId: 'PR-1042',
     lines: 3,
     reviewTime: '<20sec review',
     authorName: 'Alice Chen',
@@ -62,7 +62,7 @@ const waitingForAWhile: ReviewRow[] = [
   {
     id: '2',
     title: '[xds][Table] Fix column resize regression on Safari',
-    diffId: 'D93471823',
+    prId: 'PR-1038',
     lines: 47,
     reviewTime: '~3min review',
     authorName: 'Bob Martinez',
@@ -78,7 +78,7 @@ const needsCodeReview: ReviewRow[] = [
   {
     id: '3',
     title: '[xds][Avatar] Add XDSAvatarStatusDot size scaling',
-    diffId: 'D93502119',
+    prId: 'PR-1055',
     lines: 128,
     reviewTime: '~8min review',
     authorName: 'Carol Wu',
@@ -95,7 +95,7 @@ const needsCodeReview: ReviewRow[] = [
   {
     id: '4',
     title: '[xds][Badge] Introduce error variant with icon slot',
-    diffId: 'D93508734',
+    prId: 'PR-1061',
     lines: 52,
     reviewTime: '~2min review',
     authorName: 'Dan Kim',
@@ -108,7 +108,7 @@ const needsCodeReview: ReviewRow[] = [
   {
     id: '5',
     title: '[xds][Collapsible] Animate height transitions with CSS',
-    diffId: 'D93510092',
+    prId: 'PR-1063',
     lines: 210,
     reviewTime: '~12min review',
     authorName: 'Eve Patel',
@@ -124,7 +124,7 @@ const needsCodeReview: ReviewRow[] = [
   {
     id: '6',
     title: '[xds][TextInput] Add clearable prop with trailing icon',
-    diffId: 'D93511456',
+    prId: 'PR-1067',
     lines: 34,
     reviewTime: '<1min review',
     authorName: 'Frank Lee',
@@ -137,7 +137,7 @@ const needsCodeReview: ReviewRow[] = [
   {
     id: '7',
     title: '[xds][Layout] Support sticky header in XDSLayoutHeader',
-    diffId: 'D93512890',
+    prId: 'PR-1070',
     lines: 89,
     reviewTime: '~5min review',
     authorName: 'Grace Tan',
@@ -156,7 +156,7 @@ const acceptedAndReady: ReviewRow[] = [
   {
     id: '8',
     title: '[xds][StatusDot] Add isPulsing animation support',
-    diffId: 'D93489001',
+    prId: 'PR-1048',
     lines: 22,
     reviewTime: '<30sec review',
     authorName: 'Hank Zhou',
@@ -172,7 +172,7 @@ const acceptedAndReady: ReviewRow[] = [
   {
     id: '9',
     title: '[xds][Card] Add isFullBleed prop for edge-to-edge content',
-    diffId: 'D93495233',
+    prId: 'PR-1051',
     lines: 15,
     reviewTime: '<20sec review',
     authorName: 'Iris Nakamura',
@@ -244,7 +244,7 @@ const columns: XDSTableColumn<ReviewRow>[] = [
             <span {...stylex.props(styles.titleLink)}>{item.title}</span>
             <span {...stylex.props(styles.supportingLine)}>
               <XDSText type="supporting" color="secondary">
-                {item.diffId} · {item.lines} lines {item.reviewTime}
+                {item.prId} · {item.lines} lines {item.reviewTime}
               </XDSText>
             </span>
           </XDSVStack>
@@ -440,7 +440,7 @@ export default function TableOverviewPage() {
       row =>
         row.title.toLowerCase().includes(q) ||
         row.authorName.toLowerCase().includes(q) ||
-        row.diffId.toLowerCase().includes(q),
+        row.prId.toLowerCase().includes(q),
     );
   };
 

--- a/apps/storybook/stories/ChatToolCalls.stories.tsx
+++ b/apps/storybook/stories/ChatToolCalls.stories.tsx
@@ -82,14 +82,14 @@ export const WithNodes: Story = {
           target: 'yarn test',
           status: 'complete',
           duration: '4.2s',
-          node: 'cli:devvm',
+          node: 'cli:remote-server',
         },
         {
           name: 'bash',
           target: 'yarn build',
           status: 'complete',
           duration: '12s',
-          node: 'cli:devvm',
+          node: 'cli:remote-server',
         },
         {
           name: 'read',
@@ -119,7 +119,7 @@ export const WithStats: Story = {
           target: 'XDSButton.tsx',
           status: 'complete',
           duration: '85ms',
-          node: 'cli:devvm',
+          node: 'cli:remote-server',
           additions: 24,
           deletions: 8,
         },
@@ -128,7 +128,7 @@ export const WithStats: Story = {
           target: 'XDSButton.test.tsx',
           status: 'complete',
           duration: '60ms',
-          node: 'cli:devvm',
+          node: 'cli:remote-server',
           additions: 45,
         },
         {
@@ -136,7 +136,7 @@ export const WithStats: Story = {
           target: 'grep -r "radius"',
           status: 'complete',
           duration: '200ms',
-          node: 'cli:devvm',
+          node: 'cli:remote-server',
           stats: '6 files · 14 matches',
         },
       ]}
@@ -154,21 +154,21 @@ export const WithErrors: Story = {
           target: 'yarn build',
           status: 'complete',
           duration: '8s',
-          node: 'cli:devvm',
+          node: 'cli:remote-server',
         },
         {
           name: 'read',
           target: 'test-output.log',
           status: 'complete',
           duration: '15ms',
-          node: 'cli:devvm',
+          node: 'cli:remote-server',
         },
         {
           name: 'bash',
           target: 'yarn test',
           status: 'error',
           duration: '2.1s',
-          node: 'cli:devvm',
+          node: 'cli:remote-server',
           errorMessage: 'Process exited with code 1: FAIL src/Button.test.tsx',
         },
       ]}
@@ -185,14 +185,14 @@ export const Running: Story = {
           name: 'bash',
           target: 'yarn test --watch',
           status: 'running',
-          node: 'cli:devvm',
+          node: 'cli:remote-server',
         },
         {
           name: 'read',
           target: 'vitest.config.ts',
           status: 'complete',
           duration: '20ms',
-          node: 'cli:devvm',
+          node: 'cli:remote-server',
         },
       ]}
     />
@@ -216,7 +216,7 @@ export const Streaming: Story = {
         target: 'packages/core/src/Layer/useXDSLayer.tsx',
         status: 'complete',
         duration: '45ms',
-        node: 'cli:devvm',
+        node: 'cli:remote-server',
       },
       {
         key: '3',
@@ -224,7 +224,7 @@ export const Streaming: Story = {
         target: 'npx tsc --noEmit',
         status: 'complete',
         duration: '4.2s',
-        node: 'cli:devvm',
+        node: 'cli:remote-server',
       },
       {
         key: '4',
@@ -232,7 +232,7 @@ export const Streaming: Story = {
         target: 'XDSChatComposer.tsx',
         status: 'complete',
         duration: '120ms',
-        node: 'cli:devvm',
+        node: 'cli:remote-server',
         additions: 8,
         deletions: 2,
       },
@@ -242,7 +242,7 @@ export const Streaming: Story = {
         target: 'yarn test',
         status: 'complete',
         duration: '6.1s',
-        node: 'cli:devvm',
+        node: 'cli:remote-server',
       },
     ];
 
@@ -408,7 +408,7 @@ Time:        6.1s`;
             target: 'XDSButton.tsx',
             status: 'complete',
             duration: '85ms',
-            node: 'cli:devvm',
+            node: 'cli:remote-server',
             additions: 12,
             deletions: 3,
             resultDetail: (
@@ -424,7 +424,7 @@ Time:        6.1s`;
             target: 'yarn test',
             status: 'complete',
             duration: '6.1s',
-            node: 'cli:devvm',
+            node: 'cli:remote-server',
             resultDetail: (
               <XDSCodeBlock
                 code={testOutput}
@@ -468,21 +468,21 @@ Time:        6.84s`;
             target: 'yarn build',
             status: 'complete',
             duration: '8s',
-            node: 'cli:devvm',
+            node: 'cli:remote-server',
           },
           {
             name: 'read',
             target: 'XDSChatToolCalls.tsx',
             status: 'complete',
             duration: '15ms',
-            node: 'cli:devvm',
+            node: 'cli:remote-server',
           },
           {
             name: 'bash',
             target: 'yarn test',
             status: 'error',
             duration: '6.8s',
-            node: 'cli:devvm',
+            node: 'cli:remote-server',
             errorMessage: '4 tests failed',
             resultDetail: (
               <XDSCodeBlock

--- a/packages/cli/src/api/component.mjs
+++ b/packages/cli/src/api/component.mjs
@@ -23,7 +23,7 @@ import {findShowcase, findRelatedBlocks} from './template.mjs';
 
 /**
  * Resolve an external package by name from the discovered externals list.
- * @param {string} packageName - e.g. '@nest/xds-common'
+ * @param {string} packageName - e.g. '@acme/xds-widgets'
  * @param {string} cwd
  * @returns {{ name: string, category: string, docsDir: string } | null}
  */
@@ -38,7 +38,7 @@ function resolveExternalPackage(packageName, cwd) {
  * @param {string} [options.cwd]
  * @param {boolean} [options.list]
  * @param {string} [options.category]
- * @param {string} [options.package] - Scope to a specific external package (e.g. '@nest/xds-common')
+ * @param {string} [options.package] - Scope to a specific external package (e.g. '@acme/xds-widgets')
  * @param {boolean} [options.props]
  * @param {boolean} [options.source]
  * @param {boolean} [options.showcase]

--- a/packages/cli/src/commands/component-package.test.mjs
+++ b/packages/cli/src/commands/component-package.test.mjs
@@ -6,7 +6,7 @@ import {component} from '../api/component.mjs';
 
 // These tests create a minimal monorepo fixture with:
 // - packages/core (symlinked to real @xds/core for loadDocs compatibility)
-// - node_modules/@test/ext with a Button + Employee component (external package)
+// - node_modules/@test/ext with a Button + ProfileCard component (external package)
 //
 // This tests the --package option for disambiguating overlapping component names.
 
@@ -19,28 +19,28 @@ function createFixture() {
   fs.mkdirSync(path.dirname(coreDir), {recursive: true});
   fs.symlinkSync(realCoreDir, coreDir);
 
-  // External package with Button (different docs) + Employee (unique)
+  // External package with Button (different docs) + ProfileCard (unique)
   const extDir = path.join(tmpDir, 'node_modules', '@test', 'ext');
   const extSrc = path.join(extDir, 'src');
   fs.mkdirSync(path.join(extSrc, 'Button'), {recursive: true});
-  fs.mkdirSync(path.join(extSrc, 'Employee'), {recursive: true});
+  fs.mkdirSync(path.join(extSrc, 'ProfileCard'), {recursive: true});
 
-  // Blocks directory with an Employee showcase
-  const blocksDir = path.join(extDir, 'blocks', 'components', 'Employee');
+  // Blocks directory with a ProfileCard showcase
+  const blocksDir = path.join(extDir, 'blocks', 'components', 'ProfileCard');
   fs.mkdirSync(blocksDir, {recursive: true});
-  fs.writeFileSync(path.join(blocksDir, 'EmployeeShowcase.doc.mjs'), `
+  fs.writeFileSync(path.join(blocksDir, 'ProfileCardShowcase.doc.mjs'), `
 export const doc = {
   type: 'block',
-  name: 'Employee — Showcase',
-  description: 'Employee showcase.',
+  name: 'ProfileCard — Showcase',
+  description: 'ProfileCard showcase.',
   isReady: true,
   isShowcase: true,
   aspectRatio: 16 / 9,
-  componentsUsed: ['Employee'],
+  componentsUsed: ['ProfileCard'],
 };
 `);
-  fs.writeFileSync(path.join(blocksDir, 'EmployeeShowcase.tsx'),
-    "'use client';\nexport default function EmployeeShowcase() { return <div>Employee</div>; }");
+  fs.writeFileSync(path.join(blocksDir, 'ProfileCardShowcase.tsx'),
+    "'use client';\nexport default function ProfileCardShowcase() { return <div>ProfileCard</div>; }");
 
   fs.writeFileSync(path.join(extDir, 'package.json'), JSON.stringify({
     name: '@test/ext',
@@ -48,16 +48,16 @@ export const doc = {
   }));
   fs.writeFileSync(path.join(extSrc, 'Button', 'Button.doc.mjs'), `
 export const docs = {
-  name: 'XDSCommonButton',
+  name: 'AcmeButton',
   usage: { description: 'Common button with platform features.' },
   props: [{ name: 'label', type: 'string', description: 'Button label' }, { name: 'isLoading', type: 'boolean', description: 'Shows spinner' }],
 };
 `);
-  fs.writeFileSync(path.join(extSrc, 'Employee', 'Employee.doc.mjs'), `
+  fs.writeFileSync(path.join(extSrc, 'ProfileCard', 'ProfileCard.doc.mjs'), `
 export const docs = {
-  name: 'XDSCommonEmployee',
-  usage: { description: 'Employee profile component.' },
-  props: [{ name: 'employeeId', type: 'string', description: 'Employee FBID' }],
+  name: 'AcmeProfileCard',
+  usage: { description: 'Profile card component.' },
+  props: [{ name: 'userId', type: 'string', description: 'User identifier' }],
 };
 `);
 }
@@ -75,21 +75,21 @@ describe('component() with --package option', () => {
   it('returns external package docs when --package is specified', async () => {
     const result = await component('Button', {cwd: tmpDir, package: '@test/ext'});
     expect(result.type).toBe('component.detail');
-    expect(result.data.name).toBe('XDSCommonButton');
+    expect(result.data.name).toBe('AcmeButton');
     expect(result.data.usage.description).toContain('platform features');
   });
 
   it('returns core docs when no --package is specified (default behavior)', async () => {
     const result = await component('Button', {cwd: tmpDir});
     expect(result.type).toBe('component.detail');
-    // Core's Button doc has name 'Button', not 'XDSCommonButton'
+    // Core's Button doc has name 'Button', not 'AcmeButton'
     expect(result.data.name).toBe('Button');
   });
 
   it('resolves unique external components without --package', async () => {
-    const result = await component('Employee', {cwd: tmpDir});
+    const result = await component('ProfileCard', {cwd: tmpDir});
     expect(result.type).toBe('component.detail');
-    expect(result.data.name).toBe('XDSCommonEmployee');
+    expect(result.data.name).toBe('AcmeProfileCard');
   });
 
   it('returns props for package-scoped component', async () => {
@@ -112,10 +112,10 @@ describe('component() with --package option', () => {
   });
 
   it('returns showcase from external package when --package + --showcase', async () => {
-    const result = await component('Employee', {cwd: tmpDir, package: '@test/ext', showcase: true});
+    const result = await component('ProfileCard', {cwd: tmpDir, package: '@test/ext', showcase: true});
     expect(result.type).toBe('component.detail.showcase');
-    expect(result.data.component).toBe('Employee');
-    expect(result.data.source).toContain('EmployeeShowcase');
+    expect(result.data.component).toBe('ProfileCard');
+    expect(result.data.source).toContain('ProfileCardShowcase');
     expect(result.data.aspectRatio).toBeCloseTo(16 / 9);
   });
 });

--- a/packages/cli/src/commands/component/index.mjs
+++ b/packages/cli/src/commands/component/index.mjs
@@ -35,7 +35,7 @@ export function registerComponent(program) {
     .option('--source', 'Print component source code')
     .option('--showcase', 'Print showcase source code')
     .option('--blocks', 'List example blocks: showcase, examples, and related')
-    .option('--package <name>', 'Scope lookup to an external package (e.g. @nest/xds-common)')
+    .option('--package <name>', 'Scope lookup to an external package (e.g. @acme/xds-widgets)')
     .action(async (name, options) => {
       const run = getRunPrefix();
       const zh = program.opts().zh || false;

--- a/packages/cli/templates/blocks/components/ChatToolCalls/ChatToolCallsInteractiveToolCalls.tsx
+++ b/packages/cli/templates/blocks/components/ChatToolCalls/ChatToolCallsInteractiveToolCalls.tsx
@@ -35,7 +35,7 @@ export default function ChatToolCallsInteractiveToolCalls() {
           target: 'src/utils/formatDate.ts',
           status: 'complete',
           duration: '85ms',
-          node: 'cli:devvm',
+          node: 'cli:remote-server',
           additions: 6,
           deletions: 3,
           resultDetail: (
@@ -51,13 +51,9 @@ export default function ChatToolCallsInteractiveToolCalls() {
           target: 'yarn test',
           status: 'complete',
           duration: '1.8s',
-          node: 'cli:devvm',
+          node: 'cli:remote-server',
           resultDetail: (
-            <XDSCodeBlock
-              code={testOutput}
-              language="bash"
-              maxHeight="50vh"
-            />
+            <XDSCodeBlock code={testOutput} language="bash" maxHeight="50vh" />
           ),
         },
         {

--- a/packages/cli/templates/pages/ai-chat/page.tsx
+++ b/packages/cli/templates/pages/ai-chat/page.tsx
@@ -180,7 +180,7 @@ export default function AIChatConversationTemplate() {
                   target: 'grep -rn "refreshToken" src/',
                   status: 'complete',
                   duration: '120ms',
-                  node: 'cli:devvm',
+                  node: 'cli:remote-server',
                 },
               ]}
             />
@@ -294,7 +294,7 @@ The fix is to catch \`TokenExpiredError\` specifically and attempt a refresh bef
                   target: 'yarn test middleware',
                   status: 'complete',
                   duration: '3.2s',
-                  node: 'cli:devvm',
+                  node: 'cli:remote-server',
                 },
               ]}
             />
@@ -372,13 +372,13 @@ The fix is to catch \`TokenExpiredError\` specifically and attempt a refresh bef
                   target: 'git push -u origin fix/jwt-refresh',
                   status: 'complete',
                   duration: '1.8s',
-                  node: 'cli:devvm',
+                  node: 'cli:remote-server',
                 },
                 {
                   name: 'bash',
                   target: 'gh pr create --title "fix: handle expired JWT…"',
                   status: 'running',
-                  node: 'cli:devvm',
+                  node: 'cli:remote-server',
                 },
               ]}
             />

--- a/packages/core/src/Chat/ChatToolCalls.doc.mjs
+++ b/packages/core/src/Chat/ChatToolCalls.doc.mjs
@@ -21,7 +21,7 @@ export const docs = {
     anatomy: [
       {name: 'Status icon', required: true, description: 'A colored circle with a check, cross, or spinner indicating whether the call is pending, running, complete, or errored.'},
       {name: 'Tool name', required: true, description: 'The function or tool name displayed in monospace — bash, edit, read, web_search, etc.'},
-      {name: 'Node badge', required: false, description: 'A neutral pill badge showing which sandbox or environment ran the tool, like cli:devvm or workspace.'},
+      {name: 'Node badge', required: false, description: 'A neutral pill badge showing which sandbox or environment ran the tool, like cli:remote-server or workspace.'},
       {name: 'Target label', required: false, description: 'The target of the action — a file path, command, or search query — shown after the tool name.'},
       {name: 'Diff stats', required: false, description: 'Green additions and red deletions counts for edit operations, displayed inline after the target.'},
       {name: 'Duration', required: false, description: 'Execution time shown on the trailing edge for completed calls.'},

--- a/packages/vega/src/vegaLiteConfig.ts
+++ b/packages/vega/src/vegaLiteConfig.ts
@@ -4,7 +4,7 @@
  * @output Predefined Vega-Lite Config object for XDS-themed charts
  * @position Utility module; consumed by XDSVegaChart and exported standalone
  *
- * Ported from fbsource XDSDataVizVegaLiteConfig.js — structural config only.
+ * Ported from the internal XDS data-viz config — structural config only.
  * Colors are wired through XDS data tokens (see domainTokens/dataTokens.ts).
  *
  * SYNC: When modified, update this header and /packages/lab/src/VegaChart/README.md


### PR DESCRIPTION
Replaces placeholder identifiers and example names with more conventional, generic alternatives throughout the codebase.

**Changes:**
- **Table overview demo** — swap diff-style IDs for PR-style identifiers (`PR-1042` etc.) and shorten component names
- **CLI JSDoc + help text** — use `@acme/xds-widgets` as the example external package
- **CLI test fixtures** — rename test components to `AcmeButton`/`AcmeProfileCard` with conventional prop names
- **ChatToolCalls stories & templates** — use `cli:remote-server` as the example node name
- **Vibe-test script** — simplify certificate check function naming
- **Vega config** — clarify provenance comment

No functional changes — all mock data and documentation examples only.