### PR TITLE
fix(Markdown): handle escaped pipes in table cells

### DIFF
--- a/packages/core/src/Markdown/parser.test.ts
+++ b/packages/core/src/Markdown/parser.test.ts
@@ -366,6 +366,22 @@ describe('parseMarkdown', () => {
     }
   });
 
+  // --- Table with escaped pipes ---
+
+  it('handles escaped pipes in table cells', () => {
+    const input =
+      '| Concept | TypeScript |\n| --- | --- |\n| Null safety | `T \\| null` |\n| Union | `A \\| B \\| C` |';
+    const result = parseMarkdown(input);
+    expect(result[0].type).toBe('table');
+    if (result[0].type === 'table') {
+      expect(result[0].headers).toHaveLength(2);
+      expect(result[0].rows).toHaveLength(2);
+      // The cell should contain the escaped pipe as inline content
+      expect(result[0].rows[0]).toHaveLength(2);
+      expect(result[0].rows[1]).toHaveLength(2);
+    }
+  });
+
   // --- HR variants ---
 
   it('parses spaced HR: - - -', () => {

--- a/packages/core/src/Markdown/parser.ts
+++ b/packages/core/src/Markdown/parser.ts
@@ -418,10 +418,28 @@ function splitTableRow(line: string): string[] {
   if (end > start && line[end - 1] === '|') {
     end--;
   }
-  return line
-    .slice(start, end)
-    .split('|')
-    .map(segment => segment.trim());
+  // Split on unescaped pipes (not preceded by backslash)
+  const content = line.slice(start, end);
+  const cells: string[] = [];
+  let current = '';
+  for (let i = 0; i < content.length; i++) {
+    if (
+      content[i] === '\\' &&
+      i + 1 < content.length &&
+      content[i + 1] === '|'
+    ) {
+      // Escaped pipe — keep the backslash-pipe literal for parseInline to handle
+      current += '\\|';
+      i++;
+    } else if (content[i] === '|') {
+      cells.push(current.trim());
+      current = '';
+    } else {
+      current += content[i];
+    }
+  }
+  cells.push(current.trim());
+  return cells;
 }
 
 function parseTable(


### PR DESCRIPTION
## Problem

`splitTableRow()` was naively splitting on all `|` characters using `.split('|')`. This broke table cells containing escaped pipes like `T \| null` — common in TypeScript union types.

For example this table:

```markdown
| Concept | TypeScript |
|---|---|
| Null safety | `T \| null` |
```

Would incorrectly produce 3 columns in the data row instead of 2.

## Fix

Replaced the naive `.split('|')` with a character-by-character iteration that skips `\|` sequences. The escaped pipe literal passes through to `parseInline()`, which already handles backslash escapes correctly.

## Test

Added test case for escaped pipes in table cells — verifies correct column count is preserved.