### PR TITLE
fix(docsite): use app shell for playground

### DIFF
--- a/apps/docsite/src/app/globals.css
+++ b/apps/docsite/src/app/globals.css
@@ -62,6 +62,15 @@ body:has([data-home-page]) #xds-app-shell-main {
   padding-top: 0;
 }
 
+/* The playground uses AppShell for its side-nav/mobile-nav behavior, but it
+   intentionally has no sticky marketing/docs top nav. Keep the full-bleed
+   editor flush with the AppShell content area instead of inheriting the
+   docs top-nav offset above. */
+body:has([data-playground-page]) #xds-app-shell-main {
+  scroll-padding-top: 0;
+  padding-top: 0;
+}
+
 /* Translucent top nav — frosted glass effect.
 
    The :where(:not(.xds-app-shell .xds-app-shell *)) guard scopes every frost

--- a/apps/docsite/src/app/globals.css
+++ b/apps/docsite/src/app/globals.css
@@ -62,14 +62,6 @@ body:has([data-home-page]) #xds-app-shell-main {
   padding-top: 0;
 }
 
-/* The playground mobile top bar owns navigation between Preview / Code /
-   Properties / Theme, so hide AppShell's generated hamburger for this route. */
-@media (max-width: 768px) {
-  body:has([data-playground-page]) [data-testid='mobile-nav-toggle'] {
-    display: none;
-  }
-}
-
 /* Translucent top nav — frosted glass effect.
 
    The :where(:not(.xds-app-shell .xds-app-shell *)) guard scopes every frost

--- a/apps/docsite/src/app/globals.css
+++ b/apps/docsite/src/app/globals.css
@@ -62,6 +62,14 @@ body:has([data-home-page]) #xds-app-shell-main {
   padding-top: 0;
 }
 
+/* The playground mobile top bar owns navigation between Preview / Code /
+   Properties / Theme, so hide AppShell's generated hamburger for this route. */
+@media (max-width: 768px) {
+  body:has([data-playground-page]) [data-testid='mobile-nav-toggle'] {
+    display: none;
+  }
+}
+
 /* Translucent top nav — frosted glass effect.
 
    The :where(:not(.xds-app-shell .xds-app-shell *)) guard scopes every frost

--- a/apps/docsite/src/app/globals.css
+++ b/apps/docsite/src/app/globals.css
@@ -48,7 +48,7 @@
    it measures the rendered header (post-hydration). The 64px fallback
    approximates the default XDS top-nav height so the layout reserves
    space immediately on the first paint. */
-#xds-app-shell-main {
+body:not(:has([data-playground-page])) #xds-app-shell-main {
   scroll-padding-top: var(--appshell-header-height, 64px);
   padding-top: var(--appshell-header-height, 64px);
 }
@@ -59,15 +59,6 @@
    here would introduce a visible cream-colored gap between the nav and
    the hero. scroll-padding-top is kept for anchor-link scrolling. */
 body:has([data-home-page]) #xds-app-shell-main {
-  padding-top: 0;
-}
-
-/* The playground uses AppShell for its side-nav/mobile-nav behavior, but it
-   intentionally has no sticky marketing/docs top nav. Keep the full-bleed
-   editor flush with the AppShell content area instead of inheriting the
-   docs top-nav offset above. */
-body:has([data-playground-page]) #xds-app-shell-main {
-  scroll-padding-top: 0;
   padding-top: 0;
 }
 

--- a/apps/docsite/src/app/playground/PlaygroundClient.tsx
+++ b/apps/docsite/src/app/playground/PlaygroundClient.tsx
@@ -42,7 +42,6 @@ import {
   XDSSideNavHeading,
   XDSSideNavItem,
   XDSSideNavSection,
-  useXDSSideNavRenderMode,
 } from '@xds/core/SideNav';
 import {XDSText, XDSHeading} from '@xds/core/Text';
 import {XDSStatusDot} from '@xds/core/StatusDot';
@@ -52,12 +51,12 @@ import {
   XDSSegmentedControlItem,
 } from '@xds/core/SegmentedControl';
 import {XDSTab, XDSTabList} from '@xds/core/TabList';
