### PR TITLE
docs(appshell): document mobile shell hook

### DIFF
--- a/packages/core/src/AppShell/AppShell.doc.mjs
+++ b/packages/core/src/AppShell/AppShell.doc.mjs
@@ -5,6 +5,7 @@
 export const docs = {
   name: 'AppShell',
   displayName: 'App Shell',
+  group: 'AppShell',
   category: 'Layout',
   keywords: ["appshell","layout","scaffold","sidebar","sidenav","topnav","header","navigation","dashboard","shell","page","frame"],
   usage: {

--- a/packages/core/src/AppShell/useXDSAppShellMobile.doc.mjs
+++ b/packages/core/src/AppShell/useXDSAppShellMobile.doc.mjs
@@ -1,0 +1,152 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('../docs-types').HookDoc} */
+export const docs = {
+  name: 'useXDSAppShellMobile',
+  displayName: 'useXDSAppShellMobile',
+  group: 'AppShell',
+  category: 'layout',
+  keywords: [
+    'appshell',
+    'mobile nav',
+    'mobile drawer',
+    'hamburger',
+    'navigation toggle',
+    'responsive navigation',
+    'drawer state',
+  ],
+  params: [
+    // useXDSAppShellMobile takes no arguments — it reads AppShell context.
+  ],
+  returns: [
+    {
+      name: 'isMobile',
+      type: 'boolean',
+      description:
+        'Whether the current viewport is below the AppShell mobile navigation breakpoint.',
+    },
+    {
+      name: 'isMobileNavOpen',
+      type: 'boolean',
+      description:
+        'Whether the AppShell-managed mobile navigation drawer is open.',
+    },
+    {
+      name: 'toggleMobileNav',
+      type: '() => void',
+      description:
+        'Toggle the AppShell-managed mobile navigation drawer. No-ops when mobile nav is disabled.',
+    },
+    {
+      name: 'openMobileNav',
+      type: '() => void',
+      description:
+        'Open the AppShell-managed mobile navigation drawer. No-ops when mobile nav is disabled.',
+    },
+    {
+      name: 'closeMobileNav',
+      type: '() => void',
+      description: 'Close the AppShell-managed mobile navigation drawer.',
+    },
+    {
+      name: 'isMobileNavEnabled',
+      type: 'boolean',
+      description:
+        'Whether AppShell mobile navigation is enabled and managed by AppShell. False when mobileNav is false, there is no nav content, or a fully custom mobileNav ReactNode owns the drawer.',
+    },
+    {
+      name: 'hasAutoToggle',
+      type: 'boolean',
+      description:
+        'Whether AppShell auto-toggle behavior is enabled. False when mobileNav hasToggle is set to false; combine with isMobile and isMobileNavEnabled before rendering custom toggles.',
+    },
+  ],
+  usage: {
+    description:
+      'Hook for reading and controlling XDSAppShell mobile navigation state from descendants of AppShell. Use it for custom mobile nav triggers, custom nav items that need to close the drawer after navigation, or AppShell-aware navigation components.',
+    bestPractices: [
+      {
+        guidance: true,
+        description:
+          'Use inside the XDSAppShell tree when building custom mobile navigation controls or route-aware nav items.',
+      },
+      {
+        guidance: true,
+        description:
+          'Prefer XDSMobileNavToggle for the standard hamburger trigger — use this hook when you need custom placement, styling, or extra behavior.',
+      },
+      {
+        guidance: true,
+        description:
+          'Call closeMobileNav after a custom mobile nav item changes route so the drawer dismisses cleanly.',
+      },
+      {
+        guidance: false,
+        description:
+          'Use for arbitrary responsive layout logic outside AppShell — use useMediaQuery for unrelated viewport checks.',
+      },
+      {
+        guidance: false,
+        description:
+          'Assume it throws outside AppShell. The hook returns safe defaults and no-op callbacks when no provider is present.',
+      },
+    ],
+  },
+  relatedComponents: [
+    'AppShell',
+    'MobileNav',
+    'MobileNavToggle',
+    'TopNav',
+    'SideNav',
+  ],
+  relatedHooks: ['useMediaQuery'],
+  importPath: '@xds/core/AppShell',
+};
+
+/** @type {import('../docs-types').HookTranslationDoc} */
+export const docsDense = {
+  description:
+    'Reads/controls XDSAppShell mobile nav context. Use for custom mobile nav triggers, route-aware nav items that close drawer, or AppShell-aware nav components.',
+  returnDescriptions: {
+    isMobile: 'viewport below AppShell mobile nav breakpoint?',
+    isMobileNavOpen: 'AppShell-managed mobile nav drawer open?',
+    toggleMobileNav: 'toggle drawer; no-op when mobile nav disabled',
+    openMobileNav: 'open drawer; no-op when mobile nav disabled',
+    closeMobileNav: 'close drawer',
+    isMobileNavEnabled:
+      'AppShell owns mobile nav? false when mobileNav=false, no nav content, or custom ReactNode owns drawer',
+    hasAutoToggle:
+      'auto-toggle enabled? false when mobileNav.hasToggle=false; combine w/ isMobile + isMobileNavEnabled before custom toggle render',
+  },
+  usage: {
+    description:
+      'Reads/controls XDSAppShell mobile nav context. Use for custom mobile nav triggers, route-aware nav items that close drawer, or AppShell-aware nav components.',
+    bestPractices: [
+      {
+        guidance: true,
+        description:
+          'Use inside XDSAppShell tree for custom mobile nav controls / route-aware nav items.',
+      },
+      {
+        guidance: true,
+        description:
+          'Prefer XDSMobileNavToggle for standard hamburger; use hook for custom placement, styling, or extra behavior.',
+      },
+      {
+        guidance: true,
+        description:
+          'Call closeMobileNav after custom mobile nav item changes route so drawer dismisses.',
+      },
+      {
+        guidance: false,
+        description:
+          'Use for arbitrary responsive layout outside AppShell — use useMediaQuery instead.',
+      },
+      {
+        guidance: false,
+        description:
+          'Assume it throws outside AppShell. Hook returns safe defaults + no-op callbacks without provider.',
+      },
+    ],
+  },
+};

--- a/packages/core/src/AppShell/useXDSAppShellMobile.doc.mjs
+++ b/packages/core/src/AppShell/useXDSAppShellMobile.doc.mjs
@@ -23,7 +23,7 @@ export const docs = {
       name: 'isMobile',
       type: 'boolean',
       description:
-        'Whether the current viewport is below the AppShell mobile navigation breakpoint.',
+        'Whether the current viewport is below the AppShell mobile navigation breakpoint. Use this to synchronize AppShell-adjacent mobile UI with the same breakpoint as mobile nav.',
     },
     {
       name: 'isMobileNavOpen',
@@ -63,12 +63,12 @@ export const docs = {
   ],
   usage: {
     description:
-      'Hook for reading and controlling XDSAppShell mobile navigation state from descendants of AppShell. Use it for custom mobile nav triggers, custom nav items that need to close the drawer after navigation, or AppShell-aware navigation components.',
+      'Hook for reading and controlling XDSAppShell mobile navigation state from descendants of AppShell. Use it for custom mobile nav triggers, closing the drawer after route changes, or coordinating AppShell-adjacent mobile experiences with the same breakpoint used by mobile nav.',
     bestPractices: [
       {
         guidance: true,
         description:
-          'Use inside the XDSAppShell tree when building custom mobile navigation controls or route-aware nav items.',
+          'Use inside the XDSAppShell tree when building custom mobile navigation controls, route-aware nav items, or UI that should update at the same breakpoint as AppShell mobile nav.',
       },
       {
         guidance: true,
@@ -83,7 +83,7 @@ export const docs = {
       {
         guidance: false,
         description:
-          'Use for arbitrary responsive layout logic outside AppShell — use useMediaQuery for unrelated viewport checks.',
+          'Use as a general responsive primitive when the UI is not inside AppShell or does not need to align with AppShell mobile nav — use useMediaQuery instead.',
       },
       {
         guidance: false,
@@ -106,9 +106,10 @@ export const docs = {
 /** @type {import('../docs-types').HookTranslationDoc} */
 export const docsDense = {
   description:
-    'Reads/controls XDSAppShell mobile nav context. Use for custom mobile nav triggers, route-aware nav items that close drawer, or AppShell-aware nav components.',
+    'Reads/controls XDSAppShell mobile nav context. Use for custom triggers, closing drawer after route changes, or syncing AppShell-adjacent mobile UI to the same breakpoint as mobile nav.',
   returnDescriptions: {
-    isMobile: 'viewport below AppShell mobile nav breakpoint?',
+    isMobile:
+      'viewport below AppShell mobile nav breakpoint? Use to sync AppShell-adjacent mobile UI',
     isMobileNavOpen: 'AppShell-managed mobile nav drawer open?',
     toggleMobileNav: 'toggle drawer; no-op when mobile nav disabled',
     openMobileNav: 'open drawer; no-op when mobile nav disabled',
@@ -120,12 +121,12 @@ export const docsDense = {
   },
   usage: {
     description:
-      'Reads/controls XDSAppShell mobile nav context. Use for custom mobile nav triggers, route-aware nav items that close drawer, or AppShell-aware nav components.',
+      'Reads/controls XDSAppShell mobile nav context. Use for custom triggers, closing drawer after route changes, or syncing AppShell-adjacent mobile UI to the same breakpoint as mobile nav.',
     bestPractices: [
       {
         guidance: true,
         description:
-          'Use inside XDSAppShell tree for custom mobile nav controls / route-aware nav items.',
+          'Use inside XDSAppShell tree for custom nav controls, route-aware nav items, or UI that should update at AppShell mobile nav breakpoint.',
       },
       {
         guidance: true,
@@ -140,7 +141,7 @@ export const docsDense = {
       {
         guidance: false,
         description:
-          'Use for arbitrary responsive layout outside AppShell — use useMediaQuery instead.',
+          'Use as general responsive primitive when not inside AppShell / not aligning to AppShell mobile nav — use useMediaQuery instead.',
       },
       {
         guidance: false,


### PR DESCRIPTION
## Summary
- Add HookDoc coverage for `useXDSAppShellMobile` in the AppShell package docs
- Document returned mobile nav context fields, usage guidance, related components/hooks, and dense docs
- Clarify that the hook is valid for coordinating AppShell-adjacent mobile UI with the same breakpoint used by mobile nav
- Clarify that `useMediaQuery` should be used when there is no AppShell context or no need to align with AppShell mobile nav
- Group AppShell docs under `AppShell` so the hook appears under the AppShell doc structure

## Test Plan
- `pnpm check:repo`
- `node packages/cli/bin/xds.mjs hook useXDSAppShellMobile --detail compact`
- `node packages/cli/bin/xds.mjs --lang dense hook useXDSAppShellMobile --detail compact`