### PR TITLE
fix(docsite): use heart-handshake icon for Community nav button

### DIFF
--- a/apps/docsite/src/components/SharedTopNav.tsx
+++ b/apps/docsite/src/components/SharedTopNav.tsx
@@ -7,7 +7,7 @@ import {usePathname} from 'next/navigation';
 import {XDSTopNav, XDSTopNavHeading, XDSTopNavItem} from '@xds/core/TopNav';
 import {XDSButton} from '@xds/core/Button';
 import {XDSHStack} from '@xds/core/Layout';
-import {Search, HandHeart, Sun, Moon} from 'lucide-react';
+import {Search, HeartHandshake, Sun, Moon} from 'lucide-react';
 import {GITHUB_REPO} from '../constants';
 import {BRAND_ICON} from './XDSWordmark';
 import {SearchPalette} from './SearchPalette';
@@ -133,7 +133,7 @@ export function SharedTopNav() {
                 tooltip="Community"
                 variant="ghost"
                 isIconOnly
-                icon={<HandHeart size={20} />}
+                icon={<HeartHandshake size={20} />}
                 href="/community"
               />
               <XDSButton


### PR DESCRIPTION
## Summary
- Swap the docsite top nav **Community** button icon from `HandHeart` to `HeartHandshake` (lucide-react), per design request to use the `heart-handshake` icon.

## Test plan
- [ ] Load the docsite and confirm the Community button in the top nav shows the heart-handshake icon
- [ ] Verify the tooltip/label still reads "Community" and the link still points to `/community`

Made with [Cursor](https://cursor.com)