### PR TITLE
fix(Citation): prevent rest spread from overriding a11y props

### DIFF
--- a/packages/core/src/Citation/XDSCitation.tsx
+++ b/packages/core/src/Citation/XDSCitation.tsx
@@ -147,7 +147,12 @@ export function XDSCitation({
   const icon = source.icon;
   const Tag = href ? 'a' : 'span';
   const linkProps = href
-    ? {href, target: '_blank' as const, rel: 'noopener noreferrer' as const, title}
+    ? {
+        href,
+        target: '_blank' as const,
+        rel: 'noopener noreferrer' as const,
+        title,
+      }
     : {title};
 
   // Both <a> and <span> extend HTMLElement — narrow via intersection
@@ -157,15 +162,19 @@ export function XDSCitation({
   if (variant === 'number') {
     return (
       <Tag
+        {...rest}
         ref={elementRef}
         role="doc-noteref"
         aria-label={`Citation ${number}: ${title}`}
         data-testid={testId}
         {...linkProps}
-        {...rest}
         {...mergeProps(
           xdsClassName('citation', {variant}),
-          stylex.props(styles.number, href != null && styles.numberHover, xstyle),
+          stylex.props(
+            styles.number,
+            href != null && styles.numberHover,
+            xstyle,
+          ),
           className,
           style,
         )}>
@@ -176,12 +185,12 @@ export function XDSCitation({
 
   return (
     <Tag
+      {...rest}
       ref={elementRef}
       role="doc-noteref"
       aria-label={`Citation ${number}: ${title}`}
       data-testid={testId}
       {...linkProps}
-      {...rest}
       {...mergeProps(
         xdsClassName('citation', {variant}),
         stylex.props(

--- a/packages/core/src/Citation/index.ts
+++ b/packages/core/src/Citation/index.ts
@@ -1,4 +1,11 @@
 'use client';
 
+/**
+ * @file index.ts
+ * @input Imports XDSCitation component and types from XDSCitation.tsx
+ * @output Exports XDSCitation, XDSCitationProps, XDSCitationSource
+ * @position Component entry point; re-exported by /packages/core/src/index.ts
+ */
+
 export {XDSCitation} from './XDSCitation';
 export type {XDSCitationProps, XDSCitationSource} from './XDSCitation';


### PR DESCRIPTION
## Changes

**XDSCitation** — Move `{...rest}` spread before explicit `role` and `aria-label` attributes. Previously, any `role` or `aria-*` props passed by consumers via the base props interface would silently override the component's required `role="doc-noteref"` and `aria-label`. Now the component's accessibility contract takes priority.

Also adds the standard file header comment to `Citation/index.ts` for consistency with other component entry points.

### Findings

| Component | Category | Issue |
|-----------|----------|-------|
| Citation | a11y-gap | `{...rest}` spread positioned after explicit `role` and `aria-label`, allowing consumers to accidentally override accessibility contract |
| Citation | structure-issue | Missing file header in `index.ts` |

### Scope

Hardening issues: #2083

Night Watch — Component Auditor