### PR TITLE
fix(DropdownMenu): light-dismiss + click-toggle race on touch browsers

### DIFF
--- a/.changeset/dropdown-light-dismiss-race.md
+++ b/.changeset/dropdown-light-dismiss-race.md
@@ -1,0 +1,5 @@
+---
+'@xds/core': patch
+---
+
+Fix XDSDropdownMenu light-dismiss + click-toggle race: on iOS Safari (and other touch browsers where pointerdown fires light-dismiss before the trigger's click event), tapping the trigger to close an open menu would close and then immediately re-open on the same tap. Stamp `lastHideTimeRef` whenever the menu is hidden and short-circuit `handleButtonClick` if it fires within 50ms of that stamp.

--- a/packages/core/src/DropdownMenu/XDSDropdownMenu.test.tsx
+++ b/packages/core/src/DropdownMenu/XDSDropdownMenu.test.tsx
@@ -8,7 +8,7 @@
  */
 
 import {describe, it, expect, vi, beforeEach} from 'vitest';
-import {render, screen} from '@testing-library/react';
+import {render, screen, fireEvent} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {XDSDropdownMenu} from './XDSDropdownMenu';
 import {XDSDropdownMenuItem} from './XDSDropdownMenuItem';
@@ -107,6 +107,28 @@ describe('XDSDropdownMenu', () => {
       />,
     );
     expect(screen.getByTestId('my-dropdown')).toBeInTheDocument();
+  });
+});
+
+describe('XDSDropdownMenu light-dismiss race', () => {
+  it('does not re-open the menu when a click follows a hide within the guard window', () => {
+    // Reproduces the iOS Safari race: pointerdown fires light-dismiss before
+    // the subsequent click on the trigger; without the guard, the click would
+    // immediately re-open the menu in the same tap.
+    render(
+      <XDSDropdownMenu
+        button={{label: 'Actions'}}
+        items={[{label: 'Edit'}]}
+        data-testid="xds-dropdown-menu"
+      />,
+    );
+
+    const trigger = screen.getByTestId('xds-dropdown-menu');
+    fireEvent.click(trigger); // open
+    fireEvent.click(trigger); // close (stamps guard)
+    fireEvent.click(trigger); // would re-open without guard
+    expect(HTMLElement.prototype.showPopover).toHaveBeenCalledTimes(1);
+    expect(HTMLElement.prototype.hidePopover).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/core/src/DropdownMenu/XDSDropdownMenu.tsx
+++ b/packages/core/src/DropdownMenu/XDSDropdownMenu.tsx
@@ -192,8 +192,14 @@ export function XDSDropdownMenu({
   const isControlled = controlledIsOpen !== undefined;
   const isOpen = isControlled ? controlledIsOpen : internalIsOpen;
 
+  // Track when the menu was last hidden so a near-simultaneous trigger
+  // click — e.g. on iOS Safari where pointerdown fires light-dismiss
+  // before the trigger's click event — can't immediately re-open it.
+  const lastHideTimeRef = useRef(0);
+
   // Close menu + return focus to trigger
   const handleLayerHide = useCallback(() => {
+    lastHideTimeRef.current = Date.now();
     if (isControlled) {
       onOpenChange?.(false);
     } else {
@@ -279,6 +285,12 @@ export function XDSDropdownMenu({
   }, [popover, hasAutoFocus, focusFirst]);
 
   const handleButtonClick = useCallback(() => {
+    // If the menu was just closed by light dismiss (e.g. iOS Safari fires
+    // pointerdown → hide before the trigger's click), the click would
+    // otherwise immediately re-open it. Short-circuit within the guard window.
+    if (Date.now() - lastHideTimeRef.current < 50) {
+      return;
+    }
     onClick?.();
     if (isControlled) {
       onOpenChange?.(!controlledIsOpen);


### PR DESCRIPTION
## Summary

On iOS Safari (and other touch browsers where `pointerdown` fires light-dismiss before the trigger's `click` event), tapping the `XDSDropdownMenu` trigger to close an open menu would close and then immediately re-open on the same tap. The hide flows through `useXDSPopover`'s `onHide` first, then the click hits `handleButtonClick`, which reads `popover.isOpen=false` and toggles it back to true.

Mirror the existing 50ms hide-time guard in `XDSPopover` (lines 268, 274–277, 290–296 — same race, same fix) into `XDSDropdownMenu`: stamp `lastHideTimeRef` in `handleLayerHide`, then short-circuit `handleButtonClick` if it fires within 50ms of that stamp.

Also fixes `XDSMoreMenu` since it wraps `XDSDropdownMenu`.

This ports the equivalent internal fix (Meta D104032592 in fbsource, which patches `XDSInternalPopoverMenu.react.js` — the shared internal layer behind both `XDSDropdownMenu` and `XDSPopoverMenu`) to the public xds repo. Here, the internal layer is `useXDSPopover`, but `XDSDropdownMenu` calls into it directly with its own toggle logic, so the guard goes alongside that logic. `XDSPopover` already has the equivalent guard for the same race.

## Test Plan

Added a regression test in `XDSDropdownMenu.test.tsx` that fires open → close → click and asserts the menu does not re-open (`showPopover`/`hidePopover` each called exactly once).

```
$ yarn test packages/core/src/DropdownMenu/XDSDropdownMenu.test.tsx
 Test Files  1 passed (1)
      Tests  29 passed (29)

$ yarn test packages/core/src/Popover/XDSPopover.test.tsx packages/core/src/MoreMenu/XDSMoreMenu.test.tsx
 Test Files  2 passed (2)
      Tests  31 passed (31)

$ yarn workspace @xds/core build
✅ Build success
```

ESLint clean on the changed files (one pre-existing unused-`container` warning in an unrelated test left as-is).
