### PR TITLE
fix(docsite): preserve token source order

### DIFF
--- a/apps/docsite/src/components/tokens/ElevationTokenTable.tsx
+++ b/apps/docsite/src/components/tokens/ElevationTokenTable.tsx
@@ -17,18 +17,8 @@ const styles = stylex.create({
   },
 });
 
-const SHADOW_ORDER = ['--shadow-low', '--shadow-medium', '--shadow-high'];
-
 export function ElevationTokenTable({theme}: TokenTableProps) {
-  const allTokens = getTokensByPrefix(theme, '--shadow-');
-  // Sort by low/medium/high order, then alphabetical for any others
-  const orderMap = new Map(SHADOW_ORDER.map((k, i) => [k, i]));
-  const tokens = [...allTokens].sort((a, b) => {
-    const ai = orderMap.get(a) ?? 99;
-    const bi = orderMap.get(b) ?? 99;
-    if (ai !== bi) return ai - bi;
-    return a.localeCompare(b);
-  });
+  const tokens = getTokensByPrefix(theme, '--shadow-');
 
   const data = tokens.map(name => ({
     tokenName: name,

--- a/apps/docsite/src/components/tokens/MotionTokenTable.tsx
+++ b/apps/docsite/src/components/tokens/MotionTokenTable.tsx
@@ -42,27 +42,6 @@ const styles = stylex.create({
   },
 });
 
-const DURATION_ORDER = [
-  '--duration-fast-min',
-  '--duration-fast',
-  '--duration-fast-max',
-  '--duration-medium-min',
-  '--duration-medium',
-  '--duration-medium-max',
-  '--duration-slow-min',
-  '--duration-slow',
-  '--duration-slow-max',
-];
-
-function sortDurationTokens(tokens: string[]): string[] {
-  const orderMap = new Map(DURATION_ORDER.map((k, i) => [k, i]));
-  return [...tokens].sort((a, b) => {
-    const ai = orderMap.get(a) ?? 99;
-    const bi = orderMap.get(b) ?? 99;
-    return ai - bi;
-  });
-}
-
 function DurationBar({value}: {value: string}) {
   const [animate, setAnimate] = useState(false);
   useEffect(() => {
@@ -184,7 +163,7 @@ function EasingCurve({value}: {value: string}) {
 }
 
 export function DurationTokenTable({theme}: TokenTableProps) {
-  const tokens = sortDurationTokens(getTokensByPrefix(theme, '--duration-'));
+  const tokens = getTokensByPrefix(theme, '--duration-');
   const data = tokens.map(name => ({
     tokenName: name,
     value: resolveToken(theme, name),

--- a/apps/docsite/src/components/tokens/ShapeTokenTable.tsx
+++ b/apps/docsite/src/components/tokens/ShapeTokenTable.tsx
@@ -24,29 +24,8 @@ const styles = stylex.create({
   },
 });
 
-const RADIUS_ORDER = [
-  '--radius-none',
-  '--radius-inner',
-  '--radius-element',
-  '--radius-container',
-  '--radius-page',
-  '--radius-full',
-];
-
-function sortByOrder(tokens: string[], order: string[]): string[] {
-  const orderMap = new Map(order.map((k, i) => [k, i]));
-  return [...tokens].sort((a, b) => {
-    const ai = orderMap.get(a) ?? 99;
-    const bi = orderMap.get(b) ?? 99;
-    return ai - bi;
-  });
-}
-
 export function RadiusTokenTable({theme}: TokenTableProps) {
-  const tokens = sortByOrder(
-    getTokensByPrefix(theme, '--radius-'),
-    RADIUS_ORDER,
-  );
+  const tokens = getTokensByPrefix(theme, '--radius-');
   const data = tokens.map(name => ({
     tokenName: name,
     value: resolveToken(theme, name),


### PR DESCRIPTION
Remove all sorting from token tables. Tokens now display in the order defined in the theme source, not alphabetically or by hardcoded order arrays.

Removed: SHADOW_ORDER, RADIUS_ORDER, DURATION_ORDER, sortByOrder, sortDurationTokens.