### PR TITLE
fix(docsite): parent hook docs to their component

### DIFF
--- a/apps/docsite/scripts/generate-data.mjs
+++ b/apps/docsite/scripts/generate-data.mjs
@@ -216,6 +216,21 @@ async function generateComponentRegistry() {
       const docFiles = fs.readdirSync(dirPath).filter(f => f.endsWith('.doc.mjs'));
       if (docFiles.length === 0) continue;
 
+      // First pass: find the primary component doc name for this directory
+      // (used to parent standalone hook docs that share the directory)
+      let dirPrimaryDoc = null;
+      for (const df of docFiles) {
+        const dfPath = path.join(dirPath, df);
+        try {
+          const mod = await import(pathToFileURL(dfPath).href);
+          const d = mod.docs;
+          if (d && (d.components || d.props) && !d.params) {
+            dirPrimaryDoc = d.name || null;
+            break;
+          }
+        } catch { /* ignore */ }
+      }
+
       for (const docFileName of docFiles) {
         const docFile = path.join(dirPath, docFileName);
 
@@ -261,7 +276,7 @@ async function generateComponentRegistry() {
             });
           }
         } else if (doc.params) {
-          // HookDoc — standalone hook
+          // HookDoc — parent to the component doc in the same directory
           const name = doc.name || docFileName.replace('.doc.mjs', '');
           standaloneNames.add(name);
           components.push({
@@ -272,7 +287,7 @@ async function generateComponentRegistry() {
             description: topDescription,
             keywords,
             hidden,
-            parentDoc: null,
+            parentDoc: dirPrimaryDoc,
             props: [],
             usage,
             theming: null,

--- a/packages/core/src/HoverCard/HoverCard.doc.mjs
+++ b/packages/core/src/HoverCard/HoverCard.doc.mjs
@@ -85,64 +85,6 @@ export const docs = {
         },
       ],
     },
-    {
-      name: 'useXDSHoverCard',
-      description:
-        'Hook for hover card behavior with hover/focus triggers. Builds on useXDSLayer.',
-      props: [
-        {
-          name: 'placement',
-          type: 'LayerPlacement',
-          description: 'Position relative to the anchor element.',
-          default: "'above'",
-        },
-        {
-          name: 'alignment',
-          type: 'LayerAlignment',
-          description: 'Alignment along the placement axis.',
-          default: "'center'",
-        },
-        {
-          name: 'delay',
-          type: 'number',
-          description: 'Show delay in milliseconds.',
-          default: '300',
-        },
-        {
-          name: 'hideDelay',
-          type: 'number',
-          description: 'Hide delay in milliseconds.',
-          default: '200',
-        },
-        {
-          name: 'focusTrigger',
-          type: "'auto' | 'always' | 'never'",
-          description: 'Controls when focus events trigger the layer.',
-          default: "'auto'",
-        },
-        {
-          name: 'isEnabled',
-          type: 'boolean',
-          description: 'Enables or disables all hover and focus triggers.',
-          default: 'true',
-        },
-        {
-          name: 'isDefaultOpen',
-          type: 'boolean',
-          description: 'Whether the hover card should be shown on mount. Still dismissible.',
-        },
-        {
-          name: 'onShow',
-          type: '() => void',
-          description: 'Callback fired when the hover card becomes visible.',
-        },
-        {
-          name: 'onHide',
-          type: '() => void',
-          description: 'Callback fired when the hover card is hidden.',
-        },
-      ],
-    },
   ],
   usage: {
     description: 'HoverCard shows additional information when the user hovers or focuses a trigger element. Use it for profile cards, link summaries, or inline definitions where the user needs more context without navigating away.',
@@ -249,64 +191,6 @@ export const docsZh = {
         },
       ],
     },
