### PR TITLE
docs(blocks): add missing componentsUsed to 25 showcase templates

### DIFF
--- a/packages/cli/templates/blocks/components/ChatComposer/ChatComposerShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatComposer/ChatComposerShowcase.doc.mjs
@@ -6,4 +6,5 @@ export const doc = {
   isReady: true,
   aspectRatio: 4 / 3,
   isShowcase: true,
+  componentsUsed: ['Chat', 'Layout'],
 };

--- a/packages/cli/templates/blocks/components/ChatLayout/ChatLayoutShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatLayout/ChatLayoutShowcase.doc.mjs
@@ -6,4 +6,5 @@ export const doc = {
   isReady: true,
   aspectRatio: 4 / 3,
   isShowcase: true,
+  componentsUsed: ['Chat', 'Stack'],
 };

--- a/packages/cli/templates/blocks/components/ChatTokenizedText/ChatTokenizedTextShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatTokenizedText/ChatTokenizedTextShowcase.doc.mjs
@@ -6,4 +6,5 @@ export const doc = {
   isReady: true,
   aspectRatio: 16 / 9,
   isShowcase: true,
+  componentsUsed: ['Chat'],
 };

--- a/packages/cli/templates/blocks/components/ChatToolCalls/ChatToolCallsShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/ChatToolCalls/ChatToolCallsShowcase.doc.mjs
@@ -6,4 +6,5 @@ export const doc = {
   isReady: true,
   aspectRatio: 16 / 9,
   isShowcase: true,
+  componentsUsed: ['Chat'],
 };

--- a/packages/cli/templates/blocks/components/CheckboxList/CheckboxListShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/CheckboxList/CheckboxListShowcase.doc.mjs
@@ -6,4 +6,5 @@ export const doc = {
   isReady: true,
   aspectRatio: 1,
   isShowcase: true,
+  componentsUsed: ['CheckboxList'],
 };

--- a/packages/cli/templates/blocks/components/Grid/GridShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/Grid/GridShowcase.doc.mjs
@@ -6,4 +6,5 @@ export const doc = {
   isReady: true,
   aspectRatio: 1,
   isShowcase: true,
+  componentsUsed: ['Card', 'Grid'],
 };

--- a/packages/cli/templates/blocks/components/Heading/HeadingShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/Heading/HeadingShowcase.doc.mjs
@@ -6,4 +6,5 @@ export const doc = {
   isReady: true,
   aspectRatio: 1,
   isShowcase: true,
+  componentsUsed: ['Layout', 'Text'],
 };

--- a/packages/cli/templates/blocks/components/Icon/IconShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/Icon/IconShowcase.doc.mjs
@@ -6,4 +6,5 @@ export const doc = {
   isReady: true,
   aspectRatio: 1,
   isShowcase: true,
+  componentsUsed: ['Icon'],
 };

--- a/packages/cli/templates/blocks/components/Kbd/KbdShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/Kbd/KbdShowcase.doc.mjs
@@ -6,4 +6,5 @@ export const doc = {
   isReady: true,
   aspectRatio: 1,
   isShowcase: true,
+  componentsUsed: ['Kbd'],
 };

--- a/packages/cli/templates/blocks/components/Layout/LayoutShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/Layout/LayoutShowcase.doc.mjs
@@ -6,4 +6,5 @@ export const doc = {
   isReady: true,
   aspectRatio: 4 / 3,
   isShowcase: true,
+  componentsUsed: ['Badge', 'Button', 'Layout', 'List', 'Text'],
 };

--- a/packages/cli/templates/blocks/components/List/ListShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/List/ListShowcase.doc.mjs
@@ -6,4 +6,5 @@ export const doc = {
   isReady: true,
   aspectRatio: 1,
   isShowcase: true,
+  componentsUsed: ['List'],
 };

--- a/packages/cli/templates/blocks/components/MetadataList/MetadataListShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/MetadataList/MetadataListShowcase.doc.mjs
@@ -6,4 +6,5 @@ export const doc = {
   isReady: true,
   aspectRatio: 1,
   isShowcase: true,
+  componentsUsed: ['MetadataList'],
 };

--- a/packages/cli/templates/blocks/components/MobileNav/MobileNavShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/MobileNav/MobileNavShowcase.doc.mjs
@@ -6,4 +6,5 @@ export const doc = {
   isReady: true,
   aspectRatio: 1,
   isShowcase: true,
+  componentsUsed: ['Button', 'Icon', 'MobileNav', 'SideNav'],
 };

--- a/packages/cli/templates/blocks/components/RadioList/RadioListShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/RadioList/RadioListShowcase.doc.mjs
@@ -6,4 +6,5 @@ export const doc = {
   isReady: true,
   aspectRatio: 1,
   isShowcase: true,
+  componentsUsed: ['RadioList'],
 };

