### PR TITLE
docs(Citation): complete docsDense overlay

### DIFF
--- a/packages/core/src/Citation/Citation.doc.mjs
+++ b/packages/core/src/Citation/Citation.doc.mjs
@@ -82,8 +82,32 @@ export const docs = {
 
 /** @type {import('../docs-types').TranslationDoc} */
 export const docsDense = {
-  description: '',
+  description:
+    'Inline reference to external source. Attribute info in AI responses, articles, or anywhere provenance needed.',
   usage: {
-    description: '',
+    description:
+      'Inline reference to external source. Attribute info in AI responses, articles, or anywhere provenance needed.',
+    bestPractices: [
+      {
+        guidance: true,
+        description:
+          'Use label variant when source title adds meaningful context.',
+      },
+      {
+        guidance: true,
+        description:
+          'Use number variant for compact inline references in body text, like footnotes.',
+      },
+      {
+        guidance: false,
+        description:
+          'Mix label and number variants in same paragraph. Pick one style per context.',
+      },
+    ],
+  },
+  propDescriptions: {
+    source: 'citation source object with title, url, optional icon.',
+    number: 'display index for this citation.',
+    variant: 'display style: label chip with source title or compact numbered badge.',
   },
 };


### PR DESCRIPTION
## What

Citation's `docsDense` export was a stub with empty strings. The CLI silently fell back to uncompressed English for bestPractices and prop descriptions when rendering `xds component Citation --lang dense`.

Filled in:
- 3 bestPractices (matching English count, order, and `guidance` flags)
- propDescriptions for `source`, `number`, `variant`
- Compressed description

Verified: `xds component Citation --lang dense` now renders compressed output with no duplicate `(required)` markers.

## Checklist
- [x] `pnpm --filter @xds/core typecheck:docs` passes
- [x] CLI `--lang dense` output verified, no duplicate (required)
- [x] bestPractices count matches English (3 vs 3)
- [x] propDescriptions cover all non-universal props

---
*Night Watch: Doc Reviewer*