### PR TITLE
fix(Popover): remove close button that renders visibly outside popover

### DIFF
--- a/packages/core/src/Chat/useTriggerMenu.tsx
+++ b/packages/core/src/Chat/useTriggerMenu.tsx
@@ -281,7 +281,6 @@ export function useTriggerMenu(
       }));
     }, [removeAnchorSpan]),
     hasLightDismiss: true,
-    hasCloseButton: false,
     hasAutoFocus: false,
   });
 

--- a/packages/core/src/DateInput/XDSDateInput.tsx
+++ b/packages/core/src/DateInput/XDSDateInput.tsx
@@ -347,7 +347,6 @@ export function XDSDateInput({
 
   const popover = useXDSPopover({
     dialogLabel: 'Choose date',
-    closeButtonLabel: 'Close calendar',
     onHide: () => inputRef.current?.focus(),
   });
 

--- a/packages/core/src/DropdownMenu/XDSDropdownMenu.tsx
+++ b/packages/core/src/DropdownMenu/XDSDropdownMenu.tsx
@@ -222,7 +222,6 @@ export function XDSDropdownMenu({
     onHide: handleLayerHide,
     onShow: handleLayerShow,
     hasLightDismiss: true,
-    hasCloseButton: false,
     hasAutoFocus: false,
   });
 

--- a/packages/core/src/MultiSelector/XDSMultiSelector.tsx
+++ b/packages/core/src/MultiSelector/XDSMultiSelector.tsx
@@ -699,7 +699,6 @@ export function XDSMultiSelector<T extends XDSMultiSelectorOptionType>({
   const popover = useXDSPopover({
     hasLightDismiss: true,
     onHide: handleLayerHide,
-    hasCloseButton: false,
     hasAutoFocus: false,
     dialogLabel: `${label} options`,
   });

--- a/packages/core/src/Popover/Popover.doc.mjs
+++ b/packages/core/src/Popover/Popover.doc.mjs
@@ -67,18 +67,6 @@ export const docs = {
           description: 'Accessible label for the popover dialog.',
         },
         {
-          name: 'hasCloseButton',
-          type: 'boolean',
-          description: 'Whether to include a hidden close button for accessibility.',
-          default: 'true',
-        },
-        {
-          name: 'closeButtonLabel',
-          type: 'string',
-          description: 'Label for the hidden close button.',
-          default: "'Close popover'",
-        },
-        {
           name: 'hasAutoFocus',
           type: 'boolean',
           description: 'Whether to auto-focus the first focusable element when the popover opens. Set to false for inline showcases or documentation previews.',
@@ -188,18 +176,6 @@ export const docsZh = {
           description: '弹出框对话框的无障碍标签。',
         },
         {
-          name: 'hasCloseButton',
-          type: 'boolean',
-          description: '是否包含用于无障碍访问的隐藏关闭按钮。',
-          default: 'true',
-        },
-        {
-          name: 'closeButtonLabel',
-          type: 'string',
-          description: '隐藏关闭按钮的标签。',
-          default: "'Close popover'",
-        },
-        {
           name: 'hasAutoFocus',
           type: 'boolean',
           description: '弹出框打开时是否自动聚焦第一个可聚焦元素。内联展示或文档预览设为 false。',
@@ -273,8 +249,6 @@ export const docsDense = {
         isEnabled: 'When false, trigger interactions ignored.',
         width: 'Popover container width.',
         label: 'Accessible label for popover dialog.',
-        hasCloseButton: 'Whether to include hidden close button for accessibility.',
-        closeButtonLabel: 'Label for hidden close button.',
         hasAutoFocus: 'Auto-focus first element on open; false for showcases.',
       },
     },

--- a/packages/core/src/Popover/XDSPopover.tsx
+++ b/packages/core/src/Popover/XDSPopover.tsx
@@ -146,19 +146,6 @@ export interface XDSPopoverProps {
   style?: React.CSSProperties;
 
   /**
-   * Whether to include a hidden close button for accessibility.
-   * The button appears when keyboard users tab past the last element.
-   * @default true
-   */
-  hasCloseButton?: boolean;
-
-  /**
-   * Label for the hidden close button.
-   * @default "Close popover"
-   */
-  closeButtonLabel?: string;
-
-  /**
    * Whether to auto-focus the first focusable element when the popover opens.
    * Set to `false` for inline showcases or documentation previews.
    * @default true
@@ -253,8 +240,6 @@ export function XDSPopover({
   isEnabled = true,
   width,
   label,
-  hasCloseButton,
-  closeButtonLabel,
   hasAutoFocus,
   xstyle,
   className,
@@ -279,8 +264,6 @@ export function XDSPopover({
   const popover = useXDSPopover({
     dialogLabel: label,
     hasLightDismiss: true,
-    hasCloseButton,
-    closeButtonLabel,
     hasAutoFocus,
     onShow: handlePopoverShow,
     onHide: handlePopoverHide,

--- a/packages/core/src/Popover/useXDSPopover.tsx
+++ b/packages/core/src/Popover/useXDSPopover.tsx
@@ -23,13 +23,7 @@ import {
 } from '../Layer/useXDSLayer';
 import {useFocusTrap} from '../hooks/useFocusTrap';
 import type {StyleXStyles} from '@stylexjs/stylex';
-import {
-  colorVars,
-  spacingVars,
-  radiusVars,
-  shadowVars,
-} from '../theme/tokens.stylex';
-import {XDSButton} from '../Button';
+import {colorVars, radiusVars, shadowVars} from '../theme/tokens.stylex';
 
 const styles = stylex.create({
   // Default popover surface — background, radius, shadow.
@@ -43,39 +37,6 @@ const styles = stylex.create({
   // Focus trap container
   contentWrapper: {
     position: 'relative',
-  },
-  // Hidden close button wrapper - sr-only until focused, then positioned below popover
-  closeButtonWrapper: {
-    position: 'absolute',
-    bottom: 0,
-    left: '50%',
-    transform: 'translate(-50%, 100%)',
-    zIndex: 1,
-    // sr-only by default
-    width: {
-      default: 1,
-      ':focus-within': 'auto',
-    },
-    height: {
-      default: 1,
-      ':focus-within': 'auto',
-    },
-    overflow: {
-      default: 'hidden',
-      ':focus-within': 'visible',
-    },
-    clipPath: {
-      default: 'inset(50%)',
-      ':focus-within': 'none',
-    },
-    pointerEvents: {
-      default: 'none',
-      ':focus-within': 'auto',
-    },
-    paddingBlockStart: {
-      default: 0,
-      ':focus-within': spacingVars['--spacing-1'],
-    },
   },
 });
 
@@ -117,19 +78,6 @@ export interface UseXDSPopoverOptions {
    * @default true
    */
   hasAutoFocus?: boolean;
-
-  /**
-   * Whether to include a hidden close button for accessibility.
-   * The button appears when keyboard users tab past the last element.
-   * @default true
-   */
-  hasCloseButton?: boolean;
-
-  /**
-   * Label for the hidden close button.
-   * @default "Close popover"
-   */
-  closeButtonLabel?: string;
 
   /**
    * Accessible label for the dialog.
@@ -202,7 +150,7 @@ export interface UseXDSPopoverReturn {
 
   /**
    * Render function for popover content.
-   * Automatically wraps content in a focus trap container with a hidden close button.
+   * Wraps content in a focus trap container with surface styles.
    *
    * @example
    * ```
@@ -232,11 +180,7 @@ export interface UseXDSPopoverReturn {
  * - `useFocusTrap` for trapping focus within the popover content
  * - Auto-focus first element on open
  * - Escape key to close
- * - Hidden close button that reveals on focus for accessibility
- *
- * The render function automatically wraps your content in a focus trap container
- * and appends a hidden close button. The button appears at the end of the popover,
- * is visually hidden until focused, then shows a tooltip-like message (default: "Close popover").
+ * - Light dismiss (click outside) to close
  *
  * @example
  * ```
@@ -244,7 +188,6 @@ export interface UseXDSPopoverReturn {
  *   const inputRef = useRef<HTMLInputElement>(null);
  *   const popover = useXDSPopover({
  *     onHide: () => inputRef.current?.focus(),
- *     closeButtonLabel: 'Close calendar',
  *   });
  *   return (
  *     <>
@@ -274,8 +217,6 @@ export function useXDSPopover(
     hasLightDismiss = true,
     hasAutoFocus = true,
     hasSurface = true,
-    hasCloseButton = true,
-    closeButtonLabel = 'Close popover',
     dialogLabel,
   } = options;
 
@@ -347,7 +288,7 @@ export function useXDSPopover(
     'aria-controls': layer.id,
   };
 
-  // Wrapped render function that includes surface styles and optional hidden close button
+  // Wrapped render function that includes surface styles
   const render = useCallback(
     (children: ReactNode, props?: ContextRenderProps) => {
       return layer.render(
@@ -362,28 +303,11 @@ export function useXDSPopover(
             xstyle,
           )}>
           {children}
-          {hasCloseButton && (
-            <div {...stylex.props(styles.closeButtonWrapper)}>
-              <XDSButton
-                variant="secondary"
-                label={closeButtonLabel}
-                onClick={layer.hide}
-              />
-            </div>
-          )}
         </div>,
         {...props, xstyle: props?.xstyle},
       );
     },
-    [
-      layer,
-      hasCloseButton,
-      hasSurface,
-      closeButtonLabel,
-      contentRef,
-      dialogLabel,
-      xstyle,
-    ],
+    [layer, hasSurface, contentRef, dialogLabel, xstyle],
   );
 
   return {

--- a/packages/core/src/PowerSearch/XDSPowerSearch.tsx
+++ b/packages/core/src/PowerSearch/XDSPowerSearch.tsx
@@ -521,7 +521,6 @@ export function XDSPowerSearch({
   const popover = useXDSPopover({
     onHide: handleLayerHide,
     hasLightDismiss: true,
-    hasCloseButton: false,
     hasAutoFocus: false,
   });
 

--- a/packages/core/src/Selector/XDSSelector.tsx
+++ b/packages/core/src/Selector/XDSSelector.tsx
@@ -555,7 +555,6 @@ export function XDSSelector<T extends XDSSelectorOptionType>(
   const popover = useXDSPopover({
     onHide: handleLayerHide,
     hasLightDismiss: true,
-    hasCloseButton: false,
     hasAutoFocus: false,
   });
 

--- a/packages/core/src/SideNav/XDSSideNavHeading.tsx
+++ b/packages/core/src/SideNav/XDSSideNavHeading.tsx
@@ -371,7 +371,6 @@ export function XDSSideNavHeading({
 
   const popover = useXDSPopover({
     dialogLabel: 'Navigation menu',
-    hasCloseButton: false,
   });
 
   const {triggerProps, contentProps, menuRef, setTriggerEl} = useXDSMenuHover({
@@ -543,10 +542,7 @@ export function XDSSideNavHeading({
     <span {...stylex.props(styles.textContainer)}>
       {superheading &&
         (hasAnyHref && superheadingHref && menu ? (
-          <XDSLink
-            href={superheadingHref}
-            color="secondary"
-            size="xsm">
+          <XDSLink href={superheadingHref} color="secondary" size="xsm">
             {superheading}
           </XDSLink>
         ) : (
@@ -566,10 +562,7 @@ export function XDSSideNavHeading({
       </span>
       {subheading &&
         (hasAnyHref && subheadingHref && menu ? (
-          <XDSLink
-            href={subheadingHref}
-            color="secondary"
-            size="xsm">
+          <XDSLink href={subheadingHref} color="secondary" size="xsm">
             {subheading}
           </XDSLink>
         ) : (
@@ -757,20 +750,14 @@ export function XDSSideNavHeading({
         <span {...stylex.props(styles.textContainer)}>
           {superheading &&
             (superheadingHref ? (
-              <XDSLink
-                href={superheadingHref}
-                color="secondary"
-                size="xsm">
+              <XDSLink href={superheadingHref} color="secondary" size="xsm">
                 {superheading}
               </XDSLink>
             ) : (
               <span {...stylex.props(styles.superheading)}>{superheading}</span>
             ))}
           {headingHref ? (
-            <XDSLink
-              href={headingHref}
-              color="primary"
-              weight="semibold">
+            <XDSLink href={headingHref} color="primary" weight="semibold">
               {heading}
             </XDSLink>
           ) : (
@@ -784,10 +771,7 @@ export function XDSSideNavHeading({
           )}
           {subheading &&
             (subheadingHref ? (
-              <XDSLink
-                href={subheadingHref}
-                color="secondary"
-                size="xsm">
+              <XDSLink href={subheadingHref} color="secondary" size="xsm">
                 {subheading}
               </XDSLink>
             ) : (

--- a/packages/core/src/SideNav/XDSSideNavItem.tsx
+++ b/packages/core/src/SideNav/XDSSideNavItem.tsx
@@ -362,7 +362,6 @@ export function XDSSideNavItem({
   const popover = useXDSPopover({
     hasLightDismiss: true,
     hasAutoFocus: true,
-    hasCloseButton: false,
     dialogLabel: `${label} submenu`,
   });
 

--- a/packages/core/src/TabList/XDSTabMenu.tsx
+++ b/packages/core/src/TabList/XDSTabMenu.tsx
@@ -259,7 +259,6 @@ export function XDSTabMenu({
 
   const popover = useXDSPopover({
     hasLightDismiss: true,
-    hasCloseButton: false,
     hasAutoFocus: false,
   });
 

--- a/packages/core/src/TopNav/XDSTopNavHeading.tsx
+++ b/packages/core/src/TopNav/XDSTopNavHeading.tsx
@@ -332,7 +332,6 @@ export function XDSTopNavHeading({
 
   const popover = useXDSPopover({
     dialogLabel: 'Navigation menu',
-    hasCloseButton: false,
   });
 
   const {triggerProps, contentProps, menuRef, setTriggerEl} = useXDSMenuHover({
@@ -371,10 +370,7 @@ export function XDSTopNavHeading({
     <span {...stylex.props(styles.textContainer)}>
       {superheading &&
         (hasAnyHref && superheadingHref && menu ? (
-          <XDSLink
-            href={superheadingHref}
-            color="secondary"
-            size="xsm">
+          <XDSLink href={superheadingHref} color="secondary" size="xsm">
             {superheading}
           </XDSLink>
         ) : (
@@ -394,10 +390,7 @@ export function XDSTopNavHeading({
       </span>
       {subheading &&
         (hasAnyHref && subheadingHref && menu ? (
-          <XDSLink
-            href={subheadingHref}
-            color="secondary"
-            size="xsm">
+          <XDSLink href={subheadingHref} color="secondary" size="xsm">
             {subheading}
           </XDSLink>
         ) : (
@@ -613,20 +606,14 @@ export function XDSTopNavHeading({
         <span {...stylex.props(styles.textContainer)}>
           {superheading &&
             (superheadingHref ? (
-              <XDSLink
-                href={superheadingHref}
-                color="secondary"
-                size="xsm">
+              <XDSLink href={superheadingHref} color="secondary" size="xsm">
                 {superheading}
               </XDSLink>
             ) : (
               <span {...stylex.props(styles.superheading)}>{superheading}</span>
             ))}
           {headingHref ? (
-            <XDSLink
-              href={headingHref}
-              color="primary"
-              weight="semibold">
+            <XDSLink href={headingHref} color="primary" weight="semibold">
               {heading}
             </XDSLink>
           ) : (
@@ -634,10 +621,7 @@ export function XDSTopNavHeading({
           )}
           {subheading &&
             (subheadingHref ? (
-              <XDSLink
-                href={subheadingHref}
-                color="secondary"
-                size="xsm">
+              <XDSLink href={subheadingHref} color="secondary" size="xsm">
                 {subheading}
               </XDSLink>
             ) : (

--- a/packages/core/src/Typeahead/XDSBaseTypeahead.tsx
+++ b/packages/core/src/Typeahead/XDSBaseTypeahead.tsx
@@ -339,7 +339,6 @@ export const XDSBaseTypeahead = function XDSBaseTypeahead<
     onShow: handleLayerShow,
     onHide: handleLayerHide,
     hasLightDismiss: true,
-    hasCloseButton: false,
     hasAutoFocus: false,
   });
 


### PR DESCRIPTION
## Problem

The hidden close button in `useXDSPopover` was intended as an accessibility feature — visually hidden (sr-only) until a keyboard user tabs to it, at which point `:focus-within` reveals it below the popover.

However, when popover content has **no focusable elements** (e.g. the keyboard shortcuts popover with only text/headings), `focusFirst()` targets the close button itself on open. This triggers `:focus-within` on the wrapper, making the button **permanently visible** outside the popover.

**Repro:** https://studious-broccoli-o7e61n3.pages.github.io/sandbox/templates/PopoverKeyboardShortcuts/

## Root Cause

`useXDSPopover` has `hasAutoFocus: true` by default. When the popover opens, the focus trap's `focusFirst()` scans for focusable elements inside the container. If the popover content is purely informational (no buttons, inputs, or links), the only focusable element is the close button itself. Focusing it activates the `:focus-within` styles that were supposed to only activate on intentional keyboard tab navigation.

## Accessibility

The close button's intent was to give keyboard users a visible affordance to close the popover when they tab past the last element. In practice, it was redundant and actively harmful:

- **Escape key already closes the popover** — this is the standard keyboard dismiss pattern for dialogs and popovers per the [WAI-ARIA dialog pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/), and the focus trap already handles it.
- **The focus trap wraps** — tabbing past the last element cycles back to the first, so the user is never "stuck" needing a close button to escape.
- **The button broke accessibility for content-only popovers** — when it was the only focusable element, auto-focus grabbed it on open, so a screen reader user would hear "Close popover" as the first announced element instead of the actual content.
- **10 out of 11 consumers explicitly disabled it** (`hasCloseButton: false`) — every dropdown menu, selector, typeahead, and nav flyout opted out because a dangling close button made no sense in those contexts.

The WAI-ARIA dialog pattern does not require a visible close button — it requires Escape to close and proper focus management, both of which the hook already provides. If discoverability of the Escape key is a concern, a better future approach would be an `aria-description="Press Escape to close"` on the dialog rather than injecting a focusable element that interferes with content focus order.

## Fix

Remove the close button entirely. The popover already provides robust dismiss mechanisms:

- **Escape key** — handled by the focus trap's `onEscape` handler
- **Light dismiss** — click outside to close (via Popover API)
- **Programmatic control** — `isOpen`/`onOpenChange` for controlled popovers

This removes:
- The `hasCloseButton` and `closeButtonLabel` props from both `useXDSPopover` and `XDSPopover`
- The `closeButtonWrapper` styles
- All consumer references to these props (11 components that passed `hasCloseButton: false`)
- Doc entries for the removed props

## Testing

- All 3,287 tests pass (188 test files)
- Build succeeds
- Lint passes (0 errors)