### PR TITLE
feat(lint): add require-base-props rule and fix 49 components

### DIFF
--- a/internal/eslint-plugin-xds/index.js
+++ b/internal/eslint-plugin-xds/index.js
@@ -24,6 +24,7 @@ import noHardcodedAnchorRule from './no-hardcoded-anchor.js';
 import noBorderShorthandRule from './no-border-shorthand.js';
 import noReactNamespaceHooksRule from './no-react-namespace-hooks.js';
 import copyrightHeaderRule from './copyright-header.js';
+import requireBasePropsRule from './require-base-props.js';
 
 // =============================================================================
 // Rule: no-hardcoded-styles
@@ -233,6 +234,7 @@ const plugin = {
     'no-hardcoded-anchor': noHardcodedAnchorRule,
     'no-border-shorthand': noBorderShorthandRule,
     'no-react-namespace-hooks': noReactNamespaceHooksRule,
+    'require-base-props': requireBasePropsRule,
     'copyright-header': copyrightHeaderRule,
   },
   configs: {},
@@ -254,6 +256,7 @@ plugin.configs.strict = {
     '@xds/no-hardcoded-anchor': 'error',
     '@xds/no-border-shorthand': 'error',
     '@xds/no-react-namespace-hooks': 'error',
+    '@xds/require-base-props': 'error',
     '@xds/copyright-header': 'error',
   },
 };
@@ -274,6 +277,7 @@ plugin.configs.recommended = {
     '@xds/no-hardcoded-anchor': 'warn',
     '@xds/no-border-shorthand': 'warn',
     '@xds/no-react-namespace-hooks': 'error',
+    '@xds/require-base-props': 'warn',
     '@xds/copyright-header': 'error',
   },
 };

