### PR TITLE
fix(docsite): add Tooltip hover indication control

### DIFF
--- a/apps/docsite/src/__tests__/component-prop-controls.test.ts
+++ b/apps/docsite/src/__tests__/component-prop-controls.test.ts
@@ -2,7 +2,11 @@
 
 import {getIconRegistry} from '@xds/core/Icon';
 import {describe, expect, it} from 'vitest';
-import {parsePropType} from '../components/component-detail/parsePropType';
+import {
+  coerceDefault,
+  coerceEnumOption,
+  parsePropType,
+} from '../components/component-detail/parsePropType';
 
 describe('component detail prop controls', () => {
   it('treats XDSInputStatus as an editable status object control', () => {
@@ -50,6 +54,24 @@ describe('component detail prop controls', () => {
       options: ['sending', 'sent', 'delivered', 'read', 'error'],
       allowEmpty: false,
     });
+  });
+
+  it('expands mixed string-literal and boolean unions into enum options', () => {
+    const control = parsePropType("'auto' | boolean", 'hasHoverIndication');
+
+    expect(control).toMatchObject({
+      kind: 'enum',
+      options: ['auto', 'true', 'false'],
+      allowEmpty: false,
+    });
+    if (control.kind === 'enum') {
+      expect(coerceEnumOption(control, 'auto')).toBe('auto');
+      expect(coerceEnumOption(control, 'true')).toBe(true);
+      expect(coerceEnumOption(control, 'false')).toBe(false);
+      expect(coerceDefault('true', control)).toBe(true);
+      expect(coerceDefault('false', control)).toBe(false);
+      expect(coerceDefault("'auto'", control)).toBe('auto');
+    }
   });
 
   it('derives XDSIconType options from the canonical icon registry', () => {

--- a/apps/docsite/src/app/playground/PropertyPanel.tsx
+++ b/apps/docsite/src/app/playground/PropertyPanel.tsx
@@ -10,8 +10,9 @@
  * props table for the selected component instance. Changing a knob performs a
  * targeted source-range edit (see babelParser) and writes back through
  * onCodeChange — so edits flow into Monaco and the live preview. Only literal
- * props (boolean / enum / string / number) are editable; props set to an
- * expression are shown read-only ("set in code") to avoid clobbering.
+ * props (boolean / enum / string / number) are editable; enum controls preserve
+ * typed option values for mixed literal unions. Props set to an expression are
+ * shown read-only ("set in code") to avoid clobbering.
  */
 
 'use client';
@@ -32,6 +33,7 @@ import {XDSDropdownMenu} from '@xds/core/DropdownMenu';
 import {ChevronDown} from 'lucide-react';
 import {
   coerceDefault,
+  coerceEnumOption,
   parsePropType,
   type PropControlDescriptor,
 } from '../../components/component-detail/parsePropType';
@@ -150,15 +152,18 @@ function PropRow({
         formatAttr(prop.name, 'number', value),
       );
     } else {
-      const numeric = NUMERIC_RE.test(String(value));
+      const numeric =
+        typeof value === 'number' || NUMERIC_RE.test(String(value));
+      const attrKind =
+        typeof value === 'boolean' ? 'boolean' : numeric ? 'number' : 'string';
       next = setAttribute(
         code,
         instance,
         prop.name,
         formatAttr(
           prop.name,
-          numeric ? 'number' : 'string',
-          numeric ? Number(value) : value,
+          attrKind,
+          numeric && typeof value !== 'number' ? Number(value) : value,
         ),
       );
     }
@@ -210,7 +215,7 @@ function PropRow({
         size="sm"
         value={value}
         options={control.options}
-        onChange={next => commit('enum', next)}
+        onChange={next => commit('enum', coerceEnumOption(control, next))}
       />
     );
   } else if (control.kind === 'string') {
@@ -351,27 +356,27 @@ export function PropertyPanel({
   const required = props.filter(p => p.required);
   const optional = props.filter(p => !p.required);
 
-  const selectedLabel = used.find(u => u.module === selected)?.label ?? selected;
+  const selectedLabel =
+    used.find(u => u.module === selected)?.label ?? selected;
 
-  const menuItems = used.length > 1
-    ? used.map(u => ({
-        label: u.count > 1 ? `${u.label} (${u.count})` : u.label,
-        onClick: () => {
-          setSelected(u.module);
-          setInstanceIndex(0);
-          onFlashInstance?.(u.module, 0);
-        },
-      }))
-    : [];
+  const menuItems =
+    used.length > 1
+      ? used.map(u => ({
+          label: u.count > 1 ? `${u.label} (${u.count})` : u.label,
+          onClick: () => {
+            setSelected(u.module);
+            setInstanceIndex(0);
+            onFlashInstance?.(u.module, 0);
+          },
+        }))
+      : [];
 
   return (
     <div {...stylex.props(s.root)}>
       <div {...stylex.props(s.header)}>
         <XDSVStack gap={2}>
           <XDSHStack gap={0} vAlign="center">
-            <XDSHeading level={3}>
-              {selectedLabel}
-            </XDSHeading>
+            <XDSHeading level={3}>{selectedLabel}</XDSHeading>
             {menuItems.length > 0 && (
               <XDSDropdownMenu
                 button={{

--- a/apps/docsite/src/components/component-detail/PlaygroundPropsTable.tsx
+++ b/apps/docsite/src/components/component-detail/PlaygroundPropsTable.tsx
@@ -1,5 +1,12 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+/**
+ * @file PlaygroundPropsTable.tsx
+ * @input Prop docs, control descriptors, current playground values
+ * @output Props table rows with inline controls that write typed prop values
+ * @position Component detail page — props table and interactive preview knobs.
+ */
+
 'use client';
 
 import {createElement, useState} from 'react';
@@ -17,7 +24,7 @@ import {Minus, Plus} from 'lucide-react';
 import {useMediaQuery} from '@xds/core/hooks';
 import {allSyntaxPresets} from '@xds/core/theme/syntax';
 import {themeObjectsFull} from '../../generated/themeRegistry';
-import type {PropControlDescriptor} from './parsePropType';
+import {coerceEnumOption, type PropControlDescriptor} from './parsePropType';
 import type {KnobProp} from './InteractivePreview';
 import {resolveElementDescriptor} from './resolveElements';
 import type {
@@ -379,7 +386,9 @@ function InlineControl({
               onChange(undefined);
               return;
             }
-            onChange(isNumeric ? Number(next) : next);
+            onChange(
+              isNumeric ? Number(next) : coerceEnumOption(control, next),
+            );
           }}
         />
       );

--- a/apps/docsite/src/components/component-detail/interactiveState.ts
+++ b/apps/docsite/src/components/component-detail/interactiveState.ts
@@ -3,13 +3,15 @@
 /**
  * Builds the initial prop state for component detail interactive previews.
  * Keeps runtime-only defaults (callbacks, mock search sources, descriptor
- * resolution) out of the generated JSON registries.
+ * resolution) out of the generated JSON registries while preserving typed
+ * option values from parsed controls.
  */
 
 import {allSyntaxPresets} from '@xds/core/theme/syntax';
 import {themeObjectsFull} from '../../generated/themeRegistry';
 import {
   coerceDefault,
+  coerceEnumOption,
   parsePropType,
   type PropControlDescriptor,
 } from './parsePropType';
@@ -98,7 +100,7 @@ function getRequiredFallbackValue(
 ): unknown {
   switch (control.kind) {
     case 'enum':
-      return control.options[0];
+      return coerceEnumOption(control, control.options[0]);
     case 'theme':
       return Object.values(themeObjectsFull)[0];
     case 'syntax-theme':

--- a/apps/docsite/src/components/component-detail/parsePropType.ts
+++ b/apps/docsite/src/components/component-detail/parsePropType.ts
@@ -3,8 +3,14 @@
 import {getIconRegistry} from '@xds/core/Icon';
 
 /**
+ * @file parsePropType.ts
+ * @input Stringified TypeScript prop types from component docs
+ * @output Control descriptors and typed default/option coercion helpers
+ * @position Component detail and playground prop-control generation.
+ *
  * Parses a stringified TypeScript prop type into a control descriptor
- * that the playground can render an input for.
+ * that the playground can render an input for. Literal unions become
+ * enum controls, including mixed string-literal + boolean unions.
  *
  * Ported from the internal docsite (nest/apps/xds).
  */
@@ -16,8 +22,17 @@ export interface ElementOption {
 
 type InputStatusOption = 'error' | 'warning' | 'success';
 
+export type EnumOptionValue = string | number | boolean;
+
+export interface EnumPropControlDescriptor {
+  kind: 'enum';
+  options: string[];
+  allowEmpty: boolean;
+  optionValues?: Record<string, EnumOptionValue>;
+}
+
 export type PropControlDescriptor =
-  | {kind: 'enum'; options: string[]; allowEmpty: boolean}
+  | EnumPropControlDescriptor
   | {kind: 'input-status'; options: InputStatusOption[]; allowEmpty: boolean}
   | {kind: 'theme'}
   | {kind: 'syntax-theme'}
@@ -207,19 +222,45 @@ export function parsePropType(
 
   const parts = splitUnion(t);
   const literals: string[] = [];
+  const optionValues: Record<string, EnumOptionValue> = {};
   let allowEmpty = false;
   let onlyLiterals = true;
+  let hasNonBooleanLiteral = false;
+  let hasOptionValueOverrides = false;
+
+  function addLiteral(value: string): void {
+    if (!literals.includes(value)) {
+      literals.push(value);
+    }
+  }
+
+  function addOptionValue(option: string, value: EnumOptionValue): void {
+    optionValues[option] = value;
+    hasOptionValueOverrides = true;
+  }
 
   for (const part of parts) {
     if (part === 'undefined' || part === 'null') {
       allowEmpty = true;
       continue;
     }
+    if (part === 'boolean') {
+      addLiteral('true');
+      addLiteral('false');
+      addOptionValue('true', true);
+      addOptionValue('false', false);
+      continue;
+    }
     const sm = STRING_LITERAL_RE.exec(part);
     if (sm) {
-      literals.push(sm[1]);
+      hasNonBooleanLiteral = true;
+      addLiteral(sm[1]);
     } else if (NUMBER_LITERAL_RE.test(part)) {
-      literals.push(part);
+      hasNonBooleanLiteral = true;
+      addLiteral(part);
+    } else if (part === 'true' || part === 'false') {
+      addLiteral(part);
+      addOptionValue(part, part === 'true');
     } else {
       onlyLiterals = false;
       break;
@@ -227,17 +268,31 @@ export function parsePropType(
   }
 
   if (onlyLiterals && literals.length >= 2) {
-    return {kind: 'enum', options: literals, allowEmpty};
-  }
-
-  if (
-    onlyLiterals === false &&
-    parts.every(p => p === 'true' || p === 'false')
-  ) {
-    return {kind: 'boolean'};
+    if (!hasNonBooleanLiteral) {
+      return {kind: 'boolean'};
+    }
+    return {
+      kind: 'enum',
+      options: literals,
+      allowEmpty,
+      ...(hasOptionValueOverrides ? {optionValues} : {}),
+    };
   }
 
   return {kind: 'unknown'};
+}
+
+export function coerceEnumOption(
+  control: EnumPropControlDescriptor,
+  option: string,
+): EnumOptionValue {
+  if (
+    control.optionValues != null &&
+    Object.prototype.hasOwnProperty.call(control.optionValues, option)
+  ) {
+    return control.optionValues[option];
+  }
+  return option;
 }
 
 export function coerceDefault(
@@ -262,7 +317,9 @@ export function coerceDefault(
     case 'enum': {
       const m = STRING_LITERAL_RE.exec(v);
       const stripped = m ? m[1] : v;
-      return control.options.includes(stripped) ? stripped : undefined;
+      return control.options.includes(stripped)
+        ? coerceEnumOption(control, stripped)
+        : undefined;
     }
     case 'string': {
       const m = STRING_LITERAL_RE.exec(v);


### PR DESCRIPTION
Summary:
- Expand boolean keywords in literal unions into true/false enum options for prop controls
- Preserve typed enum option values so selecting true/false passes real booleans, not strings
- Apply the same coercion in the component detail props table and the playground Property panel
- Add coverage for hasHoverIndication (`'auto' | boolean`) options and boolean coercion

Tests:
- pnpm -F @xds/docsite exec vitest run src/__tests__/component-prop-controls.test.ts
- pnpm exec eslint apps/docsite/src/components/component-detail/parsePropType.ts apps/docsite/src/components/component-detail/interactiveState.ts apps/docsite/src/components/component-detail/PlaygroundPropsTable.tsx apps/docsite/src/app/playground/PropertyPanel.tsx apps/docsite/src/__tests__/component-prop-controls.test.ts --no-cache
- pnpm exec prettier --check apps/docsite/src/components/component-detail/parsePropType.ts apps/docsite/src/components/component-detail/interactiveState.ts apps/docsite/src/components/component-detail/PlaygroundPropsTable.tsx apps/docsite/src/app/playground/PropertyPanel.tsx apps/docsite/src/__tests__/component-prop-controls.test.ts
- pnpm check:repo
- pnpm exec tsx -e <smoke: "'auto' | boolean" options coerce to auto:string,true:boolean,false:boolean and format hasHoverIndication as boolean shorthand>

Fixes #2762