### PR TITLE
feat(AspectRatio): add isCircle prop for circular containers

### DIFF
--- a/apps/storybook/stories/AspectRatio.stories.tsx
+++ b/apps/storybook/stories/AspectRatio.stories.tsx
@@ -75,9 +75,11 @@ const meta: Meta<typeof XDSAspectRatio> = {
       control: 'number',
       description: 'The aspect ratio as width/height (e.g., 16/9 = 1.777...)',
     },
-    isCircle: {
-      control: 'boolean',
-      description: 'Clip the container to a circle (forces a 1:1 ratio).',
+    shape: {
+      control: 'select',
+      options: ['rectangle', 'ellipse'],
+      description:
+        'Container shape. Both respect the ratio; "ellipse" clips to an oval (circle at 1:1).',
     },
   },
 };
@@ -175,20 +177,42 @@ export const Ultrawide21x9: Story = {
   ),
 };
 
-export const Circle: Story = {
+export const EllipseCircle: Story = {
   args: {
-    isCircle: true,
+    ratio: 1,
+    shape: 'ellipse',
   },
   render: args => (
     <div {...stylex.props(styles.smallContainer)}>
       <XDSText type="supporting" xstyle={styles.sectionLabel}>
-        Circle - Avatars and circular media (forces 1:1)
+        Ellipse at 1:1 — a circle (avatars, profile images)
       </XDSText>
       <XDSAspectRatio {...args}>
         <img
           {...stylex.props(styles.image)}
           src={PLACEHOLDER_SQUARE}
           alt="Circular media"
+        />
+      </XDSAspectRatio>
+    </div>
+  ),
+};
+
+export const EllipseOval: Story = {
+  args: {
+    ratio: 16 / 9,
+    shape: 'ellipse',
+  },
+  render: args => (
+    <div {...stylex.props(styles.container)}>
+      <XDSText type="supporting" xstyle={styles.sectionLabel}>
+        Ellipse at 16:9 — an oval (respects the ratio)
+      </XDSText>
+      <XDSAspectRatio {...args}>
+        <img
+          {...stylex.props(styles.image)}
+          src={PLACEHOLDER_IMAGE}
+          alt="Oval media"
         />
       </XDSAspectRatio>
     </div>

--- a/apps/storybook/stories/AspectRatio.stories.tsx
+++ b/apps/storybook/stories/AspectRatio.stories.tsx
@@ -75,6 +75,10 @@ const meta: Meta<typeof XDSAspectRatio> = {
       control: 'number',
       description: 'The aspect ratio as width/height (e.g., 16/9 = 1.777...)',
     },
+    isCircle: {
+      control: 'boolean',
+      description: 'Clip the container to a circle (forces a 1:1 ratio).',
+    },
   },
 };
 
@@ -166,6 +170,26 @@ export const Ultrawide21x9: Story = {
         <div {...stylex.props(styles.gradientPlaceholder)}>
           <XDSText type="label">Ultrawide 21:9</XDSText>
         </div>
+      </XDSAspectRatio>
+    </div>
+  ),
+};
+
+export const Circle: Story = {
+  args: {
+    isCircle: true,
+  },
+  render: args => (
+    <div {...stylex.props(styles.smallContainer)}>
+      <XDSText type="supporting" xstyle={styles.sectionLabel}>
+        Circle - Avatars and circular media (forces 1:1)
+      </XDSText>
+      <XDSAspectRatio {...args}>
+        <img
+          {...stylex.props(styles.image)}
+          src={PLACEHOLDER_SQUARE}
+          alt="Circular media"
+        />
       </XDSAspectRatio>
     </div>
   ),

--- a/packages/cli/templates/blocks/components/AspectRatio/AspectRatioCircleImage.doc.mjs
+++ b/packages/cli/templates/blocks/components/AspectRatio/AspectRatioCircleImage.doc.mjs
@@ -1,0 +1,13 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  exampleFor: 'AspectRatio',
+  name: 'AspectRatio — Circle Image',
+  displayName: 'AspectRatio — Circle Image',
+  description: 'Circular container via the isCircle prop, ideal for avatars and profile images.',
+  isReady: true,
+  aspectRatio: 1,
+  componentsUsed: ['AspectRatio', 'Center'],
+};

