### PR TITLE
fix(docsite): wrap changelog tabs in Carousel for overflow

### DIFF
--- a/apps/docsite/src/components/ChangelogView.tsx
+++ b/apps/docsite/src/components/ChangelogView.tsx
@@ -7,6 +7,7 @@ import {XDSText, XDSHeading} from '@xds/core/Text';
 import {XDSVStack} from '@xds/core/Layout';
 import {XDSSection} from '@xds/core/Section';
 import {XDSTabList, XDSTab} from '@xds/core/TabList';
+import {XDSCarousel} from '@xds/core/Carousel';
 import {GITHUB_REPO} from '../constants';
 
 function linkifyPRs(markdown: string): string {
@@ -77,9 +78,11 @@ export function ChangelogView({
         {changelogs.length > 0 ? (
           <>
             <XDSTabList value={activeTab} onChange={setActiveTab} hasDivider>
-              {changelogs.map(c => (
-                <XDSTab key={c.pkg} value={c.pkg} label={c.pkg} />
-              ))}
+              <XDSCarousel gap={0.5} hasSnap={false}>
+                {changelogs.map(c => (
+                  <XDSTab key={c.pkg} value={c.pkg} label={c.pkg} />
+                ))}
+              </XDSCarousel>
             </XDSTabList>
 
             {active != null && (


### PR DESCRIPTION
Depends on #1978.

The What's New page renders one tab per package. As packages are added, the tab list overflows its container. This wraps the tabs in `XDSCarousel` to get arrow navigation and fade masks on overflow.

Single-file change — just adds `<XDSCarousel gap={0.5} hasSnap={false}>` around the tab items in `ChangelogView.tsx`.