### PR TITLE
fix(docsite): center homepage CTAs on mobile

### DIFF
--- a/apps/docsite/src/app/(site)/_landing/DiscoverShowcase.tsx
+++ b/apps/docsite/src/app/(site)/_landing/DiscoverShowcase.tsx
@@ -155,10 +155,14 @@ const styles = stylex.create({
     marginInline: 'auto',
   },
   // Two-up button row cap. maxWidth: 360 is a thumb-reachable
-  // ergonomic value, not a spacing-scale step.
+  // ergonomic value. The grid uses auto-fit 160px tracks in markup
+  // so narrow phones collapse to one centered column instead of
+  // forcing the buttons into undersized cells. Literals are button
+  // ergonomics values, not spacing-scale steps.
   buttonGrid: {
     width: '100%',
     maxWidth: 360,
+    marginInline: 'auto',
   },
   // Reading-measure cap for the supporting text paragraph. Kept as
   // a stylex rule (instead of inline style) so it composes cleanly
@@ -275,7 +279,10 @@ export function DiscoverShowcase() {
                 — pick a starting point and go.
               </XDSText>
             </XDSVStack>
-            <XDSGrid columns={2} gap={3} xstyle={styles.buttonGrid}>
+            <XDSGrid
+              columns={{minWidth: 160, repeat: 'fit'}}
+              gap={3}
+              xstyle={styles.buttonGrid}>
               <XDSButton
                 variant="primary"
                 size="lg"

--- a/apps/docsite/src/app/(site)/page.tsx
+++ b/apps/docsite/src/app/(site)/page.tsx
@@ -95,12 +95,15 @@ const styles = stylex.create({
   },
   // Hero CTA button grid. maxWidth: 420 caps the two-up button
   // row at a comfortable thumb-reachable width so the buttons
-  // don't stretch edge-to-edge on wide hero columns; literal
-  // because the cap is a button-pair ergonomics value, not a
-  // spacing-scale step.
+  // don't stretch edge-to-edge on wide hero columns. The grid
+  // uses auto-fit 160px tracks in markup so narrow phones collapse
+  // to one centered column instead of forcing two labels into
+  // undersized cells. Literals are button-pair ergonomics values,
+  // not spacing-scale steps.
   heroButtons: {
     width: '100%',
     maxWidth: 420,
+    marginInline: 'auto',
   },
   // Lighter display weight for the leading half of the hero
   // headline ("An open source design system that's"). Astryx's
@@ -223,7 +226,10 @@ export default function HomePage() {
           </XDSText>
         </XDSHeading>
         <XDSVStack gap={4} align="center">
-          <XDSGrid columns={2} gap={3} xstyle={styles.heroButtons}>
+          <XDSGrid
+            columns={{minWidth: 160, repeat: 'fit'}}
+            gap={3}
+            xstyle={styles.heroButtons}>
             <XDSButton
               variant="primary"
               size="lg"


### PR DESCRIPTION
## Summary\n- make homepage hero CTA grids auto-fit so they collapse to one centered column when the mobile content width is too narrow\n- add auto margins to the hero and discover CTA grid containers to keep capped rows centered\n\n## Tests\n- pnpm -F @xds/core build\n- pnpm -F @xds/docsite generate\n- pnpm -F @xds/docsite test\n- pnpm -F @xds/docsite typecheck\n- pnpm build