### PR TITLE
fix(docsite): add count to craft page theme tab

### DIFF
--- a/apps/docsite/src/app/craft/page.tsx
+++ b/apps/docsite/src/app/craft/page.tsx
@@ -131,7 +131,7 @@ export default function CraftPage() {
               value="templates"
               label={`Templates (${allItems.templates.length})`}
             />
-            <XDSTab value="theme" label="Theme" />
+            <XDSTab value="theme" label={`Theme (${themePackages.length})`} />
             <XDSTab
               value="showcases"
               label={`Components (${allItems.showcases.length})`}


### PR DESCRIPTION
The Theme tab on the crafts page was the only tab without a count in its label. Now shows `Theme (N)` consistent with the other tabs (All, Templates, Components).