### PR TITLE
feat(core): add lg size to all input components

### DIFF
--- a/apps/storybook/stories/DateRangeInput.stories.tsx
+++ b/apps/storybook/stories/DateRangeInput.stories.tsx
@@ -57,8 +57,7 @@ const meta: Meta<typeof XDSDateRangeInput> = {
     isDisabled: {control: 'boolean', description: 'Disable the picker'},
     size: {
       control: 'radio',
-      options: ['sm', 'md'],
-      description: 'Trigger size',
+      options: ['sm', 'md', 'lg'],
     },
     hasClear: {control: 'boolean', description: 'Show clear button'},
     numberOfMonths: {
@@ -180,14 +179,39 @@ export const Disabled: Story = {
   },
 };
 
-export const SmallSize: Story = {
-  render: args => {
-    const [value, setValue] = useState<XDSDateRange | null>(null);
-    return <XDSDateRangeInput {...args} value={value} onChange={setValue} />;
-  },
-  args: {
-    label: 'Date range',
-    size: 'sm',
+export const SizeVariants: Story = {
+  render: () => {
+    const [sm, setSm] = useState<XDSDateRange | null>(null);
+    const [md, setMd] = useState<XDSDateRange | null>(null);
+    const [lg, setLg] = useState<XDSDateRange | null>(null);
+    return (
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '16px',
+          maxWidth: '340px',
+        }}>
+        <XDSDateRangeInput
+          label="Small (28px)"
+          value={sm}
+          onChange={setSm}
+          size="sm"
+        />
+        <XDSDateRangeInput
+          label="Medium (32px)"
+          value={md}
+          onChange={setMd}
+          size="md"
+        />
+        <XDSDateRangeInput
+          label="Large (36px)"
+          value={lg}
+          onChange={setLg}
+          size="lg"
+        />
+      </div>
+    );
   },
 };
 

--- a/apps/storybook/stories/DateTimeInput.stories.tsx
+++ b/apps/storybook/stories/DateTimeInput.stories.tsx
@@ -43,8 +43,7 @@ const meta: Meta<typeof XDSDateTimeInput> = {
     },
     size: {
       control: 'radio',
-      options: ['sm', 'md'],
-      description: 'Size of the input',
+      options: ['sm', 'md', 'lg'],
     },
     hourFormat: {
       control: 'radio',
@@ -221,16 +220,42 @@ export const Disabled: Story = {
   },
 };
 
-export const SmallSize: Story = {
-  render: args => {
-    const [value, setValue] = useState<ISODateTimeString | undefined>(
-      undefined,
+export const SizeVariants: Story = {
+  render: () => {
+    const [sm, setSm] = useState<ISODateTimeString | undefined>(undefined);
+    const [md, setMd] = useState<ISODateTimeString | undefined>(undefined);
+    const [lg, setLg] = useState<ISODateTimeString | undefined>(undefined);
+    return (
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '16px',
+          maxWidth: '460px',
+        }}>
+        <XDSDateTimeInput
+          label="Small (28px)"
+          value={sm}
+          onChange={setSm}
+          placeholder="Small size"
+          size="sm"
+        />
+        <XDSDateTimeInput
+          label="Medium (32px)"
+          value={md}
+          onChange={setMd}
+          placeholder="Medium size (default)"
+          size="md"
+        />
+        <XDSDateTimeInput
+          label="Large (36px)"
+          value={lg}
+          onChange={setLg}
+          placeholder="Large size"
+          size="lg"
+        />
+      </div>
     );
-    return <XDSDateTimeInput {...args} value={value} onChange={setValue} />;
-  },
-  args: {
-    label: 'Time',
-    size: 'sm',
   },
 };
 

--- a/apps/storybook/stories/PowerSearch.stories.tsx
+++ b/apps/storybook/stories/PowerSearch.stories.tsx
@@ -312,6 +312,11 @@ const meta: Meta<typeof XDSPowerSearch> = {
     hasClear: {control: 'boolean'},
     maxTokenLength: {control: 'number'},
     popoverSaveButtonLabel: {control: 'text'},
+    size: {
+      control: 'radio',
+      options: ['sm', 'md', 'lg'],
+      description: 'Search input size',
+    },
   },
 };
 
@@ -1000,6 +1005,48 @@ export const WithContentSearchFieldKey: Story = {
   name: 'Content Search Field Key',
 };
 
+export const SizeVariants: Story = {
+  render: () => {
+    const [smFilters, setSmFilters] = useState<PowerSearchFilter[]>([
+      {field: 'status', operator: 'is', value: {type: 'enum', value: 'open'}},
+    ]);
+    const [mdFilters, setMdFilters] = useState<PowerSearchFilter[]>([
+      {field: 'status', operator: 'is', value: {type: 'enum', value: 'open'}},
+    ]);
+    const [lgFilters, setLgFilters] = useState<PowerSearchFilter[]>([
+      {field: 'status', operator: 'is', value: {type: 'enum', value: 'open'}},
+    ]);
+    return (
+      <div style={{display: 'flex', flexDirection: 'column', gap: 16}}>
+        <XDSPowerSearch
+          label="Small (28px)"
+          config={basicConfig}
+          filters={smFilters}
+          onChange={newFilters => setSmFilters([...newFilters])}
+          placeholder="Small size"
+          size="sm"
+        />
+        <XDSPowerSearch
+          label="Medium (32px)"
+          config={basicConfig}
+          filters={mdFilters}
+          onChange={newFilters => setMdFilters([...newFilters])}
+          placeholder="Medium size (default)"
+          size="md"
+        />
+        <XDSPowerSearch
+          label="Large (36px)"
+          config={basicConfig}
+          filters={lgFilters}
+          onChange={newFilters => setLgFilters([...newFilters])}
+          placeholder="Large size"
+          size="lg"
+        />
+      </div>
+    );
+  },
+};
+
 export const WithStartIcon: Story = {
   render: args => {
     const [filters, setFilters] = useState<PowerSearchFilter[]>([]);
@@ -1070,6 +1117,7 @@ export const WithEndContentPowerSearch: Story = {
     label: 'Search',
     isLabelHidden: true,
     placeholder: 'Search...',
+    size: 'lg',
   },
   name: 'With End Content and Result Count',
 };

--- a/apps/storybook/stories/TextArea.stories.tsx
+++ b/apps/storybook/stories/TextArea.stories.tsx
@@ -3,6 +3,7 @@
 import {useState} from 'react';
 import type {Meta, StoryObj} from '@storybook/react';
 import {XDSTextArea} from '@xds/core/TextArea';
+import {XDSTextInput} from '@xds/core/TextInput';
 import {
   DocumentTextIcon,
   ChatBubbleLeftIcon,
@@ -71,6 +72,11 @@ const meta: Meta<typeof XDSTextArea> = {
       control: 'number',
       description:
         'Maximum number of characters allowed. Displays a counter when set.',
+    },
+    size: {
+      control: 'radio',
+      options: ['sm', 'md', 'lg'],
+      description: 'Textarea size (affects padding, not height)',
     },
   },
 };
@@ -474,6 +480,61 @@ export const CombinedFeatures: Story = {
                 : undefined
           }
         />
+      </div>
+    );
+  },
+};
+
+export const SizeVariants: Story = {
+  render: () => {
+    const [smArea, setSmArea] = useState('');
+    const [mdArea, setMdArea] = useState('');
+    const [lgArea, setLgArea] = useState('');
+    const [smInput, setSmInput] = useState('');
+    const [mdInput, setMdInput] = useState('');
+    const [lgInput, setLgInput] = useState('');
+    return (
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '16px',
+        }}>
+        {(['sm', 'md', 'lg'] as const).map((sz, i) => {
+          const label = {sm: 'Small (28px)', md: 'Medium (32px)', lg: 'Large (36px)'}[sz];
+          const [area, setArea] = [
+            [smArea, setSmArea],
+            [mdArea, setMdArea],
+            [lgArea, setLgArea],
+          ][i] as [string, (v: string) => void];
+          const [input, setInput] = [
+            [smInput, setSmInput],
+            [mdInput, setMdInput],
+            [lgInput, setLgInput],
+          ][i] as [string, (v: string) => void];
+          return (
+            <div key={sz} style={{display: 'flex', gap: '16px'}}>
+              <div style={{flex: 1}}>
+                <XDSTextArea
+                  label={label}
+                  value={area}
+                  onChange={setArea}
+                  placeholder="TextArea"
+                  size={sz}
+                />
+              </div>
+              <div style={{flex: 1}}>
+                <XDSTextInput
+                  label={label}
+                  value={input}
+                  onChange={setInput}
+                  placeholder="TextInput"
+                  size={sz}
+                />
+              </div>
+            </div>
+          );
+        })}
       </div>
     );
   },

