### PR TITLE
feat(cli): full capability manifest via xds --json

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -162,6 +162,63 @@ if (isError(result)) {
 | `ERR_GH_CLI` | GitHub CLI (`gh`) is not installed or not authenticated. |
 | `ERR_GAP_REPORT_FAILED` | Filing a gap report failed (disabled, or the integration errored). |
 
+## Capability manifest (agent discovery)
+
+Agents don't have to scrape `--help` to learn the CLI. A single call returns a
+**self-describing manifest** — every command, its arguments, flags (with types,
+choices, and defaults), whether it supports `--json`, and the response `type`
+discriminators each command can emit. Think of it as an OpenAPI spec for the CLI.
+
+```bash
+xds manifest --json        # dedicated surface — type: "manifest"
+xds --json                 # bare invocation — embeds the same payload under data.manifest
+```
+
+Shape:
+
+```jsonc
+{
+  "apiVersion": 1,
+  "type": "manifest",
+  "data": {
+    "name": "xds",
+    "version": "0.0.14",
+    "description": "Design system CLI — components, themes, and tooling",
+    "globalOptions": [
+      {"flag": "--json", "type": "boolean", "description": "Output as typed JSON…"},
+      {"flag": "--lang <locale>", "type": "enum", "choices": ["en", "zh", "dense"]},
+      {"flag": "--detail <level>", "type": "enum", "choices": ["full", "compact", "brief"], "default": "full"}
+    ],
+    "commands": [
+      {
+        "name": "component",
+        "description": "List components or print component docs",
+        "arguments": [{"name": "name", "required": false, "variadic": false, "description": ""}],
+        "options": [{"flag": "--props", "type": "boolean", "description": "Print only the props table"}],
+        "json": true,
+        "responseTypes": ["component.list", "component.detail", "component.detail.props", "…"],
+        "examples": ["xds component XDSButton --props --json"]
+      }
+      // …one entry per command; subcommands (e.g. `theme build`) nest under `subcommands`
+    ],
+    "jsonSupported": ["component", "docs", "…"],
+    "responseTypes": {"component": ["component.list", "…"], "theme build": ["theme.build"]}
+  }
+}
+```
+
+The manifest is **derived from Commander metadata** (commands, arguments, options)
+so it can't drift from the real command definitions. The two facts Commander
+doesn't track — `--json` support and emitted response types — are layered on from
+the `JSON_SUPPORTED` allowlist and a small declarative `RESPONSE_TYPES` map in
+`src/lib/manifest.mjs`, guarded by a drift test (`manifest.test.mjs`) so adding a
+command without describing it fails CI.
+
+**Backwards-compat:** the bare `xds --json` envelope keeps `type: "help"` and its
+original shallow fields (`name`, `version`, `commands` as a `string[]` of names,
+`jsonSupported`); the full structured manifest is additive under `data.manifest`.
+For the standalone manifest envelope (`type: "manifest"`), use `xds manifest --json`.
+
 ## Programmatic API
 
 The same logic that powers `xds --json` is available as importable, type-safe functions:

--- a/packages/cli/src/index.mjs
+++ b/packages/cli/src/index.mjs
@@ -14,6 +14,7 @@ import * as path from 'node:path';
 import {checkForUpdate} from './utils/update-check.mjs';
 import {getRunPrefix} from './utils/package-manager.mjs';
 import {API_VERSION, setJsonMode} from './lib/json.mjs';
+import {buildManifest} from './lib/manifest.mjs';
 import {cliError} from './lib/cli-error.mjs';
 import {ERROR_CODES} from './lib/error-codes.mjs';
 import {levenshteinDistance} from './lib/string-utils.mjs';
@@ -60,6 +61,7 @@ export const JSON_SUPPORTED = new Set([
   'theme build',
   'gap-report',
   'upgrade',
+  'manifest',
 ]);
 
 program
@@ -112,19 +114,33 @@ program
 
     // `xds` (no subcommand) — print help, or emit a JSON envelope when --json.
     if (program.opts().json) {
-      // Emit a JSON help envelope. Treat the bare invocation as supported.
+      // Emit the full capability manifest so an agent can drive the entire
+      // CLI from one call — no need to scrape `--help` text. We derive this
+      // from Commander metadata (commands, args, flags) and layer on the
+      // JSON_SUPPORTED allowlist + per-command response types. See
+      // lib/manifest.mjs.
+      //
+      // Backwards-compat: the envelope keeps `type: 'help'` and the original
+      // shallow fields (`name`, `version`, `commands` as a string[] of names,
+      // `jsonSupported`) that earlier consumers read. The richer, structured
+      // surface is embedded under `data.manifest` (and is also available
+      // standalone via `xds manifest --json` as `type: 'manifest'`).
       process.__xdsJsonHandled = true;
+      const manifest = buildManifest(program, {
+        jsonSupported: JSON_SUPPORTED,
+        version: pkg.version,
+      });
       console.log(JSON.stringify({
         apiVersion: API_VERSION,
         type: 'help',
         data: {
-          name: 'xds',
-          version: pkg.version,
-          commands: [
-            'component', 'docs', 'discover', 'search', 'swizzle', 'template',
-            'hook', 'theme', 'gap-report', 'upgrade', 'init',
-          ],
-          jsonSupported: [...JSON_SUPPORTED].sort(),
+          name: manifest.name,
+          version: manifest.version,
+          // Original flat list of command names (string[]) — kept for compat.
+          commands: manifest.commands.map((c) => c.name),
+          jsonSupported: manifest.jsonSupported,
+          // Enriched, self-describing surface (the full manifest payload).
+          manifest,
         },
       }, null, 2));
       return;
@@ -250,6 +266,33 @@ for (const cmd of commands) {
       });
   }
 }
