### PR TITLE
feat(docsite): implement What's New changelog page

### DIFF
--- a/apps/docsite/src/app/changelog/page.tsx
+++ b/apps/docsite/src/app/changelog/page.tsx
@@ -1,23 +1,40 @@
-/**
- * Page type: changelog
- * Version history from CHANGELOG.md files across packages.
- * TODO: port generate-changelog.js into the data pipeline.
- */
+import {readFile} from 'node:fs/promises';
+import * as path from 'node:path';
+import {ChangelogView} from '../../components/ChangelogView';
+import {components} from '../../generated/componentRegistry';
+import {packages} from '../../generated/packageRegistry';
 
-import {XDSHeading, XDSText} from '@xds/core/Text';
-import {XDSVStack} from '@xds/core/Layout';
-import {XDSSection} from '@xds/core/Section';
+async function readChangelog(pkg: {
+  name: string;
+  packagePath: string;
+}): Promise<{pkg: string; content: string} | null> {
+  const changelogPath = path.resolve(
+    process.cwd(),
+    '..',
+    '..',
+    pkg.packagePath,
+    'CHANGELOG.md',
+  );
+  try {
+    const content = await readFile(changelogPath, 'utf-8');
+    return {pkg: pkg.name, content};
+  } catch {
+    return null;
+  }
+}
 
