### PR TITLE
fix(core): use --color-text-accent for active link color

### DIFF
--- a/packages/core/src/Link/XDSLink.tsx
+++ b/packages/core/src/Link/XDSLink.tsx
@@ -105,7 +105,7 @@ const linkColorStyles = stylex.create({
     color: colorVars['--color-text-secondary'],
   },
   active: {
-    color: colorVars['--color-accent'],
+    color: colorVars['--color-text-accent'],
   },
   inherit: {
     color: 'inherit',


### PR DESCRIPTION
## What

`XDSLink` was using `--color-accent` for its active-state text color. Active links are text, so they should use the semantic text token `--color-text-accent`.

## Change

- `XDSLink.tsx` `active` style: `--color-accent` → `--color-text-accent`

Note: the `:focus-visible` outline still uses `--color-accent`, which is correct — that's an outline color, not text.