### PR TITLE
feat(docsite): reorganize side-nav — Foundations before Components, Themes after

### DIFF
--- a/apps/docsite/src/components/DocsShell.tsx
+++ b/apps/docsite/src/components/DocsShell.tsx
@@ -79,9 +79,7 @@ export function DocsShell({
   const allComponentHrefs = componentItems.flatMap(item =>
     item.type === 'entry' ? [item.href] : item.entries.map(e => e.href),
   );
-  const isInGuide =
-    guideTopics.some(d => pathname === `/docs/${d.topic}`) ||
-    foundationTopics.some(d => pathname === `/docs/${d.topic}`);
+  const isInGuide = guideTopics.some(d => pathname === `/docs/${d.topic}`);
   const isInFoundations = foundationTopics.some(
     d => pathname === `/docs/${d.topic}`,
   );
@@ -133,18 +131,6 @@ export function DocsShell({
                   isSelected={pathname === `/docs/${d.topic}`}
                 />
               ))}
-              <XDSSideNavItem
-                label="Foundations"
-                collapsible={{defaultIsCollapsed: !isInFoundations}}>
-                {foundationTopics.map(d => (
-                  <XDSSideNavItem
-                    key={d.topic}
-                    label={d.title}
-                    href={`/docs/${d.topic}`}
-                    isSelected={pathname === `/docs/${d.topic}`}
-                  />
-                ))}
-              </XDSSideNavItem>
             </XDSSideNavItem>
           </XDSSideNavSection>
 
@@ -166,19 +152,17 @@ export function DocsShell({
             </XDSSideNavItem>
           </XDSSideNavSection>
 
-          {/* Themes */}
-          <XDSSideNavSection title="Themes" isHeaderHidden>
+          {/* Foundations */}
+          <XDSSideNavSection title="Foundations" isHeaderHidden>
             <XDSSideNavItem
-              label="Themes"
-              collapsible={{defaultIsCollapsed: !isInThemes}}>
-              {themePackages.map(p => (
+              label="Foundations"
+              collapsible={{defaultIsCollapsed: !isInFoundations}}>
+              {foundationTopics.map(d => (
                 <XDSSideNavItem
-                  key={p.name}
-                  label={p.displayName}
-                  href={`/packages/${p.name.replace('@xds/', '')}`}
-                  isSelected={
-                    pathname === `/packages/${p.name.replace('@xds/', '')}`
-                  }
+                  key={d.topic}
+                  label={d.title}
+                  href={`/docs/${d.topic}`}
+                  isSelected={pathname === `/docs/${d.topic}`}
                 />
               ))}
             </XDSSideNavItem>
@@ -217,6 +201,24 @@ export function DocsShell({
                   </XDSSideNavItem>
                 ),
               )}
+            </XDSSideNavItem>
+          </XDSSideNavSection>
+
+          {/* Themes */}
+          <XDSSideNavSection title="Themes" isHeaderHidden>
+            <XDSSideNavItem
+              label="Themes"
+              collapsible={{defaultIsCollapsed: !isInThemes}}>
+              {themePackages.map(p => (
+                <XDSSideNavItem
+                  key={p.name}
+                  label={p.displayName}
+                  href={`/packages/${p.name.replace('@xds/', '')}`}
+                  isSelected={
+                    pathname === `/packages/${p.name.replace('@xds/', '')}`
+                  }
+                />
+              ))}
             </XDSSideNavItem>
           </XDSSideNavSection>
 

--- a/apps/docsite/src/components/DocsShell.tsx
+++ b/apps/docsite/src/components/DocsShell.tsx
@@ -134,6 +134,22 @@ export function DocsShell({
             </XDSSideNavItem>
           </XDSSideNavSection>
 
+          {/* Foundations */}
+          <XDSSideNavSection title="Foundations" isHeaderHidden>
+            <XDSSideNavItem
+              label="Foundations"
+              collapsible={{defaultIsCollapsed: !isInFoundations}}>
+              {foundationTopics.map(d => (
+                <XDSSideNavItem
+                  key={d.topic}
+                  label={d.title}
+                  href={`/docs/${d.topic}`}
+                  isSelected={pathname === `/docs/${d.topic}`}
+                />
+              ))}
+            </XDSSideNavItem>
+          </XDSSideNavSection>
+
           {/* Libraries */}
           <XDSSideNavSection title="Libraries" isHeaderHidden>
             <XDSSideNavItem
@@ -147,22 +163,6 @@ export function DocsShell({
                   isSelected={
                     pathname === `/packages/${p.name.replace('@xds/', '')}`
                   }
-                />
-              ))}
-            </XDSSideNavItem>
-          </XDSSideNavSection>
-
-          {/* Foundations */}
-          <XDSSideNavSection title="Foundations" isHeaderHidden>
-            <XDSSideNavItem
-              label="Foundations"
-              collapsible={{defaultIsCollapsed: !isInFoundations}}>
-              {foundationTopics.map(d => (
-                <XDSSideNavItem
-                  key={d.topic}
-                  label={d.title}
-                  href={`/docs/${d.topic}`}
-                  isSelected={pathname === `/docs/${d.topic}`}
                 />
               ))}
             </XDSSideNavItem>
@@ -204,24 +204,6 @@ export function DocsShell({
             </XDSSideNavItem>
           </XDSSideNavSection>
 
-          {/* Themes */}
-          <XDSSideNavSection title="Themes" isHeaderHidden>
-            <XDSSideNavItem
-              label="Themes"
-              collapsible={{defaultIsCollapsed: !isInThemes}}>
-              {themePackages.map(p => (
-                <XDSSideNavItem
-                  key={p.name}
-                  label={p.displayName}
-                  href={`/packages/${p.name.replace('@xds/', '')}`}
-                  isSelected={
-                    pathname === `/packages/${p.name.replace('@xds/', '')}`
-                  }
-                />
-              ))}
-            </XDSSideNavItem>
-          </XDSSideNavSection>
-
           {/* Utilities */}
           {utilities.length > 0 && (
             <XDSSideNavSection title="Utilities" isHeaderHidden>
@@ -239,6 +221,24 @@ export function DocsShell({
               </XDSSideNavItem>
             </XDSSideNavSection>
           )}
+
+          {/* Themes */}
+          <XDSSideNavSection title="Themes" isHeaderHidden>
+            <XDSSideNavItem
+              label="Themes"
+              collapsible={{defaultIsCollapsed: !isInThemes}}>
+              {themePackages.map(p => (
+                <XDSSideNavItem
+                  key={p.name}
+                  label={p.displayName}
+                  href={`/packages/${p.name.replace('@xds/', '')}`}
+                  isSelected={
+                    pathname === `/packages/${p.name.replace('@xds/', '')}`
+                  }
+                />
+              ))}
+            </XDSSideNavItem>
+          </XDSSideNavSection>
         </XDSSideNav>
       }>
       {children}


### PR DESCRIPTION
## Summary

Reorganizes the docsite side-nav per design feedback:

1. **Foundations** — moved out of the "Guide" collapsible and promoted to its own top-level collapsible section, placed directly before Components

2. **Themes** — moved to after Components in the side-nav

### Before
```
Documentation
What's New
Guide ▾
  Getting Started
  ...
  Foundations ▾ (nested inside Guide)
    Tokens, Colors, Typography, ...
Libraries ▾
Themes ▾
Components ▾
Utilities ▾
```

### After
```
Documentation
What's New
Guide ▾
  Getting Started
  ...
Libraries ▾
Foundations ▾
  Tokens, Colors, Typography, ...
Components ▾
Themes ▾
Utilities ▾
```
