### PR TITLE
fix(sandbox): prefix /template-assets/* with basePath in all 14 templates

### DIFF
--- a/packages/cli/templates/pages/centered-hero/page.tsx
+++ b/packages/cli/templates/pages/centered-hero/page.tsx
@@ -20,7 +20,8 @@ import {ArrowRightIcon} from '@heroicons/react/20/solid';
 // root). In the sandbox preview it picks up `/sandbox` so /template-assets/*
 // resolves under the GH Pages basePath. The CLI swaps these paths for an
 // inline placeholder on scaffold, so end users never see them.
-const BP = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
+const BP =
+  (typeof process !== 'undefined' && process.env?.NEXT_PUBLIC_BASE_PATH) || '';
 
 const IMAGE_URL = BP + '/template-assets/light-scene-horizontal-1.png';
 

--- a/packages/cli/templates/pages/centered-hero/page.tsx
+++ b/packages/cli/templates/pages/centered-hero/page.tsx
@@ -21,7 +21,7 @@ import {ArrowRightIcon} from '@heroicons/react/20/solid';
 // resolves under the GH Pages basePath. The CLI swaps these paths for an
 // inline placeholder on scaffold, so end users never see them.
 const BP =
-  (typeof process !== 'undefined' && process.env?.NEXT_PUBLIC_BASE_PATH) || '';
+  (typeof process !== 'undefined' && process.env.NEXT_PUBLIC_BASE_PATH) || '';
 
 const IMAGE_URL = BP + '/template-assets/light-scene-horizontal-1.png';
 

--- a/packages/cli/templates/pages/centered-hero/page.tsx
+++ b/packages/cli/templates/pages/centered-hero/page.tsx
@@ -16,14 +16,10 @@ import {XDSAspectRatio} from '@xds/core/AspectRatio';
 import {XDSSection} from '@xds/core/Section';
 import {ArrowRightIcon} from '@heroicons/react/20/solid';
 
-// Optional basePath. Empty in end-user projects and the docsite (served at
-// root). In the sandbox preview it picks up `/sandbox` so /template-assets/*
-// resolves under the GH Pages basePath. The CLI swaps these paths for an
-// inline placeholder on scaffold, so end users never see them.
-const BP =
+const basePath =
   (typeof process !== 'undefined' && process.env.NEXT_PUBLIC_BASE_PATH) || '';
 
-const IMAGE_URL = BP + '/template-assets/light-scene-horizontal-1.png';
+const IMAGE_URL = basePath + '/template-assets/light-scene-horizontal-1.png';
 
 const styles = stylex.create({
   heroImage: {

--- a/packages/cli/templates/pages/centered-hero/page.tsx
+++ b/packages/cli/templates/pages/centered-hero/page.tsx
@@ -16,7 +16,13 @@ import {XDSAspectRatio} from '@xds/core/AspectRatio';
 import {XDSSection} from '@xds/core/Section';
 import {ArrowRightIcon} from '@heroicons/react/20/solid';
 
-const IMAGE_URL = '/template-assets/light-scene-horizontal-1.png';
+// Optional basePath. Empty in end-user projects and the docsite (served at
+// root). In the sandbox preview it picks up `/sandbox` so /template-assets/*
+// resolves under the GH Pages basePath. The CLI swaps these paths for an
+// inline placeholder on scaffold, so end users never see them.
+const BP = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
+
+const IMAGE_URL = BP + '/template-assets/light-scene-horizontal-1.png';
 
 const styles = stylex.create({
   heroImage: {

--- a/packages/cli/templates/pages/classic-gallery/page.tsx
+++ b/packages/cli/templates/pages/classic-gallery/page.tsx
@@ -12,6 +12,12 @@ import {XDSAspectRatio} from '@xds/core/AspectRatio';
 import {XDSTabList, XDSTab} from '@xds/core/TabList';
 import * as stylex from '@stylexjs/stylex';
 
+// Optional basePath. Empty in end-user projects and the docsite (served at
+// root). In the sandbox preview it picks up `/sandbox` so /template-assets/*
+// resolves under the GH Pages basePath. The CLI swaps these paths for an
+// inline placeholder on scaffold, so end users never see them.
+const BP = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
+
 // ─── Styles ─────────────────────────────────────────────────────────────────
 // Width + centering come from XDSLayout's contentWidth prop. The remaining
 // styles cover things with no XDS prop equivalent: asymmetric page padding,
@@ -49,42 +55,42 @@ interface GalleryImage {
 
 const GALLERY_IMAGES: GalleryImage[] = [
   {
-    src: '/template-assets/classic-gallery-working-together.png',
+    src: BP + '/template-assets/classic-gallery-working-together.png',
     alt: 'Two colleagues reviewing work on a laptop together',
     category: 'lifestyle',
   },
   {
-    src: '/template-assets/classic-gallery-lifestyle-architecture.jpg',
+    src: BP + '/template-assets/classic-gallery-lifestyle-architecture.jpg',
     alt: 'Soft blush curved architecture against a pale sky',
     category: 'lifestyle',
   },
   {
-    src: '/template-assets/classic-gallery-product-backpack.png',
+    src: BP + '/template-assets/classic-gallery-product-backpack.png',
     alt: 'Charcoal canvas backpack against a neutral backdrop',
     category: 'products',
   },
   {
-    src: '/template-assets/classic-gallery-product-headphones.png',
+    src: BP + '/template-assets/classic-gallery-product-headphones.png',
     alt: 'Over-ear headphones resting beside a stone riser',
     category: 'products',
   },
   {
-    src: '/template-assets/classic-gallery-product-mug.png',
+    src: BP + '/template-assets/classic-gallery-product-mug.png',
     alt: 'Matte graphite insulated travel mug',
     category: 'products',
   },
   {
-    src: '/template-assets/classic-gallery-product-throw.png',
+    src: BP + '/template-assets/classic-gallery-product-throw.png',
     alt: 'Folded linen throw blanket with fringed edges',
     category: 'products',
   },
   {
-    src: '/template-assets/classic-gallery-product-wallet.png',
+    src: BP + '/template-assets/classic-gallery-product-wallet.png',
     alt: 'Slim leather bifold wallet on a neutral surface',
     category: 'products',
   },
   {
-    src: '/template-assets/classic-gallery-product-watch.png',
+    src: BP + '/template-assets/classic-gallery-product-watch.png',
     alt: 'Minimalist watch with two interchangeable straps',
     category: 'products',
   },

--- a/packages/cli/templates/pages/classic-gallery/page.tsx
+++ b/packages/cli/templates/pages/classic-gallery/page.tsx
@@ -12,11 +12,7 @@ import {XDSAspectRatio} from '@xds/core/AspectRatio';
 import {XDSTabList, XDSTab} from '@xds/core/TabList';
 import * as stylex from '@stylexjs/stylex';
 
-// Optional basePath. Empty in end-user projects and the docsite (served at
-// root). In the sandbox preview it picks up `/sandbox` so /template-assets/*
-// resolves under the GH Pages basePath. The CLI swaps these paths for an
-// inline placeholder on scaffold, so end users never see them.
-const BP =
+const basePath =
   (typeof process !== 'undefined' && process.env.NEXT_PUBLIC_BASE_PATH) || '';
 
 // ─── Styles ─────────────────────────────────────────────────────────────────
@@ -56,42 +52,43 @@ interface GalleryImage {
 
 const GALLERY_IMAGES: GalleryImage[] = [
   {
-    src: BP + '/template-assets/classic-gallery-working-together.png',
+    src: basePath + '/template-assets/classic-gallery-working-together.png',
     alt: 'Two colleagues reviewing work on a laptop together',
     category: 'lifestyle',
   },
   {
-    src: BP + '/template-assets/classic-gallery-lifestyle-architecture.jpg',
+    src:
+      basePath + '/template-assets/classic-gallery-lifestyle-architecture.jpg',
     alt: 'Soft blush curved architecture against a pale sky',
     category: 'lifestyle',
   },
   {
-    src: BP + '/template-assets/classic-gallery-product-backpack.png',
+    src: basePath + '/template-assets/classic-gallery-product-backpack.png',
     alt: 'Charcoal canvas backpack against a neutral backdrop',
     category: 'products',
   },
   {
-    src: BP + '/template-assets/classic-gallery-product-headphones.png',
+    src: basePath + '/template-assets/classic-gallery-product-headphones.png',
     alt: 'Over-ear headphones resting beside a stone riser',
     category: 'products',
   },
   {
-    src: BP + '/template-assets/classic-gallery-product-mug.png',
+    src: basePath + '/template-assets/classic-gallery-product-mug.png',
     alt: 'Matte graphite insulated travel mug',
     category: 'products',
   },
   {
-    src: BP + '/template-assets/classic-gallery-product-throw.png',
+    src: basePath + '/template-assets/classic-gallery-product-throw.png',
     alt: 'Folded linen throw blanket with fringed edges',
     category: 'products',
   },
   {
-    src: BP + '/template-assets/classic-gallery-product-wallet.png',
+    src: basePath + '/template-assets/classic-gallery-product-wallet.png',
     alt: 'Slim leather bifold wallet on a neutral surface',
     category: 'products',
   },
   {
-    src: BP + '/template-assets/classic-gallery-product-watch.png',
+    src: basePath + '/template-assets/classic-gallery-product-watch.png',
     alt: 'Minimalist watch with two interchangeable straps',
     category: 'products',
   },

--- a/packages/cli/templates/pages/classic-gallery/page.tsx
+++ b/packages/cli/templates/pages/classic-gallery/page.tsx
@@ -16,7 +16,8 @@ import * as stylex from '@stylexjs/stylex';
 // root). In the sandbox preview it picks up `/sandbox` so /template-assets/*
 // resolves under the GH Pages basePath. The CLI swaps these paths for an
 // inline placeholder on scaffold, so end users never see them.
-const BP = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
+const BP =
+  (typeof process !== 'undefined' && process.env?.NEXT_PUBLIC_BASE_PATH) || '';
 
 // ─── Styles ─────────────────────────────────────────────────────────────────
 // Width + centering come from XDSLayout's contentWidth prop. The remaining

--- a/packages/cli/templates/pages/classic-gallery/page.tsx
+++ b/packages/cli/templates/pages/classic-gallery/page.tsx
@@ -17,7 +17,7 @@ import * as stylex from '@stylexjs/stylex';
 // resolves under the GH Pages basePath. The CLI swaps these paths for an
 // inline placeholder on scaffold, so end users never see them.
 const BP =
-  (typeof process !== 'undefined' && process.env?.NEXT_PUBLIC_BASE_PATH) || '';
+  (typeof process !== 'undefined' && process.env.NEXT_PUBLIC_BASE_PATH) || '';
 
 // ─── Styles ─────────────────────────────────────────────────────────────────
 // Width + centering come from XDSLayout's contentWidth prop. The remaining

--- a/packages/cli/templates/pages/detail-page/page.tsx
+++ b/packages/cli/templates/pages/detail-page/page.tsx
@@ -48,7 +48,7 @@ import * as stylex from '@stylexjs/stylex';
 // resolves under the GH Pages basePath. The CLI swaps these paths for an
 // inline placeholder on scaffold, so end users never see them.
 const BP =
-  (typeof process !== 'undefined' && process.env?.NEXT_PUBLIC_BASE_PATH) || '';
+  (typeof process !== 'undefined' && process.env.NEXT_PUBLIC_BASE_PATH) || '';
 
 // The only custom CSS in this template is small optical-alignment negative
 // margins: XDSLayoutHeader/XDSTabList have no edge-dock prop (#2622) and XDSList

--- a/packages/cli/templates/pages/detail-page/page.tsx
+++ b/packages/cli/templates/pages/detail-page/page.tsx
@@ -47,7 +47,8 @@ import * as stylex from '@stylexjs/stylex';
 // root). In the sandbox preview it picks up `/sandbox` so /template-assets/*
 // resolves under the GH Pages basePath. The CLI swaps these paths for an
 // inline placeholder on scaffold, so end users never see them.
-const BP = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
+const BP =
+  (typeof process !== 'undefined' && process.env?.NEXT_PUBLIC_BASE_PATH) || '';
 
 // The only custom CSS in this template is small optical-alignment negative
 // margins: XDSLayoutHeader/XDSTabList have no edge-dock prop (#2622) and XDSList

--- a/packages/cli/templates/pages/detail-page/page.tsx
+++ b/packages/cli/templates/pages/detail-page/page.tsx
@@ -43,11 +43,7 @@ import {
 // ─── Styles ─────────────────────────────────────────────────────────────────
 import * as stylex from '@stylexjs/stylex';
 
-// Optional basePath. Empty in end-user projects and the docsite (served at
-// root). In the sandbox preview it picks up `/sandbox` so /template-assets/*
-// resolves under the GH Pages basePath. The CLI swaps these paths for an
-// inline placeholder on scaffold, so end users never see them.
-const BP =
+const basePath =
   (typeof process !== 'undefined' && process.env.NEXT_PUBLIC_BASE_PATH) || '';
 
 // The only custom CSS in this template is small optical-alignment negative
@@ -74,15 +70,15 @@ const pageStyles = stylex.create({
 // Source: meta assets.file list -s xds_oss -g light-product-{1..5}
 const PRODUCT_IMAGES = [
   // light-product-1 from xds_oss asset set
-  BP + '/template-assets/light-product-1.png',
+  basePath + '/template-assets/light-product-1.png',
   // light-product-2 from xds_oss asset set
-  BP + '/template-assets/light-product-2.png',
+  basePath + '/template-assets/light-product-2.png',
   // light-product-3 from xds_oss asset set
-  BP + '/template-assets/light-product-3.png',
+  basePath + '/template-assets/light-product-3.png',
   // light-product-4 from xds_oss asset set
-  BP + '/template-assets/light-product-4.png',
+  basePath + '/template-assets/light-product-4.png',
   // light-product-5 from xds_oss asset set
-  BP + '/template-assets/light-product-5.png',
+  basePath + '/template-assets/light-product-5.png',
 ];
 
 const PRODUCTS = [

--- a/packages/cli/templates/pages/detail-page/page.tsx
+++ b/packages/cli/templates/pages/detail-page/page.tsx
@@ -43,6 +43,12 @@ import {
 // ─── Styles ─────────────────────────────────────────────────────────────────
 import * as stylex from '@stylexjs/stylex';
 
+// Optional basePath. Empty in end-user projects and the docsite (served at
+// root). In the sandbox preview it picks up `/sandbox` so /template-assets/*
+// resolves under the GH Pages basePath. The CLI swaps these paths for an
+// inline placeholder on scaffold, so end users never see them.
+const BP = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
+
 // The only custom CSS in this template is small optical-alignment negative
 // margins: XDSLayoutHeader/XDSTabList have no edge-dock prop (#2622) and XDSList
 // has no "bleed to container edge" prop (#2626). Everything else uses props.
@@ -67,15 +73,15 @@ const pageStyles = stylex.create({
 // Source: meta assets.file list -s xds_oss -g light-product-{1..5}
 const PRODUCT_IMAGES = [
   // light-product-1 from xds_oss asset set
-  '/template-assets/light-product-1.png',
+  BP + '/template-assets/light-product-1.png',
   // light-product-2 from xds_oss asset set
-  '/template-assets/light-product-2.png',
+  BP + '/template-assets/light-product-2.png',
   // light-product-3 from xds_oss asset set
-  '/template-assets/light-product-3.png',
+  BP + '/template-assets/light-product-3.png',
   // light-product-4 from xds_oss asset set
-  '/template-assets/light-product-4.png',
+  BP + '/template-assets/light-product-4.png',
   // light-product-5 from xds_oss asset set
-  '/template-assets/light-product-5.png',
+  BP + '/template-assets/light-product-5.png',
 ];
 
 const PRODUCTS = [

--- a/packages/cli/templates/pages/form-two-column/page.tsx
+++ b/packages/cli/templates/pages/form-two-column/page.tsx
@@ -23,7 +23,8 @@ import {XDSSelector} from '@xds/core/Selector';
 // root). In the sandbox preview it picks up `/sandbox` so /template-assets/*
 // resolves under the GH Pages basePath. The CLI swaps these paths for an
 // inline placeholder on scaffold, so end users never see them.
-const BP = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
+const BP =
+  (typeof process !== 'undefined' && process.env?.NEXT_PUBLIC_BASE_PATH) || '';
 
 // illustration-horizontal-1 from xds_oss asset set
 const ILLUSTRATION_URL = BP + '/template-assets/illustration-horizontal-1.png';

--- a/packages/cli/templates/pages/form-two-column/page.tsx
+++ b/packages/cli/templates/pages/form-two-column/page.tsx
@@ -19,15 +19,12 @@ import {XDSDivider} from '@xds/core/Divider';
 import {XDSCard} from '@xds/core/Card';
 import {XDSSelector} from '@xds/core/Selector';
 
-// Optional basePath. Empty in end-user projects and the docsite (served at
-// root). In the sandbox preview it picks up `/sandbox` so /template-assets/*
-// resolves under the GH Pages basePath. The CLI swaps these paths for an
-// inline placeholder on scaffold, so end users never see them.
-const BP =
+const basePath =
   (typeof process !== 'undefined' && process.env.NEXT_PUBLIC_BASE_PATH) || '';
 
 // illustration-horizontal-1 from xds_oss asset set
-const ILLUSTRATION_URL = BP + '/template-assets/illustration-horizontal-1.png';
+const ILLUSTRATION_URL =
+  basePath + '/template-assets/illustration-horizontal-1.png';
 
 // ─────────────────────────────────────────────────────────────
 // Constants

--- a/packages/cli/templates/pages/form-two-column/page.tsx
+++ b/packages/cli/templates/pages/form-two-column/page.tsx
@@ -19,8 +19,14 @@ import {XDSDivider} from '@xds/core/Divider';
 import {XDSCard} from '@xds/core/Card';
 import {XDSSelector} from '@xds/core/Selector';
 
+// Optional basePath. Empty in end-user projects and the docsite (served at
+// root). In the sandbox preview it picks up `/sandbox` so /template-assets/*
+// resolves under the GH Pages basePath. The CLI swaps these paths for an
+// inline placeholder on scaffold, so end users never see them.
+const BP = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
+
 // illustration-horizontal-1 from xds_oss asset set
-const ILLUSTRATION_URL = '/template-assets/illustration-horizontal-1.png';
+const ILLUSTRATION_URL = BP + '/template-assets/illustration-horizontal-1.png';
 
 // ─────────────────────────────────────────────────────────────
 // Constants

--- a/packages/cli/templates/pages/form-two-column/page.tsx
+++ b/packages/cli/templates/pages/form-two-column/page.tsx
@@ -24,7 +24,7 @@ import {XDSSelector} from '@xds/core/Selector';
 // resolves under the GH Pages basePath. The CLI swaps these paths for an
 // inline placeholder on scaffold, so end users never see them.
 const BP =
-  (typeof process !== 'undefined' && process.env?.NEXT_PUBLIC_BASE_PATH) || '';
+  (typeof process !== 'undefined' && process.env.NEXT_PUBLIC_BASE_PATH) || '';
 
 // illustration-horizontal-1 from xds_oss asset set
 const ILLUSTRATION_URL = BP + '/template-assets/illustration-horizontal-1.png';

--- a/packages/cli/templates/pages/gallery-hero/page.tsx
+++ b/packages/cli/templates/pages/gallery-hero/page.tsx
@@ -16,27 +16,23 @@ import {XDSGrid} from '@xds/core/Grid';
 import {XDSAspectRatio} from '@xds/core/AspectRatio';
 import {ArrowRightIcon} from '@heroicons/react/20/solid';
 
-// Optional basePath. Empty in end-user projects and the docsite (served at
-// root). In the sandbox preview it picks up `/sandbox` so /template-assets/*
-// resolves under the GH Pages basePath. The CLI swaps these paths for an
-// inline placeholder on scaffold, so end users never see them.
-const BP =
+const basePath =
   (typeof process !== 'undefined' && process.env.NEXT_PUBLIC_BASE_PATH) || '';
 
 const IMAGES = [
   {
     // colorful-home-horizontal-1 from xds_oss asset set
-    src: BP + '/template-assets/colorful-home-horizontal-1.png',
+    src: basePath + '/template-assets/colorful-home-horizontal-1.png',
     alt: 'Colorful home interior with vibrant decor',
   },
   {
     // colorful-lifestyle-horizontal-1 from xds_oss asset set
-    src: BP + '/template-assets/colorful-lifestyle-horizontal-1.png',
+    src: basePath + '/template-assets/colorful-lifestyle-horizontal-1.png',
     alt: 'Colorful lifestyle portrait with natural lighting',
   },
   {
     // colorful-lifestyle-horizontal-2 from xds_oss asset set
-    src: BP + '/template-assets/colorful-lifestyle-horizontal-2.png',
+    src: basePath + '/template-assets/colorful-lifestyle-horizontal-2.png',
     alt: 'Colorful lifestyle scene with warm tones',
   },
 ];

--- a/packages/cli/templates/pages/gallery-hero/page.tsx
+++ b/packages/cli/templates/pages/gallery-hero/page.tsx
@@ -20,7 +20,8 @@ import {ArrowRightIcon} from '@heroicons/react/20/solid';
 // root). In the sandbox preview it picks up `/sandbox` so /template-assets/*
 // resolves under the GH Pages basePath. The CLI swaps these paths for an
 // inline placeholder on scaffold, so end users never see them.
-const BP = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
+const BP =
+  (typeof process !== 'undefined' && process.env?.NEXT_PUBLIC_BASE_PATH) || '';
 
 const IMAGES = [
   {

--- a/packages/cli/templates/pages/gallery-hero/page.tsx
+++ b/packages/cli/templates/pages/gallery-hero/page.tsx
@@ -21,7 +21,7 @@ import {ArrowRightIcon} from '@heroicons/react/20/solid';
 // resolves under the GH Pages basePath. The CLI swaps these paths for an
 // inline placeholder on scaffold, so end users never see them.
 const BP =
-  (typeof process !== 'undefined' && process.env?.NEXT_PUBLIC_BASE_PATH) || '';
+  (typeof process !== 'undefined' && process.env.NEXT_PUBLIC_BASE_PATH) || '';
 
 const IMAGES = [
   {

--- a/packages/cli/templates/pages/gallery-hero/page.tsx
+++ b/packages/cli/templates/pages/gallery-hero/page.tsx
@@ -16,20 +16,26 @@ import {XDSGrid} from '@xds/core/Grid';
 import {XDSAspectRatio} from '@xds/core/AspectRatio';
 import {ArrowRightIcon} from '@heroicons/react/20/solid';
 
+// Optional basePath. Empty in end-user projects and the docsite (served at
+// root). In the sandbox preview it picks up `/sandbox` so /template-assets/*
+// resolves under the GH Pages basePath. The CLI swaps these paths for an
+// inline placeholder on scaffold, so end users never see them.
+const BP = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
+
 const IMAGES = [
   {
     // colorful-home-horizontal-1 from xds_oss asset set
-    src: '/template-assets/colorful-home-horizontal-1.png',
+    src: BP + '/template-assets/colorful-home-horizontal-1.png',
     alt: 'Colorful home interior with vibrant decor',
   },
   {
     // colorful-lifestyle-horizontal-1 from xds_oss asset set
-    src: '/template-assets/colorful-lifestyle-horizontal-1.png',
+    src: BP + '/template-assets/colorful-lifestyle-horizontal-1.png',
     alt: 'Colorful lifestyle portrait with natural lighting',
   },
   {
     // colorful-lifestyle-horizontal-2 from xds_oss asset set
-    src: '/template-assets/colorful-lifestyle-horizontal-2.png',
+    src: BP + '/template-assets/colorful-lifestyle-horizontal-2.png',
     alt: 'Colorful lifestyle scene with warm tones',
   },
 ];

--- a/packages/cli/templates/pages/library/page.tsx
+++ b/packages/cli/templates/pages/library/page.tsx
@@ -18,6 +18,12 @@ import {XDSOverflowList} from '@xds/core/OverflowList';
 import {XDSCenter} from '@xds/core/Center';
 import {MagnifyingGlassIcon} from '@heroicons/react/24/outline';
 
+// Optional basePath. Empty in end-user projects and the docsite (served at
+// root). In the sandbox preview it picks up `/sandbox` so /template-assets/*
+// resolves under the GH Pages basePath. The CLI swaps these paths for an
+// inline placeholder on scaffold, so end users never see them.
+const BP = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
+
 interface LibraryItem {
   id: string;
   name: string;
@@ -37,7 +43,7 @@ const ITEMS: LibraryItem[] = [
       'Vertical and horizontal stack layouts with configurable gap and alignment.',
     category: 'Layout',
     type: 'Component',
-    imageUrl: '/template-assets/colorful-home-horizontal-1.png',
+    imageUrl: BP + '/template-assets/colorful-home-horizontal-1.png',
   },
   {
     id: '2',
@@ -46,7 +52,7 @@ const ITEMS: LibraryItem[] = [
       'Responsive grid container with auto-fit columns and gap control.',
     category: 'Layout',
     type: 'Component',
-    imageUrl: '/template-assets/illustrative-horizontal-3.jpg',
+    imageUrl: BP + '/template-assets/illustrative-horizontal-3.jpg',
   },
   {
     id: '3',
@@ -55,7 +61,7 @@ const ITEMS: LibraryItem[] = [
       'Surface container with optional padding, border, and shadow variants.',
     category: 'Layout',
     type: 'Component',
-    imageUrl: '/template-assets/light-working-horizontal-2.png',
+    imageUrl: BP + '/template-assets/light-working-horizontal-2.png',
   },
   {
     id: '4',
@@ -63,7 +69,7 @@ const ITEMS: LibraryItem[] = [
     description: 'Centers its child both horizontally and vertically.',
     category: 'Layout',
     type: 'Utility',
-    imageUrl: '/template-assets/moody-scene-horizontal-1.png',
+    imageUrl: BP + '/template-assets/moody-scene-horizontal-1.png',
   },
   {
     id: '5',
@@ -71,7 +77,7 @@ const ITEMS: LibraryItem[] = [
     description: 'Semantic page section with optional heading and divider.',
     category: 'Layout',
     type: 'Pattern',
-    imageUrl: '/template-assets/colorful-lifestyle-horizontal-2.png',
+    imageUrl: BP + '/template-assets/colorful-lifestyle-horizontal-2.png',
   },
   {
     id: '6',
@@ -79,7 +85,7 @@ const ITEMS: LibraryItem[] = [
     description: 'Expandable region with animated height transition.',
     category: 'Layout',
     type: 'Component',
-    imageUrl: '/template-assets/light-scene-horizontal-1.png',
+    imageUrl: BP + '/template-assets/light-scene-horizontal-1.png',
   },
   {
     id: '7',
@@ -88,7 +94,7 @@ const ITEMS: LibraryItem[] = [
       'Single-line text field with label, placeholder, and validation states.',
     category: 'Forms',
     type: 'Component',
-    imageUrl: '/template-assets/moody-working-horizontal-1.png',
+    imageUrl: BP + '/template-assets/moody-working-horizontal-1.png',
   },
   {
     id: '8',
@@ -96,7 +102,7 @@ const ITEMS: LibraryItem[] = [
     description: 'Multi-line text field with auto-resize and character count.',
     category: 'Forms',
     type: 'Component',
-    imageUrl: '/template-assets/colorful-working-horizontal-3.png',
+    imageUrl: BP + '/template-assets/colorful-working-horizontal-3.png',
   },
   {
     id: '9',
@@ -104,7 +110,7 @@ const ITEMS: LibraryItem[] = [
     description: 'Checkbox with label, indeterminate state, and group support.',
     category: 'Forms',
     type: 'Component',
-    imageUrl: '/template-assets/illustrative-horizontal-1.jpg',
+    imageUrl: BP + '/template-assets/illustrative-horizontal-1.jpg',
   },
   {
     id: '10',
@@ -112,7 +118,7 @@ const ITEMS: LibraryItem[] = [
     description: 'Group of radio buttons with accessible fieldset wrapper.',
     category: 'Forms',
     type: 'Component',
-    imageUrl: '/template-assets/light-home-horizontal-1.png',
+    imageUrl: BP + '/template-assets/light-home-horizontal-1.png',
   },
   {
     id: '11',
@@ -120,7 +126,7 @@ const ITEMS: LibraryItem[] = [
     description: 'Toggle switch for binary on/off settings.',
     category: 'Forms',
     type: 'Component',
-    imageUrl: '/template-assets/moody-home-horizontal-2.png',
+    imageUrl: BP + '/template-assets/moody-home-horizontal-2.png',
   },
   {
     id: '12',
@@ -129,7 +135,7 @@ const ITEMS: LibraryItem[] = [
       'Dropdown or inline option selector with single and multi-select modes.',
     category: 'Forms',
     type: 'Component',
-    imageUrl: '/template-assets/colorful-product-1.png',
+    imageUrl: BP + '/template-assets/colorful-product-1.png',
   },
   {
     id: '13',
@@ -138,7 +144,7 @@ const ITEMS: LibraryItem[] = [
       'Horizontal tab navigation with underline indicator and keyboard support.',
     category: 'Navigation',
     type: 'Component',
-    imageUrl: '/template-assets/illustrative-horizontal-5.jpg',
+    imageUrl: BP + '/template-assets/illustrative-horizontal-5.jpg',
   },
   {
     id: '14',
@@ -146,7 +152,7 @@ const ITEMS: LibraryItem[] = [
     description: 'Application top bar with logo, nav links, and action slots.',
     category: 'Navigation',
     type: 'Pattern',
-    imageUrl: '/template-assets/light-working-horizontal-1.png',
+    imageUrl: BP + '/template-assets/light-working-horizontal-1.png',
   },
   {
     id: '15',
@@ -155,7 +161,7 @@ const ITEMS: LibraryItem[] = [
       'Vertical sidebar navigation with collapsible groups and active states.',
     category: 'Navigation',
     type: 'Pattern',
-    imageUrl: '/template-assets/moody-lifestyle-horizontal-1.png',
+    imageUrl: BP + '/template-assets/moody-lifestyle-horizontal-1.png',
   },
   {
     id: '16',
@@ -163,7 +169,7 @@ const ITEMS: LibraryItem[] = [
     description: 'Path trail navigation with separator and truncation support.',
     category: 'Navigation',
     type: 'Component',
-    imageUrl: '/template-assets/colorful-home-horizontal-2.png',
+    imageUrl: BP + '/template-assets/colorful-home-horizontal-2.png',
   },
   {
     id: '17',
@@ -172,7 +178,7 @@ const ITEMS: LibraryItem[] = [
       'Page navigation with prev/next controls and page count display.',
     category: 'Navigation',
     type: 'Component',
-    imageUrl: '/template-assets/colorful-working-horizontal-1.png',
+    imageUrl: BP + '/template-assets/colorful-working-horizontal-1.png',
   },
   {
     id: '18',
@@ -181,7 +187,7 @@ const ITEMS: LibraryItem[] = [
       'Bottom tab bar for mobile viewports with icon and label slots.',
     category: 'Navigation',
     type: 'Pattern',
-    imageUrl: '/template-assets/light-working-horizontal-3.png',
+    imageUrl: BP + '/template-assets/light-working-horizontal-3.png',
   },
   {
     id: '19',
@@ -190,7 +196,7 @@ const ITEMS: LibraryItem[] = [
       'Compact label for status, count, or category with semantic color variants.',
     category: 'Feedback',
     type: 'Component',
-    imageUrl: '/template-assets/moody-working-horizontal-2.png',
+    imageUrl: BP + '/template-assets/moody-working-horizontal-2.png',
   },
   {
     id: '20',
@@ -199,7 +205,7 @@ const ITEMS: LibraryItem[] = [
       'Full-width alert bar for info, success, warning, and error messages.',
     category: 'Feedback',
     type: 'Component',
-    imageUrl: '/template-assets/illustrative-horizontal-2.jpg',
+    imageUrl: BP + '/template-assets/illustrative-horizontal-2.jpg',
   },
   {
     id: '21',
@@ -207,7 +213,7 @@ const ITEMS: LibraryItem[] = [
     description: 'Animated loading indicator with size and color variants.',
     category: 'Feedback',
     type: 'Component',
-    imageUrl: '/template-assets/colorful-lifestyle-horizontal-1.png',
+    imageUrl: BP + '/template-assets/colorful-lifestyle-horizontal-1.png',
   },
   {
     id: '22',
@@ -215,7 +221,7 @@ const ITEMS: LibraryItem[] = [
     description: 'Horizontal bar indicating task completion percentage.',
     category: 'Feedback',
     type: 'Component',
-    imageUrl: '/template-assets/light-lifestyle-horizontal-1.png',
+    imageUrl: BP + '/template-assets/light-lifestyle-horizontal-1.png',
   },
   {
     id: '23',
@@ -224,7 +230,7 @@ const ITEMS: LibraryItem[] = [
       'Small dot indicator for presence, health, or pipeline status.',
     category: 'Feedback',
     type: 'Component',
-    imageUrl: '/template-assets/moody-home-horizontal-1.png',
+    imageUrl: BP + '/template-assets/moody-home-horizontal-1.png',
   },
   {
     id: '24',
@@ -233,7 +239,7 @@ const ITEMS: LibraryItem[] = [
       'Contextual label that appears on hover with configurable placement.',
     category: 'Feedback',
     type: 'Component',
-    imageUrl: '/template-assets/colorful-working-horizontal-2.png',
+    imageUrl: BP + '/template-assets/colorful-working-horizontal-2.png',
   },
   {
     id: '25',
@@ -242,7 +248,7 @@ const ITEMS: LibraryItem[] = [
       'Feature-rich data table with sorting, selection, and column resizing.',
     category: 'Data',
     type: 'Component',
-    imageUrl: '/template-assets/illustrative-horizontal-4.jpg',
+    imageUrl: BP + '/template-assets/illustrative-horizontal-4.jpg',
   },
   {
     id: '26',
@@ -251,7 +257,7 @@ const ITEMS: LibraryItem[] = [
       'User profile image with fallback initials and status dot support.',
     category: 'Data',
     type: 'Component',
-    imageUrl: '/template-assets/light-working-horizontal-4.png',
+    imageUrl: BP + '/template-assets/light-working-horizontal-4.png',
   },
   {
     id: '27',
@@ -260,7 +266,7 @@ const ITEMS: LibraryItem[] = [
       'Placeholder shimmer for loading states matching content shapes.',
     category: 'Data',
     type: 'Utility',
-    imageUrl: '/template-assets/moody-lifestyle-horizontal-2.png',
+    imageUrl: BP + '/template-assets/moody-lifestyle-horizontal-2.png',
   },
   {
     id: '28',
@@ -268,7 +274,7 @@ const ITEMS: LibraryItem[] = [
     description: 'Rich popover that appears on hover with arbitrary content.',
     category: 'Data',
     type: 'Component',
-    imageUrl: '/template-assets/moody-scene-horizontal-2.png',
+    imageUrl: BP + '/template-assets/moody-scene-horizontal-2.png',
   },
   {
     id: '29',
@@ -277,7 +283,7 @@ const ITEMS: LibraryItem[] = [
       'Command-palette style search with grouped results and keyboard nav.',
     category: 'Data',
     type: 'Pattern',
-    imageUrl: '/template-assets/colorful-product-2.png',
+    imageUrl: BP + '/template-assets/colorful-product-2.png',
   },
   {
     id: '30',
@@ -286,7 +292,7 @@ const ITEMS: LibraryItem[] = [
       'Autocomplete input with async suggestion loading and selection.',
     category: 'Data',
     type: 'Component',
-    imageUrl: '/template-assets/moody-working-horizontal-3.png',
+    imageUrl: BP + '/template-assets/moody-working-horizontal-3.png',
   },
 ];
 

--- a/packages/cli/templates/pages/library/page.tsx
+++ b/packages/cli/templates/pages/library/page.tsx
@@ -22,7 +22,8 @@ import {MagnifyingGlassIcon} from '@heroicons/react/24/outline';
 // root). In the sandbox preview it picks up `/sandbox` so /template-assets/*
 // resolves under the GH Pages basePath. The CLI swaps these paths for an
 // inline placeholder on scaffold, so end users never see them.
-const BP = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
+const BP =
+  (typeof process !== 'undefined' && process.env?.NEXT_PUBLIC_BASE_PATH) || '';
 
 interface LibraryItem {
   id: string;

--- a/packages/cli/templates/pages/library/page.tsx
+++ b/packages/cli/templates/pages/library/page.tsx
@@ -23,7 +23,7 @@ import {MagnifyingGlassIcon} from '@heroicons/react/24/outline';
 // resolves under the GH Pages basePath. The CLI swaps these paths for an
 // inline placeholder on scaffold, so end users never see them.
 const BP =
-  (typeof process !== 'undefined' && process.env?.NEXT_PUBLIC_BASE_PATH) || '';
+  (typeof process !== 'undefined' && process.env.NEXT_PUBLIC_BASE_PATH) || '';
 
 interface LibraryItem {
   id: string;

--- a/packages/cli/templates/pages/library/page.tsx
+++ b/packages/cli/templates/pages/library/page.tsx
@@ -18,11 +18,7 @@ import {XDSOverflowList} from '@xds/core/OverflowList';
 import {XDSCenter} from '@xds/core/Center';
 import {MagnifyingGlassIcon} from '@heroicons/react/24/outline';
 
-// Optional basePath. Empty in end-user projects and the docsite (served at
-// root). In the sandbox preview it picks up `/sandbox` so /template-assets/*
-// resolves under the GH Pages basePath. The CLI swaps these paths for an
-// inline placeholder on scaffold, so end users never see them.
-const BP =
+const basePath =
   (typeof process !== 'undefined' && process.env.NEXT_PUBLIC_BASE_PATH) || '';
 
 interface LibraryItem {
@@ -44,7 +40,7 @@ const ITEMS: LibraryItem[] = [
       'Vertical and horizontal stack layouts with configurable gap and alignment.',
     category: 'Layout',
     type: 'Component',
-    imageUrl: BP + '/template-assets/colorful-home-horizontal-1.png',
+    imageUrl: basePath + '/template-assets/colorful-home-horizontal-1.png',
   },
   {
     id: '2',
@@ -53,7 +49,7 @@ const ITEMS: LibraryItem[] = [
       'Responsive grid container with auto-fit columns and gap control.',
     category: 'Layout',
     type: 'Component',
-    imageUrl: BP + '/template-assets/illustrative-horizontal-3.jpg',
+    imageUrl: basePath + '/template-assets/illustrative-horizontal-3.jpg',
   },
   {
     id: '3',
@@ -62,7 +58,7 @@ const ITEMS: LibraryItem[] = [
       'Surface container with optional padding, border, and shadow variants.',
     category: 'Layout',
     type: 'Component',
-    imageUrl: BP + '/template-assets/light-working-horizontal-2.png',
+    imageUrl: basePath + '/template-assets/light-working-horizontal-2.png',
   },
   {
     id: '4',
@@ -70,7 +66,7 @@ const ITEMS: LibraryItem[] = [
     description: 'Centers its child both horizontally and vertically.',
     category: 'Layout',
     type: 'Utility',
-    imageUrl: BP + '/template-assets/moody-scene-horizontal-1.png',
+    imageUrl: basePath + '/template-assets/moody-scene-horizontal-1.png',
   },
   {
     id: '5',
@@ -78,7 +74,7 @@ const ITEMS: LibraryItem[] = [
     description: 'Semantic page section with optional heading and divider.',
     category: 'Layout',
     type: 'Pattern',
-    imageUrl: BP + '/template-assets/colorful-lifestyle-horizontal-2.png',
+    imageUrl: basePath + '/template-assets/colorful-lifestyle-horizontal-2.png',
   },
   {
     id: '6',
@@ -86,7 +82,7 @@ const ITEMS: LibraryItem[] = [
     description: 'Expandable region with animated height transition.',
     category: 'Layout',
     type: 'Component',
-    imageUrl: BP + '/template-assets/light-scene-horizontal-1.png',
+    imageUrl: basePath + '/template-assets/light-scene-horizontal-1.png',
   },
   {
     id: '7',
@@ -95,7 +91,7 @@ const ITEMS: LibraryItem[] = [
       'Single-line text field with label, placeholder, and validation states.',
     category: 'Forms',
     type: 'Component',
-    imageUrl: BP + '/template-assets/moody-working-horizontal-1.png',
+    imageUrl: basePath + '/template-assets/moody-working-horizontal-1.png',
   },
   {
     id: '8',
@@ -103,7 +99,7 @@ const ITEMS: LibraryItem[] = [
     description: 'Multi-line text field with auto-resize and character count.',
     category: 'Forms',
     type: 'Component',
-    imageUrl: BP + '/template-assets/colorful-working-horizontal-3.png',
+    imageUrl: basePath + '/template-assets/colorful-working-horizontal-3.png',
   },
   {
     id: '9',
@@ -111,7 +107,7 @@ const ITEMS: LibraryItem[] = [
     description: 'Checkbox with label, indeterminate state, and group support.',
     category: 'Forms',
     type: 'Component',
-    imageUrl: BP + '/template-assets/illustrative-horizontal-1.jpg',
+    imageUrl: basePath + '/template-assets/illustrative-horizontal-1.jpg',
   },
   {
     id: '10',
@@ -119,7 +115,7 @@ const ITEMS: LibraryItem[] = [
     description: 'Group of radio buttons with accessible fieldset wrapper.',
     category: 'Forms',
     type: 'Component',
-    imageUrl: BP + '/template-assets/light-home-horizontal-1.png',
+    imageUrl: basePath + '/template-assets/light-home-horizontal-1.png',
   },
   {
     id: '11',
@@ -127,7 +123,7 @@ const ITEMS: LibraryItem[] = [
     description: 'Toggle switch for binary on/off settings.',
     category: 'Forms',
     type: 'Component',
-    imageUrl: BP + '/template-assets/moody-home-horizontal-2.png',
+    imageUrl: basePath + '/template-assets/moody-home-horizontal-2.png',
   },
   {
     id: '12',
@@ -136,7 +132,7 @@ const ITEMS: LibraryItem[] = [
       'Dropdown or inline option selector with single and multi-select modes.',
     category: 'Forms',
     type: 'Component',
-    imageUrl: BP + '/template-assets/colorful-product-1.png',
+    imageUrl: basePath + '/template-assets/colorful-product-1.png',
   },
   {
     id: '13',
@@ -145,7 +141,7 @@ const ITEMS: LibraryItem[] = [
       'Horizontal tab navigation with underline indicator and keyboard support.',
     category: 'Navigation',
     type: 'Component',
-    imageUrl: BP + '/template-assets/illustrative-horizontal-5.jpg',
+    imageUrl: basePath + '/template-assets/illustrative-horizontal-5.jpg',
   },
   {
     id: '14',
@@ -153,7 +149,7 @@ const ITEMS: LibraryItem[] = [
     description: 'Application top bar with logo, nav links, and action slots.',
     category: 'Navigation',
     type: 'Pattern',
-    imageUrl: BP + '/template-assets/light-working-horizontal-1.png',
+    imageUrl: basePath + '/template-assets/light-working-horizontal-1.png',
   },
   {
     id: '15',
@@ -162,7 +158,7 @@ const ITEMS: LibraryItem[] = [
       'Vertical sidebar navigation with collapsible groups and active states.',
     category: 'Navigation',
     type: 'Pattern',
-    imageUrl: BP + '/template-assets/moody-lifestyle-horizontal-1.png',
+    imageUrl: basePath + '/template-assets/moody-lifestyle-horizontal-1.png',
   },
   {
     id: '16',
@@ -170,7 +166,7 @@ const ITEMS: LibraryItem[] = [
     description: 'Path trail navigation with separator and truncation support.',
     category: 'Navigation',
     type: 'Component',
-    imageUrl: BP + '/template-assets/colorful-home-horizontal-2.png',
+    imageUrl: basePath + '/template-assets/colorful-home-horizontal-2.png',
   },
   {
     id: '17',
@@ -179,7 +175,7 @@ const ITEMS: LibraryItem[] = [
       'Page navigation with prev/next controls and page count display.',
     category: 'Navigation',
     type: 'Component',
-    imageUrl: BP + '/template-assets/colorful-working-horizontal-1.png',
+    imageUrl: basePath + '/template-assets/colorful-working-horizontal-1.png',
   },
   {
     id: '18',
@@ -188,7 +184,7 @@ const ITEMS: LibraryItem[] = [
       'Bottom tab bar for mobile viewports with icon and label slots.',
     category: 'Navigation',
     type: 'Pattern',
-    imageUrl: BP + '/template-assets/light-working-horizontal-3.png',
+    imageUrl: basePath + '/template-assets/light-working-horizontal-3.png',
   },
   {
     id: '19',
@@ -197,7 +193,7 @@ const ITEMS: LibraryItem[] = [
       'Compact label for status, count, or category with semantic color variants.',
     category: 'Feedback',
     type: 'Component',
-    imageUrl: BP + '/template-assets/moody-working-horizontal-2.png',
+    imageUrl: basePath + '/template-assets/moody-working-horizontal-2.png',
   },
   {
     id: '20',
@@ -206,7 +202,7 @@ const ITEMS: LibraryItem[] = [
       'Full-width alert bar for info, success, warning, and error messages.',
     category: 'Feedback',
     type: 'Component',
-    imageUrl: BP + '/template-assets/illustrative-horizontal-2.jpg',
+    imageUrl: basePath + '/template-assets/illustrative-horizontal-2.jpg',
   },
   {
     id: '21',
@@ -214,7 +210,7 @@ const ITEMS: LibraryItem[] = [
     description: 'Animated loading indicator with size and color variants.',
     category: 'Feedback',
     type: 'Component',
-    imageUrl: BP + '/template-assets/colorful-lifestyle-horizontal-1.png',
+    imageUrl: basePath + '/template-assets/colorful-lifestyle-horizontal-1.png',
   },
   {
     id: '22',
@@ -222,7 +218,7 @@ const ITEMS: LibraryItem[] = [
     description: 'Horizontal bar indicating task completion percentage.',
     category: 'Feedback',
     type: 'Component',
-    imageUrl: BP + '/template-assets/light-lifestyle-horizontal-1.png',
+    imageUrl: basePath + '/template-assets/light-lifestyle-horizontal-1.png',
   },
   {
     id: '23',
@@ -231,7 +227,7 @@ const ITEMS: LibraryItem[] = [
       'Small dot indicator for presence, health, or pipeline status.',
     category: 'Feedback',
     type: 'Component',
-    imageUrl: BP + '/template-assets/moody-home-horizontal-1.png',
+    imageUrl: basePath + '/template-assets/moody-home-horizontal-1.png',
   },
   {
     id: '24',
@@ -240,7 +236,7 @@ const ITEMS: LibraryItem[] = [
       'Contextual label that appears on hover with configurable placement.',
     category: 'Feedback',
     type: 'Component',
-    imageUrl: BP + '/template-assets/colorful-working-horizontal-2.png',
+    imageUrl: basePath + '/template-assets/colorful-working-horizontal-2.png',
   },
   {
     id: '25',
@@ -249,7 +245,7 @@ const ITEMS: LibraryItem[] = [
       'Feature-rich data table with sorting, selection, and column resizing.',
     category: 'Data',
     type: 'Component',
-    imageUrl: BP + '/template-assets/illustrative-horizontal-4.jpg',
+    imageUrl: basePath + '/template-assets/illustrative-horizontal-4.jpg',
   },
   {
     id: '26',
@@ -258,7 +254,7 @@ const ITEMS: LibraryItem[] = [
       'User profile image with fallback initials and status dot support.',
     category: 'Data',
     type: 'Component',
-    imageUrl: BP + '/template-assets/light-working-horizontal-4.png',
+    imageUrl: basePath + '/template-assets/light-working-horizontal-4.png',
   },
   {
     id: '27',
@@ -267,7 +263,7 @@ const ITEMS: LibraryItem[] = [
       'Placeholder shimmer for loading states matching content shapes.',
     category: 'Data',
     type: 'Utility',
-    imageUrl: BP + '/template-assets/moody-lifestyle-horizontal-2.png',
+    imageUrl: basePath + '/template-assets/moody-lifestyle-horizontal-2.png',
   },
   {
     id: '28',
@@ -275,7 +271,7 @@ const ITEMS: LibraryItem[] = [
     description: 'Rich popover that appears on hover with arbitrary content.',
     category: 'Data',
     type: 'Component',
-    imageUrl: BP + '/template-assets/moody-scene-horizontal-2.png',
+    imageUrl: basePath + '/template-assets/moody-scene-horizontal-2.png',
   },
   {
     id: '29',
@@ -284,7 +280,7 @@ const ITEMS: LibraryItem[] = [
       'Command-palette style search with grouped results and keyboard nav.',
     category: 'Data',
     type: 'Pattern',
-    imageUrl: BP + '/template-assets/colorful-product-2.png',
+    imageUrl: basePath + '/template-assets/colorful-product-2.png',
   },
   {
     id: '30',
@@ -293,7 +289,7 @@ const ITEMS: LibraryItem[] = [
       'Autocomplete input with async suggestion loading and selection.',
     category: 'Data',
     type: 'Component',
-    imageUrl: BP + '/template-assets/moody-working-horizontal-3.png',
+    imageUrl: basePath + '/template-assets/moody-working-horizontal-3.png',
   },
 ];
 

--- a/packages/cli/templates/pages/login-split/page.tsx
+++ b/packages/cli/templates/pages/login-split/page.tsx
@@ -22,15 +22,12 @@ import {
   radiusVars,
 } from '@xds/core/theme/tokens.stylex';
 
-// Optional basePath. Empty in end-user projects and the docsite (served at
-// root). In the sandbox preview it picks up `/sandbox` so /template-assets/*
-// resolves under the GH Pages basePath. The CLI swaps these paths for an
-// inline placeholder on scaffold, so end users never see them.
-const BP =
+const basePath =
   (typeof process !== 'undefined' && process.env.NEXT_PUBLIC_BASE_PATH) || '';
 
 // light-working-vertical-1 from xds_oss asset set
-const COVER_IMAGE_URL = BP + '/template-assets/light-working-vertical-1.png';
+const COVER_IMAGE_URL =
+  basePath + '/template-assets/light-working-vertical-1.png';
 
 const AppleIcon = (props: React.SVGProps<SVGSVGElement>) => (
   <svg

--- a/packages/cli/templates/pages/login-split/page.tsx
+++ b/packages/cli/templates/pages/login-split/page.tsx
@@ -27,7 +27,7 @@ import {
 // resolves under the GH Pages basePath. The CLI swaps these paths for an
 // inline placeholder on scaffold, so end users never see them.
 const BP =
-  (typeof process !== 'undefined' && process.env?.NEXT_PUBLIC_BASE_PATH) || '';
+  (typeof process !== 'undefined' && process.env.NEXT_PUBLIC_BASE_PATH) || '';
 
 // light-working-vertical-1 from xds_oss asset set
 const COVER_IMAGE_URL = BP + '/template-assets/light-working-vertical-1.png';

--- a/packages/cli/templates/pages/login-split/page.tsx
+++ b/packages/cli/templates/pages/login-split/page.tsx
@@ -26,7 +26,8 @@ import {
 // root). In the sandbox preview it picks up `/sandbox` so /template-assets/*
 // resolves under the GH Pages basePath. The CLI swaps these paths for an
 // inline placeholder on scaffold, so end users never see them.
-const BP = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
+const BP =
+  (typeof process !== 'undefined' && process.env?.NEXT_PUBLIC_BASE_PATH) || '';
 
 // light-working-vertical-1 from xds_oss asset set
 const COVER_IMAGE_URL = BP + '/template-assets/light-working-vertical-1.png';

--- a/packages/cli/templates/pages/login-split/page.tsx
+++ b/packages/cli/templates/pages/login-split/page.tsx
@@ -22,8 +22,14 @@ import {
   radiusVars,
 } from '@xds/core/theme/tokens.stylex';
 
+// Optional basePath. Empty in end-user projects and the docsite (served at
+// root). In the sandbox preview it picks up `/sandbox` so /template-assets/*
+// resolves under the GH Pages basePath. The CLI swaps these paths for an
+// inline placeholder on scaffold, so end users never see them.
+const BP = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
+
 // light-working-vertical-1 from xds_oss asset set
-const COVER_IMAGE_URL = '/template-assets/light-working-vertical-1.png';
+const COVER_IMAGE_URL = BP + '/template-assets/light-working-vertical-1.png';
 
 const AppleIcon = (props: React.SVGProps<SVGSVGElement>) => (
   <svg

--- a/packages/cli/templates/pages/login-sso/page.tsx
+++ b/packages/cli/templates/pages/login-sso/page.tsx
@@ -22,7 +22,7 @@ import {XDSAvatar} from '@xds/core/Avatar';
 // resolves under the GH Pages basePath. The CLI swaps these paths for an
 // inline placeholder on scaffold, so end users never see them.
 const BP =
-  (typeof process !== 'undefined' && process.env?.NEXT_PUBLIC_BASE_PATH) || '';
+  (typeof process !== 'undefined' && process.env.NEXT_PUBLIC_BASE_PATH) || '';
 
 // ---------------------------------------------------------------------------
 // Styles

--- a/packages/cli/templates/pages/login-sso/page.tsx
+++ b/packages/cli/templates/pages/login-sso/page.tsx
@@ -25,14 +25,14 @@ const basePath =
 // ---------------------------------------------------------------------------
 
 // building from xds_oss asset set
-const BG_URL = basePath + '/template-assets/building.jpg';
+const BG_PATH = '/template-assets/building.jpg';
 
 const styles = stylex.create({
-  page: {
-    backgroundImage: `url(${BG_URL})`,
+  page: (url: string) => ({
+    backgroundImage: `url(${url})`,
     backgroundSize: 'cover',
     backgroundPosition: 'center',
-  },
+  }),
 });
 
 type SSOProvider = {
@@ -103,7 +103,10 @@ export default function LoginSSO() {
   };
 
   return (
-    <XDSCenter axis="both" height="100dvh" xstyle={styles.page}>
+    <XDSCenter
+      axis="both"
+      height="100dvh"
+      xstyle={styles.page(basePath + BG_PATH)}>
       <XDSCard padding={8} width={400}>
         <XDSVStack gap={4} hAlign="stretch">
           {/* ── Step 1: Email entry ── */}

