### PR TITLE
docs(Table): demonstrate block bleed leak through wrapper divs

### DIFF
--- a/apps/storybook/stories/Table.stories.tsx
+++ b/apps/storybook/stories/Table.stories.tsx
@@ -1059,3 +1059,98 @@ export const PropsTablePattern: Story = {
     );
   },
 };
+
+// =============================================================================
+// Block Bleed Leak Demonstration
+// =============================================================================
+
+/**
+ * ## Bug: Block bleed leaks through wrapper divs
+ *
+ * The table's block bleed uses `:first-child` / `:last-child` with
+ * `--container-padding-block-start/end` CSS custom properties. These vars
+ * cascade from the Card to all descendants via CSS inheritance. When the
+ * table is `:first-child` of a non-container wrapper (like VStack or a plain
+ * div), it incorrectly applies negative block margins using the Card's values.
+ *
+ * **Expected:** Table should only apply block bleed when it is a direct child
+ * of the actual container that sets the padding vars.
+ *
+ * **Actual:** Table bleeds through any intermediate wrapper that inherits the
+ * vars, causing unexpected negative margins that pull the table outside its
+ * parent boundaries.
+ */
+export const BlockBleedLeak: Story = {
+  decorators: [
+    Story => (
+      <div {...stylex.props(containerStoryStyles.pageWrapper)}>
+        <Story />
+      </div>
+    ),
+  ],
+  render: () => (
+    <div {...stylex.props(containerStoryStyles.storyWrapper)}>
+      {/* ✅ Correct: table is direct child of Card */}
+      <div>
+        <h4 {...stylex.props(containerStoryStyles.heading)}>
+          ✅ Direct child — bleed is correct
+        </h4>
+        <XDSCard width={400}>
+          <XDSTable data={users.slice(0, 3)} columns={simpleColumns} />
+        </XDSCard>
+      </div>
+
+      {/* ❌ Bug: table inside a wrapper div inherits Card's block vars */}
+      <div>
+        <h4 {...stylex.props(containerStoryStyles.heading)}>
+          ❌ Wrapped in plain div — leaks block bleed
+        </h4>
+        <XDSCard width={400}>
+          <div>
+            <XDSTable data={users.slice(0, 3)} columns={simpleColumns} />
+          </div>
+        </XDSCard>
+      </div>
+
+      {/* ❌ Bug: table inside VStack with heading above */}
+      <div>
+        <h4 {...stylex.props(containerStoryStyles.heading)}>
+          ❌ VStack with heading — table is not first-child
+        </h4>
+        <XDSCard width={400}>
+          <XDSVStack gap={3}>
+            <XDSHeading level={3}>Team Members</XDSHeading>
+            <XDSTable data={users.slice(0, 3)} columns={simpleColumns} />
+          </XDSVStack>
+        </XDSCard>
+      </div>
+
+      {/* ❌ Bug: table is last-child of VStack, leaks bottom bleed */}
+      <div>
+        <h4 {...stylex.props(containerStoryStyles.heading)}>
+          ❌ VStack — table is last-child, leaks bottom
+        </h4>
+        <XDSCard width={400}>
+          <XDSVStack gap={3}>
+            <XDSText type="supporting" color="secondary">
+              Showing 3 of 5 users
+            </XDSText>
+            <XDSTable data={users.slice(0, 3)} columns={simpleColumns} />
+          </XDSVStack>
+        </XDSCard>
+      </div>
+
+      {/* ❌ Bug: both edges leak with larger padding */}
+      <div>
+        <h4 {...stylex.props(containerStoryStyles.heading)}>
+          ❌ Larger padding (6) — leak is more visible
+        </h4>
+        <XDSCard width={400} padding={6}>
+          <div>
+            <XDSTable data={users.slice(0, 3)} columns={simpleColumns} />
+          </div>
+        </XDSCard>
+      </div>
+    </div>
+  ),
+};

