### PR TITLE
docs(storybook): fix @example blocks in AppShell and Popover

### DIFF
--- a/packages/core/src/AppShell/XDSAppShell.tsx
+++ b/packages/core/src/AppShell/XDSAppShell.tsx
@@ -250,9 +250,8 @@ export interface XDSAppShellProps extends XDSBaseProps<HTMLDivElement> {
    * returns `null`:
    *
    * @example
-   * ```tsx
+   * ```
    * const SIDEBAR_ROUTES = ['/dashboard', '/settings'];
-   *
    * function Layout({ children, sidebar }) {
    *   const hasSidebar = SIDEBAR_ROUTES.some(r => pathname.startsWith(r));
    *   return (

--- a/packages/core/src/Popover/XDSPopover.tsx
+++ b/packages/core/src/Popover/XDSPopover.tsx
@@ -98,13 +98,8 @@ export interface XDSPopoverProps extends Pick<
    *
    * @example
    * ```
-   * // Automatic — XDSButton already renders a <button>
    * <XDSPopover content={...}><XDSButton label="Open" /></XDSPopover>
-   *
-   * // Automatic — XDSToken renders as <button> via context
    * <XDSPopover content={...}><XDSToken label="Filter" /></XDSPopover>
-   *
-   * // Explicit — render prop for full control
    * <XDSPopover content={...}>
    *   {(triggerProps) => <MyCustomTrigger {...triggerProps} />}
    * </XDSPopover>


### PR DESCRIPTION
## What

Two Storybook autodocs parsing issues:

**XDSAppShell** (`sideNav` prop): ```tsx language tag causes Storybook to choke. Removed the `tsx` tag and collapsed a blank line inside the code block.

**XDSPopover** (`children` prop): JS comments (`//`) and blank lines inside the code block cause Storybook's markdown renderer to misparse the example. Removed both; the three usage patterns (button trigger, token trigger, render prop) are still shown.

## Checklist
- [x] No ```tsx in @example code blocks
- [x] No blank lines inside @example code blocks
- [x] No JS comments inside @example code blocks
- [x] Examples remain concise and correct

---
*Night Watch: Doc Reviewer*