### PR TITLE
fix: add hasAutoFocus to Popover/MoreMenu, disable in showcases

### DIFF
--- a/packages/cli/templates/blocks/components/DropdownMenu/DropdownMenuShowcase.tsx
+++ b/packages/cli/templates/blocks/components/DropdownMenu/DropdownMenuShowcase.tsx
@@ -10,6 +10,7 @@ export default function DropdownMenuShowcase() {
     <XDSDropdownMenu
       isMenuOpen={isMenuOpen}
       onOpenChange={setIsMenuOpen}
+      hasAutoFocus={false}
       button={{label: 'Actions'}}
       items={[
         {label: 'Edit', onClick: () => {}},

--- a/packages/cli/templates/blocks/components/DropdownMenuItem/DropdownMenuItemShowcase.tsx
+++ b/packages/cli/templates/blocks/components/DropdownMenuItem/DropdownMenuItemShowcase.tsx
@@ -3,21 +3,42 @@
 import {XDSDropdownMenu, XDSDropdownMenuItem} from '@xds/core/DropdownMenu';
 
 const PencilIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round" {...props}>
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}>
     <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
     <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
   </svg>
 );
 
 const CopyIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round" {...props}>
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}>
     <rect x="9" y="9" width="13" height="13" rx="2" />
     <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
   </svg>
 );
 
 const ShareIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round" {...props}>
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}>
     <circle cx="18" cy="5" r="3" />
     <circle cx="6" cy="12" r="3" />
     <circle cx="18" cy="19" r="3" />
@@ -27,7 +48,14 @@ const ShareIcon = (props: React.SVGProps<SVGSVGElement>) => (
 );
 
 const TrashIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round" {...props}>
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}>
     <polyline points="3 6 5 6 21 6" />
     <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
   </svg>
