### PR TITLE
fix(cli): friendly preflight error on unsupported Node versions

### DIFF
--- a/packages/cli/bin/xds.mjs
+++ b/packages/cli/bin/xds.mjs
@@ -1,9 +1,32 @@
 #!/usr/bin/env node
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-import {program} from '../src/index.mjs';
-import {isJsonMode, toErrorEnvelope} from '../src/lib/json.mjs';
-import {handleCommanderError} from '../src/lib/json-shim.mjs';
+// ---------------------------------------------------------------------------
+// Node.js version preflight gate.
+//
+// The CLI and its dependencies use `styleText` from `node:util`, added in Node
+// 22.13.0. On older runtimes the lazy-loaded subcommands die with a cryptic
+// ESM error ("...does not provide an export named 'styleText'"). To give users
+// a clear message instead, we check the running version FIRST, using only
+// built-ins, and exit early before importing anything that touches styleText.
+//
+// `node-version.mjs` is intentionally dependency-free so it loads on the
+// unsupported runtimes this guard protects against.
+import {
+  isNodeVersionSupported,
+  unsupportedNodeMessage,
+} from '../src/lib/node-version.mjs';
+
+if (!isNodeVersionSupported(process.versions.node)) {
+  console.error(unsupportedNodeMessage(process.versions.node));
+  process.exit(1);
+}
+
+// Imports that transitively load `styleText` must happen AFTER the gate above,
+// so they are dynamically imported here rather than at the top of the module.
+const {program} = await import('../src/index.mjs');
+const {isJsonMode, toErrorEnvelope} = await import('../src/lib/json.mjs');
+const {handleCommanderError} = await import('../src/lib/json-shim.mjs');
 
 /**
  * Top-level error boundary (contract guarantee #4): an uncaught throw must

--- a/packages/cli/src/lib/node-version.mjs
+++ b/packages/cli/src/lib/node-version.mjs
@@ -1,0 +1,69 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Node.js version preflight — runtime support gate.
+ *
+ * The CLI (and its dependencies) rely on `styleText` from `node:util`, which
+ * was only added in Node 22.13.0. On older runtimes the lazy-loaded
+ * subcommands die with a cryptic ESM error:
+ *
+ *   failed to load: The requested module 'node:util' does not provide an
+ *   export named 'styleText'
+ *
+ * This module exposes a tiny, dependency-free comparison helper so the entry
+ * point can gate on the running Node version BEFORE importing anything that
+ * touches `styleText`, and surface a clear "upgrade Node" message instead.
+ *
+ * Kept free of any non-builtin imports so it can run on the unsupported
+ * runtimes it is meant to guard against.
+ */
+
+/** Minimum supported Node.js version. */
+export const MIN_NODE_VERSION = '22.13.0';
+
+/**
+ * Parse a Node.js version string ("22.14.1", "v20.10.0", "16.20.2-nightly")
+ * into a {major, minor, patch} record. Missing or non-numeric segments
+ * default to 0.
+ *
+ * @param {string} version
+ * @returns {{major: number, minor: number, patch: number}}
+ */
+export function parseNodeVersion(version) {
+  const cleaned = String(version).trim().replace(/^v/, '');
+  const [major = 0, minor = 0, patch = 0] = cleaned
+    .split('.')
+    .map((seg) => parseInt(seg, 10) || 0);
+  return {major, minor, patch};
+}
+
+/**
+ * Returns true when `version` is greater than or equal to `minimum`.
+ * Compares major, then minor, then patch.
+ *
+ * @param {string} version - the running Node version (e.g. process.versions.node)
+ * @param {string} [minimum] - the minimum supported version
+ * @returns {boolean}
+ */
+export function isNodeVersionSupported(version, minimum = MIN_NODE_VERSION) {
+  const v = parseNodeVersion(version);
+  const min = parseNodeVersion(minimum);
+  if (v.major !== min.major) return v.major > min.major;
+  if (v.minor !== min.minor) return v.minor > min.minor;
+  return v.patch >= min.patch;
+}
+
+/**
+ * Builds the friendly, human-facing message shown when the runtime is too old.
+ *
+ * @param {string} version - the running Node version
+ * @param {string} [minimum] - the minimum supported version
+ * @returns {string}
+ */
+export function unsupportedNodeMessage(version, minimum = MIN_NODE_VERSION) {
+  const clean = String(version).trim().replace(/^v/, '');
+  return (
+    `xds requires Node.js >=${minimum} (you have v${clean}). ` +
+    `Please upgrade Node and try again.`
+  );
+}

