### PR TITLE
fix(cli): validate --lang, fix --detail level inversion, expose global flags in subcommand help

### DIFF
--- a/packages/cli/src/api/component.mjs
+++ b/packages/cli/src/api/component.mjs
@@ -61,11 +61,17 @@ export async function component(name, options = {}) {
     source = false,
     showcase = false,
     blocks = false,
-    detail = 'full',
+    detail: detailOption,
     lang = null,
     zh = false,
     dense = false,
   } = options;
+
+  // List views (no specific component) default to `brief` (just names) so
+  // `component --list` stays terse; single-component views default to `full`.
+  // This mirrors the CLI's default-detail handling so API and CLI stay in parity.
+  const isListMode = category || list || !name;
+  const detail = detailOption ?? (isListMode ? 'brief' : 'full');
 
   const coreDir = findCoreDir(cwd);
   if (!coreDir) {

--- a/packages/cli/src/api/component.mjs
+++ b/packages/cli/src/api/component.mjs
@@ -73,6 +73,11 @@ export async function component(name, options = {}) {
   }
 
   // ── List mode ──────────────────────────────────────────────────
+  //
+  // Detail levels (length: brief < compact < full):
+  //   brief   → just component names grouped by category (`component.list`)
+  //   compact → names + short description (`component.compact-list`)
+  //   full    → rich entries with description + import path (`component.detailed-list`)
 
   if (category || list || !name) {
     const components = discoverComponents(coreDir);
@@ -88,48 +93,58 @@ export async function component(name, options = {}) {
         );
       }
 
-      if (detail === 'brief') {
+      if (detail === 'compact' || detail === 'full') {
         const entries = [];
         for (const comp of match[1]) {
           const readme = findComponentReadme(coreDir, comp);
+          let description = '';
           if (readme && readme.endsWith('.doc.mjs')) {
             try {
               const docs = await loadDocs(readme, {zh, lang});
-              entries.push({name: comp, description: docs.usage?.description || docs.description || '', import: resolveImportPath(coreDir, comp)});
+              description = docs.usage?.description || docs.description || '';
             } catch {
-              entries.push({name: comp, description: '', import: resolveImportPath(coreDir, comp)});
+              // ignore — leave description blank
             }
+          }
+          if (detail === 'full') {
+            entries.push({name: comp, description, import: resolveImportPath(coreDir, comp)});
           } else {
-            entries.push({name: comp, description: '', import: resolveImportPath(coreDir, comp)});
+            entries.push({name: comp, description});
           }
         }
-        return {type: 'component.brief', data: {[match[0]]: entries}};
+        const type = detail === 'full' ? 'component.detailed-list' : 'component.compact-list';
+        return {type, data: {[match[0]]: entries}};
       }
 
       return {type: 'component.list', data: {[match[0]]: match[1]}};
     }
 
     // All components — merge core + external packages with grouped subcategories
-    if (detail === 'brief') {
-      /** @type {Record<string, Array<import('../types/component').ComponentBriefEntry>>} */
+    if (detail === 'compact' || detail === 'full') {
+      /** @type {Record<string, Array<{name: string, description: string, import?: string}>>} */
       const result = {};
       for (const [cat, comps] of Object.entries(components)) {
         result[cat] = [];
         for (const comp of comps) {
           const readme = findComponentReadme(coreDir, comp);
+          let description = '';
           if (readme && readme.endsWith('.doc.mjs')) {
             try {
               const docs = await loadDocs(readme, {zh, lang});
-              result[cat].push({name: comp, description: docs.usage?.description || docs.description || '', import: resolveImportPath(coreDir, comp)});
+              description = docs.usage?.description || docs.description || '';
             } catch {
-              result[cat].push({name: comp, description: '', import: resolveImportPath(coreDir, comp)});
+              // ignore
             }
+          }
+          if (detail === 'full') {
+            result[cat].push({name: comp, description, import: resolveImportPath(coreDir, comp)});
           } else {
-            result[cat].push({name: comp, description: '', import: resolveImportPath(coreDir, comp)});
+            result[cat].push({name: comp, description});
           }
         }
       }
-      return {type: 'component.brief', data: result};
+      const type = detail === 'full' ? 'component.detailed-list' : 'component.compact-list';
+      return {type, data: result};
     }
 
     const externals = discoverExternalPackages(cwd);

--- a/packages/cli/src/api/hook.mjs
+++ b/packages/cli/src/api/hook.mjs
@@ -42,6 +42,11 @@ export async function hook(name, options = {}) {
   }
 
   // ── List mode ──────────────────────────────────────────────────
+  //
+  // Detail levels (length: brief < compact < full):
+  //   brief   → just hook names grouped by category (`hook.list`)
+  //   compact → names + short description (`hook.compact-list`)
+  //   full    → rich entries with description + import path (`hook.detailed-list`)
 
   if (category || list || !name) {
     const hooks = discoverHooks(coreDir);
@@ -57,56 +62,62 @@ export async function hook(name, options = {}) {
         );
       }
 
-      if (detail === 'brief') {
+      if (detail === 'compact' || detail === 'full') {
         const entries = [];
         for (const hookName of match[1]) {
           const docPath = findHookDoc(coreDir, hookName);
+          let description = '';
+          let importPath = '@xds/core/hooks';
           if (docPath) {
             try {
               const docs = await loadDocs(docPath, {zh, lang});
-              entries.push({
-                name: hookName,
-                description: docs.usage?.description || '',
-                import: docs.importPath || '@xds/core/hooks',
-              });
+              description = docs.usage?.description || '';
+              importPath = docs.importPath || importPath;
             } catch {
-              entries.push({name: hookName, description: '', import: '@xds/core/hooks'});
+              // ignore
             }
+          }
+          if (detail === 'full') {
+            entries.push({name: hookName, description, import: importPath});
           } else {
-            entries.push({name: hookName, description: '', import: '@xds/core/hooks'});
+            entries.push({name: hookName, description});
           }
         }
-        return {type: 'hook.brief', data: {[match[0]]: entries}};
+        const type = detail === 'full' ? 'hook.detailed-list' : 'hook.compact-list';
+        return {type, data: {[match[0]]: entries}};
       }
 
       return {type: 'hook.list', data: {[match[0]]: match[1]}};
     }
 
     // All hooks
-    if (detail === 'brief') {
-      /** @type {Record<string, Array<{name: string, description: string, import: string}>>} */
+    if (detail === 'compact' || detail === 'full') {
+      /** @type {Record<string, Array<{name: string, description: string, import?: string}>>} */
       const result = {};
       for (const [cat, hookNames] of Object.entries(hooks)) {
         result[cat] = [];
         for (const hookName of hookNames) {
           const docPath = findHookDoc(coreDir, hookName);
+          let description = '';
+          let importPath = '@xds/core/hooks';
           if (docPath) {
             try {
               const docs = await loadDocs(docPath, {zh, lang});
-              result[cat].push({
-                name: hookName,
-                description: docs.usage?.description || '',
-                import: docs.importPath || '@xds/core/hooks',
-              });
+              description = docs.usage?.description || '';
+              importPath = docs.importPath || importPath;
             } catch {
-              result[cat].push({name: hookName, description: '', import: '@xds/core/hooks'});
+              // ignore
             }
+          }
+          if (detail === 'full') {
+            result[cat].push({name: hookName, description, import: importPath});
           } else {
-            result[cat].push({name: hookName, description: '', import: '@xds/core/hooks'});
+            result[cat].push({name: hookName, description});
           }
         }
       }
-      return {type: 'hook.brief', data: result};
+      const type = detail === 'full' ? 'hook.detailed-list' : 'hook.compact-list';
+      return {type, data: result};
     }
 
     return {type: 'hook.list', data: hooks};

--- a/packages/cli/src/commands/build-theme.mjs
+++ b/packages/cli/src/commands/build-theme.mjs
@@ -19,6 +19,7 @@ import {pathToFileURL, fileURLToPath} from 'node:url';
 import {createJiti} from 'jiti';
 import {getRunPrefix} from '../utils/package-manager.mjs';
 import {jsonOut, jsonError} from '../lib/json.mjs';
+import {addCommonHelp} from '../utils/help.mjs';
 
 // Import shared theme processing from core — ensures build and runtime
 // use the same logic for typography.scale expansion, prose, and component rules.
@@ -975,7 +976,7 @@ export function registerTheme(program) {
     .command('theme')
     .description('Theme tools — build, export, and manage XDS themes');
 
-  theme
+  const buildCmd = theme
     .command('build <file>')
     .description('Compile a defineTheme file to CSS + JS')
     .option('-o, --out <path>', 'Output CSS file path')
@@ -1208,4 +1209,13 @@ Or with a <link> tag:
         console.log('');
       }
     });
+
+  const buildExamples = [
+    'xds theme build ./src/themes/ocean.ts            Compile a theme to CSS + JS',
+    'xds theme build ./themes/ocean.ts -o out.css     Write CSS to a specific path',
+    'xds theme build ./themes/ocean.ts --no-prose     Skip prose (h1, p, code) mappings',
+    'xds theme build ./themes/ocean.ts --json         Structured JSON output for scripting',
+  ];
+  addCommonHelp(theme, buildExamples);
+  addCommonHelp(buildCmd, buildExamples);
 }

