### PR TITLE
fix(sandbox): fill frame height for embedded template previews

### DIFF
--- a/apps/sandbox/src/app/(fullscreen)/PreviewShell.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/PreviewShell.tsx
@@ -260,7 +260,6 @@ function ChevronDownIcon(props: React.SVGProps<SVGSVGElement>) {
   );
 }
 
-
 type ViewportSize = 'desktop' | 'tablet' | 'mobile';
 const viewportWidths: Record<ViewportSize, string> = {
   desktop: '100%',
@@ -276,7 +275,17 @@ export function PreviewShell({children}: {children: React.ReactNode}) {
   );
   const isEmbed = searchParams.get('embed') === '1';
   if (isEmbed) {
-    return <>{children}</>;
+    // Embedded template previews need a full-height chain so page roots sized
+    // with min-height:100% (e.g. centered login pages) fill the frame instead of
+    // collapsing to content height. The chain is html → body → XDSTheme wrapper
+    // ([data-xds-theme]) → template root. Rendered inline (not in the layout
+    // <head>) so it applies reliably in the embed context.
+    return (
+      <>
+        <style>{`html,body{height:100%}body>[data-xds-theme]{height:100%}`}</style>
+        {children}
+      </>
+    );
   }
   const [view, setView] = useState<'preview' | 'code'>('preview');
   const [viewport, setViewport] = useState<ViewportSize>('desktop');


### PR DESCRIPTION
## Summary

Centered page templates (`login`, `login-card`, `login-split`, `login-sso`, …) weren't filling the height of the sandbox preview frame — the card sat at the top with a large empty area below it.

### Root cause
These templates size their root with `min-height: 100%` (a deliberate change in #2655, so they also fill the smaller gallery-thumbnail and preview-dialog contexts instead of using viewport units). But `min-height: 100%` only resolves when every ancestor has a definite height. In the sandbox's embedded preview, the chain `html → body → XDSTheme wrapper ([data-xds-theme])` had no height, so `min-height: 100%` resolved against `auto` and the page collapsed to content height.

Measured before the fix: template root `392px` in an `820px` frame.

### Fix
Render an inline full-height rule in the **embed branch** of `PreviewShell` so `html`/`body` and the `XDSTheme` wrapper fill the frame:

```tsx
<style>{`html,body{height:100%}body>[data-xds-theme]{height:100%}`}</style>
```

The fix lives in the preview **host**, not the templates — so it doesn't re-break the gallery-thumbnail case #2655 fixed. Scoped to the `embed=1` path; non-embed sandbox views and the templates themselves are untouched.

(Note: I first tried adding this via the root layout `<head>` + an `xds-embed` class, but Next hoists head scripts and the class wasn't applying reliably in the embed iframe — an inline `<style>` in the embed render is deterministic.)

## Test plan
- [x] ESLint, `check:sync`, `check:package-boundaries` pass (pre-commit)
- [x] Verified in a local sandbox iframe (1180×820): all four login templates' roots now fill the frame (root height = frame height), card vertically centered — confirmed via DOM measurement + screenshots
- [x] Non-login templates and non-embed sandbox views unaffected (change is scoped to the embed branch)
- [ ] Reviewer: open `/pr/<this-PR>/sandbox/templates/login/` (and login-split / login-card / login-sso) and confirm the page fills the frame

Made with [Cursor](https://cursor.com)