### PR TITLE
fix(Tokenizer): add status to xdsClassName for theme targeting

### DIFF
--- a/packages/core/src/Tokenizer/XDSTokenizer.tsx
+++ b/packages/core/src/Tokenizer/XDSTokenizer.tsx
@@ -661,7 +661,7 @@ export function XDSTokenizer<T extends XDSSearchableItem>({
             onBlurCapture={handleBlurCapture}
             data-testid={testId}
             {...mergeProps(
-              xdsClassName('tokenizer', {size}),
+              xdsClassName('tokenizer', {size, status: status?.type}),
               stylex.props(
                 inputWrapperStyles.base,
                 styles.wrapper,
@@ -762,7 +762,7 @@ export function XDSTokenizer<T extends XDSSearchableItem>({
                 ref={placeholderRef}
                 onClick={handleWrapperClick}
                 {...mergeProps(
-                  xdsClassName('tokenizer', {size}),
+                  xdsClassName('tokenizer', {size, status: status?.type}),
                   stylex.props(
                     inputWrapperStyles.base,
                     styles.wrapper,


### PR DESCRIPTION
## Summary

Tokenizer's `xdsClassName` call only included `size`, missing the `status` prop that drives visual border/shadow styles via `inputStatusBorderStyles[status.type]`. Themes couldn't distinguish tokenizer status states (error, warning, etc.) via the `xds-tokenizer-[status]` class.

## Changes

Add `status?.type` to both `xdsClassName` calls (main wrapper and layer placeholder) to match the pattern already used by XDSTypeahead.

## Audit Notes

Found during Night Watch Component Auditor pass over hardening queue components (Token, Tokenizer, Tooltip, TreeList, Typeahead).

**Other components audited — no issues found:**
- **Token**: xdsClassName includes `color` + `size`, all visual props covered. Uses proper tokens throughout.
- **Tooltip**: Behavioral wrapper, xdsClassName on tooltip popup correct. No visual props to propagate.
- **TreeList**: xdsClassName on TreeListItem includes `density`, `selected`, `disabled` — all visual props covered.
- **Typeahead**: Already includes `status` in xdsClassName — no fix needed.

**Noted for human review (not fixed here):**
- Token, Tokenizer, Typeahead props interfaces don't extend `XDSBaseProps` — they manually define `xstyle`/`className`/`style`. This means they miss `data-*` support from XDSBaseProps. Broader API pattern decision needed.
- XDSTypeahead has no `ref` prop — may need imperative handle similar to XDSTokenizer's `XDSTokenizerHandle`.

Night Watch — Component Auditor