### PR TITLE
refactor(templates): tighten product-detail XDS purity (grade 75→82)

### DIFF
--- a/packages/cli/templates/pages/product-detail/page.tsx
+++ b/packages/cli/templates/pages/product-detail/page.tsx
@@ -25,32 +25,35 @@ import {XDSCollapsible, XDSCollapsibleGroup} from '@xds/core/Collapsible';
 import {XDSAspectRatio} from '@xds/core/AspectRatio';
 import * as stylex from '@stylexjs/stylex';
 
+// Custom CSS here is limited to what XDS components can't express today:
+// - image fill + corner radius (no XDSImage primitive — #2582)
+// - the selected-thumbnail outline and sticky info column (no props for either)
 const pageStyles = stylex.create({
-  pageWrapper: {
-    maxWidth: 1200,
-    width: '100%',
-    padding: '32px 24px',
-  },
+  // Keeps the info column in view while the gallery scrolls. No sticky prop on
+  // XDS layout primitives.
   stickyInfo: {
     position: 'sticky',
-    top: 64,
+    top: 'var(--spacing-8)',
     alignSelf: 'start',
   },
+  // Fills the XDSAspectRatio box + rounds corners. No objectFit/radius props on
+  // XDSAspectRatio (#2582).
   heroImage: {
     width: '100%',
     height: '100%',
     objectFit: 'cover',
-    borderRadius: 'var(--radius-container, 12px)',
+    borderRadius: 'var(--radius-container)',
   },
   thumbImage: {
     width: '100%',
     height: '100%',
     objectFit: 'cover',
-    borderRadius: 'var(--radius-element, 8px)',
+    borderRadius: 'var(--radius-element)',
     cursor: 'pointer',
   },
+  // Marks the active thumbnail. No "selected" affordance on a bare image.
   thumbSelected: {
-    outline: '2px solid var(--color-accent, #0866ff)',
+    outline: '2px solid var(--color-accent)',
     outlineOffset: 2,
   },
 });
