### PR TITLE
fix(Kbd): support literal "+" key via "plus" alias

### DIFF
--- a/packages/core/src/Kbd/XDSKbd.test.tsx
+++ b/packages/core/src/Kbd/XDSKbd.test.tsx
@@ -95,4 +95,10 @@ describe('XDSKbd', () => {
     const wrapper = container.firstChild as HTMLElement;
     expect(wrapper.className).toContain('xds-kbd');
   });
+
+  it('renders "plus" as a literal + key', () => {
+    render(<XDSKbd keys="shift+plus" />);
+    expect(screen.getByText('⇧')).toBeInTheDocument();
+    expect(screen.getByText('+')).toBeInTheDocument();
+  });
 });

--- a/packages/core/src/Kbd/XDSKbd.tsx
+++ b/packages/core/src/Kbd/XDSKbd.tsx
@@ -72,6 +72,7 @@ const KEY_DISPLAY: Record<string, string> = {
   down: '\u2193',
   left: '\u2190',
   right: '\u2192',
+  plus: '+',
 };
 
 /**
@@ -109,11 +110,13 @@ export interface XDSKbdProps extends XDSBaseProps<HTMLSpanElement> {
   /**
    * Keyboard shortcut string. Use "+" to separate keys.
    * Special keys: mod (Cmd on Mac), ctrl, alt, shift, enter, backspace, escape.
+   * Use "plus" to render a literal "+" key (e.g. "shift+plus").
    *
    * @example
    * ```
    * "mod+k"
    * "mod+shift+p"
+   * "shift+plus"
    * "enter"
    * ```
    */


### PR DESCRIPTION
  - Added plus: '+' to the KEY_DISPLAY map in XDSKbd.tsx:75, so "shift+plus" correctly renders as ⇧ +
  - Updated the keys prop JSDoc to document the plus alias
  - Added a test verifying <XDSKbd keys="shift+plus" /> renders both the shift symbol and +