### PR TITLE
feat(docsite): live template thumbnails — Activity + inert, no iframes

### DIFF
--- a/apps/docsite/css.d.ts
+++ b/apps/docsite/css.d.ts
@@ -1,3 +1,6 @@
 // TypeScript 6 requires type declarations for CSS side-effect imports.
 // This must be in a separate file from next-env.d.ts (which Next.js regenerates).
 declare module '*.css';
+declare module '*.png';
+declare module '*.jpg';
+declare module '*.svg';

--- a/apps/docsite/scripts/generate-data.mjs
+++ b/apps/docsite/scripts/generate-data.mjs
@@ -551,6 +551,9 @@ async function generateTemplateRegistry() {
       doc = {name: meta.name || dir.name, description: meta.description, isReady: true};
     }
 
+    // Skip scaffolds — these are starter templates, not showcases
+    if (doc.scaffold) continue;
+
     templates.push({
       slug: dir.name,
       name: doc.name || dir.name,

--- a/apps/docsite/src/app/craft/page.tsx
+++ b/apps/docsite/src/app/craft/page.tsx
@@ -20,6 +20,7 @@ import {XDSTabList, XDSTab} from '@xds/core/TabList';
 import {XDSCarousel} from '@xds/core/Carousel';
 import {XDSBadge} from '@xds/core/Badge';
 import {templates} from '../../generated/templateRegistry';
+import {TemplateThumbnail} from '../../components/TemplateThumbnail';
 import {blocks} from '../../generated/blockRegistry';
 import {packages} from '../../generated/packageRegistry';
 
@@ -50,8 +51,10 @@ const styles = stylex.create({
     display: 'flex',
     flexDirection: 'column' as const,
     justifyContent: 'flex-end',
+    alignItems: 'flex-start',
     height: '100%',
-    padding: 16,
+    width: '100%',
+    padding: 8,
   },
 });
 
@@ -218,13 +221,17 @@ function TemplateCard({item}: {item: CraftItem}) {
             </XDSVStack>
           </div>
         }>
-        <div {...stylex.props(styles.cardImage)}>
-          {!item.isReady && (
-            <div {...stylex.props(styles.comingSoon)}>
-              <XDSBadge label="Coming Soon" variant="info" />
-            </div>
-          )}
-        </div>
+        {item.type === 'template' && item.isReady ? (
+          <TemplateThumbnail slug={item.slug} />
+        ) : (
+          <div {...stylex.props(styles.cardImage)}>
+            {!item.isReady && (
+              <div {...stylex.props(styles.comingSoon)}>
+                <XDSBadge label="Coming Soon" variant="info" />
+              </div>
+            )}
+          </div>
+        )}
       </XDSOverlay>
     </XDSCard>
   );

