### PR TITLE
fix(cli): expand LayerPlacement types in overlay docs

### DIFF
--- a/apps/sandbox/.claude/CLAUDE.md
+++ b/apps/sandbox/.claude/CLAUDE.md
@@ -4,7 +4,7 @@ Project-specific guidance for AI coding agents.
 
 <!-- XDS:START -->
 
-XDS v0.0.14 — 166 components
+XDS v0.0.14 — 165 components
 
 Before writing any UI code:
 
@@ -22,7 +22,7 @@ If a component prop does what you need, use it — never replicate with CSS/styl
 No magic values — run `pnpm exec xds docs tokens` for spacing/color/radius.
 To change accent/brand colors: `pnpm exec xds theme` — never override --xds-color-\* in :root.
 
-pnpm exec xds component --list 166 components by category
+pnpm exec xds component --list 165 components by category
 pnpm exec xds component <Name> props, types, examples
 pnpm exec xds docs color Semantic color tokens for surfaces, text, icons...
 pnpm exec xds docs elevation Shadow tokens for visual elevation and inset st...

--- a/packages/core/src/HoverCard/HoverCard.doc.mjs
+++ b/packages/core/src/HoverCard/HoverCard.doc.mjs
@@ -45,13 +45,13 @@ export const docs = {
         },
         {
           name: 'placement',
-          type: 'LayerPlacement',
+          type: "'above' | 'below' | 'start' | 'end'",
           description: 'Position relative to the anchor element.',
           default: "'above'",
         },
         {
           name: 'alignment',
-          type: 'LayerAlignment',
+          type: "'start' | 'center' | 'end'",
           description: 'Alignment along the placement axis.',
           default: "'center'",
         },
@@ -153,13 +153,13 @@ export const docsZh = {
         },
         {
           name: 'placement',
-          type: 'LayerPlacement',
+          type: "'above' | 'below' | 'start' | 'end'",
           description: '相对于锚点元素的位置。',
           default: "'above'",
         },
         {
           name: 'alignment',
-          type: 'LayerAlignment',
+          type: "'start' | 'center' | 'end'",
           description: '沿放置轴的对齐方式。',
           default: "'center'",
         },

