### PR TITLE
feat(sandbox): add theme icon to sidebar, move Color Studio to tools

### DIFF
--- a/apps/sandbox/src/app/SandboxNav.tsx
+++ b/apps/sandbox/src/app/SandboxNav.tsx
@@ -28,6 +28,7 @@ const categoryIcons: Record<
   'components-patterns': BoxIcon,
   templates: AppWindowIcon,
   blocks: BlocksIcon,
+  themes: PaletteIcon,
   tools: WrenchIcon,
 };
 

--- a/apps/sandbox/src/app/sandboxPages.ts
+++ b/apps/sandbox/src/app/sandboxPages.ts
@@ -121,12 +121,6 @@ export const categories: SandboxCategory[] = [
         description:
           'Y2K pop theme — sharp corners, cream body, neon lime accent, Crimson Text display type',
       },
-      {
-        name: 'Color Studio',
-        href: '/pages/color-studio/',
-        description:
-          'Generate and explore color palettes from an accent color or image',
-      },
     ],
   },
   {
@@ -162,6 +156,12 @@ export const categories: SandboxCategory[] = [
         href: '/pages/dictation-lab/',
         description:
           'Test voice dictation, tune sound effects, and explore animation',
+      },
+      {
+        name: 'Color Studio',
+        href: '/pages/color-studio/',
+        description:
+          'Generate and explore color palettes from an accent color or image',
       },
     ],
   },


### PR DESCRIPTION
## Changes

- **Themes sidebar icon**: Added PaletteIcon to the Themes category in the sidebar navigation (it was the only category without an icon)
- **Color Studio → Tools**: Moved Color Studio from the Themes section to Tools, since it's an interactive tool for generating/exploring palettes rather than a static theme preview