### PR TITLE
fix(DateInput, DateTimePicker): replace set-state-in-effect with prev-value ref

### DIFF
--- a/packages/core/src/DateInput/XDSDateInput.test.tsx
+++ b/packages/core/src/DateInput/XDSDateInput.test.tsx
@@ -513,4 +513,28 @@ describe('XDSDateInput', () => {
       expect(onChange).toHaveBeenCalledWith(undefined);
     });
   });
+
+  describe('external value changes', () => {
+    it('clears pending input when value changes externally', () => {
+      const onChange = vi.fn();
+      const {rerender} = render(
+        <XDSDateInput label="Date" value="2026-01-15" onChange={onChange} />,
+      );
+
+      const input = screen.getByRole('combobox');
+      expect(input).toHaveValue('January 15, 2026');
+
+      // User starts typing — sets pending input
+      fireEvent.change(input, {target: {value: 'Feb'}});
+      expect(input).toHaveValue('Feb');
+
+      // Value changes externally (e.g. parent resets the date)
+      rerender(
+        <XDSDateInput label="Date" value="2026-03-20" onChange={onChange} />,
+      );
+
+      // Pending input should be cleared, showing the new formatted value
+      expect(input).toHaveValue('March 20, 2026');
+    });
+  });
 });

--- a/packages/core/src/DateInput/XDSDateInput.tsx
+++ b/packages/core/src/DateInput/XDSDateInput.tsx
@@ -4,7 +4,7 @@
 
 /**
  * @file XDSDateInput.tsx
- * @input Uses React, useId, useState, useEffect, useCallback, useRef, XDSField, XDSIcon, XDSCalendar, useXDSPopover
+ * @input Uses React, useId, useState, useCallback, useRef, XDSField, XDSIcon, XDSCalendar, useXDSPopover
  * @output Exports XDSDateInput component, XDSDateInputProps
  * @position Core implementation; consumed by index.ts, tested by XDSDateInput.test.tsx
  *
@@ -20,7 +20,6 @@ import {
   useId,
   useState,
   useCallback,
-  useEffect,
   useRef,
   useOptimistic,
   useTransition,
@@ -327,14 +326,18 @@ export function XDSDateInput({
   // Pending input while user is typing (null = show formatted value)
   const [pendingInput, setPendingInput] = useState<string | null>(null);
 
-  // Clear pending input when value changes externally
-  useEffect(() => {
-    if (value === lastFiredValueRef.current) {
-      return;
+  // Clear pending input when value changes externally (computed during render
+  // via prev-value ref instead of useEffect to avoid an extra render cycle)
+  const prevValueRef = useRef(value);
+  if (value !== prevValueRef.current) {
+    prevValueRef.current = value;
+    if (value !== lastFiredValueRef.current) {
+      lastFiredValueRef.current = undefined;
+      if (pendingInput !== null) {
+        setPendingInput(null);
+      }
     }
-    lastFiredValueRef.current = undefined;
-    setPendingInput(null);
-  }, [value]);
+  }
 
   // Display value: pending input if typing, otherwise formatted value
   const displayValue =

--- a/packages/core/src/DateTimeInput/XDSDateTimeInput.test.tsx
+++ b/packages/core/src/DateTimeInput/XDSDateTimeInput.test.tsx
@@ -370,4 +370,36 @@ describe('XDSDateTimeInput', () => {
       expect(onChange).toHaveBeenCalledWith(undefined);
     });
   });
+
+  describe('external value changes', () => {
+    it('clears pending date input when value changes externally', () => {
+      const onChange = vi.fn();
+      const {rerender} = render(
+        <XDSDateTimeInput
+          label="Meeting"
+          value={'2026-01-15T10:00' as ISODateTimeString}
+          onChange={onChange}
+        />,
+      );
+
+      const dateInput = screen.getByRole('combobox');
+      expect(dateInput).toHaveValue('January 15, 2026');
+
+      // User starts typing a new date
+      fireEvent.change(dateInput, {target: {value: 'Feb'}});
+      expect(dateInput).toHaveValue('Feb');
+
+      // Value changes externally
+      rerender(
+        <XDSDateTimeInput
+          label="Meeting"
+          value={'2026-03-20T10:00' as ISODateTimeString}
+          onChange={onChange}
+        />,
+      );
+
+      // Pending input should be cleared, showing the new formatted date
+      expect(dateInput).toHaveValue('March 20, 2026');
+    });
+  });
 });

--- a/packages/core/src/DateTimeInput/XDSDateTimeInput.tsx
+++ b/packages/core/src/DateTimeInput/XDSDateTimeInput.tsx
@@ -20,7 +20,6 @@ import {
   useId,
   useState,
   useCallback,
-  useEffect,
   useRef,
   useMemo,
   useOptimistic,
@@ -453,13 +452,16 @@ export function XDSDateTimeInput({
   // --- Date input state ---
   const [datePendingInput, setDatePendingInput] = useState<string | null>(null);
 
-  useEffect(() => {
-    if (valueParts.date === lastFiredDateRef.current) {
-      return;
+  const prevDateRef = useRef(valueParts.date);
+  if (valueParts.date !== prevDateRef.current) {
+    prevDateRef.current = valueParts.date;
+    if (valueParts.date !== lastFiredDateRef.current) {
+      lastFiredDateRef.current = undefined;
+      if (datePendingInput !== null) {
+        setDatePendingInput(null);
+      }
     }
-    lastFiredDateRef.current = undefined;
-    setDatePendingInput(null);
-  }, [valueParts.date]);
+  }
 
   const dateDisplayValue =
     datePendingInput !== null

--- a/packages/core/src/PowerSearch/PowerSearchValueEditor.test.tsx
+++ b/packages/core/src/PowerSearch/PowerSearchValueEditor.test.tsx
@@ -42,20 +42,19 @@ beforeAll(() => {
     Object.defineProperty(event, 'newState', {value: 'closed'});
     this.dispatchEvent(event);
   });
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (HTMLElement.prototype as any).matches = function (
+  HTMLElement.prototype.matches = function (
+    this: HTMLElement,
     selector: string,
-  ): boolean {
+  ) {
     if (selector === ':popover-open') {
       return popoverOpenState.get(this) ?? false;
     }
     return originalMatches.call(this, selector);
-  };
+  } as typeof HTMLElement.prototype.matches;
 });
 
 afterAll(() => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (HTMLElement.prototype as any).matches = originalMatches;
+  HTMLElement.prototype.matches = originalMatches;
 });
 
 // Minimal config stub — editors don't use it directly


### PR DESCRIPTION
  ## Summary
  - Replace `useEffect(() => setPendingInput(null), [value])` with a synchronous prev-value ref check during render in both `XDSDateInput` and `XDSDateTimePicker`
  - This avoids an extra render cycle from the set-state-in-effect anti-pattern and is compatible with React Compiler and concurrent mode
  - Remove unused `useEffect` imports from both files

  ## Test plan
  - [x] New test: `XDSDateInput` — clears pending input when value changes externally
  - [x] New test: `XDSDateTimePicker` — clears pending date input when value changes externally
  - [x] All 84 existing tests continue to pass