### PR TITLE
docsite(landing): home page refresh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,12 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      # docsite `generate` runs `xds theme build`, which imports the compiled
+      # @xds/core/theme entry (dist/theme/index.js). Build core first so that
+      # entry exists — otherwise generate fails with "Cannot find module".
+      - name: Build core package
+        run: pnpm -F @xds/core build
+
       - name: Generate and test docsite data
         run: pnpm -F @xds/docsite generate && pnpm -F @xds/docsite test
 

--- a/apps/docsite/src/app/(site)/_landing/AboutShowcase.tsx
+++ b/apps/docsite/src/app/(site)/_landing/AboutShowcase.tsx
@@ -18,20 +18,16 @@ import {spacingVars} from '@xds/core/theme/tokens.stylex';
 // breakpoint on purpose — with 1 heading + 3 features, a 2-col grid
 // produces an awkward orphan column on the last row.
 //
-// Pastel shape colors are intentionally hardcoded (not theme tokens)
-// because Astryx's --color-background-{pink,purple,yellow} tokens are
-// translucent washes (33% alpha) that would render as washed-out gray
-// on the white showcase surface. The reference design calls for
-// SATURATED pastels, so we use literal hex values to hit the brief.
-// Decorative shape colors — light pastel in light mode, deep
-// saturated equivalent in dark mode via CSS light-dark() so the
-// shapes stay legible against both body backgrounds. These are
-// one-off marketing decorations not part of the semantic token
-// system, hence the literal hex values (kept inline so the
-// palette is easy to tune per shape).
-const PINK_PASTEL = 'light-dark(#FFC5D2, #5C1F2A)';
-const LAVENDER_PASTEL = 'light-dark(#D4C5F2, #3D1F5C)';
-const YELLOW_PASTEL = 'light-dark(#FEE48B, #5C4A0F)';
+// Decorative shape fills — pulled from the categorical
+// (non-semantic) background tokens so the shapes pick up each
+// theme's pink / purple / yellow ramp automatically and invert
+// for dark mode without hand-rolled palettes. These tokens are
+// 33% alpha pastel washes by default, which read perfectly as
+// soft decorative blobs on the white showcase surface, and any
+// theme can retint them centrally without touching this file.
+const PINK_PASTEL = 'var(--color-background-pink)';
+const LAVENDER_PASTEL = 'var(--color-background-purple)';
+const YELLOW_PASTEL = 'var(--color-background-yellow)';
 
 const SHAPE_SIZE = 40;
 
@@ -99,9 +95,15 @@ const styles = stylex.create({
       '@media (min-width: 1024px)': 'start',
     },
   },
