### PR TITLE
fix(ChatToolCalls): prevent label shrinking when submessage overflows

### DIFF
--- a/packages/core/src/Chat/XDSChatToolCalls.tsx
+++ b/packages/core/src/Chat/XDSChatToolCalls.tsx
@@ -208,7 +208,8 @@ const styles = stylex.create({
     whiteSpace: 'nowrap',
     overflow: 'hidden',
     textOverflow: 'ellipsis',
-    minWidth: 0,
+    flexShrink: 1,
+    minWidth: '4ch',
   },
   callLabel: {
     fontSize: typeScaleVars['--text-supporting-size'],
@@ -218,6 +219,7 @@ const styles = stylex.create({
     whiteSpace: 'nowrap',
     overflow: 'hidden',
     textOverflow: 'ellipsis',
+    flexShrink: 10,
     minWidth: 0,
   },
   callDuration: {


### PR DESCRIPTION
The `callName` (tool call label) had `minWidth: 0` which allowed it to shrink when the sibling `callLabel` (target/submessage) content was long. Replace with `flexShrink: 0` so the label maintains its natural size and the submessage truncates instead.

Closes #2501