### PR TITLE
fix(cli): avoid double-slash in theme build import path

### DIFF
--- a/packages/cli/src/commands/build-theme.import-path.test.mjs
+++ b/packages/cli/src/commands/build-theme.import-path.test.mjs
@@ -1,0 +1,97 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Regression test for `xds theme build` install-instructions import paths.
+ *
+ * Covers the relDir-empty case: when the output directory equals the current
+ * working directory, the relative dir is an empty string. Previously this
+ * produced a double-slash import path like `from './/<name>'`. The build now
+ * collapses the prefix to `./` so the emitted import is `from './<name>'`.
+ *
+ * Also covers the non-empty subdir case (`./<sub>/<name>`) to guard against
+ * regressions in the opposite direction.
+ */
+
+import {describe, it, expect, beforeEach, afterEach} from 'vitest';
+import {execFileSync} from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import {fileURLToPath} from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CLI_BIN = path.resolve(__dirname, '../../bin/xds.mjs');
+
+function runCli(args, cwd) {
+  try {
+    const out = execFileSync('node', [CLI_BIN, ...args], {
+      cwd,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: {...process.env, FORCE_COLOR: '0'},
+    });
+    return {code: 0, stdout: out, stderr: ''};
+  } catch (e) {
+    return {
+      code: e.status ?? 1,
+      stdout: e.stdout?.toString() ?? '',
+      stderr: e.stderr?.toString() ?? '',
+    };
+  }
+}
+
+function writeTheme(dir, name) {
+  fs.mkdirSync(dir, {recursive: true});
+  const file = path.join(dir, `${name}.mjs`);
+  fs.writeFileSync(
+    file,
+    `export default { name: ${JSON.stringify(name)}, tokens: { '--color-bg': '#fff' } };\n`,
+  );
+  return file;
+}
+
+let tmpDir;
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'xds-build-theme-import-path-'));
+});
+afterEach(() => {
+  fs.rmSync(tmpDir, {recursive: true, force: true});
+});
+
+describe('theme build install-instructions import path', () => {
+  it('emits ./<name> (no double slash) when out dir equals cwd', () => {
+    // Source theme lives directly in the project root, so the output dir
+    // is the cwd and the relative dir is an empty string.
+    const project = path.join(tmpDir, 'project');
+    const themeFile = writeTheme(project, 'cwd-theme');
+
+    const result = runCli(
+      ['theme', 'build', path.relative(project, themeFile)],
+      project,
+    );
+
+    expect(result.code).toBe(0);
+    // No double slash anywhere in the install instructions.
+    expect(result.stdout).not.toContain('.//');
+    // Import + css + link paths all use the clean ./<name> form.
+    expect(result.stdout).toContain("from './cwd-theme'");
+    expect(result.stdout).toContain("import './cwd-theme.css'");
+    expect(result.stdout).toContain('href="./cwd-theme.css"');
+  });
+
+  it('emits ./<sub>/<name> when out dir is a subdirectory of cwd', () => {
+    const project = path.join(tmpDir, 'project');
+    const themeFile = writeTheme(path.join(project, 'themes'), 'sub-theme');
+
+    const result = runCli(
+      ['theme', 'build', path.relative(project, themeFile)],
+      project,
+    );
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).not.toContain('.//');
+    expect(result.stdout).toContain("from './themes/sub-theme'");
+    expect(result.stdout).toContain("import './themes/sub-theme.css'");
+    expect(result.stdout).toContain('href="./themes/sub-theme.css"');
+  });
+});

--- a/packages/cli/src/commands/build-theme.mjs
+++ b/packages/cli/src/commands/build-theme.mjs
@@ -1241,12 +1241,16 @@ export function registerTheme(program) {
 
       // Print install instructions
       const relDir = path.relative(process.cwd(), outDir);
+      // When the output dir is the cwd, relDir is empty — avoid emitting a
+      // double-slash import path like './/<name>'. Build a './<relDir>/'
+      // prefix that collapses to './' when relDir is empty.
+      const importPrefix = relDir ? `./${relDir}/` : './';
       const exportName = `${toIdentifier(baseName)}Theme`;
       humanLog(`
 Install in your app:
 
-  import { ${exportName} } from './${relDir}/${baseName}';
-  import './${relDir}/${baseName}.css';
+  import { ${exportName} } from '${importPrefix}${baseName}';
+  import '${importPrefix}${baseName}.css';
 
   <XDSTheme theme={${exportName}}>
     <App />
@@ -1254,9 +1258,9 @@ Install in your app:
 
 Or with a <link> tag:
 
-  import { ${exportName} } from './${relDir}/${baseName}';
+  import { ${exportName} } from '${importPrefix}${baseName}';
 
-  <link rel="stylesheet" href="./${relDir}/${baseName}.css" />
+  <link rel="stylesheet" href="${importPrefix}${baseName}.css" />
   <XDSTheme theme={${exportName}}>
     <App />
   </XDSTheme>


### PR DESCRIPTION
## Problem

When `xds theme build` finishes, it prints install instructions containing import paths built from `relDir = path.relative(process.cwd(), outDir)`. If the output directory equals the current working directory — e.g. running `xds theme build mytheme.mjs` with the theme file in the project root — `relDir` is an empty string, so the template literal `'./${relDir}/${baseName}'` collapses to `'.//mytheme'` with a stray double slash. Users copy-pasting these instructions get an invalid/ugly import specifier.

## Fix

Compute a single `importPrefix` that collapses to `./` when `relDir` is empty and stays `./<relDir>/` otherwise:

```js
const importPrefix = relDir ? `./${relDir}/` : './';
```

Applied consistently across all four emitted paths (the JS `import`, the CSS `import`, the `<link>`-tag import, and the stylesheet `href`).

- out dir == cwd  →  `./mytheme`, `./mytheme.css`  (was `.//mytheme`)
- out dir == subdir  →  `./themes/mytheme` (unchanged, still correct)

## Tests

Added `build-theme.import-path.test.mjs`:
- builds a theme whose source lives in the project root (out dir == cwd) and asserts the emitted instructions contain `from './cwd-theme'`, `import './cwd-theme.css'`, `href="./cwd-theme.css"`, and contain no `.//`.
- builds a theme in a `themes/` subdir and asserts the non-empty case still emits `./themes/sub-theme`.

Full `packages/cli` vitest suite passes (64 files, 776 tests).