### PR TITLE
fix(AppShell): stretch content area in auto mode for sticky footer

### DIFF
--- a/apps/storybook/stories/AppShell.stories.tsx
+++ b/apps/storybook/stories/AppShell.stories.tsx
@@ -53,6 +53,22 @@ const styles = stylex.create({
     flexDirection: 'column' as const,
     gap: 16,
   },
+  footer: {
+    borderTop: '1px solid var(--xds-color-border-default, #e0e0e0)',
+    paddingBlock: 16,
+    paddingInline: 24,
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  stickyFooterLayout: {
+    display: 'flex',
+    flexDirection: 'column' as const,
+    flex: 1,
+  },
+  stickyFooterContent: {
+    flex: '1 0 auto',
+  },
 });
 
 // =============================================================================
@@ -653,4 +669,94 @@ export const WithMobileNav: Story = {
       </XDSAppShell>
     );
   },
+};
+
+// =============================================================================
+// Sticky Footer — Auto Height
+// =============================================================================
+
+/**
+ * Demonstrates the sticky footer pattern in auto height mode.
+ * The footer pins to the bottom of the viewport when page content
+ * is shorter than the screen — no manual calc() or height hacks needed.
+ */
+export const AutoHeightStickyFooter: Story = {
+  render: () => (
+    <XDSAppShell contentPadding={6} topNav={<AppTopNav />} height="auto">
+      <div {...stylex.props(styles.stickyFooterLayout)}>
+        <div {...stylex.props(styles.stickyFooterContent)}>
+          <XDSText type="large">Short Page</XDSText>
+          <XDSText type="body">
+            This page has very little content, but the footer still pins to the
+            bottom of the viewport thanks to the auto-height flex stretch.
+          </XDSText>
+        </div>
+        <div {...stylex.props(styles.footer)}>
+          <XDSText type="caption" color="secondary">
+            © 2025 Acme Inc.
+          </XDSText>
+          <XDSText type="caption" color="secondary">
+            Privacy · Terms · Status
+          </XDSText>
+        </div>
+      </div>
+    </XDSAppShell>
+  ),
+};
+
+/**
+ * Auto height with sticky footer AND a side nav.
+ * Verifies the sticky footer works alongside the sticky sideNav behavior.
+ */
+export const AutoHeightStickyFooterWithSideNav: Story = {
+  render: () => (
+    <XDSAppShell
+      contentPadding={6}
+      topNav={<AppTopNav />}
+      sideNav={<SideNavWithoutHeader />}
+      height="auto">
+      <div {...stylex.props(styles.stickyFooterLayout)}>
+        <div {...stylex.props(styles.stickyFooterContent)}>
+          <XDSText type="large">Dashboard</XDSText>
+          <XDSText type="body">
+            Minimal content here — the footer stays at the bottom of the
+            viewport regardless.
+          </XDSText>
+        </div>
+        <div {...stylex.props(styles.footer)}>
+          <XDSText type="caption" color="secondary">
+            © 2025 Acme Inc. All rights reserved.
+          </XDSText>
+          <XDSText type="caption" color="secondary">
+            v2.4.1
+          </XDSText>
+        </div>
+      </div>
+    </XDSAppShell>
+  ),
+};
+
+/**
+ * Auto height with a long page — footer naturally appears after content.
+ * When content exceeds the viewport, the footer flows naturally below the
+ * content (no fixed pinning). This confirms the fix doesn't break scrolling.
+ */
+export const AutoHeightLongPageWithFooter: Story = {
+  render: () => (
+    <XDSAppShell contentPadding={6} topNav={<AppTopNav />} height="auto">
+      <div {...stylex.props(styles.stickyFooterLayout)}>
+        <div {...stylex.props(styles.stickyFooterContent)}>
+          <MockContent paragraphs={20} />
+        </div>
+        <div {...stylex.props(styles.footer)}>
+          <XDSText type="caption" color="secondary">
+            © 2025 Acme Inc.
+          </XDSText>
+          <XDSText type="caption" color="secondary">
+            Privacy · Terms · Status
+          </XDSText>
+        </div>
+      </div>
+    </XDSAppShell>
+  ),
 };

