### PR TITLE
fix(core): simplify XDSSpinner color resolution with useXDSTheme

### DIFF
--- a/packages/core/src/Spinner/XDSSpinner.tsx
+++ b/packages/core/src/Spinner/XDSSpinner.tsx
@@ -17,6 +17,7 @@
 import {useEffect, useRef, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars, durationVars, spacingVars} from '../theme/tokens.stylex';
+import {useXDSTheme} from '../theme/useXDSTheme';
 import {XDSBaseProps} from '../XDSBaseProps';
 import {XDSText} from '../Text/XDSText';
 import {xdsClassName, mergeProps} from '../utils';
@@ -149,6 +150,7 @@ export function XDSSpinner({
   ...restProps
 }: XDSSpinnerProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const {tokens: themeTokens} = useXDSTheme();
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -160,18 +162,13 @@ export function XDSSpinner({
     const {border, diameter} = SIZES[size];
     const pixelRatio = window.devicePixelRatio || 1;
 
-    // Resolve colors from CSS custom properties
-    const computedStyle = getComputedStyle(canvas);
+    // Resolve colors from theme tokens (useXDSTheme handles light/dark resolution)
     const activeColor =
       shade === 'onMedia'
-        ? computedStyle.getPropertyValue(colorVars['--color-on-dark']) ||
-          '#FFFFFF'
+        ? themeTokens['--color-on-dark'] || '#FFFFFF'
         : shade === 'subtle'
-          ? computedStyle.getPropertyValue(
-              colorVars['--color-text-secondary'],
-            ) || '#65676B'
-          : computedStyle.getPropertyValue(colorVars['--color-accent']) ||
-            '#0064E0';
+          ? themeTokens['--color-text-secondary'] || '#65676B'
+          : themeTokens['--color-accent'] || '#0064E0';
     const backgroundColor =
       shade === 'onMedia' ? 'rgba(255, 255, 255, 0.3)' : 'rgba(0, 0, 0, 0.08)';
 
@@ -207,7 +204,7 @@ export function XDSSpinner({
     );
     context.strokeStyle = activeColor;
     context.stroke();
-  }, [shade, size]);
+  }, [shade, size, themeTokens]);
 
   const {border, diameter} = SIZES[size];
   const frameSize = diameter + border * 2;


### PR DESCRIPTION
## Context

Per Cindy's review on #2118 — the XDSSpinner was using manual `getComputedStyle` + CSS variable lookup to resolve colors for canvas rendering. This was fragile and didn't handle light-dark() values properly.

## This PR

Replaces the manual resolution with `useXDSTheme().tokens`, which already handles light/dark mode. Removes ~20 lines of manual property resolution code.

Before:
```ts
const computedStyle = getComputedStyle(canvas);
const activeColor = computedStyle.getPropertyValue(colorVars['--color-accent']) || '#0064E0';
```

After:
```ts
const {tokens: themeTokens} = useXDSTheme();
const activeColor = themeTokens['--color-accent'] || '#0064E0';
```