+
+// Capability manifest — a single, self-describing view of the whole CLI so
+// agents can discover every command, argument, flag, and response type without
+// scraping `--help`. `xds manifest --json` is the dedicated surface; the bare
+// `xds --json` embeds the same payload under data.manifest for convenience.
+program
+  .command('manifest')
+  .description('Print the full CLI capability manifest (use with --json)')
+  .action(() => {
+    const manifest = buildManifest(program, {
+      jsonSupported: JSON_SUPPORTED,
+      version: pkg.version,
+    });
+    if (program.opts().json) {
+      process.__xdsJsonHandled = true;
+      console.log(JSON.stringify({apiVersion: API_VERSION, type: 'manifest', data: manifest}, null, 2));
+      return;
+    }
+    // Human-readable summary. Agents should use --json.
+    console.log(`\n${manifest.name} v${manifest.version} — ${manifest.commands.length} commands\n`);
+    for (const c of manifest.commands) {
+      const tag = c.json ? ' [--json]' : '';
+      console.log(`  ${c.name}${tag}`);
+      if (c.description) console.log(`    ${c.description}`);
+    }
+    console.log(`\nRun \`xds manifest --json\` for the full structured manifest.\n`);
+  });
 
 // Hidden command used by package.json postinstall scripts
 program

--- a/packages/cli/src/lib/manifest.mjs
+++ b/packages/cli/src/lib/manifest.mjs
@@ -1,0 +1,246 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Capability manifest — self-describing CLI surface for agents.
+ *
+ * `xds --json` (and `xds manifest --json`) emit a structured manifest that
+ * lets an AI agent drive the entire CLI WITHOUT scraping `--help` text. It is
+ * to the CLI what an OpenAPI spec is to an HTTP API.
+ *
+ * Most of the manifest is DERIVED from Commander metadata (program.commands,
+ * cmd.options, cmd.registeredArguments, cmd.description()) so it cannot drift
+ * out of sync with the real command definitions. The two pieces Commander does
+ * not know about — whether a command supports `--json`, and which response
+ * `type` discriminators it can emit — are layered on from:
+ *
+ *   - JSON_SUPPORTED  (the allowlist in index.mjs), and
+ *   - RESPONSE_TYPES  (the declarative map below).
+ *
+ * A drift-guard test (manifest.test.mjs) asserts every registered command
+ * appears in the manifest and every JSON-supported command has a response-type
+ * entry, so adding a command without describing it fails CI.
+ *
+ * @input  a configured Commander `program` + the JSON_SUPPORTED allowlist
+ * @output a `{ name, version, globalOptions, commands, responseTypes }` object
+ * @position consumed by the bare `xds --json` action and the `manifest` command
+ */
+
+import {API_VERSION} from './json.mjs';
+
+/**
+ * Response `type` discriminators each fully-qualified command can emit in
+ * `--json` mode. Keyed by the same name Commander reports (parent + leaf,
+ * space-joined), e.g. `theme build`. Commander has no knowledge of these —
+ * they come from each command's `jsonOut(...)` call sites — so we keep them
+ * here, close to the JSON_SUPPORTED allowlist, and guard them with a test.
+ *
+ * @type {Record<string, string[]>}
+ */
+export const RESPONSE_TYPES = {
+  component: [
+    'component.list',
+    'component.brief',
+    'component.full',
+    'component.detail',
+    'component.detail.props',
+    'component.detail.source',
+    'component.detail.showcase',
+    'component.detail.blocks',
+  ],
+  docs: ['docs.list', 'docs.detail', 'docs.detail.section'],
+  discover: ['discover.list', 'discover.detail', 'discover.detail.doc', 'discover.search'],
+  search: ['search'],
+  swizzle: ['swizzle.list', 'swizzle.copy'],
+  template: [
+    'template.list',
+    'template.show',
+    'template.skeleton',
+    'template.copy',
+    'template.get',
+  ],
+  hook: ['hook.list', 'hook.brief', 'hook.full', 'hook.detail', 'hook.detail.params'],
+  'theme build': ['theme.build'],
+  upgrade: ['upgrade.list', 'upgrade.status', 'upgrade.run'],
+  'gap-report': ['gap-report.categories', 'gap-report.dryRun', 'gap-report.file'],
+  manifest: ['manifest'],
+};
+
+/**
+ * Example invocations per fully-qualified command. Optional, agent-facing.
+ * @type {Record<string, string[]>}
+ */
+const EXAMPLES = {
+  component: ['xds component', 'xds component XDSButton', 'xds component XDSButton --props --json'],
+  docs: ['xds docs', 'xds docs spacing --json'],
+  discover: ['xds discover --json'],
+  search: ['xds search modal --json', 'xds search button --type component --json'],
+  swizzle: ['xds swizzle XDSButton'],
+  template: ['xds template --json', 'xds template dashboard ./src/app'],
+  hook: ['xds hook', 'xds hook useToggle --json'],
+  'theme build': ['xds theme build ./src/themes/ocean.ts --out ./dist/ocean.css'],
+  upgrade: ['xds upgrade --json'],
+  manifest: ['xds manifest --json', 'xds --json'],
+  init: ['xds init'],
+};
+
+/**
+ * Map a Commander Option to a flag descriptor. Derives type from whether the
+ * option takes a value (boolean vs string), surfaces `choices` and `default`.
+ *
+ * @param {import('commander').Option} opt
+ * @returns {{flag: string, description: string, type: string, choices?: string[], default?: unknown, negate?: boolean}}
+ */
+function describeOption(opt) {
+  const o = /** @type {any} */ (opt);
+  const takesValue = o.required || o.optional;
+  /** @type {any} */
+  const d = {
+    flag: o.flags,
+    description: o.description || '',
+    type: takesValue ? 'string' : 'boolean',
+  };
+  if (Array.isArray(o.argChoices) && o.argChoices.length > 0) {
+    d.choices = [...o.argChoices];
+    d.type = 'enum';
+  }
+  if (o.defaultValue !== undefined) d.default = o.defaultValue;
+  // `--no-foo` style negation flags
+  if (o.negate) d.negate = true;
+  return d;
+}
+
+/**
+ * Map a Commander positional argument to an arg descriptor.
+ * @param {import('commander').Argument} arg
+ * @returns {{name: string, required: boolean, variadic: boolean, description: string}}
+ */
+function describeArgument(arg) {
+  const a = /** @type {any} */ (arg);
+  return {
+    name: a.name(),
+    required: a.required === true,
+    variadic: a.variadic === true,
+    description: a.description || '',
+  };
+}
+
+/**
+ * Compute the fully-qualified command name relative to the root program,
+ * e.g. `theme build`. The root program itself maps to ''.
+ * @param {import('commander').Command} cmd
+ * @param {import('commander').Command} root
+ * @returns {string}
+ */
+function fullName(cmd, root) {
+  const parts = [];
+  /** @type {import('commander').Command | null} */
+  let c = cmd;
+  while (c && c !== root) {
+    parts.unshift(c.name());
+    c = c.parent;
+  }
+  return parts.join(' ');
+}
+
+/**
+ * Recursively describe a Commander command and its subcommands.
+ *
+ * @param {import('commander').Command} cmd
+ * @param {import('commander').Command} root
+ * @param {Set<string>} jsonSupported  fully-qualified names that support --json
+ * @returns {object | null}  null for hidden/internal commands
+ */
+function describeCommand(cmd, root, jsonSupported) {
+  const name = fullName(cmd, root);
+  // Skip the auto-generated help command and any hidden/internal commands
+  // (e.g. the postinstall shim) — agents never invoke these directly.
+  // `_hidden` is a Commander internal not present on its public types.
+  if (!name || /** @type {any} */ (cmd)._hidden || name === 'help') return null;
+
+  const subcommands = /** @type {object[]} */ ((cmd.commands || [])
+    .map((sub) => describeCommand(sub, root, jsonSupported))
+    .filter(Boolean));
+
+  // `registeredArguments` is Commander 12's public-ish accessor; `_args` is the
+  // older internal. Cast through any to read whichever exists.
+  const args =
+    /** @type {any[]} */ (/** @type {any} */ (cmd).registeredArguments || /** @type {any} */ (cmd)._args || []);
+
+  /** @type {any} */
+  const entry = {
+    name,
+    description: cmd.description() || '',
+    arguments: args.map(describeArgument),
+    options: (cmd.options || []).map(describeOption),
+    json: jsonSupported.has(name),
+  };
+
+  const aliases = cmd.aliases ? cmd.aliases() : [];
+  if (aliases && aliases.length > 0) entry.aliases = [...aliases];
+
+  // Response types this command can emit in --json mode (only meaningful for
+  // JSON-supported leaves). Subcommand groups (e.g. bare `theme`) have none.
+  if (RESPONSE_TYPES[name]) entry.responseTypes = [...RESPONSE_TYPES[name]];
+
+  if (EXAMPLES[name]) entry.examples = [...EXAMPLES[name]];
+
+  if (subcommands.length > 0) entry.subcommands = subcommands;
+
+  return entry;
+}
+
+/**
+ * Describe the global options declared on the root program (--json, --lang,
+ * --detail, --zh, --dense, --version). Documented once at top level so each
+ * command entry doesn't repeat them.
+ *
+ * @param {import('commander').Command} program
+ * @returns {Array<object>}
+ */
+function describeGlobalOptions(program) {
+  const opts = (program.options || []).map(describeOption);
+  // Commander registers a built-in --version flag; if for some reason it
+  // isn't present in program.options, surface it so the manifest is complete.
+  if (!opts.some((o) => /(^|[\s,])--version\b/.test(o.flag))) {
+    opts.push({
+      flag: '-V, --version',
+      description: 'Output the version number',
+      type: 'boolean',
+    });
+  }
+  return opts;
+}
+
+/**
+ * Build the full capability manifest from a configured Commander program.
+ *
+ * @param {import('commander').Command} program  the root program
+ * @param {object} [opts]
+ * @param {Set<string>} [opts.jsonSupported]  the JSON_SUPPORTED allowlist
+ * @param {string} [opts.version]  CLI version (defaults to program.version())
+ * @returns {object}  the manifest `data` payload (sans envelope)
+ */
+export function buildManifest(program, opts = {}) {
+  const jsonSupported = opts.jsonSupported || new Set();
+  const version = opts.version || /** @type {any} */ (program)._version || '';
+
+  const commands = /** @type {any[]} */ ((program.commands || [])
+    .map((cmd) => describeCommand(cmd, program, jsonSupported))
+    .filter(Boolean))
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  return {
+    name: 'xds',
+    version,
+    apiVersion: API_VERSION,
+    description: program.description() || '',
+    globalOptions: describeGlobalOptions(program),
+    commands,
+    jsonSupported: [...jsonSupported].sort(),
+    // Flat index of every response `type` discriminator the CLI can emit,
+    // keyed by command — lets an agent know what to expect back per call.
+    responseTypes: Object.fromEntries(
+      Object.entries(RESPONSE_TYPES).map(([k, v]) => [k, [...v]]),
+    ),
+  };
+}

