### PR TITLE
fix(Blockquote): remove re-declared escape hatch props

### DIFF
--- a/packages/core/src/Blockquote/XDSBlockquote.tsx
+++ b/packages/core/src/Blockquote/XDSBlockquote.tsx
@@ -18,7 +18,6 @@
 import type {ReactNode} from 'react';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
-import type {StyleXStyles} from '@stylexjs/stylex';
 import {colorVars, spacingVars, typeScaleVars} from '../theme/tokens.stylex';
 import {xdsClassName, mergeProps} from '../utils';
 
@@ -31,27 +30,6 @@ export interface XDSBlockquoteProps extends XDSBaseProps<HTMLQuoteElement> {
    * Optional attribution for the quote. Rendered in a <footer> with <cite>.
    */
   cite?: ReactNode;
-  /**
-   * StyleX styles created via `stylex.create()`. Merged with the component's
-   * base styles inside a single `stylex.props()` call for optimal deduplication.
-   *
-   * @example
-   * ```
-   * const overrides = stylex.create({ root: { marginBottom: 8 } });
-   * <XDSBlockquote xstyle={overrides.root}>Quote</XDSBlockquote>
-   * ```
-   */
-  xstyle?: StyleXStyles;
-  /**
-   * CSS class name(s) appended to the root element.
-   * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
-   */
-  className?: string;
-  /**
-   * Inline styles to apply to the root element. Spread after StyleX
-   * inline styles, so these values take priority.
-   */
-  style?: React.CSSProperties;
 }
 
 const styles = stylex.create({


### PR DESCRIPTION
XDSBlockquoteProps extends XDSBaseProps which already provides `xstyle`, `className`, and `style`. Manually re-declaring them violates the convention that escape hatches must come from XDSBaseProps, never re-declared manually.

This removes the redundant prop declarations and the now-unused `StyleXStyles` type import.

## Audit Summary (2026-06-02)

Components audited: Badge, Banner, Blockquote, Breadcrumbs, Button

### Findings

| Component | Check | Finding |
|-----------|-------|---------|
| Blockquote | Structure (#7) | Re-declares `xstyle`, `className`, `style` despite extending XDSBaseProps |

### No issues found

- **Badge** — Clean across all 10 checks
- **Banner** — Clean across all 10 checks
- **Breadcrumbs** — Clean across all 10 checks
- **Button** — Clean across all 10 checks

Night Watch — Component Auditor