### PR TITLE
feat(cli): make component discovery prefix-agnostic (P3)

### DIFF
--- a/packages/cli/src/commands/component.test.mjs
+++ b/packages/cli/src/commands/component.test.mjs
@@ -33,13 +33,19 @@ describe('discoverComponents', () => {
     const buttonDir = path.join(srcDir, 'Button');
     fs.mkdirSync(buttonDir, {recursive: true});
     fs.writeFileSync(path.join(buttonDir, 'XDSButton.tsx'), '');
-    fs.writeFileSync(path.join(buttonDir, 'Button.doc.mjs'), "export const docs = {\n  name: 'Button',\n  group: 'Buttons',\n};");
+    fs.writeFileSync(
+      path.join(buttonDir, 'Button.doc.mjs'),
+      "export const docs = {\n  name: 'Button',\n  group: 'Buttons',\n};",
+    );
 
     // IconButton with group: 'Buttons'
     const iconBtnDir = path.join(srcDir, 'IconButton');
     fs.mkdirSync(iconBtnDir, {recursive: true});
     fs.writeFileSync(path.join(iconBtnDir, 'XDSIconButton.tsx'), '');
-    fs.writeFileSync(path.join(iconBtnDir, 'IconButton.doc.mjs'), "export const docs = {\n  name: 'IconButton',\n  group: 'Buttons',\n};");
+    fs.writeFileSync(
+      path.join(iconBtnDir, 'IconButton.doc.mjs'),
+      "export const docs = {\n  name: 'IconButton',\n  group: 'Buttons',\n};",
+    );
 
     // Avatar with no group
     const avatarDir = path.join(srcDir, 'Avatar');
@@ -83,7 +89,10 @@ describe('discoverComponents', () => {
     const middleDir = path.join(srcDir, 'Middle');
     fs.mkdirSync(middleDir, {recursive: true});
     fs.writeFileSync(path.join(middleDir, 'XDSMiddle.tsx'), '');
-    fs.writeFileSync(path.join(middleDir, 'Middle.doc.mjs'), "export const docs = {\n  name: 'Middle',\n  group: 'Inputs',\n};");
+    fs.writeFileSync(
+      path.join(middleDir, 'Middle.doc.mjs'),
+      "export const docs = {\n  name: 'Middle',\n  group: 'Inputs',\n};",
+    );
 
     const result = discoverComponents(tmpDir);
     const keys = Object.keys(result);
@@ -129,6 +138,86 @@ describe('discoverComponents', () => {
     const result = discoverComponents(tmpDir);
     expect(result).toEqual({});
   });
+
+  // XDS-prefix migration (P2380608025, P4): source files are renamed from
+  // `XDS{Name}.tsx` to the bare `{Name}.tsx`. Discovery must find both.
+  it('discovers components from bare {Name}.tsx files (post-rename)', () => {
+    const srcDir = path.join(tmpDir, 'src');
+    const buttonDir = path.join(srcDir, 'Button');
+    fs.mkdirSync(buttonDir, {recursive: true});
+    // Bare component file (no XDS prefix) + its doc
+    fs.writeFileSync(path.join(buttonDir, 'Button.tsx'), '');
+    fs.writeFileSync(
+      path.join(buttonDir, 'Button.doc.mjs'),
+      "export const docs = {name: 'Button'};",
+    );
+
+    const result = discoverComponents(tmpDir);
+    expect(result).toEqual({Button: ['Button']});
+  });
+
+  it('discovers a mix of prefixed and bare component files', () => {
+    const srcDir = path.join(tmpDir, 'src');
+
+    const buttonDir = path.join(srcDir, 'Button');
+    fs.mkdirSync(buttonDir, {recursive: true});
+    fs.writeFileSync(path.join(buttonDir, 'Button.tsx'), ''); // bare
+    fs.writeFileSync(
+      path.join(buttonDir, 'Button.doc.mjs'),
+      "export const docs = {name: 'Button'};",
+    );
+
+    const cardDir = path.join(srcDir, 'Card');
+    fs.mkdirSync(cardDir, {recursive: true});
+    fs.writeFileSync(path.join(cardDir, 'XDSCard.tsx'), ''); // prefixed
+    fs.writeFileSync(
+      path.join(cardDir, 'Card.doc.mjs'),
+      "export const docs = {name: 'Card'};",
+    );
+
+    const result = discoverComponents(tmpDir);
+    expect(result).toEqual({Button: ['Button'], Card: ['Card']});
+  });
+
+  it('does not surface bare PascalCase helper files without a doc', () => {
+    const srcDir = path.join(tmpDir, 'src');
+    const overlayDir = path.join(srcDir, 'Overlay');
+    fs.mkdirSync(overlayDir, {recursive: true});
+    // Real component (documented) + an internal PascalCase helper (no doc).
+    fs.writeFileSync(path.join(overlayDir, 'Overlay.tsx'), '');
+    fs.writeFileSync(path.join(overlayDir, 'OverlayScrim.tsx'), '');
+    fs.writeFileSync(
+      path.join(overlayDir, 'Overlay.doc.mjs'),
+      "export const docs = {name: 'Overlay'};",
+    );
+
+    const result = discoverComponents(tmpDir);
+    // OverlayScrim has no doc, so it must NOT be surfaced as a component.
+    expect(result).toEqual({Overlay: ['Overlay']});
+  });
+
+  it('finds the source file for both prefixed and bare names', () => {
+    const srcDir = path.join(tmpDir, 'src');
+
+    const buttonDir = path.join(srcDir, 'Button');
+    fs.mkdirSync(buttonDir, {recursive: true});
+    fs.writeFileSync(path.join(buttonDir, 'Button.tsx'), '// bare');
+    fs.writeFileSync(
+      path.join(buttonDir, 'Button.doc.mjs'),
+      "export const docs = {name: 'Button'};",
+    );
+
+    const cardDir = path.join(srcDir, 'Card');
+    fs.mkdirSync(cardDir, {recursive: true});
+    fs.writeFileSync(path.join(cardDir, 'XDSCard.tsx'), '// prefixed');
+
+    expect(findComponentSource(tmpDir, 'Button')).toBe(
+      path.join(buttonDir, 'Button.tsx'),
+    );
+    expect(findComponentSource(tmpDir, 'Card')).toBe(
+      path.join(cardDir, 'XDSCard.tsx'),
+    );
+  });
 });
 
 describe('findComponentReadme', () => {
@@ -136,7 +225,10 @@ describe('findComponentReadme', () => {
     const srcDir = path.join(tmpDir, 'src');
     const compDir = path.join(srcDir, 'Button');
     fs.mkdirSync(compDir, {recursive: true});
-    fs.writeFileSync(path.join(compDir, 'Button.doc.mjs'), 'export const docs = {}');
+    fs.writeFileSync(
+      path.join(compDir, 'Button.doc.mjs'),
+      'export const docs = {}',
+    );
 
     const result = findComponentReadme(tmpDir, 'Button');
     expect(result).toBe(path.join(compDir, 'Button.doc.mjs'));
@@ -146,7 +238,10 @@ describe('findComponentReadme', () => {
     const srcDir = path.join(tmpDir, 'src');
     const nestedDir = path.join(srcDir, 'Layout', 'Container');
     fs.mkdirSync(nestedDir, {recursive: true});
-    fs.writeFileSync(path.join(nestedDir, 'Container.doc.mjs'), 'export const docs = {}');
+    fs.writeFileSync(
+      path.join(nestedDir, 'Container.doc.mjs'),
+      'export const docs = {}',
+    );
 
     const result = findComponentReadme(tmpDir, 'Container');
     expect(result).toBe(path.join(nestedDir, 'Container.doc.mjs'));
@@ -157,7 +252,10 @@ describe('findComponentReadme', () => {
     const stackDir = path.join(srcDir, 'Stack');
     fs.mkdirSync(stackDir, {recursive: true});
     fs.writeFileSync(path.join(stackDir, 'XDSStackItem.tsx'), '');
-    fs.writeFileSync(path.join(stackDir, 'Stack.doc.mjs'), 'export const docs = {}');
+    fs.writeFileSync(
+      path.join(stackDir, 'Stack.doc.mjs'),
+      'export const docs = {}',
+    );
 
     const result = findComponentReadme(tmpDir, 'StackItem');
     expect(result).toBe(path.join(stackDir, 'Stack.doc.mjs'));
@@ -361,25 +459,31 @@ describe('discoverExternalComponentsGrouped', () => {
     // AppShell with group
     const shellDir = path.join(docsDir, 'AppShell');
     fs.mkdirSync(shellDir, {recursive: true});
-    fs.writeFileSync(path.join(shellDir, 'AppShell.doc.mjs'),
-      "export const docs = {\n  name: 'AppShell',\n  group: 'App Chrome',\n};");
+    fs.writeFileSync(
+      path.join(shellDir, 'AppShell.doc.mjs'),
+      "export const docs = {\n  name: 'AppShell',\n  group: 'App Chrome',\n};",
+    );
 
     // SideNav with same group
     const navDir = path.join(docsDir, 'SideNav');
     fs.mkdirSync(navDir, {recursive: true});
-    fs.writeFileSync(path.join(navDir, 'SideNav.doc.mjs'),
-      "export const docs = {\n  name: 'SideNav',\n  group: 'App Chrome',\n};");
+    fs.writeFileSync(
+      path.join(navDir, 'SideNav.doc.mjs'),
+      "export const docs = {\n  name: 'SideNav',\n  group: 'App Chrome',\n};",
+    );
 
     // Diff with no group
     const diffDir = path.join(docsDir, 'Diff');
     fs.mkdirSync(diffDir, {recursive: true});
-    fs.writeFileSync(path.join(diffDir, 'Diff.doc.mjs'),
-      "export const docs = {\n  name: 'Diff',\n};");
+    fs.writeFileSync(
+      path.join(diffDir, 'Diff.doc.mjs'),
+      "export const docs = {\n  name: 'Diff',\n};",
+    );
 
     const result = discoverExternalComponentsGrouped(docsDir);
     expect(result).toEqual({
       'App Chrome': ['AppShell', 'SideNav'],
-      'Diff': ['Diff'],
+      Diff: ['Diff'],
     });
   });
 
@@ -392,14 +496,18 @@ describe('discoverExternalComponentsGrouped', () => {
     const docsDir = path.join(tmpDir, 'src');
     const compDir = path.join(docsDir, 'Internal');
     fs.mkdirSync(compDir, {recursive: true});
-    fs.writeFileSync(path.join(compDir, 'Internal.doc.mjs'),
-      "export const docs = {\n  name: 'Internal',\n  hidden: true,\n};");
+    fs.writeFileSync(
+      path.join(compDir, 'Internal.doc.mjs'),
+      "export const docs = {\n  name: 'Internal',\n  hidden: true,\n};",
+    );
 
-    fs.writeFileSync(path.join(docsDir, 'Visible.doc.mjs'),
-      "export const docs = {\n  name: 'Visible',\n};");
+    fs.writeFileSync(
+      path.join(docsDir, 'Visible.doc.mjs'),
+      "export const docs = {\n  name: 'Visible',\n};",
+    );
 
     const result = discoverExternalComponentsGrouped(docsDir);
-    expect(result).toEqual({'Visible': ['Visible']});
+    expect(result).toEqual({Visible: ['Visible']});
   });
 
   it('sorts groups and ungrouped alphabetically', () => {
@@ -407,18 +515,24 @@ describe('discoverExternalComponentsGrouped', () => {
 
     const zDir = path.join(docsDir, 'Zebra');
     fs.mkdirSync(zDir, {recursive: true});
-    fs.writeFileSync(path.join(zDir, 'Zebra.doc.mjs'),
-      "export const docs = {\n  name: 'Zebra',\n  group: 'Animals',\n};");
+    fs.writeFileSync(
+      path.join(zDir, 'Zebra.doc.mjs'),
+      "export const docs = {\n  name: 'Zebra',\n  group: 'Animals',\n};",
+    );
 
     const aDir = path.join(docsDir, 'Alpha');
     fs.mkdirSync(aDir, {recursive: true});
-    fs.writeFileSync(path.join(aDir, 'Alpha.doc.mjs'),
-      "export const docs = {\n  name: 'Alpha',\n};");
+    fs.writeFileSync(
+      path.join(aDir, 'Alpha.doc.mjs'),
+      "export const docs = {\n  name: 'Alpha',\n};",
+    );
 
     const bDir = path.join(docsDir, 'Bear');
     fs.mkdirSync(bDir, {recursive: true});
-    fs.writeFileSync(path.join(bDir, 'Bear.doc.mjs'),
-      "export const docs = {\n  name: 'Bear',\n  group: 'Animals',\n};");
+    fs.writeFileSync(
+      path.join(bDir, 'Bear.doc.mjs'),
+      "export const docs = {\n  name: 'Bear',\n  group: 'Animals',\n};",
+    );
 
     const result = discoverExternalComponentsGrouped(docsDir);
     const keys = Object.keys(result);
@@ -474,30 +588,44 @@ describe('findExternalComponentDoc', () => {
   });
 });
 
-
 describe('searchComponents', () => {
   it('finds Collapsible when searching "accordion"', async () => {
-    const {searchComponents, discoverComponents} = await import('./component/index.mjs');
+    const {searchComponents, discoverComponents} =
+      await import('./component/index.mjs');
     const components = discoverComponents('packages/core');
-    const results = await searchComponents('accordion', 'packages/core', components);
+    const results = await searchComponents(
+      'accordion',
+      'packages/core',
+      components,
+    );
     expect(results.length).toBeGreaterThan(0);
     expect(results[0].name).toBe('Collapsible');
     expect(results[0].score).toBe(90);
   });
 
   it('finds Dialog when searching "modal"', async () => {
-    const {searchComponents, discoverComponents} = await import('./component/index.mjs');
+    const {searchComponents, discoverComponents} =
+      await import('./component/index.mjs');
     const components = discoverComponents('packages/core');
-    const results = await searchComponents('modal', 'packages/core', components);
+    const results = await searchComponents(
+      'modal',
+      'packages/core',
+      components,
+    );
     const dialog = results.find(r => r.name === 'Dialog');
     expect(dialog).toBeDefined();
     expect(dialog.score).toBe(90);
   });
 
   it('returns multiple matches for ambiguous terms like "select"', async () => {
-    const {searchComponents, discoverComponents} = await import('./component/index.mjs');
+    const {searchComponents, discoverComponents} =
+      await import('./component/index.mjs');
     const components = discoverComponents('packages/core');
-    const results = await searchComponents('select', 'packages/core', components);
+    const results = await searchComponents(
+      'select',
+      'packages/core',
+      components,
+    );
     const top90 = results.filter(r => r.score === 90);
     expect(top90.length).toBeGreaterThan(1);
     const names = top90.map(r => r.name);
@@ -505,17 +633,27 @@ describe('searchComponents', () => {
   });
 
   it('finds exact name matches with score 100', async () => {
-    const {searchComponents, discoverComponents} = await import('./component/index.mjs');
+    const {searchComponents, discoverComponents} =
+      await import('./component/index.mjs');
     const components = discoverComponents('packages/core');
-    const results = await searchComponents('Button', 'packages/core', components);
+    const results = await searchComponents(
+      'Button',
+      'packages/core',
+      components,
+    );
     expect(results[0].name).toBe('Button');
     expect(results[0].score).toBe(100);
   });
 
   it('returns empty array for complete gibberish', async () => {
-    const {searchComponents, discoverComponents} = await import('./component/index.mjs');
+    const {searchComponents, discoverComponents} =
+      await import('./component/index.mjs');
     const components = discoverComponents('packages/core');
-    const results = await searchComponents('zzzzzzzzzzz', 'packages/core', components);
+    const results = await searchComponents(
+      'zzzzzzzzzzz',
+      'packages/core',
+      components,
+    );
     expect(results.length).toBe(0);
   });
 });

--- a/packages/cli/src/lib/component-discovery.mjs
+++ b/packages/cli/src/lib/component-discovery.mjs
@@ -9,6 +9,58 @@ import * as path from 'node:path';
 
 const SKIP_DIRS = new Set(['hooks', 'utils', '__tests__', 'node_modules']);
 
+// Component source files are named `XDS{Name}.tsx` today. The XDS-prefix
+// migration (P2380608025, P4) renames them to the bare `{Name}.tsx` form, so
+// discovery must recognize BOTH. The `XDS` prefix has historically doubled as
+// a "this is a top-level component" marker, so naively matching all PascalCase
+// `.tsx` files would surface internal helpers that happen to be PascalCase
+// (`OverlayScrim.tsx`, `PowerSearchEditPopover.tsx`, ...). To avoid that
+// regression, a BARE-named file is only treated as a component when a matching
+// doc file exists for it (`{Name}.doc.mjs` or `XDS{Name}.doc.mjs` in the same
+// directory). Prefixed `XDS{Name}.tsx` files keep their existing behavior.
+const PREFIXED_COMPONENT_FILE_RE = /^XDS[A-Z]\w+\.tsx$/;
+const BARE_COMPONENT_FILE_RE = /^[A-Z]\w+\.tsx$/;
+
+/**
+ * Whether a filename looks like a component source file, excluding tests,
+ * Context files, and (implicitly, via the uppercase-first match) `use*` hooks.
+ *
+ * Recognizes both the current `XDSButton.tsx` form and the post-migration
+ * bare `Button.tsx` form. Bare matches additionally require a sibling doc file
+ * so internal PascalCase helpers are not misclassified as components.
+ *
+ * @param {string} fileName
+ * @param {string} dirPath — directory containing the file (for the bare-name doc check)
+ * @returns {boolean}
+ */
+function isComponentSourceFile(fileName, dirPath) {
+  if (fileName.includes('.test.') || fileName.includes('Context.')) {
+    return false;
+  }
+  if (PREFIXED_COMPONENT_FILE_RE.test(fileName)) {
+    return true;
+  }
+  if (BARE_COMPONENT_FILE_RE.test(fileName)) {
+    const base = fileName.replace(/\.tsx$/, '');
+    return (
+      fs.existsSync(path.join(dirPath, `${base}.doc.mjs`)) ||
+      fs.existsSync(path.join(dirPath, `XDS${base}.doc.mjs`))
+    );
+  }
+  return false;
+}
+
+/**
+ * Strip the optional `XDS` prefix and `.tsx` suffix to get the bare component
+ * name. Works for both `XDSButton.tsx` and `Button.tsx`.
+ *
+ * @param {string} fileName
+ * @returns {string}
+ */
+function componentNameFromFile(fileName) {
+  return fileName.replace(/^XDS/, '').replace(/\.tsx$/, '');
+}
+
 // Matches the top-level `group: 'GroupName'` field in a .doc.mjs file.
 // Only matches at shallow indentation (≤ 4 spaces from line start) to avoid
 // picking up nested `group:` fields inside prop descriptions.
@@ -64,11 +116,7 @@ export function discoverComponents(coreDir) {
     for (const entry of entries) {
       if (entry.isDirectory()) {
         results.push(...collectXDSFiles(path.join(dirPath, entry.name)));
-      } else if (
-        /^XDS[A-Z]\w+\.tsx$/.test(entry.name) &&
-        !entry.name.includes('.test.') &&
-        !entry.name.includes('Context.')
-      ) {
+      } else if (isComponentSourceFile(entry.name, dirPath)) {
         results.push(entry.name);
       }
     }
@@ -96,7 +144,7 @@ export function discoverComponents(coreDir) {
     if (hidden) continue;
 
     for (const fileName of xdsFiles) {
-      const componentName = fileName.replace(/^XDS/, '').replace(/\.tsx$/, '');
+      const componentName = componentNameFromFile(fileName);
       if (hiddenComponents.has(componentName)) continue;
 
       // Check for a per-component doc file that overrides the directory group
@@ -222,15 +270,21 @@ export function findComponentReadme(coreDir, name) {
  */
 export function findComponentSource(coreDir, name) {
   const srcDir = path.join(coreDir, 'src');
-  const xdsName = `XDS${name}.tsx`;
+  // Try the prefixed form (`XDSButton.tsx`) first since that is the current
+  // on-disk convention, then the bare form (`Button.tsx`) that the XDS-prefix
+  // migration (P4) renames to. Listing the prefixed name first keeps behavior
+  // identical until files are actually renamed.
+  const candidateFiles = [`XDS${name}.tsx`, `${name}.tsx`];
 
   function searchDir(dirPath) {
     if (!fs.existsSync(dirPath)) return null;
     const entries = fs.readdirSync(dirPath, {withFileTypes: true});
 
-    // Check for exact match first
-    const exact = path.join(dirPath, xdsName);
-    if (fs.existsSync(exact)) return exact;
+    // Check for an exact match (prefixed or bare) first
+    for (const candidate of candidateFiles) {
+      const exact = path.join(dirPath, candidate);
+      if (fs.existsSync(exact)) return exact;
+    }
 
     // Recurse into subdirectories
     for (const entry of entries) {

--- a/packages/core/docs.mjs
+++ b/packages/core/docs.mjs
@@ -81,10 +81,12 @@ function findDocByComponent(name) {
 }
 
 function hasXDSFile(dir, name) {
-  const target = `XDS${name}.tsx`;
+  // Match the current `XDS{Name}.tsx` convention and the post-migration bare
+  // `{Name}.tsx` form (XDS-prefix migration P2380608025, P4).
+  const targets = [`XDS${name}.tsx`, `${name}.tsx`];
   try {
     for (const f of fs.readdirSync(dir, {withFileTypes: true})) {
-      if (f.name === target) return true;
+      if (targets.includes(f.name)) return true;
       if (f.isDirectory() && hasXDSFile(path.join(dir, f.name), name)) return true;
     }
   } catch {}


### PR DESCRIPTION
## Summary

**P3 (tooling & discovery)** for the XDS → Astryx prefix migration (paste P2380608025). Makes component discovery recognize both the current `XDS{Name}.tsx` source files and the post-migration bare `{Name}.tsx` form, so that P4's source renames don't silently break the tooling that depends on discovery.

## Why this matters

Discovery powers `xds component <Name>`, `xds search`, `agent-docs`, and docsite data generation — all keyed on component names derived from scanning `XDS*.tsx` filenames. When P4 renames `XDSButton.tsx` → `Button.tsx`, the hardcoded `/^XDS[A-Z]\w+\.tsx$/` regex would stop matching and components would vanish from the CLI/agent surface. P3 makes discovery robust to the rename **before** P4 runs.

## The interesting problem

The `XDS` prefix has historically doubled as a *"this is a top-level component"* marker. Naively broadening the match to all PascalCase `.tsx` files surfaces internal helpers that happen to be PascalCase — `OverlayScrim.tsx`, `PowerSearchEditPopover.tsx`, `PowerSearchValueEditor.tsx` (verified: +3 false positives).

**Resolution:** a *bare*-named file is only treated as a component when a sibling doc (`{Name}.doc.mjs` or `XDS{Name}.doc.mjs`) exists — which is the authoritative "this is a documented component" signal the system already relies on. Prefixed `XDS{Name}.tsx` files keep their exact current behavior (no new doc requirement).

This was chosen over a pure doc-scan rewrite because discovery is a careful blend — it also surfaces sub-components documented inside a parent's doc (e.g. `StackItem`, `TableBody`) and deliberately excludes hooks (handled by separate `hook-discovery.mjs`). The targeted filename-matching fix preserves all of that.

## Changes

- `component-discovery.mjs`: extract `isComponentSourceFile()` (matches both forms; bare requires a sibling doc) and `componentNameFromFile()`; `findComponentSource()` resolves both `XDS{Name}.tsx` and `{Name}.tsx`.
- `docs.mjs`: `hasXDSFile()` matches both forms.
- **swizzle** needs no change — it already strips `XDS` from user input and copies files by directory scan (filename-agnostic).

## Test plan

- Verified against the **real core tree**: 165 components discovered identically whether source files are prefixed or renamed to bare — **zero added, zero removed**, including a sub-component (`ChatComposer`) rename.
- `component.test.mjs`: **49 tests pass** (5 new): bare-name discovery, mixed prefixed/bare, helper-without-doc exclusion, dual-form `findComponentSource`.
- `import-hint-correctness.test.mjs` (515 tests, exercises `resolveImportPath` for every component) + `component-loader.test.mjs` pass.

## Note

`component-discovery.mjs` and `docs.mjs` were already prettier-dirty on the base branch; I left the pre-existing formatting untouched so the diff stays minimal and reviewable (my added lines follow the existing style).