### PR TITLE
fix(ProgressBar): add isDisabled state and neutral variant

### DIFF
--- a/apps/storybook/stories/ProgressBar.stories.tsx
+++ b/apps/storybook/stories/ProgressBar.stories.tsx
@@ -25,11 +25,6 @@ const meta: Meta<typeof XDSProgressBar> = {
       options: ['accent', 'success', 'warning', 'error', 'neutral'],
       description: 'Semantic color variant',
     },
-    status: {
-      control: 'select',
-      options: ['active', 'paused', 'canceled'],
-      description: 'Semantic status state',
-    },
     isLabelHidden: {
       control: 'boolean',
       description: 'Visually hide the label',
@@ -38,9 +33,9 @@ const meta: Meta<typeof XDSProgressBar> = {
       control: 'boolean',
       description: 'Show formatted value',
     },
-    description: {
-      control: 'text',
-      description: 'Secondary description below bar',
+    isDisabled: {
+      control: 'boolean',
+      description: 'Disabled state (grayed out)',
     },
   },
 };
@@ -89,8 +84,8 @@ export const Variants: Story = {
         hasValueLabel
       />
       <XDSProgressBar
-        value={100}
-        label="Success (complete)"
+        value={80}
+        label="Success"
         variant="success"
         hasValueLabel
       />
@@ -111,7 +106,28 @@ export const Variants: Story = {
   ),
 };
 
-export const WithDescription: Story = {
+export const Disabled: Story = {
+  render: () => (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '16px',
+        width: '300px',
+      }}>
+      <XDSProgressBar
+        value={30}
+        label="Upload canceled"
+        isDisabled
+        hasValueLabel
+      />
+      <XDSProgressBar isIndeterminate label="Processing disabled" isDisabled />
+    </div>
+  ),
+};
+
+export const ComposedWithDescription: Story = {
+  name: 'Composed: with description',
   render: () => (
     <div style={{width: '300px'}}>
       <XDSProgressBar
@@ -119,88 +135,15 @@ export const WithDescription: Story = {
         max={100}
         label="Download progress"
         hasValueLabel
-        description="40 MB / 100 MB downloaded"
       />
-    </div>
-  ),
-};
-
-export const StatusPaused: Story = {
-  name: 'Status: Paused',
-  render: () => (
-    <div
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-        gap: '16px',
-        width: '300px',
-      }}>
-      <XDSProgressBar
-        value={45}
-        label="Upload paused"
-        status="paused"
-        hasValueLabel
-        description="Paused — tap to resume"
-      />
-      <XDSProgressBar
-        isIndeterminate
-        label="Processing paused"
-        status="paused"
-      />
-    </div>
-  ),
-};
-
-export const StatusCanceled: Story = {
-  name: 'Status: Canceled',
-  render: () => (
-    <div style={{width: '300px'}}>
-      <XDSProgressBar
-        value={30}
-        label="Upload canceled"
-        status="canceled"
-        hasValueLabel
-        description="Upload was canceled"
-      />
-    </div>
-  ),
-};
-
-export const StatusIcons: Story = {
-  name: 'Status Icons',
-  render: () => (
-    <div
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-        gap: '16px',
-        width: '300px',
-      }}>
-      <XDSProgressBar
-        value={100}
-        label="Complete"
-        variant="success"
-        hasValueLabel
-      />
-      <XDSProgressBar
-        value={80}
-        label="Disk almost full"
-        variant="warning"
-        hasValueLabel
-      />
-      <XDSProgressBar
-        value={95}
-        label="Upload failed"
-        variant="error"
-        hasValueLabel
-      />
-      <XDSProgressBar value={45} label="Paused" status="paused" hasValueLabel />
-      <XDSProgressBar
-        value={30}
-        label="Canceled"
-        status="canceled"
-        hasValueLabel
-      />
+      <div
+        style={{
+          fontSize: '12px',
+          color: 'var(--color-text-secondary)',
+          marginTop: '4px',
+        }}>
+        40 MB / 100 MB downloaded
+      </div>
     </div>
   ),
 };

--- a/apps/storybook/stories/ProgressBar.stories.tsx
+++ b/apps/storybook/stories/ProgressBar.stories.tsx
@@ -22,8 +22,13 @@ const meta: Meta<typeof XDSProgressBar> = {
     },
     variant: {
       control: 'select',
-      options: ['accent', 'success', 'warning', 'error'],
+      options: ['accent', 'success', 'warning', 'error', 'neutral'],
       description: 'Semantic color variant',
+    },
+    status: {
+      control: 'select',
+      options: ['active', 'paused', 'canceled'],
+      description: 'Semantic status state',
     },
     isLabelHidden: {
       control: 'boolean',
@@ -32,6 +37,10 @@ const meta: Meta<typeof XDSProgressBar> = {
     hasValueLabel: {
       control: 'boolean',
       description: 'Show formatted value',
+    },
+    description: {
+      control: 'text',
+      description: 'Secondary description below bar',
     },
   },
 };