--- a/packages/core/src/HoverCard/useXDSHoverCard.doc.mjs
+++ b/packages/core/src/HoverCard/useXDSHoverCard.doc.mjs
@@ -7,8 +7,8 @@ export const docs = {
   group: 'HoverCard',
   keywords: ['hovercard', 'hover', 'preview', 'card', 'tooltip', 'popup', 'floating', 'anchor'],
   params: [
-    {name: 'placement', type: 'LayerPlacement', description: 'Position relative to the trigger.', default: "'above'"},
-    {name: 'alignment', type: 'LayerAlignment', description: 'Alignment along the placement axis.', default: "'center'"},
+    {name: 'placement', type: "'above' | 'below' | 'start' | 'end'", description: 'Position relative to the trigger.', default: "'above'"},
+    {name: 'alignment', type: "'start' | 'center' | 'end'", description: 'Alignment along the placement axis.', default: "'center'"},
     {name: 'delay', type: 'number', description: 'Delay before showing the hover card on hover, in milliseconds.', default: '300'},
     {name: 'hideDelay', type: 'number', description: 'Delay before hiding after mouse or focus leaves, in milliseconds.', default: '200'},
     {name: 'focusTrigger', type: "'auto' | 'always' | 'never'", description: 'When focus should open the hover card. auto only attaches focus listeners to naturally focusable elements.', default: "'auto'"},

--- a/packages/core/src/Popover/Popover.doc.mjs
+++ b/packages/core/src/Popover/Popover.doc.mjs
@@ -35,13 +35,13 @@ export const docs = {
         },
         {
           name: 'placement',
-          type: 'LayerPlacement',
+          type: "'above' | 'below' | 'start' | 'end'",
           description: 'Position placement relative to the trigger.',
           default: "'below'",
         },
         {
           name: 'alignment',
-          type: 'LayerAlignment',
+          type: "'start' | 'center' | 'end'",
           description: 'Alignment along the placement axis.',
           default: "'start'",
         },
@@ -164,13 +164,13 @@ export const docsZh = {
         },
         {
           name: 'placement',
-          type: 'LayerPlacement',
+          type: "'above' | 'below' | 'start' | 'end'",
           description: '相对于触发器的位置放置方式。',
           default: "'below'",
         },
         {
           name: 'alignment',
-          type: 'LayerAlignment',
+          type: "'start' | 'center' | 'end'",
           description: '沿放置轴的对齐方式。',
           default: "'start'",
         },

--- a/packages/core/src/Text/Heading.doc.mjs
+++ b/packages/core/src/Text/Heading.doc.mjs
@@ -50,8 +50,8 @@ export const docs = {
     },
     {
       name: 'hasTruncateTooltip',
-      type: 'boolean | LayerPlacement',
-      description: 'Controls tooltip behavior for truncated text. true shows the tooltip at the default position, false disables it, or a LayerPlacement string sets a specific position.',
+      type: "boolean | 'above' | 'below' | 'start' | 'end'",
+      description: "Controls tooltip behavior for truncated text. true shows the tooltip at the default position, false disables it, or a placement string ('above' | 'below' | 'start' | 'end') sets a specific position.",
       default: 'true',
     },
     {
@@ -131,8 +131,8 @@ export const docsZh = {
     },
     {
       name: 'hasTruncateTooltip',
-      type: 'boolean | LayerPlacement',
-      description: '控制截断文本的工具提示行为。true 在默认位置显示工具提示，false 禁用它，或者 LayerPlacement 字符串设置特定位置。',
+      type: "boolean | 'above' | 'below' | 'start' | 'end'",
+      description: "控制截断文本的工具提示行为。true 在默认位置显示工具提示，false 禁用它，或者放置字符串 ('above' | 'below' | 'start' | 'end') 设置特定位置。",
       default: 'true',
     },
     {
@@ -177,7 +177,7 @@ export const docsDense = {
     color: 'Text color.',
     display: "Display type; overridden to 'block' when maxLines>0 or hasCapsize.",
     maxLines: 'Max lines before truncation; 0=none. Shows tooltip if truncated.',
-    hasTruncateTooltip: 'Tooltip for truncated text; true=default position, false=disabled, or LayerPlacement.',
+    hasTruncateTooltip: "Tooltip for truncated text; true=default position, false=disabled, or a placement ('above' | 'below' | 'start' | 'end').",
     wordBreak: "Word break behavior; defaults 'break-all' for single-line, 'break-word' otherwise.",
     textWrap: 'Text wrapping behavior.',
     hasCapsize: 'Optical alignment via text-box-trim; forces block display.',

--- a/packages/core/src/Text/Text.doc.mjs
+++ b/packages/core/src/Text/Text.doc.mjs
@@ -68,8 +68,8 @@ export const docs = {
     },
     {
       name: 'hasTruncateTooltip',
-      type: 'boolean | LayerPlacement',
-      description: 'Controls tooltip behavior for truncated text. true shows the tooltip at the default position, false disables it, or a LayerPlacement string sets a specific position.',
+      type: "boolean | 'above' | 'below' | 'start' | 'end'",
+      description: "Controls tooltip behavior for truncated text. true shows the tooltip at the default position, false disables it, or a placement string ('above' | 'below' | 'start' | 'end') sets a specific position.",
       default: 'true',
     },
     {

--- a/packages/core/src/Tooltip/Tooltip.doc.mjs
+++ b/packages/core/src/Tooltip/Tooltip.doc.mjs
@@ -38,13 +38,13 @@ export const docs = {
         },
         {
           name: 'placement',
-          type: 'LayerPlacement',
+          type: "'above' | 'below' | 'start' | 'end'",
           description: 'Position relative to the anchor element.',
           default: "'above'",
         },
         {
           name: 'alignment',
-          type: 'LayerAlignment',
+          type: "'start' | 'center' | 'end'",
           description: 'Alignment along the placement axis.',
           default: "'center'",
         },
@@ -137,13 +137,13 @@ export const docsZh = {
         },
         {
           name: 'placement',
-          type: 'LayerPlacement',
+          type: "'above' | 'below' | 'start' | 'end'",
           description: '相对于锚点元素的位置。',
           default: "'above'",
         },
         {
           name: 'alignment',
-          type: 'LayerAlignment',
+          type: "'start' | 'center' | 'end'",
           description: '沿放置轴的对齐方式。',
           default: "'center'",
         },

--- a/packages/core/src/Tooltip/useXDSTooltip.doc.mjs
+++ b/packages/core/src/Tooltip/useXDSTooltip.doc.mjs
@@ -7,8 +7,8 @@ export const docs = {
   group: 'Tooltip',
   keywords: ['tooltip', 'hint', 'label', 'hover', 'info', 'title', 'floating'],
   params: [
-    {name: 'placement', type: 'LayerPlacement', description: 'Position relative to the trigger.', default: "'above'"},
-    {name: 'alignment', type: 'LayerAlignment', description: 'Alignment along the placement axis.', default: "'center'"},
+    {name: 'placement', type: "'above' | 'below' | 'start' | 'end'", description: 'Position relative to the trigger.', default: "'above'"},
+    {name: 'alignment', type: "'start' | 'center' | 'end'", description: 'Alignment along the placement axis.', default: "'center'"},
     {name: 'delay', type: 'number', description: 'Delay before showing on hover, in milliseconds.', default: '200'},
     {name: 'hideDelay', type: 'number', description: 'Delay before hiding after mouse or focus leaves, in milliseconds.', default: '0'},
     {name: 'focusTrigger', type: "'auto' | 'always' | 'never'", description: 'When focus should open the tooltip. auto only attaches focus listeners to naturally focusable elements.', default: "'auto'"},


### PR DESCRIPTION
## What

Expands opaque type references (`LayerPlacement`, `LayerAlignment`) to inline union literals in CLI documentation for Popover, Tooltip, HoverCard, Text, and Heading.

## Why

The vibe test nightly (issue #2824) showed agents using `placement="right"` on XDSPopover because the CLI docs displayed the type as `LayerPlacement` without revealing valid values. Agents guessed standard CSS directional values instead of XDS's semantic placements.

## Changes

- Popover.doc.mjs: `LayerPlacement` → `'above' | 'below' | 'start' | 'end'`
- Popover.doc.mjs: `LayerAlignment` → `'start' | 'center' | 'end'`
- Same expansion in HoverCard, Tooltip, useXDSHoverCard, useXDSTooltip docs
- Text.doc.mjs / Heading.doc.mjs: `boolean | LayerPlacement` → `boolean | 'above' | 'below' | 'start' | 'end'`
- Uses double-quoted JS strings where descriptions include quoted literal unions

## Verification

- [x] `pnpm -F @xds/core typecheck:docs`
- [x] `node .github/scripts/cli-smoke-test.mjs`
- [x] `pnpm test`
- [x] `pnpm check:repo` (via commit hook)
