### PR TITLE
fix(core): export ButtonGroup context type, remove redundant DateRangeInput xstyle, forward DialogHeader escape hatches

### DIFF
--- a/packages/core/src/ButtonGroup/index.ts
+++ b/packages/core/src/ButtonGroup/index.ts
@@ -13,4 +13,7 @@ export {XDSButtonGroup} from './XDSButtonGroup';
 export type {XDSButtonGroupProps} from './XDSButtonGroup';
 
 export {useXDSButtonGroup} from './XDSButtonGroupContext';
-export type {XDSButtonGroupOrientation} from './XDSButtonGroupContext';
+export type {
+  XDSButtonGroupOrientation,
+  XDSButtonGroupContextValue,
+} from './XDSButtonGroupContext';

--- a/packages/core/src/DateRangeInput/XDSDateRangeInput.tsx
+++ b/packages/core/src/DateRangeInput/XDSDateRangeInput.tsx
@@ -49,7 +49,6 @@ import {XDSSpinner} from '../Spinner';
 import {XDSCalendar, type ISODateString, type DateRange} from '../Calendar';
 import {useXDSPopover} from '../Popover';
 import {mergeProps} from '../utils';
-import type {StyleXStyles} from '@stylexjs/stylex';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import {useXDSSize} from '../SizeContext/XDSSizeContext';
 import {xdsThemeProps} from '../utils/xdsThemeProps';
@@ -316,11 +315,6 @@ export interface XDSDateRangeInputProps extends Omit<
    * @default 2
    */
   numberOfMonths?: 1 | 2;
-
-  /**
-   * Style overrides.
-   */
-  xstyle?: StyleXStyles;
 }
 
 /**

--- a/packages/core/src/Dialog/XDSDialogHeader.tsx
+++ b/packages/core/src/Dialog/XDSDialogHeader.tsx
@@ -126,6 +126,9 @@ export function XDSDialogHeader({
   startContent,
   endContent,
   hasDivider,
+  xstyle,
+  className,
+  style,
   ref,
 }: XDSDialogHeaderProps) {
   const titleRef = useRef<HTMLHeadingElement>(null);
@@ -142,7 +145,12 @@ export function XDSDialogHeader({
   }, [shouldAutoFocus]);
 
   return (
-    <XDSLayoutHeader ref={ref} hasDivider={hasDivider}>
+    <XDSLayoutHeader
+      ref={ref}
+      hasDivider={hasDivider}
+      xstyle={xstyle}
+      className={className}
+      style={style}>
       <div {...stylex.props(styles.container)}>
         {startContent && (
           <div {...stylex.props(styles.actions)}>{startContent}</div>


### PR DESCRIPTION
## Changes

**ButtonGroup** -- export `XDSButtonGroupContextValue` type from barrel index so consumers can type context values without reaching into internal paths.

**DateRangeInput** -- remove redundant `xstyle?: StyleXStyles` declaration. The interface already extends `Omit<XDSBaseProps, 'onChange' | 'defaultValue'>` which provides `xstyle`. Also removes the now-unused `StyleXStyles` import.

**DialogHeader** -- forward `xstyle`, `className`, `style` escape hatch props to the inner `XDSLayoutHeader`. Previously these props were accepted by the interface (via XDSBaseProps) but silently dropped.

## Components audited

- ButtonGroup
- Code
- DateInput
- DateRangeInput
- Dialog

Code and DateInput had no findings.

Night Watch -- Component Auditor