### PR TITLE
feat(Section): rename 'wash' variant to 'muted' for consistency with XDSCard

### DIFF
--- a/apps/docsite/src/components/component-detail/ExampleBlock.tsx
+++ b/apps/docsite/src/components/component-detail/ExampleBlock.tsx
@@ -71,13 +71,13 @@ export function ExampleBlock({entry}: ExampleBlockProps) {
 
       <LivePreview entry={entry} />
 
-      <XDSSection variant="wash" padding={1} dividers={['top']}>
+      <XDSSection variant="muted" padding={1} dividers={['top']}>
         <XDSTabList value={tab} onChange={setTab} size="sm">
           <XDSTab value="description" label="Description" />
           <XDSTab value="code" label="Code" />
         </XDSTabList>
       </XDSSection>
-      <XDSSection variant="wash">
+      <XDSSection variant="muted">
         {tab === 'description' ? (
           <XDSText type="body">
             {entry.description || 'No description available.'}

--- a/apps/sandbox/src/app/(fullscreen)/pages/codeblock-perf/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/codeblock-perf/page.tsx
@@ -360,7 +360,7 @@ export default function CodeBlockPerfPage() {
           </XDSText>
         </XDSVStack>
 
-        <XDSSection variant="wash" padding={3} dividers={['bottom']}>
+        <XDSSection variant="muted" padding={3} dividers={['bottom']}>
           <XDSHStack gap={4} vAlign="center" wrap="wrap">
             <XDSSegmentedControl
               label="Line count"

--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/DocsView.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/DocsView.tsx
@@ -5040,7 +5040,7 @@ function ComponentDetailPage({
                     </XDSText>
                   )}
                 </XDSCenter>
-                <XDSSection variant="wash" padding={3} dividers={['top']}>
+                <XDSSection variant="muted" padding={3} dividers={['top']}>
                   <XDSStack direction="vertical" gap={3}>
                     <XDSTabList
                       value={activeTab}

--- a/apps/storybook/stories/Card.stories.tsx
+++ b/apps/storybook/stories/Card.stories.tsx
@@ -244,7 +244,7 @@ export const NestedSections: Story = {
 export const SingleSection: Story = {
   render: () => (
     <XDSCard width={350}>
-      <XDSSection variant="wash">
+      <XDSSection variant="muted">
         <XDSVStack gap={2}>
           <XDSHeading level={3}>Only Section (Full Bleed All Sides)</XDSHeading>
           <p {...stylex.props(styles.text, styles.textSecondary)}>
@@ -274,7 +274,7 @@ export const MixedContent: Story = {
       <div>
         <h4 {...stylex.props(styles.heading)}>With Section</h4>
         <XDSCard width={250}>
-          <XDSSection variant="wash">
+          <XDSSection variant="muted">
             <XDSVStack gap={2}>
               <XDSHeading level={3}>Card Title</XDSHeading>
               <p {...stylex.props(styles.text, styles.textSecondary)}>

--- a/apps/storybook/stories/Center.stories.tsx
+++ b/apps/storybook/stories/Center.stories.tsx
@@ -80,7 +80,7 @@ export const Default: Story = {
     children: null,
   },
   render: args => (
-    <XDSSection variant="wash" width="100%">
+    <XDSSection variant="muted" width="100%">
       <XDSCenter {...args}>
         <Box>Centered Content</Box>
       </XDSCenter>
@@ -95,7 +95,7 @@ export const HorizontalOnly: Story = {
     children: null,
   },
   render: args => (
-    <XDSSection variant="wash" width="100%">
+    <XDSSection variant="muted" width="100%">
       <XDSCenter {...args}>
         <Box>Horizontal Center</Box>
       </XDSCenter>
@@ -111,7 +111,7 @@ export const VerticalOnly: Story = {
     children: null,
   },
   render: args => (
-    <XDSSection variant="wash" width="100%">
+    <XDSSection variant="muted" width="100%">
       <XDSCenter {...args}>
         <Box>Vertical Center</Box>
       </XDSCenter>
@@ -127,7 +127,7 @@ export const FullSize: Story = {
     children: null,
   },
   render: args => (
-    <XDSSection variant="wash">
+    <XDSSection variant="muted">
       <XDSCenter {...args}>
         <Box>Full Width, Fixed Height</Box>
       </XDSCenter>
@@ -141,7 +141,7 @@ export const Inline: Story = {
     children: null,
   },
   render: args => (
-    <XDSSection variant="wash">
+    <XDSSection variant="muted">
       <XDSCard>
         <XDSText type="body">
           Text with inline centered icon:{' '}
@@ -163,7 +163,7 @@ export const WithIcon: Story = {
     children: null,
   },
   render: args => (
-    <XDSSection variant="wash">
+    <XDSSection variant="muted">
       <XDSCenter {...args}>
         <div {...stylex.props(styles.iconWrapper)}>
           <XDSIcon icon={CheckCircleIcon} size="lg" />
@@ -179,7 +179,7 @@ export const InsideACard: Story = {
     children: null,
   },
   render: args => (
-    <XDSSection variant="wash">
+    <XDSSection variant="muted">
       <XDSCard>
         <XDSCenter {...args}>
           <Box>Centered in Card</Box>
@@ -194,7 +194,7 @@ export const AllAxisModes: Story = {
     children: null,
   },
   render: () => (
-    <XDSSection variant="wash">
+    <XDSSection variant="muted">
       <div {...stylex.props(styles.storyWrapper)}>
         <XDSCard>
           <XDSText type="supporting" display="block">

--- a/apps/storybook/stories/Divider.stories.tsx
+++ b/apps/storybook/stories/Divider.stories.tsx
@@ -50,7 +50,7 @@ type Story = StoryObj<typeof XDSDivider>;
 export const Default: Story = {
   args: {},
   render: args => (
-    <XDSSection variant="wash">
+    <XDSSection variant="muted">
       <XDSCard>
         <XDSVStack gap={3}>
           <XDSText type="body">Content above</XDSText>
@@ -67,7 +67,7 @@ export const WithLabel: Story = {
     label: 'or',
   },
   render: args => (
-    <XDSSection variant="wash">
+    <XDSSection variant="muted">
       <XDSCard>
         <XDSVStack gap={3}>
           <XDSText type="body">Content above</XDSText>
@@ -81,7 +81,7 @@ export const WithLabel: Story = {
 
 export const Variants: Story = {
   render: () => (
-    <XDSSection variant="wash">
+    <XDSSection variant="muted">
       <div {...stylex.props(styles.storyWrapper)}>
         <XDSCard>
           <XDSVStack gap={3}>
@@ -102,7 +102,7 @@ export const Variants: Story = {
 
 export const FullBleed: Story = {
   render: () => (
-    <XDSSection variant="wash">
+    <XDSSection variant="muted">
       <div {...stylex.props(styles.storyWrapper)}>
         <XDSCard>
           <XDSVStack gap={3}>
@@ -134,7 +134,7 @@ export const Vertical: Story = {
     orientation: 'vertical',
   },
   render: args => (
-    <XDSSection variant="wash">
+    <XDSSection variant="muted">
       <XDSCard height={200}>
         <XDSHStack gap={4} xstyle={styles.fullHeight}>
           <XDSText type="body">Left content</XDSText>
@@ -152,7 +152,7 @@ export const VerticalWithLabel: Story = {
     label: 'OR',
   },
   render: args => (
-    <XDSSection variant="wash">
+    <XDSSection variant="muted">
       <XDSCard height={200}>
         <XDSHStack gap={4} xstyle={styles.fullHeight}>
           <XDSText type="body">Option A</XDSText>
@@ -166,7 +166,7 @@ export const VerticalWithLabel: Story = {
 
 export const InCard: Story = {
   render: () => (
-    <XDSSection variant="wash">
+    <XDSSection variant="muted">
       <XDSCard>
         <XDSVStack gap={3}>
           <XDSText type="label">Card Title</XDSText>
@@ -187,7 +187,7 @@ export const InCard: Story = {
 
 export const FullBleedVertical: Story = {
   render: () => (
-    <XDSSection variant="wash">
+    <XDSSection variant="muted">
       <XDSCard height={200}>
         <XDSHStack gap={4} xstyle={styles.fullHeight}>
           <XDSText type="body">Left content</XDSText>

--- a/apps/storybook/stories/Grid.stories.tsx
+++ b/apps/storybook/stories/Grid.stories.tsx
@@ -294,7 +294,7 @@ export const GridSpanWithRows: Story = {
 
 export const GalleryExample: Story = {
   render: () => (
-    <XDSSection variant="wash">
+    <XDSSection variant="muted">
       <XDSText type="supporting" xstyle={styles.sectionLabel}>
         Gallery/Card Grid — Responsive with min 280px cards (auto-fill)
       </XDSText>
@@ -350,7 +350,7 @@ export const DifferentGaps: Story = {
 
 export const DashboardLayout: Story = {
   render: () => (
-    <XDSSection variant="wash">
+    <XDSSection variant="muted">
       <XDSText type="supporting" xstyle={styles.sectionLabel}>
         Dashboard-style layout with different sized widgets
       </XDSText>

--- a/apps/storybook/stories/GridMasonry.stories.tsx
+++ b/apps/storybook/stories/GridMasonry.stories.tsx
@@ -151,7 +151,7 @@ function GalleryCard({
  */
 export const MasonryGallery: Story = {
   render: () => (
-    <XDSSection variant="wash" padding={6}>
+    <XDSSection variant="muted" padding={6}>
       <XDSVStack gap={5}>
         <XDSVStack gap={2}>
           <XDSHeading level={2}>Mixed Gallery</XDSHeading>
@@ -199,7 +199,7 @@ export const MasonryGallery: Story = {
 export const DenseMasonry: Story = {
   render: () => {
     return (
-      <XDSSection variant="wash" padding={6}>
+      <XDSSection variant="muted" padding={6}>
         <XDSVStack gap={5}>
           <XDSVStack gap={2}>
             <XDSHeading level={2}>Dense Masonry</XDSHeading>
@@ -261,7 +261,7 @@ export const DenseMasonry: Story = {
 export const FeaturedMasonry: Story = {
   render: () => {
     return (
-      <XDSSection variant="wash" padding={6}>
+      <XDSSection variant="muted" padding={6}>
         <XDSVStack gap={5}>
           <XDSVStack gap={2}>
             <XDSHeading level={2}>Featured Masonry</XDSHeading>

--- a/apps/storybook/stories/Layout.stories.tsx
+++ b/apps/storybook/stories/Layout.stories.tsx
@@ -676,7 +676,7 @@ export const SectionVariants: Story = {
           />
         </XDSSection>
 
-        <XDSSection variant="wash" width={300} height={250}>
+        <XDSSection variant="muted" width={300} height={250}>
           <XDSLayout
             header={
               <XDSLayoutHeader hasDivider>

--- a/apps/storybook/stories/Section.stories.tsx
+++ b/apps/storybook/stories/Section.stories.tsx
@@ -61,7 +61,7 @@ const meta: Meta<typeof XDSSection> = {
   argTypes: {
     variant: {
       control: 'select',
-      options: ['section', 'transparent', 'wash'],
+      options: ['section', 'transparent', 'muted'],
       description: 'Visual variant of the section',
     },
     width: {
@@ -103,8 +103,8 @@ export const Variants: Story = {
         </XDSSection>
       </div>
       <div>
-        <h4 {...stylex.props(styles.heading)}>wash</h4>
-        <XDSSection variant="wash" width={200}>
+        <h4 {...stylex.props(styles.heading)}>muted</h4>
+        <XDSSection variant="muted" width={200}>
           <p {...stylex.props(styles.text)}>Wash background</p>
         </XDSSection>
       </div>
@@ -120,7 +120,7 @@ export const Variants: Story = {
 
 export const WithSimpleContent: Story = {
   render: () => (
-    <XDSSection variant="wash" width={320}>
+    <XDSSection variant="muted" width={320}>
       <XDSVStack gap={2}>
         <h3 {...stylex.props(styles.text)}>Section Title</h3>
         <p {...stylex.props(styles.text, styles.textSecondary)}>
@@ -134,7 +134,7 @@ export const WithSimpleContent: Story = {
 
 export const WithInnerLayout: Story = {
   render: () => (
-    <XDSSection variant="wash" width={350} height={250}>
+    <XDSSection variant="muted" width={350} height={250}>
       <XDSLayout
         header={
           <XDSLayoutHeader hasDivider>
@@ -203,7 +203,7 @@ export const FullBleed: Story = {
     <div {...stylex.props(styles.storyWrapper)}>
       <div>
         <h4 {...stylex.props(styles.heading)}>Default (with padding)</h4>
-        <XDSSection variant="wash" width={250}>
+        <XDSSection variant="muted" width={250}>
           <div style={{backgroundColor: 'rgba(0,100,200,0.2)', padding: 8}}>
             <p {...stylex.props(styles.text)}>Content with section padding</p>
           </div>
@@ -211,7 +211,7 @@ export const FullBleed: Story = {
       </div>
       <div>
         <h4 {...stylex.props(styles.heading)}>Full Bleed (no padding)</h4>
-        <XDSSection variant="wash" width={250} padding={0}>
+        <XDSSection variant="muted" width={250} padding={0}>
           <div style={{backgroundColor: 'rgba(0,100,200,0.2)', padding: 8}}>
             <p {...stylex.props(styles.text)}>Content touches section edges</p>
           </div>
@@ -229,7 +229,7 @@ export const NestedPaddingInheritance: Story = {
           padding=6 → nested (inherits 6)
         </h4>
         <XDSSection variant="section" width={350} padding={6}>
-          <XDSSection variant="wash">
+          <XDSSection variant="muted">
             <p {...stylex.props(styles.text)}>
               Inner section inherits padding=6 from parent. Edge compensation
               and content inset should both use 24px.
@@ -240,7 +240,7 @@ export const NestedPaddingInheritance: Story = {
       <div>
         <h4 {...stylex.props(styles.heading)}>padding=6 → nested padding=2</h4>
         <XDSSection variant="section" width={350} padding={6}>
-          <XDSSection variant="wash" padding={2}>
+          <XDSSection variant="muted" padding={2}>
             <p {...stylex.props(styles.text)}>
               Inner section explicitly sets padding=2, overriding the parent's
               padding=6. Content inset is 8px.
@@ -253,7 +253,7 @@ export const NestedPaddingInheritance: Story = {
           padding=2 → nested (inherits 2)
         </h4>
         <XDSSection variant="section" width={350} padding={2}>
-          <XDSSection variant="wash">
+          <XDSSection variant="muted">
             <p {...stylex.props(styles.text)}>
               Inner section inherits padding=2 from parent. Both edge
               compensation and content inset use 8px.

--- a/apps/storybook/stories/Table.stories.tsx
+++ b/apps/storybook/stories/Table.stories.tsx
@@ -562,7 +562,7 @@ export const InCardWithSection: Story = {
           The table below is in a wash section for visual separation.
         </p>
       </XDSVStack>
-      <XDSSection variant="wash">
+      <XDSSection variant="muted">
         <XDSTable
           data={users.slice(0, 3)}
           columns={simpleColumns}

--- a/apps/storybook/stories/Toolbar.stories.tsx
+++ b/apps/storybook/stories/Toolbar.stories.tsx
@@ -36,7 +36,7 @@ const meta: Meta<typeof XDSToolbar> = {
     label: {control: 'text'},
     size: {control: 'radio', options: ['sm', 'md', 'lg']},
     orientation: {control: 'radio', options: ['horizontal', 'vertical']},
-    variant: {control: 'select', options: ['transparent', 'section', 'wash']},
+    variant: {control: 'select', options: ['transparent', 'section', 'muted']},
     gap: {control: 'number'},
   },
 };
@@ -145,7 +145,7 @@ export const Compact: Story = {
 export const WashVariant: Story = {
   args: {
     label: 'Highlighted toolbar',
-    variant: 'wash',
+    variant: 'muted',
     startContent: <XDSText type="body">3 items selected</XDSText>,
     endContent: (
       <>
@@ -279,7 +279,7 @@ export const BulkActions: Story = {
     <XDSToolbar
       label="Bulk actions"
       size="sm"
-      variant="wash"
+      variant="muted"
       startContent={
         <>
           <XDSBadge label="5 selected" />
@@ -333,7 +333,7 @@ export const StackedToolbars: Story = {
       <XDSToolbar
         label="Filters"
         size="sm"
-        variant="wash"
+        variant="muted"
         startContent={
           <>
             <XDSTextInput

--- a/packages/cli/src/codemods/__tests__/rename-section-wash-to-muted.test.mjs
+++ b/packages/cli/src/codemods/__tests__/rename-section-wash-to-muted.test.mjs
@@ -1,0 +1,79 @@
+import {describe, expect, test} from 'vitest';
+import {applyTransform} from 'jscodeshift/dist/testUtils.js';
+import transform from '../transforms/v0.0.14/rename-section-wash-to-muted.mjs';
+
+const opts = {parser: 'tsx'};
+
+describe('rename-section-wash-to-muted', () => {
+  test('converts variant="wash" to variant="muted" on XDSSection', () => {
+    const input = `<XDSSection variant="wash">content</XDSSection>`;
+    const output = applyTransform({default: transform, parser: 'tsx'}, opts, {source: input});
+    expect(output).toContain('muted');
+    expect(output).not.toContain('wash');
+  });
+
+  test('converts variant="wash" to variant="muted" on XDSToolbar', () => {
+    const input = `<XDSToolbar label="Actions" variant="wash" />`;
+    const output = applyTransform({default: transform, parser: 'tsx'}, opts, {source: input});
+    expect(output).toContain('muted');
+    expect(output).not.toContain('wash');
+  });
+
+  test('converts expression container variant={"wash"}', () => {
+    const input = `<XDSSection variant={'wash'}>content</XDSSection>`;
+    const output = applyTransform({default: transform, parser: 'tsx'}, opts, {source: input});
+    expect(output).toContain('muted');
+    expect(output).not.toContain('wash');
+  });
+
+  test('does not modify other variant values', () => {
+    const input = `<XDSSection variant="default">content</XDSSection>`;
+    const output = applyTransform({default: transform, parser: 'tsx'}, opts, {source: input});
+    // No changes — returns empty string
+    expect(output).toBe('');
+  });
+
+  test('does not modify variant="wash" on unrelated components', () => {
+    const input = `<XDSCard variant="wash" />`;
+    const output = applyTransform({default: transform, parser: 'tsx'}, opts, {source: input});
+    expect(output).toBe('');
+  });
+
+  test('leaves XDSSection without variant unchanged', () => {
+    const input = `<XDSSection padding="lg">content</XDSSection>`;
+    const output = applyTransform({default: transform, parser: 'tsx'}, opts, {source: input});
+    expect(output).toBe('');
+  });
+
+  test('converts variant in Storybook args when XDSSection is imported', () => {
+    const input = `import {XDSSection} from '@xds/core/Section';
+const meta = { args: { variant: 'wash' } };`;
+    const output = applyTransform({default: transform, parser: 'tsx'}, opts, {source: input});
+    expect(output).toContain("variant: 'muted'");
+    expect(output).not.toContain("'wash'");
+  });
+
+  test('converts variant in Storybook args when XDSToolbar is imported', () => {
+    const input = `import {XDSToolbar} from '@xds/core/Toolbar';
+const meta = { args: { variant: 'wash' } };`;
+    const output = applyTransform({default: transform, parser: 'tsx'}, opts, {source: input});
+    expect(output).toContain("variant: 'muted'");
+    expect(output).not.toContain("'wash'");
+  });
+
+  test('skips object property transform when no relevant import', () => {
+    const input = `const x = { variant: 'wash' };`;
+    const output = applyTransform({default: transform, parser: 'tsx'}, opts, {source: input});
+    expect(output).toBe('');
+  });
+
+  test('handles multiple components in same file', () => {
+    const input = `<div>
+  <XDSSection variant="wash">section</XDSSection>
+  <XDSToolbar variant="wash" label="bar" />
+</div>`;
+    const output = applyTransform({default: transform, parser: 'tsx'}, opts, {source: input});
+    expect(output).not.toContain('wash');
+    expect(output.match(/muted/g)).toHaveLength(2);
+  });
+});

--- a/packages/cli/src/codemods/__tests__/rename-section-wash-to-muted.test.mjs
+++ b/packages/cli/src/codemods/__tests__/rename-section-wash-to-muted.test.mjs
@@ -67,6 +67,28 @@ const meta = { args: { variant: 'wash' } };`;
     expect(output).toBe('');
   });
 
+  test('converts wash in argTypes variant options array', () => {
+    const input = `import {XDSSection} from '@xds/core/Section';
+const meta = { argTypes: { variant: { control: 'select', options: ['section', 'transparent', 'wash'] } } };`;
+    const output = applyTransform({default: transform, parser: 'tsx'}, opts, {source: input});
+    expect(output).toContain("'muted'");
+    expect(output).not.toContain("'wash'");
+  });
+
+  test('converts JSX text "wash" to "muted" in files importing target components', () => {
+    const input = `import {XDSSection} from '@xds/core/Section';
+const App = () => <h4>wash</h4>;`;
+    const output = applyTransform({default: transform, parser: 'tsx'}, opts, {source: input});
+    expect(output).toContain('muted');
+    expect(output).not.toContain('wash');
+  });
+
+  test('does not convert JSX text "wash" without relevant import', () => {
+    const input = `const App = () => <h4>wash</h4>;`;
+    const output = applyTransform({default: transform, parser: 'tsx'}, opts, {source: input});
+    expect(output).toBe('');
+  });
+
   test('handles multiple components in same file', () => {
     const input = `<div>
   <XDSSection variant="wash">section</XDSSection>

--- a/packages/cli/src/codemods/__tests__/toolbar-density-to-size.test.mjs
+++ b/packages/cli/src/codemods/__tests__/toolbar-density-to-size.test.mjs
@@ -28,7 +28,7 @@ describe('toolbar-density-to-size', () => {
   });
 
   test('leaves XDSToolbar without density unchanged', () => {
-    const input = `<XDSToolbar label="Actions" variant="wash" />`;
+    const input = `<XDSToolbar label="Actions" variant="muted" />`;
     const output = applyTransform({default: transform, parser: 'tsx'}, opts, {source: input});
     // Transform returns undefined (no changes), applyTransform returns ''
     expect(output).toBe('');

--- a/packages/cli/src/codemods/transforms/v0.0.14/index.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.14/index.mjs
@@ -8,10 +8,19 @@ import renameActionProps, {
   meta as renameActionPropsMeta,
 } from './rename-action-props.mjs';
 
+import renameSectionWashToMuted, {
+  meta as renameSectionWashToMutedMeta,
+} from './rename-section-wash-to-muted.mjs';
+
 export default [
   {
     name: 'rename-action-props',
     transform: renameActionProps,
     meta: renameActionPropsMeta,
+  },
+  {
+    name: 'rename-section-wash-to-muted',
+    transform: renameSectionWashToMuted,
+    meta: renameSectionWashToMutedMeta,
   },
 ];

--- a/packages/cli/src/codemods/transforms/v0.0.14/rename-section-wash-to-muted.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.14/rename-section-wash-to-muted.mjs
@@ -1,0 +1,94 @@
+/**
+ * @file Codemod: Rename Section/Toolbar variant "wash" to "muted"
+ * @see https://github.com/facebookexperimental/xds/pull/2063
+ *
+ * XDSSection and XDSToolbar renamed the `variant="wash"` value to
+ * `variant="muted"` for consistency with XDSCard, which already uses
+ * `muted` for the same `--color-background-muted` token.
+ *
+ * Transforms:
+ * - <XDSSection variant="wash" /> → <XDSSection variant="muted" />
+ * - <XDSToolbar variant="wash" /> → <XDSToolbar variant="muted" />
+ * - Object properties: { variant: 'wash' } → { variant: 'muted' }
+ *   (only in files that import XDSSection or XDSToolbar)
+ */
+
+export const meta = {
+  title: 'Rename Section/Toolbar variant "wash" to "muted"',
+  description:
+    'Renames `variant="wash"` to `variant="muted"` on XDSSection and XDSToolbar ' +
+    'to align with XDSCard which already uses `muted` for the same background token.',
+  pr: '#2063',
+};
+
+/** Components affected by this rename. */
+const TARGET_COMPONENTS = new Set(['XDSSection', 'XDSToolbar']);
+
+export default function transformer(file, api) {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+  let hasChanges = false;
+
+  // 1. Rename JSX attribute value: variant="wash" → variant="muted"
+  //    Only on XDSSection and XDSToolbar.
+  root.find(j.JSXOpeningElement).forEach((path) => {
+    const name = path.node.name;
+    const componentName = name.type === 'JSXIdentifier' ? name.name : null;
+    if (!componentName || !TARGET_COMPONENTS.has(componentName)) return;
+
+    path.node.attributes.forEach((attr) => {
+      if (attr.type !== 'JSXAttribute') return;
+      if (attr.name.name !== 'variant') return;
+
+      const value = attr.value;
+
+      // variant="wash" (string literal)
+      if (
+        value &&
+        (value.type === 'StringLiteral' || value.type === 'Literal') &&
+        value.value === 'wash'
+      ) {
+        value.value = 'muted';
+        if (value.raw) value.raw = undefined;
+        hasChanges = true;
+      }
+
+      // variant={'wash'} (expression container with string literal)
+      if (
+        value &&
+        value.type === 'JSXExpressionContainer' &&
+        value.expression &&
+        (value.expression.type === 'StringLiteral' || value.expression.type === 'Literal') &&
+        value.expression.value === 'wash'
+      ) {
+        value.expression.value = 'muted';
+        if (value.expression.raw) value.expression.raw = undefined;
+        hasChanges = true;
+      }
+    });
+  });
+
+  // 2. Object properties in files that import XDSSection or XDSToolbar.
+  //    Handles Storybook args like: { variant: 'wash' } → { variant: 'muted' }
+  const importsTarget =
+    root.find(j.ImportSpecifier, {imported: {name: 'XDSSection'}}).length > 0 ||
+    root.find(j.ImportSpecifier, {imported: {name: 'XDSToolbar'}}).length > 0;
+
+  if (importsTarget) {
+    const PropertyType = j.ObjectProperty ?? j.Property;
+    root.find(PropertyType, {key: {name: 'variant'}}).forEach((path) => {
+      const value = path.node.value;
+      if (
+        (value.type === 'StringLiteral' || value.type === 'Literal') &&
+        value.value === 'wash'
+      ) {
+        value.value = 'muted';
+        if (value.raw) value.raw = undefined;
+        hasChanges = true;
+      }
+    });
+  }
+
+  if (!hasChanges) return undefined;
+  return root.toSource({quote: 'single'});
+}

--- a/packages/cli/src/codemods/transforms/v0.0.14/rename-section-wash-to-muted.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.14/rename-section-wash-to-muted.mjs
@@ -70,6 +70,7 @@ export default function transformer(file, api) {
 
   // 2. Object properties in files that import XDSSection or XDSToolbar.
   //    Handles Storybook args like: { variant: 'wash' } → { variant: 'muted' }
+  //    Also handles options arrays inside variant argTypes config objects.
   const importsTarget =
     root.find(j.ImportSpecifier, {imported: {name: 'XDSSection'}}).length > 0 ||
     root.find(j.ImportSpecifier, {imported: {name: 'XDSToolbar'}}).length > 0;
@@ -78,12 +79,46 @@ export default function transformer(file, api) {
     const PropertyType = j.ObjectProperty ?? j.Property;
     root.find(PropertyType, {key: {name: 'variant'}}).forEach((path) => {
       const value = path.node.value;
+
+      // variant: 'wash' → variant: 'muted'
       if (
         (value.type === 'StringLiteral' || value.type === 'Literal') &&
         value.value === 'wash'
       ) {
         value.value = 'muted';
         if (value.raw) value.raw = undefined;
+        hasChanges = true;
+      }
+
+      // variant: { options: ['...', 'wash', '...'] } → replace 'wash' with 'muted'
+      if (value.type === 'ObjectExpression') {
+        const optionsProp = value.properties.find(
+          (p) => p.key && p.key.name === 'options',
+        );
+        if (optionsProp && optionsProp.value.type === 'ArrayExpression') {
+          optionsProp.value.elements.forEach((el) => {
+            if (
+              el &&
+              (el.type === 'StringLiteral' || el.type === 'Literal') &&
+              el.value === 'wash'
+            ) {
+              el.value = 'muted';
+              if (el.raw) el.raw = undefined;
+              hasChanges = true;
+            }
+          });
+        }
+      }
+    });
+  }
+
+  // 3. JSX text children: replace "wash" text content adjacent to target components.
+  //    Covers labels like <h4>wash</h4> that describe the variant in Storybook stories.
+  if (importsTarget) {
+    root.find(j.JSXText).forEach((path) => {
+      if (path.node.value.trim() === 'wash') {
+        path.node.value = path.node.value.replace('wash', 'muted');
+        if (path.node.raw) path.node.raw = path.node.raw.replace('wash', 'muted');
         hasChanges = true;
       }
     });

--- a/packages/cli/templates/blocks/components/Layout/LayoutFullBleedContent.tsx
+++ b/packages/cli/templates/blocks/components/Layout/LayoutFullBleedContent.tsx
@@ -23,7 +23,7 @@ export default function LayoutFullBleedContent() {
         }
         content={
           <XDSLayoutContent padding={0}>
-            <XDSSection variant="wash">
+            <XDSSection variant="muted">
               <XDSText type="body">
                 XDSSection automatically escapes the parent container padding to
                 fill edge-to-edge. Useful for wash backgrounds, tables, or

--- a/packages/cli/templates/blocks/components/MediaTheme/MediaThemeShowcase.tsx
+++ b/packages/cli/templates/blocks/components/MediaTheme/MediaThemeShowcase.tsx
@@ -30,7 +30,7 @@ export default function MediaThemeShowcase() {
           </XDSStack>
         </XDSMediaTheme>
       </XDSSection>
-      <XDSSection variant="wash" padding={4} style={{flex: 1}}>
+      <XDSSection variant="muted" padding={4} style={{flex: 1}}>
         <XDSMediaTheme mode="light">
           <XDSStack direction="vertical" gap={2}>
             <XDSText type="body" weight="bold">

--- a/packages/cli/templates/blocks/components/Section/SectionVariants.doc.mjs
+++ b/packages/cli/templates/blocks/components/Section/SectionVariants.doc.mjs
@@ -4,7 +4,7 @@ export const doc = {
   exampleFor: 'Section',
   name: 'Section — Variants',
   description:
-    'All three background variants stacked — section (default surface), wash (muted), and transparent. A quick visual reference for choosing the right variant.',
+    'All three background variants stacked — section (default surface), muted, and transparent. A quick visual reference for choosing the right variant.',
   isReady: true,
   isShowcase: true,
   aspectRatio: 16 / 9,

--- a/packages/cli/templates/blocks/components/Section/SectionVariants.tsx
+++ b/packages/cli/templates/blocks/components/Section/SectionVariants.tsx
@@ -17,7 +17,7 @@ export default function SectionVariants() {
           </XDSText>
         </XDSStack>
       </XDSSection>
-      <XDSSection variant="wash" padding={5}>
+      <XDSSection variant="muted" padding={5}>
         <XDSStack direction="vertical" gap={1}>
           <XDSText type="body" weight="bold">
             Wash

--- a/packages/cli/templates/blocks/components/Section/SectionWashHighlight.doc.mjs
+++ b/packages/cli/templates/blocks/components/Section/SectionWashHighlight.doc.mjs
@@ -4,7 +4,7 @@ export const doc = {
   exampleFor: 'Section',
   name: 'Section — Default with Wash',
   description:
-    'A default section stacked with a full-width wash section. Shows how wash draws attention to a specific region like an upgrade prompt or banner.',
+    'A default section stacked with a full-width muted section. Shows how muted draws attention to a specific region like an upgrade prompt or banner.',
   isReady: true,
   aspectRatio: 4 / 3,
   componentsUsed: ['Section', 'Layout', 'Text', 'Button', 'Icon'],

--- a/packages/cli/templates/blocks/components/Section/SectionWashHighlight.tsx
+++ b/packages/cli/templates/blocks/components/Section/SectionWashHighlight.tsx
@@ -39,7 +39,7 @@ export default function SectionDefaultWithWash() {
           </XDSStack>
         </XDSStack>
       </XDSSection>
-      <XDSSection variant="wash" padding={6}>
+      <XDSSection variant="muted" padding={6}>
         <XDSStack direction="vertical" gap={2} hAlign="center">
           <XDSStack direction="horizontal" gap={2} vAlign="center">
             <XDSText type="display-3">$49</XDSText>

--- a/packages/cli/templates/blocks/components/Toolbar/ToolbarBulkActions.doc.mjs
+++ b/packages/cli/templates/blocks/components/Toolbar/ToolbarBulkActions.doc.mjs
@@ -4,7 +4,7 @@ export const doc = {
   exampleFor: 'Toolbar',
   name: 'Toolbar — Bulk Actions',
   description:
-    'A compact toolbar with the wash variant for showing bulk selection actions. Use when the user selects multiple items in a list or table and needs quick access to batch operations.',
+    'A compact toolbar with the muted variant for showing bulk selection actions. Use when the user selects multiple items in a list or table and needs quick access to batch operations.',
   isReady: true,
   aspectRatio: 16 / 9,
   componentsUsed: ['Toolbar', 'Button', 'Icon', 'Badge', 'Table'],

--- a/packages/cli/templates/blocks/components/Toolbar/ToolbarBulkActions.tsx
+++ b/packages/cli/templates/blocks/components/Toolbar/ToolbarBulkActions.tsx
@@ -38,7 +38,7 @@ export default function ToolbarBulkActions() {
         <XDSToolbar
           label="Bulk actions"
           size="sm"
-          variant="wash"
+          variant="muted"
           dividers={['bottom']}
           startContent={
             <>

--- a/packages/cli/templates/pages/documentation-design/page.tsx
+++ b/packages/cli/templates/pages/documentation-design/page.tsx
@@ -73,98 +73,368 @@ const COMPONENT_CATEGORIES = [
   {
     label: 'Core',
     items: [
-      {key: 'appshell', name: 'AppShell', desc: 'AppShell provides a foundational page layout with header, sidebar, and content regions. Use it to establish consistent structure across your application.'},
-      {key: 'avatar', name: 'Avatar', desc: 'Avatars represent a person or entity with an image, initials, or icon. They are commonly used in user profiles, comments, and contact lists.'},
-      {key: 'badge', name: 'Badge', desc: 'Badges display small counts or status labels. They can be attached to icons, buttons, or list items to surface key information at a glance.'},
-      {key: 'banner', name: 'Banner', desc: 'Banners show important, non-modal messages at the top of a page or section. They communicate status, warnings, or promotional information.'},
-      {key: 'button', name: 'Button', desc: 'Buttons let people take action. They can be used in forms, dialogs, and toolbars, or as standalone links.'},
-      {key: 'calendar', name: 'Calendar', desc: 'Calendar provides a date-picking grid for selecting single dates or date ranges. It integrates with form fields for date input.'},
-      {key: 'dialog', name: 'Dialog', desc: 'Dialogs are modal overlays that require user attention or action before continuing. They are used for confirmations, forms, and critical decisions.'},
-      {key: 'dropdownmenu', name: 'DropdownMenu', desc: 'DropdownMenu presents a list of actions or options in a floating overlay. It is triggered by a button and supports nested submenus.'},
-      {key: 'emptystate', name: 'EmptyState', desc: 'EmptyState provides a placeholder when there is no content to display. It guides users with a message, illustration, and optional call-to-action.'},
-      {key: 'hovercard', name: 'HoverCard', desc: 'HoverCard shows a rich preview of content when users hover over a trigger element. It is ideal for previewing profiles, links, or details.'},
-      {key: 'icon', name: 'Icon', desc: 'Icons are small visual symbols that represent actions, objects, or concepts. They improve scannability and reinforce meaning alongside text.'},
-      {key: 'kbd', name: 'Kbd', desc: 'Kbd renders keyboard shortcut hints in a styled inline element. Use it to show users which key combinations perform specific actions.'},
-      {key: 'link', name: 'Link', desc: 'Links provide navigation between pages or to external resources. They follow accessible anchor semantics with visual affordance.'},
-      {key: 'list', name: 'List', desc: 'List displays a vertical set of related items. It supports selection, icons, and metadata for building menus, nav lists, and more.'},
-      {key: 'metadatalist', name: 'MetadataList', desc: 'MetadataList displays key-value pairs in a structured layout. Use it for detail panels, settings summaries, and record information.'},
-      {key: 'moremenu', name: 'MoreMenu', desc: 'MoreMenu provides an overflow menu triggered by an icon button. It collects secondary actions that do not fit in the primary toolbar.'},
-      {key: 'overflowlist', name: 'OverflowList', desc: 'OverflowList renders as many items as fit in the available space and collapses the rest into an overflow menu automatically.'},
-      {key: 'pagination', name: 'Pagination', desc: 'Pagination lets users navigate through pages of content. It supports page numbers, previous/next controls, and page-size selection.'},
-      {key: 'popover', name: 'Popover', desc: 'Popover displays rich content in a floating panel anchored to a trigger element. It is used for forms, filters, and contextual tools.'},
-      {key: 'progressbar', name: 'ProgressBar', desc: 'ProgressBar shows the completion status of a task or process. It provides visual feedback for uploads, installations, and multi-step flows.'},
-      {key: 'skeleton', name: 'Skeleton', desc: 'Skeleton renders placeholder shapes that mimic content layout while loading. It reduces perceived wait time and prevents layout shifts.'},
-      {key: 'spinner', name: 'Spinner', desc: 'Spinner indicates that a process is in progress when the duration is unknown. It draws attention without blocking the interface.'},
-      {key: 'statusdot', name: 'StatusDot', desc: 'StatusDot shows a small colored indicator for online, offline, busy, or custom statuses. It is often paired with avatars or list items.'},
-      {key: 'table', name: 'Table', desc: 'Table displays structured data in rows and columns with support for sorting, selection, and custom cell rendering.'},
-      {key: 'thumbnail', name: 'Thumbnail', desc: 'Thumbnail renders a small image preview with consistent sizing and optional rounded corners. It is used in media lists, cards, and galleries.'},
-      {key: 'timestamp', name: 'Timestamp', desc: 'Timestamp formats and displays dates and times with relative or absolute labels. It updates automatically to stay current.'},
-      {key: 'toast', name: 'Toast', desc: 'Toasts display brief, non-blocking notifications at the edge of the screen. They auto-dismiss and are used for success, error, or info messages.'},
-      {key: 'togglebutton', name: 'ToggleButton', desc: 'ToggleButton is a button that switches between an on and off state. Use it for binary options like bookmarking, favoriting, or muting.'},
-      {key: 'token', name: 'Token', desc: 'Tokens display compact metadata labels such as tags, categories, or filters. They can be dismissible and support selection state.'},
-      {key: 'tooltip', name: 'Tooltip', desc: 'Tooltips show concise helper text when users hover over or focus an element. They clarify icons, truncated labels, and controls.'},
-      {key: 'treelist', name: 'TreeList', desc: 'TreeList renders hierarchical data in an expandable tree structure. It supports multi-level nesting, selection, and lazy loading.'},
+      {
+        key: 'appshell',
+        name: 'AppShell',
+        desc: 'AppShell provides a foundational page layout with header, sidebar, and content regions. Use it to establish consistent structure across your application.',
+      },
+      {
+        key: 'avatar',
+        name: 'Avatar',
+        desc: 'Avatars represent a person or entity with an image, initials, or icon. They are commonly used in user profiles, comments, and contact lists.',
+      },
+      {
+        key: 'badge',
+        name: 'Badge',
+        desc: 'Badges display small counts or status labels. They can be attached to icons, buttons, or list items to surface key information at a glance.',
+      },
+      {
+        key: 'banner',
+        name: 'Banner',
+        desc: 'Banners show important, non-modal messages at the top of a page or section. They communicate status, warnings, or promotional information.',
+      },
+      {
+        key: 'button',
+        name: 'Button',
+        desc: 'Buttons let people take action. They can be used in forms, dialogs, and toolbars, or as standalone links.',
+      },
+      {
+        key: 'calendar',
+        name: 'Calendar',
+        desc: 'Calendar provides a date-picking grid for selecting single dates or date ranges. It integrates with form fields for date input.',
+      },
+      {
+        key: 'dialog',
+        name: 'Dialog',
+        desc: 'Dialogs are modal overlays that require user attention or action before continuing. They are used for confirmations, forms, and critical decisions.',
+      },
+      {
+        key: 'dropdownmenu',
+        name: 'DropdownMenu',
+        desc: 'DropdownMenu presents a list of actions or options in a floating overlay. It is triggered by a button and supports nested submenus.',
+      },
+      {
+        key: 'emptystate',
+        name: 'EmptyState',
+        desc: 'EmptyState provides a placeholder when there is no content to display. It guides users with a message, illustration, and optional call-to-action.',
+      },
+      {
+        key: 'hovercard',
+        name: 'HoverCard',
+        desc: 'HoverCard shows a rich preview of content when users hover over a trigger element. It is ideal for previewing profiles, links, or details.',
+      },
+      {
+        key: 'icon',
+        name: 'Icon',
+        desc: 'Icons are small visual symbols that represent actions, objects, or concepts. They improve scannability and reinforce meaning alongside text.',
+      },
+      {
+        key: 'kbd',
+        name: 'Kbd',
+        desc: 'Kbd renders keyboard shortcut hints in a styled inline element. Use it to show users which key combinations perform specific actions.',
+      },
+      {
+        key: 'link',
+        name: 'Link',
+        desc: 'Links provide navigation between pages or to external resources. They follow accessible anchor semantics with visual affordance.',
+      },
+      {
+        key: 'list',
+        name: 'List',
+        desc: 'List displays a vertical set of related items. It supports selection, icons, and metadata for building menus, nav lists, and more.',
+      },
+      {
+        key: 'metadatalist',
+        name: 'MetadataList',
+        desc: 'MetadataList displays key-value pairs in a structured layout. Use it for detail panels, settings summaries, and record information.',
+      },
+      {
+        key: 'moremenu',
+        name: 'MoreMenu',
+        desc: 'MoreMenu provides an overflow menu triggered by an icon button. It collects secondary actions that do not fit in the primary toolbar.',
+      },
+      {
+        key: 'overflowlist',
+        name: 'OverflowList',
+        desc: 'OverflowList renders as many items as fit in the available space and collapses the rest into an overflow menu automatically.',
+      },
+      {
+        key: 'pagination',
+        name: 'Pagination',
+        desc: 'Pagination lets users navigate through pages of content. It supports page numbers, previous/next controls, and page-size selection.',
+      },
+      {
+        key: 'popover',
+        name: 'Popover',
+        desc: 'Popover displays rich content in a floating panel anchored to a trigger element. It is used for forms, filters, and contextual tools.',
+      },
+      {
+        key: 'progressbar',
+        name: 'ProgressBar',
+        desc: 'ProgressBar shows the completion status of a task or process. It provides visual feedback for uploads, installations, and multi-step flows.',
+      },
+      {
+        key: 'skeleton',
+        name: 'Skeleton',
+        desc: 'Skeleton renders placeholder shapes that mimic content layout while loading. It reduces perceived wait time and prevents layout shifts.',
+      },
+      {
+        key: 'spinner',
+        name: 'Spinner',
+        desc: 'Spinner indicates that a process is in progress when the duration is unknown. It draws attention without blocking the interface.',
+      },
+      {
+        key: 'statusdot',
+        name: 'StatusDot',
+        desc: 'StatusDot shows a small colored indicator for online, offline, busy, or custom statuses. It is often paired with avatars or list items.',
+      },
+      {
+        key: 'table',
+        name: 'Table',
+        desc: 'Table displays structured data in rows and columns with support for sorting, selection, and custom cell rendering.',
+      },
+      {
+        key: 'thumbnail',
+        name: 'Thumbnail',
+        desc: 'Thumbnail renders a small image preview with consistent sizing and optional rounded corners. It is used in media lists, cards, and galleries.',
+      },
+      {
+        key: 'timestamp',
+        name: 'Timestamp',
+        desc: 'Timestamp formats and displays dates and times with relative or absolute labels. It updates automatically to stay current.',
+      },
+      {
+        key: 'toast',
+        name: 'Toast',
+        desc: 'Toasts display brief, non-blocking notifications at the edge of the screen. They auto-dismiss and are used for success, error, or info messages.',
+      },
+      {
+        key: 'togglebutton',
+        name: 'ToggleButton',
+        desc: 'ToggleButton is a button that switches between an on and off state. Use it for binary options like bookmarking, favoriting, or muting.',
+      },
+      {
+        key: 'token',
+        name: 'Token',
+        desc: 'Tokens display compact metadata labels such as tags, categories, or filters. They can be dismissible and support selection state.',
+      },
+      {
+        key: 'tooltip',
+        name: 'Tooltip',
+        desc: 'Tooltips show concise helper text when users hover over or focus an element. They clarify icons, truncated labels, and controls.',
+      },
+      {
+        key: 'treelist',
+        name: 'TreeList',
+        desc: 'TreeList renders hierarchical data in an expandable tree structure. It supports multi-level nesting, selection, and lazy loading.',
+      },
     ],
   },
-  {label: 'Typography', items: [
-    {key: 'heading', name: 'Heading', desc: 'Heading renders semantic section titles from h1 through h6. It establishes visual hierarchy and supports multiple weight and size options.'},
-    {key: 'text', name: 'Text', desc: 'Text renders body copy, labels, and supporting content with consistent typography. It supports sizes from display down to caption.'},
-  ]},
-  {label: 'Layout', items: [
-    {key: 'aspectratio', name: 'AspectRatio', desc: 'AspectRatio constrains its child to a specified width-to-height ratio. Use it for responsive images, videos, and embedded media.'},
-    {key: 'card', name: 'Card', desc: 'Cards group related content and actions in a contained surface. They can include headers, media, body text, and action bars.'},
-    {key: 'center', name: 'Center', desc: 'Center aligns its child horizontally and vertically within the available space. It is useful for empty states, loading screens, and hero sections.'},
-    {key: 'divider', name: 'Divider', desc: 'Dividers separate content into distinct sections with a subtle or strong horizontal line. They can optionally include a label.'},
-    {key: 'grid', name: 'Grid', desc: 'Grid provides a CSS grid-based layout container with configurable columns, rows, and gap. It simplifies responsive multi-column designs.'},
-    {key: 'layout', name: 'Layout', desc: 'Layout provides foundational page-level primitives for header, sidebar, and content regions. It establishes consistent spacing and structure.'},
-    {key: 'section', name: 'Section', desc: 'Section wraps a block of content with consistent vertical spacing and an optional heading. It structures pages into logical groups.'},
-    {key: 'stack', name: 'Stack', desc: 'Stack arranges child elements in a row or column with consistent gap spacing. It is the primary tool for one-dimensional layout composition.'},
-    {key: 'toolbar', name: 'Toolbar', desc: 'Toolbar arranges a row of action buttons and controls in a compact, aligned strip. It is used at the top of panels, editors, and cards.'},
-  ]},
-  {label: 'Navigation', items: [
-    {key: 'breadcrumbs', name: 'Breadcrumbs', desc: "Breadcrumbs show the user's current location within a navigation hierarchy. They provide quick links back to parent pages."},
-    {key: 'mobilenav', name: 'MobileNav', desc: 'MobileNav provides a responsive navigation menu optimized for small screens. It typically slides in from the edge of the viewport.'},
-    {key: 'sidenav', name: 'SideNav', desc: 'SideNav renders a vertical navigation panel with links, sections, and collapsible groups. It is used as the primary nav in dashboard layouts.'},
-    {key: 'tablist', name: 'TabList', desc: 'TabList switches between content views using a horizontal row of tabs. Only one tab is active at a time, and content changes without a page reload.'},
-    {key: 'topnav', name: 'TopNav', desc: 'TopNav provides an app-level navigation bar across the top of the page. It holds branding, primary links, search, and user actions.'},
-  ]},
-  {label: 'Form', items: [
-    {key: 'checkboxinput', name: 'CheckboxInput', desc: 'CheckboxInput renders a single checkbox with a label. It is used for boolean opt-in choices like terms acceptance or feature toggles.'},
-    {key: 'selector', name: 'Selector', desc: 'Selector lets users pick a single item from a dropdown list. It supports search, grouping, and custom option rendering.'},
-    {key: 'switch', name: 'Switch', desc: 'Switch toggles a setting between on and off states with immediate effect. It is used for preferences, feature flags, and real-time controls.'},
-    {key: 'textinput', name: 'TextInput', desc: 'TextInput is a single-line text field for short user input like names, emails, and search queries. It supports icons, prefixes, and validation.'},
-    {key: 'typeahead', name: 'Typeahead', desc: 'Typeahead provides an autocomplete search input that suggests results as the user types. It supports async data sources and custom rendering.'},
-  ]},
-  {label: 'Components', items: [
-    {key: 'codeblock', name: 'CodeBlock', desc: 'CodeBlock displays formatted, syntax-highlighted source code. It supports line numbers, copy-to-clipboard, and language detection.'},
-    {key: 'collapsible', name: 'Collapsible', desc: 'Collapsible wraps content that can be expanded or collapsed with a trigger. It is used for FAQs, advanced settings, and progressive disclosure.'},
-    {key: 'markdown', name: 'Markdown', desc: 'Markdown renders markdown-formatted text into styled HTML. It supports headings, lists, links, code blocks, and inline formatting.'},
-  ]},
-  {label: 'Chat', items: [
-    {key: 'chat', name: 'Chat', desc: 'Chat provides a conversational message interface with message bubbles, input, and thread support. It is used for AI assistants and messaging UIs.'},
-  ]},
-  {label: 'CommandPalette', items: [
-    {key: 'commandpalette', name: 'CommandPalette', desc: 'CommandPalette is a keyboard-driven command menu for quick navigation and actions. It is opened with a hotkey and supports fuzzy search.'},
-  ]},
+  {
+    label: 'Typography',
+    items: [
+      {
+        key: 'heading',
+        name: 'Heading',
+        desc: 'Heading renders semantic section titles from h1 through h6. It establishes visual hierarchy and supports multiple weight and size options.',
+      },
+      {
+        key: 'text',
+        name: 'Text',
+        desc: 'Text renders body copy, labels, and supporting content with consistent typography. It supports sizes from display down to caption.',
+      },
+    ],
+  },
+  {
+    label: 'Layout',
+    items: [
+      {
+        key: 'aspectratio',
+        name: 'AspectRatio',
+        desc: 'AspectRatio constrains its child to a specified width-to-height ratio. Use it for responsive images, videos, and embedded media.',
+      },
+      {
+        key: 'card',
+        name: 'Card',
+        desc: 'Cards group related content and actions in a contained surface. They can include headers, media, body text, and action bars.',
+      },
+      {
+        key: 'center',
+        name: 'Center',
+        desc: 'Center aligns its child horizontally and vertically within the available space. It is useful for empty states, loading screens, and hero sections.',
+      },
+      {
+        key: 'divider',
+        name: 'Divider',
+        desc: 'Dividers separate content into distinct sections with a subtle or strong horizontal line. They can optionally include a label.',
+      },
+      {
+        key: 'grid',
+        name: 'Grid',
+        desc: 'Grid provides a CSS grid-based layout container with configurable columns, rows, and gap. It simplifies responsive multi-column designs.',
+      },
+      {
+        key: 'layout',
+        name: 'Layout',
+        desc: 'Layout provides foundational page-level primitives for header, sidebar, and content regions. It establishes consistent spacing and structure.',
+      },
+      {
+        key: 'section',
+        name: 'Section',
+        desc: 'Section wraps a block of content with consistent vertical spacing and an optional heading. It structures pages into logical groups.',
+      },
+      {
+        key: 'stack',
+        name: 'Stack',
+        desc: 'Stack arranges child elements in a row or column with consistent gap spacing. It is the primary tool for one-dimensional layout composition.',
+      },
+      {
+        key: 'toolbar',
+        name: 'Toolbar',
+        desc: 'Toolbar arranges a row of action buttons and controls in a compact, aligned strip. It is used at the top of panels, editors, and cards.',
+      },
+    ],
+  },
+  {
+    label: 'Navigation',
+    items: [
+      {
+        key: 'breadcrumbs',
+        name: 'Breadcrumbs',
+        desc: "Breadcrumbs show the user's current location within a navigation hierarchy. They provide quick links back to parent pages.",
+      },
+      {
+        key: 'mobilenav',
+        name: 'MobileNav',
+        desc: 'MobileNav provides a responsive navigation menu optimized for small screens. It typically slides in from the edge of the viewport.',
+      },
+      {
+        key: 'sidenav',
+        name: 'SideNav',
+        desc: 'SideNav renders a vertical navigation panel with links, sections, and collapsible groups. It is used as the primary nav in dashboard layouts.',
+      },
+      {
+        key: 'tablist',
+        name: 'TabList',
+        desc: 'TabList switches between content views using a horizontal row of tabs. Only one tab is active at a time, and content changes without a page reload.',
+      },
+      {
+        key: 'topnav',
+        name: 'TopNav',
+        desc: 'TopNav provides an app-level navigation bar across the top of the page. It holds branding, primary links, search, and user actions.',
+      },
+    ],
+  },
+  {
+    label: 'Form',
+    items: [
+      {
+        key: 'checkboxinput',
+        name: 'CheckboxInput',
+        desc: 'CheckboxInput renders a single checkbox with a label. It is used for boolean opt-in choices like terms acceptance or feature toggles.',
+      },
+      {
+        key: 'selector',
+        name: 'Selector',
+        desc: 'Selector lets users pick a single item from a dropdown list. It supports search, grouping, and custom option rendering.',
+      },
+      {
+        key: 'switch',
+        name: 'Switch',
+        desc: 'Switch toggles a setting between on and off states with immediate effect. It is used for preferences, feature flags, and real-time controls.',
+      },
+      {
+        key: 'textinput',
+        name: 'TextInput',
+        desc: 'TextInput is a single-line text field for short user input like names, emails, and search queries. It supports icons, prefixes, and validation.',
+      },
+      {
+        key: 'typeahead',
+        name: 'Typeahead',
+        desc: 'Typeahead provides an autocomplete search input that suggests results as the user types. It supports async data sources and custom rendering.',
+      },
+    ],
+  },
+  {
+    label: 'Components',
+    items: [
+      {
+        key: 'codeblock',
+        name: 'CodeBlock',
+        desc: 'CodeBlock displays formatted, syntax-highlighted source code. It supports line numbers, copy-to-clipboard, and language detection.',
+      },
+      {
+        key: 'collapsible',
+        name: 'Collapsible',
+        desc: 'Collapsible wraps content that can be expanded or collapsed with a trigger. It is used for FAQs, advanced settings, and progressive disclosure.',
+      },
+      {
+        key: 'markdown',
+        name: 'Markdown',
+        desc: 'Markdown renders markdown-formatted text into styled HTML. It supports headings, lists, links, code blocks, and inline formatting.',
+      },
+    ],
+  },
+  {
+    label: 'Chat',
+    items: [
+      {
+        key: 'chat',
+        name: 'Chat',
+        desc: 'Chat provides a conversational message interface with message bubbles, input, and thread support. It is used for AI assistants and messaging UIs.',
+      },
+    ],
+  },
+  {
+    label: 'CommandPalette',
+    items: [
+      {
+        key: 'commandpalette',
+        name: 'CommandPalette',
+        desc: 'CommandPalette is a keyboard-driven command menu for quick navigation and actions. It is opened with a hotkey and supports fuzzy search.',
+      },
+    ],
+  },
 ];
 
-const COMPONENT_DOCS: Record<string, {
-  usage: string;
-  bestPractices: {type: 'do' | 'dont'; text: string}[];
-  examples: {title: string; description: string; code: string}[];
-}> = {
+const COMPONENT_DOCS: Record<
+  string,
+  {
+    usage: string;
+    bestPractices: {type: 'do' | 'dont'; text: string}[];
+    examples: {title: string; description: string; code: string}[];
+  }
+> = {
   button: {
-    usage: 'Buttons provide visual cues for actions and events. These fundamental components allow users to commit actions and navigate a page flow. Use a Button when a user needs to submit a form, start a new task or action, or trigger a new UI element to appear on the page.',
+    usage:
+      'Buttons provide visual cues for actions and events. These fundamental components allow users to commit actions and navigate a page flow. Use a Button when a user needs to submit a form, start a new task or action, or trigger a new UI element to appear on the page.',
     bestPractices: [
-      {type: 'do', text: 'Convey clear action hierarchy: Each surface should only have 1 primary button. A majority of buttons should be in default or flat style.'},
-      {type: 'do', text: 'Promote clarity: Consider labels alongside icons where appropriate.'},
-      {type: 'dont', text: 'Overuse primary or special buttons: Overusing colored buttons will result in a page with less intentionality, create visual confusion and a lack of page hierarchy.'},
+      {
+        type: 'do',
+        text: 'Convey clear action hierarchy: Each surface should only have 1 primary button. A majority of buttons should be in default or flat style.',
+      },
+      {
+        type: 'do',
+        text: 'Promote clarity: Consider labels alongside icons where appropriate.',
+      },
+      {
+        type: 'dont',
+        text: 'Overuse primary or special buttons: Overusing colored buttons will result in a page with less intentionality, create visual confusion and a lack of page hierarchy.',
+      },
     ],
     examples: [
-      {title: 'Semantics', description: 'We have four semantic buttons types: flat, default, primary, and destructive. Flat buttons are used to limit visual prominence, whereas primary emphasizes a single action. Use destructive for deletions that trigger dialog confirmations.',
-        code: `<XDSButton label="Flat" variant="ghost" />\n<XDSButton label="Default" variant="secondary" />\n<XDSButton label="Primary" variant="primary" />\n<XDSButton label="Destructive" variant="destructive" />`},
-      {title: 'Default button with badge', description: 'Buttons can include a badge to highlight new or updated actions.',
-        code: `<XDSButton\n  label="Button"\n  variant="default"\n/>`},
+      {
+        title: 'Semantics',
+        description:
+          'We have four semantic buttons types: flat, default, primary, and destructive. Flat buttons are used to limit visual prominence, whereas primary emphasizes a single action. Use destructive for deletions that trigger dialog confirmations.',
+        code: `<XDSButton label="Flat" variant="ghost" />\n<XDSButton label="Default" variant="secondary" />\n<XDSButton label="Primary" variant="primary" />\n<XDSButton label="Destructive" variant="destructive" />`,
+      },
+      {
+        title: 'Default button with badge',
+        description:
+          'Buttons can include a badge to highlight new or updated actions.',
+        code: `<XDSButton\n  label="Button"\n  variant="default"\n/>`,
+      },
     ],
   },
 };
@@ -183,16 +453,34 @@ function getComponentDocs(key: string) {
   let desc = '';
   for (const cat of COMPONENT_CATEGORIES) {
     const item = cat.items.find(i => i.key === key);
-    if (item) { desc = item.desc; break; }
+    if (item) {
+      desc = item.desc;
+      break;
+    }
   }
   return {
     usage: desc,
     bestPractices: [
-      {type: 'do' as const, text: `Use ${name} in the appropriate context to provide the functionality described above.`},
-      {type: 'do' as const, text: `Pair ${name} with related components to create cohesive, accessible interfaces.`},
-      {type: 'dont' as const, text: `Use ${name} when a simpler alternative achieves the same goal with less complexity.`},
+      {
+        type: 'do' as const,
+        text: `Use ${name} in the appropriate context to provide the functionality described above.`,
+      },
+      {
+        type: 'do' as const,
+        text: `Pair ${name} with related components to create cohesive, accessible interfaces.`,
+      },
+      {
+        type: 'dont' as const,
+        text: `Use ${name} when a simpler alternative achieves the same goal with less complexity.`,
+      },
     ],
-    examples: [{title: `Basic ${name}`, description: `A simple example of the ${name} component with default settings.`, code: `<XDS${name} />`}],
+    examples: [
+      {
+        title: `Basic ${name}`,
+        description: `A simple example of the ${name} component with default settings.`,
+        code: `<XDS${name} />`,
+      },
+    ],
   };
 }
 
@@ -217,107 +505,181 @@ function ComponentDetailView({activeNav}: {activeNav: string}) {
 
   const COMPONENT_PREVIEWS: Record<string, React.ReactNode> = {
     button: (
-      <XDSButton label="Button" variant="secondary" icon={<XDSIcon icon={PlusIcon} />} endContent={<XDSBadge label="New" variant="info" />} />
+      <XDSButton
+        label="Button"
+        variant="secondary"
+        icon={<XDSIcon icon={PlusIcon} />}
+        endContent={<XDSBadge label="New" variant="info" />}
+      />
     ),
     avatar: <XDSAvatar name="Alice" size="medium" />,
     badge: <XDSBadge label="Success" variant="success" />,
-    card: (<XDSCard><XDSVStack gap={2}><XDSHeading level={4}>Card Title</XDSHeading><XDSText type="body" color="secondary">Cards group related content and actions.</XDSText></XDSVStack></XDSCard>),
-    banner: (<XDSBanner status="info" title="Information"><XDSText type="body">This is an informational banner message.</XDSText></XDSBanner>),
+    card: (
+      <XDSCard>
+        <XDSVStack gap={2}>
+          <XDSHeading level={4}>Card Title</XDSHeading>
+          <XDSText type="body" color="secondary">
+            Cards group related content and actions.
+          </XDSText>
+        </XDSVStack>
+      </XDSCard>
+    ),
+    banner: (
+      <XDSBanner status="info" title="Information">
+        <XDSText type="body">This is an informational banner message.</XDSText>
+      </XDSBanner>
+    ),
     dialog: <DialogPreview />,
     text: <XDSText type="body">Body text</XDSText>,
     divider: <XDSDivider />,
     token: <XDSToken label="Design" />,
-    tooltip: (<XDSTooltip content="Primary action"><XDSButton label="Hover me" variant="primary" /></XDSTooltip>),
+    tooltip: (
+      <XDSTooltip content="Primary action">
+        <XDSButton label="Hover me" variant="primary" />
+      </XDSTooltip>
+    ),
   };
 
   const docs = useMemo(() => getComponentDocs(activeNav), [activeNav]);
   const previews = EXAMPLE_PREVIEWS[activeNav] ?? [];
 
   return (
-    <XDSLayout contentWidth={960} content={
-      <XDSLayoutContent padding={8}>
-        <XDSVStack gap={8}>
-          <XDSVStack gap={2}>
-            <XDSText type="display-1">{getComponentName(activeNav)}</XDSText>
-            <XDSText type="supporting" color="secondary">March 30, 2026 · Updated 5:40 p.m. PST</XDSText>
-          </XDSVStack>
-
-          <XDSDivider />
-
-          <XDSCard variant="muted" padding={0}>
-            <XDSCenter height={360}>
-              {COMPONENT_PREVIEWS[activeNav] ?? (<XDSText type="supporting" color="secondary">Preview coming soon</XDSText>)}
-            </XDSCenter>
-          </XDSCard>
-
-          <XDSVStack gap={4}>
-            <XDSHeading level={2}>Usage</XDSHeading>
-            <XDSText type="large" weight="normal">{docs.usage}</XDSText>
-            <XDSHeading level={3}>Best practices</XDSHeading>
-            <XDSTable
-              data={docs.bestPractices as Record<string, unknown>[]}
-              columns={[
-                {key: 'type', header: 'Guidance', width: pixel(125), renderCell: (item: Record<string, unknown>) => (
-                  <XDSBadge label={item.type === 'do' ? 'Do' : 'Dont'} variant={item.type === 'do' ? 'success' : 'error'} />
-                )},
-                {key: 'text', header: 'Practices', renderCell: (item: Record<string, unknown>) => (
-                  <XDSText type="body" textWrap="wrap">{item.text as string}</XDSText>
-                )},
-              ]}
-              density="spacious"
-              dividers="rows"
-            />
-          </XDSVStack>
-
-          <XDSDivider />
-
-          <XDSVStack gap={4}>
-            <XDSHeading level={2}>Examples</XDSHeading>
-            <XDSText type="large" weight="normal">
-              Explore common configurations, variations, and states for this component.
-            </XDSText>
-          </XDSVStack>
+    <XDSLayout
+      contentWidth={960}
+      content={
+        <XDSLayoutContent padding={8}>
           <XDSVStack gap={8}>
-          {docs.examples.map((example, i) => {
-            const tabKey = `${activeNav}-${i}`;
-            const activeTab = exampleTabs[tabKey] ?? 'description';
-            return (
-              <XDSCard key={i} padding={0}>
-                <XDSSection padding={3} variant="transparent">
-                  <XDSHStack gap={3} vAlign="center">
-                    <XDSStackItem size="fill">
-                      <XDSText type="body" weight="medium">{example.title}</XDSText>
-                    </XDSStackItem>
-                    <XDSHStack gap={1} vAlign="center">
-                      <XDSButton label="Open in Craft" variant="ghost" size="sm" icon={<XDSIcon icon={ArrowTopRightOnSquareIcon} />} />
-                      <XDSButton label="Send to CLI" variant="ghost" size="sm" />
-                      <XDSIconButton label="Fullscreen" variant="ghost" size="sm" icon={<XDSIcon icon={ArrowsPointingOutIcon} />} />
-                    </XDSHStack>
-                  </XDSHStack>
-                </XDSSection>
-                <XDSCenter height={280}>
-                  {previews[i] ?? (<XDSText type="supporting" color="secondary">Preview coming soon</XDSText>)}
-                </XDSCenter>
-                <XDSSection variant="wash" padding={3} dividers={['top']}>
-                  <XDSVStack gap={3}>
-                    <XDSTabList value={activeTab} onChange={value => setExampleTabs(prev => ({...prev, [tabKey]: value}))} size="sm" xstyle={styles.tabListFlush}>
-                      <XDSTab value="description" label="Description" />
-                      <XDSTab value="code" label="Code" />
-                    </XDSTabList>
-                    {activeTab === 'description' ? (
-                      <XDSText type="body">{example.description}</XDSText>
-                    ) : (
-                      <XDSCodeBlock code={example.code} language="tsx" />
-                    )}
-                  </XDSVStack>
-                </XDSSection>
-              </XDSCard>
-            );
-          })}
+            <XDSVStack gap={2}>
+              <XDSText type="display-1">{getComponentName(activeNav)}</XDSText>
+              <XDSText type="supporting" color="secondary">
+                March 30, 2026 · Updated 5:40 p.m. PST
+              </XDSText>
+            </XDSVStack>
+
+            <XDSDivider />
+
+            <XDSCard variant="muted" padding={0}>
+              <XDSCenter height={360}>
+                {COMPONENT_PREVIEWS[activeNav] ?? (
+                  <XDSText type="supporting" color="secondary">
+                    Preview coming soon
+                  </XDSText>
+                )}
+              </XDSCenter>
+            </XDSCard>
+
+            <XDSVStack gap={4}>
+              <XDSHeading level={2}>Usage</XDSHeading>
+              <XDSText type="large" weight="normal">
+                {docs.usage}
+              </XDSText>
+              <XDSHeading level={3}>Best practices</XDSHeading>
+              <XDSTable
+                data={docs.bestPractices as Record<string, unknown>[]}
+                columns={[
+                  {
+                    key: 'type',
+                    header: 'Guidance',
+                    width: pixel(125),
+                    renderCell: (item: Record<string, unknown>) => (
+                      <XDSBadge
+                        label={item.type === 'do' ? 'Do' : 'Dont'}
+                        variant={item.type === 'do' ? 'success' : 'error'}
+                      />
+                    ),
+                  },
+                  {
+                    key: 'text',
+                    header: 'Practices',
+                    renderCell: (item: Record<string, unknown>) => (
+                      <XDSText type="body" textWrap="wrap">
+                        {item.text as string}
+                      </XDSText>
+                    ),
+                  },
+                ]}
+                density="spacious"
+                dividers="rows"
+              />
+            </XDSVStack>
+
+            <XDSDivider />
+
+            <XDSVStack gap={4}>
+              <XDSHeading level={2}>Examples</XDSHeading>
+              <XDSText type="large" weight="normal">
+                Explore common configurations, variations, and states for this
+                component.
+              </XDSText>
+            </XDSVStack>
+            <XDSVStack gap={8}>
+              {docs.examples.map((example, i) => {
+                const tabKey = `${activeNav}-${i}`;
+                const activeTab = exampleTabs[tabKey] ?? 'description';
+                return (
+                  <XDSCard key={i} padding={0}>
+                    <XDSSection padding={3} variant="transparent">
+                      <XDSHStack gap={3} vAlign="center">
+                        <XDSStackItem size="fill">
+                          <XDSText type="body" weight="medium">
+                            {example.title}
+                          </XDSText>
+                        </XDSStackItem>
+                        <XDSHStack gap={1} vAlign="center">
+                          <XDSButton
+                            label="Open in Craft"
+                            variant="ghost"
+                            size="sm"
+                            icon={<XDSIcon icon={ArrowTopRightOnSquareIcon} />}
+                          />
+                          <XDSButton
+                            label="Send to CLI"
+                            variant="ghost"
+                            size="sm"
+                          />
+                          <XDSIconButton
+                            label="Fullscreen"
+                            variant="ghost"
+                            size="sm"
+                            icon={<XDSIcon icon={ArrowsPointingOutIcon} />}
+                          />
+                        </XDSHStack>
+                      </XDSHStack>
+                    </XDSSection>
+                    <XDSCenter height={280}>
+                      {previews[i] ?? (
+                        <XDSText type="supporting" color="secondary">
+                          Preview coming soon
+                        </XDSText>
+                      )}
+                    </XDSCenter>
+                    <XDSSection variant="muted" padding={3} dividers={['top']}>
+                      <XDSVStack gap={3}>
+                        <XDSTabList
+                          value={activeTab}
+                          onChange={value =>
+                            setExampleTabs(prev => ({...prev, [tabKey]: value}))
+                          }
+                          size="sm"
+                          xstyle={styles.tabListFlush}>
+                          <XDSTab value="description" label="Description" />
+                          <XDSTab value="code" label="Code" />
+                        </XDSTabList>
+                        {activeTab === 'description' ? (
+                          <XDSText type="body">{example.description}</XDSText>
+                        ) : (
+                          <XDSCodeBlock code={example.code} language="tsx" />
+                        )}
+                      </XDSVStack>
+                    </XDSSection>
+                  </XDSCard>
+                );
+              })}
+            </XDSVStack>
           </XDSVStack>
-        </XDSVStack>
-      </XDSLayoutContent>
-    } />
+        </XDSLayoutContent>
+      }
+    />
   );
 }
 
@@ -333,8 +695,7 @@ export default function DesignDocumentationPage() {
       variant="section"
       height="fill"
       sideNav={
-        <XDSSideNav
-          header={<XDSSideNavHeading heading="Product Name" />}>
+        <XDSSideNav header={<XDSSideNavHeading heading="Product Name" />}>
           {COMPONENT_CATEGORIES.map(category => (
             <XDSSideNavSection key={category.label} title={category.label}>
               {category.items.map(item => (

--- a/packages/cli/templates/pages/login-sso/page.tsx
+++ b/packages/cli/templates/pages/login-sso/page.tsx
@@ -21,8 +21,7 @@ import {shadowVars} from '@xds/core/theme/tokens.stylex';
 // ---------------------------------------------------------------------------
 
 // building from xds_oss asset set
-const BG_URL =
-  'https://lookaside.facebook.com/assets/xds_oss/building.jpg';
+const BG_URL = 'https://lookaside.facebook.com/assets/xds_oss/building.jpg';
 
 const styles = stylex.create({
   page: {
@@ -108,187 +107,187 @@ export default function LoginSSO() {
   return (
     <XDSCenter axis="both" xstyle={styles.page}>
       <XDSCard padding={8} width={400} xstyle={styles.card}>
-                  <XDSVStack gap={4}>
-                {/* ── Step 1: Email entry ── */}
-                {step === 'email' && (
-                  <>
-                    <XDSVStack gap={1} hAlign="center">
-                      <XDSText type="display-1" as="h2">Welcome back</XDSText>
-                      <XDSText type="body" color="secondary" size="sm">
-                        Enter your details to sign in to your account
-                      </XDSText>
-                    </XDSVStack>
+        <XDSVStack gap={4}>
+          {/* ── Step 1: Email entry ── */}
+          {step === 'email' && (
+            <>
+              <XDSVStack gap={1} hAlign="center">
+                <XDSText type="display-1" as="h2">
+                  Welcome back
+                </XDSText>
+                <XDSText type="body" color="secondary" size="sm">
+                  Enter your details to sign in to your account
+                </XDSText>
+              </XDSVStack>
 
-                    <XDSVStack gap={2}>
-                      <XDSTextInput
-                        label="Work email"
-                        isLabelHidden
-                        type="email"
-                        placeholder="you@company.com"
-                        value={email}
-                        onChange={setEmail}
-                        size="lg"
-                        onKeyDown={(e: React.KeyboardEvent) => {
-                          if (e.key === 'Enter') handleContinue();
-                        }}
-                      />
-                      <XDSTextInput
-                        label="Password"
-                        isLabelHidden
-                        type="password"
-                        placeholder="Password"
-                        value={password}
-                        onChange={setPassword}
-                        size="lg"
-                      />
-                    </XDSVStack>
+              <XDSVStack gap={2}>
+                <XDSTextInput
+                  label="Work email"
+                  isLabelHidden
+                  type="email"
+                  placeholder="you@company.com"
+                  value={email}
+                  onChange={setEmail}
+                  size="lg"
+                  onKeyDown={(e: React.KeyboardEvent) => {
+                    if (e.key === 'Enter') handleContinue();
+                  }}
+                />
+                <XDSTextInput
+                  label="Password"
+                  isLabelHidden
+                  type="password"
+                  placeholder="Password"
+                  value={password}
+                  onChange={setPassword}
+                  size="lg"
+                />
+              </XDSVStack>
 
-                    <XDSLink
-                      href="#"
-                      size="sm"
-                      color="secondary"
-                      type="supporting">
-                      Having trouble signing in?
-                    </XDSLink>
+              <XDSLink href="#" size="sm" color="secondary" type="supporting">
+                Having trouble signing in?
+              </XDSLink>
 
-                    <XDSButton
-                      label="Sign in"
-                      variant="primary"
-                      size="lg"
-                      xstyle={styles.fullWidth}
-                      onClick={handleContinue}
-                      isDisabled={!emailValid}
-                    />
+              <XDSButton
+                label="Sign in"
+                variant="primary"
+                size="lg"
+                xstyle={styles.fullWidth}
+                onClick={handleContinue}
+                isDisabled={!emailValid}
+              />
 
-                    <XDSDivider label="Or sign in with" />
+              <XDSDivider label="Or sign in with" />
 
-                    <XDSButton
-                      label="Continue with SSO"
-                      variant="secondary"
-                      size="lg"
-                      xstyle={styles.fullWidth}
-                    />
+              <XDSButton
+                label="Continue with SSO"
+                variant="secondary"
+                size="lg"
+                xstyle={styles.fullWidth}
+              />
 
-                    <XDSVStack hAlign="center">
+              <XDSVStack hAlign="center">
+                <XDSText type="supporting" color="secondary">
+                  Don&apos;t have an account?{' '}
+                  <XDSLink href="#" type="supporting">
+                    Request access
+                  </XDSLink>
+                </XDSText>
+              </XDSVStack>
+            </>
+          )}
+
+          {/* ── Step 2a: SSO provider detected ── */}
+          {step === 'sso-confirm' && provider && (
+            <>
+              <XDSVStack gap={2} hAlign="center">
+                <XDSAvatar name={provider.name} size={48} />
+                <XDSText type="display-3" as="h2">
+                  Sign in with {provider.name}
+                </XDSText>
+                <XDSText type="body" color="secondary" size="sm">
+                  You will be redirected back after signing in.
+                </XDSText>
+              </XDSVStack>
+
+              <XDSCard padding={0}>
+                <XDSSection variant="muted" padding={4}>
+                  <XDSHStack gap={2} vAlign="center">
+                    <XDSIcon icon={ShieldCheckIcon} color="secondary" />
+                    <XDSVStack gap={0}>
+                      <XDSText type="label">{provider.name}</XDSText>
                       <XDSText type="supporting" color="secondary">
-                        Don&apos;t have an account?{' '}
-                        <XDSLink href="#" type="supporting">
-                          Request access
-                        </XDSLink>
-                      </XDSText>
-                    </XDSVStack>
-                  </>
-                )}
-
-                {/* ── Step 2a: SSO provider detected ── */}
-                {step === 'sso-confirm' && provider && (
-                  <>
-                    <XDSVStack gap={2} hAlign="center">
-                      <XDSAvatar name={provider.name} size={48} />
-                      <XDSText type="display-3" as="h2">
-                        Sign in with {provider.name}
-                      </XDSText>
-                      <XDSText type="body" color="secondary" size="sm">
-                        You will be redirected back after signing in.
-                      </XDSText>
-                    </XDSVStack>
-
-                    <XDSCard padding={0}>
-                      <XDSSection variant="wash" padding={4}>
-                        <XDSHStack gap={2} vAlign="center">
-                          <XDSIcon icon={ShieldCheckIcon} color="secondary" />
-                          <XDSVStack gap={0}>
-                            <XDSText type="label">{provider.name}</XDSText>
-                            <XDSText type="supporting" color="secondary">
-                              {email}
-                            </XDSText>
-                          </XDSVStack>
-                        </XDSHStack>
-                      </XDSSection>
-                    </XDSCard>
-
-                    <XDSVStack gap={3}>
-                      <XDSButton
-                        label={`Continue with ${provider.name}`}
-                        variant="primary"
-                        size="lg"
-                        isLoading={isLoading}
-                        xstyle={styles.fullWidth}
-                        onClick={() => setIsLoading(true)}
-                      />
-                      <XDSButton
-                        label="Use a different email"
-                        variant="ghost"
-                        size="lg"
-                        xstyle={styles.fullWidth}
-                        onClick={handleBack}
-                      />
-                    </XDSVStack>
-                  </>
-                )}
-
-                {/* ── Step 2b: No SSO — password fallback ── */}
-                {step === 'password-fallback' && (
-                  <>
-                    <XDSVStack gap={1} hAlign="center">
-                      <XDSText type="display-1" as="h2">Welcome back</XDSText>
-                      <XDSText type="body" color="secondary" size="sm">
                         {email}
                       </XDSText>
                     </XDSVStack>
+                  </XDSHStack>
+                </XDSSection>
+              </XDSCard>
 
-                    <XDSVStack gap={4}>
-                      <XDSVStack gap={1}>
-                        <XDSTextInput
-                          label="Password"
-                          type="password"
-                          value={password}
-                          size="lg"
-                          onChange={(v: string) => {
-                            setPassword(v);
-                            setLoginFailed(false);
-                          }}
-                          status={
-                            loginFailed
-                              ? {
-                                  type: 'error',
-                                  message: 'Incorrect password. Try again.',
-                                }
-                              : undefined
+              <XDSVStack gap={3}>
+                <XDSButton
+                  label={`Continue with ${provider.name}`}
+                  variant="primary"
+                  size="lg"
+                  isLoading={isLoading}
+                  xstyle={styles.fullWidth}
+                  onClick={() => setIsLoading(true)}
+                />
+                <XDSButton
+                  label="Use a different email"
+                  variant="ghost"
+                  size="lg"
+                  xstyle={styles.fullWidth}
+                  onClick={handleBack}
+                />
+              </XDSVStack>
+            </>
+          )}
+
+          {/* ── Step 2b: No SSO — password fallback ── */}
+          {step === 'password-fallback' && (
+            <>
+              <XDSVStack gap={1} hAlign="center">
+                <XDSText type="display-1" as="h2">
+                  Welcome back
+                </XDSText>
+                <XDSText type="body" color="secondary" size="sm">
+                  {email}
+                </XDSText>
+              </XDSVStack>
+
+              <XDSVStack gap={4}>
+                <XDSVStack gap={1}>
+                  <XDSTextInput
+                    label="Password"
+                    type="password"
+                    value={password}
+                    size="lg"
+                    onChange={(v: string) => {
+                      setPassword(v);
+                      setLoginFailed(false);
+                    }}
+                    status={
+                      loginFailed
+                        ? {
+                            type: 'error',
+                            message: 'Incorrect password. Try again.',
                           }
-                        />
-                        {loginFailed && (
-                          <XDSVStack hAlign="end">
-                            <XDSLink
-                              href="#"
-                              size="sm"
-                              color="secondary"
-                              type="supporting">
-                              Forgot password?
-                            </XDSLink>
-                          </XDSVStack>
-                        )}
-                      </XDSVStack>
-
-                      <XDSButton
-                        label="Sign in"
-                        variant="primary"
-                        size="lg"
-                        isLoading={isLoading}
-                        xstyle={styles.fullWidth}
-                        onClick={handleSignIn}
-                      />
-                      <XDSButton
-                        label="Use a different email"
-                        variant="ghost"
-                        size="lg"
-                        xstyle={styles.fullWidth}
-                        onClick={handleBack}
-                      />
+                        : undefined
+                    }
+                  />
+                  {loginFailed && (
+                    <XDSVStack hAlign="end">
+                      <XDSLink
+                        href="#"
+                        size="sm"
+                        color="secondary"
+                        type="supporting">
+                        Forgot password?
+                      </XDSLink>
                     </XDSVStack>
-                  </>
-                )}
-                  </XDSVStack>
+                  )}
+                </XDSVStack>
+
+                <XDSButton
+                  label="Sign in"
+                  variant="primary"
+                  size="lg"
+                  isLoading={isLoading}
+                  xstyle={styles.fullWidth}
+                  onClick={handleSignIn}
+                />
+                <XDSButton
+                  label="Use a different email"
+                  variant="ghost"
+                  size="lg"
+                  xstyle={styles.fullWidth}
+                  onClick={handleBack}
+                />
+              </XDSVStack>
+            </>
+          )}
+        </XDSVStack>
       </XDSCard>
     </XDSCenter>
   );

--- a/packages/core/src/Card/Card.doc.mjs
+++ b/packages/core/src/Card/Card.doc.mjs
@@ -56,7 +56,7 @@ export const docs = {
       name: 'variant',
       type: "'default' | 'muted' | 'blue' | 'cyan' | 'gray' | 'green' | 'orange' | 'pink' | 'purple' | 'red' | 'teal' | 'yellow'",
       description:
-        'Background color variant. `default` uses the standard card background. `muted` uses the wash background for de-emphasised cards. The non-semantic variants use the corresponding `--color-<name>-background` token.',
+        'Background color variant. `default` uses the standard card background. `muted` uses the muted background for de-emphasised cards. The non-semantic variants use the corresponding `--color-<name>-background` token.',
       default: "'default'",
     },
   ],

--- a/packages/core/src/Layout/Layout.doc.mjs
+++ b/packages/core/src/Layout/Layout.doc.mjs
@@ -203,7 +203,7 @@ export const docs = {
     {
       name: 'XDSSection',
       description:
-        'Section with background variants (section, transparent, wash), built on XDSLayoutContainer.',
+        'Section with background variants (section, transparent, muted), built on XDSLayoutContainer.',
       props: [],
     },
     {
@@ -426,7 +426,7 @@ export const docsZh = {
     {
       name: 'XDSSection',
       description:
-        '基于 XDSLayoutContainer 构建的带有背景变体（section、transparent、wash）的区块。',
+        '基于 XDSLayoutContainer 构建的带有背景变体（section、transparent、muted）的区块。',
       props: [],
     },
     {
@@ -542,7 +542,7 @@ export const docsDense = {
     {
       name: 'XDSSection',
       description:
-        'Section w/ background variants (section, transparent, wash), built on XDSLayoutContainer.',
+        'Section w/ background variants (section, transparent, muted), built on XDSLayoutContainer.',
     },
     {
       name: 'XDSHStack',

--- a/packages/core/src/Section/Section.doc.mjs
+++ b/packages/core/src/Section/Section.doc.mjs
@@ -7,7 +7,7 @@ export const docs = {
   props: [
     {
       name: 'variant',
-      type: "'section' | 'transparent' | 'wash'",
+      type: "'section' | 'transparent' | 'muted'",
       description: 'Background variant applied to the section container.',
       default: "'section'",
     },
@@ -66,9 +66,9 @@ export const docs = {
   },
   usage: {
     description:
-      'Section is a container that is used to create visual separation. Use the default variant for standard content (white), wash to emphasize or group related content (gray), and transparent for no background while still using Section\'s padding and dividers.',
+      'Section is a container that is used to create visual separation. Use the default variant for standard content (white), muted to emphasize or group related content (gray), and transparent for no background while still using Section\'s padding and dividers.',
     bestPractices: [
-      { guidance: true, description: 'Start with the default variant. Use wash only to call attention to a specific region.' },
+      { guidance: true, description: 'Start with the default variant. Use muted only to call attention to a specific region.' },
       { guidance: true, description: 'Add dividers between same-background sections that need separation.' },
     ],
   },
@@ -80,7 +80,7 @@ export const docsZh = {
   props: [
     {
       name: 'variant',
-      type: "'section' | 'transparent' | 'wash'",
+      type: "'section' | 'transparent' | 'muted'",
       description: '应用于区域容器的背景变体。',
       default: "'section'",
     },
@@ -139,9 +139,9 @@ export const docsZh = {
   },
   usage: {
     description:
-      'Section is a container that is used to create visual separation. Use the default variant for standard content (white), wash to emphasize or group related content (gray), and transparent for no background while still using Section\'s padding and dividers.',
+      'Section is a container that is used to create visual separation. Use the default variant for standard content (white), muted to emphasize or group related content (gray), and transparent for no background while still using Section\'s padding and dividers.',
     bestPractices: [
-      { guidance: true, description: 'Start with the default variant. Use wash only to call attention to a specific region.' },
+      { guidance: true, description: 'Start with the default variant. Use muted only to call attention to a specific region.' },
       { guidance: true, description: 'Add dividers between same-background sections that need separation.' },
     ],
   },
@@ -153,9 +153,9 @@ export const docsDense = {
     'Container w/ background variants for creating visually distinct regions; auto-escapes parent container padding for edge-to-edge fills.',
   usage: {
     description:
-      'Section is a container that is used to create visual separation. Use the default variant for standard content (white), wash to emphasize or group related content (gray), and transparent for no background while still using Section\'s padding and dividers.',
+      'Section is a container that is used to create visual separation. Use the default variant for standard content (white), muted to emphasize or group related content (gray), and transparent for no background while still using Section\'s padding and dividers.',
     bestPractices: [
-      { guidance: true, description: 'Start with the default variant. Use wash only to call attention to a specific region.' },
+      { guidance: true, description: 'Start with the default variant. Use muted only to call attention to a specific region.' },
       { guidance: true, description: 'Add dividers between same-background sections that need separation.' },
     ],
   },

--- a/packages/core/src/Section/XDSSection.test.tsx
+++ b/packages/core/src/Section/XDSSection.test.tsx
@@ -35,11 +35,13 @@ describe('XDSSection', () => {
     expect(inner.className).toContain('transparent');
   });
 
-  it('renders with variant="wash"', () => {
-    const {container} = render(<XDSSection variant="wash">Content</XDSSection>);
+  it('renders with variant="muted"', () => {
+    const {container} = render(
+      <XDSSection variant="muted">Content</XDSSection>,
+    );
     const inner = container.firstElementChild!.firstElementChild!;
     expect(inner.className).toContain('xds-section');
-    expect(inner.className).toContain('wash');
+    expect(inner.className).toContain('muted');
   });
 
   it('renders with dividers', () => {
@@ -105,10 +107,12 @@ describe('XDSSection', () => {
   });
 
   it('renders variant in xds class names', () => {
-    const {container} = render(<XDSSection variant="wash">Content</XDSSection>);
+    const {container} = render(
+      <XDSSection variant="muted">Content</XDSSection>,
+    );
     const inner = container.firstElementChild!.firstElementChild!;
     expect(inner.className).toContain('xds-section');
-    expect(inner.className).toContain('wash');
+    expect(inner.className).toContain('muted');
   });
 
   it('accepts xstyle prop without error', () => {

--- a/packages/core/src/Section/XDSSection.tsx
+++ b/packages/core/src/Section/XDSSection.tsx
@@ -47,7 +47,7 @@ import {xdsClassName, mergeProps} from '../utils';
 export interface XDSSectionVariantMap {
   section: true;
   transparent: true;
-  wash: true;
+  muted: true;
 }
 
 /**
@@ -63,7 +63,7 @@ const variantStyles = stylex.create({
   transparent: {
     backgroundColor: 'transparent',
   },
-  wash: {
+  muted: {
     backgroundColor: colorVars['--color-background-muted'],
   },
 });
@@ -141,7 +141,7 @@ export interface XDSSectionProps extends XDSBaseProps<HTMLElement> {
    * Visual variant of the section.
    * - 'section': Surface background color
    * - 'transparent': Fully transparent background
-   * - 'wash': Wash background color
+   * - 'muted': Muted background color
    * @default 'section'
    */
   variant?: XDSSectionVariant;
@@ -212,9 +212,9 @@ export interface XDSSectionProps extends XDSBaseProps<HTMLElement> {
  *
  * @example
  * ```
- * <XDSSection variant="wash" width={300} height={250}>
+ * <XDSSection variant="muted" width={300} height={250}>
  *   <XDSLayout
- *     content={<XDSLayoutContent>Content in wash section</XDSLayoutContent>}
+ *     content={<XDSLayoutContent>Content in muted section</XDSLayoutContent>}
  *   />
  * </XDSSection>
  * ```

--- a/packages/core/src/Toolbar/XDSToolbar.test.tsx
+++ b/packages/core/src/Toolbar/XDSToolbar.test.tsx
@@ -155,11 +155,11 @@ describe('XDSToolbar', () => {
   });
 
   it('passes variant to XDSSection', () => {
-    const {container} = render(<XDSToolbar label="Actions" variant="wash" />);
+    const {container} = render(<XDSToolbar label="Actions" variant="muted" />);
     // XDSSection renders with xds-section class containing the variant
     const sectionInner = container.querySelector('.xds-section');
     expect(sectionInner).toBeInTheDocument();
-    expect(sectionInner?.className).toContain('wash');
+    expect(sectionInner?.className).toContain('muted');
   });
 
   it('defaults to transparent variant', () => {


### PR DESCRIPTION
## Summary

Renames the XDSSection `wash` variant to `muted` to align with XDSCard, which already uses `muted` for the same `--color-background-muted` token. This makes the API more predictable — the variant name now matches the underlying color variable.

## Changes

- **Core component** (`XDSSection.tsx`): variant map, style definition, JSDoc, and code example
- **Tests**: Section and Toolbar test assertions updated
- **Docs**: Section.doc.mjs, Layout.doc.mjs, Card.doc.mjs
- **Consumers**: all storybook stories, sandbox apps, CLI templates, and block docs

## Breaking Change

`variant="wash"` is no longer valid on `XDSSection` or `XDSToolbar`. Consumers must update to `variant="muted"`.
