### PR TITLE
fix(docsite): inherit site theme mode in component examples

### DIFF
--- a/apps/docsite/src/components/component-detail/ExampleBlock.tsx
+++ b/apps/docsite/src/components/component-detail/ExampleBlock.tsx
@@ -14,10 +14,12 @@ import {XDSButton} from '@xds/core/Button';
 import {XDSHStack} from '@xds/core/Layout';
 import {XDSTheme} from '@xds/core/theme';
 import {neutralTheme} from '@xds/theme-neutral/built';
+import {useThemeMode} from '../../app/providers';
 import type {ExampleEntry} from '../../generated/exampleRegistry';
 import {buildPlaygroundHref} from '../playgroundLink';
 
 function LivePreview({entry}: {entry: ExampleEntry}) {
+  const {mode} = useThemeMode();
   const [Component, setComponent] = useState<ComponentType | null>(null);
   const [error, setError] = useState(false);
 
@@ -47,7 +49,7 @@ function LivePreview({entry}: {entry: ExampleEntry}) {
   }
 
   return (
-    <XDSTheme theme={neutralTheme}>
+    <XDSTheme theme={neutralTheme} mode={mode}>
       <div
         style={{
           width: '100%',

--- a/apps/docsite/src/components/component-detail/InteractivePreview.tsx
+++ b/apps/docsite/src/components/component-detail/InteractivePreview.tsx
@@ -20,6 +20,7 @@ import {XDSVStack} from '@xds/core/Layout';
 import {XDSText} from '@xds/core/Text';
 import {XDSTheme} from '@xds/core/theme';
 import {neutralTheme} from '@xds/theme-neutral/built';
+import {useThemeMode} from '../../app/providers';
 import {CodeBracketIcon} from '@heroicons/react/24/outline';
 import {
   coerceDefault,
@@ -233,6 +234,7 @@ export function InteractivePreviewStage({
   name: string;
   state: Record<string, unknown>;
 }) {
+  const {mode} = useThemeMode();
   const [showCode, setShowCode] = useState(false);
   const Component = getXDSComponent(name);
 
@@ -293,7 +295,7 @@ export function InteractivePreviewStage({
           <XDSCodeBlock code={code} language="tsx" hasCopyButton />
         </div>
       ) : (
-        <XDSTheme theme={neutralTheme}>
+        <XDSTheme theme={neutralTheme} mode={mode}>
           <XDSCenter
             style={{
               minHeight: 200,


### PR DESCRIPTION
Updating so that the selected mode (light/dark) is applied to all component examples, regardless of the nested theme.