### PR TITLE
fix(lint): enable rules-of-hooks and purity eslint-react rules

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -99,6 +99,10 @@ export default tseslint.config(
     files: ["packages/core/src/**/*.{ts,tsx}"],
     plugins: eslintReact.configs.recommended.plugins,
     rules: {
+      // React fundamentals
+      '@eslint-react/rules-of-hooks': reactSeverity,
+      '@eslint-react/purity': reactSeverity,
+
       // Component structure bugs
       '@eslint-react/no-nested-component-definitions': reactSeverity,
       '@eslint-react/no-unstable-default-props': reactSeverity,

--- a/packages/core/src/Resizable/useXDSResizable.ts
+++ b/packages/core/src/Resizable/useXDSResizable.ts
@@ -334,6 +334,7 @@ function useMultiResizable(
   // Call hooks unconditionally in stable order (same count every render).
 
   const regionResults = regionEntries.map(([key, regionConfig]) =>
+    // eslint-disable-next-line @eslint-react/rules-of-hooks -- region count is stable (documented contract)
     useSingleResizable({
       ...regionConfig,
       autoSaveId: autoSaveId ? `${autoSaveId}:${key}` : undefined,
@@ -361,7 +362,9 @@ export function useXDSResizable(
   config: UseXDSResizableSingleConfig | UseXDSResizableMultiConfig,
 ): ResizableRegion | Record<string, ResizableRegion> {
   if ('regions' in config) {
+    // eslint-disable-next-line @eslint-react/rules-of-hooks -- branch is determined by call-site type (stable per call site)
     return useMultiResizable(config);
   }
+  // eslint-disable-next-line @eslint-react/rules-of-hooks -- branch is determined by call-site type (stable per call site)
   return useSingleResizable(config);
 }

--- a/packages/core/src/Toast/XDSToast.tsx
+++ b/packages/core/src/Toast/XDSToast.tsx
@@ -117,11 +117,16 @@ export function XDSToast({
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isPausedRef = useRef(false);
   const remainingRef = useRef(autoHideDuration);
-  const startTimeRef = useRef(Date.now());
+  // Will be initialized by startTimer when actually used
+  const startTimeRef = useRef<number | null>(null);
 
   const startTimer = useCallback(() => {
-    if (!isAutoHide) return;
-    if (timerRef.current) clearTimeout(timerRef.current);
+    if (!isAutoHide) {
+      return;
+    }
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+    }
     startTimeRef.current = Date.now();
     timerRef.current = setTimeout(() => {
       onDismiss('auto');
@@ -129,18 +134,24 @@ export function XDSToast({
   }, [isAutoHide, onDismiss]);
 
   const pauseTimer = useCallback(() => {
-    if (!isAutoHide || isPausedRef.current) return;
+    if (!isAutoHide || isPausedRef.current) {
+      return;
+    }
     isPausedRef.current = true;
     if (timerRef.current) {
       clearTimeout(timerRef.current);
       timerRef.current = null;
     }
-    const elapsed = Date.now() - startTimeRef.current;
-    remainingRef.current = Math.max(remainingRef.current - elapsed, 1000);
+    if (startTimeRef.current != null) {
+      const elapsed = Date.now() - startTimeRef.current;
+      remainingRef.current = Math.max(remainingRef.current - elapsed, 1000);
+    }
   }, [isAutoHide]);
 
   const resumeTimer = useCallback(() => {
-    if (!isAutoHide || !isPausedRef.current) return;
+    if (!isAutoHide || !isPausedRef.current) {
+      return;
+    }
     isPausedRef.current = false;
     startTimer();
   }, [isAutoHide, startTimer]);

--- a/packages/core/src/TopNav/XDSTopNavMenu.tsx
+++ b/packages/core/src/TopNav/XDSTopNavMenu.tsx
@@ -320,6 +320,34 @@ export function XDSTopNavMenu({
   const [drawerExpanded, setDrawerExpanded] = useState(false);
   const menuId = useId();
 
+  const slot = useTopNavSlot();
+  const triggerButtonRef = useRef<HTMLButtonElement | null>(null);
+
+  const popover = useXDSPopover({
+    dialogLabel: label,
+    xstyle: styles.menuOffset,
+  });
+
+  const {triggerProps, contentProps, menuRef, setTriggerEl} = useXDSMenuHover({
+    show: popover.show,
+    hide: popover.hide,
+    isOpen: popover.isOpen,
+    isEnabled: true,
+    showDelay: delay,
+    hideDelay,
+  });
+
+  const setTriggerRef = useCallback(
+    (el: HTMLButtonElement | null) => {
+      (
+        triggerButtonRef as React.MutableRefObject<HTMLButtonElement | null>
+      ).current = el;
+      popover.triggerRef(el);
+      setTriggerEl(el);
+    },
+    [popover, setTriggerEl],
+  );
+
   // Mobile bar: hide menus entirely
   if (renderMode === 'mobile-bar') {
     return null;
@@ -382,34 +410,6 @@ export function XDSTopNavMenu({
   }
 
   // Default: desktop popover
-  const slot = useTopNavSlot();
-  const triggerButtonRef = useRef<HTMLButtonElement | null>(null);
-
-  const popover = useXDSPopover({
-    dialogLabel: label,
-    xstyle: styles.menuOffset,
-  });
-
-  const {triggerProps, contentProps, menuRef, setTriggerEl} = useXDSMenuHover({
-    show: popover.show,
-    hide: popover.hide,
-    isOpen: popover.isOpen,
-    isEnabled: true,
-    showDelay: delay,
-    hideDelay,
-  });
-
-  const setTriggerRef = useCallback(
-    (el: HTMLButtonElement | null) => {
-      (
-        triggerButtonRef as React.MutableRefObject<HTMLButtonElement | null>
-      ).current = el;
-      popover.triggerRef(el);
-      setTriggerEl(el);
-    },
-    [popover, setTriggerEl],
-  );
-
   return (
     <>
       <button


### PR DESCRIPTION
## Summary
- Enable `@eslint-react/rules-of-hooks` and `@eslint-react/purity` — two high-value bug-prevention rules that catch hooks called conditionally/in callbacks and side effects during render
- Fix all existing violations:
  - **TopNav/XDSTopNavMenu**: move hooks before early returns so they're called unconditionally
  - **Toast/XDSToast**: replace impure `Date.now()` ref initializer with `null` (value is set by `startTimer()` before use)
  - **Resizable/useXDSResizable**: suppress lint for architecturally safe patterns (stable-count `.map()` hook calls, call-site-determined conditional branches)

## Test plan
- [x] `npx eslint 'packages/core/src/**/*.{ts,tsx}'` passes with zero warnings
- [x] TypeScript compilation (`npx tsc --noEmit`) has no new errors
- [x] Pre-commit hooks (lint-staged, check:sync, check:package-boundaries) pass