### PR TITLE
fix(docsite): separate preview code controls

### DIFF
--- a/apps/docsite/src/components/component-detail/InteractivePreview.tsx
+++ b/apps/docsite/src/components/component-detail/InteractivePreview.tsx
@@ -2,6 +2,13 @@
 
 'use client';
 
+/**
+ * @file InteractivePreview.tsx
+ * @input Component registry metadata, generated playground state, and XDS components
+ * @output Interactive docsite component preview with an optional generated code view
+ * @position Component detail preview surface used by docsite property tabs
+ */
+
 import {
   createElement,
   useMemo,
@@ -33,6 +40,12 @@ import type {
 } from '../../generated/componentRegistry';
 
 export type {KnobProp} from './interactiveState';
+
+// The code view's copy button is positioned against the right edge of the
+// CodeExampleBlock. Reserve space for the absolutely positioned preview toggle
+// (right inset + icon-only button size + gap) so the two controls cannot stack.
+const CODE_VIEW_COPY_BUTTON_CLEARANCE =
+  'calc(var(--spacing-2) + var(--size-element-sm) + var(--spacing-2))';
 
 class PreviewErrorBoundary extends Component<
   {children: ReactNode; resetKeys: unknown[]},
@@ -274,7 +287,7 @@ export function InteractivePreviewStage({
           style={{
             minHeight: 200,
             overflow: 'auto',
-            paddingRight: 'var(--spacing-8)',
+            paddingRight: CODE_VIEW_COPY_BUTTON_CLEARANCE,
           }}>
           <CodeExampleBlock
             code={code}


### PR DESCRIPTION
## Summary
- replaces the partial code-view right padding from #2745 with an explicit clearance calculation
- reserves the preview toggle's right inset, small icon-button width, and gap so it cannot stack on the CodeBlock copy button
- adds the required file header for InteractivePreview

Closes #2760.

## Test plan
- pnpm -F @xds/core build
- pnpm -F @xds/docsite generate
- pnpm -F @xds/docsite test
- pnpm exec prettier --check apps/docsite/src/components/component-detail/InteractivePreview.tsx
- pnpm exec eslint apps/docsite/src/components/component-detail/InteractivePreview.tsx

Note: pnpm -F @xds/docsite typecheck was attempted after building core and generating docsite files, but the tsc process was killed by the sandbox before completion.