### PR TITLE
fix(docsite): resolve heroicons imports in playground editor

### DIFF
--- a/apps/docsite/scripts/generate-playground-types.mjs
+++ b/apps/docsite/scripts/generate-playground-types.mjs
@@ -143,10 +143,50 @@ declare module '@stylexjs/stylex' {
 }
 `;
 
+// Heroicons ambient module declarations. Template and example code still
+// imports icons from '@heroicons/react/{16,20,24}/{outline,solid}'. Bundling
+// the package's ~10k individual .d.ts files would bloat the payload, so we
+// synthesize one ambient module per variant exposing each icon as a named
+// export. Icon names are read from the installed package's per-variant
+// index.d.ts so the set stays accurate (e.g. 16/solid ships fewer icons).
+function buildHeroiconTypes() {
+  const variants = ['16/solid', '20/solid', '24/outline', '24/solid'];
+  const heroRoot = join(root, '..', '..', 'node_modules', '@heroicons', 'react');
+  const iconType =
+    'React.ComponentType<React.SVGProps<SVGSVGElement> & ' +
+    '{title?: string; titleId?: string}>';
+  const files = {};
+
+  for (const variant of variants) {
+    const indexPath = join(heroRoot, variant, 'index.d.ts');
+    if (!existsSync(indexPath)) continue;
+
+    const src = readFileSync(indexPath, 'utf-8');
+    const names = [
+      ...src.matchAll(/export \{ default as (\w+) \}/g),
+    ].map(m => m[1]);
+    if (names.length === 0) continue;
+
+    const exports = names.map(n => `  export const ${n}: HeroIcon;`).join('\n');
+    files[`${variant}.d.ts`] =
+      `declare module '@heroicons/react/${variant}' {\n` +
+      `  type HeroIcon = ${iconType};\n` +
+      `${exports}\n}`;
+  }
+
+  return files;
+}
+
+const heroiconTypes = buildHeroiconTypes();
+console.log(
+  `Generated heroicon types: ${Object.keys(heroiconTypes).length} variants`,
+);
+
 const output = {
   '@xds/core': xdsTypes,
   react: {'index.d.ts': reactTypes, 'jsx-runtime.d.ts': reactJsxRuntimeTypes},
   '@stylexjs/stylex': {'index.d.ts': stylexTypes},
+  '@heroicons/react': heroiconTypes,
 };
 
 const json = JSON.stringify(output);

--- a/apps/docsite/src/app/playground/PlaygroundClient.tsx
+++ b/apps/docsite/src/app/playground/PlaygroundClient.tsx
@@ -237,6 +237,21 @@ function configureMonaco(monaco: MonacoInstance) {
         );
       }
 
+      // Heroicons ambient declarations, one per size/style variant. Template
+      // and example code imports icons by name from
+      // '@heroicons/react/{16,20,24}/{outline,solid}', so each declaration
+      // exposes the variant's icons as named exports. Without these, every
+      // heroicons import lights up with a "Cannot find module" red squiggle
+      // once semantic validation turns on below.
+      const heroiconFiles = packages['@heroicons/react'] ?? {};
+      for (const [fileName, content] of Object.entries(heroiconFiles)) {
+        const variant = fileName.replace(/\.d\.ts$/, '');
+        ts.addExtraLib(
+          content,
+          `file:///node_modules/@heroicons/react/${variant}/index.d.ts`,
+        );
+      }
+
       const xdsFiles = packages['@xds/core'] ?? {};
       const submoduleReexports: string[] = [];
 


### PR DESCRIPTION
## Problem

Viewing a template in the docsite Playground showed a red squiggle under every `@heroicons/react/*` import in the Monaco editor.

The cause is Monaco's TypeScript language service, not runtime module resolution. The editor had an ambient module declaration for `lucide-react` but **none** for `@heroicons/react/*`. Once the real type bundle loads and semantic validation turns on, every heroicons import was flagged "Cannot find module."

Heroicons is intentionally kept — lucide has no filled/solid variants that several templates rely on for nav-selected states and star ratings.

## Fix

Generate per-variant ambient module declarations for `@heroicons/react/{16,20,24}/{outline,solid}` in the playground types bundle (`generate-playground-types.mjs`), and register them with Monaco in `PlaygroundClient.tsx`.

Each declaration exposes the variant's icons as **named exports** (`export const FunnelIcon: HeroIcon`), so named imports like `import { FunnelIcon }` resolve. Icon names are read from the installed package's per-variant `index.d.ts`, so the set stays accurate — `16/solid` ships fewer icons (316) than the others (324). Bundling the package's ~10k individual `.d.ts` files would bloat the payload, so the declarations are synthesized instead.

## Testing

- Validated **all 420 named heroicon imports** across **97 template files** (126 import statements) resolve against the generated declarations — zero unresolved.
- Negative test: an unknown icon name still errors (the declaration isn't a catch-all `any`).
- `node --check` on the generator passes.

## Notes (out of scope)

- The runtime scope map already maps all four heroicon variants, so runtime rendering was never affected — only editor types.
- The existing `lucide-react` editor stub has the same latent defect (index signature, no named exports), but no template imports lucide by name so it's never exercised.
- `scripts/generate-scope.mjs` writes to a stale path while the runner imports from a different one.