--- a/packages/cli/src/commands/cli-flags.test.mjs
+++ b/packages/cli/src/commands/cli-flags.test.mjs
@@ -1,0 +1,153 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file End-to-end tests for global CLI flags (--version --json,
+ * --lang validation, --detail level ordering, subcommand --help).
+ */
+
+import {describe, it, expect} from 'vitest';
+import {spawnSync} from 'node:child_process';
+import * as path from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const BIN = path.resolve(__dirname, '../../bin/xds.mjs');
+
+function runCli(args) {
+  const r = spawnSync(process.execPath, [BIN, ...args], {
+    encoding: 'utf-8',
+  });
+  return {
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+    status: r.status ?? 0,
+  };
+}
+
+describe('--version --json', () => {
+  it('returns plain text by default', () => {
+    const {stdout} = runCli(['--version']);
+    expect(stdout.trim()).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  it('returns a typed JSON envelope when --json is set', () => {
+    const {stdout} = runCli(['--version', '--json']);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.type).toBe('version');
+    expect(parsed.data).toBeDefined();
+    expect(parsed.data.version).toMatch(/^\d+\.\d+\.\d+/);
+  });
+});
+
+describe('--lang validation', () => {
+  it('rejects unsupported locale with exit 1 and a clear message', () => {
+    const {stdout, stderr, status} = runCli(['--lang', 'fr', 'component', 'XDSButton']);
+    expect(status).toBe(1);
+    expect(stderr).toMatch(/Unsupported language "fr"/);
+    expect(stderr).toMatch(/Supported: en, zh, dense/);
+  });
+
+  it('accepts --lang en silently', () => {
+    const {status, stderr} = runCli(['--lang', 'en', 'component', 'XDSButton']);
+    expect(status).toBe(0);
+    expect(stderr).not.toMatch(/Unsupported|incomplete/);
+  });
+
+  it('warns when --lang zh is requested (translations incomplete)', () => {
+    const {status, stderr} = runCli(['--lang', 'zh', 'component', 'XDSButton']);
+    expect(status).toBe(0);
+    expect(stderr).toMatch(/translations are incomplete/i);
+  });
+
+  it('rejects --lang fr with --json (JSON error envelope)', () => {
+    const {stdout, status} = runCli(['--lang', 'fr', '--json', 'component', 'XDSButton']);
+    expect(status).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.error).toMatch(/Unsupported language "fr"/);
+  });
+
+  it('rejects combining --lang and --zh', () => {
+    const {stderr, status} = runCli(['--lang', 'zh', '--zh', 'component', 'XDSButton']);
+    expect(status).toBe(1);
+    expect(stderr).toMatch(/Cannot combine --lang/);
+  });
+});
+
+describe('--detail level ordering on list views', () => {
+  it('component --list: brief < compact < full (in bytes)', () => {
+    const brief = runCli(['component', '--list', '--detail', 'brief']).stdout;
+    const compact = runCli(['component', '--list', '--detail', 'compact']).stdout;
+    const full = runCli(['component', '--list', '--detail', 'full']).stdout;
+
+    expect(brief.length).toBeLessThan(compact.length);
+    expect(compact.length).toBeLessThan(full.length);
+  });
+
+  it('component --list: brief, compact, full produce DIFFERENT output', () => {
+    const brief = runCli(['component', '--list', '--detail', 'brief']).stdout;
+    const compact = runCli(['component', '--list', '--detail', 'compact']).stdout;
+    const full = runCli(['component', '--list', '--detail', 'full']).stdout;
+
+    expect(brief).not.toEqual(compact);
+    expect(compact).not.toEqual(full);
+    expect(brief).not.toEqual(full);
+  });
+
+  it('hook --list: brief < compact < full (in bytes)', () => {
+    const brief = runCli(['hook', '--list', '--detail', 'brief']).stdout;
+    const compact = runCli(['hook', '--list', '--detail', 'compact']).stdout;
+    const full = runCli(['hook', '--list', '--detail', 'full']).stdout;
+
+    expect(brief.length).toBeLessThan(compact.length);
+    expect(compact.length).toBeLessThan(full.length);
+  });
+
+  it('hook --list: brief, compact, full produce DIFFERENT output', () => {
+    const brief = runCli(['hook', '--list', '--detail', 'brief']).stdout;
+    const compact = runCli(['hook', '--list', '--detail', 'compact']).stdout;
+    const full = runCli(['hook', '--list', '--detail', 'full']).stdout;
+
+    expect(brief).not.toEqual(compact);
+    expect(compact).not.toEqual(full);
+    expect(brief).not.toEqual(full);
+  });
+
+  it('JSON envelope types differ by detail level on list views', () => {
+    const brief = JSON.parse(runCli(['--json', 'component', '--list', '--detail', 'brief']).stdout);
+    const compact = JSON.parse(runCli(['--json', 'component', '--list', '--detail', 'compact']).stdout);
+    const full = JSON.parse(runCli(['--json', 'component', '--list', '--detail', 'full']).stdout);
+
+    expect(brief.type).toBe('component.list');
+    expect(compact.type).toBe('component.compact-list');
+    expect(full.type).toBe('component.detailed-list');
+  });
+});
+
+describe('subcommand --help shows global flags + Examples', () => {
+  it('component --help mentions --json, --lang, --detail', () => {
+    const {stdout} = runCli(['component', '--help']);
+    expect(stdout).toMatch(/--json/);
+    expect(stdout).toMatch(/--lang/);
+    expect(stdout).toMatch(/--detail/);
+  });
+
+  it('component --help has an Examples section', () => {
+    const {stdout} = runCli(['component', '--help']);
+    expect(stdout).toMatch(/Examples:/);
+  });
+
+  it('hook --help mentions --json, --lang, --detail and Examples', () => {
+    const {stdout} = runCli(['hook', '--help']);
+    expect(stdout).toMatch(/--json/);
+    expect(stdout).toMatch(/--lang/);
+    expect(stdout).toMatch(/--detail/);
+    expect(stdout).toMatch(/Examples:/);
+  });
+
+  it('docs --help mentions global flags and Examples', () => {
+    const {stdout} = runCli(['docs', '--help']);
+    expect(stdout).toMatch(/--json/);
+    expect(stdout).toMatch(/--lang/);
+    expect(stdout).toMatch(/Examples:/);
+  });
+});

