### PR TITLE
feat(docsite): Fixed names in components side nav

### DIFF
--- a/packages/core/src/AlertDialog/AlertDialog.doc.mjs
+++ b/packages/core/src/AlertDialog/AlertDialog.doc.mjs
@@ -39,7 +39,7 @@ export const docs = {
   components: [
     {
       name: 'XDSAlertDialog',
-      displayName: 'XDS Alert Dialog',
+      displayName: 'Alert Dialog',
       description: 'A modal dialog that asks the user to confirm a destructive action.',
       props: [
         {name: 'isOpen', type: 'boolean', required: true, description: 'Whether the dialog is open.'},

--- a/packages/core/src/Avatar/Avatar.doc.mjs
+++ b/packages/core/src/Avatar/Avatar.doc.mjs
@@ -33,7 +33,7 @@ export const docs = {
   components: [
     {
       name: 'XDSAvatar',
-      displayName: 'XDS Avatar',
+      displayName: 'Avatar',
       description:
         'Displays a user avatar with image, initials fallback, and optional status indicator.',
       props: [
@@ -72,7 +72,7 @@ export const docs = {
       ],    },
     {
       name: 'XDSAvatarStatusDot',
-      displayName: 'XDS Avatar Status Dot',
+      displayName: 'Avatar Status Dot',
       description:
         'Size-aware status indicator dot that reads avatar size from context and scales proportionally.',
       props: [
@@ -132,7 +132,7 @@ export const docsZh = {
   components: [
     {
       name: 'XDSAvatar',
-      displayName: 'XDS Avatar',
+      displayName: 'Avatar',
       description: '显示用户头像，支持图片、首字母回退和可选的状态指示器。',
       props: [
         {name: 'src', type: 'string', description: '主图片源 URL。'},
@@ -145,7 +145,7 @@ export const docsZh = {
     },
     {
       name: 'XDSAvatarStatusDot',
-      displayName: 'XDS Avatar Status Dot',
+      displayName: 'Avatar Status Dot',
       description: '尺寸感知的状态指示点，从上下文中读取头像尺寸并等比缩放。',
       props: [
         {name: 'variant', type: "'success' | 'neutral' | 'error'", description: '状态点的语义颜色变体。', default: "'success'"},
@@ -173,7 +173,7 @@ export const docsDense = {
   components: [
     {
       name: 'XDSAvatar',
-      displayName: 'XDS Avatar',
+      displayName: 'Avatar',
       description: 'user avatar w/ image, initials fallback, optional status indicator',
       propDescriptions: {
         src: 'primary image URL',
@@ -187,7 +187,7 @@ export const docsDense = {
     },
     {
       name: 'XDSAvatarStatusDot',
-      displayName: 'XDS Avatar Status Dot',
+      displayName: 'Avatar Status Dot',
       description: 'size-aware status dot, reads avatar size from context + scales proportionally',
       propDescriptions: {
         variant: 'semantic color variant',

--- a/packages/core/src/AvatarGroup/AvatarGroup.doc.mjs
+++ b/packages/core/src/AvatarGroup/AvatarGroup.doc.mjs
@@ -28,7 +28,7 @@ export const docs = {
   components: [
     {
       name: 'XDSAvatarGroup',
-      displayName: 'XDS Avatar Group',
+      displayName: 'Avatar Group',
       description: 'Stacked avatar display with overlapping layout and optional overflow indicator. Children are XDSAvatar elements.',
       props: [
         {name: 'children', type: 'ReactNode', description: 'XDSAvatar children, optionally followed by one XDSAvatarGroupOverflow. Consumers handle slicing to the desired visible count.', required: true, slotElements: [{__element: 'XDSAvatar', props: {name: 'User'}}]},
@@ -40,7 +40,7 @@ export const docs = {
     },
     {
       name: 'XDSAvatarGroupOverflow',
-      displayName: 'XDS Avatar Group Overflow',
+      displayName: 'Avatar Group Overflow',
       description: 'Slot for custom overflow content inside XDSAvatarGroup. Replaces the default "+N" indicator when present.',
       props: [
         {name: 'children', type: 'ReactNode', description: 'Custom overflow content (button, popover trigger, etc.).', required: true},
@@ -64,7 +64,7 @@ export const docsZh = {
   components: [
     {
       name: 'XDSAvatarGroup',
-      displayName: 'XDS Avatar Group',
+      displayName: 'Avatar Group',
       description: '重叠布局的堆叠头像显示，带可选溢出指示器。子元素为 XDSAvatar。',
       propDescriptions: {
         children: 'XDSAvatar 子元素，可选地后跟一个 XDSAvatarGroupOverflow。',
@@ -77,7 +77,7 @@ export const docsZh = {
     },
     {
       name: 'XDSAvatarGroupOverflow',
-      displayName: 'XDS Avatar Group Overflow',
+      displayName: 'Avatar Group Overflow',
       description: 'XDSAvatarGroup 内的自定义溢出内容插槽。存在时替换默认的 "+N" 指示器。',
       propDescriptions: {
         children: '自定义溢出内容（按钮、弹出触发器等）。',
@@ -102,7 +102,7 @@ export const docsDense = {
   components: [
     {
       name: 'XDSAvatarGroup',
-      displayName: 'XDS Avatar Group',
+      displayName: 'Avatar Group',
       description: 'overlapping avatar row w/ max truncation',
       propDescriptions: {
         children: 'XDSAvatar children + optional XDSAvatarGroupOverflow',
@@ -115,7 +115,7 @@ export const docsDense = {
     },
     {
       name: 'XDSAvatarGroupOverflow',
-      displayName: 'XDS Avatar Group Overflow',
+      displayName: 'Avatar Group Overflow',
       description: 'custom overflow slot, replaces default +N',
       propDescriptions: {
         children: 'custom overflow content',

--- a/packages/core/src/Breadcrumbs/Breadcrumbs.doc.mjs
+++ b/packages/core/src/Breadcrumbs/Breadcrumbs.doc.mjs
@@ -35,7 +35,7 @@ export const docs = {
   components: [
     {
       name: 'XDSBreadcrumbs',
-      displayName: 'XDS Breadcrumbs',
+      displayName: 'Breadcrumbs',
       description:
         'Navigation container that renders a <nav> with an ordered list of breadcrumb items.',
       props: [
@@ -76,7 +76,7 @@ export const docs = {
       ],    },
     {
       name: 'XDSBreadcrumbItem',
-      displayName: 'XDS Breadcrumb Item',
+      displayName: 'Breadcrumb Item',
       description:
         'Individual breadcrumb item that renders as a link when href is provided, or as plain text for the current page.',
       props: [
@@ -153,7 +153,7 @@ export const docsZh = {
   components: [
     {
       name: 'XDSBreadcrumbs',
-      displayName: 'XDS Breadcrumbs',
+      displayName: 'Breadcrumbs',
       description: '导航容器，渲染包含有序面包屑项列表的 <nav> 元素。',
       props: [
         {name: 'children', type: 'ReactNode', description: '在面包屑路径内渲染的 XDSBreadcrumbItem 元素。', required: true},
@@ -170,7 +170,7 @@ export const docsZh = {
     },
     {
       name: 'XDSBreadcrumbItem',
-      displayName: 'XDS Breadcrumb Item',
+      displayName: 'Breadcrumb Item',
       description: '单个面包屑项，提供 href 时渲染为链接，当前页面渲染为纯文本。',
       props: [
         {name: 'children', type: 'ReactNode', description: '面包屑项的标签内容。', required: true},
@@ -202,7 +202,7 @@ export const docsDense = {
   components: [
     {
       name: 'XDSBreadcrumbs',
-      displayName: 'XDS Breadcrumbs',
+      displayName: 'Breadcrumbs',
       description: 'nav container rendering <nav> w/ ordered breadcrumb list',
       propDescriptions: {
         children: 'XDSBreadcrumbItem elements in breadcrumb trail',
@@ -214,7 +214,7 @@ export const docsDense = {
     },
     {
       name: 'XDSBreadcrumbItem',
-      displayName: 'XDS Breadcrumb Item',
+      displayName: 'Breadcrumb Item',
       description: 'individual breadcrumb; link w/ href, plain text for current page',
       propDescriptions: {
         children: 'label content',

--- a/packages/core/src/ButtonGroup/ButtonGroup.doc.mjs
+++ b/packages/core/src/ButtonGroup/ButtonGroup.doc.mjs
@@ -20,7 +20,7 @@ export const docs = {
   components: [
     {
       name: 'XDSButtonGroup',
-      displayName: 'XDS Button Group',
+      displayName: 'Button Group',
       description: 'Groups multiple buttons together with connected styling — shared borders, proper border-radius handling (only on outer edges), and horizontal or vertical orientation.',
       props: [
         {name: 'children', type: 'ReactNode', description: 'XDSButton or XDSIconButton children.', required: true, slotElements: [{__element: 'XDSButton', props: {label: 'Action'}}]},
@@ -57,7 +57,7 @@ export const docsZh = {
   components: [
     {
       name: 'XDSButtonGroup',
-      displayName: 'XDS Button Group',
+      displayName: 'Button Group',
       description: '将多个按钮组合在一起，带有连接样式 — 共享边框、正确的圆角处理（仅外边缘），以及水平或垂直方向。',
       propDescriptions: {
         children: 'XDSButton 或 XDSIconButton 子元素。',
@@ -107,7 +107,7 @@ export const docsDense = {
   components: [
     {
       name: 'XDSButtonGroup',
-      displayName: 'XDS Button Group',
+      displayName: 'Button Group',
       description: 'connected button group w/ shared borders, outer-only radius',
       propDescriptions: {
         children: 'XDSButton or XDSIconButton children',

--- a/packages/core/src/Chat/Chat.doc.mjs
+++ b/packages/core/src/Chat/Chat.doc.mjs
@@ -39,7 +39,7 @@ export const docs = {
   components: [
     {
       name: 'XDSChatMessageList',
-      displayName: 'XDS Chat Message List',
+      displayName: 'Chat Message List',
       description: 'Presentational message container with density context and infinite scroll support. Provides role="log" with aria-live="polite" for accessibility. A flex spacer pushes messages to the bottom when the list isn\'t full.',
       props: [
         {name: 'children', type: 'ReactNode', description: 'Message elements — typically XDSChatMessage or XDSChatSystemMessage.', required: true},
@@ -53,7 +53,7 @@ export const docs = {
     },
     {
       name: 'XDSChatMessage',
-      displayName: 'XDS Chat Message',
+      displayName: 'Chat Message',
       description: 'Sender context wrapper — handles avatar, name, metadata, and alignment based on sender role.',
       props: [
         {name: 'sender', type: "'user' | 'assistant' | 'system'", description: 'Who sent this message — controls alignment and layout.', required: true},
@@ -70,7 +70,7 @@ export const docs = {
     },
     {
       name: 'XDSChatMessageBubble',
-      displayName: 'XDS Chat Message Bubble',
+      displayName: 'Chat Message Bubble',
       description: 'Styled content container — the chat “bubble.” Reads sender from parent XDSChatMessage context to auto-style the background. Use filled for standard messages and ghost when content needs alignment without a visible boundary. Supports name/metadata slots aligned with bubble padding, and multi-bubble grouping via the group prop for consecutive messages from the same sender.',
       props: [
         {name: 'children', type: 'ReactNode', description: 'Bubble content — text, XDSMarkdown, or any ReactNode.', required: true},
@@ -84,7 +84,7 @@ export const docs = {
     },
     {
       name: 'XDSChatMessageMetadata',
-      displayName: 'XDS Chat Message Metadata',
+      displayName: 'Chat Message Metadata',
       description: 'Composable metadata row for chat messages. Renders timestamp, footer content, and delivery status in a single row. Direction reverses for user sender. Renders nothing if all props are empty.',
       props: [
         {name: 'timestamp', type: 'ReactNode', description: 'Timestamp content — a string or XDSTimestamp component.',
@@ -98,7 +98,7 @@ export const docs = {
     },
     {
       name: 'XDSChatSystemMessage',
-      displayName: 'XDS Chat System Message',
+      displayName: 'Chat System Message',
       description: 'Centered system message for non-sender content like date separators, membership changes, and status notices. It is not a chat bubble — it has no avatar, no alignment, and no sender context. Use the divider variant for temporal breaks and default for inline status updates.',
       props: [
         {name: 'children', type: 'ReactNode', description: 'System message content — a short, factual string like a date, a join/leave notice, or a status change.', required: true},
@@ -110,7 +110,7 @@ export const docs = {
     },
     {
       name: 'XDSChatComposer',
-      displayName: 'XDS Chat Composer',
+      displayName: 'Chat Composer',
       description: 'Layout shell for a chat composer. Arranges named slots (drawer, header, input, footer, send) with page-radius container, hover/focus shadows, and concentric inner radius for child elements.',
       props: [
         {name: 'onSubmit', type: '(value: string) => void', description: 'Called when the user submits a message.', required: true},
@@ -148,7 +148,7 @@ export const docs = {
     },
     {
       name: 'XDSChatComposerInput',
-      displayName: 'XDS Chat Composer Input',
+      displayName: 'Chat Composer Input',
       description: 'Rich text input for the chat composer. Supports trigger menus (type @ or / to open a typeahead), inline tokens rendered as badges, message history recall with ArrowUp/Down, paste/drop file handling, and a 16px touch-device font-size floor to prevent iOS input zoom. Pass it to XDSChatComposer\'s input slot when you need more than a plain textarea.',
       props: [
         {name: 'handleRef', type: 'React.Ref<XDSChatComposerInputHandle>', description: 'Imperative handle for programmatic control — insertToken, insertText, focus, and getValue.'},
@@ -168,7 +168,7 @@ export const docs = {
     },
     {
       name: 'XDSChatComposerDrawer',
-      displayName: 'XDS Chat Composer Drawer',
+      displayName: 'Chat Composer Drawer',
       description: 'Collapsible drawer panel that sits above the chat input inside XDSChatComposer. Pass it to the composer\'s `drawer` slot to show attachments, context chips, or any supplementary content. When `count` is provided the drawer gains a collapse toggle — collapsed state shows a badge and label, expanded state shows all children.',
       props: [
         {name: 'children', type: 'ReactNode', description: 'Content to render inside the drawer — tokens, chips, previews, or any React elements.', required: true},
@@ -181,7 +181,7 @@ export const docs = {
     },
     {
       name: 'XDSChatSendButton',
-      displayName: 'XDS Chat Send Button',
+      displayName: 'Chat Send Button',
       description: 'Circular send/stop toggle button for the chat composer. Place it inside XDSChatComposer where it reads context automatically — no wiring needed. When streaming starts, the button switches from a primary send icon to a secondary stop icon. Override any context value via props for standalone or custom usage.',
       props: [
         {name: 'isStopShown', type: 'boolean', description: 'Whether the stop button is shown. Defaults to context value.'},
@@ -200,7 +200,7 @@ export const docs = {
     },
     {
       name: 'XDSChatToolCalls',
-      displayName: 'XDS Chat Tool Calls',
+      displayName: 'Chat Tool Calls',
       description: 'Displays tool/function call invocations from an LLM response. Accepts a `calls` array matching the shape LLM APIs return. Single call renders inline; multiple calls get a collapsible summary with the latest call visible at the surface.',
       props: [
         {name: 'calls', type: 'XDSChatToolCallItem[]', description: 'Array of tool call data. Each item has name, status, target, duration, node, additions, deletions, stats, resultDetail.', required: true},
@@ -212,7 +212,7 @@ export const docs = {
     },
     {
       name: 'XDSChatTokenizedText',
-      displayName: 'XDS Chat Tokenized Text',
+      displayName: 'Chat Tokenized Text',
       description: 'Renders a text string with token patterns replaced by inline XDSBadge components. Wrap any message body inside XDSChatMessageBubble to turn raw @mentions, #tags, or /commands into styled badges. When no tokens match or none are provided, the text renders as-is — so you can use ChatTokenizedText unconditionally on every message.',
       props: [
         {name: 'children', type: 'string', description: 'The plain text message containing serialized token values. Patterns matching a token\'s value are replaced with badge components inline.', required: true},
@@ -221,7 +221,7 @@ export const docs = {
     },
     {
       name: 'XDSChatComposerTokenElement',
-      displayName: 'XDS Chat Composer Token Element',
+      displayName: 'Chat Composer Token Element',
       description: 'Renders a single token chip outside the contentEditable input. Wraps a badge config or custom render function in the correct data-xds-token span so the token serializes properly and stays visually consistent with tokens inside the composer.',
       props: [
         {name: 'token', type: 'XDSChatComposerToken', description: 'The token to render. Pass a badge config ({ value, label, variant?, icon? }) for the common case, or a custom render ({ value, render }) for full control.', required: true},
@@ -263,7 +263,7 @@ export const docs = {
 // Append XDSChatLayout and XDSChatLayoutScrollButton to all doc variants
 const chatLayoutComponent = {
   name: 'XDSChatLayout',
-  displayName: 'XDS Chat Layout',
+  displayName: 'Chat Layout',
   description: 'Layout shell for full chat interfaces. Messages flow in normal page flow, composer is fixed to the bottom with a frosted glass dock. Adapts density (compact/balanced/spacious) automatically via container width observation. Includes built-in auto-scroll, a "New messages" scroll-to-bottom button, and a frosted glass blur layer behind the composer. By default the layout root is the scroll container; pass scrollRef to delegate scrolling to a parent element or the document body.',
   props: [
     {name: 'children', type: 'ReactNode', description: 'Message content — typically XDSChatMessageList. Flows naturally in the page and scrolls with the container.', required: true},
@@ -281,7 +281,7 @@ docs.components.push(chatLayoutComponent);
 
 const chatLayoutScrollButtonComponent = {
   name: 'XDSChatLayoutScrollButton',
-  displayName: 'XDS Chat Layout Scroll Button',
+  displayName: 'Chat Layout Scroll Button',
   description: 'Floating scroll-to-bottom button that appears when the user scrolls away from the latest messages. It fades in as a compact icon button and expands to show a label when new messages arrive. XDSChatLayout renders this by default — pass a custom element to the scrollButton prop to override, or null to hide it entirely.',
   props: [
     {name: 'isVisible', type: 'boolean', description: 'Whether the button is visible. Bind to a scroll-position check so the button only appears when the user has scrolled up.', required: true},
@@ -321,7 +321,7 @@ export const docsZh = {
   components: [
     {
       name: 'XDSChatMessageList',
-      displayName: 'XDS Chat Message List',
+      displayName: 'Chat Message List',
       description: '消息展示容器，支持密度上下文和无限滚动。自动滚动由 XDSChatLayout 管理。',
       propDescriptions: {
         children: '消息元素，通常是 XDSChatMessage 或 XDSChatSystemMessage。',
@@ -333,7 +333,7 @@ export const docsZh = {
     },
     {
       name: 'XDSChatMessage',
-      displayName: 'XDS Chat Message',
+      displayName: 'Chat Message',
       description: '发送者上下文包装器，根据发送者角色处理头像、名称、元数据和对齐方式。',
       propDescriptions: {
         sender: '消息发送者，控制对齐和布局。',
@@ -346,7 +346,7 @@ export const docsZh = {
     },
     {
       name: 'XDSChatMessageBubble',
-      displayName: 'XDS Chat Message Bubble',
+      displayName: 'Chat Message Bubble',
       description: '样式化的气泡容器，从父上下文读取发送者信息进行自动样式化。支持 name/metadata 插槽、多气泡分组和透明变体。',
       propDescriptions: {
         children: '气泡内容：文本、XDSMarkdown 或任何 ReactNode。',
@@ -358,19 +358,19 @@ export const docsZh = {
     },
     {
       name: 'XDSChatMessageMetadata',
-      displayName: 'XDS Chat Message Metadata',
+      displayName: 'Chat Message Metadata',
       description: '可组合的消息元数据行。渲染时间戳、页脚内容和发送状态。用户消息方向反转。',
       propDescriptions: {timestamp: '时间戳内容 — 字符串或 XDSTimestamp 组件。', footer: '页脚内容 — 模型信息、反应按钮、复制按钮。', status: '消息发送状态。显示图标和标签。'},
     },
     {
       name: 'XDSChatSystemMessage',
-      displayName: 'XDS Chat System Message',
+      displayName: 'Chat System Message',
       description: '居中的系统消息，用于日期分隔、成员变更和状态通知等非发送者内容。没有头像、对齐或气泡。使用 divider 变体做时间分隔，default 做内联状态更新。',
       propDescriptions: {children: '系统消息内容 — 简短的事实性文本，如日期、加入/离开通知或状态变更。', variant: "视觉变体。'default' 渲染居中文本。'divider' 通过 XDSDivider 在两侧添加水平线 — 用于日期分隔和段落分隔。", icon: '增强消息类型辨识度的前置图标。使用 XDSIcon 包裹以获得一致的尺寸。'},
     },
     {
       name: 'XDSChatComposer',
-      displayName: 'XDS Chat Composer',
+      displayName: 'Chat Composer',
       description: '聊天编写器布局外壳。排列命名插槽（附件、标题栏、输入、页脚、发送），带有页面圆角容器和同心内圆角。',
       propDescriptions: {
         onSubmit: '用户提交消息时调用。',
@@ -394,7 +394,7 @@ export const docsZh = {
     },
     {
       name: 'XDSChatComposerInput',
-      displayName: 'XDS Chat Composer Input',
+      displayName: 'Chat Composer Input',
       description:
         '聊天编写器的富文本输入。支持触发菜单（输入 @ 或 / 打开 typeahead）、内联标记徽章、ArrowUp/Down 消息历史回溯、粘贴/拖放文件处理，并在触控设备上将字体大小保持至少 16px 以避免 iOS 输入缩放。当需要普通文本区域以外的功能时，传入 XDSChatComposer 的 input 插槽。',
       propDescriptions: {
@@ -415,13 +415,13 @@ export const docsZh = {
     },
     {
       name: 'XDSChatComposerDrawer',
-      displayName: 'XDS Chat Composer Drawer',
+      displayName: 'Chat Composer Drawer',
       description: '位于聊天输入上方的可折叠抽屉面板。传入 XDSChatComposer 的 `drawer` 插槽，用于显示附件、上下文标签或预览内容。提供 `count` 时启用折叠切换。',
       propDescriptions: {children: '抽屉内渲染的内容——标记、标签、预览或任何 React 元素。', count: '折叠徽章中显示的总数。提供时，抽屉获得折叠/展开切换。', label: '折叠状态下显示在数量旁边的标签。', isCollapsed: '受控折叠状态。与 onCollapsedChange 一起使用。', defaultIsCollapsed: '非受控模式的初始折叠状态。', onCollapsedChange: '用户切换抽屉时触发的回调。'},
     },
     {
       name: 'XDSChatSendButton',
-      displayName: 'XDS Chat Send Button',
+      displayName: 'Chat Send Button',
       description:
         '编写器的圆形发送/停止切换按钮。默认从 XDSChatComposerContext 读取状态，在 XDSChatComposer 内自动工作。所有上下文值均可通过 props 覆盖以用于独立使用。',
       propDescriptions: {
@@ -437,7 +437,7 @@ export const docsZh = {
     },
     {
       name: 'XDSChatToolCalls',
-      displayName: 'XDS Chat Tool Calls',
+      displayName: 'Chat Tool Calls',
       description:
         '显示 LLM 响应中的工具/函数调用。接受与 LLM API 返回形状匹配的 calls 数组。单个调用内联渲染；多个调用显示可折叠摘要。',
       propDescriptions: {
@@ -451,20 +451,20 @@ export const docsZh = {
     },
     {
       name: 'XDSChatTokenizedText',
-      displayName: 'XDS Chat Tokenized Text',
+      displayName: 'Chat Tokenized Text',
       description:
         '渲染带有标记模式的文本，将匹配的模式替换为内联 XDSBadge 组件。在 XDSChatMessageBubble 内使用，将 @提及、#标签或 /命令显示为样式化徽章。未提供标记时以纯文本渲染，因此可以无条件使用。',
       propDescriptions: {children: '包含序列化标记值的纯文本消息。匹配标记值的模式将被替换为内联徽章组件。', tokens: '标记定义 — 与触发器 onSelect 返回的类型相同。每个包含 value（匹配字符串）、label（显示文本）以及可选的 variant 和 icon。'},
     },
     {
       name: 'XDSChatComposerTokenElement',
-      displayName: 'XDS Chat Composer Token Element',
+      displayName: 'Chat Composer Token Element',
       description: '在 contentEditable 外部渲染标记芯片。',
       propDescriptions: {token: '徽章配置或自定义渲染。'},
     },
     {
       name: 'XDSChatLayout',
-      displayName: 'XDS Chat Layout',
+      displayName: 'Chat Layout',
       description: '完整聊天界面的布局外壳。消息在页面中自然流动，编写器固定在底部，带有毛玻璃效果。通过容器宽度自动适配密度。',
       propDescriptions: {
         children: '消息内容 — 通常是 XDSChatMessageList。在页面中自然流动。',
@@ -476,7 +476,7 @@ export const docsZh = {
     },
     {
       name: 'XDSChatLayoutScrollButton',
-      displayName: 'XDS Chat Layout Scroll Button',
+      displayName: 'Chat Layout Scroll Button',
       description: '可组合的滚动到底部按钮。可见时淡入，提供标签时展开。',
       propDescriptions: {isVisible: '按钮是否可见。', label: '可选标签 — 展开按钮（如"新消息"）。', onClick: '点击处理器。'},
     },
@@ -508,7 +508,7 @@ export const docsDense = {
   components: [
     {
       name: 'XDSChatMessageList',
-      displayName: 'XDS Chat Message List',
+      displayName: 'Chat Message List',
       description: 'presentational msg container w/ density context + infinite scroll; auto-scroll owned by XDSChatLayout',
       propDescriptions: {
         children: 'msg elements (XDSChatMessage or XDSChatSystemMessage)',
@@ -520,7 +520,7 @@ export const docsDense = {
     },
     {
       name: 'XDSChatMessage',
-      displayName: 'XDS Chat Message',
+      displayName: 'Chat Message',
       description: 'sender context wrapper; handles avatar+name+metadata+alignment by sender role',
       propDescriptions: {
         sender: 'who sent; controls alignment+layout',
@@ -534,7 +534,7 @@ export const docsDense = {
     },
     {
       name: 'XDSChatMessageBubble',
-      displayName: 'XDS Chat Message Bubble',
+      displayName: 'Chat Message Bubble',
       description: 'styled bubble container; reads sender from context; supports name/metadata slots, group corners, ghost variant',
       propDescriptions: {
         children: 'bubble content: text, XDSMarkdown, any ReactNode',
@@ -547,7 +547,7 @@ export const docsDense = {
     },
     {
       name: 'XDSChatMessageMetadata',
-      displayName: 'XDS Chat Message Metadata',
+      displayName: 'Chat Message Metadata',
       description: 'composable metadata row; renders timestamp · footer · status; reverses for user sender',
       propDescriptions: {
         timestamp: 'timestamp content; string or XDSTimestamp',
@@ -557,7 +557,7 @@ export const docsDense = {
     },
     {
       name: 'XDSChatSystemMessage',
-      displayName: 'XDS Chat System Message',
+      displayName: 'Chat System Message',
       description: 'centered non-sender msg; divider variant for date breaks, default for status notices; supports leading icon',
       propDescriptions: {
         children: 'short factual text: date, join/leave, status change',
@@ -567,7 +567,7 @@ export const docsDense = {
     },
     {
       name: 'XDSChatComposer',
-      displayName: 'XDS Chat Composer',
+      displayName: 'Chat Composer',
       description: 'composer layout shell; named slots (drawer/header/input/footer/send) w/ page-radius + concentric inner radius',
       propDescriptions: {
         onSubmit: 'submit msg handler',
@@ -591,7 +591,7 @@ export const docsDense = {
     },
     {
       name: 'XDSChatComposerInput',
-      displayName: 'XDS Chat Composer Input',
+      displayName: 'Chat Composer Input',
       description: 'rich input for composer; trigger menus (@/commands), inline tokens, msg history, paste/drop files, 16px touch font-size floor to prevent iOS zoom. Use in XDSChatComposer input slot when you need more than plain textarea.',
       propDescriptions: {
         handleRef: 'imperative handle (insertToken/insertText/focus/getValue)',
@@ -611,7 +611,7 @@ export const docsDense = {
     },
     {
       name: 'XDSChatComposerDrawer',
-      displayName: 'XDS Chat Composer Drawer',
+      displayName: 'Chat Composer Drawer',
       description: 'collapsible drawer above chat input; pass to composer `drawer` slot for attachments, context chips, previews. `count` enables collapse toggle',
       propDescriptions: {
         children: 'drawer content — tokens, chips, previews, any React elements',
@@ -624,7 +624,7 @@ export const docsDense = {
     },
     {
       name: 'XDSChatSendButton',
-      displayName: 'XDS Chat Send Button',
+      displayName: 'Chat Send Button',
       description: 'circular send/stop toggle btn for composer; reads XDSChatComposerContext; all context vals overridable via props',
       propDescriptions: {
         isStopShown: 'stop button visibility; defaults to context',
@@ -639,7 +639,7 @@ export const docsDense = {
     },
     {
       name: 'XDSChatToolCalls',
-      displayName: 'XDS Chat Tool Calls',
+      displayName: 'Chat Tool Calls',
       description: 'tool/function call display from LLM response; single=inline, multiple=collapsible summary',
       propDescriptions: {
         calls: 'tool call data array; name+status+target+duration+node+additions+deletions+resultDetail',
@@ -651,7 +651,7 @@ export const docsDense = {
     },
     {
       name: 'XDSChatTokenizedText',
-      displayName: 'XDS Chat Tokenized Text',
+      displayName: 'Chat Tokenized Text',
       description: 'renders text w/ token patterns replaced by inline badges; use in bubble for @mentions, #tags, /commands; degrades to plain text when no tokens match',
       propDescriptions: {
         children: 'plain text msg w/ serialized token values; matching patterns become inline badges',
@@ -660,13 +660,13 @@ export const docsDense = {
     },
     {
       name: 'XDSChatComposerTokenElement',
-      displayName: 'XDS Chat Composer Token Element',
+      displayName: 'Chat Composer Token Element',
       description: 'token chip outside contentEditable; badge config or custom render in data-xds-token span',
       propDescriptions: {token: 'badge config or custom render'},
     },
     {
       name: 'XDSChatLayout',
-      displayName: 'XDS Chat Layout',
+      displayName: 'Chat Layout',
       description: 'layout shell for full chat; msgs in page flow, composer fixed bottom w/ frosted glass dock; auto density via container width; scrollRef delegates to parent/body',
       propDescriptions: {
         children: 'msg content; typically XDSChatMessageList',
@@ -678,7 +678,7 @@ export const docsDense = {
     },
     {
       name: 'XDSChatLayoutScrollButton',
-      displayName: 'XDS Chat Layout Scroll Button',
+      displayName: 'Chat Layout Scroll Button',
       description: 'floating scroll-to-bottom btn; fades in when scrolled up, expands w/ label for new msgs. Default in XDSChatLayout; override via scrollButton prop.',
       propDescriptions: {
         isVisible: 'btn visibility — bind to scroll-position check',

--- a/packages/core/src/CheckboxList/CheckboxList.doc.mjs
+++ b/packages/core/src/CheckboxList/CheckboxList.doc.mjs
@@ -10,7 +10,7 @@ export const docs = {
   components: [
     {
       name: 'XDSCheckboxList',
-      displayName: 'XDS Checkbox List',
+      displayName: 'Checkbox List',
       description:
         'Checkbox group container with field integration for label, description, and status.',      props: [
         {
@@ -92,7 +92,7 @@ export const docs = {
     },
     {
       name: 'XDSCheckboxListItem',
-      displayName: 'XDS Checkbox List Item',
+      displayName: 'Checkbox List Item',
       description:
         'Individual checkbox item with label, description, and end content slot. Works in collection mode (inside XDSCheckboxList) or standalone mode (inside XDSList).',
       props: [
@@ -169,7 +169,7 @@ export const docsZh = {
   components: [
     {
       name: 'XDSCheckboxList',
-      displayName: 'XDS Checkbox List',
+      displayName: 'Checkbox List',
       description: '复选框组容器，集成字段功能，支持标签、描述和状态。',
       props: [
         {name: 'label', type: 'string', description: '复选框组的标签文本（始终渲染以确保无障碍可访问性）。', required: true},
@@ -189,7 +189,7 @@ export const docsZh = {
     },
     {
       name: 'XDSCheckboxListItem',
-      displayName: 'XDS Checkbox List Item',
+      displayName: 'Checkbox List Item',
       description: '单个复选框选项，包含标签、描述和尾部内容插槽。可在集合模式或独立模式下使用。',
       props: [
         {name: 'label', type: 'string', description: '选项的主要文本标签。', required: true},
@@ -221,7 +221,7 @@ export const docsDense = {
   components: [
     {
       name: 'XDSCheckboxList',
-      displayName: 'XDS Checkbox List',
+      displayName: 'Checkbox List',
       description:
         'Checkbox group container w/ field integration for label, description, status.',
       propDescriptions: {
@@ -242,7 +242,7 @@ export const docsDense = {
     },
     {
       name: 'XDSCheckboxListItem',
-      displayName: 'XDS Checkbox List Item',
+      displayName: 'Checkbox List Item',
       description:
         'Individual checkbox item w/ label, description, end content slot.',
       propDescriptions: {

--- a/packages/core/src/ClickableCard/ClickableCard.doc.mjs
+++ b/packages/core/src/ClickableCard/ClickableCard.doc.mjs
@@ -4,6 +4,7 @@
 export const docs = {
   name: 'ClickableCard',
   displayName: 'Clickable Card',
+  group: 'Card',
   keywords: ['card', 'clickable', 'interactive', 'navigation', 'action', 'link'],
   usage: {
     description: 'An interactive card for navigation or action targets. Nested interactive elements work independently.',

--- a/packages/core/src/CodeBlock/CodeBlock.doc.mjs
+++ b/packages/core/src/CodeBlock/CodeBlock.doc.mjs
@@ -11,7 +11,7 @@ export const docs = {
   components: [
     {
       name: 'XDSCodeBlock',
-      displayName: 'XDS Code Block',
+      displayName: 'Code Block',
       description: 'Fenced code block with syntax highlighting. Use for multi-line code snippets.',
       props: [
         {name: 'code', type: 'string', description: 'The code string to display.', required: true},
@@ -38,7 +38,7 @@ export const docs = {
     },
     {
       name: 'XDSCode',
-      displayName: 'XDS Code',
+      displayName: 'Code',
       description: 'Inline code element. Renders a styled <code> with monospace font and muted background. For fenced blocks, use XDSCodeBlock.',
       props: [
         {name: 'children', type: 'ReactNode', description: 'Code content.', required: true},
@@ -95,7 +95,7 @@ export const docsZh = {
   components: [
     {
       name: 'XDSCodeBlock',
-      displayName: 'XDS Code Block',
+      displayName: 'Code Block',
       description: '带语法高亮的围栏代码块。用于多行代码片段。',
       propDescriptions: {
         code: '要显示的代码字符串。',
@@ -122,7 +122,7 @@ export const docsZh = {
     },
     {
       name: 'XDSCode',
-      displayName: 'XDS Code',
+      displayName: 'Code',
       description: '内联代码元素。渲染带等宽字体和低调背景的 <code>。如需围栏代码块，请使用 XDSCodeBlock。',
       propDescriptions: {
         children: '代码内容。',
@@ -151,7 +151,7 @@ export const docsDense = {
   components: [
     {
       name: 'XDSCodeBlock',
-      displayName: 'XDS Code Block',
+      displayName: 'Code Block',
       description: 'fenced code block w/ syntax highlighting; for multi-line snippets',
       propDescriptions: {
         code: 'code string to display',
@@ -178,7 +178,7 @@ export const docsDense = {
     },
     {
       name: 'XDSCode',
-      displayName: 'XDS Code',
+      displayName: 'Code',
       description: 'inline code element; styled <code> w/ monospace+muted bg; for prose',
       propDescriptions: {
         children: 'code content',

--- a/packages/core/src/Collapsible/Collapsible.doc.mjs
+++ b/packages/core/src/Collapsible/Collapsible.doc.mjs
@@ -21,7 +21,7 @@ export const docs = {
   components: [
     {
       name: 'XDSCollapsible',
-      displayName: 'XDS Collapsible',
+      displayName: 'Collapsible',
       description:
         'A primitive that makes any content collapsible — a trigger button toggles visibility of the content area, managing its own state or deferring to a parent XDSCollapsibleGroup.',
       props: [
@@ -62,7 +62,7 @@ export const docs = {
       ],    },
     {
       name: 'XDSCollapsibleGroup',
-      displayName: 'XDS Collapsible Group',
+      displayName: 'Collapsible Group',
       description:
         'Coordinates multiple XDSCollapsible instances so only one (single mode) or any number (multiple mode) can be open at a time. Renders no wrapper DOM element.',
       props: [
@@ -142,7 +142,7 @@ export const docsZh = {
   components: [
     {
       name: 'XDSCollapsible',
-      displayName: 'XDS Collapsible',
+      displayName: 'Collapsible',
       description:
         '使任何内容可折叠的原语——触发按钮切换内容区域的可见性，自行管理状态或委托给父级 XDSCollapsibleGroup。',
       props: [
@@ -156,7 +156,7 @@ export const docsZh = {
     },
     {
       name: 'XDSCollapsibleGroup',
-      displayName: 'XDS Collapsible Group',
+      displayName: 'Collapsible Group',
       description:
         '协调多个 XDSCollapsible 实例，使同一时间只有一个（single 模式）或任意数量（multiple 模式）可以展开。不渲染包裹 DOM 元素。',
       props: [
@@ -186,7 +186,7 @@ export const docsDense = {
   components: [
     {
       name: 'XDSCollapsible',
-      displayName: 'XDS Collapsible',
+      displayName: 'Collapsible',
       description: 'makes content collapsible; trigger toggles visibility, manages own state or defers to parent group',
       propDescriptions: {
         trigger: 'content in trigger area (always visible)',
@@ -199,7 +199,7 @@ export const docsDense = {
     },
     {
       name: 'XDSCollapsibleGroup',
-      displayName: 'XDS Collapsible Group',
+      displayName: 'Collapsible Group',
       description: 'coordinates multiple XDSCollapsible instances; single or multiple open. no wrapper DOM.',
       propDescriptions: {
         type: 'one or many items open simultaneously',

--- a/packages/core/src/CommandPalette/CommandPalette.doc.mjs
+++ b/packages/core/src/CommandPalette/CommandPalette.doc.mjs
@@ -21,7 +21,7 @@ export const docs = {
   components: [
     {
       name: 'XDSCommandPalette',
-      displayName: 'XDS Command Palette',
+      displayName: 'Command Palette',
       description:
         'Root component. Manages open state, search, keyboard navigation, and composition slots.',
       props: [
@@ -117,7 +117,7 @@ export const docs = {
     },
     {
       name: 'XDSCommandPaletteInput',
-      displayName: 'XDS Command Palette Input',
+      displayName: 'Command Palette Input',
       description:
         'Search input slot. Auto-focuses on mount. Wires to command palette context when used inside XDSCommandPalette.',
       props: [
@@ -165,7 +165,7 @@ export const docs = {
     },
     {
       name: 'XDSCommandPaletteList',
-      displayName: 'XDS Command Palette List',
+      displayName: 'Command Palette List',
       description:
         'Scrollable results container. Renders as a listbox for ARIA. Contains XDSCommandPaletteItem and XDSCommandPaletteGroup children.',
       props: [
@@ -191,7 +191,7 @@ export const docs = {
     },
     {
       name: 'XDSCommandPaletteItem',
-      displayName: 'XDS Command Palette Item',
+      displayName: 'Command Palette Item',
       description:
         'A selectable item. Accepts arbitrary children for full rendering control. Registers with context for keyboard navigation when inside XDSCommandPalette.',
       props: [
@@ -242,7 +242,7 @@ export const docs = {
     },
     {
       name: 'XDSCommandPaletteGroup',
-      displayName: 'XDS Command Palette Group',
+      displayName: 'Command Palette Group',
       description: 'Visual grouping with a heading label. Place inside XDSCommandPaletteList.',
       props: [
         {
@@ -267,7 +267,7 @@ export const docs = {
     },
     {
       name: 'XDSCommandPaletteFooter',
-      displayName: 'XDS Command Palette Footer',
+      displayName: 'Command Palette Footer',
       description:
         'Footer showing keyboard navigation hints. Renders default arrow/Enter/Escape hints when no children are provided.',
       props: [
@@ -287,7 +287,7 @@ export const docs = {
     },
     {
       name: 'XDSCommandPaletteEmpty',
-      displayName: 'XDS Command Palette Empty',
+      displayName: 'Command Palette Empty',
       description:
         'Empty state display for the results area. Rendered automatically by XDSCommandPalette for no-results and no-query states.',
       props: [
@@ -334,7 +334,7 @@ export const docsZh = {
   components: [
     {
       name: 'XDSCommandPalette',
-      displayName: 'XDS Command Palette',
+      displayName: 'Command Palette',
       description: '根组件。管理打开状态、搜索、键盘导航和组合插槽。',
       propDescriptions: {
         isOpen: '命令面板对话框是否可见。',
@@ -355,7 +355,7 @@ export const docsZh = {
     },
     {
       name: 'XDSCommandPaletteInput',
-      displayName: 'XDS Command Palette Input',
+      displayName: 'Command Palette Input',
       description: '搜索输入插槽。挂载时自动聚焦。在 XDSCommandPalette 内使用时连接到上下文。',
       propDescriptions: {
         placeholder: '输入框的占位文本。',
@@ -368,13 +368,13 @@ export const docsZh = {
     },
     {
       name: 'XDSCommandPaletteList',
-      displayName: 'XDS Command Palette List',
+      displayName: 'Command Palette List',
       description: '可滚动的结果容器。作为 listbox 渲染以符合 ARIA 规范。',
       propDescriptions: {children: '条目、分组和空状态。', label: 'listbox 的无障碍标签。', xstyle: 'StyleX 布局自定义样式。必须是 stylex.create() 的值。'},
     },
     {
       name: 'XDSCommandPaletteItem',
-      displayName: 'XDS Command Palette Item',
+      displayName: 'Command Palette Item',
       description: '可选择的条目。接受任意子元素以实现完整的渲染控制。',
       propDescriptions: {
         value: '用于标识和选择的唯一值。',
@@ -388,19 +388,19 @@ export const docsZh = {
     },
     {
       name: 'XDSCommandPaletteGroup',
-      displayName: 'XDS Command Palette Group',
+      displayName: 'Command Palette Group',
       description: '带标题标签的视觉分组。放置在 XDSCommandPaletteList 内。',
       propDescriptions: {heading: '分组标题文本。', children: 'XDSCommandPaletteItem 子元素。', xstyle: 'StyleX 布局自定义样式。必须是 stylex.create() 的值。'},
     },
     {
       name: 'XDSCommandPaletteFooter',
-      displayName: 'XDS Command Palette Footer',
+      displayName: 'Command Palette Footer',
       description: '显示键盘导航提示的页脚。未提供子元素时渲染默认方向键/Enter/Escape 提示。',
       propDescriptions: {children: '自定义页脚内容。省略时通过 XDSKbd 渲染默认键盘提示。', xstyle: 'StyleX 布局自定义样式。必须是 stylex.create() 的值。'},
     },
     {
       name: 'XDSCommandPaletteEmpty',
-      displayName: 'XDS Command Palette Empty',
+      displayName: 'Command Palette Empty',
       description: '结果区域的空状态展示。由 XDSCommandPalette 在无结果和无查询状态下自动渲染。',
       propDescriptions: {children: '要显示的消息或内容。'},
     },
@@ -423,7 +423,7 @@ export const docsDense = {
   components: [
     {
       name: 'XDSCommandPalette',
-      displayName: 'XDS Command Palette',
+      displayName: 'Command Palette',
       description: 'root; manages open state, search, keyboard nav, composition slots',
       propDescriptions: {
         isOpen: 'dialog visible',
@@ -444,7 +444,7 @@ export const docsDense = {
     },
     {
       name: 'XDSCommandPaletteInput',
-      displayName: 'XDS Command Palette Input',
+      displayName: 'Command Palette Input',
       description: 'search input; auto-focus on mount; wires to context inside XDSCommandPalette',
       propDescriptions: {
         placeholder: 'input placeholder text',
@@ -457,7 +457,7 @@ export const docsDense = {
     },
     {
       name: 'XDSCommandPaletteList',
-      displayName: 'XDS Command Palette List',
+      displayName: 'Command Palette List',
       description: 'scrollable results container; role=listbox',
       propDescriptions: {
         children: 'items, groups, empty states',
@@ -467,7 +467,7 @@ export const docsDense = {
     },
     {
       name: 'XDSCommandPaletteItem',
-      displayName: 'XDS Command Palette Item',
+      displayName: 'Command Palette Item',
       description: 'selectable item; arbitrary children; registers w/ context for kbd nav',
       propDescriptions: {
         value: 'unique id for selection',
@@ -481,7 +481,7 @@ export const docsDense = {
     },
     {
       name: 'XDSCommandPaletteGroup',
-      displayName: 'XDS Command Palette Group',
+      displayName: 'Command Palette Group',
       description: 'group w/ heading label; inside XDSCommandPaletteList',
       propDescriptions: {
         heading: 'group heading text',
@@ -491,7 +491,7 @@ export const docsDense = {
     },
     {
       name: 'XDSCommandPaletteFooter',
-      displayName: 'XDS Command Palette Footer',
+      displayName: 'Command Palette Footer',
       description: 'footer w/ kbd hints; default=arrow/Enter/Escape hints via XDSKbd',
       propDescriptions: {
         children: 'custom content; default renders kbd hints',
@@ -500,7 +500,7 @@ export const docsDense = {
     },
     {
       name: 'XDSCommandPaletteEmpty',
-      displayName: 'XDS Command Palette Empty',
+      displayName: 'Command Palette Empty',
       description: 'empty state; auto-rendered by palette for no-results+no-query states',
       propDescriptions: {
         children: 'message or content to display',

--- a/packages/core/src/ContextMenu/ContextMenu.doc.mjs
+++ b/packages/core/src/ContextMenu/ContextMenu.doc.mjs
@@ -22,7 +22,7 @@ export const docs = {
   components: [
     {
       name: 'XDSContextMenu',
-      displayName: 'XDS Context Menu',
+      displayName: 'Context Menu',
       description:
         'A context menu that appears on right-click at the cursor position. Wraps trigger content as children.',
       props: [
@@ -73,7 +73,7 @@ export const docs = {
     },
     {
       name: 'XDSContextMenuItem',
-      displayName: 'XDS Context Menu Item',
+      displayName: 'Context Menu Item',
       description:
         'Menu item component for compound mode. Re-exported from XDSDropdownMenuItem for discoverability.',
       props: [
@@ -138,7 +138,7 @@ export const docsZh = {
   components: [
     {
       name: 'XDSContextMenu',
-      displayName: 'XDS Context Menu',
+      displayName: 'Context Menu',
       description:
         '右键点击时在光标位置出现的上下文菜单。将触发内容作为子元素包裹。',
       props: [
@@ -188,7 +188,7 @@ export const docsZh = {
     },
     {
       name: 'XDSContextMenuItem',
-      displayName: 'XDS Context Menu Item',
+      displayName: 'Context Menu Item',
       description:
         '复合模式的菜单项组件。从 XDSDropdownMenuItem 重新导出以便发现。',
       props: [
@@ -248,7 +248,7 @@ export const docsDense = {
   components: [
     {
       name: 'XDSContextMenu',
-      displayName: 'XDS Context Menu',
+      displayName: 'Context Menu',
       description: 'right-click trigger + fixed-position popup menu',
       propDescriptions: {
         children: 'trigger area — right-click to open menu',
@@ -262,7 +262,7 @@ export const docsDense = {
     },
     {
       name: 'XDSContextMenuItem',
-      displayName: 'XDS Context Menu Item',
+      displayName: 'Context Menu Item',
       description: 're-exported XDSDropdownMenuItem for compound mode',
       propDescriptions: {
         icon: 'icon before label',

--- a/packages/core/src/DateInput/DateInput.doc.mjs
+++ b/packages/core/src/DateInput/DateInput.doc.mjs
@@ -5,6 +5,7 @@
 export const docs = {
   name: 'DateInput',
   displayName: 'Date Input',
+  group: 'DateInput',
   keywords: ["dateinput","datepicker","datefield","calendar","dateselect","dateentry","datechooser"],
   props: [
     {

--- a/packages/core/src/DateRangeInput/DateRangeInput.doc.mjs
+++ b/packages/core/src/DateRangeInput/DateRangeInput.doc.mjs
@@ -5,6 +5,7 @@
 export const docs = {
   name: 'DateRangeInput',
   displayName: 'Date Range Input',
+  group: 'DateInput',
   keywords: ["daterangepicker","daterange","range","calendar","filter","analytics","period","schedule"],
   props: [
     { name: 'label', type: 'string', description: 'Label text.', required: true },

--- a/packages/core/src/DateTimeInput/DateTimeInput.doc.mjs
+++ b/packages/core/src/DateTimeInput/DateTimeInput.doc.mjs
@@ -5,6 +5,7 @@
 export const docs = {
   name: 'DateTimeInput',
   displayName: 'Date Time Input',
+  group: 'DateInput',
   keywords: ["datetimepicker","datetime","datepicker","timepicker","calendar","schedule","event","deadline","timestamp"],
   props: [
     {

--- a/packages/core/src/Dialog/Dialog.doc.mjs
+++ b/packages/core/src/Dialog/Dialog.doc.mjs
@@ -37,7 +37,7 @@ export const docs = {
   components: [
     {
       name: 'XDSDialog',
-      displayName: 'XDS Dialog',
+      displayName: 'Dialog',
       description: 'Modal dialog using the native <dialog> element.',
       props: [
         {
@@ -100,7 +100,7 @@ export const docs = {
       ],    },
     {
       name: 'XDSDialogHeader',
-      displayName: 'XDS Dialog Header',
+      displayName: 'Dialog Header',
       description:
         'Header for dialogs with a title, optional subtitle, close button, and start/end content slots.',
       props: [
@@ -197,7 +197,7 @@ export const docsZh = {
   components: [
     {
       name: 'XDSDialog',
-      displayName: 'XDS Dialog',
+      displayName: 'Dialog',
       description: '使用原生 <dialog> 元素的模态对话框。',
       props: [
         {
@@ -254,7 +254,7 @@ export const docsZh = {
     },
     {
       name: 'XDSDialogHeader',
-      displayName: 'XDS Dialog Header',
+      displayName: 'Dialog Header',
       description:
         '对话框头部，包含标题、可选副标题、关闭按钮以及首尾内容插槽。',
       props: [
@@ -330,7 +330,7 @@ export const docsDense = {
   components: [
     {
       name: 'XDSDialog',
-      displayName: 'XDS Dialog',
+      displayName: 'Dialog',
       description: 'modal dialog using native <dialog>',
       propDescriptions: {
         isOpen: 'dialog open state',
@@ -345,7 +345,7 @@ export const docsDense = {
     },
     {
       name: 'XDSDialogHeader',
-      displayName: 'XDS Dialog Header',
+      displayName: 'Dialog Header',
       description: 'dialog header w/ title, optional subtitle, close button, start/end content slots',
       propDescriptions: {
         title: 'dialog title (receives focus on open)',

--- a/packages/core/src/DropdownMenu/DropdownMenu.doc.mjs
+++ b/packages/core/src/DropdownMenu/DropdownMenu.doc.mjs
@@ -24,7 +24,7 @@ export const docs = {
   components: [
     {
       name: 'XDSDropdownMenu',
-      displayName: 'XDS Dropdown Menu',
+      displayName: 'Dropdown Menu',
       description:
         'Main dropdown menu component with a trigger button and popup item list.',
       props: [
@@ -83,7 +83,7 @@ export const docs = {
       ],    },
     {
       name: 'XDSDropdownMenuItem',
-      displayName: 'XDS Dropdown Menu Item',
+      displayName: 'Dropdown Menu Item',
       description:
         'Helper component for custom item rendering with consistent styling.',
       props: [
@@ -148,7 +148,7 @@ export const docsZh = {
   components: [
     {
       name: 'XDSDropdownMenu',
-      displayName: 'XDS Dropdown Menu',
+      displayName: 'Dropdown Menu',
       description:
         '主下拉菜单组件，包含触发按钮和弹出项列表。',
       props: [
@@ -208,7 +208,7 @@ export const docsZh = {
     },
     {
       name: 'XDSDropdownMenuItem',
-      displayName: 'XDS Dropdown Menu Item',
+      displayName: 'Dropdown Menu Item',
       description:
         '用于自定义项渲染的辅助组件，提供一致的样式。',
       props: [
@@ -267,7 +267,7 @@ export const docsDense = {
   components: [
     {
       name: 'XDSDropdownMenu',
-      displayName: 'XDS Dropdown Menu',
+      displayName: 'Dropdown Menu',
       description: 'trigger button + popup item list',
       propDescriptions: {
         button: 'trigger button props (XDSButton props except onClick)',
@@ -283,7 +283,7 @@ export const docsDense = {
     },
     {
       name: 'XDSDropdownMenuItem',
-      displayName: 'XDS Dropdown Menu Item',
+      displayName: 'Dropdown Menu Item',
       description: 'helper for custom item rendering w/ consistent styling',
       propDescriptions: {
         icon: 'icon before label',

--- a/packages/core/src/Field/Field.doc.mjs
+++ b/packages/core/src/Field/Field.doc.mjs
@@ -29,7 +29,7 @@ export const docs = {
   components: [
     {
       name: 'XDSField',
-      displayName: 'XDS Field',
+      displayName: 'Field',
       description:
         'Form field wrapper that provides label, description, and optional/required indicators.',      props: [
         {
@@ -143,7 +143,7 @@ export const docs = {
     },
     {
       name: 'XDSFieldLabel',
-      displayName: 'XDS Field Label',
+      displayName: 'Field Label',
       description:
         'Standalone label component with optional/required indicators and tooltip support.',
       props: [
@@ -197,7 +197,7 @@ export const docs = {
     },
     {
       name: 'XDSFieldStatus',
-      displayName: 'XDS Field Status',
+      displayName: 'Field Status',
       description:
         'Status message component for form field validation feedback.',
       props: [
@@ -269,7 +269,7 @@ export const docsZh = {
   components: [
     {
       name: 'XDSField',
-      displayName: 'XDS Field',
+      displayName: 'Field',
       description:
         '表单字段包装器，提供标签、描述以及可选/必填指示器。',
       props: [
@@ -384,7 +384,7 @@ export const docsZh = {
     },
     {
       name: 'XDSFieldLabel',
-      displayName: 'XDS Field Label',
+      displayName: 'Field Label',
       description:
         '独立的标签组件，支持可选/必填指示器和工具提示。',
       props: [
@@ -438,7 +438,7 @@ export const docsZh = {
     },
     {
       name: 'XDSFieldStatus',
-      displayName: 'XDS Field Status',
+      displayName: 'Field Status',
       description:
         '用于表单字段验证反馈的状态消息组件。',
       props: [
@@ -496,7 +496,7 @@ export const docsDense = {
   components: [
     {
       name: 'XDSField',
-      displayName: 'XDS Field',
+      displayName: 'Field',
       description: 'Form field wrapper w/ label, description + optional/required indicators.',
       propDescriptions: {
         label: 'Label text for field (always rendered for a11y).',
@@ -520,7 +520,7 @@ export const docsDense = {
     },
     {
       name: 'XDSFieldLabel',
-      displayName: 'XDS Field Label',
+      displayName: 'Field Label',
       description: 'Standalone label w/ optional/required indicators + tooltip support.',
       propDescriptions: {
         label: 'Label text.',
@@ -535,7 +535,7 @@ export const docsDense = {
     },
     {
       name: 'XDSFieldStatus',
-      displayName: 'XDS Field Status',
+      displayName: 'Field Status',
       description: 'Status message for form field validation feedback.',
       propDescriptions: {
         type: 'Status type.',

--- a/packages/core/src/Grid/Grid.doc.mjs
+++ b/packages/core/src/Grid/Grid.doc.mjs
@@ -27,7 +27,7 @@ export const docs = {
   components: [
     {
       name: 'XDSGrid',
-      displayName: 'XDS Grid',
+      displayName: 'Grid',
       description: 'Grid container with fixed or responsive columns.',
       props: [
         {
@@ -94,7 +94,7 @@ export const docs = {
     },
     {
       name: 'XDSGridSpan',
-      displayName: 'XDS Grid Span',
+      displayName: 'Grid Span',
       description: 'Grid item that spans multiple columns or rows.',
       props: [
         {
@@ -131,7 +131,7 @@ export const docsZh = {
   components: [
     {
       name: 'XDSGrid',
-      displayName: 'XDS Grid',
+      displayName: 'Grid',
       description: '支持固定列或响应式列的网格容器。',
       props: [
         {
@@ -197,7 +197,7 @@ export const docsZh = {
     },
     {
       name: 'XDSGridSpan',
-      displayName: 'XDS Grid Span',
+      displayName: 'Grid Span',
       description: '可跨越多列或多行的网格项。',
       props: [
         {
@@ -249,7 +249,7 @@ export const docsDense = {
   components: [
     {
       name: 'XDSGrid',
-      displayName: 'XDS Grid',
+      displayName: 'Grid',
       description: 'Grid container w/ fixed or responsive columns.',
       propDescriptions: {
         columns: "Column config. Number for fixed cols. Object {minWidth, max?, repeat?} for responsive. repeat: 'fill' (default, consistent widths) or 'fit' (stretch).",
@@ -267,7 +267,7 @@ export const docsDense = {
     },
     {
       name: 'XDSGridSpan',
-      displayName: 'XDS Grid Span',
+      displayName: 'Grid Span',
       description: 'Grid item spanning multiple columns/rows.',
       propDescriptions: {
         columns: "Columns to span; 'full' spans entire row.",

--- a/packages/core/src/HoverCard/HoverCard.doc.mjs
+++ b/packages/core/src/HoverCard/HoverCard.doc.mjs
@@ -27,7 +27,7 @@ export const docs = {
   components: [
     {
       name: 'XDSHoverCard',
-      displayName: 'XDS Hover Card',
+      displayName: 'Hover Card',
       description:
         'Component wrapper for hover card display — a richer, larger overlay triggered on hover or focus.',      props: [
         {
@@ -135,7 +135,7 @@ export const docsZh = {
   components: [
     {
       name: 'XDSHoverCard',
-      displayName: 'XDS Hover Card',
+      displayName: 'Hover Card',
       description:
         '悬浮卡片显示的组件包装器，在悬停或聚焦时触发更丰富、更大的浮层。',
       props: [
@@ -233,7 +233,7 @@ export const docsDense = {
   components: [
     {
       name: 'XDSHoverCard',
-      displayName: 'XDS Hover Card',
+      displayName: 'Hover Card',
       description: 'Component wrapper for hover card overlay; richer overlay triggered on hover/focus.',
       propDescriptions: {
         children: 'Trigger element; must accept ref.',

--- a/packages/core/src/InputGroup/InputGroup.doc.mjs
+++ b/packages/core/src/InputGroup/InputGroup.doc.mjs
@@ -15,7 +15,7 @@ export const docs = {
   components: [
     {
       name: 'XDSInputGroup',
-      displayName: 'XDS Input Group',
+      displayName: 'Input Group',
       description: 'Groups an input with prefix/suffix addons in a visually connected container with shared border and focus ring.',
       props: [
         {name: 'children', type: 'ReactNode', description: 'Input and XDSInputGroupText children.', required: true},
@@ -34,7 +34,7 @@ export const docs = {
     },
     {
       name: 'XDSInputGroupText',
-      displayName: 'XDS Input Group Text',
+      displayName: 'Input Group Text',
       description: 'A prefix or suffix text element rendered inside XDSInputGroup. Displays text or icons.',
       props: [
         {name: 'children', type: 'ReactNode', description: 'Text or icon content.', required: true},
@@ -77,7 +77,7 @@ export const docsDense = {
   components: [
     {
       name: 'XDSInputGroup',
-      displayName: 'XDS Input Group',
+      displayName: 'Input Group',
       description: 'connected input+addon container w/ shared border, focus ring',
       propDescriptions: {
         children: 'input + addon children',
@@ -96,7 +96,7 @@ export const docsDense = {
     },
     {
       name: 'XDSInputGroupText',
-      displayName: 'XDS Input Group Text',
+      displayName: 'Input Group Text',
       description: 'prefix/suffix text/icon element',
       propDescriptions: {
         children: 'text or icon content',

--- a/packages/core/src/Item/Item.doc.mjs
+++ b/packages/core/src/Item/Item.doc.mjs
@@ -21,7 +21,7 @@ export const docs = {
   components: [
     {
       name: 'XDSItem',
-      displayName: 'XDS Item',
+      displayName: 'Item',
       description: 'A universal item primitive that unifies the "media + label + description + trailing content" layout pattern. Use as a building block for list items, menu items, contact rows, notifications, and more.',
       props: [
         {name: 'label', type: 'ReactNode', description: 'Primary text identifying this item. Accepts string (auto-truncated) or ReactNode (for rich content).', required: true},
@@ -73,7 +73,7 @@ export const docsZh = {
   components: [
     {
       name: 'XDSItem',
-      displayName: 'XDS Item',
+      displayName: 'Item',
       description: '通用项目原语，统一 "媒体 + 标签 + 描述 + 尾部内容" 布局模式。用作列表项、菜单项、联系人行、通知等的构建块。',
       propDescriptions: {
         label: '标识此项目的主要文本。接受字符串（自动截断）或 ReactNode（用于富内容）。',
@@ -139,7 +139,7 @@ export const docsDense = {
   components: [
     {
       name: 'XDSItem',
-      displayName: 'XDS Item',
+      displayName: 'Item',
       description: 'universal item primitive w/ media+label+description+trailing layout',
       propDescriptions: {
         label: 'Primary text. String auto-truncates; ReactNode for rich content.',

--- a/packages/core/src/Layout/Layout.doc.mjs
+++ b/packages/core/src/Layout/Layout.doc.mjs
@@ -26,7 +26,7 @@ export const docs = {
   components: [
     {
       name: 'XDSLayout',
-      displayName: 'XDS Layout',
+      displayName: 'Layout',
       description:
         'Page shell with header, sidebar(s), content, and footer slots for building full app layouts.',
       props: [
@@ -70,7 +70,7 @@ export const docs = {
       ],    },
     {
       name: 'XDSLayoutHeader',
-      displayName: 'XDS Layout Header',
+      displayName: 'Layout Header',
       description: 'Top bar for page titles, app bars, and toolbars.',
       props: [
         {
@@ -103,7 +103,7 @@ export const docs = {
     },
     {
       name: 'XDSLayoutContent',
-      displayName: 'XDS Layout Content',
+      displayName: 'Layout Content',
       description: 'Scrollable main content area.',
       props: [
         {
@@ -131,7 +131,7 @@ export const docs = {
     },
     {
       name: 'XDSLayoutFooter',
-      displayName: 'XDS Layout Footer',
+      displayName: 'Layout Footer',
       description: 'Bottom bar for action bars, pagination, and status bars.',
       props: [
         {
@@ -164,7 +164,7 @@ export const docs = {
     },
     {
       name: 'XDSLayoutPanel',
-      displayName: 'XDS Layout Panel',
+      displayName: 'Layout Panel',
       description: 'Sidebar for navigation, settings, or inspector panels.',
       props: [
         {
@@ -198,40 +198,40 @@ export const docs = {
     },
     {
       name: 'XDSLayoutContainer',
-      displayName: 'XDS Layout Container',
+      displayName: 'Layout Container',
       description:
         'Primitive component that sets CSS variables for padding, used as the base for XDSCard and XDSSection.',
       props: [],
     },
     {
       name: 'XDSCard',
-      displayName: 'XDS Card',
+      displayName: 'Card',
       description:
         'Card with shadow and themed styling, built on XDSLayoutContainer.',
       props: [],
     },
     {
       name: 'XDSSection',
-      displayName: 'XDS Section',
+      displayName: 'Section',
       description:
         'Section with background variants (section, transparent, muted), built on XDSLayoutContainer.',
       props: [],
     },
     {
       name: 'XDSHStack',
-      displayName: 'XDSH Stack',
+      displayName: 'H Stack',
       description: 'Horizontal stack that arranges children left-to-right.',
       props: [],
     },
     {
       name: 'XDSVStack',
-      displayName: 'XDSV Stack',
+      displayName: 'V Stack',
       description: 'Vertical stack that arranges children top-to-bottom.',
       props: [],
     },
     {
       name: 'XDSStackItem',
-      displayName: 'XDS Stack Item',
+      displayName: 'Stack Item',
       description:
         'Stack item with fill and alignment control for use inside XDSHStack or XDSVStack.',
       props: [],
@@ -265,7 +265,7 @@ export const docsZh = {
   components: [
     {
       name: 'XDSLayout',
-      displayName: 'XDS Layout',
+      displayName: 'Layout',
       description:
         '带有页眉、侧边栏、内容和页脚插槽的页面外壳，用于构建完整的应用布局。',
       props: [
@@ -305,7 +305,7 @@ export const docsZh = {
     },
     {
       name: 'XDSLayoutHeader',
-      displayName: 'XDS Layout Header',
+      displayName: 'Layout Header',
       description: '用于页面标题、应用栏和工具栏的顶部栏。',
       props: [
         {
@@ -338,7 +338,7 @@ export const docsZh = {
     },
     {
       name: 'XDSLayoutContent',
-      displayName: 'XDS Layout Content',
+      displayName: 'Layout Content',
       description: '可滚动的主内容区域。',
       props: [
         {
@@ -366,7 +366,7 @@ export const docsZh = {
     },
     {
       name: 'XDSLayoutFooter',
-      displayName: 'XDS Layout Footer',
+      displayName: 'Layout Footer',
       description: '用于操作栏、分页和状态栏的底部栏。',
       props: [
         {
@@ -399,7 +399,7 @@ export const docsZh = {
     },
     {
       name: 'XDSLayoutPanel',
-      displayName: 'XDS Layout Panel',
+      displayName: 'Layout Panel',
       description: '用于导航、设置或检查器面板的侧边栏。',
       props: [
         {
@@ -433,40 +433,40 @@ export const docsZh = {
     },
     {
       name: 'XDSLayoutContainer',
-      displayName: 'XDS Layout Container',
+      displayName: 'Layout Container',
       description:
         '设置内边距 CSS 变量的基础组件，作为 XDSCard 和 XDSSection 的基础。',
       props: [],
     },
     {
       name: 'XDSCard',
-      displayName: 'XDS Card',
+      displayName: 'Card',
       description:
         '基于 XDSLayoutContainer 构建的带有阴影和主题样式的卡片。',
       props: [],
     },
     {
       name: 'XDSSection',
-      displayName: 'XDS Section',
+      displayName: 'Section',
       description:
         '基于 XDSLayoutContainer 构建的带有背景变体（section、transparent、muted）的区块。',
       props: [],
     },
     {
       name: 'XDSHStack',
-      displayName: 'XDSH Stack',
+      displayName: 'H Stack',
       description: '将子元素从左到右排列的水平堆叠。',
       props: [],
     },
     {
       name: 'XDSVStack',
-      displayName: 'XDSV Stack',
+      displayName: 'V Stack',
       description: '将子元素从上到下排列的垂直堆叠。',
       props: [],
     },
     {
       name: 'XDSStackItem',
-      displayName: 'XDS Stack Item',
+      displayName: 'Stack Item',
       description:
         '用于 XDSHStack 或 XDSVStack 内部的堆叠项，支持填充和对齐控制。',
       props: [],
@@ -501,7 +501,7 @@ export const docsDense = {
   components: [
     {
       name: 'XDSLayout',
-      displayName: 'XDS Layout',
+      displayName: 'Layout',
       description:
         'Page shell w/ header, sidebar(s), content, footer slots for full app layouts.',
       propDescriptions: {
@@ -515,7 +515,7 @@ export const docsDense = {
     },
     {
       name: 'XDSLayoutHeader',
-      displayName: 'XDS Layout Header',
+      displayName: 'Layout Header',
       description: 'Top bar for page titles, app bars, toolbars.',
       propDescriptions: {
         children: 'Header content.',
@@ -527,7 +527,7 @@ export const docsDense = {
     },
     {
       name: 'XDSLayoutContent',
-      displayName: 'XDS Layout Content',
+      displayName: 'Layout Content',
       description: 'Scrollable main content area.',
       propDescriptions: {
         children: 'Content.',
@@ -538,7 +538,7 @@ export const docsDense = {
     },
     {
       name: 'XDSLayoutFooter',
-      displayName: 'XDS Layout Footer',
+      displayName: 'Layout Footer',
       description: 'Bottom bar for action bars, pagination, status bars.',
       propDescriptions: {
         children: 'Footer content.',
@@ -550,7 +550,7 @@ export const docsDense = {
     },
     {
       name: 'XDSLayoutPanel',
-      displayName: 'XDS Layout Panel',
+      displayName: 'Layout Panel',
       description: 'Sidebar for navigation, settings, inspector panels.',
       propDescriptions: {
         children: 'Panel content.',
@@ -562,35 +562,35 @@ export const docsDense = {
     },
     {
       name: 'XDSLayoutContainer',
-      displayName: 'XDS Layout Container',
+      displayName: 'Layout Container',
       description:
         'Primitive setting CSS padding vars; base for XDSCard + XDSSection.',
     },
     {
       name: 'XDSCard',
-      displayName: 'XDS Card',
+      displayName: 'Card',
       description:
         'Card w/ shadow + themed styling, built on XDSLayoutContainer.',
     },
     {
       name: 'XDSSection',
-      displayName: 'XDS Section',
+      displayName: 'Section',
       description:
         'Section w/ background variants (section, transparent, muted), built on XDSLayoutContainer.',
     },
     {
       name: 'XDSHStack',
-      displayName: 'XDSH Stack',
+      displayName: 'H Stack',
       description: 'Horizontal stack arranging children left-to-right.',
     },
     {
       name: 'XDSVStack',
-      displayName: 'XDSV Stack',
+      displayName: 'V Stack',
       description: 'Vertical stack arranging children top-to-bottom.',
     },
     {
       name: 'XDSStackItem',
-      displayName: 'XDS Stack Item',
+      displayName: 'Stack Item',
       description:
         'Stack item w/ fill + alignment control inside XDSHStack or XDSVStack.',
     },

--- a/packages/core/src/Link/Link.doc.mjs
+++ b/packages/core/src/Link/Link.doc.mjs
@@ -20,7 +20,7 @@ export const docs = {
   components: [
     {
       name: 'XDSLink',
-      displayName: 'XDS Link',
+      displayName: 'Link',
       description:
         'Styled anchor link with variants, external link support, and polymorphic rendering.',
       props: [
@@ -95,7 +95,7 @@ export const docs = {
       ],    },
     {
       name: 'XDSLinkProvider',
-      displayName: 'XDS Link Provider',
+      displayName: 'Link Provider',
       description:
         'Provider that sets the default link component for all XDS link-rendering components in the subtree. ' +
         'Wrap your app root to replace native <a> elements with your framework router (Next.js Link, React Router Link, etc.).',
@@ -146,7 +146,7 @@ export const docsZh = {
   components: [
     {
       name: 'XDSLink',
-      displayName: 'XDS Link',
+      displayName: 'Link',
       description:
         '带有变体、外部链接支持和多态渲染的样式化锚点链接。',
       props: [
@@ -221,7 +221,7 @@ export const docsZh = {
     },
     {
       name: 'XDSLinkProvider',
-      displayName: 'XDS Link Provider',
+      displayName: 'Link Provider',
       description:
         '为子树中所有 XDS 链接组件设置默认链接组件的 Provider。',
       props: [
@@ -283,7 +283,7 @@ export const docsDense = {
   components: [
     {
       name: 'XDSLink',
-      displayName: 'XDS Link',
+      displayName: 'Link',
       description:
         'Styled anchor link w/ variants, external link support, polymorphic rendering.',
       propDescriptions: {
@@ -304,7 +304,7 @@ export const docsDense = {
     },
     {
       name: 'XDSLinkProvider',
-      displayName: 'XDS Link Provider',
+      displayName: 'Link Provider',
       description:
         'Provider setting default link component for all XDS links in subtree.',
       propDescriptions: {

--- a/packages/core/src/List/List.doc.mjs
+++ b/packages/core/src/List/List.doc.mjs
@@ -16,7 +16,7 @@ export const docs = {
   components: [
     {
       name: 'XDSList',
-      displayName: 'XDS List',
+      displayName: 'List',
       description: 'List container with density, dividers, and header support.',      props: [
         {
           name: 'children',
@@ -60,7 +60,7 @@ export const docs = {
     },
     {
       name: 'XDSListItem',
-      displayName: 'XDS List Item',
+      displayName: 'List Item',
       description:
         'List item with label, description, start/end content slots, and interactive patterns.',
       props: [
@@ -162,7 +162,7 @@ export const docsZh = {
   components: [
     {
       name: 'XDSList',
-      displayName: 'XDS List',
+      displayName: 'List',
       description: '列表容器，支持密度、分割线和标题。',
       props: [
         {
@@ -205,7 +205,7 @@ export const docsZh = {
     },
     {
       name: 'XDSListItem',
-      displayName: 'XDS List Item',
+      displayName: 'List Item',
       description:
         '列表项，包含标签、描述、起始/结束内容插槽和交互模式。',
       props: [
@@ -313,7 +313,7 @@ export const docsDense = {
   components: [
     {
       name: 'XDSList',
-      displayName: 'XDS List',
+      displayName: 'List',
       description: 'List container w/ density, dividers, header support.',
       propDescriptions: {
         children: 'List items (XDSListItem components).',
@@ -328,7 +328,7 @@ export const docsDense = {
     },
     {
       name: 'XDSListItem',
-      displayName: 'XDS List Item',
+      displayName: 'List Item',
       description:
         'List item w/ label, description, start/end content slots, interactive patterns.',
       propDescriptions: {

--- a/packages/core/src/MetadataList/MetadataList.doc.mjs
+++ b/packages/core/src/MetadataList/MetadataList.doc.mjs
@@ -19,7 +19,7 @@ export const docs = {
   components: [
     {
       name: 'XDSMetadataList',
-      displayName: 'XDS Metadata List',
+      displayName: 'Metadata List',
       description:
         'Container for metadata items with column layout, orientation, and collapse support.',      props: [
         {
@@ -70,7 +70,7 @@ export const docs = {
     },
     {
       name: 'XDSMetadataListItem',
-      displayName: 'XDS Metadata List Item',
+      displayName: 'Metadata List Item',
       description: 'A single labeled metadata value within an XDSMetadataList.',
       props: [
         {
@@ -117,7 +117,7 @@ export const docsZh = {
   components: [
     {
       name: 'XDSMetadataList',
-      displayName: 'XDS Metadata List',
+      displayName: 'Metadata List',
       description: '带列布局、方向和折叠支持的元数据项容器。',
       propDescriptions: {
         children: '元数据项（XDSMetadataListItem 组件）。',
@@ -131,7 +131,7 @@ export const docsZh = {
     },
     {
       name: 'XDSMetadataListItem',
-      displayName: 'XDS Metadata List Item',
+      displayName: 'Metadata List Item',
       description: 'XDSMetadataList 中的单个带标签元数据值。',
       propDescriptions: {
         children: '此元数据项的内容值。',
@@ -180,7 +180,7 @@ export const docsDense = {
   components: [
     {
       name: 'XDSMetadataList',
-      displayName: 'XDS Metadata List',
+      displayName: 'Metadata List',
       description: 'metadata container w/ column layout+collapse',
       propDescriptions: {
         children: 'XDSMetadataListItem children',
@@ -194,7 +194,7 @@ export const docsDense = {
     },
     {
       name: 'XDSMetadataListItem',
-      displayName: 'XDS Metadata List Item',
+      displayName: 'Metadata List Item',
       description: 'single labeled value in XDSMetadataList',
       propDescriptions: {
         children: 'value content',

--- a/packages/core/src/MultiSelector/MultiSelector.doc.mjs
+++ b/packages/core/src/MultiSelector/MultiSelector.doc.mjs
@@ -15,7 +15,7 @@ export const docs = {
   components: [
     {
       name: 'XDSMultiSelector',
-      displayName: 'XDS Multi Selector',
+      displayName: 'Multi Selector',
       description:
         'Multi-select dropdown with checkboxes for choosing multiple items.',
       props: [
@@ -162,7 +162,7 @@ export const docsZh = {
   components: [
     {
       name: 'XDSMultiSelector',
-      displayName: 'XDS Multi Selector',
+      displayName: 'Multi Selector',
       description: '带复选框的多选下拉框，用于从列表中选择多项。',
       propDescriptions: {
         label: '无障碍标签文本。',
@@ -220,7 +220,7 @@ export const docsDense = {
   components: [
     {
       name: 'XDSMultiSelector',
-      displayName: 'XDS Multi Selector',
+      displayName: 'Multi Selector',
       description: 'checkbox multi-select dropdown',
       propDescriptions: {
         label: 'a11y label',

--- a/packages/core/src/Outline/Outline.doc.mjs
+++ b/packages/core/src/Outline/Outline.doc.mjs
@@ -34,7 +34,7 @@ export const docs = {
   components: [
     {
       name: 'XDSOutline',
-      displayName: 'XDS Outline',
+      displayName: 'Outline',
       description:
         'Document outline navigation. Renders a flat heading list as anchor links and manages scroll-spy active state when uncontrolled.',
       props: [
@@ -99,7 +99,7 @@ export const docsZh = {
   components: [
     {
       name: 'XDSOutline',
-      displayName: 'XDS Outline',
+      displayName: 'Outline',
       description:
         '文档大纲导航。将扁平标题列表渲染为锚点链接，并在非受控模式下管理滚动监听的激活状态。',
       props: [
@@ -173,7 +173,7 @@ export const docsDense = {
   components: [
     {
       name: 'XDSOutline',
-      displayName: 'XDS Outline',
+      displayName: 'Outline',
       description:
         'Document outline nav. Renders heading anchors and manages scroll-spy active state when uncontrolled.',
       propDescriptions: {

--- a/packages/core/src/Popover/Popover.doc.mjs
+++ b/packages/core/src/Popover/Popover.doc.mjs
@@ -10,7 +10,7 @@ export const docs = {
   components: [
     {
       name: 'XDSPopover',
-      displayName: 'XDS Popover',
+      displayName: 'Popover',
       description:
         'A click-triggered popover for displaying interactive content anchored to a trigger element.',      props: [
         {
@@ -139,7 +139,7 @@ export const docsZh = {
   components: [
     {
       name: 'XDSPopover',
-      displayName: 'XDS Popover',
+      displayName: 'Popover',
       description:
         '一个点击触发的弹出框，用于显示锚定到触发元素的交互式内容。',
       props: [
@@ -273,7 +273,7 @@ export const docsDense = {
   components: [
     {
       name: 'XDSPopover',
-      displayName: 'XDS Popover',
+      displayName: 'Popover',
       description:
         'Click-triggered popover for interactive content anchored to trigger element.',
       propDescriptions: {

--- a/packages/core/src/RadioList/RadioList.doc.mjs
+++ b/packages/core/src/RadioList/RadioList.doc.mjs
@@ -18,7 +18,7 @@ export const docs = {
   components: [
     {
       name: 'XDSRadioList',
-      displayName: 'XDS Radio List',
+      displayName: 'Radio List',
       description:
         'Radio group container with field integration for label, description, and status.',      props: [
         {
@@ -109,7 +109,7 @@ export const docs = {
     },
     {
       name: 'XDSRadioListItem',
-      displayName: 'XDS Radio List Item',
+      displayName: 'Radio List Item',
       description:
         'Individual radio item with label, description, and content slots.',
       props: [
@@ -188,7 +188,7 @@ export const docsZh = {
   components: [
     {
       name: 'XDSRadioList',
-      displayName: 'XDS Radio List',
+      displayName: 'Radio List',
       description:
         '单选按钮组容器，集成字段功能，支持标签、描述和状态。',
       props: [
@@ -279,7 +279,7 @@ export const docsZh = {
     },
     {
       name: 'XDSRadioListItem',
-      displayName: 'XDS Radio List Item',
+      displayName: 'Radio List Item',
       description:
         '单个单选选项，包含标签、描述和内容插槽。',
       props: [
@@ -362,7 +362,7 @@ export const docsDense = {
   components: [
     {
       name: 'XDSRadioList',
-      displayName: 'XDS Radio List',
+      displayName: 'Radio List',
       description:
         'Radio group container w/ field integration for label, description, status.',
       propDescriptions: {
@@ -384,7 +384,7 @@ export const docsDense = {
     },
     {
       name: 'XDSRadioListItem',
-      displayName: 'XDS Radio List Item',
+      displayName: 'Radio List Item',
       description:
         'Individual radio item w/ label, description, content slots.',
       propDescriptions: {

--- a/packages/core/src/Resizable/Resizable.doc.mjs
+++ b/packages/core/src/Resizable/Resizable.doc.mjs
@@ -109,7 +109,7 @@ export const docs = {
     },
     {
       name: 'XDSResizeHandle',
-      displayName: 'XDS Resize Handle',
+      displayName: 'Resize Handle',
       description:
         'Draggable separator between panels. Pill-grip design: invisible at rest, ' +
         'visible on hover (0.6 opacity), fully opaque during drag (1.0). Keyboard-accessible.',

--- a/packages/core/src/SegmentedControl/SegmentedControl.doc.mjs
+++ b/packages/core/src/SegmentedControl/SegmentedControl.doc.mjs
@@ -29,7 +29,7 @@ export const docs = {
   components: [
     {
       name: 'XDSSegmentedControl',
-      displayName: 'XDS Segmented Control',
+      displayName: 'Segmented Control',
       description:
         'Container wrapper providing context (value, onChange, size, isDisabled) to XDSSegmentedControlItem children.',
       props: [
@@ -85,7 +85,7 @@ export const docs = {
       ],    },
     {
       name: 'XDSSegmentedControlItem',
-      displayName: 'XDS Segmented Control Item',
+      displayName: 'Segmented Control Item',
       description:
         'Individual segment item rendering as a radio button within the segmented control.',
       props: [
@@ -142,7 +142,7 @@ export const docsZh = {
   components: [
     {
       name: 'XDSSegmentedControl',
-      displayName: 'XDS Segmented Control',
+      displayName: 'Segmented Control',
       description:
         '容器包装组件，通过上下文向 XDSSegmentedControlItem 子组件提供 value、onChange、size、isDisabled。',
       propDescriptions: {
@@ -158,7 +158,7 @@ export const docsZh = {
     },
     {
       name: 'XDSSegmentedControlItem',
-      displayName: 'XDS Segmented Control Item',
+      displayName: 'Segmented Control Item',
       description:
         '单个分段项，在分段控件中渲染为单选按钮。',
       propDescriptions: {
@@ -207,7 +207,7 @@ export const docsDense = {
   components: [
     {
       name: 'XDSSegmentedControl',
-      displayName: 'XDS Segmented Control',
+      displayName: 'Segmented Control',
       description: 'container; provides context (value/onChange/size/layout/isDisabled) to children',
       propDescriptions: {
         value: 'selected value (controlled)',
@@ -222,7 +222,7 @@ export const docsDense = {
     },
     {
       name: 'XDSSegmentedControlItem',
-      displayName: 'XDS Segmented Control Item',
+      displayName: 'Segmented Control Item',
       description: 'individual segment; renders as radio button in control',
       propDescriptions: {
         value: 'unique segment value; matched against parent',

--- a/packages/core/src/Selector/Selector.doc.mjs
+++ b/packages/core/src/Selector/Selector.doc.mjs
@@ -16,7 +16,7 @@ export const docs = {
   components: [
     {
       name: 'XDSSelector',
-      displayName: 'XDS Selector',
+      displayName: 'Selector',
       description: 'Dropdown selector for choosing from a list of options.',
       props: [
         {
@@ -118,7 +118,7 @@ export const docs = {
     },
     {
       name: 'XDSSelectorOption',
-      displayName: 'XDS Selector Option',
+      displayName: 'Selector Option',
       description:
         'Helper component for custom item rendering inside an XDSSelector children render prop.',
       props: [
@@ -178,7 +178,7 @@ export const docsZh = {
   components: [
     {
       name: 'XDSSelector',
-      displayName: 'XDS Selector',
+      displayName: 'Selector',
       description: '用于从选项列表中进行选择的下拉选择器。',
       props: [
         {
@@ -279,7 +279,7 @@ export const docsZh = {
     },
     {
       name: 'XDSSelectorOption',
-      displayName: 'XDS Selector Option',
+      displayName: 'Selector Option',
       description:
         '用于在 XDSSelector 的 children 渲染函数中自定义选项渲染的辅助组件。',
       props: [
@@ -353,7 +353,7 @@ export const docsDense = {
   components: [
     {
       name: 'XDSSelector',
-      displayName: 'XDS Selector',
+      displayName: 'Selector',
       description: 'Dropdown selector for choosing from list of options.',
       propDescriptions: {
         label: 'Label text for accessibility.',
@@ -377,7 +377,7 @@ export const docsDense = {
     },
     {
       name: 'XDSSelectorOption',
-      displayName: 'XDS Selector Option',
+      displayName: 'Selector Option',
       description:
         'Helper component for custom item rendering inside XDSSelector children render prop.',
       propDescriptions: {

--- a/packages/core/src/SideNav/SideNav.doc.mjs
+++ b/packages/core/src/SideNav/SideNav.doc.mjs
@@ -27,7 +27,7 @@ export const docs = {
   components: [
     {
       name: 'XDSSideNav',
-      displayName: 'XDS Side Nav',
+      displayName: 'Side Nav',
       description:
         'Container with five zones: header, topContent, children (scrollable), footer, and footerIcons. Supports collapsible mode.',
       props: [
@@ -83,7 +83,7 @@ export const docs = {
       ],    },
     {
       name: 'XDSSideNavHeading',
-      displayName: 'XDS Side Nav Heading',
+      displayName: 'Side Nav Heading',
       description:
         'Product/suite/account heading with smart interaction boundary logic for links and a menu popover.',
       props: [
@@ -140,7 +140,7 @@ export const docs = {
     },
     {
       name: 'XDSSideNavItem',
-      displayName: 'XDS Side Nav Item',
+      displayName: 'Side Nav Item',
       description:
         'Navigation item with icon, selected state, optional end content, and nesting support via children.',
       props: [
@@ -213,7 +213,7 @@ export const docs = {
     },
     {
       name: 'XDSSideNavSection',
-      displayName: 'XDS Side Nav Section',
+      displayName: 'Side Nav Section',
       description:
         'Section grouping with an optional title, subtitle, and end content.',
       props: [
@@ -260,7 +260,7 @@ export const docs = {
     },
     {
       name: 'XDSSideNavCollapseButton',
-      displayName: 'XDS Side Nav Collapse Button',
+      displayName: 'Side Nav Collapse Button',
       description:
         'Toggle button for sidenav collapse. Place inside XDSSideNav (reads context automatically) or outside (pass handleRef). Renders as an icon-only ghost button by default.',
       props: [
@@ -317,7 +317,7 @@ export const docsZh = {
   components: [
     {
       name: 'XDSSideNav',
-      displayName: 'XDS Side Nav',
+      displayName: 'Side Nav',
       description:
         '包含五个区域的容器：header、topContent、children（可滚动）、footer 和 footerIcons。',
       props: [
@@ -369,7 +369,7 @@ export const docsZh = {
     },
     {
       name: 'XDSSideNavHeading',
-      displayName: 'XDS Side Nav Heading',
+      displayName: 'Side Nav Heading',
       description:
         '产品/套件/账户头部，具有智能交互边界逻辑，支持链接和菜单弹出框。',
       props: [
@@ -423,7 +423,7 @@ export const docsZh = {
     },
     {
       name: 'XDSSideNavItem',
-      displayName: 'XDS Side Nav Item',
+      displayName: 'Side Nav Item',
       description:
         '导航项，支持图标、选中状态、可选尾部内容，以及通过 children 实现嵌套。',
       props: [
@@ -491,7 +491,7 @@ export const docsZh = {
     },
     {
       name: 'XDSSideNavSection',
-      displayName: 'XDS Side Nav Section',
+      displayName: 'Side Nav Section',
       description:
         '分组，支持可选的标题、副标题和尾部内容。',
       props: [
@@ -527,7 +527,7 @@ export const docsZh = {
     },
     {
       name: 'XDSSideNavCollapseButton',
-      displayName: 'XDS Side Nav Collapse Button',
+      displayName: 'Side Nav Collapse Button',
       description:
         '侧边栏折叠切换按钮。放置在 XDSSideNav 内部（自动读取上下文）或外部（传入 handleRef）。默认渲染为仅图标的 ghost 按钮。',
       props: [
@@ -589,7 +589,7 @@ export const docsDense = {
   components: [
     {
       name: 'XDSSideNav',
-      displayName: 'XDS Side Nav',
+      displayName: 'Side Nav',
       description:
         'Container w/ five zones: header, topContent, children (scrollable), footer, footerIcons. Supports collapsible mode.',
       propDescriptions: {
@@ -605,7 +605,7 @@ export const docsDense = {
     },
     {
       name: 'XDSSideNavHeading',
-      displayName: 'XDS Side Nav Heading',
+      displayName: 'Side Nav Heading',
       description:
         'Product/suite/account heading w/ smart interaction boundary logic for links + menu popover.',
       propDescriptions: {
@@ -622,7 +622,7 @@ export const docsDense = {
     },
     {
       name: 'XDSSideNavItem',
-      displayName: 'XDS Side Nav Item',
+      displayName: 'Side Nav Item',
       description:
         'Navigation item w/ icon, selected state, optional end content, nesting via children.',
       propDescriptions: {
@@ -641,7 +641,7 @@ export const docsDense = {
     },
     {
       name: 'XDSSideNavSection',
-      displayName: 'XDS Side Nav Section',
+      displayName: 'Side Nav Section',
       description:
         'Section grouping w/ optional title, subtitle, end content.',
       propDescriptions: {
@@ -655,7 +655,7 @@ export const docsDense = {
     },
     {
       name: 'XDSSideNavCollapseButton',
-      displayName: 'XDS Side Nav Collapse Button',
+      displayName: 'Side Nav Collapse Button',
       description:
         'Toggle button for sidenav collapse. Place inside XDSSideNav (reads context) or outside (pass handleRef). Icon-only ghost button by default.',
       propDescriptions: {

--- a/packages/core/src/Stack/Stack.doc.mjs
+++ b/packages/core/src/Stack/Stack.doc.mjs
@@ -145,7 +145,7 @@ export const docs = {
     },
     {
       name: 'XDSStackItem',
-      displayName: 'XDS Stack Item',
+      displayName: 'Stack Item',
       description:
         'Stack item for controlling individual item behavior within a stack. Supports polymorphic rendering.',
       props: [
@@ -331,7 +331,7 @@ export const docsZh = {
     },
     {
       name: 'XDSStackItem',
-      displayName: 'XDS Stack Item',
+      displayName: 'Stack Item',
       description:
         '堆叠子元素，用于控制堆叠中单个元素的行为。支持多态渲染。',
       props: [
@@ -423,7 +423,7 @@ export const docsDense = {
     },
     {
       name: 'XDSStackItem',
-      displayName: 'XDS Stack Item',
+      displayName: 'Stack Item',
       description: 'Controls individual item behavior in stack; polymorphic rendering.',
       propDescriptions: {
         size: 'Flex grow: static=natural size, fill=expand to remaining space.',

--- a/packages/core/src/TabList/TabList.doc.mjs
+++ b/packages/core/src/TabList/TabList.doc.mjs
@@ -25,7 +25,7 @@ export const docs = {
   components: [
     {
       name: 'XDSTabList',
-      displayName: 'XDS Tab List',
+      displayName: 'Tab List',
       description:
         'Nav wrapper that provides XDSTabListContext (value, onChange, size) to XDSTab and XDSTabMenu children.',
       props: [
@@ -70,7 +70,7 @@ export const docs = {
       ],    },
     {
       name: 'XDSTab',
-      displayName: 'XDS Tab',
+      displayName: 'Tab',
       description:
         'Individual tab item that renders as a button or an anchor link, with selected-state styling and optional icons.',
       props: [
@@ -132,7 +132,7 @@ export const docs = {
     },
     {
       name: 'XDSTabMenu',
-      displayName: 'XDS Tab Menu',
+      displayName: 'Tab Menu',
       description:
         "Overflow menu trigger that opens a dropdown of additional tab options, showing the selected option's label as the trigger text.",
       props: [
@@ -189,7 +189,7 @@ export const docsZh = {
   components: [
     {
       name: 'XDSTabList',
-      displayName: 'XDS Tab List',
+      displayName: 'Tab List',
       description:
         '导航容器，为 XDSTab 和 XDSTabMenu 子组件提供 XDSTabListContext（value、onChange、size）。',
       props: [
@@ -234,7 +234,7 @@ export const docsZh = {
     },
     {
       name: 'XDSTab',
-      displayName: 'XDS Tab',
+      displayName: 'Tab',
       description:
         '单个标签项，渲染为按钮或锚点链接，具有选中状态样式和可选图标。',
       props: [
@@ -290,7 +290,7 @@ export const docsZh = {
     },
     {
       name: 'XDSTabMenu',
-      displayName: 'XDS Tab Menu',
+      displayName: 'Tab Menu',
       description:
         '溢出菜单触发器，打开包含额外标签选项的下拉菜单，将选中选项的标签显示为触发器文本。',
       props: [
@@ -352,7 +352,7 @@ export const docsDense = {
   components: [
     {
       name: 'XDSTabList',
-      displayName: 'XDS Tab List',
+      displayName: 'Tab List',
       description: 'Nav wrapper providing XDSTabListContext (value, onChange, size) to children.',
       propDescriptions: {
         value: 'Currently selected tab value.',
@@ -365,7 +365,7 @@ export const docsDense = {
     },
     {
       name: 'XDSTab',
-      displayName: 'XDS Tab',
+      displayName: 'Tab',
       description: 'Individual tab; renders as button or anchor w/ selected-state styling + optional icons.',
       propDescriptions: {
         value: 'Unique value matched against XDSTabListContext.value.',
@@ -380,7 +380,7 @@ export const docsDense = {
     },
     {
       name: 'XDSTabMenu',
-      displayName: 'XDS Tab Menu',
+      displayName: 'Tab Menu',
       description: "Overflow menu trigger; dropdown of extra tab options, shows selected option's label as trigger text.",
       propDescriptions: {
         label: 'Trigger text (when no option selected) + dropdown heading.',

--- a/packages/core/src/Table/Table.doc.mjs
+++ b/packages/core/src/Table/Table.doc.mjs
@@ -32,7 +32,7 @@ export const docs = {
   components: [
     {
       name: 'XDSTable',
-      displayName: 'XDS Table',
+      displayName: 'Table',
       description:
         'Styled, data-driven table with density, dividers, hover highlight, striped rows, and named plugin support.',
       props: [
@@ -99,7 +99,7 @@ export const docs = {
       ],    },
     {
       name: 'XDSBaseTable',
-      displayName: 'XDS Base Table',
+      displayName: 'Base Table',
       description:
         'Unstyled structural table component with a plugin transform pipeline and a components prop for swapping in custom row/cell renderers.',
       props: [
@@ -148,7 +148,7 @@ export const docs = {
     },
     {
       name: 'XDSTableRow',
-      displayName: 'XDS Table Row',
+      displayName: 'Table Row',
       description:
         '<tr> wrapper that reads XDSTableContext to apply striped, hover, and divider styles when used inside XDSTable.',
       props: [
@@ -162,7 +162,7 @@ export const docs = {
     },
     {
       name: 'XDSTableCell',
-      displayName: 'XDS Table Cell',
+      displayName: 'Table Cell',
       description:
         '<td> wrapper that reads XDSTableContext to apply density padding, font size, and divider borders when used inside XDSTable.',
       props: [
@@ -175,7 +175,7 @@ export const docs = {
     },
     {
       name: 'XDSTableHeaderCell',
-      displayName: 'XDS Table Header Cell',
+      displayName: 'Table Header Cell',
       description:
         '<th> wrapper that reads XDSTableContext to apply density padding, semibold weight, secondary text color, and divider borders when used inside XDSTable.',
       props: [
@@ -473,7 +473,7 @@ export const docsZh = {
   components: [
     {
       name: 'XDSTable',
-      displayName: 'XDS Table',
+      displayName: 'Table',
       description:
         '带样式的数据驱动表格，支持密度、分隔线、悬停高亮、条纹行和命名插件。',
       props: [
@@ -541,7 +541,7 @@ export const docsZh = {
     },
     {
       name: 'XDSBaseTable',
-      displayName: 'XDS Base Table',
+      displayName: 'Base Table',
       description:
         '无样式的结构表格组件，配有插件转换管道和 components 属性，用于替换自定义行/单元格渲染器。',
       props: [
@@ -590,7 +590,7 @@ export const docsZh = {
     },
     {
       name: 'XDSTableRow',
-      displayName: 'XDS Table Row',
+      displayName: 'Table Row',
       description:
         '<tr> 包装器，读取 XDSTableContext 以在 XDSTable 内部使用时应用条纹、悬停和分隔线样式。',
       props: [
@@ -604,7 +604,7 @@ export const docsZh = {
     },
     {
       name: 'XDSTableCell',
-      displayName: 'XDS Table Cell',
+      displayName: 'Table Cell',
       description:
         '<td> 包装器，读取 XDSTableContext 以在 XDSTable 内部使用时应用密度内边距、字体大小和分隔线边框。',
       props: [
@@ -617,7 +617,7 @@ export const docsZh = {
     },
     {
       name: 'XDSTableHeaderCell',
-      displayName: 'XDS Table Header Cell',
+      displayName: 'Table Header Cell',
       description:
         '<th> 包装器，读取 XDSTableContext 以在 XDSTable 内部使用时应用密度内边距、半粗字重、次要文本颜色和分隔线边框。',
       props: [
@@ -835,7 +835,7 @@ export const docsDense = {
   components: [
     {
       name: 'XDSTable',
-      displayName: 'XDS Table',
+      displayName: 'Table',
       description: 'Styled data-driven table w/ density, dividers, hover, striped rows, named plugin support.',
       propDescriptions: {
         data: 'Array of data items to render as rows.',
@@ -852,7 +852,7 @@ export const docsDense = {
     },
     {
       name: 'XDSBaseTable',
-      displayName: 'XDS Base Table',
+      displayName: 'Base Table',
       description: 'Unstyled structural table w/ plugin transform pipeline + components prop for custom row/cell renderers.',
       propDescriptions: {
         data: 'Array of data items to render as rows.',
@@ -866,7 +866,7 @@ export const docsDense = {
     },
     {
       name: 'XDSTableRow',
-      displayName: 'XDS Table Row',
+      displayName: 'Table Row',
       description: '<tr> wrapper; reads XDSTableContext for striped/hover/divider styles.',
       propDescriptions: {
         children: 'Row cell elements.',
@@ -874,7 +874,7 @@ export const docsDense = {
     },
     {
       name: 'XDSTableCell',
-      displayName: 'XDS Table Cell',
+      displayName: 'Table Cell',
       description: '<td> wrapper; reads XDSTableContext for density padding, font size, divider borders.',
       propDescriptions: {
         children: 'Cell content.',
@@ -882,7 +882,7 @@ export const docsDense = {
     },
     {
       name: 'XDSTableHeaderCell',
-      displayName: 'XDS Table Header Cell',
+      displayName: 'Table Header Cell',
       description: '<th> wrapper; reads XDSTableContext for density padding, semibold weight, secondary color, dividers.',
       propDescriptions: {
         children: 'Header cell content.',

--- a/packages/core/src/Text/Text.doc.mjs
+++ b/packages/core/src/Text/Text.doc.mjs
@@ -21,7 +21,7 @@ export const docs = {
   components: [
     {
       name: 'XDSText',
-      displayName: 'XDS Text',
+      displayName: 'Text',
       description:
         'Semantic body text component that renders text with type-based styling from the theme, with optional truncation, decoration, and layout props.',      props: [
         {
@@ -127,7 +127,7 @@ export const docs = {
     },
     {
       name: 'XDSHeading',
-      displayName: 'XDS Heading',
+      displayName: 'Heading',
       description:
         'Semantic heading component that renders h1–h6 elements with themed styling, themed sizing via type scale tokens, and line-clamp truncation.',
       props: [
@@ -243,7 +243,7 @@ export const docsZh = {
   components: [
     {
       name: 'XDSText',
-      displayName: 'XDS Text',
+      displayName: 'Text',
       description:
         '语义化正文文本组件，使用来自主题的基于类型的样式渲染文本，支持可选的截断、装饰和布局属性。',
       props: [
@@ -350,7 +350,7 @@ export const docsZh = {
     },
     {
       name: 'XDSHeading',
-      displayName: 'XDS Heading',
+      displayName: 'Heading',
       description:
         '语义化标题组件，渲染带主题样式的 h1–h6 元素，支持可选的编辑风格比例和行截断。',
       props: [
@@ -472,7 +472,7 @@ export const docsDense = {
   components: [
     {
       name: 'XDSText',
-      displayName: 'XDS Text',
+      displayName: 'Text',
       description: 'Semantic body text w/ type-based theme styling, optional truncation, decoration, layout props.',
       propDescriptions: {
         type: 'Semantic text type; determines size, weight, line-height from theme.',
@@ -495,7 +495,7 @@ export const docsDense = {
     },
     {
       name: 'XDSHeading',
-      displayName: 'XDS Heading',
+      displayName: 'Heading',
       description: 'Semantic h1\u20136 w/ themed styling, themed sizing via type scale tokens, line-clamp truncation.',
       propDescriptions: {
         level: 'Heading level; determines HTML element + styling from theme (unless type is set).',

--- a/packages/core/src/ToggleButton/ToggleButton.doc.mjs
+++ b/packages/core/src/ToggleButton/ToggleButton.doc.mjs
@@ -21,7 +21,7 @@ export const docs = {
   components: [
     {
       name: 'XDSToggleButton',
-      displayName: 'XDS Toggle Button',
+      displayName: 'Toggle Button',
       description: 'A button that toggles between pressed and unpressed states. Thin wrapper over XDSButton with controlled toggle pattern, icon swap, and font weight emphasis.',
       props: [
         {name: 'label', type: 'string', description: 'Accessible label for the button. Used as visible text, or as aria-label for icon-only buttons.', required: true},
@@ -44,7 +44,7 @@ export const docs = {
       ],    },
     {
       name: 'XDSToggleButtonGroup',
-      displayName: 'XDS Toggle Button Group',
+      displayName: 'Toggle Button Group',
       description: 'Groups toggle buttons for exclusive (single) or multi-select behavior. Uses discriminated union on type for type-safe value/onChange.',
       props: [
         {name: 'children', type: 'ReactNode', description: 'XDSToggleButton children.', required: true, slotElements: [{__element: 'XDSToggleButton', props: {label: 'Option', value: 'option'}}]},
@@ -85,7 +85,7 @@ export const docsZh = {
   components: [
     {
       name: 'XDSToggleButton',
-      displayName: 'XDS Toggle Button',
+      displayName: 'Toggle Button',
       description: '在按下和未按下状态之间切换的按钮。XDSButton 的轻量封装，添加受控切换模式、图标切换和字重加粗。',
       propDescriptions: {
         label: '按钮的无障碍标签。作为可见文本或仅图标按钮的 aria-label。',
@@ -105,7 +105,7 @@ export const docsZh = {
     },
     {
       name: 'XDSToggleButtonGroup',
-      displayName: 'XDS Toggle Button Group',
+      displayName: 'Toggle Button Group',
       description: '将切换按钮分组，支持单选或多选行为。通过 type 判别联合类型实现类型安全。',
       propDescriptions: {
         children: 'XDSToggleButton 子元素。',
@@ -159,7 +159,7 @@ export const docsDense = {
   components: [
     {
       name: 'XDSToggleButton',
-      displayName: 'XDS Toggle Button',
+      displayName: 'Toggle Button',
       description: 'toggle btn w/ controlled pattern, icon swap, font weight emphasis; wraps XDSButton',
       propDescriptions: {
         label: 'a11y label; visible text or aria-label for icon-only',
@@ -179,7 +179,7 @@ export const docsDense = {
     },
     {
       name: 'XDSToggleButtonGroup',
-      displayName: 'XDS Toggle Button Group',
+      displayName: 'Toggle Button Group',
       description: 'groups toggle btns for exclusive/multi-select; discriminated union on type',
       propDescriptions: {
         children: 'XDSToggleButton children',

--- a/packages/core/src/Toolbar/Toolbar.doc.mjs
+++ b/packages/core/src/Toolbar/Toolbar.doc.mjs
@@ -14,7 +14,7 @@ export const docs = {
   components: [
     {
       name: 'XDSToolbar',
-      displayName: 'XDS Toolbar',
+      displayName: 'Toolbar',
       description:
         'General-purpose toolbar container with three content slots and roving tabindex.',
       props: [
@@ -99,7 +99,7 @@ export const docsZh = {
   components: [
     {
       name: 'XDSToolbar',
-      displayName: 'XDS Toolbar',
+      displayName: 'Toolbar',
       description: '通用工具栏容器，提供三个内容插槽和循环 Tab。',
       propDescriptions: {
         label: '工具栏的无障碍标签，作为 aria-label 应用。',
@@ -148,7 +148,7 @@ export const docsDense = {
   components: [
     {
       name: 'XDSToolbar',
-      displayName: 'XDS Toolbar',
+      displayName: 'Toolbar',
       description: 'Toolbar container w/ 3 content slots + roving tabindex.',
       propDescriptions: {
         label: 'A11y label, aria-label on toolbar.',

--- a/packages/core/src/Tooltip/Tooltip.doc.mjs
+++ b/packages/core/src/Tooltip/Tooltip.doc.mjs
@@ -16,7 +16,7 @@ export const docs = {
   components: [
     {
       name: 'XDSTooltip',
-      displayName: 'XDS Tooltip',
+      displayName: 'Tooltip',
       description:
         'Component wrapper for tooltip display triggered on hover or focus.',      props: [
         {
@@ -115,7 +115,7 @@ export const docsZh = {
   components: [
     {
       name: 'XDSTooltip',
-      displayName: 'XDS Tooltip',
+      displayName: 'Tooltip',
       description:
         '工具提示显示的组件包装器，通过悬停或聚焦触发。',
       props: [
@@ -223,7 +223,7 @@ export const docsDense = {
   components: [
     {
       name: 'XDSTooltip',
-      displayName: 'XDS Tooltip',
+      displayName: 'Tooltip',
       description: 'Component wrapper for tooltip display on hover/focus.',
       propDescriptions: {
         children: 'Trigger element(s) that activate tooltip.',

--- a/packages/core/src/TopNav/TopNav.doc.mjs
+++ b/packages/core/src/TopNav/TopNav.doc.mjs
@@ -27,7 +27,7 @@ export const docs = {
   components: [
     {
       name: 'XDSTopNav',
-      displayName: 'XDS Top Nav',
+      displayName: 'Top Nav',
       description: 'Main navigation bar container with slot-based layout. Children are accepted as an alias for startContent.',
       props: [
         {
@@ -83,7 +83,7 @@ export const docs = {
       ],    },
     {
       name: 'XDSTopNavHeading',
-      displayName: 'XDS Top Nav Heading',
+      displayName: 'Top Nav Heading',
       description:
         'Product/suite/account heading for the XDSTopNav heading slot. Supports smart interaction boundary logic: logo, heading text, superheading/subheading with independent links, and an optional menu popover with automatic chevron indicator.',
       props: [
@@ -165,7 +165,7 @@ export const docs = {
     },
     {
       name: 'XDSTopNavItem',
-      displayName: 'XDS Top Nav Item',
+      displayName: 'Top Nav Item',
       description:
         'Navigation link item for use in XDSTopNav startContent — renders as an anchor with hover and selected states.',
       props: [
@@ -225,7 +225,7 @@ export const docs = {
     },
     {
       name: 'XDSTopNavMenu',
-      displayName: 'XDS Top Nav Menu',
+      displayName: 'Top Nav Menu',
       description:
         'Navigation item that displays a hover-triggered popover menu with rich items containing an icon, title, and optional description.',
       props: [
@@ -259,7 +259,7 @@ export const docs = {
     },
     {
       name: 'XDSTopNavMegaMenu',
-      displayName: 'XDS Top Nav Mega Menu',
+      displayName: 'Top Nav Mega Menu',
       description:
         'Navigation item that displays a full-width mega menu panel on hover. Uses a slots API with items and featured props. XDSTopNavMegaMenuItem renders itself in both desktop and mobile drawer modes. Supports inline collapsible drawer via render mode context.',
       props: [
@@ -305,7 +305,7 @@ export const docs = {
     },
     {
       name: 'XDSTopNavMegaMenuItem',
-      displayName: 'XDS Top Nav Mega Menu Item',
+      displayName: 'Top Nav Mega Menu Item',
       description:
         'An individual item inside an XDSTopNavMegaMenu. Renders itself in both desktop (popover grid) and mobile drawer modes via render mode context.',
       props: [
@@ -346,7 +346,7 @@ export const docs = {
     },
     {
       name: 'XDSTopNavMegaMenuFeaturedCard',
-      displayName: 'XDS Top Nav Mega Menu Featured Card',
+      displayName: 'Top Nav Mega Menu Featured Card',
       description:
         'Standard featured card for the XDSTopNavMegaMenu featured slot. Provides a consistent card with optional image, title, description, and CTA link.',
       props: [
@@ -425,7 +425,7 @@ export const docsZh = {
   components: [
     {
       name: 'XDSTopNav',
-      displayName: 'XDS Top Nav',
+      displayName: 'Top Nav',
       description: '采用插槽式布局的主导航栏容器。children 可作为 startContent 的别名。',
       props: [
         {
@@ -474,7 +474,7 @@ export const docsZh = {
     },
     {
       name: 'XDSTopNavHeading',
-      displayName: 'XDS Top Nav Heading',
+      displayName: 'Top Nav Heading',
       description:
         'XDSTopNav 标题插槽的产品/套件/账户标题组件。支持智能交互边界逻辑：标志、标题文本、独立链接的上标题/下标题，以及带自动箭头指示器的可选菜单弹出层。',
       props: [
@@ -553,7 +553,7 @@ export const docsZh = {
     },
     {
       name: 'XDSTopNavItem',
-      displayName: 'XDS Top Nav Item',
+      displayName: 'Top Nav Item',
       description:
         '用于 XDSTopNav startContent 的导航链接项 — 渲染为具有悬停和选中状态的锚点。',
       props: [
@@ -605,7 +605,7 @@ export const docsZh = {
     },
     {
       name: 'XDSTopNavMenu',
-      displayName: 'XDS Top Nav Menu',
+      displayName: 'Top Nav Menu',
       description:
         '导航项，在悬停时显示弹出菜单，包含带图标、标题和可选描述的丰富菜单项。',
       props: [
@@ -639,7 +639,7 @@ export const docsZh = {
     },
     {
       name: 'XDSTopNavMegaMenu',
-      displayName: 'XDS Top Nav Mega Menu',
+      displayName: 'Top Nav Mega Menu',
       description:
         '导航项，在悬停时显示全宽超级菜单面板。使用插槽 API（items 和 featured）。XDSTopNavMegaMenuItem 在桌面和移动抽屉模式中自行渲染。',
       props: [
@@ -683,7 +683,7 @@ export const docsZh = {
     },
     {
       name: 'XDSTopNavMegaMenuItem',
-      displayName: 'XDS Top Nav Mega Menu Item',
+      displayName: 'Top Nav Mega Menu Item',
       description:
         '超级菜单中的单个项目。在桌面端（弹出层网格）和移动抽屉模式中都会自行渲染。',
       props: [
@@ -723,7 +723,7 @@ export const docsZh = {
     },
     {
       name: 'XDSTopNavMegaMenuFeaturedCard',
-      displayName: 'XDS Top Nav Mega Menu Featured Card',
+      displayName: 'Top Nav Mega Menu Featured Card',
       description:
         '超级菜单 featured 插槽的标准特色卡片。提供带可选图片、标题、描述和 CTA 链接的一致卡片。',
       props: [
@@ -806,7 +806,7 @@ export const docsDense = {
   components: [
     {
       name: 'XDSTopNav',
-      displayName: 'XDS Top Nav',
+      displayName: 'Top Nav',
       description: 'Main nav bar container w/ slot-based layout; children alias startContent.',
       propDescriptions: {
         heading: 'Heading slot (logo, brand) at left edge.',
@@ -820,7 +820,7 @@ export const docsDense = {
     },
     {
       name: 'XDSTopNavHeading',
-      displayName: 'XDS Top Nav Heading',
+      displayName: 'Top Nav Heading',
       description: 'Product/suite heading for XDSTopNav; logo+heading text w/ smart interaction boundaries, optional menu popover, superheading/subheading w/ independent links.',
       propDescriptions: {
         logo: 'Logo before heading text. Image, XDSNavIcon, or ReactNode.',
@@ -839,7 +839,7 @@ export const docsDense = {
     },
     {
       name: 'XDSTopNavItem',
-      displayName: 'XDS Top Nav Item',
+      displayName: 'Top Nav Item',
       description: 'Nav link for XDSTopNav startContent; renders as anchor w/ hover+selected states.',
       propDescriptions: {
         label: 'Visible text or aria-label when isIconOnly is true.',
@@ -853,7 +853,7 @@ export const docsDense = {
     },
     {
       name: 'XDSTopNavMenu',
-      displayName: 'XDS Top Nav Menu',
+      displayName: 'Top Nav Menu',
       description: 'Nav item w/ hover-triggered popover menu containing rich items w/ icon, title, optional description.',
       propDescriptions: {
         label: 'Trigger button visible label.',
@@ -864,7 +864,7 @@ export const docsDense = {
     },
     {
       name: 'XDSTopNavMegaMenu',
-      displayName: 'XDS Top Nav Mega Menu',
+      displayName: 'Top Nav Mega Menu',
       description: 'Nav item w/ full-width mega menu panel on hover. Slots API w/ items+featured ReactNode props. Mobile drawer inline collapsible.',
       propDescriptions: {
         label: 'Trigger button visible label.',
@@ -877,7 +877,7 @@ export const docsDense = {
     },
     {
       name: 'XDSTopNavMegaMenuItem',
-      displayName: 'XDS Top Nav Mega Menu Item',
+      displayName: 'Top Nav Mega Menu Item',
       description: 'Individual mega menu item. Renders in desktop popover grid + mobile drawer modes via context.',
       propDescriptions: {
         title: 'Display title.',
@@ -890,7 +890,7 @@ export const docsDense = {
     },
     {
       name: 'XDSTopNavMegaMenuFeaturedCard',
-      displayName: 'XDS Top Nav Mega Menu Featured Card',
+      displayName: 'Top Nav Mega Menu Featured Card',
       description: 'Standard featured card for mega menu featured slot. Optional image, title, description, CTA link.',
       propDescriptions: {
         title: 'Card title.',

--- a/packages/core/src/TreeList/TreeList.doc.mjs
+++ b/packages/core/src/TreeList/TreeList.doc.mjs
@@ -30,7 +30,7 @@ export const docs = {
   components: [
     {
       name: 'XDSTreeList',
-      displayName: 'XDS Tree List',
+      displayName: 'Tree List',
       description:
         'Tree list container. Accepts items data and rendering configuration. Expansion state is managed internally.',      props: [
         {
@@ -94,7 +94,7 @@ export const docsZh = {
   components: [
     {
       name: 'XDSTreeList',
-      displayName: 'XDS Tree List',
+      displayName: 'Tree List',
       description:
         '树列表容器。接受 items 数据和渲染配置。展开状态在内部管理。',
       props: [
@@ -161,7 +161,7 @@ export const docsDense = {
   components: [
     {
       name: 'XDSTreeList',
-      displayName: 'XDS Tree List',
+      displayName: 'Tree List',
       description: 'Tree list container. Accepts items data + rendering config. Expansion managed internally.',
       propDescriptions: {
         items: 'Recursive tree item data w/ id, label, optional children + isExpanded.',

--- a/packages/core/src/Typeahead/Typeahead.doc.mjs
+++ b/packages/core/src/Typeahead/Typeahead.doc.mjs
@@ -10,7 +10,7 @@ export const docs = {
   components: [
     {
       name: 'XDSTypeahead',
-      displayName: 'XDS Typeahead',
+      displayName: 'Typeahead',
       description:
         'Styled typeahead with label, description, validation, and all field features. Wraps XDSBaseTypeahead with XDSField for the primary use case.',
       props: [
@@ -153,7 +153,7 @@ export const docs = {
       ],    },
     {
       name: 'XDSBaseTypeahead',
-      displayName: 'XDS Base Typeahead',
+      displayName: 'Base Typeahead',
       description:
         'Unstyled combobox engine providing input, search, keyboard navigation, and dropdown. No wrapper div, no border styling, no token rendering. Used by XDSTypeahead and XDSTokenizer for custom compositions.',
       props: [
@@ -264,7 +264,7 @@ export const docs = {
     },
     {
       name: 'XDSTypeaheadItem',
-      displayName: 'XDS Typeahead Item',
+      displayName: 'Typeahead Item',
       description:
         'Default dropdown item renderer for typeahead results. Shows label with optional icon, description, and avatar. Exported for use in custom renderItem implementations.',
       props: [
@@ -327,7 +327,7 @@ export const docsZh = {
   components: [
     {
       name: 'XDSTypeahead',
-      displayName: 'XDS Typeahead',
+      displayName: 'Typeahead',
       description:
         '带有标签、描述、验证和所有字段功能的样式化预输入组件。使用 XDSField 包裹 XDSBaseTypeahead，适用于主要用例。',
       props: [
@@ -471,7 +471,7 @@ export const docsZh = {
     },
     {
       name: 'XDSBaseTypeahead',
-      displayName: 'XDS Base Typeahead',
+      displayName: 'Base Typeahead',
       description:
         '无样式的组合框引擎，提供输入、搜索、键盘导航和下拉列表。无包装 div，无边框样式，无标记渲染。由 XDSTypeahead 和 XDSTokenizer 用于自定义组合。',
       props: [
@@ -582,7 +582,7 @@ export const docsZh = {
     },
     {
       name: 'XDSTypeaheadItem',
-      displayName: 'XDS Typeahead Item',
+      displayName: 'Typeahead Item',
       description:
         '预输入结果的默认下拉项渲染器。显示标签以及可选的图标、描述和头像。导出供自定义 renderItem 实现使用。',
       props: [
@@ -655,7 +655,7 @@ export const docsDense = {
   components: [
     {
       name: 'XDSTypeahead',
-      displayName: 'XDS Typeahead',
+      displayName: 'Typeahead',
       description: 'Styled typeahead w/ label, description, validation. Wraps XDSBaseTypeahead+XDSField.',
       propDescriptions: {
         label: 'Accessible label for input.',
@@ -685,7 +685,7 @@ export const docsDense = {
     },
     {
       name: 'XDSBaseTypeahead',
-      displayName: 'XDS Base Typeahead',
+      displayName: 'Base Typeahead',
       description: 'Unstyled combobox engine; input+search+keyboard nav+dropdown. No wrapper/border/token. Used by XDSTypeahead+XDSTokenizer.',
       propDescriptions: {
         searchSource: 'Data source w/ search+bootstrap methods.',
@@ -710,7 +710,7 @@ export const docsDense = {
     },
     {
       name: 'XDSTypeaheadItem',
-      displayName: 'XDS Typeahead Item',
+      displayName: 'Typeahead Item',
       description: 'Default dropdown item renderer. Label w/ optional icon, description, avatar. Exported for custom renderItem.',
       propDescriptions: {
         item: 'Search result item to render.',

--- a/packages/lab/src/Stepper/Stepper.doc.mjs
+++ b/packages/lab/src/Stepper/Stepper.doc.mjs
@@ -35,7 +35,7 @@ export const docs = {
   components: [
     {
       name: 'XDSStepper',
-      displayName: 'XDS Stepper',
+      displayName: 'Stepper',
       description:
         'Container component that manages step state and renders steps in horizontal or vertical orientation.',
       props: [
@@ -77,7 +77,7 @@ export const docs = {
     },
     {
       name: 'XDSStep',
-      displayName: 'XDS Step',
+      displayName: 'Step',
       description:
         'Individual step within a stepper. Renders a numbered indicator, connector line, and label with optional description.',
       props: [
@@ -151,7 +151,7 @@ export const docsDense = {
   components: [
     {
       name: 'XDSStepper',
-      displayName: 'XDS Stepper',
+      displayName: 'Stepper',
       description: 'container managing step state w/ horizontal/vertical layout',
       propDescriptions: {
         activeStep: 'zero-based active step index',
@@ -164,7 +164,7 @@ export const docsDense = {
     },
     {
       name: 'XDSStep',
-      displayName: 'XDS Step',
+      displayName: 'Step',
       description: 'individual step w/ indicator, connector, label',
       propDescriptions: {
         step: 'zero-based step index',
@@ -206,7 +206,7 @@ export const docsZh = {
   components: [
     {
       name: 'XDSStepper',
-      displayName: 'XDS Stepper',
+      displayName: 'Stepper',
       description: '容器组件，管理步骤状态并以水平或垂直方向渲染步骤。',
       props: [
         {name: 'activeStep', type: 'number', description: '当前活动步骤的从零开始的索引。', required: true},
@@ -219,7 +219,7 @@ export const docsZh = {
     },
     {
       name: 'XDSStep',
-      displayName: 'XDS Step',
+      displayName: 'Step',
       description: '步骤器中的单个步骤。渲染编号指示器、连接线和带可选描述的标签。',
       props: [
         {name: 'step', type: 'number', description: '此步骤的从零开始的索引。', required: true},


### PR DESCRIPTION
A number of components were still showing the XDS prefix in the side nav of the components page.