### PR TITLE
fix(TimeInput): add state to showcase so inputs are actually editable

### DIFF
--- a/packages/cli/templates/blocks/components/TimeInput/TimeInputShowcase.tsx
+++ b/packages/cli/templates/blocks/components/TimeInput/TimeInputShowcase.tsx
@@ -1,7 +1,16 @@
 'use client';
 
-import {XDSTimeInput} from '@xds/core/TimeInput';
+import {useState} from 'react';
+import {XDSTimeInput, type ISOTimeString} from '@xds/core/TimeInput';
 
 export default function TimeInputShowcase() {
-  return <XDSTimeInput label="Time" placeholder="Select a time" />;
+  const [time, setTime] = useState<ISOTimeString | undefined>(undefined);
+  return (
+    <XDSTimeInput
+      label="Time"
+      placeholder="Select a time"
+      value={time}
+      onChange={setTime}
+    />
+  );
 }

--- a/packages/core/src/TimeInput/index.ts
+++ b/packages/core/src/TimeInput/index.ts
@@ -17,3 +17,4 @@ export type {
   XDSTimeInputStatus,
   XDSTimeInputStatusType,
 } from './XDSTimeInput';
+export type {ISOTimeString} from '../utils';


### PR DESCRIPTION
## Problem

On the docs site, clicking in the TimeInput showcase does nothing — users can't select or type a time.

## Root Cause

`TimeInputShowcase.tsx` was rendered without `value`/`onChange` props. The component needs to be paired with state to accept input. Other examples in the same folder (`TimeInputFormats`, `TimeInputStates`, `TimeInputIncrement`) correctly wire up state — the showcase was the outlier.

## Fix

Add `useState` and pass `value`/`onChange` so the showcase behaves like a real interactive example.