### PR TITLE
fix(docsite): add AppShell mobile hook example

### DIFF
--- a/packages/cli/templates/blocks/components/AppShell/AppShellMobileHookUsage.doc.mjs
+++ b/packages/cli/templates/blocks/components/AppShell/AppShellMobileHookUsage.doc.mjs
@@ -1,0 +1,14 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  exampleFor: 'useXDSAppShellMobile',
+  name: 'useXDSAppShellMobile — Custom Mobile Trigger',
+  displayName: 'useXDSAppShellMobile — Custom Mobile Trigger',
+  description:
+    'Custom mobile navigation trigger built with useXDSAppShellMobile. The trigger consumes the surrounding AppShell context instead of rendering its own shell.',
+  isReady: true,
+  aspectRatio: 4 / 3,
+  componentsUsed: ['AppShell', 'Button', 'Text', 'Layout'],
+};

--- a/packages/cli/templates/blocks/components/AppShell/AppShellMobileHookUsage.tsx
+++ b/packages/cli/templates/blocks/components/AppShell/AppShellMobileHookUsage.tsx
@@ -1,0 +1,62 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import {useXDSAppShellMobile} from '@xds/core/AppShell';
+import {XDSButton} from '@xds/core/Button';
+import {XDSHStack, XDSVStack} from '@xds/core/Layout';
+import {XDSText} from '@xds/core/Text';
+
+export default function AppShellMobileHookUsage() {
+  const {
+    closeMobileNav,
+    isMobile,
+    isMobileNavEnabled,
+    isMobileNavOpen,
+    openMobileNav,
+  } = useXDSAppShellMobile();
+
+  if (!isMobileNavEnabled) {
+    return (
+      <XDSVStack gap={2}>
+        <XDSButton label="Open navigation" variant="secondary" isDisabled />
+        <XDSText type="body" color="secondary">
+          No active AppShell mobile navigation context was detected. This hook
+          returns safe defaults outside AppShell, or when the surrounding
+          AppShell has mobile navigation disabled.
+        </XDSText>
+      </XDSVStack>
+    );
+  }
+
+  if (!isMobile) {
+    return (
+      <XDSVStack gap={2}>
+        <XDSButton label="Open navigation" variant="secondary" isDisabled />
+        <XDSText type="body" color="secondary">
+          AppShell mobile navigation context is available. Narrow the viewport
+          below the AppShell mobile breakpoint to make the custom trigger active.
+        </XDSText>
+      </XDSVStack>
+    );
+  }
+
+  return (
+    <XDSVStack gap={2}>
+      <XDSHStack gap={2} vAlign="center">
+        <XDSButton
+          label={isMobileNavOpen ? 'Close navigation' : 'Open navigation'}
+          variant="secondary"
+          onClick={isMobileNavOpen ? closeMobileNav : openMobileNav}
+        />
+        <XDSText type="body" color="secondary">
+          {isMobileNavOpen ? 'Mobile nav is open' : 'Mobile nav is closed'}
+        </XDSText>
+      </XDSHStack>
+      <XDSText type="body" color="secondary">
+        This button controls the nearest AppShell mobile nav from context — in
+        the docsite it opens and closes the surrounding page navigation.
+      </XDSText>
+    </XDSVStack>
+  );
+}

--- a/packages/cli/templates/blocks/components/AppShell/AppShellTopNavWithSideNav.doc.mjs
+++ b/packages/cli/templates/blocks/components/AppShell/AppShellTopNavWithSideNav.doc.mjs
@@ -4,7 +4,6 @@
 export const doc = {
   type: 'block',
   exampleFor: 'AppShell',
-  alsoExampleFor: ['useXDSAppShellMobile'],
   name: 'AppShell — Top Nav with Side Nav',
   displayName: 'AppShell — Top Nav with Side Nav',
   description:


### PR DESCRIPTION
## Problem

The docsite generated-data test requires every `useXDS*` hook page to have at least one example. `useXDSAppShellMobile` is generated as a hook page but did not have a dedicated example block.

A temporary fix on `main` attached the existing `AppShellTopNavWithSideNav` block via `alsoExampleFor`, but that reuses a full AppShell layout example rather than documenting the hook directly.

## Solution

Add a focused `useXDSAppShellMobile` template block that renders only a custom trigger/status component. It consumes the nearest AppShell mobile navigation context instead of rendering a nested AppShell; in the docsite, the trigger controls the surrounding page navigation when the viewport is below the AppShell mobile breakpoint.

This PR also removes the temporary `alsoExampleFor: ['useXDSAppShellMobile']` metadata from `AppShellTopNavWithSideNav` so the hook page is backed by the dedicated hook example instead.

The example explains the inactive states:

- no active AppShell mobile nav context detected
- context exists, but the viewport is above the mobile breakpoint

## Validation

Draft PR updated first for CI/verifier signal. Local follow-up validation:

- `pnpm -F @xds/cli typecheck:template-docs`
- `pnpm -F @xds/core build`
- `pnpm -F @xds/docsite generate`
- `pnpm -F @xds/docsite test`

CI:

- `docsite-test` passed on pushed head `638440ccea3ed0a35c95433020160b579586f0db`
