### PR TITLE
feat(theme): prototype stylex theme resolution via $$css + @scope

### DIFF
--- a/apps/sandbox/src/app/(sandbox)/pages/stylex-theme-test/page.tsx
+++ b/apps/sandbox/src/app/(sandbox)/pages/stylex-theme-test/page.tsx
@@ -1,0 +1,314 @@
+"use client";
+
+/**
+ * StyleX Theme Prototype — Test Page
+ *
+ * Validates:
+ * 1. Base < theme (@scope proximity beats unscoped)
+ * 2. Theme nesting — inner scope wins
+ * 3. Theme < product override (stylex.props last-arg strips theme classes)
+ */
+
+import React from "react";
+import * as stylex from "@stylexjs/stylex";
+import "./themes.css";
+
+// =============================================================================
+// THEME REGISTRY (inline for self-contained prototype)
+// =============================================================================
+
+type StyleXCSSObject = { $$css: true; [property: string]: string | true };
+
+const registry = new Map<
+  string,
+  Map<string, Record<string, StyleXCSSObject>>
+>();
+
+function registerTheme(
+  themeName: string,
+  components: Record<string, Record<string, StyleXCSSObject>>
+) {
+  const themeMap = new Map<string, Record<string, StyleXCSSObject>>();
+  for (const [component, styles] of Object.entries(components)) {
+    themeMap.set(component, styles);
+  }
+  registry.set(themeName, themeMap);
+}
+
+function getThemeStyles(
+  component: string
+): Record<string, StyleXCSSObject> | null {
+  const merged: Record<string, Record<string, string>> = {};
+
+  for (const [, themeMap] of registry) {
+    const componentStyles = themeMap.get(component);
+    if (!componentStyles) continue;
+    for (const [part, cssObj] of Object.entries(componentStyles)) {
+      if (!merged[part]) merged[part] = {};
+      for (const [prop, value] of Object.entries(cssObj)) {
+        if (prop === "$$css" || typeof value !== "string") continue;
+        merged[part][prop] = merged[part][prop]
+          ? `${merged[part][prop]} ${value}`
+          : value;
+      }
+    }
+  }
+
+  if (Object.keys(merged).length === 0) return null;
+
+  const result: Record<string, StyleXCSSObject> = {};
+  for (const [part, props] of Object.entries(merged)) {
+    result[part] = { $$css: true, ...props } as StyleXCSSObject;
+  }
+  return result;
+}
+
+// =============================================================================
+// THEME REGISTRATIONS (simulates build output IIFEs)
+// =============================================================================
+
+registerTheme("brutalist", {
+  button: {
+    root: {
+      $$css: true,
+      borderRadius: "xds-br-brutalist-btn",
+      textTransform: "xds-tt-brutalist-btn",
+      letterSpacing: "xds-ls-brutalist-btn",
+      fontWeight: "xds-fw-brutalist-btn",
+    },
+  },
+});
+
+registerTheme("neutral", {
+  button: {
+    root: {
+      $$css: true,
+      borderRadius: "xds-br-neutral-btn",
+      fontWeight: "xds-fw-neutral-btn",
+    },
+  },
+});
+
+// =============================================================================
+// PROTOTYPE BUTTON
+// =============================================================================
+
+const baseStyles = stylex.create({
+  root: {
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    padding: "8px 16px",
+    border: "none",
+    borderRadius: "6px",
+    fontSize: "14px",
+    fontWeight: "500",
+    cursor: "pointer",
+    backgroundColor: "#e4e4e7",
+    color: "#18181b",
+    fontFamily: "system-ui, sans-serif",
+  },
+});
+
+const productOverrides = stylex.create({
+  customRadius: {
+    borderRadius: "20px",
+  },
+  customWeight: {
+    fontWeight: "300",
+  },
+});
+
+function DemoButton({
+  label,
+  xstyle,
+}: {
+  label: string;
+  xstyle?: stylex.StyleXStyles;
+}) {
+  const themes = getThemeStyles("button");
+
+  // The key line: base < theme < override
+  return (
+    <button {...stylex.props(baseStyles.root, themes?.root, xstyle)}>
+      {label}
+    </button>
+  );
+}
+
+// =============================================================================
+// PAGE
+// =============================================================================
+
+const s = stylex.create({
+  page: {
+    padding: "32px",
+    fontFamily: "system-ui, sans-serif",
+    maxWidth: "800px",
+    margin: "0 auto",
+  },
+  section: {
+    marginBottom: "24px",
+    padding: "24px",
+    borderRadius: "8px",
+    border: "1px solid #e4e4e7",
+  },
+  title: {
+    fontSize: "14px",
+    fontWeight: "600",
+    marginBottom: "8px",
+  },
+  desc: {
+    fontSize: "13px",
+    color: "#71717a",
+    marginBottom: "16px",
+    lineHeight: "1.5",
+  },
+  row: {
+    display: "flex",
+    gap: "12px",
+    alignItems: "center",
+    flexWrap: "wrap",
+  },
+  nested: {
+    padding: "16px",
+    borderRadius: "6px",
+    border: "1px dashed #a1a1aa",
+    marginTop: "12px",
+  },
+  label: {
+    fontSize: "11px",
+    textTransform: "uppercase",
+    letterSpacing: "0.05em",
+    color: "#a1a1aa",
+    marginBottom: "8px",
+    fontWeight: "600",
+  },
+  h1: {
+    fontSize: "24px",
+    fontWeight: "700",
+    marginBottom: "4px",
+  },
+  subtitle: {
+    fontSize: "14px",
+    color: "#71717a",
+    marginBottom: "32px",
+  },
+  howItWorks: {
+    fontSize: "13px",
+    color: "#52525b",
+    lineHeight: "1.8",
+  },
+});
+
+export default function StyleXThemeTestPage() {
+  return (
+    <div {...stylex.props(s.page)}>
+      <h1 {...stylex.props(s.h1)}>StyleX Theme Resolution Prototype</h1>
+      <p {...stylex.props(s.subtitle)}>
+        base &lt; theme (@scope) &lt; override (stylex merge)
+      </p>
+
+      {/* Test 1: Theme overrides base */}
+      <div {...stylex.props(s.section)}>
+        <div {...stylex.props(s.title)}>Test 1: Theme overrides base</div>
+        <p {...stylex.props(s.desc)}>
+          Base: border-radius 6px, font-weight 500. Brutalist theme overrides to
+          9999px / 800 via @scope proximity (scoped beats unscoped).
+        </p>
+        <div data-xds-theme="brutalist">
+          <div {...stylex.props(s.label)}>scope: brutalist</div>
+          <div {...stylex.props(s.row)}>
+            <DemoButton label="Brutalist Button" />
+          </div>
+        </div>
+      </div>
+
+      {/* Test 2: Nested themes */}
+      <div {...stylex.props(s.section)}>
+        <div {...stylex.props(s.title)}>
+          Test 2: Nested themes — inner scope wins
+        </div>
+        <p {...stylex.props(s.desc)}>
+          Outer: brutalist (border-radius 9999px, font-weight 800). Inner:
+          neutral (border-radius 8px, font-weight 600). Inner button should show
+          neutral values.
+        </p>
+        <div data-xds-theme="brutalist">
+          <div {...stylex.props(s.label)}>outer: brutalist</div>
+          <div {...stylex.props(s.row)}>
+            <DemoButton label="Outer (brutalist)" />
+          </div>
+          <div data-xds-theme="neutral" {...stylex.props(s.nested)}>
+            <div {...stylex.props(s.label)}>inner: neutral</div>
+            <div {...stylex.props(s.row)}>
+              <DemoButton label="Inner (neutral)" />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Test 3: Product override beats theme */}
+      <div {...stylex.props(s.section)}>
+        <div {...stylex.props(s.title)}>
+          Test 3: Product override beats theme
+        </div>
+        <p {...stylex.props(s.desc)}>
+          Brutalist sets border-radius: 9999px. Product xstyle override sets
+          20px. stylex.props last-arg strips ALL theme border-radius classes.
+        </p>
+        <div data-xds-theme="brutalist">
+          <div {...stylex.props(s.label)}>brutalist + xstyle override</div>
+          <div {...stylex.props(s.row)}>
+            <DemoButton label="No override" />
+            <DemoButton
+              label="xstyle: borderRadius 20px"
+              xstyle={productOverrides.customRadius}
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Test 4: Partial override */}
+      <div {...stylex.props(s.section)}>
+        <div {...stylex.props(s.title)}>
+          Test 4: Partial override — only strips overridden property
+        </div>
+        <p {...stylex.props(s.desc)}>
+          Brutalist sets borderRadius (9999px) + fontWeight (800). Override only
+          sets fontWeight: 300. Radius should remain 9999px from theme.
+        </p>
+        <div data-xds-theme="brutalist">
+          <div {...stylex.props(s.label)}>
+            brutalist + partial xstyle (fontWeight only)
+          </div>
+          <div {...stylex.props(s.row)}>
+            <DemoButton label="No override" />
+            <DemoButton
+              label="fontWeight: 300 (radius stays)"
+              xstyle={productOverrides.customWeight}
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* How it works */}
+      <div {...stylex.props(s.section)}>
+        <div {...stylex.props(s.title)}>How it works</div>
+        <div {...stylex.props(s.howItWorks)}>
+          1. Theme build generates $$css objects + CSS with @scope wrappers
+          <br />
+          2. Theme IIFE registers into global registry at import time
+          <br />
+          3. Component calls getThemeStyles — gets merged $$css with ALL theme
+          classes per property
+          <br />
+          4. Renders: stylex.props(base, themes?.root, xstyle)
+          <br />
+          5. CSS @scope proximity picks active theme; JS last-arg strips on
+          override
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/sandbox/src/app/(sandbox)/pages/stylex-theme-test/page.tsx
+++ b/apps/sandbox/src/app/(sandbox)/pages/stylex-theme-test/page.tsx
@@ -129,8 +129,15 @@ function DemoButton({
   const themes = getThemeStyles("button");
 
   // The key line: base < theme < override
+  // Cast $$css object — runtime compatible with styleq, type system doesn't know that
   return (
-    <button {...stylex.props(baseStyles.root, themes?.root, xstyle)}>
+    <button
+      {...stylex.props(
+        baseStyles.root,
+        themes?.root as unknown as stylex.StyleXStyles,
+        xstyle
+      )}
+    >
       {label}
     </button>
   );

--- a/apps/sandbox/src/app/(sandbox)/pages/stylex-theme-test/themes.css
+++ b/apps/sandbox/src/app/(sandbox)/pages/stylex-theme-test/themes.css
@@ -1,0 +1,13 @@
+/* Generated StyleX theme atoms with @scope wrappers */
+
+@scope ([data-xds-theme="brutalist"]) {
+  .xds-br-brutalist-btn { border-radius: 9999px; }
+  .xds-tt-brutalist-btn { text-transform: uppercase; }
+  .xds-ls-brutalist-btn { letter-spacing: 0.1em; }
+  .xds-fw-brutalist-btn { font-weight: 800; }
+}
+
+@scope ([data-xds-theme="neutral"]) {
+  .xds-br-neutral-btn { border-radius: 8px; }
+  .xds-fw-neutral-btn { font-weight: 600; }
+}

--- a/apps/sandbox/src/app/sandboxPages.ts
+++ b/apps/sandbox/src/app/sandboxPages.ts
@@ -144,6 +144,12 @@ export const categories: SandboxCategory[] = [
         description:
           'Generate and explore color palettes from an accent color or image',
       },
+      {
+        name: 'StyleX Theme Prototype',
+        href: '/pages/stylex-theme-test/',
+        description:
+          'Prototype: theme resolution via $$css objects + @scope (base < theme < override)',
+      },
     ],
   },
 ];

