### PR TITLE
fix(AppShell): apply navAreaStyle to header wrapper in all height modes

### DIFF
--- a/apps/docsite/src/app/globals.css
+++ b/apps/docsite/src/app/globals.css
@@ -38,14 +38,25 @@ body:has([data-home-page]) #xds-app-shell-main {
 }
 
 /* Translucent top nav — frosted glass effect.
-   Scoped to the outermost shell only via :not(.xds-app-shell .xds-app-shell)
-   so nested AppShells in component examples/templates aren't affected. */
-.xds-app-shell:not(.xds-app-shell .xds-app-shell) > .xds-layout .xds-layout-header,
-.xds-app-shell:not(.xds-app-shell .xds-app-shell) > .xds-layout :has(> .xds-layout-header) {
+
+   The :where(:not(.xds-app-shell .xds-app-shell *)) guard scopes every frost
+   rule to the OUTERMOST AppShell only: any nav inside a *nested* AppShell
+   (component examples, templates) matches `.xds-app-shell .xds-app-shell *`
+   — it has two AppShell ancestors — and is therefore excluded, so it keeps
+   its own solid navAreaStyle background and stays seamless with its sidenav.
+
+   The guard lives inside :where() so it adds ZERO specificity. The frost
+   subject stays at (0,1,0) — identical to a bare `.xds-top-nav` — so the
+   home-page, nav-mode, and theme-preview overrides below keep winning exactly
+   as they did before. (Putting the :not() on the outer shell instead, as in
+   `.xds-app-shell:not(...) > .xds-layout .xds-top-nav`, does NOT work: the
+   nested nav is still an unrestricted descendant of the outer layout.) */
+.xds-layout-header:where(:not(.xds-app-shell .xds-app-shell *)),
+:has(> .xds-layout-header):where(:not(.xds-app-shell .xds-app-shell *)) {
   background: transparent !important;
 }
 
-.xds-app-shell:not(.xds-app-shell .xds-app-shell) > .xds-layout .xds-top-nav {
+.xds-top-nav:where(:not(.xds-app-shell .xds-app-shell *)) {
   background: color-mix(in srgb, var(--color-background-surface) 80%, transparent);
   backdrop-filter: blur(12px);
   transition: background 300ms ease;
@@ -55,13 +66,13 @@ body:has([data-home-page]) #xds-app-shell-main {
    Use the solid body color (not a color-mix) so it matches perfectly even
    without anything scrolled behind it. The backdrop-filter blur from the
    .xds-top-nav rule above is preserved. */
-body:has([data-home-page]) .xds-app-shell:not(.xds-app-shell .xds-app-shell) > .xds-layout .xds-top-nav {
+body:has([data-home-page]) .xds-top-nav:where(:not(.xds-app-shell .xds-app-shell *)) {
   background: var(--color-background-body);
 }
 
 /* When the home page IntersectionObserver detects the theming showcase has
    reached the top, switch the nav back to a surface-tinted frosted bar. */
-body[data-nav-mode='surface'] .xds-app-shell:not(.xds-app-shell .xds-app-shell) > .xds-layout .xds-top-nav {
+body[data-nav-mode='surface'] .xds-top-nav:where(:not(.xds-app-shell .xds-app-shell *)) {
   background: color-mix(in srgb, var(--color-background-surface) 80%, transparent);
 }
 

--- a/apps/docsite/src/app/globals.css
+++ b/apps/docsite/src/app/globals.css
@@ -37,13 +37,15 @@ body:has([data-home-page]) #xds-app-shell-main {
   padding-top: 0;
 }
 
-/* Translucent top nav — frosted glass effect */
-.xds-layout-header,
-:has(> .xds-layout-header) {
+/* Translucent top nav — frosted glass effect.
+   Scoped to the outermost shell only via :not(.xds-app-shell .xds-app-shell)
+   so nested AppShells in component examples/templates aren't affected. */
+.xds-app-shell:not(.xds-app-shell .xds-app-shell) > .xds-layout .xds-layout-header,
+.xds-app-shell:not(.xds-app-shell .xds-app-shell) > .xds-layout :has(> .xds-layout-header) {
   background: transparent !important;
 }
 
-.xds-top-nav {
+.xds-app-shell:not(.xds-app-shell .xds-app-shell) > .xds-layout .xds-top-nav {
   background: color-mix(in srgb, var(--color-background-surface) 80%, transparent);
   backdrop-filter: blur(12px);
   transition: background 300ms ease;
@@ -53,13 +55,13 @@ body:has([data-home-page]) #xds-app-shell-main {
    Use the solid body color (not a color-mix) so it matches perfectly even
    without anything scrolled behind it. The backdrop-filter blur from the
    .xds-top-nav rule above is preserved. */
-body:has([data-home-page]) .xds-top-nav {
+body:has([data-home-page]) .xds-app-shell:not(.xds-app-shell .xds-app-shell) > .xds-layout .xds-top-nav {
   background: var(--color-background-body);
 }
 
 /* When the home page IntersectionObserver detects the theming showcase has
    reached the top, switch the nav back to a surface-tinted frosted bar. */
-body[data-nav-mode='surface'] .xds-top-nav {
+body[data-nav-mode='surface'] .xds-app-shell:not(.xds-app-shell .xds-app-shell) > .xds-layout .xds-top-nav {
   background: color-mix(in srgb, var(--color-background-surface) 80%, transparent);
 }
 

--- a/packages/core/src/AppShell/XDSAppShell.tsx
+++ b/packages/core/src/AppShell/XDSAppShell.tsx
@@ -521,7 +521,7 @@ export function XDSAppShell({
   const navHasDividers = variant === 'section';
   const isElevated = variant === 'elevated';
   const navAreaStyle =
-    variant === 'wash' || variant === 'elevated'
+    variant === 'wash'
       ? styles.navAreaWash
       : variant === 'surface'
         ? styles.navAreaSurface
@@ -537,8 +537,10 @@ export function XDSAppShell({
 
   // Background for sticky elements in auto mode — must be opaque so content
   // doesn't show through when scrolling underneath. Uses the nav area bg if
-  // set, otherwise falls back to the shell variant bg (always surface for section).
-  const stickyBgStyle = navAreaStyle ?? styles.navAreaSurface;
+  // set, otherwise falls back to the shell variant bg (body for elevated,
+  // surface for section).
+  const stickyBgStyle =
+    navAreaStyle ?? (isElevated ? styles.navAreaWash : styles.navAreaSurface);
 
   // =========================================================================
   // Header height measurement for sticky sideNav offset (auto mode)
@@ -659,7 +661,7 @@ export function XDSAppShell({
         ref={headerRef}
         {...mergeProps(
           xdsClassName('app-shell-header', {variant}),
-          stylex.props(isAuto && styles.headerSticky, isAuto && stickyBgStyle),
+          stylex.props(navAreaStyle, isAuto && styles.headerSticky),
         )}>
         {headerInner}
       </div>
@@ -743,7 +745,7 @@ export function XDSAppShell({
       <div
         {...mergeProps(
           xdsClassName('app-shell-header', {variant}),
-          stylex.props(isAuto && styles.headerSticky, isAuto && stickyBgStyle),
+          stylex.props(navAreaStyle, isAuto && styles.headerSticky),
         )}>
         <XDSLayoutHeader padding={0} hasDivider={navHasDividers}>
           <div

--- a/packages/core/src/AppShell/XDSAppShell.tsx
+++ b/packages/core/src/AppShell/XDSAppShell.tsx
@@ -521,7 +521,7 @@ export function XDSAppShell({
   const navHasDividers = variant === 'section';
   const isElevated = variant === 'elevated';
   const navAreaStyle =
-    variant === 'wash'
+    variant === 'wash' || variant === 'elevated'
       ? styles.navAreaWash
       : variant === 'surface'
         ? styles.navAreaSurface
@@ -537,10 +537,8 @@ export function XDSAppShell({
 
   // Background for sticky elements in auto mode — must be opaque so content
   // doesn't show through when scrolling underneath. Uses the nav area bg if
-  // set, otherwise falls back to the shell variant bg (body for elevated,
-  // surface for section).
-  const stickyBgStyle =
-    navAreaStyle ?? (isElevated ? styles.navAreaWash : styles.navAreaSurface);
+  // set, otherwise falls back to the shell variant bg (always surface for section).
+  const stickyBgStyle = navAreaStyle ?? styles.navAreaSurface;
 
   // =========================================================================
   // Header height measurement for sticky sideNav offset (auto mode)


### PR DESCRIPTION
## Problem

The top nav and side nav render with subtly different background colors in the `elevated` variant (the default).

## Root Cause

The sidenav panel always receives `navAreaStyle` (explicit `--color-background-body`):
```tsx
<XDSLayoutPanel xstyle={[navAreaStyle, ...]}> // always applied
```

But the header wrapper only received a background in **auto** height mode:
```tsx
stylex.props(isAuto && styles.headerSticky, isAuto && stickyBgStyle)
//           ^^^^^^                          ^^^^^^ — only in auto mode
```

In the default **fill** mode, the header wrapper was transparent — relying on the root shell's background showing through. The sidenav painted its own layer explicitly. This mismatch caused the browser to composite them differently (sub-pixel rendering, layer boundaries from `isolation: isolate` on the elevated content backdrop), producing a visible color seam.

Introduced across PR #597 (`d0d8fca`) which added `navAreaStyle` to the panel, and PR #615 (`d0fda31`) which only added it to the header in auto mode for sticky scroll opacity.

## Fix

Apply `navAreaStyle` to the header wrapper unconditionally:

```diff
-stylex.props(isAuto && styles.headerSticky, isAuto && stickyBgStyle)
+stylex.props(navAreaStyle, isAuto && styles.headerSticky)
```

Both nav areas now paint their own background layer identically in all height modes.

## Testing

- ✅ All 33 AppShell unit tests pass
- ✅ TypeScript typecheck clean
- ✅ SYNC + package boundary checks pass