### PR TITLE
fix: unhide table-grouped and table-page templates on Craft

### DIFF
--- a/packages/cli/templates/pages/table-grouped/template.doc.mjs
+++ b/packages/cli/templates/pages/table-grouped/template.doc.mjs
@@ -3,5 +3,5 @@ export const doc = {
   type: 'page',
   name: 'Table (Grouped)',
   description: 'Grouped data table with collapsible status sections, PowerSearch, and detail panel',
-  isReady: false,
+  isReady: true,
 };

--- a/packages/cli/templates/pages/table-page/template.doc.mjs
+++ b/packages/cli/templates/pages/table-page/template.doc.mjs
@@ -4,5 +4,5 @@ export const doc = {
   name: 'Table Page',
   description:
     'Data table page with power search filtering and action toolbar.',
-  isReady: false,
+  isReady: true,
 };


### PR DESCRIPTION
Only the `table` template should be hidden — `table-grouped` and `table-page` were accidentally hidden along with it.