### PR TITLE
fix(chat): introduce --radius-chat token for chat surface rounding

### DIFF
--- a/apps/sandbox/src/app/(sandbox)/pages/doc-preview/token-tables/ShapeTokenTable.tsx
+++ b/apps/sandbox/src/app/(sandbox)/pages/doc-preview/token-tables/ShapeTokenTable.tsx
@@ -33,6 +33,7 @@ const RADIUS_ORDER = [
   '--radius-element',
   '--radius-container',
   '--radius-page',
+  '--radius-chat',
   '--radius-full',
 ];
 

--- a/packages/cli/docs/tokens.doc.mjs
+++ b/packages/cli/docs/tokens.doc.mjs
@@ -3,7 +3,7 @@
 // AUTO-GENERATED — do not edit manually.
 // Source: packages/core/src/theme/tokens.stylex.ts
 // Run: node scripts/generate-token-docs.mjs
-// Total: 183 tokens across 12 categories.
+// Total: 184 tokens across 12 categories.
 
 /** @type {import('../../core/src/docs-types').ReferenceDoc} */
 
@@ -593,6 +593,10 @@ export const docs = {
             ],
             [
               "--radius-page",
+              "28px"
+            ],
+            [
+              "--radius-chat",
               "28px"
             ],
             [

--- a/packages/cli/templates/blocks/components/ChatComposerDrawer/ChatComposerDrawerShowcase.tsx
+++ b/packages/cli/templates/blocks/components/ChatComposerDrawer/ChatComposerDrawerShowcase.tsx
@@ -14,7 +14,7 @@ import {colorVars, borderVars, radiusVars} from '@xds/core/theme/tokens.stylex';
 const styles = stylex.create({
   drawerBorder: {
     border: `${borderVars['--border-width']} solid ${colorVars['--color-border']}`,
-    borderRadius: radiusVars['--radius-page'],
+    borderRadius: radiusVars['--radius-chat'],
   },
 });
 
@@ -24,7 +24,10 @@ export default function ChatComposerDrawerShowcase() {
       <XDSChatComposer
         onSubmit={() => {}}
         drawer={
-          <XDSChatComposerDrawer count={4} label="Attachments" xstyle={styles.drawerBorder}>
+          <XDSChatComposerDrawer
+            count={4}
+            label="Attachments"
+            xstyle={styles.drawerBorder}>
             <XDSToken label="design-spec.pdf" onRemove={() => {}} />
             <XDSToken label="api-schema.json" onRemove={() => {}} />
             <XDSToken label="screenshot.png" onRemove={() => {}} />

--- a/packages/core/src/Chat/Chat.doc.mjs
+++ b/packages/core/src/Chat/Chat.doc.mjs
@@ -28,7 +28,7 @@ export const docs = {
       {className: 'xds-trigger-menu'},
     ],
     vars: [
-      {name: '--_chat-composer-radius', description: 'Border radius of the composer body. Inner elements derive their radius concentrically.', default: 'var(--radius-page)', private: true},
+      {name: '--_chat-composer-radius', description: 'Border radius of the composer body. Inner elements derive their radius concentrically.', default: 'var(--radius-chat)', private: true},
       {name: '--_chat-composer-padding', description: 'Padding of the composer body. Used in the concentric radius calculation.', default: 'var(--spacing-3)', private: true},
       {name: '--_button-radius', description: 'Concentric button radius inside the composer.', default: 'max(var(--radius-element), calc(var(--_chat-composer-radius) - var(--_chat-composer-padding)))', private: true, derived: true, formula: 'max(var(--radius-element), calc(var(--_chat-composer-radius) - var(--_chat-composer-padding)))'},
     ],

--- a/packages/core/src/Chat/XDSChatComposer.tsx
+++ b/packages/core/src/Chat/XDSChatComposer.tsx
@@ -13,7 +13,7 @@
  * page-radius container, hover/focus shadows, and concentric inner radius.
  *
  * Component CSS vars (themeable via defineTheme):
- * - `--_chat-composer-radius` (default: --radius-page) — outer border radius
+ * - `--_chat-composer-radius` (default: --radius-chat) — outer border radius
  * - `--_chat-composer-padding` (default: --spacing-3) — body padding
  * - Inner element radius = calc(--_chat-composer-radius - --_chat-composer-padding)
  *
@@ -116,7 +116,9 @@ const styles = stylex.create({
     display: 'flex',
     flexDirection: 'column',
     // Component CSS vars — themeable via defineTheme({ components: { 'chat-composer': { base: {...} } } })
-    '--_chat-composer-radius': radiusVars['--radius-page'],
+    // Uses the dedicated chat radius (28px) rather than --radius-page, so chat
+    // rounding is decoupled from page-level containers but unchanged today. #2072
+    '--_chat-composer-radius': radiusVars['--radius-chat'],
     '--_chat-composer-padding': spacingVars['--spacing-3'],
     // Concentric radius: buttons follow the outer shell's curvature.
     // Sets --_button-radius (not --radius-element) so only buttons are

--- a/packages/core/src/Chat/XDSChatComposerDrawer.tsx
+++ b/packages/core/src/Chat/XDSChatComposerDrawer.tsx
@@ -86,8 +86,11 @@ const styles = stylex.create({
     overflow: 'hidden',
     paddingInline: spacingVars['--spacing-4'],
     paddingBlockStart: spacingVars['--spacing-3'],
-    paddingBlockEnd: `calc(${spacingVars['--spacing-3']} + ${radiusVars['--radius-page']})`,
-    marginBlockEnd: `calc(-1 * ${radiusVars['--radius-page']})`,
+    // The drawer tucks behind the composer (negative marginBlockEnd) and its
+    // top corners align with the composer's outer radius. Tracks the chat
+    // radius to stay matched to the composer, decoupled from --radius-page. #2072
+    paddingBlockEnd: `calc(${spacingVars['--spacing-3']} + ${radiusVars['--radius-chat']})`,
+    marginBlockEnd: `calc(-1 * ${radiusVars['--radius-chat']})`,
     // Surface base with a muted tint layered on top, both in the element's
     // own background layer. The muted backgroundImage composites over the
     // surface backgroundColor and — by CSS rule — paints behind all in-flow
@@ -97,8 +100,8 @@ const styles = stylex.create({
     // opaque or translucent.
     backgroundColor: colorVars['--color-background-surface'],
     backgroundImage: `linear-gradient(${colorVars['--color-background-muted']}, ${colorVars['--color-background-muted']})`,
-    borderTopLeftRadius: radiusVars['--radius-page'],
-    borderTopRightRadius: radiusVars['--radius-page'],
+    borderTopLeftRadius: radiusVars['--radius-chat'],
+    borderTopRightRadius: radiusVars['--radius-chat'],
   },
 
   // Toggle row — both the bar handle and badge+label live in the

--- a/packages/core/src/Chat/XDSChatMessageBubble.tsx
+++ b/packages/core/src/Chat/XDSChatMessageBubble.tsx
@@ -93,7 +93,9 @@ const styles = stylex.create({
     display: 'flex',
     flexDirection: 'column',
     maxWidth: 'max(80%, 280px)',
-    borderRadius: radiusVars['--radius-page'],
+    // Bubbles are intentionally rounder than cards in the same view, so they
+    // use the dedicated chat radius rather than coupling to --radius-page. #2072
+    borderRadius: radiusVars['--radius-chat'],
     fontFamily: typographyVars['--font-family-body'],
     fontSize: typeScaleVars['--text-body-size'],
     lineHeight: typeScaleVars['--text-body-leading'],

--- a/packages/core/src/theme/expandRadiusScale.test.ts
+++ b/packages/core/src/theme/expandRadiusScale.test.ts
@@ -11,6 +11,7 @@ describe('expandRadiusScale', () => {
     expect(tokens['--radius-element']).toBe('8px');
     expect(tokens['--radius-container']).toBe('12px');
     expect(tokens['--radius-page']).toBe('28px');
+    expect(tokens['--radius-chat']).toBe('28px');
     expect(tokens['--radius-full']).toBe('9999px');
   });
 
@@ -20,6 +21,7 @@ describe('expandRadiusScale', () => {
     expect(tokens['--radius-element']).toBe('12px');
     expect(tokens['--radius-container']).toBe('18px');
     expect(tokens['--radius-page']).toBe('42px');
+    expect(tokens['--radius-chat']).toBe('42px');
   });
 
   it('multiplier 0 produces all zeros', () => {
@@ -29,6 +31,7 @@ describe('expandRadiusScale', () => {
     expect(tokens['--radius-element']).toBe('0px');
     expect(tokens['--radius-container']).toBe('0px');
     expect(tokens['--radius-page']).toBe('0px');
+    expect(tokens['--radius-chat']).toBe('0px');
     expect(tokens['--radius-full']).toBe('9999px');
   });
 

--- a/packages/core/src/theme/expandRadiusScale.ts
+++ b/packages/core/src/theme/expandRadiusScale.ts
@@ -16,6 +16,7 @@
  *   --radius-element   → base × 2 × multiplier (buttons, inputs)
  *   --radius-container → base × 3 × multiplier (cards, panels)
  *   --radius-page      → base × 7 × multiplier (page-level containers)
+ *   --radius-chat      → base × 7 × multiplier (chat surfaces; tracks page)
  *   --radius-full      → 9999px (fixed, pill shapes)
  *
  * SYNC: When modified, update:
@@ -73,6 +74,7 @@ export type RadiusScaleTokens = Record<string, string>;
  * // tokens['--radius-element'] === '8px'     (4 × 2 × 1)
  * // tokens['--radius-container'] === '12px'  (4 × 3 × 1)
  * // tokens['--radius-page'] === '28px'       (4 × 7 × 1)
+ * // tokens['--radius-chat'] === '28px'       (4 × 7 × 1)
  * // tokens['--radius-full'] === '9999px'
  *
  * const sharp = expandRadiusScale({ base: 4, multiplier: 0 });
@@ -89,6 +91,9 @@ export function expandRadiusScale(
     '--radius-element': `${Math.round(base * 2 * multiplier)}px`,
     '--radius-container': `${Math.round(base * 3 * multiplier)}px`,
     '--radius-page': `${Math.round(base * 7 * multiplier)}px`,
+    // Chat surfaces track the page step (× 7) so they scale with the theme
+    // multiplier, but remain a distinct token for independent theming. #2072
+    '--radius-chat': `${Math.round(base * 7 * multiplier)}px`,
     '--radius-full': '9999px',
   };
 }

--- a/packages/core/src/theme/tokens.stylex.ts
+++ b/packages/core/src/theme/tokens.stylex.ts
@@ -203,6 +203,10 @@ export const radiusDefaults = {
   '--radius-element': '8px',
   '--radius-container': '12px',
   '--radius-page': '28px',
+  // Chat surfaces (bubbles, composer, drawer) are intentionally rounder than
+  // cards in the same view. Tracks --radius-page's value by default but is a
+  // distinct token so chat rounding can be themed independently. See #2072.
+  '--radius-chat': '28px',
   '--radius-full': '9999px',
 } as const;
 


### PR DESCRIPTION
## Summary

Chat components used `--radius-page` (28px — intended for page-level containers like modals and the app shell) for their **element-level** rounding, coupling chat rounding to an unrelated semantic token.

Per the discussion on #2072, chat surfaces are **intentionally rounder** than cards in the same view, so rather than reusing `--radius-container` (which would shrink them to 12px and regress the look), this introduces a dedicated **`--radius-chat`** token.

It defaults to **28px** and tracks the page step (`base × 7`) in `expandRadiusScale`, so the rendered radius is **unchanged today** but chat rounding is now decoupled from `--radius-page` and independently themeable.

## Changes

- **`tokens.stylex.ts`** — add `--radius-chat: 28px` to `radiusDefaults`.
- **`expandRadiusScale.ts`** — generate `--radius-chat` at `base × 7 × multiplier` so it scales with the theme multiplier like `--radius-page` (following current behavior). Doc comments updated.
- **`expandRadiusScale.test.ts`** — assert `--radius-chat` in the default, multiplier, and zero-multiplier cases.
- **Chat components** — `XDSChatMessageBubble`, `XDSChatComposer`, and `XDSChatComposerDrawer` now reference `--radius-chat` instead of `--radius-page`.
- **Docs/blocks sync** — `Chat.doc.mjs` default, the `ChatComposerDrawer` block showcase border, and the docs `ShapeTokenTable` ordering updated to include the new token.

## Why a new token (not `--radius-container`)

`--radius-page` is for page-level surfaces; chat bubbles/composers are content-level but **intentionally rounder than cards**. A dedicated token captures that intent without coupling to either `--radius-page` or `--radius-container`. (See @cixzhang / @kentonquatman on #2072.)

## Testing

- `vitest run` (Chat + theme + defineTheme) — 201 passed
- `eslint` on changed files — clean
- `pnpm -F @xds/core typecheck` — clean
- `check:sync` — clean

## Visual impact

**None.** `--radius-chat` defaults to 28px, the same value chat components rendered before.

Refs #2072
