### PR TITLE
refactor(templates): tidy product-gallery to idiomatic XDS (grade 85)

### DIFF
--- a/packages/cli/templates/pages/product-gallery/page.tsx
+++ b/packages/cli/templates/pages/product-gallery/page.tsx
@@ -3,18 +3,18 @@
 'use client';
 
 import {XDSVStack, XDSLayout, XDSLayoutContent} from '@xds/core/Layout';
-import {XDSCenter} from '@xds/core/Center';
 import {XDSText, XDSHeading} from '@xds/core/Text';
 import {XDSButton} from '@xds/core/Button';
 import {XDSGrid} from '@xds/core/Grid';
 import {XDSAspectRatio} from '@xds/core/AspectRatio';
 import {XDSCard} from '@xds/core/Card';
 import {XDSIcon} from '@xds/core/Icon';
-import {XDSSection} from '@xds/core/Section';
 import {ArrowRightIcon} from '@heroicons/react/24/outline';
 import * as stylex from '@stylexjs/stylex';
 
 // ─── Styles ─────────────────────────────────────────────────────────────────
+// The only custom CSS is the image fill — there is no XDSImage primitive to
+// fill the XDSAspectRatio box with `object-fit` (#2582).
 
 const styles = stylex.create({
   image: {
@@ -42,8 +42,7 @@ const PRODUCTS: Product[] = [
       "Sometimes all it takes is one small thing to turn your whole day around. That's what good design is for.",
     price: 75.0,
     // illustrative-horizontal-1 from xds_oss asset set
-    image:
-      '/template-assets/illustrative-horizontal-1.jpg',
+    image: '/template-assets/illustrative-horizontal-1.jpg',
   },
   {
     id: 2,
@@ -52,8 +51,7 @@ const PRODUCTS: Product[] = [
       "Sometimes all it takes is one small thing to turn your whole day around. That's what good design is for.",
     price: 80.0,
     // illustrative-vertical-1 from xds_oss asset set
-    image:
-      '/template-assets/illustrative-vertical-1.jpg',
+    image: '/template-assets/illustrative-vertical-1.jpg',
   },
   {
     id: 3,
@@ -62,8 +60,7 @@ const PRODUCTS: Product[] = [
       "Sometimes all it takes is one small thing to turn your whole day around. That's what good design is for.",
     price: 75.0,
     // illustrative-horizontal-3 from xds_oss asset set
-    image:
-      '/template-assets/illustrative-horizontal-3.jpg',
+    image: '/template-assets/illustrative-horizontal-3.jpg',
   },
   {
     id: 4,
@@ -72,8 +69,7 @@ const PRODUCTS: Product[] = [
       "Sometimes all it takes is one small thing to turn your whole day around. That's what good design is for.",
     price: 75.0,
     // illustrative-horizontal-4 from xds_oss asset set
-    image:
-      '/template-assets/illustrative-horizontal-4.jpg',
+    image: '/template-assets/illustrative-horizontal-4.jpg',
   },
   {
     id: 5,
@@ -82,8 +78,7 @@ const PRODUCTS: Product[] = [
       "Sometimes all it takes is one small thing to turn your whole day around. That's what good design is for.",
     price: 60.0,
     // illustrative-horizontal-5 from xds_oss asset set
-    image:
-      '/template-assets/illustrative-horizontal-5.jpg',
+    image: '/template-assets/illustrative-horizontal-5.jpg',
   },
   {
     id: 6,
@@ -92,8 +87,7 @@ const PRODUCTS: Product[] = [
       "Sometimes all it takes is one small thing to turn your whole day around. That's what good design is for.",
     price: 80.0,
     // illustrative-horizontal-2 from xds_oss asset set
-    image:
-      '/template-assets/illustrative-horizontal-2.jpg',
+    image: '/template-assets/illustrative-horizontal-2.jpg',
   },
 ];
 
@@ -119,7 +113,9 @@ function ProductCard({product}: {product: Product}) {
         <XDSText type="body" color="secondary" maxLines={2}>
           {product.description}
         </XDSText>
-        <XDSHeading level={2}>{fmt(product.price)}</XDSHeading>
+        <XDSText type="large" weight="bold">
+          {fmt(product.price)}
+        </XDSText>
       </XDSVStack>
     </XDSVStack>
   );
@@ -131,43 +127,38 @@ export default function ProductGalleryTemplate() {
   return (
     <XDSLayout
       height="auto"
+      contentWidth={1200}
       content={
-        <XDSLayoutContent padding={0}>
-          <XDSCenter axis="horizontal">
-            <XDSSection variant="transparent" maxWidth={1200} padding={6}>
-              <XDSVStack gap={6}>
-                {/* Header — XDSGrid handles responsive stacking */}
-                <XDSGrid columns={{minWidth: 280}} gap={4} align="start">
-                  <XDSHeading level={1}>
-                    Make every day a little more delightful, one small detail at
-                    a time.
-                  </XDSHeading>
-                  <XDSVStack gap={3} hAlign="start">
-                    <XDSText type="body">
-                      We believe the smallest details are the ones that matter
-                      most. A little color, a thoughtful touch, a moment that
-                      catches your eye and makes you pause; that&apos;s what
-                      turns an ordinary day into something worth remembering.
-                    </XDSText>
-                    <XDSButton
-                      label="Get started"
-                      variant="primary"
-                      endContent={
-                        <XDSIcon icon={ArrowRightIcon} color="inherit" />
-                      }
-                    />
-                  </XDSVStack>
-                </XDSGrid>
-
-                {/* Product Grid — 3 cols desktop, wraps to 2→1 on smaller screens */}
-                <XDSGrid columns={{minWidth: 300}} gap={6}>
-                  {PRODUCTS.map(product => (
-                    <ProductCard key={product.id} product={product} />
-                  ))}
-                </XDSGrid>
+        <XDSLayoutContent padding={6}>
+          <XDSVStack gap={6}>
+            {/* Header — XDSGrid handles responsive stacking */}
+            <XDSGrid columns={{minWidth: 280}} gap={4} align="start">
+              <XDSHeading level={1}>
+                Make every day a little more delightful, one small detail at a
+                time.
+              </XDSHeading>
+              <XDSVStack gap={3} hAlign="start">
+                <XDSText type="body">
+                  We believe the smallest details are the ones that matter most.
+                  A little color, a thoughtful touch, a moment that catches your
+                  eye and makes you pause; that&apos;s what turns an ordinary
+                  day into something worth remembering.
+                </XDSText>
+                <XDSButton
+                  label="Get started"
+                  variant="primary"
+                  endContent={<XDSIcon icon={ArrowRightIcon} color="inherit" />}
+                />
               </XDSVStack>
-            </XDSSection>
-          </XDSCenter>
+            </XDSGrid>
+
+            {/* Product Grid — reflows 3 → 2 → 1 columns as width narrows */}
+            <XDSGrid columns={{minWidth: 300}} gap={6}>
+              {PRODUCTS.map(product => (
+                <ProductCard key={product.id} product={product} />
+              ))}
+            </XDSGrid>
+          </XDSVStack>
         </XDSLayoutContent>
       }
     />

--- a/packages/cli/templates/pages/product-gallery/template.doc.mjs
+++ b/packages/cli/templates/pages/product-gallery/template.doc.mjs
@@ -2,9 +2,10 @@
 
 /** @type {import('../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
-  name: 'Product',
-  displayName: 'Product',
-  description: 'Card grid of products with images, titles, descriptions, and prices',
+  name: 'Product Gallery',
+  displayName: 'Product Gallery',
+  description:
+    'Card grid of products with images, titles, descriptions, and prices',
   type: 'page',
   isReady: true,
   category: 'Gallery - Product',


### PR DESCRIPTION
## Summary

The `product-gallery` page template (`packages/cli/templates/pages/product-gallery/page.tsx`) already scores at its **pure-XDS ceiling — B (85/100)** — on the [Contributing-Templates grading rubric](https://github.com/facebookexperimental/xds/wiki/Contributing-Templates#template-grading-rubric). Both of its non-maxed categories are structurally blocked by the absence of an `XDSImage` primitive (#2582), so the score can't go higher without one (the same ceiling confirmed for the `gallery-hero` sibling, #2609). This pass makes it **more idiomatic** without changing the number.

- **Native width + centering** → `XDSLayout contentWidth={1200}` (removed the `XDSCenter` + `XDSSection` wrapper nesting). `XDSSection` is documented to *escape parent container padding for full-bleed fills*, so nesting it inside `XDSLayoutContent` fought the content padding — the original worked around that with `XDSLayoutContent padding={0}` then re-added `padding={6}` on the section. `contentWidth` does the capping + centering natively, and `XDSLayoutContent padding={6}` supplies the padding cleanly (also drops 2 components + 2 imports).
- **Price semantics** → rendered as `XDSText type=\"large\" weight=\"bold\"` instead of a second `XDSHeading level={2}` per card. Each card now has one heading (the product name), and a price isn't a heading.
- **Doc**: `name`/`displayName` `\"Product\"` → `\"Product Gallery\"` (matches the slug + gallery listing).

## Scorecard

| Category | Before | After | Max |
|----------|--------|-------|-----|
| XDS Component Purity | 25 | 25 | 30 |
| Icon Purity | 15 | 15 | 15 |
| Custom CSS | 5 | 5 | 15 |
| Layout & Structure | 15 | 15 | 15 |
| Doc Metadata | 10 | 10 | 10 |
| Image Handling | 5 | 5 | 5 |
| Code Quality | 10 | 10 | 10 |
| **Total** | **85 (B)** | **85 (B)** | 100 |

## Why not 100 — remaining gaps (all issue-backed)

The 15 missing points are **structurally blocked by the absence of an `XDSImage` primitive** — a product card grid can't reach zero raw HTML (Component Purity 25/30: one rubric-sanctioned `<img>` per card) or zero image-fill CSS (Custom CSS 5/15) without one. Every other category is already maxed (responsive `XDSGrid columns={{minWidth}}` for both the header and the product grid, proper centering, complete doc, realistic data).

| Remaining custom style | Properties | Why custom | Issue |
|---|---|---|---|
| `image` | `width: 100%`, `height: 100%`, `objectFit: cover` | Fills the `XDSAspectRatio` box; no `objectFit` prop | [#2582](https://github.com/facebookexperimental/xds/issues/2582) |

See also [#2584](https://github.com/facebookexperimental/xds/issues/2584) (rubric image/CSS exceptions structurally can't score A; the Image-Handling section cites a stale CDN).

## Note: images in the sandbox preview

Uses repo-served `/template-assets/*` (the strategy merged in #2454, served from `apps/docsite/public/`). Those paths 404 in the **sandbox** export (`apps/sandbox/public/` has no `template-assets/`) — a pre-existing, repo-wide gap from #2454, out of scope here. Rubric still scores Image Handling 5/5 (repo-served, not external/placeholder).

## Test plan

- [x] Scoped `tsc --noEmit` against real `@xds/core` source types — 0 errors
- [x] ESLint clean (pre-commit hook + manual)
- [x] `check:sync` and `check:package-boundaries` pass
- [x] Rendered locally at desktop (HTTP 200) — header reflows beside copy, product grid reflows 3 → 2 → 1
- [ ] Reviewer: verify the PR preview at `/pr/<this-PR>/sandbox/templates/product-gallery/` (images pending the #2454 sandbox-assets fix)

Made with [Cursor](https://cursor.com)