### PR TITLE
fix(core): harden Typeahead/Tokenizer clear button and checkmark icon

### DIFF
--- a/apps/storybook/stories/PowerSearch.stories.tsx
+++ b/apps/storybook/stories/PowerSearch.stories.tsx
@@ -1055,7 +1055,14 @@ export const WithEndContentPowerSearch: Story = {
         filters={filters}
         onChange={newFilters => setFilters([...newFilters])}
         resultCount={42}
-        endContent={<XDSButton label="Save" variant="primary" size="sm" />}
+        endContent={
+          <XDSButton
+            label="Save"
+            variant="primary"
+            size="sm"
+            style={{height: '20px'}}
+          />
+        }
       />
     );
   },

--- a/packages/core/src/Field/XDSInputClearButton.tsx
+++ b/packages/core/src/Field/XDSInputClearButton.tsx
@@ -1,0 +1,46 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file XDSInputClearButton.tsx
+ * @input Uses React, XDSButton, XDSIcon
+ * @output Exports XDSInputClearButton shared clear button for input components
+ * @position Shared primitive; used by XDSTypeahead, XDSTokenizer, XDSTextInput
+ */
+
+import type {ReactNode} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {XDSButton} from '../Button';
+import {XDSIcon} from '../Icon';
+
+const styles = stylex.create({
+  button: {
+    height: '20px',
+    flexShrink: 0,
+  },
+});
+
+export interface XDSInputClearButtonProps {
+  label: string;
+  onClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  xstyle?: stylex.StyleXStyles;
+}
+
+export function XDSInputClearButton({
+  label,
+  onClick,
+  xstyle,
+}: XDSInputClearButtonProps): ReactNode {
+  return (
+    <XDSButton
+      variant="ghost"
+      size="sm"
+      label={label}
+      icon={<XDSIcon icon="close" size="sm" color="inherit" />}
+      onClick={onClick}
+      isIconOnly
+      xstyle={[styles.button, xstyle]}
+    />
+  );
+}

--- a/packages/core/src/Field/index.ts
+++ b/packages/core/src/Field/index.ts
@@ -37,3 +37,6 @@ export {
   inputStatusFocusWithinStyles,
   inputStatusFocusStyles,
 } from './inputStyles.stylex';
+
+// Shared input components
+export {XDSInputClearButton} from './XDSInputClearButton';

--- a/packages/core/src/Tokenizer/XDSTokenizer.tsx
+++ b/packages/core/src/Tokenizer/XDSTokenizer.tsx
@@ -29,6 +29,7 @@ import {XDSBaseTypeahead} from '../Typeahead/XDSBaseTypeahead';
 import {useXDSSize} from '../SizeContext/XDSSizeContext';
 import {
   XDSField,
+  XDSInputClearButton,
   type XDSInputStatus,
   inputWrapperStyles,
   inputStatusBorderStyles,
@@ -36,14 +37,12 @@ import {
   inputStatusFocusWithinStyles,
 } from '../Field';
 import {XDSToken} from '../Token';
-import {XDSIcon} from '../Icon';
 import {renderIconSlot, type XDSIconType} from '../Icon';
 import {XDSOverflowList} from '../OverflowList';
 import {useXDSLayer} from '../Layer/useXDSLayer';
 import {
   colorVars,
   spacingVars,
-  radiusVars,
   sizeVars,
   typeScaleVars,
 } from '../theme/tokens.stylex';
@@ -210,32 +209,16 @@ const styles = stylex.create({
     display: 'flex',
     flexShrink: 0,
   },
-  clearAllButton: {
-    all: 'unset',
-    display: 'inline-flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    cursor: 'pointer',
-    padding: spacingVars['--spacing-1'],
-    borderRadius: radiusVars['--radius-full'],
-    color: colorVars['--color-text-secondary'],
-    opacity: {
-      default: 0.7,
-      ':hover': {
-        '@media (hover: hover)': 1,
-      },
-    },
-    flexShrink: 0,
-  },
   endSection: {
     position: 'absolute',
-    top: 0,
-    insetInlineEnd: 0,
+    // -1px to account for the wrapper's 1px border
+    top: '-1px',
+    // Match the wrapperWithTokens inline padding for consistent inset
+    insetInlineEnd: `calc(${spacingVars['--spacing-1']} - 1px)`,
     display: 'flex',
     alignItems: 'center',
-    gap: spacingVars['--spacing-1'],
+    gap: spacingVars['--spacing-2'],
     flexShrink: 0,
-    paddingInlineEnd: spacingVars['--spacing-2'],
   },
   endSectionSm: {
     height: sizeVars['--size-element-sm'],
@@ -733,16 +716,13 @@ export function XDSTokenizer<T extends XDSSearchableItem>({
           )}>
           {endContent}
           {hasClear && value.length > 0 && !isDisabled && (
-            <button
-              type="button"
-              aria-label="Clear all"
+            <XDSInputClearButton
+              label="Clear all"
               onClick={e => {
                 e.stopPropagation();
                 handleClearAll();
               }}
-              {...stylex.props(styles.clearAllButton)}>
-              <XDSIcon icon="close" size="sm" />
-            </button>
+            />
           )}
         </div>
       )}

--- a/packages/core/src/Typeahead/XDSBaseTypeahead.tsx
+++ b/packages/core/src/Typeahead/XDSBaseTypeahead.tsx
@@ -708,7 +708,7 @@ export const XDSBaseTypeahead = function XDSBaseTypeahead<
                   )}
                 </span>
                 {value?.id === item.id && (
-                  <XDSIcon icon="check" size="sm" color="accent" />
+                  <XDSIcon icon="check" size="sm" color="primary" />
                 )}
               </div>
             ))

