### PR TITLE
fix(appshell): preserve mobile nav toggle after drawer close

### DIFF
--- a/packages/core/src/AppShell/XDSAppShell.test.tsx
+++ b/packages/core/src/AppShell/XDSAppShell.test.tsx
@@ -18,7 +18,7 @@ import {
   beforeEach,
   afterEach,
 } from 'vitest';
-import {render, screen, fireEvent} from '@testing-library/react';
+import {render, screen, fireEvent, waitFor} from '@testing-library/react';
 import {XDSAppShell} from './XDSAppShell';
 import {XDSMobileNav} from '../MobileNav';
 import {XDSSideNav, XDSSideNavItem, XDSSideNavSection} from '../SideNav';
@@ -328,6 +328,52 @@ describe('XDSAppShell', () => {
     ).toBeGreaterThan(0);
     expect(screen.getByText('Home')).toBeInTheDocument();
     expect(screen.getAllByText('Side item').length).toBeGreaterThan(0);
+  });
+
+  it('does not show an auto mobile nav toggle when sideNav renders null', async () => {
+    mockMql = createMockMatchMedia(true);
+    vi.stubGlobal('matchMedia', vi.fn().mockReturnValue(mockMql));
+
+    function EmptySideNav() {
+      return null;
+    }
+
+    render(
+      <XDSAppShell sideNav={<EmptySideNav />} mobileNav={{breakpoint: 'md'}}>
+        <div>Content</div>
+      </XDSAppShell>,
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('mobile-nav-toggle')).not.toBeInTheDocument();
+    });
+  });
+
+  it('keeps the auto mobile nav toggle after closing a heading-only TopNav drawer', () => {
+    mockMql = createMockMatchMedia(true);
+    vi.stubGlobal('matchMedia', vi.fn().mockReturnValue(mockMql));
+
+    render(
+      <XDSAppShell
+        topNav={
+          <XDSTopNav
+            label="Main navigation"
+            heading={<XDSTopNavHeading heading="My App" />}
+          />
+        }
+        sideNav={<TestSideNav />}
+        mobileNav={{breakpoint: 'md'}}>
+        <div>Content</div>
+      </XDSAppShell>,
+    );
+
+    const toggle = screen.getByTestId('mobile-nav-toggle');
+    expect(toggle).toBeInTheDocument();
+
+    fireEvent.click(toggle);
+    fireEvent.click(screen.getByRole('button', {name: /close navigation/i}));
+
+    expect(screen.getByTestId('mobile-nav-toggle')).toBeInTheDocument();
   });
 
   it('renders mobile layout on first render when defaultIsMobile is true', () => {

--- a/packages/core/src/AppShell/useXDSSlotPresence.tsx
+++ b/packages/core/src/AppShell/useXDSSlotPresence.tsx
@@ -14,8 +14,9 @@
  *
  * AppShell wraps each slot render in a `display:contents` div with a ref from
  * this hook. The hook checks `childNodes` to determine whether the slot actually
- * produced DOM output. Multiple elements can share the same ref (via callback
- * ref) — only one mounts at a time, and the hook observes whichever is active.
+ * produced DOM output. When a slot temporarily unmounts because React Activity
+ * hides it, the last measured presence is preserved until the slot prop is
+ * removed or another mounted wrapper proves the slot is empty.
  */
 
 import {useCallback, useEffect, useRef, useState} from 'react';
@@ -52,6 +53,12 @@ export function useXDSSlotPresence(initialValue = false) {
   const observerRef = useRef<MutationObserver | null>(null);
   const elementRef = useRef<HTMLDivElement | null>(null);
 
+  useEffect(() => {
+    if (!initialValue) {
+      setHasContent(false);
+    }
+  }, [initialValue]);
+
   // Callback ref — called when elements mount/unmount
   const ref = useCallback((node: HTMLDivElement | null) => {
     // Clean up previous observer
@@ -63,21 +70,18 @@ export function useXDSSlotPresence(initialValue = false) {
     elementRef.current = node;
 
     if (!node) {
-      setHasContent(false);
       return;
     }
 
-    if (node) {
-      // Check immediately
-      setHasContent(hasChildContent(node));
+    // Check immediately
+    setHasContent(hasChildContent(node));
 
-      // Observe for changes
-      const observer = new MutationObserver(() => {
-        setHasContent(hasChildContent(node));
-      });
-      observer.observe(node, {childList: true, subtree: true});
-      observerRef.current = observer;
-    }
+    // Observe for changes
+    const observer = new MutationObserver(() => {
+      setHasContent(hasChildContent(node));
+    });
+    observer.observe(node, {childList: true, subtree: true});
+    observerRef.current = observer;
   }, []);
 
   // Clean up on unmount


### PR DESCRIPTION
## Summary
- Preserve slot presence when React Activity temporarily unmounts AppShell mobile drawer content
- Keep heading-only TopNav + SideNav mobile layouts from losing the hamburger toggle after opening and closing the drawer
- Rebased onto latest main and resolved the new TopNav mobile drawer regression-test conflict
- Adds regressions for empty rendered SideNav slots and the heading-only TopNav open/close lifecycle

Closes #2243

## Test plan
- pnpm exec vitest run packages/core/src/AppShell/XDSAppShell.test.tsx --root .
- pnpm -F @xds/core typecheck
- pnpm exec eslint packages/core/src/AppShell/useXDSSlotPresence.tsx packages/core/src/AppShell/XDSAppShell.test.tsx