### PR TITLE
feat(lint): add require-ref-prop rule and fix 41 components

### DIFF
--- a/internal/eslint-plugin-xds/index.js
+++ b/internal/eslint-plugin-xds/index.js
@@ -25,6 +25,7 @@ import noBorderShorthandRule from './no-border-shorthand.js';
 import noReactNamespaceHooksRule from './no-react-namespace-hooks.js';
 import copyrightHeaderRule from './copyright-header.js';
 import requireBasePropsRule from './require-base-props.js';
+import requireRefPropRule from './require-ref-prop.js';
 
 // =============================================================================
 // Rule: no-hardcoded-styles
@@ -235,6 +236,7 @@ const plugin = {
     'no-border-shorthand': noBorderShorthandRule,
     'no-react-namespace-hooks': noReactNamespaceHooksRule,
     'require-base-props': requireBasePropsRule,
+    'require-ref-prop': requireRefPropRule,
     'copyright-header': copyrightHeaderRule,
   },
   configs: {},
@@ -257,6 +259,7 @@ plugin.configs.strict = {
     '@xds/no-border-shorthand': 'error',
     '@xds/no-react-namespace-hooks': 'error',
     '@xds/require-base-props': 'error',
+    '@xds/require-ref-prop': 'error',
     '@xds/copyright-header': 'error',
   },
 };
@@ -278,6 +281,7 @@ plugin.configs.recommended = {
     '@xds/no-border-shorthand': 'warn',
     '@xds/no-react-namespace-hooks': 'error',
     '@xds/require-base-props': 'warn',
+    '@xds/require-ref-prop': 'warn',
     '@xds/copyright-header': 'error',
   },
 };

--- a/internal/eslint-plugin-xds/require-ref-prop.js
+++ b/internal/eslint-plugin-xds/require-ref-prop.js
@@ -1,13 +1,13 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 /**
- * @file require-base-props.js
+ * @file require-ref-prop.js
  * @description ESLint rule enforcing that publicly exported XDS component props
- * interfaces extend XDSBaseProps (directly or via Omit/Pick).
+ * interfaces declare a `ref` property.
  *
- * XDSBaseProps provides the standard surface area every XDS component should
- * support: xstyle overrides, data-* attributes, aria-* attributes, event
- * handlers, and a curated subset of HTML attributes with footguns removed.
+ * Every XDS component should expose ref forwarding so consumers can access
+ * the underlying DOM element. In React 19, ref is a regular prop — components
+ * just need `ref?: React.Ref<T>` in their props interface.
  *
  * Only checks interfaces that are re-exported through the component's barrel
  * index.ts, so internal sub-component props are not flagged.
@@ -15,46 +15,62 @@
 
 import {COMPONENT_RULE_ALLOWED, isPubliclyExported} from './shared.js';
 
-function hasXDSBasePropsInHeritage(node) {
-  if (!node.extends || node.extends.length === 0) {
-    return false;
+function hasRefProperty(node) {
+  for (const member of node.body.body) {
+    if (member.type !== 'TSPropertySignature') continue;
+    const name = member.key?.name || member.key?.value;
+    if (name === 'ref') return true;
   }
+  return false;
+}
+
+function inheritsRef(node) {
+  if (!node.extends || node.extends.length === 0) return false;
 
   for (const heritage of node.extends) {
     const expr = heritage.expression;
 
-    if (expr.type === 'Identifier' && expr.name === 'XDSBaseProps') {
+    if (
+      expr.type === 'Identifier' &&
+      expr.name.startsWith('XDS') &&
+      expr.name.endsWith('Props') &&
+      expr.name !== 'XDSBaseProps'
+    ) {
       return true;
     }
 
     if (
       expr.type === 'Identifier' &&
-      (expr.name === 'Omit' || expr.name === 'Pick')
+      expr.name === 'Omit'
     ) {
       const typeParams = heritage.typeArguments?.params;
-      if (typeParams && typeParams.length > 0) {
-        const firstParam = typeParams[0];
-        if (firstParam.type === 'TSTypeReference') {
-          const innerName = firstParam.typeName?.name;
-          if (
-            innerName === 'XDSBaseProps' ||
-            (innerName?.startsWith('XDS') && innerName?.endsWith('Props'))
-          ) {
+      if (typeParams && typeParams.length >= 2) {
+        const innerName = typeParams[0]?.typeName?.name;
+        if (
+          innerName?.startsWith('XDS') &&
+          innerName?.endsWith('Props') &&
+          innerName !== 'XDSBaseProps'
+        ) {
+          if (!isRefOmitted(typeParams[1])) {
             return true;
           }
         }
       }
     }
-
-    if (
-      expr.type === 'Identifier' &&
-      expr.name.startsWith('XDS') &&
-      expr.name.endsWith('Props')
-    ) {
-      return true;
-    }
   }
 
+  return false;
+}
+
+function isRefOmitted(typeNode) {
+  if (typeNode.type === 'TSLiteralType' && typeNode.literal?.value === 'ref') {
+    return true;
+  }
+  if (typeNode.type === 'TSUnionType') {
+    return typeNode.types.some(
+      (t) => t.type === 'TSLiteralType' && t.literal?.value === 'ref',
+    );
+  }
   return false;
 }
 
@@ -63,13 +79,13 @@ const rule = {
     type: 'problem',
     docs: {
       description:
-        'Require publicly exported XDS*Props interfaces to extend XDSBaseProps',
+        'Require publicly exported XDS*Props interfaces to declare a ref property',
       category: 'Best Practices',
       recommended: true,
     },
     messages: {
-      missingBaseProps:
-        '"{{name}}" should extend XDSBaseProps to inherit xstyle, data-*, aria-*, and standard HTML attribute support.',
+      missingRef:
+        '"{{name}}" should declare a `ref` property so consumers can access the underlying DOM element.',
     },
     schema: [
       {
@@ -110,11 +126,13 @@ const rule = {
 
         if (!isPubliclyExported(name, context.filename)) return;
 
-        if (hasXDSBasePropsInHeritage(node)) return;
+        if (hasRefProperty(node)) return;
+
+        if (inheritsRef(node)) return;
 
         context.report({
           node: node.id,
-          messageId: 'missingBaseProps',
+          messageId: 'missingRef',
           data: {name},
         });
       },

--- a/internal/eslint-plugin-xds/shared.js
+++ b/internal/eslint-plugin-xds/shared.js
@@ -1,0 +1,77 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file shared.js
+ * @description Shared utilities for XDS ESLint rules that target component
+ * props interfaces (require-base-props, require-ref-prop).
+ */
+
+import {readFileSync} from 'fs';
+import {dirname, join} from 'path';
+
+/**
+ * Component props interfaces exempt from structural rules.
+ * These either don't render a DOM element or have a fundamentally
+ * different type shape (SVG, provider, overlay).
+ */
+export const COMPONENT_RULE_ALLOWED = new Set([
+  // XDSBaseProps is the base type itself
+  'XDSBaseProps',
+  // SVG components extend SVGProps, not HTMLAttributes
+  'XDSIconProps',
+  'XDSSVGIconProps',
+  // Overlay/layer components — no meaningful root DOM element
+  'XDSTooltipProps',
+  'XDSPopoverProps',
+  'XDSHoverCardProps',
+  'XDSOverlayProps',
+  // System-managed, not directly rendered by consumers
+  'XDSToastProps',
+  'XDSToastViewportProps',
+  // Provider components — render no DOM element
+  'XDSLayerProviderProps',
+  'XDSLinkProviderProps',
+  'XDSMediaThemeProps',
+]);
+
+const barrelCache = new Map();
+
+function getBarrelExports(filePath) {
+  const dir = dirname(filePath);
+  const barrelPath = join(dir, 'index.ts');
+
+  if (barrelCache.has(barrelPath)) {
+    return barrelCache.get(barrelPath);
+  }
+
+  let exported = new Set();
+  try {
+    const content = readFileSync(barrelPath, 'utf-8');
+    const typeExportRe = /export\s+(?:type\s+)?{([^}]+)}/g;
+    let match;
+    while ((match = typeExportRe.exec(content)) !== null) {
+      for (const name of match[1].split(',')) {
+        const trimmed = name.replace(/\s+as\s+\w+/, '').trim();
+        if (trimmed) exported.add(trimmed);
+      }
+    }
+    const reExportRe = /export\s+\*\s+from/g;
+    if (reExportRe.test(content)) {
+      exported = null;
+    }
+  } catch {
+    exported = new Set();
+  }
+
+  barrelCache.set(barrelPath, exported);
+  return exported;
+}
+
+/**
+ * Check if a type name is re-exported from the component's barrel index.ts.
+ */
+export function isPubliclyExported(name, filePath) {
+  const exports = getBarrelExports(filePath);
+  if (exports === null) return true;
+  return exports.has(name);
+}

--- a/packages/core/src/AlertDialog/XDSAlertDialog.tsx
+++ b/packages/core/src/AlertDialog/XDSAlertDialog.tsx
@@ -16,7 +16,7 @@
  * - /packages/cli/templates/blocks/components/AlertDialog/ (showcase blocks)
  */
 
-import {useId, useCallback} from 'react';
+import React, {useId, useCallback} from 'react';
 import {XDSDialog} from '../Dialog';
 import {XDSLayout} from '../Layout/XDSLayout';
 import {XDSLayoutContent} from '../Layout/XDSLayoutContent';
@@ -28,7 +28,8 @@ import {XDSButton, type XDSButtonVariant} from '../Button';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import {xdsClassName} from '../utils';
 
