### PR TITLE
refactor(templates): make form-two-column pure XDS + responsive (grade 81→92)

### DIFF
--- a/packages/cli/templates/pages/form-two-column/page.tsx
+++ b/packages/cli/templates/pages/form-two-column/page.tsx
@@ -18,11 +18,9 @@ import {XDSLink} from '@xds/core/Link';
 import {XDSDivider} from '@xds/core/Divider';
 import {XDSCard} from '@xds/core/Card';
 import {XDSSelector} from '@xds/core/Selector';
-import {colorVars} from '@xds/core/theme/tokens.stylex';
 
 // illustration-horizontal-1 from xds_oss asset set
-const ILLUSTRATION_URL =
-  '/template-assets/illustration-horizontal-1.png';
+const ILLUSTRATION_URL = '/template-assets/illustration-horizontal-1.png';
 
 // ─────────────────────────────────────────────────────────────
 // Constants
@@ -57,15 +55,14 @@ const CONTACT_COLUMNS = [
 // Styles
 // ─────────────────────────────────────────────────────────────
 
+// The only custom styling is fitting the illustration inside its XDSAspectRatio
+// box without distortion (contain, not cover — it's line art, don't crop it).
+// No objectFit prop on XDSAspectRatio, and there's no XDSImage primitive (#2582).
 const styles = stylex.create({
-  page: {
-    backgroundColor: colorVars['--color-background-surface'],
-  },
-  imagePlaceholder: {
-    width: '85%',
-  },
-  fullWidth: {
+  illustrationImg: {
     width: '100%',
+    height: '100%',
+    objectFit: 'contain',
   },
 });
 
@@ -104,15 +101,15 @@ export default function FormTwoColumnPage() {
   const handleSubmit = () => setSubmitted(true);
 
   return (
-    <XDSCenter height="100svh" xstyle={styles.page}>
+    <XDSCenter height="100svh">
       <XDSSection
         maxWidth={1100}
         width="100%"
         padding={10}
         variant="transparent">
         <XDSVStack gap={10}>
-          {/* ── Top: two-column ── */}
-          <XDSGrid columns={2} align="center" gap={10}>
+          {/* ── Top: two-column, stacks to one column below ~520px ── */}
+          <XDSGrid columns={{minWidth: 320}} align="center" gap={10}>
             {/* Left: headline + description + illustration */}
             <XDSVStack gap={6}>
               <XDSVStack gap={3}>
@@ -124,8 +121,12 @@ export default function FormTwoColumnPage() {
                   figure out the best path forward.
                 </XDSText>
               </XDSVStack>
-              <XDSAspectRatio ratio={4 / 3} xstyle={styles.imagePlaceholder}>
-                <img src={ILLUSTRATION_URL} alt="Illustration" />
+              <XDSAspectRatio ratio={4 / 3}>
+                <img
+                  src={ILLUSTRATION_URL}
+                  alt="Person with a laptop and a lightbulb idea"
+                  {...stylex.props(styles.illustrationImg)}
+                />
               </XDSAspectRatio>
             </XDSVStack>
 
@@ -145,7 +146,7 @@ export default function FormTwoColumnPage() {
                       : undefined
                   }
                 />
-                <XDSGrid columns={2} gap={3}>
+                <XDSGrid columns={{minWidth: 180}} gap={3}>
                   <XDSTextInput
                     label="Email"
                     isLabelHidden
@@ -166,7 +167,7 @@ export default function FormTwoColumnPage() {
                     onChange={setCompany}
                   />
                 </XDSGrid>
-                <XDSGrid columns={2} gap={3}>
+                <XDSGrid columns={{minWidth: 180}} gap={3}>
                   <XDSTextInput
                     label="Job title"
                     isLabelHidden
@@ -221,29 +222,27 @@ export default function FormTwoColumnPage() {
                       : undefined
                   }
                 />
-                <XDSButton
-                  label="Let's connect"
-                  variant="primary"
-                  xstyle={styles.fullWidth}
-                  onClick={handleSubmit}
-                />
+                <XDSVStack hAlign="stretch">
+                  <XDSButton
+                    label="Let's connect"
+                    variant="primary"
+                    onClick={handleSubmit}
+                  />
+                </XDSVStack>
               </XDSVStack>
             </XDSCard>
           </XDSGrid>
 
-          {/* ── Bottom: contact strip ── */}
+          {/* ── Bottom: contact strip (stacks below ~440px) ── */}
           <XDSVStack gap={6}>
             <XDSDivider />
-            <XDSGrid columns={3} gap={6}>
+            <XDSGrid columns={{minWidth: 200}} gap={6}>
               {CONTACT_COLUMNS.map(col => (
                 <XDSVStack key={col.label} gap={1} hAlign="center">
                   <XDSText type="supporting" color="secondary">
                     {col.label}
                   </XDSText>
-                  <XDSLink
-                    href={`mailto:${col.email}`}
-                    type="body"
-                    size="sm">
+                  <XDSLink href={`mailto:${col.email}`} type="body" size="sm">
                     {col.email}
                   </XDSLink>
                 </XDSVStack>

--- a/packages/cli/templates/pages/form-two-column/page.tsx
+++ b/packages/cli/templates/pages/form-two-column/page.tsx
@@ -222,6 +222,8 @@ export default function FormTwoColumnPage() {
                       : undefined
                   }
                 />
+                {/* hAlign="stretch" = full-width button workaround; XDSButton
+                    has no full-width prop (#2600). */}
                 <XDSVStack hAlign="stretch">
                   <XDSButton
                     label="Let's connect"


### PR DESCRIPTION
## Summary

Polishes the `form-two-column` page template (`packages/cli/templates/pages/form-two-column/page.tsx`) against the [Contributing-Templates grading rubric](https://github.com/facebookexperimental/xds/wiki/Contributing-Templates#template-grading-rubric): **B (81/100) → A (92/100)**, and fixes its mobile responsiveness + a distorted illustration.

- **Removed the self-painted page background** (`page.backgroundColor`) — per the wiki, "Don't paint a background… that's the host shell's job." Also removed the now-unused `colorVars` import.
- **Made every grid responsive.** The top two-column, the paired input rows (email/company, job/phone), and the bottom contact strip used fixed `columns={2}`/`columns={3}` — so despite the doc claiming "Mobile (<768px): single column stack," they never reflowed. All now use `columns={{minWidth}}` and genuinely stack on mobile.
- **Full-width submit button** via an `XDSVStack hAlign="stretch"` wrapper (removed the `width: 100%` custom style; `XDSButton` has no `fullWidth` prop).
- **Illustration fix**: added `objectFit: contain` so the line art isn't stretched to fill the 4:3 box (it was rendering with the default `fill`), plus descriptive alt text.

## Scorecard

| Category | Before | After | Max |
|----------|--------|-------|-----|
| XDS Component Purity | 25 | 25 | 30 |
| Icon Purity | 15 | 15 | 15 |
| **Custom CSS** | 8 | **12** | 15 |
| **Layout & Structure** | 8 | **15** | 15 |
| Doc Metadata | 10 | 10 | 10 |
| Image Handling | 5 | 5 | 5 |
| Code Quality | 10 | 10 | 10 |
| **Total** | **81 (B)** | **92 (A)** | 100 |

## Why not 100 — remaining gaps (all issue-backed)

The remaining 8 points are **structurally blocked by the absence of an `XDSImage` primitive**:

| Remaining custom style | Properties | Why custom | Issue |
|---|---|---|---|
| `illustrationImg` | `width: 100%`, `height: 100%`, `objectFit: contain` | Fits the illustration in the `XDSAspectRatio` box without distortion; no `objectFit` prop, no `XDSImage` | [#2582](https://github.com/facebookexperimental/xds/issues/2582) |

- **Component Purity (25/30)** — one necessary raw `<img>` (the illustration). Blocked on #2582.
- **Custom CSS (12/15)** — the 3 image-fill declarations above (justified tier). See also [#2584](https://github.com/facebookexperimental/xds/issues/2584) (rubric image/CSS exceptions can't reach a perfect A).

**Every point not earned is traceable to a filed issue (#2582, #2584).**

## Note: images in the sandbox preview

Uses repo-served `/template-assets/*` (the #2454 strategy, served from `apps/docsite/public/`). Those 404 in the **sandbox** export — a pre-existing, repo-wide #2454 gap, out of scope here. Rubric still scores Image Handling 5/5.

## Test plan

- [x] Scoped `tsc --noEmit` against real `@xds/core` source types — 0 errors (`XDSGrid columns={{minWidth}}`, `XDSVStack hAlign`, `XDSSelector`, `XDSToken`, `XDSTextArea`, `XDSAspectRatio`)
- [x] ESLint clean (pre-commit hook + manual), `check:sync` + `check:package-boundaries` pass
- [x] Rendered desktop (two-column: copy + illustration | form card; 3-col contact strip) and mobile (everything stacks to 1 column) — confirmed the paired inputs reflow and the illustration is undistorted
- [ ] Reviewer: verify the PR preview at `/pr/<this-PR>/sandbox/templates/form-two-column/` (images pending the #2454 sandbox-assets fix)

Made with [Cursor](https://cursor.com)

## Related component gaps

- [#2582](https://github.com/facebookexperimental/xds/issues/2582) — no `XDSImage` primitive (the `illustrationImg` fill CSS + the raw `<img>`).
- [#2600](https://github.com/facebookexperimental/xds/issues/2600) — no full-width `XDSButton` (the `hAlign="stretch"` wrapper on the "Let's connect" submit).
