### PR TITLE
fix(core): join blank-line-separated lists and forward <ol start> attribute

### DIFF
--- a/.changeset/loose-ordered-lists.md
+++ b/.changeset/loose-ordered-lists.md
@@ -1,0 +1,7 @@
+---
+'@xds/core': patch
+---
+
+**Markdown:** join blank-line-separated same-style list items into a single loose list (CommonMark §5.3), and forward a non-default `start` onto the rendered `<ol>` so the number is visible to assistive tech and on copy-paste.
+
+LLM output commonly emits `1.\n\n1.\n\n1. …` to mean "an ordered list of three items"; previously each item became its own `<ol>` restarting at 1. The parser now treats blank lines between same-style/same-indent items as a loose-list continuation and sets `loose: true` on the resulting list node. `<XDSList listStyle="decimal" start={N}>` now also emits `start="N"` on the underlying `<ol>` element (the CSS counter alone is invisible to assistive tech).

--- a/packages/core/src/List/XDSList.test.tsx
+++ b/packages/core/src/List/XDSList.test.tsx
@@ -96,6 +96,28 @@ describe('XDSList', () => {
     expect(ol.className).toContain('counterStart');
   });
 
+  it('emits the start HTML attribute on <ol> when start is non-default', () => {
+    // Browsers and assistive tech read the start attribute directly; the CSS
+    // counter alone is invisible to AT and copy-paste.
+    const {container} = render(
+      <XDSList listStyle="decimal" start={5}>
+        <XDSListItem label="Fifth" />
+      </XDSList>,
+    );
+    const ol = container.querySelector('ol')!;
+    expect(ol.getAttribute('start')).toBe('5');
+  });
+
+  it('does not emit the start HTML attribute for the default (start=1)', () => {
+    const {container} = render(
+      <XDSList listStyle="decimal">
+        <XDSListItem label="First" />
+      </XDSList>,
+    );
+    const ol = container.querySelector('ol')!;
+    expect(ol.hasAttribute('start')).toBe(false);
+  });
+
   it('renders as <ul> when listStyle is disc', () => {
     const {container} = render(
       <XDSList listStyle="disc">

--- a/packages/core/src/List/XDSList.tsx
+++ b/packages/core/src/List/XDSList.tsx
@@ -166,6 +166,7 @@ export function XDSList({
       ref={ref as React.Ref<HTMLUListElement & HTMLOListElement>}
       data-testid={testId}
       aria-labelledby={header != null ? headerId : undefined}
+      {...(isOrdered && start != null && start !== 1 ? {start} : {})}
       {...(listStyle === 'none' && !isOrdered ? {role: 'list'} : {})}
       {...mergeProps(
         xdsClassName('list', {density, listStyle}),

--- a/packages/core/src/Markdown/XDSMarkdown.test.tsx
+++ b/packages/core/src/Markdown/XDSMarkdown.test.tsx
@@ -132,6 +132,21 @@ describe('XDSMarkdown', () => {
     expect(ol.className).toContain('withCounter');
   });
 
+  it('joins blank-line-separated 1./1./1. into a single ordered list', () => {
+    // Regression: LLM-style loose ordered lists (1.\n\n1.\n\n1.) used to
+    // render as three separate <ol>s each restarting at 1.
+    render(<XDSMarkdown>{'1. apple\n\n1. banana\n\n1. cherry'}</XDSMarkdown>);
+    const ols = document.querySelectorAll('ol');
+    expect(ols).toHaveLength(1);
+    expect(ols[0].querySelectorAll('li')).toHaveLength(3);
+  });
+
+  it('forwards a non-default start onto the <ol> element', () => {
+    render(<XDSMarkdown>{'5. five\n6. six\n7. seven'}</XDSMarkdown>);
+    const ol = document.querySelector('ol')!;
+    expect(ol.getAttribute('start')).toBe('5');
+  });
+
   it('renders task lists with checkboxes', () => {
     render(<XDSMarkdown>{'- [x] Done\n- [ ] Todo'}</XDSMarkdown>);
     const checkboxes = document.querySelectorAll('input[type="checkbox"]');

--- a/packages/core/src/Markdown/incremental.test.ts
+++ b/packages/core/src/Markdown/incremental.test.ts
@@ -28,6 +28,19 @@ describe('parseMarkdownIncremental', () => {
     expect(final).toEqual(full);
   });
 
+  it('joins loose ordered list across streamed chunks', () => {
+    // The boundary detector settles each pre-blank-line segment separately;
+    // without the merge step this would land as three separate <ol>s.
+    const text = '1. apple\n\n1. banana\n\n1. cherry\n';
+    const {final} = simulateStreaming(text, 5);
+    expect(final).toHaveLength(1);
+    expect(final[0].type).toBe('list');
+    if (final[0].type === 'list') {
+      expect(final[0].items).toHaveLength(3);
+      expect(final[0].loose).toBe(true);
+    }
+  });
+
   it('handles empty input', () => {
     const state = createIncrementalState();
     const result = parseMarkdownIncremental('', state);

--- a/packages/core/src/Markdown/parser.test.ts
+++ b/packages/core/src/Markdown/parser.test.ts
@@ -252,6 +252,62 @@ describe('parseMarkdown', () => {
     }
   });
 
+  it('parses an ordered list with a custom start number', () => {
+    const result = parseMarkdown('5. five\n6. six\n7. seven');
+    expect(result[0].type).toBe('list');
+    if (result[0].type === 'list') {
+      expect(result[0].ordered).toBe(true);
+      expect(result[0].start).toBe(5);
+      expect(result[0].items).toHaveLength(3);
+    }
+  });
+
+  it('joins blank-line-separated same-style items into one loose list', () => {
+    // CommonMark §5.3 loose-list: blank lines between items of the same
+    // style/indent still form a single list. LLM output very commonly uses
+    // the 1./1./1. shape — each item must be treated as a continuation.
+    const result = parseMarkdown('1. apple\n\n1. banana\n\n1. cherry');
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe('list');
+    if (result[0].type === 'list') {
+      expect(result[0].ordered).toBe(true);
+      expect(result[0].loose).toBe(true);
+      expect(result[0].items).toHaveLength(3);
+      expect(result[0].start).toBe(1);
+    }
+  });
+
+  it('joins blank-line-separated unordered items into one loose list', () => {
+    const result = parseMarkdown('- a\n\n- b\n\n- c');
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe('list');
+    if (result[0].type === 'list') {
+      expect(result[0].ordered).toBe(false);
+      expect(result[0].loose).toBe(true);
+      expect(result[0].items).toHaveLength(3);
+    }
+  });
+
+  it('does not join lists of different styles across a blank line', () => {
+    // Bulleted then numbered — these are two distinct lists.
+    const result = parseMarkdown('- a\n\n1. b');
+    expect(result).toHaveLength(2);
+    expect(result[0].type).toBe('list');
+    expect(result[1].type).toBe('list');
+    if (result[0].type === 'list' && result[1].type === 'list') {
+      expect(result[0].ordered).toBe(false);
+      expect(result[1].ordered).toBe(true);
+    }
+  });
+
+  it('treats a tight list with no blank lines as not loose', () => {
+    const result = parseMarkdown('1. a\n2. b\n3. c');
+    expect(result[0].type).toBe('list');
+    if (result[0].type === 'list') {
+      expect(result[0].loose).toBeUndefined();
+    }
+  });
+
   it('parses task lists', () => {
     const input = '- [ ] Unchecked\n- [x] Checked';
     const result = parseMarkdown(input);

--- a/packages/core/src/Markdown/parser.ts
+++ b/packages/core/src/Markdown/parser.ts
@@ -27,7 +27,13 @@ export type BlockNode =
   | {type: 'paragraph'; children: InlineNode[]}
   | {type: 'codeblock'; language: string; content: string}
   | {type: 'blockquote'; children: BlockNode[]}
-  | {type: 'list'; ordered: boolean; start?: number; items: ListItemNode[]}
+  | {
+      type: 'list';
+      ordered: boolean;
+      start?: number;
+      loose?: boolean;
+      items: ListItemNode[];
+    }
   | {
       type: 'table';
       headers: TableCellNode[];
@@ -499,6 +505,7 @@ function parseList(
   const startMatch = ordered ? lines[startIndex].match(/^ *(\d+)\./) : null;
   const start = startMatch ? parseInt(startMatch[1], 10) : undefined;
 
+  let loose = false;
   let index = startIndex;
   while (index < lines.length && itemPattern.test(lines[index])) {
     const content = ordered
@@ -537,8 +544,27 @@ function parseList(
     }
 
     items.push({checked, children: parseMarkdown(itemText, sourceIds)});
+
+    // CommonMark loose list: blank line(s) between items of the same style
+    // and indent still form one list. Skip the blanks and continue if the
+    // next non-blank line matches the same item pattern.
+    let lookahead = index;
+    while (lookahead < lines.length && lines[lookahead].trim() === '') {
+      lookahead++;
+    }
+    if (
+      lookahead > index &&
+      lookahead < lines.length &&
+      itemPattern.test(lines[lookahead])
+    ) {
+      loose = true;
+      index = lookahead;
+    }
   }
-  return {node: {type: 'list', ordered, start, items}, nextIndex: index};
+  return {
+    node: {type: 'list', ordered, start, loose: loose || undefined, items},
+    nextIndex: index,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -938,6 +964,39 @@ function trimUnsettledStructural(text: string): string {
   return lines.join('\n');
 }
 
+/**
+ * Concatenate freshly-parsed delta blocks with previously-settled blocks,
+ * merging adjacent same-style lists into a single loose list. The boundary
+ * detector settles each pre-blank segment independently, so without this
+ * merge an incrementally-streamed `1.\n\n1.\n\n1.` would land as N separate
+ * lists even though the full-text parser joins them per CommonMark §5.3.
+ */
+function mergeSettledBlocks(
+  prev: BlockNode[],
+  delta: BlockNode[],
+): BlockNode[] {
+  if (prev.length === 0 || delta.length === 0) {
+    return [...prev, ...delta];
+  }
+  const prevLast = prev[prev.length - 1];
+  const deltaFirst = delta[0];
+  if (
+    prevLast.type === 'list' &&
+    deltaFirst.type === 'list' &&
+    prevLast.ordered === deltaFirst.ordered
+  ) {
+    const merged: BlockNode = {
+      type: 'list',
+      ordered: prevLast.ordered,
+      start: prevLast.start,
+      loose: true,
+      items: [...prevLast.items, ...deltaFirst.items],
+    };
+    return [...prev.slice(0, -1), merged, ...delta.slice(1)];
+  }
+  return [...prev, ...delta];
+}
+
 export function parseMarkdownIncremental(
   input: string,
   state: IncrementalState,
@@ -976,7 +1035,7 @@ export function parseMarkdownIncremental(
     // Settled portion grew — parse only the new delta
     const delta = settledText.slice(state.settledText.length);
     const deltaBlocks = parseMarkdown(delta, sourceIds);
-    settledBlocks = [...state.settledBlocks, ...deltaBlocks];
+    settledBlocks = mergeSettledBlocks(state.settledBlocks, deltaBlocks);
   } else {
     // Content before the boundary changed — full re-parse of settled portion
     settledBlocks = parseMarkdown(settledText, sourceIds);
@@ -991,5 +1050,5 @@ export function parseMarkdownIncremental(
   state.settledUpTo = boundary;
   state.prevInput = input;
 
-  return [...settledBlocks, ...unsettledBlocks];
+  return mergeSettledBlocks(settledBlocks, unsettledBlocks);
 }


### PR DESCRIPTION
## What

Two fixes to Markdown rendering, both triggered by very common LLM output:

### 1. Join blank-line-separated same-style list items into one loose list (CommonMark §5.3)

LLMs love emitting

```
1. apple

1. banana

1. cherry
```

to mean a 3-item ordered list. Today this lands as **three** separate `<ol>`s, each restarting at 1 (since `XDSList` sets `counter-reset: xds-list` on every `<ol>`). That doesn't match CommonMark §5.3 — blank lines between items of the same style/indent form a *loose* list, not separate lists.

Fix in `packages/core/src/Markdown/parser.ts`:

- `BlockNode.list` variant gains `loose?: boolean`.
- `parseList` now skips blank lines after each item and continues consuming items while the next non-blank line matches the same item pattern; sets `loose = true` on the resulting node.
- The incremental parser's boundary detector settles each pre-blank segment independently, so without a second step the streamed shape would still end up as N separate lists. New `mergeSettledBlocks(prev, delta)` helper folds adjacent same-`ordered` lists into one loose list whenever delta blocks land — matching the full-text parser's output across streamed chunks.

### 2. Forward `<ol start>` onto the rendered element

`<XDSList listStyle="decimal" start={5}>` already styles the visible counter via CSS (added in #2277), but the HTML `start` attribute was never set on the underlying `<ol>`. The CSS counter alone is **invisible to assistive tech and lost on copy-paste** — the only signal that scales there is `<ol start="N">`.

Fix in `packages/core/src/List/XDSList.tsx`: spread `{start}` onto the `<Tag>` when `isOrdered && start != null && start !== 1`. Default (`start === 1` or unset) still omits the attribute.

## Why

Reported in https://fb.workplace.com/groups/xdsoss/posts/2426593717859007/ — the two bugs compound for LLM-generated content (rendered output looks like one list to the eye, but each chunk restarts at 1, and AT can't tell where it actually started). The Scout app currently ships a parser-level workaround that pre-collapses blank-separated items before handing the markdown to `<XDSMarkdown>`; this PR lets every `XDSMarkdown` consumer drop that workaround.

## Test plan

`packages/core/src/Markdown/parser.test.ts` adds:

- `parses an ordered list with a custom start number`
- `joins blank-line-separated same-style items into one loose list`
- `joins blank-line-separated unordered items into one loose list`
- `does not join lists of different styles across a blank line`
- `treats a tight list with no blank lines as not loose`

`packages/core/src/Markdown/incremental.test.ts` adds:

- `joins loose ordered list across streamed chunks`

`packages/core/src/Markdown/XDSMarkdown.test.tsx` adds:

- `joins blank-line-separated 1./1./1. into a single ordered list`
- `forwards a non-default start onto the <ol> element`

`packages/core/src/List/XDSList.test.tsx` adds:

- `emits the start HTML attribute on <ol> when start is non-default`
- `does not emit the start HTML attribute for the default (start=1)`

Verified locally:

```
$ vitest run packages/core/src/Markdown packages/core/src/List
 ✓ packages/core/src/Markdown/parser.test.ts        (59 tests)
 ✓ packages/core/src/Markdown/incremental.test.ts   (49 tests)
 ✓ packages/core/src/List/XDSList.test.tsx          (52 tests)
 ✓ packages/core/src/Markdown/XDSMarkdown.test.tsx  (44 tests)
 ✓ packages/core/src/Markdown/parser.perf.test.ts   (11 tests)

 Test Files  6 passed (6)
      Tests  229 passed (229)
```

`tsc --noEmit -p packages/core/tsconfig.json` clean. `prettier --check` clean on touched files.

## Notes

- The `loose` flag is currently informational on the parser node — rendering today doesn't branch on it, but downstream consumers (and a future tighter-vs-looser paragraph wrapping in XDSMarkdown) can use it without further parser changes.
- Backwards-compatible: `loose` is optional and omitted when `false`; `start` HTML attribute is only emitted for non-default values, so existing snapshots/assertions for `<ol>` with no `start` (the 99% case) stay green.