--- a/packages/cli/src/lib/manifest.test.mjs
+++ b/packages/cli/src/lib/manifest.test.mjs
@@ -1,0 +1,176 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Tests for the CLI capability manifest.
+ *
+ * Two jobs:
+ *   1. DRIFT GUARDS — the manifest is the agent-facing contract for the whole
+ *      CLI surface. These tests fail if a command is added without describing
+ *      it: every registered command must appear in the manifest, every
+ *      JSON-supported command must declare its response types, and every
+ *      response-type key must map to a real command.
+ *   2. SHAPE — each command entry carries the required fields, global options
+ *      are described once, and the bare `xds --json` / `xds manifest --json`
+ *      surfaces emit valid, enriched JSON.
+ */
+
+import {describe, it, expect} from 'vitest';
+import {spawnSync} from 'node:child_process';
+import * as path from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {program, JSON_SUPPORTED} from '../index.mjs';
+import {buildManifest, RESPONSE_TYPES} from './manifest.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CLI_BIN = path.resolve(__dirname, '../../bin/xds.mjs');
+
+const manifest = buildManifest(program, {jsonSupported: JSON_SUPPORTED, version: '0.0.0-test'});
+
+/** Flatten the manifest command tree into fully-qualified names. */
+function flatten(cmds, out = []) {
+  for (const c of cmds) {
+    out.push(c);
+    if (c.subcommands) flatten(c.subcommands, out);
+  }
+  return out;
+}
+const allEntries = flatten(manifest.commands);
+const allNames = new Set(allEntries.map((c) => c.name));
+
+/** Fully-qualified names of every registered, non-hidden command in the program. */
+function registeredNames() {
+  const names = [];
+  const walk = (cmd, prefix) => {
+    for (const sub of cmd.commands || []) {
+      if (sub._hidden || sub.name() === 'help') continue;
+      const full = prefix ? `${prefix} ${sub.name()}` : sub.name();
+      names.push(full);
+      walk(sub, full);
+    }
+  };
+  walk(program, '');
+  return names;
+}
+
+describe('manifest: drift guards', () => {
+  it('lists every registered (non-hidden) command', () => {
+    for (const name of registeredNames()) {
+      expect(allNames.has(name), `manifest is missing command "${name}"`).toBe(true);
+    }
+  });
+
+  it('marks every JSON_SUPPORTED command as json:true', () => {
+    for (const name of JSON_SUPPORTED) {
+      const entry = allEntries.find((c) => c.name === name);
+      expect(entry, `JSON_SUPPORTED command "${name}" not in manifest`).toBeDefined();
+      expect(entry.json, `"${name}" should be json:true`).toBe(true);
+    }
+  });
+
+  it('declares response types for every JSON-supported command', () => {
+    for (const name of JSON_SUPPORTED) {
+      expect(
+        RESPONSE_TYPES[name],
+        `JSON-supported command "${name}" has no response-type entry`,
+      ).toBeDefined();
+      expect(RESPONSE_TYPES[name].length).toBeGreaterThan(0);
+    }
+  });
+
+  it('has no response-type entry for a command that does not exist', () => {
+    for (const name of Object.keys(RESPONSE_TYPES)) {
+      expect(allNames.has(name), `RESPONSE_TYPES key "${name}" is not a real command`).toBe(true);
+    }
+  });
+
+  it('every command with response types is json-supported', () => {
+    for (const entry of allEntries) {
+      if (entry.responseTypes) {
+        expect(entry.json, `"${entry.name}" emits types but isn't json-supported`).toBe(true);
+      }
+    }
+  });
+});
+
+describe('manifest: shape', () => {
+  it('has top-level metadata', () => {
+    expect(manifest.name).toBe('xds');
+    expect(manifest.apiVersion).toBe(1);
+    expect(typeof manifest.description).toBe('string');
+    expect(Array.isArray(manifest.commands)).toBe(true);
+    expect(Array.isArray(manifest.globalOptions)).toBe(true);
+  });
+
+  it('describes global options once at top level (--json, --lang, --detail, --version)', () => {
+    const flags = manifest.globalOptions.map((o) => o.flag).join(' ');
+    expect(flags).toContain('--json');
+    expect(flags).toContain('--lang');
+    expect(flags).toContain('--detail');
+    expect(flags).toContain('--version');
+    // No duplicate --version
+    const versionCount = manifest.globalOptions.filter((o) => /--version\b/.test(o.flag)).length;
+    expect(versionCount).toBe(1);
+  });
+
+  it('surfaces enum choices and defaults on options', () => {
+    const detail = manifest.globalOptions.find((o) => o.flag.includes('--detail'));
+    expect(detail.type).toBe('enum');
+    expect(detail.choices).toEqual(['full', 'compact', 'brief']);
+    expect(detail.default).toBe('full');
+  });
+
+  it('each command entry carries the required fields', () => {
+    for (const c of allEntries) {
+      expect(typeof c.name).toBe('string');
+      expect(typeof c.description).toBe('string');
+      expect(Array.isArray(c.arguments)).toBe(true);
+      expect(Array.isArray(c.options)).toBe(true);
+      expect(typeof c.json).toBe('boolean');
+    }
+  });
+
+  it('derives arguments from Commander metadata', () => {
+    const component = allEntries.find((c) => c.name === 'component');
+    expect(component.arguments.map((a) => a.name)).toContain('name');
+    const themeBuild = allEntries.find((c) => c.name === 'theme build');
+    expect(themeBuild.arguments.map((a) => a.name)).toContain('file');
+    expect(themeBuild.arguments.find((a) => a.name === 'file').required).toBe(true);
+  });
+});
+
+function runCli(args) {
+  const res = spawnSync('node', [CLI_BIN, ...args], {encoding: 'utf-8', timeout: 20_000});
+  return {status: res.status, stdout: res.stdout || '', stderr: res.stderr || ''};
+}
+
+describe('manifest: e2e', () => {
+  it('xds manifest --json emits a valid manifest envelope', () => {
+    const {status, stdout} = runCli(['manifest', '--json']);
+    expect(status).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.apiVersion).toBe(1);
+    expect(parsed.type).toBe('manifest');
+    expect(parsed.data.name).toBe('xds');
+    const names = parsed.data.commands.map((c) => c.name);
+    expect(names).toContain('component');
+    expect(names).toContain('theme');
+    expect(names).toContain('manifest');
+  });
+
+  it('bare xds --json stays backwards-compatible AND embeds the manifest', () => {
+    const {status, stdout} = runCli(['--json']);
+    expect(status).toBe(0);
+    const parsed = JSON.parse(stdout);
+    // Back-compat: still type:'help' with name/version/commands(names)/jsonSupported
+    expect(parsed.type).toBe('help');
+    expect(parsed.data.name).toBe('xds');
+    expect(Array.isArray(parsed.data.commands)).toBe(true);
+    expect(parsed.data.commands.every((c) => typeof c === 'string')).toBe(true);
+    expect(parsed.data.commands).toContain('component');
+    expect(Array.isArray(parsed.data.jsonSupported)).toBe(true);
+    // Enriched: the full structured manifest is embedded.
+    expect(parsed.data.manifest).toBeDefined();
+    expect(parsed.data.manifest.commands.find((c) => c.name === 'component').responseTypes)
+      .toContain('component.list');
+  });
+});