--- a/packages/cli/src/commands/cli-flags.test.mjs
+++ b/packages/cli/src/commands/cli-flags.test.mjs
@@ -182,4 +182,20 @@ describe('subcommand --help shows global flags + Examples', () => {
     expect(stdout).toMatch(/--detail/);
     expect(stdout).toMatch(/Examples:/);
   });
+
+  it('gap-report --help mentions global flags and Examples', () => {
+    const {stdout} = runCli(['gap-report', '--help']);
+    expect(stdout).toMatch(/--json/);
+    expect(stdout).toMatch(/--lang/);
+    expect(stdout).toMatch(/--detail/);
+    expect(stdout).toMatch(/Examples:/);
+  });
+
+  it('gap-report setup --help mentions global flags and Examples', () => {
+    const {stdout} = runCli(['gap-report', 'setup', '--help']);
+    expect(stdout).toMatch(/--json/);
+    expect(stdout).toMatch(/--lang/);
+    expect(stdout).toMatch(/--detail/);
+    expect(stdout).toMatch(/Examples:/);
+  });
 });

--- a/packages/cli/src/commands/cli-flags.test.mjs
+++ b/packages/cli/src/commands/cli-flags.test.mjs
@@ -150,4 +150,36 @@ describe('subcommand --help shows global flags + Examples', () => {
     expect(stdout).toMatch(/--lang/);
     expect(stdout).toMatch(/Examples:/);
   });
+
+  it('template --help mentions global flags and Examples', () => {
+    const {stdout} = runCli(['template', '--help']);
+    expect(stdout).toMatch(/--json/);
+    expect(stdout).toMatch(/--lang/);
+    expect(stdout).toMatch(/--detail/);
+    expect(stdout).toMatch(/Examples:/);
+  });
+
+  it('template get --help mentions global flags and Examples', () => {
+    const {stdout} = runCli(['template', 'get', '--help']);
+    expect(stdout).toMatch(/--json/);
+    expect(stdout).toMatch(/--lang/);
+    expect(stdout).toMatch(/--detail/);
+    expect(stdout).toMatch(/Examples:/);
+  });
+
+  it('theme --help mentions global flags and Examples', () => {
+    const {stdout} = runCli(['theme', '--help']);
+    expect(stdout).toMatch(/--json/);
+    expect(stdout).toMatch(/--lang/);
+    expect(stdout).toMatch(/--detail/);
+    expect(stdout).toMatch(/Examples:/);
+  });
+
+  it('theme build --help mentions global flags and Examples', () => {
+    const {stdout} = runCli(['theme', 'build', '--help']);
+    expect(stdout).toMatch(/--json/);
+    expect(stdout).toMatch(/--lang/);
+    expect(stdout).toMatch(/--detail/);
+    expect(stdout).toMatch(/Examples:/);
+  });
 });