-    {
-      name: 'useXDSHoverCard',
-      description:
-        '具有悬停/聚焦触发行为的悬浮卡片 Hook，基于 useXDSLayer 构建。',
-      props: [
-        {
-          name: 'placement',
-          type: 'LayerPlacement',
-          description: '相对于锚点元素的位置。',
-          default: "'above'",
-        },
-        {
-          name: 'alignment',
-          type: 'LayerAlignment',
-          description: '沿放置轴的对齐方式。',
-          default: "'center'",
-        },
-        {
-          name: 'delay',
-          type: 'number',
-          description: '显示延迟（毫秒）。',
-          default: '300',
-        },
-        {
-          name: 'hideDelay',
-          type: 'number',
-          description: '隐藏延迟（毫秒）。',
-          default: '200',
-        },
-        {
-          name: 'focusTrigger',
-          type: "'auto' | 'always' | 'never'",
-          description: '控制焦点事件何时触发浮层。',
-          default: "'auto'",
-        },
-        {
-          name: 'isEnabled',
-          type: 'boolean',
-          description: '启用或禁用所有悬停和聚焦触发器。',
-          default: 'true',
-        },
-        {
-          name: 'isDefaultOpen',
-          type: 'boolean',
-          description: '是否在挂载时显示悬浮卡片。仍然可以关闭。',
-        },
-        {
-          name: 'onShow',
-          type: '() => void',
-          description: '悬浮卡片显示时触发的回调。',
-        },
-        {
-          name: 'onHide',
-          type: '() => void',
-          description: '悬浮卡片隐藏时触发的回调。',
-        },
-      ],
-    },
   ],
   usage: {
     description: 'HoverCard shows additional information when the user hovers or focuses a trigger element. Use it for profile cards, link summaries, or inline definitions where the user needs more context without navigating away.',
@@ -348,21 +232,6 @@ export const docsDense = {
         onOpenChange: 'Callback when visibility changes; true=shown, false=hidden.',
         hasHoverIndication: 'Dashed underline on trigger element.',
         isDefaultOpen: 'Show hover card on mount. Still dismissible.',
-      },
-    },
-    {
-      name: 'useXDSHoverCard',
-      description: 'Hook for hover card w/ hover/focus triggers. Builds on useXDSLayer.',
-      propDescriptions: {
-        placement: 'Position relative to anchor element.',
-        alignment: 'Alignment along placement axis.',
-        delay: 'Show delay in ms.',
-        hideDelay: 'Hide delay in ms.',
-        focusTrigger: 'Controls when focus events trigger layer.',
-        isEnabled: 'Enable/disable all hover + focus triggers.',
-        isDefaultOpen: 'Show hover card on mount. Still dismissible.',
-        onShow: 'Callback when hover card becomes visible.',
-        onHide: 'Callback when hover card hidden.',
       },
     },
   ],

--- a/packages/core/src/Popover/Popover.doc.mjs
+++ b/packages/core/src/Popover/Popover.doc.mjs
@@ -90,52 +90,6 @@ export const docs = {
         },
       ],
     },
-    {
-      name: 'useXDSPopover',
-      description:
-        'Hook for creating popover dialogs with focus trapping. Combines useXDSLayer with useFocusTrap.',
-      props: [
-        {
-          name: 'onShow',
-          type: '() => void',
-          description: 'Callback fired when popover is shown.',
-        },
-        {
-          name: 'onHide',
-          type: '() => void',
-          description: 'Callback fired when popover is hidden.',
-        },
-        {
-          name: 'hasLightDismiss',
-          type: 'boolean',
-          description: 'Whether clicking outside should dismiss the popover.',
-          default: 'true',
-        },
-        {
-          name: 'hasAutoFocus',
-          type: 'boolean',
-          description: 'Whether to auto-focus the first focusable element when opened.',
-          default: 'true',
-        },
-        {
-          name: 'hasCloseButton',
-          type: 'boolean',
-          description: 'Whether to include a hidden close button for accessibility.',
-          default: 'true',
-        },
-        {
-          name: 'closeButtonLabel',
-          type: 'string',
-          description: 'Label for the hidden close button.',
-          default: "'Close popover'",
-        },
-        {
-          name: 'dialogLabel',
-          type: 'string',
-          description: 'Accessible label for the dialog.',
-        },
-      ],
-    },
   ],
   theming: {
     targets: [
@@ -252,52 +206,6 @@ export const docsZh = {
         },
       ],
     },
