### PR TITLE
fix(deps): resolve tmp path traversal vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,8 @@
       "anymatch>picomatch": "^2.3.2",
       "minimatch": "^9.0.7",
       "dompurify": "^3.3.2",
-      "vite": "^6.4.2"
+      "vite": "^6.4.2",
+      "tmp": ">=0.2.6"
     },
     "onlyBuiltDependencies": [
       "esbuild",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,7 @@ overrides:
   minimatch: ^9.0.7
   dompurify: ^3.3.2
   vite: ^6.4.2
+  tmp: '>=0.2.6'
 
 importers:
 
@@ -5545,8 +5546,8 @@ packages:
     resolution: {integrity: sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==}
     hasBin: true
 
-  tmp@0.2.5:
-    resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
+  tmp@0.2.7:
+    resolution: {integrity: sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==}
     engines: {node: '>=14.14'}
 
   to-regex-range@5.0.1:
@@ -9613,7 +9614,7 @@ snapshots:
       neo-async: 2.6.2
       picocolors: 1.1.1
       recast: 0.23.11
-      tmp: 0.2.5
+      tmp: 0.2.7
       write-file-atomic: 5.0.1
     transitivePeerDependencies:
       - supports-color
@@ -10459,7 +10460,7 @@ snapshots:
     dependencies:
       tldts-core: 7.0.30
 
-  tmp@0.2.5: {}
+  tmp@0.2.7: {}
 
   to-regex-range@5.0.1:
     dependencies:


### PR DESCRIPTION
Resolves Dependabot alert #76 — tmp < 0.2.6 has a path traversal vulnerability via unsanitized prefix/postfix that enables directory escape.

## Changes

- Added pnpm override: `tmp: >=0.2.6`
- tmp is a transitive dependency via jscodeshift (devDependency only)
- Resolved version: 0.2.7 (within jscodeshift's `^0.2.3` range)

## Verification

- `pnpm install` ✓
- `pnpm build` ✓
- `pnpm test --run` ✓ (217 files, 3826 tests passed)

Night Watch — Dependencies