### PR TITLE
fix(sandbox): apply theme selector to template iframe content

### DIFF
--- a/apps/sandbox/src/app/(fullscreen)/PreviewShell.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/PreviewShell.tsx
@@ -635,12 +635,12 @@ export function PreviewShell({children}: {children: React.ReactNode}) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
 
   // Iframe src includes current theme/mode so the embedded page renders correctly
-  // on initial load. We key the iframe on pathname so it only reloads on navigation.
+  // on initial load. Only recomputes when pathname changes — theme/mode changes
+  // are synced to the iframe via postMessage to avoid triggering a reload.
   const iframeSrc = useMemo(
     () =>
       `${basePath}${pathname}?embed=1&theme=${themeName}&mode=${mode}`,
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [pathname],
+    [pathname], // intentionally excludes themeName/mode — live updates use postMessage
   );
 
   // Broadcast theme/mode changes to the embedded iframe via postMessage

--- a/apps/sandbox/src/app/(fullscreen)/PreviewShell.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/PreviewShell.tsx
@@ -632,6 +632,26 @@ export function PreviewShell({children}: {children: React.ReactNode}) {
   const {themeName, setThemeName, mode, setMode} = useThemeControls();
   const [toolbarHidden, setToolbarHidden] = useState(false);
   const [sidebarOpen, setSidebarOpen] = useState(false);
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+
+  // Iframe src includes current theme/mode so the embedded page renders correctly
+  // on initial load. We key the iframe on pathname so it only reloads on navigation.
+  const iframeSrc = useMemo(
+    () =>
+      `${basePath}${pathname}?embed=1&theme=${themeName}&mode=${mode}`,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [pathname],
+  );
+
+  // Broadcast theme/mode changes to the embedded iframe via postMessage
+  useEffect(() => {
+    const iframe = iframeRef.current;
+    if (!iframe?.contentWindow) return;
+    iframe.contentWindow.postMessage(
+      {type: 'xds-theme-sync', theme: themeName, mode},
+      '*',
+    );
+  }, [themeName, mode]);
 
   const navTree = useMemo(() => buildNavTree(pathname), [pathname]);
 
@@ -921,7 +941,8 @@ export function PreviewShell({children}: {children: React.ReactNode}) {
                 overflow: 'hidden',
               }}>
               <iframe
-                src={`${basePath}${pathname}?embed=1`}
+                ref={iframeRef}
+                src={iframeSrc}
                 title={`${pageName} — ${viewport}`}
                 style={{
                   width: '100%',
@@ -941,7 +962,8 @@ export function PreviewShell({children}: {children: React.ReactNode}) {
                 backgroundColor: '#f0f0f0',
               }}>
               <iframe
-                src={`${basePath}${pathname}?embed=1`}
+                ref={iframeRef}
+                src={iframeSrc}
                 title={`${pageName} — ${viewport}`}
                 style={{
                   width: viewportWidths[viewport],

--- a/apps/sandbox/src/app/providers.tsx
+++ b/apps/sandbox/src/app/providers.tsx
@@ -42,9 +42,53 @@ const ThemeContext = createContext<ThemeContextValue>({
 
 export const useThemeControls = () => useContext(ThemeContext);
 
+/**
+ * Reads theme/mode from URL search params when rendered inside an embed iframe.
+ * Uses window.location directly to avoid requiring a Suspense boundary for
+ * useSearchParams in the root Providers component.
+ */
+function getEmbedThemeParams(): {
+  initialTheme: string;
+  initialMode: ThemeMode;
+  isEmbed: boolean;
+} {
+  if (typeof window === 'undefined') {
+    return {initialTheme: 'default', initialMode: 'light', isEmbed: false};
+  }
+  const params = new URLSearchParams(window.location.search);
+  const isEmbed = params.get('embed') === '1';
+  const paramTheme = params.get('theme');
+  const paramMode = params.get('mode');
+
+  return {
+    initialTheme:
+      isEmbed && paramTheme && paramTheme in themes ? paramTheme : 'default',
+    initialMode:
+      isEmbed && (paramMode === 'light' || paramMode === 'dark')
+        ? (paramMode as ThemeMode)
+        : 'light',
+    isEmbed,
+  };
+}
+
 export function Providers({children}: {children: React.ReactNode}) {
-  const [themeName, setThemeName] = useState('default');
-  const [mode, setMode] = useState<ThemeMode>('light');
+  const {initialTheme, initialMode, isEmbed} = getEmbedThemeParams();
+  const [themeName, setThemeName] = useState(initialTheme);
+  const [mode, setMode] = useState<ThemeMode>(initialMode);
+
+  // When embedded, sync theme/mode from parent shell via postMessage
+  useEffect(() => {
+    if (!isEmbed) return;
+    const handler = (event: MessageEvent) => {
+      if (event.data?.type === 'xds-theme-sync') {
+        const {theme: newTheme, mode: newMode} = event.data;
+        if (newTheme && newTheme in themes) setThemeName(newTheme);
+        if (newMode === 'light' || newMode === 'dark') setMode(newMode);
+      }
+    };
+    window.addEventListener('message', handler);
+    return () => window.removeEventListener('message', handler);
+  }, [isEmbed]);
 
   // Sync color-scheme to document root
   useEffect(() => {


### PR DESCRIPTION
## Summary

The PreviewShell theme/mode selector was only applying to the shell toolbar — changing themes had no effect on the template content rendered inside the iframe.

## Changes

**`PreviewShell.tsx`**
- Passes `theme` and `mode` query params to the iframe URL so the embedded page loads with the correct theme on initial render
- Adds a `postMessage` channel (`xds-theme-sync`) to broadcast live theme/mode changes without triggering a full iframe reload
- Uses `useMemo` keyed on `pathname` to keep the iframe `src` stable during theme switches

**`providers.tsx`**
- Reads `theme` and `mode` from URL search params when rendered in embed mode (`?embed=1`)
- Listens for `xds-theme-sync` postMessage events to apply theme changes from the parent shell in real-time
- Uses `window.location` directly (no `useSearchParams`) to avoid requiring a Suspense boundary at the root

## How it works

1. **Initial load:** iframe URL contains `?embed=1&theme=brutalist&mode=dark` → Providers reads params → correct theme from first paint
2. **Live changes:** User switches theme in toolbar → shell posts `{type: 'xds-theme-sync', theme, mode}` → iframe Providers updates state → instant theme swap, no reload