### PR TITLE
fix(docsite): add bottom margin to carousel tablists

### DIFF
--- a/apps/docsite/src/app/craft/page.tsx
+++ b/apps/docsite/src/app/craft/page.tsx
@@ -30,6 +30,9 @@ const styles = stylex.create({
   heroTitle: {
     textAlign: 'center' as const,
   },
+  carouselTabs: {
+    paddingBottom: 4,
+  },
   cardImage: {
     display: 'block',
     width: '100%',
@@ -107,7 +110,11 @@ export default function CraftPage() {
         </XDSText>
 
         <XDSCarousel gap={0}>
-          <XDSTabList value={activeTab} onChange={handleTabChange} size="md">
+          <XDSTabList
+            value={activeTab}
+            onChange={handleTabChange}
+            size="md"
+            xstyle={styles.carouselTabs}>
             <XDSTab
               value="all"
               label={`All (${allItems.templates.length + allItems.showcases.length})`}

--- a/apps/docsite/src/app/craft/page.tsx
+++ b/apps/docsite/src/app/craft/page.tsx
@@ -31,7 +31,7 @@ const styles = stylex.create({
     textAlign: 'center' as const,
   },
   carouselTabs: {
-    paddingBottom: 4,
+    marginBottom: 4,
   },
   cardImage: {
     display: 'block',

--- a/apps/docsite/src/components/ChangelogView.tsx
+++ b/apps/docsite/src/components/ChangelogView.tsx
@@ -56,6 +56,9 @@ const styles = stylex.create({
     maxWidth: 960,
     marginInline: 'auto',
   },
+  carouselTab: {
+    paddingBottom: 4,
+  },
 });
 
 export function ChangelogView({
@@ -80,7 +83,12 @@ export function ChangelogView({
             <XDSTabList value={activeTab} onChange={setActiveTab} hasDivider>
               <XDSCarousel gap={0.5} hasSnap={false}>
                 {changelogs.map(c => (
-                  <XDSTab key={c.pkg} value={c.pkg} label={c.pkg} />
+                  <XDSTab
+                    key={c.pkg}
+                    value={c.pkg}
+                    label={c.pkg}
+                    xstyle={styles.carouselTab}
+                  />
                 ))}
               </XDSCarousel>
             </XDSTabList>

--- a/apps/docsite/src/components/ChangelogView.tsx
+++ b/apps/docsite/src/components/ChangelogView.tsx
@@ -57,7 +57,7 @@ const styles = stylex.create({
     marginInline: 'auto',
   },
   carouselTab: {
-    paddingBottom: 4,
+    marginBottom: 4,
   },
 });
 


### PR DESCRIPTION
Adds 4px bottom margin to carousels wrapping tablists on the Craft page and Changelog page, preventing the tab indicators from being clipped.