### PR TITLE
fix(core): add xdsClassName to ProgressBar track for theme targeting

### DIFF
--- a/packages/core/src/ProgressBar/XDSProgressBar.tsx
+++ b/packages/core/src/ProgressBar/XDSProgressBar.tsx
@@ -298,7 +298,10 @@ export function XDSProgressBar({
         aria-valuemax={isIndeterminate ? undefined : max}
         aria-labelledby={labelId}
         aria-valuetext={isIndeterminate ? undefined : valueText}
-        {...stylex.props(styles.track)}>
+        {...mergeProps(
+          xdsClassName('progressbar-track'),
+          stylex.props(styles.track),
+        )}>
         {isIndeterminate ? (
           <div
             {...mergeProps(


### PR DESCRIPTION
## Component Audit — Hardening Issues (2026-05-07)

### Components Audited
- **Popover** — clean (all 10 checks pass)
- **PowerSearch** — clean (all 10 checks pass)
- **ProgressBar** — 1 issue found (fixed below)
- **RadioList** — clean (all 10 checks pass)
- **Selector** — clean (all 10 checks pass)

### Findings

| Component | File | Issue | Category |
|-----------|------|-------|----------|
| ProgressBar | XDSProgressBar.tsx:301 | Track element has visual styles but no xdsClassName for theme targeting | missing-classname |

### Fix

Added `xdsClassName('progressbar-track')` via `mergeProps` on the track `<div>`. This allows themes to target the track element (background, border-radius, height) independently from the container and fill elements, which already have their own classNames.

---

*Night Watch — Component Auditor*