### PR TITLE
fix(docsite): remove Playground nav item from top navigation

### DIFF
--- a/apps/docsite/src/components/SharedTopNav.tsx
+++ b/apps/docsite/src/components/SharedTopNav.tsx
@@ -63,9 +63,6 @@ export function SharedTopNav() {
     if (pathname.startsWith('/components')) {
       return 'components';
     }
-    if (pathname.startsWith('/playground')) {
-      return 'playground';
-    }
     return undefined;
   };
 
@@ -96,11 +93,7 @@ export function SharedTopNav() {
               href="/themes"
               isSelected={getActiveItem() === 'themes'}
             />
-            <XDSTopNavItem
-              label="Playground"
-              href="/playground"
-              isSelected={getActiveItem() === 'playground'}
-            />
+
           </>
         }
         endContent={


### PR DESCRIPTION
Removes the Playground page link from the SharedTopNav component in the docsite app. Also cleans up the associated `getActiveItem()` case that detected the `/playground` route.