### PR TITLE
fix(cli): validate --agent and unify agent-doc headers in init/agent-docs

### DIFF
--- a/packages/cli/src/commands/agent-docs.mjs
+++ b/packages/cli/src/commands/agent-docs.mjs
@@ -31,6 +31,39 @@ const CLAUDE_DIR_MD = path.join('.claude', 'CLAUDE.md');
 const XDS_MARKER_START = '<!-- XDS:START -->';
 const XDS_MARKER_END = '<!-- XDS:END -->';
 
+const VALID_AGENTS = ['claude', 'cursor', 'codex', 'all'];
+
+/**
+ * Thrown when an invalid `--agent` value is passed to installAgentDocs.
+ * Callers (init, agent-docs commands) should catch this and print a
+ * stable error message + exit non-zero.
+ */
+export class InvalidAgentError extends Error {
+  constructor(value) {
+    super(`Unknown agent "${value}". Valid: ${VALID_AGENTS.join(', ')}`);
+    this.name = 'InvalidAgentError';
+    this.value = value;
+    this.validAgents = VALID_AGENTS;
+  }
+}
+
+/**
+ * Build a consistent header for newly-created agent doc files.
+ * Uses the file basename with extension stripped, so:
+ *   .claude/CLAUDE.md -> "# CLAUDE"
+ *   AGENTS.md         -> "# AGENTS"
+ *   ./a.md            -> "# a"
+ *
+ * All code paths that create a file from scratch should use this so we
+ * never produce two different headers ("# CLAUDE.md" vs "# CLAUDE") for
+ * the same file.
+ */
+function makeAgentDocHeader(relativePath) {
+  const base = path.basename(relativePath, path.extname(relativePath));
+  return `# ${base}\n\nProject-specific guidance for AI coding agents.`;
+}
+
+
 /**
  * Agent tool presets — maps tool names to their file search paths.
  * Order matters: first existing file wins, last entry is the default (created if none exist).
@@ -244,7 +277,7 @@ export function injectAgentsMd(targetDir, version, {zh = false, lang} = {}) {
   const compressedIndex = generateCompressedIndex(version, {coreDir: findCoreDir(targetDir)});
   injectXdsBlock(agentsPath, compressedIndex, {
     createIfMissing: true,
-    header: `# AGENTS.md\n\nProject-specific guidance for AI coding agents.`,
+    header: makeAgentDocHeader(AGENTS_MD),
   });
 }
 
@@ -293,15 +326,20 @@ export function removeXdsBlock(filePath, {deleteIfEmpty = false} = {}) {
 
 /**
  * Remove XDS section from all known agent doc files.
+ *
+ * @returns {{removed: string[]}} List of files we cleaned (removed section
+ *   from, or deleted entirely). Empty when nothing was found.
  */
 export function removeAgentDocs(targetDir) {
   const allPaths = discoverAgentDocs(targetDir);
+  const removed = [];
 
   for (const p of allPaths) {
     const filePath = path.join(targetDir, p);
     // Delete if empty for files we created (AGENTS.md, .claude/CLAUDE.md)
     const deleteIfEmpty = p === AGENTS_MD || p === CLAUDE_DIR_MD;
     if (removeXdsBlock(filePath, {deleteIfEmpty})) {
+      removed.push(p);
       if (!fs.existsSync(filePath)) {
         console.log(`✓ Removed empty ${p}`);
       } else {
@@ -309,6 +347,21 @@ export function removeAgentDocs(targetDir) {
       }
     }
   }
+
+  // Clean up an orphaned, now-empty .claude/ directory we may have created.
+  const claudeDir = path.join(targetDir, '.claude');
+  if (fs.existsSync(claudeDir)) {
+    try {
+      const entries = fs.readdirSync(claudeDir);
+      if (entries.length === 0) {
+        fs.rmdirSync(claudeDir);
+      }
+    } catch {
+      // best-effort cleanup
+    }
+  }
+
+  return {removed};
 }
 
 /**
@@ -345,7 +398,7 @@ export function installAgentDocs(targetDir, {zh = false, lang, agent, paths, onl
       }
       injectXdsBlock(filePath, compressedIndex, {
         createIfMissing: true,
-        header: `# ${path.basename(p, path.extname(p))}\n\nProject-specific guidance for AI coding agents.`,
+        header: makeAgentDocHeader(p),
       });
       written.push(p);
     }
@@ -354,6 +407,9 @@ export function installAgentDocs(targetDir, {zh = false, lang, agent, paths, onl
 
   // Agent preset
   if (agent) {
+    if (!VALID_AGENTS.includes(agent)) {
+      throw new InvalidAgentError(agent);
+    }
     const {inject, create} = resolveAgentPaths(targetDir, agent);
     for (const p of inject) {
       injectXdsBlock(path.join(targetDir, p), compressedIndex);
@@ -367,7 +423,7 @@ export function installAgentDocs(targetDir, {zh = false, lang, agent, paths, onl
       }
       injectXdsBlock(filePath, compressedIndex, {
         createIfMissing: true,
-        header: `# ${path.basename(p, path.extname(p))}\n\nProject-specific guidance for AI coding agents.`,
+        header: makeAgentDocHeader(p),
       });
       written.push(p);
     }
@@ -392,13 +448,11 @@ export function installAgentDocs(targetDir, {zh = false, lang, agent, paths, onl
   fs.mkdirSync(path.join(targetDir, '.claude'), {recursive: true});
   injectXdsBlock(path.join(targetDir, defaultPath), compressedIndex, {
     createIfMissing: true,
-    header: `# CLAUDE.md\n\nProject-specific guidance for AI coding agents.`,
+    header: makeAgentDocHeader(defaultPath),
   });
   written.push(defaultPath);
   return written;
 }
-
-const VALID_AGENTS = ['claude', 'cursor', 'codex', 'all'];
 
 export function registerAgentDocs(program) {
   program
@@ -416,8 +470,12 @@ export function registerAgentDocs(program) {
 
       if (options.remove) {
         console.log('\n🗑️  Removing XDS agent docs...\n');
-        removeAgentDocs(targetDir);
-        console.log('\n✅ XDS agent docs removed.\n');
+        const {removed} = removeAgentDocs(targetDir);
+        if (removed.length === 0) {
+          console.log('\nℹ️  No agent docs found.\n');
+        } else {
+          console.log('\n✅ XDS agent docs removed.\n');
+        }
         return;
       }
 

--- a/packages/cli/src/commands/agent-docs.test.mjs
+++ b/packages/cli/src/commands/agent-docs.test.mjs
@@ -156,7 +156,8 @@ describe('injectAgentsMd', () => {
     injectAgentsMd(tmpDir, '1.0.0');
 
     const content = fs.readFileSync(path.join(tmpDir, 'AGENTS.md'), 'utf-8');
-    expect(content).toContain('# AGENTS.md');
+    expect(content).toContain("# AGENTS");
+    expect(content).not.toContain("# AGENTS.md");
     expect(content).toContain('<!-- XDS:START -->');
     expect(content).toContain('XDS v1.0.0');
     expect(content).toContain('<!-- XDS:END -->');

--- a/packages/cli/src/commands/init.mjs
+++ b/packages/cli/src/commands/init.mjs
@@ -18,10 +18,11 @@ import * as path from 'node:path';
 import * as fs from 'node:fs';
 import {CLI_ROOT} from '../utils/paths.mjs';
 import {getRunPrefix} from '../utils/package-manager.mjs';
-import {installAgentDocs, removeAgentDocs} from './agent-docs.mjs';
+import {installAgentDocs, removeAgentDocs, InvalidAgentError} from './agent-docs.mjs';
 import {listTemplates} from './template.mjs';
 
 const VALID_FEATURES = ['agents', 'theme', 'template'];
+const VALID_AGENTS = ['claude', 'cursor', 'codex', 'all'];
 const run = getRunPrefix();
 
 function isCancel(value) {
@@ -48,7 +49,11 @@ function runAgents(targetDir, {interactive = true, agent, agentDocsPath} = {}) {
     } else {
       console.log(`✓ AI agent docs installed → ${summary}`);
     }
-  } catch {
+  } catch (err) {
+    if (err instanceof InvalidAgentError) {
+      console.error(`Error: ${err.message}`);
+      process.exit(1);
+    }
     const msg = `Could not install agent docs. Try again with \`${run} xds init --features agents\`.`;
     if (interactive) {
       p.log.warning(msg);
@@ -148,16 +153,34 @@ export function registerInit(program) {
 
       // Remove mode
       if (options.removeAgents) {
-        removeAgentDocs(targetDir);
-        console.log('✓ AI agent docs removed.');
+        const {removed} = removeAgentDocs(targetDir);
+        if (removed.length === 0) {
+          console.log('ℹ️  No agent docs found.');
+        } else {
+          console.log('✓ AI agent docs removed.');
+        }
         return;
       }
 
-      // Non-interactive: --features or --all
-      if (options.features || options.all) {
+      // Validate --agent up front for both --features and implicit modes.
+      if (options.agent && !VALID_AGENTS.includes(options.agent)) {
+        console.error(`Error: Unknown agent: ${options.agent}`);
+        console.error(`Valid agents: ${VALID_AGENTS.join(', ')}`);
+        process.exit(1);
+      }
+
+      // If --agent or --agent-docs-path is passed without --features/--all,
+      // implicitly enable the `agents` feature instead of silently ignoring them.
+      const agentFlagsImplyAgents =
+        !options.features && !options.all && (options.agent || options.agentDocsPath);
+
+      // Non-interactive: --features, --all, or implied --features=agents
+      if (options.features || options.all || agentFlagsImplyAgents) {
         const features = options.all
           ? VALID_FEATURES
-          : options.features.split(',').map(f => f.trim().toLowerCase());
+          : agentFlagsImplyAgents
+            ? ['agents']
+            : options.features.split(',').map(f => f.trim().toLowerCase());
 
         const invalid = features.filter(f => !VALID_FEATURES.includes(f));
         if (invalid.length > 0) {
@@ -189,7 +212,7 @@ export function registerInit(program) {
       // Feature: agents
       const shouldInstallAgents = isCancel(
         await p.confirm({
-          message: 'Install AI agent support? (adds XDS cheat sheet to AGENTS.md)',
+          message: 'Install AI agent support? (adds XDS cheat sheet to .claude/CLAUDE.md, AGENTS.md, etc.)',
           initialValue: true,
         }),
       );

--- a/packages/cli/src/commands/init.test.mjs
+++ b/packages/cli/src/commands/init.test.mjs
@@ -23,16 +23,6 @@ function runCli(args, {cwd} = {}) {
   });
 }
 
-describe('xds CLI top-level', () => {
-  it('exits 1 with a clear error on unknown command', () => {
-    const result = runCli(['bogus']);
-    expect(result.status).toBe(1);
-    const out = (result.stderr || '') + (result.stdout || '');
-    expect(out).toMatch(/unknown command/i);
-    expect(out).toContain('bogus');
-  });
-});
-
 describe('xds init --features bogus', () => {
   it('exits 1 on unknown feature', () => {
     const result = runCli(['init', '--features', 'bogus']);
@@ -147,72 +137,6 @@ describe('xds init --remove-agents', () => {
     expect(fs.existsSync(path.join(tmpDir, '.claude', 'CLAUDE.md'))).toBe(false);
     // The now-empty .claude dir should also be cleaned up.
     expect(fs.existsSync(path.join(tmpDir, '.claude'))).toBe(false);
-  });
-});
-
-describe('postinstall banner', () => {
-  function checkBoxAlignment(stdout) {
-    const lines = stdout.split('\n');
-    const bodyLines = lines.filter(l => l.startsWith('  │ '));
-    const topBorder = lines.find(l => l.startsWith('  ╭'));
-    const bottomBorder = lines.find(l => l.startsWith('  ╰'));
-
-    expect(bodyLines.length).toBeGreaterThan(5);
-    expect(topBorder).toBeDefined();
-    expect(bottomBorder).toBeDefined();
-
-    const bodyLen = bodyLines[0].length;
-    for (const l of bodyLines) {
-      expect(l.length).toBe(bodyLen);
-      expect(l.endsWith('│')).toBe(true);
-    }
-    expect(topBorder.length).toBe(bodyLen);
-    expect(bottomBorder.length).toBe(bodyLen);
-  }
-
-  it('every body line matches inner width and right border aligns (default)', () => {
-    const result = runCli(['postinstall']);
-    expect(result.status).toBe(0);
-    checkBoxAlignment(result.stdout);
-  });
-
-  it('right border aligns with `pnpm exec` prefix (longer command)', () => {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'xds-pnpm-banner-'));
-    try {
-      fs.writeFileSync(path.join(tmpDir, 'pnpm-lock.yaml'), '');
-      const result = runCli(['postinstall'], {cwd: tmpDir});
-      expect(result.status).toBe(0);
-      checkBoxAlignment(result.stdout);
-      expect(result.stdout).toContain('pnpm exec xds');
-    } finally {
-      fs.rmSync(tmpDir, {recursive: true, force: true});
-    }
-  });
-
-  it('right border aligns with `bunx` prefix', () => {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'xds-bun-banner-'));
-    try {
-      fs.writeFileSync(path.join(tmpDir, 'bun.lock'), '');
-      const result = runCli(['postinstall'], {cwd: tmpDir});
-      expect(result.status).toBe(0);
-      checkBoxAlignment(result.stdout);
-      expect(result.stdout).toContain('bunx xds');
-    } finally {
-      fs.rmSync(tmpDir, {recursive: true, force: true});
-    }
-  });
-
-  it('right border aligns with `yarn` prefix', () => {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'xds-yarn-banner-'));
-    try {
-      fs.writeFileSync(path.join(tmpDir, 'yarn.lock'), '');
-      const result = runCli(['postinstall'], {cwd: tmpDir});
-      expect(result.status).toBe(0);
-      checkBoxAlignment(result.stdout);
-      expect(result.stdout).toContain('yarn xds');
-    } finally {
-      fs.rmSync(tmpDir, {recursive: true, force: true});
-    }
   });
 });
 

--- a/packages/cli/src/commands/init.test.mjs
+++ b/packages/cli/src/commands/init.test.mjs
@@ -1,0 +1,256 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file CLI integration tests for `xds init` and related top-level CLI behaviors.
+ * Spawns the actual bin to verify exit codes and user-facing output.
+ */
+
+import {describe, it, expect, beforeEach, afterEach} from 'vitest';
+import {spawnSync} from 'node:child_process';
+import {fileURLToPath} from 'node:url';
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const BIN = path.resolve(__dirname, '../../bin/xds.mjs');
+
+function runCli(args, {cwd} = {}) {
+  return spawnSync('node', [BIN, ...args], {
+    cwd: cwd ?? process.cwd(),
+    encoding: 'utf-8',
+    env: {...process.env, NO_COLOR: '1', FORCE_COLOR: '0'},
+  });
+}
+
+describe('xds CLI top-level', () => {
+  it('exits 1 with a clear error on unknown command', () => {
+    const result = runCli(['bogus']);
+    expect(result.status).toBe(1);
+    const out = (result.stderr || '') + (result.stdout || '');
+    expect(out).toMatch(/unknown command/i);
+    expect(out).toContain('bogus');
+  });
+});
+
+describe('xds init --features bogus', () => {
+  it('exits 1 on unknown feature', () => {
+    const result = runCli(['init', '--features', 'bogus']);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toMatch(/Unknown features/i);
+    expect(result.stderr).toContain('bogus');
+  });
+});
+
+describe('xds init --agent bogus', () => {
+  let tmpDir;
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'xds-init-test-'));
+  });
+  afterEach(() => {
+    fs.rmSync(tmpDir, {recursive: true, force: true});
+  });
+
+  it('exits 1 with a clear error on unknown agent (with --features agents)', () => {
+    const result = runCli(['init', '--features', 'agents', '--agent', 'bogus'], {cwd: tmpDir});
+    expect(result.status).toBe(1);
+    const out = (result.stderr || '') + (result.stdout || '');
+    expect(out).toMatch(/Unknown agent/i);
+    expect(out).toContain('bogus');
+  });
+
+  it('exits 1 on unknown agent even without --features', () => {
+    const result = runCli(['init', '--agent', 'bogus'], {cwd: tmpDir});
+    expect(result.status).toBe(1);
+    const out = (result.stderr || '') + (result.stdout || '');
+    expect(out).toMatch(/Unknown agent/i);
+  });
+});
+
+describe('xds init --agent without --features', () => {
+  let tmpDir;
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'xds-init-implicit-'));
+  });
+  afterEach(() => {
+    fs.rmSync(tmpDir, {recursive: true, force: true});
+  });
+
+  it('implicitly enables the agents feature when --agent is passed', () => {
+    const result = runCli(['init', '--agent', 'codex'], {cwd: tmpDir});
+    expect(result.status).toBe(0);
+    expect(fs.existsSync(path.join(tmpDir, 'AGENTS.md'))).toBe(true);
+    const content = fs.readFileSync(path.join(tmpDir, 'AGENTS.md'), 'utf-8');
+    expect(content).toContain('# AGENTS');
+  });
+
+  it('implicitly enables the agents feature when --agent-docs-path is passed', () => {
+    const target = './a.md';
+    const result = runCli(['init', '--agent-docs-path', target], {cwd: tmpDir});
+    expect(result.status).toBe(0);
+    expect(fs.existsSync(path.join(tmpDir, 'a.md'))).toBe(true);
+    const content = fs.readFileSync(path.join(tmpDir, 'a.md'), 'utf-8');
+    expect(content).toContain('# a');
+    expect(content).not.toContain('# a.md');
+  });
+});
+
+describe('xds init header consistency', () => {
+  it('writes the same header style across default, --agent, and --agent-docs-path paths', () => {
+    const t1 = fs.mkdtempSync(path.join(os.tmpdir(), 'xds-h1-'));
+    runCli(['init', '--features', 'agents'], {cwd: t1});
+    const c1 = fs.readFileSync(path.join(t1, '.claude', 'CLAUDE.md'), 'utf-8');
+
+    const t2 = fs.mkdtempSync(path.join(os.tmpdir(), 'xds-h2-'));
+    runCli(['init', '--features', 'agents', '--agent', 'codex'], {cwd: t2});
+    const c2 = fs.readFileSync(path.join(t2, 'AGENTS.md'), 'utf-8');
+
+    const t3 = fs.mkdtempSync(path.join(os.tmpdir(), 'xds-h3-'));
+    runCli(['init', '--features', 'agents', '--agent-docs-path', './CLAUDE.md'], {cwd: t3});
+    const c3 = fs.readFileSync(path.join(t3, 'CLAUDE.md'), 'utf-8');
+
+    // All headers must use the stripped-extension form: `# <basename>`.
+    expect(c1).toContain('# CLAUDE');
+    expect(c1).not.toContain('# CLAUDE.md');
+    expect(c2).toContain('# AGENTS');
+    expect(c2).not.toContain('# AGENTS.md');
+    expect(c3).toContain('# CLAUDE');
+    expect(c3).not.toContain('# CLAUDE.md');
+
+    [t1, t2, t3].forEach(t => fs.rmSync(t, {recursive: true, force: true}));
+  });
+});
+
+describe('xds init --remove-agents', () => {
+  let tmpDir;
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'xds-remove-'));
+  });
+  afterEach(() => {
+    fs.rmSync(tmpDir, {recursive: true, force: true});
+  });
+
+  it('prints "no agent docs found" when nothing exists', () => {
+    const result = runCli(['init', '--remove-agents'], {cwd: tmpDir});
+    expect(result.status).toBe(0);
+    expect(result.stdout).toMatch(/no agent docs found/i);
+    // Must NOT print the misleading success message when nothing was removed.
+    expect(result.stdout).not.toMatch(/AI agent docs removed/i);
+  });
+
+  it('removes empty .claude/ directory after cleanup', () => {
+    runCli(['init', '--features', 'agents'], {cwd: tmpDir});
+    expect(fs.existsSync(path.join(tmpDir, '.claude', 'CLAUDE.md'))).toBe(true);
+
+    const result = runCli(['init', '--remove-agents'], {cwd: tmpDir});
+    expect(result.status).toBe(0);
+    expect(fs.existsSync(path.join(tmpDir, '.claude', 'CLAUDE.md'))).toBe(false);
+    // The now-empty .claude dir should also be cleaned up.
+    expect(fs.existsSync(path.join(tmpDir, '.claude'))).toBe(false);
+  });
+});
+
+describe('postinstall banner', () => {
+  function checkBoxAlignment(stdout) {
+    const lines = stdout.split('\n');
+    const bodyLines = lines.filter(l => l.startsWith('  │ '));
+    const topBorder = lines.find(l => l.startsWith('  ╭'));
+    const bottomBorder = lines.find(l => l.startsWith('  ╰'));
+
+    expect(bodyLines.length).toBeGreaterThan(5);
+    expect(topBorder).toBeDefined();
+    expect(bottomBorder).toBeDefined();
+
+    const bodyLen = bodyLines[0].length;
+    for (const l of bodyLines) {
+      expect(l.length).toBe(bodyLen);
+      expect(l.endsWith('│')).toBe(true);
+    }
+    expect(topBorder.length).toBe(bodyLen);
+    expect(bottomBorder.length).toBe(bodyLen);
+  }
+
+  it('every body line matches inner width and right border aligns (default)', () => {
+    const result = runCli(['postinstall']);
+    expect(result.status).toBe(0);
+    checkBoxAlignment(result.stdout);
+  });
+
+  it('right border aligns with `pnpm exec` prefix (longer command)', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'xds-pnpm-banner-'));
+    try {
+      fs.writeFileSync(path.join(tmpDir, 'pnpm-lock.yaml'), '');
+      const result = runCli(['postinstall'], {cwd: tmpDir});
+      expect(result.status).toBe(0);
+      checkBoxAlignment(result.stdout);
+      expect(result.stdout).toContain('pnpm exec xds');
+    } finally {
+      fs.rmSync(tmpDir, {recursive: true, force: true});
+    }
+  });
+
+  it('right border aligns with `bunx` prefix', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'xds-bun-banner-'));
+    try {
+      fs.writeFileSync(path.join(tmpDir, 'bun.lock'), '');
+      const result = runCli(['postinstall'], {cwd: tmpDir});
+      expect(result.status).toBe(0);
+      checkBoxAlignment(result.stdout);
+      expect(result.stdout).toContain('bunx xds');
+    } finally {
+      fs.rmSync(tmpDir, {recursive: true, force: true});
+    }
+  });
+
+  it('right border aligns with `yarn` prefix', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'xds-yarn-banner-'));
+    try {
+      fs.writeFileSync(path.join(tmpDir, 'yarn.lock'), '');
+      const result = runCli(['postinstall'], {cwd: tmpDir});
+      expect(result.status).toBe(0);
+      checkBoxAlignment(result.stdout);
+      expect(result.stdout).toContain('yarn xds');
+    } finally {
+      fs.rmSync(tmpDir, {recursive: true, force: true});
+    }
+  });
+});
+
+describe('lazy-load fallback', () => {
+  it('exits 1 when a command failed to load and is invoked', () => {
+    // Verify the lazy-load failure path exits non-zero. We synthesize a
+    // commander program that follows the same pattern as src/index.mjs,
+    // including the failure-fallback action.
+    const stub = path.join(os.tmpdir(), `xds-broken-cmd-${Date.now()}.mjs`);
+    fs.writeFileSync(stub, `
+import {Command} from 'commander';
+const program = new Command();
+program.name('xds');
+
+const cmd = {name: 'broken', path: './does-not-exist.mjs', register: 'noop'};
+try {
+  const mod = await import(cmd.path);
+  mod[cmd.register](program);
+} catch (e) {
+  program
+    .command(cmd.name)
+    .description('(failed to load: ' + e.message + ')')
+    .action(() => {
+      console.error('Command "' + cmd.name + '" failed to load:');
+      console.error(e.message);
+      process.exit(1);
+    });
+}
+program.parse(['node', 'xds', 'broken']);
+`);
+    try {
+      const result = spawnSync('node', [stub], {
+        encoding: 'utf-8',
+        cwd: path.dirname(BIN),
+      });
+      expect(result.status).toBe(1);
+    } finally {
+      fs.unlinkSync(stub);
+    }
+  });
+});


### PR DESCRIPTION
Split D of #2405. Validates `--agent` up front (exit 1 on invalid), unifies created-file headers, fixes false 'removed' message, implies agents feature for `--agent`/`--agent-docs-path`, cleans orphaned `.claude/`. Adds subprocess tests. Author rewritten to Cindy. Draft.