### PR TITLE
fix(AppShell): restore defaultIsMobile passthrough to useMediaQuery SSR

### DIFF
--- a/packages/core/src/AppShell/XDSAppShell.tsx
+++ b/packages/core/src/AppShell/XDSAppShell.tsx
@@ -492,7 +492,10 @@ export function XDSAppShell({
     sideNavBreakpoint === 'none'
       ? '(max-width: 0px)'
       : `(max-width: ${BREAKPOINT_VALUES[sideNavBreakpoint]}px)`;
-  const isBelowBreakpoint = useMediaQuery(breakpointQuery);
+  const isBelowBreakpoint = useMediaQuery(
+    breakpointQuery,
+    mobileNavConfig?.defaultIsMobile,
+  );
   const [uncontrolledMobileOpen, setUncontrolledMobileOpen] = useState(false);
   const isMobileNavOpen = mobileNavConfig?.isOpen ?? uncontrolledMobileOpen;
 

--- a/packages/core/src/hooks/useMediaQuery.test.ts
+++ b/packages/core/src/hooks/useMediaQuery.test.ts
@@ -11,6 +11,8 @@
 
 import {describe, it, expect, vi, beforeEach} from 'vitest';
 import {renderHook, act} from '@testing-library/react';
+import {renderToString} from 'react-dom/server';
+import {createElement} from 'react';
 import {useMediaQuery} from './useMediaQuery';
 
 // Mock matchMedia
@@ -114,5 +116,50 @@ describe('useMediaQuery', () => {
     rerender({query: '(max-width: 1024px)'});
     expect(result.current).toBe(true);
     expect(matchMediaFn).toHaveBeenCalledWith('(max-width: 1024px)');
+  });
+
+  it('returns serverDefault during SSR (no matchMedia)', () => {
+    // renderToString uses getServerSnapshot — simulate by calling the hook
+    // in an environment where matchMedia doesn't exist. Since JSDOM always
+    // provides matchMedia, we test the contract: the serverDefault param
+    // is accepted and does not break when the client snapshot differs.
+    mockMql = createMockMatchMedia(false);
+    vi.stubGlobal('matchMedia', vi.fn().mockReturnValue(mockMql));
+
+    // serverDefault=true but client says false → client wins on hydration
+    const {result} = renderHook(() =>
+      useMediaQuery('(max-width: 768px)', true),
+    );
+    expect(result.current).toBe(false);
+  });
+
+  it('uses serverDefault=false by default', () => {
+    mockMql = createMockMatchMedia(false);
+    vi.stubGlobal('matchMedia', vi.fn().mockReturnValue(mockMql));
+
+    // No serverDefault → same as false
+    const {result} = renderHook(() => useMediaQuery('(max-width: 768px)'));
+    expect(result.current).toBe(false);
+  });
+
+  it('SSR: returns serverDefault=true in server render', () => {
+    // renderToString uses getServerSnapshot — this is the actual SSR path
+    function TestComponent() {
+      const isMobile = useMediaQuery('(max-width: 768px)', true);
+      return createElement('div', {'data-mobile': String(isMobile)});
+    }
+
+    const html = renderToString(createElement(TestComponent));
+    expect(html).toContain('data-mobile="true"');
+  });
+
+  it('SSR: returns false when no serverDefault provided', () => {
+    function TestComponent() {
+      const isMobile = useMediaQuery('(max-width: 768px)');
+      return createElement('div', {'data-mobile': String(isMobile)});
+    }
+
+    const html = renderToString(createElement(TestComponent));
+    expect(html).toContain('data-mobile="false"');
   });
 });

--- a/packages/core/src/hooks/useMediaQuery.ts
+++ b/packages/core/src/hooks/useMediaQuery.ts
@@ -18,21 +18,21 @@
 
 import {useCallback, useSyncExternalStore} from 'react';
 
-function getServerSnapshot(): boolean {
-  return false;
-}
-
 /**
  * SSR-safe media query hook.
  * Returns whether the given media query matches.
  *
+ * @param query - CSS media query string
+ * @param serverDefault - Value to return during SSR. Pass a server-side hint
+ *   (e.g. derived from User-Agent or client hints) to avoid a layout flash.
+ *
  * @example
  * ```
  * const isMobile = useMediaQuery('(max-width: 768px)');
- * const prefersReducedMotion = useMediaQuery('(prefers-reduced-motion: reduce)');
+ * const isMobile = useMediaQuery('(max-width: 768px)', defaultIsMobile);
  * ```
  */
-export function useMediaQuery(query: string): boolean {
+export function useMediaQuery(query: string, serverDefault = false): boolean {
   const subscribe = useCallback(
     (onStoreChange: () => void) => {
       const mql = window.matchMedia(query);
@@ -45,6 +45,8 @@ export function useMediaQuery(query: string): boolean {
   const getSnapshot = useCallback(() => {
     return window.matchMedia(query).matches;
   }, [query]);
+
+  const getServerSnapshot = useCallback(() => serverDefault, [serverDefault]);
 
   return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 }


### PR DESCRIPTION
## Summary

`#2272` refactored `useMediaQuery` to use `useSyncExternalStore` but hardcoded `getServerSnapshot` to always return `false`, dropping the `defaultIsMobile` SSR hint added in `#1755`. This caused a layout flash on mobile — the server always rendered the desktop top nav, then hydration switched to the mobile nav.

## Changes

- **`useMediaQuery.ts`** — accept optional `serverDefault` param, use it in `getServerSnapshot`
- **`XDSAppShell.tsx`** — pass `mobileNavConfig.defaultIsMobile` as the second arg to `useMediaQuery`
- **`useMediaQuery.test.ts`** — added `renderToString` tests that exercise the actual SSR code path so this can't regress silently again

## Test Plan

- `pnpm vitest run packages/core/src/hooks/useMediaQuery.test.ts` — 10 tests pass
- Existing `XDSAppShell.test.tsx` `defaultIsMobile` test passes
- New SSR tests use `renderToString` to verify `getServerSnapshot` returns the hint