### PR TITLE
fix(docsite): use resolved import path and per-component usage

### DIFF
--- a/apps/docsite/scripts/generate-data.mjs
+++ b/apps/docsite/scripts/generate-data.mjs
@@ -114,6 +114,24 @@ function findDocFilesRecursive(dir) {
   return results;
 }
 
+/**
+ * Resolve the correct import path for a component given its package directory
+ * and the subdirectory it lives in. Checks the package.json "exports" field to
+ * find a matching subpath export (e.g. `@xds/core/Chat`).
+ *
+ * Falls back to the package name when no explicit export is found.
+ */
+function resolveImportPathForPkg(pkgDir, directory) {
+  const pkgJsonPath = path.join(REPO_ROOT, pkgDir, 'package.json');
+  if (!fs.existsSync(pkgJsonPath)) return null;
+  const pkg = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf-8'));
+  if (pkg.exports && pkg.exports[`./${directory}`]) {
+    return `${pkg.name}/${directory}`;
+  }
+  // No matching export — fall back to package root
+  return pkg.name;
+}
+
 // ── Package discovery ──────────────────────────────────────────────────
 
 /**
@@ -232,7 +250,7 @@ async function generateComponentRegistry() {
     const pkgJson = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, dir, 'package.json'), 'utf-8'));
     const allDocFiles = findDocFilesRecursive(srcDir);
     if (allDocFiles.length > 0) {
-      componentPackages.push({name: pkgJson.name, srcDir});
+      componentPackages.push({name: pkgJson.name, srcDir, dir});
     }
   }
 
@@ -299,6 +317,11 @@ async function generateComponentRegistry() {
             // Sub-entries whose name differs from the doc name are
             // sub-components — hide them from the overview page.
             const isSubEntry = subName !== doc.name;
+            // Each sub-component may have its own usage; fall back to
+            // the parent doc's usage only when the sub doesn't define one.
+            const subUsage = sub.usage
+              ? sanitizeForJson(sub.usage)
+              : usage;
             pendingSubComponents.push({
               name: subName,
               displayName: requireDisplayName(
@@ -307,6 +330,7 @@ async function generateComponentRegistry() {
               ),
               moduleName: sub.name || subName,
               directory: entry.name,
+              importPath: resolveImportPathForPkg(pkg.dir, entry.name),
               group,
               category,
               isHiddenFromOverview: sub.isHiddenFromOverview ?? isHiddenFromOverview,
@@ -315,7 +339,7 @@ async function generateComponentRegistry() {
               hidden,
               parentDoc: doc.name,
               props: Array.isArray(sub.props) ? sanitizeForJson(sub.props) : [],
-              usage,
+              usage: subUsage,
               theming,
               params: null,
               returns: null,
@@ -336,6 +360,7 @@ async function generateComponentRegistry() {
             ),
             moduleName: name,
             directory: entry.name,
+            importPath: resolveImportPathForPkg(pkg.dir, entry.name),
             group,
             category,
             isHiddenFromOverview,
@@ -364,6 +389,7 @@ async function generateComponentRegistry() {
             ),
             moduleName: name.startsWith('use') ? name : `XDS${name}`,
             directory: entry.name,
+            importPath: resolveImportPathForPkg(pkg.dir, entry.name),
             group,
             category,
             isHiddenFromOverview,
@@ -483,6 +509,8 @@ export interface ComponentEntry {
   displayName: string;
   moduleName: string;
   directory: string;
+  /** Resolved import path, e.g. \`@xds/core/Chat\`. Derived from package.json exports. */
+  importPath: string | null;
   group: string | null;
   /** Functional category for the overview gallery (Actions, Inputs, etc.) */
   category: string | null;

