### PR TITLE
fix(docsite): wire controlled open previews

### DIFF
--- a/apps/docsite/src/__tests__/component-preview-state.test.ts
+++ b/apps/docsite/src/__tests__/component-preview-state.test.ts
@@ -3,6 +3,7 @@
 import {describe, expect, it, vi} from 'vitest';
 import {
   buildInitialState,
+  buildRuntimePreviewState,
   getMissingRequiredProps,
   pickPrimaryProps,
 } from '../components/component-detail/interactiveState';
@@ -91,5 +92,23 @@ describe('component detail preview state', () => {
 
     expect(state.config).toBeUndefined();
     expect(getMissingRequiredProps(knobs, state)).toEqual(['config']);
+  });
+
+  it('wires controlled open previews back to their isOpen prop', () => {
+    const onPropChange = vi.fn();
+    const runtimeState = buildRuntimePreviewState(
+      {
+        children: 'Preview content',
+        isOpen: true,
+      },
+      onPropChange,
+      {canControlOpenState: true},
+    );
+
+    expect(runtimeState.onOpenChange).toEqual(expect.any(Function));
+
+    (runtimeState.onOpenChange as (isOpen: boolean) => void)(false);
+
+    expect(onPropChange).toHaveBeenCalledWith('isOpen', false);
   });
 });

--- a/apps/docsite/src/components/component-detail/ComponentDetailClient.tsx
+++ b/apps/docsite/src/components/component-detail/ComponentDetailClient.tsx
@@ -200,6 +200,11 @@ function ComponentDetailInner({
                     name={comp.name}
                     state={state}
                     missingRequiredProps={missingRequiredProps}
+                    onPropChange={setProp}
+                    canControlOpenState={
+                      comp.props.some(prop => prop.name === 'isOpen') &&
+                      comp.props.some(prop => prop.name === 'onOpenChange')
+                    }
                   />
                 </div>
 

--- a/apps/docsite/src/components/component-detail/InteractivePreview.tsx
+++ b/apps/docsite/src/components/component-detail/InteractivePreview.tsx
@@ -22,6 +22,7 @@ import {Code} from 'lucide-react';
 import {ComponentPreviewTheme} from './ComponentPreviewTheme';
 import {
   buildInitialState,
+  buildRuntimePreviewState,
   getMissingRequiredProps,
   pickPrimaryProps,
 } from './interactiveState';
@@ -187,10 +188,14 @@ export function InteractivePreviewStage({
   name,
   state,
   missingRequiredProps = [],
+  onPropChange,
+  canControlOpenState = false,
 }: {
   name: string;
   state: Record<string, unknown>;
   missingRequiredProps?: string[];
+  onPropChange?: (propName: string, value: unknown) => void;
+  canControlOpenState?: boolean;
 }) {
   const [showCode, setShowCode] = useState(false);
   const Component = getXDSComponent(name);
@@ -246,6 +251,10 @@ export function InteractivePreviewStage({
     );
   }
 
+  const runtimeState = useMemo(
+    () => buildRuntimePreviewState(state, onPropChange, {canControlOpenState}),
+    [state, onPropChange, canControlOpenState],
+  );
   const code = generateCode(name, state);
 
   return (
@@ -293,8 +302,8 @@ export function InteractivePreviewStage({
               width: '100%',
               padding: 'var(--spacing-4)',
             }}>
-            <PreviewErrorBoundary resetKeys={[Component, state]}>
-              {createElement(Component, state)}
+            <PreviewErrorBoundary resetKeys={[Component, runtimeState]}>
+              {createElement(Component, runtimeState)}
             </PreviewErrorBoundary>
           </XDSCenter>
         )}

--- a/apps/docsite/src/components/component-detail/interactiveState.ts
+++ b/apps/docsite/src/components/component-detail/interactiveState.ts
@@ -3,8 +3,8 @@
 /**
  * Builds the initial prop state for component detail interactive previews.
  * Keeps runtime-only defaults (callbacks, mock search sources, descriptor
- * resolution) out of the generated JSON registries while preserving typed
- * option values from parsed controls.
+ * resolution) and preview-only controlled callbacks out of the generated JSON
+ * registries while preserving typed option values from parsed controls.
  */
 
 import {allSyntaxPresets} from '@xds/core/theme/syntax';
@@ -205,4 +205,23 @@ export function getMissingRequiredProps(
   return knobs
     .filter(({row}) => row.required === true && state[row.name] === undefined)
     .map(({row}) => row.name);
+}
+
+export function buildRuntimePreviewState(
+  state: Record<string, unknown>,
+  onPropChange?: (propName: string, value: unknown) => void,
+  options?: {canControlOpenState?: boolean},
+): Record<string, unknown> {
+  if (
+    onPropChange == null ||
+    options?.canControlOpenState !== true ||
+    typeof state.isOpen !== 'boolean'
+  ) {
+    return state;
+  }
+
+  return {
+    ...state,
+    onOpenChange: (isOpen: boolean) => onPropChange('isOpen', isOpen),
+  };
 }


### PR DESCRIPTION
## Summary
- Wire component detail interactive previews with `isOpen`/`onOpenChange` props back to the playground state.
- Keep generated code output unchanged while passing a runtime-only `onOpenChange` callback to controlled open previews.
- Add coverage that the runtime preview callback updates `isOpen`, so Mobile Nav can close from its drawer close affordance/backdrop/Escape.

Fixes #2693

## Tests
- `pnpm -F @xds/core build`
- `pnpm -r --filter ./packages/themes/* build`
- `pnpm -F @xds/docsite generate`
- `cd apps/docsite && pnpm exec vitest run src/__tests__/component-preview-state.test.ts`
- `pnpm -F @xds/docsite typecheck`
- `cd apps/docsite && pnpm exec vitest run`