### PR TITLE
fix(ChartV2): add _isTopOfStack to SeriesDef interface

### DIFF
--- a/packages/lab/src/ChartV2/types.ts
+++ b/packages/lab/src/ChartV2/types.ts
@@ -52,6 +52,8 @@ export interface SeriesDef {
   readonly key: string;
   /** Data keys this series reads from — used to compute y domain */
   readonly dataKeys: string[];
+  /** Whether this series is the topmost in its stack (set during layout) */
+  _isTopOfStack?: boolean;
   /** Layout hints the chart root uses for cross-series coordination */
   readonly layout: {
     /** Stack group — series with same stack accumulate */


### PR DESCRIPTION
The grouped stacked bar chart feature (#2162) assigns `_isTopOfStack` on `SeriesDef` during the layout pass, but the property was never declared on the interface — causing a type error in strict builds:

```
Property '_isTopOfStack' does not exist on type 'SeriesDef'.
```

Adds the optional property to the interface.