### PR TITLE
refactor(templates): remove XDSAppShell from all page templates

### DIFF
--- a/apps/docsite/src/components/TemplatePreviewSurface.module.css
+++ b/apps/docsite/src/components/TemplatePreviewSurface.module.css
@@ -17,20 +17,8 @@
   overflow: auto;
   border-radius: var(--radius-container);
   border: var(--border-width) solid var(--color-border);
-  /* Read as a real themed app on the theme's body color. */
-  background-color: var(--color-background-body);
-}
-
-/* Host nested app-shell templates.
-
-   XDSAppShell fill mode sizes the shell to 100dvh (the viewport). Inside
-   this preview frame that would overflow the frame and create a second
-   (outer) scrollbar. Pin the shell to THIS frame's height instead so the
-   template's own content region (#xds-app-shell-main) is the single
-   scroll container, and the header + side nav stay fixed. The descendant
-   selector outweighs StyleX's single-class height:100dvh without
-   !important. */
-.frame :global(.xds-app-shell) {
-  height: 100%;
-  min-height: 0;
+  /* Templates are content-only (no XDSAppShell) and render transparent, so
+     the preview host supplies the page background. Use the surface color so
+     templates read as a real themed app surface. */
+  background-color: var(--color-background-surface);
 }

--- a/apps/docsite/src/components/TemplateThumbnail.tsx
+++ b/apps/docsite/src/components/TemplateThumbnail.tsx
@@ -25,7 +25,9 @@ const styles = stylex.create({
     overflow: 'hidden',
     position: 'relative' as const,
     borderRadius: 'var(--radius-container)',
-    backgroundColor: 'var(--color-background-muted)',
+    // Templates render transparent (content-only, no XDSAppShell), so the
+    // thumbnail host supplies the page background — use the app surface color.
+    backgroundColor: 'var(--color-background-surface)',
     contentVisibility: 'auto',
     containIntrinsicSize: 'auto 300px 187px',
   },

--- a/packages/cli/templates/pages/ai-chat-artifact/page.tsx
+++ b/packages/cli/templates/pages/ai-chat-artifact/page.tsx
@@ -6,10 +6,12 @@ import {useState} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {spacingVars, colorVars} from '@xds/core/theme/tokens.stylex';
 
-import {XDSAppShell} from '@xds/core/AppShell';
-import {XDSTopNav, XDSTopNavHeading} from '@xds/core/TopNav';
-import {XDSNavIcon} from '@xds/core/NavIcon';
-import {XDSHStack, XDSVStack} from '@xds/core/Layout';
+import {
+  XDSHStack,
+  XDSVStack,
+  XDSLayout,
+  XDSLayoutContent,
+} from '@xds/core/Layout';
 import {XDSText, XDSHeading} from '@xds/core/Text';
 import {
   XDSChatComposer,
@@ -31,13 +33,11 @@ import {XDSDropdownMenu} from '@xds/core/DropdownMenu';
 import {useXDSResizable, XDSResizeHandle} from '@xds/core/Resizable';
 
 import {
-  ChevronLeftIcon,
   DocumentTextIcon,
   ClipboardDocumentIcon,
   ShareIcon,
   AtSymbolIcon,
   PaperClipIcon,
-  CubeIcon,
 } from '@heroicons/react/24/outline';
 
 // ============= STYLES =============
@@ -131,240 +131,231 @@ export default function AIChatArtifactTemplate() {
   });
 
   return (
-    <XDSAppShell
-      variant="elevated"
-      topNav={
-        <XDSTopNav
-          label="Navigation"
-          heading={
-            <XDSHStack gap={1} vAlign="center">
-              <XDSButton
-                label="Back"
-                variant="ghost"
-                size="sm"
-                icon={<XDSIcon icon={ChevronLeftIcon} size="sm" />}
-                isIconOnly
-              />
-              <XDSTopNavHeading
-                logo={
-                  <XDSNavIcon icon={<XDSIcon icon={CubeIcon} size="sm" />} />
-                }
-                heading="My App"
-                headingHref="/"
-              />
-            </XDSHStack>
-          }
-        />
-      }>
-      <XDSHStack height="100%">
-        {/* Chat Panel */}
-        <XDSVStack height="100%" style={{width: chatResize.size}}>
-          <XDSChatLayout
-            style={{height: '100%'}}
-            composer={
-              <XDSChatComposer
-                onSubmit={() => {}}
-                placeholder={
-                  composerMode === 'ask'
-                    ? 'Ask anything...'
-                    : 'Describe your edit...'
-                }
-                input={<XDSChatComposerInput />}
-                headerActions={
-                  <>
-                    <XDSButton
-                      label="Mention"
-                      variant="ghost"
-                      size="sm"
-                      icon={<XDSIcon icon={AtSymbolIcon} size="sm" />}
-                      isIconOnly
+    <XDSLayout
+      height="fill"
+      content={
+        <XDSLayoutContent padding={0}>
+          <XDSHStack height="100%">
+            {/* Chat Panel */}
+            <XDSVStack height="100%" style={{width: chatResize.size}}>
+              <XDSChatLayout
+                style={{height: '100%'}}
+                composer={
+                  <XDSChatComposer
+                    onSubmit={() => {}}
+                    placeholder={
+                      composerMode === 'ask'
+                        ? 'Ask anything...'
+                        : 'Describe your edit...'
+                    }
+                    input={<XDSChatComposerInput />}
+                    headerActions={
+                      <>
+                        <XDSButton
+                          label="Mention"
+                          variant="ghost"
+                          size="sm"
+                          icon={<XDSIcon icon={AtSymbolIcon} size="sm" />}
+                          isIconOnly
+                        />
+                        <XDSButton
+                          label="Attach"
+                          variant="ghost"
+                          size="sm"
+                          icon={<XDSIcon icon={PaperClipIcon} size="sm" />}
+                          isIconOnly
+                        />
+                      </>
+                    }
+                    footerActions={
+                      <XDSDropdownMenu
+                        button={{
+                          label: composerMode === 'ask' ? 'Ask' : 'Edit',
+                          variant: 'ghost',
+                          size: 'sm',
+                        }}
+                        items={[
+                          {
+                            label: 'Ask',
+                            onClick: () => setComposerMode('ask'),
+                          },
+                          {
+                            label: 'Edit',
+                            onClick: () => setComposerMode('edit'),
+                          },
+                        ]}
+                      />
+                    }
+                  />
+                }>
+                <XDSChatMessageList>
+                  <XDSChatSystemMessage variant="divider">
+                    Today
+                  </XDSChatSystemMessage>
+
+                  {/* User request */}
+                  <XDSChatMessage sender="user">
+                    <XDSChatMessageBubble
+                      metadata={
+                        <XDSChatMessageMetadata
+                          timestamp={
+                            <XDSTimestamp
+                              value="2026-05-12T14:30:00"
+                              format="time"
+                            />
+                          }
+                        />
+                      }>
+                      Write me a guide about getting started with design
+                      systems. Cover the core principles, component
+                      architecture, and token systems.
+                    </XDSChatMessageBubble>
+                  </XDSChatMessage>
+
+                  {/* Assistant response */}
+                  <XDSChatMessage
+                    sender="assistant"
+                    avatar={<XDSAvatar name="AI" size="small" />}>
+                    <XDSChatMessageBubble variant="ghost" name="AI">
+                      <XDSMarkdown density="compact">
+                        {`I've created a comprehensive guide on design systems. It covers the core principles of consistency, composability, and accessibility, along with sections on component architecture and the token system.\n\nThe document is displayed in the artifact panel \u2014 you can review it there. Want me to expand any section or adjust the tone?`}
+                      </XDSMarkdown>
+                    </XDSChatMessageBubble>
+                    <XDSChatMessageMetadata
+                      timestamp={
+                        <XDSTimestamp
+                          value="2026-05-12T14:30:45"
+                          format="time"
+                        />
+                      }
                     />
-                    <XDSButton
-                      label="Attach"
-                      variant="ghost"
-                      size="sm"
-                      icon={<XDSIcon icon={PaperClipIcon} size="sm" />}
-                      isIconOnly
+                  </XDSChatMessage>
+
+                  {/* User follow-up */}
+                  <XDSChatMessage sender="user">
+                    <XDSChatMessageBubble
+                      metadata={
+                        <XDSChatMessageMetadata
+                          timestamp={
+                            <XDSTimestamp
+                              value="2026-05-12T14:32:00"
+                              format="time"
+                            />
+                          }
+                        />
+                      }>
+                      This is great. Can you add a section about next steps at
+                      the end?
+                    </XDSChatMessageBubble>
+                  </XDSChatMessage>
+
+                  {/* Assistant confirmation */}
+                  <XDSChatMessage
+                    sender="assistant"
+                    avatar={<XDSAvatar name="AI" size="small" />}>
+                    <XDSChatMessageBubble variant="ghost">
+                      <XDSMarkdown density="compact">
+                        {`Done! I've added a "Next Steps" section with actionable items for getting started. The artifact has been updated \u2014 you can see the changes in the panel.`}
+                      </XDSMarkdown>
+                    </XDSChatMessageBubble>
+                    <XDSChatMessageMetadata
+                      timestamp={
+                        <XDSTimestamp
+                          value="2026-05-12T14:32:30"
+                          format="time"
+                        />
+                      }
                     />
-                  </>
-                }
-                footerActions={
+                  </XDSChatMessage>
+                </XDSChatMessageList>
+              </XDSChatLayout>
+            </XDSVStack>
+
+            {/* Resize Handle */}
+            <XDSResizeHandle
+              direction="horizontal"
+              resizable={chatResize.props}
+              hasDivider
+              label="Resize chat panel"
+            />
+
+            {/* Artifact Panel */}
+            <XDSVStack height="100%" xstyle={styles.artifactPanel}>
+              {/* Artifact Header */}
+              <XDSHStack
+                gap={3}
+                vAlign="center"
+                hAlign="between"
+                xstyle={styles.artifactHeader}>
+                <XDSHStack gap={3} vAlign="center">
+                  <XDSIcon
+                    icon={DocumentTextIcon}
+                    size="sm"
+                    color="secondary"
+                  />
+                  <XDSVStack gap={0}>
+                    <XDSText type="label" weight="semibold">
+                      {ARTIFACT_TITLE}
+                    </XDSText>
+                    <XDSText type="supporting" color="secondary">
+                      Document \u00b7 Updated just now
+                    </XDSText>
+                  </XDSVStack>
+                </XDSHStack>
+
+                <XDSHStack gap={2} vAlign="center">
                   <XDSDropdownMenu
                     button={{
-                      label: composerMode === 'ask' ? 'Ask' : 'Edit',
+                      label: 'v2',
                       variant: 'ghost',
                       size: 'sm',
                     }}
-                    items={[
-                      {
-                        label: 'Ask',
-                        onClick: () => setComposerMode('ask'),
-                      },
-                      {
-                        label: 'Edit',
-                        onClick: () => setComposerMode('edit'),
-                      },
-                    ]}
+                    items={[{label: 'v2 (current)'}, {label: 'v1'}]}
                   />
-                }
-              />
-            }>
-            <XDSChatMessageList>
-              <XDSChatSystemMessage variant="divider">
-                Today
-              </XDSChatSystemMessage>
+                  <XDSButton
+                    label="Copy"
+                    variant="ghost"
+                    size="sm"
+                    icon={<XDSIcon icon={ClipboardDocumentIcon} size="sm" />}
+                    isIconOnly
+                  />
+                  <XDSButton
+                    label="Share"
+                    variant="ghost"
+                    size="sm"
+                    icon={<XDSIcon icon={ShareIcon} size="sm" />}
+                    isIconOnly
+                  />
+                </XDSHStack>
+              </XDSHStack>
 
-              {/* User request */}
-              <XDSChatMessage sender="user">
-                <XDSChatMessageBubble
-                  metadata={
-                    <XDSChatMessageMetadata
-                      timestamp={
-                        <XDSTimestamp
-                          value="2026-05-12T14:30:00"
-                          format="time"
-                        />
-                      }
-                    />
-                  }>
-                  Write me a guide about getting started with design systems.
-                  Cover the core principles, component architecture, and token
-                  systems.
-                </XDSChatMessageBubble>
-              </XDSChatMessage>
+              {/* Artifact Tabs */}
+              <XDSHStack vAlign="center" xstyle={styles.tabRow}>
+                <XDSTabList value={artifactTab} onChange={setArtifactTab}>
+                  <XDSTab value="document" label="Preview" />
+                  <XDSTab value="markdown" label="Markdown" />
+                </XDSTabList>
+              </XDSHStack>
 
-              {/* Assistant response */}
-              <XDSChatMessage
-                sender="assistant"
-                avatar={<XDSAvatar name="AI" size="small" />}>
-                <XDSChatMessageBubble variant="ghost" name="AI">
-                  <XDSMarkdown density="compact">
-                    {`I've created a comprehensive guide on design systems. It covers the core principles of consistency, composability, and accessibility, along with sections on component architecture and the token system.\n\nThe document is displayed in the artifact panel \u2014 you can review it there. Want me to expand any section or adjust the tone?`}
-                  </XDSMarkdown>
-                </XDSChatMessageBubble>
-                <XDSChatMessageMetadata
-                  timestamp={
-                    <XDSTimestamp value="2026-05-12T14:30:45" format="time" />
-                  }
-                />
-              </XDSChatMessage>
-
-              {/* User follow-up */}
-              <XDSChatMessage sender="user">
-                <XDSChatMessageBubble
-                  metadata={
-                    <XDSChatMessageMetadata
-                      timestamp={
-                        <XDSTimestamp
-                          value="2026-05-12T14:32:00"
-                          format="time"
-                        />
-                      }
-                    />
-                  }>
-                  This is great. Can you add a section about next steps at the
-                  end?
-                </XDSChatMessageBubble>
-              </XDSChatMessage>
-
-              {/* Assistant confirmation */}
-              <XDSChatMessage
-                sender="assistant"
-                avatar={<XDSAvatar name="AI" size="small" />}>
-                <XDSChatMessageBubble variant="ghost">
-                  <XDSMarkdown density="compact">
-                    {`Done! I've added a "Next Steps" section with actionable items for getting started. The artifact has been updated \u2014 you can see the changes in the panel.`}
-                  </XDSMarkdown>
-                </XDSChatMessageBubble>
-                <XDSChatMessageMetadata
-                  timestamp={
-                    <XDSTimestamp value="2026-05-12T14:32:30" format="time" />
-                  }
-                />
-              </XDSChatMessage>
-            </XDSChatMessageList>
-          </XDSChatLayout>
-        </XDSVStack>
-
-        {/* Resize Handle */}
-        <XDSResizeHandle
-          direction="horizontal"
-          resizable={chatResize.props}
-          hasDivider
-          label="Resize chat panel"
-        />
-
-        {/* Artifact Panel */}
-        <XDSVStack height="100%" xstyle={styles.artifactPanel}>
-          {/* Artifact Header */}
-          <XDSHStack
-            gap={3}
-            vAlign="center"
-            hAlign="between"
-            xstyle={styles.artifactHeader}>
-            <XDSHStack gap={3} vAlign="center">
-              <XDSIcon icon={DocumentTextIcon} size="sm" color="secondary" />
-              <XDSVStack gap={0}>
-                <XDSText type="label" weight="semibold">
-                  {ARTIFACT_TITLE}
-                </XDSText>
-                <XDSText type="supporting" color="secondary">
-                  Document \u00b7 Updated just now
-                </XDSText>
-              </XDSVStack>
-            </XDSHStack>
-
-            <XDSHStack gap={2} vAlign="center">
-              <XDSDropdownMenu
-                button={{
-                  label: 'v2',
-                  variant: 'ghost',
-                  size: 'sm',
-                }}
-                items={[{label: 'v2 (current)'}, {label: 'v1'}]}
-              />
-              <XDSButton
-                label="Copy"
-                variant="ghost"
-                size="sm"
-                icon={<XDSIcon icon={ClipboardDocumentIcon} size="sm" />}
-                isIconOnly
-              />
-              <XDSButton
-                label="Share"
-                variant="ghost"
-                size="sm"
-                icon={<XDSIcon icon={ShareIcon} size="sm" />}
-                isIconOnly
-              />
-            </XDSHStack>
-          </XDSHStack>
-
-          {/* Artifact Tabs */}
-          <XDSHStack vAlign="center" xstyle={styles.tabRow}>
-            <XDSTabList value={artifactTab} onChange={setArtifactTab}>
-              <XDSTab value="document" label="Preview" />
-              <XDSTab value="markdown" label="Markdown" />
-            </XDSTabList>
-          </XDSHStack>
-
-          {/* Artifact Body */}
-          <div {...stylex.props(styles.artifactContent)}>
-            <XDSVStack gap={2} xstyle={styles.articleBody}>
-              {artifactTab === 'document' ? (
-                <>
-                  <XDSHeading level={1}>{ARTIFACT_TITLE}</XDSHeading>
-                  <XDSMarkdown>{ARTIFACT_CONTENT}</XDSMarkdown>
-                </>
-              ) : (
-                <XDSText type="code">
-                  {`# ${ARTIFACT_TITLE}\n${ARTIFACT_CONTENT}`}
-                </XDSText>
-              )}
+              {/* Artifact Body */}
+              <div {...stylex.props(styles.artifactContent)}>
+                <XDSVStack gap={2} xstyle={styles.articleBody}>
+                  {artifactTab === 'document' ? (
+                    <>
+                      <XDSHeading level={1}>{ARTIFACT_TITLE}</XDSHeading>
+                      <XDSMarkdown>{ARTIFACT_CONTENT}</XDSMarkdown>
+                    </>
+                  ) : (
+                    <XDSText type="code">
+                      {`# ${ARTIFACT_TITLE}\n${ARTIFACT_CONTENT}`}
+                    </XDSText>
+                  )}
+                </XDSVStack>
+              </div>
             </XDSVStack>
-          </div>
-        </XDSVStack>
-      </XDSHStack>
-    </XDSAppShell>
+          </XDSHStack>
+        </XDSLayoutContent>
+      }
+    />
   );
 }

--- a/packages/cli/templates/pages/ai-chat-landing/page.tsx
+++ b/packages/cli/templates/pages/ai-chat-landing/page.tsx
@@ -4,15 +4,6 @@
 
 import {useCallback, useRef, useState} from 'react';
 
