### PR TITLE
feat(docsite): refresh About and Theming home page copy with related links

### DIFF
--- a/apps/docsite/src/app/(site)/_landing/AboutShowcase.tsx
+++ b/apps/docsite/src/app/(site)/_landing/AboutShowcase.tsx
@@ -6,6 +6,7 @@ import type {ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {XDSVStack} from '@xds/core/Layout';
 import {XDSHeading, XDSText} from '@xds/core/Text';
+import {XDSLink} from '@xds/core/Link';
 import {XDSBadge} from '@xds/core/Badge';
 import {XDSDivider} from '@xds/core/Divider';
 import {XDSTheme} from '@xds/core/theme';
@@ -70,6 +71,7 @@ const styles = stylex.create({
 type AboutItem = {
   title: string;
   description: string;
+  link?: ReactNode;
   icon: ReactNode;
 };
 
@@ -125,19 +127,34 @@ const items: AboutItem[] = [
   {
     title: 'Built by the people who use it',
     description:
-      'The system gets sharper when more people can see it, use it, and shape it.',
+      'The system gets sharper when we put it to work in the real world. Using it in context strengthens the whole system for everyone.',
+    link: (
+      <XDSLink type="body" href="/community" hasUnderline>
+        Learn how to contribute
+      </XDSLink>
+    ),
     icon: <BlobIcon />,
   },
   {
-    title: 'The bar keeps moving',
+    title: "Ready for what's next",
     description:
-      "The quality bar isn't fixed – it's accelerating. AI is rewriting how we design, build, and review code, and Astryx is built to evolve with it. Opinionated foundations, flexible patterns, and a system that keeps pace with where craft is going next.",
+      'The quality bar is accelerating. Astryx pairs opinionated foundations with flexible patterns so your system keeps pace — no matter how the craft evolves.',
+    link: (
+      <XDSLink type="body" href="/changelog" hasUnderline>
+        See what&apos;s new
+      </XDSLink>
+    ),
     icon: <SquareIcon />,
   },
   {
     title: 'Designed for speed',
     description:
       'Foundations you can trust, speed you can feel. The system is built so teams stop reinventing the basics and start shipping the ideas that matter.',
+    link: (
+      <XDSLink type="body" href="/docs/getting-started" hasUnderline>
+        Get started in minutes
+      </XDSLink>
+    ),
     icon: <DiamondIcon />,
   },
 ];
@@ -175,9 +192,12 @@ function AboutColumn({item, isFirst}: {item: AboutItem; isFirst: boolean}) {
         <XDSHeading level={3} color="primary">
           {item.title}
         </XDSHeading>
-        <XDSText type="body" color="secondary">
-          {item.description}
-        </XDSText>
+        <XDSVStack gap={1} align="start">
+          <XDSText type="body" color="secondary">
+            {item.description}
+          </XDSText>
+          {item.link}
+        </XDSVStack>
       </XDSVStack>
     </div>
   );

--- a/apps/docsite/src/app/(site)/_landing/ThemingShowcase.tsx
+++ b/apps/docsite/src/app/(site)/_landing/ThemingShowcase.tsx
@@ -161,11 +161,24 @@ function ShowcaseHeading() {
         xstyle={styles.fillWidth}>
         Every app deserves to look like itself
       </XDSHeading>
-      <XDSText type="body" color="secondary" xstyle={styles.fillWidth}>
-        Astryx makes it effortless. Customize color, typography, radius, and
-        motion at the token level
-        <br />— your brand, no fork required.
-      </XDSText>
+      <XDSVStack gap={1} align="center" xstyle={styles.fillWidth}>
+        <XDSText type="body" color="secondary" xstyle={styles.fillWidth}>
+          Astryx makes it effortless. Customize color, typography, radius, and
+          motion at the token level
+          <br />— your brand, no fork required.
+        </XDSText>
+        <XDSHStack gap={2} align="center">
+          <XDSLink type="body" href="/themes" hasUnderline>
+            Explore all themes
+          </XDSLink>
+          <XDSText type="body" color="secondary" aria-hidden="true">
+            ·
+          </XDSText>
+          <XDSLink type="body" href="/docs/theme" hasUnderline>
+            Create a custom theme
+          </XDSLink>
+        </XDSHStack>
+      </XDSVStack>
     </XDSVStack>
   );
 }


### PR DESCRIPTION
## Summary

Content updates to the home page (`/`) to tighten the **About us** copy and surface concrete next steps from both the About and Theming sections via inline related links.

### About section

- **"Built by the people who use it"** — new description: _"The system gets sharper when we put it to work in the real world. Using it in context strengthens the whole system for everyone."_ + link → `/community` ("Learn how to contribute")
- **"The bar keeps moving"** → renamed to **"Ready for what's next"**, with shorter, more focused copy + link → `/changelog` ("See what's new")
- **"Designed for speed"** — copy unchanged, added link → `/docs/getting-started` ("Get started in minutes")

The links sit 4px below their descriptions inside an inner `XDSVStack gap={1}`, preserving the existing 8px gap between heading and body.

### Theming section

Added two related links centered beneath the section subhead, separated by a middle-dot:

- **Explore all themes** → `/themes`
- **Create a custom theme** → `/docs/theme`

`/docs/theme` is the real theming guide; `/themes/editor` was intentionally not used because it's currently a `TODO` stub page.

### Implementation notes

- `AboutShowcase.tsx`: added an optional `link?: ReactNode` field to `AboutItem` so links live as a sibling of the text node rather than being embedded inside `<XDSText>`. This avoids nesting block-level layout inside a text element and lets the column control spacing properly.
- `ThemingShowcase.tsx`: link row uses `XDSHStack` with a `·` separator marked `aria-hidden="true"` for clean screen reader output.
- No new icons, assets, or dependencies. Existing `XDSLink` / `XDSHStack` / `XDSVStack` primitives only.

## Test plan

- [ ] Visit `/` and confirm the About section renders three columns, each with title, description, and a related link 4px beneath the description
- [ ] Confirm About section link destinations: `/community`, `/changelog`, `/docs/getting-started`
- [ ] Confirm the Theming heading shows "Explore all themes  ·  Create a custom theme" centered beneath the subhead
- [ ] Confirm Theming link destinations: `/themes`, `/docs/theme`
- [ ] Verify mobile layout — links wrap or stack acceptably at narrow widths
- [ ] Verify the middle-dot is not announced by a screen reader

Made with [Cursor](https://cursor.com)