### PR TITLE
fix(core): CommandPalette barrel 'use client', Markdown hover guards

### DIFF
--- a/packages/core/src/CommandPalette/index.ts
+++ b/packages/core/src/CommandPalette/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file index.ts
  * @input Imports CommandPalette components and types

--- a/packages/core/src/Markdown/XDSMarkdown.tsx
+++ b/packages/core/src/Markdown/XDSMarkdown.tsx
@@ -375,7 +375,7 @@ const styles = stylex.create({
     color: colorVars['--color-text-accent'],
     textDecoration: {
       default: 'none',
-      ':hover': 'underline',
+      ':hover': {'@media (hover: hover)': 'underline'},
     },
   },
   // Citation chip — inline capsule matching XDSTextCitation treatment
@@ -435,15 +435,15 @@ const styles = stylex.create({
   },
   citationNumberHover: {
     backgroundColor: {
-      ':hover': colorVars['--color-overlay-hover'],
+      ':hover': {'@media (hover: hover)': colorVars['--color-overlay-hover']},
     },
   },
   citationHover: {
     backgroundColor: {
-      ':hover': colorVars['--color-overlay-hover'],
+      ':hover': {'@media (hover: hover)': colorVars['--color-overlay-hover']},
     },
     color: {
-      ':hover': colorVars['--color-text-primary'],
+      ':hover': {'@media (hover: hover)': colorVars['--color-text-primary']},
     },
   },
   citationIconWrap: {
@@ -724,8 +724,7 @@ function wrapTextWithFade(
   return (
     <Fragment key={`fade-${key}-split`}>
       {content.slice(0, splitAt)}
-      <span
-        {...stylex.props(streamingStyles.fadeIn)}>
+      <span {...stylex.props(streamingStyles.fadeIn)}>
         {content.slice(splitAt)}
       </span>
     </Fragment>
@@ -773,7 +772,9 @@ function renderInline(
           for (let i = 0; i < segments.length; i++) {
             const seg = segments[i];
             if (seg.type === 'text') {
-              result.push(wrapTextWithFade(seg.content, cursor, `${index}-seg-${i}`));
+              result.push(
+                wrapTextWithFade(seg.content, cursor, `${index}-seg-${i}`),
+              );
             } else {
               // Plugin segment — advance cursor by matchLength, apply fade if new
               const startOffset = cursor.offset;
@@ -788,7 +789,9 @@ function renderInline(
                 );
               } else {
                 result.push(
-                  <Fragment key={`plugin-${index}-${i}`}>{seg.element}</Fragment>,
+                  <Fragment key={`plugin-${index}-${i}`}>
+                    {seg.element}
+                  </Fragment>,
                 );
               }
             }
@@ -802,7 +805,15 @@ function renderInline(
       return (
         <strong key={index} {...stylex.props(styles.bold)}>
           {node.children.map((c, i) =>
-            renderInline(c, i, onLinkClick, cursor, citationCtx, linkComponent, inlinePlugins),
+            renderInline(
+              c,
+              i,
+              onLinkClick,
+              cursor,
+              citationCtx,
+              linkComponent,
+              inlinePlugins,
+            ),
           )}
         </strong>
       );
@@ -810,7 +821,15 @@ function renderInline(
       return (
         <em key={index}>
           {node.children.map((c, i) =>
-            renderInline(c, i, onLinkClick, cursor, citationCtx, linkComponent, inlinePlugins),
+            renderInline(
+              c,
+              i,
+              onLinkClick,
+              cursor,
+              citationCtx,
+              linkComponent,
+              inlinePlugins,
+            ),
           )}
         </em>
       );
@@ -818,7 +837,15 @@ function renderInline(
       return (
         <del key={index} {...stylex.props(styles.strikethrough)}>
           {node.children.map((c, i) =>
-            renderInline(c, i, onLinkClick, cursor, citationCtx, linkComponent, inlinePlugins),
+            renderInline(
+              c,
+              i,
+              onLinkClick,
+              cursor,
+              citationCtx,
+              linkComponent,
+              inlinePlugins,
+            ),
           )}
         </del>
       );
@@ -844,7 +871,15 @@ function renderInline(
         return (
           <span key={index}>
             {node.children.map((c, i) =>
-              renderInline(c, i, onLinkClick, cursor, citationCtx, linkComponent, inlinePlugins),
+              renderInline(
+                c,
+                i,
+                onLinkClick,
+                cursor,
+                citationCtx,
+                linkComponent,
+                inlinePlugins,
+              ),
             )}
           </span>
         );
@@ -872,7 +907,15 @@ function renderInline(
             : {})}
           {...stylex.props(styles.link)}>
           {node.children.map((c, i) =>
-            renderInline(c, i, onLinkClick, cursor, citationCtx, linkComponent, inlinePlugins),
+            renderInline(
+              c,
+              i,
+              onLinkClick,
+              cursor,
+              citationCtx,
+              linkComponent,
+              inlinePlugins,
+            ),
           )}
         </LinkTag>
       );
@@ -1056,7 +1099,15 @@ function renderBlock(
             isLast && styles.noMarginBlockEnd,
           )}>
           {node.children.map((c, i) =>
-            renderInline(c, i, onLinkClick, cursor, citationCtx, linkComponent, inlinePlugins),
+            renderInline(
+              c,
+              i,
+              onLinkClick,
+              cursor,
+              citationCtx,
+              linkComponent,
+              inlinePlugins,
+            ),
           )}
         </Tag>
       );
@@ -1077,7 +1128,15 @@ function renderBlock(
             isLast && styles.noMarginBlockEnd,
           )}>
           {node.children.map((c, i) =>
-            renderInline(c, i, onLinkClick, cursor, citationCtx, linkComponent, inlinePlugins),
+            renderInline(
+              c,
+              i,
+              onLinkClick,
+              cursor,
+              citationCtx,
+              linkComponent,
+              inlinePlugins,
+            ),
           )}
         </p>
       );
@@ -1182,7 +1241,15 @@ function renderBlock(
                 const label = isInline ? (
                   <>
                     {firstChild.children.map((c, j) =>
-                      renderInline(c, j, onLinkClick, cursor, citationCtx, linkComponent, inlinePlugins),
+                      renderInline(
+                        c,
+                        j,
+                        onLinkClick,
+                        cursor,
+                        citationCtx,
+                        linkComponent,
+                        inlinePlugins,
+                      ),
                     )}
                   </>
                 ) : (
@@ -1263,7 +1330,15 @@ function renderBlock(
               const label = isInline ? (
                 <>
                   {firstChild.children.map((c, j) =>
-                    renderInline(c, j, onLinkClick, cursor, citationCtx, linkComponent, inlinePlugins),
+                    renderInline(
+                      c,
+                      j,
+                      onLinkClick,
+                      cursor,
+                      citationCtx,
+                      linkComponent,
+                      inlinePlugins,
+                    ),
                   )}
                 </>
               ) : (
@@ -1340,7 +1415,15 @@ function renderBlock(
                       alignStyle(node.alignments[i]),
                     )}>
                     {h.children.map((c, j) =>
-                      renderInline(c, j, onLinkClick, cursor, citationCtx, linkComponent, inlinePlugins),
+                      renderInline(
+                        c,
+                        j,
+                        onLinkClick,
+                        cursor,
+                        citationCtx,
+                        linkComponent,
+                        inlinePlugins,
+                      ),
                     )}
                   </th>
                 ))}
@@ -1358,7 +1441,15 @@ function renderBlock(
                       alignStyle(node.alignments[j]),
                     )}>
                     {cell.children.map((c, k) =>
-                      renderInline(c, k, onLinkClick, cursor, citationCtx, linkComponent, inlinePlugins),
+                      renderInline(
+                        c,
+                        k,
+                        onLinkClick,
+                        cursor,
+                        citationCtx,
+                        linkComponent,
+                        inlinePlugins,
+                      ),
                     )}
                   </td>
                 ));


### PR DESCRIPTION
## Component Audit — 2026-05-05

Audited 5 components: **Chat**, **CommandPalette**, **IconButton**, **Markdown**, **MultiSelector**.

### Fixes

1. **CommandPalette/index.ts** — Added missing `'use client'` directive on the barrel file. All other component barrels (Chat, Button, Dialog, Popover, etc.) include it for consistency and RSC boundary correctness.

2. **Markdown/XDSMarkdown.tsx** — Wrapped 4 `:hover` styles in `@media (hover: hover)` guards:
   - Link underline on hover
   - Citation number pill background on hover
   - Citation chip background on hover
   - Citation chip text color on hover

   Without the guard, these styles become sticky on touch devices (tap triggers hover, stays until next tap elsewhere).

### Flagged for Human Review

- **Chat/XDSChatComposer.tsx:344** — Uses `color="negative"` on XDSIcon for error status. This is the deprecated naming per #996, but cannot be changed until Icon adds `error`/`success` as valid color values (breaking change requiring codemod).
- **Markdown/XDSMarkdown.tsx** — `XDSMarkdownProps` doesn't extend `XDSBaseProps`. It has all escape hatches manually (`xstyle`, `className`, `style`, `ref`) so functionality is correct, but pattern is inconsistent.

### Components Audited (no issues)

- **IconButton** — Clean. Thin wrapper over XDSButton, proper types, displayName.
- **MultiSelector** — Clean. Extends XDSBaseProps, hover guards present, proper field props.
- **Chat** — Large composition (16 sub-components). All have `'use client'`, displayName, xdsClassName. Only finding is the deprecated `negative` color (flagged above).

Night Watch — Component Auditor