### PR TITLE
fix(docsite): resolve DateInput status preview props

### DIFF
--- a/apps/docsite/src/__tests__/component-detail-resolve-elements.test.ts
+++ b/apps/docsite/src/__tests__/component-detail-resolve-elements.test.ts
@@ -8,6 +8,7 @@ vi.mock('@xds/core', () => ({
   XDSBadge: () => null,
   XDSIcon: () => null,
   XDSSideNavItem: () => null,
+  XDSText: () => null,
 }));
 
 describe('component detail element resolution', () => {
@@ -37,5 +38,24 @@ describe('component detail element resolution', () => {
     expect(resolved.before.props).toMatchObject({icon: 'check', size: 'sm'});
     expect(isValidElement(resolved.children[0])).toBe(true);
     expect(resolved.children[0].props).toMatchObject({label: '3'});
+  });
+
+  it('resolves descriptor values nested inside status-like object props', () => {
+    const resolved = resolveValue({
+      status: {
+        type: 'error',
+        message: {
+          __element: 'XDSText',
+          props: {type: 'body'},
+          children: 'Bad date',
+        },
+      },
+    }) as {
+      status: {type: string; message: ReactElement<Record<string, unknown>>};
+    };
+
+    expect(resolved.status.type).toBe('error');
+    expect(isValidElement(resolved.status.message)).toBe(true);
+    expect(resolved.status.message.props.children).toBe('Bad date');
   });
 });

--- a/apps/docsite/src/__tests__/component-prop-controls.test.ts
+++ b/apps/docsite/src/__tests__/component-prop-controls.test.ts
@@ -56,6 +56,21 @@ describe('component detail prop controls', () => {
     });
   });
 
+  it('keeps input status props as status controls even if slot elements are present', () => {
+    expect(
+      parsePropType('XDSInputStatus', 'status', [
+        {
+          __element: 'XDSFieldStatus',
+          props: {type: 'error', message: 'Error'},
+        },
+      ]),
+    ).toEqual({
+      kind: 'input-status',
+      options: ['error', 'warning', 'success'],
+      allowEmpty: true,
+    });
+  });
+
   it('expands mixed string-literal and boolean unions into enum options', () => {
     const control = parsePropType("'auto' | boolean", 'hasHoverIndication');
 

--- a/apps/docsite/src/components/component-detail/InteractivePreview.tsx
+++ b/apps/docsite/src/components/component-detail/InteractivePreview.tsx
@@ -11,7 +11,7 @@ import {
   Component,
   type ReactNode,
 } from 'react';
-import {getXDSComponent} from './resolveElements';
+import {getXDSComponent, resolveValue} from './resolveElements';
 import {XDSButton} from '@xds/core/Button';
 import {XDSCard} from '@xds/core/Card';
 import {XDSCenter} from '@xds/core/Center';
@@ -199,6 +199,13 @@ export function InteractivePreviewStage({
 }) {
   const [showCode, setShowCode] = useState(false);
   const Component = getXDSComponent(name);
+  const runtimeState = useMemo(
+    () =>
+      resolveValue(
+        buildRuntimePreviewState(state, onPropChange, {canControlOpenState}),
+      ) as Record<string, unknown>,
+    [state, onPropChange, canControlOpenState],
+  );
 
   if (missingRequiredProps.length > 0) {
     return (
@@ -251,10 +258,6 @@ export function InteractivePreviewStage({
     );
   }
 
-  const runtimeState = useMemo(
-    () => buildRuntimePreviewState(state, onPropChange, {canControlOpenState}),
-    [state, onPropChange, canControlOpenState],
-  );
   const code = generateCode(name, state);
 
   return (

--- a/apps/docsite/src/components/component-detail/parsePropType.ts
+++ b/apps/docsite/src/components/component-detail/parsePropType.ts
@@ -128,6 +128,18 @@ export function parsePropType(
     return {kind: 'unknown'};
   }
 
+  // Status objects are edited as typed validation-state objects, not slot
+  // elements. Check this before slotElements so a stale/generated descriptor on
+  // a status row cannot make the preview pass a React element where components
+  // expect {type, message}.
+  if (isInputStatusType(t, propName)) {
+    return {
+      kind: 'input-status',
+      options: parseStatusOptions(t),
+      allowEmpty: true,
+    };
+  }
+
   // If slotElements is declared, use it directly for the element control
   if (slotElements && slotElements.length > 0) {
     const options = slotElements.map(el => ({
@@ -170,13 +182,6 @@ export function parsePropType(
   }
   if (t === 'SyntaxTheme') {
     return {kind: 'syntax-theme'};
-  }
-  if (isInputStatusType(t, propName)) {
-    return {
-      kind: 'input-status',
-      options: parseStatusOptions(t),
-      allowEmpty: true,
-    };
   }
   if (t === 'XDSIconType' || t === 'XDSIconName') {
     return {


### PR DESCRIPTION
## Summary
- keep `XDSInputStatus` props on the component detail Properties tab as status-object controls, even if slot metadata is present
- resolve element descriptors in preview state right before rendering so nested descriptor values are not passed raw to components
- preserve the controlled-open preview wiring while resolving descriptor values after rebasing onto current `main`
- add regression coverage for status controls and nested descriptor resolution

Fixes #2699

## Test plan
- `pnpm -F @xds/core build`
- `pnpm -F @xds/docsite generate`
- `pnpm -F @xds/docsite test`
- `pnpm -F @xds/docsite typecheck` (after building theme packages)
- `pnpm -F @xds/theme-default build && pnpm -F @xds/theme-neutral build && pnpm -F @xds/theme-butter build && pnpm -F @xds/theme-gothic build && pnpm -F @xds/theme-matcha build && pnpm -F @xds/theme-stone build && pnpm -F @xds/theme-y2k build`
- previous targeted validation: `pnpm exec eslint apps/docsite/src/__tests__/component-detail-resolve-elements.test.ts apps/docsite/src/__tests__/component-prop-controls.test.ts apps/docsite/src/components/component-detail/InteractivePreview.tsx apps/docsite/src/components/component-detail/parsePropType.ts`
- previous smoke: node SSR render of XDSDateInput with `status={{type: 'error', message: 'Bad date'}}`