@@ -84,9 +87,9 @@ function StarRating({rating, count}: {rating: number; count: number}) {
 // IMAGES[0] = fallback hero; IMAGES[1..6] = thumbnails (first is selected by default)
 const IMAGES = [
   // light-product-1 (fallback hero)
-  '/template-assets/light-home-horizontal-1.png',
+  '/template-assets/light-product-1.png',
   // light-product-1 (thumbnail 1)
-  '/template-assets/light-home-horizontal-1.png',
+  '/template-assets/light-product-1.png',
   // light-product-2
   '/template-assets/light-product-2.png',
   // light-product-3
@@ -95,8 +98,8 @@ const IMAGES = [
   '/template-assets/light-product-4.png',
   // light-product-5
   '/template-assets/light-product-5.png',
-  // light-product-1 (gallery variety)
-  '/template-assets/light-product-1.png',
+  // light-product-3 (gallery variety)
+  '/template-assets/light-product-3.png',
 ];
 
 // ─── Product Data ───────────────────────────────────────────────────────────
@@ -311,21 +314,18 @@ export default function ProductDetailTemplate() {
   return (
     <XDSLayout
       height="auto"
+      contentWidth={1200}
       content={
-        <XDSLayoutContent padding={0}>
-          <XDSCenter axis="horizontal">
-            <XDSVStack gap={0} xstyle={pageStyles.pageWrapper}>
-              <XDSGrid columns={{minWidth: 400}} gap={5}>
-                <ImageGallery
-                  selected={selectedThumb}
-                  onSelect={setSelectedThumb}
-                />
-                <XDSVStack gap={0} xstyle={pageStyles.stickyInfo}>
-                  <ProductInfo />
-                </XDSVStack>
-              </XDSGrid>
+        <XDSLayoutContent padding={6}>
+          <XDSGrid columns={{minWidth: 400}} gap={5}>
+            <ImageGallery
+              selected={selectedThumb}
+              onSelect={setSelectedThumb}
+            />
+            <XDSVStack gap={0} xstyle={pageStyles.stickyInfo}>
+              <ProductInfo />
             </XDSVStack>
-          </XDSCenter>
+          </XDSGrid>
         </XDSLayoutContent>
       }
     />


### PR DESCRIPTION
## Summary

Polishes the `product-detail` page template (`packages/cli/templates/pages/product-detail/page.tsx`) against the [Contributing-Templates grading rubric](https://github.com/facebookexperimental/xds/wiki/Contributing-Templates#template-grading-rubric): **B (75/100) → B (82/100)**, and fixes a wrong gallery image.

- **Width + centering** → native `XDSLayout contentWidth={1200}` + `XDSLayoutContent padding={6}`, replacing the custom `pageWrapper` (`maxWidth`/`width`/`padding`) and the `XDSCenter` wrapper (Layout & Structure 8 → 15).
- **Dropped hardcoded fallbacks** in the image CSS — use the `--radius-*` / `--color-accent` tokens directly instead of `var(--radius-container, 12px)` etc.
- **Fixed the gallery data**: the hero + first thumbnail pointed at `light-home-horizontal-1` (a home interior) despite the `light-product-1` comment — now uses the actual product photo, so the gallery is all ceramics.

## Scorecard

| Category | Before | After | Max |
|----------|--------|-------|-----|
| XDS Component Purity | 25 | 25 | 30 |
| Icon Purity | 15 | 15 | 15 |
| Custom CSS | 2 | 2 | 15 |
| Layout & Structure | 8 | 15 | 15 |
| Doc Metadata | 10 | 10 | 10 |
| Image Handling | 5 | 5 | 5 |
| Code Quality | 10 | 10 | 10 |
| **Total** | **75 (B)** | **82 (B)** | 100 |

## Why not 100 — remaining gaps (all issue-backed)

The remaining points are in **Component Purity (25/30)** and **Custom CSS (2/15)**, both structurally blocked:

| Remaining custom style | Properties | Why custom | Issue |
|---|---|---|---|
| `heroImage` / `thumbImage` | `width`, `height`, `objectFit`, `borderRadius` (+`cursor` on thumb) | Fill the `XDSAspectRatio` box + round corners; no `objectFit`/radius props, no `XDSImage` | [#2582](https://github.com/facebookexperimental/xds/issues/2582) |
| `thumbSelected` | `outline`, `outlineOffset` | Marks the active thumbnail; no "selected" affordance for a bare image | [#2582](https://github.com/facebookexperimental/xds/issues/2582) |
| `stickyInfo` | `position: sticky`, `top`, `alignSelf` | Keeps the info column in view while the gallery scrolls; no sticky prop on XDS layout primitives | [#2613](https://github.com/facebookexperimental/xds/issues/2613) |

- **Component Purity (25/30)** — two necessary raw `<img>` (hero + clickable thumbnail). Blocked on #2582 (no `XDSImage`).
- **Custom CSS (2/15)** — the image fill/radius ([#2582](https://github.com/facebookexperimental/xds/issues/2582)), the sticky info column ([#2613](https://github.com/facebookexperimental/xds/issues/2613)), and the selected-thumb outline (no XDS prop). See also [#2584](https://github.com/facebookexperimental/xds/issues/2584) (rubric image/CSS exceptions can't score A).

**Every point not earned is traceable to a filed issue (#2582, #2613, #2584).**

## Note: images in the sandbox preview

Uses repo-served `/template-assets/*` (the #2454 strategy, served from `apps/docsite/public/`). Those 404 in the **sandbox** export — a pre-existing, repo-wide #2454 gap, out of scope here. Rubric still scores Image Handling 5/5.

## Test plan

- [x] Scoped `tsc --noEmit` against real `@xds/core` source types — 0 errors (`contentWidth`, `XDSGrid columns={{minWidth}}`, `XDSAspectRatio`, `XDSSegmentedControl`, `XDSCollapsibleGroup`, `XDSNumberInput`)
- [x] ESLint clean (pre-commit hook + manual)
- [x] `check:sync` and `check:package-boundaries` pass
- [x] Rendered at desktop (two-column: gallery + sticky info) and mobile (stacked, 1 column) — all 7 images load, hero is the correct product photo, segmented controls / quantity stepper / collapsibles all present
- [ ] Reviewer: verify the PR preview at `/pr/<this-PR>/sandbox/templates/product-detail/` (images pending the #2454 sandbox-assets fix)

Made with [Cursor](https://cursor.com)


## Related component gaps

- [#2582](https://github.com/facebookexperimental/xds/issues/2582) — no `XDSImage` primitive (the hero/thumbnail fill/radius CSS + raw `<img>`).
- [#2613](https://github.com/facebookexperimental/xds/issues/2613) — no `position: sticky` prop on XDS layout primitives (the sticky info column).
- [#2584](https://github.com/facebookexperimental/xds/issues/2584) — the grading rubric's image/CSS exceptions can't score a perfect A.
