### PR TITLE
fix(docsite): filter package registry to installed dependencies

### DIFF
--- a/apps/docsite/scripts/generate-data.mjs
+++ b/apps/docsite/scripts/generate-data.mjs
@@ -120,6 +120,8 @@ function generatePackageRegistry() {
   console.log('Generating package registry...');
 
   const packageDirs = discoverPackageDirs();
+  const docsitePkg = JSON.parse(fs.readFileSync(path.join(DOCSITE_ROOT, 'package.json'), 'utf-8'));
+  const docsiteDeps = {...docsitePkg.dependencies, ...docsitePkg.devDependencies};
 
   const packages = packageDirs
     .map(dir => {
@@ -128,6 +130,9 @@ function generatePackageRegistry() {
 
       // Skip private packages
       if (raw.private === true) return null;
+
+      // Skip packages not installed in the docsite
+      if (docsiteDeps[raw.name] == null) return null;
 
       const hasReadme = fs.existsSync(path.join(REPO_ROOT, dir, 'README.md'));
       const hasChangelog = fs.existsSync(path.join(REPO_ROOT, dir, 'CHANGELOG.md'));
@@ -685,11 +690,7 @@ export const docsCount = ${docTopics.length};
 
 function generateThemeRegistry(packages) {
   console.log('Generating theme registry...');
-  const docsitePkg = JSON.parse(fs.readFileSync(path.join(DOCSITE_ROOT, 'package.json'), 'utf-8'));
-  const docsiteDeps = {...docsitePkg.dependencies, ...docsitePkg.devDependencies};
-  const themePackages = packages.filter(p =>
-    p.name.startsWith('@xds/theme-') && docsiteDeps[p.name] != null
-  );
+  const themePackages = packages.filter(p => p.name.startsWith('@xds/theme-'));
   if (!themePackages.length) {
     writeRegistry('themeRegistry.ts', `// Auto-generated — no theme packages found
 import type {XDSDefinedTheme} from '@xds/core/theme';

--- a/apps/docsite/src/__tests__/data-extraction.test.ts
+++ b/apps/docsite/src/__tests__/data-extraction.test.ts
@@ -18,7 +18,7 @@ import {exampleRegistry} from '../generated/exampleRegistry';
 // ── Package Registry ───────────────────────────────────────────────────
 
 describe('packageRegistry', () => {
-  it('discovers all published packages (private packages excluded)', () => {
+  it('discovers installed packages (private and uninstalled excluded)', () => {
     const names = packages.map(p => p.name);
     expect(names).toContain('@xds/core');
     expect(names).toContain('@xds/cli');
@@ -28,6 +28,19 @@ describe('packageRegistry', () => {
     expect(names).not.toContain('@xds/build');
     expect(names).not.toContain('@xds/theme-brutalist');
     expect(packages.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it('only includes packages listed in docsite dependencies', () => {
+    const docsitePkg = JSON.parse(
+      fs.readFileSync(new URL('../../package.json', import.meta.url), 'utf-8'),
+    );
+    const docsiteDeps = {
+      ...docsitePkg.dependencies,
+      ...docsitePkg.devDependencies,
+    };
+    for (const pkg of packages) {
+      expect(docsiteDeps[pkg.name]).toBeDefined();
+    }
   });
 
   it('each package has required fields', () => {
@@ -487,38 +500,15 @@ describe('themeRegistry', () => {
     expect(registrySource).toContain('themeObjects');
   });
 
-  it('has an import and entry for every installed theme package', () => {
-    const docsitePkg = JSON.parse(
-      fs.readFileSync(new URL('../../package.json', import.meta.url), 'utf-8'),
-    );
-    const docsiteDeps = {
-      ...docsitePkg.dependencies,
-      ...docsitePkg.devDependencies,
-    };
-    const themePackages = packages.filter(
-      p => p.name.startsWith('@xds/theme-') && docsiteDeps[p.name] != null,
+  it('has an import and entry for every theme package', () => {
+    const themePackages = packages.filter(p =>
+      p.name.startsWith('@xds/theme-'),
     );
     expect(themePackages.length).toBeGreaterThan(0);
     for (const pkg of themePackages) {
       const slug = pkg.name.replace('@xds/theme-', '');
       expect(registrySource).toContain(`from '${pkg.name}/built'`);
       expect(registrySource).toContain(`'${pkg.name}': ${slug}Theme`);
-    }
-  });
-
-  it('excludes theme packages not installed in the docsite', () => {
-    const docsitePkg = JSON.parse(
-      fs.readFileSync(new URL('../../package.json', import.meta.url), 'utf-8'),
-    );
-    const docsiteDeps = {
-      ...docsitePkg.dependencies,
-      ...docsitePkg.devDependencies,
-    };
-    const uninstalled = packages.filter(
-      p => p.name.startsWith('@xds/theme-') && docsiteDeps[p.name] == null,
-    );
-    for (const pkg of uninstalled) {
-      expect(registrySource).not.toContain(`from '${pkg.name}/built'`);
     }
   });
 


### PR DESCRIPTION
Follows up on #2035 which filtered the theme registry but missed the package registry.

The home page, craft page, and sidebar nav all iterate over `packages` from `packageRegistry.ts`. That list included every non-private monorepo package — even ones not listed as docsite dependencies (e.g. `@xds/theme-stone`). These showed up as broken cards.

**Fix:** Added an installed-deps check to `generatePackageRegistry()` so the filter applies once at the source, and every downstream consumer gets the correct list.

**Changes:**
- `generate-data.mjs`: Read docsite `package.json` deps, skip packages not listed
- `data-extraction.test.ts`: Updated package registry test, added assertion that all packages are docsite deps