--- a/apps/storybook/stories/AppShell.stories.tsx
+++ b/apps/storybook/stories/AppShell.stories.tsx
@@ -692,10 +692,10 @@ export const AutoHeightStickyFooter: Story = {
           </XDSText>
         </div>
         <div {...stylex.props(styles.footer)}>
-          <XDSText type="caption" color="secondary">
+          <XDSText type="supporting" color="secondary">
             © 2025 Acme Inc.
           </XDSText>
-          <XDSText type="caption" color="secondary">
+          <XDSText type="supporting" color="secondary">
             Privacy · Terms · Status
           </XDSText>
         </div>
@@ -724,10 +724,10 @@ export const AutoHeightStickyFooterWithSideNav: Story = {
           </XDSText>
         </div>
         <div {...stylex.props(styles.footer)}>
-          <XDSText type="caption" color="secondary">
+          <XDSText type="supporting" color="secondary">
             © 2025 Acme Inc. All rights reserved.
           </XDSText>
-          <XDSText type="caption" color="secondary">
+          <XDSText type="supporting" color="secondary">
             v2.4.1
           </XDSText>
         </div>
@@ -749,10 +749,10 @@ export const AutoHeightLongPageWithFooter: Story = {
           <MockContent paragraphs={20} />
         </div>
         <div {...stylex.props(styles.footer)}>
-          <XDSText type="caption" color="secondary">
+          <XDSText type="supporting" color="secondary">
             © 2025 Acme Inc.
           </XDSText>
-          <XDSText type="caption" color="secondary">
+          <XDSText type="supporting" color="secondary">
             Privacy · Terms · Status
           </XDSText>
         </div>

--- a/packages/core/src/AppShell/XDSAppShell.test.tsx
+++ b/packages/core/src/AppShell/XDSAppShell.test.tsx
@@ -480,6 +480,32 @@ describe('XDSAppShell', () => {
     expect(observeSpy).not.toHaveBeenCalled();
   });
 
+  it('applies flex column stretch to content area in auto mode', () => {
+    render(
+      <XDSAppShell height="auto" data-testid="shell">
+        <div data-testid="child">Content</div>
+      </XDSAppShell>,
+    );
+    // The content area (role="main") should be a flex column in auto mode
+    const main = screen.getByRole('main');
+    const style = getComputedStyle(main);
+    expect(style.display).toBe('flex');
+    expect(style.flexDirection).toBe('column');
+  });
+
+  it('does not apply flex column stretch to content area in fill mode', () => {
+    render(
+      <XDSAppShell height="fill" data-testid="shell">
+        <div data-testid="child">Content</div>
+      </XDSAppShell>,
+    );
+    const main = screen.getByRole('main');
+    const style = getComputedStyle(main);
+    // In fill mode, content area should NOT have flex-direction column
+    // (it uses default block layout with scroll containment)
+    expect(style.flexDirection).not.toBe('column');
+  });
+
   // ===========================================================================
   // Mobile nav slot
   // ===========================================================================

--- a/packages/core/src/AppShell/XDSAppShell.tsx
+++ b/packages/core/src/AppShell/XDSAppShell.tsx
@@ -404,6 +404,17 @@ const styles = stylex.create({
     flex: 1,
     overflow: 'auto',
   },
+  // Content area fix for auto mode — makes the content a flex column so that
+  // children can use flex-grow to fill remaining vertical space (sticky footer
+  // pattern). Overrides height/overflow from XDSLayoutContent's default styles
+  // which assume fill-mode (fixed-height, internally scrollable) behavior.
+  contentAutoStretch: {
+    display: 'flex',
+    flexDirection: 'column' as const,
+    height: 'auto',
+    minHeight: '100%',
+    overflow: 'visible',
+  },
 });
 
 // =============================================================================
@@ -709,7 +720,7 @@ export function XDSAppShell({
       role="main"
       id={MAIN_CONTENT_ID}
       isScrollable={isFill}
-      xstyle={contentAreaStyle}>
+      xstyle={[contentAreaStyle, isAuto && styles.contentAutoStretch]}>
       {children}
     </XDSLayoutContent>
   );


### PR DESCRIPTION
## Problem

In `height="auto"` mode, the AppShell content area (`XDSLayoutContent`) has `height: 100%` and `overflow: clip` inherited from fill-mode defaults. This prevents children from stretching to fill remaining viewport space — so short pages can't pin a footer to the bottom without manual `calc(100vh - var(--appshell-header-height))` hacks (as seen in #2421's `layout.module.css`).

## Fix

Adds a `contentAutoStretch` style applied to the content area only in auto mode:

- `display: flex; flex-direction: column` — children can use `flex: 1` to stretch
- `height: auto` — overrides the fill-mode `height: 100%`
- `min-height: 100%` — ensures content fills available space
- `overflow: visible` — overrides fill-mode `overflow: clip` (page scrolls instead)

Consumers can now use a simple flex column inside AppShell children for sticky footer behavior with no knowledge of `--appshell-header-height` or other internal CSS vars:

```tsx
<XDSAppShell height="auto" topNav={<TopNav />}>
  <div style={{ display: 'flex', flexDirection: 'column', flex: 1 }}>
    <main style={{ flex: '1 0 auto' }}>{children}</main>
    <Footer />
  </div>
</XDSAppShell>
```

## Stories

Added three stories demonstrating the pattern:
- **AutoHeightStickyFooter** — short page, footer at viewport bottom
- **AutoHeightStickyFooterWithSideNav** — same with side navigation
- **AutoHeightLongPageWithFooter** — long page, footer flows naturally after content

## Tests

Added unit tests verifying flex column is applied in auto mode and not in fill mode.

Closes the gap identified in #2421.