### PR TITLE
fix(AppShell): restore content width in auto mode (#2440 regression)

### DIFF
--- a/apps/storybook/stories/AppShell.stories.tsx
+++ b/apps/storybook/stories/AppShell.stories.tsx
@@ -64,7 +64,7 @@ const styles = stylex.create({
   stickyFooterLayout: {
     display: 'flex',
     flexDirection: 'column' as const,
-    flex: 1,
+    minHeight: '100%',
   },
   stickyFooterContent: {
     flex: '1 0 auto',

--- a/packages/core/src/AppShell/XDSAppShell.test.tsx
+++ b/packages/core/src/AppShell/XDSAppShell.test.tsx
@@ -602,30 +602,47 @@ describe('XDSAppShell', () => {
     expect(observeSpy).not.toHaveBeenCalled();
   });
 
-  it('applies flex column stretch to content area in auto mode', () => {
+  it('stretches the content area vertically in auto mode and keeps children in block flow', () => {
     render(
       <XDSAppShell height="auto" data-testid="shell">
         <div data-testid="child">Content</div>
       </XDSAppShell>,
     );
-    // The content area (role="main") should be a flex column in auto mode
     const main = screen.getByRole('main');
-    const style = getComputedStyle(main);
-    expect(style.display).toBe('flex');
-    expect(style.flexDirection).toBe('column');
+    const mainStyle = getComputedStyle(main);
+    // The content area fills remaining vertical space (sticky-footer support)
+    // via a flex column so a child can flex-grow reliably.
+    expect(mainStyle.display).toBe('flex');
+    expect(mainStyle.flexDirection).toBe('column');
+    expect(mainStyle.minHeight).toBe('100%');
+    expect(mainStyle.overflow).toBe('visible');
+
+    // Children are wrapped in a block-flow inner element that fills the width.
+    // This is what restores `max-width` + `margin-inline: auto` centering for
+    // page content (e.g. <XDSSection maxWidth={1200}>): under the parent's flex
+    // context an auto-width item with auto inline margins would collapse to its
+    // content width. The wrapper stretches to 100% width and grows vertically.
+    // See regression from #2440.
+    const inner = screen.getByTestId('child').parentElement;
+    const innerStyle = getComputedStyle(inner!);
+    expect(innerStyle.display).not.toBe('flex');
+    expect(innerStyle.width).toBe('100%');
+    expect(innerStyle.flexGrow).toBe('1');
   });
 
-  it('does not apply flex column stretch to content area in fill mode', () => {
+  it('does not wrap or stretch the content area in fill mode', () => {
     render(
       <XDSAppShell height="fill" data-testid="shell">
         <div data-testid="child">Content</div>
       </XDSAppShell>,
     );
     const main = screen.getByRole('main');
-    const style = getComputedStyle(main);
-    // In fill mode, content area should NOT have flex-direction column
-    // (it uses default block layout with scroll containment)
-    expect(style.flexDirection).not.toBe('column');
+    const mainStyle = getComputedStyle(main);
+    // Fill mode keeps XDSLayoutContent's default fixed-height, internally
+    // scrollable behavior — no auto-mode flex column, no extra wrapper.
+    expect(mainStyle.flexDirection).not.toBe('column');
+    // In fill mode children are rendered directly (no contentAutoInner wrapper).
+    expect(screen.getByTestId('child').parentElement).toBe(main);
   });
 
   // ===========================================================================

--- a/packages/core/src/AppShell/XDSAppShell.tsx
+++ b/packages/core/src/AppShell/XDSAppShell.tsx
@@ -429,16 +429,44 @@ const styles = stylex.create({
     flex: 1,
     overflow: 'auto',
   },
-  // Content area fix for auto mode — makes the content a flex column so that
-  // children can use flex-grow to fill remaining vertical space (sticky footer
-  // pattern). Overrides height/overflow from XDSLayoutContent's default styles
-  // which assume fill-mode (fixed-height, internally scrollable) behavior.
+  // Content area adjustment for auto mode. Overrides height/overflow from
+  // XDSLayoutContent's default styles, which assume fill-mode (fixed-height,
+  // internally scrollable) behavior. The content area becomes a flex column so
+  // a child can reliably fill the remaining vertical space (sticky-footer
+  // pattern) without relying on a fragile percentage-height chain:
+  // - `display: flex; flex-direction: column` — children can use flex-grow.
+  // - `height: auto` — overrides the fill-mode `height: 100%`.
+  // - `min-height: 100%` — fills available space on short pages.
+  // - `overflow: visible` — the page (not this element) owns the scroll.
   contentAutoStretch: {
     display: 'flex',
     flexDirection: 'column' as const,
     height: 'auto',
     minHeight: '100%',
     overflow: 'visible',
+  },
+  // Inner wrapper for the content area in auto mode.
+  //
+  // The content area is a flex column (above) so children can grow vertically.
+  // But page content commonly centers itself with an auto-width container plus
+  // `margin-inline: auto` (e.g. `<XDSSection maxWidth={1200}>`), and under a
+  // flex/grid formatting context an auto-width item with auto inline margins
+  // collapses to its content width instead of filling — so the column renders
+  // far narrower than its max-width (regression from #2440).
+  //
+  // This wrapper re-establishes normal block flow for that content while still
+  // participating in the parent's flex column:
+  // - `width: 100%` — fills the content area horizontally (no auto margin, so
+  //   it stretches rather than collapsing), restoring max-width + margin-auto
+  //   centering for descendants.
+  // - `flex: 1 0 auto` — grows to fill remaining vertical space, preserving the
+  //   sticky-footer capability for children placed inside it.
+  // - `display: block` (default) — descendants lay out in normal flow.
+  contentAutoInner: {
+    width: '100%',
+    flexGrow: 1,
+    flexShrink: 0,
+    flexBasis: 'auto',
   },
 });
 
@@ -730,7 +758,11 @@ export function XDSAppShell({
       id={MAIN_CONTENT_ID}
       isScrollable={isFill}
       xstyle={[contentAreaStyle, isAuto && styles.contentAutoStretch]}>
-      {children}
+      {isAuto ? (
+        <div {...stylex.props(styles.contentAutoInner)}>{children}</div>
+      ) : (
+        children
+      )}
     </XDSLayoutContent>
   );
 


### PR DESCRIPTION
## Summary

Fixes a layout regression introduced by #2440 (merged earlier today). On the docsite, the `/components` landing page content column — which should be `width: 100%` capped at `max-width: 1200px` — was collapsing to well under 600px. The same bug affects **every** `height="auto"` AppShell page that centers content via `margin-inline: auto` (docsite `/components`, `/docs`, `/docs/[topic]`, `/packages/[name]`).

## Root cause

`DocsShell` renders `<XDSAppShell height="auto">`. #2440 made the auto-mode content area (`XDSLayoutContent`) a **flex column** so children could `flex-grow` to fill remaining vertical space (sticky-footer pattern):

```js
contentAutoStretch: {
  display: 'flex',
  flexDirection: 'column',
  height: 'auto',
  minHeight: '100%',
  overflow: 'visible',
},
```

Page content commonly centers itself with an auto-width container plus `margin-inline: auto` — e.g. `<XDSSection maxWidth={1200} xstyle={{ marginInline: 'auto' }}>`. That pattern relies on **block** layout: an auto-width block fills the available inline space, then `max-width` caps it and the auto margins center it.

Under a flex formatting context, the rules change. Per the flexbox spec, a flex item with `width: auto` and an **auto inline (cross-axis) margin** does *not* stretch to fill — it resolves to its `max-content` width and the auto margins absorb the leftover space. So the section collapsed to its content width instead of filling to 1200px.

## Fix

Keep the flex column on the content area (so the sticky-footer capability from #2440 still works), but wrap children in a block-flow inner element in auto mode:

```js
contentAutoInner: {
  width: '100%',     // fills the content area (no auto margin → stretches)
  flexGrow: 1,       // still grows vertically to fill remaining space
  flexShrink: 0,
  flexBasis: 'auto',
},
```

- `width: 100%` makes the wrapper fill the content area horizontally, re-establishing the available width that `max-width` + `margin-inline: auto` descendants need to fill-then-center.
- `flex: 1 0 auto` preserves vertical fill, so sticky-footer layouts placed inside still pin correctly.
- The wrapper is a normal block box, so descendants lay out in normal flow — centering works again.

Fill mode is unchanged (no wrapper, no flex column).

## Tests / stories

- Rewrote the two AppShell tests added in #2440 to assert the corrected contract: auto mode keeps a flex column **and** wraps children in a full-width block-flow element; fill mode renders children directly with no wrapper.
- Updated the auto-height sticky-footer stories to fill height via `min-height: 100%` on the consumer's own layout wrapper (instead of `flex: 1`), matching the new structure.

## Verification

- `pnpm exec vitest run packages/core/src/AppShell/XDSAppShell.test.tsx` → 40/40 pass
- `pnpm -F @xds/core typecheck` → clean
- `eslint` on changed files → clean

## Why fix AppShell rather than the page

This breaks working consumer code with no consumer change, across multiple pages and for any external `height="auto"` AppShell user — it's a shell regression, not a page issue. Patching only `/components` would leave the same footgun everywhere else.