--- a/packages/cli/src/commands/component/index.mjs
+++ b/packages/cli/src/commands/component/index.mjs
@@ -24,11 +24,13 @@ import {
 import {resolveTheme} from '../../lib/resolve-theme.mjs';
 import {getRunPrefix} from '../../utils/package-manager.mjs';
 import {jsonOut, jsonError} from '../../lib/json.mjs';
+import {validateLang} from '../../lib/lang.mjs';
+import {addCommonHelp} from '../../utils/help.mjs';
 import {component as componentApi} from '../../api/component.mjs';
 import {findRelatedBlocks} from '../../api/template.mjs';
 
 export function registerComponent(program) {
-  program
+  const cmd = program
     .command('component [name]')
     .description('List components or print component docs')
     .option('--list', 'List all components grouped by category')
@@ -42,9 +44,20 @@ export function registerComponent(program) {
       const run = getRunPrefix();
       const zh = program.opts().zh || false;
       const dense = program.opts().dense || false;
-      const lang = program.opts().lang || null;
-      const detail = program.opts().detail || 'full';
+      // For list views, default to `brief` (just names) when the user didn't
+      // explicitly pass --detail. This keeps `xds component` and
+      // `xds component --list` short by default while still letting agents
+      // ask for more with `--detail compact` or `--detail full`.
+      const detailSource = program.getOptionValueSource('detail');
+      const isListMode = options.list || options.category || !name;
+      const detail = (isListMode && detailSource === 'default')
+        ? 'brief'
+        : (program.opts().detail || 'full');
       const json = program.opts().json || false;
+      const {lang} = validateLang({
+        lang: program.opts().lang,
+        zh, dense, json,
+      });
 
       const validDetails = ['full', 'compact', 'brief'];
       if (!validDetails.includes(detail)) {
@@ -111,14 +124,26 @@ export function registerComponent(program) {
           break;
         }
 
-        case 'component.brief': {
-          if (options.category || options.list || !name) {
-            console.log(await formatBriefAll(coreDir, {zh, lang, themeData}));
-          } else {
-            const resolvedName = (name || '').replace(/^XDS/, '');
-            const importHint = resolveImportPath(coreDir, resolvedName);
-            console.log(formatBrief(result.data, resolvedName, importHint, {themeData}));
+        case 'component.compact-list': {
+          console.log('');
+          for (const [cat, entries] of Object.entries(result.data)) {
+            console.log(cat);
+            for (const e of entries) {
+              const desc = e.description
+                ? (e.description.length > 80 ? e.description.slice(0, 77) + '...' : e.description)
+                : '';
+              console.log(desc ? `  ${e.name} — ${desc}` : `  ${e.name}`);
+            }
           }
+          console.log('');
+          console.log(`Usage: ${run} xds component <name>`);
+          console.log('');
+          break;
+        }
+
+        case 'component.detailed-list': {
+          // Full list view: per-component brief docs (signature, vars, examples).
+          console.log(await formatBriefAll(coreDir, {zh, lang, themeData}));
           break;
         }
 
@@ -190,6 +215,15 @@ export function registerComponent(program) {
         }
       }
     });
+
+  addCommonHelp(cmd, [
+    'xds component                          List all components',
+    'xds component --list --detail compact  Names + short descriptions',
+    'xds component Button                   Print full Button docs',
+    'xds component Button --props           Print only the props table',
+    'xds component Button --json            JSON output for scripting',
+    'xds component --category Form          List Form components',
+  ]);
 }
 
 

--- a/packages/cli/src/commands/discover.mjs
+++ b/packages/cli/src/commands/discover.mjs
@@ -15,17 +15,22 @@ import {scanAllPackages} from '../lib/package-scanner.mjs';
 import {formatFull, formatBrief, formatCompact} from '../lib/component-format.mjs';
 import {jsonOut, jsonError} from '../lib/json.mjs';
 import {discover as discoverApi} from '../api/discover.mjs';
+import {addCommonHelp} from '../utils/help.mjs';
+import {validateLang} from '../lib/lang.mjs';
 
 export function registerDiscover(program) {
-  program
+  const cmd = program
     .command('discover [query]')
     .description('Discover external XDS packages and components')
     .option('--components', 'List components only')
     .action(async (query, options) => {
       const detail = program.opts().detail || 'full';
       const json = program.opts().json || false;
-      const lang = program.opts().lang || null;
       const zh = program.opts().zh || false;
+      const {lang} = validateLang({
+        lang: program.opts().lang,
+        zh, dense: program.opts().dense || false, json,
+      });
 
       let result;
       try {
@@ -142,4 +147,11 @@ export function registerDiscover(program) {
         }
       }
     });
+
+  addCommonHelp(cmd, [
+    'xds discover                          List all installed XDS packages',
+    'xds discover --components             List all components across packages',
+    'xds discover button                   Search for components matching "button"',
+    'xds discover --json                   JSON output for scripting',
+  ]);
 }

--- a/packages/cli/src/commands/docs.mjs
+++ b/packages/cli/src/commands/docs.mjs
@@ -14,6 +14,8 @@
 
 import {getRunPrefix} from '../utils/package-manager.mjs';
 import {jsonOut, jsonError} from '../lib/json.mjs';
+import {validateLang} from '../lib/lang.mjs';
+import {addCommonHelp} from '../utils/help.mjs';
 import {docs as docsApi} from '../api/docs.mjs';
 
 // ─── Formatting ──────────────────────────────────────────────────────────────
@@ -98,16 +100,19 @@ function formatReferenceFull(docs, detail) {
 // ─── Command ─────────────────────────────────────────────────────────────────
 
 export function registerDocs(program) {
-  program
+  const cmd = program
     .command('docs [topic] [section]')
     .description('Print XDS reference docs')
     .action(async (topic, section) => {
       const run = getRunPrefix();
-      const lang = program.opts().lang || null;
       const zh = program.opts().zh || false;
       const dense = program.opts().dense || false;
       const detail = program.opts().detail || 'full';
       const json = program.opts().json || false;
+      const {lang} = validateLang({
+        lang: program.opts().lang,
+        zh, dense, json,
+      });
 
       let result;
       try {
@@ -145,4 +150,11 @@ export function registerDocs(program) {
         }
       }
     });
+
+  addCommonHelp(cmd, [
+    'xds docs                       List available reference topics',
+    'xds docs theming               Print the theming reference',
+    'xds docs theming variables     Print just the variables section',
+    'xds docs --json                JSON output for scripting',
+  ]);
 }

--- a/packages/cli/src/commands/gap-report.mjs
+++ b/packages/cli/src/commands/gap-report.mjs
@@ -20,6 +20,7 @@ import {
 } from '../utils/github.mjs';
 import {getRunPrefix} from '../utils/package-manager.mjs';
 import {jsonOut, jsonError} from '../lib/json.mjs';
+import {addCommonHelp} from '../utils/help.mjs';
 
 function isCancel(value) {
   if (p.isCancel(value)) {
@@ -75,7 +76,7 @@ export function registerGapReport(program) {
     .description('Report a gap in the XDS design system');
 
   // --- setup subcommand ---
-  gapCmd
+  const setupCmd = gapCmd
     .command('setup')
     .description('Configure where gap reports are sent')
     .action(async () => {
@@ -309,4 +310,15 @@ export function registerGapReport(program) {
 
       p.outro('Thanks for the feedback!');
     });
+
+  addCommonHelp(gapCmd, [
+    'xds gap-report                                     Interactively report a gap',
+    'xds gap-report --component XDSButton --reason "…"  Report a gap non-interactively',
+    'xds gap-report --list-categories                   List valid gap categories',
+    'xds gap-report setup                               Configure where gap reports are sent',
+    'xds gap-report --json                              Structured JSON output for scripting',
+  ]);
+  addCommonHelp(setupCmd, [
+    'xds gap-report setup            Configure gap-report delivery (GitHub / custom / off)',
+  ]);
 }

--- a/packages/cli/src/commands/hook/index.mjs
+++ b/packages/cli/src/commands/hook/index.mjs
@@ -18,11 +18,13 @@ import {
 } from '../../lib/hook-format.mjs';
 import {getRunPrefix} from '../../utils/package-manager.mjs';
 import {jsonOut, jsonError} from '../../lib/json.mjs';
+import {validateLang} from '../../lib/lang.mjs';
+import {addCommonHelp} from '../../utils/help.mjs';
 import {hook as hookApi} from '../../api/hook.mjs';
 import {findRelatedBlocks} from '../../api/template.mjs';
 
 export function registerHook(program) {
-  program
+  const cmd = program
     .command('hook [name]')
     .description('List hooks or print hook docs')
     .option('--list', 'List all hooks grouped by category')
@@ -31,9 +33,18 @@ export function registerHook(program) {
     .action(async (name, options) => {
       const run = getRunPrefix();
       const zh = program.opts().zh || false;
-      const lang = program.opts().lang || null;
-      const detail = program.opts().detail || 'full';
+      // For list views, default to `brief` (just names) when the user didn't
+      // explicitly pass --detail. Single-hook views still default to `full`.
+      const detailSource = program.getOptionValueSource('detail');
+      const isListMode = options.list || options.category || !name;
+      const detail = (isListMode && detailSource === 'default')
+        ? 'brief'
+        : (program.opts().detail || 'full');
       const json = program.opts().json || false;
+      const {lang} = validateLang({
+        lang: program.opts().lang,
+        zh, dense: false, json,
+      });
 
       const validDetails = ['full', 'compact', 'brief'];
       if (!validDetails.includes(detail)) {
@@ -90,12 +101,26 @@ export function registerHook(program) {
           break;
         }
 
-        case 'hook.brief': {
-          if (options.category || options.list || !name) {
-            console.log(await formatHookBriefAll(coreDir));
-          } else {
-            console.log(formatHookBrief(result.data));
+        case 'hook.compact-list': {
+          console.log('');
+          for (const [cat, entries] of Object.entries(result.data)) {
+            console.log(cat);
+            for (const e of entries) {
+              const desc = e.description
+                ? (e.description.length > 80 ? e.description.slice(0, 77) + '...' : e.description)
+                : '';
+              console.log(desc ? `  ${e.name} — ${desc}` : `  ${e.name}`);
+            }
           }
+          console.log('');
+          console.log(`Usage: ${run} xds hook <name>`);
+          console.log('');
+          break;
+        }
+
+        case 'hook.detailed-list': {
+          // Full list view: per-hook brief docs (signature, params, examples).
+          console.log(await formatHookBriefAll(coreDir));
           break;
         }
 
@@ -136,6 +161,14 @@ export function registerHook(program) {
         }
       }
     });
+
+  addCommonHelp(cmd, [
+    'xds hook                              List all hooks',
+    'xds hook --list --detail compact      Names + short descriptions',
+    'xds hook useFocusTrap                 Print full useFocusTrap docs',
+    'xds hook useFocusTrap --params        Print only the parameters table',
+    'xds hook useFocusTrap --json          JSON output for scripting',
+  ]);
 }
 
 // Re-export lib functions for external consumers

--- a/packages/cli/src/commands/init.mjs
+++ b/packages/cli/src/commands/init.mjs
@@ -18,6 +18,7 @@ import * as path from 'node:path';
 import * as fs from 'node:fs';
 import {CLI_ROOT} from '../utils/paths.mjs';
 import {getRunPrefix} from '../utils/package-manager.mjs';
+import {addCommonHelp} from '../utils/help.mjs';
 import {installAgentDocs, removeAgentDocs} from './agent-docs.mjs';
 import {listTemplates} from './template.mjs';
 
@@ -135,7 +136,7 @@ async function runTemplate(targetDir, {interactive = true, templateName} = {}) {
 // ─── Command ─────────────────────────────────────────────────────────────────
 
 export function registerInit(program) {
-  program
+  const cmd = program
     .command('init')
     .description('Initialize XDS in your project')
     .option('--features <list>', 'Comma-separated features to install (agents, theme, template)')
@@ -225,4 +226,11 @@ export function registerInit(program) {
       console.log(`    3. ${run} xds --help for all commands`);
       console.log('');
     });
+
+  addCommonHelp(cmd, [
+    'xds init                          Interactive setup',
+    'xds init --all                    Install all features, no prompts',
+    'xds init --features agents        Just install AI agent docs',
+    'xds init --remove-agents          Remove AI agent docs',
+  ]);
 }

--- a/packages/cli/src/commands/swizzle.mjs
+++ b/packages/cli/src/commands/swizzle.mjs
@@ -16,6 +16,7 @@ import * as path from 'node:path';
 import * as p from '@clack/prompts';
 import {findCoreDir, listComponents} from '../utils/paths.mjs';
 import {jsonOut, jsonError} from '../lib/json.mjs';
+import {addCommonHelp} from '../utils/help.mjs';
 import {
   checkGhCli,
   createGapReport,
@@ -56,7 +57,7 @@ function isCancel(value) {
 }
 
 export function registerSwizzle(program) {
-  program
+  const cmd = program
     .command('swizzle [component]')
     .description('Copy component source for customization')
     .option('--output <dir>', 'Output directory', './components/xds')
@@ -228,4 +229,10 @@ export function registerSwizzle(program) {
         console.error(`Warning: Could not file gap report: ${err.message}`);
       }
     });
+
+  addCommonHelp(cmd, [
+    'xds swizzle --list                List available components to swizzle',
+    'xds swizzle XDSButton             Copy Button source into ./components/xds',
+    'xds swizzle XDSButton --output ./src/ui',
+  ]);
 }

--- a/packages/cli/src/commands/template.mjs
+++ b/packages/cli/src/commands/template.mjs
@@ -8,6 +8,7 @@ import * as path from 'node:path';
 import {CLI_ROOT} from '../utils/paths.mjs';
 import {jsonOut, jsonError} from '../lib/json.mjs';
 import {template as templateApi, getTemplateById} from '../api/template.mjs';
+import {addCommonHelp} from '../utils/help.mjs';
 
 export {discoverTemplates, listTemplates, getTemplateById} from '../api/template.mjs';
 
@@ -89,7 +90,7 @@ export function registerTemplate(program) {
       }
     });
 
-  templateCmd
+  const getCmd = templateCmd
     .command('get')
     .description('Fetch a template by ID via the xds.config.mjs hook')
     .requiredOption('--id <id>', 'Template identifier to fetch')
@@ -109,4 +110,16 @@ export function registerTemplate(program) {
 
       console.log(result.data.source);
     });
+
+  addCommonHelp(templateCmd, [
+    'xds template                          List available templates',
+    'xds template dashboard ./src/app      Inject the "dashboard" template at a path',
+    'xds template --list --type block      List only block templates',
+    'xds template --skeleton               Show layout skeleton with spatial annotations',
+    'xds template --json                   Structured JSON output for scripting',
+  ]);
+  addCommonHelp(getCmd, [
+    'xds template get --id hero            Fetch a template by ID via xds.config.mjs',
+    'xds template get --id hero --json     Structured JSON output for scripting',
+  ]);
 }

--- a/packages/cli/src/commands/upgrade.mjs
+++ b/packages/cli/src/commands/upgrade.mjs
@@ -37,6 +37,7 @@ import {
 } from '../codemods/registry.mjs';
 import {runCodemods} from '../codemods/runner.mjs';
 import {installAgentDocs, discoverAgentDocs} from './agent-docs.mjs';
+import {addCommonHelp} from '../utils/help.mjs';
 import {detectPackageManager, getRunPrefix} from '../utils/package-manager.mjs';
 import {jsonOut, jsonError} from '../lib/json.mjs';
 
@@ -136,7 +137,7 @@ async function listCodemods() {
 }
 
 export function registerUpgrade(program) {
-  program
+  const cmd = program
     .command('upgrade')
     .description('Run codemods to migrate between XDS versions')
     .option('--apply', 'Write changes to disk (default: dry-run)', false)
@@ -321,4 +322,11 @@ export function registerUpgrade(program) {
       if (json) return jsonOut('upgrade.run', receipt);
       p.outro(options.apply ? 'Upgrade complete' : 'Dry run complete');
     });
+
+  addCommonHelp(cmd, [
+    'xds upgrade --list                 List available codemods',
+    'xds upgrade                        Dry-run upgrade to latest',
+    'xds upgrade --apply                Apply codemods + bump deps',
+    'xds upgrade --to 0.0.15 --apply    Upgrade to a specific version',
+  ]);
 }

--- a/packages/cli/src/index.mjs
+++ b/packages/cli/src/index.mjs
@@ -35,6 +35,19 @@ program
     program.help();
   });
 
+// `--version --json` should emit a JSON envelope instead of plain text.
+// Commander handles --version by exiting before any subcommand action runs,
+// so we have to intercept argv before parsing.
+if (process.argv.includes('--version') || process.argv.includes('-V')) {
+  if (process.argv.includes('--json')) {
+    console.log(JSON.stringify({
+      type: 'version',
+      data: {version: pkg.version},
+    }, null, 2));
+    process.exit(0);
+  }
+}
+
 /**
  * Fallback hook: if --json was requested but the command didn't call
  * jsonOut/jsonError, return a structured "not supported" error.

--- a/packages/cli/src/lib/hook-format.mjs
+++ b/packages/cli/src/lib/hook-format.mjs
@@ -85,6 +85,13 @@ export function formatHookFull(docs) {
   const desc = docs.usage?.description || '';
   if (desc) sections.push(desc + '\n');
 
+  // Import block (compact has it; full should be a superset)
+  const imp = docs.importPath;
+  if (imp) {
+    sections.push('## Import\n');
+    sections.push(`\`\`\`tsx\nimport { ${docs.name} } from '${imp}';\n\`\`\`\n`);
+  }
+
   // Best Practices (same position as component format)
   if (docs.usage?.bestPractices?.length) {
     sections.push('## Best Practices\n');
@@ -105,6 +112,32 @@ export function formatHookFull(docs) {
   if (docs.returns?.length) {
     sections.push('## Returns\n');
     sections.push(formatReturnsTable(docs.returns) + '\n');
+  }
+
+  // Examples (full should include examples; compact and brief skip them)
+  if (docs.examples?.length) {
+    sections.push('## Examples\n');
+    for (const ex of docs.examples) {
+      if (ex.title) sections.push(`### ${ex.title}\n`);
+      if (ex.description) sections.push(ex.description + '\n');
+      if (ex.code) {
+        sections.push('```tsx\n' + ex.code.trimEnd() + '\n```\n');
+      }
+    }
+  }
+
+  // Related (compact has it; full should too)
+  const relatedParts = [];
+  if (docs.relatedComponents?.length) {
+    relatedParts.push(`Components: ${docs.relatedComponents.join(', ')}`);
+  }
+  if (docs.relatedHooks?.length) {
+    relatedParts.push(`Hooks: ${docs.relatedHooks.join(', ')}`);
+  }
+  if (relatedParts.length) {
+    sections.push('## Related\n');
+    for (const part of relatedParts) sections.push(part);
+    sections.push('');
   }
 
   return sections.join('\n');

--- a/packages/cli/src/lib/lang.mjs
+++ b/packages/cli/src/lib/lang.mjs
@@ -1,0 +1,78 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Lang validation and warnings
+ *
+ * Validates --lang values, warns when translations are incomplete,
+ * and centralizes the supported locale list so commands stay in sync.
+ */
+
+import {jsonError} from './json.mjs';
+
+/**
+ * Locales the CLI claims to support. Keep this list in sync with
+ * the `--lang` description in src/index.mjs.
+ */
+export const SUPPORTED_LANGS = ['en', 'zh', 'dense'];
+
+/**
+ * Locales whose translation coverage is incomplete. When the user
+ * passes one of these, we still attempt the translation (props/labels
+ * are typically translated) but warn that some prose may fall back
+ * to English.
+ */
+export const PARTIAL_LANGS = new Set(['zh']);
+
+/**
+ * Validate the global lang options. Exits the process on invalid
+ * input (or returns a JSON error if --json is set). Emits a stderr
+ * warning when a partially-translated locale is requested.
+ *
+ * @param {{lang?: string|null, zh?: boolean, dense?: boolean, json?: boolean}} opts
+ * @returns {{lang: string|null}} normalized lang for downstream callers.
+ */
+export function validateLang(opts) {
+  const {lang, zh, dense, json} = opts;
+
+  // --zh and --dense are legacy shortcuts. They cannot be combined
+  // with --lang (the result would be ambiguous).
+  if (lang && (zh || dense)) {
+    const msg = `Cannot combine --lang with legacy --zh or --dense flags.`;
+    if (json) {
+      jsonError(msg);
+      // jsonError exits, but be defensive.
+      return {lang: null};
+    }
+    console.error(`Error: ${msg}`);
+    process.exit(1);
+  }
+
+  // Resolve the effective locale. --lang wins; otherwise fall back
+  // to the legacy shortcuts.
+  const effective = lang || (dense ? 'dense' : zh ? 'zh' : null);
+  if (!effective) return {lang: null};
+
+  if (!SUPPORTED_LANGS.includes(effective)) {
+    const msg = `Unsupported language "${effective}". Supported: ${SUPPORTED_LANGS.join(', ')}.`;
+    if (json) {
+      jsonError(msg);
+      return {lang: null};
+    }
+    console.error(`Error: ${msg}`);
+    process.exit(1);
+  }
+
+  if (PARTIAL_LANGS.has(effective)) {
+    // Warn once per process — multiple commands in tests etc. shouldn't
+    // each retrigger the warning.
+    if (!process.__xdsLangWarned) {
+      process.__xdsLangWarned = true;
+      console.error(
+        `Warning: --lang ${effective} translations are incomplete. ` +
+        `Some prose will fall back to English.`,
+      );
+    }
+  }
+
+  return {lang: effective};
+}

--- a/packages/cli/src/lib/lang.test.mjs
+++ b/packages/cli/src/lib/lang.test.mjs
@@ -1,0 +1,80 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
+import {validateLang, SUPPORTED_LANGS} from './lang.mjs';
+
+describe('validateLang', () => {
+  let exitSpy;
+  let errSpy;
+
+  beforeEach(() => {
+    delete process.__xdsLangWarned;
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit-called');
+    });
+    errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+    errSpy.mockRestore();
+  });
+
+  it('returns lang: null when no flag is passed', () => {
+    expect(validateLang({})).toEqual({lang: null});
+  });
+
+  it('accepts the supported locales', () => {
+    expect(validateLang({lang: 'en'})).toEqual({lang: 'en'});
+    expect(validateLang({lang: 'dense'})).toEqual({lang: 'dense'});
+  });
+
+  it('rejects unsupported locales with exit(1)', () => {
+    expect(() => validateLang({lang: 'fr'})).toThrow('exit-called');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(errSpy.mock.calls.flat().join(' ')).toMatch(/Unsupported language "fr"/);
+  });
+
+  it('warns once when --lang zh is requested (translations incomplete)', () => {
+    expect(validateLang({lang: 'zh'})).toEqual({lang: 'zh'});
+    expect(errSpy.mock.calls.flat().join(' ')).toMatch(/translations are incomplete/i);
+
+    // Second call in same process: should not warn again.
+    errSpy.mockClear();
+    validateLang({lang: 'zh'});
+    expect(errSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects --lang combined with --zh', () => {
+    expect(() => validateLang({lang: 'zh', zh: true})).toThrow('exit-called');
+    expect(errSpy.mock.calls.flat().join(' ')).toMatch(/Cannot combine --lang with legacy/);
+  });
+
+  it('rejects --lang combined with --dense', () => {
+    expect(() => validateLang({lang: 'en', dense: true})).toThrow('exit-called');
+  });
+
+  it('uses legacy --zh when --lang is absent', () => {
+    expect(validateLang({zh: true})).toEqual({lang: 'zh'});
+  });
+
+  it('uses legacy --dense when --lang is absent', () => {
+    expect(validateLang({dense: true})).toEqual({lang: 'dense'});
+  });
+
+  it('emits a JSON error envelope when --json is set with an unsupported lang', () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    expect(() => validateLang({lang: 'fr', json: true})).toThrow('exit-called');
+    const out = logSpy.mock.calls.flat().join('');
+    const parsed = JSON.parse(out);
+    expect(parsed.error).toMatch(/Unsupported language "fr"/);
+    logSpy.mockRestore();
+  });
+
+  it('exposes the supported lang list', () => {
+    expect(SUPPORTED_LANGS).toContain('en');
+    expect(SUPPORTED_LANGS).toContain('zh');
+    expect(SUPPORTED_LANGS).toContain('dense');
+    expect(SUPPORTED_LANGS).not.toContain('fr');
+  });
+});

