### PR TITLE
refactor(core): extract mergeRefs utility and replace 36 hand-rolled callsites

### DIFF
--- a/packages/core/src/AppShell/XDSAppShell.tsx
+++ b/packages/core/src/AppShell/XDSAppShell.tsx
@@ -50,7 +50,7 @@ import {useXDSSlotPresence} from './useXDSSlotPresence';
 import type {XDSAppShellMobileContextValue} from './XDSAppShellMobileContext';
 import type {SpacingStep} from '../utils/types';
 import type {XDSBaseProps} from '../XDSBaseProps';
-import {xdsClassName, mergeProps} from '../utils';
+import {xdsClassName, mergeProps, mergeRefs} from '../utils';
 import {useMediaQuery} from '../hooks/useMediaQuery';
 import {observeResize, unobserveResize} from '../utils/sharedResizeObserver';
 
@@ -547,17 +547,7 @@ export function XDSAppShell({
   const shellRef = useRef<HTMLDivElement>(null);
 
   // Merge forwarded ref with internal shell ref
-  const setShellRef = useCallback(
-    (node: HTMLDivElement | null) => {
-      (shellRef as React.RefObject<HTMLDivElement | null>).current = node;
-      if (typeof ref === 'function') {
-        ref(node);
-      } else if (ref) {
-        (ref as React.RefObject<HTMLDivElement | null>).current = node;
-      }
-    },
-    [ref],
-  );
+  const setShellRef = mergeRefs(ref, shellRef);
 
   useEffect(() => {
     if (!isAuto || !headerRef.current || !shellRef.current) {

--- a/packages/core/src/Breadcrumbs/XDSBreadcrumbItem.tsx
+++ b/packages/core/src/Breadcrumbs/XDSBreadcrumbItem.tsx
@@ -28,7 +28,7 @@ import {colorVars, spacingVars, typeScaleVars} from '../theme/tokens.stylex';
 import {BreadcrumbContext} from './XDSBreadcrumbs';
 import {useXDSLinkComponent} from '../Link/useXDSLinkComponent';
 import type {XDSLinkComponentType} from '../Link/types';
-import {xdsClassName, mergeProps} from '../utils';
+import {xdsClassName, mergeProps, mergeRefs} from '../utils';
 import type {XDSBaseProps} from '../XDSBaseProps';
 
 // =============================================================================
@@ -182,14 +182,7 @@ export function XDSBreadcrumbItem({
   const liRef = useRef<HTMLLIElement>(null);
 
   // Merge refs
-  const setLiRef = (element: HTMLLIElement | null) => {
-    (liRef as React.RefObject<HTMLLIElement | null>).current = element;
-    if (typeof ref === 'function') {
-      ref(element);
-    } else if (ref) {
-      (ref as React.RefObject<HTMLLIElement | null>).current = element;
-    }
-  };
+  const setLiRef = mergeRefs(ref, liRef);
 
   const isCurrent = isCurrentProp === true;
   const isAutoCandidate = isCurrentProp == null;

--- a/packages/core/src/ButtonGroup/XDSButtonGroup.tsx
+++ b/packages/core/src/ButtonGroup/XDSButtonGroup.tsx
@@ -25,7 +25,7 @@ import * as stylex from '@stylexjs/stylex';
 import type {XDSButtonSize} from '../Button';
 import {XDSSizeProvider, useXDSSize} from '../SizeContext/XDSSizeContext';
 import {useListFocus} from '../hooks/useListFocus';
-import {xdsClassName, mergeProps} from '../utils';
+import {xdsClassName, mergeProps, mergeRefs} from '../utils';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import {XDSButtonGroupContext} from './XDSButtonGroupContext';
 import type {XDSButtonGroupOrientation} from './XDSButtonGroupContext';
@@ -136,15 +136,10 @@ export function XDSButtonGroup({
     <XDSButtonGroupContext value={contextValue}>
       <XDSSizeProvider value={size}>
         <div
-          ref={(node: HTMLDivElement | null) => {
+          ref={mergeRefs(ref, (node: HTMLDivElement | null) => {
             // eslint-disable-next-line react-compiler/react-compiler -- ref callback: assigning hook-returned ref
             listRef.current = node;
-            if (typeof ref === 'function') {
-              ref(node);
-            } else if (ref) {
-              ref.current = node;
-            }
-          }}
+          })}
           role="group"
           aria-label={label}
           onKeyDown={handleKeyDown}

--- a/packages/core/src/Carousel/XDSCarousel.tsx
+++ b/packages/core/src/Carousel/XDSCarousel.tsx
@@ -31,7 +31,7 @@ import {XDSIcon} from '../Icon';
 import {useXDSLayer} from '../Layer';
 import {useScrollOverflow} from '../hooks/useScrollOverflow';
 import type {XDSBaseProps} from '../XDSBaseProps';
-import {xdsClassName, mergeProps} from '../utils';
+import {xdsClassName, mergeProps, mergeRefs} from '../utils';
 
 export interface XDSCarouselProps extends XDSBaseProps<HTMLDivElement> {
   ref?: React.Ref<HTMLDivElement>;
@@ -274,16 +274,7 @@ export function XDSCarousel({
 
   return (
     <div
-      ref={(el: HTMLDivElement | null) => {
-        if (typeof ref === 'function') {
-          ref(el);
-        } else if (ref) {
-          ref.current = el;
-        }
-        if (layer.ref) {
-          layer.ref(el as HTMLElement | null);
-        }
-      }}
+      ref={mergeRefs(ref, layer.ref as React.Ref<HTMLDivElement>)}
       data-testid={testId}
       role="region"
       aria-label={ariaLabel}

--- a/packages/core/src/Chat/XDSChatLayout.tsx
+++ b/packages/core/src/Chat/XDSChatLayout.tsx
@@ -18,18 +18,11 @@
  * - /packages/cli/templates/blocks/components/ChatLayout/ (block examples)
  */
 
-import {
-  type ReactNode,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import {type ReactNode, useEffect, useMemo, useRef, useState} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {spacingVars} from '../theme/tokens.stylex';
 import type {XDSBaseProps} from '../XDSBaseProps';
-import {xdsClassName, mergeProps} from '../utils';
+import {xdsClassName, mergeProps, mergeRefs} from '../utils';
 import {observeResize, unobserveResize} from '../utils/sharedResizeObserver';
 import {useXDSChatStreamScroll} from './useXDSChatStreamScroll';
 import {useXDSChatNewMessages} from './useXDSChatNewMessages';
@@ -306,17 +299,7 @@ export function XDSChatLayout({
   }, []);
 
   // --- Merge refs ---
-  const setRootRef = useCallback(
-    (el: HTMLDivElement | null) => {
-      rootRef.current = el;
-      if (typeof ref === 'function') {
-        ref(el);
-      } else if (ref) {
-        ref.current = el;
-      }
-    },
-    [ref],
-  );
+  const setRootRef = mergeRefs(ref, rootRef);
 
   // --- Derived styles ---
   const showEmpty = !hasVisibleContent(children);

--- a/packages/core/src/CheckboxInput/XDSCheckboxInput.tsx
+++ b/packages/core/src/CheckboxInput/XDSCheckboxInput.tsx
@@ -43,7 +43,7 @@ import {XDSFieldStatus} from '../Field/XDSFieldStatus';
 import type {XDSIconType} from '../Icon';
 import type {XDSInputStatus} from '../Field/types';
 import {XDSSpinner} from '../Spinner';
-import {xdsClassName, mergeProps} from '../utils';
+import {xdsClassName, mergeProps, mergeRefs} from '../utils';
 import {checkboxScope} from './checkbox.markers.stylex';
 
 const styles = stylex.create({
@@ -362,11 +362,7 @@ export function XDSCheckboxInput({
       if (el) {
         el.indeterminate = isIndeterminate;
       }
-      if (typeof ref === 'function') {
-        ref(el);
-      } else if (ref) {
-        ref.current = el;
-      }
+      mergeRefs(ref)(el);
     },
     [isIndeterminate, ref],
   );

--- a/packages/core/src/ClickableCard/XDSClickableCard.tsx
+++ b/packages/core/src/ClickableCard/XDSClickableCard.tsx
@@ -33,7 +33,7 @@ import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import {colorVars} from '../theme/tokens.stylex';
 import type {SizeValue, SpacingStep} from '../utils/types';
-import {xdsClassName} from '../utils';
+import {xdsClassName, mergeRefs} from '../utils';
 import {XDSCard} from '../Card/XDSCard';
 import type {XDSCardVariant} from '../Card/XDSCard';
 import {useClickableContainer} from '../hooks/useClickableContainer';
@@ -247,14 +247,9 @@ export function XDSClickableCard({
 
   return (
     <XDSCard
-      ref={(node: HTMLDivElement | null) => {
+      ref={mergeRefs(ref, (node: HTMLDivElement | null) => {
         containerRef.current = node;
-        if (typeof ref === 'function') {
-          ref(node);
-        } else if (ref != null) {
-          ref.current = node;
-        }
-      }}
+      })}
       width={width}
       height={height}
       maxWidth={maxWidth}

--- a/packages/core/src/CommandPalette/XDSCommandPaletteInput.tsx
+++ b/packages/core/src/CommandPalette/XDSCommandPaletteInput.tsx
@@ -16,7 +16,7 @@ import {useCallback, useEffect, useRef, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {XDSIcon} from '../Icon';
 import {XDSSpinner} from '../Spinner';
-import {xdsClassName, mergeProps} from '../utils';
+import {xdsClassName, mergeProps, mergeRefs} from '../utils';
 import {
   colorVars,
   typeScaleVars,
@@ -166,14 +166,7 @@ export function XDSCommandPaletteInput({
   const effectiveAutoFocus = hasAutoFocus && !(ctx?.isInline ?? false);
 
   // Merge refs
-  const setRefs = (element: HTMLInputElement | null) => {
-    inputRef.current = element;
-    if (typeof ref === 'function') {
-      ref(element);
-    } else if (ref) {
-      ref.current = element;
-    }
-  };
+  const setRefs = mergeRefs(ref, inputRef);
 
   // Auto-focus on mount
   useEffect(() => {

--- a/packages/core/src/CommandPalette/XDSCommandPaletteItem.tsx
+++ b/packages/core/src/CommandPalette/XDSCommandPaletteItem.tsx
@@ -14,7 +14,7 @@
 import {useCallback, useEffect, useMemo, useRef, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {XDSBaseProps} from '../XDSBaseProps';
-import {xdsClassName, mergeProps} from '../utils';
+import {xdsClassName, mergeProps, mergeRefs} from '../utils';
 import {
   colorVars,
   spacingVars,
@@ -130,14 +130,7 @@ export function XDSCommandPaletteItem({
   const ctx = useCommandPaletteContext();
   const itemRef = useRef<HTMLDivElement>(null);
 
-  const setRefs = (element: HTMLDivElement | null) => {
-    itemRef.current = element;
-    if (typeof ref === 'function') {
-      ref(element);
-    } else if (ref) {
-      ref.current = element;
-    }
-  };
+  const setRefs = mergeRefs(ref, itemRef);
 
   // Find this item's index in the flat selectable items list (DOM order).
   // This aligns with useCombobox's index-based navigation.

--- a/packages/core/src/DateInput/XDSDateInput.tsx
+++ b/packages/core/src/DateInput/XDSDateInput.tsx
@@ -133,7 +133,7 @@ export type {
   XDSInputStatus as XDSDateInputStatus,
   XDSInputStatusType as XDSDateInputStatusType,
 } from '../Field';
-import {xdsClassName, mergeProps} from '../utils';
+import {xdsClassName, mergeProps, mergeRefs} from '../utils';
 import {XDSBaseProps} from '../XDSBaseProps';
 
 export interface XDSDateInputProps extends Omit<
@@ -479,19 +479,6 @@ export function XDSDateInput({
     [popover, commitPendingInput],
   );
 
-  // Combine refs
-  const setRefs = useCallback(
-    (el: HTMLInputElement | null) => {
-      inputRef.current = el;
-      if (typeof ref === 'function') {
-        ref(el);
-      } else if (ref) {
-        ref.current = el;
-      }
-    },
-    [ref],
-  );
-
   return (
     <XDSField
       label={label}
@@ -541,7 +528,7 @@ export function XDSDateInput({
           <XDSIcon icon="calendar" size="sm" color="secondary" />
         </button>
         <input
-          ref={setRefs}
+          ref={mergeRefs(ref, inputRef)}
           id={id}
           type="text"
           role="combobox"

--- a/packages/core/src/DateTimeInput/XDSDateTimeInput.tsx
+++ b/packages/core/src/DateTimeInput/XDSDateTimeInput.tsx
@@ -68,6 +68,7 @@ import {
   adjustTime,
   xdsClassName,
   mergeProps,
+  mergeRefs,
 } from '../utils';
 import {
   plainDateFromISO,
@@ -741,19 +742,6 @@ export function XDSDateTimeInput({
     dateInputRef.current?.focus();
   }, [fireChange]);
 
-  // --- Refs ---
-  const setDateRefs = useCallback(
-    (el: HTMLInputElement | null) => {
-      dateInputRef.current = el;
-      if (typeof ref === 'function') {
-        ref(el);
-      } else if (ref) {
-        ref.current = el;
-      }
-    },
-    [ref],
-  );
-
   // Focus time input when clicking wrapper padding/icon
   const {onClick: handleTimeWrapperClick, onMouseUp: handleTimeWrapperMouseUp} =
     useInputContainer({
@@ -818,7 +806,7 @@ export function XDSDateTimeInput({
             <XDSIcon icon="calendar" size="sm" color="secondary" />
           </button>
           <input
-            ref={setDateRefs}
+            ref={mergeRefs(ref, dateInputRef)}
             id={dateInputId}
             type="text"
             role="combobox"

--- a/packages/core/src/Dialog/XDSDialog.tsx
+++ b/packages/core/src/Dialog/XDSDialog.tsx
@@ -37,7 +37,7 @@ import {
   spacingStepToToken,
 } from '../Layout/padding.stylex';
 import type {SpacingStep} from '../utils/types';
-import {xdsClassName, mergeProps} from '../utils';
+import {xdsClassName, mergeProps, mergeRefs} from '../utils';
 
 /**
  * Calculate a directional translate offset for dialog entry animation.
@@ -356,14 +356,7 @@ export function XDSDialog({
   const allowBackdropClick = purpose === 'info';
 
   // Merge refs
-  const setRefs = (element: HTMLDialogElement | null) => {
-    dialogRef.current = element;
-    if (typeof ref === 'function') {
-      ref(element);
-    } else if (ref) {
-      ref.current = element;
-    }
-  };
+  const setRefs = mergeRefs(ref, dialogRef);
 
   // Handle open/close state — skip for inline rendering
   useEffect(() => {

--- a/packages/core/src/FileInput/XDSFileInput.tsx
+++ b/packages/core/src/FileInput/XDSFileInput.tsx
@@ -44,7 +44,7 @@ export type {
   XDSInputStatus as XDSFileInputStatus,
   XDSInputStatusType as XDSFileInputStatusType,
 } from '../Field';
-import {xdsClassName, mergeProps} from '../utils';
+import {xdsClassName, mergeProps, mergeRefs} from '../utils';
 import {XDSBaseProps} from '../XDSBaseProps';
 
 function formatFileSize(bytes: number): string {
@@ -576,18 +576,6 @@ export function XDSFileInput({
     [isDisabled, mode, handleFiles],
   );
 
-  const setRefs = useCallback(
-    (el: HTMLInputElement | null) => {
-      inputRef.current = el;
-      if (typeof ref === 'function') {
-        ref(el);
-      } else if (ref) {
-        ref.current = el;
-      }
-    },
-    [ref],
-  );
-
   const hasFiles =
     value != null && (Array.isArray(value) ? value.length > 0 : true);
   const fileNames = hasFiles
@@ -704,7 +692,7 @@ export function XDSFileInput({
         )}>
         <input
           {...rest}
-          ref={setRefs}
+          ref={mergeRefs(ref, inputRef)}
           id={id}
           type="file"
           accept={accept}

--- a/packages/core/src/MobileNav/XDSMobileNav.tsx
+++ b/packages/core/src/MobileNav/XDSMobileNav.tsx
@@ -46,7 +46,7 @@ import {XDSButton} from '../Button';
 import {XDSIcon} from '../Icon';
 import {XDSHeading} from '../Text/XDSHeading';
 import {useXDSAppShellMobile} from '../AppShell/XDSAppShellMobileContext';
-import {xdsClassName, mergeProps} from '../utils';
+import {xdsClassName, mergeProps, mergeRefs} from '../utils';
 import {XDSBaseProps} from '../XDSBaseProps';
 
 // =============================================================================
@@ -311,17 +311,7 @@ export function XDSMobileNav({
   );
 
   // Merge refs
-  const setRefs = useCallback(
-    (element: HTMLDialogElement | null) => {
-      dialogRef.current = element;
-      if (typeof ref === 'function') {
-        ref(element);
-      } else if (ref) {
-        ref.current = element;
-      }
-    },
-    [ref],
-  );
+  const setRefs = mergeRefs(ref, dialogRef);
 
   // Open/close the dialog via showModal()/close()
   // close() is delayed so the slide-out transition can play.

--- a/packages/core/src/NavMenu/XDSNavHeadingMenu.tsx
+++ b/packages/core/src/NavMenu/XDSNavHeadingMenu.tsx
@@ -2,10 +2,10 @@
 
 'use client';
 
-import React, {useMemo, useCallback, type ReactNode} from 'react';
+import React, {useMemo, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {spacingVars} from '../theme/tokens.stylex';
-import {xdsClassName, mergeProps} from '../utils';
+import {xdsClassName, mergeProps, mergeRefs} from '../utils';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import {useListFocus} from '../hooks/useListFocus';
 import {
@@ -91,17 +91,7 @@ export function XDSNavHeadingMenu({
     onEscape: closeMenu,
   });
 
-  const mergedRef = useCallback(
-    (node: HTMLDivElement | null) => {
-      (listRef as React.MutableRefObject<HTMLDivElement | null>).current = node;
-      if (typeof ref === 'function') {
-        ref(node);
-      } else if (ref != null) {
-        (ref as React.MutableRefObject<HTMLDivElement | null>).current = node;
-      }
-    },
-    [ref, listRef],
-  );
+  const mergedRef = mergeRefs(ref, listRef);
 
   const ctx = useMemo(
     () => ({

--- a/packages/core/src/NumberInput/XDSNumberInput.tsx
+++ b/packages/core/src/NumberInput/XDSNumberInput.tsx
@@ -128,7 +128,7 @@ export type {
   XDSInputStatus as XDSNumberInputStatus,
   XDSInputStatusType as XDSNumberInputStatusType,
 } from '../Field';
-import {xdsClassName, mergeProps} from '../utils';
+import {xdsClassName, mergeProps, mergeRefs} from '../utils';
 import {XDSBaseProps} from '../XDSBaseProps';
 
 interface XDSNumberInputPropsBase extends Omit<
@@ -494,19 +494,6 @@ export function XDSNumberInput({
     ],
   );
 
-  // Combine refs
-  const setRefs = useCallback(
-    (el: HTMLInputElement | null) => {
-      inputRef.current = el;
-      if (typeof ref === 'function') {
-        ref(el);
-      } else if (ref) {
-        ref.current = el;
-      }
-    },
-    [ref],
-  );
-
   // Handle clear button click
   const handleClear = useCallback(() => {
     if (hasClear) {
@@ -548,7 +535,7 @@ export function XDSNumberInput({
       {startIcon && renderIconSlot(startIcon, {size: 'sm', color: 'secondary'})}
       <input
         {...rest}
-        ref={setRefs}
+        ref={mergeRefs(ref, inputRef)}
         id={id}
         name={htmlName}
         type="number"

--- a/packages/core/src/OverflowList/XDSOverflowList.tsx
+++ b/packages/core/src/OverflowList/XDSOverflowList.tsx
@@ -21,7 +21,7 @@ import {type ReactNode, type ReactElement, Children} from 'react';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import type {SpacingStep} from '../utils/types';
 import * as stylex from '@stylexjs/stylex';
-import {xdsClassName, mergeProps} from '../utils';
+import {xdsClassName, mergeProps, mergeRefs} from '../utils';
 import {useOverflow} from '../hooks/useOverflow';
 import {spacingVars} from '../theme/tokens.stylex';
 
@@ -243,14 +243,7 @@ export function XDSOverflowList({
 
       {/* Visible container */}
       <div
-        ref={el => {
-          containerRef(el);
-          if (typeof ref === 'function') {
-            ref(el);
-          } else if (ref) {
-            ref.current = el;
-          }
-        }}
+        ref={mergeRefs(ref, containerRef)}
         {...mergeProps(
           xdsClassName('overflow-list'),
           stylex.props(

--- a/packages/core/src/Overlay/XDSOverlay.tsx
+++ b/packages/core/src/Overlay/XDSOverlay.tsx
@@ -18,7 +18,7 @@
 import {type ReactNode, type Ref} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
-import {xdsClassName, mergeProps} from '../utils';
+import {xdsClassName, mergeProps, mergeRefs} from '../utils';
 import {useXDSOverlay} from './useXDSOverlay';
 import {useIsomorphicLayoutEffect} from '../hooks/useIsomorphicLayoutEffect';
 import {overlayScope, overlayContainerStyles} from './overlay.markers.stylex';
@@ -124,14 +124,7 @@ export function XDSOverlay({
 
   return (
     <div
-      ref={(node: HTMLDivElement | null) => {
-        overlay.containerRef.current = node;
-        if (typeof ref === 'function') {
-          ref(node);
-        } else if (ref != null) {
-          ref.current = node;
-        }
-      }}
+      ref={mergeRefs(ref, overlay.containerRef)}
       {...mergeProps(
         xdsClassName('overlay'),
         stylex.props(overlayScope, overlayContainerStyles.root, xstyle),

--- a/packages/core/src/Resizable/XDSResizeHandle.tsx
+++ b/packages/core/src/Resizable/XDSResizeHandle.tsx
@@ -30,7 +30,7 @@ import {
   radiusVars,
   spacingVars,
 } from '../theme/tokens.stylex';
-import {xdsClassName, mergeProps} from '../utils';
+import {xdsClassName, mergeProps, mergeRefs} from '../utils';
 import type {ResizableProps} from './useXDSResizable';
 
 const KEYBOARD_STEP = 10;
@@ -471,14 +471,7 @@ export function XDSResizeHandle({
 
   return (
     <div
-      ref={node => {
-        handleRef.current = node;
-        if (typeof ref === 'function') {
-          ref(node);
-        } else if (ref) {
-          ref.current = node;
-        }
-      }}
+      ref={mergeRefs(ref, handleRef)}
       role="separator"
       aria-orientation={isHorizontal ? 'vertical' : 'horizontal'}
       aria-valuenow={ariaValueNow}

--- a/packages/core/src/SegmentedControl/XDSSegmentedControl.tsx
+++ b/packages/core/src/SegmentedControl/XDSSegmentedControl.tsx
@@ -23,7 +23,7 @@ import type {
   XDSSegmentedControlSize,
   XDSSegmentedControlLayout,
 } from './XDSSegmentedControlContext';
-import {xdsClassName, mergeProps} from '../utils';
+import {xdsClassName, mergeProps, mergeRefs} from '../utils';
 import {useXDSSize} from '../SizeContext/XDSSizeContext';
 import type {XDSBaseProps} from '../XDSBaseProps';
 
@@ -135,14 +135,7 @@ export function XDSSegmentedControl({
   const containerRef = useRef<HTMLDivElement>(null);
 
   // Merge refs
-  const setContainerRef = (element: HTMLDivElement | null) => {
-    (containerRef as React.RefObject<HTMLDivElement | null>).current = element;
-    if (typeof ref === 'function') {
-      ref(element);
-    } else if (ref) {
-      (ref as React.RefObject<HTMLDivElement | null>).current = element;
-    }
-  };
+  const setContainerRef = mergeRefs(ref, containerRef);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {

--- a/packages/core/src/SelectableCard/XDSSelectableCard.tsx
+++ b/packages/core/src/SelectableCard/XDSSelectableCard.tsx
@@ -37,7 +37,7 @@ import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import {colorVars} from '../theme/tokens.stylex';
 import type {SizeValue, SpacingStep} from '../utils/types';
-import {xdsClassName} from '../utils';
+import {xdsClassName, mergeRefs} from '../utils';
 import {XDSCard} from '../Card/XDSCard';
 import type {XDSCardVariant} from '../Card/XDSCard';
 import {useClickableContainer} from '../hooks/useClickableContainer';
@@ -315,14 +315,9 @@ export function XDSSelectableCard({
 
   return (
     <XDSCard
-      ref={(node: HTMLDivElement | null) => {
+      ref={mergeRefs(ref, (node: HTMLDivElement | null) => {
         containerRef.current = node;
-        if (typeof ref === 'function') {
-          ref(node);
-        } else if (ref != null) {
-          ref.current = node;
-        }
-      }}
+      })}
       width={width}
       height={height}
       maxWidth={maxWidth}

--- a/packages/core/src/SideNav/XDSSideNav.tsx
+++ b/packages/core/src/SideNav/XDSSideNav.tsx
@@ -26,7 +26,7 @@ import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import {borderVars, colorVars, spacingVars} from '../theme/tokens.stylex';
-import {xdsClassName, mergeProps} from '../utils';
+import {xdsClassName, mergeProps, mergeRefs} from '../utils';
 import {XDSSideNavCollapseContext} from './XDSSideNavCollapseContext';
 import {XDSSideNavCollapseButton} from './XDSSideNavCollapseButton';
 import {useXDSSideNavRenderMode} from './XDSSideNavRenderContext';
@@ -454,14 +454,7 @@ export function XDSSideNav({
 
   const navElement = (
     <nav
-      ref={node => {
-        navRef.current = node;
-        if (typeof ref === 'function') {
-          ref(node);
-        } else if (ref) {
-          ref.current = node;
-        }
-      }}
+      ref={mergeRefs(ref, navRef)}
       role="navigation"
       aria-label="Side navigation"
       data-testid={testId}

--- a/packages/core/src/SideNav/XDSSideNavHeading.tsx
+++ b/packages/core/src/SideNav/XDSSideNavHeading.tsx
@@ -19,7 +19,7 @@
  * - /packages/cli/templates/blocks/components/SideNav/ (showcase blocks)
  */
 
-import {useCallback, useMemo, useRef, type ReactNode} from 'react';
+import {useMemo, useRef, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {
   colorVars,
@@ -39,7 +39,7 @@ import {navItemStyles} from '../NavItem/navItemStyles.stylex';
 import {useXDSSideNavCollapse} from './XDSSideNavCollapseContext';
 import {useXDSLinkComponent} from '../Link/useXDSLinkComponent';
 import type {XDSLinkComponentType} from '../Link/types';
-import {xdsClassName, mergeProps} from '../utils';
+import {xdsClassName, mergeProps, mergeRefs} from '../utils';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import {useXDSMenuHover} from '../hooks/useXDSMenuHover';
 import {XDSNavHeadingCloseContext} from '../NavMenu/XDSNavMenuContext';
@@ -364,20 +364,11 @@ export function XDSSideNavHeading({
     showDelay: 0,
   });
 
-  const setRef = useCallback(
-    (el: HTMLDivElement | null) => {
-      (rootRef as React.RefObject<HTMLDivElement | null>).current = el;
-      setTriggerEl(el);
-      if (typeof ref === 'function') {
-        ref(el);
-      } else if (ref) {
-        (ref as React.RefObject<HTMLDivElement | null>).current = el;
-      }
-      if (menu) {
-        popover.triggerRef(el);
-      }
-    },
-    [ref, popover, menu, setTriggerEl],
+  const setRef = mergeRefs<HTMLDivElement>(
+    rootRef,
+    setTriggerEl as React.Ref<HTMLDivElement>,
+    ref,
+    menu ? (popover.triggerRef as React.Ref<HTMLDivElement>) : undefined,
   );
 
   // In collapsed mode: hide if no icon, show icon-only if has icon
@@ -387,15 +378,10 @@ export function XDSSideNavHeading({
   if (isCollapsed && icon) {
     const collapsedIcon = <span {...stylex.props(styles.icon)}>{icon}</span>;
 
-    const collapsedSetRef = (el: HTMLElement | null) => {
-      (collapsedItemRef as React.RefObject<HTMLElement | null>).current = el;
-      if (typeof ref === 'function') {
-        ref(el as HTMLDivElement | null);
-      } else if (ref) {
-        (ref as React.RefObject<HTMLDivElement | null>).current =
-          el as HTMLDivElement | null;
-      }
-    };
+    const collapsedSetRef = mergeRefs<HTMLElement>(
+      collapsedItemRef,
+      ref as React.Ref<HTMLElement>,
+    );
 
     let collapsedElement: ReactNode;
 

--- a/packages/core/src/SideNav/XDSSideNavItem.tsx
+++ b/packages/core/src/SideNav/XDSSideNavItem.tsx
@@ -42,7 +42,7 @@ import {renderIconSlot, type XDSIconType} from '../Icon';
 import {useXDSLinkComponent} from '../Link/useXDSLinkComponent';
 import type {XDSLinkComponentType} from '../Link/types';
 import {useXDSPopover} from '../Popover/useXDSPopover';
-import {xdsClassName, mergeProps} from '../utils';
+import {xdsClassName, mergeProps, mergeRefs} from '../utils';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import {XDSTooltip} from '../Tooltip';
 import {navItemStyles, type NavItemSize} from '../NavItem/navItemStyles.stylex';
@@ -501,14 +501,7 @@ export function XDSSideNavItem({
       return (
         <div {...stylex.props(styles.root)}>
           <button
-            ref={el => {
-              popover.triggerRef(el);
-              if (typeof ref === 'function') {
-                ref(el);
-              } else if (ref) {
-                ref.current = el;
-              }
-            }}
+            ref={mergeRefs(ref, popover.triggerRef)}
             type="button"
             onClick={popover.toggle}
             onMouseEnter={handlePopoverMouseEnter}

--- a/packages/core/src/Slider/XDSSlider.tsx
+++ b/packages/core/src/Slider/XDSSlider.tsx
@@ -38,7 +38,7 @@ import {
 import {XDSField} from '../Field/XDSField';
 import {XDSTooltip} from '../Tooltip/XDSTooltip';
 import type {XDSInputStatus} from '../Field/types';
-import {xdsClassName, mergeProps} from '../utils';
+import {xdsClassName, mergeProps, mergeRefs} from '../utils';
 import type {XDSBaseProps} from '../XDSBaseProps';
 
 // =============================================================================
@@ -747,15 +747,7 @@ export function XDSSlider({ref, ...props}: XDSSliderProps) {
           stylex.props(styles.sliderRow),
         )}>
         <div
-          ref={node => {
-            // Merge refs
-            trackRef.current = node;
-            if (typeof ref === 'function') {
-              ref(node);
-            } else if (ref) {
-              ref.current = node;
-            }
-          }}
+          ref={mergeRefs(ref, trackRef)}
           {...(isRange ? {role: 'group', 'aria-label': label} : undefined)}
           onPointerDown={handlePointerDown}
           onPointerMove={handlePointerMove}

--- a/packages/core/src/TabList/XDSTabMenu.tsx
+++ b/packages/core/src/TabList/XDSTabMenu.tsx
@@ -34,7 +34,7 @@ import {useListFocus} from '../hooks/useListFocus';
 import {useXDSTabListContext} from './XDSTabListContext';
 import type {XDSTabListSize} from './XDSTabListContext';
 import {tabScope} from './tab.markers.stylex';
-import {xdsClassName, mergeProps} from '../utils';
+import {xdsClassName, mergeProps, mergeRefs} from '../utils';
 import type {XDSBaseProps} from '../XDSBaseProps';
 
 export interface XDSTabMenuOption {
@@ -293,16 +293,9 @@ export function XDSTabMenu({
     [tabListCtx, popover],
   );
 
-  const setButtonRef = useCallback(
-    (el: HTMLButtonElement | null) => {
-      popover.triggerRef(el);
-      if (typeof ref === 'function') {
-        ref(el);
-      } else if (ref) {
-        (ref as React.MutableRefObject<HTMLButtonElement | null>).current = el;
-      }
-    },
-    [popover, ref],
+  const setButtonRef = mergeRefs<HTMLButtonElement>(
+    popover.triggerRef as React.Ref<HTMLButtonElement>,
+    ref,
   );
 
   return (

--- a/packages/core/src/Table/plugins/selection/useXDSTableSelection.tsx
+++ b/packages/core/src/Table/plugins/selection/useXDSTableSelection.tsx
@@ -40,11 +40,11 @@ import {
   useMemo,
   useSyncExternalStore,
   type ReactNode,
-  type Ref,
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars} from '../../../theme/tokens.stylex';
 import {XDSCheckboxInput} from '../../../CheckboxInput';
+import {mergeRefs} from '../../../utils';
 import type {
   TablePlugin,
   XDSTableColumn,
@@ -123,26 +123,6 @@ function applyRowSelectionStyle(
     el.removeAttribute('aria-selected');
     el.style.backgroundColor = '';
   }
-}
-
-// =============================================================================
-// Ref Merging Utility
-// =============================================================================
-
-/**
- * Compose multiple refs into a single callback ref.
- * Used when multiple plugins need to attach refs to the same row.
- */
-function mergeRefs<T>(...refs: (Ref<T> | undefined)[]): React.RefCallback<T> {
-  return (el: T | null) => {
-    for (const ref of refs) {
-      if (typeof ref === 'function') {
-        ref(el);
-      } else if (ref != null) {
-        ref.current = el;
-      }
-    }
-  };
 }
 
 // =============================================================================

--- a/packages/core/src/Text/XDSHeading.tsx
+++ b/packages/core/src/Text/XDSHeading.tsx
@@ -16,7 +16,7 @@
  * - /packages/cli/templates/blocks/components/Text/ (showcase blocks)
  */
 
-import {lazy, Suspense, useCallback, useRef, type ReactNode} from 'react';
+import {lazy, Suspense, useRef, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {
   XDSTextColor,
@@ -39,7 +39,7 @@ import {
 } from './text.stylex';
 import {useTruncation} from './useTruncation';
 import type {LayerPlacement} from '../Layer';
-import {xdsClassName, mergeProps} from '../utils';
+import {xdsClassName, mergeProps, mergeRefs} from '../utils';
 import type {XDSBaseProps} from '../XDSBaseProps';
 
 const LazyXDSTooltip = lazy(() =>
@@ -230,21 +230,7 @@ export function XDSHeading({
   const headingRef = useRef<HTMLHeadingElement>(null);
 
   // Merge refs: ref, truncation.ref, headingRef
-  const mergedRef = useCallback(
-    (element: HTMLHeadingElement | null) => {
-      // Forward ref
-      if (typeof ref === 'function') {
-        ref(element);
-      } else if (ref) {
-        ref.current = element;
-      }
-      // Truncation ref
-      truncation.ref(element);
-      // Local ref for tooltip anchor
-      headingRef.current = element;
-    },
-    [ref, truncation],
-  );
+  const mergedRef = mergeRefs(ref, truncation.ref, headingRef);
 
   // Build inline style for -webkit-line-clamp (dynamic value)
   const inlineStyle = maxLines > 1 ? {WebkitLineClamp: maxLines} : undefined;

--- a/packages/core/src/Text/XDSText.tsx
+++ b/packages/core/src/Text/XDSText.tsx
@@ -16,7 +16,7 @@
  * - /packages/cli/templates/blocks/components/Text/ (showcase blocks)
  */
 
-import {lazy, Suspense, useCallback, useRef, type ReactNode} from 'react';
+import {lazy, Suspense, useRef, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {
   XDSTextType,
@@ -44,7 +44,7 @@ import {
 } from './text.stylex';
 import {useTruncation} from './useTruncation';
 import type {LayerPlacement} from '../Layer';
-import {xdsClassName, mergeProps} from '../utils';
+import {xdsClassName, mergeProps, mergeRefs} from '../utils';
 import type {XDSBaseProps} from '../XDSBaseProps';
 
 const LazyXDSTooltip = lazy(() =>
@@ -236,21 +236,7 @@ export function XDSText({
   const textRef = useRef<HTMLElement>(null);
 
   // Merge refs: ref, truncation.ref, textRef
-  const mergedRef = useCallback(
-    (element: HTMLElement | null) => {
-      // Forward ref
-      if (typeof ref === 'function') {
-        ref(element);
-      } else if (ref) {
-        ref.current = element;
-      }
-      // Truncation ref
-      truncation.ref(element);
-      // Local ref for tooltip anchor
-      textRef.current = element;
-    },
-    [ref, truncation],
-  );
+  const mergedRef = mergeRefs(ref, truncation.ref, textRef);
 
   // Build inline style for -webkit-line-clamp (dynamic value)
   const inlineStyle = maxLines > 1 ? {WebkitLineClamp: maxLines} : undefined;

--- a/packages/core/src/TextArea/XDSTextArea.tsx
+++ b/packages/core/src/TextArea/XDSTextArea.tsx
@@ -20,7 +20,6 @@ import {
   useId,
   useOptimistic,
   useTransition,
-  useCallback,
   useRef,
   type ChangeEvent,
   type ClipboardEvent,
@@ -44,7 +43,7 @@ import {
 } from '../Field';
 import {XDSIcon, renderIconSlot, type XDSIconType} from '../Icon';
 import {XDSSpinner} from '../Spinner';
-import {xdsClassName, mergeProps} from '../utils';
+import {xdsClassName, mergeProps, mergeRefs} from '../utils';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import {useInputContainer} from '../hooks/useInputContainer';
 
@@ -324,19 +323,6 @@ export function XDSTextArea({
 
   const effectivelyDisabled = isDisabled || isBusy;
 
-  // Combine refs
-  const setRefs = useCallback(
-    (el: HTMLTextAreaElement | null) => {
-      textareaRef.current = el;
-      if (typeof ref === 'function') {
-        ref(el);
-      } else if (ref) {
-        ref.current = el;
-      }
-    },
-    [ref],
-  );
-
   // Focus textarea when clicking anywhere on the wrapper (icons, padding, etc.)
   const {onClick: handleWrapperClick, onMouseUp: handleWrapperMouseUp} =
     useInputContainer({
@@ -387,7 +373,7 @@ export function XDSTextArea({
           renderIconSlot(startIcon, {size: 'sm', color: 'secondary'})}
         <textarea
           {...rest}
-          ref={setRefs}
+          ref={mergeRefs(ref, textareaRef)}
           id={id}
           name={htmlName}
           value={String(optimisticValue)}

--- a/packages/core/src/TextInput/XDSTextInput.tsx
+++ b/packages/core/src/TextInput/XDSTextInput.tsx
@@ -113,7 +113,7 @@ export type {
   XDSInputStatus as XDSTextInputStatus,
   XDSInputStatusType as XDSTextInputStatusType,
 } from '../Field';
-import {xdsClassName, mergeProps} from '../utils';
+import {xdsClassName, mergeProps, mergeRefs} from '../utils';
 import {useXDSSize} from '../SizeContext/XDSSizeContext';
 import {useInputContainer} from '../hooks/useInputContainer';
 import {useXDSInputGroup} from '../InputGroup/XDSInputGroupContext';
@@ -317,19 +317,6 @@ export function XDSTextInput({
     inputRef.current?.focus();
   }, [onChange]);
 
-  // Combine refs
-  const setRefs = useCallback(
-    (el: HTMLInputElement | null) => {
-      inputRef.current = el;
-      if (typeof ref === 'function') {
-        ref(el);
-      } else if (ref) {
-        ref.current = el;
-      }
-    },
-    [ref],
-  );
-
   // Focus input when clicking anywhere on the wrapper (icons, padding, etc.)
   const {onClick: handleWrapperClick, onMouseUp: handleWrapperMouseUp} =
     useInputContainer({
@@ -361,7 +348,7 @@ export function XDSTextInput({
       {startIcon && renderIconSlot(startIcon, {size: 'sm', color: 'secondary'})}
       <input
         {...rest}
-        ref={setRefs}
+        ref={mergeRefs(ref, inputRef)}
         id={id}
         name={htmlName}
         type={type}

--- a/packages/core/src/TimeInput/XDSTimeInput.tsx
+++ b/packages/core/src/TimeInput/XDSTimeInput.tsx
@@ -58,6 +58,7 @@ import {
   isTimeInRange,
   xdsClassName,
   mergeProps,
+  mergeRefs,
 } from '../utils';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import {useXDSSize} from '../SizeContext/XDSSizeContext';
@@ -492,19 +493,6 @@ export function XDSTimeInput({
     inputRef.current?.focus();
   }, [fireChange]);
 
-  // Combine refs
-  const setRefs = useCallback(
-    (el: HTMLInputElement | null) => {
-      inputRef.current = el;
-      if (typeof ref === 'function') {
-        ref(el);
-      } else if (ref) {
-        ref.current = el;
-      }
-    },
-    [ref],
-  );
-
   // Focus input when clicking anywhere on the wrapper (icons, padding, etc.)
   const {onClick: handleWrapperClick, onMouseUp: handleWrapperMouseUp} =
     useInputContainer({
@@ -555,7 +543,7 @@ export function XDSTimeInput({
           <XDSIcon icon="clock" size="sm" color="secondary" />
         </div>
         <input
-          ref={setRefs}
+          ref={mergeRefs(ref, inputRef)}
           id={id}
           type="text"
           value={displayValue}

--- a/packages/core/src/Timestamp/XDSTimestamp.tsx
+++ b/packages/core/src/Timestamp/XDSTimestamp.tsx
@@ -25,7 +25,7 @@ import type {
   XDSTextColor,
   XDSTextWeight,
 } from '../theme/types';
-import {xdsClassName} from '../utils';
+import {xdsClassName, mergeRefs} from '../utils';
 import type {XDSBaseProps} from '../XDSBaseProps';
 
 const LazyXDSTooltip = lazy(() =>
@@ -376,14 +376,7 @@ export function XDSTimestamp({
   }, [isLive, effectiveFormat, diffSeconds]);
 
   // Tooltip needs the ref
-  const combinedRef = (el: HTMLTimeElement | null) => {
-    timeRef.current = el;
-    if (typeof ref === 'function') {
-      ref(el);
-    } else if (ref) {
-      ref.current = el;
-    }
-  };
+  const combinedRef = mergeRefs(ref, timeRef);
 
   const showTooltip = hasTooltip && effectiveFormat === 'relative';
 

--- a/packages/core/src/TopNav/XDSTopNavHeading.tsx
+++ b/packages/core/src/TopNav/XDSTopNavHeading.tsx
@@ -20,7 +20,7 @@
  * - /packages/cli/templates/blocks/components/TopNav/ (showcase blocks)
  */
 
-import {useCallback, useMemo, useRef, type ReactNode} from 'react';
+import {useMemo, useRef, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {
   colorVars,
@@ -34,7 +34,7 @@ import {XDSLink} from '../Link';
 import {getIcon} from '../Icon/globalIconRegistry';
 import {useXDSLinkComponent} from '../Link/useXDSLinkComponent';
 import type {XDSLinkComponentType} from '../Link/types';
-import {xdsClassName, mergeProps} from '../utils';
+import {xdsClassName, mergeProps, mergeRefs} from '../utils';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import {useXDSMenuHover} from '../hooks/useXDSMenuHover';
 import {XDSNavHeadingCloseContext} from '../NavMenu/XDSNavMenuContext';
@@ -334,20 +334,11 @@ export function XDSTopNavHeading({
     showDelay: 0,
   });
 
-  const setRef = useCallback(
-    (el: HTMLElement | null) => {
-      rootRef.current = el;
-      setTriggerEl(el);
-      if (typeof ref === 'function') {
-        ref(el);
-      } else if (ref) {
-        ref.current = el;
-      }
-      if (menu) {
-        popover.triggerRef(el);
-      }
-    },
-    [ref, popover, menu, setTriggerEl],
+  const setRef = mergeRefs<HTMLElement>(
+    rootRef,
+    setTriggerEl as React.Ref<HTMLElement>,
+    ref,
+    menu ? (popover.triggerRef as React.Ref<HTMLElement>) : undefined,
   );
 
   const showChevron = !!menu;

--- a/packages/core/src/TopNav/XDSTopNavMegaMenu.tsx
+++ b/packages/core/src/TopNav/XDSTopNavMegaMenu.tsx
@@ -45,7 +45,7 @@ import {
 import {useXDSPopover} from '../Popover/useXDSPopover';
 import {XDSGrid} from '../Grid/XDSGrid';
 import {getIcon} from '../Icon/globalIconRegistry';
-import {xdsClassName, mergeProps} from '../utils';
+import {xdsClassName, mergeProps, mergeRefs} from '../utils';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import {navItemStyles} from '../NavItem/navItemStyles.stylex';
 import {useTopNavSlot} from './TopNavContext';
@@ -428,17 +428,7 @@ function DefaultMegaMenu({
     };
   }, [clearTimeouts]);
 
-  const setButtonRef = useCallback(
-    (el: HTMLButtonElement | null) => {
-      triggerButtonRef.current = el;
-      if (typeof ref === 'function') {
-        ref(el);
-      } else if (ref) {
-        (ref as React.MutableRefObject<HTMLButtonElement | null>).current = el;
-      }
-    },
-    [ref],
-  );
+  const setButtonRef = mergeRefs(triggerButtonRef, ref);
 
   return (
     <>

--- a/packages/core/src/TopNav/XDSTopNavMenu.tsx
+++ b/packages/core/src/TopNav/XDSTopNavMenu.tsx
@@ -15,18 +15,12 @@
  * - /packages/cli/templates/blocks/components/TopNav/ (showcase blocks)
  */
 
-import React, {
-  useCallback,
-  useId,
-  useRef,
-  useState,
-  type ReactNode,
-} from 'react';
+import React, {useId, useRef, useState, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {useXDSPopover} from '../Popover/useXDSPopover';
 import {useXDSMenuHover} from '../hooks/useXDSMenuHover';
 import {getIcon} from '../Icon/globalIconRegistry';
-import {xdsClassName, mergeProps} from '../utils';
+import {xdsClassName, mergeProps, mergeRefs} from '../utils';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import {navItemStyles} from '../NavItem/navItemStyles.stylex';
 import {useTopNavSlot} from './TopNavContext';
@@ -346,18 +340,11 @@ export function XDSTopNavMenu({
     hideDelay,
   });
 
-  const setTriggerRef = useCallback(
-    (el: HTMLButtonElement | null) => {
-      triggerButtonRef.current = el;
-      popover.triggerRef(el);
-      setTriggerEl(el);
-      if (typeof ref === 'function') {
-        ref(el);
-      } else if (ref) {
-        (ref as React.MutableRefObject<HTMLButtonElement | null>).current = el;
-      }
-    },
-    [popover, setTriggerEl, ref],
+  const setTriggerRef = mergeRefs<HTMLButtonElement>(
+    triggerButtonRef,
+    popover.triggerRef as React.Ref<HTMLButtonElement>,
+    setTriggerEl as React.Ref<HTMLButtonElement>,
+    ref,
   );
 
   // Mobile bar: hide menus entirely

--- a/packages/core/src/Typeahead/XDSBaseTypeahead.tsx
+++ b/packages/core/src/Typeahead/XDSBaseTypeahead.tsx
@@ -39,7 +39,7 @@ import {
   fontWeightVars,
   typeScaleVars,
 } from '../theme/tokens.stylex';
-import {xdsClassName, mergeProps} from '../utils';
+import {xdsClassName, mergeProps, mergeRefs} from '../utils';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import type {XDSSearchableItem, XDSSearchSource} from './types';
 
@@ -367,19 +367,7 @@ export const XDSBaseTypeahead = function XDSBaseTypeahead<
   }, [popover]);
 
   // Merge refs: forward ref + internal ref + fallback anchor ref
-  const setInputRef = useCallback(
-    (el: HTMLInputElement | null) => {
-      (inputRef as React.RefObject<HTMLInputElement | null>).current = el;
-      (fallbackAnchorRef as React.RefObject<HTMLInputElement | null>).current =
-        el;
-      if (typeof ref === 'function') {
-        ref(el);
-      } else if (ref) {
-        (ref as React.RefObject<HTMLInputElement | null>).current = el;
-      }
-    },
-    [ref],
-  );
+  const setInputRef = mergeRefs(ref, inputRef, fallbackAnchorRef);
 
   // Set up anchor on the provided anchorRef or fall back to the input itself
   useEffect(() => {

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -62,6 +62,7 @@ export {parseStyleKey} from './parseStyleKey';
 export {xdsClassName} from './xdsClassName';
 
 export {mergeProps} from './mergeProps';
+export {mergeRefs} from './mergeRefs';
 export {groupItems, getItemGroup} from './groupItems';
 export type {ItemGroup} from './groupItems';
 export {observeResize, unobserveResize} from './sharedResizeObserver';

--- a/packages/core/src/utils/mergeRefs.ts
+++ b/packages/core/src/utils/mergeRefs.ts
@@ -1,0 +1,32 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file mergeRefs.ts
+ * @input Multiple React refs (callback, object, or undefined)
+ * @output A single callback ref that forwards to all inputs
+ * @position Utility; used by components that need to merge an external ref
+ *   with an internal ref (e.g., popover trigger + consumer ref).
+ */
+
+import type {Ref, RefCallback} from 'react';
+
+export function mergeRefs<T>(...refs: (Ref<T> | undefined)[]): RefCallback<T> {
+  return (value: T | null) => {
+    const cleanups: (() => void)[] = [];
+    for (const ref of refs) {
+      if (typeof ref === 'function') {
+        const cleanup = ref(value);
+        if (typeof cleanup === 'function') {
+          cleanups.push(cleanup);
+        }
+      } else if (ref != null) {
+        (ref as {current: T | null}).current = value;
+      }
+    }
+    if (cleanups.length > 0) {
+      return () => {
+        for (const cleanup of cleanups) {cleanup();}
+      };
+    }
+  };
+}


### PR DESCRIPTION
## Summary

  Stacked on #<require-ref-prop PR number>.

  - **New `mergeRefs()` utility** in `packages/core/src/utils/` — combines multiple React refs into a single callback ref
  - Supports **React 19 ref cleanup functions** — if any merged callback ref returns a cleanup, the combined ref returns a cleanup that calls all of them
  - **Replaces 36 hand-rolled instances** of `typeof ref === 'function' / ref.current = el` across 33 component files (-329 net lines)
  - Removes the local `mergeRefs` copy from `useXDSTableSelection`

  ## Test plan

  - [x] `tsc --noEmit --project packages/core/tsconfig.build.json` — 0 errors
  - [x] `grep` for remaining `typeof ref === 'function'` patterns — 0 found
  - [x] All lint hooks pass