### PR TITLE
fix(hooks): remove set-state-in-effect from useXDSStreamingText

### DIFF
--- a/packages/core/src/hooks/useXDSStreamingText.ts
+++ b/packages/core/src/hooks/useXDSStreamingText.ts
@@ -115,18 +115,27 @@ export function useXDSStreamingText(
   const rafRef = useRef<number | null>(null);
 
   // Keep target ref in sync
-  useEffect(() => {
-    targetRef.current = targetText;
-  }, [targetText]);
+  targetRef.current = targetText;
 
   // Reset when target clears (new message)
-  const targetLen = targetText.length;
-  useEffect(() => {
-    if (targetLen === 0) {
+  const prevTargetLenRef = useRef(targetText.length);
+  if (targetText.length !== prevTargetLenRef.current) {
+    prevTargetLenRef.current = targetText.length;
+    if (targetText.length === 0 && displayedLen !== 0) {
       displayedLenRef.current = 0;
       setDisplayedLen(0);
     }
-  }, [targetLen]);
+  }
+
+  // Snap to full text when streaming ends
+  const prevIsStreamingRef = useRef(isStreaming);
+  if (isStreaming !== prevIsStreamingRef.current) {
+    prevIsStreamingRef.current = isStreaming;
+    if (!isStreaming && targetText.length > 0) {
+      displayedLenRef.current = targetText.length;
+      setDisplayedLen(targetText.length);
+    }
+  }
 
   // Animation loop
   useEffect(() => {
@@ -158,14 +167,6 @@ export function useXDSStreamingText(
       }
     };
   }, [isStreaming, charsPerTick, tickMs, speed]);
-
-  // Snap to full text when streaming ends
-  useEffect(() => {
-    if (!isStreaming && targetText.length > 0) {
-      displayedLenRef.current = targetText.length;
-      setDisplayedLen(targetText.length);
-    }
-  }, [isStreaming, targetText.length]);
 
   if (!isStreaming || speed === 'instant') {
     return targetText;


### PR DESCRIPTION
  ## Summary
  - Replace two `useEffect` hooks that called `setState` with synchronous render-time computation using prev-value refs
  - The reset-on-clear and snap-on-stream-end behaviors now execute during render instead of scheduling an extra render cycle via effects
  - Eliminates unnecessary double-renders and improves React Compiler compatibility
  - The animation loop effect is unchanged

  ## Test plan
  - Existing tests cover both modified behaviors:
    - "snaps to full text when streaming ends" validates the stream-end snap logic
    - "resets when target text clears" validates the clear-reset logic