### PR TITLE
docs(MobileNav): fix docsDense parity and add missing components

### DIFF
--- a/packages/core/src/MobileNav/MobileNav.doc.mjs
+++ b/packages/core/src/MobileNav/MobileNav.doc.mjs
@@ -145,6 +145,7 @@ export const docsZh = {
     bestPractices: [
       { guidance: true, description: 'Share the same nav items between MobileNav and SideNav by extracting them into a variable.' },
       { guidance: true, description: 'Provide a header when the drawer\'s purpose is not obvious from its content.' },
+      { guidance: true, description: 'Inside XDSAppShell, use XDSMobileNavToggle to open the drawer — it reads state from context. Do not pass isOpen/onOpenChange to the toggle.' },
       { guidance: false, description: 'Use MobileNav on desktop — use a persistent SideNav instead.' },
     ],
   },
@@ -158,19 +159,30 @@ export const docsDense = {
     description:
       'A slide-out drawer for mobile navigation. MobileNav is the mobile counterpart to SideNav and accepts the same children. Use it on narrow viewports where a persistent sidebar is not practical.',
     bestPractices: [
-      { guidance: true, description: 'Share the same nav items between MobileNav and SideNav by extracting them into a variable.' },
-      { guidance: true, description: 'Provide a header when the drawer\'s purpose is not obvious from its content.' },
-      { guidance: false, description: 'Use MobileNav on desktop — use a persistent SideNav instead.' },
+      { guidance: true, description: 'Share nav items between MobileNav and SideNav by extracting into a variable.' },
+      { guidance: true, description: 'Provide a header when the drawer purpose is not obvious from content.' },
+      { guidance: true, description: 'Inside XDSAppShell, use XDSMobileNavToggle to open the drawer; it reads state from context. Do not pass isOpen/onOpenChange to the toggle.' },
+      { guidance: false, description: 'Use MobileNav on desktop; use a persistent SideNav instead.' },
     ],
   },
+  components: [
+    {
+      name: 'XDSMobileNav',
+      description: 'Slide-out drawer for mobile navigation. Accepts SideNav children.',
+    },
+    {
+      name: 'XDSMobileNavToggle',
+      description: 'Hamburger button that opens/closes mobile nav drawer. Reads open state from XDSAppShell context automatically. Renders nothing above mobile breakpoint.',
+    },
+  ],
   propDescriptions: {
-    isOpen: 'Whether drawer is open.',
+    isOpen: 'whether drawer is open',
     onOpenChange:
-      'Called when drawer visibility changes (backdrop click, Escape key, close button).',
+      'called when drawer visibility changes (backdrop click, Escape, close button)',
     children:
-      'Drawer content; typically XDSSideNavSection/XDSSideNavItem or any ReactNode.',
-    header: 'Header content for the drawer (string or ReactNode). Rendered next to close button.',
-    width: 'Drawer width px. Capped at 85vw to prevent overflow on small screens.',
-    side: 'Slide direction. Start=left LTR, right RTL.',
+      'drawer content; typically XDSSideNavSection/XDSSideNavItem or any ReactNode',
+    header: 'header content (string or ReactNode), rendered next to close button',
+    width: 'drawer width px; capped at 85vw to prevent overflow on small screens',
+    side: 'slide direction; start=left LTR, right RTL',
   },
 };


### PR DESCRIPTION
## What

MobileNav's `docsDense` overlay had three issues found during Night Watch doc review:

1. **bestPractices count mismatch**: English docs have 4 entries, docsDense had only 3. The missing entry covers XDSMobileNavToggle behavior inside XDSAppShell context.
2. **Missing components array**: docsDense lacked the `components` entries for XDSMobileNav and XDSMobileNavToggle, so `xds component MobileNav --lang dense` was falling back to English for sub-component descriptions.
3. **docsZh bestPractices count**: Also had 3 entries instead of 4. Added the missing entry.

Additionally normalized propDescriptions to lowercase-leading fragments per the dense convention.

## Checklist
- [x] `pnpm --filter @xds/core typecheck:docs` passes
- [x] `npx tsc --project packages/cli/tsconfig.template-docs.json --noEmit` passes
- [x] CLI `--lang dense` output verified (no duplicate `(required)`, components render)
- [x] Dense audit passes (0 findings)

---
*Night Watch — Doc Reviewer*