--- a/apps/docsite/src/components/TemplateThumbnail.tsx
+++ b/apps/docsite/src/components/TemplateThumbnail.tsx
@@ -1,0 +1,252 @@
+'use client';
+
+import React, {
+  lazy,
+  Suspense,
+  useRef,
+  useState,
+  useEffect,
+  useCallback,
+  Activity,
+} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {XDSSkeleton} from '@xds/core/Skeleton';
+import {XDSText} from '@xds/core/Text';
+
+const FIXED_SCALE = 0.5;
+const PREVIEW_HEIGHT = 1080;
+
+const styles = stylex.create({
+  container: {
+    width: '100%',
+    aspectRatio: '16/10',
+    overflow: 'hidden',
+    position: 'relative' as const,
+    borderRadius: 'var(--radius-container)',
+    backgroundColor: 'var(--color-background-muted)',
+    contentVisibility: 'auto',
+    containIntrinsicSize: 'auto 300px 187px',
+  },
+  scaler: {
+    position: 'absolute' as const,
+    top: 0,
+    left: 0,
+    height: '200%',
+    transformOrigin: 'top left',
+    pointerEvents: 'none' as const,
+    overflow: 'hidden',
+  },
+  skeleton: {
+    width: '100%',
+    height: '100%',
+  },
+  errorFallback: {
+    width: '100%',
+    height: '100%',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'var(--color-background-muted)',
+  },
+});
+
+class ThumbnailErrorBoundary extends React.Component<
+  {children: React.ReactNode; slug: string},
+  {hasError: boolean}
+> {
+  constructor(props: {children: React.ReactNode; slug: string}) {
+    super(props);
+    this.state = {hasError: false};
+  }
+
+  static getDerivedStateFromError() {
+    return {hasError: true};
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div {...stylex.props(styles.errorFallback)}>
+          <XDSText type="supporting" color="secondary">
+            Preview unavailable
+          </XDSText>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+/**
+ * Lazy-loaded template component registry.
+ * Maps slugs to dynamically imported template page components.
+ */
+const TEMPLATE_COMPONENTS: Record<
+  string,
+  React.LazyExoticComponent<React.ComponentType>
+> = {
+  'ai-chat': lazy(
+    () => import('../../../../packages/cli/templates/pages/ai-chat/page'),
+  ),
+  'ai-chat-landing': lazy(
+    () =>
+      import('../../../../packages/cli/templates/pages/ai-chat-landing/page'),
+  ),
+  blank: lazy(
+    () => import('../../../../packages/cli/templates/pages/blank/page'),
+  ),
+  'centered-hero': lazy(
+    () => import('../../../../packages/cli/templates/pages/centered-hero/page'),
+  ),
+  'classic-gallery': lazy(
+    () =>
+      import('../../../../packages/cli/templates/pages/classic-gallery/page'),
+  ),
+  'contact-form': lazy(
+    () => import('../../../../packages/cli/templates/pages/contact-form/page'),
+  ),
+  dashboard: lazy(
+    () => import('../../../../packages/cli/templates/pages/dashboard/page'),
+  ),
+  'dashboard-portfolio': lazy(
+    () =>
+      import('../../../../packages/cli/templates/pages/dashboard-portfolio/page'),
+  ),
+  'detail-page': lazy(
+    () => import('../../../../packages/cli/templates/pages/detail-page/page'),
+  ),
+  documentation: lazy(
+    () => import('../../../../packages/cli/templates/pages/documentation/page'),
+  ),
+  'documentation-design': lazy(
+    () =>
+      import('../../../../packages/cli/templates/pages/documentation-design/page'),
+  ),
+  'documentation-technical': lazy(
+    () =>
+      import('../../../../packages/cli/templates/pages/documentation-technical/page'),
+  ),
+  editor: lazy(
+    () => import('../../../../packages/cli/templates/pages/editor/page'),
+  ),
+  'file-explorer': lazy(
+    () => import('../../../../packages/cli/templates/pages/file-explorer/page'),
+  ),
+  'form-two-column': lazy(
+    () =>
+      import('../../../../packages/cli/templates/pages/form-two-column/page'),
+  ),
+  'gallery-hero': lazy(
+    () => import('../../../../packages/cli/templates/pages/gallery-hero/page'),
+  ),
+  ide: lazy(() => import('../../../../packages/cli/templates/pages/ide/page')),
+  library: lazy(
+    () => import('../../../../packages/cli/templates/pages/library/page'),
+  ),
+  login: lazy(
+    () => import('../../../../packages/cli/templates/pages/login/page'),
+  ),
+  'login-card': lazy(
+    () => import('../../../../packages/cli/templates/pages/login-card/page'),
+  ),
+  'login-split': lazy(
+    () => import('../../../../packages/cli/templates/pages/login-split/page'),
+  ),
+  'login-sso': lazy(
+    () => import('../../../../packages/cli/templates/pages/login-sso/page'),
+  ),
+  'mixed-gallery': lazy(
+    () => import('../../../../packages/cli/templates/pages/mixed-gallery/page'),
+  ),
+  'payment-form': lazy(
+    () => import('../../../../packages/cli/templates/pages/payment-form/page'),
+  ),
+  'product-detail': lazy(
+    () =>
+      import('../../../../packages/cli/templates/pages/product-detail/page'),
+  ),
+  'product-gallery': lazy(
+    () =>
+      import('../../../../packages/cli/templates/pages/product-gallery/page'),
+  ),
+  settings: lazy(
+    () => import('../../../../packages/cli/templates/pages/settings/page'),
+  ),
+  'settings-dialog': lazy(
+    () =>
+      import('../../../../packages/cli/templates/pages/settings-dialog/page'),
+  ),
+  'settings-sidebar': lazy(
+    () =>
+      import('../../../../packages/cli/templates/pages/settings-sidebar/page'),
+  ),
+  'side-gallery': lazy(
+    () => import('../../../../packages/cli/templates/pages/side-gallery/page'),
+  ),
+  table: lazy(
+    () => import('../../../../packages/cli/templates/pages/table/page'),
+  ),
+  'table-grouped': lazy(
+    () => import('../../../../packages/cli/templates/pages/table-grouped/page'),
+  ),
+  'table-page': lazy(
+    () => import('../../../../packages/cli/templates/pages/table-page/page'),
+  ),
+};
+
+export function TemplateThumbnail({slug}: {slug: string}) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [renderWidth, setRenderWidth] = useState(0);
+  const [isVisible, setIsVisible] = useState(false);
+
+  const updateWidth = useCallback(() => {
+    if (containerRef.current) {
+      setRenderWidth(containerRef.current.offsetWidth / FIXED_SCALE);
+    }
+  }, []);
+
+  // Intersection observer: track visibility for Activity mode
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => setIsVisible(entry.isIntersecting),
+      {rootMargin: '200px'},
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  // Measure container width to compute render width
+  useEffect(() => {
+    updateWidth();
+    const el = containerRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver(updateWidth);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [updateWidth]);
+
+  const Component = TEMPLATE_COMPONENTS[slug];
+  if (!Component) return null;
+
+  return (
+    <div ref={containerRef} {...stylex.props(styles.container)} inert>
+      {renderWidth > 0 && isVisible && (
+        <div
+          {...stylex.props(styles.scaler)}
+          style={{width: renderWidth, transform: `scale(${FIXED_SCALE})`}}>
+          <Suspense
+            fallback={
+              <div {...stylex.props(styles.skeleton)}>
+                <XDSSkeleton width="100%" height="100%" />
+              </div>
+            }>
+            <Component />
+          </Suspense>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Render template previews directly in the craft grid as real React components, no iframes.

## How it works
`TemplateThumbnail` renders each template at 1920×1200 then scales down with `transform: scale()`. Templates are lazy-loaded from `packages/cli/templates/pages/`.

## Performance optimizations
- **React `<Activity>`** — `mode='hidden'` suspends effects for off-screen thumbnails
- **`content-visibility: auto`** — browser skips paint/layout for off-screen containers
- **`inert`** attribute — browser skips hit-testing/focus for all thumbnails
- **`IntersectionObserver`** with 200px rootMargin toggles Activity visibility
- **`React.lazy` + `Suspense`** — code-split per template, skeleton fallback
- **Shared CSS/JS** — all previews share the same document, no iframe overhead

No iframes, no duplicate resource loading, no N parallel page loads.