### PR TITLE
Fix grouped button press spacing

### DIFF
--- a/packages/core/src/Button/XDSButton.tsx
+++ b/packages/core/src/Button/XDSButton.tsx
@@ -73,6 +73,8 @@ const styles = stylex.create({
       '@media (prefers-reduced-motion: reduce)': '0s',
     },
     transitionTimingFunction: easeVars['--ease-standard'],
+  },
+  pressable: {
     transform: {
       default: 'scale(1)',
       ':active': 'scale(0.98)',
@@ -572,6 +574,7 @@ export function XDSButton({
     useAriaDisabled && styles.ariaDisabled,
     isLoadingState && loadingStyles.loading,
     renderAsLink && styles.link,
+    !buttonGroup && styles.pressable,
     buttonGroup &&
       (buttonGroup.orientation === 'horizontal'
         ? groupStyles.horizontal


### PR DESCRIPTION
## Summary
- Disable the active press scale transform for buttons inside XDSButtonGroup
- Preserve connected button edges while pressing grouped buttons

## Test plan
- pnpm vitest run packages/core/src/Button/XDSButton.test.tsx packages/core/src/ButtonGroup/XDSButtonGroup.test.tsx packages/lab/src/Schedule/XDSSchedule.test.tsx
- pnpm exec eslint packages/core/src/Button/XDSButton.tsx apps/storybook/stories/Schedule.stories.tsx packages/lab/src/Schedule
- targeted TypeScript check covering XDSButton and XDSSchedule files