### PR TITLE
fix(Calendar): add isolation to day cell container

### DIFF
--- a/packages/core/src/Calendar/styles.ts
+++ b/packages/core/src/Calendar/styles.ts
@@ -130,6 +130,7 @@ export const dayCellStyles = stylex.create({
     alignItems: 'center',
     justifyContent: 'center',
     height: sizeVars['--size-element-md'],
+    isolation: 'isolate',
   },
 
   // Range background - structural positioning


### PR DESCRIPTION
The day button uses `z-index: 1` to sit above the range/preview background layers. Without a stacking context on the cell, this z-index leaks to the parent and can paint over siblings like sticky headers.

`isolation: isolate` on the cell container scopes the internal stacking without affecting external layout. Same pattern as the Field/TextInput fix in #1890.