### PR TITLE
fix(docsite): support checkbox properties editor controls

### DIFF
--- a/apps/docsite/src/__tests__/component-prop-controls.test.ts
+++ b/apps/docsite/src/__tests__/component-prop-controls.test.ts
@@ -1,0 +1,71 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {describe, expect, it} from 'vitest';
+import {parsePropType} from '../components/component-detail/parsePropType';
+
+describe('component detail prop controls', () => {
+  it('treats XDSInputStatus as an editable status object control', () => {
+    expect(parsePropType('XDSInputStatus', 'status')).toEqual({
+      kind: 'input-status',
+      options: ['error', 'warning', 'success'],
+      allowEmpty: true,
+    });
+  });
+
+  it('treats inline status object types as editable status object controls', () => {
+    expect(
+      parsePropType(
+        "{ type: 'error' | 'warning' | 'success', message: string }",
+        'status',
+      ),
+    ).toEqual({
+      kind: 'input-status',
+      options: ['error', 'warning', 'success'],
+      allowEmpty: true,
+    });
+  });
+
+  it('preserves narrower inline status option unions', () => {
+    expect(
+      parsePropType(
+        "{ type: 'error' | 'warning'; message?: string }",
+        'status',
+      ),
+    ).toEqual({
+      kind: 'input-status',
+      options: ['error', 'warning'],
+      allowEmpty: true,
+    });
+  });
+
+  it('does not confuse delivery status unions for input status objects', () => {
+    expect(
+      parsePropType(
+        "'sending' | 'sent' | 'delivered' | 'read' | 'error'",
+        'status',
+      ),
+    ).toEqual({
+      kind: 'enum',
+      options: ['sending', 'sent', 'delivered', 'read', 'error'],
+      allowEmpty: false,
+    });
+  });
+
+  it('uses valid semantic icon options for XDSIconType props', () => {
+    const control = parsePropType('XDSIconType', 'labelIcon');
+
+    expect(control).toMatchObject({
+      kind: 'enum',
+      allowEmpty: true,
+    });
+    expect(control).toEqual(
+      expect.objectContaining({
+        options: expect.arrayContaining(['info', 'success', 'error', 'search']),
+      }),
+    );
+    if (control.kind === 'enum') {
+      expect(control.options).not.toContain('checkCircle');
+      expect(control.options).not.toContain('xCircle');
+    }
+  });
+});

--- a/apps/docsite/src/components/component-detail/InteractivePreview.tsx
+++ b/apps/docsite/src/components/component-detail/InteractivePreview.tsx
@@ -169,6 +169,12 @@ function buildInitialState(
         case 'syntax-theme':
           state[row.name] = allSyntaxPresets[0];
           break;
+        case 'input-status':
+          state[row.name] = {
+            type: control.options[0],
+            message: `${control.options[0]} status`,
+          };
+          break;
         case 'boolean':
           state[row.name] = false;
           break;

--- a/apps/docsite/src/components/component-detail/PlaygroundPropsTable.tsx
+++ b/apps/docsite/src/components/component-detail/PlaygroundPropsTable.tsx
@@ -81,6 +81,35 @@ function resolveSlotElement(
   }
 }
 
