### PR TITLE
feat(theme-stone): rebuild colors with HCT tonal palettes

### DIFF
--- a/apps/sandbox/src/app/(sandbox)/pages/stone-palette/page.tsx
+++ b/apps/sandbox/src/app/(sandbox)/pages/stone-palette/page.tsx
@@ -1,0 +1,814 @@
+'use client';
+
+// =============================================================================
+// Stone Theme Palette Preview
+// Uses real XDS components to render the theme as it would appear in production.
+// =============================================================================
+
+import {XDSBanner} from '@xds/core/Banner';
+import {XDSTextInput} from '@xds/core/TextInput';
+import {XDSBadge} from '@xds/core/Badge';
+import {XDSButton} from '@xds/core/Button';
+import {XDSVStack, XDSHStack} from '@xds/core/Layout';
+import {XDSText, XDSHeading} from '@xds/core/Text';
+import {XDSTheme} from '@xds/core/theme';
+import {XDSLayerProvider} from '@xds/core/Layer';
+import {stoneTheme} from '@xds/theme-stone/built';
+
+// === WCAG contrast helpers ===
+
+function hexToRgb(hex: string): [number, number, number] {
+  const h = hex.replace('#', '').slice(0, 6);
+  const full = h.length === 3 ? h[0] + h[0] + h[1] + h[1] + h[2] + h[2] : h;
+  const n = parseInt(full, 16);
+  return [(n >> 16) & 0xff, (n >> 8) & 0xff, n & 0xff];
+}
+
+function luminance(hex: string): number {
+  const [r, g, b] = hexToRgb(hex).map(c => {
+    const s = c / 255;
+    return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+  });
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+function _contrastRatio(fg: string, bg: string): number {
+  const l1 = luminance(fg);
+  const l2 = luminance(bg);
+  return (Math.max(l1, l2) + 0.05) / (Math.min(l1, l2) + 0.05);
+}
+
+function _passesAA(ratio: number): boolean {
+  return ratio >= 4.5;
+}
+
+// === HCT color space helpers for tonal palettes ===
+
+function srgbToLinear(c: number): number {
+  const s = c / 255;
+  return s <= 0.04045 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+}
+function linearToSrgb(c: number): number {
+  const s =
+    c <= 0.0031308 ? c * 12.92 : 1.055 * Math.pow(c, 1 / 2.4) - 0.055;
+  return Math.round(Math.min(255, Math.max(0, s * 255)));
+}
+function linearRgbToXyz(
+  r: number,
+  g: number,
+  b: number,
+): [number, number, number] {
+  return [
+    0.4124564 * r + 0.3575761 * g + 0.1804375 * b,
+    0.2126729 * r + 0.7151522 * g + 0.072175 * b,
+    0.0193339 * r + 0.119192 * g + 0.9503041 * b,
+  ];
+}
+function xyzToLinearRgb(
+  x: number,
+  y: number,
+  z: number,
+): [number, number, number] {
+  return [
+    3.2404542 * x - 1.5371385 * y - 0.4985314 * z,
+    -0.969266 * x + 1.8760108 * y + 0.041556 * z,
+    0.0556434 * x - 0.2040259 * y + 1.0572252 * z,
+  ];
+}
+const D65: [number, number, number] = [0.95047, 1.0, 1.08883];
+function labF(t: number): number {
+  const d = 6 / 29;
+  return t > d * d * d ? Math.cbrt(t) : t / (3 * d * d) + 4 / 29;
+}
+function labFInv(t: number): number {
+  const d = 6 / 29;
+  return t > d ? t * t * t : 3 * d * d * (t - 4 / 29);
+}
+function xyzToLab(
+  x: number,
+  y: number,
+  z: number,
+): [number, number, number] {
+  const fx = labF(x / D65[0]),
+    fy = labF(y / D65[1]),
+    fz = labF(z / D65[2]);
+  return [116 * fy - 16, 500 * (fx - fy), 200 * (fy - fz)];
+}
+function labToXyz(
+  L: number,
+  a: number,
+  b: number,
+): [number, number, number] {
+  const fy = (L + 16) / 116,
+    fx = a / 500 + fy,
+    fz = fy - b / 200;
+  return [
+    labFInv(fx) * D65[0],
+    labFInv(fy) * D65[1],
+    labFInv(fz) * D65[2],
+  ];
+}
+
+interface HCT {
+  hue: number;
+  chroma: number;
+  tone: number;
+}
+
+function hexToHct(hex: string): HCT {
+  const [r, g, b] = hexToRgb(hex);
+  const [x, y, z] = linearRgbToXyz(
+    srgbToLinear(r),
+    srgbToLinear(g),
+    srgbToLinear(b),
+  );
+  const [L, a, bL] = xyzToLab(x, y, z);
+  let hue = (Math.atan2(bL, a) * 180) / Math.PI;
+  if (hue < 0) hue += 360;
+  return {
+    hue,
+    chroma: Math.sqrt(a * a + bL * bL),
+    tone: Math.max(0, Math.min(100, L)),
+  };
+}
+
+function hctToHex({hue, chroma, tone}: HCT): string {
+  if (tone <= 0) return '#000000';
+  if (tone >= 100) return '#ffffff';
+  if (chroma < 0.5) {
+    const y = labFInv((tone + 16) / 116);
+    const g = linearToSrgb(y);
+    return (
+      '#' +
+      [g, g, g].map(c => c.toString(16).padStart(2, '0')).join('')
+    );
+  }
+  let lo = 0,
+    hi = chroma,
+    best = '#000000';
+  for (let i = 0; i < 16; i++) {
+    const mid = (lo + hi) / 2;
+    const hRad = (hue * Math.PI) / 180;
+    const a = Math.cos(hRad) * mid,
+      b = Math.sin(hRad) * mid;
+    const [x, y, z] = labToXyz(tone, a, b);
+    const [lr, lg, lb] = xyzToLinearRgb(x, y, z);
+    const r = linearToSrgb(lr),
+      g = linearToSrgb(lg),
+      bv = linearToSrgb(lb);
+    const ok =
+      Math.abs(srgbToLinear(r) - lr) < 0.02 &&
+      Math.abs(srgbToLinear(g) - lg) < 0.02 &&
+      Math.abs(srgbToLinear(bv) - lb) < 0.02 &&
+      r >= 0 &&
+      r <= 255 &&
+      g >= 0 &&
+      g <= 255 &&
+      bv >= 0 &&
+      bv <= 255;
+    if (ok) {
+      best =
+        '#' +
+        [r, g, bv].map(c => c.toString(16).padStart(2, '0')).join('');
+      lo = mid;
+    } else {
+      hi = mid;
+    }
+  }
+  return best;
+}
+
+const TONE_STEPS = [0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100];
+
+function tonalPalette(
+  hue: number,
+  chroma: number,
+): Record<number, string> {
+  const result: Record<number, string> = {};
+  for (const t of TONE_STEPS)
+    result[t] = hctToHex({hue, chroma, tone: t});
+  return result;
+}
+
+const TONAL_COLORS = [
+  {name: 'Stone Neutral', sourceHex: '#e2e2e2'},
+  {name: 'Blue', sourceHex: '#d7e4f5'},
+  {name: 'Cyan', sourceHex: '#cce8e5'},
+  {name: 'Green', sourceHex: '#d0e9ce', semantic: 'Success'},
+  {name: 'Teal', sourceHex: '#d4e7dc'},
+  {name: 'Yellow', sourceHex: '#f4e1b7', semantic: 'Warning'},
+  {name: 'Orange', sourceHex: '#ffdcbb'},
+  {name: 'Red', sourceHex: '#f9dcd7', semantic: 'Error'},
+  {name: 'Pink', sourceHex: '#f0dde8'},
+  {name: 'Purple', sourceHex: '#e8dff3'},
+];
+
+// === Hardcoded Stone palette (mirror of packages/themes/stone/src/stoneTheme.ts) ===
+
+const CORE = [
+  {hex: '#28282A', name: 'Stone 900'},
+  {hex: '#84848B', name: 'Stone 500'},
+  {hex: '#D8D8DB', name: 'Stone 300'},
+  {hex: '#f3f3f5', name: 'Stone 100'},
+  {hex: '#FFFFFF', name: 'White'},
+];
+
+type Mode = 'light' | 'dark';
+
+type Surfaces = typeof VAR_SURFACES;
+
+// Surface colors read from CSS variables — no hardcoded hex values to drift.
+const VAR_SURFACES = {
+  body: 'var(--color-background-body)',
+  surface: 'var(--color-background-surface)',
+  card: 'var(--color-background-card)',
+  border: 'var(--color-border)',
+  borderEmphasized: 'var(--color-border-emphasized)',
+  textPrimary: 'var(--color-text-primary)',
+  textSecondary: 'var(--color-text-secondary)',
+  accent: 'var(--color-accent)',
+  onAccent: 'var(--color-on-accent)',
+};
+
+interface BadgePair {
+  label: string;
+  bg: string;
+  fg: string;
+}
+
+const _SEMANTIC: Record<Mode, BadgePair[]> = {
+  light: [
+    {label: 'Success', bg: '#d0e9ce', fg: '#374c36'},
+    {label: 'Error', bg: '#f9dcd7', fg: '#58413e'},
+    {label: 'Warning', bg: '#f4e1b7', fg: '#524622'},
+    {label: 'Info', bg: '#d7e4f5', fg: '#3c4856'},
+    {label: 'Neutral', bg: '#e3e2e0', fg: '#474745'},
+  ],
+  dark: [
+    {label: 'Success', bg: '#2a4f2b', fg: '#a7d1a6'},
+    {label: 'Error', bg: '#613d38', fg: '#e9bcb5'},
+    {label: 'Warning', bg: '#554502', fg: '#dec47f'},
+    {label: 'Info', bg: '#33485f', fg: '#b3c8e4'},
+    {label: 'Neutral', bg: '#484744', fg: '#c8c6c3'},
+  ],
+};
+
+const _CATEGORICAL: Record<Mode, BadgePair[]> = {
+  light: [
+    {label: 'Blue', bg: '#d7e4f5', fg: '#3c4856'},
+    {label: 'Cyan', bg: '#cce8e5', fg: '#334b49'},
+    {label: 'Gray', bg: '#e3e2e0', fg: '#474745'},
+    {label: 'Green', bg: '#d0e9ce', fg: '#374c36'},
+    {label: 'Orange', bg: '#ffdcbb', fg: '#5b4227'},
+    {label: 'Pink', bg: '#f0dde8', fg: '#52424c'},
+    {label: 'Purple', bg: '#e8dff3', fg: '#4b4454'},
+    {label: 'Red', bg: '#f9dcd7', fg: '#58413e'},
+    {label: 'Teal', bg: '#d4e7dc', fg: '#3b4a41'},
+    {label: 'Yellow', bg: '#f4e1b7', fg: '#524622'},
+  ],
+  dark: [
+    {label: 'Blue', bg: '#33485f', fg: '#b3c8e4'},
+    {label: 'Cyan', bg: '#234e4b', fg: '#a2cfcb'},
+    {label: 'Gray', bg: '#484744', fg: '#c8c6c3'},
+    {label: 'Green', bg: '#2a4f2b', fg: '#a7d1a6'},
+    {label: 'Orange', bg: '#643e0f', fg: '#f1bd88'},
+    {label: 'Pink', bg: '#593f4f', fg: '#ddbed0'},
+    {label: 'Purple', bg: '#4d425d', fg: '#cec1e1'},
+    {label: 'Red', bg: '#613d38', fg: '#e9bcb5'},
+    {label: 'Teal', bg: '#324c3e', fg: '#afcebb'},
+    {label: 'Yellow', bg: '#554502', fg: '#dec47f'},
+  ],
+};
+
+// =============================================================================
+// Styles
+// =============================================================================
+
+const _FONT =
+  "'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif";
+const MONO = "'JetBrains Mono', 'SF Mono', Menlo, monospace";
+
+const S = {
+  page: {
+    minHeight: '100vh',
+    background: 'var(--color-background-body)',
+    color: 'var(--color-text-primary)',
+    fontFamily: 'var(--font-family-body)',
+    padding: '40px 32px',
+  } as React.CSSProperties,
+  inner: {
+    maxWidth: 1280,
+    margin: '0 auto',
+  } as React.CSSProperties,
+  title: {
+    fontSize: 32,
+    fontWeight: 700,
+    letterSpacing: '-0.02em',
+    margin: 0,
+    marginBottom: 8,
+    fontFamily: 'var(--font-family-heading)',
+  } as React.CSSProperties,
+  subtitle: {
+    fontSize: 14,
+    color: 'var(--color-text-secondary)',
+    margin: 0,
+    marginBottom: 32,
+  } as React.CSSProperties,
+  twoCol: {
+    display: 'grid',
+    gridTemplateColumns: '1fr 1fr',
+    gap: 24,
+  } as React.CSSProperties,
+  modeCol: (bg: string, fg: string) =>
+    ({
+      background: bg,
+      color: fg,
+      border: '1px solid var(--color-border)',
+      borderRadius: 16,
+      padding: 24,
+      display: 'flex',
+      flexDirection: 'column' as const,
+      gap: 28,
+    }) as React.CSSProperties,
+  modeLabel: {
+    fontSize: 11,
+    fontWeight: 600,
+    textTransform: 'uppercase' as const,
+    letterSpacing: '0.1em',
+    margin: 0,
+    marginBottom: 16,
+    opacity: 0.6,
+  } as React.CSSProperties,
+  section: {} as React.CSSProperties,
+  sectionTitle: {
+    fontSize: 13,
+    fontWeight: 600,
+    margin: 0,
+    marginBottom: 12,
+  } as React.CSSProperties,
+  coreRow: {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(5, 1fr)',
+    gap: 10,
+  } as React.CSSProperties,
+  coreSwatch: (bg: string) =>
+    ({
+      background: bg,
+      borderRadius: 10,
+      border: '1px solid rgba(0,0,0,0.08)',
+      height: 88,
+    }) as React.CSSProperties,
+  coreMeta: {
+    marginTop: 6,
+    fontFamily: MONO,
+    fontSize: 10,
+    lineHeight: 1.4,
+    opacity: 0.7,
+  } as React.CSSProperties,
+  badgeGrid: {
+    display: 'flex',
+    flexWrap: 'wrap' as const,
+    gap: 12,
+  } as React.CSSProperties,
+  badgeCell: {
+    display: 'flex',
+    flexDirection: 'column' as const,
+    alignItems: 'flex-start',
+    gap: 4,
+    minWidth: 110,
+  } as React.CSSProperties,
+  badge: (bg: string, fg: string) =>
+    ({
+      display: 'inline-flex',
+      alignItems: 'center',
+      padding: '4px 12px',
+      borderRadius: 9999,
+      background: bg,
+      color: fg,
+      fontSize: 12,
+      fontWeight: 500,
+      lineHeight: 1.5,
+    }) as React.CSSProperties,
+  contrastNote: (pass: boolean) =>
+    ({
+      fontFamily: MONO,
+      fontSize: 10,
+      opacity: 0.85,
+      color: pass ? undefined : '#b5463a',
+    }) as React.CSSProperties,
+  buttonRow: {
+    display: 'flex',
+    gap: 10,
+    flexWrap: 'wrap' as const,
+  } as React.CSSProperties,
+  primaryBtn: (s: Surfaces) =>
+    ({
+      display: 'inline-flex',
+      alignItems: 'center',
+      padding: '8px 20px',
+      borderRadius: 9999,
+      background: s.accent,
+      color: s.onAccent,
+      border: 'none',
+      fontSize: 13,
+      fontWeight: 500,
+      fontFamily: 'inherit',
+      cursor: 'default',
+    }) as React.CSSProperties,
+  secondaryBtn: (s: Surfaces) =>
+    ({
+      display: 'inline-flex',
+      alignItems: 'center',
+      padding: '6.5px 18.5px',
+      borderRadius: 9999,
+      background: 'transparent',
+      color: s.textPrimary,
+      border: `1.5px solid ${s.borderEmphasized}`,
+      fontSize: 13,
+      fontWeight: 500,
+      fontFamily: 'inherit',
+      cursor: 'default',
+    }) as React.CSSProperties,
+  ghostBtn: (s: Surfaces) =>
+    ({
+      display: 'inline-flex',
+      alignItems: 'center',
+      padding: '8px 20px',
+      borderRadius: 9999,
+      background: 'transparent',
+      color: s.textPrimary,
+      border: 'none',
+      fontSize: 13,
+      fontWeight: 500,
+      fontFamily: 'inherit',
+      cursor: 'default',
+    }) as React.CSSProperties,
+  surfacesGrid: {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(5, 1fr)',
+    gap: 8,
+  } as React.CSSProperties,
+  surfaceCell: {
+    display: 'flex',
+    flexDirection: 'column' as const,
+    gap: 4,
+  } as React.CSSProperties,
+  surfaceSwatch: (bg: string, ring: string) =>
+    ({
+      height: 56,
+      background: bg,
+      borderRadius: 8,
+      border: `1px solid ${ring}`,
+    }) as React.CSSProperties,
+  surfaceMeta: {
+    fontFamily: MONO,
+    fontSize: 9.5,
+    lineHeight: 1.3,
+    opacity: 0.7,
+  } as React.CSSProperties,
+  tonalRow: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 8,
+    marginBottom: 4,
+  } as React.CSSProperties,
+  tonalLabel: {
+    width: 80,
+    flexShrink: 0,
+    fontSize: 10,
+    fontFamily: MONO,
+    opacity: 0.7,
+  } as React.CSSProperties,
+  tonalStrip: {
+    display: 'flex',
+    flex: 1,
+    borderRadius: 6,
+    overflow: 'hidden',
+    border: '1px solid rgba(0,0,0,0.06)',
+  } as React.CSSProperties,
+  tonalCell: (bg: string) =>
+    ({
+      flex: 1,
+      height: 36,
+      background: bg,
+      display: 'flex',
+      alignItems: 'flex-end',
+      justifyContent: 'center',
+      paddingBottom: 2,
+    }) as React.CSSProperties,
+  tonalNum: (tone: number) =>
+    ({
+      fontSize: 7,
+      fontFamily: MONO,
+      color: tone >= 50 ? 'rgba(0,0,0,0.4)' : 'rgba(255,255,255,0.5)',
+      pointerEvents: 'none' as const,
+    }) as React.CSSProperties,
+  tonalHct: {
+    width: 60,
+    flexShrink: 0,
+    fontSize: 9,
+    fontFamily: MONO,
+    opacity: 0.5,
+    textAlign: 'right' as const,
+  } as React.CSSProperties,
+  markerDot: (tone: number) =>
+    ({
+      position: 'absolute' as const,
+      top: 2,
+      left: '50%',
+      transform: 'translateX(-50%)',
+      width: 6,
+      height: 6,
+      borderRadius: '50%',
+      border: `1.5px solid ${tone >= 50 ? 'rgba(0,0,0,0.5)' : 'rgba(255,255,255,0.7)'}`,
+      background: tone >= 50 ? 'rgba(0,0,0,0.15)' : 'rgba(255,255,255,0.25)',
+    }) as React.CSSProperties,
+};
+
+// =============================================================================
+// Component
+// =============================================================================
+
+function CoreSection({mode: _mode}: {mode: Mode}) {
+  return (
+    <div style={S.section}>
+      <h3 style={S.sectionTitle}>Core Palette</h3>
+      <div style={S.coreRow}>
+        {CORE.map(c => (
+          <div key={c.hex}>
+            <div style={S.coreSwatch(c.hex)} />
+            <div style={S.coreMeta}>
+              <div>{c.name}</div>
+              <div>{c.hex}</div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function TextRampSection() {
+  const base = 14;
+  const ratio = 1.25;
+  const sizes = {
+    h1: (base * ratio ** 4).toFixed(1),
+    h2: (base * ratio ** 3).toFixed(1),
+    h3: (base * ratio ** 2).toFixed(1),
+    h4: (base * ratio ** 1).toFixed(1),
+    body: base.toFixed(1),
+    supporting: '12.0',
+  };
+  return (
+    <div style={S.section}>
+      <h3 style={S.sectionTitle}>Text Hierarchy (1.25 scale, 14px base)</h3>
+      <XDSVStack gap={2}>
+        <XDSHStack gap={2} vAlign="end"><XDSHeading level={1}>Heading 1</XDSHeading><XDSText type="supporting" color="secondary">{sizes.h1}px</XDSText></XDSHStack>
+        <XDSHStack gap={2} vAlign="end"><XDSHeading level={2}>Heading 2</XDSHeading><XDSText type="supporting" color="secondary">{sizes.h2}px</XDSText></XDSHStack>
+        <XDSHStack gap={2} vAlign="end"><XDSHeading level={3}>Heading 3</XDSHeading><XDSText type="supporting" color="secondary">{sizes.h3}px</XDSText></XDSHStack>
+        <XDSHStack gap={2} vAlign="end"><XDSHeading level={4}>Heading 4</XDSHeading><XDSText type="supporting" color="secondary">{sizes.h4}px</XDSText></XDSHStack>
+        <XDSHStack gap={2} vAlign="end"><XDSText type="body">Body — primary</XDSText><XDSText type="supporting" color="secondary">{sizes.body}px</XDSText></XDSHStack>
+        <XDSHStack gap={2} vAlign="end"><XDSText type="body" color="secondary">Body — secondary</XDSText><XDSText type="supporting" color="secondary">{sizes.body}px</XDSText></XDSHStack>
+        <XDSHStack gap={2} vAlign="end"><XDSText type="supporting">Supporting</XDSText><XDSText type="supporting" color="secondary">{sizes.supporting}px</XDSText></XDSHStack>
+        <XDSHStack gap={2} vAlign="end"><XDSText type="body" color="disabled">Disabled</XDSText><XDSText type="supporting" color="secondary">{sizes.body}px</XDSText></XDSHStack>
+      </XDSVStack>
+    </div>
+  );
+}
+
+function SemanticBadgeSection() {
+  return (
+    <div style={S.section}>
+      <h3 style={S.sectionTitle}>Semantic Badges</h3>
+      <XDSHStack gap={2} wrap>
+        <XDSBadge variant="success" label="Success" />
+        <XDSBadge variant="error" label="Error" />
+        <XDSBadge variant="warning" label="Warning" />
+        <XDSBadge variant="info" label="Info" />
+        <XDSBadge variant="neutral" label="Neutral" />
+      </XDSHStack>
+    </div>
+  );
+}
+
+function CategoricalBadgeSection() {
+  return (
+    <div style={S.section}>
+      <h3 style={S.sectionTitle}>Categorical Badges</h3>
+      <XDSHStack gap={2} wrap>
+        <XDSBadge variant="blue" label="Blue" />
+        <XDSBadge variant="cyan" label="Cyan" />
+        <XDSBadge variant="green" label="Green" />
+        <XDSBadge variant="orange" label="Orange" />
+        <XDSBadge variant="pink" label="Pink" />
+        <XDSBadge variant="purple" label="Purple" />
+        <XDSBadge variant="red" label="Red" />
+        <XDSBadge variant="teal" label="Teal" />
+        <XDSBadge variant="yellow" label="Yellow" />
+      </XDSHStack>
+    </div>
+  );
+}
+
+function ButtonSection() {
+  return (
+    <div style={S.section}>
+      <h3 style={S.sectionTitle}>Buttons</h3>
+      <XDSVStack gap={4}>
+        <div>
+          <div style={{fontSize: 10, fontFamily: MONO, opacity: 0.6, marginBottom: 6}}>Default</div>
+          <XDSHStack gap={3} vAlign="center">
+            <XDSButton label="Primary" variant="primary" />
+            <XDSButton label="Secondary" variant="secondary" />
+            <XDSButton label="Ghost" variant="ghost" />
+            <XDSButton label="Destructive" variant="destructive" />
+          </XDSHStack>
+        </div>
+        <div>
+          <div style={{fontSize: 10, fontFamily: MONO, opacity: 0.6, marginBottom: 6}}>Disabled</div>
+          <XDSHStack gap={3} vAlign="center">
+            <XDSButton label="Primary" variant="primary" isDisabled />
+            <XDSButton label="Secondary" variant="secondary" isDisabled />
+            <XDSButton label="Ghost" variant="ghost" isDisabled />
+            <XDSButton label="Destructive" variant="destructive" isDisabled />
+          </XDSHStack>
+        </div>
+      </XDSVStack>
+    </div>
+  );
+}
+
+function SurfacesSection({mode}: {mode: Mode}) {
+  const ring =
+    mode === 'light' ? 'rgba(0,0,0,0.08)' : 'rgba(255,255,255,0.08)';
+  const cells = [
+    {label: 'border', hex: VAR_SURFACES.border},
+    {label: 'border-emp', hex: VAR_SURFACES.borderEmphasized},
+    {label: 'surface', hex: VAR_SURFACES.surface},
+    {label: 'body', hex: VAR_SURFACES.body},
+    {label: 'card', hex: VAR_SURFACES.card},
+  ];
+  return (
+    <div style={S.section}>
+      <h3 style={S.sectionTitle}>Borders & Surfaces</h3>
+      <div style={S.surfacesGrid}>
+        {cells.map(c => (
+          <div key={c.label} style={S.surfaceCell}>
+            <div style={S.surfaceSwatch(c.hex, ring)} />
+            <div style={S.surfaceMeta}>
+              <div>{c.label}</div>
+              <div>{c.hex}</div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function TonalSection() {
+  const usedTones = [15, 25, 75, 80];
+  return (
+    <div style={{marginBottom: 40}}>
+      <h2
+        style={{
+          fontSize: 20,
+          fontWeight: 700,
+          letterSpacing: '-0.01em',
+          margin: 0,
+          marginBottom: 6,
+          fontFamily: 'var(--font-family-heading)',
+        }}>
+        Tonal Palettes
+      </h2>
+      <p
+        style={{
+          fontSize: 12,
+          color: 'var(--color-text-secondary)',
+          margin: 0,
+          marginBottom: 20,
+        }}>
+        Full HCT tonal ramps — 16 perceptually uniform steps from black (T0) to
+        white (T100). Badge tokens use T75/T25 (light) and T15/T80 (dark).
+      </p>
+      {TONAL_COLORS.map(({name, sourceHex, semantic}) => {
+        const hct = hexToHct(sourceHex);
+        const tones = tonalPalette(hct.hue, hct.chroma);
+        return (
+          <div key={name} style={S.tonalRow}>
+            <span style={S.tonalLabel}>
+              {name}
+              {semantic && (
+                <span style={{display: 'block', fontSize: 8, opacity: 0.5}}>
+                  = {semantic}
+                </span>
+              )}
+            </span>
+            <div style={S.tonalStrip}>
+              {TONE_STEPS.map(t => (
+                <div
+                  key={t}
+                  style={{
+                    ...S.tonalCell(tones[t]),
+                    position: 'relative' as const,
+                  }}
+                  title={`${name} T${t}: ${tones[t]}`}>
+                  <span style={S.tonalNum(t)}>{t}</span>
+                  {usedTones.includes(t) && (
+                    <div style={S.markerDot(t)} />
+                  )}
+                </div>
+              ))}
+            </div>
+            <span style={S.tonalHct}>
+              H:{hct.hue.toFixed(0)} C:{hct.chroma.toFixed(0)}
+            </span>
+          </div>
+        );
+      })}
+      <p
+        style={{
+          fontSize: 10,
+          color: 'var(--color-text-secondary)',
+          margin: 0,
+          marginTop: 10,
+          fontFamily: MONO,
+        }}>
+        ● = token in use (T15 dark bg · T25 light text · T75 light bg · T80
+        dark text)
+      </p>
+    </div>
+  );
+}
+
+function BannerSection() {
+  return (
+    <div style={S.section}>
+      <h3 style={S.sectionTitle}>Banners</h3>
+      <XDSVStack gap={2}>
+        <XDSBanner status="info" title="Info banner title" description="Description text for the info state." />
+        <XDSBanner status="success" title="Success banner title" description="Description text for the success state." />
+        <XDSBanner status="warning" title="Warning banner title" description="Description text for the warning state." />
+        <XDSBanner status="error" title="Error banner title" description="Description text for the error state." />
+      </XDSVStack>
+    </div>
+  );
+}
+
+function InputSection() {
+  return (
+    <div style={S.section}>
+      <h3 style={S.sectionTitle}>Inputs</h3>
+      <XDSVStack gap={3}>
+        <XDSTextInput label="Default" placeholder="Placeholder text" value="" onChange={() => {}} />
+        <XDSTextInput label="Success" value="Valid input" onChange={() => {}} status={{type: 'success', message: 'Looks good!'}} />
+        <XDSTextInput label="Error" value="Invalid input" onChange={() => {}} status={{type: 'error', message: 'This field is required.'}} />
+        <XDSTextInput label="Warning" value="Risky value" onChange={() => {}} status={{type: 'warning', message: 'This value may cause issues.'}} />
+        <XDSTextInput label="Disabled" value="Cannot edit" onChange={() => {}} isDisabled />
+      </XDSVStack>
+    </div>
+  );
+}
+
+function ModeColumn({mode}: {mode: Mode}) {
+  return (
+    <XDSTheme theme={stoneTheme} mode={mode}>
+      <XDSLayerProvider>
+        <div style={S.modeCol(VAR_SURFACES.body, VAR_SURFACES.textPrimary)}>
+          <p style={S.modeLabel}>{mode === 'light' ? 'Light Mode' : 'Dark Mode'}</p>
+          <CoreSection mode={mode} />
+          <TextRampSection />
+          <SemanticBadgeSection />
+          <CategoricalBadgeSection />
+          <BannerSection />
+          <InputSection />
+          <ButtonSection />
+          <SurfacesSection mode={mode} />
+        </div>
+      </XDSLayerProvider>
+    </XDSTheme>
+  );
+}
+
+export default function StonePalettePage() {
+  return (
+    <XDSTheme theme={stoneTheme} mode="light">
+      <XDSLayerProvider>
+        <div style={S.page}>
+          <div style={S.inner}>
+            <h1 style={S.title}>Stone Theme Palette</h1>
+            <p style={S.subtitle}>
+              A snapshot of the warm, earthy Stone theme — every token rendered
+              alongside its dark-mode counterpart.
+            </p>
+            <TonalSection />
+            <div style={S.twoCol}>
+              <ModeColumn mode="light" />
+              <ModeColumn mode="dark" />
+            </div>
+          </div>
+        </div>
+      </XDSLayerProvider>
+    </XDSTheme>
+  );
+}

--- a/apps/sandbox/src/app/(sandbox)/pages/stone-palette/page.tsx
+++ b/apps/sandbox/src/app/(sandbox)/pages/stone-palette/page.tsx
@@ -580,7 +580,7 @@ function SemanticBadgeSection() {
   return (
     <div style={S.section}>
       <h3 style={S.sectionTitle}>Semantic Badges</h3>
-      <XDSHStack gap={2} wrap>
+      <XDSHStack gap={2} wrap="wrap">
         <XDSBadge variant="success" label="Success" />
         <XDSBadge variant="error" label="Error" />
         <XDSBadge variant="warning" label="Warning" />
@@ -595,7 +595,7 @@ function CategoricalBadgeSection() {
   return (
     <div style={S.section}>
       <h3 style={S.sectionTitle}>Categorical Badges</h3>
-      <XDSHStack gap={2} wrap>
+      <XDSHStack gap={2} wrap="wrap">
         <XDSBadge variant="blue" label="Blue" />
         <XDSBadge variant="cyan" label="Cyan" />
         <XDSBadge variant="green" label="Green" />

--- a/packages/themes/stone/src/source.ts
+++ b/packages/themes/stone/src/source.ts
@@ -1,2 +1,2 @@
-export {stoneTheme} from './stoneTheme';
+export {stoneTheme, stonePalettes} from './stoneTheme';
 export {stoneIconRegistry} from './icons';

--- a/packages/themes/stone/src/stoneTheme.ts
+++ b/packages/themes/stone/src/stoneTheme.ts
@@ -2,31 +2,31 @@
  * Stone Theme
  *
  * A warm, earthy neutral theme inspired by natural stone and sandstone.
- * Core palette: #28282A, #84848B, #D8D8DB, #F5F5F3, #FFFFFF
+ * Core palette: #28282A, #84848B, #D8D8DB, #f3f3f5, #FFFFFF
  * Uses Montserrat for headings and Figtree for body text.
  */
 
 import {defineTheme, defineSyntaxTheme} from '@xds/core/theme';
 import {stoneIconRegistry} from './icons';
 
-/** Stone syntax palette — warm, muted tones to match the earthy aesthetic. */
+/** Stone syntax palette — derived from categorical hues at T40 (light) / T70 (dark). */
 const stoneSyntax = defineSyntaxTheme({
   name: 'xds-stone',
   tokens: {
-    keyword: ['#7c5e3a', '#c4a882'],
-    string: ['#2e6b4a', '#7bc49e'],
-    comment: ['#84848B', '#84848B'],
-    number: ['#a16830', '#d4a06a'],
-    function: ['#3a5e8c', '#7ba8d4'],
-    type: ['#6b4a8c', '#b08ed4'],
-    variable: ['#28282A', '#D8D8DB'],
-    operator: ['#84848B', '#a1a1a6'],
-    constant: ['#a16830', '#d4a06a'],
-    tag: ['#b5463a', '#e08a82'],
-    attribute: ['#8c6b30', '#d4b870'],
-    property: ['#3a7c6b', '#70c4b0'],
-    punctuation: ['#84848B', '#5a5a60'],
-    background: ['#F5F5F3', '#1a1a1c'],
+    keyword: ['#645a72', '#b2a7c1'],    // Purple H=307 C=15
+    string: ['#50634f', '#9bb19a'],      // Green H=142 C=15
+    comment: ['#5e5e63', '#ababb0'],     // Gray H=291 C=3
+    number: ['#6f5b48', '#bea792'],      // Orange H=70 C=15
+    function: ['#4d6076', '#99adc6'],    // Blue H=265 C=15
+    type: ['#645a72', '#b2a7c1'],        // Purple H=307 C=15
+    variable: ['#5e5e63', '#ababb0'],    // Gray H=291 C=3
+    operator: ['#5e5e63', '#ababb0'],    // Gray H=291 C=3
+    constant: ['#6f5b48', '#bea792'],    // Orange H=70 C=15
+    tag: ['#775751', '#c7a39d'],         // Red H=33 C=15
+    attribute: ['#675d46', '#b6aa90'],   // Yellow H=90 C=15
+    property: ['#496455', '#94b2a0'],    // Teal H=158 C=15
+    punctuation: ['#5e5e63', '#ababb0'], // Gray H=291 C=3
+    background: ['#f3f3f5', '#171719'],
   },
 });
 
@@ -34,7 +34,7 @@ export const stoneTheme = defineTheme({
   name: 'stone',
 
   typography: {
-    scale: {base: 14, ratio: 1.2},
+    scale: {base: 14, ratio: 1.25},
     body: {
       family: 'Figtree',
       fallbacks:
@@ -59,119 +59,124 @@ export const stoneTheme = defineTheme({
   tokens: {
     // =========================================================================
     // Colors — warm stone palette
-    // Core: #28282A, #84848B, #D8D8DB, #F5F5F3, #FFFFFF
+    // Core: #28282A, #84848B, #D8D8DB, #f3f3f5, #FFFFFF
     // =========================================================================
 
-    // Core semantic
-    '--color-accent': ['#28282A', '#F5F5F3'],
-    '--color-accent-muted': ['#28282A14', '#F5F5F320'],
-    '--color-neutral': ['#28282A0F', '#F5F5F31A'],
-    '--color-background-surface': ['#FFFFFF', '#1a1a1c'],
-    '--color-background-body': ['#F5F5F3', '#111113'],
-    '--color-overlay': ['#28282A80', '#28282ACC'],
-    '--color-overlay-hover': ['#28282A0D', '#F5F5F30D'],
-    '--color-overlay-pressed': ['#28282A1A', '#F5F5F31A'],
-    '--color-background-muted': ['#F5F5F3', '#28282A'],
+    // Core semantic — all neutrals H=291
+    // Stone 900 T=16 C=1.4, Stone 500 T=55 C=4, Stone 300 T=86 C=1.6, Stone 100 T=96 C=1
+    '--color-accent': ['#28282a', '#f3f3f5'],
+    '--color-accent-muted': ['#28282a14', '#f3f3f520'],
+    '--color-neutral': ['#28282a0F', '#f3f3f51A'],
+    '--color-background-surface': ['#FFFFFF', '#1f1f21'],  // T12
+    '--color-background-body': ['#f3f3f5', '#171719'],     // T8
+    '--color-overlay': ['#28282a80', '#28282aCC'],
+    '--color-overlay-hover': ['#28282a0D', '#f3f3f50D'],
+    '--color-overlay-pressed': ['#28282a1A', '#f3f3f51A'],
+    '--color-background-muted': ['#f3f3f5', '#28282a'],
 
-    // Text
-    '--color-text-primary': ['#28282A', '#F5F5F3'],
-    '--color-text-secondary': ['#84848B', '#a1a1a6'],
-    '--color-text-disabled': ['#D8D8DB', '#5a5a60'],
-    '--color-text-accent': ['#28282A', '#F5F5F3'],
+    // Text — H=291
+    '--color-text-primary': ['#28282a', '#f3f3f5'],        // T16 / T96
+    '--color-text-secondary': ['#83838a', '#9d9da3'],      // T55 C=4 / T65 C=3
+    '--color-text-disabled': ['#d7d7da', '#5e5e61'],       // T86 C=1.6 / T40 C=2
+    '--color-text-accent': ['#28282a', '#f3f3f5'],
     '--color-on-dark': '#FFFFFF',
-    '--color-on-light': '#28282A',
-    '--color-on-accent': ['#FFFFFF', '#28282A'],
-    '--color-on-success': ['#FFFFFF', '#28282A'],
-    '--color-on-error': ['#FFFFFF', '#28282A'],
-    '--color-on-warning': ['#28282A', '#28282A'],
+    '--color-on-light': '#28282a',
+    '--color-on-accent': ['#FFFFFF', '#28282a'],
+    '--color-on-success': ['#374c36', '#b4cdb2'],          // Green T30 / T80
+    '--color-on-error': ['#58413e', '#dcc0bc'],             // Red T30 / T80
+    '--color-on-warning': ['#524622', '#d7c59c'],           // Yellow T30 / T80
 
-    // Icon
-    '--color-icon-accent': ['#28282A', '#F5F5F3'],
-    '--color-icon-primary': ['#28282A', '#F5F5F3'],
-    '--color-icon-secondary': ['#84848B', '#a1a1a6'],
-    '--color-icon-disabled': ['#D8D8DB', '#5a5a60'],
+    // Icon — H=291
+    '--color-icon-accent': ['#28282a', '#f3f3f5'],
+    '--color-icon-primary': ['#28282a', '#f3f3f5'],
+    '--color-icon-secondary': ['#83838a', '#9d9da3'],      // T55 C=4 / T65 C=3
+    '--color-icon-disabled': ['#d7d7da', '#5e5e61'],       // T86 C=1.6 / T40 C=2
 
-    // Surface variants
-    '--color-background-card': ['#FFFFFF', '#1e1e20'],
-    '--color-background-popover': ['#FFFFFF', '#28282A'],
-    '--color-background-inverted': ['#28282A', '#F5F5F3'],
+    // Surface variants — H=291
+    '--color-background-card': ['#FFFFFF', '#242325'],      // T14
+    '--color-background-popover': ['#FFFFFF', '#28282a'],   // T16
+    '--color-background-inverted': ['#28282a', '#f3f3f5'],
 
-    // Status / Sentiment
-    '--color-success': ['#109936', '#34c265'],
-    '--color-success-muted': ['#10993620', '#34c26520'],
-    '--color-error': ['#FD0000', '#ff5c5c'],
-    '--color-error-muted': ['#FD000020', '#ff5c5c20'],
-    '--color-warning': ['#FFB600', '#ffc940'],
-    '--color-warning-muted': ['#FFB60020', '#ffc94020'],
+    // Status / Sentiment — T50 from palette for icons/borders (visible color)
+    '--color-success': ['#374c36', '#b4cdb2'],              // Green T30 / T80
+    '--color-success-muted': ['#d0e9ce', '#b4cdb2'],       // Green T90 / T80
+    '--color-error': ['#58413e', '#dcc0bc'],                // Red T30 / T80
+    '--color-error-muted': ['#f9dcd7', '#dcc0bc'],          // Red T90 / T80
+    '--color-warning': ['#524622', '#d7c59c'],              // Yellow T30 / T80
+    '--color-warning-muted': ['#f4e1b7', '#d7c59c'],       // Yellow T90 / T80
 
-    // Border
-    '--color-border': ['#D8D8DB', '#F5F5F31A'],
-    '--color-border-emphasized': ['#84848B', '#5a5a60'],
+    // Border — H=291
+    '--color-border': ['#dddcdf', '#f3f3f51A'],             // T88 C=1.5
+    '--color-border-emphasized': ['#83838a', '#5e5e61'],    // T55 C=4 / T40 C=2
 
-    // Effects
-    '--color-skeleton': ['#D8D8DB', '#5a5a60'],
-    '--color-shadow': ['#28282A1A', '#0000004D'],
+    // Effects — H=291
+    '--color-skeleton': ['#d7d7da', '#5e5e61'],             // T86 C=1.6 / T40 C=2
+    '--color-shadow': ['#28282a1A', '#0000004D'],
     '--color-tint-hover': ['black', 'white'],
 
-    // Categorical — Blue
-    '--color-background-blue': ['#3a5e8c33', '#3a5e8c33'],
-    '--color-border-blue': ['#3a5e8c', '#7ba8d4'],
-    '--color-icon-blue': ['#3a5e8c', '#7ba8d4'],
-    '--color-text-blue': ['#2e4a6e', '#8dbce0'],
+    // Typography override
+    '--text-supporting-size': '12px',
 
-    // Categorical — Cyan
-    '--color-background-cyan': ['#3a7c7c33', '#3a7c7c33'],
-    '--color-border-cyan': ['#3a7c7c', '#70c4c4'],
-    '--color-icon-cyan': ['#3a7c7c', '#70c4c4'],
-    '--color-text-cyan': ['#2e6060', '#82d4d4'],
+    // Categorical — Blue (indigo blue)
+    // Categorical — Blue H=265 C=10
+    '--color-background-blue': ['#d7e4f5', '#a0acbd'],
+    '--color-border-blue': ['#c9d6e7', '#939faf'],
+    '--color-icon-blue': ['#3c4856', '#1b2734'],
+    '--color-text-blue': ['#3c4856', '#1b2734'],
 
-    // Categorical — Gray
-    '--color-background-gray': ['#84848B33', '#5a5a6033'],
-    '--color-border-gray': ['#84848B', '#84848B'],
-    '--color-icon-gray': ['#84848B', '#a1a1a6'],
-    '--color-text-gray': ['#28282A', '#F5F5F3'],
+    // Categorical — Cyan H=190 C=10
+    '--color-background-cyan': ['#cce8e5', '#95b1ae'],
+    '--color-border-cyan': ['#bedad7', '#88a3a0'],
+    '--color-icon-cyan': ['#334b49', '#122a28'],
+    '--color-text-cyan': ['#334b49', '#122a28'],
 
-    // Categorical — Green
-    '--color-background-green': ['#10993633', '#34c26533'],
-    '--color-border-green': ['#109936', '#34c265'],
-    '--color-icon-green': ['#109936', '#34c265'],
-    '--color-text-green': ['#0d7a2b', '#3fd672'],
+    // Categorical — Gray (pure neutral, C=0)
+    '--color-background-gray': ['#e2e2e2', '#ababab'],
+    '--color-border-gray': ['#d4d4d4', '#9e9e9e'],
+    '--color-icon-gray': ['#474747', '#262626'],
+    '--color-text-gray': ['#474747', '#262626'],
 
-    // Categorical — Orange
-    '--color-background-orange': ['#c4762033', '#d4903a33'],
-    '--color-border-orange': ['#c47620', '#d4903a'],
-    '--color-icon-orange': ['#c47620', '#d4903a'],
-    '--color-text-orange': ['#a06018', '#e0a04a'],
+    // Categorical — Green H=142 C=17
+    '--color-background-green': ['#d0e9ce', '#99b298'],
+    '--color-border-green': ['#c2dbc0', '#8ca48b'],
+    '--color-icon-green': ['#374c36', '#162a16'],
+    '--color-text-green': ['#374c36', '#162a16'],
 
-    // Categorical — Pink
-    '--color-background-pink': ['#c44a7033', '#e07a9a33'],
-    '--color-border-pink': ['#c44a70', '#e07a9a'],
-    '--color-icon-pink': ['#c44a70', '#e07a9a'],
-    '--color-text-pink': ['#a03a5a', '#f08aaa'],
+    // Categorical — Orange H=70 C=22
+    '--color-background-orange': ['#ffdcbb', '#c6a586'],
+    '--color-border-orange': ['#f1ceae', '#b89879'],
+    '--color-icon-orange': ['#5b4227', '#372104'],
+    '--color-text-orange': ['#5b4227', '#372104'],
 
-    // Categorical — Purple
-    '--color-background-purple': ['#6b4a8c33', '#b08ed433'],
-    '--color-border-purple': ['#6b4a8c', '#b08ed4'],
-    '--color-icon-purple': ['#6b4a8c', '#b08ed4'],
-    '--color-text-purple': ['#553a70', '#c0a0e0'],
+    // Categorical — Pink H=340 C=9
+    '--color-background-pink': ['#f0dde8', '#b8a6b1'],
+    '--color-border-pink': ['#e2cfda', '#ab99a3'],
+    '--color-icon-pink': ['#52424c', '#30222a'],
+    '--color-text-pink': ['#52424c', '#30222a'],
 
-    // Categorical — Red
-    '--color-background-red': ['#FD000033', '#ff5c5c33'],
-    '--color-border-red': ['#FD0000', '#ff5c5c'],
-    '--color-icon-red': ['#FD0000', '#ff5c5c'],
-    '--color-text-red': ['#cc0000', '#ff7a7a'],
+    // Categorical — Purple H=307 C=11
+    '--color-background-purple': ['#e8dff3', '#b0a8bb'],
+    '--color-border-purple': ['#d9d1e5', '#a39aad'],
+    '--color-icon-purple': ['#4b4454', '#292332'],
+    '--color-text-purple': ['#4b4454', '#292332'],
 
-    // Categorical — Teal
-    '--color-background-teal': ['#2e6b5a33', '#5ab89833'],
-    '--color-border-teal': ['#2e6b5a', '#5ab898'],
-    '--color-icon-teal': ['#2e6b5a', '#5ab898'],
-    '--color-text-teal': ['#245546', '#6ccaaa'],
+    // Categorical — Red H=33 C=11
+    '--color-background-red': ['#f9dcd7', '#c0a5a1'],
+    '--color-border-red': ['#ebcec9', '#b39893'],
+    '--color-icon-red': ['#58413e', '#35211e'],
+    '--color-text-red': ['#58413e', '#35211e'],
 
-    // Categorical — Yellow
-    '--color-background-yellow': ['#FFB60033', '#ffc94033'],
-    '--color-border-yellow': ['#FFB600', '#ffc940'],
-    '--color-icon-yellow': ['#FFB600', '#ffc940'],
-    '--color-text-yellow': ['#cc9200', '#ffd960'],
+    // Categorical — Teal H=158 C=9
+    '--color-background-teal': ['#d4e7dc', '#9dafa5'],
+    '--color-border-teal': ['#c6d9ce', '#90a297'],
+    '--color-icon-teal': ['#3b4a41', '#1a2921'],
+    '--color-text-teal': ['#3b4a41', '#1a2921'],
+
+    // Categorical — Yellow H=90 C=23
+    '--color-background-yellow': ['#f4e1b7', '#bbaa81'],
+    '--color-border-yellow': ['#e5d3a9', '#ad9c75'],
+    '--color-icon-yellow': ['#524622', '#2f2500'],
+    '--color-text-yellow': ['#524622', '#2f2500'],
 
     // =========================================================================
     // Radius — clean and subtle
@@ -194,9 +199,9 @@ export const stoneTheme = defineTheme({
       '0 4px 6px #28282A1A, 0 12px 24px #28282A26',
     '--shadow-inset-hover': 'inset 0px 0px 0px 2px #28282A30',
     '--shadow-inset-selected': 'inset 0px 0px 0px 2px #28282A50',
-    '--shadow-inset-success': 'inset 0px 0px 0px 2px #10993650',
-    '--shadow-inset-warning': 'inset 0px 0px 0px 2px #FFB60050',
-    '--shadow-inset-error': 'inset 0px 0px 0px 2px #FD000050',
+    '--shadow-inset-success': 'inset 0px 0px 0px 2px #83838a30',
+    '--shadow-inset-warning': 'inset 0px 0px 0px 2px #83838a30',
+    '--shadow-inset-error': 'inset 0px 0px 0px 2px #83838a30',
   },
 
   components: {
@@ -205,11 +210,70 @@ export const stoneTheme = defineTheme({
         borderRadius: 'var(--radius-full)',
       },
       'variant:secondary': {
-        borderWidth: '1px',
+        backgroundColor: 'transparent',
+        borderWidth: '1.5px',
         borderStyle: 'solid',
-        borderColor: 'var(--color-border)',
+        borderColor: 'var(--color-border-emphasized)',
+        ':hover': {
+          backgroundColor: 'var(--color-neutral)',
+        },
+      },
+      'variant:destructive': {
+        backgroundColor: 'light-dark(#f9dcd7, #dcc0bc)',
+        color: 'light-dark(#58413e, #4c3633)',
       },
     },
+
+    badge: {
+      'variant:info': {
+        backgroundColor: 'light-dark(#d7e4f5, #bbc8d9)',
+        color: 'light-dark(#3c4856, #313c4a)',
+      },
+      'variant:neutral': {
+        backgroundColor: 'light-dark(#e2e2e2, #c6c6c6)',
+        color: 'light-dark(#474747, #3b3b3b)',
+      },
+      'variant:success': {
+        backgroundColor: 'light-dark(#d0e9ce, #b4cdb2)',
+        color: 'light-dark(#374c36, #2b402b)',
+      },
+      'variant:warning': {
+        backgroundColor: 'light-dark(#f4e1b7, #d7c59c)',
+        color: 'light-dark(#524622, #463a18)',
+      },
+      'variant:error': {
+        backgroundColor: 'light-dark(#f9dcd7, #dcc0bc)',
+        color: 'light-dark(#58413e, #4c3633)',
+      },
+    },
+
+    banner: {
+      'status:info': {
+        backgroundColor: 'light-dark(#d7e4f5, #bbc8d9)',
+        '--color-text-primary': 'light-dark(#3c4856, #313c4a)',
+        '--color-text-secondary': 'light-dark(#3c4856, #313c4a)',
+        '--color-accent': 'light-dark(#3c4856, #313c4a)',
+      },
+      'status:success': {
+        backgroundColor: 'light-dark(#d0e9ce, #b4cdb2)',
+        '--color-text-primary': 'light-dark(#374c36, #2b402b)',
+        '--color-text-secondary': 'light-dark(#374c36, #2b402b)',
+        '--color-success': 'light-dark(#374c36, #2b402b)',
+      },
+      'status:warning': {
+        backgroundColor: 'light-dark(#f4e1b7, #d7c59c)',
+        '--color-text-primary': 'light-dark(#524622, #463a18)',
+        '--color-text-secondary': 'light-dark(#524622, #463a18)',
+        '--color-warning': 'light-dark(#524622, #463a18)',
+      },
+      'status:error': {
+        backgroundColor: 'light-dark(#f9dcd7, #dcc0bc)',
+        '--color-text-primary': 'light-dark(#58413e, #4c3633)',
+        '--color-text-secondary': 'light-dark(#58413e, #4c3633)',
+        '--color-error': 'light-dark(#58413e, #4c3633)',
+      },
+    },
+
 
     card: {
       base: {
@@ -226,3 +290,91 @@ export const stoneTheme = defineTheme({
 
   icons: stoneIconRegistry,
 });
+
+/**
+ * Raw tonal palettes — every color at every tone step (0–100 in 5s).
+ * Same hue and chroma used to derive all theme tokens.
+ * Use these for custom components or data visualization.
+ */
+export const stonePalettes = {
+  neutral: {
+    hue: 291, chroma: 3,
+    0: '#000000', 5: '#111015', 10: '#1b1b1f', 15: '#25252a', 20: '#303034',
+    25: '#3b3b3f', 30: '#46464b', 35: '#525257', 40: '#5e5e63', 45: '#6a6a6f',
+    50: '#77777c', 55: '#838388', 60: '#909095', 65: '#9d9da3', 70: '#ababb0',
+    75: '#b8b8be', 80: '#c6c6cc', 85: '#d4d4da', 90: '#e2e2e8', 95: '#f0f0f6',
+    100: '#ffffff',
+  },
+  blue: {
+    hue: 265, chroma: 10,
+    0: '#000000', 5: '#04121e', 10: '#111c29', 15: '#1b2734', 20: '#26313f',
+    25: '#313c4a', 30: '#3c4856', 35: '#485362', 40: '#545f6e', 45: '#606c7b',
+    50: '#6c7888', 55: '#798595', 60: '#8692a2', 65: '#939faf', 70: '#a0acbd',
+    75: '#adbacb', 80: '#bbc8d9', 85: '#c9d6e7', 90: '#d7e4f5', 95: '#e7f2ff',
+    100: '#ffffff',
+  },
+  cyan: {
+    hue: 190, chroma: 10,
+    0: '#000000', 5: '#001613', 10: '#071f1e', 15: '#122a28', 20: '#1d3433',
+    25: '#28403e', 30: '#334b49', 35: '#3e5755', 40: '#4a6361', 45: '#566f6d',
+    50: '#627c7a', 55: '#6f8986', 60: '#7b9693', 65: '#88a3a0', 70: '#95b1ae',
+    75: '#a3bebb', 80: '#b0ccc9', 85: '#bedad7', 90: '#cce8e5', 95: '#daf7f4',
+    100: '#ffffff',
+  },
+  green: {
+    hue: 142, chroma: 17,
+    0: '#000000', 5: '#001700', 10: '#0c200a', 15: '#162a16', 20: '#213521',
+    25: '#2b402b', 30: '#374c36', 35: '#425841', 40: '#4e644d', 45: '#5a7059',
+    50: '#667d65', 55: '#728a71', 60: '#7f977e', 65: '#8ca48b', 70: '#99b298',
+    75: '#a7bfa5', 80: '#b4cdb2', 85: '#c2dbc0', 90: '#d0e9ce', 95: '#def8dc',
+    100: '#ffffff',
+  },
+  teal: {
+    hue: 158, chroma: 9,
+    0: '#000000', 5: '#00150a', 10: '#101e17', 15: '#1a2921', 20: '#25342b',
+    25: '#303f36', 30: '#3b4a41', 35: '#46564d', 40: '#526259', 45: '#5e6e65',
+    50: '#6a7b71', 55: '#77887e', 60: '#83958a', 65: '#90a297', 70: '#9dafa5',
+    75: '#abbdb2', 80: '#b8cbc0', 85: '#c6d9ce', 90: '#d4e7dc', 95: '#e2f5ea',
+    100: '#ffffff',
+  },
+  yellow: {
+    hue: 90, chroma: 23,
+    0: '#000000', 5: '#1f0f00', 10: '#261a00', 15: '#2f2500', 20: '#3a2f0d',
+    25: '#463a18', 30: '#524622', 35: '#5e512d', 40: '#6b5d39', 45: '#786944',
+    50: '#857650', 55: '#92825c', 60: '#9f8f68', 65: '#ad9c75', 70: '#bbaa81',
+    75: '#c9b78e', 80: '#d7c59c', 85: '#e5d3a9', 90: '#f4e1b7', 95: '#ffefc7',
+    100: '#ffffff',
+  },
+  orange: {
+    hue: 70, chroma: 22,
+    0: '#000000', 5: '#250a00', 10: '#2d1700', 15: '#372104', 20: '#432c12',
+    25: '#4f361c', 30: '#5b4227', 35: '#684d32', 40: '#75593d', 45: '#826548',
+    50: '#8f7154', 55: '#9d7e60', 60: '#aa8b6d', 65: '#b89879', 70: '#c6a586',
+    75: '#d4b393', 80: '#e3c0a0', 85: '#f1ceae', 90: '#ffdcbb', 95: '#ffeddc',
+    100: '#ffffff',
+  },
+  red: {
+    hue: 33, chroma: 11,
+    0: '#000000', 5: '#210a04', 10: '#2a1714', 15: '#35211e', 20: '#402b28',
+    25: '#4c3633', 30: '#58413e', 35: '#644d49', 40: '#715955', 45: '#7e6561',
+    50: '#8a716d', 55: '#987e7a', 60: '#a58b86', 65: '#b39893', 70: '#c0a5a1',
+    75: '#ceb3ae', 80: '#dcc0bc', 85: '#ebcec9', 90: '#f9dcd7', 95: '#ffece9',
+    100: '#ffffff',
+  },
+  pink: {
+    hue: 340, chroma: 9,
+    0: '#000000', 5: '#1b0c16', 10: '#251720', 15: '#30222a', 20: '#3b2c35',
+    25: '#463740', 30: '#52424c', 35: '#5e4e57', 40: '#6a5a63', 45: '#776670',
+    50: '#83727c', 55: '#907f89', 60: '#9d8c96', 65: '#ab99a3', 70: '#b8a6b1',
+    75: '#c6b4be', 80: '#d4c1cc', 85: '#e2cfda', 90: '#f0dde8', 95: '#ffebf7',
+    100: '#ffffff',
+  },
+  purple: {
+    hue: 307, chroma: 11,
+    0: '#000000', 5: '#150e1d', 10: '#1f1927', 15: '#292332', 20: '#342e3d',
+    25: '#3f3949', 30: '#4b4454', 35: '#564f60', 40: '#635b6d', 45: '#6f6779',
+    50: '#7b7486', 55: '#888193', 60: '#958da0', 65: '#a39aad', 70: '#b0a8bb',
+    75: '#beb5c9', 80: '#cbc3d7', 85: '#d9d1e5', 90: '#e8dff3', 95: '#f6edff',
+    100: '#ffffff',
+  },
+} as const;


### PR DESCRIPTION
## Summary

Rebuild Stone theme categorical and semantic colors using HCT perceptual color space tonal palettes:

- All 10 categorical hues (blue, cyan, gray, green, orange, pink, purple, red, teal, yellow) with consistent tonal steps for light/dark modes
- Stone palette preview page (`/pages/stone-palette/`) with real XDS components, tonal ramps, and side-by-side light/dark mode
- Export raw `stonePalettes` with all tone steps

> **Note:** The standalone palette preview page may be superseded by Color Studio (PR #2119) which provides a universal palette explorer for all themes.

## Merge order

This is **2 of 4** related PRs. Merge in this order:
1. **#2120** — Core theme infra
2. **#2117** (this PR) — Stone theme: HCT tonal palettes
3. **#2118** — Y2K theme + comfortable preset
4. **#2119** — Color Studio: freeform palette builder

## Test plan

- [ ] Visit `/pages/stone-palette/` and verify all components render correctly
- [ ] Check light and dark mode columns side-by-side
- [ ] Verify tonal palette ramps display all 10 color families
- [ ] Confirm semantic badges (success/error/warning) use correct colors
- [ ] Stone theme renders without regressions in existing sandbox pages