### PR TITLE
fix(storybook): use default theme so stories render correct fonts

### DIFF
--- a/apps/storybook/.storybook/preview.tsx
+++ b/apps/storybook/.storybook/preview.tsx
@@ -109,7 +109,7 @@ const preview: Preview = {
     },
   },
   initialGlobals: {
-    xdsTheme: 'none',
+    xdsTheme: 'default',
     colorMode: 'light',
   },
   decorators: [withXDSTheme],


### PR DESCRIPTION
Stories in Storybook were rendering with the browser's default serif font because `initialGlobals.xdsTheme` was set to `'none'`. The `'none'` path bypasses `XDSTheme` entirely, so nothing sets `font-family` — the browser falls back to Times New Roman.

Switching to `'default'` ensures all stories load inside `XDSTheme` with the proper sans-serif font stack (`--font-family-body`).

**Before:** Serif text in all story examples
**After:** Correct system sans-serif fonts