### PR TITLE
chore(cli): remove dead 'doctor' entry from UPDATE_HINT_COMMANDS

### DIFF
--- a/packages/cli/src/index.mjs
+++ b/packages/cli/src/index.mjs
@@ -192,7 +192,7 @@ program.hook('postAction', (thisCommand, actionCommand) => {
  * Only fires for commands that produce output agents read (component, docs, etc.).
  * Suppressed when --json is active to avoid contaminating stdout.
  */
-const UPDATE_HINT_COMMANDS = new Set(['component', 'docs', 'doctor']);
+const UPDATE_HINT_COMMANDS = new Set(['component', 'docs']);
 program.hook('postAction', (thisCommand, actionCommand) => {
   if (program.opts().json) return;
   try {

--- a/packages/cli/src/update-hint-commands.test.mjs
+++ b/packages/cli/src/update-hint-commands.test.mjs
@@ -1,0 +1,41 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Guards the update-hint command allowlist.
+ *
+ * The post-action update hint only fires for a small set of commands
+ * (see UPDATE_HINT_COMMANDS in index.mjs). Every name in that set must
+ * map to a real, registered command — otherwise the entry is dead and
+ * the hint can never fire for it. This test imports the assembled
+ * program and verifies the invariant so a stale reference (like the
+ * removed 'doctor' entry) can't creep back in.
+ */
+
+import {describe, it, expect} from 'vitest';
+import {program} from './index.mjs';
+
+/** Commands the update hint is expected to fire for. */
+const HINTED_COMMANDS = ['component', 'docs'];
+
+/** Commands that have never existed and must not be referenced. */
+const NONEXISTENT_COMMANDS = ['doctor'];
+
+function registeredCommandNames() {
+  return program.commands.map((c) => c.name());
+}
+
+describe('update hint commands', () => {
+  it('fires only for real, registered commands', () => {
+    const registered = new Set(registeredCommandNames());
+    for (const name of HINTED_COMMANDS) {
+      expect(registered.has(name)).toBe(true);
+    }
+  });
+
+  it('does not register a "doctor" command (dead update-hint reference)', () => {
+    const registered = new Set(registeredCommandNames());
+    for (const name of NONEXISTENT_COMMANDS) {
+      expect(registered.has(name)).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## What

Removes the dead `'doctor'` reference from `UPDATE_HINT_COMMANDS` in `packages/cli/src/index.mjs`.

## Why

`UPDATE_HINT_COMMANDS` is the allowlist of commands whose `postAction` hook prints the "update available" hint. It contained `'doctor'`, but **no `doctor` command exists** anywhere in the CLI — the registered commands are `init`, `component`, `docs`, `swizzle`, `template`, `gap-report`, `upgrade`, `theme`, `hook`, and `discover`.

`grep -rn "doctor" packages/cli/src/` returns only the line in this set — it's a leftover from a planned-but-never-built command. Since `actionCommand.name()` can never equal `'doctor'`, the entry was pure dead weight. Minimal cleanup.

## Changes

- Drop `'doctor'` from `UPDATE_HINT_COMMANDS` (now `{'component', 'docs'}`).
- Add `update-hint-commands.test.mjs` — guards the invariant that every hint-eligible command is a real registered command, and that no `doctor` command exists (so a stale reference can't creep back in).

## Verification

- `npx vitest run packages/cli` → 64 files, 776 tests pass.
- `node packages/cli/bin/xds.mjs component --list` → exit 0.