### PR TITLE
fix(docsite): remove sub-components section + mobile-friendly hook params

### DIFF
--- a/apps/docsite/src/app/(docs)/components/[name]/page.tsx
+++ b/apps/docsite/src/app/(docs)/components/[name]/page.tsx
@@ -25,7 +25,6 @@ export default async function ComponentPage({
   const comp = allComponents.find(c => c.name === name);
   if (!comp) notFound();
 
-  const subComponents = allComponents.filter(c => c.parentDoc === name);
   const pkg = Object.entries(components).find(([, comps]) =>
     comps.includes(comp),
   )?.[0];
@@ -40,7 +39,6 @@ export default async function ComponentPage({
       comp={comp}
       pkg={pkg}
       pkgVersion={pkgVersion}
-      subComponents={subComponents}
       showcase={showcase}
     />
   );

--- a/apps/docsite/src/components/component-detail/ComponentDetailClient.tsx
+++ b/apps/docsite/src/components/component-detail/ComponentDetailClient.tsx
@@ -28,14 +28,12 @@ interface ComponentDetailClientProps {
   comp: ComponentEntry;
   pkg: string | undefined;
   pkgVersion: string | undefined;
-  subComponents: ComponentEntry[];
   showcase: BlockEntry | undefined;
 }
 
 function OverviewContent({
   comp,
   pkg,
-  subComponents,
   showcase: _showcase,
   hasShowcase,
 }: ComponentDetailClientProps & {hasShowcase: boolean}) {
@@ -69,33 +67,6 @@ function OverviewContent({
         <HookSignature params={comp.params} returns={comp.returns} />
       )}
 
-      {subComponents.length > 0 && (
-        <>
-          <XDSDivider />
-          <XDSVStack gap={6}>
-            <XDSVStack gap={2}>
-              <XDSHeading level={2}>Sub-components</XDSHeading>
-              <XDSText type="large" weight="normal">
-                {comp.moduleName.replace(/^XDS/, '')} is a compound component
-                with {subComponents.length} sub-component
-                {subComponents.length === 1 ? '' : 's'}.
-              </XDSText>
-            </XDSVStack>
-            {subComponents.map(sub => (
-              <XDSVStack key={sub.name} gap={3}>
-                <XDSVStack gap={1}>
-                  <XDSHeading level={3}>{sub.moduleName}</XDSHeading>
-                  <XDSText type="body" color="secondary">
-                    {sub.description}
-                  </XDSText>
-                </XDSVStack>
-                {sub.props.length > 0 && <PropsTable props={sub.props} />}
-              </XDSVStack>
-            ))}
-          </XDSVStack>
-        </>
-      )}
-
       {(exampleRegistry[comp.name] || []).length > 0 && (
         <>
           <XDSDivider />
@@ -120,7 +91,6 @@ function ComponentDetailInner({
   comp,
   pkg,
   pkgVersion,
-  subComponents,
   showcase,
 }: ComponentDetailClientProps) {
   const searchParams = useSearchParams();
@@ -176,7 +146,6 @@ function ComponentDetailInner({
                 comp={comp}
                 pkg={pkg}
                 pkgVersion={pkgVersion}
-                subComponents={subComponents}
                 showcase={showcase}
                 hasShowcase={hasShowcase}
               />
@@ -220,7 +189,6 @@ function ComponentDetailInner({
               comp={comp}
               pkg={pkg}
               pkgVersion={pkgVersion}
-              subComponents={subComponents}
               showcase={showcase}
               hasShowcase={hasShowcase}
             />

--- a/apps/docsite/src/components/component-detail/HookSignature.tsx
+++ b/apps/docsite/src/components/component-detail/HookSignature.tsx
@@ -5,6 +5,8 @@ import {XDSVStack, XDSHStack} from '@xds/core/Layout';
 import {XDSSection} from '@xds/core/Section';
 import {XDSTable, pixel} from '@xds/core/Table';
 import {XDSBadge} from '@xds/core/Badge';
+import {XDSDivider} from '@xds/core';
+import {useMediaQuery} from '@xds/core/hooks';
 import type {
   HookParamDoc,
   HookReturnDoc,
@@ -22,7 +24,48 @@ function formatParamType(type: string, defaultValue?: string): string {
   return type;
 }
 
+function ParamRowMobile({param}: {param: HookParamDoc}) {
+  return (
+    <XDSVStack gap={1} style={{paddingBlock: 8}}>
+      <XDSHStack gap={1} vAlign="center">
+        <XDSText type="code" weight="bold">
+          {param.name}
+        </XDSText>
+        {param.required && <XDSBadge label="required" variant="info" />}
+      </XDSHStack>
+      <XDSText type="code" color="secondary">
+        {formatParamType(param.type, param.default)}
+      </XDSText>
+      {param.description && (
+        <XDSText type="body" color="secondary">
+          {param.description}
+        </XDSText>
+      )}
+    </XDSVStack>
+  );
+}
+
+function ReturnRowMobile({ret}: {ret: HookReturnDoc}) {
+  return (
+    <XDSVStack gap={1} style={{paddingBlock: 8}}>
+      <XDSText type="code" weight="bold">
+        {ret.name}
+      </XDSText>
+      <XDSText type="code" color="secondary">
+        {ret.type}
+      </XDSText>
+      {ret.description && (
+        <XDSText type="body" color="secondary">
+          {ret.description}
+        </XDSText>
+      )}
+    </XDSVStack>
+  );
+}
+
 export function HookSignature({params, returns}: HookSignatureProps) {
+  const isMobile = useMediaQuery('(max-width: 768px)');
+
   const paramData = params.map(p => ({
     name: p.name as unknown,
     required: p.required as unknown,
@@ -42,39 +85,48 @@ export function HookSignature({params, returns}: HookSignatureProps) {
         <XDSSection>
           <XDSVStack gap={2}>
             <XDSHeading level={3}>Parameters</XDSHeading>
-            <XDSTable
-              data={paramData}
-              columns={[
-                {
-                  key: 'name',
-                  header: 'Param',
-                  width: pixel(160),
-                  renderCell: (item: Record<string, unknown>) => (
-                    <XDSHStack gap={1} vAlign="center">
-                      <XDSText type="code" weight="bold">
-                        {item.name as string}
+            {isMobile ? (
+              params.map(p => (
+                <div key={p.name}>
+                  <XDSDivider />
+                  <ParamRowMobile param={p} />
+                </div>
+              ))
+            ) : (
+              <XDSTable
+                data={paramData}
+                columns={[
+                  {
+                    key: 'name',
+                    header: 'Param',
+                    width: pixel(160),
+                    renderCell: (item: Record<string, unknown>) => (
+                      <XDSHStack gap={1} vAlign="center">
+                        <XDSText type="code" weight="bold">
+                          {item.name as string}
+                        </XDSText>
+                        {item.required === true && (
+                          <XDSBadge label="required" variant="info" />
+                        )}
+                      </XDSHStack>
+                    ),
+                  },
+                  {
+                    key: 'type',
+                    header: 'Type',
+                    width: pixel(240),
+                    renderCell: (item: Record<string, unknown>) => (
+                      <XDSText type="code" color="secondary">
+                        {item.type as string}
                       </XDSText>
-                      {item.required === true && (
-                        <XDSBadge label="required" variant="info" />
-                      )}
-                    </XDSHStack>
-                  ),
-                },
-                {
-                  key: 'type',
-                  header: 'Type',
-                  width: pixel(240),
-                  renderCell: (item: Record<string, unknown>) => (
-                    <XDSText type="code" color="secondary">
-                      {item.type as string}
-                    </XDSText>
-                  ),
-                },
-                {key: 'description', header: 'Description'},
-              ]}
-              density="spacious"
-              dividers="rows"
-            />
+                    ),
+                  },
+                  {key: 'description', header: 'Description'},
+                ]}
+                density="spacious"
+                dividers="rows"
+              />
+            )}
           </XDSVStack>
         </XDSSection>
       )}
@@ -82,34 +134,43 @@ export function HookSignature({params, returns}: HookSignatureProps) {
         <XDSSection>
           <XDSVStack gap={2}>
             <XDSHeading level={3}>Returns</XDSHeading>
-            <XDSTable
-              data={returnData}
-              columns={[
-                {
-                  key: 'name',
-                  header: 'Field',
-                  width: pixel(160),
-                  renderCell: (item: Record<string, unknown>) => (
-                    <XDSText type="code" weight="bold">
-                      {item.name as string}
-                    </XDSText>
-                  ),
-                },
-                {
-                  key: 'type',
-                  header: 'Type',
-                  width: pixel(240),
-                  renderCell: (item: Record<string, unknown>) => (
-                    <XDSText type="code" color="secondary">
-                      {item.type as string}
-                    </XDSText>
-                  ),
-                },
-                {key: 'description', header: 'Description'},
-              ]}
-              density="spacious"
-              dividers="rows"
-            />
+            {isMobile ? (
+              returns.map(r => (
+                <div key={r.name}>
+                  <XDSDivider />
+                  <ReturnRowMobile ret={r} />
+                </div>
+              ))
+            ) : (
+              <XDSTable
+                data={returnData}
+                columns={[
+                  {
+                    key: 'name',
+                    header: 'Field',
+                    width: pixel(160),
+                    renderCell: (item: Record<string, unknown>) => (
+                      <XDSText type="code" weight="bold">
+                        {item.name as string}
+                      </XDSText>
+                    ),
+                  },
+                  {
+                    key: 'type',
+                    header: 'Type',
+                    width: pixel(240),
+                    renderCell: (item: Record<string, unknown>) => (
+                      <XDSText type="code" color="secondary">
+                        {item.type as string}
+                      </XDSText>
+                    ),
+                  },
+                  {key: 'description', header: 'Description'},
+                ]}
+                density="spacious"
+                dividers="rows"
+              />
+            )}
           </XDSVStack>
         </XDSSection>
       )}


### PR DESCRIPTION
Two cleanup changes for the component detail page.

## 1. Remove sub-components section

The overview tab previously showed a "Sub-components" section listing all child components of a compound doc (e.g. Dialog → DialogHeader, DialogFooter) with their full props tables inline. Since each sub-component already has its own page with examples and playground, this duplicated content.

Removed: the section, the `subComponents` prop threading from page → client → overview, and the now-unused `PropsTable` import.

## 2. Mobile-friendly hook params/returns

`HookSignature` tables (Parameters, Returns) now switch to a stacked single-column layout on mobile (≤768px), matching the pattern used by `PlaygroundPropsTable`. Each param/return shows name, type, and description stacked vertically with dividers between items.