--- a/packages/core/src/Layout/container.stylex.ts
+++ b/packages/core/src/Layout/container.stylex.ts
@@ -35,6 +35,19 @@ import * as stylex from '@stylexjs/stylex';
 import {spacingVars} from '../theme/tokens.stylex';
 
 /**
+ * Data attribute for full-bleed components.
+ *
+ * Components that want to escape their container's block padding
+ * (Table, Section, Divider) apply this attribute. Containers detect it
+ * via `:has(> [data-xds-bleed]:first-child)` and zero their own block
+ * padding on that edge.
+ *
+ * Same pattern as `EDGE_COMP_ATTR` — components declare eligibility,
+ * containers own the adjustment.
+ */
+export const BLEED_ATTR = 'data-xds-bleed';
+
+/**
  * Spacing token keys for padding props.
  */
 export type SpacingToken =
@@ -59,8 +72,14 @@ const baseStyles = stylex.create({
     boxSizing: 'border-box',
     paddingInlineStart: 'var(--container-padding-inline-start)',
     paddingInlineEnd: 'var(--container-padding-inline-end)',
-    paddingBlockStart: 'var(--container-padding-block-start)',
-    paddingBlockEnd: 'var(--container-padding-block-end)',
+    paddingBlockStart: {
+      default: 'var(--container-padding-block-start)',
+      [`:has(> [${BLEED_ATTR}]:first-child)`]: '0px',
+    },
+    paddingBlockEnd: {
+      default: 'var(--container-padding-block-end)',
+      [`:has(> [${BLEED_ATTR}]:last-child)`]: '0px',
+    },
   },
 });
 

--- a/packages/core/src/Layout/index.ts
+++ b/packages/core/src/Layout/index.ts
@@ -10,7 +10,7 @@
  */
 
 // Container utility
-export {container} from './container.stylex';
+export {container, BLEED_ATTR} from './container.stylex';
 export type {
   ContainerComponent,
   ContainerOptions,

--- a/packages/core/src/Table/XDSTable.tsx
+++ b/packages/core/src/Table/XDSTable.tsx
@@ -17,6 +17,7 @@
 import {useMemo, type ReactElement, type Ref} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars} from '../theme/tokens.stylex';
+import {BLEED_ATTR} from '../Layout/container.stylex';
 import {XDSBaseTable} from './XDSBaseTable';
 import {XDSTableContext} from './XDSTableContext';
 import {useXDSBaseTablePlugins} from './useXDSBaseTablePlugins';
@@ -118,20 +119,13 @@ const scrollWrapperStyles = stylex.create({
     marginInlineEnd: 'calc(-1 * var(--container-padding-inline-end, 0px))',
     width:
       'calc(100% + var(--container-padding-inline-start, 0px) + var(--container-padding-inline-end, 0px))',
-    marginTop: {
-      default: null,
-      ':first-child': 'calc(-1 * var(--container-padding-block-start, 0px))',
-    },
-    marginBottom: {
-      default: null,
-      ':last-child': 'calc(-1 * var(--container-padding-block-end, 0px))',
-    },
   },
 });
 
 function TableScrollWrapper({children}: {children: React.ReactNode}) {
   return (
     <div
+      {...{[BLEED_ATTR]: ''}}
       {...mergeProps(
         xdsClassName('table-scroll-wrapper'),
         stylex.props(


### PR DESCRIPTION
Adds a `BlockBleedLeak` story to the Table stories that shows the CSS custom property inheritance issue.

## Problem

The table's `containerBleed` style uses `:first-child` / `:last-child` to apply negative block margins via `--container-padding-block-start/end`. These CSS custom properties cascade from the container (Card/Section) to **all** descendants. When the table is `:first-child` of an intermediate wrapper div (not the container itself), it incorrectly applies block bleed using the inherited values.

## Demo cases

| Case | Expected | Actual |
|------|----------|--------|
| Table is direct child of Card | ✅ Bleeds correctly | ✅ Works |
| Table wrapped in plain `<div>` | No block bleed | ❌ Bleeds through div |
| Table in VStack (not first-child) | No block bleed | ❌ Last-child still bleeds bottom |
| Table in VStack (is last-child) | No block bleed | ❌ Bottom bleed leaks |
| Larger padding (6) | No block bleed through wrapper | ❌ More visibly broken |

## Root cause

```
Card (sets --container-padding-block-start: 16px)
  └─ div (inherits the 16px via CSS custom property cascade)
       └─ table:first-child → marginTop: calc(-1 * 16px) ← LEAK
```

The table can't distinguish between being first-child of the container vs first-child of an arbitrary wrapper.

## Next steps

Exploring scoped approaches — see discussion in earlier draft PR #2015.