### PR TITLE
fix(cli): scope migrate-gap-to-numeric codemod to XDS layout components

### DIFF
--- a/packages/cli/src/codemods/transforms/v0.0.2/__tests__/migrate-gap-to-numeric.test.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.2/__tests__/migrate-gap-to-numeric.test.mjs
@@ -103,9 +103,59 @@ describe('migrate-gap-to-numeric', () => {
     expect(output).toContain('gap="custom"');
   });
 
-  it('converts gap on any component with gap prop', async () => {
+  it('does not modify gap on user-defined components', async () => {
     const input = '<CustomComponent gap="space3" />';
     const output = await applyTransform(input);
-    expect(output).toContain('gap={3}');
+    expect(output).toContain('gap="space3"');
+    expect(output).not.toContain('gap={3}');
+  });
+
+  it('does not modify gap on HTML elements', async () => {
+    const input = '<div gap="space4"><span /></div>';
+    const output = await applyTransform(input);
+    expect(output).toContain('gap="space4"');
+    expect(output).not.toContain('gap={4}');
+  });
+
+  it('does not modify rowGap/columnGap on non-XDS components', async () => {
+    const input =
+      '<MyGrid rowGap="space2" columnGap="space6"><div /></MyGrid>';
+    const output = await applyTransform(input);
+    expect(output).toContain('rowGap="space2"');
+    expect(output).toContain('columnGap="space6"');
+  });
+
+  it('does not modify gap on namespaced or member-expression components', async () => {
+    const input = '<Foo.Bar gap="space4"><div /></Foo.Bar>';
+    const output = await applyTransform(input);
+    expect(output).toContain('gap="space4"');
+  });
+
+  it('only rewrites XDS components in mixed files', async () => {
+    const input = `
+      <div>
+        <XDSStack gap="space2"><div /></XDSStack>
+        <CustomComponent gap="space3" />
+        <div gap="space4" />
+      </div>
+    `;
+    const output = await applyTransform(input);
+    expect(output).toContain('gap={2}');
+    expect(output).toContain('gap="space3"');
+    expect(output).toContain('gap="space4"');
+  });
+
+  it.each([
+    'XDSStack',
+    'XDSHStack',
+    'XDSVStack',
+    'XDSGrid',
+    'XDSGridSpan',
+    'XDSStackItem',
+  ])('rewrites gap on %s', async (component) => {
+    const input = `<${component} gap="space5"><div /></${component}>`;
+    const output = await applyTransform(input);
+    expect(output).toContain('gap={5}');
+    expect(output).not.toContain('"space5"');
   });
 });

