### PR TITLE
fix(docsite): stop truncating block example descriptions

### DIFF
--- a/apps/docsite/scripts/generate-data.mjs
+++ b/apps/docsite/scripts/generate-data.mjs
@@ -61,9 +61,80 @@ function requireDisplayName(displayName, where) {
   return displayName;
 }
 
+/**
+ * Parses a single/double/backtick-quoted JS string literal starting at
+ * `openIdx` (the index of the opening quote) and returns the decoded
+ * string value plus the index just past the closing quote.
+ *
+ * Unlike a naive `[^'"`]` character class, this correctly handles:
+ *   - interior quotes of a different type (e.g. `'Swap the default "/"'`)
+ *   - escaped quotes of the same type (e.g. `'won\'t close it'`)
+ *   - standard escape sequences (\n, \t, \uXXXX, \xXX, line continuations)
+ * and has no length cap, so long descriptions survive intact.
+ */
+function parseStringLiteral(content, openIdx) {
+  const quote = content[openIdx];
+  let i = openIdx + 1;
+  let out = '';
+  while (i < content.length) {
+    const ch = content[i];
+    if (ch === '\\') {
+      const next = content[i + 1];
+      switch (next) {
+        case 'n': out += '\n'; i += 2; continue;
+        case 'r': out += '\r'; i += 2; continue;
+        case 't': out += '\t'; i += 2; continue;
+        case 'b': out += '\b'; i += 2; continue;
+        case 'f': out += '\f'; i += 2; continue;
+        case 'v': out += '\v'; i += 2; continue;
+        case '0': out += '\0'; i += 2; continue;
+        case '\n': i += 2; continue; // line continuation
+        case '\r': i += content[i + 2] === '\n' ? 3 : 2; continue;
+        case 'u': {
+          if (content[i + 2] === '{') {
+            const end = content.indexOf('}', i + 3);
+            out += String.fromCodePoint(parseInt(content.slice(i + 3, end), 16));
+            i = end + 1;
+            continue;
+          }
+          out += String.fromCharCode(parseInt(content.slice(i + 2, i + 6), 16));
+          i += 6;
+          continue;
+        }
+        case 'x':
+          out += String.fromCharCode(parseInt(content.slice(i + 2, i + 4), 16));
+          i += 4;
+          continue;
+        default:
+          out += next; // \', \", \`, \\, and any other escaped char
+          i += 2;
+          continue;
+      }
+    }
+    if (ch === quote) {
+      return {value: out, end: i + 1};
+    }
+    out += ch;
+    i++;
+  }
+  return {value: out, end: i};
+}
+
+/**
+ * Extracts a top-level quoted field value (e.g. `description`) from
+ * .doc.mjs source, decoding the string literal so interior quotes and
+ * escapes survive intact. Returns null when the field is absent.
+ */
+function extractQuotedField(content, field) {
+  const re = new RegExp(`(?:^|\\n) {0,4}${field}:\\s*\\n?\\s*['"\`]`);
+  const m = re.exec(content);
+  if (!m) return null;
+  const openIdx = m.index + m[0].length - 1; // index of the opening quote
+  return parseStringLiteral(content, openIdx).value;
+}
+
 /** Extract group/description/hidden from .doc.mjs via regex (no dynamic import) */
 const GROUP_RE = /(?:^|\n) {0,4}group:\s*['"]([^'"]+)['"]/;
-const DESC_RE = /description:\s*\n?\s*['"`]([^'"`]{0,200})['"`]/;
 const HIDDEN_RE = /(?:^|\n) {0,4}hidden:\s*true/;
 const NAME_RE = /(?:^|\n) {0,4}name:\s*['"]([^'"]+)['"]/;
 const DISPLAY_NAME_RE = /(?:^|\n) {0,4}displayName:\s*['"]([^'"]+)['"]/;
@@ -75,7 +146,7 @@ function readDocMeta(docPath) {
   try {
     const content = fs.readFileSync(docPath, 'utf-8');
     const groupMatch = GROUP_RE.exec(content);
-    const descMatch = DESC_RE.exec(content);
+    const description = extractQuotedField(content, 'description');
     const nameMatch = NAME_RE.exec(content);
     const displayNameMatch = DISPLAY_NAME_RE.exec(content);
     const hidden = HIDDEN_RE.test(content);
@@ -87,7 +158,7 @@ function readDocMeta(docPath) {
     const isHiddenFromOverview = IS_HIDDEN_FROM_OVERVIEW_RE.test(content);
     return {
       group: groupMatch?.[1] ?? null,
-      description: descMatch?.[1] ?? '',
+      description: description ?? '',
       name: nameMatch?.[1] ?? null,
       displayName: displayNameMatch?.[1] ?? null,
       hidden,
@@ -1129,7 +1200,7 @@ function generateExampleRegistry() {
 
     // Read name and description from doc meta
     const nameMatch = content.match(/name:\s*['"]([^'"]+)['"]/);
-    const descMatch = content.match(/description:\s*\n?\s*['"`]([^'"`]{0,200})['"`]/);
+    const description = extractQuotedField(content, 'description');
 
     fs.copyFileSync(tsxSrc, path.join(EXAMPLES_OUT, `${basename}.tsx`));
 
@@ -1140,7 +1211,7 @@ function generateExampleRegistry() {
       exampleFor,
       basename,
       name: nameMatch?.[1] || basename,
-      description: descMatch?.[1] || '',
+      description: description || '',
       source,
     });
   }