--- a/packages/cli/templates/pages/login-sso/page.tsx
+++ b/packages/cli/templates/pages/login-sso/page.tsx
@@ -21,7 +21,8 @@ import {XDSAvatar} from '@xds/core/Avatar';
 // root). In the sandbox preview it picks up `/sandbox` so /template-assets/*
 // resolves under the GH Pages basePath. The CLI swaps these paths for an
 // inline placeholder on scaffold, so end users never see them.
-const BP = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
+const BP =
+  (typeof process !== 'undefined' && process.env?.NEXT_PUBLIC_BASE_PATH) || '';
 
 // ---------------------------------------------------------------------------
 // Styles

--- a/packages/cli/templates/pages/login-sso/page.tsx
+++ b/packages/cli/templates/pages/login-sso/page.tsx
@@ -17,12 +17,18 @@ import {XDSDivider} from '@xds/core/Divider';
 import {XDSIcon} from '@xds/core/Icon';
 import {XDSAvatar} from '@xds/core/Avatar';
 
+// Optional basePath. Empty in end-user projects and the docsite (served at
+// root). In the sandbox preview it picks up `/sandbox` so /template-assets/*
+// resolves under the GH Pages basePath. The CLI swaps these paths for an
+// inline placeholder on scaffold, so end users never see them.
+const BP = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
+
 // ---------------------------------------------------------------------------
 // Styles
 // ---------------------------------------------------------------------------
 
 // building from xds_oss asset set
