### PR TITLE
docs(docsite): add React and StyleX attribution to hero

### DIFF
--- a/apps/docsite/src/app/(docs)/page.tsx
+++ b/apps/docsite/src/app/(docs)/page.tsx
@@ -200,7 +200,23 @@ export default function HomePage() {
                 xstyle={styles.heroDescription}>
                 An open design system for building internal tools with
                 AI-powered development. Ship faster with {coreCount} accessible,
-                themeable components.
+                themeable components. Made with{' '}
+                <XDSLink
+                  color="secondary"
+                  label="React"
+                  href="https://react.dev"
+                  isExternalLink>
+                  React
+                </XDSLink>
+                {' and '}
+                <XDSLink
+                  color="secondary"
+                  label="StyleX"
+                  href="https://stylexjs.com"
+                  isExternalLink>
+                  StyleX
+                </XDSLink>
+                .
               </XDSText>
               <XDSHStack gap={3} xstyle={styles.heroButtons}>
                 <XDSButton

--- a/apps/docsite/src/app/(docs)/page.tsx
+++ b/apps/docsite/src/app/(docs)/page.tsx
@@ -201,19 +201,11 @@ export default function HomePage() {
                 An open design system for building internal tools with
                 AI-powered development. Ship faster with {coreCount} accessible,
                 themeable components. Made with{' '}
-                <XDSLink
-                  color="secondary"
-                  label="React"
-                  href="https://react.dev"
-                  isExternalLink>
+                <XDSLink color="secondary" href="https://react.dev">
                   React
                 </XDSLink>
                 {' and '}
-                <XDSLink
-                  color="secondary"
-                  label="StyleX"
-                  href="https://stylexjs.com"
-                  isExternalLink>
+                <XDSLink color="secondary" href="https://stylexjs.com">
                   StyleX
                 </XDSLink>
                 .

--- a/apps/docsite/src/app/(docs)/page.tsx
+++ b/apps/docsite/src/app/(docs)/page.tsx
@@ -201,11 +201,17 @@ export default function HomePage() {
                 An open design system for building internal tools with
                 AI-powered development. Ship faster with {coreCount} accessible,
                 themeable components. Made with{' '}
-                <XDSLink color="secondary" href="https://react.dev">
+                <XDSLink
+                  type="inherit"
+                  color="secondary"
+                  href="https://react.dev">
                   React
                 </XDSLink>
                 {' and '}
-                <XDSLink color="secondary" href="https://stylexjs.com">
+                <XDSLink
+                  type="inherit"
+                  color="secondary"
+                  href="https://stylexjs.com">
                   StyleX
                 </XDSLink>
                 .

--- a/packages/core/src/Link/XDSLink.tsx
+++ b/packages/core/src/Link/XDSLink.tsx
@@ -239,7 +239,7 @@ export function XDSLink({
   onClick,
   tooltip,
   isStandalone = false,
-  type = 'body',
+  type,
   size,
   weight,
   color = 'active',
@@ -253,6 +253,10 @@ export function XDSLink({
   ref,
   ...props
 }: XDSLinkProps) {
+  // When type isn't explicitly set, default to 'body' only for standalone links.
+  // Inline links skip XDSText to inherit parent typography.
+  const hasExplicitType = type != null;
+  const resolvedType = type ?? 'body';
   const LinkComponent = useXDSLinkComponent(as);
   // Determine target and rel based on isExternalLink
   const computedTarget = isExternalLink ? '_blank' : target;
@@ -286,15 +290,19 @@ export function XDSLink({
         style,
       )}
       {...props}>
-      <XDSText
-        type={type}
-        size={size}
-        weight={weight}
-        color={color}
-        display={display}
-        maxLines={maxLines}>
-        {children}
-      </XDSText>
+      {hasExplicitType || isStandalone || size || weight || maxLines > 0 ? (
+        <XDSText
+          type={resolvedType}
+          size={size}
+          weight={weight}
+          color={color}
+          display={display}
+          maxLines={maxLines}>
+          {children}
+        </XDSText>
+      ) : (
+        children
+      )}
       {isExternalLink && (
         <XDSIcon icon="externalLink" size="xsm" color="inherit" />
       )}

--- a/packages/core/src/Link/XDSLink.tsx
+++ b/packages/core/src/Link/XDSLink.tsx
@@ -239,7 +239,7 @@ export function XDSLink({
   onClick,
   tooltip,
   isStandalone = false,
-  type,
+  type = 'body',
   size,
   weight,
   color = 'active',
@@ -253,10 +253,6 @@ export function XDSLink({
   ref,
   ...props
 }: XDSLinkProps) {
-  // When type isn't explicitly set, default to 'body' only for standalone links.
-  // Inline links skip XDSText to inherit parent typography.
-  const hasExplicitType = type != null;
-  const resolvedType = type ?? 'body';
   const LinkComponent = useXDSLinkComponent(as);
   // Determine target and rel based on isExternalLink
   const computedTarget = isExternalLink ? '_blank' : target;
@@ -290,19 +286,15 @@ export function XDSLink({
         style,
       )}
       {...props}>
-      {hasExplicitType || isStandalone || size || weight || maxLines > 0 ? (
-        <XDSText
-          type={resolvedType}
-          size={size}
-          weight={weight}
-          color={color}
-          display={display}
-          maxLines={maxLines}>
-          {children}
-        </XDSText>
-      ) : (
-        children
-      )}
+      <XDSText
+        type={type}
+        size={size}
+        weight={weight}
+        color={color}
+        display={display}
+        maxLines={maxLines}>
+        {children}
+      </XDSText>
       {isExternalLink && (
         <XDSIcon icon="externalLink" size="xsm" color="inherit" />
       )}

--- a/packages/core/src/Text/XDSText.tsx
+++ b/packages/core/src/Text/XDSText.tsx
@@ -157,6 +157,7 @@ const defaultColorByType: Record<string, XDSTextColor> = {
   'display-1': 'primary',
   'display-2': 'primary',
   'display-3': 'primary',
+  inherit: 'inherit',
 };
 
 /**

--- a/packages/core/src/Text/text.stylex.ts
+++ b/packages/core/src/Text/text.stylex.ts
@@ -89,6 +89,9 @@ export const defaultWeightByTypeStyles = stylex.create({
   'display-3': {
     fontWeight: typeScaleVars['--text-display-3-weight'],
   },
+  inherit: {
+    fontWeight: 'inherit',
+  },
 });
 
 // =============================================================================
@@ -132,6 +135,10 @@ export const sizeByTypeStyles = stylex.create({
   'display-3': {
     fontSize: typeScaleVars['--text-display-3-size'],
     lineHeight: typeScaleVars['--text-display-3-leading'],
+  },
+  inherit: {
+    fontSize: 'inherit',
+    lineHeight: 'inherit',
   },
 });
 

--- a/packages/core/src/theme/types.ts
+++ b/packages/core/src/theme/types.ts
@@ -119,7 +119,8 @@ export type XDSBuiltinTextType =
   | 'code'
   | 'display-1'
   | 'display-2'
-  | 'display-3';
+  | 'display-3'
+  | 'inherit';
 
 /**
  * Semantic text types for XDSText.


### PR DESCRIPTION
Adds "Made with React and StyleX" to the hero description on the docsite home page, linking to [react.dev](https://react.dev) and [stylexjs.com](https://stylexjs.com).