### PR TITLE
fix(chat): include density in XDSChatMessage xdsClassName

### DIFF
--- a/packages/core/src/Chat/XDSChatMessage.tsx
+++ b/packages/core/src/Chat/XDSChatMessage.tsx
@@ -220,7 +220,7 @@ export function XDSChatMessage({
         aria-label={!hasName ? `Message from ${sender}` : undefined}
         aria-labelledby={hasName ? nameId : undefined}
         {...mergeProps(
-          xdsClassName('chat-message', {sender}),
+          xdsClassName('chat-message', {sender, density}),
           stylex.props(
             styles.root,
             rootAlignment,


### PR DESCRIPTION
## Summary

Include `density` in the `xdsClassName` call for `XDSChatMessage`.

Density drives visual styles (gap sizes via `rootGap`, `childrenGap`) on the message root element but was missing from the class name output. Other Chat family components (`chat-layout`, `chat-message-list`, `chat-message-bubble`) already include density for theme targeting consistency.

This enables themes to target density-specific message spacing via `.xds-chat-message.compact` / `.xds-chat-message.balanced` / `.xds-chat-message.spacious`.

## Needs Review

- **XDSChatToolCalls.tsx** (612 lines) and **XDSChatComposerInput.tsx** (662 lines) exceed the ~400 line guideline. Consider extracting sub-components in a future pass. Not blocking.

Night Watch — Component Auditor