### PR TITLE
feat(storybook): flatten hierarchy and add missing component stories

### DIFF
--- a/apps/storybook/stories/AlertDialog.stories.tsx
+++ b/apps/storybook/stories/AlertDialog.stories.tsx
@@ -9,7 +9,7 @@ import {
 import {XDSButton} from '@xds/core/Button';
 
 const meta: Meta<typeof XDSAlertDialog> = {
-  title: 'Core/Dialogs/AlertDialog',
+  title: 'Core/AlertDialog',
   component: XDSAlertDialog,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Breadcrumbs.stories.tsx
+++ b/apps/storybook/stories/Breadcrumbs.stories.tsx
@@ -5,7 +5,7 @@ import {XDSBreadcrumbs, XDSBreadcrumbItem} from '@xds/core/Breadcrumbs';
 import {HomeIcon, Cog6ToothIcon, FolderIcon} from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof XDSBreadcrumbs> = {
-  title: 'Core/Navigation/Breadcrumbs',
+  title: 'Core/Breadcrumbs',
   component: XDSBreadcrumbs,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Button.stories.tsx
+++ b/apps/storybook/stories/Button.stories.tsx
@@ -13,7 +13,7 @@ const buttonStoryStyles = stylex.create({
 });
 
 const meta: Meta<typeof XDSButton> = {
-  title: 'Core/Buttons/Button',
+  title: 'Core/Button',
   component: XDSButton,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/ButtonGroup.stories.tsx
+++ b/apps/storybook/stories/ButtonGroup.stories.tsx
@@ -18,7 +18,7 @@ import {
 } from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof XDSButtonGroup> = {
-  title: 'Core/Buttons/ButtonGroup',
+  title: 'Core/ButtonGroup',
   component: XDSButtonGroup,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/ChartStreamPerf.stories.tsx
+++ b/apps/storybook/stories/ChartStreamPerf.stories.tsx
@@ -14,7 +14,7 @@ import {XDSStack, XDSText} from '@xds/core';
 import {XDSHeading} from '@xds/core/Text';
 
 const meta: Meta = {
-  title: 'Lab/ChartStreamGL/Performance',
+  title: 'Lab/ChartStreamPerf',
 };
 
 export default meta;

--- a/apps/storybook/stories/ChartV2.stories.tsx
+++ b/apps/storybook/stories/ChartV2.stories.tsx
@@ -5,7 +5,7 @@ import {XDSChartV2 as XDSChart, bar, line, area} from '@xds/lab';
 import {XDSChartGrid, XDSChartAxis, currency} from '@xds/lab';
 
 const meta: Meta<typeof XDSChart> = {
-  title: 'Lab/XDSChart v2',
+  title: 'Lab/ChartV2',
   component: XDSChart,
 };
 export default meta;

--- a/apps/storybook/stories/ChartV2Advanced.stories.tsx
+++ b/apps/storybook/stories/ChartV2Advanced.stories.tsx
@@ -18,7 +18,7 @@ import {
 import {XDSChartGrid, XDSChartAxis} from '@xds/lab';
 
 const meta: Meta<typeof XDSChart> = {
-  title: 'Lab/XDSChart v2/Advanced',
+  title: 'Lab/ChartV2Advanced',
   component: XDSChart,
 };
 export default meta;

--- a/apps/storybook/stories/ChartV2Legend.stories.tsx
+++ b/apps/storybook/stories/ChartV2Legend.stories.tsx
@@ -10,7 +10,7 @@ const sampleItems = [
 ];
 
 const meta: Meta<typeof XDSChartV2Legend> = {
-  title: 'Lab/XDSChart v2/Primitives/Legend',
+  title: 'Lab/ChartV2Legend',
   component: XDSChartV2Legend,
   argTypes: {
     position: {

--- a/apps/storybook/stories/ChartV2Swatch.stories.tsx
+++ b/apps/storybook/stories/ChartV2Swatch.stories.tsx
@@ -4,7 +4,7 @@ import type {Meta, StoryObj} from '@storybook/react';
 import {XDSChartV2Swatch} from '@xds/lab';
 
 const meta: Meta<typeof XDSChartV2Swatch> = {
-  title: 'Lab/XDSChart v2/Primitives/Swatch',
+  title: 'Lab/ChartV2Swatch',
   component: XDSChartV2Swatch,
   argTypes: {
     color: {control: 'color'},

--- a/apps/storybook/stories/ChartV2Tooltip.stories.tsx
+++ b/apps/storybook/stories/ChartV2Tooltip.stories.tsx
@@ -5,7 +5,7 @@ import {XDSChartV2 as XDSChart, bar, line} from '@xds/lab';
 import {XDSChartGrid, XDSChartAxis, currency} from '@xds/lab';
 
 const meta: Meta = {
-  title: 'Lab/XDSChart v2/Primitives/Tooltip',
+  title: 'Lab/ChartV2Tooltip',
 };
 export default meta;
 

--- a/apps/storybook/stories/Chat.stories.tsx
+++ b/apps/storybook/stories/Chat.stories.tsx
@@ -19,7 +19,7 @@ import {HandThumbUpIcon, HandThumbDownIcon} from '@heroicons/react/24/outline';
 import {ClipboardDocumentIcon} from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof XDSChatMessageList> = {
-  title: 'Core/Chat/MessageList',
+  title: 'Core/Chat',
   component: XDSChatMessageList,
   tags: ['autodocs'],
 };

--- a/apps/storybook/stories/ChatAutoScroll.stories.tsx
+++ b/apps/storybook/stories/ChatAutoScroll.stories.tsx
@@ -33,7 +33,7 @@ import {useState, useCallback, useRef} from 'react';
 import * as stylex from '@stylexjs/stylex';
 
 const meta: Meta = {
-  title: 'Core/Chat/AutoScroll',
+  title: 'Core/ChatAutoScroll',
   tags: ['autodocs'],
   parameters: {layout: 'fullscreen'},
 };

--- a/apps/storybook/stories/ChatComposer.stories.tsx
+++ b/apps/storybook/stories/ChatComposer.stories.tsx
@@ -59,7 +59,7 @@ const MicIcon = (
 );
 
 const meta: Meta<typeof XDSChatComposer> = {
-  title: 'Core/Chat/Composer',
+  title: 'Core/ChatComposer',
   component: XDSChatComposer,
   tags: ['autodocs'],
   parameters: {

--- a/apps/storybook/stories/ChatComposerInput.stories.tsx
+++ b/apps/storybook/stories/ChatComposerInput.stories.tsx
@@ -13,7 +13,7 @@ import type {XDSSearchableItem, XDSSearchSource} from '@xds/core/Typeahead';
 import {useState} from 'react';
 
 const meta: Meta = {
-  title: 'Core/Chat/ComposerInput',
+  title: 'Core/ChatComposerInput',
   component: XDSChatComposerInput,
   tags: ['autodocs'],
   parameters: {

--- a/apps/storybook/stories/ChatDictation.stories.tsx
+++ b/apps/storybook/stories/ChatDictation.stories.tsx
@@ -76,7 +76,7 @@ const unsupportedDictation: UseSpeechRecognitionReturn = {
 // =============================================================================
 
 const meta: Meta<typeof XDSChatDictationButton> = {
-  title: 'Core/Chat/DictationButton',
+  title: 'Core/ChatDictation',
   component: XDSChatDictationButton,
   tags: ['autodocs'],
   parameters: {

--- a/apps/storybook/stories/ChatLayout.stories.tsx
+++ b/apps/storybook/stories/ChatLayout.stories.tsx
@@ -32,7 +32,7 @@ import {XDSEmptyState} from '@xds/core/EmptyState';
 import {useState, useCallback, useRef} from 'react';
 
 const meta: Meta<typeof XDSChatLayout> = {
-  title: 'Core/Chat/Layout',
+  title: 'Core/ChatLayout',
   component: XDSChatLayout,
   tags: ['autodocs'],
   parameters: {layout: 'fullscreen'},

--- a/apps/storybook/stories/ChatTokenizedText.stories.tsx
+++ b/apps/storybook/stories/ChatTokenizedText.stories.tsx
@@ -5,7 +5,7 @@ import {XDSChatTokenizedText} from '@xds/core/Chat';
 import {XDSChatMessage, XDSChatMessageBubble} from '@xds/core/Chat';
 
 const meta: Meta<typeof XDSChatTokenizedText> = {
-  title: 'Core/Chat/TokenizedText',
+  title: 'Core/ChatTokenizedText',
   component: XDSChatTokenizedText,
   tags: ['autodocs'],
   parameters: {layout: 'centered'},

--- a/apps/storybook/stories/ChatToolCalls.stories.tsx
+++ b/apps/storybook/stories/ChatToolCalls.stories.tsx
@@ -6,7 +6,7 @@ import {useState, useCallback} from 'react';
 import {XDSCodeBlock} from '@xds/core/CodeBlock';
 
 const meta: Meta<typeof XDSChatToolCalls> = {
-  title: 'Core/Chat/ToolCalls',
+  title: 'Core/ChatToolCalls',
   component: XDSChatToolCalls,
   tags: ['autodocs'],
   parameters: {

--- a/apps/storybook/stories/CheckboxInput.stories.tsx
+++ b/apps/storybook/stories/CheckboxInput.stories.tsx
@@ -10,7 +10,7 @@ import {
 } from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof XDSCheckboxInput> = {
-  title: 'Core/Inputs/CheckboxInput',
+  title: 'Core/CheckboxInput',
   component: XDSCheckboxInput,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/CheckboxList.stories.tsx
+++ b/apps/storybook/stories/CheckboxList.stories.tsx
@@ -7,7 +7,7 @@ import {XDSList} from '@xds/core/List';
 import {XDSCard} from '@xds/core/Card';
 
 const meta: Meta<typeof XDSCheckboxList> = {
-  title: 'Core/Inputs/CheckboxList',
+  title: 'Core/CheckboxList',
   component: XDSCheckboxList,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/ClickableCard.stories.tsx
+++ b/apps/storybook/stories/ClickableCard.stories.tsx
@@ -7,7 +7,7 @@ import {XDSButton} from '@xds/core/Button';
 import {XDSVStack, XDSHStack} from '@xds/core/Layout';
 
 const meta: Meta<typeof XDSClickableCard> = {
-  title: 'Card/XDSClickableCard',
+  title: 'Core/ClickableCard',
   component: XDSClickableCard,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/CodeEditorPerf.stories.tsx
+++ b/apps/storybook/stories/CodeEditorPerf.stories.tsx
@@ -5,7 +5,7 @@ import {useState, useRef, useEffect, useCallback} from 'react';
 import {XDSCodeEditor} from '@xds/lab';
 
 const meta: Meta<typeof XDSCodeEditor> = {
-  title: 'Lab/CodeEditor/Performance',
+  title: 'Lab/CodeEditorPerf',
   component: XDSCodeEditor,
   parameters: {layout: 'fullscreen'},
 };

--- a/apps/storybook/stories/CodeEditorTheme.stories.tsx
+++ b/apps/storybook/stories/CodeEditorTheme.stories.tsx
@@ -85,7 +85,7 @@ function ThemedEditor({
 }
 
 const meta: Meta = {
-  title: 'Lab/CodeEditor Themes',
+  title: 'Lab/CodeEditorTheme',
   parameters: {
     docs: {
       description: {

--- a/apps/storybook/stories/CodeTheme.stories.tsx
+++ b/apps/storybook/stories/CodeTheme.stories.tsx
@@ -64,7 +64,7 @@ const sampleCode = [
 ].join('\n');
 
 const meta: Meta = {
-  title: 'Core/Theme/SyntaxTheme',
+  title: 'Core/CodeTheme',
   tags: ['autodocs'],
   parameters: {
     docs: {

--- a/apps/storybook/stories/DateInput.stories.tsx
+++ b/apps/storybook/stories/DateInput.stories.tsx
@@ -7,7 +7,7 @@ import type {ISODateString} from '@xds/core/Calendar';
 import {XDSLayout, XDSLayoutContent} from '@xds/core/Layout';
 
 const meta: Meta<typeof XDSDateInput> = {
-  title: 'Core/Inputs/DateInput',
+  title: 'Core/DateInput',
   component: XDSDateInput,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/DateRangeInput.stories.tsx
+++ b/apps/storybook/stories/DateRangeInput.stories.tsx
@@ -41,7 +41,7 @@ const defaultPresets = [
 ];
 
 const meta: Meta<typeof XDSDateRangeInput> = {
-  title: 'Core/Inputs/DateRangeInput',
+  title: 'Core/DateRangeInput',
   component: XDSDateRangeInput,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/DateTimeInput.stories.tsx
+++ b/apps/storybook/stories/DateTimeInput.stories.tsx
@@ -6,7 +6,7 @@ import {XDSDateTimeInput} from '@xds/core/DateTimeInput';
 import type {ISODateTimeString} from '@xds/core/DateTimeInput';
 
 const meta: Meta<typeof XDSDateTimeInput> = {
-  title: 'Core/Inputs/DateTimeInput',
+  title: 'Core/DateTimeInput',
   component: XDSDateTimeInput,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Dialog.stories.tsx
+++ b/apps/storybook/stories/Dialog.stories.tsx
@@ -21,7 +21,7 @@ const styles = stylex.create({
 });
 
 const meta: Meta<typeof XDSDialog> = {
-  title: 'Core/Dialogs/Dialog',
+  title: 'Core/Dialog',
   component: XDSDialog,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Field.stories.tsx
+++ b/apps/storybook/stories/Field.stories.tsx
@@ -59,7 +59,7 @@ const NativeInput = ({
 );
 
 const meta: Meta<typeof XDSField> = {
-  title: 'Core/Inputs/Field',
+  title: 'Core/Field',
   component: XDSField,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/FileInput.stories.tsx
+++ b/apps/storybook/stories/FileInput.stories.tsx
@@ -5,7 +5,7 @@ import type {Meta, StoryObj} from '@storybook/react';
 import {XDSFileInput} from '@xds/core/FileInput';
 
 const meta: Meta<typeof XDSFileInput> = {
-  title: 'Core/Inputs/FileInput',
+  title: 'Core/FileInput',
   component: XDSFileInput,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/FormLayout.stories.tsx
+++ b/apps/storybook/stories/FormLayout.stories.tsx
@@ -10,7 +10,7 @@ import {XDSText} from '@xds/core/Text';
 import * as stylex from '@stylexjs/stylex';
 
 const meta: Meta<typeof XDSFormLayout> = {
-  title: 'Core/Inputs/FormLayout',
+  title: 'Core/FormLayout',
   component: XDSFormLayout,
   tags: ['autodocs'],
   args: {

--- a/apps/storybook/stories/GridMasonry.stories.tsx
+++ b/apps/storybook/stories/GridMasonry.stories.tsx
@@ -14,7 +14,7 @@ import {
 } from '@xds/core/theme/tokens.stylex';
 
 const meta: Meta = {
-  title: 'Core/Grid/Masonry Gallery',
+  title: 'Core/GridMasonry',
   tags: ['autodocs'],
 };
 

--- a/apps/storybook/stories/IconButton.stories.tsx
+++ b/apps/storybook/stories/IconButton.stories.tsx
@@ -13,7 +13,7 @@ import {
 } from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof XDSIconButton> = {
-  title: 'Core/Buttons/IconButton',
+  title: 'Core/IconButton',
   component: XDSIconButton,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/InputGroup.stories.tsx
+++ b/apps/storybook/stories/InputGroup.stories.tsx
@@ -9,7 +9,7 @@ import {XDSNumberInput} from '@xds/core/NumberInput';
 import {XDSIcon} from '@xds/core/Icon';
 
 const meta: Meta<typeof XDSInputGroup> = {
-  title: 'Core/Inputs/InputGroup',
+  title: 'Core/InputGroup',
   component: XDSInputGroup,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Layer.stories.tsx
+++ b/apps/storybook/stories/Layer.stories.tsx
@@ -1,0 +1,159 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {useState} from 'react';
+import type {Meta, StoryObj} from '@storybook/react';
+import * as stylex from '@stylexjs/stylex';
+import {useXDSLayer} from '@xds/core/Layer';
+import {XDSLayerProvider} from '@xds/core/Layer';
+import {XDSButton} from '@xds/core/Button';
+import {XDSText} from '@xds/core/Text';
+
+const styles = stylex.create({
+  popoverContent: {
+    backgroundColor: 'var(--xds-color-surface-raised)',
+    borderRadius: 8,
+    padding: 16,
+    boxShadow: '0 4px 12px rgba(0,0,0,0.15)',
+    border: '1px solid var(--xds-color-border-default)',
+  },
+  demoArea: {
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    minHeight: 200,
+  },
+});
+
+const meta: Meta = {
+  title: 'Core/Layer',
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Layer is the core positioning hook for overlay content using CSS Anchor Positioning and the Popover API. Used as the foundation for Popover, HoverCard, and Tooltip.',
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj;
+
+function ContextModeDemo() {
+  const layer = useXDSLayer({mode: 'context', lightDismiss: true});
+
+  return (
+    <div {...stylex.props(styles.demoArea)}>
+      <XDSButton
+        ref={layer.ref}
+        label="Show layer"
+        onClick={() => (layer.isOpen ? layer.hide() : layer.show())}
+      />
+      {layer.render(
+        <div {...stylex.props(styles.popoverContent)}>
+          <XDSText type="body">
+            This layer is anchored to the button using CSS Anchor Positioning.
+          </XDSText>
+        </div>,
+        {placement: 'below', alignment: 'center'},
+      )}
+    </div>
+  );
+}
+
+export const ContextMode: Story = {
+  render: () => <ContextModeDemo />,
+};
+
+function PlacementDemo() {
+  const [placement, setPlacement] = useState<
+    'above' | 'below' | 'start' | 'end'
+  >('above');
+  const layer = useXDSLayer({mode: 'context', lightDismiss: true});
+
+  return (
+    <div style={{display: 'flex', flexDirection: 'column', gap: 16, alignItems: 'center'}}>
+      <div style={{display: 'flex', gap: 8}}>
+        {(['above', 'below', 'start', 'end'] as const).map((p) => (
+          <XDSButton
+            key={p}
+            label={p}
+            variant={placement === p ? 'primary' : 'secondary'}
+            onClick={() => setPlacement(p)}
+          />
+        ))}
+      </div>
+      <div {...stylex.props(styles.demoArea)}>
+        <XDSButton
+          ref={layer.ref}
+          label="Trigger"
+          onClick={() => (layer.isOpen ? layer.hide() : layer.show())}
+        />
+        {layer.render(
+          <div {...stylex.props(styles.popoverContent)}>
+            <XDSText type="body">Placement: {placement}</XDSText>
+          </div>,
+          {placement, alignment: 'center'},
+        )}
+      </div>
+    </div>
+  );
+}
+
+export const Placements: Story = {
+  render: () => <PlacementDemo />,
+};
+
+function FixedModeDemo() {
+  const [coords, setCoords] = useState({x: 0, y: 0});
+  const layer = useXDSLayer({mode: 'fixed', lightDismiss: true});
+
+  return (
+    <div
+      style={{
+        position: 'relative',
+        minHeight: 300,
+        border: '1px dashed var(--xds-color-border-default)',
+        borderRadius: 8,
+        cursor: 'crosshair',
+      }}
+      onClick={(e) => {
+        const rect = e.currentTarget.getBoundingClientRect();
+        setCoords({x: e.clientX - rect.left + rect.left, y: e.clientY - rect.top + rect.top});
+        layer.show();
+      }}>
+      <XDSText type="supporting" style={{padding: 16}}>
+        Click anywhere in this area to show a fixed-position layer
+      </XDSText>
+      {layer.render(
+        <div {...stylex.props(styles.popoverContent)}>
+          <XDSText type="body">Fixed at ({Math.round(coords.x)}, {Math.round(coords.y)})</XDSText>
+        </div>,
+        {x: coords.x, y: coords.y},
+      )}
+    </div>
+  );
+}
+
+export const FixedMode: Story = {
+  render: () => <FixedModeDemo />,
+};
+
+function LayerProviderDemo() {
+  return (
+    <XDSLayerProvider toast={{position: 'topEnd', maxVisible: 3}}>
+      <div style={{padding: 16}}>
+        <XDSText type="body">
+          XDSLayerProvider wraps your app to configure layer systems (toast
+          positioning, max visible toasts). It is optional — hooks fall back to
+          defaults when no provider exists.
+        </XDSText>
+      </div>
+    </XDSLayerProvider>
+  );
+}
+
+export const Provider: Story = {
+  render: () => <LayerProviderDemo />,
+};

--- a/apps/storybook/stories/MarkdownCitations.stories.tsx
+++ b/apps/storybook/stories/MarkdownCitations.stories.tsx
@@ -7,7 +7,7 @@ import type {XDSMarkdownSource} from '@xds/core/Markdown';
 import {XDSButton} from '@xds/core/Button';
 
 const meta: Meta<typeof XDSMarkdown> = {
-  title: 'Core/Markdown/Citations',
+  title: 'Core/MarkdownCitations',
   component: XDSMarkdown,
   tags: ['autodocs'],
 };

--- a/apps/storybook/stories/MobileNav.stories.tsx
+++ b/apps/storybook/stories/MobileNav.stories.tsx
@@ -31,7 +31,7 @@ import {
 // =============================================================================
 
 const meta: Meta<typeof XDSMobileNav> = {
-  title: 'Core/Navigation/MobileNav',
+  title: 'Core/MobileNav',
   component: XDSMobileNav,
   tags: ['autodocs'],
   parameters: {

--- a/apps/storybook/stories/MultiSelector.stories.tsx
+++ b/apps/storybook/stories/MultiSelector.stories.tsx
@@ -5,7 +5,7 @@ import {useState} from 'react';
 import {XDSMultiSelector} from '@xds/core/MultiSelector';
 
 const meta: Meta<typeof XDSMultiSelector> = {
-  title: 'Core/Inputs/MultiSelector',
+  title: 'Core/MultiSelector',
   component: XDSMultiSelector,
   tags: ['autodocs'],
   parameters: {

--- a/apps/storybook/stories/NavIcon.stories.tsx
+++ b/apps/storybook/stories/NavIcon.stories.tsx
@@ -1,0 +1,55 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import type {Meta, StoryObj} from '@storybook/react';
+import {XDSNavIcon} from '@xds/core/NavIcon';
+import {
+  HomeIcon,
+  CubeIcon,
+  BoltIcon,
+  RocketLaunchIcon,
+  SparklesIcon,
+} from '@heroicons/react/24/solid';
+
+const meta: Meta<typeof XDSNavIcon> = {
+  title: 'Core/NavIcon',
+  component: XDSNavIcon,
+  tags: ['autodocs'],
+  argTypes: {
+    icon: {
+      description: 'Icon element to render inside the circular background',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof XDSNavIcon>;
+
+export const Default: Story = {
+  args: {
+    icon: <HomeIcon style={{width: 16, height: 16}} />,
+  },
+};
+
+export const WithCubeIcon: Story = {
+  args: {
+    icon: <CubeIcon style={{width: 16, height: 16}} />,
+  },
+};
+
+export const WithBoltIcon: Story = {
+  args: {
+    icon: <BoltIcon style={{width: 16, height: 16}} />,
+  },
+};
+
+export const Gallery: Story = {
+  render: () => (
+    <div style={{display: 'flex', gap: 16, alignItems: 'center'}}>
+      <XDSNavIcon icon={<HomeIcon style={{width: 16, height: 16}} />} />
+      <XDSNavIcon icon={<CubeIcon style={{width: 16, height: 16}} />} />
+      <XDSNavIcon icon={<BoltIcon style={{width: 16, height: 16}} />} />
+      <XDSNavIcon icon={<RocketLaunchIcon style={{width: 16, height: 16}} />} />
+      <XDSNavIcon icon={<SparklesIcon style={{width: 16, height: 16}} />} />
+    </div>
+  ),
+};

--- a/apps/storybook/stories/NavMenu.stories.tsx
+++ b/apps/storybook/stories/NavMenu.stories.tsx
@@ -1,0 +1,141 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import type {Meta, StoryObj} from '@storybook/react';
+import {XDSNavHeadingMenu, XDSNavHeadingMenuItem} from '@xds/core/NavMenu';
+import {
+  Cog6ToothIcon,
+  UserIcon,
+  ArrowRightStartOnRectangleIcon,
+  DocumentTextIcon,
+  ChartBarIcon,
+  ShieldCheckIcon,
+} from '@heroicons/react/24/outline';
+
+const meta: Meta<typeof XDSNavHeadingMenu> = {
+  title: 'Core/NavMenu',
+  component: XDSNavHeadingMenu,
+  tags: ['autodocs'],
+  argTypes: {
+    size: {
+      control: 'select',
+      options: ['sm', 'md', 'lg'],
+      description: 'Size — controls min-width and flows to items for padding',
+    },
+    minWidth: {
+      control: 'number',
+      description: 'Minimum width override',
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{padding: 24, maxWidth: 300}}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof XDSNavHeadingMenu>;
+
+export const Default: Story = {
+  args: {
+    size: 'md',
+    children: (
+      <>
+        <XDSNavHeadingMenuItem label="Dashboard" href="#" />
+        <XDSNavHeadingMenuItem label="Analytics" href="#" />
+        <XDSNavHeadingMenuItem label="Settings" href="#" />
+      </>
+    ),
+  },
+};
+
+export const WithIcons: Story = {
+  args: {
+    size: 'md',
+    children: (
+      <>
+        <XDSNavHeadingMenuItem
+          label="Profile"
+          icon={UserIcon}
+          href="#"
+        />
+        <XDSNavHeadingMenuItem
+          label="Documents"
+          icon={DocumentTextIcon}
+          href="#"
+        />
+        <XDSNavHeadingMenuItem
+          label="Analytics"
+          icon={ChartBarIcon}
+          href="#"
+        />
+        <XDSNavHeadingMenuItem
+          label="Security"
+          icon={ShieldCheckIcon}
+          href="#"
+        />
+        <XDSNavHeadingMenuItem
+          label="Settings"
+          icon={Cog6ToothIcon}
+          href="#"
+        />
+      </>
+    ),
+  },
+};
+
+export const WithDescriptions: Story = {
+  args: {
+    size: 'lg',
+    children: (
+      <>
+        <XDSNavHeadingMenuItem
+          label="Profile"
+          description="Manage your account settings"
+          icon={UserIcon}
+          href="#"
+        />
+        <XDSNavHeadingMenuItem
+          label="Settings"
+          description="Configure application preferences"
+          icon={Cog6ToothIcon}
+          href="#"
+        />
+        <XDSNavHeadingMenuItem
+          label="Sign out"
+          description="End your current session"
+          icon={ArrowRightStartOnRectangleIcon}
+        />
+      </>
+    ),
+  },
+};
+
+export const SmallSize: Story = {
+  args: {
+    size: 'sm',
+    children: (
+      <>
+        <XDSNavHeadingMenuItem label="Edit" href="#" />
+        <XDSNavHeadingMenuItem label="Duplicate" href="#" />
+        <XDSNavHeadingMenuItem label="Delete" />
+      </>
+    ),
+  },
+};
+
+export const DisabledItems: Story = {
+  args: {
+    size: 'md',
+    children: (
+      <>
+        <XDSNavHeadingMenuItem label="Dashboard" href="#" />
+        <XDSNavHeadingMenuItem label="Analytics" href="#" isDisabled />
+        <XDSNavHeadingMenuItem label="Settings" href="#" />
+        <XDSNavHeadingMenuItem label="Admin" isDisabled />
+      </>
+    ),
+  },
+};

--- a/apps/storybook/stories/NumberInput.stories.tsx
+++ b/apps/storybook/stories/NumberInput.stories.tsx
@@ -6,7 +6,7 @@ import {XDSNumberInput} from '@xds/core/NumberInput';
 import {HashtagIcon, CurrencyDollarIcon} from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof XDSNumberInput> = {
-  title: 'Core/Inputs/NumberInput',
+  title: 'Core/NumberInput',
   component: XDSNumberInput,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/PowerSearch.stories.tsx
+++ b/apps/storybook/stories/PowerSearch.stories.tsx
@@ -295,7 +295,7 @@ const fullConfig: PowerSearchConfig = {
 // =============================================================================
 
 const meta: Meta<typeof XDSPowerSearch> = {
-  title: 'Core/Inputs/PowerSearch',
+  title: 'Core/PowerSearch',
   component: XDSPowerSearch,
   tags: ['autodocs'],
   decorators: [

--- a/apps/storybook/stories/PowerSearchWithTable.stories.tsx
+++ b/apps/storybook/stories/PowerSearchWithTable.stories.tsx
@@ -167,7 +167,7 @@ const columns: XDSTableColumn<Book>[] = [
 // =============================================================================
 
 const meta: Meta = {
-  title: 'Patterns/PowerSearch + Table',
+  title: 'Core/PowerSearchWithTable',
   tags: ['autodocs'],
   decorators: [
     Story => (

--- a/apps/storybook/stories/RadioList.stories.tsx
+++ b/apps/storybook/stories/RadioList.stories.tsx
@@ -5,7 +5,7 @@ import type {Meta, StoryObj} from '@storybook/react';
 import {XDSRadioList, XDSRadioListItem} from '@xds/core/RadioList';
 
 const meta: Meta<typeof XDSRadioList> = {
-  title: 'Core/Inputs/RadioList',
+  title: 'Core/RadioList',
   component: XDSRadioList,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/SVGIconRegistry.stories.tsx
+++ b/apps/storybook/stories/SVGIconRegistry.stories.tsx
@@ -226,7 +226,7 @@ function jsxSvgToIconDef(
 // =============================================================================
 
 const meta: Meta = {
-  title: 'Lab/SVGIcon/Registry Icons',
+  title: 'Lab/SVGIconRegistry',
 };
 export default meta;
 

--- a/apps/storybook/stories/SegmentedControl.stories.tsx
+++ b/apps/storybook/stories/SegmentedControl.stories.tsx
@@ -14,7 +14,7 @@ import {
 } from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof XDSSegmentedControl> = {
-  title: 'Core/Inputs/SegmentedControl',
+  title: 'Core/SegmentedControl',
   component: XDSSegmentedControl,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/SelectableCard.stories.tsx
+++ b/apps/storybook/stories/SelectableCard.stories.tsx
@@ -7,7 +7,7 @@ import {XDSText} from '@xds/core/Text';
 import {XDSHStack, XDSVStack} from '@xds/core/Layout';
 
 const meta: Meta<typeof XDSSelectableCard> = {
-  title: 'Card/XDSSelectableCard',
+  title: 'Core/SelectableCard',
   component: XDSSelectableCard,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Selector.stories.tsx
+++ b/apps/storybook/stories/Selector.stories.tsx
@@ -6,7 +6,7 @@ import {XDSSelector, XDSSelectorOption} from '@xds/core/Selector';
 import {UserIcon, CogIcon, BellIcon} from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof XDSSelector> = {
-  title: 'Core/Inputs/Selector',
+  title: 'Core/Selector',
   component: XDSSelector,
   tags: ['autodocs'],
   parameters: {

--- a/apps/storybook/stories/SideNav.stories.tsx
+++ b/apps/storybook/stories/SideNav.stories.tsx
@@ -31,7 +31,7 @@ import {
 } from '@heroicons/react/24/solid';
 
 const meta: Meta<typeof XDSSideNav> = {
-  title: 'Core/Navigation/SideNav',
+  title: 'Core/SideNav',
   component: XDSSideNav,
   tags: ['autodocs'],
   parameters: {

--- a/apps/storybook/stories/TabList.stories.tsx
+++ b/apps/storybook/stories/TabList.stories.tsx
@@ -8,7 +8,7 @@ import {XDSButton} from '@xds/core/Button';
 import {PlusIcon, FunnelIcon} from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof XDSTabList> = {
-  title: 'Core/Navigation/TabList',
+  title: 'Core/TabList',
   component: XDSTabList,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/TableColumnResize.stories.tsx
+++ b/apps/storybook/stories/TableColumnResize.stories.tsx
@@ -72,7 +72,7 @@ const columns: XDSTableColumn<User>[] = [
 // =============================================================================
 
 const meta: Meta = {
-  title: 'Core/Table/ColumnResize',
+  title: 'Core/TableColumnResize',
   tags: ['autodocs'],
 };
 

--- a/apps/storybook/stories/TableColumnSettings.stories.tsx
+++ b/apps/storybook/stories/TableColumnSettings.stories.tsx
@@ -102,7 +102,7 @@ const defaultActiveKeys: UserColumnKey[] = [
 // =============================================================================
 
 const meta: Meta = {
-  title: 'Core/Table/ColumnSettings',
+  title: 'Core/TableColumnSettings',
   tags: ['autodocs'],
 };
 

--- a/apps/storybook/stories/TableFiltering.stories.tsx
+++ b/apps/storybook/stories/TableFiltering.stories.tsx
@@ -93,7 +93,7 @@ const fieldDefs = [
 ] as const;
 
 const meta: Meta = {
-  title: 'Core/Table/Filtering',
+  title: 'Core/TableFiltering',
   tags: ['autodocs'],
 };
 

--- a/apps/storybook/stories/TablePagination.stories.tsx
+++ b/apps/storybook/stories/TablePagination.stories.tsx
@@ -84,7 +84,7 @@ function PaginatedDemo({
 // =============================================================================
 
 const meta: Meta = {
-  title: 'Core/Table/Pagination',
+  title: 'Core/TablePagination',
   tags: ['autodocs'],
 };
 

--- a/apps/storybook/stories/TableSelection.stories.tsx
+++ b/apps/storybook/stories/TableSelection.stories.tsx
@@ -70,7 +70,7 @@ const columns: XDSTableColumn<User>[] = [
 // =============================================================================
 
 const meta: Meta = {
-  title: 'Core/Table/Selection',
+  title: 'Core/TableSelection',
   tags: ['autodocs'],
 };
 

--- a/apps/storybook/stories/TableSortable.stories.tsx
+++ b/apps/storybook/stories/TableSortable.stories.tsx
@@ -79,7 +79,7 @@ const columns: XDSTableColumn<Employee>[] = [
 // =============================================================================
 
 const meta: Meta = {
-  title: 'Core/Table/Sortable',
+  title: 'Core/TableSortable',
   tags: ['autodocs'],
 };
 

--- a/apps/storybook/stories/TextArea.stories.tsx
+++ b/apps/storybook/stories/TextArea.stories.tsx
@@ -11,7 +11,7 @@ import {
 } from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof XDSTextArea> = {
-  title: 'Core/Inputs/TextArea',
+  title: 'Core/TextArea',
   component: XDSTextArea,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/TextInput.stories.tsx
+++ b/apps/storybook/stories/TextInput.stories.tsx
@@ -10,7 +10,7 @@ import {
 } from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof XDSTextInput> = {
-  title: 'Core/Inputs/TextInput',
+  title: 'Core/TextInput',
   component: XDSTextInput,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/ThreeDChart.stories.tsx
+++ b/apps/storybook/stories/ThreeDChart.stories.tsx
@@ -14,7 +14,7 @@ import {XDSStack, XDSText} from '@xds/core';
 import {XDSHeading} from '@xds/core/Text';
 
 const meta: Meta = {
-  title: 'Lab/3DChart',
+  title: 'Lab/ThreeDChart',
   tags: ['autodocs'],
 };
 

--- a/apps/storybook/stories/TimeInput.stories.tsx
+++ b/apps/storybook/stories/TimeInput.stories.tsx
@@ -6,7 +6,7 @@ import {XDSTimeInput} from '@xds/core/TimeInput';
 import type {ISOTimeString} from '@xds/core';
 
 const meta: Meta<typeof XDSTimeInput> = {
-  title: 'Core/Inputs/TimeInput',
+  title: 'Core/TimeInput',
   component: XDSTimeInput,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/ToggleButton.stories.tsx
+++ b/apps/storybook/stories/ToggleButton.stories.tsx
@@ -30,7 +30,7 @@ import {XDSIcon} from '@xds/core/Icon';
 const iconSize = {width: 16, height: 16} as const;
 
 const meta: Meta<typeof XDSToggleButton> = {
-  title: 'Core/Buttons/ToggleButton',
+  title: 'Core/ToggleButton',
   component: XDSToggleButton,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Tokenizer.stories.tsx
+++ b/apps/storybook/stories/Tokenizer.stories.tsx
@@ -26,7 +26,7 @@ const userSource: XDSSearchSource = {
 };
 
 const meta: Meta<typeof XDSTokenizer> = {
-  title: 'Core/Inputs/Tokenizer',
+  title: 'Core/Tokenizer',
   component: XDSTokenizer,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/ToolbarEdgeCompensation.stories.tsx
+++ b/apps/storybook/stories/ToolbarEdgeCompensation.stories.tsx
@@ -27,7 +27,7 @@ import {
 } from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof XDSToolbar> = {
-  title: 'Core/Toolbar/Edge Compensation',
+  title: 'Core/ToolbarEdgeCompensation',
   component: XDSToolbar,
   parameters: {
     layout: 'padded',

--- a/apps/storybook/stories/TopNav.stories.tsx
+++ b/apps/storybook/stories/TopNav.stories.tsx
@@ -16,7 +16,7 @@ import {
 } from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof XDSTopNav> = {
-  title: 'Core/Navigation/TopNav',
+  title: 'Core/TopNav',
   component: XDSTopNav,
   tags: ['autodocs'],
   parameters: {

--- a/apps/storybook/stories/TopNavMenu.stories.tsx
+++ b/apps/storybook/stories/TopNavMenu.stories.tsx
@@ -28,7 +28,7 @@ import {
 // =============================================================================
 
 const menuMeta: Meta<typeof XDSTopNavMenu> = {
-  title: 'Core/Navigation/TopNavMenu',
+  title: 'Core/TopNavMenu',
   component: XDSTopNavMenu,
   tags: ['autodocs'],
   parameters: {

--- a/apps/storybook/stories/Typeahead.stories.tsx
+++ b/apps/storybook/stories/Typeahead.stories.tsx
@@ -25,7 +25,7 @@ const fruitSource: XDSSearchSource = {
 };
 
 const meta: Meta<typeof XDSTypeahead> = {
-  title: 'Core/Inputs/Typeahead',
+  title: 'Core/Typeahead',
   component: XDSTypeahead,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/XDSMediaTheme.stories.tsx
+++ b/apps/storybook/stories/XDSMediaTheme.stories.tsx
@@ -20,7 +20,7 @@ import {XDSCard} from '@xds/core/Card';
 // =============================================================================
 
 const meta: Meta = {
-  title: 'Core/Theme/MediaTheme',
+  title: 'Core/XDSMediaTheme',
   parameters: {
     docs: {
       description: {

--- a/apps/storybook/stories/XDSTheme.stories.tsx
+++ b/apps/storybook/stories/XDSTheme.stories.tsx
@@ -314,7 +314,7 @@ const oceanTheme = defineTheme({
 // =============================================================================
 
 const meta: Meta = {
-  title: 'Core/Theme/Theme',
+  title: 'Core/XDSTheme',
   parameters: {
     docs: {
       description: {

--- a/apps/storybook/stories/XIFSpec.stories.tsx
+++ b/apps/storybook/stories/XIFSpec.stories.tsx
@@ -57,7 +57,7 @@ function xifToSvgIconDef(xif: XIFIcon): SVGIconDef {
 // =============================================================================
 
 const meta: Meta = {
-  title: 'Lab/XDSSVGIcon/XIF Spec',
+  title: 'Lab/XIFSpec',
 };
 export default meta;
 

--- a/apps/storybook/stories/useXDSLinkify.stories.tsx
+++ b/apps/storybook/stories/useXDSLinkify.stories.tsx
@@ -68,7 +68,7 @@ function LinkifyDemo({
 // ---------------------------------------------------------------------------
 
 const meta: Meta<typeof LinkifyDemo> = {
-  title: 'Core/Hooks/useXDSLinkify',
+  title: 'Core/useXDSLinkify',
   component: LinkifyDemo,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/useXDSResizable.stories.tsx
+++ b/apps/storybook/stories/useXDSResizable.stories.tsx
@@ -36,7 +36,7 @@ function HookDemo({children}: {children: React.ReactNode}) {
 }
 
 const meta: Meta<typeof HookDemo> = {
-  title: 'Core/Hooks/useXDSResizable',
+  title: 'Core/useXDSResizable',
   component: HookDemo,
   tags: ['autodocs'],
   parameters: {

--- a/apps/storybook/stories/useXDSStreamingText.stories.tsx
+++ b/apps/storybook/stories/useXDSStreamingText.stories.tsx
@@ -93,7 +93,7 @@ const SAMPLE_TEXT =
   'Here is how you fetch a user in TypeScript:\n\nconst response = await fetch("/api/users/" + id);\nconst user = await response.json();\n\nKey points:\n- Always check response.ok before parsing\n- Use AbortController for cancellation\n- Consider a useUser hook for React apps\n\nThis approach gives you type-safe API calls with proper error handling.';
 
 const meta: Meta<typeof StreamingDemo> = {
-  title: 'Core/Hooks/useXDSStreamingText',
+  title: 'Core/useXDSStreamingText',
   component: StreamingDemo,
   tags: ['autodocs'],
   argTypes: {


### PR DESCRIPTION
## What

Reorganizes the Storybook sidebar from nested folder structure to a flat, package-scoped layout and adds stories for components that were missing them.

## Changes

### Reorganization (69 files)

All story titles are now flat by package:
- `Core/<ComponentName>` — no more nested folders (`Dialogs/`, `Buttons/`, `Chat/`, `Navigation/`, `Inputs/`, `Table/`, `Hooks/`, `Theme/`, etc.)
- `Lab/<ComponentName>` — flattened `XDSChart v2/Primitives/`, `SVGIcon/`, etc.
- `Vega/<ComponentName>`

This makes it easier to find any component by name without remembering which subfolder it lives in.

### New Stories (3 files)

- **NavIcon** — circular icon container for nav headers (used by TopNav/SideNav)
- **NavMenu** (NavHeadingMenu + NavHeadingMenuItem) — accessible menu for nav heading popovers with size variants, icons, descriptions, disabled states
- **Layer** (useXDSLayer + XDSLayerProvider) — core positioning hook demos: context mode (anchor positioning), fixed mode, and placement options