### PR TITLE
fix(FormLayout): give horizontal children equal width via CSS Grid

### DIFF
--- a/packages/core/src/FormLayout/XDSFormLayout.tsx
+++ b/packages/core/src/FormLayout/XDSFormLayout.tsx
@@ -41,8 +41,9 @@ const styles = stylex.create({
     gap: spacingVars['--spacing-4'],
   },
   horizontal: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
+    display: 'grid',
+    gridAutoFlow: 'column',
+    gridAutoColumns: '1fr',
   },
   horizontalLabels: {
     display: 'grid',
@@ -74,8 +75,8 @@ export interface XDSFormLayoutProps extends XDSBaseProps<HTMLDivElement> {
    * Direction of field arrangement.
    *
    * - `'vertical'` — Fields stack top-to-bottom (default). Most common.
-   * - `'horizontal'` — Fields arrange left-to-right, wrapping when needed.
-   *   Each child gets equal flex-grow.
+   * - `'horizontal'` — Fields arrange left-to-right in equal-width columns
+   *   using CSS Grid. Each child occupies one equal column.
    * - `'horizontal-labels'` — CSS Grid with labels to the left of inputs.
    *   Collapses to vertical when the container is narrow (≤480px).
    *

--- a/packages/core/src/FormLayout/__snapshots__/XDSFormLayout.test.tsx.snap
+++ b/packages/core/src/FormLayout/__snapshots__/XDSFormLayout.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`XDSFormLayout > matches snapshot for horizontal direction 1`] = `
 <div
-  class="xds-form-layout horizontal XDSFormLayout__styles.base x78zum5 x18g69wz XDSFormLayout__styles.horizontal x1q0g3np x1a02dak"
+  class="xds-form-layout horizontal XDSFormLayout__styles.base xdt5ytf x18g69wz XDSFormLayout__styles.horizontal xrvj5dj x1mt1orb xu6a5m6"
   data-testid="layout"
 >
   <input


### PR DESCRIPTION
## What

`XDSFormLayout` with `direction="horizontal"` only set `flexDirection: row` + `flexWrap: wrap` on the container — it never applied `flex-grow` to children. As a result, children rendered at content-width instead of the equal widths described in the JSDoc and component docs.

## How

Switch horizontal mode from flexbox to CSS Grid:

- `display: grid`
- `gridAutoFlow: column`
- `gridAutoColumns: 1fr`

Each child automatically gets an equal-width column purely from container styles — no child selectors, no `React.Children` introspection, no wrapper divs. This follows the same grid-based approach already used by `horizontal-labels` mode.

## Changes

- `XDSFormLayout.tsx` — Replace flex row/wrap with grid auto-flow column + 1fr, update JSDoc
- Snapshot updated to reflect new CSS classes