### PR TITLE
fix(Center): rename CenterAxis type to XDSCenterAxis

### DIFF
--- a/packages/core/src/Center/XDSCenter.tsx
+++ b/packages/core/src/Center/XDSCenter.tsx
@@ -15,7 +15,6 @@
  * - /packages/cli/templates/blocks/components/Center/ (showcase blocks)
  */
 
-
 import {type ReactNode} from 'react';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
@@ -46,7 +45,10 @@ const dynamicStyles = stylex.create({
   }),
 });
 
-export type CenterAxis = 'both' | 'horizontal' | 'vertical';
+export type XDSCenterAxis = 'both' | 'horizontal' | 'vertical';
+
+/** @deprecated Use `XDSCenterAxis` instead. */
+export type CenterAxis = XDSCenterAxis;
 
 export interface XDSCenterProps extends XDSBaseProps<HTMLDivElement> {
   /** Ref forwarded to the root element */
@@ -58,7 +60,7 @@ export interface XDSCenterProps extends XDSBaseProps<HTMLDivElement> {
    * - `vertical`: Center vertically only (alignItems: center)
    * @default 'both'
    */
-  axis?: CenterAxis;
+  axis?: XDSCenterAxis;
 
   /**
    * Width of the container.

--- a/packages/core/src/Center/index.ts
+++ b/packages/core/src/Center/index.ts
@@ -12,4 +12,4 @@
  */
 
 export {XDSCenter} from './XDSCenter';
-export type {XDSCenterProps, CenterAxis} from './XDSCenter';
+export type {XDSCenterProps, XDSCenterAxis, CenterAxis} from './XDSCenter';


### PR DESCRIPTION
Adds XDS prefix to the exported `CenterAxis` type per naming conventions (`XDS<Component>Variant` / status / axis types must use the prefix).

The old `CenterAxis` name is preserved as a deprecated alias for backward compatibility.

## Components Audited

- **Center** — type naming violation fixed
- **Chat** — no issues found (all 19 sub-components pass: displayName, xdsClassName, tokens, a11y, exports)
- **CheckboxInput** — no issues found
- **CheckboxList** — no issues found (soft note: doesn't extend XDSBaseProps, defines style props manually — flagged for human review but not auto-fixed as it's a design choice)
- **ClickableCard** — no issues found

Night Watch — Component Auditor