### PR TITLE
refactor(templates): responsive, pure-XDS gallery-hero (grade 78→85)

### DIFF
--- a/packages/cli/templates/pages/gallery-hero/page.tsx
+++ b/packages/cli/templates/pages/gallery-hero/page.tsx
@@ -14,7 +14,6 @@ import {XDSButton} from '@xds/core/Button';
 import {XDSIcon} from '@xds/core/Icon';
 import {XDSGrid} from '@xds/core/Grid';
 import {XDSAspectRatio} from '@xds/core/AspectRatio';
-import {XDSSection} from '@xds/core/Section';
 import {ArrowRightIcon} from '@heroicons/react/20/solid';
 
 const IMAGES = [
@@ -87,22 +86,20 @@ export default function GalleryHero() {
                 <XDSButton label="Learn more" variant="secondary" />
               </XDSHStack>
             </XDSVStack>
-            <XDSSection variant="transparent" padding={0}>
-              <XDSGrid columns={{minWidth: 240, max: 3}} gap={4}>
-                {IMAGES.map(image => (
-                  <XDSAspectRatio
-                    key={image.src}
-                    ratio={4 / 5}
-                    xstyle={styles.galleryImageClip}>
-                    <img
-                      {...stylex.props(styles.galleryImage)}
-                      src={image.src}
-                      alt={image.alt}
-                    />
-                  </XDSAspectRatio>
-                ))}
-              </XDSGrid>
-            </XDSSection>
+            <XDSGrid columns={{minWidth: 200, repeat: 'fit'}} gap={4}>
+              {IMAGES.map(image => (
+                <XDSAspectRatio
+                  key={image.src}
+                  ratio={4 / 5}
+                  xstyle={styles.galleryImageClip}>
+                  <img
+                    {...stylex.props(styles.galleryImage)}
+                    src={image.src}
+                    alt={image.alt}
+                  />
+                </XDSAspectRatio>
+              ))}
+            </XDSGrid>
           </XDSVStack>
         </XDSLayoutContent>
       }

--- a/packages/cli/templates/pages/gallery-hero/page.tsx
+++ b/packages/cli/templates/pages/gallery-hero/page.tsx
@@ -9,7 +9,7 @@ import {
   XDSLayout,
   XDSLayoutContent,
 } from '@xds/core/Layout';
-import {XDSText} from '@xds/core/Text';
+import {XDSText, XDSHeading} from '@xds/core/Text';
 import {XDSButton} from '@xds/core/Button';
 import {XDSIcon} from '@xds/core/Icon';
 import {XDSGrid} from '@xds/core/Grid';
@@ -35,24 +35,18 @@ const IMAGES = [
   },
 ];
 
