### PR TITLE
fix(CommandPalette): use semantic type scale token for item font size

### DIFF
--- a/packages/core/src/CommandPalette/XDSCommandPaletteItem.tsx
+++ b/packages/core/src/CommandPalette/XDSCommandPaletteItem.tsx
@@ -20,7 +20,7 @@ import {
   spacingVars,
   radiusVars,
   typographyVars,
-  textSizeVars,
+  typeScaleVars,
 } from '../theme/tokens.stylex';
 import {useCommandPaletteContext} from './CommandPaletteContext';
 
@@ -36,7 +36,7 @@ const styles = stylex.create({
     paddingBlock: spacingVars['--spacing-2'],
     borderRadius: radiusVars['--radius-inner'],
     fontFamily: typographyVars['--font-family-body'],
-    fontSize: textSizeVars['--font-size-base'],
+    fontSize: typeScaleVars['--text-label-size'],
     color: colorVars['--color-text-primary'],
     backgroundColor: 'transparent',
     border: 'none',


### PR DESCRIPTION
XDSCommandPaletteItem used raw `textSizeVars['--font-size-base']` instead of the semantic `typeScaleVars['--text-label-size']`. Menu items are interactive controls and should use the label type scale token, matching XDSDropdownMenuItem.

Audited components (all clean except this finding):
- Collapsible
- CommandPalette
- ContextMenu
- DateInput
- DateRangeInput

Night Watch — Component Auditor