### PR TITLE
Fix doc drift, add SECURITY.md, lock yarn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,7 +54,7 @@ apps/example-nextjs-tailwind/.next
 .parity-test-results.json
 .worktree-parity-test
 .npmrc
--e 
+
 # Patch files
 *.patch
 *.rej

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,7 +93,6 @@ yarn dev
 ```
 xds/
 ├── apps/
-│   ├── docs/           # Documentation site
 │   ├── storybook/      # Component playground (localhost:6006)
 │   └── sandbox/        # Development testing
 │
@@ -101,12 +100,10 @@ xds/
 │   ├── core/           # Core components (Button, Input, etc.)
 │   ├── cli/            # CLI tooling (npx xds)
 │   ├── lab/            # Experimental components (not yet stable)
-│   └── themes/         # Theme presets (default, neutral, brutalist)
+│   └── themes/         # Theme presets (default, neutral, daily, and more)
 │
-├── internal/           # Internal tooling (not published)
-│   └── test-utils/     # Shared test helpers
-│
-└── e2e/                # End-to-end tests
+└── internal/           # Internal tooling (not published)
+    └── test-utils/     # Shared test helpers
 ```
 
 ## Development Workflow
@@ -242,9 +239,6 @@ yarn workspace @xds/core test
 
 # With coverage
 yarn test:coverage
-
-# Screenshot tests
-yarn test:screenshots
 ```
 
 ### Test Structure
@@ -322,3 +316,19 @@ This creates a file in `.changeset/` — commit it with your PR.
 - Rebuild the package: `yarn workspace @xds/core build`
 - Hard refresh browser: Cmd+Shift+R (Mac) or Ctrl+Shift+R (Windows)
 - Clear Storybook cache: Remove `apps/storybook/node_modules/.cache`
+
+## Contributor License Agreement ("CLA")
+
+In order to accept your pull request, we need you to submit a CLA. You only need
+to do this once to work on any of Meta's open source projects.
+
+Complete your CLA here: <https://code.facebook.com/cla>
+
+## Issues
+
+We use GitHub issues to track public bugs. Please ensure your description is
+clear and has sufficient instructions to be able to reproduce the issue.
+
+Meta has a [bounty program](https://bugbounty.meta.com/) for the safe disclosure
+of security bugs. In those cases, please go through the process outlined on that
+page and do not file a public issue.

--- a/README.md
+++ b/README.md
@@ -77,7 +77,6 @@ Battle-tested design solutions for common interactions and workflows: table page
 | `apps/`     | Example apps and Storybook                                  |
 | `packages/` | Published packages: core, cli, themes                       |
 | `internal/` | Internal tooling: test utilities, eslint plugin, vibe tests |
-| `e2e/`      | End-to-end tests (Playwright)                               |
 
 ## Contributing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,29 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+The XDS team takes security seriously. If you discover a security issue,
+please bring it to our attention right away.
+
+**Please do not file a public issue.** Public issues are visible to anyone, and
+disclosing a vulnerability before it is fixed puts XDS users at risk.
+
+### Meta Bug Bounty
+
+Meta has a [bounty program](https://bugbounty.meta.com/) for the safe disclosure
+of security bugs. Please report security issues there. We will respond as quickly
+as possible.
+
+### What to Include
+
+When reporting, please include as much information as practical:
+
+- A description of the issue and its impact
+- Steps to reproduce, or a proof-of-concept
+- Affected versions or packages
+- Any potential mitigations you've identified
+
+## Supported Versions
+
+Only the latest released version of each `@xds/*` package receives security
+updates. Please keep your dependencies current.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "internal/*"
   ],
   "scripts": {
+    "preinstall": "npx only-allow yarn",
     "build": "yarn workspace @xds/build build && yarn workspace @xds/core build && yarn workspace @xds/vega build && yarn workspace @xds/theme-default build && yarn workspace @xds/theme-neutral build && yarn workspace @xds/theme-brutalist build && yarn workspace @xds/theme-daily build && yarn workspace @xds/theme-matcha build && yarn workspace @xds/theme-stone build && yarn workspace @xds/theme-gothic build && yarn workspace @xds/theme-chocolate build && yarn workspace @xds/theme-y2k build && yarn workspace @xds/theme-butter build",
     "dev": "yarn workspace @xds/storybook dev",
     "test": "vitest run",
@@ -22,7 +23,6 @@
     "lint:strict": "yarn check:repo && XDS_STRICT_LINT=1 eslint .",
     "storybook": "yarn workspace @xds/storybook dev",
     "storybook:build": "yarn workspace @xds/storybook build",
-    "docs": "yarn workspace @xds/docs dev",
     "sync:exports": "node scripts/sync-exports.js",
     "sync:exports:check": "node scripts/sync-exports.js --check",
     "xds": "yarn workspace @xds/cli xds",


### PR DESCRIPTION
Documentation drift fixes (README and CONTRIBUTING described things that do not exist):

- Remove `e2e/` row from README Project Structure (no e2e/ directory)
- Remove `e2e/` from CONTRIBUTING Project Structure tree (same)
- Remove `apps/docs/` from CONTRIBUTING Project Structure (no @xds/docs workspace exists; the corresponding root `yarn docs` script is also removed)
- Update CONTRIBUTING themes line: 12 themes ship today, not 3
- Remove `yarn test:screenshots` reference from CONTRIBUTING (no such script in any package.json)

Safety nets:

- Add "preinstall": "npx only-allow yarn" to root package.json so an accidental `npm install` from a contributor cannot regenerate package-lock.json (which PR #1796 deliberately removed and gitignored).
- Clean stray `-e ` line in .gitignore (artifact from a prior macOS echo).

Legal & contribution scaffolding:

- Add CLA section to CONTRIBUTING.md pointing at https://code.facebook.com/cla (matches Lexical's wording). Without this, the first external PR cannot be legally merged.
- Add Issues + Meta Bug Bounty section to CONTRIBUTING.md (Lexical pattern).
- Add SECURITY.md pointing to https://bugbounty.meta.com/ for vulnerability disclosure. GitHub Community Standards expects this; security researchers use it as the authoritative disclosure channel.