### PR TITLE
fix(docsite): decode example title escapes

### DIFF
--- a/apps/docsite/scripts/generate-data.mjs
+++ b/apps/docsite/scripts/generate-data.mjs
@@ -133,11 +133,9 @@ function extractQuotedField(content, field) {
   return parseStringLiteral(content, openIdx).value;
 }
 
-/** Extract group/description/hidden from .doc.mjs via regex (no dynamic import) */
+/** Extract doc metadata from .doc.mjs source without dynamic import. */
 const GROUP_RE = /(?:^|\n) {0,4}group:\s*['"]([^'"]+)['"]/;
 const HIDDEN_RE = /(?:^|\n) {0,4}hidden:\s*true/;
-const NAME_RE = /(?:^|\n) {0,4}name:\s*['"]([^'"]+)['"]/;
-const DISPLAY_NAME_RE = /(?:^|\n) {0,4}displayName:\s*['"]([^'"]+)['"]/;
 const KEYWORDS_RE = /keywords:\s*\[([^\]]*)\]/;
 const CATEGORY_RE = /(?:^|\n) {0,4}category:\s*['"]([^'"]+)['"]/;
 const IS_HIDDEN_FROM_OVERVIEW_RE = /(?:^|\n) {0,4}isHiddenFromOverview:\s*true/;
@@ -147,8 +145,8 @@ function readDocMeta(docPath) {
     const content = fs.readFileSync(docPath, 'utf-8');
     const groupMatch = GROUP_RE.exec(content);
     const description = extractQuotedField(content, 'description');
-    const nameMatch = NAME_RE.exec(content);
-    const displayNameMatch = DISPLAY_NAME_RE.exec(content);
+    const name = extractQuotedField(content, 'name');
+    const displayName = extractQuotedField(content, 'displayName');
     const hidden = HIDDEN_RE.test(content);
     const kwMatch = KEYWORDS_RE.exec(content);
     const keywords = kwMatch
@@ -159,8 +157,8 @@ function readDocMeta(docPath) {
     return {
       group: groupMatch?.[1] ?? null,
       description: description ?? '',
-      name: nameMatch?.[1] ?? null,
-      displayName: displayNameMatch?.[1] ?? null,
+      name: name ?? null,
+      displayName: displayName ?? null,
       hidden,
       keywords,
       category: categoryMatch?.[1] ?? null,
@@ -1393,7 +1391,7 @@ function generateExampleRegistry() {
     if (!fs.existsSync(tsxSrc)) continue;
 
     // Read name and description from doc meta
-    const nameMatch = content.match(/name:\s*['"]([^'"]+)['"]/);
+    const name = extractQuotedField(content, 'name');
     const description = extractQuotedField(content, 'description');
 
     let source = '';
@@ -1406,7 +1404,7 @@ function generateExampleRegistry() {
       entries.push({
         exampleFor,
         basename,
-        name: nameMatch?.[1] || basename,
+        name: name || basename,
         description: description || '',
         source,
       });
@@ -1421,7 +1419,7 @@ function generateExampleRegistry() {
       entries.push({
         exampleFor: target,
         basename: aliasBasename,
-        name: nameMatch?.[1] || basename,
+        name: name || basename,
         description: description || `Example using ${target}.`,
         source,
       });

--- a/apps/docsite/src/__tests__/data-extraction.test.ts
+++ b/apps/docsite/src/__tests__/data-extraction.test.ts
@@ -422,6 +422,14 @@ describe('blockRegistry', () => {
     }
   });
 
+  it('decodes unicode escapes in block titles', () => {
+    const block = blocks.find(b => b.dirName === 'TabListTabsWithBadge');
+    expect(block).toBeDefined();
+    expect(block!.name).toBe('TabList — With Badge');
+    expect(block!.displayName).toBe('TabList — With Badge');
+    expect(block!.name).not.toContain('\\u2014');
+  });
+
   it('showcase sources contain valid JSX', () => {
     const showcases = blocks.filter(b => b.isShowcase);
     for (const s of showcases) {
@@ -661,6 +669,14 @@ describe('exampleRegistry', () => {
     expect(separators!.description).toContain('"/"');
     // Full sentence survives past the interior quote.
     expect(separators!.description).toMatch(/separator\.?$/i);
+  });
+
+  it('decodes unicode escapes in example titles', () => {
+    const tabList = exampleRegistry['TabList'] ?? [];
+    const withBadge = tabList.find(e => /With Badge/i.test(e.name));
+    expect(withBadge).toBeDefined();
+    expect(withBadge!.name).toBe('TabList — With Badge');
+    expect(withBadge!.name).not.toContain('\\u2014');
   });
 
   // Regression: long descriptions (>200 chars) must not be dropped.


### PR DESCRIPTION
## Summary

- Decode authored `name` / `displayName` string literals when extracting doc metadata from `.doc.mjs` files
- Use the same decoded string-literal extraction for example registry titles
- Add regression coverage for block and example titles containing `\u2014`

Fixes #2767.

## Test plan

- `pnpm -F @xds/docsite generate`
- `pnpm -F @xds/docsite exec vitest run src/__tests__/data-extraction.test.ts`