--- a/apps/storybook/stories/Token.stories.tsx
+++ b/apps/storybook/stories/Token.stories.tsx
@@ -25,6 +25,11 @@ const meta: Meta<typeof XDSToken> = {
       ],
       description: 'Color variant',
     },
+    size: {
+      control: 'radio',
+      options: ['sm', 'md', 'lg'],
+      description: 'Token size',
+    },
     label: {
       control: 'text',
       description: 'Token label text',
@@ -202,6 +207,37 @@ export const Disabled: Story = {
         isDisabled
       />
       <XDSToken label="Disabled link" href="#" isDisabled />
+    </div>
+  ),
+};
+
+export const SizeVariants: Story = {
+  render: () => (
+    <div style={{display: 'flex', flexDirection: 'column', gap: 16}}>
+      <div>
+        <h4 style={{margin: '0 0 8px'}}>Small (20px)</h4>
+        <div style={{display: 'flex', gap: '8px', alignItems: 'center'}}>
+          <XDSToken label="Small" size="sm" />
+          <XDSToken label="Removable" size="sm" onRemove={() => {}} />
+          <XDSToken label="Clickable" size="sm" onClick={() => {}} />
+        </div>
+      </div>
+      <div>
+        <h4 style={{margin: '0 0 8px'}}>Medium (24px, default)</h4>
+        <div style={{display: 'flex', gap: '8px', alignItems: 'center'}}>
+          <XDSToken label="Medium" size="md" />
+          <XDSToken label="Removable" size="md" onRemove={() => {}} />
+          <XDSToken label="Clickable" size="md" onClick={() => {}} />
+        </div>
+      </div>
+      <div>
+        <h4 style={{margin: '0 0 8px'}}>Large (28px)</h4>
+        <div style={{display: 'flex', gap: '8px', alignItems: 'center'}}>
+          <XDSToken label="Large" size="lg" />
+          <XDSToken label="Removable" size="lg" onRemove={() => {}} />
+          <XDSToken label="Clickable" size="lg" onClick={() => {}} />
+        </div>
+      </div>
     </div>
   ),
 };

