### PR TITLE
Enable additional lint rules

### DIFF
--- a/apps/docsite/src/components/component-detail/PlaygroundPropsTable.tsx
+++ b/apps/docsite/src/components/component-detail/PlaygroundPropsTable.tsx
@@ -18,7 +18,10 @@ import {useMediaQuery} from '@xds/core/hooks';
 import type {PropControlDescriptor} from './parsePropType';
 import type {KnobProp} from './InteractivePreview';
 import {resolveElementDescriptor} from './resolveElements';
-import type {PropDoc} from '../../generated/componentRegistry';
+import type {
+  ElementDescriptor,
+  PropDoc,
+} from '../../generated/componentRegistry';
 
 function formatType(type: string, defaultValue?: string): React.ReactNode {
   const parts = type.split(/\s*\|\s*/);
@@ -62,9 +65,7 @@ function resolveSlotElement(
   if (slotElements) {
     const match = slotElements.find(el => el.__element === componentName);
     if (match) {
-      return resolveElementDescriptor(
-        match as import('../../generated/componentRegistry').ElementDescriptor,
-      );
+      return resolveElementDescriptor(match as ElementDescriptor);
     }
   }
   // Fallback for common components without slotElements declared
@@ -162,11 +163,10 @@ function SlotListControl({
       typeof tweaked.children === 'string'
         ? `${tweaked.children} ${n}`
         : tweaked.children;
-    const descriptor: import('../../generated/componentRegistry').ElementDescriptor =
-      {
-        ...tweaked,
-        children,
-      };
+    const descriptor: ElementDescriptor = {
+      ...tweaked,
+      children,
+    };
     const newEl = resolveElementDescriptor(descriptor);
     onChange([...items, newEl]);
   };

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -72,6 +72,10 @@ export default tseslint.config(
         assertionStyle: "as",
         objectLiteralTypeAssertions: "never",
       }],
+      "@typescript-eslint/consistent-type-imports": [
+        "warn",
+        {fixStyle: "inline-type-imports"},
+      ],
     },
   },
   // Type-aware linting for core. Keep this scoped: projectService has a
