### PR TITLE
scope workflow permissions per-job (least-privilege)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,7 @@ on:
     branches: ["main"]
   merge_group:
 
-permissions:
-  contents: write
-  pages: write
-  id-token: write
-  pull-requests: write
-  actions: read
+permissions: {}
 
 concurrency:
   group: "ci-${{ github.event.merge_group.head_sha || github.head_ref }}"
@@ -29,6 +24,8 @@ jobs:
   check-scope:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       docsite_only: ${{ steps.scope.outputs.docsite_only }}
     steps:
@@ -57,6 +54,8 @@ jobs:
   # Docsite data extraction tests — always runs, fast (~2s)
   docsite-test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
 
@@ -76,6 +75,8 @@ jobs:
     needs: [check-scope]
     if: github.event_name == 'pull_request' && needs.check-scope.outputs.docsite_only != 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       has_components: ${{ steps.check.outputs.has_components }}
     steps:
@@ -95,6 +96,8 @@ jobs:
   test:
     needs: [check-scope]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Skip for docsite-only changes
         if: needs.check-scope.outputs.docsite_only == 'true'
@@ -132,6 +135,8 @@ jobs:
   build:
     needs: [check-scope]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       storybook_url: ${{ steps.urls.outputs.storybook_url }}
       short_hash: ${{ steps.urls.outputs.short_hash }}
@@ -253,6 +258,8 @@ jobs:
     if: github.event_name == 'pull_request' && needs.check-scope.outputs.docsite_only != 'true'
     needs: [build, check-scope]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     concurrency:
       group: "pr-preview-${{ needs.build.outputs.pr_number }}"
       cancel-in-progress: true
@@ -318,6 +325,9 @@ jobs:
     if: github.event_name == 'pull_request' && needs.check-scope.outputs.docsite_only != 'true'
     needs: [build, check-scope]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -390,6 +400,8 @@ jobs:
     needs: [build, check-components]
     if: github.event_name == 'pull_request' && needs.check-components.outputs.has_components == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -434,6 +446,9 @@ jobs:
     needs: [build, check-components, pr-a11y]
     if: always() && github.event_name == 'pull_request' && needs.build.result == 'success' && needs.check-components.outputs.has_components == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/cleanup-previews.yml
+++ b/.github/workflows/cleanup-previews.yml
@@ -15,13 +15,14 @@ on:
         default: false
         type: boolean
 
-permissions:
-  contents: write
-  pull-requests: read
+permissions: {}
 
 jobs:
   cleanup:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
     steps:
       - name: Checkout gh-pages
         uses: actions/checkout@v6

--- a/.github/workflows/cli-smoke-test.yml
+++ b/.github/workflows/cli-smoke-test.yml
@@ -11,8 +11,7 @@ on:
       - "apps/docsite/**"
   merge_group:
 
-permissions:
-  contents: read
+permissions: {}
 
 concurrency:
   group: "cli-smoke-${{ github.event.merge_group.head_sha || github.head_ref }}"
@@ -21,6 +20,8 @@ concurrency:
 jobs:
   smoke-test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/codemod-verify.yml
+++ b/.github/workflows/codemod-verify.yml
@@ -19,9 +19,7 @@ on:
     paths:
       - "packages/cli/src/codemods/**"
 
-permissions:
-  contents: read
-  pull-requests: write
+permissions: {}
 
 concurrency:
   group: "codemod-verify-${{ github.head_ref }}"
@@ -30,6 +28,9 @@ concurrency:
 jobs:
   verify-codemods:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout PR
         uses: actions/checkout@v6

--- a/.github/workflows/codeowner-gate.yml
+++ b/.github/workflows/codeowner-gate.yml
@@ -19,14 +19,15 @@ on:
   pull_request_review:
     types: [submitted]
 
-permissions:
-  checks: write
-  pull-requests: read
-  contents: read
+permissions: {}
 
 jobs:
   codeowner-gate:
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      pull-requests: read
+      contents: read
     steps:
       - name: Checkout CODEOWNERS and DESIGNOWNERS
         uses: actions/checkout@v6

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,10 +22,7 @@ on:
     branches: ["main"]
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pages: write
-  id-token: write
+permissions: {}
 
 concurrency:
   group: "pages-deploy"
@@ -36,6 +33,8 @@ jobs:
   # Fails if exports are stale — run `node scripts/sync-exports.js` locally to fix.
   sync-exports:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
 
@@ -45,6 +44,8 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
         with:
