### PR TITLE
docs(deslop): batch 6 (final) - remove AI-slop tells from doc files (2 files)

### DIFF
--- a/packages/themes/y2k/README.md
+++ b/packages/themes/y2k/README.md
@@ -1,6 +1,6 @@
 # @xds/theme-y2k
 
-Bubbly Y2K pop theme for XDS — hot pink body, lime green accents, Poppins body text, and playful categorical colors derived from HCT tonal palettes.
+Bubbly Y2K pop theme for XDS: hot pink body, lime green accents, Poppins body text, and playful categorical colors derived from HCT tonal palettes.
 
 ## Install
 

--- a/packages/vega/README.md
+++ b/packages/vega/README.md
@@ -1,6 +1,6 @@
 # @xds/vega
 
-XDS Vega wrapper -- chart and data visualization components.
+XDS Vega wrapper: chart and data visualization components.
 
 Renders [Vega](https://vega.github.io/vega/) and [Vega-Lite](https://vega.github.io/vega-lite/) specifications via the Vega runtime. The component inspects `$schema` to decide whether to compile (Vega-Lite) or render directly (Vega), validates the schema URL before doing either, and exposes the full Vega `parse()` and `View` construction APIs as props.
 
@@ -12,7 +12,7 @@ Renders [Vega](https://vega.github.io/vega/) and [Vega-Lite](https://vega.github
 |------|------|---------|
 | `package.json` | Config | Package metadata, deps, build scripts |
 | `tsconfig.json` | Config | TypeScript compiler config (extends root) |
-| `tsup.config.ts` | Config | Build config -- CJS + ESM + `.d.ts` outputs |
+| `tsup.config.ts` | Config | Build config: CJS + ESM + `.d.ts` outputs |
 | `src/index.ts` | Barrel | Public API surface |
 | `src/XDSVegaChart.tsx` | Component | Inspects `$schema`, compiles or renders, owns View lifecycle |
 | `src/schema.ts` | Utility | Parses and validates Vega/Vega-Lite `$schema` URLs |
@@ -85,8 +85,8 @@ import {XDSVegaChart} from '@xds/vega';
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
 | `spec` | `AnySpec` | -- | Vega or Vega-Lite spec with `$schema` (required) |
-| `data` | `ViewData` | -- | Initial dataset values — `{datasetName: tuples[]}` |
-| `compileOptions` | `CompileOptions` | -- | Options passed to `compile(spec, options)` — Vega-Lite only |
+| `data` | `ViewData` | -- | Initial dataset values: `{datasetName: tuples[]}` |
+| `compileOptions` | `CompileOptions` | -- | Options passed to `compile(spec, options)`, Vega-Lite only |
 | `parseConfig` | `Config` | -- | Vega config passed to `parse(spec, config)` |
 | `parseOptions` | `ParseOptions` | -- | Options passed to `parse(spec, config, options)` |
 | `viewOptions` | `Omit<ViewOptions, 'container'>` | -- | Options passed to `new View(runtime, options)` |
@@ -124,7 +124,7 @@ import {XDSVegaChart} from '@xds/vega';
 
 ### Data loading
 
-`data` maps dataset names to tuple arrays and is applied via `view.data(name, tuples)` during View initialization, before the first render. It is *not reactive* — changes after mount are ignored.
+`data` maps dataset names to tuple arrays and is applied via `view.data(name, tuples)` during View initialization, before the first render. It is *not reactive*; changes after mount are ignored.
 
 To update data dynamically after render, use `onReady` to get the live View and drive it yourself:
 


### PR DESCRIPTION
## What

Batch 6 (final) of the doc-site AI-slop cleanup: removes em-dash "slop" tells from the last 2 README files.

## Scope

2 changed files: `packages/themes/y2k/README.md` and `packages/vega/README.md`. One file per commit.

## Guarantees

- **Meaning preserved** — only punctuation changed (Unicode em-dashes and prose `--` → colon/semicolon/comma).
- **N/A table cells preserved** — the `Default | -- |` placeholder cells, the `<!-- SYNC -->` HTML comment, and markdown table separators were left intact.
- **Grammar-aware** — fixes reviewed per clause.

This completes the doc-site AI-slop em-dash cleanup across the XDS repo (PRs #2652, #2656, #2658, #2661, #2662, #2663, #2664).

## Review

Human review required. No auto-merge.

---
Crafted with care by [Navi](https://navibot.dev/0c140b36-8fb7-4cb2-9a85-49409508fef7)
