### PR TITLE
feat(core): useXDSServerDialog with real RSC demo

### DIFF
--- a/apps/docsite/scripts/generate-data.mjs
+++ b/apps/docsite/scripts/generate-data.mjs
@@ -1000,6 +1000,14 @@ function generateShowcaseRegistry() {
     const destFile = `${basename}.tsx`;
     fs.copyFileSync(tsxSrc, path.join(SHOWCASE_OUT, destFile));
 
+    // Copy sibling .tsx files (e.g. server actions) excluding the showcase and doc
+    const dir = path.dirname(docPath);
+    for (const sibling of fs.readdirSync(dir)) {
+      if (sibling.endsWith('.tsx') && sibling !== basename + '.tsx') {
+        fs.copyFileSync(path.join(dir, sibling), path.join(SHOWCASE_OUT, sibling));
+      }
+    }
+
     entries.push({exampleFor, basename, destFile});
   }
 

--- a/packages/cli/templates/blocks/components/ServerDialog/ServerDialogShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/ServerDialog/ServerDialogShowcase.doc.mjs
@@ -1,0 +1,12 @@
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  exampleFor: 'useXDSServerDialog',
+  name: 'Server Dialog',
+  description:
+    'Dialog with server-fetched data using useXDSServerDialog. Shows the loading spinner fallback and resolved content with action buttons.',
+  isReady: true,
+  isShowcase: true,
+  aspectRatio: 16 / 9,
+  componentsUsed: ['Dialog', 'Layout', 'Button', 'Text', 'Spinner'],
+};

--- a/packages/cli/templates/blocks/components/ServerDialog/ServerDialogShowcase.tsx
+++ b/packages/cli/templates/blocks/components/ServerDialog/ServerDialogShowcase.tsx
@@ -1,0 +1,23 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import {useXDSServerDialog} from '@xds/core/ServerDialog';
+import {XDSButton} from '@xds/core/Button';
+import {fetchUserDialog} from './serverDialogAction';
+
+export default function ServerDialogShowcase() {
+  const [showDialog, preloadDialog, dialogElement] =
+    useXDSServerDialog(fetchUserDialog);
+
+  return (
+    <>
+      <XDSButton
+        label="Show Server Dialog"
+        onMouseEnter={() => preloadDialog({userId: '42'}, {})}
+        onClick={() => showDialog({userId: '42'}, {})}
+      />
+      {dialogElement}
+    </>
+  );
+}

--- a/packages/cli/templates/blocks/components/ServerDialog/serverDialogAction.tsx
+++ b/packages/cli/templates/blocks/components/ServerDialog/serverDialogAction.tsx
@@ -1,0 +1,63 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use server';
+
+import {XDSDialogServer, XDSDialogCloseButton} from '@xds/core/ServerDialog';
+import type {ClientProp} from '@xds/core/ServerDialog';
+import {XDSDialogHeader} from '@xds/core/Dialog';
+import {
+  XDSLayout,
+  XDSLayoutContent,
+  XDSLayoutFooter,
+  XDSHStack,
+  XDSVStack,
+} from '@xds/core/Layout';
+import {XDSText} from '@xds/core/Text';
+
+type UserDialogProps = {
+  userId: string;
+  onOpenChange: ClientProp<(isOpen: boolean) => void>;
+};
+
+export async function fetchUserDialog(props: UserDialogProps) {
+  await new Promise(resolve => setTimeout(resolve, 800));
+
+  const user = {
+    name: `User ${props.userId}`,
+    email: `user${props.userId}@example.com`,
+    role: 'Engineer',
+  };
+
+  return (
+    <XDSDialogServer isOpen onOpenChange={props.onOpenChange} width={400}>
+      <XDSLayout
+        header={
+          <XDSDialogHeader
+            title="User Details"
+            subtitle={`User ${props.userId}`}
+          />
+        }
+        content={
+          <XDSLayoutContent>
+            <XDSVStack gap={2}>
+              <XDSText type="body" weight="bold">
+                {user.name}
+              </XDSText>
+              <XDSText type="body">{user.email}</XDSText>
+              <XDSText type="supporting" color="secondary">
+                {user.role} — fetched and rendered on the server.
+              </XDSText>
+            </XDSVStack>
+          </XDSLayoutContent>
+        }
+        footer={
+          <XDSLayoutFooter>
+            <XDSHStack gap={2} hAlign="end">
+              <XDSDialogCloseButton label="Done" variant="primary" />
+            </XDSHStack>
+          </XDSLayoutFooter>
+        }
+      />
+    </XDSDialogServer>
+  );
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -469,6 +469,12 @@
       "import": "./dist/Selector/index.mjs",
       "require": "./dist/Selector/index.js"
     },
