### PR TITLE
feat(sandbox): register Stone, Gothic, and Chocolate themes

### DIFF
--- a/apps/sandbox/package.json
+++ b/apps/sandbox/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "build:deps": "yarn workspace @xds/theme-default build && yarn workspace @xds/theme-neutral build && yarn workspace @xds/theme-brutalist build && yarn workspace @xds/theme-matcha build && yarn workspace @xds/theme-daily build",
+    "build:deps": "yarn workspace @xds/theme-default build && yarn workspace @xds/theme-neutral build && yarn workspace @xds/theme-brutalist build && yarn workspace @xds/theme-matcha build && yarn workspace @xds/theme-daily build && yarn workspace @xds/theme-stone build && yarn workspace @xds/theme-gothic build && yarn workspace @xds/theme-chocolate build",
     "generate:versions": "node scripts/generate-versions.js",
     "generate:changelog": "node scripts/generate-changelog.js",
     "generate:cli": "node scripts/generate-cli-registry.mjs",
@@ -28,7 +28,10 @@
     "next": "^15.5.15",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
-    "recharts": "^2.15.3"
+    "recharts": "^2.15.3",
+    "@xds/theme-stone": "*",
+    "@xds/theme-gothic": "*",
+    "@xds/theme-chocolate": "*"
   },
   "devDependencies": {
     "@babel/preset-react": "^7.25.0",

--- a/apps/sandbox/src/app/(fullscreen)/PreviewShell.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/PreviewShell.tsx
@@ -859,6 +859,9 @@ export function PreviewShell({children}: {children: React.ReactNode}) {
             {label: 'Brutalist', onClick: () => setThemeName('brutalist')},
             {label: 'Matcha', onClick: () => setThemeName('matcha')},
             {label: 'Daily', onClick: () => setThemeName('daily')},
+            {label: 'Stone', onClick: () => setThemeName('stone')},
+            {label: 'Gothic', onClick: () => setThemeName('gothic')},
+            {label: 'Chocolate', onClick: () => setThemeName('chocolate')},
           ]}
         />
         <XDSButton

--- a/apps/sandbox/src/app/(fullscreen)/pages/example-cards/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/example-cards/page.tsx
@@ -114,6 +114,9 @@ export default function ExampleCardsPage() {
     'Meta',
     'WhatsApp',
     'Daily',
+    'Stone',
+    'Gothic',
+    'Chocolate',
   ];
   const modeOptions = ['Light', 'Dark'];
 

--- a/apps/sandbox/src/app/SandboxNav.tsx
+++ b/apps/sandbox/src/app/SandboxNav.tsx
@@ -57,6 +57,9 @@ function SandboxHeader() {
     {label: 'Brutalist', onClick: () => setThemeName('brutalist')},
     {label: 'Matcha', onClick: () => setThemeName('matcha')},
     {label: 'Daily', onClick: () => setThemeName('daily')},
+    {label: 'Stone', onClick: () => setThemeName('stone')},
+    {label: 'Gothic', onClick: () => setThemeName('gothic')},
+    {label: 'Chocolate', onClick: () => setThemeName('chocolate')},
   ];
 
   const modeItems = [

--- a/apps/sandbox/src/app/globals.css
+++ b/apps/sandbox/src/app/globals.css
@@ -5,5 +5,8 @@
 @import "@xds/theme-brutalist/theme.css";
 @import "@xds/theme-matcha/theme.css";
 @import "@xds/theme-daily/theme.css";
+@import "@xds/theme-stone/theme.css";
+@import "@xds/theme-gothic/theme.css";
+@import "@xds/theme-chocolate/theme.css";
 
 @stylex;

--- a/apps/sandbox/src/app/providers.tsx
+++ b/apps/sandbox/src/app/providers.tsx
@@ -8,6 +8,9 @@ import {neutralTheme} from '@xds/theme-neutral/built';
 import {brutalistTheme} from '@xds/theme-brutalist/built';
 import {matchaTheme} from '@xds/theme-matcha/built';
 import {dailyTheme} from '@xds/theme-daily/built';
+import {stoneTheme} from '@xds/theme-stone/built';
+import {gothicTheme} from '@xds/theme-gothic/built';
+import {chocolateTheme} from '@xds/theme-chocolate/built';
 import type {XDSDefinedTheme, ThemeMode} from '@xds/core/theme';
 
 const themes: Record<string, XDSDefinedTheme> = {
@@ -16,6 +19,9 @@ const themes: Record<string, XDSDefinedTheme> = {
   brutalist: brutalistTheme,
   matcha: matchaTheme,
   daily: dailyTheme,
+  stone: stoneTheme,
+  gothic: gothicTheme,
+  chocolate: chocolateTheme,
 };
 
 type ThemeContextValue = {


### PR DESCRIPTION
Wires the three new theme packages into the sandbox app so they appear in all theme pickers.

## Changes

- **providers.tsx** — import and register `stoneTheme`, `gothicTheme`, `chocolateTheme`
- **globals.css** — import `theme.css` for each new theme (required for built themes)
- **PreviewShell.tsx** — add to toolbar dropdown
- **SandboxNav.tsx** — add to sidebar theme picker
- **example-cards/page.tsx** — add to card example page theme options
- **package.json** — add workspace dependencies and build:deps entries

## Dependencies

This PR depends on the theme packages being merged first:
- #2020 — Stone theme
- #2024 — Gothic theme
- #2026 — Chocolate theme