### PR TITLE
fix(core): add missing file headers to ClickableCard and CodeBlock

### DIFF
--- a/packages/core/src/ClickableCard/index.ts
+++ b/packages/core/src/ClickableCard/index.ts
@@ -2,5 +2,14 @@
 
 'use client';
 
+/**
+ * @file index.ts
+ * @input Imports from XDSClickableCard.tsx
+ * @output Exports XDSClickableCard component and XDSClickableCardProps type
+ * @position Component entry point; re-exported by /packages/core/src/index.ts
+ *
+ * SYNC: When modified, update /packages/core/src/ClickableCard/ClickableCard.doc.mjs
+ */
+
 export {XDSClickableCard} from './XDSClickableCard';
 export type {XDSClickableCardProps} from './XDSClickableCard';

--- a/packages/core/src/CodeBlock/index.ts
+++ b/packages/core/src/CodeBlock/index.ts
@@ -2,6 +2,15 @@
 
 'use client';
 
+/**
+ * @file index.ts
+ * @input Imports from XDSCodeBlock.tsx, XDSCode.tsx, tokenizer.ts, highlightRanges.ts, highlightStyles.ts
+ * @output Exports XDSCodeBlock, XDSCode components, tokenizer utilities, and highlight APIs
+ * @position Component entry point; re-exported by /packages/core/src/index.ts
+ *
+ * SYNC: When modified, update /packages/core/src/CodeBlock/CodeBlock.doc.mjs
+ */
+
 export {XDSCodeBlock} from './XDSCodeBlock';
 export type {XDSCodeBlockProps} from './XDSCodeBlock';
 


### PR DESCRIPTION
Add structured file headers (`@file`, `@input`, `@output`, `@position`) to entry-point index files that were missing them:

- `packages/core/src/ClickableCard/index.ts`
- `packages/core/src/CodeBlock/index.ts`

Found during component audit of: ClickableCard, CodeBlock, Collapsible, CommandPalette, DateInput. All other checks (theming tokens, xdsClassName, prop naming, type naming, component structure, input consistency, a11y, exports) passed.

Night Watch — Component Auditor