### PR TITLE
docs: add Working with AI guide

### DIFF
--- a/packages/cli/docs/getting-started.doc.mjs
+++ b/packages/cli/docs/getting-started.doc.mjs
@@ -5,7 +5,7 @@ export const docs = {
   title: 'Getting Started',
   category: 'guide',
   description:
-    'Go from zero to a working XDS app in five steps.',
+    'Add XDS to your project and start building.',
 
   sections: [
     {
@@ -19,50 +19,58 @@ export const docs = {
           type: 'code',
           lang: 'text',
           label: 'Paste this into your AI',
-          code: 'Install @xds/core and @xds/cli in this project. Run `npx xds init` to set up the design system, theme, and agent docs. Read the generated files to learn the conventions.',
+          code: 'Install @xds/core, @xds/theme-default, and @xds/cli in this project. Run `npx xds init` to set up agent docs. Read the generated files to learn the conventions.',
         },
       ],
     },
     {
-      title: 'Install the CLI',
-  category: 'guide',
+      title: 'Install',
       content: [
         {
           type: 'prose',
-          text: 'Use the XDS CLI to scaffold a new app. It wires up Next.js, the design system, and a working theme out of the box.',
+          text: 'Add the core package, a theme, and the CLI to your existing project.',
         },
         {
           type: 'code',
           lang: 'bash',
           label: 'Terminal',
-          code: `npx @xds/cli init my-app
-cd my-app`,
+          code: `npm install @xds/core @xds/theme-default @xds/cli`,
+        },
+        {
+          type: 'prose',
+          text: 'Then run the init wizard to set up AI agent docs, pick a starter template, and learn about theming.',
+        },
+        {
+          type: 'code',
+          lang: 'bash',
+          label: 'Terminal',
+          code: `npx xds init`,
         },
       ],
     },
     {
-      title: 'Pick a theme',
-  category: 'guide',
+      title: 'Add the theme CSS',
       content: [
         {
           type: 'prose',
-          text: 'Choose between the default theme and the neutral theme. Themes live as separate packages so you can swap them without touching component code.',
+          text: 'Import the reset stylesheet and a theme in your global CSS file. Themes provide all design tokens (colors, spacing, radius, typography) as CSS custom properties.',
         },
         {
           type: 'code',
-          lang: 'tsx',
-          label: 'app/layout.tsx',
-          code: `import '@xds/theme-default/styles.css';
-
-export default function RootLayout({children}) {
-  return <html><body>{children}</body></html>;
-}`,
+          lang: 'css',
+          label: 'globals.css',
+          code: `@import '@xds/core/reset.css';
+@import '@xds/core/xds.css';
+@import '@xds/theme-default/theme.css';`,
+        },
+        {
+          type: 'prose',
+          text: 'Available themes: @xds/theme-default (blue accent), @xds/theme-neutral (grayscale), @xds/theme-brutalist (zero radius, monospace). See `npx xds docs theme` for the full theming guide.',
         },
       ],
     },
     {
       title: 'Add your first component',
-  category: 'guide',
       content: [
         {
           type: 'prose',
@@ -73,13 +81,13 @@ export default function RootLayout({children}) {
           lang: 'tsx',
           label: 'app/page.tsx',
           code: `import {XDSButton} from '@xds/core/Button';
-import {XDSStack} from '@xds/core/Layout';
+import {XDSVStack} from '@xds/core/Layout';
 
 export default function Page() {
   return (
-    <XDSStack direction="vertical" gap={2}>
-      <XDSButton label="Hello XDS" onPress={() => alert('Hi!')} />
-    </XDSStack>
+    <XDSVStack gap={2}>
+      <XDSButton label="Hello XDS" onClick={() => alert('Hi!')} />
+    </XDSVStack>
   );
 }`,
         },
@@ -87,7 +95,6 @@ export default function Page() {
     },
     {
       title: 'Customize with xstyle',
-  category: 'guide',
       content: [
         {
           type: 'prose',
@@ -108,18 +115,50 @@ const overrides = stylex.create({
       ],
     },
     {
-      title: 'Run the dev server',
-  category: 'guide',
+      title: 'Example Apps',
       content: [
         {
           type: 'prose',
-          text: 'Start the dev server and open the preview URL. Changes to components hot-reload automatically.',
+          text: 'For a full working project, clone one of the example apps from the XDS repo. These are complete setups with routing, theming, and components wired together.',
+        },
+        {
+          type: 'table',
+          headers: ['Example', 'Stack', 'Path'],
+          rows: [
+            ['Next.js', 'Next.js + XDS theme CSS', 'apps/example-nextjs'],
+            ['Next.js + StyleX', 'Next.js + StyleX for custom styles', 'apps/example-nextjs-stylex'],
+            ['Next.js + Tailwind', 'Next.js + Tailwind bridge', 'apps/example-nextjs-tailwind'],
+            ['Next.js Source', 'Next.js importing XDS from source', 'apps/example-nextjs-source'],
+            ['Vite', 'Vite + XDS', 'apps/example-vite'],
+          ],
+        },
+        {
+          type: 'code',
+          lang: 'bash',
+          label: 'Clone and run an example',
+          code: `git clone https://github.com/facebookexperimental/xds.git
+cd xds/apps/example-nextjs
+yarn install
+yarn dev`,
+        },
+      ],
+    },
+    {
+      title: 'Explore the CLI',
+      content: [
+        {
+          type: 'prose',
+          text: 'The CLI is your reference for components, tokens, templates, and docs. Use it to discover what\u2019s available.',
         },
         {
           type: 'code',
           lang: 'bash',
           label: 'Terminal',
-          code: `yarn dev`,
+          code: `npx xds component              # list all components
+npx xds component Button       # props, usage, theming for Button
+npx xds docs                   # list all doc topics
+npx xds template --list        # available page templates
+npx xds docs tokens            # spacing, color, radius reference`,
         },
       ],
     },

--- a/packages/cli/docs/getting-started.doc.mjs
+++ b/packages/cli/docs/getting-started.doc.mjs
@@ -9,6 +9,21 @@ export const docs = {
 
   sections: [
     {
+      title: 'Quick Start with AI',
+      content: [
+        {
+          type: 'prose',
+          text: 'Paste this into your AI coding tool and let it handle the setup:',
+        },
+        {
+          type: 'code',
+          lang: 'text',
+          label: 'Paste this into your AI',
+          code: 'Install @xds/core and @xds/cli in this project. Run `npx xds init` to set up the design system, theme, and agent docs. Read the generated files to learn the conventions.',
+        },
+      ],
+    },
+    {
       title: 'Install the CLI',
   category: 'guide',
       content: [

--- a/packages/cli/docs/working-with-ai.doc.mjs
+++ b/packages/cli/docs/working-with-ai.doc.mjs
@@ -90,22 +90,17 @@ npx xds agent-docs --agent-docs-path ~/.cursor/rules/xds.mdc`,
       content: [
         {
           type: 'prose',
-          text: 'After setting up agent docs, ask your AI to build a simple page. A properly configured AI should:',
+          text: 'Paste this prompt into your AI to verify it has XDS context loaded and can self-correct:',
         },
         {
-          type: 'list',
-          style: 'do',
-          items: [
-            'Import from subpaths like \'@xds/core/Button\', not \'@xds/core\'',
-            'Use XDS components for layout (XDSStack, XDSCard) instead of raw <div> elements',
-            'Use is/has prefixed booleans (isDisabled, isLoading) not bare names',
-            'Reference design tokens (var(--spacing-4), var(--color-accent)) not hardcoded values',
-            'Run `npx xds component <Name>` to look up props before writing code',
-          ],
+          type: 'code',
+          lang: 'text',
+          label: 'Diagnostic prompt',
+          code: `Run \`npx xds component Button --props\` and compare the output to your knowledge of XDS. Are you aware of the XDS design system conventions? If not, run \`npx xds agent-docs\` to install context, then read the generated file.`,
         },
         {
           type: 'prose',
-          text: 'If your AI is still making these mistakes, the context file likely isn\'t being loaded. Check that the file is in the right location for your tool and that it contains the <!-- XDS:START --> marker block.',
+          text: 'A properly configured AI will already know the conventions and confirm them against the CLI output. An unconfigured one will discover the gap and fix itself by running the install command.',
         },
       ],
     },

--- a/packages/cli/docs/working-with-ai.doc.mjs
+++ b/packages/cli/docs/working-with-ai.doc.mjs
@@ -96,41 +96,129 @@ npx xds docs`,
       content: [
         {
           type: 'prose',
-          text: 'Most AI tools let you provide persistent project context — a system prompt, rules file, or context document that gets included in every conversation. Setting this up once is the highest-leverage thing you can do for XDS code quality.',
+          text: 'Every AI tool has a way to provide persistent context — instructions that get included in every conversation without you having to repeat them. Setting this up once is the highest-leverage thing you can do for XDS code quality. The setup differs by tool.',
         },
+      ],
+    },
+    {
+      title: 'Claude Code',
+      content: [
         {
           type: 'prose',
-          text: 'Generate a context document tuned for your project:',
+          text: 'Claude Code reads CLAUDE.md files from your project root automatically. This is the most straightforward setup — just add XDS context to the file and it applies to every session in that project.',
         },
         {
           type: 'code',
           lang: 'bash',
-          label: 'Generate AI context',
-          code: `# Print the XDS principles + styling guide in dense format
+          label: 'Add XDS context to CLAUDE.md',
+          code: `# Generate dense XDS context and append to CLAUDE.md
+echo "## XDS Design System" >> CLAUDE.md
+echo "" >> CLAUDE.md
+npx xds docs principles --dense >> CLAUDE.md
+echo "" >> CLAUDE.md
+npx xds docs styling --dense >> CLAUDE.md`,
+        },
+        {
+          type: 'prose',
+          text: 'Claude Code can also run CLI commands directly. Tell it to run `npx xds component <Name> --props` before writing component code, and it will look up the real API on the fly.',
+        },
+      ],
+    },
+    {
+      title: 'Cursor',
+      content: [
+        {
+          type: 'prose',
+          text: 'Cursor has three levels of rules, and where you put XDS context matters. Project rules (.cursor/rules/*.mdc files) are committed to the repo but Cursor may not always include them — it picks which rules to apply based on relevance. For XDS rules you want applied reliably, use User Rules instead.',
+        },
+        {
+          type: 'prose',
+          text: 'User Rules live at ~/.cursor/rules/ and apply across all your projects. Since XDS conventions don\'t change per-project, this is the right place for them. Create an .mdc file with alwaysApply: true so it\'s included in every conversation.',
+        },
+        {
+          type: 'code',
+          lang: 'bash',
+          label: 'Create a user rule for XDS',
+          code: `# Create the user rules directory
+mkdir -p ~/.cursor/rules
+
+# Generate the rule file
+cat > ~/.cursor/rules/xds.mdc << 'EOF'
+---
+description: XDS design system conventions
+alwaysApply: true
+---
+
+This project uses the XDS design system (@xds/core).
+
+- Import components from '@xds/core/<ComponentName>' (e.g. '@xds/core/Button')
+- All components are prefixed with XDS (XDSButton, XDSCard, XDSTextInput)
+- Boolean props use is/has prefix (isDisabled, isLoading, hasHover)
+- Form inputs are controlled (value + onChange, where onChange passes the value directly)
+- Use semantic tokens for colors (var(--color-accent)) and spacing (var(--spacing-4))
+- Use xstyle prop with stylex.create() for component style overrides
+- Use Tailwind utilities on className for layout and wrapper styling
+
+Before writing any XDS component code, look up its props:
+  npx xds component <Name> --props
+
+For styling guidance: npx xds docs styling
+For token reference: npx xds docs tokens
+EOF`,
+        },
+        {
+          type: 'prose',
+          text: 'You can also add a project-level rule in .cursor/rules/ with richer context (component list, templates), but the user rule ensures the basics are always present even if project rules aren\'t picked up.',
+        },
+      ],
+    },
+    {
+      title: 'GitHub Copilot',
+      content: [
+        {
+          type: 'prose',
+          text: 'Copilot reads instruction files from your repo. The main file is .github/copilot-instructions.md — it applies to all Copilot interactions in the project. Copilot also reads AGENTS.md and CLAUDE.md for compatibility, so if you\'ve already set up Claude Code, Copilot benefits too.',
+        },
+        {
+          type: 'code',
+          lang: 'bash',
+          label: 'Create Copilot instructions',
+          code: `mkdir -p .github
+
+# Generate instructions with XDS context
+echo "# XDS Design System" > .github/copilot-instructions.md
+echo "" >> .github/copilot-instructions.md
+npx xds docs principles --dense >> .github/copilot-instructions.md
+echo "" >> .github/copilot-instructions.md
+npx xds docs styling --dense >> .github/copilot-instructions.md`,
+        },
+        {
+          type: 'prose',
+          text: 'For file-specific rules, Copilot supports .github/instructions/*.instructions.md with glob patterns. You could create an xds-components.instructions.md that targets *.tsx files with component-specific guidance.',
+        },
+      ],
+    },
+    {
+      title: 'ChatGPT and Claude Web',
+      content: [
+        {
+          type: 'prose',
+          text: 'For web-based AI tools without project context files, paste CLI output directly into your conversation. The --dense flag keeps the token cost low.',
+        },
+        {
+          type: 'code',
+          lang: 'bash',
+          label: 'Generate context to paste',
+          code: `# Copy this output into your conversation before asking for code
 npx xds docs principles --dense
 npx xds docs styling --dense
 
-# List all available components (so the model knows what exists)
-npx xds component --dense`,
+# Or for a specific component you're working with
+npx xds component Dialog --props --dense`,
         },
         {
           type: 'prose',
-          text: 'Paste that output into your tool\'s context file. Where it goes depends on your tool:',
-        },
-        {
-          type: 'table',
-          headers: ['Tool', 'Where to put it'],
-          rows: [
-            ['Cursor', '.cursorrules or .cursor/rules in your project root'],
-            ['Claude Code', 'CLAUDE.md in your project root'],
-            ['GitHub Copilot', '.github/copilot-instructions.md'],
-            ['ChatGPT / Claude web', 'Custom instructions or project knowledge'],
-            ['Windsurf', '.windsurfrules in your project root'],
-          ],
-        },
-        {
-          type: 'prose',
-          text: 'The key insight: the --dense flag on any CLI command outputs a compressed format designed for AI context windows. It strips verbose descriptions and examples, keeping only what a model needs to generate correct code. Use it for anything going into a rules file.',
+          text: 'ChatGPT Projects and Claude Projects both support persistent files — upload the dense CLI output as a project knowledge file so it applies to every conversation in that project.',
         },
       ],
     },
@@ -280,33 +368,6 @@ npx xds docs styling --dense`,
         {
           type: 'prose',
           text: 'For agents with tool-calling capabilities, the CLI commands can be called directly as tools. An agent that runs `npx xds component <Name> --props --dense` before generating code will produce significantly better results than one working from memory alone.',
-        },
-      ],
-    },
-    {
-      title: 'Cursor / IDE Integration',
-      content: [
-        {
-          type: 'prose',
-          text: 'For IDE-integrated AI tools like Cursor, Copilot, or Cody, add XDS context to your project rules or context files.',
-        },
-        {
-          type: 'code',
-          lang: 'text',
-          label: '.cursorrules or project context file',
-          code: `This project uses the XDS design system (@xds/core).
-
-Key rules:
-- Import components from '@xds/core/<ComponentName>' (e.g. '@xds/core/Button')
-- All components are prefixed with XDS (XDSButton, XDSCard, XDSTextInput)
-- Boolean props use is/has prefix (isDisabled, isLoading, hasHover)
-- Form inputs are controlled (value + onChange, where onChange passes the value directly)
-- Use semantic tokens for colors (var(--color-accent)) and spacing (var(--spacing-4))
-- Use xstyle prop with stylex.create() for component style overrides
-- Use Tailwind utilities on className for layout and wrapper styling
-
-Run \`npx xds component <Name> --props\` to look up any component API.
-Run \`npx xds docs styling\` for the complete styling guide.`,
         },
       ],
     },

--- a/packages/cli/docs/working-with-ai.doc.mjs
+++ b/packages/cli/docs/working-with-ai.doc.mjs
@@ -95,17 +95,19 @@ npx xds agent-docs --agent-docs-path ~/.cursor/rules/xds.mdc`,
       content: [
         {
           type: 'prose',
-          text: 'Paste this prompt into your AI. It touches 10+ XDS conventions that models get wrong 100% of the time without context \u2014 import paths, component names, prop patterns, styling, and API shapes. If your AI gets most of it right, the agent docs are working.',
+          text: 'Paste this into your AI before writing any XDS code. These three questions have a 0% pass rate without docs \u2014 models confidently guess wrong on all of them. If your AI can\'t answer them, it\'ll know to install the agent docs first.',
         },
         {
           type: 'code',
           lang: 'text',
-          label: 'Diagnostic prompt',
-          code: 'Using XDS, show a Selector with three options, a disabled Button with a label, and a Dialog the user can\'t dismiss. Include all imports.',
-        },
-        {
-          type: 'prose',
-          text: 'Check the output for: subpath imports (@xds/core/Button not @xds/core), XDS prefix on components, label prop on Button, isDisabled not disabled, options array on Selector, purpose="required" on Dialog, and xstyle/stylex for any custom styling. If the AI falls back to generic React patterns, the context file isn\'t being loaded.',
+          label: 'Paste this into your AI',
+          code: `Before writing any XDS code, check your knowledge:
+
+1. What is the correct import path for XDSButton?
+2. How do you make an XDSDialog non-dismissible?
+3. What prop does XDSSelector use for its items?
+
+If you don't know all three, run \`npx xds init --features agents\` to generate agent docs, then read the generated file.`,
         },
       ],
     },

--- a/packages/cli/docs/working-with-ai.doc.mjs
+++ b/packages/cli/docs/working-with-ai.doc.mjs
@@ -95,17 +95,17 @@ npx xds agent-docs --agent-docs-path ~/.cursor/rules/xds.mdc`,
       content: [
         {
           type: 'prose',
-          text: 'Paste this prompt into your AI to verify it has XDS context loaded and can self-correct:',
+          text: 'Paste this prompt into your AI. It touches 10+ XDS conventions that models get wrong 100% of the time without context \u2014 import paths, component names, prop patterns, styling, and API shapes. If your AI gets most of it right, the agent docs are working.',
         },
         {
           type: 'code',
           lang: 'text',
           label: 'Diagnostic prompt',
-          code: `Run \`npx xds component Button --props\` and compare the output to your knowledge of XDS. Are you aware of the XDS design system conventions? If not, run \`npx xds agent-docs\` to install context, then read the generated file.`,
+          code: 'Using XDS, show a Selector with three options, a disabled Button with a label, and a Dialog the user can\'t dismiss. Include all imports.',
         },
         {
           type: 'prose',
-          text: 'A properly configured AI will already know the conventions and confirm them against the CLI output. An unconfigured one will discover the gap and fix itself by running the install command.',
+          text: 'Check the output for: subpath imports (@xds/core/Button not @xds/core), XDS prefix on components, label prop on Button, isDisabled not disabled, options array on Selector, purpose="required" on Dialog, and xstyle/stylex for any custom styling. If the AI falls back to generic React patterns, the context file isn\'t being loaded.',
         },
       ],
     },

