### PR TITLE
fix(CheckboxInput): add state props to checkbox xdsClassName

### DIFF
--- a/packages/core/src/CheckboxInput/XDSCheckboxInput.tsx
+++ b/packages/core/src/CheckboxInput/XDSCheckboxInput.tsx
@@ -430,7 +430,15 @@ export function XDSCheckboxInput({
           <div
             aria-hidden="true"
             {...mergeProps(
-              xdsClassName('checkbox'),
+              xdsClassName('checkbox', {
+                size,
+                checked: isChecked
+                  ? 'checked'
+                  : isIndeterminate
+                    ? 'indeterminate'
+                    : null,
+                disabled: isDisabled ? 'disabled' : null,
+              }),
               stylex.props(
                 styles.checkbox,
                 checkboxSizeStyles[size],


### PR DESCRIPTION
Adds `size`, `checked`/`indeterminate`, and `disabled` state to the inner checkbox element's `xdsClassName` call.

Previously, `xdsClassName('checkbox')` emitted only the base class (`.xds-checkbox`). Themes couldn't target individual states like `.xds-checkbox-checked` or `.xds-checkbox-disabled` for style overrides.

Now emits:
- `.xds-checkbox-sm` / `.xds-checkbox-md`
- `.xds-checkbox-checked` / `.xds-checkbox-indeterminate`
- `.xds-checkbox-disabled`

**Hardening:** Resolves conventions finding for CheckboxInput from #840.

Night Watch — Component Auditor