### PR TITLE
fix(core): component audit — AspectRatio props, AppShell CSS var naming

### DIFF
--- a/packages/core/src/AppShell/XDSAppShell.tsx
+++ b/packages/core/src/AppShell/XDSAppShell.tsx
@@ -392,8 +392,8 @@ const styles = stylex.create({
     flexShrink: 0,
     overflow: 'clip',
     position: 'sticky',
-    top: 'var(--_app-shell-header-height, 0px)',
-    height: 'calc(100dvh - var(--_app-shell-header-height, 0px))',
+    top: 'var(--appshell-header-height, 0px)',
+    height: 'calc(100dvh - var(--appshell-header-height, 0px))',
     // Ensure children (XDSLayoutPanel → XDSSideNav) fill the sticky container
     display: 'flex',
     flexDirection: 'column',
@@ -556,7 +556,7 @@ export function XDSAppShell({
 
     const updateHeight = () => {
       const height = headerEl.getBoundingClientRect().height;
-      shellEl.style.setProperty('--_app-shell-header-height', `${height}px`);
+      shellEl.style.setProperty('--appshell-header-height', `${height}px`);
     };
 
     observeResize(headerEl, () => updateHeight());

--- a/packages/core/src/AppShell/XDSAppShell.tsx
+++ b/packages/core/src/AppShell/XDSAppShell.tsx
@@ -392,8 +392,8 @@ const styles = stylex.create({
     flexShrink: 0,
     overflow: 'clip',
     position: 'sticky',
-    top: 'var(--appshell-header-height, 0px)',
-    height: 'calc(100dvh - var(--appshell-header-height, 0px))',
+    top: 'var(--_app-shell-header-height, 0px)',
+    height: 'calc(100dvh - var(--_app-shell-header-height, 0px))',
     // Ensure children (XDSLayoutPanel → XDSSideNav) fill the sticky container
     display: 'flex',
     flexDirection: 'column',
@@ -556,7 +556,7 @@ export function XDSAppShell({
 
     const updateHeight = () => {
       const height = headerEl.getBoundingClientRect().height;
-      shellEl.style.setProperty('--appshell-header-height', `${height}px`);
+      shellEl.style.setProperty('--_app-shell-header-height', `${height}px`);
     };
 
     observeResize(headerEl, () => updateHeight());

--- a/packages/core/src/AspectRatio/XDSAspectRatio.tsx
+++ b/packages/core/src/AspectRatio/XDSAspectRatio.tsx
@@ -17,7 +17,6 @@
 
 import type {ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import type {StyleXStyles} from '@stylexjs/stylex';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import {xdsClassName, mergeProps} from '../utils';
 
@@ -34,28 +33,6 @@ export interface XDSAspectRatioProps extends XDSBaseProps<HTMLDivElement> {
    * The child element will be positioned absolutely to fill the container.
    */
   children: ReactNode;
-
-  /**
-   * StyleX styles created via `stylex.create()`. Merged with the component's
-   * base styles inside a single `stylex.props()` call for optimal deduplication.
-   *
-   * @example
-   * ```
-   * const overrides = stylex.create({ root: { marginBottom: 8 } });
-   * <Component xstyle={overrides.root} />
-   * ```
-   */
-  xstyle?: StyleXStyles;
-  /**
-   * CSS class name(s) appended to the root element.
-   * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
-   */
-  className?: string;
-  /**
-   * Inline styles to apply to the root element. Spread after StyleX
-   * inline styles, so these values take priority.
-   */
-  style?: React.CSSProperties;
 }
 
 const styles = stylex.create({


### PR DESCRIPTION
## Component Audit — 2026-06-01

Audited: AlertDialog, AppShell, AspectRatio, Avatar, AvatarGroup

### Findings & Fixes

**AspectRatio — structure-issue**
- Removed redundant `xstyle`, `className`, `style` prop declarations from `XDSAspectRatioProps`
- These are already provided by `XDSBaseProps<HTMLDivElement>` which the interface extends
- Also removed the unused `StyleXStyles` import

**AppShell — naming-violation**
- Renamed CSS custom property `--appshell-header-height` → `--_app-shell-header-height`
- Follows the component CSS variable naming convention: `--[_]<component>[-<part>]-<property>`
- Uses `--_` prefix (private var, internal measurement)
- Uses `app-shell` (matches `xdsClassName('app-shell', ...)`)

### No Issues Found

- AlertDialog: Clean — proper composition via XDSDialog, correct xdsClassName, good a11y
- Avatar: Clean — proper token usage, xdsClassName with variants, displayName
- AvatarGroup: Clean — proper context-based composition, correct CSS var naming

Night Watch — Component Auditor