### PR TITLE
fix(cli): replace regex skeleton extractor with AST walk

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -52,6 +52,7 @@
     "typecheck:json-api": "tsc --project tsconfig.json-api.json"
   },
   "dependencies": {
+    "@babel/parser": "^7.29.0",
     "@clack/prompts": "^1.5.0",
     "commander": "^12.1.0",
     "jiti": "^2.7.0"

--- a/packages/cli/src/api/__tests__/skeleton.test.mjs
+++ b/packages/cli/src/api/__tests__/skeleton.test.mjs
@@ -1,0 +1,281 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Tests for the AST-based layout skeleton extractor.
+ *
+ * The previous regex extractor shipped with ZERO tests — every one of the 37
+ * page templates rendered incorrectly (malformed object-literal props,
+ * orphaned trees from slot-prop `/>`, unbalanced tags, mid-tree truncation).
+ *
+ * These tests need NO stored fixtures: every real template is discovered live
+ * and checked against structural invariants that must hold for any valid
+ * skeleton, plus focused regressions for each historical bug class.
+ */
+
+import {describe, it, expect} from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {parse} from '@babel/parser';
+import {extractSkeleton} from '../skeleton.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const TEMPLATES = path.resolve(__dirname, '../../../templates');
+const PAGES_DIR = path.join(TEMPLATES, 'pages');
+const BLOCKS_DIR = path.join(TEMPLATES, 'blocks');
+
+/** The JSX body must parse as real JSX (wrapped in a fragment for multi-root). */
+function assertParseable(skeleton, label) {
+  const code = 'const __x = (<>\n' + skeleton + '\n</>);';
+  expect(
+    () => parse(code, {sourceType: 'module', plugins: ['jsx', 'typescript']}),
+    `${label} should produce parseable JSX`,
+  ).not.toThrow();
+}
+
+/** Every open tag has a matching close, in order. */
+function assertBalanced(skeleton, label) {
+  const stack = [];
+  for (const rawLine of skeleton.split('\n')) {
+    const t = rawLine.trim();
+    if (!t || t.startsWith('/*') || t === '...') continue;
+    if (/^<[A-Za-z]\w*(?:\s[^>]*)?\/>$/.test(t)) continue; // self-closing
+    const open = t.match(/^<([A-Za-z]\w*)(?:\s[^>]*)?>$/);
+    const close = t.match(/^<\/([A-Za-z]\w*)>$/);
+    if (open) stack.push(open[1]);
+    else if (close) {
+      expect(stack.length, `${label}: stray close </${close[1]}>`).toBeGreaterThan(0);
+      expect(stack.pop(), `${label}: mismatched close </${close[1]}>`).toBe(close[1]);
+    }
+  }
+  expect(stack, `${label}: unclosed tags ${stack.join(', ')}`).toEqual([]);
+}
+
+/** Component names in the header must be exactly those emitted in the body. */
+function assertHeaderMatchesBody(result, label) {
+  const inBody = new Set();
+  for (const rawLine of result.skeleton.split('\n')) {
+    const m = rawLine.trim().match(/^<\/?([A-Z]\w*)/);
+    if (m) inBody.add(m[1]);
+  }
+  expect([...result.components].sort(), `${label}: header must equal body`)
+    .toEqual([...inBody].sort());
+}
+
+function checkInvariants(name, file) {
+  const result = extractSkeleton(fs.readFileSync(file, 'utf-8'));
+  expect(result.skeleton.trim(), `${name}: non-empty skeleton`).not.toBe('');
+  // Bug 1 regression: object-literal props must never produce `="{`.
+  expect(result.skeleton, `${name}: no malformed object-literal prop`).not.toMatch(/="\{/);
+  assertParseable(result.skeleton, name);
+  assertBalanced(result.skeleton, name);
+  assertHeaderMatchesBody(result, name);
+}
+
+// ── Discover real templates ────────────────────────────────────────────
+const pageEntries = fs.readdirSync(PAGES_DIR, {withFileTypes: true})
+  .filter(e => e.isDirectory())
+  .map(e => [e.name, path.join(PAGES_DIR, e.name, 'page.tsx')])
+  .filter(([, f]) => fs.existsSync(f))
+  .sort((a, b) => a[0].localeCompare(b[0]));
+
+function findBlockTsx(dir) {
+  const out = [];
+  for (const e of fs.readdirSync(dir, {withFileTypes: true})) {
+    const f = path.join(dir, e.name);
+    if (e.isDirectory()) out.push(...findBlockTsx(f));
+    else if (/\.tsx$/.test(e.name) && !/\.doc\./.test(e.name)) out.push(f);
+  }
+  return out;
+}
+const blockEntries = findBlockTsx(BLOCKS_DIR)
+  .map(f => [path.basename(f, '.tsx'), f])
+  .sort((a, b) => a[0].localeCompare(b[0]));
+
+describe('extractSkeleton — invariants for every page template', () => {
+  it('discovers all page templates', () => {
+    expect(pageEntries.length).toBeGreaterThanOrEqual(37);
+  });
+  it.each(pageEntries)('page %s: parses, balanced, header==body, no malformed props', checkInvariants);
+});
+
+describe('extractSkeleton — invariants for every block template', () => {
+  it.each(blockEntries)('block %s', (name, file) => {
+    const result = extractSkeleton(fs.readFileSync(file, 'utf-8'));
+    // Blocks may legitimately be tiny; only require well-formedness when non-empty.
+    if (result.skeleton.trim() === '') return;
+    expect(result.skeleton, `${name}: no malformed prop`).not.toMatch(/="\{/);
+    assertParseable(result.skeleton, name);
+    assertBalanced(result.skeleton, name);
+    assertHeaderMatchesBody(result, name);
+  });
+});
+
+describe('extractSkeleton — bug-class regressions', () => {
+  it('Bug 1: object-literal props render intact, not as broken strings', () => {
+    const {skeleton} = extractSkeleton(`
+      export default function T() {
+        return <XDSGrid columns={{minWidth: 240, repeat: 'fit'}} gap={4}><XDSCard /></XDSGrid>;
+      }`);
+    expect(skeleton).toContain('columns={{minWidth: 240, repeat: "fit"}}');
+    expect(skeleton).not.toContain('columns="{minWidth:');
+  });
+
+  it('Bug 2: a self-closing child in a slot prop does NOT self-close the parent', () => {
+    const {skeleton} = extractSkeleton(`
+      export default function T() {
+        return (
+          <XDSAppShell sideNav={<XDSSideNav />} variant="elevated">
+            <XDSVStack gap={4}><XDSCard /></XDSVStack>
+          </XDSAppShell>
+        );
+      }`);
+    expect(skeleton).toMatch(/<AppShell[^>]*>/);     // opens
+    expect(skeleton).not.toMatch(/<AppShell[^>]*\/>/); // not self-closed
+    expect(skeleton).toContain('/* sideNav: */');
+    expect(skeleton).toContain('<SideNav />');
+    assertBalanced(skeleton, 'bug2');
+  });
+
+  it('Bug 3: output is always tag-balanced even with skipped wrappers', () => {
+    const {skeleton} = extractSkeleton(`
+      export default function T() {
+        return (
+          <div style={{padding: 16}}>
+            <XDSLayout><XDSLayoutContent><XDSText /></XDSLayoutContent></XDSLayout>
+          </div>
+        );
+      }`);
+    assertBalanced(skeleton, 'bug3');
+    assertParseable(skeleton, 'bug3');
+  });
+
+  it('Bug 4: truncation never leaves an unclosed tag', () => {
+    const rows = Array.from({length: 200}, () => '<XDSCard />').join('\n');
+    const {skeleton} = extractSkeleton(`
+      export default function T() {
+        return <XDSAppShell><XDSVStack gap={2}>${rows}</XDSVStack></XDSAppShell>;
+      }`);
+    expect(skeleton).toContain('...');
+    assertBalanced(skeleton, 'bug4');
+    expect(skeleton.trimEnd().endsWith('</AppShell>')).toBe(true);
+  });
+
+  it('Bug 5: header components equal body components', () => {
+    const result = extractSkeleton(`
+      export default function T() {
+        return <XDSAppShell sideNav={<XDSSideNav />}><XDSCard><XDSText /></XDSCard></XDSAppShell>;
+      }`);
+    assertHeaderMatchesBody(result, 'bug5');
+    expect(result.components).toEqual(['AppShell', 'Card', 'SideNav', 'Text']);
+  });
+
+  it('Bug 6: nesting depth reflects real structure (indentation increases)', () => {
+    const {skeleton} = extractSkeleton(`
+      export default function T() {
+        return (
+          <XDSAppShell><XDSCard><XDSVStack gap={2}><XDSText /></XDSVStack></XDSCard></XDSAppShell>
+        );
+      }`);
+    const lines = skeleton.split('\n');
+    const indent = tag => {
+      const l = lines.find(x => x.includes(tag));
+      return l.length - l.trimStart().length;
+    };
+    expect(indent('<AppShell')).toBe(0);
+    expect(indent('<Card')).toBe(2);
+    expect(indent('<VStack')).toBe(4);
+    expect(indent('<Text')).toBe(6);
+  });
+
+  it('inlines local helper components so structure is complete', () => {
+    const {skeleton, components} = extractSkeleton(`
+      function Sidebar() { return <XDSSideNav><XDSSideNavItem /></XDSSideNav>; }
+      export default function T() {
+        return <XDSAppShell sideNav={<Sidebar />}><XDSCard /></XDSAppShell>;
+      }`);
+    expect(skeleton).toContain('<SideNav>');
+    expect(skeleton).toContain('<SideNavItem />');
+    expect(components).toContain('SideNavItem');
+  });
+
+  it('descends into array .map() render callbacks', () => {
+    const {skeleton} = extractSkeleton(`
+      export default function T() {
+        return <XDSVStack gap={2}>{items.map(i => <XDSCard key={i} />)}</XDSVStack>;
+      }`);
+    expect(skeleton).toContain('<VStack gap={2}>');
+    expect(skeleton).toContain('<Card />');
+  });
+
+  it('derives slot markers structurally — any JSX-valued prop, no hardcoded list', () => {
+    // `drawer` is NOT a name the extractor knows ahead of time; it should still
+    // be treated as a slot purely because its value is JSX.
+    const {skeleton} = extractSkeleton(`
+      export default function T() {
+        return (
+          <XDSAppShell drawer={<XDSCard />} sideNav={<XDSSideNav />}>
+            <XDSText />
+          </XDSAppShell>
+        );
+      }`);
+    expect(skeleton).toContain('/* drawer: */');
+    expect(skeleton).toContain('/* sideNav: */');
+    expect(skeleton).toContain('<Card />');
+    assertBalanced(skeleton, 'derived-slots');
+  });
+
+  it('handles slot props whose value is a ternary or .map()', () => {
+    const {skeleton} = extractSkeleton(`
+      export default function T() {
+        return (
+          <XDSLayout
+            header={cond ? <XDSTopNav /> : <XDSToolbar />}
+            content={items.map(i => <XDSTab key={i} />)}>
+            <XDSText />
+          </XDSLayout>
+        );
+      }`);
+    expect(skeleton).toContain('/* header: */');
+    expect(skeleton).toContain('/* content: */');
+    expect(skeleton).toMatch(/<TopNav \/>|<Toolbar \/>/);
+    expect(skeleton).toContain('<Tab />');
+    assertBalanced(skeleton, 'slot-expr');
+  });
+
+  it('shows layout props via a noise blocklist (new XDS props appear automatically)', () => {
+    // `inset` is invented here — not in any allowlist — and must still render.
+    const {skeleton} = extractSkeleton(`
+      export default function T() {
+        return <XDSCard inset="lg" gap={4} onClick={handle} aria-label="x" className="y" />;
+      }`);
+    expect(skeleton).toContain('inset="lg"');
+    expect(skeleton).toContain('gap={4}');
+    // Noise (handlers, aria-, className) is suppressed.
+    expect(skeleton).not.toContain('onClick');
+    expect(skeleton).not.toContain('aria-label');
+    expect(skeleton).not.toContain('className');
+  });
+
+  it('omits complex/computed prop values rather than rendering garbage', () => {
+    const {skeleton} = extractSkeleton(`
+      export default function T() {
+        return <XDSGrid columns={getColumns()} gap={someVar} padding={4} />;
+      }`);
+    // Computed values are dropped; clean literals stay.
+    expect(skeleton).toContain('padding={4}');
+    expect(skeleton).not.toContain('getColumns');
+    expect(skeleton).not.toContain('someVar');
+    expect(skeleton).not.toMatch(/="\{/);
+  });
+
+  it('returns empty result for source with no default-export JSX', () => {
+    const result = extractSkeleton('export const x = 1;');
+    expect(result).toEqual({skeleton: '', components: []});
+  });
+
+  it('returns empty result for unparseable source rather than throwing', () => {
+    const result = extractSkeleton('export default function ( { <<< broken');
+    expect(result).toEqual({skeleton: '', components: []});
+  });
+});

--- a/packages/cli/src/api/skeleton.mjs
+++ b/packages/cli/src/api/skeleton.mjs
@@ -1,0 +1,418 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file AST-based layout skeleton extractor for templates.
+ *
+ * Parses a template's source with @babel/parser and walks the JSX returned
+ * by its default export, producing a compact layout outline: nesting comes
+ * from the JSX tree, structural components and spatial props (padding, gap,
+ * columns, etc.) come from the same traversal — so the component list and
+ * the rendered body are always derived from one pass and cannot disagree.
+ *
+ * This replaces a regex/line-scanning extractor that mangled object-literal
+ * props (`columns={{minWidth: 240}}`), mistook `/>` inside slot props for a
+ * self-closing parent (orphaning the whole tree), produced unbalanced tags,
+ * and truncated mid-tree.
+ *
+ * @input  source — TSX/JSX source string for a template
+ * @output { skeleton: string, components: string[] }
+ * @position packages/cli/src/api — consumed by api/template.mjs `--skeleton`
+ *
+ * SYNC: When modified, update packages/cli/src/api/README.md if present.
+ */
+
+import {parse} from '@babel/parser';
+
+/**
+ * Props that are never layout-relevant and would only add noise to a layout
+ * skeleton. Everything NOT in this set is shown, so spatial props that XDS
+ * adds in the future (e.g. a new `inset` or `flow` prop) appear automatically
+ * with no change here. A miss only ever adds/removes an annotation — it can
+ * never produce malformed output.
+ */
+const NOISE_PROPS = new Set([
+  'key', 'ref', 'id', 'className', 'class', 'style', 'xstyle', 'data-testid',
+  'label', 'aria-label', 'aria-labelledby', 'aria-describedby', 'title',
+  'href', 'src', 'alt', 'name', 'value', 'defaultValue', 'placeholder',
+  'icon', 'startIcon', 'endIcon', 'children',
+]);
+
+const MAX_LINES = 80;
+const MAX_INLINE_DEPTH = 8;
+
+/** Resolve a JSXIdentifier / JSXMemberExpression to its rightmost name. */
+function jsxName(node) {
+  if (!node) return '';
+  if (node.type === 'JSXIdentifier') return node.name;
+  if (node.type === 'JSXMemberExpression') return jsxName(node.property);
+  return '';
+}
+
+/** Stringify a literal-ish expression node, or return null if not renderable. */
+function litToStr(node) {
+  if (!node) return null;
+  switch (node.type) {
+    case 'StringLiteral': return JSON.stringify(node.value);
+    case 'NumericLiteral': return String(node.value);
+    case 'BooleanLiteral': return String(node.value);
+    case 'Identifier': return node.name;
+    case 'ObjectExpression': return objToStr(node);
+    default: return null;
+  }
+}
+
+/** Render an object literal like {minWidth: 240, repeat: 'fit'}. */
+function objToStr(node) {
+  if (node.type !== 'ObjectExpression') return null;
+  const parts = [];
+  for (const p of node.properties) {
+    if (p.type !== 'ObjectProperty') continue;
+    const k = p.key.name ?? p.key.value;
+    const v = litToStr(p.value);
+    if (v != null) parts.push(`${k}: ${v}`);
+  }
+  return '{' + parts.join(', ') + '}';
+}
+
+/**
+ * Extract layout-relevant props (preserving object literals) from an opening
+ * element. Uses a noise blocklist rather than an allowlist, so any new XDS
+ * layout prop shows up automatically. Only props whose values read cleanly
+ * (string / number / boolean / object literal) are emitted; complex
+ * expressions (handlers, refs, computed values) are omitted as noise.
+ */
+function layoutProps(opening) {
+  const out = [];
+  for (const attr of opening.attributes) {
+    if (attr.type !== 'JSXAttribute') continue;
+    const name = attr.name.name;
+    if (typeof name !== 'string') continue;
+    // Skip noise: known non-layout props, event handlers (onClick…), and ARIA.
+    if (NOISE_PROPS.has(name)) continue;
+    if (/^on[A-Z]/.test(name)) continue;
+    if (name.startsWith('aria-')) continue;
+    const v = attr.value;
+    // Boolean shorthand: `hasDivider`
+    if (v == null) { out.push(name); continue; }
+    if (v.type === 'StringLiteral') { out.push(`${name}="${v.value}"`); continue; }
+    if (v.type === 'JSXExpressionContainer') {
+      const e = v.expression;
+      if (e.type === 'BooleanLiteral') { if (e.value) out.push(name); continue; }
+      if (e.type === 'NumericLiteral') { out.push(`${name}={${e.value}}`); continue; }
+      if (e.type === 'StringLiteral') { out.push(`${name}="${e.value}"`); continue; }
+      if (e.type === 'ObjectExpression') { out.push(`${name}={${objToStr(e)}}`); continue; }
+      // Complex expressions (refs, calls, computed values) are omitted.
+    }
+  }
+  return out;
+}
+
+/** Read a `style={{padding: ..., gap: ...}}` annotation from a raw <div>. */
+function divAnnotation(opening) {
+  for (const attr of opening.attributes) {
+    if (attr.type !== 'JSXAttribute' || attr.name.name !== 'style') continue;
+    const v = attr.value;
+    if (!(v && v.type === 'JSXExpressionContainer' &&
+          v.expression.type === 'ObjectExpression')) continue;
+    const parts = [];
+    for (const p of v.expression.properties) {
+      if (p.type !== 'ObjectProperty') continue;
+      const k = p.key.name ?? p.key.value;
+      if (!['padding', 'maxWidth', 'gap', 'margin', 'marginInline'].includes(k)) continue;
+      const val = litToStr(p.value);
+      if (val != null) parts.push(`${k}: ${val.replace(/^"|"$/g, '')}`);
+    }
+    if (parts.length) return parts.join(', ');
+  }
+  return null;
+}
+
+/** Find the JSX expression returned by a function/arrow body. */
+function fnReturnJSX(fn) {
+  const body = fn.body;
+  if (!body) return null;
+  if (body.type === 'JSXElement' || body.type === 'JSXFragment') return body;
+  if (body.type === 'BlockStatement') {
+    for (let i = body.body.length - 1; i >= 0; i--) {
+      const st = body.body[i];
+      if (st.type === 'ReturnStatement' && st.argument) return st.argument;
+    }
+  }
+  return null;
+}
+
+/**
+ * Does an expression node contain JSX anywhere within it? Used to recognize
+ * slot props structurally (`sideNav={<X/>}`, `header={cond ? <A/> : <B/>}`)
+ * without a hardcoded prop-name list. Bounded by a node budget so a pathological
+ * expression can never run away.
+ */
+function containsJSX(node, budget = {n: 2000}) {
+  if (!node || typeof node !== 'object' || budget.n-- <= 0) return false;
+  if (node.type === 'JSXElement' || node.type === 'JSXFragment') return true;
+  for (const key in node) {
+    if (key === 'loc' || key === 'start' || key === 'end' ||
+        key === 'range' || key === 'leadingComments' ||
+        key === 'trailingComments') continue;
+    const v = node[key];
+    if (Array.isArray(v)) {
+      for (const item of v) if (containsJSX(item, budget)) return true;
+    } else if (v && typeof v === 'object' && typeof v.type === 'string') {
+      if (containsJSX(v, budget)) return true;
+    }
+  }
+  return false;
+}
+
+/** Collect locally-defined components (PascalCase fn/const) for inlining. */
+function collectLocals(ast) {
+  const locals = new Map();
+  const isComp = n => /^[A-Z]/.test(n);
+  for (const n of ast.program.body) {
+    if (n.type === 'FunctionDeclaration' && n.id && isComp(n.id.name)) {
+      locals.set(n.id.name, n);
+    }
+    if (n.type === 'VariableDeclaration') {
+      for (const d of n.declarations) {
+        if (d.id.type === 'Identifier' && isComp(d.id.name) && d.init &&
+            (d.init.type === 'ArrowFunctionExpression' ||
+             d.init.type === 'FunctionExpression')) {
+          locals.set(d.id.name, d.init);
+        }
+      }
+    }
+  }
+  return locals;
+}
+
+/**
+ * Build an intermediate tree of plain nodes from a JSX AST node.
+ * Node shapes:
+ *   { comp, props[], children[] }     — an XDS element
+ *   { comment }                        — a `/* ... *​/` annotation line
+ *   { slot, children[] }               — a named slot marker + its subtree
+ * Returns an array (a JSX node may expand to 0..n skeleton nodes).
+ */
+function buildTree(node, ctx) {
+  if (!node) return [];
+  switch (node.type) {
+    case 'JSXFragment': {
+      const out = [];
+      for (const c of node.children) out.push(...buildTree(c, ctx));
+      return out;
+    }
+    case 'JSXText':
+      return [];
+    case 'JSXExpressionContainer':
+      return buildExpr(node.expression, ctx);
+    case 'ParenthesizedExpression':
+      return buildTree(node.expression, ctx);
+    case 'JSXElement':
+      break;
+    default:
+      return [];
+  }
+
+  const opening = node.openingElement;
+  const raw = jsxName(opening.name);
+  const isXDS = raw.startsWith('XDS');
+
+  // JSX-valued props are treated as named slots (sideNav={<X/>}, header={<Y/>}).
+  // We detect them structurally — any prop whose value is (or contains) JSX —
+  // rather than from a hardcoded name list, so new XDS slots work automatically.
+  // Slot *markers* are only meaningful on XDS layout components; on other
+  // elements (e.g. a recharts `<Tooltip content={<X/>} />`) the same attribute
+  // is not a layout slot, so we descend into its JSX without emitting a marker.
+  const slotChildren = [];
+  for (const attr of opening.attributes) {
+    if (attr.type !== 'JSXAttribute') continue;
+    if (!attr.value || attr.value.type !== 'JSXExpressionContainer') continue;
+    const expr = attr.value.expression;
+    if (!containsJSX(expr)) continue;
+    const built = buildExpr(expr, ctx);
+    if (built.length === 0) continue;
+    if (isXDS && typeof attr.name.name === 'string') {
+      slotChildren.push({slot: attr.name.name, children: built});
+    } else {
+      slotChildren.push(...built);
+    }
+  }
+
+  if (isXDS) {
+    const comp = raw.slice(3);
+    const props = layoutProps(opening);
+    const kids = [];
+    for (const c of node.children) kids.push(...buildTree(c, ctx));
+    return [{comp, props, children: [...slotChildren, ...kids]}];
+  }
+
+  // Local helper component — inline its returned JSX so structure is complete.
+  if (/^[A-Z]/.test(raw) && ctx.locals.has(raw) &&
+      !ctx.stack.has(raw) && ctx.stack.size < MAX_INLINE_DEPTH) {
+    const ret = fnReturnJSX(ctx.locals.get(raw));
+    ctx.stack.add(raw);
+    const inlined = ret ? buildTree(ret, ctx) : [];
+    ctx.stack.delete(raw);
+    return [...slotChildren, ...inlined];
+  }
+
+  // Raw <div> with spatial style → annotation comment + its children.
+  if (raw === 'div') {
+    const ann = divAnnotation(opening);
+    const inner = [];
+    for (const c of node.children) inner.push(...buildTree(c, ctx));
+    return ann ? [{comment: `div: ${ann}`}, ...slotChildren, ...inner] : [...slotChildren, ...inner];
+  }
+
+  // Other non-XDS element (unresolved helper, fragment-like wrapper): descend
+  // into slots + children, but don't print the wrapper itself.
+  const out = [];
+  out.push(...slotChildren);
+  for (const c of node.children) out.push(...buildTree(c, ctx));
+  return out;
+}
+
+/** Descend into JSX-bearing expressions: {cond && <X/>}, {a ? <X/> : <Y/>}, {arr.map(...)}. */
+function buildExpr(node, ctx) {
+  if (!node) return [];
+  switch (node.type) {
+    case 'JSXElement':
+    case 'JSXFragment':
+      return buildTree(node, ctx);
+    case 'LogicalExpression':
+      return buildExpr(node.right, ctx);
+    case 'ConditionalExpression':
+      return [...buildExpr(node.consequent, ctx), ...buildExpr(node.alternate, ctx)];
+    case 'ParenthesizedExpression':
+      return buildExpr(node.expression, ctx);
+    case 'CallExpression': {
+      const out = [];
+      for (const arg of node.arguments) {
+        if (arg.type === 'ArrowFunctionExpression' || arg.type === 'FunctionExpression') {
+          const b = arg.body;
+          if (b.type === 'BlockStatement') {
+            for (const st of b.body) {
+              if (st.type === 'ReturnStatement' && st.argument) {
+                out.push(...buildExpr(st.argument, ctx));
+              }
+            }
+          } else {
+            out.push(...buildExpr(b, ctx));
+          }
+        }
+      }
+      return out;
+    }
+    default:
+      return [];
+  }
+}
+
+/**
+ * Serialize the intermediate tree to indented skeleton text. Truncation is
+ * depth-aware: once MAX_LINES is reached we stop opening new content and emit
+ * a single `...`, but every already-opened tag is still closed so the output
+ * is always tag-balanced.
+ *
+ * Component names are collected here — from the nodes actually emitted — so
+ * the returned list can never list a component the body doesn't show (and
+ * vice versa), even when the tree is truncated.
+ *
+ * @returns {{ text: string, components: Set<string> }}
+ */
+function serialize(tree) {
+  const out = [];
+  const components = new Set();
+  let truncated = false;
+
+  function emit(nodes, depth) {
+    const pad = '  '.repeat(depth);
+    for (const n of nodes) {
+      if (n.comment) {
+        if (out.length >= MAX_LINES) { markTruncated(pad); return; }
+        out.push(pad + `/* ${n.comment} */`);
+        continue;
+      }
+      if (n.slot) {
+        if (out.length >= MAX_LINES) { markTruncated(pad); return; }
+        out.push(pad + `/* ${n.slot}: */`);
+        emit(n.children || [], depth);
+        continue;
+      }
+      // XDS element
+      const propStr = n.props && n.props.length ? ' ' + n.props.join(' ') : '';
+      const kids = n.children || [];
+      if (kids.length === 0) {
+        if (out.length >= MAX_LINES) { markTruncated(pad); return; }
+        out.push(pad + `<${n.comp}${propStr} />`);
+        components.add(n.comp);
+        continue;
+      }
+      if (out.length >= MAX_LINES) { markTruncated(pad); return; }
+      out.push(pad + `<${n.comp}${propStr}>`);
+      components.add(n.comp);
+      emit(kids, depth + 1);
+      // Always close — even past the cap — to keep tags balanced.
+      out.push(pad + `</${n.comp}>`);
+    }
+  }
+
+  function markTruncated(pad) {
+    if (!truncated) {
+      out.push(pad + '...');
+      truncated = true;
+    }
+  }
+
+  emit(tree, 0);
+  return {text: out.join('\n'), components};
+}
+
+/** Find the JSX returned by the module's default-export component. */
+function findRootJSX(ast) {
+  let def = null;
+  for (const n of ast.program.body) {
+    if (n.type === 'ExportDefaultDeclaration') def = n.declaration;
+  }
+  if (!def) return null;
+  if (def.type === 'FunctionDeclaration' ||
+      def.type === 'FunctionExpression' ||
+      def.type === 'ArrowFunctionExpression') {
+    return fnReturnJSX(def);
+  }
+  if (def.type === 'Identifier') {
+    // `export default Foo;` — resolve to a local component if present.
+    const locals = collectLocals(ast);
+    const fn = locals.get(def.name);
+    return fn ? fnReturnJSX(fn) : null;
+  }
+  return null;
+}
+
+/**
+ * Extract a layout skeleton and its structural component list from template
+ * source. Both are produced from a single AST traversal.
+ *
+ * @param {string} source
+ * @returns {{ skeleton: string, components: string[] }}
+ */
+export function extractSkeleton(source) {
+  let ast;
+  try {
+    ast = parse(source, {sourceType: 'module', plugins: ['jsx', 'typescript']});
+  } catch {
+    return {skeleton: '', components: []};
+  }
+  const root = findRootJSX(ast);
+  if (!root) return {skeleton: '', components: []};
+
+  const ctx = {locals: collectLocals(ast), stack: new Set()};
+  const tree = buildTree(root, ctx);
+  const {text, components} = serialize(tree);
+  return {
+    skeleton: text,
+    // Components are taken from what was actually emitted, so the header and
+    // body are guaranteed consistent even under truncation.
+    components: [...components].sort(),
+  };
+}

--- a/packages/cli/src/api/template.mjs
+++ b/packages/cli/src/api/template.mjs
@@ -10,6 +10,7 @@ import {CLI_ROOT, discoverExternalPackages} from '../utils/paths.mjs';
 import {assertWithin, isFilePathArg, PathSafetyError} from '../utils/path-safety.mjs';
 import {XDSError} from './error.mjs';
 import {loadConfig} from '../lib/config.mjs';
+import {extractSkeleton} from './skeleton.mjs';
 
 const TEMPLATES_DIR = path.join(CLI_ROOT, 'templates');
 const PAGES_DIR = path.join(TEMPLATES_DIR, 'pages');
@@ -222,109 +223,9 @@ function extractComponents(pagePath) {
   )].sort();
 }
 
-const STRUCTURAL = new Set([
-  'AppShell', 'Layout', 'LayoutHeader', 'LayoutContent', 'LayoutPanel',
-  'LayoutFooter', 'Card', 'Section', 'Grid', 'GridSpan', 'List',
-  'Table', 'TabList', 'Toolbar', 'SideNav', 'TopNav', 'Dialog',
-  'FormLayout', 'Center',
-]);
-
-function extractSkeleton(source) {
-  const lines = source.split('\n');
-  const out = [];
-  let depth = 0;
-  let capturing = false;
-  let inDefaultExport = false;
-  const MAX_LINES = 35;
-  const depthStack = [];
-
-  for (let i = 0; i < lines.length; i++) {
-    const t = lines[i].trim();
-
-    if (t.match(/^export\s+default\s+function/)) { inDefaultExport = true; continue; }
-    if (inDefaultExport && t.match(/^return\s*\(/)) { capturing = true; continue; }
-    if (!capturing) continue;
-    if (out.length >= MAX_LINES) {
-      if (!out[out.length - 1]?.includes('...')) out.push('  '.repeat(depth) + '...');
-      continue;
-    }
-
-    const openMatch = t.match(/^<(XDS\w+)/);
-    if (openMatch && !t.startsWith('</')) {
-      const comp = openMatch[1].replace(/^XDS/, '');
-      let tagText = '';
-      for (let j = i; j < Math.min(i + 12, lines.length); j++) {
-        tagText += ' ' + lines[j];
-        if (lines[j].includes('>')) break;
-      }
-
-      const props = [];
-      const propRegex = /\b(padding|contentPadding|gap|rowGap|columnGap|columns|minChildWidth|hasDivider|defaultHasDividers|variant|density|role|height|width|maxWidth)\s*[=]\s*\{?\s*['"]?([^}'"\s,/>]+)/g;
-      let m;
-      while ((m = propRegex.exec(tagText)) !== null) {
-        const val = m[2];
-        if (val === 'true') props.push(m[1]);
-        else if (/^\d+$/.test(val)) props.push(`${m[1]}={${val}}`);
-        else props.push(`${m[1]}="${val}"`);
-      }
-
-      const hasSpatialProps = props.length > 0;
-      const propStr = hasSpatialProps ? ' ' + props.join(' ') : '';
-      const isVStack = comp === 'VStack' || comp === 'HStack';
-      const isSelfClosing = tagText.match(new RegExp('<' + openMatch[1] + '[^>]*/>', 's'));
-
-      if (isVStack && !hasSpatialProps) continue;
-
-      if (isSelfClosing) {
-        out.push('  '.repeat(depth) + `<${comp}${propStr} />`);
-      } else if (STRUCTURAL.has(comp) || (isVStack && hasSpatialProps)) {
-        out.push('  '.repeat(depth) + `<${comp}${propStr}>`);
-        depthStack.push(comp);
-        depth++;
-      } else {
-        out.push('  '.repeat(depth) + `<${comp}${propStr} />`);
-      }
-      continue;
-    }
-
-    const closeMatch = t.match(/^<\/(XDS\w+)>/);
-    if (closeMatch) {
-      const comp = closeMatch[1].replace(/^XDS/, '');
-      if (depthStack.length > 0 && depthStack[depthStack.length - 1] === comp) {
-        depthStack.pop();
-        depth = Math.max(0, depth - 1);
-        out.push('  '.repeat(depth) + `</${comp}>`);
-      }
-      continue;
-    }
-
-    const slotMatch = t.match(/^(header|content|footer|start|end|sideNav|topNav)\s*=\s*\{/);
-    if (slotMatch) {
-      out.push('  '.repeat(depth) + `/* ${slotMatch[1]}: */`);
-      continue;
-    }
-
-    if (t.startsWith('<div') && (t.includes('padding') || t.includes('maxWidth') || t.includes('gap:'))) {
-      const styleProps = [];
-      const divText = lines.slice(i, Math.min(i + 5, lines.length)).join(' ');
-      const pp = divText.match(/padding[^:]*:\s*['"]?([^'"},)]+)/);
-      const mw = divText.match(/maxWidth:\s*(\d+)/);
-      const gp = divText.match(/gap:\s*(\d+)/);
-      const mg = divText.match(/margin:\s*['"]([^'"]+)['"]/);
-      const mi = divText.match(/marginInline:\s*['"]([^'"]+)['"]/);
-      if (pp) styleProps.push(`padding: ${pp[1].trim()}`);
-      if (mw) styleProps.push(`maxWidth: ${mw[1]}`);
-      if (gp) styleProps.push(`gap: ${gp[1]}`);
-      if (mg) styleProps.push(`margin: ${mg[1]}`);
-      if (mi) styleProps.push(`marginInline: ${mi[1]}`);
-      if (styleProps.length > 0) {
-        out.push('  '.repeat(depth) + `/* div: ${styleProps.join(', ')} */`);
-      }
-    }
-  }
-
-  return out.filter(l => l.trim()).join('\n');
-}
+// Layout skeleton extraction lives in skeleton.mjs (AST-based). It returns
+// both the rendered skeleton and the structural component list from one
+// traversal, so the two can never disagree.
 
 /**
  * Fetch a template by ID using the `template.get` hook in xds.config.mjs.
@@ -428,13 +329,16 @@ export async function template(name, options = {}) {
       throw new XDSError(`No source file found for template "${name}"`);
     }
     const src = fs.readFileSync(match.filePath, 'utf-8');
+    // Both the component list and the skeleton body come from one AST pass,
+    // so the `# Components:` header can never disagree with the rendered tree.
+    const {skeleton: skeletonText, components} = extractSkeleton(src);
     return {
       type: 'template.skeleton',
       data: {
         template: name,
         description: match.description,
-        components: extractComponents(match.filePath),
-        skeleton: extractSkeleton(src),
+        components,
+        skeleton: skeletonText,
       },
     };
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -702,6 +702,9 @@ importers:
 
   packages/cli:
     dependencies:
+      '@babel/parser':
+        specifier: ^7.29.0
+        version: 7.29.7
       '@clack/prompts':
         specifier: ^1.5.0
         version: 1.5.0
@@ -6440,7 +6443,7 @@ snapshots:
       '@babel/code-frame': 7.29.0
       '@babel/generator': 7.29.1
       '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.29.3
+      '@babel/parser': 7.29.7
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
       debug: 4.4.3
@@ -9116,7 +9119,7 @@ snapshots:
   eslint-plugin-react-compiler@19.1.0-rc.2(eslint@10.4.1(jiti@2.7.0)):
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/parser': 7.29.3
+      '@babel/parser': 7.29.7
       '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.29.7)
       eslint: 10.4.1(jiti@2.7.0)
       hermes-parser: 0.25.1
@@ -9656,7 +9659,7 @@ snapshots:
   jscodeshift@17.3.0:
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/parser': 7.29.3
+      '@babel/parser': 7.29.7
       '@babel/plugin-transform-class-properties': 7.28.6(@babel/core@7.29.7)
       '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.7)
       '@babel/plugin-transform-nullish-coalescing-operator': 7.28.6(@babel/core@7.29.7)


### PR DESCRIPTION
## Summary

`xds template <name> --skeleton` is meant to print a compact layout outline of a template (nesting + structural components + spatial props) — it's recommended to AI agents as a "study the layout before you edit" step in 6+ docs. In practice it was built on a ~58-line regex/line-scanner with **zero tests**, and **0 of 37 page templates rendered correctly**.

This replaces the regex extractor with a real AST walk (`@babel/parser`, a normal CLI dependency) and adds a fixture-free test suite that discovers every template live.

## The 7 bug classes (all fixed)

1. **Malformed object-literal props.** `columns={{minWidth: 240}}` was emitted as `<Grid columns="{minWidth:" ...>`. (10/37 pages.)
2. **Parent wrongly self-closed → whole tree orphaned.** A self-closing child inside a slot prop (`<XDSAppShell sideNav={<SideNav />} ...>`) made the scanner treat `AppShell` as self-closing; every child then rendered flush-left and the top-level container was lost. (13/37 pages.)
3. **Unbalanced / unclosed tags.** 25/37 failed a strict JSX parse.
4. **Mid-tree truncation.** A flat 35-line cap chopped large templates mid-structure. (19/37 pages.)
5. **Header didn't match body.** The `# Components:` list came from a separate regex pass than the body, so they disagreed (e.g. `documentation-design` listed 15 components but rendered a single `<AppShell />`).
6. **Untrustworthy depth.** Indentation came from the corrupted depth stack.
7. **No tests.**

## The AST approach

`packages/cli/src/api/skeleton.mjs` parses with `@babel/parser` (jsx + typescript) and walks the JSX returned by the default export:

- **Nesting** from `children → depth`, so output is always tag-balanced.
- **Object-literal props** like `columns={{minWidth: 240, repeat: 'fit'}}` render intact.
- **Component list is collected from the nodes actually emitted**, so header and body can never disagree — even under truncation.
- **Slots are derived structurally** — any JSX-valued prop on an XDS component becomes a `/* name: */` marker. No hardcoded slot-name list, so new XDS slots (`drawer`, `composer`, `avatar`, …) work automatically.
- **Props use a noise blocklist, not an allowlist** — everything renders except known noise (`on*` handlers, `aria-*`, `key`/`ref`/`className`/`style`, `label`/`icon`/`href`, …), so a new XDS layout prop appears automatically. Complex/computed values are dropped rather than rendered as garbage.
- **Local helper components** are inlined; `{items.map(...)}` / `{cond && <X/>}` / ternary render paths are followed.
- **Truncation is depth-aware**: past the line budget it stops opening content and emits a single `...`, but every open tag is still closed.
- Unparseable source / no default-export JSX returns an empty result instead of throwing — the CLI never crashes.

## Tests

`packages/cli/src/api/__tests__/skeleton.test.mjs` — **no stored fixtures**. It discovers every page + block template live and asserts: non-empty, no malformed `="{`, parses as JSX, tag-balanced, and header components exactly equal body components. Plus focused regressions for all 7 bug classes, derived slots, blocklist props, `.map()`/ternary slots, helper inlining, and graceful empty/unparseable handling.

See the test-plan comment below for the full verification, chaos-test results (19/19 handled, 0 crashes), and sample output.

## Verification

- `npx vitest run packages/cli` → **60 files, 1232 tests pass**.
- `tsc --project tsconfig.json-api.json` passes.
- Hand-verified `dashboard`, `settings-dialog`, `ai-chat`, `login`, `table-page` against source.

The `template.skeleton` JSON contract (`{ template, description, components, skeleton }`) is unchanged — only output quality improved.

## Follow-ups (not blocking)
- Add a smoke test asserting every discovered template (including external `xds.blocks` packages) yields a non-empty skeleton.