### PR TITLE
fix(FileInput): rename onChangeAction to changeAction

### DIFF
--- a/packages/core/src/FileInput/FileInput.doc.mjs
+++ b/packages/core/src/FileInput/FileInput.doc.mjs
@@ -26,7 +26,7 @@ export const docs = {
       required: true,
     },
     {
-      name: 'onChangeAction',
+      name: 'changeAction',
       type: '(files: File | File[] | null) => Promise<void>',
       description:
         'Async change action (React 19 transitions pattern). Use for immediate upload on file selection.',
@@ -130,7 +130,7 @@ export const docs = {
       {guidance: true, description: 'Always specify an accept prop to guide users toward valid file types.'},
       {guidance: true, description: 'Use maxSize and maxFiles to prevent oversized uploads — the component handles validation and error display automatically.'},
       {guidance: true, description: 'Add a description to communicate constraints like file size limits or accepted formats.'},
-      {guidance: true, description: 'Use onChangeAction for immediate upload workflows that benefit from optimistic UI.'},
+      {guidance: true, description: 'Use changeAction for immediate upload workflows that benefit from optimistic UI.'},
       {guidance: false, description: "Don't use FileInput for directory or folder uploads — that is not supported in v1."},
       {guidance: false, description: "Don't avoid dropzone mode unless space is very constrained — drag-and-drop is the expected interaction for file uploads."},
     ],
@@ -281,7 +281,7 @@ export const docsDense = {
     label: 'Accessible label for the file input.',
     value: 'Currently selected file(s). Controlled.',
     onChange: 'Fired when files are selected or removed.',
-    onChangeAction: 'Async action after onChange. For immediate upload.',
+    changeAction: 'Async action after onChange. For immediate upload.',
     accept: 'Accepted file types (HTML accept format).',
     isMultiple: 'Allow multiple file selection.',
     maxSize: 'Max file size in bytes. Rejects oversized files.',

--- a/packages/core/src/FileInput/XDSFileInput.tsx
+++ b/packages/core/src/FileInput/XDSFileInput.tsx
@@ -305,7 +305,7 @@ export interface XDSFileInputProps extends Omit<
    * Async change action (React 19 transitions pattern).
    * Use for immediate upload on file selection.
    */
-  onChangeAction?: (files: File | File[] | null) => Promise<void>;
+  changeAction?: (files: File | File[] | null) => Promise<void>;
   /**
    * Accepted file types. Uses the HTML accept attribute format.
    * Examples: "image/*", ".pdf,.doc,.docx", "image/png,image/jpeg"
@@ -385,7 +385,7 @@ export function XDSFileInput({
   isLabelHidden = false,
   value,
   onChange,
-  onChangeAction,
+  changeAction,
   accept,
   isMultiple = false,
   maxSize,
@@ -474,9 +474,9 @@ export function XDSFileInput({
       const result = isMultiple ? valid : valid[0];
       onChange(result);
 
-      if (onChangeAction) {
+      if (changeAction) {
         startTransition(async () => {
-          await onChangeAction(result);
+          await changeAction(result);
         });
       }
     },
@@ -487,7 +487,7 @@ export function XDSFileInput({
       maxFiles,
       maxSize,
       onChange,
-      onChangeAction,
+      changeAction,
       startTransition,
     ],
   );


### PR DESCRIPTION
Aligns FileInput with the established codebase convention where all other components (TextInput, Selector, DateInput, Switch, CheckboxInput, etc.) use `changeAction` without the `on` prefix for React 19 transition actions.

A codemod for this rename already exists at `packages/cli/src/codemods/transforms/v0.0.14/rename-action-props.mjs` — FileInput was missed when it was applied.

## Components Audited

- **FileInput** — naming violation fixed
- **DateRangePicker** — no issues found
- **DateTimePicker** — no issues found

Night Watch — Component Auditor