### PR TITLE
fix(CodeBlock, ClickableCard): add use client directives and hover guard

### DIFF
--- a/packages/core/src/ClickableCard/index.ts
+++ b/packages/core/src/ClickableCard/index.ts
@@ -1,2 +1,4 @@
+'use client';
+
 export {XDSClickableCard} from './XDSClickableCard';
 export type {XDSClickableCardProps} from './XDSClickableCard';

--- a/packages/core/src/CodeBlock/XDSCodeBlock.tsx
+++ b/packages/core/src/CodeBlock/XDSCodeBlock.tsx
@@ -204,7 +204,9 @@ const styles = stylex.create({
     borderRadius: radiusVars['--radius-inner'],
     backgroundColor: {
       default: 'transparent',
-      ':hover': colorVars['--color-overlay-hover'],
+      '@media (hover: hover)': {
+        ':hover': colorVars['--color-overlay-hover'],
+      },
     },
     color: 'var(--color-syntax-comment)',
     cursor: 'pointer',

--- a/packages/core/src/CodeBlock/index.ts
+++ b/packages/core/src/CodeBlock/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 export {XDSCodeBlock} from './XDSCodeBlock';
 export type {XDSCodeBlockProps} from './XDSCodeBlock';
 


### PR DESCRIPTION
## Summary

Add missing `'use client'` directives to barrel index files and fix an unguarded hover style.

## Changes

**CodeBlock/index.ts** — Add `'use client'` directive. The component files have it but the barrel re-export did not.

**ClickableCard/index.ts** — Add `'use client'` directive. Same pattern — component file has it, barrel didn't.

**CodeBlock copy button** — Wrap `:hover` background in `@media (hover: hover)` guard. Without this, touch devices show a stuck hover state on the copy button after tap. Matches the pattern used by ClickableCard and other interactive components.

## Audit Notes

Found during Night Watch Component Auditor second-pass audit of 5 new components: AlertDialog, Carousel, CheckboxList, ClickableCard, CodeBlock.

**Components audited — no issues found:**
- **AlertDialog**: Clean composition around XDSDialog. Extends XDSBaseProps, has xdsClassName, displayName, proper a11y (role=alertdialog, aria-labelledby, aria-describedby). Uses XDSButton for actions.
- **Carousel**: Extends XDSBaseProps, xdsClassName('carousel'), all tokens properly used (spacing, color, shadow, radius, duration, ease). Uses XDSButton + XDSIcon for nav buttons. Hover not applicable (no hover styles on carousel itself).
- **CheckboxList**: xdsClassName('checkbox-list'), composes XDSField + XDSList. XDSCheckboxListItem extends XDSBaseProps and uses XDSCheckboxInput.

**Noted for human review (not fixed here):**
- **XDSCode** does not extend `XDSBaseProps` — manually defines xstyle/className/style/data-testid but misses generic `data-*` support. Structural change, needs decision.
- **XDSCheckboxListProps** does not extend `XDSBaseProps` — same pattern, manually defines escape hatches but misses `data-*` support.
- **CodeBlock copy button** uses raw `<button>` + inline SVGs instead of `XDSButton` + `XDSIcon`. Composition violation, but the button has specific sizing needs (padding-1, no label) that may justify the current approach. Flagging for review.

Night Watch — Component Auditor