### PR TITLE
feat(core): add XDSAvatarGroup component

### DIFF
--- a/apps/storybook/stories/AvatarGroup.stories.tsx
+++ b/apps/storybook/stories/AvatarGroup.stories.tsx
@@ -1,0 +1,107 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+import type {Meta, StoryObj} from '@storybook/react';
+import * as stylex from '@stylexjs/stylex';
+import {XDSAvatarGroup} from '@xds/core/AvatarGroup';
+import {spacingVars, typographyVars} from '@xds/core/theme/tokens.stylex';
+
+const AVATARS = [
+  {name: 'Alice Johnson', src: 'https://i.pravatar.cc/150?img=1', key: 'alice'},
+  {name: 'Bob Smith', src: 'https://i.pravatar.cc/150?img=2', key: 'bob'},
+  {
+    name: 'Charlie Davis',
+    src: 'https://i.pravatar.cc/150?img=3',
+    key: 'charlie',
+  },
+  {name: 'Diana Lee', src: 'https://i.pravatar.cc/150?img=4', key: 'diana'},
+  {name: 'Eve Park', src: 'https://i.pravatar.cc/150?img=5', key: 'eve'},
+];
+
+const styles = stylex.create({
+  storyWrapper: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: spacingVars['--spacing-6'],
+  },
+  heading: {
+    margin: `0 0 ${spacingVars['--spacing-2']} 0`,
+    fontFamily: typographyVars['--font-family-body'],
+  },
+});
+
+const meta: Meta<typeof XDSAvatarGroup> = {
+  title: 'Core/AvatarGroup',
+  component: XDSAvatarGroup,
+  tags: ['autodocs'],
+  argTypes: {
+    maxVisibleCount: {
+      control: 'number',
+      description: 'Maximum visible avatars before overflow',
+    },
+    overflowCount: {
+      control: 'number',
+      description: 'Additional count for overflow indicator',
+    },
+    size: {
+      control: 'select',
+      options: ['tiny', 'xsmall', 'small', 'medium', 'large'],
+      description: 'Size applied to all child avatars',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof XDSAvatarGroup>;
+
+export const Default: Story = {
+  args: {
+    avatars: AVATARS.slice(0, 3),
+    size: 'medium',
+  },
+};
+
+export const WithMax: Story = {
+  args: {
+    avatars: AVATARS,
+    maxVisibleCount: 3,
+    size: 'medium',
+  },
+};
+
+export const WithOverflowCount: Story = {
+  args: {
+    avatars: AVATARS.slice(0, 3),
+    maxVisibleCount: 3,
+    overflowCount: 44,
+    size: 'medium',
+  },
+};
+
+export const WithClickableOverflow: Story = {
+  args: {
+    avatars: AVATARS,
+    maxVisibleCount: 3,
+    size: 'medium',
+    onClickOverflow: () => alert('Show all participants'),
+  },
+};
+
+export const AllSizes: Story = {
+  render: () => (
+    <div {...stylex.props(styles.storyWrapper)}>
+      {(['tiny', 'xsmall', 'small', 'medium', 'large'] as const).map(size => (
+        <div key={size}>
+          <h4 {...stylex.props(styles.heading)}>{size}</h4>
+          <XDSAvatarGroup avatars={AVATARS} maxVisibleCount={3} size={size} />
+        </div>
+      ))}
+    </div>
+  ),
+};
+
+export const InitialsFallback: Story = {
+  args: {
+    avatars: AVATARS.map(({name, key}) => ({name, key})),
+    maxVisibleCount: 4,
+    size: 'medium',
+  },
+};

--- a/apps/storybook/stories/AvatarGroup.stories.tsx
+++ b/apps/storybook/stories/AvatarGroup.stories.tsx
@@ -1,10 +1,11 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 import type {Meta, StoryObj} from '@storybook/react';
 import * as stylex from '@stylexjs/stylex';
-import {XDSAvatarGroup} from '@xds/core/AvatarGroup';
+import {XDSAvatarGroup, XDSAvatarGroupOverflow} from '@xds/core/AvatarGroup';
+import {XDSAvatar} from '@xds/core/Avatar';
 import {spacingVars, typographyVars} from '@xds/core/theme/tokens.stylex';
 
-const AVATARS = [
+const USERS = [
   {name: 'Alice Johnson', src: 'https://i.pravatar.cc/150?img=1', key: 'alice'},
   {name: 'Bob Smith', src: 'https://i.pravatar.cc/150?img=2', key: 'bob'},
   {
@@ -16,7 +17,7 @@ const AVATARS = [
   {name: 'Eve Park', src: 'https://i.pravatar.cc/150?img=5', key: 'eve'},
 ];
 
-const styles = stylex.create({
+const storyStyles = stylex.create({
   storyWrapper: {
     display: 'flex',
     flexDirection: 'column',
@@ -33,14 +34,6 @@ const meta: Meta<typeof XDSAvatarGroup> = {
   component: XDSAvatarGroup,
   tags: ['autodocs'],
   argTypes: {
-    maxVisibleCount: {
-      control: 'number',
-      description: 'Maximum visible avatars before overflow',
-    },
-    overflowCount: {
-      control: 'number',
-      description: 'Additional count for overflow indicator',
-    },
     size: {
       control: 'select',
       options: ['tiny', 'xsmall', 'small', 'medium', 'large'],
@@ -52,56 +45,106 @@ const meta: Meta<typeof XDSAvatarGroup> = {
 export default meta;
 type Story = StoryObj<typeof XDSAvatarGroup>;
 
+/** Basic avatar group showing all members. */
 export const Default: Story = {
-  args: {
-    avatars: AVATARS.slice(0, 3),
-    size: 'medium',
-  },
+  render: () => (
+    <XDSAvatarGroup size="medium">
+      {USERS.slice(0, 3).map(u => (
+        <XDSAvatar key={u.key} src={u.src} name={u.name} />
+      ))}
+    </XDSAvatarGroup>
+  ),
 };
 
-export const WithMax: Story = {
-  args: {
-    avatars: AVATARS,
-    maxVisibleCount: 3,
-    size: 'medium',
-  },
+/** Sliced to 3 with "+N" overflow indicator. */
+export const WithOverflow: Story = {
+  render: () => (
+    <XDSAvatarGroup size="medium">
+      {USERS.slice(0, 3).map(u => (
+        <XDSAvatar key={u.key} src={u.src} name={u.name} />
+      ))}
+      <XDSAvatarGroupOverflow count={USERS.length - 3} />
+    </XDSAvatarGroup>
+  ),
 };
 
-export const WithOverflowCount: Story = {
-  args: {
-    avatars: AVATARS.slice(0, 3),
-    maxVisibleCount: 3,
-    overflowCount: 44,
-    size: 'medium',
-  },
+/** Clickable overflow indicator. */
+export const ClickableOverflow: Story = {
+  render: () => (
+    <XDSAvatarGroup size="medium">
+      {USERS.slice(0, 3).map(u => (
+        <XDSAvatar key={u.key} src={u.src} name={u.name} />
+      ))}
+      <XDSAvatarGroupOverflow
+        count={USERS.length - 3}
+        onClick={() => alert('Show all participants')}
+      />
+    </XDSAvatarGroup>
+  ),
 };
 
-export const WithClickableOverflow: Story = {
-  args: {
-    avatars: AVATARS,
-    maxVisibleCount: 3,
-    size: 'medium',
-    onClickOverflow: () => alert('Show all participants'),
-  },
+/** Server-side total count (47 participants, only 3 rendered). */
+export const ServerSideCount: Story = {
+  render: () => (
+    <XDSAvatarGroup size="medium">
+      {USERS.slice(0, 3).map(u => (
+        <XDSAvatar key={u.key} src={u.src} name={u.name} />
+      ))}
+      <XDSAvatarGroupOverflow count={44} />
+    </XDSAvatarGroup>
+  ),
 };
 
+/** Per-avatar status dots — just works with compositional API. */
+export const WithStatusDots: Story = {
+  render: () => (
+    <XDSAvatarGroup size="medium">
+      <XDSAvatar
+        src="https://i.pravatar.cc/150?img=1"
+        name="Alice"
+        statusDot={{color: 'positive'}}
+      />
+      <XDSAvatar
+        src="https://i.pravatar.cc/150?img=2"
+        name="Bob"
+        statusDot={{color: 'warning'}}
+      />
+      <XDSAvatar
+        src="https://i.pravatar.cc/150?img=3"
+        name="Charlie"
+        statusDot={{color: 'negative'}}
+      />
+    </XDSAvatarGroup>
+  ),
+};
+
+/** All sizes side by side. */
 export const AllSizes: Story = {
   render: () => (
-    <div {...stylex.props(styles.storyWrapper)}>
+    <div {...stylex.props(storyStyles.storyWrapper)}>
       {(['tiny', 'xsmall', 'small', 'medium', 'large'] as const).map(size => (
         <div key={size}>
-          <h4 {...stylex.props(styles.heading)}>{size}</h4>
-          <XDSAvatarGroup avatars={AVATARS} maxVisibleCount={3} size={size} />
+          <h4 {...stylex.props(storyStyles.heading)}>{size}</h4>
+          <XDSAvatarGroup size={size}>
+            {USERS.slice(0, 3).map(u => (
+              <XDSAvatar key={u.key} src={u.src} name={u.name} />
+            ))}
+            <XDSAvatarGroupOverflow count={USERS.length - 3} />
+          </XDSAvatarGroup>
         </div>
       ))}
     </div>
   ),
 };
 
+/** Initials fallback when no images provided. */
 export const InitialsFallback: Story = {
-  args: {
-    avatars: AVATARS.map(({name, key}) => ({name, key})),
-    maxVisibleCount: 4,
-    size: 'medium',
-  },
+  render: () => (
+    <XDSAvatarGroup size="medium">
+      {USERS.slice(0, 4).map(u => (
+        <XDSAvatar key={u.key} name={u.name} />
+      ))}
+      <XDSAvatarGroupOverflow count={1} />
+    </XDSAvatarGroup>
+  ),
 };

--- a/packages/cli/templates/blocks/components/AvatarGroup/AvatarGroupShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/AvatarGroup/AvatarGroupShowcase.doc.mjs
@@ -1,0 +1,13 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  exampleFor: 'AvatarGroup',
+  name: 'AvatarGroup',
+  description:
+    'Overlapping avatar rows with max limit and server-side overflow count. Shows team members in a compact facepile layout.',
+  isReady: true,
+  isShowcase: true,
+  aspectRatio: 16 / 9,
+  componentsUsed: ['AvatarGroup', 'Avatar', 'Layout', 'Text'],
+};

--- a/packages/cli/templates/blocks/components/AvatarGroup/AvatarGroupShowcase.tsx
+++ b/packages/cli/templates/blocks/components/AvatarGroup/AvatarGroupShowcase.tsx
@@ -1,7 +1,8 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 'use client';
 
-import {XDSAvatarGroup} from '@xds/core/AvatarGroup';
+import {XDSAvatarGroup, XDSAvatarGroupOverflow} from '@xds/core/AvatarGroup';
+import {XDSAvatar} from '@xds/core/Avatar';
 import {XDSStack} from '@xds/core/Layout';
 import {XDSText} from '@xds/core/Text';
 
@@ -40,24 +41,22 @@ export default function AvatarGroupShowcase() {
         <XDSText type="supporting" color="secondary">
           Team members
         </XDSText>
-        <XDSAvatarGroup avatars={USERS} size="medium" />
+        <XDSAvatarGroup size="medium">
+          {USERS.map(u => (
+            <XDSAvatar key={u.key} src={u.src} name={u.name} />
+          ))}
+        </XDSAvatarGroup>
       </XDSStack>
       <XDSStack direction="vertical" gap={3}>
         <XDSText type="supporting" color="secondary">
           With overflow
         </XDSText>
-        <XDSAvatarGroup avatars={USERS} maxVisibleCount={3} size="medium" />
-      </XDSStack>
-      <XDSStack direction="vertical" gap={3}>
-        <XDSText type="supporting" color="secondary">
-          Server-side count
-        </XDSText>
-        <XDSAvatarGroup
-          avatars={USERS.slice(0, 3)}
-          maxVisibleCount={3}
-          overflowCount={44}
-          size="medium"
-        />
+        <XDSAvatarGroup size="medium">
+          {USERS.slice(0, 3).map(u => (
+            <XDSAvatar key={u.key} src={u.src} name={u.name} />
+          ))}
+          <XDSAvatarGroupOverflow count={USERS.length - 3} />
+        </XDSAvatarGroup>
       </XDSStack>
     </XDSStack>
   );

--- a/packages/cli/templates/blocks/components/AvatarGroup/AvatarGroupShowcase.tsx
+++ b/packages/cli/templates/blocks/components/AvatarGroup/AvatarGroupShowcase.tsx
@@ -1,0 +1,64 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+'use client';
+
+import {XDSAvatarGroup} from '@xds/core/AvatarGroup';
+import {XDSStack} from '@xds/core/Layout';
+import {XDSText} from '@xds/core/Text';
+
+const USERS = [
+  {
+    name: 'Alex Daniels',
+    src: 'https://lookaside.facebook.com/assets/vs_datakit_profile_photos_t66173184/VS-Design-Tools-Datakit-05.jpg',
+    key: 'alex',
+  },
+  {
+    name: 'Ann Smith',
+    src: 'https://lookaside.facebook.com/assets/vs_datakit_profile_photos_t66173184/VS-Design-Tools-Datakit-30.jpg',
+    key: 'ann',
+  },
+  {
+    name: 'Carol Davis',
+    src: 'https://lookaside.facebook.com/assets/vs_datakit_profile_photos_t66173184/VS-Design-Tools-Datakit-60.jpg',
+    key: 'carol',
+  },
+  {
+    name: 'Gina Wilson',
+    src: 'https://lookaside.facebook.com/assets/vs_datakit_profile_photos_t66173184/VS-Design-Tools-Datakit-98.jpg',
+    key: 'gina',
+  },
+  {
+    name: 'Eve Park',
+    src: 'https://lookaside.facebook.com/assets/vs_datakit_profile_photos_t66173184/VS-Design-Tools-Datakit-125.jpg',
+    key: 'eve',
+  },
+];
+
+export default function AvatarGroupShowcase() {
+  return (
+    <XDSStack direction="vertical" gap={8}>
+      <XDSStack direction="vertical" gap={3}>
+        <XDSText type="supporting" color="secondary">
+          Team members
+        </XDSText>
+        <XDSAvatarGroup avatars={USERS} size="medium" />
+      </XDSStack>
+      <XDSStack direction="vertical" gap={3}>
+        <XDSText type="supporting" color="secondary">
+          With overflow
+        </XDSText>
+        <XDSAvatarGroup avatars={USERS} maxVisibleCount={3} size="medium" />
+      </XDSStack>
+      <XDSStack direction="vertical" gap={3}>
+        <XDSText type="supporting" color="secondary">
+          Server-side count
+        </XDSText>
+        <XDSAvatarGroup
+          avatars={USERS.slice(0, 3)}
+          maxVisibleCount={3}
+          overflowCount={44}
+          size="medium"
+        />
+      </XDSStack>
+    </XDSStack>
+  );
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -91,6 +91,12 @@
       "import": "./dist/Avatar/index.mjs",
       "require": "./dist/Avatar/index.js"
     },
+    "./AvatarGroup": {
+      "source": "./src/AvatarGroup/index.ts",
+      "types": "./dist/AvatarGroup/index.d.ts",
+      "import": "./dist/AvatarGroup/index.mjs",
+      "require": "./dist/AvatarGroup/index.js"
+    },
     "./Badge": {
       "source": "./src/Badge/index.ts",
       "types": "./dist/Badge/index.d.ts",

--- a/packages/core/src/Avatar/XDSAvatar.tsx
+++ b/packages/core/src/Avatar/XDSAvatar.tsx
@@ -84,7 +84,7 @@ export type XDSAvatarSize = XDSAvatarNamedSize | XDSAvatarNumericSize;
 /**
  * Resolves named sizes to their numeric pixel values
  */
-function resolveSize(size: XDSAvatarSize): number {
+export function resolveSize(size: XDSAvatarSize): number {
   if (typeof size === 'number') {
     return size;
   }

--- a/packages/core/src/Avatar/XDSAvatar.tsx
+++ b/packages/core/src/Avatar/XDSAvatar.tsx
@@ -25,6 +25,7 @@ import {
   radiusVars,
 } from '../theme/tokens.stylex';
 import {XDSAvatarSizeContext} from './XDSAvatarSizeContext';
+import {useXDSAvatarGroup} from '../AvatarGroup/XDSAvatarGroupContext';
 import {xdsClassName, mergeProps} from '../utils';
 
 /**
@@ -156,8 +157,32 @@ const dynamicStyles = stylex.create({
   statusPosition: (size: number) => ({
     bottom: size * CIRCLE_EDGE_OFFSET_RATIO,
     right: size * CIRCLE_EDGE_OFFSET_RATIO,
-    // Shift by half the element's size to center it on the circle edge
     transform: 'translate(50%, 50%)',
+  }),
+});
+
+const BORDER_WIDTH = 2;
+
+const groupStyles = stylex.create({
+  ring: {
+    borderRadius: radiusVars['--radius-full'],
+    borderWidth: BORDER_WIDTH,
+    borderStyle: 'solid',
+    borderColor: colorVars['--color-background-surface'],
+    backgroundColor: colorVars['--color-background-surface'],
+    boxSizing: 'content-box',
+  },
+  overlap: {
+    marginInlineStart: {
+      default: null,
+      ':not(:first-child)': 'var(--_avatar-group-overlap)',
+    },
+  },
+});
+
+const groupDynamicStyles = stylex.create({
+  overlap: (offset: number) => ({
+    '--_avatar-group-overlap': `${offset}px`,
   }),
 });
 
@@ -268,7 +293,9 @@ export function XDSAvatar({
   const showIcon = !showImage && !showFallbackImage && !name;
 
   const accessibleName = alt || name || 'Avatar';
-  const numericSize = useMemo(() => resolveSize(size), [size]);
+  const avatarGroup = useXDSAvatarGroup();
+  const resolvedSize = avatarGroup?.size ?? size;
+  const numericSize = useMemo(() => resolveSize(resolvedSize), [resolvedSize]);
 
   return (
     <XDSAvatarSizeContext.Provider value={numericSize}>
@@ -278,8 +305,14 @@ export function XDSAvatar({
         aria-label={accessibleName}
         data-testid={testId}
         {...mergeProps(
-          xdsClassName('avatar', {size}),
-          stylex.props(styles.wrapper, xstyle),
+          xdsClassName('avatar', {size: resolvedSize}),
+          stylex.props(
+            styles.wrapper,
+            avatarGroup && groupStyles.ring,
+            avatarGroup && groupStyles.overlap,
+            avatarGroup && groupDynamicStyles.overlap(-avatarGroup.overlap),
+            xstyle,
+          ),
           className,
           style,
         )}

--- a/packages/core/src/Avatar/index.ts
+++ b/packages/core/src/Avatar/index.ts
@@ -11,7 +11,7 @@
  * SYNC: When modified, update this header and /packages/core/src/Avatar/Avatar.doc.mjs
  */
 
-export {XDSAvatar} from './XDSAvatar';
+export {XDSAvatar, resolveSize} from './XDSAvatar';
 export type {XDSAvatarProps, XDSAvatarSize} from './XDSAvatar';
 export {XDSAvatarStatusDot} from './XDSAvatarStatusDot';
 export type {

--- a/packages/core/src/AvatarGroup/AvatarGroup.doc.mjs
+++ b/packages/core/src/AvatarGroup/AvatarGroup.doc.mjs
@@ -1,0 +1,101 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+/** @type {import('../docs-types').ComponentDoc} */
+
+export const docs = {
+  name: 'AvatarGroup',
+  group: 'Avatar',
+  keywords: ['avatar', 'group', 'facepile', 'stack', 'overlap', 'participants', 'assignees', 'members', 'team'],
+  usage: {
+    description:
+      'AvatarGroup displays multiple avatars in an overlapping row with an optional overflow count. Use it when showing group membership, participants, or assignees in a compact space.',
+    bestPractices: [
+      {guidance: true, description: 'Set maxVisibleCount to limit visible avatars when the list is long — 3-5 is typical.'},
+      {guidance: true, description: 'Use overflowCount when the server knows more participants than you pass locally.'},
+      {guidance: true, description: 'Provide an onClickOverflow handler to let users see the full participant list.'},
+      {guidance: false, description: 'Pass more avatars than needed when the server total is known — use maxVisibleCount and overflowCount instead.'},
+    ],
+    anatomy: [
+      {name: 'Avatar row', required: true, description: 'Horizontally overlapping avatars with border rings for visual separation.'},
+      {name: 'Overflow indicator', required: false, description: 'A "+N" circle at the end showing how many additional participants are hidden.'},
+    ],
+  },
+  theming: {
+    targets: [
+      {className: 'xds-avatar-group', visualProps: ['size']},
+    ],
+  },
+  props: [
+    {
+      name: 'avatars',
+      type: 'XDSAvatarGroupItem[]',
+      description: 'Array of avatar data objects ({src, fallbackSrc, name, alt, key}) to display.',
+      required: true,
+    },
+    {
+      name: 'maxVisibleCount',
+      type: 'number',
+      description: 'Maximum avatars to show before the overflow indicator appears.',
+    },
+    {
+      name: 'overflowCount',
+      type: 'number',
+      description: 'Additional count added to the overflow indicator beyond hidden avatars.',
+    },
+    {
+      name: 'size',
+      type: 'XDSAvatarSize',
+      description: 'Size applied to all avatars for visual consistency.',
+      default: "'small'",
+    },
+    {
+      name: 'onClickOverflow',
+      type: '() => void',
+      description: 'Callback when the overflow indicator is clicked. Makes the indicator a focusable button.',
+    },
+  ],
+};
+
+/** @type {import('../docs-types').ComponentDoc} */
+export const docsZh = {
+  name: 'AvatarGroup',
+  group: 'Avatar',
+  usage: {
+    description:
+      'AvatarGroup 以重叠排列方式显示多个头像，并可选择显示溢出计数。用于在紧凑空间中展示群组成员、参与者或被分配人。',
+    bestPractices: [
+      {guidance: true, description: '当列表较长时设置 max 来限制可见头像数量 — 通常 3-5 个为佳。'},
+      {guidance: true, description: '当服务器知道的参与者数量多于本地传入时使用 overflowCount。'},
+      {guidance: true, description: '提供 onClickOverflow 处理器让用户查看完整参与者列表。'},
+      {guidance: false, description: '当已知服务器总数时传入过多头像 — 改用 max 和 overflowCount。'},
+    ],
+  },
+  props: [
+    {name: 'avatars', type: 'XDSAvatarGroupItem[]', description: '要显示的头像数据对象数组。', required: true},
+    {name: 'maxVisibleCount', type: 'number', description: '溢出指示器出现前显示的最大头像数。'},
+    {name: 'overflowCount', type: 'number', description: '溢出指示器中除隐藏头像外的额外计数。'},
+    {name: 'size', type: 'XDSAvatarSize', description: '应用于所有头像的大小，确保视觉一致性。', default: "'small'"},
+    {name: 'onClickOverflow', type: '() => void', description: '点击溢出指示器时的回调。使指示器成为可聚焦按钮。'},
+  ],
+};
+
+/** @type {import('../docs-types').TranslationDoc} */
+export const docsDense = {
+  description: 'overlapping avatar row w/ +N overflow indicator for groups/participants',
+  usage: {
+    description:
+      'Stacked avatar display showing multiple avatars overlapping with an overflow count indicator. Used for showing group membership, participants, or assignees in a compact space.',
+    bestPractices: [
+      {guidance: true, description: 'Set maxVisibleCount to limit visible avatars (3-5 typical).'},
+      {guidance: true, description: 'Use overflowCount for server-side total beyond rendered avatars.'},
+      {guidance: true, description: 'Add onClickOverflow to show full participant list.'},
+      {guidance: false, description: 'Pass excess avatars when server total is known — use maxVisibleCount + overflowCount.'},
+    ],
+  },
+  propDescriptions: {
+    avatars: 'array of avatar data ({src, name, key, ...})',
+    maxVisibleCount: 'max avatars before overflow indicator',
+    overflowCount: 'additional count beyond hidden avatars',
+    size: 'size for all avatars',
+    onClickOverflow: 'overflow click callback, makes indicator a button',
+  },
+};

--- a/packages/core/src/AvatarGroup/AvatarGroup.doc.mjs
+++ b/packages/core/src/AvatarGroup/AvatarGroup.doc.mjs
@@ -7,16 +7,16 @@ export const docs = {
   keywords: ['avatar', 'group', 'facepile', 'stack', 'overlap', 'participants', 'assignees', 'members', 'team'],
   usage: {
     description:
-      'AvatarGroup displays multiple avatars in an overlapping row with an optional overflow count. Use it when showing group membership, participants, or assignees in a compact space.',
+      'AvatarGroup displays multiple avatars in an overlapping row with an optional overflow indicator. Uses a compositional API — pass XDSAvatar children directly so each avatar can carry its own props (status dots, click handlers, etc.).',
     bestPractices: [
-      {guidance: true, description: 'Set maxVisibleCount to limit visible avatars when the list is long — 3-5 is typical.'},
-      {guidance: true, description: 'Use overflowCount when the server knows more participants than you pass locally.'},
-      {guidance: true, description: 'Provide an onClickOverflow handler to let users see the full participant list.'},
-      {guidance: false, description: 'Pass more avatars than needed when the server total is known — use maxVisibleCount and overflowCount instead.'},
+      {guidance: true, description: 'Set max to limit visible avatars when the list is long — 3-5 is typical.'},
+      {guidance: true, description: 'Use XDSAvatarGroupOverflow for custom overflow content like a popover trigger or "add member" button.'},
+      {guidance: true, description: 'Pass status dots, click handlers, or tooltips directly on each XDSAvatar child.'},
+      {guidance: false, description: "Don't nest AvatarGroups — use a single group with all avatars."},
     ],
     anatomy: [
-      {name: 'Avatar row', required: true, description: 'Horizontally overlapping avatars with border rings for visual separation.'},
-      {name: 'Overflow indicator', required: false, description: 'A "+N" circle at the end showing how many additional participants are hidden.'},
+      {name: 'Avatar children', required: true, description: 'XDSAvatar elements that form the overlapping row. Each can have its own props.'},
+      {name: 'Overflow indicator', required: false, description: 'A "+N" circle at the end showing hidden count, or a custom XDSAvatarGroupOverflow slot.'},
     ],
   },
   theming: {
@@ -24,78 +24,95 @@ export const docs = {
       {className: 'xds-avatar-group', visualProps: ['size']},
     ],
   },
-  props: [
+  components: [
     {
-      name: 'avatars',
-      type: 'XDSAvatarGroupItem[]',
-      description: 'Array of avatar data objects ({src, fallbackSrc, name, alt, key}) to display.',
-      required: true,
+      name: 'XDSAvatarGroup',
+      description: 'Stacked avatar display with overlapping layout and optional overflow indicator. Children are XDSAvatar elements.',
+      props: [
+        {name: 'children', type: 'ReactNode', description: 'XDSAvatar children, optionally followed by one XDSAvatarGroupOverflow. Consumers handle slicing to the desired visible count.', required: true, slotElements: [{__element: 'XDSAvatar', props: {name: 'User'}}]},
+        {name: 'size', type: 'XDSAvatarSize', description: 'Size applied to all avatars via context.', default: "'small'"},
+        {name: 'ref', type: 'React.Ref<HTMLDivElement>', description: 'Ref forwarded to the root element.'},
+        {name: 'xstyle', type: 'StyleXStyles', description: 'StyleX styles for layout customization.'},
+        {name: 'data-testid', type: 'string', description: 'Test selector for automated testing frameworks.'},
+      ],
     },
     {
-      name: 'maxVisibleCount',
-      type: 'number',
-      description: 'Maximum avatars to show before the overflow indicator appears.',
-    },
-    {
-      name: 'overflowCount',
-      type: 'number',
-      description: 'Additional count added to the overflow indicator beyond hidden avatars.',
-    },
-    {
-      name: 'size',
-      type: 'XDSAvatarSize',
-      description: 'Size applied to all avatars for visual consistency.',
-      default: "'small'",
-    },
-    {
-      name: 'onClickOverflow',
-      type: '() => void',
-      description: 'Callback when the overflow indicator is clicked. Makes the indicator a focusable button.',
+      name: 'XDSAvatarGroupOverflow',
+      description: 'Slot for custom overflow content inside XDSAvatarGroup. Replaces the default "+N" indicator when present.',
+      props: [
+        {name: 'children', type: 'ReactNode', description: 'Custom overflow content (button, popover trigger, etc.).', required: true},
+      ],
     },
   ],
 };
 
-/** @type {import('../docs-types').ComponentDoc} */
+/** @type {import('../docs-types').TranslationDoc} */
 export const docsZh = {
-  name: 'AvatarGroup',
-  group: 'Avatar',
   usage: {
     description:
-      'AvatarGroup 以重叠排列方式显示多个头像，并可选择显示溢出计数。用于在紧凑空间中展示群组成员、参与者或被分配人。',
+      'AvatarGroup 以重叠排列方式显示多个头像，并可选择显示溢出指示器。使用组合式 API — 直接传入 XDSAvatar 子元素，每个头像可携带自己的属性。',
     bestPractices: [
       {guidance: true, description: '当列表较长时设置 max 来限制可见头像数量 — 通常 3-5 个为佳。'},
-      {guidance: true, description: '当服务器知道的参与者数量多于本地传入时使用 overflowCount。'},
-      {guidance: true, description: '提供 onClickOverflow 处理器让用户查看完整参与者列表。'},
-      {guidance: false, description: '当已知服务器总数时传入过多头像 — 改用 max 和 overflowCount。'},
+      {guidance: true, description: '使用 XDSAvatarGroupOverflow 自定义溢出内容，如弹出触发器或"添加成员"按钮。'},
+      {guidance: true, description: '直接在每个 XDSAvatar 子元素上传递状态点、点击处理器或工具提示。'},
+      {guidance: false, description: '不要嵌套 AvatarGroup — 使用单个组包含所有头像。'},
     ],
   },
-  props: [
-    {name: 'avatars', type: 'XDSAvatarGroupItem[]', description: '要显示的头像数据对象数组。', required: true},
-    {name: 'maxVisibleCount', type: 'number', description: '溢出指示器出现前显示的最大头像数。'},
-    {name: 'overflowCount', type: 'number', description: '溢出指示器中除隐藏头像外的额外计数。'},
-    {name: 'size', type: 'XDSAvatarSize', description: '应用于所有头像的大小，确保视觉一致性。', default: "'small'"},
-    {name: 'onClickOverflow', type: '() => void', description: '点击溢出指示器时的回调。使指示器成为可聚焦按钮。'},
+  components: [
+    {
+      name: 'XDSAvatarGroup',
+      description: '重叠布局的堆叠头像显示，带可选溢出指示器。子元素为 XDSAvatar。',
+      propDescriptions: {
+        children: 'XDSAvatar 子元素，可选地后跟一个 XDSAvatarGroupOverflow。',
+        max: '溢出指示器出现前显示的最大头像数。',
+        size: '应用于所有头像的大小。',
+        ref: '转发到根元素的引用。',
+        xstyle: 'StyleX 样式，用于布局自定义。',
+        'data-testid': '自动化测试的选择器。',
+      },
+    },
+    {
+      name: 'XDSAvatarGroupOverflow',
+      description: 'XDSAvatarGroup 内的自定义溢出内容插槽。存在时替换默认的 "+N" 指示器。',
+      propDescriptions: {
+        children: '自定义溢出内容（按钮、弹出触发器等）。',
+      },
+    },
   ],
 };
 
 /** @type {import('../docs-types').TranslationDoc} */
 export const docsDense = {
-  description: 'overlapping avatar row w/ +N overflow indicator for groups/participants',
+  description: 'compositional overlapping avatar row w/ +N overflow or custom slot',
   usage: {
     description:
-      'Stacked avatar display showing multiple avatars overlapping with an overflow count indicator. Used for showing group membership, participants, or assignees in a compact space.',
+      'Stacked avatar display with overlapping layout. Compositional API — XDSAvatar children with per-avatar props (status dots, clicks). Optional XDSAvatarGroupOverflow slot for custom overflow.',
     bestPractices: [
-      {guidance: true, description: 'Set maxVisibleCount to limit visible avatars (3-5 typical).'},
-      {guidance: true, description: 'Use overflowCount for server-side total beyond rendered avatars.'},
-      {guidance: true, description: 'Add onClickOverflow to show full participant list.'},
-      {guidance: false, description: 'Pass excess avatars when server total is known — use maxVisibleCount + overflowCount.'},
+      {guidance: true, description: 'Set max to limit visible avatars (3-5 typical).'},
+      {guidance: true, description: 'Use XDSAvatarGroupOverflow for custom overflow (popover, add button).'},
+      {guidance: true, description: 'Pass status dots / click handlers directly on each XDSAvatar.'},
+      {guidance: false, description: "Don't nest AvatarGroups."},
     ],
   },
-  propDescriptions: {
-    avatars: 'array of avatar data ({src, name, key, ...})',
-    maxVisibleCount: 'max avatars before overflow indicator',
-    overflowCount: 'additional count beyond hidden avatars',
-    size: 'size for all avatars',
-    onClickOverflow: 'overflow click callback, makes indicator a button',
-  },
+  components: [
+    {
+      name: 'XDSAvatarGroup',
+      description: 'overlapping avatar row w/ max truncation',
+      propDescriptions: {
+        children: 'XDSAvatar children + optional XDSAvatarGroupOverflow',
+        max: 'max avatars before overflow',
+        size: 'size for all avatars',
+        ref: 'ref to root element',
+        xstyle: 'StyleX layout styles',
+        'data-testid': 'test selector',
+      },
+    },
+    {
+      name: 'XDSAvatarGroupOverflow',
+      description: 'custom overflow slot, replaces default +N',
+      propDescriptions: {
+        children: 'custom overflow content',
+      },
+    },
+  ],
 };

--- a/packages/core/src/AvatarGroup/XDSAvatarGroup.test.tsx
+++ b/packages/core/src/AvatarGroup/XDSAvatarGroup.test.tsx
@@ -3,119 +3,39 @@ import {describe, it, expect, vi} from 'vitest';
 import {render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {XDSAvatarGroup} from './XDSAvatarGroup';
-
-const AVATARS = [
-  {name: 'Alice', src: '/alice.jpg', key: 'alice'},
-  {name: 'Bob', src: '/bob.jpg', key: 'bob'},
-  {name: 'Charlie', src: '/charlie.jpg', key: 'charlie'},
-  {name: 'Diana', src: '/diana.jpg', key: 'diana'},
-  {name: 'Eve', src: '/eve.jpg', key: 'eve'},
-];
+import {XDSAvatarGroupOverflow} from './XDSAvatarGroupOverflow';
+import {XDSAvatar} from '../Avatar';
 
 describe('XDSAvatarGroup', () => {
-  it('renders all avatars when no maxVisibleCount is set', () => {
-    render(<XDSAvatarGroup avatars={AVATARS.slice(0, 3)} />);
+  it('renders all avatar children', () => {
+    render(
+      <XDSAvatarGroup>
+        <XDSAvatar name="Alice" />
+        <XDSAvatar name="Bob" />
+        <XDSAvatar name="Charlie" />
+      </XDSAvatarGroup>,
+    );
 
     expect(screen.getByLabelText('Alice')).toBeInTheDocument();
     expect(screen.getByLabelText('Bob')).toBeInTheDocument();
     expect(screen.getByLabelText('Charlie')).toBeInTheDocument();
   });
 
-  it('limits visible avatars when maxVisibleCount is set', () => {
-    render(
-      <XDSAvatarGroup avatars={AVATARS.slice(0, 3)} maxVisibleCount={2} />,
-    );
-
-    expect(screen.getByLabelText('Alice')).toBeInTheDocument();
-    expect(screen.getByLabelText('Bob')).toBeInTheDocument();
-    expect(screen.queryByLabelText('Charlie')).not.toBeInTheDocument();
-  });
-
-  it('shows overflow indicator with hidden count', () => {
-    render(
-      <XDSAvatarGroup avatars={AVATARS.slice(0, 4)} maxVisibleCount={2} />,
-    );
-
-    expect(screen.getByLabelText('2 more')).toBeInTheDocument();
-    expect(screen.getByText('+2')).toBeInTheDocument();
-  });
-
-  it('adds overflowCount to hidden count', () => {
-    render(
-      <XDSAvatarGroup
-        avatars={AVATARS.slice(0, 3)}
-        maxVisibleCount={2}
-        overflowCount={10}
-      />,
-    );
-
-    expect(screen.getByLabelText('11 more')).toBeInTheDocument();
-    expect(screen.getByText('+11')).toBeInTheDocument();
-  });
-
-  it('shows overflowCount even when all avatars are visible', () => {
-    render(
-      <XDSAvatarGroup
-        avatars={AVATARS.slice(0, 3)}
-        maxVisibleCount={5}
-        overflowCount={44}
-      />,
-    );
-
-    expect(screen.getByLabelText('44 more')).toBeInTheDocument();
-    expect(screen.getByText('+44')).toBeInTheDocument();
-  });
-
-  it('renders overflow as span when onClickOverflow is not set', () => {
-    render(
-      <XDSAvatarGroup avatars={AVATARS.slice(0, 2)} maxVisibleCount={1} />,
-    );
-
-    const overflow = screen.getByLabelText('1 more');
-    expect(overflow.tagName).toBe('SPAN');
-  });
-
-  it('renders overflow as button when onClickOverflow is set', () => {
-    render(
-      <XDSAvatarGroup
-        avatars={AVATARS.slice(0, 2)}
-        maxVisibleCount={1}
-        onClickOverflow={() => {}}
-      />,
-    );
-
-    const overflow = screen.getByLabelText('1 more');
-    expect(overflow.tagName).toBe('BUTTON');
-  });
-
-  it('calls onClickOverflow when overflow indicator is clicked', async () => {
-    const user = userEvent.setup();
-    const handleClick = vi.fn();
-
-    render(
-      <XDSAvatarGroup
-        avatars={AVATARS.slice(0, 2)}
-        maxVisibleCount={1}
-        onClickOverflow={handleClick}
-      />,
-    );
-
-    await user.click(screen.getByLabelText('1 more'));
-    expect(handleClick).toHaveBeenCalledOnce();
-  });
-
   it('renders with role="group" and default aria-label', () => {
-    render(<XDSAvatarGroup avatars={AVATARS.slice(0, 1)} />);
+    render(
+      <XDSAvatarGroup>
+        <XDSAvatar name="Alice" />
+      </XDSAvatarGroup>,
+    );
 
     expect(screen.getByRole('group')).toHaveAttribute('aria-label', 'Avatars');
   });
 
   it('accepts a custom aria-label', () => {
     render(
-      <XDSAvatarGroup
-        avatars={AVATARS.slice(0, 1)}
-        aria-label="Team members"
-      />,
+      <XDSAvatarGroup aria-label="Team members">
+        <XDSAvatar name="Alice" />
+      </XDSAvatarGroup>,
     );
 
     expect(screen.getByRole('group')).toHaveAttribute(
@@ -126,37 +46,106 @@ describe('XDSAvatarGroup', () => {
 
   it('applies data-testid', () => {
     render(
-      <XDSAvatarGroup
-        avatars={AVATARS.slice(0, 1)}
-        data-testid="avatar-group"
-      />,
+      <XDSAvatarGroup data-testid="avatar-group">
+        <XDSAvatar name="Alice" />
+      </XDSAvatarGroup>,
     );
 
     expect(screen.getByTestId('avatar-group')).toBeInTheDocument();
   });
 
-  it('does not show overflow when maxVisibleCount exceeds avatar count', () => {
-    render(
-      <XDSAvatarGroup avatars={AVATARS.slice(0, 2)} maxVisibleCount={10} />,
-    );
-
-    expect(screen.getByLabelText('Alice')).toBeInTheDocument();
-    expect(screen.getByLabelText('Bob')).toBeInTheDocument();
-    expect(screen.queryByText(/\+\d/)).not.toBeInTheDocument();
-  });
-
   it('applies size class to the group', () => {
-    render(<XDSAvatarGroup avatars={AVATARS.slice(0, 1)} size="medium" />);
+    render(
+      <XDSAvatarGroup size="medium">
+        <XDSAvatar name="Alice" />
+      </XDSAvatarGroup>,
+    );
 
     const group = screen.getByRole('group');
     expect(group.className).toContain('xds-avatar-group');
     expect(group.className).toContain('medium');
   });
 
-  it('renders empty group when avatars is empty', () => {
-    render(<XDSAvatarGroup avatars={[]} data-testid="empty" />);
+  it('renders empty group when no children', () => {
+    render(<XDSAvatarGroup data-testid="empty">{[]}</XDSAvatarGroup>);
 
     expect(screen.getByTestId('empty')).toBeInTheDocument();
     expect(screen.queryByRole('img')).not.toBeInTheDocument();
+  });
+});
+
+describe('XDSAvatarGroupOverflow', () => {
+  it('renders overflow count as span by default', () => {
+    render(
+      <XDSAvatarGroup>
+        <XDSAvatar name="Alice" />
+        <XDSAvatarGroupOverflow count={5} />
+      </XDSAvatarGroup>,
+    );
+
+    const overflow = screen.getByLabelText('5 more');
+    expect(overflow.tagName).toBe('SPAN');
+    expect(overflow).toHaveTextContent('+5');
+  });
+
+  it('renders as button when onClick is provided', () => {
+    render(
+      <XDSAvatarGroup>
+        <XDSAvatar name="Alice" />
+        <XDSAvatarGroupOverflow count={3} onClick={() => {}} />
+      </XDSAvatarGroup>,
+    );
+
+    const overflow = screen.getByLabelText('3 more');
+    expect(overflow.tagName).toBe('BUTTON');
+  });
+
+  it('calls onClick when clicked', async () => {
+    const user = userEvent.setup();
+    const handleClick = vi.fn();
+
+    render(
+      <XDSAvatarGroup>
+        <XDSAvatar name="Alice" />
+        <XDSAvatarGroupOverflow count={3} onClick={handleClick} />
+      </XDSAvatarGroup>,
+    );
+
+    await user.click(screen.getByLabelText('3 more'));
+    expect(handleClick).toHaveBeenCalledOnce();
+  });
+
+  it('renders custom children instead of default label', () => {
+    render(
+      <XDSAvatarGroup>
+        <XDSAvatar name="Alice" />
+        <XDSAvatarGroupOverflow count={5}>
+          <span data-testid="custom">more</span>
+        </XDSAvatarGroupOverflow>
+      </XDSAvatarGroup>,
+    );
+
+    expect(screen.getByTestId('custom')).toBeInTheDocument();
+  });
+
+  it('works with sliced avatar list and server-side count', () => {
+    const users = ['Alice', 'Bob', 'Charlie', 'Diana', 'Eve'];
+    const serverTotal = 47;
+    const visibleCount = 3;
+
+    render(
+      <XDSAvatarGroup size="medium">
+        {users.slice(0, visibleCount).map(name => (
+          <XDSAvatar key={name} name={name} />
+        ))}
+        <XDSAvatarGroupOverflow count={serverTotal - visibleCount} />
+      </XDSAvatarGroup>,
+    );
+
+    expect(screen.getByLabelText('Alice')).toBeInTheDocument();
+    expect(screen.getByLabelText('Bob')).toBeInTheDocument();
+    expect(screen.getByLabelText('Charlie')).toBeInTheDocument();
+    expect(screen.getByLabelText('44 more')).toBeInTheDocument();
+    expect(screen.getByText('+44')).toBeInTheDocument();
   });
 });

--- a/packages/core/src/AvatarGroup/XDSAvatarGroup.test.tsx
+++ b/packages/core/src/AvatarGroup/XDSAvatarGroup.test.tsx
@@ -1,0 +1,162 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+import {describe, it, expect, vi} from 'vitest';
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {XDSAvatarGroup} from './XDSAvatarGroup';
+
+const AVATARS = [
+  {name: 'Alice', src: '/alice.jpg', key: 'alice'},
+  {name: 'Bob', src: '/bob.jpg', key: 'bob'},
+  {name: 'Charlie', src: '/charlie.jpg', key: 'charlie'},
+  {name: 'Diana', src: '/diana.jpg', key: 'diana'},
+  {name: 'Eve', src: '/eve.jpg', key: 'eve'},
+];
+
+describe('XDSAvatarGroup', () => {
+  it('renders all avatars when no maxVisibleCount is set', () => {
+    render(<XDSAvatarGroup avatars={AVATARS.slice(0, 3)} />);
+
+    expect(screen.getByLabelText('Alice')).toBeInTheDocument();
+    expect(screen.getByLabelText('Bob')).toBeInTheDocument();
+    expect(screen.getByLabelText('Charlie')).toBeInTheDocument();
+  });
+
+  it('limits visible avatars when maxVisibleCount is set', () => {
+    render(
+      <XDSAvatarGroup avatars={AVATARS.slice(0, 3)} maxVisibleCount={2} />,
+    );
+
+    expect(screen.getByLabelText('Alice')).toBeInTheDocument();
+    expect(screen.getByLabelText('Bob')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Charlie')).not.toBeInTheDocument();
+  });
+
+  it('shows overflow indicator with hidden count', () => {
+    render(
+      <XDSAvatarGroup avatars={AVATARS.slice(0, 4)} maxVisibleCount={2} />,
+    );
+
+    expect(screen.getByLabelText('2 more')).toBeInTheDocument();
+    expect(screen.getByText('+2')).toBeInTheDocument();
+  });
+
+  it('adds overflowCount to hidden count', () => {
+    render(
+      <XDSAvatarGroup
+        avatars={AVATARS.slice(0, 3)}
+        maxVisibleCount={2}
+        overflowCount={10}
+      />,
+    );
+
+    expect(screen.getByLabelText('11 more')).toBeInTheDocument();
+    expect(screen.getByText('+11')).toBeInTheDocument();
+  });
+
+  it('shows overflowCount even when all avatars are visible', () => {
+    render(
+      <XDSAvatarGroup
+        avatars={AVATARS.slice(0, 3)}
+        maxVisibleCount={5}
+        overflowCount={44}
+      />,
+    );
+
+    expect(screen.getByLabelText('44 more')).toBeInTheDocument();
+    expect(screen.getByText('+44')).toBeInTheDocument();
+  });
+
+  it('renders overflow as span when onClickOverflow is not set', () => {
+    render(
+      <XDSAvatarGroup avatars={AVATARS.slice(0, 2)} maxVisibleCount={1} />,
+    );
+
+    const overflow = screen.getByLabelText('1 more');
+    expect(overflow.tagName).toBe('SPAN');
+  });
+
+  it('renders overflow as button when onClickOverflow is set', () => {
+    render(
+      <XDSAvatarGroup
+        avatars={AVATARS.slice(0, 2)}
+        maxVisibleCount={1}
+        onClickOverflow={() => {}}
+      />,
+    );
+
+    const overflow = screen.getByLabelText('1 more');
+    expect(overflow.tagName).toBe('BUTTON');
+  });
+
+  it('calls onClickOverflow when overflow indicator is clicked', async () => {
+    const user = userEvent.setup();
+    const handleClick = vi.fn();
+
+    render(
+      <XDSAvatarGroup
+        avatars={AVATARS.slice(0, 2)}
+        maxVisibleCount={1}
+        onClickOverflow={handleClick}
+      />,
+    );
+
+    await user.click(screen.getByLabelText('1 more'));
+    expect(handleClick).toHaveBeenCalledOnce();
+  });
+
+  it('renders with role="group" and default aria-label', () => {
+    render(<XDSAvatarGroup avatars={AVATARS.slice(0, 1)} />);
+
+    expect(screen.getByRole('group')).toHaveAttribute('aria-label', 'Avatars');
+  });
+
+  it('accepts a custom aria-label', () => {
+    render(
+      <XDSAvatarGroup
+        avatars={AVATARS.slice(0, 1)}
+        aria-label="Team members"
+      />,
+    );
+
+    expect(screen.getByRole('group')).toHaveAttribute(
+      'aria-label',
+      'Team members',
+    );
+  });
+
+  it('applies data-testid', () => {
+    render(
+      <XDSAvatarGroup
+        avatars={AVATARS.slice(0, 1)}
+        data-testid="avatar-group"
+      />,
+    );
+
+    expect(screen.getByTestId('avatar-group')).toBeInTheDocument();
+  });
+
+  it('does not show overflow when maxVisibleCount exceeds avatar count', () => {
+    render(
+      <XDSAvatarGroup avatars={AVATARS.slice(0, 2)} maxVisibleCount={10} />,
+    );
+
+    expect(screen.getByLabelText('Alice')).toBeInTheDocument();
+    expect(screen.getByLabelText('Bob')).toBeInTheDocument();
+    expect(screen.queryByText(/\+\d/)).not.toBeInTheDocument();
+  });
+
+  it('applies size class to the group', () => {
+    render(<XDSAvatarGroup avatars={AVATARS.slice(0, 1)} size="medium" />);
+
+    const group = screen.getByRole('group');
+    expect(group.className).toContain('xds-avatar-group');
+    expect(group.className).toContain('medium');
+  });
+
+  it('renders empty group when avatars is empty', () => {
+    render(<XDSAvatarGroup avatars={[]} data-testid="empty" />);
+
+    expect(screen.getByTestId('empty')).toBeInTheDocument();
+    expect(screen.queryByRole('img')).not.toBeInTheDocument();
+  });
+});

--- a/packages/core/src/AvatarGroup/XDSAvatarGroup.tsx
+++ b/packages/core/src/AvatarGroup/XDSAvatarGroup.tsx
@@ -3,9 +3,13 @@
 
 /**
  * @file XDSAvatarGroup.tsx
- * @input Uses React, StyleX, theme tokens, XDSAvatar
- * @output Exports XDSAvatarGroup component, XDSAvatarGroupProps, XDSAvatarGroupItem types
+ * @input Uses React, StyleX, theme tokens, XDSAvatarGroupContext
+ * @output Exports XDSAvatarGroup component and XDSAvatarGroupProps
  * @position Core implementation; consumed by index.ts
+ *
+ * Compositional API: children are XDSAvatar elements (and optionally
+ * one XDSAvatarGroupOverflow). The group provides overlap styling via
+ * context — no child introspection needed.
  *
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/AvatarGroup/AvatarGroup.doc.mjs (props table, features)
@@ -14,65 +18,28 @@
  * - /packages/cli/templates/blocks/components/AvatarGroup/ (showcase blocks)
  */
 
+import {useMemo, type ReactNode} from 'react';
 import type {XDSBaseProps} from '../XDSBaseProps';
-import {XDSAvatar, resolveSize, type XDSAvatarSize} from '../Avatar';
+import {resolveSize, type XDSAvatarSize} from '../Avatar';
 import * as stylex from '@stylexjs/stylex';
-import {
-  colorVars,
-  typographyVars,
-  fontWeightVars,
-  radiusVars,
-} from '../theme/tokens.stylex';
 import {xdsClassName, mergeProps} from '../utils';
+import {XDSAvatarGroupContext} from './XDSAvatarGroupContext';
 
 const OVERLAP_RATIO = 0.25;
-const BORDER_WIDTH = 2;
-const OVERFLOW_FONT_RATIO = 0.35;
-
-/**
- * Data for a single avatar in the group.
- */
-export interface XDSAvatarGroupItem {
-  /** Primary image source URL. */
-  src?: string;
-  /** Fallback image when primary fails. */
-  fallbackSrc?: string;
-  /** User name for initials and alt text. */
-  name?: string;
-  /** Alt text (falls back to name). */
-  alt?: string;
-  /** Unique key for React reconciliation. Falls back to index if not provided. */
-  key?: string | number;
-}
 
 export interface XDSAvatarGroupProps extends XDSBaseProps<HTMLDivElement> {
   /** Ref forwarded to the root element. */
   ref?: React.Ref<HTMLDivElement>;
   /**
-   * Avatar data to display.
+   * XDSAvatar children, optionally followed by one XDSAvatarGroupOverflow.
+   * Consumers are responsible for slicing to the desired visible count.
    */
-  avatars: XDSAvatarGroupItem[];
+  children: ReactNode;
   /**
-   * Maximum number of avatars to show before overflow.
-   * Remaining avatars are hidden and counted in the overflow indicator.
-   * When not set, all avatars are shown.
-   */
-  maxVisibleCount?: number;
-  /**
-   * Additional count to add to the overflow indicator.
-   * Use when the total count exceeds the rendered avatars
-   * (e.g., server returns "47 participants" but you only pass 5).
-   */
-  overflowCount?: number;
-  /**
-   * Size applied to all avatars.
+   * Size applied to all avatars via context.
    * @default 'small'
    */
   size?: XDSAvatarSize;
-  /**
-   * Callback fired when the overflow indicator is clicked.
-   */
-  onClickOverflow?: () => void;
   /**
    * Test ID for integration testing.
    */
@@ -84,79 +51,29 @@ const styles = stylex.create({
     display: 'inline-flex',
     alignItems: 'center',
   },
-  avatarWrapper: {
-    position: 'relative',
-    borderRadius: radiusVars['--radius-full'],
-    borderWidth: BORDER_WIDTH,
-    borderStyle: 'solid',
-    borderColor: colorVars['--color-background-surface'],
-    backgroundColor: colorVars['--color-background-surface'],
-    boxSizing: 'content-box',
-    lineHeight: 0,
-  },
-  overflow: {
-    position: 'relative',
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    borderRadius: radiusVars['--radius-full'],
-    backgroundColor: colorVars['--color-neutral'],
-    color: colorVars['--color-text-secondary'],
-    fontFamily: typographyVars['--font-family-body'],
-    fontWeight: fontWeightVars['--font-weight-medium'],
-    userSelect: 'none',
-    borderWidth: BORDER_WIDTH,
-    borderStyle: 'solid',
-    borderColor: colorVars['--color-background-surface'],
-    boxSizing: 'content-box',
-  },
-  overflowButton: {
-    cursor: 'pointer',
-    padding: 0,
-  },
-});
-
-const dynamicStyles = stylex.create({
-  overlap: (offset: number) => ({
-    marginInlineStart: offset,
-  }),
-  zIndex: (z: number) => ({
-    zIndex: z,
-  }),
-  size: (s: number) => ({
-    width: s,
-    height: s,
-  }),
-  fontSize: (s: number) => ({
-    fontSize: s * OVERFLOW_FONT_RATIO,
-  }),
 });
 
 /**
  * Stacked avatar display showing multiple avatars overlapping with an
- * overflow count indicator.
+ * optional overflow indicator. Uses a compositional children-based API
+ * so each avatar can carry its own props (status dots, click handlers, etc.).
+ *
+ * Consumers handle slicing — pass only the avatars you want visible,
+ * then add an XDSAvatarGroupOverflow for the "+N" indicator.
  *
  * @example
  * ```
- * <XDSAvatarGroup
- *   size="medium"
- *   maxVisibleCount={3}
- *   avatars={[
- *     {src: '/alice.jpg', name: 'Alice'},
- *     {src: '/bob.jpg', name: 'Bob'},
- *     {src: '/charlie.jpg', name: 'Charlie'},
- *     {src: '/diana.jpg', name: 'Diana'},
- *     {src: '/eve.jpg', name: 'Eve'},
- *   ]}
- * />
+ * <XDSAvatarGroup size="medium">
+ *   {users.slice(0, 3).map(u => (
+ *     <XDSAvatar key={u.id} src={u.src} name={u.name} />
+ *   ))}
+ *   <XDSAvatarGroupOverflow count={users.length - 3} />
+ * </XDSAvatarGroup>
  * ```
  */
 export function XDSAvatarGroup({
-  avatars,
-  maxVisibleCount,
-  overflowCount,
+  children,
   size = 'small',
-  onClickOverflow,
   'data-testid': testId,
   'aria-label': ariaLabel = 'Avatars',
   xstyle,
@@ -164,78 +81,32 @@ export function XDSAvatarGroup({
   style,
   ref,
   ...props
-}: XDSAvatarGroupProps) {
-  const visibleAvatars =
-    maxVisibleCount != null ? avatars.slice(0, maxVisibleCount) : avatars;
-  const hiddenCount =
-    maxVisibleCount != null ? Math.max(0, avatars.length - maxVisibleCount) : 0;
-  const totalOverflow = hiddenCount + (overflowCount ?? 0);
-
+}: XDSAvatarGroupProps): ReactNode {
   const numericSize = resolveSize(size);
   const overlap = Math.round(numericSize * OVERLAP_RATIO);
-  const totalItems = visibleAvatars.length + (totalOverflow > 0 ? 1 : 0);
+
+  const contextValue = useMemo(
+    () => ({size, overlap, numericSize}),
+    [size, overlap, numericSize],
+  );
 
   return (
-    <div
-      ref={ref}
-      role="group"
-      aria-label={ariaLabel}
-      data-testid={testId}
-      {...mergeProps(
-        xdsClassName('avatar-group', {size}),
-        stylex.props(styles.root, xstyle),
-        className,
-        style,
-      )}
-      {...props}>
-      {visibleAvatars.map((avatar, index) => (
-        <div
-          key={avatar.key ?? index}
-          {...stylex.props(
-            styles.avatarWrapper,
-            index > 0 && dynamicStyles.overlap(-overlap),
-            dynamicStyles.zIndex(totalItems - index),
-          )}>
-          <XDSAvatar
-            src={avatar.src}
-            fallbackSrc={avatar.fallbackSrc}
-            name={avatar.name}
-            alt={avatar.alt}
-            size={size}
-          />
-        </div>
-      ))}
-      {totalOverflow > 0 &&
-        (onClickOverflow ? (
-          <button
-            type="button"
-            onClick={onClickOverflow}
-            aria-label={`${totalOverflow} more`}
-            {...stylex.props(
-              styles.overflow,
-              styles.overflowButton,
-              dynamicStyles.overlap(-overlap),
-              dynamicStyles.zIndex(0),
-              dynamicStyles.size(numericSize),
-              dynamicStyles.fontSize(numericSize),
-            )}>
-            +{totalOverflow}
-          </button>
-        ) : (
-          <span
-            role="img"
-            aria-label={`${totalOverflow} more`}
-            {...stylex.props(
-              styles.overflow,
-              dynamicStyles.overlap(-overlap),
-              dynamicStyles.zIndex(0),
-              dynamicStyles.size(numericSize),
-              dynamicStyles.fontSize(numericSize),
-            )}>
-            +{totalOverflow}
-          </span>
-        ))}
-    </div>
+    <XDSAvatarGroupContext.Provider value={contextValue}>
+      <div
+        ref={ref}
+        role="group"
+        aria-label={ariaLabel}
+        data-testid={testId}
+        {...mergeProps(
+          xdsClassName('avatar-group', {size}),
+          stylex.props(styles.root, xstyle),
+          className,
+          style,
+        )}
+        {...props}>
+        {children}
+      </div>
+    </XDSAvatarGroupContext.Provider>
   );
 }
 

--- a/packages/core/src/AvatarGroup/XDSAvatarGroup.tsx
+++ b/packages/core/src/AvatarGroup/XDSAvatarGroup.tsx
@@ -1,0 +1,242 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+'use client';
+
+/**
+ * @file XDSAvatarGroup.tsx
+ * @input Uses React, StyleX, theme tokens, XDSAvatar
+ * @output Exports XDSAvatarGroup component, XDSAvatarGroupProps, XDSAvatarGroupItem types
+ * @position Core implementation; consumed by index.ts
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/AvatarGroup/AvatarGroup.doc.mjs (props table, features)
+ * - /packages/core/src/AvatarGroup/index.ts (exports if types change)
+ * - /apps/storybook/stories/AvatarGroup.stories.tsx (storybook stories)
+ * - /packages/cli/templates/blocks/components/AvatarGroup/ (showcase blocks)
+ */
+
+import type {XDSBaseProps} from '../XDSBaseProps';
+import {XDSAvatar, resolveSize, type XDSAvatarSize} from '../Avatar';
+import * as stylex from '@stylexjs/stylex';
+import {
+  colorVars,
+  typographyVars,
+  fontWeightVars,
+  radiusVars,
+} from '../theme/tokens.stylex';
+import {xdsClassName, mergeProps} from '../utils';
+
+const OVERLAP_RATIO = 0.25;
+const BORDER_WIDTH = 2;
+const OVERFLOW_FONT_RATIO = 0.35;
+
+/**
+ * Data for a single avatar in the group.
+ */
+export interface XDSAvatarGroupItem {
+  /** Primary image source URL. */
+  src?: string;
+  /** Fallback image when primary fails. */
+  fallbackSrc?: string;
+  /** User name for initials and alt text. */
+  name?: string;
+  /** Alt text (falls back to name). */
+  alt?: string;
+  /** Unique key for React reconciliation. Falls back to index if not provided. */
+  key?: string | number;
+}
+
+export interface XDSAvatarGroupProps extends XDSBaseProps<HTMLDivElement> {
+  /** Ref forwarded to the root element. */
+  ref?: React.Ref<HTMLDivElement>;
+  /**
+   * Avatar data to display.
+   */
+  avatars: XDSAvatarGroupItem[];
+  /**
+   * Maximum number of avatars to show before overflow.
+   * Remaining avatars are hidden and counted in the overflow indicator.
+   * When not set, all avatars are shown.
+   */
+  maxVisibleCount?: number;
+  /**
+   * Additional count to add to the overflow indicator.
+   * Use when the total count exceeds the rendered avatars
+   * (e.g., server returns "47 participants" but you only pass 5).
+   */
+  overflowCount?: number;
+  /**
+   * Size applied to all avatars.
+   * @default 'small'
+   */
+  size?: XDSAvatarSize;
+  /**
+   * Callback fired when the overflow indicator is clicked.
+   */
+  onClickOverflow?: () => void;
+  /**
+   * Test ID for integration testing.
+   */
+  'data-testid'?: string;
+}
+
+const styles = stylex.create({
+  root: {
+    display: 'inline-flex',
+    alignItems: 'center',
+  },
+  avatarWrapper: {
+    position: 'relative',
+    borderRadius: radiusVars['--radius-full'],
+    borderWidth: BORDER_WIDTH,
+    borderStyle: 'solid',
+    borderColor: colorVars['--color-background-surface'],
+    backgroundColor: colorVars['--color-background-surface'],
+    boxSizing: 'content-box',
+    lineHeight: 0,
+  },
+  overflow: {
+    position: 'relative',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: radiusVars['--radius-full'],
+    backgroundColor: colorVars['--color-neutral'],
+    color: colorVars['--color-text-secondary'],
+    fontFamily: typographyVars['--font-family-body'],
+    fontWeight: fontWeightVars['--font-weight-medium'],
+    userSelect: 'none',
+    borderWidth: BORDER_WIDTH,
+    borderStyle: 'solid',
+    borderColor: colorVars['--color-background-surface'],
+    boxSizing: 'content-box',
+  },
+  overflowButton: {
+    cursor: 'pointer',
+    padding: 0,
+  },
+});
+
+const dynamicStyles = stylex.create({
+  overlap: (offset: number) => ({
+    marginInlineStart: offset,
+  }),
+  zIndex: (z: number) => ({
+    zIndex: z,
+  }),
+  size: (s: number) => ({
+    width: s,
+    height: s,
+  }),
+  fontSize: (s: number) => ({
+    fontSize: s * OVERFLOW_FONT_RATIO,
+  }),
+});
+
+/**
+ * Stacked avatar display showing multiple avatars overlapping with an
+ * overflow count indicator.
+ *
+ * @example
+ * ```
+ * <XDSAvatarGroup
+ *   size="medium"
+ *   maxVisibleCount={3}
+ *   avatars={[
+ *     {src: '/alice.jpg', name: 'Alice'},
+ *     {src: '/bob.jpg', name: 'Bob'},
+ *     {src: '/charlie.jpg', name: 'Charlie'},
+ *     {src: '/diana.jpg', name: 'Diana'},
+ *     {src: '/eve.jpg', name: 'Eve'},
+ *   ]}
+ * />
+ * ```
+ */
+export function XDSAvatarGroup({
+  avatars,
+  maxVisibleCount,
+  overflowCount,
+  size = 'small',
+  onClickOverflow,
+  'data-testid': testId,
+  'aria-label': ariaLabel = 'Avatars',
+  xstyle,
+  className,
+  style,
+  ref,
+  ...props
+}: XDSAvatarGroupProps) {
+  const visibleAvatars =
+    maxVisibleCount != null ? avatars.slice(0, maxVisibleCount) : avatars;
+  const hiddenCount =
+    maxVisibleCount != null ? Math.max(0, avatars.length - maxVisibleCount) : 0;
+  const totalOverflow = hiddenCount + (overflowCount ?? 0);
+
+  const numericSize = resolveSize(size);
+  const overlap = Math.round(numericSize * OVERLAP_RATIO);
+  const totalItems = visibleAvatars.length + (totalOverflow > 0 ? 1 : 0);
+
+  return (
+    <div
+      ref={ref}
+      role="group"
+      aria-label={ariaLabel}
+      data-testid={testId}
+      {...mergeProps(
+        xdsClassName('avatar-group', {size}),
+        stylex.props(styles.root, xstyle),
+        className,
+        style,
+      )}
+      {...props}>
+      {visibleAvatars.map((avatar, index) => (
+        <div
+          key={avatar.key ?? index}
+          {...stylex.props(
+            styles.avatarWrapper,
+            index > 0 && dynamicStyles.overlap(-overlap),
+            dynamicStyles.zIndex(totalItems - index),
+          )}>
+          <XDSAvatar
+            src={avatar.src}
+            fallbackSrc={avatar.fallbackSrc}
+            name={avatar.name}
+            alt={avatar.alt}
+            size={size}
+          />
+        </div>
+      ))}
+      {totalOverflow > 0 &&
+        (onClickOverflow ? (
+          <button
+            type="button"
+            onClick={onClickOverflow}
+            aria-label={`${totalOverflow} more`}
+            {...stylex.props(
+              styles.overflow,
+              styles.overflowButton,
+              dynamicStyles.overlap(-overlap),
+              dynamicStyles.zIndex(0),
+              dynamicStyles.size(numericSize),
+              dynamicStyles.fontSize(numericSize),
+            )}>
+            +{totalOverflow}
+          </button>
+        ) : (
+          <span
+            role="img"
+            aria-label={`${totalOverflow} more`}
+            {...stylex.props(
+              styles.overflow,
+              dynamicStyles.overlap(-overlap),
+              dynamicStyles.zIndex(0),
+              dynamicStyles.size(numericSize),
+              dynamicStyles.fontSize(numericSize),
+            )}>
+            +{totalOverflow}
+          </span>
+        ))}
+    </div>
+  );
+}
+
+XDSAvatarGroup.displayName = 'XDSAvatarGroup';

--- a/packages/core/src/AvatarGroup/XDSAvatarGroupContext.ts
+++ b/packages/core/src/AvatarGroup/XDSAvatarGroupContext.ts
@@ -1,0 +1,25 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+'use client';
+
+/**
+ * @file XDSAvatarGroupContext.ts
+ * @input None (pure context definition)
+ * @output Exports AvatarGroup context and useXDSAvatarGroup hook
+ * @position Shared context; consumed by children for group-aware styling
+ */
+
+import {createContext, useContext} from 'react';
+import type {XDSAvatarSize} from '../Avatar';
+
+export interface XDSAvatarGroupContextValue {
+  size: XDSAvatarSize;
+  overlap: number;
+  numericSize: number;
+}
+
+export const XDSAvatarGroupContext =
+  createContext<XDSAvatarGroupContextValue | null>(null);
+
+export function useXDSAvatarGroup(): XDSAvatarGroupContextValue | null {
+  return useContext(XDSAvatarGroupContext);
+}

--- a/packages/core/src/AvatarGroup/XDSAvatarGroupOverflow.tsx
+++ b/packages/core/src/AvatarGroup/XDSAvatarGroupOverflow.tsx
@@ -1,0 +1,146 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+'use client';
+
+/**
+ * @file XDSAvatarGroupOverflow.tsx
+ * @input Uses React, StyleX, AvatarGroupContext
+ * @output Exports XDSAvatarGroupOverflow for overflow indicator
+ * @position Slot component used inside XDSAvatarGroup
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/AvatarGroup/AvatarGroup.doc.mjs
+ * - /packages/core/src/AvatarGroup/index.ts
+ * - /packages/cli/templates/blocks/components/AvatarGroup/ (showcase blocks)
+ */
+
+import type {ReactNode} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {
+  colorVars,
+  typographyVars,
+  fontWeightVars,
+  radiusVars,
+} from '../theme/tokens.stylex';
+import {useXDSAvatarGroup} from './XDSAvatarGroupContext';
+
+const BORDER_WIDTH = 2;
+const OVERFLOW_FONT_RATIO = 0.35;
+
+export interface XDSAvatarGroupOverflowProps {
+  /**
+   * The overflow count to display.
+   */
+  count: number;
+
+  /**
+   * Callback fired when the overflow indicator is clicked.
+   * When provided, the indicator renders as a focusable button.
+   */
+  onClick?: () => void;
+
+  /**
+   * Custom content to render instead of the default "+N" label.
+   */
+  children?: ReactNode;
+}
+
+const styles = stylex.create({
+  base: {
+    position: 'relative',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: radiusVars['--radius-full'],
+    backgroundColor: colorVars['--color-neutral'],
+    color: colorVars['--color-text-secondary'],
+    fontFamily: typographyVars['--font-family-body'],
+    fontWeight: fontWeightVars['--font-weight-medium'],
+    userSelect: 'none',
+    borderWidth: BORDER_WIDTH,
+    borderStyle: 'solid',
+    borderColor: colorVars['--color-background-surface'],
+    boxSizing: 'content-box',
+  },
+  button: {
+    cursor: 'pointer',
+    padding: 0,
+  },
+  overlap: {
+    marginInlineStart: 'var(--_avatar-group-overlap)',
+  },
+});
+
+const dynamicStyles = stylex.create({
+  size: (s: number) => ({
+    width: s,
+    height: s,
+  }),
+  fontSize: (s: number) => ({
+    fontSize: s * OVERFLOW_FONT_RATIO,
+  }),
+  overlap: (offset: number) => ({
+    '--_avatar-group-overlap': `${offset}px`,
+  }),
+});
+
+/**
+ * Overflow indicator for XDSAvatarGroup. Shows a "+N" count and
+ * optionally handles clicks.
+ *
+ * @example
+ * ```
+ * <XDSAvatarGroup size="medium">
+ *   {users.slice(0, 3).map(u => (
+ *     <XDSAvatar key={u.id} src={u.src} name={u.name} />
+ *   ))}
+ *   <XDSAvatarGroupOverflow count={users.length - 3} onClick={showAll} />
+ * </XDSAvatarGroup>
+ * ```
+ */
+export function XDSAvatarGroupOverflow({
+  count,
+  onClick,
+  children,
+}: XDSAvatarGroupOverflowProps): ReactNode {
+  const group = useXDSAvatarGroup();
+  const numericSize = group?.numericSize ?? 36;
+  const overlap = group?.overlap ?? 0;
+
+  const label = `${count} more`;
+  const content = children ?? `+${count}`;
+
+  if (onClick) {
+    return (
+      <button
+        type="button"
+        onClick={onClick}
+        aria-label={label}
+        {...stylex.props(
+          styles.base,
+          styles.button,
+          styles.overlap,
+          dynamicStyles.size(numericSize),
+          dynamicStyles.fontSize(numericSize),
+          dynamicStyles.overlap(-overlap),
+        )}>
+        {content}
+      </button>
+    );
+  }
+
+  return (
+    <span
+      aria-label={label}
+      {...stylex.props(
+        styles.base,
+        styles.overlap,
+        dynamicStyles.size(numericSize),
+        dynamicStyles.fontSize(numericSize),
+        dynamicStyles.overlap(-overlap),
+      )}>
+      {content}
+    </span>
+  );
+}
+
+XDSAvatarGroupOverflow.displayName = 'XDSAvatarGroupOverflow';

--- a/packages/core/src/AvatarGroup/index.ts
+++ b/packages/core/src/AvatarGroup/index.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+'use client';
+
+/**
+ * @file index.ts
+ * @input Imports XDSAvatarGroup component and types from XDSAvatarGroup.tsx
+ * @output Exports XDSAvatarGroup, XDSAvatarGroupProps, XDSAvatarGroupItem
+ * @position Component entry point; re-exported by /packages/core/src/index.ts
+ *
+ * SYNC: When modified, update this header and /packages/core/src/AvatarGroup/AvatarGroup.doc.mjs
+ */
+
+export {XDSAvatarGroup} from './XDSAvatarGroup';
+export type {XDSAvatarGroupProps, XDSAvatarGroupItem} from './XDSAvatarGroup';

--- a/packages/core/src/AvatarGroup/index.ts
+++ b/packages/core/src/AvatarGroup/index.ts
@@ -3,12 +3,17 @@
 
 /**
  * @file index.ts
- * @input Imports XDSAvatarGroup component and types from XDSAvatarGroup.tsx
- * @output Exports XDSAvatarGroup, XDSAvatarGroupProps, XDSAvatarGroupItem
+ * @input Imports from XDSAvatarGroup.tsx, XDSAvatarGroupOverflow.tsx, XDSAvatarGroupContext.ts
+ * @output Exports XDSAvatarGroup, XDSAvatarGroupOverflow, context hook, and types
  * @position Component entry point; re-exported by /packages/core/src/index.ts
  *
  * SYNC: When modified, update this header and /packages/core/src/AvatarGroup/AvatarGroup.doc.mjs
  */
 
 export {XDSAvatarGroup} from './XDSAvatarGroup';
-export type {XDSAvatarGroupProps, XDSAvatarGroupItem} from './XDSAvatarGroup';
+export type {XDSAvatarGroupProps} from './XDSAvatarGroup';
+
+export {XDSAvatarGroupOverflow} from './XDSAvatarGroupOverflow';
+export type {XDSAvatarGroupOverflowProps} from './XDSAvatarGroupOverflow';
+
+export {useXDSAvatarGroup} from './XDSAvatarGroupContext';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -18,6 +18,7 @@ export type {XDSBaseProps} from './XDSBaseProps';
 export * from './AppShell';
 export * from './AspectRatio';
 export * from './Avatar';
+export * from './AvatarGroup';
 export * from './Badge';
 export * from './Banner';
 export * from './Blockquote';


### PR DESCRIPTION
## Summary

- Adds `XDSAvatarGroup` component — stacked avatar display with overlapping layout and `+N` overflow indicator
- Data-driven API via `avatars` array prop (matching `XDSSelector` pattern), with `maxVisibleCount`, `overflowCount`, `size`, and `onClickOverflow` props
- Includes unit tests (14 passing), Storybook stories with autodocs, component docs (en/zh/dense), and showcase block

It seemed nicer to have the data API rather than requiring XDSAvatar children (has same awkward issue with nested children or other components)

Closes #182

## Test plan

- [x] `yarn build` succeeds
- [x] `yarn test packages/core/src/AvatarGroup/` — 14 tests pass
- [x] `yarn lint` — no new errors in AvatarGroup files
- [x] Storybook stories render at `Core/AvatarGroup` (Default, WithMax, WithOverflowCount, WithClickableOverflow, AllSizes, InitialsFallback)
- [x] Visual review in Storybook: avatars overlap correctly at each size, overflow indicator shows correct count, clickable overflow renders as button