### PR TITLE
fix(docsite): playground circular JSON error on components with context props

### DIFF
--- a/apps/docsite/src/components/component-detail/InteractivePreview.tsx
+++ b/apps/docsite/src/components/component-detail/InteractivePreview.tsx
@@ -43,8 +43,7 @@ class PreviewErrorBoundary extends Component<
   componentDidUpdate(prevProps: {resetKeys: unknown[]}) {
     if (
       this.state.error &&
-      JSON.stringify(prevProps.resetKeys) !==
-        JSON.stringify(this.props.resetKeys)
+      prevProps.resetKeys.some((k, i) => !Object.is(k, this.props.resetKeys[i]))
     ) {
       this.setState({error: null});
     }
@@ -195,7 +194,7 @@ export function useInteractiveState(
   const reset = useCallback(() => setState(initialState), [initialState]);
 
   const isDirty = useMemo(
-    () => JSON.stringify(state) !== JSON.stringify(initialState),
+    () => Object.keys(state).some(k => !Object.is(state[k], initialState[k])),
     [state, initialState],
   );
 
@@ -275,7 +274,7 @@ export function InteractivePreviewStage({
             width: '100%',
             padding: 'var(--spacing-4)',
           }}>
-          <PreviewErrorBoundary resetKeys={[Component, JSON.stringify(state)]}>
+          <PreviewErrorBoundary resetKeys={[Component, state]}>
             {createElement(Component, state)}
           </PreviewErrorBoundary>
         </XDSCenter>


### PR DESCRIPTION
## Summary
- Replace `JSON.stringify` state comparisons in `InteractivePreview.tsx` with shallow `Object.is` checks
- Fixes "Converting circular structure to JSON" error on components whose playground defaults include non-serializable values (e.g. `onOpenChange` on Dialog resolves to a React context object with circular `Provider` references)
- Three call sites changed:
  - **`isDirty`**: compare each state key against `initialState` with `Object.is`
  - **`resetKeys`**: pass `[Component, state]` directly (referential equality)
  - **`componentDidUpdate`**: compare `resetKeys` elements with `Object.is`

## Why this is safe
Playground state is a flat `Record<string, unknown>` — values are primitives, React elements, or `undefined`. `setProp` always spreads a new object (`{...prev, [propName]: value}`), so referential equality correctly detects every change. React bails out on no-op `setState` calls, preventing unnecessary re-renders.

## Test plan
- [ ] Open http://localhost:3000/components/Dialog?tab=playground — no circular JSON error
- [ ] Toggle props in playground knobs — `isDirty` and reset button work correctly
- [ ] Trigger a render error in playground — error boundary resets when props change
- [ ] Open http://localhost:3000/components/AlertDialog?tab=playground — no error