--- a/packages/cli/docs/working-with-ai.doc.mjs
+++ b/packages/cli/docs/working-with-ai.doc.mjs
@@ -26,24 +26,29 @@ export const docs = {
       content: [
         {
           type: 'prose',
-          text: 'Install the CLI and run init. It generates an AGENTS.md (or CLAUDE.md, .cursorrules) with a compressed component index, behavioral rules, and CLI reference \u2014 all pulled from your installed version.',
+          text: 'Tell your AI to install the CLI and set itself up:',
+        },
+        {
+          type: 'code',
+          lang: 'text',
+          label: 'Paste this into your AI',
+          code: 'Install @xds/cli and run `npx xds agent-docs` to set up your XDS context. Read the generated file.',
+        },
+        {
+          type: 'prose',
+          text: 'That\'s it. The agent-docs command generates everything your AI needs \u2014 component index, behavioral rules, CLI reference \u2014 pulled from your installed version. After a version bump, run it again to update in place.',
+        },
+        {
+          type: 'prose',
+          text: 'If you prefer to target a specific file format:',
         },
         {
           type: 'code',
           lang: 'bash',
-          label: 'Set up agent context',
-          code: `# Interactive setup \u2014 picks your AI tool
-npx xds init
-
-# Or target a specific tool directly
-npx xds agent-docs --agent claude    # CLAUDE.md
+          label: 'Manual options',
+          code: `npx xds agent-docs --agent claude    # CLAUDE.md
 npx xds agent-docs --agent cursor    # .cursorrules
-npx xds agent-docs --agent codex     # AGENTS.md (Copilot, Codex, etc.)
-npx xds agent-docs --agent all       # all detected files`,
-        },
-        {
-          type: 'prose',
-          text: 'After a version bump, run `npx xds agent-docs` again to update the generated block in place.',
+npx xds agent-docs --agent codex     # AGENTS.md (Copilot, Codex, etc.)`,
         },
       ],
     },