--- a/packages/core/src/theme/stylex-themes/README.md
+++ b/packages/core/src/theme/stylex-themes/README.md
@@ -1,0 +1,24 @@
+# StyleX Theme Resolution Prototype
+
+## Problem
+
+```
+Desired:  reset > base > theme > product overrides
+Actual:   reset > (base + overrides via StyleX) > theme (CSS, always wins)
+```
+
+## Solution
+
+Generate StyleX-compatible `$$css` objects from theme configs. Components
+merge via `stylex.props()` — last-arg-wins for overrides, `@scope` for nesting.
+
+| Relationship       | Mechanism                                    |
+|-------------------|----------------------------------------------|
+| base < theme      | @scope proximity (scoped beats root-scoped)  |
+| theme nesting     | @scope proximity (inner ancestor > outer)    |
+| theme < override  | stylex.props merge (last arg strips earlier) |
+
+### styleq multi-class handling
+
+`$$css` with `"classA classB"` for same property — styleq treats as opaque
+string. Override strips entire bundle. No override = all stay, @scope picks.

--- a/packages/core/src/theme/stylex-themes/registry.ts
+++ b/packages/core/src/theme/stylex-themes/registry.ts
@@ -1,0 +1,58 @@
+/**
+ * StyleX Theme Registry (Prototype)
+ *
+ * Global registry for compiled StyleX-compatible theme objects.
+ * Resolution: all theme classes on element, @scope picks active,
+ * stylex.props last-arg-wins strips on override.
+ */
+
+export type StyleXCSSObject = {
+  $$css: true;
+  [property: string]: string | true;
+};
+
+export type ThemeComponentStyles = Record<string, StyleXCSSObject>;
+
+const registry = new Map<string, Map<string, ThemeComponentStyles>>();
+
+export function registerTheme(
+  themeName: string,
+  components: Record<string, ThemeComponentStyles>,
+): void {
+  const themeMap = new Map<string, ThemeComponentStyles>();
+  for (const [component, styles] of Object.entries(components)) {
+    themeMap.set(component, styles);
+  }
+  registry.set(themeName, themeMap);
+}
+
+export function getThemeStyles(component: string): ThemeComponentStyles | null {
+  const merged: Record<string, Record<string, string>> = {};
+
+  for (const [, themeMap] of registry) {
+    const componentStyles = themeMap.get(component);
+    if (!componentStyles) continue;
+    for (const [part, cssObj] of Object.entries(componentStyles)) {
+      if (!merged[part]) merged[part] = {};
+      for (const [prop, value] of Object.entries(cssObj)) {
+        if (prop === '$$css') continue;
+        if (typeof value !== 'string') continue;
+        merged[part][prop] = merged[part][prop]
+          ? `${merged[part][prop]} ${value}`
+          : value;
+      }
+    }
+  }
+
+  if (Object.keys(merged).length === 0) return null;
+
+  const result: ThemeComponentStyles = {};
+  for (const [part, props] of Object.entries(merged)) {
+    result[part] = {$$css: true, ...props} as StyleXCSSObject;
+  }
+  return result;
+}
+
+export function clearThemeRegistry(): void {
+  registry.clear();
+}

