### PR TITLE
fix(docsite): wrap PackageStubPage in XDSSection for consistent padding

### DIFF
--- a/apps/docsite/src/app/(docs)/packages/[name]/page.tsx
+++ b/apps/docsite/src/app/(docs)/packages/[name]/page.tsx
@@ -102,12 +102,14 @@ export default async function PackagePage({
 
   if (!isComponentPkg) {
     return (
-      <PackageStubPage
-        name={pkg.name}
-        version={pkg.version}
-        readme={pkg.readme}
-        installSteps={getInstallSteps(pkg.name)}
-      />
+      <XDSSection maxWidth="lg" padding={6}>
+        <PackageStubPage
+          name={pkg.name}
+          version={pkg.version}
+          readme={pkg.readme}
+          installSteps={getInstallSteps(pkg.name)}
+        />
+      </XDSSection>
     );
   }
 


### PR DESCRIPTION
The CLI package page (and other non-core, non-theme packages) was rendered without the `<XDSSection>` wrapper, causing content to go edge-to-edge. Theme and core package pages already had this wrapper.

**Before:** `PackageStubPage` returned directly — no outer padding
**After:** Wrapped in `<XDSSection maxWidth="lg" padding={6}>` matching the pattern used by theme and core pages