@@ -80,8 +89,8 @@ export const Variants: Story = {
         hasValueLabel
       />
       <XDSProgressBar
-        value={80}
-        label="Positive"
+        value={100}
+        label="Success (complete)"
         variant="success"
         hasValueLabel
       />
@@ -91,12 +100,7 @@ export const Variants: Story = {
         variant="warning"
         hasValueLabel
       />
-      <XDSProgressBar
-        value={92}
-        label="Negative"
-        variant="error"
-        hasValueLabel
-      />
+      <XDSProgressBar value={92} label="Error" variant="error" hasValueLabel />
       <XDSProgressBar
         value={35}
         label="Neutral"
@@ -107,8 +111,7 @@ export const Variants: Story = {
   ),
 };
 
-export const ComposedWithDescription: Story = {
-  name: 'Composed: with description',
+export const WithDescription: Story = {
   render: () => (
     <div style={{width: '300px'}}>
       <XDSProgressBar
@@ -116,15 +119,88 @@ export const ComposedWithDescription: Story = {
         max={100}
         label="Download progress"
         hasValueLabel
+        description="40 MB / 100 MB downloaded"
       />
-      <div
-        style={{
-          fontSize: '12px',
-          color: 'var(--color-text-secondary)',
-          marginTop: '4px',
-        }}>
-        40 MB / 100 MB downloaded
-      </div>
+    </div>
+  ),
+};
+
+export const StatusPaused: Story = {
+  name: 'Status: Paused',
+  render: () => (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '16px',
+        width: '300px',
+      }}>
+      <XDSProgressBar
+        value={45}
+        label="Upload paused"
+        status="paused"
+        hasValueLabel
+        description="Paused — tap to resume"
+      />
+      <XDSProgressBar
+        isIndeterminate
+        label="Processing paused"
+        status="paused"
+      />
+    </div>
+  ),
+};
+
+export const StatusCanceled: Story = {
+  name: 'Status: Canceled',
+  render: () => (
+    <div style={{width: '300px'}}>
+      <XDSProgressBar
+        value={30}
+        label="Upload canceled"
+        status="canceled"
+        hasValueLabel
+        description="Upload was canceled"
+      />
+    </div>
+  ),
+};
+
+export const StatusIcons: Story = {
+  name: 'Status Icons',
+  render: () => (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '16px',
+        width: '300px',
+      }}>
+      <XDSProgressBar
+        value={100}
+        label="Complete"
+        variant="success"
+        hasValueLabel
+      />
+      <XDSProgressBar
+        value={80}
+        label="Disk almost full"
+        variant="warning"
+        hasValueLabel
+      />
+      <XDSProgressBar
+        value={95}
+        label="Upload failed"
+        variant="error"
+        hasValueLabel
+      />
+      <XDSProgressBar value={45} label="Paused" status="paused" hasValueLabel />
+      <XDSProgressBar
+        value={30}
+        label="Canceled"
+        status="canceled"
+        hasValueLabel
+      />
     </div>
   ),
 };
@@ -188,9 +264,9 @@ export const IndeterminateVariants: Story = {
         width: '300px',
       }}>
       <XDSProgressBar isIndeterminate label="Accent" variant="accent" />
-      <XDSProgressBar isIndeterminate label="Positive" variant="success" />
+      <XDSProgressBar isIndeterminate label="Success" variant="success" />
       <XDSProgressBar isIndeterminate label="Warning" variant="warning" />
-      <XDSProgressBar isIndeterminate label="Negative" variant="error" />
+      <XDSProgressBar isIndeterminate label="Error" variant="error" />
       <XDSProgressBar isIndeterminate label="Neutral" variant="neutral" />
     </div>
   ),

