### PR TITLE
fix(cli): make global --lang honest on every command

### DIFF
--- a/packages/cli/src/commands/lang-global.test.mjs
+++ b/packages/cli/src/commands/lang-global.test.mjs
@@ -1,0 +1,106 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * End-to-end tests for the global `--lang` validation hook.
+ *
+ * Proves the advertised global `--lang` flag is HONEST on every command:
+ *
+ *   1. An unsupported locale (`--lang xx`) exits 1 with a clear message on
+ *      read commands (component, discover) AND write/action commands
+ *      (init, template, upgrade) — not a silent English fallback.
+ *   2. A write command (`init --all --lang xx`) exits 1 BEFORE touching the
+ *      filesystem — zero files written (path-safety / no half-writes).
+ *   3. `--json --lang xx` emits a structured `{ error }` envelope and exits
+ *      non-zero (contract — rejected before side effects).
+ *   4. A partially-translated locale (`--lang zh`) succeeds (exit 0) but
+ *      warns on stderr that prose falls back to English (no silent English).
+ *   5. `--lang en` succeeds with no warning.
+ *   6. `--lang zh --dense` (ambiguous combo) exits 1.
+ *
+ * Regression guard: init/template/theme/upgrade/swizzle/gap-report advertise
+ * the global `--lang` flag (declared on the root program) but never translate;
+ * before this hook they accepted `--lang xx` silently.
+ */
+
+import {describe, it, expect} from 'vitest';
+import {spawnSync} from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const cliBin = path.resolve(__dirname, '../../bin/xds.mjs');
+
+function runCli(args, opts = {}) {
+  return spawnSync('node', [cliBin, ...args], {
+    encoding: 'utf-8',
+    timeout: 30000,
+    // Non-TTY pipe (default for spawnSync) — exercises non-interactive path.
+    input: '',
+    ...opts,
+  });
+}
+
+describe('global --lang validation: unsupported locale exits 1', () => {
+  for (const args of [
+    ['component', '--list'],
+    ['discover'],
+    ['template', 'list'],
+    ['upgrade'],
+  ]) {
+    it(`xds ${args.join(' ')} --lang xx exits 1 (not silent fallback)`, () => {
+      const r = runCli([...args, '--lang', 'xx']);
+      expect(r.status).toBe(1);
+      expect(r.stderr).toMatch(/Unsupported language "xx"/);
+      expect(r.stderr).toMatch(/en, zh, dense/);
+    });
+  }
+});
+
+describe('global --lang validation: write command is side-effect-free on reject', () => {
+  it('init --all --lang xx exits 1 and writes NO files', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'xds-init-lang-'));
+    try {
+      const r = runCli(['init', '--all', '--lang', 'xx'], {cwd: tmp});
+      expect(r.status).toBe(1);
+      expect(r.stderr).toMatch(/Unsupported language "xx"/);
+      // No half-writes: the empty dir must stay empty.
+      const entries = fs.readdirSync(tmp);
+      expect(entries).toEqual([]);
+    } finally {
+      fs.rmSync(tmp, {recursive: true, force: true});
+    }
+  });
+});
+
+describe('global --lang validation: --json contract', () => {
+  it('--json --lang xx emits a structured { error } and exits non-zero', () => {
+    const r = runCli(['component', '--list', '--json', '--lang', 'xx']);
+    expect(r.status).not.toBe(0);
+    const parsed = JSON.parse(r.stdout.trim());
+    expect(parsed).toHaveProperty('error');
+    expect(parsed.error).toMatch(/Unsupported language "xx"/);
+  });
+});
+
+describe('global --lang validation: i18n honesty', () => {
+  it('--lang zh succeeds but warns that prose falls back to English', () => {
+    const r = runCli(['component', '--list', '--lang', 'zh']);
+    expect(r.status).toBe(0);
+    expect(r.stderr).toMatch(/translations are incomplete/);
+    expect(r.stderr).toMatch(/fall back to English/);
+  });
+
+  it('--lang en succeeds with no incomplete-translation warning', () => {
+    const r = runCli(['component', '--list', '--lang', 'en']);
+    expect(r.status).toBe(0);
+    expect(r.stderr).not.toMatch(/translations are incomplete/);
+  });
+
+  it('--lang zh --dense (ambiguous combo) exits 1', () => {
+    const r = runCli(['component', '--list', '--lang', 'zh', '--dense']);
+    expect(r.status).toBe(1);
+    expect(r.stderr).toMatch(/Cannot combine --lang/);
+  });
+});

--- a/packages/cli/src/index.mjs
+++ b/packages/cli/src/index.mjs
@@ -13,6 +13,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import {checkForUpdate} from './utils/update-check.mjs';
 import {getRunPrefix} from './utils/package-manager.mjs';
+import {validateLang} from './lib/lang-global.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -34,6 +35,24 @@ program
   .action(() => {
     program.help();
   });
