### PR TITLE
fix(core): resolve 210 TypeScript errors in test files and add tsc CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,6 +193,10 @@ jobs:
         if: needs.check-scope.outputs.docsite_only != 'true'
         run: pnpm -F @xds/storybook typecheck
 
+      - name: Typecheck core (including tests)
+        if: needs.check-scope.outputs.docsite_only != 'true'
+        run: pnpm -F @xds/core typecheck
+
       - name: Cache Next.js build
         if: needs.check-scope.outputs.docsite_only != 'true' && github.event_name == 'pull_request'
         uses: actions/cache@v5

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -678,6 +678,7 @@
     "test:watch": "vitest --root ../..",
     "lint": "eslint src",
     "typecheck:docs": "tsc --project tsconfig.docs.json",
+    "typecheck": "tsc --project tsconfig.json --noEmit",
     "build:css": "node ../../scripts/build-css.mjs"
   },
   "peerDependencies": {

--- a/packages/core/src/AppShell/XDSAppShell.test.tsx
+++ b/packages/core/src/AppShell/XDSAppShell.test.tsx
@@ -458,7 +458,7 @@ describe('XDSAppShell', () => {
           <XDSMobileNav
             isOpen={true}
             onOpenChange={() => {}}
-            title="Test App"
+            header="Test App"
             data-testid="appshell-mobile-nav">
             <div>Mobile Nav Content</div>
           </XDSMobileNav>

--- a/packages/core/src/Button/XDSButton.test.tsx
+++ b/packages/core/src/Button/XDSButton.test.tsx
@@ -199,8 +199,12 @@ describe('XDSButton', () => {
   it('fires onClick before clickAction', async () => {
     const user = userEvent.setup();
     const order: string[] = [];
-    const handleClick = vi.fn(() => order.push('onClick'));
-    const handleAction = vi.fn(() => order.push('clickAction'));
+    const handleClick = vi.fn(() => {
+      order.push('onClick');
+    });
+    const handleAction = vi.fn(() => {
+      order.push('clickAction');
+    });
     render(
       <XDSButton
         label="Test"

--- a/packages/core/src/Chat/XDSChatComposerInput.test.tsx
+++ b/packages/core/src/Chat/XDSChatComposerInput.test.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-import {describe, it, expect, vi} from 'vitest';
+import {describe, it, expect, vi, afterEach} from 'vitest';
 import {render, screen, fireEvent} from '@testing-library/react';
 import {XDSChatComposerInput} from './XDSChatComposerInput';
 import type {

--- a/packages/core/src/Chat/XDSChatToolCalls.test.tsx
+++ b/packages/core/src/Chat/XDSChatToolCalls.test.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 import {render, screen, fireEvent} from '@testing-library/react';
+import {describe, it, expect} from 'vitest';
 import {XDSChatToolCalls} from './XDSChatToolCalls';
 
 describe('XDSChatToolCalls', () => {

--- a/packages/core/src/CodeBlock/highlightRanges.test.ts
+++ b/packages/core/src/CodeBlock/highlightRanges.test.ts
@@ -11,13 +11,12 @@ const mockHighlightsMap = new Map<string, MockHighlight>();
 beforeEach(() => {
   mockHighlightsMap.clear();
 
-  // @ts-expect-error - mocking global CSS.highlights
   globalThis.CSS = {
     highlights: {
       get: (name: string) => mockHighlightsMap.get(name),
       set: (name: string, h: MockHighlight) => mockHighlightsMap.set(name, h),
-    },
-  };
+    } as unknown as HighlightRegistry,
+  } as typeof CSS;
 
   // @ts-expect-error - mocking global Highlight
   globalThis.Highlight = MockHighlight;
@@ -49,8 +48,8 @@ describe('applyHighlightRangesChunked', () => {
   it('creates ranges for tokens on each line', () => {
     const codeEl = createCodeElement(['const x = 1;', 'let y = 2;']);
     const tokenLines: TokenLine[] = [
-      [{type: 'keyword', start: 0, end: 5}],  // "const"
-      [{type: 'keyword', start: 0, end: 3}],  // "let"
+      [{type: 'keyword', start: 0, end: 5}], // "const"
+      [{type: 'keyword', start: 0, end: 3}], // "let"
     ];
 
     // Need to inject the style element mock
@@ -70,10 +69,7 @@ describe('applyHighlightRangesChunked', () => {
 
   it('handles empty token lines', () => {
     const codeEl = createCodeElement(['', 'const x = 1;']);
-    const tokenLines: TokenLine[] = [
-      [],
-      [{type: 'keyword', start: 0, end: 5}],
-    ];
+    const tokenLines: TokenLine[] = [[], [{type: 'keyword', start: 0, end: 5}]];
 
     const mockStyle = document.createElement('style');
     mockStyle.setAttribute('data-xds-highlight-styles', '');

--- a/packages/core/src/ContextMenu/XDSContextMenu.test.tsx
+++ b/packages/core/src/ContextMenu/XDSContextMenu.test.tsx
@@ -29,7 +29,10 @@ beforeEach(() => {
     this.dispatchEvent(event);
   });
   const originalMatches = HTMLElement.prototype.matches;
-  HTMLElement.prototype.matches = function (selector: string) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (HTMLElement.prototype as any).matches = function (
+    selector: string,
+  ): boolean {
     if (selector === ':popover-open') {
       return this.hasAttribute('popover-open');
     }

--- a/packages/core/src/DropdownMenu/XDSDropdownMenu.test.tsx
+++ b/packages/core/src/DropdownMenu/XDSDropdownMenu.test.tsx
@@ -31,7 +31,10 @@ beforeEach(() => {
     this.dispatchEvent(event);
   });
   const originalMatches = HTMLElement.prototype.matches;
-  HTMLElement.prototype.matches = function (selector: string) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (HTMLElement.prototype as any).matches = function (
+    selector: string,
+  ): boolean {
     if (selector === ':popover-open') {
       return this.hasAttribute('popover-open');
     }

--- a/packages/core/src/HoverCard/XDSHoverCard.test.tsx
+++ b/packages/core/src/HoverCard/XDSHoverCard.test.tsx
@@ -29,7 +29,10 @@ beforeAll(() => {
   });
 
   // Only intercept :popover-open, delegate everything else to original
-  HTMLElement.prototype.matches = function (selector: string) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (HTMLElement.prototype as any).matches = function (
+    selector: string,
+  ): boolean {
     if (selector === ':popover-open') {
       return popoverOpenState.get(this) ?? false;
     }
@@ -38,7 +41,8 @@ beforeAll(() => {
 });
 
 afterAll(() => {
-  HTMLElement.prototype.matches = originalMatches;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (HTMLElement.prototype as any).matches = originalMatches;
 });
 
 describe('XDSHoverCard', () => {

--- a/packages/core/src/Icon/XDSIcon.test.tsx
+++ b/packages/core/src/Icon/XDSIcon.test.tsx
@@ -43,10 +43,10 @@ describe('XDSIcon', () => {
     rerender(<XDSIcon icon={HomeIcon} color="accent" data-testid="icon" />);
     expect(screen.getByTestId('icon')).toBeInTheDocument();
 
-    rerender(<XDSIcon icon={HomeIcon} color="positive" data-testid="icon" />);
+    rerender(<XDSIcon icon={HomeIcon} color="success" data-testid="icon" />);
     expect(screen.getByTestId('icon')).toBeInTheDocument();
 
-    rerender(<XDSIcon icon={HomeIcon} color="negative" data-testid="icon" />);
+    rerender(<XDSIcon icon={HomeIcon} color="error" data-testid="icon" />);
     expect(screen.getByTestId('icon')).toBeInTheDocument();
 
     rerender(<XDSIcon icon={HomeIcon} color="warning" data-testid="icon" />);

--- a/packages/core/src/InputGroup/XDSInputGroup.test.tsx
+++ b/packages/core/src/InputGroup/XDSInputGroup.test.tsx
@@ -20,7 +20,12 @@ describe('XDSInputGroup', () => {
     render(
       <XDSInputGroup label="Price">
         <XDSInputGroupText>$</XDSInputGroupText>
-        <XDSTextInput label="Amount" isLabelHidden onChange={() => {}} />
+        <XDSTextInput
+          label="Amount"
+          isLabelHidden
+          value=""
+          onChange={() => {}}
+        />
       </XDSInputGroup>,
     );
 
@@ -32,7 +37,12 @@ describe('XDSInputGroup', () => {
   it('renders the visible label', () => {
     render(
       <XDSInputGroup label="Price">
-        <XDSTextInput label="Amount" isLabelHidden onChange={() => {}} />
+        <XDSTextInput
+          label="Amount"
+          isLabelHidden
+          value=""
+          onChange={() => {}}
+        />
       </XDSInputGroup>,
     );
 
@@ -43,7 +53,12 @@ describe('XDSInputGroup', () => {
     render(
       <XDSInputGroup label="Price">
         <XDSInputGroupText>$</XDSInputGroupText>
-        <XDSTextInput label="Amount" isLabelHidden onChange={() => {}} />
+        <XDSTextInput
+          label="Amount"
+          isLabelHidden
+          value=""
+          onChange={() => {}}
+        />
       </XDSInputGroup>,
     );
 
@@ -53,7 +68,12 @@ describe('XDSInputGroup', () => {
   it('renders the input', () => {
     render(
       <XDSInputGroup label="Price">
-        <XDSTextInput label="Amount" isLabelHidden onChange={() => {}} />
+        <XDSTextInput
+          label="Amount"
+          isLabelHidden
+          value=""
+          onChange={() => {}}
+        />
       </XDSInputGroup>,
     );
 
@@ -64,7 +84,7 @@ describe('XDSInputGroup', () => {
     render(
       <XDSInputGroup label="Website">
         <XDSInputGroupText>https://</XDSInputGroupText>
-        <XDSTextInput label="URL" isLabelHidden onChange={() => {}} />
+        <XDSTextInput label="URL" isLabelHidden value="" onChange={() => {}} />
         <XDSInputGroupText>.com</XDSInputGroupText>
       </XDSInputGroup>,
     );
@@ -77,7 +97,12 @@ describe('XDSInputGroup', () => {
   it('applies data-testid', () => {
     render(
       <XDSInputGroup label="Price" data-testid="price-group">
-        <XDSTextInput label="Amount" isLabelHidden onChange={() => {}} />
+        <XDSTextInput
+          label="Amount"
+          isLabelHidden
+          value=""
+          onChange={() => {}}
+        />
       </XDSInputGroup>,
     );
 
@@ -87,7 +112,12 @@ describe('XDSInputGroup', () => {
   it('renders description text', () => {
     render(
       <XDSInputGroup label="Price" description="Enter the price in USD">
-        <XDSTextInput label="Amount" isLabelHidden onChange={() => {}} />
+        <XDSTextInput
+          label="Amount"
+          isLabelHidden
+          value=""
+          onChange={() => {}}
+        />
       </XDSInputGroup>,
     );
 
@@ -99,7 +129,12 @@ describe('XDSInputGroup', () => {
       <XDSInputGroup
         label="Price"
         status={{type: 'error', message: 'Price is required'}}>
-        <XDSTextInput label="Amount" isLabelHidden onChange={() => {}} />
+        <XDSTextInput
+          label="Amount"
+          isLabelHidden
+          value=""
+          onChange={() => {}}
+        />
       </XDSInputGroup>,
     );
 
@@ -109,7 +144,12 @@ describe('XDSInputGroup', () => {
   it('renders with hidden label', () => {
     render(
       <XDSInputGroup label="Price" isLabelHidden>
-        <XDSTextInput label="Amount" isLabelHidden onChange={() => {}} />
+        <XDSTextInput
+          label="Amount"
+          isLabelHidden
+          value=""
+          onChange={() => {}}
+        />
       </XDSInputGroup>,
     );
 
@@ -120,14 +160,24 @@ describe('XDSInputGroup', () => {
   it('renders with different sizes', () => {
     const {rerender} = render(
       <XDSInputGroup label="Price" size="sm">
-        <XDSTextInput label="Amount" isLabelHidden onChange={() => {}} />
+        <XDSTextInput
+          label="Amount"
+          isLabelHidden
+          value=""
+          onChange={() => {}}
+        />
       </XDSInputGroup>,
     );
     expect(screen.getByRole('textbox')).toBeInTheDocument();
 
     rerender(
       <XDSInputGroup label="Price" size="lg">
-        <XDSTextInput label="Amount" isLabelHidden onChange={() => {}} />
+        <XDSTextInput
+          label="Amount"
+          isLabelHidden
+          value=""
+          onChange={() => {}}
+        />
       </XDSInputGroup>,
     );
     expect(screen.getByRole('textbox')).toBeInTheDocument();

--- a/packages/core/src/Kbd/XDSKbd.test.tsx
+++ b/packages/core/src/Kbd/XDSKbd.test.tsx
@@ -10,6 +10,7 @@
  */
 
 import {render, screen} from '@testing-library/react';
+import {describe, it, expect, afterEach} from 'vitest';
 import {XDSKbd} from './XDSKbd';
 
 describe('XDSKbd', () => {

--- a/packages/core/src/Layout/__tests__/edgeCompensation.test.tsx
+++ b/packages/core/src/Layout/__tests__/edgeCompensation.test.tsx
@@ -51,7 +51,7 @@ describe('Edge Compensation', () => {
     });
 
     it('does not apply edge comp attribute to danger variant', () => {
-      render(<XDSButton label="Delete" variant="danger" />);
+      render(<XDSButton label="Delete" variant="destructive" />);
       const button = screen.getByRole('button', {name: 'Delete'});
       expect(button).not.toHaveAttribute(EDGE_COMP_ATTR);
     });
@@ -60,8 +60,8 @@ describe('Edge Compensation', () => {
   describe('Tab data attribute', () => {
     it('applies edge comp attribute to tab', () => {
       render(
-        <XDSTabList label="Tabs">
-          <XDSTab label="Tab 1" />
+        <XDSTabList value="" onChange={() => {}} aria-label="Tabs">
+          <XDSTab value="tab1" label="Tab 1" />
         </XDSTabList>,
       );
       const tab = screen.getByRole('button', {name: 'Tab 1'});
@@ -70,8 +70,8 @@ describe('Edge Compensation', () => {
 
     it('applies edge comp attribute to TabList wrapper', () => {
       render(
-        <XDSTabList label="Tabs">
-          <XDSTab label="Tab 1" />
+        <XDSTabList value="" onChange={() => {}} aria-label="Tabs">
+          <XDSTab value="tab1" label="Tab 1" />
         </XDSTabList>,
       );
       const nav = screen.getByRole('navigation', {name: 'Tabs'});

--- a/packages/core/src/MoreMenu/XDSMoreMenu.test.tsx
+++ b/packages/core/src/MoreMenu/XDSMoreMenu.test.tsx
@@ -29,7 +29,10 @@ beforeEach(() => {
     this.dispatchEvent(event);
   });
   const originalMatches = HTMLElement.prototype.matches;
-  HTMLElement.prototype.matches = function (selector: string) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (HTMLElement.prototype as any).matches = function (
+    selector: string,
+  ): boolean {
     if (selector === ':popover-open') {
       return this.hasAttribute('popover-open');
     }

--- a/packages/core/src/MultiSelector/XDSMultiSelector.test.tsx
+++ b/packages/core/src/MultiSelector/XDSMultiSelector.test.tsx
@@ -29,7 +29,10 @@ beforeEach(() => {
     this.dispatchEvent(event);
   });
   const originalMatches = HTMLElement.prototype.matches;
-  HTMLElement.prototype.matches = function (selector: string) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (HTMLElement.prototype as any).matches = function (
+    selector: string,
+  ): boolean {
     if (selector === ':popover-open') {
       return this.hasAttribute('popover-open');
     }

--- a/packages/core/src/Popover/XDSPopover.test.tsx
+++ b/packages/core/src/Popover/XDSPopover.test.tsx
@@ -36,7 +36,10 @@ beforeAll(() => {
     this.dispatchEvent(event);
   });
 
-  HTMLElement.prototype.matches = function (selector: string) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (HTMLElement.prototype as any).matches = function (
+    selector: string,
+  ): boolean {
     if (selector === ':popover-open') {
       return popoverOpenState.get(this) ?? false;
     }
@@ -45,7 +48,8 @@ beforeAll(() => {
 });
 
 afterAll(() => {
-  HTMLElement.prototype.matches = originalMatches;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (HTMLElement.prototype as any).matches = originalMatches;
 });
 
 describe('XDSPopover', () => {

--- a/packages/core/src/PowerSearch/PowerSearchValueEditor.test.tsx
+++ b/packages/core/src/PowerSearch/PowerSearchValueEditor.test.tsx
@@ -42,7 +42,10 @@ beforeAll(() => {
     Object.defineProperty(event, 'newState', {value: 'closed'});
     this.dispatchEvent(event);
   });
-  HTMLElement.prototype.matches = function (selector: string) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (HTMLElement.prototype as any).matches = function (
+    selector: string,
+  ): boolean {
     if (selector === ':popover-open') {
       return popoverOpenState.get(this) ?? false;
     }
@@ -51,7 +54,8 @@ beforeAll(() => {
 });
 
 afterAll(() => {
-  HTMLElement.prototype.matches = originalMatches;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (HTMLElement.prototype as any).matches = originalMatches;
 });
 
 // Minimal config stub — editors don't use it directly

--- a/packages/core/src/PowerSearch/XDSPowerSearch.test.tsx
+++ b/packages/core/src/PowerSearch/XDSPowerSearch.test.tsx
@@ -44,7 +44,10 @@ beforeAll(() => {
     Object.defineProperty(event, 'newState', {value: 'closed'});
     this.dispatchEvent(event);
   });
-  HTMLElement.prototype.matches = function (selector: string) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (HTMLElement.prototype as any).matches = function (
+    selector: string,
+  ): boolean {
     if (selector === ':popover-open') {
       return popoverOpenState.get(this) ?? false;
     }
@@ -53,7 +56,8 @@ beforeAll(() => {
 });
 
 afterAll(() => {
-  HTMLElement.prototype.matches = originalMatches;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (HTMLElement.prototype as any).matches = originalMatches;
 });
 
 // =============================================================================

--- a/packages/core/src/PowerSearch/usePowerSearchConfig.test.ts
+++ b/packages/core/src/PowerSearch/usePowerSearchConfig.test.ts
@@ -9,6 +9,7 @@
 
 import {describe, it, expect} from 'vitest';
 import {createPowerSearchConfig} from './usePowerSearchConfig';
+import type {InferData} from './usePowerSearchConfig';
 import type {PowerSearchFilter} from './types';
 
 // =============================================================================
@@ -46,14 +47,14 @@ const defs = [
 
 const {config, applyFilters} = createPowerSearchConfig(defs, 'TestConfig');
 
-const data = [
+const data: Array<InferData<typeof defs>> = [
   {
     name: 'Alice Johnson',
     age: 30,
     createdAt: 1700000000,
     active: true,
     role: 'admin',
-    status: 'active',
+    status: ['active'],
     tags: ['frontend', 'lead'],
   },
   {
@@ -62,7 +63,7 @@ const data = [
     createdAt: 1700100000,
     active: false,
     role: 'user',
-    status: 'inactive',
+    status: ['inactive'],
     tags: ['backend'],
   },
   {
@@ -71,7 +72,7 @@ const data = [
     createdAt: 1700200000,
     active: true,
     role: 'user',
-    status: 'pending',
+    status: ['pending'],
     tags: ['frontend', 'backend'],
   },
   {
@@ -80,10 +81,10 @@ const data = [
     createdAt: 1700300000,
     active: true,
     role: 'admin',
-    status: 'active',
+    status: ['active'],
     tags: ['devops'],
   },
-] as const;
+];
 
 function filter(
   field: string,
@@ -479,14 +480,14 @@ describe('applyFilters', () => {
 
   describe('date: works with Date objects', () => {
     it('converts Date to unix seconds', () => {
-      const dateData = [
+      const dateData: Array<InferData<typeof defs>> = [
         {
           name: 'Test',
           age: 1,
           createdAt: new Date(1700100000 * 1000),
           active: true,
           role: 'user',
-          status: 'active',
+          status: ['active'],
           tags: ['a'],
         },
       ];
@@ -785,14 +786,14 @@ describe('applyFilters', () => {
     });
 
     it('handles string_list field with scalar value (non-array)', () => {
-      const scalarData = [
+      const scalarData: Array<InferData<typeof defs>> = [
         {
           name: 'Test',
           age: 1,
           createdAt: 0,
           active: true,
           role: 'user',
-          status: 'active',
+          status: ['active'],
           tags: 'solo' as unknown as ReadonlyArray<string>,
         },
       ];

--- a/packages/core/src/PowerSearch/usePowerSearchSource.test.ts
+++ b/packages/core/src/PowerSearch/usePowerSearchSource.test.ts
@@ -11,7 +11,11 @@ import {describe, it, expect} from 'vitest';
 import {renderHook} from '@testing-library/react';
 import {usePowerSearchSource} from './usePowerSearchSource';
 import {useInternalConfig} from './useInternalConfig';
-import type {PowerSearchConfig, PowerSearchAuxData} from './types';
+import type {
+  PowerSearchConfig,
+  PowerSearchAuxData,
+  PowerSearchItem,
+} from './types';
 
 // =============================================================================
 // Helpers
@@ -23,6 +27,27 @@ function createSource(config: PowerSearchConfig) {
     return usePowerSearchSource(internal);
   });
   return result.current;
+}
+
+function syncBootstrap(
+  source: ReturnType<typeof createSource>,
+): PowerSearchItem[] {
+  const result = source.bootstrap();
+  if (result instanceof Promise) {
+    throw new Error('Expected synchronous bootstrap');
+  }
+  return result;
+}
+
+function syncSearch(
+  source: ReturnType<typeof createSource>,
+  query: string,
+): PowerSearchItem[] {
+  const result = source.search(query);
+  if (result instanceof Promise) {
+    throw new Error('Expected synchronous search');
+  }
+  return result;
 }
 
 // =============================================================================
@@ -75,14 +100,17 @@ describe('usePowerSearchSource', () => {
   describe('bootstrap (no query)', () => {
     it('returns only field names without operator labels', () => {
       const source = createSource(baseConfig);
-      const items = source.bootstrap();
+      const items = syncBootstrap(source);
 
-      expect(items.map(i => i.label)).toEqual(['Title', 'Status']);
+      expect(items.map((i: PowerSearchItem) => i.label)).toEqual([
+        'Title',
+        'Status',
+      ]);
     });
 
     it('sets defaultOperator on bootstrap items', () => {
       const source = createSource(baseConfig);
-      const items = source.bootstrap();
+      const items = syncBootstrap(source);
 
       const titleAux = items[0].auxiliaryData as PowerSearchAuxData;
       expect(titleAux.fieldKey).toBe('title');
@@ -95,21 +123,21 @@ describe('usePowerSearchSource', () => {
 
     it('empty search returns same as bootstrap', () => {
       const source = createSource(baseConfig);
-      expect(source.search('')).toEqual(source.bootstrap());
+      expect(syncSearch(source, '')).toEqual(syncBootstrap(source));
     });
   });
 
   describe('search (with query)', () => {
     it('shows field name for partial match', () => {
       const source = createSource(baseConfig);
-      const results = source.search('tit');
+      const results = syncSearch(source, 'tit');
 
       expect(results.some(r => r.label === 'Title')).toBe(true);
     });
 
     it('shows all field+operator combos for partial match', () => {
       const source = createSource(baseConfig);
-      const results = source.search('tit');
+      const results = syncSearch(source, 'tit');
       const labels = results.map(r => r.label);
 
       expect(labels).toContain('Title');
@@ -119,21 +147,21 @@ describe('usePowerSearchSource', () => {
 
     it('matches query against combined field and operator label', () => {
       const source = createSource(baseConfig);
-      const results = source.search('title contains');
+      const results = syncSearch(source, 'title contains');
 
       expect(results.some(r => r.label === 'Title contains')).toBe(true);
     });
 
     it('matches partial field + operator query', () => {
       const source = createSource(baseConfig);
-      const results = source.search('title con');
+      const results = syncSearch(source, 'title con');
 
       expect(results.some(r => r.label === 'Title contains')).toBe(true);
     });
 
     it('field name item uses defaultOperator', () => {
       const source = createSource(baseConfig);
-      const results = source.search('tit');
+      const results = syncSearch(source, 'tit');
 
       const titleItem = results.find(r => r.label === 'Title');
       const aux = titleItem?.auxiliaryData as PowerSearchAuxData;
@@ -142,7 +170,7 @@ describe('usePowerSearchSource', () => {
 
     it('field+operator items use specific operator', () => {
       const source = createSource(baseConfig);
-      const results = source.search('tit');
+      const results = syncSearch(source, 'tit');
 
       const isItem = results.find(r => r.label === 'Title is');
       const aux = isItem?.auxiliaryData as PowerSearchAuxData;
@@ -153,7 +181,7 @@ describe('usePowerSearchSource', () => {
   describe('contentSearchFieldKey', () => {
     it('shows content search item for non-matching query', () => {
       const source = createSource(configWithContentSearch);
-      const results = source.search('foobar');
+      const results = syncSearch(source, 'foobar');
 
       expect(results[0].label).toBe('"foobar"');
       const aux = results[0].auxiliaryData as PowerSearchAuxData;
@@ -164,7 +192,7 @@ describe('usePowerSearchSource', () => {
 
     it('does not show content search item when query exactly matches a field name', () => {
       const source = createSource(configWithContentSearch);
-      const results = source.search('title');
+      const results = syncSearch(source, 'title');
 
       const contentItem = results.find(r => r.label.startsWith('"'));
       expect(contentItem).toBeUndefined();
@@ -172,7 +200,7 @@ describe('usePowerSearchSource', () => {
 
     it('does not show content search item when query exactly matches field + operator', () => {
       const source = createSource(configWithContentSearch);
-      const results = source.search('Title contains');
+      const results = syncSearch(source, 'Title contains');
 
       const contentItem = results.find(r => r.label.startsWith('"'));
       expect(contentItem).toBeUndefined();
@@ -180,7 +208,7 @@ describe('usePowerSearchSource', () => {
 
     it('exact match check is case-insensitive', () => {
       const source = createSource(configWithContentSearch);
-      const results = source.search('TITLE');
+      const results = syncSearch(source, 'TITLE');
 
       const contentItem = results.find(r => r.label.startsWith('"'));
       expect(contentItem).toBeUndefined();
@@ -188,7 +216,7 @@ describe('usePowerSearchSource', () => {
 
     it('shows content search item for partial field match', () => {
       const source = createSource(configWithContentSearch);
-      const results = source.search('tit');
+      const results = syncSearch(source, 'tit');
 
       expect(results[0].label).toBe('"tit"');
       // Field and field+operator results should still appear after
@@ -198,7 +226,7 @@ describe('usePowerSearchSource', () => {
 
     it('does not show content search item when contentSearchFieldKey is not set', () => {
       const source = createSource(baseConfig);
-      const results = source.search('foobar');
+      const results = syncSearch(source, 'foobar');
 
       const contentItem = results.find(r => r.label.startsWith('"'));
       expect(contentItem).toBeUndefined();
@@ -206,7 +234,7 @@ describe('usePowerSearchSource', () => {
 
     it('content search item is first in results', () => {
       const source = createSource(configWithContentSearch);
-      const results = source.search('sta');
+      const results = syncSearch(source, 'sta');
 
       expect(results[0].label).toBe('"sta"');
       expect(results.length).toBeGreaterThan(1);
@@ -216,7 +244,7 @@ describe('usePowerSearchSource', () => {
   describe('field+operator+value suggestions', () => {
     it('suggests all string-valued operators for "title foobar"', () => {
       const source = createSource(baseConfig);
-      const results = source.search('title foobar');
+      const results = syncSearch(source, 'title foobar');
 
       const valueItems = results.filter(r => r.label.includes('"foobar"'));
       expect(valueItems.map(r => r.label)).toEqual([
@@ -238,7 +266,7 @@ describe('usePowerSearchSource', () => {
 
     it('suggests only the matching operator for "title contains foobar"', () => {
       const source = createSource(baseConfig);
-      const results = source.search('title contains foobar');
+      const results = syncSearch(source, 'title contains foobar');
 
       const valueItems = results.filter(r => r.label.includes('"foobar"'));
       expect(valueItems).toHaveLength(1);
@@ -250,7 +278,7 @@ describe('usePowerSearchSource', () => {
 
     it('does not suggest "<field> <value>" matches when explicit operator matched', () => {
       const source = createSource(baseConfig);
-      const results = source.search('title contains foobar');
+      const results = syncSearch(source, 'title contains foobar');
 
       // Should NOT have 'Title is "contains foobar"' or similar
       const spurious = results.filter(r =>
@@ -261,7 +289,7 @@ describe('usePowerSearchSource', () => {
 
     it('suggests only the matching operator for "title is foobar"', () => {
       const source = createSource(baseConfig);
-      const results = source.search('title is foobar');
+      const results = syncSearch(source, 'title is foobar');
 
       const valueItems = results.filter(r => r.label.includes('"foobar"'));
       expect(valueItems).toHaveLength(1);
@@ -272,7 +300,7 @@ describe('usePowerSearchSource', () => {
 
     it('is case-insensitive for field and operator matching', () => {
       const source = createSource(baseConfig);
-      const results = source.search('TITLE CONTAINS hello');
+      const results = syncSearch(source, 'TITLE CONTAINS hello');
 
       const valueItem = results.find(r => r.label === 'Title contains "hello"');
       expect(valueItem).toBeDefined();
@@ -280,7 +308,7 @@ describe('usePowerSearchSource', () => {
 
     it('preserves original case of the value', () => {
       const source = createSource(baseConfig);
-      const results = source.search('title FooBar');
+      const results = syncSearch(source, 'title FooBar');
 
       const valueItem = results.find(
         r => r.label === 'Title contains "FooBar"',
@@ -292,7 +320,7 @@ describe('usePowerSearchSource', () => {
 
     it('does not suggest value match for non-string operators', () => {
       const source = createSource(baseConfig);
-      const results = source.search('status foobar');
+      const results = syncSearch(source, 'status foobar');
 
       const valueItem = results.find(r => r.label.includes('"foobar"'));
       expect(valueItem).toBeUndefined();
@@ -300,7 +328,7 @@ describe('usePowerSearchSource', () => {
 
     it('does not suggest value match when remainder matches an operator prefix', () => {
       const source = createSource(baseConfig);
-      const results = source.search('title con');
+      const results = syncSearch(source, 'title con');
 
       // "con" is a prefix of "contains", so should not suggest a value match
       const valueItem = results.find(r => r.label.includes('"con"'));
@@ -322,7 +350,7 @@ describe('usePowerSearchSource', () => {
         ],
       };
       const source = createSource(config);
-      const results = source.search('title foobar');
+      const results = syncSearch(source, 'title foobar');
 
       const valueItem = results.find(r => r.label.includes('"foobar"'));
       expect(valueItem).toBeUndefined();
@@ -346,7 +374,7 @@ describe('usePowerSearchSource', () => {
         ],
       };
       const source = createSource(config);
-      const results = source.search('tags hello');
+      const results = syncSearch(source, 'tags hello');
 
       const valueItem = results.find(r => r.label === 'Tags contains "hello"');
       expect(valueItem).toBeDefined();
@@ -391,7 +419,7 @@ describe('usePowerSearchSource', () => {
         ],
       };
       const source = createSource(config);
-      const results = source.search('genre fiction');
+      const results = syncSearch(source, 'genre fiction');
 
       const valueItems = results.filter(
         r => r.label.startsWith('Genre ') && r.label.includes('Fiction'),
@@ -443,7 +471,7 @@ describe('usePowerSearchSource', () => {
         ],
       };
       const source = createSource(config);
-      const results = source.search('genre is fiction');
+      const results = syncSearch(source, 'genre is fiction');
 
       const valueItems = results.filter(r => r.label === 'Genre is Fiction');
       expect(valueItems).toHaveLength(1);
@@ -456,7 +484,7 @@ describe('usePowerSearchSource', () => {
 
     it('suggests multiple matching enum values for partial match', () => {
       const source = createSource(baseConfig);
-      const results = source.search('status o');
+      const results = syncSearch(source, 'status o');
 
       // "o" matches "Open" and "Closed"
       const valueItems = results.filter(
@@ -470,7 +498,7 @@ describe('usePowerSearchSource', () => {
 
     it('does not suggest enum values when no labels match', () => {
       const source = createSource(baseConfig);
-      const results = source.search('status xyz');
+      const results = syncSearch(source, 'status xyz');
 
       const valueItems = results.filter(
         r => r.label.startsWith('Status is ') && r.label !== 'Status is',
@@ -502,7 +530,7 @@ describe('usePowerSearchSource', () => {
         ],
       };
       const source = createSource(config);
-      const results = source.search('tags bug');
+      const results = syncSearch(source, 'tags bug');
 
       const valueItem = results.find(r => r.label === 'Tags includes Bug');
       expect(valueItem).toBeDefined();

--- a/packages/core/src/Selector/XDSSelector.test.tsx
+++ b/packages/core/src/Selector/XDSSelector.test.tsx
@@ -29,7 +29,10 @@ beforeEach(() => {
     this.dispatchEvent(event);
   });
   const originalMatches = HTMLElement.prototype.matches;
-  HTMLElement.prototype.matches = function (selector: string) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (HTMLElement.prototype as any).matches = function (
+    selector: string,
+  ): boolean {
     if (selector === ':popover-open') {
       return this.hasAttribute('popover-open');
     }

--- a/packages/core/src/StatusDot/XDSStatusDot.test.tsx
+++ b/packages/core/src/StatusDot/XDSStatusDot.test.tsx
@@ -6,13 +6,13 @@ import {XDSStatusDot} from './XDSStatusDot';
 
 describe('XDSStatusDot', () => {
   it('renders with role="img" and aria-label', () => {
-    render(<XDSStatusDot variant="positive" label="Online" />);
+    render(<XDSStatusDot variant="success" label="Online" />);
     const dot = screen.getByRole('img', {name: 'Online'});
     expect(dot).toBeInTheDocument();
   });
 
   it('renders as a span element', () => {
-    render(<XDSStatusDot variant="positive" label="Online" />);
+    render(<XDSStatusDot variant="success" label="Online" />);
     const dot = screen.getByRole('img', {name: 'Online'});
     expect(dot.tagName).toBe('SPAN');
   });
@@ -36,21 +36,21 @@ describe('XDSStatusDot', () => {
   });
 
   it('renders at fixed 8px size', () => {
-    render(<XDSStatusDot variant="positive" label="Online" />);
+    render(<XDSStatusDot variant="success" label="Online" />);
     const dot = screen.getByRole('img', {name: 'Online'});
     expect(dot).toBeInTheDocument();
   });
 
   it('forwards ref', () => {
     const ref = {current: null as HTMLSpanElement | null};
-    render(<XDSStatusDot ref={ref} variant="positive" label="Online" />);
+    render(<XDSStatusDot ref={ref} variant="success" label="Online" />);
     expect(ref.current).toBeInstanceOf(HTMLSpanElement);
   });
 
   it('supports data-testid', () => {
     render(
       <XDSStatusDot
-        variant="positive"
+        variant="success"
         label="Online"
         data-testid="status-dot"
       />,
@@ -59,19 +59,19 @@ describe('XDSStatusDot', () => {
   });
 
   it('is not focusable', () => {
-    render(<XDSStatusDot variant="positive" label="Online" />);
+    render(<XDSStatusDot variant="success" label="Online" />);
     const dot = screen.getByRole('img', {name: 'Online'});
     expect(dot.getAttribute('tabindex')).toBeNull();
   });
 
   it('renders with isPulsing', () => {
-    render(<XDSStatusDot variant="positive" label="Live" isPulsing />);
+    render(<XDSStatusDot variant="success" label="Live" isPulsing />);
     const dot = screen.getByRole('img', {name: 'Live'});
     expect(dot).toBeInTheDocument();
   });
 
   it('renders without isPulsing by default', () => {
-    render(<XDSStatusDot variant="positive" label="Online" />);
+    render(<XDSStatusDot variant="success" label="Online" />);
     const dot = screen.getByRole('img', {name: 'Online'});
     expect(dot).toBeInTheDocument();
   });

--- a/packages/core/src/TabList/XDSTabList.test.tsx
+++ b/packages/core/src/TabList/XDSTabList.test.tsx
@@ -45,7 +45,10 @@ beforeAll(() => {
   });
 
   // Only intercept :popover-open, delegate everything else to original
-  HTMLElement.prototype.matches = function (selector: string) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (HTMLElement.prototype as any).matches = function (
+    selector: string,
+  ): boolean {
     if (selector === ':popover-open') {
       return popoverOpenState.get(this) ?? false;
     }
@@ -54,7 +57,8 @@ beforeAll(() => {
 });
 
 afterAll(() => {
-  HTMLElement.prototype.matches = originalMatches;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (HTMLElement.prototype as any).matches = originalMatches;
 });
 
 describe('XDSTabList', () => {

--- a/packages/core/src/Table/XDSTableCell.tsx
+++ b/packages/core/src/Table/XDSTableCell.tsx
@@ -45,6 +45,10 @@ export interface XDSTableCellProps extends XDSBaseProps<HTMLTableCellElement> {
   scope?: 'col' | 'row' | 'colgroup' | 'rowgroup';
   /** Space-separated list of header cell IDs this cell is described by. */
   headers?: string;
+  /** Number of columns this cell spans. Standard HTML `<td>` attribute. */
+  colSpan?: number;
+  /** Number of rows this cell spans. Standard HTML `<td>` attribute. */
+  rowSpan?: number;
   children?: ReactNode;
   /**
    * StyleX styles for layout customization (margins, positioning, sizing).

--- a/packages/core/src/Table/plugins/columnResize/useXDSTableColumnResize.test.tsx
+++ b/packages/core/src/Table/plugins/columnResize/useXDSTableColumnResize.test.tsx
@@ -81,7 +81,7 @@ function ResizeTable({
     },
     minWidth,
     maxWidth,
-    columns: columnsProp,
+    columns: columnsProp as XDSTableColumn<Record<string, unknown>>[],
   });
 
   return (

--- a/packages/core/src/Table/plugins/columnSettings/useXDSTableColumnSettings.test.tsx
+++ b/packages/core/src/Table/plugins/columnSettings/useXDSTableColumnSettings.test.tsx
@@ -133,7 +133,8 @@ describe('integration with XDSTable', () => {
     const state = useXDSTableColumnSettingsState({
       columns: columnOptions,
       activeColumnKeys: activeKeys,
-      onChangeActiveColumnKeys: setActiveKeys,
+      onChangeActiveColumnKeys: (keys: readonly string[]) =>
+        setActiveKeys([...keys]),
     });
 
     const plugin = useXDSTableColumnSettings<User>(state.columnSettingsConfig);

--- a/packages/core/src/Table/plugins/sortable/useXDSTableSortable.test.tsx
+++ b/packages/core/src/Table/plugins/sortable/useXDSTableSortable.test.tsx
@@ -551,7 +551,7 @@ describe('useXDSTableSortable', () => {
     });
 
     it('plugin object is referentially stable across renders', () => {
-      const plugins: ReturnType<typeof useXDSTableSortable>[] = [];
+      const plugins: ReturnType<typeof useXDSTableSortable<User>>[] = [];
 
       function Capture() {
         const plugin = useXDSTableSortable<User>({

--- a/packages/core/src/Tokenizer/XDSTokenizer.test.tsx
+++ b/packages/core/src/Tokenizer/XDSTokenizer.test.tsx
@@ -45,7 +45,10 @@ beforeAll(() => {
     this.dispatchEvent(event);
   });
 
-  HTMLElement.prototype.matches = function (selector: string) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (HTMLElement.prototype as any).matches = function (
+    selector: string,
+  ): boolean {
     if (selector === ':popover-open') {
       return popoverOpenState.get(this) ?? false;
     }
@@ -54,7 +57,8 @@ beforeAll(() => {
 });
 
 afterAll(() => {
-  HTMLElement.prototype.matches = originalMatches;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (HTMLElement.prototype as any).matches = originalMatches;
 });
 
 // Test data

--- a/packages/core/src/Tooltip/XDSTooltip.test.tsx
+++ b/packages/core/src/Tooltip/XDSTooltip.test.tsx
@@ -29,7 +29,10 @@ beforeAll(() => {
   });
 
   // Only intercept :popover-open, delegate everything else to original
-  HTMLElement.prototype.matches = function (selector: string) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (HTMLElement.prototype as any).matches = function (
+    selector: string,
+  ): boolean {
     if (selector === ':popover-open') {
       return popoverOpenState.get(this) ?? false;
     }
@@ -38,7 +41,8 @@ beforeAll(() => {
 });
 
 afterAll(() => {
-  HTMLElement.prototype.matches = originalMatches;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (HTMLElement.prototype as any).matches = originalMatches;
 });
 
 describe('XDSTooltip', () => {

--- a/packages/core/src/Typeahead/XDSTypeahead.test.tsx
+++ b/packages/core/src/Typeahead/XDSTypeahead.test.tsx
@@ -37,7 +37,10 @@ beforeAll(() => {
     this.dispatchEvent(event);
   });
 
-  HTMLElement.prototype.matches = function (selector: string) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (HTMLElement.prototype as any).matches = function (
+    selector: string,
+  ): boolean {
     if (selector === ':popover-open') {
       return popoverOpenState.get(this) ?? false;
     }
@@ -46,7 +49,8 @@ beforeAll(() => {
 });
 
 afterAll(() => {
-  HTMLElement.prototype.matches = originalMatches;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (HTMLElement.prototype as any).matches = originalMatches;
 });
 
 // Test data

--- a/packages/core/src/theme/onMediaTokens.test.ts
+++ b/packages/core/src/theme/onMediaTokens.test.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-import {describe, it, expect} from 'vitest';
+import {describe, it, expect, beforeAll} from 'vitest';
 import {defineTheme, generateOnMediaCSS} from './defineTheme';
 import {
   defaultOnDarkTokens,


### PR DESCRIPTION
## Summary

  - Fix all 210 TypeScript errors across 30 test files in `packages/core`
  - Add `pnpm -F @xds/core typecheck` step to CI build job to prevent regression

  ### Error categories fixed:
  - Missing vitest imports (`describe`, `it`, `expect`, `afterEach`, `beforeAll`) — 4 files
  - `HTMLElement.prototype.matches` mock type predicate mismatch — 13 files
  - Async union narrowing in `usePowerSearchSource.test.ts` — 68 errors
  - `as const` type narrowing in `usePowerSearchConfig.test.ts` — 41 errors
  - Renamed props/variants (`positive`→`success`, `danger`→`destructive`, `title`→`header`) — 3 files
  - Missing required props (`value` on TextInput, Tab, TabList) — 2 files
  - Added `colSpan`/`rowSpan` to `XDSTableCellProps` — 1 component file
  - Mock return types, generic params, casts — 4 files

  ## Test plan

  - [x] `tsc --noEmit` on `packages/core/tsconfig.json` — 0 errors
  - [x] All 2835 tests pass across 145 test files
  - [x] ESLint clean
  - [x] Pre-commit hooks pass