### PR TITLE
fix(templates): replace external image URLs with permanent xds_oss assets

### DIFF
--- a/packages/cli/templates/blocks/components/AspectRatio/AspectRatioImageGallery.tsx
+++ b/packages/cli/templates/blocks/components/AspectRatio/AspectRatioImageGallery.tsx
@@ -18,7 +18,7 @@ export default function AspectRatioImageGallery() {
       {images.map(({id, alt}) => (
         <XDSAspectRatio key={id} ratio={4 / 3}>
           <img
-            src={`https://picsum.photos/seed/${id}/400/300`}
+            src="https://lookaside.facebook.com/assets/xds_oss/illustrative-horizontal-1.jpg"
             alt={alt}
             style={{
               width: '100%',

--- a/packages/cli/templates/blocks/components/AspectRatio/AspectRatioSquareImage.tsx
+++ b/packages/cli/templates/blocks/components/AspectRatio/AspectRatioSquareImage.tsx
@@ -8,7 +8,7 @@ export default function AspectRatioSquareImage() {
     <XDSCenter width={300}>
       <XDSAspectRatio ratio={1}>
         <img
-          src="https://picsum.photos/400/400"
+          src="https://lookaside.facebook.com/assets/xds_oss/light-home-square-1.png"
           alt="1:1 square"
           style={{
             width: '100%',

--- a/packages/cli/templates/blocks/components/AspectRatio/AspectRatioWidescreen.tsx
+++ b/packages/cli/templates/blocks/components/AspectRatio/AspectRatioWidescreen.tsx
@@ -8,7 +8,7 @@ export default function AspectRatioWidescreen() {
     <XDSCenter width={600}>
       <XDSAspectRatio ratio={16 / 9}>
         <img
-          src="https://picsum.photos/800/450"
+          src="https://lookaside.facebook.com/assets/xds_oss/light-scene-horizontal-1.png"
           alt="16:9 widescreen"
           style={{
             width: '100%',

--- a/packages/cli/templates/blocks/components/ChatComposerDrawer/ChatComposerDrawerAttachments.tsx
+++ b/packages/cli/templates/blocks/components/ChatComposerDrawer/ChatComposerDrawerAttachments.tsx
@@ -9,31 +9,31 @@ import {XDSStack} from '@xds/core/Layout';
 const IMAGE_ATTACHMENTS = [
   {
     id: '1',
-    src: 'https://picsum.photos/id/1015/200/200',
+    src: 'https://lookaside.facebook.com/assets/xds_oss/illustrative-vertical-1.jpg',
     alt: 'River through a valley',
     label: 'valley.jpg',
   },
   {
     id: '2',
-    src: 'https://picsum.photos/id/1018/200/200',
+    src: 'https://lookaside.facebook.com/assets/xds_oss/illustrative-vertical-2.jpg',
     alt: 'Foggy mountain peak',
     label: 'mountain.jpg',
   },
   {
     id: '3',
-    src: 'https://picsum.photos/id/1025/200/200',
+    src: 'https://lookaside.facebook.com/assets/xds_oss/illustrative-vertical-3.jpg',
     alt: 'Golden retriever puppy',
     label: 'puppy.jpg',
   },
   {
     id: '4',
-    src: 'https://picsum.photos/id/1035/200/200',
+    src: 'https://lookaside.facebook.com/assets/xds_oss/illustrative-vertical-4.jpg',
     alt: 'Bridge at sunset',
     label: 'bridge.jpg',
   },
   {
     id: '5',
-    src: 'https://picsum.photos/id/1040/200/200',
+    src: 'https://lookaside.facebook.com/assets/xds_oss/illustrative-vertical-5.jpg',
     alt: 'Lakeside at dusk',
     label: 'lakeside.jpg',
   },

--- a/packages/cli/templates/blocks/components/Thumbnail/ThumbnailDisabled.tsx
+++ b/packages/cli/templates/blocks/components/Thumbnail/ThumbnailDisabled.tsx
@@ -13,7 +13,7 @@ export default function ThumbnailDisabled() {
         </XDSText>
         <XDSStack direction="horizontal" gap={3} vAlign="center">
           <XDSThumbnail
-            src="https://picsum.photos/id/1043/200/200"
+            src="https://lookaside.facebook.com/assets/xds_oss/moody-scene-vertical-2.png"
             alt="Bright landscape"
             label="landscape.jpg"
             onRemove={() => {}}
@@ -27,7 +27,7 @@ export default function ThumbnailDisabled() {
         </XDSText>
         <XDSStack direction="horizontal" gap={3} vAlign="center">
           <XDSThumbnail
-            src="https://picsum.photos/id/1043/200/200"
+            src="https://lookaside.facebook.com/assets/xds_oss/moody-scene-vertical-2.png"
             alt="Bright landscape"
             label="landscape.jpg"
             onRemove={() => {}}

--- a/packages/cli/templates/blocks/components/Thumbnail/ThumbnailGallery.tsx
+++ b/packages/cli/templates/blocks/components/Thumbnail/ThumbnailGallery.tsx
@@ -6,10 +6,10 @@ import {XDSStack} from '@xds/core/Layout';
 import {XDSText} from '@xds/core/Text';
 
 const ATTACHMENTS = [
-  {id: 1, src: 'https://picsum.photos/id/1015/200/200', alt: 'River through a valley', label: 'valley.jpg'},
-  {id: 2, src: 'https://picsum.photos/id/1018/200/200', alt: 'Foggy mountain peak', label: 'mountain.jpg'},
-  {id: 3, src: 'https://picsum.photos/id/1025/200/200', alt: 'Golden retriever puppy', label: 'puppy.jpg'},
-  {id: 4, src: 'https://picsum.photos/id/1035/200/200', alt: 'Bridge at sunset', label: 'bridge.jpg'},
+  {id: 1, src: 'https://lookaside.facebook.com/assets/xds_oss/illustrative-vertical-1.jpg', alt: 'River through a valley', label: 'valley.jpg'},
+  {id: 2, src: 'https://lookaside.facebook.com/assets/xds_oss/illustrative-vertical-2.jpg', alt: 'Foggy mountain peak', label: 'mountain.jpg'},
+  {id: 3, src: 'https://lookaside.facebook.com/assets/xds_oss/illustrative-vertical-3.jpg', alt: 'Golden retriever puppy', label: 'puppy.jpg'},
+  {id: 4, src: 'https://lookaside.facebook.com/assets/xds_oss/illustrative-vertical-4.jpg', alt: 'Bridge at sunset', label: 'bridge.jpg'},
 ];
 
 export default function ThumbnailGallery() {

--- a/packages/cli/templates/blocks/components/Thumbnail/ThumbnailRemovable.tsx
+++ b/packages/cli/templates/blocks/components/Thumbnail/ThumbnailRemovable.tsx
@@ -6,9 +6,9 @@ import {XDSStack} from '@xds/core/Layout';
 import {XDSText} from '@xds/core/Text';
 
 const IMAGES = [
-  {id: 1, src: 'https://picsum.photos/id/1042/200/200', alt: 'Dark cityscape at night', label: 'dark-city.jpg'},
-  {id: 2, src: 'https://picsum.photos/id/1043/200/200', alt: 'Bright snowy landscape', label: 'snow.jpg'},
-  {id: 3, src: 'https://picsum.photos/id/1044/200/200', alt: 'Warm sunset over mountains', label: 'sunset.jpg'},
+  {id: 1, src: 'https://lookaside.facebook.com/assets/xds_oss/moody-scene-vertical-1.png', alt: 'Dark cityscape at night', label: 'dark-city.jpg'},
+  {id: 2, src: 'https://lookaside.facebook.com/assets/xds_oss/moody-scene-vertical-2.png', alt: 'Bright snowy landscape', label: 'snow.jpg'},
+  {id: 3, src: 'https://lookaside.facebook.com/assets/xds_oss/moody-home-vertical-1.png', alt: 'Warm sunset over mountains', label: 'sunset.jpg'},
 ];
 
 export default function ThumbnailRemovable() {

--- a/packages/cli/templates/blocks/components/Thumbnail/ThumbnailShowcase.tsx
+++ b/packages/cli/templates/blocks/components/Thumbnail/ThumbnailShowcase.tsx
@@ -5,7 +5,7 @@ import {XDSThumbnail} from '@xds/core/Thumbnail';
 export default function ThumbnailShowcase() {
   return (
     <XDSThumbnail
-      src="https://picsum.photos/id/1043/200/200"
+      src="https://lookaside.facebook.com/assets/xds_oss/moody-scene-vertical-2.png"
       alt="Sample image"
       label="photo.jpg"
     />

--- a/packages/cli/templates/blocks/components/Thumbnail/ThumbnailStates.tsx
+++ b/packages/cli/templates/blocks/components/Thumbnail/ThumbnailStates.tsx
@@ -26,7 +26,7 @@ export default function ThumbnailStates() {
           </XDSStack>
           <XDSStack direction="vertical" gap={1} hAlign="center">
             <XDSThumbnail
-              src="https://picsum.photos/id/1044/200/200"
+              src="https://lookaside.facebook.com/assets/xds_oss/moody-home-vertical-1.png"
               alt="Mountain landscape"
               isLoading
               label="landscape.jpg"
@@ -37,7 +37,7 @@ export default function ThumbnailStates() {
           </XDSStack>
           <XDSStack direction="vertical" gap={1} hAlign="center">
             <XDSThumbnail
-              src="https://picsum.photos/id/1044/200/200"
+              src="https://lookaside.facebook.com/assets/xds_oss/moody-home-vertical-1.png"
               alt="Mountain landscape"
               label="landscape.jpg"
             />

--- a/packages/cli/templates/blocks/components/TopNav/TopNavMegaMenu.tsx
+++ b/packages/cli/templates/blocks/components/TopNav/TopNavMegaMenu.tsx
@@ -113,7 +113,7 @@ export default function TopNavMegaMenu() {
               <XDSTopNavMegaMenuFeaturedCard
                 title="What's new in v4.0"
                 description="AI-powered analytics and real-time collaboration."
-                image="https://images.unsplash.com/photo-1551434678-e076c223a692?w=560&h=280&fit=crop"
+                image="https://lookaside.facebook.com/assets/xds_oss/light-working-horizontal-1.png"
                 imageAlt="Team collaboration"
                 linkLabel="Read the announcement"
                 linkHref="#announcement"

--- a/packages/cli/templates/pages/login-split/page.tsx
+++ b/packages/cli/templates/pages/login-split/page.tsx
@@ -22,7 +22,7 @@ import {
 
 // light-working-vertical-1 from xds_oss asset set
 const COVER_IMAGE_URL =
-  'https://scontent.xx.fbcdn.net/v/t39.6806-6/671925666_4495480327349179_31826850576590602_n.png?_nc_cat=108&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=nHeGVeCH7wIQ7kNvwEe_ed5&_nc_oc=AdrmcEXVuygkqWh3Gd9ap9XNslAE4LphVAtWeNXNglbrdryrAnVn7b1pI489fHosZUwgNv1UWgRTizw-6x0E48MI&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=soyKpwlpum27aTB16xwsWg&_nc_ss=7a30f&oh=00_Af2VtQRME3fzALwgGvOuScpGMWsY5hpgmGN1E4nGG6hhWQ&oe=69EC2E2B';
+  'https://lookaside.facebook.com/assets/xds_oss/light-working-vertical-1.png';
 
 const AppleIcon = (props: React.SVGProps<SVGSVGElement>) => (
   <svg viewBox="0 0 24 24" fill="currentColor" width={16} height={16} aria-hidden="true" {...props}>

--- a/packages/cli/templates/pages/login-sso/page.tsx
+++ b/packages/cli/templates/pages/login-sso/page.tsx
@@ -22,7 +22,7 @@ import {shadowVars} from '@xds/core/theme/tokens.stylex';
 
 // building from xds_oss asset set
 const BG_URL =
-  'https://scontent.xx.fbcdn.net/v/t39.6806-6/673946116_928438936673086_7955596512102197644_n.jpg?_nc_cat=103&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=PVl7FEhjCusQ7kNvwEIGngs&_nc_oc=AdpqpGsFv2Z4UswEve2B2ZCHTKIXDjyDvMT-4Z3wfkVRnE3bKLbU4_DLcVEg3Z1ZVLDKyB3qEi1_KDcmHVsxDFWV&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=rUsd40W1gpadk3EzTZm5Tw&_nc_ss=7a30f&oh=00_Af1sx6n6V2eu3whVV18i5CYuQkQb_Ry2BN-V-2_DWlcWgw&oe=69EC4058';
+  'https://lookaside.facebook.com/assets/xds_oss/building.jpg';
 
 const styles = stylex.create({
   page: {

--- a/packages/cli/templates/pages/product-detail/page.tsx
+++ b/packages/cli/templates/pages/product-detail/page.tsx
@@ -88,19 +88,19 @@ function StarRating({rating, count}: {rating: number; count: number}) {
 // IMAGES[0] = fallback hero; IMAGES[1..6] = thumbnails (first is selected by default)
 const IMAGES = [
   // light-product-1 (fallback hero)
-  'https://scontent.xx.fbcdn.net/v/t39.6806-6/671222955_2145727732941085_520241325832272863_n.png?_nc_cat=102&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=_Ch_acjT1BcQ7kNvwFADCvm&_nc_oc=AdqqylHdxZ9J4WaGETpiBq1DXGTxM7xNmhKft8oBFP39swimIWZ7AZdZ1AKvHLbY4fQmrgJ5x2ERsTFv98HzMFN8&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=EcLE5fhnvnLjNTYpUQKeXw&_nc_ss=7a30f&oh=00_Af3jxqjOZaUZaSNIGpa3Aet1Uddvdujkk7oegd-_A0bOZA&oe=69EC5232',
+  'https://lookaside.facebook.com/assets/xds_oss/light-home-horizontal-1.png',
   // light-product-1 (thumbnail 1)
-  'https://scontent.xx.fbcdn.net/v/t39.6806-6/671222955_2145727732941085_520241325832272863_n.png?_nc_cat=102&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=_Ch_acjT1BcQ7kNvwFADCvm&_nc_oc=AdqqylHdxZ9J4WaGETpiBq1DXGTxM7xNmhKft8oBFP39swimIWZ7AZdZ1AKvHLbY4fQmrgJ5x2ERsTFv98HzMFN8&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=EcLE5fhnvnLjNTYpUQKeXw&_nc_ss=7a30f&oh=00_Af3jxqjOZaUZaSNIGpa3Aet1Uddvdujkk7oegd-_A0bOZA&oe=69EC5232',
+  'https://lookaside.facebook.com/assets/xds_oss/light-home-horizontal-1.png',
   // light-product-2
-  'https://scontent.xx.fbcdn.net/v/t39.6806-6/673826432_1199625442080268_2235614826141527510_n.png?_nc_cat=101&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=_wjLv5Lhh_8Q7kNvwGWRhyt&_nc_oc=AdpFiVWrB2w5PwJdvE3h9DoYN3IzJZB9W1TTvnhK4i5q0t83dp8bbLsfNTHtktLDqMrgdp6mMWKLZ7oJO_YNqje2&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=QNknQFLa-qbjgo-aYr3B3w&_nc_ss=7a30f&oh=00_Af2pOYyfoeSW61DtYM8HQox8tAFI5lUk5aX-TiLvgr1cjQ&oe=69EC3F31',
+  'https://lookaside.facebook.com/assets/xds_oss/light-product-2.png',
   // light-product-3
-  'https://scontent.xx.fbcdn.net/v/t39.6806-6/672681263_1894137684571541_8624778644609428792_n.png?_nc_cat=109&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=w9acCjHivWUQ7kNvwHr7aPX&_nc_oc=Adr2brJxtVS4X0T6nifDX4ilMvUWwNKMXZh6ZuLoyqWqe7tjHD5o7cQuzNQYrIEIb6_QIW5YLaq2CTx55-fGzg0B&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=3toqnQ2Xkolb6jv7QsUzdw&_nc_ss=7a30f&oh=00_Af2x_-4uoy7Vr0QQ1F6Fs9JENKFc2--Hv3wUfmKymSXuxA&oe=69EC5583',
+  'https://lookaside.facebook.com/assets/xds_oss/light-product-3.png',
   // light-product-4
-  'https://scontent.xx.fbcdn.net/v/t39.6806-6/670399674_3883527348446559_364118105607949641_n.png?_nc_cat=103&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=o3njmHZr7gYQ7kNvwGbioqf&_nc_oc=Ado4I-fGsoF4PuhuxLx6SAboigPu9Xsdnosy866WWRM5aulLrmQRc5xh7EQJrx4YDx_pK1qvGCQd_m9WDcEbzZ-D&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=C0OA-Y0wfGERdXCxRnfkMA&_nc_ss=7a30f&oh=00_Af2mjuba1-uIEO0x8d6kQtGHcS0rxRK0FsSFULQ43xApew&oe=69EC4A6D',
+  'https://lookaside.facebook.com/assets/xds_oss/light-product-4.png',
   // light-product-5
-  'https://scontent.xx.fbcdn.net/v/t39.6806-6/671457944_4516505268571219_6833232903201599778_n.png?_nc_cat=101&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=70oaCchmPvkQ7kNvwEhnyV5&_nc_oc=AdpnM83UaG_26EX-nNlHboZr9lIWze8y13UKAwTsJsDkR4zFGSk__UK8FN_f_W06xnx2eHRbElX9xyop69nEylZA&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=iolShmKEPYHkXdhBqc0ynQ&_nc_ss=7a30f&oh=00_Af22qlucAlsFv61LJs7RFu-eXP8RgSILrqeE-uLtJsthBQ&oe=69EC4495',
-  // light-product-2 (duplicate for gallery)
-  'https://scontent.xx.fbcdn.net/v/t39.6806-6/673826432_1199625442080268_2235614826141527510_n.png?_nc_cat=101&ccb=1-7&_nc_sid=56bbc2&_nc_ohc=_wjLv5Lhh_8Q7kNvwGWRhyt&_nc_oc=AdpFiVWrB2w5PwJdvE3h9DoYN3IzJZB9W1TTvnhK4i5q0t83dp8bbLsfNTHtktLDqMrgdp6mMWKLZ7oJO_YNqje2&_nc_zt=14&_nc_ht=scontent.xx&_nc_gid=QNknQFLa-qbjgo-aYr3B3w&_nc_ss=7a30f&oh=00_Af2pOYyfoeSW61DtYM8HQox8tAFI5lUk5aX-TiLvgr1cjQ&oe=69EC3F31',
+  'https://lookaside.facebook.com/assets/xds_oss/light-product-5.png',
+  // light-product-1 (gallery variety)
+  'https://lookaside.facebook.com/assets/xds_oss/light-product-1.png',
 ];
 
 // ─── Product Data ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

Template images were broken because they used expiring `scontent.xx.fbcdn.net` URLs, rate-limited `picsum.photos`, and `unsplash` URLs instead of permanent Meta asset CDN URLs.

## Fix

Replace all external image URLs with permanent `lookaside.facebook.com/assets/xds_oss/` URLs from the XDS OSS asset set.

### Page templates (3 files)
- **login-sso** — `building.jpg` background
- **login-split** — `light-working-vertical-1.png` cover image
- **product-detail** — `light-home-horizontal-1.png` hero + `light-product-{2..5}.png` gallery

### Block templates (10 files)
- **Thumbnail** (5 files) — `illustrative-vertical` + `moody-scene` assets
- **AspectRatio** (3 files) — `light-scene-horizontal`, `light-home-square` assets
- **ChatComposerDrawer** — `illustrative-vertical` attachments
- **TopNavMegaMenu** — `light-working-horizontal-1.png` featured card

## Verification
```
grep -rn 'scontent\|fbcdn\|unsplash\|picsum' packages/cli/templates/ --include='*.tsx'
# zero results
```

All 13 files now use `lookaside.facebook.com/assets/xds_oss/` which does not expire.