### PR TITLE
fix(storybook): resolve dev server spinner by disabling holdUntilCrawlEnd

### DIFF
--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -38,6 +38,13 @@ const config: StorybookConfig = {
 
     return {
       ...config,
+      optimizeDeps: {
+        ...config.optimizeDeps,
+        // Vite waits for all module transforms to finish before committing
+        // pre-bundled deps. The StyleX Babel plugin stalls on some XDS core
+        // components, so the crawl never completes and deps are never served.
+        holdUntilCrawlEnd: false,
+      },
       plugins: [
         {
           name: 'xds-color-scheme',


### PR DESCRIPTION
I am having this issue where storybook never loads:
<img width="2480" height="1600" alt="image" src="https://github.com/user-attachments/assets/ef5fc6fb-03c3-4a93-9c7a-c5300b254208" />

Claude suggests this fix. It does fix the issue, though I admit I'm not familiar with exactly what this option is doing.

Vite default holdUntilCrawlEnd: true delays committing pre-bundled deps until every module transform completes. The StyleX Babel plugin stalls on several XDS core components, so the crawl never finishes, the deps/ directory is never created, and the preview iframe hangs on a spinner until timeout.