### PR TITLE
fix(docsite): clean up token tables and code blocks

### DIFF
--- a/apps/docsite/src/components/docs/CodeBlock.tsx
+++ b/apps/docsite/src/components/docs/CodeBlock.tsx
@@ -4,7 +4,6 @@ import * as stylex from '@stylexjs/stylex';
 import {XDSVStack} from '@xds/core/Layout';
 import {XDSText} from '@xds/core/Text';
 import {XDSCodeBlock} from '@xds/core/CodeBlock';
-import {XDSCard} from '@xds/core/Card';
 
 const styles = stylex.create({
   root: {width: '100%'},
@@ -26,19 +25,12 @@ export function CodeBlockRenderer({
           {label}
         </XDSText>
       )}
-      <XDSCard variant="muted" xstyle={styles.root}>
-        <XDSCodeBlock
-          code={code}
-          language={lang}
-          hasCopyButton
-          style={
-            {
-              '--color-syntax-background': 'transparent',
-              width: '100%',
-            } as React.CSSProperties
-          }
-        />
-      </XDSCard>
+      <XDSCodeBlock
+        code={code}
+        language={lang}
+        hasCopyButton
+        xstyle={styles.root}
+      />
     </XDSVStack>
   );
 }

--- a/apps/docsite/src/components/tokens/ColorTokenTable.tsx
+++ b/apps/docsite/src/components/tokens/ColorTokenTable.tsx
@@ -3,7 +3,7 @@
 import * as stylex from '@stylexjs/stylex';
 import {XDSHStack} from '@xds/core/Layout';
 import {XDSText} from '@xds/core/Text';
-import {XDSTable, pixel} from '@xds/core/Table';
+import {XDSTable} from '@xds/core/Table';
 import type {TokenTableProps} from './types';
 import {resolveTokenForMode, hasDualMode, getTokensByPrefix} from './helpers';
 
