### PR TITLE
fix(core): add missing xdsClassName hooks and use border tokens

### DIFF
--- a/packages/core/src/AvatarGroup/XDSAvatarGroupOverflow.tsx
+++ b/packages/core/src/AvatarGroup/XDSAvatarGroupOverflow.tsx
@@ -21,6 +21,7 @@ import {
   fontWeightVars,
   radiusVars,
 } from '../theme/tokens.stylex';
+import {xdsClassName, mergeProps} from '../utils';
 import {useXDSAvatarGroup} from './XDSAvatarGroupContext';
 
 const BORDER_WIDTH = 2;
@@ -115,13 +116,16 @@ export function XDSAvatarGroupOverflow({
         type="button"
         onClick={onClick}
         aria-label={label}
-        {...stylex.props(
-          styles.base,
-          styles.button,
-          styles.overlap,
-          dynamicStyles.size(numericSize),
-          dynamicStyles.fontSize(numericSize),
-          dynamicStyles.overlap(-overlap),
+        {...mergeProps(
+          xdsClassName('avatar-group-overflow'),
+          stylex.props(
+            styles.base,
+            styles.button,
+            styles.overlap,
+            dynamicStyles.size(numericSize),
+            dynamicStyles.fontSize(numericSize),
+            dynamicStyles.overlap(-overlap),
+          ),
         )}>
         {content}
       </button>
@@ -131,12 +135,15 @@ export function XDSAvatarGroupOverflow({
   return (
     <span
       aria-label={label}
-      {...stylex.props(
-        styles.base,
-        styles.overlap,
-        dynamicStyles.size(numericSize),
-        dynamicStyles.fontSize(numericSize),
-        dynamicStyles.overlap(-overlap),
+      {...mergeProps(
+        xdsClassName('avatar-group-overflow'),
+        stylex.props(
+          styles.base,
+          styles.overlap,
+          dynamicStyles.size(numericSize),
+          dynamicStyles.fontSize(numericSize),
+          dynamicStyles.overlap(-overlap),
+        ),
       )}>
       {content}
     </span>

--- a/packages/core/src/Banner/XDSBanner.tsx
+++ b/packages/core/src/Banner/XDSBanner.tsx
@@ -34,6 +34,7 @@ import {
   radiusVars,
   fontWeightVars,
   typeScaleVars,
+  borderVars,
 } from '../theme/tokens.stylex';
 import {xdsClassName, mergeProps} from '../utils';
 import {edgeCompSlot} from '../Layout/edgeCompensation.stylex';
@@ -260,9 +261,9 @@ const styles = stylex.create({
     backgroundColor: colorVars['--color-background-card'],
     paddingBlock: spacingVars['--spacing-3'],
     paddingInline: spacingVars['--spacing-4'],
-    borderLeftWidth: 1,
-    borderRightWidth: 1,
-    borderBottomWidth: 1,
+    borderLeftWidth: borderVars['--border-width'],
+    borderRightWidth: borderVars['--border-width'],
+    borderBottomWidth: borderVars['--border-width'],
     borderLeftStyle: 'solid',
     borderRightStyle: 'solid',
     borderBottomStyle: 'solid',

--- a/packages/core/src/ButtonGroup/XDSButtonGroup.tsx
+++ b/packages/core/src/ButtonGroup/XDSButtonGroup.tsx
@@ -151,7 +151,7 @@ export function XDSButtonGroup({
           aria-disabled={isDisabled || undefined}
           data-testid={testId}
           {...mergeProps(
-            xdsClassName('button-group', {size}),
+            xdsClassName('button-group', {size, orientation}),
             stylex.props(
               styles.group,
               orientation === 'vertical' && styles.vertical,

--- a/packages/core/src/InputGroup/XDSInputGroupText.tsx
+++ b/packages/core/src/InputGroup/XDSInputGroupText.tsx
@@ -25,7 +25,7 @@ import {
   typeScaleVars,
   borderVars,
 } from '../theme/tokens.stylex';
-import {mergeProps} from '../utils';
+import {xdsClassName, mergeProps} from '../utils';
 
 const styles = stylex.create({
   text: {
@@ -106,7 +106,13 @@ export function XDSInputGroupText({
   style,
 }: XDSInputGroupTextProps) {
   return (
-    <div {...mergeProps(stylex.props(styles.text, xstyle), className, style)}>
+    <div
+      {...mergeProps(
+        xdsClassName('input-group-text'),
+        stylex.props(styles.text, xstyle),
+        className,
+        style,
+      )}>
       {children}
     </div>
   );


### PR DESCRIPTION
## Hardening Audit — AvatarGroup, InputGroup, ButtonGroup, Banner

Addresses findings from automated component audit:

### Changes

- **XDSAvatarGroupOverflow**: Add `xdsClassName('avatar-group-overflow')` so themes can target the overflow indicator element
- **XDSInputGroupText**: Add `xdsClassName('input-group-text')` so themes can target the addon text element
- **XDSButtonGroup**: Include `orientation` in the xdsClassName variant map — themes need to know the layout direction
- **XDSBanner**: Replace hardcoded `borderWidth: 1` with `borderVars['--border-width']` token in the content area

### Needs Review

- **XDSAvatarGroupOverflow** does not extend XDSBaseProps (missing escape hatches). Flagged for design decision — the component is always used inside XDSAvatarGroup, so it's unclear if full base props are needed.
- **XDSBreadcrumbItem** similarly lacks XDSBaseProps. These are compositional slot components — decision needed on whether they should be fully customizable.
- **XDSBanner** statusStyles uses a hardcoded map that won't work with custom statuses added via module augmentation (#759 tracks the general variant map pattern migration).

Night Watch — Component Auditor