### PR TITLE
fix(docsite): prevent copy button overlapping code/component toggle

### DIFF
--- a/apps/docsite/src/components/component-detail/InteractivePreview.tsx
+++ b/apps/docsite/src/components/component-detail/InteractivePreview.tsx
@@ -290,6 +290,7 @@ export function InteractivePreviewStage({
           style={{
             minHeight: 200,
             overflow: 'auto',
+            paddingRight: 'var(--spacing-8)',
           }}>
           <XDSCodeBlock
             code={code}


### PR DESCRIPTION
The copy button on the CodeBlock in the Properties tab's code view was overlapping the code/component toggle button (both positioned at the top-right corner of the card).

Adds `paddingRight: var(--spacing-8)` to the code view container so the copy button renders clear of the toggle.