### PR TITLE
docs: fix 0.0.13 changelog accuracy

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -13,7 +13,9 @@
 - `--skip-install` and `--force-install` flags for `xds upgrade` (#1547)
 - `npx xds docs icons` reference + updated icon prop descriptions (#1500)
 - Theme nudge in generated agent docs (#1456)
+- Theme `expandColorScale` — derive color tokens from accent hex in `xds theme build` (#1452)
 - Component groups read from doc files instead of hardcoded map (#1650)
+- Page and block template system (#1393)
 
 #### Fixes
 
@@ -21,6 +23,8 @@
 - Handle ternary/logical expressions in `icon-name-deprecations` codemod (#1513)
 - Don't inject XDS block into files without markers during upgrade (#1495)
 - `findShowcase` matches by directory name and `componentsUsed` (#1728)
+- Include `onMedia` CSS in built theme output (#1450)
+- Register codemods for v0.0.13 (moved from v0.0.14) (#1508)
 
 #### Upgrade
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -32,6 +32,11 @@
 - **Tailwind v4 theme bridge** (#1649)
 - **Theme `expandColorScale`** — Derive full color token ramp from a single accent hex (#1452)
 - **Theme derived var expansion** — CSS properties to internal vars (#1467)
+- **Table column alignment and row vertical alignment** (#1362)
+- **TabList visual polish** — ghost hover, primary colors, divider overlap; remove density prop (#1357, #1418)
+- **TreeList visual polish** (#1367)
+- **SideNav/TopNav heading icon toggle** (#1371)
+- **CodeBlock highlight ranges** — range-based highlighting support (#1470)
 - **Page and block template system** with 100+ component showcase blocks (#1393)
 
 #### Fixes
@@ -39,6 +44,13 @@
 - Truncation: use Range API for multi-line detection (#1816)
 - PowerSearch: add `xdsClassName` for theme targeting (#1813)
 - ToggleButton: fix theming + Chat barrel export (#1812)
+- Component audit: AppShell BaseProps, AspectRatio RTL, Badge header (#1748)
+- Component audit: data-autofocus on BaseTypeahead, displayName on TreeListBranches (#1692)
+- Component audit: SegmentedControl, Slider extend XDSBaseProps (#1519)
+- Component audit: PowerSearch token, RadioList exports (#1359)
+- Hardening audit: AlertDialog BaseProps, CheckboxList className, Table xdsClassName, use-client directives (#1518)
+- Remove internal-only exports from public API (#1603)
+- Add XDS prefix to StackAlignment type, fix StatusDot header (#1561)
 - SSR: replace `useLayoutEffect` with SSR-safe alternatives (#1721)
 - Focus: use `:focus-visible` instead of `:focus-within` for outlines (#1511)
 - Focus: remove `outline` from transition to prevent black flash (#1731)
@@ -50,11 +62,15 @@
 - Grid: cap column count via track-max (#1761)
 - Tokens: update palette border colors from DSP color ramp (#1760)
 - Slider: keep tooltip visible during thumb drag (#1751)
-- AppShell: targeting class names on sticky wrappers (#1764)
+- AppShell: targeting class names on sticky wrappers (#1764), detect empty slots via presence registration (#1377)
 - Icon: use secondary color for input startIcon slots (#1765), default to `inherit` (#1588)
-- SideNav: section custom styles, item collapsible+action split (#1666)
+- SideNav: section custom styles, item collapsible+action split (#1666), design tokens for drag handle transition (#1381)
 - Table: container padding to directional vars (#1621)
 - Toast viewport: reset UA popover background (#1644)
+- Selector: forward extra HTML attributes from XDSBaseProps (#1444)
+- TextArea/TimeInput: a11y and input consistency fixes (#1443)
+- Token: add `'use client'` directive, TopNav context naming conventions (#1465)
+- Chat: anchor trigger menu to cursor position (#1354)
 - Banner, Breadcrumbs, Spinner, StatusDot, TabList, Text, TextArea, TimeInput: extend XDSBaseProps (#1780, #1640, #1405)
 - CodeBlock: Safari span fallback, per-line token perf (#1487, #1369)
 - TextInput/TextArea: default value to empty string (#1439)
@@ -62,6 +78,11 @@
 - Divider: remove opaque background from label (#1426)
 - Field: move description into XDSFieldLabel (#1458)
 - Theme: sync `data-xds-theme` to `<html>` for root provider (#1587)
+- Edge compensation model redesigned for toolbars (#1539)
+
+#### Performance
+
+- CodeBlock: content-visibility chunking for range mode, eliminate stylesheet mutations (#1457)
 
 #### Upgrade
 

--- a/packages/themes/daily/CHANGELOG.md
+++ b/packages/themes/daily/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 # 0.0.13
 
-#### New
+#### Changes
 
-- Initial release — daily-rotating community theme with Figtree font, Lucide icons, and complete token set with component overrides (#1201, #1802)
+- Fleshed out with complete token set and component overrides (#1802)
+
+#### Patch Changes
+
+- Updated dependencies
+  - @xds/core@0.0.13


### PR DESCRIPTION
Audited all changelog entries against the `v0.0.12..v0.0.13` git range to ensure nothing from 0.0.14 leaked in and nothing was missing.

**Changes:**

**@xds/core** — added 19 missing entries:
- 3 features: Table alignment, TabList polish + density removal, TreeList polish, SideNav/TopNav heading toggle, CodeBlock highlight ranges
- 13 fixes: component audit BaseProps extensions, Selector forwarding, TextArea/TimeInput a11y, AppShell empty slots, SideNav drag handle, Chat trigger menu, remove internal exports, StackAlignment prefix, Token use-client, PowerSearch/RadioList exports
- 1 perf: CodeBlock content-visibility chunking
- 1 refactor: edge compensation redesign for toolbars

**@xds/cli** — added 4 missing entries:
- expandColorScale + onMedia CSS in theme build
- Codemod registration fix, template system

**@xds/theme-daily** — fixed `#1201` reference (that PR landed in 0.0.12, not 0.0.13)

All 111 PR references across 8 package changelogs verified to be within the v0.0.12..v0.0.13 range.