### PR TITLE
Fix carousel clipping tab indicators

### DIFF
--- a/packages/core/src/Carousel/XDSCarousel.tsx
+++ b/packages/core/src/Carousel/XDSCarousel.tsx
@@ -7,7 +7,8 @@
  * @input Uses React, StyleX, useScrollOverflow, useXDSLayer, XDSButton, XDSIcon, theme tokens
  * @output Exports XDSCarousel component
  * @position Horizontal scroll container with fade-edge overflow indication,
- *   optional prev/next buttons on the top layer, and scroll-snap.
+ *   optional prev/next buttons on the top layer, scroll-snap, and a small
+ *   visual bleed allowance for child focus/selection indicators.
  *
  * SYNC: When modified, update:
  * - /packages/core/src/Carousel/index.ts (exports)
@@ -85,13 +86,16 @@ const styles = stylex.create({
     alignItems: 'center',
     minWidth: 0,
     maxWidth: '100%',
-    overflowX: 'hidden',
+    overflow: 'clip',
+    overflowClipMargin: spacingVars['--spacing-0-5'],
   },
   scroller: {
     display: 'flex',
     alignItems: 'center',
     overflowX: 'auto',
     overflowY: 'hidden',
+    paddingBottom: spacingVars['--spacing-0-5'],
+    marginBottom: `calc(-1 * ${spacingVars['--spacing-0-5']})`,
     overscrollBehaviorX: 'contain',
     scrollBehavior: {
       default: 'smooth',

--- a/packages/core/src/TabList/XDSTab.tsx
+++ b/packages/core/src/TabList/XDSTab.tsx
@@ -6,7 +6,8 @@
  * @file XDSTab.tsx
  * @input Uses React, StyleX, XDSTabListContext
  * @output Exports XDSTab component and XDSTabProps type
- * @position Core tab item; renders as button or anchor in navigation
+ * @position Core tab item; renders as button or anchor in navigation with a
+ *   divider-overlay selected indicator
  *
  * SYNC: When modified, update:
  * - /packages/core/src/TabList/TabList.doc.mjs

--- a/packages/core/src/TabList/XDSTabMenu.tsx
+++ b/packages/core/src/TabList/XDSTabMenu.tsx
@@ -6,7 +6,8 @@
  * @file XDSTabMenu.tsx
  * @input Uses React, StyleX, useXDSPopover, XDSTabListContext
  * @output Exports XDSTabMenu component, XDSTabMenuProps type, XDSTabMenuOption type
- * @position Menu trigger button; opens dropdown of overflow menu items
+ * @position Menu trigger button; opens dropdown of overflow menu items and
+ *   mirrors selected tab indicator positioning
  *
  * SYNC: When modified, update:
  * - /packages/core/src/TabList/TabList.doc.mjs
@@ -120,7 +121,7 @@ const styles = stylex.create({
   },
   indicator: {
     position: 'absolute',
-    bottom: '-2px',
+    bottom: 'var(--_tab-indicator-bottom, -2px)',
     left: spacingVars['--spacing-3'],
     right: spacingVars['--spacing-3'],
     height: '2px',


### PR DESCRIPTION
## Summary
- allow XDSCarousel to expose a small visual bleed area for child focus/selection indicators
- preserve the existing XDSTab divider-overlay indicator position when tabs are composed inside Carousel
- make XDSTabMenu use the same indicator offset variable as XDSTab

Fixes #1985

## Test plan
- pnpm vitest run packages/core/src/TabList/XDSTabList.test.tsx packages/core/src/Carousel/XDSCarousel.test.tsx
- pnpm -F @xds/core typecheck
- pnpm -F @xds/core build