+    "./ServerDialog": {
+      "source": "./src/ServerDialog/index.ts",
+      "types": "./dist/ServerDialog/index.d.ts",
+      "import": "./dist/ServerDialog/index.mjs",
+      "require": "./dist/ServerDialog/index.js"
+    },
     "./SideNav": {
       "source": "./src/SideNav/index.ts",
       "types": "./dist/SideNav/index.d.ts",

--- a/packages/core/src/ServerDialog/ClientProp.test.ts
+++ b/packages/core/src/ServerDialog/ClientProp.test.ts
@@ -1,0 +1,79 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {describe, it, expect} from 'vitest';
+import {
+  createClientPropMarker,
+  isClientProp,
+  buildPropsWithClientMarkers,
+} from './ClientProp';
+
+describe('createClientPropMarker', () => {
+  it('creates a marker with the correct shape', () => {
+    const marker = createClientPropMarker('onDone');
+    expect(marker).toEqual({
+      __clientPropMarker: 'client-prop',
+      __propName: 'onDone',
+    });
+  });
+});
+
+describe('isClientProp', () => {
+  it('returns true for a client prop marker', () => {
+    const marker = createClientPropMarker('onDone');
+    expect(isClientProp(marker)).toBe(true);
+  });
+
+  it('returns false for null', () => {
+    expect(isClientProp(null)).toBe(false);
+  });
+
+  it('returns false for undefined', () => {
+    expect(isClientProp(undefined)).toBe(false);
+  });
+
+  it('returns false for a plain object', () => {
+    expect(isClientProp({foo: 'bar'})).toBe(false);
+  });
+
+  it('returns false for a function', () => {
+    expect(isClientProp(() => {})).toBe(false);
+  });
+
+  it('returns false for a string', () => {
+    expect(isClientProp('hello')).toBe(false);
+  });
+});
+
+describe('buildPropsWithClientMarkers', () => {
+  it('passes server props through unchanged', () => {
+    const result = buildPropsWithClientMarkers(
+      {title: 'Hello', count: 5},
+      {onDone: () => {}},
+    );
+    expect(result.title).toBe('Hello');
+    expect(result.count).toBe(5);
+  });
+
+  it('replaces client props with markers', () => {
+    const result = buildPropsWithClientMarkers(
+      {title: 'Hello'},
+      {onDone: () => {}},
+    );
+    expect(isClientProp(result.onDone)).toBe(true);
+    expect((result.onDone as {__propName: string}).__propName).toBe('onDone');
+  });
+
+  it('always includes an onOpenChange marker', () => {
+    const result = buildPropsWithClientMarkers({title: 'Hello'}, {});
+    expect(isClientProp(result.onOpenChange)).toBe(true);
+    expect((result.onOpenChange as {__propName: string}).__propName).toBe(
+      'onOpenChange',
+    );
+  });
+
+  it('does not include client prop values in the result', () => {
+    const fn = () => {};
+    const result = buildPropsWithClientMarkers({title: 'Hello'}, {onDone: fn});
+    expect(result.onDone).not.toBe(fn);
+  });
+});

--- a/packages/core/src/ServerDialog/ClientProp.ts
+++ b/packages/core/src/ServerDialog/ClientProp.ts
@@ -1,0 +1,79 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import {createContext, useContext} from 'react';
+
+const CLIENT_PROP_MARKER = 'client-prop' as const;
+
+export interface ClientProp<out T> {
+  readonly __clientPropMarker: typeof CLIENT_PROP_MARKER;
+  readonly __propName: string;
+  readonly __phantomType?: T;
+}
+
+export type MaybeClientProp<T> = ClientProp<T> | T;
+
+export type ClientPropKeys<T> = {
+  [K in keyof T]: T[K] extends ClientProp<unknown> ? K : never;
+}[keyof T];
+
+export type ExtractServerProps<T> = Omit<T, ClientPropKeys<T>>;
+
+export type ExtractClientProps<T> = {
+  [K in ClientPropKeys<T>]: T[K] extends ClientProp<infer V> ? V : never;
+};
+
+export type MakeOnOpenChangeOptional<T> = Omit<T, 'onOpenChange'> &
+  Partial<Pick<T, 'onOpenChange' & keyof T>>;
+
+export const ClientPropContext = createContext<Record<string, unknown>>({});
+ClientPropContext.displayName = "ClientPropContext";
+
+export function createClientPropMarker<T>(propName: string): ClientProp<T> {
+  return {
+    __clientPropMarker: CLIENT_PROP_MARKER,
+    __propName: propName,
+  };
+}
+
+export function isClientProp(prop: unknown): prop is ClientProp<unknown> {
+  return (
+    prop != null &&
+    typeof prop === 'object' &&
+    '__clientPropMarker' in prop &&
+    (prop as ClientProp<unknown>).__clientPropMarker === CLIENT_PROP_MARKER
+  );
+}
+
+export function useClientProp<T>(prop: ClientProp<T>): T {
+  const ctx = useContext(ClientPropContext);
+  return ctx[prop.__propName] as T;
+}
+
+export function useMaybeClientProp<T>(
+  prop: MaybeClientProp<T> | null | undefined,
+): T | null | undefined {
+  const ctx = useContext(ClientPropContext);
+  if (prop == null) {return prop;}
+  if (isClientProp(prop)) {
+    return ctx[prop.__propName] as T;
+  }
+  return prop;
+}
+
+export function buildPropsWithClientMarkers(
+  serverProps: Record<string, unknown>,
+  clientProps: Record<string, unknown>,
+): Record<string, unknown> {
+  const clientPropsMarkers = Object.fromEntries(
+    Object.keys({...clientProps, onOpenChange: null}).map(propName => [
+      propName,
+      createClientPropMarker(propName),
+    ]),
+  );
+  return {
+    ...serverProps,
+    ...clientPropsMarkers,
+  };
+}

--- a/packages/core/src/ServerDialog/ServerDialog.doc.mjs
+++ b/packages/core/src/ServerDialog/ServerDialog.doc.mjs
@@ -1,0 +1,103 @@
+/** @type {import('../docs-types').ComponentDoc} */
+
+export const docs = {
+  name: 'useXDSServerDialog',
+  group: 'Dialog',
+  keywords: ["server dialog","rsc","react server components","server function","data fetching","modal","async","suspense","preload","client prop","serialization"],
+  props: [
+    {name: 'renderDialog', type: '(props: TProps) => Promise<ReactNode>', description: 'An async server function that accepts props and returns dialog content.', required: true},
+    {name: 'showDialog', type: '(serverProps, clientProps) => void', description: 'Returned. Calls the server function, renders the dialog inside a Suspense boundary with a loading spinner. Auto-injects onOpenChange.'},
+    {name: 'preloadDialog', type: '(serverProps, clientProps) => void', description: 'Returned. Fires the server function early to warm the cache without rendering.'},
+    {name: 'dialogElement', type: 'ReactNode', description: 'Returned. The dialog element to render in your JSX tree. Null when no dialog is shown.'},
+  ],
+  usage: {
+    description: 'Bridges the React Server Components serialization boundary for dialogs. Server functions cannot receive callbacks because functions are not serializable — this hook splits props into server props (serializable data) and client props (functions that stay on the client).',
+    bestPractices: [
+      {guidance: true, description: 'Use ClientProp<T> for any function prop in your server dialog props type. Use the Server wrapper components (XDSDialogServer, XDSButtonServer) inside the server function.'},
+      {guidance: true, description: 'Use XDSDialogCloseButton for close/done buttons — it reads onOpenChange from ClientProp context automatically.'},
+      {guidance: true, description: 'Call preloadDialog on mouse enter to eliminate loading spinners — the cached result is reused by showDialog.'},
+      {guidance: true, description: 'Keep onOpenChange optional in client props — the hook auto-injects one that integrates with dismiss handling. Pass your own only for side effects.'},
+      {guidance: false, description: 'Pass function props directly to server functions — they are not serializable and will throw at the RSC boundary.'},
+      {guidance: false, description: 'Use XDSDialog or XDSButton directly inside server functions — use the Server variants (XDSDialogServer, XDSButtonServer) which resolve ClientProp markers.'},
+    ],
+    anatomy: [
+      {name: 'Server Function', required: true, description: 'An async function that fetches data and returns dialog content using XDSDialogServer.'},
+      {name: 'ClientProp markers', required: true, description: 'Serializable placeholders for function props (onOpenChange, onClick) that are resolved on the client.'},
+      {name: 'XDSDialogCloseButton', required: false, description: 'A button that closes the dialog by calling onOpenChange(false) from ClientProp context. No props needed for the close behavior.'},
+      {name: 'Loading fallback', required: false, description: 'A Suspense boundary with a spinner dialog shown while the server function resolves.'},
+    ],
+  },
+  examples: [
+    {
+      label: 'Server action with data fetching',
+      code: `
+// actions/fetchUserDialog.tsx — 'use server' file
+'use server';
+
+import {XDSDialogServer, XDSDialogCloseButton} from '@xds/core/ServerDialog';
+import type {ClientProp} from '@xds/core/ServerDialog';
+import {XDSDialogHeader} from '@xds/core/Dialog';
+import {XDSLayout, XDSLayoutContent, XDSLayoutFooter, XDSHStack, XDSVStack} from '@xds/core/Layout';
+import {XDSText} from '@xds/core/Text';
+
+type UserDialogProps = {
+  userId: string;
+  onOpenChange: ClientProp<(isOpen: boolean) => void>;
+};
+
+export async function fetchUserDialog(props: UserDialogProps) {
+  const user = await db.users.find(props.userId);
+
+  return (
+    <XDSDialogServer isOpen onOpenChange={props.onOpenChange} width={400}>
+      <XDSLayout
+        header={<XDSDialogHeader title={user.name} />}
+        content={
+          <XDSLayoutContent>
+            <XDSVStack gap={2}>
+              <XDSText type="body">{user.email}</XDSText>
+            </XDSVStack>
+          </XDSLayoutContent>
+        }
+        footer={
+          <XDSLayoutFooter>
+            <XDSHStack gap={2} hAlign="end">
+              <XDSDialogCloseButton label="Done" variant="primary" />
+            </XDSHStack>
+          </XDSLayoutFooter>
+        }
+      />
+    </XDSDialogServer>
+  );
+}
+`,
+    },
+    {
+      label: 'Client component with preloading',
+      code: `
+// components/UserButton.tsx — 'use client' file
+'use client';
+
+import {useXDSServerDialog} from '@xds/core/ServerDialog';
+import {XDSButton} from '@xds/core/Button';
+import {fetchUserDialog} from '../actions/fetchUserDialog';
+
+export function UserButton({userId}: {userId: string}) {
+  const [showDialog, preloadDialog, dialogElement] =
+    useXDSServerDialog(fetchUserDialog);
+
+  return (
+    <>
+      <XDSButton
+        label="View User"
+        onMouseEnter={() => preloadDialog({userId}, {})}
+        onClick={() => showDialog({userId}, {})}
+      />
+      {dialogElement}
+    </>
+  );
+}
+`,
+    },
+  ],
+};

--- a/packages/core/src/ServerDialog/XDSButtonServer.tsx
+++ b/packages/core/src/ServerDialog/XDSButtonServer.tsx
@@ -1,0 +1,19 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import type {XDSButtonProps} from '../Button/XDSButton';
+import {XDSButton} from '../Button/XDSButton';
+import type {MaybeClientProp} from './ClientProp';
+import {useMaybeClientProp} from './ClientProp';
+
+export interface XDSButtonServerProps extends Omit<XDSButtonProps, 'onClick'> {
+  onClick?: MaybeClientProp<XDSButtonProps['onClick']>;
+}
+
+export function XDSButtonServer({onClick, ...props}: XDSButtonServerProps) {
+  const resolvedOnClick = useMaybeClientProp(onClick);
+  return <XDSButton onClick={resolvedOnClick ?? undefined} {...props} />;
+}
+
+XDSButtonServer.displayName = 'XDSButtonServer';

--- a/packages/core/src/ServerDialog/XDSDialogCloseButton.tsx
+++ b/packages/core/src/ServerDialog/XDSDialogCloseButton.tsx
@@ -1,0 +1,21 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import {useContext} from 'react';
+import type {XDSButtonProps} from '../Button/XDSButton';
+import {XDSButton} from '../Button/XDSButton';
+import {ClientPropContext} from './ClientProp';
+
+export type XDSDialogCloseButtonProps = Omit<XDSButtonProps, 'onClick'>;
+
+export function XDSDialogCloseButton(props: XDSDialogCloseButtonProps) {
+  const clientProps = useContext(ClientPropContext);
+  const onOpenChange = clientProps.onOpenChange as
+    | ((isOpen: boolean) => void)
+    | null;
+
+  return <XDSButton onClick={() => onOpenChange?.(false)} {...props} />;
+}
+
+XDSDialogCloseButton.displayName = 'XDSDialogCloseButton';

--- a/packages/core/src/ServerDialog/XDSDialogServer.tsx
+++ b/packages/core/src/ServerDialog/XDSDialogServer.tsx
@@ -1,0 +1,27 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import type {XDSDialogProps} from '../Dialog/XDSDialog';
+import {XDSDialog} from '../Dialog/XDSDialog';
+import type {MaybeClientProp} from './ClientProp';
+import {useMaybeClientProp} from './ClientProp';
+
+export interface XDSDialogServerProps extends Omit<
+  XDSDialogProps,
+  'onOpenChange'
+> {
+  onOpenChange?: MaybeClientProp<XDSDialogProps['onOpenChange']>;
+}
+
+export function XDSDialogServer({
+  onOpenChange,
+  ...props
+}: XDSDialogServerProps) {
+  const resolvedOnOpenChange = useMaybeClientProp(onOpenChange);
+  return (
+    <XDSDialog onOpenChange={resolvedOnOpenChange ?? (() => {})} {...props} />
+  );
+}
+
+XDSDialogServer.displayName = 'XDSDialogServer';

--- a/packages/core/src/ServerDialog/index.ts
+++ b/packages/core/src/ServerDialog/index.ts
@@ -1,0 +1,29 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+export {useXDSServerDialog} from './useXDSServerDialog';
+export type {ShowDialogFn, PreloadDialogFn} from './useXDSServerDialog';
+
+export {XDSDialogServer} from './XDSDialogServer';
+export type {XDSDialogServerProps} from './XDSDialogServer';
+
+export {XDSButtonServer} from './XDSButtonServer';
+export type {XDSButtonServerProps} from './XDSButtonServer';
+
+export {XDSDialogCloseButton} from './XDSDialogCloseButton';
+export type {XDSDialogCloseButtonProps} from './XDSDialogCloseButton';
+
+export {
+  createClientPropMarker,
+  isClientProp,
+  useClientProp,
+  useMaybeClientProp,
+} from './ClientProp';
+export type {
+  ClientProp,
+  MaybeClientProp,
+  ClientPropKeys,
+  ExtractServerProps,
+  ExtractClientProps,
+} from './ClientProp';

--- a/packages/core/src/ServerDialog/useXDSServerDialog.test.tsx
+++ b/packages/core/src/ServerDialog/useXDSServerDialog.test.tsx
@@ -1,0 +1,161 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {describe, it, expect, vi, beforeAll} from 'vitest';
+import {render, screen, fireEvent, act} from '@testing-library/react';
+import {useXDSServerDialog} from './useXDSServerDialog';
+import {XDSDialogServer} from './XDSDialogServer';
+import {XDSButtonServer} from './XDSButtonServer';
+import type {ClientProp} from './ClientProp';
+
+beforeAll(() => {
+  HTMLDialogElement.prototype.showModal = vi.fn();
+  HTMLDialogElement.prototype.close = vi.fn();
+});
+
+type TestDialogProps = {
+  title: string;
+  onDone: ClientProp<() => void>;
+  onOpenChange: ClientProp<(isOpen: boolean) => void>;
+};
+
+async function fakeServerDialog(props: TestDialogProps) {
+  return (
+    <XDSDialogServer isOpen onOpenChange={props.onOpenChange} width={400}>
+      <div>
+        <span>{props.title}</span>
+        <XDSButtonServer label="Done" onClick={props.onDone} />
+      </div>
+    </XDSDialogServer>
+  );
+}
+
+function TestHarness({onDone}: {onDone: () => void}) {
+  const [showDialog, preloadDialog, dialogElement] =
+    useXDSServerDialog(fakeServerDialog);
+
+  return (
+    <div>
+      <button
+        data-testid="open"
+        onMouseEnter={() =>
+          preloadDialog({title: 'Test Title'}, {onDone: () => {}})
+        }
+        onClick={() => showDialog({title: 'Test Title'}, {onDone})}>
+        Open
+      </button>
+      {dialogElement}
+    </div>
+  );
+}
+
+describe('useXDSServerDialog', () => {
+  it('renders nothing initially', () => {
+    render(<TestHarness onDone={() => {}} />);
+    expect(screen.queryByText('Test Title')).not.toBeInTheDocument();
+  });
+
+  it('shows dialog content after showDialog is called', async () => {
+    render(<TestHarness onDone={() => {}} />);
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('open'));
+    });
+    expect(screen.getByText('Test Title')).toBeInTheDocument();
+  });
+
+  it('resolves ClientProp markers in wrapper components', async () => {
+    const onDone = vi.fn();
+    render(<TestHarness onDone={onDone} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('open'));
+    });
+
+    fireEvent.click(screen.getByText('Done'));
+    expect(onDone).toHaveBeenCalledTimes(1);
+  });
+
+  it('caches the server function result for identical props', async () => {
+    const serverFn = vi.fn(fakeServerDialog);
+
+    function CacheHarness() {
+      const [showDialog, , dialogElement] = useXDSServerDialog(serverFn);
+      return (
+        <div>
+          <button
+            data-testid="open"
+            onClick={() => showDialog({title: 'Same'}, {onDone: () => {}})}>
+            Open
+          </button>
+          {dialogElement}
+        </div>
+      );
+    }
+
+    render(<CacheHarness />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('open'));
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('open'));
+    });
+
+    expect(serverFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('preloadDialog fires the server function without rendering', async () => {
+    const serverFn = vi.fn(fakeServerDialog);
+
+    function PreloadHarness() {
+      const [, preloadDialog, dialogElement] = useXDSServerDialog(serverFn);
+      return (
+        <div>
+          <button
+            data-testid="preload"
+            onClick={() =>
+              preloadDialog({title: 'Preloaded'}, {onDone: () => {}})
+            }>
+            Preload
+          </button>
+          {dialogElement}
+        </div>
+      );
+    }
+
+    render(<PreloadHarness />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('preload'));
+    });
+
+    expect(serverFn).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText('Preloaded')).not.toBeInTheDocument();
+  });
+});
+
+describe('XDSDialogServer', () => {
+  it('renders with a direct onOpenChange function', () => {
+    const onOpenChange = vi.fn();
+    render(
+      <XDSDialogServer isOpen onOpenChange={onOpenChange} width={400}>
+        <div>Content</div>
+      </XDSDialogServer>,
+    );
+    expect(screen.getByText('Content')).toBeInTheDocument();
+  });
+});
+
+describe('XDSButtonServer', () => {
+  it('renders with a direct onClick function', () => {
+    const onClick = vi.fn();
+    render(<XDSButtonServer label="Click me" onClick={onClick} />);
+    fireEvent.click(screen.getByText('Click me'));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders without onClick', () => {
+    render(<XDSButtonServer label="No handler" />);
+    expect(screen.getByText('No handler')).toBeInTheDocument();
+  });
+});