--- a/packages/cli/src/types/base.d.ts
+++ b/packages/cli/src/types/base.d.ts
@@ -50,6 +50,7 @@ import type {
 } from './gap-report';
 import type {SearchResponse} from './search';
 import type {ErrorCode} from './error-codes';
+import type {ManifestResponse} from './manifest';
 
 /**
  * Structured error. Check `'error' in result` to discriminate.
@@ -104,7 +105,8 @@ export type CLIAnyResponse =
   | UpgradeRunResponse
   | GapReportCategoriesResponse
   | GapReportFileResponse
-  | SearchResponse;
+  | SearchResponse
+  | ManifestResponse;
 
 /** Union of all type discriminator string literals. */
 export type CLIResponseType = CLIAnyResponse['type'];

--- a/packages/cli/src/types/index.d.ts
+++ b/packages/cli/src/types/index.d.ts
@@ -12,3 +12,4 @@ export * from './gap-report';
 export * from './upgrade';
 export * from './search';
 export * from './error-codes';
+export * from './manifest';

--- a/packages/cli/src/types/manifest.d.ts
+++ b/packages/cli/src/types/manifest.d.ts
@@ -1,0 +1,73 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * Types for the CLI capability manifest emitted by `xds manifest --json`
+ * (and embedded under `data.manifest` of the bare `xds --json` help envelope).
+ *
+ * The manifest is a self-describing view of the entire CLI surface so an agent
+ * can discover every command, argument, flag, and response type in one call —
+ * without scraping `--help`. Most of it is derived from Commander metadata; see
+ * lib/manifest.mjs.
+ */
+
+/** A single command-line flag/option. */
+export interface ManifestOption {
+  /** Raw Commander flag spec, e.g. `--detail <level>` or `-o, --out <path>`. */
+  flag: string;
+  description: string;
+  /** `boolean` for flags, `string` for value options, `enum` when choices exist. */
+  type: 'boolean' | 'string' | 'enum';
+  /** Allowed values when `type` is `enum`. */
+  choices?: string[];
+  /** Default value, if any. */
+  default?: unknown;
+  /** True for `--no-foo` style negation flags. */
+  negate?: boolean;
+}
+
+/** A positional argument. */
+export interface ManifestArgument {
+  name: string;
+  required: boolean;
+  variadic: boolean;
+  description: string;
+}
+
+/** A single command (possibly with subcommands). */
+export interface ManifestCommand {
+  /** Fully-qualified name, e.g. `theme build`. */
+  name: string;
+  description: string;
+  arguments: ManifestArgument[];
+  options: ManifestOption[];
+  /** Whether this command supports `--json` (from the JSON_SUPPORTED allowlist). */
+  json: boolean;
+  /** Command aliases, if any. */
+  aliases?: string[];
+  /** Response `type` discriminators this command can emit in `--json` mode. */
+  responseTypes?: string[];
+  /** Example invocations. */
+  examples?: string[];
+  /** Nested subcommands (e.g. `theme build` under `theme`). */
+  subcommands?: ManifestCommand[];
+}
+
+/** The full manifest payload (the `data` of the `manifest` envelope). */
+export interface CLIManifest {
+  name: 'xds';
+  version: string;
+  apiVersion: number;
+  description: string;
+  globalOptions: ManifestOption[];
+  commands: ManifestCommand[];
+  /** Sorted list of fully-qualified command names that support `--json`. */
+  jsonSupported: string[];
+  /** Flat index of response `type` discriminators keyed by command name. */
+  responseTypes: Record<string, string[]>;
+}
+
+/** The `xds manifest --json` envelope. */
+export interface ManifestResponse {
+  type: 'manifest';
+  data: CLIManifest;
+}

