### PR TITLE
fix(Carousel, Center): remove redundant prop re-declarations

### DIFF
--- a/packages/core/src/Carousel/XDSCarousel.tsx
+++ b/packages/core/src/Carousel/XDSCarousel.tsx
@@ -16,7 +16,6 @@
  */
 
 import {type ReactNode, useRef, useCallback, useEffect, Children} from 'react';
-import type {StyleXStyles} from '@stylexjs/stylex';
 import * as stylex from '@stylexjs/stylex';
 import {
   spacingVars,
@@ -57,20 +56,6 @@ export interface XDSCarouselProps extends XDSBaseProps<HTMLDivElement> {
    * @default 'Carousel'
    */
   'aria-label'?: string;
-
-  /**
-   * StyleX styles for layout customization (margins, positioning, sizing).
-   * Must be a `stylex.create()` value — not an inline style object.
-   *
-   * @example
-   * ```
-   * const styles = stylex.create({ wrapper: { marginTop: 8 } });
-   * <XDSCarousel xstyle={styles.wrapper} />
-   * ```
-   */
-  xstyle?: StyleXStyles;
-  className?: string;
-  style?: React.CSSProperties;
   'data-testid'?: string;
 }
 

--- a/packages/core/src/Center/XDSCenter.tsx
+++ b/packages/core/src/Center/XDSCenter.tsx
@@ -18,7 +18,6 @@
 import type {ReactNode} from 'react';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
-import type {StyleXStyles} from '@stylexjs/stylex';
 import type {SizeValue} from '../utils/types';
 import {xdsClassName, mergeProps} from '../utils';
 
@@ -84,28 +83,6 @@ export interface XDSCenterProps extends XDSBaseProps<HTMLDivElement> {
    * Content to render inside the center container.
    */
   children: ReactNode;
-
-  /**
-   * StyleX styles created via `stylex.create()`. Merged with the component's
-   * base styles inside a single `stylex.props()` call for optimal deduplication.
-   *
-   * @example
-   * ```
-   * const overrides = stylex.create({ root: { marginBottom: 8 } });
-   * <Component xstyle={overrides.root} />
-   * ```
-   */
-  xstyle?: StyleXStyles;
-  /**
-   * CSS class name(s) appended to the root element.
-   * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
-   */
-  className?: string;
-  /**
-   * Inline styles to apply to the root element. Spread after StyleX
-   * inline styles, so these values take priority.
-   */
-  style?: React.CSSProperties;
 }
 
 /**


### PR DESCRIPTION
Both `XDSCarouselProps` and `XDSCenterProps` extend `XDSBaseProps` which already provides `xstyle`, `className`, and `style`. Re-declaring them manually violates the convention that escape hatches must come from `XDSBaseProps` (or `Pick<XDSBaseProps, ...>`), never re-declared in the component interface.

**Changes:**
- **Carousel:** Remove redundant `xstyle`, `className`, `style` declarations and unused `StyleXStyles` import
- **Center:** Remove redundant `xstyle`, `className`, `style` declarations and unused `StyleXStyles` import

All tests pass. No behavior change — types are identical since `XDSBaseProps` already provides these props.

Night Watch — Component Auditor