### PR TITLE
fix(storybook): add tsc --noEmit typecheck and fix 242 type errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,6 +189,10 @@ jobs:
         if: needs.check-scope.outputs.docsite_only != 'true'
         run: pnpm -F @xds/cli typecheck:template-docs
 
+      - name: Typecheck storybook
+        if: needs.check-scope.outputs.docsite_only != 'true'
+        run: pnpm -F @xds/storybook typecheck
+
       - name: Cache Next.js build
         if: needs.check-scope.outputs.docsite_only != 'true' && github.event_name == 'pull_request'
         uses: actions/cache@v5

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "dev": "storybook dev -p 6006",
-    "build": "storybook build -o dist"
+    "build": "storybook build -o dist",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@xds/core": "*",

--- a/apps/storybook/stories/AppShell.stories.tsx
+++ b/apps/storybook/stories/AppShell.stories.tsx
@@ -237,15 +237,10 @@ const meta: Meta<typeof XDSAppShell> = {
       control: 'radio',
       options: ['fill', 'auto'],
     },
-    defaultIsSideNavCollapsed: {
-      control: 'boolean',
-      description: 'Whether the side nav starts collapsed',
-    },
-
-    background: {
+    variant: {
       control: 'radio',
-      options: ['surface', 'wash'],
-      description: 'Background color of the shell',
+      options: ['wash', 'surface', 'section', 'elevated'],
+      description: 'Navigation background style',
     },
   },
 };
@@ -262,22 +257,12 @@ type Story = StoryObj<typeof XDSAppShell>;
  * When top nav is turned off, the side nav automatically shows a header
  * with the app title since there's no top bar to display it.
  */
