### PR TITLE
fix(cli): compute postinstall banner width from longest line

### DIFF
--- a/packages/cli/src/index.mjs
+++ b/packages/cli/src/index.mjs
@@ -118,25 +118,39 @@ program
     const run = getRunPrefix();
     const r = `${run} xds`;
     const pad = (s, len) => s + ' '.repeat(Math.max(0, len - s.length));
-    const W = 49; // inner width of the box
-    const line = (s) => `  │ ${pad(s, W)}│`;
+
+    // Build all body lines first, then compute width from the longest.
+    // The previous hard-coded W=49 broke with `pnpm exec`, `bunx`, and
+    // `yarn` prefixes whose lines exceeded the inner width and pushed
+    // the right border out of alignment.
+    const body = [
+      '',
+      '  XDS design system installed!',
+      '',
+      '  Get started:',
+      `    ${r} init          Interactive setup`,
+      `    ${r} --help        See all commands`,
+      '',
+      '  Or run directly:',
+      `    ${r} init           Setup + AI agent docs`,
+      `    ${r} component     Browse component docs`,
+      `    ${r} hook          Browse hook docs`,
+      `    ${r} docs          Design system reference`,
+      `    ${r} swizzle       Customize a component`,
+      `    ${r} template      Add a page template`,
+      '',
+    ];
+
+    // Inner width = longest line, with a sane minimum so the box
+    // doesn't collapse for an empty `r`.
+    const W = Math.max(49, ...body.map(s => s.length));
+    // Body line: `│ ` + content padded to W + ` │`. Border: `╭` + `─` × (W+2) + `╮`.
+    // Total visible width matches across body and border.
+    const line = (s) => `  │ ${pad(s, W)} │`;
+
     console.log(`
   ╭${'─'.repeat(W + 2)}╮
-${line('')}
-${line('  XDS design system installed!')}
-${line('')}
-${line('  Get started:')}
-${line(`    ${r} init          Interactive setup`)}
-${line(`    ${r} --help        See all commands`)}
-${line('')}
-${line('  Or run directly:')}
-${line(`    ${r} init           Setup + AI agent docs`)}
-${line(`    ${r} component     Browse component docs`)}
-${line(`    ${r} hook          Browse hook docs`)}
-${line(`    ${r} docs          Design system reference`)}
-${line(`    ${r} swizzle       Customize a component`)}
-${line(`    ${r} template      Add a page template`)}
-${line('')}
+${body.map(line).join('\n')}
   ╰${'─'.repeat(W + 2)}╯
 `);
   });

--- a/packages/cli/src/postinstall-banner.test.mjs
+++ b/packages/cli/src/postinstall-banner.test.mjs
@@ -1,0 +1,64 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {describe, it, expect, beforeEach, afterEach} from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import {execFileSync} from 'node:child_process';
+
+// Subprocess tests proving the postinstall welcome banner stays aligned
+// regardless of the detected package-manager run prefix. The old
+// hard-coded inner width (W=49) broke alignment for longer prefixes such
+// as `pnpm exec` and `bunx`, pushing the right border out of the box.
+const cliBin = path.resolve(import.meta.dirname, '..', 'bin', 'xds.mjs');
+
+let tmpDir;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'xds-banner-test-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, {recursive: true, force: true});
+});
+
+function renderBanner({lockfile}) {
+  if (lockfile) {
+    fs.writeFileSync(path.join(tmpDir, lockfile), '');
+  }
+  return execFileSync(process.execPath, [cliBin, 'postinstall'], {
+    cwd: tmpDir,
+    // Strip any inherited PM user-agent so lockfile detection drives the prefix.
+    env: {...process.env, FORCE_COLOR: '0', npm_config_user_agent: ''},
+    encoding: 'utf-8',
+  });
+}
+
+function bannerLines(output) {
+  return output.split('\n').filter(l => l.includes('│') || l.includes('╭') || l.includes('╰'));
+}
+
+describe('postinstall banner alignment', () => {
+  // pnpm exec (10 chars) and bunx are the prefixes that broke the old W=49.
+  for (const [name, lockfile] of [
+    ['npm (npx)', 'package-lock.json'],
+    ['pnpm (pnpm exec)', 'pnpm-lock.yaml'],
+    ['yarn (yarn)', 'yarn.lock'],
+    ['bun (bunx)', 'bun.lockb'],
+  ]) {
+    it(`right border stays aligned for ${name}`, () => {
+      const out = renderBanner({lockfile});
+      const lines = bannerLines(out);
+      expect(lines.length).toBeGreaterThan(3);
+      // Every box line must have the same visible width (use Array.from to
+      // count code points, since box-drawing chars are multi-byte).
+      const widths = new Set(lines.map(l => Array.from(l).length));
+      expect(widths.size).toBe(1);
+      // Body lines must end with the right border character.
+      const bodyLines = lines.filter(l => l.includes('│'));
+      for (const l of bodyLines) {
+        expect(l.trimEnd().endsWith('│')).toBe(true);
+      }
+    });
+  }
+});


### PR DESCRIPTION
Split B of #2405. Hard-coded box width (W=49) broke alignment for `pnpm exec`/`bunx`. Width now derives from the longest line. Subprocess tests assert aligned borders across npm/pnpm/yarn/bun. Author rewritten to Cindy. Draft.