### PR TITLE
docsite: hide chocolate and daily themes from the docsite

### DIFF
--- a/apps/docsite/package.json
+++ b/apps/docsite/package.json
@@ -18,8 +18,6 @@
     "@stylexjs/stylex": "^0.18.3",
     "@xds/cli": "*",
     "@xds/core": "*",
-    "@xds/theme-chocolate": "*",
-    "@xds/theme-daily": "*",
     "@xds/theme-default": "*",
     "@xds/theme-gothic": "*",
     "@xds/theme-matcha": "*",

--- a/apps/docsite/scripts/generate-scope.mjs
+++ b/apps/docsite/scripts/generate-scope.mjs
@@ -38,7 +38,6 @@ const components = exportKeys
 const SCOPE_THEMES = [
   {pkg: '@xds/theme-default', name: 'defaultTheme', subpath: '/built'},
   {pkg: '@xds/theme-neutral', name: 'neutralTheme', subpath: '/built'},
-  {pkg: '@xds/theme-daily', name: 'dailyTheme', subpath: '/built'},
   {pkg: '@xds/theme-matcha', name: 'matchaTheme', subpath: '/built'},
 ];
 

--- a/apps/docsite/src/__tests__/data-extraction.test.ts
+++ b/apps/docsite/src/__tests__/data-extraction.test.ts
@@ -26,10 +26,11 @@ describe('packageRegistry', () => {
     expect(names).toContain('@xds/cli');
     expect(names).toContain('@xds/theme-default');
     expect(names).toContain('@xds/theme-neutral');
-    expect(names).toContain('@xds/theme-chocolate');
     expect(names).toContain('@xds/theme-gothic');
     expect(names).toContain('@xds/theme-stone');
     expect(names).not.toContain('@xds/theme-brutalist');
+    expect(names).not.toContain('@xds/theme-chocolate');
+    expect(names).not.toContain('@xds/theme-daily');
     expect(names).not.toContain('@xds/lab');
     expect(names).not.toContain('@xds/build');
     expect(packages.length).toBeGreaterThanOrEqual(5);

--- a/apps/docsite/src/app/(preview)/playground-preview/page.tsx
+++ b/apps/docsite/src/app/(preview)/playground-preview/page.tsx
@@ -15,14 +15,12 @@ import type {XDSDefinedTheme} from '@xds/core/theme';
 import type {ThemeMode} from '@xds/core/theme';
 import {defaultTheme} from '@xds/theme-default/built';
 import {neutralTheme} from '@xds/theme-neutral/built';
-import {dailyTheme} from '@xds/theme-daily/built';
 import {matchaTheme} from '@xds/theme-matcha/built';
 import {runCode, setBabel} from './runner';
 
 const THEME_MAP: Record<string, XDSDefinedTheme> = {
   default: defaultTheme,
   neutral: neutralTheme,
-  daily: dailyTheme,
   matcha: matchaTheme,
 };
 

--- a/apps/docsite/src/app/(preview)/playground-preview/scope.ts
+++ b/apps/docsite/src/app/(preview)/playground-preview/scope.ts
@@ -112,7 +112,6 @@ import * as Typeahead from '@xds/core/Typeahead';
 
 import {defaultTheme} from '@xds/theme-default/built';
 import {neutralTheme} from '@xds/theme-neutral/built';
-import {dailyTheme} from '@xds/theme-daily/built';
 import {matchaTheme} from '@xds/theme-matcha/built';
 
 import {XDSTheme} from '@xds/core/theme';
@@ -128,7 +127,6 @@ import * as Heroicons24Solid from '@heroicons/react/24/solid';
 const SCOPE_THEMES: Record<string, XDSDefinedTheme> = {
   default: defaultTheme,
   neutral: neutralTheme,
-  daily: dailyTheme,
   matcha: matchaTheme,
 };
 
@@ -160,8 +158,6 @@ export const scope: Record<string, Record<string, unknown>> = {
   '@xds/theme-default/built': {default: defaultTheme, defaultTheme},
   '@xds/theme-neutral': {default: neutralTheme, neutralTheme},
   '@xds/theme-neutral/built': {default: neutralTheme, neutralTheme},
-  '@xds/theme-daily': {default: dailyTheme, dailyTheme},
-  '@xds/theme-daily/built': {default: dailyTheme, dailyTheme},
   '@xds/theme-matcha': {default: matchaTheme, matchaTheme},
   '@xds/theme-matcha/built': {default: matchaTheme, matchaTheme},
   '@xds/core/theme': {XDSTheme: ControlledXDSTheme},

--- a/apps/docsite/src/app/globals.css
+++ b/apps/docsite/src/app/globals.css
@@ -4,8 +4,6 @@
 @import "@xds/core/xds.css";
 @import "@xds/theme-default/theme.css";
 @import "@xds/theme-neutral/theme.css";
-@import "@xds/theme-chocolate/theme.css";
-@import "@xds/theme-daily/theme.css";
 @import "@xds/theme-gothic/theme.css";
 @import "@xds/theme-matcha/theme.css";
 @import "@xds/theme-stone/theme.css";

--- a/apps/docsite/src/app/playground/PlaygroundClient.tsx
+++ b/apps/docsite/src/app/playground/PlaygroundClient.tsx
@@ -118,7 +118,6 @@ function updateURL(code: string) {
 const THEME_OPTIONS = [
   {value: 'default', label: 'Default'},
   {value: 'neutral', label: 'Neutral'},
-  {value: 'daily', label: 'Daily'},
   {value: 'matcha', label: 'Matcha'},
 ];
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,12 +108,6 @@ importers:
       '@xds/core':
         specifier: '*'
         version: link:../../packages/core
-      '@xds/theme-chocolate':
-        specifier: '*'
-        version: link:../../packages/themes/chocolate
-      '@xds/theme-daily':
-        specifier: '*'
-        version: link:../../packages/themes/daily
       '@xds/theme-default':
         specifier: '*'
         version: link:../../packages/themes/default


### PR DESCRIPTION
## Summary

Hides the `chocolate` and `daily` themes from the docsite, mirroring how `brutalist` is already hidden today. The theme packages themselves are unchanged in `packages/themes/` and remain available for any consumer that installs them directly — the docsite simply doesn't surface them anymore.

## Mechanism

The generator at `apps/docsite/scripts/generate-data.mjs:161-162` already filters out any package that isn't a `dependencies` entry in `apps/docsite/package.json`. That's how `brutalist` has stayed invisible. This PR applies the same pattern to chocolate + daily by:

- Dropping both deps from `apps/docsite/package.json`
- Dropping the corresponding `@import` lines from `apps/docsite/src/app/globals.css`
- Regenerating `pnpm-lock.yaml`

For `daily` specifically, the docsite **also imports `dailyTheme` directly** in the playground preview (`page.tsx`, `scope.ts`, `generate-scope.mjs`) and lists it in the user-facing playground theme picker. Those direct references are removed too, so the playground theme picker now exposes 3 options (default, neutral, matcha) instead of 4.

The data-extraction test is updated to assert both themes are excluded, the same way it asserts brutalist is excluded.

## What changed where

| File | Change |
|---|---|
| `apps/docsite/package.json` | Drop `@xds/theme-chocolate` + `@xds/theme-daily` |
| `apps/docsite/src/app/globals.css` | Drop the two corresponding `@import` lines |
| `apps/docsite/src/app/playground/PlaygroundClient.tsx` | Remove `daily` from `THEME_OPTIONS` picker |
| `apps/docsite/src/app/(preview)/playground-preview/page.tsx` | Drop `dailyTheme` import + map entry |
| `apps/docsite/src/app/(preview)/playground-preview/scope.ts` | Drop `dailyTheme` import + map entry + scope entries |
| `apps/docsite/scripts/generate-scope.mjs` | Drop `daily` from `SCOPE_THEMES` regen list |
| `apps/docsite/src/__tests__/data-extraction.test.ts` | Flip chocolate to `not.toContain` + add same for daily |
| `pnpm-lock.yaml` | Regenerated |

## What we *didn't* do (and why)

The same brutalist mechanism does NOT work cleanly for the `default` theme, because the docsite depends on it for:

1. The CSS cascade baseline (every other theme extends `default`)
2. The playground's fallback theme (what it falls back to when an unknown theme name is requested)
3. The cascade reset that ships with `globals.css`

Removing it would break the playground and likely cascade. If we want to hide `default` from display surfaces in the future, the right approach is a separate display-layer allow/deny list rather than dropping the dep.

## Test plan

- [x] `pnpm install` — lockfile regenerates clean
- [x] `node apps/docsite/scripts/generate-data.mjs` — registry now reports `5 themes` (was 7)
- [x] `node apps/docsite/scripts/generate-scope.mjs` — playground scope now reports `3 themes` (was 4)
- [x] `pnpm -F @xds/core typecheck:docs` — passes
- [x] `pnpm test src/__tests__/data-extraction.test.ts` — all 64 tests pass with the updated assertions
- [x] Dev server returns 200 for `/` and `/themes`
- [x] Rendered `/themes` HTML confirms exactly 5 theme cards: Default, Gothic, Matcha, Neutral, Stone
- [x] `check:sync` + `check:package-boundaries` pre-commit hooks pass

Made with [Cursor](https://cursor.com)