### PR TITLE
fix(Slider): add playground defaults and guard against undefined value

### DIFF
--- a/packages/core/src/Slider/Slider.doc.mjs
+++ b/packages/core/src/Slider/Slider.doc.mjs
@@ -6,6 +6,12 @@ export const docs = {
   name: 'Slider',
   displayName: 'Slider',
   keywords: ["slider","range","slidebar","trackbar","scrubber","knob","thumb","rangeslider"],
+  playground: {
+    defaults: {
+      label: 'Volume',
+      value: 50,
+    },
+  },
   props: [
     {
       name: 'label',

--- a/packages/core/src/Slider/XDSSlider.tsx
+++ b/packages/core/src/Slider/XDSSlider.tsx
@@ -370,10 +370,14 @@ export function XDSSlider({ref, ...props}: XDSSliderProps) {
   const ariaDescribedBy =
     describedByParts.length > 0 ? describedByParts.join(' ') : undefined;
 
-  // Value helpers
+  // Value helpers — guard against undefined value (e.g. playground previews
+  // that render the component without providing a value prop).
   const values: number[] = useMemo(
-    () => (isRange ? value : [value]),
-    [isRange, value],
+    () =>
+      isRange
+        ? (value)
+        : [value != null ? (value) : min],
+    [isRange, value, min],
   );
 
   const valuesRef = useRef(values);


### PR DESCRIPTION
## Problem

The Slider component page on the docsite throws a TypeError when viewed on the Properties tab:

```
TypeError: Cannot read properties of undefined (reading 'cancel')
```

## Root Cause

The Slider's `value` prop has type `number | [number, number]`. The docsite's `parsePropType` utility doesn't recognize this union format — it returns `{kind: 'unknown'}`, which means no default value is generated for the interactive preview. The Slider then renders with `value=undefined`, causing pointer event handlers and the tooltip system to operate on undefined values.

## Fix

1. **Added `playground.defaults`** to `Slider.doc.mjs` — provides `value: 50` and `label: 'Volume'` so the Properties tab renders a functional slider.

2. **Added defensive guard** in `XDSSlider.tsx` — if `value` is null/undefined (e.g. from a playground preview without state management), falls back to `min` instead of passing undefined through to the internal values array.

## Testing

- All 21 existing Slider tests pass
- Showcase examples unaffected (they already provide proper values)