### PR TITLE
fix(AppShell): show mobile sidenav for heading-only TopNav

### DIFF
--- a/apps/storybook/stories/AppShell.stories.tsx
+++ b/apps/storybook/stories/AppShell.stories.tsx
@@ -308,6 +308,27 @@ export const TopNavWithSideNav: Story = {
 };
 
 /**
+ * Heading-only TopNav with SideNav. On mobile, AppShell should still show the
+ * auto hamburger toggle and open a drawer containing the SideNav items.
+ */
+export const HeadingOnlyTopNavWithSideNav: Story = {
+  render: () => (
+    <XDSAppShell
+      contentPadding={6}
+      mobileNav={{breakpoint: 'md'}}
+      topNav={
+        <XDSTopNav
+          label="Main navigation"
+          heading={<XDSTopNavHeading heading="Acme App" />}
+        />
+      }
+      sideNav={<SideNavWithoutHeader />}>
+      <MockContent />
+    </XDSAppShell>
+  ),
+};
+
+/**
  * SideNav with its own heading (icon + heading) and no TopNav.
  * Use this layout for simpler apps where a full top bar isn't needed.
  * The SideNav header provides the app identity instead.

--- a/packages/core/src/AppShell/AppShell.doc.mjs
+++ b/packages/core/src/AppShell/AppShell.doc.mjs
@@ -13,6 +13,7 @@ export const docs = {
     bestPractices: [
       {guidance: true, description: 'Choose the right height — use "fill" for dashboards with internal scrolling and "auto" for pages that grow with content.'},
       {guidance: true, description: 'Set `contentPadding` based on content type — 4 for forms and settings, 0 for tables and dashboards.'},
+      {guidance: true, description: 'Pair a heading-only TopNav with sideNav when TopNav should provide identity and SideNav should provide all page navigation.'},
       {guidance: false, description: "Nest one AppShell inside another — it's the outermost layout frame."},
       {guidance: false, description: 'Use for sub-page layouts — use Layout for content areas within AppShell.'},
     ],
@@ -140,6 +141,7 @@ export const docsZh = {
     bestPractices: [
       {guidance: true, description: 'Choose the right height — use "fill" for dashboards with internal scrolling and "auto" for pages that grow with content.'},
       {guidance: true, description: 'Set `contentPadding` based on content type — 4 for forms and settings, 0 for tables and dashboards.'},
+      {guidance: true, description: 'Pair a heading-only TopNav with sideNav when TopNav should provide identity and SideNav should provide all page navigation.'},
       {guidance: false, description: "Nest one AppShell inside another — it's the outermost layout frame."},
       {guidance: false, description: 'Use for sub-page layouts — use Layout for content areas within AppShell.'},
     ],
@@ -212,6 +214,7 @@ export const docsDense = {
     bestPractices: [
       {guidance: true, description: 'Choose the right height — use "fill" for dashboards with internal scrolling and "auto" for pages that grow with content.'},
       {guidance: true, description: 'Set `contentPadding` based on content type — 4 for forms and settings, 0 for tables and dashboards.'},
+      {guidance: true, description: 'Pair a heading-only TopNav with sideNav when TopNav should provide identity and SideNav should provide all page navigation.'},
       {guidance: false, description: "Nest one AppShell inside another — it's the outermost layout frame."},
       {guidance: false, description: 'Use for sub-page layouts — use Layout for content areas within AppShell.'},
     ],

--- a/packages/core/src/AppShell/XDSAppShell.test.tsx
+++ b/packages/core/src/AppShell/XDSAppShell.test.tsx
@@ -18,7 +18,7 @@ import {
   beforeEach,
   afterEach,
 } from 'vitest';
-import {render, screen, fireEvent} from '@testing-library/react';
+import {render, screen, fireEvent, waitFor} from '@testing-library/react';
 import {XDSAppShell} from './XDSAppShell';
 import {XDSMobileNav} from '../MobileNav';
 import {XDSSideNav, XDSSideNavItem, XDSSideNavSection} from '../SideNav';
@@ -328,6 +328,83 @@ describe('XDSAppShell', () => {
     ).toBeGreaterThan(0);
     expect(screen.getByText('Home')).toBeInTheDocument();
     expect(screen.getAllByText('Side item').length).toBeGreaterThan(0);
+  });
+
+  it('does not show an auto mobile nav toggle when sideNav renders null', async () => {
+    mockMql = createMockMatchMedia(true);
+    vi.stubGlobal('matchMedia', vi.fn().mockReturnValue(mockMql));
+
+    function EmptySideNav() {
+      return null;
+    }
+
+    render(
+      <XDSAppShell sideNav={<EmptySideNav />} mobileNav={{breakpoint: 'md'}}>
+        <div>Content</div>
+      </XDSAppShell>,
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('mobile-nav-toggle')).not.toBeInTheDocument();
+    });
+  });
+
+  it('shows auto mobile nav toggle with heading-only TopNav and sideNav', async () => {
+    mockMql = createMockMatchMedia(true);
+    vi.stubGlobal('matchMedia', vi.fn().mockReturnValue(mockMql));
+
+    render(
+      <XDSAppShell
+        topNav={
+          <XDSTopNav
+            label="Main navigation"
+            heading={<XDSTopNavHeading heading="My App" />}
+          />
+        }
+        sideNav={<TestSideNav>Settings</TestSideNav>}
+        mobileNav={{breakpoint: 'md'}}>
+        <div>Content</div>
+      </XDSAppShell>,
+    );
+
+    const toggle = screen.getByRole('button', {name: /open navigation/i});
+    expect(toggle).toBeInTheDocument();
+
+    fireEvent.click(toggle);
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog', {hidden: true})).toHaveAttribute(
+        'open',
+      );
+    });
+    expect(screen.getAllByText('Settings').length).toBeGreaterThan(0);
+  });
+
+  it('keeps the auto mobile nav toggle after closing a heading-only TopNav drawer', () => {
+    mockMql = createMockMatchMedia(true);
+    vi.stubGlobal('matchMedia', vi.fn().mockReturnValue(mockMql));
+
+    render(
+      <XDSAppShell
+        topNav={
+          <XDSTopNav
+            label="Main navigation"
+            heading={<XDSTopNavHeading heading="My App" />}
+          />
+        }
+        sideNav={<TestSideNav />}
+        mobileNav={{breakpoint: 'md'}}>
+        <div>Content</div>
+      </XDSAppShell>,
+    );
+
+    const toggle = screen.getByTestId('mobile-nav-toggle');
+    expect(toggle).toBeInTheDocument();
+
+    fireEvent.click(toggle);
+    fireEvent.click(screen.getByRole('button', {name: /close navigation/i}));
+
+    expect(screen.getByTestId('mobile-nav-toggle')).toBeInTheDocument();
   });
 
   it('renders mobile layout on first render when defaultIsMobile is true', () => {

--- a/packages/core/src/AppShell/XDSAppShell.tsx
+++ b/packages/core/src/AppShell/XDSAppShell.tsx
@@ -609,7 +609,7 @@ export function XDSAppShell({
   // Wrap with mobile content context so TopNav knows there's SideNav content
   // in the drawer and shows the toggle even without its own collapsible items.
   const mobileContentValue =
-    hasSideNavContent && mobileNavHasToggle ? (
+    hasSideNav && mobileNavHasToggle ? (
       // eslint-disable-next-line @eslint-react/no-unstable-context-value -- context transports ReactNode; instability is inherent
       <XDSSideNavRenderContext value="drawer-content">
         <div ref={sideNavRef} style={{display: 'contents'}}>
@@ -618,7 +618,7 @@ export function XDSAppShell({
       </XDSSideNavRenderContext>
     ) : null;
 
-  const drawerMobileContentValue = hasSideNavContent ? (
+  const drawerMobileContentValue = hasSideNav ? (
     // eslint-disable-next-line @eslint-react/no-unstable-context-value -- context transports ReactNode; instability is inherent
     <XDSSideNavRenderContext value="drawer-content">
       {sideNav}
@@ -813,13 +813,11 @@ export function XDSAppShell({
           mobileNavReactNode == null &&
           !mobileNavConfigContent && (
             <ActivityWrapper mode={isMobileNavOpen ? 'visible' : 'hidden'}>
-              {/* SideNav drawer — always mounted so presence detection works.
-                Hidden when TopNav owns the drawer (combined mode passes
-                sideNav via TopNav's mobile content context instead). */}
-              {hasSideNav && (
-                <div
-                  ref={sideNavRef}
-                  style={{display: hasTopNavContent ? 'none' : 'contents'}}>
+              {/* SideNav drawer for side-nav-only layouts. When TopNav owns
+                the combined drawer, sideNav is passed through mobile content
+                context instead so only one drawer instance controls state. */}
+              {hasSideNav && !hasTopNavContent && (
+                <div ref={sideNavRef} style={{display: 'contents'}}>
                   <XDSSideNavRenderContext value="drawer">
                     {sideNav}
                   </XDSSideNavRenderContext>


### PR DESCRIPTION
## Summary
- fixes #2243 by letting heading-only TopNav mobile mode receive SideNav drawer content
- avoids mounting a duplicate hidden SideNav drawer when TopNav owns the combined mobile drawer
- adds a Storybook repro story for heading-only TopNav + SideNav on mobile
- adds our regression test plus the two added AppShell tests from #2319

## Test plan
- pnpm exec vitest run packages/core/src/AppShell/XDSAppShell.test.tsx
- pnpm -F @xds/core typecheck
- pnpm -F @xds/storybook typecheck
- pnpm exec eslint packages/core/src/AppShell apps/storybook/stories/AppShell.stories.tsx
- pnpm exec eslint packages/core/src/AppShell/XDSAppShell.test.tsx
- pre-commit check:repo