### PR TITLE
feat(ChartV2): support grouped stacked bar charts

### DIFF
--- a/apps/storybook/stories/ChartV2.stories.tsx
+++ b/apps/storybook/stories/ChartV2.stories.tsx
@@ -17,6 +17,15 @@ const monthlyData = [
   {month: 'Jun', revenue: 70, costs: 40, trend: 52},
 ];
 
+const groupedStackData = [
+  {month: 'Jan', revenueA: 30, costsA: 15, revenueB: 25, costsB: 20},
+  {month: 'Feb', revenueA: 35, costsA: 18, revenueB: 28, costsB: 22},
+  {month: 'Mar', revenueA: 28, costsA: 14, revenueB: 32, costsB: 18},
+  {month: 'Apr', revenueA: 42, costsA: 20, revenueB: 35, costsB: 25},
+  {month: 'May', revenueA: 38, costsA: 17, revenueB: 30, costsB: 21},
+  {month: 'Jun', revenueA: 50, costsA: 22, revenueB: 40, costsB: 28},
+];
+
 /** Simple bar chart */
 export const SimpleBar: StoryObj = {
   render: () => (
@@ -67,6 +76,40 @@ export const GroupedBars: StoryObj = {
       series={[
         bar('revenue', {color: '#3b82f6', group: 'compare'}),
         bar('costs', {color: '#ef4444', group: 'compare'}),
+      ]}
+      grid={<XDSChartGrid horizontal />}
+      axes={
+        <>
+          <XDSChartAxis position="bottom" />
+          <XDSChartAxis position="left" />
+        </>
+      }
+      height={300}
+    />
+  ),
+};
+
+/** Grouped stacked bars — two stacks side by side per x value */
+export const GroupedStackedBars: StoryObj = {
+  render: () => (
+    <XDSChart
+      data={groupedStackData}
+      xKey="month"
+      series={[
+        // Stack A (left bar in each group)
+        bar('revenueA', {
+          color: '#3b82f6',
+          stack: 'stackA',
+          group: 'comparison',
+        }),
+        bar('costsA', {color: '#93c5fd', stack: 'stackA', group: 'comparison'}),
+        // Stack B (right bar in each group)
+        bar('revenueB', {
+          color: '#ef4444',
+          stack: 'stackB',
+          group: 'comparison',
+        }),
+        bar('costsB', {color: '#fca5a5', stack: 'stackB', group: 'comparison'}),
       ]}
       grid={<XDSChartGrid horizontal />}
       axes={

--- a/packages/lab/src/ChartV2/layout.ts
+++ b/packages/lab/src/ChartV2/layout.ts
@@ -47,9 +47,37 @@ export function computeLayout({data, xKey, series, width, height}: LayoutInput):
     if (s.layout.includeZero) includeZero = true;
   }
 
+  // Collect which keys are stacked together so we can compute stacked extents
+  const stackGroupKeys = new Map<string, string[]>();
+  for (const s of series) {
+    if (s.layout.stack) {
+      const group = stackGroupKeys.get(s.layout.stack) ?? [];
+      group.push(s.dataKeys[0]);
+      stackGroupKeys.set(s.layout.stack, group);
+    }
+  }
+
   let yMin = Infinity, yMax = -Infinity;
+
+  // For stacked series, compute the sum at each data point
+  const stackedKeys = new Set<string>();
+  for (const [, keys] of stackGroupKeys) {
+    for (const k of keys) stackedKeys.add(k);
+    for (const d of data) {
+      let sum = 0;
+      for (const k of keys) {
+        const v = d[k];
+        if (typeof v === 'number') sum += v;
+      }
+      if (sum > yMax) yMax = sum;
+      if (sum < yMin) yMin = sum;
+    }
+  }
+
+  // For non-stacked series, use individual values
   for (const d of data) {
     for (const k of allKeys) {
+      if (stackedKeys.has(k)) continue; // already handled above
       const v = d[k];
       if (typeof v === 'number') {
         if (v < yMin) yMin = v;
@@ -57,6 +85,7 @@ export function computeLayout({data, xKey, series, width, height}: LayoutInput):
       }
     }
   }
+
   if (includeZero) {
     if (yMin > 0) yMin = 0;
     if (yMax < 0) yMax = 0;
@@ -84,11 +113,18 @@ export function computeLayout({data, xKey, series, width, height}: LayoutInput):
   }
 
   // ─── 4. Bar grouping ─────────────────────────────────────────────────
+  // Bars can be grouped (side-by-side) whether or not they are stacked.
+  // For grouped stacks, each unique stack group name within the same bar
+  // group gets its own sub-band. For ungrouped non-stacked bars with a
+  // group key, each series gets its own sub-band.
   const barGroups = new Map<string, string[]>();
   for (const s of series) {
-    if (s.type === 'bar' && s.layout.group && !s.layout.stack) {
+    if (s.type === 'bar' && s.layout.group) {
       const group = barGroups.get(s.layout.group) ?? [];
-      group.push(s.key);
+      // For grouped stacks: use the stack name as the group slot identifier
+      // so all series in the same stack share one slot.
+      const slotKey = s.layout.stack ?? s.key;
+      if (!group.includes(slotKey)) group.push(slotKey);
       barGroups.set(s.layout.group, group);
     }
   }
@@ -97,14 +133,30 @@ export function computeLayout({data, xKey, series, width, height}: LayoutInput):
   const ctx: SeriesContext = {data, xKey, xScale, yScale, width, height};
   const resolved = new Map<string, ResolvedPoint[]>();
 
+  // Determine which series is the topmost in each stack group
+  const stackTopKeys = new Set<string>();
+  for (const [, keys] of stackGroups) {
+    // Last key in the stack group is rendered on top
+    if (keys.length > 0) stackTopKeys.add(keys[keys.length - 1]);
+  }
+
   for (const s of series) {
     const stackOffsets = stackedData.get(s.dataKeys[0]);
+
+    // Mark whether this series is the topmost in its stack
+    if (s.layout.stack) {
+      s._isTopOfStack = stackTopKeys.has(s.dataKeys[0]);
+    } else {
+      s._isTopOfStack = true;
+    }
 
     let groupInfo: {index: number; count: number} | undefined;
     if (s.layout.group) {
       const groupKeys = barGroups.get(s.layout.group);
       if (groupKeys) {
-        groupInfo = {index: groupKeys.indexOf(s.key), count: groupKeys.length};
+        // For grouped stacks, the slot key is the stack name
+        const slotKey = s.layout.stack ?? s.key;
+        groupInfo = {index: groupKeys.indexOf(slotKey), count: groupKeys.length};
       }
     }
 


### PR DESCRIPTION
## Summary

Adds support for combining `stack` and `group` options on bar series, enabling grouped stacked bar charts (multiple stacks side by side per x value).

### Changes
- Allow `stack` + `group` options together on bar series
- Each stack group occupies one sub-band within the bar group
- Add gutter (5% of bandwidth) between grouped bars
- Fix Y-axis domain to account for stacked totals instead of individual values
- Add `GroupedStackedBars` story

### Testing
Check the `Lab/XDSChart v2 → Grouped Stacked Bars` story in Storybook.

Stacked bar chart before:
<img width="1381" height="319" alt="Screenshot 2026-05-13 at 5 13 04 PM" src="https://github.com/user-attachments/assets/1c07dac5-6af0-4522-b7af-7927fbebf1ac" />
Stacked bar chart after:
<img width="1384" height="320" alt="Screenshot 2026-05-13 at 11 10 15 PM" src="https://github.com/user-attachments/assets/8a106119-63dd-4fe1-a6b0-3390c7e61707" />|
New grouped stacked bar chart:
<img width="1390" height="323" alt="Screenshot 2026-05-13 at 11 10 32 PM" src="https://github.com/user-attachments/assets/609dcddf-650f-407b-a63a-6ef63fa78f4a" />
