### PR TITLE
docs(slop): source-code AI-slop cleanup, pass 2 of 2 (14 files)

### DIFF
--- a/apps/storybook/stories/Layout.stories.tsx
+++ b/apps/storybook/stories/Layout.stories.tsx
@@ -602,8 +602,9 @@ export const NoDividers: Story = {
           content={
             <XDSLayoutContent>
               <p {...stylex.props(styles.bodyText)}>
+                
                 When dividers are not used, the layout automatically collapses
-                spacing between sections for a seamless visual flow.
+                spacing between sections for a smooth visual flow.
               </p>
             </XDSLayoutContent>
           }
@@ -942,7 +943,8 @@ export const ContentWidthWithDividers: Story = {
   render: () => (
     <XDSVStack gap={4} xstyle={styles.storySection}>
       <p {...stylex.props(styles.sectionLabel)}>
-        contentWidth=640 in a 900px container — dividers remain full-bleed while
+        
+        contentWidth=640 in a 900px container; dividers remain full-bleed while
         content is constrained
       </p>
       <div {...stylex.props(styles.cwContainer, styles.cwContainer900)}>
@@ -992,7 +994,8 @@ export const ContentWidthWithStartPanel: Story = {
   render: () => (
     <XDSVStack gap={4} xstyle={styles.storySection}>
       <p {...stylex.props(styles.sectionLabel)}>
-        contentWidth=640 with a 200px start panel — the middle row (panel +
+        
+        contentWidth=640 with a 200px start panel: the middle row (panel +
         content) is constrained
       </p>
       <div {...stylex.props(styles.cwContainer, styles.cwContainer900)}>
@@ -1093,7 +1096,8 @@ export const ContentWidthNoDividers: Story = {
   render: () => (
     <XDSVStack gap={4} xstyle={styles.storySection}>
       <p {...stylex.props(styles.sectionLabel)}>
-        contentWidth=640 without dividers — constraint works the same
+        
+        contentWidth=640 without dividers: constraint works the same
       </p>
       <div {...stylex.props(styles.cwContainer, styles.cwContainer900)}>
         <XDSLayout
@@ -1106,8 +1110,9 @@ export const ContentWidthNoDividers: Story = {
           content={
             <XDSLayoutContent>
               <p {...stylex.props(styles.bodyText)}>
+                
                 Even without dividers, the content is constrained to 640px and
-                centered. The visual flow is seamless with no divider lines.
+                centered. The visual flow is continuous with no divider lines.
               </p>
               <br />
               <div {...stylex.props(styles.placeholder)}>
@@ -1135,7 +1140,8 @@ export const ContentWidthNarrower: Story = {
   render: () => (
     <XDSVStack gap={4} xstyle={styles.storySection}>
       <p {...stylex.props(styles.sectionLabel)}>
-        contentWidth=400 in a 900px container — content is visibly centered
+        
+        contentWidth=400 in a 900px container: content is visibly centered
       </p>
       <div {...stylex.props(styles.cwContainer, styles.cwContainer900)}>
         <XDSLayout
@@ -1149,8 +1155,9 @@ export const ContentWidthNarrower: Story = {
           content={
             <XDSLayoutContent>
               <p {...stylex.props(styles.bodyText)}>
+                
                 This content is constrained to 400px inside a 900px container.
-                Notice the visible centering — great for focused forms or
+                Notice the visible centering, great for focused forms or
                 settings pages.
               </p>
               <br />
@@ -1179,7 +1186,8 @@ export const ContentWidthWider: Story = {
   render: () => (
     <XDSVStack gap={4} xstyle={styles.storySection}>
       <p {...stylex.props(styles.sectionLabel)}>
-        contentWidth=2000 in a 350px container — degrades gracefully to 100%
+        
+        contentWidth=2000 in a 350px container, degrades gracefully to 100%
       </p>
       <div {...stylex.props(styles.cwContainer, styles.cwContainer350)}>
         <XDSLayout
@@ -1193,8 +1201,9 @@ export const ContentWidthWider: Story = {
           content={
             <XDSLayoutContent>
               <p {...stylex.props(styles.bodyText)}>
+                
                 The contentWidth is 2000px but the container is only 350px. The
-                content fills 100% of the available space — no overflow or
+                content fills 100% of the available space, with no overflow or
                 scrollbar.
               </p>
             </XDSLayoutContent>

--- a/apps/storybook/stories/Link.stories.tsx
+++ b/apps/storybook/stories/Link.stories.tsx
@@ -303,7 +303,7 @@ export const ButtonFallbackVariants: Story = {
     docs: {
       description: {
         story:
-          'Button fallback supports all visual variants (color, underline, tooltip, disabled) — ' +
+          'Button fallback supports all visual variants (color, underline, tooltip, disabled), ' +
           'visually indistinguishable from a regular link.',
       },
     },
@@ -322,7 +322,7 @@ export const ButtonFallbackInline: Story = {
       description: {
         story:
           'Button fallback works inline within text, just like a regular link. ' +
-          'Inspect the DOM — it renders a `<button>` not an `<a>`.',
+          'Inspect the DOM; it renders a `<button>` not an `<a>`.',
       },
     },
   },
@@ -371,7 +371,8 @@ export const LinkVsButtonComparison: Story = {
         </div>
       </div>
       <XDSText type="body" size="sm" color="secondary">
-        Both look the same — but inspect the DOM to see the semantic difference.
+        
+        Both look the same, but inspect the DOM to see the semantic difference.
       </XDSText>
     </div>
   ),

--- a/apps/storybook/stories/SVGIcon.stories.tsx
+++ b/apps/storybook/stories/SVGIcon.stories.tsx
@@ -276,8 +276,9 @@ export const MaskGaps: Story = {
     <XDSStack direction="vertical" gap={3}>
       <XDSHeading level={3}>Mask Gaps on Different Backgrounds</XDSHeading>
       <XDSText type="supporting" color="secondary">
+        
         Bold mode uses mask-based knockout gaps. Because the gap is transparent
-        (not white), it works on any background — solid colors, surfaces, and
+        (not white), it works on any background: solid colors, surfaces, and
         gradients alike.
       </XDSText>
 
@@ -392,8 +393,9 @@ export const StructuralDiversity: Story = {
     <XDSStack direction="vertical" gap={3}>
       <XDSHeading level={3}>Structural Diversity</XDSHeading>
       <XDSText type="supporting" color="secondary">
-        New icons with diverse structures — organic curves, complex single
-        paths, nested overlapping fills, and mixed fill+stroke roles — across
+        
+        New icons with diverse structures: organic curves, complex single
+        paths, nested overlapping fills, and mixed fill+stroke roles, across
         all five variations.
       </XDSText>
       <div

--- a/apps/storybook/stories/SelectableCard.stories.tsx
+++ b/apps/storybook/stories/SelectableCard.stories.tsx
@@ -35,7 +35,7 @@ const meta: Meta<typeof XDSSelectableCard> = {
       description: {
         component:
           'A card that toggles between selected and unselected states. ' +
-          'Shows an accent border when selected. Manage selection state externally — ' +
+          'Shows an accent border when selected. Manage selection state externally: ' +
           'single value for radio behavior, Set for multi-select.',
       },
     },

--- a/apps/storybook/stories/TableColumnResize.stories.tsx
+++ b/apps/storybook/stories/TableColumnResize.stories.tsx
@@ -96,8 +96,9 @@ export const Default: Story = {
     return (
       <div style={{maxWidth: 600}}>
         <p style={{marginBottom: 8, fontSize: 14, color: '#666'}}>
+          
           Drag the right edge of any column header to resize. The last
-          proportional column has no handle — it flexes to fill remaining space.
+          proportional column has no handle; it flexes to fill remaining space.
         </p>
         <XDSTable
           data={users}

--- a/apps/storybook/stories/TableFiltering.stories.tsx
+++ b/apps/storybook/stories/TableFiltering.stories.tsx
@@ -536,7 +536,8 @@ export const EmptyState: Story = {
     return (
       <div style={{maxWidth: 800}}>
         <p style={{marginBottom: 8, fontSize: 14, color: '#666'}}>
-          Try filtering to get zero results — empty state appears.
+          
+          Try filtering to get zero results; empty state appears.
         </p>
         <XDSTable
           data={data}

--- a/apps/storybook/stories/Toast.stories.tsx
+++ b/apps/storybook/stories/Toast.stories.tsx
@@ -125,7 +125,7 @@ export const WithAction: StoryObj = {
     docs: {
       description: {
         story:
-          'Use `endContent` for trailing actions — buttons, links, or any content.',
+          'Use `endContent` for trailing actions: buttons, links, or any content.',
       },
     },
   },
@@ -155,7 +155,7 @@ export const ErrorPersists: StoryObj = {
     docs: {
       description: {
         story:
-          'Error toasts default to `isAutoHide: false` — they persist until the user dismisses them.',
+          'Error toasts default to `isAutoHide: false`; they persist until the user dismisses them.',
       },
     },
   },
@@ -289,7 +289,8 @@ export const NoProvider: StoryObj = {
       <XDSCard padding={4}>
         <XDSStack gap={2}>
           <p style={{margin: 0, fontSize: 14}}>
-            No XDSLayerProvider — the hook creates a fallback viewport on
+            
+            No XDSLayerProvider: the hook creates a fallback viewport on
             document.body automatically.
           </p>
           <XDSButton
@@ -336,7 +337,7 @@ export const ToastOverDialog: StoryObj = {
     docs: {
       description: {
         story:
-          "Dialog with its own `XDSToastViewport` — toasts render inside the dialog's top layer context and appear above the dialog overlay.",
+          "Dialog with its own `XDSToastViewport`: toasts render inside the dialog's top layer context and appear above the dialog overlay.",
       },
     },
   },
@@ -347,8 +348,9 @@ function DialogToastContent({onClose}: {onClose: () => void}) {
   return (
     <XDSStack gap={3}>
       <p>
+        
         This dialog has its own toast viewport. Toasts fired here render inside
-        the dialog — above its overlay.
+        the dialog, above its overlay.
       </p>
       <XDSStack direction="horizontal" gap={2} wrap="wrap">
         <XDSButton label="Close" variant="secondary" onClick={onClose} />

--- a/apps/storybook/stories/XDSMediaTheme.stories.tsx
+++ b/apps/storybook/stories/XDSMediaTheme.stories.tsx
@@ -25,7 +25,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'Inverted surface theming context. Wraps children so they render correctly on dark or light backgrounds — buttons, links, text, and icons all pick up the right colors automatically.',
+          'Inverted surface theming context. Wraps children so they render correctly on dark or light backgrounds; buttons, links, text, and icons all pick up the right colors automatically.',
       },
     },
   },
@@ -49,7 +49,8 @@ function OnDarkDemo() {
       <XDSMediaTheme mode="dark">
         <XDSStack gap={3}>
           <XDSText>
-            Content on a dark surface — text, icons, and interactive elements
+            
+            Content on a dark surface: text, icons, and interactive elements
             automatically adapt.
           </XDSText>
           <XDSStack direction="horizontal" gap={2} align="center" wrap="wrap">
@@ -107,7 +108,8 @@ function OnLightDemo() {
           <XDSMediaTheme mode="light">
             <XDSStack gap={3}>
               <XDSText>
-                Content on a light surface in dark mode — text and icons become
+                
+                Content on a light surface in dark mode: text and icons become
                 dark.
               </XDSText>
               <XDSStack
@@ -136,7 +138,7 @@ export const OnLight: StoryObj = {
     docs: {
       description: {
         story:
-          'Content on a light surface in dark mode. The inverse of OnDark — dark text on a light background when the page is dark.',
+          'Content on a light surface in dark mode. The inverse of OnDark: dark text on a light background when the page is dark.',
       },
     },
   },
@@ -210,7 +212,7 @@ export const ToastExample: StoryObj = {
     docs: {
       description: {
         story:
-          'Toast-like notifications using XDSMediaTheme. The dark surface sets up the right token context — buttons and text just work without manual color overrides.',
+          'Toast-like notifications using XDSMediaTheme. The dark surface sets up the right token context; buttons and text just work without manual color overrides.',
       },
     },
   },
@@ -232,7 +234,8 @@ function ComponentOverrideBoundaryDemo() {
     <XDSTheme theme={brutalistTheme}>
       <XDSStack gap={4}>
         <XDSText weight="semibold">
-          Brutalist theme — notice the component overrides: pill buttons,
+          
+          Brutalist theme, notice the component overrides: pill buttons,
           uppercase text, thick card borders, bordered ghost buttons.
         </XDSText>
 
@@ -288,7 +291,7 @@ export const ComponentOverrideBoundary: StoryObj = {
     docs: {
       description: {
         story:
-          'Shows component overrides flowing through to the media context. Brutalist theme applies bold component overrides (pill buttons, uppercase, thick borders) — these are preserved inside XDSMediaTheme. Only the color tokens change for the inverted surface.',
+          'Shows component overrides flowing through to the media context. Brutalist theme applies bold component overrides (pill buttons, uppercase, thick borders); these are preserved inside XDSMediaTheme. Only the color tokens change for the inverted surface.',
       },
     },
   },
@@ -358,7 +361,7 @@ export const AcrossThemes: StoryObj = {
     docs: {
       description: {
         story:
-          'Side-by-side comparison across themes. Left column shows normal surface with themed component overrides. Right column shows XDSMediaTheme dark surface — same components, inverted tokens, default styles.',
+          'Side-by-side comparison across themes. Left column shows normal surface with themed component overrides. Right column shows XDSMediaTheme dark surface: same components, inverted tokens, default styles.',
       },
     },
   },
@@ -387,7 +390,7 @@ function CustomOverridesDemo() {
     <XDSTheme theme={customTheme}>
       <XDSStack gap={3}>
         <XDSText>
-          This theme has a custom <code>onDark</code> config — the accent color
+          This theme has a custom <code>onDark</code>  config; the accent color
           on dark surfaces is a lighter purple instead of plain white.
         </XDSText>
         <div
@@ -611,7 +614,7 @@ export const RegionalDetection: StoryObj = {
     docs: {
       description: {
         story:
-          'Regional detection samples a specific area of the image instead of the full average. Useful when text overlays a specific region — the sunset image is light overall but dark at the bottom where the text sits.',
+          'Regional detection samples a specific area of the image instead of the full average. Useful when text overlays a specific region: the sunset image is light overall but dark at the bottom where the text sits.',
       },
     },
   },

--- a/apps/storybook/stories/XDSTheme.stories.tsx
+++ b/apps/storybook/stories/XDSTheme.stories.tsx
@@ -321,11 +321,11 @@ const meta: Meta = {
         component:
           '`XDSTheme` applies a theme to its children via CSS custom properties and ' +
           'provides programmatic token access through `useXDSTheme()`.\n\n' +
-          '`useXDSTheme()` returns resolved token values for the current color mode — ' +
+          '`useXDSTheme()` returns resolved token values for the current color mode, ' +
           'designed for non-CSS consumers like data visualization libraries, canvas rendering, ' +
           'and SVG charts that need concrete values (hex colors, px values) rather than ' +
           'CSS custom property references.\n\n' +
-          '**No double render.** Values are available on first paint \u2014 no `getComputedStyle` ' +
+          '**No double render.** Values are available on first paint; no `getComputedStyle` ' +
           'or `useEffect` needed.',
       },
     },

--- a/apps/storybook/stories/XIFSpec.stories.tsx
+++ b/apps/storybook/stories/XIFSpec.stories.tsx
@@ -269,8 +269,8 @@ export const PersonalityAxes: StoryObj = {
       <XDSStack direction="vertical" gap={3}>
         <XDSHeading level={3}>Personality Axes (Conceptual)</XDSHeading>
         <XDSText type="supporting">
-          Shape personality parameters adjust the <em>feel</em> of icons without
-          changing their structure. All adjustments are relative — preserving
+          Shape personality parameters adjust the <em>feel</em>  of icons without
+          changing their structure. All adjustments are relative, preserving
           the artist&apos;s hierarchy of sharp vs soft. These icons show the
           concept; path manipulation is not yet implemented.
         </XDSText>
@@ -324,9 +324,10 @@ export const PersonalityAxes: StoryObj = {
         </div>
 
         <XDSText type="supporting">
+          
           Note: opacity/stroke-width are used as visual placeholders here. The
-          real implementation will modify path geometry — rounding corners,
-          bowing segments, adjusting curve tension — all at build time via the
+          real implementation will modify path geometry, rounding corners,
+          bowing segments, adjusting curve tension, all at build time via the
           theme pipeline.
         </XDSText>
       </XDSStack>
@@ -486,16 +487,18 @@ export const PathTransformPlayground: StoryObj = {
       <XDSStack direction="vertical" gap={4}>
         <XDSHeading level={3}>Path Transform Playground</XDSHeading>
         <XDSText type="supporting">
+          
           Live path manipulation with sagitta-corrected corner rounding. Sharp
-          corners (like star tips) round less aggressively than gentle corners —
+          corners (like star tips) round less aggressively than gentle corners,
           achieving equal <em>perceived</em> roundness at all angles.
         </XDSText>
 
         {/* Corner Rounding */}
         <XDSHeading level={4}>Corner Rounding (sagitta-corrected)</XDSHeading>
         <XDSText type="supporting">
+          
           Same cornerRounding value across all shapes. Sharp corners get less
-          radius, gentle corners get more — visually balanced.
+          radius, gentle corners get more, visually balanced.
         </XDSText>
         <div
           style={{

--- a/internal/vibe-tests/src/build-previews.ts
+++ b/internal/vibe-tests/src/build-previews.ts
@@ -444,7 +444,7 @@ function ensureBaselineShims(): void {
   const utilsPath = path.join(baselineDir, 'lib', 'utils.ts');
   if (!fs.existsSync(utilsPath)) {
     throw new Error(
-      'Baseline components not found at .baseline/ — run pnpm install in internal/vibe-tests',
+      'Baseline components not found at .baseline/: run pnpm install in internal/vibe-tests',
     );
   }
 }

--- a/internal/vibe-tests/src/correct-previews.ts
+++ b/internal/vibe-tests/src/correct-previews.ts
@@ -130,7 +130,7 @@ ${docs}
 3. If a prop name is wrong, use the correct one from the docs.
 4. If a prop value is wrong (e.g. "small" → "sm"), use the correct value.
 5. If a component doesn't exist, replace with the closest real equivalent.
-6. Output ONLY the corrected .tsx file — no explanation, no markdown fences.
+6. Output ONLY the corrected .tsx file: no explanation, no markdown fences.
 `;
 }
 

--- a/internal/vibe-tests/src/universal-eval.ts
+++ b/internal/vibe-tests/src/universal-eval.ts
@@ -140,7 +140,7 @@ function analyzePhantomProps(code: string): UniversalFinding[] {
         rule: 'phantom-prop',
         severity: 'critical',
         detail:
-          'onPress is React Native — use onClick for React DOM. Handler will never fire.',
+          'onPress is React Native; use onClick for React DOM. Handler will never fire.',
         line: lineNum,
       });
     }
@@ -151,7 +151,7 @@ function analyzePhantomProps(code: string): UniversalFinding[] {
         rule: 'phantom-prop',
         severity: 'critical',
         detail:
-          'onLongPress is React Native — no DOM equivalent. Handler will never fire.',
+          'onLongPress is React Native, no DOM equivalent. Handler will never fire.',
         line: lineNum,
       });
     }
@@ -166,7 +166,7 @@ function analyzePhantomProps(code: string): UniversalFinding[] {
         findings.push({
           rule: 'phantom-prop',
           severity: 'moderate',
-          detail: 'onChange on button — buttons do not fire change events',
+          detail: 'onChange on button, buttons do not fire change events',
           line: lineNum,
         });
       }
@@ -185,7 +185,7 @@ function analyzePhantomProps(code: string): UniversalFinding[] {
           rule: 'phantom-prop',
           severity: 'moderate',
           detail:
-            'onSubmit on non-form element — only <form> fires submit events',
+            'onSubmit on non-form element, only <form> fires submit events',
           line: lineNum,
         });
       }

--- a/packages/cli/templates/blocks/components/AppShell/AppShellMobileHookUsage.tsx
+++ b/packages/cli/templates/blocks/components/AppShell/AppShellMobileHookUsage.tsx
@@ -54,7 +54,8 @@ export default function AppShellMobileHookUsage() {
         </XDSText>
       </XDSHStack>
       <XDSText type="body" color="secondary">
-        This button controls the nearest AppShell mobile nav from context — in
+        
+        This button controls the nearest AppShell mobile nav from context; in
         the docsite it opens and closes the surrounding page navigation.
       </XDSText>
     </XDSVStack>


### PR DESCRIPTION
## What

Removes AI-slop prose tells from user-facing strings in **source `.tsx`/`.ts` files**. This is PR 2 of 2 (14 files), completing the source-code pass.

Scope: Storybook stories (Layout, Link, Toast, XDSMediaTheme, XDSTheme, XIFSpec, SVGIcon, tables), vibe-test scripts' user-facing strings, and a CLI template block.

## How (programmatic pipeline, not hand edits)

Same pipeline as pass 1: TypeScript AST extraction → prose+tell filter → small-batch judging against the AI-slop rubric → deterministic minimal-diff injection with parse-gate and auto-revert. Agents only judged; a script applied every fix by exact byte match.

## What changed

- A1/A2 dashes in prose to grammatical punctuation (`;` `:` `,` `.`)
- B buzzwords cut (`seamless visual flow` to `smooth visual flow`, `seamless` to `continuous`)
- E hollow intensifiers removed

Meaning preserved. JSX whitespace-collapse handled so no `space-before-punctuation` artifacts render. All changed files parse via the TypeScript compiler.

## Kept (not slop)

Convention labels, numeric ranges, mock chat/quotes, UI ellipsis affordances, and code in template literals.

## Review

Human review required. No auto-merge.
