### PR TITLE
feat(Chat): rename isStreaming to isStopShown

### DIFF
--- a/apps/storybook/stories/ChatAutoScroll.stories.tsx
+++ b/apps/storybook/stories/ChatAutoScroll.stories.tsx
@@ -390,14 +390,13 @@ export const ScrollBehaviorComparison: StoryObj = {
             />
           </div>
         </div>
-
         {/* Chat area */}
         <XDSChatLayout
           composer={
             <XDSChatComposer
               onSubmit={() => {}}
               placeholder="Observe auto-scroll behavior above..."
-              isStreaming={isStreaming}
+              isStopShown={isStreaming}
             />
           }>
           <XDSChatMessageList>

--- a/apps/storybook/stories/ChatComposer.stories.tsx
+++ b/apps/storybook/stories/ChatComposer.stories.tsx
@@ -103,7 +103,7 @@ export const WithStreaming: Story = {
           console.log('Submit:', value);
           setIsStreaming(true);
         }}
-        isStreaming={isStreaming}
+        isStopShown={isStreaming}
         onStop={() => {
           console.log('Stopped');
           setIsStreaming(false);
@@ -170,7 +170,7 @@ export const FullFeatured: Story = {
           setIsStreaming(true);
           setTimeout(() => setIsStreaming(false), 3000);
         }}
-        isStreaming={isStreaming}
+        isStopShown={isStreaming}
         onStop={() => setIsStreaming(false)}
         placeholder="Ask me anything..."
         drawer={
@@ -325,7 +325,7 @@ export const SendStopToggle: Story = {
           setIsStreaming(true);
           setTimeout(() => setIsStreaming(false), 5000);
         }}
-        isStreaming={isStreaming}
+        isStopShown={isStreaming}
         onStop={() => {
           console.log('Stopped');
           setIsStreaming(false);

--- a/apps/storybook/stories/ChatLayout.stories.tsx
+++ b/apps/storybook/stories/ChatLayout.stories.tsx
@@ -412,7 +412,7 @@ export const FullAIChat: StoryObj = {
       <XDSChatComposer
         onSubmit={handleSubmit}
         onStop={handleStop}
-        isStreaming={isStreaming}
+        isStopShown={isStreaming}
         drawer={
           files.length > 0 ? (
             <XDSChatComposerDrawer>
@@ -720,7 +720,7 @@ export const PanelView: StoryObj = {
       <XDSChatComposer
         onSubmit={handleSubmit}
         onStop={handleStop}
-        isStreaming={isStreaming}
+        isStopShown={isStreaming}
         drawer={
           files.length > 0 ? (
             <XDSChatComposerDrawer>

--- a/packages/cli/src/codemods/__tests__/rename-isStreaming-to-isStopShown.test.mjs
+++ b/packages/cli/src/codemods/__tests__/rename-isStreaming-to-isStopShown.test.mjs
@@ -1,0 +1,58 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {describe, expect, test} from 'vitest';
+import {applyTransform} from 'jscodeshift/dist/testUtils.js';
+import transform from '../transforms/v0.0.15/rename-isStreaming-to-isStopShown.mjs';
+
+const opts = {parser: 'tsx'};
+
+describe('rename-isStreaming-to-isStopShown', () => {
+  test('renames isStreaming prop on XDSChatComposer', () => {
+    const input = `<XDSChatComposer isStreaming={isStreaming} onSubmit={handleSubmit} />`;
+    const output = applyTransform({default: transform, parser: 'tsx'}, opts, {source: input});
+    expect(output).toContain('isStopShown={isStreaming}');
+    expect(output).not.toContain('isStreaming={');
+  });
+
+  test('renames boolean isStreaming prop on XDSChatSendButton', () => {
+    const input = `<XDSChatSendButton isStreaming onStop={() => {}} />`;
+    const output = applyTransform({default: transform, parser: 'tsx'}, opts, {source: input});
+    expect(output).toContain('isStopShown');
+    expect(output).not.toContain('isStreaming');
+  });
+
+  test('renames isStreaming with expression value', () => {
+    const input = `<XDSChatComposer isStreaming={state.active} onSubmit={fn} />`;
+    const output = applyTransform({default: transform, parser: 'tsx'}, opts, {source: input});
+    expect(output).toContain('isStopShown={state.active}');
+  });
+
+  test('does not rename isStreaming on unrelated components', () => {
+    const input = `<XDSMarkdown isStreaming={true} />`;
+    const output = applyTransform({default: transform, parser: 'tsx'}, opts, {source: input});
+    expect(output).toBe('');
+  });
+
+  test('does not rename isStreaming on XDSChatReasoning', () => {
+    const input = `<XDSChatReasoning isStreaming label="Thinking" />`;
+    const output = applyTransform({default: transform, parser: 'tsx'}, opts, {source: input});
+    expect(output).toBe('');
+  });
+
+  test('renames both components in the same file', () => {
+    const input = `
+      <XDSChatComposer isStreaming={streaming} onSubmit={fn}>
+        <XDSChatSendButton isStreaming={streaming} />
+      </XDSChatComposer>
+    `;
+    const output = applyTransform({default: transform, parser: 'tsx'}, opts, {source: input});
+    expect(output).not.toContain('isStreaming');
+    expect(output.match(/isStopShown/g)).toHaveLength(2);
+  });
+
+  test('leaves files without target components unchanged', () => {
+    const input = `const isStreaming = true;`;
+    const output = applyTransform({default: transform, parser: 'tsx'}, opts, {source: input});
+    expect(output).toBe('');
+  });
+});

--- a/packages/cli/src/codemods/transforms/v0.0.15/index.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.15/index.mjs
@@ -10,10 +10,19 @@ import renameDatePickerToInput, {
   meta as renameDatePickerToInputMeta,
 } from './rename-date-picker-to-input.mjs';
 
+import renameIsStreamingToIsStopShown, {
+  meta as renameIsStreamingToIsStopShownMeta,
+} from './rename-isStreaming-to-isStopShown.mjs';
+
 export default [
   {
     name: 'rename-date-picker-to-input',
     transform: renameDatePickerToInput,
     meta: renameDatePickerToInputMeta,
+  },
+  {
+    name: 'rename-isStreaming-to-isStopShown',
+    transform: renameIsStreamingToIsStopShown,
+    meta: renameIsStreamingToIsStopShownMeta,
   },
 ];

--- a/packages/cli/src/codemods/transforms/v0.0.15/rename-isStreaming-to-isStopShown.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.15/rename-isStreaming-to-isStopShown.mjs
@@ -1,0 +1,51 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Codemod: Rename isStreaming → isStopShown on XDSChatComposer and XDSChatSendButton
+ *
+ * The `isStreaming` prop on chat components was too narrow — it implied only
+ * text streaming, but it actually controls whether the stop button is shown.
+ * Renamed to `isStopShown` for clarity.
+ *
+ * Handles:
+ * - JSX prop: `isStreaming` → `isStopShown` on XDSChatComposer and XDSChatSendButton
+ *
+ * Does NOT rename:
+ * - `isStreaming` on other components (XDSMarkdown, XDSChatReasoning)
+ * - Local variables, object properties, or state named `isStreaming`
+ */
+
+export const meta = {
+  title: 'Rename ChatComposer/ChatSendButton isStreaming to isStopShown',
+  description:
+    'Renames the `isStreaming` prop to `isStopShown` on `XDSChatComposer` and ' +
+    '`XDSChatSendButton`. The prop controls whether the stop button is shown — ' +
+    'the new name describes the affordance rather than implying a streaming state.',
+  issue: '#2328',
+};
+
+const TARGET_COMPONENTS = new Set(['XDSChatComposer', 'XDSChatSendButton']);
+
+export default function transformer(file, api) {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+  let hasChanges = false;
+
+  // Rename JSX prop on target components only
+  root.find(j.JSXOpeningElement).forEach((path) => {
+    const name = path.node.name;
+    const componentName = name.type === 'JSXIdentifier' ? name.name : null;
+    if (!TARGET_COMPONENTS.has(componentName)) return;
+
+    const attrs = path.node.attributes;
+    for (const attr of attrs) {
+      if (attr.type === 'JSXAttribute' && attr.name?.name === 'isStreaming') {
+        attr.name.name = 'isStopShown';
+        hasChanges = true;
+      }
+    }
+  });
+
+  if (!hasChanges) return undefined;
+  return root.toSource({quote: 'single'});
+}

--- a/packages/cli/templates/blocks/components/ChatComposer/ChatComposerFullFeatured.tsx
+++ b/packages/cli/templates/blocks/components/ChatComposer/ChatComposerFullFeatured.tsx
@@ -40,7 +40,7 @@ export default function ChatComposerFullFeatured() {
           setIsStreaming(true);
           setTimeout(() => setIsStreaming(false), 3000);
         }}
-        isStreaming={isStreaming}
+        isStopShown={isStreaming}
         onStop={() => setIsStreaming(false)}
         placeholder="Ask me anything..."
         input={<XDSChatComposerInput style={{minHeight: 44}} />}

--- a/packages/cli/templates/blocks/components/ChatComposer/ChatComposerStreaming.tsx
+++ b/packages/cli/templates/blocks/components/ChatComposer/ChatComposerStreaming.tsx
@@ -33,7 +33,7 @@ export default function ChatComposerStreaming() {
             setIsStreaming(true);
             setTimeout(() => setIsStreaming(false), 5000);
           }}
-          isStreaming={isStreaming}
+          isStopShown={isStreaming}
           onStop={() => {
             console.log('Stopped');
             setIsStreaming(false);

--- a/packages/cli/templates/blocks/components/ChatSendButton/ChatSendButtonCustomIcon.tsx
+++ b/packages/cli/templates/blocks/components/ChatSendButton/ChatSendButtonCustomIcon.tsx
@@ -36,7 +36,7 @@ export default function ChatSendButtonCustomIcon() {
           sendIcon={<XDSIcon icon={SparklesIcon} size="sm" />}
         />
         <XDSChatSendButton
-          isStreaming
+          isStopShown
           onStop={() => {}}
           stopIcon={<XDSIcon icon={XCircleIcon} size="sm" />}
         />

--- a/packages/cli/templates/blocks/components/ChatSendButton/ChatSendButtonShowcase.tsx
+++ b/packages/cli/templates/blocks/components/ChatSendButton/ChatSendButtonShowcase.tsx
@@ -16,7 +16,7 @@ export default function ChatSendButtonShowcase() {
         onSend={() => {}}
         sendIcon={<XDSIcon icon={SparklesIcon} size="sm" />}
       />
-      <XDSChatSendButton isStreaming onStop={() => {}} />
+      <XDSChatSendButton isStopShown onStop={() => {}} />
     </XDSStack>
   );
 }

--- a/packages/cli/templates/blocks/components/ChatSendButton/ChatSendButtonStates.tsx
+++ b/packages/cli/templates/blocks/components/ChatSendButton/ChatSendButtonStates.tsx
@@ -15,7 +15,7 @@ export default function ChatSendButtonStates() {
       <XDSStack direction="horizontal" gap={3} vAlign="center">
         <XDSChatSendButton isDisabled onSend={() => {}} />
         <XDSChatSendButton isDisabled={false} onSend={() => {}} />
-        <XDSChatSendButton isStreaming onStop={() => {}} />
+        <XDSChatSendButton isStopShown onStop={() => {}} />
       </XDSStack>
     </XDSStack>
   );

--- a/packages/cli/templates/pages/ai-chat-landing/page.tsx
+++ b/packages/cli/templates/pages/ai-chat-landing/page.tsx
@@ -499,7 +499,7 @@ export default function AIChatTemplate() {
     <XDSChatComposer
       onSubmit={handleSubmit}
       onStop={handleStop}
-      isStreaming={isStreaming}
+      isStopShown={isStreaming}
       placeholder="Ask anything"
       input={
         <XDSChatComposerInput

--- a/packages/core/src/Chat/Chat.doc.mjs
+++ b/packages/core/src/Chat/Chat.doc.mjs
@@ -108,7 +108,7 @@ export const docs = {
       props: [
         {name: 'onSubmit', type: '(value: string) => void', description: 'Called when the user submits a message.', required: true},
         {name: 'onStop', type: '() => void', description: 'Called when the user requests to stop generation.'},
-        {name: 'isStreaming', type: 'boolean', description: 'Whether the assistant is currently streaming.', default: 'false'},
+        {name: 'isStopShown', type: 'boolean', description: 'Whether the stop button is shown instead of the send button.', default: 'false'},
         {name: 'value', type: 'string', description: 'Controlled input value.'},
         {name: 'onChange', type: '(value: string) => void', description: 'Change handler for controlled mode.'},
         {name: 'placeholder', type: 'string', description: 'Placeholder text shown when the input is empty.', default: "'Type a message\u2026'"},
@@ -174,7 +174,7 @@ export const docs = {
       name: 'XDSChatSendButton',
       description: 'Circular send/stop toggle button for the chat composer. Place it inside XDSChatComposer where it reads context automatically — no wiring needed. When streaming starts, the button switches from a primary send icon to a secondary stop icon. Override any context value via props for standalone or custom usage.',
       props: [
-        {name: 'isStreaming', type: 'boolean', description: 'Whether the assistant is currently streaming. Defaults to context value.'},
+        {name: 'isStopShown', type: 'boolean', description: 'Whether the stop button is shown. Defaults to context value.'},
         {name: 'isDisabled', type: 'boolean', description: 'Whether the send button is disabled. Defaults to !canSend from context.'},
         {name: 'onSend', type: '() => void', description: 'Called when the user clicks send. Defaults to context onSubmit.'},
         {name: 'onStop', type: '() => void', description: 'Called when the user clicks stop during streaming. Defaults to context onStop.'},
@@ -354,7 +354,7 @@ export const docsZh = {
       propDescriptions: {
         onSubmit: '用户提交消息时调用。',
         onStop: '用户请求停止生成时调用。',
-        isStreaming: '助手是否正在流式输出。',
+        isStopShown: '是否显示停止按钮。',
         value: '受控输入值。',
         onChange: '受控模式的输入值变更时调用。序列化字符串包含标记占位符。',
         placeholder: '输入为空时显示的占位文本。',
@@ -401,7 +401,7 @@ export const docsZh = {
       description:
         '编写器的圆形发送/停止切换按钮。默认从 XDSChatComposerContext 读取状态，在 XDSChatComposer 内自动工作。所有上下文值均可通过 props 覆盖以用于独立使用。',
       propDescriptions: {
-        isStreaming: '助手是否正在流式响应。默认使用上下文值。',
+        isStopShown: '是否显示停止按钮。默认使用上下文值。',
         isDisabled: '发送按钮是否禁用。默认使用上下文的 !canSend。',
         onSend: '用户点击发送时调用。默认使用上下文的 onSubmit。',
         onStop: '流式响应期间用户点击停止时调用。默认使用上下文的 onStop。',
@@ -535,7 +535,7 @@ export const docsDense = {
       propDescriptions: {
         onSubmit: 'submit msg handler',
         onStop: 'stop generation handler',
-        isStreaming: 'assistant streaming state',
+        isStopShown: 'whether the stop button is shown',
         value: 'controlled input value',
         onChange: 'controlled change handler',
         placeholder: 'placeholder when empty',
@@ -587,7 +587,7 @@ export const docsDense = {
       name: 'XDSChatSendButton',
       description: 'circular send/stop toggle btn for composer; reads XDSChatComposerContext; all context vals overridable via props',
       propDescriptions: {
-        isStreaming: 'streaming state; defaults to context',
+        isStopShown: 'stop button visibility; defaults to context',
         isDisabled: 'disabled; defaults to !canSend from context',
         onSend: 'send click handler; defaults to context onSubmit',
         onStop: 'stop click handler; defaults to context onStop',

--- a/packages/core/src/Chat/XDSChatComposer.tsx
+++ b/packages/core/src/Chat/XDSChatComposer.tsx
@@ -67,10 +67,10 @@ export interface XDSChatComposerProps extends Omit<
   ref?: React.Ref<HTMLDivElement>;
   /** Called when the user submits the message */
   onSubmit: (value: string) => void;
-  /** Called when the user clicks stop during streaming */
+  /** Called when the user clicks the stop button */
   onStop?: () => void;
-  /** Whether the assistant is currently streaming a response */
-  isStreaming?: boolean;
+  /** Whether the stop button is shown instead of the send button. @default false */
+  isStopShown?: boolean;
   /** Controlled value of the input */
   value?: string;
   /** Called when the input value changes */
@@ -269,7 +269,7 @@ export function XDSChatComposer(props: XDSChatComposerProps) {
     ref,
     onSubmit,
     onStop,
-    isStreaming = false,
+    isStopShown = false,
     value: controlledValue,
     onChange,
     placeholder = 'Type a message\u2026',
@@ -360,7 +360,7 @@ export function XDSChatComposer(props: XDSChatComposerProps) {
       onSubmit: handleSubmit,
       placeholder,
       isDisabled,
-      isStreaming,
+      isStopShown,
       canSend,
       onStop,
     }),
@@ -370,7 +370,7 @@ export function XDSChatComposer(props: XDSChatComposerProps) {
       handleSubmit,
       placeholder,
       isDisabled,
-      isStreaming,
+      isStopShown,
       canSend,
       onStop,
     ],

--- a/packages/core/src/Chat/XDSChatContext.tsx
+++ b/packages/core/src/Chat/XDSChatContext.tsx
@@ -50,7 +50,7 @@ export interface XDSChatComposerContextValue {
   onSubmit: (value: string) => void;
   placeholder: string;
   isDisabled: boolean;
-  isStreaming: boolean;
+  isStopShown: boolean;
   canSend: boolean;
   onStop?: () => void;
 }

--- a/packages/core/src/Chat/XDSChatSendButton.tsx
+++ b/packages/core/src/Chat/XDSChatSendButton.tsx
@@ -31,17 +31,17 @@ import type {XDSBaseProps} from '../XDSBaseProps';
 
 export interface XDSChatSendButtonProps extends XDSBaseProps<HTMLButtonElement> {
   ref?: React.Ref<HTMLButtonElement>;
-  /** Whether the assistant is currently streaming a response. */
-  isStreaming?: boolean;
+  /** Whether the stop button is shown instead of the send button. @default false */
+  isStopShown?: boolean;
   /** Whether the send button is disabled. Defaults to `!canSend` from context. */
   isDisabled?: boolean;
   /** Called when the user clicks the send button. Defaults to context onSubmit. */
   onSend?: () => void;
-  /** Called when the user clicks the stop button during streaming. */
+  /** Called when the user clicks the stop button. */
   onStop?: () => void;
   /** Icon for the send state. Resolves from icon registry by default. */
   sendIcon?: ReactNode;
-  /** Icon for the stop/streaming state. Resolves from icon registry by default. */
+  /** Icon for the stop state. Resolves from icon registry by default. */
   stopIcon?: ReactNode;
   /** Button size. @default 'md' */
   size?: 'sm' | 'md';
@@ -77,7 +77,7 @@ export function XDSChatSendButton(props: XDSChatSendButtonProps): ReactNode {
   const context = useXDSChatComposerContext();
 
   const {
-    isStreaming = context?.isStreaming ?? false,
+    isStopShown = context?.isStopShown ?? false,
     isDisabled = !(context?.canSend ?? false),
     onSend,
     onStop = context?.onStop,
@@ -93,17 +93,17 @@ export function XDSChatSendButton(props: XDSChatSendButtonProps): ReactNode {
   return (
     <XDSButton
       ref={ref}
-      label={isStreaming ? 'Stop' : 'Send'}
-      variant={isStreaming ? 'secondary' : 'primary'}
+      label={isStopShown ? 'Stop' : 'Send'}
+      variant={isStopShown ? 'secondary' : 'primary'}
       size={size}
       icon={
-        isStreaming
+        isStopShown
           ? (stopIcon ?? getIcon('stop'))
           : (sendIcon ?? getIcon('arrowUp'))
       }
       isIconOnly
-      isDisabled={!isStreaming && isDisabled}
-      onClick={isStreaming ? onStop : handleSend}
+      isDisabled={!isStopShown && isDisabled}
+      onClick={isStopShown ? onStop : handleSend}
       className={xdsClassName('chat-send-button')}
       xstyle={[styles.root, xstyle]}
     />


### PR DESCRIPTION
## Summary

Renames `isStreaming` → `isStopShown` on `XDSChatComposer` and `XDSChatSendButton`.

## Motivation

The `isStreaming` prop implied only text streaming triggered the stop button, but in practice agents are active during tool execution, subagent dispatch, and other non-streaming work. `isStopShown` describes the **affordance** (is the stop button visible?) without implying internal state.

Follows [API Conventions](https://github.com/facebookexperimental/xds/wiki/API-Conventions):
- `is` prefix for state/condition ✓
- Precedent: `isLabelHidden` for sub-element visibility

## Scope

| Before | After |
|--------|-------|
| `XDSChatComposer.isStreaming` | `isStopShown` |
| `XDSChatSendButton.isStreaming` | `isStopShown` |
| `XDSChatComposerContextValue.isStreaming` | `isStopShown` |

**Not renamed** (legitimately about streaming):
- `XDSMarkdown.isStreaming`
- `XDSChatReasoning.isStreaming`
- `useXDSStreamingText`

## Codemod

Included in `v0.0.16`. Consumers can run:

```bash
npx xds upgrade --from 0.0.15 --to 0.0.16
```

The codemod renames the JSX prop on `XDSChatComposer` and `XDSChatSendButton` only — it does not touch unrelated `isStreaming` usage on other components.

Closes #2328