### PR TITLE
feat(templates): polish AspectRatio + Divider example blocks

### DIFF
--- a/packages/cli/templates/blocks/components/AspectRatio/AspectRatioImageGallery.tsx
+++ b/packages/cli/templates/blocks/components/AspectRatio/AspectRatioImageGallery.tsx
@@ -3,6 +3,7 @@
 'use client';
 
 import {XDSAspectRatio} from '@xds/core/AspectRatio';
+import {XDSCenter} from '@xds/core/Center';
 import {XDSGrid} from '@xds/core/Grid';
 
 const images = [
@@ -15,22 +16,29 @@ const images = [
 ];
 
 export default function AspectRatioImageGallery() {
+  // Anchor a definite width so the grid renders in shrink-to-fit contexts
+  // (e.g. the docsite example preview, which wraps blocks in a
+  // `min-width: fit-content` container). Without a fixed-width ancestor,
+  // the `width="100%"` grid collapses to zero — XDSAspectRatio positions its
+  // child absolutely, so it has no intrinsic width to size the grid from.
   return (
-    <XDSGrid columns={3} gap={4} width="100%">
-      {images.map(({id, alt}) => (
-        <XDSAspectRatio key={id} ratio={4 / 3}>
-          <img
-            src="https://lookaside.facebook.com/assets/xds_oss/illustrative-horizontal-1.jpg"
-            alt={alt}
-            style={{
-              width: '100%',
-              height: '100%',
-              objectFit: 'cover',
-              borderRadius: 8,
-            }}
-          />
-        </XDSAspectRatio>
-      ))}
-    </XDSGrid>
+    <XDSCenter width={600}>
+      <XDSGrid columns={3} gap={4} width="100%">
+        {images.map(({id, alt}) => (
+          <XDSAspectRatio key={id} ratio={4 / 3}>
+            <img
+              src="https://lookaside.facebook.com/assets/xds_oss/illustrative-horizontal-1.jpg"
+              alt={alt}
+              style={{
+                width: '100%',
+                height: '100%',
+                objectFit: 'cover',
+                borderRadius: 8,
+              }}
+            />
+          </XDSAspectRatio>
+        ))}
+      </XDSGrid>
+    </XDSCenter>
   );
 }

--- a/packages/cli/templates/blocks/components/AspectRatio/AspectRatioShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/AspectRatio/AspectRatioShowcase.doc.mjs
@@ -10,6 +10,6 @@ export const doc = {
   aspectRatio: 4 / 3,
   isShowcase: true,
   description:
-    'Three aspect ratio containers: 1:1, 4:3, and 16:9.',
-  componentsUsed: ['AspectRatio', 'Center', 'Layout', 'Text'],
+    'Three aspect ratio containers at equal height — 1:1, 4:3, and 16:9 — each showing an image with its ratio labeled below.',
+  componentsUsed: ['AspectRatio', 'Layout', 'Text'],
 };

--- a/packages/cli/templates/blocks/components/AspectRatio/AspectRatioShowcase.tsx
+++ b/packages/cli/templates/blocks/components/AspectRatio/AspectRatioShowcase.tsx
@@ -4,46 +4,59 @@
 
 import * as stylex from '@stylexjs/stylex';
 import {XDSAspectRatio} from '@xds/core/AspectRatio';
-import {XDSCenter} from '@xds/core/Center';
-import {XDSHStack} from '@xds/core/Layout';
+import {XDSHStack, XDSVStack} from '@xds/core/Layout';
 import {XDSText} from '@xds/core/Text';
-import {colorVars, radiusVars} from '@xds/core/theme/tokens.stylex';
+import {radiusVars} from '@xds/core/theme/tokens.stylex';
 
 const s = stylex.create({
-  square: {width: 120},
-  fourThree: {width: 160},
-  widescreen: {width: 200},
-  box: {
-    backgroundColor: colorVars['--color-background-muted'],
-    border: `1px solid ${colorVars['--color-border']}`,
+  // Fixed height with auto width lets the aspect ratio drive the width,
+  // so all three containers share the same height but differ in width.
+  ratioBox: {
+    height: 120,
+    width: 'auto',
     borderRadius: radiusVars['--radius-container'],
   },
+  image: {
+    width: '100%',
+    height: '100%',
+    objectFit: 'cover',
+  },
 });
+
+const items = [
+  {
+    ratio: 1,
+    label: '1 : 1',
+    src: 'https://lookaside.facebook.com/assets/xds_oss/light-home-square-1.png',
+    alt: '1:1 square',
+  },
+  {
+    ratio: 4 / 3,
+    label: '4 : 3',
+    src: 'https://lookaside.facebook.com/assets/xds_oss/illustrative-horizontal-1.jpg',
+    alt: '4:3 standard',
+  },
+  {
+    ratio: 16 / 9,
+    label: '16 : 9',
+    src: 'https://lookaside.facebook.com/assets/xds_oss/light-scene-horizontal-1.png',
+    alt: '16:9 widescreen',
+  },
+];
 
 export default function AspectRatioShowcase() {
   return (
     <XDSHStack gap={4} vAlign="start">
-      <XDSAspectRatio ratio={1} xstyle={[s.square, s.box]}>
-        <XDSCenter width="100%" height="100%">
+      {items.map(({ratio, label, src, alt}) => (
+        <XDSVStack key={label} gap={2} hAlign="center">
+          <XDSAspectRatio ratio={ratio} xstyle={s.ratioBox}>
+            <img src={src} alt={alt} {...stylex.props(s.image)} />
+          </XDSAspectRatio>
           <XDSText type="supporting" color="secondary">
-            1 : 1
+            {label}
           </XDSText>
-        </XDSCenter>
-      </XDSAspectRatio>
-      <XDSAspectRatio ratio={4 / 3} xstyle={[s.fourThree, s.box]}>
-        <XDSCenter width="100%" height="100%">
-          <XDSText type="supporting" color="secondary">
-            4 : 3
-          </XDSText>
-        </XDSCenter>
-      </XDSAspectRatio>
-      <XDSAspectRatio ratio={16 / 9} xstyle={[s.widescreen, s.box]}>
-        <XDSCenter width="100%" height="100%">
-          <XDSText type="supporting" color="secondary">
-            16 : 9
-          </XDSText>
-        </XDSCenter>
-      </XDSAspectRatio>
+        </XDSVStack>
+      ))}
     </XDSHStack>
   );
 }

--- a/packages/cli/templates/blocks/components/Divider/DividerFullBleed.tsx
+++ b/packages/cli/templates/blocks/components/Divider/DividerFullBleed.tsx
@@ -10,8 +10,8 @@ import {XDSText} from '@xds/core/Text';
 
 export default function DividerFullBleed() {
   return (
-    <XDSSection width="100%">
-      <XDSCard>
+    <XDSSection variant="transparent" width="100%">
+      <XDSCard width={400}>
         <XDSVStack gap={3}>
           <XDSText type="label">Order Summary</XDSText>
           <XDSHStack hAlign="between">

--- a/packages/cli/templates/blocks/components/Divider/DividerVariants.tsx
+++ b/packages/cli/templates/blocks/components/Divider/DividerVariants.tsx
@@ -10,8 +10,8 @@ import {XDSText} from '@xds/core/Text';
 
 export default function DividerVariants() {
   return (
-    <XDSSection width="100%">
-      <XDSCard>
+    <XDSSection variant="transparent" width="100%">
+      <XDSCard width={400}>
         <XDSVStack gap={3}>
           <XDSVStack gap={1}>
             <XDSText type="label">Sign in with email</XDSText>

--- a/packages/cli/templates/blocks/components/Divider/DividerVertical.tsx
+++ b/packages/cli/templates/blocks/components/Divider/DividerVertical.tsx
@@ -18,7 +18,7 @@ const styles = stylex.create({
 
 export default function DividerVertical() {
   return (
-    <XDSSection width="100%">
+    <XDSSection variant="transparent" width="100%">
       <XDSCard>
         <XDSHStack gap={4} align="stretch">
           <XDSStackItem size="fill">


### PR DESCRIPTION
## What

Polish to the AspectRatio and Divider CLI template blocks (surfaced on the docsite `/components/*` pages).

### 1. AspectRatio showcase — images + ratio labels
The `AspectRatioShowcase` block previously rendered three empty bordered placeholders. Now:
- Each of the three containers (1:1, 4:3, 16:9) displays a real example image (reusing the same `xds_oss` lookaside assets used by the sibling AspectRatio blocks).
- All three containers share the **same height** (120px) with **widths derived from their aspect ratio**.
- A ratio **label is rendered below each container** (`1 : 1`, `4 : 3`, `16 : 9`).

### 2. AspectRatio Image Gallery — fix blank render in docsite
The `AspectRatio — Image Gallery` example showed up **blank** on the docsite component page.

**Root cause:** the docsite example preview (`ExampleBlock` → `LivePreview`) wraps each block in a `min-width: fit-content` container. The gallery used `<XDSGrid width="100%">` with no definite-width ancestor. Because `XDSAspectRatio` positions its child absolutely (zero intrinsic width), the grid had nothing to size against in a shrink-to-fit parent, so it collapsed to ~0 width — rendering blank.

**Fix:** wrap the grid in `<XDSCenter width={600}>`, matching the pattern already used by `AspectRatioSquareImage` and `AspectRatioWidescreen`. The grid stays fluid (`width="100%"`) inside the fixed anchor.

### 3. Divider examples — equal card widths + transparent section
On the docsite, the `Divider — Full Bleed` card rendered **narrower** than the `Divider — Variants` card.

**Root cause:** both blocks wrap `<XDSCard>` in `<XDSSection width="100%">`, but the docsite preview wraps each in a `min-width: fit-content` container. With no definite width, `width="100%"` resolves to each card's **content** width — and Full Bleed's short `hAlign="between"` rows make a much narrower card than Variants' long body sentences.

**Fix:**
- Gave the Full Bleed and Variants cards an explicit `width={400}` so they match regardless of content.
- Switched all three Divider example sections (`Variants`, `Full Bleed`, `Vertical`) to `variant="transparent"`.

## Files

- `packages/cli/templates/blocks/components/AspectRatio/AspectRatioShowcase.tsx`
- `packages/cli/templates/blocks/components/AspectRatio/AspectRatioShowcase.doc.mjs`
- `packages/cli/templates/blocks/components/AspectRatio/AspectRatioImageGallery.tsx`
- `packages/cli/templates/blocks/components/Divider/DividerVariants.tsx`
- `packages/cli/templates/blocks/components/Divider/DividerFullBleed.tsx`
- `packages/cli/templates/blocks/components/Divider/DividerVertical.tsx`

## Validation

- `pnpm -F @xds/cli typecheck:template-docs` — passes
- `eslint` on changed blocks — clean (0 errors)
- `apps/docsite` `generate-data.mjs` — runs clean