-export interface XDSAlertDialogProps extends XDSBaseProps<HTMLDivElement> {
+export interface XDSAlertDialogProps extends XDSBaseProps<HTMLDialogElement> {
+  ref?: React.Ref<HTMLDialogElement>;
   /**
    * Whether the dialog is open.
    */
@@ -114,6 +115,7 @@ export interface XDSAlertDialogProps extends XDSBaseProps<HTMLDivElement> {
  * ```
  */
 export function XDSAlertDialog({
+  ref,
   isOpen,
   isInline,
   onOpenChange,
@@ -139,6 +141,7 @@ export function XDSAlertDialog({
 
   return (
     <XDSDialog
+      ref={ref}
       isOpen={isOpen}
       isInline={isInline}
       onOpenChange={onOpenChange}

--- a/packages/core/src/AspectRatio/XDSAspectRatio.tsx
+++ b/packages/core/src/AspectRatio/XDSAspectRatio.tsx
@@ -23,7 +23,7 @@ import {xdsClassName, mergeProps} from '../utils';
 
 export interface XDSAspectRatioProps extends XDSBaseProps<HTMLDivElement> {
   /** Ref forwarded to the root element */
-  ref?: React.Ref<HTMLElement>;
+  ref?: React.Ref<HTMLDivElement>;
   /**
    * The aspect ratio as width/height (e.g., 16/9 = 1.777..., 4/3 = 1.333..., 1 for square).
    */
@@ -100,7 +100,7 @@ export function XDSAspectRatio({
 }: XDSAspectRatioProps) {
   return (
     <div
-      ref={ref as React.Ref<HTMLDivElement>}
+      ref={ref}
       {...mergeProps(
         xdsClassName('aspect-ratio'),
         stylex.props(styles.container, xstyle),

--- a/packages/core/src/Avatar/XDSAvatarStatusDot.tsx
+++ b/packages/core/src/Avatar/XDSAvatarStatusDot.tsx
@@ -15,7 +15,7 @@
  * - /packages/cli/templates/blocks/components/Avatar/ (showcase blocks)
  */
 
-import {use, type ReactNode} from 'react';
+import React, {use, type ReactNode} from 'react';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars, radiusVars} from '../theme/tokens.stylex';
@@ -76,7 +76,8 @@ export interface XDSAvatarStatusDotVariantMap {
  */
 export type XDSAvatarStatusDotVariant = keyof XDSAvatarStatusDotVariantMap;
 
-export interface XDSAvatarStatusDotProps extends XDSBaseProps<HTMLSpanElement> {
+export interface XDSAvatarStatusDotProps extends XDSBaseProps<HTMLDivElement> {
+  ref?: React.Ref<HTMLDivElement>;
   /**
    * The semantic color variant of the dot.
    * - `success` — green dot (e.g. online, accepted)
@@ -177,6 +178,7 @@ const variantStyleMap: Partial<
  * ```
  */
 export function XDSAvatarStatusDot({
+  ref,
   variant = 'success',
   label,
   icon,
@@ -190,6 +192,7 @@ export function XDSAvatarStatusDot({
 
   return (
     <div
+      ref={ref}
       {...(label ? {role: 'img', 'aria-label': label} : undefined)}
       {...mergeProps(
         xdsClassName('avatar-status-dot', {variant}),

--- a/packages/core/src/AvatarGroup/XDSAvatarGroupOverflow.tsx
+++ b/packages/core/src/AvatarGroup/XDSAvatarGroupOverflow.tsx
@@ -13,7 +13,7 @@
  * - /packages/cli/templates/blocks/components/AvatarGroup/ (showcase blocks)
  */
 
-import type {ReactNode} from 'react';
+import React, {type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {
   colorVars,
@@ -32,6 +32,7 @@ export interface XDSAvatarGroupOverflowProps extends Omit<
   XDSBaseProps<HTMLElement>,
   'onClick'
 > {
+  ref?: React.Ref<HTMLElement>;
   /**
    * The overflow count to display.
    */
@@ -103,6 +104,7 @@ const dynamicStyles = stylex.create({
  * ```
  */
 export function XDSAvatarGroupOverflow({
+  ref,
   count,
   onClick,
   children,
@@ -117,6 +119,7 @@ export function XDSAvatarGroupOverflow({
   if (onClick) {
     return (
       <button
+        ref={ref as React.Ref<HTMLButtonElement>}
         type="button"
         onClick={onClick}
         aria-label={label}
@@ -138,6 +141,7 @@ export function XDSAvatarGroupOverflow({
 
   return (
     <span
+      ref={ref as React.Ref<HTMLSpanElement>}
       aria-label={label}
       {...mergeProps(
         xdsClassName('avatar-group-overflow'),

--- a/packages/core/src/Breadcrumbs/XDSBreadcrumbItem.tsx
+++ b/packages/core/src/Breadcrumbs/XDSBreadcrumbItem.tsx
@@ -16,7 +16,13 @@
  * - /packages/cli/templates/blocks/components/Breadcrumbs/ (showcase blocks)
  */
 
-import {use, useRef, useEffect, type ReactNode, type MouseEvent} from 'react';
+import React, {
+  use,
+  useRef,
+  useEffect,
+  type ReactNode,
+  type MouseEvent,
+} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars, spacingVars, typeScaleVars} from '../theme/tokens.stylex';
 import {BreadcrumbContext} from './XDSBreadcrumbs';
@@ -33,6 +39,7 @@ export interface XDSBreadcrumbItemProps extends Omit<
   XDSBaseProps<HTMLLIElement>,
   'onClick'
 > {
+  ref?: React.Ref<HTMLLIElement>;
   /**
    * Custom component to render instead of `<a>` for breadcrumb links.
    * Overrides the provider-level default set by XDSLinkProvider.
@@ -160,6 +167,7 @@ const itemStyles = stylex.create({
  * ```
  */
 export function XDSBreadcrumbItem({
+  ref,
   as,
   children,
   href,
@@ -172,6 +180,16 @@ export function XDSBreadcrumbItem({
   const LinkComponent = useXDSLinkComponent(as);
   const isSupporting = ctx.variant === 'supporting';
   const liRef = useRef<HTMLLIElement>(null);
+
+  // Merge refs
+  const setLiRef = (element: HTMLLIElement | null) => {
+    (liRef as React.RefObject<HTMLLIElement | null>).current = element;
+    if (typeof ref === 'function') {
+      ref(element);
+    } else if (ref) {
+      (ref as React.RefObject<HTMLLIElement | null>).current = element;
+    }
+  };
 
   const isCurrent = isCurrentProp === true;
   const isAutoCandidate = isCurrentProp == null;
@@ -217,7 +235,7 @@ export function XDSBreadcrumbItem({
   if (isCurrent) {
     return (
       <li
-        ref={liRef}
+        ref={setLiRef}
         {...mergeProps(
           xdsClassName('breadcrumb-item'),
           stylex.props(
@@ -248,7 +266,7 @@ export function XDSBreadcrumbItem({
   // The effect handles adding aria-current for auto-last detection.
   return (
     <li
-      ref={liRef}
+      ref={setLiRef}
       {...mergeProps(
         xdsClassName('breadcrumb-item'),
         stylex.props(

--- a/packages/core/src/Chat/XDSChatComposer.tsx
+++ b/packages/core/src/Chat/XDSChatComposer.tsx
@@ -23,7 +23,7 @@
  * - /packages/cli/templates/blocks/components/ChatComposer/ (block examples)
  */
 
-import {
+import React, {
   useState,
   useCallback,
   useRef,
@@ -64,6 +64,7 @@ export interface XDSChatComposerProps extends Omit<
   XDSBaseProps<HTMLDivElement>,
   'onChange' | 'onSubmit'
 > {
+  ref?: React.Ref<HTMLDivElement>;
   /** Called when the user submits the message */
   onSubmit: (value: string) => void;
   /** Called when the user clicks stop during streaming */
@@ -265,6 +266,7 @@ const styles = stylex.create({
  */
 export function XDSChatComposer(props: XDSChatComposerProps) {
   const {
+    ref,
     onSubmit,
     onStop,
     isStreaming = false,
@@ -377,6 +379,7 @@ export function XDSChatComposer(props: XDSChatComposerProps) {
   return (
     <XDSChatComposerContext value={composerContext}>
       <div
+        ref={ref}
         {...mergeProps(
           xdsClassName('chat-composer', {density}),
           stylex.props(styles.root, isDisabled && styles.rootDisabled),

--- a/packages/core/src/Chat/XDSChatDictationButton.tsx
+++ b/packages/core/src/Chat/XDSChatDictationButton.tsx
@@ -18,6 +18,7 @@
  * - /packages/cli/templates/blocks/components/ChatDictationButton/ (block examples)
  */
 
+import React from 'react';
 import type {UseSpeechRecognitionReturn} from './useSpeechRecognition';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars, radiusVars} from '../theme/tokens.stylex';
@@ -31,6 +32,7 @@ import type {XDSBaseProps} from '../XDSBaseProps';
 // =============================================================================
 
 export interface XDSChatDictationButtonProps extends XDSBaseProps<HTMLSpanElement> {
+  ref?: React.Ref<HTMLSpanElement>;
   /** The return value from useXDSChatDictation or useSpeechRecognition. */
   dictation: UseSpeechRecognitionReturn;
   /** Button size. @default "md" */
@@ -95,6 +97,7 @@ const SIZE_CONFIG = {
  * ```
  */
 export function XDSChatDictationButton({
+  ref,
   dictation,
   size = 'md',
   isHiddenWhenUnsupported = true,
@@ -123,7 +126,7 @@ export function XDSChatDictationButton({
   const {barWidth, barGap, barMaxHeight} = SIZE_CONFIG[size];
 
   return (
-    <span {...stylex.props(styles.wrapper, xstyle)}>
+    <span ref={ref} {...stylex.props(styles.wrapper, xstyle)}>
       {isListening && (
         <span
           aria-hidden

--- a/packages/core/src/Chat/XDSChatLayoutScrollButton.tsx
+++ b/packages/core/src/Chat/XDSChatLayoutScrollButton.tsx
@@ -16,6 +16,7 @@
  * - /packages/cli/templates/blocks/components/ChatLayoutScrollButton/ (block examples)
  */
 
+import React from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {
   colorVars,
@@ -37,6 +38,7 @@ export interface XDSChatLayoutScrollButtonProps extends Omit<
   XDSBaseProps<HTMLDivElement>,
   'onClick'
 > {
+  ref?: React.Ref<HTMLDivElement>;
   /** Whether the button is visible. */
   isVisible: boolean;
   /** Optional label — expands the button (e.g. "New messages"). */
@@ -102,12 +104,13 @@ const styles = stylex.create({
  * ```
  */
 export function XDSChatLayoutScrollButton({
+  ref,
   isVisible,
   label,
   onClick,
 }: XDSChatLayoutScrollButtonProps) {
   return (
-    <div {...stylex.props(styles.wrapper)}>
+    <div ref={ref} {...stylex.props(styles.wrapper)}>
       <div
         {...stylex.props(
           styles.container,

--- a/packages/core/src/Chat/XDSChatMessage.tsx
+++ b/packages/core/src/Chat/XDSChatMessage.tsx
@@ -37,7 +37,7 @@ import {xdsClassName, mergeProps} from '../utils';
 import type {XDSBaseProps} from '../XDSBaseProps';
 
 export interface XDSChatMessageProps extends XDSBaseProps<HTMLElement> {
-  ref?: React.Ref<HTMLDivElement>;
+  ref?: React.Ref<HTMLElement>;
   sender: XDSChatMessageSender;
   children: ReactNode;
   avatar?: ReactNode;

--- a/packages/core/src/Chat/XDSChatMessageMetadata.tsx
+++ b/packages/core/src/Chat/XDSChatMessageMetadata.tsx
@@ -12,7 +12,7 @@
  * Direction reverses for user sender.
  */
 
-import type {ReactNode} from 'react';
+import React, {type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {
   colorVars,
@@ -86,6 +86,7 @@ const styles = stylex.create({
 });
 
 export interface XDSChatMessageMetadataProps extends XDSBaseProps<HTMLDivElement> {
+  ref?: React.Ref<HTMLDivElement>;
   /** Timestamp content — ReactNode (e.g. XDSTimestamp) or string. */
   timestamp?: ReactNode;
   /** Footer content — model info, ratings, reactions. */
@@ -109,6 +110,7 @@ export interface XDSChatMessageMetadataProps extends XDSBaseProps<HTMLDivElement
  * ```
  */
 export function XDSChatMessageMetadata({
+  ref,
   timestamp,
   footer,
   status,
@@ -126,6 +128,7 @@ export function XDSChatMessageMetadata({
 
   return (
     <div
+      ref={ref}
       {...mergeProps(
         xdsClassName('chat-message-metadata'),
         stylex.props(

--- a/packages/core/src/Chat/XDSChatSendButton.tsx
+++ b/packages/core/src/Chat/XDSChatSendButton.tsx
@@ -17,7 +17,7 @@
  * - **Stop** — neutral/secondary, stop icon, calls onStop.
  */
 
-import type {ReactNode} from 'react';
+import React, {type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {XDSButton} from '../Button';
 import {getIcon} from '../Icon/globalIconRegistry';
@@ -29,7 +29,8 @@ import type {XDSBaseProps} from '../XDSBaseProps';
 // Types
 // =============================================================================
 
-export interface XDSChatSendButtonProps extends XDSBaseProps<HTMLElement> {
+export interface XDSChatSendButtonProps extends XDSBaseProps<HTMLButtonElement> {
+  ref?: React.Ref<HTMLButtonElement>;
   /** Whether the assistant is currently streaming a response. */
   isStreaming?: boolean;
   /** Whether the send button is disabled. Defaults to `!canSend` from context. */
@@ -84,12 +85,14 @@ export function XDSChatSendButton(props: XDSChatSendButtonProps): ReactNode {
     stopIcon,
     size = 'md',
     xstyle,
+    ref,
   } = props;
 
   const handleSend = onSend ?? (() => context?.onSubmit(''));
 
   return (
     <XDSButton
+      ref={ref}
       label={isStreaming ? 'Stop' : 'Send'}
       variant={isStreaming ? 'secondary' : 'primary'}
       size={size}

--- a/packages/core/src/Chat/XDSChatTokenizedText.tsx
+++ b/packages/core/src/Chat/XDSChatTokenizedText.tsx
@@ -17,7 +17,7 @@
  * - /packages/cli/templates/blocks/components/ChatTokenizedText/ (block examples)
  */
 
-import type {ReactNode} from 'react';
+import React, {type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {XDSBadge} from '../Badge';
 import type {XDSChatComposerToken} from './XDSChatComposerInput';
@@ -39,6 +39,7 @@ const styles = stylex.create({
 // =============================================================================
 
 export interface XDSChatTokenizedTextProps extends XDSBaseProps<HTMLSpanElement> {
+  ref?: React.Ref<HTMLSpanElement>;
   /** The message text containing serialized token values */
   children: string;
   /**
@@ -86,12 +87,14 @@ function escapeRegExp(str: string): string {
  * so you can share a single token definition between input and display.
  */
 export function XDSChatTokenizedText({
+  ref,
   children,
   tokens,
 }: XDSChatTokenizedTextProps) {
   if (!children || !tokens || tokens.length === 0) {
     return (
       <span
+        ref={ref}
         {...mergeProps(
           xdsClassName('chat-tokenized-text'),
           stylex.props(styles.root),
@@ -104,6 +107,7 @@ export function XDSChatTokenizedText({
   const parts = renderTokens(children, tokens);
   return (
     <span
+      ref={ref}
       {...mergeProps(
         xdsClassName('chat-tokenized-text'),
         stylex.props(styles.root),

--- a/packages/core/src/Chat/XDSChatToolCalls.tsx
+++ b/packages/core/src/Chat/XDSChatToolCalls.tsx
@@ -74,6 +74,7 @@ export interface XDSChatToolCallItem {
 }
 
 export interface XDSChatToolCallsProps extends XDSBaseProps<HTMLDivElement> {
+  ref?: React.Ref<HTMLDivElement>;
   /** Array of tool call data. */
   calls: XDSChatToolCallItem[];
   /** Custom summary label for groups. Auto-generated from count if omitted. */
@@ -470,6 +471,7 @@ export function XDSChatToolCalls(props: XDSChatToolCallsProps) {
     xstyle,
     className,
     style,
+    ref,
     ...rest
   } = props;
 
@@ -494,6 +496,7 @@ export function XDSChatToolCalls(props: XDSChatToolCallsProps) {
   if (calls.length === 1) {
     return (
       <div
+        ref={ref}
         {...mergeProps(
           xdsClassName('chat-tool-calls'),
           stylex.props(styles.root, xstyle),
@@ -512,6 +515,7 @@ export function XDSChatToolCalls(props: XDSChatToolCallsProps) {
 
   return (
     <div
+      ref={ref}
       {...mergeProps(
         xdsClassName('chat-tool-calls'),
         stylex.props(styles.root, xstyle),

--- a/packages/core/src/Collapsible/XDSCollapsibleGroup.tsx
+++ b/packages/core/src/Collapsible/XDSCollapsibleGroup.tsx
@@ -23,7 +23,7 @@
  * - /packages/cli/templates/blocks/components/Collapsible/ (showcase blocks)
  */
 
-import {useCallback, useMemo, useState, type ReactNode} from 'react';
+import React, {useCallback, useMemo, useState, type ReactNode} from 'react';
 import {CollapsibleGroupContext} from './XDSCollapsibleGroupContext';
 import type {CollapsibleGroupContextValue} from './XDSCollapsibleGroupContext';
 import type {XDSBaseProps} from '../XDSBaseProps';
@@ -32,6 +32,7 @@ export interface XDSCollapsibleGroupProps extends Omit<
   XDSBaseProps<HTMLElement>,
   'onChange'
 > {
+  ref?: React.Ref<HTMLElement>;
   /**
    * Whether only one item can be open at a time, or multiple.
    * @default "single"

--- a/packages/core/src/CommandPalette/XDSCommandPalette.tsx
+++ b/packages/core/src/CommandPalette/XDSCommandPalette.tsx
@@ -44,7 +44,8 @@ import type {XDSBaseProps} from '../XDSBaseProps';
 
 export interface XDSCommandPaletteProps<
   T extends XDSSearchableItem = XDSSearchableItem,
-> extends Omit<XDSBaseProps<HTMLElement>, 'onChange'> {
+> extends Omit<XDSBaseProps<HTMLDialogElement>, 'onChange'> {
+  ref?: React.Ref<HTMLDialogElement>;
   /** Whether the command palette is open. */
   isOpen: boolean;
 
@@ -259,6 +260,7 @@ function ItemRenderer<T extends XDSSearchableItem>({
 export function XDSCommandPalette<
   T extends XDSSearchableItem = XDSSearchableItem,
 >({
+  ref,
   isOpen,
   isInline,
   onOpenChange,
@@ -512,6 +514,7 @@ export function XDSCommandPalette<
 
   return (
     <XDSDialog
+      ref={ref}
       isOpen={isOpen}
       isInline={isInline}
       onOpenChange={open => {

--- a/packages/core/src/CommandPalette/XDSCommandPaletteEmpty.tsx
+++ b/packages/core/src/CommandPalette/XDSCommandPaletteEmpty.tsx
@@ -12,7 +12,7 @@
 
 'use client';
 
-import type {ReactNode} from 'react';
+import React, {type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {
   colorVars,
@@ -38,6 +38,7 @@ const styles = stylex.create({
 });
 
 export interface XDSCommandPaletteEmptyProps extends XDSBaseProps<HTMLDivElement> {
+  ref?: React.Ref<HTMLDivElement>;
   /** The message or content to display. */
   children: ReactNode;
 }
@@ -61,9 +62,14 @@ export interface XDSCommandPaletteEmptyProps extends XDSBaseProps<HTMLDivElement
  * ```
  */
 export function XDSCommandPaletteEmpty({
+  ref,
   children,
 }: XDSCommandPaletteEmptyProps) {
-  return <div {...stylex.props(styles.empty)}>{children}</div>;
+  return (
+    <div ref={ref} {...stylex.props(styles.empty)}>
+      {children}
+    </div>
+  );
 }
 
 XDSCommandPaletteEmpty.displayName = 'XDSCommandPaletteEmpty';

--- a/packages/core/src/Dialog/XDSDialogHeader.tsx
+++ b/packages/core/src/Dialog/XDSDialogHeader.tsx
@@ -58,9 +58,9 @@ const styles = stylex.create({
   },
 });
 
-export interface XDSDialogHeaderProps extends XDSBaseProps<HTMLElement> {
+export interface XDSDialogHeaderProps extends XDSBaseProps<HTMLDivElement> {
   /** Ref forwarded to the root element */
-  ref?: React.Ref<HTMLElement>;
+  ref?: React.Ref<HTMLDivElement>;
   /**
    * The title of the dialog.
    * This title receives focus when the dialog opens for screen reader accessibility.

--- a/packages/core/src/Divider/XDSDivider.tsx
+++ b/packages/core/src/Divider/XDSDivider.tsx
@@ -52,7 +52,7 @@ export type XDSDividerVariant = keyof XDSDividerVariantMap;
 
 export interface XDSDividerProps extends XDSBaseProps<HTMLDivElement> {
   /** Ref forwarded to the root element */
-  ref?: React.Ref<HTMLElement>;
+  ref?: React.Ref<HTMLDivElement>;
   /**
    * Orientation of the divider.
    * @default 'horizontal'
@@ -192,7 +192,7 @@ export function XDSDivider({
 
   return (
     <div
-      ref={ref as React.Ref<HTMLDivElement>}
+      ref={ref}
       role="separator"
       aria-orientation={orientation}
       {...mergeProps(

--- a/packages/core/src/Field/XDSFieldStatus.tsx
+++ b/packages/core/src/Field/XDSFieldStatus.tsx
@@ -14,6 +14,7 @@
 
 'use client';
 
+import React from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import {xdsClassName, mergeProps} from '../utils';
@@ -88,6 +89,7 @@ export interface XDSFieldStatusVariantMap {
 export type XDSFieldStatusVariant = keyof XDSFieldStatusVariantMap;
 
 export interface XDSFieldStatusProps extends XDSBaseProps<HTMLDivElement> {
+  ref?: React.Ref<HTMLDivElement>;
   /**
    * The type of status to display.
    */
@@ -122,6 +124,7 @@ export interface XDSFieldStatusProps extends XDSBaseProps<HTMLDivElement> {
  * ```
  */
 export function XDSFieldStatus({
+  ref,
   type,
   message,
   id,
@@ -131,6 +134,7 @@ export function XDSFieldStatus({
 
   return (
     <div
+      ref={ref}
       id={id}
       role={type === 'error' ? 'alert' : 'status'}
       aria-live={type === 'error' ? 'assertive' : 'polite'}

--- a/packages/core/src/Grid/XDSGrid.tsx
+++ b/packages/core/src/Grid/XDSGrid.tsx
@@ -52,7 +52,7 @@ export type XDSGridColumns =
 
 export interface XDSGridProps extends XDSBaseProps<HTMLDivElement> {
   /** Ref forwarded to the root element */
-  ref?: React.Ref<HTMLElement>;
+  ref?: React.Ref<HTMLDivElement>;
   /**
    * Column configuration.
    * - `number` — fixed equal-width columns
@@ -443,7 +443,7 @@ export function XDSGrid({
 
   return (
     <div
-      ref={ref as React.Ref<HTMLDivElement>}
+      ref={ref}
       {...mergeProps(
         xdsClassName('grid', {columns: columnsVariant, gap, align, justify}),
         stylex.props(

--- a/packages/core/src/Grid/XDSGridSpan.tsx
+++ b/packages/core/src/Grid/XDSGridSpan.tsx
@@ -21,7 +21,7 @@ import {xdsClassName, mergeProps} from '../utils';
 
 export interface XDSGridSpanProps extends XDSBaseProps<HTMLDivElement> {
   /** Ref forwarded to the root element */
-  ref?: React.Ref<HTMLElement>;
+  ref?: React.Ref<HTMLDivElement>;
   /**
    * Number of columns to span, or 'full' to span all columns.
    * - Number: `grid-column: span N`
@@ -109,7 +109,7 @@ export function XDSGridSpan({
 
   return (
     <div
-      ref={ref as React.Ref<HTMLDivElement>}
+      ref={ref}
       {...mergeProps(
         xdsClassName('grid-span'),
         stylex.props(baseStyles.span, xstyle),

--- a/packages/core/src/InputGroup/XDSInputGroupText.tsx
+++ b/packages/core/src/InputGroup/XDSInputGroupText.tsx
@@ -14,7 +14,7 @@
  * - /packages/cli/templates/blocks/components/InputGroup/
  */
 
-import type {ReactNode} from 'react';
+import React, {type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import {
@@ -66,6 +66,7 @@ const styles = stylex.create({
 });
 
 export interface XDSInputGroupTextProps extends XDSBaseProps<HTMLDivElement> {
+  ref?: React.Ref<HTMLDivElement>;
   /**
    * Content to render in the text slot.
    * Can be text or an icon.
@@ -85,6 +86,7 @@ export interface XDSInputGroupTextProps extends XDSBaseProps<HTMLDivElement> {
  * ```
  */
 export function XDSInputGroupText({
+  ref,
   children,
   xstyle,
   className,
@@ -92,6 +94,7 @@ export function XDSInputGroupText({
 }: XDSInputGroupTextProps) {
   return (
     <div
+      ref={ref}
       {...mergeProps(
         xdsClassName('input-group-text'),
         stylex.props(styles.text, xstyle),

--- a/packages/core/src/Kbd/XDSKbd.tsx
+++ b/packages/core/src/Kbd/XDSKbd.tsx
@@ -13,7 +13,7 @@
  * - /packages/cli/templates/blocks/components/Kbd/ (showcase blocks)
  */
 
-import {useState} from 'react';
+import React, {useState} from 'react';
 import {useIsomorphicLayoutEffect} from '../hooks/useIsomorphicLayoutEffect';
 import * as stylex from '@stylexjs/stylex';
 import {xdsClassName, mergeProps} from '../utils';
@@ -105,6 +105,7 @@ function detectMac(): boolean {
 }
 
 export interface XDSKbdProps extends XDSBaseProps<HTMLSpanElement> {
+  ref?: React.Ref<HTMLSpanElement>;
   /**
    * Keyboard shortcut string. Use "+" to separate keys.
    * Special keys: mod (Cmd on Mac), ctrl, alt, shift, enter, backspace, escape.
@@ -135,7 +136,14 @@ export interface XDSKbdProps extends XDSBaseProps<HTMLSpanElement> {
  * <XDSKbd keys="mod+k" />
  * ```
  */
-export function XDSKbd({keys, xstyle, className, style, ...rest}: XDSKbdProps) {
+export function XDSKbd({
+  keys,
+  ref,
+  xstyle,
+  className,
+  style,
+  ...rest
+}: XDSKbdProps) {
   const [isMac, setIsMac] = useState(false);
 
   useIsomorphicLayoutEffect(() => {
@@ -146,6 +154,7 @@ export function XDSKbd({keys, xstyle, className, style, ...rest}: XDSKbdProps) {
 
   return (
     <span
+      ref={ref}
       {...rest}
       {...mergeProps(
         xdsClassName('kbd'),

--- a/packages/core/src/Layout/XDSLayoutContent.tsx
+++ b/packages/core/src/Layout/XDSLayoutContent.tsx
@@ -94,7 +94,7 @@ const styles = stylex.create({
 });
 
 export interface XDSLayoutContentProps extends XDSBaseProps<HTMLDivElement> {
-  ref?: React.Ref<HTMLElement>;
+  ref?: React.Ref<HTMLDivElement>;
   /**
    * Content to render inside the content area.
    */
@@ -181,7 +181,7 @@ export function XDSLayoutContent({
 
   return (
     <div
-      ref={ref as React.Ref<HTMLDivElement>}
+      ref={ref}
       role={role}
       aria-label={label}
       {...mergeProps(

--- a/packages/core/src/Layout/XDSLayoutFooter.tsx
+++ b/packages/core/src/Layout/XDSLayoutFooter.tsx
@@ -76,7 +76,7 @@ const dynamicStyles = stylex.create({
 });
 
 export interface XDSLayoutFooterProps extends XDSBaseProps<HTMLDivElement> {
-  ref?: React.Ref<HTMLElement>;
+  ref?: React.Ref<HTMLDivElement>;
   /**
    * Content to render inside the footer.
    */
@@ -153,7 +153,7 @@ export function XDSLayoutFooter({
 
   return (
     <div
-      ref={ref as React.Ref<HTMLDivElement>}
+      ref={ref}
       role={role}
       aria-label={label}
       data-divider={resolvedHasDivider || undefined}

--- a/packages/core/src/Layout/XDSLayoutHeader.tsx
+++ b/packages/core/src/Layout/XDSLayoutHeader.tsx
@@ -76,7 +76,7 @@ const dynamicStyles = stylex.create({
 });
 
 export interface XDSLayoutHeaderProps extends XDSBaseProps<HTMLDivElement> {
-  ref?: React.Ref<HTMLElement>;
+  ref?: React.Ref<HTMLDivElement>;
   /**
    * Content to render inside the header.
    */
@@ -153,7 +153,7 @@ export function XDSLayoutHeader({
 
   return (
     <div
-      ref={ref as React.Ref<HTMLDivElement>}
+      ref={ref}
       role={role}
       aria-label={label}
       data-divider={resolvedHasDivider || undefined}

--- a/packages/core/src/Layout/XDSLayoutPanel.tsx
+++ b/packages/core/src/Layout/XDSLayoutPanel.tsx
@@ -107,7 +107,7 @@ const dynamicStyles = stylex.create({
 });
 
 export interface XDSLayoutPanelProps extends XDSBaseProps<HTMLDivElement> {
-  ref?: React.Ref<HTMLElement>;
+  ref?: React.Ref<HTMLDivElement>;
   /**
    * Content to render inside the panel.
    */
@@ -251,7 +251,7 @@ export function XDSLayoutPanel({
 
   return (
     <div
-      ref={ref as React.Ref<HTMLDivElement>}
+      ref={ref}
       role={role}
       aria-label={label}
       {...mergeProps(

--- a/packages/core/src/MobileNav/XDSMobileNavToggle.tsx
+++ b/packages/core/src/MobileNav/XDSMobileNavToggle.tsx
@@ -13,7 +13,7 @@
  * Can be placed anywhere in the component tree (TopNav, content area, custom toolbar, etc.).
  */
 
-import {type ReactNode} from 'react';
+import React, {type ReactNode} from 'react';
 import {XDSButton} from '../Button';
 import {XDSIcon} from '../Icon';
 import {useXDSAppShellMobile} from '../AppShell/XDSAppShellMobileContext';
@@ -23,6 +23,7 @@ export interface XDSMobileNavToggleProps extends Pick<
   XDSBaseProps,
   'xstyle' | 'className' | 'style'
 > {
+  ref?: React.Ref<HTMLButtonElement>;
   /**
    * Custom content to render instead of the default hamburger icon.
    */
@@ -57,6 +58,7 @@ export interface XDSMobileNavToggleProps extends Pick<
  * ```
  */
 export function XDSMobileNavToggle({
+  ref,
   children,
   label = 'Open navigation',
   'data-testid': testId,
@@ -74,6 +76,7 @@ export function XDSMobileNavToggle({
 
   return (
     <XDSButton
+      ref={ref}
       variant="ghost"
       label={label}
       icon={children ?? <XDSIcon icon="menu" color="inherit" />}

--- a/packages/core/src/NavMenu/XDSNavHeadingMenu.tsx
+++ b/packages/core/src/NavMenu/XDSNavHeadingMenu.tsx
@@ -2,10 +2,10 @@
 
 'use client';
 
-import {useMemo, type ReactNode} from 'react';
+import React, {useMemo, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {spacingVars} from '../theme/tokens.stylex';
-import {xdsClassName, mergeProps} from '../utils';
+import {xdsClassName, mergeProps, mergeRefs} from '../utils';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import {useListFocus} from '../hooks/useListFocus';
 import {
@@ -35,6 +35,7 @@ const sizeStyles = stylex.create({
 });
 
 export interface XDSNavHeadingMenuProps extends XDSBaseProps<HTMLDivElement> {
+  ref?: React.Ref<HTMLDivElement>;
   /** Menu items (XDSNavHeadingMenuItem, dividers, custom content). */
   children: ReactNode;
 
@@ -74,6 +75,7 @@ export interface XDSNavHeadingMenuProps extends XDSBaseProps<HTMLDivElement> {
  * ```
  */
 export function XDSNavHeadingMenu({
+  ref,
   children,
   size = 'md',
   minWidth,
@@ -102,7 +104,7 @@ export function XDSNavHeadingMenu({
   return (
     <XDSNavHeadingMenuContext value={ctx}>
       <div
-        ref={listRef as React.RefObject<HTMLDivElement>}
+        ref={mergeRefs(ref, listRef)}
         role="menu"
         onKeyDown={handleKeyDown}
         data-testid={testId}

--- a/packages/core/src/NavMenu/XDSNavHeadingMenuItem.tsx
+++ b/packages/core/src/NavMenu/XDSNavHeadingMenuItem.tsx
@@ -2,7 +2,7 @@
 
 'use client';
 
-import {useCallback, type ReactNode} from 'react';
+import React, {useCallback, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {renderIconSlot, type XDSIconType} from '../Icon';
 import {XDSText} from '../Text';
@@ -71,6 +71,7 @@ export interface XDSNavHeadingMenuItemProps extends Omit<
   XDSBaseProps<HTMLElement>,
   'onClick'
 > {
+  ref?: React.Ref<HTMLElement>;
   /** Icon to display before the label. */
   icon?: ReactNode | XDSIconType;
   /** Primary label text. */
@@ -101,6 +102,7 @@ export interface XDSNavHeadingMenuItemProps extends Omit<
  * ```
  */
 export function XDSNavHeadingMenuItem({
+  ref,
   icon,
   label,
   description,
@@ -128,6 +130,7 @@ export function XDSNavHeadingMenuItem({
 
   return (
     <Element
+      ref={ref}
       role="menuitem"
       tabIndex={isDisabled ? undefined : -1}
       aria-disabled={isDisabled || undefined}

--- a/packages/core/src/RadioList/XDSRadioList.tsx
+++ b/packages/core/src/RadioList/XDSRadioList.tsx
@@ -16,7 +16,7 @@
  * - /packages/cli/templates/blocks/components/RadioList/ (showcase blocks)
  */
 
-import {createContext, useId, useMemo, type ReactNode} from 'react';
+import React, {createContext, useId, useMemo, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {spacingVars} from '../theme/tokens.stylex';
 import {XDSField} from '../Field/XDSField';
@@ -61,6 +61,7 @@ export interface XDSRadioListProps extends Omit<
   XDSBaseProps<HTMLElement>,
   'onChange'
 > {
+  ref?: React.Ref<HTMLDivElement>;
   /**
    * Label text for the radio group (always rendered for accessibility).
    */
@@ -144,6 +145,7 @@ export interface XDSRadioListProps extends Omit<
  * ```
  */
 export function XDSRadioList({
+  ref,
   label,
   isLabelHidden = false,
   description,
@@ -174,6 +176,7 @@ export function XDSRadioList({
 
   return (
     <XDSField
+      ref={ref}
       data-testid={dataTestId}
       label={label}
       isLabelHidden={isLabelHidden}

--- a/packages/core/src/RadioList/XDSRadioListItem.tsx
+++ b/packages/core/src/RadioList/XDSRadioListItem.tsx
@@ -16,7 +16,7 @@
  * - /packages/cli/templates/blocks/components/RadioList/ (showcase blocks)
  */
 
-import {use, useId, type ReactNode} from 'react';
+import React, {use, useId, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import {
@@ -191,6 +191,7 @@ const dotSizeStyles = stylex.create({
 });
 
 export interface XDSRadioListItemProps extends XDSBaseProps<HTMLDivElement> {
+  ref?: React.Ref<HTMLDivElement>;
   /**
    * Label text for the radio item.
    */
@@ -232,6 +233,7 @@ export interface XDSRadioListItemProps extends XDSBaseProps<HTMLDivElement> {
  * ```
  */
 export function XDSRadioListItem({
+  ref,
   label,
   value,
   description,
@@ -253,6 +255,7 @@ export function XDSRadioListItem({
 
   return (
     <div
+      ref={ref}
       data-testid={dataTestId}
       {...mergeProps(
         xdsClassName('radio-list-item'),

--- a/packages/core/src/SegmentedControl/XDSSegmentedControl.tsx
+++ b/packages/core/src/SegmentedControl/XDSSegmentedControl.tsx
@@ -31,6 +31,7 @@ export interface XDSSegmentedControlProps extends Omit<
   XDSBaseProps<HTMLDivElement>,
   'onChange'
 > {
+  ref?: React.Ref<HTMLDivElement>;
   /**
    * The currently selected value (controlled).
    */
@@ -118,6 +119,7 @@ const sizeStyles = stylex.create({
  * ```
  */
 export function XDSSegmentedControl({
+  ref,
   value,
   onChange,
   label,
@@ -131,6 +133,16 @@ export function XDSSegmentedControl({
 }: XDSSegmentedControlProps) {
   const size = useXDSSize(sizeProp, 'md') as XDSSegmentedControlSize;
   const containerRef = useRef<HTMLDivElement>(null);
+
+  // Merge refs
+  const setContainerRef = (element: HTMLDivElement | null) => {
+    (containerRef as React.RefObject<HTMLDivElement | null>).current = element;
+    if (typeof ref === 'function') {
+      ref(element);
+    } else if (ref) {
+      (ref as React.RefObject<HTMLDivElement | null>).current = element;
+    }
+  };
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
@@ -197,7 +209,7 @@ export function XDSSegmentedControl({
   return (
     <XDSSegmentedControlContext value={contextValue}>
       <div
-        ref={containerRef}
+        ref={setContainerRef}
         role="radiogroup"
         aria-label={label}
         aria-disabled={isDisabled || undefined}

--- a/packages/core/src/SegmentedControl/XDSSegmentedControlItem.tsx
+++ b/packages/core/src/SegmentedControl/XDSSegmentedControlItem.tsx
@@ -15,7 +15,7 @@
  * - /packages/cli/templates/blocks/components/SegmentedControl/ (showcase blocks)
  */
 
-import {useCallback, type ReactNode} from 'react';
+import React, {useCallback, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {
   colorVars,
@@ -33,6 +33,7 @@ import {xdsClassName, mergeProps} from '../utils';
 import type {XDSBaseProps} from '../XDSBaseProps';
 
 export interface XDSSegmentedControlItemProps extends XDSBaseProps<HTMLButtonElement> {
+  ref?: React.Ref<HTMLButtonElement>;
   /**
    * Unique value for this segment. Matched against the parent's value.
    */
@@ -160,6 +161,7 @@ const iconSizeStyles = stylex.create({
  * ```
  */
 export function XDSSegmentedControlItem({
+  ref,
   value,
   label,
   isLabelHidden = false,
@@ -185,6 +187,7 @@ export function XDSSegmentedControlItem({
 
   return (
     <button
+      ref={ref}
       type="button"
       role="radio"
       aria-checked={isSelected}

--- a/packages/core/src/SideNav/XDSSideNavCollapseButton.tsx
+++ b/packages/core/src/SideNav/XDSSideNavCollapseButton.tsx
@@ -17,7 +17,7 @@
  * - /packages/cli/templates/blocks/components/SideNav/ (showcase blocks)
  */
 
-import {useCallback, type ReactNode} from 'react';
+import React, {useCallback, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {durationVars, easeVars} from '../theme/tokens.stylex';
 import {getIcon} from '../Icon/globalIconRegistry';
@@ -48,6 +48,7 @@ const styles = stylex.create({
 // =============================================================================
 
 export interface XDSSideNavCollapseButtonProps extends XDSBaseProps<HTMLButtonElement> {
+  ref?: React.Ref<HTMLButtonElement>;
   /**
    * Ref to the XDSSideNav element. Only needed when the button is
    * rendered outside the sidenav (reads collapse state via ref instead
@@ -93,6 +94,7 @@ export interface XDSSideNavCollapseButtonProps extends XDSBaseProps<HTMLButtonEl
  * ```
  */
 export function XDSSideNavCollapseButton({
+  ref,
   sideNavRef: _sideNavRef,
   label,
   children,
@@ -116,6 +118,7 @@ export function XDSSideNavCollapseButton({
 
   return (
     <XDSButton
+      ref={ref}
       label={label ?? (isCollapsed ? 'Expand sidebar' : 'Collapse sidebar')}
       variant="ghost"
       onClick={handleClick}

--- a/packages/core/src/SideNav/XDSSideNavSection.tsx
+++ b/packages/core/src/SideNav/XDSSideNavSection.tsx
@@ -18,7 +18,7 @@
  * - /packages/cli/templates/blocks/components/SideNav/ (showcase blocks)
  */
 
-import {useId, type ReactNode} from 'react';
+import React, {useId, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {
   colorVars,
@@ -90,6 +90,7 @@ const styles = stylex.create({
 // =============================================================================
 
 export interface XDSSideNavSectionProps extends XDSBaseProps<HTMLDivElement> {
+  ref?: React.Ref<HTMLDivElement>;
   /**
    * Section title.
    */
@@ -133,6 +134,7 @@ export interface XDSSideNavSectionProps extends XDSBaseProps<HTMLDivElement> {
  * ```
  */
 export function XDSSideNavSection({
+  ref,
   title,
   subtitle,
   children,
@@ -179,6 +181,7 @@ export function XDSSideNavSection({
 
   return (
     <div
+      ref={ref}
       role="group"
       aria-labelledby={titleId}
       data-testid={testId}

--- a/packages/core/src/Stack/XDSStack.tsx
+++ b/packages/core/src/Stack/XDSStack.tsx
@@ -42,7 +42,7 @@ export type XDSStackAlignment = StackMainAlignment | StackCrossAlignment;
 /** @deprecated Use `XDSStackAlignment` instead. */
 export type StackAlignment = XDSStackAlignment;
 
-export interface XDSStackProps extends XDSBaseProps<HTMLDivElement> {
+export interface XDSStackProps extends XDSBaseProps<HTMLElement> {
   /** Ref forwarded to the root element */
   ref?: React.Ref<HTMLElement>;
   /**

--- a/packages/core/src/Stack/XDSStackItem.tsx
+++ b/packages/core/src/Stack/XDSStackItem.tsx
@@ -22,7 +22,7 @@ import {
 } from './stackItem.stylex';
 import {xdsClassName, mergeProps} from '../utils';
 
-export interface XDSStackItemProps extends XDSBaseProps<HTMLDivElement> {
+export interface XDSStackItemProps extends XDSBaseProps<HTMLElement> {
   /** Ref forwarded to the root element */
   ref?: React.Ref<HTMLElement>;
   /**

--- a/packages/core/src/TabList/XDSTab.tsx
+++ b/packages/core/src/TabList/XDSTab.tsx
@@ -15,7 +15,7 @@
  * - /packages/cli/templates/blocks/components/TabList/ (showcase blocks)
  */
 
-import {useCallback, type ReactNode} from 'react';
+import React, {useCallback, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {
   colorVars,
@@ -43,6 +43,7 @@ export interface XDSTabProps extends XDSBaseProps<HTMLButtonElement> {
    * Only applies when `href` is provided. Must accept href, className, style, and children props.
    */
   as?: XDSLinkComponentType;
+  ref?: React.Ref<HTMLButtonElement>;
   /**
    * Unique value for this tab. Matched against XDSTabListContext.value.
    */
@@ -213,6 +214,7 @@ const iconSizeStyles = stylex.create({
  */
 export function XDSTab({
   as,
+  ref,
   value,
   label,
   href,
@@ -299,7 +301,11 @@ export function XDSTab({
 
   if (href != null) {
     return (
-      <LinkComponent href={href} onClick={handleSelect} {...sharedProps}>
+      <LinkComponent
+        ref={ref}
+        href={href}
+        onClick={handleSelect}
+        {...sharedProps}>
         {hoverBgElement}
         {iconElement}
         {labelElement}
@@ -310,7 +316,7 @@ export function XDSTab({
   }
 
   return (
-    <button type="button" onClick={handleSelect} {...sharedProps}>
+    <button ref={ref} type="button" onClick={handleSelect} {...sharedProps}>
       {hoverBgElement}
       {iconElement}
       {labelElement}

--- a/packages/core/src/TabList/XDSTabList.tsx
+++ b/packages/core/src/TabList/XDSTabList.tsx
@@ -15,7 +15,7 @@
  * - /packages/cli/templates/blocks/components/TabList/ (showcase blocks)
  */
 
-import {useMemo, type ReactNode} from 'react';
+import React, {useMemo, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {borderVars, colorVars, spacingVars} from '../theme/tokens.stylex';
 import {XDSBaseProps} from '../XDSBaseProps';
@@ -29,6 +29,7 @@ export interface XDSTabListProps extends Omit<
   XDSBaseProps<HTMLElement>,
   'onChange'
 > {
+  ref?: React.Ref<HTMLElement>;
   /**
    * The currently selected tab value.
    */
@@ -96,6 +97,7 @@ const styles = stylex.create({
  * ```
  */
 export function XDSTabList({
+  ref,
   value,
   onChange,
   size: sizeProp,
@@ -117,6 +119,7 @@ export function XDSTabList({
   return (
     <XDSTabListContext value={contextValue}>
       <nav
+        ref={ref}
         aria-label="Tabs"
         {...{[EDGE_COMP_ATTR]: ''}}
         {...restProps}

--- a/packages/core/src/TabList/XDSTabMenu.tsx
+++ b/packages/core/src/TabList/XDSTabMenu.tsx
@@ -50,6 +50,7 @@ export interface XDSTabMenuProps extends Pick<
   XDSBaseProps<HTMLButtonElement>,
   'xstyle' | 'className' | 'style'
 > {
+  ref?: React.Ref<HTMLButtonElement>;
   /**
    * Label for the trigger button and dropdown heading.
    * Displayed as trigger text when no option is selected.
@@ -250,6 +251,7 @@ const hoverSizeStyles = stylex.create({
  * ```
  */
 export function XDSTabMenu({
+  ref,
   label,
   options,
   xstyle,
@@ -291,10 +293,22 @@ export function XDSTabMenu({
     [tabListCtx, popover],
   );
 
+  const setButtonRef = useCallback(
+    (el: HTMLButtonElement | null) => {
+      popover.triggerRef(el);
+      if (typeof ref === 'function') {
+        ref(el);
+      } else if (ref) {
+        (ref as React.MutableRefObject<HTMLButtonElement | null>).current = el;
+      }
+    },
+    [popover, ref],
+  );
+
   return (
     <>
       <button
-        ref={popover.triggerRef}
+        ref={setButtonRef}
         type="button"
         aria-haspopup="menu"
         aria-expanded={popover.isOpen}

--- a/packages/core/src/Table/XDSTableBody.tsx
+++ b/packages/core/src/Table/XDSTableBody.tsx
@@ -1,18 +1,22 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 'use client';
+import type React from 'react';
 import type {ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import {xdsClassName, mergeProps} from '../utils';
 
 export interface XDSTableBodyProps extends XDSBaseProps<HTMLTableSectionElement> {
+  ref?: React.Ref<HTMLTableSectionElement>;
   children: ReactNode;
 }
 
-export function XDSTableBody({children, xstyle}: XDSTableBodyProps) {
+export function XDSTableBody({ref, children, xstyle}: XDSTableBodyProps) {
   return (
-    <tbody {...mergeProps(xdsClassName('table-body'), stylex.props(xstyle))}>
+    <tbody
+      ref={ref}
+      {...mergeProps(xdsClassName('table-body'), stylex.props(xstyle))}>
       {children}
     </tbody>
   );

--- a/packages/core/src/Table/XDSTableFooter.tsx
+++ b/packages/core/src/Table/XDSTableFooter.tsx
@@ -1,18 +1,22 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 'use client';
+import type React from 'react';
 import type {ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import {xdsClassName, mergeProps} from '../utils';
 
 export interface XDSTableFooterProps extends XDSBaseProps<HTMLTableSectionElement> {
+  ref?: React.Ref<HTMLTableSectionElement>;
   children: ReactNode;
 }
 
-export function XDSTableFooter({children, xstyle}: XDSTableFooterProps) {
+export function XDSTableFooter({ref, children, xstyle}: XDSTableFooterProps) {
   return (
-    <tfoot {...mergeProps(xdsClassName('table-footer'), stylex.props(xstyle))}>
+    <tfoot
+      ref={ref}
+      {...mergeProps(xdsClassName('table-footer'), stylex.props(xstyle))}>
       {children}
     </tfoot>
   );

--- a/packages/core/src/Table/XDSTableHeader.tsx
+++ b/packages/core/src/Table/XDSTableHeader.tsx
@@ -1,18 +1,22 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 'use client';
+import type React from 'react';
 import type {ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import {xdsClassName, mergeProps} from '../utils';
 
 export interface XDSTableHeaderProps extends XDSBaseProps<HTMLTableSectionElement> {
+  ref?: React.Ref<HTMLTableSectionElement>;
   children: ReactNode;
 }
 
-export function XDSTableHeader({children, xstyle}: XDSTableHeaderProps) {
+export function XDSTableHeader({ref, children, xstyle}: XDSTableHeaderProps) {
   return (
-    <thead {...mergeProps(xdsClassName('table-header'), stylex.props(xstyle))}>
+    <thead
+      ref={ref}
+      {...mergeProps(xdsClassName('table-header'), stylex.props(xstyle))}>
       {children}
     </thead>
   );

--- a/packages/core/src/Table/types.ts
+++ b/packages/core/src/Table/types.ts
@@ -11,6 +11,7 @@
  * - /packages/core/src/Table/index.ts (exports if types change)
  */
 
+import type React from 'react';
 import type {
   ComponentType,
   HTMLAttributes,
@@ -365,6 +366,7 @@ export interface TableHeaderCellComponentProps extends ThHTMLAttributes<HTMLTabl
 export interface XDSBaseTableProps<
   T extends Record<string, unknown>,
 > extends XDSBaseProps<HTMLTableElement> {
+  ref?: React.Ref<HTMLTableElement>;
   /** Array of data items to render as rows */
   data?: T[];
   /** Column definitions. If omitted, auto-generated from data keys. */

--- a/packages/core/src/ToggleButton/XDSToggleButton.tsx
+++ b/packages/core/src/ToggleButton/XDSToggleButton.tsx
@@ -20,7 +20,7 @@
  * - /packages/cli/templates/blocks/components/ToggleButton/ (showcase blocks)
  */
 
-import {useCallback, type ReactNode} from 'react';
+import React, {useCallback, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars, fontWeightVars} from '../theme/tokens.stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
@@ -69,6 +69,7 @@ const labelStyles = stylex.create({
 // =============================================================================
 
 export interface XDSToggleButtonProps extends XDSBaseProps<HTMLButtonElement> {
+  ref?: React.Ref<HTMLButtonElement>;
   /**
    * Accessible label for the button (required).
    * Used as visible text, or as aria-label for icon-only buttons.
@@ -198,6 +199,7 @@ export interface XDSToggleButtonProps extends XDSBaseProps<HTMLButtonElement> {
  * ```
  */
 export function XDSToggleButton({
+  ref,
   label,
   isPressed: isPressedProp,
   onPressedChange: onPressedChangeProp,
@@ -282,6 +284,7 @@ export function XDSToggleButton({
 
   return (
     <XDSButton
+      ref={ref}
       label={label}
       variant="ghost"
       size={size}

--- a/packages/core/src/Toolbar/XDSToolbar.tsx
+++ b/packages/core/src/Toolbar/XDSToolbar.tsx
@@ -139,7 +139,7 @@ export type XDSToolbarSize = XDSElementSize;
 
 export interface XDSToolbarProps extends XDSBaseProps<HTMLDivElement> {
   /** Ref forwarded to the root XDSSection element */
-  ref?: React.Ref<HTMLElement>;
+  ref?: React.Ref<HTMLDivElement>;
   /**
    * Content aligned to the start (left in LTR).
    */

--- a/packages/core/src/TopNav/XDSTopNavMegaMenu.tsx
+++ b/packages/core/src/TopNav/XDSTopNavMegaMenu.tsx
@@ -23,7 +23,13 @@
  * - /packages/cli/templates/blocks/components/TopNav/ (showcase blocks)
  */
 
-import {useCallback, useEffect, useRef, useState, type ReactNode} from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {
   colorVars,
@@ -203,6 +209,7 @@ const styles = stylex.create({
 // =============================================================================
 
 export interface XDSTopNavMegaMenuProps extends XDSBaseProps<HTMLButtonElement> {
+  ref?: React.Ref<HTMLButtonElement>;
   /** The visible label for the nav item trigger. */
   label: string;
   /**
@@ -276,6 +283,7 @@ export interface XDSTopNavMegaMenuProps extends XDSBaseProps<HTMLButtonElement> 
  * ```
  */
 export function XDSTopNavMegaMenu({
+  ref,
   label,
   items,
   featured,
@@ -304,6 +312,7 @@ export function XDSTopNavMegaMenu({
   // =========================================================================
   return (
     <DefaultMegaMenu
+      ref={ref}
       label={label}
       items={items}
       featured={featured}
@@ -321,6 +330,7 @@ XDSTopNavMegaMenu.displayName = 'XDSTopNavMegaMenu';
 // =============================================================================
 
 function DefaultMegaMenu({
+  ref,
   label,
   items,
   featured,
@@ -418,10 +428,22 @@ function DefaultMegaMenu({
     };
   }, [clearTimeouts]);
 
+  const setButtonRef = useCallback(
+    (el: HTMLButtonElement | null) => {
+      triggerButtonRef.current = el;
+      if (typeof ref === 'function') {
+        ref(el);
+      } else if (ref) {
+        (ref as React.MutableRefObject<HTMLButtonElement | null>).current = el;
+      }
+    },
+    [ref],
+  );
+
   return (
     <>
       <button
-        ref={triggerButtonRef}
+        ref={setButtonRef}
         type="button"
         aria-haspopup="true"
         aria-expanded={popover.isOpen}

--- a/packages/core/src/TopNav/XDSTopNavMegaMenuFeaturedCard.tsx
+++ b/packages/core/src/TopNav/XDSTopNavMegaMenuFeaturedCard.tsx
@@ -18,7 +18,7 @@
  * - /packages/cli/templates/blocks/components/TopNav/ (showcase blocks)
  */
 
-import {type ReactNode} from 'react';
+import React, {type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {
   colorVars,
@@ -76,6 +76,7 @@ const styles = stylex.create({
 // =============================================================================
 
 export interface XDSTopNavMegaMenuFeaturedCardProps extends XDSBaseProps<HTMLDivElement> {
+  ref?: React.Ref<HTMLDivElement>;
   /** Card title. */
   title: string;
   /** Description text below the title. */
@@ -122,6 +123,7 @@ export interface XDSTopNavMegaMenuFeaturedCardProps extends XDSBaseProps<HTMLDiv
  * ```
  */
 export function XDSTopNavMegaMenuFeaturedCard({
+  ref,
   title,
   description,
   image,
@@ -133,6 +135,7 @@ export function XDSTopNavMegaMenuFeaturedCard({
   const LinkComponent = useXDSLinkComponent();
   return (
     <div
+      ref={ref}
       {...mergeProps(
         xdsClassName('top-nav-mega-menu-featured-card'),
         stylex.props(styles.root),

--- a/packages/core/src/TopNav/XDSTopNavMegaMenuItem.tsx
+++ b/packages/core/src/TopNav/XDSTopNavMegaMenuItem.tsx
@@ -15,7 +15,7 @@
  * - /packages/cli/templates/blocks/components/TopNav/ (showcase blocks)
  */
 
-import {type ReactNode} from 'react';
+import React, {type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {
   colorVars,
@@ -143,6 +143,7 @@ export interface XDSTopNavMegaMenuItemProps extends Omit<
   XDSBaseProps<HTMLElement>,
   'onClick'
 > {
+  ref?: React.Ref<HTMLElement>;
   /** Display title for the menu item. */
   title: string;
   /** Optional description text displayed below the title. */
@@ -189,6 +190,7 @@ export interface XDSTopNavMegaMenuItemProps extends Omit<
  * ```
  */
 export function XDSTopNavMegaMenuItem({
+  ref,
   title,
   description,
   icon,
@@ -213,6 +215,7 @@ export function XDSTopNavMegaMenuItem({
     };
     return (
       <Element
+        ref={ref}
         href={href}
         onClick={handleDrawerClick}
         {...elementProps}
@@ -239,6 +242,7 @@ export function XDSTopNavMegaMenuItem({
   const Element = href ? LinkComponent : 'div';
   return (
     <Element
+      ref={ref}
       href={href}
       onClick={onClick}
       tabIndex={tabIndex}

--- a/packages/core/src/TopNav/XDSTopNavMenu.tsx
+++ b/packages/core/src/TopNav/XDSTopNavMenu.tsx
@@ -15,7 +15,13 @@
  * - /packages/cli/templates/blocks/components/TopNav/ (showcase blocks)
  */
 
-import {useCallback, useId, useRef, useState, type ReactNode} from 'react';
+import React, {
+  useCallback,
+  useId,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {useXDSPopover} from '../Popover/useXDSPopover';
 import {useXDSMenuHover} from '../hooks/useXDSMenuHover';
@@ -246,6 +252,7 @@ export interface XDSTopNavMenuItemData {
 }
 
 export interface XDSTopNavMenuProps extends XDSBaseProps<HTMLButtonElement> {
+  ref?: React.Ref<HTMLButtonElement>;
   /**
    * The visible label for the nav item trigger.
    */
@@ -310,6 +317,7 @@ export interface XDSTopNavMenuProps extends XDSBaseProps<HTMLButtonElement> {
  */
 
 export function XDSTopNavMenu({
+  ref,
   label,
   items,
   delay = 150,
@@ -343,8 +351,13 @@ export function XDSTopNavMenu({
       triggerButtonRef.current = el;
       popover.triggerRef(el);
       setTriggerEl(el);
+      if (typeof ref === 'function') {
+        ref(el);
+      } else if (ref) {
+        (ref as React.MutableRefObject<HTMLButtonElement | null>).current = el;
+      }
     },
-    [popover, setTriggerEl],
+    [popover, setTriggerEl, ref],
   );
 
   // Mobile bar: hide menus entirely

--- a/packages/core/src/Typeahead/XDSBaseTypeahead.tsx
+++ b/packages/core/src/Typeahead/XDSBaseTypeahead.tsx
@@ -50,6 +50,7 @@ import type {XDSSearchableItem, XDSSearchSource} from './types';
 export interface XDSBaseTypeaheadProps<
   T extends XDSSearchableItem,
 > extends Omit<XDSBaseProps<HTMLElement>, 'onChange'> {
+  ref?: React.Ref<HTMLInputElement>;
   /**
    * Search source providing items.
    */
@@ -298,7 +299,7 @@ export const XDSBaseTypeahead = function XDSBaseTypeahead<
   debounceMs = 150,
   size = 'md',
   ref,
-}: XDSBaseTypeaheadProps<T> & {ref?: React.Ref<HTMLInputElement>}) {
+}: XDSBaseTypeaheadProps<T>) {
   const generatedId = useId();
   const inputId = externalInputId ?? generatedId;
   const listboxId = useId();
@@ -737,7 +738,7 @@ export const XDSBaseTypeahead = function XDSBaseTypeahead<
     </>
   );
 } as <T extends XDSSearchableItem>(
-  props: XDSBaseTypeaheadProps<T> & {ref?: React.Ref<HTMLInputElement>},
+  props: XDSBaseTypeaheadProps<T>,
 ) => React.ReactElement;
 
 (XDSBaseTypeahead as {displayName?: string}).displayName = 'XDSBaseTypeahead';

--- a/packages/core/src/Typeahead/XDSTypeahead.tsx
+++ b/packages/core/src/Typeahead/XDSTypeahead.tsx
@@ -60,6 +60,7 @@ export interface XDSTypeaheadProps<T extends XDSSearchableItem> extends Omit<
   XDSBaseProps<HTMLDivElement>,
   'onChange'
 > {
+  ref?: React.Ref<HTMLDivElement>;
   /** Accessible label (required). */
   label: string;
   /** Visually hide the label. @default false */
@@ -192,6 +193,7 @@ const styles = stylex.create({
  * ```
  */
 export function XDSTypeahead<T extends XDSSearchableItem>({
+  ref,
   label,
   isLabelHidden = false,
   description,
@@ -346,6 +348,7 @@ export function XDSTypeahead<T extends XDSSearchableItem>({
 
   return (
     <XDSField
+      ref={ref}
       label={label}
       isLabelHidden={isLabelHidden}
       description={description}

--- a/packages/core/src/Typeahead/XDSTypeaheadItem.tsx
+++ b/packages/core/src/Typeahead/XDSTypeaheadItem.tsx
@@ -11,7 +11,7 @@
  * - /packages/cli/templates/blocks/components/Typeahead/ (showcase blocks)
  */
 
-import type {ReactNode} from 'react';
+import React, {type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {
   colorVars,
@@ -30,6 +30,7 @@ import {xdsClassName, mergeProps} from '../utils';
 export interface XDSTypeaheadItemProps<
   T extends XDSSearchableItem = XDSSearchableItem,
 > extends XDSBaseProps<HTMLDivElement> {
+  ref?: React.Ref<HTMLDivElement>;
   /**
    * The search result item.
    */
@@ -125,6 +126,7 @@ const styles = stylex.create({
  * ```
  */
 export function XDSTypeaheadItem<T extends XDSSearchableItem>({
+  ref,
   item,
   icon,
   description,
@@ -137,6 +139,7 @@ export function XDSTypeaheadItem<T extends XDSSearchableItem>({
 
   return (
     <div
+      ref={ref}
       {...mergeProps(
         xdsClassName('typeahead-item'),
         stylex.props(styles.container, isDisabled && styles.disabled),

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -62,6 +62,7 @@ export {parseStyleKey} from './parseStyleKey';
 export {xdsClassName} from './xdsClassName';
 
 export {mergeProps} from './mergeProps';
+export {mergeRefs} from './mergeRefs';
 export {groupItems, getItemGroup} from './groupItems';
 export type {ItemGroup} from './groupItems';
 export {observeResize, unobserveResize} from './sharedResizeObserver';

--- a/packages/core/src/utils/mergeRefs.ts
+++ b/packages/core/src/utils/mergeRefs.ts
@@ -1,0 +1,32 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file mergeRefs.ts
+ * @input Multiple React refs (callback, object, or undefined)
+ * @output A single callback ref that forwards to all inputs
+ * @position Utility; used by components that need to merge an external ref
+ *   with an internal ref (e.g., popover trigger + consumer ref).
+ */
+
+import type {Ref, RefCallback} from 'react';
+
+export function mergeRefs<T>(...refs: (Ref<T> | undefined)[]): RefCallback<T> {
+  return (value: T | null) => {
+    const cleanups: (() => void)[] = [];
+    for (const ref of refs) {
+      if (typeof ref === 'function') {
+        const cleanup = ref(value);
+        if (typeof cleanup === 'function') {
+          cleanups.push(cleanup);
+        }
+      } else if (ref != null) {
+        (ref as {current: T | null}).current = value;
+      }
+    }
+    if (cleanups.length > 0) {
+      return () => {
+        for (const cleanup of cleanups) {cleanup();}
+      };
+    }
+  };
+}


### PR DESCRIPTION
  ## Summary

  - **New ESLint rule `@xds/require-ref-prop`** — enforces that all publicly exported `XDS*Props` interfaces declare a `ref` property, ensuring consumers can access the
  underlying DOM element (React 19 ref-as-prop pattern)
  - **Adds `ref` to 41 component props interfaces** that were missing it, with ref forwarding wired to the root DOM element
  - Uses the same barrel-export filtering as `require-base-props` to only check public API types

  ### Exclusions (9 interfaces)

  | Category | Interfaces | Reason |
  |----------|-----------|--------|
  | Base type | `XDSBaseProps` | Ref type varies per component |
  | Overlay/layer | `XDSTooltipProps`, `XDSPopoverProps`, `XDSHoverCardProps`, `XDSOverlayProps` | No root DOM node |
  | System-managed | `XDSToastProps`, `XDSToastViewportProps` | Not directly rendered |
  | Providers | `XDSLayerProviderProps`, `XDSLinkProviderProps`, `XDSMediaThemeProps` | No DOM element |

  ### Config

  - `strict` (CI/agents): `error`
  - `recommended` (human dev): `warn`

  ## Test plan

  - [x] `@xds/require-ref-prop` lint rule — 0 violations
  - [x] `tsc --noEmit --project packages/core/tsconfig.build.json` — 0 errors
  - [x] `pnpm test` — 3535/3537 pass (pre-existing flaky timeout)
  - [x] All lint hooks pass