### PR TITLE
refactor(core): introduce PlainDate and eliminate Date usage in Calendar internals

### DIFF
--- a/packages/core/src/Calendar/XDSCalendar.tsx
+++ b/packages/core/src/Calendar/XDSCalendar.tsx
@@ -47,12 +47,12 @@ import {
   plainDateToDate,
   plainDateFromDate,
   plainDateToday,
-  plainDateFirstOfMonth,
+  plainDateSetFirstOfMonth,
   plainDateAddMonths,
   plainDateAddDays,
   plainDateIsBefore,
   plainDateIsAfter,
-  plainDateIsSameDay,
+  plainDateIsEqual,
   plainDateIsInRange,
   plainDateGetWeekNumber,
   plainDateFormatAccessible,
@@ -63,24 +63,8 @@ import {xdsClassName, mergeProps} from '../utils';
 // Types
 // =============================================================================
 
-/**
- * ISO 8601 date string in YYYY-MM-DD format.
- * Example: "2026-01-28"
- */
-
-export type ISODateString =
-  `${number}${number}${number}${number}-${number}${number}-${number}${number}`;
-
-/** Day of week: 0 = Sunday through 6 = Saturday */
-
-export type DayOfWeek = 0 | 1 | 2 | 3 | 4 | 5 | 6;
-
-/** Date range with start and end dates */
-
-export interface DateRange {
-  start: ISODateString;
-  end: ISODateString;
-}
+export type {ISODateString, DayOfWeek, DateRange} from '../utils/dateTypes';
+import type {ISODateString, DayOfWeek, DateRange} from '../utils/dateTypes';
 
 /** Imperative handle for XDSCalendar ref */
 
@@ -272,7 +256,7 @@ export function XDSCalendar({ref, ...props}: XDSCalendarProps) {
 
   // Base month (first day of focus month)
   const baseMonth = useMemo(() => {
-    return plainDateFirstOfMonth(focusDate);
+    return plainDateSetFirstOfMonth(focusDate);
   }, [focusDate]);
 
   // Generate visible months
@@ -524,12 +508,11 @@ function MonthGrid({
   onPendingFocusHandled,
 }: MonthGridProps) {
   const year = month.year;
-  const monthIndex = month.month - 1;
 
   // Use hooks for days generation and constraints
   const {days, weeks, dayNames} = useCalendarDays({
     year,
-    month: monthIndex,
+    month: month.month,
     weekStartsOn,
     hasVariableRowCount,
   });
@@ -552,7 +535,7 @@ function MonthGrid({
     days,
     today,
     year,
-    month: monthIndex,
+    month: month.month,
     isDateDisabled,
     selectedDate: selectedDateForTabindex,
   });
@@ -678,7 +661,7 @@ function MonthGrid({
   if (mode === 'range' && rangeSelectionStart && hoveredDate) {
     const startPd = plainDateFromISO(rangeSelectionStart);
     const hoverPd = plainDateFromISO(hoveredDate);
-    if (!plainDateIsSameDay(startPd, hoverPd)) {
+    if (!plainDateIsEqual(startPd, hoverPd)) {
       if (plainDateIsBefore(hoverPd, startPd)) {
         previewStart = hoverPd;
         previewEnd = startPd;
@@ -821,26 +804,26 @@ function DayCell({
   // Outside days should not be clickable even when visible
   const effectivelyDisabled = isDisabled || isOutside;
 
-  const isToday = plainDateIsSameDay(date, today);
+  const isToday = plainDateIsEqual(date, today);
   const isSelected =
-    mode === 'single' && selectedDate && plainDateIsSameDay(date, selectedDate);
+    mode === 'single' && selectedDate && plainDateIsEqual(date, selectedDate);
   const isInRange =
     mode === 'range' &&
     rangeStart &&
     rangeEnd &&
-    plainDateIsInRange(date, rangeStart, rangeEnd);
+    plainDateIsInRange(date, [rangeStart, rangeEnd]);
   const isRangeStart =
-    mode === 'range' && rangeStart && plainDateIsSameDay(date, rangeStart);
+    mode === 'range' && rangeStart && plainDateIsEqual(date, rangeStart);
   const isRangeEnd =
-    mode === 'range' && rangeEnd && plainDateIsSameDay(date, rangeEnd);
+    mode === 'range' && rangeEnd && plainDateIsEqual(date, rangeEnd);
 
   // Preview range calculations
   const isInPreview =
     previewStart &&
     previewEnd &&
-    plainDateIsInRange(date, previewStart, previewEnd);
-  const isPreviewStart = previewStart && plainDateIsSameDay(date, previewStart);
-  const isPreviewEnd = previewEnd && plainDateIsSameDay(date, previewEnd);
+    plainDateIsInRange(date, [previewStart, previewEnd]);
+  const isPreviewStart = previewStart && plainDateIsEqual(date, previewStart);
+  const isPreviewEnd = previewEnd && plainDateIsEqual(date, previewEnd);
 
   // Determine cell background for range
   const hasRangeBackground = isInRange;

--- a/packages/core/src/Calendar/XDSCalendar.tsx
+++ b/packages/core/src/Calendar/XDSCalendar.tsx
@@ -55,7 +55,8 @@ import {
   plainDateIsEqual,
   plainDateIsInRange,
   plainDateGetWeekNumber,
-  plainDateFormatAccessible,
+  plainDateFormat,
+  DATE_FORMAT_WITH_WEEKDAY,
 } from '../utils/plainDate';
 import {xdsClassName, mergeProps} from '../utils';
 
@@ -618,7 +619,7 @@ function MonthGrid({
     );
 
     const targetPd = plainDateFromISO(pendingFocus);
-    const targetLabel = plainDateFormatAccessible(targetPd);
+    const targetLabel = plainDateFormat(targetPd, DATE_FORMAT_WITH_WEEKDAY);
 
     let targetButton: HTMLElement | null = null;
     for (const button of buttons) {
@@ -877,7 +878,7 @@ function DayCell({
         type="button"
         role="gridcell"
         data-date={day.iso}
-        aria-label={plainDateFormatAccessible(date)}
+        aria-label={plainDateFormat(date, DATE_FORMAT_WITH_WEEKDAY)}
         aria-selected={isSelected || isInRange || undefined}
         aria-disabled={effectivelyDisabled || undefined}
         disabled={isDisabled}

--- a/packages/core/src/Calendar/XDSCalendar.tsx
+++ b/packages/core/src/Calendar/XDSCalendar.tsx
@@ -41,13 +41,21 @@ import {
   dayCellTheme,
 } from './styles';
 import {
-  dateToISO,
-  parseISO,
+  type PlainDate,
+  fromISO,
+  toISO,
+  toDate,
+  fromDate,
+  today as todayFn,
+  firstOfMonth,
+  addMonths,
+  addDays,
+  compare,
   isSameDay,
-  isDateInRange,
+  isInRange as isPlainDateInRange,
   getWeekNumber,
-  formatAccessibleDate,
-} from './utils';
+  formatAccessible,
+} from '../utils/plainDate';
 import {xdsClassName, mergeProps} from '../utils';
 
 // =============================================================================
@@ -204,7 +212,7 @@ export function XDSCalendar({ref, ...props}: XDSCalendarProps) {
   } = props;
 
   // Today's date (memoized)
-  const today = useMemo(() => new Date(), []);
+  const today = useMemo(() => todayFn(), []);
 
   // Internal state for uncontrolled mode
   const [internalValue, setInternalValue] = useState<
@@ -225,25 +233,25 @@ export function XDSCalendar({ref, ...props}: XDSCalendarProps) {
   const effectiveValue = value !== undefined ? value : internalValue;
 
   // Focus date state (which month is visible)
-  const [internalFocusDate, setInternalFocusDate] = useState<Date>(() => {
+  const [internalFocusDate, setInternalFocusDate] = useState<PlainDate>(() => {
     if (focusDateProp) {
-      return parseISO(focusDateProp);
+      return fromISO(focusDateProp);
     }
     if (effectiveValue) {
       if (typeof effectiveValue === 'string') {
-        return parseISO(effectiveValue);
+        return fromISO(effectiveValue);
       } else {
-        return parseISO(effectiveValue.start);
+        return fromISO(effectiveValue.start);
       }
     }
-    return new Date();
+    return todayFn();
   });
 
   // Use controlled focusDate if callback is provided, otherwise use internal state
   const isControlledFocus =
     focusDateProp !== undefined && onFocusDateChange !== undefined;
   const focusDate = isControlledFocus
-    ? parseISO(focusDateProp)
+    ? fromISO(focusDateProp)
     : internalFocusDate;
 
   // Expose imperative handle for external navigation
@@ -254,7 +262,7 @@ export function XDSCalendar({ref, ...props}: XDSCalendarProps) {
         if (isControlledFocus) {
           onFocusDateChange?.(date);
         } else {
-          setInternalFocusDate(parseISO(date));
+          setInternalFocusDate(fromISO(date));
         }
       },
     }),
@@ -263,17 +271,13 @@ export function XDSCalendar({ref, ...props}: XDSCalendarProps) {
 
   // Base month (first day of focus month)
   const baseMonth = useMemo(() => {
-    const d = new Date(focusDate);
-    d.setDate(1);
-    return d;
+    return firstOfMonth(focusDate);
   }, [focusDate]);
 
   // Generate visible months
   const visibleMonths = useMemo(() => {
     return Array.from({length: numberOfMonths}, (_, i) => {
-      const m = new Date(baseMonth);
-      m.setMonth(baseMonth.getMonth() + i);
-      return m;
+      return addMonths(baseMonth, i);
     });
   }, [baseMonth, numberOfMonths]);
 
@@ -284,9 +288,9 @@ export function XDSCalendar({ref, ...props}: XDSCalendarProps) {
       month: 'long',
     });
     if (numberOfMonths === 1) {
-      return formatter.format(visibleMonths[0]);
+      return formatter.format(toDate(visibleMonths[0]));
     }
-    return visibleMonths.map(m => formatter.format(m)).join(' – ');
+    return visibleMonths.map(m => formatter.format(toDate(m))).join(' – ');
   }, [visibleMonths, numberOfMonths]);
 
   // Determine if prev/next navigation is possible based on min/max
@@ -294,12 +298,11 @@ export function XDSCalendar({ref, ...props}: XDSCalendarProps) {
     if (!min) {
       return true;
     }
-    const minDate = parseISO(min);
+    const minDate = fromISO(min);
     // Can't go back if min is in the current focus month
     return (
-      minDate.getFullYear() < baseMonth.getFullYear() ||
-      (minDate.getFullYear() === baseMonth.getFullYear() &&
-        minDate.getMonth() < baseMonth.getMonth())
+      minDate.year < baseMonth.year ||
+      (minDate.year === baseMonth.year && minDate.month < baseMonth.month)
     );
   }, [min, baseMonth]);
 
@@ -307,36 +310,34 @@ export function XDSCalendar({ref, ...props}: XDSCalendarProps) {
     if (!max) {
       return true;
     }
-    const maxDate = parseISO(max);
+    const maxDate = fromISO(max);
     // Check against the last visible month, not just baseMonth
-    const lastVisibleMonth = new Date(baseMonth);
-    lastVisibleMonth.setMonth(baseMonth.getMonth() + numberOfMonths - 1);
+    const lastVisibleMonth = addMonths(baseMonth, numberOfMonths - 1);
     return (
-      maxDate.getFullYear() > lastVisibleMonth.getFullYear() ||
-      (maxDate.getFullYear() === lastVisibleMonth.getFullYear() &&
-        maxDate.getMonth() > lastVisibleMonth.getMonth())
+      maxDate.year > lastVisibleMonth.year ||
+      (maxDate.year === lastVisibleMonth.year &&
+        maxDate.month > lastVisibleMonth.month)
     );
   }, [max, baseMonth, numberOfMonths]);
 
   // Navigation handlers
   const navigateMonth = useCallback(
     (delta: number, focusedDate?: ISODateString, offset?: number) => {
-      const newDate = new Date(baseMonth);
-      newDate.setMonth(baseMonth.getMonth() + delta);
-      const newISO = dateToISO(newDate);
+      const newPd = addMonths(baseMonth, delta);
+      const newISO = toISO(newPd);
 
       // Calculate target focus date if a focused date was provided
       if (focusedDate) {
-        const currentDate = parseISO(focusedDate);
+        const currentPd = fromISO(focusedDate);
         const daysToMove = offset ?? 7;
-        currentDate.setDate(currentDate.getDate() + delta * daysToMove);
-        setPendingFocus(dateToISO(currentDate));
+        const targetPd = addDays(currentPd, delta * daysToMove);
+        setPendingFocus(toISO(targetPd));
       }
 
       if (onFocusDateChange) {
         onFocusDateChange(newISO);
       } else {
-        setInternalFocusDate(newDate);
+        setInternalFocusDate(newPd);
       }
     },
     [baseMonth, onFocusDateChange],
@@ -360,12 +361,12 @@ export function XDSCalendar({ref, ...props}: XDSCalendarProps) {
 
   // Day click handler
   const handleDayClick = useCallback(
-    (date: Date) => {
-      const iso = dateToISO(date);
+    (date: PlainDate) => {
+      const iso = toISO(date);
 
       if (mode === 'single') {
         setInternalValue(iso);
-        (onChange as XDSCalendarSingleProps['onChange'])?.(iso, date);
+        (onChange as XDSCalendarSingleProps['onChange'])?.(iso, toDate(date));
       } else {
         // Range mode
         if (rangeSelectionStart === null) {
@@ -373,12 +374,12 @@ export function XDSCalendar({ref, ...props}: XDSCalendarProps) {
           setRangeSelectionStart(iso);
         } else {
           // Second click - complete the range
-          const startDate = parseISO(rangeSelectionStart);
+          const startPd = fromISO(rangeSelectionStart);
           let start: ISODateString;
           let end: ISODateString;
 
           // Ensure start <= end
-          if (date < startDate) {
+          if (compare(date, startPd) < 0) {
             start = iso;
             end = rangeSelectionStart;
           } else {
@@ -434,7 +435,7 @@ export function XDSCalendar({ref, ...props}: XDSCalendarProps) {
       <div {...stylex.props(calendarStyles.monthsContainer)}>
         {visibleMonths.map(month => (
           <MonthGrid
-            key={`${month.getFullYear()}-${month.getMonth()}`}
+            key={`${month.year}-${month.month}`}
             month={month}
             value={effectiveValue}
             mode={mode}
@@ -448,7 +449,7 @@ export function XDSCalendar({ref, ...props}: XDSCalendarProps) {
             hasVariableRowCount={hasVariableRowCount}
             weekStartsOn={weekStartsOn}
             onDayClick={handleDayClick}
-            onDayHover={date => setHoveredDate(date ? dateToISO(date) : null)}
+            onDayHover={date => setHoveredDate(date ? toISO(date) : null)}
             today={today}
             onNavigatePrevious={(focusedDate, offset) =>
               navigateMonth(-1, focusedDate, offset)
@@ -472,7 +473,7 @@ XDSCalendar.displayName = 'XDSCalendar';
 // =============================================================================
 
 interface MonthGridProps {
-  month: Date;
+  month: PlainDate;
   value: ISODateString | DateRange | undefined;
   mode: 'single' | 'range';
   rangeSelectionStart: ISODateString | null;
@@ -484,9 +485,9 @@ interface MonthGridProps {
   hasWeekNumbers: boolean;
   hasVariableRowCount: boolean;
   weekStartsOn: DayOfWeek;
-  onDayClick: (date: Date) => void;
-  onDayHover: (date: Date | null) => void;
-  today: Date;
+  onDayClick: (date: PlainDate) => void;
+  onDayHover: (date: PlainDate | null) => void;
+  today: PlainDate;
   onNavigatePrevious?: (focusedDate: ISODateString, offset: number) => void;
   onNavigateNext?: (focusedDate: ISODateString, offset: number) => void;
   pendingFocus?: ISODateString | null;
@@ -514,8 +515,8 @@ function MonthGrid({
   pendingFocus,
   onPendingFocusHandled,
 }: MonthGridProps) {
-  const year = month.getFullYear();
-  const monthIndex = month.getMonth();
+  const year = month.year;
+  const monthIndex = month.month - 1;
 
   // Use hooks for days generation and constraints
   const {days, weeks, dayNames} = useCalendarDays({
@@ -534,7 +535,7 @@ function MonthGrid({
   // Parse selected date for roving tabindex priority
   const selectedDateForTabindex = useMemo(() => {
     if (mode === 'single' && value && typeof value === 'string') {
-      return parseISO(value as ISODateString);
+      return fromISO(value as ISODateString);
     }
     return null;
   }, [mode, value]);
@@ -565,7 +566,7 @@ function MonthGrid({
       return null;
     }
 
-    return dateToISO(parsed);
+    return toISO(fromDate(parsed));
   }, []);
 
   // Handle navigation to previous month
@@ -625,8 +626,8 @@ function MonthGrid({
       'button:not([disabled])',
     );
 
-    const targetDate = parseISO(pendingFocus);
-    const targetLabel = formatAccessibleDate(targetDate);
+    const targetPd = fromISO(pendingFocus);
+    const targetLabel = formatAccessible(targetPd);
 
     let targetButton: HTMLElement | null = null;
     for (const button of buttons) {
@@ -645,37 +646,37 @@ function MonthGrid({
   }, [pendingFocus, gridRef, onPendingFocusHandled]);
 
   // Parse selection
-  let selectedDate: Date | null = null;
-  let rangeStart: Date | null = null;
-  let rangeEnd: Date | null = null;
+  let selectedDate: PlainDate | null = null;
+  let rangeStart: PlainDate | null = null;
+  let rangeEnd: PlainDate | null = null;
 
   if (mode === 'single' && value && typeof value === 'string') {
-    selectedDate = parseISO(value as ISODateString);
+    selectedDate = fromISO(value as ISODateString);
   } else if (mode === 'range' && value && typeof value === 'object') {
     const range = value as DateRange;
-    rangeStart = parseISO(range.start);
-    rangeEnd = parseISO(range.end);
+    rangeStart = fromISO(range.start);
+    rangeEnd = fromISO(range.end);
   }
 
   // Handle in-progress range selection
   if (rangeSelectionStart) {
-    rangeStart = parseISO(rangeSelectionStart);
+    rangeStart = fromISO(rangeSelectionStart);
     rangeEnd = rangeStart;
   }
 
   // Calculate preview range when hovering during range selection
-  let previewStart: Date | null = null;
-  let previewEnd: Date | null = null;
+  let previewStart: PlainDate | null = null;
+  let previewEnd: PlainDate | null = null;
   if (mode === 'range' && rangeSelectionStart && hoveredDate) {
-    const startDate = parseISO(rangeSelectionStart);
-    const hoverDate = parseISO(hoveredDate);
-    if (startDate.getTime() !== hoverDate.getTime()) {
-      if (hoverDate < startDate) {
-        previewStart = hoverDate;
-        previewEnd = startDate;
+    const startPd = fromISO(rangeSelectionStart);
+    const hoverPd = fromISO(hoveredDate);
+    if (!isSameDay(startPd, hoverPd)) {
+      if (compare(hoverPd, startPd) < 0) {
+        previewStart = hoverPd;
+        previewEnd = startPd;
       } else {
-        previewStart = startDate;
-        previewEnd = hoverDate;
+        previewStart = startPd;
+        previewEnd = hoverPd;
       }
     }
   }
@@ -685,7 +686,7 @@ function MonthGrid({
     return new Intl.DateTimeFormat(undefined, {
       year: 'numeric',
       month: 'long',
-    }).format(month);
+    }).format(toDate(month));
   }, [month]);
 
   return (
@@ -773,17 +774,17 @@ interface DayCellProps {
   day: CalendarDay;
   dayIndex: number;
   mode: 'single' | 'range';
-  selectedDate: Date | null;
-  rangeStart: Date | null;
-  rangeEnd: Date | null;
-  previewStart: Date | null;
-  previewEnd: Date | null;
-  today: Date;
+  selectedDate: PlainDate | null;
+  rangeStart: PlainDate | null;
+  rangeEnd: PlainDate | null;
+  previewStart: PlainDate | null;
+  previewEnd: PlainDate | null;
+  today: PlainDate;
   hasOutsideDays: boolean;
   isDisabled: boolean;
   isTabbable: boolean;
-  onDayClick: (date: Date) => void;
-  onDayHover: (date: Date | null) => void;
+  onDayClick: (date: PlainDate) => void;
+  onDayHover: (date: PlainDate | null) => void;
 }
 
 function DayCell({
@@ -819,14 +820,16 @@ function DayCell({
     mode === 'range' &&
     rangeStart &&
     rangeEnd &&
-    isDateInRange(date, rangeStart, rangeEnd);
+    isPlainDateInRange(date, rangeStart, rangeEnd);
   const isRangeStart =
     mode === 'range' && rangeStart && isSameDay(date, rangeStart);
   const isRangeEnd = mode === 'range' && rangeEnd && isSameDay(date, rangeEnd);
 
   // Preview range calculations
   const isInPreview =
-    previewStart && previewEnd && isDateInRange(date, previewStart, previewEnd);
+    previewStart &&
+    previewEnd &&
+    isPlainDateInRange(date, previewStart, previewEnd);
   const isPreviewStart = previewStart && isSameDay(date, previewStart);
   const isPreviewEnd = previewEnd && isSameDay(date, previewEnd);
 
@@ -882,7 +885,7 @@ function DayCell({
         type="button"
         role="gridcell"
         data-date={day.iso}
-        aria-label={formatAccessibleDate(date)}
+        aria-label={formatAccessible(date)}
         aria-selected={isSelected || isInRange || undefined}
         aria-disabled={effectivelyDisabled || undefined}
         disabled={isDisabled}

--- a/packages/core/src/Calendar/XDSCalendar.tsx
+++ b/packages/core/src/Calendar/XDSCalendar.tsx
@@ -42,19 +42,20 @@ import {
 } from './styles';
 import {
   type PlainDate,
-  fromISO,
-  toISO,
-  toDate,
-  fromDate,
-  today as todayFn,
-  firstOfMonth,
-  addMonths,
-  addDays,
-  compare,
-  isSameDay,
-  isInRange as isPlainDateInRange,
-  getWeekNumber,
-  formatAccessible,
+  plainDateFromISO,
+  plainDateToISO,
+  plainDateToDate,
+  plainDateFromDate,
+  plainDateToday,
+  plainDateFirstOfMonth,
+  plainDateAddMonths,
+  plainDateAddDays,
+  plainDateIsBefore,
+  plainDateIsAfter,
+  plainDateIsSameDay,
+  plainDateIsInRange,
+  plainDateGetWeekNumber,
+  plainDateFormatAccessible,
 } from '../utils/plainDate';
 import {xdsClassName, mergeProps} from '../utils';
 
@@ -212,7 +213,7 @@ export function XDSCalendar({ref, ...props}: XDSCalendarProps) {
   } = props;
 
   // Today's date (memoized)
-  const today = useMemo(() => todayFn(), []);
+  const today = useMemo(() => plainDateToday(), []);
 
   // Internal state for uncontrolled mode
   const [internalValue, setInternalValue] = useState<
@@ -235,23 +236,23 @@ export function XDSCalendar({ref, ...props}: XDSCalendarProps) {
   // Focus date state (which month is visible)
   const [internalFocusDate, setInternalFocusDate] = useState<PlainDate>(() => {
     if (focusDateProp) {
-      return fromISO(focusDateProp);
+      return plainDateFromISO(focusDateProp);
     }
     if (effectiveValue) {
       if (typeof effectiveValue === 'string') {
-        return fromISO(effectiveValue);
+        return plainDateFromISO(effectiveValue);
       } else {
-        return fromISO(effectiveValue.start);
+        return plainDateFromISO(effectiveValue.start);
       }
     }
-    return todayFn();
+    return plainDateToday();
   });
 
   // Use controlled focusDate if callback is provided, otherwise use internal state
   const isControlledFocus =
     focusDateProp !== undefined && onFocusDateChange !== undefined;
   const focusDate = isControlledFocus
-    ? fromISO(focusDateProp)
+    ? plainDateFromISO(focusDateProp)
     : internalFocusDate;
 
   // Expose imperative handle for external navigation
@@ -262,7 +263,7 @@ export function XDSCalendar({ref, ...props}: XDSCalendarProps) {
         if (isControlledFocus) {
           onFocusDateChange?.(date);
         } else {
-          setInternalFocusDate(fromISO(date));
+          setInternalFocusDate(plainDateFromISO(date));
         }
       },
     }),
@@ -271,13 +272,13 @@ export function XDSCalendar({ref, ...props}: XDSCalendarProps) {
 
   // Base month (first day of focus month)
   const baseMonth = useMemo(() => {
-    return firstOfMonth(focusDate);
+    return plainDateFirstOfMonth(focusDate);
   }, [focusDate]);
 
   // Generate visible months
   const visibleMonths = useMemo(() => {
     return Array.from({length: numberOfMonths}, (_, i) => {
-      return addMonths(baseMonth, i);
+      return plainDateAddMonths(baseMonth, i);
     });
   }, [baseMonth, numberOfMonths]);
 
@@ -288,9 +289,11 @@ export function XDSCalendar({ref, ...props}: XDSCalendarProps) {
       month: 'long',
     });
     if (numberOfMonths === 1) {
-      return formatter.format(toDate(visibleMonths[0]));
+      return formatter.format(plainDateToDate(visibleMonths[0]));
     }
-    return visibleMonths.map(m => formatter.format(toDate(m))).join(' – ');
+    return visibleMonths
+      .map(m => formatter.format(plainDateToDate(m)))
+      .join(' – ');
   }, [visibleMonths, numberOfMonths]);
 
   // Determine if prev/next navigation is possible based on min/max
@@ -298,7 +301,7 @@ export function XDSCalendar({ref, ...props}: XDSCalendarProps) {
     if (!min) {
       return true;
     }
-    const minDate = fromISO(min);
+    const minDate = plainDateFromISO(min);
     // Can't go back if min is in the current focus month
     return (
       minDate.year < baseMonth.year ||
@@ -310,9 +313,9 @@ export function XDSCalendar({ref, ...props}: XDSCalendarProps) {
     if (!max) {
       return true;
     }
-    const maxDate = fromISO(max);
+    const maxDate = plainDateFromISO(max);
     // Check against the last visible month, not just baseMonth
-    const lastVisibleMonth = addMonths(baseMonth, numberOfMonths - 1);
+    const lastVisibleMonth = plainDateAddMonths(baseMonth, numberOfMonths - 1);
     return (
       maxDate.year > lastVisibleMonth.year ||
       (maxDate.year === lastVisibleMonth.year &&
@@ -323,15 +326,15 @@ export function XDSCalendar({ref, ...props}: XDSCalendarProps) {
   // Navigation handlers
   const navigateMonth = useCallback(
     (delta: number, focusedDate?: ISODateString, offset?: number) => {
-      const newPd = addMonths(baseMonth, delta);
-      const newISO = toISO(newPd);
+      const newPd = plainDateAddMonths(baseMonth, delta);
+      const newISO = plainDateToISO(newPd);
 
       // Calculate target focus date if a focused date was provided
       if (focusedDate) {
-        const currentPd = fromISO(focusedDate);
+        const currentPd = plainDateFromISO(focusedDate);
         const daysToMove = offset ?? 7;
-        const targetPd = addDays(currentPd, delta * daysToMove);
-        setPendingFocus(toISO(targetPd));
+        const targetPd = plainDateAddDays(currentPd, delta * daysToMove);
+        setPendingFocus(plainDateToISO(targetPd));
       }
 
       if (onFocusDateChange) {
@@ -362,11 +365,14 @@ export function XDSCalendar({ref, ...props}: XDSCalendarProps) {
   // Day click handler
   const handleDayClick = useCallback(
     (date: PlainDate) => {
-      const iso = toISO(date);
+      const iso = plainDateToISO(date);
 
       if (mode === 'single') {
         setInternalValue(iso);
-        (onChange as XDSCalendarSingleProps['onChange'])?.(iso, toDate(date));
+        (onChange as XDSCalendarSingleProps['onChange'])?.(
+          iso,
+          plainDateToDate(date),
+        );
       } else {
         // Range mode
         if (rangeSelectionStart === null) {
@@ -374,12 +380,12 @@ export function XDSCalendar({ref, ...props}: XDSCalendarProps) {
           setRangeSelectionStart(iso);
         } else {
           // Second click - complete the range
-          const startPd = fromISO(rangeSelectionStart);
+          const startPd = plainDateFromISO(rangeSelectionStart);
           let start: ISODateString;
           let end: ISODateString;
 
           // Ensure start <= end
-          if (compare(date, startPd) < 0) {
+          if (plainDateIsBefore(date, startPd)) {
             start = iso;
             end = rangeSelectionStart;
           } else {
@@ -449,7 +455,9 @@ export function XDSCalendar({ref, ...props}: XDSCalendarProps) {
             hasVariableRowCount={hasVariableRowCount}
             weekStartsOn={weekStartsOn}
             onDayClick={handleDayClick}
-            onDayHover={date => setHoveredDate(date ? toISO(date) : null)}
+            onDayHover={date =>
+              setHoveredDate(date ? plainDateToISO(date) : null)
+            }
             today={today}
             onNavigatePrevious={(focusedDate, offset) =>
               navigateMonth(-1, focusedDate, offset)
@@ -535,7 +543,7 @@ function MonthGrid({
   // Parse selected date for roving tabindex priority
   const selectedDateForTabindex = useMemo(() => {
     if (mode === 'single' && value && typeof value === 'string') {
-      return fromISO(value as ISODateString);
+      return plainDateFromISO(value as ISODateString);
     }
     return null;
   }, [mode, value]);
@@ -566,7 +574,7 @@ function MonthGrid({
       return null;
     }
 
-    return toISO(fromDate(parsed));
+    return plainDateToISO(plainDateFromDate(parsed));
   }, []);
 
   // Handle navigation to previous month
@@ -626,8 +634,8 @@ function MonthGrid({
       'button:not([disabled])',
     );
 
-    const targetPd = fromISO(pendingFocus);
-    const targetLabel = formatAccessible(targetPd);
+    const targetPd = plainDateFromISO(pendingFocus);
+    const targetLabel = plainDateFormatAccessible(targetPd);
 
     let targetButton: HTMLElement | null = null;
     for (const button of buttons) {
@@ -651,16 +659,16 @@ function MonthGrid({
   let rangeEnd: PlainDate | null = null;
 
   if (mode === 'single' && value && typeof value === 'string') {
-    selectedDate = fromISO(value as ISODateString);
+    selectedDate = plainDateFromISO(value as ISODateString);
   } else if (mode === 'range' && value && typeof value === 'object') {
     const range = value as DateRange;
-    rangeStart = fromISO(range.start);
-    rangeEnd = fromISO(range.end);
+    rangeStart = plainDateFromISO(range.start);
+    rangeEnd = plainDateFromISO(range.end);
   }
 
   // Handle in-progress range selection
   if (rangeSelectionStart) {
-    rangeStart = fromISO(rangeSelectionStart);
+    rangeStart = plainDateFromISO(rangeSelectionStart);
     rangeEnd = rangeStart;
   }
 
@@ -668,10 +676,10 @@ function MonthGrid({
   let previewStart: PlainDate | null = null;
   let previewEnd: PlainDate | null = null;
   if (mode === 'range' && rangeSelectionStart && hoveredDate) {
-    const startPd = fromISO(rangeSelectionStart);
-    const hoverPd = fromISO(hoveredDate);
-    if (!isSameDay(startPd, hoverPd)) {
-      if (compare(hoverPd, startPd) < 0) {
+    const startPd = plainDateFromISO(rangeSelectionStart);
+    const hoverPd = plainDateFromISO(hoveredDate);
+    if (!plainDateIsSameDay(startPd, hoverPd)) {
+      if (plainDateIsBefore(hoverPd, startPd)) {
         previewStart = hoverPd;
         previewEnd = startPd;
       } else {
@@ -686,7 +694,7 @@ function MonthGrid({
     return new Intl.DateTimeFormat(undefined, {
       year: 'numeric',
       month: 'long',
-    }).format(toDate(month));
+    }).format(plainDateToDate(month));
   }, [month]);
 
   return (
@@ -727,7 +735,7 @@ function MonthGrid({
         )}>
         {weeks.map((week, weekIndex) => {
           const weekDate = week.find(d => !d.isOutside)?.date || week[0].date;
-          const weekNum = getWeekNumber(weekDate);
+          const weekNum = plainDateGetWeekNumber(weekDate);
 
           return (
             <div
@@ -813,25 +821,26 @@ function DayCell({
   // Outside days should not be clickable even when visible
   const effectivelyDisabled = isDisabled || isOutside;
 
-  const isToday = isSameDay(date, today);
+  const isToday = plainDateIsSameDay(date, today);
   const isSelected =
-    mode === 'single' && selectedDate && isSameDay(date, selectedDate);
+    mode === 'single' && selectedDate && plainDateIsSameDay(date, selectedDate);
   const isInRange =
     mode === 'range' &&
     rangeStart &&
     rangeEnd &&
-    isPlainDateInRange(date, rangeStart, rangeEnd);
+    plainDateIsInRange(date, rangeStart, rangeEnd);
   const isRangeStart =
-    mode === 'range' && rangeStart && isSameDay(date, rangeStart);
-  const isRangeEnd = mode === 'range' && rangeEnd && isSameDay(date, rangeEnd);
+    mode === 'range' && rangeStart && plainDateIsSameDay(date, rangeStart);
+  const isRangeEnd =
+    mode === 'range' && rangeEnd && plainDateIsSameDay(date, rangeEnd);
 
   // Preview range calculations
   const isInPreview =
     previewStart &&
     previewEnd &&
-    isPlainDateInRange(date, previewStart, previewEnd);
-  const isPreviewStart = previewStart && isSameDay(date, previewStart);
-  const isPreviewEnd = previewEnd && isSameDay(date, previewEnd);
+    plainDateIsInRange(date, previewStart, previewEnd);
+  const isPreviewStart = previewStart && plainDateIsSameDay(date, previewStart);
+  const isPreviewEnd = previewEnd && plainDateIsSameDay(date, previewEnd);
 
   // Determine cell background for range
   const hasRangeBackground = isInRange;
@@ -885,7 +894,7 @@ function DayCell({
         type="button"
         role="gridcell"
         data-date={day.iso}
-        aria-label={formatAccessible(date)}
+        aria-label={plainDateFormatAccessible(date)}
         aria-selected={isSelected || isInRange || undefined}
         aria-disabled={effectivelyDisabled || undefined}
         disabled={isDisabled}

--- a/packages/core/src/Calendar/XDSCalendar.tsx
+++ b/packages/core/src/Calendar/XDSCalendar.tsx
@@ -51,7 +51,6 @@ import {
   plainDateAddMonths,
   plainDateAddDays,
   plainDateIsBefore,
-  plainDateIsAfter,
   plainDateIsEqual,
   plainDateIsInRange,
   plainDateGetWeekNumber,

--- a/packages/core/src/Calendar/XDSCalendar.tsx
+++ b/packages/core/src/Calendar/XDSCalendar.tsx
@@ -56,6 +56,7 @@ import {
   plainDateGetWeekNumber,
   plainDateFormat,
   DATE_FORMAT_WITH_WEEKDAY,
+  DATE_FORMAT_MONTH_YEAR,
 } from '../utils/plainDate';
 import {xdsClassName, mergeProps} from '../utils';
 
@@ -268,15 +269,11 @@ export function XDSCalendar({ref, ...props}: XDSCalendarProps) {
 
   // Format month header
   const monthYearLabel = useMemo(() => {
-    const formatter = new Intl.DateTimeFormat(undefined, {
-      year: 'numeric',
-      month: 'long',
-    });
     if (numberOfMonths === 1) {
-      return formatter.format(plainDateToDate(visibleMonths[0]));
+      return plainDateFormat(visibleMonths[0], DATE_FORMAT_MONTH_YEAR);
     }
     return visibleMonths
-      .map(m => formatter.format(plainDateToDate(m)))
+      .map(m => plainDateFormat(m, DATE_FORMAT_MONTH_YEAR))
       .join(' – ');
   }, [visibleMonths, numberOfMonths]);
 
@@ -674,10 +671,7 @@ function MonthGrid({
 
   // Month label for announcements
   const monthLabel = useMemo(() => {
-    return new Intl.DateTimeFormat(undefined, {
-      year: 'numeric',
-      month: 'long',
-    }).format(plainDateToDate(month));
+    return plainDateFormat(month, DATE_FORMAT_MONTH_YEAR);
   }, [month]);
 
   return (

--- a/packages/core/src/Calendar/hooks/useCalendarConstraints.ts
+++ b/packages/core/src/Calendar/hooks/useCalendarConstraints.ts
@@ -4,7 +4,7 @@
 
 /**
  * @file useCalendarConstraints.ts
- * @input Uses React useCallback, useMemo
+ * @input Uses React useCallback, useMemo, PlainDate utilities
  * @output Exports useCalendarConstraints hook for date validation
  * @position Calendar-specific hook; used by XDSCalendar
  *
@@ -14,6 +14,7 @@
 
 import {useCallback, useMemo} from 'react';
 import type {ISODateString} from '../XDSCalendar';
+import {type PlainDate, fromISO, toDate, compare} from '../../utils/plainDate';
 
 /**
  * Configuration for date constraints
@@ -34,20 +35,12 @@ export interface UseCalendarConstraintsOptions {
  * Return type for useCalendarConstraints hook
  */
 export interface UseCalendarConstraintsReturn {
-  /** Check if a date is disabled */
-  isDateDisabled: (date: Date) => boolean;
+  /** Check if a PlainDate is disabled */
+  isDateDisabled: (date: PlainDate) => boolean;
   /** Parsed min date (or null) */
-  minDate: Date | null;
+  minDate: PlainDate | null;
   /** Parsed max date (or null) */
-  maxDate: Date | null;
-}
-
-/**
- * Parse ISO date string to Date object.
- */
-function parseISO(str: ISODateString): Date {
-  const [year, month, day] = str.split('-').map(Number);
-  return new Date(year, month - 1, day);
+  maxDate: PlainDate | null;
 }
 
 /**
@@ -62,12 +55,12 @@ function parseISO(str: ISODateString): Date {
  *   min: '2026-01-01',
  *   max: '2026-12-31',
  *   dateConstraints: [
- *     (date) => date.getDay() !== 0, // No Sundays
+ *     (date) => date.getDay() !== 0, // No Sundays (receives native Date)
  *   ],
  * });
  *
- * // Check if a date can be selected
- * if (isDateDisabled(someDate)) {
+ * // Check if a PlainDate can be selected
+ * if (isDateDisabled({year: 2026, month: 6, day: 15})) {
  *   console.log('This date is not selectable');
  * }
  * ```
@@ -78,26 +71,26 @@ export function useCalendarConstraints(
   const {min, max, dateConstraints} = options;
 
   // Parse min/max dates
-  const minDate = useMemo(() => (min ? parseISO(min) : null), [min]);
-  const maxDate = useMemo(() => (max ? parseISO(max) : null), [max]);
+  const minDate = useMemo(() => (min ? fromISO(min) : null), [min]);
+  const maxDate = useMemo(() => (max ? fromISO(max) : null), [max]);
 
   // Check if a date is disabled
   const isDateDisabled = useCallback(
-    (date: Date): boolean => {
+    (date: PlainDate): boolean => {
       // Check min bound
-      if (minDate && date < minDate) {
+      if (minDate && compare(date, minDate) < 0) {
         return true;
       }
 
       // Check max bound
-      if (maxDate && date > maxDate) {
+      if (maxDate && compare(date, maxDate) > 0) {
         return true;
       }
 
-      // Check custom constraints
+      // Check custom constraints (convert to Date for public API compatibility)
       if (dateConstraints) {
         for (const constraint of dateConstraints) {
-          if (!constraint(date)) {
+          if (!constraint(toDate(date))) {
             return true;
           }
         }

--- a/packages/core/src/Calendar/hooks/useCalendarConstraints.ts
+++ b/packages/core/src/Calendar/hooks/useCalendarConstraints.ts
@@ -14,7 +14,13 @@
 
 import {useCallback, useMemo} from 'react';
 import type {ISODateString} from '../XDSCalendar';
-import {type PlainDate, fromISO, toDate, compare} from '../../utils/plainDate';
+import {
+  type PlainDate,
+  plainDateFromISO,
+  plainDateToDate,
+  plainDateIsBefore,
+  plainDateIsAfter,
+} from '../../utils/plainDate';
 
 /**
  * Configuration for date constraints
@@ -71,26 +77,26 @@ export function useCalendarConstraints(
   const {min, max, dateConstraints} = options;
 
   // Parse min/max dates
-  const minDate = useMemo(() => (min ? fromISO(min) : null), [min]);
-  const maxDate = useMemo(() => (max ? fromISO(max) : null), [max]);
+  const minDate = useMemo(() => (min ? plainDateFromISO(min) : null), [min]);
+  const maxDate = useMemo(() => (max ? plainDateFromISO(max) : null), [max]);
 
   // Check if a date is disabled
   const isDateDisabled = useCallback(
     (date: PlainDate): boolean => {
       // Check min bound
-      if (minDate && compare(date, minDate) < 0) {
+      if (minDate && plainDateIsBefore(date, minDate)) {
         return true;
       }
 
       // Check max bound
-      if (maxDate && compare(date, maxDate) > 0) {
+      if (maxDate && plainDateIsAfter(date, maxDate)) {
         return true;
       }
 
       // Check custom constraints (convert to Date for public API compatibility)
       if (dateConstraints) {
         for (const constraint of dateConstraints) {
-          if (!constraint(toDate(date))) {
+          if (!constraint(plainDateToDate(date))) {
             return true;
           }
         }

--- a/packages/core/src/Calendar/hooks/useCalendarConstraints.ts
+++ b/packages/core/src/Calendar/hooks/useCalendarConstraints.ts
@@ -13,7 +13,7 @@
  */
 
 import {useCallback, useMemo} from 'react';
-import type {ISODateString} from '../XDSCalendar';
+import type {ISODateString} from '../../utils/dateTypes';
 import {
   type PlainDate,
   plainDateFromISO,

--- a/packages/core/src/Calendar/hooks/useCalendarDays.ts
+++ b/packages/core/src/Calendar/hooks/useCalendarDays.ts
@@ -13,7 +13,7 @@
  */
 
 import {useMemo} from 'react';
-import type {DayOfWeek, ISODateString} from '../XDSCalendar';
+import type {DayOfWeek, ISODateString} from '../../utils/dateTypes';
 import {
   type PlainDate,
   plainDateToISO,
@@ -42,7 +42,7 @@ export interface CalendarDay {
 export interface UseCalendarDaysOptions {
   /** The year to generate days for */
   year: number;
-  /** The month index (0-11) */
+  /** The month (1-based: 1 = January, 12 = December) */
   month: number;
   /** First day of week (0=Sunday through 6=Saturday) */
   weekStartsOn?: DayOfWeek;
@@ -74,7 +74,7 @@ export interface UseCalendarDaysReturn {
  * ```
  * const {days, weeks, dayNames} = useCalendarDays({
  *   year: 2026,
- *   month: 0, // January (0-based)
+ *   month: 1, // January (1-based)
  *   weekStartsOn: 0, // Sunday
  * });
  * // days[i].date is a PlainDate { year, month (1-based), day }
@@ -86,14 +86,12 @@ export function useCalendarDays(
   const {year, month, weekStartsOn = 0, hasVariableRowCount = false} = options;
 
   // Calculate grid structure
-  // Note: `month` is 0-based from the public API; convert to 1-based for plainDate fns
   const gridInfo = useMemo(() => {
-    const month1 = month + 1; // 1-based month for plainDate utilities
-    const totalDaysInMonth = plainDateDaysInMonth(year, month1);
+    const totalDaysInMonth = plainDateDaysInMonth(year, month);
 
     // Calculate starting offset based on weekStartsOn
     let startingDayOfWeek =
-      plainDateDayOfWeek({year, month: month1, day: 1}) - weekStartsOn;
+      plainDateDayOfWeek({year, month, day: 1}) - weekStartsOn;
     if (startingDayOfWeek < 0) {
       startingDayOfWeek += 7;
     }
@@ -127,17 +125,15 @@ export function useCalendarDays(
       startingDayOfWeek,
       totalCells,
     } = gridInfo;
-    const month1 = month + 1; // 1-based month
-    const firstOfMonth: PlainDate = {year, month: month1, day: 1};
+    const firstOfMonth: PlainDate = {year, month, day: 1};
     const result: CalendarDay[] = [];
 
     for (let i = 0; i < totalCells; i++) {
       const dayOffset = i - startingDayOfWeek + 1;
       const isOutside = dayOffset < 1 || dayOffset > totalDaysInMonth;
-      // For in-month days, construct directly; for outside days, use addDays
       const pd: PlainDate = isOutside
         ? plainDateAddDays(firstOfMonth, dayOffset - 1)
-        : {year, month: month1, day: dayOffset};
+        : {year, month, day: dayOffset};
 
       result.push({
         date: pd,

--- a/packages/core/src/Calendar/hooks/useCalendarDays.ts
+++ b/packages/core/src/Calendar/hooks/useCalendarDays.ts
@@ -17,7 +17,7 @@ import type {DayOfWeek, ISODateString} from '../../utils/dateTypes';
 import {
   type PlainDate,
   plainDateToISO,
-  plainDateDaysInMonth,
+  getDaysInMonth,
   plainDateDayOfWeek,
   plainDateAddDays,
 } from '../../utils/plainDate';
@@ -87,7 +87,7 @@ export function useCalendarDays(
 
   // Calculate grid structure
   const gridInfo = useMemo(() => {
-    const totalDaysInMonth = plainDateDaysInMonth(year, month);
+    const totalDaysInMonth = getDaysInMonth(year, month);
 
     // Calculate starting offset based on weekStartsOn
     let startingDayOfWeek =

--- a/packages/core/src/Calendar/hooks/useCalendarDays.ts
+++ b/packages/core/src/Calendar/hooks/useCalendarDays.ts
@@ -16,10 +16,10 @@ import {useMemo} from 'react';
 import type {DayOfWeek, ISODateString} from '../XDSCalendar';
 import {
   type PlainDate,
-  toISO,
-  daysInMonth,
-  dayOfWeek,
-  addDays,
+  plainDateToISO,
+  plainDateDaysInMonth,
+  plainDateDayOfWeek,
+  plainDateAddDays,
 } from '../../utils/plainDate';
 
 /**
@@ -89,11 +89,11 @@ export function useCalendarDays(
   // Note: `month` is 0-based from the public API; convert to 1-based for plainDate fns
   const gridInfo = useMemo(() => {
     const month1 = month + 1; // 1-based month for plainDate utilities
-    const totalDaysInMonth = daysInMonth(year, month1);
+    const totalDaysInMonth = plainDateDaysInMonth(year, month1);
 
     // Calculate starting offset based on weekStartsOn
     let startingDayOfWeek =
-      dayOfWeek({year, month: month1, day: 1}) - weekStartsOn;
+      plainDateDayOfWeek({year, month: month1, day: 1}) - weekStartsOn;
     if (startingDayOfWeek < 0) {
       startingDayOfWeek += 7;
     }
@@ -136,12 +136,12 @@ export function useCalendarDays(
       const isOutside = dayOffset < 1 || dayOffset > totalDaysInMonth;
       // For in-month days, construct directly; for outside days, use addDays
       const pd: PlainDate = isOutside
-        ? addDays(firstOfMonth, dayOffset - 1)
+        ? plainDateAddDays(firstOfMonth, dayOffset - 1)
         : {year, month: month1, day: dayOffset};
 
       result.push({
         date: pd,
-        iso: toISO(pd),
+        iso: plainDateToISO(pd),
         isOutside,
         dayNumber: pd.day,
       });

--- a/packages/core/src/Calendar/hooks/useCalendarDays.ts
+++ b/packages/core/src/Calendar/hooks/useCalendarDays.ts
@@ -4,7 +4,7 @@
 
 /**
  * @file useCalendarDays.ts
- * @input Uses React useMemo
+ * @input Uses React useMemo, PlainDate utilities
  * @output Exports useCalendarDays hook for generating calendar day grids
  * @position Calendar-specific hook; used by XDSCalendar
  *
@@ -14,13 +14,20 @@
 
 import {useMemo} from 'react';
 import type {DayOfWeek, ISODateString} from '../XDSCalendar';
+import {
+  type PlainDate,
+  toISO,
+  daysInMonth,
+  dayOfWeek,
+  addDays,
+} from '../../utils/plainDate';
 
 /**
  * Represents a single day in the calendar grid.
  */
 export interface CalendarDay {
-  /** The date object for this day */
-  date: Date;
+  /** The PlainDate for this day */
+  date: PlainDate;
   /** ISO date string (YYYY-MM-DD) */
   iso: ISODateString;
   /** Whether this day is outside the current month */
@@ -58,16 +65,6 @@ export interface UseCalendarDaysReturn {
 }
 
 /**
- * Convert a Date to ISO date string format.
- */
-function dateToISO(date: Date): ISODateString {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
-  return `${year}-${month}-${day}` as ISODateString;
-}
-
-/**
  * Hook for generating calendar day grids.
  *
  * Calculates all the days to display for a given month, including
@@ -77,9 +74,10 @@ function dateToISO(date: Date): ISODateString {
  * ```
  * const {days, weeks, dayNames} = useCalendarDays({
  *   year: 2026,
- *   month: 0, // January
+ *   month: 0, // January (0-based)
  *   weekStartsOn: 0, // Sunday
  * });
+ * // days[i].date is a PlainDate { year, month (1-based), day }
  * ```
  */
 export function useCalendarDays(
@@ -88,24 +86,25 @@ export function useCalendarDays(
   const {year, month, weekStartsOn = 0, hasVariableRowCount = false} = options;
 
   // Calculate grid structure
+  // Note: `month` is 0-based from the public API; convert to 1-based for plainDate fns
   const gridInfo = useMemo(() => {
-    const firstDayOfMonth = new Date(year, month, 1);
-    const lastDayOfMonth = new Date(year, month + 1, 0);
-    const daysInMonth = lastDayOfMonth.getDate();
+    const month1 = month + 1; // 1-based month for plainDate utilities
+    const totalDaysInMonth = daysInMonth(year, month1);
 
     // Calculate starting offset based on weekStartsOn
-    let startingDayOfWeek = firstDayOfMonth.getDay() - weekStartsOn;
+    let startingDayOfWeek =
+      dayOfWeek({year, month: month1, day: 1}) - weekStartsOn;
     if (startingDayOfWeek < 0) {
       startingDayOfWeek += 7;
     }
 
     // Calculate total cells
-    const totalDays = daysInMonth + startingDayOfWeek;
+    const totalDays = totalDaysInMonth + startingDayOfWeek;
     const totalRows = hasVariableRowCount ? Math.ceil(totalDays / 7) : 6;
     const totalCells = totalRows * 7;
 
     return {
-      daysInMonth,
+      daysInMonth: totalDaysInMonth,
       startingDayOfWeek,
       totalCells,
     };
@@ -123,19 +122,28 @@ export function useCalendarDays(
 
   // Generate days array
   const days = useMemo(() => {
-    const {daysInMonth, startingDayOfWeek, totalCells} = gridInfo;
+    const {
+      daysInMonth: totalDaysInMonth,
+      startingDayOfWeek,
+      totalCells,
+    } = gridInfo;
+    const month1 = month + 1; // 1-based month
+    const firstOfMonth: PlainDate = {year, month: month1, day: 1};
     const result: CalendarDay[] = [];
 
     for (let i = 0; i < totalCells; i++) {
       const dayOffset = i - startingDayOfWeek + 1;
-      const date = new Date(year, month, dayOffset);
-      const isOutside = dayOffset < 1 || dayOffset > daysInMonth;
+      const isOutside = dayOffset < 1 || dayOffset > totalDaysInMonth;
+      // For in-month days, construct directly; for outside days, use addDays
+      const pd: PlainDate = isOutside
+        ? addDays(firstOfMonth, dayOffset - 1)
+        : {year, month: month1, day: dayOffset};
 
       result.push({
-        date,
-        iso: dateToISO(date),
+        date: pd,
+        iso: toISO(pd),
         isOutside,
-        dayNumber: date.getDate(),
+        dayNumber: pd.day,
       });
     }
 

--- a/packages/core/src/Calendar/hooks/useCalendarNavigation.ts
+++ b/packages/core/src/Calendar/hooks/useCalendarNavigation.ts
@@ -16,13 +16,13 @@ import {useState, useMemo, useCallback} from 'react';
 import type {ISODateString} from '../XDSCalendar';
 import {
   type PlainDate,
-  fromISO,
-  toISO,
-  toDate,
-  today as todayFn,
-  firstOfMonth,
-  addMonths,
-  addDays,
+  plainDateFromISO,
+  plainDateToISO,
+  plainDateToDate,
+  plainDateToday,
+  plainDateFirstOfMonth,
+  plainDateAddMonths,
+  plainDateAddDays,
 } from '../../utils/plainDate';
 
 /**
@@ -104,30 +104,30 @@ export function useCalendarNavigation(
   // Internal focus date state (PlainDate)
   const [internalFocusDate, setInternalFocusDate] = useState<PlainDate>(() => {
     if (focusDateProp) {
-      return fromISO(focusDateProp);
+      return plainDateFromISO(focusDateProp);
     }
     if (initialValue) {
-      return fromISO(initialValue);
+      return plainDateFromISO(initialValue);
     }
-    return todayFn();
+    return plainDateToday();
   });
 
   // Determine if focus is controlled
   const isControlledFocus =
     focusDateProp !== undefined && onFocusDateChange !== undefined;
   const focusDate: PlainDate = isControlledFocus
-    ? fromISO(focusDateProp)
+    ? plainDateFromISO(focusDateProp)
     : internalFocusDate;
 
   // Base month (first day of focus month)
   const baseMonth = useMemo(() => {
-    return firstOfMonth(focusDate);
+    return plainDateFirstOfMonth(focusDate);
   }, [focusDate]);
 
   // Generate visible months
   const visibleMonths = useMemo(() => {
     return Array.from({length: numberOfMonths}, (_, i) => {
-      return addMonths(baseMonth, i);
+      return plainDateAddMonths(baseMonth, i);
     });
   }, [baseMonth, numberOfMonths]);
 
@@ -138,24 +138,26 @@ export function useCalendarNavigation(
       month: 'long',
     });
     if (numberOfMonths === 1) {
-      return formatter.format(toDate(visibleMonths[0]));
+      return formatter.format(plainDateToDate(visibleMonths[0]));
     }
-    return visibleMonths.map(m => formatter.format(toDate(m))).join(' – ');
+    return visibleMonths
+      .map(m => formatter.format(plainDateToDate(m)))
+      .join(' – ');
   }, [visibleMonths, numberOfMonths]);
 
   // Navigate to previous/next month
   const navigateMonth = useCallback(
     (delta: number, focusedDate?: ISODateString, offset?: number) => {
-      const newMonth = addMonths(baseMonth, delta);
-      const newISO = toISO(newMonth);
+      const newMonth = plainDateAddMonths(baseMonth, delta);
+      const newISO = plainDateToISO(newMonth);
 
       // Calculate target focus date if provided
       if (focusedDate) {
-        const currentDate = fromISO(focusedDate);
+        const currentDate = plainDateFromISO(focusedDate);
         // Use the provided offset (1 for horizontal, 7 for vertical)
         const daysToMove = offset ?? 7;
-        const targetDate = addDays(currentDate, delta * daysToMove);
-        setPendingFocus(toISO(targetDate));
+        const targetDate = plainDateAddDays(currentDate, delta * daysToMove);
+        setPendingFocus(plainDateToISO(targetDate));
       }
 
       if (onFocusDateChange) {

--- a/packages/core/src/Calendar/hooks/useCalendarNavigation.ts
+++ b/packages/core/src/Calendar/hooks/useCalendarNavigation.ts
@@ -13,14 +13,14 @@
  */
 
 import {useState, useMemo, useCallback} from 'react';
-import type {ISODateString} from '../XDSCalendar';
+import type {ISODateString} from '../../utils/dateTypes';
 import {
   type PlainDate,
   plainDateFromISO,
   plainDateToISO,
   plainDateToDate,
   plainDateToday,
-  plainDateFirstOfMonth,
+  plainDateSetFirstOfMonth,
   plainDateAddMonths,
   plainDateAddDays,
 } from '../../utils/plainDate';
@@ -121,7 +121,7 @@ export function useCalendarNavigation(
 
   // Base month (first day of focus month)
   const baseMonth = useMemo(() => {
-    return plainDateFirstOfMonth(focusDate);
+    return plainDateSetFirstOfMonth(focusDate);
   }, [focusDate]);
 
   // Generate visible months

--- a/packages/core/src/Calendar/hooks/useCalendarNavigation.ts
+++ b/packages/core/src/Calendar/hooks/useCalendarNavigation.ts
@@ -18,11 +18,12 @@ import {
   type PlainDate,
   plainDateFromISO,
   plainDateToISO,
-  plainDateToDate,
   plainDateToday,
   plainDateSetFirstOfMonth,
   plainDateAddMonths,
   plainDateAddDays,
+  plainDateFormat,
+  DATE_FORMAT_MONTH_YEAR,
 } from '../../utils/plainDate';
 
 /**
@@ -133,15 +134,11 @@ export function useCalendarNavigation(
 
   // Format month header
   const monthYearLabel = useMemo(() => {
-    const formatter = new Intl.DateTimeFormat(undefined, {
-      year: 'numeric',
-      month: 'long',
-    });
     if (numberOfMonths === 1) {
-      return formatter.format(plainDateToDate(visibleMonths[0]));
+      return plainDateFormat(visibleMonths[0], DATE_FORMAT_MONTH_YEAR);
     }
     return visibleMonths
-      .map(m => formatter.format(plainDateToDate(m)))
+      .map(m => plainDateFormat(m, DATE_FORMAT_MONTH_YEAR))
       .join(' – ');
   }, [visibleMonths, numberOfMonths]);
 

--- a/packages/core/src/Calendar/hooks/useCalendarNavigation.ts
+++ b/packages/core/src/Calendar/hooks/useCalendarNavigation.ts
@@ -4,7 +4,7 @@
 
 /**
  * @file useCalendarNavigation.ts
- * @input Uses React useState, useMemo, useCallback
+ * @input Uses React useState, useMemo, useCallback, PlainDate utilities
  * @output Exports useCalendarNavigation hook for month navigation
  * @position Calendar-specific hook; used by XDSCalendar
  *
@@ -14,6 +14,16 @@
 
 import {useState, useMemo, useCallback} from 'react';
 import type {ISODateString} from '../XDSCalendar';
+import {
+  type PlainDate,
+  fromISO,
+  toISO,
+  toDate,
+  today as todayFn,
+  firstOfMonth,
+  addMonths,
+  addDays,
+} from '../../utils/plainDate';
 
 /**
  * Configuration for calendar navigation
@@ -33,10 +43,10 @@ export interface UseCalendarNavigationOptions {
  * Return type for useCalendarNavigation hook
  */
 export interface UseCalendarNavigationReturn {
-  /** The base month (first day of the focus month) */
-  baseMonth: Date;
-  /** Array of visible months to render */
-  visibleMonths: Date[];
+  /** The base month (first day of the focus month) as a PlainDate */
+  baseMonth: PlainDate;
+  /** Array of visible months to render as PlainDates */
+  visibleMonths: PlainDate[];
   /** Formatted label for the month header */
   monthYearLabel: string;
   /** Navigate to previous/next month */
@@ -49,24 +59,6 @@ export interface UseCalendarNavigationReturn {
   pendingFocus: ISODateString | null;
   /** Clear the pending focus */
   clearPendingFocus: () => void;
-}
-
-/**
- * Convert a Date to ISO date string format.
- */
-function dateToISO(date: Date): ISODateString {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
-  return `${year}-${month}-${day}` as ISODateString;
-}
-
-/**
- * Parse ISO date string to Date object.
- */
-function parseISO(str: ISODateString): Date {
-  const [year, month, day] = str.split('-').map(Number);
-  return new Date(year, month - 1, day);
 }
 
 /**
@@ -109,37 +101,33 @@ export function useCalendarNavigation(
   // Pending focus target after month navigation
   const [pendingFocus, setPendingFocus] = useState<ISODateString | null>(null);
 
-  // Internal focus date state
-  const [internalFocusDate, setInternalFocusDate] = useState<Date>(() => {
+  // Internal focus date state (PlainDate)
+  const [internalFocusDate, setInternalFocusDate] = useState<PlainDate>(() => {
     if (focusDateProp) {
-      return parseISO(focusDateProp);
+      return fromISO(focusDateProp);
     }
     if (initialValue) {
-      return parseISO(initialValue);
+      return fromISO(initialValue);
     }
-    return new Date();
+    return todayFn();
   });
 
   // Determine if focus is controlled
   const isControlledFocus =
     focusDateProp !== undefined && onFocusDateChange !== undefined;
-  const focusDate = isControlledFocus
-    ? parseISO(focusDateProp)
+  const focusDate: PlainDate = isControlledFocus
+    ? fromISO(focusDateProp)
     : internalFocusDate;
 
   // Base month (first day of focus month)
   const baseMonth = useMemo(() => {
-    const d = new Date(focusDate);
-    d.setDate(1);
-    return d;
+    return firstOfMonth(focusDate);
   }, [focusDate]);
 
   // Generate visible months
   const visibleMonths = useMemo(() => {
     return Array.from({length: numberOfMonths}, (_, i) => {
-      const m = new Date(baseMonth);
-      m.setMonth(baseMonth.getMonth() + i);
-      return m;
+      return addMonths(baseMonth, i);
     });
   }, [baseMonth, numberOfMonths]);
 
@@ -150,31 +138,30 @@ export function useCalendarNavigation(
       month: 'long',
     });
     if (numberOfMonths === 1) {
-      return formatter.format(visibleMonths[0]);
+      return formatter.format(toDate(visibleMonths[0]));
     }
-    return visibleMonths.map(m => formatter.format(m)).join(' – ');
+    return visibleMonths.map(m => formatter.format(toDate(m))).join(' – ');
   }, [visibleMonths, numberOfMonths]);
 
   // Navigate to previous/next month
   const navigateMonth = useCallback(
     (delta: number, focusedDate?: ISODateString, offset?: number) => {
-      const newDate = new Date(baseMonth);
-      newDate.setMonth(baseMonth.getMonth() + delta);
-      const newISO = dateToISO(newDate);
+      const newMonth = addMonths(baseMonth, delta);
+      const newISO = toISO(newMonth);
 
       // Calculate target focus date if provided
       if (focusedDate) {
-        const currentDate = parseISO(focusedDate);
+        const currentDate = fromISO(focusedDate);
         // Use the provided offset (1 for horizontal, 7 for vertical)
         const daysToMove = offset ?? 7;
-        currentDate.setDate(currentDate.getDate() + delta * daysToMove);
-        setPendingFocus(dateToISO(currentDate));
+        const targetDate = addDays(currentDate, delta * daysToMove);
+        setPendingFocus(toISO(targetDate));
       }
 
       if (onFocusDateChange) {
         onFocusDateChange(newISO);
       } else {
-        setInternalFocusDate(newDate);
+        setInternalFocusDate(newMonth);
       }
     },
     [baseMonth, onFocusDateChange],

--- a/packages/core/src/Calendar/hooks/useCalendarRovingTabindex.ts
+++ b/packages/core/src/Calendar/hooks/useCalendarRovingTabindex.ts
@@ -13,7 +13,7 @@
  */
 
 import {useMemo} from 'react';
-import type {ISODateString} from '../XDSCalendar';
+import type {ISODateString} from '../../utils/dateTypes';
 import {type PlainDate, plainDateToISO} from '../../utils/plainDate';
 import type {CalendarDay} from './useCalendarDays';
 
@@ -27,7 +27,7 @@ export interface UseCalendarRovingTabindexOptions {
   today: PlainDate;
   /** The year being displayed */
   year: number;
-  /** The month being displayed (0-11) */
+  /** The month being displayed (1-based: 1 = January, 12 = December) */
   month: number;
   /** Function to check if a date is disabled */
   isDateDisabled: (date: PlainDate) => boolean;
@@ -61,7 +61,7 @@ export interface UseCalendarRovingTabindexReturn {
  *   days,
  *   today: {year: 2026, month: 1, day: 20},
  *   year: 2026,
- *   month: 0, // 0-based month
+ *   month: 1, // January (1-based)
  *   isDateDisabled,
  * });
  *
@@ -78,20 +78,17 @@ export function useCalendarRovingTabindex(
 
   // Determine which day should be tabbable
   const tabbableDate = useMemo(() => {
-    // Note: `month` is 0-based from the public API; PlainDate.month is 1-based
-    const month1 = month + 1;
-
     // Priority 1: Selected date if visible in this month and enabled
     if (selectedDate) {
       const isSelectedInMonth =
-        selectedDate.year === year && selectedDate.month === month1;
+        selectedDate.year === year && selectedDate.month === month;
       if (isSelectedInMonth && !isDateDisabled(selectedDate)) {
         return plainDateToISO(selectedDate);
       }
     }
 
     // Priority 2: Today if visible in this month and enabled
-    const isTodayInMonth = today.year === year && today.month === month1;
+    const isTodayInMonth = today.year === year && today.month === month;
 
     if (isTodayInMonth && !isDateDisabled(today)) {
       return plainDateToISO(today);

--- a/packages/core/src/Calendar/hooks/useCalendarRovingTabindex.ts
+++ b/packages/core/src/Calendar/hooks/useCalendarRovingTabindex.ts
@@ -14,7 +14,7 @@
 
 import {useMemo} from 'react';
 import type {ISODateString} from '../XDSCalendar';
-import {type PlainDate, toISO} from '../../utils/plainDate';
+import {type PlainDate, plainDateToISO} from '../../utils/plainDate';
 import type {CalendarDay} from './useCalendarDays';
 
 /**
@@ -86,7 +86,7 @@ export function useCalendarRovingTabindex(
       const isSelectedInMonth =
         selectedDate.year === year && selectedDate.month === month1;
       if (isSelectedInMonth && !isDateDisabled(selectedDate)) {
-        return toISO(selectedDate);
+        return plainDateToISO(selectedDate);
       }
     }
 
@@ -94,7 +94,7 @@ export function useCalendarRovingTabindex(
     const isTodayInMonth = today.year === year && today.month === month1;
 
     if (isTodayInMonth && !isDateDisabled(today)) {
-      return toISO(today);
+      return plainDateToISO(today);
     }
 
     // Priority 3: First enabled day in this month

--- a/packages/core/src/Calendar/hooks/useCalendarRovingTabindex.ts
+++ b/packages/core/src/Calendar/hooks/useCalendarRovingTabindex.ts
@@ -4,7 +4,7 @@
 
 /**
  * @file useCalendarRovingTabindex.ts
- * @input Uses React useMemo
+ * @input Uses React useMemo, PlainDate utilities
  * @output Exports useCalendarRovingTabindex hook for accessible grid navigation
  * @position Calendar-specific hook; used by XDSCalendar
  *
@@ -14,6 +14,7 @@
 
 import {useMemo} from 'react';
 import type {ISODateString} from '../XDSCalendar';
+import {type PlainDate, toISO} from '../../utils/plainDate';
 import type {CalendarDay} from './useCalendarDays';
 
 /**
@@ -22,16 +23,16 @@ import type {CalendarDay} from './useCalendarDays';
 export interface UseCalendarRovingTabindexOptions {
   /** All days in the grid */
   days: CalendarDay[];
-  /** Today's date */
-  today: Date;
+  /** Today's date as a PlainDate */
+  today: PlainDate;
   /** The year being displayed */
   year: number;
   /** The month being displayed (0-11) */
   month: number;
   /** Function to check if a date is disabled */
-  isDateDisabled: (date: Date) => boolean;
+  isDateDisabled: (date: PlainDate) => boolean;
   /** Currently selected date (if any) */
-  selectedDate?: Date | null;
+  selectedDate?: PlainDate | null;
 }
 
 /**
@@ -42,16 +43,6 @@ export interface UseCalendarRovingTabindexReturn {
   tabbableDate: ISODateString | null;
   /** Check if a specific date is the tabbable one */
   isTabbable: (iso: ISODateString) => boolean;
-}
-
-/**
- * Convert a Date to ISO date string format.
- */
-function dateToISO(date: Date): ISODateString {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
-  return `${year}-${month}-${day}` as ISODateString;
 }
 
 /**
@@ -68,9 +59,9 @@ function dateToISO(date: Date): ISODateString {
  * ```
  * const {tabbableDate, isTabbable} = useCalendarRovingTabindex({
  *   days,
- *   today: new Date(),
+ *   today: {year: 2026, month: 1, day: 20},
  *   year: 2026,
- *   month: 0,
+ *   month: 0, // 0-based month
  *   isDateDisabled,
  * });
  *
@@ -87,22 +78,23 @@ export function useCalendarRovingTabindex(
 
   // Determine which day should be tabbable
   const tabbableDate = useMemo(() => {
+    // Note: `month` is 0-based from the public API; PlainDate.month is 1-based
+    const month1 = month + 1;
+
     // Priority 1: Selected date if visible in this month and enabled
     if (selectedDate) {
       const isSelectedInMonth =
-        selectedDate.getFullYear() === year &&
-        selectedDate.getMonth() === month;
+        selectedDate.year === year && selectedDate.month === month1;
       if (isSelectedInMonth && !isDateDisabled(selectedDate)) {
-        return dateToISO(selectedDate);
+        return toISO(selectedDate);
       }
     }
 
     // Priority 2: Today if visible in this month and enabled
-    const isTodayInMonth =
-      today.getFullYear() === year && today.getMonth() === month;
+    const isTodayInMonth = today.year === year && today.month === month1;
 
     if (isTodayInMonth && !isDateDisabled(today)) {
-      return dateToISO(today);
+      return toISO(today);
     }
 
     // Priority 3: First enabled day in this month

--- a/packages/core/src/Calendar/utils.ts
+++ b/packages/core/src/Calendar/utils.ts
@@ -7,6 +7,8 @@
  * @position Shared utilities; used by XDSCalendar, XDSCalendarMonthGrid, XDSCalendarDayCell
  */
 
+import {plainDateFormat, DATE_FORMAT_WITH_WEEKDAY} from '../utils/plainDate';
+
 export {
   type PlainDate,
   plainDateFromISO as parseISO,
@@ -14,5 +16,13 @@ export {
   plainDateIsEqual as isSameDay,
   plainDateIsInRange as isDateInRange,
   plainDateGetWeekNumber as getWeekNumber,
-  plainDateFormatAccessible as formatAccessibleDate,
 } from '../utils/plainDate';
+
+export {plainDateFormat, DATE_FORMAT_WITH_WEEKDAY};
+
+/** @deprecated Use `plainDateFormat(pd, DATE_FORMAT_WITH_WEEKDAY)` instead. */
+export function formatAccessibleDate(
+  ...args: Parameters<typeof plainDateFormat>
+): string {
+  return plainDateFormat(args[0], DATE_FORMAT_WITH_WEEKDAY);
+}

--- a/packages/core/src/Calendar/utils.ts
+++ b/packages/core/src/Calendar/utils.ts
@@ -9,10 +9,10 @@
 
 export {
   type PlainDate,
-  fromISO as parseISO,
-  toISO as dateToISO,
-  isSameDay,
-  isInRange as isDateInRange,
-  getWeekNumber,
-  formatAccessible as formatAccessibleDate,
+  plainDateFromISO as parseISO,
+  plainDateToISO as dateToISO,
+  plainDateIsSameDay as isSameDay,
+  plainDateIsInRange as isDateInRange,
+  plainDateGetWeekNumber as getWeekNumber,
+  plainDateFormatAccessible as formatAccessibleDate,
 } from '../utils/plainDate';

--- a/packages/core/src/Calendar/utils.ts
+++ b/packages/core/src/Calendar/utils.ts
@@ -3,72 +3,16 @@
 /**
  * @file utils.ts
  * @input None
- * @output Exports shared date utility functions for calendar components
+ * @output Re-exports shared date utility functions for calendar components
  * @position Shared utilities; used by XDSCalendar, XDSCalendarMonthGrid, XDSCalendarDayCell
- *
- * SYNC: When modified, update this header
  */
 
-import type {ISODateString} from './XDSCalendar';
-
-/**
- * Convert a Date to ISO date string format (YYYY-MM-DD).
- */
-export function dateToISO(date: Date): ISODateString {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
-  return `${year}-${month}-${day}` as ISODateString;
-}
-
-/**
- * Parse ISO date string (YYYY-MM-DD) to Date object.
- */
-export function parseISO(str: ISODateString): Date {
-  const [year, month, day] = str.split('-').map(Number);
-  return new Date(year, month - 1, day);
-}
-
-/**
- * Check if two dates are the same day.
- */
-export function isSameDay(a: Date, b: Date): boolean {
-  return (
-    a.getFullYear() === b.getFullYear() &&
-    a.getMonth() === b.getMonth() &&
-    a.getDate() === b.getDate()
-  );
-}
-
-/**
- * Check if a date is within a range (inclusive).
- */
-export function isDateInRange(date: Date, start: Date, end: Date): boolean {
-  const time = date.getTime();
-  return time >= start.getTime() && time <= end.getTime();
-}
-
-/**
- * Get ISO week number for a date.
- */
-export function getWeekNumber(date: Date): number {
-  const d = new Date(
-    Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()),
-  );
-  const dayNum = d.getUTCDay() || 7;
-  d.setUTCDate(d.getUTCDate() + 4 - dayNum);
-  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
-  return Math.ceil(((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
-}
-
-/**
- * Format a date for accessible screen reader label.
- */
-export function formatAccessibleDate(date: Date): string {
-  return new Intl.DateTimeFormat(undefined, {
-    weekday: 'long',
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-  }).format(date);
-}
+export {
+  type PlainDate,
+  fromISO as parseISO,
+  toISO as dateToISO,
+  isSameDay,
+  isInRange as isDateInRange,
+  getWeekNumber,
+  formatAccessible as formatAccessibleDate,
+} from '../utils/plainDate';

--- a/packages/core/src/Calendar/utils.ts
+++ b/packages/core/src/Calendar/utils.ts
@@ -11,7 +11,7 @@ export {
   type PlainDate,
   plainDateFromISO as parseISO,
   plainDateToISO as dateToISO,
-  plainDateIsSameDay as isSameDay,
+  plainDateIsEqual as isSameDay,
   plainDateIsInRange as isDateInRange,
   plainDateGetWeekNumber as getWeekNumber,
   plainDateFormatAccessible as formatAccessibleDate,

--- a/packages/core/src/DateInput/XDSDateInput.tsx
+++ b/packages/core/src/DateInput/XDSDateInput.tsx
@@ -54,7 +54,7 @@ import {
 import {useCalendarConstraints} from '../Calendar/hooks';
 import {useXDSPopover} from '../Popover';
 import {parseDateInput, formatDisplayDate} from '../utils';
-import {fromISO} from '../utils/plainDate';
+import {plainDateFromISO} from '../utils/plainDate';
 
 const styles = stylex.create({
   iconButton: {
@@ -416,7 +416,11 @@ export function XDSDateInput({
 
       // If the input is valid and passes constraints, update immediately
       const parsed = parseDateInput(newValue);
-      if (parsed && parsed !== value && !isDateDisabled(fromISO(parsed))) {
+      if (
+        parsed &&
+        parsed !== value &&
+        !isDateDisabled(plainDateFromISO(parsed))
+      ) {
         lastFiredValueRef.current = parsed;
         fireChange(parsed);
         // Navigate calendar to show the parsed date's month
@@ -441,7 +445,7 @@ export function XDSDateInput({
     }
 
     const parsed = parseDateInput(pendingInput);
-    if (parsed && !isDateDisabled(fromISO(parsed))) {
+    if (parsed && !isDateDisabled(plainDateFromISO(parsed))) {
       if (parsed !== value) {
         fireChange(parsed);
       }

--- a/packages/core/src/DateInput/XDSDateInput.tsx
+++ b/packages/core/src/DateInput/XDSDateInput.tsx
@@ -57,7 +57,8 @@ import {parseDateInput} from '../utils';
 import {
   plainDateFromISO,
   plainDateToISO,
-  plainDateFormatDisplay,
+  plainDateFormat,
+  DATE_FORMAT_LONG,
 } from '../utils/plainDate';
 
 const styles = stylex.create({
@@ -346,7 +347,7 @@ export function XDSDateInput({
     pendingInput !== null
       ? pendingInput
       : optimisticValue && /^\d{4}-\d{2}-\d{2}$/.test(optimisticValue)
-        ? plainDateFormatDisplay(plainDateFromISO(optimisticValue))
+        ? plainDateFormat(plainDateFromISO(optimisticValue), DATE_FORMAT_LONG)
         : '';
 
   // Check if current input is valid (for styling purposes)

--- a/packages/core/src/DateInput/XDSDateInput.tsx
+++ b/packages/core/src/DateInput/XDSDateInput.tsx
@@ -53,8 +53,12 @@ import {
 } from '../Calendar';
 import {useCalendarConstraints} from '../Calendar/hooks';
 import {useXDSPopover} from '../Popover';
-import {parseDateInput, formatDisplayDate} from '../utils';
-import {plainDateToISO} from '../utils/plainDate';
+import {parseDateInput} from '../utils';
+import {
+  plainDateFromISO,
+  plainDateToISO,
+  plainDateFormatDisplay,
+} from '../utils/plainDate';
 
 const styles = stylex.create({
   iconButton: {
@@ -342,7 +346,7 @@ export function XDSDateInput({
     pendingInput !== null
       ? pendingInput
       : optimisticValue && /^\d{4}-\d{2}-\d{2}$/.test(optimisticValue)
-        ? formatDisplayDate(optimisticValue)
+        ? plainDateFormatDisplay(plainDateFromISO(optimisticValue))
         : '';
 
   // Check if current input is valid (for styling purposes)

--- a/packages/core/src/DateInput/XDSDateInput.tsx
+++ b/packages/core/src/DateInput/XDSDateInput.tsx
@@ -53,7 +53,8 @@ import {
 } from '../Calendar';
 import {useCalendarConstraints} from '../Calendar/hooks';
 import {useXDSPopover} from '../Popover';
-import {parseDateInput, formatDisplayDate, parseISO} from '../utils';
+import {parseDateInput, formatDisplayDate} from '../utils';
+import {fromISO} from '../utils/plainDate';
 
 const styles = stylex.create({
   iconButton: {
@@ -415,7 +416,7 @@ export function XDSDateInput({
 
       // If the input is valid and passes constraints, update immediately
       const parsed = parseDateInput(newValue);
-      if (parsed && parsed !== value && !isDateDisabled(parseISO(parsed))) {
+      if (parsed && parsed !== value && !isDateDisabled(fromISO(parsed))) {
         lastFiredValueRef.current = parsed;
         fireChange(parsed);
         // Navigate calendar to show the parsed date's month
@@ -440,7 +441,7 @@ export function XDSDateInput({
     }
 
     const parsed = parseDateInput(pendingInput);
-    if (parsed && !isDateDisabled(parseISO(parsed))) {
+    if (parsed && !isDateDisabled(fromISO(parsed))) {
       if (parsed !== value) {
         fireChange(parsed);
       }

--- a/packages/core/src/DateInput/XDSDateInput.tsx
+++ b/packages/core/src/DateInput/XDSDateInput.tsx
@@ -54,7 +54,7 @@ import {
 import {useCalendarConstraints} from '../Calendar/hooks';
 import {useXDSPopover} from '../Popover';
 import {parseDateInput, formatDisplayDate} from '../utils';
-import {plainDateFromISO} from '../utils/plainDate';
+import {plainDateToISO} from '../utils/plainDate';
 
 const styles = stylex.create({
   iconButton: {
@@ -418,13 +418,14 @@ export function XDSDateInput({
       const parsed = parseDateInput(newValue);
       if (
         parsed &&
-        parsed !== value &&
-        !isDateDisabled(plainDateFromISO(parsed))
+        plainDateToISO(parsed) !== value &&
+        !isDateDisabled(parsed)
       ) {
-        lastFiredValueRef.current = parsed;
-        fireChange(parsed);
+        const parsedISO = plainDateToISO(parsed);
+        lastFiredValueRef.current = parsedISO;
+        fireChange(parsedISO);
         // Navigate calendar to show the parsed date's month
-        calendarRef.current?.navigateTo(parsed);
+        calendarRef.current?.navigateTo(parsedISO);
       }
     },
     [value, fireChange, isDateDisabled],
@@ -445,9 +446,10 @@ export function XDSDateInput({
     }
 
     const parsed = parseDateInput(pendingInput);
-    if (parsed && !isDateDisabled(plainDateFromISO(parsed))) {
-      if (parsed !== value) {
-        fireChange(parsed);
+    if (parsed && !isDateDisabled(parsed)) {
+      const parsedISO = plainDateToISO(parsed);
+      if (parsedISO !== value) {
+        fireChange(parsedISO);
       }
     }
     setPendingInput(null);

--- a/packages/core/src/DateRangeInput/XDSDateRangeInput.tsx
+++ b/packages/core/src/DateRangeInput/XDSDateRangeInput.tsx
@@ -20,8 +20,10 @@ import {useId, useCallback, useMemo, useOptimistic, useTransition} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {
   plainDateFromISO,
-  plainDateToDate,
   plainDateToday,
+  plainDateFormat,
+  DATE_FORMAT_SHORT,
+  DATE_FORMAT_SHORT_WITH_YEAR,
 } from '../utils/plainDate';
 import type {XDSIconName} from '../Icon';
 import {
@@ -168,17 +170,6 @@ const sizeStyles = stylex.create({
   },
 });
 
-const shortDateFormatter = new Intl.DateTimeFormat(undefined, {
-  month: 'short',
-  day: 'numeric',
-});
-
-const shortDateWithYearFormatter = new Intl.DateTimeFormat(undefined, {
-  month: 'short',
-  day: 'numeric',
-  year: 'numeric',
-});
-
 function formatRangeDisplay(range: DateRange | null): string {
   if (!range) {
     return '';
@@ -188,8 +179,8 @@ function formatRangeDisplay(range: DateRange | null): string {
   const currentYear = plainDateToday().year;
   const sameYear = start.year === end.year && start.year === currentYear;
 
-  const fmt = sameYear ? shortDateFormatter : shortDateWithYearFormatter;
-  return `${fmt.format(plainDateToDate(start))} – ${fmt.format(plainDateToDate(end))}`;
+  const fmt = sameYear ? DATE_FORMAT_SHORT : DATE_FORMAT_SHORT_WITH_YEAR;
+  return `${plainDateFormat(start, fmt)} – ${plainDateFormat(end, fmt)}`;
 }
 
 function isRangeEqual(a: DateRange | null, b: DateRange | null): boolean {

--- a/packages/core/src/DateRangeInput/XDSDateRangeInput.tsx
+++ b/packages/core/src/DateRangeInput/XDSDateRangeInput.tsx
@@ -18,6 +18,7 @@
 
 import {useId, useCallback, useMemo, useOptimistic, useTransition} from 'react';
 import * as stylex from '@stylexjs/stylex';
+import {fromISO, toDate, today as todayFn} from '../utils/plainDate';
 import type {XDSIconName} from '../Icon';
 import {
   colorVars,
@@ -174,24 +175,17 @@ const shortDateWithYearFormatter = new Intl.DateTimeFormat(undefined, {
   year: 'numeric',
 });
 
-function parseISO(iso: ISODateString): Date {
-  const [year, month, day] = iso.split('-').map(Number);
-  return new Date(year, month - 1, day);
-}
-
 function formatRangeDisplay(range: DateRange | null): string {
   if (!range) {
     return '';
   }
-  const startDate = parseISO(range.start);
-  const endDate = parseISO(range.end);
-  const currentYear = new Date().getFullYear();
-  const sameYear =
-    startDate.getFullYear() === endDate.getFullYear() &&
-    startDate.getFullYear() === currentYear;
+  const start = fromISO(range.start);
+  const end = fromISO(range.end);
+  const currentYear = todayFn().year;
+  const sameYear = start.year === end.year && start.year === currentYear;
 
   const fmt = sameYear ? shortDateFormatter : shortDateWithYearFormatter;
-  return `${fmt.format(startDate)} – ${fmt.format(endDate)}`;
+  return `${fmt.format(toDate(start))} – ${fmt.format(toDate(end))}`;
 }
 
 function isRangeEqual(a: DateRange | null, b: DateRange | null): boolean {

--- a/packages/core/src/DateRangeInput/XDSDateRangeInput.tsx
+++ b/packages/core/src/DateRangeInput/XDSDateRangeInput.tsx
@@ -18,7 +18,11 @@
 
 import {useId, useCallback, useMemo, useOptimistic, useTransition} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {fromISO, toDate, today as todayFn} from '../utils/plainDate';
+import {
+  plainDateFromISO,
+  plainDateToDate,
+  plainDateToday,
+} from '../utils/plainDate';
 import type {XDSIconName} from '../Icon';
 import {
   colorVars,
@@ -179,13 +183,13 @@ function formatRangeDisplay(range: DateRange | null): string {
   if (!range) {
     return '';
   }
-  const start = fromISO(range.start);
-  const end = fromISO(range.end);
-  const currentYear = todayFn().year;
+  const start = plainDateFromISO(range.start);
+  const end = plainDateFromISO(range.end);
+  const currentYear = plainDateToday().year;
   const sameYear = start.year === end.year && start.year === currentYear;
 
   const fmt = sameYear ? shortDateFormatter : shortDateWithYearFormatter;
-  return `${fmt.format(toDate(start))} – ${fmt.format(toDate(end))}`;
+  return `${fmt.format(plainDateToDate(start))} – ${fmt.format(plainDateToDate(end))}`;
 }
 
 function isRangeEqual(a: DateRange | null, b: DateRange | null): boolean {

--- a/packages/core/src/DateTimeInput/XDSDateTimeInput.tsx
+++ b/packages/core/src/DateTimeInput/XDSDateTimeInput.tsx
@@ -70,7 +70,7 @@ import {
   xdsClassName,
   mergeProps,
 } from '../utils';
-import {fromISO} from '../utils/plainDate';
+import {plainDateFromISO} from '../utils/plainDate';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import type {XDSBaseProps} from '../XDSBaseProps';
 
@@ -585,7 +585,7 @@ export function XDSDateTimeInput({
       if (
         parsed &&
         parsed !== valueParts.date &&
-        !isDateDisabled(fromISO(parsed))
+        !isDateDisabled(plainDateFromISO(parsed))
       ) {
         lastFiredDateRef.current = parsed;
         handleDateChange(parsed, 'input');
@@ -609,7 +609,7 @@ export function XDSDateTimeInput({
     }
 
     const parsed = parseDateInput(datePendingInput);
-    if (parsed && !isDateDisabled(fromISO(parsed))) {
+    if (parsed && !isDateDisabled(plainDateFromISO(parsed))) {
       if (parsed !== valueParts.date) {
         handleDateChange(parsed, 'input');
       }

--- a/packages/core/src/DateTimeInput/XDSDateTimeInput.tsx
+++ b/packages/core/src/DateTimeInput/XDSDateTimeInput.tsx
@@ -72,7 +72,8 @@ import {
 import {
   plainDateFromISO,
   plainDateToISO,
-  plainDateFormatDisplay,
+  plainDateFormat,
+  DATE_FORMAT_LONG,
 } from '../utils/plainDate';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import type {XDSBaseProps} from '../XDSBaseProps';
@@ -468,7 +469,7 @@ export function XDSDateTimeInput({
     datePendingInput !== null
       ? datePendingInput
       : valueParts.date && /^\d{4}-\d{2}-\d{2}$/.test(valueParts.date)
-        ? plainDateFormatDisplay(plainDateFromISO(valueParts.date))
+        ? plainDateFormat(plainDateFromISO(valueParts.date), DATE_FORMAT_LONG)
         : '';
 
   const isDateInputValid =

--- a/packages/core/src/DateTimeInput/XDSDateTimeInput.tsx
+++ b/packages/core/src/DateTimeInput/XDSDateTimeInput.tsx
@@ -60,7 +60,6 @@ import {useInputContainer} from '../hooks/useInputContainer';
 import {
   type ISOTimeString,
   parseDateInput,
-  formatDisplayDate,
   parseTimeInput,
   formatDisplayTime12h,
   formatDisplayTime24h,
@@ -70,7 +69,11 @@ import {
   xdsClassName,
   mergeProps,
 } from '../utils';
-import {plainDateToISO} from '../utils/plainDate';
+import {
+  plainDateFromISO,
+  plainDateToISO,
+  plainDateFormatDisplay,
+} from '../utils/plainDate';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import type {XDSBaseProps} from '../XDSBaseProps';
 
@@ -465,7 +468,7 @@ export function XDSDateTimeInput({
     datePendingInput !== null
       ? datePendingInput
       : valueParts.date && /^\d{4}-\d{2}-\d{2}$/.test(valueParts.date)
-        ? formatDisplayDate(valueParts.date)
+        ? plainDateFormatDisplay(plainDateFromISO(valueParts.date))
         : '';
 
   const isDateInputValid =

--- a/packages/core/src/DateTimeInput/XDSDateTimeInput.tsx
+++ b/packages/core/src/DateTimeInput/XDSDateTimeInput.tsx
@@ -70,7 +70,7 @@ import {
   xdsClassName,
   mergeProps,
 } from '../utils';
-import {plainDateFromISO} from '../utils/plainDate';
+import {plainDateToISO} from '../utils/plainDate';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import type {XDSBaseProps} from '../XDSBaseProps';
 
@@ -584,12 +584,13 @@ export function XDSDateTimeInput({
       const parsed = parseDateInput(text);
       if (
         parsed &&
-        parsed !== valueParts.date &&
-        !isDateDisabled(plainDateFromISO(parsed))
+        plainDateToISO(parsed) !== valueParts.date &&
+        !isDateDisabled(parsed)
       ) {
-        lastFiredDateRef.current = parsed;
-        handleDateChange(parsed, 'input');
-        calendarRef.current?.navigateTo(parsed);
+        const parsedISO = plainDateToISO(parsed);
+        lastFiredDateRef.current = parsedISO;
+        handleDateChange(parsedISO, 'input');
+        calendarRef.current?.navigateTo(parsedISO);
       }
     },
     [valueParts.date, isDateDisabled, handleDateChange],
@@ -609,9 +610,10 @@ export function XDSDateTimeInput({
     }
 
     const parsed = parseDateInput(datePendingInput);
-    if (parsed && !isDateDisabled(plainDateFromISO(parsed))) {
-      if (parsed !== valueParts.date) {
-        handleDateChange(parsed, 'input');
+    if (parsed && !isDateDisabled(parsed)) {
+      const parsedISO = plainDateToISO(parsed);
+      if (parsedISO !== valueParts.date) {
+        handleDateChange(parsedISO, 'input');
       }
     }
     setDatePendingInput(null);

--- a/packages/core/src/DateTimeInput/XDSDateTimeInput.tsx
+++ b/packages/core/src/DateTimeInput/XDSDateTimeInput.tsx
@@ -61,7 +61,6 @@ import {
   type ISOTimeString,
   parseDateInput,
   formatDisplayDate,
-  parseISO,
   parseTimeInput,
   formatDisplayTime12h,
   formatDisplayTime24h,
@@ -71,6 +70,7 @@ import {
   xdsClassName,
   mergeProps,
 } from '../utils';
+import {fromISO} from '../utils/plainDate';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import type {XDSBaseProps} from '../XDSBaseProps';
 
@@ -585,7 +585,7 @@ export function XDSDateTimeInput({
       if (
         parsed &&
         parsed !== valueParts.date &&
-        !isDateDisabled(parseISO(parsed))
+        !isDateDisabled(fromISO(parsed))
       ) {
         lastFiredDateRef.current = parsed;
         handleDateChange(parsed, 'input');
@@ -609,7 +609,7 @@ export function XDSDateTimeInput({
     }
 
     const parsed = parseDateInput(datePendingInput);
-    if (parsed && !isDateDisabled(parseISO(parsed))) {
+    if (parsed && !isDateDisabled(fromISO(parsed))) {
       if (parsed !== valueParts.date) {
         handleDateChange(parsed, 'input');
       }

--- a/packages/core/src/PowerSearch/PowerSearchValueEditor.tsx
+++ b/packages/core/src/PowerSearch/PowerSearchValueEditor.tsx
@@ -21,7 +21,7 @@ import type {
 } from './types';
 import type {InternalConfig} from './useInternalConfig';
 import type {XDSSearchableItem, XDSSearchSource} from '../Typeahead/types';
-import type {ISODateString} from '../Calendar';
+import type {ISODateString} from '../utils/dateTypes';
 import type {ISOTimeString} from '../utils';
 
 // Lazy import to avoid circular deps — these are all from the same package

--- a/packages/core/src/Table/plugins/filtering/useXDSTableFiltering.tsx
+++ b/packages/core/src/Table/plugins/filtering/useXDSTableFiltering.tsx
@@ -30,7 +30,7 @@ import {XDSPopover} from '../../../Popover';
 import {XDSTextInput} from '../../../TextInput';
 import {XDSNumberInput} from '../../../NumberInput';
 import {XDSDateInput} from '../../../DateInput';
-import type {ISODateString} from '../../../Calendar';
+import type {ISODateString} from '../../../utils/dateTypes';
 import {XDSTimeInput} from '../../../TimeInput';
 import type {ISOTimeString} from '../../../utils/timeParser';
 import {XDSSelector} from '../../../Selector';

--- a/packages/core/src/Tokenizer/XDSTokenizer.tsx
+++ b/packages/core/src/Tokenizer/XDSTokenizer.tsx
@@ -226,11 +226,6 @@ const styles = stylex.create({
     // since wrapperWithTokens reduces padding to 3px for border concentricity.
     marginInlineStart: `calc(${spacingVars['--spacing-2']} - ${spacingVars['--spacing-1']} + 1px)`,
   },
-  startIconWithTokens: {
-    // Restore the default 8px inline-start inset when tokens are present,
-    // since wrapperWithTokens reduces padding to 3px for border concentricity.
-    marginInlineStart: `calc(${spacingVars['--spacing-2']} - ${spacingVars['--spacing-1']} + 1px)`,
-  },
   token: {
     display: 'flex',
     flexShrink: 0,

--- a/packages/core/src/Tokenizer/XDSTokenizer.tsx
+++ b/packages/core/src/Tokenizer/XDSTokenizer.tsx
@@ -226,6 +226,11 @@ const styles = stylex.create({
     // since wrapperWithTokens reduces padding to 3px for border concentricity.
     marginInlineStart: `calc(${spacingVars['--spacing-2']} - ${spacingVars['--spacing-1']} + 1px)`,
   },
+  startIconWithTokens: {
+    // Restore the default 8px inline-start inset when tokens are present,
+    // since wrapperWithTokens reduces padding to 3px for border concentricity.
+    marginInlineStart: `calc(${spacingVars['--spacing-2']} - ${spacingVars['--spacing-1']} + 1px)`,
+  },
   token: {
     display: 'flex',
     flexShrink: 0,

--- a/packages/core/src/utils/dateParser.test.ts
+++ b/packages/core/src/utils/dateParser.test.ts
@@ -10,12 +10,7 @@
  */
 
 import {describe, it, expect} from 'vitest';
-import {
-  parseDateInput,
-  formatDisplayDate,
-  dateToISO,
-  parseISO,
-} from './dateParser';
+import {parseDateInput} from './dateParser';
 
 describe('parseDateInput', () => {
   describe('ISO format (YYYY-MM-DD)', () => {
@@ -325,37 +320,5 @@ describe('parseDateInput', () => {
     it('rejects mixed separators', () => {
       expect(parseDateInput('1/25.2026')).toBeNull();
     });
-  });
-});
-
-describe('formatDisplayDate', () => {
-  it('formats ISO date to readable format', () => {
-    expect(formatDisplayDate('2026-01-25')).toBe('January 25, 2026');
-  });
-
-  it('formats single-digit dates correctly', () => {
-    expect(formatDisplayDate('2026-01-05')).toBe('January 5, 2026');
-  });
-
-  it('formats all months correctly', () => {
-    expect(formatDisplayDate('2026-02-15')).toBe('February 15, 2026');
-    expect(formatDisplayDate('2026-12-25')).toBe('December 25, 2026');
-  });
-});
-
-describe('dateToISO', () => {
-  it('converts PlainDate to ISO string', () => {
-    expect(dateToISO({year: 2026, month: 1, day: 25})).toBe('2026-01-25');
-  });
-
-  it('pads single-digit month and day', () => {
-    expect(dateToISO({year: 2026, month: 1, day: 5})).toBe('2026-01-05');
-  });
-});
-
-describe('parseISO', () => {
-  it('parses ISO string to PlainDate', () => {
-    const pd = parseISO('2026-01-25');
-    expect(pd).toEqual({year: 2026, month: 1, day: 25});
   });
 });

--- a/packages/core/src/utils/dateParser.test.ts
+++ b/packages/core/src/utils/dateParser.test.ts
@@ -20,11 +20,19 @@ import {
 describe('parseDateInput', () => {
   describe('ISO format (YYYY-MM-DD)', () => {
     it('parses valid ISO date', () => {
-      expect(parseDateInput('2026-01-25')).toBe('2026-01-25');
+      expect(parseDateInput('2026-01-25')).toEqual({
+        year: 2026,
+        month: 1,
+        day: 25,
+      });
     });
 
     it('parses ISO date with single-digit month/day', () => {
-      expect(parseDateInput('2026-1-5')).toBe('2026-01-05');
+      expect(parseDateInput('2026-1-5')).toEqual({
+        year: 2026,
+        month: 1,
+        day: 5,
+      });
     });
 
     it('returns null for invalid ISO date', () => {
@@ -35,48 +43,132 @@ describe('parseDateInput', () => {
 
   describe('full month name formats', () => {
     it('parses "January 25, 2026"', () => {
-      expect(parseDateInput('January 25, 2026')).toBe('2026-01-25');
+      expect(parseDateInput('January 25, 2026')).toEqual({
+        year: 2026,
+        month: 1,
+        day: 25,
+      });
     });
 
     it('parses "Jan 25, 2026"', () => {
-      expect(parseDateInput('Jan 25, 2026')).toBe('2026-01-25');
+      expect(parseDateInput('Jan 25, 2026')).toEqual({
+        year: 2026,
+        month: 1,
+        day: 25,
+      });
     });
 
     it('parses "25 January 2026"', () => {
-      expect(parseDateInput('25 January 2026')).toBe('2026-01-25');
+      expect(parseDateInput('25 January 2026')).toEqual({
+        year: 2026,
+        month: 1,
+        day: 25,
+      });
     });
 
     it('parses "25 Jan 2026"', () => {
-      expect(parseDateInput('25 Jan 2026')).toBe('2026-01-25');
+      expect(parseDateInput('25 Jan 2026')).toEqual({
+        year: 2026,
+        month: 1,
+        day: 25,
+      });
     });
 
     it('parses without comma', () => {
-      expect(parseDateInput('January 25 2026')).toBe('2026-01-25');
+      expect(parseDateInput('January 25 2026')).toEqual({
+        year: 2026,
+        month: 1,
+        day: 25,
+      });
     });
 
     it('handles case insensitive month names', () => {
-      expect(parseDateInput('JANUARY 25, 2026')).toBe('2026-01-25');
-      expect(parseDateInput('january 25, 2026')).toBe('2026-01-25');
+      expect(parseDateInput('JANUARY 25, 2026')).toEqual({
+        year: 2026,
+        month: 1,
+        day: 25,
+      });
+      expect(parseDateInput('january 25, 2026')).toEqual({
+        year: 2026,
+        month: 1,
+        day: 25,
+      });
     });
 
     it('parses all month names', () => {
-      expect(parseDateInput('February 1, 2026')).toBe('2026-02-01');
-      expect(parseDateInput('March 1, 2026')).toBe('2026-03-01');
-      expect(parseDateInput('April 1, 2026')).toBe('2026-04-01');
-      expect(parseDateInput('May 1, 2026')).toBe('2026-05-01');
-      expect(parseDateInput('June 1, 2026')).toBe('2026-06-01');
-      expect(parseDateInput('July 1, 2026')).toBe('2026-07-01');
-      expect(parseDateInput('August 1, 2026')).toBe('2026-08-01');
-      expect(parseDateInput('September 1, 2026')).toBe('2026-09-01');
-      expect(parseDateInput('October 1, 2026')).toBe('2026-10-01');
-      expect(parseDateInput('November 1, 2026')).toBe('2026-11-01');
-      expect(parseDateInput('December 1, 2026')).toBe('2026-12-01');
+      expect(parseDateInput('February 1, 2026')).toEqual({
+        year: 2026,
+        month: 2,
+        day: 1,
+      });
+      expect(parseDateInput('March 1, 2026')).toEqual({
+        year: 2026,
+        month: 3,
+        day: 1,
+      });
+      expect(parseDateInput('April 1, 2026')).toEqual({
+        year: 2026,
+        month: 4,
+        day: 1,
+      });
+      expect(parseDateInput('May 1, 2026')).toEqual({
+        year: 2026,
+        month: 5,
+        day: 1,
+      });
+      expect(parseDateInput('June 1, 2026')).toEqual({
+        year: 2026,
+        month: 6,
+        day: 1,
+      });
+      expect(parseDateInput('July 1, 2026')).toEqual({
+        year: 2026,
+        month: 7,
+        day: 1,
+      });
+      expect(parseDateInput('August 1, 2026')).toEqual({
+        year: 2026,
+        month: 8,
+        day: 1,
+      });
+      expect(parseDateInput('September 1, 2026')).toEqual({
+        year: 2026,
+        month: 9,
+        day: 1,
+      });
+      expect(parseDateInput('October 1, 2026')).toEqual({
+        year: 2026,
+        month: 10,
+        day: 1,
+      });
+      expect(parseDateInput('November 1, 2026')).toEqual({
+        year: 2026,
+        month: 11,
+        day: 1,
+      });
+      expect(parseDateInput('December 1, 2026')).toEqual({
+        year: 2026,
+        month: 12,
+        day: 1,
+      });
     });
 
     it('parses abbreviated month names', () => {
-      expect(parseDateInput('Feb 1, 2026')).toBe('2026-02-01');
-      expect(parseDateInput('Sep 1, 2026')).toBe('2026-09-01');
-      expect(parseDateInput('Sept 1, 2026')).toBe('2026-09-01');
+      expect(parseDateInput('Feb 1, 2026')).toEqual({
+        year: 2026,
+        month: 2,
+        day: 1,
+      });
+      expect(parseDateInput('Sep 1, 2026')).toEqual({
+        year: 2026,
+        month: 9,
+        day: 1,
+      });
+      expect(parseDateInput('Sept 1, 2026')).toEqual({
+        year: 2026,
+        month: 9,
+        day: 1,
+      });
     });
   });
 
@@ -84,48 +176,100 @@ describe('parseDateInput', () => {
     const currentYear = new Date().getFullYear();
 
     it('parses "January 25" (month-first without year)', () => {
-      expect(parseDateInput('January 25')).toBe(`${currentYear}-01-25`);
+      expect(parseDateInput('January 25')).toEqual({
+        year: currentYear,
+        month: 1,
+        day: 25,
+      });
     });
 
     it('parses "Jan 25" (abbreviated month without year)', () => {
-      expect(parseDateInput('Jan 25')).toBe(`${currentYear}-01-25`);
+      expect(parseDateInput('Jan 25')).toEqual({
+        year: currentYear,
+        month: 1,
+        day: 25,
+      });
     });
 
     it('parses "25 January" (day-first without year)', () => {
-      expect(parseDateInput('25 January')).toBe(`${currentYear}-01-25`);
+      expect(parseDateInput('25 January')).toEqual({
+        year: currentYear,
+        month: 1,
+        day: 25,
+      });
     });
 
     it('parses "25 Jan" (day-first abbreviated without year)', () => {
-      expect(parseDateInput('25 Jan')).toBe(`${currentYear}-01-25`);
+      expect(parseDateInput('25 Jan')).toEqual({
+        year: currentYear,
+        month: 1,
+        day: 25,
+      });
     });
 
     it('parses "1/25" (numeric without year)', () => {
-      expect(parseDateInput('1/25')).toBe(`${currentYear}-01-25`);
+      expect(parseDateInput('1/25')).toEqual({
+        year: currentYear,
+        month: 1,
+        day: 25,
+      });
     });
 
     it('parses "25/1" (numeric day-first without year)', () => {
-      expect(parseDateInput('25/1')).toBe(`${currentYear}-01-25`);
+      expect(parseDateInput('25/1')).toEqual({
+        year: currentYear,
+        month: 1,
+        day: 25,
+      });
     });
 
     it('parses "12-31" (numeric with dash without year)', () => {
-      expect(parseDateInput('12-31')).toBe(`${currentYear}-12-31`);
+      expect(parseDateInput('12-31')).toEqual({
+        year: currentYear,
+        month: 12,
+        day: 31,
+      });
     });
 
     it('handles all months without year', () => {
-      expect(parseDateInput('Feb 15')).toBe(`${currentYear}-02-15`);
-      expect(parseDateInput('Dec 25')).toBe(`${currentYear}-12-25`);
+      expect(parseDateInput('Feb 15')).toEqual({
+        year: currentYear,
+        month: 2,
+        day: 15,
+      });
+      expect(parseDateInput('Dec 25')).toEqual({
+        year: currentYear,
+        month: 12,
+        day: 25,
+      });
     });
   });
 
   describe('numeric formats with heuristics', () => {
     it('detects day when first number > 12', () => {
-      expect(parseDateInput('25/1/2026')).toBe('2026-01-25');
-      expect(parseDateInput('31-12-2026')).toBe('2026-12-31');
+      expect(parseDateInput('25/1/2026')).toEqual({
+        year: 2026,
+        month: 1,
+        day: 25,
+      });
+      expect(parseDateInput('31-12-2026')).toEqual({
+        year: 2026,
+        month: 12,
+        day: 31,
+      });
     });
 
     it('detects day when second number > 12', () => {
-      expect(parseDateInput('1/25/2026')).toBe('2026-01-25');
-      expect(parseDateInput('12-31-2026')).toBe('2026-12-31');
+      expect(parseDateInput('1/25/2026')).toEqual({
+        year: 2026,
+        month: 1,
+        day: 25,
+      });
+      expect(parseDateInput('12-31-2026')).toEqual({
+        year: 2026,
+        month: 12,
+        day: 31,
+      });
     });
 
     it('returns null when both numbers > 12', () => {
@@ -148,7 +292,11 @@ describe('parseDateInput', () => {
     });
 
     it('trims whitespace', () => {
-      expect(parseDateInput('  2026-01-25  ')).toBe('2026-01-25');
+      expect(parseDateInput('  2026-01-25  ')).toEqual({
+        year: 2026,
+        month: 1,
+        day: 25,
+      });
     });
 
     it('returns null for completely invalid strings', () => {
@@ -157,13 +305,21 @@ describe('parseDateInput', () => {
     });
 
     it('validates February dates', () => {
-      expect(parseDateInput('February 29, 2024')).toBe('2024-02-29'); // Leap year
+      expect(parseDateInput('February 29, 2024')).toEqual({
+        year: 2024,
+        month: 2,
+        day: 29,
+      }); // Leap year
       expect(parseDateInput('February 29, 2025')).toBeNull(); // Not a leap year
       expect(parseDateInput('February 30, 2024')).toBeNull();
     });
 
     it('preserves years 0-99 literally instead of mapping to 1900s', () => {
-      expect(parseDateInput('01/01/0050')).toBe('0050-01-01');
+      expect(parseDateInput('01/01/0050')).toEqual({
+        year: 50,
+        month: 1,
+        day: 1,
+      });
     });
 
     it('rejects mixed separators', () => {
@@ -188,22 +344,18 @@ describe('formatDisplayDate', () => {
 });
 
 describe('dateToISO', () => {
-  it('converts Date object to ISO string', () => {
-    const date = new Date(2026, 0, 25); // January 25, 2026
-    expect(dateToISO(date)).toBe('2026-01-25');
+  it('converts PlainDate to ISO string', () => {
+    expect(dateToISO({year: 2026, month: 1, day: 25})).toBe('2026-01-25');
   });
 
   it('pads single-digit month and day', () => {
-    const date = new Date(2026, 0, 5); // January 5, 2026
-    expect(dateToISO(date)).toBe('2026-01-05');
+    expect(dateToISO({year: 2026, month: 1, day: 5})).toBe('2026-01-05');
   });
 });
 
 describe('parseISO', () => {
-  it('parses ISO string to Date object', () => {
-    const date = parseISO('2026-01-25');
-    expect(date.getFullYear()).toBe(2026);
-    expect(date.getMonth()).toBe(0); // January
-    expect(date.getDate()).toBe(25);
+  it('parses ISO string to PlainDate', () => {
+    const pd = parseISO('2026-01-25');
+    expect(pd).toEqual({year: 2026, month: 1, day: 25});
   });
 });

--- a/packages/core/src/utils/dateParser.ts
+++ b/packages/core/src/utils/dateParser.ts
@@ -18,7 +18,7 @@ import {
   plainDateToDate,
   plainDateFromISO,
   plainDateToISO,
-  plainDateDaysInMonth,
+  getDaysInMonth,
 } from './plainDate';
 
 export {
@@ -205,12 +205,7 @@ function createPlainDate(
   month: number,
   day: number,
 ): PlainDate | null {
-  if (
-    month < 1 ||
-    month > 12 ||
-    day < 1 ||
-    day > plainDateDaysInMonth(year, month)
-  ) {
+  if (month < 1 || month > 12 || day < 1 || day > getDaysInMonth(year, month)) {
     return null;
   }
   return {year, month, day};

--- a/packages/core/src/utils/dateParser.ts
+++ b/packages/core/src/utils/dateParser.ts
@@ -4,19 +4,20 @@
  * @file dateParser.ts
  * @input Uses Intl.DateTimeFormat for locale detection
  * @output Exports date parsing utilities for user input
- * @position Core utility; used by XDSDatePicker
+ * @position Core utility; used by XDSDateInput, XDSDateTimeInput
  *
  * SYNC: When modified, update:
  * - /packages/core/src/utils/dateParser.test.ts
  * - /packages/core/src/utils/index.ts
  */
 
-import type {ISODateString} from '../Calendar';
+import type {ISODateString} from './dateTypes';
 import {
+  type PlainDate,
+  plainDateFromDate,
+  plainDateToDate,
   plainDateFromISO,
   plainDateToISO,
-  plainDateToDate,
-  plainDateFromDate,
   plainDateDaysInMonth,
 } from './plainDate';
 
@@ -37,7 +38,7 @@ export function isLocaleDayFirst(): boolean {
 }
 
 /**
- * Parses user input into an ISO date string.
+ * Parses user input into a PlainDate.
  *
  * Supports:
  * - ISO format: "2026-01-25"
@@ -48,9 +49,9 @@ export function isLocaleDayFirst(): boolean {
  *
  * For ambiguous numeric formats (both numbers ≤ 12), uses locale preference.
  *
- * @returns ISODateString if valid, null if unparseable
+ * @returns PlainDate if valid, null if unparseable
  */
-export function parseDateInput(input: string): ISODateString | null {
+export function parseDateInput(input: string): PlainDate | null {
   const trimmed = input.trim();
   if (!trimmed) {
     return null;
@@ -62,7 +63,7 @@ export function parseDateInput(input: string): ISODateString | null {
   const isoMatch = trimmed.match(/^(\d{4})-(\d{1,2})-(\d{1,2})$/);
   if (isoMatch) {
     const [, year, month, day] = isoMatch;
-    return createISODate(+year, +month, +day);
+    return createPlainDate(+year, +month, +day);
   }
 
   // 2. Try full month name formats with year
@@ -74,7 +75,7 @@ export function parseDateInput(input: string): ISODateString | null {
     const [, monthName, day, year] = monthFirstWithYearMatch;
     const month = parseMonthName(monthName);
     if (month !== null) {
-      return createISODate(+year, month, +day);
+      return createPlainDate(+year, month, +day);
     }
   }
 
@@ -86,7 +87,7 @@ export function parseDateInput(input: string): ISODateString | null {
     const [, day, monthName, year] = dayFirstWithYearMatch;
     const month = parseMonthName(monthName);
     if (month !== null) {
-      return createISODate(+year, month, +day);
+      return createPlainDate(+year, month, +day);
     }
   }
 
@@ -97,7 +98,7 @@ export function parseDateInput(input: string): ISODateString | null {
     const [, monthName, day] = monthFirstNoYearMatch;
     const month = parseMonthName(monthName);
     if (month !== null) {
-      return createISODate(currentYear, month, +day);
+      return createPlainDate(currentYear, month, +day);
     }
   }
 
@@ -107,7 +108,7 @@ export function parseDateInput(input: string): ISODateString | null {
     const [, day, monthName] = dayFirstNoYearMatch;
     const month = parseMonthName(monthName);
     if (month !== null) {
-      return createISODate(currentYear, month, +day);
+      return createPlainDate(currentYear, month, +day);
     }
   }
 
@@ -117,7 +118,7 @@ export function parseDateInput(input: string): ISODateString | null {
   );
   if (numericWithYearMatch) {
     const [, first, sep1, second, sep2, year] = numericWithYearMatch;
-    // Reject mixed separators (e.g., "1/25.2026")
+
     if (sep1 !== sep2) {
       return null;
     }
@@ -134,41 +135,29 @@ export function parseDateInput(input: string): ISODateString | null {
   // 6. Fall back to native Date parsing for other formats
   const parsed = new Date(trimmed);
   if (!isNaN(parsed.getTime())) {
-    return plainDateToISO(plainDateFromDate(parsed));
+    return plainDateFromDate(parsed);
   }
 
   return null;
 }
 
-/**
- * Parses ambiguous numeric dates using heuristics and locale.
- *
- * Heuristics:
- * - If first > 12, it must be the day (e.g., 25/1/2026 → Jan 25)
- * - If second > 12, it must be the day (e.g., 1/25/2026 → Jan 25)
- * - If both ≤ 12, use locale preference (day-first vs month-first)
- */
 function parseNumericDate(
   first: number,
   second: number,
   year: number,
-): ISODateString | null {
+): PlainDate | null {
   let day: number;
   let month: number;
 
   if (first > 12 && second <= 12) {
-    // First must be day (e.g., 25/1/2026)
     day = first;
     month = second;
   } else if (second > 12 && first <= 12) {
-    // Second must be day (e.g., 1/25/2026)
     month = first;
     day = second;
   } else if (first > 12 && second > 12) {
-    // Both > 12 is invalid
     return null;
   } else {
-    // Both ≤ 12: ambiguous, use locale preference
     if (isLocaleDayFirst()) {
       day = first;
       month = second;
@@ -178,12 +167,9 @@ function parseNumericDate(
     }
   }
 
-  return createISODate(year, month, day);
+  return createPlainDate(year, month, day);
 }
 
-/**
- * Parses month name (full or abbreviated) to 1-12.
- */
 function parseMonthName(name: string): number | null {
   const months: Record<string, number> = {
     january: 1,
@@ -214,14 +200,11 @@ function parseMonthName(name: string): number | null {
   return months[name.toLowerCase()] ?? null;
 }
 
-/**
- * Creates an ISO date string, validating the date is real.
- */
-function createISODate(
+function createPlainDate(
   year: number,
   month: number,
   day: number,
-): ISODateString | null {
+): PlainDate | null {
   if (
     month < 1 ||
     month > 12 ||
@@ -230,7 +213,7 @@ function createISODate(
   ) {
     return null;
   }
-  return plainDateToISO({year, month, day});
+  return {year, month, day};
 }
 
 export function formatDisplayDate(iso: ISODateString): string {

--- a/packages/core/src/utils/dateParser.ts
+++ b/packages/core/src/utils/dateParser.ts
@@ -14,11 +14,11 @@
 import type {ISODateString} from './dateTypes';
 import {
   type PlainDate,
+  plainDateCreate,
   plainDateFromDate,
   plainDateToDate,
   plainDateFromISO,
   plainDateToISO,
-  getDaysInMonth,
 } from './plainDate';
 
 export {
@@ -63,7 +63,7 @@ export function parseDateInput(input: string): PlainDate | null {
   const isoMatch = trimmed.match(/^(\d{4})-(\d{1,2})-(\d{1,2})$/);
   if (isoMatch) {
     const [, year, month, day] = isoMatch;
-    return createPlainDate(+year, +month, +day);
+    return tryCreatePlainDate(+year, +month, +day);
   }
 
   // 2. Try full month name formats with year
@@ -75,7 +75,7 @@ export function parseDateInput(input: string): PlainDate | null {
     const [, monthName, day, year] = monthFirstWithYearMatch;
     const month = parseMonthName(monthName);
     if (month !== null) {
-      return createPlainDate(+year, month, +day);
+      return tryCreatePlainDate(+year, month, +day);
     }
   }
 
@@ -87,7 +87,7 @@ export function parseDateInput(input: string): PlainDate | null {
     const [, day, monthName, year] = dayFirstWithYearMatch;
     const month = parseMonthName(monthName);
     if (month !== null) {
-      return createPlainDate(+year, month, +day);
+      return tryCreatePlainDate(+year, month, +day);
     }
   }
 
@@ -98,7 +98,7 @@ export function parseDateInput(input: string): PlainDate | null {
     const [, monthName, day] = monthFirstNoYearMatch;
     const month = parseMonthName(monthName);
     if (month !== null) {
-      return createPlainDate(currentYear, month, +day);
+      return tryCreatePlainDate(currentYear, month, +day);
     }
   }
 
@@ -108,7 +108,7 @@ export function parseDateInput(input: string): PlainDate | null {
     const [, day, monthName] = dayFirstNoYearMatch;
     const month = parseMonthName(monthName);
     if (month !== null) {
-      return createPlainDate(currentYear, month, +day);
+      return tryCreatePlainDate(currentYear, month, +day);
     }
   }
 
@@ -167,7 +167,7 @@ function parseNumericDate(
     }
   }
 
-  return createPlainDate(year, month, day);
+  return tryCreatePlainDate(year, month, day);
 }
 
 function parseMonthName(name: string): number | null {
@@ -200,21 +200,14 @@ function parseMonthName(name: string): number | null {
   return months[name.toLowerCase()] ?? null;
 }
 
-function createPlainDate(
+function tryCreatePlainDate(
   year: number,
   month: number,
   day: number,
 ): PlainDate | null {
-  if (month < 1 || month > 12 || day < 1 || day > getDaysInMonth(year, month)) {
+  try {
+    return plainDateCreate(year, month, day);
+  } catch {
     return null;
   }
-  return {year, month, day};
-}
-
-export function formatDisplayDate(iso: ISODateString): string {
-  return new Intl.DateTimeFormat(undefined, {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-  }).format(plainDateToDate(plainDateFromISO(iso)));
 }

--- a/packages/core/src/utils/dateParser.ts
+++ b/packages/core/src/utils/dateParser.ts
@@ -12,6 +12,9 @@
  */
 
 import type {ISODateString} from '../Calendar';
+import {fromISO, toISO, toDate, fromDate, daysInMonth} from './plainDate';
+
+export {fromISO as parseISO, toISO as dateToISO} from './plainDate';
 
 /**
  * Detects if the user's locale uses day-first date format (DD/MM/YYYY).
@@ -122,7 +125,7 @@ export function parseDateInput(input: string): ISODateString | null {
   // 6. Fall back to native Date parsing for other formats
   const parsed = new Date(trimmed);
   if (!isNaN(parsed.getTime())) {
-    return dateToISO(parsed);
+    return toISO(fromDate(parsed));
   }
 
   return null;
@@ -210,58 +213,16 @@ function createISODate(
   month: number,
   day: number,
 ): ISODateString | null {
-  if (month < 1 || month > 12 || day < 1 || day > 31) {
+  if (month < 1 || month > 12 || day < 1 || day > daysInMonth(year, month)) {
     return null;
   }
-
-  const date = new Date(year, month - 1, day);
-  // new Date(year, ...) treats 0-99 as 1900s; fix with setFullYear
-  date.setFullYear(year);
-
-  // Validate the date didn't overflow (e.g., Feb 30 → Mar 2)
-  if (
-    date.getFullYear() !== year ||
-    date.getMonth() !== month - 1 ||
-    date.getDate() !== day
-  ) {
-    return null;
-  }
-
-  return dateToISO(date);
+  return toISO({year, month, day});
 }
 
-/**
- * Converts a Date object to ISO date string.
- */
-export function dateToISO(date: Date): ISODateString {
-  const year = String(date.getFullYear()).padStart(4, '0');
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
-  return `${year}-${month}-${day}` as ISODateString;
-}
-
-/**
- * Parses an ISO date string into a Date object.
- */
-export function parseISO(iso: ISODateString): Date {
-  const [year, month, day] = iso.split('-').map(Number);
-  return new Date(year, month - 1, day);
-}
-
-/**
- * Formats an ISO date string for display.
- * Uses locale-aware formatting with full month name.
- *
- * @example
- * ```
- * formatDisplayDate("2026-01-25") // "January 25, 2026"
- * ```
- */
 export function formatDisplayDate(iso: ISODateString): string {
-  const date = parseISO(iso);
   return new Intl.DateTimeFormat(undefined, {
     year: 'numeric',
     month: 'long',
     day: 'numeric',
-  }).format(date);
+  }).format(toDate(fromISO(iso)));
 }

--- a/packages/core/src/utils/dateParser.ts
+++ b/packages/core/src/utils/dateParser.ts
@@ -12,9 +12,18 @@
  */
 
 import type {ISODateString} from '../Calendar';
-import {fromISO, toISO, toDate, fromDate, daysInMonth} from './plainDate';
+import {
+  plainDateFromISO,
+  plainDateToISO,
+  plainDateToDate,
+  plainDateFromDate,
+  plainDateDaysInMonth,
+} from './plainDate';
 
-export {fromISO as parseISO, toISO as dateToISO} from './plainDate';
+export {
+  plainDateFromISO as parseISO,
+  plainDateToISO as dateToISO,
+} from './plainDate';
 
 /**
  * Detects if the user's locale uses day-first date format (DD/MM/YYYY).
@@ -125,7 +134,7 @@ export function parseDateInput(input: string): ISODateString | null {
   // 6. Fall back to native Date parsing for other formats
   const parsed = new Date(trimmed);
   if (!isNaN(parsed.getTime())) {
-    return toISO(fromDate(parsed));
+    return plainDateToISO(plainDateFromDate(parsed));
   }
 
   return null;
@@ -213,10 +222,15 @@ function createISODate(
   month: number,
   day: number,
 ): ISODateString | null {
-  if (month < 1 || month > 12 || day < 1 || day > daysInMonth(year, month)) {
+  if (
+    month < 1 ||
+    month > 12 ||
+    day < 1 ||
+    day > plainDateDaysInMonth(year, month)
+  ) {
     return null;
   }
-  return toISO({year, month, day});
+  return plainDateToISO({year, month, day});
 }
 
 export function formatDisplayDate(iso: ISODateString): string {
@@ -224,5 +238,5 @@ export function formatDisplayDate(iso: ISODateString): string {
     year: 'numeric',
     month: 'long',
     day: 'numeric',
-  }).format(toDate(fromISO(iso)));
+  }).format(plainDateToDate(plainDateFromISO(iso)));
 }

--- a/packages/core/src/utils/dateParser.ts
+++ b/packages/core/src/utils/dateParser.ts
@@ -11,15 +11,7 @@
  * - /packages/core/src/utils/index.ts
  */
 
-import type {ISODateString} from './dateTypes';
-import {
-  type PlainDate,
-  plainDateCreate,
-  plainDateFromDate,
-  plainDateToDate,
-  plainDateFromISO,
-  plainDateToISO,
-} from './plainDate';
+import {type PlainDate, plainDateCreate, plainDateFromDate} from './plainDate';
 
 export {
   plainDateFromISO as parseISO,

--- a/packages/core/src/utils/dateTypes.ts
+++ b/packages/core/src/utils/dateTypes.ts
@@ -1,0 +1,24 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file dateTypes.ts
+ * @input None
+ * @output Shared date type definitions used across Calendar, DateInput, and other components
+ * @position Core type definitions; imported by Calendar, DateInput, DateRangeInput, DateTimeInput, plainDate, dateParser
+ */
+
+/**
+ * ISO 8601 date string in YYYY-MM-DD format.
+ * Example: "2026-01-28"
+ */
+export type ISODateString =
+  `${number}${number}${number}${number}-${number}${number}-${number}${number}`;
+
+/** Day of week: 0 = Sunday through 6 = Saturday */
+export type DayOfWeek = 0 | 1 | 2 | 3 | 4 | 5 | 6;
+
+/** Date range with start and end dates */
+export interface DateRange {
+  start: ISODateString;
+  end: ISODateString;
+}

--- a/packages/core/src/utils/dateTypes.ts
+++ b/packages/core/src/utils/dateTypes.ts
@@ -17,6 +17,14 @@ export type ISODateString =
 /** Day of week: 0 = Sunday through 6 = Saturday */
 export type DayOfWeek = 0 | 1 | 2 | 3 | 4 | 5 | 6;
 
+/** Immutable date record with 1-based month. */
+export interface PlainDate {
+  readonly year: number;
+  /** 1-based (1 = January, 12 = December) */
+  readonly month: number;
+  readonly day: number;
+}
+
 /** Date range with start and end dates */
 export interface DateRange {
   start: ISODateString;

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -27,7 +27,7 @@ export {
   plainDateToDate,
   plainDateFromDate,
   plainDateToday,
-  plainDateDaysInMonth,
+  getDaysInMonth,
   plainDateDayOfWeek,
   plainDateAddMonths,
   plainDateAddDays,

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -9,17 +9,15 @@
 
 export type {SizeValue} from './types';
 
-export type {ISODateString, DayOfWeek, DateRange} from './dateTypes';
+export type {ISODateString, DayOfWeek, PlainDate, DateRange} from './dateTypes';
 
 export {
   parseDateInput,
-  formatDisplayDate,
   dateToISO,
   parseISO,
   isLocaleDayFirst,
 } from './dateParser';
 
-export type {PlainDate} from './plainDate';
 export {
   plainDateCreate,
   plainDateFromISO,
@@ -38,6 +36,7 @@ export {
   plainDateSetFirstOfMonth,
   plainDateGetWeekNumber,
   plainDateFormatAccessible,
+  plainDateFormatDisplay,
 } from './plainDate';
 
 export {

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -35,8 +35,9 @@ export {
   plainDateIsInRange,
   plainDateSetFirstOfMonth,
   plainDateGetWeekNumber,
-  plainDateFormatAccessible,
-  plainDateFormatDisplay,
+  plainDateFormat,
+  DATE_FORMAT_WITH_WEEKDAY,
+  DATE_FORMAT_LONG,
 } from './plainDate';
 
 export {

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -9,6 +9,8 @@
 
 export type {SizeValue} from './types';
 
+export type {ISODateString, DayOfWeek, DateRange} from './dateTypes';
+
 export {
   parseDateInput,
   formatDisplayDate,
@@ -19,6 +21,7 @@ export {
 
 export type {PlainDate} from './plainDate';
 export {
+  plainDateCreate,
   plainDateFromISO,
   plainDateToISO,
   plainDateToDate,
@@ -30,9 +33,9 @@ export {
   plainDateAddDays,
   plainDateIsBefore,
   plainDateIsAfter,
-  plainDateIsSameDay,
+  plainDateIsEqual,
   plainDateIsInRange,
-  plainDateFirstOfMonth,
+  plainDateSetFirstOfMonth,
   plainDateGetWeekNumber,
   plainDateFormatAccessible,
 } from './plainDate';

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -19,21 +19,22 @@ export {
 
 export type {PlainDate} from './plainDate';
 export {
-  fromISO,
-  toISO,
-  toDate,
-  fromDate,
-  today,
-  daysInMonth,
-  dayOfWeek,
-  addMonths,
-  addDays,
-  compare,
-  isSameDay,
-  isInRange,
-  firstOfMonth,
-  getWeekNumber,
-  formatAccessible,
+  plainDateFromISO,
+  plainDateToISO,
+  plainDateToDate,
+  plainDateFromDate,
+  plainDateToday,
+  plainDateDaysInMonth,
+  plainDateDayOfWeek,
+  plainDateAddMonths,
+  plainDateAddDays,
+  plainDateIsBefore,
+  plainDateIsAfter,
+  plainDateIsSameDay,
+  plainDateIsInRange,
+  plainDateFirstOfMonth,
+  plainDateGetWeekNumber,
+  plainDateFormatAccessible,
 } from './plainDate';
 
 export {

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -38,6 +38,9 @@ export {
   plainDateFormat,
   DATE_FORMAT_WITH_WEEKDAY,
   DATE_FORMAT_LONG,
+  DATE_FORMAT_MONTH_YEAR,
+  DATE_FORMAT_SHORT,
+  DATE_FORMAT_SHORT_WITH_YEAR,
 } from './plainDate';
 
 export {

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -17,6 +17,25 @@ export {
   isLocaleDayFirst,
 } from './dateParser';
 
+export type {PlainDate} from './plainDate';
+export {
+  fromISO,
+  toISO,
+  toDate,
+  fromDate,
+  today,
+  daysInMonth,
+  dayOfWeek,
+  addMonths,
+  addDays,
+  compare,
+  isSameDay,
+  isInRange,
+  firstOfMonth,
+  getWeekNumber,
+  formatAccessible,
+} from './plainDate';
+
 export {
   parseISOTime,
   formatISOTime,

--- a/packages/core/src/utils/plainDate.test.ts
+++ b/packages/core/src/utils/plainDate.test.ts
@@ -19,7 +19,8 @@ import {
   plainDateIsInRange,
   plainDateSetFirstOfMonth,
   plainDateGetWeekNumber,
-  plainDateFormatAccessible,
+  plainDateFormat,
+  DATE_FORMAT_WITH_WEEKDAY,
 } from './plainDate';
 import type {ISODateString} from './dateTypes';
 
@@ -431,9 +432,12 @@ describe('plainDateGetWeekNumber', () => {
   });
 });
 
-describe('plainDateFormatAccessible', () => {
-  it('returns a human-readable date string', () => {
-    const result = plainDateFormatAccessible({year: 2026, month: 1, day: 25});
+describe('plainDateFormat', () => {
+  it('returns a human-readable date string with weekday', () => {
+    const result = plainDateFormat(
+      {year: 2026, month: 1, day: 25},
+      DATE_FORMAT_WITH_WEEKDAY,
+    );
     expect(result).toContain('2026');
     expect(result).toContain('25');
   });

--- a/packages/core/src/utils/plainDate.test.ts
+++ b/packages/core/src/utils/plainDate.test.ts
@@ -3,27 +3,28 @@
 import {describe, it, expect} from 'vitest';
 import {
   type PlainDate,
-  fromISO,
-  toISO,
-  toDate,
-  fromDate,
-  today,
-  daysInMonth,
-  dayOfWeek,
-  addMonths,
-  addDays,
-  compare,
-  isSameDay,
-  isInRange,
-  firstOfMonth,
-  getWeekNumber,
-  formatAccessible,
+  plainDateFromISO,
+  plainDateToISO,
+  plainDateToDate,
+  plainDateFromDate,
+  plainDateToday,
+  plainDateDaysInMonth,
+  plainDateDayOfWeek,
+  plainDateAddMonths,
+  plainDateAddDays,
+  plainDateIsBefore,
+  plainDateIsAfter,
+  plainDateIsSameDay,
+  plainDateIsInRange,
+  plainDateFirstOfMonth,
+  plainDateGetWeekNumber,
+  plainDateFormatAccessible,
 } from './plainDate';
 import type {ISODateString} from '../Calendar/XDSCalendar';
 
-describe('fromISO', () => {
+describe('plainDateFromISO', () => {
   it('parses a standard ISO date', () => {
-    expect(fromISO('2026-01-25' as ISODateString)).toEqual({
+    expect(plainDateFromISO('2026-01-25' as ISODateString)).toEqual({
       year: 2026,
       month: 1,
       day: 25,
@@ -31,12 +32,12 @@ describe('fromISO', () => {
   });
 
   it('parses date with 1-based month', () => {
-    const dec = fromISO('2026-12-31' as ISODateString);
+    const dec = plainDateFromISO('2026-12-31' as ISODateString);
     expect(dec.month).toBe(12);
   });
 
   it('handles single-digit month/day when padded', () => {
-    expect(fromISO('2026-03-05' as ISODateString)).toEqual({
+    expect(plainDateFromISO('2026-03-05' as ISODateString)).toEqual({
       year: 2026,
       month: 3,
       day: 5,
@@ -44,21 +45,21 @@ describe('fromISO', () => {
   });
 });
 
-describe('toISO', () => {
+describe('plainDateToISO', () => {
   it('formats a PlainDate to ISO string', () => {
-    expect(toISO({year: 2026, month: 1, day: 25})).toBe('2026-01-25');
+    expect(plainDateToISO({year: 2026, month: 1, day: 25})).toBe('2026-01-25');
   });
 
   it('pads single-digit month and day', () => {
-    expect(toISO({year: 2026, month: 3, day: 5})).toBe('2026-03-05');
+    expect(plainDateToISO({year: 2026, month: 3, day: 5})).toBe('2026-03-05');
   });
 
   it('pads year to 4 digits', () => {
-    expect(toISO({year: 1, month: 1, day: 1})).toBe('0001-01-01');
+    expect(plainDateToISO({year: 1, month: 1, day: 1})).toBe('0001-01-01');
   });
 });
 
-describe('fromISO ↔ toISO roundtrip', () => {
+describe('plainDateFromISO / plainDateToISO roundtrip', () => {
   it.each([
     '2026-01-01',
     '2026-06-15',
@@ -66,24 +67,24 @@ describe('fromISO ↔ toISO roundtrip', () => {
     '2000-02-29',
     '1999-11-30',
   ])('roundtrips %s', iso => {
-    expect(toISO(fromISO(iso as ISODateString))).toBe(iso);
+    expect(plainDateToISO(plainDateFromISO(iso as ISODateString))).toBe(iso);
   });
 });
 
-describe('toDate / fromDate', () => {
+describe('plainDateToDate / plainDateFromDate', () => {
   it('converts PlainDate to Date and back', () => {
     const pd: PlainDate = {year: 2026, month: 3, day: 15};
-    const d = toDate(pd);
+    const d = plainDateToDate(pd);
     expect(d.getFullYear()).toBe(2026);
     expect(d.getMonth()).toBe(2); // 0-based
     expect(d.getDate()).toBe(15);
-    expect(fromDate(d)).toEqual(pd);
+    expect(plainDateFromDate(d)).toEqual(pd);
   });
 });
 
-describe('today', () => {
+describe('plainDateToday', () => {
   it('returns current date with 1-based month', () => {
-    const t = today();
+    const t = plainDateToday();
     const now = new Date();
     expect(t.year).toBe(now.getFullYear());
     expect(t.month).toBe(now.getMonth() + 1);
@@ -91,52 +92,52 @@ describe('today', () => {
   });
 });
 
-describe('daysInMonth', () => {
+describe('plainDateDaysInMonth', () => {
   it('returns 31 for January', () => {
-    expect(daysInMonth(2026, 1)).toBe(31);
+    expect(plainDateDaysInMonth(2026, 1)).toBe(31);
   });
 
   it('returns 28 for February in a non-leap year', () => {
-    expect(daysInMonth(2026, 2)).toBe(28);
+    expect(plainDateDaysInMonth(2026, 2)).toBe(28);
   });
 
   it('returns 29 for February in a leap year', () => {
-    expect(daysInMonth(2024, 2)).toBe(29);
+    expect(plainDateDaysInMonth(2024, 2)).toBe(29);
   });
 
   it('returns 30 for April', () => {
-    expect(daysInMonth(2026, 4)).toBe(30);
+    expect(plainDateDaysInMonth(2026, 4)).toBe(30);
   });
 
   it('handles century non-leap year', () => {
-    expect(daysInMonth(1900, 2)).toBe(28);
+    expect(plainDateDaysInMonth(1900, 2)).toBe(28);
   });
 
   it('handles 400-year leap year', () => {
-    expect(daysInMonth(2000, 2)).toBe(29);
+    expect(plainDateDaysInMonth(2000, 2)).toBe(29);
   });
 });
 
-describe('dayOfWeek', () => {
+describe('plainDateDayOfWeek', () => {
   it('returns 0 for a known Sunday', () => {
     // 2026-01-04 is a Sunday
-    expect(dayOfWeek({year: 2026, month: 1, day: 4})).toBe(0);
+    expect(plainDateDayOfWeek({year: 2026, month: 1, day: 4})).toBe(0);
   });
 
   it('returns 1 for a known Monday', () => {
     // 2026-01-05 is a Monday
-    expect(dayOfWeek({year: 2026, month: 1, day: 5})).toBe(1);
+    expect(plainDateDayOfWeek({year: 2026, month: 1, day: 5})).toBe(1);
   });
 
   it('returns 6 for a known Saturday', () => {
     // 2026-01-03 is a Saturday
-    expect(dayOfWeek({year: 2026, month: 1, day: 3})).toBe(6);
+    expect(plainDateDayOfWeek({year: 2026, month: 1, day: 3})).toBe(6);
   });
 });
 
-describe('addMonths', () => {
+describe('plainDateAddMonths', () => {
   it('adds months within the same year', () => {
-    expect(addMonths({year: 2026, month: 1, day: 15}, 3)).toEqual({
+    expect(plainDateAddMonths({year: 2026, month: 1, day: 15}, 3)).toEqual({
       year: 2026,
       month: 4,
       day: 15,
@@ -144,7 +145,7 @@ describe('addMonths', () => {
   });
 
   it('rolls over to the next year', () => {
-    expect(addMonths({year: 2026, month: 11, day: 15}, 3)).toEqual({
+    expect(plainDateAddMonths({year: 2026, month: 11, day: 15}, 3)).toEqual({
       year: 2027,
       month: 2,
       day: 15,
@@ -152,7 +153,7 @@ describe('addMonths', () => {
   });
 
   it('subtracts months', () => {
-    expect(addMonths({year: 2026, month: 3, day: 15}, -2)).toEqual({
+    expect(plainDateAddMonths({year: 2026, month: 3, day: 15}, -2)).toEqual({
       year: 2026,
       month: 1,
       day: 15,
@@ -160,7 +161,7 @@ describe('addMonths', () => {
   });
 
   it('rolls back to previous year', () => {
-    expect(addMonths({year: 2026, month: 1, day: 15}, -2)).toEqual({
+    expect(plainDateAddMonths({year: 2026, month: 1, day: 15}, -2)).toEqual({
       year: 2025,
       month: 11,
       day: 15,
@@ -168,7 +169,7 @@ describe('addMonths', () => {
   });
 
   it('clamps day when target month is shorter', () => {
-    expect(addMonths({year: 2026, month: 1, day: 31}, 1)).toEqual({
+    expect(plainDateAddMonths({year: 2026, month: 1, day: 31}, 1)).toEqual({
       year: 2026,
       month: 2,
       day: 28,
@@ -176,7 +177,7 @@ describe('addMonths', () => {
   });
 
   it('clamps day to Feb 29 in leap year', () => {
-    expect(addMonths({year: 2024, month: 1, day: 31}, 1)).toEqual({
+    expect(plainDateAddMonths({year: 2024, month: 1, day: 31}, 1)).toEqual({
       year: 2024,
       month: 2,
       day: 29,
@@ -184,9 +185,9 @@ describe('addMonths', () => {
   });
 });
 
-describe('addDays', () => {
+describe('plainDateAddDays', () => {
   it('adds days within the same month', () => {
-    expect(addDays({year: 2026, month: 1, day: 15}, 5)).toEqual({
+    expect(plainDateAddDays({year: 2026, month: 1, day: 15}, 5)).toEqual({
       year: 2026,
       month: 1,
       day: 20,
@@ -194,7 +195,7 @@ describe('addDays', () => {
   });
 
   it('rolls over to next month', () => {
-    expect(addDays({year: 2026, month: 1, day: 30}, 3)).toEqual({
+    expect(plainDateAddDays({year: 2026, month: 1, day: 30}, 3)).toEqual({
       year: 2026,
       month: 2,
       day: 2,
@@ -202,7 +203,7 @@ describe('addDays', () => {
   });
 
   it('rolls over to next year', () => {
-    expect(addDays({year: 2026, month: 12, day: 30}, 3)).toEqual({
+    expect(plainDateAddDays({year: 2026, month: 12, day: 30}, 3)).toEqual({
       year: 2027,
       month: 1,
       day: 2,
@@ -210,7 +211,7 @@ describe('addDays', () => {
   });
 
   it('subtracts days', () => {
-    expect(addDays({year: 2026, month: 1, day: 15}, -5)).toEqual({
+    expect(plainDateAddDays({year: 2026, month: 1, day: 15}, -5)).toEqual({
       year: 2026,
       month: 1,
       day: 10,
@@ -218,7 +219,7 @@ describe('addDays', () => {
   });
 
   it('rolls back to previous month', () => {
-    expect(addDays({year: 2026, month: 2, day: 1}, -1)).toEqual({
+    expect(plainDateAddDays({year: 2026, month: 2, day: 1}, -1)).toEqual({
       year: 2026,
       month: 1,
       day: 31,
@@ -226,42 +227,66 @@ describe('addDays', () => {
   });
 });
 
-describe('compare', () => {
-  it('returns 0 for equal dates', () => {
+describe('plainDateIsBefore / plainDateIsAfter', () => {
+  it('returns false for equal dates (isBefore)', () => {
     expect(
-      compare({year: 2026, month: 1, day: 15}, {year: 2026, month: 1, day: 15}),
-    ).toBe(0);
+      plainDateIsBefore(
+        {year: 2026, month: 1, day: 15},
+        {year: 2026, month: 1, day: 15},
+      ),
+    ).toBe(false);
   });
 
-  it('returns negative when first is earlier', () => {
+  it('returns false for equal dates (isAfter)', () => {
     expect(
-      compare({year: 2026, month: 1, day: 14}, {year: 2026, month: 1, day: 15}),
-    ).toBeLessThan(0);
+      plainDateIsAfter(
+        {year: 2026, month: 1, day: 15},
+        {year: 2026, month: 1, day: 15},
+      ),
+    ).toBe(false);
   });
 
-  it('returns positive when first is later', () => {
+  it('returns true when first is earlier (isBefore)', () => {
     expect(
-      compare({year: 2026, month: 1, day: 16}, {year: 2026, month: 1, day: 15}),
-    ).toBeGreaterThan(0);
+      plainDateIsBefore(
+        {year: 2026, month: 1, day: 14},
+        {year: 2026, month: 1, day: 15},
+      ),
+    ).toBe(true);
+  });
+
+  it('returns true when first is later (isAfter)', () => {
+    expect(
+      plainDateIsAfter(
+        {year: 2026, month: 1, day: 16},
+        {year: 2026, month: 1, day: 15},
+      ),
+    ).toBe(true);
   });
 
   it('compares by year first', () => {
     expect(
-      compare({year: 2025, month: 12, day: 31}, {year: 2026, month: 1, day: 1}),
-    ).toBeLessThan(0);
+      plainDateIsBefore(
+        {year: 2025, month: 12, day: 31},
+        {year: 2026, month: 1, day: 1},
+      ),
+    ).toBe(true);
   });
 
   it('compares by month when years equal', () => {
     expect(
-      compare({year: 2026, month: 1, day: 31}, {year: 2026, month: 2, day: 1}),
-    ).toBeLessThan(0);
+      plainDateIsBefore(
+        {year: 2026, month: 1, day: 31},
+        {year: 2026, month: 2, day: 1},
+      ),
+    ).toBe(true);
   });
 });
 
-describe('isSameDay', () => {
+describe('plainDateIsSameDay', () => {
   it('returns true for same date', () => {
     expect(
-      isSameDay(
+      plainDateIsSameDay(
         {year: 2026, month: 1, day: 15},
         {year: 2026, month: 1, day: 15},
       ),
@@ -270,7 +295,7 @@ describe('isSameDay', () => {
 
   it('returns false for different day', () => {
     expect(
-      isSameDay(
+      plainDateIsSameDay(
         {year: 2026, month: 1, day: 15},
         {year: 2026, month: 1, day: 16},
       ),
@@ -279,7 +304,7 @@ describe('isSameDay', () => {
 
   it('returns false for different month', () => {
     expect(
-      isSameDay(
+      plainDateIsSameDay(
         {year: 2026, month: 1, day: 15},
         {year: 2026, month: 2, day: 15},
       ),
@@ -287,34 +312,40 @@ describe('isSameDay', () => {
   });
 });
 
-describe('isInRange', () => {
+describe('plainDateIsInRange', () => {
   const start: PlainDate = {year: 2026, month: 1, day: 10};
   const end: PlainDate = {year: 2026, month: 1, day: 20};
 
   it('returns true for date within range', () => {
-    expect(isInRange({year: 2026, month: 1, day: 15}, start, end)).toBe(true);
+    expect(
+      plainDateIsInRange({year: 2026, month: 1, day: 15}, start, end),
+    ).toBe(true);
   });
 
   it('returns true for start boundary', () => {
-    expect(isInRange(start, start, end)).toBe(true);
+    expect(plainDateIsInRange(start, start, end)).toBe(true);
   });
 
   it('returns true for end boundary', () => {
-    expect(isInRange(end, start, end)).toBe(true);
+    expect(plainDateIsInRange(end, start, end)).toBe(true);
   });
 
   it('returns false for date before range', () => {
-    expect(isInRange({year: 2026, month: 1, day: 9}, start, end)).toBe(false);
+    expect(plainDateIsInRange({year: 2026, month: 1, day: 9}, start, end)).toBe(
+      false,
+    );
   });
 
   it('returns false for date after range', () => {
-    expect(isInRange({year: 2026, month: 1, day: 21}, start, end)).toBe(false);
+    expect(
+      plainDateIsInRange({year: 2026, month: 1, day: 21}, start, end),
+    ).toBe(false);
   });
 });
 
-describe('firstOfMonth', () => {
+describe('plainDateFirstOfMonth', () => {
   it('returns first day of the same month', () => {
-    expect(firstOfMonth({year: 2026, month: 3, day: 15})).toEqual({
+    expect(plainDateFirstOfMonth({year: 2026, month: 3, day: 15})).toEqual({
       year: 2026,
       month: 3,
       day: 1,
@@ -323,27 +354,27 @@ describe('firstOfMonth', () => {
 
   it('is a no-op for day 1', () => {
     const pd = {year: 2026, month: 3, day: 1};
-    expect(firstOfMonth(pd)).toEqual(pd);
+    expect(plainDateFirstOfMonth(pd)).toEqual(pd);
   });
 });
 
-describe('getWeekNumber', () => {
+describe('plainDateGetWeekNumber', () => {
   it('returns week 1 for Jan 1 2026 (Thursday)', () => {
-    expect(getWeekNumber({year: 2026, month: 1, day: 1})).toBe(1);
+    expect(plainDateGetWeekNumber({year: 2026, month: 1, day: 1})).toBe(1);
   });
 
   it('returns week 53 for Dec 31 2020 (Thursday in ISO week 53)', () => {
-    expect(getWeekNumber({year: 2020, month: 12, day: 31})).toBe(53);
+    expect(plainDateGetWeekNumber({year: 2020, month: 12, day: 31})).toBe(53);
   });
 
   it('returns week 1 for Jan 4 (always in ISO week 1)', () => {
-    expect(getWeekNumber({year: 2026, month: 1, day: 4})).toBe(1);
+    expect(plainDateGetWeekNumber({year: 2026, month: 1, day: 4})).toBe(1);
   });
 });
 
-describe('formatAccessible', () => {
+describe('plainDateFormatAccessible', () => {
   it('returns a human-readable date string', () => {
-    const result = formatAccessible({year: 2026, month: 1, day: 25});
+    const result = plainDateFormatAccessible({year: 2026, month: 1, day: 25});
     expect(result).toContain('2026');
     expect(result).toContain('25');
   });

--- a/packages/core/src/utils/plainDate.test.ts
+++ b/packages/core/src/utils/plainDate.test.ts
@@ -9,7 +9,7 @@ import {
   plainDateToDate,
   plainDateFromDate,
   plainDateToday,
-  plainDateDaysInMonth,
+  getDaysInMonth,
   plainDateDayOfWeek,
   plainDateAddMonths,
   plainDateAddDays,
@@ -131,29 +131,29 @@ describe('plainDateToday', () => {
   });
 });
 
-describe('plainDateDaysInMonth', () => {
+describe('getDaysInMonth', () => {
   it('returns 31 for January', () => {
-    expect(plainDateDaysInMonth(2026, 1)).toBe(31);
+    expect(getDaysInMonth(2026, 1)).toBe(31);
   });
 
   it('returns 28 for February in a non-leap year', () => {
-    expect(plainDateDaysInMonth(2026, 2)).toBe(28);
+    expect(getDaysInMonth(2026, 2)).toBe(28);
   });
 
   it('returns 29 for February in a leap year', () => {
-    expect(plainDateDaysInMonth(2024, 2)).toBe(29);
+    expect(getDaysInMonth(2024, 2)).toBe(29);
   });
 
   it('returns 30 for April', () => {
-    expect(plainDateDaysInMonth(2026, 4)).toBe(30);
+    expect(getDaysInMonth(2026, 4)).toBe(30);
   });
 
   it('handles century non-leap year', () => {
-    expect(plainDateDaysInMonth(1900, 2)).toBe(28);
+    expect(getDaysInMonth(1900, 2)).toBe(28);
   });
 
   it('handles 400-year leap year', () => {
-    expect(plainDateDaysInMonth(2000, 2)).toBe(29);
+    expect(getDaysInMonth(2000, 2)).toBe(29);
   });
 });
 

--- a/packages/core/src/utils/plainDate.test.ts
+++ b/packages/core/src/utils/plainDate.test.ts
@@ -227,19 +227,19 @@ describe('plainDateAddMonths', () => {
     });
   });
 
-  it('clamps day when target month is shorter', () => {
+  it('overflows day into next month when target month is shorter', () => {
     expect(plainDateAddMonths({year: 2026, month: 1, day: 31}, 1)).toEqual({
       year: 2026,
-      month: 2,
-      day: 28,
+      month: 3,
+      day: 3,
     });
   });
 
-  it('clamps day to Feb 29 in leap year', () => {
+  it('overflows Jan 31 + 1 month in leap year', () => {
     expect(plainDateAddMonths({year: 2024, month: 1, day: 31}, 1)).toEqual({
       year: 2024,
-      month: 2,
-      day: 29,
+      month: 3,
+      day: 2,
     });
   });
 });

--- a/packages/core/src/utils/plainDate.test.ts
+++ b/packages/core/src/utils/plainDate.test.ts
@@ -3,6 +3,7 @@
 import {describe, it, expect} from 'vitest';
 import {
   type PlainDate,
+  plainDateCreate,
   plainDateFromISO,
   plainDateToISO,
   plainDateToDate,
@@ -14,13 +15,51 @@ import {
   plainDateAddDays,
   plainDateIsBefore,
   plainDateIsAfter,
-  plainDateIsSameDay,
+  plainDateIsEqual,
   plainDateIsInRange,
-  plainDateFirstOfMonth,
+  plainDateSetFirstOfMonth,
   plainDateGetWeekNumber,
   plainDateFormatAccessible,
 } from './plainDate';
-import type {ISODateString} from '../Calendar/XDSCalendar';
+import type {ISODateString} from './dateTypes';
+
+describe('plainDateCreate', () => {
+  it('creates a valid PlainDate', () => {
+    expect(plainDateCreate(2026, 1, 25)).toEqual({
+      year: 2026,
+      month: 1,
+      day: 25,
+    });
+  });
+
+  it('throws for month < 1', () => {
+    expect(() => plainDateCreate(2026, 0, 1)).toThrow(RangeError);
+  });
+
+  it('throws for month > 12', () => {
+    expect(() => plainDateCreate(2026, 13, 1)).toThrow(RangeError);
+  });
+
+  it('throws for day < 1', () => {
+    expect(() => plainDateCreate(2026, 1, 0)).toThrow(RangeError);
+  });
+
+  it('throws for day exceeding month length', () => {
+    expect(() => plainDateCreate(2026, 2, 29)).toThrow(RangeError);
+  });
+
+  it('allows Feb 29 in a leap year', () => {
+    expect(plainDateCreate(2024, 2, 29)).toEqual({
+      year: 2024,
+      month: 2,
+      day: 29,
+    });
+  });
+
+  it('throws for Feb 30 even in a leap year', () => {
+    expect(() => plainDateCreate(2024, 2, 30)).toThrow(RangeError);
+  });
+});
 
 describe('plainDateFromISO', () => {
   it('parses a standard ISO date', () => {
@@ -283,10 +322,10 @@ describe('plainDateIsBefore / plainDateIsAfter', () => {
   });
 });
 
-describe('plainDateIsSameDay', () => {
+describe('plainDateIsEqual', () => {
   it('returns true for same date', () => {
     expect(
-      plainDateIsSameDay(
+      plainDateIsEqual(
         {year: 2026, month: 1, day: 15},
         {year: 2026, month: 1, day: 15},
       ),
@@ -295,7 +334,7 @@ describe('plainDateIsSameDay', () => {
 
   it('returns false for different day', () => {
     expect(
-      plainDateIsSameDay(
+      plainDateIsEqual(
         {year: 2026, month: 1, day: 15},
         {year: 2026, month: 1, day: 16},
       ),
@@ -304,7 +343,7 @@ describe('plainDateIsSameDay', () => {
 
   it('returns false for different month', () => {
     expect(
-      plainDateIsSameDay(
+      plainDateIsEqual(
         {year: 2026, month: 1, day: 15},
         {year: 2026, month: 2, day: 15},
       ),
@@ -318,34 +357,34 @@ describe('plainDateIsInRange', () => {
 
   it('returns true for date within range', () => {
     expect(
-      plainDateIsInRange({year: 2026, month: 1, day: 15}, start, end),
+      plainDateIsInRange({year: 2026, month: 1, day: 15}, [start, end]),
     ).toBe(true);
   });
 
   it('returns true for start boundary', () => {
-    expect(plainDateIsInRange(start, start, end)).toBe(true);
+    expect(plainDateIsInRange(start, [start, end])).toBe(true);
   });
 
   it('returns true for end boundary', () => {
-    expect(plainDateIsInRange(end, start, end)).toBe(true);
+    expect(plainDateIsInRange(end, [start, end])).toBe(true);
   });
 
   it('returns false for date before range', () => {
-    expect(plainDateIsInRange({year: 2026, month: 1, day: 9}, start, end)).toBe(
-      false,
-    );
+    expect(
+      plainDateIsInRange({year: 2026, month: 1, day: 9}, [start, end]),
+    ).toBe(false);
   });
 
   it('returns false for date after range', () => {
     expect(
-      plainDateIsInRange({year: 2026, month: 1, day: 21}, start, end),
+      plainDateIsInRange({year: 2026, month: 1, day: 21}, [start, end]),
     ).toBe(false);
   });
 });
 
-describe('plainDateFirstOfMonth', () => {
+describe('plainDateSetFirstOfMonth', () => {
   it('returns first day of the same month', () => {
-    expect(plainDateFirstOfMonth({year: 2026, month: 3, day: 15})).toEqual({
+    expect(plainDateSetFirstOfMonth({year: 2026, month: 3, day: 15})).toEqual({
       year: 2026,
       month: 3,
       day: 1,
@@ -354,7 +393,7 @@ describe('plainDateFirstOfMonth', () => {
 
   it('is a no-op for day 1', () => {
     const pd = {year: 2026, month: 3, day: 1};
-    expect(plainDateFirstOfMonth(pd)).toEqual(pd);
+    expect(plainDateSetFirstOfMonth(pd)).toEqual(pd);
   });
 });
 

--- a/packages/core/src/utils/plainDate.test.ts
+++ b/packages/core/src/utils/plainDate.test.ts
@@ -32,6 +32,26 @@ describe('plainDateCreate', () => {
     });
   });
 
+  it('throws for year < 1', () => {
+    expect(() => plainDateCreate(0, 1, 1)).toThrow(RangeError);
+  });
+
+  it('throws for negative year', () => {
+    expect(() => plainDateCreate(-1, 1, 1)).toThrow(RangeError);
+  });
+
+  it('throws for non-integer year', () => {
+    expect(() => plainDateCreate(2026.5, 1, 1)).toThrow(RangeError);
+  });
+
+  it('throws for non-integer month', () => {
+    expect(() => plainDateCreate(2026, 1.5, 1)).toThrow(RangeError);
+  });
+
+  it('throws for non-integer day', () => {
+    expect(() => plainDateCreate(2026, 1, 1.5)).toThrow(RangeError);
+  });
+
   it('throws for month < 1', () => {
     expect(() => plainDateCreate(2026, 0, 1)).toThrow(RangeError);
   });

--- a/packages/core/src/utils/plainDate.test.ts
+++ b/packages/core/src/utils/plainDate.test.ts
@@ -1,0 +1,350 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {describe, it, expect} from 'vitest';
+import {
+  type PlainDate,
+  fromISO,
+  toISO,
+  toDate,
+  fromDate,
+  today,
+  daysInMonth,
+  dayOfWeek,
+  addMonths,
+  addDays,
+  compare,
+  isSameDay,
+  isInRange,
+  firstOfMonth,
+  getWeekNumber,
+  formatAccessible,
+} from './plainDate';
+import type {ISODateString} from '../Calendar/XDSCalendar';
+
+describe('fromISO', () => {
+  it('parses a standard ISO date', () => {
+    expect(fromISO('2026-01-25' as ISODateString)).toEqual({
+      year: 2026,
+      month: 1,
+      day: 25,
+    });
+  });
+
+  it('parses date with 1-based month', () => {
+    const dec = fromISO('2026-12-31' as ISODateString);
+    expect(dec.month).toBe(12);
+  });
+
+  it('handles single-digit month/day when padded', () => {
+    expect(fromISO('2026-03-05' as ISODateString)).toEqual({
+      year: 2026,
+      month: 3,
+      day: 5,
+    });
+  });
+});
+
+describe('toISO', () => {
+  it('formats a PlainDate to ISO string', () => {
+    expect(toISO({year: 2026, month: 1, day: 25})).toBe('2026-01-25');
+  });
+
+  it('pads single-digit month and day', () => {
+    expect(toISO({year: 2026, month: 3, day: 5})).toBe('2026-03-05');
+  });
+
+  it('pads year to 4 digits', () => {
+    expect(toISO({year: 1, month: 1, day: 1})).toBe('0001-01-01');
+  });
+});
+
+describe('fromISO ↔ toISO roundtrip', () => {
+  it.each([
+    '2026-01-01',
+    '2026-06-15',
+    '2026-12-31',
+    '2000-02-29',
+    '1999-11-30',
+  ])('roundtrips %s', iso => {
+    expect(toISO(fromISO(iso as ISODateString))).toBe(iso);
+  });
+});
+
+describe('toDate / fromDate', () => {
+  it('converts PlainDate to Date and back', () => {
+    const pd: PlainDate = {year: 2026, month: 3, day: 15};
+    const d = toDate(pd);
+    expect(d.getFullYear()).toBe(2026);
+    expect(d.getMonth()).toBe(2); // 0-based
+    expect(d.getDate()).toBe(15);
+    expect(fromDate(d)).toEqual(pd);
+  });
+});
+
+describe('today', () => {
+  it('returns current date with 1-based month', () => {
+    const t = today();
+    const now = new Date();
+    expect(t.year).toBe(now.getFullYear());
+    expect(t.month).toBe(now.getMonth() + 1);
+    expect(t.day).toBe(now.getDate());
+  });
+});
+
+describe('daysInMonth', () => {
+  it('returns 31 for January', () => {
+    expect(daysInMonth(2026, 1)).toBe(31);
+  });
+
+  it('returns 28 for February in a non-leap year', () => {
+    expect(daysInMonth(2026, 2)).toBe(28);
+  });
+
+  it('returns 29 for February in a leap year', () => {
+    expect(daysInMonth(2024, 2)).toBe(29);
+  });
+
+  it('returns 30 for April', () => {
+    expect(daysInMonth(2026, 4)).toBe(30);
+  });
+
+  it('handles century non-leap year', () => {
+    expect(daysInMonth(1900, 2)).toBe(28);
+  });
+
+  it('handles 400-year leap year', () => {
+    expect(daysInMonth(2000, 2)).toBe(29);
+  });
+});
+
+describe('dayOfWeek', () => {
+  it('returns 0 for a known Sunday', () => {
+    // 2026-01-04 is a Sunday
+    expect(dayOfWeek({year: 2026, month: 1, day: 4})).toBe(0);
+  });
+
+  it('returns 1 for a known Monday', () => {
+    // 2026-01-05 is a Monday
+    expect(dayOfWeek({year: 2026, month: 1, day: 5})).toBe(1);
+  });
+
+  it('returns 6 for a known Saturday', () => {
+    // 2026-01-03 is a Saturday
+    expect(dayOfWeek({year: 2026, month: 1, day: 3})).toBe(6);
+  });
+});
+
+describe('addMonths', () => {
+  it('adds months within the same year', () => {
+    expect(addMonths({year: 2026, month: 1, day: 15}, 3)).toEqual({
+      year: 2026,
+      month: 4,
+      day: 15,
+    });
+  });
+
+  it('rolls over to the next year', () => {
+    expect(addMonths({year: 2026, month: 11, day: 15}, 3)).toEqual({
+      year: 2027,
+      month: 2,
+      day: 15,
+    });
+  });
+
+  it('subtracts months', () => {
+    expect(addMonths({year: 2026, month: 3, day: 15}, -2)).toEqual({
+      year: 2026,
+      month: 1,
+      day: 15,
+    });
+  });
+
+  it('rolls back to previous year', () => {
+    expect(addMonths({year: 2026, month: 1, day: 15}, -2)).toEqual({
+      year: 2025,
+      month: 11,
+      day: 15,
+    });
+  });
+
+  it('clamps day when target month is shorter', () => {
+    expect(addMonths({year: 2026, month: 1, day: 31}, 1)).toEqual({
+      year: 2026,
+      month: 2,
+      day: 28,
+    });
+  });
+
+  it('clamps day to Feb 29 in leap year', () => {
+    expect(addMonths({year: 2024, month: 1, day: 31}, 1)).toEqual({
+      year: 2024,
+      month: 2,
+      day: 29,
+    });
+  });
+});
+
+describe('addDays', () => {
+  it('adds days within the same month', () => {
+    expect(addDays({year: 2026, month: 1, day: 15}, 5)).toEqual({
+      year: 2026,
+      month: 1,
+      day: 20,
+    });
+  });
+
+  it('rolls over to next month', () => {
+    expect(addDays({year: 2026, month: 1, day: 30}, 3)).toEqual({
+      year: 2026,
+      month: 2,
+      day: 2,
+    });
+  });
+
+  it('rolls over to next year', () => {
+    expect(addDays({year: 2026, month: 12, day: 30}, 3)).toEqual({
+      year: 2027,
+      month: 1,
+      day: 2,
+    });
+  });
+
+  it('subtracts days', () => {
+    expect(addDays({year: 2026, month: 1, day: 15}, -5)).toEqual({
+      year: 2026,
+      month: 1,
+      day: 10,
+    });
+  });
+
+  it('rolls back to previous month', () => {
+    expect(addDays({year: 2026, month: 2, day: 1}, -1)).toEqual({
+      year: 2026,
+      month: 1,
+      day: 31,
+    });
+  });
+});
+
+describe('compare', () => {
+  it('returns 0 for equal dates', () => {
+    expect(
+      compare({year: 2026, month: 1, day: 15}, {year: 2026, month: 1, day: 15}),
+    ).toBe(0);
+  });
+
+  it('returns negative when first is earlier', () => {
+    expect(
+      compare({year: 2026, month: 1, day: 14}, {year: 2026, month: 1, day: 15}),
+    ).toBeLessThan(0);
+  });
+
+  it('returns positive when first is later', () => {
+    expect(
+      compare({year: 2026, month: 1, day: 16}, {year: 2026, month: 1, day: 15}),
+    ).toBeGreaterThan(0);
+  });
+
+  it('compares by year first', () => {
+    expect(
+      compare({year: 2025, month: 12, day: 31}, {year: 2026, month: 1, day: 1}),
+    ).toBeLessThan(0);
+  });
+
+  it('compares by month when years equal', () => {
+    expect(
+      compare({year: 2026, month: 1, day: 31}, {year: 2026, month: 2, day: 1}),
+    ).toBeLessThan(0);
+  });
+});
+
+describe('isSameDay', () => {
+  it('returns true for same date', () => {
+    expect(
+      isSameDay(
+        {year: 2026, month: 1, day: 15},
+        {year: 2026, month: 1, day: 15},
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false for different day', () => {
+    expect(
+      isSameDay(
+        {year: 2026, month: 1, day: 15},
+        {year: 2026, month: 1, day: 16},
+      ),
+    ).toBe(false);
+  });
+
+  it('returns false for different month', () => {
+    expect(
+      isSameDay(
+        {year: 2026, month: 1, day: 15},
+        {year: 2026, month: 2, day: 15},
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('isInRange', () => {
+  const start: PlainDate = {year: 2026, month: 1, day: 10};
+  const end: PlainDate = {year: 2026, month: 1, day: 20};
+
+  it('returns true for date within range', () => {
+    expect(isInRange({year: 2026, month: 1, day: 15}, start, end)).toBe(true);
+  });
+
+  it('returns true for start boundary', () => {
+    expect(isInRange(start, start, end)).toBe(true);
+  });
+
+  it('returns true for end boundary', () => {
+    expect(isInRange(end, start, end)).toBe(true);
+  });
+
+  it('returns false for date before range', () => {
+    expect(isInRange({year: 2026, month: 1, day: 9}, start, end)).toBe(false);
+  });
+
+  it('returns false for date after range', () => {
+    expect(isInRange({year: 2026, month: 1, day: 21}, start, end)).toBe(false);
+  });
+});
+
+describe('firstOfMonth', () => {
+  it('returns first day of the same month', () => {
+    expect(firstOfMonth({year: 2026, month: 3, day: 15})).toEqual({
+      year: 2026,
+      month: 3,
+      day: 1,
+    });
+  });
+
+  it('is a no-op for day 1', () => {
+    const pd = {year: 2026, month: 3, day: 1};
+    expect(firstOfMonth(pd)).toEqual(pd);
+  });
+});
+
+describe('getWeekNumber', () => {
+  it('returns week 1 for Jan 1 2026 (Thursday)', () => {
+    expect(getWeekNumber({year: 2026, month: 1, day: 1})).toBe(1);
+  });
+
+  it('returns week 53 for Dec 31 2020 (Thursday in ISO week 53)', () => {
+    expect(getWeekNumber({year: 2020, month: 12, day: 31})).toBe(53);
+  });
+
+  it('returns week 1 for Jan 4 (always in ISO week 1)', () => {
+    expect(getWeekNumber({year: 2026, month: 1, day: 4})).toBe(1);
+  });
+});
+
+describe('formatAccessible', () => {
+  it('returns a human-readable date string', () => {
+    const result = formatAccessible({year: 2026, month: 1, day: 25});
+    expect(result).toContain('2026');
+    expect(result).toContain('25');
+  });
+});

--- a/packages/core/src/utils/plainDate.ts
+++ b/packages/core/src/utils/plainDate.ts
@@ -7,14 +7,9 @@
  * @position Shared utility; replaces scattered Date usage across Calendar hooks
  */
 
-import type {ISODateString} from './dateTypes';
+import type {ISODateString, PlainDate} from './dateTypes';
 
-export interface PlainDate {
-  readonly year: number;
-  /** 1-based (1 = January, 12 = December) */
-  readonly month: number;
-  readonly day: number;
-}
+export type {PlainDate} from './dateTypes';
 
 export function plainDateCreate(
   year: number,
@@ -122,16 +117,24 @@ export function plainDateSetFirstOfMonth(pd: PlainDate): PlainDate {
 }
 
 export function plainDateGetWeekNumber(pd: PlainDate): number {
-  const d = new Date(Date.UTC(pd.year, pd.month - 1, pd.day));
-  const dayNum = d.getUTCDay() || 7;
-  d.setUTCDate(d.getUTCDate() + 4 - dayNum);
-  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+  const d = plainDateToDate(pd);
+  const dayNum = d.getDay() || 7;
+  d.setDate(d.getDate() + 4 - dayNum);
+  const yearStart = new Date(d.getFullYear(), 0, 1);
   return Math.ceil(((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
 }
 
 export function plainDateFormatAccessible(pd: PlainDate): string {
   return new Intl.DateTimeFormat(undefined, {
     weekday: 'long',
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  }).format(plainDateToDate(pd));
+}
+
+export function plainDateFormatDisplay(pd: PlainDate): string {
+  return new Intl.DateTimeFormat(undefined, {
     year: 'numeric',
     month: 'long',
     day: 'numeric',

--- a/packages/core/src/utils/plainDate.ts
+++ b/packages/core/src/utils/plainDate.ts
@@ -1,0 +1,121 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file plainDate.ts
+ * @input ISO date strings, year/month/day numbers
+ * @output Immutable PlainDate records and pure date arithmetic
+ * @position Shared utility; replaces scattered Date usage across Calendar hooks
+ */
+
+import type {ISODateString} from '../Calendar/XDSCalendar';
+
+export interface PlainDate {
+  readonly year: number;
+  /** 1-based (1 = January, 12 = December) */
+  readonly month: number;
+  readonly day: number;
+}
+
+export function fromISO(str: ISODateString): PlainDate {
+  const [year, month, day] = str.split('-').map(Number);
+  return {year, month, day};
+}
+
+export function toISO(pd: PlainDate): ISODateString {
+  const y = String(pd.year).padStart(4, '0');
+  const m = String(pd.month).padStart(2, '0');
+  const d = String(pd.day).padStart(2, '0');
+  return `${y}-${m}-${d}` as ISODateString;
+}
+
+export function toDate(pd: PlainDate): Date {
+  return new Date(pd.year, pd.month - 1, pd.day);
+}
+
+export function fromDate(d: Date): PlainDate {
+  return {
+    year: d.getFullYear(),
+    month: d.getMonth() + 1,
+    day: d.getDate(),
+  };
+}
+
+export function today(): PlainDate {
+  return fromDate(new Date());
+}
+
+export function daysInMonth(year: number, month: number): number {
+  if (month === 2) {
+    const leap = (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
+    return leap ? 29 : 28;
+  }
+  return [0, 31, 0, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31][month];
+}
+
+export function dayOfWeek(pd: PlainDate): number {
+  return new Date(pd.year, pd.month - 1, pd.day).getDay();
+}
+
+export function addMonths(pd: PlainDate, n: number): PlainDate {
+  let month = pd.month + n;
+  let year = pd.year;
+  while (month > 12) {
+    month -= 12;
+    year++;
+  }
+  while (month < 1) {
+    month += 12;
+    year--;
+  }
+  const maxDay = daysInMonth(year, month);
+  return {year, month, day: Math.min(pd.day, maxDay)};
+}
+
+export function addDays(pd: PlainDate, n: number): PlainDate {
+  // Use Date for reliable rollover across month/year boundaries
+  const d = new Date(pd.year, pd.month - 1, pd.day + n);
+  return fromDate(d);
+}
+
+export function compare(a: PlainDate, b: PlainDate): number {
+  if (a.year !== b.year) {
+    return a.year - b.year;
+  }
+  if (a.month !== b.month) {
+    return a.month - b.month;
+  }
+  return a.day - b.day;
+}
+
+export function isSameDay(a: PlainDate, b: PlainDate): boolean {
+  return a.year === b.year && a.month === b.month && a.day === b.day;
+}
+
+export function isInRange(
+  pd: PlainDate,
+  start: PlainDate,
+  end: PlainDate,
+): boolean {
+  return compare(pd, start) >= 0 && compare(pd, end) <= 0;
+}
+
+export function firstOfMonth(pd: PlainDate): PlainDate {
+  return {year: pd.year, month: pd.month, day: 1};
+}
+
+export function getWeekNumber(pd: PlainDate): number {
+  const d = new Date(Date.UTC(pd.year, pd.month - 1, pd.day));
+  const dayNum = d.getUTCDay() || 7;
+  d.setUTCDate(d.getUTCDate() + 4 - dayNum);
+  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+  return Math.ceil(((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
+}
+
+export function formatAccessible(pd: PlainDate): string {
+  return new Intl.DateTimeFormat(undefined, {
+    weekday: 'long',
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  }).format(toDate(pd));
+}

--- a/packages/core/src/utils/plainDate.ts
+++ b/packages/core/src/utils/plainDate.ts
@@ -72,16 +72,9 @@ export function plainDateDayOfWeek(pd: PlainDate): number {
 }
 
 export function plainDateAddMonths(pd: PlainDate, n: number): PlainDate {
-  // Set day to 1 first to avoid Date overflow (e.g. Jan 31 + 1 month → Mar 3)
-  const d = plainDateToDate({...pd, day: 1});
+  const d = plainDateToDate(pd);
   d.setMonth(d.getMonth() + n);
-  // Clamp day to target month length (e.g. Jan 31 + 1 month → Feb 28, not Mar 3)
-  const maxDay = getDaysInMonth(d.getFullYear(), d.getMonth() + 1);
-  return {
-    year: d.getFullYear(),
-    month: d.getMonth() + 1,
-    day: Math.min(pd.day, maxDay),
-  };
+  return plainDateFromDate(d);
 }
 
 export function plainDateAddDays(pd: PlainDate, n: number): PlainDate {

--- a/packages/core/src/utils/plainDate.ts
+++ b/packages/core/src/utils/plainDate.ts
@@ -125,20 +125,25 @@ export function plainDateGetWeekNumber(pd: PlainDate): number {
 }
 
 // e.g. "Wednesday, May 21, 2026" (locale-dependent)
-export function plainDateFormatAccessible(pd: PlainDate): string {
-  return new Intl.DateTimeFormat(undefined, {
-    weekday: 'long',
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-  }).format(plainDateToDate(pd));
-}
+export const DATE_FORMAT_WITH_WEEKDAY: Intl.DateTimeFormatOptions = {
+  weekday: 'long',
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric',
+};
 
 // e.g. "May 21, 2026" (locale-dependent)
-export function plainDateFormatDisplay(pd: PlainDate): string {
-  return new Intl.DateTimeFormat(undefined, {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-  }).format(plainDateToDate(pd));
+export const DATE_FORMAT_LONG: Intl.DateTimeFormatOptions = {
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric',
+};
+
+export function plainDateFormat(
+  pd: PlainDate,
+  options: Intl.DateTimeFormatOptions,
+): string {
+  return new Intl.DateTimeFormat(undefined, options).format(
+    plainDateToDate(pd),
+  );
 }

--- a/packages/core/src/utils/plainDate.ts
+++ b/packages/core/src/utils/plainDate.ts
@@ -16,23 +16,23 @@ export interface PlainDate {
   readonly day: number;
 }
 
-export function fromISO(str: ISODateString): PlainDate {
+export function plainDateFromISO(str: ISODateString): PlainDate {
   const [year, month, day] = str.split('-').map(Number);
   return {year, month, day};
 }
 
-export function toISO(pd: PlainDate): ISODateString {
+export function plainDateToISO(pd: PlainDate): ISODateString {
   const y = String(pd.year).padStart(4, '0');
   const m = String(pd.month).padStart(2, '0');
   const d = String(pd.day).padStart(2, '0');
   return `${y}-${m}-${d}` as ISODateString;
 }
 
-export function toDate(pd: PlainDate): Date {
+export function plainDateToDate(pd: PlainDate): Date {
   return new Date(pd.year, pd.month - 1, pd.day);
 }
 
-export function fromDate(d: Date): PlainDate {
+export function plainDateFromDate(d: Date): PlainDate {
   return {
     year: d.getFullYear(),
     month: d.getMonth() + 1,
@@ -40,11 +40,11 @@ export function fromDate(d: Date): PlainDate {
   };
 }
 
-export function today(): PlainDate {
-  return fromDate(new Date());
+export function plainDateToday(): PlainDate {
+  return plainDateFromDate(new Date());
 }
 
-export function daysInMonth(year: number, month: number): number {
+export function plainDateDaysInMonth(year: number, month: number): number {
   if (month === 2) {
     const leap = (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
     return leap ? 29 : 28;
@@ -52,11 +52,11 @@ export function daysInMonth(year: number, month: number): number {
   return [0, 31, 0, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31][month];
 }
 
-export function dayOfWeek(pd: PlainDate): number {
+export function plainDateDayOfWeek(pd: PlainDate): number {
   return new Date(pd.year, pd.month - 1, pd.day).getDay();
 }
 
-export function addMonths(pd: PlainDate, n: number): PlainDate {
+export function plainDateAddMonths(pd: PlainDate, n: number): PlainDate {
   let month = pd.month + n;
   let year = pd.year;
   while (month > 12) {
@@ -67,17 +67,16 @@ export function addMonths(pd: PlainDate, n: number): PlainDate {
     month += 12;
     year--;
   }
-  const maxDay = daysInMonth(year, month);
+  const maxDay = plainDateDaysInMonth(year, month);
   return {year, month, day: Math.min(pd.day, maxDay)};
 }
 
-export function addDays(pd: PlainDate, n: number): PlainDate {
-  // Use Date for reliable rollover across month/year boundaries
+export function plainDateAddDays(pd: PlainDate, n: number): PlainDate {
   const d = new Date(pd.year, pd.month - 1, pd.day + n);
-  return fromDate(d);
+  return plainDateFromDate(d);
 }
 
-export function compare(a: PlainDate, b: PlainDate): number {
+function compare(a: PlainDate, b: PlainDate): number {
   if (a.year !== b.year) {
     return a.year - b.year;
   }
@@ -87,11 +86,19 @@ export function compare(a: PlainDate, b: PlainDate): number {
   return a.day - b.day;
 }
 
-export function isSameDay(a: PlainDate, b: PlainDate): boolean {
+export function plainDateIsBefore(a: PlainDate, b: PlainDate): boolean {
+  return compare(a, b) < 0;
+}
+
+export function plainDateIsAfter(a: PlainDate, b: PlainDate): boolean {
+  return compare(a, b) > 0;
+}
+
+export function plainDateIsSameDay(a: PlainDate, b: PlainDate): boolean {
   return a.year === b.year && a.month === b.month && a.day === b.day;
 }
 
-export function isInRange(
+export function plainDateIsInRange(
   pd: PlainDate,
   start: PlainDate,
   end: PlainDate,
@@ -99,11 +106,11 @@ export function isInRange(
   return compare(pd, start) >= 0 && compare(pd, end) <= 0;
 }
 
-export function firstOfMonth(pd: PlainDate): PlainDate {
+export function plainDateFirstOfMonth(pd: PlainDate): PlainDate {
   return {year: pd.year, month: pd.month, day: 1};
 }
 
-export function getWeekNumber(pd: PlainDate): number {
+export function plainDateGetWeekNumber(pd: PlainDate): number {
   const d = new Date(Date.UTC(pd.year, pd.month - 1, pd.day));
   const dayNum = d.getUTCDay() || 7;
   d.setUTCDate(d.getUTCDate() + 4 - dayNum);
@@ -111,11 +118,11 @@ export function getWeekNumber(pd: PlainDate): number {
   return Math.ceil(((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
 }
 
-export function formatAccessible(pd: PlainDate): string {
+export function plainDateFormatAccessible(pd: PlainDate): string {
   return new Intl.DateTimeFormat(undefined, {
     weekday: 'long',
     year: 'numeric',
     month: 'long',
     day: 'numeric',
-  }).format(toDate(pd));
+  }).format(plainDateToDate(pd));
 }

--- a/packages/core/src/utils/plainDate.ts
+++ b/packages/core/src/utils/plainDate.ts
@@ -24,7 +24,7 @@ export function plainDateCreate(
   if (month < 1 || month > 12) {
     throw new RangeError(`month must be 1–12, got ${month}`);
   }
-  const maxDay = plainDateDaysInMonth(year, month);
+  const maxDay = getDaysInMonth(year, month);
   if (day < 1 || day > maxDay) {
     throw new RangeError(
       `day must be 1–${maxDay} for ${year}-${String(month).padStart(2, '0')}, got ${day}`,
@@ -61,7 +61,7 @@ export function plainDateToday(): PlainDate {
   return plainDateFromDate(new Date());
 }
 
-export function plainDateDaysInMonth(year: number, month: number): number {
+export function getDaysInMonth(year: number, month: number): number {
   if (month === 2) {
     const leap = (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
     return leap ? 29 : 28;
@@ -74,18 +74,13 @@ export function plainDateDayOfWeek(pd: PlainDate): number {
 }
 
 export function plainDateAddMonths(pd: PlainDate, n: number): PlainDate {
-  let month = pd.month + n;
-  let year = pd.year;
-  while (month > 12) {
-    month -= 12;
-    year++;
-  }
-  while (month < 1) {
-    month += 12;
-    year--;
-  }
-  const maxDay = plainDateDaysInMonth(year, month);
-  return {year, month, day: Math.min(pd.day, maxDay)};
+  const d = new Date(pd.year, pd.month - 1 + n, 1);
+  const maxDay = getDaysInMonth(d.getFullYear(), d.getMonth() + 1);
+  return {
+    year: d.getFullYear(),
+    month: d.getMonth() + 1,
+    day: Math.min(pd.day, maxDay),
+  };
 }
 
 export function plainDateAddDays(pd: PlainDate, n: number): PlainDate {

--- a/packages/core/src/utils/plainDate.ts
+++ b/packages/core/src/utils/plainDate.ts
@@ -7,7 +7,7 @@
  * @position Shared utility; replaces scattered Date usage across Calendar hooks
  */
 
-import type {ISODateString} from '../Calendar/XDSCalendar';
+import type {ISODateString} from './dateTypes';
 
 export interface PlainDate {
   readonly year: number;
@@ -16,9 +16,26 @@ export interface PlainDate {
   readonly day: number;
 }
 
+export function plainDateCreate(
+  year: number,
+  month: number,
+  day: number,
+): PlainDate {
+  if (month < 1 || month > 12) {
+    throw new RangeError(`month must be 1–12, got ${month}`);
+  }
+  const maxDay = plainDateDaysInMonth(year, month);
+  if (day < 1 || day > maxDay) {
+    throw new RangeError(
+      `day must be 1–${maxDay} for ${year}-${String(month).padStart(2, '0')}, got ${day}`,
+    );
+  }
+  return {year, month, day};
+}
+
 export function plainDateFromISO(str: ISODateString): PlainDate {
   const [year, month, day] = str.split('-').map(Number);
-  return {year, month, day};
+  return plainDateCreate(year, month, day);
 }
 
 export function plainDateToISO(pd: PlainDate): ISODateString {
@@ -53,7 +70,7 @@ export function plainDateDaysInMonth(year: number, month: number): number {
 }
 
 export function plainDateDayOfWeek(pd: PlainDate): number {
-  return new Date(pd.year, pd.month - 1, pd.day).getDay();
+  return plainDateToDate(pd).getDay();
 }
 
 export function plainDateAddMonths(pd: PlainDate, n: number): PlainDate {
@@ -94,19 +111,18 @@ export function plainDateIsAfter(a: PlainDate, b: PlainDate): boolean {
   return compare(a, b) > 0;
 }
 
-export function plainDateIsSameDay(a: PlainDate, b: PlainDate): boolean {
-  return a.year === b.year && a.month === b.month && a.day === b.day;
+export function plainDateIsEqual(a: PlainDate, b: PlainDate): boolean {
+  return compare(a, b) === 0;
 }
 
 export function plainDateIsInRange(
   pd: PlainDate,
-  start: PlainDate,
-  end: PlainDate,
+  range: [PlainDate, PlainDate],
 ): boolean {
-  return compare(pd, start) >= 0 && compare(pd, end) <= 0;
+  return compare(pd, range[0]) >= 0 && compare(pd, range[1]) <= 0;
 }
 
-export function plainDateFirstOfMonth(pd: PlainDate): PlainDate {
+export function plainDateSetFirstOfMonth(pd: PlainDate): PlainDate {
   return {year: pd.year, month: pd.month, day: 1};
 }
 

--- a/packages/core/src/utils/plainDate.ts
+++ b/packages/core/src/utils/plainDate.ts
@@ -139,6 +139,25 @@ export const DATE_FORMAT_LONG: Intl.DateTimeFormatOptions = {
   day: 'numeric',
 };
 
+// e.g. "January 2026" (locale-dependent)
+export const DATE_FORMAT_MONTH_YEAR: Intl.DateTimeFormatOptions = {
+  year: 'numeric',
+  month: 'long',
+};
+
+// e.g. "Jan 25" (locale-dependent)
+export const DATE_FORMAT_SHORT: Intl.DateTimeFormatOptions = {
+  month: 'short',
+  day: 'numeric',
+};
+
+// e.g. "Jan 25, 2026" (locale-dependent)
+export const DATE_FORMAT_SHORT_WITH_YEAR: Intl.DateTimeFormatOptions = {
+  month: 'short',
+  day: 'numeric',
+  year: 'numeric',
+};
+
 export function plainDateFormat(
   pd: PlainDate,
   options: Intl.DateTimeFormatOptions,

--- a/packages/core/src/utils/plainDate.ts
+++ b/packages/core/src/utils/plainDate.ts
@@ -16,11 +16,14 @@ export function plainDateCreate(
   month: number,
   day: number,
 ): PlainDate {
-  if (month < 1 || month > 12) {
+  if (!Number.isInteger(year) || year < 1) {
+    throw new RangeError(`year must be a positive integer, got ${year}`);
+  }
+  if (!Number.isInteger(month) || month < 1 || month > 12) {
     throw new RangeError(`month must be 1–12, got ${month}`);
   }
   const maxDay = getDaysInMonth(year, month);
-  if (day < 1 || day > maxDay) {
+  if (!Number.isInteger(day) || day < 1 || day > maxDay) {
     throw new RangeError(
       `day must be 1–${maxDay} for ${year}-${String(month).padStart(2, '0')}, got ${day}`,
     );
@@ -58,8 +61,8 @@ export function plainDateToday(): PlainDate {
 
 export function getDaysInMonth(year: number, month: number): number {
   if (month === 2) {
-    const leap = (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
-    return leap ? 29 : 28;
+    const isLeap = (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
+    return isLeap ? 29 : 28;
   }
   return [0, 31, 0, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31][month];
 }
@@ -69,7 +72,10 @@ export function plainDateDayOfWeek(pd: PlainDate): number {
 }
 
 export function plainDateAddMonths(pd: PlainDate, n: number): PlainDate {
-  const d = new Date(pd.year, pd.month - 1 + n, 1);
+  // Set day to 1 first to avoid Date overflow (e.g. Jan 31 + 1 month → Mar 3)
+  const d = plainDateToDate({...pd, day: 1});
+  d.setMonth(d.getMonth() + n);
+  // Clamp day to target month length (e.g. Jan 31 + 1 month → Feb 28, not Mar 3)
   const maxDay = getDaysInMonth(d.getFullYear(), d.getMonth() + 1);
   return {
     year: d.getFullYear(),
@@ -79,7 +85,8 @@ export function plainDateAddMonths(pd: PlainDate, n: number): PlainDate {
 }
 
 export function plainDateAddDays(pd: PlainDate, n: number): PlainDate {
-  const d = new Date(pd.year, pd.month - 1, pd.day + n);
+  const d = plainDateToDate(pd);
+  d.setDate(d.getDate() + n);
   return plainDateFromDate(d);
 }
 

--- a/packages/core/src/utils/plainDate.ts
+++ b/packages/core/src/utils/plainDate.ts
@@ -124,6 +124,7 @@ export function plainDateGetWeekNumber(pd: PlainDate): number {
   return Math.ceil(((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
 }
 
+// e.g. "Wednesday, May 21, 2026" (locale-dependent)
 export function plainDateFormatAccessible(pd: PlainDate): string {
   return new Intl.DateTimeFormat(undefined, {
     weekday: 'long',
@@ -133,6 +134,7 @@ export function plainDateFormatAccessible(pd: PlainDate): string {
   }).format(plainDateToDate(pd));
 }
 
+// e.g. "May 21, 2026" (locale-dependent)
 export function plainDateFormatDisplay(pd: PlainDate): string {
   return new Intl.DateTimeFormat(undefined, {
     year: 'numeric',


### PR DESCRIPTION
> **Stacked on
  rename-date-inputs** — merge that first.

  ## Summary

  Phase 1 of #372. Introduces an immutable `PlainDate` record type and consolidates all date arithmetic into `utils/plainDate.ts`.

  - **New module:** `utils/plainDate.ts` — 16 pure functions + `PlainDate` interface (`{year, month, day}` with 1-based months)
  - **Eliminated 10 duplicate functions** — 5 copies of `parseISO` and 5 copies of `dateToISO` consolidated into one canonical module
  - **Migrated internals** — Calendar hooks, XDSCalendar, DateInput, DateRangeInput, DateTimeInput all use PlainDate internally
  - **No public API changes** — `dateConstraints` callbacks still receive `Date`, `onChange` still passes `valueAsDate: Date`, all prop types unchanged
  - **Net -100 lines** despite adding a new module

  ## Test plan
Added new tests for the new utils, existing tests still pass