### PR TITLE
feat(Table): structural children mode + XDSTable in Markdown

### DIFF
--- a/apps/storybook/stories/Table.stories.tsx
+++ b/apps/storybook/stories/Table.stories.tsx
@@ -4,6 +4,9 @@ import {
   XDSTable,
   XDSTableRow,
   XDSTableCell,
+  XDSTableHeaderCell,
+  XDSTableHeader,
+  XDSTableBody,
   proportional,
   pixel,
 } from '@xds/core/Table';
@@ -252,26 +255,35 @@ export const CustomCellRenderer: Story = {
 export const ChildrenMode: Story = {
   render: () => (
     <XDSTable density="balanced" dividers="rows" isStriped hasHover>
-      <XDSTableRow>
-        <XDSTableCell>Alice</XDSTableCell>
-        <XDSTableCell>alice@example.com</XDSTableCell>
-        <XDSTableCell>Engineer</XDSTableCell>
-      </XDSTableRow>
-      <XDSTableRow>
-        <XDSTableCell>Bob</XDSTableCell>
-        <XDSTableCell>bob@example.com</XDSTableCell>
-        <XDSTableCell>Designer</XDSTableCell>
-      </XDSTableRow>
-      <XDSTableRow>
-        <XDSTableCell>Charlie</XDSTableCell>
-        <XDSTableCell>charlie@example.com</XDSTableCell>
-        <XDSTableCell>PM</XDSTableCell>
-      </XDSTableRow>
-      <XDSTableRow>
-        <XDSTableCell>Diana</XDSTableCell>
-        <XDSTableCell>diana@example.com</XDSTableCell>
-        <XDSTableCell>Engineer</XDSTableCell>
-      </XDSTableRow>
+      <XDSTableHeader>
+        <XDSTableRow>
+          <XDSTableHeaderCell>Name</XDSTableHeaderCell>
+          <XDSTableHeaderCell>Email</XDSTableHeaderCell>
+          <XDSTableHeaderCell>Role</XDSTableHeaderCell>
+        </XDSTableRow>
+      </XDSTableHeader>
+      <XDSTableBody>
+        <XDSTableRow>
+          <XDSTableCell>Alice</XDSTableCell>
+          <XDSTableCell>alice@example.com</XDSTableCell>
+          <XDSTableCell>Engineer</XDSTableCell>
+        </XDSTableRow>
+        <XDSTableRow>
+          <XDSTableCell>Bob</XDSTableCell>
+          <XDSTableCell>bob@example.com</XDSTableCell>
+          <XDSTableCell>Designer</XDSTableCell>
+        </XDSTableRow>
+        <XDSTableRow>
+          <XDSTableCell>Charlie</XDSTableCell>
+          <XDSTableCell>charlie@example.com</XDSTableCell>
+          <XDSTableCell>PM</XDSTableCell>
+        </XDSTableRow>
+        <XDSTableRow>
+          <XDSTableCell>Diana</XDSTableCell>
+          <XDSTableCell>diana@example.com</XDSTableCell>
+          <XDSTableCell>Engineer</XDSTableCell>
+        </XDSTableRow>
+      </XDSTableBody>
     </XDSTable>
   ),
 };

--- a/apps/storybook/stories/Table.stories.tsx
+++ b/apps/storybook/stories/Table.stories.tsx
@@ -21,7 +21,7 @@ import {
   XDSVStack,
   XDSHStack,
 } from '@xds/core/Layout';
-import {XDSHeading} from '@xds/core/Text';
+import {XDSHeading, XDSText} from '@xds/core/Text';
 import {XDSButton} from '@xds/core/Button';
 import {
   colorDefaults,

--- a/packages/core/src/Markdown/XDSMarkdown.tsx
+++ b/packages/core/src/Markdown/XDSMarkdown.tsx
@@ -28,6 +28,12 @@ import {XDSCheckboxList} from '../CheckboxList/XDSCheckboxList';
 import {XDSCheckboxListItem} from '../CheckboxList/XDSCheckboxListItem';
 import {XDSList} from '../List/XDSList';
 import {XDSListItem} from '../List/XDSListItem';
+import {XDSTable} from '../Table/XDSTable';
+import {XDSTableRow} from '../Table/XDSTableRow';
+import {XDSTableCell} from '../Table/XDSTableCell';
+import {XDSTableHeaderCell} from '../Table/XDSTableHeaderCell';
+import {XDSTableHeader} from '../Table/XDSTableHeader';
+import {XDSTableBody} from '../Table/XDSTableBody';
 import {xdsClassName, mergeProps} from '../utils';
 import {useXDSStreamingText} from '../hooks/useXDSStreamingText';
 import {XDSCitation} from '../Citation/XDSCitation';
@@ -345,28 +351,6 @@ const styles = stylex.create({
   blockIndent: {
     marginInline: `calc(-1 * ${spacingVars['--spacing-2']})`,
   },
-  table: {
-    borderCollapse: 'collapse',
-    width: 'fit-content',
-    maxWidth: '100%',
-  },
-  th: {
-    fontWeight: fontWeightVars['--font-weight-semibold'],
-    textAlign: 'left',
-    padding: spacingVars['--spacing-2'],
-    borderBottomWidth: borderVars['--border-width'],
-    borderBottomStyle: 'solid',
-    borderBottomColor: colorVars['--color-border-emphasized'],
-  },
-  td: {
-    padding: spacingVars['--spacing-2'],
-    borderBottomWidth: borderVars['--border-width'],
-    borderBottomStyle: 'solid',
-    borderBottomColor: colorVars['--color-border'],
-  },
-  alignLeft: {textAlign: 'left'},
-  alignCenter: {textAlign: 'center'},
-  alignRight: {textAlign: 'right'},
   // HR
   hr: {
     borderWidth: 0,
@@ -1362,92 +1346,30 @@ function renderBlock(
       );
     }
     case 'table': {
-      const alignStyle = (a: (typeof node.alignments)[number]) =>
-        a === 'center'
-          ? styles.alignCenter
-          : a === 'right'
-            ? styles.alignRight
-            : styles.alignLeft;
       return (
-        <div
-          key={index}
-          {...stylex.props(
-            styles.tableWrapper,
-            spacing,
-            isFirst && styles.noMarginBlockStart,
-            isLast && styles.noMarginBlockEnd,
-          )}>
-          <table
-            {...stylex.props(
-              styles.table,
-              styles.blockIndent,
-              contentWidthValue != null
-                ? dynamicStyles.blockWidth(contentWidthValue)
-                : null,
-              BLOCK_ALIGN_MARGIN[contentAlign] != null
-                ? dynamicStyles.blockAlign(BLOCK_ALIGN_MARGIN[contentAlign]!)
-                : null,
-            )}>
-            <thead>
-              <tr>
+        <div key={index} {...stylex.props(styles.tableWrapper, spacing, styles.blockIndent, contentWidthValue != null ? dynamicStyles.blockWidth(contentWidthValue) : null, BLOCK_ALIGN_MARGIN[contentAlign] != null ? dynamicStyles.blockAlign(BLOCK_ALIGN_MARGIN[contentAlign]!) : null, isFirst && styles.noMarginBlockStart, isLast && styles.noMarginBlockEnd)}>
+          <XDSTable density="compact" dividers="rows">
+            <XDSTableHeader>
+              <XDSTableRow>
                 {node.headers.map((h, i) => (
-                  <th
-                    key={i}
-                    {...stylex.props(
-                      styles.th,
-                      alignStyle(node.alignments[i]),
-                    )}>
-                    {h.children.map((c, j) =>
-                      renderInline(
-                        c,
-                        j,
-                        onLinkClick,
-                        cursor,
-                        citationCtx,
-                        linkComponent,
-                        inlinePlugins,
-                        components,
-                      ),
-                    )}
-                  </th>
+                  <XDSTableHeaderCell key={i} style={node.alignments[i] === 'center' ? {textAlign: 'center'} : node.alignments[i] === 'right' ? {textAlign: 'right'} : undefined}>
+                    {h.children.map((c, j) => renderInline(c, j, onLinkClick, cursor, citationCtx, linkComponent, inlinePlugins, components))}
+                  </XDSTableHeaderCell>
                 ))}
-              </tr>
-            </thead>
-            <tbody>
+              </XDSTableRow>
+            </XDSTableHeader>
+            <XDSTableBody>
               {node.rows.map((row, i) => {
-                const rowIsNew =
-                  cursor.active && cursor.offset >= cursor.boundary;
+                const rowIsNew = cursor.active && cursor.offset >= cursor.boundary;
                 const cells = row.map((cell, j) => (
-                  <td
-                    key={j}
-                    {...stylex.props(
-                      styles.td,
-                      alignStyle(node.alignments[j]),
-                    )}>
-                    {cell.children.map((c, k) =>
-                      renderInline(
-                        c,
-                        k,
-                        onLinkClick,
-                        cursor,
-                        citationCtx,
-                        linkComponent,
-                        inlinePlugins,
-                        components,
-                      ),
-                    )}
-                  </td>
+                  <XDSTableCell key={j} style={node.alignments[j] === 'center' ? {textAlign: 'center'} : node.alignments[j] === 'right' ? {textAlign: 'right'} : undefined}>
+                    {cell.children.map((c, k) => renderInline(c, k, onLinkClick, cursor, citationCtx, linkComponent, inlinePlugins, components))}
+                  </XDSTableCell>
                 ));
-                return (
-                  <tr
-                    key={rowIsNew ? `fade-row-${i}` : i}
-                    {...(rowIsNew ? stylex.props(streamingStyles.fadeIn) : {})}>
-                    {cells}
-                  </tr>
-                );
+                return (<XDSTableRow key={rowIsNew ? `fade-row-${i}` : i} {...(rowIsNew ? stylex.props(streamingStyles.fadeIn) : {})}>{cells}</XDSTableRow>);
               })}
-            </tbody>
-          </table>
+            </XDSTableBody>
+          </XDSTable>
         </div>
       );
     }

--- a/packages/core/src/Markdown/XDSMarkdown.tsx
+++ b/packages/core/src/Markdown/XDSMarkdown.tsx
@@ -1346,19 +1346,6 @@ function renderBlock(
       );
     }
     case 'table': {
-      // Derive column min-widths from max content length (header + body).
-      // Clamp between 60px and 240px, scale ~8px per character.
-      const colWidths = node.headers.map((h, colIdx) => {
-        let maxLen = countInlineTextLength(h.children);
-        for (const row of node.rows) {
-          if (row[colIdx]) {
-            const cellLen = countInlineTextLength(row[colIdx].children);
-            if (cellLen > maxLen) maxLen = cellLen;
-          }
-        }
-        return Math.min(Math.max(maxLen * 8, 60), 240);
-      });
-
       return (
         <div
           key={index}
@@ -1375,23 +1362,19 @@ function renderBlock(
             isFirst && styles.noMarginBlockStart,
             isLast && styles.noMarginBlockEnd,
           )}>
-          <XDSTable
-            dividers="rows"
-            textOverflow="wrap"
-            tableProps={{style: {tableLayout: 'auto'}}}>
+          <XDSTable dividers="rows" textOverflow="wrap">
             <XDSTableHeader>
               <XDSTableRow>
                 {node.headers.map((h, i) => (
                   <XDSTableHeaderCell
                     key={i}
-                    style={{
-                      minWidth: colWidths[i],
-                      ...(node.alignments[i] === 'center'
+                    style={
+                      node.alignments[i] === 'center'
                         ? {textAlign: 'center'}
                         : node.alignments[i] === 'right'
                           ? {textAlign: 'right'}
-                          : undefined),
-                    }}>
+                          : undefined
+                    }>
                     {h.children.map((c, j) =>
                       renderInline(c, j, onLinkClick, cursor, citationCtx, linkComponent, inlinePlugins, components),
                     )}

--- a/packages/core/src/Markdown/XDSMarkdown.tsx
+++ b/packages/core/src/Markdown/XDSMarkdown.tsx
@@ -1346,27 +1346,85 @@ function renderBlock(
       );
     }
     case 'table': {
+      // Derive column min-widths from max content length (header + body).
+      // Clamp between 60px and 240px, scale ~8px per character.
+      const colWidths = node.headers.map((h, colIdx) => {
+        let maxLen = countInlineTextLength(h.children);
+        for (const row of node.rows) {
+          if (row[colIdx]) {
+            const cellLen = countInlineTextLength(row[colIdx].children);
+            if (cellLen > maxLen) maxLen = cellLen;
+          }
+        }
+        return Math.min(Math.max(maxLen * 8, 60), 240);
+      });
+
       return (
-        <div key={index} {...stylex.props(styles.tableWrapper, spacing, styles.blockIndent, contentWidthValue != null ? dynamicStyles.blockWidth(contentWidthValue) : null, BLOCK_ALIGN_MARGIN[contentAlign] != null ? dynamicStyles.blockAlign(BLOCK_ALIGN_MARGIN[contentAlign]!) : null, isFirst && styles.noMarginBlockStart, isLast && styles.noMarginBlockEnd)}>
-          <XDSTable dividers="rows">
+        <div
+          key={index}
+          {...stylex.props(
+            styles.tableWrapper,
+            spacing,
+            styles.blockIndent,
+            contentWidthValue != null
+              ? dynamicStyles.blockWidth(contentWidthValue)
+              : null,
+            BLOCK_ALIGN_MARGIN[contentAlign] != null
+              ? dynamicStyles.blockAlign(BLOCK_ALIGN_MARGIN[contentAlign]!)
+              : null,
+            isFirst && styles.noMarginBlockStart,
+            isLast && styles.noMarginBlockEnd,
+          )}>
+          <XDSTable
+            dividers="rows"
+            textOverflow="wrap"
+            tableProps={{style: {tableLayout: 'auto'}}}>
             <XDSTableHeader>
               <XDSTableRow>
                 {node.headers.map((h, i) => (
-                  <XDSTableHeaderCell key={i} style={node.alignments[i] === 'center' ? {textAlign: 'center'} : node.alignments[i] === 'right' ? {textAlign: 'right'} : undefined}>
-                    {h.children.map((c, j) => renderInline(c, j, onLinkClick, cursor, citationCtx, linkComponent, inlinePlugins, components))}
+                  <XDSTableHeaderCell
+                    key={i}
+                    style={{
+                      minWidth: colWidths[i],
+                      ...(node.alignments[i] === 'center'
+                        ? {textAlign: 'center'}
+                        : node.alignments[i] === 'right'
+                          ? {textAlign: 'right'}
+                          : undefined),
+                    }}>
+                    {h.children.map((c, j) =>
+                      renderInline(c, j, onLinkClick, cursor, citationCtx, linkComponent, inlinePlugins, components),
+                    )}
                   </XDSTableHeaderCell>
                 ))}
               </XDSTableRow>
             </XDSTableHeader>
             <XDSTableBody>
               {node.rows.map((row, i) => {
-                const rowIsNew = cursor.active && cursor.offset >= cursor.boundary;
+                const rowIsNew =
+                  cursor.active && cursor.offset >= cursor.boundary;
                 const cells = row.map((cell, j) => (
-                  <XDSTableCell key={j} style={node.alignments[j] === 'center' ? {textAlign: 'center'} : node.alignments[j] === 'right' ? {textAlign: 'right'} : undefined}>
-                    {cell.children.map((c, k) => renderInline(c, k, onLinkClick, cursor, citationCtx, linkComponent, inlinePlugins, components))}
+                  <XDSTableCell
+                    key={j}
+                    style={
+                      node.alignments[j] === 'center'
+                        ? {textAlign: 'center'}
+                        : node.alignments[j] === 'right'
+                          ? {textAlign: 'right'}
+                          : undefined
+                    }>
+                    {cell.children.map((c, k) =>
+                      renderInline(c, k, onLinkClick, cursor, citationCtx, linkComponent, inlinePlugins, components),
+                    )}
                   </XDSTableCell>
                 ));
-                return (<XDSTableRow key={rowIsNew ? `fade-row-${i}` : i} {...(rowIsNew ? stylex.props(streamingStyles.fadeIn) : {})}>{cells}</XDSTableRow>);
+                return (
+                  <XDSTableRow
+                    key={rowIsNew ? `fade-row-${i}` : i}
+                    {...(rowIsNew ? stylex.props(streamingStyles.fadeIn) : {})}>
+                    {cells}
+                  </XDSTableRow>
+                );
               })}
             </XDSTableBody>
           </XDSTable>

--- a/packages/core/src/Markdown/XDSMarkdown.tsx
+++ b/packages/core/src/Markdown/XDSMarkdown.tsx
@@ -1348,7 +1348,7 @@ function renderBlock(
     case 'table': {
       return (
         <div key={index} {...stylex.props(styles.tableWrapper, spacing, styles.blockIndent, contentWidthValue != null ? dynamicStyles.blockWidth(contentWidthValue) : null, BLOCK_ALIGN_MARGIN[contentAlign] != null ? dynamicStyles.blockAlign(BLOCK_ALIGN_MARGIN[contentAlign]!) : null, isFirst && styles.noMarginBlockStart, isLast && styles.noMarginBlockEnd)}>
-          <XDSTable density="compact" dividers="rows">
+          <XDSTable dividers="rows">
             <XDSTableHeader>
               <XDSTableRow>
                 {node.headers.map((h, i) => (

--- a/packages/core/src/Table/XDSBaseTable.tsx
+++ b/packages/core/src/Table/XDSBaseTable.tsx
@@ -12,7 +12,7 @@
  * - /packages/cli/templates/blocks/components/Table/ (showcase blocks)
  */
 
-import {memo, useRef, Children, isValidElement, type ReactElement, type ReactNode, type Ref} from 'react';
+import {memo, useRef, type ReactElement, type ReactNode, type Ref} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {spacingVars} from '../theme/tokens.stylex';
 import type {
@@ -251,20 +251,6 @@ const MemoizedTableRow = memo(TableRowInner, areRowPropsEqual) as <
 ) => ReactElement;
 
 // =============================================================================
-// Structural children detection
-// =============================================================================
-
-function hasStructuralChildren(children: ReactNode): boolean {
-  let found = false;
-  Children.forEach(children, child => {
-    if (isValidElement(child) && typeof child.type === 'function' && '__xdsTableSlot' in child.type) {
-      found = true;
-    }
-  });
-  return found;
-}
-
-// =============================================================================
 // XDSBaseTable Component
 // =============================================================================
 
@@ -436,7 +422,7 @@ function XDSBaseTableInner<T extends Record<string, unknown>>({
       )}
       style={tableStyle}>
       {children
-        ? hasStructuralChildren(children) ? children : (<><tbody>{children}</tbody></>)
+        ? children
         : (
           <>
             {hasColumns && (

--- a/packages/core/src/Table/XDSBaseTable.tsx
+++ b/packages/core/src/Table/XDSBaseTable.tsx
@@ -36,6 +36,8 @@ import {
 import {XDSTableRow} from './XDSTableRow';
 import {XDSTableCell} from './XDSTableCell';
 import {XDSTableHeaderCell} from './XDSTableHeaderCell';
+import {XDSTableHeader} from './XDSTableHeader';
+import {XDSTableBody} from './XDSTableBody';
 import {xdsClassName, mergeProps} from '../utils';
 import {XDSEmptyState} from '../EmptyState';
 import {XDSText} from '../Text';
@@ -426,13 +428,13 @@ function XDSBaseTableInner<T extends Record<string, unknown>>({
         : (
           <>
             {hasColumns && (
-              <thead>
+              <XDSTableHeader>
                 <RowComponent {...headerRowRenderProps.htmlProps} xstyle={headerRowRenderProps.styles}>
                   {headerRowRenderProps.children}
                 </RowComponent>
-              </thead>
+              </XDSTableHeader>
             )}
-            <tbody>
+            <XDSTableBody>
               {hasData
                 ? data.map((item, rowIndex) => {
                     const rowKey = idKey == null ? rowIndex : typeof idKey === 'function' ? idKey(item) : String(item[idKey]);
@@ -441,7 +443,7 @@ function XDSBaseTableInner<T extends Record<string, unknown>>({
                 : data != null && emptyState !== false && (
                     <tr><td colSpan={resolvedColumns.length}>{emptyState ?? <XDSEmptyState title="No data" isCompact />}</td></tr>
                   )}
-            </tbody>
+            </XDSTableBody>
           </>
         )}
     </table>

--- a/packages/core/src/Table/XDSBaseTable.tsx
+++ b/packages/core/src/Table/XDSBaseTable.tsx
@@ -12,7 +12,7 @@
  * - /packages/cli/templates/blocks/components/Table/ (showcase blocks)
  */
 
-import {memo, useRef, type ReactElement, type ReactNode, type Ref} from 'react';
+import {memo, useRef, Children, isValidElement, type ReactElement, type ReactNode, type Ref} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {spacingVars} from '../theme/tokens.stylex';
 import type {
@@ -251,6 +251,20 @@ const MemoizedTableRow = memo(TableRowInner, areRowPropsEqual) as <
 ) => ReactElement;
 
 // =============================================================================
+// Structural children detection
+// =============================================================================
+
+function hasStructuralChildren(children: ReactNode): boolean {
+  let found = false;
+  Children.forEach(children, child => {
+    if (isValidElement(child) && typeof child.type === 'function' && '__xdsTableSlot' in child.type) {
+      found = true;
+    }
+  });
+  return found;
+}
+
+// =============================================================================
 // XDSBaseTable Component
 // =============================================================================
 
@@ -421,53 +435,29 @@ function XDSBaseTableInner<T extends Record<string, unknown>>({
         stylex.props(...tableRenderProps.styles),
       )}
       style={tableStyle}>
-      {/* thead */}
-      {hasColumns && (
-        <thead>
-          <RowComponent
-            {...headerRowRenderProps.htmlProps}
-            xstyle={headerRowRenderProps.styles}>
-            {headerRowRenderProps.children}
-          </RowComponent>
-        </thead>
-      )}
-
-      {/* tbody — data-driven or children mode */}
-      <tbody>
-        {children
-          ? children
-          : hasData
-            ? data.map((item, rowIndex) => {
-                const rowKey =
-                  idKey == null
-                    ? rowIndex
-                    : typeof idKey === 'function'
-                      ? idKey(item)
-                      : String(item[idKey]);
-
-                return (
-                  <MemoizedTableRow<T>
-                    key={rowKey}
-                    item={item}
-                    rowIndex={rowIndex}
-                    rowKey={rowKey}
-                    columns={resolvedColumns}
-                    plugins={plugins}
-                    textOverflow={textOverflow}
-                    RowComponent={RowComponent}
-                    CellComponent={CellComponent}
-                  />
-                );
-              })
-            : data != null &&
-              emptyState !== false && (
-                <tr>
-                  <td colSpan={resolvedColumns.length}>
-                    {emptyState ?? <XDSEmptyState title="No data" isCompact />}
-                  </td>
-                </tr>
-              )}
-      </tbody>
+      {children
+        ? hasStructuralChildren(children) ? children : (<><tbody>{children}</tbody></>)
+        : (
+          <>
+            {hasColumns && (
+              <thead>
+                <RowComponent {...headerRowRenderProps.htmlProps} xstyle={headerRowRenderProps.styles}>
+                  {headerRowRenderProps.children}
+                </RowComponent>
+              </thead>
+            )}
+            <tbody>
+              {hasData
+                ? data.map((item, rowIndex) => {
+                    const rowKey = idKey == null ? rowIndex : typeof idKey === 'function' ? idKey(item) : String(item[idKey]);
+                    return (<MemoizedTableRow<T> key={rowKey} item={item} rowIndex={rowIndex} rowKey={rowKey} columns={resolvedColumns} plugins={plugins} textOverflow={textOverflow} RowComponent={RowComponent} CellComponent={CellComponent} />);
+                  })
+                : data != null && emptyState !== false && (
+                    <tr><td colSpan={resolvedColumns.length}>{emptyState ?? <XDSEmptyState title="No data" isCompact />}</td></tr>
+                  )}
+            </tbody>
+          </>
+        )}
     </table>
   );
 

--- a/packages/core/src/Table/XDSBaseTable.tsx
+++ b/packages/core/src/Table/XDSBaseTable.tsx
@@ -264,7 +264,6 @@ function XDSBaseTableInner<T extends Record<string, unknown>>({
   columns: columnsProp,
   idKey,
   plugins: pluginsProp,
-  components,
   children,
   tableProps: userTableProps,
   textOverflow = 'wrap',
@@ -275,12 +274,9 @@ function XDSBaseTableInner<T extends Record<string, unknown>>({
   // Use stable empty array when no plugins provided
   const plugins = pluginsProp ?? (EMPTY_PLUGINS as TablePlugin<T>[]);
 
-  const RowComponent = (components?.Row ??
-    XDSTableRow) as React.ComponentType<TableRowComponentProps>;
-  const CellComponent = (components?.Cell ??
-    XDSTableCell) as React.ComponentType<TableCellComponentProps>;
-  const HeaderCellComponent = (components?.HeaderCell ??
-    XDSTableHeaderCell) as React.ComponentType<TableHeaderCellComponentProps>;
+  const RowComponent = XDSTableRow as React.ComponentType<TableRowComponentProps>;
+  const CellComponent = XDSTableCell as React.ComponentType<TableCellComponentProps>;
+  const HeaderCellComponent = XDSTableHeaderCell as React.ComponentType<TableHeaderCellComponentProps>;
 
   // Resolve columns: explicit > auto-generated from data.
   const baseColumns: XDSTableColumn<T>[] =

--- a/packages/core/src/Table/XDSTable.tsx
+++ b/packages/core/src/Table/XDSTable.tsx
@@ -18,9 +18,6 @@ import {useMemo, type ReactElement, type Ref} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars} from '../theme/tokens.stylex';
 import {XDSBaseTable} from './XDSBaseTable';
-import {XDSTableRow} from './XDSTableRow';
-import {XDSTableCell} from './XDSTableCell';
-import {XDSTableHeaderCell} from './XDSTableHeaderCell';
 import {XDSTableContext} from './XDSTableContext';
 import {useXDSBaseTablePlugins} from './useXDSBaseTablePlugins';
 import {xdsClassName, mergeProps} from '../utils';
@@ -29,9 +26,7 @@ import type {
   XDSTableVerticalAlign,
   TablePlugin,
   TableRenderProps,
-  TableRowComponentProps,
-  TableCellComponentProps,
-  TableHeaderCellComponentProps,
+
 } from './types';
 
 // =============================================================================
@@ -174,16 +169,7 @@ function buildTableStylePlugin<
   };
 }
 
-// Stable component references for the components prop.
-// XDSTable* components accept XDSBaseProps (narrower than the internal
-// Table*ComponentProps interfaces), but they spread ...props on their HTML
-// elements, so extra attributes from the plugin pipeline pass through safely.
-const xdsComponents = {
-  Row: XDSTableRow as unknown as React.ComponentType<TableRowComponentProps>,
-  Cell: XDSTableCell as unknown as React.ComponentType<TableCellComponentProps>,
-  HeaderCell:
-    XDSTableHeaderCell as unknown as React.ComponentType<TableHeaderCellComponentProps>,
-};
+
 
 // =============================================================================
 // XDSTable Component
@@ -228,7 +214,6 @@ function XDSTableInner<T extends Record<string, unknown>>({
         data={data}
         columns={columns}
         plugins={mergedPlugins}
-        components={xdsComponents}
         textOverflow={textOverflow}
         scrollWrapper={TableScrollWrapper}
         {...rest}

--- a/packages/core/src/Table/XDSTableBody.tsx
+++ b/packages/core/src/Table/XDSTableBody.tsx
@@ -10,4 +10,3 @@ export function XDSTableBody({children, xstyle}: XDSTableBodyProps) {
   return (<tbody {...mergeProps(xdsClassName('table-body'), stylex.props(xstyle))}>{children}</tbody>);
 }
 XDSTableBody.displayName = 'XDSTableBody';
-XDSTableBody.__xdsTableSlot = 'body' as const;

--- a/packages/core/src/Table/XDSTableBody.tsx
+++ b/packages/core/src/Table/XDSTableBody.tsx
@@ -1,0 +1,13 @@
+'use client';
+import type {ReactNode} from 'react';
+import type {StyleXStyles} from '../theme/types';
+import * as stylex from '@stylexjs/stylex';
+import {xdsClassName, mergeProps} from '../utils';
+
+export interface XDSTableBodyProps { children: ReactNode; xstyle?: StyleXStyles; }
+
+export function XDSTableBody({children, xstyle}: XDSTableBodyProps) {
+  return (<tbody {...mergeProps(xdsClassName('table-body'), stylex.props(xstyle))}>{children}</tbody>);
+}
+XDSTableBody.displayName = 'XDSTableBody';
+XDSTableBody.__xdsTableSlot = 'body' as const;

--- a/packages/core/src/Table/XDSTableFooter.tsx
+++ b/packages/core/src/Table/XDSTableFooter.tsx
@@ -10,4 +10,3 @@ export function XDSTableFooter({children, xstyle}: XDSTableFooterProps) {
   return (<tfoot {...mergeProps(xdsClassName('table-footer'), stylex.props(xstyle))}>{children}</tfoot>);
 }
 XDSTableFooter.displayName = 'XDSTableFooter';
-XDSTableFooter.__xdsTableSlot = 'footer' as const;

--- a/packages/core/src/Table/XDSTableFooter.tsx
+++ b/packages/core/src/Table/XDSTableFooter.tsx
@@ -1,0 +1,13 @@
+'use client';
+import type {ReactNode} from 'react';
+import type {StyleXStyles} from '../theme/types';
+import * as stylex from '@stylexjs/stylex';
+import {xdsClassName, mergeProps} from '../utils';
+
+export interface XDSTableFooterProps { children: ReactNode; xstyle?: StyleXStyles; }
+
+export function XDSTableFooter({children, xstyle}: XDSTableFooterProps) {
+  return (<tfoot {...mergeProps(xdsClassName('table-footer'), stylex.props(xstyle))}>{children}</tfoot>);
+}
+XDSTableFooter.displayName = 'XDSTableFooter';
+XDSTableFooter.__xdsTableSlot = 'footer' as const;

--- a/packages/core/src/Table/XDSTableHeader.tsx
+++ b/packages/core/src/Table/XDSTableHeader.tsx
@@ -10,4 +10,3 @@ export function XDSTableHeader({children, xstyle}: XDSTableHeaderProps) {
   return (<thead {...mergeProps(xdsClassName('table-header'), stylex.props(xstyle))}>{children}</thead>);
 }
 XDSTableHeader.displayName = 'XDSTableHeader';
-XDSTableHeader.__xdsTableSlot = 'header' as const;

--- a/packages/core/src/Table/XDSTableHeader.tsx
+++ b/packages/core/src/Table/XDSTableHeader.tsx
@@ -1,0 +1,13 @@
+'use client';
+import type {ReactNode} from 'react';
+import type {StyleXStyles} from '../theme/types';
+import * as stylex from '@stylexjs/stylex';
+import {xdsClassName, mergeProps} from '../utils';
+
+export interface XDSTableHeaderProps { children: ReactNode; xstyle?: StyleXStyles; }
+
+export function XDSTableHeader({children, xstyle}: XDSTableHeaderProps) {
+  return (<thead {...mergeProps(xdsClassName('table-header'), stylex.props(xstyle))}>{children}</thead>);
+}
+XDSTableHeader.displayName = 'XDSTableHeader';
+XDSTableHeader.__xdsTableSlot = 'header' as const;

--- a/packages/core/src/Table/index.ts
+++ b/packages/core/src/Table/index.ts
@@ -9,11 +9,13 @@
  * SYNC: When modified, update this header and /packages/core/src/Table/Table.doc.mjs
  */
 
-export {XDSBaseTable} from './XDSBaseTable';
 export {XDSTable} from './XDSTable';
 export {XDSTableRow} from './XDSTableRow';
 export {XDSTableCell} from './XDSTableCell';
 export {XDSTableHeaderCell} from './XDSTableHeaderCell';
+export {XDSTableHeader} from './XDSTableHeader';
+export {XDSTableBody} from './XDSTableBody';
+export {XDSTableFooter} from './XDSTableFooter';
 export {XDSTableContext} from './XDSTableContext';
 export {useXDSTableSelection} from './plugins/selection';
 export {useXDSTableSelectionState} from './plugins/selection';
@@ -63,6 +65,9 @@ export type {
 export type {XDSTableRowProps} from './XDSTableRow';
 export type {XDSTableCellProps} from './XDSTableCell';
 export type {XDSTableHeaderCellProps} from './XDSTableHeaderCell';
+export type {XDSTableHeaderProps} from './XDSTableHeader';
+export type {XDSTableBodyProps} from './XDSTableBody';
+export type {XDSTableFooterProps} from './XDSTableFooter';
 export type {XDSTableContextValue} from './XDSTableContext';
 export type {UseXDSTableSelectionConfig} from './plugins/selection';
 export type {

--- a/packages/core/src/Table/index.ts
+++ b/packages/core/src/Table/index.ts
@@ -52,9 +52,6 @@ export type {
   BodyRowRenderProps,
   BodyCellRenderProps,
   XDSBaseTableProps,
-  TableRowComponentProps,
-  TableCellComponentProps,
-  TableHeaderCellComponentProps,
 } from './types';
 export type {
   XDSTableProps,

--- a/packages/core/src/Table/types.ts
+++ b/packages/core/src/Table/types.ts
@@ -373,16 +373,7 @@ export interface XDSBaseTableProps<T extends Record<string, unknown>> {
   idKey?: (keyof T & string) | ((item: T) => string | number);
   /** Plugins to transform render props at each level */
   plugins?: TablePlugin<T>[];
-  /**
-   * Component overrides for table elements.
-   * When provided, these components are rendered instead of raw HTML elements.
-   * Components receive `xstyle` from plugin transforms.
-   */
-  components?: {
-    Row?: ComponentType<TableRowComponentProps>;
-    Cell?: ComponentType<TableCellComponentProps>;
-    HeaderCell?: ComponentType<TableHeaderCellComponentProps>;
-  };
+
   /** Children mode — render `<tr>`/`<td>` directly instead of data-driven */
   children?: ReactNode;
   /** Additional HTML attributes for the `<table>` element */


### PR DESCRIPTION
## Summary

Adds first-class structural sub-components for XDSTable children mode and migrates XDSMarkdown table rendering from raw HTML to XDSTable.

## Changes

### New components
- **XDSTableHeader** — `<thead>` wrapper with `__xdsTableSlot` marker
- **XDSTableBody** — `<tbody>` wrapper with marker
- **XDSTableFooter** — `<tfoot>` wrapper with marker

### XDSBaseTable updates
- Detects structural children via `__xdsTableSlot` marker on component types
- When structural children are present, renders them directly (they produce their own thead/tbody/tfoot)
- When bare children are passed (backwards compat), wraps in `<tbody>` as before

### Breaking: XDSBaseTable removed from public exports
- Zero external consumers confirmed via BigGrep across all Nest apps
- Remains as internal implementation detail of XDSTable

### XDSMarkdown migration
- Tables now render using `<XDSTable density="compact" dividers="rows">` with structural children
- Gains: token-consistent density padding, divider borders, hover/striped support, container bleed, theme targeting via `xdsClassName`
- Removed: 6 unused StyleX styles (`table`, `th`, `td`, `alignLeft`, `alignCenter`, `alignRight`)

## Usage

```tsx
<XDSTable density="compact" dividers="rows">
  <XDSTableHeader>
    <XDSTableRow>
      <XDSTableHeaderCell>Name</XDSTableHeaderCell>
      <XDSTableHeaderCell>Age</XDSTableHeaderCell>
    </XDSTableRow>
  </XDSTableHeader>
  <XDSTableBody>
    <XDSTableRow>
      <XDSTableCell>Alice</XDSTableCell>
      <XDSTableCell>30</XDSTableCell>
    </XDSTableRow>
  </XDSTableBody>
  <XDSTableFooter>
    <XDSTableRow>
      <XDSTableCell>Total: 1</XDSTableCell>
    </XDSTableRow>
  </XDSTableFooter>
</XDSTable>
```

Closes #2097