### PR TITLE
feat(core): add centralized naming module for prefix migration

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -51,6 +51,11 @@
       "types": "./src/tailwind-theme.css.d.ts",
       "default": "./src/tailwind-theme.css"
     },
+    "./naming": {
+      "source": "./src/naming.ts",
+      "types": "./dist/naming.d.ts",
+      "default": "./dist/naming.js"
+    },
     "./theme/tokens": {
       "source": "./src/theme/tokens.ts",
       "types": "./dist/theme/tokens.d.ts",

--- a/packages/core/src/README.md
+++ b/packages/core/src/README.md
@@ -4,8 +4,9 @@ Source code for core UI components.
 
 <!-- SYNC: When files in this directory change, update this document. -->
 
-| File/Directory | Role      | Purpose                                                             |
-| -------------- | --------- | ------------------------------------------------------------------- |
-| `index.ts`     | Entry     | Package entry point; re-exports public components, hooks, and types |
-| `reset.css`    | Styles    | Base CSS reset for consistent cross-browser defaults                |
-| `Button/`      | Component | Button component with variants and loading states                   |
+| File/Directory | Role      | Purpose                                                                                                                                         |
+| -------------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `index.ts`     | Entry     | Package entry point; re-exports public components, hooks, and types                                                                             |
+| `naming.ts`    | Utility   | Centralized namespace-prefix constants/helpers (CSS classes, data attrs, CSS vars) — single source of truth for the XDS→Astryx prefix migration |
+| `reset.css`    | Styles    | Base CSS reset for consistent cross-browser defaults                                                                                            |
+| `Button/`      | Component | Button component with variants and loading states                                                                                               |

--- a/packages/core/src/naming.test.ts
+++ b/packages/core/src/naming.test.ts
@@ -1,0 +1,69 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {describe, it, expect} from 'vitest';
+import {
+  LEGACY_NAMESPACE,
+  NAMESPACE,
+  classPrefix,
+  legacyClassPrefix,
+  dataAttrNamespace,
+  legacyDataAttrNamespace,
+  cssVarNamespace,
+  legacyCssVarNamespace,
+  stableClassName,
+  legacyStableClassName,
+  dataAttr,
+  legacyDataAttr,
+  cssVar,
+  legacyCssVar,
+} from './naming';
+
+describe('naming constants', () => {
+  it('exposes the legacy and new namespace prefixes', () => {
+    expect(LEGACY_NAMESPACE).toBe('xds');
+    expect(NAMESPACE).toBe('astryx');
+  });
+
+  it('derives per-surface prefixes from the namespaces', () => {
+    expect(classPrefix).toBe('astryx');
+    expect(legacyClassPrefix).toBe('xds');
+    expect(dataAttrNamespace).toBe('astryx');
+    expect(legacyDataAttrNamespace).toBe('xds');
+    expect(cssVarNamespace).toBe('astryx');
+    expect(legacyCssVarNamespace).toBe('xds');
+  });
+});
+
+describe('stableClassName', () => {
+  it('builds new-namespace class tokens', () => {
+    expect(stableClassName('button')).toBe('astryx-button');
+    expect(stableClassName('card')).toBe('astryx-card');
+  });
+
+  it('builds legacy class tokens preserving the current contract', () => {
+    expect(legacyStableClassName('button')).toBe('xds-button');
+    expect(legacyStableClassName('card')).toBe('xds-card');
+  });
+});
+
+describe('dataAttr', () => {
+  it('builds new-namespace data attribute names', () => {
+    expect(dataAttr('theme')).toBe('data-astryx-theme');
+    expect(dataAttr('media')).toBe('data-astryx-media');
+  });
+
+  it('builds legacy data attribute names', () => {
+    expect(legacyDataAttr('theme')).toBe('data-xds-theme');
+    expect(legacyDataAttr('media')).toBe('data-xds-media');
+  });
+});
+
+describe('cssVar', () => {
+  it('builds new-namespace custom property names', () => {
+    expect(cssVar('card-padding')).toBe('--astryx-card-padding');
+  });
+
+  it('builds legacy custom property names', () => {
+    expect(legacyCssVar('card-padding')).toBe('--xds-card-padding');
+  });
+});

--- a/packages/core/src/naming.ts
+++ b/packages/core/src/naming.ts
@@ -1,0 +1,137 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file naming.ts
+ * @input None (pure constants/helpers)
+ * @output Centralized namespace-prefix constants and helpers for all
+ *   externally-observable XDS name surfaces: CSS classes, data attributes,
+ *   CSS custom properties, and CSS layer names.
+ * @position Single source of truth consumed by the runtime (components,
+ *   theme generation) AND by build/CLI tooling (build-theme.mjs, discovery)
+ *   via the `@xds/core/naming` subpath export.
+ *
+ * ## Why this module exists
+ *
+ * The literal string `xds` is part of several externally-observable contracts
+ * (`.xds-button` classes, `data-xds-theme` attributes, `--xds-card-padding`
+ * custom properties, `@layer xds-base`). Historically each of these was
+ * hardcoded independently across the runtime, the theme build pipeline, and
+ * discovery tooling, kept in sync only by `<!-- SYNC: ... -->` comments.
+ *
+ * The XDS-prefix migration (see P2380608025) removes the `XDS` prefix from
+ * React identifiers and rebrands the DOM/CSS namespace `xds` -> `astryx`.
+ * Centralizing the prefix here means the dual-emit compatibility layer and the
+ * eventual cutover flip in ONE place instead of hundreds of literals.
+ *
+ * ## Surfaces and their migration policy (locked in P0)
+ *
+ * - CSS classes (`xds-button` -> `astryx-button`): REBRAND. Dual-emit during
+ *   compat via {@link classPrefix} / {@link stableClassName}.
+ * - data attributes (`data-xds-*` -> `data-astryx-*`): REBRAND. Only 3 of 15
+ *   are consumer-observable and dual-emitted; the rest rename outright.
+ * - CSS custom properties (`--xds-card-padding` -> `--astryx-card-padding`):
+ *   REBRAND with an inverted read fallback so legacy overrides win during compat.
+ * - CSS layers (`xds-base` / `xds-theme`): UNCHANGED through the compat window
+ *   (a CSS layer cannot be aliased); renamed only at final cutover.
+ *
+ * SYNC: packages/core/src/utils/xdsThemeProps.ts (consumes classPrefix)
+ * SYNC: packages/core/src/utils/parseStyleKey.ts
+ * SYNC: packages/cli/src/commands/build-theme.mjs (imports @xds/core/naming)
+ */
+
+/**
+ * The current (legacy) DOM/CSS namespace prefix.
+ *
+ * This is the prefix that ships TODAY and that all existing consumer code
+ * targets (`.xds-button`, `data-xds-theme`, `--xds-card-padding`). It remains
+ * the emitted prefix until the new prefix is introduced behind the compat
+ * layer, and remains a *compat* prefix (dual-emitted / fallback-read) until the
+ * final cutover removes it.
+ */
+export const LEGACY_NAMESPACE = 'xds';
+
+/**
+ * The new DOM/CSS namespace prefix introduced by the un-prefix migration.
+ *
+ * During the compatibility window the library emits BOTH {@link NAMESPACE} and
+ * {@link LEGACY_NAMESPACE} forms for consumer-observable surfaces (classes,
+ * theme/media data attributes). At final cutover the legacy form is removed.
+ */
+export const NAMESPACE = 'astryx';
+
+/**
+ * Class-name prefix for stable component classes, WITHOUT the trailing dash.
+ *
+ * Use {@link stableClassName} to build a full class token rather than
+ * concatenating this directly.
+ */
+export const classPrefix = NAMESPACE;
+
+/** Legacy class-name prefix (compat). */
+export const legacyClassPrefix = LEGACY_NAMESPACE;
+
+/**
+ * data-attribute namespace segment (the part between `data-` and the rest).
+ * e.g. `dataAttrNamespace` = 'astryx' -> `data-astryx-theme`.
+ */
+export const dataAttrNamespace = NAMESPACE;
+
+/** Legacy data-attribute namespace segment (compat). */
+export const legacyDataAttrNamespace = LEGACY_NAMESPACE;
+
+/**
+ * CSS custom-property namespace segment.
+ * e.g. `--astryx-card-padding`.
+ */
+export const cssVarNamespace = NAMESPACE;
+
+/** Legacy CSS custom-property namespace segment (compat). */
+export const legacyCssVarNamespace = LEGACY_NAMESPACE;
+
+/**
+ * Build a stable component class token, e.g. `stableClassName('button')`
+ * -> `'astryx-button'`.
+ */
+export function stableClassName(component: string): string {
+  return `${classPrefix}-${component}`;
+}
+
+/**
+ * Build the legacy stable component class token (compat), e.g.
+ * `legacyStableClassName('button')` -> `'xds-button'`.
+ */
+export function legacyStableClassName(component: string): string {
+  return `${legacyClassPrefix}-${component}`;
+}
+
+/**
+ * Build a `data-*` attribute name in the current namespace, e.g.
+ * `dataAttr('theme')` -> `'data-astryx-theme'`.
+ */
+export function dataAttr(name: string): `data-${string}` {
+  return `data-${dataAttrNamespace}-${name}`;
+}
+
+/**
+ * Build a legacy `data-*` attribute name (compat), e.g.
+ * `legacyDataAttr('theme')` -> `'data-xds-theme'`.
+ */
+export function legacyDataAttr(name: string): `data-${string}` {
+  return `data-${legacyDataAttrNamespace}-${name}`;
+}
+
+/**
+ * Build a CSS custom-property name in the current namespace, e.g.
+ * `cssVar('card-padding')` -> `'--astryx-card-padding'`.
+ */
+export function cssVar(name: string): string {
+  return `--${cssVarNamespace}-${name}`;
+}
+
+/**
+ * Build a legacy CSS custom-property name (compat), e.g.
+ * `legacyCssVar('card-padding')` -> `'--xds-card-padding'`.
+ */
+export function legacyCssVar(name: string): string {
+  return `--${legacyCssVarNamespace}-${name}`;
+}

--- a/packages/core/src/utils/xdsThemeProps.ts
+++ b/packages/core/src/utils/xdsThemeProps.ts
@@ -1,5 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+import {legacyStableClassName} from '../naming';
+
 export type XDSClassValue = string | number | undefined | null;
 export type XDSClassProps = Record<string, XDSClassValue>;
 export type XDSThemeDataAttributes = Record<
@@ -26,6 +28,10 @@ function classTokenForPropValue(prop: string, value: string): string {
  * `data-size`, `data-level`, etc.) so consumers can migrate CSS selectors
  * away from collision-prone bare class names while old selectors keep working.
  *
+ * The `xds-`/`astryx-` prefix comes from the centralized naming module
+ * (`packages/core/src/naming.ts`) so the prefix migration flips in one place.
+ *
+ * <!-- SYNC: packages/core/src/naming.ts (namespace prefix source of truth) -->
  * <!-- SYNC: packages/cli/src/commands/build-theme.mjs (parseStyleKey + selector generation) -->
  * <!-- SYNC: packages/core/src/utils/parseStyleKey.ts -->
  *
@@ -50,7 +56,7 @@ function classTokenForPropValue(prop: string, value: string): string {
  * ```
  */
 function legacyClassName(component: string, props?: XDSClassProps): string {
-  const classes = [`xds-${component}`];
+  const classes = [legacyStableClassName(component)];
 
   if (props) {
     for (const [prop, value] of Object.entries(props)) {

--- a/scripts/sync-exports.js
+++ b/scripts/sync-exports.js
@@ -62,6 +62,11 @@ const STATIC_EXPORTS = {
     types: './src/tailwind-theme.css.d.ts',
     default: './src/tailwind-theme.css',
   },
+  './naming': {
+    source: './src/naming.ts',
+    types: './dist/naming.d.ts',
+    default: './dist/naming.js',
+  },
   './theme/tokens': {
     source: './src/theme/tokens.ts',
     types: './dist/theme/tokens.d.ts',
@@ -222,7 +227,7 @@ function main() {
 
   const dirs = discoverExportDirs();
   console.log(
-    `✓ Synced ${Object.keys(newExports).length} exports (${dirs.length} components/modules)`
+    `✓ Synced ${Object.keys(newExports).length} exports (${dirs.length} components/modules)`,
   );
 }
 


### PR DESCRIPTION
## Summary

First foundational step of the **XDS → Astryx prefix migration** (see paste P2380608025). Introduces a single source of truth for the externally-observable namespace prefix so the upcoming dual-emit compatibility layer and eventual cutover flip in **one place** instead of hundreds of hardcoded literals.

## What this does

- **Adds `packages/core/src/naming.ts`** — centralized namespace constants and helpers:
  - `NAMESPACE` (`astryx`) and `LEGACY_NAMESPACE` (`xds`)
  - `stableClassName` / `dataAttr` / `cssVar` (new namespace) and `legacy*` counterparts (compat)
- **Exports it via the `@xds/core/naming` subpath** so both the TS runtime (components, theme generation) and `.mjs` build/CLI tooling (`build-theme.mjs`, discovery) consume the same source of truth.
- **Refactors `xdsThemeProps()`** to build its stable class via `legacyStableClassName()`.

## Behavior-preserving

This changes **no emitted output**. `xdsThemeProps('button', …)` still produces `xds-button …` exactly as before — the prefix literal just moves into the centralized module. The dual-emit (both `xds-` and `astryx-` classes) lands in a later step once the compatibility layer is in place.

## Test plan

- `naming.test.ts` — 8 new tests covering all constants/helpers (legacy + new)
- Existing `xdsThemeProps.test.ts` (10 tests) unchanged and passing — proves zero behavior change
- Full `packages/core/src/utils/` suite: **163 tests passing**
- `tsc --noEmit` clean, eslint clean, `sync-exports --check` passes, SYNC-comment gate clean