### PR TITLE
fix(lab): resolve TypeScript errors blocking sandbox build

### DIFF
--- a/packages/lab/src/Chart/webgl.ts
+++ b/packages/lab/src/Chart/webgl.ts
@@ -134,7 +134,7 @@ export function mountCanvasOverSVG(
   // This is a Tier 1 guarantee — we derive position from the SVG, not from props.
   const svgRect = svg.getBoundingClientRect();
   const parentRect = parent.getBoundingClientRect();
-  const markerCTM = svgMarker.getScreenCTM();
+  const markerCTM = (svgMarker as SVGGraphicsElement).getScreenCTM();
   if (markerCTM) {
     canvas.style.left = `${markerCTM.e - parentRect.left}px`;
     canvas.style.top = `${markerCTM.f - parentRect.top}px`;

--- a/packages/lab/src/Chart/webgl.ts
+++ b/packages/lab/src/Chart/webgl.ts
@@ -111,7 +111,7 @@ export function sizeCanvas(
  * Call from a useEffect. Returns a cleanup function.
  */
 export function mountCanvasOverSVG(
-  svgMarker: SVGElement,
+  svgMarker: SVGGraphicsElement,
   canvas: HTMLCanvasElement,
   width: number,
   height: number,
@@ -134,7 +134,7 @@ export function mountCanvasOverSVG(
   // This is a Tier 1 guarantee — we derive position from the SVG, not from props.
   const svgRect = svg.getBoundingClientRect();
   const parentRect = parent.getBoundingClientRect();
-  const markerCTM = (svgMarker as SVGGraphicsElement).getScreenCTM();
+  const markerCTM = svgMarker.getScreenCTM();
   if (markerCTM) {
     canvas.style.left = `${markerCTM.e - parentRect.left}px`;
     canvas.style.top = `${markerCTM.f - parentRect.top}px`;

--- a/packages/lab/src/ChatReasoning/XDSChatReasoning.tsx
+++ b/packages/lab/src/ChatReasoning/XDSChatReasoning.tsx
@@ -14,7 +14,7 @@
  */
 
 import {useState, useCallback, type ReactNode} from 'react';
-import type {XDSBaseProps} from '@xds/core/XDSBaseProps';
+import type {XDSBaseProps} from '@xds/core';
 import * as stylex from '@stylexjs/stylex';
 import {
   colorVars,

--- a/packages/lab/src/CodeEditor/XDSCodeEditor.tsx
+++ b/packages/lab/src/CodeEditor/XDSCodeEditor.tsx
@@ -13,7 +13,7 @@
 'use client';
 
 import {useEffect, useLayoutEffect, useRef, useCallback, useState} from 'react';
-import type {XDSBaseProps} from '@xds/core/XDSBaseProps';
+import type {XDSBaseProps} from '@xds/core';
 import * as stylex from '@stylexjs/stylex';
 import {
   colorVars,

--- a/packages/lab/src/ThreeD/types.ts
+++ b/packages/lab/src/ThreeD/types.ts
@@ -28,7 +28,7 @@ export interface Camera {
   /** Rotation above the horizontal plane in degrees (default: 20) */
   elevation: number;
   /** Distance from origin — affects perspective strength (default: 5) */
-  distance: number;
+  distance?: number;
 }
 
 /** 3D context provided by XDS3DChart to children */
@@ -53,6 +53,8 @@ export interface ThreeDContext {
   yDomain: [number, number];
   /** Domain for z axis [min, max] */
   zDomain: [number, number];
+  /** Normalize a value within a domain to [0, 1] */
+  normalize: (value: number, domain: [number, number]) => number;
   /** Camera settings */
   camera: Camera;
 }


### PR DESCRIPTION
## Summary

Four pre-existing TypeScript errors in `packages/lab/` cause the sandbox build to fail when any file imports from `@xds/lab`. This PR fixes them as a focused infrastructure change so feature PRs aren't blocked.

## Fixes

1. **`Chart/webgl.ts:137`** — `getScreenCTM()` is on `SVGGraphicsElement`, not the generic `SVGElement`. Narrow the type before the call.
2. **`ChatReasoning/XDSChatReasoning.tsx`** + **`CodeEditor/XDSCodeEditor.tsx`** — both imported `XDSBaseProps` from `@xds/core/XDSBaseProps`, which is not a public export. Switch to the `@xds/core` barrel export.
3. **`ThreeD/types.ts`** — `ThreeDContext` interface was missing the `normalize` function that `XDS3DChart` already provides and `XDS3DBar`/`XDS3DScatter`/`XDS3DSurface` consume.
4. **`ThreeD/types.ts`** — `Camera.distance` was required, but `XDS3DChart` constructs camera state with only `azimuth` and `elevation`. Mark it optional.

## Test plan

- [x] `yarn build` (apps/sandbox) succeeds end to end locally
- [ ] CI build passes on PR

## Why this is its own PR

These are pre-existing lab type errors unrelated to any specific feature. They block CI for every PR that touches `@xds/lab`. Splitting them out keeps feature PRs (templates, components) focused and reviewable.


Made with [Cursor](https://cursor.com)