### PR TITLE
fix(docsite): strip copyright from code examples

### DIFF
--- a/apps/docsite/src/__tests__/code-examples.test.ts
+++ b/apps/docsite/src/__tests__/code-examples.test.ts
@@ -1,0 +1,35 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {describe, expect, it} from 'vitest';
+import {stripCodeExampleCopyrightHeader} from '../lib/codeExamples';
+
+const HEADER = '// Copyright (c) Meta Platforms, Inc. and affiliates.';
+
+describe('stripCodeExampleCopyrightHeader', () => {
+  it('removes the canonical repo header and following blank line', () => {
+    expect(
+      stripCodeExampleCopyrightHeader(
+        `${HEADER}\n\nexport function Example() {}`,
+      ),
+    ).toBe('export function Example() {}');
+  });
+
+  it('handles CRLF line endings', () => {
+    expect(
+      stripCodeExampleCopyrightHeader(`${HEADER}\r\n\r\nconst x = 1;`),
+    ).toBe('const x = 1;');
+  });
+
+  it('preserves shebangs while removing the copyright line after them', () => {
+    expect(
+      stripCodeExampleCopyrightHeader(
+        `#!/usr/bin/env node\n${HEADER}\n\nconsole.log('hi');`,
+      ),
+    ).toBe("#!/usr/bin/env node\nconsole.log('hi');");
+  });
+
+  it('leaves non-header comments untouched', () => {
+    const code = `const x = 1;\n${HEADER}\nconst y = 2;`;
+    expect(stripCodeExampleCopyrightHeader(code)).toBe(code);
+  });
+});

--- a/apps/docsite/src/app/(docs)/components/page.tsx
+++ b/apps/docsite/src/app/(docs)/components/page.tsx
@@ -18,7 +18,7 @@ import {XDSDivider} from '@xds/core/Divider';
 import {XDSButton} from '@xds/core/Button';
 import {XDSPopover} from '@xds/core/Popover';
 import {XDSCard} from '@xds/core/Card';
-import {XDSCodeBlock} from '@xds/core/CodeBlock';
+import {CodeExampleBlock} from '../../../components/CodeExampleBlock';
 import {components as componentRegistry} from '../../../generated/componentRegistry';
 import {blocks} from '../../../generated/blockRegistry';
 import {ShowcaseThumbnail} from '../../../components/ShowcaseThumbnail';
