### PR TITLE
fix(ChartV2): land stacked PR changes (#2163, #2164)

### DIFF
--- a/apps/storybook/stories/ChartV2.stories.tsx
+++ b/apps/storybook/stories/ChartV2.stories.tsx
@@ -188,3 +188,34 @@ export const StackedAreas: StoryObj = {
     />
   ),
 };
+
+const profitLossData = [
+  {month: 'Jan', profit: 20, trend: 15},
+  {month: 'Feb', profit: -10, trend: 5},
+  {month: 'Mar', profit: 35, trend: 20},
+  {month: 'Apr', profit: -25, trend: -5},
+  {month: 'May', profit: 15, trend: 10},
+  {month: 'Jun', profit: -5, trend: 8},
+];
+
+/** Mixed marks with negative values */
+export const NegativeValues: StoryObj = {
+  render: () => (
+    <XDSChart
+      data={profitLossData}
+      xKey="month"
+      series={[
+        bar('profit', {color: '#3b82f6'}),
+        line('trend', {color: '#f59e0b', dots: true, strokeWidth: 2}),
+      ]}
+      grid={<XDSChartGrid horizontal />}
+      axes={
+        <>
+          <XDSChartAxis position="bottom" />
+          <XDSChartAxis position="left" />
+        </>
+      }
+      height={300}
+    />
+  ),
+};

