### PR TITLE
feat: add imdreamrunner as code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Default reviewers for the XDS repository
 # See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-# Cindy and Joey review everything by default
-* @cixzhang @czarandy @josephfarina
+# Cindy, Joey, and Dream review everything by default
+* @cixzhang @czarandy @josephfarina @imdreamrunner


### PR DESCRIPTION
Adds @imdreamrunner to CODEOWNERS. Since the codeowner-gate workflow reads owners directly from this file, their PRs will also auto-pass the gate.