### PR TITLE
fix(TabList): use accent color for indicator and shift up 1px

### DIFF
--- a/packages/core/src/TabList/XDSTab.tsx
+++ b/packages/core/src/TabList/XDSTab.tsx
@@ -129,7 +129,7 @@ const styles = stylex.create({
   },
   indicator: {
     position: 'absolute',
-    bottom: 'var(--_tab-indicator-bottom, -2px)',
+    bottom: 'var(--_tab-indicator-bottom, -1px)',
     left: spacingVars['--spacing-3'],
     right: spacingVars['--spacing-3'],
     height: '2px',
@@ -140,7 +140,7 @@ const styles = stylex.create({
     transitionTimingFunction: easeVars['--ease-standard'],
   },
   indicatorSelected: {
-    backgroundColor: colorVars['--color-icon-primary'],
+    backgroundColor: colorVars['--color-accent'],
     opacity: 1,
   },
   indicatorUnselected: {


### PR DESCRIPTION
## What

Fixes the tab indicator to use `--color-accent` instead of `--color-icon-primary`, and shifts it up 1px so it sits flush against the divider.

## Why

- **Color:** The tab underline indicates the *active* state — it's semantically an accent indicator, not an icon. Using `--color-icon-primary` (near-black/near-white) was incorrect; `--color-accent` (blue) matches what SelectableCard and other active-state components use.
- **Position:** The indicator was sitting 2px below the tab content, leaving a visible gap below the divider. Moving it to -1px places it flush so no pixels leak below.

## Changes

- `packages/core/src/TabList/XDSTab.tsx`:
  - `indicatorSelected` color: `--color-icon-primary` → `--color-accent`
  - `indicator` bottom: `-2px` → `-1px`

## Related

Supersedes the color portion of #2379 for TabList — that PR can focus on whether a separate `--color-border-active` token is still needed for other components (Stepper, Outline).