### PR TITLE
feat(playground): content-aware editor with component/template/theme panels

### DIFF
--- a/apps/docsite/src/app/playground/PlaygroundClient.tsx
+++ b/apps/docsite/src/app/playground/PlaygroundClient.tsx
@@ -2,59 +2,23 @@
 
 'use client';
 
-import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
-import dynamic from 'next/dynamic';
-import * as stylex from '@stylexjs/stylex';
+import {useCallback, useEffect, useState} from 'react';
+import {useSearchParams} from 'next/navigation';
 import {
   compressToEncodedURIComponent,
   decompressFromEncodedURIComponent,
 } from 'lz-string';
-import {XDSButton} from '@xds/core/Button';
-import {XDSSelector} from '@xds/core/Selector';
-import {XDSHStack} from '@xds/core/Layout';
-import {XDSText} from '@xds/core/Text';
-import {XDSStatusDot} from '@xds/core/StatusDot';
-import {XDSDivider} from '@xds/core/Divider';
-import {useXDSResizable, XDSResizeHandle} from '@xds/core/Resizable';
-import githubLight from './themes/github-light.json';
-import githubDark from './themes/github-dark.json';
 
-import type * as MonacoTypes from 'monaco-editor';
-
-/** Monaco instance type — the full runtime object passed to onMount */
-type MonacoInstance = typeof MonacoTypes & {
-  languages: typeof MonacoTypes.languages & {
-    typescript: {
-      typescriptDefaults: {
-        setCompilerOptions: (options: Record<string, unknown>) => void;
-        setDiagnosticsOptions: (options: Record<string, unknown>) => void;
-        addExtraLib: (content: string, filePath: string) => void;
-      };
-      ScriptTarget: Record<string, number>;
-      ModuleKind: Record<string, number>;
-      JsxEmit: Record<string, number>;
-      ModuleResolutionKind: Record<string, number>;
-    };
-  };
-  editor: typeof MonacoTypes.editor & {
-    defineTheme: (name: string, data: Record<string, unknown>) => void;
-  };
-};
-
-const MonacoEditor = dynamic(() => import('@monaco-editor/react'), {
-  ssr: false,
-  loading: () => (
-    <div
-      style={{
-        flex: 1,
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-      }}>
-      <XDSText color="secondary">Loading editor…</XDSText>
-    </div>
-  ),
-});
+import {PlaygroundShell} from '../../components/playground/PlaygroundShell';
+import {PlaygroundPreview} from '../../components/playground/PlaygroundPreview';
+import {PlaygroundToolbar} from '../../components/playground/PlaygroundToolbar';
+import {ComponentEditorPanel} from '../../components/playground/ComponentEditorPanel';
+import {TemplateEditorPanel} from '../../components/playground/TemplateEditorPanel';
+import {ThemeEditorPanel} from '../../components/playground/theme/ThemeEditorPanel';
+import {
+  detectContentType,
+  type ContentType,
+} from '../../components/playground/contentTypeDetector';
 
 const DEFAULT_CODE = `import {
   XDSButton,
@@ -115,210 +79,15 @@ function updateURL(code: string) {
   window.history.replaceState(null, '', `#code=${compressed}`);
 }
 