-    {
-      name: 'useXDSPopover',
-      description:
-        '用于创建带焦点捕获的弹出框对话框的钩子。将 useXDSLayer 与 useFocusTrap 结合使用。',
-      props: [
-        {
-          name: 'onShow',
-          type: '() => void',
-          description: '弹出框显示时触发的回调。',
-        },
-        {
-          name: 'onHide',
-          type: '() => void',
-          description: '弹出框隐藏时触发的回调。',
-        },
-        {
-          name: 'hasLightDismiss',
-          type: 'boolean',
-          description: '点击外部是否应关闭弹出框。',
-          default: 'true',
-        },
-        {
-          name: 'hasAutoFocus',
-          type: 'boolean',
-          description: '打开时是否自动聚焦第一个可聚焦元素。',
-          default: 'true',
-        },
-        {
-          name: 'hasCloseButton',
-          type: 'boolean',
-          description: '是否包含用于无障碍访问的隐藏关闭按钮。',
-          default: 'true',
-        },
-        {
-          name: 'closeButtonLabel',
-          type: 'string',
-          description: '隐藏关闭按钮的标签。',
-          default: "'Close popover'",
-        },
-        {
-          name: 'dialogLabel',
-          type: 'string',
-          description: '对话框的无障碍标签。',
-        },
-      ],
-    },
   ],
   theming: {
     targets: [
@@ -367,20 +275,6 @@ export const docsDense = {
         hasCloseButton: 'Whether to include hidden close button for accessibility.',
         closeButtonLabel: 'Label for hidden close button.',
         hasAutoFocus: 'Auto-focus first element on open; false for showcases.',
-      },
-    },
-    {
-      name: 'useXDSPopover',
-      description:
-        'Hook for popover dialogs w/ focus trapping. Combines useXDSLayer w/ useFocusTrap.',
-      propDescriptions: {
-        onShow: 'Callback fired when popover shown.',
-        onHide: 'Callback fired when popover hidden.',
-        hasLightDismiss: 'Whether clicking outside dismisses popover.',
-        hasAutoFocus: 'Whether to auto-focus first focusable element when opened.',
-        hasCloseButton: 'Whether to include hidden close button for accessibility.',
-        closeButtonLabel: 'Label for hidden close button.',
-        dialogLabel: 'Accessible label for dialog.',
       },
     },
   ],

--- a/packages/core/src/Tooltip/Tooltip.doc.mjs
+++ b/packages/core/src/Tooltip/Tooltip.doc.mjs
@@ -78,64 +78,6 @@ export const docs = {
         },
       ],
     },
-    {
-      name: 'useXDSTooltip',
-      description:
-        'Hook for tooltip behavior with hover/focus triggers. Builds on useXDSLayer.',
-      props: [
-        {
-          name: 'placement',
-          type: 'LayerPlacement',
-          description: 'Position relative to the anchor element.',
-          default: "'above'",
-        },
-        {
-          name: 'alignment',
-          type: 'LayerAlignment',
-          description: 'Alignment along the placement axis.',
-          default: "'center'",
-        },
-        {
-          name: 'delay',
-          type: 'number',
-          description: 'Show delay in milliseconds.',
-          default: '200',
-        },
-        {
-          name: 'hideDelay',
-          type: 'number',
-          description: 'Hide delay in milliseconds.',
-          default: '0',
-        },
-        {
-          name: 'focusTrigger',
-          type: "'auto' | 'always' | 'never'",
-          description: 'Controls when focus events trigger the tooltip.',
-          default: "'auto'",
-        },
-        {
-          name: 'isEnabled',
-          type: 'boolean',
-          description: 'Enables or disables all hover and focus triggers.',
-          default: 'true',
-        },
-        {
-          name: 'isDefaultOpen',
-          type: 'boolean',
-          description: 'Whether the tooltip should be shown on mount. Still dismissible.',
-        },
-        {
-          name: 'onShow',
-          type: '() => void',
-          description: 'Callback fired when the tooltip becomes visible.',
-        },
-        {
-          name: 'onHide',
-          type: '() => void',
-          description: 'Callback fired when the tooltip is hidden.',
-        },
-      ],
-    },
   ],
   theming: {
     targets: [
@@ -233,64 +175,6 @@ export const docsZh = {
         },
       ],
     },
