### PR TITLE
feat(Selector): add hasSearch prop for filtering options (#2131)

### DIFF
--- a/.changeset/cute-spiders-work.md
+++ b/.changeset/cute-spiders-work.md
@@ -1,0 +1,5 @@
+---
+'@xds/core': minor
+---
+
+Add hasSearch and searchPlaceholder props to XDSSelector for filtering options

--- a/.changeset/cute-spiders-work.md
+++ b/.changeset/cute-spiders-work.md
@@ -1,5 +1,0 @@
----
-'@xds/core': minor
----
-
-Add hasSearch and searchPlaceholder props to XDSSelector for filtering options

--- a/packages/core/src/Selector/Selector.doc.mjs
+++ b/packages/core/src/Selector/Selector.doc.mjs
@@ -46,6 +46,18 @@ export const docs = {
           default: 'false',
         },
         {
+          name: 'hasSearch',
+          type: 'boolean',
+          description: 'Whether to show a search input for filtering options.',
+          default: 'false',
+        },
+        {
+          name: 'searchPlaceholder',
+          type: 'string',
+          description: 'Placeholder text for the search input.',
+          default: "'Search...'",
+        },
+        {
           name: 'placeholder',
           type: 'string',
           description: 'Placeholder text shown when no value is selected.',
@@ -192,6 +204,18 @@ export const docsZh = {
           default: 'false',
         },
         {
+          name: 'hasSearch',
+          type: 'boolean',
+          description: '是否显示用于过滤选项的搜索输入。',
+          default: 'false',
+        },
+        {
+          name: 'searchPlaceholder',
+          type: 'string',
+          description: '搜索输入的占位文本。',
+          default: "'Search...'",
+        },
+        {
           name: 'placeholder',
           type: 'string',
           description: '未选择值时显示的占位文本。',
@@ -328,6 +352,8 @@ export const docsDense = {
         value: 'Currently selected value.',
         onChange: 'Callback fired when selection changes.',
         hasClear: 'Shows clear button when value selected. onChange also accepts null on clear.',
+        hasSearch: 'Shows search input for filtering options.',
+        searchPlaceholder: 'Placeholder text for search input.',
         placeholder: 'Placeholder text when no value selected.',
         size: 'Size variant for selector.',
         isDisabled: 'Disables selector.',

--- a/packages/core/src/Selector/XDSSelector.test.tsx
+++ b/packages/core/src/Selector/XDSSelector.test.tsx
@@ -267,6 +267,29 @@ describe('XDSSelector', () => {
       expect(onChange).toHaveBeenCalledWith('Banana');
     });
 
+    it('closes dropdown on Tab without preventing default focus movement', async () => {
+      const user = userEvent.setup();
+      render(
+        <>
+          <XDSSelector
+            label="Fruit"
+            options={OPTIONS}
+            value="Apple"
+            onChange={() => {}}
+            hasSearch
+          />
+          <button>Next</button>
+        </>,
+      );
+
+      const trigger = screen.getByRole('combobox');
+      await user.click(trigger);
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+
+      await user.keyboard('{Tab}');
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    });
+
     it('uses custom search placeholder', async () => {
       const user = userEvent.setup();
       render(

--- a/packages/core/src/Selector/XDSSelector.test.tsx
+++ b/packages/core/src/Selector/XDSSelector.test.tsx
@@ -278,7 +278,7 @@ describe('XDSSelector', () => {
             onChange={() => {}}
             hasSearch
           />
-          <button>Next</button>
+          <button type="button">Next</button>
         </>,
       );
 

--- a/packages/core/src/Selector/XDSSelector.test.tsx
+++ b/packages/core/src/Selector/XDSSelector.test.tsx
@@ -7,10 +7,37 @@
  * SYNC: When XDSSelector.tsx API changes, update these tests.
  */
 
-import {describe, it, expect, vi} from 'vitest';
+import {describe, it, expect, vi, beforeEach} from 'vitest';
 import {render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {XDSSelector} from './XDSSelector';
+
+// Mock showPopover and hidePopover methods since they're not implemented in jsdom
+beforeEach(() => {
+  HTMLElement.prototype.showPopover = vi.fn(function (this: HTMLElement) {
+    this.setAttribute('popover-open', '');
+    const event = new Event('toggle', {bubbles: false});
+    Object.defineProperty(event, 'newState', {value: 'open'});
+    this.dispatchEvent(event);
+  });
+  HTMLElement.prototype.hidePopover = vi.fn(function (this: HTMLElement) {
+    this.removeAttribute('popover-open');
+    const event = new Event('toggle', {bubbles: false});
+    Object.defineProperty(event, 'newState', {value: 'closed'});
+    this.dispatchEvent(event);
+  });
+  const originalMatches = HTMLElement.prototype.matches;
+  HTMLElement.prototype.matches = function (selector: string) {
+    if (selector === ':popover-open') {
+      return this.hasAttribute('popover-open');
+    }
+    return originalMatches.call(this, selector);
+  };
+});
+
+// Helper: jsdom popover content is in the DOM but may not be
+// "visible" in the accessibility tree. Use hidden: true to find it.
+const h = {hidden: true} as const;
 
 const OPTIONS = ['Apple', 'Banana', 'Cherry'];
 
@@ -154,6 +181,108 @@ describe('XDSSelector', () => {
         />,
       );
       expect(screen.getByRole('combobox')).toHaveTextContent('Yellow Banana');
+    });
+  });
+
+  describe('hasSearch', () => {
+    it('renders search input when hasSearch is true', async () => {
+      const user = userEvent.setup();
+      render(
+        <XDSSelector
+          label="Fruit"
+          options={OPTIONS}
+          value="Apple"
+          onChange={() => {}}
+          hasSearch
+        />,
+      );
+      await user.click(screen.getByRole('combobox'));
+      expect(screen.getByRole('searchbox', h)).toBeInTheDocument();
+    });
+
+    it('does not render search input when hasSearch is false', async () => {
+      const user = userEvent.setup();
+      render(
+        <XDSSelector
+          label="Fruit"
+          options={OPTIONS}
+          value="Apple"
+          onChange={() => {}}
+        />,
+      );
+      await user.click(screen.getByRole('combobox'));
+      expect(screen.queryByRole('searchbox', h)).not.toBeInTheDocument();
+    });
+
+    it('filters options by search query', async () => {
+      const user = userEvent.setup();
+      render(
+        <XDSSelector
+          label="Fruit"
+          options={OPTIONS}
+          value="Apple"
+          onChange={() => {}}
+          hasSearch
+        />,
+      );
+      await user.click(screen.getByRole('combobox'));
+      await user.type(screen.getByRole('searchbox', h), 'ban');
+      const options = screen.getAllByRole('option', h);
+      expect(options).toHaveLength(1);
+      expect(options[0]).toHaveTextContent('Banana');
+    });
+
+    it('shows empty state when no options match', async () => {
+      const user = userEvent.setup();
+      render(
+        <XDSSelector
+          label="Fruit"
+          options={OPTIONS}
+          value="Apple"
+          onChange={() => {}}
+          hasSearch
+        />,
+      );
+      await user.click(screen.getByRole('combobox'));
+      await user.type(screen.getByRole('searchbox', h), 'xyz');
+      expect(screen.queryAllByRole('option', h)).toHaveLength(0);
+      expect(screen.getByText('No results found')).toBeInTheDocument();
+    });
+
+    it('calls onChange when selecting a filtered option', async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      render(
+        <XDSSelector
+          label="Fruit"
+          options={OPTIONS}
+          value="Apple"
+          onChange={onChange}
+          hasSearch
+        />,
+      );
+      await user.click(screen.getByRole('combobox'));
+      await user.type(screen.getByRole('searchbox', h), 'ban');
+      await user.click(screen.getByRole('option', {name: /Banana/, ...h}));
+      expect(onChange).toHaveBeenCalledWith('Banana');
+    });
+
+    it('uses custom search placeholder', async () => {
+      const user = userEvent.setup();
+      render(
+        <XDSSelector
+          label="Fruit"
+          options={OPTIONS}
+          value="Apple"
+          onChange={() => {}}
+          hasSearch
+          searchPlaceholder="Find a fruit..."
+        />,
+      );
+      await user.click(screen.getByRole('combobox'));
+      expect(
+        screen.getByPlaceholderText('Find a fruit...'),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/packages/core/src/Selector/XDSSelector.tsx
+++ b/packages/core/src/Selector/XDSSelector.tsx
@@ -19,6 +19,7 @@ import React, {
   useMemo,
   useOptimistic,
   useRef,
+  useState,
   useTransition,
   type ReactNode,
 } from 'react';
@@ -203,6 +204,47 @@ const styles = stylex.create({
   // Popover container (for anchor positioning)
   popover: {
     minWidth: 'anchor-size(width)',
+  },
+  popoverWithSearch: {
+    minWidth: 'anchor-size(width)',
+    marginBlockStart: spacingVars['--spacing-1'],
+  },
+
+  // Search input
+  searchWrapper: {
+    paddingInline: spacingVars['--spacing-2'],
+    paddingBlock: spacingVars['--spacing-1'],
+  },
+  searchInput: {
+    boxSizing: 'border-box',
+    width: '100%',
+    paddingBlock: spacingVars['--spacing-1'],
+    paddingInline: spacingVars['--spacing-2'],
+    borderWidth: borderVars['--border-width'],
+    borderStyle: 'solid',
+    borderColor: colorVars['--color-border-emphasized'],
+    borderRadius: radiusVars['--radius-element'],
+    backgroundColor: colorVars['--color-background-surface'],
+    fontFamily: typographyVars['--font-family-body'],
+    fontSize: {
+      default: typeScaleVars['--text-label-size'],
+      '@media (pointer: coarse)': `max(1rem, ${typeScaleVars['--text-label-size']})`,
+    },
+    color: colorVars['--color-text-primary'],
+    outline: {
+      default: 'none',
+      ':focus': `${borderVars['--border-width']} solid ${colorVars['--color-accent']}`,
+    },
+    outlineOffset: '0',
+  },
+
+  // Empty state
+  emptyState: {
+    padding: spacingVars['--spacing-3'],
+    textAlign: 'center',
+    color: colorVars['--color-text-secondary'],
+    fontFamily: typographyVars['--font-family-body'],
+    fontSize: typeScaleVars['--text-label-size'],
   },
 
   // Section divider with label
@@ -400,6 +442,18 @@ interface XDSSelectorPropsBase<
   children?: (option: XDSSelectorOptionData) => ReactNode;
 
   /**
+   * Whether to show a search input for filtering options.
+   * @default false
+   */
+  hasSearch?: boolean;
+
+  /**
+   * Placeholder text for the search input.
+   * @default 'Search...'
+   */
+  searchPlaceholder?: string;
+
+  /**
    * Whether the dropdown starts open on mount.
    * Useful for showcases and previews.
    * @default false
@@ -490,6 +544,8 @@ export function XDSSelector<T extends XDSSelectorOptionType>(
     status,
     labelTooltip,
     children,
+    hasSearch = false,
+    searchPlaceholder = 'Search...',
     isDefaultOpen = false,
     'data-testid': testId,
     xstyle,
@@ -507,7 +563,11 @@ export function XDSSelector<T extends XDSSelectorOptionType>(
   const listboxId = useId();
   const descriptionId = useId();
   const statusMessageId = useId();
+  const searchId = useId();
   const triggerRef = useRef<HTMLButtonElement>(null);
+  const searchRef = useRef<HTMLInputElement>(null);
+
+  const [searchQuery, setSearchQuery] = useState('');
 
   const [, startTransition] = useTransition();
   const [optimisticValue, setOptimisticValue] = useOptimistic(normalizedValue);
@@ -528,6 +588,15 @@ export function XDSSelector<T extends XDSSelectorOptionType>(
     [options],
   );
 
+  // Filter items by search query
+  const filteredItems = useMemo(() => {
+    if (!searchQuery) return selectableItems;
+    const query = searchQuery.toLowerCase();
+    return selectableItems.filter(item =>
+      (item.label ?? item.value).toLowerCase().includes(query),
+    );
+  }, [selectableItems, searchQuery]);
+
   // Find selected item and its index for positioning
   const selectedItemIndex = useMemo(() => {
     return selectableItems.findIndex(item => item.value === optimisticValue);
@@ -544,6 +613,7 @@ export function XDSSelector<T extends XDSSelectorOptionType>(
 
   // Layer for dropdown positioning
   const handleLayerHide = useCallback(() => {
+    setSearchQuery('');
     triggerRef.current?.focus();
   }, []);
 
@@ -562,13 +632,18 @@ export function XDSSelector<T extends XDSSelectorOptionType>(
   }, []);
 
   // Calculate offset to position selected item over trigger
-  const {offset: selectedItemOffset, isPositioned} = useSelectedItemOffset({
-    isOpen: popover.isOpen,
-    selectedItemIndex,
-    listboxId,
-    listboxRef,
-    triggerRef,
-  });
+  const {offset: rawOffset, isPositioned: rawIsPositioned} =
+    useSelectedItemOffset({
+      isOpen: popover.isOpen,
+      selectedItemIndex,
+      listboxId,
+      listboxRef,
+      triggerRef,
+    });
+
+  // Disable macOS overlay positioning when search is active
+  const selectedItemOffset = hasSearch ? 0 : rawOffset;
+  const isPositioned = hasSearch ? true : rawIsPositioned;
 
   // Selector behavior (keyboard nav, typeahead, selection)
   const {
@@ -580,11 +655,19 @@ export function XDSSelector<T extends XDSSelectorOptionType>(
     onItemSelect,
     onItemMouseEnter,
   } = useCombobox({
-    selectableItems,
+    selectableItems: filteredItems,
     value: normalizedValue,
     isDisabled,
     isOpen: popover.isOpen,
-    onOpen: popover.show,
+    hasSearch,
+    onOpen: useCallback(() => {
+      popover.show();
+      if (hasSearch) {
+        requestAnimationFrame(() => {
+          searchRef.current?.focus();
+        });
+      }
+    }, [popover, hasSearch]),
     onClose: popover.hide,
     onSelect: useCallback(
       (newValue: string) => {
@@ -617,6 +700,44 @@ export function XDSSelector<T extends XDSSelectorOptionType>(
     },
     [onChange, changeAction, startTransition, setOptimisticValue],
   );
+
+  // Render search input
+  const renderSearch = useCallback(() => {
+    if (!hasSearch) return null;
+    return (
+      <div {...stylex.props(styles.searchWrapper)}>
+        <input
+          ref={searchRef}
+          id={searchId}
+          role="searchbox"
+          aria-controls={listboxId}
+          aria-label="Search options"
+          type="text"
+          value={searchQuery}
+          onChange={e => setSearchQuery(e.target.value)}
+          onKeyDown={e => {
+            if (
+              e.key === 'ArrowDown' ||
+              e.key === 'ArrowUp' ||
+              e.key === 'Escape' ||
+              e.key === 'Tab'
+            ) {
+              onKeyDown(e);
+            }
+          }}
+          placeholder={searchPlaceholder}
+          {...stylex.props(styles.searchInput)}
+        />
+      </div>
+    );
+  }, [
+    hasSearch,
+    searchId,
+    listboxId,
+    searchQuery,
+    searchPlaceholder,
+    onKeyDown,
+  ]);
 
   // Render an individual item
   const renderItem = useCallback(
@@ -660,6 +781,18 @@ export function XDSSelector<T extends XDSSelectorOptionType>(
 
   // Render all options (handling sections/dividers)
   const renderOptions = useCallback(() => {
+    // When search is active, render filtered items flat (no sections/dividers)
+    if (hasSearch && searchQuery) {
+      if (filteredItems.length === 0) {
+        return [
+          <div key="empty" {...stylex.props(styles.emptyState)}>
+            No results found
+          </div>,
+        ];
+      }
+      return filteredItems.map((item, index) => renderItem(item, index));
+    }
+
     let flatIndex = 0;
     const elements: ReactNode[] = [];
 
@@ -676,7 +809,6 @@ export function XDSSelector<T extends XDSSelectorOptionType>(
           sectionItems.push(renderItem(normalizeOption(opt), flatIndex));
           flatIndex++;
         }
-        // Render divider with label before the group
         if (option.title) {
           elements.push(
             <XDSDivider
@@ -698,7 +830,7 @@ export function XDSSelector<T extends XDSSelectorOptionType>(
     }
 
     return elements;
-  }, [options, renderItem, listboxId]);
+  }, [options, renderItem, listboxId, hasSearch, searchQuery, filteredItems]);
 
   return (
     <XDSField
@@ -796,22 +928,37 @@ export function XDSSelector<T extends XDSSelectorOptionType>(
       </div>
 
       {popover.render(
-        <div
-          ref={listboxRef}
-          id={listboxId}
-          role="listbox"
-          aria-labelledby={triggerId}
-          {...stylex.props(
-            styles.dropdown,
-            !isPositioned && styles.dropdownHidden,
-            styles.dropdownOffset(-selectedItemOffset),
-          )}>
-          {renderOptions()}
-        </div>,
+        hasSearch ? (
+          <div {...stylex.props(styles.dropdown)}>
+            {renderSearch()}
+            <div
+              ref={listboxRef}
+              id={listboxId}
+              role="listbox"
+              aria-labelledby={triggerId}>
+              {renderOptions()}
+            </div>
+          </div>
+        ) : (
+          <div
+            ref={listboxRef}
+            id={listboxId}
+            role="listbox"
+            aria-labelledby={triggerId}
+            {...stylex.props(
+              styles.dropdown,
+              !isPositioned && styles.dropdownHidden,
+              styles.dropdownOffset(-selectedItemOffset),
+            )}>
+            {renderOptions()}
+          </div>
+        ),
         {
           placement: 'below',
           alignment: 'start',
-          xstyle: [styles.popover, layerAnimations.below],
+          xstyle: hasSearch
+            ? styles.popoverWithSearch
+            : [styles.popover, layerAnimations.below],
         },
       )}
     </XDSField>

--- a/packages/core/src/Selector/XDSSelector.tsx
+++ b/packages/core/src/Selector/XDSSelector.tsx
@@ -205,11 +205,6 @@ const styles = stylex.create({
   popover: {
     minWidth: 'anchor-size(width)',
   },
-  popoverWithSearch: {
-    minWidth: 'anchor-size(width)',
-    marginBlockStart: spacingVars['--spacing-1'],
-  },
-
   // Search input
   searchWrapper: {
     paddingInline: spacingVars['--spacing-2'],
@@ -929,13 +924,14 @@ export function XDSSelector<T extends XDSSelectorOptionType>(
 
       {popover.render(
         hasSearch ? (
-          <div {...stylex.props(styles.dropdown)}>
+          <div>
             {renderSearch()}
             <div
               ref={listboxRef}
               id={listboxId}
               role="listbox"
-              aria-labelledby={triggerId}>
+              aria-labelledby={triggerId}
+              {...stylex.props(styles.dropdown)}>
               {renderOptions()}
             </div>
           </div>
@@ -956,9 +952,7 @@ export function XDSSelector<T extends XDSSelectorOptionType>(
         {
           placement: 'below',
           alignment: 'start',
-          xstyle: hasSearch
-            ? styles.popoverWithSearch
-            : [styles.popover, layerAnimations.below],
+          xstyle: [styles.popover, layerAnimations.below],
         },
       )}
     </XDSField>

--- a/packages/core/src/Selector/hooks.ts
+++ b/packages/core/src/Selector/hooks.ts
@@ -131,6 +131,7 @@ interface UseComboboxOptions {
   value?: string;
   isDisabled?: boolean;
   isOpen: boolean;
+  hasSearch?: boolean;
   onOpen: () => void;
   onClose: () => void;
   onSelect?: (value: string) => void;
@@ -155,6 +156,7 @@ export function useCombobox({
   value,
   isDisabled = false,
   isOpen,
+  hasSearch = false,
   onOpen,
   onClose,
   onSelect,
@@ -201,10 +203,12 @@ export function useCombobox({
       closeAndReset();
     } else {
       onOpen();
-      const selectedIndex = findSelectedIndex();
-      setHighlightedIndex(selectedIndex >= 0 ? selectedIndex : 0);
+      if (!hasSearch) {
+        const selectedIndex = findSelectedIndex();
+        setHighlightedIndex(selectedIndex >= 0 ? selectedIndex : 0);
+      }
     }
-  }, [isDisabled, isOpen, onOpen, closeAndReset, findSelectedIndex]);
+  }, [isDisabled, isOpen, onOpen, closeAndReset, findSelectedIndex, hasSearch]);
 
   const onItemMouseEnter = useCallback(
     (item: XDSSelectorOptionData, index: number) => {
@@ -251,6 +255,9 @@ export function useCombobox({
 
         case 'Enter':
         case ' ':
+          if (e.key === ' ' && hasSearch) {
+            break;
+          }
           e.preventDefault();
           if (isOpen && highlightedIndex >= 0) {
             const item = selectableItems[highlightedIndex];
@@ -259,14 +266,22 @@ export function useCombobox({
             }
           } else if (!isOpen) {
             onOpen();
-            const selectedIndex = findSelectedIndex();
-            setHighlightedIndex(selectedIndex >= 0 ? selectedIndex : 0);
+            if (!hasSearch) {
+              const selectedIndex = findSelectedIndex();
+              setHighlightedIndex(selectedIndex >= 0 ? selectedIndex : 0);
+            }
           }
           break;
 
         case 'Escape':
           if (isOpen) {
             e.preventDefault();
+            closeAndReset();
+          }
+          break;
+
+        case 'Tab':
+          if (isOpen) {
             closeAndReset();
           }
           break;
@@ -286,7 +301,7 @@ export function useCombobox({
           break;
 
         default:
-          if (e.key.length === 1 && !e.ctrlKey && !e.metaKey) {
+          if (!hasSearch && e.key.length === 1 && !e.ctrlKey && !e.metaKey) {
             const newTypeahead = typeahead + e.key.toLowerCase();
             setTypeahead(newTypeahead);
 
@@ -323,6 +338,7 @@ export function useCombobox({
       findSelectedIndex,
       getEnabledIndices,
       typeahead,
+      hasSearch,
     ],
   );
 

--- a/packages/core/src/Selector/hooks.ts
+++ b/packages/core/src/Selector/hooks.ts
@@ -253,11 +253,12 @@ export function useCombobox({
           }
           break;
 
-        case 'Enter':
         case ' ':
-          if (e.key === ' ' && hasSearch) {
+          if (hasSearch) {
             break;
           }
+        // falls through
+        case 'Enter':
           e.preventDefault();
           if (isOpen && highlightedIndex >= 0) {
             const item = selectableItems[highlightedIndex];


### PR DESCRIPTION
 ## Summary
  - Add `hasSearch` and `searchPlaceholder` props to `XDSSelector`                                                                         
  - Matching the existing filtering behavior in `XDSMultiSelector`
  - Search input renders above the listbox, filters options by case-insensitive substring match
  - Shows "No results found" empty state when no options match                                                                             
                                                                                                                                           
  Closes #2131                                                                                                                             
                                                                                                                                           
  ## Test plan         
  - [x] Unit tests added for search rendering, filtering, empty state, selection, and custom placeholder
  - [x] Verified in Storybook and sandbox app                                                           
  - [x] Existing Selector tests pass (no regression)                                                                                       
  - [x] MultiSelector tests pass (no regression) 