### PR TITLE
fix(docsite): restore natural-size feature card images, drop 120px cap

### DIFF
--- a/apps/docsite/src/app/(site)/_landing/FeaturesShowcase.tsx
+++ b/apps/docsite/src/app/(site)/_landing/FeaturesShowcase.tsx
@@ -135,18 +135,18 @@ const styles = stylex.create({
   imageWrapBleedBottom: {
     marginBottom: 'calc(var(--spacing-5) * -1)',
   },
-  // Image: full container width, natural height capped at 120px so
-  // regular cards stay compact. Wide compositions (CLI / Components)
-  // would otherwise render at their full aspect-ratio-derived
-  // height (~280px+ at desktop card widths) and pad the cards out
-  // taller than they need to be. object-fit:contain inside the
-  // capped height keeps each composition undistorted.
+  // Image: full container width, natural aspect-ratio-derived
+  // height. No maxHeight cap — each composition was sized at design
+  // time to render correctly inside its card variant (the tall
+  // card's composition is intentionally taller than the regular
+  // cards' wide-and-short compositions). A blanket maxHeight cap
+  // shrinks the tall + bleed images to a tiny strip in the corner
+  // because object-fit:contain inside the cap can't enlarge a
+  // smaller image — the wrappers (imageWrap + variants) already
+  // handle the positioning + bleed at the card edges.
   tallImage: {
     width: '100%',
     height: 'auto',
-    maxHeight: 120,
-    objectFit: 'contain',
-    objectPosition: 'bottom left',
     display: 'block',
   },
 });


### PR DESCRIPTION
## Summary

The blanket `maxHeight: 120` + `objectFit: contain` rule on the feature card image (added in #2487, last commit of the squash) shrinks the tall and bleed images on the landing page features grid to a tiny strip in the bottom-left of their cards.

The cap was meant for the wide-and-short compositions (`feature-cli.png`, `feature-components.png`, both 740x200, ~3.7:1 — naturally render ~110px tall at desktop card widths). But it gets applied to *every* image in the grid:

- `feature-measured-and-tested.png` (864x706, on the tall 2-row-span card) is meant to fill the leftover vertical space of the tall card — capped to 120px, it ends up as a ~145x120 thumbnail floating in the bottom-left.
- `feature-templates.png` + `feature-brand.png` (740x320, on the bleed-corner / bleed-bottom cards) are designed compositions that should bleed off the card's right/bottom edges — capped to 120px, only the bottom-left ~270x120 strip stays visible.

## Fix

Drop `maxHeight`, `objectFit`, and `objectPosition` from `tallImage`. This restores the "natural-size image layout" from the intermediate snapshot (`13ad1f153f`) inside the original PR — each image renders at `width: 100%; height: auto`, sized by its intrinsic aspect ratio inside its assigned wrapper variant. The five existing image-wrapper variants (`imageWrap`, `imageWrapTall`, `imageWrapRegular`, `imageWrapBleedCorner`, `imageWrapBleedBottom`) already handle positioning + bleed at the card edges.

The compact CLI / Components compositions still render fine at their natural ~110-130px height at desktop card widths — they don't need an artificial cap.

## Test plan

- [ ] Refresh `/` on Vercel preview
- [ ] Tall card (left, "Measured and tested"): code+card composition fills the card's leftover vertical space, anchored to the left padding rim, bleeds flush to the card's right edge
- [ ] Top middle card ("Over X components"): components row sits at the bottom of the card with 16px gutters left/right
- [ ] Top right card ("Your design system on the command line"): AI prompt input renders at the bottom of the card
- [ ] Bottom middle card ("Ready to ship templates"): cascading template stack bleeds flush to the right and bottom corners
- [ ] Bottom right card ("Themes that fit your brand"): full themed page mockup bleeds flush to the bottom edge with right-side 16px gutter

Made with [Cursor](https://cursor.com)