### PR TITLE
fix(sandbox): point postinstall at `xds init --features agents`

### DIFF
--- a/apps/sandbox/package.json
+++ b/apps/sandbox/package.json
@@ -11,7 +11,7 @@
     "dev": "pnpm generate && (node ../../scripts/sync-templates.js --watch & next dev)",
     "build": "pnpm generate && next build",
     "start": "next start",
-    "postinstall": "xds agent-docs"
+    "postinstall": "xds init --features agents"
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",


### PR DESCRIPTION
## What

`apps/sandbox/package.json` has `"postinstall": "xds agent-docs"`, but the `agent-docs` subcommand was removed in March (#639) when it was folded into `xds init --features agents`. Repoint the postinstall at the supported invocation.

## Why this matters now

The unknown command currently exits 0 (silently), so `pnpm install` continues. But once unknown commands start exiting 1 (which is the right behavior, per the queued exit-codes work), this latent bug will fail `pnpm install` in CI. Fix it independently first.

## Change

```diff
-    "postinstall": "xds agent-docs"
+    "postinstall": "xds init --features agents"
```

One line, one file. No test changes — the existing CI `pnpm install` step is the test.