### PR TITLE
feat(docsite): move Components to second position in top nav

### DIFF
--- a/apps/docsite/src/components/SharedTopNav.tsx
+++ b/apps/docsite/src/components/SharedTopNav.tsx
@@ -75,6 +75,11 @@ export function SharedTopNav() {
               isSelected={getActiveItem() === 'docs'}
             />
             <XDSTopNavItem
+              label="Components"
+              href="/components"
+              isSelected={getActiveItem() === 'components'}
+            />
+            <XDSTopNavItem
               label="Templates"
               href="/templates"
               isSelected={getActiveItem() === 'templates'}
@@ -83,11 +88,6 @@ export function SharedTopNav() {
               label="Themes"
               href="/themes"
               isSelected={getActiveItem() === 'themes'}
-            />
-            <XDSTopNavItem
-              label="Components"
-              href="/components"
-              isSelected={getActiveItem() === 'components'}
             />
             <XDSTopNavItem
               label="Playground"


### PR DESCRIPTION
## Summary

Reorders the top navigation so that **Components** is the second item, immediately after **Docs**.

### Before
Docs → Templates → Themes → Components → Playground

### After
Docs → **Components** → Templates → Themes → Playground
