### PR TITLE
test(Tokenizer, Typeahead, PowerSearch): add paste behavior tests

### DIFF
--- a/packages/core/src/PowerSearch/XDSPowerSearch.test.tsx
+++ b/packages/core/src/PowerSearch/XDSPowerSearch.test.tsx
@@ -1,0 +1,162 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file XDSPowerSearch.test.tsx
+ * @input Uses vitest, @testing-library/react, XDSPowerSearch
+ * @output Integration tests for XDSPowerSearch component
+ * @position Testing; validates XDSPowerSearch.tsx
+ *
+ * SYNC: When XDSPowerSearch.tsx changes, update tests to match
+ */
+
+import {useState} from 'react';
+import {describe, it, expect, vi, beforeAll, afterAll} from 'vitest';
+import {render, screen, act} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {XDSPowerSearch} from './XDSPowerSearch';
+import type {PowerSearchConfig, PowerSearchFilter} from './types';
+
+// =============================================================================
+// Test infrastructure
+// =============================================================================
+
+const originalMatches = HTMLElement.prototype.matches;
+const popoverOpenState = new WeakMap<HTMLElement, boolean>();
+
+class MockResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+beforeAll(() => {
+  globalThis.ResizeObserver =
+    MockResizeObserver as unknown as typeof ResizeObserver;
+  HTMLElement.prototype.showPopover = vi.fn(function (this: HTMLElement) {
+    popoverOpenState.set(this, true);
+    const event = new Event('toggle');
+    Object.defineProperty(event, 'newState', {value: 'open'});
+    this.dispatchEvent(event);
+  });
+  HTMLElement.prototype.hidePopover = vi.fn(function (this: HTMLElement) {
+    popoverOpenState.set(this, false);
+    const event = new Event('toggle');
+    Object.defineProperty(event, 'newState', {value: 'closed'});
+    this.dispatchEvent(event);
+  });
+  HTMLElement.prototype.matches = function (selector: string) {
+    if (selector === ':popover-open') {
+      return popoverOpenState.get(this) ?? false;
+    }
+    return originalMatches.call(this, selector);
+  };
+});
+
+afterAll(() => {
+  HTMLElement.prototype.matches = originalMatches;
+});
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+const config: PowerSearchConfig = {
+  name: 'TestSearch',
+  fields: [
+    {
+      key: 'title',
+      label: 'Title',
+      defaultOperator: 'contains',
+      operators: [
+        {key: 'contains', label: 'contains', value: {type: 'string'}},
+      ],
+    },
+    {
+      key: 'status',
+      label: 'Status',
+      defaultOperator: 'is',
+      operators: [
+        {
+          key: 'is',
+          label: 'is',
+          value: {
+            type: 'enum',
+            values: [
+              {value: 'open', label: 'Open'},
+              {value: 'closed', label: 'Closed'},
+            ],
+          },
+        },
+      ],
+    },
+  ],
+};
+
+function PowerSearchWrapper(props: {config: PowerSearchConfig}) {
+  const [filters, setFilters] = useState<PowerSearchFilter[]>([]);
+  return (
+    <XDSPowerSearch
+      config={props.config}
+      filters={filters}
+      onChange={newFilters => {
+        setFilters([...newFilters]);
+      }}
+    />
+  );
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('XDSPowerSearch', () => {
+  describe('paste behavior', () => {
+    it('pasting a field name shows matching field suggestions', async () => {
+      const user = userEvent.setup();
+      render(<PowerSearchWrapper config={config} />);
+
+      const input = screen.getByRole('combobox');
+      await user.click(input);
+      await user.paste('Tit');
+      await act(async () => {
+        await new Promise(r => setTimeout(r, 50));
+      });
+
+      expect(screen.getByText('Title')).toBeInTheDocument();
+    });
+
+    it('pasting produces same results as typing', async () => {
+      const user = userEvent.setup();
+      const {unmount} = render(<PowerSearchWrapper config={config} />);
+
+      // Paste "Stat"
+      const input1 = screen.getByRole('combobox');
+      await user.click(input1);
+      await user.paste('Stat');
+      await act(async () => {
+        await new Promise(r => setTimeout(r, 50));
+      });
+
+      const pasteResults = screen
+        .getAllByRole('option', {hidden: true})
+        .map(el => el.textContent);
+
+      unmount();
+
+      // Type "Stat"
+      render(<PowerSearchWrapper config={config} />);
+      const input2 = screen.getByRole('combobox');
+      await user.click(input2);
+      await user.type(input2, 'Stat');
+      await act(async () => {
+        await new Promise(r => setTimeout(r, 50));
+      });
+
+      const typeResults = screen
+        .getAllByRole('option', {hidden: true})
+        .map(el => el.textContent);
+
+      expect(pasteResults).toEqual(typeResults);
+    });
+  });
+});

--- a/packages/core/src/Tokenizer/XDSTokenizer.test.tsx
+++ b/packages/core/src/Tokenizer/XDSTokenizer.test.tsx
@@ -11,6 +11,7 @@
 
 import {describe, it, expect, vi, beforeAll, afterAll} from 'vitest';
 import {render, screen, fireEvent, act} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import {XDSTokenizer} from './XDSTokenizer';
 import type {XDSSearchSource, XDSSearchableItem} from '../Typeahead/types';
 
@@ -658,6 +659,53 @@ describe('XDSTokenizer', () => {
 
       // Popover should not reopen with an empty menu after selection
       expect(input).toHaveAttribute('aria-expanded', 'false');
+    });
+  });
+
+  describe('paste behavior', () => {
+    it('pasting text triggers search results like typing', async () => {
+      const user = userEvent.setup();
+      render(
+        <XDSTokenizer
+          label="Members"
+          searchSource={userSource}
+          value={[]}
+          onChange={() => {}}
+          debounceMs={0}
+        />,
+      );
+
+      const input = screen.getByRole('combobox');
+      await user.click(input);
+      await user.paste('Ali');
+      await act(async () => {
+        await new Promise(r => setTimeout(r, 50));
+      });
+
+      expect(screen.getByText('Alice')).toBeInTheDocument();
+    });
+
+    it('pasting text shows Create option with hasCreate', async () => {
+      const user = userEvent.setup();
+      render(
+        <XDSTokenizer
+          label="Tags"
+          searchSource={userSource}
+          value={[]}
+          onChange={() => {}}
+          hasCreate
+          debounceMs={0}
+        />,
+      );
+
+      const input = screen.getByRole('combobox');
+      await user.click(input);
+      await user.paste('NewTag');
+      await act(async () => {
+        await new Promise(r => setTimeout(r, 50));
+      });
+
+      expect(screen.getByText('Create "NewTag"')).toBeInTheDocument();
     });
   });
 });

