### PR TITLE
fix(Lightbox): logical properties and prop forwarding

### DIFF
--- a/packages/core/src/Lightbox/XDSLightbox.tsx
+++ b/packages/core/src/Lightbox/XDSLightbox.tsx
@@ -183,10 +183,9 @@ const styles = stylex.create({
     fontSize: typeScaleVars['--text-large-size'],
     lineHeight: typeScaleVars['--text-large-leading'],
     textAlign: 'center',
-    paddingTop: spacingVars['--spacing-2'],
-    paddingBottom: 0,
-    paddingLeft: spacingVars['--spacing-3'],
-    paddingRight: spacingVars['--spacing-3'],
+    paddingBlockStart: spacingVars['--spacing-2'],
+    paddingBlockEnd: 0,
+    paddingInline: spacingVars['--spacing-3'],
     maxWidth: '600px',
     flexShrink: 0,
   },
@@ -273,6 +272,8 @@ export function XDSLightbox({
   className,
   style,
   ref,
+  onClick: onClickProp,
+  onKeyDown: onKeyDownProp,
   ...props
 }: XDSLightboxProps) {
   const dialogRef = useRef<HTMLDialogElement>(null);
@@ -456,8 +457,14 @@ export function XDSLightbox({
     <dialog
       ref={mergeRefs(ref, dialogRef)}
       onCancel={handleCancel}
-      onClick={handleBackdropClick}
-      onKeyDown={handleKeyDown}
+      onClick={e => {
+        handleBackdropClick(e);
+        onClickProp?.(e);
+      }}
+      onKeyDown={e => {
+        handleKeyDown(e);
+        onKeyDownProp?.(e);
+      }}
       aria-label={currentItem.alt || 'Media viewer'}
       {...mergeProps(
         xdsClassName('lightbox'),

--- a/packages/core/src/Lightbox/index.ts
+++ b/packages/core/src/Lightbox/index.ts
@@ -3,7 +3,10 @@
 'use client';
 
 /**
- * @file Lightbox component barrel export
+ * @file index.ts
+ * @input Imports XDSLightbox component, useXDSLightbox hook, and types
+ * @output Exports XDSLightbox, useXDSLightbox, and all related types
+ * @position Component entry point; re-exported by /packages/core/src/index.ts
  */
 
 export {XDSLightbox} from './XDSLightbox';


### PR DESCRIPTION
## Changes

**XDSLightbox**

- **Logical properties**: Replace `paddingLeft`/`paddingRight` with `paddingInline` and `paddingTop`/`paddingBottom` with `paddingBlockStart`/`paddingBlockEnd` for RTL support in captions.

- **Prop forwarding**: Destructure `onClick` and `onKeyDown` from the rest spread, then compose them with internal handlers (`handleBackdropClick`, `handleKeyDown`). Previously the `{...props}` spread after explicit handlers would silently overwrite them if a consumer passed their own.

- **File header**: Add missing `@input`, `@output`, `@position` annotations to `index.ts`.

## Audit Notes (non-blocking)

- `transitionDuration: '200ms'` on image styles — animation token not yet defined. Will tokenize when animation tokens are established.
- `backdropFilter: 'blur(2px)'` — effects token story pending.

Night Watch — Component Auditor