### PR TITLE
fix(Thumbnail): focus ring is hidden

### DIFF
--- a/packages/core/src/Thumbnail/XDSThumbnail.tsx
+++ b/packages/core/src/Thumbnail/XDSThumbnail.tsx
@@ -153,6 +153,14 @@ const styles = stylex.create({
       },
       ':active': 0.75,
     },
+    outline: {
+      default: null,
+      ':has(:focus-visible)': `2px solid ${colorVars['--color-accent']}`,
+    },
+    outlineOffset: {
+      default: '0',
+      ':has(:focus-visible)': '2px',
+    },
   },
   interactiveButton: {
     all: 'unset',
@@ -160,14 +168,6 @@ const styles = stylex.create({
     display: 'block',
     width: '100%',
     height: '100%',
-    outline: {
-      default: null,
-      ':focus-visible': `2px solid ${colorVars['--color-accent']}`,
-    },
-    outlineOffset: {
-      default: '0',
-      ':focus-visible': '2px',
-    },
     borderRadius: radiusVars['--radius-element'],
     overflow: 'hidden',
   },


### PR DESCRIPTION
Currently XDSThumbnail doesn't show the outline ring when focused

Fix: Move the focus ring from the inner button (:focus-visible) to the imageContainer (:has(:focus-visible)) so it is no longer clipped by the container's overflow: hidden.

verified in storybook:
<img width="312" height="221" alt="image" src="https://github.com/user-attachments/assets/0e0d3534-b5f3-4c09-863b-7a5a429c6508" />
