### PR TITLE
fix(cli): scope gap-to-numeric codemod to XDS layout elements

### DIFF
--- a/packages/cli/src/codemods/transforms/v0.0.2/__tests__/migrate-gap-to-numeric.test.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.2/__tests__/migrate-gap-to-numeric.test.mjs
@@ -103,9 +103,24 @@ describe('migrate-gap-to-numeric', () => {
     expect(output).toContain('gap="custom"');
   });
 
-  it('converts gap on any component with gap prop', async () => {
+  it('does not modify gap on non-XDS components (false positive guard)', async () => {
     const input = '<CustomComponent gap="space3" />';
     const output = await applyTransform(input);
-    expect(output).toContain('gap={3}');
+    // Should leave third-party components untouched.
+    expect(output).toContain('gap="space3"');
+    expect(output).not.toContain('gap={3}');
+  });
+
+  it('does not modify gap on native HTML elements', async () => {
+    const input = '<div gap="space4">child</div>';
+    const output = await applyTransform(input);
+    expect(output).toContain('gap="space4"');
+    expect(output).not.toContain('gap={4}');
+  });
+
+  it('does not modify gap on a similarly-named non-XDS component', async () => {
+    const input = '<MyStack gap="space4">x</MyStack>';
+    const output = await applyTransform(input);
+    expect(output).toContain('gap="space4"');
   });
 });

--- a/packages/cli/src/codemods/transforms/v0.0.2/migrate-gap-to-numeric.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.2/migrate-gap-to-numeric.mjs
@@ -43,6 +43,36 @@ const TOKEN_TO_NUMBER = {
 
 const GAP_PROPS = ['gap', 'rowGap', 'columnGap'];
 
+/**
+ * XDS layout components that accept gap/rowGap/columnGap props.
+ * Scoped narrowly so we don't rewrite gap props on user-authored or
+ * third-party components (e.g. native <div gap="space4"> in unrelated code).
+ */
+const XDS_GAP_ELEMENTS = new Set([
+  'XDSStack',
+  'XDSHStack',
+  'XDSVStack',
+  'XDSGrid',
+  'XDSGridSpan',
+  'XDSStackItem',
+]);
+
+function isXDSGapElement(openingElement) {
+  if (!openingElement || openingElement.type !== 'JSXOpeningElement') {
+    return false;
+  }
+  const name = openingElement.name;
+  // Plain identifier: <XDSStack>
+  if (name.type === 'JSXIdentifier') {
+    return XDS_GAP_ELEMENTS.has(name.name);
+  }
+  // Member expression: <Foo.XDSStack> — check trailing identifier
+  if (name.type === 'JSXMemberExpression' && name.property) {
+    return XDS_GAP_ELEMENTS.has(name.property.name);
+  }
+  return false;
+}
+
 export default function transformer(file, api) {
   const j = api.jscodeshift;
   const root = j(file.source);
@@ -51,6 +81,14 @@ export default function transformer(file, api) {
   root.find(j.JSXAttribute).forEach((path) => {
     const attrName = path.node.name.name;
     if (!GAP_PROPS.includes(attrName)) {
+      return;
+    }
+
+    // Scope to known XDS layout elements only. Other component codemods
+    // narrow by element name; this one historically walked every attribute
+    // and rewrote gap on unrelated elements (e.g. <div gap="space4">).
+    const openingElement = path.parent && path.parent.node;
+    if (!isXDSGapElement(openingElement)) {
       return;
     }
 


### PR DESCRIPTION
Split E of #2405. The transform rewrote gap props on ANY element (incl. native `<div gap=...>`); now scoped to XDS layout components with a test proving non-XDS elements are untouched. Author rewritten to Cindy. Draft.