--- a/packages/cli/src/lib/node-version.test.mjs
+++ b/packages/cli/src/lib/node-version.test.mjs
@@ -1,0 +1,91 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Unit tests for the Node.js version preflight gate (`node-version.mjs`).
+ *
+ * The CLI requires Node >=22.13.0 because dependencies import `styleText` from
+ * `node:util`, which only exists from that version onward. These tests lock in
+ * the parsing and comparison logic that decides whether the running runtime is
+ * supported, so the entry-point guard reliably rejects old Node and accepts new
+ * Node across the major.minor.patch boundary.
+ */
+
+import {describe, it, expect} from 'vitest';
+import {
+  MIN_NODE_VERSION,
+  parseNodeVersion,
+  isNodeVersionSupported,
+  unsupportedNodeMessage,
+} from './node-version.mjs';
+
+describe('parseNodeVersion', () => {
+  it('parses a plain semver string', () => {
+    expect(parseNodeVersion('22.14.1')).toEqual({major: 22, minor: 14, patch: 1});
+  });
+
+  it('strips a leading v', () => {
+    expect(parseNodeVersion('v20.10.0')).toEqual({major: 20, minor: 10, patch: 0});
+  });
+
+  it('ignores a prerelease/build suffix on the patch segment', () => {
+    expect(parseNodeVersion('16.20.2-nightly')).toEqual({major: 16, minor: 20, patch: 2});
+  });
+
+  it('defaults missing segments to 0', () => {
+    expect(parseNodeVersion('24')).toEqual({major: 24, minor: 0, patch: 0});
+  });
+});
+
+describe('isNodeVersionSupported', () => {
+  it('rejects clearly old majors', () => {
+    expect(isNodeVersionSupported('16.20.2')).toBe(false);
+    expect(isNodeVersionSupported('20.10.0')).toBe(false);
+  });
+
+  it('rejects the same major but an older minor', () => {
+    expect(isNodeVersionSupported('22.12.0')).toBe(false);
+  });
+
+  it('rejects the same major but an older minor regardless of patch', () => {
+    expect(isNodeVersionSupported('22.12.99')).toBe(false);
+  });
+
+  it('accepts exactly the minimum version', () => {
+    expect(isNodeVersionSupported('22.13.0')).toBe(true);
+  });
+
+  it('accepts a newer patch within the minimum minor', () => {
+    expect(isNodeVersionSupported('22.13.1')).toBe(true);
+  });
+
+  it('accepts a newer minor', () => {
+    expect(isNodeVersionSupported('22.14.1')).toBe(true);
+  });
+
+  it('accepts a newer major', () => {
+    expect(isNodeVersionSupported('24.1.0')).toBe(true);
+  });
+
+  it('handles a v-prefixed running version', () => {
+    expect(isNodeVersionSupported('v22.13.0')).toBe(true);
+    expect(isNodeVersionSupported('v18.0.0')).toBe(false);
+  });
+
+  it('uses MIN_NODE_VERSION (22.13.0) as the default threshold', () => {
+    expect(MIN_NODE_VERSION).toBe('22.13.0');
+    expect(isNodeVersionSupported(MIN_NODE_VERSION)).toBe(true);
+  });
+});
+
+describe('unsupportedNodeMessage', () => {
+  it('names both the required minimum and the running version', () => {
+    const msg = unsupportedNodeMessage('16.20.2');
+    expect(msg).toContain('>=22.13.0');
+    expect(msg).toContain('v16.20.2');
+    expect(msg).toContain('upgrade Node');
+  });
+
+  it('normalizes a v-prefixed running version to a single v', () => {
+    expect(unsupportedNodeMessage('v20.10.0')).toContain('v20.10.0');
+  });
+});


### PR DESCRIPTION
## Problem

The XDS CLI (and its dependencies) import `styleText` from `node:util`, which only exists in Node `>=22.13.0`. On older runtimes (e.g. v16, v20, or v22.12) every lazy-loaded subcommand dies during module load with a cryptic ESM error:

```
failed to load: The requested module 'node:util' does not provide an export named 'styleText'
```

Users get a baffling stack trace instead of a clear signal that their Node version is too old.

## Fix

Add a **version preflight gate** at the very top of the entry point (`packages/cli/bin/xds.mjs`), before any import that transitively loads `styleText`:

- Detect the running version via `process.versions.node` using **only built-ins**.
- If it's below the required minimum (`22.13.0`), print a friendly message to stderr and `exit 1`:
  > `xds requires Node.js >=22.13.0 (you have vX.Y.Z). Please upgrade Node and try again.`
- The styleText-using modules (`../src/index.mjs`, etc.) are now loaded via dynamic `import()` **after** the gate passes, so they never load on an unsupported runtime.

The comparison logic lives in a small, dependency-free helper (`packages/cli/src/lib/node-version.mjs`) so it loads even on the old runtimes it guards against, and so it's unit-testable.

## Version threshold

`22.13.0` — the first Node version to ship `styleText` as a stable export of `node:util`. Comparison is major → minor → patch.

## Test coverage

New unit tests in `packages/cli/src/lib/node-version.test.mjs` cover parsing and comparison (we can't easily run the CLI under old Node in CI, so the logic is tested directly):

- `16.20.2` → fail
- `20.10.0` → fail
- `22.12.0` (and `22.12.99`) → fail
- `22.13.0` → pass (exact minimum)
- `22.13.1`, `22.14.1`, `24.1.0` → pass
- v-prefixed and prerelease-suffixed version strings parse correctly
- message contains the threshold, the running version, and an upgrade hint

Full `packages/cli` suite: **64 files, 789 tests passing** (15 new). `node packages/cli/bin/xds.mjs --version` confirmed still works normally on Node 24.