### PR TITLE
fix(docsite): make templates page mobile-friendly

### DIFF
--- a/apps/docsite/src/app/(site)/templates/page.tsx
+++ b/apps/docsite/src/app/(site)/templates/page.tsx
@@ -42,7 +42,7 @@ const styles = stylex.create({
     display: 'grid',
     gap: 'var(--spacing-4)',
     justifyContent: 'center',
-    gridTemplateColumns: `repeat(auto-fill, minmax(max(${CARD_MIN_WIDTH}px, calc((100% - var(--spacing-4)) / 2)), 1fr))`,
+    gridTemplateColumns: `repeat(auto-fill, minmax(min(100%, max(${CARD_MIN_WIDTH}px, calc((100% - var(--spacing-4)) / 2))), 1fr))`,
   },
   cardImage: {
     display: 'block',

--- a/apps/docsite/src/app/(site)/templates/page.tsx
+++ b/apps/docsite/src/app/(site)/templates/page.tsx
@@ -7,12 +7,15 @@
 'use client';
 
 import {useCallback, useMemo} from 'react';
+import type {CSSProperties} from 'react';
 import {useSearchParams, useRouter, usePathname} from 'next/navigation';
 import * as stylex from '@stylexjs/stylex';
+import {useXDSAppShellMobile} from '@xds/core/AppShell';
 import {XDSText, XDSHeading} from '@xds/core/Text';
 import {XDSVStack, XDSHStack} from '@xds/core/Layout';
 import {XDSSection} from '@xds/core/Section';
-import {XDSCard} from '@xds/core/Card';
+import {XDSClickableCard} from '@xds/core/ClickableCard';
+import {XDSGrid} from '@xds/core/Grid';
 import {XDSButton} from '@xds/core/Button';
 import {XDSOverlay} from '@xds/core/Overlay';
 import {XDSBadge} from '@xds/core/Badge';
@@ -24,7 +27,11 @@ import type {TemplatePreviewItem} from '../../../components/TemplatePreviewDialo
 import {trackOpenPlayground, trackView} from '../../../lib/analytics';
 
 const GALLERY_MAX_WIDTH = 1600;
-const CARD_MIN_WIDTH = 480;
+const CARD_MIN_WIDTH = 420;
+const CARD_STYLE: CSSProperties & {'--color-overlay': string} = {
+  '--color-overlay':
+    'color-mix(in srgb, var(--color-on-light) 78%, transparent)',
+};
 
 const styles = stylex.create({
   section: {
@@ -38,25 +45,12 @@ const styles = stylex.create({
     marginInline: 'auto',
     width: '100%',
   },
-  grid: {
-    display: 'grid',
-    gap: 'var(--spacing-4)',
-    justifyContent: 'center',
-    gridTemplateColumns: `repeat(auto-fill, minmax(min(100%, max(${CARD_MIN_WIDTH}px, calc((100% - var(--spacing-4)) / 2))), 1fr))`,
-  },
   cardImage: {
     display: 'block',
     width: '100%',
     aspectRatio: '16/10',
     backgroundColor: 'var(--color-background-muted)',
     borderRadius: 'var(--radius-container)',
-  },
-  clickableCard: {
-    outline: {
-      default: 'none',
-      ':focus-visible': '2px solid var(--color-accent)',
-    },
-    outlineOffset: '2px',
   },
   comingSoon: {
     height: '100%',
@@ -131,6 +125,8 @@ interface TemplateItem {
 }
 
 export default function TemplatesPage() {
+  const {isMobile} = useXDSAppShellMobile();
+
   const groups = useMemo(() => {
     const visible = templates.filter(t => !t.isHiddenFromOverview);
 
@@ -251,91 +247,86 @@ export default function TemplatesPage() {
           <XDSVStack key={group} gap={4}>
             <XDSHeading level={2}>{GROUP_LABELS[group] ?? group}</XDSHeading>
             <div {...stylex.props(styles.galleryWrap)}>
-              <div {...stylex.props(styles.grid)}>
-                {items.map(item => (
-                  <XDSCard
-                    key={item.slug}
-                    padding={0}
-                    xstyle={styles.clickableCard}
-                    role="button"
-                    tabIndex={0}
-                    aria-label={`Preview ${item.name}`}
-                    onClick={() => openPreview(item.slug)}
-                    onKeyDown={(e: React.KeyboardEvent) => {
-                      if (e.key === 'Enter' || e.key === ' ') {
-                        e.preventDefault();
-                        openPreview(item.slug);
-                      }
-                    }}
-                    style={
-                      {
-                        '--color-overlay':
-                          'color-mix(in srgb, var(--color-on-light) 78%, transparent)',
-                        cursor: 'pointer',
-                      } as React.CSSProperties
-                    }>
-                    <XDSOverlay
-                      showOn="hover"
-                      scrim="dark"
-                      content={
-                        <div {...stylex.props(styles.overlayInner)}>
-                          <XDSVStack gap={2}>
-                            <XDSVStack gap={0.5}>
-                              <XDSHeading level={3} style={{color: '#fff'}}>
-                                {item.name}
-                              </XDSHeading>
-                              <XDSText
-                                type="body"
-                                style={{color: 'rgba(255,255,255,0.7)'}}>
-                                {item.description.slice(0, 80)}
-                                {item.description.length > 80 ? '\u2026' : ''}
-                              </XDSText>
-                            </XDSVStack>
-                            {/* Stop card-level click/keys from firing for
-                                  the action buttons so each keeps its own
-                                  behavior (the card itself opens the preview). */}
-                            <div
-                              onClick={e => e.stopPropagation()}
-                              onKeyDown={e => e.stopPropagation()}>
-                              <XDSHStack gap={2}>
-                                <XDSButton
-                                  label="Preview"
-                                  variant="secondary"
-                                  onClick={() => openPreview(item.slug)}
-                                />
-                                {item.source && (
-                                  <XDSButton
-                                    label="Open in Playground"
-                                    variant="secondary"
-                                    onClick={() => {
-                                      trackOpenPlayground({
-                                        page: 'templates',
-                                        item: item.slug,
-                                        category: groupOf(item.category),
-                                      });
-                                      window.location.href =
-                                        buildPlaygroundHref(item.source);
-                                    }}
-                                  />
-                                )}
-                              </XDSHStack>
-                            </div>
-                          </XDSVStack>
-                        </div>
-                      }>
-                      {item.isReady ? (
-                        <TemplateThumbnail slug={item.slug} />
+              <XDSGrid
+                columns={
+                  isMobile
+                    ? 1
+                    : {minWidth: CARD_MIN_WIDTH, max: 2, repeat: 'fit'}
+                }
+                gap={4}
+                style={{maxWidth: '100%'}}>
+                {items.map(item => {
+                  const templateContent = item.isReady ? (
+                    <TemplateThumbnail slug={item.slug} />
+                  ) : (
+                    <div {...stylex.props(styles.cardImage)}>
+                      <div {...stylex.props(styles.comingSoon)}>
+                        <XDSBadge label="Coming Soon" variant="info" />
+                      </div>
+                    </div>
+                  );
+
+                  return (
+                    <XDSClickableCard
+                      key={item.slug}
+                      padding={0}
+                      maxWidth="100%"
+                      label={`Preview ${item.name}`}
+                      onClick={() => openPreview(item.slug)}
+                      style={CARD_STYLE}>
+                      {isMobile ? (
+                        templateContent
                       ) : (
-                        <div {...stylex.props(styles.cardImage)}>
-                          <div {...stylex.props(styles.comingSoon)}>
-                            <XDSBadge label="Coming Soon" variant="info" />
-                          </div>
-                        </div>
+                        <XDSOverlay
+                          showOn="hover"
+                          scrim="dark"
+                          content={
+                            <div {...stylex.props(styles.overlayInner)}>
+                              <XDSVStack gap={2}>
+                                <XDSVStack gap={0.5}>
+                                  <XDSHeading level={3} style={{color: '#fff'}}>
+                                    {item.name}
+                                  </XDSHeading>
+                                  <XDSText
+                                    type="body"
+                                    style={{color: 'rgba(255,255,255,0.7)'}}>
+                                    {item.description.slice(0, 80)}
+                                    {item.description.length > 80
+                                      ? '\u2026'
+                                      : ''}
+                                  </XDSText>
+                                </XDSVStack>
+                                <XDSHStack gap={2}>
+                                  <XDSButton
+                                    label="Preview"
+                                    variant="secondary"
+                                    onClick={() => openPreview(item.slug)}
+                                  />
+                                  {item.source && (
+                                    <XDSButton
+                                      label="Open in Playground"
+                                      variant="secondary"
+                                      href={buildPlaygroundHref(item.source)}
+                                      onClick={() => {
+                                        trackOpenPlayground({
+                                          page: 'templates',
+                                          item: item.slug,
+                                          category: groupOf(item.category),
+                                        });
+                                      }}
+                                    />
+                                  )}
+                                </XDSHStack>
+                              </XDSVStack>
+                            </div>
+                          }>
+                          {templateContent}
+                        </XDSOverlay>
                       )}
-                    </XDSOverlay>
-                  </XDSCard>
-                ))}
-              </div>
+                    </XDSClickableCard>
+                  );
+                })}
+              </XDSGrid>
             </div>
           </XDSVStack>
         ))}
@@ -351,6 +342,7 @@ export default function TemplatesPage() {
           }
         }}
         onIndexChange={setOpenIndex}
+        variant={isMobile ? 'fullscreen' : undefined}
       />
     </XDSSection>
   );

--- a/apps/docsite/src/components/TemplatePreviewDialog.tsx
+++ b/apps/docsite/src/components/TemplatePreviewDialog.tsx
@@ -59,6 +59,8 @@ interface TemplatePreviewDialogProps {
   onOpenChange: (open: boolean) => void;
   /** Request a different template (prev/next). */
   onIndexChange: (index: number) => void;
+  /** Dialog variant — pass 'fullscreen' on mobile for edge-to-edge preview. */
+  variant?: 'fullscreen';
 }
 
 const styles = stylex.create({
@@ -77,13 +79,24 @@ const styles = stylex.create({
   },
   headerRow: {
     width: '100%',
+    position: 'relative' as const,
   },
-  headerMeta: {
+  closeButton: {
+    position: 'absolute' as const,
+    top: 0,
+    insetInlineEnd: 0,
+  },
+  desktopHeaderMeta: {
     flex: 1,
     minWidth: 0,
   },
-  categoryPrefix: {
-    color: 'var(--color-text-primary)',
+  mobileHeaderMeta: {
+    minWidth: 0,
+    paddingInlineEnd: 48,
+  },
+  actionsRow: {
+    width: '100%',
+    minWidth: 0,
   },
   copyPill: {
     display: 'inline-flex',
@@ -97,6 +110,9 @@ const styles = stylex.create({
     borderWidth: 'var(--border-width, 1px)',
     borderStyle: 'solid',
     borderColor: 'var(--color-border)',
+    flex: '1 1 auto',
+    minWidth: 0,
+    overflow: 'hidden',
     fontFamily: 'var(--font-family-mono, ui-monospace, monospace)',
     fontSize: 'var(--font-size-sm, 13px)',
     color: 'var(--color-text-primary)',
@@ -145,12 +161,113 @@ const styles = stylex.create({
   },
 });
 
+interface TemplatePreviewHeaderProps {
+  item: TemplatePreviewItem;
+  isFullscreen: boolean;
+  cmdCopied: boolean;
+  onCopyCommand: () => void;
+  onClose: () => void;
+}
+
+function TemplatePreviewHeader({
+  item,
+  isFullscreen,
+  cmdCopied,
+  onCopyCommand,
+  onClose,
+}: TemplatePreviewHeaderProps) {
+  const playgroundHref = item.source ? buildPlaygroundHref(item.source) : null;
+
+  const metadata = (
+    <XDSVStack
+      gap={0.5}
+      xstyle={
+        isFullscreen ? styles.mobileHeaderMeta : styles.desktopHeaderMeta
+      }>
+      <XDSHeading level={2}>
+        {item.category ? `${item.category} ${item.name}` : item.name}
+      </XDSHeading>
+      {item.description && (
+        <XDSText type="body" color="secondary">
+          {item.description}
+        </XDSText>
+      )}
+    </XDSVStack>
+  );
+
+  const copyButton = (
+    <button
+      type="button"
+      onClick={onCopyCommand}
+      aria-label="Copy install command"
+      {...stylex.props(styles.copyPill, styles.copyPillHover)}>
+      <span {...stylex.props(styles.copyPillText)}>
+        {cmdCopied ? 'Copied!' : `npx xds template ${item.slug}`}
+      </span>
+      <XDSIcon icon={cmdCopied ? 'check' : 'copy'} size="sm" color="inherit" />
+    </button>
+  );
+
+  const playgroundButton = playgroundHref ? (
+    <XDSButton
+      label="Open in Playground"
+      variant="primary"
+      size="lg"
+      href={playgroundHref}
+      onClick={() => {
+        trackOpenPlayground({
+          page: 'templates',
+          item: item.slug,
+          category: item.category,
+        });
+      }}
+    />
+  ) : null;
+
+  const closeButton = (
+    <XDSButton
+      variant="secondary"
+      isIconOnly
+      label="Close preview"
+      size="lg"
+      icon={<XDSIcon icon="close" color="inherit" />}
+      onClick={onClose}
+      xstyle={isFullscreen ? styles.closeButton : undefined}
+    />
+  );
+
+  const actions = (
+    <XDSHStack
+      gap={2}
+      vAlign="center"
+      xstyle={isFullscreen ? styles.actionsRow : undefined}>
+      {copyButton}
+      {playgroundButton}
+      {!isFullscreen && closeButton}
+    </XDSHStack>
+  );
+
+  return isFullscreen ? (
+    <XDSVStack gap={3} xstyle={styles.headerRow}>
+      {metadata}
+      {actions}
+      {closeButton}
+    </XDSVStack>
+  ) : (
+    <XDSHStack gap={4} vAlign="start" xstyle={styles.headerRow}>
+      {metadata}
+      {actions}
+    </XDSHStack>
+  );
+}
+
 export function TemplatePreviewDialog({
   items,
   index,
   isOpen,
   onOpenChange,
   onIndexChange,
+  variant,
 }: TemplatePreviewDialogProps) {
   const [cmdCopied, setCmdCopied] = useState(false);
   const [isPending, startTransition] = useTransition();
@@ -206,11 +323,6 @@ export function TemplatePreviewDialog({
   }
 
   const useCommand = `npx xds template ${current.slug} ./src/app/${current.slug}`;
-  // Capture in a local const so the narrowing survives into the onClick
-  // closure below (property access on `current` widens back to
-  // `string | undefined` inside a deferred callback).
-  const playgroundSource = current.source;
-
   const handleCopyCmd = useCallback(() => {
     navigator.clipboard.writeText(useCommand).then(() => {
       setCmdCopied(true);
@@ -224,75 +336,28 @@ export function TemplatePreviewDialog({
     });
   }, [useCommand, current.slug, current.category]);
 
+  const isFullscreen = variant === 'fullscreen';
+
   return (
     <XDSDialog
       isOpen={isOpen}
       onOpenChange={onOpenChange}
-      width={1400}
-      maxHeight="92vh"
-      xstyle={styles.dialogTall}
+      variant={variant}
+      width={isFullscreen ? undefined : 1400}
+      maxHeight={isFullscreen ? undefined : '92vh'}
+      xstyle={isFullscreen ? undefined : styles.dialogTall}
       aria-label={current.name}>
       <XDSLayout
         height="fill"
         header={
           <XDSLayoutHeader xstyle={styles.headerRow}>
-            <XDSHStack gap={4} vAlign="start" xstyle={styles.headerRow}>
-              <XDSVStack gap={0.5} xstyle={styles.headerMeta}>
-                <XDSHeading level={2}>
-                  {current.category && (
-                    <span {...stylex.props(styles.categoryPrefix)}>
-                      {current.category}{' '}
-                    </span>
-                  )}
-                  {current.name}
-                </XDSHeading>
-                {current.description && (
-                  <XDSText type="body" color="secondary">
-                    {current.description}
-                  </XDSText>
-                )}
-              </XDSVStack>
-              <XDSHStack gap={2} vAlign="center">
-                <button
-                  type="button"
-                  onClick={handleCopyCmd}
-                  aria-label="Copy install command"
-                  {...stylex.props(styles.copyPill, styles.copyPillHover)}>
-                  <span {...stylex.props(styles.copyPillText)}>
-                    {cmdCopied ? 'Copied!' : `npx xds template ${current.slug}`}
-                  </span>
-                  <XDSIcon
-                    icon={cmdCopied ? 'check' : 'copy'}
-                    size="sm"
-                    color="inherit"
-                  />
-                </button>
-                {playgroundSource && (
-                  <XDSButton
-                    label="Open in Playground"
-                    variant="primary"
-                    size="lg"
-                    onClick={() => {
-                      trackOpenPlayground({
-                        page: 'templates',
-                        item: current.slug,
-                        category: current.category,
-                      });
-                      window.location.href =
-                        buildPlaygroundHref(playgroundSource);
-                    }}
-                  />
-                )}
-                <XDSButton
-                  variant="secondary"
-                  isIconOnly
-                  label="Close preview"
-                  size="lg"
-                  icon={<XDSIcon icon="close" color="inherit" />}
-                  onClick={() => onOpenChange(false)}
-                />
-              </XDSHStack>
-            </XDSHStack>
+            <TemplatePreviewHeader
+              item={current}
+              isFullscreen={isFullscreen}
+              cmdCopied={cmdCopied}
+              onCopyCommand={handleCopyCmd}
+              onClose={() => onOpenChange(false)}
+            />
           </XDSLayoutHeader>
         }
         content={
@@ -312,7 +377,7 @@ export function TemplatePreviewDialog({
         }
       />
 
-      {count > 1 && (
+      {count > 1 && !isFullscreen && (
         <>
           <div {...stylex.props(styles.navArrow, styles.navPrev)}>
             <XDSTooltip


### PR DESCRIPTION
## Summary

Improves the templates gallery and preview dialog on mobile while preserving the existing desktop interaction model.

## Changes

- Replace the custom templates grid with `XDSGrid` using `repeat: 'fit'` and a max of 2 columns on wide viewports.
- Use a viewport-based narrow layout for the grid so small desktop windows and phones render as a single column.
- Use `useXDSAppShellMobile()` for coordinated mobile behavior:
  - mobile cards skip the hover overlay and tap directly opens preview
  - mobile previews open in a fullscreen dialog
- Fix the mobile preview header:
  - keep the close button pinned in the top-right
  - keep the copy command and Open in Playground action inline
  - split desktop/mobile header layout styles so mobile metadata auto-sizes instead of stretching vertically
- Keep desktop behavior unchanged:
  - hover overlay remains available
  - centered modal preview remains constrained
  - prev/next side arrows remain desktop-only

## Testing

- `eslint --cache --fix` via pre-commit hook
- `pnpm check:sync`
- `pnpm check:package-boundaries`