### PR TITLE
fix(docsite): derive icon editor options from registry

### DIFF
--- a/.changeset/checkbox-icon-prop-editor.md
+++ b/.changeset/checkbox-icon-prop-editor.md
@@ -1,0 +1,5 @@
+---
+'@xds/core': patch
+---
+
+`renderIconSlot` now renders semantic icon-name strings through `XDSIcon`, so icon slots that accept semantic names display the registry icon instead of plain text. The core Icon package also exposes `XDS_ICON_NAMES`, a canonical semantic icon-name list derived from the default icon registry for tooling and docs controls.

--- a/.changeset/checkbox-icon-prop-editor.md
+++ b/.changeset/checkbox-icon-prop-editor.md
@@ -2,4 +2,4 @@
 '@xds/core': patch
 ---
 
-`renderIconSlot` now renders semantic icon-name strings through `XDSIcon`, so icon slots that accept semantic names display the registry icon instead of plain text. The core Icon package also exposes `XDS_ICON_NAMES`, a canonical semantic icon-name list derived from the default icon registry for tooling and docs controls.
+`renderIconSlot` now renders semantic icon-name strings through `XDSIcon`, so icon slots that accept semantic names display the registry icon instead of plain text. The core Icon package also exposes `getIconRegistry()`, letting tooling and docs controls derive semantic icon-name options from the same registry `XDSIcon` resolves against.

--- a/apps/docsite/src/__tests__/component-prop-controls.test.ts
+++ b/apps/docsite/src/__tests__/component-prop-controls.test.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-import {XDS_ICON_NAMES} from '@xds/core/Icon';
+import {getIconRegistry} from '@xds/core/Icon';
 import {describe, expect, it} from 'vitest';
 import {parsePropType} from '../components/component-detail/parsePropType';
 
@@ -60,7 +60,7 @@ describe('component detail prop controls', () => {
       allowEmpty: true,
     });
     if (control.kind === 'enum') {
-      expect(control.options).toEqual([...XDS_ICON_NAMES]);
+      expect(control.options).toEqual(Object.keys(getIconRegistry()));
     }
   });
 });

--- a/apps/docsite/src/__tests__/component-prop-controls.test.ts
+++ b/apps/docsite/src/__tests__/component-prop-controls.test.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+import {XDS_ICON_NAMES} from '@xds/core/Icon';
 import {describe, expect, it} from 'vitest';
 import {parsePropType} from '../components/component-detail/parsePropType';
 
@@ -51,21 +52,15 @@ describe('component detail prop controls', () => {
     });
   });
 
-  it('uses valid semantic icon options for XDSIconType props', () => {
+  it('derives XDSIconType options from the canonical icon registry', () => {
     const control = parsePropType('XDSIconType', 'labelIcon');
 
     expect(control).toMatchObject({
       kind: 'enum',
       allowEmpty: true,
     });
-    expect(control).toEqual(
-      expect.objectContaining({
-        options: expect.arrayContaining(['info', 'success', 'error', 'search']),
-      }),
-    );
     if (control.kind === 'enum') {
-      expect(control.options).not.toContain('checkCircle');
-      expect(control.options).not.toContain('xCircle');
+      expect(control.options).toEqual([...XDS_ICON_NAMES]);
     }
   });
 });

