### PR TITLE
feat(cli): add glasses layout target

### DIFF
--- a/packages/cli/src/api/layout.mjs
+++ b/packages/cli/src/api/layout.mjs
@@ -4,7 +4,7 @@
  * @file Programmatic API for the layout command (XLE/XLO).
  *
  * `xds layout` turns token-compressed layout expressions into validated
- * XDS TSX. Two input surfaces — compact (Emmet-derived XLE) and outline
+ * XDS TSX or native-shaped target payloads. Two input surfaces — compact (Emmet-derived XLE) and outline
  * (indentation-based XLO) — share one AST, one validator, and one
  * expander. See the research: pastes P2376666892 (spec) and P2376717669
  * (outline surface).
@@ -22,6 +22,7 @@ import {assertWithin, isFilePathArg, PathSafetyError} from '../utils/path-safety
 import {parse, detectForm, XLEParseError} from '../lib/xle/parse.mjs';
 import {validate} from '../lib/xle/validate.mjs';
 import {expand} from '../lib/xle/expand.mjs';
+import {emitPayload} from '../lib/xle/payload.mjs';
 import {toCompact, toOutline} from '../lib/xle/print.mjs';
 import {buildRegistry, ALIAS_TABLE} from '../lib/xle/registry.mjs';
 import {discoverTemplates, stripTemplateAssetRefs} from './template.mjs';
