### PR TITLE
fix(TopNav): stop click propagation on heading links in mixed mode

### DIFF
--- a/packages/core/src/TopNav/XDSTopNavHeading.tsx
+++ b/packages/core/src/TopNav/XDSTopNavHeading.tsx
@@ -374,6 +374,7 @@ export function XDSTopNavHeading({
         (hasAnyHref && superheadingHref && menu ? (
           <XDSLink
             href={superheadingHref}
+            onClick={(e: React.MouseEvent) => e.stopPropagation()}
             color="secondary"
             size="xsm">
             {superheading}
@@ -385,6 +386,7 @@ export function XDSTopNavHeading({
         {hasAnyHref && headingHref && menu ? (
           <LinkComponent
             href={headingHref}
+            onClick={(e: React.MouseEvent) => e.stopPropagation()}
             {...stylex.props(styles.heading, styles.headingLink)}>
             {heading}
           </LinkComponent>
@@ -397,6 +399,7 @@ export function XDSTopNavHeading({
         (hasAnyHref && subheadingHref && menu ? (
           <XDSLink
             href={subheadingHref}
+            onClick={(e: React.MouseEvent) => e.stopPropagation()}
             color="secondary"
             size="xsm">
             {subheading}
@@ -545,7 +548,10 @@ export function XDSTopNavHeading({
           )}>
           {logo &&
             (headingHref ? (
-              <LinkComponent href={headingHref} {...stylex.props(styles.logo)}>
+              <LinkComponent
+                href={headingHref}
+                onClick={(e: React.MouseEvent) => e.stopPropagation()}
+                {...stylex.props(styles.logo)}>
                 {logo}
               </LinkComponent>
             ) : (
@@ -614,20 +620,14 @@ export function XDSTopNavHeading({
         <span {...stylex.props(styles.textContainer)}>
           {superheading &&
             (superheadingHref ? (
-              <XDSLink
-                href={superheadingHref}
-                color="secondary"
-                size="xsm">
+              <XDSLink href={superheadingHref} color="secondary" size="xsm">
                 {superheading}
               </XDSLink>
             ) : (
               <span {...stylex.props(styles.superheading)}>{superheading}</span>
             ))}
           {headingHref ? (
-            <XDSLink
-              href={headingHref}
-              color="primary"
-              weight="semibold">
+            <XDSLink href={headingHref} color="primary" weight="semibold">
               {heading}
             </XDSLink>
           ) : (
@@ -635,10 +635,7 @@ export function XDSTopNavHeading({
           )}
           {subheading &&
             (subheadingHref ? (
-              <XDSLink
-                href={subheadingHref}
-                color="secondary"
-                size="xsm">
+              <XDSLink href={subheadingHref} color="secondary" size="xsm">
                 {subheading}
               </XDSLink>
             ) : (


### PR DESCRIPTION
## Problem

When `XDSTopNavHeading` has both `headingHref` and `menu` props (mixed mode), clicking the logo or heading text inconsistently triggers navigation. Sometimes it opens the menu instead.

## Root Cause

In mixed mode, the root `<div>` receives `triggerProps.onClick` from `useXDSMenuHover` which toggles the popover. Clicks on the logo `LinkComponent` and heading text `LinkComponent` bubble up to this handler, causing the menu to toggle instead of (or alongside) navigating.

The chevron button already had `e.stopPropagation()` — the link elements were just missing it.

## Fix

Add `onClick={e => e.stopPropagation()}` to all link elements rendered inside the mixed-mode trigger div:
- Logo `LinkComponent`
- Heading text `LinkComponent`
- Superheading `XDSLink`
- Subheading `XDSLink`

This ensures link clicks navigate cleanly without triggering the menu popover.

## Repro

```tsx
<XDSTopNavHeading
  logo={<MyLogo />}
  headingHref="/"
  menu={<NavMenu />}
/>
```

Click the logo rapidly — sometimes it navigates, sometimes the menu opens instead.