@@ -65,6 +66,8 @@ jobs:
     needs: test
     if: always() && !cancelled() && needs.test.result == 'success'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -258,6 +261,8 @@ jobs:
     needs: test
     if: always() && !cancelled() && needs.test.result == 'success'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -290,6 +295,8 @@ jobs:
     needs: test
     if: always() && !cancelled() && needs.test.result == 'success'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/hardening-issue.yml
+++ b/.github/workflows/hardening-issue.yml
@@ -13,15 +13,16 @@ on:
     types: [closed]
     branches: [main]
 
-permissions:
-  issues: write
-  contents: read
-  pull-requests: read
+permissions: {}
 
 jobs:
   create-hardening-issues:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
+      pull-requests: read
     steps:
       - name: Detect new components and create hardening issues
         uses: actions/github-script@v9

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,8 @@ on:
   pull_request:
     branches: [main]
 
+permissions: {}
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/prune-branches.yml
+++ b/.github/workflows/prune-branches.yml
@@ -9,13 +9,14 @@ on:
     - cron: "0 6 * * *" # daily at 6am UTC
   workflow_dispatch: # manual trigger
 
-permissions:
-  contents: write
-  pull-requests: read
+permissions: {}
 
 jobs:
   prune:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/redeploy-preview.yml
+++ b/.github/workflows/redeploy-preview.yml
@@ -16,12 +16,7 @@ on:
         required: true
         type: string
 
-permissions:
-  contents: write
-  pages: write
-  id-token: write
-  pull-requests: read
-  actions: read
+permissions: {}
 
 concurrency:
   group: "pr-preview-${{ github.event.inputs.pr_number }}"
@@ -30,6 +25,10 @@ concurrency:
 jobs:
   redeploy-preview:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+      actions: read
 
     env:
       PR_NUMBER: ${{ github.event.inputs.pr_number }}

--- a/.github/workflows/vibe-screenshots.yml
+++ b/.github/workflows/vibe-screenshots.yml
@@ -29,13 +29,14 @@ concurrency:
   group: vibe-screenshots-${{ github.run_id }}
   cancel-in-progress: false
 
-permissions:
-  contents: write
+permissions: {}
 
 jobs:
   build-previews:
     name: Build Previews
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -74,6 +75,8 @@ jobs:
     name: Capture Screenshots
     needs: build-previews
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -121,6 +124,8 @@ jobs:
     needs: screenshot
     if: ${{ github.event.inputs.deploy_to_gh_pages != 'false' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout gh-pages
         uses: actions/checkout@v6


### PR DESCRIPTION
Adopts the OSSF Scorecard: every workflow declares `permissions: {}` at the top (deny-by-default) and elevates permissions only on the specific jobs that need them. Eliminates two unused permissions (`pages: write`, `id-token: write`) that were declared workflow-wide in ci.yml, deploy.yml, and redeploy-preview.yml but consumed by no job (XDS uses gh-pages branch via raw git push, not the GitHub Pages deploy API; OIDC is not used for any publish).

The most material change is in ci.yml. Previously, all 10 jobs inherited `contents: write`, `pages: write`, `id-token: write`, `pull-requests: write` at the workflow level — including jobs that run PR-author code (test, build, pr-a11y, docsite-test). After this change, those jobs run with no write permissions; only deploy-preview retains `contents: write` (needed to push the preview to gh-pages branch) and the two pr-comment jobs retain `pull-requests: write` (needed to write the PR comment). This is the canonical mitigation for the tj-actions/changed-files supply-chain attack class.

Per-workflow summary:

  ci.yml                  WL: deny-all. Per-job: deploy-preview gets
                          contents:write; pr-comment(-update) get
                          pull-requests:write. Other 7 jobs run
                          read-only.

  deploy.yml              WL: deny-all. Per-job: deploy gets
                          contents:write. publish/canary jobs use
                          METACCIO_PUBLISH_TOKEN env-var only — no
                          GitHub-level write needed.

  redeploy-preview.yml    WL: deny-all. Per-job: contents:write +
                          pull-requests:read + actions:read on the
                          single redeploy-preview job.

  vibe-screenshots.yml    WL: deny-all. Per-job: deploy-screenshots
                          gets contents:write. build-previews and
                          screenshot run read-only.

  cleanup-previews.yml    WL: deny-all. Per-job scoping (no semantic
                          change — same perms, just scoped).
  prune-branches.yml      Same — per-job scoping, no semantic change.
  hardening-issue.yml     Same — per-job scoping, no semantic change.
  codeowner-gate.yml      Same — per-job scoping, no semantic change.
  codemod-verify.yml      Same — per-job scoping, no semantic change.
  cli-smoke-test.yml      Same — per-job scoping, no semantic change.
  lint.yml                Add explicit deny-all at workflow level for
                          OSSF Scorecard signal; no functional change.
