### PR TITLE
fix(docsite): render CommandPalette properties preview

### DIFF
--- a/apps/docsite/src/__tests__/component-preview-state.test.ts
+++ b/apps/docsite/src/__tests__/component-preview-state.test.ts
@@ -52,6 +52,37 @@ describe('component detail preview state', () => {
     expect(getMissingRequiredProps(knobs, state)).toEqual([]);
   });
 
+  it('keeps generated required fallbacks when playground defaults open an inline preview', () => {
+    const knobs = pickPrimaryProps('CommandPalette', [
+      prop({name: 'isOpen', type: 'boolean', required: true}),
+      prop({
+        name: 'onOpenChange',
+        type: '(isOpen: boolean) => void',
+        required: true,
+      }),
+      prop({name: 'searchSource', type: 'XDSSearchSource<T>', required: true}),
+      prop({name: 'isInline', type: 'boolean'}),
+    ]);
+
+    const state = buildInitialState(knobs, {
+      defaults: {
+        isOpen: true,
+        isInline: true,
+        onOpenChange: undefined,
+      },
+    });
+
+    expect(state.isOpen).toBe(true);
+    expect(state.isInline).toBe(true);
+    expect(state.onOpenChange).toEqual(expect.any(Function));
+    expect(state.searchSource).toMatchObject({
+      search: expect.any(Function),
+      bootstrap: expect.any(Function),
+      cancel: expect.any(Function),
+    });
+    expect(getMissingRequiredProps(knobs, state)).toEqual([]);
+  });
+
   it('reports required props that cannot be generated safely', () => {
     const knobs = pickPrimaryProps('CustomWidget', [
       prop({name: 'config', type: 'CustomConfig', required: true}),

--- a/packages/core/src/CommandPalette/CommandPalette.doc.mjs
+++ b/packages/core/src/CommandPalette/CommandPalette.doc.mjs
@@ -20,6 +20,13 @@ export const docs = {
     'navigation',
   ],
   description: 'Root component. Manages open state, search, keyboard navigation, and composition slots.',
+  playground: {
+    defaults: {
+      isOpen: true,
+      isInline: true,
+      onOpenChange: undefined,
+    },
+  },
   props: [
     {
       name: 'isOpen',


### PR DESCRIPTION
## Summary
- Add explicit CommandPalette playground defaults so the docsite properties preview mounts the palette open and inline, matching the other overlay previews.
- Keep the generated preview fallbacks for required props, including the mock `XDSSearchSource` with `search`, `bootstrap`, and `cancel`.
- Add regression coverage for playground defaults that open an inline preview while preserving generated required fallbacks.

Fixes #2700

## Test plan
- [x] `pnpm -F @xds/core build`
- [x] `pnpm -F @xds/docsite generate`
- [x] `pnpm -F @xds/docsite test`
- [x] `pnpm check:repo`