### PR TITLE
fix(core): remove redundant style prop declarations, wire FieldStatus escape hatches

### DIFF
--- a/packages/core/src/FieldStatus/XDSFieldStatus.tsx
+++ b/packages/core/src/FieldStatus/XDSFieldStatus.tsx
@@ -132,6 +132,10 @@ export function XDSFieldStatus({
   message,
   id,
   variant = 'attached',
+  xstyle,
+  className,
+  style,
+  ...rest
 }: XDSFieldStatusProps) {
   const entryStyle = useEntryAnimation('slideDown');
 
@@ -141,6 +145,7 @@ export function XDSFieldStatus({
       id={id}
       role={type === 'error' ? 'alert' : 'status'}
       aria-live={type === 'error' ? 'assertive' : 'polite'}
+      {...rest}
       {...mergeProps(
         xdsThemeProps('field-status', {type, variant}),
         stylex.props(
@@ -148,7 +153,10 @@ export function XDSFieldStatus({
           entryStyle,
           variant === 'attached' ? styles.attached : styles.detached,
           colorStyles[type],
+          xstyle,
         ),
+        className,
+        style,
       )}>
       {message}
     </div>

--- a/packages/core/src/FormLayout/XDSFormLayout.tsx
+++ b/packages/core/src/FormLayout/XDSFormLayout.tsx
@@ -18,7 +18,6 @@
 import {useMemo, type ReactNode} from 'react';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
-import type {StyleXStyles} from '@stylexjs/stylex';
 import {spacingVars} from '../theme/tokens.stylex';
 import {
   XDSFormLayoutContext,
@@ -86,28 +85,6 @@ export interface XDSFormLayoutProps extends XDSBaseProps<HTMLDivElement> {
    * @default 'vertical'
    */
   direction?: XDSFormLayoutDirection;
-
-  /**
-   * StyleX styles created via `stylex.create()`. Merged with the component's
-   * base styles inside a single `stylex.props()` call for optimal deduplication.
-   *
-   * @example
-   * ```
-   * const overrides = stylex.create({ root: { marginBottom: 8 } });
-   * <Component xstyle={overrides.root} />
-   * ```
-   */
-  xstyle?: StyleXStyles;
-  /**
-   * CSS class name(s) appended to the root element.
-   * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
-   */
-  className?: string;
-  /**
-   * Inline styles to apply to the root element. Spread after StyleX
-   * inline styles, so these values take priority.
-   */
-  style?: React.CSSProperties;
 }
 
 // =============================================================================

--- a/packages/core/src/FormLayout/__snapshots__/XDSFormLayout.test.tsx.snap
+++ b/packages/core/src/FormLayout/__snapshots__/XDSFormLayout.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`XDSFormLayout > matches snapshot for horizontal direction 1`] = `
 <div
   class="xds-form-layout horizontal XDSFormLayout__styles.base xdt5ytf x18g69wz XDSFormLayout__styles.horizontal xrvj5dj x1mt1orb xu6a5m6"
   data-direction="horizontal"
-  data-style-src="@xds/core:src/FormLayout/XDSFormLayout.tsx:41; @xds/core:src/FormLayout/XDSFormLayout.tsx:46"
+  data-style-src="@xds/core:src/FormLayout/XDSFormLayout.tsx:40; @xds/core:src/FormLayout/XDSFormLayout.tsx:45"
   data-testid="layout"
 >
   <input
@@ -20,7 +20,7 @@ exports[`XDSFormLayout > matches snapshot for horizontal-labels direction 1`] = 
 <div
   class="xds-form-layout horizontal-labels XDSFormLayout__styles.base xdt5ytf XDSFormLayout__styles.horizontalLabels xrvj5dj x1pmbctz xlaq8a2 x7a106z xedohl4 x1rpgqan x1a1jff"
   data-direction="horizontal-labels"
-  data-style-src="@xds/core:src/FormLayout/XDSFormLayout.tsx:41; @xds/core:src/FormLayout/XDSFormLayout.tsx:51"
+  data-style-src="@xds/core:src/FormLayout/XDSFormLayout.tsx:40; @xds/core:src/FormLayout/XDSFormLayout.tsx:50"
   data-testid="layout"
 >
   <label>
@@ -36,7 +36,7 @@ exports[`XDSFormLayout > matches snapshot for vertical direction 1`] = `
 <div
   class="xds-form-layout vertical XDSFormLayout__styles.base x78zum5 xdt5ytf x18g69wz"
   data-direction="vertical"
-  data-style-src="@xds/core:src/FormLayout/XDSFormLayout.tsx:41"
+  data-style-src="@xds/core:src/FormLayout/XDSFormLayout.tsx:40"
   data-testid="layout"
 >
   <input

--- a/packages/core/src/Grid/XDSGrid.tsx
+++ b/packages/core/src/Grid/XDSGrid.tsx
@@ -18,7 +18,6 @@
 import type {ReactNode} from 'react';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
-import type {StyleXStyles} from '@stylexjs/stylex';
 import {spacingVars} from '../theme/tokens.stylex';
 import type {SpacingStep} from '../utils/types';
 import type {SizeValue} from '../utils/types';
@@ -128,28 +127,6 @@ export interface XDSGridProps extends XDSBaseProps<HTMLDivElement> {
    * @default 'stretch'
    */
   justify?: GridAlignment;
-
-  /**
-   * StyleX styles created via `stylex.create()`. Merged with the component's
-   * base styles inside a single `stylex.props()` call for optimal deduplication.
-   *
-   * @example
-   * ```
-   * const overrides = stylex.create({ root: { marginBottom: 8 } });
-   * <Component xstyle={overrides.root} />
-   * ```
-   */
-  xstyle?: StyleXStyles;
-  /**
-   * CSS class name(s) appended to the root element.
-   * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
-   */
-  className?: string;
-  /**
-   * Inline styles to apply to the root element. Spread after StyleX
-   * inline styles, so these values take priority.
-   */
-  style?: React.CSSProperties;
 
   /**
    * Content to render inside the grid.

--- a/packages/core/src/Grid/XDSGridSpan.tsx
+++ b/packages/core/src/Grid/XDSGridSpan.tsx
@@ -16,7 +16,6 @@
 import type {ReactNode} from 'react';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
-import type {StyleXStyles} from '@stylexjs/stylex';
 import {mergeProps} from '../utils';
 import {xdsThemeProps} from '../utils/xdsThemeProps';
 
@@ -35,28 +34,6 @@ export interface XDSGridSpanProps extends XDSBaseProps<HTMLDivElement> {
    * Sets `grid-row: span N`.
    */
   rows?: number;
-
-  /**
-   * StyleX styles created via `stylex.create()`. Merged with the component's
-   * base styles inside a single `stylex.props()` call for optimal deduplication.
-   *
-   * @example
-   * ```
-   * const overrides = stylex.create({ root: { marginBottom: 8 } });
-   * <Component xstyle={overrides.root} />
-   * ```
-   */
-  xstyle?: StyleXStyles;
-  /**
-   * CSS class name(s) appended to the root element.
-   * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
-   */
-  className?: string;
-  /**
-   * Inline styles to apply to the root element. Spread after StyleX
-   * inline styles, so these values take priority.
-   */
-  style?: React.CSSProperties;
 
   /**
    * Content to render inside the grid span.


### PR DESCRIPTION
Removes redundant `xstyle`, `className`, and `style` prop declarations from
FormLayout, Grid, and GridSpan. These props are already provided by `XDSBaseProps`
which each interface extends, so re-declaring them adds noise and risks drift
if the base type changes.

Also wires escape-hatch style props and rest-spread through to the DOM element
in XDSFieldStatus, which previously extended XDSBaseProps but discarded all
base props except `id`. Consumers (and theme overrides) can now apply custom
styles and data-* attributes.

Components audited this run: FieldStatus, FileInput, FormLayout, Grid, HStack.

## Changes

- **FormLayout** -- remove redundant xstyle/className/style from XDSFormLayoutProps,
  remove unused `StyleXStyles` import
- **Grid** -- remove redundant xstyle/className/style from XDSGridProps,
  remove unused `StyleXStyles` import
- **GridSpan** -- remove redundant xstyle/className/style from XDSGridSpanProps,
  remove unused `StyleXStyles` import
- **FieldStatus** -- destructure xstyle/className/style/...rest and pass through
  to the root div element

## Needs Review

None -- all changes are mechanical.

Night Watch -- Component Auditor