-const THEME_OPTIONS = [
-  {value: 'default', label: 'Default'},
-  {value: 'neutral', label: 'Neutral'},
-  {value: 'daily', label: 'Daily'},
-  {value: 'matcha', label: 'Matcha'},
-];
-
-/**
- * Configure Monaco's TypeScript service with real XDS type definitions.
- * Loads .d.ts files from a pre-built JSON bundle (generated at build time).
- */
-function configureMonaco(monaco: MonacoInstance) {
-  const ts = monaco.languages.typescript.typescriptDefaults;
-
-  ts.setCompilerOptions({
-    target: monaco.languages.typescript.ScriptTarget.ESNext,
-    module: monaco.languages.typescript.ModuleKind.ESNext,
-    jsx: monaco.languages.typescript.JsxEmit.ReactJSX,
-    esModuleInterop: true,
-    allowSyntheticDefaultImports: true,
-    moduleResolution: monaco.languages.typescript.ModuleResolutionKind.NodeJs,
-    allowJs: true,
-    strict: false,
-  });
-
-  ts.setDiagnosticsOptions({
-    noSemanticValidation: true,
-    noSyntaxValidation: false,
-  });
-
-  // Global declarations for React hooks (available without import in playground)
-  ts.addExtraLib(
-    `declare function useState<T>(init: T | (() => T)): [T, (v: T | ((prev: T) => T)) => void];
-    declare function useEffect(fn: () => void | (() => void), deps?: readonly unknown[]): void;
-    declare function useCallback<T extends Function>(fn: T, deps: readonly unknown[]): T;
-    declare function useMemo<T>(fn: () => T, deps: readonly unknown[]): T;
-    declare function useRef<T>(init: T): { current: T };
-    declare function useReducer<S, A>(reducer: (state: S, action: A) => S, init: S): [S, (action: A) => void];
-    declare function useContext<T>(ctx: unknown): T;`,
-    'file:///globals.d.ts',
-  );
-
-  // Heroicons wildcard stub
-  ts.addExtraLib(
-    `declare module '@heroicons/react/16/solid' { const icons: Record<string, React.ComponentType<{width?: number; height?: number; className?: string}>>; export = icons; }
-    declare module '@heroicons/react/20/solid' { const icons: Record<string, React.ComponentType<{width?: number; height?: number; className?: string}>>; export = icons; }
-    declare module '@heroicons/react/24/outline' { const icons: Record<string, React.ComponentType<{width?: number; height?: number; className?: string}>>; export = icons; }
-    declare module '@heroicons/react/24/solid' { const icons: Record<string, React.ComponentType<{width?: number; height?: number; className?: string}>>; export = icons; }`,
-    'file:///node_modules/@heroicons/react/index.d.ts',
-  );
-
-  // Load real type definitions from the pre-built JSON bundle
-  fetch('/playground-types.json')
-    .then(r => r.json())
-    .then((packages: Record<string, Record<string, string>>) => {
-      // React types
-      const reactFiles = packages['react'] ?? {};
-      for (const [fileName, content] of Object.entries(reactFiles)) {
-        ts.addExtraLib(
-          content,
-          `file:///node_modules/@types/react/${fileName}`,
-        );
-      }
-
-      // StyleX types
-      const stylexFiles = packages['@stylexjs/stylex'] ?? {};
-      for (const [fileName, content] of Object.entries(stylexFiles)) {
-        ts.addExtraLib(
-          content,
-          `file:///node_modules/@stylexjs/stylex/${fileName}`,
-        );
-      }
-
-      // XDS core types — register each .d.ts under its dist path AND subpath
-      const xdsFiles = packages['@xds/core'] ?? {};
-      const submoduleReexports: string[] = [];
-
-      for (const [relPath, content] of Object.entries(xdsFiles)) {
-        ts.addExtraLib(
-          content,
-          `file:///node_modules/@xds/core/dist/${relPath}`,
-        );
-
-        // Also register as @xds/core/<SubModule>/index.d.ts
-        if (relPath.endsWith('/index.d.ts')) {
-          const moduleName = relPath.replace('/index.d.ts', '');
-          ts.addExtraLib(
-            content,
-            `file:///node_modules/@xds/core/${moduleName}/index.d.ts`,
-          );
-          submoduleReexports.push(moduleName);
-        }
-      }
-
-      // Build @xds/core barrel from submodule re-exports
-      const barrelContent = submoduleReexports
-        .map(m => `export * from '@xds/core/${m}';`)
-        .join('\n');
-      ts.addExtraLib(
-        `declare module '@xds/core' {\n${barrelContent}\n}`,
-        'file:///node_modules/@xds/core/index.d.ts',
-      );
-
-      // Types loaded — enable semantic validation
-      ts.setDiagnosticsOptions({
-        noSemanticValidation: false,
-        noSyntaxValidation: false,
-      });
-    })
-    .catch(() => {
-      // Types unavailable — keep semantic validation disabled
-    });
-}
-
-const s = stylex.create({
-  root: {
-    display: 'flex',
-    flexDirection: 'column',
-    height: '100%',
-    overflow: 'hidden',
-  },
-  toolbar: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    paddingInline: 16,
-    paddingBlock: 6,
-    flexShrink: 0,
-  },
-  main: {
-    display: 'flex',
-    flex: 1,
-    minHeight: 0,
-    flexDirection: {
-      default: 'row',
-      '@media (max-width: 768px)': 'column',
-    },
-  },
-  editorPane: {
-    display: 'flex',
-    flexDirection: 'column',
-    flexShrink: 0,
-    minWidth: 0,
-    minHeight: {
-      default: 0,
-      '@media (max-width: 768px)': 300,
-    },
-  },
-  previewPane: {
-    flex: 1,
-    display: 'flex',
-    flexDirection: 'column',
-    minWidth: 0,
-    minHeight: {
-      default: 0,
-      '@media (max-width: 768px)': 300,
-    },
-  },
-  iframe: {
-    flex: 1,
-    border: 'none',
-    width: '100%',
-    height: '100%',
-  },
-  previewBar: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    paddingInline: 12,
-    paddingBlock: 6,
-    flexShrink: 0,
-  },
-});
-
 export function PlaygroundClient() {
+  const searchParams = useSearchParams();
   const [code, setCode] = useState(getInitialCode);
   const [theme, setTheme] = useState('default');
-  const [copied, setCopied] = useState(false);
   const [previewReady, setPreviewReady] = useState(false);
   const [previewError, setPreviewError] = useState<string | null>(null);
-  const iframeRef = useRef<HTMLIFrameElement>(null);
-  const readyRef = useRef(false);
-  const pendingRef = useRef<string | null>(null);
-  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const editorPanel = useXDSResizable({
-    defaultSize: '50%',
-    minSizePx: 200,
-    collapsible: true,
-    snaps: [400, 600],
-    autoSaveId: 'xds-playground-editor-width',
-  });
-
-  const [editorTheme, setEditorTheme] = useState('github-dark');
-
-  // Sync editor theme with system preference
-  useEffect(() => {
-    const mq = window.matchMedia('(prefers-color-scheme: dark)');
-    const update = () =>
-      setEditorTheme(mq.matches ? 'github-dark' : 'github-light');
-    update();
-    mq.addEventListener('change', update);
-    return () => mq.removeEventListener('change', update);
-  }, []);
+  // Detect content type from URL params and code
+  const contentType: ContentType = detectContentType(code, searchParams);
 
   // Re-read code from hash on hashchange (e.g. SPA navigation with new code)
   useEffect(() => {
@@ -332,215 +101,59 @@ export function PlaygroundClient() {
     return () => window.removeEventListener('hashchange', onHashChange);
   }, []);
 
-  const send = useCallback((c: string) => {
-    const win = iframeRef.current?.contentWindow;
-    if (!win) {
-      return;
-    }
-    win.postMessage(
-      c ? {type: 'preview-code', code: c} : {type: 'preview-clear'},
-      window.location.origin,
-    );
-  }, []);
-
+  // Update URL when code changes
   useEffect(() => {
-    const handler = (e: MessageEvent) => {
-      if (e.source !== iframeRef.current?.contentWindow) {
-        return;
-      }
-      if (e.data?.type === 'preview-ready') {
-        readyRef.current = true;
-        setPreviewReady(true);
-        if (pendingRef.current != null) {
-          send(pendingRef.current);
-          pendingRef.current = null;
-        }
-      }
-      if (e.data?.type === 'preview-rendered') {
-        setPreviewError(null);
-      }
-      if (e.data?.type === 'preview-error') {
-        setPreviewError(e.data.message ?? 'Unknown error');
-      }
-    };
-    window.addEventListener('message', handler);
-    return () => window.removeEventListener('message', handler);
-  }, [send]);
-
-  useEffect(() => {
-    const interval = setInterval(() => {
-      if (readyRef.current) {
-        clearInterval(interval);
-        return;
-      }
-      iframeRef.current?.contentWindow?.postMessage(
-        {type: 'preview-ping'},
-        window.location.origin,
-      );
-    }, 300);
-    return () => clearInterval(interval);
-  }, []);
-
-  useEffect(() => {
-    if (debounceRef.current) {
-      clearTimeout(debounceRef.current);
-    }
-    debounceRef.current = setTimeout(() => {
-      if (!readyRef.current) {
-        pendingRef.current = code;
-      } else {
-        send(code);
-      }
+    const timer = setTimeout(() => {
       updateURL(code);
     }, 400);
-    return () => {
-      if (debounceRef.current) {
-        clearTimeout(debounceRef.current);
-      }
-    };
-  }, [code, send]);
-
-  useEffect(() => {
-    iframeRef.current?.contentWindow?.postMessage(
-      {type: 'preview-theme', theme},
-      window.location.origin,
-    );
-  }, [theme]);
+    return () => clearTimeout(timer);
+  }, [code]);
 
   const handleShare = useCallback(() => {
-    navigator.clipboard.writeText(window.location.href).then(() => {
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    });
+    navigator.clipboard.writeText(window.location.href);
   }, []);
 
-  const handleMonacoBeforeMount = useCallback((monaco: MonacoInstance) => {
-    // Register themes before editor renders so initial theme applies
-    monaco.editor.defineTheme('github-light', githubLight);
-    monaco.editor.defineTheme('github-dark', githubDark);
+  const handleReset = useCallback(() => {
+    setCode(DEFAULT_CODE);
   }, []);
 
-  const handleMonacoMount = useCallback(
-    (_editor: unknown, monaco: MonacoInstance) => {
-      configureMonaco(monaco);
-    },
-    [],
-  );
-
-  const isMobile = typeof window !== 'undefined' && window.innerWidth <= 768;
-
-  const editorOptions = useMemo(
-    () => ({
-      minimap: {enabled: false},
-      fontSize: isMobile ? 16 : 13,
-      lineNumbers: 'on' as const,
-      scrollBeyondLastLine: false,
-      automaticLayout: true,
-      tabSize: 2,
-      wordWrap: 'on' as const,
-      padding: {top: 12},
-      accessibilitySupport: 'off' as const,
-    }),
-    [isMobile],
-  );
+  // Render the appropriate editor panel based on content type
+  const renderEditorPanel = () => {
+    switch (contentType) {
+      case 'template':
+        return <TemplateEditorPanel code={code} onChange={setCode} />;
+      case 'theme':
+        return <ThemeEditorPanel code={code} onChange={setCode} />;
+      case 'component':
+      default:
+        return <ComponentEditorPanel code={code} onChange={setCode} />;
+    }
+  };
 
   return (
-    <div {...stylex.props(s.root)}>
-      <div {...stylex.props(s.toolbar)}>
-        <XDSHStack gap={8} align="center">
-          <XDSStatusDot
-            variant={
-              previewError ? 'error' : previewReady ? 'success' : 'warning'
-            }
-            label={previewError ? 'Error' : previewReady ? 'Ready' : 'Loading'}
+    <>
+      <PlaygroundShell
+        toolbar={
+          <PlaygroundToolbar
+            previewReady={previewReady}
+            previewError={previewError}
+            theme={theme}
+            onThemeChange={setTheme}
+            onReset={handleReset}
+            onShare={handleShare}
+            contentType={contentType}
           />
-          <XDSText color="secondary" type="supporting">
-            {previewError ? 'Error' : previewReady ? 'Ready' : 'Loading…'}
-          </XDSText>
-        </XDSHStack>
-        <XDSHStack gap={4} align="center">
-          <XDSSelector
-            label="Theme"
-            isLabelHidden
-            options={THEME_OPTIONS}
-            value={theme}
-            onChange={setTheme}
-            size="sm"
+        }
+        leftPanel={renderEditorPanel()}
+        rightPanel={
+          <PlaygroundPreview
+            code={code}
+            theme={theme}
+            onError={setPreviewError}
+            onReady={() => setPreviewReady(true)}
           />
-          <XDSButton
-            label="Reset"
-            variant="ghost"
-            size="sm"
-            onClick={() => setCode(DEFAULT_CODE)}
-          />
-          <XDSButton
-            label={copied ? '✓ Copied!' : 'Copy Link'}
-            variant={copied ? 'primary' : 'secondary'}
-            size="sm"
-            onClick={handleShare}
-          />
-        </XDSHStack>
-      </div>
-      <XDSDivider />
-      <div {...stylex.props(s.main)}>
-        <div
-          {...stylex.props(s.editorPane)}
-          style={
-            isMobile ? {height: editorPanel.size} : {width: editorPanel.size}
-          }>
-          <MonacoEditor
-            defaultLanguage="typescript"
-            defaultValue={code}
-            path="playground.tsx"
-            theme={editorTheme}
-            onChange={v => setCode(v ?? '')}
-            beforeMount={handleMonacoBeforeMount}
-            onMount={handleMonacoMount}
-            options={editorOptions}
-          />
-        </div>
-        <XDSResizeHandle
-          label="Resize editor panel"
-          direction={isMobile ? 'vertical' : 'horizontal'}
-          hasDivider
-          pillPlacement={isMobile ? 'end' : 'auto'}
-          resizable={editorPanel.props}
-        />
-        <div {...stylex.props(s.previewPane)}>
-          <div {...stylex.props(s.previewBar)}>
-            <XDSText color="secondary" type="supporting">
-              Preview
-            </XDSText>
-            <XDSText color="disabled" type="supporting">
-              {theme.charAt(0).toUpperCase() + theme.slice(1)}
-            </XDSText>
-          </div>
-          <XDSDivider />
-          <iframe
-            ref={iframeRef}
-            src="/playground-preview"
-            sandbox="allow-scripts allow-same-origin"
-            title="Preview"
-            {...stylex.props(s.iframe)}
-          />
-        </div>
-      </div>
-      {previewError && (
-        <>
-          <XDSDivider />
-          <div style={{padding: '8px 16px', maxHeight: 120, overflow: 'auto'}}>
-            <XDSText type="code" color="inherit">
-              <span
-                style={{
-                  color: 'var(--color-text-error, #ef4444)',
-                  whiteSpace: 'pre-wrap',
-                }}>
-                {previewError}
-              </span>
-            </XDSText>
-          </div>
-        </>
-      )}
-    </div>
+        }
+      />
+    </>
   );
 }

--- a/apps/docsite/src/app/playground/page.tsx
+++ b/apps/docsite/src/app/playground/page.tsx
@@ -1,5 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+import {Suspense} from 'react';
 import type {Metadata} from 'next';
 import {PlaygroundClient} from './PlaygroundClient';
 
@@ -9,5 +10,9 @@ export const metadata: Metadata = {
 };
 
 export default function PlaygroundPage() {
-  return <PlaygroundClient />;
+  return (
+    <Suspense>
+      <PlaygroundClient />
+    </Suspense>
+  );
 }

--- a/apps/docsite/src/components/playground/ComponentEditorPanel.tsx
+++ b/apps/docsite/src/components/playground/ComponentEditorPanel.tsx
@@ -1,0 +1,106 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import {useMemo, useState} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {XDSText, XDSHeading} from '@xds/core/Text';
+import {XDSVStack} from '@xds/core/Layout';
+import {XDSButton} from '@xds/core/Button';
+import {PlaygroundCodeEditor} from './PlaygroundCodeEditor';
+import {detectComponentName} from './contentTypeDetector';
+
+const s = stylex.create({
+  root: {
+    display: 'flex',
+    flexDirection: 'column',
+    flex: 1,
+    minHeight: 0,
+  },
+  tabs: {
+    display: 'flex',
+    gap: 0,
+    borderBottom: '1px solid var(--color-border-default, #e5e5e5)',
+    flexShrink: 0,
+  },
+  tab: {
+    paddingInline: 16,
+    paddingBlock: 8,
+    cursor: 'pointer',
+    border: 'none',
+    background: 'none',
+    fontSize: 13,
+    fontWeight: 500,
+    color: 'var(--color-text-secondary)',
+    borderBottom: '2px solid transparent',
+    transition: 'color 0.15s, border-color 0.15s',
+  },
+  tabActive: {
+    color: 'var(--color-text-primary)',
+    borderBottomColor: 'var(--color-border-focus, #0066ff)',
+  },
+  content: {
+    display: 'flex',
+    flex: 1,
+    minHeight: 0,
+  },
+  placeholder: {
+    flex: 1,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 32,
+  },
+});
+
+interface ComponentEditorPanelProps {
+  code: string;
+  onChange: (code: string) => void;
+}
+
+export function ComponentEditorPanel({
+  code,
+  onChange,
+}: ComponentEditorPanelProps) {
+  const [activeTab, setActiveTab] = useState<'code' | 'properties'>('code');
+  const componentName = useMemo(() => detectComponentName(code), [code]);
+
+  return (
+    <div {...stylex.props(s.root)}>
+      <div {...stylex.props(s.tabs)}>
+        <button
+          {...stylex.props(s.tab, activeTab === 'code' && s.tabActive)}
+          onClick={() => setActiveTab('code')}>
+          Code
+        </button>
+        <button
+          {...stylex.props(s.tab, activeTab === 'properties' && s.tabActive)}
+          onClick={() => setActiveTab('properties')}>
+          Properties
+        </button>
+      </div>
+      <div {...stylex.props(s.content)}>
+        {activeTab === 'code' ? (
+          <PlaygroundCodeEditor value={code} onChange={onChange} />
+        ) : (
+          <div {...stylex.props(s.placeholder)}>
+            <XDSVStack gap={4} hAlign="center">
+              <XDSHeading level={4}>
+                {componentName ? `XDS${componentName}` : 'Component'} Properties
+              </XDSHeading>
+              <XDSText color="secondary">
+                Interactive property controls coming soon.
+                {componentName && (
+                  <>
+                    {' '}
+                    Visit the component detail page for interactive controls.
+                  </>
+                )}
+              </XDSText>
+            </XDSVStack>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/docsite/src/components/playground/PlaygroundCodeEditor.tsx
+++ b/apps/docsite/src/components/playground/PlaygroundCodeEditor.tsx
@@ -1,0 +1,209 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import {useCallback, useEffect, useMemo, useState} from 'react';
+import dynamic from 'next/dynamic';
+import * as stylex from '@stylexjs/stylex';
+import {XDSText} from '@xds/core/Text';
+import githubLight from '../../app/playground/themes/github-light.json';
+import githubDark from '../../app/playground/themes/github-dark.json';
+
+import type * as MonacoTypes from 'monaco-editor';
+
+type MonacoInstance = typeof MonacoTypes & {
+  languages: typeof MonacoTypes.languages & {
+    typescript: {
+      typescriptDefaults: {
+        setCompilerOptions: (options: Record<string, unknown>) => void;
+        setDiagnosticsOptions: (options: Record<string, unknown>) => void;
+        addExtraLib: (content: string, filePath: string) => void;
+      };
+      ScriptTarget: Record<string, number>;
+      ModuleKind: Record<string, number>;
+      JsxEmit: Record<string, number>;
+      ModuleResolutionKind: Record<string, number>;
+    };
+  };
+  editor: typeof MonacoTypes.editor & {
+    defineTheme: (name: string, data: Record<string, unknown>) => void;
+  };
+};
+
+const MonacoEditor = dynamic(() => import('@monaco-editor/react'), {
+  ssr: false,
+  loading: () => (
+    <div {...stylex.props(s.loading)}>
+      <XDSText color="secondary">Loading editor\u2026</XDSText>
+    </div>
+  ),
+});
+
+const s = stylex.create({
+  root: {
+    display: 'flex',
+    flex: 1,
+    minHeight: 0,
+  },
+  loading: {
+    flex: 1,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});
+
+function configureMonaco(monaco: MonacoInstance) {
+  const ts = monaco.languages.typescript.typescriptDefaults;
+
+  ts.setCompilerOptions({
+    target: monaco.languages.typescript.ScriptTarget.ESNext,
+    module: monaco.languages.typescript.ModuleKind.ESNext,
+    jsx: monaco.languages.typescript.JsxEmit.ReactJSX,
+    esModuleInterop: true,
+    allowSyntheticDefaultImports: true,
+    moduleResolution: monaco.languages.typescript.ModuleResolutionKind.NodeJs,
+    allowJs: true,
+    strict: false,
+  });
+
+  ts.setDiagnosticsOptions({
+    noSemanticValidation: true,
+    noSyntaxValidation: false,
+  });
+
+  ts.addExtraLib(
+    `declare function useState<T>(init: T | (() => T)): [T, (v: T | ((prev: T) => T)) => void];
+    declare function useEffect(fn: () => void | (() => void), deps?: readonly unknown[]): void;
+    declare function useCallback<T extends Function>(fn: T, deps: readonly unknown[]): T;
+    declare function useMemo<T>(fn: () => T, deps: readonly unknown[]): T;
+    declare function useRef<T>(init: T): { current: T };
+    declare function useReducer<S, A>(reducer: (state: S, action: A) => S, init: S): [S, (action: A) => void];
+    declare function useContext<T>(ctx: unknown): T;`,
+    'file:///globals.d.ts',
+  );
+
+  ts.addExtraLib(
+    `declare module '@heroicons/react/16/solid' { const icons: Record<string, React.ComponentType<{width?: number; height?: number; className?: string}>>; export = icons; }
+    declare module '@heroicons/react/20/solid' { const icons: Record<string, React.ComponentType<{width?: number; height?: number; className?: string}>>; export = icons; }
+    declare module '@heroicons/react/24/outline' { const icons: Record<string, React.ComponentType<{width?: number; height?: number; className?: string}>>; export = icons; }
+    declare module '@heroicons/react/24/solid' { const icons: Record<string, React.ComponentType<{width?: number; height?: number; className?: string}>>; export = icons; }`,
+    'file:///node_modules/@heroicons/react/index.d.ts',
+  );
+
+  fetch('/playground-types.json')
+    .then(r => r.json())
+    .then((packages: Record<string, Record<string, string>>) => {
+      const reactFiles = packages['react'] ?? {};
+      for (const [fileName, content] of Object.entries(reactFiles)) {
+        ts.addExtraLib(
+          content,
+          `file:///node_modules/@types/react/${fileName}`,
+        );
+      }
+
+      const stylexFiles = packages['@stylexjs/stylex'] ?? {};
+      for (const [fileName, content] of Object.entries(stylexFiles)) {
+        ts.addExtraLib(
+          content,
+          `file:///node_modules/@stylexjs/stylex/${fileName}`,
+        );
+      }
+
+      const xdsFiles = packages['@xds/core'] ?? {};
+      const submoduleReexports: string[] = [];
+      for (const [relPath, content] of Object.entries(xdsFiles)) {
+        ts.addExtraLib(
+          content,
+          `file:///node_modules/@xds/core/dist/${relPath}`,
+        );
+        if (relPath.endsWith('/index.d.ts')) {
+          const moduleName = relPath.replace('/index.d.ts', '');
+          ts.addExtraLib(
+            content,
+            `file:///node_modules/@xds/core/${moduleName}/index.d.ts`,
+          );
+          submoduleReexports.push(moduleName);
+        }
+      }
+
+      const barrelContent = submoduleReexports
+        .map(m => `export * from '@xds/core/${m}';`)
+        .join('\n');
+      ts.addExtraLib(
+        `declare module '@xds/core' {\n${barrelContent}\n}`,
+        'file:///node_modules/@xds/core/index.d.ts',
+      );
+
+      ts.setDiagnosticsOptions({
+        noSemanticValidation: false,
+        noSyntaxValidation: false,
+      });
+    })
+    .catch(() => {});
+}
+
+interface PlaygroundCodeEditorProps {
+  value: string;
+  onChange: (code: string) => void;
+}
+
+export function PlaygroundCodeEditor({
+  value,
+  onChange,
+}: PlaygroundCodeEditorProps) {
+  const [editorTheme, setEditorTheme] = useState('github-dark');
+
+  useEffect(() => {
+    const mq = window.matchMedia('(prefers-color-scheme: dark)');
+    const update = () =>
+      setEditorTheme(mq.matches ? 'github-dark' : 'github-light');
+    update();
+    mq.addEventListener('change', update);
+    return () => mq.removeEventListener('change', update);
+  }, []);
+
+  const handleBeforeMount = useCallback((monaco: MonacoInstance) => {
+    monaco.editor.defineTheme('github-light', githubLight);
+    monaco.editor.defineTheme('github-dark', githubDark);
+  }, []);
+
+  const handleMount = useCallback(
+    (_editor: unknown, monaco: MonacoInstance) => {
+      configureMonaco(monaco);
+    },
+    [],
+  );
+
+  const isMobile = typeof window !== 'undefined' && window.innerWidth <= 768;
+
+  const options = useMemo(
+    () => ({
+      minimap: {enabled: false},
+      fontSize: isMobile ? 16 : 13,
+      lineNumbers: 'on' as const,
+      scrollBeyondLastLine: false,
+      automaticLayout: true,
+      tabSize: 2,
+      wordWrap: 'on' as const,
+      padding: {top: 12},
+      accessibilitySupport: 'off' as const,
+    }),
+    [isMobile],
+  );
+
+  return (
+    <div {...stylex.props(s.root)}>
+      <MonacoEditor
+        defaultLanguage="typescript"
+        defaultValue={value}
+        path="playground.tsx"
+        theme={editorTheme}
+        onChange={v => onChange(v ?? '')}
+        beforeMount={handleBeforeMount}
+        onMount={handleMount}
+        options={options}
+      />
+    </div>
+  );
+}

--- a/apps/docsite/src/components/playground/PlaygroundPreview.tsx
+++ b/apps/docsite/src/components/playground/PlaygroundPreview.tsx
@@ -1,0 +1,167 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import {useCallback, useEffect, useRef, useState} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {XDSText} from '@xds/core/Text';
+import {XDSDivider} from '@xds/core/Divider';
+
+const s = stylex.create({
+  root: {
+    display: 'flex',
+    flexDirection: 'column',
+    flex: 1,
+    minHeight: 0,
+  },
+  bar: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingInline: 12,
+    paddingBlock: 6,
+    flexShrink: 0,
+  },
+  iframe: {
+    flex: 1,
+    border: 'none',
+    width: '100%',
+    height: '100%',
+  },
+  error: {
+    padding: '8px 16px',
+    maxHeight: 120,
+    overflow: 'auto',
+  },
+});
+
+interface PlaygroundPreviewProps {
+  code: string;
+  theme: string;
+  onError?: (msg: string | null) => void;
+  onReady?: () => void;
+}
+
+export function PlaygroundPreview({
+  code,
+  theme,
+  onError,
+  onReady,
+}: PlaygroundPreviewProps) {
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const readyRef = useRef(false);
+  const pendingRef = useRef<string | null>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [previewReady, setPreviewReady] = useState(false);
+  const [previewError, setPreviewError] = useState<string | null>(null);
+
+  const send = useCallback((c: string) => {
+    const win = iframeRef.current?.contentWindow;
+    if (!win) {return;}
+    win.postMessage(
+      c ? {type: 'preview-code', code: c} : {type: 'preview-clear'},
+      window.location.origin,
+    );
+  }, []);
+
+  useEffect(() => {
+    const handler = (e: MessageEvent) => {
+      if (e.source !== iframeRef.current?.contentWindow) {return;}
+      if (e.data?.type === 'preview-ready') {
+        readyRef.current = true;
+        setPreviewReady(true);
+        onReady?.();
+        if (pendingRef.current != null) {
+          send(pendingRef.current);
+          pendingRef.current = null;
+        }
+      }
+      if (e.data?.type === 'preview-rendered') {
+        setPreviewError(null);
+        onError?.(null);
+      }
+      if (e.data?.type === 'preview-error') {
+        const msg = e.data.message ?? 'Unknown error';
+        setPreviewError(msg);
+        onError?.(msg);
+      }
+    };
+    window.addEventListener('message', handler);
+    return () => window.removeEventListener('message', handler);
+  }, [send, onReady, onError]);
+
+  // Ping until ready
+  useEffect(() => {
+    const interval = setInterval(() => {
+      if (readyRef.current) {
+        clearInterval(interval);
+        return;
+      }
+      iframeRef.current?.contentWindow?.postMessage(
+        {type: 'preview-ping'},
+        window.location.origin,
+      );
+    }, 300);
+    return () => clearInterval(interval);
+  }, []);
+
+  // Send code on change (debounced)
+  useEffect(() => {
+    if (debounceRef.current) {clearTimeout(debounceRef.current);}
+    debounceRef.current = setTimeout(() => {
+      if (!readyRef.current) {
+        pendingRef.current = code;
+      } else {
+        send(code);
+      }
+    }, 400);
+    return () => {
+      if (debounceRef.current) {clearTimeout(debounceRef.current);}
+    };
+  }, [code, send]);
+
+  // Send theme changes
+  useEffect(() => {
+    iframeRef.current?.contentWindow?.postMessage(
+      {type: 'preview-theme', theme},
+      window.location.origin,
+    );
+  }, [theme]);
+
+  return (
+    <div {...stylex.props(s.root)}>
+      <div {...stylex.props(s.bar)}>
+        <XDSText color="secondary" type="supporting">
+          Preview
+        </XDSText>
+        <XDSText color="disabled" type="supporting">
+          {theme.charAt(0).toUpperCase() + theme.slice(1)}
+        </XDSText>
+      </div>
+      <XDSDivider />
+      <iframe
+        ref={iframeRef}
+        src="/playground-preview"
+        sandbox="allow-scripts allow-same-origin"
+        title="Preview"
+        {...stylex.props(s.iframe)}
+      />
+      {previewError && (
+        <>
+          <XDSDivider />
+          <div {...stylex.props(s.error)}>
+            <XDSText type="code" color="inherit">
+              <span
+                style={{
+                  color: 'var(--color-text-error, #ef4444)',
+                  whiteSpace: 'pre-wrap',
+                }}>
+                {previewError}
+              </span>
+            </XDSText>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/docsite/src/components/playground/PlaygroundShell.tsx
+++ b/apps/docsite/src/components/playground/PlaygroundShell.tsx
@@ -1,0 +1,92 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import {type ReactNode} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {useXDSResizable, XDSResizeHandle} from '@xds/core/Resizable';
+import {XDSDivider} from '@xds/core/Divider';
+
+const s = stylex.create({
+  root: {
+    display: 'flex',
+    flexDirection: 'column',
+    height: '100%',
+    overflow: 'hidden',
+  },
+  main: {
+    display: 'flex',
+    flex: 1,
+    minHeight: 0,
+    flexDirection: {
+      default: 'row',
+      '@media (max-width: 768px)': 'column',
+    },
+  },
+  leftPane: {
+    display: 'flex',
+    flexDirection: 'column',
+    flexShrink: 0,
+    minWidth: 0,
+    minHeight: {
+      default: 0,
+      '@media (max-width: 768px)': 300,
+    },
+  },
+  rightPane: {
+    flex: 1,
+    display: 'flex',
+    flexDirection: 'column',
+    minWidth: 0,
+    minHeight: {
+      default: 0,
+      '@media (max-width: 768px)': 300,
+    },
+  },
+});
+
+interface PlaygroundShellProps {
+  toolbar?: ReactNode;
+  leftPanel: ReactNode;
+  rightPanel: ReactNode;
+}
+
+export function PlaygroundShell({
+  toolbar,
+  leftPanel,
+  rightPanel,
+}: PlaygroundShellProps) {
+  const editorPanel = useXDSResizable({
+    defaultSize: '50%',
+    minSizePx: 200,
+    collapsible: true,
+    snaps: [400, 600],
+    autoSaveId: 'xds-playground-editor-width',
+  });
+
+  const isMobile = typeof window !== 'undefined' && window.innerWidth <= 768;
+
+  return (
+    <div {...stylex.props(s.root)}>
+      {toolbar}
+      <XDSDivider />
+      <div {...stylex.props(s.main)}>
+        <div
+          {...stylex.props(s.leftPane)}
+          style={
+            isMobile ? {height: editorPanel.size} : {width: editorPanel.size}
+          }>
+          {leftPanel}
+        </div>
+        <XDSResizeHandle
+          label="Resize editor panel"
+          direction={isMobile ? 'vertical' : 'horizontal'}
+          hasDivider
+          pillPlacement={isMobile ? 'end' : 'auto'}
+          resizable={editorPanel.props}
+        />
+        <div {...stylex.props(s.rightPane)}>{rightPanel}</div>
+      </div>
+    </div>
+  );
+}

--- a/apps/docsite/src/components/playground/PlaygroundToolbar.tsx
+++ b/apps/docsite/src/components/playground/PlaygroundToolbar.tsx
@@ -1,0 +1,101 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import {useState, useCallback} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {XDSButton} from '@xds/core/Button';
+import {XDSSelector} from '@xds/core/Selector';
+import {XDSHStack} from '@xds/core/Layout';
+import {XDSText} from '@xds/core/Text';
+import {XDSStatusDot} from '@xds/core/StatusDot';
+import {XDSBadge} from '@xds/core/Badge';
+import type {ContentType} from './contentTypeDetector';
+
+const s = stylex.create({
+  root: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingInline: 16,
+    paddingBlock: 6,
+    flexShrink: 0,
+  },
+});
+
+const THEME_OPTIONS = [
+  {value: 'default', label: 'Default'},
+  {value: 'neutral', label: 'Neutral'},
+  {value: 'daily', label: 'Daily'},
+  {value: 'matcha', label: 'Matcha'},
+];
+
+const TYPE_LABELS: Record<ContentType, string> = {
+  component: 'Component',
+  template: 'Template',
+  theme: 'Theme',
+};
+
+interface PlaygroundToolbarProps {
+  previewReady: boolean;
+  previewError: string | null;
+  theme: string;
+  onThemeChange: (theme: string) => void;
+  onReset: () => void;
+  onShare: () => void;
+  contentType: ContentType;
+}
+
+export function PlaygroundToolbar({
+  previewReady,
+  previewError,
+  theme,
+  onThemeChange,
+  onReset,
+  onShare,
+  contentType,
+}: PlaygroundToolbarProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleShare = useCallback(() => {
+    onShare();
+    navigator.clipboard.writeText(window.location.href).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }, [onShare]);
+
+  return (
+    <div {...stylex.props(s.root)}>
+      <XDSHStack gap={8} align="center">
+        <XDSStatusDot
+          variant={
+            previewError ? 'error' : previewReady ? 'success' : 'warning'
+          }
+          label={previewError ? 'Error' : previewReady ? 'Ready' : 'Loading'}
+        />
+        <XDSText color="secondary" type="supporting">
+          {previewError ? 'Error' : previewReady ? 'Ready' : 'Loading\u2026'}
+        </XDSText>
+        <XDSBadge variant="neutral" label={TYPE_LABELS[contentType]} />
+      </XDSHStack>
+      <XDSHStack gap={4} align="center">
+        <XDSSelector
+          label="Theme"
+          isLabelHidden
+          options={THEME_OPTIONS}
+          value={theme}
+          onChange={onThemeChange}
+          size="sm"
+        />
+        <XDSButton label="Reset" variant="ghost" size="sm" onClick={onReset} />
+        <XDSButton
+          label={copied ? '\u2713 Copied!' : 'Copy Link'}
+          variant={copied ? 'primary' : 'secondary'}
+          size="sm"
+          onClick={handleShare}
+        />
+      </XDSHStack>
+    </div>
+  );
+}

--- a/apps/docsite/src/components/playground/TemplateEditorPanel.tsx
+++ b/apps/docsite/src/components/playground/TemplateEditorPanel.tsx
@@ -1,0 +1,125 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import {useState} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {XDSText, XDSHeading} from '@xds/core/Text';
+import {XDSVStack} from '@xds/core/Layout';
+import {XDSCard} from '@xds/core/Card';
+import {XDSTextInput} from '@xds/core/TextInput';
+
+import {PlaygroundCodeEditor} from './PlaygroundCodeEditor';
+
+const s = stylex.create({
+  root: {
+    display: 'flex',
+    flexDirection: 'column',
+    flex: 1,
+    minHeight: 0,
+  },
+  tabs: {
+    display: 'flex',
+    flexShrink: 0,
+    paddingInline: 12,
+    paddingBlock: 4,
+    gap: 4,
+  },
+  tab: {
+    paddingInline: 12,
+    paddingBlock: 6,
+    borderRadius: 'var(--radius-element, 6px)',
+    border: 'none',
+    cursor: 'pointer',
+    fontSize: 13,
+    fontWeight: 500,
+    background: 'transparent',
+    color: 'var(--color-text-secondary)',
+  },
+  tabActive: {
+    background: 'var(--color-background-muted)',
+    color: 'var(--color-text-primary)',
+  },
+  content: {
+    display: 'flex',
+    flexDirection: 'column',
+    flex: 1,
+    minHeight: 0,
+  },
+  chatPanel: {
+    padding: 24,
+    flex: 1,
+    display: 'flex',
+    flexDirection: 'column',
+    overflow: 'auto',
+  },
+  chatEmpty: {
+    flex: 1,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  chatInput: {
+    flexShrink: 0,
+    paddingBlockStart: 16,
+  },
+});
+
+type Tab = 'code' | 'chat';
+
+interface TemplateEditorPanelProps {
+  code: string;
+  onChange: (code: string) => void;
+}
+
+export function TemplateEditorPanel({
+  code,
+  onChange,
+}: TemplateEditorPanelProps) {
+  const [activeTab, setActiveTab] = useState<Tab>('code');
+
+  return (
+    <div {...stylex.props(s.root)}>
+      <div {...stylex.props(s.tabs)}>
+        <button
+          {...stylex.props(s.tab, activeTab === 'code' && s.tabActive)}
+          onClick={() => setActiveTab('code')}>
+          Code
+        </button>
+        <button
+          {...stylex.props(s.tab, activeTab === 'chat' && s.tabActive)}
+          onClick={() => setActiveTab('chat')}>
+          Chat
+        </button>
+      </div>
+      <div {...stylex.props(s.content)}>
+        {activeTab === 'code' ? (
+          <PlaygroundCodeEditor value={code} onChange={onChange} />
+        ) : (
+          <div {...stylex.props(s.chatPanel)}>
+            <div {...stylex.props(s.chatEmpty)}>
+              <XDSCard padding={5}>
+                <XDSVStack gap={4} hAlign="center">
+                  <XDSHeading level={4}>AI-Assisted Editing</XDSHeading>
+                  <XDSText color="secondary">
+                    Describe changes to your template using natural language.
+                    This feature is coming soon.
+                  </XDSText>
+                </XDSVStack>
+              </XDSCard>
+            </div>
+            <div {...stylex.props(s.chatInput)}>
+              <XDSTextInput
+                label="Message"
+                isLabelHidden
+                placeholder="Describe changes to apply…"
+                isDisabled
+                value=""
+              />
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/docsite/src/components/playground/contentTypeDetector.ts
+++ b/apps/docsite/src/components/playground/contentTypeDetector.ts
@@ -1,0 +1,88 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file contentTypeDetector.ts
+ * @input URL search params and/or code string
+ * @output Content type classification
+ */
+
+export type ContentType = 'component' | 'template' | 'theme';
+
+const THEME_PATTERNS = [
+  /\bXDSTheme\b/,
+  /\bdefineTheme\b/,
+  /\bdefineColorScheme\b/,
+  /\bgenerateThemeCSSFlat\b/,
+];
+
+const TEMPLATE_PATTERNS = [
+  /\bXDSAppShell\b/,
+  /\bXDSTopNav\b/,
+  /\bXDSNavItem\b/,
+  /<main[\s>]/,
+  /<header[\s>]/,
+];
+
+const COMPONENT_PATTERN = /<XDS(\w+)[\s/>]/;
+
+/**
+ * Detect the content type from URL params and code heuristics.
+ *
+ * Priority:
+ * 1. Explicit `?type=` URL param
+ * 2. Code pattern analysis
+ * 3. Default to 'component'
+ */
+export function detectContentType(
+  code: string,
+  searchParams?: URLSearchParams | null,
+): ContentType {
+  // 1. Explicit URL param takes priority
+  const typeParam = searchParams?.get('type');
+  if (
+    typeParam === 'component' ||
+    typeParam === 'template' ||
+    typeParam === 'theme'
+  ) {
+    return typeParam;
+  }
+
+  // 2. Theme heuristics
+  const themeScore = THEME_PATTERNS.reduce(
+    (score, pattern) => score + (pattern.test(code) ? 1 : 0),
+    0,
+  );
+  if (themeScore >= 1) {
+    return 'theme';
+  }
+
+  // 3. Template heuristics (page-level patterns)
+  const templateScore = TEMPLATE_PATTERNS.reduce(
+    (score, pattern) => score + (pattern.test(code) ? 1 : 0),
+    0,
+  );
+  if (templateScore >= 2) {
+    return 'template';
+  }
+
+  // 4. Default to component
+  return 'component';
+}
+
+/**
+ * Extract the primary XDS component name from code.
+ * Returns the name without the "XDS" prefix (e.g. "Button" not "XDSButton").
+ */
+export function detectComponentName(code: string): string | null {
+  const match = code.match(COMPONENT_PATTERN);
+  return match ? match[1] : null;
+}
+
+/**
+ * Get the content name from URL params.
+ */
+export function getContentName(
+  searchParams?: URLSearchParams | null,
+): string | null {
+  return searchParams?.get('name') ?? null;
+}

--- a/apps/docsite/src/components/playground/theme/ThemeEditorPanel.tsx
+++ b/apps/docsite/src/components/playground/theme/ThemeEditorPanel.tsx
@@ -1,0 +1,341 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import {useState, useEffect} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {XDSText, XDSHeading} from '@xds/core/Text';
+import {XDSVStack} from '@xds/core/Layout';
+
+const s = stylex.create({
+  root: {
+    display: 'flex',
+    flexDirection: 'column',
+    flex: 1,
+    minHeight: 0,
+  },
+  tabs: {
+    display: 'flex',
+    flexShrink: 0,
+    paddingInline: 12,
+    paddingBlock: 4,
+    gap: 4,
+  },
+  tab: {
+    paddingInline: 12,
+    paddingBlock: 6,
+    borderRadius: 'var(--radius-element, 6px)',
+    border: 'none',
+    cursor: 'pointer',
+    fontSize: 13,
+    fontWeight: 500,
+    background: 'transparent',
+    color: 'var(--color-text-secondary)',
+  },
+  tabActive: {
+    background: 'var(--color-background-muted)',
+    color: 'var(--color-text-primary)',
+  },
+  content: {
+    display: 'flex',
+    flexDirection: 'column',
+    flex: 1,
+    minHeight: 0,
+    overflow: 'auto',
+  },
+  panel: {
+    padding: 16,
+    flex: 1,
+  },
+  categorySection: {
+    marginBlockEnd: 24,
+  },
+  colorGrid: {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(auto-fill, minmax(140px, 1fr))',
+    gap: 8,
+    marginBlockStart: 8,
+  },
+  swatch: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 8,
+    paddingBlock: 6,
+    paddingInline: 8,
+    borderRadius: 'var(--radius-element, 6px)',
+    background: 'var(--color-background-card)',
+  },
+  swatchColor: {
+    width: 24,
+    height: 24,
+    borderRadius: 'var(--radius-element, 6px)',
+    flexShrink: 0,
+    border: '1px solid var(--color-border)',
+  },
+  tokenTable: {
+    width: '100%',
+    borderCollapse: 'collapse',
+  },
+  tokenRow: {
+    borderBlockEnd: '1px solid var(--color-border)',
+  },
+  tokenCell: {
+    paddingBlock: 8,
+    paddingInline: 12,
+    fontSize: 12,
+    fontFamily: 'monospace',
+  },
+  tokenValue: {
+    paddingBlock: 8,
+    paddingInline: 12,
+    fontSize: 12,
+  },
+  componentList: {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(auto-fill, minmax(160px, 1fr))',
+    gap: 8,
+  },
+  componentItem: {
+    paddingBlock: 10,
+    paddingInline: 14,
+    borderRadius: 'var(--radius-element, 6px)',
+    background: 'var(--color-background-card)',
+    border: '1px solid var(--color-border)',
+  },
+});
+
+const COLOR_CATEGORIES: Record<string, string[]> = {
+  'Core Semantic': [
+    '--color-accent',
+    '--color-accent-muted',
+    '--color-on-accent',
+    '--color-neutral',
+    '--color-overlay',
+  ],
+  Text: [
+    '--color-text-primary',
+    '--color-text-secondary',
+    '--color-text-disabled',
+    '--color-text-accent',
+  ],
+  Icon: [
+    '--color-icon-primary',
+    '--color-icon-secondary',
+    '--color-icon-disabled',
+    '--color-icon-accent',
+  ],
+  Surface: [
+    '--color-background-surface',
+    '--color-background-body',
+    '--color-background-card',
+    '--color-background-popover',
+    '--color-background-muted',
+  ],
+  Status: [
+    '--color-success',
+    '--color-error',
+    '--color-warning',
+    '--color-success-muted',
+    '--color-error-muted',
+    '--color-warning-muted',
+  ],
+  Border: ['--color-border', '--color-border-emphasized'],
+};
+
+const COMPONENT_NAMES = [
+  'XDSButton',
+  'XDSCard',
+  'XDSText',
+  'XDSHeading',
+  'XDSBadge',
+  'XDSBanner',
+  'XDSTextInput',
+  'XDSSelector',
+  'XDSSwitch',
+  'XDSCheckbox',
+  'XDSRadioList',
+  'XDSTable',
+  'XDSList',
+  'XDSDialog',
+  'XDSProgressBar',
+  'XDSTooltip',
+  'XDSPopover',
+  'XDSAvatar',
+  'XDSIcon',
+  'XDSGrid',
+  'XDSDivider',
+  'XDSSection',
+  'XDSTopNav',
+  'XDSAppShell',
+];
+
+type Tab = 'theme' | 'components' | 'tokens';
+
+function getTokenLabel(tokenName: string): string {
+  return tokenName
+    .replace(/^--/, '')
+    .replace(/-/g, ' ')
+    .replace(/\b\w/g, c => c.toUpperCase());
+}
+
+/** Gather all unique tokens from all categories into a flat array */
+function getAllTokens(): string[] {
+  const result: string[] = [];
+  for (const tokens of Object.values(COLOR_CATEGORIES)) {
+    for (const t of tokens) {
+      if (!result.includes(t)) {
+        result.push(t);
+      }
+    }
+  }
+  return result;
+}
+
+interface ThemeEditorPanelProps {
+  code: string;
+  onChange: (code: string) => void;
+}
+
+export function ThemeEditorPanel({code, onChange}: ThemeEditorPanelProps) {
+  const [activeTab, setActiveTab] = useState<Tab>('theme');
+  const [tokenValues, setTokenValues] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    const computed = getComputedStyle(document.documentElement);
+    const values: Record<string, string> = {};
+    for (const tokens of Object.values(COLOR_CATEGORIES)) {
+      for (const token of tokens) {
+        const val = computed.getPropertyValue(token).trim();
+        values[token] = val || '';
+      }
+    }
+    setTokenValues(values);
+  }, []);
+
+  const allTokens = getAllTokens();
+
+  return (
+    <div {...stylex.props(s.root)}>
+      <div {...stylex.props(s.tabs)}>
+        <button
+          {...stylex.props(s.tab, activeTab === 'theme' && s.tabActive)}
+          onClick={() => setActiveTab('theme')}>
+          Theme
+        </button>
+        <button
+          {...stylex.props(s.tab, activeTab === 'components' && s.tabActive)}
+          onClick={() => setActiveTab('components')}>
+          Components
+        </button>
+        <button
+          {...stylex.props(s.tab, activeTab === 'tokens' && s.tabActive)}
+          onClick={() => setActiveTab('tokens')}>
+          Tokens
+        </button>
+      </div>
+      <div {...stylex.props(s.content)}>
+        {activeTab === 'theme' && (
+          <div {...stylex.props(s.panel)}>
+            <XDSVStack gap={10}>
+              {Object.entries(COLOR_CATEGORIES).map(([category, tokens]) => (
+                <div key={category} {...stylex.props(s.categorySection)}>
+                  <XDSHeading level={5}>{category}</XDSHeading>
+                  <div {...stylex.props(s.colorGrid)}>
+                    {tokens.map(token => (
+                      <div key={token} {...stylex.props(s.swatch)}>
+                        <div
+                          {...stylex.props(s.swatchColor)}
+                          style={{
+                            backgroundColor:
+                              tokenValues[token] || `var(${token})`,
+                          }}
+                        />
+                        <XDSText type="supporting" color="secondary">
+                          {getTokenLabel(token).replace('Color ', '').trim()}
+                        </XDSText>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </XDSVStack>
+          </div>
+        )}
+        {activeTab === 'components' && (
+          <div {...stylex.props(s.panel)}>
+            <XDSVStack gap={8}>
+              <XDSHeading level={4}>Components</XDSHeading>
+              <XDSText color="secondary">
+                Preview how theme tokens affect each component.
+              </XDSText>
+              <div {...stylex.props(s.componentList)}>
+                {COMPONENT_NAMES.map(name => (
+                  <div key={name} {...stylex.props(s.componentItem)}>
+                    <XDSText type="supporting">{name}</XDSText>
+                  </div>
+                ))}
+              </div>
+            </XDSVStack>
+          </div>
+        )}
+        {activeTab === 'tokens' && (
+          <div {...stylex.props(s.panel)}>
+            <XDSVStack gap={6}>
+              <XDSHeading level={4}>Raw Tokens</XDSHeading>
+              <XDSText color="secondary">
+                CSS custom property names and their current computed values.
+              </XDSText>
+              <table {...stylex.props(s.tokenTable)}>
+                <thead>
+                  <tr {...stylex.props(s.tokenRow)}>
+                    <th {...stylex.props(s.tokenCell)}>
+                      <XDSText type="supporting" weight="bold">
+                        Token
+                      </XDSText>
+                    </th>
+                    <th {...stylex.props(s.tokenCell)}>
+                      <XDSText type="supporting" weight="bold">
+                        Value
+                      </XDSText>
+                    </th>
+                    <th {...stylex.props(s.tokenCell)}>
+                      <XDSText type="supporting" weight="bold">
+                        Preview
+                      </XDSText>
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {allTokens.map(token => (
+                    <tr key={token} {...stylex.props(s.tokenRow)}>
+                      <td {...stylex.props(s.tokenCell)}>
+                        <XDSText type="code">{token}</XDSText>
+                      </td>
+                      <td {...stylex.props(s.tokenValue)}>
+                        <XDSText type="code" color="secondary">
+                          {tokenValues[token] || '\u2014'}
+                        </XDSText>
+                      </td>
+                      <td {...stylex.props(s.tokenCell)}>
+                        <div
+                          {...stylex.props(s.swatchColor)}
+                          style={{
+                            backgroundColor:
+                              tokenValues[token] || `var(${token})`,
+                          }}
+                        />
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </XDSVStack>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/docsite/src/components/playgroundLink.ts
+++ b/apps/docsite/src/components/playgroundLink.ts
@@ -4,8 +4,27 @@ import {compressToEncodedURIComponent} from 'lz-string';
 
 /**
  * Build a playground URL with prepopulated source code.
+ *
+ * @param source - The source code to embed in the playground URL
+ * @param opts - Optional type and name parameters for content-aware editing
+ * @param opts.type - Content type: 'component' | 'template' | 'theme'
+ * @param opts.name - Content name (e.g. component name, template name)
  */
-export function buildPlaygroundHref(source: string): string {
+export function buildPlaygroundHref(
+  source: string,
+  opts?: {type?: string; name?: string},
+): string {
   const compressed = compressToEncodedURIComponent(source);
-  return `/playground#code=${compressed}`;
+  const searchParams = new URLSearchParams();
+
+  if (opts?.type) {
+    searchParams.set('type', opts.type);
+  }
+  if (opts?.name) {
+    searchParams.set('name', opts.name);
+  }
+
+  const search = searchParams.toString();
+  const prefix = search ? `/playground?${search}` : '/playground';
+  return `${prefix}#code=${compressed}`;
 }


### PR DESCRIPTION
## Summary

Refactors the monolithic `PlaygroundClient.tsx` (546 lines) into a modular, content-aware editor that detects content type and renders appropriate control panels.

## Content Types

| Type | Tabs | Detection |
|------|------|-----------|
| Component | Code \| Properties | `?type=component` or `<XDS...` pattern |
| Template | Code \| Chat (placeholder) | `?type=template` or AppShell/page patterns |
| Theme | Theme \| Components \| Tokens | `?type=theme` or `defineTheme`/`XDSTheme` |

## New Files (`apps/docsite/src/components/playground/`)

- `contentTypeDetector.ts` — URL param + code heuristic detection
- `PlaygroundShell.tsx` — Resizable split layout
- `PlaygroundPreview.tsx` — iframe preview + postMessage protocol
- `PlaygroundCodeEditor.tsx` — Monaco wrapper with XDS types
- `PlaygroundToolbar.tsx` — Status, theme picker, content type badge
- `ComponentEditorPanel.tsx` — Code + Properties tabs
- `TemplateEditorPanel.tsx` — Code + Chat tabs
- `theme/ThemeEditorPanel.tsx` — Theme + Components + Tokens tabs

## URLs

```
/playground                          → auto-detect (default: component)
/playground?type=component&name=Button → component editor
/playground?type=template&name=ai-chat → template editor
/playground?type=theme&name=default    → theme editor
/playground#code=...                   → existing LZ sharing (preserved)
```

## Unchanged

- Preview iframe + Babel runtime
- URL hash code sharing
- Monaco type intelligence