--- a/packages/cli/templates/blocks/components/SegmentedControl/SegmentedControlShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/SegmentedControl/SegmentedControlShowcase.doc.mjs
@@ -6,4 +6,5 @@ export const doc = {
   isReady: true,
   aspectRatio: 1,
   isShowcase: true,
+  componentsUsed: ['SegmentedControl'],
 };

--- a/packages/cli/templates/blocks/components/SideNav/SideNavShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/SideNav/SideNavShowcase.doc.mjs
@@ -6,4 +6,5 @@ export const doc = {
   isReady: true,
   aspectRatio: 1,
   isShowcase: true,
+  componentsUsed: ['SideNav'],
 };

--- a/packages/cli/templates/blocks/components/TabList/TabListShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/TabList/TabListShowcase.doc.mjs
@@ -6,4 +6,5 @@ export const doc = {
   isReady: true,
   aspectRatio: 1,
   isShowcase: true,
+  componentsUsed: ['TabList'],
 };

--- a/packages/cli/templates/blocks/components/Text/TextShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/Text/TextShowcase.doc.mjs
@@ -6,4 +6,5 @@ export const doc = {
   isReady: true,
   aspectRatio: 16 / 9,
   isShowcase: true,
+  componentsUsed: ['Stack', 'Text'],
 };

--- a/packages/cli/templates/blocks/components/TextInput/TextInputShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/TextInput/TextInputShowcase.doc.mjs
@@ -6,4 +6,5 @@ export const doc = {
   isReady: true,
   aspectRatio: 16 / 9,
   isShowcase: true,
+  componentsUsed: ['TextInput'],
 };

--- a/packages/cli/templates/blocks/components/Timestamp/TimestampShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/Timestamp/TimestampShowcase.doc.mjs
@@ -6,4 +6,5 @@ export const doc = {
   isReady: true,
   aspectRatio: 16 / 9,
   isShowcase: true,
+  componentsUsed: ['Timestamp'],
 };

--- a/packages/cli/templates/blocks/components/ToggleButton/ToggleButtonShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/ToggleButton/ToggleButtonShowcase.doc.mjs
@@ -6,4 +6,5 @@ export const doc = {
   isReady: true,
   aspectRatio: 16 / 9,
   isShowcase: true,
+  componentsUsed: ['Icon', 'Layout', 'ToggleButton'],
 };

--- a/packages/cli/templates/blocks/components/Token/TokenShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/Token/TokenShowcase.doc.mjs
@@ -6,4 +6,5 @@ export const doc = {
   isReady: true,
   aspectRatio: 1,
   isShowcase: true,
+  componentsUsed: ['Icon', 'Layout', 'Token'],
 };

--- a/packages/cli/templates/blocks/components/TopNav/TopNavShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/TopNav/TopNavShowcase.doc.mjs
@@ -6,4 +6,5 @@ export const doc = {
   isReady: true,
   aspectRatio: 3,
   isShowcase: true,
+  componentsUsed: ['Button', 'Icon', 'TopNav'],
 };

--- a/packages/cli/templates/blocks/components/TreeList/TreeListShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/TreeList/TreeListShowcase.doc.mjs
@@ -6,4 +6,5 @@ export const doc = {
   isReady: true,
   aspectRatio: 1,
   isShowcase: true,
+  componentsUsed: ['TreeList'],
 };

--- a/packages/cli/templates/blocks/components/Typeahead/TypeaheadShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/Typeahead/TypeaheadShowcase.doc.mjs
@@ -6,4 +6,5 @@ export const doc = {
   isReady: true,
   aspectRatio: 1,
   isShowcase: true,
+  componentsUsed: ['Typeahead'],
 };


### PR DESCRIPTION
## What

25 showcase block template `.doc.mjs` files were missing the `componentsUsed` field entirely. The CLI uses this field for component relationship mapping and discovery.

Each file now has `componentsUsed` derived from the actual `@xds/core/*` imports in the corresponding `.tsx` file.

### Affected components
ChatComposer, ChatLayout, ChatTokenizedText, ChatToolCalls, CheckboxList, Grid, Heading, Icon, Kbd, Layout, List, MetadataList, MobileNav, RadioList, SegmentedControl, SideNav, TabList, Text, TextInput, Timestamp, ToggleButton, Token, TopNav, TreeList, Typeahead

## Checklist
- [x] `npx tsc --project packages/cli/tsconfig.template-docs.json --noEmit` passes
- [x] Block templates paired with `.doc.mjs` files
- [x] `componentsUsed` matches actual imports

---
*Night Watch — Doc Reviewer*