### PR TITLE
feat(cli): add exampleFor field to all block templates

### DIFF
--- a/apps/docsite/scripts/generate-data.mjs
+++ b/apps/docsite/scripts/generate-data.mjs
@@ -320,10 +320,11 @@ async function generateBlockRegistry() {
     const meta = readDocMeta(docPath);
     const relCategory = path.relative(BLOCKS_DIR, path.dirname(docPath));
 
-    // Read isShowcase, aspectRatio, componentsUsed from the doc file
+    // Read isShowcase, aspectRatio, componentsUsed, exampleFor from the doc file
     let isShowcase = false;
     let aspectRatio = 1;
     let componentsUsed = [];
+    let exampleFor = '';
     try {
       const content = fs.readFileSync(docPath, 'utf-8');
       isShowcase = /isShowcase:\s*true/.test(content);
@@ -338,12 +339,17 @@ async function generateBlockRegistry() {
       if (cuMatch) {
         componentsUsed = [...cuMatch[1].matchAll(/['"]([^'"]+)['"]/g)].map(m => m[1]);
       }
+      const efMatch = content.match(/exampleFor:\s*['"]([^'"]+)['"]/);
+      if (efMatch) {
+        exampleFor = efMatch[1];
+      }
     } catch { /* ignore */ }
 
     blocks.push({
       dirName: basename,
       name: meta.name || basename,
       description: meta.description,
+      exampleFor,
       isShowcase,
       aspectRatio,
       componentsUsed,
@@ -361,6 +367,8 @@ export interface BlockEntry {
   dirName: string;
   name: string;
   description: string;
+  /** The component this block is an example of (e.g. 'Button', 'Dialog') */
+  exampleFor: string;
   isShowcase: boolean;
   aspectRatio: number;
   componentsUsed: string[];

--- a/apps/docsite/src/__tests__/data-extraction.test.ts
+++ b/apps/docsite/src/__tests__/data-extraction.test.ts
@@ -242,6 +242,7 @@ describe('blockRegistry', () => {
       expect(block.aspectRatio).not.toBeNaN();
       expect(Array.isArray(block.componentsUsed)).toBe(true);
       expect(block.category).toBeDefined();
+      expect(typeof block.exampleFor).toBe('string');
     }
   });
 
@@ -263,9 +264,27 @@ describe('blockRegistry', () => {
 
   it('showcase for Button exists', () => {
     const buttonShowcase = blocks.find(
-      b => b.isShowcase && b.category.includes('Button'),
+      b => b.isShowcase && b.exampleFor === 'Button',
     );
     expect(buttonShowcase).toBeDefined();
+  });
+
+  it('every block has exampleFor set', () => {
+    const missing = blocks.filter(b => !b.exampleFor);
+    expect(missing.map(b => b.dirName)).toEqual([]);
+  });
+
+  it('showcase blocks have unique exampleFor (one showcase per component)', () => {
+    const showcases = blocks.filter(b => b.isShowcase);
+    const seen = new Map<string, string[]>();
+    for (const s of showcases) {
+      if (!seen.has(s.exampleFor)) seen.set(s.exampleFor, []);
+      seen.get(s.exampleFor)!.push(s.dirName);
+    }
+    const dupes = [...seen.entries()].filter(([, v]) => v.length > 1);
+    // Some components may legitimately have multiple showcases, but flag them
+    // so we're aware. Most should have exactly one.
+    expect(dupes.length).toBeLessThan(showcases.length * 0.1);
   });
 
   it('componentsUsed links blocks to components', () => {

--- a/packages/cli/templates/blocks/components/AlertDialog/AlertDialogAsyncAction.doc.mjs
+++ b/packages/cli/templates/blocks/components/AlertDialog/AlertDialogAsyncAction.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'AlertDialog',
   name: 'AlertDialog — Loading',
   description:
     'A confirmation dialog that shows a spinner while the action runs.',

--- a/packages/cli/templates/blocks/components/AlertDialog/AlertDialogDeleteConfirmation.doc.mjs
+++ b/packages/cli/templates/blocks/components/AlertDialog/AlertDialogDeleteConfirmation.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'AlertDialog',
   name: 'AlertDialog — Delete',
   description:
     'A delete button that asks the user to confirm before deleting.',

--- a/packages/cli/templates/blocks/components/AppShell/AppShellContentOnly.doc.mjs
+++ b/packages/cli/templates/blocks/components/AppShell/AppShellContentOnly.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'AppShell',
   name: 'AppShell — Content Only',
   description:
     'Minimal shell with no navigation, useful for full-bleed pages, auth screens, or embedded views.',

--- a/packages/cli/templates/blocks/components/AppShell/AppShellShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/AppShell/AppShellShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'AppShell',
   name: 'AppShell',
   isReady: true,
   aspectRatio: 4 / 3,

--- a/packages/cli/templates/blocks/components/AppShell/AppShellSideNavOnly.doc.mjs
+++ b/packages/cli/templates/blocks/components/AppShell/AppShellSideNavOnly.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'AppShell',
   name: 'AppShell — Side Nav Only',
   description:
     'App shell with SideNav header providing app identity, no TopNav needed.',

--- a/packages/cli/templates/blocks/components/AppShell/AppShellTopNavOnly.doc.mjs
+++ b/packages/cli/templates/blocks/components/AppShell/AppShellTopNavOnly.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'AppShell',
   name: 'AppShell — Top Nav Only',
   description:
     'Simple layout with TopNav and no side navigation, suitable for landing pages.',

--- a/packages/cli/templates/blocks/components/AppShell/AppShellTopNavWithSideNav.doc.mjs
+++ b/packages/cli/templates/blocks/components/AppShell/AppShellTopNavWithSideNav.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'AppShell',
   name: 'AppShell — Top Nav with Side Nav',
   description:
     'The most common layout with TopNav for app identity and SideNav for page-level navigation.',

--- a/packages/cli/templates/blocks/components/AppShell/AppShellWithBanner.doc.mjs
+++ b/packages/cli/templates/blocks/components/AppShell/AppShellWithBanner.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'AppShell',
   name: 'AppShell — With Banner',
   description:
     'Full layout with TopNav, SideNav, and a dismissable info banner between the nav and content.',

--- a/packages/cli/templates/blocks/components/AspectRatio/AspectRatioImageGallery.doc.mjs
+++ b/packages/cli/templates/blocks/components/AspectRatio/AspectRatioImageGallery.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'AspectRatio',
   name: 'AspectRatio — Image Gallery',
   description: 'Grid of images with consistent 4:3 aspect ratios.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/AspectRatio/AspectRatioShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/AspectRatio/AspectRatioShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'AspectRatio',
   name: 'AspectRatio',
   isReady: true,
   aspectRatio: 4 / 3,

--- a/packages/cli/templates/blocks/components/AspectRatio/AspectRatioSquareImage.doc.mjs
+++ b/packages/cli/templates/blocks/components/AspectRatio/AspectRatioSquareImage.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'AspectRatio',
   name: 'AspectRatio — Square Image',
   description: '1:1 square aspect ratio, ideal for avatars and Instagram-style images.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/AspectRatio/AspectRatioWidescreen.doc.mjs
+++ b/packages/cli/templates/blocks/components/AspectRatio/AspectRatioWidescreen.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'AspectRatio',
   name: 'AspectRatio — 16:9 Widescreen Image',
   description: '16:9 widescreen aspect ratio wrapping an image.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/AspectRatio/AspectRatioWithSkeleton.doc.mjs
+++ b/packages/cli/templates/blocks/components/AspectRatio/AspectRatioWithSkeleton.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'AspectRatio',
   name: 'AspectRatio — Loading Skeleton',
   description: 'Aspect ratio container with a skeleton loading placeholder.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Avatar/AvatarFallbackChain.doc.mjs
+++ b/packages/cli/templates/blocks/components/Avatar/AvatarFallbackChain.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Avatar',
   name: 'Avatar — Fallback Chain',
   description:
     'Demonstrates the avatar fallback chain: primary image, fallback image, initials, then default icon.',

--- a/packages/cli/templates/blocks/components/Avatar/AvatarGroup.doc.mjs
+++ b/packages/cli/templates/blocks/components/Avatar/AvatarGroup.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Avatar',
   name: 'Avatar — Group',
   description: 'Overlap multiple avatars in a row to represent a group of people. Use for team lists, PR reviewers, or participant counts where you want to show faces without taking up much space.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Avatar/AvatarInitialsFallback.doc.mjs
+++ b/packages/cli/templates/blocks/components/Avatar/AvatarInitialsFallback.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Avatar',
   name: 'Avatar — Initials',
   description: 'Show initials instead of a photo. The avatar extracts the first and last initials from the name automatically. Use when you only have a user name, like in anonymous accounts or new user onboarding.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Avatar/AvatarShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/Avatar/AvatarShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Avatar',
   name: 'Avatar',
   description:
     'Avatars at every size with an image, initials fallback, and a status dot. A quick visual reference for choosing the right size.',

--- a/packages/cli/templates/blocks/components/Avatar/AvatarUserCard.doc.mjs
+++ b/packages/cli/templates/blocks/components/Avatar/AvatarUserCard.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Avatar',
   name: 'Avatar — User Card',
   description: 'Place an avatar next to a name and role to create a user card row. Use for comment headers, contact lists, profile sections, or anywhere you need to identify a person at a glance.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Avatar/AvatarWithImage.doc.mjs
+++ b/packages/cli/templates/blocks/components/Avatar/AvatarWithImage.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Avatar',
   name: 'Avatar — Photo',
   description: 'Show a profile photo at different sizes. Use when you have a user photo URL. If the image fails to load, initials are shown instead.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Avatar/AvatarWithStatus.doc.mjs
+++ b/packages/cli/templates/blocks/components/Avatar/AvatarWithStatus.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Avatar',
   name: 'Avatar — Status Dot',
   description: 'Add a status dot to an avatar to show whether someone is online, away, or busy. Use in chat, messaging, or any UI where knowing availability matters.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/AvatarStatusDot/AvatarStatusDotShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/AvatarStatusDot/AvatarStatusDotShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'AvatarStatusDot',
   name: 'AvatarStatusDot',
   description:
     'AvatarStatusDot renders a presence indicator on an Avatar, with variants for positive, neutral, and negative states. The dot size automatically coordinates with the Avatar size.',

--- a/packages/cli/templates/blocks/components/Badge/BadgeCategoryTags.doc.mjs
+++ b/packages/cli/templates/blocks/components/Badge/BadgeCategoryTags.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Badge',
   name: 'Badge — Colors',
   description: 'Tag items with color-coded categories like teams, priorities, or topics. Use the 9 non-semantic color variants when you need to distinguish groups visually.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Badge/BadgeCountBadges.doc.mjs
+++ b/packages/cli/templates/blocks/components/Badge/BadgeCountBadges.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Badge',
   name: 'Badge — Counts',
   description: 'Show a number inside a badge for notification counts, unread messages, or task totals. Use next to icons, nav items, or list labels.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Badge/BadgeShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/Badge/BadgeShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Badge',
   name: 'Badge — Variants',
   description:
     'All semantic and color badge variants in a single view. Use semantic variants for status and color variants for categories.',

--- a/packages/cli/templates/blocks/components/Badge/BadgeStatusLabels.doc.mjs
+++ b/packages/cli/templates/blocks/components/Badge/BadgeStatusLabels.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Badge',
   name: 'Badge — Status',
   description: 'Show the state of an item like Active, Pending, or Failed. Use in table rows, list items, or detail pages where users need to see status at a glance.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Banner/BannerCollapsibleContent.doc.mjs
+++ b/packages/cli/templates/blocks/components/Banner/BannerCollapsibleContent.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Banner',
   name: 'Banner — Collapsible',
   description: 'Combine an action button, dismiss control, and expandable detail area in one banner. Use for complex notifications like config changes or deployment summaries.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Banner/BannerDismissable.doc.mjs
+++ b/packages/cli/templates/blocks/components/Banner/BannerDismissable.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Banner',
   name: 'Banner — Dismiss',
   description: 'Let the user close a banner after reading it. Use for maintenance notices, feature tips, or any non-critical message the user can acknowledge.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Banner/BannerSectionVariant.doc.mjs
+++ b/packages/cli/templates/blocks/components/Banner/BannerSectionVariant.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Banner',
   name: 'Banner — Full Width',
   description: 'A full-width banner with no border radius for page-level notifications. Use at the top of a page for site-wide announcements or maintenance alerts.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Banner/BannerShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/Banner/BannerShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Banner',
   name: 'Banner — Statuses',
   description:
     'All four status banners stacked — info, success, warning, and error. A quick visual reference for choosing the right status.',

--- a/packages/cli/templates/blocks/components/Banner/BannerStatuses.doc.mjs
+++ b/packages/cli/templates/blocks/components/Banner/BannerStatuses.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Banner',
   name: 'Banner — Statuses',
   description: 'All 4 banner statuses: info, success, warning, and error. Use to show persistent messages like updates, confirmations, cautions, or problems at the top of a page or section.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Banner/BannerWithActionButton.doc.mjs
+++ b/packages/cli/templates/blocks/components/Banner/BannerWithActionButton.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Banner',
   name: 'Banner — Action',
   description: 'Add a button to a banner so the user can act on the message. Use for trial expirations, payment failures, or anything that needs a response.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/BreadcrumbItem/BreadcrumbItemShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/BreadcrumbItem/BreadcrumbItemShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'BreadcrumbItem',
   name: 'BreadcrumbItem',
   description:
     'BreadcrumbItem represents a single step in a breadcrumb trail, supporting links, icons, current-page markers, and custom link components.',

--- a/packages/cli/templates/blocks/components/Breadcrumbs/BreadcrumbsCustomSeparator.doc.mjs
+++ b/packages/cli/templates/blocks/components/Breadcrumbs/BreadcrumbsCustomSeparator.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Breadcrumbs',
   name: 'Breadcrumbs — Separators',
   description: 'Swap the default "/" for a different character like chevrons, arrows, or dots. Use when the visual style of the page calls for a different separator.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Breadcrumbs/BreadcrumbsDeepHierarchy.doc.mjs
+++ b/packages/cli/templates/blocks/components/Breadcrumbs/BreadcrumbsDeepHierarchy.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Breadcrumbs',
   name: 'Breadcrumbs — Deep Path',
   description: 'A 5-level breadcrumb trail for deeply nested content. Use in e-commerce, file browsers, or any UI with several levels of hierarchy.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Breadcrumbs/BreadcrumbsShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/Breadcrumbs/BreadcrumbsShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Breadcrumbs',
   name: 'Breadcrumbs',
   description:
     'A breadcrumb trail showing page hierarchy with linked ancestors and a current page.',

--- a/packages/cli/templates/blocks/components/Breadcrumbs/BreadcrumbsSupportingVariant.doc.mjs
+++ b/packages/cli/templates/blocks/components/Breadcrumbs/BreadcrumbsSupportingVariant.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Breadcrumbs',
   name: 'Breadcrumbs — Variants',
   description: 'Compare the default and supporting variants side by side. Use the supporting variant in dense UIs like admin panels where the breadcrumb should be subtle.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Breadcrumbs/BreadcrumbsWithIcons.doc.mjs
+++ b/packages/cli/templates/blocks/components/Breadcrumbs/BreadcrumbsWithIcons.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Breadcrumbs',
   name: 'Breadcrumbs — Icons',
   description: 'Add icons before breadcrumb labels for quick recognition. Use a home icon on the root item and contextual icons on key sections.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Button/ButtonShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/Button/ButtonShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Button',
   name: 'Button — Variants',
   description:
     'All four button variants side by side — primary, secondary, ghost, and destructive. A quick visual reference for choosing the right variant.',

--- a/packages/cli/templates/blocks/components/Button/ButtonSizeVariants.doc.mjs
+++ b/packages/cli/templates/blocks/components/Button/ButtonSizeVariants.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Button',
   name: 'Button — Sizes',
   description: 'Small, medium, and large buttons side by side. Use small in dense UIs like toolbars, medium for most cases, and large for prominent CTAs.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Button/ButtonVariants.doc.mjs
+++ b/packages/cli/templates/blocks/components/Button/ButtonVariants.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Button',
   name: 'Button — Variants',
   description: 'All 4 button variants in default, disabled, and loading states. Use primary for the main action, secondary for most others, ghost for low-emphasis, and destructive for dangerous actions.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Button/ButtonWithEndSlot.doc.mjs
+++ b/packages/cli/templates/blocks/components/Button/ButtonWithEndSlot.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Button',
   name: 'Button — End Slot',
   description: 'Buttons with a trailing badge showing a count or status. Use for notification counts, unread messages, or any button that needs a visual indicator.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Button/ButtonWithIcon.doc.mjs
+++ b/packages/cli/templates/blocks/components/Button/ButtonWithIcon.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Button',
   name: 'Button — Icon',
   description: 'Buttons with a leading icon that reinforces the label. Use when the icon helps the user identify the action faster, like a plus for "New" or a trash can for "Delete".',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Calendar/CalendarConstraints.doc.mjs
+++ b/packages/cli/templates/blocks/components/Calendar/CalendarConstraints.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Calendar',
   name: 'Calendar — Constraints',
   description: 'Limit which dates can be selected using min/max bounds and custom rules like weekdays only. Use for scheduling UIs where certain dates are unavailable.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Calendar/CalendarRangeWithValue.doc.mjs
+++ b/packages/cli/templates/blocks/components/Calendar/CalendarRangeWithValue.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Calendar',
   name: 'Calendar — Range',
   description: 'Pick a start and end date with the range highlighted between them. Use for booking dates, time-off requests, or report filters.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Calendar/CalendarShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/Calendar/CalendarShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Calendar',
   name: 'Calendar',
   description:
     'An interactive single-date calendar with a selected date. Click any day to change the selection.',

--- a/packages/cli/templates/blocks/components/Calendar/CalendarSingle.doc.mjs
+++ b/packages/cli/templates/blocks/components/Calendar/CalendarSingle.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Calendar',
   name: 'Calendar — Single',
   description: 'Pick one date from a month grid. Use for appointment dates, due dates, or any field that needs a single date.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Calendar/CalendarTwoMonths.doc.mjs
+++ b/packages/cli/templates/blocks/components/Calendar/CalendarTwoMonths.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Calendar',
   name: 'Calendar — Two Months',
   description: 'Two months side by side for selecting ranges that span a month boundary. Use in booking or travel UIs where check-in and check-out often fall in different months.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Card/CardCallout.doc.mjs
+++ b/packages/cli/templates/blocks/components/Card/CardCallout.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Card',
   name: 'Card — Callout',
   description: 'Muted-variant cards for tips, notes, or supplementary information. Use when content should be visually distinct but not prominent. The muted variant uses a wash background instead of the elevated default, making it feel recessed rather than raised. Works well in sidebars, help panels, or inline callouts.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Card/CardShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/Card/CardShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Card',
   name: 'Card',
   description:
     'A card with a heading and body text showing the default container style.',

--- a/packages/cli/templates/blocks/components/Card/CardVariants.doc.mjs
+++ b/packages/cli/templates/blocks/components/Card/CardVariants.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Card',
   name: 'Card — Variants',
   description: 'Default, muted, and color variants side by side. Use color variants to categorize cards visually, like team colors, project tags, or content types. Each color uses the corresponding background token from the theme, so they adapt to light and dark mode automatically.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Card/CardWithInnerLayout.doc.mjs
+++ b/packages/cli/templates/blocks/components/Card/CardWithInnerLayout.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Card',
   name: 'Card — Layout',
   description: 'A card with a structured header, content area, and footer with action buttons. Use for forms, dialogs, or settings panels that need clear sections. Pair XDSCard with XDSLayout to get automatic dividers between header, content, and footer. The footer aligns actions to the right by default.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Card/CardWithSimpleContent.doc.mjs
+++ b/packages/cli/templates/blocks/components/Card/CardWithSimpleContent.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Card',
   name: 'Card — Simple',
   description: 'A card with a heading and body text. Use for summaries, descriptions, or any grouped content that needs visual separation from the page. The card handles its own border, background, and padding — just pass your content as children. Set a width to constrain it, or leave it to fill the parent.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Card/ClickableCardShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/Card/ClickableCardShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Card',
   name: 'ClickableCard',
   description:
     'A clickable card that navigates on click. Nested interactive elements work independently.',

--- a/packages/cli/templates/blocks/components/Card/ClickableCardWithNestedButton.doc.mjs
+++ b/packages/cli/templates/blocks/components/Card/ClickableCardWithNestedButton.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Card',
   name: 'ClickableCardWithNestedButton',
   description:
     'A product card that navigates on click but has an independent "Add to cart" button inside.',

--- a/packages/cli/templates/blocks/components/Card/SelectableCardMulti.doc.mjs
+++ b/packages/cli/templates/blocks/components/Card/SelectableCardMulti.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Card',
   name: 'SelectableCardMulti',
   description:
     'Multi-select tag picker using color variant selectable cards with color-matched selection borders.',

--- a/packages/cli/templates/blocks/components/Card/SelectableCardShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/Card/SelectableCardShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Card',
   name: 'SelectableCard',
   description:
     'A plan picker with single-select radio behavior. Cards show an accent border when selected.',

--- a/packages/cli/templates/blocks/components/Carousel/CarouselCards.doc.mjs
+++ b/packages/cli/templates/blocks/components/Carousel/CarouselCards.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Carousel',
   name: 'Carousel — Cards',
   description: 'A horizontally scrollable row of cards with snap scrolling enabled. Use for feature grids, product lists, or any set of cards that overflows the available width. The carousel adds fade edges and navigation buttons automatically.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Carousel/CarouselShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/Carousel/CarouselShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Carousel',
   name: 'Carousel',
   description:
     'A horizontal carousel of cards with scroll-snap and navigation buttons. Scroll or click the arrows to browse.',

--- a/packages/cli/templates/blocks/components/Carousel/CarouselSnap.doc.mjs
+++ b/packages/cli/templates/blocks/components/Carousel/CarouselSnap.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Carousel',
   name: 'Carousel — Snap',
   description: 'Scroll-snap carousel with navigation buttons and team member cards. Each card snaps to the start edge on scroll. Use when items should be viewed one at a time rather than as a continuous strip.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Center/CenterHorizontal.doc.mjs
+++ b/packages/cli/templates/blocks/components/Center/CenterHorizontal.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Center',
   name: 'Center — Horizontal Center',
   description: 'An editor toolbar with a document title on the left and formatting actions on the right. This shows axis="horizontal" — centering in one direction only. Use when content needs to be horizontally centered while other elements are positioned independently around it.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Center/CenterInsideACard.doc.mjs
+++ b/packages/cli/templates/blocks/components/Center/CenterInsideACard.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Center',
   name: 'Center — Vertical & Horizontal Center',
   description: 'An empty state with an icon, heading, and description centered both vertically and horizontally inside a card. This is the most common use of Center — placing content in the middle of a fixed-height area like a panel, card, or content region. The height prop defines the centering space.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Center/CenterShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/Center/CenterShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Center',
   name: 'Center',
   description:
     'Content centered horizontally and vertically inside a fixed-height container.',

--- a/packages/cli/templates/blocks/components/ChatComposer/ChatComposerAttachments.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatComposer/ChatComposerAttachments.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ChatComposer',
   name: 'ChatComposer — Attachments',
   description: 'Chat composer with removable file tokens in a collapsible drawer. Use when users can attach files or context to their message.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/ChatComposer/ChatComposerFooterActions.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatComposer/ChatComposerFooterActions.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ChatComposer',
   name: 'ChatComposer — Footer Actions',
   description: 'Chat composer with dropdown menus for a model selector and settings in the footer, and a mic button in the send actions slot.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/ChatComposer/ChatComposerFullFeatured.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatComposer/ChatComposerFullFeatured.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ChatComposer',
   name: 'ChatComposer — Full Featured',
   description: 'Chat composer with all slots populated — collapsible attachment drawer, header actions, context progress bar, footer dropdown menus, and mic button. Shows the maximum composer configuration.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/ChatComposer/ChatComposerShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatComposer/ChatComposerShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ChatComposer',
   name: 'ChatComposer',
   isReady: true,
   aspectRatio: 4 / 3,

--- a/packages/cli/templates/blocks/components/ChatComposer/ChatComposerSimple.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatComposer/ChatComposerSimple.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ChatComposer',
   name: 'ChatComposer — Simple',
   description: 'Minimal chat composer with a placeholder and submit handler. The simplest way to drop a message input into a page.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/ChatComposer/ChatComposerStreaming.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatComposer/ChatComposerStreaming.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ChatComposer',
   name: 'ChatComposer — Streaming',
   description: 'Chat composer with streaming state and a stop button. Use when the assistant is generating a response and the user can cancel.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/ChatComposer/ChatComposerValidation.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatComposer/ChatComposerValidation.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ChatComposer',
   name: 'ChatComposer — Validation',
   description: 'Chat composer with error and warning status messages. Status can appear above or below the composer to surface validation or system feedback.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/ChatComposerDrawer/ChatComposerDrawerAttachments.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatComposerDrawer/ChatComposerDrawerAttachments.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ChatComposerDrawer',
   name: 'ChatComposerDrawer — Attachments',
   description: 'Drawer with two rows: a scrollable carousel of image thumbnails and a row of removable file tokens. Omit count to keep the drawer always expanded.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/ChatComposerDrawer/ChatComposerDrawerCollapsible.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatComposerDrawer/ChatComposerDrawerCollapsible.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ChatComposerDrawer',
   name: 'ChatComposerDrawer — Collapsible',
   description: 'Drawer with many items and a collapse toggle. Pass count to enable the toggle — collapsed state shows a badge with the total count and a label.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/ChatComposerDrawer/ChatComposerDrawerFeedback.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatComposerDrawer/ChatComposerDrawerFeedback.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ChatComposerDrawer',
   name: 'ChatComposerDrawer — Feedback',
   description: 'Chat composer drawer with a feedback prompt and selectable lettered options. Use for user confirmation workflows that require explicit action before proceeding.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/ChatComposerDrawer/ChatComposerDrawerShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatComposerDrawer/ChatComposerDrawerShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ChatComposerDrawer',
   name: 'ChatComposerDrawer',
   description: 'Composer drawer with file tokens, a collapsible toggle, and header actions. Use as a starting point for any chat composer with attachments.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/ChatComposerDrawer/ChatComposerDrawerWithProgress.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatComposerDrawer/ChatComposerDrawerWithProgress.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ChatComposerDrawer',
   name: 'ChatComposerDrawer — With Progress',
   description: 'Drawer paired with a context progress bar in the header. Show context window usage when attachments consume part of the available token budget.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/ChatComposerInput/ChatComposerInputControlledInput.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatComposerInput/ChatComposerInputControlledInput.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ChatComposerInput',
   name: 'ChatComposerInput — Controlled',
   description:
     'Controlled chat input with live value display. Use controlled mode when you need to read or transform the input value outside the composer.',

--- a/packages/cli/templates/blocks/components/ChatComposerInput/ChatComposerInputDisabled.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatComposerInput/ChatComposerInputDisabled.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ChatComposerInput',
   name: 'ChatComposerInput — Disabled',
   description:
     'Composer in a disabled state. Use when the input should be visible but not interactive, such as during streaming or when a prerequisite is unmet.',

--- a/packages/cli/templates/blocks/components/ChatComposerInput/ChatComposerInputMentionTrigger.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatComposerInput/ChatComposerInputMentionTrigger.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ChatComposerInput',
   name: 'ChatComposerInput — Mentions',
   description:
     'Chat input with an @ trigger that opens a typeahead menu for mentioning users. Selected names appear as inline tokens.',

--- a/packages/cli/templates/blocks/components/ChatComposerInput/ChatComposerInputMultipleTriggers.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatComposerInput/ChatComposerInputMultipleTriggers.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ChatComposerInput',
   name: 'ChatComposerInput — Multiple Triggers',
   description:
     'Chat input with both @ mentions and / commands. Each trigger type renders tokens in a distinct color so users can tell them apart at a glance.',

--- a/packages/cli/templates/blocks/components/ChatComposerInput/ChatComposerInputShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatComposerInput/ChatComposerInputShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ChatComposerInput',
   name: 'ChatComposerInput',
   isReady: true,
   aspectRatio: 16 / 9,

--- a/packages/cli/templates/blocks/components/ChatComposerInput/ChatComposerInputSlashCommands.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatComposerInput/ChatComposerInputSlashCommands.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ChatComposerInput',
   name: 'ChatComposerInput — Slash Commands',
   description:
     'Chat input with a / trigger for command selection. Use for AI assistants or bots that support structured commands.',

--- a/packages/cli/templates/blocks/components/ChatDictation/ChatDictationDictationInComposer.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatDictation/ChatDictationDictationInComposer.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ChatDictation',
   name: 'ChatDictationButton — In Composer',
   description: 'Dictation button placed in the sendActions slot of a chat composer. Shows the recommended integration point for voice input alongside the send button.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/ChatDictation/ChatDictationDictationStates.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatDictation/ChatDictationDictationStates.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ChatDictation',
   name: 'ChatDictationButton — States',
   description: 'Dictation button in idle, listening, and speaking states side by side. Shows the three visual phases of a voice input interaction.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/ChatDictation/ChatDictationSizes.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatDictation/ChatDictationSizes.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ChatDictation',
   name: 'ChatDictationButton — Sizes',
   description: 'Small and medium dictation buttons side by side. Use small in compact composer densities and medium for standard layouts.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/ChatDictationButton/ChatDictationButtonShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatDictationButton/ChatDictationButtonShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ChatDictationButton',
   name: 'ChatDictationButton',
   description: 'Interactive dictation button connected to the SpeechRecognition API via useXDSChatDictation. Click the mic to dictate into the composer.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/ChatLayout/ChatLayoutPanelChat.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatLayout/ChatLayoutPanelChat.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ChatLayout',
   name: 'ChatLayout — Panel View',
   description: 'Narrow sidebar chat in a constrained container that triggers compact density. Use for side panels, drawers, or embedded chat widgets where horizontal space is limited.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/ChatLayout/ChatLayoutShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatLayout/ChatLayoutShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ChatLayout',
   name: 'ChatLayout',
   isReady: true,
   aspectRatio: 4 / 3,

--- a/packages/cli/templates/blocks/components/ChatLayoutScrollButton/ChatLayoutScrollButtonLabels.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatLayoutScrollButton/ChatLayoutScrollButtonLabels.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ChatLayoutScrollButton',
   name: 'ChatLayoutScrollButton — Labels',
   description: 'Scroll button with different labels for context-specific notifications like new messages, unread replies, or a generic scroll prompt.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/ChatLayoutScrollButton/ChatLayoutScrollButtonStates.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatLayoutScrollButton/ChatLayoutScrollButtonStates.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ChatLayoutScrollButton',
   name: 'ChatLayoutScrollButton',
   description: 'Scroll button in hidden, visible, and expanded (with label) states. The button fades in when the user scrolls up and expands when new messages arrive.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/ChatMessage/ChatMessageAvatarName.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatMessage/ChatMessageAvatarName.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ChatMessage',
   name: 'ChatMessage — Avatar & Name',
   description: 'Messages with avatars and sender names. Place the name on the bubble when using bubbles, or on the message wrapper for raw content.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/ChatMessage/ChatMessageGhost.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatMessage/ChatMessageGhost.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ChatMessage',
   name: 'ChatMessage — Ghost',
   description: 'Ghost variant for messages without visible bubble boundaries. Keeps padding for alignment but renders a transparent background, useful for AI-style responses.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/ChatMessage/ChatMessageMultiBubble.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatMessage/ChatMessageMultiBubble.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ChatMessage',
   name: 'ChatMessage — Multi-Bubble',
   description: 'Grouped bubbles using the group prop for corner radius reduction. Use first, middle, and last to visually connect related bubbles from the same sender.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/ChatMessage/ChatMessageShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatMessage/ChatMessageShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ChatMessage',
   name: 'ChatMessage',
   description: 'A user multi-bubble group with delivery status and an assistant ghost response with avatar, name, timestamp, and model info.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/ChatMessageBubble/ChatMessageBubbleDensity.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatMessageBubble/ChatMessageBubbleDensity.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ChatMessageBubble',
   name: 'ChatMessageBubble — Density',
   description: 'Compact, balanced, and spacious density modes side by side. Density controls bubble padding, corner radius, and spacing between grouped bubbles.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/ChatMessageBubble/ChatMessageBubbleGrouping.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatMessageBubble/ChatMessageBubbleGrouping.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ChatMessageBubble',
   name: 'ChatMessageBubble — Grouping',
   description: 'Multi-bubble messages using first, middle, and last group positions. Grouped bubbles tighten corner radius on the sender side for a continuous visual flow.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/ChatMessageBubble/ChatMessageBubbleMetadata.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatMessageBubble/ChatMessageBubbleMetadata.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ChatMessageBubble',
   name: 'ChatMessageBubble — Metadata',
   description: 'Bubbles with name and metadata slots aligned to bubble padding. Put name on the first bubble and metadata on the last bubble in a message.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/ChatMessageBubble/ChatMessageBubbleShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatMessageBubble/ChatMessageBubbleShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ChatMessageBubble',
   name: 'ChatMessageBubble',
   description: 'Grouped user bubbles with filled styling and a ghost-variant agent response, with timestamps and delivery status.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/ChatMessageBubble/ChatMessageBubbleVariants.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatMessageBubble/ChatMessageBubbleVariants.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ChatMessageBubble',
   name: 'ChatMessageBubble — Variants',
   description: 'Filled and ghost bubble variants for both user and assistant senders. Use filled for standard messages and ghost when content needs alignment without a visual boundary.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/ChatMessageList/ChatMessageListDensity.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatMessageList/ChatMessageListDensity.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ChatMessageList',
   name: 'ChatMessageList — Density',
   description: 'Side-by-side comparison of compact, balanced, and spacious densities. Use compact in sidebars or panels, balanced for most full-page chat, and spacious for long-form reading.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/ChatMessageList/ChatMessageListFullFeatured.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatMessageList/ChatMessageListFullFeatured.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ChatMessageList',
   name: 'ChatMessageList — Full Featured',
   description: 'Conversation showcasing system messages, multi-bubble grouping, markdown, code blocks, and metadata. Combines date dividers, ghost bubbles, grouped messages, and rich content in a single example.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/ChatMessageList/ChatMessageListShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatMessageList/ChatMessageListShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ChatMessageList',
   name: 'ChatMessageList',
   description: 'Basic AI chat conversation with user and assistant messages. The simplest way to render a message list with alternating sender bubbles, metadata, and a date divider.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/ChatMessageMetadata/ChatMessageMetadataFooter.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatMessageMetadata/ChatMessageMetadataFooter.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ChatMessageMetadata',
   name: 'ChatMessageMetadata — Footer Actions',
   description: 'Assistant message with footer actions — copy, retry, thumbs up/down, and model label. Use for AI responses that need feedback or utility controls.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/ChatMessageMetadata/ChatMessageMetadataShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatMessageMetadata/ChatMessageMetadataShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ChatMessageMetadata',
   name: 'ChatMessageMetadata',
   description: 'Three-message conversation showcasing error status with retry, delivery status, and full footer actions with model label.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/ChatMessageMetadata/ChatMessageMetadataStatus.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatMessageMetadata/ChatMessageMetadataStatus.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ChatMessageMetadata',
   name: 'ChatMessageMetadata — Status',
   description: 'All 5 delivery statuses — sending, sent, delivered, read, and error — each with a timestamp. Use to show message delivery progress or surface failures.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/ChatMessageMetadata/ChatMessageMetadataTimestamp.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatMessageMetadata/ChatMessageMetadataTimestamp.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ChatMessageMetadata',
   name: 'ChatMessageMetadata — Timestamps',
   description: 'Timestamp-only metadata on user and assistant messages. Supports absolute time and relative formats via XDSTimestamp.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/ChatSendButton/ChatSendButtonCustomIcon.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatSendButton/ChatSendButtonCustomIcon.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ChatSendButton',
   name: 'ChatSendButton — Custom Icon',
   description: 'Send buttons with custom icons via sendIcon and stopIcon props. Use to match the personality of the chat experience — a paper airplane for messaging, sparkles for AI generation, or a check mark for confirmation flows.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/ChatSendButton/ChatSendButtonInComposer.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatSendButton/ChatSendButtonInComposer.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ChatSendButton',
   name: 'ChatSendButton — In Composer',
   description: 'Send button inside XDSChatComposer, where it reads state from context automatically. No wiring needed — the button enables when the input has content.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/ChatSendButton/ChatSendButtonShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatSendButton/ChatSendButtonShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ChatSendButton',
   name: 'ChatSendButton',
   description: 'Ready, custom icon, and streaming states of the send button.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/ChatSendButton/ChatSendButtonStates.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatSendButton/ChatSendButtonStates.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ChatSendButton',
   name: 'ChatSendButton — States',
   description: 'Disabled, ready, and streaming states at both sizes. The button automatically toggles between send (primary) and stop (secondary) based on streaming state.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/ChatSystemMessage/ChatSystemMessageShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatSystemMessage/ChatSystemMessageShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ChatSystemMessage',
   name: 'ChatSystemMessage',
   description: 'System messages for date dividers, status updates, and informational notices. Shows both default and divider variants in a realistic conversation flow.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/ChatSystemMessage/ChatSystemMessageStatusUpdates.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatSystemMessage/ChatSystemMessageStatusUpdates.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ChatSystemMessage',
   name: 'ChatSystemMessage — Status Updates',
   description: 'Realistic status messages in a conversation flow showing membership changes, timestamps, and resolution notices.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/ChatSystemMessage/ChatSystemMessageVariants.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatSystemMessage/ChatSystemMessageVariants.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ChatSystemMessage',
   name: 'ChatSystemMessage — Variants',
   description: 'Default and divider variants side by side. Use default for inline status updates and divider for date separators or section breaks.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/ChatSystemMessage/ChatSystemMessageWithIcon.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatSystemMessage/ChatSystemMessageWithIcon.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ChatSystemMessage',
   name: 'ChatSystemMessage — Icon',
   description: 'System messages with a leading icon that reinforces the message type. Use icons to help users scan and identify message categories at a glance.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/ChatTokenizedText/ChatTokenizedTextBasic.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatTokenizedText/ChatTokenizedTextBasic.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ChatTokenizedText',
   name: 'ChatTokenizedText — Basic',
   description: 'A message with @mention tokens. Each matching pattern is replaced with its display name badge.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/ChatTokenizedText/ChatTokenizedTextColors.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatTokenizedText/ChatTokenizedTextColors.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ChatTokenizedText',
   name: 'ChatTokenizedText — Colors',
   description: 'Tokens with different color variants to distinguish mentions, bugs, and features. Use variant colors to create a visual taxonomy — blue for people, red for bugs, green for features.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/ChatTokenizedText/ChatTokenizedTextShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatTokenizedText/ChatTokenizedTextShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ChatTokenizedText',
   name: 'ChatTokenizedText',
   isReady: true,
   aspectRatio: 16 / 9,

--- a/packages/cli/templates/blocks/components/ChatToolCalls/ChatToolCallsInteractiveToolCalls.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatToolCalls/ChatToolCallsInteractiveToolCalls.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ChatToolCalls',
   name: 'ChatToolCalls — Expandable',
   description: 'Tool calls with expandable result details showing diffs and command output in code blocks. Click a row to reveal its result.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/ChatToolCalls/ChatToolCallsShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatToolCalls/ChatToolCallsShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ChatToolCalls',
   name: 'ChatToolCalls',
   isReady: true,
   aspectRatio: 16 / 9,

--- a/packages/cli/templates/blocks/components/ChatToolCalls/ChatToolCallsStatuses.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatToolCalls/ChatToolCallsStatuses.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ChatToolCalls',
   name: 'ChatToolCalls — Statuses',
   description: 'All four status states — pending, running, complete, and error — shown together in a single group.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/ChatToolCalls/ChatToolCallsToolCallsWithNodes.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatToolCalls/ChatToolCallsToolCallsWithNodes.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ChatToolCalls',
   name: 'ChatToolCalls — Simple',
   description: 'A single inline tool call above a collapsible multi-call group with diff stats. Shows both layouts side by side.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/CheckboxInput/CheckboxInputBasic.doc.mjs
+++ b/packages/cli/templates/blocks/components/CheckboxInput/CheckboxInputBasic.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'CheckboxInput',
   name: 'CheckboxInput — States',
   description: 'Checkboxes with labels and descriptions in checked, unchecked, and disabled states. Each checkbox controls a single on/off setting. Add a description to explain what the setting does.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/CheckboxInput/CheckboxInputIndeterminateState.doc.mjs
+++ b/packages/cli/templates/blocks/components/CheckboxInput/CheckboxInputIndeterminateState.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'CheckboxInput',
   name: 'CheckboxInput — Indeterminate',
   description: 'A "select all" checkbox that controls a group of options. When only some options are checked, it shows a dash instead of a checkmark. Clicking it checks or unchecks everything.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/CheckboxInput/CheckboxInputShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/CheckboxInput/CheckboxInputShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'CheckboxInput',
   name: 'CheckboxInput',
   description:
     'Interactive checkboxes showing checked, unchecked, and indeterminate states with descriptions.',

--- a/packages/cli/templates/blocks/components/CheckboxInput/CheckboxInputStatusVariations.doc.mjs
+++ b/packages/cli/templates/blocks/components/CheckboxInput/CheckboxInputStatusVariations.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'CheckboxInput',
   name: 'CheckboxInput — Status',
   description: 'Checkboxes with error, warning, and success validation messages. Use the status prop to show feedback after form validation — errors block submission, warnings inform, and success confirms.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/CheckboxList/CheckboxListSelectAllPattern.doc.mjs
+++ b/packages/cli/templates/blocks/components/CheckboxList/CheckboxListSelectAllPattern.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'CheckboxList',
   name: 'CheckboxList — Select All With Indeterminate',
   description:
     'A "select all" toggle at the top of a checkbox list that switches to an indeterminate dash when only some items are checked — useful for bulk actions like exporting documents or assigning permissions where users often want everything at once.',

--- a/packages/cli/templates/blocks/components/CheckboxList/CheckboxListShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/CheckboxList/CheckboxListShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'CheckboxList',
   name: 'CheckboxList',
   isReady: true,
   aspectRatio: 1,

--- a/packages/cli/templates/blocks/components/CheckboxList/CheckboxListWithEndContent.doc.mjs
+++ b/packages/cli/templates/blocks/components/CheckboxList/CheckboxListWithEndContent.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'CheckboxList',
   name: 'CheckboxList — With End Content',
   description:
     'Badges in the trailing slot show contextual info — like a price or status — next to each option without cluttering the label, so users can compare choices at a glance.',

--- a/packages/cli/templates/blocks/components/CheckboxListItem/CheckboxListItemShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/CheckboxListItem/CheckboxListItemShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'CheckboxListItem',
   name: 'CheckboxListItem',
   description:
     'Checkbox list items with labels, descriptions, and different states including disabled.',

--- a/packages/cli/templates/blocks/components/Code/CodeAcrossTextSizes.doc.mjs
+++ b/packages/cli/templates/blocks/components/Code/CodeAcrossTextSizes.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Code',
   name: 'Code — Text Sizes',
   description:
     'Inline code rendered inside heading, body, supporting, and label text. XDSCode automatically matches the font size of its parent text element.',

--- a/packages/cli/templates/blocks/components/Code/CodeInlineInParagraph.doc.mjs
+++ b/packages/cli/templates/blocks/components/Code/CodeInlineInParagraph.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Code',
   name: 'Code — Inline',
   description:
     'Inline code references mixed within a paragraph of body text. Use XDSCode to mark up function names, hooks, or API terms so they stand out from surrounding prose.',

--- a/packages/cli/templates/blocks/components/Code/CodeShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/Code/CodeShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Code',
   name: 'Code',
   description:
     'Inline code snippets inside a sentence showing how Code renders alongside body text.',

--- a/packages/cli/templates/blocks/components/Code/CodeVariousContent.doc.mjs
+++ b/packages/cli/templates/blocks/components/Code/CodeVariousContent.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Code',
   name: 'Code — Content Types',
   description:
     'Inline code used for variables, terminal commands, CSS properties, file paths, and keyboard shortcuts. Shows how XDSCode adapts to different kinds of technical content.',

--- a/packages/cli/templates/blocks/components/CodeBlock/CodeBlockBashCommand.doc.mjs
+++ b/packages/cli/templates/blocks/components/CodeBlock/CodeBlockBashCommand.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'CodeBlock',
   name: 'Code — Snippet',
   description:
     'Short terminal commands with a copy button and no line numbers. Use for install instructions or one-liner commands that readers will paste directly.',

--- a/packages/cli/templates/blocks/components/CodeBlock/CodeBlockHighlightedLines.doc.mjs
+++ b/packages/cli/templates/blocks/components/CodeBlock/CodeBlockHighlightedLines.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'CodeBlock',
   name: 'Code — Highlighted',
   description:
     'TypeScript code with specific lines highlighted to draw attention to a key section. Use highlightLines to call out new or important code in tutorials and changelogs.',

--- a/packages/cli/templates/blocks/components/CodeBlock/CodeBlockJSONConfig.doc.mjs
+++ b/packages/cli/templates/blocks/components/CodeBlock/CodeBlockJSONConfig.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'CodeBlock',
   name: 'Code — Config',
   description:
     'A JSON configuration file with a title bar and line numbers. The title prop adds a filename label in the header so readers know which file the code belongs to.',

--- a/packages/cli/templates/blocks/components/CodeBlock/CodeBlockScrollableBlock.doc.mjs
+++ b/packages/cli/templates/blocks/components/CodeBlock/CodeBlockScrollableBlock.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'CodeBlock',
   name: 'Code — Scrollable',
   description:
     'A long code block with a max height that enables vertical scrolling. Use maxHeight to keep the block from dominating the page when displaying large files.',

--- a/packages/cli/templates/blocks/components/CodeBlock/CodeBlockShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/CodeBlock/CodeBlockShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'CodeBlock',
   name: 'CodeBlock',
   description:
     'A syntax-highlighted TypeScript code block with line numbers, a title bar, and a copy button.',

--- a/packages/cli/templates/blocks/components/Collapsible/CollapsibleControlledAccordion.doc.mjs
+++ b/packages/cli/templates/blocks/components/Collapsible/CollapsibleControlledAccordion.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Collapsible',
   name: 'Collapsible — Controlled',
   description: 'Manage the open section from parent state. Use when the open state needs to sync with a URL param, form, or external control.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Collapsible/CollapsibleMultipleAccordion.doc.mjs
+++ b/packages/cli/templates/blocks/components/Collapsible/CollapsibleMultipleAccordion.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Collapsible',
   name: 'Collapsible — Multiple Mode',
   description: 'Several sections open at once. Use when users need to compare content across sections, like feature lists or pricing tiers.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Collapsible/CollapsibleShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/Collapsible/CollapsibleShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Collapsible',
   name: 'Collapsible',
   description:
     'An accordion group with three collapsible sections in single mode — opening one closes the others.',

--- a/packages/cli/templates/blocks/components/Collapsible/CollapsibleSingleAccordion.doc.mjs
+++ b/packages/cli/templates/blocks/components/Collapsible/CollapsibleSingleAccordion.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Collapsible',
   name: 'Collapsible — Single Mode',
   description: 'Only one section open at a time. Use for settings pages or any list where expanding one item should close the others.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Collapsible/CollapsibleWithoutCard.doc.mjs
+++ b/packages/cli/templates/blocks/components/Collapsible/CollapsibleWithoutCard.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Collapsible',
   name: 'Collapsible — With Dividers',
   description: 'Collapsible sections separated by dividers instead of cards. Use for inline disclosure in detail panels or sidebar content where cards would add too much weight.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/CollapsibleGroup/CollapsibleGroupShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/CollapsibleGroup/CollapsibleGroupShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'CollapsibleGroup',
   name: 'CollapsibleGroup',
   description:
     'CollapsibleGroup coordinates multiple Collapsible components so that expanding one can automatically collapse the others, creating accordion behavior.',

--- a/packages/cli/templates/blocks/components/CommandPalette/CommandPaletteAsyncSearch.doc.mjs
+++ b/packages/cli/templates/blocks/components/CommandPalette/CommandPaletteAsyncSearch.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'CommandPalette',
   name: 'CommandPalette — Async Search',
   description:
     'Server-side search with loading spinner and custom empty states.',

--- a/packages/cli/templates/blocks/components/CommandPalette/CommandPaletteAutoGrouped.doc.mjs
+++ b/packages/cli/templates/blocks/components/CommandPalette/CommandPaletteAutoGrouped.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'CommandPalette',
   name: 'CommandPalette — Grouped',
   description:
     'Command palette with items grouped via auxiliaryData.group.',

--- a/packages/cli/templates/blocks/components/CommandPalette/CommandPaletteCustomFooter.doc.mjs
+++ b/packages/cli/templates/blocks/components/CommandPalette/CommandPaletteCustomFooter.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'CommandPalette',
   name: 'CommandPalette — Custom Footer',
   description: 'Command palette with a custom footer tip message.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/CommandPalette/CommandPalettePickerMode.doc.mjs
+++ b/packages/cli/templates/blocks/components/CommandPalette/CommandPalettePickerMode.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'CommandPalette',
   name: 'CommandPalette — Picker Mode',
   description:
     'Single-value picker with persistent selection and check indicator.',

--- a/packages/cli/templates/blocks/components/CommandPalette/CommandPaletteRichItems.doc.mjs
+++ b/packages/cli/templates/blocks/components/CommandPalette/CommandPaletteRichItems.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'CommandPalette',
   name: 'CommandPalette — Rich Items',
   description:
     'Custom item rendering with icons, keyboard shortcuts, and keyword search.',

--- a/packages/cli/templates/blocks/components/CommandPalette/CommandPaletteShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/CommandPalette/CommandPaletteShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'CommandPalette',
   name: 'CommandPalette',
   description: 'Basic command palette with static items and keyboard navigation.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/CommandPaletteFooter/CommandPaletteFooterShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/CommandPaletteFooter/CommandPaletteFooterShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'CommandPaletteFooter',
   name: 'CommandPaletteFooter',
   description: 'Command palette footer with custom tip content.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/CommandPaletteGroup/CommandPaletteGroupShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/CommandPaletteGroup/CommandPaletteGroupShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'CommandPaletteGroup',
   name: 'CommandPaletteGroup',
   description: 'Command palette groups in both data-driven (auxiliaryData.group) and composed (XDSCommandPaletteGroup + XDSCommandPaletteItem) forms.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/CommandPaletteItem/CommandPaletteItemShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/CommandPaletteItem/CommandPaletteItemShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'CommandPaletteItem',
   name: 'CommandPaletteItem',
   description: 'Command palette items with custom content via renderItem and as composed XDSCommandPaletteItem with icons, highlighted, selected, and disabled states.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/DateInput/DateInputClearable.doc.mjs
+++ b/packages/cli/templates/blocks/components/DateInput/DateInputClearable.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'DateInput',
   name: 'DateInput — Clearable',
   description:
     'Date input with a clear button that resets the value. Use when the date field is optional and the user may need to undo their selection.',

--- a/packages/cli/templates/blocks/components/DateInput/DateInputDateRange.doc.mjs
+++ b/packages/cli/templates/blocks/components/DateInput/DateInputDateRange.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'DateInput',
   name: 'DateInput — Date Range',
   description:
     'Date input constrained to a min/max window. Use when only certain dates are valid, like booking availability or a fiscal quarter.',

--- a/packages/cli/templates/blocks/components/DateInput/DateInputShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/DateInput/DateInputShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'DateInput',
   name: 'DateInput',
   description:
     'A date input field with a calendar popover. Type a date or click the calendar icon to pick one.',

--- a/packages/cli/templates/blocks/components/DateInput/DateInputWithDescription.doc.mjs
+++ b/packages/cli/templates/blocks/components/DateInput/DateInputWithDescription.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'DateInput',
   name: 'DateInput — Description',
   description:
     'Date input with helper text below the label explaining what the field expects. Use when the purpose of the date is not obvious from the label alone.',

--- a/packages/cli/templates/blocks/components/DateInput/DateInputWithValidation.doc.mjs
+++ b/packages/cli/templates/blocks/components/DateInput/DateInputWithValidation.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'DateInput',
   name: 'DateInput — Validation',
   description:
     'Date input in all three status states: error, warning, and success. Use to surface validation issues, caution the user, or confirm a valid selection.',

--- a/packages/cli/templates/blocks/components/Dialog/DialogConfirmationDialog.doc.mjs
+++ b/packages/cli/templates/blocks/components/Dialog/DialogConfirmationDialog.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Dialog',
   name: 'Dialog — Confirmation',
   description:
     'Asks the user to confirm a destructive action before it happens. Use before deleting projects, removing team members, revoking API keys, or any irreversible operation.',

--- a/packages/cli/templates/blocks/components/Dialog/DialogFormDialog.doc.mjs
+++ b/packages/cli/templates/blocks/components/Dialog/DialogFormDialog.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Dialog',
   name: 'Dialog — Form',
   description:
     'Collects user input without navigating away from the page. Uses purpose="form" so clicking the backdrop won\'t close it. Use for editing profiles, creating items, or updating settings inline.',

--- a/packages/cli/templates/blocks/components/Dialog/DialogFullscreenDialog.doc.mjs
+++ b/packages/cli/templates/blocks/components/Dialog/DialogFullscreenDialog.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Dialog',
   name: 'Dialog — Fullscreen',
   description:
     'Takes over the entire viewport for content that needs maximum space. Use for documentation viewers, rich text editors, multi-step wizards, or media previews where the standard dialog width is too narrow.',

--- a/packages/cli/templates/blocks/components/Dialog/DialogScrollingContent.doc.mjs
+++ b/packages/cli/templates/blocks/components/Dialog/DialogScrollingContent.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Dialog',
   name: 'Dialog — Scrollable',
   description:
     'Constrains the dialog height and scrolls the body when content overflows. Use for terms and conditions, license agreements, changelogs, or any long-form content the user needs to review before accepting.',

--- a/packages/cli/templates/blocks/components/Dialog/DialogShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/Dialog/DialogShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Dialog',
   name: 'Dialog',
   description:
     'Modal dialog with a header, body content, and close button.',

--- a/packages/cli/templates/blocks/components/Dialog/DialogWithSubtitle.doc.mjs
+++ b/packages/cli/templates/blocks/components/Dialog/DialogWithSubtitle.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Dialog',
   name: 'Dialog — Required',
   description:
     'Cannot be dismissed by Escape or backdrop click — the user must explicitly choose an action. Uses purpose="required". Use for ownership transfers, legal acknowledgements, or critical decisions where skipping is not an option.',

--- a/packages/cli/templates/blocks/components/DialogHeader/DialogHeaderShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/DialogHeader/DialogHeaderShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'DialogHeader',
   name: 'DialogHeader',
   description:
     'DialogHeader provides a structured header for dialogs with slots for title, subtitle, close button, and optional start or end content.',

--- a/packages/cli/templates/blocks/components/Divider/DividerFullBleed.doc.mjs
+++ b/packages/cli/templates/blocks/components/Divider/DividerFullBleed.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Divider',
   name: 'Divider — Full Bleed',
   description:
     'Divider that extends past container padding to span the full width. Use inside cards or panels when you want a clean edge-to-edge separation, like between an order summary and total.',

--- a/packages/cli/templates/blocks/components/Divider/DividerShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/Divider/DividerShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Divider',
   name: 'Divider — Variants',
   description:
     'Horizontal dividers in subtle and strong variants, plus a labeled divider. A quick visual reference for separator styles.',

--- a/packages/cli/templates/blocks/components/Divider/DividerVariants.doc.mjs
+++ b/packages/cli/templates/blocks/components/Divider/DividerVariants.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Divider',
   name: 'Divider — Variants',
   description:
     'Subtle, labeled, and strong dividers in a single card. Use subtle between related sections, labeled for alternatives like "or", and strong for high-contrast boundaries.',

--- a/packages/cli/templates/blocks/components/Divider/DividerVertical.doc.mjs
+++ b/packages/cli/templates/blocks/components/Divider/DividerVertical.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Divider',
   name: 'Divider — Vertical',
   description:
     'Vertical dividers separating side-by-side metrics. Use between stat cards, toolbar groups, or any horizontal layout where you need a visual boundary between sections.',

--- a/packages/cli/templates/blocks/components/DropdownMenu/DropdownMenuActions.doc.mjs
+++ b/packages/cli/templates/blocks/components/DropdownMenu/DropdownMenuActions.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'DropdownMenu',
   name: 'DropdownMenu — Actions',
   description:
     'Action menu with dividers separating safe and destructive operations. Use for row-level actions on items like documents, projects, or records.',

--- a/packages/cli/templates/blocks/components/DropdownMenu/DropdownMenuNoChevron.doc.mjs
+++ b/packages/cli/templates/blocks/components/DropdownMenu/DropdownMenuNoChevron.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'DropdownMenu',
   name: 'DropdownMenu — Icon Trigger',
   description:
     'Overflow menu triggered by an icon-only button with no chevron or label text. Use for row-level actions in tables, cards, or lists where a text button would take too much space.',

--- a/packages/cli/templates/blocks/components/DropdownMenu/DropdownMenuShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/DropdownMenu/DropdownMenuShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'DropdownMenu',
   name: 'DropdownMenu',
   description:
     'A button that opens a dropdown menu with action items. The menu starts open for preview.',

--- a/packages/cli/templates/blocks/components/DropdownMenu/DropdownMenuWithDisabledItems.doc.mjs
+++ b/packages/cli/templates/blocks/components/DropdownMenu/DropdownMenuWithDisabledItems.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'DropdownMenu',
   name: 'DropdownMenu — Disabled',
   description:
     'Menu with selectively disabled items based on permissions. Use when some actions require higher privileges, like admin-only operations.',

--- a/packages/cli/templates/blocks/components/DropdownMenu/DropdownMenuWithSections.doc.mjs
+++ b/packages/cli/templates/blocks/components/DropdownMenu/DropdownMenuWithSections.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'DropdownMenu',
   name: 'DropdownMenu — Sections',
   description:
     'Menu items organized into titled sections for easy scanning. Use when you have 6+ actions that fall into distinct categories, like Create vs Manage.',

--- a/packages/cli/templates/blocks/components/DropdownMenuItem/DropdownMenuItemShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/DropdownMenuItem/DropdownMenuItemShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'DropdownMenuItem',
   name: 'DropdownMenuItem',
   description:
     'Dropdown menu with custom-rendered items using XDSDropdownMenuItem for icons and descriptions.',

--- a/packages/cli/templates/blocks/components/EmptyState/EmptyStateActions.doc.mjs
+++ b/packages/cli/templates/blocks/components/EmptyState/EmptyStateActions.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'EmptyState',
   name: 'EmptyState — Actions',
   description:
     'Full empty state with icon, message, and action buttons. Use when a search returns no results, a filter clears all items, or a list has been emptied. The buttons give the user a way forward — go back, clear filters, or try a different query.',

--- a/packages/cli/templates/blocks/components/EmptyState/EmptyStateCompact.doc.mjs
+++ b/packages/cli/templates/blocks/components/EmptyState/EmptyStateCompact.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'EmptyState',
   name: 'EmptyState — Compact',
   description:
     'Smaller empty state with reduced spacing for constrained areas. Use inside sidebar panels, card widgets, or notification drawers where a full-size empty state would overwhelm the layout.',

--- a/packages/cli/templates/blocks/components/EmptyState/EmptyStateContainer.doc.mjs
+++ b/packages/cli/templates/blocks/components/EmptyState/EmptyStateContainer.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'EmptyState',
   name: 'EmptyState — Container',
   description:
     'Empty state wrapped in a Card for first-time setup or onboarding. Use when the user has not created any items yet — like a project list, team roster, or dashboard widget that will fill with data once they take action.',

--- a/packages/cli/templates/blocks/components/EmptyState/EmptyStateShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/EmptyState/EmptyStateShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'EmptyState',
   name: 'EmptyState',
   description:
     'A no-results empty state with an icon, descriptive message, and a call-to-action button.',

--- a/packages/cli/templates/blocks/components/Field/FieldRequired.doc.mjs
+++ b/packages/cli/templates/blocks/components/Field/FieldRequired.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Field',
   name: 'Field — Required & Optional',
   description:
     'Required and optional field indicators side by side. Use isRequired on fields the user must fill in, and isOptional to clarify which fields can be skipped.',

--- a/packages/cli/templates/blocks/components/Field/FieldShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/Field/FieldShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Field',
   name: 'Field',
   description:
     'A form field wrapping a text input with a label, description, and validation status.',

--- a/packages/cli/templates/blocks/components/Field/FieldStatusVariants.doc.mjs
+++ b/packages/cli/templates/blocks/components/Field/FieldStatusVariants.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Field',
   name: 'Field — Validation States',
   description:
     'All three validation states: error, warning, and success. Use error for invalid input, warning for potential issues like reserved names, and success to confirm valid entries like API keys.',

--- a/packages/cli/templates/blocks/components/Field/FieldWithDescription.doc.mjs
+++ b/packages/cli/templates/blocks/components/Field/FieldWithDescription.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Field',
   name: 'Field — Description',
   description:
     'Fields with helper text below the label. Use descriptions to explain format requirements, constraints, or what happens with the data — like "At least 8 characters" or "We will send a confirmation link".',

--- a/packages/cli/templates/blocks/components/FieldLabel/FieldLabelShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/FieldLabel/FieldLabelShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'FieldLabel',
   name: 'FieldLabel',
   description:
     'Standalone field labels demonstrating required, optional, tooltip, and icon variations.',

--- a/packages/cli/templates/blocks/components/FieldStatus/FieldStatusShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/FieldStatus/FieldStatusShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'FieldStatus',
   name: 'FieldStatus',
   description:
     'Field status messages in error, warning, and success states with attached and detached variants.',

--- a/packages/cli/templates/blocks/components/FormLayout/FormLayoutHorizontal.doc.mjs
+++ b/packages/cli/templates/blocks/components/FormLayout/FormLayoutHorizontal.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'FormLayout',
   name: 'FormLayout — Horizontal',
   description: 'Two fields side by side for naturally paired inputs like first and last name',
   isReady: true,

--- a/packages/cli/templates/blocks/components/FormLayout/FormLayoutHorizontalLabels.doc.mjs
+++ b/packages/cli/templates/blocks/components/FormLayout/FormLayoutHorizontalLabels.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'FormLayout',
   name: 'FormLayout — Settings Form',
   description: 'Settings form with labels placed beside their inputs',
   isReady: true,

--- a/packages/cli/templates/blocks/components/FormLayout/FormLayoutMixedControls.doc.mjs
+++ b/packages/cli/templates/blocks/components/FormLayout/FormLayoutMixedControls.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'FormLayout',
   name: 'FormLayout — Mixed Controls',
   description: 'Form with different control types — text input, selector, and checkboxes',
   isReady: true,

--- a/packages/cli/templates/blocks/components/FormLayout/FormLayoutNested.doc.mjs
+++ b/packages/cli/templates/blocks/components/FormLayout/FormLayoutNested.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'FormLayout',
   name: 'FormLayout — Nested Address Form',
   description: 'Address form mixing vertical and horizontal layouts for grouped fields',
   isReady: true,

--- a/packages/cli/templates/blocks/components/FormLayout/FormLayoutShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/FormLayout/FormLayoutShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'FormLayout',
   name: 'FormLayout',
   isReady: true,
   aspectRatio: 1,

--- a/packages/cli/templates/blocks/components/Grid/GridDashboardLayout.doc.mjs
+++ b/packages/cli/templates/blocks/components/Grid/GridDashboardLayout.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Grid',
   name: 'Grid — Dashboard Layout',
   description: 'Dashboard layout with mixed-size widgets and a full-width summary row',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Grid/GridGalleryExample.doc.mjs
+++ b/packages/cli/templates/blocks/components/Grid/GridGalleryExample.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Grid',
   name: 'Grid — Card Gallery',
   description: 'Card gallery with responsive columns that maintain consistent widths',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Grid/GridResponsiveAutoFit.doc.mjs
+++ b/packages/cli/templates/blocks/components/Grid/GridResponsiveAutoFit.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Grid',
   name: 'Grid — Responsive Auto-Fit',
   description: 'Responsive grid where cards stretch to fill remaining space',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Grid/GridShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/Grid/GridShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Grid',
   name: 'Grid',
   isReady: true,
   aspectRatio: 1,

--- a/packages/cli/templates/blocks/components/Grid/GridWithGridSpan.doc.mjs
+++ b/packages/cli/templates/blocks/components/Grid/GridWithGridSpan.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Grid',
   name: 'Grid — Column Spanning',
   description: 'Grid with featured items spanning two, three, and all columns',
   isReady: true,

--- a/packages/cli/templates/blocks/components/GridSpan/GridSpanShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/GridSpan/GridSpanShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'GridSpan',
   name: 'GridSpan',
   description:
     'GridSpan lets a grid item span multiple columns or rows within an XDSGrid, enabling masonry-style and asymmetric layouts.',

--- a/packages/cli/templates/blocks/components/HStack/HStackShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/HStack/HStackShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'HStack',
   name: 'HStack',
   description: 'Demonstrates XDSHStack arranging items horizontally with different gaps and alignments.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Heading/HeadingCardGrid.doc.mjs
+++ b/packages/cli/templates/blocks/components/Heading/HeadingCardGrid.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Heading',
   name: 'Heading — Card Grid',
   description:
     'Responsive card grid with truncated headings and descriptions for uniform layout',

--- a/packages/cli/templates/blocks/components/Heading/HeadingPageLayout.doc.mjs
+++ b/packages/cli/templates/blocks/components/Heading/HeadingPageLayout.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Heading',
   name: 'Heading — Page Hierarchy',
   description:
     'Real-world page layout demonstrating heading levels h1 through h3 with supporting text',

--- a/packages/cli/templates/blocks/components/Heading/HeadingShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/Heading/HeadingShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Heading',
   name: 'Heading',
   isReady: true,
   aspectRatio: 1,

--- a/packages/cli/templates/blocks/components/Heading/HeadingTruncation.doc.mjs
+++ b/packages/cli/templates/blocks/components/Heading/HeadingTruncation.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Heading',
   name: 'Heading — Truncation',
   description:
     'Single-line and multi-line heading truncation with ellipsis for constrained layouts',

--- a/packages/cli/templates/blocks/components/HoverCard/HoverCardInlineTextHoverCard.doc.mjs
+++ b/packages/cli/templates/blocks/components/HoverCard/HoverCardInlineTextHoverCard.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'HoverCard',
   name: 'HoverCard — Definition',
   description:
     'Shows a term definition on hover within a paragraph. Use for technical terms, jargon, or concepts that some readers may not know — like a glossary built into the text.',

--- a/packages/cli/templates/blocks/components/HoverCard/HoverCardInteractiveContent.doc.mjs
+++ b/packages/cli/templates/blocks/components/HoverCard/HoverCardInteractiveContent.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'HoverCard',
   name: 'HoverCard — Link Preview',
   description:
     'Shows a page summary when hovering a link — title, description, and URL. Use for documentation links, article references, or any URL where a preview helps the user decide whether to click.',

--- a/packages/cli/templates/blocks/components/HoverCard/HoverCardProfileHoverCard.doc.mjs
+++ b/packages/cli/templates/blocks/components/HoverCard/HoverCardProfileHoverCard.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'HoverCard',
   name: 'HoverCard — Profile Preview',
   description:
     'Shows a user profile summary on hover with name, role, and bio. Use on usernames, avatars, or mentions to let users preview a profile without navigating away.',

--- a/packages/cli/templates/blocks/components/HoverCard/HoverCardShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/HoverCard/HoverCardShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'HoverCard',
   name: 'HoverCard',
   description:
     'A hover card that shows a user profile preview when hovering over a trigger button. Starts open for preview.',

--- a/packages/cli/templates/blocks/components/Icon/IconNonSemanticColors.doc.mjs
+++ b/packages/cli/templates/blocks/components/Icon/IconNonSemanticColors.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Icon',
   name: 'Icon — Non-Semantic Colors',
   description:
     'Non-semantic color palette for icons.',

--- a/packages/cli/templates/blocks/components/Icon/IconSemanticColors.doc.mjs
+++ b/packages/cli/templates/blocks/components/Icon/IconSemanticColors.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Icon',
   name: 'Icon — Semantic Colors',
   description:
     'All semantic icon color variants with labels.',

--- a/packages/cli/templates/blocks/components/Icon/IconShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/Icon/IconShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Icon',
   name: 'Icon',
   isReady: true,
   aspectRatio: 1,

--- a/packages/cli/templates/blocks/components/Icon/IconSizes.doc.mjs
+++ b/packages/cli/templates/blocks/components/Icon/IconSizes.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Icon',
   name: 'Icon — Size Variants',
   description:
     'All icon sizes from extra-small to large.',

--- a/packages/cli/templates/blocks/components/Icon/IconStatusIcons.doc.mjs
+++ b/packages/cli/templates/blocks/components/Icon/IconStatusIcons.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Icon',
   name: 'Icon — Status Indicators',
   description:
     'Status list using semantic icons for success, warning, error, and info.',

--- a/packages/cli/templates/blocks/components/IconButton/IconButtonActionBar.doc.mjs
+++ b/packages/cli/templates/blocks/components/IconButton/IconButtonActionBar.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'IconButton',
   name: 'IconButton — Action Bar',
   description: 'Row of ghost icon buttons for a compact action toolbar',
   isReady: true,

--- a/packages/cli/templates/blocks/components/IconButton/IconButtonLoadingToggle.doc.mjs
+++ b/packages/cli/templates/blocks/components/IconButton/IconButtonLoadingToggle.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'IconButton',
   name: 'IconButton — Loading State',
   description: 'Icon buttons that show a loading spinner on click for async feedback',
   isReady: true,

--- a/packages/cli/templates/blocks/components/IconButton/IconButtonShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/IconButton/IconButtonShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'IconButton',
   name: 'IconButton',
   isReady: true,
   aspectRatio: 1,

--- a/packages/cli/templates/blocks/components/IconButton/IconButtonTooltipIconButton.doc.mjs
+++ b/packages/cli/templates/blocks/components/IconButton/IconButtonTooltipIconButton.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'IconButton',
   name: 'IconButton — With Tooltips',
   description: 'Icon buttons with tooltips that explain each action on hover',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Kbd/KbdInlineInstructions.doc.mjs
+++ b/packages/cli/templates/blocks/components/Kbd/KbdInlineInstructions.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Kbd',
   name: 'Kbd — Inline Instructions',
   description: 'Keyboard shortcuts rendered inline within instructional text',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Kbd/KbdMenuShortcuts.doc.mjs
+++ b/packages/cli/templates/blocks/components/Kbd/KbdMenuShortcuts.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Kbd',
   name: 'Kbd — Menu Shortcuts',
   description: 'Menu-style list pairing action labels with their keyboard shortcuts',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Kbd/KbdModifierCombos.doc.mjs
+++ b/packages/cli/templates/blocks/components/Kbd/KbdModifierCombos.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Kbd',
   name: 'Kbd — Modifier Combinations',
   description: 'Modifier combinations and special keys rendered as shortcut badges',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Kbd/KbdShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/Kbd/KbdShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Kbd',
   name: 'Kbd',
   isReady: true,
   aspectRatio: 1,

--- a/packages/cli/templates/blocks/components/Layout/LayoutBasicCardLayout.doc.mjs
+++ b/packages/cli/templates/blocks/components/Layout/LayoutBasicCardLayout.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Layout',
   name: 'Layout — Basic Card',
   description:
     'A card layout with header, scrollable content area, and footer with action buttons.',

--- a/packages/cli/templates/blocks/components/Layout/LayoutContentOnlyLayout.doc.mjs
+++ b/packages/cli/templates/blocks/components/Layout/LayoutContentOnlyLayout.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Layout',
   name: 'Layout — Content Only',
   description:
     'A minimal layout with just a content area inside a card, without header or footer.',

--- a/packages/cli/templates/blocks/components/Layout/LayoutContentWidth.doc.mjs
+++ b/packages/cli/templates/blocks/components/Layout/LayoutContentWidth.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Layout',
   name: 'Layout — Content Width',
   description:
     'A layout using contentWidth to constrain and center content while keeping dividers full-bleed.',

--- a/packages/cli/templates/blocks/components/Layout/LayoutDualPanelLayout.doc.mjs
+++ b/packages/cli/templates/blocks/components/Layout/LayoutDualPanelLayout.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Layout',
   name: 'Layout — Dual Panel',
   description:
     'A file browser style layout with start panel for folders, main content for files, and end panel for details.',

--- a/packages/cli/templates/blocks/components/Layout/LayoutFullBleedContent.doc.mjs
+++ b/packages/cli/templates/blocks/components/Layout/LayoutFullBleedContent.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Layout',
   name: 'Layout — Full Bleed Content',
   description:
     'A layout where content extends edge-to-edge with zero padding, ideal for tables or images.',

--- a/packages/cli/templates/blocks/components/Layout/LayoutShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/Layout/LayoutShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Layout',
   name: 'Layout',
   isReady: true,
   aspectRatio: 4 / 3,

--- a/packages/cli/templates/blocks/components/Layout/LayoutSidebarLayout.doc.mjs
+++ b/packages/cli/templates/blocks/components/Layout/LayoutSidebarLayout.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Layout',
   name: 'Layout — Sidebar Navigation',
   description:
     'A settings page layout with a navigation sidebar panel, content area, header, and footer.',

--- a/packages/cli/templates/blocks/components/LayoutContent/LayoutContentShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/LayoutContent/LayoutContentShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'LayoutContent',
   name: 'LayoutContent',
   description:
     'LayoutContent is the scrollable main content area within a Layout, providing automatic padding and scroll containment between the header and footer.',

--- a/packages/cli/templates/blocks/components/LayoutFooter/LayoutFooterShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/LayoutFooter/LayoutFooterShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'LayoutFooter',
   name: 'LayoutFooter',
   description:
     'LayoutFooter is a fixed footer slot within a Layout, pinned to the bottom for persistent actions like form buttons or navigation.',

--- a/packages/cli/templates/blocks/components/LayoutHeader/LayoutHeaderShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/LayoutHeader/LayoutHeaderShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'LayoutHeader',
   name: 'LayoutHeader',
   description:
     'LayoutHeader is a fixed header slot within a Layout, pinned to the top for titles, navigation, and action buttons.',

--- a/packages/cli/templates/blocks/components/LayoutPanel/LayoutPanelShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/LayoutPanel/LayoutPanelShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'LayoutPanel',
   name: 'LayoutPanel',
   description:
     'LayoutPanel is a sidebar slot within a Layout, used for navigation, detail views, or secondary content alongside the main content area.',

--- a/packages/cli/templates/blocks/components/Link/LinkExternalLinks.doc.mjs
+++ b/packages/cli/templates/blocks/components/Link/LinkExternalLinks.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Link',
   name: 'Link — External Links',
   description:
     'A vertical list of external links that open in a new tab with an indicator icon.',

--- a/packages/cli/templates/blocks/components/Link/LinkInlineLink.doc.mjs
+++ b/packages/cli/templates/blocks/components/Link/LinkInlineLink.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Link',
   name: 'Link — Inline Text',
   description: 'A link embedded within a paragraph of body text.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Link/LinkShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/Link/LinkShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Link',
   name: 'Link',
   isReady: true,
   aspectRatio: 1,

--- a/packages/cli/templates/blocks/components/Link/LinksWithTooltips.doc.mjs
+++ b/packages/cli/templates/blocks/components/Link/LinksWithTooltips.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Link',
   name: 'Link — With Tooltips',
   description:
     'Horizontal row of standalone links with descriptive hover tooltips.',

--- a/packages/cli/templates/blocks/components/List/ListBasicList.doc.mjs
+++ b/packages/cli/templates/blocks/components/List/ListBasicList.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'List',
   name: 'List — Basic',
   description: 'Simple list with labels and descriptions for settings-style layouts.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/List/ListBulletedFeatures.doc.mjs
+++ b/packages/cli/templates/blocks/components/List/ListBulletedFeatures.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'List',
   name: 'List — Bulleted Features',
   description: 'Bulleted list of feature highlights using disc markers.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/List/ListMessageList.doc.mjs
+++ b/packages/cli/templates/blocks/components/List/ListMessageList.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'List',
   name: 'List — Message List',
   description:
     'Chat-style message list with avatars, preview text, and unread badges.',

--- a/packages/cli/templates/blocks/components/List/ListOrderedSteps.doc.mjs
+++ b/packages/cli/templates/blocks/components/List/ListOrderedSteps.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'List',
   name: 'List — Ordered Steps',
   description: 'Numbered step-by-step instructions using decimal list markers.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/List/ListShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/List/ListShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'List',
   name: 'List',
   isReady: true,
   aspectRatio: 1,

--- a/packages/cli/templates/blocks/components/ListItem/ListItemShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/ListItem/ListItemShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ListItem',
   name: 'ListItem',
   description:
     'List items with icons, descriptions, and end content slots demonstrating the full ListItem API.',

--- a/packages/cli/templates/blocks/components/Markdown/MarkdownCitedContent.doc.mjs
+++ b/packages/cli/templates/blocks/components/Markdown/MarkdownCitedContent.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Markdown',
   name: 'Markdown — Cited Content',
   description: 'Markdown with citation chips linked to external sources',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Markdown/MarkdownCompactAIResponse.doc.mjs
+++ b/packages/cli/templates/blocks/components/Markdown/MarkdownCompactAIResponse.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Markdown',
   name: 'Markdown — Compact AI Response',
   description: 'Compact markdown styled for AI responses with shifted heading levels',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Markdown/MarkdownDataTable.doc.mjs
+++ b/packages/cli/templates/blocks/components/Markdown/MarkdownDataTable.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Markdown',
   name: 'Markdown — Data Table',
   description: 'Comparison table rendered from a markdown string',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Markdown/MarkdownRichContent.doc.mjs
+++ b/packages/cli/templates/blocks/components/Markdown/MarkdownRichContent.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Markdown',
   name: 'Markdown — Rich Content',
   description: 'Markdown with headings, lists, code blocks, tables, blockquotes, and task lists',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Markdown/MarkdownShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/Markdown/MarkdownShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Markdown',
   name: 'Markdown',
   isReady: true,
   aspectRatio: 1,

--- a/packages/cli/templates/blocks/components/MetadataList/MetadataListBasicMetadata.doc.mjs
+++ b/packages/cli/templates/blocks/components/MetadataList/MetadataListBasicMetadata.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'MetadataList',
   name: 'MetadataList — Basic',
   description: 'Single-column key-value metadata list.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/MetadataList/MetadataListCollapsibleMetadata.doc.mjs
+++ b/packages/cli/templates/blocks/components/MetadataList/MetadataListCollapsibleMetadata.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'MetadataList',
   name: 'MetadataList — Collapsible',
   description:
     'Metadata list with a show-more toggle after a set number of items.',

--- a/packages/cli/templates/blocks/components/MetadataList/MetadataListHorizontalMetadata.doc.mjs
+++ b/packages/cli/templates/blocks/components/MetadataList/MetadataListHorizontalMetadata.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'MetadataList',
   name: 'MetadataList — Horizontal',
   description:
     'Horizontal metadata items for compact inline display.',

--- a/packages/cli/templates/blocks/components/MetadataList/MetadataListMultiColumnMetadata.doc.mjs
+++ b/packages/cli/templates/blocks/components/MetadataList/MetadataListMultiColumnMetadata.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'MetadataList',
   name: 'MetadataList — Multi-Column',
   description:
     'Multi-column metadata grid with token tags.',

--- a/packages/cli/templates/blocks/components/MetadataList/MetadataListShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/MetadataList/MetadataListShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'MetadataList',
   name: 'MetadataList',
   isReady: true,
   aspectRatio: 1,

--- a/packages/cli/templates/blocks/components/MetadataListItem/MetadataListItemShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/MetadataListItem/MetadataListItemShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'MetadataListItem',
   name: 'MetadataListItem',
   description:
     'Metadata list items displaying labeled values in various formats including text, badges, and links.',

--- a/packages/cli/templates/blocks/components/MobileNav/MobileNavBasicMobileNav.doc.mjs
+++ b/packages/cli/templates/blocks/components/MobileNav/MobileNavBasicMobileNav.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'MobileNav',
   name: 'MobileNav — Basic Drawer',
   description: 'Mobile navigation drawer with sectioned nav items triggered by a menu button',
   isReady: true,

--- a/packages/cli/templates/blocks/components/MobileNav/MobileNavEndSideMobileNav.doc.mjs
+++ b/packages/cli/templates/blocks/components/MobileNav/MobileNavEndSideMobileNav.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'MobileNav',
   name: 'MobileNav — End Side Drawer',
   description: 'Navigation drawer that slides in from the right side of the screen',
   isReady: true,

--- a/packages/cli/templates/blocks/components/MobileNav/MobileNavShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/MobileNav/MobileNavShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'MobileNav',
   name: 'MobileNav',
   isReady: true,
   aspectRatio: 1,

--- a/packages/cli/templates/blocks/components/MobileNav/MobileNavWithoutTitleMobileNav.doc.mjs
+++ b/packages/cli/templates/blocks/components/MobileNav/MobileNavWithoutTitleMobileNav.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'MobileNav',
   name: 'MobileNav — Without Title',
   description: 'Mobile navigation drawer without a title header',
   isReady: true,

--- a/packages/cli/templates/blocks/components/MobileNavToggle/MobileNavToggleShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/MobileNavToggle/MobileNavToggleShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'MobileNavToggle',
   name: 'MobileNavToggle',
   description: 'Demonstrates XDSMobileNavToggle as a standalone hamburger button for opening the mobile navigation drawer.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/MoreMenu/MoreMenuDefaultMoreMenu.doc.mjs
+++ b/packages/cli/templates/blocks/components/MoreMenu/MoreMenuDefaultMoreMenu.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'MoreMenu',
   name: 'MoreMenu — Default',
   description:
     'Basic three-dot overflow menu with simple text-only action items.',

--- a/packages/cli/templates/blocks/components/MoreMenu/MoreMenuInToolbar.doc.mjs
+++ b/packages/cli/templates/blocks/components/MoreMenu/MoreMenuInToolbar.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'MoreMenu',
   name: 'MoreMenu — In Toolbar',
   description:
     'A three-dot menu alongside icon buttons in a card header toolbar.',

--- a/packages/cli/templates/blocks/components/MoreMenu/MoreMenuShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/MoreMenu/MoreMenuShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'MoreMenu',
   name: 'MoreMenu',
   description:
     'A basic three-dot menu with simple action items.',

--- a/packages/cli/templates/blocks/components/MoreMenu/MoreMenuWithDividers.doc.mjs
+++ b/packages/cli/templates/blocks/components/MoreMenu/MoreMenuWithDividers.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'MoreMenu',
   name: 'MoreMenu — With Dividers',
   description:
     'A three-dot menu with a divider separating destructive actions from safe ones.',

--- a/packages/cli/templates/blocks/components/MoreMenu/MoreMenuWithSections.doc.mjs
+++ b/packages/cli/templates/blocks/components/MoreMenu/MoreMenuWithSections.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'MoreMenu',
   name: 'MoreMenu — With Sections',
   description:
     'A three-dot menu with actions organized into labeled groups.',

--- a/packages/cli/templates/blocks/components/MultiSelector/MultiSelectorColumnVisibilitySelector.doc.mjs
+++ b/packages/cli/templates/blocks/components/MultiSelector/MultiSelectorColumnVisibilitySelector.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'MultiSelector',
   name: 'MultiSelector — Column Visibility',
   description:
     'Column visibility toggle with hidden label, search, select-all, and selection count.',

--- a/packages/cli/templates/blocks/components/MultiSelector/MultiSelectorForm.doc.mjs
+++ b/packages/cli/templates/blocks/components/MultiSelector/MultiSelectorForm.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'MultiSelector',
   name: 'MultiSelector — Form Composition',
   description:
     'Two multi-selectors in a form with required/optional states.',

--- a/packages/cli/templates/blocks/components/MultiSelector/MultiSelectorSearchableMultiSelector.doc.mjs
+++ b/packages/cli/templates/blocks/components/MultiSelector/MultiSelectorSearchableMultiSelector.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'MultiSelector',
   name: 'MultiSelector — Searchable',
   description:
     'Multi-select with search filtering and select-all.',

--- a/packages/cli/templates/blocks/components/MultiSelector/MultiSelectorSectionedMultiSelector.doc.mjs
+++ b/packages/cli/templates/blocks/components/MultiSelector/MultiSelectorSectionedMultiSelector.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'MultiSelector',
   name: 'MultiSelector — Sectioned Permissions',
   description:
     'Multi-select with options grouped into labeled sections.',

--- a/packages/cli/templates/blocks/components/MultiSelector/MultiSelectorShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/MultiSelector/MultiSelectorShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'MultiSelector',
   name: 'MultiSelector',
   isReady: true,
   aspectRatio: 1,

--- a/packages/cli/templates/blocks/components/NavIcon/NavIconShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/NavIcon/NavIconShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'NavIcon',
   name: 'NavIcon',
   description: 'Circular icon containers for navigation headers with accent backgrounds.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/NumberInput/NumberInputClearableNumberInput.doc.mjs
+++ b/packages/cli/templates/blocks/components/NumberInput/NumberInputClearableNumberInput.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'NumberInput',
   name: 'NumberInput — Clearable',
   description: 'Number input with a clear button, unit suffix, and min/max constraint',
   isReady: true,

--- a/packages/cli/templates/blocks/components/NumberInput/NumberInputRangeNumberInput.doc.mjs
+++ b/packages/cli/templates/blocks/components/NumberInput/NumberInputRangeNumberInput.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'NumberInput',
   name: 'NumberInput — Range Constrained',
   description: 'Number input with min/max boundaries and a helper description',
   isReady: true,

--- a/packages/cli/templates/blocks/components/NumberInput/NumberInputShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/NumberInput/NumberInputShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'NumberInput',
   name: 'NumberInput',
   isReady: true,
   aspectRatio: 1,

--- a/packages/cli/templates/blocks/components/NumberInput/NumberInputStatuses.doc.mjs
+++ b/packages/cli/templates/blocks/components/NumberInput/NumberInputStatuses.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'NumberInput',
   name: 'NumberInput — Status Variants',
   description: 'Number inputs showing error, warning, and success validation states',
   isReady: true,

--- a/packages/cli/templates/blocks/components/NumberInput/NumberInputWithUnits.doc.mjs
+++ b/packages/cli/templates/blocks/components/NumberInput/NumberInputWithUnits.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'NumberInput',
   name: 'NumberInput — With Units',
   description: 'Number input with a percentage unit suffix and valid range',
   isReady: true,

--- a/packages/cli/templates/blocks/components/OverflowList/OverflowListCollapseFromStartList.doc.mjs
+++ b/packages/cli/templates/blocks/components/OverflowList/OverflowListCollapseFromStartList.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'OverflowList',
   name: 'OverflowList — Collapse From Start',
   description: 'Overflow list that hides items from the start, keeping the latest visible',
   isReady: true,

--- a/packages/cli/templates/blocks/components/OverflowList/OverflowListOverflowBadges.doc.mjs
+++ b/packages/cli/templates/blocks/components/OverflowList/OverflowListOverflowBadges.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'OverflowList',
   name: 'OverflowList — Badge Tags',
   description: 'Resizable row of badges that collapses into a count badge on overflow',
   isReady: true,

--- a/packages/cli/templates/blocks/components/OverflowList/OverflowListOverflowDropdownActions.doc.mjs
+++ b/packages/cli/templates/blocks/components/OverflowList/OverflowListOverflowDropdownActions.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'OverflowList',
   name: 'OverflowList — Dropdown Actions',
   description: 'Action toolbar that collapses overflow buttons into a dropdown menu',
   isReady: true,

--- a/packages/cli/templates/blocks/components/OverflowList/OverflowListShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/OverflowList/OverflowListShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'OverflowList',
   name: 'OverflowList',
   isReady: true,
   aspectRatio: 1,

--- a/packages/cli/templates/blocks/components/Pagination/PaginationDotsCarousel.doc.mjs
+++ b/packages/cli/templates/blocks/components/Pagination/PaginationDotsCarousel.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Pagination',
   name: 'Pagination — Dots Carousel',
   description:
     'A review carousel using dot pagination to step through testimonial cards. Use the dots variant for carousels, galleries, and any paged content where the total is small and visible position matters more than a page number.',

--- a/packages/cli/templates/blocks/components/Pagination/PaginationPageSize.doc.mjs
+++ b/packages/cli/templates/blocks/components/Pagination/PaginationPageSize.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Pagination',
   name: 'Pagination — Page Size Selector',
   description:
     'A transactions table with pagination and a page size dropdown at the bottom. Shows how pagination works as a footer below real content, with adjustable rows per page.',

--- a/packages/cli/templates/blocks/components/Pagination/PaginationVariants.doc.mjs
+++ b/packages/cli/templates/blocks/components/Pagination/PaginationVariants.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Pagination',
   name: 'Pagination — Variants',
   description:
     'All four display variants stacked — dots, compact, count, and pages. A quick visual reference for choosing the right variant.',

--- a/packages/cli/templates/blocks/components/Pagination/PaginationWithTable.doc.mjs
+++ b/packages/cli/templates/blocks/components/Pagination/PaginationWithTable.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Pagination',
   name: 'Pagination — With Table',
   description:
     'Pagination below a data table with client-side page slicing. Use the count variant with small size for dense data views where users need to see item ranges.',

--- a/packages/cli/templates/blocks/components/Popover/PopoverConfirmAction.doc.mjs
+++ b/packages/cli/templates/blocks/components/Popover/PopoverConfirmAction.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Popover',
   name: 'Popover — Confirm Action',
   description:
     'Inline confirmation popover for destructive actions with delete and cancel buttons.',

--- a/packages/cli/templates/blocks/components/Popover/PopoverFilterPanel.doc.mjs
+++ b/packages/cli/templates/blocks/components/Popover/PopoverFilterPanel.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Popover',
   name: 'Popover — Filter Panel',
   description:
     'Popover with checkbox filters and apply/reset actions.',

--- a/packages/cli/templates/blocks/components/Popover/PopoverKeyboardShortcuts.doc.mjs
+++ b/packages/cli/templates/blocks/components/Popover/PopoverKeyboardShortcuts.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Popover',
   name: 'Popover — Keyboard Shortcuts',
   description:
     'Popover displaying a list of keyboard shortcuts with key and description pairs.',

--- a/packages/cli/templates/blocks/components/Popover/PopoverSettingsPanel.doc.mjs
+++ b/packages/cli/templates/blocks/components/Popover/PopoverSettingsPanel.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Popover',
   name: 'Popover — Settings Panel',
   description:
     'Popover with toggle switches for managing user preferences like notifications, dark mode, and sounds.',

--- a/packages/cli/templates/blocks/components/Popover/PopoverShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/Popover/PopoverShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Popover',
   name: 'Popover',
   isReady: true,
   aspectRatio: 1,

--- a/packages/cli/templates/blocks/components/PowerSearch/PowerSearchContentSearch.doc.mjs
+++ b/packages/cli/templates/blocks/components/PowerSearch/PowerSearchContentSearch.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'PowerSearch',
   name: 'PowerSearch — Content Search',
   description:
     'Power search with contentSearchFieldKey so free-text input maps to a title field automatically.',

--- a/packages/cli/templates/blocks/components/PowerSearch/PowerSearchFullFeatured.doc.mjs
+++ b/packages/cli/templates/blocks/components/PowerSearch/PowerSearchFullFeatured.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'PowerSearch',
   name: 'PowerSearch — Full Featured',
   description:
     'Power search with multiple field types: enum, multi-select, entity, and text filters.',

--- a/packages/cli/templates/blocks/components/PowerSearch/PowerSearchPresetFilters.doc.mjs
+++ b/packages/cli/templates/blocks/components/PowerSearch/PowerSearchPresetFilters.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'PowerSearch',
   name: 'PowerSearch — Preset Filters',
   description:
     'Power search initialized with pre-set filter tokens for status and priority.',

--- a/packages/cli/templates/blocks/components/PowerSearch/PowerSearchSearchWithTable.doc.mjs
+++ b/packages/cli/templates/blocks/components/PowerSearch/PowerSearchSearchWithTable.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'PowerSearch',
   name: 'PowerSearch — Search with Table',
   description:
     'Composition of PowerSearch with Table using usePowerSearchConfig to auto-generate config and filter data.',

--- a/packages/cli/templates/blocks/components/PowerSearch/PowerSearchShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/PowerSearch/PowerSearchShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'PowerSearch',
   name: 'PowerSearch',
   description:
     'Token-based filter bar with enum and text fields, pre-populated with sample filters.',

--- a/packages/cli/templates/blocks/components/ProgressBar/ProgressBarCustomFormat.doc.mjs
+++ b/packages/cli/templates/blocks/components/ProgressBar/ProgressBarCustomFormat.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ProgressBar',
   name: 'ProgressBar — Custom Format',
   description:
     'Progress bar with a custom value label showing disk usage in GB.',

--- a/packages/cli/templates/blocks/components/ProgressBar/ProgressBarIndeterminate.doc.mjs
+++ b/packages/cli/templates/blocks/components/ProgressBar/ProgressBarIndeterminate.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ProgressBar',
   name: 'ProgressBar — Indeterminate',
   description:
     'Indeterminate progress bar for operations with unknown duration.',

--- a/packages/cli/templates/blocks/components/ProgressBar/ProgressBarSemanticVariants.doc.mjs
+++ b/packages/cli/templates/blocks/components/ProgressBar/ProgressBarSemanticVariants.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ProgressBar',
   name: 'ProgressBar — Semantic Variants',
   description:
     'All semantic color variants stacked vertically.',

--- a/packages/cli/templates/blocks/components/ProgressBar/ProgressBarShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/ProgressBar/ProgressBarShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ProgressBar',
   name: 'ProgressBar',
   isReady: true,
   aspectRatio: 1,

--- a/packages/cli/templates/blocks/components/ProgressBar/ProgressBarWithValueLabel.doc.mjs
+++ b/packages/cli/templates/blocks/components/ProgressBar/ProgressBarWithValueLabel.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ProgressBar',
   name: 'ProgressBar — With Value Label',
   description:
     'Progress bar with its current percentage displayed.',

--- a/packages/cli/templates/blocks/components/RadioList/RadioListHorizontalLayout.doc.mjs
+++ b/packages/cli/templates/blocks/components/RadioList/RadioListHorizontalLayout.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'RadioList',
   name: 'RadioList — Horizontal Layout',
   description:
     'Radio list with horizontal orientation for compact selections.',

--- a/packages/cli/templates/blocks/components/RadioList/RadioListPricingTier.doc.mjs
+++ b/packages/cli/templates/blocks/components/RadioList/RadioListPricingTier.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'RadioList',
   name: 'RadioList — Pricing Tier',
   description:
     'Radio list with pricing info in end content for plan selection.',

--- a/packages/cli/templates/blocks/components/RadioList/RadioListShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/RadioList/RadioListShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'RadioList',
   name: 'RadioList',
   isReady: true,
   aspectRatio: 1,

--- a/packages/cli/templates/blocks/components/RadioList/RadioListWithDescriptions.doc.mjs
+++ b/packages/cli/templates/blocks/components/RadioList/RadioListWithDescriptions.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'RadioList',
   name: 'RadioList — With Descriptions',
   description:
     'Radio list with descriptions on the group and each item.',

--- a/packages/cli/templates/blocks/components/RadioList/RadioListWithValidation.doc.mjs
+++ b/packages/cli/templates/blocks/components/RadioList/RadioListWithValidation.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'RadioList',
   name: 'RadioList — With Validation',
   description:
     'Required radio list with an error message when nothing is selected.',

--- a/packages/cli/templates/blocks/components/RadioListItem/RadioListItemShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/RadioListItem/RadioListItemShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'RadioListItem',
   name: 'RadioListItem',
   description:
     'Radio list items with labels, descriptions, and different states including disabled.',

--- a/packages/cli/templates/blocks/components/Resizable/ResizableShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/Resizable/ResizableShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Resizable',
   name: 'Resizable',
   description:
     'Horizontal resizable split with a draggable handle between two panels.',

--- a/packages/cli/templates/blocks/components/Section/SectionVariants.doc.mjs
+++ b/packages/cli/templates/blocks/components/Section/SectionVariants.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Section',
   name: 'Section — Variants',
   description:
     'All three background variants stacked — section (default surface), wash (muted), and transparent. A quick visual reference for choosing the right variant.',

--- a/packages/cli/templates/blocks/components/Section/SectionWashHighlight.doc.mjs
+++ b/packages/cli/templates/blocks/components/Section/SectionWashHighlight.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Section',
   name: 'Section — Default with Wash',
   description:
     'A default section stacked with a full-width wash section. Shows how wash draws attention to a specific region like an upgrade prompt or banner.',

--- a/packages/cli/templates/blocks/components/Section/SectionWithDividers.doc.mjs
+++ b/packages/cli/templates/blocks/components/Section/SectionWithDividers.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Section',
   name: 'Section — With Dividers',
   description:
     'Adjacent sections separated by bottom dividers, like a settings page. Use dividers when stacking same-variant sections that need visual separation without a background change.',

--- a/packages/cli/templates/blocks/components/SegmentedControl/SegmentedControlDisabledItem.doc.mjs
+++ b/packages/cli/templates/blocks/components/SegmentedControl/SegmentedControlDisabledItem.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'SegmentedControl',
   name: 'SegmentedControl — Disabled Item',
   description:
     'Segmented control with an individually disabled option for unavailable choices.',

--- a/packages/cli/templates/blocks/components/SegmentedControl/SegmentedControlFillLayout.doc.mjs
+++ b/packages/cli/templates/blocks/components/SegmentedControl/SegmentedControlFillLayout.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'SegmentedControl',
   name: 'SegmentedControl \u2014 Fill Layout',
   description:
     'Segmented control that stretches segments equally to fill the available width, useful for fixed-width containers.',

--- a/packages/cli/templates/blocks/components/SegmentedControl/SegmentedControlIconOnly.doc.mjs
+++ b/packages/cli/templates/blocks/components/SegmentedControl/SegmentedControlIconOnly.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'SegmentedControl',
   name: 'SegmentedControl — Icon Only',
   description:
     'Compact segmented control with hidden labels, showing only icons for space-constrained layouts.',

--- a/packages/cli/templates/blocks/components/SegmentedControl/SegmentedControlShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/SegmentedControl/SegmentedControlShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'SegmentedControl',
   name: 'SegmentedControl',
   isReady: true,
   aspectRatio: 1,

--- a/packages/cli/templates/blocks/components/SegmentedControl/SegmentedControlWithIcons.doc.mjs
+++ b/packages/cli/templates/blocks/components/SegmentedControl/SegmentedControlWithIcons.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'SegmentedControl',
   name: 'SegmentedControl — With Icons',
   description:
     'Segmented control with icon and label pairs for a view mode switcher.',

--- a/packages/cli/templates/blocks/components/SegmentedControlItem/SegmentedControlItemShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/SegmentedControlItem/SegmentedControlItemShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'SegmentedControlItem',
   name: 'SegmentedControlItem',
   description:
     'Segmented control items with text labels and icons, including a disabled item.',

--- a/packages/cli/templates/blocks/components/Selector/SelectorClearable.doc.mjs
+++ b/packages/cli/templates/blocks/components/Selector/SelectorClearable.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Selector',
   name: 'Selector — Clearable',
   description:
     'Selector with a clear button to reset the selected value.',

--- a/packages/cli/templates/blocks/components/Selector/SelectorShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/Selector/SelectorShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Selector',
   name: 'Selector',
   isReady: true,
   aspectRatio: 1,

--- a/packages/cli/templates/blocks/components/Selector/SelectorWithSections.doc.mjs
+++ b/packages/cli/templates/blocks/components/Selector/SelectorWithSections.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Selector',
   name: 'Selector — Grouped Sections',
   description:
     'Selector with options grouped into labeled sections.',

--- a/packages/cli/templates/blocks/components/Selector/SelectorWithStatus.doc.mjs
+++ b/packages/cli/templates/blocks/components/Selector/SelectorWithStatus.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Selector',
   name: 'Selector — Validation States',
   description:
     'Selector showing error, warning, and success validation states.',

--- a/packages/cli/templates/blocks/components/SelectorOption/SelectorOptionShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/SelectorOption/SelectorOptionShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'SelectorOption',
   name: 'SelectorOption',
   description:
     'Selector with custom-rendered options using XDSSelectorOption for icons and descriptions.',

--- a/packages/cli/templates/blocks/components/SideNav/SideNavEndContent.doc.mjs
+++ b/packages/cli/templates/blocks/components/SideNav/SideNavEndContent.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'SideNav',
   name: 'SideNav — End Content',
   description:
     'Side navigation items with badges, counts, and context menus as trailing content.',

--- a/packages/cli/templates/blocks/components/SideNav/SideNavNestedItems.doc.mjs
+++ b/packages/cli/templates/blocks/components/SideNav/SideNavNestedItems.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'SideNav',
   name: 'SideNav — Nested Items',
   description:
     'Side navigation with collapsible nested items for settings or hierarchical menus.',

--- a/packages/cli/templates/blocks/components/SideNav/SideNavShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/SideNav/SideNavShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'SideNav',
   name: 'SideNav',
   isReady: true,
   aspectRatio: 1,

--- a/packages/cli/templates/blocks/components/SideNav/SideNavWithHeaderMenu.doc.mjs
+++ b/packages/cli/templates/blocks/components/SideNav/SideNavWithHeaderMenu.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'SideNav',
   name: 'SideNav — Header with Menu',
   description:
     'Side navigation with an account switcher dropdown in the header for multi-account apps.',

--- a/packages/cli/templates/blocks/components/SideNavCollapseButton/SideNavCollapseButtonShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/SideNavCollapseButton/SideNavCollapseButtonShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'SideNavCollapseButton',
   name: 'SideNavCollapseButton',
   description: 'Demonstrates XDSSideNavCollapseButton inside a collapsible SideNav.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/SideNavHeading/SideNavHeadingShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/SideNavHeading/SideNavHeadingShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'SideNavHeading',
   name: 'SideNavHeading',
   description: 'Demonstrates XDSSideNavHeading with an app name, logo icon, superheading, and subheading.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/SideNavItem/SideNavItemShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/SideNavItem/SideNavItemShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'SideNavItem',
   name: 'SideNavItem',
   description: 'Demonstrates XDSSideNavItem with selected, icon, disabled, and nested states.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/SideNavSection/SideNavSectionShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/SideNavSection/SideNavSectionShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'SideNavSection',
   name: 'SideNavSection',
   description: 'Demonstrates XDSSideNavSection with titled groups of navigation items.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Skeleton/SkeletonCardSkeleton.doc.mjs
+++ b/packages/cli/templates/blocks/components/Skeleton/SkeletonCardSkeleton.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Skeleton',
   name: 'Skeleton — Card Loading',
   description:
     'Card skeleton with avatar, name, and content lines.',

--- a/packages/cli/templates/blocks/components/Skeleton/SkeletonShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/Skeleton/SkeletonShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Skeleton',
   name: 'Skeleton',
   isReady: true,
   aspectRatio: 1,

--- a/packages/cli/templates/blocks/components/Skeleton/SkeletonStaggeredList.doc.mjs
+++ b/packages/cli/templates/blocks/components/Skeleton/SkeletonStaggeredList.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Skeleton',
   name: 'Skeleton — Staggered List',
   description:
     'Staggered skeleton lines with varying widths.',

--- a/packages/cli/templates/blocks/components/Skeleton/SkeletonTableRowSkeleton.doc.mjs
+++ b/packages/cli/templates/blocks/components/Skeleton/SkeletonTableRowSkeleton.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Skeleton',
   name: 'Skeleton — Table Rows',
   description:
     'Table skeleton with staggered column widths.',

--- a/packages/cli/templates/blocks/components/Slider/SliderFormattedValue.doc.mjs
+++ b/packages/cli/templates/blocks/components/Slider/SliderFormattedValue.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Slider',
   name: 'Slider — Formatted Value',
   description:
     'Slider with custom formatting showing temperature in Fahrenheit.',

--- a/packages/cli/templates/blocks/components/Slider/SliderRangeSlider.doc.mjs
+++ b/packages/cli/templates/blocks/components/Slider/SliderRangeSlider.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Slider',
   name: 'Slider — Range',
   description:
     'Range slider for selecting a value range like price bounds.',

--- a/packages/cli/templates/blocks/components/Slider/SliderShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/Slider/SliderShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Slider',
   name: 'Slider',
   isReady: true,
   aspectRatio: 1,

--- a/packages/cli/templates/blocks/components/Slider/SliderWithMarks.doc.mjs
+++ b/packages/cli/templates/blocks/components/Slider/SliderWithMarks.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Slider',
   name: 'Slider — With Marks',
   description:
     'Slider with labeled tick marks at fixed intervals.',

--- a/packages/cli/templates/blocks/components/Slider/SliderWithStatus.doc.mjs
+++ b/packages/cli/templates/blocks/components/Slider/SliderWithStatus.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Slider',
   name: 'Slider — Validation States',
   description:
     'Sliders with error, warning, and success validation states.',

--- a/packages/cli/templates/blocks/components/Spinner/SpinnerOnMedia.doc.mjs
+++ b/packages/cli/templates/blocks/components/Spinner/SpinnerOnMedia.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Spinner',
   name: 'Spinner — On Media Shade',
   description:
     'Default and onMedia shade spinners for light and dark backgrounds.',

--- a/packages/cli/templates/blocks/components/Spinner/SpinnerShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/Spinner/SpinnerShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Spinner',
   name: 'Spinner',
   isReady: true,
   aspectRatio: 1,

--- a/packages/cli/templates/blocks/components/Spinner/SpinnerSizes.doc.mjs
+++ b/packages/cli/templates/blocks/components/Spinner/SpinnerSizes.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Spinner',
   name: 'Spinner — Sizes',
   description: 'All spinner sizes displayed side by side.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Spinner/SpinnerWithLabel.doc.mjs
+++ b/packages/cli/templates/blocks/components/Spinner/SpinnerWithLabel.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Spinner',
   name: 'Spinner — With Label',
   description:
     'Spinners with text and rich multi-line labels.',

--- a/packages/cli/templates/blocks/components/Stack/StackAlignment.doc.mjs
+++ b/packages/cli/templates/blocks/components/Stack/StackAlignment.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Stack',
   name: 'Stack — Alignment',
   description:
     'Buttons positioned at the start, center, and end of a row.',

--- a/packages/cli/templates/blocks/components/Stack/StackDirections.doc.mjs
+++ b/packages/cli/templates/blocks/components/Stack/StackDirections.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Stack',
   name: 'Stack — Directions',
   description:
     'Badges arranged horizontally and vertically in side-by-side cards.',

--- a/packages/cli/templates/blocks/components/Stack/StackFillItem.doc.mjs
+++ b/packages/cli/templates/blocks/components/Stack/StackFillItem.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Stack',
   name: 'Stack — Fill Item',
   description:
     'An avatar, text, and button in a row — the text stretches to fill the available space.',

--- a/packages/cli/templates/blocks/components/StackItem/StackItemShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/StackItem/StackItemShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'StackItem',
   name: 'StackItem',
   description:
     'StackItem can be used within XDSHStack or XDSVStack for more granular control over individual item sizing and alignment, but is optional — stack children work without it.',

--- a/packages/cli/templates/blocks/components/StatusDot/StatusDotPulsing.doc.mjs
+++ b/packages/cli/templates/blocks/components/StatusDot/StatusDotPulsing.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'StatusDot',
   name: 'StatusDot — Pulsing',
   description: 'Animated pulsing dots for live, processing, and error states.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/StatusDot/StatusDotShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/StatusDot/StatusDotShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'StatusDot',
   name: 'StatusDot',
   isReady: true,
   aspectRatio: 1,

--- a/packages/cli/templates/blocks/components/StatusDot/StatusDotStatusIndicators.doc.mjs
+++ b/packages/cli/templates/blocks/components/StatusDot/StatusDotStatusIndicators.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'StatusDot',
   name: 'StatusDot — Status Indicators',
   description:
     'Labeled status dot list for presence indicators like online, away, and offline.',

--- a/packages/cli/templates/blocks/components/StatusDot/StatusDotVariants.doc.mjs
+++ b/packages/cli/templates/blocks/components/StatusDot/StatusDotVariants.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'StatusDot',
   name: 'StatusDot — Variants',
   description: 'All five semantic color variants displayed in a row.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Switch/SwitchDisabled.doc.mjs
+++ b/packages/cli/templates/blocks/components/Switch/SwitchDisabled.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Switch',
   name: 'Switch — Disabled',
   description: 'Disabled switch with label and description for gated features.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Switch/SwitchSettingsPanel.doc.mjs
+++ b/packages/cli/templates/blocks/components/Switch/SwitchSettingsPanel.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Switch',
   name: 'Switch — Settings Panel',
   description:
     'Settings panel with spread-spaced switches in a card.',

--- a/packages/cli/templates/blocks/components/Switch/SwitchShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/Switch/SwitchShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Switch',
   name: 'Switch',
   isReady: true,
   aspectRatio: 1,

--- a/packages/cli/templates/blocks/components/Switch/SwitchWithDescription.doc.mjs
+++ b/packages/cli/templates/blocks/components/Switch/SwitchWithDescription.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Switch',
   name: 'Switch — With Description',
   description: 'Toggle with a label and supporting description text.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Switch/SwitchWithStatus.doc.mjs
+++ b/packages/cli/templates/blocks/components/Switch/SwitchWithStatus.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Switch',
   name: 'Switch — With Status',
   description:
     'Switches with error, warning, and success validation states.',

--- a/packages/cli/templates/blocks/components/Tab/TabShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/Tab/TabShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Tab',
   name: 'Tab',
   description:
     'Tab is an individual tab item within a TabList, supporting labels, icons, selected icons, and end content slots.',

--- a/packages/cli/templates/blocks/components/TabList/TabListShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/TabList/TabListShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'TabList',
   name: 'TabList',
   isReady: true,
   aspectRatio: 1,

--- a/packages/cli/templates/blocks/components/TabList/TabListTabsFillLayout.doc.mjs
+++ b/packages/cli/templates/blocks/components/TabList/TabListTabsFillLayout.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'TabList',
   name: 'TabList — Fill Layout',
   description:
     'Tabs that stretch to fill the available width with a bottom divider.',

--- a/packages/cli/templates/blocks/components/TabList/TabListTabsWithActions.doc.mjs
+++ b/packages/cli/templates/blocks/components/TabList/TabListTabsWithActions.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'TabList',
   name: 'TabList — With Actions',
   description:
     'Page header pattern with tabs on the left and action buttons pushed to the right. When hasDivider is true, pair with a smaller button size (sm) so actions don\u2019t overpower the tab row.',

--- a/packages/cli/templates/blocks/components/TabList/TabListTabsWithBadge.doc.mjs
+++ b/packages/cli/templates/blocks/components/TabList/TabListTabsWithBadge.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'TabList',
   name: 'TabList \u2014 With Badge',
   description:
     'Tabs with notification badge counts rendered via endContent. Uses error variant for urgent counts and neutral for informational ones.',

--- a/packages/cli/templates/blocks/components/TabList/TabListTabsWithIcons.doc.mjs
+++ b/packages/cli/templates/blocks/components/TabList/TabListTabsWithIcons.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'TabList',
   name: 'TabList — With Icons',
   description: 'Tabs with leading icons alongside text labels.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/TabList/TabListTabsWithMenu.doc.mjs
+++ b/packages/cli/templates/blocks/components/TabList/TabListTabsWithMenu.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'TabList',
   name: 'TabList — With Overflow Menu',
   description:
     'Tab list with a dropdown menu for additional items that do not fit inline.',

--- a/packages/cli/templates/blocks/components/TabList/TabListTabsWithStatusDot.doc.mjs
+++ b/packages/cli/templates/blocks/components/TabList/TabListTabsWithStatusDot.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'TabList',
   name: 'TabList \u2014 With Status Dot',
   description:
     'Tabs with status dot indicators rendered via endContent to show live environment health at a glance.',

--- a/packages/cli/templates/blocks/components/TabMenu/TabMenuShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/TabMenu/TabMenuShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'TabMenu',
   name: 'TabMenu',
   description:
     'TabMenu is an overflow menu within a TabList that groups additional tab options into a dropdown, showing the selected option\'s label as the trigger text.',

--- a/packages/cli/templates/blocks/components/Table/TableColumnSettingsTable.doc.mjs
+++ b/packages/cli/templates/blocks/components/Table/TableColumnSettingsTable.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Table',
   name: 'Table — Column Settings',
   description:
     'Table with a column visibility picker in the toolbar. Toggle columns on and off.',

--- a/packages/cli/templates/blocks/components/Table/TableFilterableTable.doc.mjs
+++ b/packages/cli/templates/blocks/components/Table/TableFilterableTable.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Table',
   name: 'Table — Popover Filters',
   description:
     'Table with popover filter controls triggered by icons in column headers.',

--- a/packages/cli/templates/blocks/components/Table/TableGridDividersTable.doc.mjs
+++ b/packages/cli/templates/blocks/components/Table/TableGridDividersTable.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Table',
   name: 'Table — Grid Dividers',
   description:
     'Compact table with grid dividers showing both row and column borders, suited for dense numeric data.',

--- a/packages/cli/templates/blocks/components/Table/TableInCard.doc.mjs
+++ b/packages/cli/templates/blocks/components/Table/TableInCard.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Table',
   name: 'Table — In Card',
   description:
     'Table composed inside a card with a heading, demonstrating container bleed alignment.',

--- a/packages/cli/templates/blocks/components/Table/TableInlineFilterTable.doc.mjs
+++ b/packages/cli/templates/blocks/components/Table/TableInlineFilterTable.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Table',
   name: 'Table — Inline Filters',
   description:
     'Table with inline filter controls rendered directly below each column header.',

--- a/packages/cli/templates/blocks/components/Table/TablePaginatedTable.doc.mjs
+++ b/packages/cli/templates/blocks/components/Table/TablePaginatedTable.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Table',
   name: 'Table — Paginated Data',
   description:
     'Paginated data table navigating through a larger dataset page by page.',

--- a/packages/cli/templates/blocks/components/Table/TableResizableTable.doc.mjs
+++ b/packages/cli/templates/blocks/components/Table/TableResizableTable.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Table',
   name: 'Table — Resizable Columns',
   description:
     'Table with draggable column resize handles. Drag the right edge of any header to resize.',

--- a/packages/cli/templates/blocks/components/Table/TableRichCellTable.doc.mjs
+++ b/packages/cli/templates/blocks/components/Table/TableRichCellTable.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Table',
   name: 'Table — Rich Cell Content',
   description:
     'Table with rich cell content using XDSLink for emails and XDSBadge for role labels.',

--- a/packages/cli/templates/blocks/components/Table/TableSelectableTable.doc.mjs
+++ b/packages/cli/templates/blocks/components/Table/TableSelectableTable.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Table',
   name: 'Table — Row Selection',
   description:
     'Table with row selection checkboxes and a select-all header checkbox.',

--- a/packages/cli/templates/blocks/components/Table/TableShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/Table/TableShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Table',
   name: 'Table',
   description:
     'Data-driven table with proportional and pixel column widths and hover highlighting.',

--- a/packages/cli/templates/blocks/components/Table/TableSortableTable.doc.mjs
+++ b/packages/cli/templates/blocks/components/Table/TableSortableTable.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Table',
   name: 'Table — Sortable Columns',
   description:
     'Table with sortable columns, click headers to sort ascending or descending.',

--- a/packages/cli/templates/blocks/components/Table/TableStripedTable.doc.mjs
+++ b/packages/cli/templates/blocks/components/Table/TableStripedTable.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Table',
   name: 'Table — Striped Rows',
   description:
     'Table with alternating row colors and hover highlighting for easy scanning.',

--- a/packages/cli/templates/blocks/components/Text/TextColors.doc.mjs
+++ b/packages/cli/templates/blocks/components/Text/TextColors.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Text',
   name: 'Text — Colors',
   description: 'All text color options (primary, secondary, disabled, placeholder, active) applied to body text to show their intended use.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Text/TextHeadingLevels.doc.mjs
+++ b/packages/cli/templates/blocks/components/Text/TextHeadingLevels.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Text',
   name: 'Text — Heading Levels',
   description: 'All 6 heading levels (h1 through h6) rendered with XDSHeading to show the full type scale.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Text/TextInline.doc.mjs
+++ b/packages/cli/templates/blocks/components/Text/TextInline.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Text',
   name: 'Text — Inline',
   description: 'Mixing body and code text inline within a single line using the default inline display mode.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Text/TextShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/Text/TextShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Text',
   name: 'Text',
   isReady: true,
   aspectRatio: 16 / 9,

--- a/packages/cli/templates/blocks/components/Text/TextTruncation.doc.mjs
+++ b/packages/cli/templates/blocks/components/Text/TextTruncation.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Text',
   name: 'Text — Truncation',
   description: 'Single-line and multi-line text truncation with ellipsis using maxLines in a width-constrained container.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Text/TextTypes.doc.mjs
+++ b/packages/cli/templates/blocks/components/Text/TextTypes.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Text',
   name: 'Text — Types',
   description: 'All 5 semantic text types (body, large, label, supporting, code) with their default styling from the theme.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Text/TextWeight.doc.mjs
+++ b/packages/cli/templates/blocks/components/Text/TextWeight.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Text',
   name: 'Text — Weight',
   description: 'The 4 font weight variants (normal, medium, semibold, bold) applied to body text.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Text/TextWordBreak.doc.mjs
+++ b/packages/cli/templates/blocks/components/Text/TextWordBreak.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Text',
   name: 'Text — Word Break',
   description: 'Compares break-word and break-all word break modes on a long unbreakable string.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Text/TextWrap.doc.mjs
+++ b/packages/cli/templates/blocks/components/Text/TextWrap.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Text',
   name: 'Text — Wrap',
   description: 'The 4 text-wrap modes (wrap, nowrap, balance, pretty) shown in width-constrained containers.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/TextArea/TextAreaCharacterCount.doc.mjs
+++ b/packages/cli/templates/blocks/components/TextArea/TextAreaCharacterCount.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'TextArea',
   name: 'TextArea — Character Count',
   description: 'Textareas with maxLength and a live character counter. The counter turns red when the limit is exceeded.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/TextArea/TextAreaShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/TextArea/TextAreaShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'TextArea',
   name: 'TextArea',
   isReady: true,
   aspectRatio: 1,

--- a/packages/cli/templates/blocks/components/TextArea/TextAreaStates.doc.mjs
+++ b/packages/cli/templates/blocks/components/TextArea/TextAreaStates.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'TextArea',
   name: 'TextArea — States',
   description: 'Required, disabled, and loading textareas side by side. Shows the interactive states the component supports.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/TextArea/TextAreaValidation.doc.mjs
+++ b/packages/cli/templates/blocks/components/TextArea/TextAreaValidation.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'TextArea',
   name: 'TextArea — Validation',
   description: 'All three status variants — error, warning, and success — with status messages, plus error without a message. Use to show inline validation feedback as the user types.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/TextArea/TextAreaWithIcon.doc.mjs
+++ b/packages/cli/templates/blocks/components/TextArea/TextAreaWithIcon.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'TextArea',
   name: 'TextArea — Icon',
   description: 'Textareas with a leading icon that hints at the expected content, like a chat bubble for messages or a pencil for notes.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/TextInput/TextInputIcon.doc.mjs
+++ b/packages/cli/templates/blocks/components/TextInput/TextInputIcon.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'TextInput',
   name: 'TextInput — Icon',
   description: 'Inputs with a leading icon that hints at the expected content. Use when the icon helps users identify the field faster, like a lock for passwords or an envelope for email.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/TextInput/TextInputSearch.doc.mjs
+++ b/packages/cli/templates/blocks/components/TextInput/TextInputSearch.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'TextInput',
   name: 'TextInput — Search',
   description: 'Search input with a hidden label, start icon, and clear button. Use for toolbar and header search bars where the icon provides sufficient context.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/TextInput/TextInputShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/TextInput/TextInputShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'TextInput',
   name: 'TextInput',
   isReady: true,
   aspectRatio: 16 / 9,

--- a/packages/cli/templates/blocks/components/TextInput/TextInputSizes.doc.mjs
+++ b/packages/cli/templates/blocks/components/TextInput/TextInputSizes.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'TextInput',
   name: 'TextInput — Sizes',
   description: 'Small, medium, and large inputs side by side. Use small in dense UIs like table filters, medium for most forms, and large for prominent single-field pages.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/TextInput/TextInputStates.doc.mjs
+++ b/packages/cli/templates/blocks/components/TextInput/TextInputStates.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'TextInput',
   name: 'TextInput — States',
   description: 'Error, warning, and success validation states with status messages. Use to show users what went wrong and how to fix it.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/TextInput/TextInputTypes.doc.mjs
+++ b/packages/cli/templates/blocks/components/TextInput/TextInputTypes.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'TextInput',
   name: 'TextInput — Types',
   description: 'Text, password, and email types plus field-level features: tooltip, required, optional, description, disabled, and loading.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Thumbnail/ThumbnailDisabled.doc.mjs
+++ b/packages/cli/templates/blocks/components/Thumbnail/ThumbnailDisabled.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Thumbnail',
   name: 'Thumbnail — Disabled',
   description: 'Thumbnails in the disabled state with reduced opacity. The remove button and click handler are suppressed when disabled.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Thumbnail/ThumbnailGallery.doc.mjs
+++ b/packages/cli/templates/blocks/components/Thumbnail/ThumbnailGallery.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Thumbnail',
   name: 'Thumbnail — Gallery',
   description: 'A row of clickable thumbnails with labels that open a detail view. Use for image attachment lists where users need to preview and manage uploads.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Thumbnail/ThumbnailRemovable.doc.mjs
+++ b/packages/cli/templates/blocks/components/Thumbnail/ThumbnailRemovable.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Thumbnail',
   name: 'Thumbnail — Removable',
   description: 'Thumbnails with a remove button overlay. The close button uses APCA luminance detection to stay visible on both dark and light images.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Thumbnail/ThumbnailShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/Thumbnail/ThumbnailShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Thumbnail',
   name: 'Thumbnail',
   isReady: true,
   aspectRatio: 16 / 9,

--- a/packages/cli/templates/blocks/components/Thumbnail/ThumbnailStates.doc.mjs
+++ b/packages/cli/templates/blocks/components/Thumbnail/ThumbnailStates.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Thumbnail',
   name: 'Thumbnail — States',
   description: 'All visual states side by side: image loaded, placeholder, skeleton loading, and upload overlay. Demonstrates the full lifecycle of a thumbnail from empty to loaded.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/TimeInput/TimeInputConstrained.doc.mjs
+++ b/packages/cli/templates/blocks/components/TimeInput/TimeInputConstrained.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'TimeInput',
   name: 'TimeInput — Constrained',
   description: 'Time inputs with min/max constraints limiting selection to specific windows. Use to prevent out-of-bounds selections for appointments, reservations, or shift scheduling.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/TimeInput/TimeInputFormats.doc.mjs
+++ b/packages/cli/templates/blocks/components/TimeInput/TimeInputFormats.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'TimeInput',
   name: 'TimeInput — Formats',
   description: '12-hour, 24-hour, and seconds formats side by side. Use 12h for US-centric UIs, 24h for international or technical contexts, and seconds for precise timing.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/TimeInput/TimeInputIncrement.doc.mjs
+++ b/packages/cli/templates/blocks/components/TimeInput/TimeInputIncrement.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'TimeInput',
   name: 'TimeInput — Increment',
   description: 'Time input with a custom step increment. Arrow keys jump by the specified interval (e.g. 15 minutes) for quick slot-based scheduling.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/TimeInput/TimeInputShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/TimeInput/TimeInputShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'TimeInput',
   name: 'TimeInput',
   isReady: true,
   aspectRatio: 16 / 9,

--- a/packages/cli/templates/blocks/components/TimeInput/TimeInputStates.doc.mjs
+++ b/packages/cli/templates/blocks/components/TimeInput/TimeInputStates.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'TimeInput',
   name: 'TimeInput — States',
   description: 'Default, disabled, error, warning, and success states. Use status messages to give users clear feedback about their time selection.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Timestamp/TimestampAutoFormat.doc.mjs
+++ b/packages/cli/templates/blocks/components/Timestamp/TimestampAutoFormat.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Timestamp',
   name: 'Timestamp — Auto',
   description: 'Auto format that shows relative time for recent dates and switches to the full date for older ones. The default choice for most use cases.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Timestamp/TimestampColors.doc.mjs
+++ b/packages/cli/templates/blocks/components/Timestamp/TimestampColors.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Timestamp',
   name: 'Timestamp \u2014 Colors',
   description:
     'Timestamp rendered in each available color variant: primary, secondary, disabled, and active.',

--- a/packages/cli/templates/blocks/components/Timestamp/TimestampFormats.doc.mjs
+++ b/packages/cli/templates/blocks/components/Timestamp/TimestampFormats.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Timestamp',
   name: 'Timestamp — Formats',
   description: 'All display formats side by side: date, date_time, time, and their system equivalents. Use date and date_time for user-facing UI, system variants for logs and dev tools.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Timestamp/TimestampRelativeFormat.doc.mjs
+++ b/packages/cli/templates/blocks/components/Timestamp/TimestampRelativeFormat.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Timestamp',
   name: 'Timestamp — Relative',
   description: 'Relative time labels from seconds to months ago, with hover tooltips showing the full date. Use in feeds, comment threads, and activity logs.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Timestamp/TimestampShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/Timestamp/TimestampShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Timestamp',
   name: 'Timestamp',
   isReady: true,
   aspectRatio: 16 / 9,

--- a/packages/cli/templates/blocks/components/Timestamp/TimestampTimezone.doc.mjs
+++ b/packages/cli/templates/blocks/components/Timestamp/TimestampTimezone.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Timestamp',
   name: 'Timestamp — Timezone',
   description: 'Timestamps with the timezone abbreviation appended. Enable isTimezoneShown for audiences across time zones, like audit logs or team calendars.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Toast/ToastAction.doc.mjs
+++ b/packages/cli/templates/blocks/components/Toast/ToastAction.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Toast',
   name: 'Toast — Action',
   description: 'Persistent toasts with a trailing button or link so the user can act on the notification, like undoing a delete or viewing a report.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Toast/ToastDeduplication.doc.mjs
+++ b/packages/cli/templates/blocks/components/Toast/ToastDeduplication.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Toast',
   name: 'Toast — Deduplication',
   description: 'Prevent duplicate toasts with uniqueID. Use ignore to keep the first toast, or overwrite to replace it with updated content like a progress percentage.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Toast/ToastDismiss.doc.mjs
+++ b/packages/cli/templates/blocks/components/Toast/ToastDismiss.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Toast',
   name: 'Toast — Dismiss',
   description: 'Show a persistent toast and dismiss it programmatically using the function returned by useXDSToast. Use for long-running operations that need manual cleanup.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Toast/ToastShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/Toast/ToastShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Toast',
   name: 'Toast',
   isReady: true,
   aspectRatio: 16 / 9,

--- a/packages/cli/templates/blocks/components/Toast/ToastStacking.doc.mjs
+++ b/packages/cli/templates/blocks/components/Toast/ToastStacking.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Toast',
   name: 'Toast — Stacking',
   description: 'Multiple toasts stacking vertically with smooth enter and exit animations. Click repeatedly to see how toasts queue and dismiss.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Toast/ToastTypes.doc.mjs
+++ b/packages/cli/templates/blocks/components/Toast/ToastTypes.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Toast',
   name: 'Toast — Types',
   description: 'Info and error toast variants side by side. Info toasts auto-dismiss after 5 seconds, error toasts persist until the user dismisses them.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/ToggleButton/ToggleButtonColor.doc.mjs
+++ b/packages/cli/templates/blocks/components/ToggleButton/ToggleButtonColor.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ToggleButton',
   name: 'ToggleButton — Color',
   description: 'Toggle buttons with colored icons in the pressed state. Shows accent-colored toolbar formatting and semantic reaction colors (yellow star, red heart, blue bookmark).',
   isReady: true,

--- a/packages/cli/templates/blocks/components/ToggleButton/ToggleButtonGroup.doc.mjs
+++ b/packages/cli/templates/blocks/components/ToggleButton/ToggleButtonGroup.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ToggleButton',
   name: 'ToggleButton — Group',
   description: 'Toggle button groups in single-select and multi-select modes. Single selection acts as a view mode switcher; multiple selection forms a formatting toolbar.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/ToggleButton/ToggleButtonIconSwap.doc.mjs
+++ b/packages/cli/templates/blocks/components/ToggleButton/ToggleButtonIconSwap.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ToggleButton',
   name: 'ToggleButton — Icon Swap',
   description: 'Icon-only toggle buttons that swap between outline and solid icons when pressed. Use for actions like favorite, bookmark, or mute where the icon itself communicates the state.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/ToggleButton/ToggleButtonLabel.doc.mjs
+++ b/packages/cli/templates/blocks/components/ToggleButton/ToggleButtonLabel.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ToggleButton',
   name: 'ToggleButton — Label',
   description: 'Toggle buttons with visible text labels that show a font weight shift on press. Use when the icon alone is not enough to communicate the action.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/ToggleButton/ToggleButtonShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/ToggleButton/ToggleButtonShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ToggleButton',
   name: 'ToggleButton',
   isReady: true,
   aspectRatio: 16 / 9,

--- a/packages/cli/templates/blocks/components/ToggleButton/ToggleButtonStates.doc.mjs
+++ b/packages/cli/templates/blocks/components/ToggleButton/ToggleButtonStates.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ToggleButton',
   name: 'ToggleButton — States',
   description: 'Default, pressed, disabled, and loading states of a standalone toggle button. Shows how visual treatment changes across states.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/ToggleButtonGroup/ToggleButtonGroupShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/ToggleButtonGroup/ToggleButtonGroupShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'ToggleButtonGroup',
   name: 'ToggleButtonGroup',
   description:
     'ToggleButtonGroup manages a set of ToggleButtons with single-select or multi-select behavior for options like view modes or filters.',

--- a/packages/cli/templates/blocks/components/Token/TokenClickable.doc.mjs
+++ b/packages/cli/templates/blocks/components/Token/TokenClickable.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Token',
   name: 'Token — Clickable',
   description: 'Interactive tokens that respond to clicks. Use for toggleable filters or tokens that open a detail view when selected.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Token/TokenColors.doc.mjs
+++ b/packages/cli/templates/blocks/components/Token/TokenColors.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Token',
   name: 'Token — Colors',
   description: 'All 11 color variants in default and disabled states. Use color to categorize entities or convey status at a glance.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Token/TokenEndContent.doc.mjs
+++ b/packages/cli/templates/blocks/components/Token/TokenEndContent.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Token',
   name: 'Token — End Content',
   description: 'Tokens with trailing content like a count badge or status indicator after the label. Use for notification counts, item quantities, or compact status info.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Token/TokenIcon.doc.mjs
+++ b/packages/cli/templates/blocks/components/Token/TokenIcon.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Token',
   name: 'Token — Icon',
   description: 'Tokens with a leading icon that identifies the entity type. Use when the icon helps users recognize the token category faster, like a user icon for people or a tag icon for labels.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Token/TokenRemovable.doc.mjs
+++ b/packages/cli/templates/blocks/components/Token/TokenRemovable.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Token',
   name: 'Token — Removable',
   description: 'Tokens with a dismiss button for selections the user can undo. Use in multi-select fields, active filters, or any list of user-chosen items.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Token/TokenShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/Token/TokenShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Token',
   name: 'Token',
   isReady: true,
   aspectRatio: 1,

--- a/packages/cli/templates/blocks/components/Tokenizer/TokenizerClear.doc.mjs
+++ b/packages/cli/templates/blocks/components/Tokenizer/TokenizerClear.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Tokenizer',
   name: 'Tokenizer \u2014 Clear',
   description: 'Tokenizer with a built-in clear-all button for bulk removal of all selected tokens.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Tokenizer/TokenizerCreatable.doc.mjs
+++ b/packages/cli/templates/blocks/components/Tokenizer/TokenizerCreatable.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Tokenizer',
   name: 'Tokenizer \u2014 Creatable',
   description: 'Free-text tokenizer for creating custom tags and a combined create-or-search pattern. Use when users need to enter values that may not exist in a predefined list.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Tokenizer/TokenizerEndContent.doc.mjs
+++ b/packages/cli/templates/blocks/components/Tokenizer/TokenizerEndContent.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Tokenizer',
   name: 'Tokenizer \u2014 End Content',
   description: 'Tokenizer with an action button in the end slot. Use for inline actions like applying selections alongside the input.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Tokenizer/TokenizerIcon.doc.mjs
+++ b/packages/cli/templates/blocks/components/Tokenizer/TokenizerIcon.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Tokenizer',
   name: 'Tokenizer \u2014 Icon',
   description: 'Tokenizer with a leading search icon to visually reinforce the search behavior.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Tokenizer/TokenizerMaxEntries.doc.mjs
+++ b/packages/cli/templates/blocks/components/Tokenizer/TokenizerMaxEntries.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Tokenizer',
   name: 'Tokenizer \u2014 Max Entries',
   description: 'Tokenizer with a maximum selection limit. The input hides automatically when the limit is reached, preventing further additions.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Tokenizer/TokenizerOverflow.doc.mjs
+++ b/packages/cli/templates/blocks/components/Tokenizer/TokenizerOverflow.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Tokenizer',
   name: 'Tokenizer \u2014 Overflow',
   description: 'Tokenizer with overflow truncation when unfocused. Inline mode pushes content down on expand; layer mode overlays without shifting layout.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Tokenizer/TokenizerShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/Tokenizer/TokenizerShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Tokenizer',
   name: 'Tokenizer',
   isReady: true,
   aspectRatio: 4 / 3,

--- a/packages/cli/templates/blocks/components/Tokenizer/TokenizerStates.doc.mjs
+++ b/packages/cli/templates/blocks/components/Tokenizer/TokenizerStates.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Tokenizer',
   name: 'Tokenizer \u2014 States',
   description: 'Tokenizer in disabled, error, warning, and success states. Use to communicate validation feedback or lock a selection from editing.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Toolbar/ToolbarBulkActions.doc.mjs
+++ b/packages/cli/templates/blocks/components/Toolbar/ToolbarBulkActions.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Toolbar',
   name: 'Toolbar — Bulk Actions',
   description:
     'A compact toolbar with the wash variant for showing bulk selection actions. Use when the user selects multiple items in a list or table and needs quick access to batch operations.',

--- a/packages/cli/templates/blocks/components/Toolbar/ToolbarCardHeader.doc.mjs
+++ b/packages/cli/templates/blocks/components/Toolbar/ToolbarCardHeader.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Toolbar',
   name: 'Toolbar — Card Header',
   description:
     'A toolbar as a card header with a left-aligned title and icon actions on the right. Use Toolbar instead of LayoutHeader when your card header has interactive actions — Toolbar adds start/end slot layout, keyboard navigation, and automatic size cascading. If the header is just a title with no actions, a LayoutHeader or Section is enough.',

--- a/packages/cli/templates/blocks/components/Toolbar/ToolbarSizes.doc.mjs
+++ b/packages/cli/templates/blocks/components/Toolbar/ToolbarSizes.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Toolbar',
   name: 'Toolbar — Sizes',
   description:
     'Small, medium, and large toolbars side by side. The size prop cascades to child buttons and inputs automatically. Use small in dense UIs like cards, medium for most cases, and large for spacious layouts.',

--- a/packages/cli/templates/blocks/components/Toolbar/ToolbarTableFilter.doc.mjs
+++ b/packages/cli/templates/blocks/components/Toolbar/ToolbarTableFilter.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Toolbar',
   name: 'Toolbar — Table Filter',
   description:
     'A compact toolbar with a search input, filter buttons, and an overflow menu. Use above a data table to let users search, filter, and access view options.',

--- a/packages/cli/templates/blocks/components/Toolbar/ToolbarThreeSlot.doc.mjs
+++ b/packages/cli/templates/blocks/components/Toolbar/ToolbarThreeSlot.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Toolbar',
   name: 'Toolbar — Three Slot',
   description:
     'A toolbar with start, center, and end content using the three-column grid layout. Use when you need a centered title or heading with navigation and actions on either side.',

--- a/packages/cli/templates/blocks/components/Toolbar/ToolbarWithTabs.doc.mjs
+++ b/packages/cli/templates/blocks/components/Toolbar/ToolbarWithTabs.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Toolbar',
   name: 'Toolbar — Tab Navigation',
   description:
     'A toolbar with tabs in the start slot and an action button at the end. Use as a card or section header when content is split into tabs with a primary action alongside.',

--- a/packages/cli/templates/blocks/components/Tooltip/TooltipActionBarTooltips.doc.mjs
+++ b/packages/cli/templates/blocks/components/Tooltip/TooltipActionBarTooltips.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Tooltip',
   name: 'Tooltip — Action Bar',
   description:
     'Tooltips on an action button bar with contextual descriptions.',

--- a/packages/cli/templates/blocks/components/Tooltip/TooltipHookUsage.doc.mjs
+++ b/packages/cli/templates/blocks/components/Tooltip/TooltipHookUsage.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Tooltip',
   name: 'Tooltip — Hook Usage',
   description:
     'Tooltip using the useXDSTooltip hook for programmatic control.',

--- a/packages/cli/templates/blocks/components/Tooltip/TooltipInlineTextTooltips.doc.mjs
+++ b/packages/cli/templates/blocks/components/Tooltip/TooltipInlineTextTooltips.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Tooltip',
   name: 'Tooltip — Inline Text',
   description:
     'Tooltips on inline text terms for definitions.',

--- a/packages/cli/templates/blocks/components/Tooltip/TooltipShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/Tooltip/TooltipShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Tooltip',
   name: 'Tooltip',
   isReady: true,
   aspectRatio: 1,

--- a/packages/cli/templates/blocks/components/TopNav/TopNavCenteredNavigation.doc.mjs
+++ b/packages/cli/templates/blocks/components/TopNav/TopNavCenteredNavigation.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'TopNav',
   name: 'TopNav — Centered Navigation',
   description:
     'Navigation layout with center-aligned nav items flanked by a logo heading and end actions.',

--- a/packages/cli/templates/blocks/components/TopNav/TopNavEnterpriseDashboard.doc.mjs
+++ b/packages/cli/templates/blocks/components/TopNav/TopNavEnterpriseDashboard.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'TopNav',
   name: 'TopNav — Enterprise Dashboard',
   description:
     'Full-featured navigation bar with icon-labeled nav items, search, notifications, and a primary CTA.',

--- a/packages/cli/templates/blocks/components/TopNav/TopNavHoverMenu.doc.mjs
+++ b/packages/cli/templates/blocks/components/TopNav/TopNavHoverMenu.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'TopNav',
   name: 'TopNav — Hover Menu',
   description:
     'Navigation bar with a hover-triggered dropdown menu showing product items with icons and descriptions.',

--- a/packages/cli/templates/blocks/components/TopNav/TopNavMegaMenu.doc.mjs
+++ b/packages/cli/templates/blocks/components/TopNav/TopNavMegaMenu.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'TopNav',
   name: 'TopNav — Mega Menu',
   description:
     'Marketing-style navigation with a full-width mega menu featuring product items and a promotional featured card.',

--- a/packages/cli/templates/blocks/components/TopNav/TopNavMultipleDropdowns.doc.mjs
+++ b/packages/cli/templates/blocks/components/TopNav/TopNavMultipleDropdowns.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'TopNav',
   name: 'TopNav — Multiple Dropdowns',
   description:
     'Navigation bar with multiple hover-triggered dropdown menus that auto-close when switching between them.',

--- a/packages/cli/templates/blocks/components/TopNav/TopNavShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/TopNav/TopNavShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'TopNav',
   name: 'TopNav',
   isReady: true,
   aspectRatio: 3,

--- a/packages/cli/templates/blocks/components/TopNav/TopNavWithLogo.doc.mjs
+++ b/packages/cli/templates/blocks/components/TopNav/TopNavWithLogo.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'TopNav',
   name: 'TopNav — With Logo',
   description:
     'Navigation bar with a branded logo icon, heading link, nav items, and a profile action.',

--- a/packages/cli/templates/blocks/components/TopNavHeading/TopNavHeadingShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/TopNavHeading/TopNavHeadingShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'TopNavHeading',
   name: 'TopNavHeading',
   description: 'Demonstrates XDSTopNavHeading with a logo and text, both as a plain display and as a clickable link.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/TopNavItem/TopNavItemShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/TopNavItem/TopNavItemShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'TopNavItem',
   name: 'TopNavItem',
   description: 'Demonstrates XDSTopNavItem with selected, icon, disabled, and default states.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/TopNavMegaMenu/TopNavMegaMenuShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/TopNavMegaMenu/TopNavMegaMenuShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'TopNavMegaMenu',
   name: 'TopNavMegaMenu',
   description: 'Demonstrates XDSTopNavMegaMenu with items and a featured card in the mega menu panel.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/TopNavMegaMenuFeaturedCard/TopNavMegaMenuFeaturedCardShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/TopNavMegaMenuFeaturedCard/TopNavMegaMenuFeaturedCardShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'TopNavMegaMenuFeaturedCard',
   name: 'TopNavMegaMenuFeaturedCard',
   description: 'Demonstrates XDSTopNavMegaMenuFeaturedCard with a title, description, and CTA link inside a mega menu.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/TopNavMegaMenuItem/TopNavMegaMenuItemShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/TopNavMegaMenuItem/TopNavMegaMenuItemShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'TopNavMegaMenuItem',
   name: 'TopNavMegaMenuItem',
   description: 'Demonstrates XDSTopNavMegaMenuItem with icons, titles, and descriptions inside a mega menu.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/TopNavMenu/TopNavMenuShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/TopNavMenu/TopNavMenuShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'TopNavMenu',
   name: 'TopNavMenu',
   description: 'Demonstrates XDSTopNavMenu with a hover-triggered dropdown containing items with icons and descriptions.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/TreeList/TreeListFileTreeWithIcons.doc.mjs
+++ b/packages/cli/templates/blocks/components/TreeList/TreeListFileTreeWithIcons.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'TreeList',
   name: 'TreeList — File Tree With Icons',
   description:
     'File browser tree with folder and document icons distinguishing directories from files.',

--- a/packages/cli/templates/blocks/components/TreeList/TreeListInteractiveSettings.doc.mjs
+++ b/packages/cli/templates/blocks/components/TreeList/TreeListInteractiveSettings.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'TreeList',
   name: 'TreeList — Interactive Settings',
   description:
     'Settings tree with clickable items and a documentation link.',

--- a/packages/cli/templates/blocks/components/TreeList/TreeListMailboxTree.doc.mjs
+++ b/packages/cli/templates/blocks/components/TreeList/TreeListMailboxTree.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'TreeList',
   name: 'TreeList — Mailbox Tree',
   description:
     'Email folder tree with unread badge counts.',

--- a/packages/cli/templates/blocks/components/TreeList/TreeListNavigationTree.doc.mjs
+++ b/packages/cli/templates/blocks/components/TreeList/TreeListNavigationTree.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'TreeList',
   name: 'TreeList — Navigation Tree',
   description:
     'Navigation tree with a selected item for the current page.',

--- a/packages/cli/templates/blocks/components/TreeList/TreeListShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/TreeList/TreeListShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'TreeList',
   name: 'TreeList',
   isReady: true,
   aspectRatio: 1,

--- a/packages/cli/templates/blocks/components/TreeListBranches/TreeListBranchesShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/TreeListBranches/TreeListBranchesShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'TreeListBranches',
   name: 'TreeListBranches',
   description: 'Tree with expandable branches at multiple nesting levels.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/TreeListItem/TreeListItemShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/TreeListItem/TreeListItemShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'TreeListItem',
   name: 'TreeListItem',
   description: 'Tree items with descriptions, icons, badges, selection, disabled state, and nested expand/collapse. TreeList is data-driven — no composed children API.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Typeahead/TypeaheadLimitedResults.doc.mjs
+++ b/packages/cli/templates/blocks/components/Typeahead/TypeaheadLimitedResults.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Typeahead',
   name: 'Typeahead — Limited Results',
   description:
     'Typeahead with a capped dropdown showing at most three results.',

--- a/packages/cli/templates/blocks/components/Typeahead/TypeaheadSearchField.doc.mjs
+++ b/packages/cli/templates/blocks/components/Typeahead/TypeaheadSearchField.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Typeahead',
   name: 'Typeahead — Search Field',
   description:
     'Search input with icon and suggestions on focus.',

--- a/packages/cli/templates/blocks/components/Typeahead/TypeaheadShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/Typeahead/TypeaheadShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Typeahead',
   name: 'Typeahead',
   isReady: true,
   aspectRatio: 1,

--- a/packages/cli/templates/blocks/components/Typeahead/TypeaheadWithHelperText.doc.mjs
+++ b/packages/cli/templates/blocks/components/Typeahead/TypeaheadWithHelperText.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Typeahead',
   name: 'Typeahead — With Helper Text',
   description:
     'Typeahead with a description below the label.',

--- a/packages/cli/templates/blocks/components/Typeahead/TypeaheadWithValidation.doc.mjs
+++ b/packages/cli/templates/blocks/components/Typeahead/TypeaheadWithValidation.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'Typeahead',
   name: 'Typeahead — With Validation',
   description:
     'Typeahead with an error validation message.',

--- a/packages/cli/templates/blocks/components/TypeaheadItem/TypeaheadItemShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/TypeaheadItem/TypeaheadItemShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'TypeaheadItem',
   name: 'TypeaheadItem',
   description:
     'Typeahead with custom item rendering using XDSTypeaheadItem for avatars and descriptions.',

--- a/packages/cli/templates/blocks/components/VStack/VStackShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/VStack/VStackShowcase.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
+  exampleFor: 'VStack',
   name: 'VStack',
   description: 'Demonstrates XDSVStack arranging items vertically with different gaps.',
   isReady: true,

--- a/packages/core/src/docs-types.ts
+++ b/packages/core/src/docs-types.ts
@@ -551,11 +551,16 @@ export interface PageTemplateDoc extends BaseTemplateDoc {
 
 export interface BlockTemplateDoc extends BaseTemplateDoc {
   type: 'block';
+  /** The component this block is an example of.
+   *  Matches the component's doc name (e.g. 'Button', 'Dialog', 'Stack').
+   *  Used by the docsite to show relevant examples on component detail pages. */
+  exampleFor: string;
   /** Width-to-height ratio for preview containers (e.g. 16/9, 1, 3/4). */
   aspectRatio: number;
   /** Scale factor for the block preview (default 1). */
   scale?: number;
-  /** Component names this block uses, for cross-referencing. */
+  /** Component names this block uses, for cross-referencing.
+   *  Powers "See also" and "Used in" sections — not for primary attribution. */
   componentsUsed?: string[];
   /** When true this block is the canonical "hero" showcase for a component. */
   isShowcase?: boolean;


### PR DESCRIPTION
Adds explicit component attribution to every block template via a new `exampleFor` field.

## Problem

Block templates were attributed to components via `componentsUsed`, which is unreliable — a Dialog example that uses Button would list both, making it appear as a Button example too. The docsite needs a reliable way to know which component a block is the example *of*.

## Solution

New `exampleFor: string` field on `BlockTemplateDoc`. Every block explicitly names its parent component:

```js
export const doc = {
  type: 'block',
  exampleFor: 'Button',  // ← new
  name: 'Button — Variants',
  isShowcase: true,
  componentsUsed: ['Button', 'Layout'],  // kept for future "Used in" sections
};
```

`componentsUsed` is preserved for potential future "See also" / "Used in" cross-referencing, but is no longer the source of truth for primary attribution.

## Changes

- **`docs-types.ts`** — Added `exampleFor: string` to `BlockTemplateDoc`, updated `componentsUsed` JSDoc to clarify its role
- **468 block `.doc.mjs` files** — Added `exampleFor` derived from directory name (the reliable structural signal)
- **`generate-data.mjs`** — Extracts `exampleFor` via regex
- **`blockRegistry`** — New `exampleFor` field on `BlockEntry`
- **Tests** — Every block has `exampleFor`, showcase uniqueness check