### PR TITLE
fix(tokens): remove deprecated *Raw aliases, migrate minChildWidth usage

### DIFF
--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/ProfileView.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/ProfileView.tsx
@@ -1431,7 +1431,7 @@ export function ProfileView({
                         }}
                       />
                     </XDSHStack>
-                    <XDSGrid minChildWidth={180} gap={3}>
+                    <XDSGrid columns={{minWidth: 180}} gap={3}>
                       {PROFILE_COLLECTIONS.map((col, i) => (
                         <div
                           key={col.name}

--- a/apps/storybook/stories/AspectRatio.stories.tsx
+++ b/apps/storybook/stories/AspectRatio.stories.tsx
@@ -198,7 +198,7 @@ export const ResponsiveGrid: Story = {
       <XDSText type="supporting" xstyle={styles.sectionLabel}>
         Responsive grid of aspect ratio boxes
       </XDSText>
-      <XDSGrid minChildWidth={200} gap={4}>
+      <XDSGrid columns={{minWidth: 200}} gap={4}>
         {[
           {ratio: 16 / 9, label: '16:9'},
           {ratio: 4 / 3, label: '4:3'},

--- a/apps/storybook/stories/Grid.stories.tsx
+++ b/apps/storybook/stories/Grid.stories.tsx
@@ -161,9 +161,9 @@ export const ResponsiveAutoFit: Story = {
     <XDSVStack gap={6}>
       <div {...stylex.props(styles.container)}>
         <XDSText type="supporting" xstyle={styles.sectionLabel}>
-          minChildWidth=200 with 2 items — cards stretch to fill (auto-fit)
+          columns={{minWidth: 200}} with 2 items — cards stretch to fill (auto-fit)
         </XDSText>
-        <XDSGrid minChildWidth={200} gap={4}>
+        <XDSGrid columns={{minWidth: 200}} gap={4}>
           <GridItem>Item 1</GridItem>
           <GridItem>Item 2</GridItem>
         </XDSGrid>
@@ -172,7 +172,7 @@ export const ResponsiveAutoFit: Story = {
         <XDSText type="supporting" xstyle={styles.sectionLabel}>
           Same grid with 6 items — looks fine because items fill the tracks
         </XDSText>
-        <XDSGrid minChildWidth={200} gap={4}>
+        <XDSGrid columns={{minWidth: 200}} gap={4}>
           <GridItem>Item 1</GridItem>
           <GridItem>Item 2</GridItem>
           <GridItem>Item 3</GridItem>

--- a/packages/cli/templates/pages/classic-gallery/page.tsx
+++ b/packages/cli/templates/pages/classic-gallery/page.tsx
@@ -151,7 +151,7 @@ export default function ClassicGalleryTemplate() {
           </XDSCenter>
 
           {/* Gallery Grid */}
-          <XDSGrid minChildWidth={400} gap={4}>
+          <XDSGrid columns={{minWidth: 400}} gap={4}>
             {filteredImages.map((image, i) => (
               <XDSAspectRatio
                 key={i}

--- a/packages/cli/templates/pages/contact-form/page.tsx
+++ b/packages/cli/templates/pages/contact-form/page.tsx
@@ -131,7 +131,7 @@ export default function FormSimplePage() {
 
           {/* Why work with us */}
           <XDSVStack gap={5}>
-            <XDSGrid minChildWidth={200} gap={4}>
+            <XDSGrid columns={{minWidth: 200}} gap={4}>
               {WHY_US.map(item => (
                 <XDSCard key={item.title}>
                   <XDSVStack gap={3}>
@@ -156,7 +156,7 @@ export default function FormSimplePage() {
 
           {/* Your details */}
           <XDSVStack gap={5}>
-            <XDSGrid minChildWidth={260} gap={4}>
+            <XDSGrid columns={{minWidth: 260}} gap={4}>
               <XDSTextInput
                 label="Full Name"
                 placeholder="Full Name"
@@ -180,7 +180,7 @@ export default function FormSimplePage() {
                 }
               />
             </XDSGrid>
-            <XDSGrid minChildWidth={260} gap={4}>
+            <XDSGrid columns={{minWidth: 260}} gap={4}>
               <XDSTextInput
                 label="Company"
                 placeholder="Company"

--- a/packages/cli/templates/pages/product-detail/page.tsx
+++ b/packages/cli/templates/pages/product-detail/page.tsx
@@ -379,7 +379,7 @@ export default function ProductDetailTemplate() {
       variant="surface">
       <XDSCenter axis="horizontal">
         <XDSVStack gap={0} xstyle={pageStyles.pageWrapper}>
-          <XDSGrid minChildWidth={400} gap={5}>
+          <XDSGrid columns={{minWidth: 400}} gap={5}>
             <ImageGallery
               selected={selectedThumb}
               onSelect={setSelectedThumb}

--- a/packages/cli/templates/pages/product-gallery/page.tsx
+++ b/packages/cli/templates/pages/product-gallery/page.tsx
@@ -133,7 +133,7 @@ export default function ProductGalleryTemplate() {
         <XDSSection variant="transparent" maxWidth={1200} padding={6}>
           <XDSVStack gap={6}>
             {/* Header — XDSGrid handles responsive stacking */}
-            <XDSGrid minChildWidth={280} gap={4} align="start">
+            <XDSGrid columns={{minWidth: 280}} gap={4} align="start">
               <XDSHeading level={1}>
                 Make every day a little more delightful, one small detail at a
                 time.
@@ -154,7 +154,7 @@ export default function ProductGalleryTemplate() {
             </XDSGrid>
 
             {/* Product Grid — 3 cols desktop, wraps to 2→1 on smaller screens */}
-            <XDSGrid minChildWidth={300} gap={6}>
+            <XDSGrid columns={{minWidth: 300}} gap={6}>
               {PRODUCTS.map(product => (
                 <ProductCard key={product.id} product={product} />
               ))}

--- a/packages/cli/templates/pages/settings/page.tsx
+++ b/packages/cli/templates/pages/settings/page.tsx
@@ -112,7 +112,7 @@ export default function SettingsTemplate() {
         </XDSSection>
       }>
       <XDSVStack gap={4}>
-        <XDSGrid minChildWidth={320} gap={10}>
+        <XDSGrid columns={{minWidth: 320}} gap={10}>
           <XDSVStack gap={1}>
             <XDSHeading level={3}>Basic information</XDSHeading>
             <XDSText type="supporting" color="secondary">
@@ -148,7 +148,7 @@ export default function SettingsTemplate() {
 
         <XDSDivider />
 
-        <XDSGrid minChildWidth={320} gap={10}>
+        <XDSGrid columns={{minWidth: 320}} gap={10}>
           <XDSVStack gap={1}>
             <XDSHeading level={3}>Change password</XDSHeading>
             <XDSText type="supporting" color="secondary">
@@ -182,7 +182,7 @@ export default function SettingsTemplate() {
 
         <XDSDivider />
 
-        <XDSGrid minChildWidth={320} gap={10}>
+        <XDSGrid columns={{minWidth: 320}} gap={10}>
           <XDSVStack gap={1}>
             <XDSHeading level={3}>Advanced settings</XDSHeading>
             <XDSText type="supporting" color="secondary">

--- a/packages/core/src/TopNav/XDSTopNavMegaMenu.tsx
+++ b/packages/core/src/TopNav/XDSTopNavMegaMenu.tsx
@@ -445,7 +445,7 @@ function DefaultMegaMenu({
             {/* Menu items section */}
             {items != null && (
               <div {...stylex.props(styles.menuWrapper)}>
-                <XDSGrid columns={2} minChildWidth={200} gap={2}>
+                <XDSGrid columns={2} gap={2}>
                   {items}
                 </XDSGrid>
               </div>

--- a/packages/core/src/theme/tokens.stylex.ts
+++ b/packages/core/src/theme/tokens.stylex.ts
@@ -136,9 +136,6 @@ export const colorDefaults = {
   // Syntax highlighting
 } as const;
 
-/** @deprecated Use colorDefaults */
-export const colorRaw = colorDefaults;
-
 export const colorVars = stylex.defineVars(colorDefaults);
 
 // =============================================================================
@@ -163,9 +160,6 @@ export const spacingDefaults = {
   '--spacing-12': '48px',
 } as const;
 
-/** @deprecated Use spacingDefaults */
-export const spacingRaw = spacingDefaults;
-
 export const spacingVars = stylex.defineVars(spacingDefaults);
 
 // =============================================================================
@@ -177,9 +171,6 @@ export const sizeDefaults = {
   '--size-element-md': '32px',
   '--size-element-lg': '36px',
 } as const;
-
-/** @deprecated Use sizeDefaults */
-export const sizeRaw = sizeDefaults;
 
 export const sizeVars = stylex.defineVars(sizeDefaults);
 
@@ -208,9 +199,6 @@ export const radiusDefaults = {
   '--radius-full': '9999px',
 } as const;
 
-/** @deprecated Use radiusDefaults */
-export const radiusRaw = radiusDefaults;
-
 export const radiusVars = stylex.defineVars(radiusDefaults);
 
 // =============================================================================
@@ -234,9 +222,6 @@ export const shadowDefaults = {
   '--shadow-inset-warning': 'inset 0px 0px 0px 2px rgba(226, 164, 0, 0.3)',
   '--shadow-inset-error': 'inset 0px 0px 0px 2px rgba(227, 25, 59, 0.3)',
 } as const;
-
-/** @deprecated Use shadowDefaults */
-export const shadowRaw = shadowDefaults;
 
 export const shadowVars = stylex.defineVars(shadowDefaults);
 
@@ -304,9 +289,6 @@ export const typographyDefaults = {
     '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
 } as const;
 
-/** @deprecated Use typographyDefaults */
-export const typographyRaw = typographyDefaults;
-
 export const typographyVars = stylex.defineVars(typographyDefaults);
 
 // =============================================================================
@@ -329,9 +311,6 @@ export const textSizeDefaults = {
   '--font-size-5xl': '2.625rem', // step +6: 42px (14 × 1.2⁶ ≈ 41.80 → 42)
 } as const;
 
-/** @deprecated Use textSizeDefaults */
-export const textSizeRaw = textSizeDefaults;
-
 export const textSizeVars = stylex.defineVars(textSizeDefaults);
 
 // =============================================================================
@@ -344,9 +323,6 @@ export const fontWeightDefaults = {
   '--font-weight-semibold': '600', // emphasized body, titles
   '--font-weight-bold': '700', // strong emphasis, headings
 } as const;
-
-/** @deprecated Use fontWeightDefaults */
-export const fontWeightRaw = fontWeightDefaults;
 
 export const fontWeightVars = stylex.defineVars(fontWeightDefaults);
 


### PR DESCRIPTION
Remove deprecated token aliases (dead since v0.0.8) and migrate all internal minChildWidth usage to columns={{minWidth}} API.

**Token removals (BREAKING):** colorRaw, spacingRaw, sizeRaw, radiusRaw, shadowRaw, typographyRaw, textSizeRaw, fontWeightRaw — use *Defaults instead.

**minChildWidth migration:** All templates, stories, and internal components now use columns={{minWidth: N}}. The prop remains on XDSGrid for external consumers.