### PR TITLE
fix(sandbox): add Y2K to theme dropdown; centralize theme registry

### DIFF
--- a/apps/sandbox/src/app/SandboxNav.tsx
+++ b/apps/sandbox/src/app/SandboxNav.tsx
@@ -6,7 +6,7 @@ import Link from 'next/link';
 import {XDSSideNav, XDSSideNavItem, XDSSideNavSection} from '@xds/core/SideNav';
 import {XDSDropdownMenu} from '@xds/core/DropdownMenu';
 import {XDSText} from '@xds/core/Text';
-import {useThemeControls} from './providers';
+import {useThemeControls, SANDBOX_THEMES} from './providers';
 import type {ThemeMode} from '@xds/core/theme';
 import {categories} from './sandboxPages';
 import {
@@ -52,16 +52,10 @@ const styles = stylex.create({
 function SandboxHeader() {
   const {setThemeName, mode, setMode} = useThemeControls();
 
-  const themeItems = [
-    {label: 'Default', onClick: () => setThemeName('default')},
-    {label: 'Neutral', onClick: () => setThemeName('neutral')},
-    {label: 'Brutalist', onClick: () => setThemeName('brutalist')},
-    {label: 'Matcha', onClick: () => setThemeName('matcha')},
-    {label: 'Daily', onClick: () => setThemeName('daily')},
-    {label: 'Stone', onClick: () => setThemeName('stone')},
-    {label: 'Gothic', onClick: () => setThemeName('gothic')},
-    {label: 'Chocolate', onClick: () => setThemeName('chocolate')},
-  ];
+  const themeItems = SANDBOX_THEMES.map(({id, label}) => ({
+    label,
+    onClick: () => setThemeName(id),
+  }));
 
   const modeItems = [
     {label: 'Light', onClick: () => setMode('light' as ThemeMode)},

--- a/apps/sandbox/src/app/providers.tsx
+++ b/apps/sandbox/src/app/providers.tsx
@@ -14,17 +14,32 @@ import {chocolateTheme} from '@xds/theme-chocolate/built';
 import {y2kTheme} from '@xds/theme-y2k/built';
 import type {XDSDefinedTheme, ThemeMode} from '@xds/core/theme';
 
-const themes: Record<string, XDSDefinedTheme> = {
-  default: defaultTheme,
-  neutral: neutralTheme,
-  brutalist: brutalistTheme,
-  matcha: matchaTheme,
-  daily: dailyTheme,
-  stone: stoneTheme,
-  gothic: gothicTheme,
-  chocolate: chocolateTheme,
-  y2k: y2kTheme,
-};
+/**
+ * Ordered list of available themes — single source of truth.
+ *
+ * Adding a new theme: add an entry here and the Theme dropdown in
+ * SandboxNav, the embed sync, the localStorage hydration, and any other
+ * theme-aware UI all pick it up automatically.
+ */
+export const SANDBOX_THEMES: ReadonlyArray<{
+  id: string;
+  label: string;
+  theme: XDSDefinedTheme;
+}> = [
+  {id: 'default', label: 'Default', theme: defaultTheme},
+  {id: 'neutral', label: 'Neutral', theme: neutralTheme},
+  {id: 'brutalist', label: 'Brutalist', theme: brutalistTheme},
+  {id: 'matcha', label: 'Matcha', theme: matchaTheme},
+  {id: 'daily', label: 'Daily', theme: dailyTheme},
+  {id: 'stone', label: 'Stone', theme: stoneTheme},
+  {id: 'gothic', label: 'Gothic', theme: gothicTheme},
+  {id: 'chocolate', label: 'Chocolate', theme: chocolateTheme},
+  {id: 'y2k', label: 'Y2K', theme: y2kTheme},
+];
+
+const themes: Record<string, XDSDefinedTheme> = Object.fromEntries(
+  SANDBOX_THEMES.map(t => [t.id, t.theme]),
+);
 
 type ThemeContextValue = {
   themeName: string;


### PR DESCRIPTION
## Summary

- Y2K theme was registered in `providers.tsx` but missing from the toolbar Theme dropdown in `SandboxNav.tsx`, so users couldn't preview it from the sandbox UI.
- Centralize the theme list in `providers.tsx` as `SANDBOX_THEMES` (ordered array of `{id, label, theme}`); `SandboxNav` consumes it.
- Adding a future theme now only requires updating one place — the dropdown, embed sync, localStorage hydration, and runtime theme switching all derive from the same source.

## Test plan

- [ ] Run sandbox; click the Theme dropdown in the top toolbar; verify Y2K appears between Chocolate and the modes.
- [ ] Switch to Y2K and confirm the page re-themes correctly.
- [ ] Switch through all 9 themes; confirm none broke.
- [ ] Verify embed iframe param `?theme=y2k` still applies the theme correctly.
- [ ] Verify localStorage persists theme choice across reloads.

Made with [Cursor](https://cursor.com)