### PR TITLE
fix(cli): validate --detail globally (exit 1 on invalid value)

### DIFF
--- a/packages/cli/src/commands/detail-validation.test.mjs
+++ b/packages/cli/src/commands/detail-validation.test.mjs
@@ -1,0 +1,114 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Subprocess tests proving the global --detail flag is validated for
+ * EVERY command (checklist #1 flag validation + #2 reject-before-side-effects).
+ *
+ * Before this hardening, `--detail bogus` was silently accepted (exit 0) on
+ * discover, docs, swizzle and init — they fell back to 'full'. The central
+ * preSubcommand hook in index.mjs now rejects any unrecognized value with
+ * exit 1 before the command's action body runs.
+ */
+
+import {describe, it, expect, beforeAll, afterAll} from 'vitest';
+import {execFileSync} from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const cliBin = path.resolve(__dirname, '../../bin/xds.mjs');
+
+/**
+ * Run the CLI and capture {status, stdout, stderr} without throwing on
+ * non-zero exit.
+ */
+function runCli(args, opts = {}) {
+  try {
+    const stdout = execFileSync(process.execPath, [cliBin, ...args], {
+      env: {...process.env, FORCE_COLOR: '0'},
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      ...opts,
+    });
+    return {status: 0, stdout, stderr: ''};
+  } catch (e) {
+    return {
+      status: e.status ?? 1,
+      stdout: e.stdout?.toString() ?? '',
+      stderr: e.stderr?.toString() ?? '',
+    };
+  }
+}
+
+// Commands that previously fell back silently plus the controls that already
+// validated. Every one of these must reject an invalid --detail value.
+const INVALID_DETAIL_CASES = [
+  ['discover', ['discover']],
+  ['docs <topic>', ['docs', 'styling']],
+  ['swizzle --list', ['swizzle', '--list']],
+  ['init', ['init']],
+  ['component --list', ['component', '--list']],
+  ['hook --list', ['hook', '--list']],
+  ['theme --list', ['theme', '--list']],
+];
+
+describe('global --detail validation (subprocess)', () => {
+  for (const [label, baseArgs] of INVALID_DETAIL_CASES) {
+    it(`${label}: --detail bogus exits 1 with a clear message`, () => {
+      const r = runCli([...baseArgs, '--detail', 'bogus']);
+      expect(r.status).toBe(1);
+      expect(r.stderr).toMatch(/Invalid --detail value "bogus"/);
+      expect(r.stderr).toMatch(/full, compact, brief/);
+    });
+  }
+
+  it('leading --detail (before the subcommand) is also rejected', () => {
+    const r = runCli(['--detail', 'bogus', 'discover']);
+    expect(r.status).toBe(1);
+    expect(r.stderr).toMatch(/Invalid --detail value "bogus"/);
+  });
+
+  it('--json emits a typed { error } envelope and exits 1', () => {
+    const r = runCli(['discover', '--detail', 'bogus', '--json']);
+    expect(r.status).toBe(1);
+    const parsed = JSON.parse(r.stdout);
+    expect(parsed.error).toMatch(/Invalid --detail value "bogus"/);
+    // No stray stdout noise beyond the JSON envelope.
+    expect(r.stdout.trim().startsWith('{')).toBe(true);
+  });
+
+  it('a valid --detail value (brief) is accepted (exit 0)', () => {
+    const r = runCli(['discover', '--detail', 'brief']);
+    expect(r.status).toBe(0);
+  });
+
+  it('omitting --detail (default) is accepted (exit 0)', () => {
+    const r = runCli(['discover']);
+    expect(r.status).toBe(0);
+  });
+});
+
+describe('--detail validation fires BEFORE side effects (#2)', () => {
+  let tmpDir;
+  beforeAll(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'xds-detail-init-'));
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({name: 'detail-side-test', type: 'module'}),
+    );
+  });
+  afterAll(() => {
+    fs.rmSync(tmpDir, {recursive: true, force: true});
+  });
+
+  it('init --detail bogus writes no files and exits 1', () => {
+    const before = fs.readdirSync(tmpDir).sort();
+    const r = runCli(['init', '--detail', 'bogus', '--json'], {cwd: tmpDir});
+    expect(r.status).toBe(1);
+    const after = fs.readdirSync(tmpDir).sort();
+    // No new files/dirs were created by the rejected invocation.
+    expect(after).toEqual(before);
+  });
+});

--- a/packages/cli/src/index.mjs
+++ b/packages/cli/src/index.mjs
@@ -13,6 +13,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import {checkForUpdate} from './utils/update-check.mjs';
 import {getRunPrefix} from './utils/package-manager.mjs';
+import {jsonError} from './lib/json.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -34,6 +35,25 @@ program
   .action(() => {
     program.help();
   });
+
+/**
+ * Pre-subcommand hook: validate the global --detail flag for EVERY command
+ * before any action body runs (i.e. before side effects). An invalid value
+ * exits 1 with a clear message rather than silently falling back to 'full'.
+ * --json callers get a typed { error } envelope. Commands that re-validate
+ * --detail locally (component, hook) keep working — this is a strict superset.
+ */
+const VALID_DETAIL_LEVELS = ['full', 'compact', 'brief'];
+program.hook('preSubcommand', () => {
+  const detail = program.opts().detail;
+  if (detail != null && !VALID_DETAIL_LEVELS.includes(detail)) {
+    const msg = `Invalid --detail value "${detail}". Valid levels: ${VALID_DETAIL_LEVELS.join(', ')}`;
+    if (program.opts().json) return jsonError(msg);
+    console.error(`Error: Invalid --detail value "${detail}".`);
+    console.error(`Valid levels: ${VALID_DETAIL_LEVELS.join(', ')}`);
+    process.exit(1);
+  }
+});
 
 /**
  * Fallback hook: if --json was requested but the command didn't call


### PR DESCRIPTION
## Problem

The global `--detail` flag is documented as `full|compact|brief`, but most commands silently accepted any value and fell back to `full`:

| command | `--detail bogus` before |
|---|---|
| discover | exit 0 (silent fallback) |
| docs | exit 0 (silent fallback) |
| swizzle | exit 0 (silent fallback) |
| init | exit 0 (silent fallback) |
| component / hook / theme | exit 1 (already validated) |

This violates hardening checklist **#1 (flag validation must exit 1, not silently fall back)** and **#2 (reject before side effects)**.

## Fix

A single `preSubcommand` hook in `index.mjs` validates `--detail` for **every** command before its action body runs:
- invalid value → exit 1 with `Error: Invalid --detail value "X". Valid levels: full, compact, brief`
- `--json` → typed `{ "error": ... }` envelope, exit 1
- fires **before** any side effects (e.g. `init --detail bogus` writes no files)
- strict superset of the existing per-command checks in component/hook (those keep working)

Both leading (`xds --detail bogus discover`) and trailing (`xds discover --detail bogus`) positions are caught.

## Tests

`packages/cli/src/commands/detail-validation.test.mjs` — 12 subprocess tests via `execFileSync(bin/xds.mjs …)` proving the behavior across discover/docs/swizzle/init/component/hook/theme, both flag positions, the JSON envelope, valid/omitted values, and the no-side-effect guarantee for `init`.

Diff: 2 files (+134). No regression in existing CLI suite.