### PR TITLE
refactor(Layout): container-driven edge compensation via :has()

### DIFF
--- a/packages/core/src/Banner/XDSBanner.tsx
+++ b/packages/core/src/Banner/XDSBanner.tsx
@@ -34,6 +34,7 @@ import {
   typeScaleVars,
 } from '../theme/tokens.stylex';
 import {xdsClassName, mergeProps} from '../utils';
+import {edgeCompSlot} from '../Layout/edgeCompensation.stylex';
 
 // =============================================================================
 // Types
@@ -251,8 +252,6 @@ const styles = stylex.create({
     gap: spacingVars['--spacing-2'],
     flexShrink: 0,
     marginInlineStart: 'auto',
-    // Edge compensation: align end content flush with container edge.
-    marginInlineEnd: `calc(-1 * ${spacingVars['--spacing-2']})`,
     marginBlock: `calc(-1 * (${spacingVars['--spacing-3']} - ${spacingVars['--spacing-2']}))`,
   },
   contentArea: {
@@ -432,7 +431,11 @@ export function XDSBanner({
           )}
         </div>
         {showEndArea && (
-          <div {...stylex.props(styles.endArea)}>
+          <div
+            {...stylex.props(
+              styles.endArea,
+              edgeCompSlot.inset(spacingVars['--spacing-2'] as string),
+            )}>
             {endContent}
             {hasChildren && (
               <XDSButton

--- a/packages/core/src/Button/XDSButton.tsx
+++ b/packages/core/src/Button/XDSButton.tsx
@@ -32,7 +32,7 @@ import {
 import {XDSTooltip} from '../Tooltip/XDSTooltip';
 import {XDSSpinner} from '../Spinner';
 
-import {edgeCompensation} from '../Layout/edgeCompensation.stylex';
+import {EDGE_COMP_ATTR} from '../Layout/edgeCompensation.stylex';
 import {useXDSSize} from '../SizeContext/XDSSizeContext';
 import {xdsClassName, mergeProps} from '../utils';
 import {useXDSLinkComponent} from '../Link/useXDSLinkComponent';
@@ -488,11 +488,10 @@ export function XDSButton({
       }
     : undefined;
 
-  // Ghost buttons opt into edge compensation — they pull back at container
-  // edges via negative margin when placed as first/last child in a slot
-  // that sets --edge-inset-start/--edge-inset-end.
+  // Ghost buttons are edge-compensatable — containers detect this attribute
+  // via :has() and pull their own slot margins to align flush at edges.
   const isFlat = variant === 'ghost';
-  const edgeCompStyle = isFlat ? edgeCompensation.item : null;
+  const edgeCompAttr = isFlat ? {[EDGE_COMP_ATTR]: ''} : null;
 
   // Shared StyleX props for both button and link rendering
   const sharedStylexProps = stylex.props(
@@ -503,7 +502,6 @@ export function XDSButton({
     buttonDisabled && styles.disabled,
     useAriaDisabled && styles.ariaDisabled,
     isLoadingState && loadingStyles.loading,
-    edgeCompStyle,
     renderAsLink && styles.link,
     xstyle,
   );
@@ -574,6 +572,7 @@ export function XDSButton({
         {...sharedMergedProps}
         {...props}
         {...ariaLabelProp}
+        {...edgeCompAttr}
         onClick={handleClick}>
         {buttonContent}
       </LinkComponent>
@@ -587,6 +586,7 @@ export function XDSButton({
         {...sharedMergedProps}
         {...props}
         {...ariaLabelProp}
+        {...edgeCompAttr}
         aria-busy={isLoadingState || undefined}
         aria-disabled={useAriaDisabled || undefined}
         onClick={handleClick}

--- a/packages/core/src/Dialog/XDSDialog.test.tsx
+++ b/packages/core/src/Dialog/XDSDialog.test.tsx
@@ -278,29 +278,13 @@ describe('XDSDialog', () => {
     });
   });
 
-  describe('edge signal isolation', () => {
-    it('resets inherited --edge-end from ancestor containers', () => {
-      // Simulate the bug: Dialog rendered inside TopNav's endContent
-      // which sets --edge-end: 1 via edgeSignals.end
+  describe('edge compensation isolation', () => {
+    it('does not inherit edge compensation from ancestor containers', () => {
+      // With container-driven edge compensation (via :has() + data attributes),
+      // dialogs no longer need to reset CSS custom properties — the compensation
+      // is scoped to each container's own slot wrappers.
       render(
-        <div style={{'--edge-end': '1'} as React.CSSProperties}>
-          <XDSDialog isOpen={true} onOpenChange={() => {}}>
-            <div data-testid="child">Content</div>
-          </XDSDialog>
-        </div>,
-      );
-
-      const dialog = screen.getByRole('dialog');
-      // The dialog element should have isolateEdgeSignals styles applied,
-      // resetting --edge-start and --edge-end to 0 so ghost buttons inside
-      // (like the close button) don't apply unwanted edge compensation
-      expect(dialog).toBeInTheDocument();
-      expect(dialog.getAttribute('class')).toBeTruthy();
-    });
-
-    it('resets inherited --edge-start from ancestor containers', () => {
-      render(
-        <div style={{'--edge-start': '1'} as React.CSSProperties}>
+        <div>
           <XDSDialog isOpen={true} onOpenChange={() => {}}>
             <div data-testid="child">Content</div>
           </XDSDialog>
@@ -309,7 +293,6 @@ describe('XDSDialog', () => {
 
       const dialog = screen.getByRole('dialog');
       expect(dialog).toBeInTheDocument();
-      expect(dialog.getAttribute('class')).toBeTruthy();
     });
   });
 

--- a/packages/core/src/Dialog/XDSDialog.tsx
+++ b/packages/core/src/Dialog/XDSDialog.tsx
@@ -165,14 +165,6 @@ const styles = stylex.create({
     margin: 0,
     inset: 0,
   },
-  // Reset inherited edge signals so that dialogs rendered as DOM descendants
-  // of containers (e.g. TopNav endContent) don't inherit --edge-start/--edge-end.
-  // CSS custom properties inherit through the DOM tree even for top-layer elements,
-  // causing ghost buttons (like the close button) to apply unwanted edge compensation.
-  isolateEdgeSignals: {
-    '--edge-start': '0',
-    '--edge-end': '0',
-  },
   inner: {
     display: 'flex',
     flexDirection: 'column',
@@ -545,7 +537,6 @@ export function XDSDialog({
           styles.dialog,
           isOpen && styles.open,
           styles.backdrop,
-          styles.isolateEdgeSignals,
           !isFullscreen && dynamicStyles.sizing(width, maxHeight),
           hasPosition &&
             dynamicStyles.position(

--- a/packages/core/src/Dialog/XDSDialogHeader.tsx
+++ b/packages/core/src/Dialog/XDSDialogHeader.tsx
@@ -39,7 +39,7 @@ const styles = stylex.create({
     flex: 1,
     minWidth: 0,
     // Visual centering: align title center with close button center
-    // buttonCenter = -edgeCompensation + size-element-md/2 = -8 + 16 = 8px
+    // buttonCenter = size-element-md/2 = 16px (close button midpoint relative to edge)
     // titleCenter = heading-2-size * heading-2-leading / 2 = 14px
     // adjustment = 8 - 14 = -6px
     marginBlock: `calc(${sizeVars['--size-element-md']} / 2 - ${spacingVars['--spacing-2']} - ${typeScaleVars['--text-heading-2-size']} * ${typeScaleVars['--text-heading-2-leading']} / 2)`,

--- a/packages/core/src/Layout/__tests__/edgeCompensation.test.tsx
+++ b/packages/core/src/Layout/__tests__/edgeCompensation.test.tsx
@@ -1,94 +1,29 @@
 /**
  * @file edgeCompensation.test.tsx
  * @input Uses vitest, @testing-library/react
- * @output Unit tests for edge compensation pattern
- * @position Testing; validates edgeCompensation.stylex.ts, TopNav edge signals,
- *   and Button ghost variant edge compensation behavior
+ * @output Unit tests for container-driven edge compensation pattern
+ * @position Testing; validates data-xds-edge-comp attribute on components
+ *   and container-driven compensation via :has() selectors
  */
 
 import {describe, it, expect} from 'vitest';
 import {render, screen} from '@testing-library/react';
-import {XDSTopNav} from '../../TopNav/XDSTopNav';
 import {XDSButton} from '../../Button/XDSButton';
 import {XDSBanner} from '../../Banner/XDSBanner';
+import {XDSToolbar} from '../../Toolbar/XDSToolbar';
+import {XDSTab} from '../../TabList/XDSTab';
+import {XDSTabList} from '../../TabList/XDSTabList';
+import {EDGE_COMP_ATTR} from '../edgeCompensation.stylex';
 
 describe('Edge Compensation', () => {
-  describe('TopNav edge signals', () => {
-    it('sets --container-padding-inline on the nav element', () => {
-      render(
-        <XDSTopNav
-          label="Test nav"
-          endContent={<span data-testid="end">End</span>}
-        />,
-      );
-      const nav = screen.getByRole('navigation');
-      expect(nav).toBeInTheDocument();
-      // The nav should have the container-padding-inline style set
-      // (StyleX applies this as a class — we verify the element renders correctly)
-      expect(nav).toHaveAttribute('class');
-    });
-
-    it('renders endContent slot with edge-end signal wrapper', () => {
-      render(
-        <XDSTopNav
-          label="Test nav"
-          endContent={<span data-testid="end-item">Action</span>}
-        />,
-      );
-      const endItem = screen.getByTestId('end-item');
-      // The parent wrapper should have a class applied (edgeSignals.end)
-      expect(endItem.parentElement).toHaveAttribute('class');
-    });
-
-    it('renders leftSection with edge-start signal wrapper', () => {
-      render(
-        <XDSTopNav
-          label="Test nav"
-          heading={<span data-testid="heading">Logo</span>}
-        />,
-      );
-      const heading = screen.getByTestId('heading');
-      // heading > heading wrapper > leftSection (with edgeSignals.start)
-      const leftSection = heading.parentElement?.parentElement;
-      expect(leftSection).toHaveAttribute('class');
-    });
-  });
-
-  describe('Banner edge signals', () => {
-    it('sets --container-padding-inline on the banner header', () => {
-      render(<XDSBanner status="info" title="Test" isDismissable />);
-      // Banner renders with role="status" for info — use getAllByRole
-      // since the dismiss button's live region also has role="status"
-      const statuses = screen.getAllByRole('status');
-      expect(statuses.length).toBeGreaterThanOrEqual(1);
-    });
-
-    it('renders dismiss button without a wrapper div', () => {
-      render(<XDSBanner status="info" title="Test" isDismissable />);
-      const dismissButton = screen.getByRole('button', {name: 'Dismiss'});
-      expect(dismissButton).toBeInTheDocument();
-      // The dismiss button should NOT be wrapped in an extra div with
-      // manual negative margin — it should be a direct child of the endArea
-      // The parent should be the endArea div (which has edgeSignals.end)
-      const parent = dismissButton.closest('[class]')?.parentElement;
-      expect(parent).not.toBeNull();
-    });
-  });
-
-  describe('Button ghost variant edge compensation', () => {
-    it('applies edge compensation class to ghost text button', () => {
-      render(
-        <XDSButton label="Action" variant="ghost" data-testid="ghost-btn" />,
-      );
+  describe('Button data attribute', () => {
+    it('applies edge comp attribute to ghost button', () => {
+      render(<XDSButton label="Action" variant="ghost" />);
       const button = screen.getByRole('button', {name: 'Action'});
-      // Ghost buttons should have additional style classes for edge compensation
-      const classCount = (button.getAttribute('class') || '').split(' ').length;
-      // Ghost button has: base + ghost variant + edge compensation = more classes
-      // than a primary button
-      expect(classCount).toBeGreaterThan(0);
+      expect(button).toHaveAttribute(EDGE_COMP_ATTR);
     });
 
-    it('applies edge compensation class to ghost icon-only button', () => {
+    it('applies edge comp attribute to ghost icon-only button', () => {
       render(
         <XDSButton
           label="Settings"
@@ -98,101 +33,75 @@ describe('Edge Compensation', () => {
         />,
       );
       const button = screen.getByRole('button', {name: 'Settings'});
-      expect(button).toBeInTheDocument();
+      expect(button).toHaveAttribute(EDGE_COMP_ATTR);
     });
 
-    it('does not apply edge compensation to primary variant', () => {
-      const {container: primaryContainer} = render(
-        <XDSButton label="Primary" variant="primary" />,
+    it('does not apply edge comp attribute to primary variant', () => {
+      render(<XDSButton label="Primary" variant="primary" />);
+      const button = screen.getByRole('button', {name: 'Primary'});
+      expect(button).not.toHaveAttribute(EDGE_COMP_ATTR);
+    });
+
+    it('does not apply edge comp attribute to secondary variant', () => {
+      render(<XDSButton label="Secondary" variant="secondary" />);
+      const button = screen.getByRole('button', {name: 'Secondary'});
+      expect(button).not.toHaveAttribute(EDGE_COMP_ATTR);
+    });
+
+    it('does not apply edge comp attribute to danger variant', () => {
+      render(<XDSButton label="Delete" variant="danger" />);
+      const button = screen.getByRole('button', {name: 'Delete'});
+      expect(button).not.toHaveAttribute(EDGE_COMP_ATTR);
+    });
+  });
+
+  describe('Tab data attribute', () => {
+    it('applies edge comp attribute to tab', () => {
+      render(
+        <XDSTabList label="Tabs">
+          <XDSTab label="Tab 1" />
+        </XDSTabList>,
       );
-      const {container: ghostContainer} = render(
-        <XDSButton label="Ghost" variant="ghost" />,
+      const tab = screen.getByRole('button', {name: 'Tab 1'});
+      expect(tab).toHaveAttribute(EDGE_COMP_ATTR);
+    });
+  });
+
+  describe('Toolbar container compensation', () => {
+    it('renders ghost buttons inside toolbar slots', () => {
+      render(
+        <XDSToolbar
+          label="Actions"
+          startContent={<XDSButton label="Cut" variant="ghost" />}
+          endContent={<XDSButton label="Paste" variant="ghost" />}
+        />,
       );
-      const primaryClasses =
-        primaryContainer.querySelector('button')?.getAttribute('class') || '';
-      const ghostClasses =
-        ghostContainer.querySelector('button')?.getAttribute('class') || '';
-      // Ghost button should have more classes than primary (edge compensation adds classes)
-      expect(ghostClasses.split(' ').length).toBeGreaterThan(
-        primaryClasses.split(' ').length,
+      expect(screen.getByRole('button', {name: 'Cut'})).toHaveAttribute(
+        EDGE_COMP_ATTR,
+      );
+      expect(screen.getByRole('button', {name: 'Paste'})).toHaveAttribute(
+        EDGE_COMP_ATTR,
       );
     });
 
-    it('does not apply edge compensation to secondary variant', () => {
-      const {container: secondaryContainer} = render(
-        <XDSButton label="Secondary" variant="secondary" />,
+    it('does not add edge comp attribute to non-ghost buttons in toolbar', () => {
+      render(
+        <XDSToolbar
+          label="Actions"
+          endContent={<XDSButton label="Save" variant="primary" />}
+        />,
       );
-      const {container: ghostContainer} = render(
-        <XDSButton label="Ghost" variant="ghost" />,
-      );
-      const secondaryClasses =
-        secondaryContainer.querySelector('button')?.getAttribute('class') || '';
-      const ghostClasses =
-        ghostContainer.querySelector('button')?.getAttribute('class') || '';
-      // Ghost button should have more classes than secondary (edge compensation adds classes)
-      expect(ghostClasses.split(' ').length).toBeGreaterThan(
-        secondaryClasses.split(' ').length,
+      expect(screen.getByRole('button', {name: 'Save'})).not.toHaveAttribute(
+        EDGE_COMP_ATTR,
       );
     });
   });
 
-  describe('TopNav + Button integration', () => {
-    it('renders ghost button inside TopNav endContent', () => {
-      render(
-        <XDSTopNav
-          label="App nav"
-          endContent={
-            <XDSButton
-              label="Search"
-              variant="ghost"
-              icon={<span>search</span>}
-              isIconOnly
-            />
-          }
-        />,
-      );
-      const button = screen.getByRole('button', {name: 'Search'});
-      expect(button).toBeInTheDocument();
-      expect(screen.getByRole('navigation')).toContainElement(button);
-    });
-
-    it('renders primary button inside TopNav endContent without compensation', () => {
-      render(
-        <XDSTopNav
-          label="App nav"
-          endContent={<XDSButton label="Save" variant="primary" />}
-        />,
-      );
-      const button = screen.getByRole('button', {name: 'Save'});
-      expect(button).toBeInTheDocument();
-    });
-
-    it('renders multiple buttons in endContent', () => {
-      render(
-        <XDSTopNav
-          label="App nav"
-          endContent={
-            <>
-              <XDSButton
-                label="Search"
-                variant="ghost"
-                icon={<span>search</span>}
-                isIconOnly
-              />
-              <XDSButton
-                label="Settings"
-                variant="ghost"
-                icon={<span>gear</span>}
-                isIconOnly
-              />
-            </>
-          }
-        />,
-      );
-      expect(screen.getByRole('button', {name: 'Search'})).toBeInTheDocument();
-      expect(
-        screen.getByRole('button', {name: 'Settings'}),
-      ).toBeInTheDocument();
+  describe('Banner container compensation', () => {
+    it('renders dismissable banner with ghost dismiss button', () => {
+      render(<XDSBanner status="info" title="Test" isDismissable />);
+      const dismissButton = screen.getByRole('button', {name: 'Dismiss'});
+      expect(dismissButton).toHaveAttribute(EDGE_COMP_ATTR);
     });
   });
 });

--- a/packages/core/src/Layout/__tests__/edgeCompensation.test.tsx
+++ b/packages/core/src/Layout/__tests__/edgeCompensation.test.tsx
@@ -65,6 +65,16 @@ describe('Edge Compensation', () => {
       const tab = screen.getByRole('button', {name: 'Tab 1'});
       expect(tab).toHaveAttribute(EDGE_COMP_ATTR);
     });
+
+    it('applies edge comp attribute to TabList wrapper', () => {
+      render(
+        <XDSTabList label="Tabs">
+          <XDSTab label="Tab 1" />
+        </XDSTabList>,
+      );
+      const nav = screen.getByRole('navigation', {name: 'Tabs'});
+      expect(nav).toHaveAttribute(EDGE_COMP_ATTR);
+    });
   });
 
   describe('Toolbar container compensation', () => {

--- a/packages/core/src/Layout/edgeCompensation.stylex.ts
+++ b/packages/core/src/Layout/edgeCompensation.stylex.ts
@@ -1,27 +1,25 @@
 /**
  * @file edgeCompensation.stylex.ts
  * @input Uses @stylexjs/stylex
- * @output StyleX utilities for automatic edge padding compensation
- * @position Layout utility; used by containers (TopNav, Toolbar, etc.)
- *   and components with transparent variants (Button ghost, Tab)
+ * @output StyleX utilities for container-driven edge compensation
+ * @position Layout utility; used by containers (Toolbar, Banner, etc.)
  *
- * ## Edge Inset Pattern
+ * ## Container-Driven Edge Compensation
  *
  * Interactive components with transparent padding (ghost buttons, tabs)
  * create excess visual space at container edges. The container's padding + the
  * component's own transparent padding doubles up.
  *
- * This module provides a two-layer solution:
+ * The solution is fully container-driven:
  *
- * 1. **Containers** set the inset budget via CSS custom properties on slot wrappers:
- *    - `--edge-inset-start: <px>` — how much to pull back at the start edge
- *    - `--edge-inset-end: <px>` — how much to pull back at the end edge
+ * 1. **Components** mark themselves with `data-xds-edge-comp` (a passive
+ *    data attribute — no styles attached).
+ * 2. **Containers** use `:has(> [data-xds-edge-comp]:first-child)` and
+ *    `:has(> [data-xds-edge-comp]:last-child)` to detect edge-adjacent
+ *    compensatable items and apply negative margin to their slot wrappers.
  *
- * 2. **Components** opt in by applying `edgeCompensation.item` which uses
- *    `:first-child` / `:last-child` selectors to only compensate items
- *    actually at the edge.
- *
- * The container decides the amount. The component decides whether to participate.
+ * The container owns both the detection and the adjustment. Components
+ * just declare eligibility.
  *
  * SYNC: When modified, update /packages/core/src/Layout/Layout.doc.mjs
  */
@@ -29,92 +27,39 @@
 import * as stylex from '@stylexjs/stylex';
 import {spacingVars} from '../theme/tokens.stylex';
 
-// =============================================================================
-// Container-side: Edge inset styles
-// =============================================================================
+/**
+ * The data attribute that edge-compensatable components apply.
+ * Ghost buttons, tabs, and other transparent-padding components
+ * render this attribute so containers can detect them via `:has()`.
+ */
+export const EDGE_COMP_ATTR = 'data-xds-edge-comp';
 
 /**
- * Styles for containers to set the edge inset budget on slot wrappers.
+ * Container-side edge compensation styles.
  *
- * Apply to wrapper divs around slot content (startContent, endContent, etc.).
- * The value is the amount of negative margin that edge-adjacent components
- * will apply to pull themselves toward the container edge.
+ * Apply to slot wrapper divs. The slot detects whether its first/last
+ * child is an edge-compensatable component and pulls its own margin
+ * inward by the specified inset amount.
  *
  * @example
  * ```tsx
- * // Toolbar sets inset equal to its slot padding:
- * <div {...stylex.props(edgeInset.start4)}>
+ * <div {...stylex.props(
+ *   styles.startSlot,
+ *   edgeCompSlot.inset(spacingVars['--spacing-2']),
+ * )}>
  *   {startContent}
  * </div>
- * <div {...stylex.props(edgeInset.end4)}>
- *   {endContent}
- * </div>
  * ```
  */
-export const edgeInset = stylex.create({
-  /** Start edge inset: spacing-1 (4px) */
-  start1: {'--edge-inset-start': spacingVars['--spacing-1']},
-  /** Start edge inset: spacing-1.5 (6px) */
-  start1_5: {'--edge-inset-start': spacingVars['--spacing-1-5']},
-  /** Start edge inset: spacing-2 (8px) */
-  start2: {'--edge-inset-start': spacingVars['--spacing-2']},
-  /** Start edge inset: spacing-3 (12px) */
-  start3: {'--edge-inset-start': spacingVars['--spacing-3']},
-  /** Start edge inset: spacing-4 (16px) */
-  start4: {'--edge-inset-start': spacingVars['--spacing-4']},
-  /** Start edge inset: spacing-5 (20px) */
-  start5: {'--edge-inset-start': spacingVars['--spacing-5']},
-  /** End edge inset: spacing-1 (4px) */
-  end1: {'--edge-inset-end': spacingVars['--spacing-1']},
-  /** End edge inset: spacing-1.5 (6px) */
-  end1_5: {'--edge-inset-end': spacingVars['--spacing-1-5']},
-  /** End edge inset: spacing-2 (8px) */
-  end2: {'--edge-inset-end': spacingVars['--spacing-2']},
-  /** End edge inset: spacing-3 (12px) */
-  end3: {'--edge-inset-end': spacingVars['--spacing-3']},
-  /** End edge inset: spacing-4 (16px) */
-  end4: {'--edge-inset-end': spacingVars['--spacing-4']},
-  /** End edge inset: spacing-5 (20px) */
-  end5: {'--edge-inset-end': spacingVars['--spacing-5']},
-});
-
-// =============================================================================
-// Component-side: Edge compensation styles
-// =============================================================================
-
-/**
- * Styles for components to self-adjust at container edges.
- *
- * Components with transparent/flat padding (ghost buttons, tabs) apply
- * `edgeCompensation.item` to participate in edge compensation.
- *
- * Only the first child in a slot gets start compensation, and only the
- * last child gets end compensation — via `:first-child` / `:last-child`.
- *
- * @example
- * ```tsx
- * // In XDSButton, for ghost variant:
- * {...stylex.props(
- *   styles.base,
- *   styles.ghost,
- *   edgeCompensation.item,
- * )}
- * ```
- */
-export const edgeCompensation = stylex.create({
-  /**
-   * Edge-compensating item. Applies negative margin at container edges
-   * using the inset budget set by the parent container.
-   * Only activates when the component is :first-child (start) or :last-child (end).
-   */
-  item: {
+export const edgeCompSlot = stylex.create({
+  inset: (amount: string) => ({
     marginInlineStart: {
       default: null,
-      ':first-child': 'calc(-1 * var(--edge-inset-start, 0px))',
+      [`:has(> [${EDGE_COMP_ATTR}]:first-child)`]: `calc(-1 * ${amount})`,
     },
     marginInlineEnd: {
       default: null,
-      ':last-child': 'calc(-1 * var(--edge-inset-end, 0px))',
+      [`:has(> [${EDGE_COMP_ATTR}]:last-child)`]: `calc(-1 * ${amount})`,
     },
-  },
+  }),
 });

--- a/packages/core/src/Layout/index.ts
+++ b/packages/core/src/Layout/index.ts
@@ -18,7 +18,7 @@ export type {
 } from './container.stylex';
 
 // Edge compensation utility
-export {edgeInset, edgeCompensation} from './edgeCompensation.stylex';
+export {edgeCompSlot, EDGE_COMP_ATTR} from './edgeCompensation.stylex';
 
 // Stack utilities (re-exported from Stack module)
 export {stack} from '../Stack/stack.stylex';

--- a/packages/core/src/TabList/XDSTab.tsx
+++ b/packages/core/src/TabList/XDSTab.tsx
@@ -32,7 +32,7 @@ import {tabScope} from './tab.markers.stylex';
 import {useXDSLinkComponent} from '../Link/useXDSLinkComponent';
 import type {XDSLinkComponentType} from '../Link/types';
 import {xdsClassName, mergeProps} from '../utils';
-import {edgeCompensation} from '../Layout/edgeCompensation.stylex';
+import {EDGE_COMP_ATTR} from '../Layout/edgeCompensation.stylex';
 
 export interface XDSTabProps extends XDSBaseProps<HTMLButtonElement> {
   /**
@@ -242,6 +242,7 @@ export function XDSTab({
 
   const sharedProps = {
     ...restProps,
+    [EDGE_COMP_ATTR]: '',
     'aria-current': isSelected ? ('page' as const) : undefined,
     ...mergeProps(
       xdsClassName('tab', {
@@ -252,7 +253,6 @@ export function XDSTab({
         sizeStyles[size],
         isSelected && styles.selected,
         isFill && layoutStyles.fill,
-        edgeCompensation.item,
         tabScope,
         xstyle,
       ),

--- a/packages/core/src/TabList/XDSTabList.tsx
+++ b/packages/core/src/TabList/XDSTabList.tsx
@@ -21,6 +21,7 @@ import {XDSTabListContext} from './XDSTabListContext';
 import type {XDSTabListSize} from './XDSTabListContext';
 import {useXDSSize} from '../SizeContext/XDSSizeContext';
 import {xdsClassName, mergeProps} from '../utils';
+import {EDGE_COMP_ATTR} from '../Layout/edgeCompensation.stylex';
 
 export interface XDSTabListProps extends Omit<
   XDSBaseProps<HTMLElement>,
@@ -115,6 +116,7 @@ export function XDSTabList({
     <XDSTabListContext.Provider value={contextValue}>
       <nav
         aria-label="Tabs"
+        {...{[EDGE_COMP_ATTR]: ''}}
         {...restProps}
         {...mergeProps(
           xdsClassName('tab-list', {size}),

--- a/packages/core/src/Toolbar/XDSToolbar.tsx
+++ b/packages/core/src/Toolbar/XDSToolbar.tsx
@@ -25,6 +25,7 @@ import {xdsClassName, mergeProps} from '../utils';
 import {XDSSection} from '../Section/XDSSection';
 import {useListFocus} from '../hooks/useListFocus';
 import {XDSSizeProvider} from '../SizeContext/XDSSizeContext';
+import {edgeCompSlot} from '../Layout/edgeCompensation.stylex';
 
 /**
  * Map SpacingStep values to spacingVars keys.
@@ -122,16 +123,15 @@ const blockPaddingVarForSize: Record<XDSElementSize, string> = {
 };
 
 /**
- * Dynamic edge inset style. The inset equals container-inline-padding minus
- * the toolbar's block padding, creating even spacing around edge-compensated
- * items (ghost buttons, tabs).
+ * Edge compensation inset amount per toolbar size.
+ * Equals container-inline-padding minus the toolbar's block padding,
+ * creating even spacing around edge-compensated items (ghost buttons, tabs).
  */
-const edgeInsetStyles = stylex.create({
-  inset: (blockPadding: string) => ({
-    '--edge-inset-start': `calc(var(--container-padding-inline-start, ${spacingVars['--spacing-4']}) - ${blockPadding})`,
-    '--edge-inset-end': `calc(var(--container-padding-inline-end, ${spacingVars['--spacing-4']}) - ${blockPadding})`,
-  }),
-});
+const edgeCompInsetForSize: Record<XDSElementSize, string> = {
+  sm: `calc(var(--container-padding-inline-start, ${spacingVars['--spacing-4']}) - ${spacingVars['--spacing-2']})`,
+  md: `calc(var(--container-padding-inline-start, ${spacingVars['--spacing-4']}) - ${spacingVars['--spacing-2']})`,
+  lg: `calc(var(--container-padding-inline-start, ${spacingVars['--spacing-4']}) - ${spacingVars['--spacing-2']})`,
+};
 
 export type XDSToolbarSize = XDSElementSize;
 
@@ -272,7 +272,7 @@ export function XDSToolbar({
               <div
                 {...stylex.props(
                   styles.startSlot,
-                  edgeInsetStyles.inset(blockPaddingVarForSize[size]),
+                  edgeCompSlot.inset(edgeCompInsetForSize[size]),
                   dynamicStyles.gap(gapVar),
                 )}>
                 {startContent}
@@ -284,7 +284,7 @@ export function XDSToolbar({
               <div
                 {...stylex.props(
                   styles.endSlot,
-                  edgeInsetStyles.inset(blockPaddingVarForSize[size]),
+                  edgeCompSlot.inset(edgeCompInsetForSize[size]),
                   dynamicStyles.gap(gapVar),
                 )}>
                 {endContent}
@@ -298,7 +298,7 @@ export function XDSToolbar({
                   {...stylex.props(
                     styles.startSlot,
                     !hasEndContent && styles.startOnly,
-                    edgeInsetStyles.inset(blockPaddingVarForSize[size]),
+                    edgeCompSlot.inset(edgeCompInsetForSize[size]),
                     dynamicStyles.gap(gapVar),
                   )}>
                   {startContent}
@@ -309,7 +309,7 @@ export function XDSToolbar({
                   {...stylex.props(
                     styles.endSlot,
                     !hasStartContent && styles.endOnly,
-                    edgeInsetStyles.inset(blockPaddingVarForSize[size]),
+                    edgeCompSlot.inset(edgeCompInsetForSize[size]),
                     dynamicStyles.gap(gapVar),
                   )}>
                   {endContent}


### PR DESCRIPTION
Migrate edge compensation from a component-opt-in pattern to a container-driven pattern.

## Before
Components (ghost buttons, tabs) applied `edgeCompensation.item` styles with negative margins that read `--edge-inset-start/end` CSS vars set by parent containers. This required:
- Every compensatable component to know about and import the system
- Containers to set CSS custom properties that inherited through the DOM
- Dialog to reset inherited vars to prevent unwanted compensation

## After
Fully container-driven:
1. Components mark themselves with `data-xds-edge-comp` (a passive data attribute)
2. Containers use `:has(> [data-xds-edge-comp]:first-child)` / `:last-child)` to detect edge-adjacent items and apply negative margin to their own slot wrappers

The container owns both detection and adjustment. Components just declare eligibility.

## Changes

| File | Change |
|------|--------|
| `edgeCompensation.stylex.ts` | Replace `edgeInset`/`edgeCompensation` with `edgeCompSlot` + `EDGE_COMP_ATTR` |
| `XDSButton` | `data-xds-edge-comp` on ghost variant instead of style |
| `XDSTab` | `data-xds-edge-comp` instead of `edgeCompensation.item` |
| `XDSToolbar` | `edgeCompSlot.inset()` on slot wrappers |
| `XDSBanner` | `edgeCompSlot.inset()` on endArea, remove hardcoded negative margin |
| `XDSDialog` | Remove `isolateEdgeSignals` (no longer needed) |
| `Layout/index.ts` | Export `edgeCompSlot` + `EDGE_COMP_ATTR` |

## Breaking
`edgeInset` and `edgeCompensation` exports removed from `@xds/core` Layout. Use `edgeCompSlot` and `EDGE_COMP_ATTR` instead. No external consumers found.