@@ -35,7 +63,11 @@ const TrashIcon = (props: React.SVGProps<SVGSVGElement>) => (
 
 export default function DropdownMenuItemShowcase() {
   return (
-    <XDSDropdownMenu button={{label: 'Actions'}} isMenuOpen onOpenChange={() => {}}>
+    <XDSDropdownMenu
+      button={{label: 'Actions'}}
+      isMenuOpen
+      hasAutoFocus={false}
+      onOpenChange={() => {}}>
       <XDSDropdownMenuItem
         icon={PencilIcon}
         label="Edit"
@@ -48,11 +80,7 @@ export default function DropdownMenuItemShowcase() {
         description="Create a copy"
         onClick={() => {}}
       />
-      <XDSDropdownMenuItem
-        icon={ShareIcon}
-        label="Share"
-        onClick={() => {}}
-      />
+      <XDSDropdownMenuItem icon={ShareIcon} label="Share" onClick={() => {}} />
       <XDSDropdownMenuItem
         icon={TrashIcon}
         label="Delete"

--- a/packages/cli/templates/blocks/components/MoreMenu/MoreMenuShowcase.tsx
+++ b/packages/cli/templates/blocks/components/MoreMenu/MoreMenuShowcase.tsx
@@ -10,6 +10,7 @@ export default function MoreMenuShowcase() {
     <XDSMoreMenu
       isMenuOpen={isMenuOpen}
       onOpenChange={setIsMenuOpen}
+      hasAutoFocus={false}
       items={[
         {label: 'Edit', onClick: () => {}},
         {label: 'Duplicate', onClick: () => {}},

--- a/packages/cli/templates/blocks/components/Popover/PopoverShowcase.tsx
+++ b/packages/cli/templates/blocks/components/Popover/PopoverShowcase.tsx
@@ -14,14 +14,19 @@ export default function PopoverShowcase() {
     <XDSPopover
       isOpen={isOpen}
       onOpenChange={setIsOpen}
+      hasAutoFocus={false}
       placement="below"
       label="Settings"
       width={280}
       content={
         <XDSVStack gap={3}>
-          <XDSHeading level={4} tabIndex={0}>Settings</XDSHeading>
+          <XDSHeading level={4} tabIndex={0}>
+            Settings
+          </XDSHeading>
           <XDSDivider />
-          <XDSText type="body">Notifications, dark mode, and sound preferences.</XDSText>
+          <XDSText type="body">
+            Notifications, dark mode, and sound preferences.
+          </XDSText>
         </XDSVStack>
       }>
       <XDSButton label="Settings">Settings</XDSButton>

--- a/packages/core/src/MoreMenu/MoreMenu.doc.mjs
+++ b/packages/core/src/MoreMenu/MoreMenu.doc.mjs
@@ -43,6 +43,12 @@ export const docs = {
       default: 'false',
     },
     {
+      name: 'hasAutoFocus',
+      type: 'boolean',
+      description: 'Whether to auto-focus the first menu item when the menu opens. Set to false for inline showcases or documentation previews.',
+      default: 'true',
+    },
+    {
       name: 'children',
       type: '(item: XDSDropdownMenuItemData) => ReactNode',
       description:
@@ -113,6 +119,12 @@ export const docsZh = {
       default: 'false',
     },
     {
+      name: 'hasAutoFocus',
+      type: 'boolean',
+      description: '菜单打开时是否自动聚焦第一个菜单项。内联展示或文档预览设为 false。',
+      default: 'true',
+    },
+    {
       name: 'children',
       type: '(item: XDSDropdownMenuItemData) => ReactNode',
       description:
@@ -161,6 +173,7 @@ export const docsDense = {
     size: 'Trigger button size.',
     icon: 'Override default three-dot icon. Accepts any ReactNode.',
     isDisabled: 'Whether menu trigger disabled.',
+    hasAutoFocus: 'Auto-focus first item on open; false for showcases.',
     children: 'Custom render function for selectable items (not dividers/sections).',
     xstyle:
       'StyleX styles for layout customization (margins, positioning, sizing). Must be stylex.create() value.',

--- a/packages/core/src/MoreMenu/XDSMoreMenu.tsx
+++ b/packages/core/src/MoreMenu/XDSMoreMenu.tsx
@@ -74,6 +74,13 @@ export interface XDSMoreMenuProps {
    */
   onOpenChange?: (isOpen: boolean) => void;
 
+  /**
+   * Whether to auto-focus the first menu item when the menu opens.
+   * Set to `false` for inline showcases or documentation previews.
+   * @default true
+   */
+  hasAutoFocus?: boolean;
+
   /** Test ID for testing frameworks. */
   'data-testid'?: string;
 }
@@ -102,6 +109,7 @@ export function XDSMoreMenu({
   isDisabled = false,
   isMenuOpen,
   onOpenChange,
+  hasAutoFocus,
   'data-testid': testId,
   ref,
 }: XDSMoreMenuProps) {
@@ -125,6 +133,7 @@ export function XDSMoreMenu({
       }}
       items={items}
       hasChevron={false}
+      hasAutoFocus={hasAutoFocus}
       data-testid={testId}
     />
   );

--- a/packages/core/src/Popover/Popover.doc.mjs
+++ b/packages/core/src/Popover/Popover.doc.mjs
@@ -78,6 +78,12 @@ export const docs = {
           default: "'Close popover'",
         },
         {
+          name: 'hasAutoFocus',
+          type: 'boolean',
+          description: 'Whether to auto-focus the first focusable element when the popover opens. Set to false for inline showcases or documentation previews.',
+          default: 'true',
+        },
+        {
           name: 'xstyle',
           type: 'StyleXStyles',
           description: 'StyleX styles for layout customization (margins, positioning, sizing). Must be a stylex.create() value — not an inline style object like style={{}}.',
@@ -238,6 +244,12 @@ export const docsZh = {
           description: '隐藏关闭按钮的标签。',
           default: "'Close popover'",
         },
+        {
+          name: 'hasAutoFocus',
+          type: 'boolean',
+          description: '弹出框打开时是否自动聚焦第一个可聚焦元素。内联展示或文档预览设为 false。',
+          default: 'true',
+        },
       ],
     },
     {
@@ -354,6 +366,7 @@ export const docsDense = {
         label: 'Accessible label for popover dialog.',
         hasCloseButton: 'Whether to include hidden close button for accessibility.',
         closeButtonLabel: 'Label for hidden close button.',
+        hasAutoFocus: 'Auto-focus first element on open; false for showcases.',
       },
     },
     {

--- a/packages/core/src/Popover/XDSPopover.tsx
+++ b/packages/core/src/Popover/XDSPopover.tsx
@@ -159,6 +159,13 @@ export interface XDSPopoverProps {
   closeButtonLabel?: string;
 
   /**
+   * Whether to auto-focus the first focusable element when the popover opens.
+   * Set to `false` for inline showcases or documentation previews.
+   * @default true
+   */
+  hasAutoFocus?: boolean;
+
+  /**
    * Test ID for the popover container.
    */
   'data-testid'?: string;
@@ -248,6 +255,7 @@ export function XDSPopover({
   label,
   hasCloseButton,
   closeButtonLabel,
+  hasAutoFocus,
   xstyle,
   className,
   style,
@@ -273,6 +281,7 @@ export function XDSPopover({
     hasLightDismiss: true,
     hasCloseButton,
     closeButtonLabel,
+    hasAutoFocus,
     onShow: handlePopoverShow,
     onHide: handlePopoverHide,
   });


### PR DESCRIPTION
Follow-up to #2007. Plumbs `hasAutoFocus` through the remaining layer components and disables it in all showcases that render layers open by default.

## Changes

### New prop plumbing
- **XDSPopover**: new `hasAutoFocus` prop, forwarded to `useXDSPopover`
- **XDSMoreMenu**: new `hasAutoFocus` prop, forwarded to `XDSDropdownMenu`

### Showcase updates
| Showcase | Change |
|---|---|
| DropdownMenuShowcase | `hasAutoFocus={false}` |
| DropdownMenuItemShowcase | `hasAutoFocus={false}` |
| MoreMenuShowcase | `hasAutoFocus={false}` |
| PopoverShowcase | `hasAutoFocus={false}` |

CommandPalette showcases already handled via `isInline` context from #2007.

## Test plan
All 59 tests in Popover/MoreMenu/DropdownMenu pass.