### PR TITLE
docs(AppShell): fix bare > in @example block

### DIFF
--- a/packages/core/src/AppShell/XDSAppShell.tsx
+++ b/packages/core/src/AppShell/XDSAppShell.tsx
@@ -258,8 +258,7 @@ export interface XDSAppShellProps extends XDSBaseProps<HTMLDivElement> {
    *   return (
    *     <XDSAppShell
    *       sideNav={hasSidebar ? sidebar : undefined}
-   *       mobileNav={hasSidebar ? { breakpoint: 'md' } : false}
-   *     >
+   *       mobileNav={hasSidebar ? { breakpoint: 'md' } : false}>
    *       {children}
    *     </XDSAppShell>
    *   );


### PR DESCRIPTION
## What

Moves the closing `>` of `<XDSAppShell` from its own line onto the same line as the last prop in the third `@example` block of `XDSAppShell.tsx`.

A bare `>` on its own line inside a JSDoc code block can render as a markdown blockquote if Storybook's autodocs parser breaks the code fence.

## Checklist
- [x] `pnpm --filter @xds/core typecheck:docs` passes
- [x] `npx tsc --project packages/cli/tsconfig.template-docs.json --noEmit` passes
- [x] No bare `>` inside `@example` code blocks

---
*Night Watch -- Doc Reviewer*