### PR TITLE
fix(templates): responsive widths on small screens (login cards + classic-gallery)

### DIFF
--- a/packages/cli/templates/pages/classic-gallery/page.tsx
+++ b/packages/cli/templates/pages/classic-gallery/page.tsx
@@ -148,7 +148,7 @@ export default function ClassicGalleryTemplate() {
               </XDSCenter>
 
               {/* Gallery Grid */}
-              <XDSGrid columns={{minWidth: 400}} gap={4}>
+              <XDSGrid columns={{minWidth: 260, repeat: 'fit'}} gap={4}>
                 {filteredImages.map((image, i) => (
                   <div key={i} {...stylex.props(styles.imageWrapper)}>
                     <img

--- a/packages/cli/templates/pages/login-card/page.tsx
+++ b/packages/cli/templates/pages/login-card/page.tsx
@@ -14,7 +14,7 @@ import {XDSCard} from '@xds/core/Card';
 import {XDSLink} from '@xds/core/Link';
 import {XDSDivider} from '@xds/core/Divider';
 import {XDSIcon} from '@xds/core/Icon';
-import {colorVars} from '@xds/core/theme/tokens.stylex';
+import {colorVars, spacingVars} from '@xds/core/theme/tokens.stylex';
 
 // Brand sign-in marks — no heroicons or template-assets equivalent.
 const AppleIcon = (props: React.SVGProps<SVGSVGElement>) => (
@@ -61,6 +61,13 @@ const styles = stylex.create({
   page: {
     minHeight: '100%',
     backgroundColor: colorVars['--color-background-body'],
+    padding: spacingVars['--spacing-6'],
+  },
+  // Cap the column at 400px but let it shrink to fit narrow screens (XDSStack
+  // has no maxWidth prop, so it's set here).
+  content: {
+    width: '100%',
+    maxWidth: 400,
   },
 });
 
@@ -85,7 +92,7 @@ export default function LoginSimple() {
 
   return (
     <XDSCenter axis="both" xstyle={styles.page}>
-      <XDSVStack gap={4} hAlign="center">
+      <XDSVStack gap={4} hAlign="center" xstyle={styles.content}>
         {/* Logo */}
         <XDSVStack gap={2} hAlign="center">
           <XDSIcon icon={CubeIcon} size="lg" />
@@ -95,7 +102,7 @@ export default function LoginSimple() {
         </XDSVStack>
 
         {/* Card */}
-        <XDSCard padding={8} width={400}>
+        <XDSCard padding={8} width="100%">
           <XDSVStack gap={4} hAlign="stretch">
             {/* Header */}
             <XDSVStack gap={1} hAlign="center">
@@ -192,7 +199,7 @@ export default function LoginSimple() {
         </XDSCard>
 
         {/* Terms */}
-        <XDSVStack hAlign="center" width={400}>
+        <XDSVStack hAlign="center" width="100%">
           <XDSText type="supporting" color="secondary" justify="center">
             By clicking continue, you agree to our{' '}
             <XDSLink href="#" type="supporting">

--- a/packages/cli/templates/pages/login-sso/page.tsx
+++ b/packages/cli/templates/pages/login-sso/page.tsx
@@ -16,6 +16,7 @@ import {XDSLink} from '@xds/core/Link';
 import {XDSDivider} from '@xds/core/Divider';
 import {XDSIcon} from '@xds/core/Icon';
 import {XDSAvatar} from '@xds/core/Avatar';
+import {spacingVars} from '@xds/core/theme/tokens.stylex';
 
 // ---------------------------------------------------------------------------
 // Styles
@@ -29,6 +30,7 @@ const styles = stylex.create({
     backgroundImage: `url(${BG_URL})`,
     backgroundSize: 'cover',
     backgroundPosition: 'center',
+    padding: spacingVars['--spacing-6'],
   },
 });
 
@@ -101,7 +103,7 @@ export default function LoginSSO() {
 
   return (
     <XDSCenter axis="both" xstyle={styles.page}>
-      <XDSCard padding={8} width={400}>
+      <XDSCard padding={8} width="100%" maxWidth={400}>
         <XDSVStack gap={4} hAlign="stretch">
           {/* ── Step 1: Email entry ── */}
           {step === 'email' && (

--- a/packages/cli/templates/pages/login/page.tsx
+++ b/packages/cli/templates/pages/login/page.tsx
@@ -13,13 +13,20 @@ import {XDSCard} from '@xds/core/Card';
 import {XDSIcon} from '@xds/core/Icon';
 import {XDSBanner} from '@xds/core/Banner';
 import {CubeIcon} from '@heroicons/react/24/outline';
-import {colorVars} from '@xds/core/theme/tokens.stylex';
+import {colorVars, spacingVars} from '@xds/core/theme/tokens.stylex';
 
 // Standalone auth page paints its own body background (no host shell).
 const styles = stylex.create({
   page: {
     minHeight: '100%',
     backgroundColor: colorVars['--color-background-body'],
+    padding: spacingVars['--spacing-6'],
+  },
+  // Cap the column at 400px but let it shrink to fit narrow screens (XDSStack
+  // has no maxWidth prop, so it's set here).
+  content: {
+    width: '100%',
+    maxWidth: 400,
   },
 });
 
@@ -41,7 +48,7 @@ export default function LoginPage() {
 
   return (
     <XDSCenter axis="both" xstyle={styles.page}>
-      <XDSVStack gap={4} hAlign="center">
+      <XDSVStack gap={4} hAlign="center" xstyle={styles.content}>
         {/* Logo */}
         <XDSVStack gap={2} hAlign="center">
           <XDSIcon icon={CubeIcon} size="lg" />
@@ -51,7 +58,7 @@ export default function LoginPage() {
         </XDSVStack>
 
         {/* Card */}
-        <XDSCard padding={8} width={400}>
+        <XDSCard padding={8} width="100%">
           <XDSVStack gap={4} hAlign="stretch">
             <XDSVStack gap={1} hAlign="center">
               <XDSHeading level={2}>Sign in</XDSHeading>


### PR DESCRIPTION
## Summary

The `login`, `login-card`, and `login-sso` templates pinned their card to a fixed `width={400}`. On a phone-width viewport the card stayed 400px — edge-to-edge with no margin — and overflowed on viewports narrower than 400px (e.g. a 375px phone). `login-card` also had a second fixed `width={400}` on its terms row.

(`login-split` was already responsive and is not touched.)

## Fix
Make the card responsive instead of fixed:
- `width="100%"` capped at `maxWidth: 400` — via a small `content` wrapper style for `login` / `login-card` (since `XDSStack` has no `maxWidth` prop), and directly on the `XDSCard` for `login-sso`.
- Add page padding (`--spacing-6`) so the card keeps a margin on small screens.
- `login-card`: the terms row's fixed `width={400}` → `width="100%"`.

So the card caps at 400px on desktop and shrinks to fit (with margin) on mobile.

## Verification
Rendered each template in the playground preview at the phone width (402px) plus 320px and 800px:

| Width | Card width | Overflow |
|------|-----------|----------|
| 320 | 272px (fits w/ margin) | 0 |
| 402 | 354px (fits w/ margin) | 0 |
| 800 | 400px (capped) | 0 |

- ESLint clean; `check:sync` and `check:package-boundaries` pass (pre-commit).
- Verified visually: cards have even side margins on mobile (previously edge-to-edge) and are unchanged at desktop width.

## Notes
- This is a template fix (fixed-width cards), independent of the playground preview work (#2797). It's also what made these cards look "not scaled" in the playground's mobile view.

Made with [Cursor](https://cursor.com)