### PR TITLE
docs(common-props): add xstyle entries to 6 remaining components

### DIFF
--- a/packages/core/src/Chat/ChatToolCalls.doc.mjs
+++ b/packages/core/src/Chat/ChatToolCalls.doc.mjs
@@ -60,6 +60,12 @@ export const docs = {
       type: '(isExpanded: boolean) => void',
       description: 'Callback fired when the expanded state changes.',
     },
+    {
+      name: 'xstyle',
+      type: 'StyleXStyles',
+      description:
+        'StyleX styles for layout customization (margins, positioning, sizing). Must be a stylex.create() value — not an inline style object like style={{}}.',
+    },
   ],
 };
 

--- a/packages/core/src/ClickableCard/ClickableCard.doc.mjs
+++ b/packages/core/src/ClickableCard/ClickableCard.doc.mjs
@@ -26,6 +26,7 @@ export const docs = {
     {name: 'width', type: 'SizeValue', description: 'Card width.'},
     {name: 'height', type: 'SizeValue', description: 'Card height.'},
     {name: 'maxWidth', type: 'SizeValue', description: 'Maximum card width.'},
+    {name: 'xstyle', type: 'StyleXStyles', description: 'StyleX styles for layout customization (margins, positioning, sizing). Must be a stylex.create() value — not an inline style object like style={{}}.'},
   ],
   theming: {
     container: true,

--- a/packages/core/src/NavMenu/NavMenu.doc.mjs
+++ b/packages/core/src/NavMenu/NavMenu.doc.mjs
@@ -15,5 +15,6 @@ export const docs = {
     {name: 'children', type: 'ReactNode', required: true, description: 'Menu items.'},
     {name: 'size', type: "'sm' | 'md' | 'lg'", default: "'md'", description: 'Controls min-width and item padding.'},
     {name: 'minWidth', type: 'number | string', description: 'Minimum width override.'},
+    {name: 'xstyle', type: 'StyleXStyles', description: 'StyleX styles for layout customization (margins, positioning, sizing). Must be a stylex.create() value — not an inline style object like style={{}}.'},
   ],
 };

--- a/packages/core/src/Popover/useXDSPopover.doc.mjs
+++ b/packages/core/src/Popover/useXDSPopover.doc.mjs
@@ -43,6 +43,11 @@ export const docs = {
       type: '() => void',
       description: 'Callback fired when the popover is hidden.',
     },
+    {
+      name: 'xstyle',
+      type: 'StyleXStyles',
+      description: 'StyleX styles for the popover surface (margins, sizing). Must be a stylex.create() value — not an inline style object. Note: for styles that interact with :popover-open, pass xstyle via the render() call props instead.',
+    },
   ],
   returns: [
     {

--- a/packages/core/src/Resizable/Resizable.doc.mjs
+++ b/packages/core/src/Resizable/Resizable.doc.mjs
@@ -171,6 +171,12 @@ export const docs = {
           description:
             'Custom handle content. Overrides the default pill + divider.',
         },
+        {
+          name: 'xstyle',
+          type: 'StyleXStyles',
+          description:
+            'StyleX styles for layout customization (margins, positioning, sizing). Must be a stylex.create() value — not an inline style object like style={{}}.',
+        },
       ],
     },
   ],

--- a/packages/core/src/SelectableCard/SelectableCard.doc.mjs
+++ b/packages/core/src/SelectableCard/SelectableCard.doc.mjs
@@ -25,6 +25,7 @@ export const docs = {
     {name: 'width', type: 'SizeValue', description: 'Card width.'},
     {name: 'height', type: 'SizeValue', description: 'Card height.'},
     {name: 'maxWidth', type: 'SizeValue', description: 'Maximum card width.'},
+    {name: 'xstyle', type: 'StyleXStyles', description: 'StyleX styles for layout customization (margins, positioning, sizing). Must be a stylex.create() value — not an inline style object like style={{}}.'},
   ],
   theming: {
     container: true,


### PR DESCRIPTION
## What

Add missing `xstyle` prop documentation to the last 6 components/hooks that accept it but don't document it:

- **ChatToolCalls** — `xstyle` on root
- **ClickableCard** — `xstyle` on root  
- **NavMenu** (NavHeadingMenu) — `xstyle` on root
- **useXDSPopover** — `xstyle` param for popover surface
- **XDSResizeHandle** (in Resizable.doc.mjs) — `xstyle` on handle
- **SelectableCard** — `xstyle` on root

All entries include the `stylex.create()` guidance to prevent LLMs from passing inline style objects.

## Checklist
- [x] `yarn workspace @xds/core typecheck:docs` passes
- [x] CLI `--props` output verified
- [x] Consistent with xstyle entries in other components

---
*Night Watch — Doc Reviewer*