### PR TITLE
fix(core): semantic tokens in CodeBlock, data-autofocus in CommandPaletteInput

### DIFF
--- a/packages/core/src/CodeBlock/XDSCodeBlock.tsx
+++ b/packages/core/src/CodeBlock/XDSCodeBlock.tsx
@@ -24,7 +24,6 @@ import {
   colorVars,
   spacingVars,
   radiusVars,
-  textSizeVars,
   typographyVars,
   fontWeightVars,
   typeScaleVars,
@@ -104,7 +103,7 @@ const styles = stylex.create({
     display: 'flex',
     alignItems: 'center',
     gap: spacingVars['--spacing-1'],
-    fontSize: textSizeVars['--font-size-sm'],
+    fontSize: typeScaleVars['--text-supporting-size'],
     fontFamily: typographyVars['--font-family-code'],
     fontWeight: fontWeightVars['--font-weight-medium'],
     color: 'var(--color-syntax-comment)',
@@ -201,13 +200,13 @@ const styles = stylex.create({
     paddingInline: spacingVars['--spacing-4'],
   },
   sizeSm: {
-    fontSize: textSizeVars['--font-size-sm'],
+    fontSize: typeScaleVars['--text-supporting-size'],
   },
   sizeMd: {
     fontSize: typeScaleVars['--text-code-size'],
   },
   gutterSm: {
-    fontSize: textSizeVars['--font-size-sm'],
+    fontSize: typeScaleVars['--text-supporting-size'],
   },
   gutterMd: {
     fontSize: typeScaleVars['--text-code-size'],

--- a/packages/core/src/CommandPalette/XDSCommandPaletteInput.tsx
+++ b/packages/core/src/CommandPalette/XDSCommandPaletteInput.tsx
@@ -210,6 +210,7 @@ export function XDSCommandPaletteInput({
         }
         placeholder={placeholder}
         value={value}
+        data-autofocus={effectiveAutoFocus || undefined}
         onChange={e => {
           handleValueChange?.(e.target.value);
           onChange?.(e);


### PR DESCRIPTION
## Changes

### CodeBlock: semantic type scale tokens

Replace raw `textSizeVars['--font-size-sm']` with semantic `typeScaleVars['--text-supporting-size']` in three styles:
- `headerTitle` (language/title label)
- `sizeSm` (small code font size)
- `gutterSm` (small gutter font size)

This aligns CodeBlock with the convention that components express intent through semantic tokens rather than raw size primitives.

### CommandPaletteInput: data-autofocus

Add `data-autofocus={effectiveAutoFocus || undefined}` to the input element. XDSDialog uses `querySelector('[data-autofocus]')` to re-focus elements after `showModal()` (React's native `autoFocus` fires before the dialog is visible). Without this attribute, the command palette input doesn't get focused when rendered inside a dialog.

## Needs Review

- `XDSDateInput` has a `size` prop with `'sm' | 'md' | 'lg'` — the input convention is `'sm' | 'md'`. Intentional or should `lg` be removed?

Night Watch — Component Auditor