### PR TITLE
feat(heading): add display type variants to XDSHeading

### DIFF
--- a/packages/cli/docs/typography.doc.mjs
+++ b/packages/cli/docs/typography.doc.mjs
@@ -120,7 +120,7 @@ export const docs = {
         },
         {
           type: 'prose',
-          text: 'Display text often needs heading semantics for accessibility. Use the as prop on XDSText to render the correct HTML element: <XDSText type="display-1" as="h1"> gives you display-1 styling with an <h1> tag, so screen readers see the correct document outline.',
+          text: 'Display text often needs heading semantics for accessibility. Use the type prop on XDSHeading to apply display styling while preserving the correct HTML element: <XDSHeading level={1} type="display-1"> gives you display-1 styling with an <h1> tag, so screen readers see the correct document outline.',
         },
       ],
     },
@@ -141,6 +141,10 @@ export const docs = {
 <XDSHeading level={2}>Section</XDSHeading>
 <XDSHeading level={3}>Subsection</XDSHeading>
 
+// Display type for hero/marketing headings — level sets the HTML element
+<XDSHeading level={1} type="display-1">Hero Title</XDSHeading>
+<XDSHeading level={2} type="display-2">$1.2M Revenue</XDSHeading>
+
 // Override the accessibility level when visual ≠ document hierarchy
 <XDSHeading level={2} accessibilityLevel={3}>
   Sidebar Section
@@ -158,9 +162,8 @@ export const docs = {
 <XDSText type="supporting">Helper text, timestamps, metadata.</XDSText>
 <XDSText type="code">{'const x = 1;'}</XDSText>
 
-// Display with heading semantics for accessibility
-<XDSText type="display-1" as="h1">Hero Title</XDSText>
-<XDSText type="display-2" as="h2">$1.2M Revenue</XDSText>`,
+// Display without heading semantics (data callouts, decorative)
+<XDSText type="display-2">$1.2M Revenue</XDSText>`,
         },
         {
           type: 'code',
@@ -200,7 +203,7 @@ const denseTheme = defineTheme({
           items: [
             'Use XDSHeading for document headings and XDSText for everything else — they apply the full type scale automatically.',
             'Adjust typography holistically: change base and ratio in defineTheme to shift the entire ramp (e.g. { base: 16, ratio: 1.25 } for editorial, { base: 12, ratio: 1.125 } for dense UI).',
-            'Use display types with as="h1" (or h2/h3) when display text is a page heading — this preserves accessibility while giving you display-level sizing.',
+            'Use display types with as="h1" (or h2/h3) when display text is a page heading — this preserves accessibility while giving you display-level sizing. Or better, use <XDSHeading level={1} type="display-1"> which handles both semantics and styling.',
             'Let line-height snap to the 4px grid via the type scale — expandTypeScale computes leading automatically from base and ratio.',
             'Use the supporting type for secondary information: timestamps, helper text, metadata, captions.',
             'Use accessibilityLevel on XDSHeading when the visual hierarchy doesn\u2019t match the document outline (e.g. sidebar or card headings).',

--- a/packages/core/src/Text/Text.doc.mjs
+++ b/packages/core/src/Text/Text.doc.mjs
@@ -130,8 +130,14 @@ export const docs = {
           name: 'level',
           type: '1 | 2 | 3 | 4 | 5 | 6',
           description:
-            'Visual heading level. Determines both the HTML element (h1–h6) and the styling from the theme.',
+            'Heading level. Determines the semantic HTML element (h1–h6) and the visual styling from the theme (unless `type` is set).',
           required: true,
+        },
+        {
+          name: 'type',
+          type: "'display-1' | 'display-2' | 'display-3'",
+          description:
+            'Display type variant. Overrides the visual styling from `level` with display-scale sizing (larger, lighter weight, tighter line-height). The `level` still determines the HTML element for accessibility. Use for hero banners, marketing headlines, and data callouts.',
         },
         {
           name: 'children',
@@ -344,8 +350,14 @@ export const docsZh = {
           name: 'level',
           type: '1 | 2 | 3 | 4 | 5 | 6',
           description:
-            '视觉标题级别。同时决定 HTML 元素（h1–h6）和来自主题的样式。',
+            '标题级别。决定语义 HTML 元素（h1–h6）和来自主题的样式（除非设置了 `type`）。',
           required: true,
+        },
+        {
+          name: 'type',
+          type: "'display-1' | 'display-2' | 'display-3'",
+          description:
+            '展示类型变体。用展示级别的大小（更大、更轻的字重、更紧的行高）覆盖来自 `level` 的视觉样式。`level` 仍然决定用于无障碍的 HTML 元素。用于英雄横幅、营销标题和数据提示。',
         },
         {
           name: 'children',
@@ -476,7 +488,8 @@ export const docsDense = {
       name: 'XDSHeading',
       description: 'Semantic h1\u20136 w/ themed styling, themed sizing via type scale tokens, line-clamp truncation.',
       propDescriptions: {
-        level: 'Visual heading level; determines HTML element + styling from theme.',
+        level: 'Heading level; determines HTML element + styling from theme (unless type is set).',
+        type: "Display variant (display-1/2/3); overrides visual styling from level with display-scale sizing.",
         children: 'Heading content.',
         accessibilityLevel: 'aria-level override when different from level for document outline.',
         

--- a/packages/core/src/Text/XDSHeading.test.tsx
+++ b/packages/core/src/Text/XDSHeading.test.tsx
@@ -155,6 +155,36 @@ describe('XDSHeading', () => {
       expect(element).toHaveAttribute('aria-level', '3');
       expect(element.tagName).toBe('H2');
     });
+
+    it('accepts type prop for display variants', () => {
+      render(
+        <XDSHeading level={1} type="display-1">
+          Hero Title
+        </XDSHeading>,
+      );
+      const element = screen.getByText('Hero Title');
+      expect(element.tagName).toBe('H1');
+    });
+
+    it('renders correct heading element with display type', () => {
+      render(
+        <XDSHeading level={2} type="display-2">
+          Revenue
+        </XDSHeading>,
+      );
+      const element = screen.getByText('Revenue');
+      expect(element.tagName).toBe('H2');
+    });
+
+    it('includes display type in class names', () => {
+      render(
+        <XDSHeading level={1} type="display-1">
+          Display Heading
+        </XDSHeading>,
+      );
+      const element = screen.getByText('Display Heading');
+      expect(element.className).toContain('display-1');
+    });
   });
 
   it('renders xds-* class names for theme targeting', () => {

--- a/packages/core/src/Text/XDSHeading.tsx
+++ b/packages/core/src/Text/XDSHeading.tsx
@@ -25,6 +25,8 @@ import type {
 import {
   colorStyles,
   sizeByLevelStyles,
+  sizeByTypeStyles,
+  defaultWeightByTypeStyles,
   displayStyles,
   truncationStyles,
   wordBreakStyles,
@@ -47,6 +49,12 @@ const LazyXDSTooltip = lazy(() =>
  */
 export type XDSHeadingLevel = 1 | 2 | 3 | 4 | 5 | 6;
 
+/**
+ * Display type variants for headings. Applies display-scale sizing
+ * (larger, lighter) while preserving the semantic heading element.
+ */
+export type XDSHeadingType = 'display-1' | 'display-2' | 'display-3';
+
 export interface XDSHeadingProps extends Omit<
   XDSBaseProps<HTMLHeadingElement>,
   'children'
@@ -54,10 +62,26 @@ export interface XDSHeadingProps extends Omit<
   /** Ref forwarded to the root element */
   ref?: React.Ref<HTMLHeadingElement>;
   /**
-   * Visual heading level (1-6). Determines styling from theme.
-   * Required to ensure intentional visual hierarchy.
+   * Heading level (1-6). Determines the semantic HTML element (h1–h6).
+   * Also determines visual styling unless `type` is set.
    */
   level: XDSHeadingLevel;
+
+  /**
+   * Display type variant. When set, overrides the visual styling from `level`
+   * with display-scale sizing (larger, lighter weight, tighter line-height).
+   * The `level` still determines the HTML element for accessibility.
+   *
+   * Use for hero banners, marketing headlines, and data callouts that need
+   * heading semantics.
+   *
+   * @example
+   * ```
+   * <XDSHeading level={1} type="display-1">Hero Title</XDSHeading>
+   * <XDSHeading level={2} type="display-2">$1.2M Revenue</XDSHeading>
+   * ```
+   */
+  type?: XDSHeadingType;
 
   /**
    * Accessibility level override. When set, the `aria-level` will differ
@@ -151,12 +175,15 @@ const levelToTag = {
  * <XDSHeading level={1}>Page Title</XDSHeading>
  * <XDSHeading level={2}>Section</XDSHeading>
  * <XDSHeading level={2} accessibilityLevel={3}>Sidebar Section</XDSHeading>
+ * <XDSHeading level={1} type="display-1">Hero Title</XDSHeading>
+ * <XDSHeading level={2} type="display-2">$1.2M Revenue</XDSHeading>
  * <XDSHeading level={2} maxLines={1}>Very Long Section Title...</XDSHeading>
  * <XDSHeading level={3} color="secondary">Muted Heading</XDSHeading>
  * ```
  */
 export function XDSHeading({
   level,
+  type,
   accessibilityLevel,
   color = 'primary',
   display = 'block',
@@ -227,10 +254,11 @@ export function XDSHeading({
       <Component
         ref={mergedRef}
         {...mergeProps(
-          xdsClassName('heading', {level, color}),
+          xdsClassName('heading', {level, color, ...(type && {type})}),
           stylex.props(
             colorStyles[color],
-            sizeByLevelStyles[level],
+            type ? sizeByTypeStyles[type] : sizeByLevelStyles[level],
+            type && defaultWeightByTypeStyles[type],
             // Display: use truncation styles when maxLines > 0
             maxLines === 1
               ? truncationStyles.singleLine

--- a/packages/core/src/Text/index.ts
+++ b/packages/core/src/Text/index.ts
@@ -15,6 +15,7 @@ export {
   XDSHeading,
   type XDSHeadingProps,
   type XDSHeadingLevel,
+  type XDSHeadingType,
 } from './XDSHeading';
 
 // Re-export shared types from theme for convenience


### PR DESCRIPTION
Adds a `type` prop to `XDSHeading` that accepts display variants (`display-1`, `display-2`, `display-3`).

When set, the heading renders with display-scale sizing (larger, lighter weight, tighter line-height) while `level` still determines the semantic HTML element (h1–h6) for accessibility.

```tsx
// Before: XDSText with as prop
<XDSText type="display-1" as="h1">Hero Title</XDSText>

// After: XDSHeading with type prop
<XDSHeading level={1} type="display-1">Hero Title</XDSHeading>
<XDSHeading level={2} type="display-2">$1.2M Revenue</XDSHeading>
```

### Changes

- **XDSHeading.tsx** — new `type` prop; when set, applies `sizeByTypeStyles` and `defaultWeightByTypeStyles` instead of `sizeByLevelStyles`
- **XDSHeadingType** — new exported type (`'display-1' | 'display-2' | 'display-3'`)
- **Text.doc.mjs** — updated props table and dense/zh translations
- **typography.doc.mjs** — updated Display Text guidance and code examples to recommend `XDSHeading` with `type`
- **XDSHeading.test.tsx** — 3 new tests for display type rendering and class names