### PR TITLE
fix(docsite): inherit site theme mode in component preview thumbnails

### DIFF
--- a/apps/docsite/src/components/ShowcaseThumbnail.tsx
+++ b/apps/docsite/src/components/ShowcaseThumbnail.tsx
@@ -15,6 +15,7 @@ import {XDSSkeleton} from '@xds/core/Skeleton';
 import {XDSText} from '@xds/core/Text';
 import {XDSTheme} from '@xds/core/theme';
 import {neutralTheme} from '@xds/theme-neutral/built';
+import {useThemeMode} from '../app/providers';
 
 const FIXED_SCALE = 0.5;
 
@@ -123,6 +124,7 @@ export function ShowcaseThumbnail({
   dirName: string;
   category: string;
 }) {
+  const {mode} = useThemeMode();
   const containerRef = useRef<HTMLDivElement>(null);
   const [renderWidth, setRenderWidth] = useState(0);
   const [isVisible, setIsVisible] = useState(false);
@@ -172,7 +174,7 @@ export function ShowcaseThumbnail({
                   <XDSSkeleton width="100%" height="100%" />
                 </div>
               }>
-              <XDSTheme theme={neutralTheme}>
+              <XDSTheme theme={neutralTheme} mode={mode}>
                 <Component />
               </XDSTheme>
             </Suspense>


### PR DESCRIPTION
## Problem

On the /components page, the grid preview thumbnails render component examples using the system color scheme (via `XDSTheme` defaulting to `mode='system'`), while the site itself uses a controlled light/dark toggle. This causes a mismatch — the site can be in light mode while previews render in dark mode (or vice versa).

## Solution

Import `useThemeMode` from the site's providers and pass the active `mode` to the `XDSTheme` wrapping each showcase preview. The previews keep their neutral theme but now inherit the site's light/dark mode.

## Changes

- `apps/docsite/src/components/ShowcaseThumbnail.tsx`: Import `useThemeMode`, read `mode`, pass it as `mode={mode}` to `<XDSTheme theme={neutralTheme} mode={mode}>`