### PR TITLE
fix(docsite): open mobile theme selector above

### DIFF
--- a/apps/docsite/src/components/ThemePackagePage.tsx
+++ b/apps/docsite/src/components/ThemePackagePage.tsx
@@ -787,6 +787,7 @@ export function ThemePackagePage({packageName, theme}: ThemePackagePageProps) {
               label="Theme"
               isLabelHidden
               size="sm"
+              placement="above"
               options={switcherOptions}
               value={selectedPkgName}
               onChange={handleSelectPkg}


### PR DESCRIPTION
## Summary
- Set the mobile `/themes` page selector menu to `placement="above"` so it opens upward from the bottom floating toolbar.

## Validation
- `pnpm exec eslint apps/docsite/src/components/ThemePackagePage.tsx`
- `pnpm -F @xds/docsite generate`
- `pnpm -F @xds/theme-default -F @xds/theme-neutral -F @xds/theme-matcha -F @xds/theme-butter -F @xds/theme-gothic -F @xds/theme-stone -F @xds/theme-y2k build`
- `pnpm -F @xds/docsite typecheck`
