### PR TITLE
feat(core): add unprefixed compatibility aliases (P1 compat layer)

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test:watch": "vitest",
     "test:coverage": "vitest --coverage",
     "check:package-boundaries": "node scripts/check-package-boundaries.js",
-    "check:repo": "pnpm check:sync && pnpm check:package-boundaries",
+    "check:repo": "pnpm check:sync && pnpm check:package-boundaries && pnpm compat:aliases:check",
     "check:sync": "node scripts/check-sync.js",
     "lint": "pnpm check:repo && eslint . --cache",
     "lint:strict": "pnpm check:repo && XDS_STRICT_LINT=1 eslint . --cache",
@@ -27,7 +27,9 @@
     "release": "pnpm build && changeset publish",
     "prepare": "husky install",
     "dev:sandbox": "pnpm -F @xds/core build && pnpm -F @xds/sandbox dev",
-    "dev:sandbox:source": "XDS_SOURCE=1 pnpm -F @xds/sandbox dev"
+    "dev:sandbox:source": "XDS_SOURCE=1 pnpm -F @xds/sandbox dev",
+    "compat:aliases": "node scripts/generate-compat-aliases.mjs",
+    "compat:aliases:check": "node scripts/generate-compat-aliases.mjs --check"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.11.3",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,7 +26,8 @@
   ],
   "type": "module",
   "bin": {
-    "xds": "./bin/xds.mjs"
+    "xds": "./bin/xds.mjs",
+    "astryx": "./bin/xds.mjs"
   },
   "exports": {
     ".": "./bin/xds.mjs",

--- a/packages/core/src/AlertDialog/index.ts
+++ b/packages/core/src/AlertDialog/index.ts
@@ -7,3 +7,19 @@ export type {XDSAlertDialogProps} from './XDSAlertDialog';
 
 export {useXDSImperativeAlertDialog} from './useXDSImperativeAlertDialog';
 export type {XDSImperativeAlertDialogReturn} from './useXDSImperativeAlertDialog';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSAlertDialog as AlertDialog,
+  useXDSImperativeAlertDialog as useImperativeAlertDialog,
+} from '.';
+export type {
+  XDSAlertDialogProps as AlertDialogProps,
+  XDSImperativeAlertDialogReturn as ImperativeAlertDialogReturn,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/AppShell/index.ts
+++ b/packages/core/src/AppShell/index.ts
@@ -24,3 +24,24 @@ export {
   XDSAppShellMobileContext,
 } from './XDSAppShellMobileContext';
 export type {XDSAppShellMobileContextValue} from './XDSAppShellMobileContext';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSAppShell as AppShell,
+  XDSAppShellMobileContext as AppShellMobileContext,
+  useXDSAppShellMobile as useAppShellMobile,
+} from '.';
+export type {
+  XDSAppShellBreakpoint as AppShellBreakpoint,
+  XDSAppShellMobileContextValue as AppShellMobileContextValue,
+  XDSAppShellProps as AppShellProps,
+  XDSAppShellVariant as AppShellVariant,
+  XDSAppShellVariantMap as AppShellVariantMap,
+  XDSMobileNavConfig as MobileNavConfig,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/AspectRatio/index.ts
+++ b/packages/core/src/AspectRatio/index.ts
@@ -13,3 +13,18 @@
 
 export {XDSAspectRatio} from './XDSAspectRatio';
 export type {XDSAspectRatioProps, XDSAspectRatioShape} from './XDSAspectRatio';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSAspectRatio as AspectRatio,
+} from '.';
+export type {
+  XDSAspectRatioProps as AspectRatioProps,
+  XDSAspectRatioShape as AspectRatioShape,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Avatar/index.ts
+++ b/packages/core/src/Avatar/index.ts
@@ -19,3 +19,22 @@ export type {
   XDSAvatarStatusDotVariant,
   XDSAvatarStatusDotVariantMap,
 } from './XDSAvatarStatusDot';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSAvatar as Avatar,
+  XDSAvatarStatusDot as AvatarStatusDot,
+} from '.';
+export type {
+  XDSAvatarProps as AvatarProps,
+  XDSAvatarSize as AvatarSize,
+  XDSAvatarStatusDotProps as AvatarStatusDotProps,
+  XDSAvatarStatusDotVariant as AvatarStatusDotVariant,
+  XDSAvatarStatusDotVariantMap as AvatarStatusDotVariantMap,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/AvatarGroup/index.ts
+++ b/packages/core/src/AvatarGroup/index.ts
@@ -18,3 +18,21 @@ export type {XDSAvatarGroupOverflowProps} from './XDSAvatarGroupOverflow';
 
 export {useXDSAvatarGroup} from './XDSAvatarGroupContext';
 export type {XDSAvatarGroupContextValue} from './XDSAvatarGroupContext';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSAvatarGroup as AvatarGroup,
+  XDSAvatarGroupOverflow as AvatarGroupOverflow,
+  useXDSAvatarGroup as useAvatarGroup,
+} from '.';
+export type {
+  XDSAvatarGroupContextValue as AvatarGroupContextValue,
+  XDSAvatarGroupOverflowProps as AvatarGroupOverflowProps,
+  XDSAvatarGroupProps as AvatarGroupProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Badge/index.ts
+++ b/packages/core/src/Badge/index.ts
@@ -17,3 +17,19 @@ export type {
   XDSBadgeVariant,
   XDSBadgeVariantMap,
 } from './XDSBadge';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSBadge as Badge,
+} from '.';
+export type {
+  XDSBadgeProps as BadgeProps,
+  XDSBadgeVariant as BadgeVariant,
+  XDSBadgeVariantMap as BadgeVariantMap,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Banner/index.ts
+++ b/packages/core/src/Banner/index.ts
@@ -19,3 +19,21 @@ export type {
   XDSBannerContainer,
   XDSBannerContainerMap,
 } from './XDSBanner';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSBanner as Banner,
+} from '.';
+export type {
+  XDSBannerContainer as BannerContainer,
+  XDSBannerContainerMap as BannerContainerMap,
+  XDSBannerProps as BannerProps,
+  XDSBannerStatus as BannerStatus,
+  XDSBannerStatusMap as BannerStatusMap,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Blockquote/index.ts
+++ b/packages/core/src/Blockquote/index.ts
@@ -13,3 +13,17 @@
 
 export {XDSBlockquote} from './XDSBlockquote';
 export type {XDSBlockquoteProps} from './XDSBlockquote';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSBlockquote as Blockquote,
+} from '.';
+export type {
+  XDSBlockquoteProps as BlockquoteProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Breadcrumbs/index.ts
+++ b/packages/core/src/Breadcrumbs/index.ts
@@ -14,3 +14,21 @@ export type {
 } from './XDSBreadcrumbs';
 export {XDSBreadcrumbItem} from './XDSBreadcrumbItem';
 export type {XDSBreadcrumbItemProps} from './XDSBreadcrumbItem';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSBreadcrumbItem as BreadcrumbItem,
+  XDSBreadcrumbs as Breadcrumbs,
+} from '.';
+export type {
+  XDSBreadcrumbItemProps as BreadcrumbItemProps,
+  XDSBreadcrumbsProps as BreadcrumbsProps,
+  XDSBreadcrumbsVariant as BreadcrumbsVariant,
+  XDSBreadcrumbsVariantMap as BreadcrumbsVariantMap,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Button/index.ts
+++ b/packages/core/src/Button/index.ts
@@ -18,3 +18,20 @@ export type {
   XDSButtonSize,
 } from './XDSButton';
 export type {XDSButtonVariantMap} from './XDSButton';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSButton as Button,
+} from '.';
+export type {
+  XDSButtonProps as ButtonProps,
+  XDSButtonSize as ButtonSize,
+  XDSButtonVariant as ButtonVariant,
+  XDSButtonVariantMap as ButtonVariantMap,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/ButtonGroup/index.ts
+++ b/packages/core/src/ButtonGroup/index.ts
@@ -17,3 +17,20 @@ export type {
   XDSButtonGroupOrientation,
   XDSButtonGroupContextValue,
 } from './XDSButtonGroupContext';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSButtonGroup as ButtonGroup,
+  useXDSButtonGroup as useButtonGroup,
+} from '.';
+export type {
+  XDSButtonGroupContextValue as ButtonGroupContextValue,
+  XDSButtonGroupOrientation as ButtonGroupOrientation,
+  XDSButtonGroupProps as ButtonGroupProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Calendar/index.ts
+++ b/packages/core/src/Calendar/index.ts
@@ -49,3 +49,17 @@ export {
 
 // Re-export theme styles for customization
 
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSCalendar as Calendar,
+} from '.';
+export type {
+  XDSCalendarHandle as CalendarHandle,
+  XDSCalendarProps as CalendarProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Card/index.ts
+++ b/packages/core/src/Card/index.ts
@@ -13,3 +13,18 @@
 
 export {XDSCard} from './XDSCard';
 export type {XDSCardProps, XDSCardVariant, SizeValue} from './XDSCard';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSCard as Card,
+} from '.';
+export type {
+  XDSCardProps as CardProps,
+  XDSCardVariant as CardVariant,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Carousel/index.ts
+++ b/packages/core/src/Carousel/index.ts
@@ -11,3 +11,17 @@
 
 export {XDSCarousel} from './XDSCarousel';
 export type {XDSCarouselProps} from './XDSCarousel';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSCarousel as Carousel,
+} from '.';
+export type {
+  XDSCarouselProps as CarouselProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Center/index.ts
+++ b/packages/core/src/Center/index.ts
@@ -13,3 +13,17 @@
 
 export {XDSCenter} from './XDSCenter';
 export type {XDSCenterProps, XDSCenterAxis, CenterAxis} from './XDSCenter';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSCenter as Center,
+} from '.';
+export type {
+  XDSCenterProps as CenterProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Chat/index.ts
+++ b/packages/core/src/Chat/index.ts
@@ -111,3 +111,63 @@ export type {
 
 export {XDSChatDictationButton} from './XDSChatDictationButton';
 export type {XDSChatDictationButtonProps} from './XDSChatDictationButton';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSChatComposer as ChatComposer,
+  XDSChatComposerDrawer as ChatComposerDrawer,
+  XDSChatComposerInput as ChatComposerInput,
+  XDSChatComposerTokenElement as ChatComposerTokenElement,
+  XDSChatDictationButton as ChatDictationButton,
+  XDSChatLayout as ChatLayout,
+  XDSChatLayoutScrollButton as ChatLayoutScrollButton,
+  XDSChatMessage as ChatMessage,
+  XDSChatMessageBubble as ChatMessageBubble,
+  XDSChatMessageList as ChatMessageList,
+  XDSChatMessageMetadata as ChatMessageMetadata,
+  XDSChatSendButton as ChatSendButton,
+  XDSChatSystemMessage as ChatSystemMessage,
+  XDSChatTokenizedText as ChatTokenizedText,
+  XDSChatToolCalls as ChatToolCalls,
+  useXDSChatComposerTokens as useChatComposerTokens,
+  useXDSChatDictation as useChatDictation,
+  useXDSChatLayoutContext as useChatLayoutContext,
+  useXDSChatNewMessages as useChatNewMessages,
+  useXDSChatPasteAsToken as useChatPasteAsToken,
+  useXDSChatStreamScroll as useChatStreamScroll,
+} from '.';
+export type {
+  XDSChatComposerDensity as ChatComposerDensity,
+  XDSChatComposerDrawerProps as ChatComposerDrawerProps,
+  XDSChatComposerInputHandle as ChatComposerInputHandle,
+  XDSChatComposerInputProps as ChatComposerInputProps,
+  XDSChatComposerProps as ChatComposerProps,
+  XDSChatComposerStatus as ChatComposerStatus,
+  XDSChatComposerToken as ChatComposerToken,
+  XDSChatComposerTrigger as ChatComposerTrigger,
+  XDSChatComposerTriggerItem as ChatComposerTriggerItem,
+  XDSChatDensity as ChatDensity,
+  XDSChatDictationButtonProps as ChatDictationButtonProps,
+  XDSChatLayoutProps as ChatLayoutProps,
+  XDSChatLayoutScrollButtonProps as ChatLayoutScrollButtonProps,
+  XDSChatMessageBubbleProps as ChatMessageBubbleProps,
+  XDSChatMessageBubbleVariant as ChatMessageBubbleVariant,
+  XDSChatMessageListProps as ChatMessageListProps,
+  XDSChatMessageMetadataProps as ChatMessageMetadataProps,
+  XDSChatMessageProps as ChatMessageProps,
+  XDSChatMessageSender as ChatMessageSender,
+  XDSChatMessageStatus as ChatMessageStatus,
+  XDSChatSendButtonProps as ChatSendButtonProps,
+  XDSChatSystemMessageProps as ChatSystemMessageProps,
+  XDSChatSystemMessageVariant as ChatSystemMessageVariant,
+  XDSChatTokenizedTextProps as ChatTokenizedTextProps,
+  XDSChatToolCallItem as ChatToolCallItem,
+  XDSChatToolCallStatus as ChatToolCallStatus,
+  XDSChatToolCallsProps as ChatToolCallsProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/CheckboxInput/index.ts
+++ b/packages/core/src/CheckboxInput/index.ts
@@ -16,3 +16,18 @@ export type {
   XDSCheckboxInputProps,
   XDSCheckboxInputSize,
 } from './XDSCheckboxInput';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSCheckboxInput as CheckboxInput,
+} from '.';
+export type {
+  XDSCheckboxInputProps as CheckboxInputProps,
+  XDSCheckboxInputSize as CheckboxInputSize,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/CheckboxList/index.ts
+++ b/packages/core/src/CheckboxList/index.ts
@@ -15,3 +15,19 @@ export {XDSCheckboxList} from './XDSCheckboxList';
 export type {XDSCheckboxListProps} from './XDSCheckboxList';
 export {XDSCheckboxListItem} from './XDSCheckboxListItem';
 export type {XDSCheckboxListItemProps} from './XDSCheckboxListItem';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSCheckboxList as CheckboxList,
+  XDSCheckboxListItem as CheckboxListItem,
+} from '.';
+export type {
+  XDSCheckboxListItemProps as CheckboxListItemProps,
+  XDSCheckboxListProps as CheckboxListProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Citation/index.ts
+++ b/packages/core/src/Citation/index.ts
@@ -11,3 +11,18 @@
 
 export {XDSCitation} from './XDSCitation';
 export type {XDSCitationProps, XDSCitationSource} from './XDSCitation';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSCitation as Citation,
+} from '.';
+export type {
+  XDSCitationProps as CitationProps,
+  XDSCitationSource as CitationSource,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/ClickableCard/index.ts
+++ b/packages/core/src/ClickableCard/index.ts
@@ -13,3 +13,17 @@
 
 export {XDSClickableCard} from './XDSClickableCard';
 export type {XDSClickableCardProps} from './XDSClickableCard';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSClickableCard as ClickableCard,
+} from '.';
+export type {
+  XDSClickableCardProps as ClickableCardProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Code/index.ts
+++ b/packages/core/src/Code/index.ts
@@ -8,3 +8,17 @@
  */
 
 export {XDSCode, type XDSCodeProps} from './XDSCode';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSCode as Code,
+} from '.';
+export type {
+  XDSCodeProps as CodeProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/CodeBlock/index.ts
+++ b/packages/core/src/CodeBlock/index.ts
@@ -33,3 +33,19 @@ export {
   cleanupRanges,
 } from './highlightRanges';
 export {ensureHighlightStyles, TOKEN_TYPES} from './highlightStyles';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSCode as Code,
+  XDSCodeBlock as CodeBlock,
+} from '.';
+export type {
+  XDSCodeBlockProps as CodeBlockProps,
+  XDSCodeProps as CodeProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Collapsible/index.ts
+++ b/packages/core/src/Collapsible/index.ts
@@ -23,3 +23,21 @@ export type {
   UseXDSCollapsibleOptions,
   UseXDSCollapsibleReturn,
 } from './useXDSCollapsible';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSCollapsible as Collapsible,
+  XDSCollapsibleGroup as CollapsibleGroup,
+  useXDSCollapsible as useCollapsible,
+} from '.';
+export type {
+  XDSCollapsibleConfig as CollapsibleConfig,
+  XDSCollapsibleGroupProps as CollapsibleGroupProps,
+  XDSCollapsibleProps as CollapsibleProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/CommandPalette/index.ts
+++ b/packages/core/src/CommandPalette/index.ts
@@ -34,3 +34,29 @@ export type {XDSCommandPaletteEmptyProps} from './XDSCommandPaletteEmpty';
 
 export {useCommandPaletteContext} from './CommandPaletteContext';
 export type {CommandPaletteContextValue} from './CommandPaletteContext';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSCommandPalette as CommandPalette,
+  XDSCommandPaletteEmpty as CommandPaletteEmpty,
+  XDSCommandPaletteFooter as CommandPaletteFooter,
+  XDSCommandPaletteGroup as CommandPaletteGroup,
+  XDSCommandPaletteInput as CommandPaletteInput,
+  XDSCommandPaletteItem as CommandPaletteItem,
+  XDSCommandPaletteList as CommandPaletteList,
+} from '.';
+export type {
+  XDSCommandPaletteEmptyProps as CommandPaletteEmptyProps,
+  XDSCommandPaletteFooterProps as CommandPaletteFooterProps,
+  XDSCommandPaletteGroupProps as CommandPaletteGroupProps,
+  XDSCommandPaletteInputProps as CommandPaletteInputProps,
+  XDSCommandPaletteItemProps as CommandPaletteItemProps,
+  XDSCommandPaletteListProps as CommandPaletteListProps,
+  XDSCommandPaletteProps as CommandPaletteProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/ContextMenu/index.ts
+++ b/packages/core/src/ContextMenu/index.ts
@@ -20,3 +20,23 @@ export {
   XDSDropdownMenuItem as XDSContextMenuItem,
   type XDSDropdownMenuItemProps as XDSContextMenuItemProps,
 } from '../DropdownMenu/XDSDropdownMenuItem';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSContextMenu as ContextMenu,
+  XDSContextMenuItem as ContextMenuItem,
+} from '.';
+export type {
+  XDSContextMenuDivider as ContextMenuDivider,
+  XDSContextMenuItemData as ContextMenuItemData,
+  XDSContextMenuItemProps as ContextMenuItemProps,
+  XDSContextMenuOption as ContextMenuOption,
+  XDSContextMenuProps as ContextMenuProps,
+  XDSContextMenuSection as ContextMenuSection,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/DateInput/index.ts
+++ b/packages/core/src/DateInput/index.ts
@@ -16,3 +16,20 @@ export type {
   XDSDateInputStatus,
   XDSDateInputStatusType,
 } from './XDSDateInput';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSDateInput as DateInput,
+} from '.';
+export type {
+  XDSDateInputProps as DateInputProps,
+  XDSDateInputSize as DateInputSize,
+  XDSDateInputStatus as DateInputStatus,
+  XDSDateInputStatusType as DateInputStatusType,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/DateRangeInput/index.ts
+++ b/packages/core/src/DateRangeInput/index.ts
@@ -18,3 +18,20 @@ export type {
   XDSDateRange,
   XDSDateRangePreset,
 } from './XDSDateRangeInput';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSDateRangeInput as DateRangeInput,
+} from '.';
+export type {
+  XDSDateRangeInputProps as DateRangeInputProps,
+  XDSDateRangeInputSize as DateRangeInputSize,
+  XDSDateRangeInputStatus as DateRangeInputStatus,
+  XDSDateRangeInputStatusType as DateRangeInputStatusType,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/DateTimeInput/index.ts
+++ b/packages/core/src/DateTimeInput/index.ts
@@ -18,3 +18,21 @@ export type {
   XDSDateTimeInputStatusType,
   ISODateTimeString,
 } from './XDSDateTimeInput';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSDateTimeInput as DateTimeInput,
+} from '.';
+export type {
+  XDSDateTimeInputHourFormat as DateTimeInputHourFormat,
+  XDSDateTimeInputProps as DateTimeInputProps,
+  XDSDateTimeInputSize as DateTimeInputSize,
+  XDSDateTimeInputStatus as DateTimeInputStatus,
+  XDSDateTimeInputStatusType as DateTimeInputStatusType,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Dialog/index.ts
+++ b/packages/core/src/Dialog/index.ts
@@ -25,3 +25,25 @@ export type {XDSDialogHeaderProps} from './XDSDialogHeader';
 
 export {useXDSImperativeDialog} from './useXDSImperativeDialog';
 export type {XDSImperativeDialogReturn} from './useXDSImperativeDialog';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSDialog as Dialog,
+  XDSDialogHeader as DialogHeader,
+  useXDSImperativeDialog as useImperativeDialog,
+} from '.';
+export type {
+  XDSDialogHeaderProps as DialogHeaderProps,
+  XDSDialogPosition as DialogPosition,
+  XDSDialogProps as DialogProps,
+  XDSDialogPurpose as DialogPurpose,
+  XDSDialogVariant as DialogVariant,
+  XDSDialogVariantMap as DialogVariantMap,
+  XDSImperativeDialogReturn as ImperativeDialogReturn,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Divider/index.ts
+++ b/packages/core/src/Divider/index.ts
@@ -17,3 +17,19 @@ export type {
   XDSDividerVariant,
   XDSDividerVariantMap,
 } from './XDSDivider';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSDivider as Divider,
+} from '.';
+export type {
+  XDSDividerProps as DividerProps,
+  XDSDividerVariant as DividerVariant,
+  XDSDividerVariantMap as DividerVariantMap,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/DropdownMenu/index.ts
+++ b/packages/core/src/DropdownMenu/index.ts
@@ -22,3 +22,24 @@ export {
   XDSDropdownMenuItem,
   type XDSDropdownMenuItemProps,
 } from './XDSDropdownMenuItem';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSDropdownMenu as DropdownMenu,
+  XDSDropdownMenuItem as DropdownMenuItem,
+} from '.';
+export type {
+  XDSDropdownMenuButtonProps as DropdownMenuButtonProps,
+  XDSDropdownMenuDivider as DropdownMenuDivider,
+  XDSDropdownMenuItemData as DropdownMenuItemData,
+  XDSDropdownMenuItemProps as DropdownMenuItemProps,
+  XDSDropdownMenuOption as DropdownMenuOption,
+  XDSDropdownMenuProps as DropdownMenuProps,
+  XDSDropdownMenuSection as DropdownMenuSection,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/EmptyState/index.ts
+++ b/packages/core/src/EmptyState/index.ts
@@ -6,3 +6,17 @@
 
 export {XDSEmptyState} from './XDSEmptyState';
 export type {XDSEmptyStateProps} from './XDSEmptyState';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSEmptyState as EmptyState,
+} from '.';
+export type {
+  XDSEmptyStateProps as EmptyStateProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Field/index.ts
+++ b/packages/core/src/Field/index.ts
@@ -40,3 +40,29 @@ export {
 
 // Shared input components
 export {XDSInputClearButton} from './XDSInputClearButton';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSField as Field,
+  XDSFieldLabel as FieldLabel,
+  XDSFieldStatus as FieldStatus,
+  XDSInputClearButton as InputClearButton,
+} from '.';
+export type {
+  XDSFieldLabelProps as FieldLabelProps,
+  XDSFieldProps as FieldProps,
+  XDSFieldStatusInput as FieldStatusInput,
+  XDSFieldStatusProps as FieldStatusProps,
+  XDSFieldStatusType as FieldStatusType,
+  XDSFieldStatusVariant as FieldStatusVariant,
+  XDSFieldStatusVariantMap as FieldStatusVariantMap,
+  XDSInputSize as InputSize,
+  XDSInputStatus as InputStatus,
+  XDSInputStatusType as InputStatusType,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/FieldStatus/index.ts
+++ b/packages/core/src/FieldStatus/index.ts
@@ -15,3 +15,19 @@ export type {
   XDSFieldStatusVariant,
   XDSFieldStatusVariantMap,
 } from './XDSFieldStatus';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSFieldStatus as FieldStatus,
+} from '.';
+export type {
+  XDSFieldStatusProps as FieldStatusProps,
+  XDSFieldStatusVariant as FieldStatusVariant,
+  XDSFieldStatusVariantMap as FieldStatusVariantMap,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/FileInput/index.ts
+++ b/packages/core/src/FileInput/index.ts
@@ -17,3 +17,19 @@ export type {
   XDSFileInputStatus,
   XDSFileInputStatusType,
 } from './XDSFileInput';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSFileInput as FileInput,
+} from '.';
+export type {
+  XDSFileInputProps as FileInputProps,
+  XDSFileInputStatus as FileInputStatus,
+  XDSFileInputStatusType as FileInputStatusType,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/FormLayout/index.ts
+++ b/packages/core/src/FormLayout/index.ts
@@ -15,3 +15,19 @@ export {XDSFormLayout} from './XDSFormLayout';
 export type {XDSFormLayoutProps} from './XDSFormLayout';
 export type {XDSFormLayoutDirection} from './XDSFormLayoutContext';
 export {XDSFormLayoutContext} from './XDSFormLayoutContext';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSFormLayout as FormLayout,
+  XDSFormLayoutContext as FormLayoutContext,
+} from '.';
+export type {
+  XDSFormLayoutDirection as FormLayoutDirection,
+  XDSFormLayoutProps as FormLayoutProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Grid/index.ts
+++ b/packages/core/src/Grid/index.ts
@@ -16,3 +16,20 @@ export type {XDSGridProps, XDSGridColumns, GridAlignment} from './XDSGrid';
 
 export {XDSGridSpan} from './XDSGridSpan';
 export type {XDSGridSpanProps} from './XDSGridSpan';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSGrid as Grid,
+  XDSGridSpan as GridSpan,
+} from '.';
+export type {
+  XDSGridColumns as GridColumns,
+  XDSGridProps as GridProps,
+  XDSGridSpanProps as GridSpanProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/HStack/index.ts
+++ b/packages/core/src/HStack/index.ts
@@ -8,3 +8,17 @@
  */
 
 export {XDSHStack, type XDSHStackProps} from './XDSHStack';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSHStack as HStack,
+} from '.';
+export type {
+  XDSHStackProps as HStackProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Heading/index.ts
+++ b/packages/core/src/Heading/index.ts
@@ -13,3 +13,18 @@ export {
   type XDSHeadingLevel,
   type XDSHeadingType,
 } from './XDSHeading';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSHeading as Heading,
+} from '.';
+export type {
+  XDSHeadingProps as HeadingProps,
+  XDSHeadingType as HeadingType,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/HoverCard/index.ts
+++ b/packages/core/src/HoverCard/index.ts
@@ -22,3 +22,20 @@ export type {
 // HoverCard component
 export {XDSHoverCard} from './XDSHoverCard';
 export type {XDSHoverCardProps} from './XDSHoverCard';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSHoverCard as HoverCard,
+  useXDSHoverCard as useHoverCard,
+} from '.';
+export type {
+  XDSHoverCardOptions as HoverCardOptions,
+  XDSHoverCardProps as HoverCardProps,
+  XDSHoverCardReturn as HoverCardReturn,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Icon/index.ts
+++ b/packages/core/src/Icon/index.ts
@@ -27,3 +27,22 @@ export {
   resetIcons,
 } from './globalIconRegistry';
 export type {XDSIconName, XDSIconRegistry} from './globalIconRegistry';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSIcon as Icon,
+} from '.';
+export type {
+  XDSIconColor as IconColor,
+  XDSIconName as IconName,
+  XDSIconProps as IconProps,
+  XDSIconRegistry as IconRegistry,
+  XDSIconSize as IconSize,
+  XDSIconType as IconType,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/IconButton/index.ts
+++ b/packages/core/src/IconButton/index.ts
@@ -13,3 +13,17 @@
 
 export {XDSIconButton} from './XDSIconButton';
 export type {XDSIconButtonProps} from './XDSIconButton';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSIconButton as IconButton,
+} from '.';
+export type {
+  XDSIconButtonProps as IconButtonProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/InputGroup/index.ts
+++ b/packages/core/src/InputGroup/index.ts
@@ -16,3 +16,21 @@ export {XDSInputGroupText} from './XDSInputGroupText';
 export type {XDSInputGroupTextProps} from './XDSInputGroupText';
 
 export {useXDSInputGroup} from './XDSInputGroupContext';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSInputGroup as InputGroup,
+  XDSInputGroupText as InputGroupText,
+  useXDSInputGroup as useInputGroup,
+} from '.';
+export type {
+  XDSInputGroupProps as InputGroupProps,
+  XDSInputGroupSize as InputGroupSize,
+  XDSInputGroupTextProps as InputGroupTextProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/InteractiveRoleContext/index.ts
+++ b/packages/core/src/InteractiveRoleContext/index.ts
@@ -13,3 +13,15 @@ export {
   XDSInteractiveRoleContext,
   useXDSInteractiveRoleContext,
 } from './XDSInteractiveRoleContext';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSInteractiveRoleContext as InteractiveRoleContext,
+  useXDSInteractiveRoleContext as useInteractiveRoleContext,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Item/index.ts
+++ b/packages/core/src/Item/index.ts
@@ -11,3 +11,19 @@
 
 export {XDSItem} from './XDSItem';
 export type {XDSItemProps, XDSItemAlign, XDSItemDensity} from './XDSItem';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSItem as Item,
+} from '.';
+export type {
+  XDSItemAlign as ItemAlign,
+  XDSItemDensity as ItemDensity,
+  XDSItemProps as ItemProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Kbd/index.ts
+++ b/packages/core/src/Kbd/index.ts
@@ -9,3 +9,17 @@
 
 export {XDSKbd} from './XDSKbd';
 export type {XDSKbdProps} from './XDSKbd';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSKbd as Kbd,
+} from '.';
+export type {
+  XDSKbdProps as KbdProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Layer/index.ts
+++ b/packages/core/src/Layer/index.ts
@@ -63,3 +63,34 @@ export type {
   XDSTooltipReturn,
   XDSTooltipProps,
 } from '../Tooltip';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSHoverCard as HoverCard,
+  XDSLayerContext as LayerContext,
+  XDSLayerProvider as LayerProvider,
+  XDSPopover as Popover,
+  XDSTooltip as Tooltip,
+  useXDSHoverCard as useHoverCard,
+  useXDSLayer as useLayer,
+  useXDSLayerContext as useLayerContext,
+  useXDSPopover as usePopover,
+  useXDSTooltip as useTooltip,
+} from '.';
+export type {
+  XDSHoverCardOptions as HoverCardOptions,
+  XDSHoverCardProps as HoverCardProps,
+  XDSHoverCardReturn as HoverCardReturn,
+  XDSLayerContextValue as LayerContextValue,
+  XDSLayerProviderProps as LayerProviderProps,
+  XDSPopoverProps as PopoverProps,
+  XDSTooltipOptions as TooltipOptions,
+  XDSTooltipProps as TooltipProps,
+  XDSTooltipReturn as TooltipReturn,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Layout/index.ts
+++ b/packages/core/src/Layout/index.ts
@@ -81,3 +81,41 @@ export type {LayoutArea} from './XDSLayoutAreaContext';
 
 export {XDSLayoutDividerContext} from './XDSLayoutDividerContext';
 export type {LayoutDividerContextValue} from './XDSLayoutDividerContext';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSCard as Card,
+  XDSHStack as HStack,
+  XDSLayout as Layout,
+  XDSLayoutAreaContext as LayoutAreaContext,
+  XDSLayoutContent as LayoutContent,
+  XDSLayoutDividerContext as LayoutDividerContext,
+  XDSLayoutFooter as LayoutFooter,
+  XDSLayoutHeader as LayoutHeader,
+  XDSLayoutPanel as LayoutPanel,
+  XDSSection as Section,
+  XDSStack as Stack,
+  XDSStackItem as StackItem,
+  XDSVStack as VStack,
+} from '.';
+export type {
+  XDSCardProps as CardProps,
+  XDSHStackProps as HStackProps,
+  XDSLayoutContentProps as LayoutContentProps,
+  XDSLayoutFooterProps as LayoutFooterProps,
+  XDSLayoutHeaderProps as LayoutHeaderProps,
+  XDSLayoutHeight as LayoutHeight,
+  XDSLayoutPanelProps as LayoutPanelProps,
+  XDSLayoutProps as LayoutProps,
+  XDSSectionProps as SectionProps,
+  XDSSectionVariant as SectionVariant,
+  XDSStackItemProps as StackItemProps,
+  XDSStackProps as StackProps,
+  XDSVStackProps as VStackProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Lightbox/index.ts
+++ b/packages/core/src/Lightbox/index.ts
@@ -21,3 +21,20 @@ export type {
   UseXDSLightboxOptions,
   UseXDSLightboxReturn,
 } from './useXDSLightbox';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSLightbox as Lightbox,
+  useXDSLightbox as useLightbox,
+} from '.';
+export type {
+  XDSLightboxMedia as LightboxMedia,
+  XDSLightboxMediaType as LightboxMediaType,
+  XDSLightboxProps as LightboxProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Link/index.ts
+++ b/packages/core/src/Link/index.ts
@@ -23,3 +23,22 @@ export type {XDSLinkComponentType} from './types';
 
 export {useXDSLinkify} from './useXDSLinkify';
 export type {LinkifyPattern, UseXDSLinkifyOptions} from './useXDSLinkify';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSLink as Link,
+  XDSLinkProvider as LinkProvider,
+  useXDSLinkComponent as useLinkComponent,
+  useXDSLinkify as useLinkify,
+} from '.';
+export type {
+  XDSLinkComponentType as LinkComponentType,
+  XDSLinkProps as LinkProps,
+  XDSLinkProviderProps as LinkProviderProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/List/index.ts
+++ b/packages/core/src/List/index.ts
@@ -15,3 +15,21 @@ export {XDSList} from './XDSList';
 export type {XDSListProps, XDSListStyle, XDSListDensity} from './XDSList';
 export {XDSListItem} from './XDSListItem';
 export type {XDSListItemProps} from './XDSListItem';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSList as List,
+  XDSListItem as ListItem,
+} from '.';
+export type {
+  XDSListDensity as ListDensity,
+  XDSListItemProps as ListItemProps,
+  XDSListProps as ListProps,
+  XDSListStyle as ListStyle,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Markdown/index.ts
+++ b/packages/core/src/Markdown/index.ts
@@ -9,7 +9,12 @@
  */
 
 export {XDSMarkdown} from './XDSMarkdown';
-export type {XDSMarkdownProps, XDSMarkdownSource, XDSMarkdownComponents, MarkdownInlinePlugin} from './XDSMarkdown';
+export type {
+  XDSMarkdownProps,
+  XDSMarkdownSource,
+  XDSMarkdownComponents,
+  MarkdownInlinePlugin,
+} from './XDSMarkdown';
 
 export {
   parseMarkdown,
@@ -25,3 +30,19 @@ export type {
   TableAlignment,
   IncrementalState as IncrementalParseState,
 } from './parser';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSMarkdown as Markdown,
+} from '.';
+export type {
+  XDSMarkdownComponents as MarkdownComponents,
+  XDSMarkdownProps as MarkdownProps,
+  XDSMarkdownSource as MarkdownSource,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/MetadataList/index.ts
+++ b/packages/core/src/MetadataList/index.ts
@@ -19,3 +19,21 @@ export type {
 export {XDSMetadataListItem} from './XDSMetadataListItem';
 export type {XDSMetadataListItemProps} from './XDSMetadataListItem';
 export type {XDSMetadataListLabelConfig} from './XDSMetadataListContext';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSMetadataList as MetadataList,
+  XDSMetadataListItem as MetadataListItem,
+} from '.';
+export type {
+  XDSMetadataListColumns as MetadataListColumns,
+  XDSMetadataListItemProps as MetadataListItemProps,
+  XDSMetadataListLabelConfig as MetadataListLabelConfig,
+  XDSMetadataListProps as MetadataListProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/MobileNav/index.ts
+++ b/packages/core/src/MobileNav/index.ts
@@ -13,3 +13,19 @@ export {XDSMobileNav} from './XDSMobileNav';
 export type {XDSMobileNavProps} from './XDSMobileNav';
 export {XDSMobileNavToggle} from './XDSMobileNavToggle';
 export type {XDSMobileNavToggleProps} from './XDSMobileNavToggle';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSMobileNav as MobileNav,
+  XDSMobileNavToggle as MobileNavToggle,
+} from '.';
+export type {
+  XDSMobileNavProps as MobileNavProps,
+  XDSMobileNavToggleProps as MobileNavToggleProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/MoreMenu/index.ts
+++ b/packages/core/src/MoreMenu/index.ts
@@ -9,3 +9,17 @@
  */
 
 export {XDSMoreMenu, type XDSMoreMenuProps} from './XDSMoreMenu';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSMoreMenu as MoreMenu,
+} from '.';
+export type {
+  XDSMoreMenuProps as MoreMenuProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/MultiSelector/index.ts
+++ b/packages/core/src/MultiSelector/index.ts
@@ -22,3 +22,24 @@ export type {
   XDSMultiSelectorStatus,
 } from './types';
 export {useMultiCombobox} from './hooks';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSMultiSelector as MultiSelector,
+} from '.';
+export type {
+  XDSMultiSelectorDivider as MultiSelectorDivider,
+  XDSMultiSelectorOptionData as MultiSelectorOptionData,
+  XDSMultiSelectorOptionType as MultiSelectorOptionType,
+  XDSMultiSelectorProps as MultiSelectorProps,
+  XDSMultiSelectorSection as MultiSelectorSection,
+  XDSMultiSelectorSize as MultiSelectorSize,
+  XDSMultiSelectorStatus as MultiSelectorStatus,
+  XDSMultiSelectorStatusType as MultiSelectorStatusType,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/NavIcon/index.ts
+++ b/packages/core/src/NavIcon/index.ts
@@ -11,3 +11,17 @@
 
 export {XDSNavIcon} from './XDSNavIcon';
 export type {XDSNavIconProps} from './XDSNavIcon';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSNavIcon as NavIcon,
+} from '.';
+export type {
+  XDSNavIconProps as NavIconProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/NavMenu/index.ts
+++ b/packages/core/src/NavMenu/index.ts
@@ -20,3 +20,28 @@ export type {
 // Backward compat — use XDSNavHeadingMenuItem instead.
 export {XDSNavMenuItem} from './XDSNavMenuItem';
 export type {XDSNavMenuItemProps} from './XDSNavMenuItem';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSNavHeadingCloseContext as NavHeadingCloseContext,
+  XDSNavHeadingMenu as NavHeadingMenu,
+  XDSNavHeadingMenuContext as NavHeadingMenuContext,
+  XDSNavHeadingMenuItem as NavHeadingMenuItem,
+  XDSNavMenuItem as NavMenuItem,
+  useXDSNavHeadingCloseContext as useNavHeadingCloseContext,
+  useXDSNavHeadingMenuContext as useNavHeadingMenuContext,
+} from '.';
+export type {
+  XDSNavHeadingCloseContextValue as NavHeadingCloseContextValue,
+  XDSNavHeadingMenuContextValue as NavHeadingMenuContextValue,
+  XDSNavHeadingMenuItemProps as NavHeadingMenuItemProps,
+  XDSNavHeadingMenuProps as NavHeadingMenuProps,
+  XDSNavHeadingMenuSize as NavHeadingMenuSize,
+  XDSNavMenuItemProps as NavMenuItemProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/NumberInput/index.ts
+++ b/packages/core/src/NumberInput/index.ts
@@ -18,3 +18,20 @@ export type {
   XDSNumberInputStatus,
   XDSNumberInputStatusType,
 } from './XDSNumberInput';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSNumberInput as NumberInput,
+} from '.';
+export type {
+  XDSNumberInputProps as NumberInputProps,
+  XDSNumberInputSize as NumberInputSize,
+  XDSNumberInputStatus as NumberInputStatus,
+  XDSNumberInputStatusType as NumberInputStatusType,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Outline/index.ts
+++ b/packages/core/src/Outline/index.ts
@@ -17,3 +17,17 @@ export type {OutlineItem} from './types';
 export {parseOutlineFromMarkdown} from './parseOutlineFromMarkdown';
 export {useOutlineFromMarkdown} from './useOutlineFromMarkdown';
 export {useOutlineFromDOM} from './useOutlineFromDOM';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSOutline as Outline,
+} from '.';
+export type {
+  XDSOutlineProps as OutlineProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/OverflowList/index.ts
+++ b/packages/core/src/OverflowList/index.ts
@@ -8,3 +8,18 @@
 
 export {XDSOverflowList} from './XDSOverflowList';
 export type {XDSOverflowListProps, XDSOverflowItem} from './XDSOverflowList';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSOverflowList as OverflowList,
+} from '.';
+export type {
+  XDSOverflowItem as OverflowItem,
+  XDSOverflowListProps as OverflowListProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Overlay/index.ts
+++ b/packages/core/src/Overlay/index.ts
@@ -17,3 +17,18 @@ export type {
   OverlayAlign,
   OverlayShowOn,
 } from './OverlayScrim';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSOverlay as Overlay,
+  useXDSOverlay as useOverlay,
+} from '.';
+export type {
+  XDSOverlayProps as OverlayProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Pagination/index.ts
+++ b/packages/core/src/Pagination/index.ts
@@ -16,3 +16,20 @@ export type {
   XDSPaginationVariantMap,
   XDSPaginationSize,
 } from './XDSPagination';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSPagination as Pagination,
+} from '.';
+export type {
+  XDSPaginationProps as PaginationProps,
+  XDSPaginationSize as PaginationSize,
+  XDSPaginationVariant as PaginationVariant,
+  XDSPaginationVariantMap as PaginationVariantMap,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Popover/index.ts
+++ b/packages/core/src/Popover/index.ts
@@ -18,3 +18,18 @@ export type {UseXDSPopoverOptions, UseXDSPopoverReturn} from './useXDSPopover';
 // Popover component
 export {XDSPopover} from './XDSPopover';
 export type {XDSPopoverProps, PopoverTriggerRenderProps} from './XDSPopover';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSPopover as Popover,
+  useXDSPopover as usePopover,
+} from '.';
+export type {
+  XDSPopoverProps as PopoverProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/PowerSearch/index.ts
+++ b/packages/core/src/PowerSearch/index.ts
@@ -84,3 +84,22 @@ export type {
   PowerSearchComponentOverride,
   XDSPowerSearchComponents,
 } from './types';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSPowerSearch as PowerSearch,
+  XDSPowerSearchFilterEditor as PowerSearchFilterEditor,
+  XDSPowerSearchToken as PowerSearchToken,
+} from '.';
+export type {
+  XDSPowerSearchComponents as PowerSearchComponents,
+  XDSPowerSearchHandle as PowerSearchHandle,
+  XDSPowerSearchProps as PowerSearchProps,
+  XDSPowerSearchSize as PowerSearchSize,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/ProgressBar/index.ts
+++ b/packages/core/src/ProgressBar/index.ts
@@ -12,3 +12,19 @@ export type {
   XDSProgressBarVariant,
   XDSProgressBarVariantMap,
 } from './XDSProgressBar';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSProgressBar as ProgressBar,
+} from '.';
+export type {
+  XDSProgressBarProps as ProgressBarProps,
+  XDSProgressBarVariant as ProgressBarVariant,
+  XDSProgressBarVariantMap as ProgressBarVariantMap,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/RadioList/index.ts
+++ b/packages/core/src/RadioList/index.ts
@@ -19,3 +19,22 @@ export type {
 } from './XDSRadioList';
 export {XDSRadioListItem} from './XDSRadioListItem';
 export type {XDSRadioListItemProps} from './XDSRadioListItem';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSRadioList as RadioList,
+  XDSRadioListContext as RadioListContext,
+  XDSRadioListItem as RadioListItem,
+} from '.';
+export type {
+  XDSRadioListContextValue as RadioListContextValue,
+  XDSRadioListItemProps as RadioListItemProps,
+  XDSRadioListProps as RadioListProps,
+  XDSRadioListSize as RadioListSize,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Resizable/index.ts
+++ b/packages/core/src/Resizable/index.ts
@@ -21,3 +21,19 @@ export type {
 
 export {XDSResizeHandle} from './XDSResizeHandle';
 export type {XDSResizeHandleProps} from './XDSResizeHandle';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSResizeHandle as ResizeHandle,
+  useXDSResizable as useResizable,
+} from '.';
+export type {
+  XDSResizableConfig as ResizableConfig,
+  XDSResizeHandleProps as ResizeHandleProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Section/index.ts
+++ b/packages/core/src/Section/index.ts
@@ -17,3 +17,19 @@ export type {
   XDSSectionVariant,
   XDSSectionVariantMap,
 } from './XDSSection';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSSection as Section,
+} from '.';
+export type {
+  XDSSectionProps as SectionProps,
+  XDSSectionVariant as SectionVariant,
+  XDSSectionVariantMap as SectionVariantMap,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/SegmentedControl/index.ts
+++ b/packages/core/src/SegmentedControl/index.ts
@@ -17,4 +17,25 @@ export type {XDSSegmentedControlProps} from './XDSSegmentedControl';
 export {XDSSegmentedControlItem} from './XDSSegmentedControlItem';
 export type {XDSSegmentedControlItemProps} from './XDSSegmentedControlItem';
 
-export type {XDSSegmentedControlSize, XDSSegmentedControlLayout} from './XDSSegmentedControlContext';
+export type {
+  XDSSegmentedControlSize,
+  XDSSegmentedControlLayout,
+} from './XDSSegmentedControlContext';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSSegmentedControl as SegmentedControl,
+  XDSSegmentedControlItem as SegmentedControlItem,
+} from '.';
+export type {
+  XDSSegmentedControlItemProps as SegmentedControlItemProps,
+  XDSSegmentedControlLayout as SegmentedControlLayout,
+  XDSSegmentedControlProps as SegmentedControlProps,
+  XDSSegmentedControlSize as SegmentedControlSize,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/SelectableCard/index.ts
+++ b/packages/core/src/SelectableCard/index.ts
@@ -2,3 +2,17 @@
 
 export {XDSSelectableCard} from './XDSSelectableCard';
 export type {XDSSelectableCardProps} from './XDSSelectableCard';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSSelectableCard as SelectableCard,
+} from '.';
+export type {
+  XDSSelectableCardProps as SelectableCardProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Selector/index.ts
+++ b/packages/core/src/Selector/index.ts
@@ -23,3 +23,25 @@ export type {
   XDSSelectorSection,
 } from './types';
 export {useCombobox, useSelectedItemOffset} from './hooks';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSSelector as Selector,
+  XDSSelectorOption as SelectorOption,
+} from '.';
+export type {
+  XDSSelectorDivider as SelectorDivider,
+  XDSSelectorOptionData as SelectorOptionData,
+  XDSSelectorOptionType as SelectorOptionType,
+  XDSSelectorProps as SelectorProps,
+  XDSSelectorSection as SelectorSection,
+  XDSSelectorSize as SelectorSize,
+  XDSSelectorStatus as SelectorStatus,
+  XDSSelectorStatusType as SelectorStatusType,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/SideNav/index.ts
+++ b/packages/core/src/SideNav/index.ts
@@ -37,3 +37,31 @@ export {
   useXDSSideNavRenderMode,
 } from './XDSSideNavRenderContext';
 export type {XDSSideNavRenderMode} from './XDSSideNavRenderContext';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSSideNav as SideNav,
+  XDSSideNavCollapseButton as SideNavCollapseButton,
+  XDSSideNavHeading as SideNavHeading,
+  XDSSideNavItem as SideNavItem,
+  XDSSideNavRenderContext as SideNavRenderContext,
+  XDSSideNavSection as SideNavSection,
+  useXDSSideNavCollapse as useSideNavCollapse,
+  useXDSSideNavRenderMode as useSideNavRenderMode,
+} from '.';
+export type {
+  XDSSideNavCollapseButtonProps as SideNavCollapseButtonProps,
+  XDSSideNavCollapseState as SideNavCollapseState,
+  XDSSideNavHeadingProps as SideNavHeadingProps,
+  XDSSideNavImperativeCollapseHandle as SideNavImperativeCollapseHandle,
+  XDSSideNavItemProps as SideNavItemProps,
+  XDSSideNavProps as SideNavProps,
+  XDSSideNavRenderMode as SideNavRenderMode,
+  XDSSideNavSectionProps as SideNavSectionProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/SizeContext/index.ts
+++ b/packages/core/src/SizeContext/index.ts
@@ -13,3 +13,19 @@ export {
   useXDSSize,
   type XDSElementSize,
 } from './XDSSizeContext';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSSizeContext as SizeContext,
+  XDSSizeProvider as SizeProvider,
+  useXDSSize as useSize,
+} from '.';
+export type {
+  XDSElementSize as ElementSize,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Skeleton/index.ts
+++ b/packages/core/src/Skeleton/index.ts
@@ -13,3 +13,18 @@
 
 export {XDSSkeleton} from './XDSSkeleton';
 export type {XDSSkeletonProps, XDSSkeletonRadius} from './XDSSkeleton';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSSkeleton as Skeleton,
+} from '.';
+export type {
+  XDSSkeletonProps as SkeletonProps,
+  XDSSkeletonRadius as SkeletonRadius,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Slider/index.ts
+++ b/packages/core/src/Slider/index.ts
@@ -18,3 +18,20 @@ export type {
   XDSSliderSingleProps,
   XDSSliderRangeProps,
 } from './XDSSlider';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSSlider as Slider,
+} from '.';
+export type {
+  XDSSliderBaseProps as SliderBaseProps,
+  XDSSliderProps as SliderProps,
+  XDSSliderRangeProps as SliderRangeProps,
+  XDSSliderSingleProps as SliderSingleProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Spinner/index.ts
+++ b/packages/core/src/Spinner/index.ts
@@ -17,3 +17,19 @@ export type {
   XDSSpinnerSize,
   XDSSpinnerShade,
 } from './XDSSpinner';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSSpinner as Spinner,
+} from '.';
+export type {
+  XDSSpinnerProps as SpinnerProps,
+  XDSSpinnerShade as SpinnerShade,
+  XDSSpinnerSize as SpinnerSize,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Stack/index.ts
+++ b/packages/core/src/Stack/index.ts
@@ -24,3 +24,23 @@ export {XDSVStack, type XDSVStackProps} from '../VStack';
 
 export {XDSStackItem} from './XDSStackItem';
 export type {XDSStackItemProps} from './XDSStackItem';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSHStack as HStack,
+  XDSStack as Stack,
+  XDSStackItem as StackItem,
+  XDSVStack as VStack,
+} from '.';
+export type {
+  XDSHStackProps as HStackProps,
+  XDSStackItemProps as StackItemProps,
+  XDSStackProps as StackProps,
+  XDSVStackProps as VStackProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/StatusDot/index.ts
+++ b/packages/core/src/StatusDot/index.ts
@@ -15,3 +15,19 @@ export type {
   XDSStatusDotVariant,
   XDSStatusDotVariantMap,
 } from './XDSStatusDot';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSStatusDot as StatusDot,
+} from '.';
+export type {
+  XDSStatusDotProps as StatusDotProps,
+  XDSStatusDotVariant as StatusDotVariant,
+  XDSStatusDotVariantMap as StatusDotVariantMap,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Switch/index.ts
+++ b/packages/core/src/Switch/index.ts
@@ -17,3 +17,19 @@ export type {
   XDSSwitchLabelPosition,
   XDSSwitchLabelSpacing,
 } from './XDSSwitch';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSSwitch as Switch,
+} from '.';
+export type {
+  XDSSwitchLabelPosition as SwitchLabelPosition,
+  XDSSwitchLabelSpacing as SwitchLabelSpacing,
+  XDSSwitchProps as SwitchProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/TabList/index.ts
+++ b/packages/core/src/TabList/index.ts
@@ -22,3 +22,25 @@ export type {XDSTabMenuProps, XDSTabMenuOption} from './XDSTabMenu';
 
 export {useXDSTabListContext} from './XDSTabListContext';
 export type {XDSTabListSize, XDSTabListLayout} from './XDSTabListContext';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSTab as Tab,
+  XDSTabList as TabList,
+  XDSTabMenu as TabMenu,
+  useXDSTabListContext as useTabListContext,
+} from '.';
+export type {
+  XDSTabListLayout as TabListLayout,
+  XDSTabListProps as TabListProps,
+  XDSTabListSize as TabListSize,
+  XDSTabMenuOption as TabMenuOption,
+  XDSTabMenuProps as TabMenuProps,
+  XDSTabProps as TabProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Table/index.ts
+++ b/packages/core/src/Table/index.ts
@@ -100,3 +100,59 @@ export type {
   XDSTableFilterValue,
   XDSTableFilterFieldRef,
 } from './plugins/filtering';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSTable as Table,
+  XDSTableBody as TableBody,
+  XDSTableCell as TableCell,
+  XDSTableContext as TableContext,
+  XDSTableFooter as TableFooter,
+  XDSTableHeader as TableHeader,
+  XDSTableHeaderCell as TableHeaderCell,
+  XDSTableRow as TableRow,
+  useXDSBaseTablePlugins as useBaseTablePlugins,
+  useXDSTableColumnResize as useTableColumnResize,
+  useXDSTableColumnSettings as useTableColumnSettings,
+  useXDSTableColumnSettingsState as useTableColumnSettingsState,
+  useXDSTableFilterState as useTableFilterState,
+  useXDSTableFiltering as useTableFiltering,
+  useXDSTablePagination as useTablePagination,
+  useXDSTableSelection as useTableSelection,
+  useXDSTableSelectionState as useTableSelectionState,
+  useXDSTableSortable as useTableSortable,
+  useXDSTableSortableState as useTableSortableState,
+} from '.';
+export type {
+  XDSBaseTableProps as BaseTableProps,
+  XDSColumnSettingsOption as ColumnSettingsOption,
+  XDSTableBodyProps as TableBodyProps,
+  XDSTableCellProps as TableCellProps,
+  XDSTableColumn as TableColumn,
+  XDSTableColumnAlign as TableColumnAlign,
+  XDSTableContextValue as TableContextValue,
+  XDSTableDensity as TableDensity,
+  XDSTableDividers as TableDividers,
+  XDSTableFilterFieldRef as TableFilterFieldRef,
+  XDSTableFilterState as TableFilterState,
+  XDSTableFilterValue as TableFilterValue,
+  XDSTableFilterVariant as TableFilterVariant,
+  XDSTableFooterProps as TableFooterProps,
+  XDSTableHeaderCellProps as TableHeaderCellProps,
+  XDSTableHeaderProps as TableHeaderProps,
+  XDSTableProps as TableProps,
+  XDSTableRowProps as TableRowProps,
+  XDSTableSortComparator as TableSortComparator,
+  XDSTableSortDirection as TableSortDirection,
+  XDSTableSortEntry as TableSortEntry,
+  XDSTableSortState as TableSortState,
+  XDSTableSortableColumnConfig as TableSortableColumnConfig,
+  XDSTableTextOverflow as TableTextOverflow,
+  XDSTableVerticalAlign as TableVerticalAlign,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Text/index.ts
+++ b/packages/core/src/Text/index.ts
@@ -38,3 +38,29 @@ export {
   type UseTruncationOptions,
   type UseTruncationReturn,
 } from './useTruncation';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSHeading as Heading,
+  XDSText as Text,
+} from '.';
+export type {
+  XDSHeadingProps as HeadingProps,
+  XDSHeadingType as HeadingType,
+  XDSTextColor as TextColor,
+  XDSTextDisplay as TextDisplay,
+  XDSTextJustify as TextJustify,
+  XDSTextProps as TextProps,
+  XDSTextSize as TextSize,
+  XDSTextType as TextType,
+  XDSTextWeight as TextWeight,
+  XDSTextWrap as TextWrap,
+  XDSTextXStyleAllowed as TextXStyleAllowed,
+  XDSWordBreak as WordBreak,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/TextArea/index.ts
+++ b/packages/core/src/TextArea/index.ts
@@ -18,3 +18,20 @@ export type {
   XDSTextAreaStatusType,
   XDSTextAreaSize,
 } from './XDSTextArea';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSTextArea as TextArea,
+} from '.';
+export type {
+  XDSTextAreaProps as TextAreaProps,
+  XDSTextAreaSize as TextAreaSize,
+  XDSTextAreaStatus as TextAreaStatus,
+  XDSTextAreaStatusType as TextAreaStatusType,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/TextInput/index.ts
+++ b/packages/core/src/TextInput/index.ts
@@ -19,3 +19,21 @@ export type {
   XDSTextInputStatus,
   XDSTextInputStatusType,
 } from './XDSTextInput';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSTextInput as TextInput,
+} from '.';
+export type {
+  XDSTextInputProps as TextInputProps,
+  XDSTextInputSize as TextInputSize,
+  XDSTextInputStatus as TextInputStatus,
+  XDSTextInputStatusType as TextInputStatusType,
+  XDSTextInputType as TextInputType,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Thumbnail/index.ts
+++ b/packages/core/src/Thumbnail/index.ts
@@ -8,3 +8,17 @@
 
 export {XDSThumbnail} from './XDSThumbnail';
 export type {XDSThumbnailProps} from './XDSThumbnail';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSThumbnail as Thumbnail,
+} from '.';
+export type {
+  XDSThumbnailProps as ThumbnailProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/TimeInput/index.ts
+++ b/packages/core/src/TimeInput/index.ts
@@ -20,3 +20,21 @@ export type {
   XDSTimeInputStatusType,
 } from './XDSTimeInput';
 export type {ISOTimeString} from '../utils';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSTimeInput as TimeInput,
+} from '.';
+export type {
+  XDSTimeInputHourFormat as TimeInputHourFormat,
+  XDSTimeInputProps as TimeInputProps,
+  XDSTimeInputSize as TimeInputSize,
+  XDSTimeInputStatus as TimeInputStatus,
+  XDSTimeInputStatusType as TimeInputStatusType,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Timestamp/index.ts
+++ b/packages/core/src/Timestamp/index.ts
@@ -13,3 +13,18 @@
 
 export {XDSTimestamp} from './XDSTimestamp';
 export type {XDSTimestampProps, XDSTimestampFormat} from './XDSTimestamp';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSTimestamp as Timestamp,
+} from '.';
+export type {
+  XDSTimestampFormat as TimestampFormat,
+  XDSTimestampProps as TimestampProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Toast/index.ts
+++ b/packages/core/src/Toast/index.ts
@@ -21,3 +21,27 @@ export type {XDSToastViewportProps} from './XDSToastViewport';
 // Exported for inline rendering in previews and documentation
 export {XDSToast} from './XDSToast';
 export type {XDSToastProps} from './XDSToast';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSToast as Toast,
+  XDSToastViewport as ToastViewport,
+  useXDSToast as useToast,
+} from '.';
+export type {
+  XDSShowToastFn as ShowToastFn,
+  XDSToastCollisionBehavior as ToastCollisionBehavior,
+  XDSToastDismissFn as ToastDismissFn,
+  XDSToastDismissReason as ToastDismissReason,
+  XDSToastOptions as ToastOptions,
+  XDSToastPosition as ToastPosition,
+  XDSToastProps as ToastProps,
+  XDSToastType as ToastType,
+  XDSToastViewportProps as ToastViewportProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/ToggleButton/index.ts
+++ b/packages/core/src/ToggleButton/index.ts
@@ -18,3 +18,21 @@ export type {
   XDSToggleButtonGroupSingleProps,
   XDSToggleButtonGroupMultipleProps,
 } from './XDSToggleButtonGroup';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSToggleButton as ToggleButton,
+  XDSToggleButtonGroup as ToggleButtonGroup,
+} from '.';
+export type {
+  XDSToggleButtonGroupMultipleProps as ToggleButtonGroupMultipleProps,
+  XDSToggleButtonGroupProps as ToggleButtonGroupProps,
+  XDSToggleButtonGroupSingleProps as ToggleButtonGroupSingleProps,
+  XDSToggleButtonProps as ToggleButtonProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Token/index.ts
+++ b/packages/core/src/Token/index.ts
@@ -13,3 +13,16 @@
 
 export {XDSToken} from './XDSToken';
 export type {XDSTokenProps, XDSTokenColor, XDSTokenSize} from './XDSToken';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export type {
+  XDSTokenColor as TokenColor,
+  XDSTokenProps as TokenProps,
+  XDSTokenSize as TokenSize,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Tokenizer/index.ts
+++ b/packages/core/src/Tokenizer/index.ts
@@ -21,3 +21,23 @@ export type {
   XDSTokenizerStatus,
   XDSTokenizerStatusType,
 } from './XDSTokenizer';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSTokenizer as Tokenizer,
+} from '.';
+export type {
+  XDSTokenizerChange as TokenizerChange,
+  XDSTokenizerHandle as TokenizerHandle,
+  XDSTokenizerOverflowBehavior as TokenizerOverflowBehavior,
+  XDSTokenizerProps as TokenizerProps,
+  XDSTokenizerSize as TokenizerSize,
+  XDSTokenizerStatus as TokenizerStatus,
+  XDSTokenizerStatusType as TokenizerStatusType,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Toolbar/index.ts
+++ b/packages/core/src/Toolbar/index.ts
@@ -13,3 +13,18 @@
 
 export {XDSToolbar} from './XDSToolbar';
 export type {XDSToolbarProps, XDSToolbarSize} from './XDSToolbar';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSToolbar as Toolbar,
+} from '.';
+export type {
+  XDSToolbarProps as ToolbarProps,
+  XDSToolbarSize as ToolbarSize,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Tooltip/index.ts
+++ b/packages/core/src/Tooltip/index.ts
@@ -22,3 +22,20 @@ export type {
 // Tooltip component
 export {XDSTooltip} from './XDSTooltip';
 export type {XDSTooltipProps} from './XDSTooltip';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSTooltip as Tooltip,
+  useXDSTooltip as useTooltip,
+} from '.';
+export type {
+  XDSTooltipOptions as TooltipOptions,
+  XDSTooltipProps as TooltipProps,
+  XDSTooltipReturn as TooltipReturn,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/TopNav/index.ts
+++ b/packages/core/src/TopNav/index.ts
@@ -37,3 +37,33 @@ export {
   useXDSTopNavRenderMode,
 } from './XDSTopNavRenderContext';
 export type {XDSTopNavRenderMode} from './XDSTopNavRenderContext';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSTopNav as TopNav,
+  XDSTopNavHeading as TopNavHeading,
+  XDSTopNavItem as TopNavItem,
+  XDSTopNavMegaMenu as TopNavMegaMenu,
+  XDSTopNavMegaMenuFeaturedCard as TopNavMegaMenuFeaturedCard,
+  XDSTopNavMegaMenuItem as TopNavMegaMenuItem,
+  XDSTopNavMenu as TopNavMenu,
+  XDSTopNavRenderContext as TopNavRenderContext,
+  useXDSTopNavRenderMode as useTopNavRenderMode,
+} from '.';
+export type {
+  XDSTopNavHeadingProps as TopNavHeadingProps,
+  XDSTopNavItemProps as TopNavItemProps,
+  XDSTopNavMegaMenuFeaturedCardProps as TopNavMegaMenuFeaturedCardProps,
+  XDSTopNavMegaMenuItemProps as TopNavMegaMenuItemProps,
+  XDSTopNavMegaMenuProps as TopNavMegaMenuProps,
+  XDSTopNavMenuItemData as TopNavMenuItemData,
+  XDSTopNavMenuProps as TopNavMenuProps,
+  XDSTopNavProps as TopNavProps,
+  XDSTopNavRenderMode as TopNavRenderMode,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/TreeList/index.ts
+++ b/packages/core/src/TreeList/index.ts
@@ -14,3 +14,19 @@
 export {XDSTreeList} from './XDSTreeList';
 export type {XDSTreeListProps, XDSTreeListDensity} from './XDSTreeList';
 export type {XDSTreeListItemData} from './XDSTreeListTypes';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSTreeList as TreeList,
+} from '.';
+export type {
+  XDSTreeListDensity as TreeListDensity,
+  XDSTreeListItemData as TreeListItemData,
+  XDSTreeListProps as TreeListProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Typeahead/index.ts
+++ b/packages/core/src/Typeahead/index.ts
@@ -34,3 +34,26 @@ export type {
 // Typeahead item
 export {XDSTypeaheadItem} from './XDSTypeaheadItem';
 export type {XDSTypeaheadItemProps} from './XDSTypeaheadItem';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSBaseTypeahead as BaseTypeahead,
+  XDSTypeahead as Typeahead,
+  XDSTypeaheadItem as TypeaheadItem,
+} from '.';
+export type {
+  XDSBaseTypeaheadProps as BaseTypeaheadProps,
+  XDSSearchSource as SearchSource,
+  XDSSearchableItem as SearchableItem,
+  XDSTypeaheadItemProps as TypeaheadItemProps,
+  XDSTypeaheadProps as TypeaheadProps,
+  XDSTypeaheadSize as TypeaheadSize,
+  XDSTypeaheadStatus as TypeaheadStatus,
+  XDSTypeaheadStatusType as TypeaheadStatusType,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/VStack/index.ts
+++ b/packages/core/src/VStack/index.ts
@@ -8,3 +8,17 @@
  */
 
 export {XDSVStack, type XDSVStackProps} from './XDSVStack';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSVStack as VStack,
+} from '.';
+export type {
+  XDSVStackProps as VStackProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/compat-aliases.test.tsx
+++ b/packages/core/src/compat-aliases.test.tsx
@@ -1,0 +1,65 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file compat-aliases.test.tsx
+ * @description Verifies the XDS-prefix migration compatibility layer: bare
+ *   (unprefixed) aliases resolve to the SAME runtime values and TS types as
+ *   the prefixed XDS* exports, and the module-augmentation interface alias is
+ *   still augmentable. See P2380608025.
+ */
+
+import {describe, it, expect, expectTypeOf} from 'vitest';
+import * as Core from './index';
+import {Button, XDSButton, Card, XDSCard, useXDSTheme, useTheme} from './index';
+import type {
+  ButtonProps,
+  XDSButtonProps,
+  ButtonVariant,
+  XDSButtonVariant,
+} from './index';
+
+describe('compat aliases: runtime value identity', () => {
+  it('bare component aliases are the SAME value as the prefixed exports', () => {
+    expect(Button).toBe(XDSButton);
+    expect(Card).toBe(XDSCard);
+  });
+
+  it('bare hook aliases are the SAME value as the prefixed hooks', () => {
+    expect(useTheme).toBe(useXDSTheme);
+  });
+
+  it('a representative spread of bare aliases are exported from the root barrel', () => {
+    for (const name of [
+      'Button',
+      'Card',
+      'Text',
+      'Heading',
+      'Dialog',
+      'Table',
+      'Theme',
+      'useTheme',
+    ]) {
+      expect(Core, `@xds/core should export bare "${name}"`).toHaveProperty(
+        name,
+      );
+    }
+  });
+
+  it('keeps the prefixed exports working unchanged', () => {
+    for (const name of ['XDSButton', 'XDSCard', 'XDSTheme', 'useXDSTheme']) {
+      expect(Core, `@xds/core should still export "${name}"`).toHaveProperty(
+        name,
+      );
+    }
+  });
+});
+
+describe('compat aliases: type identity', () => {
+  it('bare prop type alias equals the prefixed prop type', () => {
+    expectTypeOf<ButtonProps>().toEqualTypeOf<XDSButtonProps>();
+  });
+
+  it('bare variant union alias equals the prefixed union', () => {
+    expectTypeOf<ButtonVariant>().toEqualTypeOf<XDSButtonVariant>();
+  });
+});

--- a/packages/core/src/hooks/index.ts
+++ b/packages/core/src/hooks/index.ts
@@ -55,3 +55,18 @@ export type {
   XDSInteractiveRole,
   UseXDSInteractiveRoleOptions,
 } from './useXDSInteractiveRole';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  useXDSInteractiveRole as useInteractiveRole,
+  useXDSStreamingText as useStreamingText,
+} from '.';
+export type {
+  XDSInteractiveRole as InteractiveRole,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/theme/index.ts
+++ b/packages/core/src/theme/index.ts
@@ -159,3 +159,40 @@ export type {
   TypographyRole,
   FontWeight,
 } from './types';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSMediaTheme as MediaTheme,
+  XDSTheme as Theme,
+  XDSThemeContext as ThemeContext,
+  useXDSSyntaxTheme as useSyntaxTheme,
+  useXDSTheme as useTheme,
+} from '.';
+export type {
+  XDSBuiltinTextType as BuiltinTextType,
+  XDSColorScaleConfig as ColorScaleConfig,
+  XDSComponentStyleMap as ComponentStyleMap,
+  XDSCoreTokenName as CoreTokenName,
+  XDSCustomTextTypes as CustomTextTypes,
+  XDSDefineThemeInput as DefineThemeInput,
+  XDSDefinedTheme as DefinedTheme,
+  XDSMediaThemeProps as MediaThemeProps,
+  XDSMotionScaleConfig as MotionScaleConfig,
+  XDSRadiusScaleConfig as RadiusScaleConfig,
+  XDSResolvedThemeMode as ResolvedThemeMode,
+  XDSStyleOverrides as StyleOverrides,
+  XDSTextColor as TextColor,
+  XDSTextSize as TextSize,
+  XDSTextType as TextType,
+  XDSTextWeight as TextWeight,
+  XDSThemeContextValue as ThemeContextValue,
+  XDSTokenName as TokenName,
+  XDSTokenValue as TokenValue,
+  XDSTypeScaleConfig as TypeScaleConfig,
+} from '.';
+// <compat-aliases:end>

--- a/scripts/generate-compat-aliases.mjs
+++ b/scripts/generate-compat-aliases.mjs
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+/**
+ * @file generate-compat-aliases.mjs
+ * @description Codegen for the XDS-prefix migration compatibility layer
+ *   (P2380608025). Appends unprefixed alias re-exports alongside the
+ *   existing XDS* exports in component barrel files (index.ts).
+ *
+ *   Idempotent: strips the old generated block, re-generates from scratch.
+ *   Skips aliases whose bare name already exists in the barrel.
+ *
+ *   Usage:
+ *     node scripts/generate-compat-aliases.mjs           # write in place
+ *     node scripts/generate-compat-aliases.mjs --check   # exit 1 if stale
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SRC = path.resolve(__dirname, '../packages/core/src');
+const MARKER_START = '// <compat-aliases:start> — generated, do not edit by hand';
+const MARKER_END = '// <compat-aliases:end>';
+
+/** Strip block + line comments from TS source. */
+function stripComments(txt) {
+  return txt.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*/g, '');
+}
+
+/**
+ * Parse all export statements from a barrel file into structured entries.
+ * Returns [{name, alias?, source, isType}] where `name` is the imported
+ * identifier, `alias` is the exported name (if renamed), and `source` is
+ * the module specifier string.
+ */
+function parseExportEntries(txt) {
+  const clean = stripComments(txt);
+  const entries = [];
+  // Matches: export [type] { ... } from '...'
+  // Also inline: export { X, type Y } from '...'
+  const re = /export\s+(type\s+)?\{([^}]*)\}\s*from\s*['"]([^'"]+)['"]/g;
+  let m;
+  while ((m = re.exec(clean))) {
+    const blockIsType = Boolean(m[1]);
+    const specifiers = m[2];
+    const source = m[3];
+    for (let part of specifiers.split(',')) {
+      part = part.trim();
+      if (!part) continue;
+      let isType = blockIsType;
+      if (part.startsWith('type ')) {
+        isType = true;
+        part = part.slice(5).trim();
+      }
+      let name, alias;
+      if (part.includes(' as ')) {
+        [name, alias] = part.split(/\s+as\s+/);
+      } else {
+        name = part;
+        alias = part;
+      }
+      entries.push({name: name.trim(), alias: alias.trim(), source, isType});
+    }
+  }
+  return entries;
+}
+
+/** Compute the bare (unprefixed) name for an XDS* or useXDS* identifier. */
+function bareName(id) {
+  if (id.startsWith('useXDS')) return 'use' + id.slice(6);
+  if (id.startsWith('XDS')) return id.slice(3);
+  return null;
+}
+
+/**
+ * Pre-pass: collect bare (non-XDS) names already exported by ANY barrel.
+ * The root barrel uses `export *`, so a generated bare alias that duplicates
+ * an existing bare export elsewhere causes TS2308 ambiguity. We skip those.
+ */
+function collectExistingBareNames() {
+  const bare = new Set();
+  for (const entry of fs.readdirSync(SRC, {withFileTypes: true})) {
+    if (!entry.isDirectory()) continue;
+    const idx = path.join(SRC, entry.name, 'index.ts');
+    if (!fs.existsSync(idx)) continue;
+    let raw = fs.readFileSync(idx, 'utf8');
+    // Only look at the human-authored part (strip any generated block) so we
+    // don't treat previously-generated aliases as "existing".
+    if (raw.includes(MARKER_START)) raw = raw.slice(0, raw.indexOf(MARKER_START));
+    for (const e of parseExportEntries(raw)) {
+      if (!e.alias.startsWith('XDS') && !e.alias.startsWith('useXDS')) {
+        bare.add(e.alias);
+      }
+    }
+  }
+  return bare;
+}
+
+const EXISTING_BARE = collectExistingBareNames();
+
+function generateBlock(filePath) {
+  const raw = fs.readFileSync(filePath, 'utf8');
+  // Strip any previous generated block to make this idempotent.
+  const base = raw.includes(MARKER_START)
+    ? raw.slice(0, raw.indexOf(MARKER_START)).replace(/\n+$/, '\n')
+    : raw.replace(/\n+$/, '\n');
+
+  const entries = parseExportEntries(base);
+  // Collect all currently-exported names (the alias/exported-as side)
+  const existingNames = new Set(entries.map(e => e.alias));
+
+  // Build alias specifiers. Every alias re-exports from the barrel itself
+  // ('.') rather than the original source module: by the time this block runs,
+  // the prefixed name is already exported by this barrel, and re-exporting from
+  // '.' avoids the renamed-re-export problem (e.g. `X as XDSFoo from './src'`
+  // where './src' has no member named `XDSFoo`).
+  const valueSpecs = [];
+  const typeSpecs = [];
+
+  for (const entry of entries) {
+    const exported = entry.alias;
+    const bare = bareName(exported);
+    if (!bare) continue;
+    if (existingNames.has(bare)) continue; // skip if bare already exported in THIS barrel
+    if (EXISTING_BARE.has(bare)) continue; // skip if bare already exported by ANY barrel (root export * ambiguity)
+    const spec = `${exported} as ${bare}`;
+    (entry.isType ? typeSpecs : valueSpecs).push(spec);
+  }
+
+  // De-dup (a barrel may export the same prefixed name more than once).
+  const uniqValue = [...new Set(valueSpecs)].sort();
+  const uniqType = [...new Set(typeSpecs)].sort();
+  if (uniqValue.length === 0 && uniqType.length === 0) return {base, block: null};
+
+  const lines = [
+    '',
+    MARKER_START,
+    '// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).',
+    '// Prefixed names above remain canonical + module-augmentation targets.',
+    '// These bare re-exports reference the SAME values/types.',
+    '// Regenerate: node scripts/generate-compat-aliases.mjs',
+  ];
+  if (uniqValue.length) {
+    lines.push('export {');
+    for (const v of uniqValue) lines.push(`  ${v},`);
+    lines.push("} from '.';");
+  }
+  if (uniqType.length) {
+    lines.push('export type {');
+    for (const t of uniqType) lines.push(`  ${t},`);
+    lines.push("} from '.';");
+  }
+  lines.push(MARKER_END);
+  return {base, block: lines.join('\n') + '\n'};
+}
+
+// Main
+const check = process.argv.includes('--check');
+let updated = 0;
+let stale = 0;
+
+for (const entry of fs.readdirSync(SRC, {withFileTypes: true})) {
+  if (!entry.isDirectory()) continue;
+  const idx = path.join(SRC, entry.name, 'index.ts');
+  if (!fs.existsSync(idx)) continue;
+
+  const {base, block} = generateBlock(idx);
+  const desired = block ? base + '\n' + block : base;
+
+  const current = fs.readFileSync(idx, 'utf8');
+  if (desired !== current) {
+    if (check) {
+      stale++;
+      console.error(`  stale: ${entry.name}/index.ts`);
+    } else {
+      fs.writeFileSync(idx, desired);
+      updated++;
+    }
+  }
+}
+
+if (check) {
+  if (stale) {
+    console.error(`\n${stale} barrel(s) have stale compat aliases.`);
+    console.error('Run: node scripts/generate-compat-aliases.mjs');
+    process.exit(1);
+  }
+  console.log('✓ Compat aliases up to date');
+} else {
+  console.log(`✓ Compat aliases: ${updated} barrel(s) updated`);
+}


### PR DESCRIPTION
## Summary

Second piece of the **XDS → Astryx prefix migration** (paste P2380608025). Builds the **compatibility layer**: every `XDS*`/`useXDS*` public export now has an unprefixed alias (`XDSButton` → `Button`, `XDSButtonProps` → `ButtonProps`, `useXDSTheme` → `useTheme`, ...). Consumers can adopt the bare names while existing `XDS*` imports keep working unchanged.

Builds on PR #2861 (P0b naming module).

## Strategy

**Bare names are canonical at the public API surface; `XDS*` is the deletable alias.** Aliases are emitted at each component's barrel (`index.ts`):

```ts
// Button/index.ts
export {XDSButton} from './XDSButton';                        // canonical declaration (unchanged)
export type {XDSButtonProps, XDSButtonVariant, ...} from './XDSButton';

// <compat-aliases:start> — generated
export { XDSButton as Button } from '.';
export type { XDSButtonProps as ButtonProps, ... } from '.';
// <compat-aliases:end>
```

The `XDS*` declaration in the source `.tsx` is **untouched** — preserves the `XDSButton.tsx` filename that discovery tooling keys on (P3's job to migrate). At final cutover (P10), the alias block becomes the canonical export and the `XDS*` references are deleted.

Re-exports are sourced from `'.'` (the barrel itself), which sidesteps a subtle issue with renamed re-exports (e.g. `ContextMenu` re-exports `XDSDropdownMenuItem as XDSContextMenuItem` — pulling the bare alias from the original source would fail since that source has no `XDSContextMenuItem`).

## Codegen

Aliases are generated by `scripts/generate-compat-aliases.mjs` (idempotent — strips and rewrites the marked block). Wired into `check:repo` via `pnpm compat:aliases:check` so the generated blocks can't drift from the prefixed exports.

A **global collision pre-pass** skips aliases whose bare names are already exported by another barrel (e.g. `Token` is already exported bare by `CodeBlock`'s tokenizer — generating it again from the `Token` component would cause root-barrel `export *` ambiguity, TS2308). Three such cases are skipped: `Token`, `HeadingLevel`, `DateRangePreset`.

## CLI alias

`@xds/cli` now also installs as `astryx` (same launcher binary as `xds`). The launcher itself is name-agnostic; help-text branding ("xds" in usage strings) is left to P5 (generated content).

## Module augmentation

The existing pattern `declare module '@xds/core/Button' { interface XDSButtonVariantMap { ... } }` continues to work — the prefixed `XDS*VariantMap` interface remains the canonical augmentation target. The bare `ButtonVariantMap` is a re-export alias of the same interface (verified empirically — `type ButtonVariantMap = XDSButtonVariantMap` would *not* work; would-be augmentations would collide with the type alias, breaking variant resolution. The `export { X as Y }` form preserves augmentability).

## Test plan

- `compat-aliases.test.tsx` — 6 tests:
  - bare component aliases (`Button`, `Card`) are the SAME runtime value as `XDSButton`, `XDSCard`
  - bare hook aliases (`useTheme`) are the SAME value as `useXDSTheme`
  - representative bare names (`Button`, `Card`, `Text`, `Heading`, `Dialog`, `Table`, `Theme`, `useTheme`) are exported from the root barrel
  - prefixed `XDS*` exports still work
  - bare prop type aliases equal the prefixed types (`ButtonProps` ↔ `XDSButtonProps`)
  - bare variant unions equal the prefixed unions
- `tsc --project tsconfig.json --noEmit` — clean
- All existing core tests pass
- `pnpm check:repo` (sync comments + package boundaries + compat aliases) — clean
- Subpath imports verified: `import {Button} from '@xds/core/Button'` resolves correctly (the alias lives in each barrel's `index.ts`, which is the subpath entry)

## Scope

- ~634 `XDS*`/`useXDS*` identifiers aliased across **100 component barrels**
- 1 CLI binary alias
- 1 codegen script (179 lines)
- 1 test file (63 lines)
- No behavior change; no source `.tsx` files modified