### PR TITLE
fix(docsite): add 'customize' to CtaTarget union type

### DIFF
--- a/apps/docsite/src/lib/analytics.ts
+++ b/apps/docsite/src/lib/analytics.ts
@@ -29,7 +29,7 @@ type CopyTarget =
   | 'share_url'
   | 'install_command';
 
-type CtaTarget = 'install' | 'get_started' | 'github' | 'community';
+type CtaTarget = 'install' | 'get_started' | 'github' | 'community' | 'customize';
 
 type NavigateTarget = 'prev_next' | 'tab' | 'view';
 


### PR DESCRIPTION
ThemePackagePage passes `'customize'` as a CTA target when navigating to the theme playground, but the type wasn't in the `CtaTarget` union in `analytics.ts`, causing a build failure:

```
Type error: Type '"customize"' is not assignable to type 'CtaTarget'.
```

Adds `'customize'` to the union.