### PR TITLE
fix(vibe-tests): add event handler guidance and import paths to READMEs

### DIFF
--- a/internal/vibe-tests/environments/project-xds-tailwind/README.md
+++ b/internal/vibe-tests/environments/project-xds-tailwind/README.md
@@ -29,10 +29,12 @@ import {XDSTheme} from '@xds/core/theme';
 
 ## Event Handlers
 
-XDS is a React DOM library. Use standard React DOM event handlers:
+XDS is a React DOM library. Use standard React DOM event handler props such as
+`onClick`, `onChange`, and `onKeyDown`. For button activation, use `onClick`:
 
 ```tsx
 <XDSButton label="Save" onClick={() => handleSave()} />
 ```
 
-Do NOT use React Native patterns like `onPress` — they don't exist in XDS.
+Do NOT use cross-platform activation props like `onPress` unless a component
+explicitly documents them.

--- a/internal/vibe-tests/environments/project-xds-tailwind/README.md
+++ b/internal/vibe-tests/environments/project-xds-tailwind/README.md
@@ -23,4 +23,16 @@ import {XDSButton} from '@xds/core/Button';
 import {XDSIconButton} from '@xds/core/IconButton';
 import {XDSCard} from '@xds/core/Card';
 import {XDSText, XDSHeading} from '@xds/core/Text';
+import {XDSToggleButton, XDSToggleButtonGroup} from '@xds/core/ToggleButton';
+import {XDSTheme} from '@xds/core/theme';
 ```
+
+## Event Handlers
+
+XDS is a React DOM library. Use standard React DOM event handlers:
+
+```tsx
+<XDSButton label="Save" onClick={() => handleSave()} />
+```
+
+Do NOT use React Native patterns like `onPress` — they don't exist in XDS.

--- a/internal/vibe-tests/environments/project-xds/README.md
+++ b/internal/vibe-tests/environments/project-xds/README.md
@@ -51,4 +51,16 @@ import {XDSButton} from '@xds/core/Button';
 import {XDSIconButton} from '@xds/core/IconButton';
 import {XDSCard} from '@xds/core/Card';
 import {XDSText, XDSHeading} from '@xds/core/Text';
+import {XDSToggleButton, XDSToggleButtonGroup} from '@xds/core/ToggleButton';
+import {XDSTheme} from '@xds/core/theme';
 ```
+
+## Event Handlers
+
+XDS is a React DOM library. Use standard React DOM event handlers:
+
+```tsx
+<XDSButton label="Save" onClick={() => handleSave()} />
+```
+
+Do NOT use React Native patterns like `onPress` — they don't exist in XDS.

--- a/internal/vibe-tests/environments/project-xds/README.md
+++ b/internal/vibe-tests/environments/project-xds/README.md
@@ -57,10 +57,12 @@ import {XDSTheme} from '@xds/core/theme';
 
 ## Event Handlers
 
-XDS is a React DOM library. Use standard React DOM event handlers:
+XDS is a React DOM library. Use standard React DOM event handler props such as
+`onClick`, `onChange`, and `onKeyDown`. For button activation, use `onClick`:
 
 ```tsx
 <XDSButton label="Save" onClick={() => handleSave()} />
 ```
 
-Do NOT use React Native patterns like `onPress` — they don't exist in XDS.
+Do NOT use cross-platform activation props like `onPress` unless a component
+explicitly documents them.


### PR DESCRIPTION
## What

Adds event handler guidance and expanded import path examples to the XDS and XDS+Tailwind vibe test environment READMEs.

## Why

The vibe test nightly (issue #2840) showed agents making consistent errors:
- Using `onPress` (cross-platform activation prop) instead of `onClick` (React DOM) — appeared in 4+ prompts
- Importing `XDSToggleButton` from `@xds/core/Button` instead of `@xds/core/ToggleButton`
- Importing `XDSThemeProvider` from `@xds/core/ThemeProvider` instead of `XDSTheme` from `@xds/core/theme`

The CLI docs are correct, but agents frequently skip CLI lookups and fall back to patterns from other libraries. The baseline environment lets agents discover event patterns by reading component source code; the XDS environment should provide equivalent discoverability through its README.

## Changes

Both `project-xds/README.md` and `project-xds-tailwind/README.md`:
- Added `XDSToggleButton`, `XDSToggleButtonGroup`, and `XDSTheme` to import examples
- Added "Event Handlers" section clarifying React DOM event props (`onClick`, `onChange`, `onKeyDown`)
- Added explicit warning against cross-platform `onPress`-style activation props unless documented

## Checker Protocol Verification

- [x] Not leaking expected components (ToggleButton/Theme are general-purpose, not test-specific)
- [x] Both XDS targets get identical changes (fairness maintained)
- [x] Additions reflect actual TypeScript types
- [x] No system-specific coaching — just documenting the import pattern and event model

## Verification

- [x] Import paths match actual package exports
- [x] Event handler patterns match XDSButtonProps interface (`onClick`, not `onPress`)

Vibe Test Debugger
