### PR TITLE
feat: utility showcases, AppShell playground defaults, mobile fixes

### DIFF
--- a/apps/docsite/src/components/component-detail/ComponentDetailClient.tsx
+++ b/apps/docsite/src/components/component-detail/ComponentDetailClient.tsx
@@ -9,6 +9,7 @@ import {XDSCard} from '@xds/core/Card';
 import {XDSDivider} from '@xds/core';
 import {XDSCodeBlock} from '@xds/core/CodeBlock';
 import {XDSTabList, XDSTab} from '@xds/core/TabList';
+import {useMediaQuery} from '@xds/core/hooks';
 import {ShowcasePreview} from './ShowcasePreview';
 import {BestPractices} from './BestPractices';
 import {HookSignature} from './HookSignature';
@@ -100,6 +101,7 @@ function ComponentDetailInner({
   const isHook = comp.params != null;
   const hasShowcase = comp.name in showcaseRegistry;
   const hasPlayground = !isHook;
+  const isMobile = useMediaQuery('(max-width: 768px)');
 
   const tab = searchParams.get('tab') ?? 'overview';
   const setTab = (value: string) => {
@@ -160,7 +162,7 @@ function ComponentDetailInner({
                     zIndex: 10,
                     backgroundColor: 'var(--color-background-page)',
                     backdropFilter: 'blur(16px)',
-                    maxHeight: 400,
+                    maxHeight: isMobile ? 250 : 400,
                     overflow: 'auto',
                   }}>
                   <InteractivePreviewStage name={comp.name} state={state} />

--- a/apps/docsite/src/components/component-detail/ExampleBlock.tsx
+++ b/apps/docsite/src/components/component-detail/ExampleBlock.tsx
@@ -71,7 +71,7 @@ export function ExampleBlock({entry}: ExampleBlockProps) {
 
       <LivePreview entry={entry} />
 
-      <XDSSection variant="wash" padding={0} dividers={['top']}>
+      <XDSSection variant="wash" padding={1} dividers={['top']}>
         <XDSTabList value={tab} onChange={setTab} size="sm">
           <XDSTab value="description" label="Description" />
           <XDSTab value="code" label="Code" />

--- a/packages/core/src/AppShell/AppShell.doc.mjs
+++ b/packages/core/src/AppShell/AppShell.doc.mjs
@@ -50,7 +50,7 @@ export const docs = {
       type: 'ReactNode',
       description:
         'Banner slot for system-wide announcements, placed above the topNav.',
-      slotElements: [{__element: 'XDSBanner', props: {title: 'Info', status: 'info'}}],
+      slotElements: [{__element: 'XDSBanner', props: {title: 'Info', status: 'info', container: 'section'}}],
     },
     {
       name: 'height',
@@ -90,6 +90,34 @@ export const docs = {
         'StyleX styles for layout customization (margins, positioning, sizing). Must be a stylex.create() value — not an inline style object like style={{}}.',
     },
   ],
+  playground: {
+    defaults: {
+      variant: 'surface',
+      contentPadding: 4,
+      topNav: {
+        __element: 'XDSTopNav',
+        props: {label: 'Navigation'},
+        children: {__element: 'XDSText', props: {type: 'body', weight: 'bold'}, children: 'My App'},
+      },
+      sideNav: {
+        __element: 'XDSSideNav',
+        props: {},
+        children: [
+          {__element: 'XDSSideNavItem', props: {label: 'Dashboard', isSelected: true}},
+          {__element: 'XDSSideNavItem', props: {label: 'Settings'}},
+          {__element: 'XDSSideNavItem', props: {label: 'Help'}},
+        ],
+      },
+      children: {
+        __element: 'XDSVStack',
+        props: {gap: 3},
+        children: [
+          {__element: 'XDSHeading', props: {level: 2}, children: 'Dashboard'},
+          {__element: 'XDSText', props: {type: 'body', color: 'secondary'}, children: 'Welcome back. Here is an overview of your workspace.'},
+        ],
+      },
+    },
+  },
   theming: {
     targets: [
       {className: 'xds-app-shell', visualProps: ['variant']},


### PR DESCRIPTION
## Showcases for theme utilities

Three new showcase blocks:

- **Theme** — side-by-side default and neutral themes wrapping identical content
- **MediaTheme** — content on inverted surfaces (dark overlay + light wash)
- **SyntaxTheme** — same code block with GitHub Light, One Dark Pro, and Dracula

## Doc improvements

- **MediaTheme.doc.mjs** — corrected description: inverted surfaces (overlays, toasts, tooltips), not system dark/light mode. Added best practices about onDark/onLight in defineTheme().
- **SyntaxTheme.doc.mjs** — expanded with 14-token architecture, preset list, defineTheme integration, defineSyntaxTheme() API.

## AppShell playground defaults

AppShell now renders with meaningful content in the playground:
- TopNav with "My App" heading
- SideNav with Dashboard/Settings/Help items
- Content area with heading and description

## Mobile fixes

- Playground preview max height capped at 250px on mobile (was 400px for all sizes)
- Example card tab section has 4px padding

## Housekeeping

- Fixed test to use `blockCount` instead of hardcoded 468
- Updated component-resolution test (Theme now has a showcase)
- Reviewed all showcases against template rubric: fixed componentsUsed, replaced raw divs