@@ -118,8 +119,8 @@ function formatIssue(issue) {
  * Parse + validate, throwing structured XDSErrors on failure.
  * Returns {doc, registry, blocks, warnings}.
  */
-async function analyze(expression, {form = 'auto', loose = false, cwd = process.cwd()} = {}) {
-  const registry = await buildRegistry({cwd});
+async function analyze(expression, {form = 'auto', loose = false, cwd = process.cwd(), target = 'core'} = {}) {
+  const registry = await buildRegistry({cwd, target});
   const blocks = await loadBlocks(cwd);
 
   let doc;
@@ -145,21 +146,41 @@ async function analyze(expression, {form = 'auto', loose = false, cwd = process.
  *
  * @param {string} expression
  * @param {object} [options]
- * @param {string} [options.targetPath] - write TSX here (validated against cwd)
+ * @param {string} [options.targetPath] - write TSX/payload artifact here (validated against cwd)
  * @param {'compact'|'outline'|'auto'} [options.form]
  * @param {boolean} [options.loose] - downgrade unknown {hints} to TODO warnings
  * @param {string} [options.name] - generated component name
  * @param {string} [options.cwd]
+ * @param {'core'|'glasses'} [options.target] - Component package target to validate/expand against.
+ * @param {'auto'|'tsx'|'payload'} [options.emit] - Output format. Auto means TSX for core, payload for glasses.
  */
 export async function layoutExpand(expression, options = {}) {
-  const {targetPath, form = 'auto', loose = false, name, cwd = process.cwd()} = options;
-  const {doc, registry, blocks, errors, warnings} = await analyze(expression, {form, loose, cwd});
+  const {targetPath, form = 'auto', loose = false, name, cwd = process.cwd(), target = 'core', emit = 'auto'} = options;
+  const {doc, registry, blocks, errors, warnings} = await analyze(expression, {form, loose, cwd, target});
 
   if (errors.length > 0) {
     throw new XDSError(
       `Layout expression is invalid:\n` + errors.map(e => `  - ${formatIssue(e)}`).join('\n'),
       errors.flatMap(e => (e.suggestions || []).map(s => ({name: s, reason: 'did you mean this?'}))),
       ERROR_CODES.ERR_LAYOUT_INVALID,
+    );
+  }
+
+  const resolvedEmit = emit === 'auto'
+    ? (target === 'glasses' ? 'payload' : 'tsx')
+    : emit;
+  if (resolvedEmit !== 'tsx' && resolvedEmit !== 'payload') {
+    throw new XDSError(
+      `--emit must be one of auto, tsx, payload — got '${emit}'`,
+      undefined,
+      ERROR_CODES.ERR_INVALID_ARGUMENT,
+    );
+  }
+  if (target === 'glasses' && resolvedEmit === 'tsx') {
+    throw new XDSError(
+      `--target glasses emits native payloads; use --emit payload or leave --emit as auto`,
+      undefined,
+      ERROR_CODES.ERR_INVALID_ARGUMENT,
     );
   }
 
@@ -171,11 +192,10 @@ export async function layoutExpand(expression, options = {}) {
       ERROR_CODES.ERR_INVALID_ARGUMENT,
     );
   }
-  const blockModules = buildBlockModules(doc, blocks);
-  const result = expand(doc, registry, {componentName, blockModules});
 
   let written = null;
-  if (targetPath) {
+  const writeArtifact = (contents, extension) => {
+    if (!targetPath) return null;
     let resolved;
     try {
       resolved = assertWithin(targetPath, cwd, {label: 'layout target path'});
@@ -187,16 +207,44 @@ export async function layoutExpand(expression, options = {}) {
     }
     const filePath = isFilePathArg(targetPath)
       ? resolved
-      : path.join(resolved, `${componentName}.tsx`);
+      : path.join(resolved, `${componentName}.${extension}`);
     fs.mkdirSync(path.dirname(filePath), {recursive: true});
-    fs.writeFileSync(filePath, result.code);
-    written = path.relative(cwd, filePath);
+    fs.writeFileSync(filePath, contents);
+    return path.relative(cwd, filePath);
+  };
+
+  if (resolvedEmit === 'payload') {
+    const result = emitPayload(doc, registry);
+    written = writeArtifact(JSON.stringify(result.payload, null, 2) + '\n', 'json');
+    return {
+      type: 'layout.expand',
+      data: {
+        form: form === 'auto' ? detectForm(expression) : form,
+        target: registry.target || target,
+        packageName: registry.packageName,
+        emit: 'payload',
+        payload: result.payload,
+        componentsUsed: result.componentsUsed,
+        states: 0,
+        todos: result.todos,
+        blocksReferenced: [],
+        warnings: warnings.map(formatIssue),
+        written,
+      },
+    };
   }
+
+  const blockModules = buildBlockModules(doc, blocks);
+  const result = expand(doc, registry, {componentName, blockModules});
+  written = writeArtifact(result.code, 'tsx');
 
   return {
     type: 'layout.expand',
     data: {
       form: form === 'auto' ? detectForm(expression) : form,
+      target: registry.target || target,
+      packageName: registry.packageName,
+      emit: 'tsx',
       code: result.code,
       componentsUsed: result.componentsUsed,
       states: result.states,
@@ -213,14 +261,16 @@ export async function layoutExpand(expression, options = {}) {
  * Validates without expanding; echoes both canonical surfaces.
  */
 export async function layoutCheck(expression, options = {}) {
-  const {form = 'auto', loose = false, cwd = process.cwd()} = options;
-  const {doc, errors, warnings} = await analyze(expression, {form, loose, cwd});
+  const {form = 'auto', loose = false, cwd = process.cwd(), target = 'core'} = options;
+  const {doc, registry, errors, warnings} = await analyze(expression, {form, loose, cwd, target});
 
   return {
     type: 'layout.check',
     data: {
       valid: errors.length === 0,
       form: doc.form,
+      target: registry.target || target,
+      packageName: registry.packageName,
       errors: errors.map(e => ({...e, formatted: formatIssue(e)})),
       warnings: warnings.map(formatIssue),
       compact: toCompact(doc),
@@ -234,8 +284,8 @@ export async function layoutCheck(expression, options = {}) {
  * generated from this branch's registry (never hand-maintained).
  */
 export async function layoutGrammar(options = {}) {
-  const {cwd = process.cwd()} = options;
-  const registry = await buildRegistry({cwd});
+  const {cwd = process.cwd(), target = 'core'} = options;
+  const registry = await buildRegistry({cwd, target});
 
   const aliasLines = [];
   const byTarget = new Map();
@@ -247,17 +297,30 @@ export async function layoutGrammar(options = {}) {
     aliasLines.push(`${aliases.join('/')}=${target}`);
   }
 
-  const text = `XLE/XLO — XDS layout expressions (branch-generated; aliases reflect this install)
+  const isGlasses = registry.target === 'glasses';
+  const compactExample = isGlasses
+    ? 'Scr[label="Ops brief"] > C[p4] > V[g2] > (Hd"Build health" + Tx.supporting"3 services need attention" + B.primary"Open")'
+    : 'A[cp6 @topNav=TN] > L > LC > S[p6] > (C{card-callout}*4) + T';
+  const outlineExample = isGlasses
+    ? 'Screen label="Ops brief"\n  Card p=4\n    VStack g=2\n      Heading "Build health"\n      Text.supporting "3 services need attention"\n      Button.primary "Open"'
+    : 'indentation = nesting · same-indent = siblings · "repeat N:" block = (...)*N\n           slot lines:  topNav: TN     (or a block:  topNav:\\n    TN ...)';
+  const structureNotes = isGlasses
+    ? '  Scr > C > V/H              root HUD screen, translucent card, shallow stack layout\n  UL > LI                       short glanceable lists; use title/subtitle/meta instead of tables\n  B.primary[action=id]          speakable/gaze action chip with optional native action id'
+    : '  Layout > LH + LC + LF + LP   children auto-route into header/content/footer/start slots\n  T > (TR>THC*4) + (TR>TC*4)*6 rows partition into TableHeader/TableBody automatically\n  TabList/inputs               required value+onChange scaffold typed useState automatically\n  overlays                     compact: tree ;; Dlg#confirm[...] · outline: overlays: section\n                               trigger: B"Delete"[opens=#confirm]';
+  const targetShell = isGlasses ? '@xds/glasses' : '@xds/core';
+
+  const text = `XLE/XLO — XDS layout expressions (${registry.packageName}; branch-generated aliases reflect this target)
 
 WORKFLOW
   xds layout check "<expr>"           validate; echoes canonical compact + outline forms
-  xds layout expand "<expr>" [path]   emit validated TSX (path optional; --name <Pascal>)
+  xds layout expand "<expr>" [path]   emit validated TSX or native payload (path optional; --name <Pascal>)
+  add --target glasses                validate/expand against @xds/glasses instead of @xds/core
+  add --emit payload                  emit a native-shaped component payload instead of TSX
   Errors carry line/col + suggestions. Fix and resubmit; nothing is guessed.
 
 TWO SURFACES, ONE LANGUAGE (autodetected; --form to force)
-  compact: A[cp6 @topNav=TN] > L > LC > S[p6] > (C{card-callout}*4) + T
-  outline: indentation = nesting · same-indent = siblings · "repeat N:" block = (...)*N
-           slot lines:  topNav: TN     (or a block:  topNav:\\n    TN ...)
+  compact: ${compactExample}
+  outline: ${outlineExample}
 
 NODE ANATOMY   Name#id.enum"payload"[attrs]{hint}*N > children
   .enum        unique enum value of any prop:  Bd.success  Tx.lg  B.primary
@@ -275,7 +338,7 @@ ATTRS [...] (outline: bare tokens after the name, no brackets)
   trigger      opens=#id  (a plain attr, no @ — binds an onClick that opens the overlay)
   fill         on a stack child → wraps in <StackItem size="fill">
 
-TEMPLATE REFERENCING  ({hint} pulls in real content — this is how XLE reaches past the @xds/core shell)
+TEMPLATE REFERENCING  ({hint} pulls in real content — this is how XLE reaches past the ${targetShell} shell)
   C{card-callout}              splice a template block (xds template --list --type block):
                               the block is co-defined once in the file, referenced, imports merged
   {kpi-card}                   standalone reference (no wrapper element) — place a component directly
@@ -285,17 +348,21 @@ TEMPLATE REFERENCING  ({hint} pulls in real content — this is how XLE reaches 
                                then {kpi-card} → import {KpiCard} + <KpiCard /> (kebab ↔ Pascal)
 
 STRUCTURE THE EXPANDER HANDLES
-  Layout > LH + LC + LF + LP   children auto-route into header/content/footer/start slots
-  T > (TR>THC*4) + (TR>TC*4)*6 rows partition into TableHeader/TableBody automatically
-  TabList/inputs               required value+onChange scaffold typed useState automatically
-  overlays                     compact: tree ;; Dlg#confirm[...] · outline: overlays: section
-                               trigger: B"Delete"[opens=#confirm]
+${structureNotes}
 
 ALIASES (full component names always valid; XDS prefix optional)
   ${aliasLines.join('  ')}
 `;
 
-  return {type: 'layout.grammar', data: {text, aliases: Object.fromEntries(registry.aliases)}};
+  return {
+    type: 'layout.grammar',
+    data: {
+      text,
+      target: registry.target || target,
+      packageName: registry.packageName,
+      aliases: Object.fromEntries(registry.aliases),
+    },
+  };
 }
 
 export {ALIAS_TABLE};

--- a/packages/cli/src/api/layout.test.mjs
+++ b/packages/cli/src/api/layout.test.mjs
@@ -19,6 +19,7 @@ import {buildRegistry} from '../lib/xle/registry.mjs';
 // parallel load that can exceed the default 5s test timeout. Warm it once.
 beforeAll(async () => {
   await buildRegistry();
+  await buildRegistry({target: 'glasses'});
 }, 120_000);
 
 const SLOW = 30_000;
@@ -166,6 +167,60 @@ describe('layoutCheck', () => {
   });
 });
 
+describe('glasses layout target', () => {
+  const DESKTOP_TASK_OVERVIEW =
+    'A[@topNav=TN] > L > LC > S[p6] > ' +
+    '(Hd"Project brief" + Tx"Status, risks, and next actions" + ' +
+    'G[c3 g4] > (C[p4] > V[g2] > Hd"Status" + Tx"On track")*3)';
+
+  const GLASSES_TASK_OVERVIEW =
+    'Scr[label="Project brief"] > C[p4] > V[g2] > ' +
+    '(Hd"Project brief" + Tx.supporting"Status: on track" + Bd.info"brief" + B.primary"Open details"[action=openDetails])';
+
+  it('validates a glasses expression against the @xds/glasses package', async () => {
+    const result = await layoutCheck(GLASSES_TASK_OVERVIEW, {target: 'glasses'});
+    expect(result.data.valid).toBe(true);
+    expect(result.data.target).toBe('glasses');
+    expect(result.data.packageName).toBe('@xds/glasses');
+    expect(result.data.compact).toContain('Scr');
+    expect(result.data.outline).toContain('B.primary "Open details" action=openDetails');
+  });
+
+  it('rejects desktop-only layout components for the glasses target', async () => {
+    const result = await layoutCheck('A > L > LC > T', {target: 'glasses'});
+    expect(result.data.valid).toBe(false);
+    const messages = result.data.errors.map(e => e.message).join('\n');
+    expect(messages).toMatch(/Unknown component or alias 'A'/);
+    expect(messages).toMatch(/Unknown component or alias 'T'/);
+  });
+
+  it('expands the same app idea into desktop TSX and a glasses native payload', async () => {
+    const desktop = await layoutExpand(DESKTOP_TASK_OVERVIEW, {name: 'DesktopTaskOverview'});
+    const glasses = await layoutExpand(GLASSES_TASK_OVERVIEW, {name: 'GlassesTaskOverview', target: 'glasses'});
+
+    expectValidTsx(desktop.data.code);
+    expect(desktop.data.emit).toBe('tsx');
+    expect(glasses.data.emit).toBe('payload');
+    expect(desktop.data.packageName).toBe('@xds/core');
+    expect(glasses.data.packageName).toBe('@xds/glasses');
+    expect(desktop.data.code).toContain("from '@xds/core/AppShell'");
+    expect(glasses.data.payload.roots[0]).toMatchObject({
+      type: 'Screen',
+      role: 'surface',
+      renderer: {android: 'ScreenRenderer'},
+      theme: {component: 'screen', mode: 'ambient-adaptive'},
+    });
+    const button = glasses.data.payload.roots[0].children[0].children[0].children[3];
+    expect(button).toMatchObject({
+      type: 'Button',
+      role: 'action',
+      renderer: {android: 'ButtonRenderer'},
+      theme: {component: 'button', mode: 'ambient-adaptive'},
+      props: {action: 'openDetails', variant: 'primary', label: 'Open details'},
+    });
+  }, SLOW);
+});
+
 describe('template referencing', () => {
   it('splices a template block: co-defined once, referenced, imports merged', async () => {
     const result = await layoutExpand('S[p6] > C{card-callout}*3', {name: 'Demo'});
@@ -234,5 +289,14 @@ describe('layoutGrammar', () => {
     expect(result.data.aliases.TB).toBe('TableBody');
     // every alias target must exist — the table is registry-filtered
     expect(Object.values(result.data.aliases)).not.toContain(undefined);
+  });
+
+  it('filters aliases against the glasses package when requested', async () => {
+    const result = await layoutGrammar({target: 'glasses'});
+    expect(result.data.packageName).toBe('@xds/glasses');
+    expect(result.data.aliases.Scr).toBe('Screen');
+    expect(result.data.aliases.C).toBe('Card');
+    expect(result.data.aliases.T).toBeUndefined();
+    expect(result.data.text).toContain('@xds/glasses');
   });
 });

--- a/packages/cli/src/commands/layout.mjs
+++ b/packages/cli/src/commands/layout.mjs
@@ -35,11 +35,13 @@ export function registerLayout(program) {
 
   layoutCmd
     .command('expand [expression] [path]')
-    .description('Expand a layout expression into validated XDS TSX')
+    .description('Expand a layout expression into validated XDS TSX or target payload')
     .option('--file <file>', 'Read the expression from a file')
     .option('--form <form>', 'Input surface: compact, outline, or auto', 'auto')
     .option('--name <name>', 'Generated component name (PascalCase)', 'GeneratedLayout')
     .option('--loose', 'Downgrade unknown {block} hints to TODO placeholders')
+    .option('--target <target>', 'Component target package: core or glasses', 'core')
+    .option('--emit <format>', 'Output format: auto, tsx, or payload', 'auto')
     .action(async (expression, targetPath, options) => {
       const json = program.opts().json || false;
       const source = await readExpression(expression, options);
@@ -54,6 +56,8 @@ export function registerLayout(program) {
           form: options.form,
           loose: options.loose || false,
           name: options.name,
+          target: options.target,
+          emit: options.emit,
           cwd: process.cwd(),
         });
       } catch (e) {
@@ -65,11 +69,14 @@ export function registerLayout(program) {
       for (const warning of result.data.warnings) humanLog(`⚠ ${warning}`);
       if (result.data.written) {
         humanLog(`\n✓ Expanded to ${result.data.written}`);
+        humanLog(`  Target: ${result.data.packageName || result.data.target}`);
         humanLog(`  Components: ${result.data.componentsUsed.join(', ')}`);
         if (result.data.todos.length > 0) {
           humanLog(`  TODOs: ${result.data.todos.length} (search for "TODO(xle)")`);
         }
         humanLog('');
+      } else if (result.data.emit === 'payload') {
+        humanLog(JSON.stringify(result.data.payload, null, 2));
       } else {
         humanLog(result.data.code);
       }
@@ -81,6 +88,7 @@ export function registerLayout(program) {
     .option('--file <file>', 'Read the expression from a file')
     .option('--form <form>', 'Input surface: compact, outline, or auto', 'auto')
     .option('--loose', 'Downgrade unknown {block} hints to TODO placeholders')
+    .option('--target <target>', 'Component target package: core or glasses', 'core')
     .action(async (expression, options) => {
       const json = program.opts().json || false;
       const source = await readExpression(expression, options);
@@ -93,6 +101,7 @@ export function registerLayout(program) {
         result = await layoutCheck(source, {
           form: options.form,
           loose: options.loose || false,
+          target: options.target,
           cwd: process.cwd(),
         });
       } catch (e) {
@@ -101,7 +110,7 @@ export function registerLayout(program) {
       }
       if (json) return jsonOut(result.type, result.data);
 
-      const {valid, form, errors, warnings, compact, outline} = result.data;
+      const {valid, form, target, packageName, errors, warnings, compact, outline} = result.data;
       if (!valid) {
         humanLog(`\n✗ Invalid (${errors.length} error${errors.length === 1 ? '' : 's'}):`);
         for (const e of errors) {
@@ -112,7 +121,7 @@ export function registerLayout(program) {
         process.exitCode = 1;
         return;
       }
-      humanLog(`\n✓ Valid (parsed as ${form})`);
+      humanLog(`\n✓ Valid (parsed as ${form}; target ${packageName || target})`);
       for (const warning of warnings) humanLog(`⚠ ${warning}`);
       humanLog('\ncompact:');
       humanLog(`  ${compact}`);
@@ -124,11 +133,12 @@ export function registerLayout(program) {
   layoutCmd
     .command('grammar')
     .description('Print the XLE/XLO cheatsheet (alias table generated from this branch)')
-    .action(async () => {
+    .option('--target <target>', 'Component target package: core or glasses', 'core')
+    .action(async (options) => {
       const json = program.opts().json || false;
       let result;
       try {
-        result = await layoutGrammar({cwd: process.cwd()});
+        result = await layoutGrammar({cwd: process.cwd(), target: options.target});
       } catch (e) {
         cliError(e.message, {suggestions: e.suggestions || [], code: e.code});
         return;

--- a/packages/cli/src/lib/component-discovery.mjs
+++ b/packages/cli/src/lib/component-discovery.mjs
@@ -268,7 +268,7 @@ export function findComponentSource(coreDir, name) {
  * Compute the Levenshtein (edit) distance between two strings.
  * Used for fuzzy-matching component names. Dependency-free.
  */
-export function resolveImportPath(coreDir, componentName) {
+export function resolveImportPath(coreDir, componentName, packageName = '@xds/core') {
   const srcDir = path.join(coreDir, 'src');
   const pkgPath = path.join(coreDir, 'package.json');
   const pkg = fs.existsSync(pkgPath)
@@ -278,7 +278,7 @@ export function resolveImportPath(coreDir, componentName) {
   // Priority 1: exact subpath export matching the component name (e.g. ./Heading)
   // This allows convenience re-export directories to win over the source directory.
   if (pkg?.exports?.[`./${componentName}`]) {
-    return `@xds/core/${componentName}`;
+    return `${packageName}/${componentName}`;
   }
 
   const sourcePath = findComponentSource(coreDir, componentName);
@@ -289,10 +289,10 @@ export function resolveImportPath(coreDir, componentName) {
   const topDir = relToSrc.split(path.sep)[0];
 
   if (pkg?.exports?.[`./${topDir}`]) {
-    return `@xds/core/${topDir}`;
+    return `${packageName}/${topDir}`;
   }
 
-  return '@xds/core';
+  return packageName;
 }
 
 // ── External package discovery ───────────────────────────────────────

--- a/packages/cli/src/lib/manifest.mjs
+++ b/packages/cli/src/lib/manifest.mjs
@@ -86,9 +86,9 @@ const EXAMPLES = {
   manifest: ['xds manifest --json', 'xds --json'],
   doctor: ['xds doctor', 'xds doctor --json'],
   init: ['xds init'],
-  'layout expand': [`xds layout expand 'V[g6] > C{card-callout}*4' ./src/Page.tsx`],
-  'layout check': [`xds layout check 'A[cp6] > L > LC > S[p6]' --json`],
-  'layout grammar': ['xds layout grammar'],
+  'layout expand': [`xds layout expand 'V[g6] > C{card-callout}*4' ./src/Page.tsx`, `xds layout expand --target glasses 'Scr > C[p4] > V[g2] > B.primary"Start"'`],
+  'layout check': [`xds layout check 'A[cp6] > L > LC > S[p6]' --json`, `xds layout check --target glasses 'Scr > C[p4] > Tx"Status"' --json`],
+  'layout grammar': ['xds layout grammar', 'xds layout grammar --target glasses'],
 };
 
 /**

--- a/packages/cli/src/lib/xle/payload.mjs
+++ b/packages/cli/src/lib/xle/payload.mjs
@@ -1,0 +1,130 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file XLE payload emitter — bound AST → native-shaped component payload.
+ *
+ * This emitter is intentionally not React/TSX. It preserves the component
+ * vocabulary and semantic props chosen by the layout grammar, then delegates
+ * per-component payload shaping to target component renderers when present
+ * (for example @xds/glasses/src/Button/renderers/payload.mjs).
+ *
+ * @input  validated doc (nodes carry .bound) + registry
+ * @output emitPayload() → {payload, componentsUsed, todos}
+ * @position lib/xle — peer to the TSX expander for non-web targets
+ */
+
+import {PAYLOAD_PROPS} from './validate.mjs';
+
+function subCounterText(text, index) {
+  if (index == null) return String(text).replace(/\\\$/g, '$');
+  return String(text).replace(/\\\$|\$/g, m => (m === '\\$' ? '$' : String(index)));
+}
+
+function mapProps(node, component, index) {
+  const props = {};
+  for (const [key, value] of node.bound.props) {
+    if (key.startsWith('__')) continue;
+    props[key] = typeof value === 'string' ? subCounterText(value, index) : value;
+  }
+
+  let textChild = null;
+  if (node.payload != null) {
+    const payload = subCounterText(node.payload, index);
+    const required = PAYLOAD_PROPS.find(p => component.props.get(p)?.required);
+    const childrenRequired = component.props.get('children')?.required;
+    const target = required
+      || (childrenRequired ? null : PAYLOAD_PROPS.find(p => component.props.has(p)));
+    if (target && props[target] == null) props[target] = payload;
+    else textChild = payload;
+  }
+
+  if (node.payload2 != null && component.props.has('value') && props.value == null) {
+    props.value = subCounterText(node.payload2, index);
+  }
+
+  return {props, textChild};
+}
+
+class PayloadEmitter {
+  constructor(registry) {
+    this.registry = registry;
+    this.componentsUsed = new Set();
+    this.todos = [];
+  }
+
+  emitItems(items, index = null) {
+    const out = [];
+    for (const item of items) {
+      if (item.kind === 'group') {
+        const count = item.repeat || 1;
+        for (let i = 1; i <= count; i++) {
+          out.push(...this.emitItems(item.children, count > 1 ? i : index));
+        }
+        continue;
+      }
+      const count = item.repeat || 1;
+      for (let i = 1; i <= count; i++) {
+        const node = this.emitNode(item, count > 1 ? i : index);
+        if (node) out.push(node);
+      }
+    }
+    return out;
+  }
+
+  emitNode(node, index = null) {
+    if (!node.bound) {
+      if (node.hint) {
+        this.todos.push(`payload hint {${node.hint.name}} needs renderer support`);
+        return {type: 'Reference', props: {name: node.hint.name}, children: []};
+      }
+      return null;
+    }
+
+    const component = node.bound.component;
+    this.componentsUsed.add(component.name);
+    const {props, textChild} = mapProps(node, component, index);
+    const children = [];
+    if (textChild != null) children.push(textChild);
+    children.push(...this.emitItems(node.children, index));
+
+    const renderPayload = component.renderers?.payload;
+    const rendered = renderPayload
+      ? renderPayload({props, children, component, spec: component.spec})
+      : {
+          type: component.spec?.payloadType || component.name,
+          role: component.spec?.nativeRole || 'component',
+          renderer: component.spec?.renderer,
+          theme: component.spec?.theme,
+          props,
+          children,
+        };
+
+    return {
+      sourceComponent: component.name,
+      ...rendered,
+    };
+  }
+}
+
+/**
+ * Emit a native-shaped payload from a validated XLE document.
+ * @param {{roots: any[], overlays: any[]}} doc
+ * @param {object} registry
+ * @returns {{payload: object, componentsUsed: string[], todos: string[]}}
+ */
+export function emitPayload(doc, registry) {
+  const emitter = new PayloadEmitter(registry);
+  const roots = emitter.emitItems(doc.roots);
+  const overlays = emitter.emitItems(doc.overlays);
+  return {
+    payload: {
+      schemaVersion: 1,
+      target: registry.target || 'core',
+      packageName: registry.packageName,
+      roots,
+      overlays,
+    },
+    componentsUsed: [...emitter.componentsUsed].sort(),
+    todos: emitter.todos,
+  };
+}

--- a/packages/cli/src/lib/xle/registry-core.mjs
+++ b/packages/cli/src/lib/xle/registry-core.mjs
@@ -26,7 +26,7 @@
  */
 export const ALIAS_TABLE = {
   // Layout core
-  A: 'AppShell', L: 'Layout', LH: 'LayoutHeader', LC: 'LayoutContent',
+  A: 'AppShell', Scr: 'Screen', L: 'Layout', LH: 'LayoutHeader', LC: 'LayoutContent',
   LF: 'LayoutFooter', LP: 'LayoutPanel', V: 'VStack', H: 'HStack',
   SI: 'StackItem', G: 'Grid', GS: 'GridSpan', S: 'Section', Ctr: 'Center',
   F: 'FormLayout', D: 'Divider', Tbar: 'Toolbar', AR: 'AspectRatio',

--- a/packages/cli/src/lib/xle/registry.mjs
+++ b/packages/cli/src/lib/xle/registry.mjs
@@ -15,7 +15,10 @@
  * @position lib/xle — shared by parse/validate/expand; no CLI concerns here
  */
 
-import {findCoreDir} from '../../utils/paths.mjs';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {pathToFileURL} from 'node:url';
+import {findXdsPackageDir} from '../../utils/paths.mjs';
 import {
   discoverComponents,
   findComponentReadme,
@@ -45,7 +48,69 @@ function findDirFor(grouped, member) {
   return null;
 }
 
-let cachedRegistry = null;
+/**
+ * Discover a docs-only target package. Unlike @xds/core, non-web targets may
+ * not have TSX implementation files; the .doc.mjs files are the component
+ * specification the layout grammar validates against.
+ */
+function discoverDocComponents(packageDir) {
+  const srcDir = path.join(packageDir, 'src');
+  const grouped = {};
+  if (!fs.existsSync(srcDir)) return grouped;
+
+  function scan(dirPath) {
+    const entries = fs.readdirSync(dirPath, {withFileTypes: true});
+    for (const entry of entries) {
+      const fullPath = path.join(dirPath, entry.name);
+      if (entry.isDirectory()) {
+        scan(fullPath);
+      } else if (entry.name.endsWith('.doc.mjs')) {
+        const dirName = path.basename(path.dirname(fullPath));
+        grouped[dirName] = [dirName];
+      }
+    }
+  }
+
+  scan(srcDir);
+  return Object.fromEntries(Object.entries(grouped).sort(([a], [b]) => a.localeCompare(b)));
+}
+
+async function loadComponentSpec(packageDir, dirName) {
+  const specPath = path.join(packageDir, 'src', dirName, `${dirName}.spec.mjs`);
+  if (!fs.existsSync(specPath)) return null;
+  try {
+    const mod = await import(pathToFileURL(specPath).href);
+    return mod.spec || null;
+  } catch {
+    return null;
+  }
+}
+
+async function loadPayloadRenderer(packageDir, dirName) {
+  const rendererPath = path.join(packageDir, 'src', dirName, 'renderers', 'payload.mjs');
+  if (!fs.existsSync(rendererPath)) return null;
+  try {
+    const mod = await import(pathToFileURL(rendererPath).href);
+    return typeof mod.renderPayload === 'function' ? mod.renderPayload : null;
+  } catch {
+    return null;
+  }
+}
+
+const TARGET_PACKAGES = {
+  core: {packageName: '@xds/core', packageDirName: 'core'},
+  glasses: {packageName: '@xds/glasses', packageDirName: 'glasses'},
+};
+
+const cachedRegistries = new Map();
+
+function resolveTarget(target = 'core') {
+  const info = TARGET_PACKAGES[target];
+  if (!info) {
+    throw new Error(`Unknown layout target '${target}'. Expected one of: ${Object.keys(TARGET_PACKAGES).join(', ')}`);
+  }
+  return info;
+}
 
 /**
  * Build (and cache) the registry: every documented component keyed by its
@@ -53,22 +118,25 @@ let cachedRegistry = null;
  *
  * @param {object} [options]
  * @param {string} [options.cwd]
- * @returns {Promise<{components: Map<string, object>, aliases: Map<string, string>, componentNames: string[]}>}
+ * @param {'core'|'glasses'} [options.target] - Component package target to validate against.
+ * @returns {Promise<{components: Map<string, object>, aliases: Map<string, string>, componentNames: string[], target: string, packageName: string}>}
  */
-export async function buildRegistry({cwd = process.cwd()} = {}) {
-  if (cachedRegistry) return cachedRegistry;
-
-  const coreDir = findCoreDir(cwd);
-  if (!coreDir) {
-    throw new Error('Could not find @xds/core package — run from an XDS workspace');
+export async function buildRegistry({cwd = process.cwd(), target = 'core'} = {}) {
+  const targetInfo = resolveTarget(target);
+  const packageDir = findXdsPackageDir(targetInfo.packageDirName, cwd);
+  if (!packageDir) {
+    throw new Error(`Could not find ${targetInfo.packageName} package — run from an XDS workspace or install the package`);
   }
 
+  const cacheKey = `${target}:${packageDir}`;
+  if (cachedRegistries.has(cacheKey)) return cachedRegistries.get(cacheKey);
+
   const components = new Map();
-  const grouped = discoverComponents(coreDir);
+  const grouped = target === 'core' ? discoverComponents(packageDir) : discoverDocComponents(packageDir);
   const dirNames = [...new Set(Object.values(grouped).flat())];
 
   for (const dirName of dirNames) {
-    const readme = findComponentReadme(coreDir, dirName);
+    const readme = findComponentReadme(packageDir, dirName);
     if (!readme || !readme.endsWith('.doc.mjs')) continue;
     let docs;
     try {
@@ -76,11 +144,15 @@ export async function buildRegistry({cwd = process.cwd()} = {}) {
     } catch {
       continue; // a malformed doc must not take down the whole language
     }
-    const importPath = resolveImportPath(coreDir, dirName);
+    const importPath = resolveImportPath(packageDir, dirName, targetInfo.packageName);
+    const spec = await loadComponentSpec(packageDir, dirName);
+    const payloadRenderer = await loadPayloadRenderer(packageDir, dirName);
 
     const register = (rawName, props) => {
       const name = normalizeName(rawName);
       const entry = toComponentEntry(name, props, dirName, importPath);
+      if (spec) entry.spec = spec;
+      if (payloadRenderer) entry.renderers = {payload: payloadRenderer};
       const existing = components.get(name);
       // Some docs list related components with empty prop arrays
       // (e.g. Layout's references to Card) — prefer the richer entry.
@@ -102,7 +174,7 @@ export async function buildRegistry({cwd = process.cwd()} = {}) {
     for (const member of members) {
       const name = normalizeName(member);
       if (components.has(name)) continue;
-      const entry = toComponentEntry(name, [], findDirFor(grouped, member) || name, resolveImportPath(coreDir, member));
+      const entry = toComponentEntry(name, [], findDirFor(grouped, member) || name, resolveImportPath(packageDir, member, targetInfo.packageName));
       entry.undocumented = true;
       components.set(name, entry);
     }
@@ -113,15 +185,18 @@ export async function buildRegistry({cwd = process.cwd()} = {}) {
     if (components.has(target)) aliases.set(alias, target);
   }
 
-  cachedRegistry = {
+  const registry = {
     components,
     aliases,
     componentNames: [...components.keys()].sort(),
+    target,
+    packageName: targetInfo.packageName,
   };
-  return cachedRegistry;
+  cachedRegistries.set(cacheKey, registry);
+  return registry;
 }
 
 /** Test seam — drop the module-level cache. */
 export function resetRegistryCache() {
-  cachedRegistry = null;
+  cachedRegistries.clear();
 }

--- a/packages/cli/src/utils/paths.mjs
+++ b/packages/cli/src/utils/paths.mjs
@@ -16,19 +16,19 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 export const CLI_ROOT = path.resolve(__dirname, '..', '..');
 
 /**
- * Find packages/core directory by walking up from startDir.
- * Also checks node_modules/@xds/core for installed usage.
+ * Find an XDS package directory by walking up from startDir.
+ * Also checks node_modules/@xds/{packageName} for installed usage.
  */
-export function findCoreDir(startDir = process.cwd()) {
+export function findXdsPackageDir(packageName, startDir = process.cwd()) {
   let dir = startDir;
 
   for (let i = 0; i < 5; i++) {
-    const candidate = path.join(dir, 'packages', 'core');
+    const candidate = path.join(dir, 'packages', packageName);
     if (fs.existsSync(candidate)) {
       return candidate;
     }
 
-    const nodeModules = path.join(dir, 'node_modules', '@xds', 'core');
+    const nodeModules = path.join(dir, 'node_modules', '@xds', packageName);
     if (fs.existsSync(nodeModules)) {
       return nodeModules;
     }
@@ -39,6 +39,14 @@ export function findCoreDir(startDir = process.cwd()) {
   }
 
   return null;
+}
+
+/**
+ * Find packages/core directory by walking up from startDir.
+ * Also checks node_modules/@xds/core for installed usage.
+ */
+export function findCoreDir(startDir = process.cwd()) {
+  return findXdsPackageDir('core', startDir);
 }
 
 /**

--- a/packages/glasses/README.md
+++ b/packages/glasses/README.md
@@ -1,0 +1,16 @@
+# @xds/glasses
+
+Prototype component target for smart-glasses HUD layout experiments.
+
+This package mirrors a small subset of core component names (`Card`, `Text`,
+`Heading`, `Button`, `List`, etc.) so the `xds layout` grammar can validate the
+same XLE/XLO syntax against a glasses-specific component registry:
+
+```bash
+xds layout check --target glasses 'Scr > C[p4] > V[g2] > B.primary"Open"'
+xds layout expand --target glasses 'Scr > C[p4] > V[g2] > B.primary"Open"'
+```
+
+The package is intentionally small. Components and docs describe a 600×600
+additive-light HUD surface, not a desktop or mobile screen. Desktop layouts
+should continue to target `@xds/core`.

--- a/packages/glasses/package.json
+++ b/packages/glasses/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@xds/glasses",
+  "version": "0.0.14",
+  "private": true,
+  "displayName": "XDS Glasses",
+  "description": "Prototype XDS components for smart glasses HUD surfaces. Used by layout grammar target validation experiments.",
+  "author": "Meta Open Source",
+  "license": "MIT",
+  "homepage": "https://github.com/facebookexperimental/xds#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/facebookexperimental/xds.git",
+    "directory": "packages/glasses"
+  },
+  "bugs": {
+    "url": "https://github.com/facebookexperimental/xds/issues"
+  },
+  "keywords": [
+    "xds",
+    "glasses",
+    "hud",
+    "design-system",
+    "layout-grammar"
+  ],
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "sideEffects": false,
+  "exports": {
+    ".": "./src/index.ts",
+    "./Screen": "./src/Screen/index.ts",
+    "./Card": "./src/Card/index.ts",
+    "./Stack": "./src/Stack/index.ts",
+    "./Text": "./src/Text/index.ts",
+    "./Badge": "./src/Badge/index.ts",
+    "./Button": "./src/Button/index.ts",
+    "./List": "./src/List/index.ts"
+  },
+  "peerDependencies": {
+    "react": ">=19.0.0"
+  }
+}

--- a/packages/glasses/src/Badge/Badge.doc.mjs
+++ b/packages/glasses/src/Badge/Badge.doc.mjs
@@ -1,0 +1,21 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
+export const docs = {
+  name: 'Badge',
+  displayName: 'Badge',
+  group: 'Glasses',
+  category: 'Feedback & Status',
+  keywords: ['glasses', 'hud', 'badge'],
+  usage: {
+    description: 'Badge displays a compact status or count on a glasses HUD. Use it when a word or number must remain recognizable against an additive-light background.',
+    bestPractices: [
+      {guidance: true, description: 'Design for one glanceable idea and preserve a clear voice or gaze path.'},
+      {guidance: false, description: 'Do not copy dense desktop layouts directly into the HUD surface.'},
+    ],
+  },
+  props: [
+    {name: 'label', type: 'string', description: 'Short visible badge text.', required: true},
+    {name: 'variant', type: "'neutral' | 'info' | 'success' | 'warning' | 'error'", description: 'Status color treatment.', default: "'neutral'"},
+  ],
+};

--- a/packages/glasses/src/Badge/Badge.spec.mjs
+++ b/packages/glasses/src/Badge/Badge.spec.mjs
@@ -1,0 +1,11 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** Machine-readable component contract for glasses payload/native renderers. */
+export const spec = {
+  name: 'Badge',
+  target: 'glasses-hud',
+  payloadType: 'Badge',
+  nativeRole: 'status',
+  renderer: {android: 'BadgeRenderer'},
+  theme: {component: 'badge', mode: 'ambient-adaptive'},
+};

--- a/packages/glasses/src/Badge/renderers/payload.mjs
+++ b/packages/glasses/src/Badge/renderers/payload.mjs
@@ -1,0 +1,15 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {spec} from '../Badge.spec.mjs';
+
+/** Convert a normalized layout node into the glasses runtime payload shape. */
+export function renderPayload({props, children}) {
+  return {
+    type: spec.payloadType,
+    role: spec.nativeRole,
+    renderer: spec.renderer,
+    theme: spec.theme,
+    props,
+    children,
+  };
+}

--- a/packages/glasses/src/Button/Button.doc.mjs
+++ b/packages/glasses/src/Button/Button.doc.mjs
@@ -1,0 +1,24 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
+export const docs = {
+  name: 'Button',
+  displayName: 'Button',
+  group: 'Glasses',
+  category: 'Action',
+  keywords: ['glasses', 'hud', 'button'],
+  usage: {
+    description: 'Button is a voice/gaze-friendly action chip for glasses. Use it for the one primary action a user can confirm from the HUD, plus one or two secondary actions when necessary.',
+    bestPractices: [
+      {guidance: true, description: 'Design for one glanceable idea and preserve a clear voice or gaze path.'},
+      {guidance: false, description: 'Do not copy dense desktop layouts directly into the HUD surface.'},
+    ],
+  },
+  props: [
+    {name: 'label', type: 'string', description: 'Short visible and speakable action label.', required: true},
+    {name: 'variant', type: "'primary' | 'secondary' | 'ghost' | 'destructive'", description: 'Action emphasis.', default: "'secondary'"},
+    {name: 'size', type: "'sm' | 'md' | 'lg'", description: 'Action chip size.', default: "'md'"},
+    {name: 'action', type: 'string', description: 'Stable action identifier for native routing or voice command dispatch.'},
+    {name: 'isDisabled', type: 'boolean', description: 'Disables the action.', default: 'false'},
+  ],
+};

--- a/packages/glasses/src/Button/Button.spec.mjs
+++ b/packages/glasses/src/Button/Button.spec.mjs
@@ -1,0 +1,11 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** Machine-readable component contract for glasses payload/native renderers. */
+export const spec = {
+  name: 'Button',
+  target: 'glasses-hud',
+  payloadType: 'Button',
+  nativeRole: 'action',
+  renderer: {android: 'ButtonRenderer'},
+  theme: {component: 'button', mode: 'ambient-adaptive'},
+};

--- a/packages/glasses/src/Button/renderers/payload.mjs
+++ b/packages/glasses/src/Button/renderers/payload.mjs
@@ -1,0 +1,15 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {spec} from '../Button.spec.mjs';
+
+/** Convert a normalized layout node into the glasses runtime payload shape. */
+export function renderPayload({props, children}) {
+  return {
+    type: spec.payloadType,
+    role: spec.nativeRole,
+    renderer: spec.renderer,
+    theme: spec.theme,
+    props,
+    children,
+  };
+}

--- a/packages/glasses/src/Card/Card.doc.mjs
+++ b/packages/glasses/src/Card/Card.doc.mjs
@@ -1,0 +1,22 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
+export const docs = {
+  name: 'Card',
+  displayName: 'Card',
+  group: 'Glasses',
+  category: 'Container',
+  keywords: ['glasses', 'hud', 'card'],
+  usage: {
+    description: 'Card is a translucent additive-light surface for one glanceable unit on glasses. Use cards sparingly to separate status, notification, or decision content from the real world behind it.',
+    bestPractices: [
+      {guidance: true, description: 'Design for one glanceable idea and preserve a clear voice or gaze path.'},
+      {guidance: false, description: 'Do not copy dense desktop layouts directly into the HUD surface.'},
+    ],
+  },
+  props: [
+    {name: 'children', type: 'ReactNode', description: 'Content rendered inside the card.'},
+    {name: 'padding', type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10', description: 'Internal padding using the spacing scale.', default: '4'},
+    {name: 'variant', type: "'default' | 'floating' | 'highVisibility' | 'status'", description: 'Glasses surface treatment.', default: "'default'"},
+  ],
+};

--- a/packages/glasses/src/Card/Card.spec.mjs
+++ b/packages/glasses/src/Card/Card.spec.mjs
@@ -1,0 +1,11 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** Machine-readable component contract for glasses payload/native renderers. */
+export const spec = {
+  name: 'Card',
+  target: 'glasses-hud',
+  payloadType: 'Card',
+  nativeRole: 'container',
+  renderer: {android: 'CardRenderer'},
+  theme: {component: 'card', mode: 'ambient-adaptive'},
+};

--- a/packages/glasses/src/Card/renderers/payload.mjs
+++ b/packages/glasses/src/Card/renderers/payload.mjs
@@ -1,0 +1,15 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {spec} from '../Card.spec.mjs';
+
+/** Convert a normalized layout node into the glasses runtime payload shape. */
+export function renderPayload({props, children}) {
+  return {
+    type: spec.payloadType,
+    role: spec.nativeRole,
+    renderer: spec.renderer,
+    theme: spec.theme,
+    props,
+    children,
+  };
+}

--- a/packages/glasses/src/HStack/HStack.doc.mjs
+++ b/packages/glasses/src/HStack/HStack.doc.mjs
@@ -1,0 +1,23 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
+export const docs = {
+  name: 'HStack',
+  displayName: 'HStack',
+  group: 'Glasses',
+  category: 'Layout',
+  keywords: ['glasses', 'hud', 'hstack'],
+  usage: {
+    description: 'HStack arranges compact HUD content horizontally. Use it for action rows or badge/meta pairs, not dense desktop-style layouts.',
+    bestPractices: [
+      {guidance: true, description: 'Design for one glanceable idea and preserve a clear voice or gaze path.'},
+      {guidance: false, description: 'Do not copy dense desktop layouts directly into the HUD surface.'},
+    ],
+  },
+  props: [
+    {name: 'children', type: 'ReactNode', description: 'Stack children.'},
+    {name: 'gap', type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10', description: 'Space between children.', default: '2'},
+    {name: 'hAlign', type: "'start' | 'center' | 'end' | 'between'", description: 'Horizontal distribution.', default: "'start'"},
+    {name: 'vAlign', type: "'start' | 'center' | 'end' | 'stretch'", description: 'Vertical alignment.', default: "'center'"},
+  ],
+};

--- a/packages/glasses/src/HStack/HStack.spec.mjs
+++ b/packages/glasses/src/HStack/HStack.spec.mjs
@@ -1,0 +1,11 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** Machine-readable component contract for glasses payload/native renderers. */
+export const spec = {
+  name: 'HStack',
+  target: 'glasses-hud',
+  payloadType: 'HStack',
+  nativeRole: 'layout',
+  renderer: {android: 'StackRenderer'},
+  theme: {component: 'stack', mode: 'ambient-adaptive'},
+};

--- a/packages/glasses/src/HStack/renderers/payload.mjs
+++ b/packages/glasses/src/HStack/renderers/payload.mjs
@@ -1,0 +1,15 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {spec} from '../HStack.spec.mjs';
+
+/** Convert a normalized layout node into the glasses runtime payload shape. */
+export function renderPayload({props, children}) {
+  return {
+    type: spec.payloadType,
+    role: spec.nativeRole,
+    renderer: spec.renderer,
+    theme: spec.theme,
+    props,
+    children,
+  };
+}

--- a/packages/glasses/src/Heading/Heading.doc.mjs
+++ b/packages/glasses/src/Heading/Heading.doc.mjs
@@ -1,0 +1,21 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
+export const docs = {
+  name: 'Heading',
+  displayName: 'Heading',
+  group: 'Glasses',
+  category: 'Content',
+  keywords: ['glasses', 'hud', 'heading'],
+  usage: {
+    description: 'Heading renders short title text for a glasses HUD card or screen. Use it to identify the single idea the user should understand first.',
+    bestPractices: [
+      {guidance: true, description: 'Design for one glanceable idea and preserve a clear voice or gaze path.'},
+      {guidance: false, description: 'Do not copy dense desktop layouts directly into the HUD surface.'},
+    ],
+  },
+  props: [
+    {name: 'children', type: 'ReactNode', description: 'Heading content.'},
+    {name: 'level', type: '1 | 2 | 3', description: 'Heading level and visual size.', default: '2'},
+  ],
+};

--- a/packages/glasses/src/Heading/Heading.spec.mjs
+++ b/packages/glasses/src/Heading/Heading.spec.mjs
@@ -1,0 +1,11 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** Machine-readable component contract for glasses payload/native renderers. */
+export const spec = {
+  name: 'Heading',
+  target: 'glasses-hud',
+  payloadType: 'Heading',
+  nativeRole: 'heading',
+  renderer: {android: 'TextRenderer'},
+  theme: {component: 'heading', mode: 'ambient-adaptive'},
+};

--- a/packages/glasses/src/Heading/renderers/payload.mjs
+++ b/packages/glasses/src/Heading/renderers/payload.mjs
@@ -1,0 +1,15 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {spec} from '../Heading.spec.mjs';
+
+/** Convert a normalized layout node into the glasses runtime payload shape. */
+export function renderPayload({props, children}) {
+  return {
+    type: spec.payloadType,
+    role: spec.nativeRole,
+    renderer: spec.renderer,
+    theme: spec.theme,
+    props,
+    children,
+  };
+}

--- a/packages/glasses/src/List/List.doc.mjs
+++ b/packages/glasses/src/List/List.doc.mjs
@@ -1,0 +1,21 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
+export const docs = {
+  name: 'List',
+  displayName: 'List',
+  group: 'Glasses',
+  category: 'Table & List',
+  keywords: ['glasses', 'hud', 'list'],
+  usage: {
+    description: 'List renders a short set of glanceable rows on glasses. Use it instead of a table when a HUD needs to show recent notifications, choices, or status items.',
+    bestPractices: [
+      {guidance: true, description: 'Design for one glanceable idea and preserve a clear voice or gaze path.'},
+      {guidance: false, description: 'Do not copy dense desktop layouts directly into the HUD surface.'},
+    ],
+  },
+  props: [
+    {name: 'children', type: 'ReactNode', description: 'ListItem children.'},
+    {name: 'gap', type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10', description: 'Space between rows.', default: '1'},
+  ],
+};

--- a/packages/glasses/src/List/List.spec.mjs
+++ b/packages/glasses/src/List/List.spec.mjs
@@ -1,0 +1,11 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** Machine-readable component contract for glasses payload/native renderers. */
+export const spec = {
+  name: 'List',
+  target: 'glasses-hud',
+  payloadType: 'List',
+  nativeRole: 'list',
+  renderer: {android: 'ListRenderer'},
+  theme: {component: 'list', mode: 'ambient-adaptive'},
+};

--- a/packages/glasses/src/List/renderers/payload.mjs
+++ b/packages/glasses/src/List/renderers/payload.mjs
@@ -1,0 +1,15 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {spec} from '../List.spec.mjs';
+
+/** Convert a normalized layout node into the glasses runtime payload shape. */
+export function renderPayload({props, children}) {
+  return {
+    type: spec.payloadType,
+    role: spec.nativeRole,
+    renderer: spec.renderer,
+    theme: spec.theme,
+    props,
+    children,
+  };
+}

--- a/packages/glasses/src/ListItem/ListItem.doc.mjs
+++ b/packages/glasses/src/ListItem/ListItem.doc.mjs
@@ -1,0 +1,23 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
+export const docs = {
+  name: 'ListItem',
+  displayName: 'ListItem',
+  group: 'Glasses',
+  category: 'Table & List',
+  keywords: ['glasses', 'hud', 'listitem'],
+  usage: {
+    description: 'ListItem is a single glanceable row with title, optional subtitle, and optional meta text. Use it to compress tabular desktop data into a HUD-friendly row.',
+    bestPractices: [
+      {guidance: true, description: 'Design for one glanceable idea and preserve a clear voice or gaze path.'},
+      {guidance: false, description: 'Do not copy dense desktop layouts directly into the HUD surface.'},
+    ],
+  },
+  props: [
+    {name: 'title', type: 'string', description: 'Primary row text.', required: true},
+    {name: 'subtitle', type: 'string', description: 'Secondary row text.'},
+    {name: 'meta', type: 'string', description: 'Compact trailing status, count, or time.'},
+    {name: 'status', type: "'neutral' | 'info' | 'success' | 'warning' | 'error'", description: 'Status color for the meta text.', default: "'neutral'"},
+  ],
+};

--- a/packages/glasses/src/ListItem/ListItem.spec.mjs
+++ b/packages/glasses/src/ListItem/ListItem.spec.mjs
@@ -1,0 +1,11 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** Machine-readable component contract for glasses payload/native renderers. */
+export const spec = {
+  name: 'ListItem',
+  target: 'glasses-hud',
+  payloadType: 'ListItem',
+  nativeRole: 'listitem',
+  renderer: {android: 'ListItemRenderer'},
+  theme: {component: 'listItem', mode: 'ambient-adaptive'},
+};

--- a/packages/glasses/src/ListItem/renderers/payload.mjs
+++ b/packages/glasses/src/ListItem/renderers/payload.mjs
@@ -1,0 +1,15 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {spec} from '../ListItem.spec.mjs';
+
+/** Convert a normalized layout node into the glasses runtime payload shape. */
+export function renderPayload({props, children}) {
+  return {
+    type: spec.payloadType,
+    role: spec.nativeRole,
+    renderer: spec.renderer,
+    theme: spec.theme,
+    props,
+    children,
+  };
+}

--- a/packages/glasses/src/Screen/Screen.doc.mjs
+++ b/packages/glasses/src/Screen/Screen.doc.mjs
@@ -1,0 +1,22 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
+export const docs = {
+  name: 'Screen',
+  displayName: 'Screen',
+  group: 'Glasses',
+  category: 'Layout',
+  keywords: ['glasses', 'hud', 'screen'],
+  usage: {
+    description: 'Screen is the root surface for a smart-glasses HUD experience. Use it for glanceable, voice-friendly UI that fits inside the 600×600 projected display.',
+    bestPractices: [
+      {guidance: true, description: 'Design for one glanceable idea and preserve a clear voice or gaze path.'},
+      {guidance: false, description: 'Do not copy dense desktop layouts directly into the HUD surface.'},
+    ],
+  },
+  props: [
+    {name: 'children', type: 'ReactNode', description: 'Glanceable content rendered inside the HUD safe area.', required: true},
+    {name: 'ambient', type: "'bright' | 'dim' | 'dark' | 'auto'", description: 'Ambient-light mode hint for additive-light rendering.', default: "'auto'"},
+    {name: 'label', type: 'string', description: 'Short accessible description of the HUD screen.'},
+  ],
+};

--- a/packages/glasses/src/Screen/Screen.spec.mjs
+++ b/packages/glasses/src/Screen/Screen.spec.mjs
@@ -1,0 +1,11 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** Machine-readable component contract for glasses payload/native renderers. */
+export const spec = {
+  name: 'Screen',
+  target: 'glasses-hud',
+  payloadType: 'Screen',
+  nativeRole: 'surface',
+  renderer: {android: 'ScreenRenderer'},
+  theme: {component: 'screen', mode: 'ambient-adaptive'},
+};

--- a/packages/glasses/src/Screen/renderers/payload.mjs
+++ b/packages/glasses/src/Screen/renderers/payload.mjs
@@ -1,0 +1,15 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {spec} from '../Screen.spec.mjs';
+
+/** Convert a normalized layout node into the glasses runtime payload shape. */
+export function renderPayload({props, children}) {
+  return {
+    type: spec.payloadType,
+    role: spec.nativeRole,
+    renderer: spec.renderer,
+    theme: spec.theme,
+    props,
+    children,
+  };
+}

--- a/packages/glasses/src/Text/Text.doc.mjs
+++ b/packages/glasses/src/Text/Text.doc.mjs
@@ -1,0 +1,22 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
+export const docs = {
+  name: 'Text',
+  displayName: 'Text',
+  group: 'Glasses',
+  category: 'Content',
+  keywords: ['glasses', 'hud', 'text'],
+  usage: {
+    description: 'Text renders short additive-light copy on a glasses HUD. Use it for glanceable labels, status summaries, and one-line explanations.',
+    bestPractices: [
+      {guidance: true, description: 'Design for one glanceable idea and preserve a clear voice or gaze path.'},
+      {guidance: false, description: 'Do not copy dense desktop layouts directly into the HUD surface.'},
+    ],
+  },
+  props: [
+    {name: 'children', type: 'ReactNode', description: 'Text content.'},
+    {name: 'type', type: "'body' | 'supporting' | 'caption'", description: 'Typographic role.', default: "'body'"},
+    {name: 'weight', type: "'regular' | 'medium' | 'bold'", description: 'Font weight emphasis.', default: "'regular'"},
+  ],
+};

--- a/packages/glasses/src/Text/Text.spec.mjs
+++ b/packages/glasses/src/Text/Text.spec.mjs
@@ -1,0 +1,11 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** Machine-readable component contract for glasses payload/native renderers. */
+export const spec = {
+  name: 'Text',
+  target: 'glasses-hud',
+  payloadType: 'Text',
+  nativeRole: 'text',
+  renderer: {android: 'TextRenderer'},
+  theme: {component: 'text', mode: 'ambient-adaptive'},
+};

--- a/packages/glasses/src/Text/renderers/payload.mjs
+++ b/packages/glasses/src/Text/renderers/payload.mjs
@@ -1,0 +1,15 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {spec} from '../Text.spec.mjs';
+
+/** Convert a normalized layout node into the glasses runtime payload shape. */
+export function renderPayload({props, children}) {
+  return {
+    type: spec.payloadType,
+    role: spec.nativeRole,
+    renderer: spec.renderer,
+    theme: spec.theme,
+    props,
+    children,
+  };
+}

--- a/packages/glasses/src/VStack/VStack.doc.mjs
+++ b/packages/glasses/src/VStack/VStack.doc.mjs
@@ -1,0 +1,23 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
+export const docs = {
+  name: 'VStack',
+  displayName: 'VStack',
+  group: 'Glasses',
+  category: 'Layout',
+  keywords: ['glasses', 'hud', 'vstack'],
+  usage: {
+    description: 'VStack arranges HUD content vertically with tokenized gaps. Use it as the default layout primitive for readable glasses experiences.',
+    bestPractices: [
+      {guidance: true, description: 'Design for one glanceable idea and preserve a clear voice or gaze path.'},
+      {guidance: false, description: 'Do not copy dense desktop layouts directly into the HUD surface.'},
+    ],
+  },
+  props: [
+    {name: 'children', type: 'ReactNode', description: 'Stack children.'},
+    {name: 'gap', type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10', description: 'Space between children.', default: '2'},
+    {name: 'hAlign', type: "'start' | 'center' | 'end' | 'stretch'", description: 'Horizontal alignment.', default: "'stretch'"},
+    {name: 'vAlign', type: "'start' | 'center' | 'end' | 'between'", description: 'Vertical distribution.', default: "'start'"},
+  ],
+};

--- a/packages/glasses/src/VStack/VStack.spec.mjs
+++ b/packages/glasses/src/VStack/VStack.spec.mjs
@@ -1,0 +1,11 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** Machine-readable component contract for glasses payload/native renderers. */
+export const spec = {
+  name: 'VStack',
+  target: 'glasses-hud',
+  payloadType: 'VStack',
+  nativeRole: 'layout',
+  renderer: {android: 'StackRenderer'},
+  theme: {component: 'stack', mode: 'ambient-adaptive'},
+};

--- a/packages/glasses/src/VStack/renderers/payload.mjs
+++ b/packages/glasses/src/VStack/renderers/payload.mjs
@@ -1,0 +1,15 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {spec} from '../VStack.spec.mjs';
+
+/** Convert a normalized layout node into the glasses runtime payload shape. */
+export function renderPayload({props, children}) {
+  return {
+    type: spec.payloadType,
+    role: spec.nativeRole,
+    renderer: spec.renderer,
+    theme: spec.theme,
+    props,
+    children,
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -774,6 +774,12 @@ importers:
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
 
+  packages/glasses:
+    dependencies:
+      react:
+        specifier: '>=19.0.0'
+        version: 19.2.7
+
   packages/lab:
     dependencies:
       '@stylexjs/stylex':


### PR DESCRIPTION
## Summary

Stacks on #2800 to test whether the layout grammar can target a first-class modality-specific component abstraction without putting TSX in the glasses output path.

- adds a private `@xds/glasses` package made of per-component folders
- each glasses component folder owns:
  - `{Component}.doc.mjs` for agent/human guidance and prop validation
  - `{Component}.spec.mjs` for native/runtime contract metadata
  - `renderers/payload.mjs` for native-shaped payload emission
- teaches `xds layout` to accept `--target glasses` for `check`, `expand`, and `grammar`
- default `xds layout expand --target glasses` now emits a native-shaped payload instead of TSX
- keeps desktop/default behavior as TSX from `@xds/core`
- adds tests that compare the same generic app idea as desktop TSX vs glasses payload, leaving modality-specific design choices to the author/agent

## Example

```bash
xds layout expand --target glasses \
  'Scr[label="Project brief"] > C[p4] > V[g2] > (Hd"Project brief" + Tx.supporting"Status: on track" + B.primary"Open details"[action=openDetails])'
```

Outputs a payload shaped for a native renderer, e.g. nodes include:

```json
{
  "type": "Button",
  "role": "action",
  "renderer": {"android": "ButtonRenderer"},
  "theme": {"component": "button", "mode": "ambient-adaptive"},
  "props": {"variant": "primary", "label": "Open details", "action": "openDetails"}
}
```

## Test plan

- `pnpm exec vitest run packages/cli/src/api/layout.test.mjs packages/cli/src/lib/xle/xle.test.mjs`
- `pnpm -F @xds/cli typecheck:json-api`
- `for f in packages/glasses/src/*/*.doc.mjs packages/glasses/src/*/*.spec.mjs packages/glasses/src/*/renderers/payload.mjs; do node --input-type=module -e "await import(process.argv[1]);" "./$f" || exit 1; done`