+type InputStatusOption = 'error' | 'warning' | 'success';
+
+const STATUS_OPTION_LABELS: Record<InputStatusOption, string> = {
+  error: 'Error',
+  warning: 'Warning',
+  success: 'Success',
+};
+
+function createStatusValue(type: InputStatusOption) {
+  return {
+    type,
+    message: `${STATUS_OPTION_LABELS[type]} status message`,
+  };
+}
+
+function getStatusValue(value: unknown): InputStatusOption | 'None' {
+  if (
+    value != null &&
+    typeof value === 'object' &&
+    'type' in value &&
+    typeof value.type === 'string' &&
+    value.type in STATUS_OPTION_LABELS
+  ) {
+    return value.type as InputStatusOption;
+  }
+
+  return 'None';
+}
+
 function humanizePackageName(pkgName: string): string {
   return pkgName
     .replace('@xds/theme-', '')
@@ -332,13 +361,47 @@ function InlineControl({
       );
     case 'enum': {
       const isNumeric = control.options.every(o => /^-?\d+(\.\d+)?$/.test(o));
+      const options = control.allowEmpty
+        ? ['None', ...control.options]
+        : control.options;
+      const selected =
+        value == null && control.allowEmpty
+          ? 'None'
+          : String(value ?? control.options[0]);
       return (
         <XDSSelector
           label={prop.name}
           isLabelHidden
-          value={String(value ?? control.options[0])}
-          options={control.options}
-          onChange={next => onChange(isNumeric ? Number(next) : next)}
+          value={selected}
+          options={options}
+          onChange={next => {
+            if (control.allowEmpty && (next === 'None' || next === '')) {
+              onChange(undefined);
+              return;
+            }
+            onChange(isNumeric ? Number(next) : next);
+          }}
+        />
+      );
+    }
+    case 'input-status': {
+      const selected = getStatusValue(value);
+      const options = control.allowEmpty
+        ? ['None', ...control.options]
+        : control.options;
+      return (
+        <XDSSelector
+          label={prop.name}
+          isLabelHidden
+          value={selected}
+          options={options}
+          onChange={next =>
+            onChange(
+              next === 'None' || next === ''
+                ? undefined
+                : createStatusValue(next as InputStatusOption),
+            )
+          }
         />
       );
     }

--- a/apps/docsite/src/components/component-detail/parsePropType.ts
+++ b/apps/docsite/src/components/component-detail/parsePropType.ts
@@ -12,8 +12,11 @@ export interface ElementOption {
   componentName: string;
 }
 
+type InputStatusOption = 'error' | 'warning' | 'success';
+
 export type PropControlDescriptor =
   | {kind: 'enum'; options: string[]; allowEmpty: boolean}
+  | {kind: 'input-status'; options: InputStatusOption[]; allowEmpty: boolean}
   | {kind: 'theme'}
   | {kind: 'syntax-theme'}
   | {kind: 'boolean'}
@@ -29,6 +32,68 @@ const NUMBER_LITERAL_RE = /^-?\d+(\.\d+)?$/;
 const CALLBACK_RE = /=>/;
 const NODE_TYPE_RE = /\b(ReactNode|ReactElement|JSX\.Element|ReactChild)\b/;
 const REACT_ELEMENT_RE = /ReactElement<(XDS\w+)Props>/g;
+
+const ICON_OPTIONS = [
+  'close',
+  'chevronDown',
+  'chevronLeft',
+  'chevronRight',
+  'check',
+  'success',
+  'error',
+  'warning',
+  'info',
+  'calendar',
+  'clock',
+  'externalLink',
+  'menu',
+  'moreHorizontal',
+  'search',
+  'arrowUp',
+  'arrowDown',
+  'arrowsUpDown',
+  'funnel',
+  'eyeSlash',
+  'viewColumns',
+  'copy',
+  'checkDouble',
+  'wrench',
+  'stop',
+  'microphone',
+];
+
+const INPUT_STATUS_OPTIONS: InputStatusOption[] = [
+  'error',
+  'warning',
+  'success',
+];
+
+function hasStringLiteral(typeStr: string, value: string): boolean {
+  return new RegExp(`['"]${value}['"]`).test(typeStr);
+}
+
+function parseStatusOptions(typeStr: string): InputStatusOption[] {
+  const literalOptions = INPUT_STATUS_OPTIONS.filter(status =>
+    hasStringLiteral(typeStr, status),
+  );
+  return literalOptions.length > 0 ? literalOptions : INPUT_STATUS_OPTIONS;
+}
+
+function isInputStatusType(typeStr: string, propName?: string): boolean {
+  if (propName !== 'status') {
+    return false;
+  }
+
+  if (/\bXDS(?:InputStatus|FieldStatus)\b/.test(typeStr)) {
+    return true;
+  }
+
+  return (
+    typeStr.trim().startsWith('{') &&
+    /\btype\s*:/.test(typeStr) &&
+    INPUT_STATUS_OPTIONS.some(status => hasStringLiteral(typeStr, status))
+  );
+}
 
 function splitUnion(input: string): string[] {
   const parts: string[] = [];
@@ -118,39 +183,18 @@ export function parsePropType(
   if (t === 'SyntaxTheme') {
     return {kind: 'syntax-theme'};
   }
-  if (t === 'XDSIconType' || t === 'XDSIconName') {
+  if (isInputStatusType(t, propName)) {
     return {
-      kind: 'enum',
-      options: [
-        'check',
-        'close',
-        'info',
-        'warning',
-        'search',
-        'calendar',
-        'clock',
-        'chevronDown',
-        'chevronLeft',
-        'chevronRight',
-        'checkCircle',
-        'xCircle',
-        'externalLink',
-        'menu',
-        'moreHorizontal',
-        'copy',
-        'wrench',
-        'arrowUp',
-        'arrowDown',
-        'eyeSlash',
-      ],
+      kind: 'input-status',
+      options: parseStatusOptions(t),
       allowEmpty: true,
     };
   }
-  if (t === 'XDSInputStatus') {
+  if (t === 'XDSIconType' || t === 'XDSIconName') {
     return {
       kind: 'enum',
-      options: ['default', 'error', 'warning', 'success'],
-      allowEmpty: false,
+      options: ICON_OPTIONS,
+      allowEmpty: true,
     };
   }
   if (t === 'XDSAppShellBreakpoint') {
@@ -250,6 +294,13 @@ export function coerceDefault(
     case 'string': {
       const m = STRING_LITERAL_RE.exec(v);
       return m ? m[1] : v;
+    }
+    case 'input-status': {
+      const m = STRING_LITERAL_RE.exec(v);
+      const stripped = m ? m[1] : v;
+      return control.options.includes(stripped as InputStatusOption)
+        ? {type: stripped, message: `${stripped} status`}
+        : undefined;
     }
     case 'element':
       return undefined;

--- a/packages/core/src/CheckboxInput/XDSCheckboxInput.test.tsx
+++ b/packages/core/src/CheckboxInput/XDSCheckboxInput.test.tsx
@@ -218,6 +218,20 @@ describe('XDSCheckboxInput', () => {
     );
   });
 
+  it('renders semantic labelIcon names as icons', () => {
+    const {container} = render(
+      <XDSCheckboxInput
+        label="Accept terms"
+        value={false}
+        onChange={() => {}}
+        labelIcon="info"
+      />,
+    );
+
+    expect(container.textContent).toBe('Accept terms');
+    expect(container.querySelector('.xds-icon')).toBeInTheDocument();
+  });
+
   it('renders status message and sets aria-invalid for error', () => {
     render(
       <XDSCheckboxInput

--- a/packages/core/src/Icon/XDSIcon.tsx
+++ b/packages/core/src/Icon/XDSIcon.tsx
@@ -282,7 +282,9 @@ function IconFromRegistry({
 }
 
 /**
- * Renders an icon slot value. Handles both ReactNode and component types:
+ * Renders an icon slot value. Handles semantic names, ReactNode values, and
+ * component types:
+ * - If the value is a semantic icon name string, wraps it in XDSIcon.
  * - If the value is a component (function or forwardRef object), wraps it in XDSIcon.
  * - Otherwise, renders the ReactNode directly.
  */
@@ -290,6 +292,10 @@ export function renderIconSlot(
   icon: React.ReactNode | XDSIconType,
   props?: {size?: XDSIconSize; color?: XDSIconColor},
 ): React.ReactNode {
+  if (typeof icon === 'string') {
+    return <XDSIcon icon={icon as XDSIconName} {...props} />;
+  }
+
   if (
     typeof icon === 'function' ||
     (typeof icon === 'object' && icon !== null && 'render' in icon)


### PR DESCRIPTION
## Summary

- Adds a dedicated docsite properties-editor control for input status object props, including inline `{type, message}` status shapes like Checkbox Input's `status` prop.
- Keeps optional enum props unset until a user selects a value, so optional icon controls no longer appear selected while the preview receives `undefined`.
- Allows semantic icon-name strings passed through icon slots to render via `XDSIcon`, so Checkbox Input `labelIcon` selections render as icons instead of text.
- Updates the docsite icon option list to valid semantic icon names and covers the new parsing behavior with tests.

Follow-up review feedback to derive icon options from the core icon registry is handled in [PR #2777](https://github.com/facebookexperimental/xds/pull/2777).

Fixes #2674.
Fixes #2675.

## Test Plan

- `pnpm -F @xds/docsite generate`
- `pnpm exec vitest run packages/core/src/CheckboxInput/XDSCheckboxInput.test.tsx`
- `cd apps/docsite && pnpm exec vitest run src/__tests__/component-prop-controls.test.ts`
- `pnpm -F @xds/docsite typecheck`
- `pnpm check:repo`
- `cd apps/docsite && pnpm exec vitest run`