### PR TITLE
fix(lint): enable naming-convention-ref-name and no-unused-state rules

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -118,6 +118,7 @@ export default tseslint.config(
       '@eslint-react/no-unnecessary-use-prefix': reactSeverity,
       '@eslint-react/no-create-ref': reactSeverity,
       '@eslint-react/no-forward-ref': reactSeverity,
+      '@eslint-react/no-unused-state': reactSeverity,
 
       // DOM correctness
       '@eslint-react/dom-no-missing-button-type': reactSeverity,
@@ -142,6 +143,7 @@ export default tseslint.config(
 
       // Naming conventions
       '@eslint-react/naming-convention-context-name': reactSeverity,
+      '@eslint-react/naming-convention-ref-name': reactSeverity,
 
       // Resource leak prevention
       '@eslint-react/web-api-no-leaked-event-listener': reactSeverity,

--- a/packages/core/src/CheckboxList/XDSCheckboxListItem.tsx
+++ b/packages/core/src/CheckboxList/XDSCheckboxListItem.tsx
@@ -16,7 +16,7 @@
  * - /packages/cli/templates/blocks/components/CheckboxList/ (showcase blocks)
  */
 
-import {useContext, useState, type ReactNode} from 'react';
+import {useContext, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import {colorVars} from '../theme/tokens.stylex';
@@ -127,8 +127,6 @@ export function XDSCheckboxListItem({
     );
   }
 
-  const [_isFocused, setIsFocused] = useState(false);
-
   // Density from list context for checkbox sizing
   const listCtx = useContext(XDSListContext);
   const density = listCtx?.density ?? 'balanced';
@@ -201,8 +199,6 @@ export function XDSCheckboxListItem({
           isLabelHidden
           value={resolvedChecked}
           onChange={() => handleToggle()}
-          onFocus={() => setIsFocused(true)}
-          onBlur={() => setIsFocused(false)}
           isDisabled={effectiveDisabled}
           isReadOnly={effectiveReadOnly}
           size={checkboxSize}

--- a/packages/core/src/ContextMenu/XDSContextMenu.tsx
+++ b/packages/core/src/ContextMenu/XDSContextMenu.tsx
@@ -187,6 +187,7 @@ export function XDSContextMenu({
 
   const menuId = useId();
   const positionRef = useRef({x: 0, y: 0});
+  // eslint-disable-next-line @eslint-react/no-unused-state -- isOpen triggers the click-outside effect
   const [isOpen, setIsOpen] = useState(false);
 
   const layer = useXDSLayer({

--- a/packages/core/src/DropdownMenu/XDSDropdownMenu.tsx
+++ b/packages/core/src/DropdownMenu/XDSDropdownMenu.tsx
@@ -208,7 +208,7 @@ export function XDSDropdownMenu({
   }, [isControlled, onOpenChange]);
 
   // Track whether to focus the first item when the menu opens
-  const shouldFocusOnOpen = useRef(false);
+  const shouldFocusOnOpenRef = useRef(false);
 
   const handleLayerShow = useCallback(() => {
     if (isControlled) {
@@ -216,8 +216,8 @@ export function XDSDropdownMenu({
     } else {
       setInternalIsOpen(true);
     }
-    if (shouldFocusOnOpen.current) {
-      shouldFocusOnOpen.current = false;
+    if (shouldFocusOnOpenRef.current) {
+      shouldFocusOnOpenRef.current = false;
       // focusFirst is called via openAndFocus below — defer to rAF
       // so the popover content is rendered before we query for items
     }

--- a/packages/core/src/Markdown/XDSMarkdown.tsx
+++ b/packages/core/src/Markdown/XDSMarkdown.tsx
@@ -1541,7 +1541,9 @@ export function XDSMarkdown({
   // When not streaming, the hook returns children unchanged (no-op).
   const smoothedText = useXDSStreamingText(children, isStreaming);
 
-  const incrementalState = useRef<IncrementalState>(createIncrementalState());
+  const incrementalStateRef = useRef<IncrementalState>(
+    createIncrementalState(),
+  );
   // Track how much text content was rendered on the previous pass.
   // Everything beyond this boundary is "new" and gets the fade-in animation.
   const prevTextLenRef = useRef(0);
@@ -1549,14 +1551,14 @@ export function XDSMarkdown({
   const blocks = useMemo(() => {
     if (isStreaming) {
       if (smoothedText === '') {
-        incrementalState.current = createIncrementalState();
+        incrementalStateRef.current = createIncrementalState();
         prevTextLenRef.current = 0;
         return [];
       }
       const input = trimStreamingArtifacts(smoothedText);
       return parseMarkdownIncremental(
         input,
-        incrementalState.current,
+        incrementalStateRef.current,
         sourceIds,
       );
     }

--- a/packages/core/src/Resizable/useXDSResizable.ts
+++ b/packages/core/src/Resizable/useXDSResizable.ts
@@ -203,8 +203,8 @@ function useSingleResizable(
   const [isCollapsed, setIsCollapsed] = useState(
     () => persisted === 0 && collapsible,
   );
-  const preCollapseSize = useRef(size);
-  const dragStartSize = useRef(size);
+  const preCollapseSizeRef = useRef(size);
+  const dragStartSizeRef = useRef(size);
 
   useEffect(() => {
     if (autoSaveId) {
@@ -214,7 +214,7 @@ function useSingleResizable(
 
   const collapse = useCallback(() => {
     if (!collapsible) return;
-    preCollapseSize.current = size;
+    preCollapseSizeRef.current = size;
     setIsCollapsed(true);
     setSize(0);
     onCollapseChange?.(true);
@@ -223,7 +223,7 @@ function useSingleResizable(
 
   const expand = useCallback(() => {
     setIsCollapsed(false);
-    const restored = preCollapseSize.current || resolvedDefault;
+    const restored = preCollapseSizeRef.current || resolvedDefault;
     const newSize = clampSize(restored, minSizePx, maxSizePx, snaps);
     setSize(newSize);
     onCollapseChange?.(false);
@@ -248,15 +248,15 @@ function useSingleResizable(
   );
 
   const onResizeStart = useCallback(() => {
-    dragStartSize.current = isCollapsed ? 0 : size;
+    dragStartSizeRef.current = isCollapsed ? 0 : size;
   }, [size, isCollapsed]);
 
   const onResizeMove = useCallback(
     (delta: number) => {
-      const raw = dragStartSize.current + delta;
+      const raw = dragStartSizeRef.current + delta;
       if (collapsible && raw < collapsedSize) {
         if (!isCollapsed) {
-          preCollapseSize.current = size;
+          preCollapseSizeRef.current = size;
           onCollapseChange?.(true);
         }
         setIsCollapsed(true);

--- a/packages/core/src/Tokenizer/XDSTokenizer.tsx
+++ b/packages/core/src/Tokenizer/XDSTokenizer.tsx
@@ -470,9 +470,6 @@ export function XDSTokenizer<T extends XDSSearchableItem>({
     [value],
   );
 
-  // Track the current query for creatable mode
-  const [_creatableQuery, setCreatableQuery] = useState('');
-
   const filteredSource: XDSSearchSource<T> = useMemo(
     () => ({
       search: async (query: string) => {
@@ -685,14 +682,7 @@ export function XDSTokenizer<T extends XDSSearchableItem>({
         hasAutoFocus={hasAutoFocus}
         inputId={inputId}
         ariaDescribedBy={ariaDescribedBy}
-        onChangeQuery={
-          hasCreate
-            ? (q: string) => {
-                setCreatableQuery(q);
-                onChangeQuery?.(q);
-              }
-            : onChangeQuery
-        }
+        onChangeQuery={onChangeQuery}
         debounceMs={debounceMs}
         onKeyDown={handleKeyDown}
         anchorRef={wrapperRef}


### PR DESCRIPTION
> **Stacked on #2252** — merge that first.

## Summary

Enable two more `@eslint-react` rules with fixes for all violations.

### naming-convention-ref-name (refs must end with `Ref`)

- `DropdownMenu`: `shouldFocusOnOpen` → `shouldFocusOnOpenRef`
- `Markdown`: `incrementalState` → `incrementalStateRef`
- `Resizable`: `preCollapseSize` → `preCollapseSizeRef`, `dragStartSize` → `dragStartSizeRef`

### no-unused-state (state variables must be read in render)

- `CheckboxListItem`: remove dead `_isFocused` state and its `onFocus`/`onBlur` handlers (value was never read)
- `Tokenizer`: remove dead `_creatableQuery` state (setter was called but value never read)
- `ContextMenu`: suppress — `isOpen` is only read in an effect, but the state is needed as a dependency to trigger the click-outside listener effect

## Test plan
- [x] `npx eslint 'packages/core/src/**/*.{ts,tsx}'` passes clean
- [x] Pre-commit hooks pass