### PR TITLE
docs(common-props): add stylex.create() guidance to 4 remaining xstyle props

### DIFF
--- a/packages/core/src/Chat/Chat.doc.mjs
+++ b/packages/core/src/Chat/Chat.doc.mjs
@@ -147,7 +147,7 @@ export const docs = {
         {name: 'sendIcon', type: 'ReactNode', description: 'Custom icon for the send state. Defaults to arrowUp from icon registry.'},
         {name: 'stopIcon', type: 'ReactNode', description: 'Custom icon for the stop state. Defaults to stop from icon registry.'},
         {name: 'size', type: "'sm' | 'md'", description: 'Button size.', default: "'md'"},
-        {name: 'xstyle', type: 'StyleXStyles', description: 'Additional StyleX styles.'},
+        {name: 'xstyle', type: 'StyleXStyles', description: 'StyleX styles for layout customization (margins, positioning, sizing). Must be a stylex.create() value — not an inline style object like style={{}}.'},
       ],
     },
     {

--- a/packages/core/src/Chat/ChatDictationButton.doc.mjs
+++ b/packages/core/src/Chat/ChatDictationButton.doc.mjs
@@ -54,7 +54,7 @@ export const docs = {
     {
       name: 'xstyle',
       type: 'StyleXStyles',
-      description: 'Additional StyleX styles applied to the wrapper.',
+      description: 'StyleX styles for layout customization (margins, positioning, sizing). Must be a stylex.create() value — not an inline style object like style={{}}.',
     },
   ],
 

--- a/packages/core/src/Layer/Layer.doc.mjs
+++ b/packages/core/src/Layer/Layer.doc.mjs
@@ -26,7 +26,7 @@ export const docs = {
       name: 'xstyle',
       type: 'StyleXStyles',
       description:
-        'StyleX styles for layout customization.',
+        'StyleX styles for layout customization (margins, positioning, sizing). Must be a stylex.create() value — not an inline style object like style={{}}.',
     },
   ],
   usage: {

--- a/packages/core/src/SegmentedControl/SegmentedControl.doc.mjs
+++ b/packages/core/src/SegmentedControl/SegmentedControl.doc.mjs
@@ -70,7 +70,7 @@ export const docs = {
         {
           name: 'xstyle',
           type: 'StyleXStyles',
-          description: 'Additional StyleX styles for the container.',
+          description: 'StyleX styles for layout customization (margins, positioning, sizing). Must be a stylex.create() value — not an inline style object like style={{}}.',
         },
       ],    },
     {


### PR DESCRIPTION
## What

Adds standard `stylex.create()` guidance to the 4 remaining xstyle doc entries that were missed in #1952:

- **Chat** (Chat.doc.mjs) — XDSChatSendButton xstyle
- **ChatDictationButton** (ChatDictationButton.doc.mjs)
- **Layer** (Layer.doc.mjs)
- **SegmentedControl** (SegmentedControl.doc.mjs)

All now use the standard description: *"StyleX styles for layout customization (margins, positioning, sizing). Must be a stylex.create() value — not an inline style object like style={{}}."*

This prevents LLMs from passing inline style objects to xstyle, which compiles but breaks StyleX's static extraction.

## Checklist
- [x] `yarn workspace @xds/core typecheck:docs` passes
- [x] `tsc --project packages/cli/tsconfig.template-docs.json --noEmit` passes
- [x] CLI `--props` output verified

---
*Night Watch — Doc Reviewer*