### PR TITLE
feat(core): add XDSCircularProgress component

### DIFF
--- a/apps/storybook/stories/CircularProgress.stories.tsx
+++ b/apps/storybook/stories/CircularProgress.stories.tsx
@@ -1,0 +1,145 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import type {Meta, StoryObj} from '@storybook/react';
+import {XDSCircularProgress} from '@xds/core/CircularProgress';
+import {XDSText} from '@xds/core/Text';
+
+const meta: Meta<typeof XDSCircularProgress> = {
+  title: 'Core/CircularProgress',
+  component: XDSCircularProgress,
+  tags: ['autodocs'],
+  argTypes: {
+    value: {
+      control: {type: 'range', min: 0, max: 100, step: 1},
+      description: 'Current value',
+    },
+    max: {
+      control: 'number',
+      description: 'Maximum value',
+    },
+    label: {
+      control: 'text',
+      description: 'Accessible label',
+    },
+    size: {
+      control: 'select',
+      options: ['sm', 'md', 'lg'],
+      description: 'Ring diameter',
+    },
+    variant: {
+      control: 'select',
+      options: ['accent', 'success', 'warning', 'error', 'neutral'],
+      description: 'Semantic color variant',
+    },
+    isIndeterminate: {
+      control: 'boolean',
+      description: 'Spinning animation',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof XDSCircularProgress>;
+
+export const Default: Story = {
+  args: {
+    value: 60,
+    label: 'Progress',
+  },
+};
+
+export const WithCenterLabel: Story = {
+  args: {
+    value: 75,
+    label: 'Upload progress',
+    size: 'lg',
+    children: '75%',
+  },
+};
+
+export const Sizes: Story = {
+  render: () => (
+    <div style={{display: 'flex', gap: '24px', alignItems: 'center'}}>
+      <XDSCircularProgress value={60} size="sm" label="Small" />
+      <XDSCircularProgress value={60} size="md" label="Medium" />
+      <XDSCircularProgress value={60} size="lg" label="Large" />
+    </div>
+  ),
+};
+
+export const SizesWithLabels: Story = {
+  render: () => (
+    <div style={{display: 'flex', gap: '24px', alignItems: 'center'}}>
+      <XDSCircularProgress value={60} size="sm" label="Small">
+        <XDSText type="supporting" style={{fontSize: 8}}>
+          60%
+        </XDSText>
+      </XDSCircularProgress>
+      <XDSCircularProgress value={60} size="md" label="Medium">
+        <XDSText type="supporting" style={{fontSize: 11}}>
+          60%
+        </XDSText>
+      </XDSCircularProgress>
+      <XDSCircularProgress value={60} size="lg" label="Large">
+        <XDSText type="body">60%</XDSText>
+      </XDSCircularProgress>
+    </div>
+  ),
+};
+
+export const Variants: Story = {
+  render: () => (
+    <div style={{display: 'flex', gap: '24px', alignItems: 'center'}}>
+      <XDSCircularProgress value={60} label="Accent" variant="accent" />
+      <XDSCircularProgress value={80} label="Positive" variant="success" />
+      <XDSCircularProgress value={50} label="Warning" variant="warning" />
+      <XDSCircularProgress value={92} label="Negative" variant="error" />
+      <XDSCircularProgress value={35} label="Neutral" variant="neutral" />
+    </div>
+  ),
+};
+
+export const Empty: Story = {
+  args: {
+    value: 0,
+    label: 'Not started',
+  },
+};
+
+export const Full: Story = {
+  args: {
+    value: 100,
+    label: 'Complete',
+    variant: 'success',
+    size: 'lg',
+    children: '100%',
+  },
+};
+
+export const Indeterminate: Story = {
+  args: {
+    isIndeterminate: true,
+    label: 'Loading...',
+  },
+};
+
+export const IndeterminateSizes: Story = {
+  render: () => (
+    <div style={{display: 'flex', gap: '24px', alignItems: 'center'}}>
+      <XDSCircularProgress isIndeterminate size="sm" label="Loading small" />
+      <XDSCircularProgress isIndeterminate size="md" label="Loading medium" />
+      <XDSCircularProgress isIndeterminate size="lg" label="Loading large" />
+    </div>
+  ),
+};
+
+export const IndeterminateVariants: Story = {
+  render: () => (
+    <div style={{display: 'flex', gap: '24px', alignItems: 'center'}}>
+      <XDSCircularProgress isIndeterminate label="Accent" variant="accent" />
+      <XDSCircularProgress isIndeterminate label="Positive" variant="success" />
+      <XDSCircularProgress isIndeterminate label="Warning" variant="warning" />
+      <XDSCircularProgress isIndeterminate label="Negative" variant="error" />
+    </div>
+  ),
+};

--- a/apps/storybook/stories/CircularProgress.stories.tsx
+++ b/apps/storybook/stories/CircularProgress.stories.tsx
@@ -31,9 +31,9 @@ const meta: Meta<typeof XDSCircularProgress> = {
       options: ['accent', 'success', 'warning', 'error', 'neutral'],
       description: 'Semantic color variant',
     },
-    isIndeterminate: {
+    isLabelHidden: {
       control: 'boolean',
-      description: 'Spinning animation',
+      description: 'Visually hide the label',
     },
   },
 };
@@ -118,7 +118,6 @@ export const Full: Story = {
 
 export const Indeterminate: Story = {
   args: {
-    isIndeterminate: true,
     label: 'Loading...',
   },
 };
@@ -126,9 +125,9 @@ export const Indeterminate: Story = {
 export const IndeterminateSizes: Story = {
   render: () => (
     <div style={{display: 'flex', gap: '24px', alignItems: 'center'}}>
-      <XDSCircularProgress isIndeterminate size="sm" label="Loading small" />
-      <XDSCircularProgress isIndeterminate size="md" label="Loading medium" />
-      <XDSCircularProgress isIndeterminate size="lg" label="Loading large" />
+      <XDSCircularProgress size="sm" label="Loading small" />
+      <XDSCircularProgress size="md" label="Loading medium" />
+      <XDSCircularProgress size="lg" label="Loading large" />
     </div>
   ),
 };
@@ -136,10 +135,10 @@ export const IndeterminateSizes: Story = {
 export const IndeterminateVariants: Story = {
   render: () => (
     <div style={{display: 'flex', gap: '24px', alignItems: 'center'}}>
-      <XDSCircularProgress isIndeterminate label="Accent" variant="accent" />
-      <XDSCircularProgress isIndeterminate label="Positive" variant="success" />
-      <XDSCircularProgress isIndeterminate label="Warning" variant="warning" />
-      <XDSCircularProgress isIndeterminate label="Negative" variant="error" />
+      <XDSCircularProgress label="Accent" variant="accent" />
+      <XDSCircularProgress label="Positive" variant="success" />
+      <XDSCircularProgress label="Warning" variant="warning" />
+      <XDSCircularProgress label="Negative" variant="error" />
     </div>
   ),
 };

--- a/packages/cli/templates/blocks/components/CircularProgress/CircularProgressShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/CircularProgress/CircularProgressShowcase.doc.mjs
@@ -1,0 +1,14 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  exampleFor: 'CircularProgress',
+  name: 'CircularProgress',
+  isReady: true,
+  aspectRatio: 1,
+  isShowcase: true,
+  description:
+    'A circular progress ring filled to 75% with a center label.',
+  componentsUsed: ['CircularProgress'],
+};

--- a/packages/cli/templates/blocks/components/CircularProgress/CircularProgressShowcase.tsx
+++ b/packages/cli/templates/blocks/components/CircularProgress/CircularProgressShowcase.tsx
@@ -1,0 +1,13 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import {XDSCircularProgress} from '@xds/core/CircularProgress';
+
+export default function CircularProgressShowcase() {
+  return (
+    <XDSCircularProgress value={75} label="Progress" size="lg">
+      75%
+    </XDSCircularProgress>
+  );
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -175,6 +175,12 @@
       "import": "./dist/CheckboxList/index.mjs",
       "require": "./dist/CheckboxList/index.js"
     },
+    "./CircularProgress": {
+      "source": "./src/CircularProgress/index.ts",
+      "types": "./dist/CircularProgress/index.d.ts",
+      "import": "./dist/CircularProgress/index.mjs",
+      "require": "./dist/CircularProgress/index.js"
+    },
     "./Citation": {
       "source": "./src/Citation/index.ts",
       "types": "./dist/Citation/index.d.ts",

--- a/packages/core/src/CircularProgress/CircularProgress.doc.mjs
+++ b/packages/core/src/CircularProgress/CircularProgress.doc.mjs
@@ -9,8 +9,7 @@ export const docs = {
     {
       name: 'value',
       type: 'number',
-      description: 'Current value (ignored when indeterminate).',
-      default: '0',
+      description: 'Current value. When omitted, renders an indeterminate spinning animation.',
     },
     {
       name: 'max',
@@ -48,12 +47,6 @@ export const docs = {
       default: "'accent'",
     },
     {
-      name: 'isIndeterminate',
-      type: 'boolean',
-      description: 'Animated spinning indicator for unknown progress. Respects prefers-reduced-motion.',
-      default: 'false',
-    },
-    {
       name: 'xstyle',
       type: 'StyleXStyles',
       description:
@@ -71,7 +64,7 @@ export const docs = {
     description:
       'A circular progress indicator that shows completion as a ring or arc. Use it for upload progress, score displays, dashboard gauges, or compact progress where horizontal space is limited. Complements XDSProgressBar for radial layouts.',
     bestPractices: [
-      { guidance: true, description: 'Use determinate mode when the total amount of work is known, and indeterminate when it cannot be calculated.' },
+      { guidance: true, description: 'Pass a value for determinate progress; omit value for an indeterminate spinner.' },
       { guidance: true, description: 'Provide center content (children) to give context — a percentage, icon, or short label.' },
       { guidance: true, description: 'Always provide a label, even though it is visually hidden by default — screen readers need it.' },
       { guidance: false, description: 'Use circular progress for long text labels — use XDSProgressBar instead, which has more room for label and value display.' },
@@ -87,8 +80,7 @@ export const docsZh = {
     {
       name: 'value',
       type: 'number',
-      description: '当前值（不确定模式下忽略）。',
-      default: '0',
+      description: '当前值。省略时渲染不确定旋转动画。',
     },
     {
       name: 'max',
@@ -126,12 +118,6 @@ export const docsZh = {
       default: "'accent'",
     },
     {
-      name: 'isIndeterminate',
-      type: 'boolean',
-      description: '用于未知进度的旋转动画指示器。遵循 prefers-reduced-motion。',
-      default: 'false',
-    },
-    {
       name: 'xstyle',
       type: 'StyleXStyles',
       description: '用于布局自定义的 StyleX 样式。必须是 stylex.create() 的值。',
@@ -148,7 +134,7 @@ export const docsZh = {
     description:
       'A circular progress indicator that shows completion as a ring or arc. Use it for upload progress, score displays, dashboard gauges, or compact progress where horizontal space is limited. Complements XDSProgressBar for radial layouts.',
     bestPractices: [
-      { guidance: true, description: 'Use determinate mode when the total amount of work is known, and indeterminate when it cannot be calculated.' },
+      { guidance: true, description: 'Pass a value for determinate progress; omit value for an indeterminate spinner.' },
       { guidance: true, description: 'Provide center content (children) to give context — a percentage, icon, or short label.' },
       { guidance: true, description: 'Always provide a label, even though it is visually hidden by default — screen readers need it.' },
       { guidance: false, description: 'Use circular progress for long text labels — use XDSProgressBar instead, which has more room for label and value display.' },
@@ -165,7 +151,7 @@ export const docsDense = {
     description:
       'A circular progress indicator that shows completion as a ring or arc. Use it for upload progress, score displays, dashboard gauges, or compact progress where horizontal space is limited. Complements XDSProgressBar for radial layouts.',
     bestPractices: [
-      { guidance: true, description: 'Use determinate mode when the total amount of work is known, and indeterminate when it cannot be calculated.' },
+      { guidance: true, description: 'Pass a value for determinate progress; omit value for an indeterminate spinner.' },
       { guidance: true, description: 'Provide center content (children) to give context — a percentage, icon, or short label.' },
       { guidance: true, description: 'Always provide a label, even though it is visually hidden by default — screen readers need it.' },
       { guidance: false, description: 'Use circular progress for long text labels — use XDSProgressBar instead, which has more room for label and value display.' },
@@ -173,14 +159,13 @@ export const docsDense = {
     ],
   },
   propDescriptions: {
-    value: 'Current value (ignored when indeterminate).',
+    value: 'Current value. Omit for indeterminate spinning animation.',
     max: 'Maximum value.',
     label: 'Accessible label for screen readers (required).',
     isLabelHidden: 'Visually hide label (remains accessible). Defaults to true.',
     children: 'Center content — percentage, icon, or custom.',
     size: 'Ring diameter (32px, 48px, 64px).',
     variant: 'Semantic color variant for the fill.',
-    isIndeterminate: 'Spinning animation for unknown progress.',
     xstyle: 'StyleX styles for layout customization. Must be stylex.create() value.',
   },
 };

--- a/packages/core/src/CircularProgress/CircularProgress.doc.mjs
+++ b/packages/core/src/CircularProgress/CircularProgress.doc.mjs
@@ -1,0 +1,186 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('../docs-types').ComponentDoc} */
+
+export const docs = {
+  name: 'CircularProgress',
+  keywords: ["circular","progress","radial","ring","arc","determinate","indeterminate","gauge","meter","donut"],
+  props: [
+    {
+      name: 'value',
+      type: 'number',
+      description: 'Current value (ignored when indeterminate).',
+      default: '0',
+    },
+    {
+      name: 'max',
+      type: 'number',
+      description: 'Maximum value.',
+      default: '100',
+    },
+    {
+      name: 'label',
+      type: 'string',
+      description: 'Accessible label for screen readers (required).',
+      required: true,
+    },
+    {
+      name: 'isLabelHidden',
+      type: 'boolean',
+      description: 'Visually hide the label (remains accessible). Defaults to true since circular progress typically shows center content instead.',
+      default: 'true',
+    },
+    {
+      name: 'children',
+      type: 'ReactNode',
+      description: 'Content displayed in the center of the ring — percentage, icon, or custom content.',
+    },
+    {
+      name: 'size',
+      type: "'sm' | 'md' | 'lg'",
+      description: 'Diameter of the progress ring (32px, 48px, 64px).',
+      default: "'md'",
+    },
+    {
+      name: 'variant',
+      type: "'accent' | 'success' | 'warning' | 'error' | 'neutral'",
+      description: 'Semantic color variant for the progress fill.',
+      default: "'accent'",
+    },
+    {
+      name: 'isIndeterminate',
+      type: 'boolean',
+      description: 'Animated spinning indicator for unknown progress. Respects prefers-reduced-motion.',
+      default: 'false',
+    },
+    {
+      name: 'xstyle',
+      type: 'StyleXStyles',
+      description:
+        'StyleX styles for layout customization (margins, positioning). Must be a stylex.create() value.',
+    },
+  ],
+  theming: {
+    targets: [
+      {className: 'xds-circular-progress', visualProps: ['variant', 'size']},
+      {className: 'xds-circular-progress-track'},
+      {className: 'xds-circular-progress-fill', visualProps: ['variant']},
+    ],
+  },
+  usage: {
+    description:
+      'A circular progress indicator that shows completion as a ring or arc. Use it for upload progress, score displays, dashboard gauges, or compact progress where horizontal space is limited. Complements XDSProgressBar for radial layouts.',
+    bestPractices: [
+      { guidance: true, description: 'Use determinate mode when the total amount of work is known, and indeterminate when it cannot be calculated.' },
+      { guidance: true, description: 'Provide center content (children) to give context — a percentage, icon, or short label.' },
+      { guidance: true, description: 'Always provide a label, even though it is visually hidden by default — screen readers need it.' },
+      { guidance: false, description: 'Use circular progress for long text labels — use XDSProgressBar instead, which has more room for label and value display.' },
+      { guidance: false, description: 'Stack multiple circular progress indicators for the same operation — use one with a value label.' },
+    ],
+  },
+};
+
+/** @type {import('../docs-types').ComponentDoc} */
+export const docsZh = {
+  name: 'CircularProgress',
+  props: [
+    {
+      name: 'value',
+      type: 'number',
+      description: '当前值（不确定模式下忽略）。',
+      default: '0',
+    },
+    {
+      name: 'max',
+      type: 'number',
+      description: '最大值。',
+      default: '100',
+    },
+    {
+      name: 'label',
+      type: 'string',
+      description: '屏幕阅读器的无障碍标签（必填）。',
+      required: true,
+    },
+    {
+      name: 'isLabelHidden',
+      type: 'boolean',
+      description: '视觉上隐藏标签（仍保持无障碍可访问性）。默认为 true，因为圆形进度条通常显示中心内容。',
+      default: 'true',
+    },
+    {
+      name: 'children',
+      type: 'ReactNode',
+      description: '在环形中心显示的内容 — 百分比、图标或自定义内容。',
+    },
+    {
+      name: 'size',
+      type: "'sm' | 'md' | 'lg'",
+      description: '进度环的直径（32px、48px、64px）。',
+      default: "'md'",
+    },
+    {
+      name: 'variant',
+      type: "'accent' | 'success' | 'warning' | 'error' | 'neutral'",
+      description: '进度填充的语义颜色变体。',
+      default: "'accent'",
+    },
+    {
+      name: 'isIndeterminate',
+      type: 'boolean',
+      description: '用于未知进度的旋转动画指示器。遵循 prefers-reduced-motion。',
+      default: 'false',
+    },
+    {
+      name: 'xstyle',
+      type: 'StyleXStyles',
+      description: '用于布局自定义的 StyleX 样式。必须是 stylex.create() 的值。',
+    },
+  ],
+  theming: {
+    targets: [
+      {className: 'xds-circular-progress', visualProps: ['variant', 'size']},
+      {className: 'xds-circular-progress-track'},
+      {className: 'xds-circular-progress-fill', visualProps: ['variant']},
+    ],
+  },
+  usage: {
+    description:
+      'A circular progress indicator that shows completion as a ring or arc. Use it for upload progress, score displays, dashboard gauges, or compact progress where horizontal space is limited. Complements XDSProgressBar for radial layouts.',
+    bestPractices: [
+      { guidance: true, description: 'Use determinate mode when the total amount of work is known, and indeterminate when it cannot be calculated.' },
+      { guidance: true, description: 'Provide center content (children) to give context — a percentage, icon, or short label.' },
+      { guidance: true, description: 'Always provide a label, even though it is visually hidden by default — screen readers need it.' },
+      { guidance: false, description: 'Use circular progress for long text labels — use XDSProgressBar instead, which has more room for label and value display.' },
+      { guidance: false, description: 'Stack multiple circular progress indicators for the same operation — use one with a value label.' },
+    ],
+  },
+};
+
+/** @type {import('../docs-types').TranslationDoc} */
+export const docsDense = {
+  description:
+    'Circular/radial progress indicator showing completion as a ring arc.',
+  usage: {
+    description:
+      'A circular progress indicator that shows completion as a ring or arc. Use it for upload progress, score displays, dashboard gauges, or compact progress where horizontal space is limited. Complements XDSProgressBar for radial layouts.',
+    bestPractices: [
+      { guidance: true, description: 'Use determinate mode when the total amount of work is known, and indeterminate when it cannot be calculated.' },
+      { guidance: true, description: 'Provide center content (children) to give context — a percentage, icon, or short label.' },
+      { guidance: true, description: 'Always provide a label, even though it is visually hidden by default — screen readers need it.' },
+      { guidance: false, description: 'Use circular progress for long text labels — use XDSProgressBar instead, which has more room for label and value display.' },
+      { guidance: false, description: 'Stack multiple circular progress indicators for the same operation — use one with a value label.' },
+    ],
+  },
+  propDescriptions: {
+    value: 'Current value (ignored when indeterminate).',
+    max: 'Maximum value.',
+    label: 'Accessible label for screen readers (required).',
+    isLabelHidden: 'Visually hide label (remains accessible). Defaults to true.',
+    children: 'Center content — percentage, icon, or custom.',
+    size: 'Ring diameter (32px, 48px, 64px).',
+    variant: 'Semantic color variant for the fill.',
+    isIndeterminate: 'Spinning animation for unknown progress.',
+    xstyle: 'StyleX styles for layout customization. Must be stylex.create() value.',
+  },
+};

--- a/packages/core/src/CircularProgress/XDSCircularProgress.test.tsx
+++ b/packages/core/src/CircularProgress/XDSCircularProgress.test.tsx
@@ -1,0 +1,165 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {describe, it, expect} from 'vitest';
+import {render, screen} from '@testing-library/react';
+import {XDSCircularProgress} from './XDSCircularProgress';
+
+describe('XDSCircularProgress', () => {
+  it('renders with default props', () => {
+    render(<XDSCircularProgress value={50} label="Progress" />);
+    const meter = screen.getByRole('meter');
+    expect(meter).toBeInTheDocument();
+    expect(meter).toHaveAttribute('aria-valuenow', '50');
+    expect(meter).toHaveAttribute('aria-valuemin', '0');
+    expect(meter).toHaveAttribute('aria-valuemax', '100');
+  });
+
+  it('renders label as visually hidden by default', () => {
+    render(<XDSCircularProgress value={50} label="Upload progress" />);
+    expect(screen.getByText('Upload progress')).toBeInTheDocument();
+    const meter = screen.getByRole('meter');
+    expect(meter).toHaveAttribute('aria-labelledby');
+  });
+
+  it('shows label visually when isLabelHidden is false', () => {
+    render(
+      <XDSCircularProgress
+        value={50}
+        label="Upload progress"
+        isLabelHidden={false}
+      />,
+    );
+    const label = screen.getByText('Upload progress');
+    expect(label).toBeInTheDocument();
+    const meter = screen.getByRole('meter');
+    expect(meter).toHaveAttribute('aria-labelledby');
+  });
+
+  it('respects custom max', () => {
+    render(<XDSCircularProgress value={3} max={10} label="Steps" />);
+    const meter = screen.getByRole('meter');
+    expect(meter).toHaveAttribute('aria-valuenow', '3');
+    expect(meter).toHaveAttribute('aria-valuemax', '10');
+  });
+
+  it('clamps value to [0, max]', () => {
+    const {rerender} = render(
+      <XDSCircularProgress value={150} max={100} label="Over" />,
+    );
+    let meter = screen.getByRole('meter');
+    expect(meter).toHaveAttribute('aria-valuenow', '100');
+
+    rerender(<XDSCircularProgress value={-10} max={100} label="Under" />);
+    meter = screen.getByRole('meter');
+    expect(meter).toHaveAttribute('aria-valuenow', '0');
+  });
+
+  it('renders children in the center', () => {
+    render(
+      <XDSCircularProgress value={75} label="Progress">
+        75%
+      </XDSCircularProgress>,
+    );
+    expect(screen.getByText('75%')).toBeInTheDocument();
+  });
+
+  it('forwards ref to outer container', () => {
+    const ref = {current: null as HTMLDivElement | null};
+    render(<XDSCircularProgress ref={ref} value={50} label="Test" />);
+    expect(ref.current).toBeInstanceOf(HTMLDivElement);
+  });
+
+  it('passes data-testid', () => {
+    render(
+      <XDSCircularProgress value={50} label="Test" data-testid="my-progress" />,
+    );
+    expect(screen.getByTestId('my-progress')).toBeInTheDocument();
+  });
+
+  it('renders with all variant options', () => {
+    const variants = [
+      'accent',
+      'success',
+      'warning',
+      'error',
+      'neutral',
+    ] as const;
+    for (const variant of variants) {
+      const {unmount} = render(
+        <XDSCircularProgress value={50} label={variant} variant={variant} />,
+      );
+      expect(screen.getByRole('meter')).toBeInTheDocument();
+      unmount();
+    }
+  });
+
+  it('renders with all size options', () => {
+    const sizes = ['sm', 'md', 'lg'] as const;
+    for (const size of sizes) {
+      const {unmount} = render(
+        <XDSCircularProgress value={50} label={size} size={size} />,
+      );
+      expect(screen.getByRole('meter')).toBeInTheDocument();
+      unmount();
+    }
+  });
+
+  it('handles zero max gracefully', () => {
+    render(<XDSCircularProgress value={0} max={0} label="Empty" />);
+    const meter = screen.getByRole('meter');
+    expect(meter).toHaveAttribute('aria-valuenow', '0');
+    expect(meter).toHaveAttribute('aria-valuemax', '0');
+  });
+
+  describe('indeterminate mode', () => {
+    it('renders with role="progressbar" when isIndeterminate', () => {
+      render(<XDSCircularProgress isIndeterminate label="Loading" />);
+      const progressbar = screen.getByRole('progressbar');
+      expect(progressbar).toBeInTheDocument();
+    });
+
+    it('does not set aria-valuenow/min/max when indeterminate', () => {
+      render(<XDSCircularProgress isIndeterminate label="Loading" />);
+      const progressbar = screen.getByRole('progressbar');
+      expect(progressbar).not.toHaveAttribute('aria-valuenow');
+      expect(progressbar).not.toHaveAttribute('aria-valuemin');
+      expect(progressbar).not.toHaveAttribute('aria-valuemax');
+    });
+
+    it('is labelled via aria-labelledby when indeterminate', () => {
+      render(<XDSCircularProgress isIndeterminate label="Loading data" />);
+      const progressbar = screen.getByRole('progressbar');
+      expect(progressbar).toHaveAttribute('aria-labelledby');
+    });
+
+    it('renders with all variants in indeterminate mode', () => {
+      const variants = [
+        'accent',
+        'success',
+        'warning',
+        'error',
+        'neutral',
+      ] as const;
+      for (const variant of variants) {
+        const {unmount} = render(
+          <XDSCircularProgress
+            isIndeterminate
+            label={variant}
+            variant={variant}
+          />,
+        );
+        expect(screen.getByRole('progressbar')).toBeInTheDocument();
+        unmount();
+      }
+    });
+
+    it('renders children alongside indeterminate animation', () => {
+      render(
+        <XDSCircularProgress isIndeterminate label="Loading">
+          ...
+        </XDSCircularProgress>,
+      );
+      expect(screen.getByText('...')).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/core/src/CircularProgress/XDSCircularProgress.test.tsx
+++ b/packages/core/src/CircularProgress/XDSCircularProgress.test.tsx
@@ -112,14 +112,14 @@ describe('XDSCircularProgress', () => {
   });
 
   describe('indeterminate mode', () => {
-    it('renders with role="progressbar" when isIndeterminate', () => {
-      render(<XDSCircularProgress isIndeterminate label="Loading" />);
+    it('renders indeterminate when value is omitted', () => {
+      render(<XDSCircularProgress label="Loading" />);
       const progressbar = screen.getByRole('progressbar');
       expect(progressbar).toBeInTheDocument();
     });
 
     it('does not set aria-valuenow/min/max when indeterminate', () => {
-      render(<XDSCircularProgress isIndeterminate label="Loading" />);
+      render(<XDSCircularProgress label="Loading" />);
       const progressbar = screen.getByRole('progressbar');
       expect(progressbar).not.toHaveAttribute('aria-valuenow');
       expect(progressbar).not.toHaveAttribute('aria-valuemin');
@@ -127,7 +127,7 @@ describe('XDSCircularProgress', () => {
     });
 
     it('is labelled via aria-labelledby when indeterminate', () => {
-      render(<XDSCircularProgress isIndeterminate label="Loading data" />);
+      render(<XDSCircularProgress label="Loading data" />);
       const progressbar = screen.getByRole('progressbar');
       expect(progressbar).toHaveAttribute('aria-labelledby');
     });
@@ -142,11 +142,7 @@ describe('XDSCircularProgress', () => {
       ] as const;
       for (const variant of variants) {
         const {unmount} = render(
-          <XDSCircularProgress
-            isIndeterminate
-            label={variant}
-            variant={variant}
-          />,
+          <XDSCircularProgress label={variant} variant={variant} />,
         );
         expect(screen.getByRole('progressbar')).toBeInTheDocument();
         unmount();
@@ -154,11 +150,7 @@ describe('XDSCircularProgress', () => {
     });
 
     it('renders children alongside indeterminate animation', () => {
-      render(
-        <XDSCircularProgress isIndeterminate label="Loading">
-          ...
-        </XDSCircularProgress>,
-      );
+      render(<XDSCircularProgress label="Loading">...</XDSCircularProgress>);
       expect(screen.getByText('...')).toBeInTheDocument();
     });
   });

--- a/packages/core/src/CircularProgress/XDSCircularProgress.tsx
+++ b/packages/core/src/CircularProgress/XDSCircularProgress.tsx
@@ -66,8 +66,7 @@ export interface XDSCircularProgressProps extends XDSBaseProps<HTMLDivElement> {
   ref?: React.Ref<HTMLDivElement>;
   /**
    * Current value of the circular progress.
-   * Ignored when `isIndeterminate` is true.
-   * @default 0
+   * When omitted, the component renders an indeterminate spinning animation.
    */
   value?: number;
   /**
@@ -102,14 +101,6 @@ export interface XDSCircularProgressProps extends XDSBaseProps<HTMLDivElement> {
    * @default 'accent'
    */
   variant?: XDSCircularProgressVariant;
-  /**
-   * When true, renders an animated spinning indicator.
-   * Use when the progress amount is unknown.
-   * The `value` prop is ignored in this mode.
-   * Respects `prefers-reduced-motion` by slowing the animation.
-   * @default false
-   */
-  isIndeterminate?: boolean;
   /**
    * Test ID for testing utilities.
    */
@@ -217,6 +208,10 @@ const styles = stylex.create({
     whiteSpace: 'nowrap',
     borderWidth: 0,
   },
+  ringWrapper: {
+    position: 'relative',
+    display: 'inline-flex',
+  },
 });
 
 const variantStyles = stylex.create({
@@ -266,18 +261,17 @@ const trackVariantStyles = stylex.create({
  * ```
  * <XDSCircularProgress value={75} label="Upload progress" />
  * <XDSCircularProgress value={75} label="Progress" max={100}>75%</XDSCircularProgress>
- * <XDSCircularProgress isIndeterminate label="Loading..." />
+ * <XDSCircularProgress label="Loading..." />
  * ```
  */
 export function XDSCircularProgress({
-  value = 0,
+  value,
   max = 100,
   label,
   isLabelHidden = true,
   children,
   size = 'md',
   variant = 'accent',
-  isIndeterminate = false,
   xstyle,
   className,
   style,
@@ -286,11 +280,13 @@ export function XDSCircularProgress({
   ...rest
 }: XDSCircularProgressProps) {
   const labelId = useId();
+  const isIndeterminate = value == null;
   const {diameter, strokeWidth} = SIZE_CONFIG[size];
   const radius = (diameter - strokeWidth) / 2;
   const circumference = 2 * Math.PI * radius;
 
-  const clampedValue = Math.min(Math.max(0, value), max);
+  const resolvedValue = value ?? 0;
+  const clampedValue = Math.min(Math.max(0, resolvedValue), max);
   const percentage = max > 0 ? clampedValue / max : 0;
   const dashoffset = circumference * (1 - percentage);
 
@@ -315,7 +311,7 @@ export function XDSCircularProgress({
         {label}
       </span>
 
-      <div style={{position: 'relative', display: 'inline-flex'}}>
+      <div {...stylex.props(styles.ringWrapper)}>
         <svg
           role={isIndeterminate ? 'progressbar' : 'meter'}
           aria-labelledby={labelId}

--- a/packages/core/src/CircularProgress/XDSCircularProgress.tsx
+++ b/packages/core/src/CircularProgress/XDSCircularProgress.tsx
@@ -1,0 +1,376 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file XDSCircularProgress.tsx
+ * @input Uses React, useId, stylex, SVG, color/spacing/duration/ease tokens
+ * @output Exports XDSCircularProgress component, XDSCircularProgressProps, XDSCircularProgressSize, XDSCircularProgressVariant types
+ * @position Core implementation; consumed by index.ts
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/CircularProgress/CircularProgress.doc.mjs (props table, features, implementation notes)
+ * - /packages/core/src/CircularProgress/XDSCircularProgress.test.tsx (tests for new/changed behavior)
+ * - /packages/core/src/CircularProgress/index.ts (exports if types change)
+ * - /apps/storybook/stories/CircularProgress.stories.tsx (storybook stories)
+ * - /packages/cli/templates/blocks/components/CircularProgress/ (showcase blocks)
+ */
+
+import {useId, type ReactNode} from 'react';
+import * as stylex from '@stylexjs/stylex';
+
+import {
+  colorVars,
+  durationVars,
+  easeVars,
+  fontWeightVars,
+  spacingVars,
+  typeScaleVars,
+} from '../theme/tokens.stylex';
+import {xdsClassName, mergeProps} from '../utils';
+import type {XDSBaseProps} from '../XDSBaseProps';
+
+/**
+ * Extensible variant map for XDSCircularProgress.
+ *
+ * Theme packages can add custom variants via TypeScript module augmentation:
+ * @example
+ * ```
+ * declare module '@xds/core/CircularProgress' {
+ *   interface XDSCircularProgressVariantMap {
+ *     'brand': true;
+ *   }
+ * }
+ * ```
+ */
+export interface XDSCircularProgressVariantMap {
+  accent: true;
+  success: true;
+  warning: true;
+  error: true;
+  neutral: true;
+}
+
+export type XDSCircularProgressVariant = keyof XDSCircularProgressVariantMap;
+
+export type XDSCircularProgressSize = 'sm' | 'md' | 'lg';
+
+const SIZE_CONFIG = {
+  sm: {diameter: 32, strokeWidth: 3},
+  md: {diameter: 48, strokeWidth: 4},
+  lg: {diameter: 64, strokeWidth: 5},
+} as const;
+
+export interface XDSCircularProgressProps extends XDSBaseProps<HTMLDivElement> {
+  /** Ref forwarded to the root element */
+  ref?: React.Ref<HTMLDivElement>;
+  /**
+   * Current value of the circular progress.
+   * Ignored when `isIndeterminate` is true.
+   * @default 0
+   */
+  value?: number;
+  /**
+   * Maximum value.
+   * @default 100
+   */
+  max?: number;
+  /**
+   * Accessible label for the progress indicator. Required for a11y.
+   */
+  label: string;
+  /**
+   * When true, the label is visually hidden but remains accessible to screen readers.
+   * @default true
+   */
+  isLabelHidden?: boolean;
+  /**
+   * Content displayed in the center of the ring.
+   * Typically a percentage string, icon, or custom content.
+   */
+  children?: ReactNode;
+  /**
+   * Diameter of the circular progress.
+   * - 'sm': 32px
+   * - 'md': 48px
+   * - 'lg': 64px
+   * @default 'md'
+   */
+  size?: XDSCircularProgressSize;
+  /**
+   * Visual style variant mapped to semantic color tokens.
+   * @default 'accent'
+   */
+  variant?: XDSCircularProgressVariant;
+  /**
+   * When true, renders an animated spinning indicator.
+   * Use when the progress amount is unknown.
+   * The `value` prop is ignored in this mode.
+   * Respects `prefers-reduced-motion` by slowing the animation.
+   * @default false
+   */
+  isIndeterminate?: boolean;
+  /**
+   * Test ID for testing utilities.
+   */
+  'data-testid'?: string;
+}
+
+// =============================================================================
+// Indeterminate animation
+// =============================================================================
+
+const indeterminateRotation = stylex.keyframes({
+  '0%': {transform: 'rotate(0deg)'},
+  '100%': {transform: 'rotate(360deg)'},
+});
+
+const indeterminateDash = stylex.keyframes({
+  '0%': {
+    strokeDasharray: '1, 150',
+    strokeDashoffset: '0',
+  },
+  '50%': {
+    strokeDasharray: '90, 150',
+    strokeDashoffset: '-35',
+  },
+  '100%': {
+    strokeDasharray: '90, 150',
+    strokeDashoffset: '-124',
+  },
+});
+
+// =============================================================================
+// Styles
+// =============================================================================
+
+const styles = stylex.create({
+  root: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    position: 'relative',
+    flexShrink: 0,
+  },
+  rootWithLabel: {
+    flexDirection: 'column',
+    gap: spacingVars['--spacing-1'],
+  },
+  svg: {
+    display: 'block',
+    transform: 'rotate(-90deg)',
+  },
+  svgIndeterminate: {
+    display: 'block',
+    animationName: indeterminateRotation,
+    animationDuration: {
+      default: '2s',
+      '@media (prefers-reduced-motion: reduce)': '4s',
+    },
+    animationTimingFunction: 'linear',
+    animationIterationCount: 'infinite',
+  },
+  track: {
+    fill: 'none',
+    stroke: colorVars['--color-track'],
+  },
+  fill: {
+    fill: 'none',
+    strokeLinecap: 'round',
+    transitionProperty: 'stroke-dashoffset',
+    transitionDuration: durationVars['--duration-medium'],
+    transitionTimingFunction: easeVars['--ease-standard'],
+  },
+  fillIndeterminate: {
+    fill: 'none',
+    strokeLinecap: 'round',
+    animationName: indeterminateDash,
+    animationDuration: {
+      default: '1.5s',
+      '@media (prefers-reduced-motion: reduce)': '3s',
+    },
+    animationTimingFunction: 'ease-in-out',
+    animationIterationCount: 'infinite',
+  },
+  children: {
+    position: 'absolute',
+    inset: 0,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    pointerEvents: 'none',
+  },
+  label: {
+    fontSize: typeScaleVars['--text-supporting-size'],
+    lineHeight: typeScaleVars['--text-supporting-leading'],
+    fontWeight: fontWeightVars['--font-weight-medium'],
+    color: colorVars['--color-text-secondary'],
+  },
+  visuallyHidden: {
+    position: 'absolute',
+    width: '1px',
+    height: '1px',
+    padding: 0,
+    margin: '-1px',
+    overflow: 'hidden',
+    clip: 'rect(0, 0, 0, 0)',
+    whiteSpace: 'nowrap',
+    borderWidth: 0,
+  },
+});
+
+const variantStyles = stylex.create({
+  accent: {
+    stroke: colorVars['--color-accent'],
+  },
+  success: {
+    stroke: colorVars['--color-success'],
+  },
+  warning: {
+    stroke: colorVars['--color-warning'],
+  },
+  error: {
+    stroke: colorVars['--color-error'],
+  },
+  neutral: {
+    stroke: colorVars['--color-text-disabled'],
+  },
+});
+
+const trackVariantStyles = stylex.create({
+  accent: {
+    stroke: colorVars['--color-accent-muted'],
+  },
+  success: {
+    stroke: colorVars['--color-success-muted'],
+  },
+  warning: {
+    stroke: colorVars['--color-warning-muted'],
+  },
+  error: {
+    stroke: colorVars['--color-error-muted'],
+  },
+  neutral: {
+    stroke: colorVars['--color-track'],
+  },
+});
+
+/**
+ * A circular/radial progress indicator that shows completion as a ring.
+ *
+ * In determinate mode, displays a known value as an arc fill.
+ * In indeterminate mode, shows an animated spinning indicator.
+ * Supports center content via children for labels, percentages, or icons.
+ *
+ * @example
+ * ```
+ * <XDSCircularProgress value={75} label="Upload progress" />
+ * <XDSCircularProgress value={75} label="Progress" max={100}>75%</XDSCircularProgress>
+ * <XDSCircularProgress isIndeterminate label="Loading..." />
+ * ```
+ */
+export function XDSCircularProgress({
+  value = 0,
+  max = 100,
+  label,
+  isLabelHidden = true,
+  children,
+  size = 'md',
+  variant = 'accent',
+  isIndeterminate = false,
+  xstyle,
+  className,
+  style,
+  'data-testid': dataTestId,
+  ref,
+  ...rest
+}: XDSCircularProgressProps) {
+  const labelId = useId();
+  const {diameter, strokeWidth} = SIZE_CONFIG[size];
+  const radius = (diameter - strokeWidth) / 2;
+  const circumference = 2 * Math.PI * radius;
+
+  const clampedValue = Math.min(Math.max(0, value), max);
+  const percentage = max > 0 ? clampedValue / max : 0;
+  const dashoffset = circumference * (1 - percentage);
+
+  const center = diameter / 2;
+
+  const showLabel = !isLabelHidden;
+
+  return (
+    <div
+      ref={ref}
+      {...mergeProps(
+        xdsClassName('circular-progress', {variant, size}),
+        stylex.props(styles.root, showLabel && styles.rootWithLabel, xstyle),
+        className,
+        style,
+      )}
+      data-testid={dataTestId}
+      {...rest}>
+      <span
+        id={labelId}
+        {...stylex.props(showLabel ? styles.label : styles.visuallyHidden)}>
+        {label}
+      </span>
+
+      <div style={{position: 'relative', display: 'inline-flex'}}>
+        <svg
+          role={isIndeterminate ? 'progressbar' : 'meter'}
+          aria-labelledby={labelId}
+          aria-valuenow={isIndeterminate ? undefined : clampedValue}
+          aria-valuemin={isIndeterminate ? undefined : 0}
+          aria-valuemax={isIndeterminate ? undefined : max}
+          width={diameter}
+          height={diameter}
+          viewBox={`0 0 ${diameter} ${diameter}`}
+          {...stylex.props(
+            isIndeterminate ? styles.svgIndeterminate : styles.svg,
+          )}>
+          <circle
+            {...mergeProps(
+              xdsClassName('circular-progress-track'),
+              stylex.props(styles.track, trackVariantStyles[variant]),
+            )}
+            cx={center}
+            cy={center}
+            r={radius}
+            strokeWidth={strokeWidth}
+          />
+          {isIndeterminate ? (
+            <circle
+              {...mergeProps(
+                xdsClassName('circular-progress-fill', {variant}),
+                stylex.props(styles.fillIndeterminate, variantStyles[variant]),
+              )}
+              cx={center}
+              cy={center}
+              r={radius}
+              strokeWidth={strokeWidth}
+            />
+          ) : (
+            <circle
+              {...mergeProps(
+                xdsClassName('circular-progress-fill', {variant}),
+                stylex.props(styles.fill, variantStyles[variant]),
+              )}
+              cx={center}
+              cy={center}
+              r={radius}
+              strokeWidth={strokeWidth}
+              strokeDasharray={circumference}
+              strokeDashoffset={dashoffset}
+            />
+          )}
+        </svg>
+
+        {children != null && (
+          <div {...stylex.props(styles.children)}>{children}</div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+XDSCircularProgress.displayName = 'XDSCircularProgress';

--- a/packages/core/src/CircularProgress/index.ts
+++ b/packages/core/src/CircularProgress/index.ts
@@ -1,0 +1,15 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file CircularProgress component barrel export
+ */
+
+export {XDSCircularProgress} from './XDSCircularProgress';
+export type {
+  XDSCircularProgressProps,
+  XDSCircularProgressSize,
+  XDSCircularProgressVariant,
+  XDSCircularProgressVariantMap,
+} from './XDSCircularProgress';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -38,6 +38,7 @@ export * from './Markdown';
 export * from './Citation';
 export * from './CheckboxInput';
 export * from './CheckboxList';
+export * from './CircularProgress';
 export * from './Collapsible';
 export * from './RadioList';
 export * from './Resizable';


### PR DESCRIPTION
## Summary
- Adds `XDSCircularProgress` — an SVG-based radial progress indicator (closes #583)
- Supports determinate mode (value/max arc fill) and indeterminate mode (spinning animation)
- 3 size variants: `sm` (32px), `md` (48px), `lg` (64px)
- 5 color variants: accent, success, warning, error, neutral — each with a muted track color
- Center content slot via `children` for percentages, icons, or custom content
- Visible label support via `isLabelHidden={false}` (hidden by default)
- Full a11y: `role="meter"` (determinate) / `role="progressbar"` (indeterminate), aria-valuenow/min/max, aria-labelledby
- Theming via 3 xdsClassName targets, extensible variants via module augmentation
- Respects `prefers-reduced-motion` for indeterminate animations

## Files
- `packages/core/src/CircularProgress/` — component, tests (16), docs, barrel export
- `apps/storybook/stories/CircularProgress.stories.tsx` — 10 stories
- `packages/cli/templates/blocks/components/CircularProgress/` — showcase block
- `packages/core/src/index.ts` + `packages/core/package.json` — wiring

## Test plan
- [x] 16 unit tests pass (determinate, indeterminate, sizes, variants, a11y, ref, clamping, children)
- [x] `pnpm build` succeeds
- [x] `pnpm lint` clean (0 errors, 0 warnings)
- [x] Visual review in Storybook