### PR TITLE
fix(docsite): inherit site theme mode in component detail preview

### DIFF
--- a/apps/docsite/src/components/component-detail/ShowcasePreview.tsx
+++ b/apps/docsite/src/components/component-detail/ShowcasePreview.tsx
@@ -10,12 +10,14 @@ import {XDSTheme} from '@xds/core/theme';
 import {useMediaQuery} from '@xds/core/hooks';
 import {neutralTheme} from '@xds/theme-neutral/built';
 import {showcaseRegistry} from '../../generated/showcaseRegistry';
+import {useThemeMode} from '../../app/providers';
 
 interface ShowcasePreviewProps {
   name: string;
 }
 
 export function ShowcasePreview({name}: ShowcasePreviewProps) {
+  const {mode} = useThemeMode();
   const [Component, setComponent] = useState<ComponentType | null>(null);
   const [error, setError] = useState(false);
   const isSmall = useMediaQuery('(max-width: 768px)');
@@ -55,7 +57,7 @@ export function ShowcasePreview({name}: ShowcasePreviewProps) {
 
   if (isSmall) {
     return (
-      <XDSTheme theme={neutralTheme}>
+      <XDSTheme theme={neutralTheme} mode={mode}>
         <div
           style={{
             width: '100%',
@@ -74,7 +76,7 @@ export function ShowcasePreview({name}: ShowcasePreviewProps) {
   }
 
   return (
-    <XDSTheme theme={neutralTheme}>
+    <XDSTheme theme={neutralTheme} mode={mode}>
       <div
         style={{
           width: '100%',


### PR DESCRIPTION
## Problem

The `ShowcasePreview` component (rendered on component detail pages like `/components/calendar`) wraps examples in `<XDSTheme theme={neutralTheme}>` without passing `mode`. This causes previews to use the system color scheme instead of the site's controlled light/dark toggle — the same issue fixed in #2389 for `ShowcaseThumbnail`.

In dark mode with the neutral theme, this makes calendar days (and other components) appear with incorrect colors because `light-dark()` resolves against the system preference rather than the site's mode.

## Solution

Import `useThemeMode` from the site's providers and pass the active `mode` to both `<XDSTheme>` wrappers (small and regular viewport paths).

## Changes

- `apps/docsite/src/components/component-detail/ShowcasePreview.tsx`: Import `useThemeMode`, read `mode`, pass it as `mode={mode}` to both `<XDSTheme theme={neutralTheme} mode={mode}>` calls.