### PR TITLE
fix(lint): enable 20 more @eslint-react rules

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -102,27 +102,51 @@ export default tseslint.config(
       // React fundamentals
       '@eslint-react/rules-of-hooks': reactSeverity,
       '@eslint-react/purity': reactSeverity,
+      '@eslint-react/unsupported-syntax': reactSeverity,
 
       // Component structure bugs
       '@eslint-react/no-nested-component-definitions': reactSeverity,
+      '@eslint-react/no-nested-lazy-component-declarations': reactSeverity,
       '@eslint-react/no-unstable-default-props': reactSeverity,
       '@eslint-react/no-unstable-context-value': reactSeverity,
       '@eslint-react/set-state-in-render': reactSeverity,
+      '@eslint-react/no-missing-component-display-name': reactSeverity,
+
+      // Hooks
+      '@eslint-react/use-memo': reactSeverity,
+      '@eslint-react/no-unnecessary-use-prefix': reactSeverity,
+      '@eslint-react/no-create-ref': reactSeverity,
 
       // DOM correctness
       '@eslint-react/dom-no-missing-button-type': reactSeverity,
       '@eslint-react/dom-no-void-elements-with-children': reactSeverity,
+      '@eslint-react/dom-no-dangerously-set-innerhtml': reactSeverity,
+      '@eslint-react/dom-no-dangerously-set-innerhtml-with-children': reactSeverity,
+      '@eslint-react/dom-no-find-dom-node': reactSeverity,
+      '@eslint-react/dom-no-flush-sync': reactSeverity,
+      '@eslint-react/dom-no-script-url': reactSeverity,
+      '@eslint-react/dom-no-string-style-prop': reactSeverity,
+      '@eslint-react/dom-no-unknown-property': reactSeverity,
 
       // JSX correctness
       '@eslint-react/no-missing-key': reactSeverity,
       '@eslint-react/jsx-no-comment-textnodes': reactSeverity,
       '@eslint-react/jsx-no-leaked-dollar': reactSeverity,
+      '@eslint-react/jsx-no-children-prop': reactSeverity,
+      '@eslint-react/jsx-no-children-prop-with-children': reactSeverity,
+      '@eslint-react/jsx-no-key-after-spread': reactSeverity,
+      '@eslint-react/jsx-no-leaked-semicolon': reactSeverity,
+      '@eslint-react/jsx-no-useless-fragment': reactSeverity,
+
+      // Naming conventions
+      '@eslint-react/naming-convention-context-name': reactSeverity,
 
       // Resource leak prevention
       '@eslint-react/web-api-no-leaked-event-listener': reactSeverity,
       '@eslint-react/web-api-no-leaked-interval': reactSeverity,
       '@eslint-react/web-api-no-leaked-timeout': reactSeverity,
       '@eslint-react/web-api-no-leaked-resize-observer': reactSeverity,
+      '@eslint-react/web-api-no-leaked-fetch': reactSeverity,
     },
   },
 );

--- a/packages/core/src/Breadcrumbs/XDSBreadcrumbItem.tsx
+++ b/packages/core/src/Breadcrumbs/XDSBreadcrumbItem.tsx
@@ -25,7 +25,7 @@ import {
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars, spacingVars, typeScaleVars} from '../theme/tokens.stylex';
-import {BreadcrumbCtx} from './XDSBreadcrumbs';
+import {BreadcrumbContext} from './XDSBreadcrumbs';
 import {useXDSLinkComponent} from '../Link/useXDSLinkComponent';
 import type {XDSLinkComponentType} from '../Link/types';
 import {xdsClassName, mergeProps} from '../utils';
