### PR TITLE
fix(docsite): keep data-pg-id markers off generic JSX type args

### DIFF
--- a/apps/docsite/src/app/playground/babelParser.ts
+++ b/apps/docsite/src/app/playground/babelParser.ts
@@ -41,7 +41,15 @@ export interface InstanceInfo {
   component: string;
   /** Start offset of the opening element (`<`). */
   openingStart: number;
-  /** Offset immediately after the element name — insertion point for new attrs. */
+  /**
+   * Offset of the safe insertion point for new attributes — immediately after
+   * the element name, or after an explicit JSX type argument when present.
+   *
+   * For a generic call like `<XDSTable<Item> ...>` the name node ends right
+   * after `XDSTable`, but inserting there would split the `<Item>` type
+   * argument (`<XDSTable data-pg-id="…"<Item>`), producing invalid JSX. We
+   * advance past the type argument so attributes land after `<Item>`.
+   */
   nameEnd: number;
   attrs: AttrInfo[];
 }
@@ -87,6 +95,24 @@ function readAttrValue(attr: Node): {
     return {valueKind: 'expression'};
   }
   return {valueKind: 'none'};
+}
+
+/**
+ * Find the offset just past the element name where new attributes can be
+ * safely spliced in. Normally this is the end of the name node, but a generic
+ * JSX call carries an explicit type argument (`<XDSTable<Item> ...>`) that sits
+ * between the name and the attribute list. Babel attaches it as
+ * `typeArguments` (older builds: `typeParameters`); we advance past it so an
+ * inserted attribute does not bisect `<Item>` and corrupt the JSX.
+ */
+function instanceNameEnd(opening: Node, nameNode: Node): number {
+  const typeArgs = (opening.typeArguments ?? opening.typeParameters) as
+    | Node
+    | undefined;
+  if (typeArgs && typeof typeArgs.end === 'number') {
+    return typeArgs.end;
+  }
+  return nameNode.end as number;
 }
 
 /**
@@ -144,7 +170,7 @@ export function analyzeCode(code: string): InstanceInfo[] | null {
           instances.push({
             component,
             openingStart: n.start as number,
-            nameEnd: nameNode.end as number,
+            nameEnd: instanceNameEnd(n, nameNode),
             attrs,
           });
         }


### PR DESCRIPTION
## Problem

Loading the **Analytics** (Dashboard) template in the Playground crashes with:

> ⚠ Render Error: `T is not defined`

## Root cause

The playground's element-targeting instrumentation (`babelParser.ts`, added in #2488) annotates every `<XDS*>` element with a `data-pg-id` marker so the preview can map a selected DOM node back to its source. The marker is inserted at the JSX **name node's** end offset.

For a generic call like `<XDSTable<T> ...>`, the name node ends right after `XDSTable` — *before* the `<T>` type argument — so the marker splits the element:

```tsx
// source
<XDSTable<T> data={data} columns={columns} idKey="id" />

// after annotation (buggy)
<XDSTable data-pg-id="XDSTable#0"<T> data={data} columns={columns} idKey="id" />
```

TypeScript's lenient `transpileModule` (single-file, no diagnostics) recovers from that by treating `<T>` as a **separate child element**, emitting:

```js
React.createElement(T, null, ...)
```

`T` is a type-only generic, so it's `undefined` at runtime → the ErrorBoundary catches it and shows "⚠ Render Error: T is not defined".

This affects **every template using the `<XDSTable<RowType>>` syntax** (7 page templates), plus any user who writes generic JSX in the Playground.

## Fix

Advance the marker insertion point past an explicit JSX type argument when present (`typeArguments`, or `typeParameters` on the bundled `@babel/parser` build), so the attribute lands after `<T>`:

```tsx
<XDSTable<T> data-pg-id="XDSTable#0" data={data} ... />
```

The annotated copy is only sent to the preview iframe — the code the user sees, edits, and shares is untouched.

## Verification

Reproduced the full pipeline (`annotateInstanceIds` → `ts.transpileModule`) against the actual templates:

- **Before:** compiled output contains `React.createElement(T, …)` → crashes at render.
- **After:** no split, marker lands correctly, all 7 generic-JSX templates render cleanly.

| Template | Before | After |
|---|---|---|
| dashboard, dashboard-portfolio, table, table-page, table-page-chart, table-page-heatmap-status, table-page-shoe-store-heatmap | marker splits `<RowType>` → render crash | marker after type arg → renders |

## Scope

Single-concern: this only fixes the generic-JSX targeting crash. It does **not** include unrelated changes (e.g. chart rendering / scope), keeping the fix easy to review and land.