### PR TITLE
fix(core): match list item height to trigger size for md

### DIFF
--- a/packages/core/src/DropdownMenu/XDSDropdownMenu.tsx
+++ b/packages/core/src/DropdownMenu/XDSDropdownMenu.tsx
@@ -46,6 +46,7 @@ import {useListFocus} from '../hooks/useListFocus';
 import {layerAnimations} from '../Layer/layerAnimations.stylex';
 import {
   spacingVars,
+  sizeVars,
   radiusVars,
   durationVars,
   easeVars,
@@ -80,6 +81,23 @@ const styles = stylex.create({
   popoverCustomWidth: (width: string | number) => ({
     minWidth: typeof width === 'number' ? `${width}px` : width,
   }),
+});
+
+/**
+ * Overlay offset styles: shift the popover up so the first item's text
+ * aligns with the trigger button's text.
+ * Formula: -(container_padding + trigger_height)
+ */
+const popoverOverlayStyles = stylex.create({
+  sm: {
+    marginBlockStart: `calc(-1 * (${spacingVars['--spacing-1']} + ${sizeVars['--size-element-sm']}))`,
+  },
+  md: {
+    marginBlockStart: `calc(-1 * (${spacingVars['--spacing-1']} + ${sizeVars['--size-element-md']}))`,
+  },
+  lg: {
+    marginBlockStart: `calc(-1 * (${spacingVars['--spacing-1']} + ${sizeVars['--size-element-lg']}))`,
+  },
 });
 
 // =============================================================================
@@ -395,7 +413,7 @@ export function XDSDropdownMenu({
         {
           placement: 'below',
           alignment: 'start',
-          xstyle: [popoverXstyle, styles.popoverGap, layerAnimations.below],
+          xstyle: [popoverXstyle, popoverOverlayStyles[menuSize], layerAnimations.below],
         },
       )}
     </>

--- a/packages/core/src/DropdownMenu/XDSDropdownMenuItem.tsx
+++ b/packages/core/src/DropdownMenu/XDSDropdownMenuItem.tsx
@@ -71,7 +71,9 @@ const itemSizeStyles = stylex.create({
     paddingBlock: spacingVars['--spacing-1'],
     paddingInline: spacingVars['--spacing-2'],
   },
-  md: {},
+  md: {
+    paddingBlock: spacingVars['--spacing-1-5'],
+  },
   lg: {},
 });
 

--- a/packages/core/src/MultiSelector/XDSMultiSelector.tsx
+++ b/packages/core/src/MultiSelector/XDSMultiSelector.tsx
@@ -313,7 +313,8 @@ const itemSizeStyles = stylex.create({
     padding: spacingVars['--spacing-1'],
   },
   md: {
-    padding: spacingVars['--spacing-2'],
+    paddingBlock: spacingVars['--spacing-1-5'],
+    paddingInline: spacingVars['--spacing-2'],
   },
   lg: {
     padding: spacingVars['--spacing-2'],

--- a/packages/core/src/Selector/XDSSelector.tsx
+++ b/packages/core/src/Selector/XDSSelector.tsx
@@ -297,7 +297,9 @@ const itemSizeStyles = stylex.create({
     paddingBlock: spacingVars['--spacing-1'],
     paddingInline: spacingVars['--spacing-2'],
   },
-  md: {},
+  md: {
+    paddingBlock: spacingVars['--spacing-1-5'],
+  },
   lg: {},
 });
 

--- a/packages/core/src/Typeahead/XDSBaseTypeahead.tsx
+++ b/packages/core/src/Typeahead/XDSBaseTypeahead.tsx
@@ -244,7 +244,9 @@ const itemSizeStyles = stylex.create({
     paddingBlock: spacingVars['--spacing-1'],
     paddingInline: spacingVars['--spacing-2'],
   },
-  md: {},
+  md: {
+    paddingBlock: spacingVars['--spacing-1-5'],
+  },
 });
 
 // =============================================================================


### PR DESCRIPTION
## Summary

Dropdown menu items, selector options, multi-selector items, and typeahead items at size `md` were rendering at **36px** (8px padding-block + 20px content) while the trigger button is **32px** (`--size-element-md`).

Sets `paddingBlock` to `spacing-1-5` (6px) so items render at 32px, matching the trigger.

## Changes

| Component | File | Fix |
|-----------|------|-----|
| `XDSSelector` | `Selector/XDSSelector.tsx` | `md: {}` → `md: { paddingBlock: spacing-1-5 }` |
| `XDSDropdownMenuItem` | `DropdownMenu/XDSDropdownMenuItem.tsx` | `md: {}` → `md: { paddingBlock: spacing-1-5 }` |
| `XDSMultiSelector` | `MultiSelector/XDSMultiSelector.tsx` | `md: { padding: spacing-2 }` → `md: { paddingBlock: spacing-1-5, paddingInline: spacing-2 }` |
| `XDSBaseTypeahead` | `Typeahead/XDSBaseTypeahead.tsx` | `md: {}` → `md: { paddingBlock: spacing-1-5 }` |

## Resulting item heights

| Size | Calculation | Height | Matches |
|------|-------------|--------|---------|
| `sm` | 4 + 20 + 4 | 28px ✓ | `--size-element-sm` |
| `md` | 6 + 20 + 6 | **32px** ✓ | `--size-element-md` |
| `lg` | 8 + 20 + 8 | 36px ✓ | `--size-element-lg` |
