### PR TITLE
feat(docsite): switch to StyleX source build via @xds/build

### DIFF
--- a/apps/docsite/babel.config.js
+++ b/apps/docsite/babel.config.js
@@ -1,27 +1,3 @@
-/* global module, require, process, __dirname */
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const path = require('path');
-
-const dev = process.env.NODE_ENV !== 'production';
-
-module.exports = {
-  presets: ['next/babel'],
-  plugins: [
-    [
-      '@stylexjs/babel-plugin',
-      {
-        dev,
-        runtimeInjection: false,
-        enableInlinedConditionalMerge: true,
-        treeshakeCompensation: true,
-        aliases: {
-          '@/*': [path.join(__dirname, '*')],
-        },
-        classNamePrefix: 'p',
-        unstable_moduleResolution: {
-          type: 'commonJS',
-        },
-      },
-    ],
-  ],
-};
+/* global module, __dirname */
+const {babel} = require('@xds/build');
+module.exports = babel(__dirname);

--- a/apps/docsite/next.config.mjs
+++ b/apps/docsite/next.config.mjs
@@ -1,11 +1,13 @@
+import {withXDS} from '@xds/build/next';
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  webpack: (config) => {
-    // Force ESM resolution for @xds/core — the CJS dist has a bug where
-    // "use client" appears after Object.defineProperty(exports, "__esModule").
-    config.resolve.conditionNames = ['import', 'module', 'require', 'default'];
-    return config;
-  },
+  transpilePackages: [
+    '@xds/theme-chocolate',
+    '@xds/theme-gothic',
+    '@xds/theme-matcha',
+    '@xds/theme-stone',
+  ],
 };
 
-export default nextConfig;
+export default withXDS(nextConfig);

--- a/apps/docsite/package.json
+++ b/apps/docsite/package.json
@@ -42,7 +42,8 @@
     "@types/react-dom": "^19.2.3",
     "autoprefixer": "^10.4.0",
     "typescript": "^6.0.3",
-    "vitest": "^3.2.1"
+    "vitest": "^3.2.1",
+    "@xds/build": "*"
   },
   "browserslist": [
     "last 1 Chrome version"

--- a/apps/docsite/postcss.config.js
+++ b/apps/docsite/postcss.config.js
@@ -1,22 +1,9 @@
-/* global module, require */
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const babelConfig = require('./babel.config');
+/* global module, __dirname */
+const path = require('path');
+const {postcss} = require('@xds/build');
 
-module.exports = {
-  plugins: {
-    '@stylexjs/postcss-plugin': {
-      include: ['src/**/*.{js,jsx,ts,tsx}'],
-      babelConfig: {
-        babelrc: false,
-        parserOpts: {
-          plugins: ['typescript', 'jsx'],
-        },
-        plugins: babelConfig.plugins,
-      },
-      useCSSLayers: {
-        before: ['reset', 'xds-base', 'xds-theme'],
-      },
-    },
-    autoprefixer: {},
-  },
-};
+const rootDir = path.resolve(__dirname, '../..');
+
+module.exports = postcss(rootDir, {
+  appDir: path.relative(rootDir, path.resolve(__dirname, 'src')),
+});

--- a/apps/docsite/src/app/globals.css
+++ b/apps/docsite/src/app/globals.css
@@ -1,5 +1,5 @@
+@import "./layers.css";
 @import "@xds/core/reset.css";
-@import "@xds/core/xds.css";
 @import "@xds/theme-default/theme.css";
 @import "@xds/theme-neutral/theme.css";
 @import "@xds/theme-chocolate/theme.css";
@@ -8,8 +8,6 @@
 @import "@xds/theme-matcha/theme.css";
 @import "@xds/theme-stone/theme.css";
 
-/* StyleX app styles injected here. useCSSLayers.before declares
-   reset, xds-base, xds-theme so product styles always win. */
 @stylex;
 
 /* Translucent top nav — frosted glass effect */

--- a/apps/docsite/src/app/layers.css
+++ b/apps/docsite/src/app/layers.css
@@ -1,0 +1,5 @@
+/* Layer order declaration — must be the first CSS in the bundle.
+   Separate file because webpack hoists @import content above inline
+   CSS, so an inline @layer statement in globals.css would appear
+   after reset.css and theme.css content in the output. */
+@layer reset, xds-base, xds-theme, product;


### PR DESCRIPTION
## What

Switch the docsite from dist-based styling (importing pre-built `xds.css`) to source compilation using `@xds/build`. Mirrors the approach in `apps/example-nextjs-source`.

## Why

- **Tree-shaken CSS** — only styles for components actually imported (~22KB vs ~77KB)
- **Independent layer separation** — `reset < xds-base < xds-theme < product` with separate class prefixes (`xds` for library, `x` for product)
- **No pre-build step** — docsite dev no longer needs `yarn build` in core first
- **Consistent with sandbox** — both apps now use the same `@xds/build` approach

## Changes

| File | Change |
|------|--------|
| `next.config.mjs` | Use `withXDS()` from `@xds/build/next` (adds transpilePackages + source conditionNames) |
| `babel.config.js` | Use `@xds/build` babel config |
| `postcss.config.js` | Use `@xds/build` postcss config (dual-pass library/product compilation) |
| `globals.css` | Remove `xds.css` import, add `layers.css` + `@stylex` directive |
| `layers.css` | New — declares CSS layer order in separate file (webpack hoisting) |
| `package.json` | Add `@xds/build` devDependency |

## Testing

- [x] `yarn dev` in docsite renders correctly
- [ ] CSS layers visible in devtools (reset, xds-base, xds-theme, product)
- [x] Theme switching still works
- [x] Build succeeds (`yarn build`)
