### PR TITLE
fix(docsite): inline changelog content at build time

### DIFF
--- a/apps/docsite/scripts/generate-data.mjs
+++ b/apps/docsite/scripts/generate-data.mjs
@@ -134,6 +134,9 @@ function generatePackageRegistry() {
       const readme = hasReadme
         ? fs.readFileSync(path.join(REPO_ROOT, dir, 'README.md'), 'utf-8')
         : null;
+      const changelog = hasChangelog
+        ? fs.readFileSync(path.join(REPO_ROOT, dir, 'CHANGELOG.md'), 'utf-8')
+        : null;
       return {
         name: raw.name,
         displayName: raw.displayName || raw.name.replace('@xds/', '').replace('theme-', 'Theme: ').replace(/^\w/, c => c.toUpperCase()),
@@ -143,6 +146,7 @@ function generatePackageRegistry() {
         hasReadme,
         hasChangelog,
         readme,
+        changelog,
       };
     })
     .filter(Boolean)
@@ -159,6 +163,7 @@ export interface PackageMeta {
   hasReadme: boolean;
   hasChangelog: boolean;
   readme: string | null;
+  changelog: string | null;
 }
 
 export const packages: PackageMeta[] = ${JSON.stringify(packages, null, 2)};

--- a/apps/docsite/src/__tests__/data-extraction.test.ts
+++ b/apps/docsite/src/__tests__/data-extraction.test.ts
@@ -58,6 +58,18 @@ describe('packageRegistry', () => {
     }
   });
 
+  it('packages with CHANGELOGs have changelog content', () => {
+    for (const pkg of packages) {
+      if (pkg.hasChangelog) {
+        expect(pkg.changelog).toBeTruthy();
+        expect(typeof pkg.changelog).toBe('string');
+        expect(pkg.changelog!.length).toBeGreaterThan(50);
+      } else {
+        expect(pkg.changelog).toBeNull();
+      }
+    }
+  });
+
   it('CLI package has a substantial README', () => {
     const cli = packages.find(p => p.name === '@xds/cli');
     expect(cli?.readme).toBeTruthy();

--- a/apps/docsite/src/app/changelog/page.tsx
+++ b/apps/docsite/src/app/changelog/page.tsx
@@ -1,34 +1,11 @@
-import {readFile} from 'node:fs/promises';
-import * as path from 'node:path';
 import {ChangelogView} from '../../components/ChangelogView';
 import {components} from '../../generated/componentRegistry';
 import {packages} from '../../generated/packageRegistry';
 
-async function readChangelog(pkg: {
-  name: string;
-  packagePath: string;
-}): Promise<{pkg: string; content: string} | null> {
-  const changelogPath = path.resolve(
-    process.cwd(),
-    '..',
-    '..',
-    pkg.packagePath,
-    'CHANGELOG.md',
-  );
-  try {
-    const content = await readFile(changelogPath, 'utf-8');
-    return {pkg: pkg.name, content};
-  } catch {
-    return null;
-  }
-}
-
-export default async function ChangelogPage() {
-  const withChangelog = packages.filter(p => p.hasChangelog);
-  const results = await Promise.all(withChangelog.map(readChangelog));
-  const changelogs = results.filter(
-    (c): c is {pkg: string; content: string} => c != null,
-  );
+export default function ChangelogPage() {
+  const changelogs = packages
+    .filter((p): p is typeof p & {changelog: string} => p.changelog != null)
+    .map(p => ({pkg: p.name, content: p.changelog}));
 
   const componentNames = Object.values(components)
     .flat()


### PR DESCRIPTION
The changelog page read CHANGELOG.md files at request time via `path.resolve(process.cwd(), '../..', packagePath)`. This works in dev (cwd is `apps/docsite` within the monorepo) but breaks after `next build` when the monorepo root isn't accessible from the output directory.

Inlines changelog content into `packageRegistry.ts` during `generate-data.mjs` — same pattern already used for README content. The page now reads from generated data instead of traversing the filesystem.

Changes:
- **generate-data.mjs** — read and embed `changelog` field alongside `readme`
- **changelog/page.tsx** — use `packages[].changelog` instead of `fs.readFile`; no longer async
- **data-extraction.test.ts** — add changelog content assertion