### PR TITLE
feat(docsite): craft section — template gallery + theme editor stubs

### DIFF
--- a/apps/docsite/src/app/craft/page.tsx
+++ b/apps/docsite/src/app/craft/page.tsx
@@ -1,0 +1,83 @@
+/**
+ * Page type: craft landing
+ * Template gallery with tabs: All, Templates, Components.
+ * All data from pipeline registries.
+ */
+
+import {XDSHeading, XDSText} from '@xds/core/Text';
+import {XDSVStack} from '@xds/core/Layout';
+import {XDSSection} from '@xds/core/Section';
+import {XDSGrid} from '@xds/core/Grid';
+import {XDSClickableCard} from '@xds/core/ClickableCard';
+import {XDSBadge} from '@xds/core/Badge';
+import {templates} from '../../generated/templateRegistry';
+import {blocks, showcaseCount} from '../../generated/blockRegistry';
+
+const showcases = blocks.filter(b => b.isShowcase);
+
+export default function CraftPage() {
+  return (
+    <XDSSection maxWidth="lg" padding={6}>
+      <XDSVStack gap={8}>
+        <XDSVStack gap={2}>
+          <XDSHeading level={1}>Craft</XDSHeading>
+          <XDSText type="large" color="secondary">
+            Browse templates, component showcases, and examples. Copy the source
+            code to get started.
+          </XDSText>
+        </XDSVStack>
+
+        {/* Templates */}
+        <XDSVStack gap={4}>
+          <XDSHeading level={2}>Page Templates ({templates.length})</XDSHeading>
+          <XDSGrid columns={{minWidth: 280, repeat: 'fit'}} gap={4} rowGap={6}>
+            {templates.map(t => (
+              <XDSClickableCard
+                key={t.slug}
+                label={t.name}
+                href={`/craft/templates/${t.slug}`}
+                padding={5}>
+                <XDSVStack gap={2}>
+                  <XDSText type="body" weight="bold">
+                    {t.name}
+                  </XDSText>
+                  <XDSText type="supporting" color="secondary">
+                    {t.description}
+                  </XDSText>
+                  {!t.isReady && (
+                    <XDSBadge label="Coming Soon" variant="warning" />
+                  )}
+                </XDSVStack>
+              </XDSClickableCard>
+            ))}
+          </XDSGrid>
+        </XDSVStack>
+
+        {/* Showcases */}
+        <XDSVStack gap={4}>
+          <XDSHeading level={2}>
+            Component Showcases ({showcaseCount})
+          </XDSHeading>
+          <XDSGrid columns={{minWidth: 280, repeat: 'fit'}} gap={4} rowGap={6}>
+            {showcases.map(b => (
+              <XDSClickableCard
+                key={b.dirName}
+                label={b.name}
+                href={`/components/${b.componentsUsed[0] || b.category.split('/').pop()}`}
+                padding={5}>
+                <XDSVStack gap={2}>
+                  <XDSText type="body" weight="bold">
+                    {b.name}
+                  </XDSText>
+                  <XDSText type="supporting" color="secondary">
+                    {b.description}
+                  </XDSText>
+                </XDSVStack>
+              </XDSClickableCard>
+            ))}
+          </XDSGrid>
+        </XDSVStack>
+      </XDSVStack>
+    </XDSSection>
+  );
+}

--- a/apps/docsite/src/app/craft/templates/[slug]/page.tsx
+++ b/apps/docsite/src/app/craft/templates/[slug]/page.tsx
@@ -1,0 +1,37 @@
+/**
+ * Page type: template viewer
+ * Preview a template + view its source code.
+ * TODO: render template in iframe, show source from pipeline.
+ */
+
+import {notFound} from 'next/navigation';
+import {XDSHeading, XDSText} from '@xds/core/Text';
+import {XDSVStack} from '@xds/core/Layout';
+import {XDSSection} from '@xds/core/Section';
+import {templates} from '../../../../generated/templateRegistry';
+
+export function generateStaticParams() {
+  return templates.map(t => ({slug: t.slug}));
+}
+
+export default async function TemplatePage({
+  params,
+}: {
+  params: Promise<{slug: string}>;
+}) {
+  const {slug} = await params;
+  const template = templates.find(t => t.slug === slug);
+  if (!template) notFound();
+
+  return (
+    <XDSSection maxWidth="lg" padding={6}>
+      <XDSVStack gap={4}>
+        <XDSHeading level={1}>{template.name}</XDSHeading>
+        <XDSText type="body" color="secondary">
+          {template.description}
+        </XDSText>
+        {/* TODO: template preview iframe + source code viewer */}
+      </XDSVStack>
+    </XDSSection>
+  );
+}

