### PR TITLE
refactor(Table): container-driven block bleed via :has()

### DIFF
--- a/packages/core/src/Layout/XDSLayoutContent.tsx
+++ b/packages/core/src/Layout/XDSLayoutContent.tsx
@@ -76,6 +76,16 @@ const styles = stylex.create({
     paddingBlockEnd: `var(--layout-padding-outer-y, ${spacingVars['--spacing-4']})`,
     '--container-padding-block-end': `var(--layout-padding-outer-y, ${spacingVars['--spacing-4']})`,
   },
+  tableBlockBleed: {
+    paddingBlockStart: {
+      default: null,
+      ':has(> .xds-table:first-child)': '0px',
+    },
+    paddingBlockEnd: {
+      default: null,
+      ':has(> .xds-table:last-child)': '0px',
+    },
+  },
   scrollable: {
     overflow: 'auto',
   },
@@ -188,6 +198,7 @@ export function XDSLayoutContent({
         xdsClassName('layout-content'),
         stylex.props(
           styles.content,
+          styles.tableBlockBleed,
           // Outer padding on container edges (unless content is full bleed)
           !hasStart && !isZeroPadding && padding == null && styles.noStart,
           !hasEnd && !isZeroPadding && padding == null && styles.noEnd,

--- a/packages/core/src/Layout/XDSLayoutFooter.tsx
+++ b/packages/core/src/Layout/XDSLayoutFooter.tsx
@@ -49,6 +49,16 @@ const styles = stylex.create({
     '--container-padding-block-start': `var(--layout-padding-inner-y, ${spacingVars['--spacing-4']})`,
     '--container-padding-block-end': `var(--layout-padding-outer-y, ${spacingVars['--spacing-4']})`,
   },
+  tableBlockBleed: {
+    paddingBlockStart: {
+      default: null,
+      ':has(> .xds-table:first-child)': '0px',
+    },
+    paddingBlockEnd: {
+      default: null,
+      ':has(> .xds-table:last-child)': '0px',
+    },
+  },
   fullBleed: {
     paddingInlineStart: 0,
     paddingInlineEnd: 0,
@@ -171,6 +181,7 @@ export function XDSLayoutFooter({
       <div
         {...stylex.props(
           styles.inner,
+          styles.tableBlockBleed,
           isZeroPadding && styles.fullBleed,
           padding != null && paddingStyles[padding],
           padding != null && containerPaddingInlineVarStyles[padding],

--- a/packages/core/src/Layout/XDSLayoutHeader.tsx
+++ b/packages/core/src/Layout/XDSLayoutHeader.tsx
@@ -49,6 +49,16 @@ const styles = stylex.create({
     '--container-padding-block-start': `var(--layout-padding-outer-y, ${spacingVars['--spacing-4']})`,
     '--container-padding-block-end': `var(--layout-padding-inner-y, ${spacingVars['--spacing-4']})`,
   },
+  tableBlockBleed: {
+    paddingBlockStart: {
+      default: null,
+      ':has(> .xds-table:first-child)': '0px',
+    },
+    paddingBlockEnd: {
+      default: null,
+      ':has(> .xds-table:last-child)': '0px',
+    },
+  },
   fullBleed: {
     paddingInlineStart: 0,
     paddingInlineEnd: 0,
@@ -171,6 +181,7 @@ export function XDSLayoutHeader({
       <div
         {...stylex.props(
           styles.inner,
+          styles.tableBlockBleed,
           isZeroPadding && styles.fullBleed,
           padding != null && paddingStyles[padding],
           padding != null && containerPaddingInlineVarStyles[padding],

--- a/packages/core/src/Layout/XDSLayoutPanel.tsx
+++ b/packages/core/src/Layout/XDSLayoutPanel.tsx
@@ -45,6 +45,16 @@ const styles = stylex.create({
     '--container-padding-block-start': `var(--layout-padding-inner-y, ${spacingVars['--spacing-4']})`,
     '--container-padding-block-end': `var(--layout-padding-inner-y, ${spacingVars['--spacing-4']})`,
   },
+  tableBlockBleed: {
+    paddingBlockStart: {
+      default: null,
+      ':has(> .xds-table:first-child)': '0px',
+    },
+    paddingBlockEnd: {
+      default: null,
+      ':has(> .xds-table:last-child)': '0px',
+    },
+  },
   // Start panel: outer-x on left edge
   startPanel: {
     paddingInlineStart: `var(--layout-padding-outer-x, ${spacingVars['--spacing-4']})`,
@@ -256,6 +266,7 @@ export function XDSLayoutPanel({
         xdsClassName('layout-panel'),
         stylex.props(
           styles.panel,
+          styles.tableBlockBleed,
           dynamicStyles.sizing(effectiveWidth ?? null),
           // Outer padding on container edges (unless component is full bleed)
           isStartPanel &&

--- a/packages/core/src/Layout/container.stylex.ts
+++ b/packages/core/src/Layout/container.stylex.ts
@@ -62,6 +62,27 @@ const baseStyles = stylex.create({
     paddingBlockStart: 'var(--container-padding-block-start)',
     paddingBlockEnd: 'var(--container-padding-block-end)',
   },
+  /**
+   * Container-driven table block bleed.
+   *
+   * When a `.xds-table` is the first or last direct child of a container,
+   * the container zeroes its own block padding on that edge so the table
+   * rows extend edge-to-edge vertically.
+   *
+   * This replaces the old pattern where the table self-applied negative
+   * block margins via `:first-child` / `:last-child`, which leaked when
+   * the table was inside non-container wrapper divs.
+   */
+  tableBlockBleed: {
+    paddingBlockStart: {
+      default: null,
+      ':has(> .xds-table:first-child)': '0px',
+    },
+    paddingBlockEnd: {
+      default: null,
+      ':has(> .xds-table:last-child)': '0px',
+    },
+  },
 });
 
 /**
@@ -466,6 +487,7 @@ export function container({
     const defaults = themeDefaultStyles[useThemeDefault];
     return [
       baseStyles.container,
+      baseStyles.tableBlockBleed,
       defaults.containerPaddingInlineStart,
       defaults.containerPaddingInlineEnd,
       defaults.containerPaddingBlockStart,
@@ -480,6 +502,7 @@ export function container({
 
   return [
     baseStyles.container,
+    baseStyles.tableBlockBleed,
     containerPaddingInlineStartStyles[outerX],
     containerPaddingInlineEndStyles[outerX],
     containerPaddingBlockStartStyles[outerY],

--- a/packages/core/src/Table/XDSTable.tsx
+++ b/packages/core/src/Table/XDSTable.tsx
@@ -116,21 +116,14 @@ const tableStyles = stylex.create({
    * so rows span edge-to-edge inside Cards and Layout areas.
    *
    * Inline bleed uses --container-padding-inline-start/end set by containers.
-   * Block bleed uses --container-padding-block-start/end for :first-child / :last-child.
+   * Block bleed is container-driven: containers use :has(> .xds-table:first-child)
+   * to zero their own block padding when a table is at the edge.
    */
   containerBleed: {
     marginInlineStart: 'calc(-1 * var(--container-padding-inline-start, 0px))',
     marginInlineEnd: 'calc(-1 * var(--container-padding-inline-end, 0px))',
     width:
       'calc(100% + var(--container-padding-inline-start, 0px) + var(--container-padding-inline-end, 0px))',
-    marginTop: {
-      default: null,
-      ':first-child': 'calc(-1 * var(--container-padding-block-start, 0px))',
-    },
-    marginBottom: {
-      default: null,
-      ':last-child': 'calc(-1 * var(--container-padding-block-end, 0px))',
-    },
   },
 });
 


### PR DESCRIPTION
Move table block bleed from table-self-applied `:first-child`/`:last-child` to container-driven `:has(> .xds-table:first-child)` pattern.

## Problem

The table's `containerBleed` style used bare `:first-child`/`:last-child` pseudo-selectors on the `<table>` element to apply negative block margins. These leaked when a table was the first/last child of **any** wrapper div (not just an XDS container), causing unexpected vertical spacing in contexts like the docsite.

## Solution

Follows the same container-driven pattern established in #1987 (edge compensation):

1. **Containers own the adjustment** — Card, Section, Dialog (via `container()`) and all Layout areas now include a `tableBlockBleed` style that uses `:has(> .xds-table:first-child)` / `:has(> .xds-table:last-child)` to zero their own block padding when a table is at the edge.

2. **Table drops self-applied block margins** — the `:first-child`/`:last-child` block margin rules are removed from `containerBleed`. Inline bleed (CSS-var-driven, already scoped) is unchanged.

## Changes

| File | Change |
|------|--------|
| `container.stylex.ts` | Add `tableBlockBleed` style to `baseStyles`, include in `container()` return |
| `XDSTable.tsx` | Remove `:first-child`/`:last-child` block margin from `containerBleed` |
| `XDSLayoutContent.tsx` | Add `tableBlockBleed` style |
| `XDSLayoutHeader.tsx` | Add `tableBlockBleed` style |
| `XDSLayoutFooter.tsx` | Add `tableBlockBleed` style |
| `XDSLayoutPanel.tsx` | Add `tableBlockBleed` style |

## Why container-driven?

The old table-driven approach had two problems:
- `:first-child`/`:last-child` on the table matched against **any parent**, not just XDS containers
- No StyleX API exists to express "I am `:first-child` of a marked parent" (scoped self-pseudo)

The container-driven approach uses `:has()` with a direct-child combinator (`>`), so it only fires when a `.xds-table` is an immediate child of the container element.

## Not changed

- **Inline bleed** — still CSS-var-driven with `--container-padding-inline-start/end`, defaults to `0px` outside containers. Already scoped correctly.
- **Cell edge padding** (`containerEdgeStyles`) — `:first-child`/`:last-child` on `<td>`/`<th>` matches against `<tr>`, which is always correct for column identification.
