### PR TITLE
fix(cli): correct import hint to show primary component

### DIFF
--- a/packages/cli/src/lib/component-format.mjs
+++ b/packages/cli/src/lib/component-format.mjs
@@ -128,7 +128,7 @@ export function formatFull(docs, options = {}) {
   sections.push(desc + '\n');
 
   if (options.importHint) {
-    const displayName = docs.components?.[0]?.name || `XDS${docs.name}`;
+    const displayName = `XDS${docs.name}`;
     sections.push(`**Import:** \`import {${displayName}} from '${options.importHint}';\`\n`);
   }
 


### PR DESCRIPTION
## What

Fixes the CLI import hint to show the primary component export instead of the first sub-component.

## Why

The vibe test nightly (issue #2859) showed agents consistently using wrong prop APIs on XDSText and XDSCodeBlock. Root cause: the CLI output's import line was showing sub-components:

- `import {XDSHeading} from '@xds/core/Text'` — should be `XDSText`
- `import {XDSCode} from '@xds/core/CodeBlock'` — should be `XDSCodeBlock`
- `import {XDSDialogHeader} from '@xds/core/Dialog'` — should be `XDSDialog`

This caused agents to conflate XDSText with XDSHeading and hallucinate a `variant` prop, leading to type errors in 7/10 prompts.

## Changes

- `packages/cli/src/lib/component-format.mjs`: Use `XDS${docs.name}` for the import hint display name instead of `docs.components[0].name`

## Verification

- [x] `npx xds component Text` now shows `import {XDSText} from '@xds/core/Text'`
- [x] `npx xds component CodeBlock` now shows `import {XDSCodeBlock} from '@xds/core/CodeBlock'`
- [x] `npx xds component Dialog` now shows `import {XDSDialog} from '@xds/core/Dialog'`
- [x] All 515 import-hint-correctness tests pass
- [x] TypeScript types match documentation

Vibe Test Debugger