### PR TITLE
fix(docsite): emit copyright header in generated registries + fix DocsShell prop names

### DIFF
--- a/apps/docsite/scripts/generate-data.mjs
+++ b/apps/docsite/scripts/generate-data.mjs
@@ -33,9 +33,12 @@ fs.mkdirSync(OUT_DIR, {recursive: true});
 
 // ── Helpers ────────────────────────────────────────────────────────────
 
+const COPYRIGHT_HEADER =
+  '// Copyright (c) Meta Platforms, Inc. and affiliates.\n\n';
+
 function writeRegistry(filename, content) {
   const outPath = path.join(OUT_DIR, filename);
-  fs.writeFileSync(outPath, content, 'utf-8');
+  fs.writeFileSync(outPath, COPYRIGHT_HEADER + content, 'utf-8');
   console.log(`  wrote ${path.relative(REPO_ROOT, outPath)}`);
 }
 

--- a/apps/docsite/src/components/DocsShell.tsx
+++ b/apps/docsite/src/components/DocsShell.tsx
@@ -48,10 +48,10 @@ function buildComponentSidebar(): {
 
 export function DocsShell({
   children,
-  _components,
+  components: _components,
   packages,
   docTopics,
-  _templates,
+  templates: _templates,
   defaultIsMobile,
 }: DocsShellProps) {
   const pathname = usePathname();


### PR DESCRIPTION
## Summary

Two bugs blocking every docsite Vercel deployment, both surfaced by reading the full build log. The Vercel project named `xds-sandbox` actually has rootDirectory=`apps/docsite`, so this single PR should get it back to green.

### Bug 1 — generated registries missing the copyright header (root cause)

- `apps/docsite/scripts/generate-data.mjs` writes 9 typed registries into `apps/docsite/src/generated/` during `prebuild`. These files are not git-tracked.
- When #2193 added the `@xds/copyright-header` ESLint rule and back-filled headers, the generated files were missed. Vercel runs ESLint after `next build`, so every docsite deployment since has been red with 9 identical errors:
  ```
  ./src/generated/blockRegistry.ts
  1:1  Error: File is missing the copyright header: "// Copyright (c) Meta Platforms, Inc. and affiliates."  @xds/copyright-header
  ```
- GHA doesn't catch this: the `test` job's `./scripts/add-copyright.sh --check` only inspects committed files; generated ones never enter the check set.
- Fix: prepend the header inside `writeRegistry()` so every generated `.ts` picks it up automatically.

### Bug 2 — `DocsShell` destructures `_components` / `_templates` from a type that declares `components` / `templates`

- Hidden behind Bug 1 (lint failed before tsc ran). With Bug 1 fixed, tsc fails on:
  ```
  ./src/components/DocsShell.tsx:51:3
  Type error: Property '_components' does not exist on type 'DocsShellProps'.
  ```
- Looks like a leftover from #2210's unused-vars cleanup — the params were prefixed with `_` but the matching `DocsShellProps` type wasn't.
- Fix: use the `components: _components` rename form so the prop name still matches the type, but the binding stays marked unused.

## Test plan

- [x] Re-ran `node apps/docsite/scripts/generate-data.mjs` locally — all 9 outputs start with the header.
- [x] Re-ran `yarn workspace @xds/docsite build` locally — compiles successfully (lint skipped locally due to plugin install state, but tsc passes).
- [ ] Vercel preview deployment goes green on this PR.