### PR TITLE
feat(core): add convenience subpath exports for Heading, Code, HStack, VStack

### DIFF
--- a/packages/cli/src/lib/component-discovery.mjs
+++ b/packages/cli/src/lib/component-discovery.mjs
@@ -270,20 +270,26 @@ export function findComponentSource(coreDir, name) {
  */
 export function resolveImportPath(coreDir, componentName) {
   const srcDir = path.join(coreDir, 'src');
+  const pkgPath = path.join(coreDir, 'package.json');
+  const pkg = fs.existsSync(pkgPath)
+    ? JSON.parse(fs.readFileSync(pkgPath, 'utf-8'))
+    : null;
+
+  // Priority 1: exact subpath export matching the component name (e.g. ./Heading)
+  // This allows convenience re-export directories to win over the source directory.
+  if (pkg?.exports?.[`./${componentName}`]) {
+    return `@xds/core/${componentName}`;
+  }
+
   const sourcePath = findComponentSource(coreDir, componentName);
   if (!sourcePath) return '@xds/core';
 
-  // Get the top-level directory under src/ from the source path
+  // Priority 2: subpath export matching the top-level source directory
   const relToSrc = path.relative(srcDir, sourcePath);
   const topDir = relToSrc.split(path.sep)[0];
 
-  // Check package.json exports for ./${topDir}
-  const pkgPath = path.join(coreDir, 'package.json');
-  if (fs.existsSync(pkgPath)) {
-    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
-    if (pkg.exports && pkg.exports[`./${topDir}`]) {
-      return `@xds/core/${topDir}`;
-    }
+  if (pkg?.exports?.[`./${topDir}`]) {
+    return `@xds/core/${topDir}`;
   }
 
   return '@xds/core';

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -163,6 +163,11 @@
       "types": "./dist/ClickableCard/index.d.ts",
       "default": "./dist/ClickableCard/index.js"
     },
+    "./Code": {
+      "source": "./src/Code/index.ts",
+      "types": "./dist/Code/index.d.ts",
+      "default": "./dist/Code/index.js"
+    },
     "./CodeBlock": {
       "source": "./src/CodeBlock/index.ts",
       "types": "./dist/CodeBlock/index.d.ts",
@@ -237,6 +242,16 @@
       "source": "./src/Grid/index.ts",
       "types": "./dist/Grid/index.d.ts",
       "default": "./dist/Grid/index.js"
+    },
+    "./HStack": {
+      "source": "./src/HStack/index.ts",
+      "types": "./dist/HStack/index.d.ts",
+      "default": "./dist/HStack/index.js"
+    },
+    "./Heading": {
+      "source": "./src/Heading/index.ts",
+      "types": "./dist/Heading/index.d.ts",
+      "default": "./dist/Heading/index.js"
     },
     "./HoverCard": {
       "source": "./src/HoverCard/index.ts",
@@ -522,6 +537,11 @@
       "source": "./src/Typeahead/index.ts",
       "types": "./dist/Typeahead/index.d.ts",
       "default": "./dist/Typeahead/index.js"
+    },
+    "./VStack": {
+      "source": "./src/VStack/index.ts",
+      "types": "./dist/VStack/index.d.ts",
+      "default": "./dist/VStack/index.js"
     },
     "./hooks": {
       "source": "./src/hooks/index.ts",

--- a/packages/core/src/Code/index.ts
+++ b/packages/core/src/Code/index.ts
@@ -1,0 +1,11 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Convenience re-export for XDSCode
+ * @position Subpath export so `@xds/core/Code` resolves correctly
+ *
+ * XDSCode lives in the CodeBlock directory (shared code rendering internals),
+ * but agents and developers naturally expect `@xds/core/Code` to work.
+ */
+
+export {XDSCode, type XDSCodeProps} from '../CodeBlock';

--- a/packages/core/src/HStack/index.ts
+++ b/packages/core/src/HStack/index.ts
@@ -1,0 +1,8 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Convenience re-export for XDSHStack
+ * @position Subpath export so `@xds/core/HStack` resolves correctly
+ */
+
+export {XDSHStack, type XDSHStackProps} from '../Stack';

--- a/packages/core/src/Heading/index.ts
+++ b/packages/core/src/Heading/index.ts
@@ -1,0 +1,16 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Convenience re-export for XDSHeading
+ * @position Subpath export so `@xds/core/Heading` resolves correctly
+ *
+ * XDSHeading lives in the Text directory (shared typography internals),
+ * but agents and developers naturally expect `@xds/core/Heading` to work.
+ */
+
+export {
+  XDSHeading,
+  type XDSHeadingProps,
+  type XDSHeadingLevel,
+  type XDSHeadingType,
+} from '../Text';

--- a/packages/core/src/VStack/index.ts
+++ b/packages/core/src/VStack/index.ts
@@ -1,0 +1,8 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Convenience re-export for XDSVStack
+ * @position Subpath export so `@xds/core/VStack` resolves correctly
+ */
+
+export {XDSVStack, type XDSVStackProps} from '../Stack';


### PR DESCRIPTION
## Problem

9/10 agent prompts fail on `@xds/core/Heading` because:
1. The CLI lists **Heading** as a standalone component
2. Agents (and developers) naturally assume `@xds/core/Heading` is the import path
3. It actually exports from `@xds/core/Text`

Same issue affects **Code** (lives in CodeBlock), **HStack** and **VStack** (live in Stack).

## Solution

Add thin re-export directories so the intuitive paths resolve:

| Path | Re-exports from |
|------|----------------|
| `@xds/core/Heading` | `../Text` |
| `@xds/core/Code` | `../CodeBlock` |
| `@xds/core/HStack` | `../Stack` |
| `@xds/core/VStack` | `../Stack` |

Also updates `resolveImportPath()` in the CLI to prefer exact subpath export matches, so `xds component --list --brief` now shows the correct intuitive import path.

## Full list of standalone components without matching exports

These 7 components appear as standalone entries in the CLI but had no matching subpath export:

- **Heading** → `@xds/core/Text` ✅ fixed
- **Code** → `@xds/core/CodeBlock` ✅ fixed  
- **HStack** → `@xds/core/Stack` ✅ fixed
- **VStack** → `@xds/core/Stack` ✅ fixed
- NavHeadingMenu → `@xds/core/NavMenu` (sub-component, less common)
- NavHeadingMenuItem → `@xds/core/NavMenu` (sub-component, less common)
- PowerSearchFilterEditor → `@xds/core/PowerSearch` (sub-component, less common)
- PowerSearchToken → `@xds/core/PowerSearch` (sub-component, less common)

The remaining ones are sub-components typically imported alongside their parent — less likely to trip up agents.

## Tests

All existing CLI tests pass (66 tests across component and component-resolution suites).