### PR TITLE
fix(sandbox): pre-build workspace deps in Vercel deployment

### DIFF
--- a/apps/sandbox/vercel.json
+++ b/apps/sandbox/vercel.json
@@ -1,0 +1,4 @@
+{
+  "installCommand": "cd ../.. && yarn install",
+  "buildCommand": "cd ../.. && yarn build && yarn workspace @xds/sandbox build"
+}


### PR DESCRIPTION
## Summary

- Vercel auto-detect for `apps/sandbox` runs `next build` directly without first running `yarn build` at repo root, so workspace packages (`@xds/core`, `@xds/build`, themes…) never have their `dist/` produced.
- Any sandbox page (or CLI template surfaced in the sandbox) that imports a subpath export — e.g. `@xds/core/Blockquote`, added in #2198 — fails type-checking with `Cannot find module …` because the exports map's `types` condition points to `dist/<Component>/index.d.ts`.
- This has been turning the `Vercel` status check red on every PR for a while.
- Fix mirrors the pattern already in `apps/docsite/vercel.json`: install from repo root so workspaces link, then run the top-level `yarn build` (builds `@xds/build`, `@xds/core`, `@xds/vega`, every theme) before the sandbox's own `next build`.

## Repro

```
rm -rf packages/core/dist
cd apps/sandbox && yarn build
# → Type error: Cannot find module '@xds/core/Blockquote'
```

After this PR, Vercel runs `cd ../.. && yarn build && yarn workspace @xds/sandbox build`, which mirrors how `deploy.yml` builds the sandbox in GitHub Actions.

## Test plan

- [ ] Vercel preview deployment goes green on this PR.
- [ ] No regression on existing GitHub Actions checks (lint, test, build, smoke-test).