### PR TITLE
fix(PowerSearch): render entity photo as token icon + tokenizer spacing fixes

### DIFF
--- a/apps/storybook/stories/PowerSearch.stories.tsx
+++ b/apps/storybook/stories/PowerSearch.stories.tsx
@@ -38,12 +38,36 @@ const tagValues = [
 ];
 
 const users: XDSSearchableItem[] = [
-  {id: 'user-1', label: 'Alice Johnson'},
-  {id: 'user-2', label: 'Bob Smith'},
-  {id: 'user-3', label: 'Charlie Brown'},
-  {id: 'user-4', label: 'Diana Prince'},
-  {id: 'user-5', label: 'Eve Williams'},
-  {id: 'user-6', label: 'Frank Miller'},
+  {
+    id: 'user-1',
+    label: 'Alice Johnson',
+    auxiliaryData: {photo: 'https://i.pravatar.cc/150?u=alice'},
+  },
+  {
+    id: 'user-2',
+    label: 'Bob Smith',
+    auxiliaryData: {photo: 'https://i.pravatar.cc/150?u=bob'},
+  },
+  {
+    id: 'user-3',
+    label: 'Charlie Brown',
+    auxiliaryData: {photo: 'https://i.pravatar.cc/150?u=charlie'},
+  },
+  {
+    id: 'user-4',
+    label: 'Diana Prince',
+    auxiliaryData: {photo: 'https://i.pravatar.cc/150?u=diana'},
+  },
+  {
+    id: 'user-5',
+    label: 'Eve Williams',
+    auxiliaryData: {photo: 'https://i.pravatar.cc/150?u=eve'},
+  },
+  {
+    id: 'user-6',
+    label: 'Frank Miller',
+    auxiliaryData: {photo: 'https://i.pravatar.cc/150?u=frank'},
+  },
 ];
 
 const userSource: XDSSearchSource = {

--- a/packages/core/src/PowerSearch/XDSPowerSearch.tsx
+++ b/packages/core/src/PowerSearch/XDSPowerSearch.tsx
@@ -789,7 +789,7 @@ export function XDSPowerSearch({
       ) {
         const entity = filter.value.value[0];
         tokenIcon = (
-          <XDSAvatar src={entity.photo} name={entity.label} size="xsmall" />
+          <XDSAvatar src={entity.photo} name={entity.label} size={16} />
         );
       }
 

--- a/packages/core/src/PowerSearch/XDSPowerSearch.tsx
+++ b/packages/core/src/PowerSearch/XDSPowerSearch.tsx
@@ -30,6 +30,7 @@ import {
 } from '../Tokenizer';
 import {XDSTypeaheadItem} from '../Typeahead/XDSTypeaheadItem';
 import {XDSToken} from '../Token';
+import {XDSAvatar} from '../Avatar';
 import {layerAnimations} from '../Layer/layerAnimations.stylex';
 import {XDSIcon} from '../Icon';
 import type {XDSIconType} from '../Icon';
@@ -779,9 +780,23 @@ export function XDSPowerSearch({
           />
         ) : undefined;
 
+      // Show entity photo as token icon for single-entity filters
+      let tokenIcon: ReactNode | undefined;
+      if (
+        filter?.value.type === 'entity_list' &&
+        filter.value.value.length === 1 &&
+        filter.value.value[0].photo
+      ) {
+        const entity = filter.value.value[0];
+        tokenIcon = (
+          <XDSAvatar src={entity.photo} name={entity.label} size="xsmall" />
+        );
+      }
+
       return (
         <XDSToken
           label={tokenLabel}
+          icon={tokenIcon}
           endContent={valueContent}
           onClick={
             handleClick

--- a/packages/core/src/Tokenizer/XDSTokenizer.tsx
+++ b/packages/core/src/Tokenizer/XDSTokenizer.tsx
@@ -217,6 +217,7 @@ const styles = stylex.create({
     // = 8 - 4 - 1 = 3px.
     paddingBlock: `calc(${spacingVars['--spacing-1']} - 1px)`,
     paddingInline: `calc(${spacingVars['--spacing-1']} - 1px)`,
+    // Row gap must match paddingBlock so wrapped rows look evenly spaced.
     rowGap: `calc(${spacingVars['--spacing-1']} - 1px)`,
   },
   token: {

--- a/packages/core/src/Tokenizer/XDSTokenizer.tsx
+++ b/packages/core/src/Tokenizer/XDSTokenizer.tsx
@@ -219,6 +219,7 @@ const styles = stylex.create({
     paddingInline: `calc(${spacingVars['--spacing-1']} - 1px)`,
   },
   token: {
+    display: 'flex',
     flexShrink: 0,
   },
   clearAllButton: {

--- a/packages/core/src/Tokenizer/XDSTokenizer.tsx
+++ b/packages/core/src/Tokenizer/XDSTokenizer.tsx
@@ -217,6 +217,7 @@ const styles = stylex.create({
     // = 8 - 4 - 1 = 3px.
     paddingBlock: `calc(${spacingVars['--spacing-1']} - 1px)`,
     paddingInline: `calc(${spacingVars['--spacing-1']} - 1px)`,
+    rowGap: `calc(${spacingVars['--spacing-1']} - 1px)`,
   },
   token: {
     display: 'flex',


### PR DESCRIPTION
## Summary

  - Render `PowerSearchEntity.photo` as a 16px `XDSAvatar` icon on the token when a single entity is selected (via `XDSToken` existing `icon` prop)
  -   - Add entity photo URLs to PowerSearch storybook data so the feature is visible in existing stories

<img width="814" height="117" alt="image" src="https://github.com/user-attachments/assets/f7d47bdd-5171-4344-b9a2-b04a25a8ffc3" />

Also a couple fixes for small visual bugs I noticed while fixing this:
  - Fix tokenizer container height inflation: the `<span>` wrapper around custom `renderToken` output inherited line-height, making it taller than the token — adding
  `display: flex` makes it shrink-wrap
  - Match `rowGap` to `paddingBlock` (3px) in the tokenizer `wrapperWithTokens` style so wrapped rows are evenly spaced

Closes #2100

  ## Test plan

  - [x] PowerSearch tests pass
  - [x] Tokenizer tests pass
  - [x] TypeScript clean (no new errors)
  - [x] ESLint clean
  - [x] Visual: verify in Storybook Full Featured story that selecting a single Assignee shows avatar icon in token
  - [x] Visual: verify token height stays at 24px and container at 32px with avatar tokens
  - [x] Visual: verify wrapped token rows have even spacing