### PR TITLE
fix(cli): template dependency installation, --no-prose, skeleton renderer

### DIFF
--- a/packages/cli/src/api/template.mjs
+++ b/packages/cli/src/api/template.mjs
@@ -13,10 +13,112 @@ import {loadConfig} from '../lib/config.mjs';
 const TEMPLATES_DIR = path.join(CLI_ROOT, 'templates');
 const PAGES_DIR = path.join(TEMPLATES_DIR, 'pages');
 const BLOCKS_DIR = path.join(TEMPLATES_DIR, 'blocks');
+/**
+ * Add template dependencies to the user's package.json. Only writes packages
+ * that aren't already declared in `dependencies` or `devDependencies`. Returns
+ * the list of newly added package names (with `latest` as the version range).
+ *
+ * If no package.json exists in `cwd`, returns the dependency list unchanged
+ * so the caller can surface it in install instructions.
+ *
+ * @param {string[]} deps
+ * @param {string} cwd
+ * @returns {{added: string[], skipped: string[], packageJsonPath: string|null}}
+ */
+export function applyTemplateDependencies(deps, cwd) {
+  if (!deps || deps.length === 0) {
+    return {added: [], skipped: [], packageJsonPath: null};
+  }
+  const pkgPath = path.join(cwd, 'package.json');
+  if (!fs.existsSync(pkgPath)) {
+    return {added: [], skipped: deps, packageJsonPath: null};
+  }
+  let pkg;
+  try {
+    pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+  } catch {
+    return {added: [], skipped: deps, packageJsonPath: pkgPath};
+  }
+  const existing = new Set([
+    ...Object.keys(pkg.dependencies || {}),
+    ...Object.keys(pkg.devDependencies || {}),
+    ...Object.keys(pkg.peerDependencies || {}),
+  ]);
+  const added = [];
+  const skipped = [];
+  pkg.dependencies = pkg.dependencies || {};
+  for (const dep of deps) {
+    if (existing.has(dep)) {
+      skipped.push(dep);
+      continue;
+    }
+    pkg.dependencies[dep] = 'latest';
+    added.push(dep);
+  }
+  if (added.length > 0) {
+    // Sort dependencies alphabetically for stable output
+    const sorted = {};
+    for (const k of Object.keys(pkg.dependencies).sort()) {
+      sorted[k] = pkg.dependencies[k];
+    }
+    pkg.dependencies = sorted;
+    fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+  }
+  return {added, skipped, packageJsonPath: pkgPath};
+}
+
 async function loadDocModule(docPath) {
   if (!fs.existsSync(docPath)) return null;
   const docModule = await import(`file://${docPath}`);
   return docModule.doc;
+}
+
+/**
+ * Auto-detect npm package dependencies from a template's source file by
+ * scanning its import statements. Filters out:
+ *   - relative imports (./foo)
+ *   - @xds/* (provided by the design system itself)
+ *   - react / react-dom (assumed present in any React app)
+ *
+ * Returns the bare-package portion of each import (e.g. `@heroicons/react`,
+ * not `@heroicons/react/24/outline`).
+ *
+ * @param {string} filePath
+ * @returns {string[]}
+ */
+function detectDependenciesFromSource(filePath) {
+  if (!fs.existsSync(filePath)) return [];
+  const src = fs.readFileSync(filePath, 'utf-8');
+  const deps = new Set();
+  // Matches both `import X from 'pkg'` and `} from 'pkg'`
+  const re = /from\s+['"]([^'"]+)['"]/g;
+  let m;
+  while ((m = re.exec(src)) !== null) {
+    const spec = m[1];
+    if (spec.startsWith('.') || spec.startsWith('/')) continue;
+    if (spec.startsWith('@xds/')) continue;
+    if (spec === 'react' || spec === 'react-dom') continue;
+    if (spec.endsWith('.png') || spec.endsWith('.jpg') || spec.endsWith('.svg')) continue;
+    // Bare-package portion: '@scope/name' or 'name'
+    const parts = spec.split('/');
+    const bare = spec.startsWith('@') ? parts.slice(0, 2).join('/') : parts[0];
+    deps.add(bare);
+  }
+  return [...deps].sort();
+}
+
+/**
+ * Resolve the full dependency list for a template. Combines explicit
+ * `dependencies` from the doc manifest (if present) with auto-detected
+ * imports from the source file. Manifest entries win on duplicates.
+ *
+ * @param {{filePath: string, dependencies?: string[]}} template
+ * @returns {string[]}
+ */
+export function resolveTemplateDependencies(template) {
+  const detected = detectDependenciesFromSource(template.filePath);
+  const declared = Array.isArray(template.dependencies) ? template.dependencies : [];
+  return [...new Set([...declared, ...detected])].sort();
 }
 
 export {discoverAll as discoverTemplates};
