### PR TITLE
feat(lab): XDSOutlineList — scroll-spy outline navigation

### DIFF
--- a/apps/storybook/stories/Outline.stories.tsx
+++ b/apps/storybook/stories/Outline.stories.tsx
@@ -25,6 +25,19 @@ const meta: Meta<typeof XDSOutline> = {
       control: 'text',
       description: 'Controlled active item id',
     },
+    size: {
+      control: 'radio',
+      options: ['sm', 'md'],
+      description: 'Size variant',
+    },
+    offset: {
+      control: 'number',
+      description: 'Scroll-spy offset in pixels',
+    },
+    hasScrollOnClick: {
+      control: 'boolean',
+      description: 'Whether clicking scrolls to the target',
+    },
   },
 };
 
@@ -77,7 +90,7 @@ function storySlug(value: string): string {
     value
       .trim()
       .toLowerCase()
-      .replace(/['"]/g, '')
+      .replace(/['\u201C\u201D"]/g, '')
       .replace(/[^a-z0-9]+/g, '-')
       .replace(/^-+|-+$/g, '') || 'section'
   );
@@ -93,6 +106,121 @@ export const Controlled: Story = {
   args: {
     items: outlineItems,
     activeId: 'tokens',
+  },
+};
+
+/** Small size variant — compact spacing for dense UIs */
+export const Small: Story = {
+  args: {
+    items: outlineItems,
+    activeId: 'installation',
+    size: 'sm',
+  },
+};
+
+/** Interactive scroll-spy demo with scrollable container */
+export const ScrollSpy: Story = {
+  render: () => {
+    const containerRef = useRef<HTMLDivElement>(null);
+
+    const sections: OutlineItem[] = [
+      {id: 'spy-overview', label: 'Overview', level: 2},
+      {id: 'spy-features', label: 'Features', level: 2},
+      {id: 'spy-usage', label: 'Usage', level: 3},
+      {id: 'spy-props', label: 'Props', level: 3},
+      {id: 'spy-advanced', label: 'Advanced', level: 2},
+      {id: 'spy-changelog', label: 'Changelog', level: 2},
+    ];
+
+    return (
+      <div style={{display: 'flex', gap: 24, height: 400}}>
+        <div style={{width: 200, position: 'sticky', top: 0}}>
+          <XDSOutline
+            items={sections}
+            scrollContainerRef={containerRef}
+            offset={0}
+          />
+        </div>
+        <div
+          ref={containerRef}
+          style={{flex: 1, overflow: 'auto', paddingInlineEnd: 16}}>
+          {sections.map(section => (
+            <div
+              key={section.id}
+              id={section.id}
+              style={{
+                minHeight: 300,
+                padding: 16,
+                borderBottom: '1px solid #eee',
+              }}>
+              <h2>{section.label}</h2>
+              <p style={{color: '#666'}}>
+                Content for the {section.label} section. Scroll to see the
+                indicator slide to the active section.
+              </p>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  },
+};
+
+/** Navigate callbacks — custom flash highlight on scroll arrival */
+export const NavigateCallbacks: Story = {
+  render: () => {
+    const containerRef = useRef<HTMLDivElement>(null);
+
+    const sections: OutlineItem[] = [
+      {id: 'nav-intro', label: 'Intro', level: 2},
+      {id: 'nav-body', label: 'Body', level: 2},
+      {id: 'nav-outro', label: 'Outro', level: 2},
+    ];
+
+    return (
+      <div style={{display: 'flex', gap: 24, height: 400}}>
+        <div style={{width: 180}}>
+          <XDSOutline
+            items={sections}
+            scrollContainerRef={containerRef}
+            onNavigateEnd={id => {
+              const el = document.getElementById(id);
+              if (!el) {
+                return;
+              }
+              el.style.transition = 'none';
+              el.style.backgroundColor =
+                'var(--color-accent-muted, rgba(0,130,251,0.15))';
+              el.style.borderRadius = '8px';
+              requestAnimationFrame(() => {
+                el.style.transition = 'background-color 800ms ease-out';
+                el.style.backgroundColor = '';
+              });
+            }}
+          />
+        </div>
+        <div
+          ref={containerRef}
+          style={{flex: 1, overflow: 'auto', paddingInlineEnd: 16}}>
+          {sections.map(section => (
+            <div
+              key={section.id}
+              id={section.id}
+              style={{
+                minHeight: 300,
+                padding: 16,
+                borderBottom: '1px solid #eee',
+              }}>
+              <h2>{section.label}</h2>
+              <p style={{color: '#666'}}>
+                Click an item to see the custom flash highlight via
+                onNavigateEnd.
+              </p>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
   },
 };
 
@@ -245,6 +373,27 @@ export const ExtractFromHTML: Story = {
         <aside style={{position: 'sticky', top: 24, alignSelf: 'start'}}>
           <XDSOutline items={items} />
         </aside>
+      </div>
+    );
+  },
+};
+
+/** Deep nesting with multiple indent levels */
+export const DeepNesting: Story = {
+  render: () => {
+    const items: OutlineItem[] = [
+      {id: 'chapter-1', label: 'Chapter 1', level: 1},
+      {id: 'section-1-1', label: 'Section 1.1', level: 2},
+      {id: 'subsection-1-1-1', label: 'Subsection 1.1.1', level: 3},
+      {id: 'subsection-1-1-2', label: 'Subsection 1.1.2', level: 3},
+      {id: 'section-1-2', label: 'Section 1.2', level: 2},
+      {id: 'chapter-2', label: 'Chapter 2', level: 1},
+      {id: 'section-2-1', label: 'Section 2.1', level: 2},
+    ];
+
+    return (
+      <div style={{width: 240}}>
+        <XDSOutline items={items} activeId="subsection-1-1-1" />
       </div>
     );
   },

--- a/packages/core/src/Outline/Outline.doc.mjs
+++ b/packages/core/src/Outline/Outline.doc.mjs
@@ -13,6 +13,7 @@ export const docs = {
     'scroll spy',
     'documentation',
     'anchors',
+    'sliding indicator',
   ],
   playground: {
     defaults: {
@@ -26,7 +27,7 @@ export const docs = {
   },
   theming: {
     targets: [
-      {className: 'xds-outline'},
+      {className: 'xds-outline', visualProps: ['size']},
       {className: 'xds-outline-item', visualProps: ['level'], states: ['active']},
     ],
   },
@@ -34,13 +35,13 @@ export const docs = {
     {
       name: 'XDSOutline',
       description:
-        'Document outline navigation. Renders a flat heading list as anchor links and manages scroll-spy active state when uncontrolled.',
+        'Document outline navigation with sliding indicator track. Renders a flat heading list as anchor links with keyboard navigation, size variants, and scroll-spy active state when uncontrolled.',
       props: [
         {
           name: 'items',
           type: 'OutlineItem[]',
           description:
-            'Ordered heading items. Each item has id, label, and level. The id should match the target heading element id.',
+            'Ordered heading items. Each item has id, label, and level (1-6). The id should match the target heading element id.',
           required: true,
         },
         {
@@ -62,6 +63,39 @@ export const docs = {
           default: "'Table of contents'",
         },
         {
+          name: 'size',
+          type: "'sm' | 'md'",
+          description: "Size variant controlling item padding. 'sm' for dense UIs, 'md' for standard spacing.",
+          default: "'md'",
+        },
+        {
+          name: 'offset',
+          type: 'number',
+          description: 'Pixel offset from the top for scroll-spy activation threshold. Useful with fixed headers.',
+          default: '0',
+        },
+        {
+          name: 'scrollContainerRef',
+          type: 'React.RefObject<HTMLElement | null>',
+          description: 'Ref to scope scroll tracking to a specific container. Defaults to viewport.',
+        },
+        {
+          name: 'hasScrollOnClick',
+          type: 'boolean',
+          description: 'Whether clicking an item smooth-scrolls to the target section.',
+          default: 'true',
+        },
+        {
+          name: 'onNavigateStart',
+          type: '(id: string) => void',
+          description: 'Callback fired when programmatic scroll begins (item clicked).',
+        },
+        {
+          name: 'onNavigateEnd',
+          type: '(id: string) => void',
+          description: 'Callback fired when programmatic scroll ends and the target section is in view.',
+        },
+        {
           name: 'xstyle',
           type: 'StyleXStyles',
           description:
@@ -72,10 +106,12 @@ export const docs = {
   ],
   usage: {
     description:
-      'A table-of-contents sidebar for documentation pages, help centers, wikis, and long settings pages. Use it for navigation within a single page, not for app routes.',
+      'A table-of-contents sidebar for documentation pages, help centers, wikis, and long settings pages. Use it for navigation within a single page, not for app routes. Features a sliding indicator track and smooth-scroll on click.',
     bestPractices: [
       {guidance: true, description: 'Pass a flat ordered list of headings and let level control indentation.'},
       {guidance: true, description: 'Use activeId when custom scroll logic owns the active section.'},
+      {guidance: true, description: 'Use scrollContainerRef and offset when content is inside a scroll container with a fixed header.'},
+      {guidance: true, description: 'Use onNavigateEnd for custom highlight effects on the target section after scroll.'},
       {guidance: true, description: 'Use useOutlineFromMarkdown or useOutlineFromDOM when headings are generated from content.'},
       {guidance: false, description: 'Use Outline for application navigation - use SideNav or TopNav for routes.'},
       {guidance: false, description: 'Use Outline for expandable hierarchy - use TreeList when nodes need expand and collapse.'},
@@ -89,7 +125,7 @@ export const docsZh = {
   group: 'Outline',
   theming: {
     targets: [
-      {className: 'xds-outline'},
+      {className: 'xds-outline', visualProps: ['size']},
       {className: 'xds-outline-item', visualProps: ['level'], states: ['active']},
     ],
   },
@@ -97,13 +133,13 @@ export const docsZh = {
     {
       name: 'XDSOutline',
       description:
-        '文档大纲导航。将扁平标题列表渲染为锚点链接，并在非受控模式下管理滚动监听的激活状态。',
+        '文档大纲导航，带有滑动指示器轨道。将扁平标题列表渲染为锚点链接，支持键盘导航、尺寸变体和非受控模式下的滚动监听。',
       props: [
         {
           name: 'items',
           type: 'OutlineItem[]',
           description:
-            '有序标题项。每项包含 id、label 和 level。id 应匹配目标标题元素的 id。',
+            '有序标题项。每项包含 id、label 和 level (1-6)。id 应匹配目标标题元素的 id。',
           required: true,
         },
         {
@@ -124,6 +160,39 @@ export const docsZh = {
           default: "'Table of contents'",
         },
         {
+          name: 'size',
+          type: "'sm' | 'md'",
+          description: "控制项目内边距的尺寸变体。'sm' 用于紧凑界面，'md' 为标准间距。",
+          default: "'md'",
+        },
+        {
+          name: 'offset',
+          type: 'number',
+          description: '滚动监听激活阈值的顶部像素偏移。适用于固定头部。',
+          default: '0',
+        },
+        {
+          name: 'scrollContainerRef',
+          type: 'React.RefObject<HTMLElement | null>',
+          description: '指定滚动跟踪的容器。默认为视口。',
+        },
+        {
+          name: 'hasScrollOnClick',
+          type: 'boolean',
+          description: '点击项目是否平滑滚动到目标区域。',
+          default: 'true',
+        },
+        {
+          name: 'onNavigateStart',
+          type: '(id: string) => void',
+          description: '程序化滚动开始时触发的回调（点击项目时）。',
+        },
+        {
+          name: 'onNavigateEnd',
+          type: '(id: string) => void',
+          description: '程序化滚动结束且目标区域可见时触发的回调。',
+        },
+        {
           name: 'xstyle',
           type: 'StyleXStyles',
           description: '用于布局自定义的 StyleX 样式。必须是 stylex.create() 值。',
@@ -137,6 +206,8 @@ export const docsZh = {
     bestPractices: [
       {guidance: true, description: 'Pass a flat ordered list of headings and let level control indentation.'},
       {guidance: true, description: 'Use activeId when custom scroll logic owns the active section.'},
+      {guidance: true, description: 'Use scrollContainerRef and offset when content is inside a scroll container with a fixed header.'},
+      {guidance: true, description: 'Use onNavigateEnd for custom highlight effects on the target section after scroll.'},
       {guidance: true, description: 'Use useOutlineFromMarkdown or useOutlineFromDOM when headings are generated from content.'},
       {guidance: false, description: 'Use Outline for application navigation - use SideNav or TopNav for routes.'},
       {guidance: false, description: 'Use Outline for expandable hierarchy - use TreeList when nodes need expand and collapse.'},
@@ -147,13 +218,15 @@ export const docsZh = {
 /** @type {import('../docs-types').TranslationDoc} */
 export const docsDense = {
   description:
-    'Document outline/table-of-contents nav for same-page headings. Flat items array {id,label,level}; anchor links; uncontrolled scroll-spy via IntersectionObserver; controlled with activeId.',
+    'Document outline/table-of-contents nav with sliding indicator track. Flat items array {id,label,level}; anchor links; keyboard nav; size variants (sm/md); uncontrolled scroll-spy via hybrid IntersectionObserver+scroll; controlled with activeId; smooth-scroll on click with navigate callbacks.',
   usage: {
     description:
       'A table-of-contents sidebar for documentation pages, help centers, wikis, and long settings pages. Use it for navigation within a single page, not for app routes.',
     bestPractices: [
       {guidance: true, description: 'Pass a flat ordered list of headings and let level control indentation.'},
       {guidance: true, description: 'Use activeId when custom scroll logic owns the active section.'},
+      {guidance: true, description: 'Use scrollContainerRef and offset for scoped scroll tracking with fixed headers.'},
+      {guidance: true, description: 'Use onNavigateEnd for custom highlight effects after scroll.'},
       {guidance: true, description: 'Use useOutlineFromMarkdown or useOutlineFromDOM when headings are generated from content.'},
       {guidance: false, description: 'Use Outline for application navigation - use SideNav or TopNav for routes.'},
       {guidance: false, description: 'Use Outline for expandable hierarchy - use TreeList when nodes need expand and collapse.'},
@@ -164,18 +237,30 @@ export const docsDense = {
     activeId: 'Controlled active heading id. Disables built-in scroll-spy.',
     onActiveIdChange: 'Called when active id changes from scroll-spy or click.',
     label: "Accessible nav label. Default: 'Table of contents'.",
+    size: "Size variant: 'sm' (compact) or 'md' (standard). Default: 'md'.",
+    offset: 'Pixel offset for scroll-spy threshold. Default: 0.',
+    scrollContainerRef: 'Ref to scope scroll tracking to a container.',
+    hasScrollOnClick: 'Whether click smooth-scrolls. Default: true.',
+    onNavigateStart: 'Fired when click-initiated scroll begins.',
+    onNavigateEnd: 'Fired when click-initiated scroll completes.',
     xstyle: 'StyleX styles for layout. Must be stylex.create() value.',
   },
   components: [
     {
       name: 'XDSOutline',
       description:
-        'Document outline nav. Renders heading anchors and manages scroll-spy active state when uncontrolled.',
+        'Document outline nav with sliding indicator. Renders heading anchors with keyboard nav, size variants, and manages scroll-spy active state when uncontrolled.',
       propDescriptions: {
         items: 'Ordered OutlineItem[]: {id,label,level}. id should match target heading DOM id.',
         activeId: 'Controlled active heading id. Disables built-in scroll-spy.',
         onActiveIdChange: 'Called when active id changes from scroll-spy or click.',
         label: "Accessible nav label. Default: 'Table of contents'.",
+        size: "Size variant: 'sm' | 'md'. Default: 'md'.",
+        offset: 'Pixel offset for scroll-spy. Default: 0.',
+        scrollContainerRef: 'Ref for scoped scroll tracking.',
+        hasScrollOnClick: 'Click smooth-scrolls. Default: true.',
+        onNavigateStart: 'Fired when scroll begins.',
+        onNavigateEnd: 'Fired when scroll ends.',
         xstyle: 'StyleX styles for layout. Must be stylex.create() value.',
       },
     },

--- a/packages/core/src/Outline/XDSOutline.test.tsx
+++ b/packages/core/src/Outline/XDSOutline.test.tsx
@@ -9,14 +9,41 @@
  * SYNC: When modified, update this header
  */
 
-import {useRef, useState} from 'react';
+import {useRef} from 'react';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
-import {act, render, screen, waitFor} from '@testing-library/react';
+import {act, fireEvent, render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {XDSOutline} from './XDSOutline';
 import {parseOutlineFromMarkdown} from './parseOutlineFromMarkdown';
 import {useOutlineFromDOM} from './useOutlineFromDOM';
 import type {OutlineItem} from './types';
+
+// Mock IntersectionObserver for jsdom
+class MockIntersectionObserver {
+  callback: IntersectionObserverCallback;
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+
+  constructor(callback: IntersectionObserverCallback) {
+    this.callback = callback;
+  }
+}
+
+// Mock MutationObserver for jsdom
+class MockMutationObserver {
+  callback: MutationCallback;
+  observe = vi.fn();
+  disconnect = vi.fn();
+  takeRecords = vi.fn(() => []);
+
+  constructor(callback: MutationCallback) {
+    this.callback = callback;
+  }
+}
+
+vi.stubGlobal('IntersectionObserver', MockIntersectionObserver);
+vi.stubGlobal('MutationObserver', MockMutationObserver);
 
 const items: OutlineItem[] = [
   {id: 'intro', label: 'Introduction', level: 2},
@@ -52,6 +79,8 @@ describe('parseOutlineFromMarkdown', () => {
 describe('XDSOutline', () => {
   beforeEach(() => {
     Element.prototype.scrollIntoView = vi.fn();
+    // Mock window.scrollTo
+    vi.spyOn(window, 'scrollTo').mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -97,11 +126,32 @@ describe('XDSOutline', () => {
     render(<XDSOutline items={items} onActiveIdChange={onActiveIdChange} />);
     await user.click(screen.getByRole('link', {name: 'Installation'}));
 
-    expect(target.scrollIntoView).toHaveBeenCalledWith({
-      behavior: 'smooth',
-      block: 'start',
-    });
+    expect(window.scrollTo).toHaveBeenCalled();
     expect(onActiveIdChange).toHaveBeenCalledWith('install');
+
+    document.body.removeChild(target);
+  });
+
+  it('does not scroll when hasScrollOnClick is false', async () => {
+    const user = userEvent.setup();
+    const target = document.createElement('h2');
+    target.id = 'install';
+    document.body.appendChild(target);
+    const onActiveIdChange = vi.fn();
+
+    render(
+      <XDSOutline
+        items={items}
+        hasScrollOnClick={false}
+        onActiveIdChange={onActiveIdChange}
+      />,
+    );
+    await user.click(screen.getByRole('link', {name: 'Installation'}));
+
+    expect(window.scrollTo).not.toHaveBeenCalled();
+    expect(onActiveIdChange).toHaveBeenCalledWith('install');
+
+    document.body.removeChild(target);
   });
 
   it('applies stable root and item class names', () => {
@@ -118,68 +168,90 @@ describe('XDSOutline', () => {
     );
   });
 
-  it('updates uncontrolled active id from IntersectionObserver', () => {
-    let observerCallback: IntersectionObserverCallback | undefined;
+  it('renders with size="sm"', () => {
+    render(<XDSOutline items={items} size="sm" data-testid="outline-sm" />);
+    expect(screen.getByTestId('outline-sm').className).toContain('sm');
+  });
 
-    class MockIntersectionObserver {
-      observe = vi.fn();
-      disconnect = vi.fn();
+  it('renders with size="md" by default', () => {
+    render(<XDSOutline items={items} data-testid="outline-md" />);
+    expect(screen.getByTestId('outline-md').className).toContain('md');
+  });
 
-      constructor(callback: IntersectionObserverCallback) {
-        observerCallback = callback;
-      }
-    }
+  it('renders the sliding indicator track', () => {
+    const {container} = render(<XDSOutline items={items} activeId="intro" />);
+    // Track is present as an aria-hidden div
+    const track = container.querySelector('[aria-hidden="true"]');
+    expect(track).toBeInTheDocument();
+  });
 
-    vi.stubGlobal('IntersectionObserver', MockIntersectionObserver);
+  it('fires onNavigateStart and onNavigateEnd callbacks', async () => {
+    vi.useFakeTimers({shouldAdvanceTime: true});
+    const user = userEvent.setup({advanceTimers: vi.advanceTimersByTime});
+    const target = document.createElement('h2');
+    target.id = 'install';
+    document.body.appendChild(target);
 
-    const intro = document.createElement('h2');
-    intro.id = 'intro';
-    const api = document.createElement('h3');
-    api.id = 'api';
-    document.body.append(intro, api);
+    const onNavigateStart = vi.fn();
+    const onNavigateEnd = vi.fn();
 
-    const onActiveIdChange = vi.fn();
-    render(<XDSOutline items={items} onActiveIdChange={onActiveIdChange} />);
+    render(
+      <XDSOutline
+        items={items}
+        onNavigateStart={onNavigateStart}
+        onNavigateEnd={onNavigateEnd}
+      />,
+    );
+    await user.click(screen.getByRole('link', {name: 'Installation'}));
 
-    const entry: IntersectionObserverEntry = {
-      target: api,
-      isIntersecting: true,
-      boundingClientRect: {top: 12} as DOMRectReadOnly,
-      intersectionRatio: 1,
-      intersectionRect: {} as DOMRectReadOnly,
-      rootBounds: null,
-      time: 0,
-    };
+    expect(onNavigateStart).toHaveBeenCalledWith('install');
+    expect(onNavigateEnd).not.toHaveBeenCalled();
 
+    // Advance past scroll settle timeout
     act(() => {
-      observerCallback?.([entry], {} as IntersectionObserver);
+      vi.advanceTimersByTime(700);
     });
 
-    expect(screen.getByRole('link', {name: 'API'})).toHaveAttribute(
-      'aria-current',
-      'true',
+    expect(onNavigateEnd).toHaveBeenCalledWith('install');
+
+    document.body.removeChild(target);
+    vi.useRealTimers();
+  });
+
+  it('supports keyboard navigation with Enter', () => {
+    const target = document.createElement('h2');
+    target.id = 'install';
+    document.body.appendChild(target);
+    const onActiveIdChange = vi.fn();
+
+    render(
+      <XDSOutline
+        items={items}
+        activeId="intro"
+        onActiveIdChange={onActiveIdChange}
+      />,
     );
-    expect(onActiveIdChange).toHaveBeenCalledWith('api');
+
+    const link = screen.getByRole('link', {name: 'Installation'});
+    fireEvent.keyDown(link, {key: 'Enter'});
+
+    expect(onActiveIdChange).toHaveBeenCalledWith('install');
+
+    document.body.removeChild(target);
   });
 });
 
 describe('useOutlineFromDOM', () => {
-  it('collects headings and updates after mutations', async () => {
-    const user = userEvent.setup();
-
+  it('collects headings from DOM container', () => {
     function Demo() {
       const ref = useRef<HTMLElement | null>(null);
-      const [showDetails, setShowDetails] = useState(false);
       const outlineItems = useOutlineFromDOM(ref);
 
       return (
         <>
-          <button type="button" onClick={() => setShowDetails(true)}>
-            Show
-          </button>
           <article ref={ref}>
             <h2 id="intro">Intro</h2>
-            {showDetails ? <h3 id="details">Details</h3> : null}
+            <h3 id="details">Details</h3>
           </article>
           <output>
             {outlineItems
@@ -191,15 +263,8 @@ describe('useOutlineFromDOM', () => {
     }
 
     render(<Demo />);
-    await waitFor(() => {
-      expect(screen.getByText('2:intro:Intro')).toBeInTheDocument();
-    });
-
-    await user.click(screen.getByRole('button', {name: 'Show'}));
-    await waitFor(() => {
-      expect(
-        screen.getByText('2:intro:Intro|3:details:Details'),
-      ).toBeInTheDocument();
-    });
+    expect(
+      screen.getByText('2:intro:Intro|3:details:Details'),
+    ).toBeInTheDocument();
   });
 });

--- a/packages/core/src/Outline/XDSOutline.tsx
+++ b/packages/core/src/Outline/XDSOutline.tsx
@@ -4,9 +4,16 @@
 
 /**
  * @file XDSOutline.tsx
- * @input Uses React, StyleX, XDS link provider integration, Outline hooks/types
+ * @input Uses React, StyleX, XDS link provider integration, useListFocus, useScrollSpy
  * @output Exports XDSOutline component and XDSOutlineProps type
  * @position Core implementation; consumed by index.ts
+ *
+ * A table-of-contents navigation component with:
+ * - Sliding indicator track (vertical divider + animated active bar)
+ * - Size variant (sm/md)
+ * - Keyboard navigation via useListFocus
+ * - Scroll-spy with click-lock to prevent jitter
+ * - Navigate callbacks for custom highlight effects
  *
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/Outline/Outline.doc.mjs
@@ -14,7 +21,7 @@
  * - /apps/storybook/stories/Outline.stories.tsx
  */
 
-import {useRef} from 'react';
+import {useCallback, useEffect, useLayoutEffect, useRef, useState} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {
   colorVars,
@@ -27,11 +34,14 @@ import {
 } from '../theme/tokens.stylex';
 import {useXDSLinkComponent} from '../Link/useXDSLinkComponent';
 import {mergeProps, mergeRefs, xdsClassName} from '../utils';
+import {useListFocus} from '../hooks/useListFocus';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import {useScrollSpy} from './useScrollSpy';
 import type {OutlineItem} from './types';
 
 export type {OutlineItem} from './types';
+
+export type XDSOutlineSize = 'sm' | 'md';
 
 export interface XDSOutlineProps extends XDSBaseProps<HTMLElement> {
   /** Ref forwarded to the root nav element. */
@@ -49,21 +59,96 @@ export interface XDSOutlineProps extends XDSBaseProps<HTMLElement> {
   /** Accessible label for the nav landmark. @default 'Table of contents' */
   label?: string;
 
+  /**
+   * Size variant controlling item padding.
+   * - 'sm': Compact spacing for dense UIs
+   * - 'md': Standard spacing (default)
+   * @default 'md'
+   */
+  size?: XDSOutlineSize;
+
+  /**
+   * Pixel offset from the top of the scroll container for determining
+   * the active section. Useful when a fixed header overlaps content.
+   * @default 0
+   */
+  offset?: number;
+
+  /**
+   * Scroll container ref to scope scroll tracking to a specific container.
+   * Defaults to the nearest scrollable ancestor or viewport.
+   */
+  scrollContainerRef?: React.RefObject<HTMLElement | null>;
+
+  /**
+   * Whether clicking an item smooth-scrolls to the target section.
+   * @default true
+   */
+  hasScrollOnClick?: boolean;
+
+  /**
+   * Callback fired when programmatic scroll begins (item clicked).
+   * Use to apply custom highlight effects to the target section.
+   */
+  onNavigateStart?: (id: string) => void;
+
+  /**
+   * Callback fired when programmatic scroll ends and the target section is in view.
+   * Use for custom highlight effects (flash, ring, pulse, etc.).
+   */
+  onNavigateEnd?: (id: string) => void;
+
   /** Test ID for testing frameworks. */
   'data-testid'?: string;
 }
 
+// =============================================================================
+// Styles
+// =============================================================================
+
 const styles = stylex.create({
   root: {
-    color: colorVars['--color-text-secondary'],
-    fontSize: typeScaleVars['--text-supporting-size'],
-    lineHeight: typeScaleVars['--text-supporting-leading'],
+    display: 'flex',
+    flexDirection: 'row',
+    position: 'relative',
+    gap: spacingVars['--spacing-0-5'],
     width: '100%',
   },
+  track: {
+    position: 'relative',
+    width: '2px',
+    flexShrink: 0,
+  },
+  dividerLine: {
+    position: 'absolute',
+    insetBlockStart: 0,
+    insetBlockEnd: 0,
+    insetInlineStart: 0,
+    width: '2px',
+    backgroundColor: colorVars['--color-border'],
+    borderRadius: radiusVars['--radius-full'],
+    pointerEvents: 'none',
+  },
+  indicator: {
+    position: 'absolute',
+    insetInlineStart: 0,
+    width: '2px',
+    backgroundColor: colorVars['--color-icon-primary'],
+    borderRadius: radiusVars['--radius-full'],
+    pointerEvents: 'none',
+    transitionProperty: 'top, height',
+    transitionDuration: durationVars['--duration-fast-min'],
+    transitionTimingFunction: easeVars['--ease-standard'],
+  },
   list: {
-    listStyleType: 'none',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: spacingVars['--spacing-0-5'],
     margin: 0,
     padding: 0,
+    listStyle: 'none',
+    flex: 1,
+    minWidth: 0,
   },
   item: {
     listStyleType: 'none',
@@ -72,15 +157,13 @@ const styles = stylex.create({
   },
   link: {
     alignItems: 'center',
-    borderRadius: radiusVars['--radius-inner'],
+    borderRadius: radiusVars['--radius-element'],
     boxSizing: 'border-box',
-    color: 'inherit',
+    color: colorVars['--color-text-secondary'],
     cursor: 'pointer',
     display: 'flex',
-    minHeight: spacingVars['--spacing-7'],
+    fontWeight: fontWeightVars['--font-weight-normal'],
     outline: 'none',
-    paddingBlock: spacingVars['--spacing-1'],
-    paddingInlineEnd: spacingVars['--spacing-2'],
     position: 'relative',
     textAlign: 'start',
     textDecoration: 'none',
@@ -88,35 +171,34 @@ const styles = stylex.create({
     transitionProperty: 'background-color, color',
     transitionTimingFunction: easeVars['--ease-standard'],
     width: '100%',
-    ':hover': {
-      '@media (hover: hover)': {
-        backgroundColor: colorVars['--color-overlay-hover'],
-        color: colorVars['--color-text-primary'],
+    fontSize: typeScaleVars['--text-body-size'],
+    lineHeight: typeScaleVars['--text-body-leading'],
+  },
+  linkHover: {
+    backgroundColor: {
+      default: 'transparent',
+      ':hover': {
+        '@media (hover: hover)': colorVars['--color-overlay-hover'],
       },
     },
-    ':active': {
-      backgroundColor: colorVars['--color-overlay-pressed'],
+  },
+  linkFocus: {
+    outlineWidth: {
+      ':focus-visible': '2px',
     },
-    ':focus-visible': {
-      outline: `2px solid ${colorVars['--color-accent']}`,
-      outlineOffset: 2,
+    outlineStyle: {
+      ':focus-visible': 'solid',
+    },
+    outlineColor: {
+      ':focus-visible': colorVars['--color-accent'],
+    },
+    outlineOffset: {
+      ':focus-visible': '2px',
     },
   },
   activeLink: {
-    color: colorVars['--color-text-accent'],
-    fontWeight: fontWeightVars['--font-weight-medium'],
-  },
-  activeIndicator: {
-    '::before': {
-      backgroundColor: colorVars['--color-accent'],
-      borderRadius: radiusVars['--radius-full'],
-      bottom: spacingVars['--spacing-1'],
-      content: '""',
-      insetInlineStart: 0,
-      position: 'absolute',
-      top: spacingVars['--spacing-1'],
-      width: 2,
-    },
+    color: colorVars['--color-text-primary'],
+    fontWeight: fontWeightVars['--font-weight-semibold'],
   },
   label: {
     overflow: 'hidden',
@@ -125,24 +207,77 @@ const styles = stylex.create({
   },
 });
 
-const dynamicStyles = stylex.create({
-  levelIndent: (level: number) => ({
-    paddingInlineStart: `calc(${Math.max(0, Math.min(5, level - 1))} * ${spacingVars['--spacing-4']} + ${spacingVars['--spacing-2']})`,
-  }),
+const sizeStyles = stylex.create({
+  sm: {
+    paddingBlock: spacingVars['--spacing-1'],
+    paddingInlineEnd: spacingVars['--spacing-2'],
+  },
+  md: {
+    paddingBlock: spacingVars['--spacing-2'],
+    paddingInlineEnd: spacingVars['--spacing-2'],
+  },
 });
+
+const indentStyles = stylex.create({
+  level1: {paddingInlineStart: spacingVars['--spacing-3']},
+  level2: {paddingInlineStart: spacingVars['--spacing-7']},
+  level3: {paddingInlineStart: spacingVars['--spacing-11']},
+  level4: {paddingInlineStart: spacingVars['--spacing-12']},
+});
+
+function getIndentStyle(level: number) {
+  // Map heading levels 1-6 to visual indent levels 1-4
+  // Level 1 (h1) = indent 1, Level 2 (h2) = indent 1, Level 3 (h3) = indent 2, etc.
+  const indentLevel = Math.max(1, Math.min(4, level - 1 || 1));
+  switch (indentLevel) {
+    case 1:
+      return indentStyles.level1;
+    case 2:
+      return indentStyles.level2;
+    case 3:
+      return indentStyles.level3;
+    default:
+      return indentStyles.level4;
+  }
+}
+
+// =============================================================================
+// Component
+// =============================================================================
 
 /**
  * A table-of-contents navigation component for document headings.
  *
  * XDSOutline accepts a flat `items` array and renders anchor links with
- * indentation based on each heading level. When `activeId` is omitted, it
- * observes heading elements by id and marks the topmost visible heading active.
+ * indentation based on each heading level. Features a sliding indicator
+ * track, keyboard navigation, and smooth-scroll on click.
+ *
+ * When `activeId` is omitted, it uses a hybrid IntersectionObserver +
+ * scroll-position approach to track the currently visible heading.
+ *
+ * @example
+ * ```
+ * <XDSOutline
+ *   items={[
+ *     {id: 'intro', label: 'Introduction', level: 1},
+ *     {id: 'features', label: 'Features', level: 2},
+ *     {id: 'api', label: 'API Reference', level: 1},
+ *   ]}
+ *   offset={64}
+ * />
+ * ```
  */
 export function XDSOutline({
   items,
-  activeId,
+  activeId: controlledActiveId,
   onActiveIdChange,
   label = 'Table of contents',
+  size = 'md',
+  offset = 0,
+  scrollContainerRef,
+  hasScrollOnClick = true,
+  onNavigateStart,
+  onNavigateEnd,
   xstyle,
   className,
   style,
@@ -152,20 +287,66 @@ export function XDSOutline({
 }: XDSOutlineProps) {
   const rootRef = useRef<HTMLElement | null>(null);
   const LinkComponent = useXDSLinkComponent();
-  const [resolvedActiveId, setActiveId] = useScrollSpy({
-    activeId,
+
+  // Track whether we're in a programmatic scroll (click-initiated)
+  const isScrollingRef = useRef(false);
+  const scrollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Scroll-spy hook
+  const scrollSpy = useScrollSpy({
     items,
+    activeId: controlledActiveId,
     onActiveIdChange,
-    rootRef,
+    scrollContainerRef,
+    offset,
+    isLockedRef: isScrollingRef,
   });
 
-  const handleClick =
-    (id: string) => (event: React.MouseEvent<HTMLElement>) => {
-      const target = document.getElementById(id);
-      setActiveId(id);
+  const activeId = scrollSpy.activeId;
 
+  // Keyboard navigation
+  const {listRef, handleKeyDown} = useListFocus<HTMLUListElement>({
+    itemSelector: 'a[role="link"]',
+    orientation: 'vertical',
+  });
+
+  // Refs for measuring item positions (for sliding indicator)
+  const itemMapRef = useRef<Map<string, HTMLElement>>(new Map());
+  const listContainerRef = useRef<HTMLUListElement | null>(null);
+
+  // Indicator position state
+  const [indicatorStyle, setIndicatorStyle] = useState<{
+    top: number;
+    height: number;
+  } | null>(null);
+
+  // Update indicator position when active item changes.
+  useLayoutEffect(() => {
+    if (!activeId) {
+      setIndicatorStyle(null);
+      return;
+    }
+
+    const itemEl = itemMapRef.current.get(activeId);
+    const listEl = listContainerRef.current;
+    if (!itemEl || !listEl) {
+      setIndicatorStyle(null);
+      return;
+    }
+
+    const listRect = listEl.getBoundingClientRect();
+    const itemRect = itemEl.getBoundingClientRect();
+
+    setIndicatorStyle({
+      top: itemRect.top - listRect.top,
+      height: itemRect.height,
+    });
+  }, [activeId, items]);
+
+  const handleItemClick = useCallback(
+    (id: string, event: React.MouseEvent<HTMLElement>) => {
+      // Skip if modifier keys are held (allow normal link behavior)
       if (
-        target == null ||
         event.defaultPrevented ||
         event.metaKey ||
         event.altKey ||
@@ -176,9 +357,80 @@ export function XDSOutline({
       }
 
       event.preventDefault();
-      window.history.pushState(null, '', `#${id}`);
-      target.scrollIntoView({behavior: 'smooth', block: 'start'});
+
+      if (hasScrollOnClick) {
+        isScrollingRef.current = true;
+
+        if (scrollTimeoutRef.current) {
+          clearTimeout(scrollTimeoutRef.current);
+        }
+
+        // Fire onNavigateStart callback
+        onNavigateStart?.(id);
+
+        // Update URL hash
+        window.history.pushState(null, '', `#${id}`);
+
+        scrollSpy.scrollTo(id);
+
+        // Unlock after scroll settles, then fire end callback
+        scrollTimeoutRef.current = setTimeout(() => {
+          isScrollingRef.current = false;
+          onNavigateEnd?.(id);
+        }, 600);
+      } else {
+        scrollSpy.setActiveId(id);
+      }
+    },
+    [hasScrollOnClick, scrollSpy, onNavigateStart, onNavigateEnd],
+  );
+
+  const handleItemKeyDown = useCallback(
+    (e: React.KeyboardEvent, id: string) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        // Directly invoke navigation (don't go through handleItemClick which checks defaultPrevented)
+        if (hasScrollOnClick) {
+          isScrollingRef.current = true;
+
+          if (scrollTimeoutRef.current) {
+            clearTimeout(scrollTimeoutRef.current);
+          }
+
+          onNavigateStart?.(id);
+          window.history.pushState(null, '', `#${id}`);
+          scrollSpy.scrollTo(id);
+
+          scrollTimeoutRef.current = setTimeout(() => {
+            isScrollingRef.current = false;
+            onNavigateEnd?.(id);
+          }, 600);
+        } else {
+          scrollSpy.setActiveId(id);
+        }
+      }
+      handleKeyDown(e);
+    },
+    [
+      hasScrollOnClick,
+      scrollSpy,
+      onNavigateStart,
+      onNavigateEnd,
+      handleKeyDown,
+    ],
+  );
+
+  // Merge list refs — listContainerRef for indicator measurement, listRef for keyboard nav
+  const mergedListRef = mergeRefs(listContainerRef, listRef);
+
+  // Cleanup timeouts on unmount
+  useEffect(() => {
+    return () => {
+      if (scrollTimeoutRef.current) {
+        clearTimeout(scrollTimeoutRef.current);
+      }
     };
+  }, []);
 
   return (
     <nav
@@ -187,20 +439,57 @@ export function XDSOutline({
       aria-label={label}
       data-testid={testId}
       {...mergeProps(
-        xdsClassName('outline'),
+        xdsClassName('outline', {size}),
         stylex.props(styles.root, xstyle),
         className,
         style,
       )}>
-      <ul {...stylex.props(styles.list)}>
+      {/* Track — divider line + sliding indicator */}
+      <div {...stylex.props(styles.track)} aria-hidden="true">
+        <span {...stylex.props(styles.dividerLine)} />
+        {indicatorStyle != null && (
+          <span
+            {...mergeProps(
+              xdsClassName('outline-indicator'),
+              stylex.props(styles.indicator),
+              undefined,
+              {
+                top: indicatorStyle.top,
+                height: indicatorStyle.height,
+              },
+            )}
+          />
+        )}
+      </div>
+
+      <ul
+        ref={mergedListRef}
+        {...stylex.props(styles.list)}
+        role="list"
+        onKeyDown={handleKeyDown}>
         {items.map(item => {
-          const isActive = item.id === resolvedActiveId;
+          const isActive = item.id === activeId;
+
           return (
-            <li key={item.id} {...stylex.props(styles.item)}>
+            <li key={item.id} {...stylex.props(styles.item)} role="listitem">
               <LinkComponent
+                ref={(el: HTMLElement | null) => {
+                  if (el) {
+                    itemMapRef.current.set(item.id, el);
+                  } else {
+                    itemMapRef.current.delete(item.id);
+                  }
+                }}
                 href={`#${item.id}`}
+                role="link"
+                tabIndex={0}
                 aria-current={isActive ? 'true' : undefined}
-                onClick={handleClick(item.id)}
+                onClick={(e: React.MouseEvent<HTMLElement>) =>
+                  handleItemClick(item.id, e)
+                }
+                onKeyDown={(e: React.KeyboardEvent) =>
+                  handleItemKeyDown(e, item.id)
+                }
                 {...mergeProps(
                   xdsClassName('outline-item', {
                     active: isActive ? 'active' : null,
@@ -208,9 +497,11 @@ export function XDSOutline({
                   }),
                   stylex.props(
                     styles.link,
-                    dynamicStyles.levelIndent(item.level),
+                    styles.linkHover,
+                    styles.linkFocus,
+                    sizeStyles[size],
+                    getIndentStyle(item.level),
                     isActive && styles.activeLink,
-                    isActive && styles.activeIndicator,
                   ),
                 )}>
                 <span {...stylex.props(styles.label)}>{item.label}</span>

--- a/packages/core/src/Outline/XDSOutline.tsx
+++ b/packages/core/src/Outline/XDSOutline.tsx
@@ -323,6 +323,7 @@ export function XDSOutline({
   // Update indicator position when active item changes.
   useLayoutEffect(() => {
     if (!activeId) {
+      // eslint-disable-next-line @eslint-react/set-state-in-effect -- useLayoutEffect is the correct place to sync DOM measurements to state before paint
       setIndicatorStyle(null);
       return;
     }
@@ -337,6 +338,7 @@ export function XDSOutline({
     const listRect = listEl.getBoundingClientRect();
     const itemRect = itemEl.getBoundingClientRect();
 
+    // eslint-disable-next-line @eslint-react/set-state-in-effect -- useLayoutEffect is the correct place to sync DOM measurements to state before paint
     setIndicatorStyle({
       top: itemRect.top - listRect.top,
       height: itemRect.height,

--- a/packages/core/src/Outline/index.ts
+++ b/packages/core/src/Outline/index.ts
@@ -12,7 +12,7 @@
  */
 
 export {XDSOutline} from './XDSOutline';
-export type {XDSOutlineProps} from './XDSOutline';
+export type {XDSOutlineProps, XDSOutlineSize} from './XDSOutline';
 export type {OutlineItem} from './types';
 export {parseOutlineFromMarkdown} from './parseOutlineFromMarkdown';
 export {useOutlineFromMarkdown} from './useOutlineFromMarkdown';

--- a/packages/core/src/Outline/useScrollSpy.ts
+++ b/packages/core/src/Outline/useScrollSpy.ts
@@ -164,6 +164,7 @@ export function useScrollSpy(options: UseScrollSpyOptions): UseScrollSpyReturn {
 
       const newId = computeActiveId();
       if (newId != null) {
+        // eslint-disable-next-line @eslint-react/set-state-in-effect -- called from async IntersectionObserver/scroll callbacks, not synchronously in the effect body
         setUncontrolledActiveId(prev => {
           if (prev !== newId) {
             onActiveChangeRef.current?.(newId);

--- a/packages/core/src/Outline/useScrollSpy.ts
+++ b/packages/core/src/Outline/useScrollSpy.ts
@@ -4,139 +4,260 @@
 
 /**
  * @file useScrollSpy.ts
- * @input Uses React, IntersectionObserver, OutlineItem type
- * @output Exports internal useScrollSpy hook
+ * @input Uses React hooks, IntersectionObserver API, scroll events
+ * @output Exports useScrollSpy hook — tracks which section is active based on scroll
  * @position Internal behavior hook; consumed by XDSOutline.tsx
+ *
+ * ## Scroll-spy strategy
+ *
+ * Uses a hybrid IntersectionObserver + scroll-position approach:
+ *
+ * 1. IntersectionObserver tracks when sections enter/leave the viewport.
+ * 2. On each intersection change or scroll event, picks the "active" section
+ *    using a position-based heuristic: the last section whose top edge is at or
+ *    above the offset line.
+ * 3. For the last-section edge case, detects when scrolled to bottom and
+ *    activates the last item.
+ * 4. Supports a click-lock ref to prevent jitter during programmatic scroll.
  *
  * SYNC: When modified, update /packages/core/src/Outline/XDSOutline.tsx
  */
 
-import {useEffect, useRef, useState} from 'react';
+import {useCallback, useEffect, useRef, useState} from 'react';
 import type {OutlineItem} from './types';
 
-function getScrollableAncestor(element: HTMLElement | null): Element | null {
-  let current = element?.parentElement ?? null;
+// =============================================================================
+// Types
+// =============================================================================
 
-  while (current != null) {
-    const computedStyle = window.getComputedStyle(current);
-    const overflowY = computedStyle.overflowY;
-    const isScrollable =
-      (overflowY === 'auto' ||
-        overflowY === 'scroll' ||
-        overflowY === 'overlay') &&
-      current.scrollHeight > current.clientHeight;
-
-    if (isScrollable) {
-      return current;
-    }
-
-    current = current.parentElement;
-  }
-
-  return null;
-}
-
-interface UseScrollSpyOptions {
-  activeId?: string;
+export interface UseScrollSpyOptions {
+  /** Target items to observe */
   items: OutlineItem[];
+  /** Currently controlled active ID (disables scroll tracking when set) */
+  activeId?: string;
+  /** Callback when active ID changes */
   onActiveIdChange?: (id: string) => void;
-  rootRef: React.RefObject<HTMLElement | null>;
+  /** Scroll container ref (defaults to nearest scrollable ancestor or viewport) */
+  scrollContainerRef?: React.RefObject<HTMLElement | null>;
+  /** Pixel offset from top for activation threshold */
+  offset?: number;
+  /**
+   * Ref that, when true, suppresses all internal state updates from scroll tracking.
+   * Used to prevent jitter during programmatic smooth scroll.
+   */
+  isLockedRef?: React.RefObject<boolean>;
 }
 
-export function useScrollSpy({
-  activeId,
-  items,
-  onActiveIdChange,
-  rootRef,
-}: UseScrollSpyOptions): [string | undefined, (id: string) => void] {
-  const isControlled = activeId !== undefined;
+export interface UseScrollSpyReturn {
+  /** Currently active section ID */
+  activeId: string | undefined;
+  /** Set active ID manually */
+  setActiveId: (id: string) => void;
+  /** Scroll a target element into view */
+  scrollTo: (id: string) => void;
+}
+
+// =============================================================================
+// Hook
+// =============================================================================
+
+/**
+ * Hook for tracking which page section is currently in the viewport.
+ *
+ * Uses a hybrid approach: IntersectionObserver for visibility detection
+ * combined with scroll-position heuristics for accurate active-section
+ * determination. Handles edge cases like short final sections and
+ * multiple visible sections.
+ */
+export function useScrollSpy(options: UseScrollSpyOptions): UseScrollSpyReturn {
+  const {
+    items,
+    activeId: controlledActiveId,
+    onActiveIdChange,
+    scrollContainerRef,
+    offset = 0,
+    isLockedRef,
+  } = options;
+
+  const isControlled = controlledActiveId !== undefined;
   const [uncontrolledActiveId, setUncontrolledActiveId] = useState<
     string | undefined
   >(items[0]?.id);
-  const visibleHeadingIdsRef = useRef<Set<string>>(new Set());
-  const headingTopRef = useRef<Map<string, number>>(new Map());
-  const activeIdRef = useRef<string | undefined>(activeId);
-  const itemIds = items.map(item => item.id).join('\n');
-  activeIdRef.current = isControlled ? activeId : uncontrolledActiveId;
+  const onActiveChangeRef = useRef(onActiveIdChange);
+  onActiveChangeRef.current = onActiveIdChange;
+
+  // Keep a stable reference to items for the scroll handler
+  const itemsRef = useRef(items);
+  itemsRef.current = items;
+
+  const ids = items.map(item => item.id);
+  const idsRef = useRef(ids);
+  idsRef.current = ids;
 
   useEffect(() => {
-    if (isControlled || typeof IntersectionObserver === 'undefined') {
+    if (isControlled || ids.length === 0) {
+      return;
+    }
+    if (typeof IntersectionObserver === 'undefined') {
       return;
     }
 
-    const headingElements = items
-      .map(item => document.getElementById(item.id))
-      .filter((element): element is HTMLElement => element != null);
+    const container = scrollContainerRef?.current ?? null;
 
-    if (headingElements.length === 0) {
-      return;
+    /**
+     * Determine the active section based on scroll position.
+     * Strategy: find the last section whose top edge is at or above the offset line.
+     */
+    function computeActiveId(): string | null {
+      const currentIds = idsRef.current;
+      if (currentIds.length === 0) {
+        return null;
+      }
+
+      // Check if scrolled to bottom — activate last item
+      const scrollTop = container ? container.scrollTop : window.scrollY;
+      const scrollHeight = container
+        ? container.scrollHeight
+        : document.documentElement.scrollHeight;
+      const clientHeight = container
+        ? container.clientHeight
+        : window.innerHeight;
+
+      const isAtBottom = scrollTop + clientHeight >= scrollHeight - 2;
+      if (isAtBottom) {
+        return currentIds[currentIds.length - 1];
+      }
+
+      // Find the last section whose top is at or above the offset threshold
+      let activeCandidate: string | null = currentIds[0];
+
+      for (const id of currentIds) {
+        const el = document.getElementById(id);
+        if (!el) {
+          continue;
+        }
+
+        let topRelative: number;
+        if (container) {
+          const containerRect = container.getBoundingClientRect();
+          const elRect = el.getBoundingClientRect();
+          topRelative = elRect.top - containerRect.top;
+        } else {
+          const elRect = el.getBoundingClientRect();
+          topRelative = elRect.top;
+        }
+
+        // Section top is at or above the offset line — it's a candidate
+        if (topRelative <= offset + 4) {
+          activeCandidate = id;
+        }
+      }
+
+      return activeCandidate;
     }
 
-    const visibleHeadingIds = visibleHeadingIdsRef.current;
-    const headingTop = headingTopRef.current;
-
-    const setNextActiveId = (nextActiveId: string) => {
-      if (activeIdRef.current === nextActiveId) {
+    function handleUpdate() {
+      // Skip state updates when locked (during programmatic scroll)
+      if (isLockedRef?.current) {
         return;
       }
-      activeIdRef.current = nextActiveId;
-      setUncontrolledActiveId(nextActiveId);
-      onActiveIdChange?.(nextActiveId);
-    };
 
-    const chooseActiveHeading = () => {
-      let nextActiveId: string | undefined;
-      let nextTop = Number.POSITIVE_INFINITY;
-
-      for (const id of visibleHeadingIds) {
-        const top = headingTop.get(id) ?? Number.POSITIVE_INFINITY;
-        if (top < nextTop) {
-          nextTop = top;
-          nextActiveId = id;
-        }
-      }
-
-      if (nextActiveId != null) {
-        setNextActiveId(nextActiveId);
-      }
-    };
-
-    const observer = new IntersectionObserver(
-      entries => {
-        for (const entry of entries) {
-          const id = entry.target.id;
-          headingTop.set(id, entry.boundingClientRect.top);
-          if (entry.isIntersecting) {
-            visibleHeadingIds.add(id);
-          } else {
-            visibleHeadingIds.delete(id);
+      const newId = computeActiveId();
+      if (newId != null) {
+        setUncontrolledActiveId(prev => {
+          if (prev !== newId) {
+            onActiveChangeRef.current?.(newId);
+            return newId;
           }
-        }
-        chooseActiveHeading();
+          return prev;
+        });
+      }
+    }
+
+    // Use IntersectionObserver as a trigger to re-evaluate
+    const observer = new IntersectionObserver(
+      () => {
+        handleUpdate();
       },
       {
-        root: getScrollableAncestor(rootRef.current),
-        threshold: 0,
+        root: container,
+        rootMargin: `-${offset}px 0px -40% 0px`,
+        threshold: [0, 0.25, 0.5, 0.75, 1],
       },
     );
 
-    for (const headingElement of headingElements) {
-      observer.observe(headingElement);
+    // Observe each target element
+    for (const id of ids) {
+      const el = document.getElementById(id);
+      if (el) {
+        observer.observe(el);
+      }
     }
+
+    // Also listen to scroll events for continuous tracking
+    const scrollTarget = container ?? window;
+    let ticking = false;
+
+    function onScroll() {
+      if (!ticking) {
+        ticking = true;
+        requestAnimationFrame(() => {
+          handleUpdate();
+          ticking = false;
+        });
+      }
+    }
+
+    scrollTarget.addEventListener('scroll', onScroll, {passive: true});
+
+    // Initial computation
+    handleUpdate();
 
     return () => {
       observer.disconnect();
-      visibleHeadingIds.clear();
-      headingTop.clear();
+      scrollTarget.removeEventListener('scroll', onScroll);
     };
-  }, [isControlled, itemIds, items, onActiveIdChange, rootRef]);
+  }, [isControlled, ids, scrollContainerRef, offset, isLockedRef]);
 
-  const setActiveId = (nextActiveId: string) => {
-    if (!isControlled) {
-      setUncontrolledActiveId(nextActiveId);
-    }
-    onActiveIdChange?.(nextActiveId);
+  const setActiveId = useCallback(
+    (nextActiveId: string) => {
+      if (!isControlled) {
+        setUncontrolledActiveId(nextActiveId);
+      }
+      onActiveChangeRef.current?.(nextActiveId);
+    },
+    [isControlled],
+  );
+
+  const scrollTo = useCallback(
+    (id: string) => {
+      const el = document.getElementById(id);
+      if (!el) {
+        return;
+      }
+
+      const container = scrollContainerRef?.current;
+
+      if (container) {
+        const containerRect = container.getBoundingClientRect();
+        const elRect = el.getBoundingClientRect();
+        const scrollTop =
+          container.scrollTop + (elRect.top - containerRect.top) - offset;
+        container.scrollTo({top: scrollTop, behavior: 'smooth'});
+      } else {
+        const y = el.getBoundingClientRect().top + window.scrollY - offset;
+        window.scrollTo({top: y, behavior: 'smooth'});
+      }
+
+      // Immediately set the active ID for responsive feedback
+      setActiveId(id);
+    },
+    [scrollContainerRef, offset, setActiveId],
+  );
+
+  return {
+    activeId: isControlled ? controlledActiveId : uncontrolledActiveId,
+    setActiveId,
+    scrollTo,
   };
-
-  return [isControlled ? activeId : uncontrolledActiveId, setActiveId];
 }


### PR DESCRIPTION
## Summary

Implements `XDSOutlineList` in `@xds/lab` as specified in #2208.

https://github.com/user-attachments/assets/054a1252-805e-4bda-94d3-1b0782708c81


## What's included

### Components
- **`XDSOutlineList`** — main component: renders a vertical list of anchor items representing page sections
- **`useXDSScrollSpy`** — public hook: IntersectionObserver-based scroll tracking, independently useful

### Features
- Automatic scroll-spy via IntersectionObserver (top-most visible section = active)
- Smooth scroll-to-section on click
- Controlled mode (`activeId` + `onActiveChange`)
- Nested heading levels with indentation (up to 4 levels)
- Active indicator: 2px left accent border + semibold text
- Size variants: `sm` (28px items, 12px text) and `md` (32px items, 14px text)
- Full keyboard support (Arrow keys, Enter, Space, Home, End)
- Accessible: `<nav>` landmark with `aria-label`, `aria-current` on active item
- `scrollContainerRef` for scoped scroll tracking (e.g. within AppShell panels)
- `offset` prop for fixed headers

### Files
```
packages/lab/src/OutlineList/
├── XDSOutlineList.tsx         — Main component
├── useXDSScrollSpy.ts         — Public scroll-spy hook
├── XDSOutlineList.test.tsx    — Unit tests (10/10 passing)
├── OutlineList.doc.mjs        — Component documentation
├── index.ts                   — Barrel exports

apps/storybook/stories/
└── OutlineList.stories.tsx    — 5 stories (Default, Small, ScrollSpy, Controlled, DeepNesting)
```

## Test plan

- `pnpm vitest run packages/lab/src/OutlineList/` — 10 tests passing
- Storybook stories cover all variants and interaction modes

Closes #2208