### PR TITLE
fix(Chat): allow text selection in ChatSystemMessage

### DIFF
--- a/packages/core/src/Chat/XDSChatSystemMessage.tsx
+++ b/packages/core/src/Chat/XDSChatSystemMessage.tsx
@@ -92,7 +92,6 @@ const styles = stylex.create({
     fontWeight: fontWeightVars['--font-weight-normal'],
     color: colorVars['--color-text-secondary'],
     textAlign: 'center',
-    userSelect: 'none',
   },
   dividerWrap: {
     width: '100%',


### PR DESCRIPTION
## Summary

Remove `userSelect: 'none'` from `XDSChatSystemMessage` styles so users can select and copy text from system messages.

## Problem

Text inside `XDSChatSystemMessage` cannot be selected (`user-select: none` was set on the root element). System messages often contain error messages, IDs, or other content that users need to copy.

## Fix

Remove the `userSelect: 'none'` declaration from `styles.root` in `XDSChatSystemMessage.tsx`. System messages now allow text selection by default.

Closes #2262