-const BG_URL = '/template-assets/building.jpg';
+const BG_URL = BP + '/template-assets/building.jpg';
 
 const styles = stylex.create({
   page: {

--- a/packages/cli/templates/pages/login-sso/page.tsx
+++ b/packages/cli/templates/pages/login-sso/page.tsx
@@ -17,11 +17,7 @@ import {XDSDivider} from '@xds/core/Divider';
 import {XDSIcon} from '@xds/core/Icon';
 import {XDSAvatar} from '@xds/core/Avatar';
 
-// Optional basePath. Empty in end-user projects and the docsite (served at
-// root). In the sandbox preview it picks up `/sandbox` so /template-assets/*
-// resolves under the GH Pages basePath. The CLI swaps these paths for an
-// inline placeholder on scaffold, so end users never see them.
-const BP =
+const basePath =
   (typeof process !== 'undefined' && process.env.NEXT_PUBLIC_BASE_PATH) || '';
 
 // ---------------------------------------------------------------------------
@@ -29,7 +25,7 @@ const BP =
 // ---------------------------------------------------------------------------
 
 // building from xds_oss asset set
-const BG_URL = BP + '/template-assets/building.jpg';
+const BG_URL = basePath + '/template-assets/building.jpg';
 
 const styles = stylex.create({
   page: {

--- a/packages/cli/templates/pages/mixed-gallery/page.tsx
+++ b/packages/cli/templates/pages/mixed-gallery/page.tsx
@@ -7,6 +7,12 @@ import {XDSText, XDSHeading} from '@xds/core/Text';
 import {XDSAspectRatio} from '@xds/core/AspectRatio';
 import * as stylex from '@stylexjs/stylex';
 
+// Optional basePath. Empty in end-user projects and the docsite (served at
+// root). In the sandbox preview it picks up `/sandbox` so /template-assets/*
+// resolves under the GH Pages basePath. The CLI swaps these paths for an
+// inline placeholder on scaffold, so end users never see them.
+const BP = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
+
 // ─── Styles ────────────────────────────────────────────────────────────────
 // The masonry needs a responsive column count AND a hero that spans 2 columns
 // on desktop but goes full-width on mobile. XDSGrid forces grid-template-columns
@@ -62,27 +68,27 @@ interface GalleryImage {
 const IMAGES: GalleryImage[] = [
   {
     // illustrative-horizontal-1 from xds_oss asset set
-    src: '/template-assets/illustrative-horizontal-1.jpg',
+    src: BP + '/template-assets/illustrative-horizontal-1.jpg',
     title: 'Going places',
   },
   {
     // light-home-horizontal-1 from xds_oss asset set
-    src: '/template-assets/light-home-horizontal-1.png',
+    src: BP + '/template-assets/light-home-horizontal-1.png',
     title: 'Making memories',
   },
   {
     // light-lifestyle-horizontal-1 from xds_oss asset set
-    src: '/template-assets/light-lifestyle-horizontal-1.png',
+    src: BP + '/template-assets/light-lifestyle-horizontal-1.png',
     title: 'Being free',
   },
   {
     // light-working-horizontal-2 from xds_oss asset set
-    src: '/template-assets/light-working-horizontal-2.png',
+    src: BP + '/template-assets/light-working-horizontal-2.png',
     title: 'Getting it done',
   },
   {
     // light-scene-horizontal-1 from xds_oss asset set
-    src: '/template-assets/light-scene-horizontal-1.png',
+    src: BP + '/template-assets/light-scene-horizontal-1.png',
     title: 'Finding calm',
   },
 ];

--- a/packages/cli/templates/pages/mixed-gallery/page.tsx
+++ b/packages/cli/templates/pages/mixed-gallery/page.tsx
@@ -11,7 +11,8 @@ import * as stylex from '@stylexjs/stylex';
 // root). In the sandbox preview it picks up `/sandbox` so /template-assets/*
 // resolves under the GH Pages basePath. The CLI swaps these paths for an
 // inline placeholder on scaffold, so end users never see them.
-const BP = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
+const BP =
+  (typeof process !== 'undefined' && process.env?.NEXT_PUBLIC_BASE_PATH) || '';
 
 // ─── Styles ────────────────────────────────────────────────────────────────
 // The masonry needs a responsive column count AND a hero that spans 2 columns

--- a/packages/cli/templates/pages/mixed-gallery/page.tsx
+++ b/packages/cli/templates/pages/mixed-gallery/page.tsx
@@ -12,7 +12,7 @@ import * as stylex from '@stylexjs/stylex';
 // resolves under the GH Pages basePath. The CLI swaps these paths for an
 // inline placeholder on scaffold, so end users never see them.
 const BP =
-  (typeof process !== 'undefined' && process.env?.NEXT_PUBLIC_BASE_PATH) || '';
+  (typeof process !== 'undefined' && process.env.NEXT_PUBLIC_BASE_PATH) || '';
 
 // ─── Styles ────────────────────────────────────────────────────────────────
 // The masonry needs a responsive column count AND a hero that spans 2 columns

--- a/packages/cli/templates/pages/mixed-gallery/page.tsx
+++ b/packages/cli/templates/pages/mixed-gallery/page.tsx
@@ -7,11 +7,7 @@ import {XDSText, XDSHeading} from '@xds/core/Text';
 import {XDSAspectRatio} from '@xds/core/AspectRatio';
 import * as stylex from '@stylexjs/stylex';
 
-// Optional basePath. Empty in end-user projects and the docsite (served at
-// root). In the sandbox preview it picks up `/sandbox` so /template-assets/*
-// resolves under the GH Pages basePath. The CLI swaps these paths for an
-// inline placeholder on scaffold, so end users never see them.
-const BP =
+const basePath =
   (typeof process !== 'undefined' && process.env.NEXT_PUBLIC_BASE_PATH) || '';
 
 // ─── Styles ────────────────────────────────────────────────────────────────
@@ -69,27 +65,27 @@ interface GalleryImage {
 const IMAGES: GalleryImage[] = [
   {
     // illustrative-horizontal-1 from xds_oss asset set
-    src: BP + '/template-assets/illustrative-horizontal-1.jpg',
+    src: basePath + '/template-assets/illustrative-horizontal-1.jpg',
     title: 'Going places',
   },
   {
     // light-home-horizontal-1 from xds_oss asset set
-    src: BP + '/template-assets/light-home-horizontal-1.png',
+    src: basePath + '/template-assets/light-home-horizontal-1.png',
     title: 'Making memories',
   },
   {
     // light-lifestyle-horizontal-1 from xds_oss asset set
-    src: BP + '/template-assets/light-lifestyle-horizontal-1.png',
+    src: basePath + '/template-assets/light-lifestyle-horizontal-1.png',
     title: 'Being free',
   },
   {
     // light-working-horizontal-2 from xds_oss asset set
-    src: BP + '/template-assets/light-working-horizontal-2.png',
+    src: basePath + '/template-assets/light-working-horizontal-2.png',
     title: 'Getting it done',
   },
   {
     // light-scene-horizontal-1 from xds_oss asset set
-    src: BP + '/template-assets/light-scene-horizontal-1.png',
+    src: basePath + '/template-assets/light-scene-horizontal-1.png',
     title: 'Finding calm',
   },
 ];

--- a/packages/cli/templates/pages/payment-form/page.tsx
+++ b/packages/cli/templates/pages/payment-form/page.tsx
@@ -114,12 +114,16 @@ const US_STATES = [
   'Wyoming',
 ];
 
-// Product photos from the local template-assets set (committed to the
-// docsite; the CLI swaps these for an inline placeholder on scaffold).
+// Optional basePath. Empty in end-user projects and the docsite (served at
+// root). In the sandbox preview it picks up `/sandbox` so /template-assets/*
+// resolves under the GH Pages basePath. The CLI swaps these paths for an
+// inline placeholder on scaffold, so end users never see them.
+const BP = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
+
 const ITEM_IMAGES: Record<string, {src: string}> = {
-  '1': {src: '/template-assets/light-product-1.png'},
-  '2': {src: '/template-assets/light-product-4.png'},
-  '3': {src: '/template-assets/light-product-5.png'},
+  '1': {src: BP + '/template-assets/light-product-1.png'},
+  '2': {src: BP + '/template-assets/light-product-4.png'},
+  '3': {src: BP + '/template-assets/light-product-5.png'},
 };
 
 const ORDER_ITEMS = [
@@ -511,7 +515,7 @@ export default function PaymentFormPage() {
                               onClick={() => {}}
                               xstyle={styles.paypalButton}>
                               <img
-                                src="/template-assets/paypal-logo.png"
+                                src={BP + '/template-assets/paypal-logo.png'}
                                 alt="PayPal"
                                 {...stylex.props(styles.paypalLogo)}
                               />
@@ -524,7 +528,10 @@ export default function PaymentFormPage() {
                               onClick={() => {}}
                               xstyle={styles.gpayButton}>
                               <img
-                                src="/template-assets/google-pay-logo-dark.svg"
+                                src={
+                                  BP +
+                                  '/template-assets/google-pay-logo-dark.svg'
+                                }
                                 alt="Google Pay"
                                 {...stylex.props(styles.gpayLogo)}
                               />
@@ -550,17 +557,17 @@ export default function PaymentFormPage() {
                           {/* Card type icons */}
                           <XDSHStack gap={1.5} vAlign="center">
                             <img
-                              src="/template-assets/visa.svg"
+                              src={BP + '/template-assets/visa.svg'}
                               alt="Visa"
                               {...stylex.props(styles.cardLogo)}
                             />
                             <img
-                              src="/template-assets/mastercard.svg"
+                              src={BP + '/template-assets/mastercard.svg'}
                               alt="Mastercard"
                               {...stylex.props(styles.cardLogo)}
                             />
                             <img
-                              src="/template-assets/amex.svg"
+                              src={BP + '/template-assets/amex.svg'}
                               alt="Amex"
                               {...stylex.props(styles.cardLogo)}
                             />

--- a/packages/cli/templates/pages/payment-form/page.tsx
+++ b/packages/cli/templates/pages/payment-form/page.tsx
@@ -118,7 +118,8 @@ const US_STATES = [
 // root). In the sandbox preview it picks up `/sandbox` so /template-assets/*
 // resolves under the GH Pages basePath. The CLI swaps these paths for an
 // inline placeholder on scaffold, so end users never see them.
-const BP = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
+const BP =
+  (typeof process !== 'undefined' && process.env?.NEXT_PUBLIC_BASE_PATH) || '';
 
 const ITEM_IMAGES: Record<string, {src: string}> = {
   '1': {src: BP + '/template-assets/light-product-1.png'},

--- a/packages/cli/templates/pages/payment-form/page.tsx
+++ b/packages/cli/templates/pages/payment-form/page.tsx
@@ -119,7 +119,7 @@ const US_STATES = [
 // resolves under the GH Pages basePath. The CLI swaps these paths for an
 // inline placeholder on scaffold, so end users never see them.
 const BP =
-  (typeof process !== 'undefined' && process.env?.NEXT_PUBLIC_BASE_PATH) || '';
+  (typeof process !== 'undefined' && process.env.NEXT_PUBLIC_BASE_PATH) || '';
 
 const ITEM_IMAGES: Record<string, {src: string}> = {
   '1': {src: BP + '/template-assets/light-product-1.png'},

--- a/packages/cli/templates/pages/payment-form/page.tsx
+++ b/packages/cli/templates/pages/payment-form/page.tsx
@@ -114,17 +114,13 @@ const US_STATES = [
   'Wyoming',
 ];
 
-// Optional basePath. Empty in end-user projects and the docsite (served at
-// root). In the sandbox preview it picks up `/sandbox` so /template-assets/*
-// resolves under the GH Pages basePath. The CLI swaps these paths for an
-// inline placeholder on scaffold, so end users never see them.
-const BP =
+const basePath =
   (typeof process !== 'undefined' && process.env.NEXT_PUBLIC_BASE_PATH) || '';
 
 const ITEM_IMAGES: Record<string, {src: string}> = {
-  '1': {src: BP + '/template-assets/light-product-1.png'},
-  '2': {src: BP + '/template-assets/light-product-4.png'},
-  '3': {src: BP + '/template-assets/light-product-5.png'},
+  '1': {src: basePath + '/template-assets/light-product-1.png'},
+  '2': {src: basePath + '/template-assets/light-product-4.png'},
+  '3': {src: basePath + '/template-assets/light-product-5.png'},
 };
 
 const ORDER_ITEMS = [
@@ -516,7 +512,9 @@ export default function PaymentFormPage() {
                               onClick={() => {}}
                               xstyle={styles.paypalButton}>
                               <img
-                                src={BP + '/template-assets/paypal-logo.png'}
+                                src={
+                                  basePath + '/template-assets/paypal-logo.png'
+                                }
                                 alt="PayPal"
                                 {...stylex.props(styles.paypalLogo)}
                               />
@@ -530,7 +528,7 @@ export default function PaymentFormPage() {
                               xstyle={styles.gpayButton}>
                               <img
                                 src={
-                                  BP +
+                                  basePath +
                                   '/template-assets/google-pay-logo-dark.svg'
                                 }
                                 alt="Google Pay"
@@ -558,17 +556,17 @@ export default function PaymentFormPage() {
                           {/* Card type icons */}
                           <XDSHStack gap={1.5} vAlign="center">
                             <img
-                              src={BP + '/template-assets/visa.svg'}
+                              src={basePath + '/template-assets/visa.svg'}
                               alt="Visa"
                               {...stylex.props(styles.cardLogo)}
                             />
                             <img
-                              src={BP + '/template-assets/mastercard.svg'}
+                              src={basePath + '/template-assets/mastercard.svg'}
                               alt="Mastercard"
                               {...stylex.props(styles.cardLogo)}
                             />
                             <img
-                              src={BP + '/template-assets/amex.svg'}
+                              src={basePath + '/template-assets/amex.svg'}
                               alt="Amex"
                               {...stylex.props(styles.cardLogo)}
                             />

--- a/packages/cli/templates/pages/product-detail/page.tsx
+++ b/packages/cli/templates/pages/product-detail/page.tsx
@@ -61,11 +61,7 @@ const pageStyles = stylex.create({
 import {MinusIcon, PlusIcon, StarIcon} from '@heroicons/react/24/outline';
 import {StarIcon as StarIconSolid} from '@heroicons/react/24/solid';
 
-// Optional basePath. Empty in end-user projects and the docsite (served at
-// root). In the sandbox preview it picks up `/sandbox` so /template-assets/*
-// resolves under the GH Pages basePath. The CLI swaps these paths for an
-// inline placeholder on scaffold, so end users never see them.
-const BP =
+const basePath =
   (typeof process !== 'undefined' && process.env.NEXT_PUBLIC_BASE_PATH) || '';
 
 // ─── Star Rating ─────────────────────────────────────────────────────────────
@@ -94,19 +90,19 @@ function StarRating({rating, count}: {rating: number; count: number}) {
 // IMAGES[0] = fallback hero; IMAGES[1..6] = thumbnails (first is selected by default)
 const IMAGES = [
   // light-product-1 (fallback hero)
-  BP + '/template-assets/light-product-1.png',
+  basePath + '/template-assets/light-product-1.png',
   // light-product-1 (thumbnail 1)
-  BP + '/template-assets/light-product-1.png',
+  basePath + '/template-assets/light-product-1.png',
   // light-product-2
-  BP + '/template-assets/light-product-2.png',
+  basePath + '/template-assets/light-product-2.png',
   // light-product-3
-  BP + '/template-assets/light-product-3.png',
+  basePath + '/template-assets/light-product-3.png',
   // light-product-4
-  BP + '/template-assets/light-product-4.png',
+  basePath + '/template-assets/light-product-4.png',
   // light-product-5
-  BP + '/template-assets/light-product-5.png',
+  basePath + '/template-assets/light-product-5.png',
   // light-product-3 (gallery variety)
-  BP + '/template-assets/light-product-3.png',
+  basePath + '/template-assets/light-product-3.png',
 ];
 
 // ─── Product Data ───────────────────────────────────────────────────────────

--- a/packages/cli/templates/pages/product-detail/page.tsx
+++ b/packages/cli/templates/pages/product-detail/page.tsx
@@ -66,7 +66,7 @@ import {StarIcon as StarIconSolid} from '@heroicons/react/24/solid';
 // resolves under the GH Pages basePath. The CLI swaps these paths for an
 // inline placeholder on scaffold, so end users never see them.
 const BP =
-  (typeof process !== 'undefined' && process.env?.NEXT_PUBLIC_BASE_PATH) || '';
+  (typeof process !== 'undefined' && process.env.NEXT_PUBLIC_BASE_PATH) || '';
 
 // ─── Star Rating ─────────────────────────────────────────────────────────────
 function StarRating({rating, count}: {rating: number; count: number}) {

--- a/packages/cli/templates/pages/product-detail/page.tsx
+++ b/packages/cli/templates/pages/product-detail/page.tsx
@@ -61,6 +61,12 @@ const pageStyles = stylex.create({
 import {MinusIcon, PlusIcon, StarIcon} from '@heroicons/react/24/outline';
 import {StarIcon as StarIconSolid} from '@heroicons/react/24/solid';
 
+// Optional basePath. Empty in end-user projects and the docsite (served at
+// root). In the sandbox preview it picks up `/sandbox` so /template-assets/*
+// resolves under the GH Pages basePath. The CLI swaps these paths for an
+// inline placeholder on scaffold, so end users never see them.
+const BP = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
+
 // ─── Star Rating ─────────────────────────────────────────────────────────────
 function StarRating({rating, count}: {rating: number; count: number}) {
   const filled = Math.round(rating);
@@ -87,19 +93,19 @@ function StarRating({rating, count}: {rating: number; count: number}) {
 // IMAGES[0] = fallback hero; IMAGES[1..6] = thumbnails (first is selected by default)
 const IMAGES = [
   // light-product-1 (fallback hero)
-  '/template-assets/light-product-1.png',
+  BP + '/template-assets/light-product-1.png',
   // light-product-1 (thumbnail 1)
-  '/template-assets/light-product-1.png',
+  BP + '/template-assets/light-product-1.png',
   // light-product-2
-  '/template-assets/light-product-2.png',
+  BP + '/template-assets/light-product-2.png',
   // light-product-3
-  '/template-assets/light-product-3.png',
+  BP + '/template-assets/light-product-3.png',
   // light-product-4
-  '/template-assets/light-product-4.png',
+  BP + '/template-assets/light-product-4.png',
   // light-product-5
-  '/template-assets/light-product-5.png',
+  BP + '/template-assets/light-product-5.png',
   // light-product-3 (gallery variety)
-  '/template-assets/light-product-3.png',
+  BP + '/template-assets/light-product-3.png',
 ];
 
 // ─── Product Data ───────────────────────────────────────────────────────────

--- a/packages/cli/templates/pages/product-detail/page.tsx
+++ b/packages/cli/templates/pages/product-detail/page.tsx
@@ -65,7 +65,8 @@ import {StarIcon as StarIconSolid} from '@heroicons/react/24/solid';
 // root). In the sandbox preview it picks up `/sandbox` so /template-assets/*
 // resolves under the GH Pages basePath. The CLI swaps these paths for an
 // inline placeholder on scaffold, so end users never see them.
-const BP = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
+const BP =
+  (typeof process !== 'undefined' && process.env?.NEXT_PUBLIC_BASE_PATH) || '';
 
 // ─── Star Rating ─────────────────────────────────────────────────────────────
 function StarRating({rating, count}: {rating: number; count: number}) {

--- a/packages/cli/templates/pages/product-gallery/page.tsx
+++ b/packages/cli/templates/pages/product-gallery/page.tsx
@@ -12,11 +12,7 @@ import {XDSIcon} from '@xds/core/Icon';
 import {ArrowRightIcon} from '@heroicons/react/24/outline';
 import * as stylex from '@stylexjs/stylex';
 
-// Optional basePath. Empty in end-user projects and the docsite (served at
-// root). In the sandbox preview it picks up `/sandbox` so /template-assets/*
-// resolves under the GH Pages basePath. The CLI swaps these paths for an
-// inline placeholder on scaffold, so end users never see them.
-const BP =
+const basePath =
   (typeof process !== 'undefined' && process.env.NEXT_PUBLIC_BASE_PATH) || '';
 
 // ─── Styles ─────────────────────────────────────────────────────────────────
@@ -49,7 +45,7 @@ const PRODUCTS: Product[] = [
       "Sometimes all it takes is one small thing to turn your whole day around. That's what good design is for.",
     price: 75.0,
     // illustrative-horizontal-1 from xds_oss asset set
-    image: BP + '/template-assets/illustrative-horizontal-1.jpg',
+    image: basePath + '/template-assets/illustrative-horizontal-1.jpg',
   },
   {
     id: 2,
@@ -58,7 +54,7 @@ const PRODUCTS: Product[] = [
       "Sometimes all it takes is one small thing to turn your whole day around. That's what good design is for.",
     price: 80.0,
     // illustrative-vertical-1 from xds_oss asset set
-    image: BP + '/template-assets/illustrative-vertical-1.jpg',
+    image: basePath + '/template-assets/illustrative-vertical-1.jpg',
   },
   {
     id: 3,
@@ -67,7 +63,7 @@ const PRODUCTS: Product[] = [
       "Sometimes all it takes is one small thing to turn your whole day around. That's what good design is for.",
     price: 75.0,
     // illustrative-horizontal-3 from xds_oss asset set
-    image: BP + '/template-assets/illustrative-horizontal-3.jpg',
+    image: basePath + '/template-assets/illustrative-horizontal-3.jpg',
   },
   {
     id: 4,
@@ -76,7 +72,7 @@ const PRODUCTS: Product[] = [
       "Sometimes all it takes is one small thing to turn your whole day around. That's what good design is for.",
     price: 75.0,
     // illustrative-horizontal-4 from xds_oss asset set
-    image: BP + '/template-assets/illustrative-horizontal-4.jpg',
+    image: basePath + '/template-assets/illustrative-horizontal-4.jpg',
   },
   {
     id: 5,
@@ -85,7 +81,7 @@ const PRODUCTS: Product[] = [
       "Sometimes all it takes is one small thing to turn your whole day around. That's what good design is for.",
     price: 60.0,
     // illustrative-horizontal-5 from xds_oss asset set
-    image: BP + '/template-assets/illustrative-horizontal-5.jpg',
+    image: basePath + '/template-assets/illustrative-horizontal-5.jpg',
   },
   {
     id: 6,
@@ -94,7 +90,7 @@ const PRODUCTS: Product[] = [
       "Sometimes all it takes is one small thing to turn your whole day around. That's what good design is for.",
     price: 80.0,
     // illustrative-horizontal-2 from xds_oss asset set
-    image: BP + '/template-assets/illustrative-horizontal-2.jpg',
+    image: basePath + '/template-assets/illustrative-horizontal-2.jpg',
   },
 ];
 

--- a/packages/cli/templates/pages/product-gallery/page.tsx
+++ b/packages/cli/templates/pages/product-gallery/page.tsx
@@ -16,7 +16,8 @@ import * as stylex from '@stylexjs/stylex';
 // root). In the sandbox preview it picks up `/sandbox` so /template-assets/*
 // resolves under the GH Pages basePath. The CLI swaps these paths for an
 // inline placeholder on scaffold, so end users never see them.
-const BP = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
+const BP =
+  (typeof process !== 'undefined' && process.env?.NEXT_PUBLIC_BASE_PATH) || '';
 
 // ─── Styles ─────────────────────────────────────────────────────────────────
 // The only custom CSS is the image fill — there is no XDSImage primitive to

--- a/packages/cli/templates/pages/product-gallery/page.tsx
+++ b/packages/cli/templates/pages/product-gallery/page.tsx
@@ -12,6 +12,12 @@ import {XDSIcon} from '@xds/core/Icon';
 import {ArrowRightIcon} from '@heroicons/react/24/outline';
 import * as stylex from '@stylexjs/stylex';
 
+// Optional basePath. Empty in end-user projects and the docsite (served at
+// root). In the sandbox preview it picks up `/sandbox` so /template-assets/*
+// resolves under the GH Pages basePath. The CLI swaps these paths for an
+// inline placeholder on scaffold, so end users never see them.
+const BP = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
+
 // ─── Styles ─────────────────────────────────────────────────────────────────
 // The only custom CSS is the image fill — there is no XDSImage primitive to
 // fill the XDSAspectRatio box with `object-fit` (#2582).
@@ -42,7 +48,7 @@ const PRODUCTS: Product[] = [
       "Sometimes all it takes is one small thing to turn your whole day around. That's what good design is for.",
     price: 75.0,
     // illustrative-horizontal-1 from xds_oss asset set
-    image: '/template-assets/illustrative-horizontal-1.jpg',
+    image: BP + '/template-assets/illustrative-horizontal-1.jpg',
   },
   {
     id: 2,
@@ -51,7 +57,7 @@ const PRODUCTS: Product[] = [
       "Sometimes all it takes is one small thing to turn your whole day around. That's what good design is for.",
     price: 80.0,
     // illustrative-vertical-1 from xds_oss asset set
-    image: '/template-assets/illustrative-vertical-1.jpg',
+    image: BP + '/template-assets/illustrative-vertical-1.jpg',
   },
   {
     id: 3,
@@ -60,7 +66,7 @@ const PRODUCTS: Product[] = [
       "Sometimes all it takes is one small thing to turn your whole day around. That's what good design is for.",
     price: 75.0,
     // illustrative-horizontal-3 from xds_oss asset set
-    image: '/template-assets/illustrative-horizontal-3.jpg',
+    image: BP + '/template-assets/illustrative-horizontal-3.jpg',
   },
   {
     id: 4,
@@ -69,7 +75,7 @@ const PRODUCTS: Product[] = [
       "Sometimes all it takes is one small thing to turn your whole day around. That's what good design is for.",
     price: 75.0,
     // illustrative-horizontal-4 from xds_oss asset set
-    image: '/template-assets/illustrative-horizontal-4.jpg',
+    image: BP + '/template-assets/illustrative-horizontal-4.jpg',
   },
   {
     id: 5,
@@ -78,7 +84,7 @@ const PRODUCTS: Product[] = [
       "Sometimes all it takes is one small thing to turn your whole day around. That's what good design is for.",
     price: 60.0,
     // illustrative-horizontal-5 from xds_oss asset set
-    image: '/template-assets/illustrative-horizontal-5.jpg',
+    image: BP + '/template-assets/illustrative-horizontal-5.jpg',
   },
   {
     id: 6,
@@ -87,7 +93,7 @@ const PRODUCTS: Product[] = [
       "Sometimes all it takes is one small thing to turn your whole day around. That's what good design is for.",
     price: 80.0,
     // illustrative-horizontal-2 from xds_oss asset set
-    image: '/template-assets/illustrative-horizontal-2.jpg',
+    image: BP + '/template-assets/illustrative-horizontal-2.jpg',
   },
 ];
 

--- a/packages/cli/templates/pages/product-gallery/page.tsx
+++ b/packages/cli/templates/pages/product-gallery/page.tsx
@@ -17,7 +17,7 @@ import * as stylex from '@stylexjs/stylex';
 // resolves under the GH Pages basePath. The CLI swaps these paths for an
 // inline placeholder on scaffold, so end users never see them.
 const BP =
-  (typeof process !== 'undefined' && process.env?.NEXT_PUBLIC_BASE_PATH) || '';
+  (typeof process !== 'undefined' && process.env.NEXT_PUBLIC_BASE_PATH) || '';
 
 // ─── Styles ─────────────────────────────────────────────────────────────────
 // The only custom CSS is the image fill — there is no XDSImage primitive to

--- a/packages/cli/templates/pages/side-gallery/page.tsx
+++ b/packages/cli/templates/pages/side-gallery/page.tsx
@@ -17,11 +17,7 @@ import {XDSGrid} from '@xds/core/Grid';
 import {XDSDivider} from '@xds/core/Divider';
 import * as stylex from '@stylexjs/stylex';
 
-// Optional basePath. Empty in end-user projects and the docsite (served at
-// root). In the sandbox preview it picks up `/sandbox` so /template-assets/*
-// resolves under the GH Pages basePath. The CLI swaps these paths for an
-// inline placeholder on scaffold, so end users never see them.
-const BP =
+const basePath =
   (typeof process !== 'undefined' && process.env.NEXT_PUBLIC_BASE_PATH) || '';
 
 // ─── Styles ─────────────────────────────────────────────────────────────────
@@ -51,47 +47,47 @@ const styles = stylex.create({
 const IMAGES = [
   // colorful-lifestyle-vertical-3 from xds_oss asset set
   {
-    src: BP + '/template-assets/colorful-lifestyle-vertical-3.png',
+    src: basePath + '/template-assets/colorful-lifestyle-vertical-3.png',
     alt: 'Colorful lifestyle scene',
   },
   // colorful-lifestyle-horizontal-1 from xds_oss asset set
   {
-    src: BP + '/template-assets/colorful-lifestyle-horizontal-1.png',
+    src: basePath + '/template-assets/colorful-lifestyle-horizontal-1.png',
     alt: 'Colorful lifestyle horizontal',
   },
   // colorful-lifestyle-vertical-1 from xds_oss asset set
   {
-    src: BP + '/template-assets/colorful-lifestyle-vertical-1.png',
+    src: basePath + '/template-assets/colorful-lifestyle-vertical-1.png',
     alt: 'Colorful lifestyle vertical',
   },
   // colorful-home-vertical-2 from xds_oss asset set
   {
-    src: BP + '/template-assets/colorful-home-vertical-2.png',
+    src: basePath + '/template-assets/colorful-home-vertical-2.png',
     alt: 'Colorful home interior',
   },
   // colorful-home-vertical-3 from xds_oss asset set
   {
-    src: BP + '/template-assets/colorful-home-vertical-3.png',
+    src: basePath + '/template-assets/colorful-home-vertical-3.png',
     alt: 'Colorful home scene',
   },
   // colorful-home-vertical-1 from xds_oss asset set
   {
-    src: BP + '/template-assets/colorful-home-vertical-1.png',
+    src: basePath + '/template-assets/colorful-home-vertical-1.png',
     alt: 'Colorful home vertical',
   },
   // colorful-lifestyle-horizontal-2 from xds_oss asset set
   {
-    src: BP + '/template-assets/colorful-lifestyle-horizontal-2.png',
+    src: basePath + '/template-assets/colorful-lifestyle-horizontal-2.png',
     alt: 'Colorful lifestyle wide',
   },
   // colorful-lifestyle-vertical-2 from xds_oss asset set
   {
-    src: BP + '/template-assets/colorful-lifestyle-vertical-2.png',
+    src: basePath + '/template-assets/colorful-lifestyle-vertical-2.png',
     alt: 'Colorful lifestyle detail',
   },
   // colorful-lifestyle-vertical-4 from xds_oss asset set
   {
-    src: BP + '/template-assets/colorful-lifestyle-vertical-4.png',
+    src: basePath + '/template-assets/colorful-lifestyle-vertical-4.png',
     alt: 'Colorful lifestyle portrait',
   },
 ];

--- a/packages/cli/templates/pages/side-gallery/page.tsx
+++ b/packages/cli/templates/pages/side-gallery/page.tsx
@@ -17,6 +17,12 @@ import {XDSGrid} from '@xds/core/Grid';
 import {XDSDivider} from '@xds/core/Divider';
 import * as stylex from '@stylexjs/stylex';
 
+// Optional basePath. Empty in end-user projects and the docsite (served at
+// root). In the sandbox preview it picks up `/sandbox` so /template-assets/*
+// resolves under the GH Pages basePath. The CLI swaps these paths for an
+// inline placeholder on scaffold, so end users never see them.
+const BP = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
+
 // ─── Styles ─────────────────────────────────────────────────────────────────
 
 const styles = stylex.create({
@@ -44,47 +50,47 @@ const styles = stylex.create({
 const IMAGES = [
   // colorful-lifestyle-vertical-3 from xds_oss asset set
   {
-    src: '/template-assets/colorful-lifestyle-vertical-3.png',
+    src: BP + '/template-assets/colorful-lifestyle-vertical-3.png',
     alt: 'Colorful lifestyle scene',
   },
   // colorful-lifestyle-horizontal-1 from xds_oss asset set
   {
-    src: '/template-assets/colorful-lifestyle-horizontal-1.png',
+    src: BP + '/template-assets/colorful-lifestyle-horizontal-1.png',
     alt: 'Colorful lifestyle horizontal',
   },
   // colorful-lifestyle-vertical-1 from xds_oss asset set
   {
-    src: '/template-assets/colorful-lifestyle-vertical-1.png',
+    src: BP + '/template-assets/colorful-lifestyle-vertical-1.png',
     alt: 'Colorful lifestyle vertical',
   },
   // colorful-home-vertical-2 from xds_oss asset set
   {
-    src: '/template-assets/colorful-home-vertical-2.png',
+    src: BP + '/template-assets/colorful-home-vertical-2.png',
     alt: 'Colorful home interior',
   },
   // colorful-home-vertical-3 from xds_oss asset set
   {
-    src: '/template-assets/colorful-home-vertical-3.png',
+    src: BP + '/template-assets/colorful-home-vertical-3.png',
     alt: 'Colorful home scene',
   },
   // colorful-home-vertical-1 from xds_oss asset set
   {
-    src: '/template-assets/colorful-home-vertical-1.png',
+    src: BP + '/template-assets/colorful-home-vertical-1.png',
     alt: 'Colorful home vertical',
   },
   // colorful-lifestyle-horizontal-2 from xds_oss asset set
   {
-    src: '/template-assets/colorful-lifestyle-horizontal-2.png',
+    src: BP + '/template-assets/colorful-lifestyle-horizontal-2.png',
     alt: 'Colorful lifestyle wide',
   },
   // colorful-lifestyle-vertical-2 from xds_oss asset set
   {
-    src: '/template-assets/colorful-lifestyle-vertical-2.png',
+    src: BP + '/template-assets/colorful-lifestyle-vertical-2.png',
     alt: 'Colorful lifestyle detail',
   },
   // colorful-lifestyle-vertical-4 from xds_oss asset set
   {
-    src: '/template-assets/colorful-lifestyle-vertical-4.png',
+    src: BP + '/template-assets/colorful-lifestyle-vertical-4.png',
     alt: 'Colorful lifestyle portrait',
   },
 ];

--- a/packages/cli/templates/pages/side-gallery/page.tsx
+++ b/packages/cli/templates/pages/side-gallery/page.tsx
@@ -21,7 +21,8 @@ import * as stylex from '@stylexjs/stylex';
 // root). In the sandbox preview it picks up `/sandbox` so /template-assets/*
 // resolves under the GH Pages basePath. The CLI swaps these paths for an
 // inline placeholder on scaffold, so end users never see them.
-const BP = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
+const BP =
+  (typeof process !== 'undefined' && process.env?.NEXT_PUBLIC_BASE_PATH) || '';
 
 // ─── Styles ─────────────────────────────────────────────────────────────────
 

--- a/packages/cli/templates/pages/side-gallery/page.tsx
+++ b/packages/cli/templates/pages/side-gallery/page.tsx
@@ -22,7 +22,7 @@ import * as stylex from '@stylexjs/stylex';
 // resolves under the GH Pages basePath. The CLI swaps these paths for an
 // inline placeholder on scaffold, so end users never see them.
 const BP =
-  (typeof process !== 'undefined' && process.env?.NEXT_PUBLIC_BASE_PATH) || '';
+  (typeof process !== 'undefined' && process.env.NEXT_PUBLIC_BASE_PATH) || '';
 
 // ─── Styles ─────────────────────────────────────────────────────────────────
 

--- a/packages/cli/templates/pages/table-page-chart/page.tsx
+++ b/packages/cli/templates/pages/table-page-chart/page.tsx
@@ -32,11 +32,7 @@ import {
   PlusIcon,
 } from '@heroicons/react/24/outline';
 
-// Optional basePath. Empty in end-user projects and the docsite (served at
-// root). In the sandbox preview it picks up `/sandbox` so /template-assets/*
-// resolves under the GH Pages basePath. The CLI swaps these paths for an
-// inline placeholder on scaffold, so end users never see them.
-const BP =
+const basePath =
   (typeof process !== 'undefined' && process.env.NEXT_PUBLIC_BASE_PATH) || '';
 
 // ============= DATA =============
@@ -60,37 +56,37 @@ const PRODUCTS = [
   {
     name: 'Ceremonial Matcha Latte',
     category: 'Matcha' as ProductCategory,
-    image: BP + '/template-assets/matcha-product-1.png',
+    image: basePath + '/template-assets/matcha-product-1.png',
     price: 6,
   },
   {
     name: 'Oat Milk Cappuccino',
     category: 'Coffee' as ProductCategory,
-    image: BP + '/template-assets/matcha-product-2.png',
+    image: basePath + '/template-assets/matcha-product-2.png',
     price: 5,
   },
   {
     name: 'Jasmine Green Tea',
     category: 'Tea' as ProductCategory,
-    image: BP + '/template-assets/matcha-product-3.png',
+    image: basePath + '/template-assets/matcha-product-3.png',
     price: 4,
   },
   {
     name: 'Mango Matcha Smoothie',
     category: 'Smoothie' as ProductCategory,
-    image: BP + '/template-assets/matcha-product-4.png',
+    image: basePath + '/template-assets/matcha-product-4.png',
     price: 8,
   },
   {
     name: 'Hojicha Latte',
     category: 'Specialty' as ProductCategory,
-    image: BP + '/template-assets/matcha-product-5.png',
+    image: basePath + '/template-assets/matcha-product-5.png',
     price: 7,
   },
   {
     name: 'Iced Yuzu Matcha',
     category: 'Matcha' as ProductCategory,
-    image: BP + '/template-assets/matcha-product-6.png',
+    image: basePath + '/template-assets/matcha-product-6.png',
     price: 7,
   },
 ];

--- a/packages/cli/templates/pages/table-page-chart/page.tsx
+++ b/packages/cli/templates/pages/table-page-chart/page.tsx
@@ -36,7 +36,8 @@ import {
 // root). In the sandbox preview it picks up `/sandbox` so /template-assets/*
 // resolves under the GH Pages basePath. The CLI swaps these paths for an
 // inline placeholder on scaffold, so end users never see them.
-const BP = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
+const BP =
+  (typeof process !== 'undefined' && process.env?.NEXT_PUBLIC_BASE_PATH) || '';
 
 // ============= DATA =============
 

--- a/packages/cli/templates/pages/table-page-chart/page.tsx
+++ b/packages/cli/templates/pages/table-page-chart/page.tsx
@@ -37,7 +37,7 @@ import {
 // resolves under the GH Pages basePath. The CLI swaps these paths for an
 // inline placeholder on scaffold, so end users never see them.
 const BP =
-  (typeof process !== 'undefined' && process.env?.NEXT_PUBLIC_BASE_PATH) || '';
+  (typeof process !== 'undefined' && process.env.NEXT_PUBLIC_BASE_PATH) || '';
 
 // ============= DATA =============
 

--- a/packages/cli/templates/pages/table-page-chart/page.tsx
+++ b/packages/cli/templates/pages/table-page-chart/page.tsx
@@ -32,6 +32,12 @@ import {
   PlusIcon,
 } from '@heroicons/react/24/outline';
 
+// Optional basePath. Empty in end-user projects and the docsite (served at
+// root). In the sandbox preview it picks up `/sandbox` so /template-assets/*
+// resolves under the GH Pages basePath. The CLI swaps these paths for an
+// inline placeholder on scaffold, so end users never see them.
+const BP = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
+
 // ============= DATA =============
 
 type ProductCategory = 'Matcha' | 'Coffee' | 'Tea' | 'Smoothie' | 'Specialty';
@@ -53,37 +59,37 @@ const PRODUCTS = [
   {
     name: 'Ceremonial Matcha Latte',
     category: 'Matcha' as ProductCategory,
-    image: '/template-assets/matcha-product-1.png',
+    image: BP + '/template-assets/matcha-product-1.png',
     price: 6,
   },
   {
     name: 'Oat Milk Cappuccino',
     category: 'Coffee' as ProductCategory,
-    image: '/template-assets/matcha-product-2.png',
+    image: BP + '/template-assets/matcha-product-2.png',
     price: 5,
   },
   {
     name: 'Jasmine Green Tea',
     category: 'Tea' as ProductCategory,
-    image: '/template-assets/matcha-product-3.png',
+    image: BP + '/template-assets/matcha-product-3.png',
     price: 4,
   },
   {
     name: 'Mango Matcha Smoothie',
     category: 'Smoothie' as ProductCategory,
-    image: '/template-assets/matcha-product-4.png',
+    image: BP + '/template-assets/matcha-product-4.png',
     price: 8,
   },
   {
     name: 'Hojicha Latte',
     category: 'Specialty' as ProductCategory,
-    image: '/template-assets/matcha-product-5.png',
+    image: BP + '/template-assets/matcha-product-5.png',
     price: 7,
   },
   {
     name: 'Iced Yuzu Matcha',
     category: 'Matcha' as ProductCategory,
-    image: '/template-assets/matcha-product-6.png',
+    image: BP + '/template-assets/matcha-product-6.png',
     price: 7,
   },
 ];


### PR DESCRIPTION
## Summary

PR #2610 mirrored the docsite's `template-assets/` into the sandbox's `public/` dir so `/sandbox/template-assets/*` is reachable on the GH Pages deploy. But every page template still hardcoded absolute `/template-assets/...` URLs in `<img src>` / `imageUrl` / `src:` literals, which Next.js doesn't auto-rewrite the way it does for `next/image` and `next/link`. So with `basePath: '/sandbox'`, the browser resolved them to `pages.github.io/template-assets/*` (missing the `/sandbox` prefix) and 404'd — every product photo and payment logo on the GH Pages preview rendered as a broken image with alt text.

This passes `process.env.NEXT_PUBLIC_BASE_PATH` through every URL so the path resolves under the sandbox's basePath:

```ts
const BP = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
src={BP + '/template-assets/visa.svg'}
```

The literal `/template-assets/<file>` substring is preserved on every line so the CLI's existing [`stripTemplateAssetRefs`](https://github.com/facebookexperimental/xds/blob/main/packages/cli/src/api/template.mjs) regex still matches and swaps these paths for the inline placeholder when end users scaffold the template via `xds template` — no CLI changes needed, and the existing CLI tests still pass.

**Coverage:** 91 `/template-assets/*` references across **14 templates**:

| Template | Refs | Fix |
|---|---:|---|
| centered-hero | 1 | ✓ |
| classic-gallery | 8 | ✓ |
| detail-page | 5 | ✓ |
| form-two-column | 1 | ✓ |
| gallery-hero | 3 | ✓ |
| library | 30 | ✓ |
| login-split | 1 | ✓ |
| login-sso | 1 | ✓ |
| mixed-gallery | 5 | ✓ |
| payment-form | 8 | ✓ (first commit) |
| product-detail | 7 | ✓ |
| product-gallery | 6 | ✓ |
| side-gallery | 9 | ✓ |
| table-page-chart | 6 | ✓ |
| **total** | **91** | |

## Per-environment behavior

| Environment | `BP` | URL | Resolves at |
|---|---|---|---|
| docsite (root) | `""` | `/template-assets/visa.svg` | `apps/docsite/public/template-assets/visa.svg` ✓ |
| sandbox / GH Pages | `"/sandbox"` | `/sandbox/template-assets/visa.svg` | `apps/sandbox/out/template-assets/visa.svg` ✓ |
| sandbox / Vercel | `""` | `/template-assets/visa.svg` | `apps/sandbox/out/template-assets/visa.svg` ✓ |
| end-user scaffolds | n/a | inline `data:image/svg+xml,...` placeholder | n/a ✓ |

## Test plan

- [x] Verified manually on PR preview: `payment-form` renders all images correctly (per @rubyycheung)
- [x] All 14 templates transpile cleanly (`ts.transpileModule` smoke check)
- [x] CLI test suite passes — `stripTemplateAssetRefs` finds all 91 references after the transform
- [x] End-to-end: `xds template payment-form ./out.tsx` swaps all 8 paths for placeholder data URIs (verified on payment-form, library, login-split, mixed-gallery)
- [ ] PR preview shows images on the other 13 templates too once CI rebuilds the preview

Refs #2610, #2454