### PR TITLE
feat(lint): enable eslint-plugin-react-compiler

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,6 +3,7 @@
 import js from "@eslint/js";
 import tseslint from "typescript-eslint";
 import eslintReact from "@eslint-react/eslint-plugin";
+import reactCompiler from "eslint-plugin-react-compiler";
 import xdsPlugin from "./internal/eslint-plugin-xds/index.js";
 
 /* global process */
@@ -71,15 +72,6 @@ export default tseslint.config(
       }],
     },
   },
-  // Test files — relax rules for test ergonomics
-  {
-    files: ["**/*.test.{ts,tsx}", "**/*.perf.test.{ts,tsx}"],
-    rules: {
-      "no-console": "off",
-      "@typescript-eslint/no-non-null-assertion": "off",
-      "@typescript-eslint/consistent-type-assertions": "off",
-    },
-  },
   // Copyright header — all source files must have the Meta copyright notice
   {
     files: ["**/*.{ts,tsx}"],
@@ -113,8 +105,13 @@ export default tseslint.config(
   // Children.*/cloneElement are already covered by @xds/no-react-introspection.
   {
     files: ["packages/core/src/**/*.{ts,tsx}"],
-    plugins: eslintReact.configs.recommended.plugins,
+    plugins: {
+      ...eslintReact.configs.recommended.plugins,
+      'react-compiler': reactCompiler,
+    },
     rules: {
+      // React Compiler compatibility
+      'react-compiler/react-compiler': reactSeverity,
       // React fundamentals
       '@eslint-react/rules-of-hooks': reactSeverity,
       '@eslint-react/purity': reactSeverity,
@@ -172,6 +169,17 @@ export default tseslint.config(
       '@eslint-react/web-api-no-leaked-timeout': reactSeverity,
       '@eslint-react/web-api-no-leaked-resize-observer': reactSeverity,
       '@eslint-react/web-api-no-leaked-fetch': reactSeverity,
+    },
+  },
+  // Test files — relax rules for test ergonomics (must be after React rules
+  // block so it overrides react-compiler/react-compiler)
+  {
+    files: ["**/*.test.{ts,tsx}", "**/*.perf.test.{ts,tsx}"],
+    rules: {
+      "no-console": "off",
+      "@typescript-eslint/no-non-null-assertion": "off",
+      "@typescript-eslint/consistent-type-assertions": "off",
+      "react-compiler/react-compiler": "off",
     },
   },
 );

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@vitejs/plugin-react": "^4.3.0",
     "@vitest/coverage-v8": "^2.1.0",
     "eslint": "^10.4.0",
+    "eslint-plugin-react-compiler": "19.1.0-rc.2",
     "husky": "^9.1.7",
     "jscodeshift": "^17.3.0",
     "jsdom": "^27.4.0",

--- a/packages/core/src/ButtonGroup/XDSButtonGroup.tsx
+++ b/packages/core/src/ButtonGroup/XDSButtonGroup.tsx
@@ -137,6 +137,7 @@ export function XDSButtonGroup({
       <XDSSizeProvider value={size}>
         <div
           ref={(node: HTMLDivElement | null) => {
+            // eslint-disable-next-line react-compiler/react-compiler -- ref callback: assigning hook-returned ref
             (listRef as React.MutableRefObject<HTMLElement | null>).current =
               node;
             if (typeof ref === 'function') {

--- a/packages/core/src/Chat/useXDSChatStreamScroll.ts
+++ b/packages/core/src/Chat/useXDSChatStreamScroll.ts
@@ -150,6 +150,7 @@ export function useXDSChatStreamScroll({
     const diff = target - el.scrollTop;
 
     if (Math.abs(diff) < 0.5 && Math.abs(velocityRef.current) < 0.1) {
+      // eslint-disable-next-line react-compiler/react-compiler -- imperative DOM: scrollTop assignment
       el.scrollTop = target;
       animatingRef.current = false;
       lastTickRef.current = undefined;

--- a/packages/core/src/DropdownMenu/XDSDropdownMenu.tsx
+++ b/packages/core/src/DropdownMenu/XDSDropdownMenu.tsx
@@ -359,14 +359,15 @@ export function XDSDropdownMenu({
             buttonRef as React.MutableRefObject<HTMLButtonElement | null>
           ).current = el;
           popover.triggerRef(el);
-          // Forward consumer ref from button config
           const consumerRef = button.ref;
           if (typeof consumerRef === 'function') {
             consumerRef(el);
           } else if (consumerRef) {
+            /* eslint-disable react-compiler/react-compiler -- ref callback: forwarding consumer ref object */
             (
               consumerRef as React.MutableRefObject<HTMLButtonElement | null>
             ).current = el;
+            /* eslint-enable react-compiler/react-compiler */
           }
         }}
         tooltip={isOpen ? undefined : button.tooltip}

--- a/packages/core/src/Overlay/XDSOverlay.tsx
+++ b/packages/core/src/Overlay/XDSOverlay.tsx
@@ -117,6 +117,7 @@ export function XDSOverlay({
     }
     const radius = getComputedStyle(firstChild).borderRadius;
     if (radius && radius !== '0px') {
+      // eslint-disable-next-line react-compiler/react-compiler -- imperative DOM: syncing border-radius from child
       el.style.borderRadius = radius;
     }
   }, []);

--- a/packages/core/src/Resizable/useXDSResizable.ts
+++ b/packages/core/src/Resizable/useXDSResizable.ts
@@ -375,9 +375,9 @@ export function useXDSResizable(
   config: UseXDSResizableSingleConfig | UseXDSResizableMultiConfig,
 ): ResizableRegion | Record<string, ResizableRegion> {
   if ('regions' in config) {
-    // eslint-disable-next-line @eslint-react/rules-of-hooks -- branch is determined by call-site type (stable per call site)
+    // eslint-disable-next-line @eslint-react/rules-of-hooks, react-compiler/react-compiler -- branch is determined by call-site type (stable per call site)
     return useMultiResizable(config);
   }
-  // eslint-disable-next-line @eslint-react/rules-of-hooks -- branch is determined by call-site type (stable per call site)
+  // eslint-disable-next-line @eslint-react/rules-of-hooks, react-compiler/react-compiler -- branch is determined by call-site type (stable per call site)
   return useSingleResizable(config);
 }

--- a/packages/core/src/Table/plugins/columnResize/useXDSTableColumnResize.tsx
+++ b/packages/core/src/Table/plugins/columnResize/useXDSTableColumnResize.tsx
@@ -312,6 +312,7 @@ function ResizeHandle({
     (dragging: boolean) => {
       const table = tableRef.current;
       if (table) {
+        // eslint-disable-next-line react-compiler/react-compiler -- imperative DOM: disable text selection during drag
         table.style.userSelect = dragging ? 'none' : '';
       }
     },

--- a/packages/core/src/hooks/useClickableContainer.ts
+++ b/packages/core/src/hooks/useClickableContainer.ts
@@ -179,6 +179,7 @@ export function useClickableContainer({
           // handles navigation (client-side transitions in Next.js, etc.).
           interactiveRef.current.click();
         } else {
+          // eslint-disable-next-line react-compiler/react-compiler -- browser navigation API
           window.location.href = href;
         }
       }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
       eslint:
         specifier: ^10.4.0
         version: 10.4.0(jiti@2.7.0)
+      eslint-plugin-react-compiler:
+        specifier: 19.1.0-rc.2
+        version: 19.1.0-rc.2(eslint@10.4.0(jiti@2.7.0))
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -1090,6 +1093,13 @@ packages:
     resolution: {integrity: sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  '@babel/plugin-proposal-private-methods@7.18.6':
+    resolution: {integrity: sha512-nutsvktDItsNn4rpGItSNV2sz1XwS+nfU0Rg8aCx3W3NOKVzdMjJRu0O5OkgDp3ZGICSTbgRpxZoWsxoKRvbeA==}
+    engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-methods instead.
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
 
   '@babel/plugin-syntax-flow@7.28.6':
     resolution: {integrity: sha512-D+OrJumc9McXNEBI/JmFnc/0uCM2/Y3PEBG3gfV3QIYkKv5pvnpzFrl1kYCrcHJP8nOeFB/SHi1IHz29pNGuew==}
@@ -4250,6 +4260,12 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
+  eslint-plugin-react-compiler@19.1.0-rc.2:
+    resolution: {integrity: sha512-oKalwDGcD+RX9mf3NEO4zOoUMeLvjSvcbbEOpquzmzqEEM2MQdp7/FY/Hx9NzmUwFzH1W9SKTz5fihfMldpEYw==}
+    engines: {node: ^14.17.0 || ^16.0.0 || >= 18.0.0}
+    peerDependencies:
+      eslint: '>=7'
+
   eslint-plugin-react-dom@5.8.1:
     resolution: {integrity: sha512-FHew3Pd39QuwHY0XCiE1mnss8jc7cq0LGwE2QElQ8cpQzOxghkxdb9RxiErjO81SvLoKEEc3c7akqd8qvjEj+w==}
     engines: {node: '>=22.0.0'}
@@ -4507,8 +4523,14 @@ packages:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
+  hermes-estree@0.25.1:
+    resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
+
   hermes-estree@0.26.0:
     resolution: {integrity: sha512-If1T7lhfXnGlVLbnsmwerNB5cyJm2oIE8TN1UKEq6/OUX1nOGUhjXMpqAwZ1wkkn9Brda0VRyJEWOGT2GgVcAQ==}
+
+  hermes-parser@0.25.1:
+    resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
   hermes-parser@0.26.0:
     resolution: {integrity: sha512-fWT40jJ/BtlzuyiiQS7lzNIlB5h6flVZoN8Jn8v5l987HL5dK9s+/4+py0FaBmeIEROC2zxt5qMLwXFTPLQ7BA==}
@@ -5945,6 +5967,15 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  zod-validation-error@3.5.4:
+    resolution: {integrity: sha512-+hEiRIiPobgyuFlEojnqjJnhFvg4r/i3cqgcm67eehZf/WBaK3g6cD02YU9mtdVxZjv8CzCA9n/Rhrs3yAAvAw==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      zod: ^3.24.4
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
@@ -6106,6 +6137,14 @@ snapshots:
   '@babel/parser@7.29.3':
     dependencies:
       '@babel/types': 7.29.0
+
+  '@babel/plugin-proposal-private-methods@7.18.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.0)
+      '@babel/helper-plugin-utils': 7.28.6
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-syntax-flow@7.28.6(@babel/core@7.29.0)':
     dependencies:
@@ -9026,6 +9065,18 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
+  eslint-plugin-react-compiler@19.1.0-rc.2(eslint@10.4.0(jiti@2.7.0)):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/parser': 7.29.3
+      '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.29.0)
+      eslint: 10.4.0(jiti@2.7.0)
+      hermes-parser: 0.25.1
+      zod: 3.25.76
+      zod-validation-error: 3.5.4(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-plugin-react-dom@5.8.1(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3):
     dependencies:
       '@eslint-react/ast': 5.8.1(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3)
@@ -9352,7 +9403,13 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hermes-estree@0.25.1: {}
+
   hermes-estree@0.26.0: {}
+
+  hermes-parser@0.25.1:
+    dependencies:
+      hermes-estree: 0.25.1
 
   hermes-parser@0.26.0:
     dependencies:
@@ -10969,5 +11026,11 @@ snapshots:
       yargs-parser: 22.0.0
 
   yocto-queue@0.1.0: {}
+
+  zod-validation-error@3.5.4(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
+
+  zod@3.25.76: {}
 
   zod@4.4.3: {}


### PR DESCRIPTION
> **Stacked on #2258** — merge that first.

## Summary

Add `eslint-plugin-react-compiler` to catch patterns incompatible with React Compiler's automatic memoization. Only 13 violations in the entire codebase (6 in tests, 7 in production) — all 7 production violations are false positives that are suppressed with explanatory comments.

### Why each suppression is a false positive

| File | What the compiler flags | Why it's safe |
|------|------------------------|---------------|
| **ButtonGroup** | "Mutating hook return value" — `listRef.current = node` | Ref callback: runs during commit, not render. `listRef` from `useListFocus` is a standard `useRef`. |
| **DropdownMenu** | "Writing to external variable" — `consumerRef.current = el` | Ref callback: the standard pattern for forwarding a consumer's ref object. |
| **Chat/streamScroll** | "Mutating hook argument" — `el.scrollTop = target` | Imperative DOM: setting scroll position in a rAF animation loop. `scrollTop` is a DOM property, not React state. |
| **Overlay** | "Mutating hook return" — `el.style.borderRadius = radius` | Imperative DOM: syncing border-radius from child element in a layout effect (runs after commit, before paint). |
| **Table/columnResize** | "Mutating prop" — `table.style.userSelect = 'none'` | Imperative DOM: disabling text selection during drag. Standard drag-handler pattern. |
| **useClickableContainer** | "Writing to global" — `window.location.href = href` | Browser navigation API: an intentional side effect in a click handler, not a rendering concern. |
| **Resizable** | "Conditional hooks" | Already suppressed for `rules-of-hooks`. Overloaded function with call-site-stable branches. |

### Config changes
- Install `eslint-plugin-react-compiler` as devDependency
- Enable `react-compiler/react-compiler` rule for production code
- Disable in test files (moved test override block to end of config so it properly overrides the React rules block)

## Test plan
- [x] `npx eslint --no-cache 'packages/core/src/**/*.{ts,tsx}'` — zero react-compiler violations
- [x] Pre-commit hooks pass