### PR TITLE
fix(cli): export hook from @xds/cli/api

### DIFF
--- a/packages/cli/src/api/index.mjs
+++ b/packages/cli/src/api/index.mjs
@@ -20,4 +20,5 @@ export {component} from './component.mjs';
 export {docs} from './docs.mjs';
 export {discover} from './discover.mjs';
 export {template} from './template.mjs';
+export {hook} from './hook.mjs';
 export {XDSError} from './error.mjs';

--- a/packages/cli/src/api/index.test.mjs
+++ b/packages/cli/src/api/index.test.mjs
@@ -1,0 +1,36 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {describe, it, expect} from 'vitest';
+import * as api from './index.mjs';
+
+// The public @xds/cli/api barrel should re-export every programmatic command
+// so consumers (AI agents, build tools) access them consistently.
+
+describe('@xds/cli/api barrel', () => {
+  it('re-exports all command functions and XDSError', () => {
+    for (const name of [
+      'component',
+      'docs',
+      'discover',
+      'template',
+      'hook',
+    ]) {
+      expect(typeof api[name], `expected api.${name} to be a function`).toBe(
+        'function',
+      );
+    }
+    expect(typeof api.XDSError).toBe('function');
+  });
+
+  it('exposes hook with parity to the other commands', () => {
+    // Regression guard: `hook` was previously missing from the barrel even
+    // though component/docs/discover/template were all exported.
+    expect(api.hook).toBeDefined();
+    expect(typeof api.hook).toBe('function');
+    // Returns a promise (async), like the other command APIs.
+    const result = api.hook(undefined, {cwd: '/nonexistent-xds-path'});
+    expect(result).toBeInstanceOf(Promise);
+    // Swallow the expected rejection (no @xds/core in this path).
+    return result.catch(() => {});
+  });
+});

--- a/packages/cli/src/types/api.d.ts
+++ b/packages/cli/src/types/api.d.ts
@@ -136,3 +136,20 @@ export declare function getTemplateById(
   id: string,
   options?: {cwd?: string},
 ): Promise<TemplateGetResponse>;
+
+// ── Hook ─────────────────────────────────────────────────────────────
+
+export interface HookOptions {
+  cwd?: string;
+  list?: boolean;
+  category?: string;
+  params?: boolean;
+  detail?: 'full' | 'compact' | 'brief';
+  lang?: string;
+  zh?: boolean;
+}
+
+export declare function hook(
+  name?: string,
+  options?: HookOptions,
+): Promise<{type: string; data: unknown}>;


### PR DESCRIPTION
## Problem

The CLI exposes a `hook` command and a programmatic API at `packages/cli/src/api/hook.mjs` (exporting an async `hook()` function), but `hook` was **not** re-exported from the public API barrel `packages/cli/src/api/index.mjs` — even though `component`, `docs`, `discover`, and `template` all are.

This left an inconsistency: programmatic consumers (AI agents, build tools) importing from `@xds/cli/api` could reach every command API *except* `hook`:

```js
import {component, docs, discover, template, hook} from '@xds/cli/api';
//                                              ^^^^ was undefined
```

## Fix

- Re-export `hook` from the API barrel (`src/api/index.mjs`), matching the existing pattern for the other commands.
- Add the matching `hook` type declaration (and `HookOptions` interface) to `src/types/api.d.ts` so TypeScript consumers of `@xds/cli/api` get types. `hook` returns the same generic `{ type, data }` envelope as `xds --json hook`.
- Add `src/api/index.test.mjs`: a barrel test asserting every command (`component`, `docs`, `discover`, `template`, `hook`) and `XDSError` are exported, with a regression guard specifically for `hook` parity.

## Verification

- `vitest run packages/cli` → **778 passed** (incl. new barrel test).
- `pnpm -F @xds/cli typecheck:json-api` → passes.

No behavior change to the `hook` command or its API — purely additive export parity.