### PR TITLE
fix(docsite): home page hero unreadable in dark mode

### DIFF
--- a/apps/docsite/src/app/(site)/page.tsx
+++ b/apps/docsite/src/app/(site)/page.tsx
@@ -4,7 +4,6 @@ import * as stylex from '@stylexjs/stylex';
 import {XDSText} from '@xds/core/Text';
 import {XDSVStack} from '@xds/core/Layout';
 import {XDSButton} from '@xds/core/Button';
-import {XDSMediaTheme} from '@xds/core/theme';
 
 const styles = stylex.create({
   hero: {
@@ -30,27 +29,25 @@ const styles = stylex.create({
 export default function HomePage() {
   return (
     <div {...stylex.props(styles.hero)}>
-      <XDSMediaTheme mode="light">
-        <XDSVStack gap={2} style={{alignItems: 'center'}}>
-          <XDSText type="display-1">XDS Open Source</XDSText>
-          <XDSText type="large" color="secondary" xstyle={styles.subtitle}>
-            An open design system for building internal tools with AI-powered
-            development.
-          </XDSText>
-          <div {...stylex.props(styles.buttons)}>
-            <XDSButton
-              variant="primary"
-              label="Get started"
-              href="/docs/getting-started"
-            />
-            <XDSButton
-              variant="secondary"
-              label="Browse components"
-              href="/components"
-            />
-          </div>
-        </XDSVStack>
-      </XDSMediaTheme>
+      <XDSVStack gap={2} style={{alignItems: 'center'}}>
+        <XDSText type="display-1">XDS Open Source</XDSText>
+        <XDSText type="large" color="secondary" xstyle={styles.subtitle}>
+          An open design system for building internal tools with AI-powered
+          development.
+        </XDSText>
+        <div {...stylex.props(styles.buttons)}>
+          <XDSButton
+            variant="primary"
+            label="Get started"
+            href="/docs/getting-started"
+          />
+          <XDSButton
+            variant="secondary"
+            label="Browse components"
+            href="/components"
+          />
+        </div>
+      </XDSVStack>
     </div>
   );
 }


### PR DESCRIPTION
## Problem

The docsite home page hero text is black-on-dark in dark mode — completely unreadable.

## Root Cause

The hero section is wrapped in `<XDSMediaTheme mode="light">`, which forces `--color-text-primary` to `var(--color-on-light)` (black). However, the page background comes from the AppShell (`variant="surface"`), which correctly resolves to dark (`#1F1F22`) in dark mode.

`XDSMediaTheme` is designed for content rendered on an explicitly inverted surface (e.g. a dark toast on a light page). It overrides **text/icon tokens only** — it does NOT set a background. Wrapping content in `XDSMediaTheme` without providing the matching background surface will always produce this mismatch.

## Fix

Remove `XDSMediaTheme mode="light"` so the hero inherits normal theme tokens. The page now works correctly in both light and dark mode.

## Design question

If a permanently-light hero is desired for brand/marketing reasons, the alternative fix is to keep `XDSMediaTheme mode="light"` but add an explicit light background to the hero div:

```tsx
<div {...stylex.props(styles.hero, styles.lightBg)}>
  <XDSMediaTheme mode="light">
    ...
  </XDSMediaTheme>
</div>
```

where `lightBg` sets `backgroundColor: colorVars['--color-background-surface']` with `colorScheme: 'light'` to force the light value.

That would create a light island on an otherwise dark page. Leaving this as a design decision for @rubycheung / @cixzhang.

## Test plan

- [x] Visual: dark mode no longer shows black text on dark background
- [x] Visual: light mode unchanged (text was already dark on light bg)