### PR TITLE
fix(CommandPalette, MultiSelector): prevent iOS zoom on input focus

### DIFF
--- a/packages/core/src/CommandPalette/XDSCommandPaletteInput.tsx
+++ b/packages/core/src/CommandPalette/XDSCommandPaletteInput.tsx
@@ -27,7 +27,6 @@ import {
   typeScaleVars,
   spacingVars,
   typographyVars,
-  textSizeVars,
 } from '../theme/tokens.stylex';
 import {useCommandPaletteContext} from './CommandPaletteContext';
 
@@ -74,7 +73,10 @@ const styles = stylex.create({
     backgroundColor: 'transparent',
     color: colorVars['--color-text-primary'],
     fontFamily: typographyVars['--font-family-body'],
-    fontSize: textSizeVars['--font-size-base'],
+    fontSize: {
+      default: typeScaleVars['--text-body-size'],
+      '@media (pointer: coarse)': `max(1rem, ${typeScaleVars['--text-body-size']})`,
+    },
     lineHeight: typeScaleVars['--text-body-leading'],
     padding: 0,
     '::placeholder': {

--- a/packages/core/src/MultiSelector/XDSMultiSelector.tsx
+++ b/packages/core/src/MultiSelector/XDSMultiSelector.tsx
@@ -240,7 +240,10 @@ const styles = stylex.create({
     borderRadius: radiusVars['--radius-element'],
     backgroundColor: colorVars['--color-background-surface'],
     fontFamily: typographyVars['--font-family-body'],
-    fontSize: typeScaleVars['--text-label-size'],
+    fontSize: {
+      default: typeScaleVars['--text-label-size'],
+      '@media (pointer: coarse)': `max(1rem, ${typeScaleVars['--text-label-size']})`,
+    },
     color: colorVars['--color-text-primary'],
     outline: {
       default: 'none',


### PR DESCRIPTION
iOS Safari zooms the viewport when focusing inputs with `font-size < 16px`. All other text inputs already use `max(1rem, ...)` on `@media (pointer: coarse)` to ensure ≥ 16px on touch devices. Two were missed:

- **CommandPaletteInput** — was using `textSizeVars['--font-size-base']` (14px) without a coarse-pointer override. Switched to `typeScaleVars['--text-body-size']` (consistent with TextInput/TextArea) and added the override.
- **MultiSelector searchInput** — was using `typeScaleVars['--text-label-size']` without a coarse-pointer override. Added the override.

Pattern applied (same as TextInput, NumberInput, DateInput, TimeInput, TextArea, Selector, Typeahead):
```ts
fontSize: {
  default: typeScaleVars['--text-body-size'],
  '@media (pointer: coarse)': `max(1rem, ${typeScaleVars['--text-body-size']})`,
},
```