--- a/packages/cli/docs/working-with-ai.doc.mjs
+++ b/packages/cli/docs/working-with-ai.doc.mjs
@@ -5,369 +5,124 @@ export const docs = {
   title: 'Working with AI',
   category: 'guide',
   description:
-    'How to use AI coding tools effectively with XDS — prompting strategies, the CLI as context source, and patterns that help models generate correct component code.',
+    'How to set up AI coding tools to generate correct XDS component code.',
 
   sections: [
     {
-      title: 'Why This Matters',
+      title: 'Overview',
       content: [
         {
           type: 'prose',
-          text: 'XDS is designed to be AI-friendly. Components follow consistent naming conventions, props use predictable patterns (is/has prefixes for booleans, on-prefixed callbacks), and the CLI can feed structured documentation directly into an AI context window. But models still need the right context to generate correct XDS code — without it, they fall back to generic React patterns or guess at prop names.',
+          text: 'XDS is designed to be AI-friendly \u2014 consistent naming, predictable prop patterns, and a CLI that feeds structured documentation directly into AI context windows. But models still need the right context to avoid falling back to generic React patterns or inventing props.',
         },
         {
           type: 'prose',
-          text: 'This guide covers how to get the best results from AI tools (Claude, Cursor, Copilot, ChatGPT, etc.) when building with XDS.',
+          text: 'The XDS CLI includes a built-in agent docs system that generates context files for your AI tool of choice. One command sets up everything your AI needs to write correct XDS code.',
         },
       ],
     },
     {
-      title: 'The CLI Is Your Context Source',
+      title: 'Quick Start',
       content: [
         {
           type: 'prose',
-          text: 'The XDS CLI is the single source of truth for component APIs. Before writing any component code — or asking an AI to write it — query the CLI to get the real props, types, and defaults.',
+          text: 'Install the CLI and run init. It generates an AGENTS.md (or CLAUDE.md, .cursorrules) with a compressed component index, behavioral rules, and CLI reference \u2014 all pulled from your installed version.',
         },
         {
           type: 'code',
           lang: 'bash',
-          label: 'Look up a component before coding',
-          code: `# Full component docs (props, theming, usage)
-npx xds component Button
+          label: 'Set up agent context',
+          code: `# Interactive setup \u2014 picks your AI tool
+npx xds init
 
-# Props table only
-npx xds component Button --props
-
-# Compressed format (fewer tokens for AI context)
-npx xds component Button --dense
-
-# JSON output (for programmatic use)
-npx xds component Button --json`,
+# Or target a specific tool directly
+npx xds agent-docs --agent claude    # CLAUDE.md
+npx xds agent-docs --agent cursor    # .cursorrules
+npx xds agent-docs --agent codex     # AGENTS.md (Copilot, Codex, etc.)
+npx xds agent-docs --agent all       # all detected files`,
         },
         {
           type: 'prose',
-          text: 'The --dense flag outputs a token-efficient format that fits more information into a smaller context window. Use it when feeding component docs into an AI prompt.',
-        },
-        {
-          type: 'code',
-          lang: 'bash',
-          label: 'Reference docs for AI context',
-          code: `# Styling guide
-npx xds docs styling --dense
-
-# Design tokens reference
-npx xds docs tokens --dense
-
-# All available topics
-npx xds docs`,
+          text: 'After a version bump, run `npx xds agent-docs` again to update the generated block in place.',
         },
       ],
     },
     {
-      title: 'Prompting Strategies',
+      title: 'What Gets Generated',
       content: [
         {
           type: 'prose',
-          text: 'The most common AI failure mode with XDS is inventing props that don\u2019t exist. The fix is simple: give the model real documentation before asking it to write code.',
+          text: 'The generated context teaches your AI a 3-step workflow before writing any UI code:',
+        },
+        {
+          type: 'list',
+          style: 'ordered',
+          items: [
+            '`npx xds template --list` \u2014 find a related page pattern to use as reference',
+            '`npx xds template <name> --skeleton` \u2014 study the layout structure',
+            '`npx xds component <Name>` \u2014 read props and examples for every component used',
+          ],
+        },
+        {
+          type: 'prose',
+          text: 'It also includes rules that prevent common mistakes (no raw divs, no style={{}}, use tokens not magic values) and a CLI quick reference. After setup, you shouldn\'t need to manually correct your AI on XDS conventions \u2014 the agent docs handle it at the system level.',
+        },
+      ],
+    },
+    {
+      title: 'Cursor Setup',
+      content: [
+        {
+          type: 'prose',
+          text: 'Cursor project rules aren\'t always picked up \u2014 it selects which rules to apply based on relevance. For reliable inclusion, install XDS context as a User Rule instead. User Rules live at ~/.cursor/rules/ and apply across all projects.',
+        },
+        {
+          type: 'code',
+          lang: 'bash',
+          label: 'Install as a Cursor user rule',
+          code: `mkdir -p ~/.cursor/rules
+npx xds agent-docs --agent-docs-path ~/.cursor/rules/xds.mdc`,
+        },
+      ],
+    },
+    {
+      title: 'Checking Your Setup',
+      content: [
+        {
+          type: 'prose',
+          text: 'After setting up agent docs, ask your AI to build a simple page. A properly configured AI should:',
         },
         {
           type: 'list',
           style: 'do',
           items: [
-            'Paste the output of `npx xds component <Name> --props` into your prompt before asking for code.',
-            'Include the styling guide (`npx xds docs styling --dense`) when asking for layout or theming work.',
-            'Ask the model to use XDS components by name — specificity reduces hallucination.',
-            'Provide a working example from your codebase as a reference pattern.',
+            'Import from subpaths like \'@xds/core/Button\', not \'@xds/core\'',
+            'Use XDS components for layout (XDSStack, XDSCard) instead of raw <div> elements',
+            'Use is/has prefixed booleans (isDisabled, isLoading) not bare names',
+            'Reference design tokens (var(--spacing-4), var(--color-accent)) not hardcoded values',
+            'Run `npx xds component <Name>` to look up props before writing code',
           ],
         },
         {
-          type: 'list',
-          style: 'dont',
-          items: [
-            'Ask for "a button component" without specifying XDS — the model will reach for native HTML or another library.',
-            'Assume the model knows XDS prop names. Even if it gets close, `disabled` vs `isDisabled` matters.',
-            'Let the model invent wrapper components when XDS already has the right primitive.',
-          ],
+          type: 'prose',
+          text: 'If your AI is still making these mistakes, the context file likely isn\'t being loaded. Check that the file is in the right location for your tool and that it contains the <!-- XDS:START --> marker block.',
         },
       ],
     },
     {
-      title: 'Setting Up Your AI',
+      title: 'The --dense Flag',
       content: [
         {
           type: 'prose',
-          text: 'Every AI tool has a way to provide persistent context — instructions that get included in every conversation without you having to repeat them. Setting this up once is the highest-leverage thing you can do for XDS code quality. The setup differs by tool.',
-        },
-      ],
-    },
-    {
-      title: 'Claude Code',
-      content: [
-        {
-          type: 'prose',
-          text: 'Claude Code reads CLAUDE.md files from your project root automatically. This is the most straightforward setup — just add XDS context to the file and it applies to every session in that project.',
+          text: 'Every CLI command supports --dense, which outputs a token-efficient format designed for AI context windows. Use it when pasting CLI output into a web-based AI tool like ChatGPT or Claude.',
         },
         {
           type: 'code',
           lang: 'bash',
-          label: 'Add XDS context to CLAUDE.md',
-          code: `# Generate dense XDS context and append to CLAUDE.md
-echo "## XDS Design System" >> CLAUDE.md
-echo "" >> CLAUDE.md
-npx xds docs principles --dense >> CLAUDE.md
-echo "" >> CLAUDE.md
-npx xds docs styling --dense >> CLAUDE.md`,
-        },
-        {
-          type: 'prose',
-          text: 'Claude Code can also run CLI commands directly. Tell it to run `npx xds component <Name> --props` before writing component code, and it will look up the real API on the fly.',
-        },
-      ],
-    },
-    {
-      title: 'Cursor',
-      content: [
-        {
-          type: 'prose',
-          text: 'Cursor has three levels of rules, and where you put XDS context matters. Project rules (.cursor/rules/*.mdc files) are committed to the repo but Cursor may not always include them — it picks which rules to apply based on relevance. For XDS rules you want applied reliably, use User Rules instead.',
-        },
-        {
-          type: 'prose',
-          text: 'User Rules live at ~/.cursor/rules/ and apply across all your projects. Since XDS conventions don\'t change per-project, this is the right place for them. Create an .mdc file with alwaysApply: true so it\'s included in every conversation.',
-        },
-        {
-          type: 'code',
-          lang: 'bash',
-          label: 'Create a user rule for XDS',
-          code: `# Create the user rules directory
-mkdir -p ~/.cursor/rules
-
-# Generate the rule file
-cat > ~/.cursor/rules/xds.mdc << 'EOF'
----
-description: XDS design system conventions
-alwaysApply: true
----
-
-This project uses the XDS design system (@xds/core).
-
-- Import components from '@xds/core/<ComponentName>' (e.g. '@xds/core/Button')
-- All components are prefixed with XDS (XDSButton, XDSCard, XDSTextInput)
-- Boolean props use is/has prefix (isDisabled, isLoading, hasHover)
-- Form inputs are controlled (value + onChange, where onChange passes the value directly)
-- Use semantic tokens for colors (var(--color-accent)) and spacing (var(--spacing-4))
-- Use xstyle prop with stylex.create() for component style overrides
-- Use Tailwind utilities on className for layout and wrapper styling
-
-Before writing any XDS component code, look up its props:
-  npx xds component <Name> --props
-
-For styling guidance: npx xds docs styling
-For token reference: npx xds docs tokens
-EOF`,
-        },
-        {
-          type: 'prose',
-          text: 'You can also add a project-level rule in .cursor/rules/ with richer context (component list, templates), but the user rule ensures the basics are always present even if project rules aren\'t picked up.',
-        },
-      ],
-    },
-    {
-      title: 'GitHub Copilot',
-      content: [
-        {
-          type: 'prose',
-          text: 'Copilot reads instruction files from your repo. The main file is .github/copilot-instructions.md — it applies to all Copilot interactions in the project. Copilot also reads AGENTS.md and CLAUDE.md for compatibility, so if you\'ve already set up Claude Code, Copilot benefits too.',
-        },
-        {
-          type: 'code',
-          lang: 'bash',
-          label: 'Create Copilot instructions',
-          code: `mkdir -p .github
-
-# Generate instructions with XDS context
-echo "# XDS Design System" > .github/copilot-instructions.md
-echo "" >> .github/copilot-instructions.md
-npx xds docs principles --dense >> .github/copilot-instructions.md
-echo "" >> .github/copilot-instructions.md
-npx xds docs styling --dense >> .github/copilot-instructions.md`,
-        },
-        {
-          type: 'prose',
-          text: 'For file-specific rules, Copilot supports .github/instructions/*.instructions.md with glob patterns. You could create an xds-components.instructions.md that targets *.tsx files with component-specific guidance.',
-        },
-      ],
-    },
-    {
-      title: 'ChatGPT and Claude Web',
-      content: [
-        {
-          type: 'prose',
-          text: 'For web-based AI tools without project context files, paste CLI output directly into your conversation. The --dense flag keeps the token cost low.',
-        },
-        {
-          type: 'code',
-          lang: 'bash',
-          label: 'Generate context to paste',
-          code: `# Copy this output into your conversation before asking for code
-npx xds docs principles --dense
+          label: 'Dense output for pasting into AI conversations',
+          code: `npx xds component Dialog --dense
 npx xds docs styling --dense
-
-# Or for a specific component you're working with
-npx xds component Dialog --props --dense`,
-        },
-        {
-          type: 'prose',
-          text: 'ChatGPT Projects and Claude Projects both support persistent files — upload the dense CLI output as a project knowledge file so it applies to every conversation in that project.',
-        },
-      ],
-    },
-    {
-      title: 'Component Discovery',
-      content: [
-        {
-          type: 'prose',
-          text: 'When you\u2019re not sure which XDS component to use, the CLI helps with discovery. This is useful both for you and for AI tools that can execute commands.',
-        },
-        {
-          type: 'code',
-          lang: 'bash',
-          label: 'Find the right component',
-          code: `# List all components
-npx xds component
-
-# Search by keyword (finds related components)
-npx xds component modal
-npx xds component dropdown
-npx xds component table
-
-# Discover hooks
-npx xds hook
-
-# Search for hooks
-npx xds hook focus`,
-        },
-        {
-          type: 'prose',
-          text: 'Component search matches against names, keywords, and descriptions. If you search for "modal", it finds Dialog. If you search for "dropdown", it finds Selector and Popover.',
-        },
-      ],
-    },
-    {
-      title: 'Block Templates as Examples',
-      content: [
-        {
-          type: 'prose',
-          text: 'XDS ships real-world code examples as block templates. These are complete, working UI patterns that demonstrate correct component composition. They\u2019re the best reference material for AI — concrete code beats abstract documentation.',
-        },
-        {
-          type: 'code',
-          lang: 'bash',
-          label: 'Browse and use templates',
-          code: `# List all templates
-npx xds template
-
-# Inject a template into your project
-npx xds template dashboard ./src/pages/
-npx xds template settings-sidebar ./src/pages/
-
-# View template source (great for AI context)
-npx xds template login-card --print`,
-        },
-        {
-          type: 'prose',
-          text: 'When asking an AI to build a complex page, paste a relevant template as a reference pattern. The model will pick up the composition style, import paths, and prop usage from the example.',
-        },
-      ],
-    },
-    {
-      title: 'Import Paths',
-      content: [
-        {
-          type: 'prose',
-          text: 'AI models frequently get import paths wrong. XDS uses per-category subpath imports for tree-shaking. Here\u2019s the pattern:',
-        },
-        {
-          type: 'code',
-          lang: 'tsx',
-          label: 'Correct import paths',
-          code: `// Components — from their directory name
-import {XDSButton} from '@xds/core/Button';
-import {XDSTextInput} from '@xds/core/TextInput';
-import {XDSCard} from '@xds/core/Card';
-import {XDSStack, XDSGrid} from '@xds/core/Layout';
-
-// Hooks — from their component or from /hooks
-import {useXDSToast} from '@xds/core/Toast';
-import {useMediaQuery} from '@xds/core/hooks';
-
-// Theme
-import {XDSTheme} from '@xds/core';
-import {defineTheme} from '@xds/core/theme';
-
-// Token imports for typed StyleX usage
-import {colorVars, spacingVars} from '@xds/core/theme/tokens.stylex';`,
-        },
-        {
-          type: 'list',
-          style: 'dont',
-          items: [
-            "Import from '@xds/core' for individual components — use the subpath.",
-            "Import from '@xds/core/components/Button' — there's no components/ prefix.",
-            "Use named imports that don't start with XDS — all components are XDS-prefixed.",
-          ],
-        },
-      ],
-    },
-    {
-      title: 'Common AI Mistakes',
-      content: [
-        {
-          type: 'prose',
-          text: 'These are the patterns AI models most frequently get wrong with XDS, and how to correct them.',
-        },
-        {
-          type: 'table',
-          headers: ['AI generates', 'Correct XDS', 'Why'],
-          rows: [
-            ['disabled={true}', 'isDisabled', 'XDS uses is/has prefixed booleans'],
-            ['variant="outlined"', 'variant="secondary"', 'XDS variants: primary, secondary, ghost, destructive'],
-            ['<Button>Click</Button>', '<XDSButton label="Click" />', 'label prop, not children (unless you need custom content)'],
-            ['onChange={(e) => ...}', 'onChange={(value) => ...}', 'XDS inputs pass the value directly, not the event'],
-            ['<input type="text" />', '<XDSTextInput />', 'Always use the XDS component when one exists'],
-            ['#0064E0', 'var(--color-accent)', 'Use semantic tokens, never hardcoded colors'],
-            ['gap: 16', "gap: 'var(--spacing-4)'", 'Use spacing tokens via CSS custom properties'],
-          ],
-        },
-      ],
-    },
-    {
-      title: 'AI Agent Integration',
-      content: [
-        {
-          type: 'prose',
-          text: 'If you\u2019re building an AI agent or coding assistant that generates XDS code, the CLI provides machine-readable output for integration.',
-        },
-        {
-          type: 'code',
-          lang: 'bash',
-          label: 'Machine-readable output',
-          code: `# JSON output for all commands
-npx xds component Button --json
-npx xds docs tokens --json
-npx xds template --json
-
-# Dense format minimizes token usage
-npx xds component --dense
-npx xds docs styling --dense`,
-        },
-        {
-          type: 'prose',
-          text: 'The JSON output returns typed envelopes with structured data — prop definitions, token values, template metadata. The dense format strips examples and verbose descriptions, keeping only what a model needs to generate correct code.',
-        },
-        {
-          type: 'prose',
-          text: 'For agents with tool-calling capabilities, the CLI commands can be called directly as tools. An agent that runs `npx xds component <Name> --props --dense` before generating code will produce significantly better results than one working from memory alone.',
+npx xds docs tokens --dense`,
         },
       ],
     },

--- a/packages/cli/docs/working-with-ai.doc.mjs
+++ b/packages/cli/docs/working-with-ai.doc.mjs
@@ -1,0 +1,314 @@
+/** @type {import('../../core/src/docs-types').ReferenceDoc} */
+
+export const docs = {
+  name: 'working-with-ai',
+  title: 'Working with AI',
+  category: 'guide',
+  description:
+    'How to use AI coding tools effectively with XDS — prompting strategies, the CLI as context source, and patterns that help models generate correct component code.',
+
+  sections: [
+    {
+      title: 'Why This Matters',
+      content: [
+        {
+          type: 'prose',
+          text: 'XDS is designed to be AI-friendly. Components follow consistent naming conventions, props use predictable patterns (is/has prefixes for booleans, on-prefixed callbacks), and the CLI can feed structured documentation directly into an AI context window. But models still need the right context to generate correct XDS code — without it, they fall back to generic React patterns or guess at prop names.',
+        },
+        {
+          type: 'prose',
+          text: 'This guide covers how to get the best results from AI tools (Claude, Cursor, Copilot, ChatGPT, etc.) when building with XDS.',
+        },
+      ],
+    },
+    {
+      title: 'The CLI Is Your Context Source',
+      content: [
+        {
+          type: 'prose',
+          text: 'The XDS CLI is the single source of truth for component APIs. Before writing any component code — or asking an AI to write it — query the CLI to get the real props, types, and defaults.',
+        },
+        {
+          type: 'code',
+          lang: 'bash',
+          label: 'Look up a component before coding',
+          code: `# Full component docs (props, theming, usage)
+npx xds component Button
+
+# Props table only
+npx xds component Button --props
+
+# Compressed format (fewer tokens for AI context)
+npx xds component Button --dense
+
+# JSON output (for programmatic use)
+npx xds component Button --json`,
+        },
+        {
+          type: 'prose',
+          text: 'The --dense flag outputs a token-efficient format that fits more information into a smaller context window. Use it when feeding component docs into an AI prompt.',
+        },
+        {
+          type: 'code',
+          lang: 'bash',
+          label: 'Reference docs for AI context',
+          code: `# Styling guide
+npx xds docs styling --dense
+
+# Design tokens reference
+npx xds docs tokens --dense
+
+# All available topics
+npx xds docs`,
+        },
+      ],
+    },
+    {
+      title: 'Prompting Strategies',
+      content: [
+        {
+          type: 'prose',
+          text: 'The most common AI failure mode with XDS is inventing props that don\u2019t exist. The fix is simple: give the model real documentation before asking it to write code.',
+        },
+        {
+          type: 'list',
+          style: 'do',
+          items: [
+            'Paste the output of `npx xds component <Name> --props` into your prompt before asking for code.',
+            'Include the styling guide (`npx xds docs styling --dense`) when asking for layout or theming work.',
+            'Ask the model to use XDS components by name — specificity reduces hallucination.',
+            'Provide a working example from your codebase as a reference pattern.',
+          ],
+        },
+        {
+          type: 'list',
+          style: 'dont',
+          items: [
+            'Ask for "a button component" without specifying XDS — the model will reach for native HTML or another library.',
+            'Assume the model knows XDS prop names. Even if it gets close, `disabled` vs `isDisabled` matters.',
+            'Let the model invent wrapper components when XDS already has the right primitive.',
+          ],
+        },
+      ],
+    },
+    {
+      title: 'Setting Up Your AI',
+      content: [
+        {
+          type: 'prose',
+          text: 'Most AI tools let you provide persistent project context — a system prompt, rules file, or context document that gets included in every conversation. Setting this up once is the highest-leverage thing you can do for XDS code quality.',
+        },
+        {
+          type: 'prose',
+          text: 'Generate a context document tuned for your project:',
+        },
+        {
+          type: 'code',
+          lang: 'bash',
+          label: 'Generate AI context',
+          code: `# Print the XDS principles + styling guide in dense format
+npx xds docs principles --dense
+npx xds docs styling --dense
+
+# List all available components (so the model knows what exists)
+npx xds component --dense`,
+        },
+        {
+          type: 'prose',
+          text: 'Paste that output into your tool\'s context file. Where it goes depends on your tool:',
+        },
+        {
+          type: 'table',
+          headers: ['Tool', 'Where to put it'],
+          rows: [
+            ['Cursor', '.cursorrules or .cursor/rules in your project root'],
+            ['Claude Code', 'CLAUDE.md in your project root'],
+            ['GitHub Copilot', '.github/copilot-instructions.md'],
+            ['ChatGPT / Claude web', 'Custom instructions or project knowledge'],
+            ['Windsurf', '.windsurfrules in your project root'],
+          ],
+        },
+        {
+          type: 'prose',
+          text: 'The key insight: the --dense flag on any CLI command outputs a compressed format designed for AI context windows. It strips verbose descriptions and examples, keeping only what a model needs to generate correct code. Use it for anything going into a rules file.',
+        },
+      ],
+    },
+    {
+      title: 'Component Discovery',
+      content: [
+        {
+          type: 'prose',
+          text: 'When you\u2019re not sure which XDS component to use, the CLI helps with discovery. This is useful both for you and for AI tools that can execute commands.',
+        },
+        {
+          type: 'code',
+          lang: 'bash',
+          label: 'Find the right component',
+          code: `# List all components
+npx xds component
+
+# Search by keyword (finds related components)
+npx xds component modal
+npx xds component dropdown
+npx xds component table
+
+# Discover hooks
+npx xds hook
+
+# Search for hooks
+npx xds hook focus`,
+        },
+        {
+          type: 'prose',
+          text: 'Component search matches against names, keywords, and descriptions. If you search for "modal", it finds Dialog. If you search for "dropdown", it finds Selector and Popover.',
+        },
+      ],
+    },
+    {
+      title: 'Block Templates as Examples',
+      content: [
+        {
+          type: 'prose',
+          text: 'XDS ships real-world code examples as block templates. These are complete, working UI patterns that demonstrate correct component composition. They\u2019re the best reference material for AI — concrete code beats abstract documentation.',
+        },
+        {
+          type: 'code',
+          lang: 'bash',
+          label: 'Browse and use templates',
+          code: `# List all templates
+npx xds template
+
+# Inject a template into your project
+npx xds template dashboard ./src/pages/
+npx xds template settings-sidebar ./src/pages/
+
+# View template source (great for AI context)
+npx xds template login-card --print`,
+        },
+        {
+          type: 'prose',
+          text: 'When asking an AI to build a complex page, paste a relevant template as a reference pattern. The model will pick up the composition style, import paths, and prop usage from the example.',
+        },
+      ],
+    },
+    {
+      title: 'Import Paths',
+      content: [
+        {
+          type: 'prose',
+          text: 'AI models frequently get import paths wrong. XDS uses per-category subpath imports for tree-shaking. Here\u2019s the pattern:',
+        },
+        {
+          type: 'code',
+          lang: 'tsx',
+          label: 'Correct import paths',
+          code: `// Components — from their directory name
+import {XDSButton} from '@xds/core/Button';
+import {XDSTextInput} from '@xds/core/TextInput';
+import {XDSCard} from '@xds/core/Card';
+import {XDSStack, XDSGrid} from '@xds/core/Layout';
+
+// Hooks — from their component or from /hooks
+import {useXDSToast} from '@xds/core/Toast';
+import {useMediaQuery} from '@xds/core/hooks';
+
+// Theme
+import {XDSTheme} from '@xds/core';
+import {defineTheme} from '@xds/core/theme';
+
+// Token imports for typed StyleX usage
+import {colorVars, spacingVars} from '@xds/core/theme/tokens.stylex';`,
+        },
+        {
+          type: 'list',
+          style: 'dont',
+          items: [
+            "Import from '@xds/core' for individual components — use the subpath.",
+            "Import from '@xds/core/components/Button' — there's no components/ prefix.",
+            "Use named imports that don't start with XDS — all components are XDS-prefixed.",
+          ],
+        },
+      ],
+    },
+    {
+      title: 'Common AI Mistakes',
+      content: [
+        {
+          type: 'prose',
+          text: 'These are the patterns AI models most frequently get wrong with XDS, and how to correct them.',
+        },
+        {
+          type: 'table',
+          headers: ['AI generates', 'Correct XDS', 'Why'],
+          rows: [
+            ['disabled={true}', 'isDisabled', 'XDS uses is/has prefixed booleans'],
+            ['variant="outlined"', 'variant="secondary"', 'XDS variants: primary, secondary, ghost, destructive'],
+            ['<Button>Click</Button>', '<XDSButton label="Click" />', 'label prop, not children (unless you need custom content)'],
+            ['onChange={(e) => ...}', 'onChange={(value) => ...}', 'XDS inputs pass the value directly, not the event'],
+            ['<input type="text" />', '<XDSTextInput />', 'Always use the XDS component when one exists'],
+            ['#0064E0', 'var(--color-accent)', 'Use semantic tokens, never hardcoded colors'],
+            ['gap: 16', "gap: 'var(--spacing-4)'", 'Use spacing tokens via CSS custom properties'],
+          ],
+        },
+      ],
+    },
+    {
+      title: 'AI Agent Integration',
+      content: [
+        {
+          type: 'prose',
+          text: 'If you\u2019re building an AI agent or coding assistant that generates XDS code, the CLI provides machine-readable output for integration.',
+        },
+        {
+          type: 'code',
+          lang: 'bash',
+          label: 'Machine-readable output',
+          code: `# JSON output for all commands
+npx xds component Button --json
+npx xds docs tokens --json
+npx xds template --json
+
+# Dense format minimizes token usage
+npx xds component --dense
+npx xds docs styling --dense`,
+        },
+        {
+          type: 'prose',
+          text: 'The JSON output returns typed envelopes with structured data — prop definitions, token values, template metadata. The dense format strips examples and verbose descriptions, keeping only what a model needs to generate correct code.',
+        },
+        {
+          type: 'prose',
+          text: 'For agents with tool-calling capabilities, the CLI commands can be called directly as tools. An agent that runs `npx xds component <Name> --props --dense` before generating code will produce significantly better results than one working from memory alone.',
+        },
+      ],
+    },
+    {
+      title: 'Cursor / IDE Integration',
+      content: [
+        {
+          type: 'prose',
+          text: 'For IDE-integrated AI tools like Cursor, Copilot, or Cody, add XDS context to your project rules or context files.',
+        },
+        {
+          type: 'code',
+          lang: 'text',
+          label: '.cursorrules or project context file',
+          code: `This project uses the XDS design system (@xds/core).
+
+Key rules:
+- Import components from '@xds/core/<ComponentName>' (e.g. '@xds/core/Button')
+- All components are prefixed with XDS (XDSButton, XDSCard, XDSTextInput)
+- Boolean props use is/has prefix (isDisabled, isLoading, hasHover)
+- Form inputs are controlled (value + onChange, where onChange passes the value directly)
+- Use semantic tokens for colors (var(--color-accent)) and spacing (var(--spacing-4))
+- Use xstyle prop with stylex.create() for component style overrides
+- Use Tailwind utilities on className for layout and wrapper styling
+
+Run \`npx xds component <Name> --props\` to look up any component API.
+Run \`npx xds docs styling\` for the complete styling guide.`,
+        },
+      ],
+    },
+  ],
+};


### PR DESCRIPTION
Adds a new reference doc (`working-with-ai.doc.mjs`) covering how to use AI coding tools effectively with XDS.

## Sections

- **Why This Matters** — why models need XDS context
- **Setting Up Your AI** — where to put context for Cursor, Claude Code, Copilot, etc.
- **The CLI Is Your Context Source** — `--dense`, `--json`, `--props` flags
- **Prompting Strategies** — do/don't guidance
- **Component Discovery** — CLI search for finding the right component
- **Block Templates as Examples** — using templates as AI reference material
- **Import Paths** — the subpath pattern models get wrong most often
- **Common AI Mistakes** — 7 most frequent hallucinations + corrections
- **AI Agent Integration** — machine-readable output for tool-calling agents
- **Cursor / IDE Integration** — project rules snippet

## Status

Draft — the prompt template section was removed pending vibe testing. The Setting Up Your AI section replaces it with grounded CLI-based setup instructions.

Accessible via `npx xds docs working-with-ai`.