### PR TITLE
fix(Lightbox): a11y and resilience improvements

### DIFF
--- a/packages/core/src/Lightbox/XDSLightbox.test.tsx
+++ b/packages/core/src/Lightbox/XDSLightbox.test.tsx
@@ -3,6 +3,7 @@
 import {describe, it, expect, vi, beforeEach} from 'vitest';
 import {render, screen, fireEvent} from '@testing-library/react';
 import {XDSLightbox} from './XDSLightbox';
+import type {XDSLightboxMedia} from './XDSLightbox';
 
 // Mock showModal/close for jsdom
 beforeEach(() => {
@@ -173,8 +174,8 @@ describe('XDSLightbox', () => {
           index={1}
         />,
       );
-      expect(screen.getByLabelText('Previous image')).toBeInTheDocument();
-      expect(screen.getByLabelText('Next image')).toBeInTheDocument();
+      expect(screen.getByLabelText('Previous')).toBeInTheDocument();
+      expect(screen.getByLabelText('Next')).toBeInTheDocument();
     });
 
     it('hides prev button on first item', () => {
@@ -186,8 +187,8 @@ describe('XDSLightbox', () => {
           index={0}
         />,
       );
-      expect(screen.queryByLabelText('Previous image')).not.toBeInTheDocument();
-      expect(screen.getByLabelText('Next image')).toBeInTheDocument();
+      expect(screen.queryByLabelText('Previous')).not.toBeInTheDocument();
+      expect(screen.getByLabelText('Next')).toBeInTheDocument();
     });
 
     it('hides next button on last item', () => {
@@ -199,8 +200,8 @@ describe('XDSLightbox', () => {
           index={2}
         />,
       );
-      expect(screen.getByLabelText('Previous image')).toBeInTheDocument();
-      expect(screen.queryByLabelText('Next image')).not.toBeInTheDocument();
+      expect(screen.getByLabelText('Previous')).toBeInTheDocument();
+      expect(screen.queryByLabelText('Next')).not.toBeInTheDocument();
     });
 
     it('calls onIndexChange when next is clicked', () => {
@@ -214,7 +215,7 @@ describe('XDSLightbox', () => {
           onIndexChange={onIndexChange}
         />,
       );
-      fireEvent.click(screen.getByLabelText('Next image'));
+      fireEvent.click(screen.getByLabelText('Next'));
       expect(onIndexChange).toHaveBeenCalledWith(1);
     });
 
@@ -229,7 +230,7 @@ describe('XDSLightbox', () => {
           onIndexChange={onIndexChange}
         />,
       );
-      fireEvent.click(screen.getByLabelText('Previous image'));
+      fireEvent.click(screen.getByLabelText('Previous'));
       expect(onIndexChange).toHaveBeenCalledWith(1);
     });
 
@@ -266,5 +267,16 @@ describe('XDSLightbox', () => {
       expect(video).toHaveAttribute('src', '/clip.mp4');
       expect(video).toHaveAttribute('controls');
     });
+  });
+
+  it('does not crash with an empty media array', () => {
+    const {container} = render(
+      <XDSLightbox
+        isOpen={true}
+        onOpenChange={() => {}}
+        media={[]}
+      />,
+    );
+    expect(container.querySelector('dialog')).not.toBeInTheDocument();
   });
 });

