### PR TITLE
fix(layer): inherit theme font in portals

### DIFF
--- a/.changeset/hovercard-layer-font.md
+++ b/.changeset/hovercard-layer-font.md
@@ -1,0 +1,5 @@
+---
+'@xds/core': patch
+---
+
+Apply the theme body font token to XDS layer roots so portaled HoverCard content and other layered overlays inherit the configured font family.

--- a/packages/core/src/HoverCard/XDSHoverCard.test.tsx
+++ b/packages/core/src/HoverCard/XDSHoverCard.test.tsx
@@ -84,6 +84,20 @@ describe('XDSHoverCard', () => {
     expect(content).toBeInTheDocument();
   });
 
+  it('applies the theme body font to the portaled layer', () => {
+    render(
+      <XDSHoverCard content={<span>Card content</span>}>
+        <button type="button">Trigger</button>
+      </XDSHoverCard>,
+    );
+
+    const layer = screen.getByText('Card content').closest('[popover]');
+    expect(layer).not.toBeNull();
+    expect(getComputedStyle(layer as Element).fontFamily).toBe(
+      'var(--font-family-body)',
+    );
+  });
+
   it('injects aria-describedby on trigger', () => {
     render(
       <XDSHoverCard content={<span>Card content</span>}>

--- a/packages/core/src/Layer/useXDSLayer.tsx
+++ b/packages/core/src/Layer/useXDSLayer.tsx
@@ -4,7 +4,7 @@
 
 /**
  * @file useXDSLayer.tsx
- * @input Uses React hooks, Popover API, CSS anchor positioning
+ * @input Uses React hooks, Popover API, CSS anchor positioning, typography tokens
  * @output Exports useXDSLayer hook for layer positioning and visibility
  * @position Core layer utility; used by useXDSHoverCard, useXDSTooltip, etc.
  *
@@ -23,7 +23,7 @@ import React, {
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {typographyVars} from '../theme/tokens.stylex';
 
 // Extend React's HTMLAttributes to include popover API attributes
 declare module 'react' {
@@ -47,6 +47,7 @@ const styles = stylex.create({
     borderWidth: 0,
     borderStyle: 'none',
     overflow: 'visible',
+    fontFamily: typographyVars['--font-family-body'],
     // Override browser default [popover] background (canvas color)
     backgroundColor: 'transparent',
   },


### PR DESCRIPTION
## Summary
- Apply the XDS body font token on the shared layer root so portaled/top-layer overlays inherit the configured theme font
- Add HoverCard coverage for the portaled layer font-family
- Add a patch changeset for @xds/core

Fixes #2726

## Test plan
- pnpm exec vitest run packages/core/src/HoverCard/XDSHoverCard.test.tsx
- pnpm exec eslint packages/core/src/Layer/useXDSLayer.tsx packages/core/src/HoverCard/XDSHoverCard.test.tsx
- pnpm check:sync
- pnpm -F @xds/core build

Note: `pnpm -F @xds/core typecheck` was attempted twice but was killed by the sandbox OOM killer; the package build completed successfully and includes `tsc --project tsconfig.build.json`.
