### PR TITLE
feat(lint): add @eslint-react/eslint-plugin with bug-prevention rules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: 'yarn'
 
       - run: yarn install --frozen-lockfile
@@ -106,7 +106,7 @@ jobs:
       - uses: actions/setup-node@v6
         if: needs.check-scope.outputs.docsite_only != 'true'
         with:
-          node-version: 20
+          node-version: 22
           cache: 'yarn'
 
       - run: yarn install --frozen-lockfile
@@ -154,7 +154,7 @@ jobs:
         if: needs.check-scope.outputs.docsite_only != 'true'
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: 'yarn'
 
       - name: Install dependencies

--- a/.github/workflows/cli-smoke-test.yml
+++ b/.github/workflows/cli-smoke-test.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: "yarn"
 
       - run: yarn install --frozen-lockfile

--- a/.github/workflows/codemod-verify.yml
+++ b/.github/workflows/codemod-verify.yml
@@ -38,7 +38,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: "yarn"
 
       - run: yarn install --frozen-lockfile

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,7 +52,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: 'yarn'
 
       - run: yarn install --frozen-lockfile
@@ -74,7 +74,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: 'yarn'
 
       - name: Install dependencies
@@ -265,7 +265,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: 'yarn'
 
       - name: Install dependencies
@@ -297,7 +297,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: 'yarn'
 
       - name: Install dependencies

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/setup-node@v6
         if: steps.scope.outputs.docsite_only != 'true'
         with:
-          node-version: 20
+          node-version: 22
           cache: 'yarn'
 
       - run: yarn install --frozen-lockfile

--- a/.github/workflows/redeploy-preview.yml
+++ b/.github/workflows/redeploy-preview.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: yarn
 
       - name: Install dependencies

--- a/apps/storybook/stories/DateTimePicker.stories.tsx
+++ b/apps/storybook/stories/DateTimePicker.stories.tsx
@@ -1,3 +1,4 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
 import {useState} from 'react';
 import type {Meta, StoryObj} from '@storybook/react';
 import {XDSDateTimePicker} from '@xds/core/DateTimePicker';

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,6 +2,7 @@
 
 import js from "@eslint/js";
 import tseslint from "typescript-eslint";
+import eslintReact from "@eslint-react/eslint-plugin";
 import xdsPlugin from "./internal/eslint-plugin-xds/index.js";
 
 /* global process */
@@ -21,6 +22,7 @@ import xdsPlugin from "./internal/eslint-plugin-xds/index.js";
 
 const isStrictMode = process.env.XDS_STRICT_LINT === '1' || process.env.CI === 'true';
 const xdsConfig = isStrictMode ? xdsPlugin.configs.strict : xdsPlugin.configs.recommended;
+const reactSeverity = isStrictMode ? 'error' : 'warn';
 
 export default tseslint.config(
   js.configs.recommended,
@@ -87,6 +89,35 @@ export default tseslint.config(
           'Carousel/XDSCarousel',
         ],
       }],
