### PR TITLE
docs(cli): de-brand prose, keep code identifiers

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,6 +1,6 @@
 # @xds/cli
 
-The XDS CLI is the primary interface for working with the XDS design system — for humans and machines alike. It provides component documentation, design tokens, page templates, theming tools, and upgrade codemods, all accessible via terminal commands, a typed JSON API, or programmatic imports. AI agents and build tools use the same API that powers the CLI, enabling end-to-end frontend development loops.
+The CLI is the primary interface for working with the design system — for humans and machines alike. It provides component documentation, design tokens, page templates, theming tools, and upgrade codemods, all accessible via terminal commands, a typed JSON API, or programmatic imports. AI agents and build tools use the same API that powers the CLI, enabling end-to-end frontend development loops.
 
 ```bash
 npx xds --help
@@ -14,15 +14,15 @@ npx xds template --list
 
 | Command       | Description                                                                             |
 | ------------- | --------------------------------------------------------------------------------------- |
-| `init`        | Initialize XDS in your project — installs packages, sets up theming, adds AI agent docs |
+| `init`        | Initialize the design system in your project — installs packages, sets up theming, adds AI agent docs |
 | `component`   | List components or print detailed docs, props, usage examples, and source               |
 | `docs`        | Print reference documentation (tokens, theme, color, typography, spacing, etc.)         |
 | `template`    | Inject page or block templates into your project                                        |
 | `hook`        | List hooks and print hook documentation                                                 |
 | `swizzle`     | Copy component source into your project for deep customization                          |
-| `upgrade`     | Run codemods to migrate between XDS versions                                            |
+| `upgrade`     | Run codemods to migrate between versions                                                |
 | `theme build` | Compile a defineTheme file to production CSS and JS                                     |
-| `discover`    | Discover external XDS packages and components                                           |
+| `discover`    | Discover external packages and components                                               |
 | `gap-report`  | Report a gap when a component doesn't meet your needs                                   |
 
 ### Global options

--- a/packages/cli/docs/color.doc.mjs
+++ b/packages/cli/docs/color.doc.mjs
@@ -17,7 +17,7 @@ export const docs = {
       content: [
         {
           type: 'prose',
-          text: 'XDS colors are semantic — tokens describe purpose, not appearance. Every color adapts automatically between light and dark modes via CSS light-dark(). Themes override the resolved values, so your code never references raw hex colors.',
+          text: 'Colors are semantic — tokens describe purpose, not appearance. Every color adapts automatically between light and dark modes via CSS light-dark(). Themes override the resolved values, so your code never references raw hex colors.',
         },
       ],
     },

--- a/packages/cli/docs/getting-started.doc.mjs
+++ b/packages/cli/docs/getting-started.doc.mjs
@@ -7,7 +7,7 @@ export const docs = {
   title: 'Getting Started',
   category: 'guide',
   description:
-    'Add XDS to your project and start building.',
+    'Add the design system to your project and start building.',
 
   sections: [
     {
@@ -76,7 +76,7 @@ export const docs = {
       content: [
         {
           type: 'prose',
-          text: 'XDS components are imported from per-category subpath entrypoints. This keeps bundles small and makes intent clear.',
+          text: 'Components are imported from per-category subpath entrypoints. This keeps bundles small and makes intent clear.',
         },
         {
           type: 'code',
@@ -100,7 +100,7 @@ export default function Page() {
       content: [
         {
           type: 'prose',
-          text: 'Every XDS component accepts an `xstyle` prop for StyleX style overrides created via `stylex.create()`.',
+          text: 'Every component accepts an `xstyle` prop for StyleX style overrides created via `stylex.create()`.',
         },
         {
           type: 'code',
@@ -121,17 +121,17 @@ const overrides = stylex.create({
       content: [
         {
           type: 'prose',
-          text: 'For a full working project, clone one of the example apps from the XDS repo. These are complete setups with routing, theming, and components wired together.',
+          text: 'For a full working project, clone one of the example apps from the repo. These are complete setups with routing, theming, and components wired together.',
         },
         {
           type: 'table',
           headers: ['Example', 'Stack', 'Path'],
           rows: [
-            ['Next.js', 'Next.js + XDS theme CSS', 'apps/example-nextjs'],
+            ['Next.js', 'Next.js + theme CSS', 'apps/example-nextjs'],
             ['Next.js + StyleX', 'Next.js + StyleX for custom styles', 'apps/example-nextjs-stylex'],
             ['Next.js + Tailwind', 'Next.js + Tailwind bridge', 'apps/example-nextjs-tailwind'],
-            ['Next.js Source', 'Next.js importing XDS from source', 'apps/example-nextjs-source'],
-            ['Vite', 'Vite + XDS', 'apps/example-vite'],
+            ['Next.js Source', 'Next.js importing from source', 'apps/example-nextjs-source'],
+            ['Vite', 'Vite', 'apps/example-vite'],
           ],
         },
         {

--- a/packages/cli/docs/icons.doc.mjs
+++ b/packages/cli/docs/icons.doc.mjs
@@ -10,7 +10,7 @@ export const docs = {
   title: 'Icons',
   category: 'foundations',
   description:
-    "Semantic icon names available in XDS. These adapt to the active theme's icon registry.",
+    "Semantic icon names available in the design system. These adapt to the active theme's icon registry.",
 
   sections: [
     {
@@ -104,7 +104,7 @@ registerIcons({
       content: [
         {
           type: 'prose',
-          text: 'To add a new semantic icon name to XDS:',
+          text: 'To add a new semantic icon name to the design system:',
         },
         {
           type: 'list',

--- a/packages/cli/docs/migration.doc.mjs
+++ b/packages/cli/docs/migration.doc.mjs
@@ -7,7 +7,7 @@ export const docs = {
   title: 'Migration Guide',
   category: 'guide',
   description:
-    'How to migrate an existing Tailwind, shadcn, or Radix application to XDS incrementally.',
+    'How to migrate an existing Tailwind, shadcn, or Radix application to the design system incrementally.',
 
   sections: [
     {
@@ -15,11 +15,11 @@ export const docs = {
       content: [
         {
           type: 'prose',
-          text: 'Treat migration as a product-shell and workflow migration, not a global class replacement. Start by putting the app inside XDSTheme and AppShell, then move one route or surface at a time to XDS primitives while keeping existing data, routing, and business logic intact.',
+          text: 'Treat migration as a product-shell and workflow migration, not a global class replacement. Start by putting the app inside XDSTheme and AppShell, then move one route or surface at a time to design system primitives while keeping existing data, routing, and business logic intact.',
         },
         {
           type: 'prose',
-          text: 'Tailwind can coexist during migration. Use it for legacy wrappers and local layout while replacing interactive controls, navigation, command surfaces, forms, alerts, dialogs, and settings UI with XDS components.',
+          text: 'Tailwind can coexist during migration. Use it for legacy wrappers and local layout while replacing interactive controls, navigation, command surfaces, forms, alerts, dialogs, and settings UI with components.',
         },
       ],
     },
@@ -30,9 +30,9 @@ export const docs = {
           type: 'list',
           style: 'ordered',
           items: [
-            'Install XDS and run init so the project has package scripts, theme CSS, and agent docs.',
+            'Install the design system and run init so the project has package scripts, theme CSS, and agent docs.',
             'Wrap the app root with XDSTheme and choose the initial light, dark, or system mode behavior.',
-            'Make Tailwind and XDS CSS layer order explicit before replacing components.',
+            'Make Tailwind and design system CSS layer order explicit before replacing components.',
             'Move the persistent frame first: AppShell, TopNav, SideNav, page content, and mobile navigation.',
             'Replace shared primitives: Button, IconButton, TextInput, NumberInput, Switch, CheckboxInput, RadioList, Selector, Tabs, Dialog, AlertDialog, Banner, Toast, Badge, Card, Table, and ListItem.',
             'Replace global workflows: command palette, settings popover, theme toggle, search, filters, create flows, and destructive confirmation dialogs.',
@@ -109,7 +109,7 @@ export function AppRoot({children}: {children: React.ReactNode}) {
         },
         {
           type: 'prose',
-          text: 'When Tailwind remains in the app, declare layer order once in the global CSS file. XDS reset and theme CSS should load before Tailwind utilities so migrated components keep XDS defaults while legacy utility classes still work.',
+          text: 'When Tailwind remains in the app, declare layer order once in the global CSS file. design system reset and theme CSS should load before Tailwind utilities so migrated components keep design system defaults while legacy utility classes still work.',
         },
         {
           type: 'code',
@@ -136,7 +136,7 @@ export function AppRoot({children}: {children: React.ReactNode}) {
         },
         {
           type: 'table',
-          headers: ['Legacy surface', 'XDS target', 'Notes'],
+          headers: ['Legacy surface', 'Component', 'Notes'],
           rows: [
             ['Header', 'XDSTopNav', 'Use for product identity, global actions, account entry, and command/search trigger.'],
             ['Sidebar', 'XDSSideNav', 'Use sections and nested nav items for route groups. Keep selection state driven by the router.'],
@@ -152,21 +152,21 @@ export function AppRoot({children}: {children: React.ReactNode}) {
       content: [
         {
           type: 'prose',
-          text: 'Do not wrap old shadcn components in XDS styles. Replace the primitive with the XDS component that owns the behavior, accessibility, state classes, and token usage.',
+          text: 'Do not wrap old shadcn components in design system styles. Replace the primitive with the component that owns the behavior, accessibility, state classes, and token usage.',
         },
         {
           type: 'table',
-          headers: ['Existing primitive', 'XDS replacement', 'Migration note'],
+          headers: ['Existing primitive', 'Component', 'Migration note'],
           rows: [
             ['button / shadcn Button', 'XDSButton or XDSIconButton', 'Use Button for labeled commands and IconButton for icon-only toolbar actions.'],
-            ['input', 'XDSTextInput', 'Keep validation state in XDS status props rather than ad hoc border classes.'],
+            ['input', 'XDSTextInput', 'Keep validation state in status props rather than ad hoc border classes.'],
             ['textarea', 'XDSTextArea', 'Use when multiline editing is the primary action.'],
             ['switch', 'XDSSwitch', 'Use for persisted boolean settings, including theme mode when represented as a binary choice.'],
             ['checkbox', 'XDSCheckboxInput or XDSCheckboxList', 'Use list variants for grouped selection.'],
             ['radio group', 'XDSRadioList', 'Use when one option must be selected from a visible set.'],
             ['select / combobox', 'XDSSelector or XDSTypeahead', 'Use Selector for bounded options and Typeahead for searchable async options.'],
             ['tabs used as page nav', 'XDSTabList', 'Use route state or current page state as the source of truth.'],
-            ['command dialog', 'XDSCommandPalette', 'Keep app-specific search sources outside the shell and feed XDS searchable items.'],
+            ['command dialog', 'XDSCommandPalette', 'Keep app-specific search sources outside the shell and feed searchable items.'],
             ['dropdown action menu', 'XDSDropdownMenu or XDSMoreMenu', 'Use MoreMenu for compact overflow actions.'],
             ['alert / callout', 'XDSBanner or XDSToast', 'Use Banner for page or section messages and Toast for transient feedback.'],
             ['dialog', 'XDSDialog or XDSAlertDialog', 'Use AlertDialog for destructive confirmation and Dialog for task flows.'],
@@ -180,7 +180,7 @@ export function AppRoot({children}: {children: React.ReactNode}) {
       content: [
         {
           type: 'prose',
-          text: 'Move global search to XDSCommandPalette once the shell exists. Treat the palette as a view over app commands: routes, contextual actions, create actions, filters, recent items, and entity results. Keep data normalization in app code so search sources always return arrays of XDS searchable items.',
+          text: 'Move global search to XDSCommandPalette once the shell exists. Treat the palette as a view over app commands: routes, contextual actions, create actions, filters, recent items, and entity results. Keep data normalization in app code so search sources always return arrays of searchable items.',
         },
         {
           type: 'prose',

--- a/packages/cli/docs/motion.doc.mjs
+++ b/packages/cli/docs/motion.doc.mjs
@@ -25,7 +25,7 @@ export const docs = {
         },
         {
           type: 'prose',
-          text: 'XDS provides duration and easing tokens that keep these moments consistent across your application.',
+          text: 'The design system provides duration and easing tokens that keep these moments consistent across your application.',
         },
       ],
     },
@@ -101,7 +101,7 @@ export const docs = {
       content: [
         {
           type: 'prose',
-          text: 'Some users experience motion sensitivity — animation that feels polished to one person can cause discomfort for another. XDS components should honor the operating system’s reduced motion setting. When it’s enabled, replace animations with instant state changes.',
+          text: 'Some users experience motion sensitivity — animation that feels polished to one person can cause discomfort for another. Components should honor the operating system’s reduced motion setting. When it’s enabled, replace animations with instant state changes.',
         },
       ],
     },

--- a/packages/cli/docs/principles.doc.dense.mjs
+++ b/packages/cli/docs/principles.doc.dense.mjs
@@ -3,10 +3,10 @@
 /** @type {import('../../core/src/docs-types').ReferenceTranslationDoc} */
 
 export const docsDense = {
-  description: 'core design principles + rules for XDS',
+  description: 'core design principles + rules for the design system',
   sections: [
     { title: 'Philosophy', content: [{ type: 'list', items: ['components over primitives', 'semantic tokens over hardcoded values', 'theme-agnostic code', 'open internals'] }] },
-    { title: 'Rules', content: [{ type: 'list', items: ['use XDS components', 'StyleX or Tailwind for styling', 'semantic tokens only', 'CSS vars for colors', 'controlled form inputs', 'useXDSLinkComponent() for navigation'] }] },
+    { title: 'Rules', content: [{ type: 'list', items: ['use components', 'StyleX or Tailwind for styling', 'semantic tokens only', 'CSS vars for colors', 'controlled form inputs', 'useXDSLinkComponent() for navigation'] }] },
     { title: 'Styling', content: [{ type: 'prose', text: 'xstyle prop for component overrides. StyleX or Tailwind for layout. See xds docs styling.' }] },
     { title: 'Anti-Patterns', content: [{ type: 'list', items: ['no inline styles on raw elements', 'no hardcoded colors — use tokens or Tailwind semantic classes', 'no hardcoded spacing', 'no hardcoded <a> — use useXDSLinkComponent()', 'read docs before inventing props'] }] },
     { title: 'Tokens', content: [{ type: 'prose', text: 'run npx xds docs tokens for full reference' }] },

--- a/packages/cli/docs/principles.doc.mjs
+++ b/packages/cli/docs/principles.doc.mjs
@@ -7,7 +7,7 @@ export const docs = {
   title: 'Principles',
   category: 'guide',
   description:
-    'Core design principles and rules for building with XDS.',
+    'Core design principles and rules for building with the design system.',
 
   sections: [
     {
@@ -16,16 +16,16 @@ export const docs = {
       content: [
         {
           type: 'prose',
-          text: 'XDS is a design system that prioritizes consistency, adaptability, and developer experience. Every decision flows from a few core ideas:',
+          text: 'A design system that prioritizes consistency, adaptability, and developer experience. Every decision flows from a few core ideas:',
         },
         {
           type: 'list',
           style: 'unordered',
           items: [
-            'Components over primitives — use XDS components for everything they cover before reaching for raw HTML',
+            'Components over primitives — use components for everything they cover before reaching for raw HTML',
             'Semantic tokens over hardcoded values — colors, spacing, and radii are named by purpose, not appearance',
             'Theme-agnostic code — your app code never references specific colors or measurements, so themes and dark mode work automatically',
-            'Open internals — every primitive is exported and composable, so you can build on top of XDS without fighting it',
+            'Open internals — every primitive is exported and composable, so you can build on top of it without fighting it',
           ],
         },
       ],
@@ -38,7 +38,7 @@ export const docs = {
           type: 'list',
           style: 'ordered',
           items: [
-            'Use XDS components for everything they cover',
+            'Use components for everything they cover',
             'StyleX or Tailwind for custom styling — both are first-class (see \`npx xds docs styling\`)',
             'Semantic tokens, not hardcoded values (see \`npx xds docs tokens\`)',
             'CSS custom properties for colors, not hex values',
@@ -54,7 +54,7 @@ export const docs = {
       content: [
         {
           type: 'prose',
-          text: 'XDS supports multiple styling approaches. Every component accepts an \`xstyle\` prop for StyleX style overrides via \`stylex.create()\`. For layout and wrapper styling outside of components, use StyleX or Tailwind utilities — both resolve to the same XDS design tokens.',
+          text: 'The design system supports multiple styling approaches. Every component accepts an \`xstyle\` prop for StyleX style overrides via \`stylex.create()\`. For layout and wrapper styling outside of components, use StyleX or Tailwind utilities — both resolve to the same design tokens.',
         },
         {
           type: 'prose',
@@ -70,7 +70,7 @@ export const docs = {
           type: 'list',
           style: 'dont',
           items: [
-            'Inline styles on raw elements. Use xstyle on XDS components',
+            'Inline styles on raw elements. Use xstyle on components',
             'Hardcoded colors (#fff). Use var(--color-*) or Tailwind semantic classes (text-primary, bg-surface)',
             'Hardcoded spacing (16px). Use spacing tokens or Tailwind spacing utilities',
             'Hardcoded <a> elements. Use useXDSLinkComponent() so consumers can swap in their framework router via XDSLinkProvider',
@@ -85,7 +85,7 @@ export const docs = {
       content: [
         {
           type: 'prose',
-          text: 'XDS provides semantic design tokens for spacing, color, radius, shadow, typography, and size. Tokens adapt to the active theme and color mode. Run \`npx xds docs tokens\` for the full reference with all values.',
+          text: 'The design system provides semantic design tokens for spacing, color, radius, shadow, typography, and size. Tokens adapt to the active theme and color mode. Run \`npx xds docs tokens\` for the full reference with all values.',
         },
       ],
     },

--- a/packages/cli/docs/shape.doc.mjs
+++ b/packages/cli/docs/shape.doc.mjs
@@ -38,7 +38,7 @@ export const docs = {
       content: [
         {
           type: 'prose',
-          text: 'When a rounded container has padding, inner elements need a smaller radius to appear concentric. XDS components like Card handle this automatically — the inner radius is computed as max(0, outerRadius - padding).',
+          text: 'When a rounded container has padding, inner elements need a smaller radius to appear concentric. Components like Card handle this automatically — the inner radius is computed as max(0, outerRadius - padding).',
         },
         {
           type: 'code',

--- a/packages/cli/docs/spacing.doc.mjs
+++ b/packages/cli/docs/spacing.doc.mjs
@@ -7,7 +7,7 @@ export const docs = {
   title: 'Spacing',
   category: 'foundations',
   description:
-    'Spacing scale tokens for padding, gap, and margin — the rhythmic foundation of XDS layouts.',
+    'Spacing scale tokens for padding, gap, and margin — the rhythmic foundation of design system layouts.',
   tokenCategory: 'spacing',
 
   sections: [
@@ -17,7 +17,7 @@ export const docs = {
       content: [
         {
           type: 'prose',
-          text: 'XDS uses a 4px base-unit spacing scale. Component gap props accept step values that map to these tokens. The scale provides fine-grained control at the small end (2px, 4px, 6px) and consistent rhythm at larger sizes (multiples of 4px).',
+          text: 'The design system uses a 4px base-unit spacing scale. Component gap props accept step values that map to these tokens. The scale provides fine-grained control at the small end (2px, 4px, 6px) and consistent rhythm at larger sizes (multiples of 4px).',
         },
       ],
     },

--- a/packages/cli/docs/styling.doc.mjs
+++ b/packages/cli/docs/styling.doc.mjs
@@ -16,13 +16,13 @@ export const docs = {
       content: [
         {
           type: 'prose',
-          text: 'XDS gives you several ways to style things. Here is when to use each:',
+          text: 'There are several ways to style things. Here is when to use each:',
         },
         {
           type: 'table',
           headers: ['Approach', 'Use for', 'Example'],
           rows: [
-            ['xstyle prop', 'Overriding a specific XDS component', 'xstyle={styles.override}'],
+            ['xstyle prop', 'Overriding a specific component', 'xstyle={styles.override}'],
             ['Tailwind utilities', 'Layout, wrappers, and utility styling', 'className="flex gap-3 p-4"'],
             ['stylex.create', 'Reusable styles, pseudo-classes, typed tokens', 'stylex.create({ card: { ... } })'],
             ['className', 'Integrating with external CSS or Tailwind on components', 'className="my-card shadow-lg"'],
@@ -30,7 +30,7 @@ export const docs = {
         },
         {
           type: 'prose',
-          text: 'All approaches resolve to the same XDS design tokens, so theming and dark mode work regardless of which you choose.',
+          text: 'All approaches resolve to the same design tokens, so theming and dark mode work regardless of which you choose.',
         },
       ],
     },
@@ -40,7 +40,7 @@ export const docs = {
       content: [
         {
           type: 'prose',
-          text: 'Every XDS component accepts an xstyle prop for style customization. It accepts StyleX styles created via stylex.create() — not inline objects, not class name strings. StyleX styles are compiled at build time for optimal deduplication and dead-code elimination.',
+          text: 'Every component accepts an xstyle prop for style customization. It accepts StyleX styles created via stylex.create() — not inline objects, not class name strings. StyleX styles are compiled at build time for optimal deduplication and dead-code elimination.',
         },
         {
           type: 'code',
@@ -91,7 +91,7 @@ const overrides = stylex.create({
       content: [
         {
           type: 'prose',
-          text: 'XDS ships a Tailwind v4 theme bridge that maps all design tokens to Tailwind utility classes. Import it once and use Tailwind classes backed by XDS tokens — colors, spacing, radius, shadows, and typography all resolve to the active theme.',
+          text: 'The design system ships a Tailwind v4 theme bridge that maps all design tokens to Tailwind utility classes. Import it once and use Tailwind classes backed by design tokens — colors, spacing, radius, shadows, and typography all resolve to the active theme.',
         },
         {
           type: 'code',
@@ -103,7 +103,7 @@ const overrides = stylex.create({
         {
           type: 'code',
           lang: 'tsx',
-          label: 'Tailwind utilities alongside XDS components',
+          label: 'Tailwind utilities alongside components',
           code: `<div className="text-primary bg-surface rounded-container p-4 flex gap-3">
   <XDSButton label="Save" variant="primary" />
   <XDSButton label="Cancel" variant="secondary" />