@@ -61,6 +163,7 @@ async function discoverPages() {
       description: doc?.description || '',
       isReady: doc?.isReady ?? true,
       scaffold: doc?.scaffold ?? false,
+      dependencies: doc?.dependencies,
       filePath: path.join(dirPath, 'page.tsx'),
       docPath: path.join(dirPath, 'template.doc.mjs'),
     });
@@ -86,6 +189,7 @@ async function discoverBlocks() {
       aspectRatio: doc?.aspectRatio ?? 1,
       componentsUsed: doc?.componentsUsed ?? [],
       isShowcase: doc?.isShowcase ?? false,
+      dependencies: doc?.dependencies,
       filePath: tsxPath,
       docPath,
       category: relPath,
@@ -258,13 +362,72 @@ function extractSkeleton(source) {
       }
 
       const props = [];
-      const propRegex = /\b(padding|contentPadding|gap|rowGap|columnGap|columns|minChildWidth|hasDivider|defaultHasDividers|variant|density|role|height|width|maxWidth)\s*[=]\s*\{?\s*['"]?([^}'"\s,/>]+)/g;
-      let m;
-      while ((m = propRegex.exec(tagText)) !== null) {
-        const val = m[2];
-        if (val === 'true') props.push(m[1]);
-        else if (/^\d+$/.test(val)) props.push(`${m[1]}={${val}}`);
-        else props.push(`${m[1]}="${val}"`);
+      const PROP_NAMES = ['padding', 'contentPadding', 'gap', 'rowGap', 'columnGap', 'columns', 'minChildWidth', 'hasDivider', 'defaultHasDividers', 'variant', 'density', 'role', 'height', 'width', 'maxWidth'];
+      const propNamePattern = `\\b(${PROP_NAMES.join('|')})\\s*=`;
+      const propNameRe = new RegExp(propNamePattern, 'g');
+      let nameMatch;
+      while ((nameMatch = propNameRe.exec(tagText)) !== null) {
+        const propName = nameMatch[1];
+        let i = nameMatch.index + nameMatch[0].length;
+        // Skip whitespace
+        while (i < tagText.length && /\s/.test(tagText[i])) i++;
+        if (i >= tagText.length) continue;
+
+        const ch = tagText[i];
+        let val;
+        if (ch === '"' || ch === "'") {
+          // Quoted string: foo="bar"
+          const close = tagText.indexOf(ch, i + 1);
+          if (close === -1) continue;
+          val = tagText.slice(i + 1, close);
+          if (val === 'true') props.push(propName);
+          else if (/^\d+$/.test(val)) props.push(`${propName}={${val}}`);
+          else props.push(`${propName}="${val}"`);
+        } else if (ch === '{') {
+          // Brace expression: foo={...} — match balanced braces
+          let depth = 0;
+          let end = i;
+          for (; end < tagText.length; end++) {
+            if (tagText[end] === '{') depth++;
+            else if (tagText[end] === '}') {
+              depth--;
+              if (depth === 0) { end++; break; }
+            }
+          }
+          const inner = tagText.slice(i + 1, end - 1).trim();
+          // Simple values: foo={42}, foo={true}, foo={'bar'}
+          if (/^\d+$/.test(inner)) {
+            props.push(`${propName}={${inner}}`);
+          } else if (inner === 'true') {
+            props.push(propName);
+          } else if (inner === 'false') {
+            // Skip false-valued boolean props in skeleton
+          } else if (/^['"][^'"]*['"]$/.test(inner)) {
+            props.push(`${propName}=${inner.replace(/^['"]|['"]$/g, '"')}`);
+          } else if (inner.startsWith('{') && inner.endsWith('}')) {
+            // Object literal — try to extract a useful summary key
+            const minWidthMatch = inner.match(/minWidth\s*:\s*(\d+)/);
+            if (minWidthMatch) {
+              props.push(`${propName}={{minWidth: ${minWidthMatch[1]}}}`);
+            } else {
+              props.push(`${propName}={{...}}`);
+            }
+          } else {
+            // Variable reference or expression — show as expression
+            // Truncate long expressions
+            const summary = inner.length > 24 ? inner.slice(0, 21) + '...' : inner;
+            props.push(`${propName}={${summary}}`);
+          }
+        } else {
+          // No quotes/braces — bare token (rare in JSX)
+          const tokenMatch = tagText.slice(i).match(/^([^\s,/>]+)/);
+          if (tokenMatch) {
+            const val2 = tokenMatch[1];
+            if (val2 === 'true') props.push(propName);
+            else if (/^\d+$/.test(val2)) props.push(`${propName}={${val2}}`);
+            else props.push(`${propName}="${val2}"`);
+          }
+        }
       }
 
       const hasSpatialProps = props.length > 0;
@@ -455,7 +618,40 @@ export async function template(name, options = {}) {
     };
   }
 
-  const outputDir = path.resolve(cwd, targetPath);
+  // If the target path looks like a file (has a .tsx/.jsx/.ts/.js extension),
+  // and isn't an existing directory, write the template directly to that path
+  // instead of treating it as a directory and creating <path>/page.tsx.
+  const resolved = path.resolve(cwd, targetPath);
+  const looksLikeFile = /\.(tsx|jsx|ts|js)$/.test(targetPath);
+  const existsAsDir = fs.existsSync(resolved) && fs.statSync(resolved).isDirectory();
+
+  const dependencies = resolveTemplateDependencies(match);
+  const depsResult = applyTemplateDependencies(dependencies, cwd);
+
+  if (looksLikeFile && !existsAsDir) {
+    const outFilePath = resolved;
+    fs.mkdirSync(path.dirname(outFilePath), {recursive: true});
+    fs.copyFileSync(match.filePath, outFilePath);
+    const relOutput = path.relative(cwd, outFilePath);
+    return {
+      type: 'template.copy',
+      data: {
+        template: name,
+        outputDir: path.relative(cwd, path.dirname(outFilePath)) || '.',
+        fileName: path.basename(outFilePath),
+        outputPath: relOutput,
+        filesCopied: 1,
+        dependencies,
+        dependenciesAdded: depsResult.added,
+        dependenciesSkipped: depsResult.skipped,
+        packageJsonPath: depsResult.packageJsonPath
+          ? path.relative(cwd, depsResult.packageJsonPath)
+          : null,
+      },
+    };
+  }
+
+  const outputDir = resolved;
   const outputFileName = match.type === 'block'
     ? path.basename(match.filePath)
     : 'page.tsx';
@@ -465,6 +661,17 @@ export async function template(name, options = {}) {
   const relOutput = path.relative(cwd, outputDir);
   return {
     type: 'template.copy',
-    data: {template: name, outputDir: relOutput, fileName: outputFileName, filesCopied: 1},
+    data: {
+      template: name,
+      outputDir: relOutput,
+      fileName: outputFileName,
+      filesCopied: 1,
+      dependencies,
+      dependenciesAdded: depsResult.added,
+      dependenciesSkipped: depsResult.skipped,
+      packageJsonPath: depsResult.packageJsonPath
+        ? path.relative(cwd, depsResult.packageJsonPath)
+        : null,
+    },
   };
 }

--- a/packages/cli/src/commands/build-theme.mjs
+++ b/packages/cli/src/commands/build-theme.mjs
@@ -983,6 +983,8 @@ export function registerTheme(program) {
     .action(async (file, options) => {
       const filePath = path.resolve(process.cwd(), file);
       const json = program.opts().json || false;
+      // Commander sets options.prose = false when --no-prose is passed.
+      const includeProse = options.prose !== false;
 
       if (!fs.existsSync(filePath)) {
         if (json) return jsonError('File not found: ' + filePath);
@@ -1049,7 +1051,12 @@ export function registerTheme(program) {
         const scopeTo = `[data-xds-theme]`;
 
         if (_generateThemeRulesSplit) {
-          const {component, prose} = _generateThemeRulesSplit(resolvedTheme);
+          // Pass {prose} so core can omit prose rules at the source when
+          // supported. Older core builds ignore the second arg — we also
+          // drop the prose array below as a belt-and-braces guarantee.
+          const split = _generateThemeRulesSplit(resolvedTheme, {prose: includeProse});
+          const component = split.component;
+          const prose = includeProse ? split.prose : [];
           const cssParts = [];
           if (prose.length > 0) {
             const proseInner = prose.join('\n\n');
@@ -1092,9 +1099,11 @@ export function registerTheme(program) {
       } else {
         // Legacy fallback when core isn't built yet
         const scopeBlocks = [];
-        const proseCss = generateProseCSS(themeDef);
-        if (proseCss) scopeBlocks.push(proseCss);
-        const mainCss = generateCSS(themeDef);
+        if (includeProse) {
+          const proseCss = generateProseCSS(themeDef);
+          if (proseCss) scopeBlocks.push(proseCss);
+        }
+        const mainCss = generateCSS(themeDef, {prose: includeProse});
         if (mainCss) scopeBlocks.push(mainCss);
         if (scopeBlocks.length === 0) {
           if (!json) console.log('No overrides found — nothing to build.');

--- a/packages/cli/src/commands/build-theme.test.mjs
+++ b/packages/cli/src/commands/build-theme.test.mjs
@@ -1,0 +1,91 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file build-theme.test.mjs — exercise the --no-prose flag end-to-end.
+ *
+ * We can't easily invoke the registerTheme commander action in a unit test
+ * (it lives inside .action()), so we instead verify the underlying core API
+ * accepts {prose: false} and that prose rules are excluded.
+ */
+
+import {describe, it, expect} from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import {execSync} from 'node:child_process';
+
+import {
+  defineTheme,
+  generateThemeRulesSplit,
+} from '@xds/core/theme';
+
+describe('generateThemeRulesSplit prose option', () => {
+  const theme = defineTheme({
+    name: 'test-theme',
+    tokens: {
+      '--color-bg-primary': '#ffffff',
+      '--color-text-primary': '#000000',
+    },
+  });
+
+  it('emits prose rules by default', () => {
+    const {prose, component} = generateThemeRulesSplit(theme);
+    expect(prose.length).toBeGreaterThan(0);
+    expect(prose.join('\n')).toMatch(/:where\(h1, h2/);
+    expect(component.length).toBeGreaterThan(0);
+  });
+
+  it('emits prose rules when prose: true', () => {
+    const {prose} = generateThemeRulesSplit(theme, {prose: true});
+    expect(prose.length).toBeGreaterThan(0);
+  });
+
+  it('omits prose rules when prose: false', () => {
+    const {prose, component} = generateThemeRulesSplit(theme, {prose: false});
+    expect(prose).toEqual([]);
+    // Component rules should still be present (token block survives)
+    expect(component.length).toBeGreaterThan(0);
+  });
+});
+
+describe('xds theme build --no-prose (cli)', () => {
+  // Resolve from CWD (vitest runs from repo root) — robust across vitest/node.
+  const repoRoot = process.cwd();
+  const cliBin = path.join(repoRoot, 'packages/cli/bin/xds.mjs');
+  const themeFile = path.join(repoRoot, 'packages/themes/default/src/defaultTheme.ts');
+
+  // Skip when the default theme source isn't present (e.g. partial checkout)
+  const canRun = fs.existsSync(themeFile) && fs.existsSync(cliBin);
+  const maybeIt = canRun ? it : it.skip;
+
+  maybeIt('produces CSS without prose selectors when --no-prose is passed', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'xds-no-prose-'));
+    try {
+      const outNoProse = path.join(tmpDir, 'no-prose.css');
+      const outWithProse = path.join(tmpDir, 'with-prose.css');
+      execSync(
+        `node ${cliBin} theme build ${themeFile} -o ${outNoProse} --no-prose`,
+        {stdio: 'pipe'},
+      );
+      execSync(
+        `node ${cliBin} theme build ${themeFile} -o ${outWithProse}`,
+        {stdio: 'pipe'},
+      );
+      const noProse = fs.readFileSync(outNoProse, 'utf-8');
+      const withProse = fs.readFileSync(outWithProse, 'utf-8');
+
+      // With prose: must contain :where(h1...) and an @layer reset
+      expect(withProse).toMatch(/:where\(h1, h2, h3/);
+      expect(withProse).toMatch(/@layer reset/);
+
+      // Without prose: must NOT contain those
+      expect(noProse).not.toMatch(/:where\(h1, h2, h3/);
+      expect(noProse).not.toMatch(/@layer reset/);
+
+      // No-prose output should be smaller
+      expect(noProse.length).toBeLessThan(withProse.length);
+    } finally {
+      fs.rmSync(tmpDir, {recursive: true, force: true});
+    }
+  }, 30000);
+});

--- a/packages/cli/src/commands/init.mjs
+++ b/packages/cli/src/commands/init.mjs
@@ -14,12 +14,10 @@
  */
 
 import * as p from '@clack/prompts';
-import * as path from 'node:path';
-import * as fs from 'node:fs';
-import {CLI_ROOT} from '../utils/paths.mjs';
 import {getRunPrefix} from '../utils/package-manager.mjs';
 import {installAgentDocs, removeAgentDocs} from './agent-docs.mjs';
 import {listTemplates} from './template.mjs';
+import {template as templateApi} from '../api/template.mjs';
 
 const VALID_FEATURES = ['agents', 'theme', 'template'];
 const run = getRunPrefix();
@@ -91,11 +89,16 @@ async function runTemplate(targetDir, {interactive = true, templateName} = {}) {
       return;
     }
 
-    const outputDir = path.resolve(targetDir, `./src/pages/${templateName}`);
-    const srcPath = path.join(CLI_ROOT, 'templates', 'pages', templateName, 'page.tsx');
-    fs.mkdirSync(outputDir, {recursive: true});
-    fs.copyFileSync(srcPath, path.join(outputDir, 'page.tsx'));
-    console.log(`✓ Template created at ${path.relative(targetDir, outputDir)}/page.tsx`);
+    const outputRel = `./src/pages/${templateName}`;
+    const result = await templateApi(templateName, {targetPath: outputRel, cwd: targetDir});
+    const outputPath = result.data.outputPath
+      || `${result.data.outputDir}/${result.data.fileName}`;
+    console.log(`✓ Template created at ${outputPath}`);
+    if (result.data.dependenciesAdded && result.data.dependenciesAdded.length > 0) {
+      console.log(`  Added to package.json: ${result.data.dependenciesAdded.join(', ')}`);
+    } else if (result.data.dependencies && result.data.dependencies.length > 0 && !result.data.packageJsonPath) {
+      console.log(`  This template needs: ${result.data.dependencies.join(', ')}`);
+    }
     return;
   }
 
@@ -123,13 +126,15 @@ async function runTemplate(targetDir, {interactive = true, templateName} = {}) {
     }),
   );
 
-  const outputDir = path.resolve(targetDir, targetPath);
-  const srcPath = path.join(CLI_ROOT, 'templates', 'pages', templateChoice, 'page.tsx');
-
-  fs.mkdirSync(outputDir, {recursive: true});
-  fs.copyFileSync(srcPath, path.join(outputDir, 'page.tsx'));
-
-  p.log.success(`Template created at ${path.relative(targetDir, outputDir)}/page.tsx`);
+  const result = await templateApi(templateChoice, {targetPath, cwd: targetDir});
+  const outputPath = result.data.outputPath
+    || `${result.data.outputDir}/${result.data.fileName}`;
+  p.log.success(`Template created at ${outputPath}`);
+  if (result.data.dependenciesAdded && result.data.dependenciesAdded.length > 0) {
+    p.log.info(`Added to package.json: ${result.data.dependenciesAdded.join(', ')}`);
+  } else if (result.data.dependencies && result.data.dependencies.length > 0 && !result.data.packageJsonPath) {
+    p.log.warning(`This template needs: ${result.data.dependencies.join(', ')}`);
+  }
 }
 
 // ─── Command ─────────────────────────────────────────────────────────────────

--- a/packages/cli/src/commands/template.mjs
+++ b/packages/cli/src/commands/template.mjs
@@ -83,7 +83,22 @@ export function registerTemplate(program) {
         }
 
         case 'template.copy': {
-          console.log(`\n✓ Copied template to ${result.data.outputDir}/${result.data.fileName}\n`);
+          const display = result.data.outputPath
+            || `${result.data.outputDir}/${result.data.fileName}`;
+          console.log(`\n✓ Copied template to ${display}`);
+          const {dependencies, dependenciesAdded, packageJsonPath} = result.data;
+          if (dependenciesAdded && dependenciesAdded.length > 0) {
+            console.log(
+              `\n  Added to ${packageJsonPath || 'package.json'}: ${dependenciesAdded.join(', ')}`,
+            );
+            console.log(`  Run your package manager's install command to fetch them.`);
+          } else if (dependencies && dependencies.length > 0 && !packageJsonPath) {
+            console.log(
+              `\n  This template needs: ${dependencies.join(', ')}`,
+            );
+            console.log(`  Add them to your package.json before importing.`);
+          }
+          console.log('');
           break;
         }
       }

--- a/packages/cli/src/commands/template.test.mjs
+++ b/packages/cli/src/commands/template.test.mjs
@@ -60,3 +60,98 @@ describe('listTemplates integration', () => {
     expect(Array.isArray(result)).toBe(true);
   });
 });
+
+describe('template api — file-path target', () => {
+  it('writes to a file path directly when target ends in .tsx', async () => {
+    const {template} = await import('../api/template.mjs');
+    const targetPath = './out.tsx';
+    const result = await template('blank', {targetPath, cwd: tmpDir});
+    expect(result.type).toBe('template.copy');
+    const expected = path.join(tmpDir, 'out.tsx');
+    expect(fs.existsSync(expected)).toBe(true);
+    expect(fs.statSync(expected).isFile()).toBe(true);
+    // Should NOT have created out.tsx/page.tsx
+    expect(fs.existsSync(path.join(expected, 'page.tsx'))).toBe(false);
+  });
+
+  it('still treats extension-less target as a directory', async () => {
+    const {template} = await import('../api/template.mjs');
+    const targetPath = './out-dir';
+    const result = await template('blank', {targetPath, cwd: tmpDir});
+    expect(result.type).toBe('template.copy');
+    const expected = path.join(tmpDir, 'out-dir', 'page.tsx');
+    expect(fs.existsSync(expected)).toBe(true);
+  });
+
+  it('writes into existing directory even if it has an extension-like name', async () => {
+    const {template} = await import('../api/template.mjs');
+    const dirPath = path.join(tmpDir, 'pre-existing.tsx');
+    fs.mkdirSync(dirPath, {recursive: true});
+    const result = await template('blank', {targetPath: './pre-existing.tsx', cwd: tmpDir});
+    expect(result.type).toBe('template.copy');
+    // Existing directory wins — page.tsx goes inside
+    expect(fs.existsSync(path.join(dirPath, 'page.tsx'))).toBe(true);
+  });
+});
+
+describe('template api — dependency installation', () => {
+  it('adds template-required deps to package.json when one exists', async () => {
+    const {template} = await import('../api/template.mjs');
+    const pkgPath = path.join(tmpDir, 'package.json');
+    fs.writeFileSync(pkgPath, JSON.stringify({
+      name: 'test-app',
+      dependencies: {react: '^18.0.0'},
+    }, null, 2));
+    const result = await template('dashboard', {targetPath: './page.tsx', cwd: tmpDir});
+    expect(result.type).toBe('template.copy');
+    expect(result.data.dependencies).toContain('@heroicons/react');
+    expect(result.data.dependenciesAdded).toContain('@heroicons/react');
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+    expect(pkg.dependencies['@heroicons/react']).toBeTruthy();
+  });
+
+  it('does not duplicate already-declared deps', async () => {
+    const {template} = await import('../api/template.mjs');
+    const pkgPath = path.join(tmpDir, 'package.json');
+    fs.writeFileSync(pkgPath, JSON.stringify({
+      name: 'test-app',
+      dependencies: {
+        react: '^18.0.0',
+        '@heroicons/react': '^2.0.0',
+      },
+    }, null, 2));
+    const result = await template('login', {targetPath: './page.tsx', cwd: tmpDir});
+    expect(result.data.dependenciesAdded).not.toContain('@heroicons/react');
+    expect(result.data.dependenciesSkipped).toContain('@heroicons/react');
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+    expect(pkg.dependencies['@heroicons/react']).toBe('^2.0.0');
+  });
+
+  it('reports dependencies even when no package.json exists', async () => {
+    const {template} = await import('../api/template.mjs');
+    const result = await template('login', {targetPath: './page.tsx', cwd: tmpDir});
+    expect(result.data.dependencies).toContain('@heroicons/react');
+    expect(result.data.packageJsonPath).toBeNull();
+    expect(result.data.dependenciesSkipped).toContain('@heroicons/react');
+  });
+});
+
+describe('template api — skeleton renderer', () => {
+  it('produces parseable JSX for templates with object-literal props', async () => {
+    const {template} = await import('../api/template.mjs');
+    const result = await template('dashboard', {skeleton: true});
+    expect(result.type).toBe('template.skeleton');
+    const skel = result.data.skeleton;
+    // No malformed Grid attrs
+    expect(skel).not.toMatch(/columns="\{minWidth:"/);
+    expect(skel).not.toMatch(/=\{\{[^}]*$/m);
+    // Object props should render as {{...}} or {{minWidth: N}} form
+    if (skel.includes('Grid columns')) {
+      expect(skel).toMatch(/columns=\{\{(\.\.\.|minWidth: \d+)/);
+    }
+    // Should not produce unbalanced quotes
+    const dquotes = (skel.match(/"/g) || []).length;
+    expect(dquotes % 2).toBe(0);
+  });
+});
+

--- a/packages/core/src/theme/defineTheme.ts
+++ b/packages/core/src/theme/defineTheme.ts
@@ -1026,10 +1026,15 @@ export interface ThemeRulesSplit {
  *
  * Component rules (tokens, .xds-* overrides) are intentional theme overrides
  * that need to beat StyleX — they stay in xds-theme (above StyleX layers).
+ *
+ * Pass `{prose: false}` to skip prose rules entirely. The returned `prose`
+ * array will be empty in that case.
  */
 export function generateThemeRulesSplit(
   theme: XDSDefinedTheme,
+  options: {prose?: boolean} = {},
 ): ThemeRulesSplit {
+  const {prose: includeProse = true} = options;
   const allRules = generateThemeRules(theme);
 
   const prose: string[] = [];
@@ -1037,7 +1042,7 @@ export function generateThemeRulesSplit(
 
   for (const rule of allRules) {
     if (rule.trimStart().startsWith(':where(')) {
-      prose.push(rule);
+      if (includeProse) {prose.push(rule);}
     } else {
       component.push(rule);
     }


### PR DESCRIPTION
## What

Four CLI bug fixes around `xds template` and `xds theme build`:

### `xds template <name>` now installs declared dependencies (HIGH-10)

Page templates like `dashboard` and `login` import packages that the CLI
never declares. Running `xds template dashboard ./pages/dashboard` left
projects with `Cannot find module '@heroicons/react/24/outline'`.

The template API now:

- Auto-detects npm imports from the template source (anything that isn't
  relative, `@xds/*`, `react`, or an asset import).
- Honors an explicit `dependencies: string[]` field in `template.doc.mjs`
  for cases where detection isn't enough.
- Adds missing entries to the user's `package.json` (range: `latest`)
  when one exists in `cwd`.
- Falls back to printing the required packages when no `package.json` is
  found.

The change flows through both `xds template <name> <path>` and the `xds
init --features template` wizard.

### `xds template <name> ./foo.tsx` writes a file, not a directory (HIGH-11)

Previously, `targetPath` was always treated as a directory, so:

```
$ xds template dashboard ./foo.tsx
✓ Copied template to foo.tsx/page.tsx     # ← surprise
```

Now: if the path has a `.tsx`/`.jsx`/`.ts`/`.js` extension and isn't an
existing directory, it's written directly. Existing-directory targets
keep the old behavior so `xds template foo ./mydir` still produces
`./mydir/page.tsx`.

### `xds theme build --no-prose` actually skips prose (HIGH-12)

The flag was plumbed through commander but never read. Two changes:

1. `packages/core/src/theme/defineTheme.ts`: `generateThemeRulesSplit`
   gained an optional `{prose?: boolean}` option. When `false`, the
   prose array comes back empty.
2. `packages/cli/src/commands/build-theme.mjs`: the action now reads
   `options.prose` (commander sets it to `false` for `--no-prose`),
   passes it through to core, and also drops the prose layer
   client-side as a belt-and-braces guarantee for older core builds.
   The legacy fallback path (when `@xds/core/theme` isn't built yet)
   also honors the flag.

Verified end-to-end: `xds theme build defaultTheme.ts --no-prose`
output contains no `:where(h1...)` selectors and no `@layer reset`
block, and is ~25% smaller than the prose-included version.

### `xds template <name> --skeleton` emits valid JSX (MED)

The skeleton renderer's prop regex collapsed when a template used object
literals like `<Grid columns={{minWidth: 320, repeat: 'fit'}} gap={4}>`
— it captured `{minWidth:` as the prop value and produced
`<Grid columns="{minWidth:" gap={4}>`. The extractor now walks balanced
braces and renders objects as `{{minWidth: N}}` (when a numeric
minWidth is found) or `{{...}}` otherwise.

## Why this matters

`xds init` is the first thing a user runs. Before this PR, picking the
`dashboard` or `login` template put the project into a broken state.
`--no-prose` is the documented escape hatch for themes that own their
own typography reset; silently ignoring it left those themes shipping
double resets. `--skeleton` is meant to be readable; emitting bad JSX
broke that contract for the dashboard/portfolio templates.

## Tests

- `packages/cli/src/commands/template.test.mjs`:
  - File-path target writes to the file directly.
  - Extension-less target still creates a directory.
  - Pre-existing directory wins over the file-path heuristic.
  - Dashboard template adds `@heroicons/react`/`recharts` to a
    `package.json` that doesn't already declare them.
  - Already-declared deps aren't bumped or duplicated.
  - Missing `package.json` surfaces the dep list in the result.
  - Dashboard skeleton produces parseable JSX (no `columns="{minWidth:"`,
    balanced quotes).

- `packages/cli/src/commands/build-theme.test.mjs` (new):
  - `generateThemeRulesSplit` honors `{prose: true|false}` and the
    default.
  - End-to-end: invokes the CLI on the real default theme, asserts the
    `--no-prose` output contains no `:where(h1, h2, h3)` and no
    `@layer reset`, and is smaller than the with-prose output.

`pnpm -F @xds/cli test` (601 tests) and `pnpm -w lint` both pass.

## Notes for reviewers

- I made a tiny change to `packages/core/src/theme/defineTheme.ts` to
  add the `{prose}` option to `generateThemeRulesSplit`. Existing
  callers (XDSTheme runtime, `generateThemeCSS`) keep the default,
  which is `prose: true` — behavior unchanged.
- `init.mjs` was refactored to call the template API instead of
  re-implementing the copy + (now) dependency logic. Less duplication,
  and the wizard now also installs deps.