--- a/packages/core/src/Typeahead/XDSTypeahead.test.tsx
+++ b/packages/core/src/Typeahead/XDSTypeahead.test.tsx
@@ -11,6 +11,7 @@
 
 import {describe, it, expect, vi, beforeAll, afterAll} from 'vitest';
 import {render, screen, fireEvent, waitFor} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import {XDSTypeahead} from './XDSTypeahead';
 import {XDSBaseTypeahead} from './XDSBaseTypeahead';
 import type {XDSSearchSource, XDSSearchableItem} from './types';
@@ -456,5 +457,47 @@ describe('XDSTypeahead edit mode', () => {
 
     // onChange should not have been called — value restored
     expect(onChange).not.toHaveBeenCalled();
+  });
+});
+
+describe('XDSBaseTypeahead paste behavior', () => {
+  it('pasting text triggers search results like typing', async () => {
+    const user = userEvent.setup();
+    render(
+      <XDSBaseTypeahead
+        searchSource={fruitSource}
+        value={null}
+        onChange={() => {}}
+        debounceMs={0}
+      />,
+    );
+
+    const input = screen.getByRole('combobox');
+    await user.click(input);
+    await user.paste('App');
+
+    await waitFor(() => {
+      expect(screen.getByText('Apple')).toBeInTheDocument();
+    });
+  });
+
+  it('pasting non-matching text shows no results', async () => {
+    const user = userEvent.setup();
+    render(
+      <XDSBaseTypeahead
+        searchSource={fruitSource}
+        value={null}
+        onChange={() => {}}
+        debounceMs={0}
+      />,
+    );
+
+    const input = screen.getByRole('combobox');
+    await user.click(input);
+    await user.paste('xyz');
+
+    await waitFor(() => {
+      expect(screen.getByText('No results found')).toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
## Summary

  - Add `userEvent.paste()` tests at each layer to verify paste produces identical behavior to typing
  - **Tokenizer**: paste triggers search results and Create option
  - **XDSBaseTypeahead**: paste triggers search and no-results state
  - **XDSPowerSearch**: paste shows field suggestions and a direct comparison test confirming paste and type produce identical results

These all pass already, just adding them to ensure we don't regress.

  ## Test plan

  - [x] All 3 test files pass (34 Tokenizer, 23 Typeahead, 2 PowerSearch)
  - [x] Lint clean
  - [x] Pre-commit hooks pass