### PR TITLE
fix(docsite): render template StyleX in playground + gallery preview

### DIFF
--- a/apps/docsite/postcss.config.js
+++ b/apps/docsite/postcss.config.js
@@ -7,7 +7,15 @@ const babelConfig = require('./babel.config');
 module.exports = {
   plugins: {
     '@stylexjs/postcss-plugin': {
-      include: ['src/**/*.{js,jsx,ts,tsx}'],
+      // Scan the docsite's own source plus the CLI page templates — the docsite
+      // renders those template page.tsx files directly (gallery + preview), so
+      // their stylex.create() styles must be extracted into CSS here. Without
+      // this, template-only classes (e.g. order-summary thumbnail sizing) ship
+      // in the JS with no matching CSS rule and render unstyled.
+      include: [
+        'src/**/*.{js,jsx,ts,tsx}',
+        '../../packages/cli/templates/**/*.{js,jsx,ts,tsx}',
+      ],
       babelConfig: {
         babelrc: false,
         parserOpts: {

--- a/apps/docsite/postcss.config.js
+++ b/apps/docsite/postcss.config.js
@@ -7,11 +7,8 @@ const babelConfig = require('./babel.config');
 module.exports = {
   plugins: {
     '@stylexjs/postcss-plugin': {
-      // Scan the docsite's own source plus the CLI page templates — the docsite
-      // renders those template page.tsx files directly (gallery + preview), so
-      // their stylex.create() styles must be extracted into CSS here. Without
-      // this, template-only classes (e.g. order-summary thumbnail sizing) ship
-      // in the JS with no matching CSS rule and render unstyled.
+      // The docsite renders CLI page templates directly, so extract their
+      // StyleX too — otherwise template-only classes ship without CSS.
       include: [
         'src/**/*.{js,jsx,ts,tsx}',
         '../../packages/cli/templates/**/*.{js,jsx,ts,tsx}',

--- a/apps/docsite/scripts/generate-scope.mjs
+++ b/apps/docsite/scripts/generate-scope.mjs
@@ -65,13 +65,9 @@ lines.push("import React, {useState, useCallback, useMemo, useEffect, useRef} fr
 lines.push('');
 
 // ── StyleX mock ────────────────────────────────────────────────────────
-// The playground transpiles user/template code in-browser WITHOUT the StyleX
-// compiler, so stylex.create() returns its raw style objects and stylex.props()
-// runs at runtime. To make template/example layout actually render, props()
-// flattens those plain CSS-property objects into an inline `style` (covers the
-// common case: width/height/objectFit/padding/etc., incl. `var(--token)`). It
-// can't reproduce pseudo/media/`stylex.when` styles — responsive objects
-// collapse to their `default` branch and pseudo-selector keys are skipped.
+// The playground transpiles code in-browser without the StyleX compiler, so
+// props() flattens plain CSS-property objects into an inline `style`. Pseudo/
+// media entries can't be inlined: responsive objects collapse to `default`.
 lines.push(`const STYLEX_SKIP_KEY = /^(:|::|@|--)/;
 const stylexFlatten = (style: Record<string, unknown>, obj: unknown): void => {
   if (obj == null || typeof obj !== 'object') return;

--- a/apps/docsite/scripts/generate-scope.mjs
+++ b/apps/docsite/scripts/generate-scope.mjs
@@ -65,11 +65,33 @@ lines.push("import React, {useState, useCallback, useMemo, useEffect, useRef} fr
 lines.push('');
 
 // ── StyleX mock ────────────────────────────────────────────────────────
-lines.push(`const stylexMock = {
+// The playground transpiles user/template code in-browser WITHOUT the StyleX
+// compiler, so stylex.create() returns its raw style objects and stylex.props()
+// runs at runtime. To make template/example layout actually render, props()
+// flattens those plain CSS-property objects into an inline `style` (covers the
+// common case: width/height/objectFit/padding/etc., incl. `var(--token)`). It
+// can't reproduce pseudo/media/`stylex.when` styles — responsive objects
+// collapse to their `default` branch and pseudo-selector keys are skipped.
+lines.push(`const STYLEX_SKIP_KEY = /^(:|::|@|--)/;
+const stylexFlatten = (style: Record<string, unknown>, obj: unknown): void => {
+  if (obj == null || typeof obj !== 'object') return;
+  for (const [k, v] of Object.entries(obj as Record<string, unknown>)) {
+    if (v == null || v === false) continue;
+    if (STYLEX_SKIP_KEY.test(k)) continue;
+    if (typeof v === 'object') {
+      const d = (v as Record<string, unknown>).default;
+      if (d != null && typeof d !== 'object') style[k] = d as string;
+      continue;
+    }
+    style[k] = v as string;
+  }
+};
+const stylexMock = {
   create: <T extends Record<string, unknown>>(styles: T): T => styles,
-  props: (..._styles: unknown[]) => {
-    const style: Record<string, string> = {};
-    return {className: '', style};
+  props: (...styles: unknown[]) => {
+    const style: Record<string, unknown> = {};
+    for (const s of styles.flat(Infinity)) stylexFlatten(style, s);
+    return {className: '', style: style as Record<string, string>};
   },
   defineVars: <T extends Record<string, unknown>>(tokens: T): T => tokens,
   keyframes: (kf: Record<string, Record<string, string>>) => kf,

--- a/apps/docsite/src/app/(preview)/playground-preview/page.tsx
+++ b/apps/docsite/src/app/(preview)/playground-preview/page.tsx
@@ -587,10 +587,7 @@ export default function PreviewPage() {
 
   const stageStyle: CSSProperties = fill
     ? {
-        // `height: 100%` (not just minHeight) so the chain down to the rendered
-        // root is definite — templates that size with `minHeight: 100%` /
-        // `height: 100%` resolve against it. Taller content still grows/scrolls
-        // via the template's own scroll regions.
+        // Definite height so templates sized with `height: 100%` resolve.
         height: '100%',
         minHeight: '100%',
         display: 'block',
@@ -606,10 +603,6 @@ export default function PreviewPage() {
         backgroundColor: 'var(--color-background-surface)',
       };
 
-  // In fill mode the wrapper is a full-size block so the rendered root fills
-  // width/height — and, crucially, gives a definite height for templates that
-  // size with `minHeight: 100%` / `height: 100%` to resolve against (a
-  // `display: contents` wrapper has no box, so percentage heights collapse).
   const contentStyle: CSSProperties = fill
     ? {height: '100%', width: '100%'}
     : {};

--- a/apps/docsite/src/app/(preview)/playground-preview/page.tsx
+++ b/apps/docsite/src/app/(preview)/playground-preview/page.tsx
@@ -587,6 +587,11 @@ export default function PreviewPage() {
 
   const stageStyle: CSSProperties = fill
     ? {
+        // `height: 100%` (not just minHeight) so the chain down to the rendered
+        // root is definite — templates that size with `minHeight: 100%` /
+        // `height: 100%` resolve against it. Taller content still grows/scrolls
+        // via the template's own scroll regions.
+        height: '100%',
         minHeight: '100%',
         display: 'block',
         backgroundColor: 'var(--color-background-surface)',
@@ -601,9 +606,13 @@ export default function PreviewPage() {
         backgroundColor: 'var(--color-background-surface)',
       };
 
-  // In fill mode the wrapper has no box (display: contents) so the rendered
-  // root participates directly in block flow and fills width/height naturally.
-  const contentStyle: CSSProperties = fill ? {display: 'contents'} : {};
+  // In fill mode the wrapper is a full-size block so the rendered root fills
+  // width/height — and, crucially, gives a definite height for templates that
+  // size with `minHeight: 100%` / `height: 100%` to resolve against (a
+  // `display: contents` wrapper has no box, so percentage heights collapse).
+  const contentStyle: CSSProperties = fill
+    ? {height: '100%', width: '100%'}
+    : {};
 
   return (
     <XDSTheme theme={theme} mode={themeMode}>


### PR DESCRIPTION
## Summary

Two docsite-infrastructure fixes so CLI page templates render with their own StyleX styles in the docsite. These are foundational — without them, template layout (sizing, object-fit, padding) silently drops in the docsite.

- **Playground**: the playground transpiles template/user code in-browser without the StyleX compiler, so the generated playground-scope's `stylex.props()` mock returned an empty `className`/`style` — dropping every inline `stylex.create()` style. The mock now flattens plain CSS-property objects into an inline `style` (covers width/height/object-fit/padding/etc., incl. `var(--token)`). Pseudo/media/`stylex.when` can't be expressed inline, so responsive objects collapse to their `default` branch and pseudo keys are skipped.
- **Gallery/preview build**: the StyleX PostCSS plugin only scanned `src/**`, so template-only classes shipped in the JS with no matching CSS rule (e.g. order-summary thumbnails rendered at full natural size). Added `packages/cli/templates/**` to the PostCSS `include` (the sandbox already does this via `@xds/build`).

## Why stacked / first

A follow-up PR reverts the template image localization and fixes several templates; those template thumbnails only render at the correct size because of the PostCSS fix here. This PR is the foundation.

## Test plan

- `node apps/docsite/scripts/generate-scope.mjs` regenerates `playground-scope.ts` with the flattening mock.
- Docsite gallery/preview: template `stylex.create` styles now emit matching CSS (verified `width:var(--spacing-12)` rule now present and matches the component's class).
- Playground: a `stylex.props`-styled box renders at its intended size (was 0×0 before).
- `vitest run` (docsite) passes.

Made with [Cursor](https://cursor.com)