-export default function ChangelogPage() {
+export default async function ChangelogPage() {
+  const withChangelog = packages.filter(p => p.hasChangelog);
+  const results = await Promise.all(withChangelog.map(readChangelog));
+  const changelogs = results.filter(
+    (c): c is {pkg: string; content: string} => c != null,
+  );
+
+  const componentNames = Object.values(components)
+    .flat()
+    .map(c => c.name);
+
   return (
-    <XDSSection maxWidth="md" padding={6}>
-      <XDSVStack gap={4}>
-        <XDSHeading level={1}>Changelog</XDSHeading>
-        <XDSText type="body" color="secondary">
-          Version history coming soon.
-        </XDSText>
-        {/* TODO: render from changelogRegistry once ported to pipeline */}
-      </XDSVStack>
-    </XDSSection>
+    <ChangelogView changelogs={changelogs} componentNames={componentNames} />
   );
 }

--- a/apps/docsite/src/components/ChangelogView.tsx
+++ b/apps/docsite/src/components/ChangelogView.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import {useState} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {XDSMarkdown} from '@xds/core/Markdown';
+import {XDSText, XDSHeading} from '@xds/core/Text';
+import {XDSVStack} from '@xds/core/Layout';
+import {XDSSection} from '@xds/core/Section';
+import {XDSTabList, XDSTab} from '@xds/core/TabList';
+import {GITHUB_REPO} from '../constants';
+
+function linkifyPRs(markdown: string): string {
+  return markdown.replace(/(?<!\[)#(\d+)/g, `[#$1](${GITHUB_REPO}/pull/$1)`);
+}
+
+function stripTitle(markdown: string): string {
+  return markdown.replace(/^#\s+.+\n+/, '');
+}
+
+function linkifyComponents(markdown: string, names: string[]): string {
+  if (names.length === 0) return markdown;
+
+  const nameToHref = new Map<string, string>();
+  for (const name of names) {
+    nameToHref.set(name, `/components/${name}`);
+    nameToHref.set('XDS' + name, `/components/${name}`);
+  }
+
+  const sorted = [...nameToHref.keys()].sort((a, b) => b.length - a.length);
+  const escaped = sorted.map(s => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+  const pattern = new RegExp(
+    '(?<!`|\\[)\\b(' + escaped.join('|') + ')\\b(?!`|\\])',
+    'g',
+  );
+
+  return markdown.replace(pattern, match => {
+    const href = nameToHref.get(match);
+    if (!href) return match;
+    return '[' + match + '](' + href + ')';
+  });
+}
+
+interface ChangelogEntry {
+  pkg: string;
+  content: string;
+}
+
+interface ChangelogViewProps {
+  changelogs: ChangelogEntry[];
+  componentNames: string[];
+}
+
+const styles = stylex.create({
+  container: {
+    maxWidth: 960,
+    marginInline: 'auto',
+  },
+});
+
+export function ChangelogView({
+  changelogs,
+  componentNames,
+}: ChangelogViewProps) {
+  const [activeTab, setActiveTab] = useState(changelogs[0]?.pkg ?? '');
+  const active = changelogs.find(c => c.pkg === activeTab);
+
+  return (
+    <XDSSection maxWidth="lg" padding={6} xstyle={styles.container}>
+      <XDSVStack gap={6}>
+        <XDSVStack gap={2}>
+          <XDSHeading level={1}>What&apos;s New</XDSHeading>
+          <XDSText type="body" color="secondary">
+            Release notes and changelog for XDS packages.
+          </XDSText>
+        </XDSVStack>
+
+        {changelogs.length > 0 ? (
+          <>
+            <XDSTabList value={activeTab} onChange={setActiveTab} hasDivider>
+              {changelogs.map(c => (
+                <XDSTab key={c.pkg} value={c.pkg} label={c.pkg} />
+              ))}
+            </XDSTabList>
+
+            {active != null && (
+              <XDSMarkdown headingLevelStart={2}>
+                {linkifyComponents(
+                  linkifyPRs(stripTitle(active.content)),
+                  componentNames,
+                )}
+              </XDSMarkdown>
+            )}
+          </>
+        ) : (
+          <XDSText type="body" color="secondary">
+            Changelogs could not be loaded.
+          </XDSText>
+        )}
+      </XDSVStack>
+    </XDSSection>
+  );
+}

--- a/apps/docsite/src/components/DocsShell.tsx
+++ b/apps/docsite/src/components/DocsShell.tsx
@@ -7,6 +7,7 @@ import {XDSSideNav, XDSSideNavItem, XDSSideNavSection} from '@xds/core/SideNav';
 import {XDSButton} from '@xds/core/Button';
 import {XDSLink} from '@xds/core/Link';
 import {XDSVStack} from '@xds/core/Layout';
+import {GITHUB_REPO} from '../constants';
 import type {ComponentEntry} from '../generated/componentRegistry';
 import type {PackageMeta} from '../generated/packageRegistry';
 import type {DocTopic} from '../generated/docsRegistry';
@@ -201,11 +202,7 @@ export function DocsShell({
           label="XDS navigation"
           heading={<XDSTopNavHeading logo={XDS_WORDMARK} headingHref="/" />}
           endContent={
-            <XDSButton
-              label="GitHub"
-              variant="ghost"
-              href="https://github.com/facebookexperimental/xds"
-            />
+            <XDSButton label="GitHub" variant="ghost" href={GITHUB_REPO} />
           }
         />
       }

--- a/apps/docsite/src/constants.ts
+++ b/apps/docsite/src/constants.ts
@@ -1,0 +1,1 @@
+export const GITHUB_REPO = 'https://github.com/facebookexperimental/xds';


### PR DESCRIPTION
Replaces the placeholder changelog page with a working implementation that reads `CHANGELOG.md` from each package at build time.

Adapted from the internal Nest docsite's whats-new page pattern.

**How it works:**
- Server component reads changelogs directly from `packages/*/CHANGELOG.md`
- Client component (`ChangelogView`) renders with tabbed per-package view
- `XDSMarkdown` handles rendering with `headingLevelStart={2}` for proper hierarchy
- PR references like `#1234` are auto-linked to GitHub pull requests
- Component names (e.g. Dialog, XDSButton) are auto-linked to their docs pages

**Files:**
- `apps/docsite/src/app/changelog/page.tsx` — server component (data loading)
- `apps/docsite/src/components/ChangelogView.tsx` — client component (tabs + rendering)