+
+/**
+ * Global pre-action hook: validate the advertised `--lang` / `--zh` /
+ * `--dense` flags for EVERY command before any side effects run. An
+ * unsupported locale exits 1 (or emits a JSON error) instead of being
+ * silently ignored; a partially-translated locale warns. This makes the
+ * global `--lang` flag honest on write/action commands (init, template,
+ * theme, upgrade, swizzle, build, gap-report) that never translate.
+ */
+program.hook('preAction', () => {
+  const opts = program.opts();
+  validateLang({
+    lang: opts.lang ?? null,
+    zh: Boolean(opts.zh),
+    dense: Boolean(opts.dense),
+    json: Boolean(opts.json),
+  });
+});
 
 /**
  * Fallback hook: if --json was requested but the command didn't call

--- a/packages/cli/src/lib/lang-global.mjs
+++ b/packages/cli/src/lib/lang-global.mjs
@@ -1,0 +1,76 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Global --lang validation
+ *
+ * Centralizes validation of the global `--lang` / `--zh` / `--dense`
+ * flags so that EVERY command rejects unsupported locales (exit 1)
+ * before doing any work, and warns when a requested locale is only
+ * partially translated. This closes the "advertised-but-silently-
+ * ignored" honesty gap for write/action commands (init, template,
+ * theme, upgrade, swizzle, build, gap-report) that accept the global
+ * `--lang` flag from the root program but never translate.
+ *
+ * MERGE NOTE: PR #2407 introduces `src/lib/lang.mjs` with the same
+ * `SUPPORTED_LANGS` / `validateLang` contract wired per-command into
+ * component/hook/discover/docs. This module installs the SAME
+ * validator as a single global preAction hook so it also covers the
+ * write commands 2407 does not touch. At merge, prefer #2407's
+ * `lang.mjs` as the canonical validator and have the global hook
+ * import from it (delete this file's duplicate `validateLang`); keep
+ * the global preAction hook from this PR. Both buckets are "contract".
+ */
+
+import {jsonError} from './json.mjs';
+
+/** Locales the CLI claims to support (keep in sync with --lang desc). */
+export const SUPPORTED_LANGS = ['en', 'zh', 'dense'];
+
+/** Locales whose translation coverage is incomplete. */
+export const PARTIAL_LANGS = new Set(['zh']);
+
+/**
+ * Validate the global lang options. Exits 1 on invalid input (or emits
+ * a JSON error if --json is set). Emits a one-time stderr warning when a
+ * partially-translated locale is requested so we never silently produce
+ * English for an advertised locale.
+ *
+ * @param {{lang?: string|null, zh?: boolean, dense?: boolean, json?: boolean}} opts
+ * @returns {{lang: string|null}} normalized effective locale.
+ */
+export function validateLang(opts = {}) {
+  const {lang, zh, dense, json} = opts;
+
+  if (lang && (zh || dense)) {
+    const msg = 'Cannot combine --lang with legacy --zh or --dense flags.';
+    if (json) {
+      jsonError(msg);
+      return {lang: null};
+    }
+    console.error(`Error: ${msg}`);
+    process.exit(1);
+  }
+
+  const effective = lang || (dense ? 'dense' : zh ? 'zh' : null);
+  if (!effective) return {lang: null};
+
+  if (!SUPPORTED_LANGS.includes(effective)) {
+    const msg = `Unsupported language "${effective}". Supported: ${SUPPORTED_LANGS.join(', ')}.`;
+    if (json) {
+      jsonError(msg);
+      return {lang: null};
+    }
+    console.error(`Error: ${msg}`);
+    process.exit(1);
+  }
+
+  if (PARTIAL_LANGS.has(effective) && !process.__xdsLangWarned) {
+    process.__xdsLangWarned = true;
+    console.error(
+      `Warning: --lang ${effective} translations are incomplete. ` +
+        'Some prose will fall back to English.',
+    );
+  }
+
+  return {lang: effective};
+}


### PR DESCRIPTION
## What

The global `--lang` flag is declared on the root program, so it appears in **every** subcommand's `--help`. But only `component`/`hook`/`discover`/`docs` actually translate. The write/action commands — `init`, `template`, `theme`, `upgrade`, `swizzle`, `theme build`, `gap-report` — silently accepted `--lang xx` (and `--lang zh`) and produced English. That's an honesty gap (hardening checklist #10) and a flag-validation gap (#1).

## Change

A single global `preAction` hook in `index.mjs` validates `--lang` / `--zh` / `--dense` for every command **before any side effects**:

- unsupported locale → exit 1 with a clear message (or structured `{ error }` under `--json`)
- partially-translated locale (`zh`) → exit 0 + one-time stderr warning (no silent English)
- `--lang` combined with legacy `--zh`/`--dense` → exit 1 (ambiguous)

`init --all --lang xx` now exits 1 with **zero files written** (no half-writes / path-safety).

## Tests (prove the behavior)

9 subprocess/e2e tests in `lang-global.test.mjs` exercising read commands, write commands, the `--json` contract, side-effect-free rejection, and i18n honesty (zh warns, en doesn't).

## Checklist items closed

#1 (flag validation exits 1, not silent fallback) and #10 (i18n honesty) for the write/action commands **not** covered by #2407.

## Merge note

Same "contract" bucket as #2407 and #2402/#2430. #2407 introduces `src/lib/lang.mjs` with the same `SUPPORTED_LANGS` / `validateLang` contract wired per-command. At merge, prefer #2407's canonical `lang.mjs` and have this global hook import from it (drop the duplicate `lang-global.mjs` validator); **keep the global preAction hook** so write commands stay covered. Will also textually touch the same `index.mjs` hook region as #2402 (json) / #2430 (detail) — resolve by keeping all hooks.