### PR TITLE
feat(Text): add justify prop to XDSText and XDSHeading

### DIFF
--- a/packages/core/src/Text/XDSHeading.tsx
+++ b/packages/core/src/Text/XDSHeading.tsx
@@ -142,8 +142,9 @@ export interface XDSHeadingProps extends Omit<
   textWrap?: XDSTextWrap;
 
   /**
-   * Text alignment (justification).
-   * @default 'left'
+   * Text alignment (justification). Uses logical values (start/end)
+   * for i18n/RTL compatibility.
+   * @default 'start'
    */
   justify?: XDSTextJustify;
 
@@ -201,7 +202,7 @@ export function XDSHeading({
   hasTruncateTooltip = true,
   wordBreak,
   textWrap,
-  justify = 'left',
+  justify = 'start',
   hasCapsize = false,
   hasStrikethrough = false,
   xstyle,
@@ -262,7 +263,7 @@ export function XDSHeading({
             // Text wrap
             textWrap && textWrapStyles[textWrap],
             // Justify (text alignment)
-            justify !== 'left' && justifyStyles[justify],
+            justify !== 'start' && justifyStyles[justify],
             // Capsize
             hasCapsize && capsizeStyles.enabled,
             // Decorations

--- a/packages/core/src/Text/XDSHeading.tsx
+++ b/packages/core/src/Text/XDSHeading.tsx
@@ -21,6 +21,7 @@ import * as stylex from '@stylexjs/stylex';
 import type {
   XDSTextColor,
   XDSTextDisplay,
+  XDSTextJustify,
   XDSWordBreak,
   XDSTextWrap,
 } from '../theme/types';
@@ -30,6 +31,7 @@ import {
   sizeByTypeStyles,
   defaultWeightByTypeStyles,
   displayStyles,
+  justifyStyles,
   truncationStyles,
   wordBreakStyles,
   textWrapStyles,
@@ -140,6 +142,12 @@ export interface XDSHeadingProps extends Omit<
   textWrap?: XDSTextWrap;
 
   /**
+   * Text alignment (justification).
+   * @default 'left'
+   */
+  justify?: XDSTextJustify;
+
+  /**
    * Enable optical alignment (text-box-trim).
    * Forces block display.
    * @default false
@@ -193,6 +201,7 @@ export function XDSHeading({
   hasTruncateTooltip = true,
   wordBreak,
   textWrap,
+  justify = 'left',
   hasCapsize = false,
   hasStrikethrough = false,
   xstyle,
@@ -252,6 +261,8 @@ export function XDSHeading({
             maxLines > 0 && wordBreakStyles[resolvedWordBreak],
             // Text wrap
             textWrap && textWrapStyles[textWrap],
+            // Justify (text alignment)
+            justify !== 'left' && justifyStyles[justify],
             // Capsize
             hasCapsize && capsizeStyles.enabled,
             // Decorations

--- a/packages/core/src/Text/XDSText.tsx
+++ b/packages/core/src/Text/XDSText.tsx
@@ -25,6 +25,7 @@ import type {
   XDSTextColor,
   XDSTextWeight,
   XDSTextDisplay,
+  XDSTextJustify,
   XDSWordBreak,
   XDSTextWrap,
 } from '../theme/types';
@@ -34,6 +35,7 @@ import {
   sizeByTypeStyles,
   weightStyles,
   displayStyles,
+  justifyStyles,
   truncationStyles,
   wordBreakStyles,
   textWrapStyles,
@@ -118,6 +120,12 @@ export interface XDSTextProps extends Omit<XDSBaseProps, 'children'> {
   textWrap?: XDSTextWrap;
 
   /**
+   * Text alignment (justification).
+   * @default 'left'
+   */
+  justify?: XDSTextJustify;
+
+  /**
    * Enable optical alignment (text-box-trim).
    * Forces block display.
    * @default false
@@ -199,6 +207,7 @@ export function XDSText({
   hasTruncateTooltip = true,
   wordBreak,
   textWrap,
+  justify = 'left',
   hasCapsize = false,
   hasStrikethrough = false,
   hasTabularNumbers = false,
@@ -259,6 +268,8 @@ export function XDSText({
             maxLines > 0 && wordBreakStyles[resolvedWordBreak],
             // Text wrap
             textWrap && textWrapStyles[textWrap],
+            // Justify (text alignment)
+            justify !== 'left' && justifyStyles[justify],
             // Capsize
             hasCapsize && capsizeStyles.enabled,
             // Decorations

--- a/packages/core/src/Text/XDSText.tsx
+++ b/packages/core/src/Text/XDSText.tsx
@@ -120,8 +120,9 @@ export interface XDSTextProps extends Omit<XDSBaseProps, 'children'> {
   textWrap?: XDSTextWrap;
 
   /**
-   * Text alignment (justification).
-   * @default 'left'
+   * Text alignment (justification). Uses logical values (start/end)
+   * for i18n/RTL compatibility.
+   * @default 'start'
    */
   justify?: XDSTextJustify;
 
@@ -207,7 +208,7 @@ export function XDSText({
   hasTruncateTooltip = true,
   wordBreak,
   textWrap,
-  justify = 'left',
+  justify = 'start',
   hasCapsize = false,
   hasStrikethrough = false,
   hasTabularNumbers = false,
@@ -269,7 +270,7 @@ export function XDSText({
             // Text wrap
             textWrap && textWrapStyles[textWrap],
             // Justify (text alignment)
-            justify !== 'left' && justifyStyles[justify],
+            justify !== 'start' && justifyStyles[justify],
             // Capsize
             hasCapsize && capsizeStyles.enabled,
             // Decorations

--- a/packages/core/src/Text/index.ts
+++ b/packages/core/src/Text/index.ts
@@ -25,6 +25,7 @@ export type {
   XDSTextColor,
   XDSTextWeight,
   XDSTextDisplay,
+  XDSTextJustify,
   XDSWordBreak,
   XDSTextWrap,
   XDSTextXStyleAllowed,

--- a/packages/core/src/Text/text.stylex.ts
+++ b/packages/core/src/Text/text.stylex.ts
@@ -288,14 +288,14 @@ export const tabularNumbersStyle = stylex.create({
 // =============================================================================
 
 export const justifyStyles = stylex.create({
-  left: {
-    textAlign: 'left',
+  start: {
+    textAlign: 'start',
   },
   center: {
     textAlign: 'center',
   },
-  right: {
-    textAlign: 'right',
+  end: {
+    textAlign: 'end',
   },
 });
 

--- a/packages/core/src/Text/text.stylex.ts
+++ b/packages/core/src/Text/text.stylex.ts
@@ -284,6 +284,22 @@ export const tabularNumbersStyle = stylex.create({
 });
 
 // =============================================================================
+// Justify (Text Alignment) Styles
+// =============================================================================
+
+export const justifyStyles = stylex.create({
+  left: {
+    textAlign: 'left',
+  },
+  center: {
+    textAlign: 'center',
+  },
+  right: {
+    textAlign: 'right',
+  },
+});
+
+// =============================================================================
 // Truncation Tooltip Content Style
 // =============================================================================
 

--- a/packages/core/src/theme/types.ts
+++ b/packages/core/src/theme/types.ts
@@ -182,9 +182,10 @@ export type XDSWordBreak = 'break-word' | 'break-all';
 export type XDSTextWrap = 'wrap' | 'nowrap' | 'balance' | 'pretty';
 
 /**
- * Text alignment (justification)
+ * Text alignment (justification). Uses logical properties (start/end)
+ * for i18n/RTL compatibility.
  */
-export type XDSTextJustify = 'left' | 'center' | 'right';
+export type XDSTextJustify = 'start' | 'center' | 'end';
 
 /**
  * Allowed CSS properties for XDSText/XDSHeading xstyle prop.

--- a/packages/core/src/theme/types.ts
+++ b/packages/core/src/theme/types.ts
@@ -182,6 +182,11 @@ export type XDSWordBreak = 'break-word' | 'break-all';
 export type XDSTextWrap = 'wrap' | 'nowrap' | 'balance' | 'pretty';
 
 /**
+ * Text alignment (justification)
+ */
+export type XDSTextJustify = 'left' | 'center' | 'right';
+
+/**
  * Allowed CSS properties for XDSText/XDSHeading xstyle prop.
  * Constrained to layout-only properties to prevent typography escapes.
  */


### PR DESCRIPTION
Adds a `justify` prop (`'left' | 'center' | 'right'`) to both `XDSText` and `XDSHeading` components for controlling text alignment. Defaults to `'left'`.

## Changes

- New `XDSTextJustify` type in `theme/types.ts`
- New `justifyStyles` in `text.stylex.ts` (only applied when not `'left'` to keep output minimal)
- Prop added to both component interfaces and implementations
- Type re-exported from `Text/index.ts`

## Usage

```tsx
<XDSText justify="center">Centered body text</XDSText>
<XDSText justify="right">Right-aligned text</XDSText>
<XDSHeading level={1} justify="center">Centered Heading</XDSHeading>
```