### PR TITLE
feat(tokens): add --color-border-active for active position indicators

### DIFF
--- a/packages/cli/docs/tokens.doc.mjs
+++ b/packages/cli/docs/tokens.doc.mjs
@@ -3,7 +3,7 @@
 // AUTO-GENERATED — do not edit manually.
 // Source: packages/core/src/theme/tokens.stylex.ts
 // Run: node scripts/generate-token-docs.mjs
-// Total: 183 tokens across 12 categories.
+// Total: 184 tokens across 12 categories.
 
 /** @type {import('../../core/src/docs-types').ReferenceDoc} */
 
@@ -202,6 +202,11 @@ export const docs = {
               "--color-border-emphasized",
               "#CCD3DB",
               "#494D53"
+            ],
+            [
+              "--color-border-active",
+              "#0064E0",
+              "#2694FE"
             ],
             [
               "--color-skeleton",

--- a/packages/core/src/TabList/XDSTab.tsx
+++ b/packages/core/src/TabList/XDSTab.tsx
@@ -140,7 +140,7 @@ const styles = stylex.create({
     transitionTimingFunction: easeVars['--ease-standard'],
   },
   indicatorSelected: {
-    backgroundColor: colorVars['--color-icon-primary'],
+    backgroundColor: colorVars['--color-border-active'],
     opacity: 1,
   },
   indicatorUnselected: {

--- a/packages/core/src/theme/tokens.stylex.ts
+++ b/packages/core/src/theme/tokens.stylex.ts
@@ -68,6 +68,7 @@ export const colorDefaults = {
   // Border
   '--color-border': 'light-dark(#05365919, #F2F4F619)',
   '--color-border-emphasized': 'light-dark(#CCD3DB, #494D53)',
+  '--color-border-active': 'light-dark(#0064E0, #2694FE)', // Active position indicator (tabs, stepper, outline)
 
   // Effects
   '--color-skeleton': 'light-dark(#CCD3DB, #5A5E66)',


### PR DESCRIPTION
## What

Adds a new semantic design token `--color-border-active` for active/selected position indicators (tab underlines, stepper progress lines, outline sliding bars).

**Default value:** `light-dark(#0064E0, #2694FE)` — matches `--color-accent` / `--color-border-blue` but can be themed independently.

## Why

Several components use a colored line/border to indicate the active or selected state. Currently they reach for different tokens inconsistently:

- **TabList** used `--color-icon-primary` (semantically wrong — it's not an icon)
- **Stepper** (PR #2308) uses `--color-accent`
- **Outline** (PR #2292) uses `--color-accent`

This token gives that visual pattern a proper semantic name, making it:
- Easier to understand intent when reading styles
- Independently themeable (e.g. a brand could use a different active indicator color without affecting all accents)
- Consistent across all position-indicator components

## Changes

1. **`packages/core/src/theme/tokens.stylex.ts`** — Added `--color-border-active` in the Border section
2. **`packages/core/src/TabList/XDSTab.tsx`** — Migrated `indicatorSelected` from `--color-icon-primary` → `--color-border-active`

## What's next

Stepper (#2308) and Outline (#2292) will consume this token after rebasing onto main.

## Token Naming Vibe Test

Discoverability test — "given a styling need, would a developer find and pick the right token?"

| # | Scenario | Expected | Alternatives dev might try | Verdict |
|---|----------|----------|---------------------------|---------|
| 1 | "I need a color for the underline under the currently selected tab" | `--color-border-active` | `--color-accent`, `--color-border-blue` | ✅ Strong — "active tab" → "border-active" is direct |
| 2 | "I'm styling the progress bar segments that show completed steps" | `--color-border-active` | `--color-accent`, `--color-success` | ⚠️ Medium — "completed" might lead to accent first, but obvious once seen |
| 3 | "I need the color for a 2px vertical bar that indicates which outline item is active" | `--color-border-active` | `--color-accent`, `--color-icon-primary` | ✅ Strong — "active" + "bar/border" maps directly |
| 4 | "I want the left accent bar color on the selected nav item" | `--color-border-active` | `--color-accent`, `--color-border-blue` | ✅ Strong — "selected" ≈ "active", accent bar = border |
| 5 | "I need a hover border color for an input field" | NOT this token | `--color-border-emphasized` | ✅ Correct exclusion — no confusion with input states |
| 6 | "I need the focus ring color for a button" | NOT this token | `--color-accent` | ✅ Correct exclusion — focus rings stay on accent |

**Result: 5/6 immediately intuitive, 0 false positives.**

The one medium case (stepper "completed" segments) is because "completed" doesn't immediately evoke "active" — but once a developer sees `--color-border-active` in the token list alongside `--color-border` and `--color-border-emphasized`, it's the obviously correct choice for any "line that shows position/state."