### PR TITLE
fix(cli): reject invalid template --type with exit 1

### DIFF
--- a/packages/cli/src/api/template.mjs
+++ b/packages/cli/src/api/template.mjs
@@ -390,6 +390,17 @@ export async function getTemplateById(id, options = {}) {
  */
 export async function template(name, options = {}) {
   const {list = false, skeleton = false, show = false, targetPath, type, cwd = process.cwd()} = options;
+
+  // Validate --type up front (before any discovery / side effects) so an
+  // invalid value fails loudly with exit 1 instead of silently returning
+  // an empty list. Only 'page' and 'block' are valid template types.
+  const VALID_TYPES = ['page', 'block'];
+  if (type != null && !VALID_TYPES.includes(type)) {
+    throw new XDSError(
+      `Unknown template type "${type}". Valid types: ${VALID_TYPES.join(', ')}`,
+    );
+  }
+
   const templates = await discoverAll();
 
   if (list || (!name && !skeleton)) {

--- a/packages/cli/src/commands/template.test.mjs
+++ b/packages/cli/src/commands/template.test.mjs
@@ -60,3 +60,59 @@ describe('listTemplates integration', () => {
     expect(Array.isArray(result)).toBe(true);
   });
 });
+
+// Subprocess tests: prove the REAL exit code and JSON envelope for invalid
+// --type, validated before any side effects (checklist #1, #2, #5).
+import {execFileSync} from 'node:child_process';
+
+const cliBin = path.resolve(import.meta.dirname, '..', '..', 'bin', 'xds.mjs');
+
+function runCli(args) {
+  try {
+    const stdout = execFileSync(process.execPath, [cliBin, ...args], {
+      env: {...process.env, FORCE_COLOR: '0'},
+      stdio: 'pipe',
+      encoding: 'utf-8',
+    });
+    return {code: 0, stdout, stderr: ''};
+  } catch (err) {
+    return {
+      code: err.status ?? 1,
+      stdout: err.stdout?.toString() ?? '',
+      stderr: err.stderr?.toString() ?? '',
+    };
+  }
+}
+
+describe('template --type flag validation', () => {
+  it('rejects an invalid --type with exit 1 and a clear message', () => {
+    const {code, stderr} = runCli(['template', '--list', '--type', 'bogus']);
+    expect(code).toBe(1);
+    expect(stderr).toMatch(/Unknown template type "bogus"/);
+    expect(stderr).toMatch(/page, block/);
+  });
+
+  it('rejects an invalid --type with --json as a structured error (exit 1)', () => {
+    const {code, stdout} = runCli(['template', '--list', '--type', 'bogus', '--json']);
+    expect(code).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.error).toMatch(/Unknown template type "bogus"/);
+  });
+
+  it('does NOT silently return an empty list for an invalid --type', () => {
+    const {code, stdout} = runCli(['template', '--list', '--type', 'nope']);
+    // Regression guard: previously exited 0 with an empty filtered list.
+    expect(code).not.toBe(0);
+    expect(stdout).not.toMatch(/Page Templates/);
+  });
+
+  it('accepts a valid --type page (exit 0)', () => {
+    const {code} = runCli(['template', '--list', '--type', 'page']);
+    expect(code).toBe(0);
+  });
+
+  it('accepts a valid --type block (exit 0)', () => {
+    const {code} = runCli(['template', '--list', '--type', 'block']);
+    expect(code).toBe(0);
+  });
+});


### PR DESCRIPTION
Checklist #1/#2/#5 gap (not covered by 2401): `template --list --type bogus` silently returned an empty list + exit 0. Now validates `--type` (page|block) before any side effects, throws XDSError -> CLI exit 1, `--json` -> structured error. 5 subprocess tests prove real exit codes + JSON envelope. Author Cindy. Draft.