### PR TITLE
fix(core): export toast from core barrel

### DIFF
--- a/.changeset/toast-barrel-export.md
+++ b/.changeset/toast-barrel-export.md
@@ -1,0 +1,5 @@
+---
+'@xds/core': patch
+---
+
+Export `XDSToast` and its props from the `@xds/core` package barrel so docsite playground previews can resolve and render Toast examples.

--- a/packages/core/src/README.md
+++ b/packages/core/src/README.md
@@ -4,8 +4,8 @@ Source code for core UI components.
 
 <!-- SYNC: When files in this directory change, update this document. -->
 
-| File/Directory | Role      | Purpose                                              |
-| -------------- | --------- | ---------------------------------------------------- |
-| `index.ts`     | Entry     | Package entry point; re-exports all components       |
-| `reset.css`    | Styles    | Base CSS reset for consistent cross-browser defaults |
-| `Button/`      | Component | Button component with variants and loading states    |
+| File/Directory | Role      | Purpose                                                             |
+| -------------- | --------- | ------------------------------------------------------------------- |
+| `index.ts`     | Entry     | Package entry point; re-exports public components, hooks, and types |
+| `reset.css`    | Styles    | Base CSS reset for consistent cross-browser defaults                |
+| `Button/`      | Component | Button component with variants and loading states                   |

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,8 +4,8 @@
 
 /**
  * @file index.ts
- * @input Imports from component directories (Button/, Card/, Layout/, Layer/)
- * @output Exports all public components and types for @xds/core
+ * @input Imports from component directories (Button/, Card/, Layout/, Layer/, Toast/)
+ * @output Exports all public components, hooks, and types for @xds/core
  * @position Package entry point; consumed by external applications
  *
  * SYNC: When modified, update this header and /packages/core/src/README.md
@@ -119,8 +119,9 @@ export {XDSLayerProvider} from './Layer';
 export type {XDSLayerProviderProps, LayerToastConfig} from './Layer';
 
 // Toast
-export {useXDSToast} from './Toast';
+export {XDSToast, useXDSToast} from './Toast';
 export type {
+  XDSToastProps,
   XDSToastType,
   XDSToastPosition,
   XDSToastCollisionBehavior,


### PR DESCRIPTION
## Summary

- Export `XDSToast` and `XDSToastProps` from the `@xds/core` barrel.
- Keep the core source README/header in sync with the barrel export surface.
- Add a patch changeset for `@xds/core`.

Fixes #2764.

## Test plan

- `pnpm -F @xds/core typecheck`
- `pnpm -F @xds/core build`
- `pnpm sync:exports:check`
- Verified `packages/core/dist/index.js` exposes `XDSToast` and `useXDSToast`, and `packages/core/dist/index.d.ts` includes `XDSToastProps`.
