### PR TITLE
fix(TopNav): add selected state to TopNavItem xdsClassName

### DIFF
--- a/packages/core/src/TopNav/XDSTopNavItem.tsx
+++ b/packages/core/src/TopNav/XDSTopNavItem.tsx
@@ -211,7 +211,10 @@ export function XDSTopNavItem({
         aria-disabled={isDisabled || undefined}
         tabIndex={isDisabled ? -1 : undefined}
         {...mergeProps(
-          xdsClassName('top-nav-item', {mode: 'drawer'}),
+          xdsClassName('top-nav-item', {
+            mode: 'drawer',
+            selected: isSelected ? 'selected' : null,
+          }),
           stylex.props(
             navItemStyles.item,
             navItemStyles[size],
@@ -243,7 +246,9 @@ export function XDSTopNavItem({
       aria-disabled={isDisabled || undefined}
       tabIndex={isDisabled ? -1 : undefined}
       {...mergeProps(
-        xdsClassName('top-nav-item'),
+        xdsClassName('top-nav-item', {
+          selected: isSelected ? 'selected' : null,
+        }),
         stylex.props(
           styles.base,
           isSelected && styles.selected,


### PR DESCRIPTION
## Summary

TopNavItem's `xdsClassName` call didn't include the `isSelected` state, even though it drives visual styles (background color, font weight). Themes couldn't distinguish selected vs unselected nav items via the `xds-top-nav-item-selected` class.

## Changes

Add `selected` state to both `xdsClassName` calls (drawer mode and default mode), following the same pattern used by TreeListItem.

## Audit Notes

Found during Night Watch Component Auditor pass over queue components (Timestamp, TopNav).

**Timestamp** — audited, no issues found. Uses xdsClassName with format variant, proper token usage, extends XDSBaseProps.

**TopNav** — this fix. All sub-components checked:
- TopNavHeading: no visual variant props to propagate
- TopNavMenu: no selected state
- TopNavMegaMenu: no visual variant props
- TopNavMegaMenuItem: no selected state

**Queue status:** All 63 core components have now been audited. Queue will rebuild on next run.

Night Watch — Component Auditor