### PR TITLE
feat(docsite): reorganize side-nav — Foundations & Themes as top-level sections

### DIFF
--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/DocsView.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/DocsView.tsx
@@ -5132,23 +5132,10 @@ export function DocsView({
                     setActiveNav('whats-new');
                   }}
                 />
-                <XDSSideNavItem label="Foundations" collapsible>
-                  {FOUNDATION_ITEMS.map(item => (
-                    <XDSSideNavItem
-                      key={item.key}
-                      label={item.title}
-                      isSelected={
-                        selectedComponent !== null && activeNav === item.key
-                      }
-                      onClick={() => {
-                        onComponentChange(item.key);
-                        setActiveNav(item.key);
-                      }}
-                    />
-                  ))}
-                </XDSSideNavItem>
                 <XDSSideNavItem label="Libraries" collapsible>
-                  {LIBRARY_PACKAGES.filter(pkg => !pkg.href).map(pkg => (
+                  {LIBRARY_PACKAGES.filter(
+                    pkg => !pkg.href && !pkg.key.startsWith('pkg-theme'),
+                  ).map(pkg => (
                     <XDSSideNavItem
                       key={pkg.key}
                       label={pkg.name}
@@ -5163,6 +5150,22 @@ export function DocsView({
                   ))}
                 </XDSSideNavItem>
               </XDSSideNavItem>
+            </XDSSideNavSection>
+
+            <XDSSideNavSection title="Foundations">
+              {FOUNDATION_ITEMS.map(item => (
+                <XDSSideNavItem
+                  key={item.key}
+                  label={item.title}
+                  isSelected={
+                    selectedComponent !== null && activeNav === item.key
+                  }
+                  onClick={() => {
+                    onComponentChange(item.key);
+                    setActiveNav(item.key);
+                  }}
+                />
+              ))}
             </XDSSideNavSection>
 
             {COMPONENT_CATEGORIES.map(category => (
@@ -5182,6 +5185,24 @@ export function DocsView({
                 ))}
               </XDSSideNavSection>
             ))}
+
+            <XDSSideNavSection title="Themes">
+              {LIBRARY_PACKAGES.filter(pkg =>
+                pkg.key.startsWith('pkg-theme'),
+              ).map(pkg => (
+                <XDSSideNavItem
+                  key={pkg.key}
+                  label={pkg.name}
+                  isSelected={
+                    selectedComponent !== null && activeNav === pkg.key
+                  }
+                  onClick={() => {
+                    onComponentChange(pkg.key);
+                    setActiveNav(pkg.key);
+                  }}
+                />
+              ))}
+            </XDSSideNavSection>
           </XDSSideNav>
         }>
         {/* MAIN CONTENT */}


### PR DESCRIPTION
## Summary

Reorganizes the docs side-nav per design feedback:

1. **Foundations** — moved out of the "Guide" collapsible section and placed as its own top-level section, directly before the component categories (Core, Typography, Layout, etc.)

2. **Themes** — added as a new top-level section after all component categories, listing the theme packages (@xds/theme-default, @xds/theme-neutral)

3. **Libraries** — theme packages are no longer listed under Libraries (since they have their own section now)

### Before
```
Guide ▾
  Getting Started
  What's New
  Foundations ▾ (nested inside Guide)
    Typography, Colors, Shape, ...
  Libraries ▾
    @xds/cli, @xds/core, @xds/theme-default, ...
Core
Typography
...
```

### After
```
Guide ▾
  Getting Started
  What's New
  Libraries ▾
    @xds/cli, @xds/core, @xds/vega
Foundations
  Typography, Colors, Shape, ...
Core
Typography
Layout
...
CommandPalette
Themes
  @xds/theme-default
  @xds/theme-neutral
```
