### PR TITLE
fix(docsite): scroll Discover card under sticky nav

### DIFF
--- a/apps/docsite/src/app/(site)/_landing/DiscoverShowcase.tsx
+++ b/apps/docsite/src/app/(site)/_landing/DiscoverShowcase.tsx
@@ -39,6 +39,14 @@ const styles = stylex.create({
     maxWidth: 1200,
     overflow: 'hidden',
     borderRadius: 'var(--radius-container)',
+    // Isolate the stage into its own stacking context so the card (zIndex: 1)
+    // and floating images (zIndex: 2) below are scoped locally. Without this,
+    // those z-indexes leak up to the root stacking context (the stage, its
+    // overlay, and heroScope ancestors are all `position: relative` with no
+    // z-index, so none of them form a stacking context) and paint on top of
+    // the AppShell's sticky nav (zIndex: 1). Isolating keeps the whole stage
+    // below the nav while preserving the images-above-card ordering inside.
+    isolation: 'isolate',
   },
   card: {
     position: 'relative',

--- a/apps/docsite/src/app/(site)/_landing/DiscoverShowcase.tsx
+++ b/apps/docsite/src/app/(site)/_landing/DiscoverShowcase.tsx
@@ -39,13 +39,6 @@ const styles = stylex.create({
     maxWidth: 1200,
     overflow: 'hidden',
     borderRadius: 'var(--radius-container)',
-    // Isolate the stage into its own stacking context so the card (zIndex: 1)
-    // and floating images (zIndex: 2) below are scoped locally. Without this,
-    // those z-indexes leak up to the root stacking context (the stage, its
-    // overlay, and heroScope ancestors are all `position: relative` with no
-    // z-index, so none of them form a stacking context) and paint on top of
-    // the AppShell's sticky nav (zIndex: 1). Isolating keeps the whole stage
-    // below the nav while preserving the images-above-card ordering inside.
     isolation: 'isolate',
   },
   card: {


### PR DESCRIPTION
## Problem

On the homepage, the **"Discover the full design system"** card (the one with the "Browse 150+ components" copy and the four floating screenshots) sits **on top of** the site's sticky top navigation when the page scrolls. It should scroll *under* the nav like the rest of the page content.

## Root cause

The card and its decorative images live inside the `stage` element in `DiscoverShowcase.tsx`:

- floating images → `zIndex: 2`
- `XDSCard` → `zIndex: 1`

`stage` is `position: relative` **with no `z-index`**, so it does **not** form a stacking context. Neither do its ancestors (`showcaseOverlay`, `heroScope` — all `position: relative` with no z-index). As a result, those inner z-indexes promote to the **root** stacking context and compete directly with the AppShell sticky nav (`zIndex: 1`) — winning by DOM order, since the showcase comes later in the document.

## Fix

Add `isolation: isolate` to the `stage` style. This gives the stage its own local stacking context, so:

- the card (`zIndex: 1`) and images (`zIndex: 2`) are scoped **inside** the stage, preserving their relative ordering (images above card), and
- the stage itself (no `z-index`) paints **below** the sticky nav.

Result: the Discover card now scrolls cleanly under the navigation.

## Scope & constraints

- **Docsite-only.** No `@xds/core` component changes — the fix is a single CSS property on a docsite-local style.
- `isolation` is an already-supported StyleX property (used elsewhere in core), so it compiles to a standard atomic class.

## Verification

- `pnpm -F @xds/docsite typecheck` → clean (exit 0)
- `pnpm -F @xds/docsite test` → 117/117 passing
- Confirmed in the dev server's compiled CSS that the `stage` element now carries the `isolation: isolate` atomic class.