-export const Playground: StoryObj<
-  typeof XDSAppShell & {showTopNav: boolean; showSideNav: boolean}
-> = {
+export const Playground: StoryObj<typeof XDSAppShell> = {
   argTypes: {
-    showTopNav: {
-      control: 'boolean',
-      description: 'Show the top navigation bar',
-    },
-    showSideNav: {
-      control: 'boolean',
-      description: 'Show the side navigation',
-    },
-    background: {
+    variant: {
       control: 'radio',
-      options: ['surface', 'wash'],
-      description: 'Background color of the shell',
+      options: ['wash', 'surface', 'section', 'elevated'],
+      description: 'Navigation background style',
     },
     height: {
       control: 'radio',
@@ -285,31 +270,16 @@ export const Playground: StoryObj<
     },
   },
   args: {
-    showTopNav: true,
-    showSideNav: true,
-    background: 'wash',
+    variant: 'elevated',
     height: 'fill',
   },
-  render: function PlaygroundStory(args: {
-    showTopNav: boolean;
-    showSideNav: boolean;
-    background: 'surface' | 'wash';
-    height: 'fill' | 'auto';
-  }) {
+  render: function PlaygroundStory(args) {
     return (
       <XDSAppShell
         contentPadding={6}
-        topNav={args.showTopNav ? <AppTopNav /> : undefined}
-        sideNav={
-          args.showSideNav ? (
-            args.showTopNav ? (
-              <SideNavWithoutHeader />
-            ) : (
-              <SideNavWithHeader />
-            )
-          ) : undefined
-        }
-        background={args.background}
+        topNav={<AppTopNav />}
+        sideNav={<SideNavWithoutHeader />}
+        variant={args.variant}
         height={args.height}>
         <MockContent />
       </XDSAppShell>
@@ -461,7 +431,7 @@ export const FullFeatured: Story = {
       banner={
         <XDSBanner
           status="info"
-          variant="section"
+          container="section"
           title="System maintenance scheduled"
           description="The system will undergo maintenance tonight at 10pm UTC."
           isDismissable
@@ -491,13 +461,12 @@ export const AutoHeight: Story = {
 /**
  * Controlled collapse with external state.
  *
- * The toggle button lives in the TopNav but the collapse state lives in
- * AppShell. Pass `isSideNavCollapsed` and `onSideNavCollapsedChange` to
- * control the sidebar programmatically.
+ * The toggle button lives in the TopNav. The sidebar auto-collapses
+ * at the configured breakpoint. AppShell handles collapse and mobile
+ * overlay internally based on viewport size.
  */
 export const ControlledCollapse: Story = {
   render: function ControlledCollapseStory() {
-    const [collapsed, setCollapsed] = useState(false);
     return (
       <XDSAppShell
         contentPadding={6}
@@ -510,15 +479,12 @@ export const ControlledCollapse: Story = {
                 label="Toggle sidebar"
                 variant="ghost"
                 icon={<Bars3Icon style={{width: 16, height: 16}} />}
-                onClick={() => setCollapsed(!collapsed)}
                 isIconOnly
               />
             }
           />
         }
-        sideNav={<SideNavWithoutHeader />}
-        isSideNavCollapsed={collapsed}
-        onSideNavCollapsedChange={setCollapsed}>
+        sideNav={<SideNavWithoutHeader />}>
         <MockContent />
       </XDSAppShell>
     );
@@ -550,7 +516,7 @@ export const WithBanner: Story = {
       banner={
         <XDSBanner
           status="info"
-          variant="section"
+          container="section"
           title="System maintenance scheduled"
           description="The system will undergo maintenance tonight at 10pm UTC."
           isDismissable
@@ -679,7 +645,7 @@ export const WithMobileNav: Story = {
           <XDSMobileNav
             isOpen={mobileNavOpen}
             onOpenChange={open => setMobileNavOpen(open)}
-            title="Acme App">
+            header="Acme App">
             {navSections}
           </XDSMobileNav>
         }>

--- a/apps/storybook/stories/AvatarGroup.stories.tsx
+++ b/apps/storybook/stories/AvatarGroup.stories.tsx
@@ -3,6 +3,7 @@ import type {Meta, StoryObj} from '@storybook/react';
 import * as stylex from '@stylexjs/stylex';
 import {XDSAvatarGroup, XDSAvatarGroupOverflow} from '@xds/core/AvatarGroup';
 import {XDSAvatar} from '@xds/core/Avatar';
+import {XDSStatusDot} from '@xds/core/StatusDot';
 import {spacingVars, typographyVars} from '@xds/core/theme/tokens.stylex';
 
 const USERS = [
@@ -102,17 +103,17 @@ export const WithStatusDots: Story = {
       <XDSAvatar
         src="https://i.pravatar.cc/150?img=1"
         name="Alice"
-        statusDot={{color: 'positive'}}
+        status={<XDSStatusDot variant="success" label="Online" />}
       />
       <XDSAvatar
         src="https://i.pravatar.cc/150?img=2"
         name="Bob"
-        statusDot={{color: 'warning'}}
+        status={<XDSStatusDot variant="warning" label="Away" />}
       />
       <XDSAvatar
         src="https://i.pravatar.cc/150?img=3"
         name="Charlie"
-        statusDot={{color: 'negative'}}
+        status={<XDSStatusDot variant="error" label="Offline" />}
       />
     </XDSAvatarGroup>
   ),

--- a/apps/storybook/stories/Button.stories.tsx
+++ b/apps/storybook/stories/Button.stories.tsx
@@ -1,9 +1,16 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 import type {Meta, StoryObj} from '@storybook/react';
+import * as stylex from '@stylexjs/stylex';
 import {XDSButton} from '@xds/core/Button';
 import {XDSBadge} from '@xds/core/Badge';
 import {Cog6ToothIcon, TrashIcon} from '@heroicons/react/24/outline';
+
+const buttonStoryStyles = stylex.create({
+  fullWidth: {
+    width: '100%',
+  },
+});
 
 const meta: Meta<typeof XDSButton> = {
   title: 'Core/Buttons/Button',
@@ -332,7 +339,7 @@ export const Truncation: Story = {
             <XDSButton
               label="Submit this extremely long form action"
               variant="primary"
-              xstyle={{width: '100%'}}
+              xstyle={buttonStoryStyles.fullWidth}
             />
           </div>
           <XDSButton label="Cancel" variant="secondary" />

--- a/apps/storybook/stories/ChartV2Advanced.stories.tsx
+++ b/apps/storybook/stories/ChartV2Advanced.stories.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 import type {Meta, StoryObj} from '@storybook/react';
-import {useMemo, useRef, useEffect} from 'react';
+import {useMemo, useRef, useEffect, type MutableRefObject} from 'react';
 import {
   XDSChartV2 as XDSChart,
   bar,
@@ -13,6 +13,7 @@ import {
   dotGL,
   heatmapGL,
   streamGL,
+  type StreamGLHandle,
 } from '@xds/lab';
 import {XDSChartGrid, XDSChartAxis} from '@xds/lab';
 
@@ -32,7 +33,8 @@ const stockData = Array.from({length: 30}, (_, i) => {
     day: `Day ${i + 1}`,
     open: Math.round(open * 10) / 10,
     close: Math.round(close * 10) / 10,
-    high: Math.round(Math.max(open, close, base + Math.random() * 10) * 10) / 10,
+    high:
+      Math.round(Math.max(open, close, base + Math.random() * 10) * 10) / 10,
     low: Math.round(Math.min(open, close, base - Math.random() * 10) * 10) / 10,
     volume: Math.round(500 + Math.random() * 1000),
   };
@@ -60,7 +62,7 @@ const salesData = [
   {month: 'Jun', sales: 70, target: 50, errorHigh: 76, errorLow: 64},
 ];
 
-const scatterData = Array.from({length: 200}, (_) => ({
+const scatterData = Array.from({length: 200}, _ => ({
   x: Math.random() * 100,
   y: Math.random() * 100,
 }));
@@ -73,7 +75,10 @@ for (const day of days) {
       hour: `${hour}`,
       day,
       traffic: Math.round(
-        50 + Math.sin(hour / 4) * 30 + (day === 'Sat' || day === 'Sun' ? -20 : 10) + Math.random() * 20,
+        50 +
+          Math.sin(hour / 4) * 30 +
+          (day === 'Sat' || day === 'Sun' ? -20 : 10) +
+          Math.random() * 20,
       ),
     });
   }
@@ -88,10 +93,22 @@ export const Candlestick: StoryObj = {
       data={stockData}
       xKey="day"
       series={[
-        candlestick({open: 'open', high: 'high', low: 'low', close: 'close', upColor: '#22c55e', downColor: '#ef4444'}),
+        candlestick({
+          open: 'open',
+          high: 'high',
+          low: 'low',
+          close: 'close',
+          upColor: '#22c55e',
+          downColor: '#ef4444',
+        }),
       ]}
       grid={<XDSChartGrid horizontal />}
-      axes={<><XDSChartAxis position="bottom" /><XDSChartAxis position="left" /></>}
+      axes={
+        <>
+          <XDSChartAxis position="bottom" />
+          <XDSChartAxis position="left" />
+        </>
+      }
       height={350}
     />
   ),
@@ -105,7 +122,20 @@ export const FinancialComposite: StoryObj = {
       let sum = 0;
       return stockData.map((d, i) => {
         sum += d.close;
-        return {...d, ma5: i >= 4 ? Math.round((sum - stockData.slice(0, i - 4).reduce((s, v) => s + v.close, 0)) / 5 * 10) / 10 : undefined};
+        return {
+          ...d,
+          ma5:
+            i >= 4
+              ? Math.round(
+                  ((sum -
+                    stockData
+                      .slice(0, i - 4)
+                      .reduce((s, v) => s + v.close, 0)) /
+                    5) *
+                    10,
+                ) / 10
+              : undefined,
+        };
       });
     }, []);
     return (
@@ -113,12 +143,24 @@ export const FinancialComposite: StoryObj = {
         data={data}
         xKey="day"
         series={[
-          candlestick({open: 'open', high: 'high', low: 'low', close: 'close', upColor: '#22c55e', downColor: '#ef4444'}),
+          candlestick({
+            open: 'open',
+            high: 'high',
+            low: 'low',
+            close: 'close',
+            upColor: '#22c55e',
+            downColor: '#ef4444',
+          }),
           line('ma5', {color: '#f59e0b', strokeWidth: 1.5}),
           bar('volume', {color: '#94a3b8', opacity: 0.3}),
         ]}
         grid={<XDSChartGrid horizontal />}
-        axes={<><XDSChartAxis position="bottom" /><XDSChartAxis position="left" /></>}
+        axes={
+          <>
+            <XDSChartAxis position="bottom" />
+            <XDSChartAxis position="left" />
+          </>
+        }
         height={400}
       />
     );
@@ -132,12 +174,27 @@ export const ConfidenceBands: StoryObj = {
       data={predictionData}
       xKey="x"
       series={[
-        band({upper: 'upper95', lower: 'lower95', color: '#3b82f6', opacity: 0.1}),
-        band({upper: 'upper80', lower: 'lower80', color: '#3b82f6', opacity: 0.2}),
+        band({
+          upper: 'upper95',
+          lower: 'lower95',
+          color: '#3b82f6',
+          opacity: 0.1,
+        }),
+        band({
+          upper: 'upper80',
+          lower: 'lower80',
+          color: '#3b82f6',
+          opacity: 0.2,
+        }),
         line('mean', {color: '#3b82f6', strokeWidth: 2}),
       ]}
       grid={<XDSChartGrid horizontal />}
-      axes={<><XDSChartAxis position="bottom" /><XDSChartAxis position="left" /></>}
+      axes={
+        <>
+          <XDSChartAxis position="bottom" />
+          <XDSChartAxis position="left" />
+        </>
+      }
       height={300}
     />
   ),
@@ -154,10 +211,21 @@ export const ErrorBarsWithTarget: StoryObj = {
         bar('sales', {color: '#3b82f6'}),
         errorBar({high: 'errorHigh', low: 'errorLow', color: '#1e3a5f'}),
         referenceLine({y: 50, label: 'Target', color: '#ef4444'}),
-        referenceLine({y: 40, y2: 60, label: 'Acceptable', color: '#22c55e', opacity: 0.1}),
+        referenceLine({
+          y: 40,
+          y2: 60,
+          label: 'Acceptable',
+          color: '#22c55e',
+          bandOpacity: 0.1,
+        }),
       ]}
       grid={<XDSChartGrid horizontal />}
-      axes={<><XDSChartAxis position="bottom" /><XDSChartAxis position="left" /></>}
+      axes={
+        <>
+          <XDSChartAxis position="bottom" />
+          <XDSChartAxis position="left" />
+        </>
+      }
       height={300}
     />
   ),
@@ -172,7 +240,12 @@ export const WebGLScatter: StoryObj = {
       xKey="x"
       series={[dotGL('y', {color: '#3b82f6', size: 4})]}
       grid={<XDSChartGrid horizontal vertical />}
-      axes={<><XDSChartAxis position="bottom" /><XDSChartAxis position="left" /></>}
+      axes={
+        <>
+          <XDSChartAxis position="bottom" />
+          <XDSChartAxis position="left" />
+        </>
+      }
       height={400}
     />
   ),
@@ -186,9 +259,19 @@ export const WebGLHeatmap: StoryObj = {
       data={heatmapData}
       xKey="hour"
       series={[
-        heatmapGL({xKey: 'hour', yKey: 'day', valueKey: 'traffic', colorRange: ['#eff6ff', '#1e40af']}),
+        heatmapGL({
+          xKey: 'hour',
+          yKey: 'day',
+          valueKey: 'traffic',
+          colorRange: ['#eff6ff', '#1e40af'],
+        }),
       ]}
-      axes={<><XDSChartAxis position="bottom" /><XDSChartAxis position="left" /></>}
+      axes={
+        <>
+          <XDSChartAxis position="bottom" />
+          <XDSChartAxis position="left" />
+        </>
+      }
       height={280}
     />
   ),
@@ -198,11 +281,16 @@ export const WebGLHeatmap: StoryObj = {
 export const StreamingLine: StoryObj = {
   name: 'Streaming (streamGL)',
   render: () => {
-    const handleRef = useRef<{push: (point: {x: number; y: number}) => void}>(null);
+    const handleRef = useRef<StreamGLHandle | null>(
+      null,
+    ) as MutableRefObject<StreamGLHandle | null>;
     useEffect(() => {
       let t = 0;
       const interval = setInterval(() => {
-        handleRef.current?.push({x: t, y: 50 + Math.sin(t / 10) * 30 + Math.random() * 10});
+        handleRef.current?.push(
+          t,
+          50 + Math.sin(t / 10) * 30 + Math.random() * 10,
+        );
         t++;
       }, 200);
       return () => clearInterval(interval);
@@ -212,9 +300,14 @@ export const StreamingLine: StoryObj = {
       <XDSChart
         data={[]}
         xKey="x"
-        series={[streamGL('y', {handleRef, window: 60000, color: '#3b82f6'})]}
+        series={[streamGL({handleRef, color: '#3b82f6'})]}
         grid={<XDSChartGrid horizontal />}
-        axes={<><XDSChartAxis position="bottom" /><XDSChartAxis position="left" /></>}
+        axes={
+          <>
+            <XDSChartAxis position="bottom" />
+            <XDSChartAxis position="left" />
+          </>
+        }
         height={300}
       />
     );
@@ -227,24 +320,45 @@ export const KitchenSink: StoryObj = {
   render: () => {
     const data = salesData.map((d, i, arr) => ({
       ...d,
-      runAvg: Math.round(arr.slice(0, i + 1).reduce((s, v) => s + v.sales, 0) / (i + 1) * 10) / 10,
-      upper: Math.round((arr.slice(0, i + 1).reduce((s, v) => s + v.sales, 0) / (i + 1) + 8) * 10) / 10,
-      lower: Math.round((arr.slice(0, i + 1).reduce((s, v) => s + v.sales, 0) / (i + 1) - 8) * 10) / 10,
+      runAvg:
+        Math.round(
+          (arr.slice(0, i + 1).reduce((s, v) => s + v.sales, 0) / (i + 1)) * 10,
+        ) / 10,
+      upper:
+        Math.round(
+          (arr.slice(0, i + 1).reduce((s, v) => s + v.sales, 0) / (i + 1) + 8) *
+            10,
+        ) / 10,
+      lower:
+        Math.round(
+          (arr.slice(0, i + 1).reduce((s, v) => s + v.sales, 0) / (i + 1) - 8) *
+            10,
+        ) / 10,
     }));
     return (
       <XDSChart
         data={data}
         xKey="month"
         series={[
-          referenceLine({y: 40, y2: 60, color: '#22c55e', opacity: 0.08}),
+          referenceLine({y: 40, y2: 60, color: '#22c55e', bandOpacity: 0.08}),
           referenceLine({y: 50, label: 'Target', color: '#ef4444'}),
-          band({upper: 'upper', lower: 'lower', color: '#f59e0b', opacity: 0.15}),
+          band({
+            upper: 'upper',
+            lower: 'lower',
+            color: '#f59e0b',
+            opacity: 0.15,
+          }),
           bar('sales', {color: '#3b82f6'}),
           errorBar({high: 'errorHigh', low: 'errorLow', color: '#1e3a5f'}),
           line('runAvg', {color: '#f59e0b', strokeWidth: 2}),
         ]}
         grid={<XDSChartGrid horizontal />}
-        axes={<><XDSChartAxis position="bottom" /><XDSChartAxis position="left" /></>}
+        axes={
+          <>
+            <XDSChartAxis position="bottom" />
+            <XDSChartAxis position="left" />
+          </>
+        }
         height={400}
       />
     );

--- a/apps/storybook/stories/ChatLayout.stories.tsx
+++ b/apps/storybook/stories/ChatLayout.stories.tsx
@@ -514,7 +514,10 @@ export const FullAIChat: StoryObj = {
                         <XDSChatMessageMetadata
                           timestamp={
                             <XDSTimestamp
-                              value={msg.sentAt ?? new Date(msg.id)}
+                              value={
+                                msg.sentAt?.toISOString() ??
+                                new Date(msg.id).toISOString()
+                              }
                               format="time"
                             />
                           }
@@ -555,7 +558,10 @@ export const FullAIChat: StoryObj = {
                   {!msg.isStreaming && msg.text && (
                     <XDSChatMessageMetadata
                       timestamp={
-                        <XDSTimestamp value={new Date(msg.id)} format="time" />
+                        <XDSTimestamp
+                          value={new Date(msg.id).toISOString()}
+                          format="time"
+                        />
                       }
                       footer={
                         <>

--- a/apps/storybook/stories/CheckboxInput.stories.tsx
+++ b/apps/storybook/stories/CheckboxInput.stories.tsx
@@ -320,7 +320,7 @@ export const WithStartIcon: Story = {
   args: {
     label: 'Enable notifications',
     description: 'Receive alerts when important events occur',
-    startIcon: BellIcon,
+    labelIcon: BellIcon,
   },
 };
 

--- a/apps/storybook/stories/Code.stories.tsx
+++ b/apps/storybook/stories/Code.stories.tsx
@@ -42,7 +42,7 @@ export const InParagraph: Story = {
 export const InstructionalParagraph: Story = {
   name: 'Instructional text',
   render: () => (
-    <XDSStack gap="md">
+    <XDSStack gap={3}>
       <XDSText type="body">
         Install the package with <XDSCode>npm install @xds/core</XDSCode>, then
         import the component:
@@ -74,7 +74,7 @@ export const MixedInline: Story = {
 export const VariousContent: Story = {
   name: 'Various code content',
   render: () => (
-    <XDSStack gap="sm">
+    <XDSStack gap={2}>
       <XDSText type="body">
         Variable: <XDSCode>const count = 0</XDSCode>
       </XDSText>
@@ -97,14 +97,14 @@ export const VariousContent: Story = {
 export const TextSizes: Story = {
   name: 'Across text sizes',
   render: () => (
-    <XDSStack gap="sm">
-      <XDSText type="heading3">
+    <XDSStack gap={2}>
+      <XDSText type="large">
         Heading with <XDSCode>inline code</XDSCode>
       </XDSText>
       <XDSText type="body">
         Body text with <XDSCode>inline code</XDSCode>
       </XDSText>
-      <XDSText type="detail">
+      <XDSText type="supporting">
         Detail text with <XDSCode>inline code</XDSCode>
       </XDSText>
       <XDSText type="label">

--- a/apps/storybook/stories/CommandPalette.stories.tsx
+++ b/apps/storybook/stories/CommandPalette.stories.tsx
@@ -18,6 +18,7 @@ import {XDSButton} from '@xds/core/Button';
 import {XDSIcon} from '@xds/core/Icon';
 import {createStaticSource} from '@xds/core/Typeahead';
 import type {XDSSearchSource, XDSSearchableItem} from '@xds/core/Typeahead';
+import type {XDSIconName} from '@xds/core/Icon';
 
 const meta: Meta<typeof XDSCommandPalette> = {
   title: 'Core/CommandPalette',
@@ -107,7 +108,7 @@ export const AutoGrouped: Story = {
 // ─── Custom rendering via renderItem ─────────────────────────────────────────
 
 type RichCommand = XDSSearchableItem<{
-  icon?: string;
+  icon?: XDSIconName;
   group?: string;
   shortcut?: string;
   keywords?: string[];
@@ -124,17 +125,17 @@ export const WithRenderItem: Story = {
       {
         id: 'dashboard',
         label: 'Go to Dashboard',
-        auxiliaryData: {icon: 'home', group: 'Navigation'},
+        auxiliaryData: {icon: 'menu', group: 'Navigation'},
       },
       {
         id: 'settings',
         label: 'Open Settings',
-        auxiliaryData: {icon: 'settings', group: 'Navigation', shortcut: '⌘,'},
+        auxiliaryData: {icon: 'wrench', group: 'Navigation', shortcut: '⌘,'},
       },
       {
         id: 'profile',
         label: 'View Profile',
-        auxiliaryData: {icon: 'user', group: 'Navigation'},
+        auxiliaryData: {icon: 'info', group: 'Navigation'},
       },
       {
         id: 'dark-mode',
@@ -233,15 +234,15 @@ export const Picker: Story = {
 export const AsyncSearch: Story = {
   render: function Render() {
     const [isOpen, setIsOpen] = useState(false);
-    const source = useMemo<XDSSearchSource>(
-      () => ({
-        _controller: null as AbortController | null,
+    const source = useMemo<XDSSearchSource>(() => {
+      let controller: AbortController | null = null;
+      return {
         cancel() {
-          this._controller?.abort();
+          controller?.abort();
         },
         async search(query: string) {
-          this.cancel();
-          this._controller = new AbortController();
+          controller?.abort();
+          controller = new AbortController();
           await new Promise(r => setTimeout(r, 400));
           const all = [
             {id: 'readme', label: 'README.md'},
@@ -257,9 +258,8 @@ export const AsyncSearch: Story = {
         bootstrap() {
           return [];
         },
-      }),
-      [],
-    );
+      };
+    }, []);
     return (
       <>
         <XDSButton label="Open File Search" onClick={() => setIsOpen(true)} />

--- a/apps/storybook/stories/DateInput.stories.tsx
+++ b/apps/storybook/stories/DateInput.stories.tsx
@@ -325,7 +325,7 @@ export const AllVariations: Story = {
 
 export const Clearable: Story = {
   render: args => {
-    const [value, setValue] = useState<string | undefined>('2026-04-06');
+    const [value, setValue] = useState<ISODateString | undefined>('2026-04-06');
     return (
       <XDSDateInput {...args} value={value} onChange={setValue} hasClear />
     );
@@ -338,7 +338,7 @@ export const Clearable: Story = {
 
 export const ClearableWithStatus: Story = {
   render: args => {
-    const [value, setValue] = useState<string | undefined>('2026-04-06');
+    const [value, setValue] = useState<ISODateString | undefined>('2026-04-06');
     return (
       <XDSDateInput {...args} value={value} onChange={setValue} hasClear />
     );

--- a/apps/storybook/stories/FormLayout.stories.tsx
+++ b/apps/storybook/stories/FormLayout.stories.tsx
@@ -233,7 +233,7 @@ export const InDialog: Story = {
     return (
       <div {...stylex.props(dialogStyles.container)}>
         <div {...stylex.props(dialogStyles.header)}>
-          <XDSText variant="subtitle">Edit Profile</XDSText>
+          <XDSText type="label">Edit Profile</XDSText>
         </div>
         <div {...stylex.props(dialogStyles.body)}>
           <form

--- a/apps/storybook/stories/Grid.stories.tsx
+++ b/apps/storybook/stories/Grid.stories.tsx
@@ -163,7 +163,9 @@ export const ResponsiveAutoFit: Story = {
     <XDSVStack gap={6}>
       <div {...stylex.props(styles.container)}>
         <XDSText type="supporting" xstyle={styles.sectionLabel}>
-          columns={{minWidth: 200}} with 2 items — cards stretch to fill (auto-fit)
+          {
+            'columns={{minWidth: 200}} with 2 items — cards stretch to fill (auto-fit)'
+          }
         </XDSText>
         <XDSGrid columns={{minWidth: 200}} gap={4}>
           <GridItem>Item 1</GridItem>

--- a/apps/storybook/stories/Layout.stories.tsx
+++ b/apps/storybook/stories/Layout.stories.tsx
@@ -121,7 +121,7 @@ const styles = stylex.create({
   // contentWidth demo containers
   cwContainer: {
     border: '2px dashed',
-    borderColor: colorVars['--color-border-default'],
+    borderColor: colorVars['--color-border'],
     borderRadius: radiusVars['--radius-container'],
     overflow: 'hidden',
   },
@@ -202,23 +202,25 @@ type Story = StoryObj<typeof XDSLayout>;
 // Interactive Playground
 // =============================================================================
 
+type SpacingStep = 0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10;
+
 interface PlaygroundArgs {
   // Card props
   cardWidth: number;
   cardHeight: number;
   // Layout props
-  layoutPadding: number;
+  layoutPadding: SpacingStep;
   // Header props
   showHeader: boolean;
   headerHasDivider: boolean;
-  headerPadding: number;
+  headerPadding: SpacingStep;
   // Content props
-  contentPadding: number;
+  contentPadding: SpacingStep;
   contentIsScrollable: boolean;
   // Footer props
   showFooter: boolean;
   footerHasDivider: boolean;
-  footerPadding: number;
+  footerPadding: SpacingStep;
   // Start panel props
   showStartPanel: boolean;
   startPanelWidth: number;
@@ -1326,7 +1328,7 @@ export const ContentWidthInAppShell: Story = {
         XDSLayout with contentWidth=640 nested inside an XDSAppShell
       </p>
       <div {...stylex.props(styles.cwContainer, styles.cwContainer900)}>
-        <XDSAppShell height={400}>
+        <XDSAppShell height="auto">
           <XDSLayout
             contentWidth={640}
             defaultHasDividers

--- a/apps/storybook/stories/List.stories.tsx
+++ b/apps/storybook/stories/List.stories.tsx
@@ -235,13 +235,13 @@ function ToggleHeaderDemo() {
             alignItems: 'center',
             justifyContent: 'space-between',
           }}>
-          <XDSText variant="label" size="large">
+          <XDSText type="label" size="lg">
             Notifications
           </XDSText>
           <XDSSwitch
             label="Show archived"
-            isSelected={showArchived}
-            onChange={setShowArchived}
+            value={showArchived}
+            onChange={checked => setShowArchived(checked)}
           />
         </div>
       }>
@@ -289,7 +289,7 @@ export const HeaderInFlexParent: Story = {
         padding: 16,
       }}>
       <div style={{flex: 1}}>
-        <XDSText variant="label" size="large">
+        <XDSText type="label" size="lg">
           Sidebar
         </XDSText>
       </div>

--- a/apps/storybook/stories/MobileNav.stories.tsx
+++ b/apps/storybook/stories/MobileNav.stories.tsx
@@ -61,7 +61,7 @@ export const Default: Story = {
         <XDSMobileNav
           isOpen={isOpen}
           onOpenChange={open => setIsOpen(open)}
-          title="Navigation">
+          header="Navigation">
           <XDSSideNavSection title="Main">
             <XDSSideNavItem
               label="Dashboard"
@@ -143,7 +143,7 @@ export const WithSideNavChildren: Story = {
         <XDSMobileNav
           isOpen={isOpen}
           onOpenChange={open => setIsOpen(open)}
-          title="My App">
+          header="My App">
           {navSections}
         </XDSMobileNav>
       </>
@@ -207,7 +207,7 @@ export const ResponsivePattern: Story = {
           <XDSMobileNav
             isOpen={drawerOpen}
             onOpenChange={open => setDrawerOpen(open)}
-            title="My App">
+            header="My App">
             {navSections}
           </XDSMobileNav>
         </>
@@ -249,7 +249,7 @@ export const EndSide: Story = {
         <XDSMobileNav
           isOpen={isOpen}
           onOpenChange={open => setIsOpen(open)}
-          title="Settings"
+          header="Settings"
           side="end">
           <XDSSideNavSection title="Settings">
             <XDSSideNavItem
@@ -279,7 +279,7 @@ export const CustomWidth: Story = {
         <XDSMobileNav
           isOpen={isOpen}
           onOpenChange={open => setIsOpen(open)}
-          title="Wide Navigation"
+          header="Wide Navigation"
           width={360}>
           <XDSSideNavSection title="Main">
             <XDSSideNavItem

--- a/apps/storybook/stories/MoreMenu.stories.tsx
+++ b/apps/storybook/stories/MoreMenu.stories.tsx
@@ -258,11 +258,8 @@ export const CustomItemRendering: Story = {
         {label: 'Alice Johnson', onClick: () => console.log('Alice')},
         {label: 'Bob Smith', onClick: () => console.log('Bob')},
         {label: 'Carol Williams', onClick: () => console.log('Carol')},
-      ]}>
-      {item => (
-        <XDSDropdownMenuItem label={item.label} description="Team member" />
-      )}
-    </XDSMoreMenu>
+      ]}
+    />
   ),
 };
 

--- a/apps/storybook/stories/NumberInput.stories.tsx
+++ b/apps/storybook/stories/NumberInput.stories.tsx
@@ -55,7 +55,7 @@ const meta: Meta<typeof XDSNumberInput> = {
       description:
         'Status indicator with type (warning/error/success) and optional message',
     },
-    tooltip: {
+    labelTooltip: {
       control: 'text',
       description:
         'Tooltip text to display in an info icon at the end of the label',
@@ -452,7 +452,7 @@ export const WithTooltip: Story = {
   args: {
     label: 'API Rate Limit',
     placeholder: 'Enter rate limit',
-    tooltip: 'Maximum number of API requests per minute',
+    labelTooltip: 'Maximum number of API requests per minute',
   },
 };
 
@@ -483,7 +483,9 @@ export const WithEventHandlers: Story = {
     return (
       <div style={{maxWidth: '300px'}}>
         <XDSNumberInput
-          {...args}
+          label={args.label}
+          placeholder={args.placeholder}
+          description={args.description}
           value={value}
           onChange={v => {
             setValue(v);

--- a/apps/storybook/stories/Pagination.stories.tsx
+++ b/apps/storybook/stories/Pagination.stories.tsx
@@ -38,7 +38,9 @@ export default meta;
 type Story = StoryObj<typeof XDSPagination>;
 
 // Interactive wrapper for controlled state
-function PaginationDemo(props: React.ComponentProps<typeof XDSPagination>) {
+function PaginationDemo(
+  props: Omit<React.ComponentProps<typeof XDSPagination>, 'onChange'>,
+) {
   const [page, setPage] = useState(props.page ?? 1);
   const [pageSize, setPageSize] = useState(props.pageSize ?? 10);
   return (

--- a/apps/storybook/stories/PowerSearch.stories.tsx
+++ b/apps/storybook/stories/PowerSearch.stories.tsx
@@ -715,7 +715,7 @@ export const WithOnChangeTracking: Story = {
           {...args}
           config={basicConfig}
           filters={filters}
-          onChange={(newFilters, _changeType, _index) => {
+          onChange={(newFilters, changeType, index) => {
             setFilters([...newFilters]);
             setLog(prev => [
               ...prev,
@@ -1136,7 +1136,7 @@ function StatusToken({
   filter,
   field,
   operator,
-  _maxLength,
+  maxLength: _maxLength,
   onClick,
   onRemove,
   isDisabled,
@@ -1172,12 +1172,12 @@ function StatusToken({
 }
 
 function CustomIntegerEditor({
-  _config,
+  config: _config,
   filter,
-  _mode,
+  mode: _mode,
   onSave,
   onCancel,
-  _saveButtonLabel,
+  saveButtonLabel: _saveButtonLabel,
   isReadOnly,
 }: PowerSearchEditorProps) {
   const current = filter.value?.type === 'integer' ? filter.value.value : 50;

--- a/apps/storybook/stories/ProgressBar.stories.tsx
+++ b/apps/storybook/stories/ProgressBar.stories.tsx
@@ -25,9 +25,6 @@ const meta: Meta<typeof XDSProgressBar> = {
       options: ['accent', 'success', 'warning', 'error'],
       description: 'Semantic color variant',
     },
-    size: {
-      table: {disable: true},
-    },
     isLabelHidden: {
       control: 'boolean',
       description: 'Visually hide the label',

--- a/apps/storybook/stories/Resizable.stories.tsx
+++ b/apps/storybook/stories/Resizable.stories.tsx
@@ -59,7 +59,7 @@ export const HorizontalSplit: Story = {
           start={
             <>
               <XDSLayoutPanel width={sidebar.size} hasDivider={false}>
-                <XDSStack gap="space2">
+                <XDSStack gap={2}>
                   <XDSHeading level={4}>Sidebar</XDSHeading>
                   <XDSText>
                     <span {...stylex.props(ps.sz)}>{sidebar.size}px</span>
@@ -79,7 +79,7 @@ export const HorizontalSplit: Story = {
           }
           content={
             <XDSLayoutContent>
-              <XDSStack gap="space2">
+              <XDSStack gap={2}>
                 <XDSHeading level={4}>Content</XDSHeading>
                 <XDSText>Main content area fills remaining space.</XDSText>
               </XDSStack>
@@ -106,7 +106,7 @@ export const VerticalSplit: Story = {
           header={
             <div style={{height: top.size}}>
               <XDSLayoutPanel padding={4} width="100%">
-                <XDSStack gap="space2">
+                <XDSStack gap={2}>
                   <XDSHeading level={4}>Editor</XDSHeading>
                   <XDSText>
                     <span {...stylex.props(ps.sz)}>{top.size}px</span>
@@ -123,7 +123,7 @@ export const VerticalSplit: Story = {
           }
           content={
             <XDSLayoutContent>
-              <XDSStack gap="space2">
+              <XDSStack gap={2}>
                 <XDSHeading level={4}>Terminal</XDSHeading>
                 <XDSText>Bottom panel fills remaining space.</XDSText>
               </XDSStack>
@@ -152,7 +152,7 @@ export const Collapsible: Story = {
             <>
               {!sidebar.isCollapsed && (
                 <XDSLayoutPanel width={sidebar.size} hasDivider={false}>
-                  <XDSStack gap="space2">
+                  <XDSStack gap={2}>
                     <XDSHeading level={4}>Sidebar</XDSHeading>
                     <XDSText>
                       <span {...stylex.props(ps.sz)}>{sidebar.size}px</span>
@@ -173,7 +173,7 @@ export const Collapsible: Story = {
           }
           content={
             <XDSLayoutContent>
-              <XDSStack gap="space2">
+              <XDSStack gap={2}>
                 <XDSHeading level={4}>Content</XDSHeading>
                 <XDSText>
                   Sidebar is {sidebar.isCollapsed ? 'collapsed' : 'expanded'}.
@@ -214,7 +214,7 @@ export const ThreePanelIDE: Story = {
           start={
             <>
               <XDSLayoutPanel width={explorer.size} hasDivider={false}>
-                <XDSStack gap="space2">
+                <XDSStack gap={2}>
                   <XDSHeading level={4}>Explorer</XDSHeading>
                   <XDSText>
                     <span {...stylex.props(ps.sz)}>{explorer.size}px</span>
@@ -238,7 +238,7 @@ export const ThreePanelIDE: Story = {
                   height: '100%',
                 }}>
                 <div style={{flex: 'none', height: editor.size, padding: 16}}>
-                  <XDSStack gap="space2">
+                  <XDSStack gap={2}>
                     <XDSHeading level={4}>Editor</XDSHeading>
                     <XDSText>
                       <span {...stylex.props(ps.sz)}>{editor.size}px</span>
@@ -283,7 +283,7 @@ export const SnapPoints: Story = {
                 {isRail ? (
                   <XDSText>{'\u2630'}</XDSText>
                 ) : (
-                  <XDSStack gap="space2">
+                  <XDSStack gap={2}>
                     <XDSHeading level={4}>Sidebar</XDSHeading>
                     <XDSText>
                       <span {...stylex.props(ps.sz)}>{sidebar.size}px</span>
@@ -328,7 +328,7 @@ export const HiddenPill: Story = {
           start={
             <>
               <XDSLayoutPanel width={sidebar.size} hasDivider={false}>
-                <XDSStack gap="space2">
+                <XDSStack gap={2}>
                   <XDSHeading level={4}>Sidebar</XDSHeading>
                   <XDSText>
                     <span {...stylex.props(ps.sz)}>{sidebar.size}px</span>
@@ -411,7 +411,7 @@ export const WithXDSLayout: Story = {
                   hasDivider={false}
                   role="navigation"
                   label="Sidebar">
-                  <XDSStack gap="space2">
+                  <XDSStack gap={2}>
                     <XDSHeading level={4}>Navigation</XDSHeading>
                     <XDSText>
                       <span {...stylex.props(ps.sz)}>{sidebar.size}px</span>
@@ -432,7 +432,7 @@ export const WithXDSLayout: Story = {
           }
           content={
             <XDSLayoutContent>
-              <XDSStack gap="space3">
+              <XDSStack gap={3}>
                 <XDSHeading level={3}>Main Content</XDSHeading>
                 <XDSText>
                   XDSLayoutPanel with resizable prop + XDSResizeHandle with
@@ -496,7 +496,7 @@ export const WithAppShell: Story = {
           }
           content={
             <XDSLayoutContent>
-              <XDSStack gap="space3">
+              <XDSStack gap={3}>
                 <XDSHeading level={3}>Dashboard</XDSHeading>
                 <XDSText>
                   <span {...stylex.props(ps.sz)}>{nav.size}px</span>

--- a/apps/storybook/stories/SVGIcon.stories.tsx
+++ b/apps/storybook/stories/SVGIcon.stories.tsx
@@ -18,6 +18,7 @@ import {
   lockIcon,
 } from '@xds/lab';
 import {XDSStack, XDSText, XDSDivider} from '@xds/core';
+import {XDSHeading} from '@xds/core/Text';
 
 const meta: Meta<typeof XDSSVGIcon> = {
   title: 'Lab/SVGIcon',
@@ -85,8 +86,8 @@ const VARIATIONS: SVGIconVariation[] = [
 export const VariationMatrix: Story = {
   render: () => (
     <XDSStack direction="vertical" gap={3}>
-      <XDSText variant="heading-3">Variation Matrix</XDSText>
-      <XDSText variant="body-sm" color="secondary">
+      <XDSHeading level={3}>Variation Matrix</XDSHeading>
+      <XDSText type="supporting" color="secondary">
         Same SVG paths, different visual treatments via CSS custom properties.
         Note how stroke-role elements (menu lines, calendar pegs, bell clapper)
         stay as strokes even in bold/bulk mode.
@@ -103,7 +104,7 @@ export const VariationMatrix: Story = {
         {VARIATIONS.map(v => (
           <XDSText
             key={v}
-            variant="label-sm"
+            type="label"
             color="secondary"
             style={{textAlign: 'center'}}>
             {v}
@@ -113,7 +114,7 @@ export const VariationMatrix: Story = {
         {/* Icon rows */}
         {starterIcons.map(icon => (
           <Fragment key={icon.name}>
-            <XDSText variant="label-sm">{icon.name}</XDSText>
+            <XDSText type="label">{icon.name}</XDSText>
             {VARIATIONS.map(v => (
               <div
                 key={`${icon.name}-${v}`}
@@ -135,22 +136,22 @@ export const VariationMatrix: Story = {
 export const RoleBehavior: Story = {
   render: () => (
     <XDSStack direction="vertical" gap={3}>
-      <XDSText variant="heading-3">Path Roles: Fill vs Stroke</XDSText>
-      <XDSText variant="body-sm" color="secondary">
+      <XDSHeading level={3}>Path Roles: Fill vs Stroke</XDSHeading>
+      <XDSText type="supporting" color="secondary">
         Stroke-role elements always stay as strokes. Fill-role elements switch
         between stroke (linear) and fill (bold). Compare Menu (all stroke-role)
         vs Home (fill-role body + fill-role door with mask knockout).
       </XDSText>
 
       <XDSStack direction="vertical" gap={2}>
-        <XDSText variant="label-sm" color="secondary">
+        <XDSText type="label" color="secondary">
           Menu — all stroke-role (lines never become fills)
         </XDSText>
-        <XDSStack direction="row" gap={3}>
+        <XDSStack direction="horizontal" gap={3}>
           {VARIATIONS.map(v => (
             <XDSStack direction="vertical" key={v} gap={0.5} hAlign="center">
               <XDSSVGIcon icon={menuIcon} variation={v} size="lg" />
-              <XDSText variant="label-sm" color="secondary">
+              <XDSText type="label" color="secondary">
                 {v}
               </XDSText>
             </XDSStack>
@@ -159,14 +160,14 @@ export const RoleBehavior: Story = {
 
         <XDSDivider />
 
-        <XDSText variant="label-sm" color="secondary">
+        <XDSText type="label" color="secondary">
           Home — fill-role body + door (mask gap in bold)
         </XDSText>
-        <XDSStack direction="row" gap={3}>
+        <XDSStack direction="horizontal" gap={3}>
           {VARIATIONS.map(v => (
             <XDSStack direction="vertical" key={v} gap={0.5} hAlign="center">
               <XDSSVGIcon icon={homeIcon} variation={v} size="lg" />
-              <XDSText variant="label-sm" color="secondary">
+              <XDSText type="label" color="secondary">
                 {v}
               </XDSText>
             </XDSStack>
@@ -175,14 +176,14 @@ export const RoleBehavior: Story = {
 
         <XDSDivider />
 
-        <XDSText variant="label-sm" color="secondary">
+        <XDSText type="label" color="secondary">
           Settings — fill-role gear + circle (mask gap in bold)
         </XDSText>
-        <XDSStack direction="row" gap={3}>
+        <XDSStack direction="horizontal" gap={3}>
           {VARIATIONS.map(v => (
             <XDSStack direction="vertical" key={v} gap={0.5} hAlign="center">
               <XDSSVGIcon icon={settingsIcon} variation={v} size="lg" />
-              <XDSText variant="label-sm" color="secondary">
+              <XDSText type="label" color="secondary">
                 {v}
               </XDSText>
             </XDSStack>
@@ -202,17 +203,15 @@ const SIZES: SVGIconSize[] = ['xsm', 'sm', 'md', 'lg'];
 export const SizeScale: Story = {
   render: () => (
     <XDSStack direction="vertical" gap={2}>
-      <XDSText variant="heading-3">
-        Size Scale with Optical Compensation
-      </XDSText>
-      <XDSText variant="body-sm" color="secondary">
+      <XDSHeading level={3}>Size Scale with Optical Compensation</XDSHeading>
+      <XDSText type="supporting" color="secondary">
         Stroke width auto-adjusts at smaller sizes for legibility.
       </XDSText>
-      <XDSStack direction="row" gap={3} vAlign="end">
+      <XDSStack direction="horizontal" gap={3} vAlign="end">
         {SIZES.map(size => (
           <XDSStack direction="vertical" key={size} gap={1} hAlign="center">
             <XDSSVGIcon icon={settingsIcon} variation="linear" size={size} />
-            <XDSText variant="label-sm" color="secondary">
+            <XDSText type="label" color="secondary">
               {size}
             </XDSText>
           </XDSStack>
@@ -239,8 +238,8 @@ const COLORS: SVGIconColor[] = [
 export const Colors: Story = {
   render: () => (
     <XDSStack direction="vertical" gap={2}>
-      <XDSText variant="heading-3">Semantic Colors</XDSText>
-      <XDSStack direction="row" gap={3}>
+      <XDSHeading level={3}>Semantic Colors</XDSHeading>
+      <XDSStack direction="horizontal" gap={3}>
         {COLORS.map(c => (
           <XDSStack direction="vertical" key={c} gap={1} hAlign="center">
             <XDSSVGIcon
@@ -249,7 +248,7 @@ export const Colors: Story = {
               size="lg"
               color={c}
             />
-            <XDSText variant="label-sm" color="secondary">
+            <XDSText type="label" color="secondary">
               {c}
             </XDSText>
           </XDSStack>
@@ -275,8 +274,8 @@ const MASK_GAP_ICONS = [
 export const MaskGaps: Story = {
   render: () => (
     <XDSStack direction="vertical" gap={3}>
-      <XDSText variant="heading-3">Mask Gaps on Different Backgrounds</XDSText>
-      <XDSText variant="body-sm" color="secondary">
+      <XDSHeading level={3}>Mask Gaps on Different Backgrounds</XDSHeading>
+      <XDSText type="supporting" color="secondary">
         Bold mode uses mask-based knockout gaps. Because the gap is transparent
         (not white), it works on any background — solid colors, surfaces, and
         gradients alike.
@@ -292,7 +291,7 @@ export const MaskGaps: Story = {
         },
       ].map(({label, bg}) => (
         <XDSStack direction="vertical" key={label} gap={1}>
-          <XDSText variant="label-sm" color="secondary">
+          <XDSText type="label" color="secondary">
             {label}
           </XDSText>
           <div
@@ -337,8 +336,8 @@ const STROKE_WIDTHS = [1, 1.5, 2, 2.5, 3];
 export const StrokeWidthRange: Story = {
   render: () => (
     <XDSStack direction="vertical" gap={3}>
-      <XDSText variant="heading-3">Stroke Width Range</XDSText>
-      <XDSText variant="body-sm" color="secondary">
+      <XDSHeading level={3}>Stroke Width Range</XDSHeading>
+      <XDSText type="supporting" color="secondary">
         Linear mode at stroke widths from 1 to 3. Thinner strokes feel lighter
         and more refined; thicker strokes add visual weight.
       </XDSText>
@@ -354,7 +353,7 @@ export const StrokeWidthRange: Story = {
         {STROKE_WIDTHS.map(w => (
           <XDSText
             key={w}
-            variant="label-sm"
+            type="label"
             color="secondary"
             style={{textAlign: 'center'}}>
             {w}
@@ -364,7 +363,7 @@ export const StrokeWidthRange: Story = {
         {/* Icon rows — first 8 starterIcons */}
         {starterIcons.slice(0, 8).map(icon => (
           <Fragment key={icon.name}>
-            <XDSText variant="label-sm">{icon.name}</XDSText>
+            <XDSText type="label">{icon.name}</XDSText>
             {STROKE_WIDTHS.map(w => (
               <div
                 key={`${icon.name}-${w}`}
@@ -391,8 +390,8 @@ export const StrokeWidthRange: Story = {
 export const StructuralDiversity: Story = {
   render: () => (
     <XDSStack direction="vertical" gap={3}>
-      <XDSText variant="heading-3">Structural Diversity</XDSText>
-      <XDSText variant="body-sm" color="secondary">
+      <XDSHeading level={3}>Structural Diversity</XDSHeading>
+      <XDSText type="supporting" color="secondary">
         New icons with diverse structures — organic curves, complex single
         paths, nested overlapping fills, and mixed fill+stroke roles — across
         all five variations.
@@ -409,7 +408,7 @@ export const StructuralDiversity: Story = {
         {VARIATIONS.map(v => (
           <XDSText
             key={v}
-            variant="label-sm"
+            type="label"
             color="secondary"
             style={{textAlign: 'center'}}>
             {v}
@@ -419,7 +418,7 @@ export const StructuralDiversity: Story = {
         {/* Icon rows — new icons only */}
         {starterIcons.slice(7).map(icon => (
           <Fragment key={icon.name}>
-            <XDSText variant="label-sm">{icon.name}</XDSText>
+            <XDSText type="label">{icon.name}</XDSText>
             {VARIATIONS.map(v => (
               <div
                 key={`${icon.name}-${v}`}

--- a/apps/storybook/stories/SVGIconRegistry.stories.tsx
+++ b/apps/storybook/stories/SVGIconRegistry.stories.tsx
@@ -1,7 +1,13 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 import type {Meta, StoryObj} from '@storybook/react';
-import {Fragment, type ReactElement, Children, isValidElement} from 'react';
+import {
+  Fragment,
+  type ReactElement,
+  type ReactNode,
+  Children,
+  isValidElement,
+} from 'react';
 import {
   XDSSVGIcon,
   type SVGIconVariation,
@@ -17,32 +23,48 @@ import {defaultIcons} from '../../../packages/core/src/Icon/defaultIcons';
 // =============================================================================
 
 interface BBox {
-  x: number; y: number; width: number; height: number;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
 }
 
 /** Rough bounding box from path d attribute (looks at M/L/C coordinate values) */
 function estimateBBox(attrs: Record<string, string>, type: string): BBox {
   if (type === 'circle') {
-    const cx = Number(attrs.cx || 0), cy = Number(attrs.cy || 0), r = Number(attrs.r || 0);
+    const cx = Number(attrs.cx || 0),
+      cy = Number(attrs.cy || 0),
+      r = Number(attrs.r || 0);
     return {x: cx - r, y: cy - r, width: r * 2, height: r * 2};
   }
   if (type === 'rect') {
     return {
-      x: Number(attrs.x || 0), y: Number(attrs.y || 0),
-      width: Number(attrs.width || 0), height: Number(attrs.height || 0),
+      x: Number(attrs.x || 0),
+      y: Number(attrs.y || 0),
+      width: Number(attrs.width || 0),
+      height: Number(attrs.height || 0),
     };
   }
   // For paths/lines, extract all numbers and find bounds
-  const d = attrs.d || `${attrs.x1 || 0} ${attrs.y1 || 0} ${attrs.x2 || 0} ${attrs.y2 || 0}`;
+  const d =
+    attrs.d ||
+    `${attrs.x1 || 0} ${attrs.y1 || 0} ${attrs.x2 || 0} ${attrs.y2 || 0}`;
   const nums = d.match(/-?[\d.]+/g)?.map(Number) || [];
   if (nums.length < 2) return {x: 0, y: 0, width: 24, height: 24};
-  
-  let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+
+  let minX = Infinity,
+    minY = Infinity,
+    maxX = -Infinity,
+    maxY = -Infinity;
   for (let i = 0; i < nums.length - 1; i += 2) {
-    const x = nums[i], y = nums[i + 1];
-    if (x < 100 && y < 100) { // filter out large numbers that aren't coords
-      minX = Math.min(minX, x); maxX = Math.max(maxX, x);
-      minY = Math.min(minY, y); maxY = Math.max(maxY, y);
+    const x = nums[i],
+      y = nums[i + 1];
+    if (x < 100 && y < 100) {
+      // filter out large numbers that aren't coords
+      minX = Math.min(minX, x);
+      maxX = Math.max(maxX, x);
+      minY = Math.min(minY, y);
+      maxY = Math.max(maxY, y);
     }
   }
   if (!isFinite(minX)) return {x: 0, y: 0, width: 24, height: 24};
@@ -51,9 +73,12 @@ function estimateBBox(attrs: Record<string, string>, type: string): BBox {
 
 /** Check if box A fully contains box B */
 function contains(a: BBox, b: BBox): boolean {
-  return a.x <= b.x && a.y <= b.y && 
-         a.x + a.width >= b.x + b.width && 
-         a.y + a.height >= b.y + b.height;
+  return (
+    a.x <= b.x &&
+    a.y <= b.y &&
+    a.x + a.width >= b.x + b.width &&
+    a.y + a.height >= b.y + b.height
+  );
 }
 
 function bboxArea(b: BBox): number {
@@ -64,32 +89,60 @@ function bboxArea(b: BBox): number {
 // Auto-converter: JSX SVG → SVGIconDef
 // =============================================================================
 
-function jsxSvgToIconDef(name: string, element: ReactElement): SVGIconDef | null {
+function jsxSvgToIconDef(
+  name: string,
+  element: ReactElement,
+): SVGIconDef | null {
   if (!element?.props) return null;
 
-  const children = Children.toArray(element.props.children).filter(isValidElement);
-  const isSolid = element.props.fill === 'currentColor' && !element.props.stroke;
-  
+  const elementProps = element.props as Record<string, unknown>;
+  const children = Children.toArray(elementProps.children as ReactNode).filter(
+    isValidElement,
+  );
+  const isSolid = elementProps.fill === 'currentColor' && !elementProps.stroke;
+
   const shapes: Array<IconShape & {bbox: BBox}> = [];
-  
+
   for (const child of children) {
     if (!isValidElement(child)) continue;
     const type = child.type as string;
-    if (!['path', 'circle', 'rect', 'line', 'polyline', 'polygon'].includes(type)) continue;
-    
-    const {key: _key, children: _, ...rawAttrs} = child.props as Record<string, unknown>;
-    
+    if (
+      !['path', 'circle', 'rect', 'line', 'polyline', 'polygon'].includes(type)
+    )
+      continue;
+
+    const childProps = child.props as Record<string, unknown>;
+    const {key: _key, children: _, ...rawAttrs} = childProps;
+
     // Clean attrs
     const attrs: Record<string, string> = {};
-    const geoAttrs = ['d', 'cx', 'cy', 'r', 'x', 'y', 'width', 'height', 'rx', 'ry', 
-                      'x1', 'y1', 'x2', 'y2', 'points', 'fillRule', 'clipRule'];
+    const geoAttrs = [
+      'd',
+      'cx',
+      'cy',
+      'r',
+      'x',
+      'y',
+      'width',
+      'height',
+      'rx',
+      'ry',
+      'x1',
+      'y1',
+      'x2',
+      'y2',
+      'points',
+      'fillRule',
+      'clipRule',
+    ];
     for (const [k, v] of Object.entries(rawAttrs)) {
       if (geoAttrs.includes(k) && v != null) {
-        const attrName = k === 'fillRule' ? 'fill-rule' : k === 'clipRule' ? 'clip-rule' : k;
+        const attrName =
+          k === 'fillRule' ? 'fill-rule' : k === 'clipRule' ? 'clip-rule' : k;
         attrs[attrName] = String(v);
       }
     }
-    
+
     // Role heuristic
     let role: IconShapeRole = 'stroke';
     if (isSolid) {
@@ -105,18 +158,18 @@ function jsxSvgToIconDef(name: string, element: ReactElement): SVGIconDef | null
         role = 'fill';
       }
     }
-    
+
     const bbox = estimateBBox(attrs, type);
     shapes.push({type: type as IconShape['type'], attrs, role, bbox});
   }
-  
+
   if (shapes.length === 0) return null;
-  
+
   // Layer classification: CONTAINMENT-BASED
   // Only classify as secondary if geometrically contained within a larger shape
   const primary: IconShape[] = [];
   const secondary: IconShape[] = [];
-  
+
   if (shapes.length === 1) {
     primary.push(shapes[0]);
   } else {
@@ -125,16 +178,22 @@ function jsxSvgToIconDef(name: string, element: ReactElement): SVGIconDef | null
     let largestArea = 0;
     shapes.forEach((s, i) => {
       const area = bboxArea(s.bbox);
-      if (area > largestArea) { largestArea = area; largestIdx = i; }
+      if (area > largestArea) {
+        largestArea = area;
+        largestIdx = i;
+      }
     });
-    
+
     const largestBBox = shapes[largestIdx].bbox;
-    
+
     shapes.forEach((s, i) => {
       if (i === largestIdx) {
         // Largest is always primary
         primary.push({type: s.type, attrs: s.attrs, role: s.role});
-      } else if (contains(largestBBox, s.bbox) && bboxArea(s.bbox) < largestArea * 0.5) {
+      } else if (
+        contains(largestBBox, s.bbox) &&
+        bboxArea(s.bbox) < largestArea * 0.5
+      ) {
         // Contained within the largest AND significantly smaller → secondary
         secondary.push({type: s.type, attrs: s.attrs, role: s.role});
       } else {
@@ -143,7 +202,7 @@ function jsxSvgToIconDef(name: string, element: ReactElement): SVGIconDef | null
       }
     });
   }
-  
+
   return {
     name,
     primary,
@@ -160,7 +219,13 @@ const meta: Meta = {
 };
 export default meta;
 
-const VARIATIONS: SVGIconVariation[] = ['linear', 'bold', 'twotone', 'bulk', 'broken'];
+const VARIATIONS: SVGIconVariation[] = [
+  'linear',
+  'bold',
+  'twotone',
+  'bulk',
+  'broken',
+];
 
 export const DefaultRegistryIcons: StoryObj = {
   render: () => {
@@ -172,31 +237,42 @@ export const DefaultRegistryIcons: StoryObj = {
 
     return (
       <XDSStack direction="vertical" gap={3}>
-        <XDSText type="heading-3">Default Registry Icons \u2192 SVGIcon System</XDSText>
-        <XDSText type="supporting">
-          {converted.length} icons auto-converted. Heuristic: containment-based layer classification
-          (only elements fully contained within a larger shape become secondary).
-          Peer elements (same size, not contained) stay primary.
+        <XDSText type="large">
+          Default Registry Icons \u2192 SVGIcon System
         </XDSText>
-        
-        <div style={{
-          display: 'grid',
-          gridTemplateColumns: `130px repeat(${VARIATIONS.length}, 1fr)`,
-          gap: '8px 4px',
-          alignItems: 'center',
-        }}>
+        <XDSText type="supporting">
+          {converted.length} icons auto-converted. Heuristic: containment-based
+          layer classification (only elements fully contained within a larger
+          shape become secondary). Peer elements (same size, not contained) stay
+          primary.
+        </XDSText>
+
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: `130px repeat(${VARIATIONS.length}, 1fr)`,
+            gap: '8px 4px',
+            alignItems: 'center',
+          }}>
           <div />
           {VARIATIONS.map(v => (
-            <XDSText key={v} type="label" style={{textAlign: 'center', fontSize: 10}}>
+            <XDSText
+              key={v}
+              type="label"
+              style={{textAlign: 'center', fontSize: 10}}>
               {v}
             </XDSText>
           ))}
 
           {converted.map(({name, def}) => (
             <Fragment key={name}>
-              <XDSText type="label" style={{fontSize: 11}}>{name}</XDSText>
+              <XDSText type="label" style={{fontSize: 11}}>
+                {name}
+              </XDSText>
               {VARIATIONS.map(v => (
-                <div key={`${name}-${v}`} style={{display: 'flex', justifyContent: 'center'}}>
+                <div
+                  key={`${name}-${v}`}
+                  style={{display: 'flex', justifyContent: 'center'}}>
                   <XDSSVGIcon icon={def} variation={v} size="lg" />
                 </div>
               ))}

--- a/apps/storybook/stories/Selector.stories.tsx
+++ b/apps/storybook/stories/Selector.stories.tsx
@@ -81,16 +81,23 @@ type Story = StoryObj<typeof XDSSelector>;
 // Basic with strings
 export const Default: Story = {
   render: args => {
-    const [value, setValue] = useState<string | undefined>(args.value);
+    const {
+      value: argsValue,
+      onChange: _onChange,
+      changeAction: _ca,
+      hasClear: _hc,
+      ...rest
+    } = args;
+    const [value, setValue] = useState(argsValue ?? undefined);
     return (
       <XDSSelector
-        {...args}
+        {...rest}
         label={args.label ?? 'Fruit'}
         options={
           args.options ?? ['Apple', 'Banana', 'Orange', 'Mango', 'Pineapple']
         }
         value={value}
-        onChange={setValue}
+        onChange={v => setValue(v)}
       />
     );
   },
@@ -102,15 +109,22 @@ export const Default: Story = {
 // With hidden label
 export const HiddenLabel: Story = {
   render: args => {
-    const [value, setValue] = useState<string | undefined>(args.value);
+    const {
+      value: argsValue,
+      onChange: _onChange,
+      changeAction: _ca,
+      hasClear: _hc,
+      ...rest
+    } = args;
+    const [value, setValue] = useState(argsValue ?? undefined);
     return (
       <XDSSelector
-        {...args}
+        {...rest}
         label="Fruit"
         isLabelHidden
         options={['Apple', 'Banana', 'Orange', 'Mango', 'Pineapple']}
         value={value}
-        onChange={setValue}
+        onChange={v => setValue(v)}
         placeholder="Select a fruit..."
       />
     );
@@ -120,15 +134,22 @@ export const HiddenLabel: Story = {
 // With description
 export const WithDescription: Story = {
   render: args => {
-    const [value, setValue] = useState<string | undefined>(args.value);
+    const {
+      value: argsValue,
+      onChange: _onChange,
+      changeAction: _ca,
+      hasClear: _hc,
+      ...rest
+    } = args;
+    const [value, setValue] = useState(argsValue ?? undefined);
     return (
       <XDSSelector
-        {...args}
+        {...rest}
         label="Fruit"
         description="Choose your favorite fruit from the list"
         options={['Apple', 'Banana', 'Orange', 'Mango', 'Pineapple']}
         value={value}
-        onChange={setValue}
+        onChange={v => setValue(v)}
         placeholder="Select a fruit..."
       />
     );
@@ -138,10 +159,17 @@ export const WithDescription: Story = {
 // With objects
 export const WithObjects: Story = {
   render: args => {
-    const [value, setValue] = useState<string | undefined>(args.value);
+    const {
+      value: argsValue,
+      onChange: _onChange,
+      changeAction: _ca,
+      hasClear: _hc,
+      ...rest
+    } = args;
+    const [value, setValue] = useState(argsValue ?? undefined);
     return (
       <XDSSelector
-        {...args}
+        {...rest}
         label="Fruit"
         options={[
           {value: 'apple', label: 'Apple'},
@@ -150,7 +178,7 @@ export const WithObjects: Story = {
           {value: 'mango', label: 'Mango'},
         ]}
         value={value}
-        onChange={setValue}
+        onChange={v => setValue(v)}
       />
     );
   },
@@ -162,10 +190,17 @@ export const WithObjects: Story = {
 // With icons
 export const WithIcons: Story = {
   render: args => {
-    const [value, setValue] = useState<string | undefined>(args.value);
+    const {
+      value: argsValue,
+      onChange: _onChange,
+      changeAction: _ca,
+      hasClear: _hc,
+      ...rest
+    } = args;
+    const [value, setValue] = useState(argsValue ?? undefined);
     return (
       <XDSSelector
-        {...args}
+        {...rest}
         label="Settings"
         options={[
           {value: 'profile', label: 'Profile', icon: UserIcon},
@@ -173,7 +208,7 @@ export const WithIcons: Story = {
           {value: 'notifications', label: 'Notifications', icon: BellIcon},
         ]}
         value={value}
-        onChange={setValue}
+        onChange={v => setValue(v)}
       />
     );
   },
@@ -185,10 +220,17 @@ export const WithIcons: Story = {
 // With sections and dividers
 export const WithSections: Story = {
   render: args => {
-    const [value, setValue] = useState<string | undefined>(args.value);
+    const {
+      value: argsValue,
+      onChange: _onChange,
+      changeAction: _ca,
+      hasClear: _hc,
+      ...rest
+    } = args;
+    const [value, setValue] = useState(argsValue ?? undefined);
     return (
       <XDSSelector
-        {...args}
+        {...rest}
         label="Fruit"
         options={[
           {value: 'apple', label: 'Apple'},
@@ -212,7 +254,7 @@ export const WithSections: Story = {
           },
         ]}
         value={value}
-        onChange={setValue}
+        onChange={v => setValue(v)}
       />
     );
   },
@@ -224,7 +266,14 @@ export const WithSections: Story = {
 // Custom render
 export const CustomRender: Story = {
   render: args => {
-    const [value, setValue] = useState<string | undefined>(args.value);
+    const {
+      value: argsValue,
+      onChange: _onChange,
+      changeAction: _ca,
+      hasClear: _hc,
+      ...rest
+    } = args;
+    const [value, setValue] = useState(argsValue ?? undefined);
     const users = [
       {value: 'user1', label: 'Alice Johnson', email: 'alice@example.com'},
       {value: 'user2', label: 'Bob Smith', email: 'bob@example.com'},
@@ -232,11 +281,11 @@ export const CustomRender: Story = {
     ];
     return (
       <XDSSelector
-        {...args}
+        {...rest}
         label="User"
         options={users}
         value={value}
-        onChange={setValue}
+        onChange={v => setValue(v)}
         placeholder="Select a user...">
         {user => (
           <XDSSelectorOption
@@ -379,14 +428,21 @@ export const Disabled: Story = {
 // Pre-selected
 export const PreSelected: Story = {
   render: args => {
+    const {
+      value: _value,
+      onChange: _onChange,
+      changeAction: _ca,
+      hasClear: _hc,
+      ...rest
+    } = args;
     const [value, setValue] = useState('Banana');
     return (
       <XDSSelector
-        {...args}
+        {...rest}
         label="Fruit"
         options={['Apple', 'Banana', 'Orange', 'Mango']}
         value={value}
-        onChange={setValue}
+        onChange={v => setValue(v)}
       />
     );
   },
@@ -449,13 +505,20 @@ export const AllVariations: Story = {
 
 export const Clearable: Story = {
   render: args => {
+    const {
+      value: _value,
+      onChange: _onChange,
+      changeAction: _changeAction,
+      hasClear: _hc,
+      ...rest
+    } = args;
     const [value, setValue] = useState<string | null>('Banana');
     return (
       <XDSSelector
-        {...args}
+        {...rest}
         options={['Apple', 'Banana', 'Cherry', 'Date']}
         value={value}
-        onChange={setValue}
+        onChange={v => setValue(v)}
         hasClear
       />
     );
@@ -468,13 +531,20 @@ export const Clearable: Story = {
 
 export const ClearableWithStatus: Story = {
   render: args => {
+    const {
+      value: _value,
+      onChange: _onChange,
+      changeAction: _changeAction,
+      hasClear: _hc,
+      ...rest
+    } = args;
     const [value, setValue] = useState<string | null>('Banana');
     return (
       <XDSSelector
-        {...args}
+        {...rest}
         options={['Apple', 'Banana', 'Cherry']}
         value={value}
-        onChange={setValue}
+        onChange={v => setValue(v)}
         hasClear
       />
     );

--- a/apps/storybook/stories/Skeleton.stories.tsx
+++ b/apps/storybook/stories/Skeleton.stories.tsx
@@ -20,7 +20,7 @@ const meta: Meta<typeof XDSSkeleton> = {
     },
     radius: {
       control: 'select',
-      options: ['none', 'inner', 'content', 'element', 'container', 'rounded'],
+      options: ['none', 0, 1, 2, 3, 4, 'rounded'],
       description: 'Border radius using design tokens',
     },
     index: {
@@ -37,7 +37,7 @@ export const Default: Story = {
   args: {
     width: 200,
     height: 20,
-    radius: 'container',
+    radius: 3,
     index: 0,
   },
 };
@@ -46,8 +46,8 @@ export const Shapes: Story = {
   render: () => (
     <XDSHStack gap={4} vAlign="center">
       <XDSSkeleton width={40} height={40} radius="rounded" />
-      <XDSSkeleton width={100} height={20} radius="container" />
-      <XDSSkeleton width={120} height={32} radius="element" />
+      <XDSSkeleton width={100} height={20} radius={3} />
+      <XDSSkeleton width={120} height={32} radius={2} />
       <XDSSkeleton width={80} height={80} radius="none" />
     </XDSHStack>
   ),

--- a/apps/storybook/stories/StatusDot.stories.tsx
+++ b/apps/storybook/stories/StatusDot.stories.tsx
@@ -13,9 +13,6 @@ const meta: Meta<typeof XDSStatusDot> = {
       options: ['success', 'warning', 'error', 'accent', 'neutral'],
       description: 'Semantic color variant',
     },
-    size: {
-      table: {disable: true},
-    },
     label: {
       control: 'text',
       description: 'Accessible label',

--- a/apps/storybook/stories/Stepper.stories.tsx
+++ b/apps/storybook/stories/Stepper.stories.tsx
@@ -156,8 +156,16 @@ export const VerticalWithContent: Story = {
           <XDSStep step={0} label="Account" description="Create your account">
             {activeStep === 0 && (
               <div style={{display: 'flex', flexDirection: 'column', gap: 12}}>
-                <XDSTextInput label="Email" placeholder="you@example.com" />
-                <XDSTextInput label="Password" placeholder="••••••••" />
+                <XDSTextInput
+                  label="Email"
+                  placeholder="you@example.com"
+                  value=""
+                />
+                <XDSTextInput
+                  label="Password"
+                  placeholder="••••••••"
+                  value=""
+                />
                 <div>
                   <XDSButton
                     label="Continue"
@@ -174,9 +182,17 @@ export const VerticalWithContent: Story = {
             description="Tell us about yourself">
             {activeStep === 1 && (
               <div style={{display: 'flex', flexDirection: 'column', gap: 12}}>
-                <XDSTextInput label="Full name" placeholder="Jane Doe" />
-                <XDSTextInput label="Company" placeholder="Acme Inc." />
-                <XDSTextInput label="Role" placeholder="Engineer" />
+                <XDSTextInput
+                  label="Full name"
+                  placeholder="Jane Doe"
+                  value=""
+                />
+                <XDSTextInput
+                  label="Company"
+                  placeholder="Acme Inc."
+                  value=""
+                />
+                <XDSTextInput label="Role" placeholder="Engineer" value="" />
                 <div style={{display: 'flex', gap: 8}}>
                   <XDSButton
                     label="Back"

--- a/apps/storybook/stories/Table.stories.tsx
+++ b/apps/storybook/stories/Table.stories.tsx
@@ -98,7 +98,7 @@ const columns: XDSTableColumn<User>[] = [
 // Meta
 // =============================================================================
 
-const meta: Meta<typeof XDSTable> = {
+const meta: Meta = {
   title: 'Core/Table',
   component: XDSTable,
   tags: ['autodocs'],
@@ -130,7 +130,7 @@ const meta: Meta<typeof XDSTable> = {
 };
 
 export default meta;
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj;
 
 // =============================================================================
 // Stories

--- a/apps/storybook/stories/TableColumnResize.stories.tsx
+++ b/apps/storybook/stories/TableColumnResize.stories.tsx
@@ -87,7 +87,7 @@ export const Default: Story = {
 
     const resizePlugin = useXDSTableColumnResize<User>({
       columnWidths,
-      columns,
+      columns: columns as XDSTableColumn<Record<string, unknown>>[],
       onColumnResizeEnd: updates => {
         setColumnWidths(prev => ({...prev, ...updates}));
       },
@@ -121,7 +121,7 @@ export const WithMinMaxConstraints: Story = {
       onColumnResizeEnd: updates => {
         setColumnWidths(prev => ({...prev, ...updates}));
       },
-      columns,
+      columns: columns as XDSTableColumn<Record<string, unknown>>[],
       minWidth: 80,
       maxWidth: 300,
     });
@@ -150,7 +150,7 @@ export const PersistingWidths: Story = {
 
     const resizePlugin = useXDSTableColumnResize<User>({
       columnWidths,
-      columns,
+      columns: columns as XDSTableColumn<Record<string, unknown>>[],
       onColumnResizeEnd: updates => {
         setColumnWidths(prev => ({...prev, ...updates}));
       },
@@ -190,7 +190,7 @@ export const KeyboardResize: Story = {
 
     const resizePlugin = useXDSTableColumnResize<User>({
       columnWidths,
-      columns,
+      columns: columns as XDSTableColumn<Record<string, unknown>>[],
       onColumnResizeEnd: updates => {
         setColumnWidths(prev => ({...prev, ...updates}));
       },
@@ -230,7 +230,7 @@ export const WithSelectionAndResize: Story = {
 
     const resizePlugin = useXDSTableColumnResize<User>({
       columnWidths,
-      columns,
+      columns: columns as XDSTableColumn<Record<string, unknown>>[],
       onColumnResizeEnd: updates => {
         setColumnWidths(prev => ({...prev, ...updates}));
       },
@@ -267,7 +267,7 @@ export const AllPixelColumns: Story = {
 
     const resizePlugin = useXDSTableColumnResize<User>({
       columnWidths,
-      columns: pixelColumns,
+      columns: pixelColumns as XDSTableColumn<Record<string, unknown>>[],
       onColumnResizeEnd: updates => {
         setColumnWidths(prev => ({...prev, ...updates}));
       },

--- a/apps/storybook/stories/TableColumnSettings.stories.tsx
+++ b/apps/storybook/stories/TableColumnSettings.stories.tsx
@@ -117,9 +117,12 @@ export const BasicColumnToggle: Story = {
     const state = useXDSTableColumnSettingsState<UserColumnKey>({
       columns: columnOptions,
       activeColumnKeys: activeKeys,
-      onChangeActiveColumnKeys: setActiveKeys,
+      onChangeActiveColumnKeys: (keys: ReadonlyArray<UserColumnKey>) =>
+        setActiveKeys([...keys]),
     });
-    const plugin = useXDSTableColumnSettings<User>(state.columnSettingsConfig);
+    const plugin = useXDSTableColumnSettings<User, UserColumnKey>(
+      state.columnSettingsConfig,
+    );
     const selectorOptions = columnOptions.map(c => ({
       value: c.key,
       label: c.label,
@@ -163,9 +166,12 @@ export const DisabledColumns: Story = {
     const state = useXDSTableColumnSettingsState<UserColumnKey>({
       columns: columnOptions,
       activeColumnKeys: activeKeys,
-      onChangeActiveColumnKeys: setActiveKeys,
+      onChangeActiveColumnKeys: (keys: ReadonlyArray<UserColumnKey>) =>
+        setActiveKeys([...keys]),
     });
-    const plugin = useXDSTableColumnSettings<User>(state.columnSettingsConfig);
+    const plugin = useXDSTableColumnSettings<User, UserColumnKey>(
+      state.columnSettingsConfig,
+    );
     const selectorOptions = columnOptions.map(c => ({
       value: c.key,
       label: c.label,
@@ -210,10 +216,13 @@ export const ResetToDefault: Story = {
     const state = useXDSTableColumnSettingsState<UserColumnKey>({
       columns: columnOptions,
       activeColumnKeys: activeKeys,
-      onChangeActiveColumnKeys: setActiveKeys,
+      onChangeActiveColumnKeys: (keys: ReadonlyArray<UserColumnKey>) =>
+        setActiveKeys([...keys]),
       defaultColumnKeys: defaultKeys,
     });
-    const plugin = useXDSTableColumnSettings<User>(state.columnSettingsConfig);
+    const plugin = useXDSTableColumnSettings<User, UserColumnKey>(
+      state.columnSettingsConfig,
+    );
     const selectorOptions = columnOptions.map(c => ({
       value: c.key,
       label: c.label,
@@ -266,9 +275,10 @@ export const WithSelection: Story = {
     const state = useXDSTableColumnSettingsState<UserColumnKey>({
       columns: columnOptions,
       activeColumnKeys: activeKeys,
-      onChangeActiveColumnKeys: setActiveKeys,
+      onChangeActiveColumnKeys: (keys: ReadonlyArray<UserColumnKey>) =>
+        setActiveKeys([...keys]),
     });
-    const columnPlugin = useXDSTableColumnSettings<User>(
+    const columnPlugin = useXDSTableColumnSettings<User, UserColumnKey>(
       state.columnSettingsConfig,
     );
     const selectorOptions = columnOptions.map(c => ({

--- a/apps/storybook/stories/TableFiltering.stories.tsx
+++ b/apps/storybook/stories/TableFiltering.stories.tsx
@@ -19,53 +19,47 @@ import {XDSEmptyState} from '@xds/core/EmptyState';
 import type {PowerSearchFilter} from '@xds/core/PowerSearch';
 
 interface Employee extends Record<string, unknown> {
-  id: string;
   name: string;
   email: string;
   role: string;
-  department: string;
+  department: readonly string[];
   level: number;
 }
 
 const employees: Employee[] = [
   {
-    id: '1',
     name: 'Alice',
     email: 'alice@example.com',
     role: 'Engineer',
-    department: 'Platform',
+    department: ['Platform'],
     level: 5,
   },
   {
-    id: '2',
     name: 'Bob',
     email: 'bob@example.com',
     role: 'Designer',
-    department: 'Product',
+    department: ['Product'],
     level: 4,
   },
   {
-    id: '3',
     name: 'Charlie',
     email: 'charlie@example.com',
     role: 'Manager',
-    department: 'Platform',
+    department: ['Platform'],
     level: 6,
   },
   {
-    id: '4',
     name: 'Diana',
     email: 'diana@example.com',
     role: 'Engineer',
-    department: 'Infrastructure',
+    department: ['Infrastructure'],
     level: 5,
   },
   {
-    id: '5',
     name: 'Eve',
     email: 'eve@example.com',
     role: 'Admin',
-    department: 'Operations',
+    department: ['Operations'],
     level: 3,
   },
 ];
@@ -133,7 +127,7 @@ export const TextFilter: Story = {
         <XDSTable
           data={data}
           columns={columns}
-          idKey="id"
+          idKey="name"
           plugins={{filter: filterPlugin}}
         />
       </div>
@@ -168,7 +162,7 @@ export const SelectorFilter: Story = {
         <XDSTable
           data={data}
           columns={columns}
-          idKey="id"
+          idKey="name"
           plugins={{filter: filterPlugin}}
         />
       </div>
@@ -204,7 +198,7 @@ export const MultiSelectorFilter: Story = {
         <XDSTable
           data={data}
           columns={columns}
-          idKey="id"
+          idKey="name"
           plugins={{filter: filterPlugin}}
         />
       </div>
@@ -240,7 +234,7 @@ export const NumberFilter: Story = {
         <XDSTable
           data={data}
           columns={columns}
-          idKey="id"
+          idKey="name"
           plugins={{filter: filterPlugin}}
         />
       </div>
@@ -276,7 +270,7 @@ export const InlineVariant: Story = {
         <XDSTable
           data={data}
           columns={columns}
-          idKey="id"
+          idKey="name"
           plugins={{filter: filterPlugin}}
         />
       </div>
@@ -306,7 +300,7 @@ export const WithSelection: Story = {
     );
     const {selectionConfig} = useXDSTableSelectionState({
       data,
-      idKey: 'id',
+      idKey: 'name',
       selectedKeys,
       setSelectedKeys,
     });
@@ -320,7 +314,7 @@ export const WithSelection: Story = {
         <XDSTable
           data={data}
           columns={columns}
-          idKey="id"
+          idKey="name"
           plugins={{selection: selectionPlugin, filter: filterPlugin}}
         />
       </div>
@@ -365,7 +359,7 @@ export const WithSorting: Story = {
         <XDSTable
           data={data}
           columns={columns}
-          idKey="id"
+          idKey="name"
           plugins={{sort: sortPlugin, filter: filterPlugin}}
         />
       </div>
@@ -396,7 +390,7 @@ export const WithResize: Story = {
       columnWidths,
       onColumnResizeEnd: updates =>
         setColumnWidths(prev => ({...prev, ...updates})),
-      columns,
+      columns: columns as XDSTableColumn<Record<string, unknown>>[],
     });
     const data = applyFilters(
       toSearchFilters(filters, columns, config) as PowerSearchFilter[],
@@ -411,7 +405,7 @@ export const WithResize: Story = {
         <XDSTable
           data={data}
           columns={columns}
-          idKey="id"
+          idKey="name"
           plugins={{filter: filterPlugin, resize: resizePlugin}}
         />
       </div>
@@ -446,7 +440,7 @@ export const WithAllPlugins: Story = {
       columnWidths,
       onColumnResizeEnd: updates =>
         setColumnWidths(prev => ({...prev, ...updates})),
-      columns,
+      columns: columns as XDSTableColumn<Record<string, unknown>>[],
     });
     const filtered = applyFilters(
       toSearchFilters(filters, columns, config) as PowerSearchFilter[],
@@ -455,7 +449,7 @@ export const WithAllPlugins: Story = {
     const data = applySort(filtered);
     const {selectionConfig} = useXDSTableSelectionState({
       data,
-      idKey: 'id',
+      idKey: 'name',
       selectedKeys,
       setSelectedKeys,
     });
@@ -469,7 +463,7 @@ export const WithAllPlugins: Story = {
         <XDSTable
           data={data}
           columns={columns}
-          idKey="id"
+          idKey="name"
           plugins={{
             selection: selectionPlugin,
             sort: sortPlugin,
@@ -511,7 +505,7 @@ export const InlineWithClear: Story = {
         <XDSTable
           data={data}
           columns={columns}
-          idKey="id"
+          idKey="name"
           plugins={{filter: filterPlugin}}
         />
       </div>
@@ -547,13 +541,13 @@ export const EmptyState: Story = {
         <XDSTable
           data={data}
           columns={columns}
-          idKey="id"
+          idKey="name"
           plugins={{filter: filterPlugin}}
           emptyState={
             <XDSEmptyState
               title="No results"
               description="Try adjusting your filters to find what you're looking for."
-              size="compact"
+              isCompact
             />
           }
         />

--- a/apps/storybook/stories/TablePagination.stories.tsx
+++ b/apps/storybook/stories/TablePagination.stories.tsx
@@ -259,6 +259,7 @@ export const WithSelection: Story = {
   render: () => {
     const [page, setPage] = useState(1);
     const [selectedKeys, setSelectedKeys] = useState<Set<string>>(new Set());
+    const pageSize = 10;
 
     const plugin = useXDSTablePagination<User>({
       page,
@@ -300,7 +301,11 @@ export const WithSelection: Story = {
  * Interactive playground — use the controls panel to explore every combination
  * of variant, position, and align.
  */
-export const Playground: Story = {
+export const Playground: StoryObj<{
+  variant: Variant;
+  position: Position;
+  align: Align;
+}> = {
   argTypes: {
     variant: {
       control: 'select',
@@ -323,7 +328,7 @@ export const Playground: Story = {
     position: 'below',
     align: 'center',
   },
-  render: (args: {variant: Variant; position: Position; align: Align}) => (
+  render: args => (
     <div style={{maxWidth: 700}}>
       <PaginatedDemo
         variant={args.variant}

--- a/apps/storybook/stories/TableSortable.stories.tsx
+++ b/apps/storybook/stories/TableSortable.stories.tsx
@@ -93,7 +93,7 @@ export const SingleSort: Story = {
       defaultSort: [{sortKey: 'name', direction: 'ascending'}],
     });
 
-    const sortablePlugin = useXDSTableSortable(sortConfig);
+    const sortablePlugin = useXDSTableSortable<Employee>(sortConfig);
 
     return (
       <div style={{maxWidth: 700}}>
@@ -120,7 +120,7 @@ export const MultiSort: Story = {
       isMultiSortEnabled: true,
     });
 
-    const sortablePlugin = useXDSTableSortable(sortConfig);
+    const sortablePlugin = useXDSTableSortable<Employee>(sortConfig);
 
     return (
       <div style={{maxWidth: 700}}>
@@ -157,7 +157,7 @@ export const CustomSortKey: Story = {
       },
     });
 
-    const sortablePlugin = useXDSTableSortable(sortConfig);
+    const sortablePlugin = useXDSTableSortable<Employee>(sortConfig);
 
     return (
       <div style={{maxWidth: 700}}>
@@ -184,7 +184,7 @@ export const AllowUnsortedState: Story = {
       allowUnsortedState: true,
     });
 
-    const sortablePlugin = useXDSTableSortable(sortConfig);
+    const sortablePlugin = useXDSTableSortable<Employee>(sortConfig);
 
     return (
       <div style={{maxWidth: 700}}>
@@ -214,7 +214,7 @@ export const WithSelection: Story = {
       defaultSort: [{sortKey: 'name', direction: 'ascending'}],
     });
 
-    const sortablePlugin = useXDSTableSortable(sortConfig);
+    const sortablePlugin = useXDSTableSortable<Employee>(sortConfig);
 
     const {selectionConfig} = useXDSTableSelectionState<Employee>({
       data: sortedData,
@@ -254,7 +254,7 @@ export const Controlled: Story = {
       onSortChange: setSort,
     });
 
-    const sortablePlugin = useXDSTableSortable(sortConfig);
+    const sortablePlugin = useXDSTableSortable<Employee>(sortConfig);
 
     return (
       <div style={{maxWidth: 700}}>

--- a/apps/storybook/stories/Toast.stories.tsx
+++ b/apps/storybook/stories/Toast.stories.tsx
@@ -50,7 +50,7 @@ export const Types: StoryObj = {
     const toast = useXDSToast();
     const types: XDSToastType[] = ['info', 'error'];
     return (
-      <XDSStack direction="row" gap={2}>
+      <XDSStack direction="horizontal" gap={2}>
         {types.map(type => (
           <XDSButton
             key={type}
@@ -85,7 +85,7 @@ export const WithAction: StoryObj = {
   render: function WithActionStory() {
     const toast = useXDSToast();
     return (
-      <XDSStack direction="row" gap={2}>
+      <XDSStack direction="horizontal" gap={2}>
         <XDSButton
           label="With button"
           onClick={() =>
@@ -170,7 +170,7 @@ export const ProgrammaticDismiss: StoryObj = {
     const toast = useXDSToast();
     const dismissRef = useRef<(() => void) | null>(null);
     return (
-      <XDSStack direction="row" gap={2}>
+      <XDSStack direction="horizontal" gap={2}>
         <XDSButton
           label="Show persistent toast"
           onClick={() => {
@@ -209,7 +209,7 @@ export const Deduplication: StoryObj = {
   render: function DeduplicationStory() {
     const toast = useXDSToast();
     return (
-      <XDSStack direction="row" gap={2}>
+      <XDSStack direction="horizontal" gap={2}>
         <XDSButton
           label="Offline (ignore)"
           onClick={() =>
@@ -272,8 +272,7 @@ export const Stacking: StoryObj = {
   parameters: {
     docs: {
       description: {
-        story:
-          'Multiple toasts stack vertically. Default max visible is 5.',
+        story: 'Multiple toasts stack vertically. Default max visible is 5.',
       },
     },
   },
@@ -325,10 +324,7 @@ export const ToastOverDialog: StoryObj = {
     return (
       <XDSStack gap={2}>
         <XDSButton label="Open dialog" onClick={() => setIsOpen(true)} />
-        <XDSDialog
-          isOpen={isOpen}
-          onClose={() => setIsOpen(false)}
-          title="Dialog with scoped toasts">
+        <XDSDialog isOpen={isOpen} onOpenChange={() => setIsOpen(false)}>
           <XDSToastViewport isTopLayer={false}>
             <DialogToastContent onClose={() => setIsOpen(false)} />
           </XDSToastViewport>
@@ -340,7 +336,7 @@ export const ToastOverDialog: StoryObj = {
     docs: {
       description: {
         story:
-          'Dialog with its own `XDSToastViewport` — toasts render inside the dialog\'s top layer context and appear above the dialog overlay.',
+          "Dialog with its own `XDSToastViewport` — toasts render inside the dialog's top layer context and appear above the dialog overlay.",
       },
     },
   },
@@ -351,15 +347,11 @@ function DialogToastContent({onClose}: {onClose: () => void}) {
   return (
     <XDSStack gap={3}>
       <p>
-        This dialog has its own toast viewport. Toasts fired here render
-        inside the dialog — above its overlay.
+        This dialog has its own toast viewport. Toasts fired here render inside
+        the dialog — above its overlay.
       </p>
-      <XDSStack direction="row" gap={2} wrap="wrap">
-        <XDSButton
-          label="Close"
-          variant="secondary"
-          onClick={onClose}
-        />
+      <XDSStack direction="horizontal" gap={2} wrap="wrap">
+        <XDSButton label="Close" variant="secondary" onClick={onClose} />
         <XDSButton
           label="Show toast"
           onClick={() => {

--- a/apps/storybook/stories/VegaChart.stories.tsx
+++ b/apps/storybook/stories/VegaChart.stories.tsx
@@ -80,13 +80,7 @@ const meta: Meta<typeof XDSVegaChart> = {
   parameters: {
     layout: 'centered',
   },
-  argTypes: {
-    renderer: {
-      control: 'radio',
-      options: ['svg', 'canvas'],
-      description: 'Vega rendering backend',
-    },
-  },
+  argTypes: {},
 };
 
 export default meta;

--- a/apps/storybook/stories/XDSMediaTheme.stories.tsx
+++ b/apps/storybook/stories/XDSMediaTheme.stories.tsx
@@ -52,7 +52,7 @@ function OnDarkDemo() {
             Content on a dark surface — text, icons, and interactive elements
             automatically adapt.
           </XDSText>
-          <XDSStack direction="row" gap={2} align="center" wrap="wrap">
+          <XDSStack direction="horizontal" gap={2} align="center" wrap="wrap">
             <XDSButton label="Primary" />
             <XDSButton label="Secondary" variant="secondary" />
             <XDSButton label="Ghost" variant="ghost" />
@@ -60,7 +60,7 @@ function OnDarkDemo() {
               A link
             </XDSLink>
           </XDSStack>
-          <XDSStack direction="row" gap={2} align="center" wrap="wrap">
+          <XDSStack direction="horizontal" gap={2} align="center" wrap="wrap">
             <XDSBadge label="Badge" />
             <XDSIcon icon="info" size="md" />
             <XDSIcon icon="success" size="md" />
@@ -110,7 +110,11 @@ function OnLightDemo() {
                 Content on a light surface in dark mode — text and icons become
                 dark.
               </XDSText>
-              <XDSStack direction="row" gap={2} align="center" wrap="wrap">
+              <XDSStack
+                direction="horizontal"
+                gap={2}
+                align="center"
+                wrap="wrap">
                 <XDSButton label="Primary" />
                 <XDSButton label="Secondary" variant="secondary" />
                 <XDSButton label="Ghost" variant="ghost" />
@@ -157,7 +161,7 @@ function ToastDemo() {
           width: '100%',
         }}>
         <XDSMediaTheme mode="dark">
-          <XDSStack direction="row" gap={3} align="center" wrap="wrap">
+          <XDSStack direction="horizontal" gap={3} align="center" wrap="wrap">
             <XDSText style={{flex: 1}}>Changes saved successfully.</XDSText>
             <XDSButton label="Undo" variant="secondary" size="sm" />
             <XDSButton
@@ -182,7 +186,7 @@ function ToastDemo() {
           width: '100%',
         }}>
         <XDSMediaTheme mode="dark">
-          <XDSStack direction="row" gap={3} align="center" wrap="wrap">
+          <XDSStack direction="horizontal" gap={3} align="center" wrap="wrap">
             <XDSText style={{flex: 1}}>
               Failed to save. Check your connection.
             </XDSText>
@@ -238,7 +242,7 @@ function ComponentOverrideBoundaryDemo() {
             <XDSText type="supporting" weight="semibold">
               Normal surface (themed overrides)
             </XDSText>
-            <XDSStack direction="row" gap={2} align="center" wrap="wrap">
+            <XDSStack direction="horizontal" gap={2} align="center" wrap="wrap">
               <XDSButton label="Primary" />
               <XDSButton label="Secondary" variant="secondary" />
               <XDSButton label="Ghost" variant="ghost" />
@@ -260,7 +264,11 @@ function ComponentOverrideBoundaryDemo() {
               <XDSText type="supporting" weight="semibold">
                 Dark surface (same overrides, inverted tokens)
               </XDSText>
-              <XDSStack direction="row" gap={2} align="center" wrap="wrap">
+              <XDSStack
+                direction="horizontal"
+                gap={2}
+                align="center"
+                wrap="wrap">
                 <XDSButton label="Primary" />
                 <XDSButton label="Secondary" variant="secondary" />
                 <XDSButton label="Ghost" variant="ghost" />
@@ -301,7 +309,7 @@ function ThemedDemo() {
         <XDSTheme key={label} theme={theme}>
           <XDSStack gap={2}>
             <XDSText weight="semibold">{label}</XDSText>
-            <XDSStack direction="row" gap={3}>
+            <XDSStack direction="horizontal" gap={3}>
               {/* Normal surface */}
               <div
                 style={{
@@ -390,7 +398,7 @@ function CustomOverridesDemo() {
             padding: 16,
           }}>
           <XDSMediaTheme mode="dark">
-            <XDSStack direction="row" gap={2} align="center" wrap="wrap">
+            <XDSStack direction="horizontal" gap={2} align="center" wrap="wrap">
               <XDSButton label="Accent button" />
               <XDSButton label="Secondary" variant="secondary" />
               <XDSLink href="#" hasUnderline>
@@ -501,7 +509,7 @@ function AutoDetectDemo() {
         <code>useImageMode</code>, then applies the correct{' '}
         <code>XDSMediaTheme</code> surface. Text color adapts automatically.
       </XDSText>
-      <XDSStack direction="row" gap={3} style={{flexWrap: 'wrap'}}>
+      <XDSStack direction="horizontal" gap={3} style={{flexWrap: 'wrap'}}>
         {DEMO_IMAGES.map(img => (
           <ImageCard key={img.url} {...img} />
         ))}

--- a/apps/storybook/stories/XIFSpec.stories.tsx
+++ b/apps/storybook/stories/XIFSpec.stories.tsx
@@ -2,8 +2,14 @@
 
 import type {Meta, StoryObj} from '@storybook/react';
 import {Fragment} from 'react';
-import {XDSSVGIcon, type SVGIconVariation, type SVGIconDef} from '@xds/lab';
+import {
+  XDSSVGIcon,
+  type SVGIconVariation,
+  type SVGIconDef,
+  type IconShape,
+} from '@xds/lab';
 import {XDSStack, XDSText, XDSDivider} from '@xds/core';
+import {XDSHeading} from '@xds/core/Text';
 import type {
   XIFIcon,
   XIFPath,
@@ -22,14 +28,16 @@ import {
 // =============================================================================
 
 function xifToSvgIconDef(xif: XIFIcon): SVGIconDef {
-  const toPaths = (paths: XIFPath[]) =>
-    paths.map(p => ({
-      type: p.type ?? ('path' as const),
-      attrs: Object.fromEntries(
-        Object.entries(p.attrs).map(([k, v]) => [k, String(v)]),
-      ),
-      role: p.role,
-    }));
+  const toPaths = (paths: XIFPath[]): IconShape[] =>
+    paths
+      .filter(p => (p.type ?? 'path') !== 'ellipse')
+      .map(p => ({
+        type: (p.type ?? 'path') as IconShape['type'],
+        attrs: Object.fromEntries(
+          Object.entries(p.attrs).map(([k, v]) => [k, String(v)]),
+        ),
+        role: p.role,
+      }));
 
   const primary = toPaths(
     xif.paths.filter(p => (p.layer ?? 'primary') === 'primary'),
@@ -68,7 +76,7 @@ const VARIATIONS: SVGIconVariation[] = [
 export const SpecExamples: StoryObj = {
   render: () => (
     <XDSStack direction="vertical" gap={3}>
-      <XDSText type="heading-3">XIF Spec Examples</XDSText>
+      <XDSHeading level={3}>XIF Spec Examples</XDSHeading>
       <XDSText type="supporting">
         Icons defined using the XDS Icon Format specification. Each demonstrates
         a different capability: stroke-only, two-layer knockout, composable
@@ -187,7 +195,7 @@ export const CompositionSlots: StoryObj = {
 
     return (
       <XDSStack direction="vertical" gap={3}>
-        <XDSText type="heading-3">Composition via Slots</XDSText>
+        <XDSHeading level={3}>Composition via Slots</XDSHeading>
         <XDSText type="supporting">
           Icons with <code>slots</code> accept sub-icons. One shield base +
           different badges = many composed icons without extra path data.
@@ -215,7 +223,7 @@ export const CompositionSlots: StoryObj = {
 
         <XDSDivider />
 
-        <XDSText type="heading-4">Slot Definition</XDSText>
+        <XDSHeading level={4}>Slot Definition</XDSHeading>
         <XDSText type="supporting">
           The shield icon defines:{' '}
           <code>
@@ -251,7 +259,7 @@ export const PersonalityAxes: StoryObj = {
 
     return (
       <XDSStack direction="vertical" gap={3}>
-        <XDSText type="heading-3">Personality Axes (Conceptual)</XDSText>
+        <XDSHeading level={3}>Personality Axes (Conceptual)</XDSHeading>
         <XDSText type="supporting">
           Shape personality parameters adjust the <em>feel</em> of icons without
           changing their structure. All adjustments are relative — preserving
@@ -378,7 +386,7 @@ export const AnimationIntent: StoryObj = {
     return (
       <XDSStack direction="vertical" gap={3}>
         <style dangerouslySetInnerHTML={{__html: animStyles}} />
-        <XDSText type="heading-3">Animation Types (Live)</XDSText>
+        <XDSHeading level={3}>Animation Types (Live)</XDSHeading>
         <XDSText type="supporting">
           Icons declare animation intent per path. The theme resolves timing.
           Each demo loops on page load.
@@ -468,7 +476,7 @@ export const PathTransformPlayground: StoryObj = {
 
     return (
       <XDSStack direction="vertical" gap={4}>
-        <XDSText type="heading-3">Path Transform Playground</XDSText>
+        <XDSHeading level={3}>Path Transform Playground</XDSHeading>
         <XDSText type="supporting">
           Live path manipulation with sagitta-corrected corner rounding. Sharp
           corners (like star tips) round less aggressively than gentle corners —
@@ -476,7 +484,7 @@ export const PathTransformPlayground: StoryObj = {
         </XDSText>
 
         {/* Corner Rounding */}
-        <XDSText type="heading-4">Corner Rounding (sagitta-corrected)</XDSText>
+        <XDSHeading level={4}>Corner Rounding (sagitta-corrected)</XDSHeading>
         <XDSText type="supporting">
           Same cornerRounding value across all shapes. Sharp corners get less
           radius, gentle corners get more — visually balanced.
@@ -526,7 +534,7 @@ export const PathTransformPlayground: StoryObj = {
         <XDSDivider />
 
         {/* Segment Curvature */}
-        <XDSText type="heading-4">Segment Curvature</XDSText>
+        <XDSHeading level={4}>Segment Curvature</XDSHeading>
         <XDSText type="supporting">
           Straight line segments gain a perpendicular bow. Subtle at low values,
           pronounced at high.
@@ -576,9 +584,9 @@ export const PathTransformPlayground: StoryObj = {
         <XDSDivider />
 
         {/* Combined: Rounding + Curvature presets */}
-        <XDSText type="heading-4">
+        <XDSHeading level={4}>
           Personality Presets (combined transforms)
-        </XDSText>
+        </XDSHeading>
         <div
           style={{
             display: 'grid',

--- a/apps/storybook/stories/useXDSLinkify.stories.tsx
+++ b/apps/storybook/stories/useXDSLinkify.stories.tsx
@@ -56,7 +56,7 @@ function LinkifyDemo({
         }}>
         <XDSText type="body">{nodes}</XDSText>
       </div>
-      <XDSText type="detail" color="secondary">
+      <XDSText type="supporting" color="secondary">
         {nodes.length} node{nodes.length !== 1 ? 's' : ''} rendered
       </XDSText>
     </XDSStack>
@@ -169,8 +169,9 @@ export const Interactive: Story = {
     return (
       <XDSStack gap={4}>
         <XDSTextInput
+          label="Enter text to linkify"
           value={text}
-          onChange={(e) => setText(e.target.value)}
+          onChange={newValue => setText(newValue)}
         />
         <div
           style={{

--- a/apps/storybook/tsconfig.json
+++ b/apps/storybook/tsconfig.json
@@ -12,6 +12,9 @@
       "@xds/theme/*": [
         "../../packages/theme/src/*/index.ts",
         "../../packages/theme/src/*"
+      ],
+      "@xds/build/vite": [
+        "../../packages/build/src/vite.ts"
       ]
     }
   },

--- a/packages/build/src/vite.ts
+++ b/packages/build/src/vite.ts
@@ -94,7 +94,9 @@ export interface XDSVitePluginOptions {
  *
  * @param options — optional overrides
  */
-export function xdsStylex(options: XDSVitePluginOptions | XDSVitePluginLegacyOptions = {}): Plugin[] {
+export function xdsStylex(
+  options: XDSVitePluginOptions | XDSVitePluginLegacyOptions = {},
+): Plugin[] {
   // Detect legacy API: xdsStylex({stylexOptions: {...}})
   if ('stylexOptions' in options && options.stylexOptions) {
     return xdsStylexLegacy(options as XDSVitePluginLegacyOptions);
@@ -174,7 +176,8 @@ export function xdsStylex(options: XDSVitePluginOptions | XDSVitePluginLegacyOpt
         const fs = require('fs');
         const xdsDir = path.resolve(rootDir, 'node_modules/@xds');
         if (fs.existsSync(xdsDir)) {
-          xdsPackages = fs.readdirSync(xdsDir)
+          xdsPackages = fs
+            .readdirSync(xdsDir)
             .filter((name: string) => !name.startsWith('.'))
             .map((name: string) => `@xds/${name}`);
         }
@@ -293,13 +296,13 @@ function xdsStylexLegacy(options: XDSVitePluginLegacyOptions): Plugin[] {
   const productLayer = layers.product ?? 'product';
 
   const xdsBabelPlugin = path.resolve(__dirname, 'babel.js');
-  const existingPlugins = stylexOptions.babelConfig?.plugins ?? [];
+  const existingPlugins = (stylexOptions as any).babelConfig?.plugins ?? [];
 
   const basePlugin = stylex.vite({
-    ...stylexOptions,
+    ...(stylexOptions as any),
     useCSSLayers: true,
     babelConfig: {
-      ...stylexOptions.babelConfig,
+      ...(stylexOptions as any).babelConfig,
       plugins: [
         [
           xdsBabelPlugin,


### PR DESCRIPTION
  - Adds a typecheck script to apps/storybook/package.json and a CI step after existing typecheck steps
  - Fixes all 242 accumulated type errors across 37 story files (direction renames, prop renames, generic variance, spacing tokens, stale argTypes, etc.)
  - Fixes 5 pre-existing type errors in packages/build/src/vite.ts exposed by the new path alias