### PR TITLE
docs(dense): add missing bestPractices to ChatLayout and FieldStatus overlays

### DIFF
--- a/packages/core/src/Chat/ChatLayout.doc.mjs
+++ b/packages/core/src/Chat/ChatLayout.doc.mjs
@@ -125,6 +125,15 @@ export const docsDense = {
   name: 'ChatLayout',
   displayName: 'Chat Layout',
   description: 'layout shell for full chat; msgs in page flow, composer fixed bottom w/ frosted glass dock; auto density via container width; scrollRef delegates to parent/body',
+  usage: {
+    bestPractices: [
+      {guidance: true, description: 'Pass XDSChatMessageList as children and XDSChatComposer as composer prop for complete chat.'},
+      {guidance: true, description: 'Provide emptyState so new conversations show a prompt, not blank screen.'},
+      {guidance: true, description: 'Use scrollRef when chat is embedded in a page where a parent element handles scrolling.'},
+      {guidance: false, description: 'Apply fixed height on layout; let it fill container with flex: 1.'},
+      {guidance: false, description: 'Render multiple ChatLayout instances in same scroll container; each expects to own its scroll context.'},
+    ],
+  },
   propDescriptions: {
     children: 'msg content; typically XDSChatMessageList',
     composer: 'composer element; typically XDSChatComposer; fixed bottom w/ frosted glass',

--- a/packages/core/src/FieldStatus/FieldStatus.doc.mjs
+++ b/packages/core/src/FieldStatus/FieldStatus.doc.mjs
@@ -67,6 +67,13 @@ export const docs = {
 export const docsDense = {
   description:
     'Validation feedback message for fields/custom controls. Supports error, warning, success and attached/detached variants.',
+  usage: {
+    bestPractices: [
+      {guidance: true, description: 'Use attached status below bordered inputs when message belongs to that input.'},
+      {guidance: true, description: 'Use detached status for checkboxes, switches, and custom controls where overlap is visually awkward.'},
+      {guidance: false, description: 'Use FieldStatus for general alerts or page-level notices; use Banner or Toast instead.'},
+    ],
+  },
   propDescriptions: {
     type: 'error/warning/success status tone',
     message: 'visible validation feedback text',


### PR DESCRIPTION
## What

ChatLayout and FieldStatus had `docsDense` overlays with prop descriptions but no `usage.bestPractices`, causing the CLI `--lang dense` output to silently fall back to English best practices instead of rendering compressed versions.

### ChatLayout
- English has 5 bestPractices entries; dense had 0
- Added 5 matching entries with guidance flags preserved

### FieldStatus
- English has 3 bestPractices entries; dense had 0
- Added 3 matching entries with guidance flags preserved

## Validation
- `pnpm --filter @xds/core typecheck:docs` passes
- `npx tsc --project packages/cli/tsconfig.template-docs.json --noEmit` passes
- `xds component ChatLayout --lang dense` renders bestPractices correctly
- `xds component FieldStatus --lang dense` renders bestPractices correctly
- No duplicate `(required)` markers in output

---
*Night Watch \x97 Doc Reviewer*