### PR TITLE
fix(sandbox): persist theme/mode across navigation + ghost copy button in templates table

### DIFF
--- a/apps/sandbox/src/app/(sandbox)/templates/page.tsx
+++ b/apps/sandbox/src/app/(sandbox)/templates/page.tsx
@@ -20,6 +20,8 @@ import {usePowerSearchConfig} from '@xds/core/PowerSearch';
 import type {PowerSearchFilter} from '@xds/core/PowerSearch';
 import {XDSLink} from '@xds/core/Link';
 import {XDSBadge} from '@xds/core/Badge';
+import {XDSButton} from '@xds/core/Button';
+import {CopyIcon} from '../../icons';
 import {templates} from '../../../generated/templateRegistry';
 import {blocks} from '../../../generated/blockRegistry';
 
@@ -147,13 +149,17 @@ function useTableSearchParams() {
   return {sort, onSortChange, filters, onFilterChange};
 }
 
-function CopyPath({path}: {path: string}) {
+function CopyPath({path, label}: {path: string; label: string}) {
   return (
-    <XDSLink
-      onClick={() => navigator.clipboard.writeText(path)}
-      style={{cursor: 'pointer'}}>
-      Copy Path
-    </XDSLink>
+    <XDSButton
+      label={label}
+      icon={<CopyIcon />}
+      variant="ghost"
+      size="sm"
+      isIconOnly
+      tooltip={label}
+      clickAction={() => navigator.clipboard.writeText(path)}
+    />
   );
 }
 
@@ -234,14 +240,18 @@ const columns: XDSTableColumn<TemplateRow>[] = [
   {
     key: 'codePath',
     header: 'Code',
-    width: pixel(50),
-    renderCell: (row: TemplateRow) => <CopyPath path={row.codePath} />,
+    width: pixel(60),
+    renderCell: (row: TemplateRow) => (
+      <CopyPath path={row.codePath} label="Copy code path" />
+    ),
   },
   {
     key: 'docPath',
     header: 'Doc',
-    width: pixel(50),
-    renderCell: (row: TemplateRow) => <CopyPath path={row.docPath} />,
+    width: pixel(60),
+    renderCell: (row: TemplateRow) => (
+      <CopyPath path={row.docPath} label="Copy doc path" />
+    ),
   },
 ];
 

--- a/apps/sandbox/src/app/providers.tsx
+++ b/apps/sandbox/src/app/providers.tsx
@@ -42,10 +42,17 @@ const ThemeContext = createContext<ThemeContextValue>({
 
 export const useThemeControls = () => useContext(ThemeContext);
 
+const THEME_STORAGE_KEY = 'xds-sandbox-theme';
+const MODE_STORAGE_KEY = 'xds-sandbox-mode';
+
 /**
  * Reads theme/mode from URL search params when rendered inside an embed iframe.
  * Uses window.location directly to avoid requiring a Suspense boundary for
  * useSearchParams in the root Providers component.
+ *
+ * For non-embed contexts, localStorage hydration is handled via useEffect in
+ * Providers so the initial server render matches the client (avoiding hydration
+ * mismatches on Next.js SSR).
  */
 function getEmbedThemeParams(): {
   initialTheme: string;
@@ -75,6 +82,49 @@ export function Providers({children}: {children: React.ReactNode}) {
   const {initialTheme, initialMode, isEmbed} = getEmbedThemeParams();
   const [themeName, setThemeName] = useState(initialTheme);
   const [mode, setMode] = useState<ThemeMode>(initialMode);
+  const [hasHydrated, setHasHydrated] = useState(false);
+
+  // Hydrate theme/mode from localStorage after mount (non-embed only).
+  // Doing this in useEffect ensures server and initial client render match —
+  // we start with defaults on both, then sync to the stored preference.
+  useEffect(() => {
+    if (isEmbed) {
+      setHasHydrated(true);
+      return;
+    }
+    try {
+      const storedTheme = window.localStorage.getItem(THEME_STORAGE_KEY);
+      const storedMode = window.localStorage.getItem(MODE_STORAGE_KEY);
+      if (storedTheme && storedTheme in themes) setThemeName(storedTheme);
+      if (storedMode === 'light' || storedMode === 'dark') {
+        setMode(storedMode as ThemeMode);
+      }
+    } catch {
+      // localStorage can throw in private mode / sandboxed iframes
+    }
+    setHasHydrated(true);
+  }, [isEmbed]);
+
+  // Persist theme/mode to localStorage so selection survives navigation.
+  // Skip writes until after hydration to avoid overwriting stored values on
+  // first render, and skip entirely when embedded (parent controls theme).
+  useEffect(() => {
+    if (isEmbed || !hasHydrated) return;
+    try {
+      window.localStorage.setItem(THEME_STORAGE_KEY, themeName);
+    } catch {
+      // ignore
+    }
+  }, [themeName, isEmbed, hasHydrated]);
+
+  useEffect(() => {
+    if (isEmbed || !hasHydrated) return;
+    try {
+      window.localStorage.setItem(MODE_STORAGE_KEY, mode);
+    } catch {
+      // ignore
+    }
+  }, [mode, isEmbed, hasHydrated]);
 
   // When embedded, sync theme/mode from parent shell via postMessage
   useEffect(() => {


### PR DESCRIPTION
## Problem

Two UX issues in the sandbox:

1. **Theme + mode selection didn't persist.** Picking a theme (e.g. Gothic + dark) got reset back to default + light every time you navigated between route groups (home → templates → components) or reloaded the page.
2. **Templates table "Copy Path" link wrapped to two lines** in the Code and Doc columns, making every row taller than needed.

## Fix

**Theme persistence (`providers.tsx`)**
- Added `localStorage`-backed persistence for `themeName` and `mode`.
- Hydration runs in a `useEffect` after mount so server and initial client render match (avoids Next.js hydration mismatch — initial render uses `default`/`light`, then syncs to stored value).
- Embed iframes (`?embed=1`) stay controlled by their parent via URL params + `postMessage`, unchanged.
- A `hasHydrated` guard prevents the persist-on-change effects from overwriting stored values on first render.

**Templates table (`templates/page.tsx`)**
- Replaced the text "Copy Path" link with a ghost `XDSButton` + `CopyIcon`, `isIconOnly`, and a tooltip ("Copy code path" / "Copy doc path").
- Bumped Code/Doc column widths 50 → 60px so the button sits comfortably.

## Verification

Playwright end-to-end: opened sandbox, clicked theme picker → Gothic, clicked mode toggle, navigated to `/templates/`, reloaded. Theme + mode persisted through both navigation and full reload.
