### PR TITLE
fix(Section): propagate explicit padding to nested sections

### DIFF
--- a/apps/storybook/stories/Section.stories.tsx
+++ b/apps/storybook/stories/Section.stories.tsx
@@ -220,3 +220,47 @@ export const FullBleed: Story = {
     </div>
   ),
 };
+
+export const NestedPaddingInheritance: Story = {
+  render: () => (
+    <div {...stylex.props(styles.storyWrapper)}>
+      <div>
+        <h4 {...stylex.props(styles.heading)}>
+          padding=6 → nested (inherits 6)
+        </h4>
+        <XDSSection variant="section" width={350} padding={6}>
+          <XDSSection variant="wash">
+            <p {...stylex.props(styles.text)}>
+              Inner section inherits padding=6 from parent. Edge compensation
+              and content inset should both use 24px.
+            </p>
+          </XDSSection>
+        </XDSSection>
+      </div>
+      <div>
+        <h4 {...stylex.props(styles.heading)}>padding=6 → nested padding=2</h4>
+        <XDSSection variant="section" width={350} padding={6}>
+          <XDSSection variant="wash" padding={2}>
+            <p {...stylex.props(styles.text)}>
+              Inner section explicitly sets padding=2, overriding the parent's
+              padding=6. Content inset is 8px.
+            </p>
+          </XDSSection>
+        </XDSSection>
+      </div>
+      <div>
+        <h4 {...stylex.props(styles.heading)}>
+          padding=2 → nested (inherits 2)
+        </h4>
+        <XDSSection variant="section" width={350} padding={2}>
+          <XDSSection variant="wash">
+            <p {...stylex.props(styles.text)}>
+              Inner section inherits padding=2 from parent. Both edge
+              compensation and content inset use 8px.
+            </p>
+          </XDSSection>
+        </XDSSection>
+      </div>
+    </div>
+  ),
+};

--- a/packages/core/src/Layout/padding.stylex.ts
+++ b/packages/core/src/Layout/padding.stylex.ts
@@ -270,3 +270,23 @@ export const paddingBlockStyles = stylex.create({
     paddingBlockEnd: spacingVars['--spacing-10'],
   },
 });
+
+/**
+ * Propagation styles for --xds-section-padding.
+ * When a parent section sets explicit padding, this propagates the value
+ * through the CSS custom property cascade so nested sections that use
+ * useThemeDefault inherit the parent's padding instead of the theme default.
+ */
+export const sectionPaddingPropagationStyles = stylex.create({
+  0: {'--xds-section-padding': spacingVars['--spacing-0']},
+  0.5: {'--xds-section-padding': spacingVars['--spacing-0-5']},
+  1: {'--xds-section-padding': spacingVars['--spacing-1']},
+  1.5: {'--xds-section-padding': spacingVars['--spacing-1-5']},
+  2: {'--xds-section-padding': spacingVars['--spacing-2']},
+  3: {'--xds-section-padding': spacingVars['--spacing-3']},
+  4: {'--xds-section-padding': spacingVars['--spacing-4']},
+  5: {'--xds-section-padding': spacingVars['--spacing-5']},
+  6: {'--xds-section-padding': spacingVars['--spacing-6']},
+  8: {'--xds-section-padding': spacingVars['--spacing-8']},
+  10: {'--xds-section-padding': spacingVars['--spacing-10']},
+});

--- a/packages/core/src/Section/XDSSection.test.tsx
+++ b/packages/core/src/Section/XDSSection.test.tsx
@@ -150,4 +150,30 @@ describe('XDSSection', () => {
     render(<XDSSection data-testid="custom-section">Content</XDSSection>);
     expect(screen.getByTestId('custom-section')).toBeInTheDocument();
   });
+
+  it('propagates explicit padding to nested sections via --xds-section-padding', () => {
+    const {container} = render(
+      <XDSSection padding={6}>
+        <XDSSection data-testid="inner">Inner</XDSSection>
+      </XDSSection>,
+    );
+    // Outer section's inner div should set --xds-section-padding
+    const outerInner = container.firstElementChild!.firstElementChild!;
+    expect(outerInner.className).toBeDefined();
+    // Inner section should render without error
+    expect(screen.getByTestId('inner')).toBeInTheDocument();
+    expect(screen.getByText('Inner')).toBeInTheDocument();
+  });
+
+  it('renders nested sections with explicit inner padding override', () => {
+    const {container} = render(
+      <XDSSection padding={6}>
+        <XDSSection padding={2} data-testid="inner">
+          Inner
+        </XDSSection>
+      </XDSSection>,
+    );
+    expect(screen.getByTestId('inner')).toBeInTheDocument();
+    expect(screen.getByText('Inner')).toBeInTheDocument();
+  });
 });

--- a/packages/core/src/Section/XDSSection.tsx
+++ b/packages/core/src/Section/XDSSection.tsx
@@ -25,6 +25,7 @@ import {
   containerPaddingInlineVarStyles,
   containerPaddingBlockStartVarStyles,
   containerPaddingBlockEndVarStyles,
+  sectionPaddingPropagationStyles,
   spacingStepToToken,
 } from '../Layout/padding.stylex';
 import type {SizeValue, SpacingStep} from '../utils/types';
@@ -289,6 +290,8 @@ export function XDSSection({
             !useThemeDefault &&
               effectivePadding !== 4 &&
               containerPaddingBlockEndVarStyles[effectivePadding],
+            !useThemeDefault &&
+              sectionPaddingPropagationStyles[effectivePadding],
             paddingBlock != null && paddingBlockStyles[paddingBlock],
             paddingBlock != null &&
               containerPaddingBlockStartVarStyles[paddingBlock],

--- a/packages/core/src/theme/derivedVarRegistry.test.ts
+++ b/packages/core/src/theme/derivedVarRegistry.test.ts
@@ -48,6 +48,7 @@ const STRUCTURAL_VARS = new Set([
   '--indicator-width',
   '--table-resize-height',
   '--separator-display',
+  '--xds-section-padding',
 ]);
 
 /**


### PR DESCRIPTION
## Problem

When nesting `<XDSSection>` inside a parent with explicit padding, the inner section falls back to the theme default (`--spacing-4` / 16px) instead of inheriting the parent's padding:

```tsx
<XDSSection padding={6}>   {/* 24px */}
  <XDSSection>             {/* gets 16px instead of 24px */}
    ...
  </XDSSection>
</XDSSection>
```

The inner section's edge compensation uses the parent's 24px padding (correct negative margins), but its own content padding is 16px — causing a visual mismatch.

## Fix

When a section sets explicit `padding`, propagate the value via `--xds-section-padding` CSS custom property on the inner container. Nested sections using `useThemeDefault: 'section'` already read from this property in the var() fallback chain, so they naturally inherit the parent's value through CSS cascade.

The propagation uses `spacingVars` (not hardcoded px) so it respects custom theme spacing scales.

## Changes

- **`padding.stylex.ts`** — Added `sectionPaddingPropagationStyles` map (`SpacingStep → --xds-section-padding`)
- **`XDSSection.tsx`** — Apply propagation style when `padding` is explicitly set
- **`Section.stories.tsx`** — Added `NestedPaddingInheritance` story showing correct behavior
- **`XDSSection.test.tsx`** — Added tests for nested section rendering