### PR TITLE
fix(cli): exit 1 on unknown command instead of masking with help

### DIFF
--- a/apps/sandbox/package.json
+++ b/apps/sandbox/package.json
@@ -11,7 +11,7 @@
     "dev": "pnpm generate && (node ../../scripts/sync-templates.js --watch & next dev)",
     "build": "pnpm generate && next build",
     "start": "next start",
-    "postinstall": "xds agent-docs"
+    "postinstall": "xds init --features agents"
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",

--- a/packages/cli/src/index.mjs
+++ b/packages/cli/src/index.mjs
@@ -31,9 +31,29 @@ program
   .option('--detail <level>', 'Output detail level (full, compact, brief)', 'full')
   .option('--json', 'Output as typed JSON (envelope: { type, data })')
   .addHelpCommand('help', 'Show all commands')
-  .action(() => {
+  .showHelpAfterError(true)
+  .action(function () {
+    // If positional args were passed, they didn't match any subcommand —
+    // commander otherwise silently runs this default action. Reject with
+    // a clear error and non-zero exit code instead of printing help with
+    // exit 0.
+    const args = this.args || [];
+    if (args.length > 0) {
+      console.error(`error: unknown command '${args[0]}'`);
+      console.error(`Run \`xds --help\` to see available commands.`);
+      process.exit(1);
+    }
     program.help();
   });
+
+// Backstop: also wire up a `command:*` listener for the case where no
+// default action would run (e.g. if the default is removed in the future).
+program.on('command:*', (operands) => {
+  const unknown = operands[0];
+  console.error(`error: unknown command '${unknown}'`);
+  console.error(`Run \`xds --help\` to see available commands.`);
+  process.exit(1);
+});
 
 /**
  * Fallback hook: if --json was requested but the command didn't call

--- a/packages/cli/src/index.test.mjs
+++ b/packages/cli/src/index.test.mjs
@@ -1,0 +1,59 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {describe, it, expect} from 'vitest';
+import * as path from 'node:path';
+import {execFileSync} from 'node:child_process';
+
+// Subprocess tests for top-level CLI dispatch. These run the real bin so
+// we prove the actual process exit code, not a mocked one.
+const cliBin = path.resolve(import.meta.dirname, '..', 'bin', 'xds.mjs');
+
+function runCli(args) {
+  try {
+    const stdout = execFileSync(process.execPath, [cliBin, ...args], {
+      env: {...process.env, FORCE_COLOR: '0'},
+      stdio: 'pipe',
+      encoding: 'utf-8',
+    });
+    return {code: 0, stdout, stderr: ''};
+  } catch (err) {
+    return {
+      code: err.status ?? 1,
+      stdout: err.stdout?.toString() ?? '',
+      stderr: err.stderr?.toString() ?? '',
+    };
+  }
+}
+
+describe('xds top-level command dispatch', () => {
+  it('exits 0 and prints help when run with no args', () => {
+    const {code, stdout} = runCli([]);
+    expect(code).toBe(0);
+    expect(stdout).toContain('xds');
+  });
+
+  it('exits 0 for --help', () => {
+    const {code, stdout} = runCli(['--help']);
+    expect(code).toBe(0);
+    expect(stdout).toContain('Commands');
+  });
+
+  it('exits 1 with a clear error for an unknown command', () => {
+    const {code, stderr} = runCli(['definitely-not-a-command']);
+    expect(code).toBe(1);
+    expect(stderr).toContain("unknown command 'definitely-not-a-command'");
+  });
+
+  it('does NOT mask an unknown command as exit 0 + help', () => {
+    const {code} = runCli(['bogus-subcommand']);
+    // Regression guard: commander's default action used to print help and
+    // exit 0 for unmatched positionals.
+    expect(code).not.toBe(0);
+  });
+
+  it('reports the unknown command name (first positional)', () => {
+    const {code, stderr} = runCli(['frobnicate', '--json']);
+    expect(code).toBe(1);
+    expect(stderr).toContain("unknown command 'frobnicate'");
+  });
+});


### PR DESCRIPTION
Split A of #2405. Top-level CLI dispatch rejected unmatched positionals by printing help and exiting 0; now exits 1 with a clear error + `command:*` backstop. Subprocess tests prove real exit codes. Author rewritten to Cindy (was navi-bot in #2405). Draft.