### PR TITLE
fix(docsite): close overlay showcases by default

### DIFF
--- a/packages/cli/templates/blocks/components/Carousel/CarouselShowcase.tsx
+++ b/packages/cli/templates/blocks/components/Carousel/CarouselShowcase.tsx
@@ -30,6 +30,7 @@ export default function CarouselShowcase() {
     <XDSCarousel
       gap={2}
       hasSnap
+      hasButtons={false}
       aria-label="Workflow steps"
       xstyle={styles.root}>
       {ITEMS.map(item => (

--- a/packages/cli/templates/blocks/components/DropdownMenu/DropdownMenuShowcase.tsx
+++ b/packages/cli/templates/blocks/components/DropdownMenu/DropdownMenuShowcase.tsx
@@ -6,7 +6,7 @@ import {useState} from 'react';
 import {XDSDropdownMenu} from '@xds/core/DropdownMenu';
 
 export default function DropdownMenuShowcase() {
-  const [isMenuOpen, setIsMenuOpen] = useState(true);
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
 
   return (
     <XDSDropdownMenu

--- a/packages/cli/templates/blocks/components/HoverCard/HoverCardShowcase.tsx
+++ b/packages/cli/templates/blocks/components/HoverCard/HoverCardShowcase.tsx
@@ -19,7 +19,6 @@ export default function HoverCardShowcase() {
   return (
     <XDSHoverCard
       placement="above"
-      isDefaultOpen
       content={
         <XDSStack direction="vertical" gap={2} xstyle={styles.card}>
           <XDSStack direction="horizontal" gap={2} vAlign="center">

--- a/packages/cli/templates/blocks/components/MoreMenu/MoreMenuShowcase.tsx
+++ b/packages/cli/templates/blocks/components/MoreMenu/MoreMenuShowcase.tsx
@@ -6,7 +6,7 @@ import {useState} from 'react';
 import {XDSMoreMenu} from '@xds/core/MoreMenu';
 
 export default function MoreMenuShowcase() {
-  const [isMenuOpen, setIsMenuOpen] = useState(true);
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
 
   return (
     <XDSMoreMenu

--- a/packages/cli/templates/blocks/components/MultiSelector/MultiSelectorShowcase.tsx
+++ b/packages/cli/templates/blocks/components/MultiSelector/MultiSelectorShowcase.tsx
@@ -7,7 +7,6 @@ export default function MultiSelectorShowcase() {
     <div style={{width: 300}}>
       <XDSMultiSelector
         label="Columns"
-        isDefaultOpen
         options={['Name', 'Email', 'Role', 'Status', 'Created']}
         value={[]}
         onChange={() => {}}

--- a/packages/cli/templates/blocks/components/Popover/PopoverShowcase.tsx
+++ b/packages/cli/templates/blocks/components/Popover/PopoverShowcase.tsx
@@ -10,7 +10,7 @@ import {XDSText, XDSHeading} from '@xds/core/Text';
 import {XDSDivider} from '@xds/core/Divider';
 
 export default function PopoverShowcase() {
-  const [isOpen, setIsOpen] = useState(true);
+  const [isOpen, setIsOpen] = useState(false);
 
   return (
     <XDSPopover

--- a/packages/cli/templates/blocks/components/Tooltip/TooltipShowcase.tsx
+++ b/packages/cli/templates/blocks/components/Tooltip/TooltipShowcase.tsx
@@ -7,7 +7,7 @@ import {XDSButton} from '@xds/core/Button';
 
 export default function TooltipShowcase() {
   return (
-    <XDSTooltip content="This is a helpful tooltip" placement="above" isDefaultOpen>
+    <XDSTooltip content="This is a helpful tooltip" placement="above">
       <XDSButton label="Hover me" />
     </XDSTooltip>
   );


### PR DESCRIPTION
## Problem

On the [components overview page](https://xds-sandbox.vercel.app/components), showcase thumbnails for overlay components (Multi Selector, Popover, Hover Card, etc.) were opening their overlay by default. Because these overlays render their floating layer through a fixed-position portal, the overlay content escaped the bounds of the thumbnail card and rendered outside of it.

## Fix

Default the following showcases to a **closed** state so the preview stays contained within the card:

- **Popover** — `useState(true)` → `useState(false)`
- **DropdownMenu** — `useState(true)` → `useState(false)`
- **MoreMenu** — `useState(true)` → `useState(false)`
- **HoverCard** — removed `isDefaultOpen`
- **Tooltip** — removed `isDefaultOpen`
- **MultiSelector** — removed `isDefaultOpen`

The overlays still open on interaction (click/hover) — the same showcase component is reused interactively on the component detail page via `ShowcasePreview`, and all triggers/`onOpenChange` handlers are left intact.

Inline overlays (Dialog, CommandPalette, Toast) were left unchanged — they render contained via `isInline` and don't escape the card. Lightbox already defaults closed.