### PR TITLE
fix(docsite): theme component preview containers

### DIFF
--- a/apps/docsite/src/__tests__/component-preview-theme.test.ts
+++ b/apps/docsite/src/__tests__/component-preview-theme.test.ts
@@ -1,0 +1,41 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {readFileSync} from 'node:fs';
+import {dirname, join} from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {describe, expect, it} from 'vitest';
+
+const componentDetailDir = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '../components/component-detail',
+);
+
+function readComponentDetailFile(name: string): string {
+  return readFileSync(join(componentDetailDir, name), 'utf8');
+}
+
+describe('component detail preview theming', () => {
+  it('applies the neutral preview theme around preview containers', () => {
+    expect(readComponentDetailFile('ComponentDetailClient.tsx')).toMatch(
+      /<ComponentPreviewTheme>\s*<XDSCard variant="muted" padding=\{0\}>/,
+    );
+    expect(readComponentDetailFile('InteractivePreview.tsx')).toMatch(
+      /<ComponentPreviewTheme>\s*<XDSCard[\s>]/,
+    );
+    expect(readComponentDetailFile('ExampleBlock.tsx')).toMatch(
+      /<ComponentPreviewTheme>\s*<XDSCard padding=\{3\}>/,
+    );
+  });
+
+  it('keeps the theme boundary at the container instead of inside content', () => {
+    expect(readComponentDetailFile('ShowcasePreview.tsx')).not.toContain(
+      'XDSTheme theme={neutralTheme}',
+    );
+    expect(readComponentDetailFile('InteractivePreview.tsx')).not.toContain(
+      'XDSTheme theme={neutralTheme}',
+    );
+    expect(readComponentDetailFile('ExampleBlock.tsx')).not.toContain(
+      'XDSTheme theme={neutralTheme}',
+    );
+  });
+});

--- a/apps/docsite/src/components/component-detail/ComponentDetailClient.tsx
+++ b/apps/docsite/src/components/component-detail/ComponentDetailClient.tsx
@@ -14,6 +14,7 @@ import {CodeExampleBlock} from '../CodeExampleBlock';
 import {XDSTabList, XDSTab} from '@xds/core/TabList';
 import {useMediaQuery} from '@xds/core/hooks';
 import {ShowcasePreview} from './ShowcasePreview';
+import {ComponentPreviewTheme} from './ComponentPreviewTheme';
 import {BestPractices} from './BestPractices';
 import {HookSignature} from './HookSignature';
 import {ExampleBlock} from './ExampleBlock';
