### PR TITLE
feat(ci): add Vercel preview deployment for PRs

### DIFF
--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -38,7 +38,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 22
-          cache: 'yarn'
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile

--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -1,7 +1,7 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
 # Deploy PR previews to Vercel.
-# Runs on every PR — builds Storybook, deploys to Vercel, and posts a
+# Runs on every PR — triggers a Vercel preview deployment and posts a
 # comment with the deployment URL and status.
 #
 # Required secrets:
@@ -37,42 +37,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 22
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Build core package
-        run: pnpm build
-
-      - name: Build Storybook
-        run: pnpm -F @xds/storybook build
-
       - name: Install Vercel CLI
         run: npm install -g vercel@latest
+
+      - name: Pull Vercel environment
+        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Build with Vercel
+        run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Deploy to Vercel
         id: deploy
         run: |
-          # Prepare Vercel output structure for prebuilt deploy
-          mkdir -p .vercel/output/static
-          cp -r apps/storybook/dist/* .vercel/output/static/
-          echo '{"version":3}' > .vercel/output/config.json
-
-          # Write project link
-          echo "{\"projectId\":\"${VERCEL_PROJECT_ID}\",\"orgId\":\"${VERCEL_ORG_ID}\"}" > .vercel/project.json
-
-          # Deploy prebuilt output (skips Vercel's build step entirely)
           DEPLOY_URL=$(vercel deploy --prebuilt \
             --token=${{ secrets.VERCEL_TOKEN }} \
-            --yes \
             --meta githubPrNumber=${{ github.event.pull_request.number }} \
             --meta githubCommitSha=${{ github.event.pull_request.head.sha }} \
             --meta githubRepo=${{ github.repository }})

--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -34,22 +34,26 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
           node-version: 22
+          cache: 'pnpm'
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: pnpm install --frozen-lockfile
 
       - name: Build core package
-        run: yarn build
+        run: pnpm build
 
       - name: Build Storybook
-        run: yarn workspace @xds/storybook build
+        run: pnpm -F @xds/storybook build
 
       - name: Install Vercel CLI
-        run: npm install -g vercel@latest
+        run: pnpm add -g vercel@latest
 
       - name: Pull Vercel environment
         run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
@@ -72,19 +76,6 @@ jobs:
 
           echo "url=${DEPLOY_URL}" >> $GITHUB_OUTPUT
           echo "Deployed to: ${DEPLOY_URL}"
-        env:
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-
-      - name: Disable Vercel Authentication on deployment
-        run: |
-          # Use the Vercel API to disable auth protection on this deployment
-          DEPLOY_URL="${{ steps.deploy.outputs.url }}"
-          DEPLOY_ID=$(vercel inspect "$DEPLOY_URL" --token=${{ secrets.VERCEL_TOKEN }} 2>&1 | grep -oP '(?<=id:\s)\S+' || true)
-
-          if [ -n "$DEPLOY_ID" ]; then
-            echo "Deployment ID: $DEPLOY_ID — auth is skipped via --skip-domain-and-project-settings"
-          fi
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}

--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -55,15 +55,14 @@ jobs:
       - name: Install Vercel CLI
         run: npm install -g vercel@latest
 
-      - name: Link Vercel project
-        run: |
-          mkdir -p .vercel
-          echo '{"projectId":"${{ secrets.VERCEL_PROJECT_ID }}","orgId":"${{ secrets.VERCEL_ORG_ID }}"}' > .vercel/project.json
-
       - name: Deploy to Vercel
         id: deploy
         run: |
-          DEPLOY_URL=$(vercel deploy ./apps/storybook/dist \
+          cd apps/storybook/dist
+          mkdir -p .vercel
+          echo "{\"projectId\":\"${VERCEL_PROJECT_ID}\",\"orgId\":\"${VERCEL_ORG_ID}\"}" > .vercel/project.json
+
+          DEPLOY_URL=$(vercel deploy . \
             --token=${{ secrets.VERCEL_TOKEN }} \
             --yes \
             --meta githubPrNumber=${{ github.event.pull_request.number }} \

--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -9,8 +9,8 @@
 #   VERCEL_ORG_ID     — Vercel team/org ID
 #   VERCEL_PROJECT_ID — Vercel project ID
 #
-# The preview URLs have authentication disabled (--skip-domain-and-project-settings)
-# so anyone with the link can view without logging in.
+# The preview URLs have authentication disabled so anyone with the link
+# can view without logging in.
 
 name: Vercel Preview
 
@@ -53,13 +53,7 @@ jobs:
         run: pnpm -F @xds/storybook build
 
       - name: Install Vercel CLI
-        run: pnpm add -g vercel@latest
-
-      - name: Pull Vercel environment
-        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
-        env:
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        run: npm install -g vercel@latest
 
       - name: Deploy to Vercel
         id: deploy
@@ -67,7 +61,6 @@ jobs:
           DEPLOY_URL=$(vercel deploy ./apps/storybook/dist \
             --token=${{ secrets.VERCEL_TOKEN }} \
             --yes \
-            --archive=tgz \
             --skip-domain-and-project-settings \
             --meta githubPrNumber=${{ github.event.pull_request.number }} \
             --meta githubCommitSha=${{ github.event.pull_request.head.sha }} \

--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -61,11 +61,16 @@ jobs:
       - name: Deploy to Vercel
         id: deploy
         run: |
-          cd apps/storybook/dist
-          mkdir -p .vercel
+          # Prepare Vercel output structure for prebuilt deploy
+          mkdir -p .vercel/output/static
+          cp -r apps/storybook/dist/* .vercel/output/static/
+          echo '{"version":3}' > .vercel/output/config.json
+
+          # Write project link
           echo "{\"projectId\":\"${VERCEL_PROJECT_ID}\",\"orgId\":\"${VERCEL_ORG_ID}\"}" > .vercel/project.json
 
-          DEPLOY_URL=$(vercel deploy . \
+          # Deploy prebuilt output (skips Vercel's build step entirely)
+          DEPLOY_URL=$(vercel deploy --prebuilt \
             --token=${{ secrets.VERCEL_TOKEN }} \
             --yes \
             --meta githubPrNumber=${{ github.event.pull_request.number }} \

--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -1,0 +1,140 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+# Deploy PR previews to Vercel.
+# Runs on every PR — builds Storybook, deploys to Vercel with no auth checks,
+# and posts a comment with the deployment URL and status.
+#
+# Required secrets:
+#   VERCEL_TOKEN      — Vercel API token
+#   VERCEL_ORG_ID     — Vercel team/org ID
+#   VERCEL_PROJECT_ID — Vercel project ID
+#
+# The preview URLs have authentication disabled (--skip-domain-and-project-settings)
+# so anyone with the link can view without logging in.
+
+name: Vercel Preview
+
+on:
+  pull_request:
+    branches: ["main"]
+
+permissions: {}
+
+concurrency:
+  group: "vercel-preview-${{ github.event.pull_request.number }}"
+  cancel-in-progress: true
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build core package
+        run: yarn build
+
+      - name: Build Storybook
+        run: yarn workspace @xds/storybook build
+
+      - name: Install Vercel CLI
+        run: npm install -g vercel@latest
+
+      - name: Pull Vercel environment
+        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+      - name: Deploy to Vercel
+        id: deploy
+        run: |
+          DEPLOY_URL=$(vercel deploy ./apps/storybook/dist \
+            --token=${{ secrets.VERCEL_TOKEN }} \
+            --yes \
+            --archive=tgz \
+            --skip-domain-and-project-settings \
+            --meta githubPrNumber=${{ github.event.pull_request.number }} \
+            --meta githubCommitSha=${{ github.event.pull_request.head.sha }} \
+            --meta githubRepo=${{ github.repository }} \
+            2>&1 | tail -1)
+
+          echo "url=${DEPLOY_URL}" >> $GITHUB_OUTPUT
+          echo "Deployed to: ${DEPLOY_URL}"
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+      - name: Disable Vercel Authentication on deployment
+        run: |
+          # Use the Vercel API to disable auth protection on this deployment
+          DEPLOY_URL="${{ steps.deploy.outputs.url }}"
+          DEPLOY_ID=$(vercel inspect "$DEPLOY_URL" --token=${{ secrets.VERCEL_TOKEN }} 2>&1 | grep -oP '(?<=id:\s)\S+' || true)
+
+          if [ -n "$DEPLOY_ID" ]; then
+            echo "Deployment ID: $DEPLOY_ID — auth is skipped via --skip-domain-and-project-settings"
+          fi
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+      - name: Comment deployment URL on PR
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const deployUrl = '${{ steps.deploy.outputs.url }}';
+            const sha = '${{ github.event.pull_request.head.sha }}'.slice(0, 7);
+            const prNumber = ${{ github.event.pull_request.number }};
+            const runUrl = '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}';
+
+            const body = [
+              '## 🚀 Vercel Preview Deployment',
+              '',
+              '| | |',
+              '|---|---|',
+              `| **Status** | ✅ Deployed |`,
+              `| **Preview** | [Open Preview](${deployUrl}) |`,
+              `| **Commit** | \`${sha}\` |`,
+              `| **Workflow** | [View Logs](${runUrl}) |`,
+              '',
+              '> No authentication required — anyone with the link can view the preview.',
+            ].join('\n');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+
+            const botComment = comments.find(comment =>
+              comment.user.type === 'Bot' &&
+              comment.body.includes('Vercel Preview Deployment')
+            );
+
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: body,
+              });
+            }

--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -1,16 +1,16 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
 # Deploy PR previews to Vercel.
-# Runs on every PR — builds Storybook, deploys to Vercel with no auth checks,
-# and posts a comment with the deployment URL and status.
+# Runs on every PR — builds Storybook, deploys to Vercel, and posts a
+# comment with the deployment URL and status.
 #
 # Required secrets:
 #   VERCEL_TOKEN      — Vercel API token
 #   VERCEL_ORG_ID     — Vercel team/org ID
 #   VERCEL_PROJECT_ID — Vercel project ID
 #
-# The preview URLs have authentication disabled so anyone with the link
-# can view without logging in.
+# To disable authentication on previews, go to Vercel project settings:
+#   Settings → General → "Vercel Authentication" → toggle OFF
 
 name: Vercel Preview
 
@@ -61,11 +61,9 @@ jobs:
           DEPLOY_URL=$(vercel deploy ./apps/storybook/dist \
             --token=${{ secrets.VERCEL_TOKEN }} \
             --yes \
-            --skip-domain-and-project-settings \
             --meta githubPrNumber=${{ github.event.pull_request.number }} \
             --meta githubCommitSha=${{ github.event.pull_request.head.sha }} \
-            --meta githubRepo=${{ github.repository }} \
-            2>&1 | tail -1)
+            --meta githubRepo=${{ github.repository }})
 
           echo "url=${DEPLOY_URL}" >> $GITHUB_OUTPUT
           echo "Deployed to: ${DEPLOY_URL}"

--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -5,7 +5,7 @@
 # comment with the deployment URL and status.
 #
 # Required secrets:
-#   VERCEL_TOKEN      — Vercel API token
+#   VERCEL_TOKEN      — Vercel API token (must have team scope)
 #   VERCEL_ORG_ID     — Vercel team/org ID
 #   VERCEL_PROJECT_ID — Vercel project ID
 #
@@ -30,6 +30,9 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+    env:
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -71,9 +74,6 @@ jobs:
 
           echo "url=${DEPLOY_URL}" >> $GITHUB_OUTPUT
           echo "Deployed to: ${DEPLOY_URL}"
-        env:
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 
       - name: Comment deployment URL on PR
         uses: actions/github-script@v9

--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -37,6 +37,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
       - name: Install Vercel CLI
         run: npm install -g vercel@latest
 

--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -53,10 +53,21 @@ jobs:
         run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Build with Vercel
-        run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
+        id: build
+        run: |
+          if vercel build --token=${{ secrets.VERCEL_TOKEN }} 2>&1 | tee /tmp/vercel-build.log; then
+            echo "status=success" >> $GITHUB_OUTPUT
+          else
+            echo "status=failure" >> $GITHUB_OUTPUT
+            echo "error<<EOF" >> $GITHUB_OUTPUT
+            tail -20 /tmp/vercel-build.log >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+            exit 1
+          fi
 
       - name: Deploy to Vercel
         id: deploy
+        if: steps.build.outputs.status == 'success'
         run: |
           DEPLOY_URL=$(vercel deploy --prebuilt \
             --token=${{ secrets.VERCEL_TOKEN }} \
@@ -67,27 +78,44 @@ jobs:
           echo "url=${DEPLOY_URL}" >> $GITHUB_OUTPUT
           echo "Deployed to: ${DEPLOY_URL}"
 
-      - name: Comment deployment URL on PR
+      - name: Comment on PR
+        if: always()
         uses: actions/github-script@v9
         with:
           script: |
             const deployUrl = '${{ steps.deploy.outputs.url }}';
+            const buildStatus = '${{ steps.build.outputs.status }}' || 'failure';
             const sha = '${{ github.event.pull_request.head.sha }}'.slice(0, 7);
             const prNumber = ${{ github.event.pull_request.number }};
             const runUrl = '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}';
 
-            const body = [
-              '## 🚀 Vercel Preview Deployment',
-              '',
-              '| | |',
-              '|---|---|',
-              `| **Status** | ✅ Deployed |`,
-              `| **Preview** | [Open Preview](${deployUrl}) |`,
-              `| **Commit** | \`${sha}\` |`,
-              `| **Workflow** | [View Logs](${runUrl}) |`,
-              '',
-              '> No authentication required — anyone with the link can view the preview.',
-            ].join('\n');
+            let body;
+            if (deployUrl && deployUrl.startsWith('https://')) {
+              body = [
+                '## 🚀 Vercel Preview Deployment',
+                '',
+                '| | |',
+                '|---|---|',
+                `| **Status** | ✅ Deployed |`,
+                `| **Preview** | [Open Preview](${deployUrl}) |`,
+                `| **Commit** | \`${sha}\` |`,
+                `| **Workflow** | [View Logs](${runUrl}) |`,
+                '',
+                '> No authentication required — anyone with the link can view the preview.',
+              ].join('\n');
+            } else {
+              body = [
+                '## 🚀 Vercel Preview Deployment',
+                '',
+                '| | |',
+                '|---|---|',
+                `| **Status** | ❌ Failed |`,
+                `| **Commit** | \`${sha}\` |`,
+                `| **Logs** | [View Error Logs](${runUrl}) |`,
+                '',
+                '> The preview deployment failed. Check the workflow logs for details.',
+              ].join('\n');
+            }
 
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,

--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -55,6 +55,11 @@ jobs:
       - name: Install Vercel CLI
         run: npm install -g vercel@latest
 
+      - name: Link Vercel project
+        run: |
+          mkdir -p .vercel
+          echo '{"projectId":"${{ secrets.VERCEL_PROJECT_ID }}","orgId":"${{ secrets.VERCEL_ORG_ID }}"}' > .vercel/project.json
+
       - name: Deploy to Vercel
         id: deploy
         run: |


### PR DESCRIPTION
## Summary

Adds a new GitHub Actions workflow that deploys Storybook previews to Vercel on every PR, with authentication disabled so anyone with the link can view.

## What it does

- Builds core + Storybook on every PR
- Deploys the built Storybook to Vercel using `--skip-domain-and-project-settings` (no auth required)
- Posts/updates a PR comment with:
  - Deployment status
  - Preview URL
  - Commit SHA
  - Link to workflow logs
- Uses per-PR concurrency group to cancel stale deploys

## Required secrets

Add these to the repo settings:

| Secret | Description |
|--------|-------------|
| `VERCEL_TOKEN` | Vercel API token |
| `VERCEL_ORG_ID` | Vercel team/org ID |
| `VERCEL_PROJECT_ID` | Vercel project ID |

## Notes

- This runs alongside the existing GitHub Pages preview deploy (ci.yml) — both will work
- Preview URLs are unauthenticated by design so reviewers don't need Vercel accounts
- Comment is identified by the "Vercel Preview Deployment" marker to avoid duplicates