--- a/apps/storybook/stories/Tokenizer.stories.tsx
+++ b/apps/storybook/stories/Tokenizer.stories.tsx
@@ -37,6 +37,11 @@ const meta: Meta<typeof XDSTokenizer> = {
     isOptional: {control: 'boolean'},
     hasClear: {control: 'boolean'},
     maxEntries: {control: 'number'},
+    size: {
+      control: 'radio',
+      options: ['sm', 'md', 'lg'],
+      description: 'Input size',
+    },
   },
   decorators: [
     Story => (
@@ -328,6 +333,45 @@ export const Creatable: Story = {
     label: 'Tags',
   },
   name: 'Creatable (Free Text)',
+};
+
+export const SizeVariants: Story = {
+  render: () => {
+    const [sm, setSm] = useState<XDSSearchableItem[]>([]);
+    const [md, setMd] = useState<XDSSearchableItem[]>([users[0], users[2]]);
+    const [lg, setLg] = useState<XDSSearchableItem[]>([]);
+    return (
+      <div style={{display: 'flex', flexDirection: 'column', gap: 16}}>
+        <XDSTokenizer
+          label="Small (28px)"
+          searchSource={userSource}
+          value={sm}
+          onChange={items => setSm(items)}
+          placeholder="Small size"
+          size="sm"
+          hasClear
+        />
+        <XDSTokenizer
+          label="Medium (32px)"
+          searchSource={userSource}
+          value={md}
+          onChange={items => setMd(items)}
+          placeholder="Medium size (default)"
+          size="md"
+          hasClear
+        />
+        <XDSTokenizer
+          label="Large (36px)"
+          searchSource={userSource}
+          value={lg}
+          onChange={items => setLg(items)}
+          placeholder="Large size"
+          size="lg"
+          hasClear
+        />
+      </div>
+    );
+  },
 };
 
 export const CreatableWithSearch: Story = {

--- a/apps/storybook/stories/Typeahead.stories.tsx
+++ b/apps/storybook/stories/Typeahead.stories.tsx
@@ -37,6 +37,11 @@ const meta: Meta<typeof XDSTypeahead> = {
     hasEntriesOnFocus: {control: 'boolean'},
     hasClear: {control: 'boolean'},
     maxMenuItems: {control: 'number'},
+    size: {
+      control: 'radio',
+      options: ['sm', 'md', 'lg'],
+      description: 'Input size',
+    },
   },
   decorators: [
     Story => (
@@ -150,6 +155,42 @@ export const LimitedResults: Story = {
     maxMenuItems: 3,
   },
   name: 'Max 3 Results',
+};
+
+export const SizeVariants: Story = {
+  render: () => {
+    const [sm, setSm] = useState<XDSSearchableItem | null>(null);
+    const [md, setMd] = useState<XDSSearchableItem | null>(null);
+    const [lg, setLg] = useState<XDSSearchableItem | null>(null);
+    return (
+      <div style={{display: 'flex', flexDirection: 'column', gap: 16}}>
+        <XDSTypeahead
+          label="Small (28px)"
+          searchSource={fruitSource}
+          value={sm}
+          onChange={setSm}
+          placeholder="Small size"
+          size="sm"
+        />
+        <XDSTypeahead
+          label="Medium (32px)"
+          searchSource={fruitSource}
+          value={md}
+          onChange={setMd}
+          placeholder="Medium size (default)"
+          size="md"
+        />
+        <XDSTypeahead
+          label="Large (36px)"
+          searchSource={fruitSource}
+          value={lg}
+          onChange={setLg}
+          placeholder="Large size"
+          size="lg"
+        />
+      </div>
+    );
+  },
 };
 
 export const WithStartIcon: Story = {

--- a/packages/core/src/DateRangeInput/DateRangeInput.doc.mjs
+++ b/packages/core/src/DateRangeInput/DateRangeInput.doc.mjs
@@ -22,7 +22,7 @@ export const docs = {
     { name: 'presets', type: 'Array<XDSDateRangePreset>', description: 'Preset ranges shown as quick-select options beside the calendar.' },
     { name: 'hasClear', type: 'boolean', description: 'Shows a clear button when a range is selected.', default: 'true' },
     { name: 'placeholder', type: 'string', description: 'Placeholder text when no range is selected.', default: "'Select date range'" },
-    { name: 'size', type: "'sm' | 'md'", description: 'Size of the trigger.', default: "'md'" },
+    { name: 'size', type: "'sm' | 'md' | 'lg'", description: 'Size of the trigger.', default: "'md'" },
     { name: 'status', type: 'XDSInputStatus', description: 'Status indicator for error, warning, or success states.' },
     { name: 'labelTooltip', type: 'string', description: 'Tooltip text via info icon at label end.' },
     { name: 'numberOfMonths', type: '1 | 2', description: 'Number of months in the calendar.', default: '2' },

--- a/packages/core/src/DateRangeInput/XDSDateRangeInput.test.tsx
+++ b/packages/core/src/DateRangeInput/XDSDateRangeInput.test.tsx
@@ -222,6 +222,18 @@ describe('XDSDateRangeInput', () => {
     expect(screen.getByRole('button', {name: 'Open calendar'})).toBeDisabled();
   });
 
+  it('renders with size="lg"', () => {
+    render(
+      <XDSDateRangeInput
+        label="Date range"
+        value={null}
+        onChange={() => {}}
+        size="lg"
+      />,
+    );
+    expect(screen.getByText('Date range')).toBeInTheDocument();
+  });
+
   describe('hasClear', () => {
     it('shows clear button when hasClear is true and value exists', () => {
       const range: XDSDateRange = {

--- a/packages/core/src/DateRangeInput/XDSDateRangeInput.tsx
+++ b/packages/core/src/DateRangeInput/XDSDateRangeInput.tsx
@@ -51,6 +51,7 @@ import {useXDSPopover} from '../Popover';
 import {xdsClassName, mergeProps} from '../utils';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import type {XDSBaseProps} from '../XDSBaseProps';
+import {useXDSSize} from '../SizeContext/XDSSizeContext';
 
 export type {DateRange as XDSDateRange} from '../Calendar';
 
@@ -59,7 +60,7 @@ export interface XDSDateRangePreset {
   getRange: () => DateRange;
 }
 
-export type XDSDateRangeInputSize = 'sm' | 'md';
+export type XDSDateRangeInputSize = 'sm' | 'md' | 'lg';
 
 export type {
   XDSInputStatus as XDSDateRangeInputStatus,
@@ -166,6 +167,10 @@ const sizeStyles = stylex.create({
   },
   md: {
     height: sizeVars['--size-element-md'],
+    minWidth: 180,
+  },
+  lg: {
+    height: sizeVars['--size-element-lg'],
     minWidth: 180,
   },
 });
@@ -350,7 +355,7 @@ export function XDSDateRangeInput({
   presets,
   hasClear = true,
   placeholder = 'Select date range',
-  size = 'md',
+  size: sizeProp,
   status,
   labelTooltip,
   numberOfMonths = 2,
@@ -360,6 +365,7 @@ export function XDSDateRangeInput({
   ref,
   ...rest
 }: XDSDateRangeInputProps) {
+  const size = useXDSSize(sizeProp, 'md') as XDSDateRangeInputSize;
   const id = useId();
   const descriptionID = useId();
   const statusMessageID = useId();

--- a/packages/core/src/DateTimeInput/DateTimeInput.doc.mjs
+++ b/packages/core/src/DateTimeInput/DateTimeInput.doc.mjs
@@ -110,7 +110,7 @@ export const docs = {
     },
     {
       name: 'size',
-      type: "'sm' | 'md'",
+      type: "'sm' | 'md' | 'lg'",
       description: 'Size of the input control.',
       default: "'md'",
     },
@@ -199,7 +199,7 @@ export const docsZh = {
     {name: 'timeIncrement', type: 'number', description: '在时间输入中按箭头键时增减的分钟数。', default: '1'},
     {name: 'hasClear', type: 'boolean', description: '当有值时显示清除按钮。', default: 'false'},
     {name: 'placeholder', type: 'string', description: '未选择日期时显示的占位符文本。', default: "'Select a date'"},
-    {name: 'size', type: "'sm' | 'md'", description: '输入控件的尺寸。', default: "'md'"},
+    {name: 'size', type: "'sm' | 'md' | 'lg'", description: '输入控件的尺寸。', default: "'md'"},
     {name: 'status', type: 'XDSInputStatus', description: '错误、警告或成功状态的状态指示对象，附带消息。'},
     {name: 'labelTooltip', type: 'string', description: '通过标签末尾的信息图标显示的提示文本。'},
     {name: 'numberOfMonths', type: '1 | 2', description: '日历中同时显示的月份数量。', default: '1'},

--- a/packages/core/src/DateTimeInput/XDSDateTimeInput.test.tsx
+++ b/packages/core/src/DateTimeInput/XDSDateTimeInput.test.tsx
@@ -306,6 +306,13 @@ describe('XDSDateTimeInput', () => {
     expect(onChange).toHaveBeenCalledWith('2026-03-15T15:45');
   });
 
+  it('renders with size="lg"', () => {
+    render(
+      <XDSDateTimeInput label="Meeting time" onChange={() => {}} size="lg" />,
+    );
+    expect(screen.getByLabelText('Meeting time')).toBeInTheDocument();
+  });
+
   describe('hasClear', () => {
     it('shows clear button when hasClear is true and value exists', () => {
       render(

--- a/packages/core/src/DateTimeInput/XDSDateTimeInput.tsx
+++ b/packages/core/src/DateTimeInput/XDSDateTimeInput.tsx
@@ -77,6 +77,7 @@ import {
 } from '../utils/plainDate';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import type {XDSBaseProps} from '../XDSBaseProps';
+import {useXDSSize} from '../SizeContext/XDSSizeContext';
 
 export type ISODateTimeString = string & {
   readonly __brand: 'ISODateTimeString';
@@ -84,7 +85,7 @@ export type ISODateTimeString = string & {
 
 export type XDSDateTimeInputHourFormat = '12h' | '24h';
 
-export type XDSDateTimeInputSize = 'sm' | 'md';
+export type XDSDateTimeInputSize = 'sm' | 'md' | 'lg';
 
 export type {
   XDSInputStatus as XDSDateTimeInputStatus,
@@ -164,6 +165,9 @@ const sizeStyles = stylex.create({
   },
   md: {
     height: sizeVars['--size-element-md'],
+  },
+  lg: {
+    height: sizeVars['--size-element-lg'],
   },
 });
 
@@ -374,7 +378,7 @@ export function XDSDateTimeInput({
   timeIncrement = 1,
   hasClear = false,
   placeholder = 'Select a date',
-  size = 'md',
+  size: sizeProp,
   status,
   labelTooltip,
   numberOfMonths = 1,
@@ -384,6 +388,7 @@ export function XDSDateTimeInput({
   ref,
   ...rest
 }: XDSDateTimeInputProps) {
+  const size = useXDSSize(sizeProp, 'md') as XDSDateTimeInputSize;
   const dateInputId = useId();
   const timeInputId = useId();
   const descriptionID = useId();

--- a/packages/core/src/Field/types.ts
+++ b/packages/core/src/Field/types.ts
@@ -37,4 +37,4 @@ export interface XDSInputStatus {
 /**
  * Standard size options for input components.
  */
-export type XDSInputSize = 'sm' | 'md';
+export type XDSInputSize = 'sm' | 'md' | 'lg';

--- a/packages/core/src/MultiSelector/XDSMultiSelector.tsx
+++ b/packages/core/src/MultiSelector/XDSMultiSelector.tsx
@@ -66,6 +66,7 @@ import {
 import {useMultiCombobox} from './hooks';
 import {xdsClassName, mergeProps} from '../utils';
 import {XDSBaseProps} from '../XDSBaseProps';
+import {useXDSSize} from '../SizeContext/XDSSizeContext';
 
 // Sentinel value for the select-all item in keyboard navigation
 const SELECT_ALL_VALUE = '__xds_select_all__';
@@ -542,7 +543,7 @@ export function XDSMultiSelector<T extends XDSMultiSelectorOptionType>({
   changeAction,
   isLoading = false,
   placeholder = 'Select...',
-  size = 'md',
+  size: sizeProp,
   status,
   labelTooltip,
   startIcon,
@@ -560,6 +561,7 @@ export function XDSMultiSelector<T extends XDSMultiSelectorOptionType>({
   className,
   style,
 }: XDSMultiSelectorProps<T>) {
+  const size = useXDSSize(sizeProp, 'md') as XDSMultiSelectorSize;
   const triggerId = useId();
   const listboxId = useId();
   const descriptionId = useId();

--- a/packages/core/src/PowerSearch/PowerSearch.doc.mjs
+++ b/packages/core/src/PowerSearch/PowerSearch.doc.mjs
@@ -115,6 +115,12 @@ export const docs = {
         'Number of results matching the current filters. When a number, formatted as "N results". When a string, displayed as-is.',
     },
     {
+      name: 'size',
+      type: "'sm' | 'md' | 'lg'",
+      description: 'Size of the search input and tokens.',
+      default: "'md'",
+    },
+    {
       name: 'xstyle',
       type: 'StyleXStyles',
       description:
@@ -242,6 +248,12 @@ export const docsZh = {
         '匹配当前过滤器的结果数量。数字类型时格式化为"N results"。字符串类型时按原样显示。',
     },
     {
+      name: 'size',
+      type: "'sm' | 'md' | 'lg'",
+      description: '搜索输入框和标记的尺寸。',
+      default: "'md'",
+    },
+    {
       name: 'xstyle',
       type: 'StyleXStyles',
       description: '用于布局自定义的 StyleX 样式。必须是 stylex.create() 值。',
@@ -289,6 +301,7 @@ export const docsDense = {
     ref: 'Imperative handle w/ focusTypeahead() + blurTypeahead() methods.',
     endContent: 'Content at end of input row. Useful for action buttons or controls.',
     resultCount: 'Result count matching current filters. Number formatted as "N results"; string displayed as-is.',
+    size: 'Search input+token size.',
     xstyle: 'StyleX styles for layout customization. Must be stylex.create() value.',
   },
 };

--- a/packages/core/src/PowerSearch/XDSPowerSearch.tsx
+++ b/packages/core/src/PowerSearch/XDSPowerSearch.tsx
@@ -27,6 +27,7 @@ import {
   XDSTokenizer,
   type XDSTokenizerHandle,
   type XDSTokenizerOverflowBehavior,
+  type XDSTokenizerSize,
 } from '../Tokenizer';
 import {XDSTypeaheadItem} from '../Typeahead/XDSTypeaheadItem';
 import {XDSToken} from '../Token';
@@ -44,6 +45,7 @@ import {
   fontWeightVars,
 } from '../theme/tokens.stylex';
 import {xdsClassName} from '../utils';
+import {useXDSSize} from '../SizeContext/XDSSizeContext';
 import {useInternalConfig} from './useInternalConfig';
 import {usePowerSearchSource} from './usePowerSearchSource';
 import {formatFilterValue} from './formatFilterValue';
@@ -325,6 +327,8 @@ function PowerSearchTokenValue({
 // Types
 // =============================================================================
 
+export type XDSPowerSearchSize = 'sm' | 'md' | 'lg';
+
 export interface XDSPowerSearchProps extends Omit<
   XDSBaseProps<HTMLElement>,
   'onChange'
@@ -392,6 +396,11 @@ export interface XDSPowerSearchProps extends Omit<
   resultCount?: number | string;
   /** Imperative handle ref. */
   ref?: React.Ref<XDSPowerSearchHandle>;
+  /**
+   * Size of the search input.
+   * @default 'md'
+   */
+  size?: XDSPowerSearchSize;
   /**
    * Per-type component overrides for token and editor rendering.
    * Keys are operator value types (e.g. 'string', 'enum', 'date_absolute').
@@ -507,12 +516,14 @@ export function XDSPowerSearch({
   endContent,
   resultCount,
   ref,
+  size: sizeProp,
   'data-testid': testId,
   xstyle,
   className,
   style,
   components: componentOverrides,
 }: XDSPowerSearchProps) {
+  const size = useXDSSize(sizeProp, 'md') as XDSPowerSearchSize;
   const config = useInternalConfig(configProp);
   const searchSource = usePowerSearchSource(config);
   const tokenizerRef = useRef<XDSTokenizerHandle>(null);
@@ -788,6 +799,7 @@ export function XDSPowerSearch({
       return (
         <XDSToken
           label={tokenLabel}
+          size={size}
           icon={tokenIcon}
           endContent={valueContent}
           onClick={
@@ -808,6 +820,7 @@ export function XDSPowerSearch({
       config,
       configProp,
       maxTokenLength,
+      size,
       isReadOnly,
       isDisabled,
       handleTokenClick,
@@ -963,6 +976,7 @@ export function XDSPowerSearch({
           startIcon={startIcon}
           endContent={combinedEndContent}
           isDisabled={isDisabled}
+          size={size}
           tokenOverflowBehavior={tokenOverflowBehavior}
           hasEntriesOnFocus
           debounceMs={0}

--- a/packages/core/src/PowerSearch/index.ts
+++ b/packages/core/src/PowerSearch/index.ts
@@ -12,7 +12,7 @@
  */
 
 export {XDSPowerSearch} from './XDSPowerSearch';
-export type {XDSPowerSearchProps} from './XDSPowerSearch';
+export type {XDSPowerSearchProps, XDSPowerSearchSize} from './XDSPowerSearch';
 
 export {XDSPowerSearchToken} from './XDSPowerSearchToken';
 export {XDSPowerSearchFilterEditor} from './XDSPowerSearchFilterEditor';

--- a/packages/core/src/TextArea/TextArea.doc.mjs
+++ b/packages/core/src/TextArea/TextArea.doc.mjs
@@ -123,6 +123,12 @@ export const docs = {
       default: 'false',
     },
     {
+      name: 'size',
+      type: "'sm' | 'md' | 'lg'",
+      description: 'Size of the textarea, affecting internal padding. Height is controlled by rows, not size.',
+      default: "'md'",
+    },
+    {
       name: 'onPaste',
       type: '(e: ClipboardEvent<HTMLTextAreaElement>) => void',
       description: 'Callback fired when content is pasted into the textarea.',
@@ -152,7 +158,7 @@ export const docs = {
   ],
   theming: {
     targets: [
-      {className: 'xds-textarea', visualProps: ['status']},
+      {className: 'xds-textarea', visualProps: ['size', 'status']},
     ],
   },
   usage: {
@@ -280,6 +286,12 @@ export const docsZh = {
       default: 'false',
     },
     {
+      name: 'size',
+      type: "'sm' | 'md' | 'lg'",
+      description: '文本域的尺寸，影响内部填充。高度由 rows 控制，而非 size。',
+      default: "'md'",
+    },
+    {
       name: 'onPaste',
       type: '(e: ClipboardEvent<HTMLTextAreaElement>) => void',
       description: '内容粘贴到文本域时触发的回调。',
@@ -307,7 +319,7 @@ export const docsZh = {
   ],
   theming: {
     targets: [
-      {className: 'xds-textarea', visualProps: ['status']},
+      {className: 'xds-textarea', visualProps: ['size', 'status']},
     ],
   },
   usage: {
@@ -361,6 +373,7 @@ export const docsDense = {
     startIcon: 'Icon inside leading edge of textarea wrapper.',
     hasSpellCheck: 'Enables/disables browser spell checking.',
     hasAutoFocus: 'Auto-focus textarea on mount.',
+    size: 'Textarea size; affects internal padding. Height controlled by rows.',
     onPaste: 'Fired on paste into textarea.',
     htmlName: 'HTML name attr for form submissions.',
     onFocus: 'Callback on focus.',

--- a/packages/core/src/TextArea/XDSTextArea.test.tsx
+++ b/packages/core/src/TextArea/XDSTextArea.test.tsx
@@ -338,6 +338,18 @@ describe('XDSTextArea', () => {
     expect(document.querySelector('svg')).not.toBeInTheDocument();
   });
 
+  it('renders with size="lg"', () => {
+    render(
+      <XDSTextArea
+        label="Description"
+        value=""
+        onChange={() => {}}
+        size="lg"
+      />,
+    );
+    expect(screen.getByLabelText('Description')).toBeInTheDocument();
+  });
+
   describe('hasSpellCheck prop', () => {
     it('enables spellcheck by default', () => {
       render(<XDSTextArea label="Description" value="" onChange={() => {}} />);

--- a/packages/core/src/TextArea/XDSTextArea.tsx
+++ b/packages/core/src/TextArea/XDSTextArea.tsx
@@ -46,6 +46,7 @@ import {XDSSpinner} from '../Spinner';
 import {xdsClassName, mergeProps, mergeRefs} from '../utils';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import {useInputContainer} from '../hooks/useInputContainer';
+import {useXDSSize} from '../SizeContext/XDSSizeContext';
 
 const COUNTER_WARNING_THRESHOLD = 0.8;
 
@@ -115,7 +116,17 @@ const styles = stylex.create({
   },
 });
 
+const textareaSizeStyles = stylex.create({
+  sm: {},
+  md: {},
+  lg: {
+    paddingBlock: spacingVars['--spacing-2'],
+  },
+});
+
 export type XDSTextAreaStatusType = 'warning' | 'error' | 'success';
+
+export type XDSTextAreaSize = 'sm' | 'md' | 'lg';
 
 export interface XDSTextAreaStatus {
   /**
@@ -223,6 +234,12 @@ export interface XDSTextAreaProps extends Omit<
    */
   hasAutoFocus?: boolean;
   /**
+   * The size of the textarea, affecting internal padding.
+   * Height is controlled by `rows`, not size.
+   * @default 'md'
+   */
+  size?: XDSTextAreaSize;
+  /**
    * The HTML name attribute for the textarea.
    * Useful for form submissions.
    */
@@ -266,6 +283,7 @@ export function XDSTextArea({
   onPaste,
   maxLength,
   hasAutoFocus = false,
+  size: sizeProp,
   htmlName,
   onFocus,
   onBlur,
@@ -275,6 +293,7 @@ export function XDSTextArea({
   ref,
   ...rest
 }: XDSTextAreaProps) {
+  const size = useXDSSize(sizeProp, 'md') as XDSTextAreaSize;
   const id = useId();
   const descriptionID = useId();
   const statusMessageID = useId();
@@ -356,10 +375,11 @@ export function XDSTextArea({
         onClick={handleWrapperClick}
         onMouseUp={handleWrapperMouseUp}
         {...mergeProps(
-          xdsClassName('textarea', {status: status?.type ?? null}),
+          xdsClassName('textarea', {size, status: status?.type ?? null}),
           stylex.props(
             inputWrapperStyles.base,
             styles.wrapper,
+            textareaSizeStyles[size],
             effectivelyDisabled && inputWrapperStyles.disabled,
             status && inputStatusBorderStyles[status.type],
             status && inputStatusHoverShadowStyles[status.type],

--- a/packages/core/src/TextArea/index.ts
+++ b/packages/core/src/TextArea/index.ts
@@ -16,4 +16,5 @@ export type {
   XDSTextAreaProps,
   XDSTextAreaStatus,
   XDSTextAreaStatusType,
+  XDSTextAreaSize,
 } from './XDSTextArea';

--- a/packages/core/src/Token/Token.doc.mjs
+++ b/packages/core/src/Token/Token.doc.mjs
@@ -14,7 +14,7 @@ export const docs = {
     },
     {
       name: 'size',
-      type: "'sm' | 'md'",
+      type: "'sm' | 'md' | 'lg'",
       description: 'The size of the token.',
       default: "'md'",
     },
@@ -122,7 +122,7 @@ export const docsZh = {
     },
     {
       name: 'size',
-      type: "'sm' | 'md'",
+      type: "'sm' | 'md' | 'lg'",
       description: '标记的大小。',
       default: "'md'",
     },
@@ -216,7 +216,7 @@ export const docsZh = {
 
 /** @type {import('../docs-types').TranslationDoc} */
 export const docsDense = {
-  description: 'compact chip/tag for inline metadata, filters, selections. 11 colors, 2 sizes, removable, clickable, linkable.',
+  description: 'compact chip/tag for inline metadata, filters, selections. 11 colors, 3 sizes, removable, clickable, linkable.',
   usage: {
     description:
       'Token is a small, inline element for representing discrete pieces of associated data — like tags, categories, or selections. Use for labeling content, showing active filters, or representing removable items.',
@@ -232,7 +232,7 @@ export const docsDense = {
   },
   propDescriptions: {
     label: 'Text label inside token.',
-    size: "Token size; 'sm' or 'md'.",
+    size: "Token size; 'sm', 'md', or 'lg'.",
     color: 'Color variant of token.',
     icon: 'Optional icon before label.',
     isDisabled: 'Reduces opacity, blocks interactions.',

--- a/packages/core/src/Token/XDSToken.test.tsx
+++ b/packages/core/src/Token/XDSToken.test.tsx
@@ -343,6 +343,14 @@ describe('XDSToken text overflow', () => {
   });
 });
 
+describe('XDSToken size', () => {
+  it('renders with size="lg"', () => {
+    render(<XDSToken label="Tag" size="lg" data-testid="lg-token" />);
+    expect(screen.getByTestId('lg-token')).toBeInTheDocument();
+    expect(screen.getByText('Tag')).toBeInTheDocument();
+  });
+});
+
 describe('XDSToken focus outline', () => {
   it('invisible button does not show its own focus outline', async () => {
     const user = userEvent.setup();

--- a/packages/core/src/Token/XDSToken.tsx
+++ b/packages/core/src/Token/XDSToken.tsx
@@ -53,7 +53,7 @@ export type XDSTokenColor =
   | 'pink'
   | 'gray';
 
-export type XDSTokenSize = 'sm' | 'md';
+export type XDSTokenSize = 'sm' | 'md' | 'lg';
 
 export interface XDSTokenProps extends XDSBaseProps<HTMLElement> {
   /** Ref forwarded to the root element */
@@ -227,6 +227,10 @@ const sizeStyles = stylex.create({
   },
   md: {
     height: `calc(${sizeVars['--size-element-md']} - 8px)`,
+    paddingInline: spacingVars['--spacing-2'],
+  },
+  lg: {
+    height: `calc(${sizeVars['--size-element-lg']} - 8px)`,
     paddingInline: spacingVars['--spacing-2'],
   },
 });

--- a/packages/core/src/Tokenizer/Tokenizer.doc.mjs
+++ b/packages/core/src/Tokenizer/Tokenizer.doc.mjs
@@ -128,7 +128,7 @@ export const docs = {
     },
     {
       name: 'size',
-      type: "'sm' | 'md'",
+      type: "'sm' | 'md' | 'lg'",
       description: 'Input and token size.',
       default: "'md'",
     },
@@ -322,7 +322,7 @@ export const docsZh = {
     },
     {
       name: 'size',
-      type: "'sm' | 'md'",
+      type: "'sm' | 'md' | 'lg'",
       description: '\u8f93\u5165\u6846\u548c\u6807\u8bb0\u7684\u5c3a\u5bf8\u3002',
       default: "'md'",
     },

--- a/packages/core/src/Tokenizer/XDSTokenizer.test.tsx
+++ b/packages/core/src/Tokenizer/XDSTokenizer.test.tsx
@@ -329,6 +329,20 @@ describe('XDSTokenizer', () => {
     expect(tokenElements.length).toBeGreaterThanOrEqual(2);
   });
 
+  it('renders with size="lg"', () => {
+    render(
+      <XDSTokenizer
+        label="Members"
+        searchSource={userSource}
+        value={[]}
+        onChange={() => {}}
+        size="lg"
+      />,
+    );
+    expect(screen.getByText('Members')).toBeInTheDocument();
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+  });
+
   describe('tokenOverflowBehavior', () => {
     it('none: renders all tokens directly without XDSOverflowList', () => {
       const {container} = render(

--- a/packages/core/src/Tokenizer/XDSTokenizer.tsx
+++ b/packages/core/src/Tokenizer/XDSTokenizer.tsx
@@ -68,7 +68,7 @@ export type XDSTokenizerChange<T extends XDSSearchableItem> =
   | {item: T; type: 'remove'}
   | {type: 'reorder'};
 
-export type XDSTokenizerSize = 'sm' | 'md';
+export type XDSTokenizerSize = 'sm' | 'md' | 'lg';
 
 /**
  * Controls overflow behavior when tokens exceed the available width.
@@ -211,26 +211,11 @@ const styles = stylex.create({
   },
   endSection: {
     position: 'absolute',
-    // -1px to account for the wrapper's 1px border
-    top: '-1px',
-    // Match the wrapperWithTokens inline padding for consistent inset
     insetInlineEnd: `calc(${spacingVars['--spacing-1']} - 1px)`,
     display: 'flex',
     alignItems: 'center',
     gap: spacingVars['--spacing-2'],
     flexShrink: 0,
-  },
-  endSectionSm: {
-    height: sizeVars['--size-element-sm'],
-  },
-  endSectionMd: {
-    height: sizeVars['--size-element-md'],
-  },
-  sizeSm: {
-    minHeight: sizeVars['--size-element-sm'],
-  },
-  sizeMd: {
-    minHeight: sizeVars['--size-element-md'],
   },
   inputAtMax: {
     width: 0,
@@ -252,18 +237,6 @@ const styles = stylex.create({
     flexWrap: 'nowrap',
     overflow: 'hidden',
   },
-  truncatedSm: {
-    height: sizeVars['--size-element-sm'],
-  },
-  truncatedMd: {
-    height: sizeVars['--size-element-md'],
-  },
-  layerPlaceholderSm: {
-    height: sizeVars['--size-element-sm'],
-  },
-  layerPlaceholderMd: {
-    height: sizeVars['--size-element-md'],
-  },
   layerPopover: {
     // Top-layer popover: match the anchor width exactly so the expanded
     // tokenizer looks like an in-place expansion, overlapping the
@@ -277,6 +250,30 @@ const styles = stylex.create({
     color: colorVars['--color-text-secondary'],
     paddingInline: spacingVars['--spacing-1'],
   },
+});
+
+const sizeStyles = stylex.create({
+  sm: {minHeight: sizeVars['--size-element-sm']},
+  md: {minHeight: sizeVars['--size-element-md']},
+  lg: {minHeight: sizeVars['--size-element-lg']},
+});
+
+const endSectionSizeStyles = stylex.create({
+  sm: {top: `calc(${sizeVars['--size-element-sm']} / 2 - 1px)`, transform: 'translateY(-50%)'},
+  md: {top: `calc(${sizeVars['--size-element-md']} / 2 - 1px)`, transform: 'translateY(-50%)'},
+  lg: {top: `calc(${sizeVars['--size-element-lg']} / 2 - 1px)`, transform: 'translateY(-50%)'},
+});
+
+const truncatedSizeStyles = stylex.create({
+  sm: {height: sizeVars['--size-element-sm']},
+  md: {height: sizeVars['--size-element-md']},
+  lg: {height: sizeVars['--size-element-lg']},
+});
+
+const layerPlaceholderSizeStyles = stylex.create({
+  sm: {height: sizeVars['--size-element-sm']},
+  md: {height: sizeVars['--size-element-md']},
+  lg: {height: sizeVars['--size-element-lg']},
 });
 
 // =============================================================================
@@ -602,7 +599,7 @@ export function XDSTokenizer<T extends XDSSearchableItem>({
       .filter(Boolean)
       .join(' ') || undefined;
 
-  const sizeStyle = size === 'sm' ? styles.sizeSm : styles.sizeMd;
+  const sizeStyle = sizeStyles[size];
 
   // Render tokens
   const tokens = value.map(item => {
@@ -651,9 +648,7 @@ export function XDSTokenizer<T extends XDSSearchableItem>({
           styles.wrapper,
           value.length > 0 && styles.wrapperWithTokens,
           isTruncated
-            ? size === 'sm'
-              ? styles.truncatedSm
-              : styles.truncatedMd
+            ? truncatedSizeStyles[size]
             : sizeStyle,
           isTruncated && styles.truncatedWrapper,
           isDisabled && inputWrapperStyles.disabled,
@@ -712,7 +707,7 @@ export function XDSTokenizer<T extends XDSSearchableItem>({
         <div
           {...stylex.props(
             styles.endSection,
-            size === 'sm' ? styles.endSectionSm : styles.endSectionMd,
+            endSectionSizeStyles[size],
           )}>
           {endContent}
           {hasClear && value.length > 0 && !isDisabled && (
@@ -731,8 +726,7 @@ export function XDSTokenizer<T extends XDSSearchableItem>({
 
   let tokenizerContent: ReactNode;
   if (isLayerMode) {
-    const placeholderSizeStyle =
-      size === 'sm' ? styles.layerPlaceholderSm : styles.layerPlaceholderMd;
+    const placeholderSizeStyle = layerPlaceholderSizeStyles[size];
     tokenizerContent = (
       <>
         <div

--- a/packages/core/src/Typeahead/Typeahead.doc.mjs
+++ b/packages/core/src/Typeahead/Typeahead.doc.mjs
@@ -121,7 +121,7 @@ export const docs = {
         },
         {
           name: 'size',
-          type: "'sm' | 'md'",
+          type: "'sm' | 'md' | 'lg'",
           description: 'Input and token size.',
           default: "'md'",
         },
@@ -434,7 +434,7 @@ export const docsZh = {
         },
         {
           name: 'size',
-          type: "'sm' | 'md'",
+          type: "'sm' | 'md' | 'lg'",
           description: '输入框和标记的尺寸。',
           default: "'md'",
         },

--- a/packages/core/src/Typeahead/XDSBaseTypeahead.tsx
+++ b/packages/core/src/Typeahead/XDSBaseTypeahead.tsx
@@ -156,7 +156,7 @@ export interface XDSBaseTypeaheadProps<
    * When 'sm', items get compact padding to match the trigger size.
    * @default 'md'
    */
-  size?: 'sm' | 'md';
+  size?: 'sm' | 'md' | 'lg';
 }
 
 // =============================================================================
@@ -250,6 +250,9 @@ const itemSizeStyles = stylex.create({
   },
   md: {
     paddingBlock: spacingVars['--spacing-1-5'],
+  },
+  lg: {
+    paddingBlock: spacingVars['--spacing-2'],
   },
 });
 

--- a/packages/core/src/Typeahead/XDSTypeahead.test.tsx
+++ b/packages/core/src/Typeahead/XDSTypeahead.test.tsx
@@ -272,6 +272,21 @@ describe('XDSTypeahead', () => {
   });
 });
 
+describe('XDSTypeahead size', () => {
+  it('renders with size="lg"', () => {
+    render(
+      <XDSTypeahead
+        label="Fruit"
+        searchSource={fruitSource}
+        value={null}
+        onChange={() => {}}
+        size="lg"
+      />,
+    );
+    expect(screen.getByLabelText('Fruit')).toBeInTheDocument();
+  });
+});
+
 describe('XDSBaseTypeahead hasEntriesOnFocus', () => {
   it('shows bootstrap results on mouse click', async () => {
     render(

--- a/packages/core/src/Typeahead/XDSTypeahead.tsx
+++ b/packages/core/src/Typeahead/XDSTypeahead.tsx
@@ -49,7 +49,7 @@ export type {
   XDSInputStatusType as XDSTypeaheadStatusType,
 } from '../Field';
 
-export type XDSTypeaheadSize = 'sm' | 'md';
+export type XDSTypeaheadSize = 'sm' | 'md' | 'lg';
 
 export interface XDSTypeaheadProps<T extends XDSSearchableItem> extends Omit<
   XDSBaseProps<HTMLDivElement>,
@@ -141,12 +141,6 @@ const styles = stylex.create({
     top: `calc((${sizeVars['--size-element-sm']} - 20px) / 2 - 1px)`,
     insetInlineEnd: `calc((${sizeVars['--size-element-sm']} - 20px) / 2 - 1px)`,
   },
-  sizeSmWrapper: {
-    minHeight: sizeVars['--size-element-sm'],
-  },
-  sizeMdWrapper: {
-    minHeight: sizeVars['--size-element-md'],
-  },
   inputHidden: {
     width: 0,
     minWidth: 0,
@@ -155,6 +149,12 @@ const styles = stylex.create({
     opacity: 0,
     position: 'absolute' as const,
   },
+});
+
+const wrapperSizeStyles = stylex.create({
+  sm: {minHeight: sizeVars['--size-element-sm']},
+  md: {minHeight: sizeVars['--size-element-md']},
+  lg: {minHeight: sizeVars['--size-element-lg']},
 });
 
 // =============================================================================
@@ -334,7 +334,7 @@ export function XDSTypeahead<T extends XDSSearchableItem>({
       .filter(Boolean)
       .join(' ') || undefined;
 
-  const sizeStyle = size === 'sm' ? styles.sizeSmWrapper : styles.sizeMdWrapper;
+  const sizeStyle = wrapperSizeStyles[size];
 
   return (
     <XDSField


### PR DESCRIPTION
  ## Summary
  - Add `lg` (36px) size support to **Token**, **Typeahead**, **Tokenizer**, **DateTimeInput**, **DateRangeInput**, **TextArea**, and **PowerSearch**
  - `XDSInputSize` type in `Field/types.ts` now includes `'lg'`
  - Token lg height = 28px (36px − 8px for border concentricity)
  - TextArea lg adds increased `paddingBlock` only (height is controlled by `rows`)
  - PowerSearch forwards `size` to its internal Tokenizer and Token
  - All size ternaries converted to lookup maps for consistency
  - Doc file updates (`*.doc.mjs`)
  - Storybook stories with `size` argType `['sm', 'md', 'lg']`
  - Smoke tests for `size="lg"` rendering

  ## Test plan
  - [x] `pnpm -F @xds/core exec tsc --noEmit` — clean build
  - [x] 293 tests pass across Token, Typeahead, Tokenizer, DateTimeInput, DateRangeInput, TextArea, PowerSearch
  - [x] Visual check in Storybook at all three sizes