-import {XDSAppShell} from '@xds/core/AppShell';
-import {
-  XDSSideNav,
-  XDSSideNavHeading,
-  XDSSideNavItem,
-  XDSSideNavSection,
-} from '@xds/core/SideNav';
-import {XDSNavIcon} from '@xds/core/NavIcon';
-import {XDSBadge} from '@xds/core/Badge';
 import {
   XDSLayout,
   XDSLayoutContent,
@@ -51,10 +42,6 @@ import {XDSIcon} from '@xds/core/Icon';
 
 import {XDSDropdownMenu, XDSDropdownMenuItem} from '@xds/core/DropdownMenu';
 import {
-  ChatBubbleOvalLeftIcon,
-  FolderIcon,
-  DocumentTextIcon,
-  CubeIcon,
   Cog6ToothIcon,
   AtSymbolIcon,
   SparklesIcon,
@@ -66,10 +53,6 @@ import {
   PaperClipIcon,
   LightBulbIcon,
 } from '@heroicons/react/24/outline';
-import {
-  ChatBubbleOvalLeftIcon as ChatBubbleOvalLeftIconSolid,
-  FolderIcon as FolderIconSolid,
-} from '@heroicons/react/24/solid';
 
 const TOKEN_MODES: Record<string, string> = {
   sensitive: '/sensitive',
@@ -284,46 +267,6 @@ const SIMULATED_RESPONSE =
   'Thanks for your message! I’m looking into this now.\n\nHere’s what I found so far:\n\n1. **First**, I reviewed the relevant context from the attached files\n2. **Next**, I cross-referenced with the latest documentation\n3. **Finally**, I have a few recommendations\n\nLet me know if you’d like me to dive deeper into any of these areas, or if you have follow-up questions.';
 
 // ============= SIDENAV =============
-
-function AIChatSideNav() {
-  const [active, setActive] = useState('ai-chat');
-  return (
-    <XDSSideNav
-      header={
-        <XDSSideNavHeading
-          icon={<XDSNavIcon icon={<XDSIcon icon={CubeIcon} size="sm" />} />}
-          heading="My App"
-          headingHref="/"
-        />
-      }>
-      <XDSSideNavSection title="Main">
-        <XDSSideNavItem
-          label="AI Chat"
-          icon={ChatBubbleOvalLeftIcon}
-          selectedIcon={ChatBubbleOvalLeftIconSolid}
-          isSelected={active === 'ai-chat'}
-          onClick={() => setActive('ai-chat')}
-        />
-        <XDSSideNavItem
-          label="Projects"
-          icon={FolderIcon}
-          selectedIcon={FolderIconSolid}
-          isSelected={active === 'projects'}
-          onClick={() => setActive('projects')}
-          endContent={<XDSBadge label="3" />}
-        />
-      </XDSSideNavSection>
-      <XDSSideNavSection title="Documents">
-        <XDSSideNavItem
-          label="All Documents"
-          icon={DocumentTextIcon}
-          isSelected={active === 'documents'}
-          onClick={() => setActive('documents')}
-        />
-      </XDSSideNavSection>
-    </XDSSideNav>
-  );
-}
 
 // ============= MAIN COMPONENT =============
 
@@ -608,64 +551,71 @@ export default function AIChatTemplate() {
 
   if (view === 'chat') {
     return (
-      <XDSAppShell sideNav={<AIChatSideNav />} variant="elevated">
-        <XDSChatLayout
-          style={{height: '100%'}}
-          composer={
-            <>
-              {fileInput}
-              {renderComposer({inputMinHeight: '44px'})}
-            </>
-          }>
-          <XDSChatMessageList>
-            {messages.map(msg => {
-              if (msg.role === 'system') {
-                return (
-                  <XDSChatSystemMessage key={msg.id} variant="divider">
-                    {msg.text}
-                  </XDSChatSystemMessage>
-                );
-              }
-              if (msg.role === 'user') {
-                return (
-                  <XDSChatMessage key={msg.id} sender="user">
-                    {msg.attachments && msg.attachments.length > 0 && (
-                      <XDSHStack gap={1} style={{flexWrap: 'wrap'}}>
-                        {msg.attachments.map(f => (
-                          <XDSToken key={f} label={f} />
-                        ))}
-                      </XDSHStack>
-                    )}
-                    <XDSChatMessageBubble
-                      metadata={
+      <XDSLayout
+        height="fill"
+        content={
+          <XDSLayoutContent padding={0}>
+            <XDSChatLayout
+              style={{height: '100%'}}
+              composer={
+                <>
+                  {fileInput}
+                  {renderComposer({inputMinHeight: '44px'})}
+                </>
+              }>
+              <XDSChatMessageList>
+                {messages.map(msg => {
+                  if (msg.role === 'system') {
+                    return (
+                      <XDSChatSystemMessage key={msg.id} variant="divider">
+                        {msg.text}
+                      </XDSChatSystemMessage>
+                    );
+                  }
+                  if (msg.role === 'user') {
+                    return (
+                      <XDSChatMessage key={msg.id} sender="user">
+                        {msg.attachments && msg.attachments.length > 0 && (
+                          <XDSHStack gap={1} style={{flexWrap: 'wrap'}}>
+                            {msg.attachments.map(f => (
+                              <XDSToken key={f} label={f} />
+                            ))}
+                          </XDSHStack>
+                        )}
+                        <XDSChatMessageBubble
+                          metadata={
+                            <XDSChatMessageMetadata
+                              timestamp={
+                                <XDSTimestamp
+                                  value={msg.sentAt.getTime()}
+                                  format="time"
+                                />
+                              }
+                            />
+                          }>
+                          {msg.text}
+                        </XDSChatMessageBubble>
+                      </XDSChatMessage>
+                    );
+                  }
+                  return (
+                    <XDSChatMessage key={msg.id} sender="assistant">
+                      <XDSMarkdown density="compact">{msg.text}</XDSMarkdown>
+                      {!msg.isStreaming && msg.text && (
                         <XDSChatMessageMetadata
                           timestamp={
-                            <XDSTimestamp
-                              value={msg.sentAt.getTime()}
-                              format="time"
-                            />
+                            <XDSTimestamp value={msg.id} format="time" />
                           }
                         />
-                      }>
-                      {msg.text}
-                    </XDSChatMessageBubble>
-                  </XDSChatMessage>
-                );
-              }
-              return (
-                <XDSChatMessage key={msg.id} sender="assistant">
-                  <XDSMarkdown density="compact">{msg.text}</XDSMarkdown>
-                  {!msg.isStreaming && msg.text && (
-                    <XDSChatMessageMetadata
-                      timestamp={<XDSTimestamp value={msg.id} format="time" />}
-                    />
-                  )}
-                </XDSChatMessage>
-              );
-            })}
-          </XDSChatMessageList>
-        </XDSChatLayout>
-      </XDSAppShell>
+                      )}
+                    </XDSChatMessage>
+                  );
+                })}
+              </XDSChatMessageList>
+            </XDSChatLayout>
+          </XDSLayoutContent>
+        }
+      />
     );
   }
 
@@ -674,105 +624,102 @@ export default function AIChatTemplate() {
   // ---------------------------------------------------------------------------
 
   return (
-    <XDSAppShell sideNav={<AIChatSideNav />} variant="elevated">
-      <XDSLayout
-        contentWidth={720}
-        padding={6}
-        content={
-          <XDSLayoutContent>
-            <XDSVStack gap={8} vAlign="center" style={{minHeight: '100%'}}>
-              {/* Greeting */}
-              <XDSVStack gap={1}>
-                <XDSHStack gap={2} vAlign="center">
-                  <XDSIcon icon={SparklesIcon} size="md" color="accent" />
-                  <XDSText type="large" as="h2">
-                    Hi, Andrew
-                  </XDSText>
-                </XDSHStack>
-                <XDSText type="display-2" as="h1">
-                  Where should we start?
+    <XDSLayout
+      height="fill"
+      contentWidth={720}
+      padding={6}
+      content={
+        <XDSLayoutContent>
+          <XDSVStack gap={8} vAlign="center" style={{minHeight: '100%'}}>
+            {/* Greeting */}
+            <XDSVStack gap={1}>
+              <XDSHStack gap={2} vAlign="center">
+                <XDSIcon icon={SparklesIcon} size="md" color="accent" />
+                <XDSText type="large" as="h2">
+                  Hi, Andrew
                 </XDSText>
-              </XDSVStack>
+              </XDSHStack>
+              <XDSText type="display-2" as="h1">
+                Where should we start?
+              </XDSText>
+            </XDSVStack>
 
-              {/* Composer */}
-              {fileInput}
-              {renderComposer({
-                inputMinHeight: '84px',
-                extraFooterActions: (
-                  <XDSDropdownMenu
-                    button={{
-                      label: 'Settings',
-                      variant: 'ghost',
-                      size: 'md',
-                      icon: <XDSIcon icon={Cog6ToothIcon} size="sm" />,
-                      children: 'Settings',
-                    }}
-                    menuWidth={200}
-                    items={[
-                      {label: 'Preferences', onClick: () => {}},
-                      {label: 'Keyboard shortcuts', onClick: () => {}},
-                      {label: 'About', onClick: () => {}},
-                    ]}
+            {/* Composer */}
+            {fileInput}
+            {renderComposer({
+              inputMinHeight: '84px',
+              extraFooterActions: (
+                <XDSDropdownMenu
+                  button={{
+                    label: 'Settings',
+                    variant: 'ghost',
+                    size: 'md',
+                    icon: <XDSIcon icon={Cog6ToothIcon} size="sm" />,
+                    children: 'Settings',
+                  }}
+                  menuWidth={200}
+                  items={[
+                    {label: 'Preferences', onClick: () => {}},
+                    {label: 'Keyboard shortcuts', onClick: () => {}},
+                    {label: 'About', onClick: () => {}},
+                  ]}
+                />
+              ),
+            })}
+
+            {/* Category toggle buttons */}
+            <XDSVStack gap={6} style={{paddingInline: 'var(--spacing-3)'}}>
+              <XDSToggleButtonGroup
+                label="Category"
+                value={category}
+                onChange={setCategory}
+                size="lg">
+                {CATEGORIES.map(cat => (
+                  <XDSToggleButton
+                    key={cat.key}
+                    value={cat.key}
+                    label={cat.label}
+                    icon={<XDSIcon icon={cat.icon} size="sm" />}
                   />
-                ),
-              })}
+                ))}
+              </XDSToggleButtonGroup>
 
-              {/* Category toggle buttons */}
-              <XDSVStack gap={6} style={{paddingInline: 'var(--spacing-3)'}}>
-                <XDSToggleButtonGroup
-                  label="Category"
-                  value={category}
-                  onChange={setCategory}
-                  size="lg">
-                  {CATEGORIES.map(cat => (
-                    <XDSToggleButton
-                      key={cat.key}
-                      value={cat.key}
-                      label={cat.label}
-                      icon={<XDSIcon icon={cat.icon} size="sm" />}
-                    />
-                  ))}
-                </XDSToggleButtonGroup>
-
-                {/* Suggestion cards */}
-                {suggestions && (
-                  <XDSGrid columns={{minWidth: 280}} gap={3}>
-                    {suggestions.map(suggestion => (
-                      <XDSCard
-                        variant="muted"
-                        key={suggestion.heading}
-                        padding={3}
-                        style={{cursor: 'pointer'}}
-                        role="button"
-                        tabIndex={0}
-                        onClick={() => {
+              {/* Suggestion cards */}
+              {suggestions && (
+                <XDSGrid columns={{minWidth: 280}} gap={3}>
+                  {suggestions.map(suggestion => (
+                    <XDSCard
+                      variant="muted"
+                      key={suggestion.heading}
+                      padding={3}
+                      style={{cursor: 'pointer'}}
+                      role="button"
+                      tabIndex={0}
+                      onClick={() => {
+                        replaceWithSuggestion(suggestion.prompt);
+                        setMode(category);
+                      }}
+                      onKeyDown={(e: React.KeyboardEvent) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          e.preventDefault();
                           replaceWithSuggestion(suggestion.prompt);
                           setMode(category);
-                        }}
-                        onKeyDown={(e: React.KeyboardEvent) => {
-                          if (e.key === 'Enter' || e.key === ' ') {
-                            e.preventDefault();
-                            replaceWithSuggestion(suggestion.prompt);
-                            setMode(category);
-                          }
-                        }}>
-                        <XDSVStack gap={0.5}>
-                          <XDSHeading level={4}>
-                            {suggestion.heading}
-                          </XDSHeading>
-                          <XDSText type="body" color="secondary" size="xsm">
-                            {suggestion.body}
-                          </XDSText>
-                        </XDSVStack>
-                      </XDSCard>
-                    ))}
-                  </XDSGrid>
-                )}
-              </XDSVStack>
+                        }
+                      }}>
+                      <XDSVStack gap={0.5}>
+                        <XDSHeading level={4}>{suggestion.heading}</XDSHeading>
+                        <XDSText type="body" color="secondary" size="xsm">
+                          {suggestion.body}
+                        </XDSText>
+                      </XDSVStack>
+                    </XDSCard>
+                  ))}
+                </XDSGrid>
+              )}
             </XDSVStack>
-          </XDSLayoutContent>
-        }
-      />
-    </XDSAppShell>
+          </XDSVStack>
+        </XDSLayoutContent>
+      }
+    />
   );
 }

--- a/packages/cli/templates/pages/ai-chat/page.tsx
+++ b/packages/cli/templates/pages/ai-chat/page.tsx
@@ -2,18 +2,7 @@
 
 'use client';
 
-import {useState} from 'react';
-
-import {XDSAppShell} from '@xds/core/AppShell';
-import {
-  XDSSideNav,
-  XDSSideNavHeading,
-  XDSSideNavItem,
-  XDSSideNavSection,
-} from '@xds/core/SideNav';
-import {XDSNavIcon} from '@xds/core/NavIcon';
-import {XDSBadge} from '@xds/core/Badge';
-import {XDSHStack} from '@xds/core/Layout';
+import {XDSHStack, XDSLayout, XDSLayoutContent} from '@xds/core/Layout';
 import {XDSText} from '@xds/core/Text';
 import {
   XDSChatComposer,
@@ -35,18 +24,7 @@ import {XDSToken} from '@xds/core/Token';
 import {XDSButton} from '@xds/core/Button';
 import {XDSIcon} from '@xds/core/Icon';
 
-import {
-  ChatBubbleOvalLeftIcon,
-  FolderIcon,
-  DocumentTextIcon,
-  CubeIcon,
-  AtSymbolIcon,
-  PaperClipIcon,
-} from '@heroicons/react/24/outline';
-import {
-  ChatBubbleOvalLeftIcon as ChatBubbleOvalLeftIconSolid,
-  FolderIcon as FolderIconSolid,
-} from '@heroicons/react/24/solid';
+import {AtSymbolIcon, PaperClipIcon} from '@heroicons/react/24/outline';
 
 // ============= TOKENS =============
 
@@ -56,140 +34,108 @@ const MENTION_TOKENS = [
 
 // ============= SIDENAV =============
 
-function AIChatSideNav() {
-  const [active, setActive] = useState('ai-chat');
-  return (
-    <XDSSideNav
-      header={
-        <XDSSideNavHeading
-          icon={<XDSNavIcon icon={<XDSIcon icon={CubeIcon} size="sm" />} />}
-          heading="My App"
-          headingHref="/"
-        />
-      }>
-      <XDSSideNavSection title="Main">
-        <XDSSideNavItem
-          label="AI Chat"
-          icon={ChatBubbleOvalLeftIcon}
-          selectedIcon={ChatBubbleOvalLeftIconSolid}
-          isSelected={active === 'ai-chat'}
-          onClick={() => setActive('ai-chat')}
-        />
-        <XDSSideNavItem
-          label="Projects"
-          icon={FolderIcon}
-          selectedIcon={FolderIconSolid}
-          isSelected={active === 'projects'}
-          onClick={() => setActive('projects')}
-          endContent={<XDSBadge label="3" />}
-        />
-      </XDSSideNavSection>
-      <XDSSideNavSection title="Documents">
-        <XDSSideNavItem
-          label="All Documents"
-          icon={DocumentTextIcon}
-          isSelected={active === 'documents'}
-          onClick={() => setActive('documents')}
-        />
-      </XDSSideNavSection>
-    </XDSSideNav>
-  );
-}
-
 // ============= MAIN COMPONENT =============
 
 export default function AIChatConversationTemplate() {
   return (
-    <XDSAppShell sideNav={<AIChatSideNav />} variant="elevated">
-      <XDSChatLayout
-        style={{height: '100%'}}
-        composer={
-          <XDSChatComposer
-            onSubmit={() => {}}
-            placeholder="Ask anything"
-            input={<XDSChatComposerInput />}
-            headerActions={
-              <>
-                <XDSButton
-                  label="Mention"
-                  variant="ghost"
-                  size="sm"
-                  icon={<XDSIcon icon={AtSymbolIcon} size="sm" />}
-                  isIconOnly
-                />
-                <XDSButton
-                  label="Attach"
-                  variant="ghost"
-                  size="sm"
-                  icon={<XDSIcon icon={PaperClipIcon} size="sm" />}
-                  isIconOnly
-                />
-              </>
-            }
-          />
-        }>
-        <XDSChatMessageList>
-          {/* ── System message: date divider ── */}
-          <XDSChatSystemMessage variant="divider">Today</XDSChatSystemMessage>
+    <XDSLayout
+      height="fill"
+      content={
+        <XDSLayoutContent padding={0}>
+          <XDSChatLayout
+            style={{height: '100%'}}
+            composer={
+              <XDSChatComposer
+                onSubmit={() => {}}
+                placeholder="Ask anything"
+                input={<XDSChatComposerInput />}
+                headerActions={
+                  <>
+                    <XDSButton
+                      label="Mention"
+                      variant="ghost"
+                      size="sm"
+                      icon={<XDSIcon icon={AtSymbolIcon} size="sm" />}
+                      isIconOnly
+                    />
+                    <XDSButton
+                      label="Attach"
+                      variant="ghost"
+                      size="sm"
+                      icon={<XDSIcon icon={PaperClipIcon} size="sm" />}
+                      isIconOnly
+                    />
+                  </>
+                }
+              />
+            }>
+            <XDSChatMessageList>
+              {/* ── System message: date divider ── */}
+              <XDSChatSystemMessage variant="divider">
+                Today
+              </XDSChatSystemMessage>
 
-          {/* ── User message with tokenized mention and file attachments ── */}
-          <XDSChatMessage sender="user">
-            <XDSHStack gap={1} wrap="wrap">
-              <XDSToken label="auth-service.ts" />
-              <XDSToken label="middleware.ts" />
-            </XDSHStack>
-            <XDSChatMessageBubble
-              metadata={
-                <XDSChatMessageMetadata
-                  timestamp={
-                    <XDSTimestamp value="2026-04-29T10:15:00" format="time" />
-                  }
+              {/* ── User message with tokenized mention and file attachments ── */}
+              <XDSChatMessage sender="user">
+                <XDSHStack gap={1} wrap="wrap">
+                  <XDSToken label="auth-service.ts" />
+                  <XDSToken label="middleware.ts" />
+                </XDSHStack>
+                <XDSChatMessageBubble
+                  metadata={
+                    <XDSChatMessageMetadata
+                      timestamp={
+                        <XDSTimestamp
+                          value="2026-04-29T10:15:00"
+                          format="time"
+                        />
+                      }
+                    />
+                  }>
+                  <XDSChatTokenizedText tokens={MENTION_TOKENS}>
+                    @agent Can you review these auth files? The JWT refresh
+                    logic seems broken — tokens expire but the middleware
+                    doesn't catch it.
+                  </XDSChatTokenizedText>
+                </XDSChatMessageBubble>
+              </XDSChatMessage>
+
+              {/* ── Assistant message with tool calls ── */}
+              <XDSChatMessage
+                sender="assistant"
+                avatar={<XDSAvatar name="Agent" size="small" />}>
+                <XDSChatMessageBubble variant="ghost" name="Agent">
+                  Looking into the auth files now. Let me read through the code
+                  and trace the token refresh flow.
+                </XDSChatMessageBubble>
+                <XDSChatToolCalls
+                  defaultIsExpanded
+                  calls={[
+                    {
+                      name: 'read',
+                      target: 'auth-service.ts',
+                      status: 'complete',
+                      duration: '45ms',
+                    },
+                    {
+                      name: 'read',
+                      target: 'middleware.ts',
+                      status: 'complete',
+                      duration: '38ms',
+                    },
+                    {
+                      name: 'bash',
+                      target: 'grep -rn "refreshToken" src/',
+                      status: 'complete',
+                      duration: '120ms',
+                      node: 'cli:remote-server',
+                    },
+                  ]}
                 />
-              }>
-              <XDSChatTokenizedText tokens={MENTION_TOKENS}>
-                @agent Can you review these auth files? The JWT refresh logic
-                seems broken — tokens expire but the middleware doesn't catch
-                it.
-              </XDSChatTokenizedText>
-            </XDSChatMessageBubble>
-          </XDSChatMessage>
 
-          {/* ── Assistant message with tool calls ── */}
-          <XDSChatMessage
-            sender="assistant"
-            avatar={<XDSAvatar name="Agent" size="small" />}>
-            <XDSChatMessageBubble variant="ghost" name="Agent">
-              Looking into the auth files now. Let me read through the code and
-              trace the token refresh flow.
-            </XDSChatMessageBubble>
-            <XDSChatToolCalls
-              defaultIsExpanded
-              calls={[
-                {
-                  name: 'read',
-                  target: 'auth-service.ts',
-                  status: 'complete',
-                  duration: '45ms',
-                },
-                {
-                  name: 'read',
-                  target: 'middleware.ts',
-                  status: 'complete',
-                  duration: '38ms',
-                },
-                {
-                  name: 'bash',
-                  target: 'grep -rn "refreshToken" src/',
-                  status: 'complete',
-                  duration: '120ms',
-                  node: 'cli:remote-server',
-                },
-              ]}
-            />
-
-            {/* Markdown response with analysis */}
-            <XDSChatMessageBubble variant="ghost">
-              <XDSMarkdown density="compact">{`Found the issue. In \`middleware.ts\`, the token validation runs **before** the refresh check. When a token expires, the middleware rejects the request immediately instead of attempting a refresh.
+                {/* Markdown response with analysis */}
+                <XDSChatMessageBubble variant="ghost">
+                  <XDSMarkdown density="compact">{`Found the issue. In \`middleware.ts\`, the token validation runs **before** the refresh check. When a token expires, the middleware rejects the request immediately instead of attempting a refresh.
 
 Here's the problematic sequence:
 
@@ -198,14 +144,14 @@ Here's the problematic sequence:
 3. The catch block returns \`401\` — never reaching \`refreshToken()\`
 
 The fix is to catch \`TokenExpiredError\` specifically and attempt a refresh before rejecting:`}</XDSMarkdown>
-            </XDSChatMessageBubble>
+                </XDSChatMessageBubble>
 
-            {/* Code block with the fix */}
-            <XDSChatMessageBubble variant="ghost">
-              <XDSCodeBlock
-                title="middleware.ts"
-                language="typescript"
-                code={`async function authMiddleware(req: Request) {
+                {/* Code block with the fix */}
+                <XDSChatMessageBubble variant="ghost">
+                  <XDSCodeBlock
+                    title="middleware.ts"
+                    language="typescript"
+                    code={`async function authMiddleware(req: Request) {
   try {
     const decoded = validateToken(req.headers.authorization);
     req.user = decoded;
@@ -223,85 +169,88 @@ The fix is to catch \`TokenExpiredError\` specifically and attempt a refresh bef
   }
   return next(req);
 }`}
-              />
-            </XDSChatMessageBubble>
+                  />
+                </XDSChatMessageBubble>
 
-            <XDSChatToolCalls
-              calls={[
-                {
-                  name: 'edit',
-                  target: 'middleware.ts',
-                  status: 'complete',
-                  duration: '85ms',
-                  additions: 8,
-                  deletions: 2,
-                },
-              ]}
-            />
+                <XDSChatToolCalls
+                  calls={[
+                    {
+                      name: 'edit',
+                      target: 'middleware.ts',
+                      status: 'complete',
+                      duration: '85ms',
+                      additions: 8,
+                      deletions: 2,
+                    },
+                  ]}
+                />
 
-            <XDSChatMessageMetadata
-              timestamp={
-                <XDSTimestamp value="2026-04-29T10:15:30" format="time" />
-              }
-              footer={
-                <XDSText type="supporting" color="secondary">
-                  Agent
-                </XDSText>
-              }
-            />
-          </XDSChatMessage>
-
-          {/* ── User multi-bubble follow-up ── */}
-          <XDSChatMessage sender="user">
-            <XDSChatMessageBubble group="first">
-              Nice catch, that makes sense
-            </XDSChatMessageBubble>
-            <XDSChatMessageBubble
-              group="last"
-              metadata={
                 <XDSChatMessageMetadata
                   timestamp={
-                    <XDSTimestamp value="2026-04-29T10:16:00" format="time" />
+                    <XDSTimestamp value="2026-04-29T10:15:30" format="time" />
                   }
-                  status="delivered"
+                  footer={
+                    <XDSText type="supporting" color="secondary">
+                      Agent
+                    </XDSText>
+                  }
                 />
-              }>
-              Can you also add a test for the refresh path?
-            </XDSChatMessageBubble>
-          </XDSChatMessage>
+              </XDSChatMessage>
 
-          {/* ── Assistant response with test code ── */}
-          <XDSChatMessage
-            sender="assistant"
-            avatar={<XDSAvatar name="Agent" size="small" />}>
-            <XDSChatToolCalls
-              defaultIsExpanded
-              calls={[
-                {
-                  name: 'read',
-                  target: 'middleware.test.ts',
-                  status: 'complete',
-                  duration: '32ms',
-                },
-                {
-                  name: 'edit',
-                  target: 'middleware.test.ts',
-                  status: 'complete',
-                  duration: '110ms',
-                  additions: 24,
-                  deletions: 0,
-                },
-                {
-                  name: 'bash',
-                  target: 'yarn test middleware',
-                  status: 'complete',
-                  duration: '3.2s',
-                  node: 'cli:remote-server',
-                },
-              ]}
-            />
-            <XDSChatMessageBubble variant="ghost">
-              <XDSMarkdown density="compact">{`Added a test for the refresh flow. All **4 tests** pass:
+              {/* ── User multi-bubble follow-up ── */}
+              <XDSChatMessage sender="user">
+                <XDSChatMessageBubble group="first">
+                  Nice catch, that makes sense
+                </XDSChatMessageBubble>
+                <XDSChatMessageBubble
+                  group="last"
+                  metadata={
+                    <XDSChatMessageMetadata
+                      timestamp={
+                        <XDSTimestamp
+                          value="2026-04-29T10:16:00"
+                          format="time"
+                        />
+                      }
+                      status="delivered"
+                    />
+                  }>
+                  Can you also add a test for the refresh path?
+                </XDSChatMessageBubble>
+              </XDSChatMessage>
+
+              {/* ── Assistant response with test code ── */}
+              <XDSChatMessage
+                sender="assistant"
+                avatar={<XDSAvatar name="Agent" size="small" />}>
+                <XDSChatToolCalls
+                  defaultIsExpanded
+                  calls={[
+                    {
+                      name: 'read',
+                      target: 'middleware.test.ts',
+                      status: 'complete',
+                      duration: '32ms',
+                    },
+                    {
+                      name: 'edit',
+                      target: 'middleware.test.ts',
+                      status: 'complete',
+                      duration: '110ms',
+                      additions: 24,
+                      deletions: 0,
+                    },
+                    {
+                      name: 'bash',
+                      target: 'yarn test middleware',
+                      status: 'complete',
+                      duration: '3.2s',
+                      node: 'cli:remote-server',
+                    },
+                  ]}
+                />
+                <XDSChatMessageBubble variant="ghost">
+                  <XDSMarkdown density="compact">{`Added a test for the refresh flow. All **4 tests** pass:
 
 | Test | Status |
 |------|--------|
@@ -309,13 +258,13 @@ The fix is to catch \`TokenExpiredError\` specifically and attempt a refresh bef
 | Expired token triggers refresh | ✅ |
 | Expired token with invalid refresh returns 401 | ✅ |
 | Malformed token returns 401 immediately | ✅ |`}</XDSMarkdown>
-            </XDSChatMessageBubble>
+                </XDSChatMessageBubble>
 
-            <XDSChatMessageBubble variant="ghost">
-              <XDSCodeBlock
-                title="middleware.test.ts"
-                language="typescript"
-                code={`describe('authMiddleware', () => {
+                <XDSChatMessageBubble variant="ghost">
+                  <XDSCodeBlock
+                    title="middleware.test.ts"
+                    language="typescript"
+                    code={`describe('authMiddleware', () => {
   it('refreshes an expired token silently', async () => {
     const expiredToken = createExpiredJWT(mockUser);
     const validRefresh = createRefreshToken(mockUser);
@@ -332,61 +281,66 @@ The fix is to catch \`TokenExpiredError\` specifically and attempt a refresh bef
     expect(req.newAccessToken).toBeDefined();
   });
 });`}
-              />
-            </XDSChatMessageBubble>
-            <XDSChatMessageMetadata
-              timestamp={
-                <XDSTimestamp value="2026-04-29T10:16:45" format="time" />
-              }
-            />
-          </XDSChatMessage>
-
-          {/* ── System message: status ── */}
-          <XDSChatSystemMessage>
-            Changes saved to workspace
-          </XDSChatSystemMessage>
-
-          {/* ── User follow-up ── */}
-          <XDSChatMessage sender="user">
-            <XDSChatMessageBubble
-              metadata={
+                  />
+                </XDSChatMessageBubble>
                 <XDSChatMessageMetadata
                   timestamp={
-                    <XDSTimestamp value="2026-04-29T10:17:00" format="time" />
+                    <XDSTimestamp value="2026-04-29T10:16:45" format="time" />
                   }
                 />
-              }>
-              Perfect. Ship it — create a PR with these changes.
-            </XDSChatMessageBubble>
-          </XDSChatMessage>
+              </XDSChatMessage>
 
-          {/* ── Assistant with running tool call ── */}
-          <XDSChatMessage
-            sender="assistant"
-            avatar={<XDSAvatar name="Agent" size="small" />}>
-            <XDSChatMessageBubble variant="ghost">
-              On it — pushing the branch and opening a PR now.
-            </XDSChatMessageBubble>
-            <XDSChatToolCalls
-              calls={[
-                {
-                  name: 'bash',
-                  target: 'git push -u origin fix/jwt-refresh',
-                  status: 'complete',
-                  duration: '1.8s',
-                  node: 'cli:remote-server',
-                },
-                {
-                  name: 'bash',
-                  target: 'gh pr create --title "fix: handle expired JWT…"',
-                  status: 'running',
-                  node: 'cli:remote-server',
-                },
-              ]}
-            />
-          </XDSChatMessage>
-        </XDSChatMessageList>
-      </XDSChatLayout>
-    </XDSAppShell>
+              {/* ── System message: status ── */}
+              <XDSChatSystemMessage>
+                Changes saved to workspace
+              </XDSChatSystemMessage>
+
+              {/* ── User follow-up ── */}
+              <XDSChatMessage sender="user">
+                <XDSChatMessageBubble
+                  metadata={
+                    <XDSChatMessageMetadata
+                      timestamp={
+                        <XDSTimestamp
+                          value="2026-04-29T10:17:00"
+                          format="time"
+                        />
+                      }
+                    />
+                  }>
+                  Perfect. Ship it — create a PR with these changes.
+                </XDSChatMessageBubble>
+              </XDSChatMessage>
+
+              {/* ── Assistant with running tool call ── */}
+              <XDSChatMessage
+                sender="assistant"
+                avatar={<XDSAvatar name="Agent" size="small" />}>
+                <XDSChatMessageBubble variant="ghost">
+                  On it — pushing the branch and opening a PR now.
+                </XDSChatMessageBubble>
+                <XDSChatToolCalls
+                  calls={[
+                    {
+                      name: 'bash',
+                      target: 'git push -u origin fix/jwt-refresh',
+                      status: 'complete',
+                      duration: '1.8s',
+                      node: 'cli:remote-server',
+                    },
+                    {
+                      name: 'bash',
+                      target: 'gh pr create --title "fix: handle expired JWT…"',
+                      status: 'running',
+                      node: 'cli:remote-server',
+                    },
+                  ]}
+                />
+              </XDSChatMessage>
+            </XDSChatMessageList>
+          </XDSChatLayout>
+        </XDSLayoutContent>
+      }
+    />
   );
 }

--- a/packages/cli/templates/pages/centered-hero/page.tsx
+++ b/packages/cli/templates/pages/centered-hero/page.tsx
@@ -3,12 +3,15 @@
 'use client';
 
 import * as stylex from '@stylexjs/stylex';
-import {XDSVStack, XDSHStack} from '@xds/core/Layout';
+import {
+  XDSVStack,
+  XDSHStack,
+  XDSLayout,
+  XDSLayoutContent,
+} from '@xds/core/Layout';
 import {XDSText} from '@xds/core/Text';
 import {XDSButton} from '@xds/core/Button';
 import {XDSIcon} from '@xds/core/Icon';
-import {XDSAppShell} from '@xds/core/AppShell';
-import {XDSTopNav, XDSTopNavHeading, XDSTopNavItem} from '@xds/core/TopNav';
 import {ArrowRightIcon} from '@heroicons/react/20/solid';
 
 // light-scene-horizontal-1 from xds_oss asset set
@@ -40,60 +43,48 @@ const styles = stylex.create({
 
 export default function CenteredHero() {
   return (
-    <XDSAppShell
-      variant="surface"
-      topNav={
-        <XDSTopNav
-          label="Main navigation"
-          heading={<XDSTopNavHeading heading="OCEAN" />}
-          endContent={
-            <>
-              <XDSTopNavItem label="Products" href="#" />
-              <XDSTopNavItem label="Solutions" href="#" />
-              <XDSTopNavItem label="Pricing" href="#" />
-              <XDSTopNavItem label="About" href="#" />
-            </>
-          }
-        />
-      }
-      contentPadding={0}>
-      <XDSVStack gap={10}>
-        <XDSVStack gap={6} hAlign="center" xstyle={styles.topSpacing}>
-          <XDSVStack gap={3} hAlign="center">
-            <XDSText
-              type="display-2"
-              as="h1"
-              weight="bold"
-              textWrap="balance"
-              xstyle={[styles.textCenter, styles.titleResponsive]}>
-              Little joys, everywhere you go
-            </XDSText>
-            <XDSText
-              type="body"
-              color="secondary"
-              textWrap="balance"
-              xstyle={styles.textCenter}>
-              Sometimes all it takes is one small thing to turn your whole day
-              around.
-            </XDSText>
-          </XDSVStack>
-          <XDSHStack gap={3}>
-            <XDSButton
-              label="Get started"
-              variant="primary"
-              endContent={
-                <XDSIcon icon={ArrowRightIcon} size="sm" color="inherit" />
-              }
+    <XDSLayout
+      content={
+        <XDSLayoutContent padding={0}>
+          <XDSVStack gap={10}>
+            <XDSVStack gap={6} hAlign="center" xstyle={styles.topSpacing}>
+              <XDSVStack gap={3} hAlign="center">
+                <XDSText
+                  type="display-2"
+                  as="h1"
+                  weight="bold"
+                  textWrap="balance"
+                  xstyle={[styles.textCenter, styles.titleResponsive]}>
+                  Little joys, everywhere you go
+                </XDSText>
+                <XDSText
+                  type="body"
+                  color="secondary"
+                  textWrap="balance"
+                  xstyle={styles.textCenter}>
+                  Sometimes all it takes is one small thing to turn your whole
+                  day around.
+                </XDSText>
+              </XDSVStack>
+              <XDSHStack gap={3}>
+                <XDSButton
+                  label="Get started"
+                  variant="primary"
+                  endContent={
+                    <XDSIcon icon={ArrowRightIcon} size="sm" color="inherit" />
+                  }
+                />
+                <XDSButton label="Learn more" variant="secondary" />
+              </XDSHStack>
+            </XDSVStack>
+            <img
+              {...stylex.props(styles.heroImage)}
+              src={IMAGE_URL}
+              alt="Serene landscape with cotton fields and towering clouds"
             />
-            <XDSButton label="Learn more" variant="secondary" />
-          </XDSHStack>
-        </XDSVStack>
-        <img
-          {...stylex.props(styles.heroImage)}
-          src={IMAGE_URL}
-          alt="Serene landscape with cotton fields and towering clouds"
-        />
-      </XDSVStack>
-    </XDSAppShell>
+          </XDSVStack>
+        </XDSLayoutContent>
+      }
+    />
   );
 }

--- a/packages/cli/templates/pages/classic-gallery/page.tsx
+++ b/packages/cli/templates/pages/classic-gallery/page.tsx
@@ -3,8 +3,7 @@
 'use client';
 
 import {useState} from 'react';
-import {XDSAppShell} from '@xds/core/AppShell';
-import {XDSVStack} from '@xds/core/Layout';
+import {XDSVStack, XDSLayout, XDSLayoutContent} from '@xds/core/Layout';
 import {XDSCenter} from '@xds/core/Center';
 import {XDSText, XDSHeading} from '@xds/core/Text';
 import {XDSGrid} from '@xds/core/Grid';
@@ -123,52 +122,57 @@ export default function ClassicGalleryTemplate() {
       : GALLERY_IMAGES.filter(img => img.category === filter);
 
   return (
-    <XDSAppShell height="auto" contentPadding={0} variant="surface">
-      <XDSCenter axis="horizontal">
-        <XDSVStack gap={8} xstyle={styles.outer}>
-          {/* Header */}
+    <XDSLayout
+      height="auto"
+      content={
+        <XDSLayoutContent padding={0}>
           <XDSCenter axis="horizontal">
-            <XDSSection variant="transparent" maxWidth={680} padding={0}>
-              <XDSVStack gap={4} hAlign="center" xstyle={styles.textCenter}>
-                <XDSVStack gap={2} hAlign="center">
-                  <XDSHeading level={1}>
-                    Make every day a little more delightful, one detail at a
-                    time.
-                  </XDSHeading>
-                  <XDSText type="body" color="secondary">
-                    We believe the smallest details are the ones that matter
-                    most. A little color, a thoughtful touch, a moment that
-                    catches your eye and makes you pause; that&apos;s what turns
-                    an ordinary day into something worth remembering.
-                  </XDSText>
-                </XDSVStack>
+            <XDSVStack gap={8} xstyle={styles.outer}>
+              {/* Header */}
+              <XDSCenter axis="horizontal">
+                <XDSSection variant="transparent" maxWidth={680} padding={0}>
+                  <XDSVStack gap={4} hAlign="center" xstyle={styles.textCenter}>
+                    <XDSVStack gap={2} hAlign="center">
+                      <XDSHeading level={1}>
+                        Make every day a little more delightful, one detail at a
+                        time.
+                      </XDSHeading>
+                      <XDSText type="body" color="secondary">
+                        We believe the smallest details are the ones that matter
+                        most. A little color, a thoughtful touch, a moment that
+                        catches your eye and makes you pause; that&apos;s what
+                        turns an ordinary day into something worth remembering.
+                      </XDSText>
+                    </XDSVStack>
 
-                <XDSTabList
-                  value={filter}
-                  onChange={v => setFilter(v as Category)}>
-                  <XDSTab value="all" label="All" />
-                  <XDSTab value="lifestyle" label="Lifestyle" />
-                  <XDSTab value="scene" label="Scenery" />
-                  <XDSTab value="home" label="Home" />
-                </XDSTabList>
-              </XDSVStack>
-            </XDSSection>
+                    <XDSTabList
+                      value={filter}
+                      onChange={v => setFilter(v as Category)}>
+                      <XDSTab value="all" label="All" />
+                      <XDSTab value="lifestyle" label="Lifestyle" />
+                      <XDSTab value="scene" label="Scenery" />
+                      <XDSTab value="home" label="Home" />
+                    </XDSTabList>
+                  </XDSVStack>
+                </XDSSection>
+              </XDSCenter>
+
+              {/* Gallery Grid */}
+              <XDSGrid columns={{minWidth: 400}} gap={4}>
+                {filteredImages.map((image, i) => (
+                  <div key={i} {...stylex.props(styles.imageWrapper)}>
+                    <img
+                      src={image.src}
+                      alt={image.alt}
+                      {...stylex.props(styles.imgFill)}
+                    />
+                  </div>
+                ))}
+              </XDSGrid>
+            </XDSVStack>
           </XDSCenter>
-
-          {/* Gallery Grid */}
-          <XDSGrid columns={{minWidth: 400}} gap={4}>
-            {filteredImages.map((image, i) => (
-              <div key={i} {...stylex.props(styles.imageWrapper)}>
-                <img
-                  src={image.src}
-                  alt={image.alt}
-                  {...stylex.props(styles.imgFill)}
-                />
-              </div>
-            ))}
-          </XDSGrid>
-        </XDSVStack>
-      </XDSCenter>
-    </XDSAppShell>
+        </XDSLayoutContent>
+      }
+    />
   );
 }

--- a/packages/cli/templates/pages/dashboard-portfolio/page.tsx
+++ b/packages/cli/templates/pages/dashboard-portfolio/page.tsx
@@ -4,10 +4,12 @@
 
 import {useState} from 'react';
 
-import {XDSAppShell} from '@xds/core/AppShell';
-import {XDSSideNav, XDSSideNavHeading, XDSSideNavItem} from '@xds/core/SideNav';
-import {XDSNavIcon} from '@xds/core/NavIcon';
-import {XDSVStack, XDSHStack} from '@xds/core/Layout';
+import {
+  XDSVStack,
+  XDSHStack,
+  XDSLayout,
+  XDSLayoutContent,
+} from '@xds/core/Layout';
 import {XDSText, XDSHeading} from '@xds/core/Text';
 import {XDSCard} from '@xds/core/Card';
 import {XDSGrid, XDSGridSpan} from '@xds/core/Grid';
@@ -33,17 +35,7 @@ import {
   ResponsiveContainer,
 } from 'recharts';
 
-import {
-  DocumentTextIcon,
-  ArrowUpIcon,
-  ArrowDownIcon,
-  ArrowTrendingUpIcon,
-  Squares2X2Icon,
-} from '@heroicons/react/24/outline';
-import {
-  CurrencyDollarIcon,
-  Squares2X2Icon as Squares2X2IconSolid,
-} from '@heroicons/react/24/solid';
+import {ArrowUpIcon, ArrowDownIcon} from '@heroicons/react/24/outline';
 
 // ============= DATA =============
 
@@ -666,151 +658,118 @@ function AssetRow({
 
 // ============= SIDENAV =============
 
-function DashboardSideNav() {
-  const [active, setActive] = useState('dashboard');
-  return (
-    <XDSSideNav
-      header={
-        <XDSSideNavHeading
-          icon={
-            <XDSNavIcon
-              icon={<XDSIcon icon={CurrencyDollarIcon} size="sm" />}
-            />
-          }
-          heading="Financials"
-          headingHref="/"
-        />
-      }>
-      <XDSSideNavItem
-        label="Dashboard"
-        icon={active === 'dashboard' ? Squares2X2IconSolid : Squares2X2Icon}
-        isSelected={active === 'dashboard'}
-        onClick={() => setActive('dashboard')}
-      />
-      <XDSSideNavItem
-        label="Market"
-        icon={ArrowTrendingUpIcon}
-        isSelected={active === 'data'}
-        onClick={() => setActive('data')}
-      />
-      <XDSSideNavItem
-        label="Reports"
-        icon={DocumentTextIcon}
-        isSelected={active === 'reports'}
-        onClick={() => setActive('reports')}
-      />
-    </XDSSideNav>
-  );
-}
-
 // ============= MAIN COMPONENT =============
 
 export default function DashboardPortfolioTemplate() {
   const [timeRange, setTimeRange] = useState('1 year');
 
   return (
-    <XDSAppShell
-      sideNav={<DashboardSideNav />}
-      variant="elevated"
+    <XDSLayout
       height="fill"
-      contentPadding={6}>
-      <XDSVStack gap={6}>
-        {/* Page header */}
-        <XDSHStack hAlign="between" vAlign="center">
-          <XDSHeading level={1}>My Portfolio</XDSHeading>
-          <XDSDropdownMenu
-            button={{
-              label: timeRange,
-              variant: 'secondary',
-              size: 'lg',
-            }}
-            hasChevron
-            items={[
-              {label: '1 month', onClick: () => setTimeRange('1 month')},
-              {label: '3 months', onClick: () => setTimeRange('3 months')},
-              {label: '6 months', onClick: () => setTimeRange('6 months')},
-              {label: '1 year', onClick: () => setTimeRange('1 year')},
-              {label: '5 years', onClick: () => setTimeRange('5 years')},
-              {label: 'All time', onClick: () => setTimeRange('All time')},
-            ]}
-          />
-        </XDSHStack>
+      content={
+        <XDSLayoutContent padding={6}>
+          <XDSVStack gap={6}>
+            {/* Page header */}
+            <XDSHStack hAlign="between" vAlign="center">
+              <XDSHeading level={1}>My Portfolio</XDSHeading>
+              <XDSDropdownMenu
+                button={{
+                  label: timeRange,
+                  variant: 'secondary',
+                  size: 'lg',
+                }}
+                hasChevron
+                items={[
+                  {label: '1 month', onClick: () => setTimeRange('1 month')},
+                  {label: '3 months', onClick: () => setTimeRange('3 months')},
+                  {label: '6 months', onClick: () => setTimeRange('6 months')},
+                  {label: '1 year', onClick: () => setTimeRange('1 year')},
+                  {label: '5 years', onClick: () => setTimeRange('5 years')},
+                  {label: 'All time', onClick: () => setTimeRange('All time')},
+                ]}
+              />
+            </XDSHStack>
 
-        {/* KPI metric cards */}
-        <XDSGrid columns={{minWidth: 280, repeat: 'fit'}} gap={4}>
-          {Array.from({length: Math.ceil(metrics.length / 2)}, (_, i) => (
-            <XDSGrid key={i} columns={{minWidth: 280, repeat: 'fit'}} gap={4}>
-              {metrics.slice(i * 2, i * 2 + 2).map(m => (
-                <MetricCard key={m.label} {...m} />
+            {/* KPI metric cards */}
+            <XDSGrid columns={{minWidth: 280, repeat: 'fit'}} gap={4}>
+              {Array.from({length: Math.ceil(metrics.length / 2)}, (_, i) => (
+                <XDSGrid
+                  key={i}
+                  columns={{minWidth: 280, repeat: 'fit'}}
+                  gap={4}>
+                  {metrics.slice(i * 2, i * 2 + 2).map(m => (
+                    <MetricCard key={m.label} {...m} />
+                  ))}
+                </XDSGrid>
               ))}
             </XDSGrid>
-          ))}
-        </XDSGrid>
 
-        {/* Chart + Top assets */}
-        <XDSGrid columns={{minWidth: 280, max: 4}} gap={4}>
-          <XDSGridSpan columns={3}>
+            {/* Chart + Top assets */}
+            <XDSGrid columns={{minWidth: 280, max: 4}} gap={4}>
+              <XDSGridSpan columns={3}>
+                <XDSCard>
+                  <XDSVStack gap={4}>
+                    <XDSHStack hAlign="between" vAlign="center">
+                      <XDSHeading level={3}>Portfolio Value</XDSHeading>
+                      <XDSLink href="#">View details</XDSLink>
+                    </XDSHStack>
+                    <PortfolioChart />
+                  </XDSVStack>
+                </XDSCard>
+              </XDSGridSpan>
+              <XDSGridSpan columns={1}>
+                <XDSCard>
+                  <XDSVStack gap={4}>
+                    <XDSHStack hAlign="between" vAlign="center">
+                      <XDSHeading level={3}>Top Assets</XDSHeading>
+                      <XDSLink href="#">View all</XDSLink>
+                    </XDSHStack>
+                    <XDSList density="spacious">
+                      {topAssets.map(asset => (
+                        <AssetRow key={asset.ticker} {...asset} />
+                      ))}
+                    </XDSList>
+                  </XDSVStack>
+                </XDSCard>
+              </XDSGridSpan>
+            </XDSGrid>
+
+            <XDSDivider />
+
+            {/* Market section */}
+            <XDSHStack hAlign="between" vAlign="start">
+              <XDSVStack gap={1}>
+                <XDSHeading level={1}>Market Today</XDSHeading>
+                <XDSText type="body" color="secondary">
+                  Past 24 hours
+                </XDSText>
+              </XDSVStack>
+              <XDSButton label="View more" variant="secondary" size="lg" />
+            </XDSHStack>
+
+            {/* Market index cards */}
+            <XDSGrid columns={{minWidth: 320, repeat: 'fit'}} gap={4}>
+              {marketIndices.map(m => (
+                <MarketCard key={m.ticker} {...m} />
+              ))}
+            </XDSGrid>
+
+            {/* Trending stocks table */}
             <XDSCard>
               <XDSVStack gap={4}>
-                <XDSHStack hAlign="between" vAlign="center">
-                  <XDSHeading level={3}>Portfolio Value</XDSHeading>
-                  <XDSLink href="#">View details</XDSLink>
-                </XDSHStack>
-                <PortfolioChart />
+                <XDSHeading level={3}>Trending Stocks</XDSHeading>
+                <XDSTable<StockRow>
+                  data={trendingStocks}
+                  columns={trendingColumns}
+                  idKey="id"
+                  hasHover
+                  dividers="rows"
+                />
               </XDSVStack>
             </XDSCard>
-          </XDSGridSpan>
-          <XDSGridSpan columns={1}>
-            <XDSCard>
-              <XDSVStack gap={4}>
-                <XDSHStack hAlign="between" vAlign="center">
-                  <XDSHeading level={3}>Top Assets</XDSHeading>
-                  <XDSLink href="#">View all</XDSLink>
-                </XDSHStack>
-                <XDSList density="spacious">
-                  {topAssets.map(asset => (
-                    <AssetRow key={asset.ticker} {...asset} />
-                  ))}
-                </XDSList>
-              </XDSVStack>
-            </XDSCard>
-          </XDSGridSpan>
-        </XDSGrid>
-
-        <XDSDivider />
-
-        {/* Market section */}
-        <XDSHStack hAlign="between" vAlign="start">
-          <XDSVStack gap={1}>
-            <XDSHeading level={1}>Market Today</XDSHeading>
-            <XDSText type="body" color="secondary">
-              Past 24 hours
-            </XDSText>
           </XDSVStack>
-          <XDSButton label="View more" variant="secondary" size="lg" />
-        </XDSHStack>
-
-        {/* Market index cards */}
-        <XDSGrid columns={{minWidth: 320, repeat: 'fit'}} gap={4}>
-          {marketIndices.map(m => (
-            <MarketCard key={m.ticker} {...m} />
-          ))}
-        </XDSGrid>
-
-        {/* Trending stocks table */}
-        <XDSCard>
-          <XDSVStack gap={4}>
-            <XDSHeading level={3}>Trending Stocks</XDSHeading>
-            <XDSTable<StockRow>
-              data={trendingStocks}
-              columns={trendingColumns}
-              idKey="id"
-              hasHover
-              dividers="rows"
-            />
-          </XDSVStack>
-        </XDSCard>
-      </XDSVStack>
-    </XDSAppShell>
+        </XDSLayoutContent>
+      }
+    />
   );
 }

--- a/packages/cli/templates/pages/dashboard/page.tsx
+++ b/packages/cli/templates/pages/dashboard/page.tsx
@@ -2,20 +2,15 @@
 
 'use client';
 
-import {useState} from 'react';
-
-import {XDSAppShell} from '@xds/core/AppShell';
 import {
-  XDSSideNav,
-  XDSSideNavHeading,
-  XDSSideNavItem,
-  XDSSideNavSection,
-} from '@xds/core/SideNav';
-import {XDSVStack, XDSHStack} from '@xds/core/Layout';
+  XDSVStack,
+  XDSHStack,
+  XDSLayout,
+  XDSLayoutContent,
+} from '@xds/core/Layout';
 import {XDSText, XDSHeading} from '@xds/core/Text';
 import {XDSCard} from '@xds/core/Card';
 import {XDSButton} from '@xds/core/Button';
-import {XDSNavIcon} from '@xds/core/NavIcon';
 import {XDSProgressBar} from '@xds/core/ProgressBar';
 import {
   BarChart,
@@ -38,20 +33,11 @@ import {XDSIcon} from '@xds/core/Icon';
 // ============= ICONS =============
 
 import {
-  Squares2X2Icon,
-  FolderIcon,
-  UserGroupIcon,
-  CircleStackIcon,
-  DocumentTextIcon,
   ArrowPathIcon,
   ArrowUpIcon,
   ArrowDownIcon,
 } from '@heroicons/react/24/outline';
-import {
-  Squares2X2Icon as Squares2X2IconSolid,
-  ChartBarIcon as ChartBarIconSolid,
-  StopIcon,
-} from '@heroicons/react/24/solid';
+import {StopIcon} from '@heroicons/react/24/solid';
 
 // ============= DATA =============
 
@@ -738,135 +724,85 @@ function TableCard<T extends {id: string}>({
 
 // ============= SIDENAV =============
 
-function DashboardSideNav() {
-  const [active, setActive] = useState('dashboard');
-  return (
-    <XDSSideNav
-      header={
-        <XDSSideNavHeading
-          icon={
-            <XDSNavIcon icon={<XDSIcon icon={ChartBarIconSolid} size="sm" />} />
-          }
-          heading="Analytics"
-          headingHref="/"
-        />
-      }>
-      <XDSSideNavSection title="Platform">
-        <XDSSideNavItem
-          label="Dashboard"
-          icon={active === 'dashboard' ? Squares2X2IconSolid : Squares2X2Icon}
-          isSelected={active === 'dashboard'}
-          onClick={() => setActive('dashboard')}
-        />
-        <XDSSideNavItem
-          label="Projects"
-          icon={FolderIcon}
-          isSelected={active === 'projects'}
-          onClick={() => setActive('projects')}
-        />
-        <XDSSideNavItem
-          label="Team"
-          icon={UserGroupIcon}
-          isSelected={active === 'team'}
-          onClick={() => setActive('team')}
-        />
-      </XDSSideNavSection>
-      <XDSSideNavSection title="Documents">
-        <XDSSideNavItem
-          label="Data Library"
-          icon={CircleStackIcon}
-          isSelected={active === 'data'}
-          onClick={() => setActive('data')}
-        />
-        <XDSSideNavItem
-          label="Reports"
-          icon={DocumentTextIcon}
-          isSelected={active === 'reports'}
-          onClick={() => setActive('reports')}
-        />
-      </XDSSideNavSection>
-    </XDSSideNav>
-  );
-}
-
 // ============= MAIN COMPONENT =============
 
 export default function DashboardTemplate() {
   return (
-    <XDSAppShell
-      sideNav={<DashboardSideNav />}
-      variant="elevated"
+    <XDSLayout
       height="auto"
-      contentPadding={6}>
-      <XDSVStack gap={6}>
-        {/* Active Users Chart */}
-        <XDSVStack gap={6}>
-          <XDSHStack hAlign="between" vAlign="center">
-            <XDSHeading level={3}>Active users</XDSHeading>
-            <XDSButton
-              label="Reload"
-              variant="secondary"
-              size="md"
-              icon={<XDSIcon icon={ArrowPathIcon} size="sm" />}
-            />
-          </XDSHStack>
-          <ActiveUsersChart />
-        </XDSVStack>
-
-        {/* Metric Cards */}
-        <XDSGrid columns={{minWidth: 320, repeat: 'fit'}} gap={4}>
-          {[0, 2].map(start => (
-            <XDSGrid
-              key={start}
-              columns={{minWidth: 240, repeat: 'fit'}}
-              gap={4}>
-              {metrics.slice(start, start + 2).map((m, i) => (
-                <MetricCard
-                  key={m.label}
-                  {...m}
-                  sparkline={sparklines[start + i]}
+      content={
+        <XDSLayoutContent padding={6}>
+          <XDSVStack gap={6}>
+            {/* Active Users Chart */}
+            <XDSVStack gap={6}>
+              <XDSHStack hAlign="between" vAlign="center">
+                <XDSHeading level={3}>Active users</XDSHeading>
+                <XDSButton
+                  label="Reload"
+                  variant="secondary"
+                  size="md"
+                  icon={<XDSIcon icon={ArrowPathIcon} size="sm" />}
                 />
+              </XDSHStack>
+              <ActiveUsersChart />
+            </XDSVStack>
+
+            {/* Metric Cards */}
+            <XDSGrid columns={{minWidth: 320, repeat: 'fit'}} gap={4}>
+              {[0, 2].map(start => (
+                <XDSGrid
+                  key={start}
+                  columns={{minWidth: 240, repeat: 'fit'}}
+                  gap={4}>
+                  {metrics.slice(start, start + 2).map((m, i) => (
+                    <MetricCard
+                      key={m.label}
+                      {...m}
+                      sparkline={sparklines[start + i]}
+                    />
+                  ))}
+                </XDSGrid>
               ))}
             </XDSGrid>
-          ))}
-        </XDSGrid>
 
-        <XDSDivider />
+            <XDSDivider />
 
-        {/* Demographics */}
-        <XDSHStack hAlign="between" vAlign="center">
-          <XDSHeading level={3}>Demographics</XDSHeading>
-          <XDSButton label="View more" variant="secondary" size="md" />
-        </XDSHStack>
-        <XDSGrid columns={{minWidth: 320, repeat: 'fit'}} gap={4}>
-          <StackedBarCard title="Region" data={regionData} />
-          <StackedBarCard title="Role" data={roleData} />
-        </XDSGrid>
+            {/* Demographics */}
+            <XDSHStack hAlign="between" vAlign="center">
+              <XDSHeading level={3}>Demographics</XDSHeading>
+              <XDSButton label="View more" variant="secondary" size="md" />
+            </XDSHStack>
+            <XDSGrid columns={{minWidth: 320, repeat: 'fit'}} gap={4}>
+              <StackedBarCard title="Region" data={regionData} />
+              <StackedBarCard title="Role" data={roleData} />
+            </XDSGrid>
 
-        <XDSDivider />
+            <XDSDivider />
 
-        {/* Engagement */}
-        <XDSHStack hAlign="between" vAlign="center">
-          <XDSHeading level={3}>Engagement</XDSHeading>
-          <XDSButton label="View more" variant="secondary" size="md" />
-        </XDSHStack>
-        <XDSGrid columns={{minWidth: 320, repeat: 'fit'}} gap={4}>
-          <TableCard
-            title="Top pages"
-            linkLabel="All pages"
-            linkHref="#"
-            data={topPagesData}
-            columns={topPagesColumns}
-          />
-          <TableCard
-            title="Top events"
-            linkLabel="All events"
-            linkHref="#"
-            data={topEventsData}
-            columns={topEventsColumns}
-          />
-        </XDSGrid>
-      </XDSVStack>
-    </XDSAppShell>
+            {/* Engagement */}
+            <XDSHStack hAlign="between" vAlign="center">
+              <XDSHeading level={3}>Engagement</XDSHeading>
+              <XDSButton label="View more" variant="secondary" size="md" />
+            </XDSHStack>
+            <XDSGrid columns={{minWidth: 320, repeat: 'fit'}} gap={4}>
+              <TableCard
+                title="Top pages"
+                linkLabel="All pages"
+                linkHref="#"
+                data={topPagesData}
+                columns={topPagesColumns}
+              />
+              <TableCard
+                title="Top events"
+                linkLabel="All events"
+                linkHref="#"
+                data={topEventsData}
+                columns={topEventsColumns}
+              />
+            </XDSGrid>
+          </XDSVStack>
+        </XDSLayoutContent>
+      }
+    />
   );
 }

--- a/packages/cli/templates/pages/detail-page/page.tsx
+++ b/packages/cli/templates/pages/detail-page/page.tsx
@@ -3,15 +3,7 @@
 'use client';
 
 import {useState} from 'react';
-import {XDSAppShell} from '@xds/core/AppShell';
 import {useMediaQuery} from '@xds/core/hooks';
-import {XDSNavIcon} from '@xds/core/NavIcon';
-import {
-  XDSSideNav,
-  XDSSideNavHeading,
-  XDSSideNavItem,
-  XDSSideNavSection,
-} from '@xds/core/SideNav';
 import {
   XDSLayout,
   XDSLayoutHeader,
@@ -38,14 +30,6 @@ import {XDSIcon} from '@xds/core/Icon';
 import {XDSThumbnail} from '@xds/core/Thumbnail';
 import {XDSOverflowList} from '@xds/core/OverflowList';
 import {
-  HomeIcon,
-  ClipboardDocumentListIcon,
-  CubeIcon,
-  UserGroupIcon,
-  DocumentTextIcon,
-  ChartBarIcon,
-  Cog6ToothIcon,
-  QuestionMarkCircleIcon,
   CalendarIcon,
   FlagIcon,
   FunnelIcon,
@@ -55,7 +39,6 @@ import {
   ArrowLeftIcon,
   ViewColumnsIcon,
 } from '@heroicons/react/24/outline';
-import {BuildingStorefrontIcon} from '@heroicons/react/24/solid';
 
 // ─── Styles ─────────────────────────────────────────────────────────────────
 import * as stylex from '@stylexjs/stylex';
@@ -164,89 +147,6 @@ const ACTIVITY = [
     time: 'Feb 23 at 2:15 PM',
   },
 ];
-
-// ─── Side Nav ───────────────────────────────────────────────────────────────
-function ShopSideNav() {
-  const [active, setActive] = useState('orders');
-  return (
-    <XDSSideNav
-      collapsible
-      header={
-        <XDSSideNavHeading
-          icon={
-            <XDSNavIcon
-              icon={
-                <XDSIcon
-                  icon={BuildingStorefrontIcon}
-                  size="sm"
-                  color="inherit"
-                />
-              }
-            />
-          }
-          heading="Kiln & Table"
-          headingHref="/"
-        />
-      }
-      footer={
-        <XDSVStack gap={0}>
-          <XDSSideNavItem
-            label="Settings"
-            icon={Cog6ToothIcon}
-            isSelected={active === 'settings'}
-            onClick={() => setActive('settings')}
-          />
-          <XDSSideNavItem
-            label="Help Center"
-            icon={QuestionMarkCircleIcon}
-            isSelected={active === 'help'}
-            onClick={() => setActive('help')}
-          />
-        </XDSVStack>
-      }>
-      <XDSSideNavSection title="Main" isHeaderHidden>
-        <XDSSideNavItem
-          label="Home"
-          icon={HomeIcon}
-          isSelected={active === 'home'}
-          onClick={() => setActive('home')}
-        />
-        <XDSSideNavItem
-          label="Orders"
-          icon={ClipboardDocumentListIcon}
-          isSelected={active === 'orders'}
-          onClick={() => setActive('orders')}
-        />
-        <XDSSideNavItem
-          label="Products"
-          icon={CubeIcon}
-          isSelected={active === 'products'}
-          onClick={() => setActive('products')}
-        />
-      </XDSSideNavSection>
-      <XDSSideNavSection title="Sales channels">
-        <XDSSideNavItem
-          label="Customers"
-          icon={UserGroupIcon}
-          isSelected={active === 'customers'}
-          onClick={() => setActive('customers')}
-        />
-        <XDSSideNavItem
-          label="Content"
-          icon={DocumentTextIcon}
-          isSelected={active === 'content'}
-          onClick={() => setActive('content')}
-        />
-        <XDSSideNavItem
-          label="Analytics"
-          icon={ChartBarIcon}
-          isSelected={active === 'analytics'}
-          onClick={() => setActive('analytics')}
-        />
-      </XDSSideNavSection>
-    </XDSSideNav>
-  );
-}
 
 // ─── Bullet separator ───────────────────────────────────────────────────────
 function Bullet() {
@@ -650,33 +550,28 @@ export default function DetailPage2Template() {
   const [isPanelOpen, setIsPanelOpen] = useState(!isNarrow);
 
   return (
-    <XDSAppShell
-      sideNav={<ShopSideNav />}
-      variant="elevated"
-      contentPadding={0}>
-      <XDSLayout
-        height="fill"
-        contentWidth={1000}
-        defaultHasDividers
-        header={
-          <PageHeader
-            activeTab={activeTab}
-            onTabChange={setActiveTab}
-            isPanelOpen={isPanelOpen}
-            onTogglePanel={() => setIsPanelOpen(prev => !prev)}
-          />
-        }
-        content={
-          <XDSLayoutContent role="main">
-            <XDSVStack gap={4}>
-              <ItemsCard />
-              <InvoiceCard />
-              <TimelineSection />
-            </XDSVStack>
-          </XDSLayoutContent>
-        }
-        end={isPanelOpen ? <RightPanel /> : undefined}
-      />
-    </XDSAppShell>
+    <XDSLayout
+      height="fill"
+      contentWidth={1000}
+      defaultHasDividers
+      header={
+        <PageHeader
+          activeTab={activeTab}
+          onTabChange={setActiveTab}
+          isPanelOpen={isPanelOpen}
+          onTogglePanel={() => setIsPanelOpen(prev => !prev)}
+        />
+      }
+      content={
+        <XDSLayoutContent role="main">
+          <XDSVStack gap={4}>
+            <ItemsCard />
+            <InvoiceCard />
+            <TimelineSection />
+          </XDSVStack>
+        </XDSLayoutContent>
+      }
+      end={isPanelOpen ? <RightPanel /> : undefined}
+    />
   );
 }

--- a/packages/cli/templates/pages/documentation-design/page.tsx
+++ b/packages/cli/templates/pages/documentation-design/page.tsx
@@ -4,7 +4,6 @@
 
 import {useState, useMemo} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {XDSAppShell} from '@xds/core/AppShell';
 import {
   XDSSideNav,
   XDSSideNavHeading,
@@ -22,7 +21,7 @@ import {XDSBanner} from '@xds/core/Banner';
 import {XDSCodeBlock} from '@xds/core/CodeBlock';
 import {XDSTabList, XDSTab} from '@xds/core/TabList';
 import {XDSHStack, XDSVStack, XDSStackItem} from '@xds/core/Stack';
-import {XDSLayout, XDSLayoutContent} from '@xds/core/Layout';
+import {XDSLayout, XDSLayoutContent, XDSLayoutPanel} from '@xds/core/Layout';
 import {XDSDialog, XDSDialogHeader} from '@xds/core/Dialog';
 import {XDSDivider} from '@xds/core/Divider';
 import {XDSTooltip} from '@xds/core/Tooltip';
@@ -494,7 +493,13 @@ function getComponentDocs(key: string) {
 // ComponentDetailView
 // ---------------------------------------------------------------------------
 
-function ComponentDetailView({activeNav}: {activeNav: string}) {
+function ComponentDetailView({
+  activeNav,
+  nav,
+}: {
+  activeNav: string;
+  nav: React.ReactNode;
+}) {
   const [exampleTabs, setExampleTabs] = useState<Record<string, string>>({});
 
   const EXAMPLE_PREVIEWS: Record<string, React.ReactNode[]> = {
@@ -551,7 +556,13 @@ function ComponentDetailView({activeNav}: {activeNav: string}) {
 
   return (
     <XDSLayout
+      height="fill"
       contentWidth={960}
+      start={
+        <XDSLayoutPanel hasDivider padding={0}>
+          {nav}
+        </XDSLayoutPanel>
+      }
       content={
         <XDSLayoutContent padding={8}>
           <XDSVStack gap={8}>
@@ -697,10 +708,9 @@ export default function DesignDocumentationPage() {
   const [activePage, setActivePage] = useState<string>('button');
 
   return (
-    <XDSAppShell
-      variant="section"
-      height="fill"
-      sideNav={
+    <ComponentDetailView
+      activeNav={activePage}
+      nav={
         <XDSSideNav header={<XDSSideNavHeading heading="Product Name" />}>
           {COMPONENT_CATEGORIES.map(category => (
             <XDSSideNavSection key={category.label} title={category.label}>
@@ -719,8 +729,7 @@ export default function DesignDocumentationPage() {
             </XDSSideNavSection>
           ))}
         </XDSSideNav>
-      }>
-      <ComponentDetailView activeNav={activePage} />
-    </XDSAppShell>
+      }
+    />
   );
 }

--- a/packages/cli/templates/pages/documentation-technical/page.tsx
+++ b/packages/cli/templates/pages/documentation-technical/page.tsx
@@ -2,7 +2,6 @@
 
 'use client';
 
-import {XDSAppShell} from '@xds/core/AppShell';
 import {
   XDSSideNav,
   XDSSideNavHeading,
@@ -16,7 +15,7 @@ import {XDSDropdownMenu} from '@xds/core/DropdownMenu';
 import {XDSList, XDSListItem} from '@xds/core/List';
 import {XDSCodeBlock} from '@xds/core/CodeBlock';
 import {XDSHStack, XDSVStack, XDSStackItem} from '@xds/core/Stack';
-import {XDSLayout, XDSLayoutContent} from '@xds/core/Layout';
+import {XDSLayout, XDSLayoutContent, XDSLayoutPanel} from '@xds/core/Layout';
 import {XDSDivider} from '@xds/core/Divider';
 import {XDSIcon} from '@xds/core/Icon';
 import {
@@ -31,131 +30,155 @@ import {
 
 export default function TechnicalDocumentationPage() {
   return (
-    <XDSAppShell
-      variant="section"
+    <XDSLayout
       height="fill"
-      sideNav={
-        <XDSSideNav
-          header={<XDSSideNavHeading heading="Product Name" />}>
-          <XDSSideNavSection title="Navigation" isHeaderHidden>
-            <XDSSideNavItem label="Home" />
-            <XDSSideNavItem label="Getting started" isSelected />
-          </XDSSideNavSection>
-        </XDSSideNav>
-      }>
-      <XDSLayout contentWidth={960} content={
+      contentWidth={960}
+      start={
+        <XDSLayoutPanel hasDivider padding={0}>
+          <XDSSideNav header={<XDSSideNavHeading heading="Product Name" />}>
+            <XDSSideNavSection title="Navigation" isHeaderHidden>
+              <XDSSideNavItem label="Home" />
+              <XDSSideNavItem label="Getting started" isSelected />
+            </XDSSideNavSection>
+          </XDSSideNav>
+        </XDSLayoutPanel>
+      }
+      content={
         <XDSLayoutContent padding={8}>
           <XDSVStack gap={8}>
-          <XDSVStack gap={2}>
-            <XDSText type="display-1">
-              Getting started with Product Name
-            </XDSText>
-            <XDSText type="supporting" color="secondary">
-              Last updated March 30, 2026
-            </XDSText>
-            <XDSText type="body">
-              Install the package, configure your theme, and build your first
-              component in three steps.
-            </XDSText>
-          </XDSVStack>
-
-          <XDSCard>
-            <XDSVStack gap={3}>
-              <XDSHStack gap={2} vAlign="center">
-                <XDSStackItem size="fill">
-                  <XDSHStack gap={2} vAlign="center">
-                    <XDSIcon icon={SparklesIcon} size="sm" color="secondary" />
-                    <XDSText type="body" weight="semibold">AI Assistance</XDSText>
-                  </XDSHStack>
-                </XDSStackItem>
-                <XDSButton
-                  label="Copy prompt"
-                  variant="ghost"
-                  size="sm"
-                  icon={<XDSIcon icon={ClipboardDocumentIcon} />}
-                  onClick={() => {
-                    void navigator.clipboard.writeText(
-                      'Help me get set up with Product Name. Based on my project, do the following: 1. Install @xds/core and the StyleX compiler. 2. Wrap my app in XDSThemeProvider. 3. Replace one existing component with an XDS equivalent. After setup, suggest relevant next steps based on my project.',
-                    );
-                  }}
-                />
-                <XDSDropdownMenu
-                  button={{label: 'More options', variant: 'ghost', size: 'sm', isIconOnly: true, icon: <XDSIcon icon={ChevronDownIcon} />}}
-                  items={[
-                    {label: 'Open in v0', onClick: () => {}},
-                    {label: 'Open in Claude', onClick: () => {}},
-                    {label: 'Open in ChatGPT', onClick: () => {}},
-                    {label: 'Open in Cursor', onClick: () => {}},
-                  ]}
-                />
-              </XDSHStack>
-              <XDSText type="body" color="secondary">
-                Help me get set up with Product Name. Based on my project, do the
-                following: 1. Install @xds/core and the StyleX compiler. 2. Wrap
-                my app in XDSThemeProvider. 3. Replace one existing component with
-                an XDS equivalent.
+            <XDSVStack gap={2}>
+              <XDSText type="display-1">
+                Getting started with Product Name
+              </XDSText>
+              <XDSText type="supporting" color="secondary">
+                Last updated March 30, 2026
+              </XDSText>
+              <XDSText type="body">
+                Install the package, configure your theme, and build your first
+                component in three steps.
               </XDSText>
             </XDSVStack>
-          </XDSCard>
 
-          <XDSVStack gap={4}>
-            <XDSHeading level={2}>Prerequisites</XDSHeading>
-            <XDSList density="compact" listStyle="disc">
-              <XDSListItem label="Node.js 18+" />
-              <XDSListItem label="React 18 or 19" />
-              <XDSListItem label="A package manager (npm, yarn, or pnpm)" />
-            </XDSList>
-          </XDSVStack>
+            <XDSCard>
+              <XDSVStack gap={3}>
+                <XDSHStack gap={2} vAlign="center">
+                  <XDSStackItem size="fill">
+                    <XDSHStack gap={2} vAlign="center">
+                      <XDSIcon
+                        icon={SparklesIcon}
+                        size="sm"
+                        color="secondary"
+                      />
+                      <XDSText type="body" weight="semibold">
+                        AI Assistance
+                      </XDSText>
+                    </XDSHStack>
+                  </XDSStackItem>
+                  <XDSButton
+                    label="Copy prompt"
+                    variant="ghost"
+                    size="sm"
+                    icon={<XDSIcon icon={ClipboardDocumentIcon} />}
+                    onClick={() => {
+                      void navigator.clipboard.writeText(
+                        'Help me get set up with Product Name. Based on my project, do the following: 1. Install @xds/core and the StyleX compiler. 2. Wrap my app in XDSThemeProvider. 3. Replace one existing component with an XDS equivalent. After setup, suggest relevant next steps based on my project.',
+                      );
+                    }}
+                  />
+                  <XDSDropdownMenu
+                    button={{
+                      label: 'More options',
+                      variant: 'ghost',
+                      size: 'sm',
+                      isIconOnly: true,
+                      icon: <XDSIcon icon={ChevronDownIcon} />,
+                    }}
+                    items={[
+                      {label: 'Open in v0', onClick: () => {}},
+                      {label: 'Open in Claude', onClick: () => {}},
+                      {label: 'Open in ChatGPT', onClick: () => {}},
+                      {label: 'Open in Cursor', onClick: () => {}},
+                    ]}
+                  />
+                </XDSHStack>
+                <XDSText type="body" color="secondary">
+                  Help me get set up with Product Name. Based on my project, do
+                  the following: 1. Install @xds/core and the StyleX compiler.
+                  2. Wrap my app in XDSThemeProvider. 3. Replace one existing
+                  component with an XDS equivalent.
+                </XDSText>
+              </XDSVStack>
+            </XDSCard>
 
-          <XDSDivider />
-
-          <XDSVStack gap={4}>
-            <XDSHeading level={2}>Install the package</XDSHeading>
-            <XDSText type="body">
-              Every project starts with installing the core package. This gives
-              you access to all components, tokens, and utilities.
-            </XDSText>
-            <XDSVStack gap={2}>
-              <XDSText type="body" weight="bold">Step 1: Install the core package</XDSText>
-              <XDSCard padding={0}>
-                <XDSCodeBlock code="npm install @xds/core" language="bash" />
-              </XDSCard>
+            <XDSVStack gap={4}>
+              <XDSHeading level={2}>Prerequisites</XDSHeading>
+              <XDSList density="compact" listStyle="disc">
+                <XDSListItem label="Node.js 18+" />
+                <XDSListItem label="React 18 or 19" />
+                <XDSListItem label="A package manager (npm, yarn, or pnpm)" />
+              </XDSList>
             </XDSVStack>
-            <XDSVStack gap={2}>
-              <XDSText type="body" weight="bold">Step 2: Add the StyleX compiler</XDSText>
-              <XDSText type="body" color="secondary">
-                XDS uses StyleX for styling. Add the compiler plugin to your build configuration.
+
+            <XDSDivider />
+
+            <XDSVStack gap={4}>
+              <XDSHeading level={2}>Install the package</XDSHeading>
+              <XDSText type="body">
+                Every project starts with installing the core package. This
+                gives you access to all components, tokens, and utilities.
               </XDSText>
-              <XDSCard padding={0}>
-                <XDSCodeBlock code="npm install @stylexjs/babel-plugin" language="bash" />
-              </XDSCard>
-            </XDSVStack>
-            <XDSVStack gap={2}>
-              <XDSText type="body" weight="bold">Step 3: Import your first component</XDSText>
-              <XDSCard padding={0}>
-                <XDSCodeBlock
-                  code={`import { XDSButton } from '@xds/core/Button';
+              <XDSVStack gap={2}>
+                <XDSText type="body" weight="bold">
+                  Step 1: Install the core package
+                </XDSText>
+                <XDSCard padding={0}>
+                  <XDSCodeBlock code="npm install @xds/core" language="bash" />
+                </XDSCard>
+              </XDSVStack>
+              <XDSVStack gap={2}>
+                <XDSText type="body" weight="bold">
+                  Step 2: Add the StyleX compiler
+                </XDSText>
+                <XDSText type="body" color="secondary">
+                  XDS uses StyleX for styling. Add the compiler plugin to your
+                  build configuration.
+                </XDSText>
+                <XDSCard padding={0}>
+                  <XDSCodeBlock
+                    code="npm install @stylexjs/babel-plugin"
+                    language="bash"
+                  />
+                </XDSCard>
+              </XDSVStack>
+              <XDSVStack gap={2}>
+                <XDSText type="body" weight="bold">
+                  Step 3: Import your first component
+                </XDSText>
+                <XDSCard padding={0}>
+                  <XDSCodeBlock
+                    code={`import { XDSButton } from '@xds/core/Button';
 
 export default function App() {
   return <XDSButton label="Hello XDS" variant="primary" />;
 }`}
-                  language="tsx"
-                />
-              </XDSCard>
+                    language="tsx"
+                  />
+                </XDSCard>
+              </XDSVStack>
             </XDSVStack>
-          </XDSVStack>
 
-          <XDSDivider />
+            <XDSDivider />
 
-          <XDSVStack gap={4}>
-            <XDSHeading level={2}>Configure theming</XDSHeading>
-            <XDSText type="body">
-              XDS ships with a default theme that works out of the box. To
-              customize colors, typography, and spacing, wrap your app in a theme provider.
-            </XDSText>
-            <XDSCard padding={0}>
-              <XDSCodeBlock
-                code={`import { XDSThemeProvider } from '@xds/core/Theme';
+            <XDSVStack gap={4}>
+              <XDSHeading level={2}>Configure theming</XDSHeading>
+              <XDSText type="body">
+                XDS ships with a default theme that works out of the box. To
+                customize colors, typography, and spacing, wrap your app in a
+                theme provider.
+              </XDSText>
+              <XDSCard padding={0}>
+                <XDSCodeBlock
+                  code={`import { XDSThemeProvider } from '@xds/core/Theme';
 
 export default function App({ children }) {
   return (
@@ -164,29 +187,29 @@ export default function App({ children }) {
     </XDSThemeProvider>
   );
 }`}
-                language="tsx"
-              />
-            </XDSCard>
-            <XDSText type="body" color="secondary">
-              See the theming guide for the full list of customizable tokens.
-            </XDSText>
-          </XDSVStack>
+                  language="tsx"
+                />
+              </XDSCard>
+              <XDSText type="body" color="secondary">
+                See the theming guide for the full list of customizable tokens.
+              </XDSText>
+            </XDSVStack>
 
-          <XDSDivider />
+            <XDSDivider />
 
-          <XDSVStack gap={4}>
-            <XDSHeading level={2}>Next steps</XDSHeading>
-            <XDSList density="compact" listStyle="disc">
-              <XDSListItem label="Fundamental concepts — How theming, layout, and composition work" />
-              <XDSListItem label="Component API reference — Props, variants, and examples for every component" />
-              <XDSListItem label="Accessibility — Built-in a11y features and ARIA patterns" />
-              <XDSListItem label="CLI tools — Scaffold projects and manage templates" />
-              <XDSListItem label="Design tokens — Colors, spacing, typography, and sizing" />
-            </XDSList>
+            <XDSVStack gap={4}>
+              <XDSHeading level={2}>Next steps</XDSHeading>
+              <XDSList density="compact" listStyle="disc">
+                <XDSListItem label="Fundamental concepts — How theming, layout, and composition work" />
+                <XDSListItem label="Component API reference — Props, variants, and examples for every component" />
+                <XDSListItem label="Accessibility — Built-in a11y features and ARIA patterns" />
+                <XDSListItem label="CLI tools — Scaffold projects and manage templates" />
+                <XDSListItem label="Design tokens — Colors, spacing, typography, and sizing" />
+              </XDSList>
+            </XDSVStack>
           </XDSVStack>
-        </XDSVStack>
         </XDSLayoutContent>
-      } />
-    </XDSAppShell>
+      }
+    />
   );
 }

--- a/packages/cli/templates/pages/documentation/page.tsx
+++ b/packages/cli/templates/pages/documentation/page.tsx
@@ -3,7 +3,6 @@
 'use client';
 
 import * as stylex from '@stylexjs/stylex';
-import {XDSAppShell} from '@xds/core/AppShell';
 import {
   XDSSideNav,
   XDSSideNavHeading,
@@ -14,7 +13,7 @@ import {XDSText} from '@xds/core/Text';
 import {XDSButton} from '@xds/core/Button';
 import {XDSCard} from '@xds/core/Card';
 import {XDSHStack, XDSVStack, XDSStackItem} from '@xds/core/Stack';
-import {XDSLayout, XDSLayoutContent} from '@xds/core/Layout';
+import {XDSLayout, XDSLayoutContent, XDSLayoutPanel} from '@xds/core/Layout';
 import {XDSGrid} from '@xds/core/Grid';
 import {radiusVars} from '@xds/core/theme/tokens.stylex';
 
@@ -33,52 +32,176 @@ const COMPONENT_CATEGORIES = [
   {
     label: 'Core',
     items: [
-      {key: 'appshell', name: 'AppShell', desc: 'AppShell provides a foundational page layout with header, sidebar, and content regions. Use it to establish consistent structure across your application.'},
-      {key: 'avatar', name: 'Avatar', desc: 'Avatars represent a person or entity with an image, initials, or icon. They are commonly used in user profiles, comments, and contact lists.'},
-      {key: 'badge', name: 'Badge', desc: 'Badges display small counts or status labels. They can be attached to icons, buttons, or list items to surface key information at a glance.'},
-      {key: 'banner', name: 'Banner', desc: 'Banners show important, non-modal messages at the top of a page or section. They communicate status, warnings, or promotional information.'},
-      {key: 'button', name: 'Button', desc: 'Buttons let people take action. They can be used in forms, dialogs, and toolbars, or as standalone links.'},
-      {key: 'calendar', name: 'Calendar', desc: 'Calendar provides a date-picking grid for selecting single dates or date ranges. It integrates with form fields for date input.'},
-      {key: 'dialog', name: 'Dialog', desc: 'Dialogs are modal overlays that require user attention or action before continuing. They are used for confirmations, forms, and critical decisions.'},
-      {key: 'dropdownmenu', name: 'DropdownMenu', desc: 'DropdownMenu presents a list of actions or options in a floating overlay. It is triggered by a button and supports nested submenus.'},
-      {key: 'emptystate', name: 'EmptyState', desc: 'EmptyState provides a placeholder when there is no content to display. It guides users with a message, illustration, and optional call-to-action.'},
-      {key: 'hovercard', name: 'HoverCard', desc: 'HoverCard shows a rich preview of content when users hover over a trigger element. It is ideal for previewing profiles, links, or details.'},
-      {key: 'icon', name: 'Icon', desc: 'Icons are small visual symbols that represent actions, objects, or concepts. They improve scannability and reinforce meaning alongside text.'},
-      {key: 'kbd', name: 'Kbd', desc: 'Kbd renders keyboard shortcut hints in a styled inline element. Use it to show users which key combinations perform specific actions.'},
-      {key: 'link', name: 'Link', desc: 'Links provide navigation between pages or to external resources. They follow accessible anchor semantics with visual affordance.'},
-      {key: 'list', name: 'List', desc: 'List displays a vertical set of related items. It supports selection, icons, and metadata for building menus, nav lists, and more.'},
-      {key: 'popover', name: 'Popover', desc: 'Popover displays rich content in a floating panel anchored to a trigger element. It is used for forms, filters, and contextual tools.'},
-      {key: 'table', name: 'Table', desc: 'Table displays structured data in rows and columns with support for sorting, selection, and custom cell rendering.'},
-      {key: 'token', name: 'Token', desc: 'Tokens display compact metadata labels such as tags, categories, or filters. They can be dismissible and support selection state.'},
-      {key: 'tooltip', name: 'Tooltip', desc: 'Tooltips show concise helper text when users hover over or focus an element. They clarify icons, truncated labels, and controls.'},
+      {
+        key: 'appshell',
+        name: 'AppShell',
+        desc: 'AppShell provides a foundational page layout with header, sidebar, and content regions. Use it to establish consistent structure across your application.',
+      },
+      {
+        key: 'avatar',
+        name: 'Avatar',
+        desc: 'Avatars represent a person or entity with an image, initials, or icon. They are commonly used in user profiles, comments, and contact lists.',
+      },
+      {
+        key: 'badge',
+        name: 'Badge',
+        desc: 'Badges display small counts or status labels. They can be attached to icons, buttons, or list items to surface key information at a glance.',
+      },
+      {
+        key: 'banner',
+        name: 'Banner',
+        desc: 'Banners show important, non-modal messages at the top of a page or section. They communicate status, warnings, or promotional information.',
+      },
+      {
+        key: 'button',
+        name: 'Button',
+        desc: 'Buttons let people take action. They can be used in forms, dialogs, and toolbars, or as standalone links.',
+      },
+      {
+        key: 'calendar',
+        name: 'Calendar',
+        desc: 'Calendar provides a date-picking grid for selecting single dates or date ranges. It integrates with form fields for date input.',
+      },
+      {
+        key: 'dialog',
+        name: 'Dialog',
+        desc: 'Dialogs are modal overlays that require user attention or action before continuing. They are used for confirmations, forms, and critical decisions.',
+      },
+      {
+        key: 'dropdownmenu',
+        name: 'DropdownMenu',
+        desc: 'DropdownMenu presents a list of actions or options in a floating overlay. It is triggered by a button and supports nested submenus.',
+      },
+      {
+        key: 'emptystate',
+        name: 'EmptyState',
+        desc: 'EmptyState provides a placeholder when there is no content to display. It guides users with a message, illustration, and optional call-to-action.',
+      },
+      {
+        key: 'hovercard',
+        name: 'HoverCard',
+        desc: 'HoverCard shows a rich preview of content when users hover over a trigger element. It is ideal for previewing profiles, links, or details.',
+      },
+      {
+        key: 'icon',
+        name: 'Icon',
+        desc: 'Icons are small visual symbols that represent actions, objects, or concepts. They improve scannability and reinforce meaning alongside text.',
+      },
+      {
+        key: 'kbd',
+        name: 'Kbd',
+        desc: 'Kbd renders keyboard shortcut hints in a styled inline element. Use it to show users which key combinations perform specific actions.',
+      },
+      {
+        key: 'link',
+        name: 'Link',
+        desc: 'Links provide navigation between pages or to external resources. They follow accessible anchor semantics with visual affordance.',
+      },
+      {
+        key: 'list',
+        name: 'List',
+        desc: 'List displays a vertical set of related items. It supports selection, icons, and metadata for building menus, nav lists, and more.',
+      },
+      {
+        key: 'popover',
+        name: 'Popover',
+        desc: 'Popover displays rich content in a floating panel anchored to a trigger element. It is used for forms, filters, and contextual tools.',
+      },
+      {
+        key: 'table',
+        name: 'Table',
+        desc: 'Table displays structured data in rows and columns with support for sorting, selection, and custom cell rendering.',
+      },
+      {
+        key: 'token',
+        name: 'Token',
+        desc: 'Tokens display compact metadata labels such as tags, categories, or filters. They can be dismissible and support selection state.',
+      },
+      {
+        key: 'tooltip',
+        name: 'Tooltip',
+        desc: 'Tooltips show concise helper text when users hover over or focus an element. They clarify icons, truncated labels, and controls.',
+      },
     ],
   },
   {
     label: 'Layout',
     items: [
-      {key: 'card', name: 'Card', desc: 'Cards group related content and actions in a contained surface. They can include headers, media, body text, and action bars.'},
-      {key: 'divider', name: 'Divider', desc: 'Dividers separate content into distinct sections with a subtle or strong horizontal line. They can optionally include a label.'},
-      {key: 'grid', name: 'Grid', desc: 'Grid provides a CSS grid-based layout container with configurable columns, rows, and gap. It simplifies responsive multi-column designs.'},
-      {key: 'stack', name: 'Stack', desc: 'Stack arranges child elements in a row or column with consistent gap spacing. It is the primary tool for one-dimensional layout composition.'},
+      {
+        key: 'card',
+        name: 'Card',
+        desc: 'Cards group related content and actions in a contained surface. They can include headers, media, body text, and action bars.',
+      },
+      {
+        key: 'divider',
+        name: 'Divider',
+        desc: 'Dividers separate content into distinct sections with a subtle or strong horizontal line. They can optionally include a label.',
+      },
+      {
+        key: 'grid',
+        name: 'Grid',
+        desc: 'Grid provides a CSS grid-based layout container with configurable columns, rows, and gap. It simplifies responsive multi-column designs.',
+      },
+      {
+        key: 'stack',
+        name: 'Stack',
+        desc: 'Stack arranges child elements in a row or column with consistent gap spacing. It is the primary tool for one-dimensional layout composition.',
+      },
     ],
   },
   {
     label: 'Navigation',
     items: [
-      {key: 'breadcrumbs', name: 'Breadcrumbs', desc: "Breadcrumbs show the user's current location within a navigation hierarchy. They provide quick links back to parent pages."},
-      {key: 'sidenav', name: 'SideNav', desc: 'SideNav renders a vertical navigation panel with links, sections, and collapsible groups. It is used as the primary nav in dashboard layouts.'},
-      {key: 'tablist', name: 'TabList', desc: 'TabList switches between content views using a horizontal row of tabs. Only one tab is active at a time, and content changes without a page reload.'},
-      {key: 'topnav', name: 'TopNav', desc: 'TopNav provides an app-level navigation bar across the top of the page. It holds branding, primary links, search, and user actions.'},
+      {
+        key: 'breadcrumbs',
+        name: 'Breadcrumbs',
+        desc: "Breadcrumbs show the user's current location within a navigation hierarchy. They provide quick links back to parent pages.",
+      },
+      {
+        key: 'sidenav',
+        name: 'SideNav',
+        desc: 'SideNav renders a vertical navigation panel with links, sections, and collapsible groups. It is used as the primary nav in dashboard layouts.',
+      },
+      {
+        key: 'tablist',
+        name: 'TabList',
+        desc: 'TabList switches between content views using a horizontal row of tabs. Only one tab is active at a time, and content changes without a page reload.',
+      },
+      {
+        key: 'topnav',
+        name: 'TopNav',
+        desc: 'TopNav provides an app-level navigation bar across the top of the page. It holds branding, primary links, search, and user actions.',
+      },
     ],
   },
   {
     label: 'Form',
     items: [
-      {key: 'checkboxinput', name: 'CheckboxInput', desc: 'CheckboxInput renders a single checkbox with a label. It is used for boolean opt-in choices like terms acceptance or feature toggles.'},
-      {key: 'selector', name: 'Selector', desc: 'Selector lets users pick a single item from a dropdown list. It supports search, grouping, and custom option rendering.'},
-      {key: 'switch', name: 'Switch', desc: 'Switch toggles a setting between on and off states with immediate effect. It is used for preferences, feature flags, and real-time controls.'},
-      {key: 'textinput', name: 'TextInput', desc: 'TextInput is a single-line text field for short user input like names, emails, and search queries. It supports icons, prefixes, and validation.'},
-      {key: 'typeahead', name: 'Typeahead', desc: 'Typeahead provides an autocomplete search input that suggests results as the user types. It supports async data sources and custom rendering.'},
+      {
+        key: 'checkboxinput',
+        name: 'CheckboxInput',
+        desc: 'CheckboxInput renders a single checkbox with a label. It is used for boolean opt-in choices like terms acceptance or feature toggles.',
+      },
+      {
+        key: 'selector',
+        name: 'Selector',
+        desc: 'Selector lets users pick a single item from a dropdown list. It supports search, grouping, and custom option rendering.',
+      },
+      {
+        key: 'switch',
+        name: 'Switch',
+        desc: 'Switch toggles a setting between on and off states with immediate effect. It is used for preferences, feature flags, and real-time controls.',
+      },
+      {
+        key: 'textinput',
+        name: 'TextInput',
+        desc: 'TextInput is a single-line text field for short user input like names, emails, and search queries. It supports icons, prefixes, and validation.',
+      },
+      {
+        key: 'typeahead',
+        name: 'Typeahead',
+        desc: 'Typeahead provides an autocomplete search input that suggests results as the user types. It supports async data sources and custom rendering.',
+      },
     ],
   },
 ];
@@ -89,27 +212,28 @@ const COMPONENT_CATEGORIES = [
 
 export default function DocumentationOverviewPage() {
   return (
-    <XDSAppShell
-      variant="section"
+    <XDSLayout
       height="fill"
-      sideNav={
-        <XDSSideNav
-          header={<XDSSideNavHeading heading="Product Name" />}>
-          <XDSSideNavSection title="Navigation" isHeaderHidden>
-            <XDSSideNavItem label="Home" isSelected />
-            <XDSSideNavItem label="Getting started" />
-          </XDSSideNavSection>
-
-          {COMPONENT_CATEGORIES.map(category => (
-            <XDSSideNavSection key={category.label} title={category.label}>
-              {category.items.map(item => (
-                <XDSSideNavItem key={item.key} label={item.name} />
-              ))}
+      contentWidth={1200}
+      start={
+        <XDSLayoutPanel hasDivider padding={0}>
+          <XDSSideNav header={<XDSSideNavHeading heading="Product Name" />}>
+            <XDSSideNavSection title="Navigation" isHeaderHidden>
+              <XDSSideNavItem label="Home" isSelected />
+              <XDSSideNavItem label="Getting started" />
             </XDSSideNavSection>
-          ))}
-        </XDSSideNav>
-      }>
-      <XDSLayout contentWidth={1200} content={
+
+            {COMPONENT_CATEGORIES.map(category => (
+              <XDSSideNavSection key={category.label} title={category.label}>
+                {category.items.map(item => (
+                  <XDSSideNavItem key={item.key} label={item.name} />
+                ))}
+              </XDSSideNavSection>
+            ))}
+          </XDSSideNav>
+        </XDSLayoutPanel>
+      }
+      content={
         <XDSLayoutContent padding={8}>
           <XDSVStack gap={10}>
             <XDSCard variant="cyan" padding={10}>
@@ -147,8 +271,12 @@ export default function DocumentationOverviewPage() {
                         xstyle={styles.previewCard}
                       />
                       <XDSVStack gap={0.5}>
-                        <XDSText type="body" weight="bold">{item.name}</XDSText>
-                        <XDSText type="body" color="secondary">{item.desc}</XDSText>
+                        <XDSText type="body" weight="bold">
+                          {item.name}
+                        </XDSText>
+                        <XDSText type="body" color="secondary">
+                          {item.desc}
+                        </XDSText>
                       </XDSVStack>
                     </XDSVStack>
                   ))}
@@ -157,7 +285,7 @@ export default function DocumentationOverviewPage() {
             ))}
           </XDSVStack>
         </XDSLayoutContent>
-      } />
-    </XDSAppShell>
+      }
+    />
   );
 }

--- a/packages/cli/templates/pages/gallery-hero/page.tsx
+++ b/packages/cli/templates/pages/gallery-hero/page.tsx
@@ -3,15 +3,18 @@
 'use client';
 
 import * as stylex from '@stylexjs/stylex';
-import {XDSVStack, XDSHStack} from '@xds/core/Layout';
+import {
+  XDSVStack,
+  XDSHStack,
+  XDSLayout,
+  XDSLayoutContent,
+} from '@xds/core/Layout';
 import {XDSText} from '@xds/core/Text';
 import {XDSButton} from '@xds/core/Button';
 import {XDSIcon} from '@xds/core/Icon';
 import {XDSGrid} from '@xds/core/Grid';
 import {XDSAspectRatio} from '@xds/core/AspectRatio';
 import {XDSSection} from '@xds/core/Section';
-import {XDSAppShell} from '@xds/core/AppShell';
-import {XDSTopNav, XDSTopNavHeading, XDSTopNavItem} from '@xds/core/TopNav';
 import {ArrowRightIcon} from '@heroicons/react/20/solid';
 
 const IMAGES = [
@@ -57,71 +60,59 @@ const styles = stylex.create({
 
 export default function GalleryHero() {
   return (
-    <XDSAppShell
-      variant="surface"
-      topNav={
-        <XDSTopNav
-          label="Main navigation"
-          heading={<XDSTopNavHeading heading="GALLERY" />}
-          endContent={
-            <>
-              <XDSTopNavItem label="Products" href="#" />
-              <XDSTopNavItem label="Solutions" href="#" />
-              <XDSTopNavItem label="Pricing" href="#" />
-              <XDSTopNavItem label="About" href="#" />
-            </>
-          }
-        />
-      }
-      contentPadding={0}>
-      <XDSVStack gap={10}>
-        <XDSVStack gap={6} hAlign="center" xstyle={styles.topSpacing}>
-          <XDSVStack gap={3} hAlign="center">
-            <XDSText
-              type="display-2"
-              as="h1"
-              weight="bold"
-              textWrap="balance"
-              xstyle={[styles.textCenter, styles.titleResponsive]}>
-              Little joys, everywhere you go
-            </XDSText>
-            <XDSText
-              type="body"
-              color="secondary"
-              textWrap="balance"
-              xstyle={styles.textCenter}>
-              Sometimes all it takes is one small thing to turn your whole day
-              around.
-            </XDSText>
-          </XDSVStack>
-          <XDSHStack gap={3}>
-            <XDSButton
-              label="Get started"
-              variant="secondary"
-              endContent={
-                <XDSIcon icon={ArrowRightIcon} size="sm" color="inherit" />
-              }
-            />
-            <XDSButton label="Learn more" variant="ghost" />
-          </XDSHStack>
-        </XDSVStack>
-        <XDSSection variant="transparent" padding={6}>
-          <XDSGrid columns={3} gap={4}>
-            {IMAGES.map((image, i) => (
-              <XDSAspectRatio
-                key={i}
-                ratio={4 / 5}
-                xstyle={styles.galleryImageClip}>
-                <img
-                  {...stylex.props(styles.galleryImage)}
-                  src={image.src}
-                  alt={image.alt}
+    <XDSLayout
+      content={
+        <XDSLayoutContent padding={0}>
+          <XDSVStack gap={10}>
+            <XDSVStack gap={6} hAlign="center" xstyle={styles.topSpacing}>
+              <XDSVStack gap={3} hAlign="center">
+                <XDSText
+                  type="display-2"
+                  as="h1"
+                  weight="bold"
+                  textWrap="balance"
+                  xstyle={[styles.textCenter, styles.titleResponsive]}>
+                  Little joys, everywhere you go
+                </XDSText>
+                <XDSText
+                  type="body"
+                  color="secondary"
+                  textWrap="balance"
+                  xstyle={styles.textCenter}>
+                  Sometimes all it takes is one small thing to turn your whole
+                  day around.
+                </XDSText>
+              </XDSVStack>
+              <XDSHStack gap={3}>
+                <XDSButton
+                  label="Get started"
+                  variant="secondary"
+                  endContent={
+                    <XDSIcon icon={ArrowRightIcon} size="sm" color="inherit" />
+                  }
                 />
-              </XDSAspectRatio>
-            ))}
-          </XDSGrid>
-        </XDSSection>
-      </XDSVStack>
-    </XDSAppShell>
+                <XDSButton label="Learn more" variant="ghost" />
+              </XDSHStack>
+            </XDSVStack>
+            <XDSSection variant="transparent" padding={6}>
+              <XDSGrid columns={3} gap={4}>
+                {IMAGES.map((image, i) => (
+                  <XDSAspectRatio
+                    key={i}
+                    ratio={4 / 5}
+                    xstyle={styles.galleryImageClip}>
+                    <img
+                      {...stylex.props(styles.galleryImage)}
+                      src={image.src}
+                      alt={image.alt}
+                    />
+                  </XDSAspectRatio>
+                ))}
+              </XDSGrid>
+            </XDSSection>
+          </XDSVStack>
+        </XDSLayoutContent>
+      }
+    />
   );
 }

--- a/packages/cli/templates/pages/ide/page.tsx
+++ b/packages/cli/templates/pages/ide/page.tsx
@@ -4,8 +4,6 @@
 
 import {useState, useMemo} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {XDSAppShell} from '@xds/core/AppShell';
-import {XDSTopNav, XDSTopNavItem} from '@xds/core/TopNav';
 import {XDSSideNav, XDSSideNavItem, XDSSideNavSection} from '@xds/core/SideNav';
 
 import {XDSLayout, XDSLayoutContent, XDSLayoutPanel} from '@xds/core/Layout';
@@ -14,7 +12,6 @@ import {XDSText, XDSHeading} from '@xds/core/Text';
 import {XDSCodeBlock} from '@xds/core/CodeBlock';
 import {colorVars, spacingVars} from '@xds/core/theme/tokens.stylex';
 import {XDSStack} from '@xds/core/Layout';
-import {XDSOverflowList} from '@xds/core/OverflowList';
 import {XDSTabList, XDSTab} from '@xds/core/TabList';
 import {
   XDSSegmentedControl,
@@ -32,8 +29,6 @@ import {
   DocumentTextIcon,
   CodeBracketIcon,
   MagnifyingGlassIcon,
-  PlayIcon,
-  StopIcon,
   CommandLineIcon,
   ExclamationTriangleIcon,
   InformationCircleIcon,
@@ -251,318 +246,299 @@ export default function ResizableWorkspacePage() {
   });
 
   return (
-    <XDSAppShell
-      variant="elevated"
+    <XDSLayout
       height="fill"
-      topNav={
-        <XDSTopNav
-          heading="Acme"
-          startContent={
-            <>
-              <XDSTopNavItem label="File" href="#" />
-              <XDSTopNavItem label="Edit" href="#" />
-              <XDSTopNavItem label="View" href="#" />
-              <XDSTopNavItem label="Run" href="#" />
-              <XDSTopNavItem label="Help" href="#" />
-            </>
-          }
-          endContent={
-            <XDSOverflowList gap={2}>
-              <XDSButton
-                label="Run"
-                icon={<XDSIcon icon={PlayIcon} size="sm" />}
-                size="sm"
+      start={
+        <XDSLayoutPanel hasDivider={false} padding={0}>
+          <XDSSideNav
+            collapsible={{defaultIsCollapsed: true}}
+            resizable
+            xstyle={styles.hideSideNav}>
+            <XDSSideNavSection title="Navigation" isHeaderHidden>
+              <XDSSideNavItem
+                label="Home"
+                icon={HomeIcon}
+                selectedIcon={HomeIconSolid}
+                isSelected={activeNavItem === 'Home'}
+                onClick={() => setActiveNavItem('Home')}
               />
-              <XDSButton
-                label="Stop"
-                icon={<XDSIcon icon={StopIcon} size="sm" />}
-                size="sm"
-                variant="secondary"
+              <XDSSideNavItem
+                label="Explorer"
+                icon={FolderOpenIcon}
+                selectedIcon={FolderOpenSolid}
+                isSelected={activeNavItem === 'Explorer'}
+                onClick={() => setActiveNavItem('Explorer')}
               />
-            </XDSOverflowList>
-          }
-        />
+              <XDSSideNavItem
+                label="Search"
+                icon={MagnifyingGlassIcon}
+                selectedIcon={MagnifyingGlassSolid}
+                isSelected={activeNavItem === 'Search'}
+                onClick={() => setActiveNavItem('Search')}
+              />
+              <XDSSideNavItem
+                label="Source Control"
+                icon={CodeBracketIcon}
+                isSelected={activeNavItem === 'Source Control'}
+                onClick={() => setActiveNavItem('Source Control')}
+              />
+              <XDSSideNavItem
+                label="Extensions"
+                icon={PuzzlePieceIcon}
+                selectedIcon={PuzzlePieceSolid}
+                isSelected={activeNavItem === 'Extensions'}
+                onClick={() => setActiveNavItem('Extensions')}
+              />
+            </XDSSideNavSection>
+          </XDSSideNav>
+        </XDSLayoutPanel>
       }
-      sideNav={
-        <XDSSideNav
-          collapsible={{defaultIsCollapsed: true}}
-          resizable
-          xstyle={styles.hideSideNav}>
-          <XDSSideNavSection title="Navigation" isHeaderHidden>
-            <XDSSideNavItem
-              label="Home"
-              icon={HomeIcon}
-              selectedIcon={HomeIconSolid}
-              isSelected={activeNavItem === 'Home'}
-              onClick={() => setActiveNavItem('Home')}
-            />
-            <XDSSideNavItem
-              label="Explorer"
-              icon={FolderOpenIcon}
-              selectedIcon={FolderOpenSolid}
-              isSelected={activeNavItem === 'Explorer'}
-              onClick={() => setActiveNavItem('Explorer')}
-            />
-            <XDSSideNavItem
-              label="Search"
-              icon={MagnifyingGlassIcon}
-              selectedIcon={MagnifyingGlassSolid}
-              isSelected={activeNavItem === 'Search'}
-              onClick={() => setActiveNavItem('Search')}
-            />
-            <XDSSideNavItem
-              label="Source Control"
-              icon={CodeBracketIcon}
-              isSelected={activeNavItem === 'Source Control'}
-              onClick={() => setActiveNavItem('Source Control')}
-            />
-            <XDSSideNavItem
-              label="Extensions"
-              icon={PuzzlePieceIcon}
-              selectedIcon={PuzzlePieceSolid}
-              isSelected={activeNavItem === 'Extensions'}
-              onClick={() => setActiveNavItem('Extensions')}
-            />
-          </XDSSideNavSection>
-        </XDSSideNav>
-      }>
-      <XDSLayout
-        height="fill"
-        start={
-          <div {...stylex.props(styles.hideOnMobile)}>
-            {!startPanel.isCollapsed && (
-              <XDSLayoutPanel
-                width={startPanel.size}
-                hasDivider={false}
-                padding={0}>
-                <XDSStack
-                  direction="vertical"
-                  xstyle={styles.fileExplorer}
-                  gap={2}>
-                  <XDSTextInput
-                    label="Search files"
-                    isLabelHidden
-                    value=""
-                    placeholder="Search"
-                    size="md"
-                    startIcon={MagnifyingGlassIcon}
-                  />
-                  <XDSTreeList items={fileTree} density="compact" />
-                </XDSStack>
-              </XDSLayoutPanel>
-            )}
-            <XDSResizeHandle
-              direction="horizontal"
-              hasDivider
-              isAlwaysVisible={false}
-              resizable={startPanel.props}
-              label="Resize file explorer"
-            />
-          </div>
-        }
-        content={
-          <XDSLayoutContent padding={0}>
-            <XDSLayout
-              height="fill"
-              content={
-                <XDSLayoutContent padding={0}>
-                  <XDSStack direction="vertical" xstyle={styles.contentFill}>
-                    <div {...stylex.props(styles.editorArea)}>
-                      <XDSCodeBlock
-                        code={EDITOR_CODE}
-                        language="typescript"
-                        hasLineNumbers
-                        highlightLines={[21]}
-                        hasCopyButton={false}
-                        size="sm"
-                        style={{
-                          width: '100%',
-                          height: '100%',
-                          borderWidth: 0,
-                          borderRadius: 0,
-                        }}
-                      />
-                    </div>
-                    <XDSResizeHandle
+      content={
+        <XDSLayoutContent padding={0}>
+          <XDSLayout
+            height="fill"
+            start={
+              <div {...stylex.props(styles.hideOnMobile)}>
+                {!startPanel.isCollapsed && (
+                  <XDSLayoutPanel
+                    width={startPanel.size}
+                    hasDivider={false}
+                    padding={0}>
+                    <XDSStack
                       direction="vertical"
-                      hasDivider
-                      isReversed
-                      isAlwaysVisible={false}
-                      resizable={bottomPanel.props}
-                      label="Resize terminal"
-                    />
-                    {!bottomPanel.isCollapsed && (
-                      <div
-                        style={{
-                          height: bottomPanel.size,
-                          flexShrink: 0,
-                          overflow: 'hidden',
-                        }}>
-                        <XDSStack
-                          direction="vertical"
-                          xstyle={styles.contentFill}>
-                          <XDSTabList
-                            value={activeTermTab}
-                            onChange={val => setActiveTermTab(val)}
+                      xstyle={styles.fileExplorer}
+                      gap={2}>
+                      <XDSTextInput
+                        label="Search files"
+                        isLabelHidden
+                        value=""
+                        placeholder="Search"
+                        size="md"
+                        startIcon={MagnifyingGlassIcon}
+                      />
+                      <XDSTreeList items={fileTree} density="compact" />
+                    </XDSStack>
+                  </XDSLayoutPanel>
+                )}
+                <XDSResizeHandle
+                  direction="horizontal"
+                  hasDivider
+                  isAlwaysVisible={false}
+                  resizable={startPanel.props}
+                  label="Resize file explorer"
+                />
+              </div>
+            }
+            content={
+              <XDSLayoutContent padding={0}>
+                <XDSLayout
+                  height="fill"
+                  content={
+                    <XDSLayoutContent padding={0}>
+                      <XDSStack
+                        direction="vertical"
+                        xstyle={styles.contentFill}>
+                        <div {...stylex.props(styles.editorArea)}>
+                          <XDSCodeBlock
+                            code={EDITOR_CODE}
+                            language="typescript"
+                            hasLineNumbers
+                            highlightLines={[21]}
+                            hasCopyButton={false}
                             size="sm"
-                            hasDivider={false}
-                            xstyle={styles.tabListPadding}>
-                            <XDSTab
-                              label="Terminal"
-                              value="terminal"
-                              icon={
-                                <XDSIcon icon={CommandLineIcon} size="sm" />
-                              }
-                            />
-                            <XDSTab
-                              label="Problems"
-                              value="problems"
-                              icon={
-                                <XDSIcon
-                                  icon={ExclamationTriangleIcon}
-                                  size="sm"
-                                />
-                              }
-                            />
-                            <XDSTab
-                              label="Output"
-                              value="output"
-                              icon={
-                                <XDSIcon
-                                  icon={InformationCircleIcon}
-                                  size="sm"
-                                />
-                              }
-                            />
-                            <XDSTab
-                              label="Debug"
-                              value="debug"
-                              icon={<XDSIcon icon={BugAntIcon} size="sm" />}
-                            />
-                          </XDSTabList>
-                          <div {...stylex.props(styles.terminalWrapper)}>
-                            <XDSCodeBlock
-                              code={TERMINAL_OUTPUT}
-                              language="bash"
-                              hasCopyButton={false}
-                              size="sm"
-                              style={{
-                                width: '100%',
-                                height: '100%',
-                                borderWidth: 0,
-                                borderRadius: 0,
-                              }}
-                            />
-                          </div>
-                        </XDSStack>
-                      </div>
-                    )}
-                  </XDSStack>
-                </XDSLayoutContent>
-              }
-              end={
-                <div {...stylex.props(styles.hideOnMobile)}>
-                  <XDSResizeHandle
-                    direction="horizontal"
-                    hasDivider
-                    isReversed
-                    isAlwaysVisible={false}
-                    resizable={endPanel.props}
-                    label="Resize properties panel"
-                  />
-                  {!endPanel.isCollapsed && (
-                    <XDSLayoutPanel
-                      width={endPanel.size}
-                      hasDivider={false}
-                      padding={4}>
-                      <XDSStack direction="vertical" gap={3}>
-                        <XDSSegmentedControl
-                          label="Properties panel sections"
-                          value={activePropertiesTab}
-                          onChange={setActivePropertiesTab}
-                          size="sm"
-                          layout="fill">
-                          <XDSSegmentedControlItem
-                            label="Properties"
-                            value="properties"
+                            style={{
+                              width: '100%',
+                              height: '100%',
+                              borderWidth: 0,
+                              borderRadius: 0,
+                            }}
                           />
-                          <XDSSegmentedControlItem
-                            label="History"
-                            value="history"
-                          />
-                        </XDSSegmentedControl>
-                        {activePropertiesTab === 'properties' ? (
-                          <>
-                            <XDSStack direction="vertical" gap={1}>
-                              <XDSHeading level={3}>{activeFile}</XDSHeading>
-                              <XDSText color="secondary" type="supporting">
-                                src/components/{activeFile}
-                              </XDSText>
-                            </XDSStack>
-                            <XDSMetadataList xstyle={styles.metadataCompact}>
-                              {PROPERTIES.map(prop => (
-                                <XDSMetadataListItem
-                                  key={prop.label}
-                                  label={prop.label}>
-                                  {prop.value}
-                                </XDSMetadataListItem>
-                              ))}
-                            </XDSMetadataList>
-                            <XDSStack direction="vertical" gap={2}>
-                              <XDSStack direction="vertical" gap={2}>
-                                <XDSButton
-                                  label="Format Document"
-                                  size="md"
-                                  variant="secondary"
-                                />
-                                <XDSButton
-                                  label="Go to Definition"
-                                  size="md"
-                                  variant="secondary"
-                                />
-                                <XDSButton
-                                  label="Find References"
-                                  size="md"
-                                  variant="secondary"
-                                />
-                              </XDSStack>
-                            </XDSStack>
-                          </>
-                        ) : (
-                          <XDSStack direction="vertical" gap={1}>
-                            <XDSList>
-                              {HISTORY_ITEMS.map(item => (
-                                <XDSListItem
-                                  key={item.label}
-                                  label={item.label}
-                                  endContent={
-                                    <XDSText
-                                      type="supporting"
-                                      color="secondary">
-                                      {item.time}
-                                    </XDSText>
+                        </div>
+                        <XDSResizeHandle
+                          direction="vertical"
+                          hasDivider
+                          isReversed
+                          isAlwaysVisible={false}
+                          resizable={bottomPanel.props}
+                          label="Resize terminal"
+                        />
+                        {!bottomPanel.isCollapsed && (
+                          <div
+                            style={{
+                              height: bottomPanel.size,
+                              flexShrink: 0,
+                              overflow: 'hidden',
+                            }}>
+                            <XDSStack
+                              direction="vertical"
+                              xstyle={styles.contentFill}>
+                              <XDSTabList
+                                value={activeTermTab}
+                                onChange={val => setActiveTermTab(val)}
+                                size="sm"
+                                hasDivider={false}
+                                xstyle={styles.tabListPadding}>
+                                <XDSTab
+                                  label="Terminal"
+                                  value="terminal"
+                                  icon={
+                                    <XDSIcon icon={CommandLineIcon} size="sm" />
                                   }
-                                  startContent={
-                                    <span
-                                      {...stylex.props(
-                                        styles.historyTimelineDot,
-                                      )}
+                                />
+                                <XDSTab
+                                  label="Problems"
+                                  value="problems"
+                                  icon={
+                                    <XDSIcon
+                                      icon={ExclamationTriangleIcon}
+                                      size="sm"
                                     />
                                   }
                                 />
-                              ))}
-                            </XDSList>
-                          </XDSStack>
+                                <XDSTab
+                                  label="Output"
+                                  value="output"
+                                  icon={
+                                    <XDSIcon
+                                      icon={InformationCircleIcon}
+                                      size="sm"
+                                    />
+                                  }
+                                />
+                                <XDSTab
+                                  label="Debug"
+                                  value="debug"
+                                  icon={<XDSIcon icon={BugAntIcon} size="sm" />}
+                                />
+                              </XDSTabList>
+                              <div {...stylex.props(styles.terminalWrapper)}>
+                                <XDSCodeBlock
+                                  code={TERMINAL_OUTPUT}
+                                  language="bash"
+                                  hasCopyButton={false}
+                                  size="sm"
+                                  style={{
+                                    width: '100%',
+                                    height: '100%',
+                                    borderWidth: 0,
+                                    borderRadius: 0,
+                                  }}
+                                />
+                              </div>
+                            </XDSStack>
+                          </div>
                         )}
                       </XDSStack>
-                    </XDSLayoutPanel>
-                  )}
-                </div>
-              }
-            />
-          </XDSLayoutContent>
-        }
-      />
-    </XDSAppShell>
+                    </XDSLayoutContent>
+                  }
+                  end={
+                    <div {...stylex.props(styles.hideOnMobile)}>
+                      <XDSResizeHandle
+                        direction="horizontal"
+                        hasDivider
+                        isReversed
+                        isAlwaysVisible={false}
+                        resizable={endPanel.props}
+                        label="Resize properties panel"
+                      />
+                      {!endPanel.isCollapsed && (
+                        <XDSLayoutPanel
+                          width={endPanel.size}
+                          hasDivider={false}
+                          padding={4}>
+                          <XDSStack direction="vertical" gap={3}>
+                            <XDSSegmentedControl
+                              label="Properties panel sections"
+                              value={activePropertiesTab}
+                              onChange={setActivePropertiesTab}
+                              size="sm"
+                              layout="fill">
+                              <XDSSegmentedControlItem
+                                label="Properties"
+                                value="properties"
+                              />
+                              <XDSSegmentedControlItem
+                                label="History"
+                                value="history"
+                              />
+                            </XDSSegmentedControl>
+                            {activePropertiesTab === 'properties' ? (
+                              <>
+                                <XDSStack direction="vertical" gap={1}>
+                                  <XDSHeading level={3}>
+                                    {activeFile}
+                                  </XDSHeading>
+                                  <XDSText color="secondary" type="supporting">
+                                    src/components/{activeFile}
+                                  </XDSText>
+                                </XDSStack>
+                                <XDSMetadataList
+                                  xstyle={styles.metadataCompact}>
+                                  {PROPERTIES.map(prop => (
+                                    <XDSMetadataListItem
+                                      key={prop.label}
+                                      label={prop.label}>
+                                      {prop.value}
+                                    </XDSMetadataListItem>
+                                  ))}
+                                </XDSMetadataList>
+                                <XDSStack direction="vertical" gap={2}>
+                                  <XDSStack direction="vertical" gap={2}>
+                                    <XDSButton
+                                      label="Format Document"
+                                      size="md"
+                                      variant="secondary"
+                                    />
+                                    <XDSButton
+                                      label="Go to Definition"
+                                      size="md"
+                                      variant="secondary"
+                                    />
+                                    <XDSButton
+                                      label="Find References"
+                                      size="md"
+                                      variant="secondary"
+                                    />
+                                  </XDSStack>
+                                </XDSStack>
+                              </>
+                            ) : (
+                              <XDSStack direction="vertical" gap={1}>
+                                <XDSList>
+                                  {HISTORY_ITEMS.map(item => (
+                                    <XDSListItem
+                                      key={item.label}
+                                      label={item.label}
+                                      endContent={
+                                        <XDSText
+                                          type="supporting"
+                                          color="secondary">
+                                          {item.time}
+                                        </XDSText>
+                                      }
+                                      startContent={
+                                        <span
+                                          {...stylex.props(
+                                            styles.historyTimelineDot,
+                                          )}
+                                        />
+                                      }
+                                    />
+                                  ))}
+                                </XDSList>
+                              </XDSStack>
+                            )}
+                          </XDSStack>
+                        </XDSLayoutPanel>
+                      )}
+                    </div>
+                  }
+                />
+              </XDSLayoutContent>
+            }
+          />
+        </XDSLayoutContent>
+      }
+    />
   );
 }

--- a/packages/cli/templates/pages/library/page.tsx
+++ b/packages/cli/templates/pages/library/page.tsx
@@ -15,28 +15,8 @@ import {XDSGrid} from '@xds/core/Grid';
 import {XDSHStack, XDSVStack, XDSStackItem} from '@xds/core/Stack';
 import {XDSDropdownMenu} from '@xds/core/DropdownMenu';
 import {XDSOverflowList} from '@xds/core/OverflowList';
-import {XDSAppShell} from '@xds/core/AppShell';
-import {
-  XDSSideNav,
-  XDSSideNavHeading,
-  XDSSideNavSection,
-  XDSSideNavItem,
-} from '@xds/core/SideNav';
-import {XDSNavIcon} from '@xds/core/NavIcon';
-import {XDSIcon} from '@xds/core/Icon';
 import {XDSCenter} from '@xds/core/Center';
-import {
-  HomeIcon,
-  BookOpenIcon,
-  CubeIcon,
-  Squares2X2Icon,
-  WrenchScrewdriverIcon,
-  MagnifyingGlassIcon,
-} from '@heroicons/react/24/outline';
-import {
-  HomeIcon as HomeIconSolid,
-  BookOpenIcon as BookOpenIconSolid,
-} from '@heroicons/react/24/solid';
+import {MagnifyingGlassIcon} from '@heroicons/react/24/outline';
 
 interface LibraryItem {
   id: string;
@@ -360,47 +340,6 @@ const styles = stylex.create({
 // Side Nav
 // =============================================================================
 
-function LibraryNav() {
-  return (
-    <XDSSideNav
-      header={
-        <XDSSideNavHeading
-          icon={
-            <XDSNavIcon
-              icon={<XDSIcon icon={CubeIcon} size="sm" color="inherit" />}
-            />
-          }
-          heading="My App"
-          headingHref="#"
-        />
-      }>
-      <XDSSideNavSection title="Main">
-        <XDSSideNavItem
-          label="Home"
-          href="#"
-          icon={HomeIcon}
-          selectedIcon={HomeIconSolid}
-        />
-        <XDSSideNavItem
-          label="Library"
-          href="#"
-          icon={BookOpenIcon}
-          selectedIcon={BookOpenIconSolid}
-          isSelected
-        />
-      </XDSSideNavSection>
-      <XDSSideNavSection title="Browse">
-        <XDSSideNavItem label="Components" href="#" icon={Squares2X2Icon} />
-        <XDSSideNavItem
-          label="Templates"
-          href="#"
-          icon={WrenchScrewdriverIcon}
-        />
-      </XDSSideNavSection>
-    </XDSSideNav>
-  );
-}
-
 function LibraryCard({item}: {item: LibraryItem}) {
   return (
     <XDSCard padding={0}>
@@ -489,96 +428,94 @@ export default function LibraryPage() {
   }, [activeTab, filtered]);
 
   return (
-    <XDSAppShell sideNav={<LibraryNav />} contentPadding={0}>
-      <XDSLayout
-        header={
-          <XDSLayoutHeader hasDivider padding={6}>
-            <XDSHeading level={1}>Library</XDSHeading>
-          </XDSLayoutHeader>
-        }
-        content={
-          <XDSLayoutContent padding={6}>
-            <XDSVStack gap={6}>
-              <XDSVStack gap={4}>
-                <XDSTextInput
-                  label="Search"
-                  isLabelHidden
-                  placeholder="Search..."
-                  value={search}
-                  onChange={setSearch}
-                  startIcon={MagnifyingGlassIcon}
-                  size="lg"
+    <XDSLayout
+      header={
+        <XDSLayoutHeader hasDivider padding={6}>
+          <XDSHeading level={1}>Library</XDSHeading>
+        </XDSLayoutHeader>
+      }
+      content={
+        <XDSLayoutContent padding={6}>
+          <XDSVStack gap={6}>
+            <XDSVStack gap={4}>
+              <XDSTextInput
+                label="Search"
+                isLabelHidden
+                placeholder="Search..."
+                value={search}
+                onChange={setSearch}
+                startIcon={MagnifyingGlassIcon}
+                size="lg"
+              />
+              <XDSHStack vAlign="center" gap={4}>
+                <XDSStackItem size="fill">
+                  <XDSVStack>
+                    <XDSToggleButtonGroup
+                      label="Filter by category"
+                      value={activeTab}
+                      onChange={v => setActiveTab(v ?? 'All')}>
+                      <XDSOverflowList
+                        gap={1}
+                        behavior="observeParent"
+                        overflowRenderer={overflowItems => (
+                          <XDSDropdownMenu
+                            button={{
+                              label: `+${overflowItems.length}`,
+                              variant: 'ghost',
+                              size: 'lg',
+                            }}
+                            items={overflowItems.map(({index}) => ({
+                              label: CATEGORIES[index],
+                              onClick: () => setActiveTab(CATEGORIES[index]),
+                            }))}
+                          />
+                        )}>
+                        {CATEGORIES.map(cat => (
+                          <XDSToggleButton
+                            key={cat}
+                            label={cat}
+                            value={cat}
+                            size="lg"
+                          />
+                        ))}
+                      </XDSOverflowList>
+                    </XDSToggleButtonGroup>
+                  </XDSVStack>
+                </XDSStackItem>
+                <XDSDropdownMenu
+                  button={{label: sortOrder, size: 'lg'}}
+                  items={[
+                    {label: 'A-Z', onClick: () => setSortOrder('A-Z')},
+                    {label: 'Z-A', onClick: () => setSortOrder('Z-A')},
+                    {label: 'Newest', onClick: () => setSortOrder('Newest')},
+                  ]}
                 />
-                <XDSHStack vAlign="center" gap={4}>
-                  <XDSStackItem size="fill">
-                    <XDSVStack>
-                      <XDSToggleButtonGroup
-                        label="Filter by category"
-                        value={activeTab}
-                        onChange={v => setActiveTab(v ?? 'All')}>
-                        <XDSOverflowList
-                          gap={1}
-                          behavior="observeParent"
-                          overflowRenderer={overflowItems => (
-                            <XDSDropdownMenu
-                              button={{
-                                label: `+${overflowItems.length}`,
-                                variant: 'ghost',
-                                size: 'lg',
-                              }}
-                              items={overflowItems.map(({index}) => ({
-                                label: CATEGORIES[index],
-                                onClick: () => setActiveTab(CATEGORIES[index]),
-                              }))}
-                            />
-                          )}>
-                          {CATEGORIES.map(cat => (
-                            <XDSToggleButton
-                              key={cat}
-                              label={cat}
-                              value={cat}
-                              size="lg"
-                            />
-                          ))}
-                        </XDSOverflowList>
-                      </XDSToggleButtonGroup>
-                    </XDSVStack>
-                  </XDSStackItem>
-                  <XDSDropdownMenu
-                    button={{label: sortOrder, size: 'lg'}}
-                    items={[
-                      {label: 'A-Z', onClick: () => setSortOrder('A-Z')},
-                      {label: 'Z-A', onClick: () => setSortOrder('Z-A')},
-                      {label: 'Newest', onClick: () => setSortOrder('Newest')},
-                    ]}
-                  />
-                </XDSHStack>
-              </XDSVStack>
-
-              {filtered.length === 0 ? (
-                <XDSCenter>
-                  <XDSText type="supporting" color="secondary">
-                    No results found.
-                  </XDSText>
-                </XDSCenter>
-              ) : (
-                <XDSVStack gap={6}>
-                  {(
-                    groupedSections ?? [{category: activeTab, items: filtered}]
-                  ).flatMap(section => [
-                    <XDSDivider key={`d-${section.category}`} />,
-                    <LibrarySection
-                      key={section.category}
-                      category={section.category}
-                      items={section.items}
-                    />,
-                  ])}
-                </XDSVStack>
-              )}
+              </XDSHStack>
             </XDSVStack>
-          </XDSLayoutContent>
-        }
-      />
-    </XDSAppShell>
+
+            {filtered.length === 0 ? (
+              <XDSCenter>
+                <XDSText type="supporting" color="secondary">
+                  No results found.
+                </XDSText>
+              </XDSCenter>
+            ) : (
+              <XDSVStack gap={6}>
+                {(
+                  groupedSections ?? [{category: activeTab, items: filtered}]
+                ).flatMap(section => [
+                  <XDSDivider key={`d-${section.category}`} />,
+                  <LibrarySection
+                    key={section.category}
+                    category={section.category}
+                    items={section.items}
+                  />,
+                ])}
+              </XDSVStack>
+            )}
+          </XDSVStack>
+        </XDSLayoutContent>
+      }
+    />
   );
 }

--- a/packages/cli/templates/pages/mixed-gallery/page.tsx
+++ b/packages/cli/templates/pages/mixed-gallery/page.tsx
@@ -2,8 +2,7 @@
 
 'use client';
 
-import {XDSAppShell} from '@xds/core/AppShell';
-import {XDSVStack} from '@xds/core/Layout';
+import {XDSVStack, XDSLayout, XDSLayoutContent} from '@xds/core/Layout';
 import {XDSCenter} from '@xds/core/Center';
 import {XDSText, XDSHeading} from '@xds/core/Text';
 import {XDSSection} from '@xds/core/Section';
@@ -92,11 +91,7 @@ const IMAGES: GalleryImage[] = [
 function GalleryCard({image}: {image: GalleryImage}) {
   return (
     <div {...stylex.props(styles.card)}>
-      <img
-        src={image.src}
-        alt={image.title}
-        {...stylex.props(styles.img)}
-      />
+      <img src={image.src} alt={image.title} {...stylex.props(styles.img)} />
     </div>
   );
 }
@@ -105,53 +100,62 @@ function GalleryCard({image}: {image: GalleryImage}) {
 
 export default function MixedGalleryTemplate() {
   return (
-    <XDSAppShell height="auto" contentPadding={6} variant="surface">
-      <XDSCenter axis="horizontal">
-        <XDSSection variant="transparent" maxWidth={1400} width="100%" padding={0}>
-          <XDSVStack gap={6}>
-            {/* Header — capped with XDSSection maxWidth */}
-            <XDSCenter axis="horizontal">
-              <XDSSection variant="transparent" maxWidth={680}>
-                <XDSVStack gap={2} xstyle={styles.textCenter}>
-                  <XDSHeading level={1}>
-                    Make every day a little more delightful, one detail at a
-                    time.
-                  </XDSHeading>
-                  <XDSText type="body">
-                    We believe the smallest details are the ones that matter
-                    most. That&apos;s what turns an ordinary day into something
-                    worth remembering.
-                  </XDSText>
-                </XDSVStack>
-              </XDSSection>
-            </XDSCenter>
+    <XDSLayout
+      height="auto"
+      content={
+        <XDSLayoutContent padding={6}>
+          <XDSCenter axis="horizontal">
+            <XDSSection
+              variant="transparent"
+              maxWidth={1400}
+              width="100%"
+              padding={0}>
+              <XDSVStack gap={6}>
+                {/* Header — capped with XDSSection maxWidth */}
+                <XDSCenter axis="horizontal">
+                  <XDSSection variant="transparent" maxWidth={680}>
+                    <XDSVStack gap={2} xstyle={styles.textCenter}>
+                      <XDSHeading level={1}>
+                        Make every day a little more delightful, one detail at a
+                        time.
+                      </XDSHeading>
+                      <XDSText type="body">
+                        We believe the smallest details are the ones that matter
+                        most. That&apos;s what turns an ordinary day into
+                        something worth remembering.
+                      </XDSText>
+                    </XDSVStack>
+                  </XDSSection>
+                </XDSCenter>
 
-            {/* Featured masonry — hero + sidebar + bottom row */}
-            <XDSGrid columns={3} rowHeight={90} gap={3}>
-              {/* Hero — 2 cols × 5 rows */}
-              <XDSGridSpan columns={2} rows={5}>
-                <GalleryCard image={IMAGES[0]} />
-              </XDSGridSpan>
+                {/* Featured masonry — hero + sidebar + bottom row */}
+                <XDSGrid columns={3} rowHeight={90} gap={3}>
+                  {/* Hero — 2 cols × 5 rows */}
+                  <XDSGridSpan columns={2} rows={5}>
+                    <GalleryCard image={IMAGES[0]} />
+                  </XDSGridSpan>
 
-              {/* Sidebar — full height */}
-              <XDSGridSpan rows={5}>
-                <GalleryCard image={IMAGES[2]} />
-              </XDSGridSpan>
+                  {/* Sidebar — full height */}
+                  <XDSGridSpan rows={5}>
+                    <GalleryCard image={IMAGES[2]} />
+                  </XDSGridSpan>
 
-              {/* Bottom row */}
-              <XDSGridSpan rows={3}>
-                <GalleryCard image={IMAGES[3]} />
-              </XDSGridSpan>
-              <XDSGridSpan rows={3}>
-                <GalleryCard image={IMAGES[4]} />
-              </XDSGridSpan>
-              <XDSGridSpan rows={3}>
-                <GalleryCard image={IMAGES[1]} />
-              </XDSGridSpan>
-            </XDSGrid>
-          </XDSVStack>
-        </XDSSection>
-      </XDSCenter>
-    </XDSAppShell>
+                  {/* Bottom row */}
+                  <XDSGridSpan rows={3}>
+                    <GalleryCard image={IMAGES[3]} />
+                  </XDSGridSpan>
+                  <XDSGridSpan rows={3}>
+                    <GalleryCard image={IMAGES[4]} />
+                  </XDSGridSpan>
+                  <XDSGridSpan rows={3}>
+                    <GalleryCard image={IMAGES[1]} />
+                  </XDSGridSpan>
+                </XDSGrid>
+              </XDSVStack>
+            </XDSSection>
+          </XDSCenter>
+        </XDSLayoutContent>
+      }
+    />
   );
 }

--- a/packages/cli/templates/pages/payment-form/page.tsx
+++ b/packages/cli/templates/pages/payment-form/page.tsx
@@ -4,7 +4,14 @@
 
 import {useState} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {XDSVStack, XDSHStack, XDSStack, XDSStackItem} from '@xds/core/Layout';
+import {
+  XDSVStack,
+  XDSHStack,
+  XDSStack,
+  XDSStackItem,
+  XDSLayout,
+  XDSLayoutContent,
+} from '@xds/core/Layout';
 import {XDSGrid} from '@xds/core/Grid';
 import {XDSButton} from '@xds/core/Button';
 import {XDSText} from '@xds/core/Text';
@@ -23,7 +30,6 @@ import {XDSCollapsible} from '@xds/core/Collapsible';
 import {XDSBadge} from '@xds/core/Badge';
 import {XDSNumberInput} from '@xds/core/NumberInput';
 import {useMediaQuery} from '@xds/core/hooks';
-import {XDSAppShell} from '@xds/core/AppShell';
 import {XDSSection} from '@xds/core/Section';
 import {XDSCenter} from '@xds/core/Center';
 import {XDSAspectRatio} from '@xds/core/AspectRatio';
@@ -250,759 +256,776 @@ export default function PaymentFormPage() {
     : {};
 
   return (
-    <XDSAppShell height="auto" contentPadding={0} variant="surface">
-      <XDSCenter axis="horizontal">
-        <XDSSection
-          variant="transparent"
-          maxWidth={1100}
-          width="100%"
-          padding={6}>
-          <XDSVStack gap={5}>
-            {/* Page header */}
-            <XDSVStack gap={2} {...stylex.props(styles.headerArea)}>
-              <XDSText type="display-1" as="h1">
-                Payment Request
-              </XDSText>
-              <XDSText type="body" color="secondary">
-                Review your order and complete your purchase. All transactions
-                are secured with 256-bit SSL encryption.
-              </XDSText>
-              <div {...stylex.props(styles.dividerWrap)}>
-                <XDSDivider />
-              </div>
-            </XDSVStack>
+    <XDSLayout
+      height="auto"
+      content={
+        <XDSLayoutContent padding={0}>
+          <XDSCenter axis="horizontal">
+            <XDSSection
+              variant="transparent"
+              maxWidth={1100}
+              width="100%"
+              padding={6}>
+              <XDSVStack gap={5}>
+                {/* Page header */}
+                <XDSVStack gap={2} {...stylex.props(styles.headerArea)}>
+                  <XDSText type="display-1" as="h1">
+                    Payment Request
+                  </XDSText>
+                  <XDSText type="body" color="secondary">
+                    Review your order and complete your purchase. All
+                    transactions are secured with 256-bit SSL encryption.
+                  </XDSText>
+                  <div {...stylex.props(styles.dividerWrap)}>
+                    <XDSDivider />
+                  </div>
+                </XDSVStack>
 
-            <XDSStack
-              direction={isMobile ? 'vertical' : 'horizontal'}
-              gap={8}
-              vAlign="start">
-              <XDSStackItem
-                size="fill"
-                style={{flexBasis: isMobile ? undefined : 0}}>
-                <XDSVStack gap={8}>
-                  {/* Sign in */}
-                  <XDSVStack gap={1}>
-                    <XDSHStack gap={2} hAlign="between" vAlign="center">
-                      <XDSText type="large" weight="bold">
-                        Sign in to check out
-                      </XDSText>
-                      <XDSButton
-                        label="Sign In"
-                        variant="secondary"
-                        size="sm"
-                        onClick={() => {}}
-                      />
-                    </XDSHStack>
-                    <XDSText type="supporting" color="secondary">
-                      Sign in to track your order and save your information for
-                      faster checkout.
-                    </XDSText>
-                  </XDSVStack>
-
-                  {/* Contact Information */}
-                  <XDSVStack gap={3}>
-                    <XDSText type="large" weight="bold">
-                      Contact Information
-                    </XDSText>
-                    <XDSTextInput
-                      size="lg"
-                      label="Email"
-                      placeholder="you@example.com"
-                      value={email}
-                      onChange={setEmail}
-                      status={
-                        errors.email
-                          ? {type: 'error', message: errors.email}
-                          : undefined
-                      }
-                    />
-                    <XDSCheckboxInput
-                      label="Email me with news and offers"
-                      value={emailOffers}
-                      onChange={setEmailOffers}
-                    />
-                  </XDSVStack>
-
-                  {/* Shipping Information */}
-                  <XDSVStack gap={3}>
-                    <XDSText type="large" weight="bold">
-                      Shipping Information
-                    </XDSText>
-                    <XDSGrid columns={2} gap={3}>
-                      <XDSTextInput
-                        size="lg"
-                        label="First Name"
-                        placeholder="John"
-                        value={firstName}
-                        onChange={setFirstName}
-                        status={
-                          errors.firstName
-                            ? {type: 'error', message: errors.firstName}
-                            : undefined
-                        }
-                      />
-                      <XDSTextInput
-                        size="lg"
-                        label="Last Name"
-                        placeholder="Doe"
-                        value={lastName}
-                        onChange={setLastName}
-                        status={
-                          errors.lastName
-                            ? {type: 'error', message: errors.lastName}
-                            : undefined
-                        }
-                      />
-                    </XDSGrid>
-                    <XDSTextInput
-                      size="lg"
-                      label="Address"
-                      placeholder="123 Main Street"
-                      value={address}
-                      onChange={setAddress}
-                      status={
-                        errors.address
-                          ? {type: 'error', message: errors.address}
-                          : undefined
-                      }
-                    />
-                    <XDSGrid columns={2} gap={3}>
-                      <XDSTextInput
-                        size="lg"
-                        label="City"
-                        placeholder="New York"
-                        value={city}
-                        onChange={setCity}
-                        status={
-                          errors.city
-                            ? {type: 'error', message: errors.city}
-                            : undefined
-                        }
-                      />
-                      <XDSTextInput
-                        size="lg"
-                        label="ZIP Code"
-                        placeholder="10001"
-                        value={zip}
-                        onChange={setZip}
-                        status={
-                          errors.zip
-                            ? {type: 'error', message: errors.zip}
-                            : undefined
-                        }
-                      />
-                    </XDSGrid>
-                    <XDSSelector
-                      size="lg"
-                      label="State"
-                      placeholder="Select state"
-                      options={US_STATES}
-                      value={state}
-                      onChange={setState}
-                      status={
-                        errors.state
-                          ? {type: 'error', message: errors.state}
-                          : undefined
-                      }
-                    />
-                    <XDSTextInput
-                      size="lg"
-                      label="Phone Number"
-                      placeholder="+1 (555) 123-4567"
-                      value={phone}
-                      onChange={setPhone}
-                      labelTooltip="We use your phone number to provide shipping updates and contact you about your delivery if needed."
-                      status={
-                        errors.phone
-                          ? {type: 'error', message: errors.phone}
-                          : undefined
-                      }
-                    />
-                    <XDSCheckboxInput
-                      label="Save my information for a faster checkout"
-                      value={saveInfo}
-                      onChange={setSaveInfo}
-                    />
-                  </XDSVStack>
-
-                  {/* Delivery */}
-                  <XDSVStack gap={3}>
-                    <XDSVStack gap={1}>
-                      <XDSText type="large" weight="bold">
-                        Delivery
-                      </XDSText>
-                      <XDSText type="supporting" color="secondary">
-                        Please allow 1–3 business days processing time before
-                        your order ships.
-                      </XDSText>
-                    </XDSVStack>
-                    <XDSRadioList
-                      label="Delivery method"
-                      value={deliveryMethod}
-                      onChange={setDeliveryMethod}>
-                      <XDSRadioListItem
-                        value="standard"
-                        label="Standard (3–7 business days)"
-                        endContent={
-                          <XDSText type="body" weight="medium">
-                            $4.95
+                <XDSStack
+                  direction={isMobile ? 'vertical' : 'horizontal'}
+                  gap={8}
+                  vAlign="start">
+                  <XDSStackItem
+                    size="fill"
+                    style={{flexBasis: isMobile ? undefined : 0}}>
+                    <XDSVStack gap={8}>
+                      {/* Sign in */}
+                      <XDSVStack gap={1}>
+                        <XDSHStack gap={2} hAlign="between" vAlign="center">
+                          <XDSText type="large" weight="bold">
+                            Sign in to check out
                           </XDSText>
-                        }
-                      />
-                      <XDSRadioListItem
-                        value="expedited"
-                        label="Expedited (1–2 business days)"
-                        endContent={
-                          <XDSText type="body" weight="medium">
-                            $9.95
-                          </XDSText>
-                        }
-                      />
-                    </XDSRadioList>
-                  </XDSVStack>
-
-                  {/* Payment Method */}
-                  <XDSVStack gap={3}>
-                    <XDSVStack gap={1}>
-                      <XDSText type="large" weight="bold">
-                        Payment Method
-                      </XDSText>
-                      <XDSText type="supporting" color="secondary">
-                        All transactions are secure and encrypted.
-                      </XDSText>
-                    </XDSVStack>
-
-                    {/* Express checkout */}
-                    <XDSVStack gap={3}>
-                      <XDSGrid columns={2} gap={3}>
-                        {/* PayPal */}
-                        <XDSButton
-                          label="PayPal"
-                          variant="primary"
-                          size="sm"
-                          onClick={() => {}}
-                          style={{
-                            backgroundColor: '#FFC439',
-                            borderColor: '#FFC439',
-                          }}>
-                          <img
-                            src="https://www.paypalobjects.com/webstatic/mktg/Logo/pp-logo-100px.png"
-                            alt="PayPal"
-                            style={{height: 20, width: 'auto'}}
+                          <XDSButton
+                            label="Sign In"
+                            variant="secondary"
+                            size="sm"
+                            onClick={() => {}}
                           />
-                        </XDSButton>
-                        {/* Google Pay */}
-                        <XDSButton
-                          label="Google Pay"
-                          variant="primary"
-                          size="sm"
-                          onClick={() => {}}
-                          style={{
-                            backgroundColor: '#000',
-                            borderColor: '#000',
-                          }}>
-                          <img
-                            src="https://pay.google.com/about/static_kcs/images/logos/google-pay-logo.svg"
-                            alt="Google Pay"
-                            style={{
-                              height: 22,
-                              width: 'auto',
-                              filter: 'brightness(0) invert(1)',
-                            }}
-                          />
-                        </XDSButton>
-                      </XDSGrid>
-                    </XDSVStack>
+                        </XDSHStack>
+                        <XDSText type="supporting" color="secondary">
+                          Sign in to track your order and save your information
+                          for faster checkout.
+                        </XDSText>
+                      </XDSVStack>
 
-                    {/* OR divider */}
-                    <XDSHStack gap={3} vAlign="center">
-                      <XDSStackItem size="fill">
-                        <XDSDivider />
-                      </XDSStackItem>
-                      <XDSText type="supporting" color="secondary">
-                        OR
-                      </XDSText>
-                      <XDSStackItem size="fill">
-                        <XDSDivider />
-                      </XDSStackItem>
-                    </XDSHStack>
-
-                    {/* Credit card fields */}
-                    <XDSVStack gap={3}>
-                      {/* Card type icons */}
-                      <XDSHStack gap={1.5} vAlign="center">
-                        <img
-                          src="https://raw.githubusercontent.com/aaronfagan/svg-credit-card-payment-icons/main/flat/visa.svg"
-                          alt="Visa"
-                          style={{
-                            height: 'var(--spacing-7)',
-                            width: 'auto',
-                            borderRadius: 'var(--radius-element)',
-                            border:
-                              'var(--border-width) solid var(--color-border)',
-                            backgroundColor: 'var(--color-background-surface)',
-                          }}
-                        />
-                        <img
-                          src="https://raw.githubusercontent.com/aaronfagan/svg-credit-card-payment-icons/main/flat/mastercard.svg"
-                          alt="Mastercard"
-                          style={{
-                            height: 'var(--spacing-7)',
-                            width: 'auto',
-                            borderRadius: 'var(--radius-element)',
-                            border:
-                              'var(--border-width) solid var(--color-border)',
-                            backgroundColor: 'var(--color-background-surface)',
-                          }}
-                        />
-                        <img
-                          src="https://raw.githubusercontent.com/aaronfagan/svg-credit-card-payment-icons/main/flat/amex.svg"
-                          alt="Amex"
-                          style={{
-                            height: 'var(--spacing-7)',
-                            width: 'auto',
-                            borderRadius: 'var(--radius-element)',
-                            border:
-                              'var(--border-width) solid var(--color-border)',
-                            backgroundColor: 'var(--color-background-surface)',
-                          }}
-                        />
-                      </XDSHStack>
-                      <XDSTextInput
-                        size="lg"
-                        label="Card Number"
-                        placeholder="1234 5678 9012 3456"
-                        value={cardNumber}
-                        onChange={setCardNumber}
-                        status={
-                          errors.cardNumber
-                            ? {type: 'error', message: errors.cardNumber}
-                            : undefined
-                        }
-                      />
-                      <XDSGrid columns={3} gap={3}>
-                        <XDSSelector
+                      {/* Contact Information */}
+                      <XDSVStack gap={3}>
+                        <XDSText type="large" weight="bold">
+                          Contact Information
+                        </XDSText>
+                        <XDSTextInput
                           size="lg"
-                          label="Expiry Month"
-                          placeholder="MM"
-                          options={MONTHS}
-                          value={expiry}
-                          onChange={setExpiry}
+                          label="Email"
+                          placeholder="you@example.com"
+                          value={email}
+                          onChange={setEmail}
                           status={
-                            errors.expiry
-                              ? {type: 'error', message: errors.expiry}
+                            errors.email
+                              ? {type: 'error', message: errors.email}
                               : undefined
                           }
                         />
+                        <XDSCheckboxInput
+                          label="Email me with news and offers"
+                          value={emailOffers}
+                          onChange={setEmailOffers}
+                        />
+                      </XDSVStack>
+
+                      {/* Shipping Information */}
+                      <XDSVStack gap={3}>
+                        <XDSText type="large" weight="bold">
+                          Shipping Information
+                        </XDSText>
+                        <XDSGrid columns={2} gap={3}>
+                          <XDSTextInput
+                            size="lg"
+                            label="First Name"
+                            placeholder="John"
+                            value={firstName}
+                            onChange={setFirstName}
+                            status={
+                              errors.firstName
+                                ? {type: 'error', message: errors.firstName}
+                                : undefined
+                            }
+                          />
+                          <XDSTextInput
+                            size="lg"
+                            label="Last Name"
+                            placeholder="Doe"
+                            value={lastName}
+                            onChange={setLastName}
+                            status={
+                              errors.lastName
+                                ? {type: 'error', message: errors.lastName}
+                                : undefined
+                            }
+                          />
+                        </XDSGrid>
+                        <XDSTextInput
+                          size="lg"
+                          label="Address"
+                          placeholder="123 Main Street"
+                          value={address}
+                          onChange={setAddress}
+                          status={
+                            errors.address
+                              ? {type: 'error', message: errors.address}
+                              : undefined
+                          }
+                        />
+                        <XDSGrid columns={2} gap={3}>
+                          <XDSTextInput
+                            size="lg"
+                            label="City"
+                            placeholder="New York"
+                            value={city}
+                            onChange={setCity}
+                            status={
+                              errors.city
+                                ? {type: 'error', message: errors.city}
+                                : undefined
+                            }
+                          />
+                          <XDSTextInput
+                            size="lg"
+                            label="ZIP Code"
+                            placeholder="10001"
+                            value={zip}
+                            onChange={setZip}
+                            status={
+                              errors.zip
+                                ? {type: 'error', message: errors.zip}
+                                : undefined
+                            }
+                          />
+                        </XDSGrid>
                         <XDSSelector
                           size="lg"
-                          label="Expiry Year"
-                          placeholder="YY"
-                          options={YEARS}
-                          value={expYear}
-                          onChange={setExpYear}
+                          label="State"
+                          placeholder="Select state"
+                          options={US_STATES}
+                          value={state}
+                          onChange={setState}
                           status={
-                            errors.expYear
-                              ? {type: 'error', message: errors.expYear}
+                            errors.state
+                              ? {type: 'error', message: errors.state}
                               : undefined
                           }
                         />
                         <XDSTextInput
                           size="lg"
-                          label="CVC"
-                          placeholder="123"
-                          value={cvc}
-                          onChange={setCvc}
-                          labelTooltip="3-digit security code usually found on the back of your card. American Express cards have a 4-digit code located on the front."
+                          label="Phone Number"
+                          placeholder="+1 (555) 123-4567"
+                          value={phone}
+                          onChange={setPhone}
+                          labelTooltip="We use your phone number to provide shipping updates and contact you about your delivery if needed."
                           status={
-                            errors.cvc
-                              ? {type: 'error', message: errors.cvc}
+                            errors.phone
+                              ? {type: 'error', message: errors.phone}
                               : undefined
                           }
                         />
-                      </XDSGrid>
-                      <XDSTextInput
-                        size="lg"
-                        label="Name on Card"
-                        placeholder="John Doe"
-                        value={cardName}
-                        onChange={setCardName}
-                        status={
-                          errors.cardName
-                            ? {type: 'error', message: errors.cardName}
-                            : undefined
-                        }
-                      />
-                      <XDSCheckboxInput
-                        label="Use shipping address as billing address"
-                        value={billingMatchesShipping}
-                        onChange={setBillingMatchesShipping}
-                      />
-                      {!billingMatchesShipping && (
+                        <XDSCheckboxInput
+                          label="Save my information for a faster checkout"
+                          value={saveInfo}
+                          onChange={setSaveInfo}
+                        />
+                      </XDSVStack>
+
+                      {/* Delivery */}
+                      <XDSVStack gap={3}>
+                        <XDSVStack gap={1}>
+                          <XDSText type="large" weight="bold">
+                            Delivery
+                          </XDSText>
+                          <XDSText type="supporting" color="secondary">
+                            Please allow 1–3 business days processing time
+                            before your order ships.
+                          </XDSText>
+                        </XDSVStack>
+                        <XDSRadioList
+                          label="Delivery method"
+                          value={deliveryMethod}
+                          onChange={setDeliveryMethod}>
+                          <XDSRadioListItem
+                            value="standard"
+                            label="Standard (3–7 business days)"
+                            endContent={
+                              <XDSText type="body" weight="medium">
+                                $4.95
+                              </XDSText>
+                            }
+                          />
+                          <XDSRadioListItem
+                            value="expedited"
+                            label="Expedited (1–2 business days)"
+                            endContent={
+                              <XDSText type="body" weight="medium">
+                                $9.95
+                              </XDSText>
+                            }
+                          />
+                        </XDSRadioList>
+                      </XDSVStack>
+
+                      {/* Payment Method */}
+                      <XDSVStack gap={3}>
+                        <XDSVStack gap={1}>
+                          <XDSText type="large" weight="bold">
+                            Payment Method
+                          </XDSText>
+                          <XDSText type="supporting" color="secondary">
+                            All transactions are secure and encrypted.
+                          </XDSText>
+                        </XDSVStack>
+
+                        {/* Express checkout */}
                         <XDSVStack gap={3}>
+                          <XDSGrid columns={2} gap={3}>
+                            {/* PayPal */}
+                            <XDSButton
+                              label="PayPal"
+                              variant="primary"
+                              size="sm"
+                              onClick={() => {}}
+                              style={{
+                                backgroundColor: '#FFC439',
+                                borderColor: '#FFC439',
+                              }}>
+                              <img
+                                src="https://www.paypalobjects.com/webstatic/mktg/Logo/pp-logo-100px.png"
+                                alt="PayPal"
+                                style={{height: 20, width: 'auto'}}
+                              />
+                            </XDSButton>
+                            {/* Google Pay */}
+                            <XDSButton
+                              label="Google Pay"
+                              variant="primary"
+                              size="sm"
+                              onClick={() => {}}
+                              style={{
+                                backgroundColor: '#000',
+                                borderColor: '#000',
+                              }}>
+                              <img
+                                src="https://pay.google.com/about/static_kcs/images/logos/google-pay-logo.svg"
+                                alt="Google Pay"
+                                style={{
+                                  height: 22,
+                                  width: 'auto',
+                                  filter: 'brightness(0) invert(1)',
+                                }}
+                              />
+                            </XDSButton>
+                          </XDSGrid>
+                        </XDSVStack>
+
+                        {/* OR divider */}
+                        <XDSHStack gap={3} vAlign="center">
+                          <XDSStackItem size="fill">
+                            <XDSDivider />
+                          </XDSStackItem>
+                          <XDSText type="supporting" color="secondary">
+                            OR
+                          </XDSText>
+                          <XDSStackItem size="fill">
+                            <XDSDivider />
+                          </XDSStackItem>
+                        </XDSHStack>
+
+                        {/* Credit card fields */}
+                        <XDSVStack gap={3}>
+                          {/* Card type icons */}
+                          <XDSHStack gap={1.5} vAlign="center">
+                            <img
+                              src="https://raw.githubusercontent.com/aaronfagan/svg-credit-card-payment-icons/main/flat/visa.svg"
+                              alt="Visa"
+                              style={{
+                                height: 'var(--spacing-7)',
+                                width: 'auto',
+                                borderRadius: 'var(--radius-element)',
+                                border:
+                                  'var(--border-width) solid var(--color-border)',
+                                backgroundColor:
+                                  'var(--color-background-surface)',
+                              }}
+                            />
+                            <img
+                              src="https://raw.githubusercontent.com/aaronfagan/svg-credit-card-payment-icons/main/flat/mastercard.svg"
+                              alt="Mastercard"
+                              style={{
+                                height: 'var(--spacing-7)',
+                                width: 'auto',
+                                borderRadius: 'var(--radius-element)',
+                                border:
+                                  'var(--border-width) solid var(--color-border)',
+                                backgroundColor:
+                                  'var(--color-background-surface)',
+                              }}
+                            />
+                            <img
+                              src="https://raw.githubusercontent.com/aaronfagan/svg-credit-card-payment-icons/main/flat/amex.svg"
+                              alt="Amex"
+                              style={{
+                                height: 'var(--spacing-7)',
+                                width: 'auto',
+                                borderRadius: 'var(--radius-element)',
+                                border:
+                                  'var(--border-width) solid var(--color-border)',
+                                backgroundColor:
+                                  'var(--color-background-surface)',
+                              }}
+                            />
+                          </XDSHStack>
                           <XDSTextInput
                             size="lg"
-                            label="Address"
-                            placeholder="123 Main Street"
-                            value={billingAddress}
-                            onChange={setBillingAddress}
+                            label="Card Number"
+                            placeholder="1234 5678 9012 3456"
+                            value={cardNumber}
+                            onChange={setCardNumber}
                             status={
-                              errors.billingAddress
-                                ? {
-                                    type: 'error',
-                                    message: errors.billingAddress,
-                                  }
+                              errors.cardNumber
+                                ? {type: 'error', message: errors.cardNumber}
                                 : undefined
                             }
                           />
-                          <XDSGrid columns={2} gap={3}>
-                            <XDSTextInput
+                          <XDSGrid columns={3} gap={3}>
+                            <XDSSelector
                               size="lg"
-                              label="City"
-                              placeholder="New York"
-                              value={billingCity}
-                              onChange={setBillingCity}
+                              label="Expiry Month"
+                              placeholder="MM"
+                              options={MONTHS}
+                              value={expiry}
+                              onChange={setExpiry}
                               status={
-                                errors.billingCity
-                                  ? {
-                                      type: 'error',
-                                      message: errors.billingCity,
-                                    }
+                                errors.expiry
+                                  ? {type: 'error', message: errors.expiry}
+                                  : undefined
+                              }
+                            />
+                            <XDSSelector
+                              size="lg"
+                              label="Expiry Year"
+                              placeholder="YY"
+                              options={YEARS}
+                              value={expYear}
+                              onChange={setExpYear}
+                              status={
+                                errors.expYear
+                                  ? {type: 'error', message: errors.expYear}
                                   : undefined
                               }
                             />
                             <XDSTextInput
                               size="lg"
-                              label="ZIP Code"
-                              placeholder="10001"
-                              value={billingZip}
-                              onChange={setBillingZip}
+                              label="CVC"
+                              placeholder="123"
+                              value={cvc}
+                              onChange={setCvc}
+                              labelTooltip="3-digit security code usually found on the back of your card. American Express cards have a 4-digit code located on the front."
                               status={
-                                errors.billingZip
-                                  ? {
-                                      type: 'error',
-                                      message: errors.billingZip,
-                                    }
+                                errors.cvc
+                                  ? {type: 'error', message: errors.cvc}
                                   : undefined
                               }
                             />
                           </XDSGrid>
-                          <XDSSelector
+                          <XDSTextInput
                             size="lg"
-                            label="State"
-                            placeholder="Select state"
-                            options={US_STATES}
-                            value={billingState}
-                            onChange={setBillingState}
+                            label="Name on Card"
+                            placeholder="John Doe"
+                            value={cardName}
+                            onChange={setCardName}
                             status={
-                              errors.billingState
-                                ? {
-                                    type: 'error',
-                                    message: errors.billingState,
-                                  }
+                              errors.cardName
+                                ? {type: 'error', message: errors.cardName}
                                 : undefined
                             }
                           />
-                        </XDSVStack>
-                      )}
-                    </XDSVStack>
-                  </XDSVStack>
-
-                  {/* Promo Code */}
-                  <XDSVStack gap={3}>
-                    <XDSText type="large" weight="bold">
-                      Promo Code
-                    </XDSText>
-                    <XDSHStack gap={2} vAlign="center">
-                      <XDSTextInput
-                        size="lg"
-                        label="Promo code"
-                        isLabelHidden
-                        placeholder="Enter promo code"
-                        value={promo}
-                        onChange={setPromo}
-                        xstyle={styles.fullWidth}
-                      />
-                      <XDSButton
-                        label="Apply"
-                        variant="secondary"
-                        size="lg"
-                        onClick={() => {}}
-                      />
-                    </XDSHStack>
-                  </XDSVStack>
-
-                  {/* Gift Options */}
-                  <XDSVStack gap={3}>
-                    <XDSText type="large" weight="bold">
-                      Gift Options
-                    </XDSText>
-                    <XDSCheckboxInput
-                      label="Add a gift message"
-                      value={addGiftMessage}
-                      onChange={setAddGiftMessage}
-                    />
-                    {addGiftMessage && (
-                      <XDSVStack gap={3}>
-                        <XDSGrid columns={2} gap={3}>
-                          <XDSTextInput
-                            size="lg"
-                            label="To"
-                            isLabelHidden
-                            placeholder="To"
-                            value={giftTo}
-                            onChange={setGiftTo}
+                          <XDSCheckboxInput
+                            label="Use shipping address as billing address"
+                            value={billingMatchesShipping}
+                            onChange={setBillingMatchesShipping}
                           />
-                          <XDSTextInput
-                            size="lg"
-                            label="From"
-                            isLabelHidden
-                            placeholder="From"
-                            value={giftFrom}
-                            onChange={setGiftFrom}
-                          />
-                        </XDSGrid>
-                        <XDSTextArea
-                          label="Gift message"
-                          isLabelHidden
-                          placeholder="Write something here"
-                          value={giftMessage}
-                          onChange={setGiftMessage}
-                        />
-                      </XDSVStack>
-                    )}
-                  </XDSVStack>
-
-                  {/* Trust bar + CTAs + policy links */}
-                  <XDSVStack gap={4}>
-                    <XDSHStack gap={5} hAlign="center" wrap="wrap">
-                      <XDSHStack gap={1} vAlign="center">
-                        <XDSIcon
-                          icon={ShieldCheckIcon}
-                          size="sm"
-                          color="secondary"
-                        />
-                        <XDSText type="supporting" color="secondary">
-                          Secure Payment
-                        </XDSText>
-                      </XDSHStack>
-                      <XDSHStack gap={1} vAlign="center">
-                        <XDSIcon
-                          icon={LockClosedIcon}
-                          size="sm"
-                          color="secondary"
-                        />
-                        <XDSText type="supporting" color="secondary">
-                          SSL Encrypted
-                        </XDSText>
-                      </XDSHStack>
-                      <XDSHStack gap={1} vAlign="center">
-                        <XDSIcon
-                          icon={CheckCircleIcon}
-                          size="sm"
-                          color="secondary"
-                        />
-                        <XDSText type="supporting" color="secondary">
-                          Free Returns
-                        </XDSText>
-                      </XDSHStack>
-                    </XDSHStack>
-                    <XDSVStack gap={2}>
-                      <XDSButton
-                        label="Place Order"
-                        variant="primary"
-                        size="lg"
-                        xstyle={styles.fullWidth}
-                        onClick={() => setSubmitted(true)}
-                        endContent={
-                          <XDSIcon
-                            icon={ArrowRightIcon}
-                            size="sm"
-                            color="inherit"
-                          />
-                        }
-                      />
-                      <XDSButton
-                        label="← Continue Shopping"
-                        variant="secondary"
-                        size="lg"
-                        xstyle={styles.fullWidth}
-                        onClick={() => {}}
-                      />
-                    </XDSVStack>
-                    <XDSDivider />
-                    <XDSHStack gap={4} vAlign="center">
-                      <XDSLink href="#" type="supporting">
-                        Refund policy
-                      </XDSLink>
-                      <XDSLink href="#" type="supporting">
-                        Privacy policy
-                      </XDSLink>
-                      <XDSLink href="#" type="supporting">
-                        Terms of service
-                      </XDSLink>
-                      <XDSLink href="#" type="supporting">
-                        Cancellations
-                      </XDSLink>
-                    </XDSHStack>
-                  </XDSVStack>
-                </XDSVStack>
-              </XDSStackItem>
-
-              <XDSStackItem
-                size="fill"
-                style={
-                  isMobile
-                    ? {order: -1}
-                    : {
-                        flexBasis: 0,
-                        position: 'sticky',
-                        top: 16,
-                        alignSelf: 'flex-start',
-                      }
-                }>
-                <XDSCard padding={5}>
-                  <XDSVStack gap={4}>
-                    {/* Accordion header — clickable on mobile only */}
-                    <XDSCollapsible
-                      trigger="Order Summary"
-                      defaultIsOpen={true}>
-                      <XDSVStack gap={4}>
-                        {/* Line items */}
-                        {ORDER_ITEMS.map(item => (
-                          <XDSVStack key={item.id} gap={3}>
-                            <XDSHStack gap={3} vAlign="start">
-                              {/* Placeholder thumbnail */}
-                              <div {...stylex.props(styles.orderThumb)}>
-                                <XDSAspectRatio ratio={1}>
-                                  <img
-                                    src={
-                                      (ITEM_IMAGES[item.id] as {src: string})
-                                        .src
-                                    }
-                                    alt={item.name}
-                                    style={{objectFit: 'cover'}}
-                                  />
-                                </XDSAspectRatio>
-                              </div>
-                              <XDSStackItem size="fill">
-                                <XDSVStack gap={1}>
-                                  <XDSHStack
-                                    gap={2}
-                                    hAlign="between"
-                                    vAlign="start">
-                                    <XDSHStack gap={2} vAlign="center">
-                                      <XDSText type="body" weight="medium">
-                                        {item.name}
-                                      </XDSText>
-                                      {item.limited && (
-                                        <XDSBadge
-                                          variant="green"
-                                          label="LIMITED EDITION"
-                                        />
-                                      )}
-                                    </XDSHStack>
-                                    <XDSText type="body" weight="bold">
-                                      {fmt(item.price)}
-                                    </XDSText>
-                                  </XDSHStack>
-                                  <XDSText type="supporting" color="secondary">
-                                    {item.variant}
-                                  </XDSText>
-                                  <XDSHStack gap={2} vAlign="center">
-                                    <XDSNumberInput
-                                      label="Qty"
-                                      isLabelHidden
-                                      value={quantities[item.id] ?? item.qty}
-                                      onChange={v =>
-                                        setQuantities(q => ({
-                                          ...q,
-                                          [item.id]: v,
-                                        }))
+                          {!billingMatchesShipping && (
+                            <XDSVStack gap={3}>
+                              <XDSTextInput
+                                size="lg"
+                                label="Address"
+                                placeholder="123 Main Street"
+                                value={billingAddress}
+                                onChange={setBillingAddress}
+                                status={
+                                  errors.billingAddress
+                                    ? {
+                                        type: 'error',
+                                        message: errors.billingAddress,
                                       }
-                                      min={1}
-                                      max={10}
-                                      isIntegerOnly
-                                    />
-                                    <XDSLink href="#" type="supporting">
-                                      Remove
-                                    </XDSLink>
-                                    <XDSLink href="#" type="supporting">
-                                      Save
-                                    </XDSLink>
-                                  </XDSHStack>
-                                </XDSVStack>
-                              </XDSStackItem>
-                            </XDSHStack>
-                            <XDSDivider />
-                          </XDSVStack>
-                        ))}
+                                    : undefined
+                                }
+                              />
+                              <XDSGrid columns={2} gap={3}>
+                                <XDSTextInput
+                                  size="lg"
+                                  label="City"
+                                  placeholder="New York"
+                                  value={billingCity}
+                                  onChange={setBillingCity}
+                                  status={
+                                    errors.billingCity
+                                      ? {
+                                          type: 'error',
+                                          message: errors.billingCity,
+                                        }
+                                      : undefined
+                                  }
+                                />
+                                <XDSTextInput
+                                  size="lg"
+                                  label="ZIP Code"
+                                  placeholder="10001"
+                                  value={billingZip}
+                                  onChange={setBillingZip}
+                                  status={
+                                    errors.billingZip
+                                      ? {
+                                          type: 'error',
+                                          message: errors.billingZip,
+                                        }
+                                      : undefined
+                                  }
+                                />
+                              </XDSGrid>
+                              <XDSSelector
+                                size="lg"
+                                label="State"
+                                placeholder="Select state"
+                                options={US_STATES}
+                                value={billingState}
+                                onChange={setBillingState}
+                                status={
+                                  errors.billingState
+                                    ? {
+                                        type: 'error',
+                                        message: errors.billingState,
+                                      }
+                                    : undefined
+                                }
+                              />
+                            </XDSVStack>
+                          )}
+                        </XDSVStack>
+                      </XDSVStack>
 
-                        {/* Order total subsection */}
-                        <XDSVStack gap={3}>
-                          <XDSText type="large" weight="bold">
-                            Order Total
-                          </XDSText>
-                          <XDSVStack gap={2}>
-                            <XDSHStack hAlign="between" vAlign="center">
-                              <XDSText type="body" color="secondary">
-                                Subtotal
-                              </XDSText>
-                              <XDSText type="body">{fmt(SUBTOTAL)}</XDSText>
-                            </XDSHStack>
-                            <XDSHStack hAlign="between" vAlign="center">
-                              <XDSText type="body" color="secondary">
-                                Shipping
-                              </XDSText>
-                              <XDSText type="body">
-                                {fmt(
-                                  deliveryMethod === 'expedited' ? 9.95 : 4.95,
-                                )}
-                              </XDSText>
-                            </XDSHStack>
-                            <XDSHStack hAlign="between" vAlign="center">
-                              <XDSText type="body" color="secondary">
-                                Tax
-                              </XDSText>
-                              <XDSText type="body">{fmt(TAX)}</XDSText>
-                            </XDSHStack>
+                      {/* Promo Code */}
+                      <XDSVStack gap={3}>
+                        <XDSText type="large" weight="bold">
+                          Promo Code
+                        </XDSText>
+                        <XDSHStack gap={2} vAlign="center">
+                          <XDSTextInput
+                            size="lg"
+                            label="Promo code"
+                            isLabelHidden
+                            placeholder="Enter promo code"
+                            value={promo}
+                            onChange={setPromo}
+                            xstyle={styles.fullWidth}
+                          />
+                          <XDSButton
+                            label="Apply"
+                            variant="secondary"
+                            size="lg"
+                            onClick={() => {}}
+                          />
+                        </XDSHStack>
+                      </XDSVStack>
+
+                      {/* Gift Options */}
+                      <XDSVStack gap={3}>
+                        <XDSText type="large" weight="bold">
+                          Gift Options
+                        </XDSText>
+                        <XDSCheckboxInput
+                          label="Add a gift message"
+                          value={addGiftMessage}
+                          onChange={setAddGiftMessage}
+                        />
+                        {addGiftMessage && (
+                          <XDSVStack gap={3}>
+                            <XDSGrid columns={2} gap={3}>
+                              <XDSTextInput
+                                size="lg"
+                                label="To"
+                                isLabelHidden
+                                placeholder="To"
+                                value={giftTo}
+                                onChange={setGiftTo}
+                              />
+                              <XDSTextInput
+                                size="lg"
+                                label="From"
+                                isLabelHidden
+                                placeholder="From"
+                                value={giftFrom}
+                                onChange={setGiftFrom}
+                              />
+                            </XDSGrid>
+                            <XDSTextArea
+                              label="Gift message"
+                              isLabelHidden
+                              placeholder="Write something here"
+                              value={giftMessage}
+                              onChange={setGiftMessage}
+                            />
                           </XDSVStack>
-                          <XDSDivider />
-                          <XDSHStack hAlign="between" vAlign="center">
-                            <XDSText type="large" weight="bold">
-                              Total
-                            </XDSText>
-                            <XDSText type="large" weight="bold">
-                              {fmt(
-                                SUBTOTAL +
-                                  (deliveryMethod === 'expedited'
-                                    ? 9.95
-                                    : 4.95) +
-                                  TAX,
-                              )}
+                        )}
+                      </XDSVStack>
+
+                      {/* Trust bar + CTAs + policy links */}
+                      <XDSVStack gap={4}>
+                        <XDSHStack gap={5} hAlign="center" wrap="wrap">
+                          <XDSHStack gap={1} vAlign="center">
+                            <XDSIcon
+                              icon={ShieldCheckIcon}
+                              size="sm"
+                              color="secondary"
+                            />
+                            <XDSText type="supporting" color="secondary">
+                              Secure Payment
                             </XDSText>
                           </XDSHStack>
-                          <div {...stylex.props(styles.freeBanner)}>
+                          <XDSHStack gap={1} vAlign="center">
                             <XDSIcon
-                              icon={TruckIcon}
+                              icon={LockClosedIcon}
                               size="sm"
-                              color="primary"
+                              color="secondary"
                             />
-                            <XDSText type="supporting">
-                              Free shipping on orders over $300
+                            <XDSText type="supporting" color="secondary">
+                              SSL Encrypted
                             </XDSText>
-                          </div>
+                          </XDSHStack>
+                          <XDSHStack gap={1} vAlign="center">
+                            <XDSIcon
+                              icon={CheckCircleIcon}
+                              size="sm"
+                              color="secondary"
+                            />
+                            <XDSText type="supporting" color="secondary">
+                              Free Returns
+                            </XDSText>
+                          </XDSHStack>
+                        </XDSHStack>
+                        <XDSVStack gap={2}>
+                          <XDSButton
+                            label="Place Order"
+                            variant="primary"
+                            size="lg"
+                            xstyle={styles.fullWidth}
+                            onClick={() => setSubmitted(true)}
+                            endContent={
+                              <XDSIcon
+                                icon={ArrowRightIcon}
+                                size="sm"
+                                color="inherit"
+                              />
+                            }
+                          />
+                          <XDSButton
+                            label="← Continue Shopping"
+                            variant="secondary"
+                            size="lg"
+                            xstyle={styles.fullWidth}
+                            onClick={() => {}}
+                          />
                         </XDSVStack>
+                        <XDSDivider />
+                        <XDSHStack gap={4} vAlign="center">
+                          <XDSLink href="#" type="supporting">
+                            Refund policy
+                          </XDSLink>
+                          <XDSLink href="#" type="supporting">
+                            Privacy policy
+                          </XDSLink>
+                          <XDSLink href="#" type="supporting">
+                            Terms of service
+                          </XDSLink>
+                          <XDSLink href="#" type="supporting">
+                            Cancellations
+                          </XDSLink>
+                        </XDSHStack>
                       </XDSVStack>
-                    </XDSCollapsible>
-                  </XDSVStack>
-                  {/* end outer card XDSVStack gap={4} */}
-                </XDSCard>
-              </XDSStackItem>
-            </XDSStack>
-          </XDSVStack>
-        </XDSSection>
-      </XDSCenter>
-    </XDSAppShell>
+                    </XDSVStack>
+                  </XDSStackItem>
+
+                  <XDSStackItem
+                    size="fill"
+                    style={
+                      isMobile
+                        ? {order: -1}
+                        : {
+                            flexBasis: 0,
+                            position: 'sticky',
+                            top: 16,
+                            alignSelf: 'flex-start',
+                          }
+                    }>
+                    <XDSCard padding={5}>
+                      <XDSVStack gap={4}>
+                        {/* Accordion header — clickable on mobile only */}
+                        <XDSCollapsible
+                          trigger="Order Summary"
+                          defaultIsOpen={true}>
+                          <XDSVStack gap={4}>
+                            {/* Line items */}
+                            {ORDER_ITEMS.map(item => (
+                              <XDSVStack key={item.id} gap={3}>
+                                <XDSHStack gap={3} vAlign="start">
+                                  {/* Placeholder thumbnail */}
+                                  <div {...stylex.props(styles.orderThumb)}>
+                                    <XDSAspectRatio ratio={1}>
+                                      <img
+                                        src={
+                                          (
+                                            ITEM_IMAGES[item.id] as {
+                                              src: string;
+                                            }
+                                          ).src
+                                        }
+                                        alt={item.name}
+                                        style={{objectFit: 'cover'}}
+                                      />
+                                    </XDSAspectRatio>
+                                  </div>
+                                  <XDSStackItem size="fill">
+                                    <XDSVStack gap={1}>
+                                      <XDSHStack
+                                        gap={2}
+                                        hAlign="between"
+                                        vAlign="start">
+                                        <XDSHStack gap={2} vAlign="center">
+                                          <XDSText type="body" weight="medium">
+                                            {item.name}
+                                          </XDSText>
+                                          {item.limited && (
+                                            <XDSBadge
+                                              variant="green"
+                                              label="LIMITED EDITION"
+                                            />
+                                          )}
+                                        </XDSHStack>
+                                        <XDSText type="body" weight="bold">
+                                          {fmt(item.price)}
+                                        </XDSText>
+                                      </XDSHStack>
+                                      <XDSText
+                                        type="supporting"
+                                        color="secondary">
+                                        {item.variant}
+                                      </XDSText>
+                                      <XDSHStack gap={2} vAlign="center">
+                                        <XDSNumberInput
+                                          label="Qty"
+                                          isLabelHidden
+                                          value={
+                                            quantities[item.id] ?? item.qty
+                                          }
+                                          onChange={v =>
+                                            setQuantities(q => ({
+                                              ...q,
+                                              [item.id]: v,
+                                            }))
+                                          }
+                                          min={1}
+                                          max={10}
+                                          isIntegerOnly
+                                        />
+                                        <XDSLink href="#" type="supporting">
+                                          Remove
+                                        </XDSLink>
+                                        <XDSLink href="#" type="supporting">
+                                          Save
+                                        </XDSLink>
+                                      </XDSHStack>
+                                    </XDSVStack>
+                                  </XDSStackItem>
+                                </XDSHStack>
+                                <XDSDivider />
+                              </XDSVStack>
+                            ))}
+
+                            {/* Order total subsection */}
+                            <XDSVStack gap={3}>
+                              <XDSText type="large" weight="bold">
+                                Order Total
+                              </XDSText>
+                              <XDSVStack gap={2}>
+                                <XDSHStack hAlign="between" vAlign="center">
+                                  <XDSText type="body" color="secondary">
+                                    Subtotal
+                                  </XDSText>
+                                  <XDSText type="body">{fmt(SUBTOTAL)}</XDSText>
+                                </XDSHStack>
+                                <XDSHStack hAlign="between" vAlign="center">
+                                  <XDSText type="body" color="secondary">
+                                    Shipping
+                                  </XDSText>
+                                  <XDSText type="body">
+                                    {fmt(
+                                      deliveryMethod === 'expedited'
+                                        ? 9.95
+                                        : 4.95,
+                                    )}
+                                  </XDSText>
+                                </XDSHStack>
+                                <XDSHStack hAlign="between" vAlign="center">
+                                  <XDSText type="body" color="secondary">
+                                    Tax
+                                  </XDSText>
+                                  <XDSText type="body">{fmt(TAX)}</XDSText>
+                                </XDSHStack>
+                              </XDSVStack>
+                              <XDSDivider />
+                              <XDSHStack hAlign="between" vAlign="center">
+                                <XDSText type="large" weight="bold">
+                                  Total
+                                </XDSText>
+                                <XDSText type="large" weight="bold">
+                                  {fmt(
+                                    SUBTOTAL +
+                                      (deliveryMethod === 'expedited'
+                                        ? 9.95
+                                        : 4.95) +
+                                      TAX,
+                                  )}
+                                </XDSText>
+                              </XDSHStack>
+                              <div {...stylex.props(styles.freeBanner)}>
+                                <XDSIcon
+                                  icon={TruckIcon}
+                                  size="sm"
+                                  color="primary"
+                                />
+                                <XDSText type="supporting">
+                                  Free shipping on orders over $300
+                                </XDSText>
+                              </div>
+                            </XDSVStack>
+                          </XDSVStack>
+                        </XDSCollapsible>
+                      </XDSVStack>
+                      {/* end outer card XDSVStack gap={4} */}
+                    </XDSCard>
+                  </XDSStackItem>
+                </XDSStack>
+              </XDSVStack>
+            </XDSSection>
+          </XDSCenter>
+        </XDSLayoutContent>
+      }
+    />
   );
 }

--- a/packages/cli/templates/pages/product-detail/page.tsx
+++ b/packages/cli/templates/pages/product-detail/page.tsx
@@ -3,9 +3,12 @@
 'use client';
 
 import {useState} from 'react';
-import {XDSAppShell} from '@xds/core/AppShell';
-import {XDSTopNav, XDSTopNavHeading, XDSTopNavItem} from '@xds/core/TopNav';
-import {XDSVStack, XDSHStack} from '@xds/core/Layout';
+import {
+  XDSVStack,
+  XDSHStack,
+  XDSLayout,
+  XDSLayoutContent,
+} from '@xds/core/Layout';
 import {XDSCenter} from '@xds/core/Center';
 import {XDSGrid} from '@xds/core/Grid';
 import {XDSText, XDSHeading} from '@xds/core/Text';
@@ -19,7 +22,6 @@ import {
 import {XDSBadge} from '@xds/core/Badge';
 import {XDSDivider} from '@xds/core/Divider';
 import {XDSCollapsible, XDSCollapsibleGroup} from '@xds/core/Collapsible';
-import {XDSNavIcon} from '@xds/core/NavIcon';
 import {XDSAspectRatio} from '@xds/core/AspectRatio';
 import * as stylex from '@stylexjs/stylex';
 
@@ -53,15 +55,7 @@ const pageStyles = stylex.create({
   },
 });
 
-import {
-  ShoppingBagIcon,
-  UserIcon,
-  MagnifyingGlassIcon,
-  HeartIcon,
-  MinusIcon,
-  PlusIcon,
-  StarIcon,
-} from '@heroicons/react/24/outline';
+import {MinusIcon, PlusIcon, StarIcon} from '@heroicons/react/24/outline';
 import {StarIcon as StarIconSolid} from '@heroicons/react/24/solid';
 
 // ─── Star Rating ─────────────────────────────────────────────────────────────
@@ -133,65 +127,6 @@ const FINISHES = [
 ];
 
 const fmt = (n: number) => `$${n.toFixed(2)}`;
-
-// ─── TopNav ─────────────────────────────────────────────────────────────────
-function StoreTopNav() {
-  return (
-    <XDSTopNav
-      label="Store navigation"
-      heading={
-        <XDSTopNavHeading
-          heading="Kiln & Table"
-          logo={
-            <XDSNavIcon
-              icon={
-                <XDSIcon icon={ShoppingBagIcon} size="sm" color="inherit" />
-              }
-            />
-          }
-          href="#"
-        />
-      }
-      centerContent={
-        <>
-          <XDSTopNavItem label="New Arrivals" href="#" />
-          <XDSTopNavItem label="Mugs" href="#" isSelected />
-          <XDSTopNavItem label="Plates & Bowls" href="#" />
-          <XDSTopNavItem label="Serveware" href="#" />
-          <XDSTopNavItem label="About" href="#" />
-        </>
-      }
-      endContent={
-        <XDSHStack gap={2}>
-          <XDSButton
-            label="Search"
-            variant="ghost"
-            icon={<XDSIcon icon={MagnifyingGlassIcon} size="sm" />}
-            isIconOnly
-          />
-          <XDSButton
-            label="Wishlist"
-            variant="ghost"
-            icon={<XDSIcon icon={HeartIcon} size="sm" />}
-            isIconOnly
-          />
-          <XDSButton
-            label="Account"
-            variant="ghost"
-            icon={<XDSIcon icon={UserIcon} size="sm" />}
-            isIconOnly
-          />
-          <XDSButton
-            label="Cart"
-            variant="ghost"
-            icon={<XDSIcon icon={ShoppingBagIcon} size="sm" />}
-            isIconOnly
-          />
-        </XDSHStack>
-      }
-    />
-  );
-}
 
 // ─── Image Gallery ──────────────────────────────────────────────────────────
 function ImageGallery({
@@ -374,24 +309,25 @@ export default function ProductDetailTemplate() {
   const [selectedThumb, setSelectedThumb] = useState(0);
 
   return (
-    <XDSAppShell
-      topNav={<StoreTopNav />}
+    <XDSLayout
       height="auto"
-      contentPadding={0}
-      variant="surface">
-      <XDSCenter axis="horizontal">
-        <XDSVStack gap={0} xstyle={pageStyles.pageWrapper}>
-          <XDSGrid columns={{minWidth: 400}} gap={5}>
-            <ImageGallery
-              selected={selectedThumb}
-              onSelect={setSelectedThumb}
-            />
-            <XDSVStack gap={0} xstyle={pageStyles.stickyInfo}>
-              <ProductInfo />
+      content={
+        <XDSLayoutContent padding={0}>
+          <XDSCenter axis="horizontal">
+            <XDSVStack gap={0} xstyle={pageStyles.pageWrapper}>
+              <XDSGrid columns={{minWidth: 400}} gap={5}>
+                <ImageGallery
+                  selected={selectedThumb}
+                  onSelect={setSelectedThumb}
+                />
+                <XDSVStack gap={0} xstyle={pageStyles.stickyInfo}>
+                  <ProductInfo />
+                </XDSVStack>
+              </XDSGrid>
             </XDSVStack>
-          </XDSGrid>
-        </XDSVStack>
-      </XDSCenter>
-    </XDSAppShell>
+          </XDSCenter>
+        </XDSLayoutContent>
+      }
+    />
   );
 }

--- a/packages/cli/templates/pages/product-gallery/page.tsx
+++ b/packages/cli/templates/pages/product-gallery/page.tsx
@@ -2,8 +2,7 @@
 
 'use client';
 
-import {XDSAppShell} from '@xds/core/AppShell';
-import {XDSVStack} from '@xds/core/Layout';
+import {XDSVStack, XDSLayout, XDSLayoutContent} from '@xds/core/Layout';
 import {XDSCenter} from '@xds/core/Center';
 import {XDSText, XDSHeading} from '@xds/core/Text';
 import {XDSButton} from '@xds/core/Button';
@@ -130,40 +129,47 @@ function ProductCard({product}: {product: Product}) {
 
 export default function ProductGalleryTemplate() {
   return (
-    <XDSAppShell height="auto" contentPadding={0} variant="surface">
-      <XDSCenter axis="horizontal">
-        <XDSSection variant="transparent" maxWidth={1200} padding={6}>
-          <XDSVStack gap={6}>
-            {/* Header — XDSGrid handles responsive stacking */}
-            <XDSGrid columns={{minWidth: 280}} gap={4} align="start">
-              <XDSHeading level={1}>
-                Make every day a little more delightful, one small detail at a
-                time.
-              </XDSHeading>
-              <XDSVStack gap={3} hAlign="start">
-                <XDSText type="body">
-                  We believe the smallest details are the ones that matter most.
-                  A little color, a thoughtful touch, a moment that catches your
-                  eye and makes you pause; that&apos;s what turns an ordinary
-                  day into something worth remembering.
-                </XDSText>
-                <XDSButton
-                  label="Get started"
-                  variant="primary"
-                  endContent={<XDSIcon icon={ArrowRightIcon} color="inherit" />}
-                />
-              </XDSVStack>
-            </XDSGrid>
+    <XDSLayout
+      height="auto"
+      content={
+        <XDSLayoutContent padding={0}>
+          <XDSCenter axis="horizontal">
+            <XDSSection variant="transparent" maxWidth={1200} padding={6}>
+              <XDSVStack gap={6}>
+                {/* Header — XDSGrid handles responsive stacking */}
+                <XDSGrid columns={{minWidth: 280}} gap={4} align="start">
+                  <XDSHeading level={1}>
+                    Make every day a little more delightful, one small detail at
+                    a time.
+                  </XDSHeading>
+                  <XDSVStack gap={3} hAlign="start">
+                    <XDSText type="body">
+                      We believe the smallest details are the ones that matter
+                      most. A little color, a thoughtful touch, a moment that
+                      catches your eye and makes you pause; that&apos;s what
+                      turns an ordinary day into something worth remembering.
+                    </XDSText>
+                    <XDSButton
+                      label="Get started"
+                      variant="primary"
+                      endContent={
+                        <XDSIcon icon={ArrowRightIcon} color="inherit" />
+                      }
+                    />
+                  </XDSVStack>
+                </XDSGrid>
 
-            {/* Product Grid — 3 cols desktop, wraps to 2→1 on smaller screens */}
-            <XDSGrid columns={{minWidth: 300}} gap={6}>
-              {PRODUCTS.map(product => (
-                <ProductCard key={product.id} product={product} />
-              ))}
-            </XDSGrid>
-          </XDSVStack>
-        </XDSSection>
-      </XDSCenter>
-    </XDSAppShell>
+                {/* Product Grid — 3 cols desktop, wraps to 2→1 on smaller screens */}
+                <XDSGrid columns={{minWidth: 300}} gap={6}>
+                  {PRODUCTS.map(product => (
+                    <ProductCard key={product.id} product={product} />
+                  ))}
+                </XDSGrid>
+              </XDSVStack>
+            </XDSSection>
+          </XDSCenter>
+        </XDSLayoutContent>
+      }
+    />
   );
 }

--- a/packages/cli/templates/pages/settings-dialog/page.tsx
+++ b/packages/cli/templates/pages/settings-dialog/page.tsx
@@ -4,7 +4,6 @@
 
 import React, {useState} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {XDSAppShell} from '@xds/core/AppShell';
 import {
   XDSVStack,
   XDSHStack,
@@ -27,7 +26,11 @@ import {XDSTabList, XDSTab} from '@xds/core/TabList';
 import {XDSBadge} from '@xds/core/Badge';
 import {XDSIcon} from '@xds/core/Icon';
 import {XDSCenter} from '@xds/core/Center';
-import {colorVars, radiusVars, spacingVars} from '@xds/core/theme/tokens.stylex';
+import {
+  colorVars,
+  radiusVars,
+  spacingVars,
+} from '@xds/core/theme/tokens.stylex';
 import {
   UserIcon,
   LockClosedIcon,
@@ -231,11 +234,7 @@ function InfoRowItem({
             {value}
           </XDSText>
         </XDSVStack>
-        {action && (
-          <XDSLink href="#">
-            {action}
-          </XDSLink>
-        )}
+        {action && <XDSLink href="#">{action}</XDSLink>}
       </XDSHStack>
       <XDSDivider />
     </>
@@ -272,14 +271,20 @@ export default function SettingsDialogTemplate() {
   const handleSave = () => setExpandedRow(null);
 
   return (
-    <XDSAppShell>
-      <XDSCenter height="80vh">
-        <XDSButton
-          label="Open settings"
-          variant="primary"
-          onClick={() => setIsOpen(true)}
-        />
-      </XDSCenter>
+    <>
+      <XDSLayout
+        content={
+          <XDSLayoutContent padding={0}>
+            <XDSCenter height="80vh">
+              <XDSButton
+                label="Open settings"
+                variant="primary"
+                onClick={() => setIsOpen(true)}
+              />
+            </XDSCenter>
+          </XDSLayoutContent>
+        }
+      />
 
       <XDSDialog
         isOpen={isOpen}
@@ -300,7 +305,9 @@ export default function SettingsDialogTemplate() {
               padding={0}
               xstyle={styles.panelFull}>
               <XDSVStack gap={4} xstyle={styles.sideNavPadding}>
-                <XDSHeading level={2} xstyle={styles.sideNavHeading}>Account settings</XDSHeading>
+                <XDSHeading level={2} xstyle={styles.sideNavHeading}>
+                  Account settings
+                </XDSHeading>
                 <XDSList density="spacious">
                   {NAV_ITEMS.map(item => (
                     <XDSListItem
@@ -330,7 +337,11 @@ export default function SettingsDialogTemplate() {
             <XDSLayoutContent isScrollable padding={0}>
               <XDSVStack xstyle={styles.headerPadding}>
                 <XDSDialogHeader
-                  title={activeNav === 'Personal information' ? 'Personal info' : activeNav}
+                  title={
+                    activeNav === 'Personal information'
+                      ? 'Personal info'
+                      : activeNav
+                  }
                   onOpenChange={open => setIsOpen(open)}
                   hasDivider={false}
                 />
@@ -467,8 +478,8 @@ export default function SettingsDialogTemplate() {
                               type="supporting"
                               color="secondary"
                               display="block">
-                              We&apos;re hiding some account details to
-                              protect your identity.
+                              We&apos;re hiding some account details to protect
+                              your identity.
                             </XDSText>
                           </XDSVStack>
                         </XDSHStack>
@@ -546,7 +557,9 @@ export default function SettingsDialogTemplate() {
                     {activeTab === 'login' && (
                       <XDSVStack gap={8}>
                         <XDSVStack gap={0}>
-                          <XDSHeading level={3} xstyle={styles.sectionHeading}>Login</XDSHeading>
+                          <XDSHeading level={3} xstyle={styles.sectionHeading}>
+                            Login
+                          </XDSHeading>
                           <XDSDivider />
                           {LOGIN_ROWS.map(row => (
                             <InfoRowItem key={row.label} {...row} />
@@ -554,7 +567,9 @@ export default function SettingsDialogTemplate() {
                         </XDSVStack>
 
                         <XDSVStack gap={0}>
-                          <XDSHeading level={3} xstyle={styles.sectionHeading}>Social accounts</XDSHeading>
+                          <XDSHeading level={3} xstyle={styles.sectionHeading}>
+                            Social accounts
+                          </XDSHeading>
                           <XDSDivider />
                           {SOCIAL_ROWS.map(row => (
                             <InfoRowItem key={row.label} {...row} />
@@ -562,7 +577,9 @@ export default function SettingsDialogTemplate() {
                         </XDSVStack>
 
                         <XDSVStack gap={0}>
-                          <XDSHeading level={3} xstyle={styles.sectionHeading}>Device history</XDSHeading>
+                          <XDSHeading level={3} xstyle={styles.sectionHeading}>
+                            Device history
+                          </XDSHeading>
                           <XDSDivider />
                           {DEVICE_ROWS.map((device, i) => (
                             <React.Fragment key={i}>
@@ -590,9 +607,7 @@ export default function SettingsDialogTemplate() {
                                   </XDSVStack>
                                 </XDSStackItem>
                                 {device.action && (
-                                  <XDSLink href="#">
-                                    {device.action}
-                                  </XDSLink>
+                                  <XDSLink href="#">{device.action}</XDSLink>
                                 )}
                               </XDSHStack>
                               <XDSDivider />
@@ -601,7 +616,9 @@ export default function SettingsDialogTemplate() {
                         </XDSVStack>
 
                         <XDSVStack gap={0}>
-                          <XDSHeading level={3} xstyle={styles.sectionHeading}>Account</XDSHeading>
+                          <XDSHeading level={3} xstyle={styles.sectionHeading}>
+                            Account
+                          </XDSHeading>
                           <XDSDivider />
                           <XDSHStack
                             hAlign="between"
@@ -621,9 +638,7 @@ export default function SettingsDialogTemplate() {
                                 This action cannot be undone
                               </XDSText>
                             </XDSVStack>
-                            <XDSLink href="#">
-                              Deactivate
-                            </XDSLink>
+                            <XDSLink href="#">Deactivate</XDSLink>
                           </XDSHStack>
                           <XDSDivider />
                         </XDSVStack>
@@ -633,7 +648,9 @@ export default function SettingsDialogTemplate() {
                     {activeTab === 'shared' && (
                       <XDSVStack gap={8}>
                         <XDSVStack gap={2}>
-                          <XDSHeading level={3} xstyle={styles.sectionHeading}>Shared access</XDSHeading>
+                          <XDSHeading level={3} xstyle={styles.sectionHeading}>
+                            Shared access
+                          </XDSHeading>
                           <XDSDivider />
                           <XDSText type="body" color="secondary">
                             Review each request carefully before approving
@@ -754,9 +771,7 @@ export default function SettingsDialogTemplate() {
                           <XDSText type="body" weight="semibold">
                             Blocked people
                           </XDSText>
-                          <XDSLink href="#">
-                            View
-                          </XDSLink>
+                          <XDSLink href="#">View</XDSLink>
                         </XDSHStack>
                         <XDSDivider />
                       </XDSVStack>
@@ -780,9 +795,7 @@ export default function SettingsDialogTemplate() {
                         <XDSHeading level={3}>Reviews</XDSHeading>
                         <XDSText type="supporting" color="secondary">
                           Choose what&apos;s shared when you write a review.{' '}
-                          <XDSLink
-                            href="#"
-                            type="supporting">
+                          <XDSLink href="#" type="supporting">
                             Learn more
                           </XDSLink>
                         </XDSText>
@@ -830,9 +843,7 @@ export default function SettingsDialogTemplate() {
                             <XDSText type="body">
                               Request my personal data
                             </XDSText>
-                            <XDSLink href="#">
-                              Request
-                            </XDSLink>
+                            <XDSLink href="#">Request</XDSLink>
                           </XDSHStack>
                         </XDSCard>
                         <XDSSwitch
@@ -846,9 +857,7 @@ export default function SettingsDialogTemplate() {
                         <XDSCard>
                           <XDSHStack hAlign="between" vAlign="center">
                             <XDSText type="body">Delete my account</XDSText>
-                            <XDSLink href="#">
-                              Delete
-                            </XDSLink>
+                            <XDSLink href="#">Delete</XDSLink>
                           </XDSHStack>
                         </XDSCard>
                         <XDSCard variant="muted">
@@ -866,9 +875,7 @@ export default function SettingsDialogTemplate() {
                               <XDSText type="supporting" color="secondary">
                                 We&apos;re committed to keeping your data
                                 protected. See details in our{' '}
-                                <XDSLink
-                                  href="#"
-                                  type="supporting">
+                                <XDSLink href="#" type="supporting">
                                   Privacy Policy
                                 </XDSLink>
                                 .
@@ -885,6 +892,6 @@ export default function SettingsDialogTemplate() {
           }
         />
       </XDSDialog>
-    </XDSAppShell>
+    </>
   );
 }

--- a/packages/cli/templates/pages/settings-sidebar/page.tsx
+++ b/packages/cli/templates/pages/settings-sidebar/page.tsx
@@ -4,13 +4,13 @@
 
 import {useState} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {XDSAppShell} from '@xds/core/AppShell';
 import {
   XDSVStack,
   XDSHStack,
   XDSStackItem,
   XDSLayout,
   XDSLayoutContent,
+  XDSLayoutPanel,
 } from '@xds/core/Layout';
 import {XDSList, XDSListItem} from '@xds/core/List';
 import {XDSText, XDSHeading} from '@xds/core/Text';
@@ -25,7 +25,11 @@ import {XDSTabList, XDSTab} from '@xds/core/TabList';
 import {XDSBadge} from '@xds/core/Badge';
 import {XDSIcon} from '@xds/core/Icon';
 import {XDSCenter} from '@xds/core/Center';
-import {colorVars, radiusVars, spacingVars} from '@xds/core/theme/tokens.stylex';
+import {
+  colorVars,
+  radiusVars,
+  spacingVars,
+} from '@xds/core/theme/tokens.stylex';
 import {
   UserIcon,
   LockClosedIcon,
@@ -118,11 +122,7 @@ function InfoRowItem({label, value, action}: InfoRow) {
             {value}
           </XDSText>
         </XDSVStack>
-        {action && (
-          <XDSLink href="#">
-            {action}
-          </XDSLink>
-        )}
+        {action && <XDSLink href="#">{action}</XDSLink>}
       </XDSHStack>
       <XDSDivider />
     </>
@@ -237,13 +237,15 @@ export default function SettingsSecurityTemplate() {
   const [emergencyContact, setEmergencyContact] = useState('Provided');
 
   return (
-    <XDSAppShell
+    <XDSLayout
       height="fill"
-      variant="section"
-      contentPadding={4}
-      sideNav={
-        <XDSVStack gap={4} xstyle={styles.sideNavPadding}>
-            <XDSHeading level={2} xstyle={styles.sideNavHeading}>Account settings</XDSHeading>
+      contentWidth={700}
+      start={
+        <XDSLayoutPanel hasDivider padding={0}>
+          <XDSVStack gap={4} xstyle={styles.sideNavPadding}>
+            <XDSHeading level={2} xstyle={styles.sideNavHeading}>
+              Account settings
+            </XDSHeading>
             <XDSList density="spacious">
               {NAV_ITEMS.map(item => (
                 <XDSListItem
@@ -263,537 +265,530 @@ export default function SettingsSecurityTemplate() {
                 onClick={() => {}}
               />
             </XDSList>
-        </XDSVStack>
-      }>
-      <XDSLayout contentWidth={700} content={
+          </XDSVStack>
+        </XDSLayoutPanel>
+      }
+      content={
         <XDSLayoutContent padding={4}>
-        <XDSVStack gap={0}>
-        {activeNav === 'Login & security' && (
-          <XDSVStack gap={6}>
-            <XDSHeading level={2}>Login &amp; security</XDSHeading>
+          <XDSVStack gap={0}>
+            {activeNav === 'Login & security' && (
+              <XDSVStack gap={6}>
+                <XDSHeading level={2}>Login &amp; security</XDSHeading>
 
-            <XDSTabList
-              value={activeTab}
-              onChange={setActiveTab}
-              hasDivider>
-              <XDSTab value="login" label="Login" />
-              <XDSTab value="shared" label="Shared access" />
-            </XDSTabList>
+                <XDSTabList
+                  value={activeTab}
+                  onChange={setActiveTab}
+                  hasDivider>
+                  <XDSTab value="login" label="Login" />
+                  <XDSTab value="shared" label="Shared access" />
+                </XDSTabList>
 
-            {activeTab === 'login' && (
-              <XDSVStack gap={8}>
-                <XDSVStack gap={0}>
-                  <XDSHeading level={3}>Login</XDSHeading>
-                  <XDSDivider />
-                  {LOGIN_ROWS.map(row => (
-                    <InfoRowItem key={row.label} {...row} />
-                  ))}
-                </XDSVStack>
+                {activeTab === 'login' && (
+                  <XDSVStack gap={8}>
+                    <XDSVStack gap={0}>
+                      <XDSHeading level={3}>Login</XDSHeading>
+                      <XDSDivider />
+                      {LOGIN_ROWS.map(row => (
+                        <InfoRowItem key={row.label} {...row} />
+                      ))}
+                    </XDSVStack>
 
-                <XDSVStack gap={0}>
-                  <XDSHeading level={3}>Social accounts</XDSHeading>
-                  <XDSDivider />
-                  {SOCIAL_ROWS.map(row => (
-                    <InfoRowItem key={row.label} {...row} />
-                  ))}
-                </XDSVStack>
+                    <XDSVStack gap={0}>
+                      <XDSHeading level={3}>Social accounts</XDSHeading>
+                      <XDSDivider />
+                      {SOCIAL_ROWS.map(row => (
+                        <InfoRowItem key={row.label} {...row} />
+                      ))}
+                    </XDSVStack>
 
-                <XDSVStack gap={0}>
-                  <XDSHeading level={3}>Device history</XDSHeading>
-                  <XDSDivider />
-                  {DEVICE_ROWS.map((device, i) => (
-                    <XDSHStack
-                      key={i}
-                      gap={3}
-                      vAlign="start"
-                      xstyle={styles.rowPadding}>
-                      <XDSIcon icon={ComputerDesktopIcon} />
-                      <XDSStackItem size="fill">
+                    <XDSVStack gap={0}>
+                      <XDSHeading level={3}>Device history</XDSHeading>
+                      <XDSDivider />
+                      {DEVICE_ROWS.map((device, i) => (
+                        <XDSHStack
+                          key={i}
+                          gap={3}
+                          vAlign="start"
+                          xstyle={styles.rowPadding}>
+                          <XDSIcon icon={ComputerDesktopIcon} />
+                          <XDSStackItem size="fill">
+                            <XDSVStack gap={0}>
+                              <XDSHStack gap={2} vAlign="center">
+                                <XDSText type="body" weight="semibold">
+                                  {device.label}
+                                </XDSText>
+                                {device.badge && (
+                                  <XDSBadge label={device.badge} />
+                                )}
+                              </XDSHStack>
+                              <XDSText
+                                type="supporting"
+                                color="secondary"
+                                display="block">
+                                {device.location}
+                              </XDSText>
+                            </XDSVStack>
+                          </XDSStackItem>
+                          {device.action && (
+                            <XDSLink href="#">{device.action}</XDSLink>
+                          )}
+                        </XDSHStack>
+                      ))}
+                      <XDSDivider />
+                    </XDSVStack>
+
+                    <XDSVStack gap={0}>
+                      <XDSHeading level={3}>Account</XDSHeading>
+                      <XDSDivider />
+                      <XDSHStack
+                        hAlign="between"
+                        vAlign="start"
+                        xstyle={styles.rowPadding}>
                         <XDSVStack gap={0}>
-                          <XDSHStack gap={2} vAlign="center">
-                            <XDSText type="body" weight="semibold">
-                              {device.label}
-                            </XDSText>
-                            {device.badge && (
-                              <XDSBadge label={device.badge} />
-                            )}
-                          </XDSHStack>
+                          <XDSText
+                            type="body"
+                            weight="semibold"
+                            display="block">
+                            Deactivate your account
+                          </XDSText>
                           <XDSText
                             type="supporting"
                             color="secondary"
                             display="block">
-                            {device.location}
+                            This action cannot be undone
                           </XDSText>
                         </XDSVStack>
-                      </XDSStackItem>
-                      {device.action && (
-                        <XDSLink href="#">
-                          {device.action}
-                        </XDSLink>
-                      )}
-                    </XDSHStack>
-                  ))}
-                  <XDSDivider />
-                </XDSVStack>
-
-                <XDSVStack gap={0}>
-                  <XDSHeading level={3}>Account</XDSHeading>
-                  <XDSDivider />
-                  <XDSHStack
-                    hAlign="between"
-                    vAlign="start"
-                    xstyle={styles.rowPadding}>
-                    <XDSVStack gap={0}>
-                      <XDSText type="body" weight="semibold" display="block">
-                        Deactivate your account
-                      </XDSText>
-                      <XDSText
-                        type="supporting"
-                        color="secondary"
-                        display="block">
-                        This action cannot be undone
-                      </XDSText>
+                        <XDSLink href="#">Deactivate</XDSLink>
+                      </XDSHStack>
+                      <XDSDivider />
                     </XDSVStack>
-                    <XDSLink href="#">
-                      Deactivate
-                    </XDSLink>
-                  </XDSHStack>
-                  <XDSDivider />
-                </XDSVStack>
-              </XDSVStack>
-            )}
+                  </XDSVStack>
+                )}
 
-            {activeTab === 'shared' && (
-              <XDSVStack gap={8}>
-                <XDSVStack gap={2}>
-                  <XDSHeading level={3}>Shared access</XDSHeading>
-                  <XDSDivider />
-                  <XDSText type="body" color="secondary">
-                    Review each request carefully before approving access.
-                    We&apos;ll email your employee or co-worker a 4-digit code
-                    that lets them log into your account with their trusted
-                    device.
-                  </XDSText>
-                </XDSVStack>
-
-                <XDSCard variant="muted">
-                  <XDSHStack gap={4} vAlign="start">
-                    <XDSCenter
-                      width={48}
-                      height={48}
-                      xstyle={styles.iconBox}>
-                      <XDSIcon icon={LockClosedIcon} />
-                    </XDSCenter>
-                    <XDSVStack gap={1}>
-                      <XDSText type="body" weight="bold">
-                        Adding devices from people you trust
-                      </XDSText>
+                {activeTab === 'shared' && (
+                  <XDSVStack gap={8}>
+                    <XDSVStack gap={2}>
+                      <XDSHeading level={3}>Shared access</XDSHeading>
+                      <XDSDivider />
                       <XDSText type="body" color="secondary">
-                        When you approve a request, you grant someone full
-                        access to your account. They&apos;ll be able to change
-                        reservations and send messages on your behalf.
+                        Review each request carefully before approving access.
+                        We&apos;ll email your employee or co-worker a 4-digit
+                        code that lets them log into your account with their
+                        trusted device.
                       </XDSText>
                     </XDSVStack>
-                  </XDSHStack>
+
+                    <XDSCard variant="muted">
+                      <XDSHStack gap={4} vAlign="start">
+                        <XDSCenter
+                          width={48}
+                          height={48}
+                          xstyle={styles.iconBox}>
+                          <XDSIcon icon={LockClosedIcon} />
+                        </XDSCenter>
+                        <XDSVStack gap={1}>
+                          <XDSText type="body" weight="bold">
+                            Adding devices from people you trust
+                          </XDSText>
+                          <XDSText type="body" color="secondary">
+                            When you approve a request, you grant someone full
+                            access to your account. They&apos;ll be able to
+                            change reservations and send messages on your
+                            behalf.
+                          </XDSText>
+                        </XDSVStack>
+                      </XDSHStack>
+                    </XDSCard>
+                  </XDSVStack>
+                )}
+              </XDSVStack>
+            )}
+
+            {activeNav === 'Languages & currency' && (
+              <XDSVStack gap={6}>
+                <XDSHeading level={2}>Languages &amp; currency</XDSHeading>
+                <XDSVStack gap={0}>
+                  <ExpandableRow
+                    label="Preferred language"
+                    value={
+                      LANGUAGES.find(l => l.value === language)?.label ??
+                      language
+                    }
+                    isExpanded={expandedRow === 'language'}
+                    onEdit={() => setExpandedRow('language')}
+                    onCancel={() => setExpandedRow(null)}
+                    onSave={() => setExpandedRow(null)}>
+                    <XDSSelector
+                      label="Language"
+                      isLabelHidden
+                      size="lg"
+                      value={language}
+                      onChange={setLanguage}
+                      options={LANGUAGES}
+                    />
+                  </ExpandableRow>
+                  <ExpandableRow
+                    label="Preferred currency"
+                    value={
+                      CURRENCIES.find(c => c.value === currency)?.label ??
+                      currency
+                    }
+                    isExpanded={expandedRow === 'currency'}
+                    onEdit={() => setExpandedRow('currency')}
+                    onCancel={() => setExpandedRow(null)}
+                    onSave={() => setExpandedRow(null)}>
+                    <XDSSelector
+                      label="Currency"
+                      isLabelHidden
+                      size="lg"
+                      value={currency}
+                      onChange={setCurrency}
+                      options={CURRENCIES}
+                    />
+                  </ExpandableRow>
+                  <ExpandableRow
+                    label="Time zone"
+                    value={
+                      TIMEZONES.find(t => t.value === timezone)?.label ??
+                      timezone
+                    }
+                    isExpanded={expandedRow === 'timezone'}
+                    onEdit={() => setExpandedRow('timezone')}
+                    onCancel={() => setExpandedRow(null)}
+                    onSave={() => setExpandedRow(null)}>
+                    <XDSSelector
+                      label="Time zone"
+                      isLabelHidden
+                      size="lg"
+                      value={timezone}
+                      onChange={setTimezone}
+                      options={TIMEZONES}
+                    />
+                  </ExpandableRow>
+                </XDSVStack>
+              </XDSVStack>
+            )}
+
+            {activeNav === 'Personal information' && (
+              <XDSVStack gap={6}>
+                <XDSHeading level={2}>Personal info</XDSHeading>
+                <XDSVStack gap={0}>
+                  <ExpandableRow
+                    label="Legal name"
+                    value={legalName}
+                    isExpanded={expandedRow === 'legalName'}
+                    onEdit={() => setExpandedRow('legalName')}
+                    onCancel={() => setExpandedRow(null)}
+                    onSave={() => setExpandedRow(null)}>
+                    <XDSTextInput
+                      label="Legal name"
+                      isLabelHidden
+                      value={legalName}
+                      onChange={setLegalName}
+                    />
+                  </ExpandableRow>
+                  <ExpandableRow
+                    label="Preferred first name"
+                    value={preferredName || 'Not provided'}
+                    isExpanded={expandedRow === 'preferredName'}
+                    onEdit={() => setExpandedRow('preferredName')}
+                    onCancel={() => setExpandedRow(null)}
+                    onSave={() => setExpandedRow(null)}>
+                    <XDSTextInput
+                      label="Preferred first name"
+                      isLabelHidden
+                      value={preferredName}
+                      onChange={setPreferredName}
+                    />
+                  </ExpandableRow>
+                  <ExpandableRow
+                    label="Email address"
+                    value={email}
+                    isExpanded={expandedRow === 'email'}
+                    onEdit={() => setExpandedRow('email')}
+                    onCancel={() => setExpandedRow(null)}
+                    onSave={() => setExpandedRow(null)}>
+                    <XDSTextInput
+                      label="Email address"
+                      isLabelHidden
+                      value={email}
+                      onChange={setEmail}
+                    />
+                  </ExpandableRow>
+                  <ExpandableRow
+                    label="Phone number"
+                    value={phone}
+                    isExpanded={expandedRow === 'phone'}
+                    onEdit={() => setExpandedRow('phone')}
+                    onCancel={() => setExpandedRow(null)}
+                    onSave={() => setExpandedRow(null)}>
+                    <XDSTextInput
+                      label="Phone number"
+                      isLabelHidden
+                      value={phone}
+                      onChange={setPhone}
+                    />
+                  </ExpandableRow>
+                  <InfoRowItem
+                    label="Identity verification"
+                    value="Verified"
+                    action=""
+                  />
+                  <ExpandableRow
+                    label="Residential address"
+                    value={address || 'Not provided'}
+                    isExpanded={expandedRow === 'address'}
+                    onEdit={() => setExpandedRow('address')}
+                    onCancel={() => setExpandedRow(null)}
+                    onSave={() => setExpandedRow(null)}>
+                    <XDSTextInput
+                      label="Residential address"
+                      isLabelHidden
+                      value={address}
+                      onChange={setAddress}
+                    />
+                  </ExpandableRow>
+                  <ExpandableRow
+                    label="Mailing address"
+                    value={mailingAddress || 'Not provided'}
+                    isExpanded={expandedRow === 'mailingAddress'}
+                    onEdit={() => setExpandedRow('mailingAddress')}
+                    onCancel={() => setExpandedRow(null)}
+                    onSave={() => setExpandedRow(null)}>
+                    <XDSTextInput
+                      label="Mailing address"
+                      isLabelHidden
+                      value={mailingAddress}
+                      onChange={setMailingAddress}
+                    />
+                  </ExpandableRow>
+                  <ExpandableRow
+                    label="Emergency contact"
+                    value={emergencyContact}
+                    isExpanded={expandedRow === 'emergencyContact'}
+                    onEdit={() => setExpandedRow('emergencyContact')}
+                    onCancel={() => setExpandedRow(null)}
+                    onSave={() => setExpandedRow(null)}>
+                    <XDSTextInput
+                      label="Emergency contact"
+                      isLabelHidden
+                      value={emergencyContact}
+                      onChange={setEmergencyContact}
+                    />
+                  </ExpandableRow>
+                </XDSVStack>
+
+                <XDSCard padding={0}>
+                  <XDSVStack gap={0} xstyle={styles.cardContentPadding}>
+                    <XDSHStack
+                      gap={3}
+                      vAlign="start"
+                      xstyle={styles.rowPadding}>
+                      <XDSCenter width={48} height={48} xstyle={styles.iconBox}>
+                        <XDSIcon icon={LockClosedIcon} />
+                      </XDSCenter>
+                      <XDSVStack gap={0}>
+                        <XDSText type="body" weight="semibold" display="block">
+                          Why isn&apos;t my info shown here?
+                        </XDSText>
+                        <XDSText
+                          type="supporting"
+                          color="secondary"
+                          display="block">
+                          We&apos;re hiding some account details to protect your
+                          identity.
+                        </XDSText>
+                      </XDSVStack>
+                    </XDSHStack>
+                    <XDSDivider />
+                    <XDSHStack
+                      gap={3}
+                      vAlign="start"
+                      xstyle={styles.rowPadding}>
+                      <XDSCenter width={48} height={48} xstyle={styles.iconBox}>
+                        <XDSIcon icon={PencilSquareIcon} />
+                      </XDSCenter>
+                      <XDSVStack gap={0}>
+                        <XDSText type="body" weight="semibold" display="block">
+                          Which details can be edited?
+                        </XDSText>
+                        <XDSText
+                          type="supporting"
+                          color="secondary"
+                          display="block">
+                          Contact info and personal details can be edited. If
+                          this info was used to verify your identity,
+                          you&apos;ll need to get verified again the next time
+                          you book—or to continue hosting.
+                        </XDSText>
+                      </XDSVStack>
+                    </XDSHStack>
+                    <XDSDivider />
+                    <XDSHStack
+                      gap={3}
+                      vAlign="start"
+                      xstyle={styles.rowPadding}>
+                      <XDSCenter width={48} height={48} xstyle={styles.iconBox}>
+                        <XDSIcon icon={ShareIcon} />
+                      </XDSCenter>
+                      <XDSVStack gap={0}>
+                        <XDSText type="body" weight="semibold" display="block">
+                          What info is shared with others?
+                        </XDSText>
+                        <XDSText
+                          type="supporting"
+                          color="secondary"
+                          display="block">
+                          We only release contact information after a
+                          reservation is confirmed.
+                        </XDSText>
+                      </XDSVStack>
+                    </XDSHStack>
+                  </XDSVStack>
                 </XDSCard>
               </XDSVStack>
             )}
-          </XDSVStack>
-        )}
 
-        {activeNav === 'Languages & currency' && (
-          <XDSVStack gap={6}>
-            <XDSHeading level={2}>Languages &amp; currency</XDSHeading>
-            <XDSVStack gap={0}>
-              <ExpandableRow
-                label="Preferred language"
-                value={
-                  LANGUAGES.find(l => l.value === language)?.label ?? language
-                }
-                isExpanded={expandedRow === 'language'}
-                onEdit={() => setExpandedRow('language')}
-                onCancel={() => setExpandedRow(null)}
-                onSave={() => setExpandedRow(null)}>
-                <XDSSelector
-                  label="Language"
-                  isLabelHidden
-                  size="lg"
-                  value={language}
-                  onChange={setLanguage}
-                  options={LANGUAGES}
-                />
-              </ExpandableRow>
-              <ExpandableRow
-                label="Preferred currency"
-                value={
-                  CURRENCIES.find(c => c.value === currency)?.label ?? currency
-                }
-                isExpanded={expandedRow === 'currency'}
-                onEdit={() => setExpandedRow('currency')}
-                onCancel={() => setExpandedRow(null)}
-                onSave={() => setExpandedRow(null)}>
-                <XDSSelector
-                  label="Currency"
-                  isLabelHidden
-                  size="lg"
-                  value={currency}
-                  onChange={setCurrency}
-                  options={CURRENCIES}
-                />
-              </ExpandableRow>
-              <ExpandableRow
-                label="Time zone"
-                value={
-                  TIMEZONES.find(t => t.value === timezone)?.label ?? timezone
-                }
-                isExpanded={expandedRow === 'timezone'}
-                onEdit={() => setExpandedRow('timezone')}
-                onCancel={() => setExpandedRow(null)}
-                onSave={() => setExpandedRow(null)}>
-                <XDSSelector
-                  label="Time zone"
-                  isLabelHidden
-                  size="lg"
-                  value={timezone}
-                  onChange={setTimezone}
-                  options={TIMEZONES}
-                />
-              </ExpandableRow>
-            </XDSVStack>
-          </XDSVStack>
-        )}
+            {activeNav === 'Privacy' && (
+              <XDSVStack gap={6}>
+                <XDSHeading level={2}>Privacy</XDSHeading>
 
-        {activeNav === 'Personal information' && (
-          <XDSVStack gap={6}>
-            <XDSHeading level={2}>Personal info</XDSHeading>
-            <XDSVStack gap={0}>
-              <ExpandableRow
-                label="Legal name"
-                value={legalName}
-                isExpanded={expandedRow === 'legalName'}
-                onEdit={() => setExpandedRow('legalName')}
-                onCancel={() => setExpandedRow(null)}
-                onSave={() => setExpandedRow(null)}>
-                <XDSTextInput
-                  label="Legal name"
-                  isLabelHidden
-                  value={legalName}
-                  onChange={setLegalName}
-                />
-              </ExpandableRow>
-              <ExpandableRow
-                label="Preferred first name"
-                value={preferredName || 'Not provided'}
-                isExpanded={expandedRow === 'preferredName'}
-                onEdit={() => setExpandedRow('preferredName')}
-                onCancel={() => setExpandedRow(null)}
-                onSave={() => setExpandedRow(null)}>
-                <XDSTextInput
-                  label="Preferred first name"
-                  isLabelHidden
-                  value={preferredName}
-                  onChange={setPreferredName}
-                />
-              </ExpandableRow>
-              <ExpandableRow
-                label="Email address"
-                value={email}
-                isExpanded={expandedRow === 'email'}
-                onEdit={() => setExpandedRow('email')}
-                onCancel={() => setExpandedRow(null)}
-                onSave={() => setExpandedRow(null)}>
-                <XDSTextInput
-                  label="Email address"
-                  isLabelHidden
-                  value={email}
-                  onChange={setEmail}
-                />
-              </ExpandableRow>
-              <ExpandableRow
-                label="Phone number"
-                value={phone}
-                isExpanded={expandedRow === 'phone'}
-                onEdit={() => setExpandedRow('phone')}
-                onCancel={() => setExpandedRow(null)}
-                onSave={() => setExpandedRow(null)}>
-                <XDSTextInput
-                  label="Phone number"
-                  isLabelHidden
-                  value={phone}
-                  onChange={setPhone}
-                />
-              </ExpandableRow>
-              <InfoRowItem
-                label="Identity verification"
-                value="Verified"
-                action=""
-              />
-              <ExpandableRow
-                label="Residential address"
-                value={address || 'Not provided'}
-                isExpanded={expandedRow === 'address'}
-                onEdit={() => setExpandedRow('address')}
-                onCancel={() => setExpandedRow(null)}
-                onSave={() => setExpandedRow(null)}>
-                <XDSTextInput
-                  label="Residential address"
-                  isLabelHidden
-                  value={address}
-                  onChange={setAddress}
-                />
-              </ExpandableRow>
-              <ExpandableRow
-                label="Mailing address"
-                value={mailingAddress || 'Not provided'}
-                isExpanded={expandedRow === 'mailingAddress'}
-                onEdit={() => setExpandedRow('mailingAddress')}
-                onCancel={() => setExpandedRow(null)}
-                onSave={() => setExpandedRow(null)}>
-                <XDSTextInput
-                  label="Mailing address"
-                  isLabelHidden
-                  value={mailingAddress}
-                  onChange={setMailingAddress}
-                />
-              </ExpandableRow>
-              <ExpandableRow
-                label="Emergency contact"
-                value={emergencyContact}
-                isExpanded={expandedRow === 'emergencyContact'}
-                onEdit={() => setExpandedRow('emergencyContact')}
-                onCancel={() => setExpandedRow(null)}
-                onSave={() => setExpandedRow(null)}>
-                <XDSTextInput
-                  label="Emergency contact"
-                  isLabelHidden
-                  value={emergencyContact}
-                  onChange={setEmergencyContact}
-                />
-              </ExpandableRow>
-            </XDSVStack>
-
-            <XDSCard padding={0}>
-              <XDSVStack gap={0} xstyle={styles.cardContentPadding}>
-                <XDSHStack gap={3} vAlign="start" xstyle={styles.rowPadding}>
-                  <XDSCenter
-                    width={48}
-                    height={48}
-                    xstyle={styles.iconBox}>
-                    <XDSIcon icon={LockClosedIcon} />
-                  </XDSCenter>
+                <XDSVStack gap={8}>
                   <XDSVStack gap={0}>
-                    <XDSText type="body" weight="semibold" display="block">
-                      Why isn&apos;t my info shown here?
-                    </XDSText>
-                    <XDSText
-                      type="supporting"
-                      color="secondary"
-                      display="block">
-                      We&apos;re hiding some account details to protect your
-                      identity.
-                    </XDSText>
-                  </XDSVStack>
-                </XDSHStack>
-                <XDSDivider />
-                <XDSHStack
-                  gap={3}
-                  vAlign="start"
-                  xstyle={styles.rowPadding}>
-                  <XDSCenter
-                    width={48}
-                    height={48}
-                    xstyle={styles.iconBox}>
-                    <XDSIcon icon={PencilSquareIcon} />
-                  </XDSCenter>
-                  <XDSVStack gap={0}>
-                    <XDSText type="body" weight="semibold" display="block">
-                      Which details can be edited?
-                    </XDSText>
-                    <XDSText
-                      type="supporting"
-                      color="secondary"
-                      display="block">
-                      Contact info and personal details can be edited. If this
-                      info was used to verify your identity, you&apos;ll need
-                      to get verified again the next time you book—or to
-                      continue hosting.
-                    </XDSText>
-                  </XDSVStack>
-                </XDSHStack>
-                <XDSDivider />
-                <XDSHStack gap={3} vAlign="start" xstyle={styles.rowPadding}>
-                  <XDSCenter
-                    width={48}
-                    height={48}
-                    xstyle={styles.iconBox}>
-                    <XDSIcon icon={ShareIcon} />
-                  </XDSCenter>
-                  <XDSVStack gap={0}>
-                    <XDSText type="body" weight="semibold" display="block">
-                      What info is shared with others?
-                    </XDSText>
-                    <XDSText
-                      type="supporting"
-                      color="secondary"
-                      display="block">
-                      We only release contact information after a reservation
-                      is confirmed.
-                    </XDSText>
-                  </XDSVStack>
-                </XDSHStack>
-              </XDSVStack>
-            </XDSCard>
-          </XDSVStack>
-        )}
-
-        {activeNav === 'Privacy' && (
-          <XDSVStack gap={6}>
-            <XDSHeading level={2}>Privacy</XDSHeading>
-
-            <XDSVStack gap={8}>
-              <XDSVStack gap={0}>
-                <XDSHeading level={3}>Messages</XDSHeading>
-                <XDSVStack xstyle={styles.rowPadding}>
-                  <XDSSwitch
-                    label="Show people when I've read their messages."
-                    value={readReceipts}
-                    onChange={setReadReceipts}
-                    labelPosition="start"
-                    labelSpacing="spread"
-                  />
-                </XDSVStack>
-                <XDSHStack
-                  hAlign="between"
-                  vAlign="center"
-                  xstyle={styles.rowPadding}>
-                  <XDSText type="body" weight="semibold">
-                    Blocked people
-                  </XDSText>
-                  <XDSLink href="#">
-                    View
-                  </XDSLink>
-                </XDSHStack>
-                <XDSDivider />
-              </XDSVStack>
-
-              <XDSVStack gap={0}>
-                <XDSHeading level={3}>Listings</XDSHeading>
-                <XDSVStack xstyle={styles.rowPadding}>
-                  <XDSSwitch
-                    label="Include my listing(s) in search engines"
-                    description="Turning this on means search engines, like Google, will display your listing page(s) in search results."
-                    value={searchEngines}
-                    onChange={setSearchEngines}
-                    labelPosition="start"
-                    labelSpacing="spread"
-                  />
-                </XDSVStack>
-                <XDSDivider />
-              </XDSVStack>
-
-              <XDSVStack gap={4}>
-                <XDSHeading level={3}>Reviews</XDSHeading>
-                <XDSText type="supporting" color="secondary">
-                  Choose what&apos;s shared when you write a review.{' '}
-                  <XDSLink href="#" type="supporting">
-                    Learn more
-                  </XDSLink>
-                </XDSText>
-                <XDSVStack gap={4}>
-                  <XDSSwitch
-                    label="Show my home city and country"
-                    description="Ex: City and country"
-                    value={showCity}
-                    onChange={setShowCity}
-                    labelPosition="start"
-                    labelSpacing="spread"
-                  />
-                  <XDSSwitch
-                    label="Show my trip type"
-                    description="Ex: Stayed with kids or pets"
-                    value={showTripType}
-                    onChange={setShowTripType}
-                    labelPosition="start"
-                    labelSpacing="spread"
-                  />
-                  <XDSSwitch
-                    label="Show my length of stay"
-                    description="Ex: A few nights, about a week, etc."
-                    value={showStayLength}
-                    onChange={setShowStayLength}
-                    labelPosition="start"
-                    labelSpacing="spread"
-                  />
-                  <XDSSwitch
-                    label="Show my booked services"
-                    description="Ex: Gourmet brunch or tasting menu"
-                    value={showServices}
-                    onChange={setShowServices}
-                    labelPosition="start"
-                    labelSpacing="spread"
-                  />
-                </XDSVStack>
-                <XDSDivider />
-              </XDSVStack>
-
-              <XDSVStack gap={4}>
-                <XDSHeading level={3}>Data privacy</XDSHeading>
-                <XDSCard>
-                  <XDSHStack hAlign="between" vAlign="center">
-                    <XDSText type="body">Request my personal data</XDSText>
-                    <XDSLink href="#">
-                      Request
-                    </XDSLink>
-                  </XDSHStack>
-                </XDSCard>
-                <XDSSwitch
-                  label="Help improve AI-powered features"
-                  description="When this is on, we use your data to develop and improve AI models."
-                  value={aiFeatures}
-                  onChange={setAiFeatures}
-                  labelPosition="start"
-                  labelSpacing="spread"
-                />
-                <XDSCard>
-                  <XDSHStack hAlign="between" vAlign="center">
-                    <XDSText type="body">Delete my account</XDSText>
-                    <XDSLink href="#">
-                      Delete
-                    </XDSLink>
-                  </XDSHStack>
-                </XDSCard>
-                <XDSCard variant="muted">
-                  <XDSHStack gap={4} vAlign="start">
-                    <XDSCenter
-                      width={48}
-                      height={48}
-                      xstyle={styles.iconBox}>
-                      <XDSIcon icon={ShieldCheckIcon} />
-                    </XDSCenter>
-                    <XDSVStack gap={1}>
-                      <XDSText type="body" weight="bold">
-                        Committed to privacy
-                      </XDSText>
-                      <XDSText type="supporting" color="secondary">
-                        We&apos;re committed to keeping your data protected.
-                        See details in our{' '}
-                        <XDSLink
-                          href="#"
-                          type="supporting">
-                          Privacy Policy
-                        </XDSLink>
-                        .
-                      </XDSText>
+                    <XDSHeading level={3}>Messages</XDSHeading>
+                    <XDSVStack xstyle={styles.rowPadding}>
+                      <XDSSwitch
+                        label="Show people when I've read their messages."
+                        value={readReceipts}
+                        onChange={setReadReceipts}
+                        labelPosition="start"
+                        labelSpacing="spread"
+                      />
                     </XDSVStack>
-                  </XDSHStack>
-                </XDSCard>
+                    <XDSHStack
+                      hAlign="between"
+                      vAlign="center"
+                      xstyle={styles.rowPadding}>
+                      <XDSText type="body" weight="semibold">
+                        Blocked people
+                      </XDSText>
+                      <XDSLink href="#">View</XDSLink>
+                    </XDSHStack>
+                    <XDSDivider />
+                  </XDSVStack>
+
+                  <XDSVStack gap={0}>
+                    <XDSHeading level={3}>Listings</XDSHeading>
+                    <XDSVStack xstyle={styles.rowPadding}>
+                      <XDSSwitch
+                        label="Include my listing(s) in search engines"
+                        description="Turning this on means search engines, like Google, will display your listing page(s) in search results."
+                        value={searchEngines}
+                        onChange={setSearchEngines}
+                        labelPosition="start"
+                        labelSpacing="spread"
+                      />
+                    </XDSVStack>
+                    <XDSDivider />
+                  </XDSVStack>
+
+                  <XDSVStack gap={4}>
+                    <XDSHeading level={3}>Reviews</XDSHeading>
+                    <XDSText type="supporting" color="secondary">
+                      Choose what&apos;s shared when you write a review.{' '}
+                      <XDSLink href="#" type="supporting">
+                        Learn more
+                      </XDSLink>
+                    </XDSText>
+                    <XDSVStack gap={4}>
+                      <XDSSwitch
+                        label="Show my home city and country"
+                        description="Ex: City and country"
+                        value={showCity}
+                        onChange={setShowCity}
+                        labelPosition="start"
+                        labelSpacing="spread"
+                      />
+                      <XDSSwitch
+                        label="Show my trip type"
+                        description="Ex: Stayed with kids or pets"
+                        value={showTripType}
+                        onChange={setShowTripType}
+                        labelPosition="start"
+                        labelSpacing="spread"
+                      />
+                      <XDSSwitch
+                        label="Show my length of stay"
+                        description="Ex: A few nights, about a week, etc."
+                        value={showStayLength}
+                        onChange={setShowStayLength}
+                        labelPosition="start"
+                        labelSpacing="spread"
+                      />
+                      <XDSSwitch
+                        label="Show my booked services"
+                        description="Ex: Gourmet brunch or tasting menu"
+                        value={showServices}
+                        onChange={setShowServices}
+                        labelPosition="start"
+                        labelSpacing="spread"
+                      />
+                    </XDSVStack>
+                    <XDSDivider />
+                  </XDSVStack>
+
+                  <XDSVStack gap={4}>
+                    <XDSHeading level={3}>Data privacy</XDSHeading>
+                    <XDSCard>
+                      <XDSHStack hAlign="between" vAlign="center">
+                        <XDSText type="body">Request my personal data</XDSText>
+                        <XDSLink href="#">Request</XDSLink>
+                      </XDSHStack>
+                    </XDSCard>
+                    <XDSSwitch
+                      label="Help improve AI-powered features"
+                      description="When this is on, we use your data to develop and improve AI models."
+                      value={aiFeatures}
+                      onChange={setAiFeatures}
+                      labelPosition="start"
+                      labelSpacing="spread"
+                    />
+                    <XDSCard>
+                      <XDSHStack hAlign="between" vAlign="center">
+                        <XDSText type="body">Delete my account</XDSText>
+                        <XDSLink href="#">Delete</XDSLink>
+                      </XDSHStack>
+                    </XDSCard>
+                    <XDSCard variant="muted">
+                      <XDSHStack gap={4} vAlign="start">
+                        <XDSCenter
+                          width={48}
+                          height={48}
+                          xstyle={styles.iconBox}>
+                          <XDSIcon icon={ShieldCheckIcon} />
+                        </XDSCenter>
+                        <XDSVStack gap={1}>
+                          <XDSText type="body" weight="bold">
+                            Committed to privacy
+                          </XDSText>
+                          <XDSText type="supporting" color="secondary">
+                            We&apos;re committed to keeping your data protected.
+                            See details in our{' '}
+                            <XDSLink href="#" type="supporting">
+                              Privacy Policy
+                            </XDSLink>
+                            .
+                          </XDSText>
+                        </XDSVStack>
+                      </XDSHStack>
+                    </XDSCard>
+                  </XDSVStack>
+                </XDSVStack>
               </XDSVStack>
-            </XDSVStack>
+            )}
           </XDSVStack>
-        )}
-      </XDSVStack>
         </XDSLayoutContent>
-      } />
-    </XDSAppShell>
+      }
+    />
   );
 }

--- a/packages/cli/templates/pages/settings/page.tsx
+++ b/packages/cli/templates/pages/settings/page.tsx
@@ -3,8 +3,15 @@
 'use client';
 
 import {useState} from 'react';
-import {XDSAppShell} from '@xds/core/AppShell';
-import {XDSVStack, XDSHStack, XDSStackItem} from '@xds/core/Layout';
+import {
+  XDSVStack,
+  XDSHStack,
+  XDSStackItem,
+  XDSLayout,
+  XDSLayoutContent,
+  XDSLayoutHeader,
+  XDSLayoutPanel,
+} from '@xds/core/Layout';
 import {XDSGrid} from '@xds/core/Grid';
 import {XDSList, XDSListItem} from '@xds/core/List';
 import {XDSText, XDSHeading} from '@xds/core/Text';
@@ -77,145 +84,154 @@ export default function SettingsTemplate() {
   );
 
   return (
-    <XDSAppShell
+    <XDSLayout
       height="auto"
-      variant="section"
-      contentPadding={4}
       xstyle={styles.constrainedShell}
-      topNav={
-        <XDSHStack vAlign="center" xstyle={styles.headerPadding}>
-          <XDSStackItem size="fill">
-            <XDSHeading level={1}>Settings</XDSHeading>
-          </XDSStackItem>
-          <XDSTypeahead
-            label="Search"
-            isLabelHidden
-            placeholder="Search settings..."
-            searchSource={settingsSearchSource}
-            value={searchValue}
-            onChange={setSearchValue}
-            hasEntriesOnFocus
-            startIcon={MagnifyingGlassIcon}
-          />
-        </XDSHStack>
+      header={
+        <XDSLayoutHeader hasDivider>
+          <XDSHStack vAlign="center" xstyle={styles.headerPadding}>
+            <XDSStackItem size="fill">
+              <XDSHeading level={1}>Settings</XDSHeading>
+            </XDSStackItem>
+            <XDSTypeahead
+              label="Search"
+              isLabelHidden
+              placeholder="Search settings..."
+              searchSource={settingsSearchSource}
+              value={searchValue}
+              onChange={setSearchValue}
+              hasEntriesOnFocus
+              startIcon={MagnifyingGlassIcon}
+            />
+          </XDSHStack>
+        </XDSLayoutHeader>
       }
-      sideNav={
-        <XDSSection padding={2} variant="transparent" xstyle={styles.sideNavWidth}>
-          <XDSList density="balanced">
-            {NAV_ITEMS.map(item => (
-              <XDSListItem
-                key={item}
-                label={item}
-                isSelected={activeNav === item}
-                onClick={() => setActiveNav(item)}
-              />
-            ))}
-          </XDSList>
-        </XDSSection>
-      }>
-      <XDSVStack gap={4}>
-        <XDSGrid columns={{minWidth: 320}} gap={10}>
-          <XDSVStack gap={1}>
-            <XDSHeading level={3}>Basic information</XDSHeading>
-            <XDSText type="supporting" color="secondary">
-              View and update your personal details and account information.
-            </XDSText>
-          </XDSVStack>
+      start={
+        <XDSLayoutPanel hasDivider={false} padding={0}>
+          <XDSSection
+            padding={2}
+            variant="transparent"
+            xstyle={styles.sideNavWidth}>
+            <XDSList density="balanced">
+              {NAV_ITEMS.map(item => (
+                <XDSListItem
+                  key={item}
+                  label={item}
+                  isSelected={activeNav === item}
+                  onClick={() => setActiveNav(item)}
+                />
+              ))}
+            </XDSList>
+          </XDSSection>
+        </XDSLayoutPanel>
+      }
+      content={
+        <XDSLayoutContent padding={4}>
           <XDSVStack gap={4}>
-            <XDSTextInput
-              label="Username"
-              value={username}
-              onChange={setUsername}
-            />
-            <XDSTextInput
-              label="First name"
-              value={firstName}
-              onChange={setFirstName}
-            />
-            <XDSTextInput
-              label="Last name"
-              value={lastName}
-              onChange={setLastName}
-            />
-            <XDSTextInput
-              label="Email address"
-              value={email}
-              onChange={setEmail}
-            />
-            <XDSHStack>
-              <XDSButton label="Save" variant="primary" />
-            </XDSHStack>
-          </XDSVStack>
-        </XDSGrid>
+            <XDSGrid columns={{minWidth: 320}} gap={10}>
+              <XDSVStack gap={1}>
+                <XDSHeading level={3}>Basic information</XDSHeading>
+                <XDSText type="supporting" color="secondary">
+                  View and update your personal details and account information.
+                </XDSText>
+              </XDSVStack>
+              <XDSVStack gap={4}>
+                <XDSTextInput
+                  label="Username"
+                  value={username}
+                  onChange={setUsername}
+                />
+                <XDSTextInput
+                  label="First name"
+                  value={firstName}
+                  onChange={setFirstName}
+                />
+                <XDSTextInput
+                  label="Last name"
+                  value={lastName}
+                  onChange={setLastName}
+                />
+                <XDSTextInput
+                  label="Email address"
+                  value={email}
+                  onChange={setEmail}
+                />
+                <XDSHStack>
+                  <XDSButton label="Save" variant="primary" />
+                </XDSHStack>
+              </XDSVStack>
+            </XDSGrid>
 
-        <XDSDivider />
+            <XDSDivider />
 
-        <XDSGrid columns={{minWidth: 320}} gap={10}>
-          <XDSVStack gap={1}>
-            <XDSHeading level={3}>Change password</XDSHeading>
-            <XDSText type="supporting" color="secondary">
-              Update your password to keep your account secure.
-            </XDSText>
-          </XDSVStack>
-          <XDSVStack gap={4}>
-            <XDSTextInput
-              label="Verify current password"
-              type="password"
-              value={currentPw}
-              onChange={setCurrentPw}
-            />
-            <XDSTextInput
-              label="New password"
-              type="password"
-              value={newPw}
-              onChange={setNewPw}
-            />
-            <XDSTextInput
-              label="Confirm password"
-              type="password"
-              value={confirmPw}
-              onChange={setConfirmPw}
-            />
-            <XDSHStack>
-              <XDSButton label="Save" variant="primary" />
-            </XDSHStack>
-          </XDSVStack>
-        </XDSGrid>
+            <XDSGrid columns={{minWidth: 320}} gap={10}>
+              <XDSVStack gap={1}>
+                <XDSHeading level={3}>Change password</XDSHeading>
+                <XDSText type="supporting" color="secondary">
+                  Update your password to keep your account secure.
+                </XDSText>
+              </XDSVStack>
+              <XDSVStack gap={4}>
+                <XDSTextInput
+                  label="Verify current password"
+                  type="password"
+                  value={currentPw}
+                  onChange={setCurrentPw}
+                />
+                <XDSTextInput
+                  label="New password"
+                  type="password"
+                  value={newPw}
+                  onChange={setNewPw}
+                />
+                <XDSTextInput
+                  label="Confirm password"
+                  type="password"
+                  value={confirmPw}
+                  onChange={setConfirmPw}
+                />
+                <XDSHStack>
+                  <XDSButton label="Save" variant="primary" />
+                </XDSHStack>
+              </XDSVStack>
+            </XDSGrid>
 
-        <XDSDivider />
+            <XDSDivider />
 
-        <XDSGrid columns={{minWidth: 320}} gap={10}>
-          <XDSVStack gap={1}>
-            <XDSHeading level={3}>Advanced settings</XDSHeading>
-            <XDSText type="supporting" color="secondary">
-              Configure detailed account preferences and security options.
-            </XDSText>
+            <XDSGrid columns={{minWidth: 320}} gap={10}>
+              <XDSVStack gap={1}>
+                <XDSHeading level={3}>Advanced settings</XDSHeading>
+                <XDSText type="supporting" color="secondary">
+                  Configure detailed account preferences and security options.
+                </XDSText>
+              </XDSVStack>
+              <XDSVStack gap={5}>
+                <XDSCheckboxInput
+                  label="Data Export Access"
+                  description="Allow export of personal data and backups."
+                  value={dataExport}
+                  onChange={setDataExport}
+                />
+                <XDSCheckboxInput
+                  label="Allow Admin to Add Members"
+                  description="Admins can invite and manage members."
+                  value={adminMembers}
+                  onChange={setAdminMembers}
+                />
+                <XDSCheckboxInput
+                  label="Enable Two-Factor Authentication"
+                  description="Require 2FA for added account security."
+                  value={twoFactor}
+                  onChange={setTwoFactor}
+                />
+                <XDSHStack>
+                  <XDSButton label="Save" variant="primary" />
+                </XDSHStack>
+              </XDSVStack>
+            </XDSGrid>
           </XDSVStack>
-          <XDSVStack gap={5}>
-            <XDSCheckboxInput
-              label="Data Export Access"
-              description="Allow export of personal data and backups."
-              value={dataExport}
-              onChange={setDataExport}
-            />
-            <XDSCheckboxInput
-              label="Allow Admin to Add Members"
-              description="Admins can invite and manage members."
-              value={adminMembers}
-              onChange={setAdminMembers}
-            />
-            <XDSCheckboxInput
-              label="Enable Two-Factor Authentication"
-              description="Require 2FA for added account security."
-              value={twoFactor}
-              onChange={setTwoFactor}
-            />
-            <XDSHStack>
-              <XDSButton label="Save" variant="primary" />
-            </XDSHStack>
-          </XDSVStack>
-        </XDSGrid>
-      </XDSVStack>
-    </XDSAppShell>
+        </XDSLayoutContent>
+      }
+    />
   );
 }

--- a/packages/cli/templates/pages/side-gallery/page.tsx
+++ b/packages/cli/templates/pages/side-gallery/page.tsx
@@ -2,8 +2,12 @@
 
 'use client';
 
-import {XDSAppShell} from '@xds/core/AppShell';
-import {XDSVStack, XDSHStack} from '@xds/core/Layout';
+import {
+  XDSVStack,
+  XDSHStack,
+  XDSLayout,
+  XDSLayoutContent,
+} from '@xds/core/Layout';
 import {XDSCenter} from '@xds/core/Center';
 import {XDSSection} from '@xds/core/Section';
 import {XDSText, XDSHeading} from '@xds/core/Text';
@@ -118,46 +122,55 @@ function ImageGrid() {
 
 export default function SideGalleryTemplate() {
   return (
-    <XDSAppShell height="auto" contentPadding={0} variant="surface">
-      <XDSCenter axis="horizontal">
-        <XDSSection variant="transparent" maxWidth={1400} padding={6}>
-          <div {...stylex.props(styles.splitLayout)}>
-            {/* Left side: Text + CTA */}
-            <XDSVStack gap={6} vAlign="center">
-              <XDSVStack gap={3}>
-                <XDSText type="supporting" color="secondary" weight="semibold">
-                  COLORFUL
-                </XDSText>
-                <XDSHeading level={1}>
-                  Make every day a little more delightful, one small detail at a
-                  time.
-                </XDSHeading>
-                <XDSText type="body" color="secondary">
-                  The smallest details are the ones that matter most. A little
-                  color that catches your eye and makes you pause; that&apos;s
-                  what turns an ordinary day into something worth remembering.
-                </XDSText>
-              </XDSVStack>
+    <XDSLayout
+      height="auto"
+      content={
+        <XDSLayoutContent padding={0}>
+          <XDSCenter axis="horizontal">
+            <XDSSection variant="transparent" maxWidth={1400} padding={6}>
+              <div {...stylex.props(styles.splitLayout)}>
+                {/* Left side: Text + CTA */}
+                <XDSVStack gap={6} vAlign="center">
+                  <XDSVStack gap={3}>
+                    <XDSText
+                      type="supporting"
+                      color="secondary"
+                      weight="semibold">
+                      COLORFUL
+                    </XDSText>
+                    <XDSHeading level={1}>
+                      Make every day a little more delightful, one small detail
+                      at a time.
+                    </XDSHeading>
+                    <XDSText type="body" color="secondary">
+                      The smallest details are the ones that matter most. A
+                      little color that catches your eye and makes you pause;
+                      that&apos;s what turns an ordinary day into something
+                      worth remembering.
+                    </XDSText>
+                  </XDSVStack>
 
-              <XDSHStack gap={3} vAlign="center">
-                <XDSButton label="Explore" variant="primary" />
-              </XDSHStack>
+                  <XDSHStack gap={3} vAlign="center">
+                    <XDSButton label="Explore" variant="primary" />
+                  </XDSHStack>
 
-              <XDSVStack gap={4}>
-                <XDSDivider />
-                <XDSHStack gap={6}>
-                  <StatBlock value="12k+" label="Photos" />
-                  <StatBlock value="350+" label="Projects" />
-                  <StatBlock value="8yrs" label="Experience" />
-                </XDSHStack>
-              </XDSVStack>
-            </XDSVStack>
+                  <XDSVStack gap={4}>
+                    <XDSDivider />
+                    <XDSHStack gap={6}>
+                      <StatBlock value="12k+" label="Photos" />
+                      <StatBlock value="350+" label="Projects" />
+                      <StatBlock value="8yrs" label="Experience" />
+                    </XDSHStack>
+                  </XDSVStack>
+                </XDSVStack>
 
-            {/* Right side: Image Grid */}
-            <ImageGrid />
-          </div>
-        </XDSSection>
-      </XDSCenter>
-    </XDSAppShell>
+                {/* Right side: Image Grid */}
+                <ImageGrid />
+              </div>
+            </XDSSection>
+          </XDSCenter>
+        </XDSLayoutContent>
+      }
+    />
   );
 }

--- a/packages/cli/templates/pages/table-grouped/page.tsx
+++ b/packages/cli/templates/pages/table-grouped/page.tsx
@@ -6,13 +6,6 @@ import React, {useState, useMemo} from 'react';
 import {useXDSResizable, XDSResizeHandle} from '@xds/core/Resizable';
 import type {ResizableProps} from '@xds/core/Resizable';
 import * as stylex from '@stylexjs/stylex';
-import {XDSAppShell} from '@xds/core/AppShell';
-import {
-  XDSSideNav,
-  XDSSideNavHeading,
-  XDSSideNavItem,
-  XDSSideNavSection,
-} from '@xds/core/SideNav';
 import {
   XDSLayout,
   XDSLayoutContent,
@@ -37,7 +30,6 @@ import {XDSRadioList, XDSRadioListItem} from '@xds/core/RadioList';
 import {XDSDropdownMenu} from '@xds/core/DropdownMenu';
 import {XDSCenter} from '@xds/core/Center';
 import {XDSIcon} from '@xds/core/Icon';
-import {XDSNavIcon} from '@xds/core/NavIcon';
 import {XDSStatusDot} from '@xds/core/StatusDot';
 import {XDSDivider} from '@xds/core/Divider';
 import {XDSMetadataList, XDSMetadataListItem} from '@xds/core/MetadataList';
@@ -51,12 +43,6 @@ import {
 } from '@xds/core/Table';
 import type {XDSTableColumn} from '@xds/core/Table';
 import {
-  ClockIcon,
-  InboxIcon,
-  Squares2X2Icon,
-  EyeIcon,
-  UserGroupIcon,
-  ArrowPathIcon,
   ChevronRightIcon,
   ChevronDownIcon,
   PencilIcon,
@@ -68,16 +54,7 @@ import {
   EllipsisHorizontalIcon,
 } from '@heroicons/react/24/outline';
 import {XMarkIcon} from '@heroicons/react/24/outline';
-import {
-  ChartBarIcon,
-  CommandLineIcon,
-  ClockIcon as ClockIconSolid,
-  InboxIcon as InboxIconSolid,
-  Squares2X2Icon as Squares2X2IconSolid,
-  EyeIcon as EyeIconSolid,
-  UserGroupIcon as UserGroupIconSolid,
-  ArrowPathIcon as ArrowPathIconSolid,
-} from '@heroicons/react/24/solid';
+import {ChartBarIcon} from '@heroicons/react/24/solid';
 
 const pageStyles = stylex.create({
   groupHeaderRow: {
@@ -754,107 +731,6 @@ const powerSearchConfig: PowerSearchConfig = {
   ],
 };
 
-function TaskTrackerSideNav() {
-  const [active, setActive] = useState('issues');
-  return (
-    <XDSSideNav
-      header={
-        <XDSSideNavHeading
-          heading="Acme"
-          icon={
-            <XDSNavIcon
-              icon={
-                <XDSIcon icon={CommandLineIcon} size="sm" color="inherit" />
-              }
-            />
-          }
-        />
-      }
-      collapsible>
-      <XDSSideNavSection title="Workspace" isHeaderHidden>
-        <XDSSideNavItem
-          label="Inbox"
-          icon={InboxIcon}
-          selectedIcon={InboxIconSolid}
-          isSelected={active === 'inbox'}
-          onClick={() => setActive('inbox')}
-        />
-        <XDSSideNavItem
-          label="My issues"
-          icon={ClockIcon}
-          selectedIcon={ClockIconSolid}
-          isSelected={active === 'my-issues'}
-          onClick={() => setActive('my-issues')}
-        />
-      </XDSSideNavSection>
-      <XDSSideNavSection title="Workspace">
-        <XDSSideNavItem
-          label="Projects"
-          icon={Squares2X2Icon}
-          selectedIcon={Squares2X2IconSolid}
-          isSelected={active === 'projects'}
-          onClick={() => setActive('projects')}
-        />
-        <XDSSideNavItem
-          label="Views"
-          icon={EyeIcon}
-          selectedIcon={EyeIconSolid}
-          isSelected={active === 'views'}
-          onClick={() => setActive('views')}
-        />
-        <XDSSideNavItem
-          label="Teams"
-          icon={UserGroupIcon}
-          selectedIcon={UserGroupIconSolid}
-          isSelected={active === 'teams'}
-          onClick={() => setActive('teams')}
-        />
-      </XDSSideNavSection>
-      <XDSSideNavSection title="Your teams">
-        <XDSSideNavItem
-          label="Issues"
-          icon={ClockIcon}
-          selectedIcon={ClockIconSolid}
-          isSelected={active === 'issues'}
-          onClick={() => setActive('issues')}
-          collapsible>
-          <XDSSideNavItem
-            label="Active"
-            isSelected={active === 'active'}
-            onClick={() => setActive('active')}
-          />
-          <XDSSideNavItem
-            label="Backlog"
-            isSelected={active === 'backlog'}
-            onClick={() => setActive('backlog')}
-          />
-        </XDSSideNavItem>
-        <XDSSideNavItem
-          label="Projects"
-          icon={Squares2X2Icon}
-          selectedIcon={Squares2X2IconSolid}
-          isSelected={active === 'team-projects'}
-          onClick={() => setActive('team-projects')}
-        />
-        <XDSSideNavItem
-          label="Views"
-          icon={EyeIcon}
-          selectedIcon={EyeIconSolid}
-          isSelected={active === 'team-views'}
-          onClick={() => setActive('team-views')}
-        />
-        <XDSSideNavItem
-          label="Cycles"
-          icon={ArrowPathIcon}
-          selectedIcon={ArrowPathIconSolid}
-          isSelected={active === 'cycles'}
-          onClick={() => setActive('cycles')}
-        />
-      </XDSSideNavSection>
-    </XDSSideNav>
-  );
-}
-
 const PRIORITY_LABEL: Record<TaskPriority, string> = {
   urgent: 'Urgent',
   high: 'High',
@@ -1026,10 +902,7 @@ export default function DataTableTemplate() {
   const resolvedWidths = resolveColumnWidths(columns);
 
   return (
-    <XDSAppShell
-      sideNav={<TaskTrackerSideNav />}
-      variant="elevated"
-      contentPadding={0}>
+    <>
       <XDSLayout
         height="fill"
         header={
@@ -1347,6 +1220,6 @@ export default function DataTableTemplate() {
           }
         />
       </XDSDialog>
-    </XDSAppShell>
+    </>
   );
 }

--- a/packages/cli/templates/pages/table-page-chart/page.tsx
+++ b/packages/cli/templates/pages/table-page-chart/page.tsx
@@ -2,8 +2,14 @@
 
 'use client';
 
-import {XDSAppShell} from '@xds/core/AppShell';
-import {XDSVStack, XDSHStack, XDSStackItem} from '@xds/core/Layout';
+import {
+  XDSVStack,
+  XDSHStack,
+  XDSStackItem,
+  XDSLayout,
+  XDSLayoutContent,
+  XDSLayoutHeader,
+} from '@xds/core/Layout';
 import {XDSText, XDSHeading} from '@xds/core/Text';
 import {XDSButton} from '@xds/core/Button';
 import {XDSIconButton} from '@xds/core/IconButton';
@@ -517,58 +523,66 @@ const columns: XDSTableColumn<OrderRow>[] = [
 
 export default function TablePageChartTemplate() {
   return (
-    <XDSAppShell variant="elevated" contentPadding={3} height="auto">
-      <XDSVStack gap={4}>
-        <XDSHStack gap={2} vAlign="center">
-          <XDSStackItem size="fill">
-            <XDSHeading level={1}>Sales</XDSHeading>
-          </XDSStackItem>
-          <XDSIconButton
-            label="Filter"
-            icon={<XDSIcon icon={FunnelIcon} size="sm" />}
-            variant="ghost"
-          />
-          <XDSIconButton
-            label="Export"
-            icon={<XDSIcon icon={ArrowDownTrayIcon} size="sm" />}
-            variant="ghost"
-          />
-          <XDSButton
-            label="New order"
-            icon={<XDSIcon icon={PlusIcon} size="sm" />}
-          />
-        </XDSHStack>
+    <XDSLayout
+      height="auto"
+      header={
+        <XDSLayoutHeader hasDivider>
+          <XDSHStack gap={2} vAlign="center">
+            <XDSStackItem size="fill">
+              <XDSHeading level={1}>Sales</XDSHeading>
+            </XDSStackItem>
+            <XDSIconButton
+              label="Filter"
+              icon={<XDSIcon icon={FunnelIcon} size="sm" />}
+              variant="ghost"
+            />
+            <XDSIconButton
+              label="Export"
+              icon={<XDSIcon icon={ArrowDownTrayIcon} size="sm" />}
+              variant="ghost"
+            />
+            <XDSButton
+              label="New order"
+              icon={<XDSIcon icon={PlusIcon} size="sm" />}
+            />
+          </XDSHStack>
+        </XDSLayoutHeader>
+      }
+      content={
+        <XDSLayoutContent padding={3}>
+          <XDSVStack gap={4}>
+            <XDSChart
+              data={revenueData}
+              xKey="date"
+              series={[
+                area('revenue', {color: '#14b8a6', gradient: true}),
+                line('revenue', {color: '#14b8a6'}),
+              ]}
+              grid={<XDSChartGrid horizontal />}
+              axes={
+                <>
+                  <XDSChartAxis position="bottom" />
+                  <XDSChartAxis
+                    position="left"
+                    tickFormat={(v: unknown) => `$${v}`}
+                  />
+                </>
+              }
+              height={280}
+              margin={{left: 40, right: 10, top: 10, bottom: 30}}
+            />
 
-        <XDSChart
-          data={revenueData}
-          xKey="date"
-          series={[
-            area('revenue', {color: '#14b8a6', gradient: true}),
-            line('revenue', {color: '#14b8a6'}),
-          ]}
-          grid={<XDSChartGrid horizontal />}
-          axes={
-            <>
-              <XDSChartAxis position="bottom" />
-              <XDSChartAxis
-                position="left"
-                tickFormat={(v: unknown) => `$${v}`}
-              />
-            </>
-          }
-          height={280}
-          margin={{left: 40, right: 10, top: 10, bottom: 30}}
-        />
-
-        <XDSTable<OrderRow>
-          data={orders}
-          columns={columns}
-          idKey="id"
-          density="balanced"
-          dividers="rows"
-          hasHover
-        />
-      </XDSVStack>
-    </XDSAppShell>
+            <XDSTable<OrderRow>
+              data={orders}
+              columns={columns}
+              idKey="id"
+              density="balanced"
+              dividers="rows"
+              hasHover
+            />
+          </XDSVStack>
+        </XDSLayoutContent>
+      }
+    />
   );
 }

--- a/packages/cli/templates/pages/table-page-heatmap-status/page.tsx
+++ b/packages/cli/templates/pages/table-page-heatmap-status/page.tsx
@@ -3,8 +3,14 @@
 'use client';
 
 import {useMemo} from 'react';
-import {XDSAppShell} from '@xds/core/AppShell';
-import {XDSVStack, XDSHStack, XDSStackItem} from '@xds/core/Layout';
+import {
+  XDSVStack,
+  XDSHStack,
+  XDSStackItem,
+  XDSLayout,
+  XDSLayoutContent,
+  XDSLayoutHeader,
+} from '@xds/core/Layout';
 import {XDSText, XDSHeading} from '@xds/core/Text';
 import {XDSButton} from '@xds/core/Button';
 import {XDSIconButton} from '@xds/core/IconButton';
@@ -423,39 +429,47 @@ function OutageHeatmap() {
 
 export default function TablePageHeatmapStatusTemplate() {
   return (
-    <XDSAppShell variant="elevated" contentPadding={3} height="auto">
-      <XDSVStack gap={4}>
-        <XDSHStack gap={2} vAlign="center">
-          <XDSStackItem size="fill">
-            <XDSHeading level={1}>Status</XDSHeading>
-          </XDSStackItem>
-          <XDSIconButton
-            label="Filter"
-            icon={<XDSIcon icon={FunnelIcon} size="sm" />}
-            variant="ghost"
-          />
-          <XDSIconButton
-            label="Export"
-            icon={<XDSIcon icon={ArrowDownTrayIcon} size="sm" />}
-            variant="ghost"
-          />
-          <XDSButton
-            label="Refresh"
-            icon={<XDSIcon icon={ArrowPathIcon} size="sm" />}
-          />
-        </XDSHStack>
+    <XDSLayout
+      height="auto"
+      header={
+        <XDSLayoutHeader hasDivider>
+          <XDSHStack gap={2} vAlign="center">
+            <XDSStackItem size="fill">
+              <XDSHeading level={1}>Status</XDSHeading>
+            </XDSStackItem>
+            <XDSIconButton
+              label="Filter"
+              icon={<XDSIcon icon={FunnelIcon} size="sm" />}
+              variant="ghost"
+            />
+            <XDSIconButton
+              label="Export"
+              icon={<XDSIcon icon={ArrowDownTrayIcon} size="sm" />}
+              variant="ghost"
+            />
+            <XDSButton
+              label="Refresh"
+              icon={<XDSIcon icon={ArrowPathIcon} size="sm" />}
+            />
+          </XDSHStack>
+        </XDSLayoutHeader>
+      }
+      content={
+        <XDSLayoutContent padding={3}>
+          <XDSVStack gap={4}>
+            <OutageHeatmap />
 
-        <OutageHeatmap />
-
-        <XDSTable<IncidentRow>
-          data={incidents}
-          columns={columns}
-          idKey="id"
-          density="balanced"
-          dividers="rows"
-          hasHover
-        />
-      </XDSVStack>
-    </XDSAppShell>
+            <XDSTable<IncidentRow>
+              data={incidents}
+              columns={columns}
+              idKey="id"
+              density="balanced"
+              dividers="rows"
+              hasHover
+            />
+          </XDSVStack>
+        </XDSLayoutContent>
+      }
+    />
   );
 }

--- a/packages/cli/templates/pages/table-page-shoe-store-heatmap/page.tsx
+++ b/packages/cli/templates/pages/table-page-shoe-store-heatmap/page.tsx
@@ -2,8 +2,14 @@
 
 'use client';
 
-import {XDSAppShell} from '@xds/core/AppShell';
-import {XDSVStack, XDSHStack, XDSStackItem} from '@xds/core/Layout';
+import {
+  XDSVStack,
+  XDSHStack,
+  XDSStackItem,
+  XDSLayout,
+  XDSLayoutContent,
+  XDSLayoutHeader,
+} from '@xds/core/Layout';
 import {XDSText, XDSHeading} from '@xds/core/Text';
 import {XDSButton} from '@xds/core/Button';
 import {XDSIconButton} from '@xds/core/IconButton';
@@ -874,58 +880,66 @@ const columns: XDSTableColumn<OrderRow>[] = [
 
 export default function TablePageShoeStoreHeatmapTemplate() {
   return (
-    <XDSAppShell variant="elevated" contentPadding={3} height="auto">
-      <XDSVStack gap={4}>
-        <XDSHStack gap={2} vAlign="center">
-          <XDSStackItem size="fill">
-            <XDSHeading level={1}>Sales</XDSHeading>
-          </XDSStackItem>
-          <XDSIconButton
-            label="Filter"
-            icon={<XDSIcon icon={FunnelIcon} size="sm" />}
-            variant="ghost"
-          />
-          <XDSIconButton
-            label="Export"
-            icon={<XDSIcon icon={ArrowDownTrayIcon} size="sm" />}
-            variant="ghost"
-          />
-          <XDSButton
-            label="New order"
-            icon={<XDSIcon icon={PlusIcon} size="sm" />}
-          />
-        </XDSHStack>
+    <XDSLayout
+      height="auto"
+      header={
+        <XDSLayoutHeader hasDivider>
+          <XDSHStack gap={2} vAlign="center">
+            <XDSStackItem size="fill">
+              <XDSHeading level={1}>Sales</XDSHeading>
+            </XDSStackItem>
+            <XDSIconButton
+              label="Filter"
+              icon={<XDSIcon icon={FunnelIcon} size="sm" />}
+              variant="ghost"
+            />
+            <XDSIconButton
+              label="Export"
+              icon={<XDSIcon icon={ArrowDownTrayIcon} size="sm" />}
+              variant="ghost"
+            />
+            <XDSButton
+              label="New order"
+              icon={<XDSIcon icon={PlusIcon} size="sm" />}
+            />
+          </XDSHStack>
+        </XDSLayoutHeader>
+      }
+      content={
+        <XDSLayoutContent padding={3}>
+          <XDSVStack gap={4}>
+            <XDSChart
+              data={revenueData}
+              xKey="date"
+              series={[
+                area('revenue', {color: '#3b82f6', gradient: true}),
+                line('revenue', {color: '#3b82f6'}),
+              ]}
+              grid={<XDSChartGrid horizontal />}
+              axes={
+                <>
+                  <XDSChartAxis position="bottom" />
+                  <XDSChartAxis
+                    position="left"
+                    tickFormat={(v: unknown) => `$${Number(v) / 1000}k`}
+                  />
+                </>
+              }
+              height={280}
+              margin={{left: 40, right: 10, top: 10, bottom: 30}}
+            />
 
-        <XDSChart
-          data={revenueData}
-          xKey="date"
-          series={[
-            area('revenue', {color: '#3b82f6', gradient: true}),
-            line('revenue', {color: '#3b82f6'}),
-          ]}
-          grid={<XDSChartGrid horizontal />}
-          axes={
-            <>
-              <XDSChartAxis position="bottom" />
-              <XDSChartAxis
-                position="left"
-                tickFormat={(v: unknown) => `$${Number(v) / 1000}k`}
-              />
-            </>
-          }
-          height={280}
-          margin={{left: 40, right: 10, top: 10, bottom: 30}}
-        />
-
-        <XDSTable<OrderRow>
-          data={orders}
-          columns={columns}
-          idKey="id"
-          density="balanced"
-          dividers="rows"
-          hasHover
-        />
-      </XDSVStack>
-    </XDSAppShell>
+            <XDSTable<OrderRow>
+              data={orders}
+              columns={columns}
+              idKey="id"
+              density="balanced"
+              dividers="rows"
+              hasHover
+            />
+          </XDSVStack>
+        </XDSLayoutContent>
+      }
+    />
   );
 }

--- a/packages/cli/templates/pages/table-page/page.tsx
+++ b/packages/cli/templates/pages/table-page/page.tsx
@@ -3,8 +3,14 @@
 'use client';
 
 import {useState, useMemo} from 'react';
-import {XDSAppShell} from '@xds/core/AppShell';
-import {XDSVStack, XDSHStack, XDSStackItem} from '@xds/core/Layout';
+import {
+  XDSVStack,
+  XDSHStack,
+  XDSStackItem,
+  XDSLayout,
+  XDSLayoutContent,
+  XDSLayoutHeader,
+} from '@xds/core/Layout';
 import {XDSText, XDSHeading} from '@xds/core/Text';
 import {XDSButton} from '@xds/core/Button';
 import {XDSIconButton} from '@xds/core/IconButton';
@@ -382,42 +388,54 @@ export default function TablePageTemplate() {
   }, [filters, applyFilters]);
 
   return (
-    <XDSAppShell variant="elevated" contentPadding={3} height="auto">
-      <XDSVStack gap={4}>
-        <XDSHStack gap={2} vAlign="center">
-          <XDSStackItem size="fill">
-            <XDSHeading level={1}>Dogs</XDSHeading>
-          </XDSStackItem>
-          <XDSIconButton
-            label="Filter"
-            icon={<XDSIcon icon={FunnelIcon} size="sm" />}
-            variant="ghost"
-          />
-          <XDSIconButton
-            label="Download"
-            icon={<XDSIcon icon={ArrowDownTrayIcon} size="sm" />}
-            variant="ghost"
-          />
-          <XDSButton label="Add" icon={<XDSIcon icon={PlusIcon} size="sm" />} />
-        </XDSHStack>
-        <XDSPowerSearch
-          config={config}
-          filters={filters}
-          onChange={newFilters => {
-            setFilters([...newFilters]);
-          }}
-          placeholder="Search dogs..."
-          resultCount={filtered.length}
-        />
-        <XDSTable<DogRow>
-          data={filtered}
-          columns={columns}
-          idKey="id"
-          density="balanced"
-          dividers="rows"
-          hasHover
-        />
-      </XDSVStack>
-    </XDSAppShell>
+    <XDSLayout
+      height="auto"
+      header={
+        <XDSLayoutHeader hasDivider>
+          <XDSHStack gap={2} vAlign="center">
+            <XDSStackItem size="fill">
+              <XDSHeading level={1}>Dogs</XDSHeading>
+            </XDSStackItem>
+            <XDSIconButton
+              label="Filter"
+              icon={<XDSIcon icon={FunnelIcon} size="sm" />}
+              variant="ghost"
+            />
+            <XDSIconButton
+              label="Download"
+              icon={<XDSIcon icon={ArrowDownTrayIcon} size="sm" />}
+              variant="ghost"
+            />
+            <XDSButton
+              label="Add"
+              icon={<XDSIcon icon={PlusIcon} size="sm" />}
+            />
+          </XDSHStack>
+        </XDSLayoutHeader>
+      }
+      content={
+        <XDSLayoutContent padding={3}>
+          <XDSVStack gap={4}>
+            <XDSPowerSearch
+              config={config}
+              filters={filters}
+              onChange={newFilters => {
+                setFilters([...newFilters]);
+              }}
+              placeholder="Search dogs..."
+              resultCount={filtered.length}
+            />
+            <XDSTable<DogRow>
+              data={filtered}
+              columns={columns}
+              idKey="id"
+              density="balanced"
+              dividers="rows"
+              hasHover
+            />
+          </XDSVStack>
+        </XDSLayoutContent>
+      }
+    />
   );
 }

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -15,8 +15,10 @@ node node_modules/@xds/core/docs.mjs --list --brief  # brief summaries
 ## Page Layouts
 
 Building a full page? Start with a template rather than composing from scratch.
-Templates show how to combine `XDSAppShell`, `XDSLayout`, `XDSTopNav`, and `XDSSideNav`
-into common page patterns (dashboards, settings, forms, detail pages).
+Templates are content-only — they compose `XDSLayout` with header, content, and
+panel slots into common page patterns (dashboards, settings, forms, detail pages).
+Wrap them in your own app chrome (`XDSAppShell`, `XDSTopNav`, `XDSSideNav`) to add
+global navigation.
 
 Requires `@xds/cli` (`npm install -D @xds/cli`):
 


### PR DESCRIPTION
## Summary

Removes `XDSAppShell` from all 27 page templates that used it, making every template **content-only**. Templates now compose `XDSLayout` (with header/content/panel slots) instead of providing their own app shell.

## Why

Two goals:
1. **Consistency** — every template is now content-only; none ship their own nav chrome.
2. **No internal/external shell conditional** — because templates never ship a shell, the host (internal App Chrome, OSS sandbox, or none) owns the shell. There's no "wrap in internal shell vs external shell" branch to maintain, and no shell-inside-a-shell nesting to detect/strip.

The decision that shaped the approach: since the internal App Chrome *swaps out* the AppShell, a template that ships its own (even empty-slotted) shell would collide with the host's. So templates must ship no shell at all. Shell + nav becomes a separate, swappable layer (the existing `blocks/components/AppShell/*` showcase blocks remain for that).

## Approach

Three nav treatments, applied per-template based on what the nav actually does:

| Treatment | When | Result |
|---|---|---|
| **Delete** | Global/app-chrome nav (Home/Orders, File/Edit/View, marketing top nav, conversation lists) | Removed; host provides |
| **→ `XDSLayoutHeader`** | Page header (title + page-level search/actions) | Promoted to layout header slot |
| **→ `XDSLayoutPanel` (start)** | In-page section nav (state-driven tab/section switching) | Moved into the body as a side panel |

`contentPadding` → `XDSLayoutContent padding`; `height` carries to `XDSLayout`; `variant` dropped (host paints background).

## Templates changed (27)

- **Container-only (9):** classic-gallery, mixed-gallery, payment-form, product-gallery, side-gallery, table-page, table-page-chart, table-page-heatmap-status, table-page-shoe-store-heatmap
- **App-chrome nav deleted (8):** detail-page, table-grouped, centered-hero, gallery-hero, product-detail, ai-chat, ai-chat-artifact, ai-chat-landing
- **In-page nav → panel (6):** settings, settings-sidebar, documentation, documentation-technical, documentation-design, ide
- **Dashboards/misc (4):** dashboard, dashboard-portfolio, library, settings-dialog

Deleted now-orphaned nav helpers (DashboardSideNav, ShopSideNav, StoreTopNav, AIChatSideNav, LibraryNav, TaskTrackerSideNav) and pruned unused imports. Updated `packages/core/README.md` to describe templates as content-only.

## Validation

- ESLint clean (0 errors, 0 warnings) across all 27 files.
- Each template's JSX parses; all `XDS*` identifiers used are imported.
- Prettier-formatted to repo config.

## Notes for reviewers

- `ide`: File/Edit/View menubar (app chrome) removed; the VSCode-style activity bar + file tree are intrinsic to the template, kept as layout panels.
- ai-chat surfaces use `XDSLayout height="fill"` so `XDSChatLayout` keeps full height.
- A follow-up will add a dedicated "Application Shell" template category for shell composition examples.