--- a/apps/docsite/src/components/component-detail/parsePropType.ts
+++ b/apps/docsite/src/components/component-detail/parsePropType.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-import {XDS_ICON_NAMES} from '@xds/core/Icon';
+import {getIconRegistry} from '@xds/core/Icon';
 
 /**
  * Parses a stringified TypeScript prop type into a control descriptor
@@ -166,7 +166,7 @@ export function parsePropType(
   if (t === 'XDSIconType' || t === 'XDSIconName') {
     return {
       kind: 'enum',
-      options: [...XDS_ICON_NAMES],
+      options: Object.keys(getIconRegistry()),
       allowEmpty: true,
     };
   }

--- a/apps/docsite/src/components/component-detail/parsePropType.ts
+++ b/apps/docsite/src/components/component-detail/parsePropType.ts
@@ -1,5 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+import {XDS_ICON_NAMES} from '@xds/core/Icon';
+
 /**
  * Parses a stringified TypeScript prop type into a control descriptor
  * that the playground can render an input for.
@@ -32,35 +34,6 @@ const NUMBER_LITERAL_RE = /^-?\d+(\.\d+)?$/;
 const CALLBACK_RE = /=>/;
 const NODE_TYPE_RE = /\b(ReactNode|ReactElement|JSX\.Element|ReactChild)\b/;
 const REACT_ELEMENT_RE = /ReactElement<(XDS\w+)Props>/g;
-
-const ICON_OPTIONS = [
-  'close',
-  'chevronDown',
-  'chevronLeft',
-  'chevronRight',
-  'check',
-  'success',
-  'error',
-  'warning',
-  'info',
-  'calendar',
-  'clock',
-  'externalLink',
-  'menu',
-  'moreHorizontal',
-  'search',
-  'arrowUp',
-  'arrowDown',
-  'arrowsUpDown',
-  'funnel',
-  'eyeSlash',
-  'viewColumns',
-  'copy',
-  'checkDouble',
-  'wrench',
-  'stop',
-  'microphone',
-];
 
 const INPUT_STATUS_OPTIONS: InputStatusOption[] = [
   'error',
@@ -193,7 +166,7 @@ export function parsePropType(
   if (t === 'XDSIconType' || t === 'XDSIconName') {
     return {
       kind: 'enum',
-      options: ICON_OPTIONS,
+      options: [...XDS_ICON_NAMES],
       allowEmpty: true,
     };
   }

--- a/packages/core/src/Icon/globalIconRegistry.test.tsx
+++ b/packages/core/src/Icon/globalIconRegistry.test.tsx
@@ -1,11 +1,22 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 import {describe, it, expect, beforeEach} from 'vitest';
-import {registerIcons, getIcon, resetIcons} from './globalIconRegistry';
+import {defaultIcons} from './defaultIcons';
+import {
+  registerIcons,
+  getIcon,
+  resetIcons,
+  XDS_ICON_NAMES,
+} from './globalIconRegistry';
 
 describe('iconRegistry (global, RSC-compatible)', () => {
   beforeEach(() => {
     resetIcons();
+  });
+
+  it('derives icon names from the default icon map', () => {
+    expect(XDS_ICON_NAMES).toEqual(Object.keys(defaultIcons));
+    expect(Object.isFrozen(XDS_ICON_NAMES)).toBe(true);
   });
 
   it('returns default icons when nothing is registered', () => {

--- a/packages/core/src/Icon/globalIconRegistry.test.tsx
+++ b/packages/core/src/Icon/globalIconRegistry.test.tsx
@@ -4,9 +4,9 @@ import {describe, it, expect, beforeEach} from 'vitest';
 import {defaultIcons} from './defaultIcons';
 import {
   registerIcons,
+  getIconRegistry,
   getIcon,
   resetIcons,
-  XDS_ICON_NAMES,
 } from './globalIconRegistry';
 
 describe('iconRegistry (global, RSC-compatible)', () => {
@@ -14,9 +14,12 @@ describe('iconRegistry (global, RSC-compatible)', () => {
     resetIcons();
   });
 
-  it('derives icon names from the default icon map', () => {
-    expect(XDS_ICON_NAMES).toEqual(Object.keys(defaultIcons));
-    expect(Object.isFrozen(XDS_ICON_NAMES)).toBe(true);
+  it('returns a default icon registry snapshot', () => {
+    const registry = getIconRegistry();
+
+    expect(Object.keys(registry)).toEqual(Object.keys(defaultIcons));
+    expect(registry).toEqual(defaultIcons);
+    expect(registry).not.toBe(defaultIcons);
   });
 
   it('returns default icons when nothing is registered', () => {
@@ -28,7 +31,10 @@ describe('iconRegistry (global, RSC-compatible)', () => {
   it('returns registered icons over defaults', () => {
     const customClose = 'custom-close-icon';
     registerIcons({close: customClose});
+
     expect(getIcon('close')).toBe(customClose);
+    expect(getIconRegistry().close).toBe(customClose);
+    expect(getIconRegistry().check).toBe(defaultIcons.check);
   });
 
   it('falls back to defaults for unregistered names', () => {
@@ -37,6 +43,13 @@ describe('iconRegistry (global, RSC-compatible)', () => {
     const checkIcon = getIcon('check');
     expect(checkIcon).toBeDefined();
     expect(checkIcon).not.toBe('custom-close');
+  });
+
+  it('keeps registry snapshots aligned with getIcon fallback behavior', () => {
+    registerIcons({close: null});
+
+    expect(getIcon('close')).toBe(defaultIcons.close);
+    expect(getIconRegistry().close).toBe(defaultIcons.close);
   });
 
   it('merges multiple registerIcons calls', () => {

--- a/packages/core/src/Icon/globalIconRegistry.tsx
+++ b/packages/core/src/Icon/globalIconRegistry.tsx
@@ -57,6 +57,15 @@ export type XDSIconName =
  */
 export type XDSIconRegistry = Record<XDSIconName, ReactNode>;
 
+/**
+ * Canonical list of semantic icon names supported by the default registry.
+ * Keep controls and docs in sync by deriving options from this list instead
+ * of hand-copying icon names.
+ */
+export const XDS_ICON_NAMES = Object.freeze(
+  Object.keys(defaultIcons),
+) as ReadonlyArray<XDSIconName>;
+
 // =============================================================================
 // Global Registry
 // =============================================================================