@@ -111,7 +111,7 @@ const overrides = stylex.create({
         },
         {
           type: 'prose',
-          text: 'The bridge is pure CSS with zero JS. Theme changes (dark mode, custom themes) apply automatically because the utilities reference the same CSS custom properties that XDS components use.',
+          text: 'The bridge is pure CSS with zero JS. Theme changes (dark mode, custom themes) apply automatically because the utilities reference the same CSS custom properties that components use.',
         },
       ],
     },
@@ -144,7 +144,7 @@ const overrides = stylex.create({
       content: [
         {
           type: 'prose',
-          text: 'XDS components extend HTML attributes and spread rest props onto their root DOM element. This means data-* attributes, aria-* attributes, event handlers, and other HTML props pass through automatically.',
+          text: 'Components extend HTML attributes and spread rest props onto their root DOM element. This means data-* attributes, aria-* attributes, event handlers, and other HTML props pass through automatically.',
         },
         {
           type: 'code',
@@ -178,7 +178,7 @@ const overrides = stylex.create({
       content: [
         {
           type: 'prose',
-          text: 'Complex components are composed from smaller XDS components. Each sub-component accepts its own xstyle, className, and rest props. You style the parts individually — there\'s no single "drill into sub-part" prop.',
+          text: 'Complex components are composed from smaller components. Each sub-component accepts its own xstyle, className, and rest props. You style the parts individually — there\'s no single "drill into sub-part" prop.',
         },
         {
           type: 'code',
@@ -224,7 +224,7 @@ const overrides = stylex.create({
       content: [
         {
           type: 'prose',
-          text: 'Every component renders a stable xds-* class name (e.g. xds-button, xds-card) plus variant classes. These are the targeting surface for theme overrides in defineTheme. You rarely need to use them directly, but they\'re useful for debugging and for external CSS that needs to target XDS components.',
+          text: 'Every component renders a stable xds-* class name (e.g. xds-button, xds-card) plus variant classes. These are the targeting surface for theme overrides in defineTheme. You rarely need to use them directly, but they\'re useful for debugging and for external CSS that needs to target components.',
         },
         {
           type: 'code',
@@ -259,7 +259,7 @@ const overrides = stylex.create({
       content: [
         {
           type: 'prose',
-          text: 'When writing custom styles, use design tokens instead of hardcoded values. Tokens are CSS custom properties that adapt to the active theme and color mode. XDS provides tokens for spacing, color, radius, shadow, typography, and size.',
+          text: 'When writing custom styles, use design tokens instead of hardcoded values. Tokens are CSS custom properties that adapt to the active theme and color mode. The design system provides tokens for spacing, color, radius, shadow, typography, and size.',
         },
         {
           type: 'code',
@@ -309,10 +309,10 @@ const styles = stylex.create({
           type: 'list',
           style: 'dont',
           items: [
-            'style={{}} on raw <div> wrappers. Use xstyle on the XDS component directly.',
+            'style={{}} on raw <div> wrappers. Use xstyle on the component directly.',
             'Hardcoded colors (#fff, rgb(...)). Use var(--color-*) tokens or Tailwind semantic classes (text-primary, bg-surface).',
             'Hardcoded spacing (16px, 1rem). Use var(--spacing-*) tokens or Tailwind spacing utilities (p-4, gap-3).',
-            'Wrapping an XDS component in a <div> just to add margin. Use xstyle with stylex.create on the component.',
+            'Wrapping a component in a <div> just to add margin. Use xstyle with stylex.create on the component.',
             'Using !important. If styles aren\'t applying, check specificity — xstyle is merged last.',
           ],
         },

--- a/packages/cli/docs/theme.doc.mjs
+++ b/packages/cli/docs/theme.doc.mjs
@@ -108,7 +108,7 @@ function App() {
       content: [
         {
           type: 'prose',
-          text: 'Use the CLI wizard (recommended) or create manually with defineTheme. Only override tokens that differ from defaults — omitted tokens use the XDS defaults.',
+          text: 'Use the CLI wizard (recommended) or create manually with defineTheme. Only override tokens that differ from defaults — omitted tokens use the design system defaults.',
         },
         {
           type: 'code',
@@ -384,7 +384,7 @@ import './themes/ocean.css';
       content: [
         {
           type: 'prose',
-          text: 'XDS themes work in two modes:',
+          text: 'Themes work in two modes:',
         },
         {
           type: 'table',

--- a/packages/cli/docs/typography.doc.mjs
+++ b/packages/cli/docs/typography.doc.mjs
@@ -18,7 +18,7 @@ export const docs = {
       content: [
         {
           type: 'prose',
-          text: 'XDS typography is built on a geometric type scale: base size × ratio^step, with 14px and 1.2 as defaults. Every text style is a semantic token that composes font size, weight, and line-height — so components express intent (heading, body, label) rather than raw values.',
+          text: 'Typography is built on a geometric type scale: base size × ratio^step, with 14px and 1.2 as defaults. Every text style is a semantic token that composes font size, weight, and line-height — so components express intent (heading, body, label) rather than raw values.',
         },
         {
           type: 'prose',

--- a/packages/cli/docs/working-with-ai.doc.mjs
+++ b/packages/cli/docs/working-with-ai.doc.mjs
@@ -7,7 +7,7 @@ export const docs = {
   title: 'Working with AI',
   category: 'guide',
   description:
-    'How to set up AI coding tools to generate correct XDS component code.',
+    'How to set up AI coding tools to generate correct component code.',
 
   sections: [
     {
@@ -15,11 +15,11 @@ export const docs = {
       content: [
         {
           type: 'prose',
-          text: 'XDS is designed to be AI-friendly \u2014 consistent naming, predictable prop patterns, and a CLI that feeds structured documentation directly into AI context windows. But models still need the right context to avoid falling back to generic React patterns or inventing props.',
+          text: 'The design system is built to be AI-friendly \u2014 consistent naming, predictable prop patterns, and a CLI that feeds structured documentation directly into AI context windows. But models still need the right context to avoid falling back to generic React patterns or inventing props.',
         },
         {
           type: 'prose',
-          text: 'The XDS CLI includes a built-in agent docs system that generates context files for your AI tool of choice. One command sets up everything your AI needs to write correct XDS code.',
+          text: 'The CLI includes a built-in agent docs system that generates context files for your AI tool of choice. One command sets up everything your AI needs to write correct component code.',
         },
       ],
     },
@@ -72,7 +72,7 @@ npx xds agent-docs --agent codex     # AGENTS.md (Copilot, Codex, etc.)`,
         },
         {
           type: 'prose',
-          text: 'It also includes rules that prevent common mistakes (no raw divs, no style={{}}, use tokens not magic values) and a CLI quick reference. After setup, you shouldn\'t need to manually correct your AI on XDS conventions \u2014 the agent docs handle it at the system level.',
+          text: 'It also includes rules that prevent common mistakes (no raw divs, no style={{}}, use tokens not magic values) and a CLI quick reference. After setup, you shouldn\'t need to manually correct your AI on these conventions \u2014 the agent docs handle it at the system level.',
         },
       ],
     },
@@ -81,7 +81,7 @@ npx xds agent-docs --agent codex     # AGENTS.md (Copilot, Codex, etc.)`,
       content: [
         {
           type: 'prose',
-          text: 'Cursor project rules aren\'t always picked up \u2014 it selects which rules to apply based on relevance. For reliable inclusion, install XDS context as a User Rule instead. User Rules live at ~/.cursor/rules/ and apply across all projects.',
+          text: 'Cursor project rules aren\'t always picked up \u2014 it selects which rules to apply based on relevance. For reliable inclusion, install the design system context as a User Rule instead. User Rules live at ~/.cursor/rules/ and apply across all projects.',
         },
         {
           type: 'code',
@@ -97,7 +97,7 @@ npx xds agent-docs --agent-docs-path ~/.cursor/rules/xds.mdc`,
       content: [
         {
           type: 'prose',
-          text: 'Paste this into your AI before writing any XDS code. These three questions have a 0% pass rate without docs \u2014 models confidently guess wrong on all of them. If your AI can\'t answer them, it\'ll know to install the agent docs first.',
+          text: 'Paste this into your AI before writing any component code. These three questions have a 0% pass rate without docs \u2014 models confidently guess wrong on all of them. If your AI can\'t answer them, it\'ll know to install the agent docs first.',
         },
         {
           type: 'code',

--- a/packages/cli/src/codemods/transforms/v0.0.15/rename-imperative-ref-to-handleRef.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.15/rename-imperative-ref-to-handleRef.mjs
@@ -15,7 +15,7 @@
 export const meta = {
   title: 'Rename imperative ref props to handleRef',
   description:
-    'Renames imperative `ref` usages to `handleRef` on XDS components whose ' +
+    'Renames imperative `ref` usages to `handleRef` on components whose ' +
     '`ref` prop now points at the root DOM element. Also renames ' +
     '`XDSSideNavCollapseButton` `sideNavRef` to `handleRef`.',
   issue: '#2359',

--- a/packages/cli/src/commands/agent-docs.mjs
+++ b/packages/cli/src/commands/agent-docs.mjs
@@ -127,9 +127,9 @@ export function generateCompressedIndex(version, {coreDir, zh = false, lang, run
   lines.push('');
 
   // Rules — inline, compact, prevents the top error categories
-  lines.push('No <div> anywhere — not for layout, not for wrappers, not for spacing. Use XDS components.');
+  lines.push('No <div> anywhere — not for layout, not for wrappers, not for spacing. Use components.');
   lines.push('Full-page shells → XDSAppShell (not XDSLayout). Sidebar nav → XDSSideNav (not XDSList).');
-  lines.push('No style={{}} — use the xstyle prop on XDS components for custom styling.');
+  lines.push('No style={{}} — use the xstyle prop on components for custom styling.');
   lines.push('If a component prop does what you need, use it — never replicate with CSS/stylex.');
   lines.push(`No magic values — run \`${run} docs tokens\` for spacing/color/radius.`);
   lines.push(`To change accent/brand colors: \`${run} theme\` — never override --xds-color-* in :root.`);
@@ -308,7 +308,7 @@ export function removeAgentDocs(targetDir) {
       if (!fs.existsSync(filePath)) {
         humanLog(`✓ Removed empty ${p}`);
       } else {
-        humanLog(`✓ Removed XDS section from ${p}`);
+        humanLog(`✓ Removed design system section from ${p}`);
       }
     }
   }
@@ -412,8 +412,8 @@ const VALID_AGENTS = ['claude', 'cursor', 'codex', 'all'];
 export function registerAgentDocs(program) {
   program
     .command('agent-docs')
-    .description('Install/update XDS component index for AI coding agents')
-    .option('--remove', 'Remove XDS section from all agent doc files')
+    .description('Install/update the component index for AI coding agents')
+    .option('--remove', 'Remove the design system section from all agent doc files')
     .option('--agent <tool>', 'Target tool: claude, cursor, codex, all')
     .option('--agent-docs-path <path...>', 'Explicit file path(s) to write to')
     .action(options => {
@@ -424,9 +424,9 @@ export function registerAgentDocs(program) {
       const lang = program.opts().lang || null;
 
       if (options.remove) {
-        humanLog('\n🗑️  Removing XDS agent docs...\n');
+        humanLog('\n🗑️  Removing agent docs...\n');
         removeAgentDocs(targetDir);
-        humanLog('\n✅ XDS agent docs removed.\n');
+        humanLog('\n✅ Agent docs removed.\n');
         return;
       }
 
@@ -436,7 +436,7 @@ export function registerAgentDocs(program) {
         return;
       }
 
-      humanLog(`\n📚 Installing XDS agent docs (v${version})...\n`);
+      humanLog(`\n📚 Installing agent docs (v${version})...\n`);
 
       // Collect explicit paths from --agent-docs-path (commander parses variadic as array or single)
       const explicitPaths = options.agentDocsPath
@@ -469,14 +469,14 @@ export function registerAgentDocs(program) {
       }
 
       humanLog(`
-✅ XDS agent docs installed!
+✅ Agent docs installed!
 
 Your AI coding agent will now:
-  • See the XDS component index in ${targets.join(' and ')}
+  • See the component index in ${targets.join(' and ')}
   • Run \`${run} component <name>\` to read detailed docs
   • Run \`${run} docs principles\` for design principles
   • Run \`${run} docs tokens\` for design token reference
-  • Follow XDS patterns and avoid anti-patterns
+  • Follow design system patterns and avoid anti-patterns
 
 To update:
   ${run} agent-docs

--- a/packages/cli/src/commands/build-theme.mjs
+++ b/packages/cli/src/commands/build-theme.mjs
@@ -976,7 +976,7 @@ function validatePrivateVars(themeDef) {
 export function registerTheme(program) {
   const theme = program
     .command('theme')
-    .description('Theme tools — build, export, and manage XDS themes')
+    .description('Theme tools — build, export, and manage themes')
     .action((options, cmd) => {
       // Parent group has no default behaviour. If the user passed an
       // unknown subcommand (e.g. `xds theme bogus`), Commander hands it to

--- a/packages/cli/src/commands/discover.mjs
+++ b/packages/cli/src/commands/discover.mjs
@@ -20,7 +20,7 @@ import {discover as discoverApi} from '../api/discover.mjs';
 export function registerDiscover(program) {
   program
     .command('discover [query]')
-    .description('Discover external XDS packages and components')
+    .description('Discover external packages and components')
     .option('--components', 'List components only')
     .action(async (query, options) => {
       const detail = program.opts().detail || 'full';
@@ -57,7 +57,7 @@ export function registerDiscover(program) {
               humanLog("    packages: ['/path/to/your/libs'],");
               humanLog('  };');
             } else {
-              humanLog('No external XDS packages found.');
+              humanLog('No external packages found.');
               humanLog('');
               humanLog('Packages opt in by adding an "xds" field to package.json:');
               humanLog('');

--- a/packages/cli/src/commands/docs.mjs
+++ b/packages/cli/src/commands/docs.mjs
@@ -101,7 +101,7 @@ function formatReferenceFull(docs, detail) {
 export function registerDocs(program) {
   program
     .command('docs [topic] [section]')
-    .description('Print XDS reference docs')
+    .description('Print reference docs')
     .action(async (topic, section) => {
       const run = getRunPrefix();
       const lang = program.opts().lang || null;

--- a/packages/cli/src/commands/gap-report.mjs
+++ b/packages/cli/src/commands/gap-report.mjs
@@ -122,7 +122,7 @@ export default {
 export function registerGapReport(program) {
   const gapCmd = program
     .command('gap-report')
-    .description('Report a gap in the XDS design system');
+    .description('Report a gap in the design system');
 
   // --- setup subcommand ---
   gapCmd
@@ -357,7 +357,7 @@ export function registerGapReport(program) {
       }
 
       // Interactive mode
-      p.intro('Report an XDS gap');
+      p.intro('Report a gap');
 
       const component = isCancel(
         await p.text({

--- a/packages/cli/src/commands/init.mjs
+++ b/packages/cli/src/commands/init.mjs
@@ -154,7 +154,7 @@ async function runTemplate(targetDir, {interactive = true, templateName} = {}) {
 export function registerInit(program) {
   program
     .command('init')
-    .description('Initialize XDS in your project')
+    .description('Initialize the design system in your project')
     .option('--features <list>', 'Comma-separated features to install (agents, theme, template)')
     .option('--all', 'Install all features, no prompts')
     .option('--remove-agents', 'Remove AI agent docs from all agent doc files')
@@ -204,17 +204,17 @@ export function registerInit(program) {
         hint: `\`${run} xds init --all\` or \`--features agents,theme,template\``,
       });
 
-      p.intro('Welcome to XDS');
+      p.intro('Welcome to the design system');
 
       p.note(
-        'XDS is a design system for building internal tools\nwith 300+ React components.',
+        'A design system for building internal tools\nwith 300+ React components.',
         'About',
       );
 
       // Feature: agents
       const shouldInstallAgents = isCancel(
         await p.confirm({
-          message: 'Install AI agent support? (adds XDS cheat sheet to AGENTS.md)',
+          message: 'Install AI agent support? (adds a design system cheat sheet to AGENTS.md)',
           initialValue: true,
         }),
       );
@@ -239,7 +239,7 @@ export function registerInit(program) {
       await runTheme();
 
       // Outro
-      p.outro('XDS initialized!');
+      p.outro('Design system initialized!');
 
       humanLog('');
       humanLog('  Next steps:');

--- a/packages/cli/src/commands/swizzle.mjs
+++ b/packages/cli/src/commands/swizzle.mjs
@@ -87,7 +87,7 @@ export function registerSwizzle(program) {
 
       if (!coreDir) {
         cliError(
-          'Could not find @xds/core package. Make sure you are inside the XDS monorepo or have @xds/core installed.',
+          'Could not find @xds/core package. Make sure you are inside the design system monorepo or have @xds/core installed.',
         );
         return;
       }

--- a/packages/cli/src/commands/upgrade.mjs
+++ b/packages/cli/src/commands/upgrade.mjs
@@ -139,7 +139,7 @@ async function listCodemods() {
 export function registerUpgrade(program) {
   program
     .command('upgrade')
-    .description('Run codemods to migrate between XDS versions')
+    .description('Run codemods to migrate between versions')
     .option('--apply', 'Write changes to disk (default: dry-run)', false)
     .option('--from <version>', 'Previous version (overrides package.json detection)')
     .option('--to <version>', 'Target version', latestVersion)
@@ -153,7 +153,7 @@ export function registerUpgrade(program) {
     .option('--list', 'List available codemods', false)
     .action(async (options) => {
       const json = program.opts().json || false;
-      if (!json) p.intro('XDS Upgrade');
+      if (!json) p.intro('Upgrade');
 
       // Validate --to / --from upfront so callers don't silently accept
       // typos like `--to bogus` (which used to flow through getTransformsBetween

--- a/packages/cli/src/index.mjs
+++ b/packages/cli/src/index.mjs
@@ -62,7 +62,7 @@ export const JSON_SUPPORTED = new Set([
 
 program
   .name('xds')
-  .description('XDS design system CLI — components, themes, and tooling')
+  .description('Design system CLI — components, themes, and tooling')
   .version(pkg.version)
   .option('--zh', 'Output docs in Chinese Simplified')
   .option('--dense', 'Output docs in compressed dense format (token-efficient)')
@@ -254,7 +254,7 @@ program
     console.log(`
   ╭${'─'.repeat(W + 2)}╮
 ${line('')}
-${line('  XDS design system installed!')}
+${line('  Design system installed!')}
 ${line('')}
 ${line('  Get started:')}
 ${line(`    ${r} init          Interactive setup`)}

--- a/packages/cli/src/lib/resolve-theme.mjs
+++ b/packages/cli/src/lib/resolve-theme.mjs
@@ -110,14 +110,14 @@ export function resolveTheme(cwd = process.cwd()) {
     // File path
     mod = tryLoadModule(specifier, cwd);
     if (!mod) {
-      console.warn(`⚠ XDS theme: could not resolve file "${specifier}" from ${cwd}`);
+      console.warn(`⚠ theme: could not resolve file "${specifier}" from ${cwd}`);
       return null;
     }
   } else if (specifier.startsWith('@')) {
     // Scoped package
     mod = tryLoadModule(specifier, cwd);
     if (!mod) {
-      console.warn(`⚠ XDS theme: could not resolve package "${specifier}"`);
+      console.warn(`⚠ theme: could not resolve package "${specifier}"`);
       return null;
     }
   } else {
@@ -127,7 +127,7 @@ export function resolveTheme(cwd = process.cwd()) {
       mod = tryLoadModule(specifier, cwd);
     }
     if (!mod) {
-      console.warn(`⚠ XDS theme: could not resolve "${specifier}" (tried @xds/theme-${specifier} and ${specifier})`);
+      console.warn(`⚠ theme: could not resolve "${specifier}" (tried @xds/theme-${specifier} and ${specifier})`);
       return null;
     }
   }
@@ -135,7 +135,7 @@ export function resolveTheme(cwd = process.cwd()) {
   // 3. Extract theme data
   const theme = extractTheme(mod);
   if (!theme) {
-    console.warn(`⚠ XDS theme: loaded "${specifier}" but could not find a theme object`);
+    console.warn(`⚠ theme: loaded "${specifier}" but could not find a theme object`);
     return null;
   }
 

--- a/packages/cli/templates/pages/library/template.doc.mjs
+++ b/packages/cli/templates/pages/library/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Card Grid',
   displayName: 'Card Grid',
-  description: 'Browsable grid of XDS components organized by category with tabs and filters',
+  description: 'Browsable grid of components organized by category with tabs and filters',
   isReady: true,
   category: 'Content - Card Grid',
 };


### PR DESCRIPTION
De-brands the CLI docs: strips "XDS" as a *system name* from prose, while keeping all code identifiers, package names, and the `xds` binary name intact.

## Rules applied

In **prose only** (command descriptions, doc topic `text`/`description`/`title`, table cells, README copy, CLI output strings):

- "XDS design system" → "the design system"
- "XDS components" → "components"
- "XDS Button" → "Button"
- "the XDS CLI" → "the CLI"
- "XDS is a design system…" → "A design system…" / "The design system…"

## Kept (intentionally untouched)

- **Code identifiers** — `XDSButton`, `XDSStack`, `XDSAppShell`, `useXDSLinkComponent`, etc.
- **JSX in code blocks** — `<XDSStack>`, `<XDSButton …>`, every `type: 'code'` block
- **Package names** — `@xds/core`, `@xds/cli`, `@xds/theme-*`
- **CLI invocations** — `xds init`, `xds component`, `npx xds …`
- **Anything inside backticks or fenced code blocks** — including the AI "paste this into your AI" prompts that still say `XDS` (those are literal instructions to the model, not prose)
- **`<!-- XDS:START -->` / `<!-- XDS:END -->` markers** and the `XDS v{version}` header — load-bearing, asserted by tests
- **`xds-*` CSS class names** (`xds-button`, `xds-card`) and `--xds-color-*` vars
- **Internal JSDoc `@file` headers and code comments**, regex literals (`/^XDS/`), and template-literal identifier construction (`` `XDS${name}.tsx` ``) — these are implementation, not user-facing prose

## Commits (one per category, for reviewability)

1. **CLI surfaces** — command `.description()` strings, install banner, `init` wizard copy, `agent-docs` status output, `theme` resolution warnings, generated cheat-sheet rules, one codemod `meta.description`
2. **Reference doc topic prose** — `docs/*.doc.mjs` (`getting-started`, `principles`, `styling`, `migration`, `working-with-ai`, `color`, `motion`, `shape`, `spacing`, `typography`, `theme`, `icons`)
3. **README + library template** — `@xds/cli` README intro + command table, Card Grid template description

## ⚠️ Left for follow-up — non-English translations

The `--zh` and `--dense` doc exports contain Simplified Chinese prose that already reads "XDS" inside translated sentences. I de-branded the **English** `principles.doc.dense.mjs` but deliberately **did not touch** the already-translated zh content, since de-branding translated copy needs a native check for grammar/flow:

- `docs/principles.doc.zh.mjs` — `description` + two list items reference `XDS 组件` / `XDS`
- `docs/theme.doc.zh.mjs` — `XDSTheme` references are *identifiers* (keep), but the `description` prose says `XDSTheme 提供者` (borderline — identifier-led, left as-is)
- `docs/tokens.doc.zh.mjs` — clean (no standalone system-name XDS)

**→ Flagging for Joey's Night Watch** to handle the zh prose de-brand with a native review.

## Tests

`vitest run packages/cli` — **703 passed** (was 701 on the base; delta is collection variance, all green). No assertions touched.
