### PR TITLE
fix: add isolation to components with leaky z-index

### DIFF
--- a/packages/core/src/CheckboxInput/XDSCheckboxInput.tsx
+++ b/packages/core/src/CheckboxInput/XDSCheckboxInput.tsx
@@ -59,6 +59,7 @@ const styles = stylex.create({
     alignItems: 'center',
     justifyContent: 'center',
     flexShrink: 0,
+    isolation: 'isolate',
   },
   input: {
     position: 'absolute',

--- a/packages/core/src/RadioList/XDSRadioListItem.tsx
+++ b/packages/core/src/RadioList/XDSRadioListItem.tsx
@@ -42,6 +42,7 @@ const styles = stylex.create({
     alignItems: 'center',
     justifyContent: 'center',
     flexShrink: 0,
+    isolation: 'isolate',
   },
   input: {
     position: 'absolute',

--- a/packages/core/src/Slider/XDSSlider.tsx
+++ b/packages/core/src/Slider/XDSSlider.tsx
@@ -128,6 +128,7 @@ const styles = stylex.create({
     flexGrow: 1,
     touchAction: 'none',
     userSelect: 'none',
+    isolation: 'isolate',
   },
   trackContainerHorizontal: {
     height: THUMB_SIZE,

--- a/packages/core/src/Switch/XDSSwitch.tsx
+++ b/packages/core/src/Switch/XDSSwitch.tsx
@@ -73,6 +73,7 @@ const styles = stylex.create({
     flexShrink: 0,
     width: SWITCH_WIDTH,
     height: SWITCH_HEIGHT,
+    isolation: 'isolate',
   },
   input: {
     position: 'absolute',

--- a/packages/core/src/Thumbnail/XDSThumbnail.tsx
+++ b/packages/core/src/Thumbnail/XDSThumbnail.tsx
@@ -103,6 +103,7 @@ const styles = stylex.create({
     flexDirection: 'column',
     width: 64,
     flexShrink: 0,
+    isolation: 'isolate',
   },
   imageContainer: {
     position: 'relative',
@@ -256,20 +257,14 @@ export function XDSThumbnail({
   const showPlaceholder = !isLoading && !hasSrc;
   const isInteractive = onClick != null && !isDisabled && !isLoading;
   const accessibleName =
-    label && alt ? `${label} — ${alt}` : label ?? alt ?? 'thumbnail';
+    label && alt ? `${label} — ${alt}` : (label ?? alt ?? 'thumbnail');
 
   const imageContent = (
     <>
       {showImage && (
-        <img
-          src={src}
-          alt={alt ?? ''}
-          {...stylex.props(styles.image)}
-        />
+        <img src={src} alt={alt ?? ''} {...stylex.props(styles.image)} />
       )}
-      {showSkeleton && (
-        <XDSSkeleton radius={2} />
-      )}
+      {showSkeleton && <XDSSkeleton radius={2} />}
       {showPlaceholder && (
         <div {...stylex.props(styles.placeholder)}>
           <ImagePlaceholder />
@@ -301,11 +296,7 @@ export function XDSThumbnail({
       aria-label={accessibleName}
       {...mergeProps(
         xdsClassName('thumbnail'),
-        stylex.props(
-          styles.root,
-          isDisabled && styles.disabled,
-          xstyle,
-        ),
+        stylex.props(styles.root, isDisabled && styles.disabled, xstyle),
         className,
         style,
       )}
@@ -333,9 +324,7 @@ export function XDSThumbnail({
           </div>
         )}
         {removeButtonEl != null && imageMode != null ? (
-          <XDSMediaTheme mode={imageMode}>
-            {removeButtonEl}
-          </XDSMediaTheme>
+          <XDSMediaTheme mode={imageMode}>{removeButtonEl}</XDSMediaTheme>
         ) : (
           removeButtonEl
         )}


### PR DESCRIPTION
Sweep of all `z-index` usage in core — five components use z-index internally but their containers lacked a stacking context, letting values leak to the parent.

Adds `isolation: isolate` to:

| Component | Container | Why z-index exists |
|---|---|---|
| **CheckboxInput** | `checkboxWrapper` | Hidden input above visible checkbox |
| **RadioListItem** | `radioWrapper` | Hidden input above radio visual |
| **Switch** | `switchWrapper` | Hidden input above track |
| **Slider** | `trackContainer` | Thumb above track/filled track |
| **Thumbnail** | `root` | Remove button + upload overlay above image |

Companion to #2001 (Calendar). The remaining z-index sites are already contained (Field, Chat, CodeBlock, AppShell) or intentionally cross-boundary (SideNav sticky, Toast, Popover, Table resize, Resizable handle).