--- a/packages/core/src/Typeahead/XDSTypeahead.test.tsx
+++ b/packages/core/src/Typeahead/XDSTypeahead.test.tsx
@@ -201,7 +201,7 @@ describe('XDSTypeahead', () => {
     expect(screen.getByText('Selection required')).toBeInTheDocument();
   });
 
-  it('shows selected value as a token with remove button', () => {
+  it('shows selected value as a token', () => {
     render(
       <XDSTypeahead
         label="Fruit"
@@ -210,12 +210,40 @@ describe('XDSTypeahead', () => {
         onChange={() => {}}
       />,
     );
+    expect(screen.getByText(fruits[0].label)).toBeInTheDocument();
+  });
+
+  it('shows clear button when hasClear and value is selected', () => {
+    render(
+      <XDSTypeahead
+        label="Fruit"
+        searchSource={fruitSource}
+        value={fruits[0]}
+        onChange={() => {}}
+        hasClear
+      />,
+    );
     expect(
-      screen.getByRole('button', {name: `Remove ${fruits[0].label}`}),
+      screen.getByRole('button', {name: 'Clear selection'}),
     ).toBeInTheDocument();
   });
 
-  it('calls onChange with null when token remove is clicked', () => {
+  it('does not show clear button when hasClear is false', () => {
+    render(
+      <XDSTypeahead
+        label="Fruit"
+        searchSource={fruitSource}
+        value={fruits[0]}
+        onChange={() => {}}
+        hasClear={false}
+      />,
+    );
+    expect(
+      screen.queryByRole('button', {name: 'Clear selection'}),
+    ).not.toBeInTheDocument();
+  });
+
+  it('calls onChange with null when clear button is clicked', () => {
     const onChange = vi.fn();
     render(
       <XDSTypeahead
@@ -223,11 +251,10 @@ describe('XDSTypeahead', () => {
         searchSource={fruitSource}
         value={fruits[0]}
         onChange={onChange}
+        hasClear
       />,
     );
-    fireEvent.click(
-      screen.getByRole('button', {name: `Remove ${fruits[0].label}`}),
-    );
+    fireEvent.click(screen.getByRole('button', {name: 'Clear selection'}));
     expect(onChange).toHaveBeenCalledWith(null);
   });
 
@@ -427,11 +454,9 @@ describe('XDSTypeahead edit mode', () => {
     );
     screen.getByRole('combobox');
 
-    // Click the token area to enter edit mode
-    const removeButton = screen.getByRole('button', {
-      name: `Remove ${fruits[0].label}`,
-    });
-    const tokenContainer = removeButton.closest('div')!;
+    // Click the token text to enter edit mode
+    const tokenText = screen.getByText(fruits[0].label);
+    const tokenContainer = tokenText.closest('div')!;
     fireEvent.click(tokenContainer);
 
     // onChange should NOT have been called (value is preserved for restore)
@@ -451,10 +476,8 @@ describe('XDSTypeahead edit mode', () => {
     const input = screen.getByRole('combobox');
 
     // Enter edit mode
-    const removeButton = screen.getByRole('button', {
-      name: `Remove ${fruits[0].label}`,
-    });
-    fireEvent.click(removeButton.closest('div')!);
+    const tokenText = screen.getByText(fruits[0].label);
+    fireEvent.click(tokenText.closest('div')!);
 
     // Blur without selecting anything
     fireEvent.blur(input);

--- a/packages/core/src/Typeahead/XDSTypeahead.tsx
+++ b/packages/core/src/Typeahead/XDSTypeahead.tsx
@@ -30,6 +30,7 @@ import {XDSBaseTypeahead} from './XDSBaseTypeahead';
 import {useXDSSize} from '../SizeContext/XDSSizeContext';
 import {
   XDSField,
+  XDSInputClearButton,
   type XDSInputStatus,
   inputWrapperStyles,
   inputStatusBorderStyles,
@@ -37,14 +38,8 @@ import {
   inputStatusFocusWithinStyles,
 } from '../Field';
 import {XDSToken} from '../Token';
-import {XDSIcon} from '../Icon';
 import {renderIconSlot, type XDSIconType} from '../Icon';
-import {
-  colorVars,
-  spacingVars,
-  radiusVars,
-  sizeVars,
-} from '../theme/tokens.stylex';
+import {spacingVars, sizeVars} from '../theme/tokens.stylex';
 import {xdsClassName, mergeProps} from '../utils';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import type {XDSSearchableItem, XDSSearchSource} from './types';
@@ -122,6 +117,7 @@ export interface XDSTypeaheadProps<T extends XDSSearchableItem> extends Omit<
 
 const styles = stylex.create({
   wrapper: {
+    position: 'relative',
     flexWrap: 'wrap',
     gap: spacingVars['--spacing-1'],
     // Standard padding minus border width to prevent height jump
@@ -136,20 +132,14 @@ const styles = stylex.create({
     margin: `calc(-1 * (${spacingVars['--spacing-2']} - ${spacingVars['--spacing-1']} + 1px))`,
   },
   clearButton: {
-    all: 'unset',
-    display: 'inline-flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    cursor: 'pointer',
-    padding: spacingVars['--spacing-1'],
-    borderRadius: radiusVars['--radius-full'],
-    color: colorVars['--color-text-secondary'],
-    opacity: {
-      default: 0.7,
-      ':hover': {
-        '@media (hover: hover)': 1,
-      },
-    },
+    position: 'absolute',
+    top: `calc((${sizeVars['--size-element-md']} - 20px) / 2 - 1px)`,
+    insetInlineEnd: `calc((${sizeVars['--size-element-md']} - 20px) / 2 - 1px)`,
+    height: '20px',
+  },
+  clearButtonSm: {
+    top: `calc((${sizeVars['--size-element-sm']} - 20px) / 2 - 1px)`,
+    insetInlineEnd: `calc((${sizeVars['--size-element-sm']} - 20px) / 2 - 1px)`,
   },
   sizeSmWrapper: {
     minHeight: sizeVars['--size-element-sm'],
@@ -395,7 +385,6 @@ export function XDSTypeahead<T extends XDSSearchableItem>({
             label={value.label}
             size={size}
             onClick={handleEnterEditMode}
-            onRemove={hasClear && !isDisabled ? handleClear : undefined}
             isDisabled={isDisabled}
             xstyle={styles.token}
           />
@@ -422,17 +411,15 @@ export function XDSTypeahead<T extends XDSSearchableItem>({
           inputXStyle={showToken ? styles.inputHidden : undefined}
           size={size}
         />
-        {hasClear && value && !isDisabled && isEditing && (
-          <button
-            type="button"
-            aria-label="Clear selection"
+        {hasClear && value && !isDisabled && (
+          <XDSInputClearButton
+            label="Clear selection"
             onClick={e => {
               e.stopPropagation();
               handleClear();
             }}
-            {...stylex.props(styles.clearButton)}>
-            <XDSIcon icon="close" size="sm" />
-          </button>
+            xstyle={[styles.clearButton, size === 'sm' && styles.clearButtonSm]}
+          />
         )}
       </div>
     </XDSField>


### PR DESCRIPTION
  ## Summary

Fixing issues from #753:
  - Remove `onRemove` from Typeahead token — tokens no longer show individual × buttons inside XDSTypeahead
  - Show clear button in resting state (removed `isEditing` gate) so `hasClear` actually works
  - Extract `XDSInputClearButton` as a shared 20px ghost icon button for input components (Typeahead, Tokenizer)
  - Replace raw `<button>` with `XDSInputClearButton` in both Typeahead and Tokenizer
  - Fix typeahead dropdown checkmark icon color from `accent` to `primary`
  - Fix Tokenizer endSection padding/positioning for consistent inset with wrapper border
  - 
  ## Test plan
  - [x] `pnpm -F @xds/core exec tsc --noEmit` passes
  - [x] All 156 related tests pass (Typeahead, Tokenizer, PowerSearch)
  - [x] Visual check: Typeahead clear button visible in resting state when value selected
  - [x] Visual check: Tokenizer clear button aligned with wrapper edge
  - [x] Visual check: Checkmark icon uses primary color in dropdown
  - [x] Visual check: PowerSearch "With End Content" story Save button is proportional