--- a/packages/cli/templates/blocks/components/AspectRatio/AspectRatioCircleImage.doc.mjs
+++ b/packages/cli/templates/blocks/components/AspectRatio/AspectRatioCircleImage.doc.mjs
@@ -6,7 +6,7 @@ export const doc = {
   exampleFor: 'AspectRatio',
   name: 'AspectRatio — Circle Image',
   displayName: 'AspectRatio — Circle Image',
-  description: 'Circular container via the isCircle prop, ideal for avatars and profile images.',
+  description: 'Circular container via shape="ellipse" with ratio={1}, ideal for avatars and profile images.',
   isReady: true,
   aspectRatio: 1,
   componentsUsed: ['AspectRatio', 'Center'],

--- a/packages/cli/templates/blocks/components/AspectRatio/AspectRatioCircleImage.tsx
+++ b/packages/cli/templates/blocks/components/AspectRatio/AspectRatioCircleImage.tsx
@@ -1,0 +1,24 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import {XDSAspectRatio} from '@xds/core/AspectRatio';
+import {XDSCenter} from '@xds/core/Center';
+
+export default function AspectRatioCircleImage() {
+  return (
+    <XDSCenter width={300}>
+      <XDSAspectRatio isCircle>
+        <img
+          src="https://lookaside.facebook.com/assets/xds_oss/light-home-square-1.png"
+          alt="Circular image"
+          style={{
+            width: '100%',
+            height: '100%',
+            objectFit: 'cover',
+          }}
+        />
+      </XDSAspectRatio>
+    </XDSCenter>
+  );
+}

--- a/packages/cli/templates/blocks/components/AspectRatio/AspectRatioCircleImage.tsx
+++ b/packages/cli/templates/blocks/components/AspectRatio/AspectRatioCircleImage.tsx
@@ -8,7 +8,7 @@ import {XDSCenter} from '@xds/core/Center';
 export default function AspectRatioCircleImage() {
   return (
     <XDSCenter width={300}>
-      <XDSAspectRatio isCircle>
+      <XDSAspectRatio ratio={1} shape="ellipse">
         <img
           src="https://lookaside.facebook.com/assets/xds_oss/light-home-square-1.png"
           alt="Circular image"

--- a/packages/core/src/AspectRatio/AspectRatio.doc.mjs
+++ b/packages/core/src/AspectRatio/AspectRatio.doc.mjs
@@ -13,7 +13,7 @@ export const docs = {
     bestPractices: [
       {guidance: true, description: 'Express the ratio as a fraction like `16/9` or `4/3` for readability.'},
       {guidance: true, description: 'Use for media that needs consistent proportions across screen sizes.'},
-      {guidance: true, description: 'Use `isCircle` for circular media like avatars; it forces a 1:1 ratio and clips to a circle.'},
+      {guidance: true, description: 'Use `shape="ellipse"` for circular/oval media like avatars; combine with `ratio={1}` for a perfect circle.'},
       {guidance: false, description: 'Use for general layout containers — use standard layout components instead.'},
       {guidance: false, description: 'Nest AspectRatio containers — one level is sufficient.'},
     ],
@@ -22,14 +22,14 @@ export const docs = {
     {
       name: 'ratio',
       type: 'number',
-      description: 'Aspect ratio as width/height (e.g. 16/9, 1). Optional when `isCircle` is set.',
-      required: false,
+      description: 'Aspect ratio as width/height (e.g. 16/9, 1).',
+      required: true,
     },
     {
-      name: 'isCircle',
-      type: 'boolean',
-      description: 'Clip the container into a circle (forces a 1:1 ratio with a fully rounded border). Ignores `ratio` when set.',
-      default: 'false',
+      name: 'shape',
+      type: "'rectangle' | 'ellipse'",
+      description: 'Container shape. Both respect the `ratio`. `ellipse` clips to an oval (a circle when `ratio={1}`).',
+      default: "'rectangle'",
     },
     {
       name: 'children',
@@ -47,6 +47,7 @@ export const docs = {
   playground: {
     defaults: {
       ratio: 16 / 9,
+      shape: 'rectangle',
       // Fixed height + auto width lets the CSS `aspect-ratio` drive the box
       // width as the ratio knob changes (the component's base width is 100%,
       // which is why the preview was full-width regardless of the ratio).
@@ -68,7 +69,7 @@ export const docs = {
   },
   theming: {
     targets: [
-      {className: 'xds-aspect-ratio'},
+      {className: 'xds-aspect-ratio', visualProps: ['shape']},
     ],
   },
 };
@@ -83,13 +84,14 @@ export const docsZh = {
     bestPractices: [
       {guidance: true, description: 'Express the ratio as a fraction like `16/9` or `4/3` for readability.'},
       {guidance: true, description: 'Use for media that needs consistent proportions across screen sizes.'},
+      {guidance: true, description: 'Use `shape="ellipse"` for circular/oval media like avatars; combine with `ratio={1}` for a perfect circle.'},
       {guidance: false, description: 'Use for general layout containers — use standard layout components instead.'},
       {guidance: false, description: 'Nest AspectRatio containers — one level is sufficient.'},
     ],
   },
   props: [
-    {name: 'ratio', type: 'number', description: '宽高比，以宽/高表示（例如 16/9、1）。设置 `isCircle` 时可选。', required: false},
-    {name: 'isCircle', type: 'boolean', description: '将容器裁剪为圆形（强制 1:1 比例并应用完全圆角）。设置后将忽略 `ratio`。', default: 'false'},
+    {name: 'ratio', type: 'number', description: '宽高比，以宽/高表示（例如 16/9、1）。', required: true},
+    {name: 'shape', type: "'rectangle' | 'ellipse'", description: '容器形状，二者均遵循 `ratio`。`ellipse` 裁剪为椭圆（当 `ratio={1}` 时为圆形）。', default: "'rectangle'"},
     {name: 'children', type: 'ReactNode', description: '通过绝对定位填充容器的内容。', required: true},
     {
       name: 'xstyle',
@@ -100,7 +102,7 @@ export const docsZh = {
   ],
   theming: {
     targets: [
-      {className: 'xds-aspect-ratio'},
+      {className: 'xds-aspect-ratio', visualProps: ['shape']},
     ],
   },
 };
@@ -114,13 +116,14 @@ export const docsDense = {
     bestPractices: [
       {guidance: true, description: 'Express the ratio as a fraction like `16/9` or `4/3` for readability.'},
       {guidance: true, description: 'Use for media that needs consistent proportions across screen sizes.'},
+      {guidance: true, description: 'Use `shape="ellipse"` for circular/oval media like avatars; combine with `ratio={1}` for a perfect circle.'},
       {guidance: false, description: 'Use for general layout containers — use standard layout components instead.'},
       {guidance: false, description: 'Nest AspectRatio containers — one level is sufficient.'},
     ],
   },
   propDescriptions: {
-    ratio: 'width/height ratio (e.g. 16/9, 1); optional when isCircle is set',
-    isCircle: 'clip container to a circle (forces 1:1, ignores ratio)',
+    ratio: 'width/height ratio (e.g. 16/9, 1)',
+    shape: "container shape: 'rectangle' (default) or 'ellipse'; both respect ratio",
     children: 'content positioned absolutely to fill container',
     xstyle: 'StyleX layout customization via stylex.create()',
   },

--- a/packages/core/src/AspectRatio/AspectRatio.doc.mjs
+++ b/packages/core/src/AspectRatio/AspectRatio.doc.mjs
@@ -13,6 +13,7 @@ export const docs = {
     bestPractices: [
       {guidance: true, description: 'Express the ratio as a fraction like `16/9` or `4/3` for readability.'},
       {guidance: true, description: 'Use for media that needs consistent proportions across screen sizes.'},
+      {guidance: true, description: 'Use `isCircle` for circular media like avatars; it forces a 1:1 ratio and clips to a circle.'},
       {guidance: false, description: 'Use for general layout containers — use standard layout components instead.'},
       {guidance: false, description: 'Nest AspectRatio containers — one level is sufficient.'},
     ],
@@ -21,8 +22,14 @@ export const docs = {
     {
       name: 'ratio',
       type: 'number',
-      description: 'Aspect ratio as width/height (e.g. 16/9, 1).',
-      required: true,
+      description: 'Aspect ratio as width/height (e.g. 16/9, 1). Optional when `isCircle` is set.',
+      required: false,
+    },
+    {
+      name: 'isCircle',
+      type: 'boolean',
+      description: 'Clip the container into a circle (forces a 1:1 ratio with a fully rounded border). Ignores `ratio` when set.',
+      defaultValue: 'false',
     },
     {
       name: 'children',
@@ -65,7 +72,8 @@ export const docsZh = {
     ],
   },
   props: [
-    {name: 'ratio', type: 'number', description: '宽高比，以宽/高表示（例如 16/9、1）。', required: true},
+    {name: 'ratio', type: 'number', description: '宽高比，以宽/高表示（例如 16/9、1）。设置 `isCircle` 时可选。', required: false},
+    {name: 'isCircle', type: 'boolean', description: '将容器裁剪为圆形（强制 1:1 比例并应用完全圆角）。设置后将忽略 `ratio`。', defaultValue: 'false'},
     {name: 'children', type: 'ReactNode', description: '通过绝对定位填充容器的内容。', required: true},
     {
       name: 'xstyle',
@@ -95,7 +103,8 @@ export const docsDense = {
     ],
   },
   propDescriptions: {
-    ratio: 'width/height ratio (e.g. 16/9, 1)',
+    ratio: 'width/height ratio (e.g. 16/9, 1); optional when isCircle is set',
+    isCircle: 'clip container to a circle (forces 1:1, ignores ratio)',
     children: 'content positioned absolutely to fill container',
     xstyle: 'StyleX layout customization via stylex.create()',
   },

--- a/packages/core/src/AspectRatio/AspectRatio.doc.mjs
+++ b/packages/core/src/AspectRatio/AspectRatio.doc.mjs
@@ -47,7 +47,23 @@ export const docs = {
   playground: {
     defaults: {
       ratio: 16 / 9,
-      children: {__element: 'XDSCenter', props: {height: '100%'}, children: {__element: 'XDSText', props: {color: 'secondary'}, children: '16:9'}},
+      // Fixed height + auto width lets the CSS `aspect-ratio` drive the box
+      // width as the ratio knob changes (the component's base width is 100%,
+      // which is why the preview was full-width regardless of the ratio).
+      style: {
+        height: 300,
+        width: 'auto',
+        backgroundColor: 'var(--color-background-blue)',
+      },
+      children: {
+        __element: 'XDSCenter',
+        props: {height: '100%'},
+        children: {
+          __element: 'XDSText',
+          props: {color: 'primary'},
+          children: 'Aspect Ratio',
+        },
+      },
     },
   },
   theming: {

--- a/packages/core/src/AspectRatio/AspectRatio.doc.mjs
+++ b/packages/core/src/AspectRatio/AspectRatio.doc.mjs
@@ -29,7 +29,7 @@ export const docs = {
       name: 'isCircle',
       type: 'boolean',
       description: 'Clip the container into a circle (forces a 1:1 ratio with a fully rounded border). Ignores `ratio` when set.',
-      defaultValue: 'false',
+      default: 'false',
     },
     {
       name: 'children',
@@ -73,7 +73,7 @@ export const docsZh = {
   },
   props: [
     {name: 'ratio', type: 'number', description: '宽高比，以宽/高表示（例如 16/9、1）。设置 `isCircle` 时可选。', required: false},
-    {name: 'isCircle', type: 'boolean', description: '将容器裁剪为圆形（强制 1:1 比例并应用完全圆角）。设置后将忽略 `ratio`。', defaultValue: 'false'},
+    {name: 'isCircle', type: 'boolean', description: '将容器裁剪为圆形（强制 1:1 比例并应用完全圆角）。设置后将忽略 `ratio`。', default: 'false'},
     {name: 'children', type: 'ReactNode', description: '通过绝对定位填充容器的内容。', required: true},
     {
       name: 'xstyle',

--- a/packages/core/src/AspectRatio/XDSAspectRatio.test.tsx
+++ b/packages/core/src/AspectRatio/XDSAspectRatio.test.tsx
@@ -82,35 +82,39 @@ describe('XDSAspectRatio', () => {
     expect(element.style.aspectRatio).toBe(String(ratio));
   });
 
-  it('renders as a circle with a 1:1 ratio when circle is set', () => {
+  it('renders an ellipse that respects the ratio (circle at 1:1)', () => {
     render(
-      <XDSAspectRatio isCircle data-testid="aspect-ratio">
+      <XDSAspectRatio ratio={1} shape="ellipse" data-testid="aspect-ratio">
         <div>Circle</div>
       </XDSAspectRatio>,
     );
     const element = screen.getByTestId('aspect-ratio');
     expect(element.style.aspectRatio).toBe('1');
+    expect(element.className).toContain('ellipse');
   });
 
-  it('ignores the ratio prop when circle is set', () => {
+  it('ellipse respects a non-square ratio (oval)', () => {
     render(
-      <XDSAspectRatio isCircle ratio={16 / 9} data-testid="aspect-ratio">
-        <div>Circle wins</div>
+      <XDSAspectRatio ratio={16 / 9} shape="ellipse" data-testid="aspect-ratio">
+        <div>Oval</div>
       </XDSAspectRatio>,
     );
     const element = screen.getByTestId('aspect-ratio');
-    expect(element.style.aspectRatio).toBe('1');
+    // Ratio is preserved — the ellipse does not force 1:1.
+    expect(element.style.aspectRatio).toBe(String(16 / 9));
+    expect(element.className).toContain('ellipse');
   });
 
-  it('does not apply circle styling by default', () => {
+  it('defaults to the rectangle shape', () => {
     render(
       <XDSAspectRatio ratio={1} data-testid="aspect-ratio">
-        <div>Square, not circle</div>
+        <div>Rectangle by default</div>
       </XDSAspectRatio>,
     );
     const element = screen.getByTestId('aspect-ratio');
     expect(element.style.aspectRatio).toBe('1');
-    // No fully-rounded border radius when circle is not set
+    expect(element.className).toContain('rectangle');
+    // No ellipse border-radius when shape is the default rectangle
     expect(element.style.borderRadius).toBe('');
   });
 

--- a/packages/core/src/AspectRatio/XDSAspectRatio.test.tsx
+++ b/packages/core/src/AspectRatio/XDSAspectRatio.test.tsx
@@ -82,6 +82,38 @@ describe('XDSAspectRatio', () => {
     expect(element.style.aspectRatio).toBe(String(ratio));
   });
 
+  it('renders as a circle with a 1:1 ratio when circle is set', () => {
+    render(
+      <XDSAspectRatio isCircle data-testid="aspect-ratio">
+        <div>Circle</div>
+      </XDSAspectRatio>,
+    );
+    const element = screen.getByTestId('aspect-ratio');
+    expect(element.style.aspectRatio).toBe('1');
+  });
+
+  it('ignores the ratio prop when circle is set', () => {
+    render(
+      <XDSAspectRatio isCircle ratio={16 / 9} data-testid="aspect-ratio">
+        <div>Circle wins</div>
+      </XDSAspectRatio>,
+    );
+    const element = screen.getByTestId('aspect-ratio');
+    expect(element.style.aspectRatio).toBe('1');
+  });
+
+  it('does not apply circle styling by default', () => {
+    render(
+      <XDSAspectRatio ratio={1} data-testid="aspect-ratio">
+        <div>Square, not circle</div>
+      </XDSAspectRatio>,
+    );
+    const element = screen.getByTestId('aspect-ratio');
+    expect(element.style.aspectRatio).toBe('1');
+    // No fully-rounded border radius when circle is not set
+    expect(element.style.borderRadius).toBe('');
+  });
+
   it('forwards ref correctly', () => {
     const ref = vi.fn();
     render(

--- a/packages/core/src/AspectRatio/XDSAspectRatio.tsx
+++ b/packages/core/src/AspectRatio/XDSAspectRatio.tsx
@@ -18,6 +18,7 @@
 import type {ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {XDSBaseProps} from '../XDSBaseProps';
+import {radiusVars} from '../theme/tokens.stylex';
 import {xdsClassName, mergeProps} from '../utils';
 
 export interface XDSAspectRatioProps extends XDSBaseProps<HTMLDivElement> {
@@ -25,8 +26,27 @@ export interface XDSAspectRatioProps extends XDSBaseProps<HTMLDivElement> {
   ref?: React.Ref<HTMLDivElement>;
   /**
    * The aspect ratio as width/height (e.g., 16/9 = 1.777..., 4/3 = 1.333..., 1 for square).
+   *
+   * Optional when `isCircle` is set, in which case the ratio defaults to 1 (square)
+   * and any provided value is ignored.
    */
-  ratio: number;
+  ratio?: number;
+
+  /**
+   * Renders the container as a circle. Forces a 1:1 (square) ratio and applies a
+   * fully rounded border so content is clipped to a circular shape. Pair with a
+   * child that fills the container (e.g. an image with `objectFit: 'cover'`).
+   *
+   * When set, the `ratio` prop is ignored.
+   *
+   * @example
+   * ```
+   * <XDSAspectRatio isCircle>
+   *   <img src="avatar.jpg" alt="" style={{objectFit: 'cover'}} />
+   * </XDSAspectRatio>
+   * ```
+   */
+  isCircle?: boolean;
 
   /**
    * Content to render inside the aspect ratio container.
@@ -42,6 +62,9 @@ const styles = stylex.create({
     overflow: 'clip',
     minHeight: 0,
     flexShrink: 0,
+  },
+  circle: {
+    borderRadius: radiusVars['--radius-full'],
   },
   child: {
     position: 'absolute',
@@ -59,15 +82,26 @@ const styles = stylex.create({
  * is positioned absolutely to fill the container, which is useful for images,
  * videos, embeds, and placeholders.
  *
+ * Set `isCircle` to clip the container into a circle (1:1 ratio with a fully
+ * rounded border) — useful for avatars and circular media.
+ *
  * @example
  * ```
  * <XDSAspectRatio ratio={16 / 9}>
  *   <img src="image.jpg" alt="Widescreen image" style={{objectFit: 'cover'}} />
  * </XDSAspectRatio>
  * ```
+ *
+ * @example
+ * ```
+ * <XDSAspectRatio isCircle>
+ *   <img src="avatar.jpg" alt="" style={{objectFit: 'cover'}} />
+ * </XDSAspectRatio>
+ * ```
  */
 export function XDSAspectRatio({
   ratio,
+  isCircle = false,
   children,
   xstyle,
   className,
@@ -75,14 +109,17 @@ export function XDSAspectRatio({
   ref,
   ...props
 }: XDSAspectRatioProps) {
+  // A circle is a 1:1 container with a fully rounded border; an explicit
+  // `ratio` is ignored in that case.
+  const resolvedRatio = isCircle ? 1 : ratio;
   return (
     <div
       ref={ref}
       {...mergeProps(
         xdsClassName('aspect-ratio'),
-        stylex.props(styles.container, xstyle),
+        stylex.props(styles.container, isCircle && styles.circle, xstyle),
         className,
-        {...style, aspectRatio: ratio},
+        {...style, aspectRatio: resolvedRatio},
       )}
       {...props}>
       <div {...stylex.props(styles.child)}>{children}</div>

--- a/packages/core/src/AspectRatio/XDSAspectRatio.tsx
+++ b/packages/core/src/AspectRatio/XDSAspectRatio.tsx
@@ -18,35 +18,41 @@
 import type {ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {XDSBaseProps} from '../XDSBaseProps';
-import {radiusVars} from '../theme/tokens.stylex';
 import {xdsClassName, mergeProps} from '../utils';
+
+/**
+ * The shape of the aspect ratio container.
+ * - `rectangle`: standard rectangular container (default).
+ * - `ellipse`: clips the container to an ellipse. Combined with the `ratio`,
+ *   this renders a circle at `ratio={1}` and an oval at non-square ratios.
+ */
+export type XDSAspectRatioShape = 'rectangle' | 'ellipse';
 
 export interface XDSAspectRatioProps extends XDSBaseProps<HTMLDivElement> {
   /** Ref forwarded to the root element */
   ref?: React.Ref<HTMLDivElement>;
   /**
    * The aspect ratio as width/height (e.g., 16/9 = 1.777..., 4/3 = 1.333..., 1 for square).
-   *
-   * Optional when `isCircle` is set, in which case the ratio defaults to 1 (square)
-   * and any provided value is ignored.
    */
-  ratio?: number;
+  ratio: number;
 
   /**
-   * Renders the container as a circle. Forces a 1:1 (square) ratio and applies a
-   * fully rounded border so content is clipped to a circular shape. Pair with a
-   * child that fills the container (e.g. an image with `objectFit: 'cover'`).
+   * The shape of the container. Both shapes respect the provided `ratio`.
+   * - `rectangle` (default): a standard rectangular container.
+   * - `ellipse`: clips the container to an ellipse — a circle when `ratio={1}`,
+   *   or an oval at other ratios. Pair with a child that fills the container
+   *   (e.g. an image with `objectFit: 'cover'`).
    *
-   * When set, the `ratio` prop is ignored.
+   * @default 'rectangle'
    *
    * @example
    * ```
-   * <XDSAspectRatio isCircle>
+   * <XDSAspectRatio ratio={1} shape="ellipse">
    *   <img src="avatar.jpg" alt="" style={{objectFit: 'cover'}} />
    * </XDSAspectRatio>
    * ```
    */
-  isCircle?: boolean;
+  shape?: XDSAspectRatioShape;
 
   /**
    * Content to render inside the aspect ratio container.
@@ -63,8 +69,10 @@ const styles = stylex.create({
     minHeight: 0,
     flexShrink: 0,
   },
-  circle: {
-    borderRadius: radiusVars['--radius-full'],
+  ellipse: {
+    // 50% on both axes follows the box dimensions, so the clip respects the
+    // ratio: a circle at 1:1 and an oval at non-square ratios.
+    borderRadius: '50%',
   },
   child: {
     position: 'absolute',
@@ -82,8 +90,9 @@ const styles = stylex.create({
  * is positioned absolutely to fill the container, which is useful for images,
  * videos, embeds, and placeholders.
  *
- * Set `isCircle` to clip the container into a circle (1:1 ratio with a fully
- * rounded border) — useful for avatars and circular media.
+ * Use `shape="ellipse"` to clip the container into an ellipse — a circle at
+ * `ratio={1}` or an oval at other ratios. Both shapes respect the provided
+ * `ratio`.
  *
  * @example
  * ```
@@ -94,14 +103,14 @@ const styles = stylex.create({
  *
  * @example
  * ```
- * <XDSAspectRatio isCircle>
+ * <XDSAspectRatio ratio={1} shape="ellipse">
  *   <img src="avatar.jpg" alt="" style={{objectFit: 'cover'}} />
  * </XDSAspectRatio>
  * ```
  */
 export function XDSAspectRatio({
   ratio,
-  isCircle = false,
+  shape = 'rectangle',
   children,
   xstyle,
   className,
@@ -109,17 +118,18 @@ export function XDSAspectRatio({
   ref,
   ...props
 }: XDSAspectRatioProps) {
-  // A circle is a 1:1 container with a fully rounded border; an explicit
-  // `ratio` is ignored in that case.
-  const resolvedRatio = isCircle ? 1 : ratio;
   return (
     <div
       ref={ref}
       {...mergeProps(
-        xdsClassName('aspect-ratio'),
-        stylex.props(styles.container, isCircle && styles.circle, xstyle),
+        xdsClassName('aspect-ratio', {shape}),
+        stylex.props(
+          styles.container,
+          shape === 'ellipse' && styles.ellipse,
+          xstyle,
+        ),
         className,
-        {...style, aspectRatio: resolvedRatio},
+        {...style, aspectRatio: ratio},
       )}
       {...props}>
       <div {...stylex.props(styles.child)}>{children}</div>

--- a/packages/core/src/AspectRatio/index.ts
+++ b/packages/core/src/AspectRatio/index.ts
@@ -12,4 +12,4 @@
  */
 
 export {XDSAspectRatio} from './XDSAspectRatio';
-export type {XDSAspectRatioProps} from './XDSAspectRatio';
+export type {XDSAspectRatioProps, XDSAspectRatioShape} from './XDSAspectRatio';


### PR DESCRIPTION
## What

Adds a `shape` prop to `XDSAspectRatio` for clipping the container into different shapes, alongside the existing aspect-ratio behavior. Also adds an example block and fixes the broken Properties-tab playground preview.

`shape` accepts `'rectangle'` (default) or `'ellipse'`. **Both shapes respect the provided `ratio`** — `ellipse` renders a circle at `ratio={1}` and an oval at other ratios. The enum is designed to be extended with more shapes in the future.

```tsx
{/* circle */}
<XDSAspectRatio ratio={1} shape="ellipse">
  <img src="avatar.jpg" alt="" style={{objectFit: 'cover'}} />
</XDSAspectRatio>

{/* oval — respects the ratio */}
<XDSAspectRatio ratio={16 / 9} shape="ellipse">
  <img src="banner.jpg" alt="" style={{objectFit: 'cover'}} />
</XDSAspectRatio>
```

## How

- **`XDSAspectRatio.tsx`** — added the `shape?: 'rectangle' | 'ellipse'` prop (default `'rectangle'`) and exported the `XDSAspectRatioShape` type. The `ellipse` shape applies `border-radius: 50%`, which follows the box dimensions so it respects the ratio (circle at 1:1, oval otherwise). The shape is also emitted as an `xdsClassName` variant for theming.
- **`index.ts`** — re-exports the new `XDSAspectRatioShape` type.
- **`AspectRatio.doc.mjs`** — documented the `shape` prop (EN + ZH + dense), added a best-practice entry, added a `shape` knob to the playground, and listed `shape` under theming `visualProps`.
- **`XDSAspectRatio.test.tsx`** — tests for ellipse-at-1:1 (circle), ellipse-at-16:9 (oval, ratio preserved), and the default rectangle shape.
- **`AspectRatio.stories.tsx`** — `shape` select control plus `EllipseCircle` and `EllipseOval` stories.
- **`AspectRatioCircleImage.tsx` / `.doc.mjs`** — "AspectRatio — Circle Image" example block using `ratio={1} shape="ellipse"`.
- **`AspectRatio.doc.mjs` (playground)** — fixed the Properties-tab preview, which was full-width regardless of the `ratio` knob. The container now has a fixed `height: 300px` with `width: auto`, so the CSS `aspect-ratio` drives the box width. Background uses `--color-background-blue` and the label text uses `--color-text-primary`.

## API note

This replaces the earlier `isCircle` boolean (introduced in an earlier commit on this branch) with the more extensible `shape` enum. Unlike `isCircle` — which forced a 1:1 ratio — `shape="ellipse"` honors whatever `ratio` is set, so it supports ovals as well as circles.

## Testing

- `pnpm vitest run packages/core/src/AspectRatio` — 14/14 pass
- `pnpm exec eslint` on changed files (incl. new block) — clean
- `node scripts/check-sync.js` — SYNC comments clean
- `pnpm -F @xds/core typecheck:docs` — clean (CI build step)
- `node apps/docsite/scripts/generate-data.mjs` — Circle Image block + `shape` playground registered
- `tsc --noEmit` on `@xds/core` — no errors

## Fixes

- CI `build` was failing because `PropDoc` entries used a `defaultValue` field that doesn't exist on the type. Corrected to the supported `default` field, validated against the `typecheck:docs` CI step.