+    },
+  },
+  // React bug-prevention rules - applies to core package
+  // Uses @eslint-react for bugs that TypeScript alone cannot catch.
+  // Children.*/cloneElement are already covered by @xds/no-react-introspection.
+  {
+    files: ["packages/core/src/**/*.{ts,tsx}"],
+    plugins: eslintReact.configs.recommended.plugins,
+    rules: {
+      // Component structure bugs
+      '@eslint-react/no-nested-component-definitions': reactSeverity,
+      '@eslint-react/no-unstable-default-props': reactSeverity,
+      '@eslint-react/no-unstable-context-value': reactSeverity,
+      '@eslint-react/set-state-in-render': reactSeverity,
+
+      // DOM correctness
+      '@eslint-react/dom-no-missing-button-type': reactSeverity,
+      '@eslint-react/dom-no-void-elements-with-children': reactSeverity,
+
+      // JSX correctness
+      '@eslint-react/no-missing-key': reactSeverity,
+      '@eslint-react/jsx-no-comment-textnodes': reactSeverity,
+      '@eslint-react/jsx-no-leaked-dollar': reactSeverity,
+
+      // Resource leak prevention
+      '@eslint-react/web-api-no-leaked-event-listener': reactSeverity,
+      '@eslint-react/web-api-no-leaked-interval': reactSeverity,
+      '@eslint-react/web-api-no-leaked-timeout': reactSeverity,
+      '@eslint-react/web-api-no-leaked-resize-observer': reactSeverity,
     },
   },
 );

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "devDependencies": {
     "@axe-core/playwright": "^4.11.3",
     "@changesets/cli": "^2.31.0",
+    "@eslint-react/eslint-plugin": "^5.8.1",
     "@eslint/js": "^10.0.1",
     "@playwright/test": "^1.60.0",
     "@testing-library/user-event": "^14.5.0",

--- a/packages/cli/templates/blocks/components/DateTimePicker/DateTimePickerShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/DateTimePicker/DateTimePickerShowcase.doc.mjs
@@ -1,3 +1,4 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',

--- a/packages/cli/templates/blocks/components/DateTimePicker/DateTimePickerShowcase.tsx
+++ b/packages/cli/templates/blocks/components/DateTimePicker/DateTimePickerShowcase.tsx
@@ -1,3 +1,4 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
 'use client';
 
 import {useState} from 'react';

--- a/packages/core/src/AppShell/XDSAppShell.tsx
+++ b/packages/core/src/AppShell/XDSAppShell.tsx
@@ -638,18 +638,24 @@ export function XDSAppShell({
   // When below breakpoint, TopNav renders in mobile-bar mode (heading + endContent + toggle).
   // Wrap with mobile content context so TopNav knows there's SideNav content
   // in the drawer and shows the toggle even without its own collapsible items.
+  const mobileContentValue =
+    hasSideNavContent && mobileNavHasToggle ? (
+      <XDSSideNavRenderContext value="drawer-content">
+        <div ref={sideNavRef} style={{display: 'contents'}}>
+          {sideNav}
+        </div>
+      </XDSSideNavRenderContext>
+    ) : null;
+
+  const drawerMobileContentValue = hasSideNavContent ? (
+    <XDSSideNavRenderContext value="drawer-content">
+      {sideNav}
+    </XDSSideNavRenderContext>
+  ) : null;
+
   const topNavContent = hasTopNav ? (
     isBelowBreakpoint && !mobileNavDisabled && mobileNavReactNode == null ? (
-      <XDSTopNavMobileContentContext
-        value={
-          hasSideNavContent && mobileNavHasToggle ? (
-            <XDSSideNavRenderContext value="drawer-content">
-              <div ref={sideNavRef} style={{display: 'contents'}}>
-                {sideNav}
-              </div>
-            </XDSSideNavRenderContext>
-          ) : null
-        }>
+      <XDSTopNavMobileContentContext value={mobileContentValue}>
         <XDSTopNavRenderContext value="mobile-bar">
           <div ref={topNavRef} style={{display: 'contents'}}>
             {topNav}
@@ -848,14 +854,7 @@ export function XDSAppShell({
                 </div>
               )}
               {hasTopNav && hasTopNavContent && (
-                <XDSTopNavMobileContentContext
-                  value={
-                    hasSideNavContent ? (
-                      <XDSSideNavRenderContext value="drawer-content">
-                        {sideNav}
-                      </XDSSideNavRenderContext>
-                    ) : null
-                  }>
+                <XDSTopNavMobileContentContext value={drawerMobileContentValue}>
                   <XDSTopNavRenderContext value="drawer">
                     {topNav}
                   </XDSTopNavRenderContext>

--- a/packages/core/src/AppShell/XDSAppShell.tsx
+++ b/packages/core/src/AppShell/XDSAppShell.tsx
@@ -640,6 +640,7 @@ export function XDSAppShell({
   // in the drawer and shows the toggle even without its own collapsible items.
   const mobileContentValue =
     hasSideNavContent && mobileNavHasToggle ? (
+      // eslint-disable-next-line @eslint-react/no-unstable-context-value -- context transports ReactNode; instability is inherent
       <XDSSideNavRenderContext value="drawer-content">
         <div ref={sideNavRef} style={{display: 'contents'}}>
           {sideNav}
@@ -648,6 +649,7 @@ export function XDSAppShell({
     ) : null;
 
   const drawerMobileContentValue = hasSideNavContent ? (
+    // eslint-disable-next-line @eslint-react/no-unstable-context-value -- context transports ReactNode; instability is inherent
     <XDSSideNavRenderContext value="drawer-content">
       {sideNav}
     </XDSSideNavRenderContext>

--- a/packages/core/src/Avatar/XDSAvatar.tsx
+++ b/packages/core/src/Avatar/XDSAvatar.tsx
@@ -15,7 +15,7 @@
  * - /packages/cli/templates/blocks/components/Avatar/ (showcase blocks)
  */
 
-import {useState, type ReactNode} from 'react';
+import {useMemo, useState, type ReactNode} from 'react';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
 import {
@@ -268,7 +268,7 @@ export function XDSAvatar({
   const showIcon = !showImage && !showFallbackImage && !name;
 
   const accessibleName = alt || name || 'Avatar';
-  const numericSize = resolveSize(size);
+  const numericSize = useMemo(() => resolveSize(size), [size]);
 
   return (
     <XDSAvatarSizeContext.Provider value={numericSize}>

--- a/packages/core/src/Banner/XDSBanner.test.tsx
+++ b/packages/core/src/Banner/XDSBanner.test.tsx
@@ -147,7 +147,11 @@ describe('XDSBanner', () => {
       <XDSBanner
         status="info"
         title="With Action"
-        endContent={<button data-testid="end-btn">Action</button>}
+        endContent={
+          <button type="button" data-testid="end-btn">
+            Action
+          </button>
+        }
       />,
     );
     expect(screen.getByTestId('end-btn')).toBeInTheDocument();

--- a/packages/core/src/Breadcrumbs/XDSBreadcrumbs.tsx
+++ b/packages/core/src/Breadcrumbs/XDSBreadcrumbs.tsx
@@ -16,7 +16,7 @@
  * - /packages/cli/templates/blocks/components/Breadcrumbs/ (showcase blocks)
  */
 
-import {createContext, type ReactNode} from 'react';
+import {createContext, useMemo, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {spacingVars} from '../theme/tokens.stylex';
 import {xdsClassName, mergeProps} from '../utils';
@@ -152,7 +152,10 @@ export function XDSBreadcrumbs({
   ref,
   ...rest
 }: XDSBreadcrumbsProps) {
-  const ctxValue: BreadcrumbContextValue = {variant, separator};
+  const ctxValue = useMemo<BreadcrumbContextValue>(
+    () => ({variant, separator}),
+    [variant, separator],
+  );
 
   return (
     <BreadcrumbCtx.Provider value={ctxValue}>

--- a/packages/core/src/Chat/XDSChatLayout.test.tsx
+++ b/packages/core/src/Chat/XDSChatLayout.test.tsx
@@ -90,7 +90,7 @@ describe('XDSChatLayout', () => {
     render(
       <XDSChatLayout
         composer={<div>composer</div>}
-        scrollButton={<button>Scroll to bottom</button>}>
+        scrollButton={<button type="button">Scroll to bottom</button>}>
         <div>msg</div>
       </XDSChatLayout>,
     );

--- a/packages/core/src/CheckboxList/XDSCheckboxList.test.tsx
+++ b/packages/core/src/CheckboxList/XDSCheckboxList.test.tsx
@@ -235,7 +235,11 @@ describe('XDSCheckboxList', () => {
         <XDSCheckboxListItem
           label="Option A"
           value="a"
-          endContent={<button data-testid="end-btn">Action</button>}
+          endContent={
+            <button type="button" data-testid="end-btn">
+              Action
+            </button>
+          }
         />
       </XDSCheckboxList>,
     );

--- a/packages/core/src/CheckboxList/XDSCheckboxList.tsx
+++ b/packages/core/src/CheckboxList/XDSCheckboxList.tsx
@@ -16,7 +16,14 @@
  * - /packages/cli/templates/blocks/components/CheckboxList/ (showcase blocks)
  */
 
-import {useId, useOptimistic, useTransition, type ReactNode} from 'react';
+import {
+  useCallback,
+  useId,
+  useMemo,
+  useOptimistic,
+  useTransition,
+  type ReactNode,
+} from 'react';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import {XDSField} from '../Field/XDSField';
 import type {XDSInputStatus} from '../Field/types';
@@ -170,23 +177,36 @@ export function XDSCheckboxList({
   const [optimisticValue, setOptimisticValue] = useOptimistic(effectiveValue);
   const isBusy = isLoading || optimisticValue !== effectiveValue;
 
-  const handleChange = (newValues: string[]) => {
-    onChange?.(newValues);
-    if (changeAction) {
-      startTransition(async () => {
-        setOptimisticValue(newValues);
-        await changeAction(newValues);
-      });
-    }
-  };
+  const handleChange = useCallback(
+    (newValues: string[]) => {
+      onChange?.(newValues);
+      if (changeAction) {
+        startTransition(async () => {
+          setOptimisticValue(newValues);
+          await changeAction(newValues);
+        });
+      }
+    },
+    [onChange, changeAction, startTransition, setOptimisticValue],
+  );
 
-  const contextValue: XDSCheckboxListContextValue = {
-    value: isCollectionMode ? optimisticValue : undefined,
-    onChange: isCollectionMode ? handleChange : undefined,
-    isDisabled,
-    isReadOnly,
-    isBusy,
-  };
+  const contextValue = useMemo<XDSCheckboxListContextValue>(
+    () => ({
+      value: isCollectionMode ? optimisticValue : undefined,
+      onChange: isCollectionMode ? handleChange : undefined,
+      isDisabled,
+      isReadOnly,
+      isBusy,
+    }),
+    [
+      isCollectionMode,
+      optimisticValue,
+      handleChange,
+      isDisabled,
+      isReadOnly,
+      isBusy,
+    ],
+  );
 
   return (
     <XDSField

--- a/packages/core/src/ClickableCard/XDSClickableCard.test.tsx
+++ b/packages/core/src/ClickableCard/XDSClickableCard.test.tsx
@@ -52,7 +52,9 @@ describe('XDSClickableCard', () => {
     const handleButtonClick = vi.fn();
     render(
       <XDSClickableCard label="Test card" onClick={handleCardClick}>
-        <button onClick={handleButtonClick}>Nested</button>
+        <button type="button" onClick={handleButtonClick}>
+          Nested
+        </button>
       </XDSClickableCard>,
     );
     fireEvent.click(screen.getByText('Nested'));
@@ -73,7 +75,10 @@ describe('XDSClickableCard', () => {
 
   it('hidden link passes target attribute', () => {
     render(
-      <XDSClickableCard label="External" href="https://example.com" target="_blank">
+      <XDSClickableCard
+        label="External"
+        href="https://example.com"
+        target="_blank">
         Content
       </XDSClickableCard>,
     );

--- a/packages/core/src/DateTimePicker/DateTimePicker.doc.mjs
+++ b/packages/core/src/DateTimePicker/DateTimePicker.doc.mjs
@@ -1,3 +1,4 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
 /** @type {import('../docs-types').ComponentDoc} */
 
 export const docs = {

--- a/packages/core/src/DateTimePicker/XDSDateTimePicker.test.tsx
+++ b/packages/core/src/DateTimePicker/XDSDateTimePicker.test.tsx
@@ -1,3 +1,4 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
 /**
  * @file XDSDateTimePicker.test.tsx
  * @input Uses vitest, @testing-library/react, XDSDateTimePicker component

--- a/packages/core/src/DateTimePicker/XDSDateTimePicker.tsx
+++ b/packages/core/src/DateTimePicker/XDSDateTimePicker.tsx
@@ -1,3 +1,4 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
 'use client';
 
 /**

--- a/packages/core/src/DateTimePicker/index.ts
+++ b/packages/core/src/DateTimePicker/index.ts
@@ -1,3 +1,4 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
 'use client';
 
 /**

--- a/packages/core/src/Dialog/XDSDialogHeader.test.tsx
+++ b/packages/core/src/Dialog/XDSDialogHeader.test.tsx
@@ -129,7 +129,7 @@ describe('XDSDialogHeader', () => {
     render(
       <XDSDialogHeader
         title="Title"
-        endContent={<button>Custom Action</button>}
+        endContent={<button type="button">Custom Action</button>}
       />,
     );
     expect(
@@ -142,7 +142,7 @@ describe('XDSDialogHeader', () => {
       <XDSDialogHeader
         title="Title"
         onOpenChange={() => {}}
-        endContent={<button>Custom Action</button>}
+        endContent={<button type="button">Custom Action</button>}
       />,
     );
     expect(
@@ -153,7 +153,10 @@ describe('XDSDialogHeader', () => {
 
   it('renders startContent before the title', () => {
     render(
-      <XDSDialogHeader title="Title" startContent={<button>Back</button>} />,
+      <XDSDialogHeader
+        title="Title"
+        startContent={<button type="button">Back</button>}
+      />,
     );
     expect(screen.getByRole('button', {name: 'Back'})).toBeInTheDocument();
   });
@@ -162,8 +165,8 @@ describe('XDSDialogHeader', () => {
     render(
       <XDSDialogHeader
         title="Title"
-        startContent={<button>Back</button>}
-        endContent={<button>Save</button>}
+        startContent={<button type="button">Back</button>}
+        endContent={<button type="button">Save</button>}
         onOpenChange={() => {}}
       />,
     );

--- a/packages/core/src/Dialog/useXDSImperativeDialog.test.tsx
+++ b/packages/core/src/Dialog/useXDSImperativeDialog.test.tsx
@@ -15,10 +15,14 @@ function TestHarness() {
 
   return (
     <div>
-      <button onClick={() => dialog.show(<div>Dialog content</div>)}>
+      <button
+        type="button"
+        onClick={() => dialog.show(<div>Dialog content</div>)}>
         Open
       </button>
-      <button onClick={() => dialog.hide()}>Close</button>
+      <button type="button" onClick={() => dialog.hide()}>
+        Close
+      </button>
       <span data-testid="status">{dialog.isOpen ? 'open' : 'closed'}</span>
       {dialog.element}
     </div>
@@ -56,7 +60,9 @@ describe('useXDSImperativeDialog', () => {
       const dialog = useXDSImperativeDialog();
       return (
         <div>
-          <button onClick={() => dialog.show(<div>Wide content</div>, {width: 720})}>
+          <button
+            type="button"
+            onClick={() => dialog.show(<div>Wide content</div>, {width: 720})}>
             Open Wide
           </button>
           <span data-testid="status">{dialog.isOpen ? 'open' : 'closed'}</span>

--- a/packages/core/src/DropdownMenu/XDSDropdownMenu.tsx
+++ b/packages/core/src/DropdownMenu/XDSDropdownMenu.tsx
@@ -169,8 +169,10 @@ export type XDSDropdownMenuProps =
  * />
  * ```
  */
+const DEFAULT_BUTTON = {label: 'Menu'} as const;
+
 export function XDSDropdownMenu({
-  button = {label: 'Menu'},
+  button = DEFAULT_BUTTON,
   isMenuOpen: controlledIsOpen,
   onOpenChange,
   menuWidth,

--- a/packages/core/src/EmptyState/XDSEmptyState.test.tsx
+++ b/packages/core/src/EmptyState/XDSEmptyState.test.tsx
@@ -84,7 +84,11 @@ describe('XDSEmptyState', () => {
     render(
       <XDSEmptyState
         title="No results"
-        actions={<button data-testid="action-btn">Retry</button>}
+        actions={
+          <button type="button" data-testid="action-btn">
+            Retry
+          </button>
+        }
       />,
     );
     expect(screen.getByTestId('action-btn')).toBeInTheDocument();
@@ -127,8 +131,8 @@ describe('XDSEmptyState', () => {
         description="Try a different search term."
         actions={
           <>
-            <button>Clear filters</button>
-            <button>Go back</button>
+            <button type="button">Clear filters</button>
+            <button type="button">Go back</button>
           </>
         }
         data-testid="full-empty-state"

--- a/packages/core/src/HoverCard/XDSHoverCard.test.tsx
+++ b/packages/core/src/HoverCard/XDSHoverCard.test.tsx
@@ -45,7 +45,7 @@ describe('XDSHoverCard', () => {
   it('renders trigger element', () => {
     render(
       <XDSHoverCard content={<span>Card content</span>}>
-        <button>Trigger</button>
+        <button type="button">Trigger</button>
       </XDSHoverCard>,
     );
     expect(screen.getByRole('button', {name: 'Trigger'})).toBeInTheDocument();
@@ -54,7 +54,7 @@ describe('XDSHoverCard', () => {
   it('does not show content initially', () => {
     render(
       <XDSHoverCard content={<span>Card content</span>}>
-        <button>Trigger</button>
+        <button type="button">Trigger</button>
       </XDSHoverCard>,
     );
     // Content is in DOM (popover not open but element exists)
@@ -65,7 +65,7 @@ describe('XDSHoverCard', () => {
   it('injects aria-describedby on trigger', () => {
     render(
       <XDSHoverCard content={<span>Card content</span>}>
-        <button>Trigger</button>
+        <button type="button">Trigger</button>
       </XDSHoverCard>,
     );
     const trigger = screen.getByRole('button', {name: 'Trigger'});
@@ -75,7 +75,9 @@ describe('XDSHoverCard', () => {
   it('merges existing aria-describedby', () => {
     render(
       <XDSHoverCard content={<span>Card content</span>}>
-        <button aria-describedby="existing-id">Trigger</button>
+        <button type="button" aria-describedby="existing-id">
+          Trigger
+        </button>
       </XDSHoverCard>,
     );
     const trigger = screen.getByRole('button', {name: 'Trigger'});
@@ -90,7 +92,7 @@ describe('XDSHoverCard', () => {
         content={<span>Card content</span>}
         onOpenChange={onOpenChange}
         delay={0}>
-        <button>Trigger</button>
+        <button type="button">Trigger</button>
       </XDSHoverCard>,
     );
 
@@ -110,7 +112,7 @@ describe('XDSHoverCard', () => {
         onOpenChange={onOpenChange}
         isEnabled={false}
         delay={0}>
-        <button>Trigger</button>
+        <button type="button">Trigger</button>
       </XDSHoverCard>,
     );
 
@@ -141,7 +143,7 @@ describe('XDSHoverCard', () => {
       vi.mocked(HTMLElement.prototype.showPopover).mockClear();
       render(
         <XDSHoverCard content={<span>Default open card</span>} isDefaultOpen>
-          <button>Trigger</button>
+          <button type="button">Trigger</button>
         </XDSHoverCard>,
       );
 
@@ -157,7 +159,7 @@ describe('XDSHoverCard', () => {
           content={<span>Default open card</span>}
           isDefaultOpen
           onOpenChange={onOpenChange}>
-          <button>Trigger</button>
+          <button type="button">Trigger</button>
         </XDSHoverCard>,
       );
 
@@ -170,7 +172,7 @@ describe('XDSHoverCard', () => {
       vi.mocked(HTMLElement.prototype.showPopover).mockClear();
       render(
         <XDSHoverCard content={<span>Not default open</span>}>
-          <button>Trigger</button>
+          <button type="button">Trigger</button>
         </XDSHoverCard>,
       );
 
@@ -186,7 +188,7 @@ describe('XDSHoverCard', () => {
           isDefaultOpen
           onOpenChange={onOpenChange}
           hideDelay={0}>
-          <button>Trigger</button>
+          <button type="button">Trigger</button>
         </XDSHoverCard>,
       );
 
@@ -215,7 +217,7 @@ describe('XDSHoverCard', () => {
           onOpenChange={onOpenChange}
           delay={0}
           hideDelay={0}>
-          <button>Trigger</button>
+          <button type="button">Trigger</button>
         </XDSHoverCard>,
       );
 
@@ -241,10 +243,10 @@ describe('XDSHoverCard', () => {
 
       render(
         <XDSHoverCard
-          content={<button>Interactive button</button>}
+          content={<button type="button">Interactive button</button>}
           delay={0}
           hideDelay={0}>
-          <button>Trigger</button>
+          <button type="button">Trigger</button>
         </XDSHoverCard>,
       );
 
@@ -269,10 +271,10 @@ describe('XDSHoverCard', () => {
     it('refocuses trigger after Escape from content', async () => {
       render(
         <XDSHoverCard
-          content={<button>Interactive button</button>}
+          content={<button type="button">Interactive button</button>}
           delay={0}
           hideDelay={0}>
-          <button>Trigger</button>
+          <button type="button">Trigger</button>
         </XDSHoverCard>,
       );
 
@@ -300,11 +302,11 @@ describe('XDSHoverCard', () => {
       const onOpenChange = vi.fn();
       render(
         <XDSHoverCard
-          content={<button>Interactive button</button>}
+          content={<button type="button">Interactive button</button>}
           onOpenChange={onOpenChange}
           delay={0}
           hideDelay={0}>
-          <button>Trigger</button>
+          <button type="button">Trigger</button>
         </XDSHoverCard>,
       );
 

--- a/packages/core/src/Layer/XDSLayerProvider.tsx
+++ b/packages/core/src/Layer/XDSLayerProvider.tsx
@@ -30,9 +30,11 @@ export interface XDSLayerProviderProps {
  * </XDSLayerProvider>
  * ```
  */
+const DEFAULT_TOAST_CONFIG = {};
+
 export function XDSLayerProvider({
   children,
-  toast: toastConfig = {},
+  toast: toastConfig = DEFAULT_TOAST_CONFIG,
 }: XDSLayerProviderProps) {
   const existingContext = useXDSLayerContext();
 

--- a/packages/core/src/MultiSelector/XDSMultiSelector.test.tsx
+++ b/packages/core/src/MultiSelector/XDSMultiSelector.test.tsx
@@ -296,7 +296,7 @@ describe('XDSMultiSelector', () => {
           value={[]}
           onChange={() => {}}
         />
-        <button>Next</button>
+        <button type="button">Next</button>
       </>,
     );
 

--- a/packages/core/src/Popover/XDSPopover.test.tsx
+++ b/packages/core/src/Popover/XDSPopover.test.tsx
@@ -52,7 +52,7 @@ describe('XDSPopover', () => {
   it('renders trigger element', () => {
     render(
       <XDSPopover content={<span>Popover content</span>} label="Test popover">
-        <button>Open</button>
+        <button type="button">Open</button>
       </XDSPopover>,
     );
     expect(screen.getByRole('button', {name: 'Open'})).toBeInTheDocument();
@@ -61,7 +61,7 @@ describe('XDSPopover', () => {
   it('sets aria-haspopup on trigger', () => {
     render(
       <XDSPopover content={<span>Content</span>} label="Test">
-        <button>Trigger</button>
+        <button type="button">Trigger</button>
       </XDSPopover>,
     );
     const trigger = screen.getByRole('button', {name: 'Trigger'});
@@ -71,7 +71,7 @@ describe('XDSPopover', () => {
   it('sets aria-expanded=false initially', () => {
     render(
       <XDSPopover content={<span>Content</span>} label="Test">
-        <button>Trigger</button>
+        <button type="button">Trigger</button>
       </XDSPopover>,
     );
     const trigger = screen.getByRole('button', {name: 'Trigger'});
@@ -81,7 +81,7 @@ describe('XDSPopover', () => {
   it('opens on click and updates aria-expanded', () => {
     render(
       <XDSPopover content={<span>Popover content</span>} label="Test">
-        <button>Open</button>
+        <button type="button">Open</button>
       </XDSPopover>,
     );
     const trigger = screen.getByRole('button', {name: 'Open'});
@@ -92,7 +92,7 @@ describe('XDSPopover', () => {
   it('renders popover content with role=dialog', () => {
     render(
       <XDSPopover content={<span>Hello</span>} label="Greeting">
-        <button>Open</button>
+        <button type="button">Open</button>
       </XDSPopover>,
     );
     // The dialog is inside a popover element — hidden from accessibility tree
@@ -109,7 +109,7 @@ describe('XDSPopover', () => {
         content={<span>Content</span>}
         label="Test"
         onOpenChange={onOpenChange}>
-        <button>Open</button>
+        <button type="button">Open</button>
       </XDSPopover>,
     );
     fireEvent.click(screen.getByRole('button', {name: 'Open'}));
@@ -124,7 +124,7 @@ describe('XDSPopover', () => {
         label="Test"
         isEnabled={false}
         onOpenChange={onOpenChange}>
-        <button>Open</button>
+        <button type="button">Open</button>
       </XDSPopover>,
     );
     fireEvent.click(screen.getByRole('button', {name: 'Open'}));
@@ -137,7 +137,7 @@ describe('XDSPopover', () => {
         content={<span>Content</span>}
         label="Test"
         data-testid="my-popover">
-        <button>Open</button>
+        <button type="button">Open</button>
       </XDSPopover>,
     );
     expect(screen.getByTestId('my-popover')).toBeInTheDocument();
@@ -148,7 +148,9 @@ describe('XDSPopover', () => {
       const ref = useRef<HTMLButtonElement>(null);
       return (
         <>
-          <button ref={ref}>Anchor</button>
+          <button type="button" ref={ref}>
+            Anchor
+          </button>
           <XDSPopover
             anchorRef={ref as React.RefObject<HTMLElement>}
             content={<span>Sibling content</span>}
@@ -167,7 +169,7 @@ describe('XDSPopover', () => {
     render(
       <XDSPopover content={<span>Content</span>} label="Test">
         <div>
-          <button>Nested button</button>
+          <button type="button">Nested button</button>
         </div>
       </XDSPopover>,
     );

--- a/packages/core/src/RadioList/XDSRadioList.tsx
+++ b/packages/core/src/RadioList/XDSRadioList.tsx
@@ -16,7 +16,7 @@
  * - /packages/cli/templates/blocks/components/RadioList/ (showcase blocks)
  */
 
-import {createContext, useId, type ReactNode} from 'react';
+import {createContext, useId, useMemo, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {spacingVars} from '../theme/tokens.stylex';
 import {XDSField} from '../Field/XDSField';
@@ -56,7 +56,10 @@ const styles = stylex.create({
   },
 });
 
-export interface XDSRadioListProps extends Omit<XDSBaseProps<HTMLElement>, 'onChange'> {
+export interface XDSRadioListProps extends Omit<
+  XDSBaseProps<HTMLElement>,
+  'onChange'
+> {
   /**
    * Label text for the radio group (always rendered for accessibility).
    */
@@ -163,15 +166,10 @@ export function XDSRadioList({
   const descriptionID = useId();
   const statusMessageID = useId();
 
-  const contextValue: XDSRadioListContextValue = {
-    name,
-    value,
-    onChange,
-    isDisabled,
-    isRequired,
-    size,
-    status,
-  };
+  const contextValue = useMemo<XDSRadioListContextValue>(
+    () => ({name, value, onChange, isDisabled, isRequired, size, status}),
+    [name, value, onChange, isDisabled, isRequired, size, status],
+  );
 
   return (
     <XDSField

--- a/packages/core/src/SideNav/XDSSideNav.test.tsx
+++ b/packages/core/src/SideNav/XDSSideNav.test.tsx
@@ -254,10 +254,15 @@ describe('XDSSideNavHeading', () => {
 // XDSSideNavHeading — collapsed mode
 // =============================================================================
 
+const COLLAPSED_CONTEXT = {
+  isCollapsed: true,
+  toggle: () => {},
+  isCollapsible: true,
+};
+
 function CollapsedWrapper({children}: {children: ReactNode}) {
   return (
-    <XDSSideNavCollapseContext.Provider
-      value={{isCollapsed: true, toggle: () => {}, isCollapsible: true}}>
+    <XDSSideNavCollapseContext.Provider value={COLLAPSED_CONTEXT}>
       {children}
     </XDSSideNavCollapseContext.Provider>
   );
@@ -721,9 +726,9 @@ describe('SideNav integration', () => {
     render(
       <XDSSideNav
         header={<XDSSideNavHeading heading="My App" />}
-        topContent={<button>Create</button>}
+        topContent={<button type="button">Create</button>}
         footer={<div data-testid="promo">Promo</div>}
-        footerIcons={<button>Help</button>}>
+        footerIcons={<button type="button">Help</button>}>
         <XDSSideNavSection title="Main">
           <XDSSideNavItem label="Dashboard" isSelected />
           <XDSSideNavItem label="Projects" />

--- a/packages/core/src/SideNav/XDSSideNavHeading.tsx
+++ b/packages/core/src/SideNav/XDSSideNavHeading.tsx
@@ -19,7 +19,7 @@
  * - /packages/cli/templates/blocks/components/SideNav/ (showcase blocks)
  */
 
-import {useCallback, useRef, type ReactNode} from 'react';
+import {useCallback, useMemo, useRef, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import {
@@ -376,6 +376,11 @@ export function XDSSideNavHeading({
     hasCloseButton: false,
   });
 
+  const closeMenuCtx = useMemo(
+    () => ({closeMenu: popover.hide}),
+    [popover.hide],
+  );
+
   const {triggerProps, contentProps, menuRef, setTriggerEl} = useXDSMenuHover({
     show: popover.show,
     hide: popover.hide,
@@ -494,8 +499,7 @@ export function XDSSideNavHeading({
                   )}
                 </span>
               </button>
-              <XDSNavHeadingCloseContext.Provider
-                value={{closeMenu: popover.hide}}>
+              <XDSNavHeadingCloseContext.Provider value={closeMenuCtx}>
                 {menu}
               </XDSNavHeadingCloseContext.Provider>
             </div>,
@@ -546,10 +550,7 @@ export function XDSSideNavHeading({
     <span {...stylex.props(styles.textContainer)}>
       {superheading &&
         (hasAnyHref && superheadingHref && menu ? (
-          <XDSLink
-            href={superheadingHref}
-            color="secondary"
-            size="xsm">
+          <XDSLink href={superheadingHref} color="secondary" size="xsm">
             {superheading}
           </XDSLink>
         ) : (
@@ -569,10 +570,7 @@ export function XDSSideNavHeading({
       </span>
       {subheading &&
         (hasAnyHref && subheadingHref && menu ? (
-          <XDSLink
-            href={subheadingHref}
-            color="secondary"
-            size="xsm">
+          <XDSLink href={subheadingHref} color="secondary" size="xsm">
             {subheading}
           </XDSLink>
         ) : (
@@ -760,20 +758,14 @@ export function XDSSideNavHeading({
         <span {...stylex.props(styles.textContainer)}>
           {superheading &&
             (superheadingHref ? (
-              <XDSLink
-                href={superheadingHref}
-                color="secondary"
-                size="xsm">
+              <XDSLink href={superheadingHref} color="secondary" size="xsm">
                 {superheading}
               </XDSLink>
             ) : (
               <span {...stylex.props(styles.superheading)}>{superheading}</span>
             ))}
           {headingHref ? (
-            <XDSLink
-              href={headingHref}
-              color="primary"
-              weight="semibold">
+            <XDSLink href={headingHref} color="primary" weight="semibold">
               {heading}
             </XDSLink>
           ) : (
@@ -787,10 +779,7 @@ export function XDSSideNavHeading({
           )}
           {subheading &&
             (subheadingHref ? (
-              <XDSLink
-                href={subheadingHref}
-                color="secondary"
-                size="xsm">
+              <XDSLink href={subheadingHref} color="secondary" size="xsm">
                 {subheading}
               </XDSLink>
             ) : (

--- a/packages/core/src/Table/XDSTable.perf.test.tsx
+++ b/packages/core/src/Table/XDSTable.perf.test.tsx
@@ -61,7 +61,7 @@ describe('XDSTable render performance', () => {
 
         return (
           <div>
-            <button onClick={() => setUnrelatedState(n => n + 1)}>
+            <button type="button" onClick={() => setUnrelatedState(n => n + 1)}>
               Increment: {unrelatedState}
             </button>
             <XDSTable data={data} columns={testColumns} idKey="id" />
@@ -99,7 +99,7 @@ describe('XDSTable render performance', () => {
 
         return (
           <div>
-            <button onClick={() => setUnrelatedState(n => n + 1)}>
+            <button type="button" onClick={() => setUnrelatedState(n => n + 1)}>
               Increment: {unrelatedState}
             </button>
             <XDSTable data={data} columns={inlineColumns} idKey="id" />
@@ -154,7 +154,9 @@ describe('XDSTable render performance', () => {
 
         return (
           <div>
-            <button onClick={updateSingleRow}>Update Row 2</button>
+            <button type="button" onClick={updateSingleRow}>
+              Update Row 2
+            </button>
             <XDSTable data={data} columns={stableColumns} idKey="id" />
           </div>
         );
@@ -218,7 +220,9 @@ describe('XDSTable render performance', () => {
 
         return (
           <div>
-            <button onClick={updateSingleRow}>Update Row 2</button>
+            <button type="button" onClick={updateSingleRow}>
+              Update Row 2
+            </button>
             <XDSTable data={data} columns={columns} idKey="id" />
           </div>
         );
@@ -268,7 +272,9 @@ describe('XDSTable render performance', () => {
 
         return (
           <div>
-            <button onClick={replaceWithSameContent}>Replace Data</button>
+            <button type="button" onClick={replaceWithSameContent}>
+              Replace Data
+            </button>
             <XDSTable data={data} columns={stableColumns} idKey="id" />
           </div>
         );
@@ -315,7 +321,7 @@ describe('XDSTable render performance', () => {
 
         return (
           <div>
-            <button onClick={() => setData(prev => [...prev])}>
+            <button type="button" onClick={() => setData(prev => [...prev])}>
               Force Update
             </button>
             <XDSTable data={data} columns={stableColumns} idKey="id" />
@@ -364,7 +370,7 @@ describe('XDSTable render performance', () => {
 
         return (
           <div>
-            <button onClick={() => setData(prev => [...prev])}>
+            <button type="button" onClick={() => setData(prev => [...prev])}>
               Force Update
             </button>
             <XDSTable data={data} columns={columns} idKey="id" />
@@ -406,7 +412,7 @@ describe('XDSTable render performance', () => {
 
         return (
           <div>
-            <button onClick={() => setData(createTestData(5))}>
+            <button type="button" onClick={() => setData(createTestData(5))}>
               Recreate Data
             </button>
             <XDSTable data={data} columns={testColumns} idKey="id" />
@@ -469,6 +475,7 @@ describe('XDSTable render performance', () => {
         return (
           <div>
             <button
+              type="button"
               onClick={() =>
                 setItems(prev =>
                   prev.map((item, i) =>

--- a/packages/core/src/Table/plugins/columnResize/useXDSTableColumnResize.test.tsx
+++ b/packages/core/src/Table/plugins/columnResize/useXDSTableColumnResize.test.tsx
@@ -54,8 +54,10 @@ const pixelColumns: XDSTableColumn<TestItem>[] = [
 // Test Helpers
 // =============================================================================
 
+const EMPTY_WIDTHS: Record<string, number> = {};
+
 function ResizeTable({
-  columnWidths: initialWidths = {},
+  columnWidths: initialWidths = EMPTY_WIDTHS,
   onColumnResizeEnd,
   minWidth,
   maxWidth,
@@ -616,7 +618,7 @@ describe('useXDSTableColumnResize', () => {
         });
         return (
           <div>
-            <button onClick={() => setCols([...cols].reverse())}>
+            <button type="button" onClick={() => setCols([...cols].reverse())}>
               Reorder
             </button>
             <XDSTable

--- a/packages/core/src/Table/plugins/filtering/useXDSTableFiltering.tsx
+++ b/packages/core/src/Table/plugins/filtering/useXDSTableFiltering.tsx
@@ -820,20 +820,23 @@ function PopoverFilterTrigger({
 
   // Build a local store override so FilterControl writes to the draft
   // instead of the consumer's state.
-  const draftStore: FilterStore = {
-    getConfig() {
-      return {
-        ...store.getConfig(),
-        filters: {
-          ...store.getConfig().filters,
-          [columnKey]: draft ?? undefined,
-        },
-        onFilterChange: (_key: string, val: XDSTableFilterValue | null) => {
-          setDraft(val);
-        },
-      };
-    },
-  };
+  const draftStore = useMemo<FilterStore>(
+    () => ({
+      getConfig() {
+        return {
+          ...store.getConfig(),
+          filters: {
+            ...store.getConfig().filters,
+            [columnKey]: draft ?? undefined,
+          },
+          onFilterChange: (_key: string, val: XDSTableFilterValue | null) => {
+            setDraft(val);
+          },
+        };
+      },
+    }),
+    [store, columnKey, draft, setDraft],
+  );
 
   return (
     <XDSPopover

--- a/packages/core/src/Table/plugins/pagination/useXDSTablePagination-perf.test.tsx
+++ b/packages/core/src/Table/plugins/pagination/useXDSTablePagination-perf.test.tsx
@@ -74,13 +74,22 @@ function PluginStabilityTracker({
 
   return (
     <div>
-      <button data-testid="next-page" onClick={() => setPage(p => p + 1)}>
+      <button
+        type="button"
+        data-testid="next-page"
+        onClick={() => setPage(p => p + 1)}>
         Next
       </button>
-      <button data-testid="prev-page" onClick={() => setPage(p => p - 1)}>
+      <button
+        type="button"
+        data-testid="prev-page"
+        onClick={() => setPage(p => p - 1)}>
         Prev
       </button>
-      <button data-testid="change-size" onClick={() => setPageSize(10)}>
+      <button
+        type="button"
+        data-testid="change-size"
+        onClick={() => setPageSize(10)}>
         Size 10
       </button>
       <span data-testid="page">{page}</span>
@@ -131,7 +140,10 @@ function PaginationRenderCountTable({
 
   return (
     <div>
-      <button data-testid="next-page" onClick={() => setPage(p => p + 1)}>
+      <button
+        type="button"
+        data-testid="next-page"
+        onClick={() => setPage(p => p + 1)}>
         Next
       </button>
       <XDSTable

--- a/packages/core/src/Table/plugins/selection/useXDSTableSelectionState.test.tsx
+++ b/packages/core/src/Table/plugins/selection/useXDSTableSelectionState.test.tsx
@@ -40,11 +40,13 @@ const columns: XDSTableColumn<TestItem>[] = [{key: 'name', header: 'Name'}];
 // Helper
 // =============================================================================
 
+const EMPTY_SET = new Set<string>();
+
 function StateHelperTable({
   data = testData,
   getIsItemEnabled,
   getIsItemSelectable,
-  initialSelected = new Set<string>(),
+  initialSelected = EMPTY_SET,
 }: {
   data?: TestItem[];
   getIsItemEnabled?: (item: TestItem) => boolean;

--- a/packages/core/src/Table/plugins/sortable/useXDSTableSortable.test.tsx
+++ b/packages/core/src/Table/plugins/sortable/useXDSTableSortable.test.tsx
@@ -43,10 +43,12 @@ const sortableColumns: XDSTableColumn<User>[] = [
 // Test Helpers
 // =============================================================================
 
+const EMPTY_SORT: XDSTableSortState = [];
+
 function SortableTable({
   columns = sortableColumns,
   data = users,
-  initialSort = [] as XDSTableSortState,
+  initialSort = EMPTY_SORT,
   allowUnsortedState = false,
   isMultiSortEnabled = false,
   onSortChange: externalOnSortChange,

--- a/packages/core/src/Table/plugins/sortable/useXDSTableSortableState.test.tsx
+++ b/packages/core/src/Table/plugins/sortable/useXDSTableSortableState.test.tsx
@@ -292,13 +292,17 @@ describe('useXDSTableSortableState', () => {
       return (
         <>
           <button
+            type="button"
             data-testid="external-sort"
             onClick={() =>
               setSort([{sortKey: 'age', direction: 'descending'}])
             }>
             Sort by age desc
           </button>
-          <button data-testid="clear-sort" onClick={() => setSort([])}>
+          <button
+            type="button"
+            data-testid="clear-sort"
+            onClick={() => setSort([])}>
             Clear sort
           </button>
           <SortableStateTable sort={sort} onSortChange={setSort} />

--- a/packages/core/src/Toolbar/XDSToolbar.test.tsx
+++ b/packages/core/src/Toolbar/XDSToolbar.test.tsx
@@ -178,9 +178,9 @@ describe('XDSToolbar', () => {
         label="Actions"
         startContent={
           <>
-            <button>Cut</button>
-            <button>Copy</button>
-            <button>Paste</button>
+            <button type="button">Cut</button>
+            <button type="button">Copy</button>
+            <button type="button">Paste</button>
           </>
         }
       />,
@@ -208,9 +208,9 @@ describe('XDSToolbar', () => {
         orientation="vertical"
         startContent={
           <>
-            <button>Cut</button>
-            <button>Copy</button>
-            <button>Paste</button>
+            <button type="button">Cut</button>
+            <button type="button">Copy</button>
+            <button type="button">Paste</button>
           </>
         }
       />,
@@ -234,9 +234,9 @@ describe('XDSToolbar', () => {
         label="Actions"
         startContent={
           <>
-            <button>Cut</button>
-            <button>Copy</button>
-            <button>Paste</button>
+            <button type="button">Cut</button>
+            <button type="button">Copy</button>
+            <button type="button">Paste</button>
           </>
         }
       />,

--- a/packages/core/src/Tooltip/XDSTooltip.test.tsx
+++ b/packages/core/src/Tooltip/XDSTooltip.test.tsx
@@ -45,7 +45,7 @@ describe('XDSTooltip', () => {
   it('renders trigger element', () => {
     render(
       <XDSTooltip content="Tooltip text">
-        <button>Trigger</button>
+        <button type="button">Trigger</button>
       </XDSTooltip>,
     );
     expect(screen.getByRole('button', {name: 'Trigger'})).toBeInTheDocument();
@@ -55,7 +55,7 @@ describe('XDSTooltip', () => {
     const onOpenChange = vi.fn();
     render(
       <XDSTooltip content="Tooltip text" onOpenChange={onOpenChange} delay={0}>
-        <button>Trigger</button>
+        <button type="button">Trigger</button>
       </XDSTooltip>,
     );
 
@@ -71,7 +71,7 @@ describe('XDSTooltip', () => {
     it('shows tooltip on mount when isDefaultOpen is true', async () => {
       render(
         <XDSTooltip content="Default open tooltip" isDefaultOpen>
-          <button>Trigger</button>
+          <button type="button">Trigger</button>
         </XDSTooltip>,
       );
 
@@ -88,7 +88,7 @@ describe('XDSTooltip', () => {
           content="Default open tooltip"
           isDefaultOpen
           onOpenChange={onOpenChange}>
-          <button>Trigger</button>
+          <button type="button">Trigger</button>
         </XDSTooltip>,
       );
 
@@ -101,7 +101,7 @@ describe('XDSTooltip', () => {
       vi.mocked(HTMLElement.prototype.showPopover).mockClear();
       render(
         <XDSTooltip content="Not default open">
-          <button>Trigger</button>
+          <button type="button">Trigger</button>
         </XDSTooltip>,
       );
 
@@ -118,7 +118,7 @@ describe('XDSTooltip', () => {
           isDefaultOpen
           onOpenChange={onOpenChange}
           hideDelay={0}>
-          <button>Trigger</button>
+          <button type="button">Trigger</button>
         </XDSTooltip>,
       );
 

--- a/packages/core/src/TopNav/XDSTopNavHeading.tsx
+++ b/packages/core/src/TopNav/XDSTopNavHeading.tsx
@@ -20,7 +20,7 @@
  * - /packages/cli/templates/blocks/components/TopNav/ (showcase blocks)
  */
 
-import {useCallback, useRef, type ReactNode} from 'react';
+import {useCallback, useMemo, useRef, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import {
@@ -337,6 +337,11 @@ export function XDSTopNavHeading({
     hasCloseButton: false,
   });
 
+  const closeMenuCtx = useMemo(
+    () => ({closeMenu: popover.hide}),
+    [popover.hide],
+  );
+
   const {triggerProps, contentProps, menuRef, setTriggerEl} = useXDSMenuHover({
     show: popover.show,
     hide: popover.hide,
@@ -519,8 +524,7 @@ export function XDSTopNavHeading({
             {...stylex.props(styles.popoverContent)}
             {...contentProps}>
             {popoverHeadingContent}
-            <XDSNavHeadingCloseContext.Provider
-              value={{closeMenu: popover.hide}}>
+            <XDSNavHeadingCloseContext.Provider value={closeMenuCtx}>
               {menu}
             </XDSNavHeadingCloseContext.Provider>
           </div>,
@@ -583,8 +587,7 @@ export function XDSTopNavHeading({
             {...stylex.props(styles.popoverContent)}
             {...contentProps}>
             {popoverHeadingContent}
-            <XDSNavHeadingCloseContext.Provider
-              value={{closeMenu: popover.hide}}>
+            <XDSNavHeadingCloseContext.Provider value={closeMenuCtx}>
               {menu}
             </XDSNavHeadingCloseContext.Provider>
           </div>,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1286,6 +1286,86 @@
   resolved "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz"
   integrity sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==
 
+"@eslint-react/ast@5.8.1":
+  version "5.8.1"
+  resolved "https://registry.yarnpkg.com/@eslint-react/ast/-/ast-5.8.1.tgz#49cd1912ea3ea3947e4a49224555796110d6d10b"
+  integrity sha512-6d6unnLCq/eWB7UKYa46911LEj3OLJaTaOMmGygRmjf65sjQKFpShDs42IYJJNsH0b1GyqVTqhFWcq9syI+puA==
+  dependencies:
+    "@typescript-eslint/types" "^8.59.3"
+    "@typescript-eslint/typescript-estree" "^8.59.3"
+    "@typescript-eslint/utils" "^8.59.3"
+    string-ts "^2.3.1"
+
+"@eslint-react/core@5.8.1":
+  version "5.8.1"
+  resolved "https://registry.yarnpkg.com/@eslint-react/core/-/core-5.8.1.tgz#adf38ba6a86d2399a43c4e90b30660b086e87b8d"
+  integrity sha512-y1l/6aagxL5aIn42Rj71szgZI0sJORBo0zDiUmhsDttr4EyctdZa4L+bCEUz9HmT/5MfzfWvn1G4sgJAZqDD7w==
+  dependencies:
+    "@eslint-react/ast" "5.8.1"
+    "@eslint-react/eslint" "5.8.1"
+    "@eslint-react/jsx" "5.8.1"
+    "@eslint-react/shared" "5.8.1"
+    "@eslint-react/var" "5.8.1"
+    "@typescript-eslint/scope-manager" "^8.59.3"
+    "@typescript-eslint/types" "^8.59.3"
+    "@typescript-eslint/utils" "^8.59.3"
+    ts-pattern "^5.9.0"
+
+"@eslint-react/eslint-plugin@^5.8.1":
+  version "5.8.1"
+  resolved "https://registry.yarnpkg.com/@eslint-react/eslint-plugin/-/eslint-plugin-5.8.1.tgz#b76fc9e9109d2865b5f381712f61a7d5768bbcd0"
+  integrity sha512-UmSZrt7tmxm02sEJwKIm74w38Q48WMhynyAlx7jv+OeQRsUUa1eL0mPFTme1TDYoczzG6NAafAJXXyCIraRQhA==
+  dependencies:
+    "@eslint-react/shared" "5.8.1"
+    eslint-plugin-react-dom "5.8.1"
+    eslint-plugin-react-jsx "5.8.1"
+    eslint-plugin-react-naming-convention "5.8.1"
+    eslint-plugin-react-rsc "5.8.1"
+    eslint-plugin-react-web-api "5.8.1"
+    eslint-plugin-react-x "5.8.1"
+
+"@eslint-react/eslint@5.8.1":
+  version "5.8.1"
+  resolved "https://registry.yarnpkg.com/@eslint-react/eslint/-/eslint-5.8.1.tgz#2da59dd57eabb1366f10706f3810f0d0e8c2d88f"
+  integrity sha512-iqXUPGQiBqMoZMpo2TueBTc0enIQaWLF50mjjetQ9EIvBTe6CDiRBFZE+xuG0Trhjy0HfKdX991sE05ZZZ3Yag==
+  dependencies:
+    "@typescript-eslint/utils" "^8.59.3"
+
+"@eslint-react/jsx@5.8.1":
+  version "5.8.1"
+  resolved "https://registry.yarnpkg.com/@eslint-react/jsx/-/jsx-5.8.1.tgz#2fb5d167c2a6098481b0ba8f4573322e67d3a607"
+  integrity sha512-4RLxDRNpoEra8lFx1uz73gYoe4mrT6HmM3RJ1fLtqAMn4WhpsIBoAbDQLybcyu/NU4WnbX/GYF8CParodaDnWA==
+  dependencies:
+    "@eslint-react/ast" "5.8.1"
+    "@eslint-react/eslint" "5.8.1"
+    "@eslint-react/shared" "5.8.1"
+    "@eslint-react/var" "5.8.1"
+    "@typescript-eslint/types" "^8.59.3"
+    "@typescript-eslint/utils" "^8.59.3"
+    ts-pattern "^5.9.0"
+
+"@eslint-react/shared@5.8.1":
+  version "5.8.1"
+  resolved "https://registry.yarnpkg.com/@eslint-react/shared/-/shared-5.8.1.tgz#2114ef45511d6454705e95be0fe3c842b37810e4"
+  integrity sha512-CRV+FuVwHaGsZsRAtedi6ROG2kHfWe/01Eide+ySvMBz3ObPsjlG38P3fvPf/5RFY9nsYBQd5yy3ust7tOxFXQ==
+  dependencies:
+    "@eslint-react/eslint" "5.8.1"
+    "@typescript-eslint/utils" "^8.59.3"
+    ts-pattern "^5.9.0"
+    zod "^4.4.3"
+
+"@eslint-react/var@5.8.1":
+  version "5.8.1"
+  resolved "https://registry.yarnpkg.com/@eslint-react/var/-/var-5.8.1.tgz#88601c0f8c4bc70a05c2c9b330716f9845204585"
+  integrity sha512-6siWKB+jfxG/MjCbdMkBHVzzvueBhwOj8k059Ur+MEtVuaQbclewgBnKgKYClCJLVo+Cyxiy816pS7ntsEbHeg==
+  dependencies:
+    "@eslint-react/ast" "5.8.1"
+    "@eslint-react/eslint" "5.8.1"
+    "@typescript-eslint/scope-manager" "^8.59.3"
+    "@typescript-eslint/types" "^8.59.3"
+    "@typescript-eslint/utils" "^8.59.3"
+    ts-pattern "^5.9.0"
+
 "@eslint/config-array@^0.23.5":
   version "0.23.5"
   resolved "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz"
@@ -3086,6 +3166,15 @@
     "@typescript-eslint/types" "^8.59.3"
     debug "^4.4.3"
 
+"@typescript-eslint/project-service@8.59.4":
+  version "8.59.4"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/project-service/-/project-service-8.59.4.tgz#5830535a0e7a3ae806e2669964f47a74c4bc6b0e"
+  integrity sha512-Ly00Vu4oAacfDeHp2Zg85ioNG6l8HG+tN1D7J+xTHSxu9y0awYKJ2zH1rFBn8ZSfuGK+7FxK3Cgl3uAz0aZZLg==
+  dependencies:
+    "@typescript-eslint/tsconfig-utils" "^8.59.4"
+    "@typescript-eslint/types" "^8.59.4"
+    debug "^4.4.3"
+
 "@typescript-eslint/scope-manager@8.59.3":
   version "8.59.3"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-8.59.3.tgz#91a60f66803fe9dae0696fbab2451f5723f119d2"
@@ -3094,10 +3183,23 @@
     "@typescript-eslint/types" "8.59.3"
     "@typescript-eslint/visitor-keys" "8.59.3"
 
+"@typescript-eslint/scope-manager@8.59.4", "@typescript-eslint/scope-manager@^8.59.3":
+  version "8.59.4"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-8.59.4.tgz#507d1258c758147dac1adee9517a205a8ac1e046"
+  integrity sha512-mUeR/3H1WrTAddJrwut8OoPjfauaztMQmRwV5fQTUyNVJCLiUXXe4lGEyYIL2oFDpP7UtgbGJXCt72wT0z2S3Q==
+  dependencies:
+    "@typescript-eslint/types" "8.59.4"
+    "@typescript-eslint/visitor-keys" "8.59.4"
+
 "@typescript-eslint/tsconfig-utils@8.59.3", "@typescript-eslint/tsconfig-utils@^8.59.3":
   version "8.59.3"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.3.tgz#88ca9036b42ccdd1e630cfdafd2e042c2ca6a835"
   integrity sha512-PcIJHjmaREXLgIAIzLnSY9VucEzz8FKXsRgFa1DmdGCK/5tJpW03TKJF01Q6VZd1lLdz2sIKPWaDUZN9dp//dw==
+
+"@typescript-eslint/tsconfig-utils@8.59.4", "@typescript-eslint/tsconfig-utils@^8.59.4":
+  version "8.59.4"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.4.tgz#218ba229d96dde35212e3a76a7d0a6bc831398be"
+  integrity sha512-DLCpnKgD4alVxTBSKulK+gU1KCqOgUXfDRDXh2mZgzokQKa/70ax93I2uVO3m/LLvIAtWZIFoiifudmIqAxpMA==
 
 "@typescript-eslint/type-utils@8.59.3":
   version "8.59.3"
@@ -3110,10 +3212,26 @@
     debug "^4.4.3"
     ts-api-utils "^2.5.0"
 
+"@typescript-eslint/type-utils@^8.59.3":
+  version "8.59.4"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-8.59.4.tgz#359fc53ba39a1f1860fddda40ebe5bfe0d87faed"
+  integrity sha512-uonTuPAAKr9XaBGqJ3LjYTh72zy5DyGesljO9gtmk/eFW0W1fRHjnwVYKB35Lm8d5Q5CluEW3gPHjTvZTmgrfA==
+  dependencies:
+    "@typescript-eslint/types" "8.59.4"
+    "@typescript-eslint/typescript-estree" "8.59.4"
+    "@typescript-eslint/utils" "8.59.4"
+    debug "^4.4.3"
+    ts-api-utils "^2.5.0"
+
 "@typescript-eslint/types@8.59.3", "@typescript-eslint/types@^8.59.3":
   version "8.59.3"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-8.59.3.tgz#b7ca539c5e302fdde9a7cadb73caed107ef8f2cd"
   integrity sha512-ePFoH0g4ludssdRFqqDxQePCxU4WQyRa9+XVwjm7yLn0FKhMeoetC+qBEEI1Eyb1pGSDveTIT09Bvw2WhlGayg==
+
+"@typescript-eslint/types@8.59.4", "@typescript-eslint/types@^8.59.4":
+  version "8.59.4"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-8.59.4.tgz#c29d5c21bfbaa8347ddc677d3ac1fcd2db0f848e"
+  integrity sha512-F1o7WJcCq+bc8dwcO/YsSEOudAH8RDtaOhM6wcAQhcUsFhnWQl81JKy48q1hoxAU0qrzM89+31GYh1515Zde3Q==
 
 "@typescript-eslint/typescript-estree@8.59.3":
   version "8.59.3"
@@ -3130,6 +3248,21 @@
     tinyglobby "^0.2.15"
     ts-api-utils "^2.5.0"
 
+"@typescript-eslint/typescript-estree@8.59.4", "@typescript-eslint/typescript-estree@^8.59.3":
+  version "8.59.4"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.4.tgz#d005e5e1fb425526f39685594bed34a04ad755ea"
+  integrity sha512-F+RuOmcDXo4+TPdfd/TCLS3m2nw8gE9XXyZLrA3JBfaA5tz9TtdkyD3YJFmPxulyc2cKbEok/CvFE3MgSLWnag==
+  dependencies:
+    "@typescript-eslint/project-service" "8.59.4"
+    "@typescript-eslint/tsconfig-utils" "8.59.4"
+    "@typescript-eslint/types" "8.59.4"
+    "@typescript-eslint/visitor-keys" "8.59.4"
+    debug "^4.4.3"
+    minimatch "^10.2.2"
+    semver "^7.7.3"
+    tinyglobby "^0.2.15"
+    ts-api-utils "^2.5.0"
+
 "@typescript-eslint/utils@8.59.3":
   version "8.59.3"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-8.59.3.tgz#f693f979deb4dc3994de03ff8b23976d625c36c5"
@@ -3140,12 +3273,30 @@
     "@typescript-eslint/types" "8.59.3"
     "@typescript-eslint/typescript-estree" "8.59.3"
 
+"@typescript-eslint/utils@8.59.4", "@typescript-eslint/utils@^8.59.3":
+  version "8.59.4"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-8.59.4.tgz#8ccd2b08aecc72c7efc0d7ac6695631d199d256e"
+  integrity sha512-cYXeNAUsG4lJo5dbc1FcKm+JwIWrj1/UpTORsC6tGMjEZ81DYcvIr9/ueikhMa/Y/gDQYGp+YX9/xQrXje5BJw==
+  dependencies:
+    "@eslint-community/eslint-utils" "^4.9.1"
+    "@typescript-eslint/scope-manager" "8.59.4"
+    "@typescript-eslint/types" "8.59.4"
+    "@typescript-eslint/typescript-estree" "8.59.4"
+
 "@typescript-eslint/visitor-keys@8.59.3":
   version "8.59.3"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.3.tgz#820843b1b5ca4290009cf189382abcf6fe00dfa6"
   integrity sha512-f1UQF7ggd42YiwI5wGrRaPsa+P0CINBlrkLPmGfpq/u/I/oVtecoEIfFR9ag/oa1sLOsRNZ6xehf6qMZhQGBDg==
   dependencies:
     "@typescript-eslint/types" "8.59.3"
+    eslint-visitor-keys "^5.0.0"
+
+"@typescript-eslint/visitor-keys@8.59.4":
+  version "8.59.4"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.4.tgz#1ac23b747b011f5cbdb449da97769f6c5f3a9355"
+  integrity sha512-U3gxVaDVnuZKhSspW/MzMxE1kq7zOdc072FcSNoqA1I9p8HyKbBFfEHoWckBAMgNMph4MamwS5iTVzFmrnt8TQ==
+  dependencies:
+    "@typescript-eslint/types" "8.59.4"
     eslint-visitor-keys "^5.0.0"
 
 "@vitejs/plugin-react@^4.3.0":
@@ -3470,6 +3621,11 @@ bidi-js@^1.0.3:
   dependencies:
     require-from-string "^2.0.2"
 
+birecord@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/birecord/-/birecord-0.1.1.tgz#abc07c8187bf24fb1e0055cd9feb18b30e477a03"
+  integrity sha512-VUpsf/qykW0heRlC8LooCq28Kxn3mAqKohhDG/49rrsQ1dT1CXyj/pgXS+5BSRzFTR/3DyIBOqQOrGyZOh71Aw==
+
 brace-expansion@^1.1.13, brace-expansion@^1.1.7, brace-expansion@^2.0.2, brace-expansion@^5.0.5:
   version "1.1.14"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.14.tgz#d9de602370d91347cd9ddad1224d4fd701eb348b"
@@ -3650,6 +3806,11 @@ commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz"
   integrity sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==
+
+compare-versions@^6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-6.1.1.tgz#7af3cc1099ba37d244b3145a9af5201b629148a9"
+  integrity sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -4169,6 +4330,94 @@ escape-string-regexp@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
+
+eslint-plugin-react-dom@5.8.1:
+  version "5.8.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-dom/-/eslint-plugin-react-dom-5.8.1.tgz#4ecfbe8053e5f01b544fd06ade17390e5d594d35"
+  integrity sha512-FHew3Pd39QuwHY0XCiE1mnss8jc7cq0LGwE2QElQ8cpQzOxghkxdb9RxiErjO81SvLoKEEc3c7akqd8qvjEj+w==
+  dependencies:
+    "@eslint-react/ast" "5.8.1"
+    "@eslint-react/eslint" "5.8.1"
+    "@eslint-react/jsx" "5.8.1"
+    "@eslint-react/shared" "5.8.1"
+    "@typescript-eslint/types" "^8.59.3"
+    "@typescript-eslint/utils" "^8.59.3"
+    compare-versions "^6.1.1"
+
+eslint-plugin-react-jsx@5.8.1:
+  version "5.8.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-jsx/-/eslint-plugin-react-jsx-5.8.1.tgz#d43aa0ce9f37ef06d3bc44cadca541ae973bdf22"
+  integrity sha512-P6TSoCkXmg63/WSPbv1nh+UWtsg00WAr95GYnKufStQpRrfltxUWiFXB/t5tL0GfjgF5oeCCj+0solDR4GSDdA==
+  dependencies:
+    "@eslint-react/ast" "5.8.1"
+    "@eslint-react/core" "5.8.1"
+    "@eslint-react/eslint" "5.8.1"
+    "@eslint-react/jsx" "5.8.1"
+    "@eslint-react/shared" "5.8.1"
+    "@typescript-eslint/types" "^8.59.3"
+    "@typescript-eslint/utils" "^8.59.3"
+
+eslint-plugin-react-naming-convention@5.8.1:
+  version "5.8.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-naming-convention/-/eslint-plugin-react-naming-convention-5.8.1.tgz#9899fb892129d3131ab3166df5982941ace16584"
+  integrity sha512-uRXcGgh5eExyzQjbdrHXC7H88n2U4I06DN8hwSTOEHQanXXyBtkX8Hf5opBVKOSoyMDhQawGhXRZvNnnXWhwZA==
+  dependencies:
+    "@eslint-react/ast" "5.8.1"
+    "@eslint-react/core" "5.8.1"
+    "@eslint-react/eslint" "5.8.1"
+    "@eslint-react/var" "5.8.1"
+    "@typescript-eslint/types" "^8.59.3"
+    "@typescript-eslint/utils" "^8.59.3"
+    ts-pattern "^5.9.0"
+
+eslint-plugin-react-rsc@5.8.1:
+  version "5.8.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-rsc/-/eslint-plugin-react-rsc-5.8.1.tgz#4a71d8321128be839d5a1a62e3f8150d8a21c952"
+  integrity sha512-66M0TIac6VbtDYRddQMdPCVnwm7HuB2yYm4dAtasvC2EhIbVagoIPAc0w8S78hvNdiAOYc0nsifCCA1MSM0Lng==
+  dependencies:
+    "@eslint-react/ast" "5.8.1"
+    "@eslint-react/core" "5.8.1"
+    "@eslint-react/eslint" "5.8.1"
+    "@eslint-react/shared" "5.8.1"
+    "@eslint-react/var" "5.8.1"
+    "@typescript-eslint/types" "^8.59.3"
+    "@typescript-eslint/utils" "^8.59.3"
+
+eslint-plugin-react-web-api@5.8.1:
+  version "5.8.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-web-api/-/eslint-plugin-react-web-api-5.8.1.tgz#891f07850b3ac94164a6050db43f177042dd4bc0"
+  integrity sha512-F4boO9KiaA1ZTejJdtgXsxj9wP7FmN/OvF8Su/1+JPvZpD1ouduNVKiacktv/FSkhDWiPVNrKQVdH6egingqLg==
+  dependencies:
+    "@eslint-react/ast" "5.8.1"
+    "@eslint-react/core" "5.8.1"
+    "@eslint-react/eslint" "5.8.1"
+    "@eslint-react/shared" "5.8.1"
+    "@eslint-react/var" "5.8.1"
+    "@typescript-eslint/types" "^8.59.3"
+    "@typescript-eslint/utils" "^8.59.3"
+    birecord "^0.1.1"
+    ts-pattern "^5.9.0"
+
+eslint-plugin-react-x@5.8.1:
+  version "5.8.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-x/-/eslint-plugin-react-x-5.8.1.tgz#a19fbc20f46e03783180c5c6cec36e6ba8001472"
+  integrity sha512-j7cRA35mk06acWzRQaO9/vv4dQr68uSfDmSGIynanBGwKBQzLCkhz91L8HzDUi8nSzC8eDRvKHjW9f7wsq+0Hg==
+  dependencies:
+    "@eslint-react/ast" "5.8.1"
+    "@eslint-react/core" "5.8.1"
+    "@eslint-react/eslint" "5.8.1"
+    "@eslint-react/jsx" "5.8.1"
+    "@eslint-react/shared" "5.8.1"
+    "@eslint-react/var" "5.8.1"
+    "@typescript-eslint/scope-manager" "^8.59.3"
+    "@typescript-eslint/type-utils" "^8.59.3"
+    "@typescript-eslint/types" "^8.59.3"
+    "@typescript-eslint/typescript-estree" "^8.59.3"
+    "@typescript-eslint/utils" "^8.59.3"
+    compare-versions "^6.1.1"
+    string-ts "^2.3.1"
+    ts-api-utils "^2.5.0"
+    ts-pattern "^5.9.0"
 
 eslint-scope@^9.1.2:
   version "9.1.2"
@@ -6076,6 +6325,11 @@ storybook@^10.4.0:
     use-sync-external-store "^1.5.0"
     ws "^8.18.0"
 
+string-ts@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/string-ts/-/string-ts-2.3.1.tgz#ef5394c8bd81139a2d49487623605f1208250d5a"
+  integrity sha512-xSJq+BS52SaFFAVxuStmx6n5aYZU571uYUnUrPXkPFCfdHyZMMlbP2v2Wx5sNBnAVzq/2+0+mcBLBa3Xa5ubYw==
+
 "string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
@@ -6369,6 +6623,11 @@ ts-interface-checker@^0.1.9:
   version "0.1.13"
   resolved "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz"
   integrity sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==
+
+ts-pattern@^5.9.0:
+  version "5.9.0"
+  resolved "https://registry.yarnpkg.com/ts-pattern/-/ts-pattern-5.9.0.tgz#f0fb5205ce0b0c59af72beba62fee7612a61cea4"
+  integrity sha512-6s5V71mX8qBUmlgbrfL33xDUwO0fq48rxAu2LBE11WBeGdpCPOsXksQbZJHvHwhrd3QjUusd3mAOM5Gg0mFBLg==
 
 tsconfig-paths@^4.2.0:
   version "4.2.0"
@@ -7089,3 +7348,8 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zod@^4.4.3:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-4.4.3.tgz#b680f172885d18bbebf21a834ea25e55a1bbf356"
+  integrity sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==


### PR DESCRIPTION
## Summary

- Adds `@eslint-react/eslint-plugin` with 13 selective React lint rules focused on catching bugs that TypeScript alone cannot detect
- Follows the existing two-tier severity model (`warn` for humans, `error` for CI/agents)
- Fixes all existing violations introduced by the new rules

### Rules enabled

| Category | Rules |
|----------|-------|
| Component structure | `no-nested-component-definitions`, `no-unstable-default-props`, `no-unstable-context-value`, `set-state-in-render` |
| DOM correctness | `dom-no-missing-button-type`, `dom-no-void-elements-with-children` |
| JSX correctness | `no-missing-key`, `jsx-no-comment-textnodes`, `jsx-no-leaked-dollar` |
| Resource leak prevention | `web-api-no-leaked-event-listener`, `web-api-no-leaked-interval`, `web-api-no-leaked-timeout`, `web-api-no-leaked-resize-observer` |

### Bugs fixed

**Unstable context values (8 production components)** — objects created every render caused unnecessary re-renders of entire consumer subtrees:
- `Breadcrumbs`, `CheckboxList`, `RadioList`, `Avatar` — wrapped context values in `useMemo`
- `SideNavHeading`, `TopNavHeading` — extracted memoized `closeMenuCtx`
- `AppShell` — extracted JSX context values to variables
- `useXDSTableFiltering` — wrapped `draftStore` in `useMemo`

**Unstable default props (5)** — object/array defaults in destructuring create new identity each render, breaking `React.memo` and risking infinite loops:
- `DropdownMenu` (`button = {label: 'Menu'}`) → `DEFAULT_BUTTON` constant
- `XDSLayerProvider` (`toast = {}`) → `DEFAULT_TOAST_CONFIG` constant
- 3 test helpers → extracted constants

**Missing button type (16 test files)** — `<button>` without `type="button"` defaults to `type="submit"`, risking accidental form submission:
- Added `type="button"` to 76 bare `<button>` elements

## Test plan

- [x] `yarn lint` passes with 0 errors, 208 warnings (same count as before — all pre-existing `no-unused-vars`)
- [x] `XDS_STRICT_LINT=1 yarn lint` passes with 0 errors
- [x] All tests pass for modified components (661 tests across 31 test files)
- [x] No new lint violations introduced