### PR TITLE
fix(templates): add page background color to contact-form and file-explorer

### DIFF
--- a/packages/cli/templates/pages/contact-form/page.tsx
+++ b/packages/cli/templates/pages/contact-form/page.tsx
@@ -18,6 +18,7 @@ import {XDSRadioList, XDSRadioListItem} from '@xds/core/RadioList';
 import {XDSTextArea} from '@xds/core/TextArea';
 import {XDSDivider} from '@xds/core/Divider';
 import {XDSBanner} from '@xds/core/Banner';
+import {colorVars} from '@xds/core/theme/tokens.stylex';
 
 const WHY_US_IMAGES = [
   // illustration-horizontal-3 from xds_oss asset set
@@ -76,6 +77,10 @@ const WHY_US = [
 ];
 
 const styles = stylex.create({
+  page: {
+    minHeight: '100dvh',
+    backgroundColor: colorVars['--color-background-body'],
+  },
   imgFull: {
     width: '100%',
   },
@@ -115,7 +120,7 @@ export default function FormSimplePage() {
     );
 
   return (
-    <XDSCenter axis="horizontal">
+    <XDSCenter axis="horizontal" xstyle={styles.page}>
       <XDSVStack hAlign="center" width="100%">
         <XDSSection maxWidth={800} padding={6} paddingBlock={10} variant="section">
           <XDSVStack gap={6}>

--- a/packages/cli/templates/pages/contact-form/page.tsx
+++ b/packages/cli/templates/pages/contact-form/page.tsx
@@ -79,7 +79,7 @@ const WHY_US = [
 const styles = stylex.create({
   page: {
     minHeight: '100dvh',
-    backgroundColor: colorVars['--color-background-body'],
+    backgroundColor: colorVars['--color-background-surface'],
   },
   imgFull: {
     width: '100%',

--- a/packages/cli/templates/pages/file-explorer/page.tsx
+++ b/packages/cli/templates/pages/file-explorer/page.tsx
@@ -262,7 +262,7 @@ const FILESYSTEM: FileSystemItem[] = [
 const styles = stylex.create({
   page: {
     minHeight: '100dvh',
-    backgroundColor: colorVars['--color-background-body'],
+    backgroundColor: colorVars['--color-background-surface'],
   },
   fillHeight: {height: '100%'},
   scrollable: {overflowY: 'auto'},

--- a/packages/cli/templates/pages/file-explorer/page.tsx
+++ b/packages/cli/templates/pages/file-explorer/page.tsx
@@ -31,6 +31,7 @@ import {
   DocumentIcon,
 } from '@heroicons/react/24/outline';
 import {FolderIcon} from '@heroicons/react/24/solid';
+import {colorVars} from '@xds/core/theme/tokens.stylex';
 
 interface FileSystemItem {
   id: string;
@@ -259,6 +260,10 @@ const FILESYSTEM: FileSystemItem[] = [
 ];
 
 const styles = stylex.create({
+  page: {
+    minHeight: '100dvh',
+    backgroundColor: colorVars['--color-background-body'],
+  },
   fillHeight: {height: '100%'},
   scrollable: {overflowY: 'auto'},
   fixedColumn: {flexShrink: 0, alignSelf: 'stretch'},
@@ -335,6 +340,7 @@ export default function FileExplorerPage() {
 
   return (
     <XDSLayout
+      xstyle={styles.page}
       height="fill"
       header={
         <XDSToolbar


### PR DESCRIPTION
Both templates were missing a page-level background color, rendering with a transparent/white background instead of the themed body color.

Uses `backgroundColor: colorVars['--color-background-body']` with `minHeight: 100dvh` — same lightweight pattern as the login template (no AppShell needed).