### PR TITLE
fix(test): allow re-export wrapper dirs in import-hint-correctness

### DIFF
--- a/packages/cli/src/commands/import-hint-correctness.test.mjs
+++ b/packages/cli/src/commands/import-hint-correctness.test.mjs
@@ -174,7 +174,22 @@ describe('import hint correctness', () => {
         const topDir = relToSrc.split(path.sep)[0];
 
         // The import subpath should match the top-level src directory
-        // (case-insensitive check since theme/Theme is valid)
+        // (case-insensitive check since theme/Theme is valid).
+        //
+        // Exception: convenience subpath exports (e.g. `@xds/core/HStack`,
+        // `@xds/core/VStack`, `@xds/core/Heading`, `@xds/core/Code`) live
+        // at `src/<Subpath>/index.ts` as thin re-export wrappers around a
+        // sibling source directory. The export is real and tree-shakeable;
+        // the source file just lives next door. Accept the match if the
+        // subpath has its own index.ts wrapper.
+        const wrapperIndex = path.join(srcDir, subpath, 'index.ts');
+        if (
+          subpath.toLowerCase() !== topDir.toLowerCase() &&
+          fs.existsSync(wrapperIndex)
+        ) {
+          return;
+        }
+
         expect(subpath.toLowerCase()).toBe(topDir.toLowerCase());
       });
     }


### PR DESCRIPTION
## Summary

The Deploy workflow on `main` has been failing since #2571 merged because the new `import-hint-correctness` test conflicts with a pattern introduced earlier in #2420.

`@xds/core/HStack`, `@xds/core/VStack`, `@xds/core/Heading`, and `@xds/core/Code` are convenience subpath exports that live at `src/<Name>/index.ts` as thin re-exports of a sibling source directory:

```ts
// packages/core/src/HStack/index.ts
export {XDSHStack, type XDSHStackProps} from '../Stack';
```

The export is real and tree-shakeable; only the source file lives next door. But the test in `packages/cli/src/commands/import-hint-correctness.test.mjs:178` walks to the actual source file (`src/Stack/XDSHStack.tsx`, top dir `Stack`) and compares it to the import path subpath (`HStack`) — failing on case-insensitive equality:

```
AssertionError: expected 'hstack' to be 'stack'
AssertionError: expected 'vstack' to be 'stack'
```

This blocks every push to main from deploying. Confirmed by checking recent Deploy workflow runs — all failures back to #2571 share this same test failure.

## Fix

Teach the test to accept re-export wrappers: if `subpath/index.ts` exists in `src/`, treat it as a valid match even when the actual source lives in a sibling directory. This is the pattern `#2420` deliberately set up.

## Test plan

- `pnpm exec vitest run packages/cli/src/commands/import-hint-correctness.test.mjs` — 530/530 passing locally
- All four affected components (`HStack`, `VStack`, `Heading`, `Code`) now pass
- Other components still validated against their actual source dir as before
- Once landed: re-run Deploy on main to confirm sandbox preview catches up to main HEAD