--- a/packages/cli/tsconfig.json-api.json
+++ b/packages/cli/tsconfig.json-api.json
@@ -10,6 +10,7 @@
   "include": [
     "src/types/**/*.d.ts",
     "src/lib/json.mjs",
+    "src/lib/manifest.mjs",
     "src/lib/parse.mjs",
     "../core/src/docs-types.ts"
   ]


### PR DESCRIPTION
## Problem

The XDS CLI is heavily driven by AI agents, but discovering its surface is awkward. Today the bare `xds --json` returns a **shallow** manifest — just command *names* and the `--json` allowlist. To learn each command's arguments, flags, and what response types it emits, an agent has to **scrape `--help` text**. That's brittle and easy to get wrong.

## What this does

Adds a **self-describing capability manifest** so an agent can drive the entire CLI from one call — no `--help` scraping. It's to the CLI what an OpenAPI spec is to an HTTP API.

For **every command** the manifest describes:
- name, description, aliases
- **arguments** (name, required, variadic, description)
- **options/flags** (flag, description, type, `choices` for enums, `default`)
- whether it supports `--json` (`json: true/false`, from the `JSON_SUPPORTED` allowlist)
- the **response `type` discriminators** it can emit (e.g. `component` → `component.list`, `component.detail`, `component.detail.props`, …)
- example invocations
- nested subcommands (e.g. `theme build` under `theme`)

