### PR TITLE
docs(cli): document npx fallback in detectPackageManager return type

### DIFF
--- a/packages/cli/src/utils/package-manager.mjs
+++ b/packages/cli/src/utils/package-manager.mjs
@@ -15,7 +15,9 @@ import * as path from 'node:path';
  * Walks up from targetDir looking for lockfiles.
  *
  * @param {string} [targetDir=process.cwd()]
- * @returns {'yarn'|'pnpm'|'bun'|'npm'}
+ * @returns {'yarn'|'pnpm'|'bun'|'npm'|'npx'} The package manager name, or
+ *   `'npx'` as a last-resort runner fallback when no lockfile, packageManager
+ *   field, or user-agent hint is available.
  */
 export function detectPackageManager(targetDir = process.cwd()) {
   const KNOWN_PMS = new Set(['yarn', 'pnpm', 'bun', 'npm']);


### PR DESCRIPTION
Split C of #2405. JSDoc `@returns` omitted the `'npx'` last-resort runner that the function actually returns (line 56). Type-honesty fix. Author rewritten to Cindy. Draft.