### PR TITLE
fix(ci): build @xds/core before docsite generate in docsite-test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,12 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      # docsite `generate` runs `xds theme build`, which imports the compiled
+      # @xds/core/theme entry (dist/theme/index.js). Build core first so that
+      # entry exists — otherwise generate fails with "Cannot find module".
+      - name: Build core package
+        run: pnpm -F @xds/core build
+
       - name: Generate and test docsite data
         run: pnpm -F @xds/docsite generate && pnpm -F @xds/docsite test
 


### PR DESCRIPTION
## Summary

The `docsite-test` CI job fails on docsite PRs (e.g. #2560) with:

```
Error: Failed to load theme from apps/docsite/src/themes/astryxTheme.ts:
Cannot find module '.../apps/docsite/node_modules/@xds/core/dist/theme/index.js'
```

**Root cause:** the docsite `generate` script runs `xds theme build`, which loads `astryxTheme.ts`. That file imports `@xds/core/theme`, which resolves to the compiled entry `@xds/core/dist/theme/index.js`. In fresh CI the `docsite-test` job never builds `@xds/core`, so `dist/` doesn't exist and theme loading throws.

**Fix:** add a `pnpm -F @xds/core build` step before the generate step so the compiled theme entry exists. This unblocks all docsite PRs.

This was reproduced locally (deleting `packages/core/dist` reproduces the exact `Cannot find module` error via the CLI's jiti import) and verified fixed — after building core, `pnpm -F @xds/docsite generate && pnpm -F @xds/docsite test` passes (86/86 docsite tests green).

## Test plan
- [ ] `docsite-test` check passes on this PR
- [ ] Rebase/retrigger #2560 and confirm its `docsite-test` check goes green

Made with [Cursor](https://cursor.com)