--- a/packages/cli/src/types/component.d.ts
+++ b/packages/cli/src/types/component.d.ts
@@ -3,35 +3,52 @@
 /**
  * Component command JSON responses.
  *
- * Invocation                                 -> type discriminator
+ * Invocation                                       -> type discriminator
  * ------------------------------------------------------------------
- * xds --json component                      -> component.list
- * xds --json component --list               -> component.list
- * xds --json component --category Form      -> component.list (filtered)
- * xds --json component --detail brief       -> component.brief
- * xds --json component Button               -> component.detail
- * xds --json component Button --props       -> component.detail.props
- * xds --json component Button --source      -> component.detail.source
- * xds --json component Button --showcase    -> component.detail.showcase
- * xds --json component Button --blocks      -> component.detail.blocks
- * (not found)                               -> CLIError
+ * xds --json component                            -> component.list
+ * xds --json component --list                     -> component.list
+ * xds --json component --category Form            -> component.list (filtered)
+ * xds --json component --list --detail compact    -> component.compact-list
+ * xds --json component --list --detail full       -> component.detailed-list
+ * xds --json component Button                     -> component.detail
+ * xds --json component Button --props             -> component.detail.props
+ * xds --json component Button --source            -> component.detail.source
+ * xds --json component Button --showcase          -> component.detail.showcase
+ * xds --json component Button --blocks            -> component.detail.blocks
+ * (not found)                                     -> CLIError
+ *
+ * Detail levels (length: brief < compact < full):
+ *   brief   -> just names                         -> component.list
+ *   compact -> names + short description          -> component.compact-list
+ *   full    -> names + description + import path  -> component.detailed-list
  */
 
 import type {ComponentDoc, PropDoc} from '../../../core/src/docs-types';
 
