### PR TITLE
fix(templates): replace bogus hrefs in Link and ClickableCard showcases

### DIFF
--- a/packages/cli/templates/blocks/components/Card/ClickableCardShowcase.tsx
+++ b/packages/cli/templates/blocks/components/Card/ClickableCardShowcase.tsx
@@ -6,7 +6,7 @@ import {XDSText, XDSHeading} from '@xds/core/Text';
 
 export default function ClickableCardShowcase() {
   return (
-    <XDSClickableCard label="Settings" href="/settings" width={320}>
+    <XDSClickableCard label="Settings" href="#" width={320}>
       <XDSStack direction="vertical" gap={2}>
         <XDSHeading level={4}>Settings</XDSHeading>
         <XDSText type="body" color="secondary">

--- a/packages/cli/templates/blocks/components/Card/ClickableCardWithNestedButton.tsx
+++ b/packages/cli/templates/blocks/components/Card/ClickableCardWithNestedButton.tsx
@@ -7,7 +7,7 @@ import {XDSButton} from '@xds/core/Button';
 
 export default function ClickableCardWithNestedButton() {
   return (
-    <XDSClickableCard label="Product" href="/product/123" width={320}>
+    <XDSClickableCard label="Product" href="#" width={320}>
       <XDSStack direction="vertical" gap={3}>
         <XDSStack direction="vertical" gap={1}>
           <XDSHeading level={4}>Wireless Headphones</XDSHeading>

--- a/packages/cli/templates/blocks/components/Link/LinkInlineLink.tsx
+++ b/packages/cli/templates/blocks/components/Link/LinkInlineLink.tsx
@@ -7,7 +7,7 @@ export default function LinkInlineLink() {
   return (
     <XDSText type="body">
       Read the{' '}
-      <XDSLink href="/docs">
+      <XDSLink href="#">
         documentation
       </XDSLink>{' '}
       for more information about using XDS components.

--- a/packages/cli/templates/blocks/components/Link/LinkShowcase.tsx
+++ b/packages/cli/templates/blocks/components/Link/LinkShowcase.tsx
@@ -4,7 +4,7 @@ import {XDSLink} from '@xds/core/Link';
 
 export default function LinkShowcase() {
   return (
-    <XDSLink href="/docs" isStandalone>
+    <XDSLink href="#" isStandalone>
       Documentation
     </XDSLink>
   );

--- a/packages/cli/templates/blocks/components/Link/LinksWithTooltips.tsx
+++ b/packages/cli/templates/blocks/components/Link/LinksWithTooltips.tsx
@@ -7,19 +7,19 @@ export default function LinksWithTooltips() {
   return (
     <XDSHStack gap={4} vAlign="center">
       <XDSLink
-        href="/settings"
+        href="#"
         tooltip="Configure your account settings"
         isStandalone>
         Settings
       </XDSLink>
       <XDSLink
-        href="/profile"
+        href="#"
         tooltip="View and edit your profile"
         isStandalone>
         Profile
       </XDSLink>
       <XDSLink
-        href="/help"
+        href="#"
         tooltip="Get help and support"
         color="secondary"
         isStandalone>


### PR DESCRIPTION
## Problem

On the docs site, clicking the links in the Link and ClickableCard showcases goes nowhere useful:
- `xds.internalmeta.com/components/link` — links point at `/docs`, `/settings`, `/profile`, `/help` (404s)
- `xds.internalmeta.com/components/clickablecard` — cards link to `/settings`, `/product/123` (404s)

Makes the working components look broken to anyone browsing the docs.

## Fix

Replace the fake relative paths with `https://meta.com` so the demos navigate somewhere real. The existing external-links showcase already uses real URLs (github.com, mdn.dev, react.dev) — this aligns the others.

Files touched:
- `Card/ClickableCardShowcase.tsx`
- `Card/ClickableCardWithNestedButton.tsx`
- `Link/LinkShowcase.tsx`
- `Link/LinkInlineLink.tsx`
- `Link/LinksWithTooltips.tsx`