--- a/apps/docsite/src/__tests__/data-extraction.test.ts
+++ b/apps/docsite/src/__tests__/data-extraction.test.ts
@@ -621,4 +621,40 @@ describe('exampleRegistry', () => {
     expect(exampleCount + showcaseCount).toBeLessThanOrEqual(blockCount);
     expect(exampleCount).toBeGreaterThan(showcaseCount);
   });
+
+  // Regression: the description extractor used to truncate at the first
+  // interior quote (e.g. 'Swap the default "/"...') and drop any
+  // description longer than 200 characters entirely — surfacing as
+  // "No description available." in the docsite. Every authored doc has a
+  // description, so the registry should never carry an empty one.
+  it('every example has a non-empty description', () => {
+    const missing: string[] = [];
+    for (const examples of Object.values(exampleRegistry)) {
+      for (const ex of examples) {
+        if (!ex.description || ex.description.trim().length === 0) {
+          missing.push(ex.name);
+        }
+      }
+    }
+    expect(missing).toEqual([]);
+  });
+
+  // Regression: descriptions containing interior double quotes must be
+  // preserved in full rather than cut off at the first quote.
+  it('preserves descriptions with interior quotes', () => {
+    const breadcrumbs = exampleRegistry['Breadcrumbs'] ?? [];
+    const separators = breadcrumbs.find(e => /Separator/i.test(e.name));
+    expect(separators).toBeDefined();
+    expect(separators!.description).toContain('"/"');
+    // Full sentence survives past the interior quote.
+    expect(separators!.description).toMatch(/separator\.?$/i);
+  });
+
+  // Regression: long descriptions (>200 chars) must not be dropped.
+  it('keeps long descriptions intact', () => {
+    const longest = Object.values(exampleRegistry)
+      .flat()
+      .reduce((max, e) => Math.max(max, e.description.length), 0);
+    expect(longest).toBeGreaterThan(200);
+  });
 });


### PR DESCRIPTION
## Problem

On component detail pages in the docsite, many block examples show **"No description available."** — even though their `{Name}.doc.mjs` files clearly have a `description`. Others render a description that's cut off mid-sentence.

## Root cause

The description extractor in `apps/docsite/scripts/generate-data.mjs` used:

```js
/description:\s*\n?\s*['"`]([^'"`]{0,200})['"`]/
```

Two bugs in the capture group:

1. **Interior quotes** — `[^'"`]` excludes *all three* quote characters. A single-quoted description containing an interior double quote (e.g. `'Swap the default "/" for a different character...'`) gets truncated at the first `"`.
2. **200-char cap** — `{0,200}` means any description longer than 200 chars *with no interior quote to stop it earlier* fails to match at all, yielding an empty string → "No description available."

The regex feeds both `readDocMeta()` (block registry) and the example registry generator, so both surfaces were affected.

## Impact (before fix)

26 example blocks affected:
- **15 blanked** → "No description available." (e.g. all `Card` examples, `EmptyState`, `Toolbar`, `Pagination — Dots`, several `Dialog`/`Chat` examples — all had descriptions >200 chars)
- **11 truncated** mid-sentence (e.g. `Breadcrumbs — Separators`, `Button — Icon`, `Divider — Variants`, `Field — With Description`)

## Fix

Replace the regex with a small string-literal parser (`parseStringLiteral` + `extractQuotedField`) that:
- respects the opening quote type, so interior quotes of a different type are preserved
- decodes standard escape sequences (`\n`, `\t`, `\uXXXX`, `\xXX`, escaped quotes, line continuations)
- has **no length cap**

Applied in both `readDocMeta` and `generateExampleRegistry`.

## Tests

Added 3 regression tests to `data-extraction.test.ts`:
- every example has a non-empty description
- descriptions with interior quotes are preserved in full
- long (>200 char) descriptions stay intact

Full suite: **67/67 passing**. After regenerating, the example registry has **0 empty descriptions** (was 15) and interior quotes survive.

## Note on showcases

35 `*Showcase.doc.mjs` files have no `description` field at all, but showcases are intentionally excluded from the example registry and `ShowcasePreview` doesn't render a description — so they are not a source of the "No description available." text and are out of scope for this fix.
