### PR TITLE
fix(AvatarGroup): export XDSAvatarGroupContextValue type

### DIFF
--- a/packages/core/src/AvatarGroup/index.ts
+++ b/packages/core/src/AvatarGroup/index.ts
@@ -17,3 +17,4 @@ export {XDSAvatarGroupOverflow} from './XDSAvatarGroupOverflow';
 export type {XDSAvatarGroupOverflowProps} from './XDSAvatarGroupOverflow';
 
 export {useXDSAvatarGroup} from './XDSAvatarGroupContext';
+export type {XDSAvatarGroupContextValue} from './XDSAvatarGroupContext';


### PR DESCRIPTION
Export the `XDSAvatarGroupContextValue` type from `packages/core/src/AvatarGroup/index.ts`.

The `useXDSAvatarGroup` hook returns `XDSAvatarGroupContextValue | null`, but consumers who need to type that return value explicitly had no access to the type from the package entry point.

## Audit Summary

Audited 5 components: AlertDialog, AppShell, AspectRatio, Avatar, AvatarGroup.

**Findings:**
- **AvatarGroup** (export-gap): `XDSAvatarGroupContextValue` type not exported from index.ts despite being the return type of the public `useXDSAvatarGroup` hook. Fixed.

**Observations (no action needed):**
- AppShell variant style application uses ternary chain rather than extensible variant map lookup. Low-priority since shell-level variants are unlikely to be extended by themes, but worth noting for consistency.
- Avatar uses an inline SVG for the default person icon fallback. Acceptable: requiring icon registry setup just for the avatar no-data state would be burdensome.

**No issues found in:** AlertDialog, AspectRatio, Avatar (theming, naming, a11y, structure all clean).

Night Watch — Component Auditor