### PR TITLE
feat(cli): add showcases for Theme, MediaTheme, and SyntaxTheme

### DIFF
--- a/apps/docsite/src/__tests__/data-extraction.test.ts
+++ b/apps/docsite/src/__tests__/data-extraction.test.ts
@@ -599,7 +599,7 @@ describe('exampleRegistry', () => {
     // Just verify count makes sense: examples + showcases ≈ total blocks
     const showcaseCount = Object.keys(showcaseRegistry).length;
     const exampleCount = Object.values(exampleRegistry).flat().length;
-    expect(exampleCount + showcaseCount).toBeLessThanOrEqual(468);
+    expect(exampleCount + showcaseCount).toBeLessThanOrEqual(blockCount);
     expect(exampleCount).toBeGreaterThan(showcaseCount);
   });
 });

--- a/packages/cli/src/commands/component-resolution.test.mjs
+++ b/packages/cli/src/commands/component-resolution.test.mjs
@@ -163,10 +163,10 @@ describe('component() blocks integration', () => {
     expect(result.data.showcase.name).toMatch(/ClickableCard/);
   });
 
-  it('component with no blocks returns null showcase and empty arrays', async () => {
+  it('component with showcase returns showcase data', async () => {
     const result = await component('Theme', {...CWD, blocks: true});
-    expect(result.data.showcase).toBeNull();
-    expect(result.data.examples).toEqual([]);
-    expect(result.data.related).toEqual([]);
+    expect(result.data.showcase).not.toBeNull();
+    expect(result.data.showcase.name).toBe('ThemeShowcase');
+    expect(result.data.showcase.isShowcase).toBe(true);
   });
 });

--- a/packages/cli/templates/blocks/components/MediaTheme/MediaThemeShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/MediaTheme/MediaThemeShowcase.doc.mjs
@@ -1,0 +1,12 @@
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  exampleFor: 'MediaTheme',
+  name: 'MediaTheme — Inverted Surfaces',
+  description:
+    'Content rendered over inverted surfaces — dark backgrounds (media, overlays, toasts) and light scrims. XDSMediaTheme provides the correct token overrides so text and controls remain legible.',
+  isReady: true,
+  isShowcase: true,
+  aspectRatio: 16 / 9,
+  componentsUsed: ['MediaTheme', 'Section', 'Layout', 'Text', 'Button'],
+};

--- a/packages/cli/templates/blocks/components/MediaTheme/MediaThemeShowcase.tsx
+++ b/packages/cli/templates/blocks/components/MediaTheme/MediaThemeShowcase.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import {XDSMediaTheme} from '@xds/core/theme';
+import {XDSSection} from '@xds/core/Section';
+import {XDSStack} from '@xds/core/Layout';
+import {XDSText} from '@xds/core/Text';
+import {XDSButton} from '@xds/core/Button';
+
+export default function MediaThemeShowcase() {
+  return (
+    <XDSStack direction="horizontal" gap={4} vAlign="stretch">
+      <XDSSection
+        variant="transparent"
+        padding={4}
+        style={{
+          flex: 1,
+          backgroundColor: 'var(--color-background-inverted)',
+          borderRadius: 'var(--radius-container)',
+        }}>
+        <XDSMediaTheme mode="dark">
+          <XDSStack direction="vertical" gap={2}>
+            <XDSText type="body" weight="bold">
+              Dark surface
+            </XDSText>
+            <XDSText type="supporting" color="secondary">
+              Content over media, overlays, or inverted backgrounds like toasts
+              and tooltips.
+            </XDSText>
+            <XDSButton label="Action" variant="ghost" />
+          </XDSStack>
+        </XDSMediaTheme>
+      </XDSSection>
+      <XDSSection variant="wash" padding={4} style={{flex: 1}}>
+        <XDSMediaTheme mode="light">
+          <XDSStack direction="vertical" gap={2}>
+            <XDSText type="body" weight="bold">
+              Light surface
+            </XDSText>
+            <XDSText type="supporting" color="secondary">
+              Content on light overlays or scrims where the background is
+              bright.
+            </XDSText>
+            <XDSButton label="Action" variant="ghost" />
+          </XDSStack>
+        </XDSMediaTheme>
+      </XDSSection>
+    </XDSStack>
+  );
+}

--- a/packages/cli/templates/blocks/components/SyntaxTheme/SyntaxThemeShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/SyntaxTheme/SyntaxThemeShowcase.doc.mjs
@@ -1,0 +1,12 @@
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  exampleFor: 'SyntaxTheme',
+  name: 'SyntaxTheme — Presets',
+  description:
+    'The same code block rendered with three different syntax themes — GitHub Light, One Dark Pro, and Dracula — showing how XDSSyntaxTheme changes code highlighting colors.',
+  isReady: true,
+  isShowcase: true,
+  aspectRatio: 4 / 3,
+  componentsUsed: ['SyntaxTheme', 'CodeBlock', 'Layout', 'Text'],
+};

