### PR TITLE
fix(Breadcrumbs, AvatarGroup): forward xstyle/className/style escape hatches

### DIFF
--- a/packages/core/src/AvatarGroup/XDSAvatarGroupOverflow.tsx
+++ b/packages/core/src/AvatarGroup/XDSAvatarGroupOverflow.tsx
@@ -108,6 +108,9 @@ export function XDSAvatarGroupOverflow({
   count,
   onClick,
   children,
+  xstyle,
+  className,
+  style,
 }: XDSAvatarGroupOverflowProps): ReactNode {
   const group = useXDSAvatarGroup();
   const numericSize = group?.numericSize ?? 36;
@@ -132,7 +135,10 @@ export function XDSAvatarGroupOverflow({
             dynamicStyles.size(numericSize),
             dynamicStyles.fontSize(numericSize),
             dynamicStyles.overlap(-overlap),
+            xstyle,
           ),
+          className,
+          style,
         )}>
         {content}
       </button>
@@ -151,7 +157,10 @@ export function XDSAvatarGroupOverflow({
           dynamicStyles.size(numericSize),
           dynamicStyles.fontSize(numericSize),
           dynamicStyles.overlap(-overlap),
+          xstyle,
         ),
+        className,
+        style,
       )}>
       {content}
     </span>

--- a/packages/core/src/Breadcrumbs/XDSBreadcrumbItem.tsx
+++ b/packages/core/src/Breadcrumbs/XDSBreadcrumbItem.tsx
@@ -174,6 +174,9 @@ export function XDSBreadcrumbItem({
   onClick,
   isCurrent: isCurrentProp,
   startIcon,
+  xstyle,
+  className,
+  style,
   'data-testid': testId,
 }: XDSBreadcrumbItemProps) {
   const ctx = use(BreadcrumbContext);
@@ -231,7 +234,10 @@ export function XDSBreadcrumbItem({
           stylex.props(
             itemStyles.root,
             isSupporting ? itemStyles.supportingSize : itemStyles.defaultSize,
+            xstyle,
           ),
+          className,
+          style,
         )}
         data-testid={testId}>
         <span aria-hidden="true" {...stylex.props(itemStyles.separator)}>
@@ -262,7 +268,10 @@ export function XDSBreadcrumbItem({
         stylex.props(
           itemStyles.root,
           isSupporting ? itemStyles.supportingSize : itemStyles.defaultSize,
+          xstyle,
         ),
+        className,
+        style,
       )}
       data-testid={testId}>
       <span aria-hidden="true" {...stylex.props(itemStyles.separator)}>


### PR DESCRIPTION
XDSBreadcrumbItem and XDSAvatarGroupOverflow declare `xstyle`, `className`, and `style` in their props type (via XDSBaseProps) but never destructure or apply them. Consumers passing these props got no effect.

## Changes

- **XDSBreadcrumbItem**: destructure `xstyle`, `className`, `style` and forward to root `<li>` via `mergeProps`
- **XDSAvatarGroupOverflow**: destructure `xstyle`, `className`, `style` and forward to root element (button or span) via `mergeProps`

## Audit Summary

Components audited this pass: AppShell, AvatarGroup, Blockquote, Breadcrumbs, Button.

All other checks passed:
- ✅ CSS variable usage (no hardcoded colors, shadows, spacing, radii, typography)
- ✅ xdsClassName placement and variant inclusion
- ✅ Component reuse
- ✅ Prop naming conventions (`is`/`has` booleans, `on{Verb}` callbacks)
- ✅ Type/context naming (`XDS` prefix)
- ✅ Component structure (displayName, file header, BaseProps, `'use client'`)
- ✅ Accessibility (aria-label, role, hover guards)
- ✅ Export hygiene (index.ts, package.json exports, tsup entry points)

Night Watch — Component Auditor