@@ -85,7 +85,7 @@ export function ColorTokenTable({theme}: TokenTableProps) {
       <XDSTable
         data={data as Record<string, unknown>[]}
         columns={[
-          {key: 'tokenName', header: 'Token', width: pixel(300)},
+          {key: 'tokenName', header: 'Token'},
           {
             key: 'light',
             header: 'Light',
@@ -122,7 +122,7 @@ export function ColorTokenTable({theme}: TokenTableProps) {
     <XDSTable
       data={data as Record<string, unknown>[]}
       columns={[
-        {key: 'tokenName', header: 'Token', width: pixel(300)},
+        {key: 'tokenName', header: 'Token'},
         {
           key: 'light',
           header: 'Value',

--- a/apps/docsite/src/components/tokens/ElevationTokenTable.tsx
+++ b/apps/docsite/src/components/tokens/ElevationTokenTable.tsx
@@ -3,7 +3,7 @@
 import * as stylex from '@stylexjs/stylex';
 import {XDSHStack} from '@xds/core/Layout';
 import {XDSText} from '@xds/core/Text';
-import {XDSTable, pixel} from '@xds/core/Table';
+import {XDSTable} from '@xds/core/Table';
 import type {TokenTableProps} from './types';
 import {resolveToken, getTokensByPrefix} from './helpers';
 
@@ -29,7 +29,7 @@ export function ElevationTokenTable({theme}: TokenTableProps) {
     <XDSTable
       data={data as Record<string, unknown>[]}
       columns={[
-        {key: 'tokenName', header: 'Token', width: pixel(300)},
+        {key: 'tokenName', header: 'Token'},
         {
           key: 'value',
           header: 'Value',

--- a/apps/docsite/src/components/tokens/FontTokenTables.tsx
+++ b/apps/docsite/src/components/tokens/FontTokenTables.tsx
@@ -3,7 +3,7 @@
 import * as stylex from '@stylexjs/stylex';
 import {XDSHStack} from '@xds/core/Layout';
 import {XDSText} from '@xds/core/Text';
-import {XDSTable, pixel} from '@xds/core/Table';
+import {XDSTable} from '@xds/core/Table';
 import type {TokenTableProps} from './types';
 import {resolveToken, getTokensByPrefix} from './helpers';
 
@@ -39,7 +39,7 @@ export function FontFamilyTokenTable({theme}: TokenTableProps) {
     <XDSTable
       data={data as Record<string, unknown>[]}
       columns={[
-        {key: 'tokenName', header: 'Token', width: pixel(300)},
+        {key: 'tokenName', header: 'Token'},
         {
           key: 'value',
           header: 'Value',
@@ -79,7 +79,7 @@ export function FontWeightTokenTable({theme}: TokenTableProps) {
     <XDSTable
       data={data as Record<string, unknown>[]}
       columns={[
-        {key: 'tokenName', header: 'Token', width: pixel(300)},
+        {key: 'tokenName', header: 'Token'},
         {
           key: 'value',
           header: 'Value',
@@ -115,7 +115,7 @@ export function FontSizeTokenTable({theme}: TokenTableProps) {
     <XDSTable
       data={data as Record<string, unknown>[]}
       columns={[
-        {key: 'tokenName', header: 'Token', width: pixel(300)},
+        {key: 'tokenName', header: 'Token'},
         {
           key: 'value',
           header: 'Value',

--- a/apps/docsite/src/components/tokens/MotionTokenTable.tsx
+++ b/apps/docsite/src/components/tokens/MotionTokenTable.tsx
@@ -4,7 +4,7 @@ import {useState, useEffect, useRef} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {XDSVStack, XDSHStack} from '@xds/core/Layout';
 import {XDSText, XDSHeading} from '@xds/core/Text';
-import {XDSTable, pixel} from '@xds/core/Table';
+import {XDSTable} from '@xds/core/Table';
 import type {TokenTableProps} from './types';
 import {resolveToken, getTokensByPrefix} from './helpers';
 
@@ -173,7 +173,7 @@ export function DurationTokenTable({theme}: TokenTableProps) {
     <XDSTable
       data={data as Record<string, unknown>[]}
       columns={[
-        {key: 'tokenName', header: 'Token', width: pixel(300)},
+        {key: 'tokenName', header: 'Token'},
         {
           key: 'value',
           header: 'Value',
@@ -205,7 +205,7 @@ export function EasingTokenTable({theme}: TokenTableProps) {
     <XDSTable
       data={data as Record<string, unknown>[]}
       columns={[
-        {key: 'tokenName', header: 'Token', width: pixel(300)},
+        {key: 'tokenName', header: 'Token'},
         {
           key: 'value',
           header: 'Value',

--- a/apps/docsite/src/components/tokens/ShapeTokenTable.tsx
+++ b/apps/docsite/src/components/tokens/ShapeTokenTable.tsx
@@ -3,7 +3,7 @@
 import * as stylex from '@stylexjs/stylex';
 import {XDSVStack, XDSHStack} from '@xds/core/Layout';
 import {XDSText, XDSHeading} from '@xds/core/Text';
-import {XDSTable, pixel} from '@xds/core/Table';
+import {XDSTable} from '@xds/core/Table';
 import type {TokenTableProps} from './types';
 import {resolveToken, getTokensByPrefix} from './helpers';
 
@@ -35,7 +35,7 @@ export function RadiusTokenTable({theme}: TokenTableProps) {
     <XDSTable
       data={data as Record<string, unknown>[]}
       columns={[
-        {key: 'tokenName', header: 'Token', width: pixel(300)},
+        {key: 'tokenName', header: 'Token'},
         {
           key: 'value',
           header: 'Value',
@@ -72,7 +72,7 @@ export function BorderTokenTable({theme}: TokenTableProps) {
     <XDSTable
       data={data as Record<string, unknown>[]}
       columns={[
-        {key: 'tokenName', header: 'Token', width: pixel(300)},
+        {key: 'tokenName', header: 'Token'},
         {
           key: 'value',
           header: 'Value',

--- a/apps/docsite/src/components/tokens/SpacingTokenTable.tsx
+++ b/apps/docsite/src/components/tokens/SpacingTokenTable.tsx
@@ -3,7 +3,7 @@
 import * as stylex from '@stylexjs/stylex';
 import {XDSHStack} from '@xds/core/Layout';
 import {XDSText} from '@xds/core/Text';
-import {XDSTable, pixel} from '@xds/core/Table';
+import {XDSTable} from '@xds/core/Table';
 import type {TokenTableProps} from './types';
 import {resolveToken, getTokensByPrefix} from './helpers';
 
@@ -30,7 +30,7 @@ export function SpacingTokenTable({theme}: TokenTableProps) {
     <XDSTable
       data={data as Record<string, unknown>[]}
       columns={[
-        {key: 'tokenName', header: 'Token', width: pixel(300)},
+        {key: 'tokenName', header: 'Token'},
         {
           key: 'value',
           header: 'Value',

--- a/apps/docsite/src/components/tokens/TypographyTokenTable.tsx
+++ b/apps/docsite/src/components/tokens/TypographyTokenTable.tsx
@@ -131,7 +131,7 @@ export function TypographyTokenTable({theme}: TokenTableProps) {
                 fontWeight: item.fontWeight as string,
                 lineHeight: (item.leading as string)?.split(' ')[0],
               }}>
-              {item.sampleText as string}
+              {item.label as string}
             </span>
           ),
         },

--- a/apps/docsite/src/components/tokens/TypographyTokenTable.tsx
+++ b/apps/docsite/src/components/tokens/TypographyTokenTable.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import * as stylex from '@stylexjs/stylex';
+import {XDSVStack} from '@xds/core/Layout';
+import {XDSText} from '@xds/core/Text';
 import {XDSTable, proportional} from '@xds/core/Table';
 import type {XDSTextType} from '@xds/core';
 import type {XDSHeadingLevel} from '@xds/core/Text';
@@ -118,7 +120,7 @@ export function TypographyTokenTable({theme}: TokenTableProps) {
       columns={[
         {
           key: 'label',
-          header: 'Style',
+          header: 'Sample',
           width: proportional(2),
           renderCell: (item: Record<string, unknown>) => (
             <span
@@ -129,20 +131,25 @@ export function TypographyTokenTable({theme}: TokenTableProps) {
                 fontWeight: item.fontWeight as string,
                 lineHeight: (item.leading as string)?.split(' ')[0],
               }}>
-              {item.label as string}
+              {item.sampleText as string}
             </span>
           ),
         },
         {
-          key: 'fontFamily',
-          header: 'Font',
+          key: 'tokens',
+          header: 'Tokens',
           renderCell: (item: Record<string, unknown>) => (
-            <>{(item.fontFamily as string)?.split(',')[0]?.trim()}</>
+            <XDSVStack gap={1}>
+              <XDSText type="code" color="secondary">
+                {item.fontSize as string} ·{' '}
+                {(item.fontFamily as string)?.split(',')[0]?.trim()}
+              </XDSText>
+              <XDSText type="code" color="secondary">
+                {item.fontWeight as string} · {item.leading as string}
+              </XDSText>
+            </XDSVStack>
           ),
         },
-        {key: 'fontSize', header: 'Size'},
-        {key: 'fontWeight', header: 'Weight'},
-        {key: 'leading', header: 'Leading'},
       ]}
       density="spacious"
       dividers="rows"


### PR DESCRIPTION
- Remove `pixel(300)` min-width on Token columns across all token tables — lets them size naturally
- Collapse type scale table from 5 columns (Style, Font, Size, Weight, Leading) to 2 columns (Sample, Tokens) — more compact and mobile-friendly
- Remove `XDSCard variant="muted"` wrapper from code blocks — `XDSCodeBlock` has its own background via `--color-syntax-background`