+import {XDSTopNav, XDSTopNavHeading} from '@xds/core/TopNav';
 import {XDSDropdownMenu} from '@xds/core/DropdownMenu';
 import {useMediaQuery} from '@xds/core/hooks';
 import {useXDSResizable, XDSResizeHandle} from '@xds/core/Resizable';
 import {XDSToggleButton} from '@xds/core/ToggleButton';
 import {
-  ArrowLeft,
   Check,
   Code2,
   Copy,
@@ -374,32 +373,6 @@ const s = stylex.create({
     transitionDuration: '0.5s',
     transitionTimingFunction: 'ease',
   },
-  topbarHeader: {
-    display: 'grid',
-    alignItems: 'center',
-    gridTemplateColumns: 'minmax(0, 1fr) auto minmax(0, 1fr)',
-    gap: 'var(--spacing-2)',
-    flex: 1,
-    width: '100%',
-    minWidth: 0,
-    boxSizing: 'border-box',
-    paddingInline: 'var(--spacing-1)',
-  },
-  topbarBrand: {
-    gridColumn: '1',
-    justifySelf: 'start',
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    flexShrink: 0,
-    width: 'var(--size-element-md)',
-    height: 'var(--size-element-md)',
-  },
-  mobileTabs: {
-    gridColumn: '2',
-    justifySelf: 'center',
-    flexShrink: 0,
-  },
   sideNavHeading: {
     paddingInline: {
       default: null,
@@ -412,103 +385,7 @@ const s = stylex.create({
       '@media (min-width: 769px)': 'calc(var(--spacing-12) + var(--spacing-2))',
     },
   },
-  topbarActions: {
-    gridColumn: '3',
-    justifySelf: 'end',
-    flexShrink: 0,
-  },
 });
-
-interface PlaygroundMobileShareActionProps {
-  copied: boolean;
-  onShare: () => void;
-}
-
-interface PlaygroundSideNavHeaderProps {
-  mobileTab: MobileTopTab;
-  copied: boolean;
-  onMobileTabChange: (tab: MobileTopTab) => void;
-  onShare: () => void;
-}
-
-function PlaygroundMobileShareAction({
-  copied,
-  onShare,
-}: PlaygroundMobileShareActionProps) {
-  return (
-    <XDSButton
-      label={copied ? '✓ Copied' : 'Share'}
-      variant="primary"
-      size="md"
-      onClick={onShare}
-      xstyle={s.topbarActions}
-    />
-  );
-}
-
-function PlaygroundSideNavHeader({
-  mobileTab,
-  copied,
-  onMobileTabChange,
-  onShare,
-}: PlaygroundSideNavHeaderProps) {
-  const renderMode = useXDSSideNavRenderMode();
-
-  if (renderMode === 'topbar') {
-    return (
-      <div {...stylex.props(s.topbarHeader)}>
-        <XDSLink
-          href="/"
-          label="Back to main site"
-          tooltip="Back to main site"
-          color="inherit"
-          xstyle={s.topbarBrand}>
-          {BRAND_ICON}
-        </XDSLink>
-        <XDSTabList
-          value={mobileTab}
-          onChange={value => onMobileTabChange(value as MobileTopTab)}
-          size="sm"
-          xstyle={s.mobileTabs}>
-          <XDSTab
-            value="preview"
-            label="Preview"
-            icon={<Monitor size={14} />}
-            isLabelHidden
-          />
-          <XDSTab
-            value="code"
-            label="Code"
-            icon={<Code2 size={14} />}
-            isLabelHidden
-          />
-          <XDSTab
-            value="property"
-            label="Properties"
-            icon={<SlidersHorizontal size={14} />}
-            isLabelHidden
-          />
-          <XDSTab
-            value="theme"
-            label="Theme"
-            icon={<Palette size={14} />}
-            isLabelHidden
-          />
-        </XDSTabList>
-        <PlaygroundMobileShareAction copied={copied} onShare={onShare} />
-      </div>
-    );
-  }
-
-  return (
-    <XDSSideNavHeading
-      icon={BRAND_ICON}
-      heading="Playground"
-      headingHref="/"
-      xstyle={s.sideNavHeading}
-    />
-  );
-}
 
 interface PlaygroundClientProps {
   defaultIsMobile?: boolean;
@@ -1033,30 +910,64 @@ export function PlaygroundClient({defaultIsMobile}: PlaygroundClientProps) {
     setIsFullscreen(true);
   }, []);
 
+  const mobileTopNav = isMobile ? (
+    <XDSTopNav
+      label="Playground navigation"
+      heading={<XDSTopNavHeading logo={BRAND_ICON} headingHref="/" />}
+      centerContent={
+        <XDSTabList
+          value={mobileTab}
+          onChange={value => handleMobileTabChange(value as MobileTopTab)}
+          size="sm">
+          <XDSTab
+            value="preview"
+            label="Preview"
+            icon={<Monitor size={14} />}
+            isLabelHidden
+          />
+          <XDSTab
+            value="code"
+            label="Code"
+            icon={<Code2 size={14} />}
+            isLabelHidden
+          />
+          <XDSTab
+            value="property"
+            label="Properties"
+            icon={<SlidersHorizontal size={14} />}
+            isLabelHidden
+          />
+          <XDSTab
+            value="theme"
+            label="Theme"
+            icon={<Palette size={14} />}
+            isLabelHidden
+          />
+        </XDSTabList>
+      }
+      endContent={
+        <XDSButton
+          label={copied ? '✓ Copied' : 'Share'}
+          variant="primary"
+          size="md"
+          onClick={handleShare}
+        />
+      }
+    />
+  ) : undefined;
+
   const playgroundSideNav = (
     <XDSSideNav
       header={
-        <PlaygroundSideNavHeader
-          mobileTab={mobileTab}
-          copied={copied}
-          onMobileTabChange={handleMobileTabChange}
-          onShare={handleShare}
+        <XDSSideNavHeading
+          icon={BRAND_ICON}
+          heading="Playground"
+          headingHref="/"
+          xstyle={s.sideNavHeading}
         />
       }
       collapsible={{isCollapsed: true, hasButton: false}}
-      xstyle={s.desktopCollapsedSideNav}
-      footerIcons={
-        !isMobile ? (
-          <XDSButton
-            label="Back to site"
-            tooltip="Back to site"
-            href="/"
-            variant="ghost"
-            isIconOnly
-            icon={<ArrowLeft size={20} />}
-          />
-        ) : undefined
-      }>
+      xstyle={s.desktopCollapsedSideNav}>
       <XDSSideNavSection title="Playground views" isHeaderHidden>
         <XDSSideNavItem
           label="Code"
@@ -1097,7 +1008,8 @@ export function PlaygroundClient({defaultIsMobile}: PlaygroundClientProps) {
       variant="section"
       height="fill"
       contentPadding={0}
-      mobileNav={{defaultIsMobile}}
+      mobileNav={isMobile ? false : {defaultIsMobile}}
+      topNav={mobileTopNav}
       sideNav={playgroundSideNav}>
       {/* Playground content */}
       <XDSHStack

--- a/apps/docsite/src/app/playground/PlaygroundClient.tsx
+++ b/apps/docsite/src/app/playground/PlaygroundClient.tsx
@@ -402,8 +402,17 @@ const s = stylex.create({
     justifySelf: 'center',
     flexShrink: 0,
   },
-  mobileIconTab: {
-    paddingInline: 'var(--spacing-2)',
+  sideNavHeading: {
+    paddingInline: {
+      default: null,
+      '@media (min-width: 769px)': 'var(--spacing-1)',
+    },
+  },
+  desktopCollapsedSideNav: {
+    width: {
+      default: null,
+      '@media (min-width: 769px)': 'calc(var(--spacing-12) + var(--spacing-2))',
+    },
   },
   topbarActions: {
     gridColumn: '3',
@@ -545,31 +554,27 @@ function PlaygroundSideNavHeader({
           xstyle={s.mobileTabs}>
           <XDSTab
             value="preview"
-            label=""
-            aria-label="Preview"
+            label="Preview"
             icon={<Monitor size={14} />}
-            xstyle={s.mobileIconTab}
+            isLabelHidden
           />
           <XDSTab
             value="code"
-            label=""
-            aria-label="Code"
+            label="Code"
             icon={<Code2 size={14} />}
-            xstyle={s.mobileIconTab}
+            isLabelHidden
           />
           <XDSTab
             value="property"
-            label=""
-            aria-label="Properties"
+            label="Properties"
             icon={<SlidersHorizontal size={14} />}
-            xstyle={s.mobileIconTab}
+            isLabelHidden
           />
           <XDSTab
             value="theme"
-            label=""
-            aria-label="Theme"
+            label="Theme"
             icon={<Palette size={14} />}
-            xstyle={s.mobileIconTab}
+            isLabelHidden
           />
         </XDSTabList>
         <PlaygroundMobileShareAction copied={copied} onShare={onShare} />
@@ -577,7 +582,14 @@ function PlaygroundSideNavHeader({
     );
   }
 
-  return <XDSSideNavHeading icon={BRAND_ICON} heading="Playground" />;
+  return (
+    <XDSSideNavHeading
+      icon={BRAND_ICON}
+      heading="Playground"
+      headingHref="/"
+      xstyle={s.sideNavHeading}
+    />
+  );
 }
 
 interface PlaygroundClientProps {
@@ -1114,6 +1126,7 @@ export function PlaygroundClient({defaultIsMobile}: PlaygroundClientProps) {
         />
       }
       collapsible={{isCollapsed: true, hasButton: false}}
+      xstyle={s.desktopCollapsedSideNav}
       footerIcons={
         !isMobile ? (
           <XDSButton

--- a/apps/docsite/src/app/playground/PlaygroundClient.tsx
+++ b/apps/docsite/src/app/playground/PlaygroundClient.tsx
@@ -42,6 +42,7 @@ import {
   XDSSideNavHeading,
   XDSSideNavItem,
   XDSSideNavSection,
+  useXDSSideNavRenderMode,
 } from '@xds/core/SideNav';
 import {XDSText, XDSHeading} from '@xds/core/Text';
 import {XDSStatusDot} from '@xds/core/StatusDot';
@@ -51,10 +52,15 @@ import {
   XDSSegmentedControlItem,
 } from '@xds/core/SegmentedControl';
 import {XDSDropdownMenu} from '@xds/core/DropdownMenu';
+import {useMediaQuery} from '@xds/core/hooks';
 import {useXDSResizable, XDSResizeHandle} from '@xds/core/Resizable';
 import {XDSToggleButton} from '@xds/core/ToggleButton';
 import {
+  ArrowLeft,
   Code2,
+  Copy,
+  Download,
+  LayoutTemplate,
   Moon,
   Palette,
   SlidersHorizontal,
@@ -290,6 +296,9 @@ function configureMonaco(monaco: MonacoInstance) {
 
 type LeftView = 'code' | 'property' | 'theme';
 type BuildStatus = 'idle' | 'building' | 'finished' | 'error';
+type PlaygroundMenuItem = {label: string; onClick: () => void};
+
+const MOBILE_BREAKPOINT_QUERY = '(max-width: 768px)';
 
 const BUILD_STATUS_META: Record<
   Exclude<BuildStatus, 'idle'>,
@@ -313,13 +322,19 @@ const s = stylex.create({
   root: {
     flex: 1,
     minWidth: 0,
+    width: '100%',
+    maxWidth: '100%',
     overflow: 'hidden',
     backgroundColor: 'var(--color-background-surface)',
   },
   leftPanel: {
-    flexShrink: 0,
+    flexShrink: {
+      default: 0,
+      '@media (max-width: 768px)': 1,
+    },
     overflow: 'hidden',
     minWidth: 0,
+    maxWidth: '100%',
   },
   leftPanelHeader: {
     flexShrink: 0,
@@ -360,13 +375,131 @@ const s = stylex.create({
     transitionDuration: '0.5s',
     transitionTimingFunction: 'ease',
   },
+  topbarHeader: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 'var(--spacing-2)',
+    width: '100%',
+    minWidth: 0,
+  },
+  topbarBrand: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+    width: 'var(--size-element-md)',
+    height: 'var(--size-element-md)',
+  },
+  topbarActions: {
+    flexShrink: 0,
+  },
 });
+
+interface PlaygroundHeaderActionsProps {
+  activeView: LeftView;
+  templateMenuItems: PlaygroundMenuItem[];
+  themeMenuItems: PlaygroundMenuItem[];
+  isCompact?: boolean;
+}
+
+function PlaygroundHeaderActions({
+  activeView,
+  templateMenuItems,
+  themeMenuItems,
+  isCompact = false,
+}: PlaygroundHeaderActionsProps) {
+  const variant = isCompact ? 'ghost' : 'secondary';
+  const gap = isCompact ? 0.5 : 2;
+
+  if (activeView === 'code') {
+    return (
+      <XDSHStack
+        gap={gap}
+        align="center"
+        xstyle={isCompact ? s.topbarActions : undefined}>
+        <XDSDropdownMenu
+          button={{
+            label: 'Templates',
+            tooltip: 'Templates',
+            variant,
+            size: 'sm',
+            ...(isCompact
+              ? {isIconOnly: true, icon: <LayoutTemplate size={18} />}
+              : {}),
+          }}
+          hasChevron={!isCompact}
+          items={templateMenuItems}
+        />
+        <XDSButton
+          variant={variant}
+          size="sm"
+          label="Copy Code"
+          tooltip={isCompact ? 'Copy Code' : undefined}
+          isIconOnly={isCompact}
+          icon={isCompact ? <Copy size={18} /> : undefined}
+        />
+      </XDSHStack>
+    );
+  }
+
+  if (activeView === 'theme') {
+    return (
+      <XDSHStack
+        gap={gap}
+        align="center"
+        xstyle={isCompact ? s.topbarActions : undefined}>
+        <XDSDropdownMenu
+          button={{
+            label: 'Apply Theme',
+            tooltip: 'Apply Theme',
+            variant,
+            size: 'sm',
+            ...(isCompact
+              ? {isIconOnly: true, icon: <Palette size={18} />}
+              : {}),
+          }}
+          hasChevron={!isCompact}
+          items={themeMenuItems}
+        />
+        <XDSButton
+          variant={variant}
+          size="sm"
+          label="Export Theme"
+          tooltip={isCompact ? 'Export Theme' : undefined}
+          isIconOnly={isCompact}
+          icon={isCompact ? <Download size={18} /> : undefined}
+        />
+      </XDSHStack>
+    );
+  }
+
+  return null;
+}
+
+function PlaygroundSideNavHeader(props: PlaygroundHeaderActionsProps) {
+  const renderMode = useXDSSideNavRenderMode();
+
+  if (renderMode === 'topbar') {
+    return (
+      <div {...stylex.props(s.topbarHeader)}>
+        <span {...stylex.props(s.topbarBrand)} aria-hidden="true">
+          {BRAND_ICON}
+        </span>
+        <PlaygroundHeaderActions {...props} isCompact />
+      </div>
+    );
+  }
+
+  return <XDSSideNavHeading icon={BRAND_ICON} heading="Playground" />;
+}
 
 interface PlaygroundClientProps {
   defaultIsMobile?: boolean;
 }
 
 export function PlaygroundClient({defaultIsMobile}: PlaygroundClientProps) {
+  const isMobile = useMediaQuery(MOBILE_BREAKPOINT_QUERY, defaultIsMobile);
   // The editor chrome follows the docsite's own light/dark mode, not the OS
   // (operator) color-scheme preference.
   const {mode: siteMode} = useThemeMode();
@@ -871,14 +1004,15 @@ export function PlaygroundClient({defaultIsMobile}: PlaygroundClientProps) {
   const playgroundSideNav = (
     <XDSSideNav
       header={
-        <XDSSideNavHeading
-          icon={BRAND_ICON}
-          heading="Playground"
-          headingHref="/"
+        <PlaygroundSideNavHeader
+          activeView={activeView}
+          templateMenuItems={templateMenuItems}
+          themeMenuItems={themeMenuItems}
         />
       }
       collapsible={{isCollapsed: true, hasButton: false}}>
       <XDSSideNavSection title="Playground views" isHeaderHidden>
+        <XDSSideNavItem label="Back to site" href="/" icon={ArrowLeft} />
         <XDSSideNavItem
           label="Code"
           icon={Code2}
@@ -917,33 +1051,37 @@ export function PlaygroundClient({defaultIsMobile}: PlaygroundClientProps) {
         xstyle={s.root}
         onPointerDownCapture={handleResizeProbe}>
         {/* Left panel — editor */}
-        <XDSVStack xstyle={s.leftPanel} width={editorPanel.size || 440}>
-          <XDSHStack
-            justify="between"
-            align="center"
-            xstyle={s.leftPanelHeader}>
-            <XDSHeading level={3}>Playground</XDSHeading>
-            <XDSHStack gap={2} align="center">
-              <XDSDropdownMenu
-                button={{
-                  label: 'Themes',
-                  variant: 'secondary',
-                  size: 'md',
-                }}
-                hasChevron
-                items={themeMenuItems}
-              />
-              <XDSDropdownMenu
-                button={{
-                  label: 'Templates',
-                  variant: 'secondary',
-                  size: 'md',
-                }}
-                hasChevron
-                items={templateMenuItems}
-              />
+        <XDSVStack
+          xstyle={s.leftPanel}
+          width={isMobile ? '100%' : editorPanel.size || 440}>
+          {!isMobile && (
+            <XDSHStack
+              justify="between"
+              align="center"
+              xstyle={s.leftPanelHeader}>
+              <XDSHeading level={3}>Playground</XDSHeading>
+              <XDSHStack gap={2} align="center">
+                <XDSDropdownMenu
+                  button={{
+                    label: 'Themes',
+                    variant: 'secondary',
+                    size: 'md',
+                  }}
+                  hasChevron
+                  items={themeMenuItems}
+                />
+                <XDSDropdownMenu
+                  button={{
+                    label: 'Templates',
+                    variant: 'secondary',
+                    size: 'md',
+                  }}
+                  hasChevron
+                  items={templateMenuItems}
+                />
+              </XDSHStack>
             </XDSHStack>
-          </XDSHStack>
+          )}
           <div {...stylex.props(s.tabBody)}>
             {/* Code: Monaco stays mounted to preserve typedefs + editor state */}
             <div
@@ -998,214 +1136,222 @@ export function PlaygroundClient({defaultIsMobile}: PlaygroundClientProps) {
           </div>
         </XDSVStack>
 
-        <XDSResizeHandle
-          label="Resize editor panel"
-          resizable={editorPanel.props}
-          pillPlacement="center"
-          hasDivider
-        />
+        {!isMobile && (
+          <XDSResizeHandle
+            label="Resize editor panel"
+            resizable={editorPanel.props}
+            pillPlacement="center"
+            hasDivider
+          />
+        )}
 
         {/* Right panel — preview */}
-        <XDSVStack xstyle={s.rightPanel}>
-          <XDSToolbar
-            label="Preview controls"
-            startContent={
-              <XDSToggleButton
-                label="Target element"
-                tooltip={
-                  isTargeting
-                    ? 'Exit targeting (Esc)'
-                    : 'Click to select an element'
-                }
-                isPressed={isTargeting}
-                onPressedChange={toggleTargeting}
-                size="md"
-                isIconOnly
-                icon={<Crosshair size={20} />}
-              />
-            }
-            centerContent={
-              <XDSHStack gap={2} vAlign="center">
-                <XDSButton
-                  label={
-                    mode === 'light' ? 'Switch to dark' : 'Switch to light'
+        {!isMobile && (
+          <XDSVStack xstyle={s.rightPanel}>
+            <XDSToolbar
+              label="Preview controls"
+              startContent={
+                <XDSToggleButton
+                  label="Target element"
+                  tooltip={
+                    isTargeting
+                      ? 'Exit targeting (Esc)'
+                      : 'Click to select an element'
                   }
-                  tooltip={mode === 'light' ? 'Dark mode' : 'Light mode'}
-                  variant="ghost"
+                  isPressed={isTargeting}
+                  onPressedChange={toggleTargeting}
                   size="md"
                   isIconOnly
-                  icon={
-                    mode === 'light' ? <Moon size={20} /> : <Sun size={20} />
-                  }
-                  onClick={() =>
-                    setMode(m => (m === 'light' ? 'dark' : 'light'))
-                  }
+                  icon={<Crosshair size={20} />}
                 />
-                <XDSSegmentedControl
-                  label="Viewport size"
-                  size="md"
-                  value={viewport}
-                  onChange={v => setViewport(v as Viewport)}>
-                  <XDSSegmentedControlItem
-                    value="desktop"
-                    label="Desktop"
-                    isLabelHidden
-                    icon={<Monitor size={20} />}
-                  />
-                  <XDSSegmentedControlItem
-                    value="phone"
-                    label="Phone"
-                    isLabelHidden
-                    icon={<Smartphone size={20} />}
-                  />
-                </XDSSegmentedControl>
-                <XDSButton
-                  label="Expand"
-                  tooltip="Fullscreen preview"
-                  variant="ghost"
-                  size="md"
-                  isIconOnly
-                  icon={<Maximize2 size={20} />}
-                  onClick={() => setIsFullscreen(true)}
-                />
-              </XDSHStack>
-            }
-            endContent={
-              <XDSHStack gap={4} vAlign="center">
-                {buildStatus !== 'idle' && (
-                  <div
-                    {...stylex.props(s.buildStatus)}
-                    style={{opacity: statusFading ? 0 : 1}}>
-                    <XDSStatusDot
-                      variant={BUILD_STATUS_META[buildStatus].variant}
-                      label={BUILD_STATUS_META[buildStatus].label}
-                      isPulsing={buildStatus === 'building'}
-                    />
-                    <XDSText type="supporting" color="secondary">
-                      {BUILD_STATUS_META[buildStatus].label}
-                    </XDSText>
-                    {buildStatus === 'error' && (
-                      <XDSButton
-                        label="Rebuild"
-                        tooltip="Rebuild"
-                        variant="ghost"
-                        size="sm"
-                        isIconOnly
-                        icon={<RotateCw size={16} />}
-                        onClick={handleRebuild}
-                      />
-                    )}
-                  </div>
-                )}
-                <XDSPopover
-                  label="Share template"
-                  placement="below"
-                  alignment="end"
-                  xstyle={s.popoverPadding}
-                  onOpenChange={open => {
-                    if (open) {
-                      setShareUrl(window.location.href);
-                      // Snapshot the live (ref-held) theme so the download
-                      // link below can derive its href from reactive state.
-                      setExportTheme(
-                        customThemeRef.current ?? editorInitialTheme,
-                      );
-                    }
-                  }}
-                  content={
-                    <XDSVStack gap={6}>
-                      <XDSVStack gap={2}>
-                        <XDSText type="label" weight="semibold">
-                          Share Playground
-                        </XDSText>
-                        <XDSHStack gap={2} vAlign="center" width="100%">
-                          <XDSTextInput
-                            label="Share URL"
-                            isLabelHidden
-                            isDisabled
-                            value={shareUrl}
-                            onChange={() => {}}
-                            xstyle={s.shareInput}
-                          />
-                          <XDSButton
-                            label={copied ? 'Copied' : 'Copy URL'}
-                            tooltip={copied ? 'Copied' : 'Copy URL'}
-                            variant="secondary"
-                            size="md"
-                            isIconOnly
-                            icon={
-                              copied ? <Check size={16} /> : <Copy size={16} />
-                            }
-                            onClick={handleShare}
-                          />
-                        </XDSHStack>
-                      </XDSVStack>
-                      <XDSVStack gap={2}>
-                        <XDSText type="label" weight="semibold">
-                          Export Theme File
-                        </XDSText>
-                        <XDSHStack gap={2} vAlign="center" width="100%">
-                          <XDSTextInput
-                            label="Theme name"
-                            isLabelHidden
-                            placeholder="Enter theme name"
-                            value={themeName}
-                            onChange={v =>
-                              setThemeName(v.replace(/[\s-]/g, ''))
-                            }
-                            xstyle={s.shareInput}
-                          />
-                          <XDSButton
-                            label="Download theme"
-                            tooltip="Download theme"
-                            variant="secondary"
-                            size="md"
-                            isIconOnly
-                            isDisabled={themeExport == null}
-                            icon={<Download size={16} />}
-                            onClick={() => downloadLinkRef.current?.click()}
-                          />
-                          {/* The real download target: a normally-rendered
-                              link whose href/download come from reactive
-                              state. The button above clicks it, so the
-                              browser performs a native download without us
-                              fabricating an <a> in the handler. */}
-                          {themeExport && (
-                            <a
-                              ref={downloadLinkRef}
-                              href={themeExport.href}
-                              download={themeExport.filename}
-                              {...stylex.props(s.hidden)}
-                              aria-hidden="true"
-                              tabIndex={-1}>
-                              Download theme file
-                            </a>
-                          )}
-                        </XDSHStack>
-                        <XDSLink href="/docs/theme" hasUnderline>
-                          Learn about using themes
-                        </XDSLink>
-                      </XDSVStack>
-                    </XDSVStack>
-                  }>
+              }
+              centerContent={
+                <XDSHStack gap={2} vAlign="center">
                   <XDSButton
-                    label="Export"
-                    variant="primary"
+                    label={
+                      mode === 'light' ? 'Switch to dark' : 'Switch to light'
+                    }
+                    tooltip={mode === 'light' ? 'Dark mode' : 'Light mode'}
+                    variant="ghost"
                     size="md"
-                    endContent={<ExternalLink size={16} />}
+                    isIconOnly
+                    icon={
+                      mode === 'light' ? <Moon size={20} /> : <Sun size={20} />
+                    }
+                    onClick={() =>
+                      setMode(m => (m === 'light' ? 'dark' : 'light'))
+                    }
                   />
-                </XDSPopover>
-              </XDSHStack>
-            }
-          />
-          <PreviewStage
-            viewport={viewport}
-            isFullscreen={isFullscreen}
-            onExitFullscreen={() => setIsFullscreen(false)}
-            iframeRef={iframeRef}
-            isInteractionDisabled={isResizing}
-          />
-        </XDSVStack>
+                  <XDSSegmentedControl
+                    label="Viewport size"
+                    size="md"
+                    value={viewport}
+                    onChange={v => setViewport(v as Viewport)}>
+                    <XDSSegmentedControlItem
+                      value="desktop"
+                      label="Desktop"
+                      isLabelHidden
+                      icon={<Monitor size={20} />}
+                    />
+                    <XDSSegmentedControlItem
+                      value="phone"
+                      label="Phone"
+                      isLabelHidden
+                      icon={<Smartphone size={20} />}
+                    />
+                  </XDSSegmentedControl>
+                  <XDSButton
+                    label="Expand"
+                    tooltip="Fullscreen preview"
+                    variant="ghost"
+                    size="md"
+                    isIconOnly
+                    icon={<Maximize2 size={20} />}
+                    onClick={() => setIsFullscreen(true)}
+                  />
+                </XDSHStack>
+              }
+              endContent={
+                <XDSHStack gap={4} vAlign="center">
+                  {buildStatus !== 'idle' && (
+                    <div
+                      {...stylex.props(s.buildStatus)}
+                      style={{opacity: statusFading ? 0 : 1}}>
+                      <XDSStatusDot
+                        variant={BUILD_STATUS_META[buildStatus].variant}
+                        label={BUILD_STATUS_META[buildStatus].label}
+                        isPulsing={buildStatus === 'building'}
+                      />
+                      <XDSText type="supporting" color="secondary">
+                        {BUILD_STATUS_META[buildStatus].label}
+                      </XDSText>
+                      {buildStatus === 'error' && (
+                        <XDSButton
+                          label="Rebuild"
+                          tooltip="Rebuild"
+                          variant="ghost"
+                          size="sm"
+                          isIconOnly
+                          icon={<RotateCw size={16} />}
+                          onClick={handleRebuild}
+                        />
+                      )}
+                    </div>
+                  )}
+                  <XDSPopover
+                    label="Share template"
+                    placement="below"
+                    alignment="end"
+                    xstyle={s.popoverPadding}
+                    onOpenChange={open => {
+                      if (open) {
+                        setShareUrl(window.location.href);
+                        // Snapshot the live (ref-held) theme so the download
+                        // link below can derive its href from reactive state.
+                        setExportTheme(
+                          customThemeRef.current ?? editorInitialTheme,
+                        );
+                      }
+                    }}
+                    content={
+                      <XDSVStack gap={6}>
+                        <XDSVStack gap={2}>
+                          <XDSText type="label" weight="semibold">
+                            Share Playground
+                          </XDSText>
+                          <XDSHStack gap={2} vAlign="center" width="100%">
+                            <XDSTextInput
+                              label="Share URL"
+                              isLabelHidden
+                              isDisabled
+                              value={shareUrl}
+                              onChange={() => {}}
+                              xstyle={s.shareInput}
+                            />
+                            <XDSButton
+                              label={copied ? 'Copied' : 'Copy URL'}
+                              tooltip={copied ? 'Copied' : 'Copy URL'}
+                              variant="secondary"
+                              size="md"
+                              isIconOnly
+                              icon={
+                                copied ? (
+                                  <Check size={16} />
+                                ) : (
+                                  <Copy size={16} />
+                                )
+                              }
+                              onClick={handleShare}
+                            />
+                          </XDSHStack>
+                        </XDSVStack>
+                        <XDSVStack gap={2}>
+                          <XDSText type="label" weight="semibold">
+                            Export Theme File
+                          </XDSText>
+                          <XDSHStack gap={2} vAlign="center" width="100%">
+                            <XDSTextInput
+                              label="Theme name"
+                              isLabelHidden
+                              placeholder="Enter theme name"
+                              value={themeName}
+                              onChange={v =>
+                                setThemeName(v.replace(/[\s-]/g, ''))
+                              }
+                              xstyle={s.shareInput}
+                            />
+                            <XDSButton
+                              label="Download theme"
+                              tooltip="Download theme"
+                              variant="secondary"
+                              size="md"
+                              isIconOnly
+                              isDisabled={themeExport == null}
+                              icon={<Download size={16} />}
+                              onClick={() => downloadLinkRef.current?.click()}
+                            />
+                            {/* The real download target: a normally-rendered
+                                link whose href/download come from reactive
+                                state. The button above clicks it, so the
+                                browser performs a native download without us
+                                fabricating an <a> in the handler. */}
+                            {themeExport && (
+                              <a
+                                ref={downloadLinkRef}
+                                href={themeExport.href}
+                                download={themeExport.filename}
+                                {...stylex.props(s.hidden)}
+                                aria-hidden="true"
+                                tabIndex={-1}>
+                                Download theme file
+                              </a>
+                            )}
+                          </XDSHStack>
+                          <XDSLink href="/docs/theme" hasUnderline>
+                            Learn about using themes
+                          </XDSLink>
+                        </XDSVStack>
+                      </XDSVStack>
+                    }>
+                    <XDSButton
+                      label="Export"
+                      variant="primary"
+                      size="md"
+                      endContent={<ExternalLink size={16} />}
+                    />
+                  </XDSPopover>
+                </XDSHStack>
+              }
+            />
+            <PreviewStage
+              viewport={viewport}
+              isFullscreen={isFullscreen}
+              onExitFullscreen={() => setIsFullscreen(false)}
+              iframeRef={iframeRef}
+              isInteractionDisabled={isResizing}
+            />
+          </XDSVStack>
+        )}
       </XDSHStack>
 
       <ConfirmDialog

--- a/apps/docsite/src/app/playground/PlaygroundClient.tsx
+++ b/apps/docsite/src/app/playground/PlaygroundClient.tsx
@@ -51,6 +51,7 @@ import {
   XDSSegmentedControl,
   XDSSegmentedControlItem,
 } from '@xds/core/SegmentedControl';
+import {XDSTab, XDSTabList} from '@xds/core/TabList';
 import {XDSDropdownMenu} from '@xds/core/DropdownMenu';
 import {useMediaQuery} from '@xds/core/hooks';
 import {useXDSResizable, XDSResizeHandle} from '@xds/core/Resizable';
@@ -295,6 +296,7 @@ function configureMonaco(monaco: MonacoInstance) {
 }
 
 type LeftView = 'code' | 'property' | 'theme';
+type MobileTopTab = 'preview' | 'code' | 'property' | 'theme';
 type BuildStatus = 'idle' | 'building' | 'finished' | 'error';
 type PlaygroundMenuItem = {label: string; onClick: () => void};
 
@@ -364,6 +366,8 @@ const s = stylex.create({
   rightPanel: {
     flex: 1,
     minWidth: 0,
+    width: '100%',
+    maxWidth: '100%',
     overflow: 'hidden',
     backgroundColor: 'var(--color-background-muted)',
   },
@@ -378,7 +382,7 @@ const s = stylex.create({
   topbarHeader: {
     display: 'flex',
     alignItems: 'center',
-    justifyContent: 'space-between',
+    justifyContent: 'flex-start',
     gap: 'var(--spacing-2)',
     width: '100%',
     minWidth: 0,
@@ -391,8 +395,15 @@ const s = stylex.create({
     width: 'var(--size-element-md)',
     height: 'var(--size-element-md)',
   },
+  mobileTabs: {
+    flexShrink: 0,
+  },
+  mobileIconTab: {
+    paddingInline: 'var(--spacing-2)',
+  },
   topbarActions: {
     flexShrink: 0,
+    marginInlineStart: 'auto',
   },
 });
 
@@ -401,6 +412,11 @@ interface PlaygroundHeaderActionsProps {
   templateMenuItems: PlaygroundMenuItem[];
   themeMenuItems: PlaygroundMenuItem[];
   isCompact?: boolean;
+}
+
+interface PlaygroundSideNavHeaderProps extends PlaygroundHeaderActionsProps {
+  mobileTab: MobileTopTab;
+  onMobileTabChange: (tab: MobileTopTab) => void;
 }
 
 function PlaygroundHeaderActions({
@@ -477,7 +493,11 @@ function PlaygroundHeaderActions({
   return null;
 }
 
-function PlaygroundSideNavHeader(props: PlaygroundHeaderActionsProps) {
+function PlaygroundSideNavHeader({
+  mobileTab,
+  onMobileTabChange,
+  ...actionsProps
+}: PlaygroundSideNavHeaderProps) {
   const renderMode = useXDSSideNavRenderMode();
 
   if (renderMode === 'topbar') {
@@ -486,7 +506,47 @@ function PlaygroundSideNavHeader(props: PlaygroundHeaderActionsProps) {
         <span {...stylex.props(s.topbarBrand)} aria-hidden="true">
           {BRAND_ICON}
         </span>
-        <PlaygroundHeaderActions {...props} isCompact />
+        <XDSTabList
+          value={mobileTab}
+          onChange={value => onMobileTabChange(value as MobileTopTab)}
+          size="sm"
+          xstyle={s.mobileTabs}>
+          <XDSTab
+            value="preview"
+            label=""
+            aria-label="Preview"
+            icon={<Monitor size={14} />}
+            xstyle={s.mobileIconTab}
+          />
+          <XDSTab
+            value="code"
+            label=""
+            aria-label="Code"
+            icon={<Code2 size={14} />}
+            xstyle={s.mobileIconTab}
+          />
+          <XDSTab
+            value="property"
+            label=""
+            aria-label="Properties"
+            icon={<SlidersHorizontal size={14} />}
+            xstyle={s.mobileIconTab}
+          />
+          <XDSTab
+            value="theme"
+            label=""
+            aria-label="Theme"
+            icon={<Palette size={14} />}
+            xstyle={s.mobileIconTab}
+          />
+        </XDSTabList>
+        {(mobileTab === 'code' || mobileTab === 'theme') && (
+          <PlaygroundHeaderActions
+            {...actionsProps}
+            activeView={mobileTab}
+            isCompact
+          />
+        )}
       </div>
     );
   }
@@ -526,6 +586,7 @@ export function PlaygroundClient({defaultIsMobile}: PlaygroundClientProps) {
   const editorInitialTheme =
     themeByValue[selectedTheme] ?? themeByValue[DEFAULT_PLAYGROUND_THEME];
   const [activeView, setActiveView] = useState<LeftView>('code');
+  const [mobileTab, setMobileTab] = useState<MobileTopTab>('code');
   const [viewport, setViewport] = useState<Viewport>('desktop');
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [isResizing, setIsResizing] = useState(false);
@@ -1001,6 +1062,13 @@ export function PlaygroundClient({defaultIsMobile}: PlaygroundClientProps) {
     [],
   );
 
+  const handleMobileTabChange = useCallback((tab: MobileTopTab) => {
+    setMobileTab(tab);
+    if (tab === 'code' || tab === 'property' || tab === 'theme') {
+      setActiveView(tab);
+    }
+  }, []);
+
   const playgroundSideNav = (
     <XDSSideNav
       header={
@@ -1008,6 +1076,8 @@ export function PlaygroundClient({defaultIsMobile}: PlaygroundClientProps) {
           activeView={activeView}
           templateMenuItems={templateMenuItems}
           themeMenuItems={themeMenuItems}
+          mobileTab={mobileTab}
+          onMobileTabChange={handleMobileTabChange}
         />
       }
       collapsible={{isCollapsed: true, hasButton: false}}>
@@ -1017,23 +1087,35 @@ export function PlaygroundClient({defaultIsMobile}: PlaygroundClientProps) {
           label="Code"
           icon={Code2}
           isSelected={activeView === 'code'}
-          onClick={() => setActiveView('code')}
+          onClick={() => {
+            setActiveView('code');
+            setMobileTab('code');
+          }}
         />
         <XDSSideNavItem
           label="Properties"
           icon={SlidersHorizontal}
           isSelected={activeView === 'property'}
-          onClick={() => setActiveView('property')}
+          onClick={() => {
+            setActiveView('property');
+            setMobileTab('property');
+          }}
         />
         <XDSSideNavItem
           label="Theme"
           icon={Palette}
           isSelected={activeView === 'theme'}
-          onClick={() => setActiveView('theme')}
+          onClick={() => {
+            setActiveView('theme');
+            setMobileTab('theme');
+          }}
         />
       </XDSSideNavSection>
     </XDSSideNav>
   );
+
+  const showEditorPanel = !isMobile || mobileTab !== 'preview';
+  const showPreviewPanel = !isMobile || mobileTab === 'preview';
 
   return (
     <XDSAppShell
@@ -1052,7 +1134,7 @@ export function PlaygroundClient({defaultIsMobile}: PlaygroundClientProps) {
         onPointerDownCapture={handleResizeProbe}>
         {/* Left panel — editor */}
         <XDSVStack
-          xstyle={s.leftPanel}
+          xstyle={[s.leftPanel, !showEditorPanel && s.hidden]}
           width={isMobile ? '100%' : editorPanel.size || 440}>
           {!isMobile && (
             <XDSHStack
@@ -1146,212 +1228,206 @@ export function PlaygroundClient({defaultIsMobile}: PlaygroundClientProps) {
         )}
 
         {/* Right panel — preview */}
-        {!isMobile && (
-          <XDSVStack xstyle={s.rightPanel}>
-            <XDSToolbar
-              label="Preview controls"
-              startContent={
-                <XDSToggleButton
-                  label="Target element"
-                  tooltip={
-                    isTargeting
-                      ? 'Exit targeting (Esc)'
-                      : 'Click to select an element'
+        <XDSVStack xstyle={[s.rightPanel, !showPreviewPanel && s.hidden]}>
+          <XDSToolbar
+            label="Preview controls"
+            startContent={
+              <XDSToggleButton
+                label="Target element"
+                tooltip={
+                  isTargeting
+                    ? 'Exit targeting (Esc)'
+                    : 'Click to select an element'
+                }
+                isPressed={isTargeting}
+                onPressedChange={toggleTargeting}
+                size="md"
+                isIconOnly
+                icon={<Crosshair size={20} />}
+              />
+            }
+            centerContent={
+              <XDSHStack gap={2} vAlign="center">
+                <XDSButton
+                  label={
+                    mode === 'light' ? 'Switch to dark' : 'Switch to light'
                   }
-                  isPressed={isTargeting}
-                  onPressedChange={toggleTargeting}
+                  tooltip={mode === 'light' ? 'Dark mode' : 'Light mode'}
+                  variant="ghost"
                   size="md"
                   isIconOnly
-                  icon={<Crosshair size={20} />}
+                  icon={
+                    mode === 'light' ? <Moon size={20} /> : <Sun size={20} />
+                  }
+                  onClick={() =>
+                    setMode(m => (m === 'light' ? 'dark' : 'light'))
+                  }
                 />
-              }
-              centerContent={
-                <XDSHStack gap={2} vAlign="center">
-                  <XDSButton
-                    label={
-                      mode === 'light' ? 'Switch to dark' : 'Switch to light'
-                    }
-                    tooltip={mode === 'light' ? 'Dark mode' : 'Light mode'}
-                    variant="ghost"
-                    size="md"
-                    isIconOnly
-                    icon={
-                      mode === 'light' ? <Moon size={20} /> : <Sun size={20} />
-                    }
-                    onClick={() =>
-                      setMode(m => (m === 'light' ? 'dark' : 'light'))
-                    }
+                <XDSSegmentedControl
+                  label="Viewport size"
+                  size="md"
+                  value={viewport}
+                  onChange={v => setViewport(v as Viewport)}>
+                  <XDSSegmentedControlItem
+                    value="desktop"
+                    label="Desktop"
+                    isLabelHidden
+                    icon={<Monitor size={20} />}
                   />
-                  <XDSSegmentedControl
-                    label="Viewport size"
-                    size="md"
-                    value={viewport}
-                    onChange={v => setViewport(v as Viewport)}>
-                    <XDSSegmentedControlItem
-                      value="desktop"
-                      label="Desktop"
-                      isLabelHidden
-                      icon={<Monitor size={20} />}
-                    />
-                    <XDSSegmentedControlItem
-                      value="phone"
-                      label="Phone"
-                      isLabelHidden
-                      icon={<Smartphone size={20} />}
-                    />
-                  </XDSSegmentedControl>
-                  <XDSButton
-                    label="Expand"
-                    tooltip="Fullscreen preview"
-                    variant="ghost"
-                    size="md"
-                    isIconOnly
-                    icon={<Maximize2 size={20} />}
-                    onClick={() => setIsFullscreen(true)}
+                  <XDSSegmentedControlItem
+                    value="phone"
+                    label="Phone"
+                    isLabelHidden
+                    icon={<Smartphone size={20} />}
                   />
-                </XDSHStack>
-              }
-              endContent={
-                <XDSHStack gap={4} vAlign="center">
-                  {buildStatus !== 'idle' && (
-                    <div
-                      {...stylex.props(s.buildStatus)}
-                      style={{opacity: statusFading ? 0 : 1}}>
-                      <XDSStatusDot
-                        variant={BUILD_STATUS_META[buildStatus].variant}
-                        label={BUILD_STATUS_META[buildStatus].label}
-                        isPulsing={buildStatus === 'building'}
+                </XDSSegmentedControl>
+                <XDSButton
+                  label="Expand"
+                  tooltip="Fullscreen preview"
+                  variant="ghost"
+                  size="md"
+                  isIconOnly
+                  icon={<Maximize2 size={20} />}
+                  onClick={() => setIsFullscreen(true)}
+                />
+              </XDSHStack>
+            }
+            endContent={
+              <XDSHStack gap={4} vAlign="center">
+                {buildStatus !== 'idle' && (
+                  <div
+                    {...stylex.props(s.buildStatus)}
+                    style={{opacity: statusFading ? 0 : 1}}>
+                    <XDSStatusDot
+                      variant={BUILD_STATUS_META[buildStatus].variant}
+                      label={BUILD_STATUS_META[buildStatus].label}
+                      isPulsing={buildStatus === 'building'}
+                    />
+                    <XDSText type="supporting" color="secondary">
+                      {BUILD_STATUS_META[buildStatus].label}
+                    </XDSText>
+                    {buildStatus === 'error' && (
+                      <XDSButton
+                        label="Rebuild"
+                        tooltip="Rebuild"
+                        variant="ghost"
+                        size="sm"
+                        isIconOnly
+                        icon={<RotateCw size={16} />}
+                        onClick={handleRebuild}
                       />
-                      <XDSText type="supporting" color="secondary">
-                        {BUILD_STATUS_META[buildStatus].label}
-                      </XDSText>
-                      {buildStatus === 'error' && (
-                        <XDSButton
-                          label="Rebuild"
-                          tooltip="Rebuild"
-                          variant="ghost"
-                          size="sm"
-                          isIconOnly
-                          icon={<RotateCw size={16} />}
-                          onClick={handleRebuild}
-                        />
-                      )}
-                    </div>
-                  )}
-                  <XDSPopover
-                    label="Share template"
-                    placement="below"
-                    alignment="end"
-                    xstyle={s.popoverPadding}
-                    onOpenChange={open => {
-                      if (open) {
-                        setShareUrl(window.location.href);
-                        // Snapshot the live (ref-held) theme so the download
-                        // link below can derive its href from reactive state.
-                        setExportTheme(
-                          customThemeRef.current ?? editorInitialTheme,
-                        );
-                      }
-                    }}
-                    content={
-                      <XDSVStack gap={6}>
-                        <XDSVStack gap={2}>
-                          <XDSText type="label" weight="semibold">
-                            Share Playground
-                          </XDSText>
-                          <XDSHStack gap={2} vAlign="center" width="100%">
-                            <XDSTextInput
-                              label="Share URL"
-                              isLabelHidden
-                              isDisabled
-                              value={shareUrl}
-                              onChange={() => {}}
-                              xstyle={s.shareInput}
-                            />
-                            <XDSButton
-                              label={copied ? 'Copied' : 'Copy URL'}
-                              tooltip={copied ? 'Copied' : 'Copy URL'}
-                              variant="secondary"
-                              size="md"
-                              isIconOnly
-                              icon={
-                                copied ? (
-                                  <Check size={16} />
-                                ) : (
-                                  <Copy size={16} />
-                                )
-                              }
-                              onClick={handleShare}
-                            />
-                          </XDSHStack>
-                        </XDSVStack>
-                        <XDSVStack gap={2}>
-                          <XDSText type="label" weight="semibold">
-                            Export Theme File
-                          </XDSText>
-                          <XDSHStack gap={2} vAlign="center" width="100%">
-                            <XDSTextInput
-                              label="Theme name"
-                              isLabelHidden
-                              placeholder="Enter theme name"
-                              value={themeName}
-                              onChange={v =>
-                                setThemeName(v.replace(/[\s-]/g, ''))
-                              }
-                              xstyle={s.shareInput}
-                            />
-                            <XDSButton
-                              label="Download theme"
-                              tooltip="Download theme"
-                              variant="secondary"
-                              size="md"
-                              isIconOnly
-                              isDisabled={themeExport == null}
-                              icon={<Download size={16} />}
-                              onClick={() => downloadLinkRef.current?.click()}
-                            />
-                            {/* The real download target: a normally-rendered
-                                link whose href/download come from reactive
-                                state. The button above clicks it, so the
-                                browser performs a native download without us
-                                fabricating an <a> in the handler. */}
-                            {themeExport && (
-                              <a
-                                ref={downloadLinkRef}
-                                href={themeExport.href}
-                                download={themeExport.filename}
-                                {...stylex.props(s.hidden)}
-                                aria-hidden="true"
-                                tabIndex={-1}>
-                                Download theme file
-                              </a>
-                            )}
-                          </XDSHStack>
-                          <XDSLink href="/docs/theme" hasUnderline>
-                            Learn about using themes
-                          </XDSLink>
-                        </XDSVStack>
+                    )}
+                  </div>
+                )}
+                <XDSPopover
+                  label="Share template"
+                  placement="below"
+                  alignment="end"
+                  xstyle={s.popoverPadding}
+                  onOpenChange={open => {
+                    if (open) {
+                      setShareUrl(window.location.href);
+                      // Snapshot the live (ref-held) theme so the download
+                      // link below can derive its href from reactive state.
+                      setExportTheme(
+                        customThemeRef.current ?? editorInitialTheme,
+                      );
+                    }
+                  }}
+                  content={
+                    <XDSVStack gap={6}>
+                      <XDSVStack gap={2}>
+                        <XDSText type="label" weight="semibold">
+                          Share Playground
+                        </XDSText>
+                        <XDSHStack gap={2} vAlign="center" width="100%">
+                          <XDSTextInput
+                            label="Share URL"
+                            isLabelHidden
+                            isDisabled
+                            value={shareUrl}
+                            onChange={() => {}}
+                            xstyle={s.shareInput}
+                          />
+                          <XDSButton
+                            label={copied ? 'Copied' : 'Copy URL'}
+                            tooltip={copied ? 'Copied' : 'Copy URL'}
+                            variant="secondary"
+                            size="md"
+                            isIconOnly
+                            icon={
+                              copied ? <Check size={16} /> : <Copy size={16} />
+                            }
+                            onClick={handleShare}
+                          />
+                        </XDSHStack>
                       </XDSVStack>
-                    }>
-                    <XDSButton
-                      label="Export"
-                      variant="primary"
-                      size="md"
-                      endContent={<ExternalLink size={16} />}
-                    />
-                  </XDSPopover>
-                </XDSHStack>
-              }
-            />
-            <PreviewStage
-              viewport={viewport}
-              isFullscreen={isFullscreen}
-              onExitFullscreen={() => setIsFullscreen(false)}
-              iframeRef={iframeRef}
-              isInteractionDisabled={isResizing}
-            />
-          </XDSVStack>
-        )}
+                      <XDSVStack gap={2}>
+                        <XDSText type="label" weight="semibold">
+                          Export Theme File
+                        </XDSText>
+                        <XDSHStack gap={2} vAlign="center" width="100%">
+                          <XDSTextInput
+                            label="Theme name"
+                            isLabelHidden
+                            placeholder="Enter theme name"
+                            value={themeName}
+                            onChange={v =>
+                              setThemeName(v.replace(/[\s-]/g, ''))
+                            }
+                            xstyle={s.shareInput}
+                          />
+                          <XDSButton
+                            label="Download theme"
+                            tooltip="Download theme"
+                            variant="secondary"
+                            size="md"
+                            isIconOnly
+                            isDisabled={themeExport == null}
+                            icon={<Download size={16} />}
+                            onClick={() => downloadLinkRef.current?.click()}
+                          />
+                          {/* The real download target: a normally-rendered
+                              link whose href/download come from reactive
+                              state. The button above clicks it, so the
+                              browser performs a native download without us
+                              fabricating an <a> in the handler. */}
+                          {themeExport && (
+                            <a
+                              ref={downloadLinkRef}
+                              href={themeExport.href}
+                              download={themeExport.filename}
+                              {...stylex.props(s.hidden)}
+                              aria-hidden="true"
+                              tabIndex={-1}>
+                              Download theme file
+                            </a>
+                          )}
+                        </XDSHStack>
+                        <XDSLink href="/docs/theme" hasUnderline>
+                          Learn about using themes
+                        </XDSLink>
+                      </XDSVStack>
+                    </XDSVStack>
+                  }>
+                  <XDSButton
+                    label="Export"
+                    variant="primary"
+                    size="md"
+                    endContent={<ExternalLink size={16} />}
+                  />
+                </XDSPopover>
+              </XDSHStack>
+            }
+          />
+          <PreviewStage
+            viewport={viewport}
+            isFullscreen={isFullscreen}
+            onExitFullscreen={() => setIsFullscreen(false)}
+            iframeRef={iframeRef}
+            isInteractionDisabled={isResizing}
+          />
+        </XDSVStack>
       </XDSHStack>
 
       <ConfirmDialog

--- a/apps/docsite/src/app/playground/PlaygroundClient.tsx
+++ b/apps/docsite/src/app/playground/PlaygroundClient.tsx
@@ -6,7 +6,8 @@
  * @output Full-page two-panel playground (editor + live preview)
  * @position app/playground — the interactive XDS code playground.
  *
- * Sidebar: icon-only nav strip — back, Code view, Properties view.
+ * AppShell: side-nav-only shell; desktop nav is controlled collapsed to
+ * an icon rail while AppShell owns the mobile top bar and drawer.
  * Left panel: Monaco editor (Code) or knobs (Properties).
  *   - Code: Monaco editor (controlled) with real XDS .d.ts typedefs.
  *   - Property: component selector + instance picker + knobs that edit the code.
@@ -30,11 +31,18 @@ import {
   compressToEncodedURIComponent,
   decompressFromEncodedURIComponent,
 } from 'lz-string';
+import {XDSAppShell} from '@xds/core/AppShell';
 import {XDSButton} from '@xds/core/Button';
-import {XDSPopover} from '@xds/core/Popover';
-import {XDSTextInput} from '@xds/core/TextInput';
 import {XDSLink} from '@xds/core/Link';
 import {XDSHStack, XDSVStack} from '@xds/core/Layout';
+import {XDSPopover} from '@xds/core/Popover';
+import {XDSTextInput} from '@xds/core/TextInput';
+import {
+  XDSSideNav,
+  XDSSideNavHeading,
+  XDSSideNavItem,
+  XDSSideNavSection,
+} from '@xds/core/SideNav';
 import {XDSText, XDSHeading} from '@xds/core/Text';
 import {XDSStatusDot} from '@xds/core/StatusDot';
 import {XDSToolbar} from '@xds/core/Toolbar';
@@ -44,7 +52,7 @@ import {
 } from '@xds/core/SegmentedControl';
 import {XDSDropdownMenu} from '@xds/core/DropdownMenu';
 import {useXDSResizable, XDSResizeHandle} from '@xds/core/Resizable';
-import {XDSToggleButton, XDSToggleButtonGroup} from '@xds/core/ToggleButton';
+import {XDSToggleButton} from '@xds/core/ToggleButton';
 import {
   Code2,
   Moon,
@@ -302,22 +310,11 @@ const s = stylex.create({
   popoverPadding: {
     padding: 'var(--spacing-4)',
   },
-  navGroup: {
-    gap: 'var(--spacing-2)',
-  },
   root: {
     flex: 1,
     minWidth: 0,
     overflow: 'hidden',
     backgroundColor: 'var(--color-background-surface)',
-  },
-  sidebar: {
-    flexShrink: 0,
-    backgroundColor: 'var(--color-background-surface)',
-    borderInlineEndWidth: '1px',
-    borderInlineEndStyle: 'solid',
-    borderInlineEndColor: 'var(--color-border)',
-    padding: 'var(--spacing-3)',
   },
   leftPanel: {
     flexShrink: 0,
@@ -365,7 +362,11 @@ const s = stylex.create({
   },
 });
 
-export function PlaygroundClient() {
+interface PlaygroundClientProps {
+  defaultIsMobile?: boolean;
+}
+
+export function PlaygroundClient({defaultIsMobile}: PlaygroundClientProps) {
   // The editor chrome follows the docsite's own light/dark mode, not the OS
   // (operator) color-scheme preference.
   const {mode: siteMode} = useThemeMode();
@@ -867,50 +868,52 @@ export function PlaygroundClient() {
     [],
   );
 
-  return (
-    <XDSHStack align="stretch" height="100%" width="100%">
-      {/* Playground navigation */}
-      <XDSVStack align="center" xstyle={s.sidebar} gap={4}>
-        <XDSLink href="/" label="Go to home">
-          {BRAND_ICON}
-        </XDSLink>
-        <XDSToggleButtonGroup
-          type="single"
-          orientation="vertical"
-          label="Playground view"
-          value={activeView}
-          // Single-select groups allow deselecting to null; guard against it so
-          // one view is always active.
-          onChange={v => v && setActiveView(v as LeftView)}
-          size="md"
-          xstyle={s.navGroup}>
-          <XDSToggleButton
-            value="code"
-            label="Code"
-            tooltip="Code"
-            isIconOnly
-            icon={<Code2 size={20} />}
-          />
-          <XDSToggleButton
-            value="property"
-            label="Properties"
-            tooltip="Properties"
-            isIconOnly
-            icon={<SlidersHorizontal size={20} />}
-          />
-          <XDSToggleButton
-            value="theme"
-            label="Theme"
-            tooltip="Theme"
-            isIconOnly
-            icon={<Palette size={20} />}
-          />
-        </XDSToggleButtonGroup>
-      </XDSVStack>
+  const playgroundSideNav = (
+    <XDSSideNav
+      header={
+        <XDSSideNavHeading
+          icon={BRAND_ICON}
+          heading="Playground"
+          headingHref="/"
+        />
+      }
+      collapsible={{isCollapsed: true, hasButton: false}}>
+      <XDSSideNavSection title="Playground views" isHeaderHidden>
+        <XDSSideNavItem
+          label="Code"
+          icon={Code2}
+          isSelected={activeView === 'code'}
+          onClick={() => setActiveView('code')}
+        />
+        <XDSSideNavItem
+          label="Properties"
+          icon={SlidersHorizontal}
+          isSelected={activeView === 'property'}
+          onClick={() => setActiveView('property')}
+        />
+        <XDSSideNavItem
+          label="Theme"
+          icon={Palette}
+          isSelected={activeView === 'theme'}
+          onClick={() => setActiveView('theme')}
+        />
+      </XDSSideNavSection>
+    </XDSSideNav>
+  );
 
+  return (
+    <XDSAppShell
+      variant="section"
+      height="fill"
+      contentPadding={0}
+      mobileNav={{defaultIsMobile}}
+      sideNav={playgroundSideNav}>
       {/* Playground content */}
       <XDSHStack
+        data-playground-page="true"
+        align="stretch"
         height="100%"
+        width="100%"
         xstyle={s.root}
         onPointerDownCapture={handleResizeProbe}>
         {/* Left panel — editor */}
@@ -1230,6 +1233,6 @@ export function PlaygroundClient() {
           setPendingTemplateSource(null);
         }}
       />
-    </XDSHStack>
+    </XDSAppShell>
   );
 }

--- a/apps/docsite/src/app/playground/PlaygroundClient.tsx
+++ b/apps/docsite/src/app/playground/PlaygroundClient.tsx
@@ -380,14 +380,16 @@ const s = stylex.create({
     transitionTimingFunction: 'ease',
   },
   topbarHeader: {
-    display: 'flex',
+    display: 'grid',
     alignItems: 'center',
-    justifyContent: 'flex-start',
+    gridTemplateColumns: 'minmax(0, 1fr) auto minmax(0, 1fr)',
     gap: 'var(--spacing-2)',
     width: '100%',
     minWidth: 0,
   },
   topbarBrand: {
+    gridColumn: '1',
+    justifySelf: 'start',
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
@@ -396,14 +398,17 @@ const s = stylex.create({
     height: 'var(--size-element-md)',
   },
   mobileTabs: {
+    gridColumn: '2',
+    justifySelf: 'center',
     flexShrink: 0,
   },
   mobileIconTab: {
     paddingInline: 'var(--spacing-2)',
   },
   topbarActions: {
+    gridColumn: '3',
+    justifySelf: 'end',
     flexShrink: 0,
-    marginInlineStart: 'auto',
   },
 });
 
@@ -414,9 +419,22 @@ interface PlaygroundHeaderActionsProps {
   isCompact?: boolean;
 }
 
+interface PlaygroundPreviewHeaderActionsProps {
+  mode: 'light' | 'dark';
+  copied: boolean;
+  onToggleMode: () => void;
+  onExpand: () => void;
+  onShare: () => void;
+}
+
 interface PlaygroundSideNavHeaderProps extends PlaygroundHeaderActionsProps {
   mobileTab: MobileTopTab;
+  mode: 'light' | 'dark';
+  copied: boolean;
   onMobileTabChange: (tab: MobileTopTab) => void;
+  onToggleMode: () => void;
+  onExpand: () => void;
+  onShare: () => void;
 }
 
 function PlaygroundHeaderActions({
@@ -493,9 +511,54 @@ function PlaygroundHeaderActions({
   return null;
 }
 
+function PlaygroundPreviewHeaderActions({
+  mode,
+  copied,
+  onToggleMode,
+  onExpand,
+  onShare,
+}: PlaygroundPreviewHeaderActionsProps) {
+  return (
+    <XDSHStack gap={0.5} align="center" xstyle={s.topbarActions}>
+      <XDSButton
+        label={mode === 'light' ? 'Switch to dark' : 'Switch to light'}
+        tooltip={mode === 'light' ? 'Dark mode' : 'Light mode'}
+        variant="ghost"
+        size="sm"
+        isIconOnly
+        icon={mode === 'light' ? <Moon size={18} /> : <Sun size={18} />}
+        onClick={onToggleMode}
+      />
+      <XDSButton
+        label="Expand"
+        tooltip="Fullscreen preview"
+        variant="ghost"
+        size="sm"
+        isIconOnly
+        icon={<Maximize2 size={18} />}
+        onClick={onExpand}
+      />
+      <XDSButton
+        label={copied ? 'Copied' : 'Share'}
+        tooltip={copied ? 'Copied' : 'Share'}
+        variant="ghost"
+        size="sm"
+        isIconOnly
+        icon={<Share2 size={18} />}
+        onClick={onShare}
+      />
+    </XDSHStack>
+  );
+}
+
 function PlaygroundSideNavHeader({
   mobileTab,
+  mode,
+  copied,
   onMobileTabChange,
+  onToggleMode,
+  onExpand,
+  onShare,
   ...actionsProps
 }: PlaygroundSideNavHeaderProps) {
   const renderMode = useXDSSideNavRenderMode();
@@ -540,6 +603,15 @@ function PlaygroundSideNavHeader({
             xstyle={s.mobileIconTab}
           />
         </XDSTabList>
+        {mobileTab === 'preview' && (
+          <PlaygroundPreviewHeaderActions
+            mode={mode}
+            copied={copied}
+            onToggleMode={onToggleMode}
+            onExpand={onExpand}
+            onShare={onShare}
+          />
+        )}
         {(mobileTab === 'code' || mobileTab === 'theme') && (
           <PlaygroundHeaderActions
             {...actionsProps}
@@ -1069,6 +1141,14 @@ export function PlaygroundClient({defaultIsMobile}: PlaygroundClientProps) {
     }
   }, []);
 
+  const togglePreviewMode = useCallback(() => {
+    setMode(m => (m === 'light' ? 'dark' : 'light'));
+  }, []);
+
+  const expandPreview = useCallback(() => {
+    setIsFullscreen(true);
+  }, []);
+
   const playgroundSideNav = (
     <XDSSideNav
       header={
@@ -1077,7 +1157,12 @@ export function PlaygroundClient({defaultIsMobile}: PlaygroundClientProps) {
           templateMenuItems={templateMenuItems}
           themeMenuItems={themeMenuItems}
           mobileTab={mobileTab}
+          mode={mode}
+          copied={copied}
           onMobileTabChange={handleMobileTabChange}
+          onToggleMode={togglePreviewMode}
+          onExpand={expandPreview}
+          onShare={handleShare}
         />
       }
       collapsible={{isCollapsed: true, hasButton: false}}>
@@ -1229,203 +1314,208 @@ export function PlaygroundClient({defaultIsMobile}: PlaygroundClientProps) {
 
         {/* Right panel — preview */}
         <XDSVStack xstyle={[s.rightPanel, !showPreviewPanel && s.hidden]}>
-          <XDSToolbar
-            label="Preview controls"
-            startContent={
-              <XDSToggleButton
-                label="Target element"
-                tooltip={
-                  isTargeting
-                    ? 'Exit targeting (Esc)'
-                    : 'Click to select an element'
-                }
-                isPressed={isTargeting}
-                onPressedChange={toggleTargeting}
-                size="md"
-                isIconOnly
-                icon={<Crosshair size={20} />}
-              />
-            }
-            centerContent={
-              <XDSHStack gap={2} vAlign="center">
-                <XDSButton
-                  label={
-                    mode === 'light' ? 'Switch to dark' : 'Switch to light'
+          {!isMobile && (
+            <XDSToolbar
+              label="Preview controls"
+              startContent={
+                <XDSToggleButton
+                  label="Target element"
+                  tooltip={
+                    isTargeting
+                      ? 'Exit targeting (Esc)'
+                      : 'Click to select an element'
                   }
-                  tooltip={mode === 'light' ? 'Dark mode' : 'Light mode'}
-                  variant="ghost"
+                  isPressed={isTargeting}
+                  onPressedChange={toggleTargeting}
                   size="md"
                   isIconOnly
-                  icon={
-                    mode === 'light' ? <Moon size={20} /> : <Sun size={20} />
-                  }
-                  onClick={() =>
-                    setMode(m => (m === 'light' ? 'dark' : 'light'))
-                  }
+                  icon={<Crosshair size={20} />}
                 />
-                <XDSSegmentedControl
-                  label="Viewport size"
-                  size="md"
-                  value={viewport}
-                  onChange={v => setViewport(v as Viewport)}>
-                  <XDSSegmentedControlItem
-                    value="desktop"
-                    label="Desktop"
-                    isLabelHidden
-                    icon={<Monitor size={20} />}
-                  />
-                  <XDSSegmentedControlItem
-                    value="phone"
-                    label="Phone"
-                    isLabelHidden
-                    icon={<Smartphone size={20} />}
-                  />
-                </XDSSegmentedControl>
-                <XDSButton
-                  label="Expand"
-                  tooltip="Fullscreen preview"
-                  variant="ghost"
-                  size="md"
-                  isIconOnly
-                  icon={<Maximize2 size={20} />}
-                  onClick={() => setIsFullscreen(true)}
-                />
-              </XDSHStack>
-            }
-            endContent={
-              <XDSHStack gap={4} vAlign="center">
-                {buildStatus !== 'idle' && (
-                  <div
-                    {...stylex.props(s.buildStatus)}
-                    style={{opacity: statusFading ? 0 : 1}}>
-                    <XDSStatusDot
-                      variant={BUILD_STATUS_META[buildStatus].variant}
-                      label={BUILD_STATUS_META[buildStatus].label}
-                      isPulsing={buildStatus === 'building'}
-                    />
-                    <XDSText type="supporting" color="secondary">
-                      {BUILD_STATUS_META[buildStatus].label}
-                    </XDSText>
-                    {buildStatus === 'error' && (
-                      <XDSButton
-                        label="Rebuild"
-                        tooltip="Rebuild"
-                        variant="ghost"
-                        size="sm"
-                        isIconOnly
-                        icon={<RotateCw size={16} />}
-                        onClick={handleRebuild}
-                      />
-                    )}
-                  </div>
-                )}
-                <XDSPopover
-                  label="Share template"
-                  placement="below"
-                  alignment="end"
-                  xstyle={s.popoverPadding}
-                  onOpenChange={open => {
-                    if (open) {
-                      setShareUrl(window.location.href);
-                      // Snapshot the live (ref-held) theme so the download
-                      // link below can derive its href from reactive state.
-                      setExportTheme(
-                        customThemeRef.current ?? editorInitialTheme,
-                      );
-                    }
-                  }}
-                  content={
-                    <XDSVStack gap={6}>
-                      <XDSVStack gap={2}>
-                        <XDSText type="label" weight="semibold">
-                          Share Playground
-                        </XDSText>
-                        <XDSHStack gap={2} vAlign="center" width="100%">
-                          <XDSTextInput
-                            label="Share URL"
-                            isLabelHidden
-                            isDisabled
-                            value={shareUrl}
-                            onChange={() => {}}
-                            xstyle={s.shareInput}
-                          />
-                          <XDSButton
-                            label={copied ? 'Copied' : 'Copy URL'}
-                            tooltip={copied ? 'Copied' : 'Copy URL'}
-                            variant="secondary"
-                            size="md"
-                            isIconOnly
-                            icon={
-                              copied ? <Check size={16} /> : <Copy size={16} />
-                            }
-                            onClick={handleShare}
-                          />
-                        </XDSHStack>
-                      </XDSVStack>
-                      <XDSVStack gap={2}>
-                        <XDSText type="label" weight="semibold">
-                          Export Theme File
-                        </XDSText>
-                        <XDSHStack gap={2} vAlign="center" width="100%">
-                          <XDSTextInput
-                            label="Theme name"
-                            isLabelHidden
-                            placeholder="Enter theme name"
-                            value={themeName}
-                            onChange={v =>
-                              setThemeName(v.replace(/[\s-]/g, ''))
-                            }
-                            xstyle={s.shareInput}
-                          />
-                          <XDSButton
-                            label="Download theme"
-                            tooltip="Download theme"
-                            variant="secondary"
-                            size="md"
-                            isIconOnly
-                            isDisabled={themeExport == null}
-                            icon={<Download size={16} />}
-                            onClick={() => downloadLinkRef.current?.click()}
-                          />
-                          {/* The real download target: a normally-rendered
-                              link whose href/download come from reactive
-                              state. The button above clicks it, so the
-                              browser performs a native download without us
-                              fabricating an <a> in the handler. */}
-                          {themeExport && (
-                            <a
-                              ref={downloadLinkRef}
-                              href={themeExport.href}
-                              download={themeExport.filename}
-                              {...stylex.props(s.hidden)}
-                              aria-hidden="true"
-                              tabIndex={-1}>
-                              Download theme file
-                            </a>
-                          )}
-                        </XDSHStack>
-                        <XDSLink href="/docs/theme" hasUnderline>
-                          Learn about using themes
-                        </XDSLink>
-                      </XDSVStack>
-                    </XDSVStack>
-                  }>
+              }
+              centerContent={
+                <XDSHStack gap={2} vAlign="center">
                   <XDSButton
-                    label="Export"
-                    variant="primary"
+                    label={
+                      mode === 'light' ? 'Switch to dark' : 'Switch to light'
+                    }
+                    tooltip={mode === 'light' ? 'Dark mode' : 'Light mode'}
+                    variant="ghost"
                     size="md"
-                    endContent={<ExternalLink size={16} />}
+                    isIconOnly
+                    icon={
+                      mode === 'light' ? <Moon size={20} /> : <Sun size={20} />
+                    }
+                    onClick={togglePreviewMode}
                   />
-                </XDSPopover>
-              </XDSHStack>
-            }
-          />
+                  <XDSSegmentedControl
+                    label="Viewport size"
+                    size="md"
+                    value={viewport}
+                    onChange={v => setViewport(v as Viewport)}>
+                    <XDSSegmentedControlItem
+                      value="desktop"
+                      label="Desktop"
+                      isLabelHidden
+                      icon={<Monitor size={20} />}
+                    />
+                    <XDSSegmentedControlItem
+                      value="phone"
+                      label="Phone"
+                      isLabelHidden
+                      icon={<Smartphone size={20} />}
+                    />
+                  </XDSSegmentedControl>
+                  <XDSButton
+                    label="Expand"
+                    tooltip="Fullscreen preview"
+                    variant="ghost"
+                    size="md"
+                    isIconOnly
+                    icon={<Maximize2 size={20} />}
+                    onClick={expandPreview}
+                  />
+                </XDSHStack>
+              }
+              endContent={
+                <XDSHStack gap={4} vAlign="center">
+                  {buildStatus !== 'idle' && (
+                    <div
+                      {...stylex.props(s.buildStatus)}
+                      style={{opacity: statusFading ? 0 : 1}}>
+                      <XDSStatusDot
+                        variant={BUILD_STATUS_META[buildStatus].variant}
+                        label={BUILD_STATUS_META[buildStatus].label}
+                        isPulsing={buildStatus === 'building'}
+                      />
+                      <XDSText type="supporting" color="secondary">
+                        {BUILD_STATUS_META[buildStatus].label}
+                      </XDSText>
+                      {buildStatus === 'error' && (
+                        <XDSButton
+                          label="Rebuild"
+                          tooltip="Rebuild"
+                          variant="ghost"
+                          size="sm"
+                          isIconOnly
+                          icon={<RotateCw size={16} />}
+                          onClick={handleRebuild}
+                        />
+                      )}
+                    </div>
+                  )}
+                  <XDSPopover
+                    label="Share template"
+                    placement="below"
+                    alignment="end"
+                    xstyle={s.popoverPadding}
+                    onOpenChange={open => {
+                      if (open) {
+                        setShareUrl(window.location.href);
+                        // Snapshot the live (ref-held) theme so the download
+                        // link below can derive its href from reactive state.
+                        setExportTheme(
+                          customThemeRef.current ?? editorInitialTheme,
+                        );
+                      }
+                    }}
+                    content={
+                      <XDSVStack gap={6}>
+                        <XDSVStack gap={2}>
+                          <XDSText type="label" weight="semibold">
+                            Share Playground
+                          </XDSText>
+                          <XDSHStack gap={2} vAlign="center" width="100%">
+                            <XDSTextInput
+                              label="Share URL"
+                              isLabelHidden
+                              isDisabled
+                              value={shareUrl}
+                              onChange={() => {}}
+                              xstyle={s.shareInput}
+                            />
+                            <XDSButton
+                              label={copied ? 'Copied' : 'Copy URL'}
+                              tooltip={copied ? 'Copied' : 'Copy URL'}
+                              variant="secondary"
+                              size="md"
+                              isIconOnly
+                              icon={
+                                copied ? (
+                                  <Check size={16} />
+                                ) : (
+                                  <Copy size={16} />
+                                )
+                              }
+                              onClick={handleShare}
+                            />
+                          </XDSHStack>
+                        </XDSVStack>
+                        <XDSVStack gap={2}>
+                          <XDSText type="label" weight="semibold">
+                            Export Theme File
+                          </XDSText>
+                          <XDSHStack gap={2} vAlign="center" width="100%">
+                            <XDSTextInput
+                              label="Theme name"
+                              isLabelHidden
+                              placeholder="Enter theme name"
+                              value={themeName}
+                              onChange={v =>
+                                setThemeName(v.replace(/[\s-]/g, ''))
+                              }
+                              xstyle={s.shareInput}
+                            />
+                            <XDSButton
+                              label="Download theme"
+                              tooltip="Download theme"
+                              variant="secondary"
+                              size="md"
+                              isIconOnly
+                              isDisabled={themeExport == null}
+                              icon={<Download size={16} />}
+                              onClick={() => downloadLinkRef.current?.click()}
+                            />
+                            {/* The real download target: a normally-rendered
+                                link whose href/download come from reactive
+                                state. The button above clicks it, so the
+                                browser performs a native download without us
+                                fabricating an <a> in the handler. */}
+                            {themeExport && (
+                              <a
+                                ref={downloadLinkRef}
+                                href={themeExport.href}
+                                download={themeExport.filename}
+                                {...stylex.props(s.hidden)}
+                                aria-hidden="true"
+                                tabIndex={-1}>
+                                Download theme file
+                              </a>
+                            )}
+                          </XDSHStack>
+                          <XDSLink href="/docs/theme" hasUnderline>
+                            Learn about using themes
+                          </XDSLink>
+                        </XDSVStack>
+                      </XDSVStack>
+                    }>
+                    <XDSButton
+                      label="Export"
+                      variant="primary"
+                      size="md"
+                      endContent={<ExternalLink size={16} />}
+                    />
+                  </XDSPopover>
+                </XDSHStack>
+              }
+            />
+          )}
           <PreviewStage
-            viewport={viewport}
+            viewport={isMobile ? 'phone' : viewport}
             isFullscreen={isFullscreen}
             onExitFullscreen={() => setIsFullscreen(false)}
             iframeRef={iframeRef}
             isInteractionDisabled={isResizing}
+            isFullBleed={isMobile}
           />
         </XDSVStack>
       </XDSHStack>

--- a/apps/docsite/src/app/playground/PlaygroundClient.tsx
+++ b/apps/docsite/src/app/playground/PlaygroundClient.tsx
@@ -386,6 +386,7 @@ const s = stylex.create({
     gap: 'var(--spacing-2)',
     width: '100%',
     minWidth: 0,
+    paddingInline: 'var(--spacing-1)',
   },
   topbarBrand: {
     gridColumn: '1',
@@ -544,9 +545,14 @@ function PlaygroundSideNavHeader({
   if (renderMode === 'topbar') {
     return (
       <div {...stylex.props(s.topbarHeader)}>
-        <span {...stylex.props(s.topbarBrand)} aria-hidden="true">
+        <XDSLink
+          href="/"
+          label="Back to main site"
+          tooltip="Back to main site"
+          color="inherit"
+          xstyle={s.topbarBrand}>
           {BRAND_ICON}
-        </span>
+        </XDSLink>
         <XDSTabList
           value={mobileTab}
           onChange={value => onMobileTabChange(value as MobileTopTab)}

--- a/apps/docsite/src/app/playground/PlaygroundClient.tsx
+++ b/apps/docsite/src/app/playground/PlaygroundClient.tsx
@@ -58,10 +58,11 @@ import {useXDSResizable, XDSResizeHandle} from '@xds/core/Resizable';
 import {XDSToggleButton} from '@xds/core/ToggleButton';
 import {
   ArrowLeft,
+  Check,
   Code2,
   Copy,
   Download,
-  LayoutTemplate,
+  ExternalLink,
   Moon,
   Palette,
   SlidersHorizontal,
@@ -71,10 +72,6 @@ import {
   Maximize2,
   RotateCw,
   Crosshair,
-  ExternalLink,
-  Copy,
-  Check,
-  Download,
 } from 'lucide-react';
 import githubLight from './themes/github-light.json';
 import githubDark from './themes/github-dark.json';
@@ -298,8 +295,6 @@ function configureMonaco(monaco: MonacoInstance) {
 type LeftView = 'code' | 'property' | 'theme';
 type MobileTopTab = 'preview' | 'code' | 'property' | 'theme';
 type BuildStatus = 'idle' | 'building' | 'finished' | 'error';
-type PlaygroundMenuItem = {label: string; onClick: () => void};
-
 const MOBILE_BREAKPOINT_QUERY = '(max-width: 768px)';
 
 const BUILD_STATUS_META: Record<
@@ -384,8 +379,10 @@ const s = stylex.create({
     alignItems: 'center',
     gridTemplateColumns: 'minmax(0, 1fr) auto minmax(0, 1fr)',
     gap: 'var(--spacing-2)',
+    flex: 1,
     width: '100%',
     minWidth: 0,
+    boxSizing: 'border-box',
     paddingInline: 'var(--spacing-1)',
   },
   topbarBrand: {
@@ -422,13 +419,6 @@ const s = stylex.create({
   },
 });
 
-interface PlaygroundHeaderActionsProps {
-  activeView: LeftView;
-  templateMenuItems: PlaygroundMenuItem[];
-  themeMenuItems: PlaygroundMenuItem[];
-  isCompact?: boolean;
-}
-
 interface PlaygroundMobileShareActionProps {
   copied: boolean;
   onShare: () => void;
@@ -441,96 +431,18 @@ interface PlaygroundSideNavHeaderProps {
   onShare: () => void;
 }
 
-function PlaygroundHeaderActions({
-  activeView,
-  templateMenuItems,
-  themeMenuItems,
-  isCompact = false,
-}: PlaygroundHeaderActionsProps) {
-  const variant = isCompact ? 'ghost' : 'secondary';
-  const gap = isCompact ? 0.5 : 2;
-
-  if (activeView === 'code') {
-    return (
-      <XDSHStack
-        gap={gap}
-        align="center"
-        xstyle={isCompact ? s.topbarActions : undefined}>
-        <XDSDropdownMenu
-          button={{
-            label: 'Templates',
-            tooltip: 'Templates',
-            variant,
-            size: 'sm',
-            ...(isCompact
-              ? {isIconOnly: true, icon: <LayoutTemplate size={18} />}
-              : {}),
-          }}
-          hasChevron={!isCompact}
-          items={templateMenuItems}
-        />
-        <XDSButton
-          variant={variant}
-          size="sm"
-          label="Copy Code"
-          tooltip={isCompact ? 'Copy Code' : undefined}
-          isIconOnly={isCompact}
-          icon={isCompact ? <Copy size={18} /> : undefined}
-        />
-      </XDSHStack>
-    );
-  }
-
-  if (activeView === 'theme') {
-    return (
-      <XDSHStack
-        gap={gap}
-        align="center"
-        xstyle={isCompact ? s.topbarActions : undefined}>
-        <XDSDropdownMenu
-          button={{
-            label: 'Apply Theme',
-            tooltip: 'Apply Theme',
-            variant,
-            size: 'sm',
-            ...(isCompact
-              ? {isIconOnly: true, icon: <Palette size={18} />}
-              : {}),
-          }}
-          hasChevron={!isCompact}
-          items={themeMenuItems}
-        />
-        <XDSButton
-          variant={variant}
-          size="sm"
-          label="Export Theme"
-          tooltip={isCompact ? 'Export Theme' : undefined}
-          isIconOnly={isCompact}
-          icon={isCompact ? <Download size={18} /> : undefined}
-        />
-      </XDSHStack>
-    );
-  }
-
-  return null;
-}
-
 function PlaygroundMobileShareAction({
   copied,
   onShare,
 }: PlaygroundMobileShareActionProps) {
   return (
-    <XDSHStack gap={0.5} align="center" xstyle={s.topbarActions}>
-      <XDSButton
-        label={copied ? 'Copied' : 'Share'}
-        tooltip={copied ? 'Copied' : 'Share'}
-        variant="ghost"
-        size="sm"
-        isIconOnly
-        icon={<Share2 size={18} />}
-        onClick={onShare}
-      />
-    </XDSHStack>
+    <XDSButton
+      label={copied ? '✓ Copied' : 'Share'}
+      variant="primary"
+      size="md"
+      onClick={onShare}
+      xstyle={s.topbarActions}
+    />
   );
 }
 

--- a/apps/docsite/src/app/playground/PlaygroundClient.tsx
+++ b/apps/docsite/src/app/playground/PlaygroundClient.tsx
@@ -419,21 +419,15 @@ interface PlaygroundHeaderActionsProps {
   isCompact?: boolean;
 }
 
-interface PlaygroundPreviewHeaderActionsProps {
-  mode: 'light' | 'dark';
+interface PlaygroundMobileShareActionProps {
   copied: boolean;
-  onToggleMode: () => void;
-  onExpand: () => void;
   onShare: () => void;
 }
 
-interface PlaygroundSideNavHeaderProps extends PlaygroundHeaderActionsProps {
+interface PlaygroundSideNavHeaderProps {
   mobileTab: MobileTopTab;
-  mode: 'light' | 'dark';
   copied: boolean;
   onMobileTabChange: (tab: MobileTopTab) => void;
-  onToggleMode: () => void;
-  onExpand: () => void;
   onShare: () => void;
 }
 
@@ -511,33 +505,12 @@ function PlaygroundHeaderActions({
   return null;
 }
 
-function PlaygroundPreviewHeaderActions({
-  mode,
+function PlaygroundMobileShareAction({
   copied,
-  onToggleMode,
-  onExpand,
   onShare,
-}: PlaygroundPreviewHeaderActionsProps) {
+}: PlaygroundMobileShareActionProps) {
   return (
     <XDSHStack gap={0.5} align="center" xstyle={s.topbarActions}>
-      <XDSButton
-        label={mode === 'light' ? 'Switch to dark' : 'Switch to light'}
-        tooltip={mode === 'light' ? 'Dark mode' : 'Light mode'}
-        variant="ghost"
-        size="sm"
-        isIconOnly
-        icon={mode === 'light' ? <Moon size={18} /> : <Sun size={18} />}
-        onClick={onToggleMode}
-      />
-      <XDSButton
-        label="Expand"
-        tooltip="Fullscreen preview"
-        variant="ghost"
-        size="sm"
-        isIconOnly
-        icon={<Maximize2 size={18} />}
-        onClick={onExpand}
-      />
       <XDSButton
         label={copied ? 'Copied' : 'Share'}
         tooltip={copied ? 'Copied' : 'Share'}
@@ -553,13 +526,9 @@ function PlaygroundPreviewHeaderActions({
 
 function PlaygroundSideNavHeader({
   mobileTab,
-  mode,
   copied,
   onMobileTabChange,
-  onToggleMode,
-  onExpand,
   onShare,
-  ...actionsProps
 }: PlaygroundSideNavHeaderProps) {
   const renderMode = useXDSSideNavRenderMode();
 
@@ -603,22 +572,7 @@ function PlaygroundSideNavHeader({
             xstyle={s.mobileIconTab}
           />
         </XDSTabList>
-        {mobileTab === 'preview' && (
-          <PlaygroundPreviewHeaderActions
-            mode={mode}
-            copied={copied}
-            onToggleMode={onToggleMode}
-            onExpand={onExpand}
-            onShare={onShare}
-          />
-        )}
-        {(mobileTab === 'code' || mobileTab === 'theme') && (
-          <PlaygroundHeaderActions
-            {...actionsProps}
-            activeView={mobileTab}
-            isCompact
-          />
-        )}
+        <PlaygroundMobileShareAction copied={copied} onShare={onShare} />
       </div>
     );
   }
@@ -1153,21 +1107,26 @@ export function PlaygroundClient({defaultIsMobile}: PlaygroundClientProps) {
     <XDSSideNav
       header={
         <PlaygroundSideNavHeader
-          activeView={activeView}
-          templateMenuItems={templateMenuItems}
-          themeMenuItems={themeMenuItems}
           mobileTab={mobileTab}
-          mode={mode}
           copied={copied}
           onMobileTabChange={handleMobileTabChange}
-          onToggleMode={togglePreviewMode}
-          onExpand={expandPreview}
           onShare={handleShare}
         />
       }
-      collapsible={{isCollapsed: true, hasButton: false}}>
+      collapsible={{isCollapsed: true, hasButton: false}}
+      footerIcons={
+        !isMobile ? (
+          <XDSButton
+            label="Back to site"
+            tooltip="Back to site"
+            href="/"
+            variant="ghost"
+            isIconOnly
+            icon={<ArrowLeft size={20} />}
+          />
+        ) : undefined
+      }>
       <XDSSideNavSection title="Playground views" isHeaderHidden>
-        <XDSSideNavItem label="Back to site" href="/" icon={ArrowLeft} />
         <XDSSideNavItem
           label="Code"
           icon={Code2}

--- a/apps/docsite/src/app/playground/PreviewStage.tsx
+++ b/apps/docsite/src/app/playground/PreviewStage.tsx
@@ -61,6 +61,12 @@ const s = stylex.create({
     borderWidth: 0,
     boxShadow: 'none',
   },
+  cardFullBleed: {
+    flex: 1,
+    minHeight: 0,
+    width: '100%',
+    height: '100%',
+  },
   card: {
     maxWidth: '100%',
     maxHeight: '100%',
@@ -78,10 +84,6 @@ const s = stylex.create({
     // Transparent so the iframe's own themed body color shows (not the
     // docsite/astryx body color). The selected theme paints inside the iframe.
     backgroundColor: 'transparent',
-  },
-  iframeFullBleed: {
-    flex: 1,
-    minHeight: 0,
   },
   // Let pointer events pass through to window while the panel is being resized,
   // so dragging over the iframe doesn't stall the drag.
@@ -141,32 +143,22 @@ export function PreviewStage({
           />
         </XDSCard>
       )}
-      {isFullBleed && !isFullscreen ? (
+      <XDSCard
+        padding={0}
+        xstyle={[
+          s.card,
+          (isFullscreen || isFullBleed) && s.cardFullscreen,
+          isFullBleed && !isFullscreen && s.cardFullBleed,
+        ]}
+        style={{width, height}}>
         <iframe
           ref={iframeRef}
           src="/playground-preview"
           sandbox="allow-scripts allow-same-origin"
           title="Preview"
-          {...stylex.props(
-            s.iframe,
-            s.iframeFullBleed,
-            isInteractionDisabled && s.iframeInert,
-          )}
+          {...stylex.props(s.iframe, isInteractionDisabled && s.iframeInert)}
         />
-      ) : (
-        <XDSCard
-          padding={0}
-          xstyle={[s.card, isFullscreen && s.cardFullscreen]}
-          style={{width, height}}>
-          <iframe
-            ref={iframeRef}
-            src="/playground-preview"
-            sandbox="allow-scripts allow-same-origin"
-            title="Preview"
-            {...stylex.props(s.iframe, isInteractionDisabled && s.iframeInert)}
-          />
-        </XDSCard>
-      )}
+      </XDSCard>
     </div>
   );
 }

--- a/apps/docsite/src/app/playground/PreviewStage.tsx
+++ b/apps/docsite/src/app/playground/PreviewStage.tsx
@@ -38,6 +38,11 @@ const s = stylex.create({
     paddingBlockEnd: 'var(--spacing-4)',
     paddingBlockStart: 0,
   },
+  areaFullBleed: {
+    paddingInline: 0,
+    paddingBlockEnd: 0,
+    paddingBlockStart: 0,
+  },
   areaCenter: {
     alignItems: 'center',
   },
@@ -74,6 +79,10 @@ const s = stylex.create({
     // docsite/astryx body color). The selected theme paints inside the iframe.
     backgroundColor: 'transparent',
   },
+  iframeFullBleed: {
+    flex: 1,
+    minHeight: 0,
+  },
   // Let pointer events pass through to window while the panel is being resized,
   // so dragging over the iframe doesn't stall the drag.
   iframeInert: {
@@ -95,6 +104,8 @@ interface PreviewStageProps {
   iframeRef: React.RefObject<HTMLIFrameElement | null>;
   /** Disable iframe pointer events (e.g. while the panel is being resized). */
   isInteractionDisabled?: boolean;
+  /** Render the iframe directly, without the preview card/device frame. */
+  isFullBleed?: boolean;
 }
 
 export function PreviewStage({
@@ -103,8 +114,9 @@ export function PreviewStage({
   onExitFullscreen,
   iframeRef,
   isInteractionDisabled = false,
+  isFullBleed = false,
 }: PreviewStageProps) {
-  const isPhone = !isFullscreen && viewport === 'phone';
+  const isPhone = !isFullscreen && !isFullBleed && viewport === 'phone';
   const width = isPhone ? PHONE_WIDTH : '100%';
   const height = isPhone ? PHONE_HEIGHT : '100%';
 
@@ -112,6 +124,7 @@ export function PreviewStage({
     <div
       {...stylex.props(
         s.area,
+        isFullBleed && !isFullscreen && s.areaFullBleed,
         isPhone && s.areaCenter,
         isFullscreen && s.fullscreen,
       )}>
@@ -128,18 +141,32 @@ export function PreviewStage({
           />
         </XDSCard>
       )}
-      <XDSCard
-        padding={0}
-        xstyle={[s.card, isFullscreen && s.cardFullscreen]}
-        style={{width, height}}>
+      {isFullBleed && !isFullscreen ? (
         <iframe
           ref={iframeRef}
           src="/playground-preview"
           sandbox="allow-scripts allow-same-origin"
           title="Preview"
-          {...stylex.props(s.iframe, isInteractionDisabled && s.iframeInert)}
+          {...stylex.props(
+            s.iframe,
+            s.iframeFullBleed,
+            isInteractionDisabled && s.iframeInert,
+          )}
         />
-      </XDSCard>
+      ) : (
+        <XDSCard
+          padding={0}
+          xstyle={[s.card, isFullscreen && s.cardFullscreen]}
+          style={{width, height}}>
+          <iframe
+            ref={iframeRef}
+            src="/playground-preview"
+            sandbox="allow-scripts allow-same-origin"
+            title="Preview"
+            {...stylex.props(s.iframe, isInteractionDisabled && s.iframeInert)}
+          />
+        </XDSCard>
+      )}
     </div>
   );
 }

--- a/apps/docsite/src/app/playground/layout.tsx
+++ b/apps/docsite/src/app/playground/layout.tsx
@@ -2,14 +2,14 @@
 
 /**
  * Page type: playground (full-bleed tool)
- * Renders the interactive code playground full-screen with no marketing top
- * nav / footer chrome — a left editor panel and a right live-preview panel.
+ * The PlaygroundClient owns its XDSAppShell so its stateful side navigation
+ * can drive Code / Properties / Theme tabs and still get AppShell mobile nav.
  * Theme context is provided by the root <Providers> (app/providers.tsx), so
- * this layout only needs to establish a full-viewport, overflow-hidden frame.
+ * this route layout intentionally adds no extra chrome or scroll container.
  *
  * @input children — the PlaygroundClient tree
- * @output Full-height surface container
- * @position app/playground layout wrapper
+ * @output Children unchanged; PlaygroundClient provides the full-height shell
+ * @position app/playground route layout
  */
 
 export default function PlaygroundLayout({
@@ -17,14 +17,5 @@ export default function PlaygroundLayout({
 }: {
   children: React.ReactNode;
 }) {
-  return (
-    <div
-      style={{
-        height: '100vh',
-        overflow: 'hidden',
-        backgroundColor: 'var(--color-background-surface)',
-      }}>
-      {children}
-    </div>
-  );
+  return children;
 }

--- a/apps/docsite/src/app/playground/page.tsx
+++ b/apps/docsite/src/app/playground/page.tsx
@@ -2,6 +2,7 @@
 
 import type {Metadata} from 'next';
 import {Suspense} from 'react';
+import {headers} from 'next/headers';
 import {PlaygroundClient} from './PlaygroundClient';
 
 export const metadata: Metadata = {
@@ -9,10 +10,14 @@ export const metadata: Metadata = {
   description: 'Interactive code playground for Astryx components',
 };
 
-export default function PlaygroundPage() {
+export default async function PlaygroundPage() {
+  const headersList = await headers();
+  const ua = headersList.get('user-agent') ?? '';
+  const defaultIsMobile = /mobile|android|iphone|ipad/i.test(ua);
+
   return (
     <Suspense fallback={null}>
-      <PlaygroundClient />
+      <PlaygroundClient defaultIsMobile={defaultIsMobile} />
     </Suspense>
   );
 }


### PR DESCRIPTION
## Summary

This updates the docsite playground to use `XDSAppShell` and adds a responsive mobile layout for the playground.

### Desktop

- Wraps the playground in `XDSAppShell`.
- Replaces the custom icon rail with a controlled-collapsed `XDSSideNav`.
- Keeps the desktop side nav heading linked back to the main docsite.
- Preserves the existing desktop editor / preview split, resize handle, toolbar controls, and share/export popover.

### Mobile

- Uses AppShell's `topNav` slot with a real `XDSTopNav`.
- Uses TopNav slots for:
  - `heading`: docsite brand link back to `/`
  - `centerContent`: centered icon-only tabs for Preview, Code, Properties, and Theme
  - `endContent`: primary Share button with the same copied-state behavior as desktop
- Disables AppShell's generated mobile drawer for this route so TopNav center content stays in the top bar instead of being moved into drawer content.
- Makes the editor/properties/theme panel full-width and hides the desktop resize handle on mobile.
- Renders the mobile preview full-bleed instead of inside the desktop preview card/device frame.
- Keeps the preview iframe mounted while switching desktop/mobile/full-bleed presentation so preview content is not lost during responsive changes.

### Layout cleanup

- Removes the route-level viewport wrapper so AppShell owns the page frame.
- Excludes the playground from the docs top-nav offset selector so it uses default AppShell content positioning.

## Tests

- `pnpm exec eslint apps/docsite/src/app/playground/PlaygroundClient.tsx apps/docsite/src/app/playground/PreviewStage.tsx apps/docsite/src/app/playground/page.tsx apps/docsite/src/app/playground/layout.tsx`
- `pnpm -F @xds/docsite typecheck`
- pre-commit `pnpm check:repo`