### PR TITLE
fix(docsite): make theme preview responsive on mobile

### DIFF
--- a/apps/docsite/src/components/ThemeShowcasePreview.tsx
+++ b/apps/docsite/src/components/ThemeShowcasePreview.tsx
@@ -46,6 +46,7 @@ const styles = stylex.create({
   },
   fontCard: {
     borderColor: 'transparent',
+    minWidth: 0,
   },
   fontSample: {
     height: '100%',
@@ -55,6 +56,8 @@ const styles = stylex.create({
   },
   componentCard: {
     borderColor: 'transparent',
+    overflow: 'hidden',
+    minWidth: 0,
   },
 });
 
@@ -314,7 +317,7 @@ function ThemeShowcaseDetails() {
       </XDSGrid>
 
       <XDSCard padding={6} xstyle={styles.componentCard}>
-        <XDSGrid columns={{minWidth: 280}} gap={8}>
+        <XDSGrid columns={{minWidth: 240}} gap={8}>
           <XDSVStack gap={4}>
             <XDSText type="label" weight="bold">
               Components

--- a/apps/docsite/src/components/ThemeShowcasePreview.tsx
+++ b/apps/docsite/src/components/ThemeShowcasePreview.tsx
@@ -10,7 +10,7 @@ import {XDSCenter} from '@xds/core/Center';
 import {XDSSection} from '@xds/core/Section';
 import {XDSGrid} from '@xds/core/Grid';
 import {XDSBadge} from '@xds/core/Badge';
-import {XDSTable} from '@xds/core/Table';
+import {XDSTable, proportional} from '@xds/core/Table';
 import {XDSAspectRatio} from '@xds/core/AspectRatio';
 import {XDSTopNav, XDSTopNavHeading} from '@xds/core/TopNav';
 import {XDSRadioList, XDSRadioListItem} from '@xds/core/RadioList';
@@ -209,7 +209,7 @@ export function ThemeShowcasePreview({
             </XDSVStack>
           </XDSCenter>
 
-          <XDSGrid columns={3} gap={4}>
+          <XDSGrid columns={{minWidth: 240}} gap={4}>
             {PRODUCTS.map((p, i) => (
               <XDSCard key={p.name} padding={0}>
                 <XDSVStack gap={0}>
@@ -244,10 +244,14 @@ export function ThemeShowcasePreview({
           <XDSTable
             data={TABLE_DATA}
             columns={[
-              {key: 'name', header: 'Name'},
-              {key: 'description', header: 'Description'},
-              {key: 'price', header: 'Price'},
-              {key: 'stock', header: 'Stock'},
+              {key: 'name', header: 'Name', width: proportional(1)},
+              {
+                key: 'description',
+                header: 'Description',
+                width: proportional(2),
+              },
+              {key: 'price', header: 'Price', width: proportional(1)},
+              {key: 'stock', header: 'Stock', width: proportional(1)},
             ]}
             density="spacious"
             dividers="rows"
@@ -266,7 +270,7 @@ function ThemeShowcaseDetails() {
 
   return (
     <XDSVStack gap={4}>
-      <XDSGrid columns={2} gap={4}>
+      <XDSGrid columns={{minWidth: 280}} gap={4}>
         <XDSCard padding={6} xstyle={styles.fontCard}>
           <XDSVStack gap={4}>
             <XDSText type="label" weight="bold">
@@ -310,7 +314,7 @@ function ThemeShowcaseDetails() {
       </XDSGrid>
 
       <XDSCard padding={6} xstyle={styles.componentCard}>
-        <XDSGrid columns={2} gap={8}>
+        <XDSGrid columns={{minWidth: 280}} gap={8}>
           <XDSVStack gap={4}>
             <XDSText type="label" weight="bold">
               Components
@@ -332,7 +336,7 @@ function ThemeShowcaseDetails() {
               <XDSBadge label="Warning" variant="warning" />
               <XDSBadge label="Error" variant="error" />
             </XDSHStack>
-            <XDSGrid columns={2} gap={4}>
+            <XDSGrid columns={{minWidth: 180}} gap={4}>
               <XDSVStack gap={2}>
                 <XDSText type="supporting" weight="bold">
                   Label

--- a/apps/docsite/src/components/ThemeShowcasePreview.tsx
+++ b/apps/docsite/src/components/ThemeShowcasePreview.tsx
@@ -319,7 +319,7 @@ function ThemeShowcaseDetails() {
             <XDSText type="label" weight="bold">
               Components
             </XDSText>
-            <XDSHStack gap={2}>
+            <XDSHStack gap={2} wrap="wrap">
               <XDSButton label="Primary" variant="primary" size="sm" href="#" />
               <XDSButton
                 label="Secondary"
@@ -329,7 +329,7 @@ function ThemeShowcaseDetails() {
               />
               <XDSButton label="Ghost" variant="ghost" size="sm" href="#" />
             </XDSHStack>
-            <XDSHStack gap={2}>
+            <XDSHStack gap={2} wrap="wrap">
               <XDSBadge label="Badge" />
               <XDSBadge label="Info" variant="info" />
               <XDSBadge label="Success" variant="success" />


### PR DESCRIPTION
Makes the theme package preview page mobile-friendly:

- **Product cards**: `columns={3}` → `columns={{minWidth: 240}}` — cards wrap responsively instead of staying fixed at 3
- **Table**: adds `proportional(1)` widths to all columns (description gets `proportional(2)`), enabling horizontal scroll with enforced min-widths on narrow viewports
- **Colors/Fonts cards**: `columns={2}` → `columns={{minWidth: 280}}` — stack on mobile
- **Components card**: outer grid and inner Radio/List grid both use responsive `minWidth` breakpoints