--- a/packages/cli/src/codemods/transforms/v0.0.2/migrate-gap-to-numeric.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.2/migrate-gap-to-numeric.mjs
@@ -43,42 +43,75 @@ const TOKEN_TO_NUMBER = {
 
 const GAP_PROPS = ['gap', 'rowGap', 'columnGap'];
 
+/**
+ * Only XDS layout components accept the numeric gap scale. We must not
+ * rewrite gap props on user-defined components or HTML elements that happen
+ * to share the prop name — doing so would silently corrupt their code when
+ * `xds upgrade` runs.
+ */
+const XDS_LAYOUT_ELEMENTS = new Set([
+  'XDSStack',
+  'XDSHStack',
+  'XDSVStack',
+  'XDSGrid',
+  'XDSGridSpan',
+  'XDSStackItem',
+]);
+
 export default function transformer(file, api) {
   const j = api.jscodeshift;
   const root = j(file.source);
   let hasChanges = false;
 
-  root.find(j.JSXAttribute).forEach((path) => {
-    const attrName = path.node.name.name;
-    if (!GAP_PROPS.includes(attrName)) {
+  root.find(j.JSXOpeningElement).forEach((elementPath) => {
+    const nameNode = elementPath.node.name;
+    // Only handle simple identifier element names like <XDSStack>. Skip member
+    // expressions (e.g. <Foo.Bar>) and namespaced names — they're never XDS.
+    if (!nameNode || nameNode.type !== 'JSXIdentifier') {
+      return;
+    }
+    if (!XDS_LAYOUT_ELEMENTS.has(nameNode.name)) {
       return;
     }
 
-    const value = path.node.value;
-
-    // Handle gap="space4" — JSX string attributes are Literal nodes
-    if (value && (value.type === 'Literal' || value.type === 'StringLiteral')) {
-      const numericValue = TOKEN_TO_NUMBER[value.value];
-      if (numericValue !== undefined) {
-        path.node.value = j.jsxExpressionContainer(
-          j.literal(numericValue),
-        );
-        hasChanges = true;
+    for (const attr of elementPath.node.attributes ?? []) {
+      if (attr.type !== 'JSXAttribute' || !attr.name) {
+        continue;
       }
-    }
-    // Handle gap={"space4"} (JSXExpressionContainer wrapping a string)
-    if (
-      value &&
-      value.type === 'JSXExpressionContainer' &&
-      (value.expression.type === 'Literal' ||
-        value.expression.type === 'StringLiteral')
-    ) {
-      const strValue = value.expression.value;
-      if (typeof strValue === 'string') {
-        const numericValue = TOKEN_TO_NUMBER[strValue];
+      const attrName = attr.name.name;
+      if (!GAP_PROPS.includes(attrName)) {
+        continue;
+      }
+
+      const value = attr.value;
+
+      // Handle gap="space4" — JSX string attributes are Literal nodes
+      if (
+        value &&
+        (value.type === 'Literal' || value.type === 'StringLiteral')
+      ) {
+        const numericValue = TOKEN_TO_NUMBER[value.value];
         if (numericValue !== undefined) {
-          value.expression = j.literal(numericValue);
+          attr.value = j.jsxExpressionContainer(j.literal(numericValue));
           hasChanges = true;
+        }
+        continue;
+      }
+
+      // Handle gap={"space4"} (JSXExpressionContainer wrapping a string)
+      if (
+        value &&
+        value.type === 'JSXExpressionContainer' &&
+        (value.expression.type === 'Literal' ||
+          value.expression.type === 'StringLiteral')
+      ) {
+        const strValue = value.expression.value;
+        if (typeof strValue === 'string') {
+          const numericValue = TOKEN_TO_NUMBER[strValue];
+          if (numericValue !== undefined) {
+            value.expression = j.literal(numericValue);
+            hasChanges = true;
+          }
         }
       }
     }


### PR DESCRIPTION
## What

The `migrate-gap-to-numeric` codemod walked every `JSXAttribute` named `gap`, `rowGap`, or `columnGap` without checking the parent element. Any element with a string `gap` prop got rewritten — including user-defined components and HTML elements that have nothing to do with XDS.

## Why it matters

This codemod runs as part of `xds upgrade`. A user with their own `<MyDialog gap="space4">` or `<div gap="space4">` would have it silently rewritten to `gap={4}` on upgrade, corrupting their code without warning.

## The fix

- Walk `JSXOpeningElement` instead of `JSXAttribute` so we have the parent element name in scope.
- Only rewrite when the element name is in the XDS layout allowlist: `XDSStack`, `XDSHStack`, `XDSVStack`, `XDSGrid`, `XDSGridSpan`, `XDSStackItem`.
- Skip member-expression names (`<Foo.Bar>`) and namespaced names — those are never XDS layout elements.

## Tests

- Replaced the old `converts gap on any component with gap prop` test (which codified the buggy behavior) with negative tests:
  - `<CustomComponent gap="space3" />` is unchanged.
  - `<div gap="space4">` is unchanged.
  - `<MyGrid rowGap="space2" columnGap="space6">` is unchanged.
  - `<Foo.Bar gap="space4">` is unchanged.
- Added a mixed-file test that asserts only the XDS element is rewritten when XDS and non-XDS elements appear together.
- Added a parametrized test that exercises gap rewriting on each of the 6 XDS layout elements.
- All previous positive tests still pass — they all use XDS layout components.

`vitest run packages/cli`: 713/713 passing.