--- a/apps/docsite/src/components/component-detail/ComponentDetailClient.tsx
+++ b/apps/docsite/src/components/component-detail/ComponentDetailClient.tsx
@@ -49,7 +49,8 @@ function OverviewContent({
   hasShowcase,
 }: ComponentDetailClientProps & {hasShowcase: boolean}) {
   const isHook = comp.params != null;
-  const importPath = `import {${comp.moduleName}} from '${pkg}/${comp.directory}'`;
+  const importFrom = comp.importPath ?? `${pkg}/${comp.directory}`;
+  const importPath = `import {${comp.moduleName}} from '${importFrom}'`;
 
   return (
     <XDSVStack gap={8}>

--- a/packages/core/src/Chat/Chat.doc.mjs
+++ b/packages/core/src/Chat/Chat.doc.mjs
@@ -273,6 +273,23 @@ const chatLayoutComponent = {
   name: 'XDSChatLayout',
   displayName: 'Chat Layout',
   description: 'Layout shell for full chat interfaces. Messages flow in normal page flow, composer is fixed to the bottom with a frosted glass dock. Adapts density (compact/balanced/spacious) automatically via container width observation. Includes built-in auto-scroll, a "New messages" scroll-to-bottom button, and a frosted glass blur layer behind the composer. By default the layout root is the scroll container; pass scrollRef to delegate scrolling to a parent element or the document body.',
+  usage: {
+    description: 'XDSChatLayout is the layout shell for full-page chat interfaces. It renders messages in normal page flow and docks the composer to the bottom with a frosted glass blur layer. Density adapts automatically via container width observation. Use it to wrap XDSChatMessageList and XDSChatComposer for a complete chat experience with built-in auto-scroll and a scroll-to-bottom button.',
+    bestPractices: [
+      { guidance: true, description: 'Pass XDSChatMessageList as children and XDSChatComposer as the composer prop for a complete chat interface.' },
+      { guidance: true, description: 'Provide an emptyState so new conversations show a prompt instead of a blank screen.' },
+      { guidance: true, description: 'Use scrollRef when the chat is embedded in a page where a parent element handles scrolling.' },
+      { guidance: false, description: 'Don\'t apply a fixed height on the layout — let it fill its container with flex: 1.' },
+      { guidance: false, description: 'Don\'t render multiple ChatLayout instances in the same scroll container — each expects to own its scroll context.' },
+    ],
+    anatomy: [
+      { name: 'Message area', required: true, description: 'Scrollable region for messages. Renders children (typically XDSChatMessageList) in a flex column that pushes content to the bottom when the list is short.' },
+      { name: 'Frosted glass dock', required: true, description: 'Sticky or fixed container at the bottom with a backdrop-blur layer. Houses the scroll button and composer.' },
+      { name: 'Scroll-to-bottom button', required: false, description: 'Appears when the user scrolls up or new messages arrive. Defaults to XDSChatLayoutScrollButton; pass null to hide or a custom element to override.' },
+      { name: 'Composer', required: true, description: 'The input area for sending messages, typically XDSChatComposer. Docked at the bottom inside the frosted glass layer.' },
+      { name: 'Empty state', required: false, description: 'Centered placeholder shown when no messages exist. Use XDSEmptyState for a consistent look.' },
+    ],
+  },
   props: [
     {name: 'children', type: 'ReactNode', description: 'Message content — typically XDSChatMessageList. Flows naturally in the page and scrolls with the container.', required: true},
     {name: 'composer', type: 'ReactNode', description: 'Composer element — typically XDSChatComposer. Fixed to the bottom with a frosted glass dock.', required: true,


### PR DESCRIPTION
## Problem

The ChatLayout component page at https://xds-sandbox.vercel.app/components/ChatLayout shows:
1. **Wrong docs** — displays ChatMessageList's usage description instead of ChatLayout's
2. **Wrong import** — the import statement was naively constructed as `${pkg}/${directory}` without checking package.json exports

## Root Cause

1. **Usage inheritance**: In `generate-data.mjs`, all sub-components in a multi-component doc file (`Chat.doc.mjs`) inherit the parent doc's `usage` object. ChatLayout had no `usage` of its own, so it fell through to the parent's (written for ChatMessageList).

2. **Import path**: `ComponentDetailClient.tsx` naively built the import as `${pkg}/${comp.directory}` (e.g. `@xds/core/Chat`). While this happens to be correct for the Chat case, it's fragile — the CLI already has a proper `resolveImportPath` function that checks package.json exports. The docsite should use the same logic.

## Fix

- **`generate-data.mjs`**: Added `resolveImportPathForPkg()` that checks package.json exports for the correct subpath. Each component entry now includes an `importPath` field in the registry. Sub-components now check for their own `usage` before falling back to the parent's.
- **`ComponentDetailClient.tsx`**: Uses `comp.importPath` (with fallback to the old naive path).
- **`Chat.doc.mjs`**: Added a dedicated `usage` block to the ChatLayout sub-component with its own description, best practices, and anatomy.

## Verification

- `pnpm generate` succeeds, produces correct `importPath: "@xds/core/Chat"` and ChatLayout-specific usage in the registry
- All 86 docsite tests pass