@@ -85,6 +89,10 @@ export default tseslint.config(
       },
     },
     rules: {
+      "@typescript-eslint/array-type": [
+        reactSeverity,
+        {default: "array", readonly: "generic"},
+      ],
       "@typescript-eslint/await-thenable": reactSeverity,
       "@typescript-eslint/no-array-delete": reactSeverity,
       "@typescript-eslint/no-base-to-string": reactSeverity,
@@ -93,6 +101,7 @@ export default tseslint.config(
       "@typescript-eslint/no-floating-promises": reactSeverity,
       "@typescript-eslint/no-for-in-array": reactSeverity,
       "@typescript-eslint/no-implied-eval": reactSeverity,
+      "@typescript-eslint/no-import-type-side-effects": reactSeverity,
       "@typescript-eslint/no-invalid-void-type": reactSeverity,
       "@typescript-eslint/no-misused-promises": reactSeverity,
       "@typescript-eslint/no-unnecessary-type-conversion": reactSeverity,
@@ -102,6 +111,10 @@ export default tseslint.config(
       "@typescript-eslint/only-throw-error": reactSeverity,
       "@typescript-eslint/prefer-includes": reactSeverity,
       "@typescript-eslint/prefer-string-starts-ends-with": reactSeverity,
+      "@typescript-eslint/promise-function-async": [
+        reactSeverity,
+        {allowAny: false},
+      ],
       "@typescript-eslint/require-array-sort-compare": reactSeverity,
       "@typescript-eslint/restrict-plus-operands": reactSeverity,
       "@typescript-eslint/restrict-template-expressions": reactSeverity,
@@ -160,6 +173,7 @@ export default tseslint.config(
       '@eslint-react/no-nested-lazy-component-declarations': reactSeverity,
       '@eslint-react/no-unstable-default-props': reactSeverity,
       '@eslint-react/no-unstable-context-value': reactSeverity,
+      '@eslint-react/set-state-in-effect': reactSeverity,
       '@eslint-react/set-state-in-render': reactSeverity,
       '@eslint-react/no-missing-component-display-name': reactSeverity,
 

--- a/internal/vibe-tests/src/screenshot-previews.ts
+++ b/internal/vibe-tests/src/screenshot-previews.ts
@@ -20,6 +20,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as http from 'node:http';
+import type {chromium as PlaywrightChromium, Page} from 'playwright';
 import {getResultsDir, ensureDir, writeJson} from './utils.js';
 
 const VIEWPORTS = {
@@ -109,10 +110,7 @@ function serveStatic(
  * For self-contained HTML previews, we inject prefers-color-scheme
  * emulation via Playwright's CDP.
  */
-async function setTheme(
-  page: import('playwright').Page,
-  theme: 'light' | 'dark',
-) {
+async function setTheme(page: Page, theme: 'light' | 'dark') {
   await page.emulateMedia({colorScheme: theme});
 }
 
@@ -121,7 +119,7 @@ async function main() {
   const resultsDir = getResultsDir();
 
   // Import playwright
-  let chromium: typeof import('playwright').chromium;
+  let chromium: typeof PlaywrightChromium;
   try {
     const pw = await import('playwright');
     chromium = pw.chromium;

--- a/internal/vibe-tests/src/screenshot.ts
+++ b/internal/vibe-tests/src/screenshot.ts
@@ -13,6 +13,7 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import type {chromium as PlaywrightChromium} from 'playwright';
 import {getResultsDir, readJson, ensureDir} from './utils.js';
 
 const VIEWPORTS = {
@@ -130,7 +131,7 @@ async function main() {
   }
 
   // Try to import playwright
-  let chromium: typeof import('playwright').chromium;
+  let chromium: typeof PlaywrightChromium;
   try {
     const pw = await import('playwright');
     chromium = pw.chromium;

--- a/packages/core/src/AppShell/XDSAppShell.test.tsx
+++ b/packages/core/src/AppShell/XDSAppShell.test.tsx
@@ -66,7 +66,7 @@ function TestSideNav({children}: {children?: React.ReactNode}) {
 
 // Mock matchMedia
 function createMockMatchMedia(matches: boolean) {
-  const listeners: Array<(e: MediaQueryListEvent) => void> = [];
+  const listeners: ((e: MediaQueryListEvent) => void)[] = [];
   const mql = {
     matches,
     media: '',

--- a/packages/core/src/AspectRatio/XDSAspectRatio.tsx
+++ b/packages/core/src/AspectRatio/XDSAspectRatio.tsx
@@ -15,7 +15,7 @@
  * - /packages/cli/templates/blocks/components/AspectRatio/ (showcase blocks)
  */
 
-import {type ReactNode} from 'react';
+import type {ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import type {XDSBaseProps} from '../XDSBaseProps';

--- a/packages/core/src/Badge/XDSBadge.tsx
+++ b/packages/core/src/Badge/XDSBadge.tsx
@@ -16,7 +16,7 @@
  * - /packages/cli/templates/blocks/components/Badge/ (showcase blocks)
  */
 
-import {type ReactNode} from 'react';
+import type {ReactNode} from 'react';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
 import {

--- a/packages/core/src/Blockquote/XDSBlockquote.tsx
+++ b/packages/core/src/Blockquote/XDSBlockquote.tsx
@@ -15,7 +15,7 @@
  * - /packages/cli/templates/blocks/components/Blockquote/ (showcase blocks)
  */
 
-import {type ReactNode} from 'react';
+import type {ReactNode} from 'react';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';

--- a/packages/core/src/Button/XDSButton.tsx
+++ b/packages/core/src/Button/XDSButton.tsx
@@ -288,7 +288,7 @@ export interface XDSButtonProps extends XDSBaseProps<HTMLButtonElement> {
   /** HTML name attribute for form submission. */
   name?: string;
   /** HTML value attribute for form submission. */
-  value?: string | number | readonly string[];
+  value?: string | number | ReadonlyArray<string>;
   /** Associates the button with a form element by ID. */
   form?: string;
   /**

--- a/packages/core/src/Card/XDSCard.tsx
+++ b/packages/core/src/Card/XDSCard.tsx
@@ -15,7 +15,7 @@
  * - /packages/cli/templates/blocks/components/Card/ (showcase blocks)
  */
 
-import {type ReactNode} from 'react';
+import type {ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {borderVars, colorVars, radiusVars} from '../theme/tokens.stylex';
 import {container} from '../Layout/container.stylex';

--- a/packages/core/src/Center/XDSCenter.tsx
+++ b/packages/core/src/Center/XDSCenter.tsx
@@ -15,7 +15,7 @@
  * - /packages/cli/templates/blocks/components/Center/ (showcase blocks)
  */
 
-import {type ReactNode} from 'react';
+import type {ReactNode} from 'react';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';

--- a/packages/core/src/Chat/XDSChatSystemMessage.tsx
+++ b/packages/core/src/Chat/XDSChatSystemMessage.tsx
@@ -19,7 +19,7 @@
  * - /packages/cli/templates/blocks/components/ChatSystemMessage/ (block examples)
  */
 
-import {type ReactNode} from 'react';
+import type {ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {
   colorVars,

--- a/packages/core/src/CodeBlock/XDSCode.tsx
+++ b/packages/core/src/CodeBlock/XDSCode.tsx
@@ -13,7 +13,7 @@
  * - /packages/cli/templates/blocks/components/CodeBlock/ (showcase blocks)
  */
 
-import {type ReactNode} from 'react';
+import type {ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {
   colorVars,

--- a/packages/core/src/CodeBlock/XDSCodeBlock.tsx
+++ b/packages/core/src/CodeBlock/XDSCodeBlock.tsx
@@ -357,7 +357,7 @@ export interface XDSCodeBlockProps extends XDSBaseProps<HTMLPreElement> {
   tokenizer?: (
     code: string,
     language: string,
-  ) => Array<{type: string; start: number; end: number}>;
+  ) => {type: string; start: number; end: number}[];
   highlightMode?: 'auto' | 'ranges' | 'spans';
 }
 
@@ -394,57 +394,65 @@ function useTokenLines(
   language: string,
   customTokenizer?: XDSCodeBlockProps['tokenizer'],
 ): TokenLine[] {
-  const [asyncTokens, setAsyncTokens] = useState<TokenLine[] | null>(null);
+  const [asyncTokenResult, setAsyncTokenResult] = useState<{
+    code: string;
+    language: string;
+    tokens: TokenLine[];
+  } | null>(null);
 
   const syncTokens = useMemo(() => {
-    if (code.length >= SYNC_TOKENIZE_THRESHOLD) {
-      return null;
-    }
     if (customTokenizer) {
       return flatTokensToLines(customTokenizer(code, language), code);
+    }
+    if (code.length >= SYNC_TOKENIZE_THRESHOLD) {
+      return null;
     }
     return tokenize(code, language);
   }, [code, language, customTokenizer]);
 
   useEffect(() => {
-    if (code.length < SYNC_TOKENIZE_THRESHOLD) {
+    if (code.length < SYNC_TOKENIZE_THRESHOLD || customTokenizer) {
       return;
     }
 
     const abortController = new AbortController();
 
-    if (customTokenizer) {
+    async function tokenizeLargeCode() {
       try {
+        const tokens = await tokenizeAsync(
+          code,
+          language,
+          abortController.signal,
+        );
         if (!abortController.signal.aborted) {
-          const flat = customTokenizer(code, language);
-          setAsyncTokens(flatTokensToLines(flat, code));
+          setAsyncTokenResult({code, language, tokens});
         }
       } catch {
         if (!abortController.signal.aborted) {
-          setAsyncTokens(null);
+          setAsyncTokenResult({code, language, tokens: []});
         }
       }
-    } else {
-      void tokenizeAsync(code, language, abortController.signal)
-        .then(tokens => {
-          if (!abortController.signal.aborted) {
-            setAsyncTokens(tokens);
-          }
-        })
-        .catch(() => {
-          if (!abortController.signal.aborted) {
-            setAsyncTokens(null);
-          }
-        });
     }
+
+    void tokenizeLargeCode();
 
     return () => {
       abortController.abort();
-      setAsyncTokens(null);
     };
   }, [code, language, customTokenizer]);
 
-  return syncTokens ?? asyncTokens ?? [];
+  if (syncTokens != null) {
+    return syncTokens;
+  }
+
+  if (
+    asyncTokenResult?.code === code &&
+    asyncTokenResult.language === language
+  ) {
+    return asyncTokenResult.tokens;
+  }
+
+  return [];
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/CodeBlock/highlightRanges.ts
+++ b/packages/core/src/CodeBlock/highlightRanges.ts
@@ -381,7 +381,7 @@ export function applyHighlightRangesFlat(
 
   // Collect text nodes with absolute offsets
   const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT);
-  const textNodes: Array<{node: Text; start: number; length: number}> = [];
+  const textNodes: {node: Text; start: number; length: number}[] = [];
   let totalOffset = 0;
   let current = walker.nextNode();
   while (current) {
@@ -435,7 +435,7 @@ export function applyHighlightRangesFlat(
 }
 
 function resolveOffset(
-  textNodes: Array<{node: Text; start: number; length: number}>,
+  textNodes: {node: Text; start: number; length: number}[],
   absOffset: number,
 ): {node: Text; offset: number} | null {
   for (const entry of textNodes) {

--- a/packages/core/src/CodeBlock/tokenizer.test.ts
+++ b/packages/core/src/CodeBlock/tokenizer.test.ts
@@ -1,7 +1,12 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 import {describe, it, expect} from 'vitest';
-import {tokenize, tokenizeAsync, tokenizeStreaming, flatTokensToLines} from './tokenizer';
+import {
+  tokenize,
+  tokenizeAsync,
+  tokenizeStreaming,
+  flatTokensToLines,
+} from './tokenizer';
 import type {TokenLine} from './tokenizer';
 
 describe('tokenize', () => {
@@ -109,7 +114,9 @@ describe('tokenizeAsync', () => {
 
     const result = await tokenizeAsync(code, 'typescript', controller.signal);
     // Should return partial/empty result
-    expect(result.length).toBeLessThanOrEqual(tokenize(code, 'typescript').length);
+    expect(result.length).toBeLessThanOrEqual(
+      tokenize(code, 'typescript').length,
+    );
   });
 });
 
@@ -117,7 +124,7 @@ describe('tokenizeStreaming', () => {
   it('calls onBatch with progressive results', async () => {
     const lines = Array.from({length: 50}, (_, i) => `const x${i} = ${i};`);
     const code = lines.join('\n');
-    const batches: Array<{lines: TokenLine[]; startLine: number}> = [];
+    const batches: {lines: TokenLine[]; startLine: number}[] = [];
 
     await tokenizeStreaming(code, 'typescript', (batchLines, startLine) => {
       batches.push({lines: batchLines, startLine});
@@ -140,10 +147,10 @@ describe('flatTokensToLines', () => {
   it('converts absolute offsets to line-relative', () => {
     const code = 'const x = 1;\nlet y = 2;';
     const flatTokens = [
-      {type: 'keyword', start: 0, end: 5},   // "const" in line 0
-      {type: 'number', start: 10, end: 11},   // "1" in line 0
-      {type: 'keyword', start: 13, end: 16},  // "let" in line 1
-      {type: 'number', start: 21, end: 22},   // "2" in line 1
+      {type: 'keyword', start: 0, end: 5}, // "const" in line 0
+      {type: 'number', start: 10, end: 11}, // "1" in line 0
+      {type: 'keyword', start: 13, end: 16}, // "let" in line 1
+      {type: 'number', start: 21, end: 22}, // "2" in line 1
     ];
 
     const result = flatTokensToLines(flatTokens, code);

--- a/packages/core/src/CodeBlock/tokenizer.ts
+++ b/packages/core/src/CodeBlock/tokenizer.ts
@@ -30,7 +30,7 @@ export type TokenLine = Token[];
 // ---------------------------------------------------------------------------
 
 type LangDef = {
-  patterns: Array<{type: string; regex: RegExp; anchored: RegExp}>;
+  patterns: {type: string; regex: RegExp; anchored: RegExp}[];
   /** Token type that matches the element's default text color (skipped in output). */
   defaultType: string;
 };
@@ -80,10 +80,8 @@ function buildLanguageUncached(lang: string): LangDef | null {
   };
 }
 
-function buildLanguagePatterns(
-  lang: string,
-): {
-  patterns: Array<{type: string; regex: RegExp}>;
+function buildLanguagePatterns(lang: string): {
+  patterns: {type: string; regex: RegExp}[];
   defaultType: string;
 } | null {
   switch (lang) {
@@ -329,7 +327,7 @@ const ASYNC_CHUNK_SIZE = 800;
  * Yield to the main thread. Uses `scheduler.yield()` when available,
  * falling back to `setTimeout(resolve, 0)`.
  */
-function yieldToMain(): Promise<void> {
+async function yieldToMain(): Promise<void> {
   if (
     typeof scheduler !== 'undefined' &&
     typeof scheduler.yield === 'function'
@@ -502,7 +500,7 @@ export async function tokenizeStreaming(
  * tokenizers that return the old format.
  */
 export function flatTokensToLines(
-  tokens: Array<{type: string; start: number; end: number}>,
+  tokens: {type: string; start: number; end: number}[],
   code: string,
 ): TokenLine[] {
   const lineStarts: number[] = [0];

--- a/packages/core/src/Collapsible/XDSCollapsible.tsx
+++ b/packages/core/src/Collapsible/XDSCollapsible.tsx
@@ -21,7 +21,7 @@
  * - /packages/cli/templates/blocks/components/Collapsible/ (showcase blocks)
  */
 
-import {type ReactNode} from 'react';
+import type {ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {
   colorVars,

--- a/packages/core/src/CommandPalette/CommandPaletteContext.ts
+++ b/packages/core/src/CommandPalette/CommandPaletteContext.ts
@@ -29,7 +29,7 @@ export interface CommandPaletteContextValue {
   /** Get the DOM id for an item by its flat index. */
   getItemId: (index: number) => string;
   /** Flat list of selectable items in DOM order (after grouping/filtering). */
-  selectableItems: Array<{value: string; label?: string; disabled?: boolean}>;
+  selectableItems: {value: string; label?: string; disabled?: boolean}[];
   /** The search result items (typed). */
   searchResults: XDSSearchableItem[];
   /** Select an item by value and close. */

--- a/packages/core/src/DateInput/XDSDateInput.tsx
+++ b/packages/core/src/DateInput/XDSDateInput.tsx
@@ -133,7 +133,7 @@ export type {
   XDSInputStatusType as XDSDateInputStatusType,
 } from '../Field';
 import {xdsClassName, mergeProps, mergeRefs} from '../utils';
-import {XDSBaseProps} from '../XDSBaseProps';
+import type {XDSBaseProps} from '../XDSBaseProps';
 
 export interface XDSDateInputProps extends Omit<
   XDSBaseProps,

--- a/packages/core/src/Dialog/XDSDialogHeader.tsx
+++ b/packages/core/src/Dialog/XDSDialogHeader.tsx
@@ -165,7 +165,9 @@ export function XDSDialogHeader({
                 label="Close"
                 tooltip="Close"
                 icon={<XDSIcon icon="close" color="inherit" />}
-                onClick={() => onOpenChange?.(false)}
+                onClick={() => {
+                  onOpenChange?.(false);
+                }}
                 isIconOnly
               />
             )}

--- a/packages/core/src/Divider/XDSDivider.tsx
+++ b/packages/core/src/Divider/XDSDivider.tsx
@@ -15,7 +15,7 @@
  * - /packages/cli/templates/blocks/components/Divider/ (showcase blocks)
  */
 
-import {type ReactNode} from 'react';
+import type {ReactNode} from 'react';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';

--- a/packages/core/src/DropdownMenu/renderXDSDropdownItems.tsx
+++ b/packages/core/src/DropdownMenu/renderXDSDropdownItems.tsx
@@ -6,7 +6,7 @@
  * @position Utility; used by XDSDropdownMenu to unify data-driven and compound paths
  */
 
-import {type ReactNode} from 'react';
+import type {ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {XDSDivider} from '../Divider';
 import {XDSDropdownMenuItem} from './XDSDropdownMenuItem';

--- a/packages/core/src/Field/XDSFieldLabel.tsx
+++ b/packages/core/src/Field/XDSFieldLabel.tsx
@@ -12,7 +12,7 @@
  * - /packages/cli/templates/blocks/components/Field/ (showcase blocks)
  */
 
-import {type ReactNode} from 'react';
+import type {ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import {xdsClassName, mergeProps} from '../utils';

--- a/packages/core/src/FileInput/XDSFileInput.tsx
+++ b/packages/core/src/FileInput/XDSFileInput.tsx
@@ -45,7 +45,7 @@ export type {
   XDSInputStatusType as XDSFileInputStatusType,
 } from '../Field';
 import {xdsClassName, mergeProps, mergeRefs} from '../utils';
-import {XDSBaseProps} from '../XDSBaseProps';
+import type {XDSBaseProps} from '../XDSBaseProps';
 
 function formatFileSize(bytes: number): string {
   if (bytes < 1024) {

--- a/packages/core/src/Grid/XDSGrid.tsx
+++ b/packages/core/src/Grid/XDSGrid.tsx
@@ -15,7 +15,7 @@
  * - /packages/cli/templates/blocks/components/Grid/ (showcase blocks)
  */
 
-import {type ReactNode} from 'react';
+import type {ReactNode} from 'react';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';

--- a/packages/core/src/Grid/XDSGridSpan.tsx
+++ b/packages/core/src/Grid/XDSGridSpan.tsx
@@ -13,7 +13,7 @@
  * - /packages/cli/templates/blocks/components/Grid/ (showcase blocks)
  */
 
-import {type ReactNode} from 'react';
+import type {ReactNode} from 'react';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';

--- a/packages/core/src/HoverCard/useXDSHoverCard.tsx
+++ b/packages/core/src/HoverCard/useXDSHoverCard.tsx
@@ -447,7 +447,7 @@ export function useXDSHoverCard(
 
   // Render function that wraps layer.render with hover card behavior
   const renderHoverCard = useCallback(
-    (children: ReactNode, props?: ContextRenderProps) => {
+    (children: ReactNode, props?: ContextRenderProps): ReactNode => {
       const renderPlacement = props?.placement ?? placement;
       const renderProps = {
         placement: renderPlacement,

--- a/packages/core/src/Kbd/XDSKbd.tsx
+++ b/packages/core/src/Kbd/XDSKbd.tsx
@@ -13,8 +13,7 @@
  * - /packages/cli/templates/blocks/components/Kbd/ (showcase blocks)
  */
 
-import React, {useState} from 'react';
-import {useIsomorphicLayoutEffect} from '../hooks/useIsomorphicLayoutEffect';
+import React, {useSyncExternalStore} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {xdsClassName, mergeProps} from '../utils';
 import type {XDSBaseProps} from '../XDSBaseProps';
@@ -86,6 +85,14 @@ function getKeyDisplay(key: string, isMac: boolean): string {
   return KEY_DISPLAY[key] ?? key.toUpperCase();
 }
 
+function subscribeToPlatformChanges(): () => void {
+  return () => {};
+}
+
+function getServerPlatformSnapshot(): boolean {
+  return false;
+}
+
 /**
  * Detects whether the current platform is macOS/iOS.
  * Prefers the User-Agent Client Hints API when available (modern Chrome/Edge),
@@ -127,9 +134,8 @@ export interface XDSKbdProps extends XDSBaseProps<HTMLSpanElement> {
  * anywhere in the system — tooltips, menus, documentation, etc.
  *
  * Platform-aware: `mod` renders as ⌘ on macOS and Ctrl elsewhere.
- * SSR-safe — defers platform detection to a layout effect to avoid
- * hydration mismatches. Uses useIsomorphicLayoutEffect so the platform-correct
- * symbol is set before the browser paints (no visible flicker).
+ * SSR-safe — defers platform detection through useSyncExternalStore to avoid
+ * hydration mismatches.
  *
  * @example
  * ```
@@ -144,11 +150,11 @@ export function XDSKbd({
   style,
   ...rest
 }: XDSKbdProps) {
-  const [isMac, setIsMac] = useState(false);
-
-  useIsomorphicLayoutEffect(() => {
-    setIsMac(detectMac());
-  }, []);
+  const isMac = useSyncExternalStore(
+    subscribeToPlatformChanges,
+    detectMac,
+    getServerPlatformSnapshot,
+  );
 
   const parts = keys.split('+').map(key => key.trim().toLowerCase());
 

--- a/packages/core/src/Layout/XDSLayout.tsx
+++ b/packages/core/src/Layout/XDSLayout.tsx
@@ -25,7 +25,7 @@ import {XDSLayoutDividerContext} from './XDSLayoutDividerContext';
 import {stack} from '../Stack/stack.stylex';
 import {stackItem} from '../Stack/stackItem.stylex';
 import {xdsClassName, mergeProps} from '../utils';
-import {XDSBaseProps} from '../XDSBaseProps';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import type {SpacingStep} from '../utils/types';
 import {
   layoutPaddingOuterXVarStyles,

--- a/packages/core/src/Link/XDSLink.test.tsx
+++ b/packages/core/src/Link/XDSLink.test.tsx
@@ -153,7 +153,9 @@ describe('XDSLink', () => {
 
   it('handles click events', async () => {
     const user = userEvent.setup();
-    const handleClick = vi.fn(e => e.preventDefault());
+    const handleClick = vi.fn((e: React.MouseEvent<HTMLAnchorElement>) => {
+      e.preventDefault();
+    });
     render(
       <XDSLink href="/test" onClick={handleClick}>
         Click me

--- a/packages/core/src/Link/XDSLink.tsx
+++ b/packages/core/src/Link/XDSLink.tsx
@@ -16,7 +16,7 @@
  * - /packages/cli/templates/blocks/components/Link/ (showcase blocks)
  */
 
-import {type ReactNode} from 'react';
+import type {ReactNode} from 'react';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
 

--- a/packages/core/src/Markdown/XDSMarkdown.tsx
+++ b/packages/core/src/Markdown/XDSMarkdown.tsx
@@ -54,6 +54,8 @@ import {
 } from './parser';
 import type {BlockNode, InlineNode, IncrementalState} from './parser';
 
+type SyncReactNode = Exclude<React.ReactNode, Promise<unknown>>;
+
 // ---------------------------------------------------------------------------
 // Props
 // ---------------------------------------------------------------------------
@@ -641,7 +643,7 @@ function wrapTextWithFade(
   content: string,
   cursor: StreamingCursor,
   key: string | number,
-): React.ReactNode {
+): SyncReactNode {
   const startOffset = cursor.offset;
   cursor.offset += content.length;
 
@@ -702,7 +704,7 @@ function renderInline(
   linkComponent: XDSLinkComponentType = 'a',
   inlinePlugins?: MarkdownInlinePlugin[],
   components?: Partial<XDSMarkdownComponents>,
-): React.ReactNode {
+): SyncReactNode {
   switch (node.type) {
     case 'text': {
       if (inlinePlugins && inlinePlugins.length > 0) {
@@ -1005,7 +1007,7 @@ function renderBlock(
   linkComponent: XDSLinkComponentType = 'a',
   inlinePlugins?: MarkdownInlinePlugin[],
   components?: Partial<XDSMarkdownComponents>,
-): React.ReactNode {
+): SyncReactNode {
   const blockAlignMargin = BLOCK_ALIGN_MARGIN[contentAlign];
   const blockAlignStyle =
     blockAlignMargin != null

--- a/packages/core/src/Markdown/incremental.test.ts
+++ b/packages/core/src/Markdown/incremental.test.ts
@@ -7,7 +7,7 @@ import {
   createIncrementalState,
   trimStreamingArtifacts,
 } from './parser';
-import type {BlockNode} from './parser';
+import type {BlockNode, InlineNode} from './parser';
 
 function simulateStreaming(fullText: string, chunkSize = 10) {
   const state = createIncrementalState();
@@ -401,7 +401,7 @@ describe('streaming end-to-end: no raw syntax visible', () => {
     return text;
   }
 
-  function extractInlineText(nodes: import('./parser').InlineNode[]): string {
+  function extractInlineText(nodes: InlineNode[]): string {
     let text = '';
     for (const node of nodes) {
       switch (node.type) {

--- a/packages/core/src/Markdown/parser.ts
+++ b/packages/core/src/Markdown/parser.ts
@@ -779,7 +779,7 @@ export function trimStreamingArtifacts(input: string): string {
   // renders with formatting immediately as it streams in.
   {
     let searchFrom = 0;
-    const markers: Array<{pos: number; len: number}> = [];
+    const markers: {pos: number; len: number}[] = [];
     while (searchFrom < tail.length) {
       const idx = tail.indexOf('*', searchFrom);
       if (idx === -1) {

--- a/packages/core/src/MobileNav/XDSMobileNav.tsx
+++ b/packages/core/src/MobileNav/XDSMobileNav.tsx
@@ -47,7 +47,7 @@ import {XDSIcon} from '../Icon';
 import {XDSHeading} from '../Text/XDSHeading';
 import {useXDSAppShellMobile} from '../AppShell/XDSAppShellMobileContext';
 import {xdsClassName, mergeProps, mergeRefs} from '../utils';
-import {XDSBaseProps} from '../XDSBaseProps';
+import type {XDSBaseProps} from '../XDSBaseProps';
 
 // =============================================================================
 // Styles
@@ -330,11 +330,13 @@ export function XDSMobileNav({
         if (trigger && trigger !== document.body) {
           const rect = trigger.getBoundingClientRect();
           const triggerCenter = rect.left + rect.width / 2;
+          // eslint-disable-next-line @eslint-react/set-state-in-effect -- side is resolved from trigger layout immediately before showModal()
           setResolvedSide(
             triggerCenter < window.innerWidth / 2 ? 'start' : 'end',
           );
         }
       } else {
+        // eslint-disable-next-line @eslint-react/set-state-in-effect -- side prop changes must update the open dialog placement
         setResolvedSide(side);
       }
 

--- a/packages/core/src/MobileNav/XDSMobileNavToggle.tsx
+++ b/packages/core/src/MobileNav/XDSMobileNavToggle.tsx
@@ -17,7 +17,7 @@ import React, {type ReactNode} from 'react';
 import {XDSButton} from '../Button';
 import {XDSIcon} from '../Icon';
 import {useXDSAppShellMobile} from '../AppShell/XDSAppShellMobileContext';
-import {XDSBaseProps} from '../XDSBaseProps';
+import type {XDSBaseProps} from '../XDSBaseProps';
 
 export interface XDSMobileNavToggleProps extends Pick<
   XDSBaseProps,

--- a/packages/core/src/MoreMenu/XDSMoreMenu.tsx
+++ b/packages/core/src/MoreMenu/XDSMoreMenu.tsx
@@ -18,7 +18,7 @@
  * - /packages/cli/templates/blocks/components/MoreMenu/ (showcase blocks)
  */
 
-import {type ReactNode} from 'react';
+import type {ReactNode} from 'react';
 import {getIcon} from '../Icon/globalIconRegistry';
 import {XDSDropdownMenu} from '../DropdownMenu/XDSDropdownMenu';
 import {useXDSSize} from '../SizeContext/XDSSizeContext';

--- a/packages/core/src/MultiSelector/XDSMultiSelector.tsx
+++ b/packages/core/src/MultiSelector/XDSMultiSelector.tsx
@@ -65,7 +65,7 @@ import {
 } from '../Selector/utils';
 import {useMultiCombobox} from './hooks';
 import {xdsClassName, mergeProps} from '../utils';
-import {XDSBaseProps} from '../XDSBaseProps';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import {useXDSSize} from '../SizeContext/XDSSizeContext';
 
 // Sentinel value for the select-all item in keyboard navigation

--- a/packages/core/src/NavIcon/XDSNavIcon.tsx
+++ b/packages/core/src/NavIcon/XDSNavIcon.tsx
@@ -14,7 +14,7 @@
  * - /packages/cli/templates/blocks/components/NavIcon/NavIconShowcase.tsx
  */
 
-import {type ReactNode} from 'react';
+import type {ReactNode} from 'react';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars, sizeVars} from '../theme/tokens.stylex';

--- a/packages/core/src/NumberInput/XDSNumberInput.tsx
+++ b/packages/core/src/NumberInput/XDSNumberInput.tsx
@@ -129,7 +129,7 @@ export type {
   XDSInputStatusType as XDSNumberInputStatusType,
 } from '../Field';
 import {xdsClassName, mergeProps, mergeRefs} from '../utils';
-import {XDSBaseProps} from '../XDSBaseProps';
+import type {XDSBaseProps} from '../XDSBaseProps';
 
 interface XDSNumberInputPropsBase extends Omit<
   XDSBaseProps,

--- a/packages/core/src/Overlay/OverlayScrim.tsx
+++ b/packages/core/src/Overlay/OverlayScrim.tsx
@@ -12,7 +12,7 @@
  * useXDSOverlay (hook), both of which render this internally.
  */
 
-import {type ReactNode} from 'react';
+import type {ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {
   colorVars,

--- a/packages/core/src/Overlay/XDSOverlay.tsx
+++ b/packages/core/src/Overlay/XDSOverlay.tsx
@@ -15,7 +15,7 @@
  * use the useXDSOverlay hook directly.
  */
 
-import {type ReactNode, type Ref} from 'react';
+import type {ReactNode, Ref} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import {xdsClassName, mergeProps, mergeRefs} from '../utils';

--- a/packages/core/src/Pagination/XDSPagination.tsx
+++ b/packages/core/src/Pagination/XDSPagination.tsx
@@ -259,7 +259,7 @@ export function generatePageRange(
   currentPage: number,
   totalPages: number,
   siblingCount: number,
-): Array<number | '...'> {
+): (number | '...')[] {
   // Total page number slots (excluding ellipses):
   // first + last + current + 2*siblings = 3 + 2*siblings
   // With 2 potential ellipsis slots: 5 + 2*siblings
@@ -279,7 +279,7 @@ export function generatePageRange(
   if (!showLeftEllipsis && showRightEllipsis) {
     // Near the start: show more pages on the left
     const leftRange = 3 + 2 * siblingCount;
-    const pages: Array<number | '...'> = Array.from(
+    const pages: (number | '...')[] = Array.from(
       {length: leftRange},
       (_, i) => i + 1,
     );
@@ -290,7 +290,7 @@ export function generatePageRange(
   if (showLeftEllipsis && !showRightEllipsis) {
     // Near the end: show more pages on the right
     const rightRange = 3 + 2 * siblingCount;
-    const pages: Array<number | '...'> = [1, '...'];
+    const pages: (number | '...')[] = [1, '...'];
     for (let i = totalPages - rightRange + 1; i <= totalPages; i++) {
       pages.push(i);
     }
@@ -298,7 +298,7 @@ export function generatePageRange(
   }
 
   // In the middle: show ellipsis on both sides
-  const pages: Array<number | '...'> = [1, '...'];
+  const pages: (number | '...')[] = [1, '...'];
   for (let i = leftSiblingIndex; i <= rightSiblingIndex; i++) {
     pages.push(i);
   }

--- a/packages/core/src/Popover/useXDSPopover.tsx
+++ b/packages/core/src/Popover/useXDSPopover.tsx
@@ -346,7 +346,7 @@ export function useXDSPopover(
 
   // Wrapped render function that includes surface styles and optional hidden close button
   const render = useCallback(
-    (children: ReactNode, props?: ContextRenderProps) => {
+    (children: ReactNode, props?: ContextRenderProps): ReactNode => {
       return layer.render(
         <div
           ref={contentRef}

--- a/packages/core/src/PowerSearch/PowerSearchEditPopover.test.tsx
+++ b/packages/core/src/PowerSearch/PowerSearchEditPopover.test.tsx
@@ -28,7 +28,7 @@ class MockResizeObserver {
   disconnect() {}
 }
 
-let rafCallbacks: Array<FrameRequestCallback> = [];
+let rafCallbacks: FrameRequestCallback[] = [];
 let rafId = 0;
 
 beforeAll(() => {

--- a/packages/core/src/PowerSearch/PowerSearchEditPopover.tsx
+++ b/packages/core/src/PowerSearch/PowerSearchEditPopover.tsx
@@ -352,7 +352,7 @@ function NestedSubFilterRow({
 interface NestedEditorProps {
   config: InternalConfig;
   partialFilter: PartialFilter;
-  operatorOptions: Array<{value: string; label: string}>;
+  operatorOptions: {value: string; label: string}[];
   onOperatorChange: (operatorKey: string) => void;
   onPartialFilterChange: (filter: PartialFilter) => void;
   isReadOnly: boolean;

--- a/packages/core/src/PowerSearch/PowerSearchValueEditor.tsx
+++ b/packages/core/src/PowerSearch/PowerSearchValueEditor.tsx
@@ -309,7 +309,7 @@ function DateRelativeEditor({
     filterValue?.type === 'date_relative' ? filterValue.value : undefined;
 
   const options = useMemo(() => {
-    const result: Array<{value: string; label: string}> = [];
+    const result: {value: string; label: string}[] = [];
     const units = [
       {unit: 'day', plural: 'days'},
       {unit: 'week', plural: 'weeks'},

--- a/packages/core/src/PowerSearch/XDSPowerSearch.tsx
+++ b/packages/core/src/PowerSearch/XDSPowerSearch.tsx
@@ -929,7 +929,7 @@ export function XDSPowerSearch({
   ]);
 
   // Build combined endContent from resultCount + endContent props
-  const combinedEndContent = useMemo(() => {
+  const combinedEndContent = useMemo((): React.ReactNode => {
     let resultCountNode: React.ReactNode = null;
     if (resultCount != null) {
       if (typeof resultCount === 'number') {

--- a/packages/core/src/PowerSearch/usePowerSearchConfig.test.ts
+++ b/packages/core/src/PowerSearch/usePowerSearchConfig.test.ts
@@ -47,7 +47,7 @@ const defs = [
 
 const {config, applyFilters} = createPowerSearchConfig(defs, 'TestConfig');
 
-const data: Array<InferData<typeof defs>> = [
+const data: InferData<typeof defs>[] = [
   {
     name: 'Alice Johnson',
     age: 30,
@@ -480,7 +480,7 @@ describe('applyFilters', () => {
 
   describe('date: works with Date objects', () => {
     it('converts Date to unix seconds', () => {
-      const dateData: Array<InferData<typeof defs>> = [
+      const dateData: InferData<typeof defs>[] = [
         {
           name: 'Test',
           age: 1,
@@ -786,7 +786,7 @@ describe('applyFilters', () => {
     });
 
     it('handles string_list field with scalar value (non-array)', () => {
-      const scalarData: Array<InferData<typeof defs>> = [
+      const scalarData: InferData<typeof defs>[] = [
         {
           name: 'Test',
           age: 1,

--- a/packages/core/src/PowerSearch/usePowerSearchConfig.ts
+++ b/packages/core/src/PowerSearch/usePowerSearchConfig.ts
@@ -555,7 +555,7 @@ export function createPowerSearchConfig<
   applyFilters: <T extends InferData<D>>(
     filters: ReadonlyArray<PowerSearchFilter>,
     data: ReadonlyArray<T>,
-  ) => Array<T>;
+  ) => T[];
 } {
   const fields = definitions.map(buildField);
 
@@ -567,7 +567,7 @@ export function createPowerSearchConfig<
   function applyFilters<T extends InferData<D>>(
     filters: ReadonlyArray<PowerSearchFilter>,
     data: ReadonlyArray<T>,
-  ): Array<T> {
+  ): T[] {
     if (filters.length === 0) {
       return [...data];
     }
@@ -609,7 +609,7 @@ export function usePowerSearchConfig<
   applyFilters: <T extends InferData<D>>(
     filters: ReadonlyArray<PowerSearchFilter>,
     data: ReadonlyArray<T>,
-  ) => Array<T>;
+  ) => T[];
 } {
   return useMemo(
     () => createPowerSearchConfig(definitions, configName),

--- a/packages/core/src/Section/XDSSection.tsx
+++ b/packages/core/src/Section/XDSSection.tsx
@@ -15,7 +15,7 @@
  * - /packages/cli/templates/blocks/components/Section/ (showcase blocks)
  */
 
-import {type ReactNode} from 'react';
+import type {ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars} from '../theme/tokens.stylex';
 import type {XDSBaseProps} from '../XDSBaseProps';
@@ -186,7 +186,7 @@ export interface XDSSectionProps extends XDSBaseProps<HTMLElement> {
    * dividers={['top', 'bottom']}
    * ```
    */
-  dividers?: Array<'top' | 'bottom' | 'start' | 'end'>;
+  dividers?: ('top' | 'bottom' | 'start' | 'end')[];
 
   /**
    * Internal padding of the section using the spacing scale.

--- a/packages/core/src/Selector/XDSSelector.tsx
+++ b/packages/core/src/Selector/XDSSelector.tsx
@@ -50,7 +50,7 @@ import {
   typeScaleVars,
   borderVars,
 } from '../theme/tokens.stylex';
-import {type XDSSelectorOptionType, type XDSSelectorOptionData} from './types';
+import type {XDSSelectorOptionType, XDSSelectorOptionData} from './types';
 import {
   isOptionData,
   isDivider,
@@ -62,7 +62,7 @@ import {useCombobox, useSelectedItemOffset} from './hooks';
 import {XDSSelectorOption} from './XDSSelectorOption';
 import {xdsClassName, mergeProps} from '../utils';
 import {useXDSSize} from '../SizeContext/XDSSizeContext';
-import {XDSBaseProps} from '../XDSBaseProps';
+import type {XDSBaseProps} from '../XDSBaseProps';
 
 const styles = stylex.create({
   // Trigger container — the enhanced click target wrapping the combobox button and clear button as siblings

--- a/packages/core/src/Selector/hooks.ts
+++ b/packages/core/src/Selector/hooks.ts
@@ -50,16 +50,25 @@ export function useSelectedItemOffset({
   const [offset, setOffset] = useState(0);
   const [isPositioned, setIsPositioned] = useState(false);
 
+  const commitPosition = useCallback(
+    (nextOffset: number, nextIsPositioned: boolean) => {
+      // eslint-disable-next-line @eslint-react/set-state-in-effect -- selector popover position is derived from DOM layout
+      setOffset(nextOffset);
+      // eslint-disable-next-line @eslint-react/set-state-in-effect -- selector popover position is derived from DOM layout
+      setIsPositioned(nextIsPositioned);
+    },
+    [],
+  );
+
   useIsomorphicLayoutEffect(() => {
     if (!isOpen) {
       // Reset offset when closed
-      setOffset(0);
-      setIsPositioned(false);
+      commitPosition(0, false);
       return;
     }
 
     if (!listboxRef.current || !triggerRef.current) {
-      setIsPositioned(true);
+      commitPosition(0, true);
       return;
     }
 
@@ -70,8 +79,7 @@ export function useSelectedItemOffset({
     const targetItem = document.getElementById(targetItemId);
 
     if (!targetItem) {
-      setOffset(0);
-      setIsPositioned(true);
+      commitPosition(0, true);
       return;
     }
 
@@ -117,9 +125,15 @@ export function useSelectedItemOffset({
       clampedOffset = 0;
     }
 
-    setOffset(clampedOffset);
-    setIsPositioned(true);
-  }, [isOpen, selectedItemIndex, listboxId, listboxRef, triggerRef]);
+    commitPosition(clampedOffset, true);
+  }, [
+    isOpen,
+    selectedItemIndex,
+    listboxId,
+    listboxRef,
+    triggerRef,
+    commitPosition,
+  ]);
 
   return {offset, isPositioned};
 }

--- a/packages/core/src/SideNav/XDSSideNav.test.tsx
+++ b/packages/core/src/SideNav/XDSSideNav.test.tsx
@@ -13,7 +13,7 @@ import React from 'react';
 import {describe, it, expect, vi} from 'vitest';
 import {render, screen, act, fireEvent} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import {type ReactNode} from 'react';
+import type {ReactNode} from 'react';
 import {XDSSideNav} from './XDSSideNav';
 import {XDSSideNavHeading} from './XDSSideNavHeading';
 import {XDSSideNavItem} from './XDSSideNavItem';

--- a/packages/core/src/Slider/XDSSlider.tsx
+++ b/packages/core/src/Slider/XDSSlider.tsx
@@ -80,7 +80,7 @@ export interface XDSSliderBaseProps extends Omit<
   /** How the current value is displayed. @default "tooltip" */
   valueDisplay?: 'tooltip' | 'text' | 'none';
   /** Tick marks at specified positions with optional labels. */
-  marks?: Array<{value: number; label?: string}>;
+  marks?: {value: number; label?: string}[];
   /** Test ID for the root element. */
   'data-testid'?: string;
 }

--- a/packages/core/src/Spinner/XDSSpinner.tsx
+++ b/packages/core/src/Spinner/XDSSpinner.tsx
@@ -20,7 +20,7 @@ import {useEffect, useRef, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {durationVars, spacingVars} from '../theme/tokens.stylex';
 import {useXDSTheme} from '../theme/useXDSTheme';
-import {XDSBaseProps} from '../XDSBaseProps';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import {XDSText} from '../Text/XDSText';
 import {xdsClassName, mergeProps} from '../utils';
 

--- a/packages/core/src/Stack/XDSStack.tsx
+++ b/packages/core/src/Stack/XDSStack.tsx
@@ -13,7 +13,7 @@
  */
 
 import {createElement, type ElementType, type ReactNode, type Ref} from 'react';
-import {XDSBaseProps} from '../XDSBaseProps';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import {

--- a/packages/core/src/Stack/XDSStackItem.tsx
+++ b/packages/core/src/Stack/XDSStackItem.tsx
@@ -12,7 +12,7 @@
  */
 
 import {createElement, type ElementType, type ReactNode, type Ref} from 'react';
-import {XDSBaseProps} from '../XDSBaseProps';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import {

--- a/packages/core/src/StatusDot/XDSStatusDot.tsx
+++ b/packages/core/src/StatusDot/XDSStatusDot.tsx
@@ -18,7 +18,7 @@
 
 import * as stylex from '@stylexjs/stylex';
 import {colorVars} from '../theme/tokens.stylex';
-import {XDSBaseProps} from '../XDSBaseProps';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import {XDSTooltip} from '../Tooltip/XDSTooltip';
 import {xdsClassName, mergeProps} from '../utils';
 

--- a/packages/core/src/Switch/XDSSwitch.tsx
+++ b/packages/core/src/Switch/XDSSwitch.tsx
@@ -41,7 +41,7 @@ import type {XDSInputStatus} from '../Field/types';
 import {XDSSpinner} from '../Spinner';
 import {xdsClassName, mergeProps} from '../utils';
 import {switchScope} from './switch.markers.stylex';
-import {XDSBaseProps} from '../XDSBaseProps';
+import type {XDSBaseProps} from '../XDSBaseProps';
 
 // Fixed dimensions: 40px width, 24px height, 16px thumb (off), 20px thumb (on)
 const SWITCH_WIDTH = 40;

--- a/packages/core/src/TabList/XDSTab.tsx
+++ b/packages/core/src/TabList/XDSTab.tsx
@@ -27,7 +27,7 @@ import {
   fontWeightVars,
   typeScaleVars,
 } from '../theme/tokens.stylex';
-import {XDSBaseProps} from '../XDSBaseProps';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import {useXDSTabListContext} from './XDSTabListContext';
 import type {XDSTabListSize} from './XDSTabListContext';
 import {tabScope} from './tab.markers.stylex';

--- a/packages/core/src/TabList/XDSTabList.tsx
+++ b/packages/core/src/TabList/XDSTabList.tsx
@@ -18,7 +18,7 @@
 import React, {useMemo, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {borderVars, colorVars, spacingVars} from '../theme/tokens.stylex';
-import {XDSBaseProps} from '../XDSBaseProps';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import {XDSTabListContext} from './XDSTabListContext';
 import type {XDSTabListSize} from './XDSTabListContext';
 import {useXDSSize} from '../SizeContext/XDSSizeContext';

--- a/packages/core/src/Table/XDSTable.test.tsx
+++ b/packages/core/src/Table/XDSTable.test.tsx
@@ -125,7 +125,9 @@ describe('columnUtils', () => {
       const cols = generateColumns(users);
       for (const col of cols) {
         // Min-width should be at least the floor
-        expect((col.width as ProportionalWidth).minWidth).toBeGreaterThanOrEqual(60);
+        expect(
+          (col.width as ProportionalWidth).minWidth,
+        ).toBeGreaterThanOrEqual(60);
       }
     });
 
@@ -177,7 +179,11 @@ describe('columnUtils', () => {
       // This test verifies the contract: explicit widths pass through unchanged.
       const explicit: XDSTableColumn<User>[] = [
         {key: 'name', header: 'Name', width: pixel(200)},
-        {key: 'email', header: 'Email', width: proportional(3, {minWidth: 300})},
+        {
+          key: 'email',
+          header: 'Email',
+          width: proportional(3, {minWidth: 300}),
+        },
       ];
       // resolveColumnWidths should use the explicit values, not re-derive
       const resolved = resolveColumnWidths(explicit);
@@ -424,7 +430,7 @@ describe('XDSBaseTable', () => {
     });
 
     it('applies transformBodyCell plugin with column and item context', () => {
-      const calls: Array<{col: string; name: string}> = [];
+      const calls: {col: string; name: string}[] = [];
       const plugin: TablePlugin<User> = {
         transformBodyCell: (props, column, item) => {
           calls.push({col: column.key, name: item.name});
@@ -624,7 +630,9 @@ describe('XDSTable', () => {
     const {container} = render(
       <XDSTable dividers="rows">
         <tbody>
-          <tr><td>Content</td></tr>
+          <tr>
+            <td>Content</td>
+          </tr>
         </tbody>
       </XDSTable>,
     );
@@ -633,13 +641,10 @@ describe('XDSTable', () => {
   });
 
   it('uses table-layout: fixed in data-driven mode', () => {
-    const {container} = render(
-      <XDSTable data={users} columns={columns} />,
-    );
+    const {container} = render(<XDSTable data={users} columns={columns} />);
     const table = container.querySelector('table');
     expect(table).toHaveStyle({tableLayout: 'fixed'});
   });
-
 
   it('renders all data values', () => {
     render(<XDSTable data={users} columns={columns} />);

--- a/packages/core/src/Table/XDSTableCell.tsx
+++ b/packages/core/src/Table/XDSTableCell.tsx
@@ -14,7 +14,7 @@
  * - /packages/cli/templates/blocks/components/Table/ (showcase blocks)
  */
 
-import {type ReactNode} from 'react';
+import type {ReactNode} from 'react';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
 import {

--- a/packages/core/src/Table/XDSTableHeaderCell.tsx
+++ b/packages/core/src/Table/XDSTableHeaderCell.tsx
@@ -14,7 +14,7 @@
  * - /packages/cli/templates/blocks/components/Table/ (showcase blocks)
  */
 
-import {type ReactNode} from 'react';
+import type {ReactNode} from 'react';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
 import {

--- a/packages/core/src/Table/columnUtils.ts
+++ b/packages/core/src/Table/columnUtils.ts
@@ -61,11 +61,11 @@ export function resolveColumnWidths<T extends Record<string, unknown>>(
   // --- Pass 1: Categorize columns and compute totals ---
   let totalProportion = 0;
   let pixelTotal = 0;
-  const proportionalCols: Array<{
+  const proportionalCols: {
     key: string;
     proportion: number;
     minWidth: number;
-  }> = [];
+  }[] = [];
 
   for (const col of columns) {
     const w = col.width;

--- a/packages/core/src/Table/plugins/columnSettings/useXDSTableColumnSettings.test.tsx
+++ b/packages/core/src/Table/plugins/columnSettings/useXDSTableColumnSettings.test.tsx
@@ -133,7 +133,7 @@ describe('integration with XDSTable', () => {
     const state = useXDSTableColumnSettingsState({
       columns: columnOptions,
       activeColumnKeys: activeKeys,
-      onChangeActiveColumnKeys: (keys: readonly string[]) =>
+      onChangeActiveColumnKeys: (keys: ReadonlyArray<string>) =>
         setActiveKeys([...keys]),
     });
 

--- a/packages/core/src/Table/plugins/pagination/useXDSTablePagination.tsx
+++ b/packages/core/src/Table/plugins/pagination/useXDSTablePagination.tsx
@@ -236,7 +236,7 @@ export function useXDSTablePagination<T extends Record<string, unknown>>(
   // Stable plugin object \u2014 created once, reads config via ref.
   return useMemo(
     (): TablePlugin<T> => ({
-      transformTableContext(children: ReactNode) {
+      transformTableContext(children: ReactNode): ReactNode {
         const {
           position: pos,
           paginationProps: props,

--- a/packages/core/src/Table/useXDSBaseTablePlugins.ts
+++ b/packages/core/src/Table/useXDSBaseTablePlugins.ts
@@ -43,7 +43,7 @@ import type {TablePlugin} from './types';
  * Plugins are sorted by their position in this array.
  * Unknown names are appended after the known set.
  */
-const PLUGIN_ORDER: readonly string[] = [
+const PLUGIN_ORDER: ReadonlyArray<string> = [
   'columnSettings',
   'sort',
   'selection',

--- a/packages/core/src/Text/XDSHeading.tsx
+++ b/packages/core/src/Text/XDSHeading.tsx
@@ -42,7 +42,7 @@ import type {LayerPlacement} from '../Layer';
 import {xdsClassName, mergeProps, mergeRefs} from '../utils';
 import type {XDSBaseProps} from '../XDSBaseProps';
 
-const LazyXDSTooltip = lazy(() =>
+const LazyXDSTooltip = lazy(async () =>
   import('../Tooltip/XDSTooltip').then(mod => ({default: mod.XDSTooltip})),
 );
 

--- a/packages/core/src/Text/XDSText.tsx
+++ b/packages/core/src/Text/XDSText.tsx
@@ -47,7 +47,7 @@ import type {LayerPlacement} from '../Layer';
 import {xdsClassName, mergeProps, mergeRefs} from '../utils';
 import type {XDSBaseProps} from '../XDSBaseProps';
 
-const LazyXDSTooltip = lazy(() =>
+const LazyXDSTooltip = lazy(async () =>
   import('../Tooltip/XDSTooltip').then(mod => ({default: mod.XDSTooltip})),
 );
 

--- a/packages/core/src/TextInput/XDSTextInput.tsx
+++ b/packages/core/src/TextInput/XDSTextInput.tsx
@@ -117,7 +117,7 @@ import {xdsClassName, mergeProps, mergeRefs} from '../utils';
 import {useXDSSize} from '../SizeContext/XDSSizeContext';
 import {useInputContainer} from '../hooks/useInputContainer';
 import {useXDSInputGroup} from '../InputGroup/XDSInputGroupContext';
-import {XDSBaseProps} from '../XDSBaseProps';
+import type {XDSBaseProps} from '../XDSBaseProps';
 
 export type XDSTextInputType = 'text' | 'password' | 'email';
 

--- a/packages/core/src/Timestamp/XDSTimestamp.tsx
+++ b/packages/core/src/Timestamp/XDSTimestamp.tsx
@@ -28,7 +28,7 @@ import type {
 import {xdsClassName, mergeRefs} from '../utils';
 import type {XDSBaseProps} from '../XDSBaseProps';
 
-const LazyXDSTooltip = lazy(() =>
+const LazyXDSTooltip = lazy(async () =>
   import('../Tooltip/XDSTooltip').then(mod => ({default: mod.XDSTooltip})),
 );
 

--- a/packages/core/src/Token/XDSToken.tsx
+++ b/packages/core/src/Token/XDSToken.tsx
@@ -16,7 +16,7 @@
  * - /packages/cli/templates/blocks/components/Token/ (showcase blocks)
  */
 
-import {type ReactNode} from 'react';
+import type {ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {
   colorVars,

--- a/packages/core/src/Toolbar/XDSToolbar.tsx
+++ b/packages/core/src/Toolbar/XDSToolbar.tsx
@@ -16,7 +16,7 @@
  * - /packages/cli/templates/blocks/components/Toolbar/ (showcase blocks)
  */
 
-import {type ReactNode} from 'react';
+import type {ReactNode} from 'react';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import type {XDSSectionVariant} from '../Section/XDSSection';
 import type {SpacingStep} from '../utils/types';
@@ -193,7 +193,7 @@ export interface XDSToolbarProps extends XDSBaseProps<HTMLDivElement> {
    * dividers={['bottom']}
    * ```
    */
-  dividers?: Array<'top' | 'bottom' | 'start' | 'end'>;
+  dividers?: ('top' | 'bottom' | 'start' | 'end')[];
 }
 
 /**

--- a/packages/core/src/Tooltip/useXDSTooltip.tsx
+++ b/packages/core/src/Tooltip/useXDSTooltip.tsx
@@ -424,7 +424,7 @@ export function useXDSTooltip(
 
   // Render function that wraps layer.render with tooltip styling
   const renderTooltip = useCallback(
-    (children: ReactNode, props?: ContextRenderProps) => {
+    (children: ReactNode, props?: ContextRenderProps): ReactNode => {
       const renderPlacement = props?.placement ?? placement;
       const renderProps = {
         placement: renderPlacement,

--- a/packages/core/src/TopNav/XDSTopNav.tsx
+++ b/packages/core/src/TopNav/XDSTopNav.tsx
@@ -16,7 +16,7 @@
  * - /packages/cli/templates/blocks/components/TopNav/ (showcase blocks)
  */
 
-import {type ReactNode} from 'react';
+import type {ReactNode} from 'react';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
 import {spacingVars} from '../theme/tokens.stylex';

--- a/packages/core/src/TopNav/XDSTopNavItem.tsx
+++ b/packages/core/src/TopNav/XDSTopNavItem.tsx
@@ -16,7 +16,7 @@
  * - /packages/cli/templates/blocks/components/TopNav/ (showcase blocks)
  */
 
-import {type ReactNode} from 'react';
+import type {ReactNode} from 'react';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
 import {

--- a/packages/core/src/docs-types.ts
+++ b/packages/core/src/docs-types.ts
@@ -478,14 +478,14 @@ export interface TranslationDoc {
     anatomy?: AnatomyElement[];
   };
   /** Sub-component translations. Must match docs.components length and order (if present). */
-  components?: Array<{
+  components?: {
     /** Exact name from docs.components[n].name */
     name: string;
     /** Compressed/translated sub-component description. */
     description: string;
     /** Prop descriptions keyed by prop name. */
     propDescriptions?: Record<string, string>;
-  }>;
+  }[];
 }
 
 // =============================================================================

--- a/packages/core/src/hooks/useImageMode.ts
+++ b/packages/core/src/hooks/useImageMode.ts
@@ -102,11 +102,13 @@ export function useImageMode(
   options: UseImageModeOptions = {},
 ): 'dark' | 'light' | null {
   const {region, threshold = 0.5, fallback = null} = options;
-  const [mode, setMode] = useState<'dark' | 'light' | null>(fallback);
+  const [detectedResult, setDetectedResult] = useState<{
+    src: string;
+    mode: 'dark' | 'light' | null;
+  } | null>(null);
 
   useEffect(() => {
     if (!src) {
-      setMode(fallback);
       return;
     }
 
@@ -166,11 +168,14 @@ export function useImageMode(
         }
 
         const lightness = perceptualLightness(r, g, b);
-        setMode(lightness > threshold ? 'light' : 'dark');
+        setDetectedResult({
+          src: srcUrl,
+          mode: lightness > threshold ? 'light' : 'dark',
+        });
       } catch {
         // CORS error, network error, etc. — keep fallback
         if (!cancelled) {
-          setMode(fallback);
+          setDetectedResult({src: srcUrl, mode: fallback});
         }
       }
     }
@@ -182,5 +187,9 @@ export function useImageMode(
     };
   }, [src, region, threshold, fallback]);
 
-  return mode;
+  if (!src || detectedResult?.src !== src) {
+    return fallback;
+  }
+
+  return detectedResult.mode;
 }

--- a/packages/core/src/hooks/useMediaQuery.test.ts
+++ b/packages/core/src/hooks/useMediaQuery.test.ts
@@ -15,7 +15,7 @@ import {useMediaQuery} from './useMediaQuery';
 
 // Mock matchMedia
 function createMockMatchMedia(matches: boolean) {
-  const listeners: Array<(e: MediaQueryListEvent) => void> = [];
+  const listeners: ((e: MediaQueryListEvent) => void)[] = [];
   return {
     matches,
     media: '',

--- a/packages/core/src/hooks/useOverflow.test.ts
+++ b/packages/core/src/hooks/useOverflow.test.ts
@@ -15,7 +15,7 @@ function mockMeasure(
   itemWidths: number[],
   indicatorWidth?: number,
 ): HTMLElement {
-  const children: Array<{offsetWidth: number}> = itemWidths.map(w => ({
+  const children: {offsetWidth: number}[] = itemWidths.map(w => ({
     offsetWidth: w,
   }));
   if (indicatorWidth != null) {

--- a/packages/core/src/hooks/useOverflow.ts
+++ b/packages/core/src/hooks/useOverflow.ts
@@ -132,6 +132,7 @@ export function useOverflow(
       : 0;
 
     if (children.length === 0) {
+      // eslint-disable-next-line @eslint-react/set-state-in-effect -- overflow count is derived from measured DOM widths
       setVisibleCount(0);
       return;
     }
@@ -168,6 +169,7 @@ export function useOverflow(
       count++;
     }
 
+    // eslint-disable-next-line @eslint-react/set-state-in-effect -- overflow count is derived from measured DOM widths
     setVisibleCount(Math.max(Math.min(count, itemCount), minVisibleItems));
   }, [itemCount, gap, minVisibleItems, collapseFrom, observeParent]);
 

--- a/packages/core/src/hooks/useXDSStreamingText.test.ts
+++ b/packages/core/src/hooks/useXDSStreamingText.test.ts
@@ -5,7 +5,7 @@ import {renderHook, act} from '@testing-library/react';
 import {useXDSStreamingText} from './useXDSStreamingText';
 
 describe('useXDSStreamingText', () => {
-  let rafCallbacks: Array<(time: number) => void>;
+  let rafCallbacks: ((time: number) => void)[];
   let originalRAF: typeof requestAnimationFrame;
   let originalCAF: typeof cancelAnimationFrame;
 

--- a/packages/core/src/theme/derivedVarRegistry.test.ts
+++ b/packages/core/src/theme/derivedVarRegistry.test.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-require-imports */
+/* eslint-disable @typescript-eslint/no-require-imports */
 /**
  * @file Validates derivedVarRegistry stays in sync with component doc files,
  * AND detects undocumented component CSS custom properties in source files.
@@ -18,6 +18,21 @@ import {readdirSync, readFileSync, existsSync} from 'fs';
 import {join} from 'path';
 
 const SRC_DIR = join(__dirname, '..');
+
+type ComponentDocModule = {
+  docs?: {
+    theming?: {
+      vars?: {name: string}[];
+      derived?: DerivedDocEntry[];
+    };
+  };
+};
+
+type DerivedDocEntry = {
+  property: string;
+  vars?: string[];
+  expand?: string;
+};
 
 // ---------------------------------------------------------------------------
 // Source scanning: find CSS custom property declarations in component files
@@ -99,7 +114,7 @@ interface ComponentInfo {
   dir: string;
   sourceVars: string[];
   docVars: string[];
-  docDerived: Array<{property: string; vars?: string[]; expand?: string}>;
+  docDerived: {property: string; vars?: string[]; expand?: string}[];
 }
 
 function discoverComponents(): ComponentInfo[] {
@@ -138,10 +153,10 @@ function discoverComponents(): ComponentInfo[] {
     }
 
     let docVars: string[] = [];
-    let docDerived: any[] = [];
+    let docDerived: DerivedDocEntry[] = [];
     try {
-      const mod = require(docPath);
-      docVars = (mod.docs?.theming?.vars || []).map((v: any) => v.name);
+      const mod = require(docPath) as ComponentDocModule;
+      docVars = (mod.docs?.theming?.vars || []).map(v => v.name);
       docDerived = mod.docs?.theming?.derived || [];
     } catch {
       /* skip */
@@ -214,12 +229,10 @@ describe('component CSS vars are documented and themeable', () => {
     it(`${dir}: documented vars have derived entries for theming`, () => {
       // Every var that maps to a standard CSS property should have a
       // derived entry so theme authors can write standard CSS.
-      const derivedVarNames = new Set(
-        docDerived.flatMap((d: any) => d.vars || []),
-      );
+      const derivedVarNames = new Set(docDerived.flatMap(d => d.vars || []));
       const derivedExpands = docDerived
-        .filter((d: any) => d.expand)
-        .map((d: any) => d.expand);
+        .filter(d => d.expand)
+        .map(d => d.expand);
       const hasContainerExpand = derivedExpands.includes('container');
 
       const missingDerived = docVars.filter(varName => {

--- a/packages/lab/src/Sankey/XDSSankeyLabel.tsx
+++ b/packages/lab/src/Sankey/XDSSankeyLabel.tsx
@@ -14,6 +14,7 @@
  */
 
 import {useSankey} from './SankeyContext';
+import type {SankeyNodeLayout} from './types';
 
 export interface XDSSankeyLabelProps {
   /** Show percentage below the node (default: true) */
@@ -118,7 +119,7 @@ function RotatedLabel({
   showPercent,
   height,
 }: {
-  node: import('./types').SankeyNodeLayout;
+  node: SankeyNodeLayout;
   nodeWidth: number;
   nodeColor?: string;
   text: string;
@@ -174,7 +175,7 @@ function BesideLabel({
   height,
   isLastColumn,
 }: {
-  node: import('./types').SankeyNodeLayout;
+  node: SankeyNodeLayout;
   nodeWidth: number;
   text: string;
   pctStr: string;

--- a/packages/lab/src/Stepper/XDSStep.tsx
+++ b/packages/lab/src/Stepper/XDSStep.tsx
@@ -16,7 +16,7 @@
  * - /packages/cli/templates/blocks/components/Stepper/ (showcase blocks)
  */
 
-import {type ReactNode} from 'react';
+import type {ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 
 import {


### PR DESCRIPTION
## Summary
- enable additional TypeScript ESLint rules for type-only imports, promise-returning functions, consistent type imports, and array type style
- enable @eslint-react/set-state-in-effect for core React code
- fix surfaced lint findings and document intentional DOM-measurement/layout exceptions

## Test plan
- pnpm exec eslint packages/core/src
- pnpm -F @xds/core typecheck
- pnpm lint:strict