### PR TITLE
feat(docsite): add component categories and sub-component tagging

### DIFF
--- a/apps/docsite/scripts/generate-data.mjs
+++ b/apps/docsite/scripts/generate-data.mjs
@@ -69,7 +69,7 @@ const NAME_RE = /(?:^|\n) {0,4}name:\s*['"]([^'"]+)['"]/;
 const DISPLAY_NAME_RE = /(?:^|\n) {0,4}displayName:\s*['"]([^'"]+)['"]/;
 const KEYWORDS_RE = /keywords:\s*\[([^\]]*)\]/;
 const CATEGORY_RE = /(?:^|\n) {0,4}category:\s*['"]([^'"]+)['"]/;
-const SUB_COMPONENT_OF_RE = /(?:^|\n) {0,4}subComponentOf:\s*['"]([^'"]+)['"]/;
+const IS_HIDDEN_FROM_OVERVIEW_RE = /(?:^|\n) {0,4}isHiddenFromOverview:\s*true/;
 
 function readDocMeta(docPath) {
   try {
@@ -84,7 +84,7 @@ function readDocMeta(docPath) {
       ? [...kwMatch[1].matchAll(/['"]([^'"]+)['"]/g)].map(m => m[1])
       : [];
     const categoryMatch = CATEGORY_RE.exec(content);
-    const subComponentOfMatch = SUB_COMPONENT_OF_RE.exec(content);
+    const isHiddenFromOverview = IS_HIDDEN_FROM_OVERVIEW_RE.test(content);
     return {
       group: groupMatch?.[1] ?? null,
       description: descMatch?.[1] ?? '',
@@ -93,10 +93,10 @@ function readDocMeta(docPath) {
       hidden,
       keywords,
       category: categoryMatch?.[1] ?? null,
-      subComponentOf: subComponentOfMatch?.[1] ?? null,
+      isHiddenFromOverview,
     };
   } catch {
-    return {group: null, description: '', name: null, displayName: null, hidden: false, keywords: [], category: null, subComponentOf: null};
+    return {group: null, description: '', name: null, displayName: null, hidden: false, keywords: [], category: null, isHiddenFromOverview: false};
   }
 }
 
@@ -284,7 +284,7 @@ async function generateComponentRegistry() {
 
         const group = doc.group || null;
         const category = doc.category || null;
-        const subComponentOf = doc.subComponentOf || null;
+        const isHiddenFromOverview = doc.isHiddenFromOverview ?? false;
         const keywords = doc.keywords || [];
         const hidden = doc.hidden ?? false;
         const topDescription = doc.usage?.description || doc.description || '';
@@ -296,11 +296,9 @@ async function generateComponentRegistry() {
           for (const sub of doc.components) {
             const subName = (sub.name || '').replace(/^XDS/, '');
             if (!subName) continue;
-            // Determine subComponentOf: if explicitly set on the doc, use that.
-            // Otherwise, sub-entries whose name differs from the doc name are
-            // sub-components of the doc's primary component.
+            // Sub-entries whose name differs from the doc name are
+            // sub-components — hide them from the overview page.
             const isSubEntry = subName !== doc.name;
-            const resolvedSubComponentOf = subComponentOf || (isSubEntry ? doc.name : null);
             pendingSubComponents.push({
               name: subName,
               displayName: requireDisplayName(
@@ -311,7 +309,7 @@ async function generateComponentRegistry() {
               directory: entry.name,
               group,
               category,
-              subComponentOf: resolvedSubComponentOf,
+              isHiddenFromOverview: isHiddenFromOverview || isSubEntry,
               description: sub.description || topDescription,
               keywords,
               hidden,
@@ -340,7 +338,7 @@ async function generateComponentRegistry() {
             directory: entry.name,
             group,
             category,
-            subComponentOf,
+            isHiddenFromOverview,
             description: topDescription,
             keywords,
             hidden,
@@ -368,7 +366,7 @@ async function generateComponentRegistry() {
             directory: entry.name,
             group,
             category,
-            subComponentOf,
+            isHiddenFromOverview,
             description: topDescription,
             keywords,
             hidden,
@@ -488,8 +486,8 @@ export interface ComponentEntry {
   group: string | null;
   /** Functional category for the overview gallery (Actions, Inputs, etc.) */
   category: string | null;
-  /** Parent component name if this is a sub-component. */
-  subComponentOf: string | null;
+  /** Whether this component is hidden from the overview page. */
+  isHiddenFromOverview: boolean;
   description: string;
   keywords: string[];
   hidden: boolean;

--- a/apps/docsite/scripts/generate-data.mjs
+++ b/apps/docsite/scripts/generate-data.mjs
@@ -68,6 +68,8 @@ const HIDDEN_RE = /(?:^|\n) {0,4}hidden:\s*true/;
 const NAME_RE = /(?:^|\n) {0,4}name:\s*['"]([^'"]+)['"]/;
 const DISPLAY_NAME_RE = /(?:^|\n) {0,4}displayName:\s*['"]([^'"]+)['"]/;
 const KEYWORDS_RE = /keywords:\s*\[([^\]]*)\]/;
+const CATEGORY_RE = /(?:^|\n) {0,4}category:\s*['"]([^'"]+)['"]/;
+const SUB_COMPONENT_OF_RE = /(?:^|\n) {0,4}subComponentOf:\s*['"]([^'"]+)['"]/;
 
 function readDocMeta(docPath) {
   try {
@@ -81,6 +83,8 @@ function readDocMeta(docPath) {
     const keywords = kwMatch
       ? [...kwMatch[1].matchAll(/['"]([^'"]+)['"]/g)].map(m => m[1])
       : [];
+    const categoryMatch = CATEGORY_RE.exec(content);
+    const subComponentOfMatch = SUB_COMPONENT_OF_RE.exec(content);
     return {
       group: groupMatch?.[1] ?? null,
       description: descMatch?.[1] ?? '',
@@ -88,9 +92,11 @@ function readDocMeta(docPath) {
       displayName: displayNameMatch?.[1] ?? null,
       hidden,
       keywords,
+      category: categoryMatch?.[1] ?? null,
+      subComponentOf: subComponentOfMatch?.[1] ?? null,
     };
   } catch {
-    return {group: null, description: '', name: null, displayName: null, hidden: false, keywords: []};
+    return {group: null, description: '', name: null, displayName: null, hidden: false, keywords: [], category: null, subComponentOf: null};
   }
 }
 
@@ -277,6 +283,8 @@ async function generateComponentRegistry() {
         }
 
         const group = doc.group || null;
+        const category = doc.category || null;
+        const subComponentOf = doc.subComponentOf || null;
         const keywords = doc.keywords || [];
         const hidden = doc.hidden ?? false;
         const topDescription = doc.usage?.description || doc.description || '';
@@ -288,6 +296,11 @@ async function generateComponentRegistry() {
           for (const sub of doc.components) {
             const subName = (sub.name || '').replace(/^XDS/, '');
             if (!subName) continue;
+            // Determine subComponentOf: if explicitly set on the doc, use that.
+            // Otherwise, sub-entries whose name differs from the doc name are
+            // sub-components of the doc's primary component.
+            const isSubEntry = subName !== doc.name;
+            const resolvedSubComponentOf = subComponentOf || (isSubEntry ? doc.name : null);
             pendingSubComponents.push({
               name: subName,
               displayName: requireDisplayName(
@@ -297,6 +310,8 @@ async function generateComponentRegistry() {
               moduleName: sub.name || subName,
               directory: entry.name,
               group,
+              category,
+              subComponentOf: resolvedSubComponentOf,
               description: sub.description || topDescription,
               keywords,
               hidden,
@@ -324,6 +339,8 @@ async function generateComponentRegistry() {
             moduleName: name,
             directory: entry.name,
             group,
+            category,
+            subComponentOf,
             description: topDescription,
             keywords,
             hidden,
@@ -350,6 +367,8 @@ async function generateComponentRegistry() {
             moduleName: name.startsWith('use') ? name : `XDS${name}`,
             directory: entry.name,
             group,
+            category,
+            subComponentOf,
             description: topDescription,
             keywords,
             hidden,
@@ -467,6 +486,10 @@ export interface ComponentEntry {
   moduleName: string;
   directory: string;
   group: string | null;
+  /** Functional category for the overview gallery (Actions, Inputs, etc.) */
+  category: string | null;
+  /** Parent component name if this is a sub-component. */
+  subComponentOf: string | null;
   description: string;
   keywords: string[];
   hidden: boolean;

--- a/apps/docsite/src/app/(docs)/components/page.tsx
+++ b/apps/docsite/src/app/(docs)/components/page.tsx
@@ -145,7 +145,7 @@ export default function ComponentsGalleryPage() {
           isLabelHidden
           value={query}
           onChange={setQuery}
-          placeholder="Search components\u2026"
+          placeholder="Search components…"
           startIcon={MagnifyingGlassIcon}
           hasClear
         />

--- a/apps/docsite/src/app/(docs)/components/page.tsx
+++ b/apps/docsite/src/app/(docs)/components/page.tsx
@@ -6,21 +6,49 @@
 
 'use client';
 
-import {useMemo} from 'react';
+import {useMemo, useState} from 'react';
 import * as stylex from '@stylexjs/stylex';
+import {MagnifyingGlassIcon} from '@heroicons/react/24/outline';
 import {XDSText} from '@xds/core/Text';
+import {XDSHeading} from '@xds/core/Text';
 import {XDSVStack} from '@xds/core/Layout';
 import {XDSSection} from '@xds/core/Section';
 import {XDSGrid} from '@xds/core/Grid';
 import {XDSClickableCard} from '@xds/core/ClickableCard';
+import {XDSTextInput} from '@xds/core/TextInput';
+import {XDSDivider} from '@xds/core/Divider';
+import {components as componentRegistry} from '../../../generated/componentRegistry';
 import {blocks} from '../../../generated/blockRegistry';
 import {ShowcaseThumbnail} from '../../../components/ShowcaseThumbnail';
 
-const showcases = blocks.filter(b => b.isShowcase);
+/**
+ * Category display order for the overview page.
+ * Sourced from component .doc.mjs `category` fields.
+ */
+const CATEGORIES = [
+  'Actions',
+  'Communications',
+  'Containers',
+  'Layout',
+  'Inputs',
+  'Lists',
+  'Navigation',
+  'Performance',
+] as const;
+
+/** Map of showcase blocks by component name for thumbnails */
+const showcaseMap = new Map(
+  blocks
+    .filter(b => b.isShowcase)
+    .map(b => [b.componentsUsed[0] || b.exampleFor, b]),
+);
 
 const styles = stylex.create({
   heroTitle: {
     textAlign: 'center' as const,
+  },
+  categorySection: {
+    paddingBlock: 'var(--spacing-4)',
   },
   cardImage: {
     display: 'block',
@@ -31,18 +59,73 @@ const styles = stylex.create({
   },
 });
 
+interface CategoryItem {
+  name: string;
+  displayName: string;
+  description: string;
+  href: string;
+  category: string;
+  /** Showcase block for thumbnail, if available */
+  showcase: (typeof blocks)[number] | undefined;
+}
+
 export default function ComponentsGalleryPage() {
-  const items = useMemo(
-    () =>
-      showcases.map(b => ({
-        name: b.displayName,
-        description: b.description,
-        slug: b.dirName,
-        category: b.category,
-        href: `/components/${b.componentsUsed[0] || b.category.split('/').pop()}`,
-      })),
-    [],
-  );
+  const [query, setQuery] = useState('');
+
+  /** All categorized components (excluding hidden, hooks, and utilities) */
+  const categorizedItems = useMemo(() => {
+    const coreComponents = componentRegistry['@xds/core'] ?? [];
+    const items: CategoryItem[] = [];
+
+    for (const comp of coreComponents) {
+      // Skip components explicitly hidden from overview
+      if (comp.isHiddenFromOverview) continue;
+      // Skip hidden components
+      if (comp.hidden) continue;
+      // Skip hooks (they appear in the Utilities section)
+      if (comp.name.startsWith('use')) continue;
+      // Skip components without a category
+      if (!comp.category) continue;
+      // Skip utilities group
+      if (comp.group === 'Utilities') continue;
+
+      items.push({
+        name: comp.name,
+        displayName: comp.displayName,
+        description: comp.description,
+        href: `/components/${comp.name}`,
+        category: comp.category,
+        showcase: showcaseMap.get(comp.name),
+      });
+    }
+
+    return items;
+  }, []);
+
+  /** Filtered items based on search query */
+  const filteredItems = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return categorizedItems;
+    return categorizedItems.filter(
+      item =>
+        item.name.toLowerCase().includes(q) ||
+        item.displayName.toLowerCase().includes(q) ||
+        item.description.toLowerCase().includes(q),
+    );
+  }, [categorizedItems, query]);
+
+  /** Group filtered items by category */
+  const groupedByCategory = useMemo(() => {
+    const map = new Map<string, CategoryItem[]>();
+    for (const cat of CATEGORIES) {
+      map.set(cat, []);
+    }
+    for (const item of filteredItems) {
+      const list = map.get(item.category);
+      if (list) list.push(item);
+    }
+    return map;
+  }, [filteredItems]);
 
   return (
     <XDSSection maxWidth="xl" padding={6}>
@@ -57,27 +140,53 @@ export default function ComponentsGalleryPage() {
           </XDSText>
         </XDSVStack>
 
-        <XDSGrid columns={{minWidth: 300, repeat: 'fill'}} gap={4} rowGap={6}>
-          {items.map(item => (
-            <XDSVStack key={item.slug} gap={2}>
-              <XDSClickableCard
-                label={item.name}
-                href={item.href}
-                padding={0}
-                variant="transparent">
-                {item.category ? (
-                  <ShowcaseThumbnail
-                    dirName={item.slug}
-                    category={item.category}
-                  />
-                ) : (
-                  <div {...stylex.props(styles.cardImage)} />
-                )}
-              </XDSClickableCard>
-              <XDSText>{item.name}</XDSText>
+        <XDSTextInput
+          label="Search components"
+          isLabelHidden
+          value={query}
+          onChange={setQuery}
+          placeholder="Search components\u2026"
+          startIcon={MagnifyingGlassIcon}
+          hasClear
+        />
+
+        {CATEGORIES.map(cat => {
+          const items = groupedByCategory.get(cat) ?? [];
+          if (items.length === 0) return null;
+
+          return (
+            <XDSVStack key={cat} gap={4} xstyle={styles.categorySection}>
+              <XDSHeading level={2}>{cat}</XDSHeading>
+
+              <XDSGrid
+                columns={{minWidth: 280, repeat: 'fill'}}
+                gap={4}
+                rowGap={6}>
+                {items.map(item => (
+                  <XDSVStack key={item.name} gap={2}>
+                    <XDSClickableCard
+                      label={item.displayName}
+                      href={item.href}
+                      padding={0}
+                      variant="transparent">
+                      {item.showcase ? (
+                        <ShowcaseThumbnail
+                          dirName={item.showcase.dirName}
+                          category={item.showcase.category}
+                        />
+                      ) : (
+                        <div {...stylex.props(styles.cardImage)} />
+                      )}
+                    </XDSClickableCard>
+                    <XDSText type="supporting">{item.displayName}</XDSText>
+                  </XDSVStack>
+                ))}
+              </XDSGrid>
+
+              <XDSDivider />
             </XDSVStack>
-          ))}
-        </XDSGrid>
+          );
+        })}
       </XDSVStack>
     </XDSSection>
   );

--- a/packages/core/src/AlertDialog/AlertDialog.doc.mjs
+++ b/packages/core/src/AlertDialog/AlertDialog.doc.mjs
@@ -6,6 +6,7 @@ export const docs = {
   name: 'AlertDialog',
   displayName: 'Alert Dialog',
   group: 'Dialog',
+  category: 'Containers',
   keywords: [
     'alert',
     'alertdialog',

--- a/packages/core/src/AppShell/AppShell.doc.mjs
+++ b/packages/core/src/AppShell/AppShell.doc.mjs
@@ -5,6 +5,7 @@
 export const docs = {
   name: 'AppShell',
   displayName: 'App Shell',
+  category: 'Containers',
   keywords: ["appshell","layout","scaffold","sidebar","sidenav","topnav","header","navigation","dashboard","shell","page","frame"],
   usage: {
     description:

--- a/packages/core/src/AspectRatio/AspectRatio.doc.mjs
+++ b/packages/core/src/AspectRatio/AspectRatio.doc.mjs
@@ -5,6 +5,7 @@
 export const docs = {
   name: 'AspectRatio',
   displayName: 'Aspect Ratio',
+  category: 'Layout',
   keywords: ["aspect-ratio","ratio","proportion","responsive","embed","container","widescreen","thumbnail","letterbox","crop"],
   usage: {
     description:

--- a/packages/core/src/Avatar/Avatar.doc.mjs
+++ b/packages/core/src/Avatar/Avatar.doc.mjs
@@ -6,6 +6,7 @@ export const docs = {
   name: 'Avatar',
   displayName: 'Avatar',
   group: 'Avatar',
+  category: 'Communications',
   keywords: ["avatar","profile","user","photo","thumbnail","initials","gravatar","pfp","userpic"],
   usage: {
     description:

--- a/packages/core/src/AvatarGroup/AvatarGroup.doc.mjs
+++ b/packages/core/src/AvatarGroup/AvatarGroup.doc.mjs
@@ -5,6 +5,7 @@ export const docs = {
   name: 'AvatarGroup',
   displayName: 'Avatar Group',
   group: 'Avatar',
+  category: 'Communications',
   keywords: ['avatar', 'group', 'facepile', 'stack', 'overlap', 'participants', 'assignees', 'members', 'team'],
   usage: {
     description:

--- a/packages/core/src/Badge/Badge.doc.mjs
+++ b/packages/core/src/Badge/Badge.doc.mjs
@@ -5,6 +5,7 @@
 export const docs = {
   name: 'Badge',
   displayName: 'Badge',
+  category: 'Communications',
   keywords: ["badge","tag","chip","label","status","indicator","count","counter","pill","notification","marker"],
   props: [
     {

--- a/packages/core/src/Banner/Banner.doc.mjs
+++ b/packages/core/src/Banner/Banner.doc.mjs
@@ -5,6 +5,7 @@
 export const docs = {
   name: 'Banner',
   displayName: 'Banner',
+  category: 'Communications',
   keywords: ["banner","alert","notification","callout","notice","status","message","info","warning","error","success","toast"],
   usage: {
     description:

--- a/packages/core/src/Blockquote/Blockquote.doc.mjs
+++ b/packages/core/src/Blockquote/Blockquote.doc.mjs
@@ -7,6 +7,7 @@
 export const docs = {
   name: 'Blockquote',
   displayName: 'Blockquote',
+  category: 'Communications',
   keywords: ["blockquote","quote","citation","pullquote","quotation","cite","excerpt"],
   props: [
     {

--- a/packages/core/src/Breadcrumbs/Breadcrumbs.doc.mjs
+++ b/packages/core/src/Breadcrumbs/Breadcrumbs.doc.mjs
@@ -6,6 +6,7 @@ export const docs = {
   name: 'Breadcrumbs',
   displayName: 'Breadcrumbs',
   group: 'Breadcrumbs',
+  category: 'Navigation',
   keywords: ["breadcrumbs","breadcrumb","navigation","nav","crumbs","trail","path","hierarchy","wayfinding","steps"],
   usage: {
     description:

--- a/packages/core/src/Button/Button.doc.mjs
+++ b/packages/core/src/Button/Button.doc.mjs
@@ -6,6 +6,7 @@ export const docs = {
   name: 'Button',
   displayName: 'Button',
   group: 'Button',
+  category: 'Actions',
 
   keywords: ["button","btn","cta","submit","action","loading","primary","secondary","ghost","destructive","danger"],
 

--- a/packages/core/src/ButtonGroup/ButtonGroup.doc.mjs
+++ b/packages/core/src/ButtonGroup/ButtonGroup.doc.mjs
@@ -6,6 +6,7 @@ export const docs = {
   name: 'ButtonGroup',
   displayName: 'Button Group',
   group: 'Button',
+  category: 'Actions',
   keywords: ["button-group","connected","split","toolbar","actions","grouped","buttons"],
   playground: {
     defaults: {

--- a/packages/core/src/Calendar/Calendar.doc.mjs
+++ b/packages/core/src/Calendar/Calendar.doc.mjs
@@ -5,6 +5,7 @@
 export const docs = {
   name: 'Calendar',
   displayName: 'Calendar',
+  category: 'Inputs',
   keywords: ["calendar","datepicker","date picker","rangepicker","date range","monthview","daypicker"],
   usage: {
     description:

--- a/packages/core/src/Card/Card.doc.mjs
+++ b/packages/core/src/Card/Card.doc.mjs
@@ -6,6 +6,7 @@ export const docs = {
   name: 'Card',
   displayName: 'Card',
   group: 'Card',
+  category: 'Containers',
   keywords: ["card","surface","panel","container","elevated","shadow","box","paper","tile","well"],
   usage: {
     description:

--- a/packages/core/src/Carousel/Carousel.doc.mjs
+++ b/packages/core/src/Carousel/Carousel.doc.mjs
@@ -5,6 +5,7 @@
 export const docs = {
   name: 'Carousel',
   displayName: 'Carousel',
+  category: 'Lists',
   keywords: ['carousel', 'slider', 'scroll', 'gallery', 'filmstrip', 'swiper', 'horizontal', 'overflow', 'snap'],
   usage: {
     description:

--- a/packages/core/src/Center/Center.doc.mjs
+++ b/packages/core/src/Center/Center.doc.mjs
@@ -6,6 +6,7 @@ export const docs = {
   name: 'Center',
   displayName: 'Center',
   group: 'Layout',
+  category: 'Layout',
   keywords: ["center","centered","centering","align","alignment","justify","flexbox","middle"],
   props: [
     {

--- a/packages/core/src/Chat/Chat.doc.mjs
+++ b/packages/core/src/Chat/Chat.doc.mjs
@@ -6,6 +6,7 @@ export const docs = {
   name: 'Chat',
   displayName: 'Chat',
   group: 'Chat',
+  category: 'Communications',
   keywords: ['chat', 'message', 'bubble', 'conversation', 'ai', 'assistant', 'thread', 'system-message', 'composer', 'mention', 'trigger', 'typeahead', 'token', 'imperative', 'tokenized-text'],
   theming: {
     targets: [

--- a/packages/core/src/Chat/ChatDictationButton.doc.mjs
+++ b/packages/core/src/Chat/ChatDictationButton.doc.mjs
@@ -6,6 +6,8 @@ export const docs = {
   name: 'ChatDictationButton',
   displayName: 'Chat Dictation Button',
   group: 'Chat',
+  category: 'Communications',
+  subComponentOf: 'Chat',
   hidden: false,
 
   keywords: ['dictation', 'microphone', 'voice', 'speech', 'recording', 'stt', 'speech-to-text', 'voice-input', 'mic'],

--- a/packages/core/src/Chat/ChatDictationButton.doc.mjs
+++ b/packages/core/src/Chat/ChatDictationButton.doc.mjs
@@ -7,7 +7,7 @@ export const docs = {
   displayName: 'Chat Dictation Button',
   group: 'Chat',
   category: 'Communications',
-  subComponentOf: 'Chat',
+  isHiddenFromOverview: true,
   hidden: false,
 
   keywords: ['dictation', 'microphone', 'voice', 'speech', 'recording', 'stt', 'speech-to-text', 'voice-input', 'mic'],

--- a/packages/core/src/Chat/ChatToolCalls.doc.mjs
+++ b/packages/core/src/Chat/ChatToolCalls.doc.mjs
@@ -6,6 +6,8 @@ export const docs = {
   name: 'ChatToolCalls',
   displayName: 'Chat Tool Calls',
   group: 'Chat',
+  category: 'Communications',
+  subComponentOf: 'Chat',
 
   keywords: ['tool', 'function', 'call', 'invocation', 'llm', 'agent', 'bash', 'edit', 'read', 'search', 'status', 'running', 'error', 'complete', 'diff', 'stats'],
 

--- a/packages/core/src/Chat/ChatToolCalls.doc.mjs
+++ b/packages/core/src/Chat/ChatToolCalls.doc.mjs
@@ -7,7 +7,7 @@ export const docs = {
   displayName: 'Chat Tool Calls',
   group: 'Chat',
   category: 'Communications',
-  subComponentOf: 'Chat',
+  isHiddenFromOverview: true,
 
   keywords: ['tool', 'function', 'call', 'invocation', 'llm', 'agent', 'bash', 'edit', 'read', 'search', 'status', 'running', 'error', 'complete', 'diff', 'stats'],
 

--- a/packages/core/src/CheckboxInput/CheckboxInput.doc.mjs
+++ b/packages/core/src/CheckboxInput/CheckboxInput.doc.mjs
@@ -6,6 +6,7 @@ export const docs = {
   name: 'CheckboxInput',
   displayName: 'Checkbox Input',
   group: 'Checkbox',
+  category: 'Inputs',
   keywords: ["checkbox","check","toggle","tick","indeterminate","boolean","tristate"],
   props: [
     {

--- a/packages/core/src/CheckboxList/CheckboxList.doc.mjs
+++ b/packages/core/src/CheckboxList/CheckboxList.doc.mjs
@@ -6,6 +6,7 @@ export const docs = {
   name: 'CheckboxList',
   displayName: 'Checkbox List',
   group: 'Checkbox',
+  category: 'Inputs',
   keywords: ["checkboxlist","checkbox","checkboxgroup","multichoice","multiselect","checklist"],
   components: [
     {

--- a/packages/core/src/ClickableCard/ClickableCard.doc.mjs
+++ b/packages/core/src/ClickableCard/ClickableCard.doc.mjs
@@ -5,6 +5,7 @@ export const docs = {
   name: 'ClickableCard',
   displayName: 'Clickable Card',
   group: 'Card',
+  category: 'Actions',
   keywords: ['card', 'clickable', 'interactive', 'navigation', 'action', 'link'],
   usage: {
     description: 'An interactive card for navigation or action targets. Nested interactive elements work independently.',

--- a/packages/core/src/CodeBlock/CodeBlock.doc.mjs
+++ b/packages/core/src/CodeBlock/CodeBlock.doc.mjs
@@ -4,6 +4,7 @@
 export const docs = {
   name: 'CodeBlock',
   displayName: 'Code Block',
+  category: 'Communications',
   keywords: [
     'code', 'syntax', 'highlight', 'snippet', 'prism', 'shiki',
     'pre', 'monospace', 'codeblock', 'inline',

--- a/packages/core/src/Collapsible/Collapsible.doc.mjs
+++ b/packages/core/src/Collapsible/Collapsible.doc.mjs
@@ -6,6 +6,7 @@ export const docs = {
   name: 'Collapsible',
   displayName: 'Collapsible',
   group: 'Collapsible',
+  category: 'Containers',
   keywords: ["accordion","collapse","expandable","disclosure","toggle","panel","foldable","expander","expand"],
   playground: {
     defaults: {

--- a/packages/core/src/CommandPalette/CommandPalette.doc.mjs
+++ b/packages/core/src/CommandPalette/CommandPalette.doc.mjs
@@ -5,6 +5,7 @@ export const docs = {
   name: 'CommandPalette',
   displayName: 'Command Palette',
   group: 'CommandPalette',
+  category: 'Actions',
   keywords: [
     'command',
     'spotlight',

--- a/packages/core/src/ContextMenu/ContextMenu.doc.mjs
+++ b/packages/core/src/ContextMenu/ContextMenu.doc.mjs
@@ -5,6 +5,7 @@ export const docs = {
   name: 'ContextMenu',
   displayName: 'Context Menu',
   group: 'ContextMenu',
+  category: 'Actions',
   keywords: ["contextmenu","right-click","menu","popover","actions","context"],
   theming: {
     targets: [

--- a/packages/core/src/DateInput/DateInput.doc.mjs
+++ b/packages/core/src/DateInput/DateInput.doc.mjs
@@ -6,6 +6,7 @@ export const docs = {
   name: 'DateInput',
   displayName: 'Date Input',
   group: 'DateInput',
+  category: 'Inputs',
   keywords: ["dateinput","datepicker","datefield","calendar","dateselect","dateentry","datechooser"],
   props: [
     {

--- a/packages/core/src/DateRangeInput/DateRangeInput.doc.mjs
+++ b/packages/core/src/DateRangeInput/DateRangeInput.doc.mjs
@@ -6,6 +6,7 @@ export const docs = {
   name: 'DateRangeInput',
   displayName: 'Date Range Input',
   group: 'DateInput',
+  category: 'Inputs',
   keywords: ["daterangepicker","daterange","range","calendar","filter","analytics","period","schedule"],
   props: [
     { name: 'label', type: 'string', description: 'Label text.', required: true },

--- a/packages/core/src/DateTimeInput/DateTimeInput.doc.mjs
+++ b/packages/core/src/DateTimeInput/DateTimeInput.doc.mjs
@@ -6,6 +6,7 @@ export const docs = {
   name: 'DateTimeInput',
   displayName: 'Date Time Input',
   group: 'DateInput',
+  category: 'Inputs',
   keywords: ["datetimepicker","datetime","datepicker","timepicker","calendar","schedule","event","deadline","timestamp"],
   props: [
     {

--- a/packages/core/src/Dialog/Dialog.doc.mjs
+++ b/packages/core/src/Dialog/Dialog.doc.mjs
@@ -6,6 +6,7 @@ export const docs = {
   name: 'Dialog',
   displayName: 'Dialog',
   group: 'Dialog',
+  category: 'Containers',
   keywords: ["dialog","modal","popup","overlay","lightbox","alert","confirm","prompt","backdrop","focus trap","imperative"],
   playground: {
     defaults: {

--- a/packages/core/src/Divider/Divider.doc.mjs
+++ b/packages/core/src/Divider/Divider.doc.mjs
@@ -7,6 +7,7 @@
 export const docs = {
   name: 'Divider',
   displayName: 'Divider',
+  category: 'Layout',
   keywords: ["divider","separator","hr","rule","line","border","spacer","horizontal rule"],
   props: [
     {

--- a/packages/core/src/DropdownMenu/DropdownMenu.doc.mjs
+++ b/packages/core/src/DropdownMenu/DropdownMenu.doc.mjs
@@ -6,6 +6,7 @@ export const docs = {
   name: 'DropdownMenu',
   displayName: 'Dropdown Menu',
   group: 'DropdownMenu',
+  category: 'Actions',
   keywords: ["dropdown","menu","popover","select","actions","contextmenu","overflow","kebab","menubutton"],
   theming: {
     targets: [

--- a/packages/core/src/EmptyState/EmptyState.doc.mjs
+++ b/packages/core/src/EmptyState/EmptyState.doc.mjs
@@ -5,6 +5,7 @@
 export const docs = {
   name: 'EmptyState',
   displayName: 'Empty State',
+  category: 'Communications',
   keywords: ["emptystate","empty","placeholder","nodata","blank","noresults","illustration","blankslate"],
   props: [
     {

--- a/packages/core/src/Field/Field.doc.mjs
+++ b/packages/core/src/Field/Field.doc.mjs
@@ -6,6 +6,7 @@ export const docs = {
   name: 'Field',
   displayName: 'Field',
   group: 'Field',
+  category: 'Inputs',
   keywords: ["field","formfield","formgroup","formcontrol","label","input","required","optional","helpertext","hint"],
   playground: {
     defaults: {

--- a/packages/core/src/FileInput/FileInput.doc.mjs
+++ b/packages/core/src/FileInput/FileInput.doc.mjs
@@ -5,6 +5,7 @@
 export const docs = {
   name: 'FileInput',
   displayName: 'File Input',
+  category: 'Inputs',
   keywords: ["fileinput","file","upload","drag","drop","dropzone","attachment","browse"],
   props: [
     {

--- a/packages/core/src/FormLayout/FormLayout.doc.mjs
+++ b/packages/core/src/FormLayout/FormLayout.doc.mjs
@@ -6,6 +6,7 @@ export const docs = {
   name: 'FormLayout',
   displayName: 'Form Layout',
   group: 'Layout',
+  category: 'Layout',
   keywords: ["formlayout","form","fieldset","formgroup","formcontainer","fields","vertical","horizontal"],
   props: [
     {

--- a/packages/core/src/Grid/Grid.doc.mjs
+++ b/packages/core/src/Grid/Grid.doc.mjs
@@ -6,6 +6,7 @@ export const docs = {
   name: 'Grid',
   displayName: 'Grid',
   group: 'Layout',
+  category: 'Layout',
   keywords: ["grid","columns","responsive","auto-fill","auto-fit","masonry","tiles","row","col","simplegrid","responsive grid","card grid"],
   usage: {
     description:

--- a/packages/core/src/HoverCard/HoverCard.doc.mjs
+++ b/packages/core/src/HoverCard/HoverCard.doc.mjs
@@ -6,6 +6,7 @@ export const docs = {
   name: 'HoverCard',
   displayName: 'Hover Card',
   group: 'HoverCard',
+  category: 'Communications',
   keywords: ["hovercard","hover card","popover","tooltip","preview card","flyout","overlay","hover popup"],
   playground: {
     defaults: {

--- a/packages/core/src/Icon/Icon.doc.mjs
+++ b/packages/core/src/Icon/Icon.doc.mjs
@@ -5,6 +5,7 @@
 export const docs = {
   name: 'Icon',
   displayName: 'Icon',
+  category: 'Communications',
   keywords: ["icon","svg","glyph","symbol","pictogram","graphic","vector"],
   props: [
     {

--- a/packages/core/src/IconButton/IconButton.doc.mjs
+++ b/packages/core/src/IconButton/IconButton.doc.mjs
@@ -6,6 +6,7 @@ export const docs = {
   name: 'IconButton',
   displayName: 'Icon Button',
   group: 'Button',
+  category: 'Actions',
   keywords: ['icon-button', 'icon', 'button', 'toolbar', 'action', 'compact'],
 
   props: [

--- a/packages/core/src/InputGroup/InputGroup.doc.mjs
+++ b/packages/core/src/InputGroup/InputGroup.doc.mjs
@@ -6,6 +6,7 @@ export const docs = {
   name: 'InputGroup',
   displayName: 'Input Group',
   group: 'Field',
+  category: 'Inputs',
   keywords: ["inputgroup","addon","prefix","suffix","connected","grouped","input"],
   theming: {
     targets: [

--- a/packages/core/src/Item/Item.doc.mjs
+++ b/packages/core/src/Item/Item.doc.mjs
@@ -6,6 +6,7 @@ export const docs = {
   name: 'Item',
   displayName: 'Item',
   group: 'Item',
+  category: 'Lists',
   keywords: ["item","list-item","media-object","row","cell","entity","contact","notification","preview"],
   playground: {
     defaults: {

--- a/packages/core/src/Kbd/Kbd.doc.mjs
+++ b/packages/core/src/Kbd/Kbd.doc.mjs
@@ -5,6 +5,7 @@
 export const docs = {
   name: 'Kbd',
   displayName: 'Kbd',
+  category: 'Communications',
   keywords: ["kbd","keyboard","shortcut","hotkey","keybinding","keystroke","keycombo","modifier","accelerator"],
   props: [
     {

--- a/packages/core/src/Layout/Layout.doc.mjs
+++ b/packages/core/src/Layout/Layout.doc.mjs
@@ -6,6 +6,7 @@ export const docs = {
   name: 'Layout',
   displayName: 'Layout',
   group: 'Layout',
+  category: 'Layout',
   keywords: ["layout","container","content","flex","box","wrapper","scaffold","page","shell"],
   playground: {
     defaults: {

--- a/packages/core/src/Lightbox/Lightbox.doc.mjs
+++ b/packages/core/src/Lightbox/Lightbox.doc.mjs
@@ -5,6 +5,7 @@
 export const docs = {
   name: 'Lightbox',
   displayName: 'Lightbox',
+  category: 'Containers',
   keywords: ["lightbox","image","video","viewer","gallery","zoom","fullscreen","media","photo","preview"],
   props: [
     {

--- a/packages/core/src/Link/Link.doc.mjs
+++ b/packages/core/src/Link/Link.doc.mjs
@@ -5,6 +5,7 @@
 export const docs = {
   name: 'Link',
   displayName: 'Link',
+  category: 'Actions',
   keywords: ["link","anchor","href","hyperlink","navigation","url","external","textlink"],
   playground: {
     defaults: {

--- a/packages/core/src/Link/LinkProvider.doc.mjs
+++ b/packages/core/src/Link/LinkProvider.doc.mjs
@@ -6,7 +6,7 @@ export const docs = {
   name: 'LinkProvider',
   displayName: 'Link Provider',
   group: 'Utilities',
-  subComponentOf: 'Link',
+  isHiddenFromOverview: true,
   keywords: ['link', 'provider', 'router', 'nextjs', 'client-side-routing'],
   usage: {
     description: 'Wraps your app to replace the default <a> tag with a framework-specific link component (e.g. Next.js Link) for client-side routing across all XDS components.',

--- a/packages/core/src/Link/LinkProvider.doc.mjs
+++ b/packages/core/src/Link/LinkProvider.doc.mjs
@@ -6,6 +6,7 @@ export const docs = {
   name: 'LinkProvider',
   displayName: 'Link Provider',
   group: 'Utilities',
+  subComponentOf: 'Link',
   keywords: ['link', 'provider', 'router', 'nextjs', 'client-side-routing'],
   usage: {
     description: 'Wraps your app to replace the default <a> tag with a framework-specific link component (e.g. Next.js Link) for client-side routing across all XDS components.',

--- a/packages/core/src/List/List.doc.mjs
+++ b/packages/core/src/List/List.doc.mjs
@@ -6,6 +6,7 @@ export const docs = {
   name: 'List',
   displayName: 'List',
   group: 'List',
+  category: 'Lists',
   keywords: ["list","listitem","listbox","menu","collection","items","ul","navlist"],
   theming: {
     targets: [

--- a/packages/core/src/Markdown/Markdown.doc.mjs
+++ b/packages/core/src/Markdown/Markdown.doc.mjs
@@ -5,6 +5,7 @@
 export const docs = {
   name: 'Markdown',
   displayName: 'Markdown',
+  category: 'Communications',
   keywords: [
     'markdown',
     'rich text',

--- a/packages/core/src/MetadataList/MetadataList.doc.mjs
+++ b/packages/core/src/MetadataList/MetadataList.doc.mjs
@@ -6,6 +6,7 @@ export const docs = {
   name: 'MetadataList',
   displayName: 'Metadata List',
   group: 'MetadataList',
+  category: 'Lists',
   keywords: ["metadata","description","definition","keyvalue","properties","details","attributes","summary"],
   theming: {
     targets: [

--- a/packages/core/src/MobileNav/MobileNav.doc.mjs
+++ b/packages/core/src/MobileNav/MobileNav.doc.mjs
@@ -6,6 +6,7 @@ export const docs = {
   name: 'MobileNav',
   displayName: 'Mobile Nav',
   group: 'MobileNav',
+  category: 'Navigation',
   keywords: ["mobilenav","drawer","sidebar","navigation","hamburger","menu","offcanvas","slideout","navdrawer"],
   props: [
     {

--- a/packages/core/src/MoreMenu/MoreMenu.doc.mjs
+++ b/packages/core/src/MoreMenu/MoreMenu.doc.mjs
@@ -5,6 +5,7 @@
 export const docs = {
   name: 'MoreMenu',
   displayName: 'More Menu',
+  category: 'Actions',
   keywords: ["moremenu","overflow","kebab","dotmenu","threedot","ellipsis","dropdown","contextmenu","actionmenu"],
   props: [
     {

--- a/packages/core/src/MultiSelector/MultiSelector.doc.mjs
+++ b/packages/core/src/MultiSelector/MultiSelector.doc.mjs
@@ -6,6 +6,7 @@ export const docs = {
   name: 'MultiSelector',
   displayName: 'Multi Selector',
   group: 'Selector',
+  category: 'Inputs',
   keywords: ['multiselect', 'checkbox', 'dropdown', 'multi', 'picker', 'checklist', 'facet', 'filter', 'select'],
   theming: {
     targets: [

--- a/packages/core/src/NavIcon/NavIcon.doc.mjs
+++ b/packages/core/src/NavIcon/NavIcon.doc.mjs
@@ -5,6 +5,8 @@
 export const docs = {
   name: 'NavIcon',
   displayName: 'Nav Icon',
+  category: 'Navigation',
+  subComponentOf: 'TopNav',
   hidden: false,
   keywords: ["navicon","iconbutton","toolbar icon","appbar icon","nav button"],
   props: [

--- a/packages/core/src/NavIcon/NavIcon.doc.mjs
+++ b/packages/core/src/NavIcon/NavIcon.doc.mjs
@@ -6,7 +6,7 @@ export const docs = {
   name: 'NavIcon',
   displayName: 'Nav Icon',
   category: 'Navigation',
-  subComponentOf: 'TopNav',
+  isHiddenFromOverview: true,
   hidden: false,
   keywords: ["navicon","iconbutton","toolbar icon","appbar icon","nav button"],
   props: [

--- a/packages/core/src/NavMenu/NavMenu.doc.mjs
+++ b/packages/core/src/NavMenu/NavMenu.doc.mjs
@@ -6,7 +6,7 @@ export const docs = {
   name: 'NavHeadingMenu',
   displayName: 'Nav Heading Menu',
   category: 'Navigation',
-  subComponentOf: 'TopNav',
+  isHiddenFromOverview: true,
   hidden: false,
   keywords: ['nav', 'menu', 'navigation', 'heading', 'menu-item', 'popover'],
   usage: {

--- a/packages/core/src/NavMenu/NavMenu.doc.mjs
+++ b/packages/core/src/NavMenu/NavMenu.doc.mjs
@@ -5,6 +5,8 @@
 export const docs = {
   name: 'NavHeadingMenu',
   displayName: 'Nav Heading Menu',
+  category: 'Navigation',
+  subComponentOf: 'TopNav',
   hidden: false,
   keywords: ['nav', 'menu', 'navigation', 'heading', 'menu-item', 'popover'],
   usage: {

--- a/packages/core/src/NumberInput/NumberInput.doc.mjs
+++ b/packages/core/src/NumberInput/NumberInput.doc.mjs
@@ -5,6 +5,7 @@
 export const docs = {
   name: 'NumberInput',
   displayName: 'Number Input',
+  category: 'Inputs',
   keywords: ["numberinput","numberfield","stepper","spinner","counter","increment","decrement","quantity","numberpicker"],
   props: [
     {

--- a/packages/core/src/Outline/Outline.doc.mjs
+++ b/packages/core/src/Outline/Outline.doc.mjs
@@ -6,6 +6,7 @@ export const docs = {
   name: 'Outline',
   displayName: 'Outline',
   group: 'Outline',
+  category: 'Navigation',
   keywords: [
     'outline',
     'table of contents',

--- a/packages/core/src/OverflowList/OverflowList.doc.mjs
+++ b/packages/core/src/OverflowList/OverflowList.doc.mjs
@@ -5,6 +5,7 @@
 export const docs = {
   name: 'OverflowList',
   displayName: 'Overflow List',
+  category: 'Lists',
   keywords: [
     'overflow',
     'truncate',

--- a/packages/core/src/Pagination/Pagination.doc.mjs
+++ b/packages/core/src/Pagination/Pagination.doc.mjs
@@ -5,6 +5,7 @@
 export const docs = {
   name: 'Pagination',
   displayName: 'Pagination',
+  category: 'Navigation',
   keywords: ["pagination","pager","paginator","pagenavigation","paging","paginate","pages","pagecontrol"],
   props: [
     {

--- a/packages/core/src/Popover/Popover.doc.mjs
+++ b/packages/core/src/Popover/Popover.doc.mjs
@@ -6,6 +6,7 @@ export const docs = {
   name: 'Popover',
   displayName: 'Popover',
   group: 'Popover',
+  category: 'Communications',
   keywords: ["popover","popup","dropdown","tooltip","overlay","flyout","callout","popper","anchor","floating","bubble"],
   components: [
     {

--- a/packages/core/src/PowerSearch/PowerSearch.doc.mjs
+++ b/packages/core/src/PowerSearch/PowerSearch.doc.mjs
@@ -5,6 +5,7 @@
 export const docs = {
   name: 'PowerSearch',
   displayName: 'Power Search',
+  category: 'Inputs',
   keywords: ["powersearch","search","searchbar","filter","filterbar","faceted","querybuilder","structured","omnibar"],
   props: [
     {

--- a/packages/core/src/ProgressBar/ProgressBar.doc.mjs
+++ b/packages/core/src/ProgressBar/ProgressBar.doc.mjs
@@ -5,6 +5,7 @@
 export const docs = {
   name: 'ProgressBar',
   displayName: 'Progress Bar',
+  category: 'Performance',
   keywords: ["progressbar","progress","loader","loading","linear","determinate","indeterminate","meter"],
   props: [
     {

--- a/packages/core/src/RadioList/RadioList.doc.mjs
+++ b/packages/core/src/RadioList/RadioList.doc.mjs
@@ -6,6 +6,7 @@ export const docs = {
   name: 'RadioList',
   displayName: 'Radio List',
   group: 'Radio',
+  category: 'Inputs',
   keywords: ["radiolist","radio","radiogroup","radiobutton","optionlist","singlechoice","choicelist"],
   theming: {
     targets: [

--- a/packages/core/src/Resizable/Resizable.doc.mjs
+++ b/packages/core/src/Resizable/Resizable.doc.mjs
@@ -5,6 +5,7 @@ export const docs = {
   name: 'Resizable',
   displayName: 'Resizable',
   group: 'Resizable',
+  category: 'Layout',
   keywords: [
     'resize',
     'resizable',

--- a/packages/core/src/Section/Section.doc.mjs
+++ b/packages/core/src/Section/Section.doc.mjs
@@ -6,6 +6,7 @@ export const docs = {
   name: 'Section',
   displayName: 'Section',
   group: 'Layout',
+  category: 'Containers',
   keywords: ["section","panel","container","group","fieldset","region","block"],
   props: [
     {

--- a/packages/core/src/SegmentedControl/SegmentedControl.doc.mjs
+++ b/packages/core/src/SegmentedControl/SegmentedControl.doc.mjs
@@ -6,6 +6,7 @@ export const docs = {
   name: 'SegmentedControl',
   displayName: 'Segmented Control',
   group: 'SegmentedControl',
+  category: 'Inputs',
   keywords: ['radio', 'tabs', 'toggle', 'toggle-group', 'pill', 'button-group', 'switch', 'segment', 'control'],
   playground: {
     defaults: {

--- a/packages/core/src/SelectableCard/SelectableCard.doc.mjs
+++ b/packages/core/src/SelectableCard/SelectableCard.doc.mjs
@@ -5,6 +5,7 @@ export const docs = {
   name: 'SelectableCard',
   displayName: 'Selectable Card',
   group: 'Card',
+  category: 'Actions',
   keywords: ['card', 'selectable', 'toggle', 'checkbox', 'radio', 'selection'],
   usage: {
     description: 'A card that toggles between selected and unselected states with an accent border. For navigation use ClickableCard.',

--- a/packages/core/src/Selector/Selector.doc.mjs
+++ b/packages/core/src/Selector/Selector.doc.mjs
@@ -6,6 +6,7 @@ export const docs = {
   name: 'Selector',
   displayName: 'Selector',
   group: 'Selector',
+  category: 'Inputs',
   keywords: ["selector","select","dropdown","combobox","picker","listbox","chooser","autocomplete","option","selectmenu"],
   theming: {
     targets: [

--- a/packages/core/src/SideNav/SideNav.doc.mjs
+++ b/packages/core/src/SideNav/SideNav.doc.mjs
@@ -6,6 +6,7 @@ export const docs = {
   name: 'SideNav',
   displayName: 'Side Nav',
   group: 'SideNav',
+  category: 'Navigation',
   keywords: ["sidenav","sidebar","navigation","drawer","menu","nav","aside","sidemenu","navmenu","sider","treeview"],
   playground: {
     defaults: {

--- a/packages/core/src/Skeleton/Skeleton.doc.mjs
+++ b/packages/core/src/Skeleton/Skeleton.doc.mjs
@@ -5,6 +5,7 @@
 export const docs = {
   name: 'Skeleton',
   displayName: 'Skeleton',
+  category: 'Performance',
   keywords: ["skeleton","placeholder","loading","shimmer","pulse","loader","bone","ghost","preloader"],
   props: [
     {

--- a/packages/core/src/Slider/Slider.doc.mjs
+++ b/packages/core/src/Slider/Slider.doc.mjs
@@ -5,6 +5,7 @@
 export const docs = {
   name: 'Slider',
   displayName: 'Slider',
+  category: 'Inputs',
   keywords: ["slider","range","slidebar","trackbar","scrubber","knob","thumb","rangeslider"],
   playground: {
     defaults: {

--- a/packages/core/src/Spinner/Spinner.doc.mjs
+++ b/packages/core/src/Spinner/Spinner.doc.mjs
@@ -5,6 +5,7 @@
 export const docs = {
   name: 'Spinner',
   displayName: 'Spinner',
+  category: 'Performance',
   keywords: ["spinner","loader","loading","circular","progress","spin","activity","busy","indeterminate"],
   props: [
     {

--- a/packages/core/src/Stack/Stack.doc.mjs
+++ b/packages/core/src/Stack/Stack.doc.mjs
@@ -6,6 +6,7 @@ export const docs = {
   name: 'Stack',
   displayName: 'Stack',
   group: 'Layout',
+  category: 'Layout',
   keywords: ["stack","hstack","vstack","flexbox","flex","spacing","gap","horizontal","vertical","row","column"],
   theming: {
     targets: [

--- a/packages/core/src/StatusDot/StatusDot.doc.mjs
+++ b/packages/core/src/StatusDot/StatusDot.doc.mjs
@@ -5,6 +5,7 @@
 export const docs = {
   name: 'StatusDot',
   displayName: 'Status Dot',
+  category: 'Communications',
   keywords: ["statusdot","dot","indicator","status","signal","presence","availability","online","pip"],
   props: [
     {

--- a/packages/core/src/Switch/Switch.doc.mjs
+++ b/packages/core/src/Switch/Switch.doc.mjs
@@ -5,6 +5,7 @@
 export const docs = {
   name: 'Switch',
   displayName: 'Switch',
+  category: 'Inputs',
   keywords: ["switch","toggle","onoff","flipswitch","boolean","toggleswitch"],
   props: [
     {

--- a/packages/core/src/TabList/TabList.doc.mjs
+++ b/packages/core/src/TabList/TabList.doc.mjs
@@ -6,6 +6,7 @@ export const docs = {
   name: 'TabList',
   displayName: 'Tab List',
   group: 'Tabs',
+  category: 'Navigation',
   keywords: ["tabs","tabbar","tabstrip","navigation","tabpanel","tabgroup","segmented","navtabs","tab"],
   playground: {
     defaults: {

--- a/packages/core/src/Table/Table.doc.mjs
+++ b/packages/core/src/Table/Table.doc.mjs
@@ -6,6 +6,7 @@ export const docs = {
   name: 'Table',
   displayName: 'Table',
   group: 'Table',
+  category: 'Lists',
   keywords: ["table","datatable","datagrid","spreadsheet","sorting","virtualized","columns","rows","selection","pinning"],
   playground: {
     defaults: {

--- a/packages/core/src/Text/Text.doc.mjs
+++ b/packages/core/src/Text/Text.doc.mjs
@@ -5,6 +5,7 @@
 export const docs = {
   name: 'Text',
   displayName: 'Text',
+  category: 'Communications',
   keywords: ["text","typography","label","paragraph","heading","caption","font","body","subtitle"],
   playground: {
     defaults: {

--- a/packages/core/src/TextArea/TextArea.doc.mjs
+++ b/packages/core/src/TextArea/TextArea.doc.mjs
@@ -5,6 +5,7 @@
 export const docs = {
   name: 'TextArea',
   displayName: 'Text Area',
+  category: 'Inputs',
   keywords: ["textarea","textfield","multiline","comment","message","autoresize","autosize","charlimit"],
   props: [
     {

--- a/packages/core/src/TextInput/TextInput.doc.mjs
+++ b/packages/core/src/TextInput/TextInput.doc.mjs
@@ -5,6 +5,7 @@
 export const docs = {
   name: 'TextInput',
   displayName: 'Text Input',
+  category: 'Inputs',
   keywords: ["textinput","textfield","input","search","clearable","prefix","suffix","adornment","validation"],
   props: [
     {

--- a/packages/core/src/Thumbnail/Thumbnail.doc.mjs
+++ b/packages/core/src/Thumbnail/Thumbnail.doc.mjs
@@ -5,6 +5,7 @@
 export const docs = {
   name: 'Thumbnail',
   displayName: 'Thumbnail',
+  category: 'Communications',
   keywords: ["thumbnail","attachment","preview","image","upload","dismiss","remove","loading"],
   props: [
     {

--- a/packages/core/src/TimeInput/TimeInput.doc.mjs
+++ b/packages/core/src/TimeInput/TimeInput.doc.mjs
@@ -5,6 +5,7 @@
 export const docs = {
   name: 'TimeInput',
   displayName: 'Time Input',
+  category: 'Inputs',
   keywords: ["timeinput","timepicker","time","clock","hour","minute","ampm","timeselect","timefield","schedule"],
 
   usage: {

--- a/packages/core/src/Timestamp/Timestamp.doc.mjs
+++ b/packages/core/src/Timestamp/Timestamp.doc.mjs
@@ -5,6 +5,7 @@
 export const docs = {
   name: 'Timestamp',
   displayName: 'Timestamp',
+  category: 'Communications',
   keywords: ['date', 'time', 'datetime', 'relative', 'ago', 'clock', 'format', 'duration'],
   props: [
     {

--- a/packages/core/src/Toast/Toast.doc.mjs
+++ b/packages/core/src/Toast/Toast.doc.mjs
@@ -6,6 +6,7 @@ export const docs = {
   name: 'Toast',
   displayName: 'Toast',
   group: 'Toast',
+  category: 'Communications',
   hiddenComponents: ['ToastViewport'],
   keywords: ["toast","notification","snackbar","alert","message","feedback","status"],
 

--- a/packages/core/src/ToggleButton/ToggleButton.doc.mjs
+++ b/packages/core/src/ToggleButton/ToggleButton.doc.mjs
@@ -6,6 +6,7 @@ export const docs = {
   name: 'ToggleButton',
   displayName: 'Toggle Button',
   group: 'Button',
+  category: 'Actions',
   keywords: ["toggle","togglebutton","pressed","toolbar","formatting","segmented","button-group","exclusive","multi-select"],
   playground: {
     defaults: {

--- a/packages/core/src/Token/Token.doc.mjs
+++ b/packages/core/src/Token/Token.doc.mjs
@@ -5,6 +5,7 @@
 export const docs = {
   name: 'Token',
   displayName: 'Token',
+  category: 'Communications',
   keywords: ["token","chip","tag","pill","label","removable","dismissible","filter chip","closable"],
   props: [
     {

--- a/packages/core/src/Tokenizer/Tokenizer.doc.mjs
+++ b/packages/core/src/Tokenizer/Tokenizer.doc.mjs
@@ -5,6 +5,7 @@
 export const docs = {
   name: 'Tokenizer',
   displayName: 'Tokenizer',
+  category: 'Communications',
   keywords: ["tokenizer","multiselect","multi-select","chips","tags","combobox","autocomplete","taginput","chipinput"],
   props: [
     {

--- a/packages/core/src/Toolbar/Toolbar.doc.mjs
+++ b/packages/core/src/Toolbar/Toolbar.doc.mjs
@@ -5,6 +5,7 @@
 export const docs = {
   name: 'Toolbar',
   displayName: 'Toolbar',
+  category: 'Navigation',
   keywords: ['toolbar', 'nav', 'bar', 'actions', 'buttonbar', 'header', 'footer', 'action-bar', 'control-bar'],
   theming: {
     targets: [

--- a/packages/core/src/Tooltip/Tooltip.doc.mjs
+++ b/packages/core/src/Tooltip/Tooltip.doc.mjs
@@ -6,6 +6,7 @@ export const docs = {
   name: 'Tooltip',
   displayName: 'Tooltip',
   group: 'Tooltip',
+  category: 'Communications',
   playground: {
     defaults: {
       content: 'Helpful tooltip text',

--- a/packages/core/src/TopNav/TopNav.doc.mjs
+++ b/packages/core/src/TopNav/TopNav.doc.mjs
@@ -6,6 +6,7 @@ export const docs = {
   name: 'TopNav',
   displayName: 'Top Nav',
   group: 'TopNav',
+  category: 'Navigation',
   keywords: ["topnav","navbar","appbar","header","toolbar","navigation","menubar","topbar"],
   playground: {
     defaults: {

--- a/packages/core/src/TreeList/TreeList.doc.mjs
+++ b/packages/core/src/TreeList/TreeList.doc.mjs
@@ -6,6 +6,7 @@ export const docs = {
   name: 'TreeList',
   displayName: 'Tree List',
   group: 'TreeList',
+  category: 'Lists',
   keywords: ['tree', 'hierarchy', 'nested', 'accordion', 'folder', 'expand', 'collapse', 'treeview', 'outline'],
   playground: {
     defaults: {

--- a/packages/core/src/Typeahead/Typeahead.doc.mjs
+++ b/packages/core/src/Typeahead/Typeahead.doc.mjs
@@ -6,6 +6,7 @@ export const docs = {
   name: 'Typeahead',
   displayName: 'Typeahead',
   group: 'Typeahead',
+  category: 'Inputs',
   keywords: ["typeahead","autocomplete","combobox","searchbox","autosuggest","select","dropdown","lookup","searchable","suggestion","picker"],
   components: [
     {

--- a/packages/core/src/docs-types.ts
+++ b/packages/core/src/docs-types.ts
@@ -413,6 +413,33 @@ interface BaseDoc {
    *  Groups cluster related components that are always used together
    *  or are variants of each other. */
   group?: string;
+  /** Component category for the overview page gallery. Independent of
+   *  `group` (which is for the sidebar). Categories represent the
+   *  component's functional role in a UI.
+   *
+   *  Valid values:
+   *  - `'Actions'` — interactive components like buttons and links
+   *  - `'Communications'` — informational display: tooltips, toasts, badges
+   *  - `'Containers'` — wrappers: cards, dialogs, collapsibles
+   *  - `'Layout'` — structural: grid, stack, center, dividers
+   *  - `'Inputs'` — data entry: text fields, selectors, date pickers
+   *  - `'Lists'` — data display in list/table form
+   *  - `'Navigation'` — wayfinding: tabs, breadcrumbs, sidebars
+   *  - `'Performance'` — progress indication: spinners, skeletons, bars */
+  category?:
+    | 'Actions'
+    | 'Communications'
+    | 'Containers'
+    | 'Layout'
+    | 'Inputs'
+    | 'Lists'
+    | 'Navigation'
+    | 'Performance';
+  /** When set, marks this component as a sub-component that is only used
+   *  within the context of its parent. The value is the parent component's
+   *  `name` (e.g. `'Chat'` for ChatToolCalls). Sub-components are excluded
+   *  from the categorized overview page but remain in the sidebar. */
+  subComponentOf?: string;
   /** Theming configuration. Documents the stable CSS class names
    *  rendered by this component that themes can target via `@scope`
    *  selectors in `defineTheme`. */

--- a/packages/core/src/docs-types.ts
+++ b/packages/core/src/docs-types.ts
@@ -435,11 +435,11 @@ interface BaseDoc {
     | 'Lists'
     | 'Navigation'
     | 'Performance';
-  /** When set, marks this component as a sub-component that is only used
-   *  within the context of its parent. The value is the parent component's
-   *  `name` (e.g. `'Chat'` for ChatToolCalls). Sub-components are excluded
-   *  from the categorized overview page but remain in the sidebar. */
-  subComponentOf?: string;
+  /** When true, this component is excluded from the categorized overview
+   *  page but remains in the sidebar and CLI. Use for sub-components that
+   *  only make sense within a parent (e.g. BreadcrumbItem, DialogHeader)
+   *  or internal primitives that shouldn't appear in the gallery. */
+  isHiddenFromOverview?: boolean;
   /** Theming configuration. Documents the stable CSS class names
    *  rendered by this component that themes can target via `@scope`
    *  selectors in `defineTheme`. */

--- a/packages/lab/src/CircularProgress/CircularProgress.doc.mjs
+++ b/packages/lab/src/CircularProgress/CircularProgress.doc.mjs
@@ -5,6 +5,7 @@
 export const docs = {
   name: 'CircularProgress',
   displayName: 'Circular Progress',
+  category: 'Performance',
   keywords: ["circular","progress","radial","ring","arc","determinate","indeterminate","gauge","meter","donut"],
   props: [
     {

--- a/packages/lab/src/Stepper/Stepper.doc.mjs
+++ b/packages/lab/src/Stepper/Stepper.doc.mjs
@@ -5,6 +5,7 @@
 export const docs = {
   name: 'Stepper',
   displayName: 'Stepper',
+  category: 'Navigation',
   group: 'Stepper',
   keywords: ['stepper', 'steps', 'wizard', 'workflow', 'progress', 'multi-step', 'form wizard', 'onboarding'],
   usage: {


### PR DESCRIPTION
## Summary

Addresses feedback from [PR #2411](https://github.com/facebookexperimental/xds/pull/2411) — the categories on the components overview page should not be hard-coded.

This PR adds a data-driven category system to the component documentation:

### New fields on `BaseDoc` (docs-types.ts)

- **`category`** — Functional category for the overview gallery. Independent of `group` (which controls sidebar nav). Values: `Actions`, `Communications`, `Containers`, `Layout`, `Inputs`, `Lists`, `Navigation`, `Performance`
- **`isHiddenFromOverview`** — Boolean opt-out for components that shouldn't appear on the overview page (sub-components like `BreadcrumbItem`, `DialogHeader`, `ChatToolCalls`). These remain in the sidebar.

### Category definitions

| Category | Examples |
|----------|----------|
| Actions | Button, Link, DropdownMenu, ContextMenu |
| Communications | Tooltip, Toast, Badge, Avatar, Text |
| Containers | Card, Dialog, Collapsible, AppShell |
| Layout | Grid, Center, Divider, FormLayout |
| Inputs | TextInput, Selector, DateInput, Switch |
| Lists | Table, List, TreeList, Carousel |
| Navigation | Breadcrumbs, TabList, SideNav, Toolbar |
| Performance | Spinner, Skeleton, ProgressBar |

### What changed

- `packages/core/src/docs-types.ts` — Added `category` and `isHiddenFromOverview` to BaseDoc
- `packages/core/src/**/*.doc.mjs` — Tagged all core components with categories
- `packages/lab/src/**/*.doc.mjs` — Tagged lab components with categories
- `apps/docsite/scripts/generate-data.mjs` — Extracts and propagates new fields; sub-entries in multi-component docs are automatically marked `isHiddenFromOverview: true`
- `apps/docsite/src/app/(docs)/components/page.tsx` — Rewrote overview to group by category, filtering out hidden components

### What's unchanged

- **Side navigation** — Still uses `group` field, completely unaffected
- **CLI discovery** — Still works via `keywords`
- **Component detail pages** — Untouched
- **Hero text** — "Browse the library" heading and description preserved