### PR TITLE
fix(core): EmptyState kebab-case className, InputClearButton displayName

### DIFF
--- a/apps/docsite/src/components/themePlayground/constants.ts
+++ b/apps/docsite/src/components/themePlayground/constants.ts
@@ -329,7 +329,7 @@ export const ALL_COMPONENT_NAMES = [
   'dialog',
   'divider',
   'dropdown-menu',
-  'emptystate',
+  'empty-state',
   'field',
   'heading',
   'hovercard',

--- a/apps/sandbox/src/app/(fullscreen)/pages/documentation/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/documentation/page.tsx
@@ -179,7 +179,7 @@ const COMPONENT_CATEGORIES = [
         desc: 'DropdownMenu presents a list of actions or options in a floating overlay. It is triggered by a button and supports nested submenus.',
       },
       {
-        key: 'emptystate',
+        key: 'empty-state',
         name: 'EmptyState',
         desc: 'EmptyState provides a placeholder when there is no content to display. It guides users with a message, illustration, and optional call-to-action.',
       },

--- a/packages/cli/src/commands/build-theme.mjs
+++ b/packages/cli/src/commands/build-theme.mjs
@@ -797,7 +797,7 @@ const KNOWN_COMPONENTS = {
   dialog: ['variant', 'position'],
   divider: ['variant', 'orientation'],
   dropdownmenu: [],
-  emptystate: [],
+  'empty-state': [],
   field: [],
   formlayout: [],
   grid: ['align'],

--- a/packages/cli/templates/pages/documentation-design/page.tsx
+++ b/packages/cli/templates/pages/documentation-design/page.tsx
@@ -115,7 +115,7 @@ const COMPONENT_CATEGORIES = [
         desc: 'DropdownMenu presents a list of actions or options in a floating overlay. It is triggered by a button and supports nested submenus.',
       },
       {
-        key: 'emptystate',
+        key: 'empty-state',
         name: 'EmptyState',
         desc: 'EmptyState provides a placeholder when there is no content to display. It guides users with a message, illustration, and optional call-to-action.',
       },

--- a/packages/cli/templates/pages/documentation/page.tsx
+++ b/packages/cli/templates/pages/documentation/page.tsx
@@ -73,7 +73,7 @@ const COMPONENT_CATEGORIES = [
         desc: 'DropdownMenu presents a list of actions or options in a floating overlay. It is triggered by a button and supports nested submenus.',
       },
       {
-        key: 'emptystate',
+        key: 'empty-state',
         name: 'EmptyState',
         desc: 'EmptyState provides a placeholder when there is no content to display. It guides users with a message, illustration, and optional call-to-action.',
       },

--- a/packages/core/src/EmptyState/EmptyState.doc.mjs
+++ b/packages/core/src/EmptyState/EmptyState.doc.mjs
@@ -65,7 +65,7 @@ export const docs = {
   },
   theming: {
     targets: [
-      {className: 'xds-emptystate'},
+      {className: 'xds-empty-state'},
     ],
   },
   usage: {
@@ -140,7 +140,7 @@ export const docsZh = {
   ],
   theming: {
     targets: [
-      {className: 'xds-emptystate'},
+      {className: 'xds-empty-state'},
     ],
   },
   usage: {

--- a/packages/core/src/EmptyState/XDSEmptyState.tsx
+++ b/packages/core/src/EmptyState/XDSEmptyState.tsx
@@ -156,7 +156,7 @@ export function XDSEmptyState({
       ref={ref}
       role="status"
       {...mergeProps(
-        xdsThemeProps('emptystate', {variant: isCompact ? 'compact' : null}),
+        xdsThemeProps('empty-state', {variant: isCompact ? 'compact' : null}),
         stylex.props(
           styles.container,
           isCompact && styles.containerCompact,

--- a/packages/core/src/Field/XDSInputClearButton.tsx
+++ b/packages/core/src/Field/XDSInputClearButton.tsx
@@ -44,3 +44,5 @@ export function XDSInputClearButton({
     />
   );
 }
+
+XDSInputClearButton.displayName = 'XDSInputClearButton';


### PR DESCRIPTION
## Summary

Fixes two issues found during component audit of DateTimeInput, Divider, DropdownMenu, EmptyState, and Field.

### Changes

1. **EmptyState xdsThemeProps key: `emptystate` -> `empty-state`**
   All other multi-word components use kebab-case (`dropdown-menu`, `date-time-input`, `alert-dialog`, `button-group`, etc.). EmptyState was the only outlier using concatenated lowercase. Updated the component, doc file, CLI theme builder registry, docsite constants, and template pages.

2. **XDSInputClearButton: added missing displayName**
   This exported component was missing `displayName`, which prevents minified builds from showing a readable name in React DevTools.

### Needs Review

- The EmptyState rename changes the DOM class from `xds-emptystate` to `xds-empty-state`. No internal themes target this class (verified), but external CSS selectors would need updating. Consider whether this warrants a codemod entry.
- XDSDropdownMenuItem manually declares `xstyle`, `className`, `style` instead of extending `XDSBaseProps`. This means consumers cannot pass `data-*` attributes, `id`, or ARIA props. Flagging for future API discussion rather than fixing here (would be a breaking type change).

### Audit Notes (no issues found)

- **DateTimeInput**: Clean. Uses semantic type scale tokens, proper XDSField composition, correct xdsThemeProps with size+status, proper a11y wiring (aria-expanded, aria-controls, combobox role, describedby), extends XDSBaseProps.
- **Divider**: Clean. All tokens used correctly, extensible variant map via module augmentation, proper role=separator with aria-orientation.
- **DropdownMenu**: Clean. Proper composition (XDSButton, XDSIcon, XDSItem, XDSDivider), extensible via compound-component pattern, correct ARIA menu wiring, xdsThemeProps on both menu and menu-item.
- **Field**: Clean. Well-structured form field wrapper with proper label/description/status pattern, shared inputStyles for cross-component consistency.

Night Watch \u2014 Component Auditor