--- a/packages/core/src/theme/stylex-themes/theme-brutalist.ts
+++ b/packages/core/src/theme/stylex-themes/theme-brutalist.ts
@@ -1,0 +1,13 @@
+import {registerTheme} from './registry';
+
+registerTheme('brutalist', {
+  button: {
+    root: {
+      $$css: true,
+      borderRadius: 'xds-br-brutalist-btn',
+      textTransform: 'xds-tt-brutalist-btn',
+      letterSpacing: 'xds-ls-brutalist-btn',
+      fontWeight: 'xds-fw-brutalist-btn',
+    },
+  },
+});

--- a/packages/core/src/theme/stylex-themes/theme-neutral.ts
+++ b/packages/core/src/theme/stylex-themes/theme-neutral.ts
@@ -1,0 +1,11 @@
+import {registerTheme} from './registry';
+
+registerTheme('neutral', {
+  button: {
+    root: {
+      $$css: true,
+      borderRadius: 'xds-br-neutral-btn',
+      fontWeight: 'xds-fw-neutral-btn',
+    },
+  },
+});

--- a/packages/core/src/theme/stylex-themes/themes.css
+++ b/packages/core/src/theme/stylex-themes/themes.css
@@ -1,0 +1,13 @@
+/* Generated StyleX theme atoms with @scope wrappers */
+
+@scope ([data-xds-theme="brutalist"]) {
+  .xds-br-brutalist-btn { border-radius: 9999px; }
+  .xds-tt-brutalist-btn { text-transform: uppercase; }
+  .xds-ls-brutalist-btn { letter-spacing: 0.1em; }
+  .xds-fw-brutalist-btn { font-weight: 800; }
+}
+
+@scope ([data-xds-theme="neutral"]) {
+  .xds-br-neutral-btn { border-radius: 8px; }
+  .xds-fw-neutral-btn { font-weight: 600; }
+}


