### PR TITLE
fix(Markdown): table alignment and width fixes

### DIFF
--- a/packages/core/src/Markdown/XDSMarkdown.tsx
+++ b/packages/core/src/Markdown/XDSMarkdown.tsx
@@ -1390,11 +1390,11 @@ function renderBlock(
                 {node.headers.map((h, i) => (
                   <XDSTableHeaderCell
                     key={i}
-                    {...stylex.props(
+                    xstyle={[
                       dynamicStyles.cellMinWidth(`${colMinWidths[i]}px`),
                       node.alignments[i] === 'center' && cellAlignStyles.center,
                       node.alignments[i] === 'right' && cellAlignStyles.right,
-                    )}>
+                    ]}>
                     {h.children.map((c, j) =>
                       renderInline(c, j, onLinkClick, cursor, citationCtx, linkComponent, inlinePlugins, components),
                     )}
@@ -1409,10 +1409,10 @@ function renderBlock(
                 const cells = row.map((cell, j) => (
                   <XDSTableCell
                     key={j}
-                    {...stylex.props(
+                    xstyle={[
                       node.alignments[j] === 'center' && cellAlignStyles.center,
                       node.alignments[j] === 'right' && cellAlignStyles.right,
-                    )}>
+                    ]}>
                     {cell.children.map((c, k) =>
                       renderInline(c, k, onLinkClick, cursor, citationCtx, linkComponent, inlinePlugins, components),
                     )}

--- a/packages/core/src/Markdown/XDSMarkdown.tsx
+++ b/packages/core/src/Markdown/XDSMarkdown.tsx
@@ -1380,7 +1380,14 @@ function renderBlock(
         <div
           key={index}
           {...stylex.props(
+            styles.tableWrapper,
             spacing,
+            contentWidthValue != null
+              ? dynamicStyles.blockWidth(contentWidthValue)
+              : null,
+            BLOCK_ALIGN_MARGIN[contentAlign] != null
+              ? dynamicStyles.blockAlign(BLOCK_ALIGN_MARGIN[contentAlign]!)
+              : null,
             isFirst && styles.noMarginBlockStart,
             isLast && styles.noMarginBlockEnd,
           )}>


### PR DESCRIPTION
## Summary

Fixes alignment issues and width constraints for tables rendered in XDSMarkdown.

## Changes

- **Pass styles via `xstyle` prop** — spreading `stylex.props()` onto XDSTableHeaderCell/Cell conflicted with their internal style merging. Using `xstyle` feeds through the proper merge pipeline.
- **Restore table wrapper with width/align constraints** — same pattern as codeblock: `overflowX: auto`, `blockWidth` (preferred width = contentWidth), `blockAlign` (centering). Gives tables auto-width, centered when `contentAlign` is set, max 100%.
- **Content-derived min-widths on header cells** — uses `computeTableColumnMinWidths()` to set per-column minWidth via `xstyle`.

Follows from #2098 (merged).