### PR TITLE
fix(Banner): use duration and ease tokens for chevron transition

### DIFF
--- a/packages/core/src/Banner/XDSBanner.tsx
+++ b/packages/core/src/Banner/XDSBanner.tsx
@@ -37,6 +37,8 @@ import {
   fontWeightVars,
   typeScaleVars,
   borderVars,
+  durationVars,
+  easeVars,
 } from '../theme/tokens.stylex';
 import {xdsClassName, mergeProps} from '../utils';
 import {edgeCompSlot} from '../Layout/edgeCompensation.stylex';
@@ -285,7 +287,9 @@ const styles = stylex.create({
   },
   chevron: {
     display: 'inline-flex',
-    transition: 'transform 150ms ease',
+    transitionProperty: 'transform',
+    transitionDuration: durationVars['--duration-fast'],
+    transitionTimingFunction: easeVars['--ease-standard'],
   },
   chevronExpanded: {
     transform: 'rotate(180deg)',


### PR DESCRIPTION
Replaces the hardcoded `transition: 'transform 150ms ease'` in the Banner chevron animation with `durationVars['--duration-fast']` and `easeVars['--ease-standard']` tokens.

This ensures the chevron expand/collapse animation respects theme-provided timing values and follows the convention of using token variables for all animation properties.

Night Watch — Component Auditor