### PR TITLE
fix(lint): correct lineHeight token reference in no-hardcoded-styles

### DIFF
--- a/internal/eslint-plugin-xds/index.js
+++ b/internal/eslint-plugin-xds/index.js
@@ -43,9 +43,9 @@ const STYLE_PROPERTIES = {
   },
   lineHeight: {
     pattern: /^['"]?\d+(\.\d+)?(px|rem|em)?['"]?$/,
-    tokenVar: 'lineHeightVars',
-    message: 'Consider using lineHeightVars token for consistency',
-    examples: ["lineHeightVars['--leading-normal']"],
+    tokenVar: 'typeScaleVars',
+    message: 'Consider using a typeScaleVars leading token for consistency',
+    examples: ["typeScaleVars['--text-body-leading']"],
   },
   // Spacing properties
   padding: {


### PR DESCRIPTION
## Summary
- The `no-hardcoded-styles` lint rule referenced a nonexistent `lineHeightVars` token and `--leading-normal` variable
- Line-height tokens actually live in `typeScaleVars` (e.g. `--text-body-leading`, `--text-label-leading`)
- Updated the rule to point to the correct token export and example

## Test plan
- [x] `yarn lint` passes with 0 errors