### PR TITLE
feat(build): make the theme CSS layer name configurable (P3c, part 1)

### DIFF
--- a/packages/build/src/vite.test.ts
+++ b/packages/build/src/vite.test.ts
@@ -1,0 +1,59 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file vite.test.ts
+ * @description Verifies CSS layer-order injection in the XDS Vite plugin,
+ *   including the configurable theme layer added for the XDS-prefix migration
+ *   (P2380608025). Default theme layer is `xds-theme`; consumers may opt into
+ *   a rebranded layer (e.g. `astryx-theme`) before final cutover.
+ */
+
+import {describe, it, expect} from 'vitest';
+import {xdsStylex} from './vite';
+
+/** Pull the injected `@layer ...;` order statement out of the plugin set. */
+function getLayerOrder(plugins: ReturnType<typeof xdsStylex>): string {
+  const layerPlugin = plugins.find(p => p.name === 'xds-css-layer-order');
+  expect(layerPlugin, 'xds-css-layer-order plugin should exist').toBeTruthy();
+  const transform = (layerPlugin as any).transformIndexHtml;
+  const tags =
+    typeof transform === 'function' ? transform() : transform.handler();
+  const styleTag = tags.find((t: any) => t.tag === 'style');
+  expect(styleTag, 'a <style> tag should be injected').toBeTruthy();
+  return styleTag.children as string;
+}
+
+describe('xdsStylex layer order (modern API)', () => {
+  it('defaults to the legacy xds-* layer names', () => {
+    const order = getLayerOrder(xdsStylex());
+    expect(order).toBe('@layer reset, xds-base, xds-theme, product;');
+  });
+
+  it('honors a configured theme layer (astryx-theme opt-in)', () => {
+    const order = getLayerOrder(xdsStylex({layers: {theme: 'astryx-theme'}}));
+    expect(order).toBe('@layer reset, xds-base, astryx-theme, product;');
+  });
+
+  it('honors all configured layer names together', () => {
+    const order = getLayerOrder(
+      xdsStylex({
+        layers: {library: 'astryx-base', theme: 'astryx-theme', product: 'app'},
+      }),
+    );
+    expect(order).toBe('@layer reset, astryx-base, astryx-theme, app;');
+  });
+});
+
+describe('xdsStylex layer order (legacy API)', () => {
+  it('defaults to the legacy xds-* layer names', () => {
+    const order = getLayerOrder(xdsStylex({stylexOptions: {}}));
+    expect(order).toBe('@layer reset, xds-base, xds-theme, product;');
+  });
+
+  it('honors a configured theme layer', () => {
+    const order = getLayerOrder(
+      xdsStylex({stylexOptions: {}, layers: {theme: 'astryx-theme'}}),
+    );
+    expect(order).toBe('@layer reset, xds-base, astryx-theme, product;');
+  });
+});

--- a/packages/build/src/vite.ts
+++ b/packages/build/src/vite.ts
@@ -31,6 +31,8 @@ export interface XDSVitePluginLegacyOptions {
   libraryPattern?: string;
   layers?: {
     library?: string;
+    /** Layer name for theme overrides @default 'xds-theme' */
+    theme?: string;
     product?: string;
   };
 }
@@ -60,6 +62,15 @@ export interface XDSVitePluginOptions {
   layers?: {
     /** Layer name for XDS library styles @default 'xds-base' */
     library?: string;
+    /**
+     * Layer name for XDS theme overrides @default 'xds-theme'
+     *
+     * Configurable to support the XDS-prefix migration (P2380608025): a
+     * consumer can opt into the rebranded `astryx-theme` layer before the
+     * final cutover by setting this (and the matching runtime theme-layer
+     * name). Defaults to `xds-theme` so existing consumers are unaffected.
+     */
+    theme?: string;
     /** Layer name for product styles @default 'product' */
     product?: string;
   };
@@ -113,6 +124,7 @@ export function xdsStylex(
   } = opts;
 
   const libraryLayer = layers.library ?? 'xds-base';
+  const themeLayer = layers.theme ?? 'xds-theme';
   const productLayer = layers.product ?? 'product';
 
   // Build StyleX options with sensible defaults
@@ -157,7 +169,7 @@ export function xdsStylex(
       return [
         {
           tag: 'style',
-          children: `@layer reset, ${libraryLayer}, xds-theme, ${productLayer};`,
+          children: `@layer reset, ${libraryLayer}, ${themeLayer}, ${productLayer};`,
           injectTo: 'head-prepend',
         },
       ];
@@ -293,6 +305,7 @@ function xdsStylexLegacy(options: XDSVitePluginLegacyOptions): Plugin[] {
   } = options;
 
   const libraryLayer = layers.library ?? 'xds-base';
+  const themeLayer = layers.theme ?? 'xds-theme';
   const productLayer = layers.product ?? 'product';
 
   const xdsBabelPlugin = path.resolve(__dirname, 'babel.js');
@@ -322,7 +335,7 @@ function xdsStylexLegacy(options: XDSVitePluginLegacyOptions): Plugin[] {
       return [
         {
           tag: 'style',
-          children: `@layer reset, ${libraryLayer}, xds-theme, ${productLayer};`,
+          children: `@layer reset, ${libraryLayer}, ${themeLayer}, ${productLayer};`,
           injectTo: 'head-prepend',
         },
       ];


### PR DESCRIPTION
## Summary

Part of **P3c (build pipeline)** for the XDS → Astryx prefix migration (paste P2380608025). Makes the **theme CSS layer name configurable** in the XDS Vite plugin, so a consumer can opt into the rebranded `astryx-theme` layer *before* the final cutover.

## Why

CSS layers can't be aliased or dual-emitted (an element's rules live in exactly one layer), so the layer rename is the one surface that stays on `xds-*` names through the whole compat window and flips at final cutover (P10). To decouple the layer migration from the package-scope cutover, the library makes the theme-layer name **configurable** — consumers opt in per-app on their own schedule.

`library` and `product` layer names were already configurable; `theme` was hardcoded in the injected order statement:

```diff
- `@layer reset, ${libraryLayer}, xds-theme, ${productLayer};`
+ `@layer reset, ${libraryLayer}, ${themeLayer}, ${productLayer};`
```

`themeLayer` defaults to `xds-theme`, so **existing consumers are completely unaffected** — this is a pure capability addition.

## Scope note

`@xds/build` is `private: true` / unpublished, so this is an **internal-only** surface with no consumer compat obligation (confirmed in P0 research — 0 consumers use `@xds/build`; all consume the prebuilt `xds.css`). The matching **runtime** theme-layer name (emitted by `XDSTheme.tsx`) and the var-codegen inverted fallback are the remaining P3c pieces, landing in follow-up PRs.

## Changes

- Add `layers.theme` to both `XDSVitePluginOptions` and the legacy options interface
- Thread `themeLayer` through both layer-order injections (modern + legacy API paths)

## Test plan

- New `packages/build/src/vite.test.ts` — 5 tests:
  - default theme layer is `xds-theme` (modern + legacy API)
  - `layers.theme: 'astryx-theme'` opt-in produces `@layer reset, xds-base, astryx-theme, product;`
  - all three layer names configurable together
- `@xds/build` builds cleanly (`pnpm --filter @xds/build build`)
- prettier clean