### PR TITLE
fix(ci): increase Node heap for sandbox build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -106,6 +106,7 @@ jobs:
         run: pnpm -F @xds/sandbox build
         env:
           SANDBOX_BASE_PATH: /sandbox
+          NODE_OPTIONS: '--max-old-space-size=4096'
 
       - name: Preserve PR previews and reports from gh-pages
         run: |


### PR DESCRIPTION
## Problem

Every main deploy has been failing since May 20 (the pnpm migration) with exit code 134 (SIGABRT) during the Build Sandbox step.

```
FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
```

The Next.js static export hits the default ~2GB Node.js heap limit on GitHub Actions runners.

## Fix

Set `NODE_OPTIONS=--max-old-space-size=4096` for the Build Sandbox step.