### PR TITLE
fix(lint): enable React 19 context rules

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -117,6 +117,7 @@ export default tseslint.config(
       '@eslint-react/use-memo': reactSeverity,
       '@eslint-react/no-unnecessary-use-prefix': reactSeverity,
       '@eslint-react/no-create-ref': reactSeverity,
+      '@eslint-react/no-forward-ref': reactSeverity,
 
       // DOM correctness
       '@eslint-react/dom-no-missing-button-type': reactSeverity,

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -118,6 +118,7 @@ export default tseslint.config(
       '@eslint-react/no-unnecessary-use-prefix': reactSeverity,
       '@eslint-react/no-create-ref': reactSeverity,
       '@eslint-react/no-forward-ref': reactSeverity,
+      '@eslint-react/no-unused-state': reactSeverity,
 
       // DOM correctness
       '@eslint-react/dom-no-missing-button-type': reactSeverity,
@@ -142,6 +143,7 @@ export default tseslint.config(
 
       // Naming conventions
       '@eslint-react/naming-convention-context-name': reactSeverity,
+      '@eslint-react/naming-convention-ref-name': reactSeverity,
 
       // Resource leak prevention
       '@eslint-react/web-api-no-leaked-event-listener': reactSeverity,

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -145,6 +145,11 @@ export default tseslint.config(
       '@eslint-react/naming-convention-context-name': reactSeverity,
       '@eslint-react/naming-convention-ref-name': reactSeverity,
 
+      // React 19 modernization
+      '@eslint-react/no-context-provider': reactSeverity,
+      '@eslint-react/no-use-context': reactSeverity,
+      '@eslint-react/no-missing-context-display-name': reactSeverity,
+
       // Resource leak prevention
       '@eslint-react/web-api-no-leaked-event-listener': reactSeverity,
       '@eslint-react/web-api-no-leaked-interval': reactSeverity,

--- a/packages/core/src/AppShell/XDSAppShell.tsx
+++ b/packages/core/src/AppShell/XDSAppShell.tsx
@@ -798,7 +798,7 @@ export function XDSAppShell({
     ) : undefined;
 
   return (
-    <XDSAppShellMobileContext.Provider value={mobileContextValue}>
+    <XDSAppShellMobileContext value={mobileContextValue}>
       <div
         ref={setShellRef}
         data-testid={dataTestId}
@@ -871,7 +871,7 @@ export function XDSAppShell({
             </ActivityWrapper>
           )}
       </div>
-    </XDSAppShellMobileContext.Provider>
+    </XDSAppShellMobileContext>
   );
 }
 

--- a/packages/core/src/AppShell/XDSAppShellMobileContext.tsx
+++ b/packages/core/src/AppShell/XDSAppShellMobileContext.tsx
@@ -4,7 +4,7 @@
 
 /**
  * @file XDSAppShellMobileContext.tsx
- * @input Uses React createContext, useContext
+ * @input Uses React createContext, use
  * @output Exports XDSAppShellMobileContext, useXDSAppShellMobile
  * @position Internal context for mobile nav state; consumed by XDSMobileNavToggle, XDSTopNav (future)
  *
@@ -13,7 +13,7 @@
  * to adapt rendering based on mobile context.
  */
 
-import {createContext, useContext} from 'react';
+import {createContext, use} from 'react';
 
 export interface XDSAppShellMobileContextValue {
   /** Whether the viewport is below the mobile breakpoint */
@@ -44,10 +44,11 @@ const defaultValue: XDSAppShellMobileContextValue = {
 
 export const XDSAppShellMobileContext =
   createContext<XDSAppShellMobileContextValue>(defaultValue);
+XDSAppShellMobileContext.displayName = 'XDSAppShellMobileContext';
 
 /**
  * Hook to access mobile nav state from anywhere in the AppShell tree.
  */
 export function useXDSAppShellMobile(): XDSAppShellMobileContextValue {
-  return useContext(XDSAppShellMobileContext);
+  return use(XDSAppShellMobileContext);
 }

--- a/packages/core/src/Avatar/XDSAvatar.tsx
+++ b/packages/core/src/Avatar/XDSAvatar.tsx
@@ -298,7 +298,7 @@ export function XDSAvatar({
   const numericSize = useMemo(() => resolveSize(resolvedSize), [resolvedSize]);
 
   return (
-    <XDSAvatarSizeContext.Provider value={numericSize}>
+    <XDSAvatarSizeContext value={numericSize}>
       <div
         ref={ref}
         role="img"
@@ -359,7 +359,7 @@ export function XDSAvatar({
           </div>
         )}
       </div>
-    </XDSAvatarSizeContext.Provider>
+    </XDSAvatarSizeContext>
   );
 }
 

--- a/packages/core/src/Avatar/XDSAvatarSizeContext.ts
+++ b/packages/core/src/Avatar/XDSAvatarSizeContext.ts
@@ -12,7 +12,6 @@
  * - /packages/core/src/Avatar/Avatar.doc.mjs
  */
 
-
 import {createContext} from 'react';
 
 /**
@@ -22,3 +21,4 @@ import {createContext} from 'react';
  * Default value of 36 matches the default 'small' avatar size.
  */
 export const XDSAvatarSizeContext = createContext<number>(36);
+XDSAvatarSizeContext.displayName = 'XDSAvatarSizeContext';

--- a/packages/core/src/Avatar/XDSAvatarStatusDot.tsx
+++ b/packages/core/src/Avatar/XDSAvatarStatusDot.tsx
@@ -15,7 +15,7 @@
  * - /packages/cli/templates/blocks/components/Avatar/ (showcase blocks)
  */
 
-import {useContext, type ReactNode} from 'react';
+import {use, type ReactNode} from 'react';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars, radiusVars} from '../theme/tokens.stylex';
@@ -185,7 +185,7 @@ export function XDSAvatarStatusDot({
   style,
   ...props
 }: XDSAvatarStatusDotProps) {
-  const avatarSize = useContext(XDSAvatarSizeContext);
+  const avatarSize = use(XDSAvatarSizeContext);
   const {dotSize, borderWidth, iconSize} = resolveStatusDotSize(avatarSize);
 
   return (

--- a/packages/core/src/AvatarGroup/XDSAvatarGroup.tsx
+++ b/packages/core/src/AvatarGroup/XDSAvatarGroup.tsx
@@ -91,7 +91,7 @@ export function XDSAvatarGroup({
   );
 
   return (
-    <XDSAvatarGroupContext.Provider value={contextValue}>
+    <XDSAvatarGroupContext value={contextValue}>
       <div
         ref={ref}
         role="group"
@@ -106,7 +106,7 @@ export function XDSAvatarGroup({
         {...props}>
         {children}
       </div>
-    </XDSAvatarGroupContext.Provider>
+    </XDSAvatarGroupContext>
   );
 }
 

--- a/packages/core/src/AvatarGroup/XDSAvatarGroupContext.ts
+++ b/packages/core/src/AvatarGroup/XDSAvatarGroupContext.ts
@@ -8,7 +8,7 @@
  * @position Shared context; consumed by children for group-aware styling
  */
 
-import {createContext, useContext} from 'react';
+import {createContext, use} from 'react';
 import type {XDSAvatarSize} from '../Avatar';
 
 export interface XDSAvatarGroupContextValue {
@@ -19,7 +19,8 @@ export interface XDSAvatarGroupContextValue {
 
 export const XDSAvatarGroupContext =
   createContext<XDSAvatarGroupContextValue | null>(null);
+XDSAvatarGroupContext.displayName = 'XDSAvatarGroupContext';
 
 export function useXDSAvatarGroup(): XDSAvatarGroupContextValue | null {
-  return useContext(XDSAvatarGroupContext);
+  return use(XDSAvatarGroupContext);
 }

--- a/packages/core/src/Breadcrumbs/XDSBreadcrumbItem.tsx
+++ b/packages/core/src/Breadcrumbs/XDSBreadcrumbItem.tsx
@@ -4,7 +4,7 @@
 
 /**
  * @file XDSBreadcrumbItem.tsx
- * @input Uses React useContext/useRef/useEffect, stylex, theme tokens, BreadcrumbContext
+ * @input Uses React use/useRef/useEffect, stylex, theme tokens, BreadcrumbContext
  * @output Exports XDSBreadcrumbItem component and XDSBreadcrumbItemProps
  * @position Individual breadcrumb item; used inside XDSBreadcrumbs
  *
@@ -16,13 +16,7 @@
  * - /packages/cli/templates/blocks/components/Breadcrumbs/ (showcase blocks)
  */
 
-import {
-  useContext,
-  useRef,
-  useEffect,
-  type ReactNode,
-  type MouseEvent,
-} from 'react';
+import {use, useRef, useEffect, type ReactNode, type MouseEvent} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars, spacingVars, typeScaleVars} from '../theme/tokens.stylex';
 import {BreadcrumbContext} from './XDSBreadcrumbs';
@@ -174,7 +168,7 @@ export function XDSBreadcrumbItem({
   startIcon,
   'data-testid': testId,
 }: XDSBreadcrumbItemProps) {
-  const ctx = useContext(BreadcrumbContext);
+  const ctx = use(BreadcrumbContext);
   const LinkComponent = useXDSLinkComponent(as);
   const isSupporting = ctx.variant === 'supporting';
   const liRef = useRef<HTMLLIElement>(null);

--- a/packages/core/src/Breadcrumbs/XDSBreadcrumbs.test.tsx
+++ b/packages/core/src/Breadcrumbs/XDSBreadcrumbs.test.tsx
@@ -3,19 +3,21 @@
 import {describe, it, expect, vi} from 'vitest';
 import {render, screen, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import {forwardRef, type ComponentPropsWithoutRef} from 'react';
 import {XDSBreadcrumbs} from './XDSBreadcrumbs';
 import {XDSBreadcrumbItem} from './XDSBreadcrumbItem';
 import {XDSLinkProvider} from '../Link/XDSLinkProvider';
 
-const CustomLink = forwardRef<HTMLAnchorElement, ComponentPropsWithoutRef<'a'>>(
-  ({children, ...props}, ref) => (
+function CustomLink({
+  children,
+  ref,
+  ...props
+}: React.ComponentPropsWithRef<'a'>) {
+  return (
     <a ref={ref} data-custom-link {...props}>
       {children}
     </a>
-  ),
-);
-CustomLink.displayName = 'CustomLink';
+  );
+}
 
 describe('XDSBreadcrumbs', () => {
   it('renders a nav landmark with aria-label', () => {

--- a/packages/core/src/Breadcrumbs/XDSBreadcrumbs.tsx
+++ b/packages/core/src/Breadcrumbs/XDSBreadcrumbs.tsx
@@ -67,6 +67,7 @@ export const BreadcrumbContext = createContext<BreadcrumbContextValue>({
   variant: 'default',
   separator: '/',
 });
+BreadcrumbContext.displayName = 'BreadcrumbContext';
 
 // =============================================================================
 // Props
@@ -158,7 +159,7 @@ export function XDSBreadcrumbs({
   );
 
   return (
-    <BreadcrumbContext.Provider value={ctxValue}>
+    <BreadcrumbContext value={ctxValue}>
       <nav
         ref={ref}
         aria-label={label}
@@ -171,7 +172,7 @@ export function XDSBreadcrumbs({
         {...rest}>
         <ol {...stylex.props(listStyles.root)}>{children}</ol>
       </nav>
-    </BreadcrumbContext.Provider>
+    </BreadcrumbContext>
   );
 }
 

--- a/packages/core/src/ButtonGroup/XDSButtonGroup.tsx
+++ b/packages/core/src/ButtonGroup/XDSButtonGroup.tsx
@@ -133,7 +133,7 @@ export function XDSButtonGroup({
   );
 
   return (
-    <XDSButtonGroupContext.Provider value={contextValue}>
+    <XDSButtonGroupContext value={contextValue}>
       <XDSSizeProvider value={size}>
         <div
           ref={(node: HTMLDivElement | null) => {
@@ -164,7 +164,7 @@ export function XDSButtonGroup({
           {children}
         </div>
       </XDSSizeProvider>
-    </XDSButtonGroupContext.Provider>
+    </XDSButtonGroupContext>
   );
 }
 

--- a/packages/core/src/ButtonGroup/XDSButtonGroupContext.ts
+++ b/packages/core/src/ButtonGroup/XDSButtonGroupContext.ts
@@ -9,7 +9,7 @@
  * @position Shared context; consumed by XDSButton for group-aware styling
  */
 
-import {createContext, useContext} from 'react';
+import {createContext, use} from 'react';
 
 export type XDSButtonGroupOrientation = 'horizontal' | 'vertical';
 
@@ -20,11 +20,12 @@ export interface XDSButtonGroupContextValue {
 
 export const XDSButtonGroupContext =
   createContext<XDSButtonGroupContextValue | null>(null);
+XDSButtonGroupContext.displayName = 'XDSButtonGroupContext';
 
 /**
  * Hook for XDSButton to detect when it's inside a ButtonGroup.
  * Returns null when used outside a group.
  */
 export function useXDSButtonGroup(): XDSButtonGroupContextValue | null {
-  return useContext(XDSButtonGroupContext);
+  return use(XDSButtonGroupContext);
 }

--- a/packages/core/src/Chat/XDSChatComposer.tsx
+++ b/packages/core/src/Chat/XDSChatComposer.tsx
@@ -373,7 +373,7 @@ export function XDSChatComposer(props: XDSChatComposerProps) {
   );
 
   return (
-    <XDSChatComposerContext.Provider value={composerContext}>
+    <XDSChatComposerContext value={composerContext}>
       <div
         {...mergeProps(
           xdsClassName('chat-composer', {density}),
@@ -415,7 +415,7 @@ export function XDSChatComposer(props: XDSChatComposerProps) {
 
         {statusPosition === 'bottom' && statusEl}
       </div>
-    </XDSChatComposerContext.Provider>
+    </XDSChatComposerContext>
   );
 }
 

--- a/packages/core/src/Chat/XDSChatContext.tsx
+++ b/packages/core/src/Chat/XDSChatContext.tsx
@@ -9,7 +9,7 @@
  * @position Internal context; consumed by XDSChatMessage and XDSChatMessageBubble
  */
 
-import {createContext, useContext} from 'react';
+import {createContext, use} from 'react';
 
 export type XDSChatMessageSender = 'user' | 'assistant' | 'system';
 export type XDSChatDensity = 'compact' | 'balanced' | 'spacious';
@@ -21,9 +21,10 @@ export interface XDSChatMessageContextValue {
 
 export const XDSChatMessageContext =
   createContext<XDSChatMessageContextValue | null>(null);
+XDSChatMessageContext.displayName = 'XDSChatMessageContext';
 
 export function useXDSChatMessageContext(): XDSChatMessageContextValue | null {
-  return useContext(XDSChatMessageContext);
+  return use(XDSChatMessageContext);
 }
 
 export interface XDSChatListContextValue {
@@ -33,9 +34,10 @@ export interface XDSChatListContextValue {
 export const XDSChatListContext = createContext<XDSChatListContextValue | null>(
   null,
 );
+XDSChatListContext.displayName = 'XDSChatListContext';
 
 export function useXDSChatListContext(): XDSChatListContextValue | null {
-  return useContext(XDSChatListContext);
+  return use(XDSChatListContext);
 }
 
 // =============================================================================
@@ -55,9 +57,10 @@ export interface XDSChatComposerContextValue {
 
 export const XDSChatComposerContext =
   createContext<XDSChatComposerContextValue | null>(null);
+XDSChatComposerContext.displayName = 'XDSChatComposerContext';
 
 export function useXDSChatComposerContext(): XDSChatComposerContextValue | null {
-  return useContext(XDSChatComposerContext);
+  return use(XDSChatComposerContext);
 }
 
 // =============================================================================
@@ -73,7 +76,8 @@ export interface XDSChatLayoutContextValue {
 
 export const XDSChatLayoutContext =
   createContext<XDSChatLayoutContextValue | null>(null);
+XDSChatLayoutContext.displayName = 'XDSChatLayoutContext';
 
 export function useXDSChatLayoutContext(): XDSChatLayoutContextValue | null {
-  return useContext(XDSChatLayoutContext);
+  return use(XDSChatLayoutContext);
 }

--- a/packages/core/src/Chat/XDSChatLayout.tsx
+++ b/packages/core/src/Chat/XDSChatLayout.tsx
@@ -366,7 +366,7 @@ export function XDSChatLayout({
         : styles.dockInnerBalanced;
 
   return (
-    <XDSChatLayoutContext.Provider value={layoutContext}>
+    <XDSChatLayoutContext value={layoutContext}>
       <div
         ref={setRootRef}
         data-testid={testId}
@@ -412,7 +412,7 @@ export function XDSChatLayout({
           </div>
         </div>
       </div>
-    </XDSChatLayoutContext.Provider>
+    </XDSChatLayoutContext>
   );
 }
 

--- a/packages/core/src/Chat/XDSChatMessage.tsx
+++ b/packages/core/src/Chat/XDSChatMessage.tsx
@@ -227,7 +227,7 @@ export function XDSChatMessage({
   const nameId = useId();
 
   return (
-    <XDSChatMessageContext.Provider value={contextValue}>
+    <XDSChatMessageContext value={contextValue}>
       <article
         ref={ref}
         data-testid={testId}
@@ -265,7 +265,7 @@ export function XDSChatMessage({
           {metadata != null && !isSystem && <div>{metadata}</div>}
         </div>
       </article>
-    </XDSChatMessageContext.Provider>
+    </XDSChatMessageContext>
   );
 }
 

--- a/packages/core/src/Chat/XDSChatMessageList.tsx
+++ b/packages/core/src/Chat/XDSChatMessageList.tsx
@@ -214,7 +214,7 @@ export function XDSChatMessageList({
         : styles.gapBalanced;
 
   return (
-    <XDSChatListContext.Provider value={contextValue}>
+    <XDSChatListContext value={contextValue}>
       <div
         ref={ref}
         role="log"
@@ -249,7 +249,7 @@ export function XDSChatMessageList({
           ) : null}
         </div>
       </div>
-    </XDSChatListContext.Provider>
+    </XDSChatListContext>
   );
 }
 

--- a/packages/core/src/CheckboxList/XDSCheckboxList.tsx
+++ b/packages/core/src/CheckboxList/XDSCheckboxList.tsx
@@ -233,11 +233,11 @@ export function XDSCheckboxList({
         xdsClassName('checkbox-list') + (className ? ` ${className}` : '')
       }
       style={style}>
-      <XDSCheckboxListContext.Provider value={contextValue}>
+      <XDSCheckboxListContext value={contextValue}>
         <XDSList density={density} hasDividers={hasDividers}>
           {children}
         </XDSList>
-      </XDSCheckboxListContext.Provider>
+      </XDSCheckboxListContext>
     </XDSField>
   );
 }

--- a/packages/core/src/CheckboxList/XDSCheckboxListContext.tsx
+++ b/packages/core/src/CheckboxList/XDSCheckboxListContext.tsx
@@ -21,3 +21,4 @@ export interface XDSCheckboxListContextValue {
 
 export const XDSCheckboxListContext =
   createContext<XDSCheckboxListContextValue | null>(null);
+XDSCheckboxListContext.displayName = 'XDSCheckboxListContext';

--- a/packages/core/src/CheckboxList/XDSCheckboxListItem.tsx
+++ b/packages/core/src/CheckboxList/XDSCheckboxListItem.tsx
@@ -16,7 +16,7 @@
  * - /packages/cli/templates/blocks/components/CheckboxList/ (showcase blocks)
  */
 
-import {useContext, useState, type ReactNode} from 'react';
+import {useContext, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import {colorVars} from '../theme/tokens.stylex';
@@ -127,8 +127,6 @@ export function XDSCheckboxListItem({
     );
   }
 
-  const [_isFocused, setIsFocused] = useState(false);
-
   // Density from list context for checkbox sizing
   const listCtx = useContext(XDSListContext);
   const density = listCtx?.density ?? 'balanced';
@@ -201,8 +199,6 @@ export function XDSCheckboxListItem({
           isLabelHidden
           value={resolvedChecked}
           onChange={() => handleToggle()}
-          onFocus={() => setIsFocused(true)}
-          onBlur={() => setIsFocused(false)}
           isDisabled={effectiveDisabled}
           isReadOnly={effectiveReadOnly}
           size={checkboxSize}

--- a/packages/core/src/CheckboxList/XDSCheckboxListItem.tsx
+++ b/packages/core/src/CheckboxList/XDSCheckboxListItem.tsx
@@ -16,7 +16,7 @@
  * - /packages/cli/templates/blocks/components/CheckboxList/ (showcase blocks)
  */
 
-import {useContext, type ReactNode} from 'react';
+import {use, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import {colorVars} from '../theme/tokens.stylex';
@@ -119,7 +119,7 @@ export function XDSCheckboxListItem({
   style,
   ...restProps
 }: XDSCheckboxListItemProps) {
-  const ctx = useContext(XDSCheckboxListContext);
+  const ctx = use(XDSCheckboxListContext);
 
   if (ctx && ctx.value !== undefined && value === undefined) {
     throw new Error(
@@ -128,7 +128,7 @@ export function XDSCheckboxListItem({
   }
 
   // Density from list context for checkbox sizing
-  const listCtx = useContext(XDSListContext);
+  const listCtx = use(XDSListContext);
   const density = listCtx?.density ?? 'balanced';
   const checkboxSize = density === 'compact' ? 'sm' : 'md';
 

--- a/packages/core/src/Collapsible/XDSCollapsibleGroup.tsx
+++ b/packages/core/src/Collapsible/XDSCollapsibleGroup.tsx
@@ -23,7 +23,6 @@
  * - /packages/cli/templates/blocks/components/Collapsible/ (showcase blocks)
  */
 
-
 import {useCallback, useMemo, useState, type ReactNode} from 'react';
 import {CollapsibleGroupContext} from './XDSCollapsibleGroupContext';
 import type {CollapsibleGroupContextValue} from './XDSCollapsibleGroupContext';
@@ -169,9 +168,9 @@ export function XDSCollapsibleGroup({
   );
 
   return (
-    <CollapsibleGroupContext.Provider value={contextValue}>
+    <CollapsibleGroupContext value={contextValue}>
       {children}
-    </CollapsibleGroupContext.Provider>
+    </CollapsibleGroupContext>
   );
 }
 

--- a/packages/core/src/Collapsible/XDSCollapsibleGroupContext.tsx
+++ b/packages/core/src/Collapsible/XDSCollapsibleGroupContext.tsx
@@ -14,7 +14,6 @@
  * - /packages/cli/templates/blocks/components/Collapsible/ (showcase blocks)
  */
 
-
 import {createContext} from 'react';
 
 /**
@@ -33,3 +32,4 @@ export interface CollapsibleGroupContextValue {
  */
 export const CollapsibleGroupContext =
   createContext<CollapsibleGroupContextValue | null>(null);
+CollapsibleGroupContext.displayName = 'CollapsibleGroupContext';

--- a/packages/core/src/Collapsible/useXDSCollapsible.ts
+++ b/packages/core/src/Collapsible/useXDSCollapsible.ts
@@ -4,7 +4,7 @@
 
 /**
  * @file useXDSCollapsible.ts
- * @input Uses React useState/useContext, CollapsibleGroupContext
+ * @input Uses React useState/use, CollapsibleGroupContext
  * @output Exports useXDSCollapsible hook, XDSCollapsibleConfig (formerly CollapsibleConfig), UseXDSCollapsibleOptions, UseXDSCollapsibleReturn types
  * @position Reusable hook for collapsible behavior — used by XDSCard, XDSSection, etc.
  *
@@ -21,7 +21,7 @@
  * NOTE: Public hooks use the `useXDS` prefix per XDS naming conventions.
  */
 
-import {useState, useContext} from 'react';
+import {useState, use} from 'react';
 import {CollapsibleGroupContext} from './XDSCollapsibleGroupContext';
 
 /**
@@ -82,7 +82,7 @@ export function useXDSCollapsible(
   const {isCollapsible, value} = options;
 
   // Check for CollapsibleGroup context
-  const group = useContext(CollapsibleGroupContext);
+  const group = use(CollapsibleGroupContext);
   const isControlledByGroup = group != null && value != null;
 
   // Parse config: true → empty config, object → as-is, false/undefined → null

--- a/packages/core/src/CommandPalette/CommandPaletteContext.ts
+++ b/packages/core/src/CommandPalette/CommandPaletteContext.ts
@@ -8,7 +8,7 @@
  * @position Internal context; consumed by composable sub-components
  */
 
-import {createContext, useContext} from 'react';
+import {createContext, use} from 'react';
 import type {XDSSearchableItem} from '../Typeahead';
 
 export interface CommandPaletteContextValue {
@@ -48,11 +48,12 @@ export interface CommandPaletteContextValue {
 
 export const CommandPaletteContext =
   createContext<CommandPaletteContextValue | null>(null);
+CommandPaletteContext.displayName = 'CommandPaletteContext';
 
 /**
  * Access the command palette context.
  * Returns null when used outside a CommandPalette (for standalone usage).
  */
 export function useCommandPaletteContext(): CommandPaletteContextValue | null {
-  return useContext(CommandPaletteContext);
+  return use(CommandPaletteContext);
 }

--- a/packages/core/src/CommandPalette/XDSCommandPalette.tsx
+++ b/packages/core/src/CommandPalette/XDSCommandPalette.tsx
@@ -519,7 +519,7 @@ export function XDSCommandPalette<
       maxHeight={maxHeight}
       purpose="info"
       aria-label={label}>
-      <CommandPaletteContext.Provider value={contextValue}>
+      <CommandPaletteContext value={contextValue}>
         <XDSLayout
           defaultHasDividers
           header={
@@ -538,7 +538,7 @@ export function XDSCommandPalette<
             </XDSLayoutFooter>
           }
         />
-      </CommandPaletteContext.Provider>
+      </CommandPaletteContext>
     </XDSDialog>
   );
 }

--- a/packages/core/src/CommandPalette/XDSCommandPaletteInput.test.tsx
+++ b/packages/core/src/CommandPalette/XDSCommandPaletteInput.test.tsx
@@ -100,9 +100,9 @@ describe('XDSCommandPaletteInput inline context', () => {
   it('does not auto-focus when context isInline is true', () => {
     const focusSpy = vi.spyOn(HTMLElement.prototype, 'focus');
     render(
-      <CommandPaletteContext.Provider value={makeContext({isInline: true})}>
+      <CommandPaletteContext value={makeContext({isInline: true})}>
         <XDSCommandPaletteInput />
-      </CommandPaletteContext.Provider>,
+      </CommandPaletteContext>,
     );
 
     const input = screen.getByRole('combobox');
@@ -115,9 +115,9 @@ describe('XDSCommandPaletteInput inline context', () => {
 
   it('auto-focuses when context isInline is false', async () => {
     render(
-      <CommandPaletteContext.Provider value={makeContext({isInline: false})}>
+      <CommandPaletteContext value={makeContext({isInline: false})}>
         <XDSCommandPaletteInput />
-      </CommandPaletteContext.Provider>,
+      </CommandPaletteContext>,
     );
 
     // Auto-focus uses requestAnimationFrame — flush it

--- a/packages/core/src/ContextMenu/XDSContextMenu.tsx
+++ b/packages/core/src/ContextMenu/XDSContextMenu.tsx
@@ -293,9 +293,9 @@ export function XDSContextMenu({
             className,
             style,
           )}>
-          <XDSDropdownMenuContext.Provider value={contextValue}>
+          <XDSDropdownMenuContext value={contextValue}>
             {resolvedMenuContent}
-          </XDSDropdownMenuContext.Provider>
+          </XDSDropdownMenuContext>
         </div>,
         {
           x: positionRef.current.x,

--- a/packages/core/src/ContextMenu/XDSContextMenu.tsx
+++ b/packages/core/src/ContextMenu/XDSContextMenu.tsx
@@ -187,6 +187,7 @@ export function XDSContextMenu({
 
   const menuId = useId();
   const positionRef = useRef({x: 0, y: 0});
+  // eslint-disable-next-line @eslint-react/no-unused-state -- isOpen triggers the click-outside effect
   const [isOpen, setIsOpen] = useState(false);
 
   const layer = useXDSLayer({

--- a/packages/core/src/Dialog/XDSDialogHeader.test.tsx
+++ b/packages/core/src/Dialog/XDSDialogHeader.test.tsx
@@ -86,9 +86,9 @@ describe('XDSDialogHeader', () => {
   it('renders with divider when context defaultHasDividers is true', () => {
     // With context true and no explicit prop, should match explicit hasDivider={true}
     const {container: ctxTrue} = render(
-      <XDSLayoutDividerContext.Provider value={{defaultHasDividers: true}}>
+      <XDSLayoutDividerContext value={{defaultHasDividers: true}}>
         <XDSDialogHeader title="Ctx true" />
-      </XDSLayoutDividerContext.Provider>,
+      </XDSLayoutDividerContext>,
     );
     const {container: explicitTrue} = render(
       <XDSDialogHeader title="Explicit true" hasDivider={true} />,
@@ -100,9 +100,9 @@ describe('XDSDialogHeader', () => {
 
   it('explicit hasDivider={false} overrides context defaultHasDividers=true', () => {
     const {container: overridden} = render(
-      <XDSLayoutDividerContext.Provider value={{defaultHasDividers: true}}>
+      <XDSLayoutDividerContext value={{defaultHasDividers: true}}>
         <XDSDialogHeader title="Overridden" hasDivider={false} />
-      </XDSLayoutDividerContext.Provider>,
+      </XDSLayoutDividerContext>,
     );
     const {container: noDivider} = render(
       <XDSDialogHeader title="No divider" hasDivider={false} />,

--- a/packages/core/src/DropdownMenu/XDSDropdownMenu.tsx
+++ b/packages/core/src/DropdownMenu/XDSDropdownMenu.tsx
@@ -391,9 +391,9 @@ export function XDSDropdownMenu({
             className,
             style,
           )}>
-          <XDSDropdownMenuContext.Provider value={contextValue}>
+          <XDSDropdownMenuContext value={contextValue}>
             {menuContent}
-          </XDSDropdownMenuContext.Provider>
+          </XDSDropdownMenuContext>
         </div>,
         {
           placement: 'below',

--- a/packages/core/src/DropdownMenu/XDSDropdownMenu.tsx
+++ b/packages/core/src/DropdownMenu/XDSDropdownMenu.tsx
@@ -214,7 +214,7 @@ export function XDSDropdownMenu({
   }, [isControlled, onOpenChange]);
 
   // Track whether to focus the first item when the menu opens
-  const shouldFocusOnOpen = useRef(false);
+  const shouldFocusOnOpenRef = useRef(false);
 
   const handleLayerShow = useCallback(() => {
     if (isControlled) {
@@ -222,8 +222,8 @@ export function XDSDropdownMenu({
     } else {
       setInternalIsOpen(true);
     }
-    if (shouldFocusOnOpen.current) {
-      shouldFocusOnOpen.current = false;
+    if (shouldFocusOnOpenRef.current) {
+      shouldFocusOnOpenRef.current = false;
       // focusFirst is called via openAndFocus below — defer to rAF
       // so the popover content is rendered before we query for items
     }

--- a/packages/core/src/DropdownMenu/XDSDropdownMenuContext.tsx
+++ b/packages/core/src/DropdownMenu/XDSDropdownMenuContext.tsx
@@ -12,7 +12,7 @@
  * items don't need to register themselves.
  */
 
-import {createContext, useContext} from 'react';
+import {createContext, use} from 'react';
 
 export interface XDSDropdownMenuContextValue {
   /** Close the menu and return focus to trigger */
@@ -23,11 +23,12 @@ export interface XDSDropdownMenuContextValue {
 
 export const XDSDropdownMenuContext =
   createContext<XDSDropdownMenuContextValue | null>(null);
+XDSDropdownMenuContext.displayName = 'XDSDropdownMenuContext';
 
 /**
  * Hook for compound menu items to access menu state.
  * Returns null outside of a DropdownMenu.
  */
 export function useXDSDropdownMenuContext(): XDSDropdownMenuContextValue | null {
-  return useContext(XDSDropdownMenuContext);
+  return use(XDSDropdownMenuContext);
 }

--- a/packages/core/src/Field/XDSField.test.tsx
+++ b/packages/core/src/Field/XDSField.test.tsx
@@ -272,9 +272,9 @@ describe('XDSField', () => {
     }: {
       children: React.ReactNode;
     }) => (
-      <XDSFormLayoutContext.Provider value={{direction: 'horizontal-labels'}}>
+      <XDSFormLayoutContext value={{direction: 'horizontal-labels'}}>
         {children}
-      </XDSFormLayoutContext.Provider>
+      </XDSFormLayoutContext>
     );
 
     it('applies display:contents when in horizontal-labels context', () => {

--- a/packages/core/src/Field/XDSField.tsx
+++ b/packages/core/src/Field/XDSField.tsx
@@ -16,7 +16,7 @@
  * - /packages/cli/templates/blocks/components/Field/ (showcase blocks)
  */
 
-import {type HTMLAttributes, type ReactNode, useContext} from 'react';
+import {type HTMLAttributes, type ReactNode, use} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import {XDSFieldLabel} from './XDSFieldLabel';
@@ -190,7 +190,7 @@ export function XDSField({
   ref,
   ...props
 }: XDSFieldProps) {
-  const {direction} = useContext(XDSFormLayoutContext);
+  const {direction} = use(XDSFormLayoutContext);
   const isHorizontalLabels = direction === 'horizontal-labels';
 
   const resolvedDescriptionID =

--- a/packages/core/src/FormLayout/XDSFormLayout.test.tsx
+++ b/packages/core/src/FormLayout/XDSFormLayout.test.tsx
@@ -11,7 +11,7 @@
 
 import {describe, it, expect} from 'vitest';
 import {render, screen} from '@testing-library/react';
-import {useContext} from 'react';
+import {use} from 'react';
 import {XDSFormLayout} from './XDSFormLayout';
 import {XDSFormLayoutContext} from './XDSFormLayoutContext';
 import type {XDSFormLayoutDirection} from './XDSFormLayoutContext';
@@ -19,7 +19,7 @@ import {XDSField} from '../Field';
 
 // Helper component to read context
 function DirectionReader() {
-  const {direction} = useContext(XDSFormLayoutContext);
+  const {direction} = use(XDSFormLayoutContext);
   return <span data-testid="direction">{direction}</span>;
 }
 

--- a/packages/core/src/FormLayout/XDSFormLayout.tsx
+++ b/packages/core/src/FormLayout/XDSFormLayout.tsx
@@ -143,7 +143,7 @@ export function XDSFormLayout({
   const contextValue = useMemo(() => ({direction}), [direction]);
 
   return (
-    <XDSFormLayoutContext.Provider value={contextValue}>
+    <XDSFormLayoutContext value={contextValue}>
       <div
         ref={ref}
         {...mergeProps(
@@ -160,7 +160,7 @@ export function XDSFormLayout({
         {...props}>
         {children}
       </div>
-    </XDSFormLayoutContext.Provider>
+    </XDSFormLayoutContext>
   );
 }
 

--- a/packages/core/src/FormLayout/XDSFormLayoutContext.ts
+++ b/packages/core/src/FormLayout/XDSFormLayoutContext.ts
@@ -11,7 +11,6 @@
  * SYNC: When modified, update these files to stay in sync:
  */
 
-
 import {createContext} from 'react';
 
 /**
@@ -34,3 +33,4 @@ export type XDSFormLayoutDirection =
 export const XDSFormLayoutContext = createContext<{
   direction: XDSFormLayoutDirection;
 }>({direction: 'vertical'});
+XDSFormLayoutContext.displayName = 'XDSFormLayoutContext';

--- a/packages/core/src/InputGroup/XDSInputGroup.tsx
+++ b/packages/core/src/InputGroup/XDSInputGroup.tsx
@@ -160,7 +160,7 @@ export function XDSInputGroup({
   const contextValue = useMemo(() => ({isInGroup: true as const}), []);
 
   return (
-    <XDSInputGroupContext.Provider value={contextValue}>
+    <XDSInputGroupContext value={contextValue}>
       <XDSSizeProvider value={size}>
         <XDSField
           label={label}
@@ -205,7 +205,7 @@ export function XDSInputGroup({
           </div>
         </XDSField>
       </XDSSizeProvider>
-    </XDSInputGroupContext.Provider>
+    </XDSInputGroupContext>
   );
 }
 

--- a/packages/core/src/InputGroup/XDSInputGroupContext.ts
+++ b/packages/core/src/InputGroup/XDSInputGroupContext.ts
@@ -9,7 +9,7 @@
  * @position Shared context; consumed by input components for group-aware styling
  */
 
-import {createContext, useContext} from 'react';
+import {createContext, use} from 'react';
 
 export interface XDSInputGroupContextValue {
   isInGroup: true;
@@ -17,11 +17,12 @@ export interface XDSInputGroupContextValue {
 
 export const XDSInputGroupContext =
   createContext<XDSInputGroupContextValue | null>(null);
+XDSInputGroupContext.displayName = 'XDSInputGroupContext';
 
 /**
  * Hook for input components to detect when inside an InputGroup.
  * Returns null when used outside a group.
  */
 export function useXDSInputGroup(): XDSInputGroupContextValue | null {
-  return useContext(XDSInputGroupContext);
+  return use(XDSInputGroupContext);
 }

--- a/packages/core/src/Layer/XDSLayerContext.ts
+++ b/packages/core/src/Layer/XDSLayerContext.ts
@@ -13,7 +13,7 @@
  * - /packages/core/src/Layer/XDSLayerProvider.tsx
  */
 
-import {createContext, useContext} from 'react';
+import {createContext, use} from 'react';
 
 /**
  * Toast configuration passed through the layer provider.
@@ -47,10 +47,11 @@ export interface XDSLayerContextValue {
  * Default value is null — hooks detect this and use the fallback.
  */
 export const XDSLayerContext = createContext<XDSLayerContextValue | null>(null);
+XDSLayerContext.displayName = 'XDSLayerContext';
 
 /**
  * Hook to access the layer context. Returns null if no provider exists.
  */
 export function useXDSLayerContext(): XDSLayerContextValue | null {
-  return useContext(XDSLayerContext);
+  return use(XDSLayerContext);
 }

--- a/packages/core/src/Layer/XDSLayerProvider.tsx
+++ b/packages/core/src/Layer/XDSLayerProvider.tsx
@@ -49,14 +49,14 @@ export function XDSLayerProvider({
   }
 
   return (
-    <XDSLayerContext.Provider value={contextValue}>
+    <XDSLayerContext value={contextValue}>
       <XDSToastViewport
         position={toastConfig.position}
         maxVisible={toastConfig.maxVisible}
         inset={toastConfig.inset}>
         {children}
       </XDSToastViewport>
-    </XDSLayerContext.Provider>
+    </XDSLayerContext>
   );
 }
 

--- a/packages/core/src/Layout/XDSLayout.tsx
+++ b/packages/core/src/Layout/XDSLayout.tsx
@@ -171,11 +171,7 @@ function AreaProvider({
   if (children == null) {
     return null;
   }
-  return (
-    <XDSLayoutAreaContext.Provider value={area}>
-      {children}
-    </XDSLayoutAreaContext.Provider>
-  );
+  return <XDSLayoutAreaContext value={area}>{children}</XDSLayoutAreaContext>;
 }
 
 /**
@@ -257,7 +253,7 @@ export function XDSLayout({
   );
 
   const tree = (
-    <XDSLayoutSlotsContext.Provider value={slotsValue}>
+    <XDSLayoutSlotsContext value={slotsValue}>
       <div
         ref={ref}
         {...mergeProps(
@@ -297,14 +293,14 @@ export function XDSLayout({
           <AreaProvider area="footer">{footer}</AreaProvider>
         </div>
       </div>
-    </XDSLayoutSlotsContext.Provider>
+    </XDSLayoutSlotsContext>
   );
 
   if (dividerCtxValue != null) {
     return (
-      <XDSLayoutDividerContext.Provider value={dividerCtxValue}>
+      <XDSLayoutDividerContext value={dividerCtxValue}>
         {tree}
-      </XDSLayoutDividerContext.Provider>
+      </XDSLayoutDividerContext>
     );
   }
 

--- a/packages/core/src/Layout/XDSLayoutAreaContext.ts
+++ b/packages/core/src/Layout/XDSLayoutAreaContext.ts
@@ -12,7 +12,6 @@
  * - /packages/core/src/Layout/Layout.doc.mjs
  */
 
-
 import {createContext} from 'react';
 
 /**
@@ -35,3 +34,4 @@ export type LayoutArea =
  * - Adjust internal spacing
  */
 export const XDSLayoutAreaContext = createContext<LayoutArea>(null);
+XDSLayoutAreaContext.displayName = 'XDSLayoutAreaContext';

--- a/packages/core/src/Layout/XDSLayoutContent.tsx
+++ b/packages/core/src/Layout/XDSLayoutContent.tsx
@@ -17,7 +17,7 @@
 
 import type {AriaRole, ReactNode} from 'react';
 import type {XDSBaseProps} from '../XDSBaseProps';
-import {useContext} from 'react';
+import {use} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {spacingVars} from '../theme/tokens.stylex';
 import {XDSLayoutSlotsContext} from './XDSLayoutSlotsContext';
@@ -175,9 +175,7 @@ export function XDSLayoutContent({
   ref,
   ...props
 }: XDSLayoutContentProps) {
-  const {hasHeader, hasFooter, hasStart, hasEnd} = useContext(
-    XDSLayoutSlotsContext,
-  );
+  const {hasHeader, hasFooter, hasStart, hasEnd} = use(XDSLayoutSlotsContext);
 
   const isZeroPadding = padding === 0;
 

--- a/packages/core/src/Layout/XDSLayoutDividerContext.ts
+++ b/packages/core/src/Layout/XDSLayoutDividerContext.ts
@@ -24,3 +24,4 @@ export interface LayoutDividerContextValue {
 
 export const XDSLayoutDividerContext =
   createContext<LayoutDividerContextValue | null>(null);
+XDSLayoutDividerContext.displayName = 'XDSLayoutDividerContext';

--- a/packages/core/src/Layout/XDSLayoutFooter.tsx
+++ b/packages/core/src/Layout/XDSLayoutFooter.tsx
@@ -17,7 +17,7 @@
 
 import type {AriaRole, ReactNode} from 'react';
 import type {XDSBaseProps} from '../XDSBaseProps';
-import {useContext} from 'react';
+import {use} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {XDSLayoutDividerContext} from './XDSLayoutDividerContext';
 import {colorVars, spacingVars} from '../theme/tokens.stylex';
@@ -146,7 +146,7 @@ export function XDSLayoutFooter({
   ref,
   ...props
 }: XDSLayoutFooterProps) {
-  const dividerCtx = useContext(XDSLayoutDividerContext);
+  const dividerCtx = use(XDSLayoutDividerContext);
   const resolvedHasDivider =
     hasDivider ?? dividerCtx?.defaultHasDividers ?? false;
   const isZeroPadding = padding === 0;

--- a/packages/core/src/Layout/XDSLayoutHeader.tsx
+++ b/packages/core/src/Layout/XDSLayoutHeader.tsx
@@ -17,7 +17,7 @@
 
 import type {AriaRole, ReactNode} from 'react';
 import type {XDSBaseProps} from '../XDSBaseProps';
-import {useContext} from 'react';
+import {use} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {XDSLayoutDividerContext} from './XDSLayoutDividerContext';
 import {colorVars, spacingVars} from '../theme/tokens.stylex';
@@ -146,7 +146,7 @@ export function XDSLayoutHeader({
   ref,
   ...props
 }: XDSLayoutHeaderProps) {
-  const dividerCtx = useContext(XDSLayoutDividerContext);
+  const dividerCtx = use(XDSLayoutDividerContext);
   const resolvedHasDivider =
     hasDivider ?? dividerCtx?.defaultHasDividers ?? false;
   const isZeroPadding = padding === 0;

--- a/packages/core/src/Layout/XDSLayoutPanel.tsx
+++ b/packages/core/src/Layout/XDSLayoutPanel.tsx
@@ -17,7 +17,7 @@
 
 import type {AriaRole, ReactNode} from 'react';
 import type {XDSBaseProps} from '../XDSBaseProps';
-import {useContext} from 'react';
+import {use} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars, spacingVars} from '../theme/tokens.stylex';
 import {XDSLayoutAreaContext} from './XDSLayoutAreaContext';
@@ -219,8 +219,8 @@ export function XDSLayoutPanel({
   ref,
   ...props
 }: XDSLayoutPanelProps) {
-  const area = useContext(XDSLayoutAreaContext);
-  const {hasHeader, hasFooter} = useContext(XDSLayoutSlotsContext);
+  const area = use(XDSLayoutAreaContext);
+  const {hasHeader, hasFooter} = use(XDSLayoutSlotsContext);
 
   // When resizable props are provided, use the hook-driven size
   const effectiveWidth = resizable ? resizable._size : width;

--- a/packages/core/src/Layout/XDSLayoutSlotsContext.ts
+++ b/packages/core/src/Layout/XDSLayoutSlotsContext.ts
@@ -47,3 +47,4 @@ const defaultSlots: LayoutSlots = {
  * (for applying outer padding).
  */
 export const XDSLayoutSlotsContext = createContext<LayoutSlots>(defaultSlots);
+XDSLayoutSlotsContext.displayName = 'XDSLayoutSlotsContext';

--- a/packages/core/src/Link/XDSLink.test.tsx
+++ b/packages/core/src/Link/XDSLink.test.tsx
@@ -12,18 +12,20 @@
 import {describe, it, expect, vi} from 'vitest';
 import {render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import {forwardRef, type ComponentPropsWithoutRef} from 'react';
 import {XDSLink} from './XDSLink';
 import {XDSLinkProvider} from './XDSLinkProvider';
 
-const CustomLink = forwardRef<HTMLAnchorElement, ComponentPropsWithoutRef<'a'>>(
-  ({children, ...props}, ref) => (
+function CustomLink({
+  children,
+  ref,
+  ...props
+}: React.ComponentPropsWithRef<'a'>) {
+  return (
     <a ref={ref} data-custom-link {...props}>
       {children}
     </a>
-  ),
-);
-CustomLink.displayName = 'CustomLink';
+  );
+}
 
 describe('XDSLink', () => {
   it('renders children as link text', () => {
@@ -192,16 +194,17 @@ describe('XDSLink', () => {
   });
 
   it('as prop overrides XDSLinkProvider', () => {
-    const AnotherLink = forwardRef<
-      HTMLAnchorElement,
-      ComponentPropsWithoutRef<'a'>
-    >(function AnotherLink({children, ...props}, ref) {
+    function AnotherLink({
+      children,
+      ref,
+      ...props
+    }: React.ComponentPropsWithRef<'a'>) {
       return (
         <a ref={ref} data-another-link {...props}>
           {children}
         </a>
       );
-    });
+    }
     render(
       <XDSLinkProvider component={AnotherLink}>
         <XDSLink href="/override" as={CustomLink}>

--- a/packages/core/src/Link/XDSLinkContext.ts
+++ b/packages/core/src/Link/XDSLinkContext.ts
@@ -19,7 +19,6 @@
  * - /packages/core/src/Link/Link.doc.mjs
  */
 
-
 import {createContext} from 'react';
 import type {XDSLinkComponentType} from './types';
 
@@ -35,3 +34,4 @@ export interface XDSLinkContextValue {
  * Defaults to null (components fall back to native `<a>`).
  */
 export const XDSLinkContext = createContext<XDSLinkContextValue | null>(null);
+XDSLinkContext.displayName = 'XDSLinkContext';

--- a/packages/core/src/Link/XDSLinkProvider.tsx
+++ b/packages/core/src/Link/XDSLinkProvider.tsx
@@ -25,7 +25,6 @@
  * - /packages/cli/templates/blocks/components/Link/ (showcase blocks)
  */
 
-
 import {useMemo, type ReactNode} from 'react';
 import {XDSLinkContext} from './XDSLinkContext';
 import type {XDSLinkComponentType} from './types';
@@ -54,7 +53,5 @@ export interface XDSLinkProviderProps {
  */
 export function XDSLinkProvider({component, children}: XDSLinkProviderProps) {
   const value = useMemo(() => ({component}), [component]);
-  return (
-    <XDSLinkContext.Provider value={value}>{children}</XDSLinkContext.Provider>
-  );
+  return <XDSLinkContext value={value}>{children}</XDSLinkContext>;
 }

--- a/packages/core/src/Link/useXDSLinkComponent.test.tsx
+++ b/packages/core/src/Link/useXDSLinkComponent.test.tsx
@@ -9,7 +9,6 @@
 
 import {describe, it, expect, vi} from 'vitest';
 import {render, screen} from '@testing-library/react';
-import {forwardRef, type ComponentPropsWithoutRef} from 'react';
 import {useXDSLinkComponent} from './useXDSLinkComponent';
 import {XDSLinkProvider} from './XDSLinkProvider';
 import type {XDSLinkComponentType} from './types';
@@ -24,43 +23,52 @@ function TestConsumer({as}: {as?: XDSLinkComponentType}) {
   );
 }
 
-const CustomLink = forwardRef<HTMLAnchorElement, ComponentPropsWithoutRef<'a'>>(
-  ({children, ...props}, ref) => (
+function CustomLink({
+  children,
+  ref,
+  ...props
+}: React.ComponentPropsWithRef<'a'>) {
+  return (
     <a ref={ref} data-custom-link {...props}>
       {children}
     </a>
-  ),
-);
-CustomLink.displayName = 'CustomLink';
+  );
+}
 
-const AnotherLink = forwardRef<
-  HTMLAnchorElement,
-  ComponentPropsWithoutRef<'a'>
->(({children, ...props}, ref) => (
-  <a ref={ref} data-another-link {...props}>
-    {children}
-  </a>
-));
-AnotherLink.displayName = 'AnotherLink';
+function AnotherLink({
+  children,
+  ref,
+  ...props
+}: React.ComponentPropsWithRef<'a'>) {
+  return (
+    <a ref={ref} data-another-link {...props}>
+      {children}
+    </a>
+  );
+}
 
 /**
  * A mock "to"-based router link that reads `to` instead of `href`.
  * Simulates React Router / TanStack Router behavior.
  */
-const ToBasedRouterLink = forwardRef<
-  HTMLAnchorElement,
-  {
-    to?: string;
-    href?: string;
-    children?: React.ReactNode;
-    [key: string]: unknown;
-  }
->(({to, children, ...props}, ref) => (
-  <a ref={ref} href={to} data-router-link data-to={to} {...props}>
-    {children}
-  </a>
-));
-ToBasedRouterLink.displayName = 'ToBasedRouterLink';
+function ToBasedRouterLink({
+  to,
+  children,
+  ref,
+  ...props
+}: {
+  to?: string;
+  href?: string;
+  children?: React.ReactNode;
+  ref?: React.Ref<HTMLAnchorElement>;
+  [key: string]: unknown;
+}) {
+  return (
+    <a ref={ref} href={to} data-router-link data-to={to} {...props}>
+      {children}
+    </a>
+  );
+}
 
 // =============================================================================
 // useXDSLinkComponent
@@ -126,11 +134,12 @@ describe('useXDSLinkComponent — to prop', () => {
         </a>
       ),
     );
-    const SpyLink = forwardRef<
-      HTMLAnchorElement,
-      {children?: React.ReactNode; [key: string]: unknown}
-    >((props, _ref) => spy(props));
-    SpyLink.displayName = 'SpyLink';
+    function SpyLink(props: {
+      children?: React.ReactNode;
+      [key: string]: unknown;
+    }) {
+      return spy(props);
+    }
 
     render(
       <XDSLinkProvider component={SpyLink}>
@@ -157,11 +166,12 @@ describe('useXDSLinkComponent — to prop', () => {
         </a>
       ),
     );
-    const SpyLink = forwardRef<
-      HTMLAnchorElement,
-      {children?: React.ReactNode; [key: string]: unknown}
-    >((props, _ref) => spy(props));
-    SpyLink.displayName = 'SpyLink';
+    function SpyLink(props: {
+      children?: React.ReactNode;
+      [key: string]: unknown;
+    }) {
+      return spy(props);
+    }
 
     render(<TestConsumer as={SpyLink} />);
 

--- a/packages/core/src/Link/useXDSLinkComponent.ts
+++ b/packages/core/src/Link/useXDSLinkComponent.ts
@@ -4,7 +4,7 @@
 
 /**
  * @file useXDSLinkComponent.ts
- * @input React useContext, useMemo, createElement, forwardRef, XDSLinkContext, XDSLinkComponentType
+ * @input React use, useMemo, createElement, forwardRef, XDSLinkContext, XDSLinkComponentType
  * @output Exports useXDSLinkComponent hook
  * @position Hook for resolving the link component in XDS components
  *
@@ -20,7 +20,7 @@
  * - /packages/core/src/Link/Link.doc.mjs
  */
 
-import {useContext, useMemo, createElement} from 'react';
+import {use, useMemo, createElement} from 'react';
 import {XDSLinkContext} from './XDSLinkContext';
 import type {XDSLinkComponentType} from './types';
 
@@ -78,7 +78,7 @@ function createLinkWithTo(
 export function useXDSLinkComponent(
   as?: XDSLinkComponentType,
 ): XDSLinkComponentType {
-  const ctx = useContext(XDSLinkContext);
+  const ctx = use(XDSLinkContext);
   const resolved = as ?? ctx?.component ?? 'a';
 
   // Memoize the wrapper to maintain referential stability.

--- a/packages/core/src/Link/useXDSLinkComponent.ts
+++ b/packages/core/src/Link/useXDSLinkComponent.ts
@@ -20,7 +20,7 @@
  * - /packages/core/src/Link/Link.doc.mjs
  */
 
-import {useContext, useMemo, forwardRef, createElement} from 'react';
+import {useContext, useMemo, createElement} from 'react';
 import {XDSLinkContext} from './XDSLinkContext';
 import type {XDSLinkComponentType} from './types';
 
@@ -35,11 +35,17 @@ import type {XDSLinkComponentType} from './types';
 function createLinkWithTo(
   Component: XDSLinkComponentType,
 ): XDSLinkComponentType {
-  const LinkWithTo = forwardRef<unknown, {href?: string; to?: string}>(
-    ({href, ...rest}, ref) => {
-      return createElement(Component, {ref, href, to: href, ...rest});
-    },
-  );
+  function LinkWithTo({
+    href,
+    ref,
+    ...rest
+  }: {
+    href?: string;
+    to?: string;
+    ref?: React.Ref<unknown>;
+  }) {
+    return createElement(Component, {ref, href, to: href, ...rest});
+  }
   LinkWithTo.displayName = `LinkWithTo(${
     typeof Component === 'string'
       ? Component

--- a/packages/core/src/List/XDSList.tsx
+++ b/packages/core/src/List/XDSList.tsx
@@ -169,22 +169,18 @@ export function XDSList({
   );
 
   if (header == null) {
-    return (
-      <XDSListContext.Provider value={contextValue}>
-        {listElement}
-      </XDSListContext.Provider>
-    );
+    return <XDSListContext value={contextValue}>{listElement}</XDSListContext>;
   }
 
   return (
-    <XDSListContext.Provider value={contextValue}>
+    <XDSListContext value={contextValue}>
       <div {...stylex.props(styles.root)}>
         <div id={headerId} {...stylex.props(styles.header)}>
           {header}
         </div>
         {listElement}
       </div>
-    </XDSListContext.Provider>
+    </XDSListContext>
   );
 }
 

--- a/packages/core/src/List/XDSListContext.tsx
+++ b/packages/core/src/List/XDSListContext.tsx
@@ -21,3 +21,4 @@ export interface XDSListContextValue {
 }
 
 export const XDSListContext = createContext<XDSListContextValue | null>(null);
+XDSListContext.displayName = 'XDSListContext';

--- a/packages/core/src/List/XDSListItem.tsx
+++ b/packages/core/src/List/XDSListItem.tsx
@@ -16,7 +16,7 @@
  * - /packages/cli/templates/blocks/components/List/ (showcase blocks)
  */
 
-import {useContext, type ReactNode} from 'react';
+import {use, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {
   colorVars,
@@ -346,7 +346,7 @@ export function XDSListItem({
   ref,
   ...restProps
 }: XDSListItemProps) {
-  const ctx = useContext(XDSListContext);
+  const ctx = use(XDSListContext);
   const LinkComponent = useXDSLinkComponent();
   const density = ctx?.density ?? 'balanced';
   const hasDividers = ctx?.hasDividers ?? false;

--- a/packages/core/src/Markdown/XDSMarkdown.tsx
+++ b/packages/core/src/Markdown/XDSMarkdown.tsx
@@ -1541,7 +1541,9 @@ export function XDSMarkdown({
   // When not streaming, the hook returns children unchanged (no-op).
   const smoothedText = useXDSStreamingText(children, isStreaming);
 
-  const incrementalState = useRef<IncrementalState>(createIncrementalState());
+  const incrementalStateRef = useRef<IncrementalState>(
+    createIncrementalState(),
+  );
   // Track how much text content was rendered on the previous pass.
   // Everything beyond this boundary is "new" and gets the fade-in animation.
   const prevTextLenRef = useRef(0);
@@ -1549,14 +1551,14 @@ export function XDSMarkdown({
   const blocks = useMemo(() => {
     if (isStreaming) {
       if (smoothedText === '') {
-        incrementalState.current = createIncrementalState();
+        incrementalStateRef.current = createIncrementalState();
         prevTextLenRef.current = 0;
         return [];
       }
       const input = trimStreamingArtifacts(smoothedText);
       return parseMarkdownIncremental(
         input,
-        incrementalState.current,
+        incrementalStateRef.current,
         sourceIds,
       );
     }

--- a/packages/core/src/MetadataList/XDSMetadataList.tsx
+++ b/packages/core/src/MetadataList/XDSMetadataList.tsx
@@ -252,7 +252,7 @@ export function XDSMetadataList({
         : undefined;
 
   return (
-    <XDSMetadataListContext.Provider value={contextValue}>
+    <XDSMetadataListContext value={contextValue}>
       <div
         ref={ref}
         data-testid={testId}
@@ -284,7 +284,7 @@ export function XDSMetadataList({
           </button>
         )}
       </div>
-    </XDSMetadataListContext.Provider>
+    </XDSMetadataListContext>
   );
 }
 

--- a/packages/core/src/MetadataList/XDSMetadataListContext.tsx
+++ b/packages/core/src/MetadataList/XDSMetadataListContext.tsx
@@ -23,3 +23,4 @@ export interface XDSMetadataListContextValue {
 
 export const XDSMetadataListContext =
   createContext<XDSMetadataListContextValue | null>(null);
+XDSMetadataListContext.displayName = 'XDSMetadataListContext';

--- a/packages/core/src/MetadataList/XDSMetadataListItem.tsx
+++ b/packages/core/src/MetadataList/XDSMetadataListItem.tsx
@@ -16,7 +16,7 @@
  * - /packages/cli/templates/blocks/components/MetadataList/ (showcase blocks)
  */
 
-import {useContext, type ReactNode} from 'react';
+import {use, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {
   colorVars,
@@ -144,7 +144,7 @@ export function XDSMetadataListItem({
   'data-testid': testId,
   ref,
 }: XDSMetadataListItemProps) {
-  const ctx = useContext(XDSMetadataListContext);
+  const ctx = use(XDSMetadataListContext);
   const labelPosition = ctx?.labelConfig.position ?? 'start';
   const isStacked =
     labelPosition === 'top' || ctx?.orientation === 'horizontal';

--- a/packages/core/src/NavMenu/XDSNavHeadingMenu.test.tsx
+++ b/packages/core/src/NavMenu/XDSNavHeadingMenu.test.tsx
@@ -216,9 +216,9 @@ describe('context forwarding', () => {
       </XDSNavHeadingMenu>,
       {
         wrapper: ({children}) => (
-          <XDSNavHeadingCloseContext.Provider value={{closeMenu}}>
+          <XDSNavHeadingCloseContext value={{closeMenu}}>
             {children}
-          </XDSNavHeadingCloseContext.Provider>
+          </XDSNavHeadingCloseContext>
         ),
       },
     );
@@ -235,9 +235,9 @@ describe('context forwarding', () => {
       </XDSNavHeadingMenu>,
       {
         wrapper: ({children}) => (
-          <XDSNavHeadingCloseContext.Provider value={{closeMenu}}>
+          <XDSNavHeadingCloseContext value={{closeMenu}}>
             {children}
-          </XDSNavHeadingCloseContext.Provider>
+          </XDSNavHeadingCloseContext>
         ),
       },
     );

--- a/packages/core/src/NavMenu/XDSNavHeadingMenu.tsx
+++ b/packages/core/src/NavMenu/XDSNavHeadingMenu.tsx
@@ -115,7 +115,7 @@ export function XDSNavHeadingMenu({
   const inlineStyle = minWidth != null ? {...styleProp, minWidth} : styleProp;
 
   return (
-    <XDSNavHeadingMenuContext.Provider value={ctx}>
+    <XDSNavHeadingMenuContext value={ctx}>
       <div
         ref={listRef as React.RefObject<HTMLDivElement>}
         role="menu"
@@ -129,7 +129,7 @@ export function XDSNavHeadingMenu({
         )}>
         {children}
       </div>
-    </XDSNavHeadingMenuContext.Provider>
+    </XDSNavHeadingMenuContext>
   );
 }
 

--- a/packages/core/src/NavMenu/XDSNavMenuContext.tsx
+++ b/packages/core/src/NavMenu/XDSNavMenuContext.tsx
@@ -2,7 +2,7 @@
 
 'use client';
 
-import {createContext, useContext} from 'react';
+import {createContext, use} from 'react';
 
 export type XDSNavHeadingMenuSize = 'sm' | 'md' | 'lg';
 
@@ -17,9 +17,10 @@ export interface XDSNavHeadingCloseContextValue {
 
 export const XDSNavHeadingCloseContext =
   createContext<XDSNavHeadingCloseContextValue | null>(null);
+XDSNavHeadingCloseContext.displayName = 'XDSNavHeadingCloseContext';
 
 export function useXDSNavHeadingCloseContext(): XDSNavHeadingCloseContextValue | null {
-  return useContext(XDSNavHeadingCloseContext);
+  return use(XDSNavHeadingCloseContext);
 }
 
 /**
@@ -33,7 +34,8 @@ export interface XDSNavHeadingMenuContextValue {
 
 export const XDSNavHeadingMenuContext =
   createContext<XDSNavHeadingMenuContextValue | null>(null);
+XDSNavHeadingMenuContext.displayName = 'XDSNavHeadingMenuContext';
 
 export function useXDSNavHeadingMenuContext(): XDSNavHeadingMenuContextValue | null {
-  return useContext(XDSNavHeadingMenuContext);
+  return use(XDSNavHeadingMenuContext);
 }

--- a/packages/core/src/RadioList/XDSRadioList.tsx
+++ b/packages/core/src/RadioList/XDSRadioList.tsx
@@ -41,6 +41,7 @@ export interface XDSRadioListContextValue {
 
 export const XDSRadioListContext =
   createContext<XDSRadioListContextValue | null>(null);
+XDSRadioListContext.displayName = 'XDSRadioListContext';
 
 const styles = stylex.create({
   radiogroup: {
@@ -216,9 +217,9 @@ export function XDSRadioList({
             orientation === 'vertical' ? styles.vertical : styles.horizontal,
           ),
         )}>
-        <XDSRadioListContext.Provider value={contextValue}>
+        <XDSRadioListContext value={contextValue}>
           {children}
-        </XDSRadioListContext.Provider>
+        </XDSRadioListContext>
       </div>
     </XDSField>
   );

--- a/packages/core/src/RadioList/XDSRadioListItem.tsx
+++ b/packages/core/src/RadioList/XDSRadioListItem.tsx
@@ -4,7 +4,7 @@
 
 /**
  * @file XDSRadioListItem.tsx
- * @input Uses React useContext, useId, XDSRadioListContext
+ * @input Uses React use, useId, XDSRadioListContext
  * @output Exports XDSRadioListItem component, XDSRadioListItemProps
  * @position Core implementation; consumed by index.ts, tested by XDSRadioList.test.tsx
  *
@@ -16,7 +16,7 @@
  * - /packages/cli/templates/blocks/components/RadioList/ (showcase blocks)
  */
 
-import {useContext, useId, type ReactNode} from 'react';
+import {use, useId, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {
   colorVars,
@@ -243,7 +243,7 @@ export function XDSRadioListItem({
   endContent,
   'data-testid': dataTestId,
 }: XDSRadioListItemProps) {
-  const context = useContext(XDSRadioListContext);
+  const context = use(XDSRadioListContext);
   if (!context) {
     throw new Error('XDSRadioListItem must be used within an XDSRadioList');
   }

--- a/packages/core/src/Resizable/useXDSResizable.ts
+++ b/packages/core/src/Resizable/useXDSResizable.ts
@@ -203,8 +203,8 @@ function useSingleResizable(
   const [isCollapsed, setIsCollapsed] = useState(
     () => persisted === 0 && collapsible,
   );
-  const preCollapseSize = useRef(size);
-  const dragStartSize = useRef(size);
+  const preCollapseSizeRef = useRef(size);
+  const dragStartSizeRef = useRef(size);
 
   useEffect(() => {
     if (autoSaveId) {
@@ -214,7 +214,7 @@ function useSingleResizable(
 
   const collapse = useCallback(() => {
     if (!collapsible) return;
-    preCollapseSize.current = size;
+    preCollapseSizeRef.current = size;
     setIsCollapsed(true);
     setSize(0);
     onCollapseChange?.(true);
@@ -223,7 +223,7 @@ function useSingleResizable(
 
   const expand = useCallback(() => {
     setIsCollapsed(false);
-    const restored = preCollapseSize.current || resolvedDefault;
+    const restored = preCollapseSizeRef.current || resolvedDefault;
     const newSize = clampSize(restored, minSizePx, maxSizePx, snaps);
     setSize(newSize);
     onCollapseChange?.(false);
@@ -248,15 +248,15 @@ function useSingleResizable(
   );
 
   const onResizeStart = useCallback(() => {
-    dragStartSize.current = isCollapsed ? 0 : size;
+    dragStartSizeRef.current = isCollapsed ? 0 : size;
   }, [size, isCollapsed]);
 
   const onResizeMove = useCallback(
     (delta: number) => {
-      const raw = dragStartSize.current + delta;
+      const raw = dragStartSizeRef.current + delta;
       if (collapsible && raw < collapsedSize) {
         if (!isCollapsed) {
-          preCollapseSize.current = size;
+          preCollapseSizeRef.current = size;
           onCollapseChange?.(true);
         }
         setIsCollapsed(true);

--- a/packages/core/src/SegmentedControl/XDSSegmentedControl.tsx
+++ b/packages/core/src/SegmentedControl/XDSSegmentedControl.tsx
@@ -189,7 +189,7 @@ export function XDSSegmentedControl({
   );
 
   return (
-    <XDSSegmentedControlContext.Provider value={contextValue}>
+    <XDSSegmentedControlContext value={contextValue}>
       <div
         ref={containerRef}
         role="radiogroup"
@@ -210,7 +210,7 @@ export function XDSSegmentedControl({
         )}>
         {children}
       </div>
-    </XDSSegmentedControlContext.Provider>
+    </XDSSegmentedControlContext>
   );
 }
 

--- a/packages/core/src/SegmentedControl/XDSSegmentedControlContext.ts
+++ b/packages/core/src/SegmentedControl/XDSSegmentedControlContext.ts
@@ -4,15 +4,14 @@
 
 /**
  * @file XDSSegmentedControlContext.ts
- * @input React createContext, useContext
+ * @input React createContext, use
  * @output Exports XDSSegmentedControlContext, useXDSSegmentedControlContext
  * @position Context provider; consumed by XDSSegmentedControlItem.tsx
  *
  * SYNC: When modified, update /packages/core/src/SegmentedControl/SegmentedControl.doc.mjs
  */
 
-
-import {createContext, useContext} from 'react';
+import {createContext, use} from 'react';
 
 export type XDSSegmentedControlSize = 'sm' | 'md' | 'lg';
 export type XDSSegmentedControlLayout = 'hug' | 'fill';
@@ -27,9 +26,10 @@ export interface XDSSegmentedControlContextValue {
 
 export const XDSSegmentedControlContext =
   createContext<XDSSegmentedControlContextValue | null>(null);
+XDSSegmentedControlContext.displayName = 'XDSSegmentedControlContext';
 
 export function useXDSSegmentedControlContext(): XDSSegmentedControlContextValue {
-  const ctx = useContext(XDSSegmentedControlContext);
+  const ctx = use(XDSSegmentedControlContext);
   if (ctx == null) {
     throw new Error(
       'useXDSSegmentedControlContext must be used within XDSSegmentedControl. ' +

--- a/packages/core/src/SideNav/XDSSideNav.test.tsx
+++ b/packages/core/src/SideNav/XDSSideNav.test.tsx
@@ -265,9 +265,9 @@ const COLLAPSED_CONTEXT = {
 
 function CollapsedWrapper({children}: {children: ReactNode}) {
   return (
-    <XDSSideNavCollapseContext.Provider value={COLLAPSED_CONTEXT}>
+    <XDSSideNavCollapseContext value={COLLAPSED_CONTEXT}>
       {children}
-    </XDSSideNavCollapseContext.Provider>
+    </XDSSideNavCollapseContext>
   );
 }
 
@@ -1016,7 +1016,7 @@ describe('XDSSideNavItem — mobile drawer close-on-activate', () => {
     return {
       closeMobileNav,
       ...render(
-        <XDSAppShellMobileContext.Provider
+        <XDSAppShellMobileContext
           value={{
             isMobile: true,
             isMobileNavOpen: true,
@@ -1027,7 +1027,7 @@ describe('XDSSideNavItem — mobile drawer close-on-activate', () => {
             hasAutoToggle: true,
           }}>
           <XDSSideNavRenderContext value="drawer">{ui}</XDSSideNavRenderContext>
-        </XDSAppShellMobileContext.Provider>,
+        </XDSAppShellMobileContext>,
       ),
     };
   }
@@ -1071,7 +1071,7 @@ describe('XDSSideNavItem — mobile drawer close-on-activate', () => {
     const user = userEvent.setup();
     const closeMobileNav = vi.fn();
     render(
-      <XDSAppShellMobileContext.Provider
+      <XDSAppShellMobileContext
         value={{
           isMobile: false,
           isMobileNavOpen: false,
@@ -1082,7 +1082,7 @@ describe('XDSSideNavItem — mobile drawer close-on-activate', () => {
           hasAutoToggle: true,
         }}>
         <XDSSideNavItem label="Home" href="/" data-testid="item" />
-      </XDSAppShellMobileContext.Provider>,
+      </XDSAppShellMobileContext>,
     );
     await user.click(screen.getByTestId('item'));
     expect(closeMobileNav).not.toHaveBeenCalled();

--- a/packages/core/src/SideNav/XDSSideNav.test.tsx
+++ b/packages/core/src/SideNav/XDSSideNav.test.tsx
@@ -13,7 +13,7 @@ import React from 'react';
 import {describe, it, expect, vi} from 'vitest';
 import {render, screen, act, fireEvent} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import {forwardRef, type ComponentPropsWithoutRef, type ReactNode} from 'react';
+import {type ReactNode} from 'react';
 import {XDSSideNav} from './XDSSideNav';
 import {XDSSideNavHeading} from './XDSSideNavHeading';
 import {XDSSideNavItem} from './XDSSideNavItem';
@@ -21,14 +21,17 @@ import {XDSSideNavSection} from './XDSSideNavSection';
 import {XDSLinkProvider} from '../Link/XDSLinkProvider';
 import {XDSSideNavCollapseContext} from './XDSSideNavCollapseContext';
 
-const CustomLink = forwardRef<HTMLAnchorElement, ComponentPropsWithoutRef<'a'>>(
-  ({children, ...props}, ref) => (
+function CustomLink({
+  children,
+  ref,
+  ...props
+}: React.ComponentPropsWithRef<'a'>) {
+  return (
     <a ref={ref} data-custom-link {...props}>
       {children}
     </a>
-  ),
-);
-CustomLink.displayName = 'CustomLink';
+  );
+}
 
 // =============================================================================
 // XDSSideNav

--- a/packages/core/src/SideNav/XDSSideNavCollapseContext.ts
+++ b/packages/core/src/SideNav/XDSSideNavCollapseContext.ts
@@ -4,7 +4,7 @@
 
 /**
  * @file XDSSideNavCollapseContext.ts
- * @input React createContext, useContext
+ * @input React createContext, use
  * @output Exports XDSSideNavCollapseContext and useXDSSideNavCollapse hook
  * @position Internal context for sidenav collapse state
  *
@@ -12,7 +12,7 @@
  * sidenav children. Set by XDSSideNav when isCollapsible is true.
  */
 
-import {createContext, useContext} from 'react';
+import {createContext, use} from 'react';
 
 export interface XDSSideNavCollapseState {
   /** Whether the sidenav is currently collapsed */
@@ -28,12 +28,14 @@ export interface XDSSideNavCollapseState {
  */
 export type SideNavCollapseState = XDSSideNavCollapseState;
 
-export const XDSSideNavCollapseContext =
-  createContext<XDSSideNavCollapseState>({
+export const XDSSideNavCollapseContext = createContext<XDSSideNavCollapseState>(
+  {
     isCollapsed: false,
     toggle: () => {},
     isCollapsible: false,
-  });
+  },
+);
+XDSSideNavCollapseContext.displayName = 'XDSSideNavCollapseContext';
 
 /**
  * Read the sidenav collapse state from context.
@@ -41,5 +43,5 @@ export const XDSSideNavCollapseContext =
  * When used outside a sidenav with isCollapsible, isCollapsible is false.
  */
 export function useXDSSideNavCollapse(): XDSSideNavCollapseState {
-  return useContext(XDSSideNavCollapseContext);
+  return use(XDSSideNavCollapseContext);
 }

--- a/packages/core/src/SideNav/XDSSideNavHeading.tsx
+++ b/packages/core/src/SideNav/XDSSideNavHeading.tsx
@@ -499,9 +499,9 @@ export function XDSSideNavHeading({
                   )}
                 </span>
               </button>
-              <XDSNavHeadingCloseContext.Provider value={closeMenuCtx}>
+              <XDSNavHeadingCloseContext value={closeMenuCtx}>
                 {menu}
-              </XDSNavHeadingCloseContext.Provider>
+              </XDSNavHeadingCloseContext>
             </div>,
             {placement: 'below', alignment: 'start', xstyle: styles.popover},
           )}

--- a/packages/core/src/SideNav/XDSSideNavRenderContext.ts
+++ b/packages/core/src/SideNav/XDSSideNavRenderContext.ts
@@ -4,7 +4,7 @@
 
 /**
  * @file XDSSideNavRenderContext.ts
- * @input React createContext, useContext
+ * @input React createContext, use
  * @output Exports XDSSideNavRenderContext and useXDSSideNavRenderMode hook
  * @position Internal context for controlling SideNav rendering mode
  *
@@ -15,7 +15,7 @@
  * - 'drawer': children only, skip heading + footerIcons (mobile drawer)
  */
 
-import {createContext, useContext} from 'react';
+import {createContext, use} from 'react';
 
 export type XDSSideNavRenderMode =
   | 'default'
@@ -25,10 +25,11 @@ export type XDSSideNavRenderMode =
 
 export const XDSSideNavRenderContext =
   createContext<XDSSideNavRenderMode>('default');
+XDSSideNavRenderContext.displayName = 'XDSSideNavRenderContext';
 
 /**
  * Read the current SideNav render mode from context.
  */
 export function useXDSSideNavRenderMode(): XDSSideNavRenderMode {
-  return useContext(XDSSideNavRenderContext);
+  return use(XDSSideNavRenderContext);
 }

--- a/packages/core/src/SizeContext/XDSSizeContext.ts
+++ b/packages/core/src/SizeContext/XDSSizeContext.ts
@@ -4,7 +4,7 @@
 
 /**
  * @file XDSSizeContext.ts
- * @input React createContext, useContext
+ * @input React createContext, use
  * @output Exports XDSSizeContext, useXDSSize, XDSElementSize, XDSSizeProvider
  * @position Context provider; consumed by Button, TextInput, TabList, Selector, etc.
  *
@@ -13,7 +13,7 @@
  * fallback — an explicit `size` prop always wins.
  */
 
-import {createContext, useContext} from 'react';
+import {createContext, use} from 'react';
 
 /**
  * Standard element sizes used across interactive components.
@@ -26,6 +26,7 @@ export type XDSElementSize = 'sm' | 'md' | 'lg';
  * `null` means no container is providing a size — components use their own default.
  */
 export const XDSSizeContext = createContext<XDSElementSize | null>(null);
+XDSSizeContext.displayName = 'XDSSizeContext';
 
 /**
  * Resolve the effective size from an explicit prop, inherited context, or default.
@@ -44,7 +45,7 @@ export function useXDSSize<T extends string = XDSElementSize>(
   sizeProp?: T,
   defaultSize: T = 'md' as T,
 ): T {
-  const inherited = useContext(XDSSizeContext);
+  const inherited = use(XDSSizeContext);
   return sizeProp ?? (inherited as T | null) ?? defaultSize;
 }
 

--- a/packages/core/src/Stepper/XDSStepper.tsx
+++ b/packages/core/src/Stepper/XDSStepper.tsx
@@ -112,7 +112,7 @@ export function XDSStepper({
   );
 
   return (
-    <XDSStepperContext.Provider value={ctxValue}>
+    <XDSStepperContext value={ctxValue}>
       <nav ref={ref} aria-label={label} {...rest}>
         <ol
           {...mergeProps(
@@ -130,7 +130,7 @@ export function XDSStepper({
           {children}
         </ol>
       </nav>
-    </XDSStepperContext.Provider>
+    </XDSStepperContext>
   );
 }
 

--- a/packages/core/src/Stepper/XDSStepperContext.ts
+++ b/packages/core/src/Stepper/XDSStepperContext.ts
@@ -4,7 +4,7 @@
 
 /**
  * @file XDSStepperContext.ts
- * @input Uses React createContext/useContext
+ * @input Uses React createContext/use
  * @output Exports XDSStepperContext, useXDSStepperContext, and context types
  * @position Context for XDSStepper <-> XDSStep communication
  *
@@ -13,7 +13,7 @@
  * - /packages/core/src/Stepper/index.ts
  */
 
-import {createContext, useContext} from 'react';
+import {createContext, use} from 'react';
 
 export type XDSStepperOrientation = 'horizontal' | 'vertical';
 
@@ -27,9 +27,10 @@ export interface XDSStepperContextValue {
 export const XDSStepperContext = createContext<XDSStepperContextValue | null>(
   null,
 );
+XDSStepperContext.displayName = 'XDSStepperContext';
 
 export function useXDSStepperContext(): XDSStepperContextValue {
-  const ctx = useContext(XDSStepperContext);
+  const ctx = use(XDSStepperContext);
   if (ctx == null) {
     throw new Error(
       'useXDSStepperContext must be used within XDSStepper. ' +

--- a/packages/core/src/TabList/XDSTabList.test.tsx
+++ b/packages/core/src/TabList/XDSTabList.test.tsx
@@ -12,20 +12,22 @@
 import {describe, it, expect, vi, beforeAll, afterAll} from 'vitest';
 import {render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import {forwardRef, type ComponentPropsWithoutRef} from 'react';
 import {XDSTabList} from './XDSTabList';
 import {XDSTab} from './XDSTab';
 import {XDSTabMenu} from './XDSTabMenu';
 import {XDSLinkProvider} from '../Link/XDSLinkProvider';
 
-const CustomLink = forwardRef<HTMLAnchorElement, ComponentPropsWithoutRef<'a'>>(
-  ({children, ...props}, ref) => (
+function CustomLink({
+  children,
+  ref,
+  ...props
+}: React.ComponentPropsWithRef<'a'>) {
+  return (
     <a ref={ref} data-custom-link {...props}>
       {children}
     </a>
-  ),
-);
-CustomLink.displayName = 'CustomLink';
+  );
+}
 
 // Store original matches to restore later
 const originalMatches = HTMLElement.prototype.matches;

--- a/packages/core/src/TabList/XDSTabList.tsx
+++ b/packages/core/src/TabList/XDSTabList.tsx
@@ -115,7 +115,7 @@ export function XDSTabList({
   );
 
   return (
-    <XDSTabListContext.Provider value={contextValue}>
+    <XDSTabListContext value={contextValue}>
       <nav
         aria-label="Tabs"
         {...{[EDGE_COMP_ATTR]: ''}}
@@ -133,7 +133,7 @@ export function XDSTabList({
         )}>
         {children}
       </nav>
-    </XDSTabListContext.Provider>
+    </XDSTabListContext>
   );
 }
 

--- a/packages/core/src/TabList/XDSTabListContext.ts
+++ b/packages/core/src/TabList/XDSTabListContext.ts
@@ -4,14 +4,14 @@
 
 /**
  * @file XDSTabListContext.ts
- * @input React createContext, useContext
+ * @input React createContext, use
  * @output Exports XDSTabListContext, useXDSTabListContext
  * @position Context provider; consumed by XDSTab.tsx, XDSTabMenu.tsx
  *
  * SYNC: When modified, update /packages/core/src/TabList/TabList.doc.mjs
  */
 
-import {createContext, useContext} from 'react';
+import {createContext, use} from 'react';
 
 /**
  * Size variants for tab list items.
@@ -39,12 +39,13 @@ export interface XDSTabListContextValue {
 export const XDSTabListContext = createContext<XDSTabListContextValue | null>(
   null,
 );
+XDSTabListContext.displayName = 'XDSTabListContext';
 
 /**
  * Returns XDSTabListContext value or throws if used outside XDSTabList.
  */
 export function useXDSTabListContext(): XDSTabListContextValue {
-  const ctx = useContext(XDSTabListContext);
+  const ctx = use(XDSTabListContext);
   if (ctx == null) {
     throw new Error(
       'useXDSTabListContext must be used within XDSTabList. ' +

--- a/packages/core/src/Table/XDSTable.tsx
+++ b/packages/core/src/Table/XDSTable.tsx
@@ -28,7 +28,6 @@ import type {
   XDSTableVerticalAlign,
   TablePlugin,
   TableRenderProps,
-
 } from './types';
 
 // =============================================================================
@@ -171,8 +170,6 @@ function buildTableStylePlugin<
   };
 }
 
-
-
 // =============================================================================
 // XDSTable Component
 // =============================================================================
@@ -210,7 +207,7 @@ function XDSTableInner<T extends Record<string, unknown>>({
   );
 
   return (
-    <XDSTableContext.Provider value={contextValue}>
+    <XDSTableContext value={contextValue}>
       <XDSBaseTable<T>
         ref={ref}
         data={data}
@@ -220,7 +217,7 @@ function XDSTableInner<T extends Record<string, unknown>>({
         scrollWrapper={TableScrollWrapper}
         {...rest}
       />
-    </XDSTableContext.Provider>
+    </XDSTableContext>
   );
 }
 

--- a/packages/core/src/Table/XDSTableContext.ts
+++ b/packages/core/src/Table/XDSTableContext.ts
@@ -28,3 +28,4 @@ export interface XDSTableContextValue {
 }
 
 export const XDSTableContext = createContext<XDSTableContextValue | null>(null);
+XDSTableContext.displayName = 'XDSTableContext';

--- a/packages/core/src/Table/XDSTableRow.tsx
+++ b/packages/core/src/Table/XDSTableRow.tsx
@@ -14,7 +14,7 @@
  * - /packages/cli/templates/blocks/components/Table/ (showcase blocks)
  */
 
-import {useContext, type ReactNode} from 'react';
+import {use, type ReactNode} from 'react';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars, durationVars, easeVars} from '../theme/tokens.stylex';
@@ -95,7 +95,7 @@ export function XDSTableRow({
   ref,
   ...props
 }: XDSTableRowProps) {
-  const ctx = useContext(XDSTableContext);
+  const ctx = use(XDSTableContext);
 
   if (!ctx) {
     return (

--- a/packages/core/src/Table/plugins/filtering/useXDSTableFiltering.tsx
+++ b/packages/core/src/Table/plugins/filtering/useXDSTableFiltering.tsx
@@ -15,7 +15,7 @@
 
 import {
   createContext,
-  useContext,
+  use,
   useRef,
   useMemo,
   useState,
@@ -312,10 +312,12 @@ interface FilterStore {
 }
 
 const FilterStoreContext = createContext<FilterStore | null>(null);
+FilterStoreContext.displayName = 'FilterStoreContext';
 
 /** Variant is stable per plugin instance — kept in a separate context so
  *  slot components can read it without going through the mutable store. */
 const FilterVariantContext = createContext<XDSTableFilterVariant>('popover');
+FilterVariantContext.displayName = 'FilterVariantContext';
 
 // =============================================================================
 // Styles
@@ -394,7 +396,7 @@ function TextFilterControl({
   size: 'sm' | 'md';
   hasClear?: boolean;
 }) {
-  const store = useContext(FilterStoreContext)!;
+  const store = use(FilterStoreContext)!;
   const config = store.getConfig();
   const value = config.filters[columnKey];
   const strValue = typeof value === 'string' ? value : '';
@@ -429,7 +431,7 @@ function NumberFilterControl({
   size: 'sm' | 'md';
   hasClear?: boolean;
 }) {
-  const store = useContext(FilterStoreContext)!;
+  const store = use(FilterStoreContext)!;
   const config = store.getConfig();
   const value = config.filters[columnKey];
   const numValue = typeof value === 'number' ? value : null;
@@ -488,7 +490,7 @@ function SelectorFilterControl({
   size: 'sm' | 'md';
   hasClear?: boolean;
 }) {
-  const store = useContext(FilterStoreContext)!;
+  const store = use(FilterStoreContext)!;
   const config = store.getConfig();
   const value = config.filters[columnKey];
   const strValue = typeof value === 'string' ? value : '';
@@ -551,7 +553,7 @@ function MultiSelectorFilterControl({
   size: 'sm' | 'md';
   hasClear?: boolean;
 }) {
-  const store = useContext(FilterStoreContext)!;
+  const store = use(FilterStoreContext)!;
   const config = store.getConfig();
   const value = config.filters[columnKey];
   const arrValue = Array.isArray(value) ? value : [];
@@ -592,7 +594,7 @@ function DateFilterControl({
   size: 'sm' | 'md';
   hasClear?: boolean;
 }) {
-  const store = useContext(FilterStoreContext)!;
+  const store = use(FilterStoreContext)!;
   const value = store.getConfig().filters[columnKey] as string | undefined;
 
   return (
@@ -620,7 +622,7 @@ function TimeFilterControl({
   size: 'sm' | 'md';
   hasClear?: boolean;
 }) {
-  const store = useContext(FilterStoreContext)!;
+  const store = use(FilterStoreContext)!;
   const value = store.getConfig().filters[columnKey] as string | undefined;
 
   return (
@@ -650,7 +652,7 @@ function StringListFilterControl({
   size: 'sm' | 'md';
   hasClear?: boolean;
 }) {
-  const store = useContext(FilterStoreContext)!;
+  const store = use(FilterStoreContext)!;
   const value =
     (store.getConfig().filters[columnKey] as string[] | undefined) ?? [];
 
@@ -787,7 +789,7 @@ function PopoverFilterTrigger({
   header: string;
   operatorValue: OperatorValue;
 }) {
-  const store = useContext(FilterStoreContext)!;
+  const store = use(FilterStoreContext)!;
   const config = store.getConfig();
   const value = config.filters[columnKey];
   const hasValue = value != null;
@@ -846,7 +848,7 @@ function PopoverFilterTrigger({
       placement="below"
       alignment="start"
       content={
-        <FilterStoreContext.Provider value={draftStore}>
+        <FilterStoreContext value={draftStore}>
           <div {...stylex.props(filterStyles.popoverContent)}>
             <FilterControl
               columnKey={columnKey}
@@ -870,7 +872,7 @@ function PopoverFilterTrigger({
               />
             </div>
           </div>
-        </FilterStoreContext.Provider>
+        </FilterStoreContext>
       }>
       <button
         type="button"
@@ -948,7 +950,7 @@ function InlineFilterSlot({
   header: string;
   operatorValue: OperatorValue | undefined;
 }) {
-  const variant = useContext(FilterVariantContext);
+  const variant = use(FilterVariantContext);
   const size = 'sm';
   const placeholderStyle =
     variant === 'inline-compact'
@@ -1043,11 +1045,11 @@ export function useXDSTableFiltering<T extends Record<string, unknown>>(
 
       transformTableContext(children: ReactNode) {
         return (
-          <FilterStoreContext.Provider value={store}>
-            <FilterVariantContext.Provider value={variant}>
+          <FilterStoreContext value={store}>
+            <FilterVariantContext value={variant}>
               {children}
-            </FilterVariantContext.Provider>
-          </FilterStoreContext.Provider>
+            </FilterVariantContext>
+          </FilterStoreContext>
         );
       },
 

--- a/packages/core/src/Table/plugins/selection/useXDSTableSelection.tsx
+++ b/packages/core/src/Table/plugins/selection/useXDSTableSelection.tsx
@@ -33,7 +33,7 @@
 
 import {
   createContext,
-  useContext,
+  use,
   useCallback,
   useEffect,
   useRef,
@@ -151,6 +151,7 @@ function mergeRefs<T>(...refs: (Ref<T> | undefined)[]): React.RefCallback<T> {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const SelectionStoreContext = createContext<SelectionStore<any> | null>(null);
+SelectionStoreContext.displayName = 'SelectionStoreContext';
 
 // =============================================================================
 // Hooks for subscribing to selection state
@@ -173,7 +174,7 @@ function useIsItemSelected<T extends Record<string, unknown>>(
 // =============================================================================
 
 function SelectAllCheckbox() {
-  const store = useContext(SelectionStoreContext);
+  const store = use(SelectionStoreContext);
   if (!store) return null;
 
   return <SelectAllCheckboxInner store={store} />;
@@ -232,7 +233,7 @@ function SelectionCellContent<T extends Record<string, unknown>>({
 }: {
   item: T;
 }) {
-  const store = useContext(SelectionStoreContext);
+  const store = use(SelectionStoreContext);
   if (!store) return null;
 
   return <SelectionCellContentInner store={store} item={item} />;
@@ -334,9 +335,9 @@ export function useXDSTableSelection<T extends Record<string, unknown>>(
     (): TablePlugin<T> => ({
       transformTableContext(children: ReactNode) {
         return (
-          <SelectionStoreContext.Provider value={store}>
+          <SelectionStoreContext value={store}>
             {children}
-          </SelectionStoreContext.Provider>
+          </SelectionStoreContext>
         );
       },
 

--- a/packages/core/src/Table/useTableCellStyles.ts
+++ b/packages/core/src/Table/useTableCellStyles.ts
@@ -17,7 +17,7 @@
  * - /packages/core/src/Table/XDSTableHeaderCell.tsx
  */
 
-import {useContext} from 'react';
+import {use} from 'react';
 import type {StyleXStyles} from '../theme/types';
 import {XDSTableContext, type XDSTableContextValue} from './XDSTableContext';
 
@@ -68,5 +68,5 @@ export function mergeXStyle(
  * signaling that the component should render unstyled.
  */
 export function useTableContext(): XDSTableContextValue | null {
-  return useContext(XDSTableContext);
+  return use(XDSTableContext);
 }

--- a/packages/core/src/Toast/XDSToastContext.ts
+++ b/packages/core/src/Toast/XDSToastContext.ts
@@ -20,3 +20,4 @@ export interface XDSToastContextValue {
  * falls back to a self-mounting viewport when no provider exists.
  */
 export const XDSToastContext = createContext<XDSToastContextValue | null>(null);
+XDSToastContext.displayName = 'XDSToastContext';

--- a/packages/core/src/Toast/XDSToastViewport.tsx
+++ b/packages/core/src/Toast/XDSToastViewport.tsx
@@ -184,7 +184,7 @@ export function XDSToastViewport({
           : styles.bottomEnd;
 
   return (
-    <XDSToastContext.Provider value={contextValue}>
+    <XDSToastContext value={contextValue}>
       {children}
       <div
         ref={viewportRef}
@@ -233,7 +233,7 @@ export function XDSToastViewport({
           );
         })}
       </div>
-    </XDSToastContext.Provider>
+    </XDSToastContext>
   );
 }
 XDSToastViewport.displayName = 'XDSToastViewport';

--- a/packages/core/src/Toast/useXDSToast.tsx
+++ b/packages/core/src/Toast/useXDSToast.tsx
@@ -2,7 +2,7 @@
 
 'use client';
 
-import {useCallback, useContext, useEffect, useRef} from 'react';
+import {useCallback, use, useEffect, useRef} from 'react';
 import {createRoot} from 'react-dom/client';
 import {XDSToastContext, type XDSToastContextValue} from './XDSToastContext';
 import {XDSToastViewport} from './XDSToastViewport';
@@ -46,7 +46,7 @@ function getFallbackContext(): XDSToastContextValue {
   });
 
   const FallbackCapture = () => {
-    const ctx = useContext(XDSToastContext);
+    const ctx = use(XDSToastContext);
     const doneRef = useRef(false);
     useEffect(() => {
       if (ctx && !doneRef.current) {
@@ -124,7 +124,7 @@ function generateToastId(): string {
  * ```
  */
 export function useXDSToast(): XDSShowToastFn {
-  const contextFromProvider = useContext(XDSToastContext);
+  const contextFromProvider = use(XDSToastContext);
 
   const showToast = useCallback(
     (options: XDSToastOptions): XDSToastDismissFn => {

--- a/packages/core/src/ToggleButton/XDSToggleButtonGroup.tsx
+++ b/packages/core/src/ToggleButton/XDSToggleButtonGroup.tsx
@@ -18,13 +18,7 @@
  * - /packages/cli/templates/blocks/components/ToggleButton/ (showcase blocks)
  */
 
-import {
-  createContext,
-  useCallback,
-  useContext,
-  useMemo,
-  type ReactNode,
-} from 'react';
+import {createContext, useCallback, use, useMemo, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {spacingVars} from '../theme/tokens.stylex';
 import type {XDSButtonSize} from '../Button';
@@ -48,13 +42,14 @@ interface XDSToggleButtonGroupContextValue {
 
 export const XDSToggleButtonGroupContext =
   createContext<XDSToggleButtonGroupContextValue | null>(null);
+XDSToggleButtonGroupContext.displayName = 'XDSToggleButtonGroupContext';
 
 /**
  * Hook for XDSToggleButton to read group context.
  * Returns null when used outside a group.
  */
 export function useXDSToggleButtonGroup(): XDSToggleButtonGroupContextValue | null {
-  return useContext(XDSToggleButtonGroupContext);
+  return use(XDSToggleButtonGroupContext);
 }
 
 // =============================================================================
@@ -229,7 +224,7 @@ export function XDSToggleButtonGroup(
   );
 
   return (
-    <XDSToggleButtonGroupContext.Provider value={contextValue}>
+    <XDSToggleButtonGroupContext value={contextValue}>
       <div
         role="group"
         aria-label={label}
@@ -244,7 +239,7 @@ export function XDSToggleButtonGroup(
         )}>
         {children}
       </div>
-    </XDSToggleButtonGroupContext.Provider>
+    </XDSToggleButtonGroupContext>
   );
 }
 

--- a/packages/core/src/Tokenizer/XDSTokenizer.tsx
+++ b/packages/core/src/Tokenizer/XDSTokenizer.tsx
@@ -470,9 +470,6 @@ export function XDSTokenizer<T extends XDSSearchableItem>({
     [value],
   );
 
-  // Track the current query for creatable mode
-  const [_creatableQuery, setCreatableQuery] = useState('');
-
   const filteredSource: XDSSearchSource<T> = useMemo(
     () => ({
       search: async (query: string) => {
@@ -685,14 +682,7 @@ export function XDSTokenizer<T extends XDSSearchableItem>({
         hasAutoFocus={hasAutoFocus}
         inputId={inputId}
         ariaDescribedBy={ariaDescribedBy}
-        onChangeQuery={
-          hasCreate
-            ? (q: string) => {
-                setCreatableQuery(q);
-                onChangeQuery?.(q);
-              }
-            : onChangeQuery
-        }
+        onChangeQuery={onChangeQuery}
         debounceMs={debounceMs}
         onKeyDown={handleKeyDown}
         anchorRef={wrapperRef}

--- a/packages/core/src/TopNav/TopNavContext.ts
+++ b/packages/core/src/TopNav/TopNavContext.ts
@@ -2,7 +2,7 @@
 
 'use client';
 
-import {createContext, useContext} from 'react';
+import {createContext, use} from 'react';
 
 export type XDSTopNavSlot = 'start' | 'center' | 'end';
 
@@ -12,6 +12,7 @@ export type XDSTopNavSlot = 'start' | 'center' | 'end';
 export type TopNavSlot = XDSTopNavSlot;
 
 export const XDSTopNavSlotContext = createContext<XDSTopNavSlot>('start');
+XDSTopNavSlotContext.displayName = 'XDSTopNavSlotContext';
 
 /**
  * @deprecated Use XDSTopNavSlotContext instead.
@@ -19,5 +20,5 @@ export const XDSTopNavSlotContext = createContext<XDSTopNavSlot>('start');
 export const TopNavSlotContext = XDSTopNavSlotContext;
 
 export function useTopNavSlot(): XDSTopNavSlot {
-  return useContext(XDSTopNavSlotContext);
+  return use(XDSTopNavSlotContext);
 }

--- a/packages/core/src/TopNav/XDSTopNav.test.tsx
+++ b/packages/core/src/TopNav/XDSTopNav.test.tsx
@@ -12,21 +12,23 @@
 import {describe, it, expect, vi} from 'vitest';
 import {render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import {forwardRef, type ComponentPropsWithoutRef} from 'react';
 import {XDSTopNav} from './XDSTopNav';
 import {XDSTopNavHeading} from './XDSTopNavHeading';
 import {XDSNavIcon} from '../NavIcon';
 import {XDSTopNavItem} from './XDSTopNavItem';
 import {XDSLinkProvider} from '../Link/XDSLinkProvider';
 
-const CustomLink = forwardRef<HTMLAnchorElement, ComponentPropsWithoutRef<'a'>>(
-  ({children, ...props}, ref) => (
+function CustomLink({
+  children,
+  ref,
+  ...props
+}: React.ComponentPropsWithRef<'a'>) {
+  return (
     <a ref={ref} data-custom-link {...props}>
       {children}
     </a>
-  ),
-);
-CustomLink.displayName = 'CustomLink';
+  );
+}
 
 describe('XDSTopNav', () => {
   it('renders with navigation role', () => {
@@ -303,16 +305,17 @@ describe('XDSTopNavItem', () => {
   });
 
   it('as prop overrides XDSLinkProvider', () => {
-    const AnotherLink = forwardRef<
-      HTMLAnchorElement,
-      ComponentPropsWithoutRef<'a'>
-    >(function AnotherLink({children, ...props}, ref) {
+    function AnotherLink({
+      children,
+      ref,
+      ...props
+    }: React.ComponentPropsWithRef<'a'>) {
       return (
         <a ref={ref} data-another-link {...props}>
           {children}
         </a>
       );
-    });
+    }
     render(
       <XDSLinkProvider component={AnotherLink}>
         <XDSTopNavItem label="Home" href="/" as={CustomLink} />

--- a/packages/core/src/TopNav/XDSTopNavHeading.tsx
+++ b/packages/core/src/TopNav/XDSTopNavHeading.tsx
@@ -524,9 +524,9 @@ export function XDSTopNavHeading({
             {...stylex.props(styles.popoverContent)}
             {...contentProps}>
             {popoverHeadingContent}
-            <XDSNavHeadingCloseContext.Provider value={closeMenuCtx}>
+            <XDSNavHeadingCloseContext value={closeMenuCtx}>
               {menu}
-            </XDSNavHeadingCloseContext.Provider>
+            </XDSNavHeadingCloseContext>
           </div>,
           {
             placement: 'below',
@@ -587,9 +587,9 @@ export function XDSTopNavHeading({
             {...stylex.props(styles.popoverContent)}
             {...contentProps}>
             {popoverHeadingContent}
-            <XDSNavHeadingCloseContext.Provider value={closeMenuCtx}>
+            <XDSNavHeadingCloseContext value={closeMenuCtx}>
               {menu}
-            </XDSNavHeadingCloseContext.Provider>
+            </XDSNavHeadingCloseContext>
           </div>,
           {
             placement: 'below',

--- a/packages/core/src/TopNav/XDSTopNavMegaMenu.test.tsx
+++ b/packages/core/src/TopNav/XDSTopNavMegaMenu.test.tsx
@@ -82,12 +82,12 @@ describe('XDSTopNavMegaMenu — default mode', () => {
 describe('XDSTopNavMegaMenu — mobile-bar mode', () => {
   it('returns null in mobile-bar mode', () => {
     const {container} = render(
-      <XDSTopNavRenderContext.Provider value="mobile-bar">
+      <XDSTopNavRenderContext value="mobile-bar">
         <XDSTopNavMegaMenu
           label="Products"
           items={<XDSTopNavMegaMenuItem title="Analytics" href="/analytics" />}
         />
-      </XDSTopNavRenderContext.Provider>,
+      </XDSTopNavRenderContext>,
     );
     expect(container.innerHTML).toBe('');
   });
@@ -100,12 +100,12 @@ describe('XDSTopNavMegaMenu — mobile-bar mode', () => {
 describe('XDSTopNavMegaMenu — drawer mode', () => {
   it('renders a collapsible trigger with label', () => {
     render(
-      <XDSTopNavRenderContext.Provider value="drawer">
+      <XDSTopNavRenderContext value="drawer">
         <XDSTopNavMegaMenu
           label="Products"
           items={<XDSTopNavMegaMenuItem title="Analytics" href="/analytics" />}
         />
-      </XDSTopNavRenderContext.Provider>,
+      </XDSTopNavRenderContext>,
     );
     const trigger = screen.getByRole('button', {name: 'Products'});
     expect(trigger).toBeInTheDocument();
@@ -116,7 +116,7 @@ describe('XDSTopNavMegaMenu — drawer mode', () => {
     const user = userEvent.setup();
 
     render(
-      <XDSTopNavRenderContext.Provider value="drawer">
+      <XDSTopNavRenderContext value="drawer">
         <XDSTopNavMegaMenu
           label="Products"
           items={
@@ -126,7 +126,7 @@ describe('XDSTopNavMegaMenu — drawer mode', () => {
             </>
           }
         />
-      </XDSTopNavRenderContext.Provider>,
+      </XDSTopNavRenderContext>,
     );
 
     const trigger = screen.getByRole('button', {name: 'Products'});
@@ -143,12 +143,12 @@ describe('XDSTopNavMegaMenu — drawer mode', () => {
     const user = userEvent.setup();
 
     render(
-      <XDSTopNavRenderContext.Provider value="drawer">
+      <XDSTopNavRenderContext value="drawer">
         <XDSTopNavMegaMenu
           label="Products"
           items={<XDSTopNavMegaMenuItem title="Analytics" href="/analytics" />}
         />
-      </XDSTopNavRenderContext.Provider>,
+      </XDSTopNavRenderContext>,
     );
 
     const trigger = screen.getByRole('button', {name: 'Products'});
@@ -162,7 +162,7 @@ describe('XDSTopNavMegaMenu — drawer mode', () => {
     const user = userEvent.setup();
 
     render(
-      <XDSTopNavRenderContext.Provider value="drawer">
+      <XDSTopNavRenderContext value="drawer">
         <XDSTopNavMegaMenu
           label="Products"
           items={
@@ -173,7 +173,7 @@ describe('XDSTopNavMegaMenu — drawer mode', () => {
             />
           }
         />
-      </XDSTopNavRenderContext.Provider>,
+      </XDSTopNavRenderContext>,
     );
 
     await user.click(screen.getByRole('button', {name: 'Products'}));
@@ -186,12 +186,12 @@ describe('XDSTopNavMegaMenu — drawer mode', () => {
     const user = userEvent.setup();
 
     render(
-      <XDSTopNavRenderContext.Provider value="drawer">
+      <XDSTopNavRenderContext value="drawer">
         <XDSTopNavMegaMenu
           label="Products"
           items={<XDSTopNavMegaMenuItem title="Analytics" href="/analytics" />}
         />
-      </XDSTopNavRenderContext.Provider>,
+      </XDSTopNavRenderContext>,
     );
 
     await user.click(screen.getByRole('button', {name: 'Products'}));
@@ -205,12 +205,12 @@ describe('XDSTopNavMegaMenu — drawer mode', () => {
     const handleClick = vi.fn();
 
     render(
-      <XDSTopNavRenderContext.Provider value="drawer">
+      <XDSTopNavRenderContext value="drawer">
         <XDSTopNavMegaMenu
           label="Tools"
           items={<XDSTopNavMegaMenuItem title="Export" onClick={handleClick} />}
         />
-      </XDSTopNavRenderContext.Provider>,
+      </XDSTopNavRenderContext>,
     );
 
     await user.click(screen.getByRole('button', {name: 'Tools'}));
@@ -223,13 +223,13 @@ describe('XDSTopNavMegaMenu — drawer mode', () => {
     const user = userEvent.setup();
 
     render(
-      <XDSTopNavRenderContext.Provider value="drawer">
+      <XDSTopNavRenderContext value="drawer">
         <XDSTopNavMegaMenu
           label="Products"
           items={<XDSTopNavMegaMenuItem title="Analytics" href="/analytics" />}
           featured={<span>Featured: New AI Tools</span>}
         />
-      </XDSTopNavRenderContext.Provider>,
+      </XDSTopNavRenderContext>,
     );
 
     await user.click(screen.getByRole('button', {name: 'Products'}));
@@ -262,9 +262,9 @@ describe('XDSTopNavMegaMenuItem', () => {
 
   it('renders as a drawer item in drawer context', () => {
     render(
-      <XDSTopNavRenderContext.Provider value="drawer">
+      <XDSTopNavRenderContext value="drawer">
         <XDSTopNavMegaMenuItem title="Analytics" href="/analytics" />
-      </XDSTopNavRenderContext.Provider>,
+      </XDSTopNavRenderContext>,
     );
     expect(screen.getByRole('link', {name: /Analytics/})).toBeInTheDocument();
   });

--- a/packages/core/src/TopNav/XDSTopNavMobileContentContext.ts
+++ b/packages/core/src/TopNav/XDSTopNavMobileContentContext.ts
@@ -4,7 +4,7 @@
 
 /**
  * @file XDSTopNavMobileContentContext.ts
- * @input React createContext, useContext
+ * @input React createContext, use
  * @output Exports XDSTopNavMobileContentContext and useXDSTopNavMobileContent
  * @position Internal context for passing additional drawer content to TopNav
  *
@@ -13,14 +13,15 @@
  * mobile drawer, producing a single combined drawer.
  */
 
-import {createContext, useContext, type ReactNode} from 'react';
+import {createContext, use, type ReactNode} from 'react';
 
 export const XDSTopNavMobileContentContext = createContext<ReactNode>(null);
+XDSTopNavMobileContentContext.displayName = 'XDSTopNavMobileContentContext';
 
 /**
  * Read additional mobile drawer content provided by AppShell.
  * Returns null when no additional content is available.
  */
 export function useXDSTopNavMobileContent(): ReactNode {
-  return useContext(XDSTopNavMobileContentContext);
+  return use(XDSTopNavMobileContentContext);
 }

--- a/packages/core/src/TopNav/XDSTopNavRenderContext.ts
+++ b/packages/core/src/TopNav/XDSTopNavRenderContext.ts
@@ -4,7 +4,7 @@
 
 /**
  * @file XDSTopNavRenderContext.ts
- * @input React createContext, useContext
+ * @input React createContext, use
  * @output Exports XDSTopNavRenderContext and useXDSTopNavRenderMode hook
  * @position Internal context for controlling TopNav rendering mode
  *
@@ -15,16 +15,17 @@
  * - 'drawer': nav items as vertical list elements (mobile drawer)
  */
 
-import {createContext, useContext} from 'react';
+import {createContext, use} from 'react';
 
 export type XDSTopNavRenderMode = 'default' | 'mobile-bar' | 'drawer';
 
 export const XDSTopNavRenderContext =
   createContext<XDSTopNavRenderMode>('default');
+XDSTopNavRenderContext.displayName = 'XDSTopNavRenderContext';
 
 /**
  * Read the current TopNav render mode from context.
  */
 export function useXDSTopNavRenderMode(): XDSTopNavRenderMode {
-  return useContext(XDSTopNavRenderContext);
+  return use(XDSTopNavRenderContext);
 }

--- a/packages/core/src/theme/XDSTheme.tsx
+++ b/packages/core/src/theme/XDSTheme.tsx
@@ -34,7 +34,7 @@
  * ```
  */
 
-import React, {useContext, useId, useInsertionEffect, useMemo} from 'react';
+import React, {use, useId, useInsertionEffect, useMemo} from 'react';
 import {useIsomorphicLayoutEffect} from '../hooks/useIsomorphicLayoutEffect';
 import * as stylex from '@stylexjs/stylex';
 import type {ThemeMode} from './types';
@@ -85,6 +85,7 @@ const wrapperStyles = stylex.create({
  * @internal
  */
 const XDSThemeNestingContext = React.createContext(false);
+XDSThemeNestingContext.displayName = 'XDSThemeNestingContext';
 
 // =============================================================================
 // Style injection for unbuilt themes
@@ -228,7 +229,7 @@ export function XDSTheme({
   mode = 'system',
   children,
 }: XDSThemeProps): React.ReactElement {
-  const isNested = useContext(XDSThemeNestingContext);
+  const isNested = use(XDSThemeNestingContext);
 
   useThemeStyleInjection(theme);
   useRootThemeSync(isNested, mode, theme.name);
@@ -251,16 +252,16 @@ export function XDSTheme({
   const ctxValue = useMemo(() => ({theme, mode}), [theme, mode]);
 
   return (
-    <XDSThemeContext.Provider value={ctxValue}>
-      <XDSThemeNestingContext.Provider value={true}>
+    <XDSThemeContext value={ctxValue}>
+      <XDSThemeNestingContext value={true}>
         <div
           {...stylex.props(wrapperStyles.base, colorSchemeStyle)}
           data-xds-theme={theme.name}
           data-theme={mode === 'system' ? undefined : mode}>
           {children}
         </div>
-      </XDSThemeNestingContext.Provider>
-    </XDSThemeContext.Provider>
+      </XDSThemeNestingContext>
+    </XDSThemeContext>
   );
 }
 

--- a/packages/core/src/theme/syntax/XDSSyntaxTheme.tsx
+++ b/packages/core/src/theme/syntax/XDSSyntaxTheme.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-"use client";
+'use client';
 
 /**
  * @file XDSSyntaxTheme.tsx
@@ -11,7 +11,7 @@
  * @see https://github.com/facebookexperimental/xds/issues/1148
  */
 
-import React, {createContext, useContext, useMemo} from 'react';
+import React, {createContext, use, useMemo} from 'react';
 import {
   syntaxThemeStyle,
   resolveSyntaxTokenForMode,
@@ -31,6 +31,7 @@ interface SyntaxThemeContextValue {
 }
 
 const SyntaxThemeContext = createContext<SyntaxThemeContextValue | null>(null);
+SyntaxThemeContext.displayName = 'SyntaxThemeContext';
 
 // =============================================================================
 // Return type
@@ -70,7 +71,7 @@ export interface UseXDSSyntaxThemeReturn {
  * }
  */
 export function useXDSSyntaxTheme(): UseXDSSyntaxThemeReturn | null {
-  const ctx = useContext(SyntaxThemeContext);
+  const ctx = use(SyntaxThemeContext);
   const prefersDark = useMediaQuery('(prefers-color-scheme: dark)');
   const effectiveMode: 'light' | 'dark' = prefersDark ? 'dark' : 'light';
 
@@ -117,11 +118,11 @@ export function XDSSyntaxTheme({
   const value = useMemo(() => ({theme}), [theme]);
 
   return (
-    <SyntaxThemeContext.Provider value={value}>
+    <SyntaxThemeContext value={value}>
       <div style={style} data-xds-syntax-theme={theme.name}>
         {children}
       </div>
-    </SyntaxThemeContext.Provider>
+    </SyntaxThemeContext>
   );
 }
 

--- a/packages/core/src/theme/useXDSTheme.ts
+++ b/packages/core/src/theme/useXDSTheme.ts
@@ -15,7 +15,7 @@
  * - /packages/core/src/theme/index.ts
  */
 
-import {createContext, useContext, useMemo} from 'react';
+import {createContext, use, useMemo} from 'react';
 import type {ThemeMode} from './types';
 import type {XDSDefinedTheme, XDSTokenValue} from './defineTheme';
 import {xdsTokenDefaults} from './defineTheme';
@@ -42,6 +42,7 @@ export interface XDSThemeContextValue {
  * @internal
  */
 export const XDSThemeContext = createContext<XDSThemeContextValue | null>(null);
+XDSThemeContext.displayName = 'XDSThemeContext';
 
 // =============================================================================
 // Return type
@@ -168,7 +169,7 @@ function buildDefaultTokens(mode: 'light' | 'dark'): Record<string, string> {
  * ```
  */
 export function useXDSTheme(): UseXDSThemeReturn {
-  const ctx = useContext(XDSThemeContext);
+  const ctx = use(XDSThemeContext);
 
   // Resolve 'system' to 'light' | 'dark' using the OS preference
   const prefersDark = useMediaQuery('(prefers-color-scheme: dark)');


### PR DESCRIPTION
## Summary

Enable three `@eslint-react` rules for React 19 context modernization. 162 violations fixed across 90 files.

### no-context-provider (62 violations → 0)
Replace `<Context.Provider value={...}>` with `<Context value={...}>` across the codebase. In React 19, the Context object itself is a valid provider — `.Provider` is no longer needed.

### no-use-context (57 violations → 0)
Replace `useContext(ctx)` with `use(ctx)` across the codebase. React 19's `use()` is the preferred API — it works in loops, conditionals, and after early returns.

### no-missing-context-display-name (43 violations → 0)
Add `displayName` to all 43 `createContext` calls for better React DevTools debugging.

## Test plan
- [x] `npx eslint --no-cache 'packages/core/src/**/*.{ts,tsx}'` passes clean
- [x] Pre-commit hooks pass (lint-staged, check:sync, check:package-boundaries)