### PR TITLE
fix(Chat): use useMemo for SpeechRecognition support detection

### DIFF
--- a/packages/core/src/Chat/useSpeechRecognition.ts
+++ b/packages/core/src/Chat/useSpeechRecognition.ts
@@ -276,7 +276,7 @@ export function useSpeechRecognition(
     [externalAudioContext],
   );
 
-  const [isSupported, setIsSupported] = useState(false);
+  const [isSupported] = useState(() => getSpeechRecognition() != null);
   const [isListening, setIsListening] = useState(false);
   const [isSpeaking, setIsSpeaking] = useState(false);
   const [volume, setVolume] = useState(0);
@@ -308,8 +308,6 @@ export function useSpeechRecognition(
   };
 
   useEffect(() => {
-    const SR = getSpeechRecognition();
-    setIsSupported(SR != null);
     return () => {
       recognitionRef.current?.abort();
       recognitionRef.current = null;

--- a/packages/core/src/Chat/useSpeechRecognition.ts
+++ b/packages/core/src/Chat/useSpeechRecognition.ts
@@ -13,7 +13,7 @@
  * volume level from the microphone via AudioContext analyser.
  */
 
-import {useState, useCallback, useEffect, useRef} from 'react';
+import {useState, useCallback, useEffect, useMemo, useRef} from 'react';
 
 // =============================================================================
 // Types
@@ -276,7 +276,7 @@ export function useSpeechRecognition(
     [externalAudioContext],
   );
 
-  const [isSupported] = useState(() => getSpeechRecognition() != null);
+  const isSupported = useMemo(() => getSpeechRecognition() != null, []);
   const [isListening, setIsListening] = useState(false);
   const [isSpeaking, setIsSpeaking] = useState(false);
   const [volume, setVolume] = useState(0);


### PR DESCRIPTION
  ## Summary
  - Replace effect-based `setIsSupported` with `useMemo`, since browser support is a static value that won't change during component lifetime
  - Eliminates unnecessary state and an extra render cycle on mount
  - Unmount cleanup effect preserved unchanged

  ## Test plan
  - Existing tests pass (18/18): `isSupported` true/false detection, start/stop/toggle/abort, callbacks, transcript handling, cleanup on unmount