### PR TITLE
feat(Table): change textOverflow default from 'wrap' to 'truncate'

### DIFF
--- a/packages/core/src/Table/XDSTable.test.tsx
+++ b/packages/core/src/Table/XDSTable.test.tsx
@@ -732,8 +732,17 @@ describe('XDSTable', () => {
     );
   });
 
-  it('wraps text by default (textOverflow="wrap")', () => {
+  it('truncates text by default (textOverflow="truncate")', () => {
     render(<XDSTable data={users} columns={columns} />);
+    const cells = screen.getAllByRole('cell');
+    // Default-rendered cells contain an XDSText child element (a <span>)
+    const textEl = cells[0].querySelector('span');
+    expect(textEl).toBeTruthy();
+    expect(textEl).toHaveTextContent('Alice');
+  });
+
+  it('wraps text when textOverflow="wrap"', () => {
+    render(<XDSTable data={users} columns={columns} textOverflow="wrap" />);
     const cells = screen.getAllByRole('cell');
     // In wrap mode, no title attribute is added (text is visible, not hidden)
     expect(cells[0]).not.toHaveAttribute('title');

--- a/packages/core/src/Table/XDSTable.tsx
+++ b/packages/core/src/Table/XDSTable.tsx
@@ -90,11 +90,11 @@ export interface XDSTableProps<T extends Record<string, unknown>> extends Omit<
    *
    * Header cells always truncate regardless of this setting.
    *
-   * @default 'wrap'
+   * @default 'truncate'
    *
    * @example
    * ```
-   * <XDSTable data={logs} columns={columns} textOverflow="truncate" />
+   * <XDSTable data={logs} columns={columns} textOverflow="wrap" />
    * ```
    */
   textOverflow?: 'wrap' | 'truncate';
@@ -195,7 +195,7 @@ function XDSTableInner<T extends Record<string, unknown>>({
   isStriped = false,
   hasHover = false,
   verticalAlign = 'middle',
-  textOverflow = 'wrap',
+  textOverflow = 'truncate',
   plugins: userPlugins,
   columns,
   data,

--- a/packages/core/src/Table/table.stylex.ts
+++ b/packages/core/src/Table/table.stylex.ts
@@ -43,7 +43,7 @@ export const overflowStyles = stylex.create({
 /**
  * Wrap styles for table cells.
  *
- * Applied at the <td>/<th> level when textOverflow is 'wrap' (the default).
+ * Applied at the <td>/<th> level when textOverflow is 'wrap'.
  * Text wraps naturally and the row grows taller to fit. No content is hidden.
  */
 export const wrapStyles = stylex.create({

--- a/packages/core/src/Table/types.ts
+++ b/packages/core/src/Table/types.ts
@@ -404,7 +404,7 @@ export interface XDSBaseTableProps<T extends Record<string, unknown>> {
    * Only affects cells using the default renderer (no `renderCell`).
    * Cells with `renderCell` control their own overflow behavior.
    *
-   * @default 'wrap'
+   * @default 'truncate'
    */
   textOverflow?: 'wrap' | 'truncate';
   /**


### PR DESCRIPTION
## Summary

Changes the default `textOverflow` prop on `XDSTable` from `'wrap'` back to `'truncate'`.

## Motivation

Restores the original default from v0.0.13. The switch to `'wrap'` was an unintentional breaking change — this puts it back to the expected behavior.

Tables in data-dense UIs should truncate by default. Truncated cells show a tooltip on hover, so no content is lost. Consumers who need wrapping can opt in with `textOverflow="wrap"`.

## Changes

- `XDSTable`: default value `'wrap'` → `'truncate'`
- `types.ts`: updated `@default` JSDoc tag
- `table.stylex.ts`: updated comment
- `XDSTable.test.tsx`: updated default behavior test, added explicit wrap test