### PR TITLE
fix(cli): centralize interactivity contract — no command hangs in non-TTY/CI

### DIFF
--- a/packages/cli/src/commands/init.mjs
+++ b/packages/cli/src/commands/init.mjs
@@ -20,6 +20,7 @@ import {CLI_ROOT} from '../utils/paths.mjs';
 import {getRunPrefix} from '../utils/package-manager.mjs';
 import {installAgentDocs, removeAgentDocs} from './agent-docs.mjs';
 import {listTemplates} from './template.mjs';
+import {requireInteractive} from '../utils/interactive.mjs';
 
 const VALID_FEATURES = ['agents', 'theme', 'template'];
 const run = getRunPrefix();
@@ -179,6 +180,15 @@ export function registerInit(program) {
       }
 
       // Interactive wizard
+      //
+      // Guard: this wizard blocks on prompts. In a non-interactive context
+      // (CI, piped stdin/stdout, no TTY) it would hang forever. Fail fast
+      // with actionable guidance via the shared interactivity contract.
+      requireInteractive({
+        command: 'init',
+        hint: `\`${run} xds init --all\` or \`--features agents,theme,template\``,
+      });
+
       p.intro('Welcome to XDS');
 
       p.note(

--- a/packages/cli/src/commands/interactive-guard.test.mjs
+++ b/packages/cli/src/commands/interactive-guard.test.mjs
@@ -3,8 +3,8 @@
 /**
  * @file Subprocess no-hang tests for the interactivity contract.
  *
- * The wizard commands (`init`, `theme`) block on @clack/prompts. In a
- * non-interactive context they must fail fast (exit 1) instead of hanging.
+ * The wizard command `init` blocks on @clack/prompts. In a
+ * non-interactive context it must fail fast (exit 1) instead of hanging.
  * These tests spawn the CLI as a real subprocess with stdin/stdout NOT a TTY
  * (stdio 'ignore'/'pipe'), which is exactly the CI / piped condition. If the
  * guard were missing, spawnSync would hit the timeout (signal SIGTERM,
@@ -65,21 +65,5 @@ describe('init non-interactive safety', () => {
     expect(r.signal).toBeNull();
     expect(r.status).toBe(0);
     expect(fs.readdirSync(tmpDir).length).toBeGreaterThan(0);
-  });
-});
-
-describe('theme non-interactive safety', () => {
-  it('fails fast (exit 1, no hang) with no preset', () => {
-    const r = runCli(['theme']);
-    expect(r.signal).toBeNull();
-    expect(r.status).toBe(1);
-    expect(r.stderr + r.stdout).toMatch(/requires a TTY/i);
-  });
-
-  it('still scaffolds non-interactively when given a preset', () => {
-    const r = runCli(['theme', 'default', '--output', 'my-theme.ts']);
-    expect(r.signal).toBeNull();
-    expect(r.status).toBe(0);
-    expect(fs.existsSync(path.join(tmpDir, 'my-theme.ts'))).toBe(true);
   });
 });

--- a/packages/cli/src/commands/interactive-guard.test.mjs
+++ b/packages/cli/src/commands/interactive-guard.test.mjs
@@ -1,0 +1,85 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Subprocess no-hang tests for the interactivity contract.
+ *
+ * The wizard commands (`init`, `theme`) block on @clack/prompts. In a
+ * non-interactive context they must fail fast (exit 1) instead of hanging.
+ * These tests spawn the CLI as a real subprocess with stdin/stdout NOT a TTY
+ * (stdio 'ignore'/'pipe'), which is exactly the CI / piped condition. If the
+ * guard were missing, spawnSync would hit the timeout (signal SIGTERM,
+ * status null) — so asserting `signal === null && status === 1` proves the
+ * process exited cleanly rather than hanging.
+ */
+
+import {describe, it, expect, beforeEach, afterEach} from 'vitest';
+import {spawnSync} from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import {fileURLToPath} from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CLI = path.resolve(__dirname, '..', '..', 'bin', 'xds.mjs');
+
+let tmpDir;
+
+function runCli(args) {
+  return spawnSync(process.execPath, [CLI, ...args], {
+    cwd: tmpDir,
+    encoding: 'utf8',
+    timeout: 20_000,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: {...process.env, FORCE_COLOR: '0', CI: ''},
+  });
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'xds-interactive-guard-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, {recursive: true, force: true});
+});
+
+describe('init non-interactive safety', () => {
+  it('fails fast (exit 1, no hang) and writes no files', () => {
+    const r = runCli(['init']);
+    expect(r.signal).toBeNull();
+    expect(r.status).toBe(1);
+    expect(fs.readdirSync(tmpDir)).toEqual([]);
+  });
+
+  it('prints actionable guidance (--all / --features)', () => {
+    const out = (() => {
+      const r = runCli(['init']);
+      return r.stderr + r.stdout;
+    })();
+    expect(out).toMatch(/requires a TTY/i);
+    expect(out).toMatch(/--all/);
+    expect(out).toMatch(/--features/);
+  });
+
+  it('still runs --features agents non-interactively (guard does not over-catch)', () => {
+    const r = runCli(['init', '--features', 'agents']);
+    expect(r.signal).toBeNull();
+    expect(r.status).toBe(0);
+    expect(fs.readdirSync(tmpDir).length).toBeGreaterThan(0);
+  });
+});
+
+describe('theme non-interactive safety', () => {
+  it('fails fast (exit 1, no hang) with no preset', () => {
+    const r = runCli(['theme']);
+    expect(r.signal).toBeNull();
+    expect(r.status).toBe(1);
+    expect(r.stderr + r.stdout).toMatch(/requires a TTY/i);
+  });
+
+  it('still scaffolds non-interactively when given a preset', () => {
+    const r = runCli(['theme', 'default', '--output', 'my-theme.ts']);
+    expect(r.signal).toBeNull();
+    expect(r.status).toBe(0);
+    expect(fs.existsSync(path.join(tmpDir, 'my-theme.ts'))).toBe(true);
+  });
+});

