### PR TITLE
fix(Chat): drawer muted tint paints over content (+ CLI parity fix)

### DIFF
--- a/packages/cli/src/api/component.mjs
+++ b/packages/cli/src/api/component.mjs
@@ -45,7 +45,7 @@ function resolveExternalPackage(packageName, cwd) {
  * @param {boolean} [options.source]
  * @param {boolean} [options.showcase]
  * @param {boolean} [options.blocks]
- * @param {'full'|'compact'|'brief'} [options.detail]
+ * @param {'full'|'compact'|'brief'} [options.detail] - Defaults to 'full' for a single component, 'brief' for list views (list/category/no name), matching the CLI.
  * @param {string} [options.lang]
  * @param {boolean} [options.zh]
  * @param {boolean} [options.dense]
@@ -61,11 +61,18 @@ export async function component(name, options = {}) {
     source = false,
     showcase = false,
     blocks = false,
-    detail = 'full',
+    detail: detailOption,
     lang = null,
     zh = false,
     dense = false,
   } = options;
+
+  // Default detail level mirrors the CLI (see commands/component/index.mjs):
+  // single-component views default to 'full', list-style views (--list,
+  // --category, or no name) default to 'brief' (scannable name lists).
+  // Keeping this in sync with the CLI is what the API↔CLI parity test checks.
+  const isListView = list || category != null || !name;
+  const detail = detailOption ?? (isListView ? 'brief' : 'full');
 
   const coreDir = findCoreDir(cwd);
   if (!coreDir) {

--- a/packages/core/src/Chat/XDSChatComposerDrawer.tsx
+++ b/packages/core/src/Chat/XDSChatComposerDrawer.tsx
@@ -88,16 +88,15 @@ const styles = stylex.create({
     paddingBlockStart: spacingVars['--spacing-3'],
     paddingBlockEnd: `calc(${spacingVars['--spacing-3']} + ${radiusVars['--radius-page']})`,
     marginBlockEnd: `calc(-1 * ${radiusVars['--radius-page']})`,
+    // Surface base with a muted tint layered on top, both in the element's
+    // own background layer. The muted backgroundImage composites over the
+    // surface backgroundColor and — by CSS rule — paints behind all in-flow
+    // content (tokens, labels, collapse handle) automatically. This restores
+    // the original "surface bg + muted tint" intent (#1182) without a
+    // positioned ::before, so it needs no z-index and works whether muted is
+    // opaque or translucent.
     backgroundColor: colorVars['--color-background-surface'],
-    '::before': {
-      content: '""',
-      position: 'absolute',
-      inset: 0,
-      borderTopLeftRadius: 'inherit',
-      borderTopRightRadius: 'inherit',
-      backgroundColor: colorVars['--color-background-muted'],
-      pointerEvents: 'none',
-    },
+    backgroundImage: `linear-gradient(${colorVars['--color-background-muted']}, ${colorVars['--color-background-muted']})`,
     borderTopLeftRadius: radiusVars['--radius-page'],
     borderTopRightRadius: radiusVars['--radius-page'],
   },


### PR DESCRIPTION
## Problem

On the ChatComposer docs (the **Full Featured** example), the drawer's `XDSToken`s show only the remove ✕ — no token shape, no labels — the collapse handle is invisible but still clickable, and collapsing makes content flicker then vanish.

## Root cause

`XDSChatComposerDrawer` painted its muted panel as an absolutely-positioned `::before`. A positioned descendant paints **above** in-flow content, so the tint covered the tokens, labels, and the collapse handle. `pointer-events: none` on the overlay is why the handle stayed clickable but unseen.

The bug was masked while `--color-background-muted` was near-transparent (default theme); it only surfaced under an opaque muted (the neutral theme, which wraps the doc previews).

## Fix

Express the fill the way the original intent (#1182, *"surface bg + muted tint"*) actually called for: a muted `backgroundImage` gradient layered over the surface `backgroundColor`, both in the element's **own background layer**. Backgrounds paint behind in-flow content by CSS rule, so content shows automatically — no positioned `::before`, no z-index, and it works whether muted is opaque or translucent.

```js
backgroundColor: colorVars['--color-background-surface'],
backgroundImage: `linear-gradient(${colorVars['--color-background-muted']}, ${colorVars['--color-background-muted']})`,
```

> Per review feedback, the `--color-background-muted` token change has been **pulled out** of this PR — it touches ~19 components and is a deliberate themes decision that deserves its own PR.

## Also included: CLI smoke-test fix

This PR's required `smoke-test` check (the **API \u2194 CLI parity** step) was failing **before this PR** — red on `main` and every open PR. #2522 changed the CLI so list-style component views default to `detail: 'brief'`, but `api component()` still defaulted to `'full'`, so the parity test saw `component.full` (API) vs `component.list` (CLI) for every category — 81 mismatches.

Fix (`packages/cli/src/api/component.mjs`): mirror the CLI's default in the API — list views default to `'brief'`, single-component views stay `'full'`. Matches the documented contract in `api/index.mjs`.

## Testing

- Chat + Token suites — **187 passed**
- API \u2194 CLI parity — **277 pass, 0 fail** (was 196/81)
- CLI smoke, `--json` smoke, `typecheck:json-api` — green
- `@xds/core` typecheck + build — clean; compiled CSS emits the muted `background-image` gradient on the drawer root
