### PR TITLE
fix(docsite): correct Chat group label and re-consolidate Navigation group

### DIFF
--- a/apps/docsite/scripts/generate-data.mjs
+++ b/apps/docsite/scripts/generate-data.mjs
@@ -520,6 +520,20 @@ export const componentCount = ${totalCount};
   return {allComponents, totalCount};
 }
 
+/**
+ * Humanize a raw group label (a PascalCase component/group name) into a
+ * spaced display label, e.g. 'TopNav' -> 'Top Nav', 'Chat' -> 'Chat'.
+ * Used as the group label when no member's name exactly matches the group
+ * (so the label doesn't fall back to an arbitrary member's displayName like
+ * 'Chat Composer' for the 'Chat' group).
+ */
+function humanizeGroupLabel(label) {
+  return label
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2')
+    .trim();
+}
+
 function generateGroupedComponentRegistry(allComponents) {
   console.log('Generating grouped component registry...');
 
@@ -591,10 +605,16 @@ function generateGroupedComponentRegistry(allComponents) {
       if (members.length === 1) {
         items.push({sortKey: members[0].name, item: {type: 'entry', name: members[0].name, displayName: members[0].displayName, href: members[0].href, description: members[0].description}});
       } else {
-        const canonical = members.find(m => m.name === label) || members[0];
-        // Use the canonical member's already-required displayName as the
-        // group label. Falls back to the raw label only as a safety net.
-        items.push({sortKey: label, item: {type: 'group', label, displayName: canonical.displayName || label, description: canonical.description, entries: members.map(m => ({name: m.name, displayName: m.displayName, href: m.href}))}});
+        const canonical = members.find(m => m.name === label);
+        // Prefer the canonical member's already-required displayName as the
+        // group label. When no member's name matches the group label (e.g. the
+        // 'Chat' group has no component literally named 'Chat'), humanize the
+        // raw label instead of falling back to an arbitrary member's
+        // displayName (which produced labels like 'Chat Composer').
+        const groupDisplayName = canonical
+          ? canonical.displayName
+          : humanizeGroupLabel(label);
+        items.push({sortKey: label, item: {type: 'group', label, displayName: groupDisplayName, description: (canonical || members[0]).description, entries: members.map(m => ({name: m.name, displayName: m.displayName, href: m.href}))}});
       }
     }
     for (const entry of ungrouped) {

--- a/packages/core/src/MobileNav/MobileNav.doc.mjs
+++ b/packages/core/src/MobileNav/MobileNav.doc.mjs
@@ -5,7 +5,7 @@
 export const docs = {
   name: 'MobileNav',
   displayName: 'Mobile Nav',
-  group: 'MobileNav',
+  group: 'Navigation',
   category: 'Navigation',
   isHiddenFromOverview: true,
   keywords: ["mobilenav","drawer","sidebar","navigation","hamburger","menu","offcanvas","slideout","navdrawer"],

--- a/packages/core/src/NavIcon/NavIcon.doc.mjs
+++ b/packages/core/src/NavIcon/NavIcon.doc.mjs
@@ -5,6 +5,7 @@
 export const docs = {
   name: 'NavIcon',
   displayName: 'Nav Icon',
+  group: 'Navigation',
   category: 'Navigation',
   isHiddenFromOverview: true,
   hidden: false,

--- a/packages/core/src/NavMenu/NavMenu.doc.mjs
+++ b/packages/core/src/NavMenu/NavMenu.doc.mjs
@@ -5,6 +5,7 @@
 export const docs = {
   name: 'NavHeadingMenu',
   displayName: 'Nav Heading Menu',
+  group: 'Navigation',
   category: 'Navigation',
   isHiddenFromOverview: true,
   hidden: false,

--- a/packages/core/src/SideNav/SideNav.doc.mjs
+++ b/packages/core/src/SideNav/SideNav.doc.mjs
@@ -5,7 +5,7 @@
 export const docs = {
   name: 'SideNav',
   displayName: 'Side Nav',
-  group: 'SideNav',
+  group: 'Navigation',
   category: 'Navigation',
   keywords: ["sidenav","sidebar","navigation","drawer","menu","nav","aside","sidemenu","navmenu","sider","treeview"],
   playground: {

--- a/packages/core/src/TopNav/TopNav.doc.mjs
+++ b/packages/core/src/TopNav/TopNav.doc.mjs
@@ -5,7 +5,7 @@
 export const docs = {
   name: 'TopNav',
   displayName: 'Top Nav',
-  group: 'TopNav',
+  group: 'Navigation',
   category: 'Navigation',
   keywords: ["topnav","navbar","appbar","header","toolbar","navigation","menubar","topbar"],
   playground: {


### PR DESCRIPTION
## What

Two related fixes to the **Components** sidebar accordions in the docsite.

### 1. Chat group mislabeled as "Chat Composer" (bug)

The grouped-component registry derived a group's display label from an **arbitrary member** when no component's name exactly matched the group label:

```js
const canonical = members.find(m => m.name === label) || members[0];
// displayName: canonical.displayName || label
```

The `Chat` group has no component literally named `Chat` (the `Chat.doc.mjs` parent only contributes sub-components like `XDSChatComposer`), so the label fell back to its alphabetically-first member → **"Chat Composer."**

Same root cause quietly mislabeled other groups:

| Group | Was shown as | Now |
|---|---|---|
| `Chat` | Chat Composer | **Chat** |
| `Checkbox` | Checkbox Input | **Checkbox** |
| `Tabs` | Tab | **Tabs** |
| `Radio` | Radio List | **Radio** |
| `Resizable` | Resize Handle | **Resizable** |

**Fix:** when no member's name matches the group label, humanize the raw PascalCase label (`TopNav` → "Top Nav", `Chat` → "Chat") instead of borrowing a member's `displayName`. Groups that *do* have a same-named member (Avatar, Button, Selector, …) are unchanged.

### 2. Re-consolidate Navigation into one sidebar group

Navigation was previously split into separate `TopNav` / `SideNav` / `MobileNav` accordions (#1657). This restores a single **Navigation** group by setting `group: 'Navigation'` on:

- `TopNav`
- `SideNav`
- `MobileNav`
- `NavHeadingMenu` (in `NavMenu/`)
- `NavIcon`

`Outline` and `Pagination` are intentionally left as separate entries.

## Testing

- Regenerated the registry: `Chat` group now labels "Chat" (15 entries); a single `Navigation` group contains all 15 nav entries; old `TopNav`/`SideNav`/`MobileNav` groups removed.
- `$XDS component --list` renders one consolidated **Navigation** group (Outline/Pagination remain separate).
- `apps/docsite` tests: 64 passed.
- `packages/cli` component tests: 45 passed.
- Pre-commit `check:sync` + `check:package-boundaries` clean.

> Note: `apps/docsite/src/generated/groupedComponentRegistry.ts` is build-time generated (gitignored), so no generated file is included in this PR.