### PR TITLE
cleanup: remove all MutableRefObject casts

### DIFF
--- a/packages/core/src/ButtonGroup/XDSButtonGroup.tsx
+++ b/packages/core/src/ButtonGroup/XDSButtonGroup.tsx
@@ -138,13 +138,11 @@ export function XDSButtonGroup({
         <div
           ref={(node: HTMLDivElement | null) => {
             // eslint-disable-next-line react-compiler/react-compiler -- ref callback: assigning hook-returned ref
-            (listRef as React.MutableRefObject<HTMLElement | null>).current =
-              node;
+            listRef.current = node;
             if (typeof ref === 'function') {
               ref(node);
             } else if (ref) {
-              (ref as React.MutableRefObject<HTMLDivElement | null>).current =
-                node;
+              ref.current = node;
             }
           }}
           role="group"

--- a/packages/core/src/Carousel/XDSCarousel.tsx
+++ b/packages/core/src/Carousel/XDSCarousel.tsx
@@ -278,7 +278,7 @@ export function XDSCarousel({
         if (typeof ref === 'function') {
           ref(el);
         } else if (ref) {
-          (ref as React.MutableRefObject<HTMLDivElement | null>).current = el;
+          ref.current = el;
         }
         if (layer.ref) {
           layer.ref(el as HTMLElement | null);

--- a/packages/core/src/Chat/XDSChatLayout.tsx
+++ b/packages/core/src/Chat/XDSChatLayout.tsx
@@ -310,7 +310,7 @@ export function XDSChatLayout({
 
   // --- Content ref callback for message list ---
   const setContentRef = useCallback((el: HTMLElement | null) => {
-    (contentRef as React.MutableRefObject<HTMLElement | null>).current = el;
+    contentRef.current = el;
   }, []);
 
   // --- Layout context ---
@@ -334,11 +334,11 @@ export function XDSChatLayout({
   // --- Merge refs ---
   const setRootRef = useCallback(
     (el: HTMLDivElement | null) => {
-      (rootRef as React.MutableRefObject<HTMLDivElement | null>).current = el;
+      rootRef.current = el;
       if (typeof ref === 'function') {
         ref(el);
       } else if (ref) {
-        (ref as React.MutableRefObject<HTMLDivElement | null>).current = el;
+        ref.current = el;
       }
     },
     [ref],

--- a/packages/core/src/ClickableCard/XDSClickableCard.tsx
+++ b/packages/core/src/ClickableCard/XDSClickableCard.tsx
@@ -28,13 +28,7 @@
  * For toggle selection, use XDSSelectableCard.
  */
 
-import {
-  type ReactNode,
-  type MouseEvent,
-  type MutableRefObject,
-  useRef,
-  type Ref,
-} from 'react';
+import {type ReactNode, type MouseEvent, useRef, type Ref} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import {colorVars} from '../theme/tokens.stylex';
@@ -258,7 +252,7 @@ export function XDSClickableCard({
         if (typeof ref === 'function') {
           ref(node);
         } else if (ref != null) {
-          (ref as MutableRefObject<HTMLDivElement | null>).current = node;
+          ref.current = node;
         }
       }}
       width={width}

--- a/packages/core/src/CommandPalette/XDSCommandPaletteInput.tsx
+++ b/packages/core/src/CommandPalette/XDSCommandPaletteInput.tsx
@@ -182,13 +182,11 @@ export function XDSCommandPaletteInput({
 
   // Merge refs
   const setRefs = (element: HTMLInputElement | null) => {
-    (inputRef as React.MutableRefObject<HTMLInputElement | null>).current =
-      element;
+    inputRef.current = element;
     if (typeof ref === 'function') {
       ref(element);
     } else if (ref) {
-      (ref as React.MutableRefObject<HTMLInputElement | null>).current =
-        element;
+      ref.current = element;
     }
   };
 

--- a/packages/core/src/CommandPalette/XDSCommandPaletteItem.tsx
+++ b/packages/core/src/CommandPalette/XDSCommandPaletteItem.tsx
@@ -131,12 +131,11 @@ export function XDSCommandPaletteItem({
   const itemRef = useRef<HTMLDivElement>(null);
 
   const setRefs = (element: HTMLDivElement | null) => {
-    (itemRef as React.MutableRefObject<HTMLDivElement | null>).current =
-      element;
+    itemRef.current = element;
     if (typeof ref === 'function') {
       ref(element);
     } else if (ref) {
-      (ref as React.MutableRefObject<HTMLDivElement | null>).current = element;
+      ref.current = element;
     }
   };
 

--- a/packages/core/src/Dialog/XDSDialog.tsx
+++ b/packages/core/src/Dialog/XDSDialog.tsx
@@ -357,8 +357,7 @@ export function XDSDialog({
 
   // Merge refs
   const setRefs = (element: HTMLDialogElement | null) => {
-    (dialogRef as React.MutableRefObject<HTMLDialogElement | null>).current =
-      element;
+    dialogRef.current = element;
     if (typeof ref === 'function') {
       ref(element);
     } else if (ref) {

--- a/packages/core/src/DropdownMenu/XDSDropdownMenu.tsx
+++ b/packages/core/src/DropdownMenu/XDSDropdownMenu.tsx
@@ -355,18 +355,14 @@ export function XDSDropdownMenu({
       <XDSButton
         {...button}
         ref={el => {
-          (
-            buttonRef as React.MutableRefObject<HTMLButtonElement | null>
-          ).current = el;
+          buttonRef.current = el;
           popover.triggerRef(el);
           const consumerRef = button.ref;
           if (typeof consumerRef === 'function') {
             consumerRef(el);
           } else if (consumerRef) {
             /* eslint-disable react-compiler/react-compiler -- ref callback: forwarding consumer ref object */
-            (
-              consumerRef as React.MutableRefObject<HTMLButtonElement | null>
-            ).current = el;
+            consumerRef.current = el;
             /* eslint-enable react-compiler/react-compiler */
           }
         }}

--- a/packages/core/src/FileInput/XDSFileInput.tsx
+++ b/packages/core/src/FileInput/XDSFileInput.tsx
@@ -582,7 +582,7 @@ export function XDSFileInput({
       if (typeof ref === 'function') {
         ref(el);
       } else if (ref) {
-        (ref as React.MutableRefObject<HTMLInputElement | null>).current = el;
+        ref.current = el;
       }
     },
     [ref],

--- a/packages/core/src/MobileNav/XDSMobileNav.tsx
+++ b/packages/core/src/MobileNav/XDSMobileNav.tsx
@@ -313,8 +313,7 @@ export function XDSMobileNav({
   // Merge refs
   const setRefs = useCallback(
     (element: HTMLDialogElement | null) => {
-      (dialogRef as React.MutableRefObject<HTMLDialogElement | null>).current =
-        element;
+      dialogRef.current = element;
       if (typeof ref === 'function') {
         ref(element);
       } else if (ref) {

--- a/packages/core/src/OverflowList/XDSOverflowList.tsx
+++ b/packages/core/src/OverflowList/XDSOverflowList.tsx
@@ -17,7 +17,6 @@
  * - /packages/cli/templates/blocks/components/OverflowList/ (showcase blocks)
  */
 
-
 import {type ReactNode, type ReactElement, Children} from 'react';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import type {SpacingStep} from '../utils/types';
@@ -249,7 +248,7 @@ export function XDSOverflowList({
           if (typeof ref === 'function') {
             ref(el);
           } else if (ref) {
-            (ref as React.MutableRefObject<HTMLDivElement | null>).current = el;
+            ref.current = el;
           }
         }}
         {...mergeProps(

--- a/packages/core/src/Overlay/XDSOverlay.tsx
+++ b/packages/core/src/Overlay/XDSOverlay.tsx
@@ -125,13 +125,11 @@ export function XDSOverlay({
   return (
     <div
       ref={(node: HTMLDivElement | null) => {
-        (
-          overlay.containerRef as React.MutableRefObject<HTMLElement | null>
-        ).current = node;
+        overlay.containerRef.current = node;
         if (typeof ref === 'function') {
           ref(node);
         } else if (ref != null) {
-          (ref as React.MutableRefObject<HTMLDivElement | null>).current = node;
+          ref.current = node;
         }
       }}
       {...mergeProps(

--- a/packages/core/src/Resizable/XDSResizeHandle.tsx
+++ b/packages/core/src/Resizable/XDSResizeHandle.tsx
@@ -474,12 +474,11 @@ export function XDSResizeHandle({
   return (
     <div
       ref={node => {
-        (handleRef as React.MutableRefObject<HTMLDivElement | null>).current =
-          node;
+        handleRef.current = node;
         if (typeof ref === 'function') {
           ref(node);
         } else if (ref) {
-          (ref as React.MutableRefObject<HTMLDivElement | null>).current = node;
+          ref.current = node;
         }
       }}
       role="separator"

--- a/packages/core/src/SelectableCard/XDSSelectableCard.tsx
+++ b/packages/core/src/SelectableCard/XDSSelectableCard.tsx
@@ -29,7 +29,6 @@
 import {
   type ReactNode,
   type MouseEvent,
-  type MutableRefObject,
   useRef,
   useCallback,
   type Ref,
@@ -321,7 +320,7 @@ export function XDSSelectableCard({
         if (typeof ref === 'function') {
           ref(node);
         } else if (ref != null) {
-          (ref as MutableRefObject<HTMLDivElement | null>).current = node;
+          ref.current = node;
         }
       }}
       width={width}

--- a/packages/core/src/SideNav/XDSSideNav.tsx
+++ b/packages/core/src/SideNav/XDSSideNav.tsx
@@ -459,7 +459,7 @@ export function XDSSideNav({
         if (typeof ref === 'function') {
           ref(node);
         } else if (ref) {
-          (ref as React.MutableRefObject<HTMLElement | null>).current = node;
+          ref.current = node;
         }
       }}
       role="navigation"

--- a/packages/core/src/SideNav/XDSSideNavItem.tsx
+++ b/packages/core/src/SideNav/XDSSideNavItem.tsx
@@ -509,8 +509,7 @@ export function XDSSideNavItem({
               if (typeof ref === 'function') {
                 ref(el);
               } else if (ref) {
-                (ref as React.MutableRefObject<HTMLElement | null>).current =
-                  el;
+                ref.current = el;
               }
             }}
             type="button"

--- a/packages/core/src/Slider/XDSSlider.tsx
+++ b/packages/core/src/Slider/XDSSlider.tsx
@@ -749,14 +749,11 @@ export function XDSSlider({ref, ...props}: XDSSliderProps) {
         <div
           ref={node => {
             // Merge refs
-            (
-              trackRef as React.MutableRefObject<HTMLDivElement | null>
-            ).current = node;
+            trackRef.current = node;
             if (typeof ref === 'function') {
               ref(node);
             } else if (ref) {
-              (ref as React.MutableRefObject<HTMLDivElement | null>).current =
-                node;
+              ref.current = node;
             }
           }}
           {...(isRange ? {role: 'group', 'aria-label': label} : undefined)}

--- a/packages/core/src/Table/plugins/selection/useXDSTableSelection.tsx
+++ b/packages/core/src/Table/plugins/selection/useXDSTableSelection.tsx
@@ -139,7 +139,7 @@ function mergeRefs<T>(...refs: (Ref<T> | undefined)[]): React.RefCallback<T> {
       if (typeof ref === 'function') {
         ref(el);
       } else if (ref != null) {
-        (ref as React.MutableRefObject<T | null>).current = el;
+        ref.current = el;
       }
     }
   };

--- a/packages/core/src/Text/XDSHeading.tsx
+++ b/packages/core/src/Text/XDSHeading.tsx
@@ -241,9 +241,7 @@ export function XDSHeading({
       // Truncation ref
       truncation.ref(element);
       // Local ref for tooltip anchor
-      (
-        headingRef as React.MutableRefObject<HTMLHeadingElement | null>
-      ).current = element;
+      headingRef.current = element;
     },
     [ref, truncation],
   );

--- a/packages/core/src/Text/XDSText.tsx
+++ b/packages/core/src/Text/XDSText.tsx
@@ -247,7 +247,7 @@ export function XDSText({
       // Truncation ref
       truncation.ref(element);
       // Local ref for tooltip anchor
-      (textRef as React.MutableRefObject<HTMLElement | null>).current = element;
+      textRef.current = element;
     },
     [ref, truncation],
   );

--- a/packages/core/src/TextArea/XDSTextArea.tsx
+++ b/packages/core/src/TextArea/XDSTextArea.tsx
@@ -331,8 +331,7 @@ export function XDSTextArea({
       if (typeof ref === 'function') {
         ref(el);
       } else if (ref) {
-        (ref as React.MutableRefObject<HTMLTextAreaElement | null>).current =
-          el;
+        ref.current = el;
       }
     },
     [ref],

--- a/packages/core/src/TextInput/XDSTextInput.tsx
+++ b/packages/core/src/TextInput/XDSTextInput.tsx
@@ -324,7 +324,7 @@ export function XDSTextInput({
       if (typeof ref === 'function') {
         ref(el);
       } else if (ref) {
-        (ref as React.MutableRefObject<HTMLInputElement | null>).current = el;
+        ref.current = el;
       }
     },
     [ref],

--- a/packages/core/src/Timestamp/XDSTimestamp.tsx
+++ b/packages/core/src/Timestamp/XDSTimestamp.tsx
@@ -377,11 +377,11 @@ export function XDSTimestamp({
 
   // Tooltip needs the ref
   const combinedRef = (el: HTMLTimeElement | null) => {
-    (timeRef as React.MutableRefObject<HTMLTimeElement | null>).current = el;
+    timeRef.current = el;
     if (typeof ref === 'function') {
       ref(el);
     } else if (ref) {
-      (ref as React.MutableRefObject<HTMLTimeElement | null>).current = el;
+      ref.current = el;
     }
   };
 

--- a/packages/core/src/TopNav/XDSTopNavHeading.tsx
+++ b/packages/core/src/TopNav/XDSTopNavHeading.tsx
@@ -352,12 +352,12 @@ export function XDSTopNavHeading({
 
   const setRef = useCallback(
     (el: HTMLElement | null) => {
-      (rootRef as React.MutableRefObject<HTMLElement | null>).current = el;
+      rootRef.current = el;
       setTriggerEl(el);
       if (typeof ref === 'function') {
         ref(el);
       } else if (ref) {
-        (ref as React.MutableRefObject<HTMLElement | null>).current = el;
+        ref.current = el;
       }
       if (menu) {
         popover.triggerRef(el);

--- a/packages/core/src/TopNav/XDSTopNavMenu.tsx
+++ b/packages/core/src/TopNav/XDSTopNavMenu.tsx
@@ -339,9 +339,7 @@ export function XDSTopNavMenu({
 
   const setTriggerRef = useCallback(
     (el: HTMLButtonElement | null) => {
-      (
-        triggerButtonRef as React.MutableRefObject<HTMLButtonElement | null>
-      ).current = el;
+      triggerButtonRef.current = el;
       popover.triggerRef(el);
       setTriggerEl(el);
     },


### PR DESCRIPTION
> **Stacked on #2260** — merge that first.
  ## Summary

  React 19 RefObject has a mutable .current property, making MutableRefObject casts unnecessary. This removes all 36 instances across 25 files — direct .current assignment
   works without casting.

  ## Test plan
  - [x] tsc --noEmit passes clean
  - [x] Pre-commit hooks pass