### PR TITLE
fix(Markdown): reset block padding vars on table wrapper

### DIFF
--- a/packages/core/src/Markdown/XDSMarkdown.tsx
+++ b/packages/core/src/Markdown/XDSMarkdown.tsx
@@ -355,6 +355,10 @@ const styles = stylex.create({
   tableWrapper: {
     overflowX: 'auto',
     maxWidth: '100%',
+    '--container-padding-inline-start': '0px',
+    '--container-padding-inline-end': '0px',
+    '--container-padding-block-start': '0px',
+    '--container-padding-block-end': '0px',
   },
   blockIndent: {
     marginInline: `calc(-1 * ${spacingVars['--spacing-2']})`,


### PR DESCRIPTION
The Markdown table wrapper div inherits `--container-padding-block-start/end` from ancestor containers (Card, Section). The XDSTable inside uses `:first-child` with these vars to apply block bleed — but since the table is first-child of the wrapper (not the container), this causes unwanted negative margins.

Reset both block padding vars to `0px` on the `tableWrapper` style so the table's block bleed doesn't fire through the Markdown wrapper.

This is the targeted fix for the docsite table spacing issue. The broader container-driven bleed solution is tracked in #2084.