Plus **global flags** (`--json`, `--lang`, `--detail`, `--version`, …) described once at the top level, and a flat `responseTypes` index keyed by command.

## Surface choice

I did **both**, cleanly:

- **`xds manifest --json`** — dedicated surface, returns the full manifest under `type: "manifest"`.
- **Bare `xds --json`** — kept **fully backwards-compatible**: still `type: "help"` with the original shallow fields (`name`, `version`, `commands` as a `string[]` of names, `jsonSupported`). The full structured manifest is **additive** under `data.manifest`. No existing `{type:'help'}` consumer breaks.

## Can't drift

The manifest is **derived from Commander metadata** (`program.commands`, `cmd.options`, `cmd.registeredArguments`, `cmd.description()`) so it can't fall out of sync with the real command definitions. The only two facts Commander doesn't track — `--json` support and emitted response types — are layered on from the `JSON_SUPPORTED` allowlist and a small declarative `RESPONSE_TYPES` map in `src/lib/manifest.mjs`, kept right next to the allowlist.

A **drift-guard test** (`manifest.test.mjs`) enforces this: every registered command must appear in the manifest, every `JSON_SUPPORTED` command must declare response types, and every `RESPONSE_TYPES` key must map to a real command. Adding a command without describing it fails CI.

> Note: there's a 38-code error taxonomy in flight (`error-codes.mjs`) but it isn't on `main` yet, so this PR doesn't depend on it. Per-command error codes can be folded into the manifest in a follow-up once it lands.

## Tests

- New `manifest.test.mjs` — 12 tests: drift guards, shape checks, and e2e for both `xds --json` and `xds manifest --json`.
- Full CLI suite green: **809 passed**.
- API↔CLI parity: **304/304**.
- `tsconfig.json-api` typecheck clean (manifest lib + types added to the checked set).

## Docs

`packages/cli/README.md` gains a **"Capability manifest (agent discovery)"** section documenting both surfaces, the shape, the no-drift design, and the back-compat guarantee, plus a `manifest` row in the type-discriminator table.
