### PR TITLE
feat(theme): remove runtime font loading from defineTheme

### DIFF
--- a/packages/core/src/theme/XDSTheme.tsx
+++ b/packages/core/src/theme/XDSTheme.tsx
@@ -34,13 +34,7 @@
  * ```
  */
 
-import React, {
-  useContext,
-  useId,
-  useInsertionEffect,
-  useMemo,
-  useRef,
-} from 'react';
+import React, {useContext, useId, useInsertionEffect, useMemo} from 'react';
 import {useIsomorphicLayoutEffect} from '../hooks/useIsomorphicLayoutEffect';
 import * as stylex from '@stylexjs/stylex';
 import type {ThemeMode} from './types';
@@ -171,80 +165,6 @@ function useThemeStyleInjection(theme: XDSDefinedTheme): void {
 }
 
 // =============================================================================
-// Font loading for themes that declare fonts
-// =============================================================================
-
-/**
- * Hook that loads fonts declared in theme.fonts at runtime.
- *
- * Uses useIsomorphicLayoutEffect to inject font stylesheets before the browser paints,
- * minimizing flash of unstyled text (FOUT).
- *
- * This is the fallback loading path — the preferred approach is to add
- * <link rel="stylesheet" href="..."> to your document <head>. For discoverability,
- * `npx xds theme build` prints font instructions in the build output.
- *
- * A console warning is logged for each font loaded at runtime
- * to encourage moving to the preload path.
- */
-function useThemeFontLoading(theme: XDSDefinedTheme): void {
-  const injectedLinksRef = useRef<HTMLLinkElement[]>([]);
-
-  useIsomorphicLayoutEffect(() => {
-    if (typeof document === 'undefined') return;
-    if (!theme.fonts || theme.fonts.length === 0) return;
-
-    const newLinks: HTMLLinkElement[] = [];
-
-    for (const font of theme.fonts) {
-      // Check if this specific font family has a loaded @font-face
-      // NOTE: document.fonts.check() is unreliable here — it returns true
-      // when ANY font in the fallback stack can render the text, even if
-      // the requested family isn't actually loaded. Instead, check if a
-      // FontFace with this family name exists in the FontFaceSet.
-      const hasFontFace = [...document.fonts].some(
-        f =>
-          f.family.replace(/["']/g, '') === font.family &&
-          f.status === 'loaded',
-      );
-      if (hasFontFace) continue;
-
-      // Check if we already injected a link for this URL
-      const existing = document.head.querySelector(
-        `link[rel="stylesheet"][href="${font.url}"]`,
-      );
-      if (existing) continue;
-
-      // Inject the font stylesheet
-      const link = document.createElement('link');
-      link.rel = 'stylesheet';
-      link.href = font.url;
-      document.head.appendChild(link);
-      newLinks.push(link);
-
-      // Dev-mode warning to encourage preloading
-      // Warn to encourage preloading — only visible in devtools
-      console.warn(
-        `[XDS] Theme "${theme.name}" loaded font "${font.family}" at runtime. ` +
-          `For better performance, add to your document <head>:\n` +
-          `  <link rel="stylesheet" href="${font.url}" />`,
-      );
-    }
-
-    injectedLinksRef.current = newLinks;
-
-    return () => {
-      for (const link of injectedLinksRef.current) {
-        if (link.parentNode) {
-          link.parentNode.removeChild(link);
-        }
-      }
-      injectedLinksRef.current = [];
-    };
-  }, [theme.fonts, theme.name]);
-}
-
-// =============================================================================
 // Root color-scheme sync
 // =============================================================================
 
@@ -311,7 +231,6 @@ export function XDSTheme({
   const isNested = useContext(XDSThemeNestingContext);
 
   useThemeStyleInjection(theme);
-  useThemeFontLoading(theme);
   useRootThemeSync(isNested, mode, theme.name);
 
   // Get color-scheme style

--- a/packages/core/src/theme/defineTheme.test.ts
+++ b/packages/core/src/theme/defineTheme.test.ts
@@ -80,7 +80,6 @@ describe('defineTheme', () => {
   });
 
   it('includes icons in the theme', () => {
-     
     const icons = {close: 'X'} as Partial<XDSIconRegistry>;
     const theme = defineTheme({name: 'icons', icons});
     expect(theme.icons).toBe(icons);
@@ -562,60 +561,7 @@ describe('custom status via components', () => {
   });
 });
 
-describe('typography fonts derivation', () => {
-  it('derives fonts array from typography roles with urls', () => {
-    const theme = defineTheme({
-      name: 'font-test',
-      typography: {
-        body: {
-          family: 'Figtree',
-          fallbacks: 'sans-serif',
-          url: 'https://fonts.googleapis.com/css2?family=Figtree:wght@400;500;600;700',
-        },
-        code: {
-          family: 'JetBrains Mono',
-          fallbacks: 'monospace',
-          url: 'https://fonts.googleapis.com/css2?family=JetBrains+Mono',
-        },
-      },
-    });
-    expect(theme.fonts).toHaveLength(2);
-    expect(theme.fonts![0].family).toBe('Figtree');
-    expect(theme.fonts![1].family).toBe('JetBrains Mono');
-    expect(theme.fonts![1].url).toContain('JetBrains');
-  });
-
-  it('returns undefined fonts when no typography specified', () => {
-    const theme = defineTheme({name: 'no-fonts'});
-    expect(theme.fonts).toBeUndefined();
-  });
-
-  it('returns undefined fonts when typography has no urls', () => {
-    const theme = defineTheme({
-      name: 'no-urls',
-      typography: {
-        body: {family: 'Courier New', fallbacks: 'monospace'},
-      },
-    });
-    expect(theme.fonts).toBeUndefined();
-  });
-
-  it('deduplicates fonts when heading inherits from body', () => {
-    const theme = defineTheme({
-      name: 'dedup',
-      typography: {
-        body: {
-          family: 'Geist',
-          fallbacks: 'sans-serif',
-          url: 'https://example.com/geist.css',
-        },
-        // heading inherits body — same font, should not duplicate
-      },
-    });
-    expect(theme.fonts).toHaveLength(1);
-    expect(theme.fonts![0].family).toBe('Geist');
-  });
-
+describe('typography font family derivation', () => {
   it('derives font family tokens from typography roles', () => {
     const theme = defineTheme({
       name: 'family-tokens',
@@ -671,12 +617,10 @@ describe('typography fonts derivation', () => {
         body: {
           family: 'Figtree',
           fallbacks: 'sans-serif',
-          url: 'https://fonts.googleapis.com/css2?family=Figtree',
         },
       },
     });
     expect(theme.name).toBe('combo');
-    expect(theme.fonts).toHaveLength(1);
     expect(theme.tokens['--font-family-body']).toBe('Figtree, sans-serif');
     // scale tokens should still be present
     expect(theme.tokens['--text-heading-4-size']).toBeDefined();
@@ -1153,22 +1097,19 @@ describe('defineTheme extends', () => {
     expect(child.name).toBe('my-brand');
   });
 
-  it('inherits fonts from base theme', () => {
+  it('inherits font family tokens from base theme', () => {
     const base = defineTheme({
       name: 'base',
       typography: {
         body: {
           family: 'Geist',
           fallbacks: 'sans-serif',
-          url: 'https://fonts.example.com/geist.css',
         },
         scale: {base: 14, ratio: 1.2},
       },
     });
     const child = defineTheme({name: 'child', extends: base});
-    expect(child.fonts).toEqual([
-      {family: 'Geist', url: 'https://fonts.example.com/geist.css'},
-    ]);
+    expect(child.tokens['--font-family-body']).toBe('Geist, sans-serif');
   });
 
   it('typography in child overrides base typography tokens', () => {

--- a/packages/core/src/theme/defineTheme.ts
+++ b/packages/core/src/theme/defineTheme.ts
@@ -31,7 +31,7 @@
  */
 
 import type {XDSIconRegistry} from '../Icon/globalIconRegistry';
-import type {ThemeFontSource, TypographyConfig, FontWeight} from './types';
+import type {TypographyConfig, FontWeight} from './types';
 import {
   resolveOnMedia,
   type OnMediaOverrides,
@@ -189,17 +189,19 @@ export interface XDSDefineThemeInput {
   /**
    * Unified typography configuration — fonts, scale, and weights.
    *
-   * Replaces the separate `typeScale` and `fonts` fields with a single
-   * config. Scale controls sizing; roles (body, heading, code) declare
+   * Scale controls sizing; roles (body, heading, code) declare
    * fonts, fallbacks, and weights. Heading inherits from body if omitted.
+   *
+   * Font loading is the consumer's responsibility — add a <link> or
+   * @import for your fonts before rendering the theme.
    *
    * @example
    * ```tsx
    * typography: {
    *   scale: { base: 14, ratio: 1.2 },
-   *   body: { family: 'Geist', fallbacks: '-apple-system, sans-serif', url: '...' },
+   *   body: { family: 'Geist', fallbacks: '-apple-system, sans-serif' },
    *   heading: { weight: 'semibold', weights: { 3: 'bold', 4: 'bold' } },
-   *   code: { family: 'Geist Mono', fallbacks: '"SF Mono", monospace', url: '...' },
+   *   code: { family: 'Geist Mono', fallbacks: '"SF Mono", monospace' },
    * }
    * ```
    */
@@ -335,11 +337,6 @@ export interface XDSDefinedTheme {
   icons?: Partial<XDSIconRegistry>;
   /** Whether this theme has been pre-compiled by theme build CLI */
   __built?: true;
-  /**
-   * Font declarations — fonts this theme requires.
-   * Passed through from defineTheme input unchanged.
-   */
-  fonts?: ThemeFontSource[];
   /**
    * Raw input tokens preserved from defineTheme() input.
    * Keeps [light, dark] tuples intact for programmatic access
@@ -603,51 +600,21 @@ export function defineTheme(input: XDSDefineThemeInput): XDSDefinedTheme {
     components = deepMergeComponents(base.components, components);
   }
 
-  // 4. Derive fonts array from typography roles (for runtime loading)
-  let fonts: ThemeFontSource[] | undefined;
-  if (typo) {
-    const seen = new Set<string>();
-    const fontList: ThemeFontSource[] = [];
-    // Heading inherits from body — collect body first, then heading (may be same), then code
-    for (const role of [typo.body, typo.heading, typo.code]) {
-      if (role?.family && role.url && !seen.has(role.family)) {
-        seen.add(role.family);
-        fontList.push({family: role.family, url: role.url});
-      }
-    }
-    // If heading has no family/url but body does, body is already in the list
-    if (fontList.length > 0) fonts = fontList;
-  }
-
-  // 5. Resolve on-media token overrides (defaults + user overrides)
+  // 4. Resolve on-media token overrides (defaults + user overrides)
   const __onDark = resolveOnMedia('dark', input.onDark);
   const __onLight = resolveOnMedia('light', input.onLight);
 
-  // 6. Merge icons — input icons override base icons
+  // 5. Merge icons — input icons override base icons
   const icons =
     input.icons && base?.icons
       ? {...base.icons, ...input.icons}
-      : input.icons ?? base?.icons;
-
-  // 7. Merge fonts — input fonts take priority, deduplicate by family
-  let mergedFonts = fonts;
-  if (!mergedFonts && base?.fonts) {
-    mergedFonts = base.fonts;
-  } else if (mergedFonts && base?.fonts) {
-    const seen = new Set(mergedFonts.map(f => f.family));
-    for (const font of base.fonts) {
-      if (!seen.has(font.family)) {
-        mergedFonts.push(font);
-      }
-    }
-  }
+      : (input.icons ?? base?.icons);
 
   return {
     name: input.name,
     tokens,
     components,
     icons,
-    fonts: mergedFonts,
     __inputTokens: input.tokens,
     __onDark,
     __onLight,
@@ -885,9 +852,10 @@ export function generateThemeRules(theme: XDSDefinedTheme): string[] {
             const derived = getDerivedVars(component, prop);
             // Padding longhands (paddingBlock, paddingInline, etc.) also
             // match the 'padding' derived entry for container expansion.
-            const paddingDerived = PADDING_PROPS.has(prop) && prop !== 'padding'
-              ? getDerivedVars(component, 'padding')
-              : [];
+            const paddingDerived =
+              PADDING_PROPS.has(prop) && prop !== 'padding'
+                ? getDerivedVars(component, 'padding')
+                : [];
             for (const entry of [...derived, ...paddingDerived]) {
               if (entry.expand === 'container' && PADDING_PROPS.has(prop)) {
                 containerExpanded = true;

--- a/packages/core/src/theme/index.ts
+++ b/packages/core/src/theme/index.ts
@@ -144,7 +144,6 @@ export type {
   XDSTextSize,
   XDSTextWeight,
   XDSTextColor,
-  ThemeFontSource,
   TypographyConfig,
   TypographyRole,
   FontWeight,

--- a/packages/core/src/theme/types.ts
+++ b/packages/core/src/theme/types.ts
@@ -6,25 +6,6 @@
  * Shared types used across XDS components.
  */
 
-/**
- * A font source declaration for a theme.
- * Used to declare fonts the theme requires so they can be preloaded,
- * reported at build time, and loaded at runtime as a fallback.
- *
- * @example
- * ```
- * fonts: [
- *   { family: 'Figtree', url: 'https://fonts.googleapis.com/css2?family=Figtree:wght@400;500;600;700' },
- * ]
- * ```
- */
-export interface ThemeFontSource {
-  /** Font family name, e.g. 'Figtree' */
-  family: string;
-  /** URL to load the font from, e.g. a Google Fonts URL */
-  url: string;
-}
-
 // =============================================================================
 // Typography config types
 // =============================================================================
@@ -43,23 +24,24 @@ export type FontWeight =
 /**
  * A typography role declaration (body, heading, or code).
  *
+ * Fonts must be loaded by the consumer (e.g. via a <link> tag in <head>
+ * or an @import in CSS). XDS does not handle font loading — it only
+ * sets the font-family token so the font is used once available.
+ *
  * @example
  * ```
  * body: {
  *   family: 'Geist',
  *   fallbacks: '"Geist Fallback", -apple-system, sans-serif',
- *   url: 'https://cdn.jsdelivr.net/npm/geist@1/dist/fonts/geist-sans/style.css',
  *   weight: 'normal',
  * }
  * ```
  */
 export interface TypographyRole {
-  /** Primary font name — used for font loading detection via document.fonts.check() */
+  /** Primary font name — must be loaded by the consumer (e.g. Google Fonts link tag) */
   family?: string;
   /** CSS fallback font stack (appended after family in the computed --font-* token) */
   fallbacks?: string;
-  /** Stylesheet URL for runtime font loading. Omit for system fonts. */
-  url?: string;
   /** Default font weight for this role */
   weight?: FontWeight;
   /** Per-level weight overrides (heading only: keys are heading levels 1–6) */
@@ -69,20 +51,20 @@ export interface TypographyRole {
 /**
  * Unified typography configuration.
  *
- * Replaces the separate `typeScale`, `fonts`, and font token overrides
- * with a single config object.
- *
  * - `scale` controls the geometric type scale (base size + ratio)
  * - `body`, `heading`, `code` declare fonts, fallbacks, weights per role
- * - `heading` inherits family/fallbacks/url from `body` if not specified
+ * - `heading` inherits family/fallbacks from `body` if not specified
+ *
+ * Font loading is the consumer's responsibility. Add a <link> or @import
+ * for your fonts before rendering the theme.
  *
  * @example
  * ```
  * typography: {
  *   scale: { base: 14, ratio: 1.2 },
- *   body: { family: 'Geist', fallbacks: '-apple-system, sans-serif', url: '...' },
+ *   body: { family: 'Geist', fallbacks: '-apple-system, sans-serif' },
  *   heading: { weight: 'semibold', weights: { 3: 'bold', 4: 'bold' } },
- *   code: { family: 'Geist Mono', fallbacks: '"SF Mono", monospace', url: '...' },
+ *   code: { family: 'Geist Mono', fallbacks: '"SF Mono", monospace' },
  * }
  * ```
  */

--- a/packages/themes/stone/src/stoneTheme.ts
+++ b/packages/themes/stone/src/stoneTheme.ts
@@ -21,13 +21,13 @@ import {stoneIconRegistry} from './icons';
  */
 const INPUT_STATUS_VARS = {
   'status:success': {
-    '--color-success': 'light-dark(#7f977e, #99b298)',  // Green T60 / T70
+    '--color-success': 'light-dark(#7f977e, #99b298)', // Green T60 / T70
   },
   'status:warning': {
-    '--color-warning': 'light-dark(#9f8f68, #bbaa81)',   // Yellow T60 / T70
+    '--color-warning': 'light-dark(#9f8f68, #bbaa81)', // Yellow T60 / T70
   },
   'status:error': {
-    '--color-error': 'light-dark(#a58b86, #c0a5a1)',     // Red T60 / T70
+    '--color-error': 'light-dark(#a58b86, #c0a5a1)', // Red T60 / T70
   },
 } as const;
 
@@ -42,18 +42,18 @@ const INPUT_STATUS_VARS = {
 const stoneSyntax = defineSyntaxTheme({
   name: 'xds-stone',
   tokens: {
-    keyword: ['#645a72', '#b2a7c1'],     // Purple T40 / T70
-    string: ['#4e6357', '#9bb19a'],      // Teal T40 / Green T70
-    comment: ['#5e5e5e', '#ababb0'],     // Stone Neutral T40 / T70
-    number: ['#755752', '#bea792'],      // Red T40 / Orange T70
-    function: ['#506072', '#99adc6'],    // Blue T40 / T70
-    type: ['#645a72', '#b2a7c1'],        // Purple T40 / T70
-    variable: ['#5e5e5e', '#ababb0'],    // Stone Neutral T40 / T70
-    operator: ['#5e5e5e', '#ababb0'],    // Stone Neutral T40 / T70
-    constant: ['#755752', '#bea792'],    // Red T40 / Orange T70
-    tag: ['#775751', '#c7a39d'],         // Red T40 / T70
-    attribute: ['#79693f', '#b6aa90'],   // Yellow T45 / T70
-    property: ['#4e6357', '#94b2a0'],    // Teal T40 / T70
+    keyword: ['#645a72', '#b2a7c1'], // Purple T40 / T70
+    string: ['#4e6357', '#9bb19a'], // Teal T40 / Green T70
+    comment: ['#5e5e5e', '#ababb0'], // Stone Neutral T40 / T70
+    number: ['#755752', '#bea792'], // Red T40 / Orange T70
+    function: ['#506072', '#99adc6'], // Blue T40 / T70
+    type: ['#645a72', '#b2a7c1'], // Purple T40 / T70
+    variable: ['#5e5e5e', '#ababb0'], // Stone Neutral T40 / T70
+    operator: ['#5e5e5e', '#ababb0'], // Stone Neutral T40 / T70
+    constant: ['#755752', '#bea792'], // Red T40 / Orange T70
+    tag: ['#775751', '#c7a39d'], // Red T40 / T70
+    attribute: ['#79693f', '#b6aa90'], // Yellow T45 / T70
+    property: ['#4e6357', '#94b2a0'], // Teal T40 / T70
     punctuation: ['#5e5e5e', '#ababb0'], // Stone Neutral T40 / T70
     background: ['#f3f3f5', '#171719'],
   },
@@ -66,20 +66,17 @@ export const stoneTheme = defineTheme({
     scale: {base: 14, ratio: 1.25},
     body: {
       family: 'Figtree',
-      url: 'https://fonts.googleapis.com/css2?family=Figtree:wght@400;500;600;700&display=swap',
       fallbacks:
         '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
     },
     heading: {
       family: 'Montserrat',
-      url: 'https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap',
       fallbacks:
         '"Figtree", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
       weights: {3: 'bold', 4: 'bold'},
     },
     code: {
       family: 'JetBrains Mono',
-      url: 'https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap',
       fallbacks: '"SF Mono", Monaco, Consolas, monospace',
     },
   },
@@ -96,55 +93,55 @@ export const stoneTheme = defineTheme({
 
     // Core semantic — all neutrals H=291
     // Stone 900 T=16 C=1.4, Stone 500 T=55 C=4, Stone 300 T=86 C=1.6, Stone 100 T=96 C=1
-    '--color-accent': ['#25252a', '#f3f3f5'],  // light: Stone Neutral T15
-    '--color-accent-muted': ['#25252a14', '#f3f3f5'],  // light: Stone Neutral T15 · 8%
-    '--color-neutral': ['#25252a0f', '#f3f3f5'],  // light: Stone Neutral T15 · 6%
-    '--color-background-surface': ['#ffffff', '#1b1b1f'],  // dark: Stone Neutral T10
-    '--color-background-body': ['#f3f3f5', '#111015'],  // dark: Stone Neutral T5
-    '--color-overlay': ['#25252a80', '#28282a'],  // light: Stone Neutral T15 · 50%
-    '--color-overlay-hover': ['#25252a0d', '#f3f3f5'],  // light: Stone Neutral T15 · 5%
-    '--color-overlay-pressed': ['#25252a1a', '#f3f3f5'],  // light: Stone Neutral T15 · 10%
-    '--color-background-muted': ['#e2e2e8', '#3b3b3f'],  // light: Stone Neutral T90
+    '--color-accent': ['#25252a', '#f3f3f5'], // light: Stone Neutral T15
+    '--color-accent-muted': ['#25252a14', '#f3f3f5'], // light: Stone Neutral T15 · 8%
+    '--color-neutral': ['#25252a0f', '#f3f3f5'], // light: Stone Neutral T15 · 6%
+    '--color-background-surface': ['#ffffff', '#1b1b1f'], // dark: Stone Neutral T10
+    '--color-background-body': ['#f3f3f5', '#111015'], // dark: Stone Neutral T5
+    '--color-overlay': ['#25252a80', '#28282a'], // light: Stone Neutral T15 · 50%
+    '--color-overlay-hover': ['#25252a0d', '#f3f3f5'], // light: Stone Neutral T15 · 5%
+    '--color-overlay-pressed': ['#25252a1a', '#f3f3f5'], // light: Stone Neutral T15 · 10%
+    '--color-background-muted': ['#e2e2e8', '#3b3b3f'], // light: Stone Neutral T90
 
     // Text — H=291
-    '--color-text-primary': ['#25252a', '#f3f3f5'],  // light: Stone Neutral T15
-    '--color-text-secondary': ['#83838a', '#9d9da3'],      // T55 C=4 / T65 C=3
-    '--color-text-disabled': ['#d7d7da', '#5e5e61'],       // T86 C=1.6 / T40 C=2
-    '--color-text-accent': ['#25252a', '#f3f3f5'],  // light: Stone Neutral T15
+    '--color-text-primary': ['#25252a', '#f3f3f5'], // light: Stone Neutral T15
+    '--color-text-secondary': ['#83838a', '#9d9da3'], // T55 C=4 / T65 C=3
+    '--color-text-disabled': ['#d7d7da', '#5e5e61'], // T86 C=1.6 / T40 C=2
+    '--color-text-accent': ['#25252a', '#f3f3f5'], // light: Stone Neutral T15
     '--color-on-dark': '#FFFFFF',
-    '--color-on-light': ['#25252a', '#28282a'],  // light: Stone Neutral T15
-    '--color-on-accent': ['#ffffff', '#25252a'],  // dark: Stone Neutral T15
+    '--color-on-light': ['#25252a', '#28282a'], // light: Stone Neutral T15
+    '--color-on-accent': ['#ffffff', '#25252a'], // dark: Stone Neutral T15
     // Text on top of matching status surface (badge fill, banner content).
-    '--color-on-success': ['#374c36', '#d0e9ce'],          // Green T30 / T90
-    '--color-on-error': ['#58413e', '#f9dcd7'],             // Red T30 / T90
-    '--color-on-warning': ['#524622', '#f4e1b7'],           // Yellow T30 / T90
+    '--color-on-success': ['#374c36', '#d0e9ce'], // Green T30 / T90
+    '--color-on-error': ['#58413e', '#f9dcd7'], // Red T30 / T90
+    '--color-on-warning': ['#524622', '#f4e1b7'], // Yellow T30 / T90
 
     // Icon — H=291
-    '--color-icon-accent': ['#25252a', '#f3f3f5'],  // light: Stone Neutral T15
-    '--color-icon-primary': ['#25252a', '#f3f3f5'],  // light: Stone Neutral T15
-    '--color-icon-secondary': ['#83838a', '#9d9da3'],      // T55 C=4 / T65 C=3
-    '--color-icon-disabled': ['#d7d7da', '#5e5e61'],       // T86 C=1.6 / T40 C=2
+    '--color-icon-accent': ['#25252a', '#f3f3f5'], // light: Stone Neutral T15
+    '--color-icon-primary': ['#25252a', '#f3f3f5'], // light: Stone Neutral T15
+    '--color-icon-secondary': ['#83838a', '#9d9da3'], // T55 C=4 / T65 C=3
+    '--color-icon-disabled': ['#d7d7da', '#5e5e61'], // T86 C=1.6 / T40 C=2
 
     // Surface variants — H=291
-    '--color-background-card': ['#FFFFFF', '#242325'],      // T14
-    '--color-background-popover': ['#ffffff', '#25252a'],  // dark: Stone Neutral T15
-    '--color-background-inverted': ['#25252a', '#f3f3f5'],  // light: Stone Neutral T15
+    '--color-background-card': ['#FFFFFF', '#242325'], // T14
+    '--color-background-popover': ['#ffffff', '#25252a'], // dark: Stone Neutral T15
+    '--color-background-inverted': ['#25252a', '#f3f3f5'], // light: Stone Neutral T15
 
     // Status / Sentiment — T50 from palette for icons/borders (visible color)
-    '--color-success': ['#374c36', '#b4cdb2'],              // Green T30 / T80
-    '--color-success-muted': ['#d0e9ce', '#b4cdb2'],       // Green T90 / T80
-    '--color-error': ['#58413e', '#dcc0bc'],                // Red T30 / T80
-    '--color-error-muted': ['#f9dcd7', '#dcc0bc'],          // Red T90 / T80
-    '--color-warning': ['#524622', '#d7c59c'],              // Yellow T30 / T80
-    '--color-warning-muted': ['#f4e1b7', '#d7c59c'],       // Yellow T90 / T80
+    '--color-success': ['#374c36', '#b4cdb2'], // Green T30 / T80
+    '--color-success-muted': ['#d0e9ce', '#b4cdb2'], // Green T90 / T80
+    '--color-error': ['#58413e', '#dcc0bc'], // Red T30 / T80
+    '--color-error-muted': ['#f9dcd7', '#dcc0bc'], // Red T90 / T80
+    '--color-warning': ['#524622', '#d7c59c'], // Yellow T30 / T80
+    '--color-warning-muted': ['#f4e1b7', '#d7c59c'], // Yellow T90 / T80
 
     // Border — H=291
-    '--color-border': ['#e2e2e8', '#f3f3f5'],  // light: Stone Neutral T90
-    '--color-border-emphasized': ['#83838a', '#5e5e61'],    // T55 C=4 / T40 C=2
+    '--color-border': ['#e2e2e8', '#f3f3f5'], // light: Stone Neutral T90
+    '--color-border-emphasized': ['#83838a', '#5e5e61'], // T55 C=4 / T40 C=2
 
     // Effects — H=291
-    '--color-skeleton': ['#d4d4da', '#5e5e64'],             // T85 / T40 from H=291 C=3
-    '--color-shadow': ['#25252a1a', '#000000'],  // light: Stone Neutral T15 · 10%
+    '--color-skeleton': ['#d4d4da', '#5e5e64'], // T85 / T40 from H=291 C=3
+    '--color-shadow': ['#25252a1a', '#000000'], // light: Stone Neutral T15 · 10%
     '--color-tint-hover': ['black', 'white'],
 
     // Typography override
@@ -160,9 +157,9 @@ export const stoneTheme = defineTheme({
     //          modes, matching the light-mode T90/T85 spacing.
 
     // Categorical — Blue H=265 C=10
-    '--color-background-blue': ['#d7e4f5', '#485362'],     // light T90 / dark T35
-    '--color-border-blue': ['#c9d6e7', '#313c4a'],          // light T85 / dark T25
-    '--color-icon-blue': ['#3c4856', '#d7e4f5'],            // light T30 / dark T90
+    '--color-background-blue': ['#d7e4f5', '#485362'], // light T90 / dark T35
+    '--color-border-blue': ['#c9d6e7', '#313c4a'], // light T85 / dark T25
+    '--color-icon-blue': ['#3c4856', '#d7e4f5'], // light T30 / dark T90
     '--color-text-blue': ['#3c4856', '#d7e4f5'],
 
     // Categorical — Cyan H=190 C=10
@@ -173,10 +170,10 @@ export const stoneTheme = defineTheme({
 
     // Categorical — Gray (pure neutral, C=0). Same T35/T25/T90 pattern from
     // the neutral H=291 C=3 ramp.
-    '--color-background-gray': ['#e2e2e8', '#525257'],  // light: Stone Neutral T90
-    '--color-border-gray': ['#d4d4da', '#3b3b3f'],  // light: Stone Neutral T85
-    '--color-icon-gray': ['#46464b', '#e2e2e8'],  // light: Stone Neutral T30
-    '--color-text-gray': ['#46464b', '#e2e2e8'],  // light: Stone Neutral T30
+    '--color-background-gray': ['#e2e2e8', '#525257'], // light: Stone Neutral T90
+    '--color-border-gray': ['#d4d4da', '#3b3b3f'], // light: Stone Neutral T85
+    '--color-icon-gray': ['#46464b', '#e2e2e8'], // light: Stone Neutral T30
+    '--color-text-gray': ['#46464b', '#e2e2e8'], // light: Stone Neutral T30
 
     // Categorical — Green H=142 C=17
     '--color-background-green': ['#d0e9ce', '#425841'],
@@ -233,12 +230,9 @@ export const stoneTheme = defineTheme({
     // =========================================================================
     // Shadows
     // =========================================================================
-    '--shadow-low':
-      '0 2px 4px #28282A0D, 0 4px 8px #28282A1A',
-    '--shadow-med':
-      '0 2px 4px #28282A0D, 0 4px 12px #28282A1A',
-    '--shadow-high':
-      '0 4px 6px #28282A1A, 0 12px 24px #28282A26',
+    '--shadow-low': '0 2px 4px #28282A0D, 0 4px 8px #28282A1A',
+    '--shadow-med': '0 2px 4px #28282A0D, 0 4px 12px #28282A1A',
+    '--shadow-high': '0 4px 6px #28282A1A, 0 12px 24px #28282A26',
     '--shadow-inset-hover': 'inset 0px 0px 0px 2px #28282A30',
     '--shadow-inset-selected': 'inset 0px 0px 0px 2px #28282A50',
     '--shadow-inset-success': 'inset 0px 0px 0px 2px #83838a30',
@@ -327,16 +321,16 @@ export const stoneTheme = defineTheme({
     // indeterminate both route to blue for the in-progress / loading look.
     'progressbar-fill': {
       'variant:accent': {
-        backgroundColor: 'light-dark(#d7e4f5, #a0acbc)',  // Blue T90 / T70
+        backgroundColor: 'light-dark(#d7e4f5, #a0acbc)', // Blue T90 / T70
       },
       'variant:success': {
-        backgroundColor: 'light-dark(#d0e9ce, #9ab298)',  // Green T90 / T70
+        backgroundColor: 'light-dark(#d0e9ce, #9ab298)', // Green T90 / T70
       },
       'variant:warning': {
-        backgroundColor: 'light-dark(#f4e1b7, #bbaa82)',   // Yellow T90 / T70
+        backgroundColor: 'light-dark(#f4e1b7, #bbaa82)', // Yellow T90 / T70
       },
       'variant:error': {
-        backgroundColor: 'light-dark(#f9dcd7, #c0a5a0)',   // Red T90 / T70
+        backgroundColor: 'light-dark(#f9dcd7, #c0a5a0)', // Red T90 / T70
       },
     },
 
@@ -374,16 +368,14 @@ export const stoneTheme = defineTheme({
     // Input status borders + icons across all 9 input components share the
     // same softer T60/T70 redirection. See INPUT_STATUS_VARS above.
     'text-input': INPUT_STATUS_VARS,
-    'textarea': INPUT_STATUS_VARS,
+    textarea: INPUT_STATUS_VARS,
     'number-input': INPUT_STATUS_VARS,
     'date-input': INPUT_STATUS_VARS,
     'time-input': INPUT_STATUS_VARS,
-    'selector': INPUT_STATUS_VARS,
+    selector: INPUT_STATUS_VARS,
     'multi-selector': INPUT_STATUS_VARS,
-    'typeahead': INPUT_STATUS_VARS,
-    'tokenizer': INPUT_STATUS_VARS,
-
-
+    typeahead: INPUT_STATUS_VARS,
+    tokenizer: INPUT_STATUS_VARS,
 
     card: {
       base: {
@@ -408,83 +400,253 @@ export const stoneTheme = defineTheme({
  */
 export const stonePalettes = {
   neutral: {
-    hue: 291, chroma: 3,
-    0: '#000000', 5: '#111015', 10: '#1b1b1f', 15: '#25252a', 20: '#303034',
-    25: '#3b3b3f', 30: '#46464b', 35: '#525257', 40: '#5e5e63', 45: '#6a6a6f',
-    50: '#77777c', 55: '#838388', 60: '#909095', 65: '#9d9da3', 70: '#ababb0',
-    75: '#b8b8be', 80: '#c6c6cc', 85: '#d4d4da', 90: '#e2e2e8', 95: '#f0f0f6',
+    hue: 291,
+    chroma: 3,
+    0: '#000000',
+    5: '#111015',
+    10: '#1b1b1f',
+    15: '#25252a',
+    20: '#303034',
+    25: '#3b3b3f',
+    30: '#46464b',
+    35: '#525257',
+    40: '#5e5e63',
+    45: '#6a6a6f',
+    50: '#77777c',
+    55: '#838388',
+    60: '#909095',
+    65: '#9d9da3',
+    70: '#ababb0',
+    75: '#b8b8be',
+    80: '#c6c6cc',
+    85: '#d4d4da',
+    90: '#e2e2e8',
+    95: '#f0f0f6',
     100: '#ffffff',
   },
   blue: {
-    hue: 265, chroma: 10,
-    0: '#000000', 5: '#04121e', 10: '#111c29', 15: '#1b2734', 20: '#26313f',
-    25: '#313c4a', 30: '#3c4856', 35: '#485362', 40: '#545f6e', 45: '#606c7b',
-    50: '#6c7888', 55: '#798595', 60: '#8692a2', 65: '#939faf', 70: '#a0acbd',
-    75: '#adbacb', 80: '#bbc8d9', 85: '#c9d6e7', 90: '#d7e4f5', 95: '#e7f2ff',
+    hue: 265,
+    chroma: 10,
+    0: '#000000',
+    5: '#04121e',
+    10: '#111c29',
+    15: '#1b2734',
+    20: '#26313f',
+    25: '#313c4a',
+    30: '#3c4856',
+    35: '#485362',
+    40: '#545f6e',
+    45: '#606c7b',
+    50: '#6c7888',
+    55: '#798595',
+    60: '#8692a2',
+    65: '#939faf',
+    70: '#a0acbd',
+    75: '#adbacb',
+    80: '#bbc8d9',
+    85: '#c9d6e7',
+    90: '#d7e4f5',
+    95: '#e7f2ff',
     100: '#ffffff',
   },
   cyan: {
-    hue: 190, chroma: 10,
-    0: '#000000', 5: '#001613', 10: '#071f1e', 15: '#122a28', 20: '#1d3433',
-    25: '#28403e', 30: '#334b49', 35: '#3e5755', 40: '#4a6361', 45: '#566f6d',
-    50: '#627c7a', 55: '#6f8986', 60: '#7b9693', 65: '#88a3a0', 70: '#95b1ae',
-    75: '#a3bebb', 80: '#b0ccc9', 85: '#bedad7', 90: '#cce8e5', 95: '#daf7f4',
+    hue: 190,
+    chroma: 10,
+    0: '#000000',
+    5: '#001613',
+    10: '#071f1e',
+    15: '#122a28',
+    20: '#1d3433',
+    25: '#28403e',
+    30: '#334b49',
+    35: '#3e5755',
+    40: '#4a6361',
+    45: '#566f6d',
+    50: '#627c7a',
+    55: '#6f8986',
+    60: '#7b9693',
+    65: '#88a3a0',
+    70: '#95b1ae',
+    75: '#a3bebb',
+    80: '#b0ccc9',
+    85: '#bedad7',
+    90: '#cce8e5',
+    95: '#daf7f4',
     100: '#ffffff',
   },
   green: {
-    hue: 142, chroma: 17,
-    0: '#000000', 5: '#001700', 10: '#0c200a', 15: '#162a16', 20: '#213521',
-    25: '#2b402b', 30: '#374c36', 35: '#425841', 40: '#4e644d', 45: '#5a7059',
-    50: '#667d65', 55: '#728a71', 60: '#7f977e', 65: '#8ca48b', 70: '#99b298',
-    75: '#a7bfa5', 80: '#b4cdb2', 85: '#c2dbc0', 90: '#d0e9ce', 95: '#def8dc',
+    hue: 142,
+    chroma: 17,
+    0: '#000000',
+    5: '#001700',
+    10: '#0c200a',
+    15: '#162a16',
+    20: '#213521',
+    25: '#2b402b',
+    30: '#374c36',
+    35: '#425841',
+    40: '#4e644d',
+    45: '#5a7059',
+    50: '#667d65',
+    55: '#728a71',
+    60: '#7f977e',
+    65: '#8ca48b',
+    70: '#99b298',
+    75: '#a7bfa5',
+    80: '#b4cdb2',
+    85: '#c2dbc0',
+    90: '#d0e9ce',
+    95: '#def8dc',
     100: '#ffffff',
   },
   teal: {
-    hue: 158, chroma: 9,
-    0: '#000000', 5: '#00150a', 10: '#101e17', 15: '#1a2921', 20: '#25342b',
-    25: '#303f36', 30: '#3b4a41', 35: '#46564d', 40: '#526259', 45: '#5e6e65',
-    50: '#6a7b71', 55: '#77887e', 60: '#83958a', 65: '#90a297', 70: '#9dafa5',
-    75: '#abbdb2', 80: '#b8cbc0', 85: '#c6d9ce', 90: '#d4e7dc', 95: '#e2f5ea',
+    hue: 158,
+    chroma: 9,
+    0: '#000000',
+    5: '#00150a',
+    10: '#101e17',
+    15: '#1a2921',
+    20: '#25342b',
+    25: '#303f36',
+    30: '#3b4a41',
+    35: '#46564d',
+    40: '#526259',
+    45: '#5e6e65',
+    50: '#6a7b71',
+    55: '#77887e',
+    60: '#83958a',
+    65: '#90a297',
+    70: '#9dafa5',
+    75: '#abbdb2',
+    80: '#b8cbc0',
+    85: '#c6d9ce',
+    90: '#d4e7dc',
+    95: '#e2f5ea',
     100: '#ffffff',
   },
   yellow: {
-    hue: 90, chroma: 23,
-    0: '#000000', 5: '#1f0f00', 10: '#261a00', 15: '#2f2500', 20: '#3a2f0d',
-    25: '#463a18', 30: '#524622', 35: '#5e512d', 40: '#6b5d39', 45: '#786944',
-    50: '#857650', 55: '#92825c', 60: '#9f8f68', 65: '#ad9c75', 70: '#bbaa81',
-    75: '#c9b78e', 80: '#d7c59c', 85: '#e5d3a9', 90: '#f4e1b7', 95: '#ffefc7',
+    hue: 90,
+    chroma: 23,
+    0: '#000000',
+    5: '#1f0f00',
+    10: '#261a00',
+    15: '#2f2500',
+    20: '#3a2f0d',
+    25: '#463a18',
+    30: '#524622',
+    35: '#5e512d',
+    40: '#6b5d39',
+    45: '#786944',
+    50: '#857650',
+    55: '#92825c',
+    60: '#9f8f68',
+    65: '#ad9c75',
+    70: '#bbaa81',
+    75: '#c9b78e',
+    80: '#d7c59c',
+    85: '#e5d3a9',
+    90: '#f4e1b7',
+    95: '#ffefc7',
     100: '#ffffff',
   },
   orange: {
-    hue: 70, chroma: 22,
-    0: '#000000', 5: '#250a00', 10: '#2d1700', 15: '#372104', 20: '#432c12',
-    25: '#4f361c', 30: '#5b4227', 35: '#684d32', 40: '#75593d', 45: '#826548',
-    50: '#8f7154', 55: '#9d7e60', 60: '#aa8b6d', 65: '#b89879', 70: '#c6a586',
-    75: '#d4b393', 80: '#e3c0a0', 85: '#f1ceae', 90: '#ffdcbb', 95: '#ffeddc',
+    hue: 70,
+    chroma: 22,
+    0: '#000000',
+    5: '#250a00',
+    10: '#2d1700',
+    15: '#372104',
+    20: '#432c12',
+    25: '#4f361c',
+    30: '#5b4227',
+    35: '#684d32',
+    40: '#75593d',
+    45: '#826548',
+    50: '#8f7154',
+    55: '#9d7e60',
+    60: '#aa8b6d',
+    65: '#b89879',
+    70: '#c6a586',
+    75: '#d4b393',
+    80: '#e3c0a0',
+    85: '#f1ceae',
+    90: '#ffdcbb',
+    95: '#ffeddc',
     100: '#ffffff',
   },
   red: {
-    hue: 33, chroma: 11,
-    0: '#000000', 5: '#210a04', 10: '#2a1714', 15: '#35211e', 20: '#402b28',
-    25: '#4c3633', 30: '#58413e', 35: '#644d49', 40: '#715955', 45: '#7e6561',
-    50: '#8a716d', 55: '#987e7a', 60: '#a58b86', 65: '#b39893', 70: '#c0a5a1',
-    75: '#ceb3ae', 80: '#dcc0bc', 85: '#ebcec9', 90: '#f9dcd7', 95: '#ffece9',
+    hue: 33,
+    chroma: 11,
+    0: '#000000',
+    5: '#210a04',
+    10: '#2a1714',
+    15: '#35211e',
+    20: '#402b28',
+    25: '#4c3633',
+    30: '#58413e',
+    35: '#644d49',
+    40: '#715955',
+    45: '#7e6561',
+    50: '#8a716d',
+    55: '#987e7a',
+    60: '#a58b86',
+    65: '#b39893',
+    70: '#c0a5a1',
+    75: '#ceb3ae',
+    80: '#dcc0bc',
+    85: '#ebcec9',
+    90: '#f9dcd7',
+    95: '#ffece9',
     100: '#ffffff',
   },
   pink: {
-    hue: 340, chroma: 9,
-    0: '#000000', 5: '#1b0c16', 10: '#251720', 15: '#30222a', 20: '#3b2c35',
-    25: '#463740', 30: '#52424c', 35: '#5e4e57', 40: '#6a5a63', 45: '#776670',
-    50: '#83727c', 55: '#907f89', 60: '#9d8c96', 65: '#ab99a3', 70: '#b8a6b1',
-    75: '#c6b4be', 80: '#d4c1cc', 85: '#e2cfda', 90: '#f0dde8', 95: '#ffebf7',
+    hue: 340,
+    chroma: 9,
+    0: '#000000',
+    5: '#1b0c16',
+    10: '#251720',
+    15: '#30222a',
+    20: '#3b2c35',
+    25: '#463740',
+    30: '#52424c',
+    35: '#5e4e57',
+    40: '#6a5a63',
+    45: '#776670',
+    50: '#83727c',
+    55: '#907f89',
+    60: '#9d8c96',
+    65: '#ab99a3',
+    70: '#b8a6b1',
+    75: '#c6b4be',
+    80: '#d4c1cc',
+    85: '#e2cfda',
+    90: '#f0dde8',
+    95: '#ffebf7',
     100: '#ffffff',
   },
   purple: {
-    hue: 307, chroma: 11,
-    0: '#000000', 5: '#150e1d', 10: '#1f1927', 15: '#292332', 20: '#342e3d',
-    25: '#3f3949', 30: '#4b4454', 35: '#564f60', 40: '#635b6d', 45: '#6f6779',
-    50: '#7b7486', 55: '#888193', 60: '#958da0', 65: '#a39aad', 70: '#b0a8bb',
-    75: '#beb5c9', 80: '#cbc3d7', 85: '#d9d1e5', 90: '#e8dff3', 95: '#f6edff',
+    hue: 307,
+    chroma: 11,
+    0: '#000000',
+    5: '#150e1d',
+    10: '#1f1927',
+    15: '#292332',
+    20: '#342e3d',
+    25: '#3f3949',
+    30: '#4b4454',
+    35: '#564f60',
+    40: '#635b6d',
+    45: '#6f6779',
+    50: '#7b7486',
+    55: '#888193',
+    60: '#958da0',
+    65: '#a39aad',
+    70: '#b0a8bb',
+    75: '#beb5c9',
+    80: '#cbc3d7',
+    85: '#d9d1e5',
+    90: '#e8dff3',
+    95: '#f6edff',
     100: '#ffffff',
   },
 } as const;


### PR DESCRIPTION
## What

Removes the runtime font loading mechanism from `defineTheme`. Consumers should load fonts themselves (e.g. `<link>` tag in `<head>` or `@import` in CSS).

## Why

The `typography.url` + `useThemeFontLoading` approach was:
- Unreliable (CSP restrictions, SSR environments, timing/FOUT issues)
- Already positioned as a "fallback" that logged console warnings encouraging the manual approach
- Only used by the Stone theme

## What's removed

- `ThemeFontSource` type and `fonts` field from `XDSDefinedTheme`
- `url` field from `TypographyRole`  
- `useThemeFontLoading` hook from `XDSTheme`
- Font derivation/merging logic in `defineTheme()`
- `url` declarations from Stone theme

## What still works

`typography.family` and `typography.fallbacks` are unchanged — `defineTheme` still sets `--font-family-body`, `--font-family-heading`, `--font-family-code` tokens so the font is applied once loaded.

## Migration

If you were relying on the runtime font injection, add a `<link>` to your HTML:

```html
<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Figtree:wght@400;500;600;700&display=swap" />
```