### PR TITLE
feat(docs): move legal links to homepage footer, add GitHub link to sidenav

### DIFF
--- a/apps/docsite/src/app/(docs)/page.tsx
+++ b/apps/docsite/src/app/(docs)/page.tsx
@@ -157,6 +157,9 @@ const styles = stylex.create({
     color: 'inherit',
     cursor: 'pointer',
   },
+  footerDivider: {
+    paddingBlockStart: spacingVars['--spacing-12'],
+  },
   footer: {
     paddingBlockStart: spacingVars['--spacing-12'],
     paddingBlockEnd: spacingVars['--spacing-12'],
@@ -317,10 +320,11 @@ export default function HomePage() {
         </XDSVStack>
       </XDSSection>
 
-      <XDSDivider />
+      <XDSDivider xstyle={styles.footerDivider} />
       <footer {...stylex.props(styles.footer)}>
         <XDSText type="supporting" color="secondary">
           <XDSLink
+            color="secondary"
             label="Terms of Use"
             href="https://opensource.fb.com/legal/terms"
             isExternalLink>
@@ -328,6 +332,7 @@ export default function HomePage() {
           </XDSLink>
           {' | '}
           <XDSLink
+            color="secondary"
             label="Privacy Policy"
             href="https://opensource.fb.com/legal/privacy"
             isExternalLink>

--- a/apps/docsite/src/app/(docs)/page.tsx
+++ b/apps/docsite/src/app/(docs)/page.tsx
@@ -12,6 +12,8 @@ import {XDSGrid} from '@xds/core/Grid';
 import {XDSSection} from '@xds/core/Section';
 import {XDSButton} from '@xds/core/Button';
 import {XDSTheme, XDSMediaTheme} from '@xds/core/theme';
+import {XDSDivider} from '@xds/core/Divider';
+import {XDSLink} from '@xds/core/Link';
 import {packages} from '../../generated/packageRegistry';
 import {componentCount} from '../../generated/componentRegistry';
 import {docTopics} from '../../generated/docsRegistry';
@@ -153,6 +155,14 @@ const styles = stylex.create({
     textDecoration: 'none',
     color: 'inherit',
     cursor: 'pointer',
+  },
+  footer: {
+    paddingBlockStart: 48,
+    paddingBlockEnd: 64,
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    gap: 8,
   },
 });
 
@@ -305,6 +315,21 @@ export default function HomePage() {
           </XDSVStack>
         </XDSVStack>
       </XDSSection>
+
+      <XDSDivider />
+      <footer {...stylex.props(styles.footer)}>
+        <XDSText type="supporting" color="secondary">
+          <XDSLink href="https://opensource.fb.com/legal/terms" isExternalLink>
+            Terms of Use
+          </XDSLink>
+          {' | '}
+          <XDSLink
+            href="https://opensource.fb.com/legal/privacy"
+            isExternalLink>
+            Privacy Policy
+          </XDSLink>
+        </XDSText>
+      </footer>
     </div>
   );
 }

--- a/apps/docsite/src/app/(docs)/page.tsx
+++ b/apps/docsite/src/app/(docs)/page.tsx
@@ -14,6 +14,7 @@ import {XDSButton} from '@xds/core/Button';
 import {XDSTheme, XDSMediaTheme} from '@xds/core/theme';
 import {XDSDivider} from '@xds/core/Divider';
 import {XDSLink} from '@xds/core/Link';
+import {spacingVars} from '@xds/core/theme/tokens.stylex';
 import {packages} from '../../generated/packageRegistry';
 import {componentCount} from '../../generated/componentRegistry';
 import {docTopics} from '../../generated/docsRegistry';
@@ -157,12 +158,12 @@ const styles = stylex.create({
     cursor: 'pointer',
   },
   footer: {
-    paddingBlockStart: 48,
-    paddingBlockEnd: 64,
+    paddingBlockStart: spacingVars['--spacing-12'],
+    paddingBlockEnd: spacingVars['--spacing-12'],
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'center',
-    gap: 8,
+    gap: spacingVars['--spacing-2'],
   },
 });
 

--- a/apps/docsite/src/app/(docs)/page.tsx
+++ b/apps/docsite/src/app/(docs)/page.tsx
@@ -319,11 +319,15 @@ export default function HomePage() {
       <XDSDivider />
       <footer {...stylex.props(styles.footer)}>
         <XDSText type="supporting" color="secondary">
-          <XDSLink href="https://opensource.fb.com/legal/terms" isExternalLink>
+          <XDSLink
+            label="Terms of Use"
+            href="https://opensource.fb.com/legal/terms"
+            isExternalLink>
             Terms of Use
           </XDSLink>
           {' | '}
           <XDSLink
+            label="Privacy Policy"
             href="https://opensource.fb.com/legal/privacy"
             isExternalLink>
             Privacy Policy

--- a/apps/docsite/src/components/DocsShell.tsx
+++ b/apps/docsite/src/components/DocsShell.tsx
@@ -2,6 +2,7 @@
 
 import {usePathname} from 'next/navigation';
 import {XDSAppShell} from '@xds/core/AppShell';
+import {XDSCenter} from '@xds/core/Center';
 import {XDSSideNav, XDSSideNavItem, XDSSideNavSection} from '@xds/core/SideNav';
 import {SharedTopNav} from './SharedTopNav';
 import {XDSLink} from '@xds/core/Link';
@@ -198,14 +199,15 @@ export function DocsShell({
       sideNav={
         <XDSSideNav
           footer={
-            <XDSText type="supporting" color="secondary">
+            <XDSCenter>
               <XDSLink
+                color="secondary"
                 label="GitHub Pages"
                 href="https://studious-broccoli-o7e61n3.pages.github.io/"
                 isExternalLink>
                 GitHub Pages
               </XDSLink>
-            </XDSText>
+            </XDSCenter>
           }>
           {/* Home */}
           <XDSSideNavSection title="Home" isHeaderHidden>

--- a/apps/docsite/src/components/DocsShell.tsx
+++ b/apps/docsite/src/components/DocsShell.tsx
@@ -202,7 +202,7 @@ export function DocsShell({
               <XDSLink
                 href="https://github.com/facebookexperimental/xds/tree/main"
                 isExternalLink>
-                GitHub
+                GitHub Pages
               </XDSLink>
             </XDSText>
           }>

--- a/apps/docsite/src/components/DocsShell.tsx
+++ b/apps/docsite/src/components/DocsShell.tsx
@@ -200,7 +200,8 @@ export function DocsShell({
           footer={
             <XDSText type="supporting" color="secondary">
               <XDSLink
-                href="https://github.com/facebookexperimental/xds/tree/main"
+                label="GitHub Pages"
+                href="https://studious-broccoli-o7e61n3.pages.github.io/"
                 isExternalLink>
                 GitHub Pages
               </XDSLink>

--- a/apps/docsite/src/components/DocsShell.tsx
+++ b/apps/docsite/src/components/DocsShell.tsx
@@ -5,7 +5,7 @@ import {XDSAppShell} from '@xds/core/AppShell';
 import {XDSSideNav, XDSSideNavItem, XDSSideNavSection} from '@xds/core/SideNav';
 import {SharedTopNav} from './SharedTopNav';
 import {XDSLink} from '@xds/core/Link';
-import {XDSVStack} from '@xds/core/Layout';
+import {XDSText} from '@xds/core/Text';
 import type {ComponentEntry} from '../generated/componentRegistry';
 import type {PackageMeta} from '../generated/packageRegistry';
 import type {DocTopic} from '../generated/docsRegistry';
@@ -198,20 +198,13 @@ export function DocsShell({
       sideNav={
         <XDSSideNav
           footer={
-            <XDSVStack gap={1}>
+            <XDSText type="supporting" color="secondary">
               <XDSLink
-                label="Terms of Use"
-                href="https://opensource.fb.com/legal/terms"
+                href="https://github.com/facebookexperimental/xds/tree/main"
                 isExternalLink>
-                Terms of Use
+                GitHub
               </XDSLink>
-              <XDSLink
-                label="Privacy Policy"
-                href="https://opensource.fb.com/legal/privacy"
-                isExternalLink>
-                Privacy Policy
-              </XDSLink>
-            </XDSVStack>
+            </XDSText>
           }>
           {/* Home */}
           <XDSSideNavSection title="Home" isHeaderHidden>


### PR DESCRIPTION
Moves the legal disclosure links from the sidenav footer to a proper homepage footer area, and replaces the sidenav footer with a link to the GitHub repo.

### Homepage footer
- Adds a `<XDSDivider />` after the main content
- Centered footer area with generous padding
- **Terms of Use | Privacy Policy** in supporting text format

### Sidenav footer
- Replaces the two legal links with a single **GitHub** link pointing to `main`
- Supporting text appearance to keep it lightweight