### PR TITLE
refactor(core): scope expandColorScale to minimal API

### DIFF
--- a/packages/core/src/theme/expandColorScale.test.ts
+++ b/packages/core/src/theme/expandColorScale.test.ts
@@ -42,77 +42,18 @@ describe('expandColorScale', () => {
     });
   });
 
-  describe('darkMode', () => {
-    it('adaptive mode uses different light/dark values', () => {
-      const tokens = expandColorScale({
+  describe('contrast', () => {
+    it('high contrast shifts text tones', () => {
+      const standard = expandColorScale({
         accent: '#0064E0',
-        darkMode: 'adaptive',
+        contrast: 'standard',
       });
-      const bg = tokens['--color-background-green'];
-      const match = bg.match(/^light-dark\(([^,]+),\s*([^)]+)\)/);
-      expect(match).toBeTruthy();
-      expect(match![1].trim()).not.toBe(match![2].trim());
-    });
+      const high = expandColorScale({accent: '#0064E0', contrast: 'high'});
 
-    it('preserve mode uses same hex for light and dark', () => {
-      const tokens = expandColorScale({
-        accent: '#0064E0',
-        darkMode: 'preserve',
-      });
-      const bg = tokens['--color-background-green'];
-      const match = bg.match(/^light-dark\(([^,]+),\s*([^)]+)\)/);
-      expect(match).toBeTruthy();
-      expect(match![1].trim()).toBe(match![2].trim());
-    });
-
-    it('invert mode swaps light/dark assignments', () => {
-      const adaptive = expandColorScale({
-        accent: '#0064E0',
-        darkMode: 'adaptive',
-      });
-      const inverted = expandColorScale({
-        accent: '#0064E0',
-        darkMode: 'invert',
-      });
-
-      const adaptiveMatch = adaptive['--color-background-green'].match(
-        /^light-dark\(([^,]+),\s*([^)]+)\)/,
+      // High contrast should produce different text tokens
+      expect(standard['--color-text-primary']).not.toBe(
+        high['--color-text-primary'],
       );
-      const invertMatch = inverted['--color-background-green'].match(
-        /^light-dark\(([^,]+),\s*([^)]+)\)/,
-      );
-
-      // Inverted light should equal adaptive dark and vice versa
-      expect(invertMatch![1].trim()).toBe(adaptiveMatch![2].trim());
-      expect(invertMatch![2].trim()).toBe(adaptiveMatch![1].trim());
-    });
-  });
-
-  describe('equalize', () => {
-    it('without equalization, different hues have different chromas', () => {
-      const tokens = expandColorScale({accent: '#0064E0', equalize: false});
-      // Both should exist
-      expect(tokens['--color-background-green']).toBeTruthy();
-      expect(tokens['--color-background-blue']).toBeTruthy();
-    });
-
-    it('with equalization, all hues produce valid tokens', () => {
-      const tokens = expandColorScale({accent: '#0064E0', equalize: true});
-      expect(tokens['--color-background-green']).toMatch(/^light-dark\(/);
-      expect(tokens['--color-background-red']).toMatch(/^light-dark\(/);
-      expect(tokens['--color-background-blue']).toMatch(/^light-dark\(/);
-      expect(tokens['--color-background-cyan']).toMatch(/^light-dark\(/);
-    });
-  });
-
-  describe('chromaBoost', () => {
-    it('chroma boost produces valid tokens', () => {
-      const tokens = expandColorScale({
-        accent: '#0064E0',
-        chromaBoost: {belowTone: 50, factor: 1.5, cap: 2.0},
-      });
-      expect(tokens['--color-accent']).toMatch(/^light-dark\(/);
-      expect(tokens['--color-background-green']).toMatch(/^light-dark\(/);
     });
   });
 

--- a/packages/core/src/theme/expandColorScale.ts
+++ b/packages/core/src/theme/expandColorScale.ts
@@ -1,6 +1,6 @@
 /**
  * @file expandColorScale.ts
- * @input Color scale configuration { accent, body?, neutralStyle?, contrast?, darkMode?, chromaBoost?, equalize? }
+ * @input Color scale configuration { accent, body?, neutralStyle?, contrast? }
  * @output Token overrides for derivable color tokens
  * @position Theme utility; consumed by defineTheme.ts
  *
@@ -13,13 +13,7 @@
  * - /packages/core/src/theme/defineTheme.ts
  */
 
-import {
-  hexToHct,
-  hctToHex,
-  tonalPalette,
-  hexWithAlpha,
-  maxChromaAtTone,
-} from './hct';
+import {hexToHct, tonalPalette, hexWithAlpha} from './hct';
 
 // =============================================================================
 // Types
@@ -39,9 +33,6 @@ import {
  *   body: '#FFF6ED',
  *   neutralStyle: 'warm',
  *   contrast: 'high',
- *   darkMode: 'preserve',
- *   chromaBoost: { belowTone: 50, factor: 1.5, cap: 2.0 },
- *   equalize: true,
  * }
  * ```
  */
@@ -79,42 +70,6 @@ export interface XDSColorScaleConfig {
    * @default 'standard'
    */
   contrast?: 'standard' | 'high';
-
-  /**
-   * How colors adapt between light and dark mode. Applies to all generated
-   * palette colors (accent, categorical, neutral surfaces).
-   *
-   * - 'adaptive' (default): remap tones for each mode (e.g. T90 bg in light → T30 in dark)
-   * - 'preserve': use identical hex values in both modes (brand-locked colors)
-   * - 'invert': swap the light/dark assignments
-   * @default 'adaptive'
-   */
-  darkMode?: 'adaptive' | 'preserve' | 'invert';
-
-  /**
-   * Boost chroma at dark tones to keep them vibrant. Without this, dark
-   * tones can appear washed out due to gamut compression.
-   *
-   * @param belowTone - Tones below this value get boosted. @default 50
-   * @param factor - Divisor for the boost curve — higher values produce a gentler boost. @default 1.5
-   * @param cap - Maximum chroma multiplier cap (e.g. 2.0 = at most 2× the base chroma). @default 2.0
-   */
-  chromaBoost?: {
-    /** Tones below this value get boosted. @default 50 */
-    belowTone?: number;
-    /** Divisor for the boost curve — higher = gentler ramp. @default 1.5 */
-    factor?: number;
-    /** Maximum chroma multiplier. 2.0 means chroma can at most double. @default 2.0 */
-    cap?: number;
-  };
-
-  /**
-   * Perceptual equalization. When true, categorical background colors
-   * are adjusted so all hues appear equally saturated at the same tone.
-   * Prevents some hues (e.g. yellow) from looking more vivid than others.
-   * @default false
-   */
-  equalize?: boolean;
 }
 
 export type ColorScaleTokens = Record<string, string>;
@@ -153,30 +108,6 @@ const CATEGORICAL_HUES = [
 ];
 
 // =============================================================================
-// Perceptual equalization
-// =============================================================================
-
-/**
- * Compute a chroma value for each hue that produces the same perceived
- * colorfulness at a given tone. Uses the max in-gamut chroma as an
- * upper bound and normalizes to the smallest achievable colorfulness.
- */
-function equalizeChromasAtTone(
-  hues: {hue: number; chroma: number}[],
-  tone: number,
-): number[] {
-  const maxChromas = hues.map(h =>
-    h.chroma === 0 ? 0 : maxChromaAtTone(h.hue, tone),
-  );
-  const achievable = hues.map((h, i) => Math.min(h.chroma, maxChromas[i]));
-  const minNonZero = achievable
-    .filter(c => c > 0)
-    .reduce((a, b) => Math.min(a, b), Infinity);
-  if (!isFinite(minNonZero)) return achievable;
-  return achievable.map(c => (c === 0 ? 0 : minNonZero));
-}
-
-// =============================================================================
 // Computation
 // =============================================================================
 
@@ -201,15 +132,7 @@ function ld(light: string, dark: string): string {
 export function expandColorScale(
   config: XDSColorScaleConfig,
 ): ColorScaleTokens {
-  const {
-    accent,
-    body,
-    neutralStyle = 'cool',
-    contrast = 'standard',
-    darkMode = 'adaptive',
-    chromaBoost,
-    equalize = false,
-  } = config;
+  const {accent, body, neutralStyle = 'cool', contrast = 'standard'} = config;
 
   const seed = hexToHct(accent);
   const seedHue = seed.hue;
@@ -232,9 +155,9 @@ export function expandColorScale(
     neutralVariantChroma = NEUTRAL_VARIANT_CHROMA[neutralStyle] ?? 8;
   }
 
-  const P = tonalPalette(seedHue, primaryChroma, chromaBoost);
-  const N = tonalPalette(neutralHue, neutralChroma, chromaBoost);
-  const NV = tonalPalette(neutralHue, neutralVariantChroma, chromaBoost);
+  const P = tonalPalette(seedHue, primaryChroma);
+  const N = tonalPalette(neutralHue, neutralChroma);
+  const NV = tonalPalette(neutralHue, neutralVariantChroma);
 
   const isHigh = contrast === 'high';
 
@@ -242,18 +165,6 @@ export function expandColorScale(
   const textPrimaryDarkTone = isHigh ? 99 : 90;
   const textSecondaryLightTone = isHigh ? 20 : 30;
   const textSecondaryDarkTone = isHigh ? 80 : 70;
-
-  // Light-dark helper that respects darkMode strategy
-  const catLd = (lightHex: string, darkHex: string): string => {
-    switch (darkMode) {
-      case 'preserve':
-        return ld(lightHex, lightHex);
-      case 'invert':
-        return ld(darkHex, lightHex);
-      default:
-        return ld(lightHex, darkHex);
-    }
-  };
 
   const tokens: ColorScaleTokens = {
     // Core semantic
@@ -313,30 +224,26 @@ export function expandColorScale(
     '--color-tint-hover': ld('black', 'white'),
   };
 
-  // Generate categorical colors with optional equalization
+  // Generate categorical colors
   const catHues = CATEGORICAL_HUES.filter(h => h.name !== 'gray');
-  let chromas = catHues.map(h => h.chroma);
-
-  if (equalize) {
-    chromas = equalizeChromasAtTone(catHues, 90);
-  }
+  const chromas = catHues.map(h => h.chroma);
 
   for (let i = 0; i < catHues.length; i++) {
     const {name, hue} = catHues[i];
     const c = chromas[i];
-    const palette = tonalPalette(hue, c, chromaBoost);
+    const palette = tonalPalette(hue, c);
 
-    tokens[`--color-background-${name}`] = catLd(palette[90], palette[30]);
-    tokens[`--color-border-${name}`] = catLd(palette[80], palette[40]);
-    tokens[`--color-icon-${name}`] = catLd(palette[30], palette[80]);
-    tokens[`--color-text-${name}`] = catLd(palette[30], palette[80]);
+    tokens[`--color-background-${name}`] = ld(palette[90], palette[30]);
+    tokens[`--color-border-${name}`] = ld(palette[80], palette[40]);
+    tokens[`--color-icon-${name}`] = ld(palette[30], palette[80]);
+    tokens[`--color-text-${name}`] = ld(palette[30], palette[80]);
   }
 
   // Gray uses neutral palette
-  tokens['--color-background-gray'] = catLd(N[90], N[30]);
-  tokens['--color-border-gray'] = catLd(N[80], N[40]);
-  tokens['--color-icon-gray'] = catLd(N[30], N[80]);
-  tokens['--color-text-gray'] = catLd(N[30], N[80]);
+  tokens['--color-background-gray'] = ld(N[90], N[30]);
+  tokens['--color-border-gray'] = ld(N[80], N[40]);
+  tokens['--color-icon-gray'] = ld(N[30], N[80]);
+  tokens['--color-text-gray'] = ld(N[30], N[80]);
 
   return tokens;
 }


### PR DESCRIPTION
## Context

`expandColorScale` currently exposes `darkMode`, `chromaBoost`, and `equalize` options in the core `defineTheme` API. None of our themes (Y2K, Stone, etc.) use these — they all set tokens directly. The only consumer is Color Studio, which has its own parallel color pipeline anyway.

## This PR

Removes `darkMode`, `chromaBoost`, and `equalize` from `XDSColorScaleConfig`. These experimental knobs will live as Color Studio UI controls instead, feeding into the lower-level `tonalPalette()` / `hexToHct()` utilities directly.

**Remaining API surface:**
- `accent` — seed color
- `body` — body background (determines neutral warmth)  
- `neutralStyle` — warm/cool/neutral (fallback when no body set)
- `contrast` — standard/high

## Why

- Keeps the core theme API minimal while theme design is still in flux
- Avoids exposing options that no theme author would understand without Color Studio
- Color Studio can still use the full HCT utilities directly for advanced controls
- Easier to promote options back to the API later if they prove useful