--- a/packages/core/src/Icon/globalIconRegistry.tsx
+++ b/packages/core/src/Icon/globalIconRegistry.tsx
@@ -3,7 +3,7 @@
 /**
  * @file globalIconRegistry.tsx
  * @input None (pure module-level state)
- * @output Exports registerIcons, getIcon, resetIcons, XDSIconName, XDSIconRegistry
+ * @output Exports registerIcons, getIconRegistry, getIcon, resetIcons, XDSIconName, XDSIconRegistry
  * @position Global icon registry; works in both server and client environments
  *
  * This module has NO 'use client' directive — it's importable from RSC.
@@ -57,15 +57,6 @@ export type XDSIconName =
  */
 export type XDSIconRegistry = Record<XDSIconName, ReactNode>;
 
-/**
- * Canonical list of semantic icon names supported by the default registry.
- * Keep controls and docs in sync by deriving options from this list instead
- * of hand-copying icon names.
- */
-export const XDS_ICON_NAMES = Object.freeze(
-  Object.keys(defaultIcons),
-) as ReadonlyArray<XDSIconName>;
-
 // =============================================================================
 // Global Registry
 // =============================================================================
@@ -88,6 +79,24 @@ let globalRegistry: Partial<XDSIconRegistry> = {};
  */
 export function registerIcons(icons: Partial<XDSIconRegistry>): void {
   globalRegistry = {...globalRegistry, ...icons};
+}
+
+/**
+ * Get a snapshot of the full icon registry, with registered icons overriding
+ * built-in defaults.
+ *
+ * Works in both server and client environments. Useful for tooling that needs
+ * to derive valid semantic icon-name options from the same registry XDSIcon
+ * resolves against.
+ */
+export function getIconRegistry(): Readonly<XDSIconRegistry> {
+  const registry = {...defaultIcons};
+
+  for (const name of Object.keys(globalRegistry) as XDSIconName[]) {
+    registry[name] = globalRegistry[name] ?? defaultIcons[name];
+  }
+
+  return registry;
 }
 
 /**

--- a/packages/core/src/Icon/index.ts
+++ b/packages/core/src/Icon/index.ts
@@ -5,7 +5,7 @@
 /**
  * @file index.ts
  * @input Imports XDSIcon component/types, icon registry, and global registration
- * @output Exports XDSIcon, icon registry, registerIcons, getIcon
+ * @output Exports XDSIcon, icon registry, icon names, registerIcons, getIcon
  * @position Component entry point; re-exported by /packages/core/src/index.ts
  *
  * SYNC: When modified, update this header and /packages/core/src/Icon/Icon.doc.mjs
@@ -20,5 +20,10 @@ export type {
 } from './XDSIcon';
 
 // Global registry (RSC-compatible, no 'use client')
-export {registerIcons, getIcon, resetIcons} from './globalIconRegistry';
+export {
+  registerIcons,
+  getIcon,
+  resetIcons,
+  XDS_ICON_NAMES,
+} from './globalIconRegistry';
 export type {XDSIconName, XDSIconRegistry} from './globalIconRegistry';

--- a/packages/core/src/Icon/index.ts
+++ b/packages/core/src/Icon/index.ts
@@ -5,7 +5,7 @@
 /**
  * @file index.ts
  * @input Imports XDSIcon component/types, icon registry, and global registration
- * @output Exports XDSIcon, icon registry, icon names, registerIcons, getIcon
+ * @output Exports XDSIcon, icon registry helpers, registerIcons, getIconRegistry, getIcon
  * @position Component entry point; re-exported by /packages/core/src/index.ts
  *
  * SYNC: When modified, update this header and /packages/core/src/Icon/Icon.doc.mjs
@@ -22,8 +22,8 @@ export type {
 // Global registry (RSC-compatible, no 'use client')
 export {
   registerIcons,
+  getIconRegistry,
   getIcon,
   resetIcons,
-  XDS_ICON_NAMES,
 } from './globalIconRegistry';
 export type {XDSIconName, XDSIconRegistry} from './globalIconRegistry';


### PR DESCRIPTION
## Summary

- Follows up on review feedback from [PR #2776](https://github.com/facebookexperimental/xds/pull/2776) by deriving docsite icon editor options from the core icon registry instead of a local hand-maintained list.
- Exposes `getIconRegistry()` from `@xds/core/Icon`, so tooling can inspect the same default-plus-registered icon registry that `XDSIcon` resolves against.
- Adds registry tests covering the default registry snapshot, registered icon overrides, and fallback behavior; updates the docsite parser test to assert it derives icon options from `getIconRegistry()`.

## Test Plan

- `pnpm -F @xds/core typecheck`
- `pnpm -F @xds/core test packages/core/src/Icon/globalIconRegistry.test.tsx`
- `pnpm -F @xds/core build`
- `pnpm -F @xds/docsite generate`
- `pnpm -F @xds/docsite test src/__tests__/component-prop-controls.test.ts`
- `pnpm check:repo`
