### PR TITLE
feat(PowerSearch): add components map for per-type token and editor overrides

### DIFF
--- a/apps/storybook/stories/Citation.stories.tsx
+++ b/apps/storybook/stories/Citation.stories.tsx
@@ -1,0 +1,89 @@
+import type {Meta, StoryObj} from '@storybook/react';
+import {XDSCitation} from '@xds/core/Citation';
+
+const meta: Meta<typeof XDSCitation> = {
+  title: 'Core/Citation',
+  component: XDSCitation,
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['label', 'number'],
+      description: 'Display style — label chip or numbered badge',
+    },
+    number: {
+      control: 'number',
+      description: 'Citation display number',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof XDSCitation>;
+
+export const Label: Story = {
+  args: {
+    source: {title: 'React Documentation', url: 'https://react.dev'},
+    number: 1,
+    variant: 'label',
+  },
+};
+
+export const Number: Story = {
+  args: {
+    source: {title: 'TypeScript Handbook', url: 'https://typescriptlang.org'},
+    number: 2,
+    variant: 'number',
+  },
+};
+
+export const WithIcon: Story = {
+  args: {
+    source: {
+      title: 'GitHub',
+      url: 'https://github.com',
+      icon: 'https://github.githubassets.com/favicons/favicon.svg',
+    },
+    number: 3,
+    variant: 'label',
+  },
+};
+
+export const NoLink: Story = {
+  args: {
+    source: {title: 'Internal reference'},
+    number: 4,
+    variant: 'label',
+  },
+};
+
+export const Variants: Story = {
+  render: () => (
+    <div style={{display: 'flex', gap: '12px', alignItems: 'center', flexWrap: 'wrap'}}>
+      <XDSCitation
+        source={{title: 'React Docs', url: 'https://react.dev'}}
+        number={1}
+        variant="label"
+      />
+      <XDSCitation
+        source={{title: 'TypeScript', url: 'https://typescriptlang.org'}}
+        number={2}
+        variant="number"
+      />
+      <XDSCitation
+        source={{
+          title: 'GitHub',
+          url: 'https://github.com',
+          icon: 'https://github.githubassets.com/favicons/favicon.svg',
+        }}
+        number={3}
+        variant="label"
+      />
+      <XDSCitation
+        source={{title: 'A very long source title that should be truncated with ellipsis'}}
+        number={4}
+        variant="label"
+      />
+    </div>
+  ),
+};

--- a/apps/storybook/stories/PowerSearch.stories.tsx
+++ b/apps/storybook/stories/PowerSearch.stories.tsx
@@ -1,10 +1,7 @@
 import {useState} from 'react';
 import type {Meta, StoryObj} from '@storybook/react';
 import {XDSPowerSearch} from '@xds/core/PowerSearch';
-import type {
-  PowerSearchConfig,
-  PowerSearchFilter,
-} from '@xds/core/PowerSearch';
+import type {PowerSearchConfig, PowerSearchFilter} from '@xds/core/PowerSearch';
 import type {XDSSearchSource, XDSSearchableItem} from '@xds/core/Typeahead';
 import {XDSButton} from '@xds/core/Button';
 import {MagnifyingGlassIcon} from '@heroicons/react/24/outline';
@@ -319,7 +316,11 @@ export const Default: Story = {
 export const WithPresetFilters: Story = {
   render: args => {
     const [filters, setFilters] = useState<PowerSearchFilter[]>([
-      {field: 'status', operator: 'is', value: {type: 'enum', value: 'open'}},
+      {
+        field: 'status',
+        operator: 'any_of',
+        value: {type: 'enum_list', value: ['open', 'in_progress']},
+      },
       {
         field: 'priority',
         operator: 'is',
@@ -556,7 +557,11 @@ export const WithEmptyFilter: Story = {
 export const ReadOnly: Story = {
   render: args => {
     const filters: PowerSearchFilter[] = [
-      {field: 'status', operator: 'is', value: {type: 'enum', value: 'open'}},
+      {
+        field: 'status',
+        operator: 'any_of',
+        value: {type: 'enum_list', value: ['open', 'in_progress']},
+      },
       {
         field: 'priority',
         operator: 'is',
@@ -582,7 +587,11 @@ export const ReadOnly: Story = {
 export const Disabled: Story = {
   render: args => {
     const filters: PowerSearchFilter[] = [
-      {field: 'status', operator: 'is', value: {type: 'enum', value: 'open'}},
+      {
+        field: 'status',
+        operator: 'any_of',
+        value: {type: 'enum_list', value: ['open', 'in_progress']},
+      },
     ];
     return (
       <XDSPowerSearch
@@ -1001,7 +1010,11 @@ export const WithStartIcon: Story = {
 export const WithResultCount: Story = {
   render: args => {
     const [filters, setFilters] = useState<PowerSearchFilter[]>([
-      {field: 'status', operator: 'is', value: {type: 'enum', value: 'open'}},
+      {
+        field: 'status',
+        operator: 'any_of',
+        value: {type: 'enum_list', value: ['open', 'in_progress']},
+      },
     ]);
     return (
       <XDSPowerSearch

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -157,6 +157,12 @@
       "import": "./dist/CheckboxList/index.mjs",
       "require": "./dist/CheckboxList/index.js"
     },
+    "./Citation": {
+      "source": "./src/Citation/index.ts",
+      "types": "./dist/Citation/index.d.ts",
+      "import": "./dist/Citation/index.mjs",
+      "require": "./dist/Citation/index.js"
+    },
     "./ClickableCard": {
       "source": "./src/ClickableCard/index.ts",
       "types": "./dist/ClickableCard/index.d.ts",

--- a/packages/core/src/Citation/XDSCitation.tsx
+++ b/packages/core/src/Citation/XDSCitation.tsx
@@ -1,0 +1,186 @@
+'use client';
+
+import type React from 'react';
+import type {StyleXStyles} from '@stylexjs/stylex';
+import * as stylex from '@stylexjs/stylex';
+import {
+  colorVars,
+  spacingVars,
+  radiusVars,
+  typeScaleVars,
+  fontWeightVars,
+  borderVars,
+  durationVars,
+  easeVars,
+} from '../theme/tokens.stylex';
+import {xdsClassName, mergeProps} from '../utils';
+
+export interface XDSCitationSource {
+  title?: string;
+  url?: string;
+  icon?: string;
+}
+
+export interface XDSCitationProps {
+  ref?: React.Ref<HTMLElement>;
+  source: XDSCitationSource;
+  number: number;
+  variant?: 'label' | 'number';
+  xstyle?: StyleXStyles;
+  className?: string;
+  'data-testid'?: string;
+}
+
+const styles = stylex.create({
+  label: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: spacingVars['--spacing-1'],
+    verticalAlign: 'baseline',
+    height: spacingVars['--spacing-5'],
+    fontSize: typeScaleVars['--text-supporting-size'],
+    fontWeight: typeScaleVars['--text-supporting-weight'],
+    lineHeight: typeScaleVars['--text-supporting-leading'],
+    color: colorVars['--color-text-secondary'],
+    borderRadius: radiusVars['--radius-element'],
+    borderWidth: borderVars['--border-width'],
+    borderStyle: 'solid',
+    borderColor: colorVars['--color-border'],
+    paddingInline: spacingVars['--spacing-2'],
+    marginInlineStart: spacingVars['--spacing-0-5'],
+    textDecoration: 'none',
+    cursor: 'pointer',
+    transitionProperty: 'background-color, border-color, color',
+    transitionDuration: durationVars['--duration-fast-max'],
+    transitionTimingFunction: easeVars['--ease-standard'],
+    maxWidth: '15em',
+    overflow: 'hidden',
+  },
+  labelWithIcon: {
+    paddingInlineStart: spacingVars['--spacing-0-5'],
+  },
+  labelText: {
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+    minWidth: 0,
+  },
+  labelHover: {
+    backgroundColor: {':hover': colorVars['--color-overlay-hover']},
+    color: {':hover': colorVars['--color-text-primary']},
+  },
+  number: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    verticalAlign: 'super',
+    fontSize: typeScaleVars['--text-supporting-size'],
+    fontWeight: fontWeightVars['--font-weight-semibold'],
+    lineHeight: typeScaleVars['--text-supporting-leading'],
+    color: colorVars['--color-text-accent'],
+    backgroundColor: colorVars['--color-accent-muted'],
+    borderRadius: radiusVars['--radius-full'],
+    minWidth: spacingVars['--spacing-5'],
+    height: spacingVars['--spacing-5'],
+    paddingInline: spacingVars['--spacing-1'],
+    textDecoration: 'none',
+    cursor: 'pointer',
+    transitionProperty: 'background-color',
+    transitionDuration: durationVars['--duration-fast-max'],
+    transitionTimingFunction: easeVars['--ease-standard'],
+  },
+  numberHover: {
+    backgroundColor: {':hover': colorVars['--color-overlay-hover']},
+  },
+  iconWrap: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: spacingVars['--spacing-4'],
+    height: spacingVars['--spacing-4'],
+    borderRadius: radiusVars['--radius-full'],
+    backgroundColor: colorVars['--color-background-surface'],
+    borderWidth: borderVars['--border-width'],
+    borderStyle: 'solid',
+    borderColor: colorVars['--color-border'],
+    overflow: 'hidden',
+    flexShrink: 0,
+  },
+  icon: {
+    width: spacingVars['--spacing-3'],
+    height: spacingVars['--spacing-3'],
+  },
+});
+
+export function XDSCitation({
+  ref,
+  source,
+  number,
+  variant = 'label',
+  xstyle,
+  className,
+  'data-testid': testId,
+}: XDSCitationProps): React.ReactElement {
+  const title = source.title ?? String(number);
+  const href = source.url;
+  const icon = source.icon;
+  const Tag = href ? 'a' : 'span';
+  const linkProps = href
+    ? {href, target: '_blank' as const, rel: 'noopener noreferrer' as const, title}
+    : {title};
+
+  // Both <a> and <span> extend HTMLElement — narrow via intersection
+  const elementRef = ref as React.Ref<HTMLAnchorElement> &
+    React.Ref<HTMLSpanElement>;
+
+  if (variant === 'number') {
+    return (
+      <Tag
+        ref={elementRef}
+        role="doc-noteref"
+        aria-label={`Citation ${number}: ${title}`}
+        data-testid={testId}
+        {...linkProps}
+        {...mergeProps(
+          xdsClassName('citation', {variant}),
+          stylex.props(styles.number, href != null && styles.numberHover, xstyle),
+          className,
+        )}>
+        {number}
+      </Tag>
+    );
+  }
+
+  return (
+    <Tag
+      ref={elementRef}
+      role="doc-noteref"
+      aria-label={`Citation ${number}: ${title}`}
+      data-testid={testId}
+      {...linkProps}
+      {...mergeProps(
+        xdsClassName('citation', {variant}),
+        stylex.props(
+          styles.label,
+          icon != null && styles.labelWithIcon,
+          href != null && styles.labelHover,
+          xstyle,
+        ),
+        className,
+      )}>
+      {icon && (
+        <span {...stylex.props(styles.iconWrap)}>
+          <img
+            src={icon}
+            alt=""
+            aria-hidden="true"
+            {...stylex.props(styles.icon)}
+          />
+        </span>
+      )}
+      <span {...stylex.props(styles.labelText)}>{title}</span>
+    </Tag>
+  );
+}
+
+XDSCitation.displayName = 'XDSCitation';

--- a/packages/core/src/Citation/index.ts
+++ b/packages/core/src/Citation/index.ts
@@ -1,0 +1,4 @@
+'use client';
+
+export {XDSCitation} from './XDSCitation';
+export type {XDSCitationProps, XDSCitationSource} from './XDSCitation';

--- a/packages/core/src/Markdown/XDSMarkdown.tsx
+++ b/packages/core/src/Markdown/XDSMarkdown.tsx
@@ -30,6 +30,8 @@ import {XDSList} from '../List/XDSList';
 import {XDSListItem} from '../List/XDSListItem';
 import {xdsClassName, mergeProps} from '../utils';
 import {useXDSStreamingText} from '../hooks/useXDSStreamingText';
+import {XDSCitation} from '../Citation/XDSCitation';
+import type {XDSCitationSource} from '../Citation/XDSCitation';
 import {useXDSLinkComponent} from '../Link/useXDSLinkComponent';
 import type {XDSLinkComponentType} from '../Link/types';
 import {
@@ -74,13 +76,18 @@ export interface MarkdownInlinePlugin {
  * When `sources` is provided, bracket content matching a source key is rendered
  * as a compact superscript citation pill instead of plain text.
  */
-export interface XDSMarkdownSource {
-  /** Human-readable title for the source. */
-  title?: string;
-  /** URL to navigate to when the citation is clicked. */
-  url?: string;
-  /** Optional favicon or icon URL to display in the citation pill. */
-  icon?: string;
+export type XDSMarkdownSource = XDSCitationSource;
+
+export interface XDSMarkdownComponents {
+  code?: React.ComponentType<{code: string; language?: string}>;
+  inlineCode?: React.ComponentType<{children: string}>;
+  citation?: React.ComponentType<{source: XDSCitationSource; number: number; variant: 'label' | 'number'}>;
+  link?: React.ComponentType<{href: string; children: React.ReactNode}>;
+  heading?: React.ComponentType<{level: 1|2|3|4|5|6; children: React.ReactNode}>;
+  paragraph?: React.ComponentType<{children: React.ReactNode}>;
+  image?: React.ComponentType<{src: string; alt: string}>;
+  blockquote?: React.ComponentType<{children: React.ReactNode}>;
+  hr?: React.ComponentType<Record<string, never>>;
 }
 
 export interface XDSMarkdownProps {
@@ -131,6 +138,7 @@ export interface XDSMarkdownProps {
    * @default 'start'
    */
   contentAlign?: 'start' | 'center';
+  components?: Partial<XDSMarkdownComponents>;
   /**
    * Plugins that transform text patterns into custom React elements.
    * Applied to text nodes after parsing — code blocks and inline code
@@ -377,92 +385,6 @@ const styles = stylex.create({
       default: 'none',
       ':hover': 'underline',
     },
-  },
-  // Citation chip — inline capsule matching XDSTextCitation treatment
-  citation: {
-    display: 'inline-flex',
-    alignItems: 'center',
-    gap: spacingVars['--spacing-1'],
-    verticalAlign: 'baseline',
-    height: spacingVars['--spacing-5'],
-    fontSize: typeScaleVars['--text-supporting-size'],
-    fontWeight: typeScaleVars['--text-supporting-weight'],
-    lineHeight: typeScaleVars['--text-supporting-leading'],
-    color: colorVars['--color-text-secondary'],
-    borderRadius: radiusVars['--radius-element'],
-    borderWidth: borderVars['--border-width'],
-    borderStyle: 'solid',
-    borderColor: colorVars['--color-border'],
-    paddingInline: spacingVars['--spacing-2'],
-    marginInlineStart: spacingVars['--spacing-0-5'],
-    textDecoration: 'none',
-    cursor: 'pointer',
-    transitionProperty: 'background-color, border-color, color',
-    transitionDuration: durationVars['--duration-fast-max'],
-    transitionTimingFunction: easeVars['--ease-standard'],
-    maxWidth: '15em',
-    overflow: 'hidden',
-  },
-  citationWithIcon: {
-    paddingInlineStart: spacingVars['--spacing-0-5'],
-  },
-  citationLabel: {
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
-    minWidth: 0,
-  },
-  // Number mode — compact superscript badge
-  citationNumber: {
-    display: 'inline-flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    verticalAlign: 'super',
-    fontSize: typeScaleVars['--text-supporting-size'],
-    fontWeight: fontWeightVars['--font-weight-semibold'],
-    lineHeight: typeScaleVars['--text-supporting-leading'],
-    color: colorVars['--color-text-accent'],
-    backgroundColor: colorVars['--color-accent-muted'],
-    borderRadius: radiusVars['--radius-full'],
-    minWidth: spacingVars['--spacing-5'],
-    height: spacingVars['--spacing-5'],
-    paddingInline: spacingVars['--spacing-1'],
-    textDecoration: 'none',
-    cursor: 'pointer',
-    transitionProperty: 'background-color',
-    transitionDuration: durationVars['--duration-fast-max'],
-    transitionTimingFunction: easeVars['--ease-standard'],
-  },
-  citationNumberHover: {
-    backgroundColor: {
-      ':hover': colorVars['--color-overlay-hover'],
-    },
-  },
-  citationHover: {
-    backgroundColor: {
-      ':hover': colorVars['--color-overlay-hover'],
-    },
-    color: {
-      ':hover': colorVars['--color-text-primary'],
-    },
-  },
-  citationIconWrap: {
-    display: 'inline-flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    width: spacingVars['--spacing-4'],
-    height: spacingVars['--spacing-4'],
-    borderRadius: radiusVars['--radius-full'],
-    backgroundColor: colorVars['--color-background-surface'],
-    borderWidth: borderVars['--border-width'],
-    borderStyle: 'solid',
-    borderColor: colorVars['--color-border'],
-    overflow: 'hidden',
-    flexShrink: 0,
-  },
-  citationIcon: {
-    width: spacingVars['--spacing-3'],
-    height: spacingVars['--spacing-3'],
   },
 });
 
@@ -760,6 +682,7 @@ function renderInline(
   citationCtx: CitationContext | null,
   linkComponent: XDSLinkComponentType = 'a',
   inlinePlugins?: MarkdownInlinePlugin[],
+  components?: Partial<XDSMarkdownComponents>,
 ): React.ReactNode {
   switch (node.type) {
     case 'text': {
@@ -802,7 +725,7 @@ function renderInline(
       return (
         <strong key={index} {...stylex.props(styles.bold)}>
           {node.children.map((c, i) =>
-            renderInline(c, i, onLinkClick, cursor, citationCtx, linkComponent, inlinePlugins),
+            renderInline(c, i, onLinkClick, cursor, citationCtx, linkComponent, inlinePlugins, components),
           )}
         </strong>
       );
@@ -810,7 +733,7 @@ function renderInline(
       return (
         <em key={index}>
           {node.children.map((c, i) =>
-            renderInline(c, i, onLinkClick, cursor, citationCtx, linkComponent, inlinePlugins),
+            renderInline(c, i, onLinkClick, cursor, citationCtx, linkComponent, inlinePlugins, components),
           )}
         </em>
       );
@@ -818,7 +741,7 @@ function renderInline(
       return (
         <del key={index} {...stylex.props(styles.strikethrough)}>
           {node.children.map((c, i) =>
-            renderInline(c, i, onLinkClick, cursor, citationCtx, linkComponent, inlinePlugins),
+            renderInline(c, i, onLinkClick, cursor, citationCtx, linkComponent, inlinePlugins, components),
           )}
         </del>
       );
@@ -826,16 +749,18 @@ function renderInline(
       // Track code content length for cursor but don't split inside code
       const startOffset = cursor.offset;
       cursor.offset += node.content.length;
+      const InlineCodeComp = components?.inlineCode;
+      const codeEl = InlineCodeComp ? <InlineCodeComp key={index}>{node.content}</InlineCodeComp> : <XDSCode key={index}>{node.content}</XDSCode>;
       if (cursor.active && startOffset >= cursor.boundary) {
         return (
           <span
             key={`fade-code-${index}-${startOffset}`}
             {...stylex.props(streamingStyles.fadeIn)}>
-            <XDSCode>{node.content}</XDSCode>
+            {codeEl}
           </span>
         );
       }
-      return <XDSCode key={index}>{node.content}</XDSCode>;
+      return codeEl;
     }
     case 'link': {
       const safeHref = sanitizeUrl(node.href);
@@ -844,10 +769,14 @@ function renderInline(
         return (
           <span key={index}>
             {node.children.map((c, i) =>
-              renderInline(c, i, onLinkClick, cursor, citationCtx, linkComponent, inlinePlugins),
+              renderInline(c, i, onLinkClick, cursor, citationCtx, linkComponent, inlinePlugins, components),
             )}
           </span>
         );
+      }
+      const LinkComp = components?.link;
+      if (LinkComp) {
+        return (<LinkComp key={index} href={safeHref}>{node.children.map((c, i) => renderInline(c, i, onLinkClick, cursor, citationCtx, linkComponent, inlinePlugins, components))}</LinkComp>);
       }
       const isExternal = safeHref.startsWith('http');
       const handleClick = onLinkClick
@@ -872,7 +801,7 @@ function renderInline(
             : {})}
           {...stylex.props(styles.link)}>
           {node.children.map((c, i) =>
-            renderInline(c, i, onLinkClick, cursor, citationCtx, linkComponent, inlinePlugins),
+            renderInline(c, i, onLinkClick, cursor, citationCtx, linkComponent, inlinePlugins, components),
           )}
         </LinkTag>
       );
@@ -880,6 +809,8 @@ function renderInline(
     case 'image': {
       const safeSrc = sanitizeUrl(node.src);
       if (safeSrc == null) return <span key={index}>[{node.alt}]</span>;
+      const ImageComp = components?.image;
+      if (ImageComp) return <ImageComp key={index} src={safeSrc} alt={node.alt} />;
       return (
         <img
           key={index}
@@ -899,59 +830,12 @@ function renderInline(
         return <span key={index}>[{node.sourceId}]</span>;
       }
       const num = getCitationNumber(citationCtx, node.sourceId);
-      const source = citationCtx.sources[node.sourceId];
-      const title = source?.title ?? node.sourceId;
-      const href = source?.url;
-      const icon = source?.icon;
-      const Tag = href ? 'a' : 'span';
-      const linkProps = href
-        ? {
-            href,
-            target: '_blank' as const,
-            rel: 'noopener noreferrer' as const,
-            title,
-          }
-        : {title};
-
+      const source = citationCtx.sources[node.sourceId] ?? {title: node.sourceId};
       const isNew = cursor.active && cursor.offset >= cursor.boundary;
-      const isNumberMode = citationCtx.style === 'number';
+      const citVariant = citationCtx.style === 'number' ? 'number' : 'label';
+      const CitationComp = components?.citation;
+      const chip = CitationComp ? <CitationComp key={index} source={source} number={num} variant={citVariant} /> : <XDSCitation key={index} source={source} number={num} variant={citVariant} />;
 
-      const chip = isNumberMode ? (
-        <Tag
-          key={index}
-          role="doc-noteref"
-          aria-label={`Citation ${num}: ${title}`}
-          {...linkProps}
-          {...stylex.props(
-            styles.citationNumber,
-            href != null && styles.citationNumberHover,
-          )}>
-          {num}
-        </Tag>
-      ) : (
-        <Tag
-          key={index}
-          role="doc-noteref"
-          aria-label={`Citation ${num}: ${title}`}
-          {...linkProps}
-          {...stylex.props(
-            styles.citation,
-            icon != null && styles.citationWithIcon,
-            href != null && styles.citationHover,
-          )}>
-          {icon && (
-            <span {...stylex.props(styles.citationIconWrap)}>
-              <img
-                src={icon}
-                alt=""
-                aria-hidden="true"
-                {...stylex.props(styles.citationIcon)}
-              />
-            </span>
-          )}
-          <span {...stylex.props(styles.citationLabel)}>{title}</span>
-        </Tag>
-      );
 
       return isNew ? (
         <span
@@ -1024,6 +908,7 @@ function renderBlock(
   contentAlign: 'start' | 'center',
   linkComponent: XDSLinkComponentType = 'a',
   inlinePlugins?: MarkdownInlinePlugin[],
+  components?: Partial<XDSMarkdownComponents>,
 ): React.ReactNode {
   const spacing = getElementSpacing(node, density);
   const isFirst = index === 0;
@@ -1038,6 +923,9 @@ function renderBlock(
         | 4
         | 5
         | 6;
+      const headingChildren = node.children.map((c, i) => renderInline(c, i, onLinkClick, cursor, citationCtx, linkComponent, inlinePlugins, components));
+      const HeadingComp = components?.heading;
+      if (HeadingComp) return <HeadingComp key={index} level={level}>{headingChildren}</HeadingComp>;
       const Tag = `h${level}` as const;
       return (
         <Tag
@@ -1055,13 +943,14 @@ function renderBlock(
             isFirst && styles.noMarginBlockStart,
             isLast && styles.noMarginBlockEnd,
           )}>
-          {node.children.map((c, i) =>
-            renderInline(c, i, onLinkClick, cursor, citationCtx, linkComponent, inlinePlugins),
-          )}
+          {headingChildren}
         </Tag>
       );
     }
-    case 'paragraph':
+    case 'paragraph': {
+      const paraChildren = node.children.map((c, i) => renderInline(c, i, onLinkClick, cursor, citationCtx, linkComponent, inlinePlugins, components));
+      const ParagraphComp = components?.paragraph;
+      if (ParagraphComp) return <ParagraphComp key={index}>{paraChildren}</ParagraphComp>;
       return (
         <p
           key={index}
@@ -1076,14 +965,15 @@ function renderBlock(
             isFirst && styles.noMarginBlockStart,
             isLast && styles.noMarginBlockEnd,
           )}>
-          {node.children.map((c, i) =>
-            renderInline(c, i, onLinkClick, cursor, citationCtx, linkComponent, inlinePlugins),
-          )}
+          {paraChildren}
         </p>
       );
+    }
     case 'codeblock': {
       // Track codeblock content in cursor for accurate character counting
       cursor.offset += node.content.length;
+      const CodeBlockComp = components?.code;
+      if (CodeBlockComp) return <CodeBlockComp key={index} code={node.content} language={node.language} />;
       return (
         <div
           key={index}
@@ -1109,7 +999,12 @@ function renderBlock(
         </div>
       );
     }
-    case 'blockquote':
+    case 'blockquote': {
+      const BlockquoteComp = components?.blockquote;
+      if (BlockquoteComp) {
+        const bqC = node.children.map((c,i) => renderBlock(c,i,node.children.length,density,headingLevelStart,onLinkClick,cursor,citationCtx,contentWidthValue,contentAlign,linkComponent,inlinePlugins,components));
+        return <BlockquoteComp key={index}>{bqC}</BlockquoteComp>;
+      }
       return (
         <blockquote
           key={index}
@@ -1139,10 +1034,12 @@ function renderBlock(
               contentAlign,
               linkComponent,
               inlinePlugins,
+            components,
             ),
           )}
         </blockquote>
       );
+    }
     case 'list': {
       // Detect task lists: all items have a checked state
       const isTaskList =
@@ -1182,7 +1079,7 @@ function renderBlock(
                 const label = isInline ? (
                   <>
                     {firstChild.children.map((c, j) =>
-                      renderInline(c, j, onLinkClick, cursor, citationCtx, linkComponent, inlinePlugins),
+                      renderInline(c, j, onLinkClick, cursor, citationCtx, linkComponent, inlinePlugins, components),
                     )}
                   </>
                 ) : (
@@ -1201,6 +1098,7 @@ function renderBlock(
                         contentAlign,
                         linkComponent,
                         inlinePlugins,
+                      components,
                       ),
                     )}
                   </>
@@ -1263,7 +1161,7 @@ function renderBlock(
               const label = isInline ? (
                 <>
                   {firstChild.children.map((c, j) =>
-                    renderInline(c, j, onLinkClick, cursor, citationCtx, linkComponent, inlinePlugins),
+                    renderInline(c, j, onLinkClick, cursor, citationCtx, linkComponent, inlinePlugins, components),
                   )}
                 </>
               ) : (
@@ -1282,6 +1180,7 @@ function renderBlock(
                       contentAlign,
                       linkComponent,
                       inlinePlugins,
+                    components,
                     ),
                   )}
                 </>
@@ -1340,7 +1239,7 @@ function renderBlock(
                       alignStyle(node.alignments[i]),
                     )}>
                     {h.children.map((c, j) =>
-                      renderInline(c, j, onLinkClick, cursor, citationCtx, linkComponent, inlinePlugins),
+                      renderInline(c, j, onLinkClick, cursor, citationCtx, linkComponent, inlinePlugins, components),
                     )}
                   </th>
                 ))}
@@ -1358,7 +1257,7 @@ function renderBlock(
                       alignStyle(node.alignments[j]),
                     )}>
                     {cell.children.map((c, k) =>
-                      renderInline(c, k, onLinkClick, cursor, citationCtx, linkComponent, inlinePlugins),
+                      renderInline(c, k, onLinkClick, cursor, citationCtx, linkComponent, inlinePlugins, components),
                     )}
                   </td>
                 ));
@@ -1375,7 +1274,9 @@ function renderBlock(
         </div>
       );
     }
-    case 'hr':
+    case 'hr': {
+      const HrComp = components?.hr;
+      if (HrComp) return <HrComp key={index} />;
       return (
         <hr
           key={index}
@@ -1387,6 +1288,7 @@ function renderBlock(
           )}
         />
       );
+    }
     case 'image': {
       const safeSrc = sanitizeUrl(node.src);
       if (safeSrc == null) {
@@ -1443,6 +1345,7 @@ export function XDSMarkdown({
   citationStyle = 'label',
   contentWidth = 680,
   contentAlign = 'start',
+  components,
   inlinePlugins,
   xstyle,
   className,
@@ -1525,6 +1428,7 @@ export function XDSMarkdown({
           contentAlign,
           LinkComponent,
           inlinePlugins,
+        components,
         ),
       )}
     </div>

--- a/packages/core/src/Markdown/index.ts
+++ b/packages/core/src/Markdown/index.ts
@@ -7,7 +7,7 @@
  */
 
 export {XDSMarkdown} from './XDSMarkdown';
-export type {XDSMarkdownProps, XDSMarkdownSource, MarkdownInlinePlugin} from './XDSMarkdown';
+export type {XDSMarkdownProps, XDSMarkdownSource, XDSMarkdownComponents, MarkdownInlinePlugin} from './XDSMarkdown';
 
 export {
   parseMarkdown,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -30,6 +30,7 @@ export * from './CodeBlock';
 export * from './CommandPalette';
 export * from './Chat';
 export * from './Markdown';
+export * from './Citation';
 export * from './CheckboxInput';
 export * from './CheckboxList';
 export * from './Collapsible';


### PR DESCRIPTION
## Summary

Adds a `components` prop to `XDSPowerSearch` that allows consumers to override how specific filter types render as token chips and how their values are edited — without forking or wrapping the entire component.

This follows the same decomposition pattern as `XDSMarkdown`'s `components` prop (#2073).

## Changes

- **New `XDSPowerSearchComponents` type** — a partial map from `OperatorValue` type names to override entries
- **New `PowerSearchComponentOverride` interface** — each entry can provide a `Token` (chip renderer) and/or `Editor` (value editor)
- **New `components` prop on `XDSPowerSearch`** — overrides fall through to XDS defaults for unspecified types
- **Wired through** to `PowerSearchEditPopover` → `PowerSearchValueEditor`

## Usage

```tsx
import type { XDSPowerSearchComponents } from "@xds/core/PowerSearch";

const components: XDSPowerSearchComponents = {
  date_absolute: {
    Token: ({ filterValue }) => <span>{myFormatDate(filterValue)}</span>,
    Editor: ({ filterValue, onChange }) => (
      <MyCustomDatePicker value={filterValue} onChange={onChange} />
    ),
  },
  enum: {
    // Only override the editor — token uses XDS default
    Editor: ({ operatorValue, filterValue, onChange }) => (
      <MyRadioGroup options={operatorValue.values} ... />
    ),
  },
};

<XDSPowerSearch config={config} filters={filters} onChange={setFilters} components={components} />
```

## New exported types

- `XDSPowerSearchComponents`
- `PowerSearchComponentOverride`
- `PowerSearchTokenRendererProps`
- `PowerSearchEditorProps`