### PR TITLE
fix(docsite): update footer copyright notice

### DIFF
--- a/apps/docsite/src/components/SiteFooter.tsx
+++ b/apps/docsite/src/components/SiteFooter.tsx
@@ -37,7 +37,7 @@ export function SiteFooter() {
     <footer {...stylex.props(styles.footer)}>
       <XDSHStack gap={3} wrap="wrap" justify="center" align="center">
         <XDSText type="supporting" color="primary">
-          Copyright © {year} Meta Platforms Inc.
+          Copyright ©{year} Meta Platforms, Inc.
         </XDSText>
         {links.map(link => (
           <Fragment key={link.href}>


### PR DESCRIPTION
## Summary
- Update the docsite footer copyright notice to `Copyright ©{year} Meta Platforms, Inc.`
- Keeps the word `Copyright` while ensuring the rendered footer text matches the required test regex

## Required regex
```text
re"/(Copyright|©|Copyright\s+©)(20[0-9]{2},?)\s+Meta Platforms,\s+Inc/"
```

## Testing
- `git diff --check`
- `node` regex check against rendered footer text
- pre-commit hooks: `eslint --cache --fix`, `prettier --write`, `pnpm check:repo`