--- a/packages/core/src/ServerDialog/useXDSServerDialog.tsx
+++ b/packages/core/src/ServerDialog/useXDSServerDialog.tsx
@@ -1,0 +1,150 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import {
+  type ReactNode,
+  useRef,
+  useCallback,
+  useState,
+  Suspense,
+  use,
+} from 'react';
+import {XDSDialog} from '../Dialog/XDSDialog';
+import {XDSSpinner} from '../Spinner';
+import {
+  type ExtractServerProps,
+  type ExtractClientProps,
+  type MakeOnOpenChangeOptional,
+  ClientPropContext,
+  buildPropsWithClientMarkers,
+} from './ClientProp';
+
+type ServerDialogFn<TProps> = (props: TProps) => Promise<ReactNode>;
+
+type ServerProps<TProps> = ExtractServerProps<TProps>;
+
+type ClientProps<TProps> = MakeOnOpenChangeOptional<ExtractClientProps<TProps>>;
+
+export type ShowDialogFn<TProps> = (
+  serverProps: ServerProps<TProps>,
+  clientProps: ClientProps<TProps>,
+) => void;
+
+export type PreloadDialogFn<TProps> = (
+  serverProps: ServerProps<TProps>,
+  clientProps: ClientProps<TProps>,
+) => void;
+
+function LoadingDialog() {
+  return (
+    <XDSDialog isOpen onOpenChange={() => {}} width={400}>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: '48px 0',
+        }}>
+        <XDSSpinner size="md" />
+      </div>
+    </XDSDialog>
+  );
+}
+
+function DialogRenderer({dialogPromise}: {dialogPromise: Promise<ReactNode>}) {
+  const content = use(dialogPromise);
+  return <>{content}</>;
+}
+
+export function useXDSServerDialog<TProps extends Record<string, unknown>>(
+  renderDialog: ServerDialogFn<TProps>,
+): [ShowDialogFn<TProps>, PreloadDialogFn<TProps>, ReactNode] {
+  const [dialogState, setDialogState] = useState<{
+    promise: Promise<ReactNode>;
+    clientProps: Record<string, unknown>;
+  } | null>(null);
+
+  const cacheRef = useRef<{
+    key: string;
+    promise: Promise<ReactNode>;
+  } | null>(null);
+
+  const getOrFetchDialog = useCallback(
+    async (mergedProps: Record<string, unknown>): Promise<ReactNode> => {
+      const key = JSON.stringify(mergedProps);
+      if (cacheRef.current?.key === key) {
+        return cacheRef.current.promise;
+      }
+      const promise = renderDialog(mergedProps as TProps);
+      cacheRef.current = {key, promise};
+      return promise;
+    },
+    [renderDialog],
+  );
+
+  const hideDialog = useCallback(() => {
+    setDialogState(null);
+  }, []);
+
+  const showDialog = useCallback(
+    (serverProps: ServerProps<TProps>, clientProps: ClientProps<TProps>) => {
+      const userOnOpenChange = (clientProps as Record<string, unknown>)
+        .onOpenChange as ((isOpen: boolean) => void) | undefined;
+
+      const clientPropsWithOnOpenChange: Record<string, unknown> = {
+        ...(clientProps as Record<string, unknown>),
+        onOpenChange: (isOpen: boolean) => {
+          if (!isOpen) {
+            hideDialog();
+            userOnOpenChange?.(false);
+          }
+        },
+      };
+
+      const mergedProps = buildPropsWithClientMarkers(
+        serverProps,
+        clientPropsWithOnOpenChange,
+      );
+
+      const promise = getOrFetchDialog(mergedProps);
+
+      setDialogState({
+        promise,
+        clientProps: clientPropsWithOnOpenChange,
+      });
+    },
+    [getOrFetchDialog, hideDialog],
+  );
+
+  const preloadDialog = useCallback(
+    (serverProps: ServerProps<TProps>, clientProps: ClientProps<TProps>) => {
+      const clientPropsWithOnOpenChange: Record<string, unknown> = {
+        ...(clientProps as Record<string, unknown>),
+        onOpenChange: null,
+      };
+
+      const mergedProps = buildPropsWithClientMarkers(
+        serverProps,
+        clientPropsWithOnOpenChange,
+      );
+
+      getOrFetchDialog(mergedProps);
+    },
+    [getOrFetchDialog],
+  );
+
+  const element = dialogState ? (
+    <ClientPropContext.Provider value={dialogState.clientProps}>
+      <Suspense fallback={<LoadingDialog />}>
+        <DialogRenderer dialogPromise={dialogState.promise} />
+      </Suspense>
+    </ClientPropContext.Provider>
+  ) : null;
+
+  return [showDialog, preloadDialog, element] as [
+    ShowDialogFn<TProps>,
+    PreloadDialogFn<TProps>,
+    ReactNode,
+  ];
+}


### PR DESCRIPTION
## Summary

- **`useXDSServerDialog` hook** — bridges the RSC serialization boundary for dialogs, splitting props into server (serializable) and client (functions via `ClientProp` markers)
- **`XDSDialogCloseButton`** — new component that reads `onOpenChange` from `ClientPropContext` so close buttons inside server-rendered dialogs work without extra wiring
- **Real `'use server'` demo** — showcase uses a real server action with `XDSDialogServer`/`XDSDialogCloseButton` instead of a fake client-side async function
- **Doc improvements** — code examples for server action and client component patterns, updated best practices
- **`ServerDialog` export** — added missing subpath export to `package.json`
- **Generate script** — copies sibling `.tsx` files alongside showcases (needed for server action file)

## Known issues

- RSC client manifest error when the server action renders client components from `@xds/core` — needs investigation into how the docsite's bundler registers client component references from `'use server'` files

## Test plan

- [x] `pnpm vitest run packages/core/src/ServerDialog/` — 19 tests pass
- [x] Docsite builds and serves at localhost:3000
- [ ] Verify server action demo works end-to-end (blocked by manifest issue)
- [ ] Verify `XDSDialogCloseButton` closes the dialog