### PR TITLE
refactor(overlay): reduce OverlayScrim complexity

### DIFF
--- a/packages/core/src/Overlay/OverlayScrim.tsx
+++ b/packages/core/src/Overlay/OverlayScrim.tsx
@@ -195,6 +195,57 @@ const positionMap = {
 } as const;
 
 // =============================================================================
+// Visibility style helpers — extract branching logic from render
+// =============================================================================
+
+/**
+ * Returns visibility/animation styles for JS-controlled overlays (isOpen defined).
+ * Uses position to determine slide direction for strips.
+ */
+function getControlledVisibility(isOpen: boolean, position: OverlayPosition) {
+  if (isOpen) {
+    return {
+      base: styles.visible,
+      bottom: position === 'bottom' && styles.visibleFromBottom,
+      top: position === 'top' && styles.visibleFromTop,
+    };
+  }
+  return {
+    base: styles.hidden,
+    bottom: position === 'bottom' && styles.hiddenBottom,
+    top: position === 'top' && styles.hiddenTop,
+  };
+}
+
+/**
+ * Returns visibility/animation styles for CSS-driven overlays (showOn mode).
+ * Each mode has a base reveal style + optional position-based slide.
+ */
+function getShowOnVisibility(showOn: OverlayShowOn, position: OverlayPosition) {
+  switch (showOn) {
+    case 'always':
+      return {
+        base: styles.visible,
+        bottom: position === 'bottom' && styles.visibleFromBottom,
+        top: position === 'top' && styles.visibleFromTop,
+      };
+    case 'hover':
+    case 'hover-or-focus':
+      return {
+        base: styles.hoverReveal,
+        bottom: position === 'bottom' && styles.hoverRevealBottom,
+        top: position === 'top' && styles.hoverRevealTop,
+      };
+    case 'focus':
+      return {
+        base: styles.focusReveal,
+        bottom: position === 'bottom' && styles.focusRevealBottom,
+        top: position === 'top' && styles.focusRevealTop,
+      };
+  }
+}
+
+// =============================================================================
 // Component (internal)
 // =============================================================================
 
@@ -206,7 +257,6 @@ export function OverlayScrim({
   isOpen,
   children,
 }: OverlayScrimProps) {
-  const isHoverMode = showOn === 'hover' || showOn === 'hover-or-focus';
   const isControlled = isOpen !== undefined;
 
   const themeMode =
@@ -218,6 +268,10 @@ export function OverlayScrim({
     children
   );
 
+  const visibility = isControlled
+    ? getControlledVisibility(isOpen, position)
+    : getShowOnVisibility(showOn, position);
+
   return (
     <div
       {...mergeProps(
@@ -228,53 +282,9 @@ export function OverlayScrim({
           alignMap[align],
           scrim === 'dark' && styles.scrimDark,
           scrim === 'light' && styles.scrimLight,
-
-          // JS-controlled visibility
-          isControlled && isOpen && styles.visible,
-          isControlled &&
-            isOpen &&
-            position === 'bottom' &&
-            styles.visibleFromBottom,
-          isControlled && isOpen && position === 'top' && styles.visibleFromTop,
-          isControlled && !isOpen && styles.hidden,
-          isControlled &&
-            !isOpen &&
-            position === 'bottom' &&
-            styles.hiddenBottom,
-          isControlled && !isOpen && position === 'top' && styles.hiddenTop,
-
-          // showOn="always"
-          !isControlled && showOn === 'always' && styles.visible,
-          !isControlled &&
-            showOn === 'always' &&
-            position === 'bottom' &&
-            styles.visibleFromBottom,
-          !isControlled &&
-            showOn === 'always' &&
-            position === 'top' &&
-            styles.visibleFromTop,
-
-          // showOn="hover" / "hover-or-focus"
-          !isControlled && isHoverMode && styles.hoverReveal,
-          !isControlled &&
-            isHoverMode &&
-            position === 'bottom' &&
-            styles.hoverRevealBottom,
-          !isControlled &&
-            isHoverMode &&
-            position === 'top' &&
-            styles.hoverRevealTop,
-
-          // showOn="focus"
-          !isControlled && showOn === 'focus' && styles.focusReveal,
-          !isControlled &&
-            showOn === 'focus' &&
-            position === 'bottom' &&
-            styles.focusRevealBottom,
-          !isControlled &&
-            showOn === 'focus' &&
-            position === 'top' &&
-            styles.focusRevealTop,
+          visibility.base,
+          visibility.bottom,
+          visibility.top,
         ),
       )}
       inert={isControlled && !isOpen ? true : undefined}>


### PR DESCRIPTION
## What

Refactors `OverlayScrim` to reduce cyclomatic complexity from ~49 (critical) to ~15 by extracting style resolution into focused helper functions.

## Why

`OverlayScrim` has the highest CRAP score (2450) in the entire codebase — indicating both high complexity and low test coverage. The component's render body had deeply nested conditional expressions determining which styles to apply. Breaking the logic into named helpers makes it easier to reason about, test, and maintain.

## Changes

- Extract `getControlledVisibility(isOpen, position)` — resolves visible/hidden + slide styles when the overlay is JS-controlled (`isOpen` is defined)
- Extract `getShowOnVisibility(showOn, position)` — resolves reveal + slide styles when the overlay is CSS-driven (always/hover/focus modes)
- Each helper returns a `{base, bottom, top}` shape that the component spreads into `stylex.props()` without additional conditionals
- Remove 15+ inline `&&` branches from the render body
- No visual or behavioral changes — pure refactoring
- TypeScript and build pass cleanly