### PR TITLE
fix(docsite): filter theme registry to only installed packages

### DIFF
--- a/apps/docsite/scripts/generate-data.mjs
+++ b/apps/docsite/scripts/generate-data.mjs
@@ -685,7 +685,11 @@ export const docsCount = ${docTopics.length};
 
 function generateThemeRegistry(packages) {
   console.log('Generating theme registry...');
-  const themePackages = packages.filter(p => p.name.startsWith('@xds/theme-'));
+  const docsitePkg = JSON.parse(fs.readFileSync(path.join(DOCSITE_ROOT, 'package.json'), 'utf-8'));
+  const docsiteDeps = {...docsitePkg.dependencies, ...docsitePkg.devDependencies};
+  const themePackages = packages.filter(p =>
+    p.name.startsWith('@xds/theme-') && docsiteDeps[p.name] != null
+  );
   if (!themePackages.length) {
     writeRegistry('themeRegistry.ts', `// Auto-generated — no theme packages found
 import type {XDSDefinedTheme} from '@xds/core/theme';

--- a/apps/docsite/src/__tests__/data-extraction.test.ts
+++ b/apps/docsite/src/__tests__/data-extraction.test.ts
@@ -487,15 +487,38 @@ describe('themeRegistry', () => {
     expect(registrySource).toContain('themeObjects');
   });
 
-  it('has an import and entry for every theme package', () => {
-    const themePackages = packages.filter(p =>
-      p.name.startsWith('@xds/theme-'),
+  it('has an import and entry for every installed theme package', () => {
+    const docsitePkg = JSON.parse(
+      fs.readFileSync(new URL('../../package.json', import.meta.url), 'utf-8'),
+    );
+    const docsiteDeps = {
+      ...docsitePkg.dependencies,
+      ...docsitePkg.devDependencies,
+    };
+    const themePackages = packages.filter(
+      p => p.name.startsWith('@xds/theme-') && docsiteDeps[p.name] != null,
     );
     expect(themePackages.length).toBeGreaterThan(0);
     for (const pkg of themePackages) {
       const slug = pkg.name.replace('@xds/theme-', '');
       expect(registrySource).toContain(`from '${pkg.name}/built'`);
       expect(registrySource).toContain(`'${pkg.name}': ${slug}Theme`);
+    }
+  });
+
+  it('excludes theme packages not installed in the docsite', () => {
+    const docsitePkg = JSON.parse(
+      fs.readFileSync(new URL('../../package.json', import.meta.url), 'utf-8'),
+    );
+    const docsiteDeps = {
+      ...docsitePkg.dependencies,
+      ...docsitePkg.devDependencies,
+    };
+    const uninstalled = packages.filter(
+      p => p.name.startsWith('@xds/theme-') && docsiteDeps[p.name] == null,
+    );
+    for (const pkg of uninstalled) {
+      expect(registrySource).not.toContain(`from '${pkg.name}/built'`);
     }
   });
 


### PR DESCRIPTION
The theme registry generator was including all non-private `@xds/theme-*` packages discovered in the monorepo, even if they aren't actually listed as dependencies of the docsite. This would cause build failures when a theme package exists in `packages/themes/` but isn't installed in the docsite (e.g. `@xds/theme-stone`).

Now reads the docsite's `package.json` to filter to only themes that are actual dependencies.

**Changes:**
- `generate-data.mjs`: Read docsite deps, filter theme packages against them
- `data-extraction.test.ts`: Updated theme registry tests to match new behavior, added test for exclusion of uninstalled themes