### PR TITLE
fix(cli): align component/hook API detail default with CLI list views

### DIFF
--- a/packages/cli/src/api/component.mjs
+++ b/packages/cli/src/api/component.mjs
@@ -61,11 +61,19 @@ export async function component(name, options = {}) {
     source = false,
     showcase = false,
     blocks = false,
-    detail = 'full',
+    detail: detailOption,
     lang = null,
     zh = false,
     dense = false,
   } = options;
+
+  // Resolve the default detail level the same way the CLI does, so the API
+  // and `xds --json` agree by construction (enforced by the parity test):
+  // single-item views default to `full`; list views (--list, --category, or
+  // no name) default to `brief` because they are scannable name lists. An
+  // explicit `detail` always wins.
+  const isListView = list || Boolean(category) || !name;
+  const detail = detailOption ?? (isListView ? 'brief' : 'full');
 
   const coreDir = findCoreDir(cwd);
   if (!coreDir) {

--- a/packages/cli/src/api/hook.mjs
+++ b/packages/cli/src/api/hook.mjs
@@ -31,10 +31,16 @@ export async function hook(name, options = {}) {
     list = false,
     category,
     params = false,
-    detail = 'full',
+    detail: detailOption,
     lang = null,
     zh = false,
   } = options;
+
+  // Match the CLI's default-detail resolution so the API and `xds --json`
+  // agree: single-item views default to `full`, list views to `brief`. An
+  // explicit `detail` always wins.
+  const isListView = list || Boolean(category) || !name;
+  const detail = detailOption ?? (isListView ? 'brief' : 'full');
 
   const coreDir = findCoreDir(cwd);
   if (!coreDir) {


### PR DESCRIPTION
## Summary

The API↔CLI parity smoke test is **failing on `main`** (196 pass / 81 fail) — reproducible on a clean `origin/main` checkout with no other changes. This fixes it.

## Root cause

PR #2522 (`fix(cli): correct --detail level ordering on list views`) made list views default to `brief`, but it only applied that default in the **CLI command layer** (`commands/component/index.mjs`):

```js
const isListView = options.list || options.category || !name;
let detail = program.opts().detail || 'full';
if (isListView && detailSource === 'default') detail = 'brief';
```

The **API** (`api/component.mjs`) still hardcodes `detail = 'full'`. So the two now disagree for any bare list call:

- `xds --json component --list` → `component.list` (CLI applies the brief default)
- `api.component(undefined, {list: true})` → `component.full` (API defaults to full)

The parity test calls the API directly, so it correctly flags the divergence across all 81 list/category cases. `hook` has the identical latent divergence from the same PR.

## Fix

Move the default-detail resolution into the API so it matches the CLI by construction — single-item views default to `full`, list views (`--list`, `--category`, or no name) default to `brief`. An explicit `detail` always wins. Applied to both `component` and `hook`.

This is a one-place change per API; the CLI already passes a resolved `detail`, so CLI behavior is unchanged.

## Verification

- API↔CLI parity test: **277 pass / 0 fail** (was 196/81 on main).
- `npx vitest run packages/cli` → **63 files, 774 tests pass**.
- `detail-levels.test.mjs` (the #2522 coverage) still passes — it drives the CLI with explicit `--detail` flags, which are unaffected.

No envelope/type changes; only the *default* detail level for direct API list calls.