-    {
-      name: 'useXDSTooltip',
-      description:
-        '用于悬停/聚焦触发的工具提示行为的钩子。基于 useXDSLayer 构建。',
-      props: [
-        {
-          name: 'placement',
-          type: 'LayerPlacement',
-          description: '相对于锚点元素的位置。',
-          default: "'above'",
-        },
-        {
-          name: 'alignment',
-          type: 'LayerAlignment',
-          description: '沿放置轴的对齐方式。',
-          default: "'center'",
-        },
-        {
-          name: 'delay',
-          type: 'number',
-          description: '显示延迟（毫秒）。',
-          default: '200',
-        },
-        {
-          name: 'hideDelay',
-          type: 'number',
-          description: '隐藏延迟（毫秒）。',
-          default: '0',
-        },
-        {
-          name: 'focusTrigger',
-          type: "'auto' | 'always' | 'never'",
-          description: '控制聚焦事件何时触发工具提示。',
-          default: "'auto'",
-        },
-        {
-          name: 'isEnabled',
-          type: 'boolean',
-          description: '启用或禁用所有悬停和聚焦触发器。',
-          default: 'true',
-        },
-        {
-          name: 'isDefaultOpen',
-          type: 'boolean',
-          description: '是否在挂载时显示工具提示。仍然可以关闭。',
-        },
-        {
-          name: 'onShow',
-          type: '() => void',
-          description: '工具提示变为可见时触发的回调。',
-        },
-        {
-          name: 'onHide',
-          type: '() => void',
-          description: '工具提示隐藏时触发的回调。',
-        },
-      ],
-    },
   ],
   theming: {
     targets: [
@@ -339,21 +223,6 @@ export const docsDense = {
         onOpenChange: 'Callback when visibility changes; true=shown, false=hidden.',
         hasHoverIndication: 'Dashed underline on trigger element.',
         isDefaultOpen: 'Show tooltip on mount. Still dismissible.',
-      },
-    },
-    {
-      name: 'useXDSTooltip',
-      description: 'Hook for tooltip w/ hover/focus triggers. Builds on useXDSLayer.',
-      propDescriptions: {
-        placement: 'Position relative to anchor.',
-        alignment: 'Alignment along placement axis.',
-        delay: 'Show delay in ms.',
-        hideDelay: 'Hide delay in ms.',
-        focusTrigger: 'Controls when focus events trigger tooltip.',
-        isEnabled: 'Enables/disables all hover+focus triggers.',
-        isDefaultOpen: 'Show tooltip on mount. Still dismissible.',
-        onShow: 'Fired when tooltip becomes visible.',
-        onHide: 'Fired when tooltip hidden.',
       },
     },
   ],


### PR DESCRIPTION
Hooks like `useXDSTooltip`, `useXDSHoverCard`, and `useXDSPopover` have their own `.doc.mjs` files but were appearing as standalone top-level entries in the component list instead of being grouped under their parent component (Tooltip, HoverCard, Popover).

## Changes

**Pipeline (`generate-data.mjs`):** Standalone hook docs (`HookDoc` with `params`) now inherit `parentDoc` from the component doc in the same directory. Hooks in directories with no component doc (e.g. `hooks/`) remain standalone.

**Doc files (Tooltip, HoverCard, Popover):** Removed duplicate `useXDS*` entries from the parent component's `components[]` array across all three translations (`docs`, `docsZh`, `docsDense`). The hooks have their own dedicated `.doc.mjs` files with richer metadata (`params`, `returns`, `relatedComponents`, etc.) so the duplication was unnecessary.

## Result

- `useXDSTooltip` → `parentDoc: "Tooltip"`
- `useXDSHoverCard` → `parentDoc: "HoverCard"`
- `useXDSPopover` → `parentDoc: "Popover"`
- Standalone hooks in `hooks/` dir → unchanged (`parentDoc: null`)
- Component count unchanged (172) — hooks are still in the registry, just parented