### PR TITLE
fix(Field): use neutral gray for hover shadow, apply focus border on input

### DIFF
--- a/packages/cli/docs/tokens.doc.mjs
+++ b/packages/cli/docs/tokens.doc.mjs
@@ -625,7 +625,7 @@ export const docs = {
             ],
             [
               "--shadow-inset-hover",
-              "inset 0px 0px 0px 2px rgba(1, 113, 227, 0.3)"
+              "inset 0px 0px 0px 2px light-dark(rgba(5, 54, 89, 0.15), rgba(223, 226, 229, 0.2))"
             ],
             [
               "--shadow-inset-selected",

--- a/packages/core/src/Field/inputStyles.stylex.ts
+++ b/packages/core/src/Field/inputStyles.stylex.ts
@@ -44,6 +44,7 @@ export const inputWrapperStyles = stylex.create({
       ':hover': {
         '@media (hover: hover)': colorVars['--color-border-emphasized'],
       },
+      ':focus-within': colorVars['--color-accent'],
     },
     '--_field-radius': radiusVars['--radius-element'],
     borderRadius: 'var(--_field-radius)',
@@ -59,12 +60,9 @@ export const inputWrapperStyles = stylex.create({
       ':hover': {
         '@media (hover: hover)': shadowVars['--shadow-inset-hover'],
       },
+      ':focus-within': shadowVars['--shadow-inset-selected'],
     },
-    outline: {
-      default: 'none',
-      ':focus-within': `${borderVars['--border-width']} solid ${colorVars['--color-accent']}`,
-    },
-    outlineOffset: '0',
+    outline: 'none',
   },
   disabled: {
     cursor: 'not-allowed',
@@ -121,53 +119,53 @@ export const inputStatusHoverShadowStyles = stylex.create({
 });
 
 /**
- * Status focus outline styles using :focus-within.
+ * Status focus border styles using :focus-within.
  * Used by input wrappers that contain a child input/textarea element.
  * Keyed by XDSInputStatusType.
  */
 export const inputStatusFocusWithinStyles = stylex.create({
   warning: {
-    outline: {
-      default: 'none',
-      ':focus-within': `${borderVars['--border-width']} solid ${colorVars['--color-warning']}`,
+    borderColor: {
+      default: colorVars['--color-warning'],
+      ':focus-within': colorVars['--color-warning'],
     },
   },
   error: {
-    outline: {
-      default: 'none',
-      ':focus-within': `${borderVars['--border-width']} solid ${colorVars['--color-error']}`,
+    borderColor: {
+      default: colorVars['--color-error'],
+      ':focus-within': colorVars['--color-error'],
     },
   },
   success: {
-    outline: {
-      default: 'none',
-      ':focus-within': `${borderVars['--border-width']} solid ${colorVars['--color-success']}`,
+    borderColor: {
+      default: colorVars['--color-success'],
+      ':focus-within': colorVars['--color-success'],
     },
   },
 });
 
 /**
- * Status focus outline styles using :focus.
+ * Status focus border styles using :focus.
  * Used by components where the wrapper itself receives focus (e.g. Selector button).
  * Keyed by XDSInputStatusType.
  */
 export const inputStatusFocusStyles = stylex.create({
   warning: {
-    outline: {
-      default: 'none',
-      ':focus': `${borderVars['--border-width']} solid ${colorVars['--color-warning']}`,
+    borderColor: {
+      default: colorVars['--color-warning'],
+      ':focus': colorVars['--color-warning'],
     },
   },
   error: {
-    outline: {
-      default: 'none',
-      ':focus': `${borderVars['--border-width']} solid ${colorVars['--color-error']}`,
+    borderColor: {
+      default: colorVars['--color-error'],
+      ':focus': colorVars['--color-error'],
     },
   },
   success: {
-    outline: {
-      default: 'none',
-      ':focus': `${borderVars['--border-width']} solid ${colorVars['--color-success']}`,
+    borderColor: {
+      default: colorVars['--color-success'],
+      ':focus': colorVars['--color-success'],
     },
   },
 });

--- a/packages/core/src/Field/inputStyles.stylex.ts
+++ b/packages/core/src/Field/inputStyles.stylex.ts
@@ -41,9 +41,6 @@ export const inputWrapperStyles = stylex.create({
     borderStyle: 'solid',
     borderColor: {
       default: colorVars['--color-border-emphasized'],
-      ':hover': {
-        '@media (hover: hover)': colorVars['--color-border-emphasized'],
-      },
       ':focus-within': colorVars['--color-accent'],
     },
     '--_field-radius': radiusVars['--radius-element'],
@@ -57,7 +54,7 @@ export const inputWrapperStyles = stylex.create({
     transitionTimingFunction: easeVars['--ease-standard'],
     boxShadow: {
       default: 'none',
-      ':hover': {
+      ':hover:not(:focus-within)': {
         '@media (hover: hover)': shadowVars['--shadow-inset-hover'],
       },
       ':focus-within': shadowVars['--shadow-inset-selected'],
@@ -95,7 +92,7 @@ export const inputStatusHoverShadowStyles = stylex.create({
   warning: {
     boxShadow: {
       default: 'none',
-      ':hover': {
+      ':hover:not(:focus-within)': {
         '@media (hover: hover)': shadowVars['--shadow-inset-warning'],
       },
     },
@@ -103,7 +100,7 @@ export const inputStatusHoverShadowStyles = stylex.create({
   error: {
     boxShadow: {
       default: 'none',
-      ':hover': {
+      ':hover:not(:focus-within)': {
         '@media (hover: hover)': shadowVars['--shadow-inset-error'],
       },
     },
@@ -111,7 +108,7 @@ export const inputStatusHoverShadowStyles = stylex.create({
   success: {
     boxShadow: {
       default: 'none',
-      ':hover': {
+      ':hover:not(:focus-within)': {
         '@media (hover: hover)': shadowVars['--shadow-inset-success'],
       },
     },

--- a/packages/core/src/MultiSelector/XDSMultiSelector.tsx
+++ b/packages/core/src/MultiSelector/XDSMultiSelector.tsx
@@ -86,6 +86,7 @@ const styles = stylex.create({
       ':hover': {
         '@media (hover: hover)': colorVars['--color-border-emphasized'],
       },
+      ':focus-within': colorVars['--color-accent'],
     },
     borderRadius: radiusVars['--radius-element'],
     backgroundColor: colorVars['--color-background-surface'],
@@ -102,12 +103,9 @@ const styles = stylex.create({
       ':hover': {
         '@media (hover: hover)': shadowVars['--shadow-inset-hover'],
       },
+      ':focus-within': shadowVars['--shadow-inset-selected'],
     },
-    outline: {
-      default: 'none',
-      ':focus-within': `${borderVars['--border-width']} solid ${colorVars['--color-accent']}`,
-    },
-    outlineOffset: '0',
+    outline: 'none',
   },
   // Trigger button — the actual combobox button, visually integrated with the container
   trigger: {

--- a/packages/core/src/MultiSelector/XDSMultiSelector.tsx
+++ b/packages/core/src/MultiSelector/XDSMultiSelector.tsx
@@ -83,9 +83,6 @@ const styles = stylex.create({
     borderStyle: 'solid',
     borderColor: {
       default: colorVars['--color-border-emphasized'],
-      ':hover': {
-        '@media (hover: hover)': colorVars['--color-border-emphasized'],
-      },
       ':focus-within': colorVars['--color-accent'],
     },
     borderRadius: radiusVars['--radius-element'],
@@ -100,7 +97,7 @@ const styles = stylex.create({
     transitionTimingFunction: easeVars['--ease-standard'],
     boxShadow: {
       default: 'none',
-      ':hover': {
+      ':hover:not(:focus-within)': {
         '@media (hover: hover)': shadowVars['--shadow-inset-hover'],
       },
       ':focus-within': shadowVars['--shadow-inset-selected'],

--- a/packages/core/src/Selector/XDSSelector.tsx
+++ b/packages/core/src/Selector/XDSSelector.tsx
@@ -76,9 +76,6 @@ const styles = stylex.create({
     borderStyle: 'solid',
     borderColor: {
       default: colorVars['--color-border-emphasized'],
-      ':hover': {
-        '@media (hover: hover)': colorVars['--color-border-emphasized'],
-      },
       ':focus-within': colorVars['--color-accent'],
     },
     borderRadius: radiusVars['--radius-element'],
@@ -96,7 +93,7 @@ const styles = stylex.create({
     transitionTimingFunction: easeVars['--ease-standard'],
     boxShadow: {
       default: 'none',
-      ':hover': {
+      ':hover:not(:focus-within)': {
         '@media (hover: hover)': shadowVars['--shadow-inset-hover'],
       },
       ':focus-within': shadowVars['--shadow-inset-selected'],

--- a/packages/core/src/Selector/XDSSelector.tsx
+++ b/packages/core/src/Selector/XDSSelector.tsx
@@ -79,6 +79,7 @@ const styles = stylex.create({
       ':hover': {
         '@media (hover: hover)': colorVars['--color-border-emphasized'],
       },
+      ':focus-within': colorVars['--color-accent'],
     },
     borderRadius: radiusVars['--radius-element'],
     backgroundColor: colorVars['--color-background-surface'],
@@ -98,12 +99,9 @@ const styles = stylex.create({
       ':hover': {
         '@media (hover: hover)': shadowVars['--shadow-inset-hover'],
       },
+      ':focus-within': shadowVars['--shadow-inset-selected'],
     },
-    outline: {
-      default: 'none',
-      ':focus-within': `${borderVars['--border-width']} solid ${colorVars['--color-accent']}`,
-    },
-    outlineOffset: '0',
+    outline: 'none',
   },
   // Trigger button — the actual combobox button, visually integrated with the container
   trigger: {

--- a/packages/core/src/theme/tokens.stylex.ts
+++ b/packages/core/src/theme/tokens.stylex.ts
@@ -75,43 +75,43 @@ export const colorDefaults = {
 
   // Blue
   '--color-background-blue': 'light-dark(#0171E333, #0171E333)',
-  '--color-border-blue': 'light-dark(#0064E0, #2694FE)',  // Blue 650 / 500
+  '--color-border-blue': 'light-dark(#0064E0, #2694FE)', // Blue 650 / 500
   '--color-icon-blue': 'light-dark(#0064E0, #2694FE)',
   '--color-text-blue': 'light-dark(#042F97, #AFD7FF)',
 
   // Cyan
   '--color-background-cyan': 'light-dark(#03A7D733, #03A7D733)',
-  '--color-border-cyan': 'light-dark(#089DD0, #0171A4)',  // Cyan 500 / 650
+  '--color-border-cyan': 'light-dark(#089DD0, #0171A4)', // Cyan 500 / 650
   '--color-icon-cyan': 'light-dark(#00ACC1, #26C6DA)',
   '--color-text-cyan': 'light-dark(#014975, #A1EEF9)',
 
   // Gray
   '--color-background-gray': 'light-dark(#0A131733, #666A724C)',
-  '--color-border-gray': 'light-dark(#647685, #748695)',  // Gray 600 / 550
+  '--color-border-gray': 'light-dark(#647685, #748695)', // Gray 600 / 550
   '--color-icon-gray': 'light-dark(#4E606F, #AAAFB5)',
   '--color-text-gray': 'light-dark(#0A1317, #E7EAED)',
 
   // Green
   '--color-background-green': 'light-dark(#24BB5E33, #24BB5E33)',
-  '--color-border-green': 'light-dark(#0D8626, #0B991F)',  // Green 600 / 550
+  '--color-border-green': 'light-dark(#0D8626, #0B991F)', // Green 600 / 550
   '--color-icon-green': 'light-dark(#0D8626, #26A756)',
   '--color-text-green': 'light-dark(#09441F, #A5F690)',
 
   // Orange
   '--color-background-orange': 'light-dark(#F2790233, #F2790233)',
-  '--color-border-orange': 'light-dark(#EB6E00, #B34A01)',  // Orange 500 / 650
+  '--color-border-orange': 'light-dark(#EB6E00, #B34A01)', // Orange 500 / 650
   '--color-icon-orange': 'light-dark(#E9690B, #FB8C00)',
   '--color-text-orange': 'light-dark(#6B2203, #FDB876)',
 
   // Pink
   '--color-background-pink': 'light-dark(#E638B333, #E638B333)',
-  '--color-border-pink': 'light-dark(#F351C0, #C02294)',  // Pink 500 / 650
+  '--color-border-pink': 'light-dark(#F351C0, #C02294)', // Pink 500 / 650
   '--color-icon-pink': 'light-dark(#C2185B, #EC407A)',
   '--color-text-pink': 'light-dark(#650053, #FEADE3)',
 
   // Purple
   '--color-background-purple': 'light-dark(#7952FF33, #7952FF33)',
-  '--color-border-purple': 'light-dark(#9081FF, #7340FE)',  // Purple 500 / 650
+  '--color-border-purple': 'light-dark(#9081FF, #7340FE)', // Purple 500 / 650
   '--color-icon-purple': 'light-dark(#5B08D8, #7952FF)',
   '--color-text-purple': 'light-dark(#3E0697, #B3B0FE)',
 
@@ -123,13 +123,13 @@ export const colorDefaults = {
 
   // Teal
   '--color-background-teal': 'light-dark(#0DB7AF33, #0DB7AF33)',
-  '--color-border-teal': 'light-dark(#08A3A3, #08767D)',  // Teal 500 / 650
+  '--color-border-teal': 'light-dark(#08A3A3, #08767D)', // Teal 500 / 650
   '--color-icon-teal': 'light-dark(#009688, #26A69A)',
   '--color-text-teal': 'light-dark(#083943, #40DCCD)',
 
   // Yellow
   '--color-background-yellow': 'light-dark(#E2A40033, #E2A40033)',
-  '--color-border-yellow': 'light-dark(#C58600, #B47700)',  // Yellow 500 / 550
+  '--color-border-yellow': 'light-dark(#C58600, #B47700)', // Yellow 500 / 550
   '--color-icon-yellow': 'light-dark(#FBC02D, #FFEE58)',
   '--color-text-yellow': 'light-dark(#753F07, #FBCE03)',
 
@@ -216,7 +216,8 @@ export const shadowDefaults = {
   '--shadow-high':
     '0px 2px 2px light-dark(rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.2)), 0px 8px 24px light-dark(rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.3))',
   // Inset shadows for input border rings (interaction + validation states)
-  '--shadow-inset-hover': 'inset 0px 0px 0px 2px rgba(1, 113, 227, 0.3)',
+  '--shadow-inset-hover':
+    'inset 0px 0px 0px 2px light-dark(rgba(5, 54, 89, 0.15), rgba(223, 226, 229, 0.2))',
   '--shadow-inset-selected': 'inset 0px 0px 0px 2px rgba(1, 113, 227, 0.5)',
   '--shadow-inset-success': 'inset 0px 0px 0px 2px rgba(38, 167, 86, 0.3)',
   '--shadow-inset-warning': 'inset 0px 0px 0px 2px rgba(226, 164, 0, 0.3)',


### PR DESCRIPTION
## Summary

- **Hover shadow**: Changed `--shadow-inset-hover` token from blue (`rgba(1, 113, 227, 0.3)`) to neutral gray using `light-dark()` — matches the neutral color palette.
- **Focus border**: Replaced `outline` (which rendered outside the input) with `borderColor` on `:focus-within` so the accent color appears on the input's own border.
- Added `--shadow-inset-selected` blue inset ring on `:focus-within` to preserve the blue visual for focus state.
- Updated Selector and MultiSelector components to match the same pattern.
- Updated `inputStatusFocusWithinStyles` and `inputStatusFocusStyles` to use `borderColor` instead of `outline` for consistency.

## Files Changed

- `packages/core/src/theme/tokens.stylex.ts` — hover shadow token
- `packages/core/src/Field/inputStyles.stylex.ts` — shared input wrapper styles
- `packages/core/src/Selector/XDSSelector.tsx` — selector focus/hover
- `packages/core/src/MultiSelector/XDSMultiSelector.tsx` — multi-selector focus/hover