--- a/packages/cli/templates/blocks/components/SyntaxTheme/SyntaxThemeShowcase.tsx
+++ b/packages/cli/templates/blocks/components/SyntaxTheme/SyntaxThemeShowcase.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import {XDSSyntaxTheme} from '@xds/core/theme';
+import {oneDarkPro, githubLight, dracula} from '@xds/core/theme/syntax';
+import {XDSCodeBlock} from '@xds/core/CodeBlock';
+import {XDSStack} from '@xds/core/Layout';
+import {XDSText} from '@xds/core/Text';
+
+const sampleCode = `import {XDSButton} from '@xds/core/Button';
+
+export function App() {
+  return (
+    <XDSButton
+      label="Hello XDS"
+      variant="primary"
+      onClick={() => console.log('clicked')}
+    />
+  );
+}`;
+
+function ThemePreview({
+  theme,
+  label,
+}: {
+  theme: Parameters<typeof XDSSyntaxTheme>[0]['theme'];
+  label: string;
+}) {
+  return (
+    <XDSSyntaxTheme theme={theme}>
+      <XDSStack direction="vertical" gap={1}>
+        <XDSText type="supporting" weight="bold" color="secondary">
+          {label}
+        </XDSText>
+        <XDSCodeBlock code={sampleCode} language="tsx" />
+      </XDSStack>
+    </XDSSyntaxTheme>
+  );
+}
+
+export default function SyntaxThemeShowcase() {
+  return (
+    <XDSStack direction="vertical" gap={4}>
+      <ThemePreview theme={githubLight} label="GitHub Light" />
+      <ThemePreview theme={oneDarkPro} label="One Dark Pro" />
+      <ThemePreview theme={dracula} label="Dracula" />
+    </XDSStack>
+  );
+}

--- a/packages/cli/templates/blocks/components/Theme/ThemeShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/Theme/ThemeShowcase.doc.mjs
@@ -1,0 +1,12 @@
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  exampleFor: 'Theme',
+  name: 'Theme — Side by Side',
+  description:
+    'Two theme providers wrapping identical content to show how XDSTheme changes the visual treatment of all child components.',
+  isReady: true,
+  isShowcase: true,
+  aspectRatio: 16 / 9,
+  componentsUsed: ['Theme', 'Card', 'Layout', 'Text', 'Button', 'Badge'],
+};

--- a/packages/cli/templates/blocks/components/Theme/ThemeShowcase.tsx
+++ b/packages/cli/templates/blocks/components/Theme/ThemeShowcase.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import {XDSTheme} from '@xds/core/theme';
+import {XDSCard} from '@xds/core/Card';
+import {XDSStack} from '@xds/core/Layout';
+import {XDSHeading, XDSText} from '@xds/core/Text';
+import {XDSButton} from '@xds/core/Button';
+import {XDSBadge} from '@xds/core/Badge';
+import {defaultTheme} from '@xds/theme-default/built';
+import {neutralTheme} from '@xds/theme-neutral/built';
+
+function ThemeCard({label}: {label: string}) {
+  return (
+    <XDSCard padding={4}>
+      <XDSStack direction="vertical" gap={3}>
+        <XDSStack direction="horizontal" gap={2} vAlign="center">
+          <XDSHeading level={4}>{label}</XDSHeading>
+          <XDSBadge label="Active" variant="success" />
+        </XDSStack>
+        <XDSText type="body" color="secondary">
+          Components inherit colors, typography, and radius from the nearest
+          theme provider.
+        </XDSText>
+        <XDSStack direction="horizontal" gap={2}>
+          <XDSButton label="Primary" variant="primary" />
+          <XDSButton label="Secondary" variant="secondary" />
+          <XDSButton label="Ghost" variant="ghost" />
+        </XDSStack>
+      </XDSStack>
+    </XDSCard>
+  );
+}
+
+export default function ThemeShowcase() {
+  return (
+    <XDSStack direction="horizontal" gap={4}>
+      <XDSTheme theme={defaultTheme}>
+        <ThemeCard label="Default" />
+      </XDSTheme>
+      <XDSTheme theme={neutralTheme}>
+        <ThemeCard label="Neutral" />
+      </XDSTheme>
+    </XDSStack>
+  );
+}