--- a/packages/core/src/Lightbox/XDSLightbox.tsx
+++ b/packages/core/src/Lightbox/XDSLightbox.tsx
@@ -166,7 +166,10 @@ const styles = stylex.create({
     objectFit: 'contain',
     pointerEvents: 'none',
     transitionProperty: 'transform',
-    transitionDuration: '200ms',
+    transitionDuration: {
+      default: '200ms',
+      '@media (prefers-reduced-motion: reduce)': '0ms',
+    },
     transitionTimingFunction: 'ease-out',
   },
   imageDragging: {
@@ -304,8 +307,11 @@ export function XDSLightbox({
   // Resolve current media item
   const mediaArray = Array.isArray(media) ? media : [media];
   const isGallery = mediaArray.length > 1;
-  const currentItem = mediaArray[Math.min(index, mediaArray.length - 1)];
-  const currentType = currentItem.type ?? 'image';
+  const currentItem =
+    mediaArray.length > 0
+      ? mediaArray[Math.min(index, mediaArray.length - 1)]
+      : null;
+  const currentType = currentItem?.type ?? 'image';
   const isVideo = currentType === 'video';
   const canPrev = isGallery && index > 0;
   const canNext = isGallery && index < mediaArray.length - 1;
@@ -320,7 +326,7 @@ export function XDSLightbox({
     setZoom(1);
     // eslint-disable-next-line @eslint-react/set-state-in-effect
     setPan({x: 0, y: 0});
-  }, [index, currentItem.src]);
+  }, [index, currentItem?.src]);
 
   // Open/close dialog
   useIsomorphicLayoutEffect(() => {
@@ -453,6 +459,10 @@ export function XDSLightbox({
       ? null
       : `scale(${zoom}) translate(${pan.x / zoom}px, ${pan.y / zoom}px)`;
 
+  if (!currentItem) {
+    return null;
+  }
+
   return (
     <dialog
       ref={mergeRefs(ref, dialogRef)}
@@ -490,7 +500,7 @@ export function XDSLightbox({
           <div {...stylex.props(styles.navButton, styles.navPrev)}>
             <XDSIconButton
               icon={<XDSIcon icon="chevronLeft" size="sm" color="inherit" />}
-              label="Previous image"
+              label="Previous"
               variant="ghost"
               onClick={goToPrev}
               xstyle={styles.controlButton}
@@ -543,7 +553,7 @@ export function XDSLightbox({
           <div {...stylex.props(styles.navButton, styles.navNext)}>
             <XDSIconButton
               icon={<XDSIcon icon="chevronRight" size="sm" color="inherit" />}
-              label="Next image"
+              label="Next"
               variant="ghost"
               onClick={goToNext}
               xstyle={styles.controlButton}

--- a/packages/core/src/Lightbox/useXDSLightbox.tsx
+++ b/packages/core/src/Lightbox/useXDSLightbox.tsx
@@ -56,6 +56,7 @@ export interface UseXDSLightboxReturn {
   triggerProps: {
     role: 'button';
     tabIndex: 0;
+    'aria-haspopup': 'dialog';
     onClick: () => void;
     onKeyDown: (e: React.KeyboardEvent) => void;
   };
@@ -63,6 +64,7 @@ export interface UseXDSLightboxReturn {
   getTriggerProps: (index: number) => {
     role: 'button';
     tabIndex: 0;
+    'aria-haspopup': 'dialog';
     onClick: () => void;
     onKeyDown: (e: React.KeyboardEvent) => void;
   };
@@ -106,6 +108,7 @@ export function useXDSLightbox(
     () => ({
       role: 'button' as const,
       tabIndex: 0 as const,
+      'aria-haspopup': 'dialog' as const,
       onClick: () => open(),
       onKeyDown: (e: React.KeyboardEvent) => {
         if (e.key === 'Enter' || e.key === ' ') {
@@ -121,6 +124,7 @@ export function useXDSLightbox(
     (i: number) => ({
       role: 'button' as const,
       tabIndex: 0 as const,
+      'aria-haspopup': 'dialog' as const,
       onClick: () => open(i),
       onKeyDown: (e: React.KeyboardEvent) => {
         if (e.key === 'Enter' || e.key === ' ') {


### PR DESCRIPTION
  ## Summary
  - Use media-agnostic nav button labels ("Previous"/"Next" instead of "Previous image"/"Next image")
  - Add `aria-haspopup="dialog"` to trigger props in `useXDSLightbox`
  - Respect `prefers-reduced-motion` for zoom transitions
  - Guard against empty media array to prevent runtime crash

  ## Test plan
  - [x] Existing Lightbox tests updated and passing (19/19)
  - [x] Verify nav buttons read "Previous"/"Next" with screen reader
  - [x] Verify zoom animation is instant with reduced-motion enabled