### PR DESCRIPTION
## What

Proof-of-concept for a new theme resolution strategy that eliminates the specificity tension between StyleX-compiled base/override styles and CSS-based themes.

### Problem

```
Desired:  reset > base > theme > product overrides
Actual:   reset > (base + overrides via StyleX) > theme (CSS, always wins)
```

Product overrides can never beat theme without layer hacks because theme CSS sits outside StyleX's control.

### Solution

Generate StyleX-compatible `$$css` objects from theme configs. Components merge theme styles via `stylex.props()` — last-arg-wins handles override precedence while `@scope` handles theme nesting.

```tsx
function Button({ xstyle }) {
  const themes = getThemeStyles('button');
  return <button {...stylex.props(styles.root, themes?.root, xstyle)} />;
}
```

### Resolution Table

| Relationship | Mechanism |
|---|---|
| base < theme | @scope proximity (scoped beats root-scoped) |
| theme nesting | @scope proximity (inner ancestor > outer) |
| theme < override | stylex.props merge (last arg strips earlier) |

### Key Insight: styleq multi-class handling

`stylex.props` uses `styleq` internally. When a `$$css` object has multiple classes for the same property (`"classA classB"`), styleq treats it as an opaque string — all-or-nothing:

- **Override exists:** entire bundle stripped, override wins
- **No override:** all classes stay on element, @scope picks winner

### Test Cases (sandbox page)

1. Theme overrides base styles
2. Nested themes — inner scope wins
3. Product overrides beat theme
4. Partial overrides only strip targeted properties

### Files

- `packages/core/src/theme/stylex-themes/` — Registry + theme registrations
- `apps/sandbox/.../stylex-theme-test/` — Self-contained test page