--- a/packages/core/src/theme/MediaTheme.doc.mjs
+++ b/packages/core/src/theme/MediaTheme.doc.mjs
@@ -3,12 +3,19 @@
 export const docs = {
   name: 'MediaTheme',
   group: 'Utilities',
-  keywords: ['theme', 'dark-mode', 'light-mode', 'media', 'prefers-color-scheme'],
+  keywords: ['theme', 'dark-mode', 'light-mode', 'media', 'inverted', 'overlay', 'scrim', 'toast', 'tooltip'],
   usage: {
-    description: 'Applies a theme that adapts to the system light/dark preference via prefers-color-scheme.',
+    description:
+      'Provides token overrides for content rendered on inverted surfaces — media overlays, scrims, toasts, and tooltips. The base behavior flips color-scheme so all light-dark() tokens resolve to the correct side. Only a small set of tokens need explicit overrides beyond that. Themes can further customize component appearance on media surfaces via onDark/onLight in defineTheme(), with both token overrides (e.g. "--color-accent": "#90CAF9") and component overrides (e.g. ghost buttons get a border on dark surfaces).',
+    bestPractices: [
+      {guidance: true, description: 'Use for any content placed over a dark background (image overlays, video scrims, dark cards) or other inverted surfaces like toasts and tooltips.'},
+      {guidance: true, description: 'Pair with a background color — MediaTheme flips the token context but does not add a background. Set backgroundColor on the parent element.'},
+      {guidance: true, description: 'Themes can customize components on media surfaces via onDark.components and onLight.components in defineTheme(). For example, add a border to ghost buttons on dark surfaces.'},
+      {guidance: false, description: 'Use MediaTheme for app-level dark mode — use XDSTheme with mode="dark" or mode="system" instead. MediaTheme is for local surface inversions, not page-wide color scheme.'},
+    ],
   },
   props: [
-    {name: 'mode', type: "'dark' | 'light'", required: true, description: 'Surface luminance context — dark for light text on dark backgrounds, light for dark text on light backgrounds.'},
-    {name: 'children', type: 'ReactNode', required: true, description: 'Content to render in the media context.'},
+    {name: 'mode', type: "'dark' | 'light'", required: true, description: 'Surface luminance context — dark for content over dark backgrounds (light text, white-tinted interactions), light for content over light backgrounds (dark text, black-tinted interactions).'},
+    {name: 'children', type: 'ReactNode', required: true, description: 'Content to render with inverted token context. Components inherit the correct colors automatically.'},
   ],
 };

--- a/packages/core/src/theme/SyntaxTheme.doc.mjs
+++ b/packages/core/src/theme/SyntaxTheme.doc.mjs
@@ -3,12 +3,19 @@
 export const docs = {
   name: 'SyntaxTheme',
   group: 'Utilities',
-  keywords: ['syntax', 'highlighting', 'code', 'theme'],
+  keywords: ['syntax', 'highlighting', 'code', 'theme', 'codeblock', 'prism', 'shiki'],
   usage: {
-    description: 'Applies syntax highlighting colors to XDSCodeBlock components.',
+    description:
+      'Applies syntax highlighting colors to XDSCodeBlock and any code component in the subtree. By default, code components use the theme-level syntax colors (set via defineTheme({ syntax: ... })), which derive from the palette (--color-text-accent for keywords, --color-text-green for strings, etc.). XDSSyntaxTheme lets you override those per-region. The system uses 14 semantic tokens (keyword, string, comment, number, function, type, variable, operator, constant, tag, attribute, property, punctuation, background) validated against 11 community themes. Custom themes are created with defineSyntaxTheme() and can use [light, dark] tuples for automatic color-scheme adaptation. Built-in presets: oneDarkPro, dracula, monokai, nord, tokyoNight, catppuccinMocha, githubLight, githubDark, solarizedLight, oneLight (import from @xds/core/theme/syntax).',
+    bestPractices: [
+      {guidance: true, description: 'Use the syntax field in defineTheme() for app-wide code styling. Use XDSSyntaxTheme only when a specific section needs a different look.'},
+      {guidance: true, description: 'Pick from built-in presets or create a custom theme with defineSyntaxTheme() for brand-specific colors.'},
+      {guidance: true, description: 'Syntax themes support light-dark() tuples — each token can have different values for light and dark mode, resolved automatically by the color scheme.'},
+      {guidance: false, description: 'Wrap individual CodeBlock instances with XDSSyntaxTheme — use the syntaxTheme prop on XDSCodeBlock directly for per-instance overrides.'},
+    ],
   },
   props: [
-    {name: 'theme', type: 'SyntaxTheme', required: true, description: 'Syntax highlighting theme to apply to child code components.'},
-    {name: 'children', type: 'ReactNode', required: true, description: 'Content to render with the syntax theme.'},
+    {name: 'theme', type: 'SyntaxTheme', required: true, description: 'Syntax highlighting theme — a preset from @xds/core/theme/syntax or a custom theme created with defineSyntaxTheme().'},
+    {name: 'children', type: 'ReactNode', required: true, description: 'Content subtree. All XDSCodeBlock components within will use this syntax theme.'},
   ],
 };


### PR DESCRIPTION
Three new showcase blocks for theme utility components, picked up automatically by the docsite pipeline.

## Theme
Side-by-side default and neutral themes wrapping identical content — card with heading, badges, and buttons showing how `XDSTheme` changes the visual treatment of all children.

## MediaTheme
Light and dark mode panels showing how `XDSMediaTheme` adapts text, surfaces, and controls to the specified luminance context.

## SyntaxTheme
Same code block rendered with three syntax theme presets (GitHub Light, One Dark Pro, Dracula) showing how `XDSSyntaxTheme` changes code highlighting colors.

## Pipeline integration
Each showcase follows the standard pattern:
- `.tsx` + `.doc.mjs` pair in `packages/cli/templates/blocks/components/{Name}/`
- `exampleFor` matches the component doc name (`Theme`, `MediaTheme`, `SyntaxTheme`)
- `isShowcase: true` for the hero preview
- Pipeline copies to `src/generated/showcases/` and adds to `showcaseRegistry`