### PR TITLE
fix(lint): enable no-forward-ref eslint-react rule

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -117,6 +117,7 @@ export default tseslint.config(
       '@eslint-react/use-memo': reactSeverity,
       '@eslint-react/no-unnecessary-use-prefix': reactSeverity,
       '@eslint-react/no-create-ref': reactSeverity,
+      '@eslint-react/no-forward-ref': reactSeverity,
 
       // DOM correctness
       '@eslint-react/dom-no-missing-button-type': reactSeverity,

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -118,6 +118,7 @@ export default tseslint.config(
       '@eslint-react/no-unnecessary-use-prefix': reactSeverity,
       '@eslint-react/no-create-ref': reactSeverity,
       '@eslint-react/no-forward-ref': reactSeverity,
+      '@eslint-react/no-unused-state': reactSeverity,
 
       // DOM correctness
       '@eslint-react/dom-no-missing-button-type': reactSeverity,
@@ -142,6 +143,7 @@ export default tseslint.config(
 
       // Naming conventions
       '@eslint-react/naming-convention-context-name': reactSeverity,
+      '@eslint-react/naming-convention-ref-name': reactSeverity,
 
       // Resource leak prevention
       '@eslint-react/web-api-no-leaked-event-listener': reactSeverity,

--- a/packages/core/src/Breadcrumbs/XDSBreadcrumbs.test.tsx
+++ b/packages/core/src/Breadcrumbs/XDSBreadcrumbs.test.tsx
@@ -3,19 +3,21 @@
 import {describe, it, expect, vi} from 'vitest';
 import {render, screen, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import {forwardRef, type ComponentPropsWithoutRef} from 'react';
 import {XDSBreadcrumbs} from './XDSBreadcrumbs';
 import {XDSBreadcrumbItem} from './XDSBreadcrumbItem';
 import {XDSLinkProvider} from '../Link/XDSLinkProvider';
 
-const CustomLink = forwardRef<HTMLAnchorElement, ComponentPropsWithoutRef<'a'>>(
-  ({children, ...props}, ref) => (
+function CustomLink({
+  children,
+  ref,
+  ...props
+}: React.ComponentPropsWithRef<'a'>) {
+  return (
     <a ref={ref} data-custom-link {...props}>
       {children}
     </a>
-  ),
-);
-CustomLink.displayName = 'CustomLink';
+  );
+}
 
 describe('XDSBreadcrumbs', () => {
   it('renders a nav landmark with aria-label', () => {

--- a/packages/core/src/CheckboxList/XDSCheckboxListItem.tsx
+++ b/packages/core/src/CheckboxList/XDSCheckboxListItem.tsx
@@ -16,7 +16,7 @@
  * - /packages/cli/templates/blocks/components/CheckboxList/ (showcase blocks)
  */
 
-import {useContext, useState, type ReactNode} from 'react';
+import {useContext, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import {colorVars} from '../theme/tokens.stylex';
@@ -127,8 +127,6 @@ export function XDSCheckboxListItem({
     );
   }
 
-  const [_isFocused, setIsFocused] = useState(false);
-
   // Density from list context for checkbox sizing
   const listCtx = useContext(XDSListContext);
   const density = listCtx?.density ?? 'balanced';
@@ -201,8 +199,6 @@ export function XDSCheckboxListItem({
           isLabelHidden
           value={resolvedChecked}
           onChange={() => handleToggle()}
-          onFocus={() => setIsFocused(true)}
-          onBlur={() => setIsFocused(false)}
           isDisabled={effectiveDisabled}
           isReadOnly={effectiveReadOnly}
           size={checkboxSize}

--- a/packages/core/src/ContextMenu/XDSContextMenu.tsx
+++ b/packages/core/src/ContextMenu/XDSContextMenu.tsx
@@ -187,6 +187,7 @@ export function XDSContextMenu({
 
   const menuId = useId();
   const positionRef = useRef({x: 0, y: 0});
+  // eslint-disable-next-line @eslint-react/no-unused-state -- isOpen triggers the click-outside effect
   const [isOpen, setIsOpen] = useState(false);
 
   const layer = useXDSLayer({

--- a/packages/core/src/DropdownMenu/XDSDropdownMenu.tsx
+++ b/packages/core/src/DropdownMenu/XDSDropdownMenu.tsx
@@ -208,7 +208,7 @@ export function XDSDropdownMenu({
   }, [isControlled, onOpenChange]);
 
   // Track whether to focus the first item when the menu opens
-  const shouldFocusOnOpen = useRef(false);
+  const shouldFocusOnOpenRef = useRef(false);
 
   const handleLayerShow = useCallback(() => {
     if (isControlled) {
@@ -216,8 +216,8 @@ export function XDSDropdownMenu({
     } else {
       setInternalIsOpen(true);
     }
-    if (shouldFocusOnOpen.current) {
-      shouldFocusOnOpen.current = false;
+    if (shouldFocusOnOpenRef.current) {
+      shouldFocusOnOpenRef.current = false;
       // focusFirst is called via openAndFocus below — defer to rAF
       // so the popover content is rendered before we query for items
     }

--- a/packages/core/src/Link/XDSLink.test.tsx
+++ b/packages/core/src/Link/XDSLink.test.tsx
@@ -12,18 +12,20 @@
 import {describe, it, expect, vi} from 'vitest';
 import {render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import {forwardRef, type ComponentPropsWithoutRef} from 'react';
 import {XDSLink} from './XDSLink';
 import {XDSLinkProvider} from './XDSLinkProvider';
 
-const CustomLink = forwardRef<HTMLAnchorElement, ComponentPropsWithoutRef<'a'>>(
-  ({children, ...props}, ref) => (
+function CustomLink({
+  children,
+  ref,
+  ...props
+}: React.ComponentPropsWithRef<'a'>) {
+  return (
     <a ref={ref} data-custom-link {...props}>
       {children}
     </a>
-  ),
-);
-CustomLink.displayName = 'CustomLink';
+  );
+}
 
 describe('XDSLink', () => {
   it('renders children as link text', () => {
@@ -192,16 +194,17 @@ describe('XDSLink', () => {
   });
 
   it('as prop overrides XDSLinkProvider', () => {
-    const AnotherLink = forwardRef<
-      HTMLAnchorElement,
-      ComponentPropsWithoutRef<'a'>
-    >(function AnotherLink({children, ...props}, ref) {
+    function AnotherLink({
+      children,
+      ref,
+      ...props
+    }: React.ComponentPropsWithRef<'a'>) {
       return (
         <a ref={ref} data-another-link {...props}>
           {children}
         </a>
       );
-    });
+    }
     render(
       <XDSLinkProvider component={AnotherLink}>
         <XDSLink href="/override" as={CustomLink}>

--- a/packages/core/src/Link/useXDSLinkComponent.test.tsx
+++ b/packages/core/src/Link/useXDSLinkComponent.test.tsx
@@ -9,7 +9,6 @@
 
 import {describe, it, expect, vi} from 'vitest';
 import {render, screen} from '@testing-library/react';
-import {forwardRef, type ComponentPropsWithoutRef} from 'react';
 import {useXDSLinkComponent} from './useXDSLinkComponent';
 import {XDSLinkProvider} from './XDSLinkProvider';
 import type {XDSLinkComponentType} from './types';
@@ -24,43 +23,52 @@ function TestConsumer({as}: {as?: XDSLinkComponentType}) {
   );
 }
 
-const CustomLink = forwardRef<HTMLAnchorElement, ComponentPropsWithoutRef<'a'>>(
-  ({children, ...props}, ref) => (
+function CustomLink({
+  children,
+  ref,
+  ...props
+}: React.ComponentPropsWithRef<'a'>) {
+  return (
     <a ref={ref} data-custom-link {...props}>
       {children}
     </a>
-  ),
-);
-CustomLink.displayName = 'CustomLink';
+  );
+}
 
-const AnotherLink = forwardRef<
-  HTMLAnchorElement,
-  ComponentPropsWithoutRef<'a'>
->(({children, ...props}, ref) => (
-  <a ref={ref} data-another-link {...props}>
-    {children}
-  </a>
-));
-AnotherLink.displayName = 'AnotherLink';
+function AnotherLink({
+  children,
+  ref,
+  ...props
+}: React.ComponentPropsWithRef<'a'>) {
+  return (
+    <a ref={ref} data-another-link {...props}>
+      {children}
+    </a>
+  );
+}
 
 /**
  * A mock "to"-based router link that reads `to` instead of `href`.
  * Simulates React Router / TanStack Router behavior.
  */
-const ToBasedRouterLink = forwardRef<
-  HTMLAnchorElement,
-  {
-    to?: string;
-    href?: string;
-    children?: React.ReactNode;
-    [key: string]: unknown;
-  }
->(({to, children, ...props}, ref) => (
-  <a ref={ref} href={to} data-router-link data-to={to} {...props}>
-    {children}
-  </a>
-));
-ToBasedRouterLink.displayName = 'ToBasedRouterLink';
+function ToBasedRouterLink({
+  to,
+  children,
+  ref,
+  ...props
+}: {
+  to?: string;
+  href?: string;
+  children?: React.ReactNode;
+  ref?: React.Ref<HTMLAnchorElement>;
+  [key: string]: unknown;
+}) {
+  return (
+    <a ref={ref} href={to} data-router-link data-to={to} {...props}>
+      {children}
+    </a>
+  );
+}
 
 // =============================================================================
 // useXDSLinkComponent
@@ -126,11 +134,12 @@ describe('useXDSLinkComponent — to prop', () => {
         </a>
       ),
     );
-    const SpyLink = forwardRef<
-      HTMLAnchorElement,
-      {children?: React.ReactNode; [key: string]: unknown}
-    >((props, _ref) => spy(props));
-    SpyLink.displayName = 'SpyLink';
+    function SpyLink(props: {
+      children?: React.ReactNode;
+      [key: string]: unknown;
+    }) {
+      return spy(props);
+    }
 
     render(
       <XDSLinkProvider component={SpyLink}>
@@ -157,11 +166,12 @@ describe('useXDSLinkComponent — to prop', () => {
         </a>
       ),
     );
-    const SpyLink = forwardRef<
-      HTMLAnchorElement,
-      {children?: React.ReactNode; [key: string]: unknown}
-    >((props, _ref) => spy(props));
-    SpyLink.displayName = 'SpyLink';
+    function SpyLink(props: {
+      children?: React.ReactNode;
+      [key: string]: unknown;
+    }) {
+      return spy(props);
+    }
 
     render(<TestConsumer as={SpyLink} />);
 

--- a/packages/core/src/Link/useXDSLinkComponent.ts
+++ b/packages/core/src/Link/useXDSLinkComponent.ts
@@ -20,7 +20,7 @@
  * - /packages/core/src/Link/Link.doc.mjs
  */
 
-import {useContext, useMemo, forwardRef, createElement} from 'react';
+import {useContext, useMemo, createElement} from 'react';
 import {XDSLinkContext} from './XDSLinkContext';
 import type {XDSLinkComponentType} from './types';
 
@@ -35,11 +35,17 @@ import type {XDSLinkComponentType} from './types';
 function createLinkWithTo(
   Component: XDSLinkComponentType,
 ): XDSLinkComponentType {
-  const LinkWithTo = forwardRef<unknown, {href?: string; to?: string}>(
-    ({href, ...rest}, ref) => {
-      return createElement(Component, {ref, href, to: href, ...rest});
-    },
-  );
+  function LinkWithTo({
+    href,
+    ref,
+    ...rest
+  }: {
+    href?: string;
+    to?: string;
+    ref?: React.Ref<unknown>;
+  }) {
+    return createElement(Component, {ref, href, to: href, ...rest});
+  }
   LinkWithTo.displayName = `LinkWithTo(${
     typeof Component === 'string'
       ? Component

--- a/packages/core/src/Markdown/XDSMarkdown.tsx
+++ b/packages/core/src/Markdown/XDSMarkdown.tsx
@@ -1541,7 +1541,9 @@ export function XDSMarkdown({
   // When not streaming, the hook returns children unchanged (no-op).
   const smoothedText = useXDSStreamingText(children, isStreaming);
 
-  const incrementalState = useRef<IncrementalState>(createIncrementalState());
+  const incrementalStateRef = useRef<IncrementalState>(
+    createIncrementalState(),
+  );
   // Track how much text content was rendered on the previous pass.
   // Everything beyond this boundary is "new" and gets the fade-in animation.
   const prevTextLenRef = useRef(0);
@@ -1549,14 +1551,14 @@ export function XDSMarkdown({
   const blocks = useMemo(() => {
     if (isStreaming) {
       if (smoothedText === '') {
-        incrementalState.current = createIncrementalState();
+        incrementalStateRef.current = createIncrementalState();
         prevTextLenRef.current = 0;
         return [];
       }
       const input = trimStreamingArtifacts(smoothedText);
       return parseMarkdownIncremental(
         input,
-        incrementalState.current,
+        incrementalStateRef.current,
         sourceIds,
       );
     }

--- a/packages/core/src/Resizable/useXDSResizable.ts
+++ b/packages/core/src/Resizable/useXDSResizable.ts
@@ -203,8 +203,8 @@ function useSingleResizable(
   const [isCollapsed, setIsCollapsed] = useState(
     () => persisted === 0 && collapsible,
   );
-  const preCollapseSize = useRef(size);
-  const dragStartSize = useRef(size);
+  const preCollapseSizeRef = useRef(size);
+  const dragStartSizeRef = useRef(size);
 
   useEffect(() => {
     if (autoSaveId) {
@@ -214,7 +214,7 @@ function useSingleResizable(
 
   const collapse = useCallback(() => {
     if (!collapsible) return;
-    preCollapseSize.current = size;
+    preCollapseSizeRef.current = size;
     setIsCollapsed(true);
     setSize(0);
     onCollapseChange?.(true);
@@ -223,7 +223,7 @@ function useSingleResizable(
 
   const expand = useCallback(() => {
     setIsCollapsed(false);
-    const restored = preCollapseSize.current || resolvedDefault;
+    const restored = preCollapseSizeRef.current || resolvedDefault;
     const newSize = clampSize(restored, minSizePx, maxSizePx, snaps);
     setSize(newSize);
     onCollapseChange?.(false);
@@ -248,15 +248,15 @@ function useSingleResizable(
   );
 
   const onResizeStart = useCallback(() => {
-    dragStartSize.current = isCollapsed ? 0 : size;
+    dragStartSizeRef.current = isCollapsed ? 0 : size;
   }, [size, isCollapsed]);
 
   const onResizeMove = useCallback(
     (delta: number) => {
-      const raw = dragStartSize.current + delta;
+      const raw = dragStartSizeRef.current + delta;
       if (collapsible && raw < collapsedSize) {
         if (!isCollapsed) {
-          preCollapseSize.current = size;
+          preCollapseSizeRef.current = size;
           onCollapseChange?.(true);
         }
         setIsCollapsed(true);

--- a/packages/core/src/SideNav/XDSSideNav.test.tsx
+++ b/packages/core/src/SideNav/XDSSideNav.test.tsx
@@ -13,7 +13,7 @@ import React from 'react';
 import {describe, it, expect, vi} from 'vitest';
 import {render, screen, act, fireEvent} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import {forwardRef, type ComponentPropsWithoutRef, type ReactNode} from 'react';
+import {type ReactNode} from 'react';
 import {XDSSideNav} from './XDSSideNav';
 import {XDSSideNavHeading} from './XDSSideNavHeading';
 import {XDSSideNavItem} from './XDSSideNavItem';
@@ -21,14 +21,17 @@ import {XDSSideNavSection} from './XDSSideNavSection';
 import {XDSLinkProvider} from '../Link/XDSLinkProvider';
 import {XDSSideNavCollapseContext} from './XDSSideNavCollapseContext';
 
-const CustomLink = forwardRef<HTMLAnchorElement, ComponentPropsWithoutRef<'a'>>(
-  ({children, ...props}, ref) => (
+function CustomLink({
+  children,
+  ref,
+  ...props
+}: React.ComponentPropsWithRef<'a'>) {
+  return (
     <a ref={ref} data-custom-link {...props}>
       {children}
     </a>
-  ),
-);
-CustomLink.displayName = 'CustomLink';
+  );
+}
 
 // =============================================================================
 // XDSSideNav

--- a/packages/core/src/TabList/XDSTabList.test.tsx
+++ b/packages/core/src/TabList/XDSTabList.test.tsx
@@ -12,20 +12,22 @@
 import {describe, it, expect, vi, beforeAll, afterAll} from 'vitest';
 import {render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import {forwardRef, type ComponentPropsWithoutRef} from 'react';
 import {XDSTabList} from './XDSTabList';
 import {XDSTab} from './XDSTab';
 import {XDSTabMenu} from './XDSTabMenu';
 import {XDSLinkProvider} from '../Link/XDSLinkProvider';
 
-const CustomLink = forwardRef<HTMLAnchorElement, ComponentPropsWithoutRef<'a'>>(
-  ({children, ...props}, ref) => (
+function CustomLink({
+  children,
+  ref,
+  ...props
+}: React.ComponentPropsWithRef<'a'>) {
+  return (
     <a ref={ref} data-custom-link {...props}>
       {children}
     </a>
-  ),
-);
-CustomLink.displayName = 'CustomLink';
+  );
+}
 
 // Store original matches to restore later
 const originalMatches = HTMLElement.prototype.matches;

--- a/packages/core/src/Tokenizer/XDSTokenizer.tsx
+++ b/packages/core/src/Tokenizer/XDSTokenizer.tsx
@@ -470,9 +470,6 @@ export function XDSTokenizer<T extends XDSSearchableItem>({
     [value],
   );
 
-  // Track the current query for creatable mode
-  const [_creatableQuery, setCreatableQuery] = useState('');
-
   const filteredSource: XDSSearchSource<T> = useMemo(
     () => ({
       search: async (query: string) => {
@@ -685,14 +682,7 @@ export function XDSTokenizer<T extends XDSSearchableItem>({
         hasAutoFocus={hasAutoFocus}
         inputId={inputId}
         ariaDescribedBy={ariaDescribedBy}
-        onChangeQuery={
-          hasCreate
-            ? (q: string) => {
-                setCreatableQuery(q);
-                onChangeQuery?.(q);
-              }
-            : onChangeQuery
-        }
+        onChangeQuery={onChangeQuery}
         debounceMs={debounceMs}
         onKeyDown={handleKeyDown}
         anchorRef={wrapperRef}

--- a/packages/core/src/TopNav/XDSTopNav.test.tsx
+++ b/packages/core/src/TopNav/XDSTopNav.test.tsx
@@ -12,21 +12,23 @@
 import {describe, it, expect, vi} from 'vitest';
 import {render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import {forwardRef, type ComponentPropsWithoutRef} from 'react';
 import {XDSTopNav} from './XDSTopNav';
 import {XDSTopNavHeading} from './XDSTopNavHeading';
 import {XDSNavIcon} from '../NavIcon';
 import {XDSTopNavItem} from './XDSTopNavItem';
 import {XDSLinkProvider} from '../Link/XDSLinkProvider';
 
-const CustomLink = forwardRef<HTMLAnchorElement, ComponentPropsWithoutRef<'a'>>(
-  ({children, ...props}, ref) => (
+function CustomLink({
+  children,
+  ref,
+  ...props
+}: React.ComponentPropsWithRef<'a'>) {
+  return (
     <a ref={ref} data-custom-link {...props}>
       {children}
     </a>
-  ),
-);
-CustomLink.displayName = 'CustomLink';
+  );
+}
 
 describe('XDSTopNav', () => {
   it('renders with navigation role', () => {
@@ -303,16 +305,17 @@ describe('XDSTopNavItem', () => {
   });
 
   it('as prop overrides XDSLinkProvider', () => {
-    const AnotherLink = forwardRef<
-      HTMLAnchorElement,
-      ComponentPropsWithoutRef<'a'>
-    >(function AnotherLink({children, ...props}, ref) {
+    function AnotherLink({
+      children,
+      ref,
+      ...props
+    }: React.ComponentPropsWithRef<'a'>) {
       return (
         <a ref={ref} data-another-link {...props}>
           {children}
         </a>
       );
-    });
+    }
     render(
       <XDSLinkProvider component={AnotherLink}>
         <XDSTopNavItem label="Home" href="/" as={CustomLink} />


### PR DESCRIPTION
> **Stacked on #2250** — merge that first.

## Summary

Enable `@eslint-react/no-forward-ref` to enforce React 19's ref-as-prop pattern. Remove all `forwardRef` usage across the codebase.

### Changes

**Production code (1 file):**
- `Link/useXDSLinkComponent.ts`: convert `createLinkWithTo` wrapper from `forwardRef` to a plain function component accepting `ref` as a prop

**Test files (6 files):**
- Convert `CustomLink`, `AnotherLink`, `ToBasedRouterLink`, `SpyLink` helpers from `forwardRef` to plain function components using `React.ComponentPropsWithRef<'a'>`
- Remove unused `forwardRef` / `ComponentPropsWithoutRef` imports

## Test plan
- [x] `npx eslint 'packages/core/src/**/*.{ts,tsx}'` passes clean
- [x] Pre-commit hooks pass