@@ -151,7 +151,7 @@ export default function ComponentsGalleryPage() {
                     1. Install the package
                   </XDSText>
                   <XDSCard padding={0}>
-                    <XDSCodeBlock
+                    <CodeExampleBlock
                       code="npm install @xds/core"
                       language="bash"
                       hasCopyButton
@@ -163,7 +163,7 @@ export default function ComponentsGalleryPage() {
                     2. Import a component
                   </XDSText>
                   <XDSCard padding={0}>
-                    <XDSCodeBlock
+                    <CodeExampleBlock
                       code="import {...} from '@xds/core/ComponentName';"
                       language="typescript"
                       hasCopyButton

--- a/apps/docsite/src/app/playground/PlaygroundClient.tsx
+++ b/apps/docsite/src/app/playground/PlaygroundClient.tsx
@@ -71,6 +71,7 @@ import {annotateInstanceIds} from './babelParser';
 import {trackCopy} from '../../lib/analytics';
 import {PlaygroundThemeEditor} from '../../components/themePlayground/PlaygroundThemeEditor';
 import {DEFAULT_CODE} from './defaultCode';
+import {stripCodeExampleCopyrightHeader} from '../../lib/codeExamples';
 
 import type * as MonacoTypes from 'monaco-editor';
 import type {XDSDefinedTheme} from '@xds/core/theme';
@@ -735,7 +736,7 @@ export function PlaygroundClient() {
         .map(({label, source}) => ({
           label,
           onClick: () => {
-            setCode(source);
+            setCode(stripCodeExampleCopyrightHeader(source));
             requestAnimationFrame(() => editorRef.current?.focus());
           },
         })),

--- a/apps/docsite/src/components/CodeExampleBlock.tsx
+++ b/apps/docsite/src/components/CodeExampleBlock.tsx
@@ -1,0 +1,19 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file CodeExampleBlock.tsx
+ * @input XDSCodeBlock props for docsite-rendered examples
+ * @output XDSCodeBlock with docsite-only source cleanup applied
+ * @position Shared docsite wrapper for displayed/copyable code snippets
+ */
+
+import {XDSCodeBlock, type XDSCodeBlockProps} from '@xds/core/CodeBlock';
+import {stripCodeExampleCopyrightHeader} from '../lib/codeExamples';
+
+export function CodeExampleBlock({code, ...props}: XDSCodeBlockProps) {
+  return (
+    <XDSCodeBlock {...props} code={stripCodeExampleCopyrightHeader(code)} />
+  );
+}

--- a/apps/docsite/src/components/component-detail/ComponentDetailClient.tsx
+++ b/apps/docsite/src/components/component-detail/ComponentDetailClient.tsx
@@ -10,7 +10,7 @@ import {XDSVStack} from '@xds/core/Layout';
 import {XDSSection} from '@xds/core/Section';
 import {XDSCard} from '@xds/core/Card';
 import {XDSDivider} from '@xds/core';
-import {XDSCodeBlock} from '@xds/core/CodeBlock';
+import {CodeExampleBlock} from '../CodeExampleBlock';
 import {XDSTabList, XDSTab} from '@xds/core/TabList';
 import {useMediaQuery} from '@xds/core/hooks';
 import {ShowcasePreview} from './ShowcasePreview';
@@ -70,7 +70,7 @@ function OverviewContent({
             {comp.usage.description}
           </XDSText>
 
-          <XDSCodeBlock
+          <CodeExampleBlock
             code={importPath}
             language="ts"
             width="100%"

--- a/apps/docsite/src/components/component-detail/ExampleBlock.tsx
+++ b/apps/docsite/src/components/component-detail/ExampleBlock.tsx
@@ -7,7 +7,7 @@ import {XDSCard} from '@xds/core/Card';
 import {XDSSection} from '@xds/core/Section';
 import {XDSCenter} from '@xds/core/Center';
 import {XDSText} from '@xds/core/Text';
-import {XDSCodeBlock} from '@xds/core/CodeBlock';
+import {CodeExampleBlock} from '../CodeExampleBlock';
 import {XDSTabList, XDSTab} from '@xds/core/TabList';
 import {XDSSpinner} from '@xds/core/Spinner';
 import {XDSButton} from '@xds/core/Button';
@@ -110,7 +110,7 @@ export function ExampleBlock({entry}: ExampleBlockProps) {
             {entry.description || 'No description available.'}
           </XDSText>
         ) : (
-          <XDSCodeBlock
+          <CodeExampleBlock
             code={entry.source}
             language="tsx"
             hasCopyButton

--- a/apps/docsite/src/components/component-detail/InteractivePreview.tsx
+++ b/apps/docsite/src/components/component-detail/InteractivePreview.tsx
@@ -15,7 +15,7 @@ import {getXDSComponent, resolveValue} from './resolveElements';
 import {XDSButton} from '@xds/core/Button';
 import {XDSCard} from '@xds/core/Card';
 import {XDSCenter} from '@xds/core/Center';
-import {XDSCodeBlock} from '@xds/core/CodeBlock';
+import {CodeExampleBlock} from '../CodeExampleBlock';
 import {XDSVStack} from '@xds/core/Layout';
 import {XDSText} from '@xds/core/Text';
 import {XDSTheme} from '@xds/core/theme';
@@ -292,7 +292,7 @@ export function InteractivePreviewStage({
             overflow: 'auto',
             paddingRight: 'var(--spacing-8)',
           }}>
-          <XDSCodeBlock
+          <CodeExampleBlock
             code={code}
             language="tsx"
             hasCopyButton

--- a/apps/docsite/src/components/docs/CodeBlock.tsx
+++ b/apps/docsite/src/components/docs/CodeBlock.tsx
@@ -5,7 +5,7 @@
 import * as stylex from '@stylexjs/stylex';
 import {XDSVStack} from '@xds/core/Layout';
 import {XDSText} from '@xds/core/Text';
-import {XDSCodeBlock} from '@xds/core/CodeBlock';
+import {CodeExampleBlock} from '../CodeExampleBlock';
 
 const styles = stylex.create({
   root: {width: '100%'},
@@ -27,7 +27,7 @@ export function CodeBlockRenderer({
           {label}
         </XDSText>
       )}
-      <XDSCodeBlock
+      <CodeExampleBlock
         code={code}
         language={lang}
         hasCopyButton

--- a/apps/docsite/src/components/docs/PackageActions.tsx
+++ b/apps/docsite/src/components/docs/PackageActions.tsx
@@ -5,7 +5,7 @@
 import {XDSText} from '@xds/core/Text';
 import {XDSVStack, XDSHStack} from '@xds/core/Layout';
 import {XDSPopover} from '@xds/core/Popover';
-import {XDSCodeBlock} from '@xds/core/CodeBlock';
+import {CodeExampleBlock} from '../CodeExampleBlock';
 import {XDSButton} from '@xds/core/Button';
 import {XDSCard} from '@xds/core/Card';
 
@@ -54,7 +54,7 @@ export function PackageActions({
                   {i + 1}. {step.label}
                 </XDSText>
                 <XDSCard padding={0}>
-                  <XDSCodeBlock
+                  <CodeExampleBlock
                     code={step.code}
                     language={step.language ?? 'bash'}
                     hasCopyButton

--- a/apps/docsite/src/components/playgroundLink.ts
+++ b/apps/docsite/src/components/playgroundLink.ts
@@ -1,15 +1,18 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 import {compressToEncodedURIComponent} from 'lz-string';
+import {stripCodeExampleCopyrightHeader} from '../lib/codeExamples';
 
 /**
  * Build a playground URL with prepopulated source code, and optionally a
  * seeded theme. When `theme` is given (a short theme slug like "neutral"),
  * it's added as a `?theme=` query param so the playground opens with that
  * theme applied + its Theme editor populated; the code rides in the hash.
+ * Repo-only copyright headers are stripped so examples open copy-ready.
  */
 export function buildPlaygroundHref(source: string, theme?: string): string {
-  const compressed = compressToEncodedURIComponent(source);
+  const cleanedSource = stripCodeExampleCopyrightHeader(source);
+  const compressed = compressToEncodedURIComponent(cleanedSource);
   const query = theme ? `?theme=${encodeURIComponent(theme)}` : '';
   return `/playground${query}#code=${compressed}`;
 }

--- a/apps/docsite/src/components/themePlayground/ComponentPreview.tsx
+++ b/apps/docsite/src/components/themePlayground/ComponentPreview.tsx
@@ -39,7 +39,7 @@ import {XDSRadioList, XDSRadioListItem} from '@xds/core/RadioList';
 import {XDSToken} from '@xds/core/Token';
 import {XDSTooltip} from '@xds/core/Tooltip';
 
-import {XDSCodeBlock} from '@xds/core/CodeBlock';
+import {CodeExampleBlock} from '../CodeExampleBlock';
 import {XDSCollapsible, XDSCollapsibleGroup} from '@xds/core/Collapsible';
 import {XDSStatusDot} from '@xds/core/StatusDot';
 import {XDSTextArea} from '@xds/core/TextArea';
@@ -828,7 +828,7 @@ export function ComponentPreview() {
                       }
                       value="export">
                       <div style={{paddingBlock: 'var(--spacing-3)'}}>
-                        <XDSCodeBlock
+                        <CodeExampleBlock
                           code={`Tax Year: 2024\nAccount: ***4821\nTotal Gains: $10,160.00\nDividends: $3,130.00`}
                           language="text"
                           size="sm"

--- a/apps/docsite/src/components/themePlayground/ThemeEditorView.tsx
+++ b/apps/docsite/src/components/themePlayground/ThemeEditorView.tsx
@@ -10,7 +10,7 @@ import {XDSButton} from '@xds/core/Button';
 import {XDSCard} from '@xds/core/Card';
 import {XDSHStack, XDSVStack} from '@xds/core/Stack';
 import {XDSText} from '@xds/core/Text';
-import {XDSCodeBlock} from '@xds/core/CodeBlock';
+import {CodeExampleBlock} from '../CodeExampleBlock';
 import {XDSDropdownMenu} from '@xds/core/DropdownMenu';
 import {
   ArrowLeftFilled16Icon as ArrowLeftIcon,
@@ -740,12 +740,16 @@ export function ThemeEditorView({
               <XDSText type="label">
                 1. Save as a theme file (e.g. {themeId}-theme.ts)
               </XDSText>
-              <XDSCodeBlock code={themeCode} language="typescript" size="sm" />
+              <CodeExampleBlock
+                code={themeCode}
+                language="typescript"
+                size="sm"
+              />
             </XDSVStack>
 
             <XDSVStack gap={2}>
               <XDSText type="label">2. Wrap your app with the theme</XDSText>
-              <XDSCodeBlock code={usageSnippet} language="tsx" size="sm" />
+              <CodeExampleBlock code={usageSnippet} language="tsx" size="sm" />
               <XDSText type="supporting" color="secondary">
                 Token and component overrides apply at runtime through{' '}
                 <code>XDSTheme</code>. To consume the theme as a stylesheet

--- a/apps/docsite/src/lib/codeExamples.ts
+++ b/apps/docsite/src/lib/codeExamples.ts
@@ -1,0 +1,20 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file codeExamples.ts
+ * @input Raw source strings used by docsite code examples and playground links
+ * @output Source strings with repository-only boilerplate removed for readers
+ * @position Shared docsite utility consumed by code blocks and playground links
+ */
+
+const META_COPYRIGHT_HEADER_RE =
+  /^(\uFEFF?(?:#![^\r\n]*(?:\r?\n))?)\/\/ Copyright \(c\) Meta Platforms, Inc\. and affiliates\.\r?\n(?:\r?\n)*/;
+
+/**
+ * Remove the repository copyright header from copied/rendered examples while
+ * leaving the rest of the source untouched. The header is useful in repo files
+ * but adds noise when people read or copy docs snippets.
+ */
+export function stripCodeExampleCopyrightHeader(code: string): string {
+  return code.replace(META_COPYRIGHT_HEADER_RE, '$1');
+}


### PR DESCRIPTION
## Summary

- add a docsite `CodeExampleBlock` wrapper that strips the repo copyright header before rendering or copying snippets
- apply the wrapper to docsite code examples and clean example sources used for playground links/template loads
- add coverage for canonical headers, CRLF line endings, shebang-preserving scripts, and non-header comments

Fixes #2676

## Test Plan

- `pnpm -F @xds/docsite generate`
- `pnpm -F @xds/docsite test -- src/__tests__/code-examples.test.ts`
- `pnpm -F @xds/docsite typecheck`
- `pnpm exec eslint apps/docsite/src/lib/codeExamples.ts apps/docsite/src/components/CodeExampleBlock.tsx apps/docsite/src/__tests__/code-examples.test.ts apps/docsite/src/components/playgroundLink.ts apps/docsite/src/app/playground/PlaygroundClient.tsx apps/docsite/src/components/docs/CodeBlock.tsx apps/docsite/src/components/docs/PackageActions.tsx apps/docsite/src/components/component-detail/ExampleBlock.tsx apps/docsite/src/components/component-detail/InteractivePreview.tsx apps/docsite/src/components/component-detail/ComponentDetailClient.tsx apps/docsite/src/components/themePlayground/ThemeEditorView.tsx apps/docsite/src/components/themePlayground/ComponentPreview.tsx 'apps/docsite/src/app/(docs)/components/page.tsx'`
- `pnpm check:repo`