--- a/packages/cli/src/commands/swizzle.mjs
+++ b/packages/cli/src/commands/swizzle.mjs
@@ -15,6 +15,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as p from '@clack/prompts';
 import {findCoreDir, listComponents} from '../utils/paths.mjs';
+import {isInteractive} from '../utils/interactive.mjs';
 import {jsonOut, jsonError} from '../lib/json.mjs';
 import {
   buildGapReportPreview,
@@ -239,6 +240,15 @@ export function registerSwizzle(program) {
       }
 
       // Interactive gap report prompt
+      //
+      // This prompt is OPTIONAL — the swizzle copy already succeeded above.
+      // In a non-interactive context (CI, piped I/O, no TTY) we must not
+      // block on it; skip gracefully rather than hang. Use --gap with
+      // explicit flags for non-interactive gap reporting.
+      if (!isInteractive()) {
+        return;
+      }
+
       if (!gapConfig.command && !checkGhCli()) {
         // Silently skip if gh isn't available and no custom command configured
         return;

--- a/packages/cli/src/commands/theme.mjs
+++ b/packages/cli/src/commands/theme.mjs
@@ -15,7 +15,6 @@ import * as path from 'node:path';
 import * as p from '@clack/prompts';
 import {findCoreDir} from '../utils/paths.mjs';
 import {getRunPrefix} from '../utils/package-manager.mjs';
-import {requireInteractive} from '../utils/interactive.mjs';
 
 function isCancel(value) {
   if (p.isCancel(value)) {
@@ -214,16 +213,6 @@ export function registerTheme(program) {
       // =====================================================================
       // Interactive mode
       // =====================================================================
-      //
-      // Guard: the scaffold wizard blocks on prompts. In a non-interactive
-      // context (CI, piped stdin/stdout, no TTY) it would hang forever. Fail
-      // fast with actionable guidance instead. Pass a preset name (e.g.
-      // `xds theme default`) to scaffold without prompts.
-      requireInteractive({
-        command: 'theme',
-        hint: `\`${getRunPrefix()} xds theme <preset>\` (e.g. default, neutral) or \`--list\``,
-      });
-
       p.intro('XDS Theme Scaffold');
 
       // Step 1: Choose starting point

--- a/packages/cli/src/commands/theme.mjs
+++ b/packages/cli/src/commands/theme.mjs
@@ -15,6 +15,7 @@ import * as path from 'node:path';
 import * as p from '@clack/prompts';
 import {findCoreDir} from '../utils/paths.mjs';
 import {getRunPrefix} from '../utils/package-manager.mjs';
+import {requireInteractive} from '../utils/interactive.mjs';
 
 function isCancel(value) {
   if (p.isCancel(value)) {
@@ -213,6 +214,16 @@ export function registerTheme(program) {
       // =====================================================================
       // Interactive mode
       // =====================================================================
+      //
+      // Guard: the scaffold wizard blocks on prompts. In a non-interactive
+      // context (CI, piped stdin/stdout, no TTY) it would hang forever. Fail
+      // fast with actionable guidance instead. Pass a preset name (e.g.
+      // `xds theme default`) to scaffold without prompts.
+      requireInteractive({
+        command: 'theme',
+        hint: `\`${getRunPrefix()} xds theme <preset>\` (e.g. default, neutral) or \`--list\``,
+      });
+
       p.intro('XDS Theme Scaffold');
 
       // Step 1: Choose starting point

--- a/packages/cli/src/utils/interactive.mjs
+++ b/packages/cli/src/utils/interactive.mjs
@@ -1,0 +1,76 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Interactivity contract for the CLI.
+ *
+ * A single source of truth for "can this process prompt the user?". Several
+ * commands launch @clack/prompts wizards; in a non-interactive context (CI,
+ * piped stdin/stdout, no TTY) those prompts block forever. Historically each
+ * command answered this question differently — some checked `stdout.isTTY`,
+ * one checked `stdin.isTTY`, one added `!process.env.CI`, and some had no
+ * guard at all. This module centralizes the check so every command behaves
+ * identically.
+ *
+ * Two entry points, for two situations:
+ *
+ *   - `requireInteractive()` — for commands whose prompt IS the work
+ *     (e.g. `xds init`, `xds theme`). With no TTY there is nothing to do, so
+ *     fail fast (exit 1) with actionable, non-interactive guidance.
+ *
+ *   - `isInteractive()` — for commands with an OPTIONAL secondary prompt
+ *     (e.g. swizzle's post-copy "report a gap?"). The primary work already
+ *     succeeded; callers use this to skip the prompt gracefully.
+ */
+
+/**
+ * True when the process can safely run an interactive prompt.
+ *
+ * Requires BOTH stdin and stdout to be TTYs (clack reads stdin and renders to
+ * stdout) and that we are not in a CI environment. A CI runner may allocate a
+ * pseudo-TTY, so `process.env.CI` is an explicit override: never prompt in CI.
+ *
+ * @param {object} [env] - Override hook for tests.
+ * @param {boolean} [env.stdinTTY=process.stdin.isTTY]
+ * @param {boolean} [env.stdoutTTY=process.stdout.isTTY]
+ * @param {boolean} [env.ci=Boolean(process.env.CI)]
+ * @returns {boolean}
+ */
+export function isInteractive({
+  stdinTTY = Boolean(process.stdin && process.stdin.isTTY),
+  stdoutTTY = Boolean(process.stdout && process.stdout.isTTY),
+  ci = Boolean(process.env.CI),
+} = {}) {
+  if (ci) return false;
+  return stdinTTY && stdoutTTY;
+}
+
+/**
+ * Guard for commands whose primary action is an interactive wizard. When the
+ * process is non-interactive, prints an actionable error and exits 1 instead
+ * of hanging on a prompt that will never receive input.
+ *
+ * @param {object} options
+ * @param {string} options.command - Command name for the message, e.g. 'init'.
+ * @param {string} options.hint - Concrete non-interactive invocation, e.g.
+ *   '`pnpm xds init --all` or `--features agents,theme,template`'.
+ * @param {boolean} [options.json=false] - When true, the command does not
+ *   support --json; we still exit 1 but skip the human-formatted guidance.
+ * @param {object} [env] - Forwarded to isInteractive (test hook).
+ * @returns {void} Returns when interactive; otherwise calls process.exit(1).
+ */
+export function requireInteractive({command, hint, json = false} = {}, env) {
+  if (isInteractive(env)) return;
+  const name = command ? `xds ${command}` : 'this command';
+  console.error(
+    `Error: \`${name}\` with no flags is interactive and requires a TTY.`,
+  );
+  if (hint) {
+    console.error(`Run non-interactively with: ${hint}`);
+  }
+  if (!json) {
+    console.error(
+      'Detected a non-interactive environment (no TTY, piped I/O, or CI=1).',
+    );
+  }
+  process.exit(1);
+}

--- a/packages/cli/src/utils/interactive.test.mjs
+++ b/packages/cli/src/utils/interactive.test.mjs
@@ -1,0 +1,68 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Unit tests for the interactivity contract.
+ *
+ * isInteractive() is pure given its injected env, so these are fast unit
+ * tests. The "does the command actually fail fast instead of hanging" proof
+ * lives in the per-command subprocess tests (init/theme non-interactive).
+ */
+
+import {describe, it, expect, vi, afterEach} from 'vitest';
+import {isInteractive, requireInteractive} from './interactive.mjs';
+
+describe('isInteractive', () => {
+  it('is true only when stdin AND stdout are TTYs and not CI', () => {
+    expect(isInteractive({stdinTTY: true, stdoutTTY: true, ci: false})).toBe(true);
+  });
+
+  it('is false when stdin is not a TTY (piped input)', () => {
+    expect(isInteractive({stdinTTY: false, stdoutTTY: true, ci: false})).toBe(false);
+  });
+
+  it('is false when stdout is not a TTY (piped output)', () => {
+    expect(isInteractive({stdinTTY: true, stdoutTTY: false, ci: false})).toBe(false);
+  });
+
+  it('is false in CI even with a pseudo-TTY on both streams', () => {
+    expect(isInteractive({stdinTTY: true, stdoutTTY: true, ci: true})).toBe(false);
+  });
+});
+
+describe('requireInteractive', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns (does not exit) when interactive', () => {
+    const exit = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit should not be called');
+    });
+    expect(() =>
+      requireInteractive(
+        {command: 'init', hint: '`xds init --all`'},
+        {stdinTTY: true, stdoutTTY: true, ci: false},
+      ),
+    ).not.toThrow();
+    expect(exit).not.toHaveBeenCalled();
+  });
+
+  it('exits 1 with actionable guidance when non-interactive', () => {
+    const exit = vi
+      .spyOn(process, 'exit')
+      .mockImplementation(() => {
+        throw new Error('__exit__');
+      });
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() =>
+      requireInteractive(
+        {command: 'theme', hint: '`xds theme <preset>`'},
+        {stdinTTY: false, stdoutTTY: false, ci: false},
+      ),
+    ).toThrow('__exit__');
+    expect(exit).toHaveBeenCalledWith(1);
+    const output = err.mock.calls.map(c => c.join(' ')).join('\n');
+    expect(output).toMatch(/requires a TTY/i);
+    expect(output).toMatch(/xds theme <preset>/);
+  });
+});


### PR DESCRIPTION
Replaces the single-command init hang fix with one shared interactivity contract for the whole CLI.

## The problem
Several commands launch `@clack/prompts` wizards. In a non-interactive context (CI, piped I/O, no TTY) those prompts block forever. The detection was inconsistent across the codebase:
- `init` — **no guard** → hung forever
- `swizzle` — only `checkGhCli()`, not a TTY check
- `gap-report` — `stdout.isTTY`
- `ensure-jscodeshift` — `stdout.isTTY && !process.env.CI` (the most correct)

Four different ways to ask "can we prompt?", and real coverage gaps.

## The fix — one contract
New `utils/interactive.mjs`:
- **`isInteractive()`** — true only when **stdin AND stdout are TTYs** and **`!process.env.CI`** (CI runners can allocate a pseudo-TTY, so CI is an explicit override). For optional secondary prompts (swizzle's gap report) — skip gracefully.
- **`requireInteractive({command, hint})`** — for commands whose primary action IS the wizard (`init`); fails fast with exit 1 + actionable non-interactive guidance instead of hanging.

Wired into **init** (`requireInteractive`) and **swizzle** (`isInteractive` on the optional gap prompt).

## Scope note (found during testing)
`commands/theme.mjs` (the interactive scaffolder) is **orphaned** — it's never registered in `index.mjs`; the real `theme` command comes from `build-theme.mjs` (`theme build <file>`, non-interactive). So it has no hang risk and is intentionally **not** guarded here.

## Tests
- `interactive.test.mjs` — 6 unit tests for the contract (TTY/CI matrix, both entry points).
- `interactive-guard.test.mjs` — 3 real-subprocess no-hang tests: `init` with no TTY exits 1 (not SIGTERM timeout), writes no files, prints `--all`/`--features` guidance, and `--features agents` still works.
- All green; no regressions in theme/swizzle suites.

Supersedes the earlier `navi/fix/cli-harden-init` (closed) — that was a one-command bandaid using `stdin.isTTY` only.