### PR TITLE
feat(lint): add no-border-shorthand rule and fix all violations

### DIFF
--- a/internal/eslint-plugin-xds/index.js
+++ b/internal/eslint-plugin-xds/index.js
@@ -19,6 +19,7 @@ import noStylexNullOverrideRule from './no-stylex-null-override.js';
 import noReactIntrospectionRule from './no-react-introspection.js';
 import noClassnameClobberRule from './no-classname-clobber.js';
 import noHardcodedAnchorRule from './no-hardcoded-anchor.js';
+import noBorderShorthandRule from './no-border-shorthand.js';
 
 // =============================================================================
 // Rule: no-hardcoded-styles
@@ -226,6 +227,7 @@ const plugin = {
     'no-react-introspection': noReactIntrospectionRule,
     'no-classname-clobber': noClassnameClobberRule,
     'no-hardcoded-anchor': noHardcodedAnchorRule,
+    'no-border-shorthand': noBorderShorthandRule,
   },
   configs: {},
 };
@@ -244,6 +246,7 @@ plugin.configs.strict = {
     '@xds/no-react-introspection': 'error',
     '@xds/no-classname-clobber': 'error',
     '@xds/no-hardcoded-anchor': 'error',
+    '@xds/no-border-shorthand': 'error',
   },
 };
 
@@ -261,6 +264,7 @@ plugin.configs.recommended = {
     '@xds/no-react-introspection': 'error',
     '@xds/no-classname-clobber': 'error',
     '@xds/no-hardcoded-anchor': 'warn',
+    '@xds/no-border-shorthand': 'warn',
   },
 };
 

--- a/internal/eslint-plugin-xds/no-border-shorthand.js
+++ b/internal/eslint-plugin-xds/no-border-shorthand.js
@@ -1,0 +1,96 @@
+/**
+ * @file no-border-shorthand.js
+ * @description Disallow border shorthand in stylex.create(). StyleX should use
+ *   individual borderWidth, borderStyle, borderColor (or side-specific variants)
+ *   instead of the combined `border` shorthand.
+ */
+
+/**
+ * Border shorthand properties that should be split into longhand.
+ * Maps shorthand → the three longhands to use instead.
+ */
+const SHORTHAND_MAP = {
+  border: ['borderWidth', 'borderStyle', 'borderColor'],
+  borderTop: ['borderTopWidth', 'borderTopStyle', 'borderTopColor'],
+  borderRight: ['borderRightWidth', 'borderRightStyle', 'borderRightColor'],
+  borderBottom: ['borderBottomWidth', 'borderBottomStyle', 'borderBottomColor'],
+  borderLeft: ['borderLeftWidth', 'borderLeftStyle', 'borderLeftColor'],
+  borderBlock: ['borderBlockWidth', 'borderBlockStyle', 'borderBlockColor'],
+  borderInline: ['borderInlineWidth', 'borderInlineStyle', 'borderInlineColor'],
+  borderBlockStart: ['borderBlockStartWidth', 'borderBlockStartStyle', 'borderBlockStartColor'],
+  borderBlockEnd: ['borderBlockEndWidth', 'borderBlockEndStyle', 'borderBlockEndColor'],
+  borderInlineStart: ['borderInlineStartWidth', 'borderInlineStartStyle', 'borderInlineStartColor'],
+  borderInlineEnd: ['borderInlineEndWidth', 'borderInlineEndStyle', 'borderInlineEndColor'],
+};
+
+/** Values that are acceptable as shorthand (full resets). */
+const ALLOWED_VALUES = new Set(['none', '0', 'inherit', 'initial', 'unset']);
+
+function isInsideStylexCreate(node) {
+  let current = node;
+  while (current) {
+    if (
+      current.type === 'CallExpression' &&
+      current.callee?.type === 'MemberExpression' &&
+      current.callee.object?.name === 'stylex' &&
+      current.callee.property?.name === 'create'
+    ) {
+      return true;
+    }
+    current = current.parent;
+  }
+  return false;
+}
+
+function getStaticValue(node) {
+  if (!node) return null;
+  if (node.type === 'Literal' && typeof node.value === 'string') {
+    return node.value;
+  }
+  return null;
+}
+
+const rule = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow border shorthand properties inside stylex.create(). ' +
+        'Use borderWidth, borderStyle, borderColor (or side-specific variants) instead.',
+      category: 'Best Practices',
+      recommended: true,
+    },
+    messages: {
+      noBorderShorthand:
+        'Don\'t use `{{prop}}` shorthand in stylex.create(). ' +
+        'Split into {{replacements}} instead.',
+    },
+    schema: [],
+  },
+  create(context) {
+    return {
+      Property(node) {
+        if (!isInsideStylexCreate(node)) return;
+
+        const propName = node.key?.name || node.key?.value;
+        if (!propName || !SHORTHAND_MAP[propName]) return;
+
+        // Allow `border: 'none'` and similar resets
+        const value = getStaticValue(node.value);
+        if (value !== null && ALLOWED_VALUES.has(value)) return;
+
+        const replacements = SHORTHAND_MAP[propName];
+        context.report({
+          node,
+          messageId: 'noBorderShorthand',
+          data: {
+            prop: propName,
+            replacements: replacements.join(', '),
+          },
+        });
+      },
+    };
+  },
+};
+
+export default rule;

