### PR TITLE
fix(cli): skip components without .doc.mjs in discovery

### DIFF
--- a/packages/cli/src/commands/component.test.mjs
+++ b/packages/cli/src/commands/component.test.mjs
@@ -43,6 +43,10 @@ describe('discoverComponents', () => {
     const avatarDir = path.join(srcDir, 'Avatar');
     fs.mkdirSync(avatarDir, {recursive: true});
     fs.writeFileSync(path.join(avatarDir, 'XDSAvatar.tsx'), '');
+    fs.writeFileSync(
+      path.join(avatarDir, 'Avatar.doc.mjs'),
+      "export const docs = {name: 'Avatar'};",
+    );
 
     const result = discoverComponents(tmpDir);
 
@@ -59,11 +63,19 @@ describe('discoverComponents', () => {
     const zebraDir = path.join(srcDir, 'Zebra');
     fs.mkdirSync(zebraDir, {recursive: true});
     fs.writeFileSync(path.join(zebraDir, 'XDSZebra.tsx'), '');
+    fs.writeFileSync(
+      path.join(zebraDir, 'Zebra.doc.mjs'),
+      "export const docs = {name: 'Zebra'};",
+    );
 
     // Alpha (ungrouped)
     const alphaDir = path.join(srcDir, 'Alpha');
     fs.mkdirSync(alphaDir, {recursive: true});
     fs.writeFileSync(path.join(alphaDir, 'XDSAlpha.tsx'), '');
+    fs.writeFileSync(
+      path.join(alphaDir, 'Alpha.doc.mjs'),
+      "export const docs = {name: 'Alpha'};",
+    );
 
     // Middle in group 'Inputs'
     const middleDir = path.join(srcDir, 'Middle');
@@ -83,19 +95,23 @@ describe('discoverComponents', () => {
     fs.mkdirSync(buttonDir, {recursive: true});
     fs.writeFileSync(path.join(buttonDir, 'XDSButton.tsx'), '');
     fs.writeFileSync(path.join(buttonDir, 'XDSButton.test.tsx'), '');
+    fs.writeFileSync(
+      path.join(buttonDir, 'Button.doc.mjs'),
+      "export const docs = {name: 'Button'};",
+    );
 
     const result = discoverComponents(tmpDir);
     expect(result).toEqual({Button: ['Button']});
   });
 
-  it('ungrouped components without .doc.mjs appear as standalone entries', () => {
+  it('skips components without a .doc.mjs file', () => {
     const srcDir = path.join(tmpDir, 'src');
     const customDir = path.join(srcDir, 'CustomWidget');
     fs.mkdirSync(customDir, {recursive: true});
     fs.writeFileSync(path.join(customDir, 'XDSCustomWidget.tsx'), '');
 
     const result = discoverComponents(tmpDir);
-    expect(result).toEqual({CustomWidget: ['CustomWidget']});
+    expect(result).toEqual({});
   });
 
   it('skips hooks/utils directories', () => {

--- a/packages/cli/src/lib/component-discovery.mjs
+++ b/packages/cli/src/lib/component-discovery.mjs
@@ -103,10 +103,16 @@ export function discoverComponents(coreDir) {
       if (!fs.existsSync(compDoc)) {
         compDoc = path.join(dirPath, `XDS${componentName}.doc.mjs`);
       }
-      if (fs.existsSync(compDoc)) {
+      const hasComponentDoc = fs.existsSync(compDoc);
+      if (hasComponentDoc) {
         const compMeta = readDocMeta(compDoc);
         if (compMeta.group) compGroup = compMeta.group;
       }
+
+      // Skip components without any .doc.mjs file (directory-level or
+      // component-level). They can't be documented, so surfacing them in
+      // the component list leads to broken docs-site links.
+      if (!fs.existsSync(docFile) && !hasComponentDoc) continue;
 
       if (!componentGroups.has(componentName)) {
         componentGroups.set(componentName, compGroup);


### PR DESCRIPTION
## Problem

On the docs site, /components/citation shows "Component not found — That component doesn't exist in XDS" even though Citation appears in the sidebar.

## Root Cause

`discoverComponents()` in `component-discovery.mjs` scans `packages/core/src/*/` for `XDS*.tsx` files and adds every one to the component list. It doesn't check whether a matching `.doc.mjs` file exists. For components introduced without one (like `XDSCitation`, extracted from `XDSMarkdown` in #2073), the sidebar entry is surfaced but clicking it leads to a broken detail page because `getComponentDetail()` can't find any doc file.

## Fix

Skip components in `discoverComponents()` when neither a directory-level (`Citation.doc.mjs`) nor component-level (`XDSCitation.doc.mjs`) doc file exists. This matches how `discoverExternalComponentsGrouped()` already behaves — it only surfaces entries with doc files.

Components can be re-added to the sidebar by authoring a `.doc.mjs`.