### PR TITLE
chore: release 0.0.14

### DIFF
--- a/packages/build/CHANGELOG.md
+++ b/packages/build/CHANGELOG.md
@@ -1,0 +1,15 @@
+# @xds/build
+
+# 0.0.14
+
+*First public release* — `@xds/build` is now published to the npm registry.
+
+#### New Features
+
+- **Streamlined `xdsStylex()` Vite API** — Simplified configuration for Vite projects (#2227)
+- **Build step for Vite plugin** — Proper dist output for the Vite integration (#2205)
+
+#### Internal
+
+- **Migrated to pnpm** (#2197)
+- **Bumped esbuild** from 0.24.2 to 0.28.0 (#2246)

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@xds/build",
-  "version": "0.0.13",
-  "private": true,
+  "version": "0.0.14",
   "description": "Build plugins for XDS source builds — babel, PostCSS, and Vite integrations",
   "author": "Meta Open Source",
   "license": "MIT",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,33 @@
 # @xds/cli
 
+# 0.0.14
+
+#### Codemods
+
+- `rename-action-props` — Rename `on*Action` props to `*Action` (React 19 convention) (#1942)
+- `rename-status-variants` — Rename `positive`/`negative` status to `success`/`error` (#2175)
+- `rename-section-wash-to-muted` — Rename Section `wash` variant to `muted` (#2063)
+
+#### New Features
+
+- **New component showcases** — XDSAvatarGroup, XDSInputGroup, XDSStepper, XDSButtonGroup, XDSContextMenu, XDSFileInput, XDSDateRangePicker, XDSDateTimePicker, XDSBlockquote
+- **Hook documentation system** — `xds hooks` CLI command for hook docs (#1849)
+- **Playground defaults** — Added to 19 more components (#2047)
+- **Theme/MediaTheme/SyntaxTheme showcases** — Utility showcase support (#2040, #2028)
+- **Slot elements** — Wired through playground UI for ReactNode props (#2012, #2005)
+- **`exampleFor` field** — Added to all block templates (#1966)
+- **`scaffold` flag** — Template metadata scaffold support (#1939)
+- **Table page templates** — Heatmap Status, Matcha Store, Chart Shoe Store (#2172, #2149, #2154)
+
+#### Fixes
+
+- **Group useXDSToast and useXDSCollapsible** with their parent components in docs (#2049)
+- **DropdownMenu inline data types** — Inline into items prop docs (#2027)
+- **Parent hook docs** to their component in docsite (#2022)
+
+
+---
+
 # 0.0.13
 
 #### Codemods

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xds/cli",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "displayName": "CLI",
   "description": "Scaffold projects, browse templates, generate themes, and get agent-ready docs from the command line.",
   "author": "Meta Open Source",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,116 @@
 # @xds/core
 
+# 0.0.14
+
+#### Breaking Changes
+
+- **`on*Action` → `*Action` (React 19 convention)** — `onChangeAction` → `changeAction`, `onClickAction` → `clickAction`, `onPressedChangeAction` → `pressedChangeAction`, `onScrollToTopAction` → `scrollToTopAction`. Aligns with React 19 action prop naming. (#1942)
+  **Codemod:** `npx xds upgrade --codemod rename-action-props`
+- **Status naming: `positive`/`negative` → `success`/`error`** — Converge status variant naming across all components. (#2175)
+  **Codemod:** `npx xds upgrade --codemod rename-status-variants`
+- **Section `wash` → `muted`** — Rename variant for consistency with XDSCard. (#2063)
+  **Codemod:** `npx xds upgrade --codemod rename-section-wash-to-muted`
+- **Stack `direction` defaults to `vertical`** — `XDSStack` no longer requires an explicit `direction` prop; omitting it gives vertical layout. (#1945)
+- **Table `textOverflow` default changed to `truncate`** — Was `wrap`, now truncates by default with tooltip on hover. (#2096)
+- **Remove deprecated `*Raw` token aliases** — Migrate any `*Raw` usage to standard tokens. (#2095)
+- **Remove runtime font loading from `defineTheme`** — Fonts are now handled at the CSS level only. (#2226)
+
+#### Upgrade
+
+```bash
+npx xds upgrade --apply
+```
+
+This runs all three codemods (`rename-action-props`, `rename-status-variants`, `rename-section-wash-to-muted`) in sequence.
+
+#### New Components
+
+- **XDSAvatarGroup** — Stacked avatar display for teams and lists (#2183)
+- **XDSInputGroup** — Combine multiple inputs into a single visual group (#2207)
+- **XDSStepper / XDSStep** — Multi-step flows and progress indicators (#2206)
+- **XDSButtonGroup** — Group related buttons with shared styling (#2202)
+- **XDSContextMenu** — Right-click context menus with nested items (#2195)
+- **XDSFileInput** — File upload with drag-and-drop support (#2184)
+- **XDSDateRangePicker** — Date range selection with calendar UI (#2201)
+- **XDSDateTimePicker** — Combined date and time input (#2199)
+- **XDSBlockquote** — Styled blockquote component (#2198)
+- **XDSOverlay** — Scrim + media theme overlay with CSS-first hover and touch support (#1912)
+- **XDSNavHeadingMenu** — Container component with size and keyboard nav (#1999)
+
+#### New Features
+
+- **Link `to` prop** — Pass `to` alongside `href` for router compatibility (#2237)
+- **Selector `hasSearch`** — Enable filtering/searching within selector options (#2142)
+- **CodeBlock `container` prop** — Control width and border on code blocks (#2132)
+- **Heading `display` type variants** — Large display headings for hero sections (#2054)
+- **Text custom theme-defined types** — Support arbitrary text types from your theme (#1840)
+- **Table structural children mode** — Use `<XDSTable>` with JSX children + Markdown integration (#2098)
+- **Table content-aware column widths** — Auto layout for children mode (#2105)
+- **Table responsive horizontal scroll** — Default column min-widths (#2043)
+- **TabList carousel overflow** — Arrow navigation for overflowing tabs (#1978)
+- **PowerSearch `components` map** — Per-type token and editor overrides (#2076)
+- **Markdown `components` map** — Custom component injection + XDSCitation extraction (#2073)
+- **Markdown `inlinePlugins`** — Custom text pattern rendering (#1917)
+- **SideNav built-in resize** — Integrate `useXDSResizable` directly (#1877)
+- **Resizable pill placement offset** — Auto-collapse flipping (#1876)
+- **Theme `--color-track` token** — Spinner consumes it for fully tokenized track (#2170)
+- **Server-safe utility subpath exports** — `@xds/core/server` for RSC (#1981)
+- **XDSLinkProvider adoption** — All link-rendering components now use the provider (#1906)
+
+#### Fixes
+
+- **Chat composer paste** — Fix silently dropped paste when no forwarded ref (#2179)
+- **Citation** — Prevent rest spread from overriding accessibility props; extend XDSBaseProps (#2217, #2092)
+- **Field** — Neutral gray hover shadow, focus border on input, horizontal-labels grid, z-index containment, click-to-focus on wrapper (#2157, #2059, #1890, #1839)
+- **FormLayout** — Equal-width horizontal children via CSS Grid (#2058)
+- **Link `label`** — Make optional; aria-label harms AT on text links (#2031)
+- **TopNav** — Stop click propagation on heading links, remove hover delay, add selected state to xdsClassName (#2135, #2133, #1997)
+- **Spinner** — Simplify color resolution with useXDSTheme (#2124)
+- **Markdown tables** — Reset container padding, alignment and width fixes (#2121, #2109)
+- **Calendar** — Add isolation to day cell container (#2001)
+- **CommandPalette/MultiSelector** — Prevent iOS zoom on input focus (#1993)
+- **Dialog** — Target-based backdrop detection for native popup compat (#1892)
+- **Typeahead** — Propagate generic type; prevent empty popover after selection (#2014, #1943)
+- **Selector/MultiSelector** — Resolve nested button HTML violation (#1853)
+- **ClickableCard** — Merge caller xstyle with internal interactive styles (#1893)
+- **RadioList** — Extend XDSBaseProps for standard prop inheritance; fix typography tokens (#2093, #1902)
+- **Tokenizer** — Add status to xdsClassName for theme targeting (#1995)
+- **List** — Wrap header + list in column container for flex parents (#2017)
+- **Section** — Propagate explicit padding to nested sections (#1972)
+- **AppShell** — Match flex layout properties on sticky sidenav container (#1850)
+- **Menu hover** — Gate behind `(hover: hover)` media query (#2046)
+- **ResizeObserver** — Migrate all usage to shared singleton for performance (#1990)
+- **Layout** — Container-driven edge compensation via :has() (#1987)
+- **Missing `xdsClassName` hooks** — Added to components using border tokens (#2244)
+- **ProgressBar** — Add xdsClassName to track for theme targeting (#2079)
+- **z-index isolation** — Add isolation to components with leaky z-index (#2004)
+- **`use client` directives** — Added to CommandPalette barrel, CodeBlock, ClickableCard, and others (#2069, #2048, #1833)
+- **Thumbnail** — Focus ring clipped by overflow hidden (#2264)
+- **DropdownMenu** — Light-dismiss + click-toggle race on touch browsers (#2186)
+- **Theme** — Baseline media theme color-scheme flip, standalone theme text styling fixes (#1921, #1831)
+
+#### Contributors
+
+Thanks to everyone who contributed to this release:
+
+- @cixzhang
+- @czarandy
+- @ernestt
+- @josephfarina
+- @kentonquatman
+- @lexs
+- @marie-lucas
+- @nynexman4464
+- @rubyycheung
+- @rumble
+- @saivazian
+- @tedmcdo
+- @thedjpetersen
+- @zurfyx
+- @imdreamrunner
+
+---
+
 # 0.0.13
 
 #### Breaking Changes
@@ -381,6 +492,7 @@ Preview changes first (dry run): `npx xds upgrade --to 0.0.2`
 List all available codemods: `npx xds upgrade --list`
 
 12 codemods included:
+
 - `rename-selector-items-to-options` — Selector `items` → `options`
 - `unify-visibility-to-onOpenChange` — onHide/onClose/onShow/onToggle → `onOpenChange`
 - `unify-uncontrolled-to-defaultX` — initialIsOpen/initialIsExpanded → defaultX

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xds/core",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "displayName": "XDS Core",
   "description": "The component library. Accessible, themeable React components with built-in spacing, dark mode, and StyleX styling.",
   "author": "Meta Open Source",

--- a/packages/lab/package.json
+++ b/packages/lab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xds/lab",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": true,
   "description": "Experimental XDS components — not published, available in storybook and sandbox for testing",
   "author": "Meta Open Source",
@@ -25,7 +25,7 @@
   "sideEffects": false,
   "peerDependencies": {
     "@stylexjs/stylex": ">=0.10.0",
-    "@xds/core": "0.0.13",
+    "@xds/core": "0.0.14",
     "react": ">=19.0.0",
     "react-dom": ">=19.0.0"
   },

--- a/packages/themes/brutalist/package.json
+++ b/packages/themes/brutalist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xds/theme-brutalist",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": true,
   "description": "Brutalist theme for XDS — zero radius, monospace, heavy borders",
   "author": "Meta Open Source",
@@ -49,9 +49,9 @@
     "build": "xds theme build src/brutalistTheme.ts -o dist/theme.css && tsup && tsc --project tsconfig.build.json"
   },
   "peerDependencies": {
-    "@xds/core": "0.0.13"
+    "@xds/core": "0.0.14"
   },
   "devDependencies": {
-    "@xds/cli": "0.0.13"
+    "@xds/cli": "0.0.14"
   }
 }

--- a/packages/themes/butter/package.json
+++ b/packages/themes/butter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xds/theme-butter",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "displayName": "Butter Theme",
   "private": false,
   "description": "Warm, golden butter theme for XDS — creamy yellow palette with soft, inviting tones",
@@ -52,11 +52,11 @@
     "lucide-react": "^1.16.0"
   },
   "peerDependencies": {
-    "@xds/core": "0.0.13",
+    "@xds/core": "0.0.14",
     "react": ">=19"
   },
   "devDependencies": {
-    "@xds/cli": "0.0.13"
+    "@xds/cli": "0.0.14"
   },
   "module": "./dist/source.mjs"
 }

--- a/packages/themes/chocolate/package.json
+++ b/packages/themes/chocolate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xds/theme-chocolate",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "displayName": "Chocolate Theme",
   "private": false,
   "description": "Warm chocolate theme for XDS \u2014 rich brown palette with Fraunces headings, Albert Sans body, and Lucide icons",
@@ -52,11 +52,11 @@
     "lucide-react": "^1.16.0"
   },
   "peerDependencies": {
-    "@xds/core": "0.0.13",
+    "@xds/core": "0.0.14",
     "react": ">=19"
   },
   "devDependencies": {
-    "@xds/cli": "0.0.13"
+    "@xds/cli": "0.0.14"
   },
   "module": "./dist/source.mjs"
 }

--- a/packages/themes/daily/package.json
+++ b/packages/themes/daily/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xds/theme-daily",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": false,
   "description": "Daily theme for XDS — warm, productivity-focused palette with Lucide icon set",
   "author": "Meta Open Source",
@@ -51,11 +51,11 @@
     "lucide-react": "^1.16.0"
   },
   "peerDependencies": {
-    "@xds/core": "0.0.13",
+    "@xds/core": "0.0.14",
     "react": ">=19"
   },
   "devDependencies": {
-    "@xds/cli": "0.0.13"
+    "@xds/cli": "0.0.14"
   },
   "module": "./dist/source.mjs"
 }

--- a/packages/themes/default/package.json
+++ b/packages/themes/default/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xds/theme-default",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "displayName": "Default Theme",
   "private": false,
   "description": "Clean neutrals with a blue accent. Pairs with Heroicons for a polished, professional look.",
@@ -52,11 +52,11 @@
     "@heroicons/react": "^2.2.0"
   },
   "peerDependencies": {
-    "@xds/core": "0.0.13",
+    "@xds/core": "0.0.14",
     "react": ">=19"
   },
   "devDependencies": {
-    "@xds/cli": "0.0.13"
+    "@xds/cli": "0.0.14"
   },
   "module": "./dist/source.mjs"
 }

--- a/packages/themes/gothic/package.json
+++ b/packages/themes/gothic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xds/theme-gothic",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "displayName": "Gothic Theme",
   "private": false,
   "description": "Dark gothic theme for XDS \u2014 deep blue-gray palette with Manufacturing Consent headings, Fustat body, and Lucide icons",
@@ -52,11 +52,11 @@
     "lucide-react": "^1.16.0"
   },
   "peerDependencies": {
-    "@xds/core": "0.0.13",
+    "@xds/core": "0.0.14",
     "react": ">=19"
   },
   "devDependencies": {
-    "@xds/cli": "0.0.13"
+    "@xds/cli": "0.0.14"
   },
   "module": "./dist/source.mjs"
 }

--- a/packages/themes/matcha/package.json
+++ b/packages/themes/matcha/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xds/theme-matcha",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": false,
   "description": "Matcha theme for XDS — earthy green palette with Figtree typography and Lucide icons",
   "author": "Meta Open Source",
@@ -51,11 +51,11 @@
     "lucide-react": "^1.16.0"
   },
   "peerDependencies": {
-    "@xds/core": "0.0.13",
+    "@xds/core": "0.0.14",
     "react": ">=19"
   },
   "devDependencies": {
-    "@xds/cli": "0.0.13"
+    "@xds/cli": "0.0.14"
   },
   "module": "./dist/source.mjs"
 }

--- a/packages/themes/neutral/package.json
+++ b/packages/themes/neutral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xds/theme-neutral",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "displayName": "Neutral Theme",
   "private": false,
   "description": "Understated warm grays with a subtle palette. Pairs with Lucide icons for a minimal, quiet aesthetic.",
@@ -52,11 +52,11 @@
     "lucide-react": "^1.16.0"
   },
   "peerDependencies": {
-    "@xds/core": "0.0.13",
+    "@xds/core": "0.0.14",
     "react": ">=19"
   },
   "devDependencies": {
-    "@xds/cli": "0.0.13"
+    "@xds/cli": "0.0.14"
   },
   "module": "./dist/source.mjs"
 }

--- a/packages/themes/stone/package.json
+++ b/packages/themes/stone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xds/theme-stone",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "displayName": "Stone Theme",
   "private": false,
   "description": "Warm stone and slate theme for XDS \u2014 earthy neutral palette with Montserrat headings, Figtree body, and Lucide icons",
@@ -52,11 +52,11 @@
     "lucide-react": "^1.16.0"
   },
   "peerDependencies": {
-    "@xds/core": "0.0.13",
+    "@xds/core": "0.0.14",
     "react": ">=19"
   },
   "devDependencies": {
-    "@xds/cli": "0.0.13"
+    "@xds/cli": "0.0.14"
   },
   "module": "./dist/source.mjs"
 }

--- a/packages/themes/y2k/package.json
+++ b/packages/themes/y2k/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xds/theme-y2k",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "displayName": "Y2K Theme",
   "private": false,
   "description": "Bubbly Y2K pop theme for XDS — hot pink body, lime green accents, Poppins body, and playful categorical colors",
@@ -52,11 +52,11 @@
     "lucide-react": "^1.16.0"
   },
   "peerDependencies": {
-    "@xds/core": "0.0.13",
+    "@xds/core": "0.0.14",
     "react": ">=19"
   },
   "devDependencies": {
-    "@xds/cli": "0.0.13"
+    "@xds/cli": "0.0.14"
   },
   "module": "./dist/source.mjs"
 }

--- a/packages/vega/package.json
+++ b/packages/vega/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xds/vega",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": true,
   "description": "XDS Vega wrapper — chart and data visualization components",
   "author": "Meta Open Source",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -764,7 +764,7 @@ importers:
         specifier: '>=0.10.0'
         version: 0.18.3
       '@xds/core':
-        specifier: 0.0.13
+        specifier: 0.0.14
         version: link:../core
       d3-array:
         specifier: ^3.2.4
@@ -795,17 +795,17 @@ importers:
   packages/themes/brutalist:
     dependencies:
       '@xds/core':
-        specifier: 0.0.13
+        specifier: 0.0.14
         version: link:../../core
     devDependencies:
       '@xds/cli':
-        specifier: 0.0.13
+        specifier: 0.0.14
         version: link:../../cli
 
   packages/themes/butter:
     dependencies:
       '@xds/core':
-        specifier: 0.0.13
+        specifier: 0.0.14
         version: link:../../core
       lucide-react:
         specifier: ^1.16.0
@@ -815,13 +815,13 @@ importers:
         version: 19.2.6
     devDependencies:
       '@xds/cli':
-        specifier: 0.0.13
+        specifier: 0.0.14
         version: link:../../cli
 
   packages/themes/chocolate:
     dependencies:
       '@xds/core':
-        specifier: 0.0.13
+        specifier: 0.0.14
         version: link:../../core
       lucide-react:
         specifier: ^1.16.0
@@ -831,13 +831,13 @@ importers:
         version: 19.2.6
     devDependencies:
       '@xds/cli':
-        specifier: 0.0.13
+        specifier: 0.0.14
         version: link:../../cli
 
   packages/themes/daily:
     dependencies:
       '@xds/core':
-        specifier: 0.0.13
+        specifier: 0.0.14
         version: link:../../core
       lucide-react:
         specifier: ^1.16.0
@@ -847,7 +847,7 @@ importers:
         version: 19.2.6
     devDependencies:
       '@xds/cli':
-        specifier: 0.0.13
+        specifier: 0.0.14
         version: link:../../cli
 
   packages/themes/default:
@@ -856,20 +856,20 @@ importers:
         specifier: ^2.2.0
         version: 2.2.0(react@19.2.6)
       '@xds/core':
-        specifier: 0.0.13
+        specifier: 0.0.14
         version: link:../../core
       react:
         specifier: '>=19'
         version: 19.2.6
     devDependencies:
       '@xds/cli':
-        specifier: 0.0.13
+        specifier: 0.0.14
         version: link:../../cli
 
   packages/themes/gothic:
     dependencies:
       '@xds/core':
-        specifier: 0.0.13
+        specifier: 0.0.14
         version: link:../../core
       lucide-react:
         specifier: ^1.16.0
@@ -879,13 +879,13 @@ importers:
         version: 19.2.6
     devDependencies:
       '@xds/cli':
-        specifier: 0.0.13
+        specifier: 0.0.14
         version: link:../../cli
 
   packages/themes/matcha:
     dependencies:
       '@xds/core':
-        specifier: 0.0.13
+        specifier: 0.0.14
         version: link:../../core
       lucide-react:
         specifier: ^1.16.0
@@ -895,13 +895,13 @@ importers:
         version: 19.2.6
     devDependencies:
       '@xds/cli':
-        specifier: 0.0.13
+        specifier: 0.0.14
         version: link:../../cli
 
   packages/themes/neutral:
     dependencies:
       '@xds/core':
-        specifier: 0.0.13
+        specifier: 0.0.14
         version: link:../../core
       lucide-react:
         specifier: ^1.16.0
@@ -911,13 +911,13 @@ importers:
         version: 19.2.6
     devDependencies:
       '@xds/cli':
-        specifier: 0.0.13
+        specifier: 0.0.14
         version: link:../../cli
 
   packages/themes/stone:
     dependencies:
       '@xds/core':
-        specifier: 0.0.13
+        specifier: 0.0.14
         version: link:../../core
       lucide-react:
         specifier: ^1.16.0
@@ -927,13 +927,13 @@ importers:
         version: 19.2.6
     devDependencies:
       '@xds/cli':
-        specifier: 0.0.13
+        specifier: 0.0.14
         version: link:../../cli
 
   packages/themes/y2k:
     dependencies:
       '@xds/core':
-        specifier: 0.0.13
+        specifier: 0.0.14
         version: link:../../core
       lucide-react:
         specifier: ^1.16.0
@@ -943,7 +943,7 @@ importers:
         version: 19.2.6
     devDependencies:
       '@xds/cli':
-        specifier: 0.0.13
+        specifier: 0.0.14
         version: link:../../cli
 
   packages/vega:


### PR DESCRIPTION
## Release 0.0.14

- Bump all packages to 0.0.14
- Mark `@xds/build` as public (remove `"private": true`) so it gets published to npm

### Packages
- `@xds/core` → 0.0.14
- `@xds/cli` → 0.0.14
- `@xds/build` → 0.0.14 *(now public)*
- `@xds/lab` → 0.0.14 (private)
- `@xds/vega` → 0.0.14 (private)
- All theme packages → 0.0.14