--- a/internal/eslint-plugin-xds/no-border-shorthand.test.mjs
+++ b/internal/eslint-plugin-xds/no-border-shorthand.test.mjs
@@ -1,0 +1,208 @@
+/**
+ * @file no-border-shorthand.test.mjs
+ */
+
+import {RuleTester} from 'eslint';
+import rule from './no-border-shorthand.js';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module',
+  },
+});
+
+ruleTester.run('no-border-shorthand', rule, {
+  valid: [
+    // border: 'none' is allowed (reset)
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          base: { border: 'none' },
+        });
+      `,
+    },
+    // border: '0' is allowed
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          base: { border: '0' },
+        });
+      `,
+    },
+    // Longhand properties are fine
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          base: {
+            borderWidth: 1,
+            borderStyle: 'solid',
+            borderColor: 'red',
+          },
+        });
+      `,
+    },
+    // Side-specific longhand is fine
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          base: {
+            borderBottomWidth: 1,
+            borderBottomStyle: 'solid',
+            borderBottomColor: 'red',
+          },
+        });
+      `,
+    },
+    // Outside stylex.create is fine
+    {
+      code: `
+        const obj = { border: '1px solid red' };
+      `,
+    },
+    // border: 'inherit' is allowed
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          base: { border: 'inherit' },
+        });
+      `,
+    },
+  ],
+  invalid: [
+    // border shorthand with string literal
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          base: { border: '1px solid red' },
+        });
+      `,
+      errors: [
+        {
+          messageId: 'noBorderShorthand',
+          data: {
+            prop: 'border',
+            replacements: 'borderWidth, borderStyle, borderColor',
+          },
+        },
+      ],
+    },
+    // border shorthand with template literal
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const w = '1px';
+        const styles = stylex.create({
+          base: { border: \`\${w} solid red\` },
+        });
+      `,
+      errors: [
+        {
+          messageId: 'noBorderShorthand',
+          data: {
+            prop: 'border',
+            replacements: 'borderWidth, borderStyle, borderColor',
+          },
+        },
+      ],
+    },
+    // borderTop shorthand
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          base: { borderTop: '1px solid blue' },
+        });
+      `,
+      errors: [
+        {
+          messageId: 'noBorderShorthand',
+          data: {
+            prop: 'borderTop',
+            replacements: 'borderTopWidth, borderTopStyle, borderTopColor',
+          },
+        },
+      ],
+    },
+    // borderBottom shorthand
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          base: { borderBottom: '2px dashed green' },
+        });
+      `,
+      errors: [
+        {
+          messageId: 'noBorderShorthand',
+          data: {
+            prop: 'borderBottom',
+            replacements: 'borderBottomWidth, borderBottomStyle, borderBottomColor',
+          },
+        },
+      ],
+    },
+    // borderRight shorthand
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          base: { borderRight: '1px solid #ccc' },
+        });
+      `,
+      errors: [
+        {
+          messageId: 'noBorderShorthand',
+          data: {
+            prop: 'borderRight',
+            replacements: 'borderRightWidth, borderRightStyle, borderRightColor',
+          },
+        },
+      ],
+    },
+    // borderInline shorthand
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          base: { borderInline: '1px solid black' },
+        });
+      `,
+      errors: [
+        {
+          messageId: 'noBorderShorthand',
+          data: {
+            prop: 'borderInline',
+            replacements: 'borderInlineWidth, borderInlineStyle, borderInlineColor',
+          },
+        },
+      ],
+    },
+    // border with variable expression (not a static value, not an allowed reset)
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          base: { border: someVar },
+        });
+      `,
+      errors: [
+        {
+          messageId: 'noBorderShorthand',
+          data: {
+            prop: 'border',
+            replacements: 'borderWidth, borderStyle, borderColor',
+          },
+        },
+      ],
+    },
+  ],
+});
+
+console.log('All tests passed!');

--- a/packages/core/src/CodeBlock/XDSCodeBlock.tsx
+++ b/packages/core/src/CodeBlock/XDSCodeBlock.tsx
@@ -58,7 +58,9 @@ const styles = stylex.create({
     maxWidth: '100%',
     borderRadius: radiusVars['--radius-element'],
     backgroundColor: 'var(--color-syntax-background)',
-    border: `${borderVars['--border-width']} solid ${colorVars['--color-border']}`,
+    borderWidth: borderVars['--border-width'],
+    borderStyle: 'solid',
+    borderColor: colorVars['--color-border'],
     overflow: 'hidden',
   },
   header: {
@@ -73,7 +75,9 @@ const styles = stylex.create({
   },
   headerWithDivider: {
     paddingBlock: spacingVars['--spacing-2'],
-    borderBottom: `${borderVars['--border-width']} solid ${colorVars['--color-border']}`,
+    borderBottomWidth: borderVars['--border-width'],
+    borderBottomStyle: 'solid',
+    borderBottomColor: colorVars['--color-border'],
   },
   headerCompact: {
     paddingBlock: spacingVars['--spacing-2'],
@@ -141,7 +145,9 @@ const styles = stylex.create({
     textAlign: 'end',
     userSelect: 'none',
     color: 'var(--color-syntax-punctuation)',
-    borderRight: `${borderVars['--border-width']} solid ${colorVars['--color-border']}`,
+    borderRightWidth: borderVars['--border-width'],
+    borderRightStyle: 'solid',
+    borderRightColor: colorVars['--color-border'],
   },
   gutterLine: {
     fontFamily: typographyVars['--font-family-code'],

--- a/packages/core/src/List/XDSListItem.tsx
+++ b/packages/core/src/List/XDSListItem.tsx
@@ -125,7 +125,9 @@ const styles = stylex.create({
     borderRadius: 0,
   },
   withDivider: {
-    borderBlockEnd: `${borderVars['--border-width']} solid ${colorVars['--color-border']}`,
+    borderBlockEndWidth: borderVars['--border-width'],
+    borderBlockEndStyle: 'solid',
+    borderBlockEndColor: colorVars['--color-border'],
     ':last-child': {
       borderBlockEnd: 'none',
     },

--- a/packages/core/src/SideNav/XDSSideNav.tsx
+++ b/packages/core/src/SideNav/XDSSideNav.tsx
@@ -109,7 +109,9 @@ const styles = stylex.create({
     paddingInline: spacingVars['--spacing-2'],
     paddingBlockStart: spacingVars['--spacing-1'],
     paddingBlockEnd: spacingVars['--spacing-2'],
-    borderBlockStart: `${borderVars['--border-width']} solid ${colorVars['--color-border']}`,
+    borderBlockStartWidth: borderVars['--border-width'],
+    borderBlockStartStyle: 'solid',
+    borderBlockStartColor: colorVars['--color-border'],
   },
   footerRow: {
     display: 'flex',
@@ -139,7 +141,9 @@ const styles = stylex.create({
     marginBlockStart: 'auto',
     gap: spacingVars['--spacing-2'],
     paddingBlockStart: spacingVars['--spacing-2'],
-    borderBlockStart: `${borderVars['--border-width']} solid ${colorVars['--color-border']}`,
+    borderBlockStartWidth: borderVars['--border-width'],
+    borderBlockStartStyle: 'solid',
+    borderBlockStartColor: colorVars['--color-border'],
   },
   drawerFooterIcons: {
     display: 'flex',

--- a/packages/core/src/TopNav/XDSTopNavMegaMenu.tsx
+++ b/packages/core/src/TopNav/XDSTopNavMegaMenu.tsx
@@ -116,7 +116,9 @@ const styles = stylex.create({
   // Visual styles for the panel content container.
   panelContainer: {
     backgroundColor: colorVars['--color-background-popover'],
-    borderTop: `${borderVars['--border-width']} solid ${colorVars['--color-border']}`,
+    borderTopWidth: borderVars['--border-width'],
+    borderTopStyle: 'solid',
+    borderTopColor: colorVars['--color-border'],
     borderRadius: radiusVars['--radius-container'],
     boxShadow: shadowVars['--shadow-low'],
     overflow: 'hidden',


### PR DESCRIPTION
## Summary

Adds a new `@xds/no-border-shorthand` ESLint rule that disallows border shorthand properties inside `stylex.create()`. StyleX works better with individual longhand properties.

### The rule

Catches these shorthand properties: `border`, `borderTop`, `borderRight`, `borderBottom`, `borderLeft`, `borderBlock`, `borderInline`, `borderBlockStart`, `borderBlockEnd`, `borderInlineStart`, `borderInlineEnd`.

**Allowed:** reset values like `border: 'none'`, `border: '0'`, `border: 'inherit'`.

**Flagged:** anything that combines width + style + color into one value:
```js
// Bad
border: \`\${borderVars['--border-width']} solid \${colorVars['--color-border']}\`

// Good
borderWidth: borderVars['--border-width'],
borderStyle: 'solid',
borderColor: colorVars['--color-border'],
```

### Fixes

7 violations across 4 core components:

| File | Properties fixed |
|------|-----------------|
| `CodeBlock/XDSCodeBlock.tsx` | `border`, `borderBottom`, `borderRight` |
| `TopNav/XDSTopNavMegaMenu.tsx` | `borderTop` |
| `List/XDSListItem.tsx` | `borderBlockEnd` |
| `SideNav/XDSSideNav.tsx` | `borderBlockStart` ×2 |

### Config

- **strict** (CI/agents): error
- **recommended** (local dev): warn