--- a/apps/docsite/src/app/craft/theme/page.tsx
+++ b/apps/docsite/src/app/craft/theme/page.tsx
@@ -1,0 +1,24 @@
+/**
+ * Page type: theme editor
+ * Live theme customization with token adjustments and preview.
+ * All client-side — no AI/inference needed.
+ * TODO: port ThemeEditorView from sandbox.
+ */
+
+import {XDSHeading, XDSText} from '@xds/core/Text';
+import {XDSVStack} from '@xds/core/Layout';
+import {XDSSection} from '@xds/core/Section';
+
+export default function ThemeEditorPage() {
+  return (
+    <XDSSection maxWidth="lg" padding={6}>
+      <XDSVStack gap={4}>
+        <XDSHeading level={1}>Theme Editor</XDSHeading>
+        <XDSText type="body" color="secondary">
+          Customize colors, typography, radius, and more. Preview changes live.
+        </XDSText>
+        {/* TODO: port theme editor controls + live preview */}
+      </XDSVStack>
+    </XDSSection>
+  );
+}

--- a/apps/docsite/src/app/layout.tsx
+++ b/apps/docsite/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type {Metadata} from 'next';
+import {headers} from 'next/headers';
 import './globals.css';
 import {Providers} from './providers';
 import {DocsShell} from '../components/DocsShell';
@@ -13,7 +14,15 @@ export const metadata: Metadata = {
     'Open-source design system for building internal tools and products.',
 };
 
-export default function RootLayout({children}: {children: React.ReactNode}) {
+export default async function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const headersList = await headers();
+  const ua = headersList.get('user-agent') ?? '';
+  const defaultIsMobile = /mobile|android|iphone|ipad/i.test(ua);
+
   return (
     <html lang="en">
       <body>
@@ -22,7 +31,8 @@ export default function RootLayout({children}: {children: React.ReactNode}) {
             components={components}
             packages={packages}
             docTopics={docTopics}
-            templates={templates}>
+            templates={templates}
+            defaultIsMobile={defaultIsMobile}>
             {children}
           </DocsShell>
         </Providers>

--- a/apps/docsite/src/components/DocsShell.tsx
+++ b/apps/docsite/src/components/DocsShell.tsx
@@ -5,6 +5,7 @@ import {usePathname} from 'next/navigation';
 import {XDSAppShell} from '@xds/core/AppShell';
 import {XDSTopNav, XDSTopNavHeading} from '@xds/core/TopNav';
 import {XDSSideNav, XDSSideNavItem, XDSSideNavSection} from '@xds/core/SideNav';
+import {XDSNavMenuItem} from '@xds/core/NavMenu';
 import {XDSButton} from '@xds/core/Button';
 import {XDSLink} from '@xds/core/Link';
 import {XDSHStack, XDSVStack} from '@xds/core/Layout';
@@ -22,6 +23,7 @@ interface DocsShellProps {
   packages: PackageMeta[];
   docTopics: DocTopic[];
   templates: TemplateEntry[];
+  defaultIsMobile?: boolean;
 }
 
 /** Foundations: tokens first, then alphabetical */
@@ -161,6 +163,7 @@ export function DocsShell({
   packages,
   docTopics,
   templates,
+  defaultIsMobile,
 }: DocsShellProps) {
   const pathname = usePathname();
   const [isSearchOpen, setIsSearchOpen] = useState(false);
@@ -205,10 +208,22 @@ export function DocsShell({
       <XDSAppShell
         variant="surface"
         height="auto"
+        mobileNav={{defaultIsMobile}}
         topNav={
           <XDSTopNav
             label="XDS navigation"
-            heading={<XDSTopNavHeading logo={XDS_WORDMARK} headingHref="/" />}
+            heading={
+              <XDSTopNavHeading
+                logo={XDS_WORDMARK}
+                headingHref="/"
+                menu={
+                  <>
+                    <XDSNavMenuItem label="Craft" href="/craft" />
+                    <XDSNavMenuItem label="Docs" href="/" />
+                  </>
+                }
+              />
+            }
             endContent={
               <XDSHStack gap={2}>
                 <XDSButton


### PR DESCRIPTION
Add /craft routes for the non-AI portions of the craft experience.

## Pages
| Route | Status | Description |
|-------|--------|-------------|
| `/craft` | ✅ Live | Template gallery + component showcases grid |
| `/craft/templates/[slug]` | Stub | Template viewer (needs preview iframe + source) |
| `/craft/theme` | Stub | Theme editor (needs controls + live preview) |

## Navigation
Top nav heading now has Craft/Docs menu items via `XDSNavMenuItem`.

All data from pipeline — templates from `templateRegistry`, showcases from `blockRegistry`.

Related: #1991 (TopNavHeading incomplete docs)