### PR TITLE
feat(color-studio): focused palette builder with custom colors and steps

### DIFF
--- a/apps/sandbox/src/app/(sandbox)/pages/color-studio/colorUtils.ts
+++ b/apps/sandbox/src/app/(sandbox)/pages/color-studio/colorUtils.ts
@@ -863,6 +863,7 @@ export interface PaletteColor {
   name: string;
   hex: string;
   role?: ThemeRole;
+  chroma?: number;
 }
 
 export const THEME_ROLES: {value: ThemeRole; label: string; group: string}[] = [

--- a/apps/sandbox/src/app/(sandbox)/pages/color-studio/page.tsx
+++ b/apps/sandbox/src/app/(sandbox)/pages/color-studio/page.tsx
@@ -203,48 +203,63 @@ function PaletteEntry({
     [color.role, usedRoles],
   );
 
+  const oklch = useMemo(() => hexToOklch(color.hex), [color.hex]);
+  const effectiveChroma = color.chroma ?? oklch.C;
+
   return (
-    <XDSHStack gap={2} vAlign="center" style={{padding: '6px 0'}}>
-      <div style={S.swatch(color.hex)}>
-        <input
-          type="color"
-          value={color.hex}
-          onChange={e => onChange(color.id, {hex: e.target.value})}
-          style={S.colorInput}
-        />
-      </div>
-      <div style={{flex: 1, minWidth: 0}}>
-        <XDSTextInput
-          label="Hex"
+    <XDSVStack gap={1} style={{padding: '6px 0'}}>
+      <XDSHStack gap={2} vAlign="center">
+        <div style={S.swatch(color.hex)}>
+          <input
+            type="color"
+            value={color.hex}
+            onChange={e => onChange(color.id, {hex: e.target.value, chroma: undefined})}
+            style={S.colorInput}
+          />
+        </div>
+        <div style={{flex: 1, minWidth: 0}}>
+          <XDSTextInput
+            label="Hex"
+            isLabelHidden
+            value={color.hex}
+            onChange={v => {
+              const parsed = parseColorInput(v.trim());
+              if (parsed) onChange(color.id, {hex: parsed, chroma: undefined});
+            }}
+            size="sm"
+          />
+        </div>
+        <XDSSelector
+          label="Role"
           isLabelHidden
-          value={color.hex}
-          onChange={v => {
-            const parsed = parseColorInput(v.trim());
-            if (parsed) onChange(color.id, {hex: parsed});
-          }}
+          options={roleOptions}
+          value={color.role ?? ''}
+          onChange={v =>
+            onChange(color.id, {role: (v || undefined) as ThemeRole | undefined})
+          }
           size="sm"
         />
-      </div>
-      <XDSSelector
-        label="Role"
+        {canRemove && (
+          <XDSIconButton
+            label="Remove"
+            variant="ghost"
+            size="sm"
+            onClick={() => onRemove(color.id)}
+            icon={<span style={{fontSize: 14, lineHeight: 1}}>✕</span>}
+          />
+        )}
+      </XDSHStack>
+      <XDSSlider
+        label="Chroma"
         isLabelHidden
-        options={roleOptions}
-        value={color.role ?? ''}
-        onChange={v =>
-          onChange(color.id, {role: (v || undefined) as ThemeRole | undefined})
-        }
-        size="sm"
+        min={0}
+        max={40}
+        step={1}
+        value={Math.round(effectiveChroma * 100)}
+        onChange={v => onChange(color.id, {chroma: v / 100})}
+        formatValue={v => `C:${(v / 100).toFixed(2)}`}
       />
-      {canRemove && (
-        <XDSIconButton
-          label="Remove"
-          variant="ghost"
-          size="sm"
-          onClick={() => onRemove(color.id)}
-          icon={<span style={{fontSize: 14, lineHeight: 1}}>✕</span>}
-        />
-      )}
-    </XDSHStack>
+    </XDSVStack>
   );
 }
 
@@ -354,9 +369,12 @@ function TonalRamps({
           hue = assigned
             ? hexToOklch(assigned.hex).H
             : grayTone === 'warm' ? 60 : grayTone === 'cool' ? 260 : 0;
-          chroma = (assigned
+          chroma = (assigned?.chroma ?? (assigned
             ? Math.min(hexToOklch(assigned.hex).C, 0.02)
-            : grayTone === 'neutral' ? 0.003 : 0.012) * vibrancy;
+            : grayTone === 'neutral' ? 0.003 : 0.012)) * vibrancy;
+        } else if (assigned?.chroma != null) {
+          hue = hexToOklch(assigned.hex).H;
+          chroma = assigned.chroma * vibrancy;
         } else if (ch.role === 'accent') {
           const oklch = assigned ? hexToOklch(assigned.hex) : {C: ch.oklchChroma, H: ch.oklchHue};
           hue = oklch.H;

--- a/apps/sandbox/src/app/(sandbox)/pages/color-studio/page.tsx
+++ b/apps/sandbox/src/app/(sandbox)/pages/color-studio/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import {useState, useCallback, useMemo, useRef} from 'react';
+import {useState, useCallback, useMemo} from 'react';
 import {XDSTextInput} from '@xds/core/TextInput';
 import {XDSButton} from '@xds/core/Button';
 import {XDSVStack, XDSHStack} from '@xds/core/Layout';
@@ -8,6 +8,7 @@ import {XDSText, XDSHeading} from '@xds/core/Text';
 import {XDSIconButton} from '@xds/core/IconButton';
 import {XDSSelector} from '@xds/core/Selector';
 import {XDSSlider} from '@xds/core/Slider';
+import {XDSNumberInput} from '@xds/core/NumberInput';
 import {
   XDSSegmentedControl,
   XDSSegmentedControlItem,
@@ -24,7 +25,6 @@ import {
   toneToOklabL,
   DEFAULT_OKLCH_CHROMA,
   DEFAULT_OKLCH_HUE,
-  extractColorsFromImage,
   parseColorInput,
   generateExportCode,
   THEME_ROLES,
@@ -102,25 +102,6 @@ const S = {
     border: 'none',
     cursor: 'pointer',
     opacity: 0,
-  } as React.CSSProperties,
-  dropZone: {
-    border: '2px dashed #d0d0d0',
-    borderRadius: 8,
-    padding: '12px 8px',
-    textAlign: 'center' as const,
-    cursor: 'pointer',
-    position: 'relative' as const,
-  } as React.CSSProperties,
-  dropInput: {
-    position: 'absolute' as const,
-    inset: 0,
-    opacity: 0,
-    cursor: 'pointer',
-  } as React.CSSProperties,
-  imgThumb: {
-    width: '100%',
-    borderRadius: 6,
-    marginTop: 8,
   } as React.CSSProperties,
   tonalRow: {
     display: 'flex',
@@ -203,63 +184,48 @@ function PaletteEntry({
     [color.role, usedRoles],
   );
 
-  const oklch = useMemo(() => hexToOklch(color.hex), [color.hex]);
-  const effectiveChroma = color.chroma ?? oklch.C;
-
   return (
-    <XDSVStack gap={1} style={{padding: '6px 0'}}>
-      <XDSHStack gap={2} vAlign="center">
-        <div style={S.swatch(color.hex)}>
-          <input
-            type="color"
-            value={color.hex}
-            onChange={e => onChange(color.id, {hex: e.target.value, chroma: undefined})}
-            style={S.colorInput}
-          />
-        </div>
-        <div style={{flex: 1, minWidth: 0}}>
-          <XDSTextInput
-            label="Hex"
-            isLabelHidden
-            value={color.hex}
-            onChange={v => {
-              const parsed = parseColorInput(v.trim());
-              if (parsed) onChange(color.id, {hex: parsed, chroma: undefined});
-            }}
-            size="sm"
-          />
-        </div>
-        <XDSSelector
-          label="Role"
+    <XDSHStack gap={2} vAlign="center" style={{padding: '6px 0'}}>
+      <div style={S.swatch(color.hex)}>
+        <input
+          type="color"
+          value={color.hex}
+          onChange={e => onChange(color.id, {hex: e.target.value})}
+          style={S.colorInput}
+        />
+      </div>
+      <div style={{flex: 1, minWidth: 0}}>
+        <XDSTextInput
+          label="Hex"
           isLabelHidden
-          options={roleOptions}
-          value={color.role ?? ''}
-          onChange={v =>
-            onChange(color.id, {role: (v || undefined) as ThemeRole | undefined})
-          }
+          value={color.hex}
+          onChange={v => {
+            const parsed = parseColorInput(v.trim());
+            if (parsed) onChange(color.id, {hex: parsed});
+          }}
           size="sm"
         />
-        {canRemove && (
-          <XDSIconButton
-            label="Remove"
-            variant="ghost"
-            size="sm"
-            onClick={() => onRemove(color.id)}
-            icon={<span style={{fontSize: 14, lineHeight: 1}}>✕</span>}
-          />
-        )}
-      </XDSHStack>
-      <XDSSlider
-        label="Chroma"
+      </div>
+      <XDSSelector
+        label="Role"
         isLabelHidden
-        min={0}
-        max={40}
-        step={1}
-        value={Math.round(effectiveChroma * 100)}
-        onChange={v => onChange(color.id, {chroma: v / 100})}
-        formatValue={v => `C:${(v / 100).toFixed(2)}`}
+        options={roleOptions}
+        value={color.role ?? ''}
+        onChange={v =>
+          onChange(color.id, {role: (v || undefined) as ThemeRole | undefined})
+        }
+        size="sm"
       />
-    </XDSVStack>
+      {canRemove && (
+        <XDSIconButton
+          label="Remove"
+          variant="ghost"
+          size="sm"
+          onClick={() => onRemove(color.id)}
+          icon={<span style={{fontSize: 14, lineHeight: 1}}>✕</span>}
+        />
+      )}
+    </XDSHStack>
   );
 }
 
@@ -369,20 +335,13 @@ function TonalRamps({
           hue = assigned
             ? hexToOklch(assigned.hex).H
             : grayTone === 'warm' ? 60 : grayTone === 'cool' ? 260 : 0;
-          chroma = (assigned?.chroma ?? (assigned
+          chroma = (assigned
             ? Math.min(hexToOklch(assigned.hex).C, 0.02)
-            : grayTone === 'neutral' ? 0.003 : 0.012)) * vibrancy;
-        } else if (assigned?.chroma != null) {
-          hue = hexToOklch(assigned.hex).H;
-          chroma = assigned.chroma * vibrancy;
-        } else if (ch.role === 'accent') {
-          const oklch = assigned ? hexToOklch(assigned.hex) : {C: ch.oklchChroma, H: ch.oklchHue};
-          hue = oklch.H;
-          chroma = Math.max(oklch.C, 0.09) * vibrancy;
+            : grayTone === 'neutral' ? 0.003 : 0.012) * vibrancy;
         } else {
           const oklch = assigned ? hexToOklch(assigned.hex) : {C: ch.oklchChroma, H: ch.oklchHue};
           hue = oklch.H;
-          chroma = Math.max(oklch.C, ch.oklchChroma) * vibrancy;
+          chroma = oklch.C * vibrancy;
         }
 
         return (
@@ -403,7 +362,7 @@ function TonalRamps({
       })}
       {customChannels.map(cc => {
         const oklch = hexToOklch(cc.hex);
-        const chroma = Math.max(oklch.C, 0.09) * vibrancy;
+        const chroma = oklch.C * vibrancy;
         return (
           <div key={cc.id} style={S.tonalRow}>
             <span style={{...S.tonalLabel, color: '#4f46e5', fontWeight: 600}}>{cc.name}</span>
@@ -490,8 +449,6 @@ export default function ColorStudioPage() {
   const [grayTone, setGrayTone] = useState<'warm' | 'neutral' | 'cool'>(
     'neutral',
   );
-  const [imgSrc, setImgSrc] = useState<string | null>(null);
-  const fileRef = useRef<HTMLInputElement>(null);
 
   const usedRoles = useMemo(
     () => new Set(palette.filter(c => c.role).map(c => c.role!)),
@@ -529,30 +486,6 @@ export default function ColorStudioPage() {
     setPalette(prev => [...prev, makePaletteColor('Color ' + _nextId, hex)]);
   }, []);
 
-  const handleImage = useCallback((file: File) => {
-    const reader = new FileReader();
-    reader.onload = ev => {
-      const src = ev.target?.result as string;
-      setImgSrc(src);
-      const img = new Image();
-      img.onload = () => {
-        const colors = extractColorsFromImage(img);
-        if (colors.length) {
-          setPalette(
-            colors.map((hex, i) =>
-              makePaletteColor(
-                `Extract ${i + 1}`,
-                hex,
-                i === 0 ? 'accent' : undefined,
-              ),
-            ),
-          );
-        }
-      };
-      img.src = src;
-    };
-    reader.readAsDataURL(file);
-  }, []);
 
   return (
     <div style={S.page}>
@@ -565,72 +498,37 @@ export default function ColorStudioPage() {
           </div>
 
           <div style={S.sidebarScroll}>
-            <XDSVStack gap={3}>
-              {/* Colors — palette + custom, unified list */}
-              {palette.map(c => (
-                <PaletteEntry
-                  key={c.id}
-                  color={c}
-                  canRemove={palette.length > 1}
-                  usedRoles={usedRoles}
-                  onChange={updateColor}
-                  onRemove={removeColor}
-                />
-              ))}
-              {customChannels.map(cc => (
-                <XDSHStack key={cc.id} gap={2} vAlign="center">
-                  <div style={S.swatch(cc.hex)}>
-                    <input
-                      type="color"
-                      value={cc.hex}
-                      onChange={e => setCustomChannels(prev => prev.map(c => c.id === cc.id ? {...c, hex: e.target.value} : c))}
-                      style={S.colorInput}
-                    />
-                  </div>
-                  <div style={{flex: 1, minWidth: 0}}>
-                    <XDSTextInput
-                      label="Name"
-                      isLabelHidden
-                      value={cc.name}
-                      onChange={v => setCustomChannels(prev => prev.map(c => c.id === cc.id ? {...c, name: v} : c))}
-                      size="sm"
-                    />
-                  </div>
-                  <XDSIconButton
-                    label="Remove"
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => setCustomChannels(prev => prev.filter(c => c.id !== cc.id))}
-                    icon={<span style={{fontSize: 14, lineHeight: 1}}>✕</span>}
-                  />
-                </XDSHStack>
-              ))}
-
-              {/* Add buttons */}
-              <XDSHStack gap={2}>
-                <XDSButton label="+ Color" variant="ghost" size="sm" onClick={addColor} />
-                <XDSButton
-                  label="+ Custom"
-                  variant="ghost"
+            <XDSVStack gap={5}>
+              {/* Controls */}
+              <XDSHStack vAlign="center" style={{justifyContent: 'space-between'}}>
+                <XDSText type="supporting" color="secondary">Steps</XDSText>
+                <XDSNumberInput
+                  label="Steps"
+                  isLabelHidden
+                  value={stepCount}
+                  onChange={v => setStepCount(Math.max(2, Math.min(41, v)))}
+                  min={2}
+                  max={41}
+                  step={1}
                   size="sm"
-                  onClick={() => {
-                    const h = Math.random() * 360;
-                    const hex = oklchClampedHex(0.5, 0.12, h);
-                    setCustomChannels(prev => [...prev, {id: nextId(), name: `Custom ${prev.length + 1}`, hex}]);
-                  }}
                 />
               </XDSHStack>
 
-              {/* Controls — inline, compact */}
-              <XDSSlider
-                label="Vibrancy"
-                min={50}
-                max={200}
-                step={10}
-                value={vibrancy * 100}
-                onChange={(v: number) => setVibrancy(v / 100)}
-                formatValue={v => `${Math.round(v)}%`}
-              />
+              <XDSHStack vAlign="center" gap={3} style={{justifyContent: 'space-between'}}>
+                <XDSText type="supporting" color="secondary" style={{flexShrink: 0}}>Vibrancy</XDSText>
+                <div style={{flex: 1}}>
+                  <XDSSlider
+                    label="Vibrancy"
+                    isLabelHidden
+                    min={50}
+                    max={200}
+                    step={10}
+                    value={vibrancy * 100}
+                    onChange={(v: number) => setVibrancy(v / 100)}
+                    formatValue={v => `${Math.round(v)}%`}
+                  />
+                </div>
+              </XDSHStack>
 
               <XDSHStack vAlign="center" style={{justifyContent: 'space-between'}}>
                 <XDSText type="supporting" color="secondary">Gray</XDSText>
@@ -645,28 +543,79 @@ export default function ColorStudioPage() {
                 </XDSSegmentedControl>
               </XDSHStack>
 
-              <XDSSlider
-                label="Steps"
-                min={5}
-                max={41}
-                step={1}
-                value={stepCount}
-                onChange={v => setStepCount(v)}
-                formatValue={v => `${v}`}
-              />
+              {/* Color Set — colors with role assignments */}
+              <XDSVStack gap={2}>
+                <XDSHStack vAlign="center" style={{justifyContent: 'space-between'}}>
+                  <XDSText type="label" weight="semibold">Brand Colors</XDSText>
+                  <XDSIconButton
+                    label="Add color"
+                    variant="ghost"
+                    size="sm"
+                    onClick={addColor}
+                    icon={<span style={{fontSize: 16, lineHeight: 1}}>+</span>}
+                  />
+                </XDSHStack>
+                {palette.map(c => (
+                  <PaletteEntry
+                    key={c.id}
+                    color={c}
+                    canRemove={palette.length > 1}
+                    usedRoles={usedRoles}
+                    onChange={updateColor}
+                    onRemove={removeColor}
+                  />
+                ))}
+              </XDSVStack>
 
-              {/* Image extraction */}
-              <div style={S.dropZone} onClick={() => fileRef.current?.click()}>
-                <input
-                  ref={fileRef}
-                  type="file"
-                  accept="image/*"
-                  style={S.dropInput}
-                  onChange={e => e.target.files?.[0] && handleImage(e.target.files[0])}
-                />
-                <XDSText type="supporting" color="secondary">Drop image or click</XDSText>
-              </div>
-              {imgSrc && <img src={imgSrc} alt="preview" style={S.imgThumb} />}
+              {/* Custom Colors — extra ramps without roles */}
+              <XDSVStack gap={2}>
+                <XDSHStack vAlign="center" style={{justifyContent: 'space-between'}}>
+                  <XDSText type="label" weight="semibold">Color Sets</XDSText>
+                  <XDSIconButton
+                    label="Add custom color"
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => {
+                      const h = Math.random() * 360;
+                      const hex = oklchClampedHex(0.5, 0.12, h);
+                      setCustomChannels(prev => [...prev, {id: nextId(), name: `Custom ${prev.length + 1}`, hex}]);
+                    }}
+                    icon={<span style={{fontSize: 16, lineHeight: 1}}>+</span>}
+                  />
+                </XDSHStack>
+                {customChannels.length === 0 && (
+                  <XDSText type="supporting" color="secondary">Add colors to generate extra ramps</XDSText>
+                )}
+                {customChannels.map(cc => (
+                  <XDSHStack key={cc.id} gap={2} vAlign="center" style={{padding: '4px 0'}}>
+                    <div style={S.swatch(cc.hex)}>
+                      <input
+                        type="color"
+                        value={cc.hex}
+                        onChange={e => setCustomChannels(prev => prev.map(c => c.id === cc.id ? {...c, hex: e.target.value} : c))}
+                        style={S.colorInput}
+                      />
+                    </div>
+                    <div style={{flex: 1, minWidth: 0}}>
+                      <XDSTextInput
+                        label="Name"
+                        isLabelHidden
+                        value={cc.name}
+                        onChange={v => setCustomChannels(prev => prev.map(c => c.id === cc.id ? {...c, name: v} : c))}
+                        size="sm"
+                      />
+                    </div>
+                    <XDSIconButton
+                      label="Remove"
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => setCustomChannels(prev => prev.filter(c => c.id !== cc.id))}
+                      icon={<span style={{fontSize: 14, lineHeight: 1}}>✕</span>}
+                    />
+                  </XDSHStack>
+                ))}
+              </XDSVStack>
+
             </XDSVStack>
           </div>
         </div>

--- a/apps/sandbox/src/app/(sandbox)/pages/color-studio/page.tsx
+++ b/apps/sandbox/src/app/(sandbox)/pages/color-studio/page.tsx
@@ -290,7 +290,10 @@ interface CustomChannel {
   hex: string;
 }
 
-const DEFAULT_TONE_STEPS = [0, 5, 10, 20, 30, 40, 50, 60, 70, 80, 90, 95, 99, 100];
+function generateToneSteps(count: number): number[] {
+  if (count <= 1) return [50];
+  return Array.from({length: count}, (_, i) => Math.round((i / (count - 1)) * 100));
+}
 
 function TonalRamps({
   palette,
@@ -464,8 +467,8 @@ export default function ColorStudioPage() {
   ]);
   const [vibrancy, setVibrancy] = useState(1.0);
   const [customChannels, setCustomChannels] = useState<CustomChannel[]>([]);
-  const [toneSteps, setToneSteps] = useState<number[]>(DEFAULT_TONE_STEPS);
-  const [newStep, setNewStep] = useState('');
+  const [stepCount, setStepCount] = useState(21);
+  const toneSteps = useMemo(() => generateToneSteps(stepCount), [stepCount]);
   const [grayTone, setGrayTone] = useState<'warm' | 'neutral' | 'cool'>(
     'neutral',
   );
@@ -544,202 +547,108 @@ export default function ColorStudioPage() {
           </div>
 
           <div style={S.sidebarScroll}>
-            <XDSVStack gap={5}>
-              {/* --- Palette --- */}
-              <XDSVStack gap={3}>
-                <XDSHStack hAlign="between" vAlign="center">
-                  <XDSText type="label" weight="semibold">
-                    Palette
-                  </XDSText>
-                  <XDSIconButton
-                    label="Add color"
-                    variant="ghost"
-                    size="sm"
-                    onClick={addColor}
-                    icon={<span style={{fontSize: 16, lineHeight: 1}}>+</span>}
-                  />
-                </XDSHStack>
-                <XDSVStack gap={2}>
-                  {palette.map(c => (
-                    <PaletteEntry
-                      key={c.id}
-                      color={c}
-                      canRemove={palette.length > 1}
-                      usedRoles={usedRoles}
-                      onChange={updateColor}
-                      onRemove={removeColor}
-                    />
-                  ))}
-                </XDSVStack>
-              </XDSVStack>
-
-              {/* --- Options --- */}
-              <XDSVStack gap={4}>
-                <XDSText type="label" weight="semibold">
-                  Options
-                </XDSText>
-
-                <XDSSlider
-                  label="Vibrancy"
-                  min={50}
-                  max={200}
-                  step={10}
-                  value={vibrancy * 100}
-                  onChange={(v: number) => setVibrancy(v / 100)}
-                  formatValue={v => `${Math.round(v)}%`}
+            <XDSVStack gap={3}>
+              {/* Colors — palette + custom, unified list */}
+              {palette.map(c => (
+                <PaletteEntry
+                  key={c.id}
+                  color={c}
+                  canRemove={palette.length > 1}
+                  usedRoles={usedRoles}
+                  onChange={updateColor}
+                  onRemove={removeColor}
                 />
-
-                <XDSHStack
-                  vAlign="center"
-                  style={{justifyContent: 'space-between'}}>
-                  <XDSText type="supporting" color="secondary">
-                    Gray Tone
-                  </XDSText>
-                  <XDSSegmentedControl
-                    label="Gray tone"
-                    value={grayTone}
-                    onChange={v =>
-                      setGrayTone(v as 'warm' | 'neutral' | 'cool')
-                    }
-                    size="sm">
-                    <XDSSegmentedControlItem value="warm" label="Warm" />
-                    <XDSSegmentedControlItem value="neutral" label="Neutral" />
-                    <XDSSegmentedControlItem value="cool" label="Cool" />
-                  </XDSSegmentedControl>
-                </XDSHStack>
-
-              </XDSVStack>
-
-              {/* --- Custom Colors --- */}
-              <XDSVStack gap={3}>
-                <XDSHStack hAlign="space-between" vAlign="center">
-                  <XDSText type="label" weight="semibold">Custom Colors</XDSText>
-                  <XDSIconButton
-                    label="Add custom color"
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => {
-                      const h = Math.random() * 360;
-                      const hex = oklchClampedHex(0.5, 0.12, h);
-                      setCustomChannels(prev => [...prev, {id: nextId(), name: `Custom ${prev.length + 1}`, hex}]);
-                    }}
-                    icon={<span style={{fontSize: 16, lineHeight: 1}}>+</span>}
-                  />
-                </XDSHStack>
-                {customChannels.map(cc => (
-                  <XDSHStack key={cc.id} gap={2} vAlign="center" style={{padding: '4px 0'}}>
-                    <div style={S.swatch(cc.hex)}>
-                      <input
-                        type="color"
-                        value={cc.hex}
-                        onChange={e => setCustomChannels(prev => prev.map(c => c.id === cc.id ? {...c, hex: e.target.value} : c))}
-                        style={S.colorInput}
-                      />
-                    </div>
-                    <div style={{flex: 1, minWidth: 0}}>
-                      <XDSTextInput
-                        label="Name"
-                        isLabelHidden
-                        value={cc.name}
-                        onChange={v => setCustomChannels(prev => prev.map(c => c.id === cc.id ? {...c, name: v} : c))}
-                        size="sm"
-                      />
-                    </div>
-                    <XDSIconButton
-                      label="Remove"
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => setCustomChannels(prev => prev.filter(c => c.id !== cc.id))}
-                      icon={<span style={{fontSize: 14, lineHeight: 1}}>✕</span>}
+              ))}
+              {customChannels.map(cc => (
+                <XDSHStack key={cc.id} gap={2} vAlign="center">
+                  <div style={S.swatch(cc.hex)}>
+                    <input
+                      type="color"
+                      value={cc.hex}
+                      onChange={e => setCustomChannels(prev => prev.map(c => c.id === cc.id ? {...c, hex: e.target.value} : c))}
+                      style={S.colorInput}
                     />
-                  </XDSHStack>
-                ))}
-              </XDSVStack>
-
-              {/* --- Tone Steps --- */}
-              <XDSVStack gap={3}>
-                <XDSText type="label" weight="semibold">Tone Steps</XDSText>
-                <XDSHStack gap={1} wrap="wrap">
-                  {toneSteps.map(t => (
-                    <span
-                      key={t}
-                      onClick={() => setToneSteps(prev => prev.filter(s => s !== t))}
-                      style={{
-                        display: 'inline-flex',
-                        alignItems: 'center',
-                        gap: 3,
-                        padding: '2px 4px 2px 6px',
-                        fontSize: 10,
-                        fontFamily: MONO,
-                        borderRadius: 4,
-                        background: 'var(--color-background-muted)',
-                        cursor: 'pointer',
-                        color: 'var(--color-text-secondary)',
-                      }}
-                      title={`Remove step ${t}`}
-                    >
-                      {t}
-                      <span style={{fontSize: 8, opacity: 0.4}}>✕</span>
-                    </span>
-                  ))}
-                </XDSHStack>
-                <XDSHStack gap={2} vAlign="center">
+                  </div>
                   <div style={{flex: 1, minWidth: 0}}>
                     <XDSTextInput
-                      label="Add step"
+                      label="Name"
                       isLabelHidden
-                      placeholder="e.g. 15"
-                      value={newStep}
-                      onChange={v => setNewStep(v)}
+                      value={cc.name}
+                      onChange={v => setCustomChannels(prev => prev.map(c => c.id === cc.id ? {...c, name: v} : c))}
                       size="sm"
                     />
                   </div>
-                  <XDSButton
-                    label="Add"
-                    variant="secondary"
-                    size="sm"
-                    onClick={() => {
-                      const n = parseInt(newStep, 10);
-                      if (!isNaN(n) && n >= 0 && n <= 100 && !toneSteps.includes(n)) {
-                        setToneSteps(prev => [...prev, n].sort((a, b) => a - b));
-                        setNewStep('');
-                      }
-                    }}
-                  />
-                  <XDSButton
-                    label="Reset"
+                  <XDSIconButton
+                    label="Remove"
                     variant="ghost"
                     size="sm"
-                    onClick={() => setToneSteps(DEFAULT_TONE_STEPS)}
+                    onClick={() => setCustomChannels(prev => prev.filter(c => c.id !== cc.id))}
+                    icon={<span style={{fontSize: 14, lineHeight: 1}}>✕</span>}
                   />
                 </XDSHStack>
-              </XDSVStack>
+              ))}
 
-              {/* --- Image Extraction --- */}
-              <XDSVStack gap={3}>
-                <XDSText type="label" weight="semibold">
-                  Extract from Image
-                </XDSText>
-                <div
-                  style={S.dropZone}
-                  onClick={() => fileRef.current?.click()}>
-                  <input
-                    ref={fileRef}
-                    type="file"
-                    accept="image/*"
-                    style={S.dropInput}
-                    onChange={e =>
-                      e.target.files?.[0] && handleImage(e.target.files[0])
-                    }
-                  />
-                  <XDSText type="supporting" color="secondary">
-                    Drop image or click
-                  </XDSText>
-                </div>
-                {imgSrc && (
-                  <img src={imgSrc} alt="preview" style={S.imgThumb} />
-                )}
-              </XDSVStack>
+              {/* Add buttons */}
+              <XDSHStack gap={2}>
+                <XDSButton label="+ Color" variant="ghost" size="sm" onClick={addColor} />
+                <XDSButton
+                  label="+ Custom"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => {
+                    const h = Math.random() * 360;
+                    const hex = oklchClampedHex(0.5, 0.12, h);
+                    setCustomChannels(prev => [...prev, {id: nextId(), name: `Custom ${prev.length + 1}`, hex}]);
+                  }}
+                />
+              </XDSHStack>
+
+              {/* Controls — inline, compact */}
+              <XDSSlider
+                label="Vibrancy"
+                min={50}
+                max={200}
+                step={10}
+                value={vibrancy * 100}
+                onChange={(v: number) => setVibrancy(v / 100)}
+                formatValue={v => `${Math.round(v)}%`}
+              />
+
+              <XDSHStack vAlign="center" style={{justifyContent: 'space-between'}}>
+                <XDSText type="supporting" color="secondary">Gray</XDSText>
+                <XDSSegmentedControl
+                  label="Gray tone"
+                  value={grayTone}
+                  onChange={v => setGrayTone(v as 'warm' | 'neutral' | 'cool')}
+                  size="sm">
+                  <XDSSegmentedControlItem value="warm" label="Warm" />
+                  <XDSSegmentedControlItem value="neutral" label="Neutral" />
+                  <XDSSegmentedControlItem value="cool" label="Cool" />
+                </XDSSegmentedControl>
+              </XDSHStack>
+
+              <XDSSlider
+                label="Steps"
+                min={5}
+                max={41}
+                step={1}
+                value={stepCount}
+                onChange={v => setStepCount(v)}
+                formatValue={v => `${v}`}
+              />
+
+              {/* Image extraction */}
+              <div style={S.dropZone} onClick={() => fileRef.current?.click()}>
+                <input
+                  ref={fileRef}
+                  type="file"
+                  accept="image/*"
+                  style={S.dropInput}
+                  onChange={e => e.target.files?.[0] && handleImage(e.target.files[0])}
+                />
+                <XDSText type="supporting" color="secondary">Drop image or click</XDSText>
+              </div>
+              {imgSrc && <img src={imgSrc} alt="preview" style={S.imgThumb} />}
             </XDSVStack>
           </div>
         </div>

--- a/apps/sandbox/src/app/(sandbox)/pages/color-studio/page.tsx
+++ b/apps/sandbox/src/app/(sandbox)/pages/color-studio/page.tsx
@@ -1,18 +1,10 @@
 'use client';
 
 import {useState, useCallback, useMemo, useRef} from 'react';
-import {XDSBanner} from '@xds/core/Banner';
 import {XDSTextInput} from '@xds/core/TextInput';
-import {XDSBadge} from '@xds/core/Badge';
 import {XDSButton} from '@xds/core/Button';
 import {XDSVStack, XDSHStack} from '@xds/core/Layout';
 import {XDSText, XDSHeading} from '@xds/core/Text';
-import {XDSTheme, defineTheme} from '@xds/core/theme';
-import {XDSLayerProvider} from '@xds/core/Layer';
-import {XDSSpinner} from '@xds/core/Spinner';
-import {XDSSwitch} from '@xds/core/Switch';
-import {XDSCard} from '@xds/core/Card';
-import {XDSProgressBar} from '@xds/core/ProgressBar';
 import {XDSIconButton} from '@xds/core/IconButton';
 import {XDSSelector} from '@xds/core/Selector';
 import {XDSSlider} from '@xds/core/Slider';
@@ -29,11 +21,11 @@ import {
   tonalPalette,
   oklchTonalPalette,
   TONE_STEPS,
+  toneToOklabL,
   DEFAULT_OKLCH_CHROMA,
   DEFAULT_OKLCH_HUE,
   extractColorsFromImage,
   parseColorInput,
-  buildThemeTokens,
   generateExportCode,
   THEME_ROLES,
   type PaletteColor,
@@ -130,29 +122,6 @@ const S = {
     borderRadius: 6,
     marginTop: 8,
   } as React.CSSProperties,
-  previewCol: {
-    background: 'var(--color-background-body)',
-    color: 'var(--color-text-primary)',
-    border: '1px solid var(--color-border)',
-    padding: 20,
-    display: 'flex',
-    flexDirection: 'column' as const,
-    gap: 24,
-  } as React.CSSProperties,
-  previewLabel: {
-    fontSize: 10,
-    fontWeight: 600,
-    textTransform: 'uppercase' as const,
-    letterSpacing: '0.1em',
-    opacity: 0.6,
-  } as React.CSSProperties,
-  compSection: {} as React.CSSProperties,
-  compTitle: {
-    fontSize: 13,
-    fontWeight: 600,
-    margin: 0,
-    marginBottom: 10,
-  } as React.CSSProperties,
   tonalRow: {
     display: 'flex',
     alignItems: 'center',
@@ -195,406 +164,6 @@ const S = {
 // Multi-color presets
 // =============================================================================
 
-interface PresetPalette {
-  label: string;
-  colors: {name: string; hex: string; role?: ThemeRole}[];
-}
-
-const PRESETS: PresetPalette[] = [
-  {
-    label: 'Default',
-    colors: [{name: 'Accent', hex: '#0064E0', role: 'accent'}],
-  },
-  {
-    label: 'Brutalist',
-    colors: [{name: 'Hot Pink', hex: '#FF1493', role: 'accent'}],
-  },
-  {
-    label: 'Chocolate',
-    colors: [
-      {name: 'Brown', hex: '#8C5927', role: 'accent'},
-      {name: 'Caramel', hex: '#B88859', role: 'orange'},
-      {name: 'Cream', hex: '#EDE4D4', role: 'gray'},
-    ],
-  },
-  {
-    label: 'Daily',
-    colors: [
-      {name: 'Charcoal', hex: '#292724', role: 'accent'},
-      {name: 'Warm Gray', hex: '#85817A', role: 'gray'},
-    ],
-  },
-  {
-    label: 'Gothic',
-    colors: [
-      {name: 'Dark Blue', hex: '#24292D', role: 'accent'},
-      {name: 'Slate', hex: '#495056', role: 'gray'},
-      {name: 'Ice', hex: '#E8F1F6', role: 'cyan'},
-    ],
-  },
-  {
-    label: 'Matcha',
-    colors: [
-      {name: 'Earth Green', hex: '#3E481D', role: 'accent'},
-      {name: 'Moss', hex: '#707E46', role: 'green'},
-      {name: 'Sage', hex: '#C0CBA9', role: 'teal'},
-    ],
-  },
-  {
-    label: 'Neutral',
-    colors: [
-      {name: 'Black', hex: '#1A1A1A', role: 'accent'},
-      {name: 'Gray', hex: '#888888', role: 'gray'},
-    ],
-  },
-  {
-    label: 'Stone',
-    colors: [
-      {name: 'Charcoal', hex: '#28282A', role: 'accent'},
-      {name: 'Warm Gray', hex: '#84848B', role: 'gray'},
-    ],
-  },
-  {
-    label: 'Y2K',
-    colors: [
-      {name: 'Olive', hex: '#7B9900', role: 'accent'},
-      {name: 'Orange', hex: '#E8791D', role: 'orange'},
-      {name: 'Teal', hex: '#2A9D8F', role: 'teal'},
-      {name: 'Pink', hex: '#FF69B4', role: 'pink'},
-      {name: 'Purple', hex: '#9B59B6', role: 'purple'},
-    ],
-  },
-];
-
-// =============================================================================
-// Component Sections (unchanged)
-// =============================================================================
-
-const CARD_VARIANTS = [
-  'default',
-  'muted',
-  'blue',
-  'cyan',
-  'gray',
-  'green',
-  'orange',
-  'pink',
-  'purple',
-  'red',
-  'teal',
-  'yellow',
-] as const;
-
-function BadgeSection() {
-  return (
-    <div style={S.compSection}>
-      <h3 style={S.compTitle}>Semantic Badges</h3>
-      <XDSHStack gap={2} wrap="wrap">
-        <XDSBadge variant="success" label="Success" />
-        <XDSBadge variant="error" label="Error" />
-        <XDSBadge variant="warning" label="Warning" />
-        <XDSBadge variant="info" label="Info" />
-        <XDSBadge variant="neutral" label="Neutral" />
-      </XDSHStack>
-      <div style={{marginTop: 10}}>
-        <h3 style={S.compTitle}>Categorical Badges</h3>
-        <XDSHStack gap={2} wrap="wrap">
-          <XDSBadge variant="blue" label="Blue" />
-          <XDSBadge variant="cyan" label="Cyan" />
-          <XDSBadge variant="green" label="Green" />
-          <XDSBadge variant="orange" label="Orange" />
-          <XDSBadge variant="pink" label="Pink" />
-          <XDSBadge variant="purple" label="Purple" />
-          <XDSBadge variant="red" label="Red" />
-          <XDSBadge variant="teal" label="Teal" />
-          <XDSBadge variant="yellow" label="Yellow" />
-        </XDSHStack>
-      </div>
-    </div>
-  );
-}
-
-function BannerSection() {
-  return (
-    <div style={S.compSection}>
-      <h3 style={S.compTitle}>Banners</h3>
-      <XDSVStack gap={2}>
-        <XDSBanner
-          status="info"
-          title="Info banner"
-          description="Uses accent color."
-        />
-        <XDSBanner
-          status="success"
-          title="Success banner"
-          description="Description text."
-        />
-        <XDSBanner
-          status="warning"
-          title="Warning banner"
-          description="Description text."
-        />
-        <XDSBanner
-          status="error"
-          title="Error banner"
-          description="Description text."
-        />
-      </XDSVStack>
-    </div>
-  );
-}
-
-function InputSection() {
-  return (
-    <div style={S.compSection}>
-      <h3 style={S.compTitle}>Inputs</h3>
-      <XDSVStack gap={3}>
-        <XDSTextInput
-          label="Default"
-          placeholder="Placeholder text"
-          value=""
-          onChange={() => {}}
-        />
-        <XDSTextInput
-          label="Success"
-          value="Valid"
-          onChange={() => {}}
-          status={{type: 'success', message: 'Looks good!'}}
-        />
-        <XDSTextInput
-          label="Error"
-          value="Invalid"
-          onChange={() => {}}
-          status={{type: 'error', message: 'Required.'}}
-        />
-        <XDSTextInput
-          label="Disabled"
-          value="Cannot edit"
-          onChange={() => {}}
-          isDisabled
-        />
-      </XDSVStack>
-    </div>
-  );
-}
-
-function ButtonSection() {
-  return (
-    <div style={S.compSection}>
-      <h3 style={S.compTitle}>Buttons</h3>
-      <XDSHStack gap={3} vAlign="center">
-        <XDSButton label="Primary" variant="primary" />
-        <XDSButton label="Secondary" variant="secondary" />
-        <XDSButton label="Ghost" variant="ghost" />
-        <XDSButton label="Destructive" variant="destructive" />
-      </XDSHStack>
-    </div>
-  );
-}
-
-function SwitchSection() {
-  return (
-    <div style={S.compSection}>
-      <h3 style={S.compTitle}>Switch</h3>
-      <XDSVStack gap={3}>
-        <XDSSwitch label="Off" value={false} onChange={() => {}} />
-        <XDSSwitch label="On" value={true} onChange={() => {}} />
-        <XDSSwitch
-          label="Disabled"
-          value={false}
-          onChange={() => {}}
-          isDisabled
-        />
-      </XDSVStack>
-    </div>
-  );
-}
-
-function ProgressSection() {
-  return (
-    <div style={S.compSection}>
-      <h3 style={S.compTitle}>Progress</h3>
-      <XDSVStack gap={3}>
-        <XDSProgressBar value={75} label="Progress" hasValueLabel />
-        <XDSProgressBar
-          value={40}
-          label="Upload"
-          variant="positive"
-          hasValueLabel
-        />
-        <XDSProgressBar
-          value={90}
-          label="Storage"
-          variant="warning"
-          hasValueLabel
-        />
-        <XDSProgressBar isIndeterminate label="Loading..." />
-      </XDSVStack>
-    </div>
-  );
-}
-
-function CardVariantsSection() {
-  return (
-    <div style={S.compSection}>
-      <h3 style={S.compTitle}>Card Variants</h3>
-      <div
-        style={{
-          display: 'grid',
-          gridTemplateColumns: 'repeat(4, 1fr)',
-          gap: 8,
-        }}>
-        {CARD_VARIANTS.map(v => (
-          <XDSCard key={v} variant={v} padding={2}>
-            <XDSText type="supporting" weight="bold">
-              {v}
-            </XDSText>
-          </XDSCard>
-        ))}
-      </div>
-    </div>
-  );
-}
-
-function TextHierarchy() {
-  return (
-    <div style={S.compSection}>
-      <h3 style={S.compTitle}>Text Hierarchy</h3>
-      <XDSVStack gap={1}>
-        <XDSHeading level={1}>Heading 1</XDSHeading>
-        <XDSHeading level={2}>Heading 2</XDSHeading>
-        <XDSHeading level={3}>Heading 3</XDSHeading>
-        <XDSText type="body">Body — primary</XDSText>
-        <XDSText type="body" color="secondary">
-          Body — secondary
-        </XDSText>
-        <XDSText type="supporting">Supporting text</XDSText>
-      </XDSVStack>
-    </div>
-  );
-}
-
-function SpinnerSection() {
-  return (
-    <div style={S.compSection}>
-      <h3 style={S.compTitle}>Spinners</h3>
-      <XDSHStack gap={4} vAlign="center">
-        <XDSSpinner size="sm" />
-        <XDSSpinner size="md" />
-        <XDSSpinner size="lg" />
-      </XDSHStack>
-    </div>
-  );
-}
-
-const BACKGROUND_SURFACES = [
-  {name: 'Body', token: '--color-background-body', light: 'N99', dark: 'N5'},
-  {
-    name: 'Surface',
-    token: '--color-background-surface',
-    light: 'N100',
-    dark: 'N10',
-  },
-  {name: 'Card', token: '--color-background-card', light: 'N100', dark: 'N15'},
-  {
-    name: 'Popover',
-    token: '--color-background-popover',
-    light: 'N100',
-    dark: 'N20',
-  },
-  {
-    name: 'Muted',
-    token: '--color-background-muted',
-    light: 'N10 @5%',
-    dark: 'N10 @50%',
-  },
-  {
-    name: 'Inverted',
-    token: '--color-background-inverted',
-    light: 'N10',
-    dark: 'N99',
-  },
-] as const;
-
-function BackgroundsSection({mode}: {mode: 'light' | 'dark'}) {
-  return (
-    <div style={S.compSection}>
-      <h3 style={S.compTitle}>Backgrounds</h3>
-      <div
-        style={{
-          display: 'grid',
-          gridTemplateColumns: 'repeat(3, 1fr)',
-          gap: 6,
-        }}>
-        {BACKGROUND_SURFACES.map(bg => (
-          <div
-            key={bg.name}
-            style={{
-              background: `var(${bg.token})`,
-              border: '1px solid var(--color-border)',
-              borderRadius: 6,
-              padding: '12px 8px',
-              textAlign: 'center' as const,
-            }}>
-            <span
-              style={{
-                fontSize: 10,
-                fontWeight: 600,
-                color:
-                  bg.name === 'Inverted'
-                    ? 'var(--color-text-primary)'
-                    : undefined,
-                mixBlendMode:
-                  bg.name === 'Inverted' ? ('difference' as const) : undefined,
-                display: 'flex',
-                flexDirection: 'column' as const,
-                gap: 2,
-              }}>
-              <span>{bg.name}</span>
-              <span style={{fontSize: 8, fontWeight: 400, opacity: 0.6}}>
-                {mode === 'light' ? bg.light : bg.dark}
-              </span>
-            </span>
-          </div>
-        ))}
-      </div>
-    </div>
-  );
-}
-
-// =============================================================================
-// Preview Column
-// =============================================================================
-
-function PreviewColumn({
-  mode,
-  theme,
-}: {
-  mode: 'light' | 'dark';
-  theme: ReturnType<typeof defineTheme>;
-}) {
-  return (
-    <XDSTheme theme={theme} mode={mode}>
-      <XDSLayerProvider>
-        <div style={S.previewCol}>
-          <p style={S.previewLabel}>
-            {mode === 'light' ? 'Light Mode' : 'Dark Mode'}
-          </p>
-          <BackgroundsSection mode={mode} />
-          <TextHierarchy />
-          <BadgeSection />
-          <BannerSection />
-          <InputSection />
-          <ButtonSection />
-          <SwitchSection />
-          <SpinnerSection />
-          <ProgressSection />
-          <CardVariantsSection />
-        </div>
-      </XDSLayerProvider>
-    </XDSTheme>
-  );
-}
 
 // =============================================================================
 // Palette Color Entry
@@ -701,43 +270,40 @@ function makeChannel(name: string, role: ThemeRole): ColorChannel {
   };
 }
 
-const CHANNEL_GROUPS: {label: string; channels: ColorChannel[]}[] = [
-  {
-    label: 'Core',
-    channels: [makeChannel('Accent', 'accent'), makeChannel('Gray', 'gray')],
-  },
-  {
-    label: 'Categorical',
-    channels: [
-      makeChannel('Red', 'red'),
-      makeChannel('Orange', 'orange'),
-      makeChannel('Yellow', 'yellow'),
-      makeChannel('Green', 'green'),
-      makeChannel('Teal', 'teal'),
-      makeChannel('Cyan', 'cyan'),
-      makeChannel('Blue', 'blue'),
-      makeChannel('Purple', 'purple'),
-      makeChannel('Pink', 'pink'),
-    ],
-  },
+const DEFAULT_CHANNELS: ColorChannel[] = [
+  makeChannel('Accent', 'accent'),
+  makeChannel('Gray', 'gray'),
+  makeChannel('Red', 'red'),
+  makeChannel('Orange', 'orange'),
+  makeChannel('Yellow', 'yellow'),
+  makeChannel('Green', 'green'),
+  makeChannel('Teal', 'teal'),
+  makeChannel('Cyan', 'cyan'),
+  makeChannel('Blue', 'blue'),
+  makeChannel('Purple', 'purple'),
+  makeChannel('Pink', 'pink'),
 ];
 
-const STATUS_CHANNELS: ColorChannel[] = [
-  makeChannel('Success', 'success'),
-  makeChannel('Warning', 'warning'),
-  makeChannel('Error', 'error'),
-];
+interface CustomChannel {
+  id: string;
+  name: string;
+  hex: string;
+}
+
+const DEFAULT_TONE_STEPS = [0, 5, 10, 20, 30, 40, 50, 60, 70, 80, 90, 95, 99, 100];
 
 function TonalRamps({
   palette,
   vibrancy,
-  themeName,
   grayTone,
+  customChannels,
+  toneSteps,
 }: {
   palette: PaletteColor[];
   vibrancy: number;
-  themeName: string;
   grayTone: 'warm' | 'neutral' | 'cool';
+  customChannels: CustomChannel[];
+  toneSteps: number[];
 }) {
   const roleMap = useMemo(() => {
     const map = new Map<ThemeRole, PaletteColor>();
@@ -759,250 +325,76 @@ function TonalRamps({
           margin: 0,
           marginBottom: 4,
         }}>
-        Tonal Palettes{' '}
-        <span style={{fontWeight: 400, color: '#888'}}> — {themeName}</span>
+        Tonal Palettes
       </h2>
       <p style={{fontSize: 11, color: '#888', margin: 0, marginBottom: 12}}>
-        OKLCH tonal ramps — {TONE_STEPS.length} steps per channel, perceptually
-        equalized.
-        {vibrancy !== 1.0 && ` Vibrancy: ${vibrancy.toFixed(1)}x.`} Channels
-        with palette overrides are highlighted.
+        OKLCH tonal ramps — {toneSteps.length} steps per channel.
+        {vibrancy !== 1.0 && ` Vibrancy: ${vibrancy.toFixed(1)}x.`}
       </p>
       <div style={{...S.tonalRow, marginBottom: 6}}>
         <span style={S.tonalLabel} />
         <div style={S.tonalStrip}>
-          {TONE_STEPS.map(t => (
-            <div
-              key={t}
-              style={{
-                flex: 1,
-                textAlign: 'center' as const,
-                fontSize: 8,
-                fontFamily: MONO,
-                color: '#aaa',
-              }}>
+          {toneSteps.map(t => (
+            <div key={t} style={{flex: 1, textAlign: 'center' as const, fontSize: 8, fontFamily: MONO, color: '#aaa'}}>
               {t}
             </div>
           ))}
         </div>
         <span style={S.tonalHct} />
       </div>
-      {CHANNEL_GROUPS.map(group => (
-        <div key={group.label} style={{marginBottom: 14}}>
-          <div
-            style={{
-              fontSize: 9,
-              fontWeight: 600,
-              color: '#aaa',
-              textTransform: 'uppercase' as const,
-              letterSpacing: '0.8px',
-              marginBottom: 4,
-            }}>
-            {group.label}
-          </div>
-          {group.channels.map(ch => {
-            const assigned = roleMap.get(ch.role);
-            const hue = assigned ? hexToOklch(assigned.hex).H : ch.oklchHue;
-            if (ch.role === 'gray') {
-              const grayHue = assigned
-                ? hexToOklch(assigned.hex).H
-                : grayTone === 'warm'
-                  ? 60
-                  : grayTone === 'cool'
-                    ? 260
-                    : 0;
-              const grayC = assigned
-                ? Math.min(hexToOklch(assigned.hex).C, 0.02)
-                : grayTone === 'neutral'
-                  ? 0.003
-                  : 0.012;
-              const tones = oklchTonalPalette(grayHue, grayC, vibrancy);
-              return (
-                <div key={ch.role} style={S.tonalRow}>
-                  <span
-                    style={{
-                      ...S.tonalLabel,
-                      color: assigned ? '#4f46e5' : '#888',
-                      fontWeight: assigned ? 600 : 400,
-                    }}
-                    title={
-                      assigned
-                        ? `${ch.name} ← ${assigned.name}`
-                        : `${ch.name} (default)`
-                    }>
-                    {ch.name}
-                  </span>
-                  <div style={S.tonalStrip}>
-                    {TONE_STEPS.map(t => (
-                      <div
-                        key={t}
-                        style={S.tonalCell(tones[t])}
-                        title={`${ch.name} T${t}: ${tones[t]}`}
-                      />
-                    ))}
-                  </div>
-                  <span style={S.tonalHct}>
-                    H:{grayHue.toFixed(0)} C:{(grayC * vibrancy).toFixed(2)}
-                  </span>
-                </div>
-              );
-            }
-            if (group.label === 'Categorical') {
-              const catChroma = assigned
-                ? Math.max(hexToOklch(assigned.hex).C, ch.oklchChroma)
-                : ch.oklchChroma;
-              const tones = oklchTonalPalette(hue, catChroma, vibrancy);
-              return (
-                <div key={ch.role} style={S.tonalRow}>
-                  <span
-                    style={{
-                      ...S.tonalLabel,
-                      color: assigned ? '#4f46e5' : '#888',
-                      fontWeight: assigned ? 600 : 400,
-                    }}
-                    title={
-                      assigned
-                        ? `${ch.name} ← ${assigned.name}`
-                        : `${ch.name} (default)`
-                    }>
-                    {ch.name}
-                  </span>
-                  <div style={S.tonalStrip}>
-                    {TONE_STEPS.map(t => (
-                      <div
-                        key={t}
-                        style={S.tonalCell(tones[t])}
-                        title={`${ch.name} T${t}: ${tones[t]}`}
-                      />
-                    ))}
-                  </div>
-                  <span style={S.tonalHct}>H:{hue.toFixed(0)}</span>
-                </div>
-              );
-            }
-            const coreOklch = assigned
-              ? hexToOklch(assigned.hex)
-              : {L: 0.5, C: ch.oklchChroma, H: ch.oklchHue};
-            const coreChroma = Math.max(coreOklch.C, 0.09);
-            const tones = oklchTonalPalette(hue, coreChroma, vibrancy);
-            return (
-              <div key={ch.role} style={S.tonalRow}>
-                <span
-                  style={{
-                    ...S.tonalLabel,
-                    color: assigned ? '#4f46e5' : '#888',
-                    fontWeight: assigned ? 600 : 400,
-                  }}
-                  title={
-                    assigned
-                      ? `${ch.name} ← ${assigned.name} (${assigned.hex})`
-                      : `${ch.name} (default)`
-                  }>
-                  {ch.name}
-                </span>
-                <div style={S.tonalStrip}>
-                  {TONE_STEPS.map(t => (
-                    <div
-                      key={t}
-                      style={S.tonalCell(tones[t])}
-                      title={`${ch.name} T${t}: ${tones[t]}`}
-                    />
-                  ))}
-                </div>
-                <span style={S.tonalHct}>
-                  H:{hue.toFixed(0)} C:{(coreChroma * vibrancy).toFixed(2)}
-                </span>
-              </div>
-            );
-          })}
-        </div>
-      ))}
-      {(() => {
-        const assignedStatus = STATUS_CHANNELS.filter(ch =>
-          roleMap.has(ch.role),
-        );
-        if (!assignedStatus.length) return null;
+      {DEFAULT_CHANNELS.map(ch => {
+        const assigned = roleMap.get(ch.role);
+        let hue: number;
+        let chroma: number;
+
+        if (ch.role === 'gray') {
+          hue = assigned
+            ? hexToOklch(assigned.hex).H
+            : grayTone === 'warm' ? 60 : grayTone === 'cool' ? 260 : 0;
+          chroma = (assigned
+            ? Math.min(hexToOklch(assigned.hex).C, 0.02)
+            : grayTone === 'neutral' ? 0.003 : 0.012) * vibrancy;
+        } else if (ch.role === 'accent') {
+          const oklch = assigned ? hexToOklch(assigned.hex) : {C: ch.oklchChroma, H: ch.oklchHue};
+          hue = oklch.H;
+          chroma = Math.max(oklch.C, 0.09) * vibrancy;
+        } else {
+          const oklch = assigned ? hexToOklch(assigned.hex) : {C: ch.oklchChroma, H: ch.oklchHue};
+          hue = oklch.H;
+          chroma = Math.max(oklch.C, ch.oklchChroma) * vibrancy;
+        }
+
         return (
-          <div style={{marginBottom: 14}}>
-            <div
-              style={{
-                fontSize: 9,
-                fontWeight: 600,
-                color: '#aaa',
-                textTransform: 'uppercase' as const,
-                letterSpacing: '0.8px',
-                marginBottom: 4,
-              }}>
-              Status
+          <div key={ch.role} style={S.tonalRow}>
+            <span
+              style={{...S.tonalLabel, color: assigned ? '#4f46e5' : '#888', fontWeight: assigned ? 600 : 400}}
+              title={assigned ? `${ch.name} ← ${assigned.name}` : `${ch.name} (default)`}>
+              {ch.name}
+            </span>
+            <div style={S.tonalStrip}>
+              {toneSteps.map(t => (
+                <div key={t} style={S.tonalCell(oklchClampedHex(toneToOklabL(t), chroma, hue))} title={`${ch.name} T${t}`} />
+              ))}
             </div>
-            {assignedStatus.map(ch => {
-              const assigned = roleMap.get(ch.role)!;
-              const oklch = hexToOklch(assigned.hex);
-              const chroma = Math.max(oklch.C, ch.oklchChroma) * vibrancy;
-              const tones = oklchTonalPalette(oklch.H, chroma);
-              return (
-                <div key={ch.role} style={S.tonalRow}>
-                  <span
-                    style={{...S.tonalLabel, color: '#4f46e5', fontWeight: 600}}
-                    title={`${ch.name} ← ${assigned.name} (${assigned.hex})`}>
-                    {ch.name}
-                  </span>
-                  <div style={S.tonalStrip}>
-                    {TONE_STEPS.map(t => (
-                      <div
-                        key={t}
-                        style={S.tonalCell(tones[t])}
-                        title={`${ch.name} T${t}: ${tones[t]}`}
-                      />
-                    ))}
-                  </div>
-                  <span style={S.tonalHct}>
-                    H:{oklch.H.toFixed(0)} C:{chroma.toFixed(2)}
-                  </span>
-                </div>
-              );
-            })}
+            <span style={S.tonalHct}>H:{hue.toFixed(0)}</span>
           </div>
         );
-      })()}
-      {unassigned.length > 0 && (
-        <>
-          <div
-            style={{
-              fontSize: 9,
-              fontWeight: 600,
-              color: '#888',
-              textTransform: 'uppercase' as const,
-              letterSpacing: '0.8px',
-              marginTop: 12,
-              marginBottom: 6,
-            }}>
-            Unassigned
+      })}
+      {customChannels.map(cc => {
+        const oklch = hexToOklch(cc.hex);
+        const chroma = Math.max(oklch.C, 0.09) * vibrancy;
+        return (
+          <div key={cc.id} style={S.tonalRow}>
+            <span style={{...S.tonalLabel, color: '#4f46e5', fontWeight: 600}}>{cc.name}</span>
+            <div style={S.tonalStrip}>
+              {toneSteps.map(t => (
+                <div key={t} style={S.tonalCell(oklchClampedHex(toneToOklabL(t), chroma, oklch.H))} title={`${cc.name} T${t}`} />
+              ))}
+            </div>
+            <span style={S.tonalHct}>H:{oklch.H.toFixed(0)}</span>
           </div>
-          {unassigned.map(pc => {
-            const oklch = hexToOklch(pc.hex);
-            const chroma = Math.max(oklch.C, 0.05) * vibrancy;
-            const tones = oklchTonalPalette(oklch.H, chroma);
-            return (
-              <div key={pc.id} style={S.tonalRow}>
-                <span style={S.tonalLabel}>{pc.name}</span>
-                <div style={S.tonalStrip}>
-                  {TONE_STEPS.map(t => (
-                    <div
-                      key={t}
-                      style={S.tonalCell(tones[t])}
-                      title={`${pc.name} T${t}: ${tones[t]}`}
-                    />
-                  ))}
-                </div>
-                <span style={S.tonalHct}>
-                  H:{oklch.H.toFixed(0)} C:{chroma.toFixed(2)}
-                </span>
-              </div>
-            );
-          })}
-        </>
-      )}
+        );
+      })}
     </div>
   );
 }
@@ -1070,51 +462,31 @@ export default function ColorStudioPage() {
   const [palette, setPalette] = useState<PaletteColor[]>([
     makePaletteColor('Blue', '#0064E0', 'accent'),
   ]);
-  const [themeName, setThemeName] = useState('Custom');
-  const [exactAccent, setExactAccent] = useState(true);
   const [vibrancy, setVibrancy] = useState(1.0);
+  const [customChannels, setCustomChannels] = useState<CustomChannel[]>([]);
+  const [toneSteps, setToneSteps] = useState<number[]>(DEFAULT_TONE_STEPS);
+  const [newStep, setNewStep] = useState('');
   const [grayTone, setGrayTone] = useState<'warm' | 'neutral' | 'cool'>(
     'neutral',
   );
   const [imgSrc, setImgSrc] = useState<string | null>(null);
   const fileRef = useRef<HTMLInputElement>(null);
 
-  const themeOptions: ThemeOptions = useMemo(
-    () => ({
-      warmth: grayTone as 'warm' | 'cool' | 'neutral',
-      surfaceStyle: 'tinted' as const,
-      exactAccent,
-      vibrancy,
-      radiusMultiplier: 1,
-    }),
-    [grayTone, exactAccent, vibrancy],
-  );
-
   const usedRoles = useMemo(
     () => new Set(palette.filter(c => c.role).map(c => c.role!)),
     [palette],
   );
 
-  const theme = useMemo(() => {
-    const {accentHex, tokens} = buildThemeTokens(palette, themeOptions);
-    const bodyColor =
-      grayTone === 'warm'
-        ? '#F5F0E8'
-        : grayTone === 'cool'
-          ? '#EEF2F7'
-          : undefined;
-
-    return defineTheme({
-      name: 'studio-preview',
-      color: {
-        accent: accentHex,
-        neutralStyle: grayTone,
-        ...(bodyColor ? {bodyColor} : {}),
-      },
-      radius: {base: 4, multiplier: 1},
-      tokens,
-    });
-  }, [palette, themeOptions, grayTone]);
+  const themeOptions: ThemeOptions = useMemo(
+    () => ({
+      warmth: grayTone as 'warm' | 'cool' | 'neutral',
+      surfaceStyle: 'tinted' as const,
+      exactAccent: true,
+      vibrancy,
+      radiusMultiplier: 1,
+    }),
+    [grayTone, vibrancy],
+  );
 
   const updateColor = useCallback(
     (id: string, changes: Partial<PaletteColor>) => {
@@ -1134,11 +506,6 @@ export default function ColorStudioPage() {
     const c = 30 + Math.random() * 50;
     const hex = hctToHex({hue: h, chroma: c, tone: 50});
     setPalette(prev => [...prev, makePaletteColor('Color ' + _nextId, hex)]);
-  }, []);
-
-  const loadPreset = useCallback((preset: PresetPalette) => {
-    setThemeName(preset.label);
-    setPalette(preset.colors.map(c => makePaletteColor(c.name, c.hex, c.role)));
   }, []);
 
   const handleImage = useCallback((file: File) => {
@@ -1178,24 +545,6 @@ export default function ColorStudioPage() {
 
           <div style={S.sidebarScroll}>
             <XDSVStack gap={5}>
-              {/* --- Presets --- */}
-              <XDSVStack gap={3}>
-                <XDSText type="label" weight="semibold">
-                  Presets
-                </XDSText>
-                <XDSHStack gap={1} wrap="wrap">
-                  {PRESETS.map(p => (
-                    <XDSButton
-                      key={p.label}
-                      label={p.label}
-                      variant={themeName === p.label ? 'primary' : 'secondary'}
-                      size="sm"
-                      onClick={() => loadPreset(p)}
-                    />
-                  ))}
-                </XDSHStack>
-              </XDSVStack>
-
               {/* --- Palette --- */}
               <XDSVStack gap={3}>
                 <XDSHStack hAlign="between" vAlign="center">
@@ -1259,20 +608,106 @@ export default function ColorStudioPage() {
                   </XDSSegmentedControl>
                 </XDSHStack>
 
-                <XDSHStack
-                  vAlign="center"
-                  style={{justifyContent: 'space-between'}}>
-                  <XDSText type="supporting" color="secondary">
-                    Accent Match
-                  </XDSText>
-                  <XDSSegmentedControl
-                    label="Accent match"
-                    value={exactAccent ? 'exact' : 'derived'}
-                    onChange={v => setExactAccent(v === 'exact')}
-                    size="sm">
-                    <XDSSegmentedControlItem value="derived" label="Tonal" />
-                    <XDSSegmentedControlItem value="exact" label="Exact" />
-                  </XDSSegmentedControl>
+              </XDSVStack>
+
+              {/* --- Custom Colors --- */}
+              <XDSVStack gap={3}>
+                <XDSHStack hAlign="space-between" vAlign="center">
+                  <XDSText type="label" weight="semibold">Custom Colors</XDSText>
+                  <XDSIconButton
+                    label="Add custom color"
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => {
+                      const h = Math.random() * 360;
+                      const hex = oklchClampedHex(0.5, 0.12, h);
+                      setCustomChannels(prev => [...prev, {id: nextId(), name: `Custom ${prev.length + 1}`, hex}]);
+                    }}
+                    icon={<span style={{fontSize: 16, lineHeight: 1}}>+</span>}
+                  />
+                </XDSHStack>
+                {customChannels.map(cc => (
+                  <XDSHStack key={cc.id} gap={2} vAlign="center" style={{padding: '4px 0'}}>
+                    <div style={S.swatch(cc.hex)}>
+                      <input
+                        type="color"
+                        value={cc.hex}
+                        onChange={e => setCustomChannels(prev => prev.map(c => c.id === cc.id ? {...c, hex: e.target.value} : c))}
+                        style={S.colorInput}
+                      />
+                    </div>
+                    <div style={{flex: 1, minWidth: 0}}>
+                      <XDSTextInput
+                        label="Name"
+                        isLabelHidden
+                        value={cc.name}
+                        onChange={v => setCustomChannels(prev => prev.map(c => c.id === cc.id ? {...c, name: v} : c))}
+                        size="sm"
+                      />
+                    </div>
+                    <XDSIconButton
+                      label="Remove"
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => setCustomChannels(prev => prev.filter(c => c.id !== cc.id))}
+                      icon={<span style={{fontSize: 14, lineHeight: 1}}>✕</span>}
+                    />
+                  </XDSHStack>
+                ))}
+              </XDSVStack>
+
+              {/* --- Tone Steps --- */}
+              <XDSVStack gap={3}>
+                <XDSText type="label" weight="semibold">Tone Steps</XDSText>
+                <XDSHStack gap={1} wrap="wrap">
+                  {toneSteps.map(t => (
+                    <span
+                      key={t}
+                      onClick={() => setToneSteps(prev => prev.filter(s => s !== t))}
+                      style={{
+                        padding: '2px 6px',
+                        fontSize: 10,
+                        fontFamily: MONO,
+                        borderRadius: 4,
+                        background: 'var(--color-background-muted)',
+                        cursor: 'pointer',
+                        color: 'var(--color-text-secondary)',
+                      }}
+                      title="Click to remove"
+                    >
+                      {t}
+                    </span>
+                  ))}
+                </XDSHStack>
+                <XDSHStack gap={2} vAlign="center">
+                  <div style={{flex: 1, minWidth: 0}}>
+                    <XDSTextInput
+                      label="Add step"
+                      isLabelHidden
+                      placeholder="e.g. 15"
+                      value={newStep}
+                      onChange={v => setNewStep(v)}
+                      size="sm"
+                    />
+                  </div>
+                  <XDSButton
+                    label="Add"
+                    variant="secondary"
+                    size="sm"
+                    onClick={() => {
+                      const n = parseInt(newStep, 10);
+                      if (!isNaN(n) && n >= 0 && n <= 100 && !toneSteps.includes(n)) {
+                        setToneSteps(prev => [...prev, n].sort((a, b) => a - b));
+                        setNewStep('');
+                      }
+                    }}
+                  />
+                  <XDSButton
+                    label="Reset"
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setToneSteps(DEFAULT_TONE_STEPS)}
+                  />
                 </XDSHStack>
               </XDSVStack>
 
@@ -1311,14 +746,11 @@ export default function ColorStudioPage() {
         <TonalRamps
           palette={palette}
           vibrancy={vibrancy}
-          themeName={themeName}
           grayTone={grayTone}
+          customChannels={customChannels}
+          toneSteps={toneSteps}
         />
 
-        <div style={{display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 20}}>
-          <PreviewColumn mode="light" theme={theme} />
-          <PreviewColumn mode="dark" theme={theme} />
-        </div>
       </main>
     </div>
   );

--- a/apps/sandbox/src/app/(sandbox)/pages/color-studio/page.tsx
+++ b/apps/sandbox/src/app/(sandbox)/pages/color-studio/page.tsx
@@ -665,7 +665,10 @@ export default function ColorStudioPage() {
                       key={t}
                       onClick={() => setToneSteps(prev => prev.filter(s => s !== t))}
                       style={{
-                        padding: '2px 6px',
+                        display: 'inline-flex',
+                        alignItems: 'center',
+                        gap: 3,
+                        padding: '2px 4px 2px 6px',
                         fontSize: 10,
                         fontFamily: MONO,
                         borderRadius: 4,
@@ -673,9 +676,10 @@ export default function ColorStudioPage() {
                         cursor: 'pointer',
                         color: 'var(--color-text-secondary)',
                       }}
-                      title="Click to remove"
+                      title={`Remove step ${t}`}
                     >
                       {t}
+                      <span style={{fontSize: 8, opacity: 0.4}}>✕</span>
                     </span>
                   ))}
                 </XDSHStack>

--- a/apps/sandbox/src/components/ThemePalettePreview.tsx
+++ b/apps/sandbox/src/components/ThemePalettePreview.tsx
@@ -190,6 +190,8 @@ export interface ThemePalettePreviewProps {
   coreSwatches: CoreSwatch[];
   /** Additional sections to render at the end of each mode column */
   extraSections?: React.ReactNode;
+  /** Hide the title, subtitle, and tonal section (useful when embedded in another layout) */
+  componentPreviewOnly?: boolean;
 }
 
 type Mode = 'light' | 'dark';
@@ -887,7 +889,27 @@ export function ThemePalettePreview({
   tonalColors,
   coreSwatches,
   extraSections,
+  componentPreviewOnly = false,
 }: ThemePalettePreviewProps) {
+  if (componentPreviewOnly) {
+    return (
+      <div style={S.twoCol}>
+        <ModeColumn
+          theme={theme}
+          mode="light"
+          coreSwatches={coreSwatches}
+          extraSections={extraSections}
+        />
+        <ModeColumn
+          theme={theme}
+          mode="dark"
+          coreSwatches={coreSwatches}
+          extraSections={extraSections}
+        />
+      </div>
+    );
+  }
+
   return (
     <XDSTheme theme={theme} mode="light">
       <XDSLayerProvider>


### PR DESCRIPTION
## Summary

Simplify Color Studio into a focused palette creation tool:

- **Remove component preview** — component previews live on dedicated theme palette pages using `ThemePalettePreview`
- **Remove presets and accent match toggle** — keep the tool focused on palette exploration
- **Flat tonal ramps** — no Core/Categorical/Status section grouping, just a clean list of all channels
- **Custom color channels** — add any named color beyond the default 11, each gets its own OKLCH tonal ramp
- **Custom tone steps** — add/remove steps (0–100), click a step chip to remove it, "Reset" restores defaults
- **`componentPreviewOnly` prop** added to `ThemePalettePreview` for embedding just the component sections without title/tonal ramps
- Sidebar: palette editor, vibrancy slider, gray tone, custom colors, tone steps, image extraction, export

## Test plan

- [ ] Add custom colors — each appears as a new ramp row
- [ ] Add/remove tone steps — ramp columns update instantly
- [ ] Vibrancy slider scales all ramps uniformly
- [ ] Gray tone toggle shifts the Gray channel hue
- [ ] Export copies valid `defineTheme()` config
- [ ] Image extraction populates palette from image
- [ ] No sandbox nav on Color Studio page

Made with [Cursor](https://cursor.com)