### PR TITLE
fix(docsite): inherit site theme mode on templates, themes, and docs pages

### DIFF
--- a/apps/docsite/src/app/(docs)/docs/page.tsx
+++ b/apps/docsite/src/app/(docs)/docs/page.tsx
@@ -13,8 +13,9 @@ import {XDSVStack, XDSHStack} from '@xds/core/Layout';
 import {XDSGrid} from '@xds/core/Grid';
 import {XDSSection} from '@xds/core/Section';
 import {XDSButton} from '@xds/core/Button';
-import {XDSTheme, XDSMediaTheme} from '@xds/core/theme';
+import {XDSMediaTheme} from '@xds/core/theme';
 import {XDSLink} from '@xds/core/Link';
+import {ThemedPreview} from '../../../components/ThemedPreview';
 import {packages} from '../../../generated/packageRegistry';
 import {componentCount} from '../../../generated/componentRegistry';
 import {docTopics} from '../../../generated/docsRegistry';
@@ -248,11 +249,11 @@ export default function HomePage() {
                     href={`/packages/${pkg.name.replace('@xds/', '')}`}
                     {...stylex.props(styles.linkReset)}>
                     {theme ? (
-                      <XDSTheme theme={theme}>
+                      <ThemedPreview theme={theme}>
                         <div {...stylex.props(styles.packageImageWrapper)}>
                           <ThemeShowcaseTile label={pkg.displayName} />
                         </div>
-                      </XDSTheme>
+                      </ThemedPreview>
                     ) : (
                       <div
                         {...stylex.props(styles.packageImageWrapper)}

--- a/apps/docsite/src/app/(site)/themes/page.tsx
+++ b/apps/docsite/src/app/(site)/themes/page.tsx
@@ -15,6 +15,7 @@ import {XDSCard} from '@xds/core/Card';
 import {XDSButton} from '@xds/core/Button';
 import {XDSOverlay} from '@xds/core/Overlay';
 import {XDSTheme} from '@xds/core/theme';
+import {useThemeMode} from '../../providers';
 import {packages} from '../../../generated/packageRegistry';
 import {themeObjects} from '../../../generated/themeRegistry';
 import {ThemeShowcaseTile} from '../../../components/ThemeShowcaseTile';
@@ -44,6 +45,7 @@ const styles = stylex.create({
 });
 
 export default function ThemesPage() {
+  const {mode} = useThemeMode();
   return (
     <XDSSection maxWidth="xl" padding={6}>
       <XDSVStack gap={6}>
@@ -101,7 +103,7 @@ export default function ThemesPage() {
                   }>
                   <div style={{aspectRatio: '16/10'}} inert>
                     {theme ? (
-                      <XDSTheme theme={theme}>
+                      <XDSTheme theme={theme} mode={mode}>
                         <ThemeShowcaseTile label={label} />
                       </XDSTheme>
                     ) : (

--- a/apps/docsite/src/components/TemplateThumbnail.tsx
+++ b/apps/docsite/src/components/TemplateThumbnail.tsx
@@ -14,6 +14,7 @@ import * as stylex from '@stylexjs/stylex';
 import {XDSSkeleton} from '@xds/core/Skeleton';
 import {XDSTheme} from '@xds/core/theme';
 import {neutralTheme} from '@xds/theme-neutral/built';
+import {useThemeMode} from '../app/providers';
 
 const FIXED_SCALE = 0.5;
 
@@ -169,6 +170,7 @@ const TEMPLATE_COMPONENTS: Record<
 };
 
 export function TemplateThumbnail({slug}: {slug: string}) {
+  const {mode} = useThemeMode();
   const containerRef = useRef<HTMLDivElement>(null);
   const [renderWidth, setRenderWidth] = useState(0);
   const [isVisible, setIsVisible] = useState(false);
@@ -223,7 +225,7 @@ export function TemplateThumbnail({slug}: {slug: string}) {
                 <XDSSkeleton width="100%" height="100%" />
               </div>
             }>
-            <XDSTheme theme={neutralTheme}>
+            <XDSTheme theme={neutralTheme} mode={mode}>
               <Component />
             </XDSTheme>
           </Suspense>

--- a/apps/docsite/src/components/ThemedPreview.tsx
+++ b/apps/docsite/src/components/ThemedPreview.tsx
@@ -1,0 +1,26 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import {XDSTheme} from '@xds/core/theme';
+import type {ReactNode} from 'react';
+import {useThemeMode} from '../app/providers';
+
+/**
+ * Client wrapper that applies a given theme with the site's active mode.
+ * Use in server components that can't call useThemeMode directly.
+ */
+export function ThemedPreview({
+  theme,
+  children,
+}: {
+  theme: Parameters<typeof XDSTheme>[0]['theme'];
+  children: ReactNode;
+}) {
+  const {mode} = useThemeMode();
+  return (
+    <XDSTheme theme={theme} mode={mode}>
+      {children}
+    </XDSTheme>
+  );
+}


### PR DESCRIPTION
## Problem

On the /templates, /themes, and /docs pages, preview cards render using the system color scheme instead of the site's light/dark toggle — same issue fixed for /components in #2389, #2390, and #2392.

## Solution

- **TemplateThumbnail**: import `useThemeMode`, pass `mode` to `<XDSTheme>`
- **themes/page**: import `useThemeMode`, pass `mode` to `<XDSTheme>`
- **docs/page**: since this is a server component, a new `ThemedPreview` client component wraps the themed card previews with the site mode

## Changes

- `apps/docsite/src/components/TemplateThumbnail.tsx`
- `apps/docsite/src/app/(site)/themes/page.tsx`
- `apps/docsite/src/app/(docs)/docs/page.tsx`
- `apps/docsite/src/components/ThemedPreview.tsx` (new)