### PR TITLE
fix(cli): validate --lang against allowed locales

### DIFF
--- a/packages/cli/src/index.mjs
+++ b/packages/cli/src/index.mjs
@@ -66,7 +66,12 @@ program
   .version(pkg.version)
   .option('--zh', 'Output docs in Chinese Simplified')
   .option('--dense', 'Output docs in compressed dense format (token-efficient)')
-  .option('--lang <locale>', 'Output docs in specified language/format (en, zh, dense)')
+  .addOption(
+    new Option(
+      '--lang <locale>',
+      'Output docs in specified language/format (en, zh, dense)',
+    ).choices(['en', 'zh', 'dense']),
+  )
   .addOption(
     new Option('--detail <level>', 'Output detail level (full, compact, brief)')
       .choices(['full', 'compact', 'brief'])

--- a/packages/cli/src/lib/json-shim.test.mjs
+++ b/packages/cli/src/lib/json-shim.test.mjs
@@ -141,6 +141,37 @@ describe('--json shim: invalid --detail choice', () => {
   });
 });
 
+describe('--json shim: invalid --lang choice', () => {
+  it('xds docs color --lang fr --json emits a single error envelope, exit 1', () => {
+    const {status, stdout} = runCli(['docs', 'color', '--lang', 'fr', '--json']);
+    expect(status).toBe(1);
+    const parsed = parseJson(stdout);
+    expect(parsed.apiVersion).toBe(1);
+    expect(parsed.error).toMatch(/--lang/);
+    expect(parsed.error).toMatch(/invalid|allowed/i);
+    // Single emission only — stdout must be exactly one JSON document.
+    const topLevelBraces = stdout.split('\n').filter((l) => l === '{').length;
+    expect(topLevelBraces).toBe(1);
+  });
+
+  it('xds docs color --lang fr (no --json) writes to stderr and exits 1', () => {
+    const {status, stdout, stderr} = runCli(['docs', 'color', '--lang', 'fr']);
+    expect(status).toBe(1);
+    expect(stdout).toBe('');
+    expect(stderr).toMatch(/--lang/);
+  });
+
+  it('xds docs color --lang zh is accepted (exit 0)', () => {
+    const {status} = runCli(['docs', 'color', '--lang', 'zh']);
+    expect(status).toBe(0);
+  });
+
+  it('xds docs color --lang en is accepted (exit 0)', () => {
+    const {status} = runCli(['docs', 'color', '--lang', 'en']);
+    expect(status).toBe(0);
+  });
+});
+
 describe('--json shim: non-JSON behavior is preserved', () => {
   it('xds theme build (no --json, missing arg) writes to stderr and exits 1', () => {
     const {status, stdout, stderr} = runCli(['theme', 'build']);
@@ -185,6 +216,7 @@ describe('--json shim: stdout discipline under --json', () => {
       ['--bogus-flag', '--json'],
       ['bogus-cmd', '--json'],
       ['--detail', 'bogus', '--json'],
+      ['docs', 'color', '--lang', 'fr', '--json'],
     ];
     for (const args of cases) {
       const {stderr} = runCli(args);


### PR DESCRIPTION
## Problem

The global `--lang <locale>` option accepted **any** string. Passing an unsupported locale (e.g. `xds docs --lang fr`) silently fell back to English and exited `0`, masking the user's typo. The only valid values are `en`, `zh`, and `dense`.

## Fix

Give `--lang` a Commander `.choices(['en', 'zh', 'dense'])` constraint, mirroring exactly how `--detail` is already validated (`.choices(['full', 'compact', 'brief'])`). Now an invalid value produces a clear error and a non-zero exit:

```
error: option '--lang <locale>' argument 'fr' is invalid. Allowed choices are en, zh, dense.
```

This integrates cleanly with the existing json-shim / `exitOverride` setup: under `--json`, an invalid `--lang` now emits a proper JSON error envelope on stdout (`{ apiVersion, error }`) with empty stderr, exactly like other parse-time errors. The legacy `--zh` and `--dense` shortcut flags are untouched.

## Test coverage

Extended `packages/cli/src/lib/json-shim.test.mjs` (mirroring the existing `--detail` cases):
- `docs color --lang fr` → exit 1, stderr mentions `--lang`
- `docs color --lang fr --json` → single JSON error envelope, exit 1, empty stderr
- `docs color --lang zh` → exit 0
- `docs color --lang en` → exit 0

Full `packages/cli` suite passes (778 tests).