### PR TITLE
fix(link): make label optional — aria-label harms AT on text links

### DIFF
--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/DocsView.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/DocsView.tsx
@@ -371,7 +371,6 @@ function ChangelogItemRow({item}: {item: ChangelogItem}) {
       </XDSText>
       {item.pr != null && (
         <XDSLink
-          label={`Pull request #${item.pr}`}
           href={`https://github.com/${GITHUB_REPO}/pull/${item.pr}`}
           target="_blank"
           rel="noopener noreferrer"
@@ -4804,7 +4803,6 @@ function LibraryOverview({
                           <>
                             {offering.description.slice(0, idx)}
                             <XDSLink
-                              label={offering.descriptionLinkText}
                               href={offering.descriptionLinkHref}
                               type="supporting"
                               color="secondary"
@@ -4852,7 +4850,6 @@ function LibraryOverview({
         <XDSText type="supporting" color="secondary">
           Prefer a human? Open an issue on{' '}
           <XDSLink
-            label="GitHub"
             href="https://github.com/facebookexperimental/xds/issues"
             color="secondary"
             type="supporting">

--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/ThemeEditorView.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/ThemeEditorView.tsx
@@ -1365,7 +1365,7 @@ function ComponentPreview() {
                       Your latest account activity.
                     </XDSText>
                   </XDSVStack>
-                  <XDSLink label="View All" href="#">
+                  <XDSLink href="#">
                     View All
                   </XDSLink>
                 </div>
@@ -1492,7 +1492,7 @@ function ComponentPreview() {
                   Payment Due
                 </XDSText>
                 <XDSHeading level={3}>1 Apr</XDSHeading>
-                <XDSLink label="Pay Early" href="#">
+                <XDSLink href="#">
                   Pay Early
                 </XDSLink>
               </XDSVStack>

--- a/apps/sandbox/src/app/(fullscreen)/pages/example-cards/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/example-cards/page.tsx
@@ -600,7 +600,7 @@ export default function ExampleCardsPage() {
                     Your latest account activity.
                   </XDSText>
                 </XDSVStack>
-                <XDSLink label="View All" href="#">
+                <XDSLink href="#">
                   View All
                 </XDSLink>
               </div>
@@ -691,7 +691,7 @@ export default function ExampleCardsPage() {
                     Payment Due
                   </XDSText>
                   <XDSHeading level={3}>1 Apr</XDSHeading>
-                  <XDSLink label="Pay Early" href="#">
+                  <XDSLink href="#">
                     Pay Early
                   </XDSLink>
                 </XDSVStack>

--- a/apps/sandbox/src/app/(sandbox)/pages/polymorphic-link/page.tsx
+++ b/apps/sandbox/src/app/(sandbox)/pages/polymorphic-link/page.tsx
@@ -213,7 +213,7 @@ export default function PolymorphicLinkPage() {
                 <XDSText type="supporting" weight="bold">
                   XDSLink
                 </XDSText>
-                <XDSLink label="Documentation link" href="/docs">
+                <XDSLink href="/docs">
                   Go to documentation
                 </XDSLink>
               </XDSVStack>

--- a/apps/sandbox/src/app/(sandbox)/templates/page.tsx
+++ b/apps/sandbox/src/app/(sandbox)/templates/page.tsx
@@ -150,7 +150,6 @@ function useTableSearchParams() {
 function CopyPath({path}: {path: string}) {
   return (
     <XDSLink
-      label={`Copy path: ${path}`}
       onClick={() => navigator.clipboard.writeText(path)}
       style={{cursor: 'pointer'}}>
       Copy Path
@@ -204,7 +203,7 @@ const columns: XDSTableColumn<TemplateRow>[] = [
     filter: 'name',
     width: pixel(250),
     renderCell: (row: TemplateRow) => (
-      <XDSLink label={row.name} href={row.href} as={Link} target="_blank">
+      <XDSLink href={row.href} as={Link} target="_blank">
         {row.name}
       </XDSLink>
     ),

--- a/apps/storybook/stories/Code.stories.tsx
+++ b/apps/storybook/stories/Code.stories.tsx
@@ -60,7 +60,7 @@ export const MixedInline: Story = {
     <XDSText type="body">
       The <XDSCode>XDSThemeProvider</XDSCode> component wraps your app and
       supplies design tokens. See the{' '}
-      <XDSLink label="theme docs" href="/docs/theme" isExternalLink={false}>
+      <XDSLink href="/docs/theme" isExternalLink={false}>
         theme docs
       </XDSLink>{' '}
       for setup. Set <XDSCode>colorScheme=&quot;dark&quot;</XDSCode> to enable

--- a/apps/storybook/stories/Link.stories.tsx
+++ b/apps/storybook/stories/Link.stories.tsx
@@ -128,7 +128,7 @@ export const InlineWithText: Story = {
   render: () => (
     <XDSText type="body">
       Read the{' '}
-      <XDSLink label="documentation" href="/docs">
+      <XDSLink href="/docs">
         documentation
       </XDSLink>{' '}
       for more information about using XDS components.
@@ -146,40 +146,36 @@ export const AllVariants: Story = {
         maxWidth: '600px',
       }}>
       <div style={{display: 'flex', gap: '16px', alignItems: 'center'}}>
-        <XDSLink label="Active (default)" href="/active" isStandalone>
+        <XDSLink href="/active" isStandalone>
           Active (default)
         </XDSLink>
-        <XDSLink label="Primary" href="/primary" color="primary" isStandalone>
+        <XDSLink href="/primary" color="primary" isStandalone>
           Primary
         </XDSLink>
         <XDSLink
-          label="Secondary"
           href="/secondary"
           color="secondary"
           isStandalone>
           Secondary
         </XDSLink>
-        <XDSLink label="Inherit" href="/inherit" color="inherit" isStandalone>
+        <XDSLink href="/inherit" color="inherit" isStandalone>
           Inherit
         </XDSLink>
       </div>
       <div style={{display: 'flex', gap: '16px', alignItems: 'center'}}>
         <XDSLink
-          label="With underline"
           href="/underlined"
           hasUnderline
           isStandalone>
           With underline
         </XDSLink>
         <XDSLink
-          label="External"
           href="https://example.com"
           isExternalLink
           isStandalone>
           External
         </XDSLink>
         <XDSLink
-          label="With tooltip"
           href="/tooltip"
           tooltip="Helpful info"
           isStandalone>
@@ -188,14 +184,12 @@ export const AllVariants: Story = {
       </div>
       <div style={{display: 'flex', gap: '16px', alignItems: 'center'}}>
         <XDSLink
-          label="Disabled active"
           href="/disabled"
           isDisabled
           isStandalone>
           Disabled active
         </XDSLink>
         <XDSLink
-          label="Disabled secondary"
           href="/disabled"
           color="secondary"
           isDisabled
@@ -216,21 +210,18 @@ export const ExternalLinks: Story = {
         gap: '8px',
       }}>
       <XDSLink
-        label="GitHub"
         href="https://github.com"
         isExternalLink
         isStandalone>
         GitHub
       </XDSLink>
       <XDSLink
-        label="MDN Web Docs"
         href="https://developer.mozilla.org"
         isExternalLink
         isStandalone>
         MDN Web Docs
       </XDSLink>
       <XDSLink
-        label="React Documentation"
         href="https://react.dev"
         isExternalLink
         hasUnderline
@@ -245,21 +236,18 @@ export const LinksWithTooltips: Story = {
   render: () => (
     <div style={{display: 'flex', gap: '16px', alignItems: 'center'}}>
       <XDSLink
-        label="Settings"
         href="/settings"
         tooltip="Configure your account settings"
         isStandalone>
         Settings
       </XDSLink>
       <XDSLink
-        label="Profile"
         href="/profile"
         tooltip="View and edit your profile"
         isStandalone>
         Profile
       </XDSLink>
       <XDSLink
-        label="Help"
         href="/help"
         tooltip="Get help and support"
         color="secondary"

--- a/apps/storybook/stories/useXDSLinkify.stories.tsx
+++ b/apps/storybook/stories/useXDSLinkify.stories.tsx
@@ -167,7 +167,6 @@ export const Interactive: Story = {
     return (
       <XDSStack gap={4}>
         <XDSTextInput
-          label="Input text"
           value={text}
           onChange={(e) => setText(e.target.value)}
         />

--- a/packages/cli/templates/blocks/components/Link/LinkExternalLinks.tsx
+++ b/packages/cli/templates/blocks/components/Link/LinkExternalLinks.tsx
@@ -7,21 +7,18 @@ export default function LinkExternalLinks() {
   return (
     <XDSVStack gap={2}>
       <XDSLink
-        label="GitHub"
         href="https://github.com"
         isExternalLink
         isStandalone>
         GitHub
       </XDSLink>
       <XDSLink
-        label="MDN Web Docs"
         href="https://developer.mozilla.org"
         isExternalLink
         isStandalone>
         MDN Web Docs
       </XDSLink>
       <XDSLink
-        label="React Documentation"
         href="https://react.dev"
         isExternalLink
         hasUnderline

--- a/packages/cli/templates/blocks/components/Link/LinkInlineLink.tsx
+++ b/packages/cli/templates/blocks/components/Link/LinkInlineLink.tsx
@@ -7,7 +7,7 @@ export default function LinkInlineLink() {
   return (
     <XDSText type="body">
       Read the{' '}
-      <XDSLink label="documentation" href="/docs">
+      <XDSLink href="/docs">
         documentation
       </XDSLink>{' '}
       for more information about using XDS components.

--- a/packages/cli/templates/blocks/components/Link/LinkShowcase.tsx
+++ b/packages/cli/templates/blocks/components/Link/LinkShowcase.tsx
@@ -4,7 +4,7 @@ import {XDSLink} from '@xds/core/Link';
 
 export default function LinkShowcase() {
   return (
-    <XDSLink label="Documentation" href="/docs" isStandalone>
+    <XDSLink href="/docs" isStandalone>
       Documentation
     </XDSLink>
   );

--- a/packages/cli/templates/blocks/components/Link/LinksWithTooltips.tsx
+++ b/packages/cli/templates/blocks/components/Link/LinksWithTooltips.tsx
@@ -7,21 +7,18 @@ export default function LinksWithTooltips() {
   return (
     <XDSHStack gap={4} vAlign="center">
       <XDSLink
-        label="Settings"
         href="/settings"
         tooltip="Configure your account settings"
         isStandalone>
         Settings
       </XDSLink>
       <XDSLink
-        label="Profile"
         href="/profile"
         tooltip="View and edit your profile"
         isStandalone>
         Profile
       </XDSLink>
       <XDSLink
-        label="Help"
         href="/help"
         tooltip="Get help and support"
         color="secondary"

--- a/packages/cli/templates/blocks/components/MetadataListItem/MetadataListItemShowcase.tsx
+++ b/packages/cli/templates/blocks/components/MetadataListItem/MetadataListItemShowcase.tsx
@@ -12,14 +12,14 @@ export default function MetadataListItemShowcase() {
         <XDSBadge label="Active" variant="green" />
       </XDSMetadataListItem>
       <XDSMetadataListItem label="Owner">
-        <XDSLink label="Alice Johnson" href="#">Alice Johnson</XDSLink>
+        <XDSLink href="#">Alice Johnson</XDSLink>
       </XDSMetadataListItem>
       <XDSMetadataListItem label="Created">January 15, 2025</XDSMetadataListItem>
       <XDSMetadataListItem label="Priority">
         <XDSBadge label="High" variant="red" />
       </XDSMetadataListItem>
       <XDSMetadataListItem label="Repository">
-        <XDSLink label="github.com/org/design-system" href="#">github.com/org/design-system</XDSLink>
+        <XDSLink href="#">github.com/org/design-system</XDSLink>
       </XDSMetadataListItem>
     </XDSMetadataList>
   );

--- a/packages/cli/templates/blocks/components/Table/TableRichCellTable.tsx
+++ b/packages/cli/templates/blocks/components/Table/TableRichCellTable.tsx
@@ -64,7 +64,7 @@ const columns: XDSTableColumn<User>[] = [
     header: 'Email',
     width: proportional(2),
     renderCell: item => (
-      <XDSLink label={item.email} href={`mailto:${item.email}`}>{item.email}</XDSLink>
+      <XDSLink href={`mailto:${item.email}`}>{item.email}</XDSLink>
     ),
   },
   {

--- a/packages/cli/templates/blocks/components/Toast/ToastAction.tsx
+++ b/packages/cli/templates/blocks/components/Toast/ToastAction.tsx
@@ -32,7 +32,7 @@ export default function ToastAction() {
         type="info"
         body="Your report is ready."
         endContent={
-          <XDSLink href="#" label="View report" hasUnderline>
+          <XDSLink href="#" hasUnderline>
             View report
           </XDSLink>
         }

--- a/packages/cli/templates/pages/contact-form/page.tsx
+++ b/packages/cli/templates/pages/contact-form/page.tsx
@@ -301,7 +301,7 @@ export default function FormSimplePage() {
             <XDSHStack gap={1} hAlign="center">
               <XDSText type="supporting" color="secondary">
                 By submitting you agree to our{' '}
-                <XDSLink label="Privacy Policy" href="#" type="supporting">
+                <XDSLink href="#" type="supporting">
                   Privacy Policy
                 </XDSLink>
                 .

--- a/packages/cli/templates/pages/dashboard-portfolio/page.tsx
+++ b/packages/cli/templates/pages/dashboard-portfolio/page.tsx
@@ -748,7 +748,7 @@ export default function DashboardPortfolioTemplate() {
               <XDSVStack gap={4}>
                 <XDSHStack hAlign="between" vAlign="center">
                   <XDSHeading level={3}>Portfolio Value</XDSHeading>
-                  <XDSLink label="View details" href="#">
+                  <XDSLink href="#">
                     View details
                   </XDSLink>
                 </XDSHStack>
@@ -761,7 +761,7 @@ export default function DashboardPortfolioTemplate() {
               <XDSVStack gap={4}>
                 <XDSHStack hAlign="between" vAlign="center">
                   <XDSHeading level={3}>Top Assets</XDSHeading>
-                  <XDSLink label="View all" href="#">
+                  <XDSLink href="#">
                     View all
                   </XDSLink>
                 </XDSHStack>

--- a/packages/cli/templates/pages/dashboard/page.tsx
+++ b/packages/cli/templates/pages/dashboard/page.tsx
@@ -719,7 +719,7 @@ function TableCard<T extends {id: string}>({
       <XDSVStack gap={6}>
         <XDSHStack hAlign="between" vAlign="center">
           <XDSHeading level={4}>{title}</XDSHeading>
-          <XDSLink label={linkLabel} href={linkHref}>
+          <XDSLink href={linkHref}>
             {linkLabel}
           </XDSLink>
         </XDSHStack>

--- a/packages/cli/templates/pages/detail-page/page.tsx
+++ b/packages/cli/templates/pages/detail-page/page.tsx
@@ -272,7 +272,7 @@ function PageHeader({
         <XDSHStack gap={4} vAlign="start">
           <XDSStackItem size="fill">
             <XDSVStack gap={0}>
-              <XDSLink href="#" label="All orders" color="secondary">
+              <XDSLink href="#" color="secondary">
                 <XDSHStack gap={1} vAlign="center">
                   <XDSIcon icon={ArrowLeftIcon} size="sm" color="inherit" />
                   All orders
@@ -308,7 +308,7 @@ function PageHeader({
                     </XDSText>
                   </XDSHStack>
                   <Bullet />
-                  <XDSLink href="#" label="See all" color="secondary">
+                  <XDSLink href="#" color="secondary">
                     See all
                   </XDSLink>
                 </XDSHStack>
@@ -576,7 +576,7 @@ function RightPanel() {
             Customer is a repeat buyer — 3rd order this quarter. Prefers snow
             and oat glazes. Requested gift wrapping for the mug set. Ships to a
             residential address in CA.{' '}
-            <XDSLink href="#" label="Show more" color="secondary">
+            <XDSLink href="#" color="secondary">
               Show more
             </XDSLink>
           </XDSText>

--- a/packages/cli/templates/pages/form-two-column/page.tsx
+++ b/packages/cli/templates/pages/form-two-column/page.tsx
@@ -239,7 +239,6 @@ export default function FormTwoColumnPage() {
                     {col.label}
                   </XDSText>
                   <XDSLink
-                    label={col.email}
                     href={`mailto:${col.email}`}
                     type="body"
                     size="sm">

--- a/packages/cli/templates/pages/login-card/page.tsx
+++ b/packages/cli/templates/pages/login-card/page.tsx
@@ -121,7 +121,6 @@ export default function LoginSimple() {
                 {loginFailed && (
                   <XDSVStack hAlign="end">
                     <XDSLink
-                      label="Forgot password?"
                       href="#"
                       size="sm"
                       color="secondary"
@@ -168,7 +167,7 @@ export default function LoginSimple() {
             <XDSVStack hAlign="center">
               <XDSText type="supporting" color="secondary">
                 Don&apos;t have an account?{' '}
-                <XDSLink label="Sign up" href="#" type="supporting">
+                <XDSLink href="#" type="supporting">
                   Sign up
                 </XDSLink>
               </XDSText>
@@ -180,11 +179,11 @@ export default function LoginSimple() {
         <XDSVStack hAlign="center" xstyle={styles.termsFooter}>
           <XDSText type="supporting" color="secondary" xstyle={styles.centered}>
             By clicking continue, you agree to our{' '}
-            <XDSLink label="Terms of Service" href="#" type="supporting">
+            <XDSLink href="#" type="supporting">
               Terms of Service
             </XDSLink>{' '}
             and{' '}
-            <XDSLink label="Privacy Policy" href="#" type="supporting">
+            <XDSLink href="#" type="supporting">
               Privacy Policy
             </XDSLink>
             .

--- a/packages/cli/templates/pages/login-split/page.tsx
+++ b/packages/cli/templates/pages/login-split/page.tsx
@@ -145,7 +145,6 @@ export default function LoginTwoColumn() {
                         {loginFailed && (
                           <XDSVStack hAlign="end">
                             <XDSLink
-                              label="Forgot your password?"
                               href="#"
                               size="sm"
                               color="secondary"
@@ -196,7 +195,7 @@ export default function LoginTwoColumn() {
               {!isSuccess && (
               <XDSText type="supporting" color="secondary">
                 Don&apos;t have an account?{' '}
-                <XDSLink label="Sign up" href="#" type="supporting">
+                <XDSLink href="#" type="supporting">
                   Sign up
                 </XDSLink>
               </XDSText>
@@ -218,11 +217,11 @@ export default function LoginTwoColumn() {
         <XDSVStack hAlign="center">
           <XDSText type="supporting" color="secondary">
             By clicking continue, you agree to our{' '}
-            <XDSLink label="Terms of Service" href="#" type="supporting">
+            <XDSLink href="#" type="supporting">
               Terms of Service
             </XDSLink>{' '}
             and{' '}
-            <XDSLink label="Privacy Policy" href="#" type="supporting">
+            <XDSLink href="#" type="supporting">
               Privacy Policy
             </XDSLink>
             .

--- a/packages/cli/templates/pages/login-sso/page.tsx
+++ b/packages/cli/templates/pages/login-sso/page.tsx
@@ -144,7 +144,6 @@ export default function LoginSSO() {
                     </XDSVStack>
 
                     <XDSLink
-                      label="Having trouble signing in?"
                       href="#"
                       size="sm"
                       color="secondary"
@@ -173,7 +172,7 @@ export default function LoginSSO() {
                     <XDSVStack hAlign="center">
                       <XDSText type="supporting" color="secondary">
                         Don&apos;t have an account?{' '}
-                        <XDSLink label="Request access" href="#" type="supporting">
+                        <XDSLink href="#" type="supporting">
                           Request access
                         </XDSLink>
                       </XDSText>
@@ -261,7 +260,6 @@ export default function LoginSSO() {
                         {loginFailed && (
                           <XDSVStack hAlign="end">
                             <XDSLink
-                              label="Forgot password?"
                               href="#"
                               size="sm"
                               color="secondary"

--- a/packages/cli/templates/pages/payment-form/page.tsx
+++ b/packages/cli/templates/pages/payment-form/page.tsx
@@ -830,22 +830,20 @@ export default function PaymentFormPage() {
                     </XDSVStack>
                     <XDSDivider />
                     <XDSHStack gap={4} vAlign="center">
-                      <XDSLink label="Refund policy" href="#" type="supporting">
+                      <XDSLink href="#" type="supporting">
                         Refund policy
                       </XDSLink>
                       <XDSLink
-                        label="Privacy policy"
                         href="#"
                         type="supporting">
                         Privacy policy
                       </XDSLink>
                       <XDSLink
-                        label="Terms of service"
                         href="#"
                         type="supporting">
                         Terms of service
                       </XDSLink>
-                      <XDSLink label="Cancellations" href="#" type="supporting">
+                      <XDSLink href="#" type="supporting">
                         Cancellations
                       </XDSLink>
                     </XDSHStack>
@@ -929,13 +927,11 @@ export default function PaymentFormPage() {
                                       isIntegerOnly
                                     />
                                     <XDSLink
-                                      label="Remove"
                                       href="#"
                                       type="supporting">
                                       Remove
                                     </XDSLink>
                                     <XDSLink
-                                      label="Save"
                                       href="#"
                                       type="supporting">
                                       Save

--- a/packages/cli/templates/pages/settings-dialog/page.tsx
+++ b/packages/cli/templates/pages/settings-dialog/page.tsx
@@ -195,7 +195,6 @@ function ExpandableRow({
             </XDSText>
           </XDSVStack>
           <XDSLink
-            label="Edit"
             href="#"
             onClick={(e: React.MouseEvent) => {
               e.preventDefault();
@@ -231,7 +230,7 @@ function InfoRowItem({
           </XDSText>
         </XDSVStack>
         {action && (
-          <XDSLink label={action} href="#">
+          <XDSLink href="#">
             {action}
           </XDSLink>
         )}
@@ -589,7 +588,7 @@ export default function SettingsDialogTemplate() {
                                   </XDSVStack>
                                 </XDSStackItem>
                                 {device.action && (
-                                  <XDSLink label={device.action} href="#">
+                                  <XDSLink href="#">
                                     {device.action}
                                   </XDSLink>
                                 )}
@@ -620,7 +619,7 @@ export default function SettingsDialogTemplate() {
                                 This action cannot be undone
                               </XDSText>
                             </XDSVStack>
-                            <XDSLink label="Deactivate" href="#">
+                            <XDSLink href="#">
                               Deactivate
                             </XDSLink>
                           </XDSHStack>
@@ -753,7 +752,7 @@ export default function SettingsDialogTemplate() {
                           <XDSText type="body" weight="semibold">
                             Blocked people
                           </XDSText>
-                          <XDSLink label="View" href="#">
+                          <XDSLink href="#">
                             View
                           </XDSLink>
                         </XDSHStack>
@@ -780,7 +779,6 @@ export default function SettingsDialogTemplate() {
                         <XDSText type="supporting" color="secondary">
                           Choose what&apos;s shared when you write a review.{' '}
                           <XDSLink
-                            label="Learn more"
                             href="#"
                             type="supporting">
                             Learn more
@@ -830,7 +828,7 @@ export default function SettingsDialogTemplate() {
                             <XDSText type="body">
                               Request my personal data
                             </XDSText>
-                            <XDSLink label="Request" href="#">
+                            <XDSLink href="#">
                               Request
                             </XDSLink>
                           </XDSHStack>
@@ -846,7 +844,7 @@ export default function SettingsDialogTemplate() {
                         <XDSCard>
                           <XDSHStack hAlign="between" vAlign="center">
                             <XDSText type="body">Delete my account</XDSText>
-                            <XDSLink label="Delete" href="#">
+                            <XDSLink href="#">
                               Delete
                             </XDSLink>
                           </XDSHStack>
@@ -867,7 +865,6 @@ export default function SettingsDialogTemplate() {
                                 We&apos;re committed to keeping your data
                                 protected. See details in our{' '}
                                 <XDSLink
-                                  label="Privacy Policy"
                                   href="#"
                                   type="supporting">
                                   Privacy Policy

--- a/packages/cli/templates/pages/settings-sidebar/page.tsx
+++ b/packages/cli/templates/pages/settings-sidebar/page.tsx
@@ -117,7 +117,7 @@ function InfoRowItem({label, value, action}: InfoRow) {
           </XDSText>
         </XDSVStack>
         {action && (
-          <XDSLink label={action} href="#">
+          <XDSLink href="#">
             {action}
           </XDSLink>
         )}
@@ -170,7 +170,6 @@ function ExpandableRow({
             </XDSText>
           </XDSVStack>
           <XDSLink
-            label="Edit"
             href="#"
             onClick={(e: React.MouseEvent) => {
               e.preventDefault();
@@ -326,7 +325,7 @@ export default function SettingsSecurityTemplate() {
                         </XDSVStack>
                       </XDSStackItem>
                       {device.action && (
-                        <XDSLink label={device.action} href="#">
+                        <XDSLink href="#">
                           {device.action}
                         </XDSLink>
                       )}
@@ -353,7 +352,7 @@ export default function SettingsSecurityTemplate() {
                         This action cannot be undone
                       </XDSText>
                     </XDSVStack>
-                    <XDSLink label="Deactivate" href="#">
+                    <XDSLink href="#">
                       Deactivate
                     </XDSLink>
                   </XDSHStack>
@@ -668,7 +667,7 @@ export default function SettingsSecurityTemplate() {
                   <XDSText type="body" weight="semibold">
                     Blocked people
                   </XDSText>
-                  <XDSLink label="View" href="#">
+                  <XDSLink href="#">
                     View
                   </XDSLink>
                 </XDSHStack>
@@ -694,7 +693,7 @@ export default function SettingsSecurityTemplate() {
                 <XDSHeading level={3}>Reviews</XDSHeading>
                 <XDSText type="supporting" color="secondary">
                   Choose what&apos;s shared when you write a review.{' '}
-                  <XDSLink label="Learn more" href="#" type="supporting">
+                  <XDSLink href="#" type="supporting">
                     Learn more
                   </XDSLink>
                 </XDSText>
@@ -740,7 +739,7 @@ export default function SettingsSecurityTemplate() {
                 <XDSCard>
                   <XDSHStack hAlign="between" vAlign="center">
                     <XDSText type="body">Request my personal data</XDSText>
-                    <XDSLink label="Request" href="#">
+                    <XDSLink href="#">
                       Request
                     </XDSLink>
                   </XDSHStack>
@@ -756,7 +755,7 @@ export default function SettingsSecurityTemplate() {
                 <XDSCard>
                   <XDSHStack hAlign="between" vAlign="center">
                     <XDSText type="body">Delete my account</XDSText>
-                    <XDSLink label="Delete" href="#">
+                    <XDSLink href="#">
                       Delete
                     </XDSLink>
                   </XDSHStack>
@@ -777,7 +776,6 @@ export default function SettingsSecurityTemplate() {
                         We&apos;re committed to keeping your data protected.
                         See details in our{' '}
                         <XDSLink
-                          label="Privacy Policy"
                           href="#"
                           type="supporting">
                           Privacy Policy

--- a/packages/core/src/Link/Link.doc.mjs
+++ b/packages/core/src/Link/Link.doc.mjs
@@ -22,8 +22,7 @@ export const docs = {
         {
           name: 'label',
           type: 'string',
-          description: 'Accessible label',
-          required: true,
+          description: 'Accessible label (aria-label). Only use when children are not self-descriptive (e.g. icon-only links). Omit for text links — the link text is the accessible name.',
         },
         {
           name: 'href',
@@ -103,9 +102,10 @@ export const docs = {
     bestPractices: [
       { guidance: true, description: 'Write descriptive, concise link text that clearly communicates the destination.' },
       { guidance: true, description: 'Set `isStandalone` when the link appears outside of inline text, so it receives proper base font sizing.' },
+      { guidance: true, description: 'Only set `label` when the link content is not descriptive text (e.g. an icon-only link). For text links, the visible text is already the accessible name — adding `label` overrides it for screen readers, which is harmful.' },
       { guidance: false, description: 'Use Link for actions that do not navigate — use a Button instead.' },
       { guidance: false, description: 'Use generic text like "click here" or "read more" — describe the destination.' },
-      { guidance: false, description: 'Use icon-only links without a visible text label.' },
+      { guidance: false, description: 'Set `label` on text links — `aria-label` prevents assistive technology from reading the actual link content.' },
     ],
     anatomy: [
       {name: 'Label', required: true, description: 'The visible text of the link.'},
@@ -137,8 +137,7 @@ export const docsZh = {
         {
           name: 'label',
           type: 'string',
-          description: '无障碍标签',
-          required: true,
+          description: '无障碍标签（aria-label）。仅在子内容不是描述性文本时使用（如纯图标链接）。文本链接请省略此项。',
         },
         {
           name: 'href',
@@ -218,9 +217,10 @@ export const docsZh = {
     bestPractices: [
       { guidance: true, description: 'Write descriptive, concise link text that clearly communicates the destination.' },
       { guidance: true, description: 'Set `isStandalone` when the link appears outside of inline text, so it receives proper base font sizing.' },
+      { guidance: true, description: 'Only set `label` when the link content is not descriptive text (e.g. an icon-only link). For text links, the visible text is already the accessible name — adding `label` overrides it for screen readers, which is harmful.' },
       { guidance: false, description: 'Use Link for actions that do not navigate — use a Button instead.' },
       { guidance: false, description: 'Use generic text like "click here" or "read more" — describe the destination.' },
-      { guidance: false, description: 'Use icon-only links without a visible text label.' },
+      { guidance: false, description: 'Set `label` on text links — `aria-label` prevents assistive technology from reading the actual link content.' },
     ],
     anatomy: [
       {name: 'Label', required: true, description: 'The visible text of the link.'},
@@ -240,9 +240,10 @@ export const docsDense = {
     bestPractices: [
       { guidance: true, description: 'Write descriptive, concise link text that clearly communicates the destination.' },
       { guidance: true, description: 'Set `isStandalone` when the link appears outside of inline text, so it receives proper base font sizing.' },
+      { guidance: true, description: 'Only set `label` when the link content is not descriptive text (e.g. an icon-only link). For text links, the visible text is already the accessible name — adding `label` overrides it for screen readers, which is harmful.' },
       { guidance: false, description: 'Use Link for actions that do not navigate — use a Button instead.' },
       { guidance: false, description: 'Use generic text like "click here" or "read more" — describe the destination.' },
-      { guidance: false, description: 'Use icon-only links without a visible text label.' },
+      { guidance: false, description: 'Set `label` on text links — `aria-label` prevents assistive technology from reading the actual link content.' },
     ],
     anatomy: [
       {name: 'Label', required: true, description: 'The visible text of the link.'},
@@ -257,7 +258,7 @@ export const docsDense = {
         'Styled anchor link w/ variants, external link support, polymorphic rendering.',
       propDescriptions: {
         as: 'Custom component to render instead of <a>',
-        label: 'Accessible label',
+        label: 'Accessible label (aria-label). Only for non-text content like icon-only links.',
         href: 'Link destination URL',
         hasUnderline: 'Always show underline',
         isDisabled: 'Disables link',

--- a/packages/core/src/Link/XDSLink.test.tsx
+++ b/packages/core/src/Link/XDSLink.test.tsx
@@ -26,7 +26,7 @@ CustomLink.displayName = 'CustomLink';
 describe('XDSLink', () => {
   it('renders children as link text', () => {
     render(
-      <XDSLink label="Click me" href="/test">
+      <XDSLink href="/test">
         Click me
       </XDSLink>,
     );
@@ -35,17 +35,26 @@ describe('XDSLink', () => {
 
   it('renders with href attribute', () => {
     render(
-      <XDSLink label="Link" href="/destination">
+      <XDSLink href="/destination">
         Link
       </XDSLink>,
     );
     expect(screen.getByRole('link')).toHaveAttribute('href', '/destination');
   });
 
-  it('renders with aria-label from label prop', () => {
+  it('does not render aria-label when label is omitted', () => {
+    render(
+      <XDSLink href="/test">
+        Visible text
+      </XDSLink>,
+    );
+    expect(screen.getByRole('link')).not.toHaveAttribute('aria-label');
+  });
+
+  it('renders aria-label when label prop is provided', () => {
     render(
       <XDSLink label="Accessible label" href="/test">
-        Visible text
+        <span aria-hidden="true">🏠</span>
       </XDSLink>,
     );
     expect(screen.getByRole('link')).toHaveAttribute(
@@ -56,21 +65,21 @@ describe('XDSLink', () => {
 
   it('renders with different color values', () => {
     const {rerender} = render(
-      <XDSLink label="Active" href="/test" color="active">
+      <XDSLink href="/test" color="active">
         Active
       </XDSLink>,
     );
     expect(screen.getByRole('link')).toBeInTheDocument();
 
     rerender(
-      <XDSLink label="Secondary" href="/test" color="secondary">
+      <XDSLink href="/test" color="secondary">
         Secondary
       </XDSLink>,
     );
     expect(screen.getByRole('link')).toBeInTheDocument();
 
     rerender(
-      <XDSLink label="Inherit" href="/test" color="inherit">
+      <XDSLink href="/test" color="inherit">
         Inherit
       </XDSLink>,
     );
@@ -79,7 +88,7 @@ describe('XDSLink', () => {
 
   it('applies hasUnderline style when true', () => {
     render(
-      <XDSLink label="Underlined" href="/test" hasUnderline>
+      <XDSLink href="/test" hasUnderline>
         Underlined Link
       </XDSLink>,
     );
@@ -88,7 +97,7 @@ describe('XDSLink', () => {
 
   it('applies isDisabled state correctly', () => {
     render(
-      <XDSLink label="Disabled Link" href="/test" isDisabled>
+      <XDSLink href="/test" isDisabled>
         Disabled Link
       </XDSLink>,
     );
@@ -99,21 +108,19 @@ describe('XDSLink', () => {
 
   it('renders external link with icon and target="_blank"', () => {
     render(
-      <XDSLink label="External" href="https://example.com" isExternalLink>
+      <XDSLink href="https://example.com" isExternalLink>
         External Link
       </XDSLink>,
     );
     const link = screen.getByRole('link');
     expect(link).toHaveAttribute('target', '_blank');
     expect(link).toHaveAttribute('rel', 'noopener noreferrer');
-    // Check for the icon (SVG element)
     expect(link.querySelector('svg')).toBeInTheDocument();
   });
 
   it('renders external link with existing rel merged', () => {
     render(
       <XDSLink
-        label="External"
         href="https://example.com"
         isExternalLink
         rel="sponsored">
@@ -126,7 +133,7 @@ describe('XDSLink', () => {
 
   it('renders with custom target without isExternalLink', () => {
     render(
-      <XDSLink label="Target" href="/test" target="_parent">
+      <XDSLink href="/test" target="_parent">
         Parent Link
       </XDSLink>,
     );
@@ -138,7 +145,7 @@ describe('XDSLink', () => {
     const user = userEvent.setup();
     const handleClick = vi.fn(e => e.preventDefault());
     render(
-      <XDSLink label="Click me" href="/test" onClick={handleClick}>
+      <XDSLink href="/test" onClick={handleClick}>
         Click me
       </XDSLink>,
     );
@@ -150,7 +157,7 @@ describe('XDSLink', () => {
   it('forwards ref correctly', () => {
     const ref = vi.fn();
     render(
-      <XDSLink label="Test" href="/test" ref={ref}>
+      <XDSLink href="/test" ref={ref}>
         Test
       </XDSLink>,
     );
@@ -159,7 +166,7 @@ describe('XDSLink', () => {
 
   it('renders standalone link', () => {
     render(
-      <XDSLink label="Standalone Link" href="/standalone" isStandalone>
+      <XDSLink href="/standalone" isStandalone>
         Standalone Link
       </XDSLink>,
     );
@@ -168,7 +175,7 @@ describe('XDSLink', () => {
 
   it('renders link with tooltip', () => {
     render(
-      <XDSLink label="Settings" href="/settings" tooltip="Configure settings">
+      <XDSLink href="/settings" tooltip="Configure settings">
         Settings
       </XDSLink>,
     );
@@ -178,11 +185,11 @@ describe('XDSLink', () => {
 
   it('renders custom component when as is provided', () => {
     render(
-      <XDSLink label="Custom" href="/custom" as={CustomLink}>
+      <XDSLink href="/custom" as={CustomLink}>
         Custom Link
       </XDSLink>,
     );
-    const link = screen.getByRole('link', {name: 'Custom'});
+    const link = screen.getByRole('link', {name: 'Custom Link'});
     expect(link).toHaveAttribute('data-custom-link');
     expect(link).toHaveAttribute('href', '/custom');
   });
@@ -190,12 +197,12 @@ describe('XDSLink', () => {
   it('renders custom component from XDSLinkProvider', () => {
     render(
       <XDSLinkProvider component={CustomLink}>
-        <XDSLink label="Provider" href="/provider">
+        <XDSLink href="/provider">
           Provider Link
         </XDSLink>
       </XDSLinkProvider>,
     );
-    const link = screen.getByRole('link', {name: 'Provider'});
+    const link = screen.getByRole('link', {name: 'Provider Link'});
     expect(link).toHaveAttribute('data-custom-link');
   });
 
@@ -210,23 +217,23 @@ describe('XDSLink', () => {
     ));
     render(
       <XDSLinkProvider component={AnotherLink}>
-        <XDSLink label="Override" href="/override" as={CustomLink}>
+        <XDSLink href="/override" as={CustomLink}>
           Override Link
         </XDSLink>
       </XDSLinkProvider>,
     );
-    const link = screen.getByRole('link', {name: 'Override'});
+    const link = screen.getByRole('link', {name: 'Override Link'});
     expect(link).toHaveAttribute('data-custom-link');
     expect(link).not.toHaveAttribute('data-another-link');
   });
 
   it('renders xds-* class names for theme targeting', () => {
     render(
-      <XDSLink label="Themed" href="/test" color="secondary">
+      <XDSLink href="/test" color="secondary">
         Themed Link
       </XDSLink>,
     );
-    const link = screen.getByRole('link', {name: 'Themed'});
+    const link = screen.getByRole('link', {name: 'Themed Link'});
     expect(link.className).toContain('xds-link');
     expect(link.className).toContain('secondary');
   });

--- a/packages/core/src/Link/XDSLink.tsx
+++ b/packages/core/src/Link/XDSLink.tsx
@@ -119,10 +119,12 @@ export interface XDSLinkProps extends XDSBaseProps<HTMLAnchorElement> {
    */
   as?: XDSLinkComponentType;
   /**
-   * Accessible label for the link (required for accessibility).
-   * Used as aria-label when content is not self-descriptive.
+   * Accessible label for the link.
+   * Used as aria-label when content is not self-descriptive
+   * (e.g. icon-only links). When children are text, this is
+   * unnecessary — the link text itself serves as the label.
    */
-  label: string;
+  label?: string;
   /**
    * Link destination URL.
    */
@@ -219,10 +221,11 @@ export interface XDSLinkProps extends XDSBaseProps<HTMLAnchorElement> {
  *
  * @example
  * ```
- * <XDSLink label="Documentation" href="/docs">Documentation</XDSLink>
- * <XDSLink label="GitHub" href="https://github.com" isExternalLink>GitHub</XDSLink>
- * <XDSLink label="Settings" href="/settings" color="secondary">Settings</XDSLink>
- * <XDSLink label="Privacy Policy" href="/privacy" hasUnderline>Privacy Policy</XDSLink>
+ * <XDSLink href="/docs">Documentation</XDSLink>
+ * <XDSLink href="https://github.com" isExternalLink>GitHub</XDSLink>
+ * <XDSLink href="/settings" color="secondary">Settings</XDSLink>
+ * <XDSLink href="/privacy" hasUnderline>Privacy Policy</XDSLink>
+ * <XDSLink label="Close dialog" href="/home"><XDSIcon icon="x" /></XDSLink>
  * ```
  */
 export function XDSLink({
@@ -266,7 +269,7 @@ export function XDSLink({
       target={computedTarget}
       rel={computedRel}
       onClick={onClick}
-      aria-label={label}
+      aria-label={label || undefined}
       aria-disabled={isDisabled || undefined}
       tabIndex={isDisabled ? -1 : undefined}
       {...mergeProps(

--- a/packages/core/src/Link/useXDSLinkify.tsx
+++ b/packages/core/src/Link/useXDSLinkify.tsx
@@ -198,7 +198,6 @@ export function useXDSLinkify(
         <XDSLink
           key={`linkify-${i}`}
           href={m.href}
-          label={m.label}
           isExternalLink={m.isExternal}
         >
           {m.label}

--- a/packages/core/src/SideNav/XDSSideNavHeading.tsx
+++ b/packages/core/src/SideNav/XDSSideNavHeading.tsx
@@ -544,7 +544,6 @@ export function XDSSideNavHeading({
       {superheading &&
         (hasAnyHref && superheadingHref && menu ? (
           <XDSLink
-            label={superheading}
             href={superheadingHref}
             color="secondary"
             size="xsm">
@@ -568,7 +567,6 @@ export function XDSSideNavHeading({
       {subheading &&
         (hasAnyHref && subheadingHref && menu ? (
           <XDSLink
-            label={subheading}
             href={subheadingHref}
             color="secondary"
             size="xsm">
@@ -760,7 +758,6 @@ export function XDSSideNavHeading({
           {superheading &&
             (superheadingHref ? (
               <XDSLink
-                label={superheading}
                 href={superheadingHref}
                 color="secondary"
                 size="xsm">
@@ -771,7 +768,6 @@ export function XDSSideNavHeading({
             ))}
           {headingHref ? (
             <XDSLink
-              label={heading}
               href={headingHref}
               color="primary"
               weight="semibold">
@@ -789,7 +785,6 @@ export function XDSSideNavHeading({
           {subheading &&
             (subheadingHref ? (
               <XDSLink
-                label={subheading}
                 href={subheadingHref}
                 color="secondary"
                 size="xsm">

--- a/packages/core/src/TopNav/XDSTopNavHeading.tsx
+++ b/packages/core/src/TopNav/XDSTopNavHeading.tsx
@@ -372,7 +372,6 @@ export function XDSTopNavHeading({
       {superheading &&
         (hasAnyHref && superheadingHref && menu ? (
           <XDSLink
-            label={superheading}
             href={superheadingHref}
             color="secondary"
             size="xsm">
@@ -396,7 +395,6 @@ export function XDSTopNavHeading({
       {subheading &&
         (hasAnyHref && subheadingHref && menu ? (
           <XDSLink
-            label={subheading}
             href={subheadingHref}
             color="secondary"
             size="xsm">
@@ -616,7 +614,6 @@ export function XDSTopNavHeading({
           {superheading &&
             (superheadingHref ? (
               <XDSLink
-                label={superheading}
                 href={superheadingHref}
                 color="secondary"
                 size="xsm">
@@ -627,7 +624,6 @@ export function XDSTopNavHeading({
             ))}
           {headingHref ? (
             <XDSLink
-              label={heading ?? ''}
               href={headingHref}
               color="primary"
               weight="semibold">
@@ -639,7 +635,6 @@ export function XDSTopNavHeading({
           {subheading &&
             (subheadingHref ? (
               <XDSLink
-                label={subheading}
                 href={subheadingHref}
                 color="secondary"
                 size="xsm">


### PR DESCRIPTION
## Problem

`XDSLink` has required `label: string` since the initial implementation (#97), modeled after `XDSButton`. But links and buttons have fundamentally different accessibility semantics:

- **Buttons**: `label` is the visible text *and* the accessible name — it serves double duty.
- **Links**: The **children text IS the accessible name**. Adding `aria-label` on top actually *overrides* the visible text for screen readers.

This means every text link in XDS was harming assistive technology users — screen readers would announce the `aria-label` instead of reading the actual link content. It also forced developers to duplicate the link text as a prop, which was pure boilerplate.

## Changes

### Core
- Make `label` optional on `XDSLink` — only renders `aria-label` when explicitly provided
- Update JSDoc to clarify: only use `label` when children are not self-descriptive (e.g. icon-only links)

### Docs
- Add best practice: *"Only set `label` when the link content is not descriptive text"*
- Add anti-pattern: *"Don't set `label` on text links — aria-label prevents AT from reading actual link content"*
- Updated across all three doc variants (en, zh, dense)

### Callsite cleanup
- Removed redundant `label` props from **all** text link callsites across templates, storybook, sandbox, and core components (SideNavHeading, TopNavHeading, useXDSLinkify)

### Tests
- Updated tests to not pass `label` by default
- Added explicit test: `does not render aria-label when label is omitted`
- Added explicit test: `renders aria-label when label prop is provided`

## When to use `label`

```tsx
// ✅ Text links — no label needed
<XDSLink href="/docs">Documentation</XDSLink>

// ✅ Icon-only link — label required for accessibility  
<XDSLink label="Close dialog" href="/home"><XDSIcon icon="x" /></XDSLink>
```