### PR TITLE
fix(docsite): suppress overlays in components overview thumbnails

### DIFF
--- a/apps/docsite/src/components/ShowcaseThumbnail.tsx
+++ b/apps/docsite/src/components/ShowcaseThumbnail.tsx
@@ -14,6 +14,7 @@ import * as stylex from '@stylexjs/stylex';
 import {XDSSkeleton} from '@xds/core/Skeleton';
 import {XDSText} from '@xds/core/Text';
 import {XDSTheme} from '@xds/core/theme';
+import {XDSStaticPreviewProvider} from '@xds/core/Layer';
 import {neutralTheme} from '@xds/theme-neutral/built';
 import {useThemeMode} from '../app/providers';
 
@@ -175,7 +176,9 @@ export function ShowcaseThumbnail({
                 </div>
               }>
               <XDSTheme theme={neutralTheme} mode={mode}>
-                <Component />
+                <XDSStaticPreviewProvider>
+                  <Component />
+                </XDSStaticPreviewProvider>
               </XDSTheme>
             </Suspense>
           </ShowcaseErrorBoundary>

--- a/internal/eslint-plugin-xds/shared.js
+++ b/internal/eslint-plugin-xds/shared.js
@@ -30,6 +30,7 @@ export const COMPONENT_RULE_ALLOWED = new Set([
   'XDSToastViewportProps',
   // Provider components — render no DOM element
   'XDSLayerProviderProps',
+  'XDSStaticPreviewProviderProps',
   'XDSLinkProviderProps',
   'XDSMediaThemeProps',
 ]);

--- a/packages/core/src/Layer/XDSStaticPreviewContext.test.tsx
+++ b/packages/core/src/Layer/XDSStaticPreviewContext.test.tsx
@@ -1,0 +1,106 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file XDSStaticPreviewContext.test.tsx
+ * @input Uses vitest, @testing-library/react, XDSPopover, XDSStaticPreviewProvider
+ * @output Unit tests verifying overlays do not open inside a static preview
+ * @position Testing; validates XDSStaticPreviewContext.tsx behavior
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeAll,
+  afterAll,
+  beforeEach,
+} from 'vitest';
+import {render, screen, fireEvent} from '@testing-library/react';
+import React from 'react';
+import {XDSPopover} from '../Popover';
+import {XDSStaticPreviewProvider} from './XDSStaticPreviewContext';
+
+const originalMatches = HTMLElement.prototype.matches;
+const popoverOpenState = new WeakMap<HTMLElement, boolean>();
+
+beforeAll(() => {
+  HTMLElement.prototype.showPopover = vi.fn(function (this: HTMLElement) {
+    popoverOpenState.set(this, true);
+    const event = new Event('toggle');
+    Object.defineProperty(event, 'newState', {value: 'open'});
+    this.dispatchEvent(event);
+  });
+  HTMLElement.prototype.hidePopover = vi.fn(function (this: HTMLElement) {
+    popoverOpenState.set(this, false);
+    const event = new Event('toggle');
+    Object.defineProperty(event, 'newState', {value: 'closed'});
+    this.dispatchEvent(event);
+  });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (HTMLElement.prototype as any).matches = function (
+    selector: string,
+  ): boolean {
+    if (selector === ':popover-open') {
+      return popoverOpenState.get(this) ?? false;
+    }
+    return originalMatches.call(this, selector);
+  };
+});
+
+afterAll(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (HTMLElement.prototype as any).matches = originalMatches;
+});
+
+describe('XDSStaticPreviewProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the trigger but does not open a controlled popover inside a static preview', () => {
+    render(
+      <XDSStaticPreviewProvider>
+        <XDSPopover
+          isOpen
+          onOpenChange={() => {}}
+          label="Settings"
+          content={<span>Popover content</span>}>
+          <button type="button">Open</button>
+        </XDSPopover>
+      </XDSStaticPreviewProvider>,
+    );
+
+    // Trigger still renders so the card showcase looks identical.
+    expect(screen.getByText('Open')).toBeInTheDocument();
+    // showPopover is never called, so the overlay never enters the top layer.
+    expect(HTMLElement.prototype.showPopover).not.toHaveBeenCalled();
+  });
+
+  it('opens a controlled popover normally outside a static preview', () => {
+    render(
+      <XDSPopover
+        isOpen
+        onOpenChange={() => {}}
+        label="Settings"
+        content={<span>Popover content</span>}>
+        <button type="button">Open</button>
+      </XDSPopover>,
+    );
+
+    expect(HTMLElement.prototype.showPopover).toHaveBeenCalled();
+  });
+
+  it('does not open a popover on user click inside a static preview', () => {
+    render(
+      <XDSStaticPreviewProvider>
+        <XDSPopover label="Settings" content={<span>Popover content</span>}>
+          <button type="button">Open</button>
+        </XDSPopover>
+      </XDSStaticPreviewProvider>,
+    );
+
+    fireEvent.click(screen.getByText('Open'));
+    expect(HTMLElement.prototype.showPopover).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/Layer/XDSStaticPreviewContext.tsx
+++ b/packages/core/src/Layer/XDSStaticPreviewContext.tsx
@@ -1,0 +1,61 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file XDSStaticPreviewContext.tsx
+ * @input React context
+ * @output Exports XDSStaticPreviewProvider and useXDSIsStaticPreview
+ * @position Context for suppressing overlay layers in non-interactive previews
+ *
+ * SYNC: When modified, update:
+ * - /packages/core/src/Layer/index.ts
+ * - /packages/core/src/Layer/useXDSLayer.tsx
+ *
+ * Some surfaces render live components purely as static, non-interactive
+ * previews (e.g. a thumbnail gallery). Overlay-based components — Popover,
+ * HoverCard, MultiSelector, DateRangeInput, etc. — reveal their content via
+ * the native Popover API (top layer) or a portal to `document.body`. Both
+ * escape an ancestor's `overflow: hidden`, so an open overlay visually leaks
+ * out of the preview frame.
+ *
+ * Wrapping a preview in <XDSStaticPreviewProvider> turns `useXDSLayer`'s
+ * `show()` into a no-op, so overlays never open inside that subtree. Because
+ * React context propagates through portals, this also covers portaled
+ * overlays like HoverCard. Default is `false`, so normal usage is unaffected.
+ */
+
+import {createContext, use, type ReactNode} from 'react';
+
+/**
+ * True when the current subtree is a static, non-interactive preview where
+ * overlay layers should not open. Defaults to `false`.
+ */
+export const XDSStaticPreviewContext = createContext<boolean>(false);
+XDSStaticPreviewContext.displayName = 'XDSStaticPreviewContext';
+
+/**
+ * Hook to read whether the current subtree is a static preview.
+ */
+export function useXDSIsStaticPreview(): boolean {
+  return use(XDSStaticPreviewContext);
+}
+
+export interface XDSStaticPreviewProviderProps {
+  children: ReactNode;
+}
+
+/**
+ * Marks its subtree as a static, non-interactive preview. Overlay components
+ * inside will not open their layers, keeping content contained within the
+ * preview frame.
+ */
+export function XDSStaticPreviewProvider({
+  children,
+}: XDSStaticPreviewProviderProps) {
+  return (
+    <XDSStaticPreviewContext value={true}>{children}</XDSStaticPreviewContext>
+  );
+}
+
+XDSStaticPreviewProvider.displayName = 'XDSStaticPreviewProvider';

--- a/packages/core/src/Layer/index.ts
+++ b/packages/core/src/Layer/index.ts
@@ -35,6 +35,14 @@ export type {XDSLayerProviderProps} from './XDSLayerProvider';
 export {XDSLayerContext, useXDSLayerContext} from './XDSLayerContext';
 export type {XDSLayerContextValue, LayerToastConfig} from './XDSLayerContext';
 
+// Static preview context — suppresses overlay layers in non-interactive previews
+export {
+  XDSStaticPreviewContext,
+  XDSStaticPreviewProvider,
+  useXDSIsStaticPreview,
+} from './XDSStaticPreviewContext';
+export type {XDSStaticPreviewProviderProps} from './XDSStaticPreviewContext';
+
 // Shared entry animation styles for layer-based components
 export {layerAnimations} from './layerAnimations.stylex';
 

--- a/packages/core/src/Layer/useXDSLayer.tsx
+++ b/packages/core/src/Layer/useXDSLayer.tsx
@@ -23,6 +23,7 @@ import React, {
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
+import {useXDSIsStaticPreview} from './XDSStaticPreviewContext';
 
 // Extend React's HTMLAttributes to include popover API attributes
 declare module 'react' {
@@ -286,6 +287,10 @@ export function useXDSLayer(
   const id = useId();
   const anchorId = `--xds-layer-${id.replace(/:/g, '')}`;
 
+  // In a static preview surface, overlays must not open — their top-layer /
+  // portaled content would escape the preview frame's clipping.
+  const isStaticPreview = useXDSIsStaticPreview();
+
   const [isOpen, setIsOpen] = useState(false);
   const popoverRef = useRef<HTMLElement | null>(null);
   const triggerRef = useRef<HTMLElement | null>(null);
@@ -296,13 +301,16 @@ export function useXDSLayer(
   const isOpenRef = useRef(false);
 
   const show = useCallback(() => {
+    if (isStaticPreview) {
+      return;
+    }
     if (popoverRef.current && !isOpenRef.current) {
       popoverRef.current.showPopover();
       isOpenRef.current = true;
       setIsOpen(true);
       onShow?.();
     }
-  }, [onShow]);
+  }, [isStaticPreview, onShow]);
 
   const hide = useCallback(() => {
     if (isOpenRef.current) {


### PR DESCRIPTION
## Problem

On the [components overview page](https://xds-sandbox.vercel.app/components), each card renders a live showcase. Components with an overlay element — Date Range Input, Popover, Hover Card, Multi Selector — were rendering that overlay **open and outside the card**.

The root cause: overlay components reveal their content via the native Popover API (top layer) or a `createPortal` to `document.body`. Both escape the card's `overflow: hidden`, so the open overlay visually leaks out of the thumbnail frame.

## Fix

A small `XDSStaticPreviewProvider` context in `@xds/core/Layer` that makes `useXDSLayer`'s `show()` a no-op for its subtree. Since React context crosses portals, this covers portaled overlays (Hover Card) as well as top-layer ones (Popover, Multi Selector, Date Range Input).

The components **overview** wraps each showcase thumbnail in this provider, so:
- Overlays stay contained — nothing renders outside the card.
- The **Multi Selector** card looks the same as before, except the menu no longer appears open by default (it renders the collapsed trigger).

## Scope

- **Overview only.** The component **detail page** (`ShowcasePreview`) does not use the provider, so its showcases remain fully interactive.
- The shared showcase template blocks under `packages/cli/templates/blocks` are **untouched**.
- Default behavior of `useXDSLayer` is unchanged (context defaults to `false`).

## Testing

- New unit tests (`XDSStaticPreviewContext.test.tsx`) verify overlays don't open inside a static preview (controlled open + user click), and open normally outside it.
- All existing Popover / HoverCard / MultiSelector / DateRangeInput / Layer tests pass (92 total).
- `tsc` and `eslint` clean for core and docsite.