### PR TITLE
fix(ContextMenu): add aria-haspopup to trigger wrapper

### DIFF
--- a/packages/core/src/ContextMenu/XDSContextMenu.tsx
+++ b/packages/core/src/ContextMenu/XDSContextMenu.tsx
@@ -281,7 +281,11 @@ export function XDSContextMenu({
 
   return (
     <>
-      <div ref={ref} onContextMenu={handleContextMenu} data-testid={testId}>
+      <div
+        ref={ref}
+        onContextMenu={handleContextMenu}
+        aria-haspopup="menu"
+        data-testid={testId}>
         {children}
       </div>
 


### PR DESCRIPTION
Adds `aria-haspopup="menu"` to the XDSContextMenu trigger wrapper div.

Without this attribute, assistive technology has no way to announce that a context menu is available on the element. This is part of the WAI-ARIA menu pattern for context menus.

## Changes

- `packages/core/src/ContextMenu/XDSContextMenu.tsx`: Added `aria-haspopup="menu"` to the trigger `<div>`

## Audit Summary (2026-05-25)

**Components audited:** AlertDialog, AspectRatio, Avatar, Badge, Banner, Blockquote, Breadcrumbs, ContextMenu, TimeInput, Tokenizer

**Findings:**

| Component | Category | Status |
|-----------|----------|--------|
| ContextMenu | a11y-gap | Fixed (this PR) |

All other components passed all checks (theming tokens, xdsClassName, prop naming, displayName, type naming, export hygiene, input consistency, accessibility).

**Noted (not fixed — systemic or needs human decision):**
- 185 files have `'use client'` on line 3 instead of line 1 (copyright comment comes first). Systemic — needs architectural decision.
- Banner/Badge use hardcoded variant style maps (#759 tracks migration to extensible pattern).
- Avatar uses inline SVG for person fallback (no `user` icon in registry — would need registry addition first).

Night Watch — Component Auditor