### PR TITLE
fix(cli): group useXDSToast and useXDSCollapsible with their components

### DIFF
--- a/packages/core/src/Collapsible/useXDSCollapsible.doc.mjs
+++ b/packages/core/src/Collapsible/useXDSCollapsible.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../docs-types').HookDoc} */
 export const docs = {
   name: 'useXDSCollapsible',
+  group: 'Collapsible',
   keywords: ['collapsible', 'collapse', 'expand', 'toggle', 'accordion', 'disclosure', 'fold'],
   params: [
     {

--- a/packages/core/src/Toast/useXDSToast.doc.mjs
+++ b/packages/core/src/Toast/useXDSToast.doc.mjs
@@ -1,6 +1,7 @@
 /** @type {import('../docs-types').HookDoc} */
 export const docs = {
   name: 'useXDSToast',
+  group: 'Toast',
   keywords: ['toast', 'notification', 'snackbar', 'alert', 'message', 'feedback', 'flash'],
   params: [
     // useXDSToast takes no arguments — returns a show function


### PR DESCRIPTION
Adds missing `group` field so these hooks appear alongside their companion components in the sidebar instead of in the ungrouped utilities section.