### PR TITLE
fix(docsite): reliably load seeded playground code on soft navigation

### DIFF
--- a/apps/docsite/src/app/playground/PlaygroundClient.tsx
+++ b/apps/docsite/src/app/playground/PlaygroundClient.tsx
@@ -476,19 +476,37 @@ export function PlaygroundClient() {
     return () => window.removeEventListener('hashchange', onHashChange);
   }, []);
 
-  // Re-read the hash once on mount. When arriving via a soft (client-side)
-  // navigation — e.g. the Themes page's "Open in Playground" link routed
-  // through Next's <Link> — the App Router commits the new URL slightly
-  // after this component first renders, so the synchronous getInitialCode()
-  // seed for `code` above can miss the fragment and fall back to
-  // DEFAULT_CODE. A hashchange event isn't emitted for that navigation
-  // (the page itself changes, not just the fragment), so we read the
-  // committed hash here, after mount, and adopt the seeded code if present.
+  // Re-read the hash after mount. When arriving via a soft (client-side)
+  // navigation — e.g. the templates dialog's or themes page's "Open in
+  // Playground" link routed through Next's <Link> — the App Router commits
+  // the new URL slightly after this component first renders, so the
+  // synchronous getInitialCode() seed for `code` above can miss the fragment
+  // and fall back to DEFAULT_CODE. A hashchange event isn't emitted for that
+  // navigation (the route changes, not just the fragment), so we can't rely
+  // on the listener above. The exact commit timing varies (heavy lazy trees
+  // like Monaco can push it past a single tick), so we poll for a few frames
+  // until the committed hash carries a `code=` fragment, then adopt it.
   useEffect(() => {
-    const seeded = getInitialCode();
-    if (seeded !== DEFAULT_CODE) {
-      setCode(prev => (prev === seeded ? prev : seeded));
+    // If the synchronous seed already captured shared code, nothing to do.
+    if (getInitialCode() !== DEFAULT_CODE) {
+      return;
     }
+    let raf = 0;
+    // ~1s of frames (≈16ms each) — generous enough for a slow cross-route
+    // commit, bounded so we don't poll forever on a genuinely empty hash.
+    let attemptsLeft = 60;
+    const tryAdopt = () => {
+      const seeded = getInitialCode();
+      if (seeded !== DEFAULT_CODE) {
+        setCode(prev => (prev === seeded ? prev : seeded));
+        return;
+      }
+      if (attemptsLeft-- > 0) {
+        raf = requestAnimationFrame(tryAdopt);
+      }
+    };
+    raf = requestAnimationFrame(tryAdopt);
+    return () => cancelAnimationFrame(raf);
     // Runs once on mount; the hashchange listener above covers later changes.
   }, []);
 


### PR DESCRIPTION
## Summary

- "Open in Playground" from the **templates dialog** (and the themes page) routes through Next's `<Link>` — a soft, cross-route navigation. The App Router commits the new `/playground#code=…` URL *after* `PlaygroundClient` first renders, and no `hashchange` event fires for a route change. The one-shot post-mount read of the `#code` fragment (added in #2739) could therefore run before the URL was committed, fall back to `DEFAULT_CODE`, and the template would never load. Heavy lazy trees (Monaco, the preview iframe) make missing that single tick likely — which is why the templates dialog reproduced it reliably.
- Fix: after mount, poll for a few animation frames until the committed hash actually carries a `code=` fragment, then adopt it. It bails immediately when the synchronous seed already captured the code, never overwrites with `DEFAULT_CODE` (so it can't clobber user edits), and is bounded (~1s / 60 frames) so a genuinely empty `/playground` stops cleanly.
- Single-file change in `apps/docsite/src/app/playground/PlaygroundClient.tsx`. No `@xds/core` changes.

## Test plan

- [ ] `/templates` → click a template card → **Open in Playground** → editor loads that template's source (not the default snippet).
- [ ] Repeat for several templates and via the card hover overlay's "Open in Playground" button.
- [ ] Themes page → **Open in Playground** still seeds code + `?theme=` correctly.
- [ ] Direct hard navigation to a shared `/playground#code=…` URL still loads the code.
- [ ] Opening a bare `/playground` (no hash) still shows the default snippet and remains editable.
- [ ] In-playground edits still sync to the URL and survive a refresh.