### PR TITLE
fix(ChartV2): support negative values — position x-axis at zero mark

### DIFF
--- a/apps/storybook/stories/ChartV2.stories.tsx
+++ b/apps/storybook/stories/ChartV2.stories.tsx
@@ -188,3 +188,34 @@ export const StackedAreas: StoryObj = {
     />
   ),
 };
+
+const profitLossData = [
+  {month: 'Jan', profit: 20, trend: 15},
+  {month: 'Feb', profit: -10, trend: 5},
+  {month: 'Mar', profit: 35, trend: 20},
+  {month: 'Apr', profit: -25, trend: -5},
+  {month: 'May', profit: 15, trend: 10},
+  {month: 'Jun', profit: -5, trend: 8},
+];
+
+/** Mixed marks with negative values */
+export const NegativeValues: StoryObj = {
+  render: () => (
+    <XDSChart
+      data={profitLossData}
+      xKey="month"
+      series={[
+        bar('profit', {color: '#3b82f6'}),
+        line('trend', {color: '#f59e0b', dots: true, strokeWidth: 2}),
+      ]}
+      grid={<XDSChartGrid horizontal />}
+      axes={
+        <>
+          <XDSChartAxis position="bottom" />
+          <XDSChartAxis position="left" />
+        </>
+      }
+      height={300}
+    />
+  ),
+};

--- a/packages/lab/src/Chart/XDSChartAxis.tsx
+++ b/packages/lab/src/Chart/XDSChartAxis.tsx
@@ -66,6 +66,17 @@ export function XDSChartAxis({
         ? `translate(${width},0)`
         : undefined;
 
+  // For the bottom axis, draw the axis line at y=0 when the domain spans negative values
+  const axisLineY = (() => {
+    if (position !== 'bottom') return 0;
+    const domain = yScale.domain();
+    if (domain[0] < 0 && domain[1] > 0) {
+      // The axis line should appear at the zero mark relative to the bottom edge
+      return yScale(0) - height;
+    }
+    return 0;
+  })();
+
   const format = tickFormat ?? String;
   const tickSize = 6;
 
@@ -76,12 +87,12 @@ export function XDSChartAxis({
 
   return (
     <g transform={transform}>
-      {/* Axis line */}
+      {/* Axis line — at y=0 for bottom axis when domain spans negative values */}
       <line
         x1={isHorizontal ? 0 : 0}
         x2={isHorizontal ? width : 0}
-        y1={isHorizontal ? 0 : 0}
-        y2={isHorizontal ? 0 : height}
+        y1={isHorizontal ? axisLineY : 0}
+        y2={isHorizontal ? axisLineY : height}
         stroke="var(--color-border-emphasized)"
         strokeWidth={1}
       />


### PR DESCRIPTION
## Summary

Fixes chart rendering when data includes negative values. The x-axis line now renders at the zero mark (instead of the bottom edge) when the y domain spans negative values.

### Changes
- Move bottom axis line to `yScale(0)` when domain crosses zero
- Bars already render correctly for negatives (rounded bottom corners for downward bars)
- Add `NegativeValues` story with mixed marks (bars + line) crossing zero

### Testing
Check `Lab/XDSChart v2 → Negative Values` story in Storybook.

<img width="1395" height="334" alt="Screenshot 2026-05-13 at 11 53 14 PM" src="https://github.com/user-attachments/assets/7cd0c82e-cb75-466c-83c0-c0035ac6eb3a" />


> **Note:** Stacks on #2163