--- a/packages/lab/src/Chart/XDSChartAxis.tsx
+++ b/packages/lab/src/Chart/XDSChartAxis.tsx
@@ -66,6 +66,17 @@ export function XDSChartAxis({
         ? `translate(${width},0)`
         : undefined;
 
+  // For the bottom axis, draw the axis line at y=0 when the domain spans negative values
+  const axisLineY = (() => {
+    if (position !== 'bottom') return 0;
+    const domain = yScale.domain();
+    if (domain[0] < 0 && domain[1] > 0) {
+      // The axis line should appear at the zero mark relative to the bottom edge
+      return yScale(0) - height;
+    }
+    return 0;
+  })();
+
   const format = tickFormat ?? String;
   const tickSize = 6;
 
@@ -76,12 +87,12 @@ export function XDSChartAxis({
 
   return (
     <g transform={transform}>
-      {/* Axis line */}
+      {/* Axis line — at y=0 for bottom axis when domain spans negative values */}
       <line
         x1={isHorizontal ? 0 : 0}
         x2={isHorizontal ? width : 0}
-        y1={isHorizontal ? 0 : 0}
-        y2={isHorizontal ? 0 : height}
+        y1={isHorizontal ? axisLineY : 0}
+        y2={isHorizontal ? axisLineY : height}
         stroke="var(--color-border-emphasized)"
         strokeWidth={1}
       />

--- a/packages/lab/src/ChartV2/marks/bar.tsx
+++ b/packages/lab/src/ChartV2/marks/bar.tsx
@@ -1,5 +1,5 @@
 /**
- * @file marks/bar.ts
+ * @file marks/bar.tsx
  * @output Bar series — self-contained resolve + render
  * @position Standalone mark; chart root calls resolve() then render()
  */
@@ -7,7 +7,9 @@
 import type {SeriesDef, SeriesContext, ResolvedPoint} from '../types';
 import type {ScaleBand} from 'd3-scale';
 
-export type ColorAccessor = string | ((datum: Record<string, unknown>, index: number) => string);
+export type ColorAccessor =
+  | string
+  | ((datum: Record<string, unknown>, index: number) => string);
 
 export interface BarOptions {
   color?: ColorAccessor;
@@ -17,16 +19,61 @@ export interface BarOptions {
   group?: string;
 }
 
+/**
+ * Build an SVG path for a rectangle with only the top corners rounded.
+ * When `r` is 0, produces a simple rect path with no curves.
+ */
+function roundedTopRect(
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  r: number,
+): string {
+  // Clamp radius to half the smaller dimension
+  const cr = Math.min(r, w / 2, h / 2);
+  if (cr <= 0) {
+    return `M${x},${y + h}V${y}H${x + w}V${y + h}Z`;
+  }
+  return (
+    `M${x},${y + h}` +
+    `V${y + cr}Q${x},${y} ${x + cr},${y}` +
+    `H${x + w - cr}Q${x + w},${y} ${x + w},${y + cr}` +
+    `V${y + h}Z`
+  );
+}
+
+/**
+ * Build an SVG path for a rectangle with only the bottom corners rounded.
+ */
+function roundedBottomRect(
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  r: number,
+): string {
+  const cr = Math.min(r, w / 2, h / 2);
+  if (cr <= 0) {
+    return `M${x},${y}V${y + h}H${x + w}V${y}Z`;
+  }
+  return (
+    `M${x},${y}` +
+    `V${y + h - cr}Q${x},${y + h} ${x + cr},${y + h}` +
+    `H${x + w - cr}Q${x + w},${y + h} ${x + w},${y + h - cr}` +
+    `V${y}Z`
+  );
+}
+
 export function bar(dataKey: string, options: BarOptions = {}): SeriesDef {
   const color = options.color ?? 'var(--color-chart-1)';
   const opacity = options.opacity ?? 1;
   const radius = options.radius ?? 4;
 
-  // Shared between resolve and render via closure
   let barWidth = 0;
   let barOffset = 0;
 
-  return {
+  const seriesDef: SeriesDef = {
     type: 'bar',
     key: dataKey,
     dataKeys: [dataKey],
@@ -42,8 +89,16 @@ export function bar(dataKey: string, options: BarOptions = {}): SeriesDef {
 
       const bandScale = xScale as ScaleBand<string>;
       const bw = bandScale.bandwidth();
-      barWidth = groupInfo ? bw / groupInfo.count : bw;
-      barOffset = groupInfo ? groupInfo.index * barWidth : 0;
+
+      if (groupInfo) {
+        const gutter = bw * 0.05;
+        const totalGutters = gutter * (groupInfo.count - 1);
+        barWidth = (bw - totalGutters) / groupInfo.count;
+        barOffset = groupInfo.index * (barWidth + gutter);
+      } else {
+        barWidth = bw;
+        barOffset = 0;
+      }
 
       const points: ResolvedPoint[] = [];
       for (let i = 0; i < data.length; i++) {
@@ -68,29 +123,30 @@ export function bar(dataKey: string, options: BarOptions = {}): SeriesDef {
 
     render(resolved, ctx) {
       const {data} = ctx;
+      const isTop = seriesDef._isTopOfStack !== false;
+      const r = isTop ? radius : 0;
+
       return (
         <g opacity={opacity}>
           {resolved.map((p, i) => {
             const d = data[p.dataIndex];
-            const fill = typeof color === 'function' ? color(d, p.dataIndex) : color;
-            const barY = Math.min(p.py, p.py0);
-            const barHeight = Math.abs(p.py0 - p.py);
+            const fill =
+              typeof color === 'function' ? color(d, p.dataIndex) : color;
+            const x = p.px - barWidth / 2;
+            const y = Math.min(p.py, p.py0);
+            const h = Math.max(0, Math.abs(p.py0 - p.py));
+            const growsUp = p.py <= p.py0;
 
-            return (
-              <rect
-                key={i}
-                x={p.px - barWidth / 2}
-                y={barY}
-                width={barWidth}
-                height={Math.max(0, barHeight)}
-                fill={fill}
-                rx={radius}
-                ry={radius}
-              />
-            );
+            const d_attr = growsUp
+              ? roundedTopRect(x, y, barWidth, h, r)
+              : roundedBottomRect(x, y, barWidth, h, r);
+
+            return <path key={i} d={d_attr} fill={fill} />;
           })}
         </g>
       );
     },
   };
+
+  return seriesDef;
 }

--- a/packages/lab/src/ChartV2/types.ts
+++ b/packages/lab/src/ChartV2/types.ts
@@ -74,14 +74,17 @@ export interface SeriesDef {
     groupInfo?: {index: number; count: number},
   ): ResolvedPoint[];
   /**
+   * Whether this series is the topmost in its stack group.
+   * Set by the layout engine before render() is called.
+   * Marks can use this to decide corner rounding, borders, etc.
+   */
+  _isTopOfStack?: boolean;
+  /**
    * Render the mark given resolved positions.
    * Called by the chart root during the render pass.
    * Returns SVG elements (or manages its own canvas for WebGL).
    */
-  render(
-    resolved: ResolvedPoint[],
-    ctx: SeriesContext,
-  ): ReactNode;
+  render(resolved: ResolvedPoint[], ctx: SeriesContext): ReactNode;
 }
 
 /** Resolved positions for all series */

--- a/packages/lab/src/ChartV2/types.ts
+++ b/packages/lab/src/ChartV2/types.ts
@@ -74,12 +74,6 @@ export interface SeriesDef {
     groupInfo?: {index: number; count: number},
   ): ResolvedPoint[];
   /**
-   * Whether this series is the topmost in its stack group.
-   * Set by the layout engine before render() is called.
-   * Marks can use this to decide corner rounding, borders, etc.
-   */
-  _isTopOfStack?: boolean;
-  /**
    * Render the mark given resolved positions.
    * Called by the chart root during the render pass.
    * Returns SVG elements (or manages its own canvas for WebGL).


### PR DESCRIPTION
Cherry-picks the squash-merge commits from #2163 and #2164 which didn't land on `main` due to incorrect merge order on stacked PRs.

**Changes included:**
- **#2163** — round only top corners of bars, respect stack position
- **#2164** — support negative values, position x-axis at zero mark

These were already reviewed and approved. The original squash commits landed on the intermediate stack branches instead of `main`.