-  // Decorative shape slot — fixed 48x48 box so the SVG renders at the
-  // expected size and the column header sits at a consistent baseline
-  // across all three feature columns.
+  // Decorative shape slot — fixed 40x40 box so the SVG renders at
+  // the expected size and the column header sits at a consistent
+  // baseline across all three feature columns.
+  //
+  // Rendered as a raw <span> in the JSX because XDS has no
+  // primitive for "fixed-size inline-block decorative SVG wrapper"
+  // (XDSIcon is glyph-only and bound to its registry; XDSThumbnail
+  // is chat-attachment chrome). The wrapper exists purely to reserve
+  // space and clip the shape — there is no semantic content here.
   shapeSlot: {
     width: SHAPE_SIZE,
     height: SHAPE_SIZE,
@@ -133,20 +135,19 @@ type AboutColumn = {
 // defined three soft, organic silhouettes (a 16-bump rounded
 // flower/blob, a pillow-shaped rounded square with concave sides,
 // and a rounded-corner diamond) that already match the "irregular
-// pastel splat" treatment in the new design reference. We reuse the
-// exact path data here and only swap the fill color (from the
-// translucent --color-background-{orange,purple,yellow} theme tokens
-// to saturated pastel hex values) and scale the viewBox-rendered
-// size from the original 40px to the spec's 48px.
+// pastel splat" treatment in the new design reference. We reuse
+// the exact path data here, swap the orange-channel to pink, and
+// render each shape at SHAPE_SIZE (40px) — same viewBox the
+// original used so the path math stays unchanged.
 //
-// Mapping (original color -> new pastel for this redesign):
-//   BlobIcon    (orange) -> Pink   #FFC5D2 -> "Design for speed"
-//   SquareIcon  (purple) -> Lavender #D4C5F2 -> "Built by the people who use it"
-//   DiamondIcon (yellow) -> Yellow #FEE48B -> "Ready for what's next"
+// Mapping (original color -> new categorical token):
+//   BlobIcon    (orange) -> --color-background-pink   "Design for speed"
+//   SquareIcon  (purple) -> --color-background-purple "Built by the people who use it"
+//   DiamondIcon (yellow) -> --color-background-yellow "Ready for what's next"
 
 // Pink "rounded flower" blob — 16 alternating bumps around a circle.
 // Reused verbatim from origin/main's BlobIcon (40x40 viewBox), just
-// scaled up to render at 48px and re-tinted from orange to pink.
+// re-tinted from the orange categorical token to the pink one.
 function PinkBlobShape() {
   return (
     <svg
@@ -274,6 +275,12 @@ function AboutColumn({column}: {column: AboutColumn}) {
 export function AboutShowcase() {
   return (
     <XDSVStack as="section" align="center" width="100%">
+      {/* sectionLayout / grid / columnsGrid are kept as plain <div>s
+          because each is a CSS-grid container with responsive
+          `grid-template-columns` (see styles below). XDSGrid hardcodes
+          a single integer column count and a single gap, so it can't
+          express the 1fr-stack → 1fr/2fr → repeat(3, 1fr) responsive
+          patterns this section needs. */}
       <div {...stylex.props(styles.sectionLayout)}>
         <div {...stylex.props(styles.grid)}>
           <AboutHeading />

--- a/apps/docsite/src/app/(site)/_landing/AboutShowcase.tsx
+++ b/apps/docsite/src/app/(site)/_landing/AboutShowcase.tsx
@@ -23,9 +23,15 @@ import {spacingVars} from '@xds/core/theme/tokens.stylex';
 // translucent washes (33% alpha) that would render as washed-out gray
 // on the white showcase surface. The reference design calls for
 // SATURATED pastels, so we use literal hex values to hit the brief.
-const PINK_PASTEL = '#FFC5D2';
-const LAVENDER_PASTEL = '#D4C5F2';
-const YELLOW_PASTEL = '#FEE48B';
+// Decorative shape colors — light pastel in light mode, deep
+// saturated equivalent in dark mode via CSS light-dark() so the
+// shapes stay legible against both body backgrounds. These are
+// one-off marketing decorations not part of the semantic token
+// system, hence the literal hex values (kept inline so the
+// palette is easy to tune per shape).
+const PINK_PASTEL = 'light-dark(#FFC5D2, #5C1F2A)';
+const LAVENDER_PASTEL = 'light-dark(#D4C5F2, #3D1F5C)';
+const YELLOW_PASTEL = 'light-dark(#FEE48B, #5C4A0F)';
 
 const SHAPE_SIZE = 40;
 

--- a/apps/docsite/src/app/(site)/_landing/AboutShowcase.tsx
+++ b/apps/docsite/src/app/(site)/_landing/AboutShowcase.tsx
@@ -4,146 +4,236 @@
 
 import type {ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {XDSCard, XDSVStack} from '@xds/core/Layout';
-import {XDSGrid} from '@xds/core/Grid';
-import {XDSAspectRatio} from '@xds/core/AspectRatio';
+import {XDSVStack} from '@xds/core/Layout';
 import {XDSHeading, XDSText} from '@xds/core/Text';
 import {XDSLink} from '@xds/core/Link';
+import {spacingVars} from '@xds/core/theme/tokens.stylex';
+
+// Editorial-style "about" section: a left-anchored heading block sits
+// alongside three feature columns. Each feature column leads with a
+// small pastel decorative shape, then a bold title, body copy, and a
+// "→" CTA link. The four blocks share a single CSS grid so they snap
+// to a clean 1fr / 1fr / 1fr / 1fr layout at >=720px and reflow into
+// a single stacked column below that. We skip an intermediate 2-col
+// breakpoint on purpose — with 1 heading + 3 features, a 2-col grid
+// produces an awkward orphan column on the last row.
+//
+// Pastel shape colors are intentionally hardcoded (not theme tokens)
+// because Astryx's --color-background-{pink,purple,yellow} tokens are
+// translucent washes (33% alpha) that would render as washed-out gray
+// on the white showcase surface. The reference design calls for
+// SATURATED pastels, so we use literal hex values to hit the brief.
+const PINK_PASTEL = '#FFC5D2';
+const LAVENDER_PASTEL = '#D4C5F2';
+const YELLOW_PASTEL = '#FEE48B';
+
+const SHAPE_SIZE = 40;
 
 const styles = stylex.create({
-  headingBlock: {
-    textAlign: 'center',
-    width: '100%',
-    maxWidth: 680,
-  },
-  // Layout glue for the XDSGrid: cap at 1200px. XDSGrid doesn't expose
-  // maxWidth as a prop, so we pass it through xstyle.
-  gridLayout: {
+  // Cap the section at the same 1200px maxWidth used by sibling
+  // showcases (Features, Discover) so all three sections line up
+  // vertically inside the showcaseOverlay container.
+  sectionLayout: {
     width: '100%',
     maxWidth: 1200,
   },
-  iconSlot: {
-    height: 40,
+  // Responsive grid for the heading + 3 feature columns.
+  //
+  // Breakpoints (mirrors FeaturesShowcase):
+  //   < 1024px  -> 1 column (everything stacks vertically)
+  //   >= 1024px -> heading 1fr | 3-feature-grid 2fr side-by-side
+  //
+  // We skip the intermediate 2-col arrangement because at
+  // 720-1023 the 1fr / 2fr split squishes each sub-column to
+  // ~150px which makes the body copy unreadable. Going straight
+  // from 1-col stack to the full desktop layout keeps the design
+  // legible at every width.
+  grid: {
+    width: '100%',
+    display: 'grid',
+    gap: spacingVars['--spacing-8'],
+    gridTemplateColumns: {
+      default: '1fr',
+      '@media (min-width: 1024px)': '1fr 2fr',
+    },
   },
-  // "ABOUT US" eyebrow heading above the section title. Uppercase +
-  // tracked, matching the editorial treatment on the Features
-  // section above.
-  eyebrow: {
-    textTransform: 'uppercase',
-    letterSpacing: '0.08em',
+  // Inner sub-grid for the three feature columns — split evenly
+  // inside the 2/3 cell on the right of the parent grid. Same
+  // breakpoint as the outer grid so the stack/3-col switch
+  // happens together.
+  columnsGrid: {
+    display: 'grid',
+    gap: spacingVars['--spacing-8'],
+    gridTemplateColumns: {
+      default: '1fr',
+      '@media (min-width: 1024px)': 'repeat(3, 1fr)',
+    },
   },
-  // Constrain the description copy under the section heading so it
-  // doesn't run too wide; 560px reads as ~70 characters per line.
-  descriptionWidth: {
-    maxWidth: 560,
+  // Each feature column: shape on top, then a small gap, then title,
+  // body, and link. Always flush-left at every viewport — at desktop
+  // it reads as a side-by-side editorial layout; at mobile the
+  // columns stack vertically but stay left-aligned for consistency.
+  column: {
+    width: '100%',
+    alignItems: 'flex-start',
+    textAlign: 'start',
+  },
+  // Mobile centering for the section heading + description block.
+  // Same breakpoint as the column stack — when everything is in a
+  // single vertical column, the eye expects centered content; the
+  // start-aligned look only makes sense in the side-by-side grid.
+  headingBlock: {
+    width: '100%',
+    alignItems: {
+      default: 'center',
+      '@media (min-width: 1024px)': 'flex-start',
+    },
+    textAlign: {
+      default: 'center',
+      '@media (min-width: 1024px)': 'start',
+    },
+  },
+  // Decorative shape slot — fixed 48x48 box so the SVG renders at the
+  // expected size and the column header sits at a consistent baseline
+  // across all three feature columns.
+  shapeSlot: {
+    width: SHAPE_SIZE,
+    height: SHAPE_SIZE,
+    display: 'block',
+    flexShrink: 0,
+  },
+  // "→" arrow trail on the CTA link. Astryx's XDSLink renders inline
+  // by default; the arrow lives inside the link label so it inherits
+  // the link color + hover state automatically.
+  cta: {
+    // Bump the CTA away from the body text. The XDSVStack gap holds
+    // title↔body at 8px; the CTA wants more breathing room (16px)
+    // so the link reads as a separate action zone rather than part
+    // of the paragraph.
+    marginTop: spacingVars['--spacing-2'],
   },
 });
 
-type AboutItem = {
+type AboutColumn = {
   title: string;
   description: string;
-  link?: ReactNode;
-  icon: ReactNode;
+  ctaLabel: string;
+  ctaHref: string;
+  shape: ReactNode;
 };
 
-function BlobIcon() {
+// All three decorative shapes are inherited verbatim from the
+// pre-redesign AboutShowcase (origin/main) — the original file
+// defined three soft, organic silhouettes (a 16-bump rounded
+// flower/blob, a pillow-shaped rounded square with concave sides,
+// and a rounded-corner diamond) that already match the "irregular
+// pastel splat" treatment in the new design reference. We reuse the
+// exact path data here and only swap the fill color (from the
+// translucent --color-background-{orange,purple,yellow} theme tokens
+// to saturated pastel hex values) and scale the viewBox-rendered
+// size from the original 40px to the spec's 48px.
+//
+// Mapping (original color -> new pastel for this redesign):
+//   BlobIcon    (orange) -> Pink   #FFC5D2 -> "Design for speed"
+//   SquareIcon  (purple) -> Lavender #D4C5F2 -> "Built by the people who use it"
+//   DiamondIcon (yellow) -> Yellow #FEE48B -> "Ready for what's next"
+
+// Pink "rounded flower" blob — 16 alternating bumps around a circle.
+// Reused verbatim from origin/main's BlobIcon (40x40 viewBox), just
+// scaled up to render at 48px and re-tinted from orange to pink.
+function PinkBlobShape() {
   return (
     <svg
-      width={40}
-      height={40}
+      width={SHAPE_SIZE}
+      height={SHAPE_SIZE}
       viewBox="0 0 40 40"
       fill="none"
       aria-hidden="true">
       <path
-        fill="var(--color-background-orange)"
+        fill={PINK_PASTEL}
         d="M17.081 1.19166C18.7027 -0.397219 21.2973 -0.397219 22.919 1.19166C23.9616 2.21324 25.4625 2.61539 26.8763 2.25201C29.0751 1.68683 31.3221 2.98415 31.9321 5.17099C32.3243 6.57703 33.423 7.67574 34.829 8.06792C37.0159 8.67788 38.3132 10.9249 37.748 13.1237C37.3846 14.5375 37.7868 16.0384 38.8083 17.081C40.3972 18.7027 40.3972 21.2973 38.8083 22.919C37.7868 23.9616 37.3846 25.4625 37.748 26.8763C38.3132 29.0751 37.0159 31.3221 34.829 31.9321C33.423 32.3243 32.3243 33.423 31.9321 34.829C31.3221 37.0159 29.0751 38.3132 26.8763 37.748C25.4625 37.3846 23.9616 37.7868 22.919 38.8083C21.2973 40.3972 18.7027 40.3972 17.081 38.8083C16.0384 37.7868 14.5375 37.3846 13.1237 37.748C10.9249 38.3132 8.67788 37.0159 8.06792 34.829C7.67574 33.423 6.57703 32.3243 5.17099 31.9321C2.98415 31.3221 1.68683 29.0751 2.25201 26.8763C2.61539 25.4625 2.21324 23.9616 1.19166 22.919C-0.397219 21.2973 -0.397219 18.7027 1.19166 17.081C2.21324 16.0384 2.61539 14.5375 2.25201 13.1237C1.68683 10.9249 2.98415 8.67788 5.17099 8.06792C6.57703 7.67574 7.67574 6.57703 8.06792 5.17099C8.67788 2.98415 10.9249 1.68683 13.1237 2.25201C14.5375 2.61539 16.0384 2.21324 17.081 1.19166Z"
       />
     </svg>
   );
 }
 
-function SquareIcon() {
+// Lavender pillow / "soft cloud" — chunky rounded square with concave
+// indents on each side. Reused verbatim from origin/main's SquareIcon,
+// re-tinted from purple to lavender.
+function LavenderCloudShape() {
   return (
     <svg
-      width={40}
-      height={40}
+      width={SHAPE_SIZE}
+      height={SHAPE_SIZE}
       viewBox="0 0 40 40"
       fill="none"
       aria-hidden="true">
       <path
-        fill="var(--color-background-purple)"
+        fill={LAVENDER_PASTEL}
         d="M33.0469 0C36.8869 0.00014921 39.9999 3.11308 40 6.95312C40 9.9458 38.109 12.4963 35.457 13.4766C38.109 14.4568 39.9999 17.0074 40 20C40 22.9927 38.109 25.5431 35.457 26.5234C38.109 27.5037 39.9999 30.0542 40 33.0469C40 36.887 36.887 39.9998 33.0469 40H6.95312C3.113 39.9999 0 36.887 0 33.0469C9.21712e-05 30.0545 1.89042 27.5039 4.54199 26.5234C1.89043 25.5429 0 22.9924 0 20C9.21712e-05 17.0077 1.89042 14.457 4.54199 13.4766C1.89043 12.496 0 9.94549 0 6.95312C0.000107288 3.11307 3.11307 0.000125546 6.95312 0H33.0469Z"
       />
     </svg>
   );
 }
 
-function DiamondIcon() {
+// Yellow rounded diamond — a rotated rounded square. Reused verbatim
+// from origin/main's DiamondIcon (28x28 inner rect, 6px corner
+// radius, rotated 45deg around the 40x40 center), just re-tinted
+// with a saturated pastel yellow.
+function YellowDiamondShape() {
   return (
-    <svg width={40} height={40} viewBox="0 0 40 40" aria-hidden="true">
+    <svg
+      width={SHAPE_SIZE}
+      height={SHAPE_SIZE}
+      viewBox="0 0 40 40"
+      aria-hidden="true">
       <rect
         x={6}
         y={6}
         width={28}
         height={28}
         rx={6}
-        fill="var(--color-background-yellow)"
+        fill={YELLOW_PASTEL}
         transform="rotate(45 20 20)"
       />
     </svg>
   );
 }
 
-const items: AboutItem[] = [
+const columns: AboutColumn[] = [
   {
-    title: 'Designed for speed',
+    title: 'Design for speed',
     description:
       'Foundations you can trust, speed you can feel. The system is built so teams stop reinventing the basics and start shipping the ideas that matter.',
-    link: (
-      <XDSLink
-        type="body"
-        color="primary"
-        href="/docs/getting-started"
-        hasUnderline>
-        Get started in minutes
-      </XDSLink>
-    ),
-    icon: <DiamondIcon />,
+    ctaLabel: 'Get started in minutes →',
+    ctaHref: '/docs/getting-started',
+    shape: <PinkBlobShape />,
   },
   {
     title: 'Built by the people who use it',
     description:
       'The system gets sharper when we put it to work in the real world. Using it in context strengthens the whole system for everyone.',
-    link: (
-      <XDSLink type="body" color="primary" href="/community" hasUnderline>
-        Learn how to contribute
-      </XDSLink>
-    ),
-    icon: <BlobIcon />,
+    ctaLabel: 'Learn how to contribute →',
+    ctaHref: '/community',
+    shape: <LavenderCloudShape />,
   },
   {
     title: "Ready for what's next",
     description:
       'The quality bar is accelerating. Astryx pairs opinionated foundations with flexible patterns so your system keeps pace — no matter how the craft evolves.',
-    link: (
-      <XDSLink type="body" color="primary" href="/changelog" hasUnderline>
-        See what&apos;s new
-      </XDSLink>
-    ),
-    icon: <SquareIcon />,
+    ctaLabel: "See what's new →",
+    ctaHref: '/changelog',
+    shape: <YellowDiamondShape />,
   },
 ];
 
 function AboutHeading() {
   return (
-    <XDSVStack gap={4} align="center" xstyle={styles.headingBlock}>
-      <XDSHeading level={4} color="primary" xstyle={styles.eyebrow}>
-        About us
-      </XDSHeading>
+    <XDSVStack gap={4} xstyle={styles.headingBlock}>
       <XDSHeading level={2} type="display-2" color="primary">
         Astryx powers over 13,000 apps
       </XDSHeading>
-      <XDSText type="body" color="secondary" xstyle={styles.descriptionWidth}>
+      <XDSText type="large" weight="normal" color="secondary">
         Astryx has grown inside Meta over the last eight years, shaped by the
         engineers, designers, and product teams who depend on it every day.
       </XDSText>
@@ -151,39 +241,43 @@ function AboutHeading() {
   );
 }
 
-function AboutColumn({item}: {item: AboutItem}) {
+function AboutColumn({column}: {column: AboutColumn}) {
   return (
-    <XDSCard padding={5}>
-      <XDSVStack gap={6}>
-        <XDSAspectRatio ratio={1} xstyle={styles.iconSlot}>
-          {item.icon}
-        </XDSAspectRatio>
-        <XDSVStack gap={1} align="stretch">
-          <XDSHeading level={3} color="primary">
-            {item.title}
-          </XDSHeading>
-          <XDSText type="body" color="secondary">
-            {item.description}
-          </XDSText>
-        </XDSVStack>
-        {item.link}
+    <XDSVStack gap={3} xstyle={styles.column}>
+      <span {...stylex.props(styles.shapeSlot)}>{column.shape}</span>
+      <XDSVStack gap={2}>
+        <XDSHeading level={2} color="primary">
+          {column.title}
+        </XDSHeading>
+        <XDSText type="body" color="primary">
+          {column.description}
+        </XDSText>
       </XDSVStack>
-    </XDSCard>
+      <XDSLink
+        type="body"
+        color="primary"
+        href={column.ctaHref}
+        hasUnderline={false}
+        xstyle={styles.cta}>
+        {column.ctaLabel}
+      </XDSLink>
+    </XDSVStack>
   );
 }
 
 export function AboutShowcase() {
   return (
-    <XDSVStack as="section" align="center" gap={10} width="100%">
-      <AboutHeading />
-      <XDSGrid
-        columns={{minWidth: 280, repeat: 'fit'}}
-        gap={4}
-        xstyle={styles.gridLayout}>
-        {items.map(item => (
-          <AboutColumn key={item.title} item={item} />
-        ))}
-      </XDSGrid>
+    <XDSVStack as="section" align="center" width="100%">
+      <div {...stylex.props(styles.sectionLayout)}>
+        <div {...stylex.props(styles.grid)}>
+          <AboutHeading />
+          <div {...stylex.props(styles.columnsGrid)}>
+            {columns.map(col => (
+              <AboutColumn key={col.title} column={col} />
+            ))}
+          </div>
+        </div>
+      </div>
     </XDSVStack>
   );
 }

--- a/apps/docsite/src/app/(site)/_landing/DiscoverShowcase.tsx
+++ b/apps/docsite/src/app/(site)/_landing/DiscoverShowcase.tsx
@@ -189,9 +189,9 @@ export function DiscoverShowcase() {
             spread ? styles.floatBottomRightEnd : styles.floatBottomRightStart,
           )}
         />
-        <XDSCard variant="blue" padding={0} xstyle={styles.card}>
-          <XDSVStack gap={10} align="center" xstyle={styles.cardContent}>
-            <XDSVStack gap={4} align="center">
+        <XDSCard variant="gray" padding={0} xstyle={styles.card}>
+          <XDSVStack gap={6} align="center" xstyle={styles.cardContent}>
+            <XDSVStack gap={6} align="center">
               <XDSHeading level={2} type="display-1" color="primary">
                 Discover the full
                 <img

--- a/apps/docsite/src/app/(site)/_landing/DiscoverShowcase.tsx
+++ b/apps/docsite/src/app/(site)/_landing/DiscoverShowcase.tsx
@@ -27,6 +27,12 @@ const styles = stylex.create({
     width: '100%',
     overflowX: 'clip',
   },
+  // The "stage" hosts the absolutely-positioned floating preview
+  // images + the centered CTA card. maxWidth: 1200 matches the
+  // shared marketing-section cap used by FeaturesShowcase and
+  // AboutShowcase so all three sections line up vertically inside
+  // showcaseOverlay; the value isn't on the spacing scale, it's a
+  // marketing page measure intentionally kept as a literal.
   stage: {
     position: 'relative',
     width: '100%',
@@ -38,7 +44,10 @@ const styles = stylex.create({
     position: 'relative',
     width: '100%',
     zIndex: 1,
-    // 96px / 80px — beyond --spacing-12 (48px), so expressed as 2x token values.
+    // 96px / 80px — beyond --spacing-12 (48px), so expressed as
+    // calc() over spacing tokens (2× spacing-12, 2× spacing-10)
+    // rather than as literals so the rhythm scales with any
+    // future spacing-scale theme override.
     paddingBlock: `calc(${spacingVars['--spacing-12']} * 2)`,
     paddingInline: `calc(${spacingVars['--spacing-10']} * 2)`,
   },
@@ -46,6 +55,13 @@ const styles = stylex.create({
   // anchored to one of the four card corners (slightly outside them).
   // The transform is animated from a centered "clumped" pose to the
   // resting pose with rotation when the section scrolls into view.
+  //
+  // width: 260 is a literal preview card size — these are decorative
+  // marketing thumbnails tuned for the desktop composition, not a
+  // size scale value. The 960px desktop-on breakpoint is a one-off
+  // marketing cutoff (the spread-out poses overflow tighter
+  // viewports awkwardly), not the standard 1024px breakpoint used
+  // by FeaturesShowcase/AboutShowcase.
   floatingImage: {
     position: 'absolute',
     width: 260,
@@ -62,9 +78,13 @@ const styles = stylex.create({
       '@media (min-width: 960px)': 'block',
     },
   },
-  // Starting "clumped" pose — all four images near the center of the card
-  // but with slight offsets and rotations so they fan out as an overlapping
-  // rosette (rather than perfectly stacked) before the spread animation.
+  // Starting "clumped" pose — all four images near the center of the
+  // card but with slight offsets and rotations so they fan out as an
+  // overlapping rosette (rather than perfectly stacked) before the
+  // spread animation. The translate offsets (60-80px) and small
+  // rotations (5-8deg) are visual composition values picked to read
+  // as a single tight cluster; literal because they're tied to
+  // image dimensions, not to the spacing scale.
   floatTopLeftStart: {
     top: '50%',
     left: '50%',
@@ -85,8 +105,14 @@ const styles = stylex.create({
     left: '50%',
     transform: 'translate(calc(-50% + 60px), calc(-50% + 32px)) rotate(-5deg)',
   },
-  // Resting "spread" poses — each image hugs a corner of the card with
-  // a slight offset outward so it overlaps just a little.
+  // Resting "spread" poses — each image hugs a corner of the card
+  // with a slight outward offset so it overlaps just a little. The
+  // negative inset values (-64 / -32) are intentional bleed past the
+  // stage edge so the floating images read as "popping out of" the
+  // central card rather than being fully contained by it; literal
+  // because they're spatial overhangs tied to image dimensions, not
+  // spacing-scale values. Negative spacing tokens don't exist in
+  // the scale, so even non-bleed offsets here would be literals.
   floatTopLeftEnd: {
     top: -64,
     left: -64,
@@ -107,21 +133,39 @@ const styles = stylex.create({
     right: -32,
     transform: 'rotate(-6deg)',
   },
+  // Inline wordmark glyph baked into the heading text. Sized by
+  // `em` (.625em) so the wordmark scales with the heading's font
+  // size automatically. marginInline: 16 is a literal because it
+  // anchors to the heading glyph metrics, not the spacing scale —
+  // the wordmark needs a precise visual gap before and after it
+  // (slightly tighter than --spacing-5/20px, slightly wider than
+  // --spacing-3/12px) so it reads as a single inline word.
   inlineWordmark: {
     display: 'inline-block',
     verticalAlign: 'baseline',
     height: '.625em',
     width: 'auto',
-    marginInline: 16,
+    marginInline: spacingVars['--spacing-4'],
   },
+  // CTA body copy + buttons cap. maxWidth: 560 is a reading
+  // measure for the body paragraph, not a spacing-scale value.
   cardContent: {
     maxWidth: 560,
     textAlign: 'center',
     marginInline: 'auto',
   },
+  // Two-up button row cap. maxWidth: 360 is a thumb-reachable
+  // ergonomic value, not a spacing-scale step.
   buttonGrid: {
     width: '100%',
     maxWidth: 360,
+  },
+  // Reading-measure cap for the supporting text paragraph. Kept as
+  // a stylex rule (instead of inline style) so it composes cleanly
+  // with XDSText's xstyle pipeline. 480 is a body-copy reading
+  // measure, not a spacing-scale value.
+  supportingText: {
+    maxWidth: 480,
   },
 });
 
@@ -152,7 +196,22 @@ export function DiscoverShowcase() {
 
   return (
     <XDSVStack as="section" gap={10} align="center" xstyle={styles.section}>
+      {/* "stage" is kept as a raw <div> because its sole job is to
+          act as the position:relative anchor for four
+          absolutely-positioned floating preview <img>s + the
+          centered XDSCard. XDSVStack / XDSHStack would impose flex
+          semantics that fight the absolute positioning model and
+          would also stack the floating images instead of layering
+          them. */}
       <div ref={stageRef} {...stylex.props(styles.stage)}>
+        {/* Floating decorative preview images. Kept as raw <img>s
+            because @xds/core does not export a general-purpose
+            image component (XDSThumbnail is chat-attachment chrome
+            with built-in remove buttons; XDSIcon is a glyph
+            registry). aria-hidden + empty alt keep them out of the
+            accessibility tree — they're pure decoration that
+            animates from a clumped pose to a spread pose when the
+            section scrolls into view. */}
         <img
           src="/discover-card-1.png"
           alt=""
@@ -194,6 +253,12 @@ export function DiscoverShowcase() {
             <XDSVStack gap={6} align="center">
               <XDSHeading level={2} type="display-1" color="primary">
                 Discover the full
+                {/* Inline wordmark <img> baked into the heading as
+                    a visual word substitute. Raw <img> because no
+                    XDS Image primitive exists, and we need the
+                    image to inherit the heading's font-size
+                    cadence (sized in `em` via inlineWordmark
+                    xstyle) so it scales with the heading. */}
                 <img
                   src="/astryx-logo.svg"
                   alt="Astryx"
@@ -201,7 +266,10 @@ export function DiscoverShowcase() {
                 />
                 design system
               </XDSHeading>
-              <XDSText type="body" color="secondary" style={{maxWidth: 480}}>
+              <XDSText
+                type="body"
+                color="secondary"
+                xstyle={styles.supportingText}>
                 Browse {CORE_COMPONENT_COUNT_ROUNDED}+ components, explore
                 production-ready templates, and tune themes to match your brand
                 — pick a starting point and go.

--- a/apps/docsite/src/app/(site)/_landing/FeaturesShowcase.tsx
+++ b/apps/docsite/src/app/(site)/_landing/FeaturesShowcase.tsx
@@ -5,7 +5,6 @@
 import * as stylex from '@stylexjs/stylex';
 import {XDSCard} from '@xds/core/Card';
 import {XDSVStack} from '@xds/core/Layout';
-import {XDSGrid} from '@xds/core/Grid';
 import {XDSHeading, XDSText} from '@xds/core/Text';
 import {XDSLink} from '@xds/core/Link';
 import {components} from '../../../generated/componentRegistry';
@@ -22,63 +21,145 @@ const CORE_COMPONENT_COUNT = (components['@xds/core'] ?? []).filter(
 const CORE_COMPONENT_COUNT_ROUNDED = Math.floor(CORE_COMPONENT_COUNT / 10) * 10;
 
 const styles = stylex.create({
-  headingBlock: {
-    textAlign: 'center',
-    width: '100%',
-    maxWidth: 680,
-  },
-  // Layout glue for the XDSGrid: cap at 1200px. gridAutoRows: 1fr is
-  // intentionally NOT set here — it would force the tall first card
-  // (which spans 2 rows) to make every row at LEAST half its height,
-  // ballooning the regular cards out. With auto rows each row sizes
-  // to its actual content, and the tall card stretches naturally to
-  // fill both rows of whatever the regular row heights end up being.
+  // Layout glue for the XDSGrid: cap at 1200px. Each grid cell now
+  // holds a full-height column wrapper (XDSVStack with height:100%)
+  // rather than a single card, so the grid auto-stretches all three
+  // columns to the tallest column's natural content height — which
+  // is what gives us visually-balanced column heights even when one
+  // column has one tall card and another has a tall card plus a
+  // short card stacked.
+  // 3-column desktop bento, 1-column mobile stack.
+  //
+  //   <1024px: single column — every card stacks vertically.
+  //   ≥1024px: 3 fixed columns. Each column has a wrapper
+  //            (XDSVStack with column style) that holds 1-2
+  //            cards. Grid is align-items:stretch by default,
+  //            so each column wrapper takes the full row height
+  //            (set by min-height below). Cards inside with
+  //            flex:1 (isFlex / isTall) grow to fill column
+  //            leftover space.
+  //
+  // The column wrapper style (`column` below) uses display:
+  // contents at mobile to dissolve the wrapper so cards become
+  // direct children of the grid and the 1-col gridTemplateColumns
+  // can lay them all out in source order.
   gridLayout: {
     width: '100%',
     maxWidth: 1200,
-  },
-  // Feature cards use the categorical "gray" variant, which Astryx
-  // re-tints to a warm beige via --color-background-gray (see
-  // astryxTheme.ts) so the cards sit as a recessed beige surface
-  // on the cream body background.
-  //
-  // overflow:hidden lets bleeding images (negative margin) clip
-  // cleanly at the rounded corners.
-  cardTall: {
-    height: '100%',
-    overflow: 'hidden',
-    gridRow: {
-      default: 'auto',
-      '@media (min-width: 720px)': 'span 2',
+    display: 'grid',
+    gap: 32,
+    gridTemplateColumns: {
+      default: '1fr',
+      '@media (min-width: 1024px)': '1fr 1fr 1fr',
+    },
+    minHeight: {
+      default: 0,
+      '@media (min-width: 1024px)': 720,
     },
   },
+  // Column wrapper. At desktop it's a flex column that takes the
+  // full grid-cell height and stacks its 1-2 child cards. At
+  // mobile (<1024) display:contents dissolves the wrapper so
+  // its children become direct grid children — combined with
+  // the parent's gridTemplateColumns:1fr at mobile, every card
+  // gets its own row at full width.
+  column: {
+    display: {
+      default: 'contents',
+      '@media (min-width: 1024px)': 'flex',
+    },
+    flexDirection: 'column',
+    gap: 32,
+    width: '100%',
+    height: '100%',
+  },
+  // Heading cell — the top-left column starts with plain text on
+  // the page background (no card wrapper) per the bento reference.
+  // paddingBlockStart matches the cards' internal padding
+  // (spacing-5 = 20px) so the heading baseline visually aligns
+  // with the heading inside the top-center "Over 150 components"
+  // card. NO inline padding: the reference shows the heading text
+  // starting flush at the column's left edge (NOT inset to match
+  // the cards' internal padding) — keeping the full column width
+  // also gives the display heading enough room to break onto
+  // natural lines without being clipped by a tighter inner width.
+  headingCell: {
+    paddingBlockStart: 'var(--spacing-5)',
+    width: '100%',
+    // On desktop the heading block sits in a side-by-side grid
+    // with the cards, where flush-left reads as an editorial
+    // section header. Under 1024px (single-column stack — same
+    // breakpoint as the grid switch) the heading is standalone
+    // above the cards and centering reads better — matches the
+    // centering treatment used in the AboutShowcase mobile layout.
+    alignItems: {
+      default: 'center',
+      '@media (min-width: 1024px)': 'flex-start',
+    },
+    textAlign: {
+      default: 'center',
+      '@media (min-width: 1024px)': 'start',
+    },
+  },
+  // All cards use XDSCard padding={0} and apply their own padding
+  // via the innerPadding* styles below. This is intentional: XDSCard's
+  // `padding={N}` prop wires its `padding-bottom` through a
+  // (0,5,0)-specificity selector (`.xds-card-XXX:not(#\#):not(#\#)
+  // :not(#\#):not(#\#)`) which beats any xstyle override at (0,1,0).
+  // The CSS variable indirection ALSO doesn't work because the card
+  // sets `padding-bottom: var(--spacing-N)` directly (not via the
+  // --container-padding-block-end var). So owning the padding via
+  // the inner stack is the only reliable way to get 0 bottom padding
+  // for image cards while leaving full padding on the text-only card.
+
+  // Tall card variant — applied to the right-column "Themes" card.
+  // flex:1 grows the card to fill its parent column wrapper, which
+  // is stretched by the grid to match the tallest sibling column.
+  cardTall: {
+    flex: 1,
+    backgroundColor: 'light-dark(#E6F0FF, #1A2333)',
+    overflow: 'hidden',
+  },
+  // Regular image card. overflow:hidden because the image is
+  // intended to sit flush at the card's bottom edge but NOT bleed
+  // past it (the image's bottom aligns with the card's bottom
+  // rounded corner).
   card: {
     height: '100%',
     overflow: 'hidden',
+    backgroundColor: 'light-dark(#E6F0FF, #1A2333)',
   },
-  // "KEY FEATURES" eyebrow heading above the section title. Uppercase
-  // + tracked, replacing the previous XDSBadge for a flatter editorial
-  // treatment that doesn't compete visually with the cards' own
-  // badge-like accents.
-  eyebrow: {
-    textTransform: 'uppercase',
-    letterSpacing: '0.08em',
+  // Flex variant of `card` — image card that grows to fill its
+  // column's leftover height so a column with a short text-only
+  // sibling can still match the height of an adjacent column with
+  // only one tall card.
+  cardFlex: {
+    flex: 1,
+    overflow: 'hidden',
+    backgroundColor: 'light-dark(#E6F0FF, #1A2333)',
   },
-  // Constrain the description copy under the section heading so it
-  // doesn't run too wide. 420px reads as ~55 characters per line —
-  // a tighter cap than the other sections because the Features
-  // heading is short and a narrow description column visually
-  // balances it.
-  descriptionWidth: {
-    maxWidth: 420,
+  // Text-only feature card variant — no image, so overflow hidden
+  // keeps the card contour tidy at the rounded corners.
+  cardTextOnly: {
+    height: 'auto',
+    overflow: 'hidden',
+    backgroundColor: 'light-dark(#E6F0FF, #1A2333)',
   },
-  // Inner stack of the tall card — pushes the heading/text block to
-  // the top and lets the image grow into the leftover vertical space.
-  // height:100% so the stack itself fills the card body (cards are
-  // gridAutoRows: 1fr, so the row has a known height it can stretch
-  // into).
-  tallStack: {
-    height: '100%',
+  // Padding for image cards: 40px on top + sides + 0 on bottom so
+  // the image wrapper inside sits flush at the card's bottom edge
+  // and can then bleed past it via its own negative marginBottom.
+  innerPaddingImage: {
+    paddingBlockStart: 40,
+    paddingInlineStart: 40,
+    paddingInlineEnd: 40,
+    paddingBlockEnd: 0,
+  },
+  // Padding for the text-only card: 40px on all sides (matches the
+  // other cards' visual padding rhythm — image cards use the same
+  // 40px on top + sides, the only difference is the missing bottom
+  // padding for the bleed).
+  innerPaddingText: {
+    padding: 40,
   },
   // Explore link spacing — VStack gap holds heading↔description at
   // 4px, but the link below the description wants more breathing room
@@ -87,65 +168,82 @@ const styles = stylex.create({
   exploreLink: {
     marginTop: 'calc(var(--spacing-3))',
   },
-  // Shared image wrapper styles for any feature card with an image.
-  // marginTop:auto pushes the wrapper to the bottom of the card so
-  // every card's image sits on the same baseline regardless of how
-  // much text wraps above it. paddingTop:16 guarantees a 16px gap
-  // between the "Explore →" link and the image even on short cards.
-  // No fixed height — the inner <img> uses height:auto + width:100%
-  // so the wrapper grows to exactly the image's natural rendered
-  // height (preserves each composition's aspect ratio without
-  // distortion or empty padding). The negative marginBottom bleeds
-  // the image toward the card's bottom edge with a 16px gutter.
+  // Image wrapper for the 3 feature cards with images. The wrapper
+  // is a full-width flex row (alignSelf:stretch overrides the parent
+  // VStack's align="start" so this wrapper spans the full card
+  // interior width, then justifyContent positions the inner image
+  // horizontally within that full-width row).
+  //
+  // Regular cards left-align the image (justifyContent:flex-start)
+  // per the bento reference; the tall card centers its larger
+  // composition (see imageWrapTall).
+  //
+  // marginTop:auto pushes the wrapper to the bottom of the card's
+  // content stack so the image always sits at the bottom regardless
+  // of how much text wraps above.
+  //
+  // paddingTop creates breathing room between the "Explore" link
+  // and the image.
+  //
+  // marginBottom is a literal negative pixel value (not tied to a
+  // spacing token) that bleeds the image past the card's bottom
+  // edge — combined with overflow:visible on the card AND
+  // paddingBlockEnd:0 on the card, the image visibly pops past the
+  // rounded corner. Note the image already sits flush at the card's
+  // bottom (paddingBlockEnd:0); the negative margin is the
+  // additional overhang.
   imageWrap: {
     marginTop: 'auto',
-    paddingTop: 16,
-    marginBottom: 'calc(var(--spacing-5) * -1 + 16px)',
+    paddingTop: 24,
     alignSelf: 'stretch',
-    overflow: 'hidden',
-  },
-  // Tall-card variant: image bleeds flush to the right edge of the
-  // card (full bleed right) but keeps a 16px inset on the left so
-  // the composition reads as anchored to the left padding rim.
-  // marginTop:auto + marginBottom:auto vertically centers the image
-  // in the leftover space below the heading/link content, so the
-  // tall card's empty space splits equally above and below the
-  // composition instead of all collecting at top or bottom.
-  imageWrapTall: {
-    marginInlineStart: 'calc(var(--spacing-5) * -1 + 16px)',
-    marginInlineEnd: 'calc(var(--spacing-5) * -1)',
-    marginTop: 'auto',
-    marginBottom: 'auto',
-  },
-  // Regular-card variant: 16px inset on BOTH sides so the image
-  // sits inside the card text padding minus the outer rim.
-  imageWrapRegular: {
-    marginInlineStart: 'calc(var(--spacing-5) * -1 + 16px)',
-    marginInlineEnd: 'calc(var(--spacing-5) * -1 + 16px)',
-  },
-  // Bleed-to-corner variant: drops the 16px right + bottom insets
-  // so the image runs flush to the card's right and bottom edges.
-  imageWrapBleedCorner: {
-    marginInlineEnd: 'calc(var(--spacing-5) * -1)',
-    marginBottom: 'calc(var(--spacing-5) * -1)',
-  },
-  // Bleed-bottom variant: drops only the 16px bottom inset so the
-  // image runs flush to the bottom edge while keeping the right
-  // inset.
-  imageWrapBleedBottom: {
-    marginBottom: 'calc(var(--spacing-5) * -1)',
-  },
-  // Image: full container width, natural aspect-ratio-derived
-  // height. No maxHeight cap — each composition was sized at design
-  // time to render correctly inside its card variant (the tall
-  // card's composition is intentionally taller than the regular
-  // cards' wide-and-short compositions). A blanket maxHeight cap
-  // shrinks the tall + bleed images to a tiny strip in the corner
-  // because object-fit:contain inside the cap can't enlarge a
-  // smaller image — the wrappers (imageWrap + variants) already
-  // handle the positioning + bleed at the card edges.
-  tallImage: {
     width: '100%',
+    minWidth: 0,
+    maxWidth: '100%',
+    // overflow:hidden keeps the image contained inside the wrapper
+    // (and therefore inside the card, since the card itself uses
+    // overflow:hidden too). No bleed past the card edges in any
+    // direction; the image sits flush at the card's bottom.
+    overflow: 'hidden',
+    display: 'flex',
+    justifyContent: 'flex-start',
+  },
+  // Tall-card image wrapper variant. Centered (the tall right card
+  // gets a wider composition that reads better centered than
+  // hugging an edge). More top padding because the tall card has
+  // more vertical room above the image baseline that we want to
+  // leave visually open. Slightly more bleed (-32 vs -24) so the
+  // larger image's overhang reads proportionally to its size.
+  imageWrapTall: {
+    marginTop: 'auto',
+    paddingTop: 40,
+    alignSelf: 'stretch',
+    width: '100%',
+    minWidth: 0,
+    maxWidth: '100%',
+    // Hard clip so the tall card's image stays inside the card.
+    overflow: 'hidden',
+    display: 'flex',
+    justifyContent: 'center',
+  },
+  // Default image: capped at 320px so a single composition (badges,
+  // a small UI sample, a stack of mocks) doesn't span the full
+  // card width — the reference shows images occupying the left
+  // ~70% of the card's interior with whitespace to the right.
+  // height:auto preserves natural aspect ratio. display:block kills
+  // the inline baseline gap so there's no mystery whitespace under
+  // the image.
+  featureImage: {
+    width: '100%',
+    maxWidth: 320,
+    height: 'auto',
+    display: 'block',
+  },
+  // Tall-card image: larger cap so the composition reads as the
+  // dominant lower-half element of the tall card per the reference.
+  // Still height:auto so the natural aspect ratio is preserved.
+  featureImageTall: {
+    width: '100%',
+    maxWidth: 400,
     height: 'auto',
     display: 'block',
   },
@@ -156,75 +254,34 @@ type Feature = {
   description: string;
   href: string;
   /**
-   * Optional supporting image rendered below the description. Used to
-   * give each card a visual anchor (code samples, component swatches,
-   * a cascading template stack, etc.).
+   * Optional supporting image rendered below the description. When
+   * present, the image is centered horizontally and bleeds past
+   * the card's bottom edge per the bento layout reference. When
+   * omitted, the card renders as text-only.
    */
   image?: {
     src: string;
     alt: string;
-    /**
-     * When true, the image bleeds flush to the card's right and
-     * bottom edges (no 16px breathing room). Used by image
-     * compositions that are designed as "running off the corner"
-     * artwork — e.g. the cascading template stack — where the
-     * visual intent depends on having the corner clip.
-     */
-    bleedToCorner?: boolean;
-    /**
-     * When true, the image bleeds flush to the card's bottom edge
-     * only. Used for compositions that should keep their right-
-     * side breathing room but feel "rooted" at the bottom of the
-     * card — e.g. a full themed page mockup that reads as
-     * extending below the visible card frame.
-     */
-    bleedBottom?: boolean;
   };
 };
 
-const features: Feature[] = [
-  {
-    title: 'Measured and tested',
-    description:
-      'Every API choice is measured against real usage by people and LLMs before it ships.',
-    href: '/docs',
-    image: {
-      src: '/feature-measured-and-tested.png',
-      alt: 'A typescript code sample alongside a card preview and People / AI agents checks',
-    },
-  },
-  {
+// Looked up by slot key in the JSX below so each card's position in
+// the bento grid is self-documenting. Keyed strings instead of an
+// ordered array because the visual order in the grid is not the
+// same as any obvious data order — explicit slot mapping is clearer
+// than counting indices.
+const features: Record<string, Feature> = {
+  components: {
     title: `Over ${CORE_COMPONENT_COUNT_ROUNDED} components`,
     description:
-      'Accessible and themeable React components with built-in spacing, dark mode, and StyleX styling.',
+      'Accessible and themeable React components with built-in spacing, dark mode, and flexible styling.',
     href: '/components',
     image: {
       src: '/feature-components.png',
       alt: 'Sample XDS components — Badge, Switch, Secondary button, Primary button, Search input',
     },
   },
-  {
-    title: 'Your design system on the command line',
-    description:
-      'Scaffold projects, browse templates, generate themes, and get agent-ready docs from the command line.',
-    href: '/docs/cli',
-    image: {
-      src: '/feature-cli.png',
-      alt: 'AI prompt input asking "Can you create me a table page" with a send button',
-    },
-  },
-  {
-    title: 'Ready to ship templates',
-    description:
-      'Production-ready templates for common pages, just plug in your content.',
-    href: '/templates',
-    image: {
-      src: '/feature-templates.png',
-      alt: 'Stacked theme preview pages cascading toward a fully designed Butter theme example',
-      bleedToCorner: true,
-    },
-  },
-  {
+  themes: {
     title: 'Themes that fit your brand',
     description:
       'Fully customizable themes ready for use. Make it yours without starting from scratch.',
@@ -232,22 +289,75 @@ const features: Feature[] = [
     image: {
       src: '/feature-brand.png',
       alt: 'Butter theme applied to a full product landing page with display script, primary CTA, and three product cards',
-      bleedBottom: true,
     },
   },
-];
+  templates: {
+    title: 'Ready to ship templates',
+    description:
+      'Production-ready templates for common pages, just plug in your content.',
+    href: '/templates',
+    image: {
+      src: '/feature-templates.png',
+      alt: 'Stacked theme preview pages cascading toward a fully designed Butter theme example',
+    },
+  },
+  cli: {
+    title: 'A design system that your agent can use',
+    description:
+      'Scaffold projects, browse templates, generate themes, and get agent-ready docs from the command line or MCP.',
+    href: '/docs/cli',
+    // No image — this card is intentionally text-only per the bento
+    // reference. The text-only card sits in the middle-bottom slot
+    // and acts as visual counterweight against the three image-
+    // anchored cards.
+  },
+};
 
-function FeatureCard({feature, isTall}: {feature: Feature; isTall?: boolean}) {
-  const showImage = feature.image != null;
+function FeatureCard({
+  feature,
+  isTall = false,
+  isFlex = false,
+}: {
+  feature: Feature;
+  /**
+   * Renders the card with the tall-variant image treatment (larger
+   * image cap + more top padding above the image). Used by the
+   * right-column "Themes" card which is the only card with a wider
+   * vertical canvas for its composition.
+   */
+  isTall?: boolean;
+  /**
+   * When true, the card uses flex:1 so it grows to fill any leftover
+   * vertical space inside its parent column. Used for the image
+   * cards that need to balance against a short text-only sibling in
+   * an adjacent column. Has no effect for the tall card (cardTall
+   * already includes flex:1) or the text-only card (which is
+   * intentionally shrink-to-content).
+   */
+  isFlex?: boolean;
+}) {
+  const hasImage = feature.image != null;
+  // Style precedence:
+  //   1. isTall   → cardTall (right-column dominant card)
+  //   2. isFlex   → cardFlex (grow-to-fill image card)
+  //   3. hasImage → card     (natural-height image card)
+  //   4. else     → cardTextOnly (shrink-to-content text-only card)
+  // Only one of these applies at a time.
+  const cardStyle = isTall
+    ? styles.cardTall
+    : isFlex
+      ? styles.cardFlex
+      : hasImage
+        ? styles.card
+        : styles.cardTextOnly;
+
   return (
-    <XDSCard
-      variant="gray"
-      padding={5}
-      xstyle={isTall ? styles.cardTall : styles.card}>
+    <XDSCard variant="blue" padding={0} xstyle={cardStyle}>
       <XDSVStack
         gap={1}
         align="start"
-        xstyle={showImage ? styles.tallStack : undefined}>
+        height="100%"
+        xstyle={hasImage ? styles.innerPaddingImage : styles.innerPaddingText}>
         <XDSHeading level={2} color="primary">
           {feature.title}
         </XDSHeading>
@@ -262,18 +372,15 @@ function FeatureCard({feature, isTall}: {feature: Feature; isTall?: boolean}) {
           xstyle={styles.exploreLink}>
           Explore →
         </XDSLink>
-        {showImage && feature.image && (
+        {hasImage && feature.image && (
           <div
-            {...stylex.props(
-              styles.imageWrap,
-              isTall ? styles.imageWrapTall : styles.imageWrapRegular,
-              feature.image.bleedToCorner && styles.imageWrapBleedCorner,
-              feature.image.bleedBottom && styles.imageWrapBleedBottom,
-            )}>
+            {...stylex.props(isTall ? styles.imageWrapTall : styles.imageWrap)}>
             <img
               src={feature.image.src}
               alt={feature.image.alt}
-              {...stylex.props(styles.tallImage)}
+              {...stylex.props(
+                isTall ? styles.featureImageTall : styles.featureImage,
+              )}
             />
           </div>
         )}
@@ -282,20 +389,24 @@ function FeatureCard({feature, isTall}: {feature: Feature; isTall?: boolean}) {
   );
 }
 
-function FeaturesHeading() {
+// Plain heading block — sits in the top-left grid slot on the page
+// background (no card wrapper) per the bento reference. The text is
+// flush-left to the grid column edge (no inline padding) so the
+// display heading has the full column width to break onto natural
+// lines. The block's paddingBlockStart matches the cards' internal
+// top padding so the heading and the adjacent card titles sit on
+// roughly the same vertical baseline at the top of the row.
+function HeadingBlock() {
   return (
-    <XDSVStack gap={4} align="center" xstyle={styles.headingBlock}>
-      <XDSHeading level={4} color="primary" xstyle={styles.eyebrow}>
-        Key features
-      </XDSHeading>
+    <XDSVStack gap={4} xstyle={styles.headingCell}>
       <XDSHeading level={2} type="display-2" color="primary">
-        Start&nbsp;anywhere. Change&nbsp;anything.&nbsp;Ship&nbsp;faster.
+        Start anywhere.
+        <br />
+        Change anything.
+        <br />
+        Ship faster.
       </XDSHeading>
-      <XDSText
-        display="block"
-        type="body"
-        color="secondary"
-        xstyle={styles.descriptionWidth}>
+      <XDSText display="block" type="large" weight="normal" color="secondary">
         A design system that adapts to your workflow, not the other way around.
         Built for speed, clarity, and creative freedom.
       </XDSText>
@@ -304,17 +415,40 @@ function FeaturesHeading() {
 }
 
 export function FeaturesShowcase() {
+  // Each grid cell holds a full-height column wrapper (XDSVStack
+  // height:100%) rather than a single card, so the grid stretches
+  // all three columns to the height of the tallest column. Cards
+  // marked isFlex / isTall use flex:1 to grow into any leftover
+  // vertical space inside their column, which is what visually
+  // balances the column heights: the "Over 150 components" card in
+  // the middle column grows to fill the space the short "CLI"
+  // sibling leaves behind, matching the heights of the dedicated
+  // "Templates" card on the left and the "Themes" card on the
+  // right.
+  //
+  // Layout on desktop (≥720px):
+  //   col 1: HeadingBlock + Templates (flex)
+  //   col 2: Components (flex) + CLI (text-only, natural height)
+  //   col 3: Themes (tall, flex)
+  //
+  // Below 720px the grid collapses to 1 column. Each column wrapper
+  // renders top-to-bottom in DOM order, so the cards stack as:
+  // heading → templates → components → CLI → themes.
   return (
     <XDSVStack as="section" align="center" gap={10} width="100%">
-      <FeaturesHeading />
-      <XDSGrid
-        columns={{minWidth: 320, repeat: 'fit'}}
-        gap={4}
-        xstyle={styles.gridLayout}>
-        {features.map((feature, i) => (
-          <FeatureCard key={feature.title} feature={feature} isTall={i === 0} />
-        ))}
-      </XDSGrid>
+      <div {...stylex.props(styles.gridLayout)}>
+        <div {...stylex.props(styles.column)}>
+          <HeadingBlock />
+          <FeatureCard feature={features.templates} isFlex />
+        </div>
+        <div {...stylex.props(styles.column)}>
+          <FeatureCard feature={features.components} isFlex />
+          <FeatureCard feature={features.cli} />
+        </div>
+        <div {...stylex.props(styles.column)}>
+          <FeatureCard feature={features.themes} isTall />
+        </div>
+      </div>
     </XDSVStack>
   );
 }

--- a/apps/docsite/src/app/(site)/_landing/FeaturesShowcase.tsx
+++ b/apps/docsite/src/app/(site)/_landing/FeaturesShowcase.tsx
@@ -4,7 +4,7 @@
 
 import * as stylex from '@stylexjs/stylex';
 import {XDSCard} from '@xds/core/Card';
-import {XDSVStack} from '@xds/core/Layout';
+import {XDSVStack, XDSHStack} from '@xds/core/Layout';
 import {XDSHeading, XDSText} from '@xds/core/Text';
 import {XDSLink} from '@xds/core/Link';
 import {spacingVars} from '@xds/core/theme/tokens.stylex';
@@ -22,13 +22,13 @@ const CORE_COMPONENT_COUNT = (components['@xds/core'] ?? []).filter(
 const CORE_COMPONENT_COUNT_ROUNDED = Math.floor(CORE_COMPONENT_COUNT / 10) * 10;
 
 const styles = stylex.create({
-  // Layout glue for the XDSGrid: cap at 1200px. Each grid cell now
-  // holds a full-height column wrapper (XDSVStack with height:100%)
-  // rather than a single card, so the grid auto-stretches all three
-  // columns to the tallest column's natural content height — which
-  // is what gives us visually-balanced column heights even when one
-  // column has one tall card and another has a tall card plus a
-  // short card stacked.
+  // Bento CSS-grid layout. Each grid cell holds a full-height
+  // column wrapper (XDSVStack with height:100%) rather than a
+  // single card, so the grid auto-stretches all three columns to
+  // the tallest column's natural content height — which is what
+  // gives us visually-balanced column heights even when one column
+  // has one tall card and another has a tall card plus a short
+  // card stacked.
   // 3-column desktop bento, 1-column mobile stack.
   //
   //   <1024px: single column — every card stacks vertically.
@@ -44,6 +44,15 @@ const styles = stylex.create({
   // contents at mobile to dissolve the wrapper so cards become
   // direct children of the grid and the 1-col gridTemplateColumns
   // can lay them all out in source order.
+  //
+  // Literal pixel values are intentional marketing-section
+  // dimensions, not derivable from the spacing scale:
+  //   • maxWidth 1200 — shared content cap across all three home
+  //     showcases (Features, About, Discover) so they line up.
+  //   • minHeight 720 — keeps the bento tall enough on desktop
+  //     that the dominant "Themes" card has room for its larger
+  //     image composition; below this height the right column
+  //     reads as cramped against the left/middle.
   gridLayout: {
     width: '100%',
     maxWidth: 1200,
@@ -58,21 +67,24 @@ const styles = stylex.create({
       '@media (min-width: 1024px)': 720,
     },
   },
-  // Column wrapper. At desktop it's a flex column that takes the
-  // full grid-cell height and stacks its 1-2 child cards. At
-  // mobile (<1024) display:contents dissolves the wrapper so
-  // its children become direct grid children — combined with
-  // the parent's gridTemplateColumns:1fr at mobile, every card
-  // gets its own row at full width.
+  // Column wrapper. At desktop it's a flex column (rendered as an
+  // XDSVStack with gap={8} width="100%" height="100%") that takes
+  // the full grid-cell height and stacks its 1-2 child cards. At
+  // mobile (<1024) the xstyle below flips display to `contents`,
+  // which dissolves the wrapper so its children become direct grid
+  // children — combined with the parent's gridTemplateColumns:1fr
+  // at mobile, every card gets its own row at full width.
+  //
+  // The display override is the ONLY thing in this xstyle because
+  // XDSVStack already sets `display: flex` + `flex-direction:
+  // column` + the gap; xstyle is applied last in XDSStack so the
+  // mobile `display: contents` cleanly wins at narrow widths and
+  // falls back to flex at desktop without re-declaring anything.
   column: {
     display: {
       default: 'contents',
       '@media (min-width: 1024px)': 'flex',
     },
-    flexDirection: 'column',
-    gap: spacingVars['--spacing-8'],
-    width: '100%',
-    height: '100%',
   },
   // Heading cell — the top-left column starts with plain text on
   // the page background (no card wrapper) per the bento reference.
@@ -113,12 +125,22 @@ const styles = stylex.create({
   // the inner stack is the only reliable way to get 0 bottom padding
   // for image cards while leaving full padding on the text-only card.
 
+  // All four card variants share the same pastel backdrop, pulled
+  // from a marketing-only theme token (defined in astryxTheme.ts as
+  // `--xds-marketing-feature-card-bg`). Sourcing the color from the
+  // theme keeps the bento palette tunable in one place and avoids
+  // baking literal hex values into the component. We do NOT use
+  // XDSCard's `variant="blue"` here because that token (--color-
+  // background-blue, 20%-alpha saturated wash) prints too vivid
+  // against the white showcase surface — the marketing token is a
+  // soft pastel band hand-tuned for this section.
+
   // Tall card variant — applied to the right-column "Themes" card.
   // flex:1 grows the card to fill its parent column wrapper, which
   // is stretched by the grid to match the tallest sibling column.
   cardTall: {
     flex: 1,
-    backgroundColor: 'light-dark(#E6F0FF, #1A2333)',
+    backgroundColor: 'var(--xds-marketing-feature-card-bg)',
     overflow: 'hidden',
   },
   // Regular image card. overflow:hidden because the image is
@@ -128,7 +150,7 @@ const styles = stylex.create({
   card: {
     height: '100%',
     overflow: 'hidden',
-    backgroundColor: 'light-dark(#E6F0FF, #1A2333)',
+    backgroundColor: 'var(--xds-marketing-feature-card-bg)',
   },
   // Flex variant of `card` — image card that grows to fill its
   // column's leftover height so a column with a short text-only
@@ -137,14 +159,14 @@ const styles = stylex.create({
   cardFlex: {
     flex: 1,
     overflow: 'hidden',
-    backgroundColor: 'light-dark(#E6F0FF, #1A2333)',
+    backgroundColor: 'var(--xds-marketing-feature-card-bg)',
   },
   // Text-only feature card variant — no image, so overflow hidden
   // keeps the card contour tidy at the rounded corners.
   cardTextOnly: {
     height: 'auto',
     overflow: 'hidden',
-    backgroundColor: 'light-dark(#E6F0FF, #1A2333)',
+    backgroundColor: 'var(--xds-marketing-feature-card-bg)',
   },
   // Padding for image cards: --spacing-10 (40px) on top + sides +
   // 0 on bottom so the image wrapper inside sits flush at the
@@ -169,15 +191,12 @@ const styles = stylex.create({
   exploreLink: {
     marginTop: spacingVars['--spacing-3'],
   },
-  // Image wrapper for the 3 feature cards with images. The wrapper
-  // is a full-width flex row (alignSelf:stretch overrides the parent
-  // VStack's align="start" so this wrapper spans the full card
-  // interior width, then justifyContent positions the inner image
-  // horizontally within that full-width row).
-  //
-  // Regular cards left-align the image (justifyContent:flex-start)
-  // per the bento reference; the tall card centers its larger
-  // composition (see imageWrapTall).
+  // Image wrapper for the 3 feature cards with images. Rendered as an
+  // XDSHStack with hAlign="start" so the inner image left-aligns per
+  // the bento reference (the tall card uses hAlign="center"; see the
+  // imageWrapTall xstyle below). alignSelf:stretch overrides the
+  // parent VStack's align="start" so this wrapper spans the full card
+  // interior width.
   //
   // marginTop:auto pushes the wrapper to the bottom of the card's
   // content stack so the image always sits at the bottom regardless
@@ -186,45 +205,30 @@ const styles = stylex.create({
   // paddingTop creates breathing room between the "Explore" link
   // and the image.
   //
-  // marginBottom is a literal negative pixel value (not tied to a
-  // spacing token) that bleeds the image past the card's bottom
-  // edge — combined with overflow:visible on the card AND
-  // paddingBlockEnd:0 on the card, the image visibly pops past the
-  // rounded corner. Note the image already sits flush at the card's
-  // bottom (paddingBlockEnd:0); the negative margin is the
-  // additional overhang.
+  // overflow:hidden keeps the image contained inside the wrapper
+  // (and therefore inside the card, since the card itself uses
+  // overflow:hidden too). No bleed past the card edges in any
+  // direction; the image sits flush at the card's bottom.
   imageWrap: {
     marginTop: 'auto',
     paddingTop: spacingVars['--spacing-6'],
     alignSelf: 'stretch',
-    width: '100%',
     minWidth: 0,
     maxWidth: '100%',
-    // overflow:hidden keeps the image contained inside the wrapper
-    // (and therefore inside the card, since the card itself uses
-    // overflow:hidden too). No bleed past the card edges in any
-    // direction; the image sits flush at the card's bottom.
     overflow: 'hidden',
-    display: 'flex',
-    justifyContent: 'flex-start',
   },
-  // Tall-card image wrapper variant. Centered (the tall right card
-  // gets a wider composition that reads better centered than
-  // hugging an edge). More top padding because the tall card has
-  // more vertical room above the image baseline that we want to
-  // leave visually open. Slightly more bleed (-32 vs -24) so the
-  // larger image's overhang reads proportionally to its size.
+  // Tall-card image wrapper variant. Centered via hAlign="center"
+  // on its XDSHStack (the tall right card gets a wider composition
+  // that reads better centered than hugging an edge). More top
+  // padding because the tall card has more vertical room above the
+  // image baseline that we want to leave visually open.
   imageWrapTall: {
     marginTop: 'auto',
     paddingTop: spacingVars['--spacing-10'],
     alignSelf: 'stretch',
-    width: '100%',
     minWidth: 0,
     maxWidth: '100%',
-    // Hard clip so the tall card's image stays inside the card.
     overflow: 'hidden',
-    display: 'flex',
-    justifyContent: 'center',
   },
   // Default image: capped at 320px so a single composition (badges,
   // a small UI sample, a stack of mocks) doesn't span the full
@@ -353,7 +357,10 @@ function FeatureCard({
         : styles.cardTextOnly;
 
   return (
-    <XDSCard variant="blue" padding={0} xstyle={cardStyle}>
+    // variant="transparent" suppresses XDSCard's default border + bg
+    // so the marketing token painted by `cardStyle` below is the
+    // sole surface color (no blend with --color-background-card).
+    <XDSCard variant="transparent" padding={0} xstyle={cardStyle}>
       <XDSVStack
         gap={1}
         align="start"
@@ -374,8 +381,17 @@ function FeatureCard({
           Explore →
         </XDSLink>
         {hasImage && feature.image && (
-          <div
-            {...stylex.props(isTall ? styles.imageWrapTall : styles.imageWrap)}>
+          // XDSHStack handles the flex+direction+alignment chrome;
+          // marginTop/padding/overflow/sizing live in the xstyle.
+          <XDSHStack
+            width="100%"
+            hAlign={isTall ? 'center' : 'start'}
+            xstyle={isTall ? styles.imageWrapTall : styles.imageWrap}>
+            {/* Decorative image — kept as a raw <img> because @xds/core
+                does not export a dedicated Image primitive (XDSThumbnail
+                is a chat/attachment chrome, not a fit-to-container
+                marketing image). Sizing + display:block come from the
+                featureImage / featureImageTall xstyles below. */}
             <img
               src={feature.image.src}
               alt={feature.image.alt}
@@ -383,7 +399,7 @@ function FeatureCard({
                 isTall ? styles.featureImageTall : styles.featureImage,
               )}
             />
-          </div>
+          </XDSHStack>
         )}
       </XDSVStack>
     </XDSCard>
@@ -437,18 +453,29 @@ export function FeaturesShowcase() {
   // heading → templates → components → CLI → themes.
   return (
     <XDSVStack as="section" align="center" gap={10} width="100%">
+      {/* CSS-grid container with responsive column count. Kept as a
+          plain <div> (rather than XDSGrid) because we depend on grid's
+          align-items:stretch + min-height behavior to drive equal
+          column heights, and we need to control gap/minHeight via
+          @media at the wrapper level. XDSGrid is optimized for fixed
+          column counts + a single gap and doesn't expose the
+          minHeight responsive variant pattern we need here. */}
       <div {...stylex.props(styles.gridLayout)}>
-        <div {...stylex.props(styles.column)}>
+        {/* Column wrappers use XDSVStack at desktop and dissolve via
+            `display: contents` at mobile (see styles.column comment).
+            XDSVStack handles flex+direction+gap+sizing; the xstyle
+            owns only the responsive display switch. */}
+        <XDSVStack gap={8} width="100%" height="100%" xstyle={styles.column}>
           <HeadingBlock />
           <FeatureCard feature={features.templates} isFlex />
-        </div>
-        <div {...stylex.props(styles.column)}>
+        </XDSVStack>
+        <XDSVStack gap={8} width="100%" height="100%" xstyle={styles.column}>
           <FeatureCard feature={features.components} isFlex />
           <FeatureCard feature={features.cli} />
-        </div>
-        <div {...stylex.props(styles.column)}>
+        </XDSVStack>
+        <XDSVStack gap={8} width="100%" height="100%" xstyle={styles.column}>
           <FeatureCard feature={features.themes} isTall />
-        </div>
+        </XDSVStack>
       </div>
     </XDSVStack>
   );

--- a/apps/docsite/src/app/(site)/_landing/FeaturesShowcase.tsx
+++ b/apps/docsite/src/app/(site)/_landing/FeaturesShowcase.tsx
@@ -7,6 +7,7 @@ import {XDSCard} from '@xds/core/Card';
 import {XDSVStack} from '@xds/core/Layout';
 import {XDSHeading, XDSText} from '@xds/core/Text';
 import {XDSLink} from '@xds/core/Link';
+import {spacingVars} from '@xds/core/theme/tokens.stylex';
 import {components} from '../../../generated/componentRegistry';
 
 // Count of public @xds/core components (excluding hooks and hidden entries).
@@ -47,7 +48,7 @@ const styles = stylex.create({
     width: '100%',
     maxWidth: 1200,
     display: 'grid',
-    gap: 32,
+    gap: spacingVars['--spacing-8'],
     gridTemplateColumns: {
       default: '1fr',
       '@media (min-width: 1024px)': '1fr 1fr 1fr',
@@ -69,7 +70,7 @@ const styles = stylex.create({
       '@media (min-width: 1024px)': 'flex',
     },
     flexDirection: 'column',
-    gap: 32,
+    gap: spacingVars['--spacing-8'],
     width: '100%',
     height: '100%',
   },
@@ -84,7 +85,7 @@ const styles = stylex.create({
   // also gives the display heading enough room to break onto
   // natural lines without being clipped by a tighter inner width.
   headingCell: {
-    paddingBlockStart: 'var(--spacing-5)',
+    paddingBlockStart: spacingVars['--spacing-5'],
     width: '100%',
     // On desktop the heading block sits in a side-by-side grid
     // with the cards, where flush-left reads as an editorial
@@ -145,28 +146,28 @@ const styles = stylex.create({
     overflow: 'hidden',
     backgroundColor: 'light-dark(#E6F0FF, #1A2333)',
   },
-  // Padding for image cards: 40px on top + sides + 0 on bottom so
-  // the image wrapper inside sits flush at the card's bottom edge
-  // and can then bleed past it via its own negative marginBottom.
+  // Padding for image cards: --spacing-10 (40px) on top + sides +
+  // 0 on bottom so the image wrapper inside sits flush at the
+  // card's bottom edge.
   innerPaddingImage: {
-    paddingBlockStart: 40,
-    paddingInlineStart: 40,
-    paddingInlineEnd: 40,
+    paddingBlockStart: spacingVars['--spacing-10'],
+    paddingInlineStart: spacingVars['--spacing-10'],
+    paddingInlineEnd: spacingVars['--spacing-10'],
     paddingBlockEnd: 0,
   },
-  // Padding for the text-only card: 40px on all sides (matches the
-  // other cards' visual padding rhythm — image cards use the same
-  // 40px on top + sides, the only difference is the missing bottom
-  // padding for the bleed).
+  // Padding for the text-only card: --spacing-10 (40px) on all
+  // sides (matches the image cards' top + sides; only difference
+  // is the bottom padding which the image cards drop to 0 for
+  // their image bleed).
   innerPaddingText: {
-    padding: 40,
+    padding: spacingVars['--spacing-10'],
   },
   // Explore link spacing — VStack gap holds heading↔description at
   // 4px, but the link below the description wants more breathing room
   // (16px). Adding a top margin on the link gives the +12px extra
   // beyond the 4px stack gap to reach the 16px total.
   exploreLink: {
-    marginTop: 'calc(var(--spacing-3))',
+    marginTop: spacingVars['--spacing-3'],
   },
   // Image wrapper for the 3 feature cards with images. The wrapper
   // is a full-width flex row (alignSelf:stretch overrides the parent
@@ -194,7 +195,7 @@ const styles = stylex.create({
   // additional overhang.
   imageWrap: {
     marginTop: 'auto',
-    paddingTop: 24,
+    paddingTop: spacingVars['--spacing-6'],
     alignSelf: 'stretch',
     width: '100%',
     minWidth: 0,
@@ -215,7 +216,7 @@ const styles = stylex.create({
   // larger image's overhang reads proportionally to its size.
   imageWrapTall: {
     marginTop: 'auto',
-    paddingTop: 40,
+    paddingTop: spacingVars['--spacing-10'],
     alignSelf: 'stretch',
     width: '100%',
     minWidth: 0,

--- a/apps/docsite/src/app/(site)/_landing/HeroMockups.tsx
+++ b/apps/docsite/src/app/(site)/_landing/HeroMockups.tsx
@@ -1,0 +1,492 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @input  none — purely decorative marketing surface.
+ * @output Two independent sticker compositions exported via the
+ *         single `<HeroMockups />` component: one anchored to the
+ *         LEFT edge of the hero, one to the RIGHT edge. Each group
+ *         clips part of itself past the viewport edge for the
+ *         "peeking in from off-screen" effect.
+ * @position Rendered as a sibling of <Hero /> and heroContent inside
+ *           heroScope on the home page. Must appear AFTER the aurora
+ *           gradient but BEFORE heroContent in source order so the
+ *           stickers layer behind the sticky hero copy without
+ *           breaking the pin-and-cover scroll reveal.
+ *
+ * Composition mirrors the reference design:
+ *   • Left group  — a tall portrait photo card with a "2:01"
+ *     timestamp pill, an overlapping HOT SLOTH pink product card
+ *     ("Add to cart" CTA), a ★★★★★ rating pill, and an "Add tags
+ *     to your video" card with green chips below the photo.
+ *   • Right group — a tall portrait photo card with a "2:01"
+ *     timestamp pill, two stacked check pills ("Increase Sales",
+ *     "Add to cart from video"), a green "—UP TO / 20X / Jump in
+ *     product discovery" tile, and a SABINE Backless Maxi Dress
+ *     card with avatar + "Shop Now" CTA overlapping the photo's
+ *     bottom edge.
+ *
+ * Critically, the central horizontal band (~600px wide where the
+ * wordmark + headline + CTAs sit) is left COMPLETELY CLEAR — the
+ * two groups stay in the outer thirds of the hero canvas, so no
+ * sticker is positioned behind the hero copy.
+ *
+ * Real XDS components do all the chrome (XDSCard, XDSBadge,
+ * XDSButton, XDSText, XDSAvatar, XDSIcon, XDSVStack, XDSHStack).
+ * Only marketing-composition coordinates + per-sticker rotations
+ * live as literals in this file.
+ *
+ * Hidden below 1024px (desktop-only decoration) so the stickers
+ * never compete with the hero copy on phones and tablets.
+ */
+
+'use client';
+
+import * as stylex from '@stylexjs/stylex';
+import {XDSCard} from '@xds/core/Card';
+import {XDSVStack, XDSHStack} from '@xds/core/Layout';
+import {XDSText} from '@xds/core/Text';
+import {XDSBadge} from '@xds/core/Badge';
+import {XDSButton} from '@xds/core/Button';
+import {XDSIcon} from '@xds/core/Icon';
+import {XDSAvatar} from '@xds/core/Avatar';
+import {spacingVars} from '@xds/core/theme/tokens.stylex';
+
+// All literal pixel values in this file are intentional marketing-
+// composition coordinates tied to the photo card's portrait
+// geometry (300 × 440) and the reference design's sticker layout.
+// They are NOT spacing-scale values and would not benefit from
+// being expressed as calc() over spacing tokens — they encode
+// "this sticker sits 40px left and 80px down from the photo
+// card's top-left corner at -6° rotation", which is photo-anchored,
+// not rhythm-anchored.
+//
+// Rotation values (±3° to ±8°) are picked to read as "hand-placed
+// on a moodboard" — small enough to feel intentional, varied
+// enough to break out of a mechanical grid.
+//
+// All colors / radii / shadows / typography resolve to theme
+// tokens (via the XDS components consumed below + the few token
+// references in this rule).
+const styles = stylex.create({
+  // Group wrapper — both groups share this base. Anchors a group
+  // to heroScope via position:absolute, sized to a single photo-
+  // card-wide column (320px) so the absolutely-positioned stickers
+  // inside layer correctly around the photo. The group itself
+  // doesn't carry the edge offset (left:-X / right:-X) — that lives
+  // on the per-group leftGroup / rightGroup styles below — so this
+  // base can stay symmetric.
+  //
+  // pointerEvents:none so the decorative stickers never intercept
+  // clicks on the hero CTAs even when their bounding boxes overlap
+  // the sticky heroContent (the headline + buttons sit ~280px from
+  // the central axis, well outside the 320px-wide groups, so
+  // overlap is rare — but pointer-events:none is the belt to the
+  // edge-clip suspenders).
+  //
+  // No z-index — relies on source order in heroScope (rendered
+  // before heroContent) to layer behind the sticky hero copy.
+  // Adding z-index here would establish a stacking context that
+  // breaks the sticky pin-and-cover scroll reveal.
+  //
+  // Hidden below 1024px: at narrower widths the central hero
+  // column collapses toward the edges where the groups sit, and
+  // they would crash into the wordmark + headline. Desktop-only
+  // decoration is the simplest correct rule.
+  // Sticky wrapper that holds BOTH mockup groups. Sticks to the
+  // top of the viewport (just below the top nav) so the mockups
+  // pin in place as the user scrolls past the hero — same pin
+  // behavior as the heroContent sibling. The wrapper itself has
+  // 0 height (it's just a positioning context); the two groups
+  // inside are absolutely positioned against it.
+  //
+  // Hidden below 1024px since the mockups are desktop-only
+  // decoration.
+  mockupsSticky: {
+    position: 'sticky',
+    top: 'calc(var(--appshell-header-height, 0px) + 60px)',
+    width: '100%',
+    height: 0,
+    pointerEvents: 'none',
+    display: {
+      default: 'none',
+      '@media (min-width: 1024px)': 'block',
+    },
+  },
+  // Each group is absolutely positioned against the sticky
+  // wrapper above. Same 320×540 box as before; the wrapper
+  // controls when the box sticks vs. scrolls.
+  group: {
+    position: 'absolute',
+    width: 320,
+    top: 0,
+    height: 540,
+    pointerEvents: 'none',
+  },
+  // Left group offset. left:-120 clips ~120px (≈38% of the 320px
+  // group width) past the viewport's left edge for the "peeking
+  // in" effect.
+  leftGroup: {
+    left: -120,
+  },
+  // Right group offset — mirror of leftGroup.
+  rightGroup: {
+    right: -120,
+  },
+  // Every sticker inside a group is position:absolute against the
+  // group wrapper. This base only carries the absolute-positioning
+  // primitive; individual sticker rules below set top/left/right
+  // + transform (rotation).
+  sticker: {
+    position: 'absolute',
+  },
+  // Photo card — the anchor of each group. Portrait phone-shape
+  // (300 × 440). Rounded with shadow-high to read as the primary
+  // "lifted" surface. opacity bumped to 0.95 (vs. the prior 0.6)
+  // because the groups no longer sit behind the sticky hero copy,
+  // so the photo can read more boldly without competing with text.
+  photoSticker: {
+    top: 0,
+    left: 10,
+    width: 300,
+  },
+  photoCard: {
+    width: '100%',
+    height: 400,
+    objectFit: 'cover',
+    display: 'block',
+    borderRadius: 'var(--radius-container)',
+    boxShadow: 'var(--shadow-high)',
+    backgroundColor: 'var(--color-background-muted)',
+    opacity: 0.95,
+  },
+  // "2:01" timestamp pill, anchored to the photo's top-center.
+  photoTimestamp: {
+    position: 'absolute',
+    top: spacingVars['--spacing-3'],
+    left: '50%',
+    transform: 'translateX(-50%)',
+  },
+  // ============================================================
+  // LEFT GROUP stickers
+  // ============================================================
+  // ★★★★★ rating pill, floats above-right of the left photo.
+  // Slight counter-clockwise tilt.
+  ratingSticker: {
+    top: 60,
+    right: -10,
+    transform: 'rotate(-6deg)',
+  },
+  // HOT SLOTH pink product card, overlaps the photo's bottom-right
+  // corner. Negative rotation so it tilts away from the photo.
+  hotSlothSticker: {
+    top: 240,
+    right: -30,
+    transform: 'rotate(-5deg)',
+    width: 180,
+  },
+  hotSlothImage: {
+    width: '100%',
+    height: 120,
+    objectFit: 'cover',
+    display: 'block',
+    borderRadius: 'var(--radius-element)',
+    backgroundColor: 'var(--color-background-pink)',
+  },
+  hotSlothTimestamp: {
+    position: 'absolute',
+    top: spacingVars['--spacing-2'],
+    left: spacingVars['--spacing-2'],
+  },
+  // "Add tags to your video" card, below the photo. Slight counter-
+  // clockwise tilt. top:420 places it just past the photo's bottom
+  // edge (photo ends at top:400) so the chips peek out below.
+  addTagsSticker: {
+    top: 420,
+    left: 30,
+    transform: 'rotate(-4deg)',
+    width: 220,
+  },
+  // ============================================================
+  // RIGHT GROUP stickers
+  // ============================================================
+  // "Increase Sales" check pill, top-left of the right photo.
+  // Slight clockwise tilt.
+  increaseSalesSticker: {
+    top: 70,
+    left: -40,
+    transform: 'rotate(-3deg)',
+  },
+  // "Add to cart from video" check pill, directly below Increase
+  // Sales, slightly more counter-clockwise tilt for variety.
+  addToCartSticker: {
+    top: 140,
+    left: -30,
+    transform: 'rotate(-4deg)',
+  },
+  // Green 20X jump tile, mid-left of the right photo. Slight
+  // clockwise tilt.
+  twentyXSticker: {
+    top: 220,
+    left: -50,
+    transform: 'rotate(3deg)',
+    width: 170,
+  },
+  // SABINE product card, overlaps the photo's bottom edge,
+  // anchored slightly left of center so it bleeds past the photo's
+  // left side. Slight clockwise tilt.
+  sabineSticker: {
+    top: 340,
+    left: -60,
+    transform: 'rotate(2deg)',
+    width: 260,
+  },
+  // ============================================================
+  // SHARED inner styles
+  // ============================================================
+  // Small filled-circle check icon used inside the "Increase Sales"
+  // and "Add to cart from video" pills. The reference shows a
+  // black circle with a white check — XDSAvatar doesn't render a
+  // glyph (only photos / initials / silhouette), and XDSBadge with
+  // a check icon doesn't give us the filled-circle background. So
+  // a small styled wrapper carries the circle chrome and an
+  // XDSIcon carries the glyph itself — only ~12 lines of literal
+  // chrome live in this file.
+  //
+  // Hardcoded inverted-surface background + on-dark icon color are
+  // both theme tokens (--color-background-inverted resolves to
+  // light's #0A1317 / dark's #FFFFFF, --color-on-dark resolves to
+  // white), so this small primitive cleanly adapts to dark mode
+  // without further work.
+  checkCircle: {
+    width: 24,
+    height: 24,
+    borderRadius: 'var(--radius-full)',
+    backgroundColor: 'var(--color-background-inverted)',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    color: 'var(--color-on-dark)',
+    flexShrink: 0,
+  },
+  // Star row inside the rating pill — extra letter-spacing so the
+  // five glyphs read as a row, not a clump.
+  stars: {
+    letterSpacing: spacingVars['--spacing-0-5'],
+  },
+  // Copy column inside the SABINE card flexes to fill remaining
+  // horizontal space so the copy left-aligns against the avatar.
+  sabineCopy: {
+    flex: 1,
+  },
+  // Full-width button override for the "Shop Now" and "Add to
+  // cart" CTAs inside the SABINE and HOT SLOTH cards. XDSButton
+  // has no `width` prop, but it does accept an xstyle override,
+  // so a direct width:100% on the button element fills the parent
+  // XDSCard's content column.
+  fullWidthButton: {
+    width: '100%',
+  },
+});
+
+// Inline asset paths — single source of truth so each group's
+// placeholder portrait can be swapped to a real person photo by
+// replacing one constant. preview-headphones is a tall, dark
+// product shot that anchors the LEFT group; preview-backpack is a
+// neutral gray product shot that anchors the RIGHT group; the two
+// different subjects keep the groups feeling varied rather than
+// mirror-identical. preview-watch fills the HOT SLOTH pink card
+// (left group); preview-mug fills the SABINE card's circular
+// avatar (right group).
+const LEFT_PHOTO_SRC = '/neutral/preview-headphones.png';
+const RIGHT_PHOTO_SRC = '/neutral/preview-backpack.png';
+const HOT_SLOTH_SRC = '/neutral/preview-watch.png';
+const SABINE_AVATAR_SRC = '/neutral/preview-mug.png';
+
+/**
+ * Decorative LEFT-edge sticker group. Tall photo card with HOT
+ * SLOTH product overlay, ★★★★★ rating pill above-right, and an
+ * "Add tags to your video" card below. The whole group sits at
+ * `left: -120px` so part of it clips past the viewport edge for
+ * the "peeking in" effect.
+ */
+function LeftMockupGroup(): React.ReactElement {
+  return (
+    // Raw <div> because this wrapper has no semantics — it's a
+    // purely decorative absolutely-positioned visual layer.
+    // aria-hidden keeps the entire group out of the accessibility
+    // tree.
+    <div {...stylex.props(styles.group, styles.leftGroup)} aria-hidden="true">
+      {/* Central photo + its inline timestamp pill. */}
+      <div {...stylex.props(styles.sticker, styles.photoSticker)}>
+        {/* Raw <img> — @xds/core does not export a general-purpose
+            image component. Stand-in portrait photo; the visual
+            anchors the group regardless of subject. */}
+        <img src={LEFT_PHOTO_SRC} alt="" {...stylex.props(styles.photoCard)} />
+        <span {...stylex.props(styles.photoTimestamp)}>
+          <XDSBadge label="2:01" variant="neutral" />
+        </span>
+      </div>
+
+      {/* ★★★★★ rating pill, above-right of the photo. */}
+      <div {...stylex.props(styles.sticker, styles.ratingSticker)}>
+        <XDSCard variant="pink" padding={2}>
+          <XDSText
+            type="body"
+            weight="bold"
+            color="primary"
+            xstyle={styles.stars}>
+            ★★★★★
+          </XDSText>
+        </XDSCard>
+      </div>
+
+      {/* HOT SLOTH pink product card overlapping the photo's
+          bottom-right corner. */}
+      <div {...stylex.props(styles.sticker, styles.hotSlothSticker)}>
+        <XDSCard variant="pink" padding={2}>
+          <XDSVStack gap={2}>
+            <div style={{position: 'relative'}}>
+              <img
+                src={HOT_SLOTH_SRC}
+                alt=""
+                {...stylex.props(styles.hotSlothImage)}
+              />
+              <span {...stylex.props(styles.hotSlothTimestamp)}>
+                <XDSBadge label="2:01" variant="neutral" />
+              </span>
+            </div>
+            <XDSButton
+              variant="primary"
+              size="md"
+              label="Add to cart"
+              xstyle={styles.fullWidthButton}
+            />
+          </XDSVStack>
+        </XDSCard>
+      </div>
+
+      {/* "Add tags to your video" card, below the photo. */}
+      <div {...stylex.props(styles.sticker, styles.addTagsSticker)}>
+        <XDSCard variant="default" padding={3}>
+          <XDSVStack gap={2}>
+            <XDSText type="body" color="primary" weight="medium">
+              Add tags to your video
+            </XDSText>
+            <XDSHStack gap={2} wrap="wrap">
+              <XDSBadge label="+ Black" variant="green" />
+              <XDSBadge label="+ Trouser" variant="green" />
+              <XDSBadge label="+ Fashion" variant="green" />
+            </XDSHStack>
+          </XDSVStack>
+        </XDSCard>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Decorative RIGHT-edge sticker group. Tall photo card with two
+ * stacked check pills ("Increase Sales", "Add to cart from
+ * video"), a green "20X" jump tile, and a SABINE product card with
+ * avatar + "Shop Now" CTA overlapping the photo's bottom. The
+ * whole group sits at `right: -120px` so part of it clips past
+ * the viewport edge for the "peeking in" effect.
+ */
+function RightMockupGroup(): React.ReactElement {
+  return (
+    <div {...stylex.props(styles.group, styles.rightGroup)} aria-hidden="true">
+      {/* Central photo + its inline timestamp pill. */}
+      <div {...stylex.props(styles.sticker, styles.photoSticker)}>
+        <img src={RIGHT_PHOTO_SRC} alt="" {...stylex.props(styles.photoCard)} />
+        <span {...stylex.props(styles.photoTimestamp)}>
+          <XDSBadge label="2:01" variant="neutral" />
+        </span>
+      </div>
+
+      {/* "Increase Sales" check pill, top-left of the photo. */}
+      <div {...stylex.props(styles.sticker, styles.increaseSalesSticker)}>
+        <XDSCard variant="default" padding={2}>
+          <XDSHStack gap={2} align="center">
+            <span {...stylex.props(styles.checkCircle)}>
+              <XDSIcon icon="check" color="inherit" size="sm" />
+            </span>
+            <XDSText type="body" color="primary" weight="medium">
+              Increase Sales
+            </XDSText>
+          </XDSHStack>
+        </XDSCard>
+      </div>
+
+      {/* "Add to cart from video" check pill, below Increase Sales. */}
+      <div {...stylex.props(styles.sticker, styles.addToCartSticker)}>
+        <XDSCard variant="default" padding={2}>
+          <XDSHStack gap={2} align="center">
+            <span {...stylex.props(styles.checkCircle)}>
+              <XDSIcon icon="check" color="inherit" size="sm" />
+            </span>
+            <XDSText type="body" color="primary" weight="medium">
+              Add to cart from video
+            </XDSText>
+          </XDSHStack>
+        </XDSCard>
+      </div>
+
+      {/* Green 20X jump tile, mid-left of the photo. */}
+      <div {...stylex.props(styles.sticker, styles.twentyXSticker)}>
+        <XDSCard variant="green" padding={4}>
+          <XDSVStack gap={1}>
+            <XDSText type="supporting" color="primary" weight="medium">
+              — UP TO
+            </XDSText>
+            <XDSText type="large" color="primary" weight="bold" size="3xl">
+              20X
+            </XDSText>
+            <XDSText type="body" color="primary">
+              Jump in product discovery
+            </XDSText>
+          </XDSVStack>
+        </XDSCard>
+      </div>
+
+      {/* SABINE product card, overlapping the photo's bottom edge. */}
+      <div {...stylex.props(styles.sticker, styles.sabineSticker)}>
+        <XDSCard variant="default" padding={3}>
+          <XDSVStack gap={3}>
+            <XDSHStack gap={3} align="center">
+              <XDSAvatar src={SABINE_AVATAR_SRC} name="SABINE" size="medium" />
+              <XDSVStack gap={0.5} xstyle={styles.sabineCopy}>
+                <XDSText type="body" color="primary" weight="medium">
+                  SABINE Backless Maxi Dress in Black
+                </XDSText>
+                <XDSText type="supporting" color="secondary">
+                  $159.00 USD
+                </XDSText>
+              </XDSVStack>
+            </XDSHStack>
+            <XDSButton
+              variant="primary"
+              size="md"
+              label="Shop Now"
+              xstyle={styles.fullWidthButton}
+            />
+          </XDSVStack>
+        </XDSCard>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Both edge groups wrapped in a single component for clean import
+ * at the page level. React fragment because there is no shared
+ * wrapper element — each group anchors independently to its
+ * viewport edge via its own position:absolute + left/right offset.
+ */
+export function HeroMockups(): React.ReactElement {
+  return (
+    <div {...stylex.props(styles.mockupsSticky)} aria-hidden="true">
+      <LeftMockupGroup />
+      <RightMockupGroup />
+    </div>
+  );
+}

--- a/apps/docsite/src/app/(site)/page.tsx
+++ b/apps/docsite/src/app/(site)/page.tsx
@@ -11,10 +11,15 @@ import {XDSVStack} from '@xds/core/Layout';
 import {XDSGrid} from '@xds/core/Grid';
 import {XDSButton} from '@xds/core/Button';
 import {XDSPagination} from '@xds/core/Pagination';
+import {XDSTheme} from '@xds/core/theme';
+import type {XDSDefinedTheme} from '@xds/core/theme';
 import {spacingVars} from '@xds/core/theme/tokens.stylex';
 import {FeaturesShowcase} from './_landing/FeaturesShowcase';
 import {AboutShowcase} from './_landing/AboutShowcase';
 import {DiscoverShowcase} from './_landing/DiscoverShowcase';
+import {HeroMockups} from './_landing/HeroMockups';
+import {themeObjects} from '../../generated/themeRegistry';
+import {astryxTheme} from '../../themes/astryx';
 
 // Carousel slide data — each slide drives the three CSS vars that
 // paint the heroAurora gradient blobs. Color values resolve to
@@ -24,6 +29,16 @@ import {DiscoverShowcase} from './_landing/DiscoverShowcase';
 // itself a `light-dark()` pair, so dark mode handling is inherited
 // for free.
 interface HeroSlide {
+  /**
+   * Package name of the XDS theme to scope around the hero while
+   * this slide is active. Looked up against the generated
+   * themeObjects registry. The hero subtree (aurora + mockups +
+   * sticky heroContent) renders inside <XDSTheme theme={...}> so
+   * every theme token (--color-background-body, the splash bg
+   * colors below, button accent, etc.) retints in place as the
+   * carousel advances.
+   */
+  themeName: string;
   colorLeft: string;
   colorCenter: string;
   colorRight: string;
@@ -31,31 +46,48 @@ interface HeroSlide {
 
 // Hero splash palettes — pulled from the categorical (non-
 // semantic) background color tokens so each slide maps to a
-// theme's pink / yellow / orange / blue / etc. ramp. Theme
-// authors can override these tokens to retint the hero
-// splashes without touching this file, and dark mode is handled
-// by the tokens' built-in light-dark() pairs.
+// theme's pink / yellow / orange / blue / etc. ramp. The active
+// slide's themeName scopes an <XDSTheme> wrapper around the
+// entire hero, so these tokens resolve to that theme's specific
+// palette automatically (and dark mode is inherited from the
+// token's built-in light-dark() pairs).
+// Local theme registry that augments the generated public theme
+// packages with the docsite's own Astryx theme. Astryx is the
+// docsite's brand theme (lives under apps/docsite/src/themes/)
+// and isn't part of the generated package registry, so we mix
+// it in by name here to make it usable as a slide theme below.
+const HERO_THEMES = {
+  ...themeObjects,
+  astryx: astryxTheme,
+};
+
 const HERO_SLIDES: ReadonlyArray<HeroSlide> = [
-  // Neutral — warm yellow + soft pink (matches the reference SVG).
+  // Astryx — the docsite's own brand theme. Used as the first /
+  // default slide so the hero opens in the same identity the
+  // rest of the site uses.
   {
+    themeName: 'astryx',
     colorLeft: 'var(--color-background-yellow)',
     colorCenter: 'var(--color-background-yellow)',
     colorRight: 'var(--color-background-pink)',
   },
   // Butter — all yellows + a peach kicker.
   {
+    themeName: '@xds/theme-butter',
     colorLeft: 'var(--color-background-yellow)',
     colorCenter: 'var(--color-background-yellow)',
     colorRight: 'var(--color-background-orange)',
   },
   // Matcha — sage greens + a butter warm accent.
   {
+    themeName: '@xds/theme-matcha',
     colorLeft: 'var(--color-background-green)',
     colorCenter: 'var(--color-background-cyan)',
     colorRight: 'var(--color-background-yellow)',
   },
   // Y2K — candy pinks + lavender + cyan.
   {
+    themeName: '@xds/theme-y2k',
     colorLeft: 'var(--color-background-pink)',
     colorCenter: 'var(--color-background-purple)',
     colorRight: 'var(--color-background-blue)',
@@ -73,6 +105,50 @@ const styles = stylex.create({
   heroScope: {
     position: 'relative',
     backgroundColor: 'var(--color-background-body)',
+  },
+  // Slide-themed background fill — sits inside the <XDSTheme
+  // theme={slideTheme}> wrapper so its --color-background-body
+  // resolves to the ACTIVE slide's theme body color (not Astryx's
+  // default). Pinned to the hero area only (top:0, height matches
+  // the hero aurora's painted region) so the body color swap only
+  // covers the hero, not the entire heroScope (which contains the
+  // showcase below — that section stays on Astryx default).
+  //
+  // Renders as the FIRST child inside XDSTheme (before the
+  // aurora) so it sits behind everything else via source order;
+  // pointer-events:none so it never intercepts clicks.
+  heroThemeFill: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    height: 900,
+    backgroundColor: 'var(--color-background-body)',
+    pointerEvents: 'none',
+    transition: 'background-color 600ms ease',
+  },
+  // Slide-themed band fixed to the top of the viewport, painted
+  // behind the transparent topnav. Lives inside the slide-themed
+  // XDSTheme wrapper so its --color-background-body resolves to
+  // the active slide's body color. position:fixed escapes the
+  // AppShell's wrappers (which paint white) so the band shows
+  // through the nav cleanly. Height matches the appshell nav
+  // height so it covers exactly the nav strip and nothing else.
+  navBackdrop: {
+    position: 'fixed',
+    top: 0,
+    left: 0,
+    right: 0,
+    height: 'var(--appshell-header-height, 64px)',
+    backgroundColor: 'var(--color-background-body)',
+    pointerEvents: 'none',
+    transition: 'background-color 600ms ease',
+    // Below the nav itself but above the AppShell-header surface
+    // (which paints white at default stacking). The nav is the
+    // top of the document flow, so a z-index of 0 with fixed
+    // positioning puts this band underneath the nav but above
+    // page content.
+    zIndex: 0,
   },
   // Aurora gradient layer — three soft blurred-circle blobs
   // behind the hero, matching the reference "Background
@@ -177,6 +253,13 @@ const styles = stylex.create({
     paddingInline: spacingVars['--spacing-6'],
     textAlign: 'center',
     gap: spacingVars['--spacing-6'],
+    // Lock the hero block to a fixed minimum height so the
+    // carousel theme swap (which retints typography tokens too,
+    // not just colors — themes like Butter define their own
+    // font family + scale ratio) doesn't reflow the heroContent
+    // to a slightly different height per slide and cause the
+    // showcase below to jump up/down on every tick.
+    minHeight: 600,
   },
   // Wrapper around the wordmark + floating Beta badge. Sized
   // exactly to the wordmark image (display:inline-block with no
@@ -369,6 +452,27 @@ export default function HomePage() {
     };
   }, []);
 
+  // Resolve the active slide's XDSTheme. Falls back to the first
+  // slide's theme if a slide's themeName ever fails to resolve
+  // (defensive — themeObjects always contains the registered
+  // theme packages, so this is just to keep the wrapper from
+  // crashing if a theme package is renamed/removed).
+  const slideTheme: XDSDefinedTheme =
+    HERO_THEMES[activeSlide.themeName] ?? HERO_THEMES[HERO_SLIDES[0].themeName];
+
+  // The hero scope is wrapped in <XDSTheme theme={slideTheme}> so
+  // the body background, gradient splashes, and chrome inside the
+  // mockup stickers all retint with the active carousel slide.
+  // XDSTheme renders a `display: contents` wrapper, so it doesn't
+  // create a new positioning context — the sticky heroContent
+  // stays bound to heroScope as before and the pin-and-cover
+  // scroll reveal continues to work.
+  //
+  // Critically, the showcaseOverlay is rendered as a SIBLING of
+  // the themed wrapper (not inside it) so the FeaturesShowcase /
+  // AboutShowcase / DiscoverShowcase below stay on the default
+  // Astryx theme. The slide theme swap is scoped to the hero
+  // chrome only.
   return (
     <div
       {...stylex.props(styles.heroScope)}
@@ -384,7 +488,44 @@ export default function HomePage() {
       onBlurCapture={() => {
         pauseRef.current = false;
       }}>
-      <Hero slide={activeSlide} />
+      {/* The slide-themed XDSTheme wraps everything that should
+          retint per carousel slide: the body-color fill, the
+          aurora gradient splashes, AND the floating mockup
+          stickers (whose XDS chrome — XDSCard / XDSBadge /
+          XDSButton — picks up the active slide's tokens and
+          dogfoods the theme swap visually).
+
+          The sticky heroContent (wordmark + headline + buttons +
+          dots) is a SIBLING OUTSIDE this wrapper so its
+          typography + accent colors stay on Astryx defaults and
+          don't reflow per slide.
+
+          XDSTheme renders a display:contents wrapper so it
+          doesn't break heroScope's containing block — the sticky
+          heroContent below is still bound to heroScope's height
+          and the pin-and-cover scroll reveal works as before. */}
+      <XDSTheme theme={slideTheme}>
+        {/* Fixed-position band that paints behind the transparent
+            topnav with the active slide's body color. Lives inside
+            this XDSTheme wrapper so --color-background-body
+            resolves to the slide's value; position:fixed escapes
+            the AppShell's white surface so the band shows through
+            the nav. */}
+        <div {...stylex.props(styles.navBackdrop)} aria-hidden="true" />
+        <div
+          data-hero-theme-fill="true"
+          {...stylex.props(styles.heroThemeFill)}
+          aria-hidden="true"
+        />
+        <Hero slide={activeSlide} />
+        {/* Decorative scattered sticker composition — two
+            edge-anchored groups of XDS chrome stickers that pin
+            (position: sticky) to the viewport as the user scrolls
+            past the hero. Inside the slide-themed XDSTheme so
+            cards/badges/buttons inside retint with each carousel
+            slide. Hidden below 1024px (desktop-only). */}
+        <HeroMockups />
+      </XDSTheme>
       <XDSVStack
         data-home-page="true"
         align="stretch"

--- a/apps/docsite/src/app/(site)/page.tsx
+++ b/apps/docsite/src/app/(site)/page.tsx
@@ -17,45 +17,48 @@ import {AboutShowcase} from './_landing/AboutShowcase';
 import {DiscoverShowcase} from './_landing/DiscoverShowcase';
 
 // Carousel slide data — each slide drives the three CSS vars that
-// paint the heroAurora gradient blobs. Hex literals (not theme
-// tokens) because Astryx's cream body bg #F8F4ED is so close to
-// most pastel theme tokens that they wash out completely.
+// paint the heroAurora gradient blobs. Color values resolve to
+// marketing-only theme tokens declared in astryxTheme.ts
+// (`--xds-marketing-hero-*-{left,center,right}`); the slide data
+// here only names which palette feeds the gradient. Each token is
+// itself a `light-dark()` pair, so dark mode handling is inherited
+// for free.
 interface HeroSlide {
   colorLeft: string;
   colorCenter: string;
   colorRight: string;
 }
 
-// Each color uses CSS light-dark() so the same slot picks a
-// pastel in light mode and a deep saturated equivalent in dark
-// mode. We use CSS-native light-dark() (not theme tokens) because
-// these are decorative one-off splash colors not part of the
-// semantic token system — keeping them inline keeps the slide
-// palette self-contained and easy to tune per slide.
+// Hero splash palettes — pulled from the categorical (non-
+// semantic) background color tokens so each slide maps to a
+// theme's pink / yellow / orange / blue / etc. ramp. Theme
+// authors can override these tokens to retint the hero
+// splashes without touching this file, and dark mode is handled
+// by the tokens' built-in light-dark() pairs.
 const HERO_SLIDES: ReadonlyArray<HeroSlide> = [
-  // Neutral — matches the reference SVG (warm yellow + soft pink)
+  // Neutral — warm yellow + soft pink (matches the reference SVG).
   {
-    colorLeft: 'light-dark(#FEE48B, #5C4A0F)',
-    colorCenter: 'light-dark(#FEE48B, #5C4A0F)',
-    colorRight: 'light-dark(#FFC5C5, #5C1F2A)',
+    colorLeft: 'var(--color-background-yellow)',
+    colorCenter: 'var(--color-background-yellow)',
+    colorRight: 'var(--color-background-pink)',
   },
-  // Butter — warmer all-yellow palette with a peach kicker
+  // Butter — all yellows + a peach kicker.
   {
-    colorLeft: 'light-dark(#FDEE8C, #5C5018)',
-    colorCenter: 'light-dark(#FFE0A8, #5C3D14)',
-    colorRight: 'light-dark(#FFD4A8, #5C2E10)',
+    colorLeft: 'var(--color-background-yellow)',
+    colorCenter: 'var(--color-background-yellow)',
+    colorRight: 'var(--color-background-orange)',
   },
-  // Matcha — sage greens with a butter warm accent
+  // Matcha — sage greens + a butter warm accent.
   {
-    colorLeft: 'light-dark(#C5E0B4, #1F3D14)',
-    colorCenter: 'light-dark(#B8E0D2, #143D2E)',
-    colorRight: 'light-dark(#FFE8B0, #5C470F)',
+    colorLeft: 'var(--color-background-green)',
+    colorCenter: 'var(--color-background-cyan)',
+    colorRight: 'var(--color-background-yellow)',
   },
-  // Y2K — candy pinks + lavender + cyan
+  // Y2K — candy pinks + lavender + cyan.
   {
-    colorLeft: 'light-dark(#FFB6E1, #5C1F4A)',
-    colorCenter: 'light-dark(#D4B6FF, #3D1F5C)',
-    colorRight: 'light-dark(#B6E0FF, #143D5C)',
+    colorLeft: 'var(--color-background-pink)',
+    colorCenter: 'var(--color-background-purple)',
+    colorRight: 'var(--color-background-blue)',
   },
 ];
 
@@ -81,12 +84,35 @@ const styles = stylex.create({
   // the blob positions to percentages of a multi-screen-tall
   // container and push them off-screen.
   //
-  // Overscan (negative top/left/right) gives the gaussian blur
-  // room to fade past the visible edges cleanly. No z-index
-  // here — source order keeps the aurora behind the sticky
-  // heroContent and showcaseOverlay siblings without
+  // No z-index here — source order keeps the aurora behind the
+  // sticky heroContent and showcaseOverlay siblings without
   // establishing a stacking context that would break the
   // sticky pin-and-cover scroll reveal.
+  //
+  // Every literal pixel value in this rule is a one-off
+  // marketing-visual dimension, NOT something derivable from
+  // the design system's spacing scale. These are tuned by hand
+  // against the reference SVG and should stay as literals:
+  //
+  //   • left: -200 / right: -200 — overscan so the gaussian
+  //     blur fades past the visible viewport edges cleanly;
+  //     200px is roughly 3.5× the blur radius (60px) so the
+  //     halo never clips against the screen edge.
+  //   • height: 1050 — fixed hero band height in viewport
+  //     space, matching the reference SVG canvas. Not the
+  //     viewport height (`100vh`) because the blobs are placed
+  //     at percentages of THIS height; tying that to viewport
+  //     would mean the composition moves around vertically on
+  //     short screens.
+  //   • filter: blur(60px) — mirrors the reference SVG's
+  //     feGaussianBlur stdDeviation=85. Turns each solid disc
+  //     into a soft halo bloom that reads as "out of focus
+  //     colored lights" rather than a sharp painted edge.
+  //   • radial-gradient `circle 220px/200px/260px` — disc
+  //     radii from the reference SVG; the slight per-blob
+  //     variation reads as organic rather than mechanical.
+  //   • Percentage positions (22% 55%, 65% 65%, 78% 45%)
+  //     trace the reference SVG's blob placement exactly.
   heroAurora: {
     // position:fixed so the blobs stay locked to the viewport
     // as the user scrolls — they don't parallax with the page.
@@ -109,20 +135,14 @@ const styles = stylex.create({
     // background-image only is enough since the inline CSS vars
     // (--hero-blob-*) are interpolated when the property changes.
     transition: 'background-image 800ms ease',
-    // Heavy gaussian blur — mirrors the reference SVG's
-    // feGaussianBlur stdDeviation=85. Turns each solid radial
-    // disc into a soft halo bloom that reads as "out of focus
-    // colored lights" rather than a sharp painted edge.
     filter: 'blur(60px)',
     // Three solid-color discs (fully saturated to ~90% of
-    // their radius then quick fade to transparent). Positions
-    // trace the reference SVG: yellow lower-left, yellow
-    // center, pink upper-right. Colors come from CSS vars set
-    // inline by the active carousel slide so the gradient can
-    // crossfade between palettes without re-rendering the
-    // stylex rule. Hex literals (not theme tokens) because
-    // Astryx's cream body bg #F8F4ED is so close to most pastel
-    // theme tokens that they wash out completely.
+    // their radius then quick fade to transparent). Colors come
+    // from --hero-blob-* CSS vars set inline by the active
+    // carousel slide; each --hero-blob-* var resolves to a
+    // marketing theme token (--xds-marketing-hero-*), so the
+    // entire palette stays at the theme layer and the
+    // background-image declaration carries no literal colors.
     backgroundImage:
       'radial-gradient(circle 220px at 22% 55%, var(--hero-blob-left), var(--hero-blob-left) 90%, transparent 100%), ' +
       'radial-gradient(circle 200px at 65% 65%, var(--hero-blob-center), var(--hero-blob-center) 90%, transparent 100%), ' +
@@ -141,6 +161,13 @@ const styles = stylex.create({
     justifyContent: 'center',
     marginBlockStart: spacingVars['--spacing-8'],
   },
+  // Hero content column. maxWidth: 800 is an editorial reading-
+  // measure cap (≈ display-1 + body at a comfortable line length);
+  // not derivable from the spacing scale, kept as a literal
+  // because it's a marketing-section measure, not a system primitive.
+  // paddingBlock = --spacing-12 * 3 → 144px top/bottom; expressed
+  // as a calc() over the spacing token so the rhythm scales with
+  // any future spacing-scale theme override.
   heroContent: {
     position: 'sticky',
     top: 'var(--appshell-header-height, 0px)',
@@ -182,6 +209,14 @@ const styles = stylex.create({
   // brand mark without overlapping any of the glyphs. The XDS
   // Badge component carries the pill chrome (background, radius,
   // typography); only positioning + rotation lives here.
+  //
+  // right: -24 is a literal pixel offset (not a spacing token)
+  // because the badge anchor is tied to the wordmark glyph
+  // geometry — the badge needs to clear the rightmost ligature
+  // by a precise visual margin that doesn't correspond to any
+  // spacing-scale step. Negative spacing tokens don't exist in
+  // the scale anyway, so even the symmetric "24px" would be a
+  // literal here.
   heroWordmarkBeta: {
     position: 'absolute',
     bottom: '100%',
@@ -190,6 +225,11 @@ const styles = stylex.create({
     transform: 'rotate(8deg)',
     transformOrigin: 'bottom right',
   },
+  // Hero CTA button grid. maxWidth: 420 caps the two-up button
+  // row at a comfortable thumb-reachable width so the buttons
+  // don't stretch edge-to-edge on wide hero columns; literal
+  // because the cap is a button-pair ergonomics value, not a
+  // spacing-scale step.
   heroButtons: {
     width: '100%',
     maxWidth: 420,
@@ -205,22 +245,28 @@ const styles = stylex.create({
   heroHeadline: {
     fontWeight: 'var(--font-weight-normal)',
   },
-  // Emphasis weight for the trailing half of the headline so the
-  // contrast with the lighter lead reads as an intentional
-  // pairing rather than an accidental weight shift.
-  heroHeadlineEmphasis: {
-    fontWeight: 'var(--font-weight-semibold)',
-  },
+  // The showcase overlay paints the surface that scrolls UP over
+  // the pinned hero (pin-and-cover reveal). Surface color +
+  // top-rounded corners + body padding all sit on tokens, but
+  // paddingBlockStart and gap are literal 100px values — these
+  // are marketing-section rhythm, NOT primitives in the spacing
+  // scale (closest tokens would be --spacing-12 at 48px, or
+  // --spacing-11 at 44px). Picking 100 lets the showcase sections
+  // breathe with the surrounding hero air without snapping to a
+  // narrower system step that would feel cramped. Kept as
+  // literals (not exotic `calc()` chains over spacing tokens)
+  // because the intent is "this is a one-off marketing rhythm",
+  // not "this is 2× spacing-12 + spacing-1".
   showcaseOverlay: {
     position: 'relative',
     overflow: 'hidden',
     borderTopLeftRadius: 'var(--radius-page)',
     borderTopRightRadius: 'var(--radius-page)',
     backgroundColor: 'var(--color-background-surface)',
-    paddingBlockStart: 100,
+    paddingBlockStart: 'var(--xds-marketing-section-gap)',
     paddingBlockEnd: spacingVars['--spacing-12'],
     paddingInline: spacingVars['--spacing-6'],
-    gap: 100,
+    gap: 'var(--xds-marketing-section-gap)',
   },
 });
 
@@ -231,11 +277,22 @@ const styles = stylex.create({
 // reveal. Must remain the FIRST child of heroScope so source-order
 // stacking keeps it behind heroContent + showcaseOverlay.
 //
-// Theme tokens were tried earlier and washed out against Astryx's
-// cream body bg — so the carousel slide drives raw hex colors
-// straight into three CSS vars consumed by the radial-gradient
-// stack in styles.heroAurora. Animating background-image (declared
-// in the stylex rule) gives a smooth crossfade between slides.
+// Each carousel slide's three color slots resolve to marketing
+// theme tokens (--xds-marketing-hero-*-{left,center,right} in
+// astryxTheme.ts) — the slide forwards those token references into
+// three local CSS vars (--hero-blob-*) via inline `style`, which
+// the radial-gradient stack in styles.heroAurora consumes.
+// Animating background-image (declared in the stylex rule) gives
+// a smooth crossfade between slides; the CSS vars carry the
+// concrete colors so the static stylex rule never re-renders.
+//
+// Rendered as a raw <div> because this is a purely decorative,
+// absolutely-positioned visual layer (aria-hidden) with no
+// semantics — no XDS primitive represents "decorative background
+// layer". Inline style is the documented stylex pattern for
+// per-instance CSS-var values (see stylex docs: dynamic / runtime
+// values must go through inline style or stylex.create()
+// dynamic-function styles).
 function Hero({slide}: {slide: HeroSlide}): React.ReactElement {
   return (
     <div
@@ -332,12 +389,28 @@ export default function HomePage() {
         data-home-page="true"
         align="stretch"
         xstyle={styles.heroContent}>
+        {/* heroWordmarkWrap is a raw <div> because its sole job is
+            to establish a `position: relative` context for the
+            absolutely-positioned Beta badge while sizing exactly to
+            the inline wordmark image's natural width. XDSVStack /
+            XDSHStack would impose flex semantics that fight the
+            inline-block sizing; no other XDS primitive represents
+            "positioning context that hugs an inline child". */}
         <div {...stylex.props(styles.heroWordmarkWrap)}>
+          {/* Raw <img> — @xds/core does not export a general-purpose
+              image component (XDSThumbnail is chat-attachment chrome;
+              XDSIcon is a glyph registry). Sizing + responsive
+              breakpoints come from the heroWordmark xstyle. */}
           <img
             src="/astryx-logo.svg"
             alt="Astryx"
             {...stylex.props(styles.heroWordmark)}
           />
+          {/* heroWordmarkBeta is a raw <span> because we need an
+              inline-level element that establishes its own
+              position:absolute context for the XDSBadge — a stack
+              would force flex children and break the floating
+              callout placement. */}
           <span {...stylex.props(styles.heroWordmarkBeta)}>
             <XDSBadge label="Beta" variant="blue" />
           </span>
@@ -348,9 +421,16 @@ export default function HomePage() {
           color="primary"
           xstyle={styles.heroHeadline}>
           An open source design system that's{' '}
-          <span {...stylex.props(styles.heroHeadlineEmphasis)}>
+          {/* XDSText emphasis span — type/color="inherit" picks up
+              the heading's display-1 size + color so only the
+              weight changes, and weight="semibold" provides the
+              contrast against the parent heading's normal weight
+              (set via styles.heroHeadline above). Using XDSText
+              keeps the inline emphasis on a typed XDS primitive
+              instead of a raw <span> + xstyle escape. */}
+          <XDSText as="span" type="inherit" color="inherit" weight="semibold">
             fully customizable and agent ready
-          </span>
+          </XDSText>
         </XDSHeading>
         <XDSVStack gap={4} align="center">
           <XDSGrid columns={2} gap={3} xstyle={styles.heroButtons}>

--- a/apps/docsite/src/app/(site)/page.tsx
+++ b/apps/docsite/src/app/(site)/page.tsx
@@ -2,7 +2,7 @@
 
 'use client';
 
-import {useEffect, useRef} from 'react';
+import {useEffect, useRef, useState} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {XDSHeading, XDSText} from '@xds/core/Text';
 import {XDSLink} from '@xds/core/Link';
@@ -10,11 +10,56 @@ import {XDSBadge} from '@xds/core/Badge';
 import {XDSVStack} from '@xds/core/Layout';
 import {XDSGrid} from '@xds/core/Grid';
 import {XDSButton} from '@xds/core/Button';
+import {XDSPagination} from '@xds/core/Pagination';
 import {spacingVars} from '@xds/core/theme/tokens.stylex';
-import {ThemingShowcase} from './_landing/ThemingShowcase';
 import {FeaturesShowcase} from './_landing/FeaturesShowcase';
 import {AboutShowcase} from './_landing/AboutShowcase';
 import {DiscoverShowcase} from './_landing/DiscoverShowcase';
+
+// Carousel slide data — each slide drives the three CSS vars that
+// paint the heroAurora gradient blobs. Hex literals (not theme
+// tokens) because Astryx's cream body bg #F8F4ED is so close to
+// most pastel theme tokens that they wash out completely.
+interface HeroSlide {
+  colorLeft: string;
+  colorCenter: string;
+  colorRight: string;
+}
+
+// Each color uses CSS light-dark() so the same slot picks a
+// pastel in light mode and a deep saturated equivalent in dark
+// mode. We use CSS-native light-dark() (not theme tokens) because
+// these are decorative one-off splash colors not part of the
+// semantic token system — keeping them inline keeps the slide
+// palette self-contained and easy to tune per slide.
+const HERO_SLIDES: ReadonlyArray<HeroSlide> = [
+  // Neutral — matches the reference SVG (warm yellow + soft pink)
+  {
+    colorLeft: 'light-dark(#FEE48B, #5C4A0F)',
+    colorCenter: 'light-dark(#FEE48B, #5C4A0F)',
+    colorRight: 'light-dark(#FFC5C5, #5C1F2A)',
+  },
+  // Butter — warmer all-yellow palette with a peach kicker
+  {
+    colorLeft: 'light-dark(#FDEE8C, #5C5018)',
+    colorCenter: 'light-dark(#FFE0A8, #5C3D14)',
+    colorRight: 'light-dark(#FFD4A8, #5C2E10)',
+  },
+  // Matcha — sage greens with a butter warm accent
+  {
+    colorLeft: 'light-dark(#C5E0B4, #1F3D14)',
+    colorCenter: 'light-dark(#B8E0D2, #143D2E)',
+    colorRight: 'light-dark(#FFE8B0, #5C470F)',
+  },
+  // Y2K — candy pinks + lavender + cyan
+  {
+    colorLeft: 'light-dark(#FFB6E1, #5C1F4A)',
+    colorCenter: 'light-dark(#D4B6FF, #3D1F5C)',
+    colorRight: 'light-dark(#B6E0FF, #143D5C)',
+  },
+];
+
+const HERO_AUTOPLAY_INTERVAL_MS = 5000;
 
 const styles = stylex.create({
   // Wraps hero + showcase together so the sticky hero (position: sticky)
@@ -26,6 +71,76 @@ const styles = stylex.create({
     position: 'relative',
     backgroundColor: 'var(--color-background-body)',
   },
+  // Aurora gradient layer — three soft blurred-circle blobs
+  // behind the hero, matching the reference "Background
+  // Gradient.svg" composition (two warm yellow circles + one
+  // peach pink). Pinned to the top of heroScope with a fixed
+  // height so it covers only the hero area, not the entire
+  // marketing page below — heroScope is the full marketing
+  // wrapper (hero + showcase sections), so inset:0 would map
+  // the blob positions to percentages of a multi-screen-tall
+  // container and push them off-screen.
+  //
+  // Overscan (negative top/left/right) gives the gaussian blur
+  // room to fade past the visible edges cleanly. No z-index
+  // here — source order keeps the aurora behind the sticky
+  // heroContent and showcaseOverlay siblings without
+  // establishing a stacking context that would break the
+  // sticky pin-and-cover scroll reveal.
+  heroAurora: {
+    // position:fixed so the blobs stay locked to the viewport
+    // as the user scrolls — they don't parallax with the page.
+    // The hero content above uses position:sticky and pins to
+    // the same viewport region, so visually the gradient feels
+    // anchored to the hero for the entire pin duration. When
+    // the showcase scrolls up and covers the hero, it also
+    // covers this fixed gradient (showcaseOverlay paints a
+    // solid white surface on top), so the gradient cleanly
+    // disappears past the hero rather than bleeding into the
+    // showcase below.
+    position: 'fixed',
+    top: 'var(--appshell-header-height, 0px)',
+    left: -200,
+    right: -200,
+    height: 1050,
+    pointerEvents: 'none',
+    opacity: 0.5,
+    // Smooth crossfade as the carousel advances. Animating
+    // background-image only is enough since the inline CSS vars
+    // (--hero-blob-*) are interpolated when the property changes.
+    transition: 'background-image 800ms ease',
+    // Heavy gaussian blur — mirrors the reference SVG's
+    // feGaussianBlur stdDeviation=85. Turns each solid radial
+    // disc into a soft halo bloom that reads as "out of focus
+    // colored lights" rather than a sharp painted edge.
+    filter: 'blur(60px)',
+    // Three solid-color discs (fully saturated to ~90% of
+    // their radius then quick fade to transparent). Positions
+    // trace the reference SVG: yellow lower-left, yellow
+    // center, pink upper-right. Colors come from CSS vars set
+    // inline by the active carousel slide so the gradient can
+    // crossfade between palettes without re-rendering the
+    // stylex rule. Hex literals (not theme tokens) because
+    // Astryx's cream body bg #F8F4ED is so close to most pastel
+    // theme tokens that they wash out completely.
+    backgroundImage:
+      'radial-gradient(circle 220px at 22% 55%, var(--hero-blob-left), var(--hero-blob-left) 90%, transparent 100%), ' +
+      'radial-gradient(circle 200px at 65% 65%, var(--hero-blob-center), var(--hero-blob-center) 90%, transparent 100%), ' +
+      'radial-gradient(circle 260px at 78% 45%, var(--hero-blob-right), var(--hero-blob-right) 90%, transparent 100%)',
+  },
+  // Pagination dot indicator anchored at the bottom of the hero
+  // stack. Center the dot row (the XDSPagination nav element is
+  // a flex row by default — this just justifies it horizontally
+  // within the centered hero column) and add breathing room above
+  // so it doesn't crowd the "Built on React and StyleX" line.
+  // Intentionally no z-index here — the sticky scroll reveal
+  // depends on heroContent + every descendant staying out of any
+  // explicit stacking context so showcaseOverlay can naturally
+  // cover them via source-order stacking.
+  heroPagination: {
+    justifyContent: 'center',
+    marginBlockStart: spacingVars['--spacing-8'],
+  },
   heroContent: {
     position: 'sticky',
     top: 'var(--appshell-header-height, 0px)',
@@ -34,7 +149,7 @@ const styles = stylex.create({
     paddingBlock: `calc(${spacingVars['--spacing-12']} * 3)`,
     paddingInline: spacingVars['--spacing-6'],
     textAlign: 'center',
-    gap: spacingVars['--spacing-12'],
+    gap: spacingVars['--spacing-6'],
   },
   // Wrapper around the wordmark + floating Beta badge. Sized
   // exactly to the wordmark image (display:inline-block with no
@@ -50,8 +165,16 @@ const styles = stylex.create({
   },
   heroWordmark: {
     display: 'block',
-    height: 42,
+    // Responsive: scale down on narrow viewports so the wordmark
+    // doesn't overflow the hero column. 80px at desktop is the
+    // designed size; 56px keeps the wordmark visible without
+    // clipping on phones at ~375px viewport.
+    height: {
+      default: 80,
+      '@media (max-width: 480px)': 56,
+    },
     width: 'auto',
+    maxWidth: '100%',
   },
   // Floating Beta badge wrapper — positions the XDSBadge above
   // the wordmark (bottom anchored to the wordmark's top edge)
@@ -71,20 +194,85 @@ const styles = stylex.create({
     width: '100%',
     maxWidth: 420,
   },
+  // Lighter display weight for the leading half of the hero
+  // headline ("An open source design system that's"). Astryx's
+  // theme override pushes display-1 to semibold (600); we want
+  // the leading copy to read as a softer editorial setup so the
+  // value-prop tail ("fully customizable and agent ready") can
+  // land harder. Applied per-span via xstyle, not as a theme
+  // token change, so the rest of the site keeps Astryx's display
+  // semibold default.
+  heroHeadline: {
+    fontWeight: 400,
+  },
+  // Emphasis weight for the trailing half of the headline so the
+  // contrast with the lighter lead reads as an intentional
+  // pairing rather than an accidental weight shift.
+  heroHeadlineEmphasis: {
+    fontWeight: 600,
+  },
   showcaseOverlay: {
     position: 'relative',
     overflow: 'hidden',
     borderTopLeftRadius: 'var(--radius-page)',
     borderTopRightRadius: 'var(--radius-page)',
     backgroundColor: 'var(--color-background-surface)',
-    paddingBlock: spacingVars['--spacing-12'],
+    paddingBlockStart: 100,
+    paddingBlockEnd: spacingVars['--spacing-12'],
     paddingInline: spacingVars['--spacing-6'],
-    gap: `calc(${spacingVars['--spacing-12']} * 2)`,
+    gap: 100,
   },
 });
 
+// Aurora gradient layer for the hero. Rendered as a sibling inside
+// heroScope (NOT a wrapper around heroContent) so it shares the
+// sticky parent without establishing a stacking context that would
+// trap heroContent and break the sticky pin-and-cover scroll
+// reveal. Must remain the FIRST child of heroScope so source-order
+// stacking keeps it behind heroContent + showcaseOverlay.
+//
+// Theme tokens were tried earlier and washed out against Astryx's
+// cream body bg — so the carousel slide drives raw hex colors
+// straight into three CSS vars consumed by the radial-gradient
+// stack in styles.heroAurora. Animating background-image (declared
+// in the stylex rule) gives a smooth crossfade between slides.
+function Hero({slide}: {slide: HeroSlide}): React.ReactElement {
+  return (
+    <div
+      {...stylex.props(styles.heroAurora)}
+      aria-hidden="true"
+      style={
+        {
+          '--hero-blob-left': slide.colorLeft,
+          '--hero-blob-center': slide.colorCenter,
+          '--hero-blob-right': slide.colorRight,
+        } as React.CSSProperties
+      }
+    />
+  );
+}
+
 export default function HomePage() {
   const showcaseRef = useRef<HTMLDivElement | null>(null);
+  const [activeIndex, setActiveIndex] = useState(0);
+  // Pause flag for the autoplay loop. A ref (not state) so the
+  // interval handler reads the latest value WITHOUT tearing down
+  // and rebuilding the timer on every hover/focus toggle — that
+  // churn would reset the visible 5s cadence each time the cursor
+  // moved across the hero.
+  const pauseRef = useRef(false);
+  const slideCount = HERO_SLIDES.length;
+  const activeSlide = HERO_SLIDES[activeIndex];
+
+  useEffect(() => {
+    const id = window.setInterval(() => {
+      if (pauseRef.current) {
+        return;
+      }
+      setActiveIndex(prev => (prev + 1) % slideCount);
+    }, HERO_AUTOPLAY_INTERVAL_MS);
+    return () => window.clearInterval(id);
+  }, [slideCount]);
 
   useEffect(() => {
     const el = showcaseRef.current;
@@ -125,7 +313,21 @@ export default function HomePage() {
   }, []);
 
   return (
-    <div {...stylex.props(styles.heroScope)}>
+    <div
+      {...stylex.props(styles.heroScope)}
+      onMouseEnter={() => {
+        pauseRef.current = true;
+      }}
+      onMouseLeave={() => {
+        pauseRef.current = false;
+      }}
+      onFocusCapture={() => {
+        pauseRef.current = true;
+      }}
+      onBlurCapture={() => {
+        pauseRef.current = false;
+      }}>
+      <Hero slide={activeSlide} />
       <XDSVStack
         data-home-page="true"
         align="stretch"
@@ -140,8 +342,15 @@ export default function HomePage() {
             <XDSBadge label="Beta" variant="blue" />
           </span>
         </div>
-        <XDSHeading level={1} type="display-1" color="primary">
-          An open source design system that's fully customizable and agent ready
+        <XDSHeading
+          level={1}
+          type="display-1"
+          color="primary"
+          xstyle={styles.heroHeadline}>
+          An open source design system that's{' '}
+          <span {...stylex.props(styles.heroHeadlineEmphasis)}>
+            fully customizable and agent ready
+          </span>
         </XDSHeading>
         <XDSVStack gap={4} align="center">
           <XDSGrid columns={2} gap={3} xstyle={styles.heroButtons}>
@@ -168,12 +377,30 @@ export default function HomePage() {
               rel="noopener noreferrer"
               hasUnderline>
               React
+            </XDSLink>{' '}
+            and{' '}
+            <XDSLink
+              type="body"
+              color="primary"
+              href="https://stylexjs.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              hasUnderline>
+              StyleX
             </XDSLink>
           </XDSText>
         </XDSVStack>
+        <XDSPagination
+          variant="dots"
+          page={activeIndex + 1}
+          onChange={p => setActiveIndex(p - 1)}
+          totalPages={slideCount}
+          size="md"
+          label="Hero theme carousel"
+          xstyle={styles.heroPagination}
+        />
       </XDSVStack>
       <XDSVStack ref={showcaseRef} xstyle={styles.showcaseOverlay}>
-        <ThemingShowcase />
         <FeaturesShowcase />
         <AboutShowcase />
         <DiscoverShowcase />

--- a/apps/docsite/src/app/(site)/page.tsx
+++ b/apps/docsite/src/app/(site)/page.tsx
@@ -186,7 +186,7 @@ const styles = stylex.create({
     position: 'absolute',
     bottom: '100%',
     right: -24,
-    marginBottom: 4,
+    marginBottom: spacingVars['--spacing-1'],
     transform: 'rotate(8deg)',
     transformOrigin: 'bottom right',
   },
@@ -203,13 +203,13 @@ const styles = stylex.create({
   // token change, so the rest of the site keeps Astryx's display
   // semibold default.
   heroHeadline: {
-    fontWeight: 400,
+    fontWeight: 'var(--font-weight-normal)',
   },
   // Emphasis weight for the trailing half of the headline so the
   // contrast with the lighter lead reads as an intentional
   // pairing rather than an accidental weight shift.
   heroHeadlineEmphasis: {
-    fontWeight: 600,
+    fontWeight: 'var(--font-weight-semibold)',
   },
   showcaseOverlay: {
     position: 'relative',

--- a/apps/docsite/src/app/globals.css
+++ b/apps/docsite/src/app/globals.css
@@ -37,6 +37,26 @@ body:has([data-home-page]) #xds-app-shell-main {
   padding-top: 0;
 }
 
+/* On the home page, paint the AppShell wrappers (which sit
+   ABOVE heroScope and would otherwise show their default white
+   surface through the transparent nav) with the body background
+   color so the nav reveals a continuous color band from the top
+   of the page through the hero. Uses --color-background-body
+   which inherits whatever theme is active on the body — the
+   slide-theme XDSTheme wrapper around the hero doesn't reach
+   these AppShell wrappers (they're parents of heroScope), so
+   this rule resolves against the page-level Astryx theme.
+
+   For the active slide's color to actually reach the nav, the
+   page-level theme would need to swap too — see page.tsx for
+   the runtime mechanism that mirrors the slide's body color to
+   these wrappers via element.style. This rule is the static
+   fallback for the initial paint. */
+body:has([data-home-page]) .xds-app-shell-header.surface,
+body:has([data-home-page]) #xds-app-shell-main {
+  background-color: var(--color-background-body) !important;
+}
+
 /* Translucent top nav — frosted glass effect.
 
    The :where(:not(.xds-app-shell .xds-app-shell *)) guard scopes every frost
@@ -62,12 +82,22 @@ body:has([data-home-page]) #xds-app-shell-main {
   transition: background 300ms ease;
 }
 
-/* On the home page only, blend the top nav with the cream body background.
-   Use the solid body color (not a color-mix) so it matches perfectly even
-   without anything scrolled behind it. The backdrop-filter blur from the
-   .xds-top-nav rule above is preserved. */
+/* On the home page only, make the top nav transparent so the
+   hero's body background (which retints per active carousel
+   slide via the XDSTheme wrapper) shows through the nav. The
+   backdrop-filter blur from the global .xds-top-nav rule above
+   stays in place so anything that scrolls behind the nav still
+   gets softened. */
 body:has([data-home-page]) .xds-top-nav:where(:not(.xds-app-shell .xds-app-shell *)) {
-  background: var(--color-background-body);
+  background: transparent;
+  /* Drop the backdrop-filter blur from the global frost rule
+     on the home page only. Blurring transparent over the
+     slide-themed AppShell-header below produces a washed-out
+     gray cast (the blur samples and averages the colored
+     pixels behind, ending up close to mid-gray). On the home
+     page we want the colored bg to read cleanly through the
+     nav, no frost. */
+  backdrop-filter: none;
 }
 
 /* When the home page IntersectionObserver detects the theming showcase has

--- a/apps/docsite/src/app/globals.css
+++ b/apps/docsite/src/app/globals.css
@@ -76,6 +76,20 @@ body[data-nav-mode='surface'] .xds-top-nav:where(:not(.xds-app-shell .xds-app-sh
   background: color-mix(in srgb, var(--color-background-surface) 80%, transparent);
 }
 
+/* Hide the prev/next chevron buttons inside the home page's hero
+   carousel pagination so only the dot indicators show. XDSPagination's
+   variant="dots" ships with chevrons by default; the hero wants a
+   minimal indicator-only treatment. Scoped to [data-home-page] so
+   other XDSPagination instances across the site stay untouched. */
+[data-home-page]
+  .xds-pagination
+  button[aria-label='Go to previous page'],
+[data-home-page]
+  .xds-pagination
+  button[aria-label='Go to next page'] {
+  display: none;
+}
+
 /* The /themes/<name> dedicated page renders a faux app top nav INSIDE
    its preview surface. The global `.xds-top-nav` rule above gives it a
    surface-tinted frosted background, which leaks through and makes the

--- a/apps/docsite/src/themes/astryxTheme.ts
+++ b/apps/docsite/src/themes/astryxTheme.ts
@@ -10,9 +10,57 @@
  * Everything else (surfaces, text, borders, status, radius, motion) is
  * inherited from the default XDS theme behavior so the design system
  * stays the source of truth and Astryx is a thin brand layer on top.
+ *
+ * In addition to the standard XDS token overrides, this theme defines
+ * a small set of marketing-only `--xds-marketing-*` custom tokens used
+ * exclusively by the docsite home page (hero aurora carousel + feature
+ * card backdrops). Capturing these palettes at the theme layer keeps
+ * the page components free of literal hex colors and gives each token
+ * a single, named source of truth — change a palette here and the
+ * marketing surface updates without touching component code.
  */
 
 import {defineTheme} from '@xds/core/theme';
+
+// Marketing-only custom tokens. These are NOT part of the semantic XDS
+// token system — they exist solely to back the docsite home page's
+// hero aurora gradient + bento feature cards. They live in the theme
+// (rather than as inline literals) so the entire marketing palette can
+// be retuned in one place and so dark mode is handled by the token's
+// own `light-dark()` value rather than by every consumer.
+//
+// All values stay as raw hex literals because Astryx's cream body bg
+// (#F8F4ED) is so close to most pastel semantic tokens that they wash
+// out completely — the saturated pastel choices below are tuned by
+// hand against the cream body and don't map onto any semantic ramp.
+//
+// Keyed with the `--xds-marketing-*` prefix so they're trivially
+// greppable and never collide with the standard XDS token namespace
+// (`--color-*`, `--spacing-*`, etc.).
+//
+// Typed as Record<string, string> here so they pass through
+// defineTheme's strict `Partial<Record<XDSTokenName, ...>>` shape via
+// the cast at the call site below — defineTheme's runtime accepts any
+// string-keyed token and emits it verbatim as a CSS custom property.
+const marketingTokens: Record<string, string> = {
+  // Feature card backdrop. Soft pastel blue in light mode, deep
+  // navy in dark mode. Used by FeaturesShowcase's four bento cards
+  // as `backgroundColor: var(--xds-marketing-feature-card-bg)`.
+  // Picked specifically because Astryx's stock --color-background-blue
+  // is a 20%-alpha saturated wash that would render too vivid against
+  // the showcase's white surface; this token gives the cards a soft
+  // pastel band the eye reads as a single related group.
+  '--xds-marketing-feature-card-bg': 'light-dark(#E6F0FF, #1A2333)',
+
+  // Marketing-section vertical rhythm. The XDS spacing scale tops
+  // out at --spacing-12 = 48px, which is fine for in-app density
+  // but too tight for a landing-page section break. Use this token
+  // for the gap between major home-page sections (hero ↔ features
+  // ↔ about ↔ discover) and for the page's first paddingBlockStart
+  // so the rhythm reads as deliberate marketing pacing rather than
+  // a maxed-out spacing step.
+  '--xds-marketing-section-gap': '100px',
+};
 
 export const astryxTheme = defineTheme({
   name: 'astryx',
@@ -22,6 +70,12 @@ export const astryxTheme = defineTheme({
   // and bleeds the accent's hue into neutrals (which made all the "gray"
   // surfaces come out brown). Setting --color-accent directly leaves every
   // other token at the XDS default.
+  //
+  // Cast to relax `Partial<Record<XDSTokenName, ...>>` so the
+  // marketing custom tokens above (which intentionally sit outside
+  // the XDS semantic namespace) typecheck without per-key cast noise.
+  // defineTheme's runtime accepts any string-keyed token and emits
+  // it verbatim as a CSS custom property declaration.
   tokens: {
     // light-dark() so primary buttons / accent surfaces invert in
     // dark mode — near-black warm in light, warm cream in dark, so
@@ -60,7 +114,8 @@ export const astryxTheme = defineTheme({
     '--radius-element': '12px',
     '--radius-container': '16px',
     '--radius-page': '32px',
-  },
+    ...marketingTokens,
+  } as Parameters<typeof defineTheme>[0]['tokens'],
 
   typography: {
     body: {

--- a/apps/docsite/src/themes/astryxTheme.ts
+++ b/apps/docsite/src/themes/astryxTheme.ts
@@ -23,11 +23,17 @@ export const astryxTheme = defineTheme({
   // surfaces come out brown). Setting --color-accent directly leaves every
   // other token at the XDS default.
   tokens: {
-    '--color-accent': '#292724',
+    // light-dark() so primary buttons / accent surfaces invert in
+    // dark mode — near-black warm in light, warm cream in dark, so
+    // the brand pill stays legible against the body background in
+    // both modes.
+    '--color-accent': 'light-dark(#292724, #E8E3DA)',
+    // Text on the accent surface flips with it: white-on-dark in
+    // light mode, dark-on-cream in dark mode.
+    '--color-on-accent': 'light-dark(#FFFFFF, #292724)',
     // Setting --color-accent alone leaves the *derived* accent tokens
     // (text/icon/muted) at the XDS default blue, so links and accent icons
     // across the docsite stayed blue. Point them at the brand accent too.
-    // light-dark() keeps dark mode legible (near-black is invisible on dark).
     '--color-text-accent': 'light-dark(#292724, #E8E3DA)',
     '--color-icon-accent': 'light-dark(#292724, #E8E3DA)',
     '--color-accent-muted':


### PR DESCRIPTION
## Summary

Home page refresh:

- **Hero** — bigger wordmark, mixed-weight headline, React + StyleX subtitle links, soft splash gradient with a 4-slide theme carousel (auto-advance + pause on hover/focus, indicated by `<XDSPagination variant="dots">` with chevrons scoped-hidden on the home page only). Splash colors use CSS `light-dark()` so they invert in dark mode.
- **Features** — blue-card bento (3-col desktop, 1-col below 1024). Inner padding moved off the `XDSCard` `padding` prop onto an inner `XDSVStack` so the text-only card keeps full padding while image cards can bleed flush to the bottom rim (working around the (0,5,0) specificity of the built-in card padding rules).
- **About** — 1fr / 2fr editorial layout (heading + 3 decorative-shape columns); single-column stack below 1024.
- **Discover** — gray card variant; tightened inner stack gap.
- **Astryx theme** — `--color-accent` + `--color-on-accent` wrapped in `light-dark()` so primary buttons invert in dark mode (cream pill / dark label) instead of staying dark-on-dark.

ThemingShowcase is removed from the home page (still available standalone at `/themes`).

## Test plan
- [ ] Visit `/` and verify the hero gradient auto-advances every 5s and pauses on hover
- [ ] Click each pagination dot and confirm the gradient swaps to that slide's palette
- [ ] Scroll the home page and confirm the sticky hero pin-and-cover reveal still works
- [ ] Resize the viewport across 375 / 768 / 1024 / 1280px and confirm Features + About both stack cleanly under 1024px and render as 3-col / 1fr-2fr above
- [ ] Toggle dark mode and confirm the primary CTA inverts to a light pill with dark text, and the splash gradients/Feature cards use their dark-mode equivalents

Made with [Cursor](https://cursor.com)