### PR TITLE
fix(cli): align API list/category default detail with CLI (parity)

### DIFF
--- a/packages/cli/src/api/component.mjs
+++ b/packages/cli/src/api/component.mjs
@@ -61,11 +61,17 @@ export async function component(name, options = {}) {
     source = false,
     showcase = false,
     blocks = false,
-    detail = 'full',
+    detail: detailOpt,
     lang = null,
     zh = false,
     dense = false,
   } = options;
+
+  // Default detail depends on mode: single-component view defaults to 'full'
+  // (the rich doc the user asked for); list/category views default to 'brief'
+  // (a scannable name list). This mirrors the CLI command so the API and CLI
+  // stay in parity. Callers can override with an explicit detail value.
+  const detail = detailOpt || ((category || list || !name) ? 'brief' : 'full');
 
   const coreDir = findCoreDir(cwd);
   if (!coreDir) {

--- a/packages/cli/src/api/hook.mjs
+++ b/packages/cli/src/api/hook.mjs
@@ -31,10 +31,15 @@ export async function hook(name, options = {}) {
     list = false,
     category,
     params = false,
-    detail = 'full',
+    detail: detailOpt,
     lang = null,
     zh = false,
   } = options;
+
+  // Default detail depends on mode: single-hook view defaults to 'full'; list/
+  // category views default to 'brief' (scannable name list). Mirrors the CLI
+  // command so the API and CLI stay in parity. Callers can override.
+  const detail = detailOpt || ((category || list || !name) ? 'brief' : 'full');
 
   const coreDir = findCoreDir(cwd);
   if (!coreDir) {


### PR DESCRIPTION
## Problem

main's smoke-test is **red** — the API ↔ CLI parity test fails with 81 mismatches on every `component --list` / `--category` (and the hook equivalents).

Root cause: a default-detail split introduced when `--detail` ordering landed (#2522).
- The **CLI** command defaults list/category views to `brief` (scannable names) and single-component views to `full`.
- The **API** (`api.component` / `api.hook`) defaulted `detail` to `full` for **all** modes.

So `xds component --list` returned `component.list` while `api.component(undefined, {list:true})` returned `component.full` — same logical call, different envelope.

## Fix

Make the API mirror the CLI: list/category modes default to `brief`, single-item views stay `full`. Explicit `detail` still overrides. Applied to both `component` and `hook` APIs.

## Verification
- API ↔ CLI parity: **196/277 → 277/277**
- Full `@xds/cli` vitest suite: **774 passing**

This unblocks main's smoke-test and any branch currently red on the same parity failure.