### PR TITLE
fix(templates): correct IDE template syntax theme import path

### DIFF
--- a/packages/cli/templates/pages/ide/page.tsx
+++ b/packages/cli/templates/pages/ide/page.tsx
@@ -14,7 +14,7 @@ import {
 import {XDSResizeHandle, useXDSResizable} from '@xds/core/Resizable';
 import {XDSText, XDSHeading} from '@xds/core/Text';
 import {XDSCodeBlock} from '@xds/core/CodeBlock';
-import {XDSSyntaxTheme, defineSyntaxTheme} from '@xds/core';
+import {XDSSyntaxTheme, defineSyntaxTheme} from '@xds/core/theme/syntax';
 import {colorVars, spacingVars} from '@xds/core/theme/tokens.stylex';
 import {XDSStack} from '@xds/core/Layout';
 import {XDSOverflowList} from '@xds/core/OverflowList';


### PR DESCRIPTION
The IDE template was importing `XDSSyntaxTheme` and `defineSyntaxTheme` from `'@xds/core'` — the correct subpath export is `'@xds/core/theme/syntax'`.