@@ -56,9 +57,11 @@ function OverviewContent({
   return (
     <XDSVStack gap={8}>
       {hasShowcase && (
-        <XDSCard variant="muted" padding={0}>
-          <ShowcasePreview name={comp.name} />
-        </XDSCard>
+        <ComponentPreviewTheme>
+          <XDSCard variant="muted" padding={0}>
+            <ShowcasePreview name={comp.name} />
+          </XDSCard>
+        </ComponentPreviewTheme>
       )}
 
       {comp.usage && (

--- a/apps/docsite/src/components/component-detail/ComponentPreviewTheme.tsx
+++ b/apps/docsite/src/components/component-detail/ComponentPreviewTheme.tsx
@@ -1,0 +1,27 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * ComponentPreviewTheme.
+ *
+ * @input component preview chrome and preview content from the docsite
+ * @output children rendered under the neutral preview theme with the current mode
+ * @position Component detail previews — wraps the preview container as well as
+ * the component so their backgrounds, borders, and content tokens match.
+ */
+
+import {type ReactNode} from 'react';
+import {XDSTheme} from '@xds/core/theme';
+import {neutralTheme} from '@xds/theme-neutral/built';
+import {useThemeMode} from '../../app/providers';
+
+export function ComponentPreviewTheme({children}: {children: ReactNode}) {
+  const {mode} = useThemeMode();
+
+  return (
+    <XDSTheme theme={neutralTheme} mode={mode}>
+      {children}
+    </XDSTheme>
+  );
+}

--- a/apps/docsite/src/components/component-detail/ExampleBlock.tsx
+++ b/apps/docsite/src/components/component-detail/ExampleBlock.tsx
@@ -12,15 +12,12 @@ import {XDSTabList, XDSTab} from '@xds/core/TabList';
 import {XDSSpinner} from '@xds/core/Spinner';
 import {XDSButton} from '@xds/core/Button';
 import {XDSHStack} from '@xds/core/Layout';
-import {XDSTheme} from '@xds/core/theme';
-import {neutralTheme} from '@xds/theme-neutral/built';
-import {useThemeMode} from '../../app/providers';
 import type {ExampleEntry} from '../../generated/exampleRegistry';
+import {ComponentPreviewTheme} from './ComponentPreviewTheme';
 import {buildPlaygroundHref} from '../playgroundLink';
 import {trackOpenPlayground} from '../../lib/analytics';
 
 function LivePreview({entry}: {entry: ExampleEntry}) {
-  const {mode} = useThemeMode();
   const [Component, setComponent] = useState<ComponentType | null>(null);
   const [error, setError] = useState(false);
 
@@ -50,21 +47,19 @@ function LivePreview({entry}: {entry: ExampleEntry}) {
   }
 
   return (
-    <XDSTheme theme={neutralTheme} mode={mode}>
-      <div
-        style={{
-          width: '100%',
-          overflow: 'auto',
-          minHeight: 200,
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-        }}>
-        <div style={{minWidth: 'fit-content', padding: 'var(--spacing-4)'}}>
-          <Component />
-        </div>
+    <div
+      style={{
+        width: '100%',
+        overflow: 'auto',
+        minHeight: 200,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}>
+      <div style={{minWidth: 'fit-content', padding: 'var(--spacing-4)'}}>
+        <Component />
       </div>
-    </XDSTheme>
+    </div>
   );
 }
 
@@ -76,49 +71,51 @@ export function ExampleBlock({entry}: ExampleBlockProps) {
   const [tab, setTab] = useState<string>('description');
 
   return (
-    <XDSCard padding={3}>
-      <XDSText type="body" weight="medium">
-        {entry.name}
-      </XDSText>
+    <ComponentPreviewTheme>
+      <XDSCard padding={3}>
+        <XDSText type="body" weight="medium">
+          {entry.name}
+        </XDSText>
 
-      <LivePreview entry={entry} />
+        <LivePreview entry={entry} />
 
-      <XDSSection variant="muted" padding={1} dividers={['top']}>
-        <XDSHStack
-          gap={1}
-          style={{justifyContent: 'space-between', alignItems: 'center'}}>
-          <XDSTabList value={tab} onChange={setTab} size="sm">
-            <XDSTab value="description" label="Description" />
-            <XDSTab value="code" label="Code" />
-          </XDSTabList>
-          {entry.source && (
-            <XDSButton
-              label="Open in Playground"
-              variant="ghost"
-              size="sm"
-              onClick={() => {
-                trackOpenPlayground({page: 'components', item: entry.name});
-                window.location.href = buildPlaygroundHref(entry.source);
-              }}
+        <XDSSection variant="muted" padding={1} dividers={['top']}>
+          <XDSHStack
+            gap={1}
+            style={{justifyContent: 'space-between', alignItems: 'center'}}>
+            <XDSTabList value={tab} onChange={setTab} size="sm">
+              <XDSTab value="description" label="Description" />
+              <XDSTab value="code" label="Code" />
+            </XDSTabList>
+            {entry.source && (
+              <XDSButton
+                label="Open in Playground"
+                variant="ghost"
+                size="sm"
+                onClick={() => {
+                  trackOpenPlayground({page: 'components', item: entry.name});
+                  window.location.href = buildPlaygroundHref(entry.source);
+                }}
+              />
+            )}
+          </XDSHStack>
+        </XDSSection>
+        <XDSSection variant="muted" padding={tab === 'code' ? 0 : 4}>
+          {tab === 'description' ? (
+            <XDSText type="body">
+              {entry.description || 'No description available.'}
+            </XDSText>
+          ) : (
+            <CodeExampleBlock
+              code={entry.source}
+              language="tsx"
+              hasCopyButton
+              container="section"
+              width="100%"
             />
           )}
-        </XDSHStack>
-      </XDSSection>
-      <XDSSection variant="muted" padding={tab === 'code' ? 0 : 4}>
-        {tab === 'description' ? (
-          <XDSText type="body">
-            {entry.description || 'No description available.'}
-          </XDSText>
-        ) : (
-          <CodeExampleBlock
-            code={entry.source}
-            language="tsx"
-            hasCopyButton
-            container="section"
-            width="100%"
-          />
-        )}
-      </XDSSection>
-    </XDSCard>
+        </XDSSection>
+      </XDSCard>
+    </ComponentPreviewTheme>
   );
 }

--- a/apps/docsite/src/components/component-detail/InteractivePreview.tsx
+++ b/apps/docsite/src/components/component-detail/InteractivePreview.tsx
@@ -18,10 +18,8 @@ import {XDSCenter} from '@xds/core/Center';
 import {CodeExampleBlock} from '../CodeExampleBlock';
 import {XDSVStack} from '@xds/core/Layout';
 import {XDSText} from '@xds/core/Text';
-import {XDSTheme} from '@xds/core/theme';
-import {neutralTheme} from '@xds/theme-neutral/built';
-import {useThemeMode} from '../../app/providers';
 import {Code} from 'lucide-react';
+import {ComponentPreviewTheme} from './ComponentPreviewTheme';
 import {
   buildInitialState,
   getMissingRequiredProps,
@@ -194,98 +192,101 @@ export function InteractivePreviewStage({
   state: Record<string, unknown>;
   missingRequiredProps?: string[];
 }) {
-  const {mode} = useThemeMode();
   const [showCode, setShowCode] = useState(false);
   const Component = getXDSComponent(name);
 
   if (missingRequiredProps.length > 0) {
     return (
-      <XDSCard variant="muted" padding={0}>
-        <XDSCenter style={{minHeight: 200, width: '100%'}}>
-          <XDSVStack
-            gap={1}
-            style={{
-              paddingBlock: 24,
-              paddingInline: 16,
-              textAlign: 'center',
-            }}>
-            <XDSText type="supporting" color="secondary">
-              Interactive preview needs required props that cannot be generated
-              automatically.
-            </XDSText>
-            <XDSText type="supporting" color="secondary">
-              Missing: {missingRequiredProps.join(', ')}
-            </XDSText>
-          </XDSVStack>
-        </XDSCenter>
-      </XDSCard>
+      <ComponentPreviewTheme>
+        <XDSCard variant="muted" padding={0}>
+          <XDSCenter style={{minHeight: 200, width: '100%'}}>
+            <XDSVStack
+              gap={1}
+              style={{
+                paddingBlock: 24,
+                paddingInline: 16,
+                textAlign: 'center',
+              }}>
+              <XDSText type="supporting" color="secondary">
+                Interactive preview needs required props that cannot be
+                generated automatically.
+              </XDSText>
+              <XDSText type="supporting" color="secondary">
+                Missing: {missingRequiredProps.join(', ')}
+              </XDSText>
+            </XDSVStack>
+          </XDSCenter>
+        </XDSCard>
+      </ComponentPreviewTheme>
     );
   }
 
   if (!Component) {
     return (
-      <XDSCard variant="muted" padding={0}>
-        <XDSCenter style={{minHeight: 200, width: '100%'}}>
-          <XDSVStack
-            gap={1}
-            style={{
-              paddingBlock: 24,
-              paddingInline: 16,
-              textAlign: 'center',
-            }}>
-            <XDSText type="supporting" color="secondary">
-              Interactive preview not available for {name}.
-            </XDSText>
-            <XDSText type="supporting" color="secondary">
-              This component is not part of @xds/core.
-            </XDSText>
-          </XDSVStack>
-        </XDSCenter>
-      </XDSCard>
+      <ComponentPreviewTheme>
+        <XDSCard variant="muted" padding={0}>
+          <XDSCenter style={{minHeight: 200, width: '100%'}}>
+            <XDSVStack
+              gap={1}
+              style={{
+                paddingBlock: 24,
+                paddingInline: 16,
+                textAlign: 'center',
+              }}>
+              <XDSText type="supporting" color="secondary">
+                Interactive preview not available for {name}.
+              </XDSText>
+              <XDSText type="supporting" color="secondary">
+                This component is not part of @xds/core.
+              </XDSText>
+            </XDSVStack>
+          </XDSCenter>
+        </XDSCard>
+      </ComponentPreviewTheme>
     );
   }
 
   const code = generateCode(name, state);
 
   return (
-    <XDSCard
-      variant="muted"
-      padding={0}
-      style={{width: '100%', position: 'relative'}}>
-      <div
-        style={{
-          position: 'absolute',
-          top: 'var(--spacing-2)',
-          right: 'var(--spacing-2)',
-          zIndex: 2,
-        }}>
-        <XDSButton
-          label="Show code"
-          tooltip="Show code"
-          icon={<Code size={16} />}
-          isIconOnly
-          variant={showCode ? 'secondary' : 'ghost'}
-          size="sm"
-          onClick={() => setShowCode(v => !v)}
-        />
-      </div>
-      {showCode ? (
+    <ComponentPreviewTheme>
+      <XDSCard
+        variant="muted"
+        padding={0}
+        style={{width: '100%', position: 'relative'}}>
         <div
           style={{
-            minHeight: 200,
-            overflow: 'auto',
-            paddingRight: 'var(--spacing-8)',
+            position: 'absolute',
+            top: 'var(--spacing-2)',
+            right: 'var(--spacing-2)',
+            zIndex: 2,
           }}>
-          <CodeExampleBlock
-            code={code}
-            language="tsx"
-            hasCopyButton
-            container="section"
-            width="100%"
+          <XDSButton
+            label="Show code"
+            tooltip="Show code"
+            icon={<Code size={16} />}
+            isIconOnly
+            variant={showCode ? 'secondary' : 'ghost'}
+            size="sm"
+            onClick={() => setShowCode(v => !v)}
           />
         </div>
-      ) : (
-        <XDSTheme theme={neutralTheme} mode={mode}>
+        {showCode ? (
+          <div
+            style={{
+              minHeight: 200,
+              overflow: 'auto',
+              paddingRight: 'var(--spacing-8)',
+            }}>
+            <CodeExampleBlock
+              code={code}
+              language="tsx"
+              hasCopyButton
+              container="section"
+              width="100%"
+            />
+          </div>
+        ) : (
           <XDSCenter
             style={{
               minHeight: 200,
@@ -296,8 +297,8 @@ export function InteractivePreviewStage({
               {createElement(Component, state)}
             </PreviewErrorBoundary>
           </XDSCenter>
-        </XDSTheme>
-      )}
-    </XDSCard>
+        )}
+      </XDSCard>
+    </ComponentPreviewTheme>
   );
 }

--- a/apps/docsite/src/components/component-detail/ShowcasePreview.tsx
+++ b/apps/docsite/src/components/component-detail/ShowcasePreview.tsx
@@ -6,18 +6,14 @@ import {useEffect, useState, type ComponentType} from 'react';
 import {XDSCenter} from '@xds/core/Center';
 import {XDSText} from '@xds/core/Text';
 import {XDSSpinner} from '@xds/core/Spinner';
-import {XDSTheme} from '@xds/core/theme';
 import {useMediaQuery} from '@xds/core/hooks';
-import {neutralTheme} from '@xds/theme-neutral/built';
 import {showcaseRegistry} from '../../generated/showcaseRegistry';
-import {useThemeMode} from '../../app/providers';
 
 interface ShowcasePreviewProps {
   name: string;
 }
 
 export function ShowcasePreview({name}: ShowcasePreviewProps) {
-  const {mode} = useThemeMode();
   const [Component, setComponent] = useState<ComponentType | null>(null);
   const [error, setError] = useState(false);
   const isSmall = useMediaQuery('(max-width: 768px)');
@@ -57,37 +53,33 @@ export function ShowcasePreview({name}: ShowcasePreviewProps) {
 
   if (isSmall) {
     return (
-      <XDSTheme theme={neutralTheme} mode={mode}>
-        <div
-          style={{
-            width: '100%',
-            overflow: 'auto',
-            minHeight: 160,
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-          }}>
-          <div style={{minWidth: 'fit-content'}}>
-            <Component />
-          </div>
-        </div>
-      </XDSTheme>
-    );
-  }
-
-  return (
-    <XDSTheme theme={neutralTheme} mode={mode}>
       <div
         style={{
           width: '100%',
-          aspectRatio: '16 / 9',
           overflow: 'auto',
+          minHeight: 160,
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
         }}>
-        <Component />
+        <div style={{minWidth: 'fit-content'}}>
+          <Component />
+        </div>
       </div>
-    </XDSTheme>
+    );
+  }
+
+  return (
+    <div
+      style={{
+        width: '100%',
+        aspectRatio: '16 / 9',
+        overflow: 'auto',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}>
+      <Component />
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

- Add a shared neutral theme wrapper for component detail preview surfaces
- Move showcase, interactive, and example preview containers into the same neutral theme scope as the previewed components
- Add coverage to guard against placing the neutral theme boundary inside preview content only

Fixes #2681.

## Test Plan

- `pnpm -F @xds/docsite exec vitest run --maxWorkers=1`
- `pnpm exec eslint apps/docsite/src/components/component-detail/ComponentPreviewTheme.tsx apps/docsite/src/components/component-detail/ComponentDetailClient.tsx apps/docsite/src/components/component-detail/ShowcasePreview.tsx apps/docsite/src/components/component-detail/InteractivePreview.tsx apps/docsite/src/components/component-detail/ExampleBlock.tsx apps/docsite/src/__tests__/component-preview-theme.test.ts`
