### PR TITLE
fix(chat): prevent iOS composer input zoom

### DIFF
--- a/packages/core/src/Chat/Chat.doc.mjs
+++ b/packages/core/src/Chat/Chat.doc.mjs
@@ -137,7 +137,7 @@ export const docs = {
     },
     {
       name: 'XDSChatComposerInput',
-      description: 'Rich text input for the chat composer. Supports trigger menus (type @ or / to open a typeahead), inline tokens rendered as badges, message history recall with ArrowUp/Down, and paste/drop file handling. Pass it to XDSChatComposer\'s input slot when you need more than a plain textarea.',
+      description: 'Rich text input for the chat composer. Supports trigger menus (type @ or / to open a typeahead), inline tokens rendered as badges, message history recall with ArrowUp/Down, paste/drop file handling, and a 16px touch-device font-size floor to prevent iOS input zoom. Pass it to XDSChatComposer\'s input slot when you need more than a plain textarea.',
       props: [
         {name: 'ref', type: 'React.Ref<XDSChatComposerInputHandle>', description: 'Imperative handle for programmatic control — insertToken, insertText, focus, and getValue.'},
         {name: 'value', type: 'string', description: 'Controlled input value. Pair with onChange for two-way binding.'},
@@ -368,7 +368,7 @@ export const docsZh = {
     {
       name: 'XDSChatComposerInput',
       description:
-        '聊天编写器的富文本输入。支持触发菜单（输入 @ 或 / 打开 typeahead）、内联标记徽章、ArrowUp/Down 消息历史回溯、粘贴/拖放文件处理。当需要普通文本区域以外的功能时，传入 XDSChatComposer 的 input 插槽。',
+        '聊天编写器的富文本输入。支持触发菜单（输入 @ 或 / 打开 typeahead）、内联标记徽章、ArrowUp/Down 消息历史回溯、粘贴/拖放文件处理，并在触控设备上将字体大小保持至少 16px 以避免 iOS 输入缩放。当需要普通文本区域以外的功能时，传入 XDSChatComposer 的 input 插槽。',
       propDescriptions: {
         ref: '命令式句柄，用于编程式控制 — insertToken、insertText、focus 和 getValue。',
         value: '受控输入值。与 onChange 配对实现双向绑定。',
@@ -546,7 +546,7 @@ export const docsDense = {
     },
     {
       name: 'XDSChatComposerInput',
-      description: 'rich input for composer; trigger menus (@/commands), inline tokens, msg history, paste/drop files. Use in XDSChatComposer input slot when you need more than plain textarea.',
+      description: 'rich input for composer; trigger menus (@/commands), inline tokens, msg history, paste/drop files, 16px touch font-size floor to prevent iOS zoom. Use in XDSChatComposer input slot when you need more than plain textarea.',
       propDescriptions: {
         ref: 'imperative handle (insertToken/insertText/focus/getValue)',
         value: 'controlled value; pair w/ onChange for two-way binding',

--- a/packages/core/src/Chat/XDSChatComposerInput.tsx
+++ b/packages/core/src/Chat/XDSChatComposerInput.tsx
@@ -11,7 +11,7 @@
  * ContentEditable-based rich input for the chat composer.
  * Supports trigger menus (@ mentions, / commands) via XDSSearchSource,
  * inline token rendering, serialization, Enter/Shift+Enter, message
- * history, paste/drop file handling.
+ * history, paste/drop file handling, and mobile-safe touch typography.
  *
  *
  * SYNC: When modified, update:
@@ -207,7 +207,10 @@ const styles = stylex.create({
     whiteSpace: 'pre-wrap',
     wordBreak: 'break-word',
     overflowY: 'auto',
-    fontSize: typeScaleVars['--text-body-size'],
+    fontSize: {
+      default: typeScaleVars['--text-body-size'],
+      '@media (pointer: coarse)': `max(1rem, ${typeScaleVars['--text-body-size']})`,
+    },
     lineHeight: `${LINE_HEIGHT_PX}px`,
     fontFamily: typographyVars['--font-family-body'],
     color: colorVars['--color-text-primary'],
@@ -221,7 +224,10 @@ const styles = stylex.create({
     right: 0,
     pointerEvents: 'none',
     color: colorVars['--color-text-secondary'],
-    fontSize: typeScaleVars['--text-body-size'],
+    fontSize: {
+      default: typeScaleVars['--text-body-size'],
+      '@media (pointer: coarse)': `max(1rem, ${typeScaleVars['--text-body-size']})`,
+    },
     lineHeight: `${LINE_HEIGHT_PX}px`,
     fontFamily: typographyVars['--font-family-body'],
     userSelect: 'none',


### PR DESCRIPTION
## Summary

- Apply the existing XDS touch-device font-size floor pattern to `XDSChatComposerInput`
- Keep the placeholder typography in sync with the editable content
- Document the mobile-safe touch typography behavior

Fixes #2316.

## Testing

- `pnpm vitest run packages/core/src/Chat/XDSChatComposerInput.test.tsx`
- `pnpm check:repo`
- `pnpm -F @xds/core build`
- `pnpm exec eslint packages/core/src/Chat/XDSChatComposerInput.tsx`
- `pnpm exec prettier --check packages/core/src/Chat/XDSChatComposerInput.tsx`