### PR TITLE
docs(templates): hide recharts and @xds/lab templates from gallery

### DIFF
--- a/packages/cli/templates/pages/dashboard-portfolio/template.doc.mjs
+++ b/packages/cli/templates/pages/dashboard-portfolio/template.doc.mjs
@@ -8,4 +8,5 @@ export const doc = {
   description: 'Investment portfolio dashboard with KPI metrics, area chart, and top asset holdings',
   isReady: true,
   category: 'Dashboard - Portfolio',
+  isHiddenFromOverview: true,
 };

--- a/packages/cli/templates/pages/dashboard/template.doc.mjs
+++ b/packages/cli/templates/pages/dashboard/template.doc.mjs
@@ -8,4 +8,5 @@ export const doc = {
   description: 'Analytics dashboard with KPI cards, charts, and data tables',
   isReady: true,
   category: 'Dashboard - Analytics',
+  isHiddenFromOverview: true,
 };

--- a/packages/cli/templates/pages/table-page-heatmap-status/template.doc.mjs
+++ b/packages/cli/templates/pages/table-page-heatmap-status/template.doc.mjs
@@ -9,4 +9,5 @@ export const doc = {
     'Product status page with an outage heatmap and incident log table.',
   isReady: true,
   category: 'Table - Heatmap',
+  isHiddenFromOverview: true,
 };


### PR DESCRIPTION
## What

Hides page templates from the **/templates** overview gallery if they depend on either:
- **`recharts`** charts, or
- components from the **`@xds/lab`** package

Hidden templates are removed from the gallery via `isHiddenFromOverview: true` in their `template.doc.mjs`. They remain available through the CLI (`xds template <name>`) — this only affects gallery visibility.

## Templates hidden in this PR

These 3 templates had `isHiddenFromOverview: true` added:

| Template (slug) | Name | Reason |
|---|---|---|
| `dashboard` | Analytics | imports from `recharts` |
| `dashboard-portfolio` | Portfolio | imports from `recharts` |
| `table-page-heatmap-status` | Heatmap | imports from `@xds/lab` |

## Already hidden (no change needed)

These two `@xds/lab` templates were already hidden, so they're correct as-is — listed here for completeness:

| Template (slug) | Name | Reason |
|---|---|---|
| `table-page-chart` | Chart | imports from `@xds/lab` |
| `table-page-shoe-store-heatmap` | Chart | imports from `@xds/lab` |

## How it works

The Templates gallery (`apps/docsite/src/app/(site)/templates/page.tsx`) filters out any template where `isHiddenFromOverview` is true. That flag is sourced from each template's `template.doc.mjs` and baked into the generated `templateRegistry.ts` by `scripts/generate-data.mjs`.

## Verification

Re-ran the registry generation logic against the updated docs — all 5 recharts/`@xds/lab` templates now resolve to `isHiddenFromOverview: true`.