### PR TITLE
fix(ChartV2): round only top corners of bars, respect stack position

### DIFF
--- a/packages/lab/src/ChartV2/marks/bar.tsx
+++ b/packages/lab/src/ChartV2/marks/bar.tsx
@@ -1,5 +1,5 @@
 /**
- * @file marks/bar.ts
+ * @file marks/bar.tsx
  * @output Bar series — self-contained resolve + render
  * @position Standalone mark; chart root calls resolve() then render()
  */
@@ -7,7 +7,9 @@
 import type {SeriesDef, SeriesContext, ResolvedPoint} from '../types';
 import type {ScaleBand} from 'd3-scale';
 
-export type ColorAccessor = string | ((datum: Record<string, unknown>, index: number) => string);
+export type ColorAccessor =
+  | string
+  | ((datum: Record<string, unknown>, index: number) => string);
 
 export interface BarOptions {
   color?: ColorAccessor;
@@ -17,16 +19,61 @@ export interface BarOptions {
   group?: string;
 }
 
+/**
+ * Build an SVG path for a rectangle with only the top corners rounded.
+ * When `r` is 0, produces a simple rect path with no curves.
+ */
+function roundedTopRect(
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  r: number,
+): string {
+  // Clamp radius to half the smaller dimension
+  const cr = Math.min(r, w / 2, h / 2);
+  if (cr <= 0) {
+    return `M${x},${y + h}V${y}H${x + w}V${y + h}Z`;
+  }
+  return (
+    `M${x},${y + h}` +
+    `V${y + cr}Q${x},${y} ${x + cr},${y}` +
+    `H${x + w - cr}Q${x + w},${y} ${x + w},${y + cr}` +
+    `V${y + h}Z`
+  );
+}
+
+/**
+ * Build an SVG path for a rectangle with only the bottom corners rounded.
+ */
+function roundedBottomRect(
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  r: number,
+): string {
+  const cr = Math.min(r, w / 2, h / 2);
+  if (cr <= 0) {
+    return `M${x},${y}V${y + h}H${x + w}V${y}Z`;
+  }
+  return (
+    `M${x},${y}` +
+    `V${y + h - cr}Q${x},${y + h} ${x + cr},${y + h}` +
+    `H${x + w - cr}Q${x + w},${y + h} ${x + w},${y + h - cr}` +
+    `V${y}Z`
+  );
+}
+
 export function bar(dataKey: string, options: BarOptions = {}): SeriesDef {
   const color = options.color ?? 'var(--color-chart-1)';
   const opacity = options.opacity ?? 1;
   const radius = options.radius ?? 4;
 
-  // Shared between resolve and render via closure
   let barWidth = 0;
   let barOffset = 0;
 
-  return {
+  const seriesDef: SeriesDef = {
     type: 'bar',
     key: dataKey,
     dataKeys: [dataKey],
@@ -42,8 +89,16 @@ export function bar(dataKey: string, options: BarOptions = {}): SeriesDef {
 
       const bandScale = xScale as ScaleBand<string>;
       const bw = bandScale.bandwidth();
-      barWidth = groupInfo ? bw / groupInfo.count : bw;
-      barOffset = groupInfo ? groupInfo.index * barWidth : 0;
+
+      if (groupInfo) {
+        const gutter = bw * 0.05;
+        const totalGutters = gutter * (groupInfo.count - 1);
+        barWidth = (bw - totalGutters) / groupInfo.count;
+        barOffset = groupInfo.index * (barWidth + gutter);
+      } else {
+        barWidth = bw;
+        barOffset = 0;
+      }
 
       const points: ResolvedPoint[] = [];
       for (let i = 0; i < data.length; i++) {
@@ -68,29 +123,30 @@ export function bar(dataKey: string, options: BarOptions = {}): SeriesDef {
 
     render(resolved, ctx) {
       const {data} = ctx;
+      const isTop = seriesDef._isTopOfStack !== false;
+      const r = isTop ? radius : 0;
+
       return (
         <g opacity={opacity}>
           {resolved.map((p, i) => {
             const d = data[p.dataIndex];
-            const fill = typeof color === 'function' ? color(d, p.dataIndex) : color;
-            const barY = Math.min(p.py, p.py0);
-            const barHeight = Math.abs(p.py0 - p.py);
+            const fill =
+              typeof color === 'function' ? color(d, p.dataIndex) : color;
+            const x = p.px - barWidth / 2;
+            const y = Math.min(p.py, p.py0);
+            const h = Math.max(0, Math.abs(p.py0 - p.py));
+            const growsUp = p.py <= p.py0;
 
-            return (
-              <rect
-                key={i}
-                x={p.px - barWidth / 2}
-                y={barY}
-                width={barWidth}
-                height={Math.max(0, barHeight)}
-                fill={fill}
-                rx={radius}
-                ry={radius}
-              />
-            );
+            const d_attr = growsUp
+              ? roundedTopRect(x, y, barWidth, h, r)
+              : roundedBottomRect(x, y, barWidth, h, r);
+
+            return <path key={i} d={d_attr} fill={fill} />;
           })}
         </g>
       );
     },
   };
+
+  return seriesDef;
 }

--- a/packages/lab/src/ChartV2/types.ts
+++ b/packages/lab/src/ChartV2/types.ts
@@ -72,14 +72,17 @@ export interface SeriesDef {
     groupInfo?: {index: number; count: number},
   ): ResolvedPoint[];
   /**
+   * Whether this series is the topmost in its stack group.
+   * Set by the layout engine before render() is called.
+   * Marks can use this to decide corner rounding, borders, etc.
+   */
+  _isTopOfStack?: boolean;
+  /**
    * Render the mark given resolved positions.
    * Called by the chart root during the render pass.
    * Returns SVG elements (or manages its own canvas for WebGL).
    */
-  render(
-    resolved: ResolvedPoint[],
-    ctx: SeriesContext,
-  ): ReactNode;
+  render(resolved: ResolvedPoint[], ctx: SeriesContext): ReactNode;
 }
 
 /** Resolved positions for all series */


### PR DESCRIPTION
## Summary

Fixes bar chart corner rounding so only the top corners (away from baseline) are rounded. In stacked bars, only the topmost segment gets rounded — intermediate segments are flat for visual continuity.

### Changes
- Replace `<rect rx/ry>` with path-based rendering for per-corner radius control
- Extract `roundedTopRect`/`roundedBottomRect` SVG path helpers
- Add `_isTopOfStack` field to `SeriesDef`, set by layout engine
- Only the topmost series in a stack gets rounded top corners
- Non-stacked bars always get rounded top corners
- Bottom corners are never rounded (bars grow from baseline)

### Testing
Check any bar chart story — compare stacked vs non-stacked bars.

<img width="1394" height="326" alt="Screenshot 2026-05-13 at 11 11 11 PM" src="https://github.com/user-attachments/assets/58611d5f-304c-46ca-9928-8004fdab9175" />
<img width="1397" height="331" alt="Screenshot 2026-05-13 at 11 11 05 PM" src="https://github.com/user-attachments/assets/d411929c-0818-44a2-a383-0774c663d2d9" />
<img width="1393" height="328" alt="Screenshot 2026-05-13 at 11 10 59 PM" src="https://github.com/user-attachments/assets/62b2b065-d588-40e8-b76e-8effc93d84db" />

> **Note:** Stacks on #2162