-/** xds --json component [--list] [--category X] */
+/** xds --json component [--list] [--category X] (default detail: brief) */
 export interface ComponentListResponse {
   type: 'component.list';
   data: Record<string, string[]>;
 }
 
-/** xds --json component --detail brief [--category X] */
-export interface ComponentBriefResponse {
-  type: 'component.brief';
-  data: Record<string, ComponentBriefEntry[]>;
+/** xds --json component --list --detail compact */
+export interface ComponentCompactListResponse {
+  type: 'component.compact-list';
+  data: Record<string, ComponentCompactEntry[]>;
 }
 
-export interface ComponentBriefEntry {
+export interface ComponentCompactEntry {
+  name: string;
+  description: string;
+}
+
+/** xds --json component --list --detail full */
+export interface ComponentDetailedListResponse {
+  type: 'component.detailed-list';
+  data: Record<string, ComponentDetailedEntry[]>;
+}
+
+export interface ComponentDetailedEntry {
   name: string;
   description: string;
   import: string;

--- a/packages/cli/src/utils/help.mjs
+++ b/packages/cli/src/utils/help.mjs
@@ -1,0 +1,40 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Help-text helpers
+ *
+ * Subcommands hide global flags by default. We re-surface them in
+ * each subcommand's `--help` so agents and humans can discover
+ * `--json`, `--lang`, `--detail`, `--zh`, `--dense` without bouncing
+ * up to `xds --help`.
+ *
+ * Also supports a small `Examples:` block per command.
+ */
+
+const GLOBAL_FLAGS_BLOCK = `
+Global Options (inherited from \`xds\`):
+  --json              Output as typed JSON (envelope: { type, data })
+  --detail <level>    Output detail level: brief, compact, full (default: full)
+  --lang <locale>     Output language/format: en, zh, dense
+  --zh                Shortcut for --lang zh (legacy)
+  --dense             Shortcut for --lang dense (legacy)
+`.trimEnd();
+
+/**
+ * Attach an Examples block + the global-flags reference to a subcommand.
+ *
+ * @param {import('commander').Command} cmd
+ * @param {string[]} [examples] - one example per line, including the leading `xds ...`.
+ */
+export function addCommonHelp(cmd, examples = []) {
+  cmd.addHelpText('after', () => {
+    const parts = [];
+    if (examples.length > 0) {
+      parts.push('\nExamples:');
+      for (const ex of examples) parts.push(`  ${ex}`);
+    }
+    parts.push('');
+    parts.push(GLOBAL_FLAGS_BLOCK);
+    return parts.join('\n');
+  });
+}


### PR DESCRIPTION
Fixes four CLI usability issues surfaced by recent agent-facing audits:

## 1. \`--lang\` was silently lying

\`--lang fr\`, \`--lang ja\`, \`--lang zh\` all returned English. The flag is advertised in \`--help\` but had no validator, so unsupported locales were silently swallowed and \`zh\` was only partially translated (props translated, prose not).

**Fix:**
- Validate against the supported set: \`en\`, \`zh\`, \`dense\`. Anything else → exit 1 with a clear message (or JSON error envelope when \`--json\`).
- Reject combining \`--lang\` with the legacy \`--zh\` / \`--dense\` shortcuts (was previously ambiguous).
- Warn on stderr when \`--lang zh\` is requested:
  \`\`\`
  Warning: --lang zh translations are incomplete. Some prose will fall back to English.
  \`\`\`

> **Follow-up (not in this PR):** flesh out \`docsZh\` coverage on every \`.doc.mjs\` so prose (descriptions, best practices, anatomy) is actually translated. Today \`docsZh\` exists but most files only translate prop tables. Once coverage is complete, drop the warning and remove \`PARTIAL_LANGS\` in \`packages/cli/src/lib/lang.mjs\`.

## 2. \`--detail\` levels were inverted on list views

Before:
| Command | bytes |
|---|---|
| \`xds component --list --detail brief\`   | **66,952** |
| \`xds component --list --detail compact\` | 17,430 |
| \`xds component --list --detail full\`    |  2,538 |

So \`brief\` was 26× larger than \`full\` — exactly backwards.

After:
| Command | bytes |
|---|---|
| \`xds component --list --detail brief\`   |  2,538 |
| \`xds component --list --detail compact\` | 17,430 |
| \`xds component --list --detail full\`    | 66,952 |

Same fix applied to \`xds hook --list\`. Detail levels now follow the documented \`brief < compact < full\` ordering, and all three produce **different** output.

JSON envelope types reflect the new contract:
- \`brief\`   → \`component.list\`           (just names)
- \`compact\` → \`component.compact-list\`   (names + short description) — **new**
- \`full\`    → \`component.detailed-list\`  (names + description + import path)

Implicit defaults preserved: when no \`--detail\` flag is passed on a list view, we default to \`brief\` so \`xds component --list\` stays terse for humans. Single-component views still default to \`full\`.

Bonus fix: \`formatHookFull\` was missing the \`## Import\` / \`## Related\` / \`## Examples\` sections that \`formatHookCompact\` already had, so \`compact\` could be longer than \`full\` for single hooks. \`formatHookFull\` is now a strict superset.

## 3. Subcommand \`--help\` omitted all global flags & had no examples

Before:
\`\`\`
$ xds component --help
Usage: xds component [options] [name]
…
Options:
  --list                 …
  --category <category>  …
  -h, --help             display help for command
\`\`\`

No mention of \`--json\`, \`--lang\`, or \`--detail\` — even though those flags significantly change the output. No \`Examples:\` section anywhere in the CLI.

**Fix:** new \`addCommonHelp(cmd, examples)\` helper in \`packages/cli/src/utils/help.mjs\` injects an \`Examples:\` block plus a \"Global Options (inherited from \`xds\`)\" reference into every subcommand. Wired into: \`component\`, \`hook\`, \`docs\`, \`init\`, \`swizzle\`, \`discover\`, \`upgrade\`.

## 4. \`xds --version --json\` returned plain text

\`\`\`
$ xds --version --json
0.0.14
\`\`\`

**Fix:**

\`\`\`
$ xds --version --json
{
  \"type\": \"version\",
  \"data\": {
    \"version\": \"0.0.14\"
  }
}
\`\`\`

Plain \`xds --version\` still returns plain text.

## Tests

- New: \`packages/cli/src/lib/lang.test.mjs\` (10 tests) — \`validateLang\` unit tests.
- New: \`packages/cli/src/commands/cli-flags.test.mjs\` (16 tests) — end-to-end CLI tests covering version-json, lang validation, detail level ordering on list views, and subcommand --help global-flags / Examples surfacing.
- Existing: 590 → 616 cli vitest tests, all passing.
- \`pnpm lint\` clean.

## Files

- \`packages/cli/src/lib/lang.mjs\` (new) — \`validateLang\`, \`SUPPORTED_LANGS\`.
- \`packages/cli/src/utils/help.mjs\` (new) — \`addCommonHelp\`.
- \`packages/cli/src/index.mjs\` — \`--version --json\` interceptor.
- \`packages/cli/src/api/{component,hook}.mjs\` — list-mode detail routing.
- \`packages/cli/src/commands/{component,hook,docs,init,swizzle,discover,upgrade}/...\` — wire validation + help.
- \`packages/cli/src/lib/hook-format.mjs\` — \`formatHookFull\` superset of \`formatHookCompact\`.
- \`packages/cli/src/types/component.d.ts\` — new envelope types.