--- a/internal/eslint-plugin-xds/require-base-props.js
+++ b/internal/eslint-plugin-xds/require-base-props.js
@@ -1,0 +1,186 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file require-base-props.js
+ * @description ESLint rule enforcing that publicly exported XDS component props
+ * interfaces extend XDSBaseProps (directly or via Omit/Pick).
+ *
+ * XDSBaseProps provides the standard surface area every XDS component should
+ * support: xstyle overrides, data-* attributes, aria-* attributes, event
+ * handlers, and a curated subset of HTML attributes with footguns removed.
+ *
+ * Only checks interfaces that are re-exported through the component's barrel
+ * index.ts, so internal sub-component props are not flagged.
+ */
+
+import {readFileSync} from 'fs';
+import {dirname, join} from 'path';
+
+const ALLOWED = new Set([
+  // XDSBaseProps is the base type itself
+  'XDSBaseProps',
+  // SVG components extend SVGProps, not HTMLAttributes
+  'XDSIconProps',
+  'XDSSVGIconProps',
+  // Overlay/layer components — no meaningful root DOM element
+  'XDSTooltipProps',
+  'XDSPopoverProps',
+  'XDSHoverCardProps',
+  'XDSOverlayProps',
+  // System-managed, not directly rendered by consumers
+  'XDSToastProps',
+  'XDSToastViewportProps',
+  // Provider components — render no DOM element
+  'XDSLayerProviderProps',
+  'XDSLinkProviderProps',
+  'XDSMediaThemeProps',
+]);
+
+const barrelCache = new Map();
+
+function getBarrelExports(filePath) {
+  const dir = dirname(filePath);
+  const barrelPath = join(dir, 'index.ts');
+
+  if (barrelCache.has(barrelPath)) {
+    return barrelCache.get(barrelPath);
+  }
+
+  let exported = new Set();
+  try {
+    const content = readFileSync(barrelPath, 'utf-8');
+    const typeExportRe = /export\s+(?:type\s+)?{([^}]+)}/g;
+    let match;
+    while ((match = typeExportRe.exec(content)) !== null) {
+      for (const name of match[1].split(',')) {
+        const trimmed = name.replace(/\s+as\s+\w+/, '').trim();
+        if (trimmed) exported.add(trimmed);
+      }
+    }
+    const reExportRe = /export\s+\*\s+from/g;
+    if (reExportRe.test(content)) {
+      exported = null;
+    }
+  } catch {
+    exported = new Set();
+  }
+
+  barrelCache.set(barrelPath, exported);
+  return exported;
+}
+
+function isPubliclyExported(name, filePath) {
+  const exports = getBarrelExports(filePath);
+  // null means wildcard re-export — assume everything is public
+  if (exports === null) return true;
+  return exports.has(name);
+}
+
+function hasXDSBasePropsInHeritage(node) {
+  if (!node.extends || node.extends.length === 0) {
+    return false;
+  }
+
+  for (const heritage of node.extends) {
+    const expr = heritage.expression;
+
+    if (expr.type === 'Identifier' && expr.name === 'XDSBaseProps') {
+      return true;
+    }
+
+    if (
+      expr.type === 'Identifier' &&
+      (expr.name === 'Omit' || expr.name === 'Pick')
+    ) {
+      const typeParams = heritage.typeArguments?.params;
+      if (typeParams && typeParams.length > 0) {
+        const firstParam = typeParams[0];
+        if (firstParam.type === 'TSTypeReference') {
+          const innerName = firstParam.typeName?.name;
+          if (
+            innerName === 'XDSBaseProps' ||
+            (innerName?.startsWith('XDS') && innerName?.endsWith('Props'))
+          ) {
+            return true;
+          }
+        }
+      }
+    }
+
+    if (
+      expr.type === 'Identifier' &&
+      expr.name.startsWith('XDS') &&
+      expr.name.endsWith('Props')
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+const rule = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Require publicly exported XDS*Props interfaces to extend XDSBaseProps',
+      category: 'Best Practices',
+      recommended: true,
+    },
+    messages: {
+      missingBaseProps:
+        '"{{name}}" should extend XDSBaseProps to inherit xstyle, data-*, aria-*, and standard HTML attribute support.',
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          allowNames: {
+            type: 'array',
+            items: {type: 'string'},
+            description:
+              'Interface names that are exempt from this rule.',
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+  },
+  create(context) {
+    const options = context.options[0] || {};
+    const allowNames = new Set([
+      ...ALLOWED,
+      ...(options.allowNames || []),
+    ]);
+
+    return {
+      TSInterfaceDeclaration(node) {
+        const name = node.id?.name;
+        if (!name) return;
+
+        if (!name.startsWith('XDS') || !name.endsWith('Props')) return;
+
+        const parent = node.parent;
+        const isExported =
+          parent?.type === 'ExportNamedDeclaration' ||
+          parent?.type === 'ExportDefaultDeclaration';
+        if (!isExported) return;
+
+        if (allowNames.has(name)) return;
+
+        if (!isPubliclyExported(name, context.filename)) return;
+
+        if (hasXDSBasePropsInHeritage(node)) return;
+
+        context.report({
+          node: node.id,
+          messageId: 'missingBaseProps',
+          data: {name},
+        });
+      },
+    };
+  },
+};
+
+export default rule;

--- a/packages/core/src/AvatarGroup/XDSAvatarGroupOverflow.tsx
+++ b/packages/core/src/AvatarGroup/XDSAvatarGroupOverflow.tsx
@@ -23,11 +23,15 @@ import {
 } from '../theme/tokens.stylex';
 import {xdsClassName, mergeProps} from '../utils';
 import {useXDSAvatarGroup} from './XDSAvatarGroupContext';
+import type {XDSBaseProps} from '../XDSBaseProps';
 
 const BORDER_WIDTH = 2;
 const OVERFLOW_FONT_RATIO = 0.35;
 
-export interface XDSAvatarGroupOverflowProps {
+export interface XDSAvatarGroupOverflowProps extends Omit<
+  XDSBaseProps<HTMLElement>,
+  'onClick'
+> {
   /**
    * The overflow count to display.
    */

--- a/packages/core/src/Breadcrumbs/XDSBreadcrumbItem.tsx
+++ b/packages/core/src/Breadcrumbs/XDSBreadcrumbItem.tsx
@@ -23,12 +23,16 @@ import {BreadcrumbContext} from './XDSBreadcrumbs';
 import {useXDSLinkComponent} from '../Link/useXDSLinkComponent';
 import type {XDSLinkComponentType} from '../Link/types';
 import {xdsClassName, mergeProps} from '../utils';
+import type {XDSBaseProps} from '../XDSBaseProps';
 
 // =============================================================================
 // Props
 // =============================================================================
 
-export interface XDSBreadcrumbItemProps {
+export interface XDSBreadcrumbItemProps extends Omit<
+  XDSBaseProps<HTMLLIElement>,
+  'onClick'
+> {
   /**
    * Custom component to render instead of `<a>` for breadcrumb links.
    * Overrides the provider-level default set by XDSLinkProvider.
@@ -57,10 +61,6 @@ export interface XDSBreadcrumbItemProps {
    * Optional icon rendered before the label.
    */
   startIcon?: ReactNode;
-  /**
-   * Test ID for the list item.
-   */
-  'data-testid'?: string;
 }
 
 // =============================================================================

--- a/packages/core/src/Chat/XDSChatDictationButton.tsx
+++ b/packages/core/src/Chat/XDSChatDictationButton.tsx
@@ -20,17 +20,17 @@
 
 import type {UseSpeechRecognitionReturn} from './useSpeechRecognition';
 import * as stylex from '@stylexjs/stylex';
-import type {StyleXStyles} from '@stylexjs/stylex';
 import {colorVars, radiusVars} from '../theme/tokens.stylex';
 import {XDSButton} from '../Button';
 import {XDSIcon} from '../Icon';
 import {mergeProps} from '../utils';
+import type {XDSBaseProps} from '../XDSBaseProps';
 
 // =============================================================================
 // Types
 // =============================================================================
 
-export interface XDSChatDictationButtonProps {
+export interface XDSChatDictationButtonProps extends XDSBaseProps<HTMLSpanElement> {
   /** The return value from useXDSChatDictation or useSpeechRecognition. */
   dictation: UseSpeechRecognitionReturn;
   /** Button size. @default "md" */
@@ -39,17 +39,6 @@ export interface XDSChatDictationButtonProps {
   isHiddenWhenUnsupported?: boolean;
   /** Accessible label override. */
   label?: string;
-  /**
-   * StyleX styles for layout customization (margins, positioning, sizing).
-   * Must be a `stylex.create()` value — not an inline style object.
-   *
-   * @example
-   * ```
-   * const styles = stylex.create({ wrapper: { marginTop: 8 } });
-   * <XDSChatDictationButton xstyle={styles.wrapper} />
-   * ```
-   */
-  xstyle?: StyleXStyles;
 }
 
 // =============================================================================

--- a/packages/core/src/Chat/XDSChatLayout.tsx
+++ b/packages/core/src/Chat/XDSChatLayout.tsx
@@ -27,8 +27,8 @@ import {
   useState,
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
-import type {StyleXStyles} from '@stylexjs/stylex';
 import {spacingVars} from '../theme/tokens.stylex';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import {xdsClassName, mergeProps} from '../utils';
 import {observeResize, unobserveResize} from '../utils/sharedResizeObserver';
 import {useXDSChatStreamScroll} from './useXDSChatStreamScroll';
@@ -53,7 +53,7 @@ export interface XDSChatLayoutHandle {
   scrollToLastMessage: () => void;
 }
 
-export interface XDSChatLayoutProps {
+export interface XDSChatLayoutProps extends XDSBaseProps<HTMLDivElement> {
   /** Ref forwarded to the root element. */
   ref?: React.Ref<HTMLDivElement>;
 
@@ -94,24 +94,6 @@ export interface XDSChatLayoutProps {
    * When omitted, the layout root itself is the scroll container.
    */
   scrollRef?: React.RefObject<HTMLElement | null>;
-
-  /**
-   * StyleX styles for layout customization (margins, positioning, sizing).
-   * Must be a `stylex.create()` value — not an inline style object.
-   *
-   * @example
-   * ```
-   * const styles = stylex.create({ wrapper: { marginTop: 8 } });
-   * <XDSChatLayout xstyle={styles.wrapper} />
-   * ```
-   */
-  xstyle?: StyleXStyles;
-  /** CSS class name(s) appended to the root element. */
-  className?: string;
-  /** Inline styles. */
-  style?: React.CSSProperties;
-  /** Test ID. */
-  'data-testid'?: string;
 }
 
 // =============================================================================

--- a/packages/core/src/Chat/XDSChatLayoutScrollButton.tsx
+++ b/packages/core/src/Chat/XDSChatLayoutScrollButton.tsx
@@ -27,12 +27,16 @@ import {
 } from '../theme/tokens.stylex';
 import {XDSIcon} from '../Icon';
 import {XDSButton} from '../Button';
+import type {XDSBaseProps} from '../XDSBaseProps';
 
 // =============================================================================
 // Types
 // =============================================================================
 
-export interface XDSChatLayoutScrollButtonProps {
+export interface XDSChatLayoutScrollButtonProps extends Omit<
+  XDSBaseProps<HTMLDivElement>,
+  'onClick'
+> {
   /** Whether the button is visible. */
   isVisible: boolean;
   /** Optional label — expands the button (e.g. "New messages"). */

--- a/packages/core/src/Chat/XDSChatMessage.tsx
+++ b/packages/core/src/Chat/XDSChatMessage.tsx
@@ -21,7 +21,6 @@
 
 import {type ReactNode, useMemo, useId} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import type {StyleXStyles} from '@stylexjs/stylex';
 import {
   colorVars,
   spacingVars,
@@ -35,8 +34,9 @@ import {
   type XDSChatDensity,
 } from './XDSChatContext';
 import {xdsClassName, mergeProps} from '../utils';
+import type {XDSBaseProps} from '../XDSBaseProps';
 
-export interface XDSChatMessageProps {
+export interface XDSChatMessageProps extends XDSBaseProps<HTMLElement> {
   ref?: React.Ref<HTMLDivElement>;
   sender: XDSChatMessageSender;
   children: ReactNode;
@@ -56,20 +56,6 @@ export interface XDSChatMessageProps {
    */
   metadata?: ReactNode;
   density?: XDSChatDensity;
-  /**
-   * StyleX styles for layout customization (margins, positioning, sizing).
-   * Must be a `stylex.create()` value — not an inline style object.
-   *
-   * @example
-   * ```
-   * const styles = stylex.create({ wrapper: { marginTop: 8 } });
-   * <XDSChatMessage xstyle={styles.wrapper} />
-   * ```
-   */
-  xstyle?: StyleXStyles;
-  className?: string;
-  style?: React.CSSProperties;
-  'data-testid'?: string;
 }
 
 const styles = stylex.create({

--- a/packages/core/src/Chat/XDSChatMessageBubble.tsx
+++ b/packages/core/src/Chat/XDSChatMessageBubble.tsx
@@ -27,7 +27,6 @@
 
 import type {ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import type {StyleXStyles} from '@stylexjs/stylex';
 import {
   colorVars,
   spacingVars,
@@ -37,10 +36,11 @@ import {
 } from '../theme/tokens.stylex';
 import {useXDSChatMessageContext} from './XDSChatContext';
 import {xdsClassName, mergeProps} from '../utils';
+import type {XDSBaseProps} from '../XDSBaseProps';
 
 export type XDSChatMessageBubbleVariant = 'filled' | 'ghost';
 
-export interface XDSChatMessageBubbleProps {
+export interface XDSChatMessageBubbleProps extends XDSBaseProps<HTMLDivElement> {
   /** Ref forwarded to the root element */
   ref?: React.Ref<HTMLDivElement>;
 
@@ -82,24 +82,6 @@ export interface XDSChatMessageBubbleProps {
    * Leave unset for standalone bubbles (full radius).
    */
   group?: 'first' | 'middle' | 'last';
-
-  /**
-   * StyleX styles for layout customization (margins, positioning, sizing).
-   * Must be a `stylex.create()` value — not an inline style object.
-   *
-   * @example
-   * ```
-   * const styles = stylex.create({ wrapper: { marginTop: 8 } });
-   * <XDSChatMessageBubble xstyle={styles.wrapper} />
-   * ```
-   */
-  xstyle?: StyleXStyles;
-  /** CSS class name(s). */
-  className?: string;
-  /** Inline styles. */
-  style?: React.CSSProperties;
-  /** Test ID. */
-  'data-testid'?: string;
 }
 
 // =============================================================================

--- a/packages/core/src/Chat/XDSChatMessageList.tsx
+++ b/packages/core/src/Chat/XDSChatMessageList.tsx
@@ -24,7 +24,6 @@
 
 import {type ReactNode, useEffect, useMemo, useRef, useTransition} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import type {StyleXStyles} from '@stylexjs/stylex';
 import {spacingVars} from '../theme/tokens.stylex';
 import {
   XDSChatListContext,
@@ -33,8 +32,9 @@ import {
 } from './XDSChatContext';
 import {xdsClassName, mergeProps} from '../utils';
 import {XDSSpinner} from '../Spinner';
+import type {XDSBaseProps} from '../XDSBaseProps';
 
-export interface XDSChatMessageListProps {
+export interface XDSChatMessageListProps extends XDSBaseProps<HTMLDivElement> {
   /** Ref forwarded to the root element */
   ref?: React.Ref<HTMLDivElement>;
 
@@ -62,24 +62,6 @@ export interface XDSChatMessageListProps {
    * @default 'balanced'
    */
   density?: XDSChatDensity;
-
-  /**
-   * StyleX styles for layout customization (margins, positioning, sizing).
-   * Must be a `stylex.create()` value — not an inline style object.
-   *
-   * @example
-   * ```
-   * const styles = stylex.create({ wrapper: { marginTop: 8 } });
-   * <XDSChatMessageList xstyle={styles.wrapper} />
-   * ```
-   */
-  xstyle?: StyleXStyles;
-  /** CSS class name(s) appended to the root element. */
-  className?: string;
-  /** Inline styles. */
-  style?: React.CSSProperties;
-  /** Test ID. */
-  'data-testid'?: string;
 }
 
 // =============================================================================

--- a/packages/core/src/Chat/XDSChatMessageMetadata.tsx
+++ b/packages/core/src/Chat/XDSChatMessageMetadata.tsx
@@ -24,6 +24,7 @@ import {useXDSChatMessageContext} from './XDSChatContext';
 import {XDSIcon} from '../Icon';
 import type {XDSIconName} from '../Icon/globalIconRegistry';
 import {mergeProps, xdsClassName} from '../utils';
+import type {XDSBaseProps} from '../XDSBaseProps';
 
 export type XDSChatMessageStatus =
   | 'sending'
@@ -84,7 +85,7 @@ const styles = stylex.create({
   },
 });
 
-export interface XDSChatMessageMetadataProps {
+export interface XDSChatMessageMetadataProps extends XDSBaseProps<HTMLDivElement> {
   /** Timestamp content — ReactNode (e.g. XDSTimestamp) or string. */
   timestamp?: ReactNode;
   /** Footer content — model info, ratings, reactions. */

--- a/packages/core/src/Chat/XDSChatSendButton.tsx
+++ b/packages/core/src/Chat/XDSChatSendButton.tsx
@@ -18,18 +18,18 @@
  */
 
 import type {ReactNode} from 'react';
-import type {StyleXStyles} from '@stylexjs/stylex';
 import * as stylex from '@stylexjs/stylex';
 import {XDSButton} from '../Button';
 import {getIcon} from '../Icon/globalIconRegistry';
 import {useXDSChatComposerContext} from './XDSChatContext';
 import {xdsClassName} from '../utils';
+import type {XDSBaseProps} from '../XDSBaseProps';
 
 // =============================================================================
 // Types
 // =============================================================================
 
-export interface XDSChatSendButtonProps {
+export interface XDSChatSendButtonProps extends XDSBaseProps<HTMLElement> {
   /** Whether the assistant is currently streaming a response. */
   isStreaming?: boolean;
   /** Whether the send button is disabled. Defaults to `!canSend` from context. */
@@ -44,17 +44,6 @@ export interface XDSChatSendButtonProps {
   stopIcon?: ReactNode;
   /** Button size. @default 'md' */
   size?: 'sm' | 'md';
-  /**
-   * StyleX styles for layout customization (margins, positioning, sizing).
-   * Must be a `stylex.create()` value — not an inline style object.
-   *
-   * @example
-   * ```
-   * const styles = stylex.create({ wrapper: { marginTop: 8 } });
-   * <XDSChatSendButton xstyle={styles.wrapper} />
-   * ```
-   */
-  xstyle?: StyleXStyles;
 }
 
 // =============================================================================

--- a/packages/core/src/Chat/XDSChatSystemMessage.tsx
+++ b/packages/core/src/Chat/XDSChatSystemMessage.tsx
@@ -21,7 +21,6 @@
 
 import {type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import type {StyleXStyles} from '@stylexjs/stylex';
 import {
   colorVars,
   spacingVars,
@@ -31,10 +30,11 @@ import {
 } from '../theme/tokens.stylex';
 import {xdsClassName, mergeProps} from '../utils';
 import {XDSDivider} from '../Divider';
+import type {XDSBaseProps} from '../XDSBaseProps';
 
 export type XDSChatSystemMessageVariant = 'default' | 'divider';
 
-export interface XDSChatSystemMessageProps {
+export interface XDSChatSystemMessageProps extends XDSBaseProps<HTMLDivElement> {
   /** Ref forwarded to the root element */
   ref?: React.Ref<HTMLDivElement>;
 
@@ -56,24 +56,6 @@ export interface XDSChatSystemMessageProps {
    * Accepts any ReactNode — typically an XDSIcon.
    */
   icon?: ReactNode;
-
-  /**
-   * StyleX styles for layout customization (margins, positioning, sizing).
-   * Must be a `stylex.create()` value — not an inline style object.
-   *
-   * @example
-   * ```
-   * const styles = stylex.create({ wrapper: { marginTop: 8 } });
-   * <XDSChatSystemMessage xstyle={styles.wrapper} />
-   * ```
-   */
-  xstyle?: StyleXStyles;
-  /** CSS class name(s). */
-  className?: string;
-  /** Inline styles. */
-  style?: React.CSSProperties;
-  /** Test ID. */
-  'data-testid'?: string;
 }
 
 // =============================================================================

--- a/packages/core/src/Chat/XDSChatTokenizedText.tsx
+++ b/packages/core/src/Chat/XDSChatTokenizedText.tsx
@@ -22,6 +22,7 @@ import * as stylex from '@stylexjs/stylex';
 import {XDSBadge} from '../Badge';
 import type {XDSChatComposerToken} from './XDSChatComposerInput';
 import {mergeProps, xdsClassName} from '../utils';
+import type {XDSBaseProps} from '../XDSBaseProps';
 
 // =============================================================================
 // Styles
@@ -37,7 +38,7 @@ const styles = stylex.create({
 // Types
 // =============================================================================
 
-export interface XDSChatTokenizedTextProps {
+export interface XDSChatTokenizedTextProps extends XDSBaseProps<HTMLSpanElement> {
   /** The message text containing serialized token values */
   children: string;
   /**

--- a/packages/core/src/CheckboxList/XDSCheckboxList.tsx
+++ b/packages/core/src/CheckboxList/XDSCheckboxList.tsx
@@ -24,7 +24,7 @@ import {
   useTransition,
   type ReactNode,
 } from 'react';
-import type {StyleXStyles} from '@stylexjs/stylex';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import {XDSField} from '../Field/XDSField';
 import type {XDSInputStatus} from '../Field/types';
 import {XDSList} from '../List/XDSList';
@@ -37,7 +37,12 @@ import {
 
 const EMPTY_ARRAY: string[] = [];
 
-export interface XDSCheckboxListProps {
+export interface XDSCheckboxListProps extends Omit<
+  XDSBaseProps<HTMLDivElement>,
+  'onChange'
+> {
+  /** Ref forwarded to the root element */
+  ref?: React.Ref<HTMLDivElement>;
   /**
    * Label text for the checkbox group (always rendered for accessibility).
    */
@@ -100,33 +105,6 @@ export interface XDSCheckboxListProps {
    * Checkbox list items to render.
    */
   children: ReactNode;
-  /** Ref forwarded to the root element */
-  ref?: React.Ref<HTMLDivElement>;
-  /**
-   * StyleX styles created via `stylex.create()`. Merged with the component's
-   * base styles inside a single `stylex.props()` call for optimal deduplication.
-   *
-   * @example
-   * ```
-   * const overrides = stylex.create({ root: { marginBottom: 8 } });
-   * <Component xstyle={overrides.root} />
-   * ```
-   */
-  xstyle?: StyleXStyles;
-  /**
-   * CSS class name(s) appended to the root element.
-   * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
-   */
-  className?: string;
-  /**
-   * Inline styles to apply to the root element. Spread after StyleX
-   * inline styles, so these values take priority.
-   */
-  style?: React.CSSProperties;
-  /**
-   * Test ID for the outer container.
-   */
-  'data-testid'?: string;
 }
 
 /**

--- a/packages/core/src/CodeBlock/XDSCode.tsx
+++ b/packages/core/src/CodeBlock/XDSCode.tsx
@@ -15,7 +15,6 @@
 
 import {type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import type {StyleXStyles} from '@stylexjs/stylex';
 import {
   colorVars,
   spacingVars,
@@ -24,6 +23,7 @@ import {
   typeScaleVars,
 } from '../theme/tokens.stylex';
 import {xdsClassName, mergeProps} from '../utils';
+import type {XDSBaseProps} from '../XDSBaseProps';
 
 const styles = stylex.create({
   base: {
@@ -40,27 +40,11 @@ const styles = stylex.create({
   },
 });
 
-export interface XDSCodeProps {
+export interface XDSCodeProps extends XDSBaseProps<HTMLElement> {
   /** Ref forwarded to the root element */
   ref?: React.Ref<HTMLElement>;
   /** Code content */
   children: ReactNode;
-  /**
-   * StyleX styles for layout customization (margins, positioning, sizing).
-   * Must be a `stylex.create()` value — not an inline style object.
-   *
-   * @example
-   * ```
-   * const styles = stylex.create({ wrapper: { marginTop: 8 } });
-   * <XDSCode xstyle={styles.wrapper} />
-   * ```
-   */
-  xstyle?: StyleXStyles;
-  /** CSS class name(s) */
-  className?: string;
-  /** Inline styles */
-  style?: React.CSSProperties;
-  'data-testid'?: string;
 }
 
 /**
@@ -93,8 +77,7 @@ export function XDSCode({
         className,
         style,
       )}
-      data-testid={props['data-testid']}
-    >
+      data-testid={props['data-testid']}>
       {children}
     </code>
   );

--- a/packages/core/src/Collapsible/XDSCollapsibleGroup.tsx
+++ b/packages/core/src/Collapsible/XDSCollapsibleGroup.tsx
@@ -26,8 +26,12 @@
 import {useCallback, useMemo, useState, type ReactNode} from 'react';
 import {CollapsibleGroupContext} from './XDSCollapsibleGroupContext';
 import type {CollapsibleGroupContextValue} from './XDSCollapsibleGroupContext';
+import type {XDSBaseProps} from '../XDSBaseProps';
 
-export interface XDSCollapsibleGroupProps {
+export interface XDSCollapsibleGroupProps extends Omit<
+  XDSBaseProps<HTMLElement>,
+  'onChange'
+> {
   /**
    * Whether only one item can be open at a time, or multiple.
    * @default "single"

--- a/packages/core/src/CommandPalette/XDSCommandPalette.tsx
+++ b/packages/core/src/CommandPalette/XDSCommandPalette.tsx
@@ -40,10 +40,11 @@ import {XDSCommandPaletteGroup} from './XDSCommandPaletteGroup';
 import {XDSCommandPaletteInput} from './XDSCommandPaletteInput';
 import {XDSCommandPaletteFooter} from './XDSCommandPaletteFooter';
 import {XDSCommandPaletteEmpty} from './XDSCommandPaletteEmpty';
+import type {XDSBaseProps} from '../XDSBaseProps';
 
 export interface XDSCommandPaletteProps<
   T extends XDSSearchableItem = XDSSearchableItem,
-> {
+> extends Omit<XDSBaseProps<HTMLElement>, 'onChange'> {
   /** Whether the command palette is open. */
   isOpen: boolean;
 

--- a/packages/core/src/CommandPalette/XDSCommandPaletteEmpty.tsx
+++ b/packages/core/src/CommandPalette/XDSCommandPaletteEmpty.tsx
@@ -20,6 +20,7 @@ import {
   typeScaleVars,
   typographyVars,
 } from '../theme/tokens.stylex';
+import type {XDSBaseProps} from '../XDSBaseProps';
 
 const styles = stylex.create({
   empty: {
@@ -36,7 +37,7 @@ const styles = stylex.create({
   },
 });
 
-export interface XDSCommandPaletteEmptyProps {
+export interface XDSCommandPaletteEmptyProps extends XDSBaseProps<HTMLDivElement> {
   /** The message or content to display. */
   children: ReactNode;
 }

--- a/packages/core/src/CommandPalette/XDSCommandPaletteInput.tsx
+++ b/packages/core/src/CommandPalette/XDSCommandPaletteInput.tsx
@@ -12,15 +12,8 @@
  * - /packages/cli/templates/blocks/components/CommandPalette/ (showcase blocks)
  */
 
-import {
-  useCallback,
-  useEffect,
-  useRef,
-  type InputHTMLAttributes,
-  type ReactNode,
-} from 'react';
+import {useCallback, useEffect, useRef, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import type {StyleXStyles} from '@stylexjs/stylex';
 import {XDSIcon} from '../Icon';
 import {XDSSpinner} from '../Spinner';
 import {xdsClassName, mergeProps} from '../utils';
@@ -31,6 +24,7 @@ import {
   typographyVars,
 } from '../theme/tokens.stylex';
 import {useCommandPaletteContext} from './CommandPaletteContext';
+import type {XDSBaseProps} from '../XDSBaseProps';
 
 const styles = stylex.create({
   wrapper: {
@@ -88,8 +82,8 @@ const styles = stylex.create({
 });
 
 export interface XDSCommandPaletteInputProps extends Omit<
-  InputHTMLAttributes<HTMLInputElement>,
-  'type' | 'role' | 'children' | 'autoFocus'
+  XDSBaseProps<HTMLInputElement>,
+  'onChange'
 > {
   /** Ref forwarded to the input element (for focus management). */
   ref?: React.Ref<HTMLInputElement>;
@@ -125,17 +119,8 @@ export interface XDSCommandPaletteInputProps extends Omit<
    */
   endContent?: ReactNode;
 
-  /**
-   * StyleX styles for layout customization (margins, positioning, sizing).
-   * Must be a `stylex.create()` value — not an inline style object.
-   *
-   * @example
-   * ```
-   * const styles = stylex.create({ wrapper: { marginTop: 8 } });
-   * <XDSCommandPaletteInput xstyle={styles.wrapper} />
-   * ```
-   */
-  xstyle?: StyleXStyles;
+  /** Native onChange handler for the input element. */
+  onChange?: React.ChangeEventHandler<HTMLInputElement>;
 }
 
 /**

--- a/packages/core/src/Dialog/XDSDialogHeader.tsx
+++ b/packages/core/src/Dialog/XDSDialogHeader.tsx
@@ -24,6 +24,7 @@ import {XDSButton} from '../Button';
 import {XDSIcon} from '../Icon';
 import {XDSHeading} from '../Text/XDSHeading';
 import {XDSText} from '../Text/XDSText';
+import type {XDSBaseProps} from '../XDSBaseProps';
 
 const styles = stylex.create({
   container: {
@@ -57,7 +58,7 @@ const styles = stylex.create({
   },
 });
 
-export interface XDSDialogHeaderProps {
+export interface XDSDialogHeaderProps extends XDSBaseProps<HTMLElement> {
   /** Ref forwarded to the root element */
   ref?: React.Ref<HTMLElement>;
   /**

--- a/packages/core/src/Field/XDSField.tsx
+++ b/packages/core/src/Field/XDSField.tsx
@@ -16,9 +16,9 @@
  * - /packages/cli/templates/blocks/components/Field/ (showcase blocks)
  */
 
-import {type HTMLAttributes, type ReactNode, use} from 'react';
+import {type ReactNode, use} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import type {StyleXStyles} from '@stylexjs/stylex';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import {XDSFieldLabel} from './XDSFieldLabel';
 import {XDSFieldStatus} from './XDSFieldStatus';
 import {spacingVars, borderVars} from '../theme/tokens.stylex';
@@ -69,7 +69,7 @@ export interface XDSFieldStatus {
 }
 
 export interface XDSFieldProps extends Omit<
-  HTMLAttributes<HTMLDivElement>,
+  XDSBaseProps<HTMLDivElement>,
   'children'
 > {
   /** Ref forwarded to the root element */
@@ -131,27 +131,6 @@ export interface XDSFieldProps extends Omit<
    * @default 'attached'
    */
   statusVariant?: 'attached' | 'detached';
-  /**
-   * StyleX styles created via `stylex.create()`. Merged with the component's
-   * base styles inside a single `stylex.props()` call for optimal deduplication.
-   *
-   * @example
-   * ```
-   * const overrides = stylex.create({ root: { marginBottom: 8 } });
-   * <Component xstyle={overrides.root} />
-   * ```
-   */
-  xstyle?: StyleXStyles;
-  /**
-   * CSS class name(s) appended to the root element.
-   * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
-   */
-  className?: string;
-  /**
-   * Inline styles to apply to the root element. Spread after StyleX
-   * inline styles, so these values take priority.
-   */
-  style?: React.CSSProperties;
   /**
    * The input or control to render inside the field.
    */

--- a/packages/core/src/Field/XDSFieldLabel.tsx
+++ b/packages/core/src/Field/XDSFieldLabel.tsx
@@ -14,6 +14,7 @@
 
 import {type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import {xdsClassName, mergeProps} from '../utils';
 
 import {
@@ -70,7 +71,7 @@ const styles = stylex.create({
   },
 });
 
-export interface XDSFieldLabelProps {
+export interface XDSFieldLabelProps extends XDSBaseProps<HTMLLabelElement> {
   /** Ref forwarded to the root element */
   ref?: React.Ref<HTMLLabelElement>;
   /**

--- a/packages/core/src/Field/XDSFieldStatus.tsx
+++ b/packages/core/src/Field/XDSFieldStatus.tsx
@@ -15,6 +15,7 @@
 'use client';
 
 import * as stylex from '@stylexjs/stylex';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import {xdsClassName, mergeProps} from '../utils';
 import {
   colorVars,
@@ -86,7 +87,7 @@ export interface XDSFieldStatusVariantMap {
  */
 export type XDSFieldStatusVariant = keyof XDSFieldStatusVariantMap;
 
-export interface XDSFieldStatusProps {
+export interface XDSFieldStatusProps extends XDSBaseProps<HTMLDivElement> {
   /**
    * The type of status to display.
    */
@@ -95,10 +96,6 @@ export interface XDSFieldStatusProps {
    * The status message to display.
    */
   message: string;
-  /**
-   * ID for the status message element (use for aria-describedby on the input).
-   */
-  id?: string;
   /**
    * Visual variant of the status message.
    * - 'attached': Overlaps with input above (used in XDSField)

--- a/packages/core/src/InputGroup/XDSInputGroupText.tsx
+++ b/packages/core/src/InputGroup/XDSInputGroupText.tsx
@@ -16,7 +16,7 @@
 
 import type {ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import type {StyleXStyles} from '@stylexjs/stylex';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import {
   colorVars,
   spacingVars,
@@ -65,27 +65,12 @@ const styles = stylex.create({
   },
 });
 
-export interface XDSInputGroupTextProps {
+export interface XDSInputGroupTextProps extends XDSBaseProps<HTMLDivElement> {
   /**
    * Content to render in the text slot.
    * Can be text or an icon.
    */
   children: ReactNode;
-
-  /**
-   * StyleX styles for customization.
-   */
-  xstyle?: StyleXStyles;
-
-  /**
-   * CSS class name(s).
-   */
-  className?: string;
-
-  /**
-   * Inline styles.
-   */
-  style?: React.CSSProperties;
 }
 
 /**

--- a/packages/core/src/Markdown/XDSMarkdown.tsx
+++ b/packages/core/src/Markdown/XDSMarkdown.tsx
@@ -12,8 +12,8 @@
 import {useMemo, useRef} from 'react';
 import type React from 'react';
 import {Fragment} from 'react';
-import type {StyleXStyles} from '@stylexjs/stylex';
 import * as stylex from '@stylexjs/stylex';
+import type {StyleXStyles} from '@stylexjs/stylex';
 import {
   colorVars,
   spacingVars,
@@ -39,6 +39,7 @@ import {XDSTableHeader} from '../Table/XDSTableHeader';
 import {XDSTableBody} from '../Table/XDSTableBody';
 import {xdsClassName, mergeProps} from '../utils';
 import {useXDSStreamingText} from '../hooks/useXDSStreamingText';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import {XDSCitation} from '../Citation/XDSCitation';
 import type {XDSCitationSource} from '../Citation/XDSCitation';
 import {useXDSLinkComponent} from '../Link/useXDSLinkComponent';
@@ -106,7 +107,7 @@ export interface XDSMarkdownComponents {
   hr?: React.ComponentType<object>;
 }
 
-export interface XDSMarkdownProps {
+export interface XDSMarkdownProps extends XDSBaseProps<HTMLDivElement> {
   ref?: React.Ref<HTMLDivElement>;
   children: string;
   density?: 'default' | 'compact';
@@ -162,20 +163,6 @@ export interface XDSMarkdownProps {
    * for overlapping ranges.
    */
   inlinePlugins?: MarkdownInlinePlugin[];
-  /**
-   * StyleX styles for layout customization (margins, positioning, sizing).
-   * Must be a `stylex.create()` value — not an inline style object.
-   *
-   * @example
-   * ```
-   * const styles = stylex.create({ wrapper: { marginTop: 8 } });
-   * <XDSMarkdown xstyle={styles.wrapper} />
-   * ```
-   */
-  xstyle?: StyleXStyles;
-  className?: string;
-  style?: React.CSSProperties;
-  'data-testid'?: string;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/NavMenu/XDSNavHeadingMenu.tsx
+++ b/packages/core/src/NavMenu/XDSNavHeadingMenu.tsx
@@ -4,9 +4,9 @@
 
 import {useMemo, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import type {StyleXStyles} from '@stylexjs/stylex';
 import {spacingVars} from '../theme/tokens.stylex';
 import {xdsClassName, mergeProps} from '../utils';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import {useListFocus} from '../hooks/useListFocus';
 import {
   XDSNavHeadingMenuContext,
@@ -34,7 +34,7 @@ const sizeStyles = stylex.create({
   },
 });
 
-export interface XDSNavHeadingMenuProps {
+export interface XDSNavHeadingMenuProps extends XDSBaseProps<HTMLDivElement> {
   /** Menu items (XDSNavHeadingMenuItem, dividers, custom content). */
   children: ReactNode;
 
@@ -48,21 +48,6 @@ export interface XDSNavHeadingMenuProps {
    * Minimum width override. Takes precedence over size-based defaults.
    */
   minWidth?: number | string;
-
-  /**
-   * StyleX styles for layout customization.
-   * Must be a `stylex.create()` value.
-   */
-  xstyle?: StyleXStyles;
-
-  /** CSS class name(s) appended to the root element. */
-  className?: string;
-
-  /** Inline styles applied to the root element. */
-  style?: React.CSSProperties;
-
-  /** Test ID for testing frameworks. */
-  'data-testid'?: string;
 }
 
 /**

--- a/packages/core/src/NavMenu/XDSNavHeadingMenuItem.tsx
+++ b/packages/core/src/NavMenu/XDSNavHeadingMenuItem.tsx
@@ -4,7 +4,6 @@
 
 import {useCallback, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import type {StyleXStyles} from '@stylexjs/stylex';
 import {renderIconSlot, type XDSIconType} from '../Icon';
 import {XDSText} from '../Text';
 import {
@@ -15,6 +14,7 @@ import {
   radiusVars,
 } from '../theme/tokens.stylex';
 import {xdsClassName, mergeProps} from '../utils';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import {useXDSNavHeadingMenuContext} from './XDSNavMenuContext';
 import {useXDSLinkComponent} from '../Link/useXDSLinkComponent';
 
@@ -67,7 +67,10 @@ const sizeStyles = stylex.create({
   },
 });
 
-export interface XDSNavHeadingMenuItemProps {
+export interface XDSNavHeadingMenuItemProps extends Omit<
+  XDSBaseProps<HTMLElement>,
+  'onClick'
+> {
   /** Icon to display before the label. */
   icon?: ReactNode | XDSIconType;
   /** Primary label text. */
@@ -80,17 +83,6 @@ export interface XDSNavHeadingMenuItemProps {
   onClick?: () => void;
   /** Whether the item is disabled. @default false */
   isDisabled?: boolean;
-  /**
-   * StyleX styles for layout customization.
-   * Must be a `stylex.create()` value.
-   */
-  xstyle?: StyleXStyles;
-  /** CSS class name(s) appended to the root element. */
-  className?: string;
-  /** Inline styles applied to the root element. */
-  style?: React.CSSProperties;
-  /** Test ID for testing frameworks. */
-  'data-testid'?: string;
 }
 
 /**

--- a/packages/core/src/PowerSearch/XDSPowerSearch.tsx
+++ b/packages/core/src/PowerSearch/XDSPowerSearch.tsx
@@ -22,7 +22,7 @@ import React, {
   type ReactNode,
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
-import type {StyleXStyles} from '@stylexjs/stylex';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import {
   XDSTokenizer,
   type XDSTokenizerHandle,
@@ -325,7 +325,10 @@ function PowerSearchTokenValue({
 // Types
 // =============================================================================
 
-export interface XDSPowerSearchProps {
+export interface XDSPowerSearchProps extends Omit<
+  XDSBaseProps<HTMLElement>,
+  'onChange'
+> {
   /** PowerSearch configuration defining available fields and operators. */
   config: PowerSearchConfig;
   /** Currently active filters. */
@@ -389,17 +392,6 @@ export interface XDSPowerSearchProps {
   resultCount?: number | string;
   /** Imperative handle ref. */
   ref?: React.Ref<XDSPowerSearchHandle>;
-  /** Test ID. */
-  'data-testid'?: string;
-  /**
-   * StyleX styles for layout customization (margins, positioning, sizing).
-   * Must be a `stylex.create()` value — not an inline style object.
-   */
-  xstyle?: StyleXStyles;
-  /** CSS class name. */
-  className?: string;
-  /** Inline styles. */
-  style?: React.CSSProperties;
   /**
    * Per-type component overrides for token and editor rendering.
    * Keys are operator value types (e.g. 'string', 'enum', 'date_absolute').

--- a/packages/core/src/RadioList/XDSRadioListItem.tsx
+++ b/packages/core/src/RadioList/XDSRadioListItem.tsx
@@ -18,6 +18,7 @@
 
 import {use, useId, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import {
   colorVars,
   spacingVars,
@@ -189,7 +190,7 @@ const dotSizeStyles = stylex.create({
   },
 });
 
-export interface XDSRadioListItemProps {
+export interface XDSRadioListItemProps extends XDSBaseProps<HTMLDivElement> {
   /**
    * Label text for the radio item.
    */
@@ -215,10 +216,6 @@ export interface XDSRadioListItemProps {
    * Content to render after the label.
    */
   endContent?: ReactNode;
-  /**
-   * Test ID for the radio item container.
-   */
-  'data-testid'?: string;
 }
 
 /**

--- a/packages/core/src/Resizable/XDSResizeHandle.tsx
+++ b/packages/core/src/Resizable/XDSResizeHandle.tsx
@@ -20,8 +20,9 @@
  */
 
 import {useCallback, useEffect, useRef, useState} from 'react';
-import type {HTMLAttributes, ReactNode} from 'react';
+import type {ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import {
   colorVars,
   durationVars,
@@ -210,7 +211,7 @@ const dynamicStyles = stylex.create({
 });
 
 export interface XDSResizeHandleProps extends Omit<
-  HTMLAttributes<HTMLDivElement>,
+  XDSBaseProps<HTMLDivElement>,
   'style' | 'className'
 > {
   ref?: React.Ref<HTMLDivElement>;
@@ -280,9 +281,6 @@ export interface XDSResizeHandleProps extends Omit<
 
   /** Custom handle content. Overrides the default pill. */
   children?: ReactNode;
-
-  /** StyleX styles override. */
-  xstyle?: stylex.StyleXStyles;
 }
 
 /**

--- a/packages/core/src/SegmentedControl/XDSSegmentedControlItem.tsx
+++ b/packages/core/src/SegmentedControl/XDSSegmentedControlItem.tsx
@@ -30,8 +30,9 @@ import {
 import {useXDSSegmentedControlContext} from './XDSSegmentedControlContext';
 import type {XDSSegmentedControlSize} from './XDSSegmentedControlContext';
 import {xdsClassName, mergeProps} from '../utils';
+import type {XDSBaseProps} from '../XDSBaseProps';
 
-export interface XDSSegmentedControlItemProps {
+export interface XDSSegmentedControlItemProps extends XDSBaseProps<HTMLButtonElement> {
   /**
    * Unique value for this segment. Matched against the parent's value.
    */

--- a/packages/core/src/SideNav/XDSSideNavCollapseButton.tsx
+++ b/packages/core/src/SideNav/XDSSideNavCollapseButton.tsx
@@ -22,6 +22,7 @@ import * as stylex from '@stylexjs/stylex';
 import {durationVars, easeVars} from '../theme/tokens.stylex';
 import {getIcon} from '../Icon/globalIconRegistry';
 import {XDSButton} from '../Button';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import {useXDSSideNavCollapse} from './XDSSideNavCollapseContext';
 import {useXDSAppShellMobile} from '../AppShell/XDSAppShellMobileContext';
 
@@ -46,7 +47,7 @@ const styles = stylex.create({
 // Types
 // =============================================================================
 
-export interface XDSSideNavCollapseButtonProps {
+export interface XDSSideNavCollapseButtonProps extends XDSBaseProps<HTMLButtonElement> {
   /**
    * Ref to the XDSSideNav element. Only needed when the button is
    * rendered outside the sidenav (reads collapse state via ref instead

--- a/packages/core/src/SideNav/XDSSideNavHeading.tsx
+++ b/packages/core/src/SideNav/XDSSideNavHeading.tsx
@@ -21,7 +21,6 @@
 
 import {useCallback, useMemo, useRef, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import type {StyleXStyles} from '@stylexjs/stylex';
 import {
   colorVars,
   spacingVars,
@@ -41,6 +40,7 @@ import {useXDSSideNavCollapse} from './XDSSideNavCollapseContext';
 import {useXDSLinkComponent} from '../Link/useXDSLinkComponent';
 import type {XDSLinkComponentType} from '../Link/types';
 import {xdsClassName, mergeProps} from '../utils';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import {useXDSMenuHover} from '../hooks/useXDSMenuHover';
 import {XDSNavHeadingCloseContext} from '../NavMenu/XDSNavMenuContext';
 
@@ -235,7 +235,7 @@ const styles = stylex.create({
 // Types
 // =============================================================================
 
-export interface XDSSideNavHeadingProps {
+export interface XDSSideNavHeadingProps extends XDSBaseProps<HTMLDivElement> {
   /** Ref forwarded to the root element */
   ref?: React.Ref<HTMLDivElement>;
   /**
@@ -285,31 +285,6 @@ export interface XDSSideNavHeadingProps {
    * - With hrefs → links are independent, chevron/remaining area is the trigger
    */
   menu?: ReactNode;
-  /**
-   * StyleX styles created via `stylex.create()`. Merged with the component's
-   * base styles inside a single `stylex.props()` call for optimal deduplication.
-   *
-   * @example
-   * ```
-   * const overrides = stylex.create({ root: { marginBottom: 8 } });
-   * <Component xstyle={overrides.root} />
-   * ```
-   */
-  xstyle?: StyleXStyles;
-  /**
-   * CSS class name(s) appended to the root element.
-   * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
-   */
-  className?: string;
-  /**
-   * Inline styles to apply to the root element. Spread after StyleX
-   * inline styles, so these values take priority.
-   */
-  style?: React.CSSProperties;
-  /**
-   * Test ID for the root element.
-   */
-  'data-testid'?: string;
 }
 
 // =============================================================================

--- a/packages/core/src/SideNav/XDSSideNavItem.tsx
+++ b/packages/core/src/SideNav/XDSSideNavItem.tsx
@@ -43,6 +43,7 @@ import {useXDSLinkComponent} from '../Link/useXDSLinkComponent';
 import type {XDSLinkComponentType} from '../Link/types';
 import {useXDSPopover} from '../Popover/useXDSPopover';
 import {xdsClassName, mergeProps} from '../utils';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import {XDSTooltip} from '../Tooltip';
 import {navItemStyles, type NavItemSize} from '../NavItem/navItemStyles.stylex';
 import {
@@ -242,7 +243,7 @@ function NavItemElement({
 // Types
 // =============================================================================
 
-export interface XDSSideNavItemProps {
+export interface XDSSideNavItemProps extends XDSBaseProps<HTMLElement> {
   /** Ref forwarded to the root element */
   ref?: React.Ref<HTMLElement>;
   /**
@@ -312,10 +313,6 @@ export interface XDSSideNavItemProps {
    * @default 'md'
    */
   size?: NavItemSize;
-  /**
-   * Test ID for the item element.
-   */
-  'data-testid'?: string;
 }
 
 // =============================================================================

--- a/packages/core/src/SideNav/XDSSideNavSection.tsx
+++ b/packages/core/src/SideNav/XDSSideNavSection.tsx
@@ -20,7 +20,6 @@
 
 import {useId, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import type {StyleXStyles} from '@stylexjs/stylex';
 import {
   colorVars,
   spacingVars,
@@ -28,6 +27,7 @@ import {
   typeScaleVars,
 } from '../theme/tokens.stylex';
 import {xdsClassName, mergeProps} from '../utils';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import {useXDSSideNavCollapse} from './XDSSideNavCollapseContext';
 // =============================================================================
 // Styles
@@ -89,7 +89,7 @@ const styles = stylex.create({
 // Types
 // =============================================================================
 
-export interface XDSSideNavSectionProps {
+export interface XDSSideNavSectionProps extends XDSBaseProps<HTMLDivElement> {
   /**
    * Section title.
    */
@@ -112,30 +112,6 @@ export interface XDSSideNavSectionProps {
    * @default false
    */
   isHeaderHidden?: boolean;
-  /**
-   * StyleX styles created via `stylex.create()`. Merged with the component's
-   * base styles inside a single `stylex.props()` call for optimal deduplication.
-   *
-   * @example
-   * ```
-   * const overrides = stylex.create({ root: { marginBottom: 8 } });
-   * <XDSSideNavSection title="Main" xstyle={overrides.root}>...</XDSSideNavSection>
-   * ```
-   */
-  xstyle?: StyleXStyles;
-  /**
-   * CSS class name(s) appended to the root element.
-   * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
-   */
-  className?: string;
-  /**
-   * Inline styles to apply to the root element.
-   */
-  style?: React.CSSProperties;
-  /**
-   * Test ID for the section element.
-   */
-  'data-testid'?: string;
 }
 
 // =============================================================================

--- a/packages/core/src/Table/XDSTableBody.tsx
+++ b/packages/core/src/Table/XDSTableBody.tsx
@@ -2,13 +2,19 @@
 
 'use client';
 import type {ReactNode} from 'react';
-import type {StyleXStyles} from '../theme/types';
 import * as stylex from '@stylexjs/stylex';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import {xdsClassName, mergeProps} from '../utils';
 
-export interface XDSTableBodyProps { children: ReactNode; xstyle?: StyleXStyles; }
+export interface XDSTableBodyProps extends XDSBaseProps<HTMLTableSectionElement> {
+  children: ReactNode;
+}
 
 export function XDSTableBody({children, xstyle}: XDSTableBodyProps) {
-  return (<tbody {...mergeProps(xdsClassName('table-body'), stylex.props(xstyle))}>{children}</tbody>);
+  return (
+    <tbody {...mergeProps(xdsClassName('table-body'), stylex.props(xstyle))}>
+      {children}
+    </tbody>
+  );
 }
 XDSTableBody.displayName = 'XDSTableBody';

--- a/packages/core/src/Table/XDSTableFooter.tsx
+++ b/packages/core/src/Table/XDSTableFooter.tsx
@@ -2,13 +2,19 @@
 
 'use client';
 import type {ReactNode} from 'react';
-import type {StyleXStyles} from '../theme/types';
 import * as stylex from '@stylexjs/stylex';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import {xdsClassName, mergeProps} from '../utils';
 
-export interface XDSTableFooterProps { children: ReactNode; xstyle?: StyleXStyles; }
+export interface XDSTableFooterProps extends XDSBaseProps<HTMLTableSectionElement> {
+  children: ReactNode;
+}
 
 export function XDSTableFooter({children, xstyle}: XDSTableFooterProps) {
-  return (<tfoot {...mergeProps(xdsClassName('table-footer'), stylex.props(xstyle))}>{children}</tfoot>);
+  return (
+    <tfoot {...mergeProps(xdsClassName('table-footer'), stylex.props(xstyle))}>
+      {children}
+    </tfoot>
+  );
 }
 XDSTableFooter.displayName = 'XDSTableFooter';

--- a/packages/core/src/Table/XDSTableHeader.tsx
+++ b/packages/core/src/Table/XDSTableHeader.tsx
@@ -2,13 +2,19 @@
 
 'use client';
 import type {ReactNode} from 'react';
-import type {StyleXStyles} from '../theme/types';
 import * as stylex from '@stylexjs/stylex';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import {xdsClassName, mergeProps} from '../utils';
 
-export interface XDSTableHeaderProps { children: ReactNode; xstyle?: StyleXStyles; }
+export interface XDSTableHeaderProps extends XDSBaseProps<HTMLTableSectionElement> {
+  children: ReactNode;
+}
 
 export function XDSTableHeader({children, xstyle}: XDSTableHeaderProps) {
-  return (<thead {...mergeProps(xdsClassName('table-header'), stylex.props(xstyle))}>{children}</thead>);
+  return (
+    <thead {...mergeProps(xdsClassName('table-header'), stylex.props(xstyle))}>
+      {children}
+    </thead>
+  );
 }
 XDSTableHeader.displayName = 'XDSTableHeader';

--- a/packages/core/src/Table/types.ts
+++ b/packages/core/src/Table/types.ts
@@ -20,6 +20,7 @@ import type {
   ReactNode,
 } from 'react';
 import type {StyleXStyles} from '../theme/types';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import type {XDSTableFilterFieldRef} from './plugins/filtering/useXDSTableFiltering';
 
 // =============================================================================
@@ -361,7 +362,9 @@ export interface TableHeaderCellComponentProps extends ThHTMLAttributes<HTMLTabl
  *
  * @template T - The row data type
  */
-export interface XDSBaseTableProps<T extends Record<string, unknown>> {
+export interface XDSBaseTableProps<
+  T extends Record<string, unknown>,
+> extends XDSBaseProps<HTMLTableElement> {
   /** Array of data items to render as rows */
   data?: T[];
   /** Column definitions. If omitted, auto-generated from data keys. */

--- a/packages/core/src/ToggleButton/XDSToggleButton.tsx
+++ b/packages/core/src/ToggleButton/XDSToggleButton.tsx
@@ -27,6 +27,7 @@ import type {StyleXStyles} from '@stylexjs/stylex';
 import {xdsClassName} from '../utils';
 import {XDSButton, type XDSButtonSize} from '../Button';
 import {useXDSToggleButtonGroup} from './XDSToggleButtonGroup';
+import type {XDSBaseProps} from '../XDSBaseProps';
 
 // =============================================================================
 // Styles
@@ -67,7 +68,7 @@ const labelStyles = stylex.create({
 // Props
 // =============================================================================
 
-export interface XDSToggleButtonProps {
+export interface XDSToggleButtonProps extends XDSBaseProps<HTMLButtonElement> {
   /**
    * Accessible label for the button (required).
    * Used as visible text, or as aria-label for icon-only buttons.
@@ -168,25 +169,6 @@ export interface XDSToggleButtonProps {
    * Required when used in a group.
    */
   value?: string;
-
-  /** Test ID for testing frameworks. */
-  'data-testid'?: string;
-
-  /**
-   * StyleX styles created via `stylex.create()`. Merged with the component's
-   * base styles inside a single `stylex.props()` call for optimal deduplication.
-   */
-  xstyle?: StyleXStyles;
-  /**
-   * CSS class name(s) appended to the root element.
-   * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
-   */
-  className?: string;
-  /**
-   * Inline styles to apply to the root element. Spread after StyleX
-   * inline styles, so these values take priority.
-   */
-  style?: React.CSSProperties;
 }
 
 // =============================================================================

--- a/packages/core/src/Token/XDSToken.tsx
+++ b/packages/core/src/Token/XDSToken.tsx
@@ -18,7 +18,6 @@
 
 import {type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import type {StyleXStyles} from '@stylexjs/stylex';
 import {
   colorVars,
   spacingVars,
@@ -32,6 +31,7 @@ import {
 import {XDSIcon} from '../Icon';
 import {xdsClassName, mergeProps} from '../utils';
 import {useXDSLinkComponent} from '../Link/useXDSLinkComponent';
+import type {XDSBaseProps} from '../XDSBaseProps';
 
 // =============================================================================
 // Types
@@ -55,7 +55,7 @@ export type XDSTokenColor =
 
 export type XDSTokenSize = 'sm' | 'md';
 
-export interface XDSTokenProps {
+export interface XDSTokenProps extends XDSBaseProps<HTMLElement> {
   /** Ref forwarded to the root element */
   ref?: React.Ref<HTMLElement>;
   /**
@@ -108,31 +108,6 @@ export interface XDSTokenProps {
    * @default false
    */
   isLabelHidden?: boolean;
-  /**
-   * StyleX styles created via `stylex.create()`. Merged with the component's
-   * base styles inside a single `stylex.props()` call for optimal deduplication.
-   *
-   * @example
-   * ```
-   * const overrides = stylex.create({ root: { marginBottom: 8 } });
-   * <Component xstyle={overrides.root} />
-   * ```
-   */
-  xstyle?: StyleXStyles;
-  /**
-   * CSS class name(s) appended to the root element.
-   * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
-   */
-  className?: string;
-  /**
-   * Inline styles to apply to the root element. Spread after StyleX
-   * inline styles, so these values take priority.
-   */
-  style?: React.CSSProperties;
-  /**
-   * Test ID for testing frameworks.
-   */
-  'data-testid'?: string;
 }
 
 // =============================================================================

--- a/packages/core/src/Tokenizer/XDSTokenizer.tsx
+++ b/packages/core/src/Tokenizer/XDSTokenizer.tsx
@@ -24,7 +24,7 @@ import React, {
   type ReactNode,
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
-import type {StyleXStyles} from '@stylexjs/stylex';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import {XDSBaseTypeahead} from '../Typeahead/XDSBaseTypeahead';
 import {useXDSSize} from '../SizeContext/XDSSizeContext';
 import {
@@ -92,7 +92,10 @@ export interface XDSTokenizerHandle {
   blur(): void;
 }
 
-export interface XDSTokenizerProps<T extends XDSSearchableItem> {
+export interface XDSTokenizerProps<T extends XDSSearchableItem> extends Omit<
+  XDSBaseProps<HTMLDivElement>,
+  'onChange'
+> {
   /** Accessible label (required). */
   label: string;
   /** Visually hide the label. @default false */
@@ -172,29 +175,6 @@ export interface XDSTokenizerProps<T extends XDSSearchableItem> {
   onFocus?: (e: React.FocusEvent) => void;
   /** Fires when focus leaves the tokenizer entirely. */
   onBlur?: (e: React.FocusEvent) => void;
-  /**
-   * StyleX styles created via `stylex.create()`. Merged with the component's
-   * base styles inside a single `stylex.props()` call for optimal deduplication.
-   *
-   * @example
-   * ```
-   * const overrides = stylex.create({ root: { marginBottom: 8 } });
-   * <Component xstyle={overrides.root} />
-   * ```
-   */
-  xstyle?: StyleXStyles;
-  /**
-   * CSS class name(s) appended to the root element.
-   * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
-   */
-  className?: string;
-  /**
-   * Inline styles to apply to the root element. Spread after StyleX
-   * inline styles, so these values take priority.
-   */
-  style?: React.CSSProperties;
-  /** Test ID. */
-  'data-testid'?: string;
   /** Imperative handle ref for focus/blur control. */
   ref?: React.Ref<XDSTokenizerHandle>;
 }

--- a/packages/core/src/TopNav/XDSTopNavHeading.tsx
+++ b/packages/core/src/TopNav/XDSTopNavHeading.tsx
@@ -22,7 +22,6 @@
 
 import {useCallback, useMemo, useRef, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import type {StyleXStyles} from '@stylexjs/stylex';
 import {
   colorVars,
   spacingVars,
@@ -36,6 +35,7 @@ import {getIcon} from '../Icon/globalIconRegistry';
 import {useXDSLinkComponent} from '../Link/useXDSLinkComponent';
 import type {XDSLinkComponentType} from '../Link/types';
 import {xdsClassName, mergeProps} from '../utils';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import {useXDSMenuHover} from '../hooks/useXDSMenuHover';
 import {XDSNavHeadingCloseContext} from '../NavMenu/XDSNavMenuContext';
 
@@ -205,7 +205,7 @@ const styles = stylex.create({
 // Types
 // =============================================================================
 
-export interface XDSTopNavHeadingProps {
+export interface XDSTopNavHeadingProps extends XDSBaseProps<HTMLElement> {
   /** Ref forwarded to the root element */
   ref?: React.Ref<HTMLElement>;
   /**
@@ -261,22 +261,6 @@ export interface XDSTopNavHeadingProps {
    * Must accept href, className, style, and children props.
    */
   as?: XDSLinkComponentType;
-  /**
-   * StyleX styles created via `stylex.create()`.
-   */
-  xstyle?: StyleXStyles;
-  /**
-   * CSS class name(s) appended to the root element.
-   */
-  className?: string;
-  /**
-   * Inline styles to apply to the root element.
-   */
-  style?: React.CSSProperties;
-  /**
-   * Test ID for the root element.
-   */
-  'data-testid'?: string;
 }
 
 // =============================================================================

--- a/packages/core/src/TopNav/XDSTopNavMegaMenu.tsx
+++ b/packages/core/src/TopNav/XDSTopNavMegaMenu.tsx
@@ -40,6 +40,7 @@ import {useXDSPopover} from '../Popover/useXDSPopover';
 import {XDSGrid} from '../Grid/XDSGrid';
 import {getIcon} from '../Icon/globalIconRegistry';
 import {xdsClassName, mergeProps} from '../utils';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import {navItemStyles} from '../NavItem/navItemStyles.stylex';
 import {useTopNavSlot} from './TopNavContext';
 import {useXDSTopNavRenderMode} from './XDSTopNavRenderContext';
@@ -201,7 +202,7 @@ const styles = stylex.create({
 // Types
 // =============================================================================
 
-export interface XDSTopNavMegaMenuProps {
+export interface XDSTopNavMegaMenuProps extends XDSBaseProps<HTMLButtonElement> {
   /** The visible label for the nav item trigger. */
   label: string;
   /**

--- a/packages/core/src/TopNav/XDSTopNavMegaMenuFeaturedCard.tsx
+++ b/packages/core/src/TopNav/XDSTopNavMegaMenuFeaturedCard.tsx
@@ -27,6 +27,7 @@ import {
   fontWeightVars,
 } from '../theme/tokens.stylex';
 import {xdsClassName, mergeProps} from '../utils';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import {useXDSLinkComponent} from '../Link/useXDSLinkComponent';
 
 // =============================================================================
@@ -74,7 +75,7 @@ const styles = stylex.create({
 // Types
 // =============================================================================
 
-export interface XDSTopNavMegaMenuFeaturedCardProps {
+export interface XDSTopNavMegaMenuFeaturedCardProps extends XDSBaseProps<HTMLDivElement> {
   /** Card title. */
   title: string;
   /** Description text below the title. */

--- a/packages/core/src/TopNav/XDSTopNavMegaMenuItem.tsx
+++ b/packages/core/src/TopNav/XDSTopNavMegaMenuItem.tsx
@@ -31,6 +31,7 @@ import {useXDSLinkComponent} from '../Link/useXDSLinkComponent';
 import type {XDSLinkComponentType} from '../Link/types';
 import {useXDSTopNavRenderMode} from './XDSTopNavRenderContext';
 import {xdsClassName, mergeProps} from '../utils';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import {useXDSAppShellMobile} from '../AppShell/XDSAppShellMobileContext';
 
 // =============================================================================
@@ -138,7 +139,10 @@ const styles = stylex.create({
 // Types
 // =============================================================================
 
-export interface XDSTopNavMegaMenuItemProps {
+export interface XDSTopNavMegaMenuItemProps extends Omit<
+  XDSBaseProps<HTMLElement>,
+  'onClick'
+> {
   /** Display title for the menu item. */
   title: string;
   /** Optional description text displayed below the title. */
@@ -154,11 +158,6 @@ export interface XDSTopNavMegaMenuItemProps {
    * Overrides the provider-level default set by XDSLinkProvider.
    */
   as?: XDSLinkComponentType;
-  /**
-   * tabIndex — set by parent when inside a closed popover.
-   * @internal
-   */
-  tabIndex?: number;
 }
 
 // =============================================================================

--- a/packages/core/src/TopNav/XDSTopNavMenu.tsx
+++ b/packages/core/src/TopNav/XDSTopNavMenu.tsx
@@ -21,6 +21,7 @@ import {useXDSPopover} from '../Popover/useXDSPopover';
 import {useXDSMenuHover} from '../hooks/useXDSMenuHover';
 import {getIcon} from '../Icon/globalIconRegistry';
 import {xdsClassName, mergeProps} from '../utils';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import {navItemStyles} from '../NavItem/navItemStyles.stylex';
 import {useTopNavSlot} from './TopNavContext';
 import {useXDSTopNavRenderMode} from './XDSTopNavRenderContext';
@@ -244,7 +245,7 @@ export interface XDSTopNavMenuItemData {
   onClick?: () => void;
 }
 
-export interface XDSTopNavMenuProps {
+export interface XDSTopNavMenuProps extends XDSBaseProps<HTMLButtonElement> {
   /**
    * The visible label for the nav item trigger.
    */

--- a/packages/core/src/Typeahead/XDSBaseTypeahead.tsx
+++ b/packages/core/src/Typeahead/XDSBaseTypeahead.tsx
@@ -40,13 +40,16 @@ import {
   typeScaleVars,
 } from '../theme/tokens.stylex';
 import {xdsClassName, mergeProps} from '../utils';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import type {XDSSearchableItem, XDSSearchSource} from './types';
 
 // =============================================================================
 // Types
 // =============================================================================
 
-export interface XDSBaseTypeaheadProps<T extends XDSSearchableItem> {
+export interface XDSBaseTypeaheadProps<
+  T extends XDSSearchableItem,
+> extends Omit<XDSBaseProps<HTMLElement>, 'onChange'> {
   /**
    * Search source providing items.
    */

--- a/packages/core/src/Typeahead/XDSTypeahead.tsx
+++ b/packages/core/src/Typeahead/XDSTypeahead.tsx
@@ -26,7 +26,6 @@ import React, {
   type ReactNode,
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
-import type {StyleXStyles} from '@stylexjs/stylex';
 import {XDSBaseTypeahead} from './XDSBaseTypeahead';
 import {useXDSSize} from '../SizeContext/XDSSizeContext';
 import {
@@ -47,6 +46,7 @@ import {
   sizeVars,
 } from '../theme/tokens.stylex';
 import {xdsClassName, mergeProps} from '../utils';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import type {XDSSearchableItem, XDSSearchSource} from './types';
 
 export type {
@@ -56,7 +56,10 @@ export type {
 
 export type XDSTypeaheadSize = 'sm' | 'md';
 
-export interface XDSTypeaheadProps<T extends XDSSearchableItem> {
+export interface XDSTypeaheadProps<T extends XDSSearchableItem> extends Omit<
+  XDSBaseProps<HTMLDivElement>,
+  'onChange'
+> {
   /** Accessible label (required). */
   label: string;
   /** Visually hide the label. @default false */
@@ -110,29 +113,6 @@ export interface XDSTypeaheadProps<T extends XDSSearchableItem> {
   onChangeQuery?: (query: string) => void;
   /** Callback when dropdown opens/closes. */
   onOpenChange?: (isOpen: boolean) => void;
-  /**
-   * StyleX styles created via `stylex.create()`. Merged with the component's
-   * base styles inside a single `stylex.props()` call for optimal deduplication.
-   *
-   * @example
-   * ```
-   * const overrides = stylex.create({ root: { marginBottom: 8 } });
-   * <Component xstyle={overrides.root} />
-   * ```
-   */
-  xstyle?: StyleXStyles;
-  /**
-   * CSS class name(s) appended to the root element.
-   * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
-   */
-  className?: string;
-  /**
-   * Inline styles to apply to the root element. Spread after StyleX
-   * inline styles, so these values take priority.
-   */
-  style?: React.CSSProperties;
-  /** Test ID. */
-  'data-testid'?: string;
 }
 
 // =============================================================================

--- a/packages/core/src/Typeahead/XDSTypeaheadItem.tsx
+++ b/packages/core/src/Typeahead/XDSTypeaheadItem.tsx
@@ -20,6 +20,7 @@ import {
   typeScaleVars,
 } from '../theme/tokens.stylex';
 import type {XDSSearchableItem} from './types';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import {xdsClassName, mergeProps} from '../utils';
 
 // =============================================================================
@@ -28,7 +29,7 @@ import {xdsClassName, mergeProps} from '../utils';
 
 export interface XDSTypeaheadItemProps<
   T extends XDSSearchableItem = XDSSearchableItem,
-> {
+> extends XDSBaseProps<HTMLDivElement> {
   /**
    * The search result item.
    */


### PR DESCRIPTION
## Summary

  - **New ESLint rule `@xds/require-base-props`** — enforces that all publicly exported `XDS*Props` interfaces extend `XDSBaseProps`, ensuring every public component
  inherits `xstyle`, `data-*`, `aria-*`, and standard HTML attribute support
  - **Migrates 49 component props interfaces** to extend `XDSBaseProps`, removing ~400 lines of duplicate prop declarations (`xstyle`, `className`, `style`, `data-testid`,
   etc.) that are now inherited
  - Rule checks barrel `index.ts` re-exports to distinguish public API from internal types

  ### Exclusions (12 interfaces, 5 categories)

  | Category | Interfaces | Reason |
  |----------|-----------|--------|
  | Self-referential | `XDSBaseProps` | Is the base type itself |
  | SVG | `XDSIconProps`, `XDSSVGIconProps` | Extend `SVGProps`, not HTML |
  | Overlay/layer | `XDSTooltipProps`, `XDSPopoverProps`, `XDSHoverCardProps`, `XDSOverlayProps` | `display: contents` — no root DOM node |
  | System-managed | `XDSToastProps`, `XDSToastViewportProps` | Rendered by toast system |
  | Providers | `XDSLayerProviderProps`, `XDSLinkProviderProps`, `XDSMediaThemeProps` | No DOM element |

  ### Config

  - `strict` (CI/agents): `error`
  - `recommended` (human dev): `warn`

  ## Test plan

  - [x] `npx eslint --rule '@xds/require-base-props: error' packages/core/src/**/*.{ts,tsx}` — 0 violations
  - [x] `tsc --noEmit --project packages/core/tsconfig.build.json` — 0 errors
  - [x] `pnpm test`
  - [x] All lint hooks pass