### PR TITLE
fix(docsite): prevent SideNav preview navigation

### DIFF
--- a/apps/docsite/src/components/component-detail/ComponentDetailClient.tsx
+++ b/apps/docsite/src/components/component-detail/ComponentDetailClient.tsx
@@ -104,7 +104,7 @@ function OverviewContent({
           </XDSVStack>
           <XDSVStack gap={10}>
             {(exampleRegistry[comp.name] || []).map((entry, i) => (
-              <ExampleBlock key={i} entry={entry} />
+              <ExampleBlock key={i} entry={entry} componentName={comp.name} />
             ))}
           </XDSVStack>
         </>

--- a/apps/docsite/src/components/component-detail/ExampleBlock.tsx
+++ b/apps/docsite/src/components/component-detail/ExampleBlock.tsx
@@ -17,8 +17,15 @@ import {ComponentPreviewTheme} from './ComponentPreviewTheme';
 import {buildPlaygroundHref} from '../playgroundLink';
 import {trackOpenPlayground} from '../../lib/analytics';
 import {MarkdownText} from '../MarkdownText';
+import {preventPreviewNavigation} from './previewNavigation';
 
-function LivePreview({entry}: {entry: ExampleEntry}) {
+function LivePreview({
+  entry,
+  componentName,
+}: {
+  entry: ExampleEntry;
+  componentName: string;
+}) {
   const [Component, setComponent] = useState<ComponentType | null>(null);
   const [error, setError] = useState(false);
 
@@ -28,6 +35,11 @@ function LivePreview({entry}: {entry: ExampleEntry}) {
       .then(mod => setComponent(() => mod.default))
       .catch(() => setError(true));
   }, [entry]);
+
+  const previewNavigationProps =
+    componentName === 'SideNav'
+      ? {onClickCapture: preventPreviewNavigation}
+      : {};
 
   if (error) {
     return (
@@ -56,7 +68,8 @@ function LivePreview({entry}: {entry: ExampleEntry}) {
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
-      }}>
+      }}
+      {...previewNavigationProps}>
       <div style={{minWidth: 'fit-content', padding: 'var(--spacing-4)'}}>
         <Component />
       </div>
@@ -66,9 +79,10 @@ function LivePreview({entry}: {entry: ExampleEntry}) {
 
 interface ExampleBlockProps {
   entry: ExampleEntry;
+  componentName: string;
 }
 
-export function ExampleBlock({entry}: ExampleBlockProps) {
+export function ExampleBlock({entry, componentName}: ExampleBlockProps) {
   const [tab, setTab] = useState<string>('description');
 
   return (
@@ -78,7 +92,7 @@ export function ExampleBlock({entry}: ExampleBlockProps) {
           {entry.name}
         </XDSText>
 
-        <LivePreview entry={entry} />
+        <LivePreview entry={entry} componentName={componentName} />
 
         <XDSSection variant="muted" padding={1} dividers={['top']}>
           <XDSHStack

--- a/apps/docsite/src/components/component-detail/ShowcasePreview.tsx
+++ b/apps/docsite/src/components/component-detail/ShowcasePreview.tsx
@@ -8,6 +8,7 @@ import {XDSText} from '@xds/core/Text';
 import {XDSSpinner} from '@xds/core/Spinner';
 import {useMediaQuery} from '@xds/core/hooks';
 import {showcaseRegistry} from '../../generated/showcaseRegistry';
+import {preventPreviewNavigation} from './previewNavigation';
 
 interface ShowcasePreviewProps {
   name: string;
@@ -28,6 +29,9 @@ export function ShowcasePreview({name}: ShowcasePreviewProps) {
       .then(mod => setComponent(() => mod.default))
       .catch(() => setError(true));
   }, [name]);
+
+  const previewNavigationProps =
+    name === 'SideNav' ? {onClickCapture: preventPreviewNavigation} : {};
 
   const placeholderStyle = isSmall
     ? {minHeight: 160, width: '100%'}
@@ -61,7 +65,8 @@ export function ShowcasePreview({name}: ShowcasePreviewProps) {
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
-        }}>
+        }}
+        {...previewNavigationProps}>
         <div style={{minWidth: 'fit-content'}}>
           <Component />
         </div>
@@ -78,7 +83,8 @@ export function ShowcasePreview({name}: ShowcasePreviewProps) {
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
-      }}>
+      }}
+      {...previewNavigationProps}>
       <Component />
     </div>
   );

--- a/apps/docsite/src/components/component-detail/previewNavigation.ts
+++ b/apps/docsite/src/components/component-detail/previewNavigation.ts
@@ -1,0 +1,21 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import type {MouseEvent} from 'react';
+
+/**
+ * Prevents example preview links from navigating the docsite while preserving
+ * the realistic hrefs shown in the source example.
+ */
+export function preventPreviewNavigation(event: MouseEvent<HTMLElement>) {
+  const target = event.target;
+  if (!(target instanceof Element)) {
+    return;
+  }
+
+  const anchor = target.closest('a[href]');
+  if (anchor == null) {
+    return;
+  }
+
+  event.preventDefault();
+}


### PR DESCRIPTION
## Summary
- Add a docsite preview navigation guard that prevents SideNav showcase/example links from navigating the docs app
- Apply the guard only to SideNav preview surfaces, preserving the realistic hrefs in the displayed source examples

## Rationale

The preview guard keeps the SideNav examples and showcases realistic: their source can still demonstrate real `href` values, while the docsite preview surface prevents those links from navigating away during interaction. Updating every example to use inert links would avoid navigation too, but it would make the displayed source less representative of how consumers wire SideNav in apps.

Fixes #2723

## Test plan
- pnpm -F @xds/docsite generate
- pnpm -F @xds/core build
- pnpm -F @xds/docsite test
- pnpm -F @xds/docsite typecheck
- pnpm exec eslint apps/docsite/src/components/component-detail/previewNavigation.ts apps/docsite/src/components/component-detail/ShowcasePreview.tsx apps/docsite/src/components/component-detail/ExampleBlock.tsx apps/docsite/src/components/component-detail/ComponentDetailClient.tsx

Note: full `pnpm lint` completed check:repo, then the all-repo eslint process was killed in the sandbox; the targeted eslint command above passed.