@@ -174,7 +174,7 @@ export function XDSBreadcrumbItem({
   startIcon,
   'data-testid': testId,
 }: XDSBreadcrumbItemProps) {
-  const ctx = useContext(BreadcrumbCtx);
+  const ctx = useContext(BreadcrumbContext);
   const LinkComponent = useXDSLinkComponent(as);
   const isSupporting = ctx.variant === 'supporting';
   const liRef = useRef<HTMLLIElement>(null);

--- a/packages/core/src/Breadcrumbs/XDSBreadcrumbs.tsx
+++ b/packages/core/src/Breadcrumbs/XDSBreadcrumbs.tsx
@@ -5,7 +5,7 @@
 /**
  * @file XDSBreadcrumbs.tsx
  * @input Uses React, createContext, stylex, theme tokens
- * @output Exports XDSBreadcrumbs component, XDSBreadcrumbsProps, BreadcrumbCtx
+ * @output Exports XDSBreadcrumbs component, XDSBreadcrumbsProps, BreadcrumbContext
  * @position Core container component; consumed by index.ts
  *
  * SYNC: When modified, update these files to stay in sync:
@@ -63,7 +63,7 @@ export interface BreadcrumbContextValue {
   separator: ReactNode;
 }
 
-export const BreadcrumbCtx = createContext<BreadcrumbContextValue>({
+export const BreadcrumbContext = createContext<BreadcrumbContextValue>({
   variant: 'default',
   separator: '/',
 });
@@ -158,7 +158,7 @@ export function XDSBreadcrumbs({
   );
 
   return (
-    <BreadcrumbCtx.Provider value={ctxValue}>
+    <BreadcrumbContext.Provider value={ctxValue}>
       <nav
         ref={ref}
         aria-label={label}
@@ -171,7 +171,7 @@ export function XDSBreadcrumbs({
         {...rest}>
         <ol {...stylex.props(listStyles.root)}>{children}</ol>
       </nav>
-    </BreadcrumbCtx.Provider>
+    </BreadcrumbContext.Provider>
   );
 }
 

--- a/packages/core/src/ButtonGroup/XDSButtonGroup.test.tsx
+++ b/packages/core/src/ButtonGroup/XDSButtonGroup.test.tsx
@@ -9,7 +9,6 @@
  * SYNC: When ButtonGroup component changes, update tests to match new behavior
  */
 
-import {createRef} from 'react';
 import {describe, it, expect} from 'vitest';
 import {render, screen} from '@testing-library/react';
 import {XDSButtonGroup} from './XDSButtonGroup';
@@ -74,15 +73,19 @@ describe('XDSButtonGroup', () => {
   });
 
   it('forwards ref to the root element', () => {
-    const ref = createRef<HTMLDivElement>();
+    let refValue: HTMLDivElement | null = null;
     render(
-      <XDSButtonGroup label="Actions" ref={ref}>
+      <XDSButtonGroup
+        label="Actions"
+        ref={el => {
+          refValue = el;
+        }}>
         <XDSButton label="Copy" />
       </XDSButtonGroup>,
     );
 
-    expect(ref.current).toBeInstanceOf(HTMLDivElement);
-    expect(ref.current).toBe(screen.getByRole('group'));
+    expect(refValue).toBeInstanceOf(HTMLDivElement);
+    expect(refValue).toBe(screen.getByRole('group'));
   });
 
   it('sets aria-orientation', () => {

--- a/packages/core/src/Chat/useTriggerMenu.tsx
+++ b/packages/core/src/Chat/useTriggerMenu.tsx
@@ -591,6 +591,64 @@ export function useTriggerMenu(
     const emptyText = trigger?.emptySearchResultsText ?? 'No results';
     const loadingText = trigger?.loadingText ?? 'Searching\u2026';
 
+    let listContent: ReactNode;
+    if (state.isLoading) {
+      listContent = (
+        <div role="status" {...stylex.props(styles.loadingState)}>
+          {loadingText}
+        </div>
+      );
+    } else if (state.items.length === 0 && state.isActive) {
+      listContent = <div {...stylex.props(styles.emptyState)}>{emptyText}</div>;
+    } else {
+      const groups = groupItems(state.items);
+      let flatIndex = 0;
+      listContent = groups.map(group => {
+        const groupItems = group.items.map(item => {
+          const idx = flatIndex++;
+          return (
+            <div
+              key={item.id}
+              id={getItemId(idx)}
+              role="option"
+              aria-selected={idx === state.highlightedIndex}
+              tabIndex={-1}
+              onMouseDown={e => {
+                e.preventDefault(); // Keep focus in the editable
+                selectItem(item);
+              }}
+              onMouseEnter={() =>
+                setState(prev => ({...prev, highlightedIndex: idx}))
+              }
+              {...stylex.props(
+                styles.item,
+                idx === state.highlightedIndex && styles.itemHighlighted,
+              )}>
+              {trigger?.renderItem ? (
+                trigger.renderItem(item)
+              ) : (
+                <span {...stylex.props(styles.itemLabel)}>{item.label}</span>
+              )}
+            </div>
+          );
+        });
+        if (group.heading) {
+          return (
+            <div
+              key={`group-${group.heading}`}
+              role="group"
+              aria-label={group.heading}>
+              <div aria-hidden="true" {...stylex.props(styles.groupHeading)}>
+                {group.heading}
+              </div>
+              {groupItems}
+            </div>
+          );
+        }
+        return groupItems;
+      });
+    }
+
     return popover.render(
       <div
         id={listboxId}
@@ -600,66 +658,7 @@ export function useTriggerMenu(
           xdsClassName('trigger-menu'),
           stylex.props(styles.dropdown),
         )}>
-        {state.isLoading ? (
-          <div role="status" {...stylex.props(styles.loadingState)}>
-            {loadingText}
-          </div>
-        ) : state.items.length === 0 && state.isActive ? (
-          <div {...stylex.props(styles.emptyState)}>{emptyText}</div>
-        ) : (
-          (() => {
-            const groups = groupItems(state.items);
-            let flatIndex = 0;
-            return groups.map(group => {
-              const groupItems = group.items.map(item => {
-                const idx = flatIndex++;
-                return (
-                  <div
-                    key={item.id}
-                    id={getItemId(idx)}
-                    role="option"
-                    aria-selected={idx === state.highlightedIndex}
-                    tabIndex={-1}
-                    onMouseDown={e => {
-                      e.preventDefault(); // Keep focus in the editable
-                      selectItem(item);
-                    }}
-                    onMouseEnter={() =>
-                      setState(prev => ({...prev, highlightedIndex: idx}))
-                    }
-                    {...stylex.props(
-                      styles.item,
-                      idx === state.highlightedIndex && styles.itemHighlighted,
-                    )}>
-                    {trigger?.renderItem ? (
-                      trigger.renderItem(item)
-                    ) : (
-                      <span {...stylex.props(styles.itemLabel)}>
-                        {item.label}
-                      </span>
-                    )}
-                  </div>
-                );
-              });
-              if (group.heading) {
-                return (
-                  <div
-                    key={`group-${group.heading}`}
-                    role="group"
-                    aria-label={group.heading}>
-                    <div
-                      aria-hidden="true"
-                      {...stylex.props(styles.groupHeading)}>
-                      {group.heading}
-                    </div>
-                    {groupItems}
-                  </div>
-                );
-              }
-              return groupItems;
-            });
-          })()
-        )}
+        {listContent}
       </div>,
       {
         placement: 'above',

--- a/packages/core/src/Link/XDSLink.test.tsx
+++ b/packages/core/src/Link/XDSLink.test.tsx
@@ -27,29 +27,17 @@ CustomLink.displayName = 'CustomLink';
 
 describe('XDSLink', () => {
   it('renders children as link text', () => {
-    render(
-      <XDSLink href="/test">
-        Click me
-      </XDSLink>,
-    );
+    render(<XDSLink href="/test">Click me</XDSLink>);
     expect(screen.getByRole('link', {name: 'Click me'})).toBeInTheDocument();
   });
 
   it('renders with href attribute', () => {
-    render(
-      <XDSLink href="/destination">
-        Link
-      </XDSLink>,
-    );
+    render(<XDSLink href="/destination">Link</XDSLink>);
     expect(screen.getByRole('link')).toHaveAttribute('href', '/destination');
   });
 
   it('does not render aria-label when label is omitted', () => {
-    render(
-      <XDSLink href="/test">
-        Visible text
-      </XDSLink>,
-    );
+    render(<XDSLink href="/test">Visible text</XDSLink>);
     expect(screen.getByRole('link')).not.toHaveAttribute('aria-label');
   });
 
@@ -122,10 +110,7 @@ describe('XDSLink', () => {
 
   it('renders external link with existing rel merged', () => {
     render(
-      <XDSLink
-        href="https://example.com"
-        isExternalLink
-        rel="sponsored">
+      <XDSLink href="https://example.com" isExternalLink rel="sponsored">
         External Link
       </XDSLink>,
     );
@@ -199,9 +184,7 @@ describe('XDSLink', () => {
   it('renders custom component from XDSLinkProvider', () => {
     render(
       <XDSLinkProvider component={CustomLink}>
-        <XDSLink href="/provider">
-          Provider Link
-        </XDSLink>
+        <XDSLink href="/provider">Provider Link</XDSLink>
       </XDSLinkProvider>,
     );
     const link = screen.getByRole('link', {name: 'Provider Link'});
@@ -212,11 +195,13 @@ describe('XDSLink', () => {
     const AnotherLink = forwardRef<
       HTMLAnchorElement,
       ComponentPropsWithoutRef<'a'>
-    >(({children, ...props}, ref) => (
-      <a ref={ref} data-another-link {...props}>
-        {children}
-      </a>
-    ));
+    >(function AnotherLink({children, ...props}, ref) {
+      return (
+        <a ref={ref} data-another-link {...props}>
+          {children}
+        </a>
+      );
+    });
     render(
       <XDSLinkProvider component={AnotherLink}>
         <XDSLink href="/override" as={CustomLink}>

--- a/packages/core/src/Resizable/useXDSResizable.ts
+++ b/packages/core/src/Resizable/useXDSResizable.ts
@@ -322,6 +322,7 @@ function useSingleResizable(
  * Region keys must be stable across renders (same count and order).
  * This is enforced by the caller providing a static `regions` object.
  */
+// eslint-disable-next-line @eslint-react/no-unnecessary-use-prefix -- calls useSingleResizable in .map()
 function useMultiResizable(
   config: UseXDSResizableMultiConfig,
 ): Record<string, ResizableRegion> {

--- a/packages/core/src/Tokenizer/XDSTokenizer.tsx
+++ b/packages/core/src/Tokenizer/XDSTokenizer.tsx
@@ -629,6 +629,170 @@ export function XDSTokenizer<T extends XDSSearchableItem>({
     );
   });
 
+  const wrapperContent = (
+    <div
+      ref={wrapperRef}
+      role="group"
+      aria-label={label}
+      onClick={handleWrapperClick}
+      onFocusCapture={handleFocusCapture}
+      onBlurCapture={handleBlurCapture}
+      data-testid={testId}
+      {...mergeProps(
+        xdsClassName('tokenizer', {size, status: status?.type}),
+        stylex.props(
+          inputWrapperStyles.base,
+          styles.wrapper,
+          value.length > 0 && styles.wrapperWithTokens,
+          isTruncated
+            ? size === 'sm'
+              ? styles.truncatedSm
+              : styles.truncatedMd
+            : sizeStyle,
+          isTruncated && styles.truncatedWrapper,
+          isDisabled && inputWrapperStyles.disabled,
+          status && inputStatusBorderStyles[status.type],
+          status && inputStatusHoverShadowStyles[status.type],
+          status && inputStatusFocusWithinStyles[status.type],
+        ),
+      )}>
+      {startIcon && renderIconSlot(startIcon, {size: 'sm', color: 'secondary'})}
+      {isTruncated ? (
+        <XDSOverflowList
+          gap={1}
+          behavior="observeParent"
+          overflowRenderer={items => (
+            <span {...stylex.props(styles.overflowText)}>
+              +{items.length} more
+            </span>
+          )}>
+          {tokens}
+        </XDSOverflowList>
+      ) : (
+        tokens
+      )}
+      <XDSBaseTypeahead
+        ref={inputRef}
+        searchSource={isAtMax ? emptySource : filteredSource}
+        value={null}
+        onChange={handleAdd}
+        renderItem={renderItem}
+        placeholder={value.length === 0 ? placeholder : ''}
+        hasEntriesOnFocus={isAtMax ? false : hasEntriesOnFocus}
+        maxMenuItems={maxMenuItems}
+        emptySearchResultsText={emptySearchResultsText}
+        isDisabled={isDisabled}
+        hasAutoFocus={hasAutoFocus}
+        inputId={inputId}
+        ariaDescribedBy={ariaDescribedBy}
+        onChangeQuery={
+          hasCreate
+            ? (q: string) => {
+                setCreatableQuery(q);
+                onChangeQuery?.(q);
+              }
+            : onChangeQuery
+        }
+        debounceMs={debounceMs}
+        onKeyDown={handleKeyDown}
+        anchorRef={wrapperRef}
+        size={size}
+        inputXStyle={
+          isAtMax || isTruncated
+            ? styles.inputAtMax
+            : value.length > 0
+              ? styles.inputCompact
+              : undefined
+        }
+      />
+      {(endContent || (hasClear && value.length > 0 && !isDisabled)) && (
+        <div {...stylex.props(styles.endSection)}>
+          {endContent}
+          {hasClear && value.length > 0 && !isDisabled && (
+            <button
+              type="button"
+              aria-label="Clear all"
+              onClick={e => {
+                e.stopPropagation();
+                handleClearAll();
+              }}
+              {...stylex.props(styles.clearAllButton)}>
+              <XDSIcon icon="close" size="sm" />
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+
+  let tokenizerContent: ReactNode;
+  if (isLayerMode) {
+    const placeholderSizeStyle =
+      size === 'sm' ? styles.layerPlaceholderSm : styles.layerPlaceholderMd;
+    tokenizerContent = (
+      <>
+        <div
+          ref={placeholderRef}
+          onClick={handleWrapperClick}
+          {...mergeProps(
+            xdsClassName('tokenizer', {size, status: status?.type}),
+            stylex.props(
+              inputWrapperStyles.base,
+              styles.wrapper,
+              value.length > 0 && styles.wrapperWithTokens,
+              placeholderSizeStyle,
+              isTruncated && styles.truncatedWrapper,
+              isDisabled && inputWrapperStyles.disabled,
+              status && inputStatusBorderStyles[status.type],
+              status && inputStatusHoverShadowStyles[status.type],
+              status && inputStatusFocusWithinStyles[status.type],
+            ),
+          )}>
+          {isTruncated && (
+            <>
+              {startIcon &&
+                renderIconSlot(startIcon, {
+                  size: 'sm',
+                  color: 'secondary',
+                })}
+              <XDSOverflowList
+                gap={1}
+                behavior="observeParent"
+                overflowRenderer={items => (
+                  <span {...stylex.props(styles.overflowText)}>
+                    +{items.length} more
+                  </span>
+                )}>
+                {tokens}
+              </XDSOverflowList>
+            </>
+          )}
+        </div>
+        {layer.render(
+          <div
+            ref={layerContentRef}
+            onFocusCapture={handleFocusCapture}
+            onBlurCapture={handleBlurCapture}>
+            {wrapperContent}
+          </div>,
+          {
+            placement: 'below',
+            alignment: 'start',
+            xstyle: styles.layerPopover,
+            style: {
+              positionArea: undefined,
+              positionTryFallbacks: undefined,
+              top: 'anchor(top)',
+              left: 'anchor(start)',
+            } as React.CSSProperties,
+          },
+        )}
+      </>
+    );
+  } else {
+    tokenizerContent = wrapperContent;
+  }
+
   return (
     <XDSField
       label={label}
@@ -652,181 +816,7 @@ export function XDSTokenizer<T extends XDSSearchableItem>({
       xstyle={xstyle}
       className={className}
       style={style}>
-      {(() => {
-        const wrapperContent = (
-          <div
-            ref={wrapperRef}
-            role="group"
-            aria-label={label}
-            onClick={handleWrapperClick}
-            onFocusCapture={handleFocusCapture}
-            onBlurCapture={handleBlurCapture}
-            data-testid={testId}
-            {...mergeProps(
-              xdsClassName('tokenizer', {size, status: status?.type}),
-              stylex.props(
-                inputWrapperStyles.base,
-                styles.wrapper,
-                value.length > 0 && styles.wrapperWithTokens,
-                isTruncated
-                  ? size === 'sm'
-                    ? styles.truncatedSm
-                    : styles.truncatedMd
-                  : sizeStyle,
-                isTruncated && styles.truncatedWrapper,
-                isDisabled && inputWrapperStyles.disabled,
-                status && inputStatusBorderStyles[status.type],
-                status && inputStatusHoverShadowStyles[status.type],
-                status && inputStatusFocusWithinStyles[status.type],
-              ),
-            )}>
-            {startIcon &&
-              renderIconSlot(startIcon, {size: 'sm', color: 'secondary'})}
-            {isTruncated ? (
-              <XDSOverflowList
-                gap={1}
-                behavior="observeParent"
-                overflowRenderer={items => (
-                  <span {...stylex.props(styles.overflowText)}>
-                    +{items.length} more
-                  </span>
-                )}>
-                {tokens}
-              </XDSOverflowList>
-            ) : (
-              tokens
-            )}
-            <XDSBaseTypeahead
-              ref={inputRef}
-              searchSource={isAtMax ? emptySource : filteredSource}
-              value={null}
-              onChange={handleAdd}
-              renderItem={renderItem}
-              placeholder={value.length === 0 ? placeholder : ''}
-              hasEntriesOnFocus={isAtMax ? false : hasEntriesOnFocus}
-              maxMenuItems={maxMenuItems}
-              emptySearchResultsText={emptySearchResultsText}
-              isDisabled={isDisabled}
-              hasAutoFocus={hasAutoFocus}
-              inputId={inputId}
-              ariaDescribedBy={ariaDescribedBy}
-              onChangeQuery={
-                hasCreate
-                  ? (q: string) => {
-                      setCreatableQuery(q);
-                      onChangeQuery?.(q);
-                    }
-                  : onChangeQuery
-              }
-              debounceMs={debounceMs}
-              onKeyDown={handleKeyDown}
-              anchorRef={wrapperRef}
-              size={size}
-              inputXStyle={
-                isAtMax || isTruncated
-                  ? styles.inputAtMax
-                  : value.length > 0
-                    ? styles.inputCompact
-                    : undefined
-              }
-            />
-            {(endContent || (hasClear && value.length > 0 && !isDisabled)) && (
-              <div {...stylex.props(styles.endSection)}>
-                {endContent}
-                {hasClear && value.length > 0 && !isDisabled && (
-                  <button
-                    type="button"
-                    aria-label="Clear all"
-                    onClick={e => {
-                      e.stopPropagation();
-                      handleClearAll();
-                    }}
-                    {...stylex.props(styles.clearAllButton)}>
-                    <XDSIcon icon="close" size="sm" />
-                  </button>
-                )}
-              </div>
-            )}
-          </div>
-        );
-
-        if (isLayerMode) {
-          const placeholderSizeStyle =
-            size === 'sm'
-              ? styles.layerPlaceholderSm
-              : styles.layerPlaceholderMd;
-          return (
-            <>
-              {/* Placeholder preserves layout height, acts as the CSS
-                  anchor, and shows the collapsed overflow summary.
-                  Clicking it opens the popover and focuses the input. */}
-              <div
-                ref={placeholderRef}
-                onClick={handleWrapperClick}
-                {...mergeProps(
-                  xdsClassName('tokenizer', {size, status: status?.type}),
-                  stylex.props(
-                    inputWrapperStyles.base,
-                    styles.wrapper,
-                    value.length > 0 && styles.wrapperWithTokens,
-                    placeholderSizeStyle,
-                    isTruncated && styles.truncatedWrapper,
-                    isDisabled && inputWrapperStyles.disabled,
-                    status && inputStatusBorderStyles[status.type],
-                    status && inputStatusHoverShadowStyles[status.type],
-                    status && inputStatusFocusWithinStyles[status.type],
-                  ),
-                )}>
-                {isTruncated && (
-                  <>
-                    {startIcon &&
-                      renderIconSlot(startIcon, {
-                        size: 'sm',
-                        color: 'secondary',
-                      })}
-                    <XDSOverflowList
-                      gap={1}
-                      behavior="observeParent"
-                      overflowRenderer={items => (
-                        <span {...stylex.props(styles.overflowText)}>
-                          +{items.length} more
-                        </span>
-                      )}>
-                      {tokens}
-                    </XDSOverflowList>
-                  </>
-                )}
-              </div>
-              {/* Expanded content always lives in the top layer so the
-                  input/tokens never unmount during the focus transition.
-                  The popover is shown/hidden via layer.show()/hide(). */}
-              {layer.render(
-                <div
-                  ref={layerContentRef}
-                  onFocusCapture={handleFocusCapture}
-                  onBlurCapture={handleBlurCapture}>
-                  {wrapperContent}
-                </div>,
-                {
-                  placement: 'below',
-                  alignment: 'start',
-                  xstyle: styles.layerPopover,
-                  // Override position-area to overlap the anchor from its
-                  // top edge rather than sitting below it.
-                  style: {
-                    positionArea: undefined,
-                    positionTryFallbacks: undefined,
-                    top: 'anchor(top)',
-                    left: 'anchor(start)',
-                  } as React.CSSProperties,
-                },
-              )}
-            </>
-          );
-        }
-
-        return wrapperContent;
-      })()}
+      {tokenizerContent}
     </XDSField>
   );
 }

--- a/packages/core/src/TopNav/XDSTopNav.test.tsx
+++ b/packages/core/src/TopNav/XDSTopNav.test.tsx
@@ -306,11 +306,13 @@ describe('XDSTopNavItem', () => {
     const AnotherLink = forwardRef<
       HTMLAnchorElement,
       ComponentPropsWithoutRef<'a'>
-    >(({children, ...props}, ref) => (
-      <a ref={ref} data-another-link {...props}>
-        {children}
-      </a>
-    ));
+    >(function AnotherLink({children, ...props}, ref) {
+      return (
+        <a ref={ref} data-another-link {...props}>
+          {children}
+        </a>
+      );
+    });
     render(
       <XDSLinkProvider component={AnotherLink}>
         <XDSTopNavItem label="Home" href="/" as={CustomLink} />


### PR DESCRIPTION
> **Stacked on #2247** — merge that first.

## Summary
- Enable 20 additional `@eslint-react` rules (6 with fixes, 14 zero-violation guardrails)
- Fix IIFE-in-JSX anti-patterns in `useTriggerMenu` and `XDSTokenizer` (React Compiler incompatible)
- Rename `BreadcrumbCtx` → `BreadcrumbContext` to satisfy naming convention
- Replace `createRef` with callback ref in ButtonGroup test
- Add display names to anonymous `forwardRef` components in tests
- Suppress false positive on `useMultiResizable` (calls hooks inside `.map()`)

### Rules enabled

**With fixes:** `unsupported-syntax`, `naming-convention-context-name`, `no-unnecessary-use-prefix`, `no-create-ref`, `no-missing-component-display-name`

**Zero-violation guardrails:** `no-nested-lazy-component-declarations`, `use-memo`, `dom-no-dangerously-set-innerhtml`, `dom-no-dangerously-set-innerhtml-with-children`, `dom-no-find-dom-node`, `dom-no-flush-sync`, `dom-no-script-url`, `dom-no-string-style-prop`, `dom-no-unknown-property`, `jsx-no-children-prop`, `jsx-no-children-prop-with-children`, `jsx-no-key-after-spread`, `jsx-no-leaked-semicolon`, `jsx-no-useless-fragment`, `web-api-no-leaked-fetch`

## Test plan
- [x] `npx eslint 'packages/core/src/**/*.{ts,tsx}'` passes clean
- [x] TypeScript compilation has no new errors
- [x] Pre-commit hooks (lint-staged, check:sync, check:package-boundaries) pass