### PR TITLE
fix(nav): remove hover popover open delay to prevent flickering

### DIFF
--- a/packages/core/src/SideNav/XDSSideNavHeading.tsx
+++ b/packages/core/src/SideNav/XDSSideNavHeading.tsx
@@ -379,6 +379,7 @@ export function XDSSideNavHeading({
     hide: popover.hide,
     isOpen: popover.isOpen,
     isEnabled: !!menu,
+    showDelay: 0,
   });
 
   const setRef = useCallback(

--- a/packages/core/src/TopNav/XDSTopNavHeading.tsx
+++ b/packages/core/src/TopNav/XDSTopNavHeading.tsx
@@ -340,6 +340,7 @@ export function XDSTopNavHeading({
     hide: popover.hide,
     isOpen: popover.isOpen,
     isEnabled: !!menu,
+    showDelay: 0,
   });
 
   const setRef = useCallback(

--- a/packages/core/src/hooks/useXDSMenuHover.ts
+++ b/packages/core/src/hooks/useXDSMenuHover.ts
@@ -126,9 +126,13 @@ export function useXDSMenuHover(
     }
     hoverModeRef.current = true;
     clearTimeouts();
-    showTimerRef.current = setTimeout(() => {
+    if (showDelay > 0) {
+      showTimerRef.current = setTimeout(() => {
+        show({skipAutoFocus: true});
+      }, showDelay);
+    } else {
       show({skipAutoFocus: true});
-    }, showDelay);
+    }
   }, [hasHover, clearTimeouts, show, showDelay]);
 
   // Hover: mouseleave only closes if in hover mode


### PR DESCRIPTION
## Summary

Removes the 150ms show delay on nav heading hover menus (`XDSSideNavHeading` and `XDSTopNavHeading`) to prevent flickering.

## Problem

The heading popover menus had a 150ms delay before opening on hover (inherited from the shared `useXDSMenuHover` hook default). Unlike nav items/menus which appear in groups where debouncing prevents accidental triggers, the heading is always a single target — the delay just caused visible flicker with no upside.

## Changes

- **`XDSSideNavHeading`** — passes `showDelay: 0` to `useXDSMenuHover`
- **`XDSTopNavHeading`** — passes `showDelay: 0` to `useXDSMenuHover`
- **`useXDSMenuHover`** — when `showDelay` is 0, calls `show()` synchronously instead of wrapping in an unnecessary `setTimeout(..., 0)`

## Not changed

`XDSTopNavMenu`, `XDSTopNavMegaMenu`, and `XDSSideNavItem` keep their 150ms delay since they appear in groups where debouncing across multiple targets is useful.