+// NOTE: The only custom styling here is image fill + corner radius. It exists
+// because XDS has no image primitive — XDSAspectRatio exposes no objectFit or
+// radius props and there's no XDSImage. Tracked in issue #2582; replace these
+// with component props once it lands.
 const styles = stylex.create({
-  textCenter: {
-    textAlign: 'center',
-  },
-  titleResponsive: {
-    fontSize: {
-      default: 'var(--text-display-2-size)',
-      '@media (max-width: 640px)': 'var(--text-display-3-size)',
-    },
-  },
-  topSpacing: {
-    paddingTop: 'var(--spacing-12)',
-  },
+  // Fills the XDSAspectRatio box. No objectFit prop on XDSAspectRatio (#2582).
   galleryImage: {
     width: '100%',
     height: '100%',
     objectFit: 'cover',
   },
+  // Rounds the image corners. No radius prop on XDSAspectRatio (#2582).
   galleryImageClip: {
     borderRadius: 'var(--radius-container)',
   },
@@ -62,23 +56,22 @@ export default function GalleryHero() {
   return (
     <XDSLayout
       content={
-        <XDSLayoutContent padding={0}>
+        <XDSLayoutContent padding={6}>
           <XDSVStack gap={10}>
-            <XDSVStack gap={6} hAlign="center" xstyle={styles.topSpacing}>
+            <XDSVStack gap={6} hAlign="center">
               <XDSVStack gap={3} hAlign="center">
-                <XDSText
+                <XDSHeading
+                  level={1}
                   type="display-2"
-                  as="h1"
-                  weight="bold"
-                  textWrap="balance"
-                  xstyle={[styles.textCenter, styles.titleResponsive]}>
+                  justify="center"
+                  textWrap="balance">
                   Little joys, everywhere you go
-                </XDSText>
+                </XDSHeading>
                 <XDSText
                   type="body"
                   color="secondary"
-                  textWrap="balance"
-                  xstyle={styles.textCenter}>
+                  justify="center"
+                  textWrap="balance">
                   Sometimes all it takes is one small thing to turn your whole
                   day around.
                 </XDSText>
@@ -86,19 +79,19 @@ export default function GalleryHero() {
               <XDSHStack gap={3}>
                 <XDSButton
                   label="Get started"
-                  variant="secondary"
+                  variant="primary"
                   endContent={
                     <XDSIcon icon={ArrowRightIcon} size="sm" color="inherit" />
                   }
                 />
-                <XDSButton label="Learn more" variant="ghost" />
+                <XDSButton label="Learn more" variant="secondary" />
               </XDSHStack>
             </XDSVStack>
-            <XDSSection variant="transparent" padding={6}>
-              <XDSGrid columns={3} gap={4}>
-                {IMAGES.map((image, i) => (
+            <XDSSection variant="transparent" padding={0}>
+              <XDSGrid columns={{minWidth: 240, max: 3}} gap={4}>
+                {IMAGES.map(image => (
                   <XDSAspectRatio
-                    key={i}
+                    key={image.src}
                     ratio={4 / 5}
                     xstyle={styles.galleryImageClip}>
                     <img

--- a/packages/cli/templates/pages/gallery-hero/template.doc.mjs
+++ b/packages/cli/templates/pages/gallery-hero/template.doc.mjs
@@ -3,11 +3,10 @@
 /** @type {import('../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'page',
-  name: 'Hero',
-  displayName: 'Hero',
+  name: 'Gallery Hero',
+  displayName: 'Gallery Hero',
   description:
     'Centered headline, description, and CTA buttons above a three-image gallery grid.',
-  isReady: false,
+  isReady: true,
   category: 'Gallery - Hero',
-  isHiddenFromOverview: true,
 };


### PR DESCRIPTION
## Summary

Polishes the `gallery-hero` page template (`packages/cli/templates/pages/gallery-hero/page.tsx`) against the [Contributing-Templates rubric](https://github.com/facebookexperimental/xds/wiki/Contributing-Templates#template-grading-rubric) and fixes two layout issues found in the live preview: **B (78/100) → B (85/100)**, and marks it ready. Mirrors the polished `centered-hero` sibling (#2583).

### Grading fixes
- **Headline** → `XDSHeading level={1} type="display-2" justify="center" textWrap="balance"` (was `XDSText` with `as="h1"` + a `textCenter` custom style and an `@media` font override). Native `justify` replaces the custom centering; the responsive font swap is dropped (no responsive `type`/`size` prop — [#2580](https://github.com/facebookexperimental/xds/issues/2580)).
- **Top spacing** → `XDSLayoutContent padding={6}` (removed the custom `topSpacing` style).
- **Doc**: `name` `"Hero"` → `"Gallery Hero"`, `isReady: true`, removed `isHiddenFromOverview`.

### Layout fixes (from preview review)
- **Missing side padding.** The gallery row bled edge-to-edge while the header had margins, because it was wrapped in `XDSSection` — whose documented behavior is to *escape parent container padding for full-bleed fills*, cancelling `XDSLayoutContent`'s padding. Removed the wrapper; the grid now sits in the padded content and aligns with the header (also drops a component + import).
- **Not responsive.** The three images didn't reflow (fixed `columns={3}`, default `'fill'` left an empty track at narrow widths). Now `columns={{minWidth: 200, repeat: 'fit'}}` cleanly reflows **3 → 2 → 1** and always stretches to fill the row.

## Scorecard

| Category | main | After | Max |
|----------|------|-------|-----|
| XDS Component Purity | 25 | 25 | 30 |
| Icon Purity | 15 | 15 | 15 |
| Custom CSS | 5 | 5 | 15 |
| Layout & Structure | 8 | 15 | 15 |
| Doc Metadata | 10 | 10 | 10 |
| Image Handling | 5 | 5 | 5 |
| Code Quality | 10 | 10 | 10 |
| **Total** | **78 (B)** | **85 (B)** | 100 |

## Why not 100 — remaining gaps (all issue-backed)

The remaining 15 points are **structurally blocked by the absence of an `XDSImage` primitive** — an image template can't reach zero raw HTML (Component Purity 25/30: one rubric-sanctioned `<img>`) or zero image-fill CSS (Custom CSS 5/15). Every other category is maxed, and unlike `mixed-gallery` this one stays fully prop-driven (responsive via native `XDSGrid columns={{minWidth, repeat}}`, no `@container`).

| Remaining custom style | Properties | Why custom | Issue |
|---|---|---|---|
| `galleryImage` | `width: 100%`, `height: 100%`, `objectFit: cover` | Fills the `XDSAspectRatio` box; no `objectFit` prop | [#2582](https://github.com/facebookexperimental/xds/issues/2582) |
| `galleryImageClip` | `borderRadius` | Rounds the corners; no radius prop | [#2582](https://github.com/facebookexperimental/xds/issues/2582) |

See also [#2584](https://github.com/facebookexperimental/xds/issues/2584) (rubric image/CSS exceptions can't score A; Image-Handling cites a stale CDN).

## Note: images in the sandbox preview

Uses repo-served `/template-assets/*` (the #2454 strategy, served from `apps/docsite/public/`). Those 404 in the **sandbox** export — a pre-existing, repo-wide #2454 gap, out of scope here. Rubric still scores Image Handling 5/5.

## Test plan

- [x] Scoped `tsc --noEmit` against real `@xds/core` source types — 0 errors
- [x] ESLint clean (pre-commit hook + manual)
- [x] `check:sync` and `check:package-boundaries` pass
- [x] Rendered at desktop (3-up, padded, aligned with header) and mobile (1 column) — confirmed reflow and side padding
- [ ] Reviewer: verify the PR preview at `/pr/<this-PR>/sandbox/templates/gallery-hero/` (images pending the #2454 sandbox-assets fix)

Made with [Cursor](https://cursor.com)

## Related component gaps

- [#2582](https://github.com/facebookexperimental/xds/issues/2582) — no `XDSImage` primitive (the image fill/radius CSS + raw `<img>`).
- [#2580](https://github.com/facebookexperimental/xds/issues/2580) — no responsive `type`/`size` on `XDSHeading`/`XDSText` (drove dropping the `@media` headline-size swap).
- [#2584](https://github.com/facebookexperimental/xds/issues/2584) — the grading rubric's image/CSS exceptions can't score a perfect A.
