### PR TITLE
Fix existing lint warnings

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -32,6 +32,7 @@ export default tseslint.config(
     ignores: [
       "**/dist/**",
       "**/node_modules/**",
+      ".claude/**",
       "**/internal/eslint-plugin-xds/**",
       ".github/scripts/**",
       "scripts/**",
@@ -187,6 +188,7 @@ export default tseslint.config(
   {
     files: [
       "apps/storybook/stories/**/*.{ts,tsx}",
+      "apps/docsite/src/generated/**/*.{ts,tsx}",
       "apps/sandbox/**/*.{ts,tsx}",
       "apps/example-*/**/*.{ts,tsx}",
       "internal/**/*.{ts,tsx}",

--- a/packages/core/src/PowerSearch/XDSPowerSearch.tsx
+++ b/packages/core/src/PowerSearch/XDSPowerSearch.tsx
@@ -27,7 +27,6 @@ import {
   XDSTokenizer,
   type XDSTokenizerHandle,
   type XDSTokenizerOverflowBehavior,
-  type XDSTokenizerSize,
 } from '../Tokenizer';
 import {XDSTypeaheadItem} from '../Typeahead/XDSTypeaheadItem';
 import {XDSToken} from '../Token';

--- a/packages/lab/src/Chart/formatters.ts
+++ b/packages/lab/src/Chart/formatters.ts
@@ -11,10 +11,18 @@
 
 export function compactNumber(value: unknown): string {
   const n = Number(value);
-  if (isNaN(n)) return String(value);
-  if (Math.abs(n) >= 1_000_000_000) return `${strip(n / 1_000_000_000)}B`;
-  if (Math.abs(n) >= 1_000_000) return `${strip(n / 1_000_000)}M`;
-  if (Math.abs(n) >= 1_000) return `${strip(n / 1_000)}K`;
+  if (isNaN(n)) {
+    return String(value);
+  }
+  if (Math.abs(n) >= 1_000_000_000) {
+    return `${strip(n / 1_000_000_000)}B`;
+  }
+  if (Math.abs(n) >= 1_000_000) {
+    return `${strip(n / 1_000_000)}M`;
+  }
+  if (Math.abs(n) >= 1_000) {
+    return `${strip(n / 1_000)}K`;
+  }
   return n.toString();
 }
 
@@ -31,11 +39,18 @@ export function compactNumber(value: unknown): string {
 export function currency(symbol = '$'): (value: unknown) => string {
   return (value: unknown) => {
     const n = Number(value);
-    if (isNaN(n)) return String(value);
-    if (Math.abs(n) >= 1_000_000_000)
+    if (isNaN(n)) {
+      return String(value);
+    }
+    if (Math.abs(n) >= 1_000_000_000) {
       return `${symbol}${strip(n / 1_000_000_000)}B`;
-    if (Math.abs(n) >= 1_000_000) return `${symbol}${strip(n / 1_000_000)}M`;
-    if (Math.abs(n) >= 1_000) return `${symbol}${strip(n / 1_000)}K`;
+    }
+    if (Math.abs(n) >= 1_000_000) {
+      return `${symbol}${strip(n / 1_000_000)}M`;
+    }
+    if (Math.abs(n) >= 1_000) {
+      return `${symbol}${strip(n / 1_000)}K`;
+    }
     return `${symbol}${n.toLocaleString()}`;
   };
 }
@@ -51,7 +66,9 @@ function strip(n: number): string {
  */
 export function percent(value: unknown): string {
   const n = Number(value);
-  if (isNaN(n)) return String(value);
+  if (isNaN(n)) {
+    return String(value);
+  }
   return `${Math.round(n * 100)}%`;
 }
 
@@ -60,7 +77,9 @@ export function percent(value: unknown): string {
  */
 export function shortDate(value: unknown): string {
   const d = value instanceof Date ? value : new Date(Number(value));
-  if (isNaN(d.getTime())) return String(value);
+  if (isNaN(d.getTime())) {
+    return String(value);
+  }
   return d.toLocaleDateString(undefined, {month: 'short', day: 'numeric'});
 }
 
@@ -69,6 +88,8 @@ export function shortDate(value: unknown): string {
  */
 export function monthYear(value: unknown): string {
   const d = value instanceof Date ? value : new Date(Number(value));
-  if (isNaN(d.getTime())) return String(value);
+  if (isNaN(d.getTime())) {
+    return String(value);
+  }
   return d.toLocaleDateString(undefined, {month: 'short', year: 'numeric'});
 }

--- a/packages/lab/src/ChartV2/XDSChartLegend.tsx
+++ b/packages/lab/src/ChartV2/XDSChartLegend.tsx
@@ -37,7 +37,9 @@ export function XDSChartLegend({
   position = 'bottom',
   alignment = 'start',
 }: XDSChartLegendProps) {
-  if (items.length === 0) return null;
+  if (items.length === 0) {
+    return null;
+  }
 
   const isVertical = position === 'start' || position === 'end';
 

--- a/packages/lab/src/ChartV2/XDSChartTooltip.tsx
+++ b/packages/lab/src/ChartV2/XDSChartTooltip.tsx
@@ -172,7 +172,9 @@ export function XDSChartTooltip({
     (e: ChartPointerEvent) => {
       const card = cardRef.current;
       const svg = svgRef.current;
-      if (!card) return;
+      if (!card) {
+        return;
+      }
       if (!svg || !e.nearest) {
         card.style.display = 'none';
         return;
@@ -240,13 +242,19 @@ export function XDSChartTooltip({
 
   // Hover dots — read from the resolved map at the hovered index.
   const dots = useMemo(() => {
-    if (!showHoverDots || hoveredIndex == null) return null;
+    if (!showHoverDots || hoveredIndex == null) {
+      return null;
+    }
     const elements: ReactNode[] = [];
     for (const s of series) {
-      if (!shouldRenderHoverDot(s.type)) continue;
+      if (!shouldRenderHoverDot(s.type)) {
+        continue;
+      }
       const points = resolved.get(s.key);
       const point = points?.find(p => p.dataIndex === hoveredIndex);
-      if (!point) continue;
+      if (!point) {
+        continue;
+      }
       elements.push(
         <circle
           key={s.key}
@@ -265,10 +273,16 @@ export function XDSChartTooltip({
 
   // Band highlight — only on band scales (categorical x-axis).
   const bandHighlight = useMemo(() => {
-    if (!highlightBand || hoveredIndex == null) return null;
-    if (!('bandwidth' in xScale)) return null;
+    if (!highlightBand || hoveredIndex == null) {
+      return null;
+    }
+    if (!('bandwidth' in xScale)) {
+      return null;
+    }
     const xv = data[hoveredIndex]?.[xKey];
-    if (xv == null) return null;
+    if (xv == null) {
+      return null;
+    }
     const bandScale = xScale as ScaleBand<string>;
     const x = bandScale(String(xv)) ?? 0;
     const bw = bandScale.bandwidth();

--- a/packages/lab/src/ChartV2/legend.ts
+++ b/packages/lab/src/ChartV2/legend.ts
@@ -15,12 +15,18 @@ export interface LegendItem {
   type?: string;
 }
 
+function hasLegendColor(
+  series: SeriesDef,
+): series is SeriesDef & {readonly color: string} {
+  return !isUtilityMarkType(series.type) && series.color != null;
+}
+
 /**
  * Derive legend items from series definitions.
  * Skips utility marks and series without a color.
  */
 export function deriveLegendItems(series: readonly SeriesDef[]): LegendItem[] {
   return series
-    .filter(s => !isUtilityMarkType(s.type) && s.color)
-    .map(s => ({label: s.label ?? s.key, color: s.color!, type: s.type}));
+    .filter(hasLegendColor)
+    .map(s => ({label: s.label ?? s.key, color: s.color, type: s.type}));
 }

--- a/packages/lab/src/ChartV2/tooltip.ts
+++ b/packages/lab/src/ChartV2/tooltip.ts
@@ -38,11 +38,17 @@ export function deriveTooltipSeriesValues(
   datum: Record<string, unknown> | undefined,
   resolvedKeys: ReadonlySet<string>,
 ): TooltipSeriesValue[] {
-  if (!datum) return [];
+  if (!datum) {
+    return [];
+  }
   const out: TooltipSeriesValue[] = [];
   for (const s of series) {
-    if (isUtilityMarkType(s.type)) continue;
-    if (!resolvedKeys.has(s.key)) continue;
+    if (isUtilityMarkType(s.type)) {
+      continue;
+    }
+    if (!resolvedKeys.has(s.key)) {
+      continue;
+    }
     out.push({
       key: s.key,
       label: s.label ?? s.key,


### PR DESCRIPTION
## Summary
- ignore local .claude worktrees during ESLint runs
- allow generated docsite examples under the non-production console override
- clean up existing lint warnings in PowerSearch and lab chart code

## Test plan
- pnpm lint