### PR TITLE
fix(cli): honor --no-prose in theme build

### DIFF
--- a/packages/cli/src/commands/build-theme.mjs
+++ b/packages/cli/src/commands/build-theme.mjs
@@ -1074,7 +1074,7 @@ export function registerTheme(program) {
         if (_generateThemeRulesSplit) {
           const {component, prose} = _generateThemeRulesSplit(resolvedTheme);
           const cssParts = [];
-          if (prose.length > 0) {
+          if (options.prose !== false && prose.length > 0) {
             const proseInner = prose.join('\n\n');
             cssParts.push(`@layer reset {\n@scope (${scopeSelector}) to (${scopeTo}) {\n${proseInner}\n}\n}`);
           }
@@ -1115,8 +1115,10 @@ export function registerTheme(program) {
       } else {
         // Legacy fallback when core isn't built yet
         const scopeBlocks = [];
-        const proseCss = generateProseCSS(themeDef);
-        if (proseCss) scopeBlocks.push(proseCss);
+        if (options.prose !== false) {
+          const proseCss = generateProseCSS(themeDef);
+          if (proseCss) scopeBlocks.push(proseCss);
+        }
         const mainCss = generateCSS(themeDef);
         if (mainCss) scopeBlocks.push(mainCss);
         if (scopeBlocks.length === 0) {

--- a/packages/cli/src/commands/build-theme.no-prose.test.mjs
+++ b/packages/cli/src/commands/build-theme.no-prose.test.mjs
@@ -1,0 +1,111 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Regression test for `xds theme build --no-prose`.
+ *
+ * Covers:
+ *   - Default build emits the `@layer reset` block with prose mappings
+ *     (h1, p, code, hr, …) so unstyled HTML inherits XDS typography.
+ *   - `--no-prose` skips that block entirely. Useful when a project ships
+ *     its own typography (Tailwind prose, CMS prose styles, etc.) and
+ *     wants only the component layer.
+ */
+
+import {describe, it, expect, beforeEach, afterEach} from 'vitest';
+import {execFileSync} from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import {fileURLToPath} from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CLI_BIN = path.resolve(__dirname, '../../bin/xds.mjs');
+
+function runCli(args, cwd) {
+  try {
+    const out = execFileSync('node', [CLI_BIN, ...args], {
+      cwd,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: {...process.env, FORCE_COLOR: '0'},
+    });
+    return {code: 0, stdout: out, stderr: ''};
+  } catch (e) {
+    return {
+      code: e.status ?? 1,
+      stdout: e.stdout?.toString() ?? '',
+      stderr: e.stderr?.toString() ?? '',
+    };
+  }
+}
+
+function writeTheme(dir, name) {
+  fs.mkdirSync(dir, {recursive: true});
+  // The CLI writes <basename>.css next to the source file, so use the
+  // theme name as the filename for unambiguous fixtures.
+  const file = path.join(dir, `${name}.mjs`);
+  fs.writeFileSync(
+    file,
+    `export default { name: ${JSON.stringify(name)}, tokens: { '--color-bg': '#fff' } };\n`,
+  );
+  return file;
+}
+
+let tmpDir;
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'xds-build-theme-no-prose-'));
+});
+afterEach(() => {
+  fs.rmSync(tmpDir, {recursive: true, force: true});
+});
+
+describe('theme build --no-prose', () => {
+  it('emits prose mappings by default', () => {
+    const project = path.join(tmpDir, 'project');
+    const themesDir = path.join(project, 'themes');
+    const themeFile = writeTheme(themesDir, 'with-prose');
+
+    const result = runCli(
+      ['theme', 'build', path.relative(project, themeFile)],
+      project,
+    );
+
+    expect(result.code).toBe(0);
+
+    const cssPath = path.join(themesDir, 'with-prose.css');
+    expect(fs.existsSync(cssPath)).toBe(true);
+    const css = fs.readFileSync(cssPath, 'utf-8');
+
+    // Prose markers — at least one heading reset and the reset layer
+    // should be present in the default build.
+    const hasProse =
+      /h1\s*,\s*h2/.test(css) ||
+      /:is\(h1, h2/.test(css) ||
+      /@layer reset/.test(css);
+    expect(hasProse).toBe(true);
+  });
+
+  it('omits prose mappings when --no-prose is passed', () => {
+    const project = path.join(tmpDir, 'project');
+    const themesDir = path.join(project, 'themes');
+    const themeFile = writeTheme(themesDir, 'no-prose');
+
+    const result = runCli(
+      ['theme', 'build', path.relative(project, themeFile), '--no-prose'],
+      project,
+    );
+
+    expect(result.code).toBe(0);
+
+    const cssPath = path.join(themesDir, 'no-prose.css');
+    expect(fs.existsSync(cssPath)).toBe(true);
+    const css = fs.readFileSync(cssPath, 'utf-8');
+
+    // None of the prose markers should appear when --no-prose is set.
+    expect(css).not.toMatch(/@layer reset/);
+    expect(css).not.toMatch(/:is\(h1, h2, h3/);
+    expect(css).not.toMatch(/^\s*h1\s*\{/m);
+    expect(css).not.toMatch(/^\s*p\s*\{/m);
+    expect(css).not.toMatch(/^\s*hr\s*\{/m);
+  });
+});


### PR DESCRIPTION
## What

The `--no-prose` flag on `xds theme build` was being parsed by Commander but never reached the emit branch, so prose styles (h1, h2, p, code, hr, etc.) shipped in the generated CSS regardless of the flag. The flag was a no-op.

## Why

A few real cases where you want tokens + components without prose:

- **Tailwind typography** — `prose` class collides with XDS's heading/paragraph resets.
- **CMS-driven content** — site already ships its own typography from the CMS.
- **Tokens-only themes** — embedding XDS into an existing app where global typography is owned by another system.

Today there's no way to opt out short of post-processing the generated CSS.

## Fix

In `packages/cli/src/commands/build-theme.mjs`, gate the prose emit on `options.prose !== false` for both code paths:

- Modern path (`_generateThemeRulesSplit` from `@xds/core`): skip pushing the `@layer reset` block that contains the prose mappings.
- Legacy fallback (regex+eval, used when core isn't built yet): skip the `generateProseCSS` call.

No `@xds/core` changes — filtered at the consumer.

## Test

New `packages/cli/src/commands/build-theme.no-prose.test.mjs`:

- Default build emits the `@layer reset` prose block.
- `--no-prose` build does NOT emit `@layer reset`, `:is(h1, h2, h3`, or bare `h1`/`p`/`hr` selectors.

Full `packages/cli` suite (703 tests) passes locally.