### PR TITLE
fix(cli): remove unused imports from block examples

### DIFF
--- a/packages/cli/templates/blocks/components/Center/CenterHorizontal.tsx
+++ b/packages/cli/templates/blocks/components/Center/CenterHorizontal.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import {XDSCenter} from '@xds/core/Center';
 import {XDSCard} from '@xds/core/Card';
 import {XDSStack} from '@xds/core/Layout';
 import {XDSHeading} from '@xds/core/Text';

--- a/packages/cli/templates/blocks/components/ChatLayout/ChatLayoutShowcase.tsx
+++ b/packages/cli/templates/blocks/components/ChatLayout/ChatLayoutShowcase.tsx
@@ -8,7 +8,6 @@ import {
   XDSChatComposer,
   XDSChatTokenizedText,
 } from '@xds/core/Chat';
-import {XDSAvatar} from '@xds/core/Avatar';
 import {XDSVStack} from '@xds/core/Stack';
 
 const TOKENS = [{value: '/review', label: '/review', variant: 'blue' as const}];

--- a/packages/cli/templates/blocks/components/ProgressBar/ProgressBarCustomFormat.tsx
+++ b/packages/cli/templates/blocks/components/ProgressBar/ProgressBarCustomFormat.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import {XDSProgressBar} from '@xds/core/ProgressBar';
-import {XDSCenter} from '@xds/core/Center';
 import {XDSVStack} from '@xds/core/Layout';
 import {XDSText} from '@xds/core/Text';
 

--- a/packages/cli/templates/blocks/components/ProgressBar/ProgressBarIndeterminate.tsx
+++ b/packages/cli/templates/blocks/components/ProgressBar/ProgressBarIndeterminate.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import {XDSProgressBar} from '@xds/core/ProgressBar';
-import {XDSCenter} from '@xds/core/Center';
 
 export default function ProgressBarIndeterminate() {
   return (

--- a/packages/cli/templates/blocks/components/ProgressBar/ProgressBarSemanticVariants.tsx
+++ b/packages/cli/templates/blocks/components/ProgressBar/ProgressBarSemanticVariants.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import {XDSProgressBar} from '@xds/core/ProgressBar';
-import {XDSCenter} from '@xds/core/Center';
 import {XDSVStack} from '@xds/core/Layout';
 
 export default function ProgressBarSemanticVariants() {

--- a/packages/cli/templates/blocks/components/ProgressBar/ProgressBarWithValueLabel.tsx
+++ b/packages/cli/templates/blocks/components/ProgressBar/ProgressBarWithValueLabel.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import {XDSProgressBar} from '@xds/core/ProgressBar';
-import {XDSCenter} from '@xds/core/Center';
 
 export default function ProgressBarWithValueLabel() {
   return (

--- a/packages/cli/templates/blocks/components/Section/SectionWashHighlight.tsx
+++ b/packages/cli/templates/blocks/components/Section/SectionWashHighlight.tsx
@@ -2,7 +2,7 @@
 
 import {XDSSection} from '@xds/core/Section';
 import {XDSStack} from '@xds/core/Layout';
-import {XDSHeading, XDSText} from '@xds/core/Text';
+import {XDSText} from '@xds/core/Text';
 import {XDSButton} from '@xds/core/Button';
 import {XDSIcon} from '@xds/core/Icon';
 import {CheckIcon} from '@heroicons/react/24/solid';

--- a/packages/cli/templates/blocks/components/Slider/SliderWithStatus.tsx
+++ b/packages/cli/templates/blocks/components/Slider/SliderWithStatus.tsx
@@ -3,7 +3,6 @@
 import {useState} from 'react';
 import {XDSSlider} from '@xds/core/Slider';
 import {XDSVStack} from '@xds/core/Layout';
-import {XDSCenter} from '@xds/core/Center';
 
 export default function SliderWithStatus() {
   const [value1, setValue1] = useState(95);


### PR DESCRIPTION
Clean up unused imports across block component templates in `packages/cli/templates/blocks/components`:

- Remove unused `XDSCenter` imports from Center, ProgressBar, and Slider examples
- Remove unused `XDSAvatar` import from ChatLayout showcase
- Remove unused `XDSHeading` import from Section example

**8 files cleaned**, no functional changes.