### PR TITLE
docs(slop): full-rubric cleanup pass 2 - complete the hollow-intensifier + ellipsis fixes (5 files)

### DIFF
--- a/packages/cli/docs/typography.doc.mjs
+++ b/packages/cli/docs/typography.doc.mjs
@@ -22,7 +22,7 @@ export const docs = {
         },
         {
           type: 'prose',
-          text: 'Two layers work together: raw size tokens (--font-size-xs … --font-size-5xl) form the geometric scale, and semantic type scale tokens (--text-heading-1-size, --text-body-leading, etc.) reference them by var(). Themes override the entire scale by adjusting base and ratio in defineTheme; all semantic tokens recompute automatically.',
+          text: 'Two layers work together: raw size tokens (--font-size-xs ... --font-size-5xl) form the geometric scale, and semantic type scale tokens (--text-heading-1-size, --text-body-leading, etc.) reference them by var(). Themes override the entire scale by adjusting base and ratio in defineTheme; all semantic tokens recompute automatically.',
         },
       ],
     },

--- a/packages/core/src/DateTimeInput/DateTimeInput.doc.mjs
+++ b/packages/core/src/DateTimeInput/DateTimeInput.doc.mjs
@@ -150,7 +150,7 @@ export const docs = {
     bestPractices: [
       { guidance: true, description: 'Provide clear labels and descriptions so users understand what datetime is expected.' },
       { guidance: true, description: 'Use min and max to restrict selectable datetimes to valid ranges.' },
-      { guidance: true, description: 'Use hasClear when the datetime is optional so the user can easily reset it.' },
+      { guidance: true, description: 'Use hasClear when the datetime is optional so the user can reset it.' },
       { guidance: true, description: "Choose the hour format (12h or 24h) that matches your audience's locale." },
       { guidance: false, description: 'Use DateTimeInput when only a date is needed; use DateInput instead.' },
       { guidance: false, description: 'Use DateTimeInput when only a time is needed; use TimeInput instead.' },
@@ -177,7 +177,7 @@ export const docsZh = {
     bestPractices: [
       { guidance: true, description: 'Provide clear labels and descriptions so users understand what datetime is expected.' },
       { guidance: true, description: 'Use min and max to restrict selectable datetimes to valid ranges.' },
-      { guidance: true, description: 'Use hasClear when the datetime is optional so the user can easily reset it.' },
+      { guidance: true, description: 'Use hasClear when the datetime is optional so the user can reset it.' },
       { guidance: true, description: "Choose the hour format (12h or 24h) that matches your audience's locale." },
       { guidance: false, description: 'Use DateTimeInput when only a date is needed; use DateInput instead.' },
       { guidance: false, description: 'Use DateTimeInput when only a time is needed; use TimeInput instead.' },

--- a/packages/core/src/FileInput/FileInput.doc.mjs
+++ b/packages/core/src/FileInput/FileInput.doc.mjs
@@ -134,7 +134,7 @@ export const docs = {
       {guidance: true, description: 'Add a description to communicate constraints like file size limits or accepted formats.'},
       {guidance: true, description: 'Use changeAction for immediate upload workflows that benefit from optimistic UI.'},
       {guidance: false, description: "Don't use FileInput for directory or folder uploads; that is not supported in v1."},
-      {guidance: false, description: "Don't avoid dropzone mode unless space is very constrained; drag-and-drop is the expected interaction for file uploads."},
+      {guidance: false, description: "Don't avoid dropzone mode unless space is constrained; drag-and-drop is the expected interaction for file uploads."},
     ],
     anatomy: [
       {name: 'Label', required: true, description: 'Text that identifies the field. Always rendered for accessibility even when visually hidden.'},
@@ -247,7 +247,7 @@ export const docsZh = {
       {guidance: true, description: 'Use maxSize and maxFiles to prevent oversized uploads.'},
       {guidance: true, description: 'Add a description to communicate constraints.'},
       {guidance: false, description: "Don't use FileInput for directory uploads."},
-      {guidance: false, description: "Don't use mode='input' unless space is very constrained; dropzone mode provides a better experience."},
+      {guidance: false, description: "Don't use mode='input' unless space is constrained; dropzone mode provides a better experience."},
     ],
     anatomy: [
       {name: 'Label', required: true, description: 'Text identifying the field.'},
@@ -271,7 +271,7 @@ export const docsDense = {
       {guidance: true, description: 'Add a description to communicate constraints.'},
       {guidance: true, description: 'Use changeAction for immediate upload workflows that benefit from optimistic UI.'},
       {guidance: false, description: "Don't use FileInput for directory uploads."},
-      {guidance: false, description: "Don't use mode='input' unless space is very constrained; dropzone mode provides a better experience."},
+      {guidance: false, description: "Don't use mode='input' unless space is constrained; dropzone mode provides a better experience."},
     ],
     anatomy: [
       {name: 'Label', required: true, description: 'Text identifying the field.'},

--- a/packages/core/src/RadioList/RadioList.doc.mjs
+++ b/packages/core/src/RadioList/RadioList.doc.mjs
@@ -117,7 +117,7 @@ export const docs = {
     bestPractices: [
       { guidance: true, description: 'Keep the number of options small: typically 2 to 7 choices.' },
       { guidance: true, description: 'Use clear, concise labels that differentiate each option at a glance.' },
-      { guidance: true, description: "Pre-select a default option when there's a sensible default; don't leave the group empty unless the choice is truly optional." },
+      { guidance: true, description: "Pre-select a default option when there's a sensible default; don't leave the group empty unless the choice is optional." },
       { guidance: false, description: 'Use when multiple selections are needed; use CheckboxList instead.' },
       { guidance: false, description: 'Use for long lists; use Selector for better discoverability.' },
       { guidance: false, description: 'Use horizontal layout with more than 4 options; it wraps awkwardly.' },
@@ -138,7 +138,7 @@ export const docsZh = {
     bestPractices: [
       { guidance: true, description: 'Keep the number of options small: typically 2 to 7 choices.' },
       { guidance: true, description: 'Use clear, concise labels that differentiate each option at a glance.' },
-      { guidance: true, description: "Pre-select a default option when there's a sensible default; don't leave the group empty unless the choice is truly optional." },
+      { guidance: true, description: "Pre-select a default option when there's a sensible default; don't leave the group empty unless the choice is optional." },
       { guidance: false, description: 'Use when multiple selections are needed; use CheckboxList instead.' },
       { guidance: false, description: 'Use for long lists; use Selector for better discoverability.' },
       { guidance: false, description: 'Use horizontal layout with more than 4 options; it wraps awkwardly.' },
@@ -161,7 +161,7 @@ export const docsDense = {
     bestPractices: [
       { guidance: true, description: 'Keep the number of options small: typically 2 to 7 choices.' },
       { guidance: true, description: 'Use clear, concise labels that differentiate each option at a glance.' },
-      { guidance: true, description: "Pre-select a default option when there's a sensible default; don't leave the group empty unless the choice is truly optional." },
+      { guidance: true, description: "Pre-select a default option when there's a sensible default; don't leave the group empty unless the choice is optional." },
       { guidance: false, description: 'Use when multiple selections are needed; use CheckboxList instead.' },
       { guidance: false, description: 'Use for long lists; use Selector for better discoverability.' },
       { guidance: false, description: 'Use horizontal layout with more than 4 options; it wraps awkwardly.' },

--- a/packages/core/src/TextInput/TextInput.doc.mjs
+++ b/packages/core/src/TextInput/TextInput.doc.mjs
@@ -143,7 +143,7 @@ export const docs = {
       {guidance: true, description: 'Add a clear button for search and filter inputs so users can quickly reset without selecting all text.'},
       {guidance: false, description: "Don't use placeholder text as a replacement for a label; placeholders disappear on focus and are not reliably read by screen readers."},
       {guidance: false, description: "Don't use TextInput for multi-line content like comments or descriptions; use TextArea instead."},
-      {guidance: false, description: "Don't mark every field as required; only flag truly mandatory fields so users are not overwhelmed by validation errors."},
+      {guidance: false, description: "Don't mark every field as required; only flag mandatory fields so users are not overwhelmed by validation errors."},
     ],
     anatomy: [
       {name: 'Label', required: true, description: 'Text that identifies the field. Always rendered for accessibility even when visually hidden.'},
@@ -295,7 +295,7 @@ export const docsZh = {
       {guidance: true, description: 'Add a clear button for search and filter inputs so users can quickly reset without selecting all text.'},
       {guidance: false, description: "Don't use placeholder text as a replacement for a label; placeholders disappear on focus and are not reliably read by screen readers."},
       {guidance: false, description: "Don't use TextInput for multi-line content like comments or descriptions; use TextArea instead."},
-      {guidance: false, description: "Don't mark every field as required; only flag truly mandatory fields so users are not overwhelmed by validation errors."},
+      {guidance: false, description: "Don't mark every field as required; only flag mandatory fields so users are not overwhelmed by validation errors."},
     ],
     anatomy: [
       {name: 'Label', required: true, description: 'Text that identifies the field. Always rendered for accessibility even when visually hidden.'},
@@ -322,7 +322,7 @@ export const docsDense = {
       {guidance: true, description: 'Add a clear button for search and filter inputs so users can quickly reset without selecting all text.'},
       {guidance: false, description: "Don't use placeholder text as a replacement for a label; placeholders disappear on focus and are not reliably read by screen readers."},
       {guidance: false, description: "Don't use TextInput for multi-line content like comments or descriptions; use TextArea instead."},
-      {guidance: false, description: "Don't mark every field as required; only flag truly mandatory fields so users are not overwhelmed by validation errors."},
+      {guidance: false, description: "Don't mark every field as required; only flag mandatory fields so users are not overwhelmed by validation errors."},
     ],
     anatomy: [
       {name: 'Label', required: true, description: 'Text that identifies the field. Always rendered for accessibility even when visually hidden.'},


### PR DESCRIPTION
## What

Completes the full-rubric AI-slop cleanup. PR #2666 (pass 1) shipped incomplete: 5 files of hollow-intensifier and ellipsis fixes did not make it into the merged squash. This PR lands the remainder.

## Fixes (5 files, 12 changes)

| Category | Fix | Count |
|---|---|---|
| E hollow intensifier | `easily reset` to `reset` (DateTimeInput) | 2 |
| E hollow intensifier | `very constrained` to `constrained` (FileInput) | 3 |
| E hollow intensifier | `truly optional` to `optional` (RadioList) | 3 |
| E hollow intensifier | `truly mandatory` to `mandatory` (TextInput) | 3 |
| A5 ellipsis char | `xs … 5xl` to `xs ... 5xl` (typography) | 1 |

## Guarantees

- Meaning preserved; only filler words removed and one ellipsis character normalized.
- Em dashes on touched lines left intact (handled by the merged dash PRs; not duplicated here).
- Code and API terms untouched; prose strings only.
- All 4 changed `.doc.mjs` files parse via `import()`.

## Review

Human review required. No auto-merge.

---
Night Watch style: no AI-slop in this PR body either.
