### PR TITLE
fix(FileInput): use color-mix for hover shadow and XDSInputClearButton

### DIFF
--- a/packages/core/src/FileInput/XDSFileInput.tsx
+++ b/packages/core/src/FileInput/XDSFileInput.tsx
@@ -36,7 +36,12 @@ import {
   durationVars,
   easeVars,
 } from '../theme/tokens.stylex';
-import {XDSField, type XDSInputStatus, type XDSInputStatusType} from '../Field';
+import {
+  XDSField,
+  XDSInputClearButton,
+  type XDSInputStatus,
+  type XDSInputStatusType,
+} from '../Field';
 import {XDSIcon, type XDSIconName} from '../Icon';
 import {XDSSpinner} from '../Spinner';
 
@@ -137,7 +142,7 @@ const styles = stylex.create({
     boxShadow: {
       default: null,
       ':hover': {
-        '@media (hover: hover)': `inset 0 0 0 2px ${String(colorVars['--color-accent'])}33`,
+        '@media (hover: hover)': `inset 0 0 0 2px color-mix(in srgb, ${colorVars['--color-accent']} 20%, transparent)`,
       },
     },
   },
@@ -176,7 +181,7 @@ const styles = stylex.create({
     boxShadow: {
       default: 'none',
       ':hover:not(:focus-within)': {
-        '@media (hover: hover)': `inset 0 0 0 2px ${String(colorVars['--color-accent'])}33`,
+        '@media (hover: hover)': `inset 0 0 0 2px color-mix(in srgb, ${colorVars['--color-accent']} 20%, transparent)`,
       },
     },
     cursor: 'pointer',
@@ -223,24 +228,6 @@ const styles = stylex.create({
     whiteSpace: 'nowrap',
     flex: 1,
     minWidth: 0,
-  },
-  clearButton: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    padding: 0,
-    margin: 0,
-    borderWidth: 0,
-    borderStyle: 'none',
-    backgroundColor: 'transparent',
-    cursor: 'pointer',
-    borderRadius: radiusVars['--radius-element'],
-    outline: {
-      default: 'none',
-      ':focus-visible': `${borderVars['--border-width']} solid ${colorVars['--color-accent']}`,
-    },
-    outlineOffset: 1,
-    flexShrink: 0,
   },
   fileNameDropzone: {
     textAlign: 'center',
@@ -707,13 +694,7 @@ export function XDSFileInput({
         />
         {isDropzone ? renderDropzoneContent() : renderCompactContent()}
         {hasFiles && !isDisabled && !isLoading && (
-          <button
-            type="button"
-            onClick={handleClear}
-            aria-label={`Clear ${label}`}
-            {...stylex.props(styles.clearButton)}>
-            <XDSIcon icon="close" size="sm" color="secondary" />
-          </button>
+          <XDSInputClearButton label={`Clear ${label}`} onClick={handleClear} />
         )}
       </div>
       <div


### PR DESCRIPTION
## Changes

**XDSFileInput** — two hardening fixes:

1. **Shadow tokenization**: Replaced partially-tokenized box-shadow strings (`${colorVars['--color-accent']}33`) with `color-mix(in srgb, ${colorVars['--color-accent']} 20%, transparent)`. The hex-alpha suffix approach doesn't compose correctly with CSS custom properties in all runtimes. `color-mix` is the standard pattern used by `inputStyles.stylex.ts`.

2. **Component reuse**: Replaced the raw `<button>` clear action with `XDSInputClearButton` (shared Field primitive). This ensures consistent sizing, focus ring, and ghost button styling across all input components.

Removed the now-unused `clearButton` style definition.

## Components Audited

| Component | Result |
|-----------|--------|
| Tooltip | Clean |
| EmptyState | Clean |
| Field | Clean |
| FileInput | Fixed (this PR) |
| FormLayout | Clean |
| Grid | Clean |

Night Watch — Component Auditor