--- a/packages/core/src/ProgressBar/ProgressBar.doc.mjs
+++ b/packages/core/src/ProgressBar/ProgressBar.doc.mjs
@@ -55,25 +55,10 @@ export const docs = {
       default: 'false',
     },
     {
-      name: 'status',
-      type: "'active' | 'paused' | 'canceled'",
-      description: 'Semantic state of the progress operation. Shows status icons automatically.',
-      default: "'active'",
-    },
-    {
-      name: 'description',
-      type: 'string',
-      description: 'Secondary description shown below the bar (e.g. "40 MB / 100 MB downloaded").',
-    },
-    {
-      name: 'endContent',
-      type: 'ReactNode',
-      description: 'Content rendered in the header row to the right.',
-    },
-    {
-      name: 'bottomContent',
-      type: 'ReactNode',
-      description: 'Content rendered below the progress bar track.',
+      name: 'isDisabled',
+      type: 'boolean',
+      description: 'Visually disabled state — grays out the fill and text. Use for canceled or inactive operations.',
+      default: 'false',
     },
     {
       name: 'xstyle',
@@ -144,7 +129,7 @@ export const docsZh = {
     },
     {
       name: 'variant',
-      type: "'accent' | 'success' | 'warning' | 'error'",
+      type: "'accent' | 'success' | 'warning' | 'error' | 'neutral'",
       description: '语义颜色变体。',
       default: "'accent'",
     },
@@ -152,6 +137,12 @@ export const docsZh = {
       name: 'isIndeterminate',
       type: 'boolean',
       description: '用于未知进度的动画加载指示器。',
+      default: 'false',
+    },
+    {
+      name: 'isDisabled',
+      type: 'boolean',
+      description: '视觉禁用状态——使填充条和文本变灰。用于已取消或不活跃的操作。',
       default: 'false',
     },
     {
@@ -206,10 +197,7 @@ export const docsDense = {
     formatValueLabel: 'Custom value label formatter; defaults to percentage string.',
     variant: 'Semantic color variant.',
     isIndeterminate: 'Animated loading indicator for unknown progress.',
-    status: 'Semantic state: active, paused, or canceled. Shows status icons automatically.',
-    description: 'Secondary description below the bar.',
-    endContent: 'Content in the header row to the right.',
-    bottomContent: 'Content below the progress bar track.',
+    isDisabled: 'Visually disabled — grays out fill and text.',
     xstyle: 'StyleX styles for layout customization. Must be stylex.create() value.',
   },
 };

--- a/packages/core/src/ProgressBar/ProgressBar.doc.mjs
+++ b/packages/core/src/ProgressBar/ProgressBar.doc.mjs
@@ -44,7 +44,7 @@ export const docs = {
     },
     {
       name: 'variant',
-      type: "'accent' | 'success' | 'warning' | 'error'",
+      type: "'accent' | 'success' | 'warning' | 'error' | 'neutral'",
       description: 'Semantic color variant.',
       default: "'accent'",
     },
@@ -53,6 +53,27 @@ export const docs = {
       type: 'boolean',
       description: 'Animated loading indicator for unknown progress.',
       default: 'false',
+    },
+    {
+      name: 'status',
+      type: "'active' | 'paused' | 'canceled'",
+      description: 'Semantic state of the progress operation. Shows status icons automatically.',
+      default: "'active'",
+    },
+    {
+      name: 'description',
+      type: 'string',
+      description: 'Secondary description shown below the bar (e.g. "40 MB / 100 MB downloaded").',
+    },
+    {
+      name: 'endContent',
+      type: 'ReactNode',
+      description: 'Content rendered in the header row to the right.',
+    },
+    {
+      name: 'bottomContent',
+      type: 'ReactNode',
+      description: 'Content rendered below the progress bar track.',
     },
     {
       name: 'xstyle',
@@ -185,6 +206,10 @@ export const docsDense = {
     formatValueLabel: 'Custom value label formatter; defaults to percentage string.',
     variant: 'Semantic color variant.',
     isIndeterminate: 'Animated loading indicator for unknown progress.',
+    status: 'Semantic state: active, paused, or canceled. Shows status icons automatically.',
+    description: 'Secondary description below the bar.',
+    endContent: 'Content in the header row to the right.',
+    bottomContent: 'Content below the progress bar track.',
     xstyle: 'StyleX styles for layout customization. Must be stylex.create() value.',
   },
 };

--- a/packages/core/src/ProgressBar/XDSProgressBar.test.tsx
+++ b/packages/core/src/ProgressBar/XDSProgressBar.test.tsx
@@ -21,10 +21,8 @@ describe('XDSProgressBar', () => {
 
   it('hides label visually when isLabelHidden is true', () => {
     render(<XDSProgressBar value={50} label="Hidden label" isLabelHidden />);
-    // Label should still be in the DOM for a11y
     const label = screen.getByText('Hidden label');
     expect(label).toBeInTheDocument();
-    // The meter should still be labelled
     const meter = screen.getByRole('meter');
     expect(meter).toHaveAttribute('aria-labelledby');
   });
@@ -88,7 +86,13 @@ describe('XDSProgressBar', () => {
   });
 
   it('renders with all variant options', () => {
-    const variants = ['accent', 'success', 'warning', 'error'] as const;
+    const variants = [
+      'accent',
+      'success',
+      'warning',
+      'error',
+      'neutral',
+    ] as const;
     for (const variant of variants) {
       const {unmount} = render(
         <XDSProgressBar value={50} label={variant} variant={variant} />,
@@ -108,7 +112,6 @@ describe('XDSProgressBar', () => {
       <XDSProgressBar value={60} label="Hidden" isLabelHidden hasValueLabel />,
     );
     expect(screen.getByText('60%')).toBeInTheDocument();
-    // Label is still in DOM for a11y
     expect(screen.getByText('Hidden')).toBeInTheDocument();
   });
 
@@ -160,7 +163,13 @@ describe('XDSProgressBar', () => {
     });
 
     it('renders with all variants in indeterminate mode', () => {
-      const variants = ['accent', 'success', 'warning', 'error'] as const;
+      const variants = [
+        'accent',
+        'success',
+        'warning',
+        'error',
+        'neutral',
+      ] as const;
       for (const variant of variants) {
         const {unmount} = render(
           <XDSProgressBar isIndeterminate label={variant} variant={variant} />,
@@ -168,6 +177,94 @@ describe('XDSProgressBar', () => {
         expect(screen.getByRole('progressbar')).toBeInTheDocument();
         unmount();
       }
+    });
+  });
+
+  // Status tests
+  describe('status', () => {
+    it('renders with paused status', () => {
+      render(
+        <XDSProgressBar
+          value={50}
+          label="Upload"
+          status="paused"
+          hasValueLabel
+        />,
+      );
+      expect(screen.getByRole('meter')).toBeInTheDocument();
+      expect(screen.getByText('50%')).toBeInTheDocument();
+    });
+
+    it('renders with canceled status', () => {
+      render(
+        <XDSProgressBar
+          value={50}
+          label="Upload"
+          status="canceled"
+          hasValueLabel
+        />,
+      );
+      expect(screen.getByRole('meter')).toBeInTheDocument();
+      expect(screen.getByText('50%')).toBeInTheDocument();
+    });
+
+    it('renders status icons as aria-hidden', () => {
+      const {container} = render(
+        <XDSProgressBar value={50} label="Upload" status="paused" />,
+      );
+      const svgs = container.querySelectorAll('svg');
+      for (const svg of svgs) {
+        expect(svg).toHaveAttribute('aria-hidden', 'true');
+      }
+    });
+  });
+
+  // Description and content slots
+  describe('description and content slots', () => {
+    it('renders description below the bar', () => {
+      render(
+        <XDSProgressBar
+          value={40}
+          label="Download"
+          description="40 MB / 100 MB"
+        />,
+      );
+      expect(screen.getByText('40 MB / 100 MB')).toBeInTheDocument();
+    });
+
+    it('renders endContent in the header', () => {
+      render(
+        <XDSProgressBar
+          value={50}
+          label="Upload"
+          endContent={<span data-testid="end">End</span>}
+        />,
+      );
+      expect(screen.getByTestId('end')).toBeInTheDocument();
+    });
+
+    it('renders bottomContent below the bar', () => {
+      render(
+        <XDSProgressBar
+          value={50}
+          label="Upload"
+          bottomContent={<span data-testid="bottom">Bottom</span>}
+        />,
+      );
+      expect(screen.getByTestId('bottom')).toBeInTheDocument();
+    });
+
+    it('bottomContent takes precedence over description', () => {
+      render(
+        <XDSProgressBar
+          value={50}
+          label="Upload"
+          description="Should not show"
+          bottomContent={<span>Custom bottom</span>}
+        />,
+      );
+      expect(screen.getByText('Custom bottom')).toBeInTheDocument();
+      expect(screen.queryByText('Should not show')).not.toBeInTheDocument();
     });
   });
 });

--- a/packages/core/src/ProgressBar/XDSProgressBar.test.tsx
+++ b/packages/core/src/ProgressBar/XDSProgressBar.test.tsx
@@ -122,6 +122,22 @@ describe('XDSProgressBar', () => {
     expect(meter).toHaveAttribute('aria-valuemax', '0');
   });
 
+  // Disabled state
+  describe('disabled state', () => {
+    it('renders with isDisabled', () => {
+      render(
+        <XDSProgressBar value={50} label="Canceled" isDisabled hasValueLabel />,
+      );
+      expect(screen.getByRole('meter')).toBeInTheDocument();
+      expect(screen.getByText('50%')).toBeInTheDocument();
+    });
+
+    it('still renders label when disabled', () => {
+      render(<XDSProgressBar value={50} label="Canceled upload" isDisabled />);
+      expect(screen.getByText('Canceled upload')).toBeInTheDocument();
+    });
+  });
+
   // Indeterminate mode tests
   describe('indeterminate mode', () => {
     it('renders with role="progressbar" when isIndeterminate', () => {
@@ -177,94 +193,6 @@ describe('XDSProgressBar', () => {
         expect(screen.getByRole('progressbar')).toBeInTheDocument();
         unmount();
       }
-    });
-  });
-
-  // Status tests
-  describe('status', () => {
-    it('renders with paused status', () => {
-      render(
-        <XDSProgressBar
-          value={50}
-          label="Upload"
-          status="paused"
-          hasValueLabel
-        />,
-      );
-      expect(screen.getByRole('meter')).toBeInTheDocument();
-      expect(screen.getByText('50%')).toBeInTheDocument();
-    });
-
-    it('renders with canceled status', () => {
-      render(
-        <XDSProgressBar
-          value={50}
-          label="Upload"
-          status="canceled"
-          hasValueLabel
-        />,
-      );
-      expect(screen.getByRole('meter')).toBeInTheDocument();
-      expect(screen.getByText('50%')).toBeInTheDocument();
-    });
-
-    it('renders status icons as aria-hidden', () => {
-      const {container} = render(
-        <XDSProgressBar value={50} label="Upload" status="paused" />,
-      );
-      const svgs = container.querySelectorAll('svg');
-      for (const svg of svgs) {
-        expect(svg).toHaveAttribute('aria-hidden', 'true');
-      }
-    });
-  });
-
-  // Description and content slots
-  describe('description and content slots', () => {
-    it('renders description below the bar', () => {
-      render(
-        <XDSProgressBar
-          value={40}
-          label="Download"
-          description="40 MB / 100 MB"
-        />,
-      );
-      expect(screen.getByText('40 MB / 100 MB')).toBeInTheDocument();
-    });
-
-    it('renders endContent in the header', () => {
-      render(
-        <XDSProgressBar
-          value={50}
-          label="Upload"
-          endContent={<span data-testid="end">End</span>}
-        />,
-      );
-      expect(screen.getByTestId('end')).toBeInTheDocument();
-    });
-
-    it('renders bottomContent below the bar', () => {
-      render(
-        <XDSProgressBar
-          value={50}
-          label="Upload"
-          bottomContent={<span data-testid="bottom">Bottom</span>}
-        />,
-      );
-      expect(screen.getByTestId('bottom')).toBeInTheDocument();
-    });
-
-    it('bottomContent takes precedence over description', () => {
-      render(
-        <XDSProgressBar
-          value={50}
-          label="Upload"
-          description="Should not show"
-          bottomContent={<span>Custom bottom</span>}
-        />,
-      );
-      expect(screen.getByText('Custom bottom')).toBeInTheDocument();
-      expect(screen.queryByText('Should not show')).not.toBeInTheDocument();
     });
   });
 });

--- a/packages/core/src/ProgressBar/XDSProgressBar.tsx
+++ b/packages/core/src/ProgressBar/XDSProgressBar.tsx
@@ -16,7 +16,7 @@
  * - /packages/cli/templates/blocks/components/ProgressBar/ (showcase blocks)
  */
 
-import {useId, type ReactNode} from 'react';
+import {useId} from 'react';
 import * as stylex from '@stylexjs/stylex';
 
 import {
@@ -29,8 +29,6 @@ import {
   typeScaleVars,
 } from '../theme/tokens.stylex';
 import {xdsClassName, mergeProps} from '../utils';
-import {XDSIcon} from '../Icon';
-import type {XDSIconName, XDSIconColor} from '../Icon';
 import type {XDSBaseProps} from '../XDSBaseProps';
 
 /**
@@ -59,11 +57,6 @@ export interface XDSProgressBarVariantMap {
  * Extensible via module augmentation of XDSProgressBarVariantMap.
  */
 export type XDSProgressBarVariant = keyof XDSProgressBarVariantMap;
-
-/**
- * Semantic state of the progress operation.
- */
-export type XDSProgressBarStatus = 'active' | 'paused' | 'canceled';
 
 export interface XDSProgressBarProps extends XDSBaseProps<HTMLDivElement> {
   /** Ref forwarded to the root element */
@@ -113,45 +106,16 @@ export interface XDSProgressBarProps extends XDSBaseProps<HTMLDivElement> {
    */
   isIndeterminate?: boolean;
   /**
-   * Semantic state of the progress operation.
-   * - `'active'` (default): normal progress
-   * - `'paused'`: operation is paused, shows pause icon
-   * - `'canceled'`: operation was canceled, grays out bar, shows X icon
-   * @default 'active'
+   * When true, the progress bar is visually disabled — the fill bar and
+   * text use disabled colors. Use for canceled or inactive operations.
+   * @default false
    */
-  status?: XDSProgressBarStatus;
-  /**
-   * Secondary description shown below the bar.
-   * Use for additional context like "40 MB / 100 MB downloaded".
-   */
-  description?: string;
-  /**
-   * Content rendered in the header row to the right.
-   * Use for custom icons, badges, or actions.
-   */
-  endContent?: ReactNode;
-  /**
-   * Content rendered below the progress bar track.
-   * Takes precedence over `description` when both are provided.
-   */
-  bottomContent?: ReactNode;
+  isDisabled?: boolean;
   /**
    * Test ID for testing utilities.
    */
   'data-testid'?: string;
 }
-
-// =============================================================================
-// Status icon mapping
-// =============================================================================
-
-const statusIconNames: Record<string, XDSIconName> = {
-  canceled: 'close',
-  paused: 'stop',
-  success: 'success',
-  warning: 'warning',
-  error: 'error',
-};
 
 // =============================================================================
 // Indeterminate animation
@@ -183,25 +147,13 @@ const styles = stylex.create({
     justifyContent: 'space-between',
     alignItems: 'baseline',
   },
-  headerLeft: {
-    display: 'flex',
-    alignItems: 'baseline',
-    gap: spacingVars['--spacing-2'],
-    minWidth: 0,
-  },
-  headerRight: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: spacingVars['--spacing-1'],
-    flexShrink: 0,
-  },
   label: {
     fontSize: typeScaleVars['--text-body-size'],
     lineHeight: typeScaleVars['--text-body-leading'],
     fontWeight: fontWeightVars['--font-weight-medium'],
     color: colorVars['--color-text-primary'],
   },
-  labelCanceled: {
+  labelDisabled: {
     color: colorVars['--color-text-disabled'],
   },
   valueLabel: {
@@ -210,7 +162,7 @@ const styles = stylex.create({
     fontWeight: fontWeightVars['--font-weight-normal'],
     color: colorVars['--color-text-secondary'],
   },
-  valueLabelCanceled: {
+  valueLabelDisabled: {
     color: colorVars['--color-text-disabled'],
   },
   visuallyHidden: {
@@ -250,21 +202,6 @@ const styles = stylex.create({
     animationTimingFunction: 'ease-in-out',
     animationIterationCount: 'infinite',
   },
-  indeterminatePaused: {
-    animationPlayState: 'paused',
-  },
-  description: {
-    fontSize: typeScaleVars['--text-supporting-size'],
-    lineHeight: typeScaleVars['--text-supporting-leading'],
-    fontWeight: fontWeightVars['--font-weight-normal'],
-    color: colorVars['--color-text-secondary'],
-  },
-  descriptionCanceled: {
-    color: colorVars['--color-text-disabled'],
-  },
-  bottom: {
-    marginTop: `calc(-1 * ${spacingVars['--spacing-1']})`,
-  },
 });
 
 const variantStyles = stylex.create({
@@ -283,7 +220,7 @@ const variantStyles = stylex.create({
   neutral: {
     backgroundColor: colorVars['--color-text-disabled'],
   },
-  canceled: {
+  disabled: {
     backgroundColor: colorVars['--color-text-disabled'],
   },
 });
@@ -293,44 +230,15 @@ function defaultFormatValueLabel(value: number, max: number): string {
 }
 
 /**
- * Resolve the status icon to show based on variant, status, and completion.
- */
-function resolveStatusIcon(
-  variant: XDSProgressBarVariant,
-  status: XDSProgressBarStatus,
-  isComplete: boolean,
-  isIndeterminate: boolean,
-): {iconName: XDSIconName; iconColor: XDSIconColor} | null {
-  if (status === 'canceled') {
-    return {iconName: statusIconNames.canceled, iconColor: 'disabled'};
-  }
-  if (status === 'paused') {
-    return {iconName: statusIconNames.paused, iconColor: 'secondary'};
-  }
-  if (isIndeterminate) {
-    return null;
-  }
-  if (variant === 'success' && isComplete) {
-    return {iconName: statusIconNames.success, iconColor: 'success'};
-  }
-  if (variant === 'warning') {
-    return {iconName: statusIconNames.warning, iconColor: 'warning'};
-  }
-  if (variant === 'error') {
-    return {iconName: statusIconNames.error, iconColor: 'error'};
-  }
-  return null;
-}
-
-/**
  * A progress bar for displaying determinate or indeterminate progress.
  *
  * In determinate mode, displays a known value within a range (upload progress,
  * disk usage, etc). In indeterminate mode, shows an animated loading indicator
  * for unknown progress.
  *
- * Supports semantic status states (paused, canceled) with auto-derived icons,
- * and flexible layout via description and content slots.
+ * ProgressBar is intentionally minimal — compose additional labels, status
+ * icons, and descriptions alongside the bar using layout components rather
+ * than adding props to ProgressBar itself.
  *
  * Styles use XDS theme tokens via StyleX.
  * Wrap your app in <Theme> to apply a theme.
@@ -339,9 +247,9 @@ function resolveStatusIcon(
  * ```
  * <XDSProgressBar value={75} label="Upload progress" />
  * <XDSProgressBar isIndeterminate label="Loading..." />
- * <XDSProgressBar value={75} label="Upload" status="paused" hasValueLabel />
- * <XDSProgressBar value={40} label="Download" hasValueLabel
- *   description="40 MB / 100 MB downloaded" />
+ * <XDSProgressBar value={3.2} max={5} label="Disk usage" hasValueLabel
+ *   formatValueLabel={(v, m) => `${v} GB / ${m} GB`} />
+ * <XDSProgressBar value={30} label="Canceled" isDisabled hasValueLabel />
  * ```
  */
 export function XDSProgressBar({
@@ -353,10 +261,7 @@ export function XDSProgressBar({
   formatValueLabel = defaultFormatValueLabel,
   variant = 'accent',
   isIndeterminate = false,
-  status = 'active',
-  description,
-  endContent,
-  bottomContent,
+  isDisabled = false,
   xstyle,
   className,
   style,
@@ -368,34 +273,16 @@ export function XDSProgressBar({
   const clampedValue = Math.min(Math.max(0, value), max);
   const percentage = max > 0 ? (clampedValue / max) * 100 : 0;
   const valueText = formatValueLabel(clampedValue, max);
-  const isComplete = clampedValue >= max && max > 0;
-  const isCanceled = status === 'canceled';
-  const isPaused = status === 'paused';
 
   const showValueLabel = hasValueLabel && !isIndeterminate;
 
-  const statusIconResult = resolveStatusIcon(
-    variant,
-    status,
-    isComplete,
-    isIndeterminate,
-  );
-
-  const fillVariant = isCanceled ? 'canceled' : variant;
-
-  const hasHeader =
-    !isLabelHidden ||
-    showValueLabel ||
-    statusIconResult != null ||
-    endContent != null;
-
-  const hasBottom = bottomContent != null || description != null;
+  const fillVariant = isDisabled ? 'disabled' : variant;
 
   return (
     <div
       ref={ref}
       {...mergeProps(
-        xdsClassName('progressbar', {variant, status}),
+        xdsClassName('progressbar', {variant}),
         stylex.props(styles.container, xstyle),
         className,
         style,
@@ -403,38 +290,26 @@ export function XDSProgressBar({
       data-testid={dataTestId}
       {...rest}>
       {/* Label row */}
-      {hasHeader ? (
+      {!isLabelHidden || showValueLabel ? (
         <div {...stylex.props(styles.header)}>
-          <div {...stylex.props(styles.headerLeft)}>
+          <span
+            id={labelId}
+            {...stylex.props(
+              styles.label,
+              isLabelHidden && styles.visuallyHidden,
+              isDisabled && styles.labelDisabled,
+            )}>
+            {label}
+          </span>
+          {showValueLabel && (
             <span
-              id={labelId}
               {...stylex.props(
-                styles.label,
-                isLabelHidden && styles.visuallyHidden,
-                isCanceled && styles.labelCanceled,
+                styles.valueLabel,
+                isDisabled && styles.valueLabelDisabled,
               )}>
-              {label}
+              {valueText}
             </span>
-          </div>
-          <div {...stylex.props(styles.headerRight)}>
-            {statusIconResult && (
-              <XDSIcon
-                icon={statusIconResult.iconName}
-                size="xsm"
-                color={statusIconResult.iconColor}
-              />
-            )}
-            {showValueLabel && (
-              <span
-                {...stylex.props(
-                  styles.valueLabel,
-                  isCanceled && styles.valueLabelCanceled,
-                )}>
-                {valueText}
-              </span>
-            )}
-            {endContent}
-          </div>
+          )}
         </div>
       ) : (
         <span id={labelId} {...stylex.props(styles.visuallyHidden)}>
@@ -461,7 +336,6 @@ export function XDSProgressBar({
               stylex.props(
                 styles.indeterminateFill,
                 variantStyles[fillVariant],
-                isPaused && styles.indeterminatePaused,
               ),
             )}
           />
@@ -475,21 +349,6 @@ export function XDSProgressBar({
           />
         )}
       </div>
-
-      {/* Bottom content */}
-      {hasBottom && (
-        <div {...stylex.props(styles.bottom)}>
-          {bottomContent ?? (
-            <span
-              {...stylex.props(
-                styles.description,
-                isCanceled && styles.descriptionCanceled,
-              )}>
-              {description}
-            </span>
-          )}
-        </div>
-      )}
     </div>
   );
 }

--- a/packages/core/src/ProgressBar/XDSProgressBar.tsx
+++ b/packages/core/src/ProgressBar/XDSProgressBar.tsx
@@ -16,7 +16,7 @@
  * - /packages/cli/templates/blocks/components/ProgressBar/ (showcase blocks)
  */
 
-import {useId} from 'react';
+import {useId, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 
 import {
@@ -29,6 +29,8 @@ import {
   typeScaleVars,
 } from '../theme/tokens.stylex';
 import {xdsClassName, mergeProps} from '../utils';
+import {XDSIcon} from '../Icon';
+import type {XDSIconName, XDSIconColor} from '../Icon';
 import type {XDSBaseProps} from '../XDSBaseProps';
 
 /**
@@ -57,6 +59,11 @@ export interface XDSProgressBarVariantMap {
  * Extensible via module augmentation of XDSProgressBarVariantMap.
  */
 export type XDSProgressBarVariant = keyof XDSProgressBarVariantMap;
+
+/**
+ * Semantic state of the progress operation.
+ */
+export type XDSProgressBarStatus = 'active' | 'paused' | 'canceled';
 
 export interface XDSProgressBarProps extends XDSBaseProps<HTMLDivElement> {
   /** Ref forwarded to the root element */
@@ -106,10 +113,45 @@ export interface XDSProgressBarProps extends XDSBaseProps<HTMLDivElement> {
    */
   isIndeterminate?: boolean;
   /**
+   * Semantic state of the progress operation.
+   * - `'active'` (default): normal progress
+   * - `'paused'`: operation is paused, shows pause icon
+   * - `'canceled'`: operation was canceled, grays out bar, shows X icon
+   * @default 'active'
+   */
+  status?: XDSProgressBarStatus;
+  /**
+   * Secondary description shown below the bar.
+   * Use for additional context like "40 MB / 100 MB downloaded".
+   */
+  description?: string;
+  /**
+   * Content rendered in the header row to the right.
+   * Use for custom icons, badges, or actions.
+   */
+  endContent?: ReactNode;
+  /**
+   * Content rendered below the progress bar track.
+   * Takes precedence over `description` when both are provided.
+   */
+  bottomContent?: ReactNode;
+  /**
    * Test ID for testing utilities.
    */
   'data-testid'?: string;
 }
+
+// =============================================================================
+// Status icon mapping
+// =============================================================================
+
+const statusIconNames: Record<string, XDSIconName> = {
+  canceled: 'close',
+  paused: 'stop',
+  success: 'success',
+  warning: 'warning',
+  error: 'error',
+};
 
 // =============================================================================
 // Indeterminate animation
@@ -141,17 +183,35 @@ const styles = stylex.create({
     justifyContent: 'space-between',
     alignItems: 'baseline',
   },
+  headerLeft: {
+    display: 'flex',
+    alignItems: 'baseline',
+    gap: spacingVars['--spacing-2'],
+    minWidth: 0,
+  },
+  headerRight: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: spacingVars['--spacing-1'],
+    flexShrink: 0,
+  },
   label: {
     fontSize: typeScaleVars['--text-body-size'],
     lineHeight: typeScaleVars['--text-body-leading'],
     fontWeight: fontWeightVars['--font-weight-medium'],
     color: colorVars['--color-text-primary'],
   },
+  labelCanceled: {
+    color: colorVars['--color-text-disabled'],
+  },
   valueLabel: {
     fontSize: typeScaleVars['--text-body-size'],
     lineHeight: typeScaleVars['--text-body-leading'],
     fontWeight: fontWeightVars['--font-weight-normal'],
     color: colorVars['--color-text-secondary'],
+  },
+  valueLabelCanceled: {
+    color: colorVars['--color-text-disabled'],
   },
   visuallyHidden: {
     position: 'absolute',
@@ -190,6 +250,21 @@ const styles = stylex.create({
     animationTimingFunction: 'ease-in-out',
     animationIterationCount: 'infinite',
   },
+  indeterminatePaused: {
+    animationPlayState: 'paused',
+  },
+  description: {
+    fontSize: typeScaleVars['--text-supporting-size'],
+    lineHeight: typeScaleVars['--text-supporting-leading'],
+    fontWeight: fontWeightVars['--font-weight-normal'],
+    color: colorVars['--color-text-secondary'],
+  },
+  descriptionCanceled: {
+    color: colorVars['--color-text-disabled'],
+  },
+  bottom: {
+    marginTop: `calc(-1 * ${spacingVars['--spacing-1']})`,
+  },
 });
 
 const variantStyles = stylex.create({
@@ -208,10 +283,43 @@ const variantStyles = stylex.create({
   neutral: {
     backgroundColor: colorVars['--color-text-disabled'],
   },
+  canceled: {
+    backgroundColor: colorVars['--color-text-disabled'],
+  },
 });
 
 function defaultFormatValueLabel(value: number, max: number): string {
   return `${Math.round((value / max) * 100)}%`;
+}
+
+/**
+ * Resolve the status icon to show based on variant, status, and completion.
+ */
+function resolveStatusIcon(
+  variant: XDSProgressBarVariant,
+  status: XDSProgressBarStatus,
+  isComplete: boolean,
+  isIndeterminate: boolean,
+): {iconName: XDSIconName; iconColor: XDSIconColor} | null {
+  if (status === 'canceled') {
+    return {iconName: statusIconNames.canceled, iconColor: 'disabled'};
+  }
+  if (status === 'paused') {
+    return {iconName: statusIconNames.paused, iconColor: 'secondary'};
+  }
+  if (isIndeterminate) {
+    return null;
+  }
+  if (variant === 'success' && isComplete) {
+    return {iconName: statusIconNames.success, iconColor: 'success'};
+  }
+  if (variant === 'warning') {
+    return {iconName: statusIconNames.warning, iconColor: 'warning'};
+  }
+  if (variant === 'error') {
+    return {iconName: statusIconNames.error, iconColor: 'error'};
+  }
+  return null;
 }
 
 /**
@@ -221,19 +329,19 @@ function defaultFormatValueLabel(value: number, max: number): string {
  * disk usage, etc). In indeterminate mode, shows an animated loading indicator
  * for unknown progress.
  *
+ * Supports semantic status states (paused, canceled) with auto-derived icons,
+ * and flexible layout via description and content slots.
+ *
  * Styles use XDS theme tokens via StyleX.
  * Wrap your app in <Theme> to apply a theme.
- *
- * ProgressBar is intentionally minimal — compose additional labels, status
- * icons, and descriptions alongside the bar using layout components rather
- * than adding props to ProgressBar itself.
  *
  * @example
  * ```
  * <XDSProgressBar value={75} label="Upload progress" />
  * <XDSProgressBar isIndeterminate label="Loading..." />
- * <XDSProgressBar value={3.2} max={5} label="Disk usage" hasValueLabel
- *   formatValueLabel={(v, m) => `${v} GB / ${m} GB`} />
+ * <XDSProgressBar value={75} label="Upload" status="paused" hasValueLabel />
+ * <XDSProgressBar value={40} label="Download" hasValueLabel
+ *   description="40 MB / 100 MB downloaded" />
  * ```
  */
 export function XDSProgressBar({
@@ -245,6 +353,10 @@ export function XDSProgressBar({
   formatValueLabel = defaultFormatValueLabel,
   variant = 'accent',
   isIndeterminate = false,
+  status = 'active',
+  description,
+  endContent,
+  bottomContent,
   xstyle,
   className,
   style,
@@ -256,15 +368,34 @@ export function XDSProgressBar({
   const clampedValue = Math.min(Math.max(0, value), max);
   const percentage = max > 0 ? (clampedValue / max) * 100 : 0;
   const valueText = formatValueLabel(clampedValue, max);
+  const isComplete = clampedValue >= max && max > 0;
+  const isCanceled = status === 'canceled';
+  const isPaused = status === 'paused';
 
-  // In indeterminate mode, don't show value label
   const showValueLabel = hasValueLabel && !isIndeterminate;
+
+  const statusIconResult = resolveStatusIcon(
+    variant,
+    status,
+    isComplete,
+    isIndeterminate,
+  );
+
+  const fillVariant = isCanceled ? 'canceled' : variant;
+
+  const hasHeader =
+    !isLabelHidden ||
+    showValueLabel ||
+    statusIconResult != null ||
+    endContent != null;
+
+  const hasBottom = bottomContent != null || description != null;
 
   return (
     <div
       ref={ref}
       {...mergeProps(
-        xdsClassName('progressbar', {variant}),
+        xdsClassName('progressbar', {variant, status}),
         stylex.props(styles.container, xstyle),
         className,
         style,
@@ -272,19 +403,38 @@ export function XDSProgressBar({
       data-testid={dataTestId}
       {...rest}>
       {/* Label row */}
-      {!isLabelHidden || showValueLabel ? (
+      {hasHeader ? (
         <div {...stylex.props(styles.header)}>
-          <span
-            id={labelId}
-            {...stylex.props(
-              styles.label,
-              isLabelHidden && styles.visuallyHidden,
-            )}>
-            {label}
-          </span>
-          {showValueLabel && (
-            <span {...stylex.props(styles.valueLabel)}>{valueText}</span>
-          )}
+          <div {...stylex.props(styles.headerLeft)}>
+            <span
+              id={labelId}
+              {...stylex.props(
+                styles.label,
+                isLabelHidden && styles.visuallyHidden,
+                isCanceled && styles.labelCanceled,
+              )}>
+              {label}
+            </span>
+          </div>
+          <div {...stylex.props(styles.headerRight)}>
+            {statusIconResult && (
+              <XDSIcon
+                icon={statusIconResult.iconName}
+                size="xsm"
+                color={statusIconResult.iconColor}
+              />
+            )}
+            {showValueLabel && (
+              <span
+                {...stylex.props(
+                  styles.valueLabel,
+                  isCanceled && styles.valueLabelCanceled,
+                )}>
+                {valueText}
+              </span>
+            )}
+            {endContent}
+          </div>
         </div>
       ) : (
         <span id={labelId} {...stylex.props(styles.visuallyHidden)}>
@@ -307,20 +457,39 @@ export function XDSProgressBar({
         {isIndeterminate ? (
           <div
             {...mergeProps(
-              xdsClassName('progressbar-fill', {variant}),
-              stylex.props(styles.indeterminateFill, variantStyles[variant]),
+              xdsClassName('progressbar-fill', {variant: fillVariant}),
+              stylex.props(
+                styles.indeterminateFill,
+                variantStyles[fillVariant],
+                isPaused && styles.indeterminatePaused,
+              ),
             )}
           />
         ) : (
           <div
             {...mergeProps(
-              xdsClassName('progressbar-fill', {variant}),
-              stylex.props(styles.fill, variantStyles[variant]),
+              xdsClassName('progressbar-fill', {variant: fillVariant}),
+              stylex.props(styles.fill, variantStyles[fillVariant]),
             )}
             style={{width: `${percentage}%`}}
           />
         )}
       </div>
+
+      {/* Bottom content */}
+      {hasBottom && (
+        <div {...stylex.props(styles.bottom)}>
+          {bottomContent ?? (
+            <span
+              {...stylex.props(
+                styles.description,
+                isCanceled && styles.descriptionCanceled,
+              )}>
+              {description}
+            </span>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/core/src/ProgressBar/index.ts
+++ b/packages/core/src/ProgressBar/index.ts
@@ -11,5 +11,4 @@ export type {
   XDSProgressBarProps,
   XDSProgressBarVariant,
   XDSProgressBarVariantMap,
-  XDSProgressBarStatus,
 } from './XDSProgressBar';

--- a/packages/core/src/ProgressBar/index.ts
+++ b/packages/core/src/ProgressBar/index.ts
@@ -11,4 +11,5 @@ export type {
   XDSProgressBarProps,
   XDSProgressBarVariant,
   XDSProgressBarVariantMap,
+  XDSProgressBarStatus,
 } from './XDSProgressBar';


### PR DESCRIPTION
  ## Summary
  - Add `isDisabled` prop — grays out fill bar and label/value text with disabled colors. Use for canceled or inactive operations.
  - Add `neutral` variant using `--color-text-disabled` fill (for paused-like states)
  - API kept intentionally lean: extra labels, status icons, and descriptions should be composed alongside the bar using layout components

  ## Test plan
  - [x] `pnpm vitest run packages/core/src/ProgressBar/XDSProgressBar.test.tsx` — all 22 tests pass
  - [x] No ProgressBar-specific type errors from `tsc --noEmit`
  - [x] Pre-commit hooks pass (lint, sync check, package boundaries)
  - [x] Verify disabled state in Storybook (Disabled story)
  - [x] Verify neutral variant in Storybook (Variants story)