### PR TITLE
feat(ci): make checks & CI prefix-agnostic for component files (P3b)

### DIFF
--- a/.github/scripts/analyze-pr.js
+++ b/.github/scripts/analyze-pr.js
@@ -149,7 +149,20 @@ function getPropsCount(componentName) {
   const componentDir = path.join(process.cwd(), CORE_SRC, componentName);
   try {
     const files = fs.readdirSync(componentDir);
-    const mainFile = files.find(f => f.startsWith('XDS') && f.endsWith('.tsx'));
+    // The main component file is `XDS{Name}.tsx` today, or the bare `{Name}.tsx`
+    // after the XDS-prefix migration (P2380608025, P4). Prefer the file named
+    // after the component directory (prefixed or bare); otherwise fall back to
+    // any prefixed/PascalCase component file in the directory.
+    const mainFile =
+      [`XDS${componentName}.tsx`, `${componentName}.tsx`].find(f =>
+        files.includes(f),
+      ) ||
+      files.find(
+        f =>
+          (/^XDS[A-Z]\w+\.tsx$/.test(f) || /^[A-Z]\w+\.tsx$/.test(f)) &&
+          !f.includes('.test.') &&
+          !f.includes('Context.'),
+      );
 
     if (!mainFile) return null;
 

--- a/.github/workflows/hardening-issue.yml
+++ b/.github/workflows/hardening-issue.yml
@@ -37,8 +37,10 @@ jobs:
               { owner, repo, pull_number: pr.number }
             );
 
-            // Find new component directories: packages/core/src/<Name>/XDS<Name>.tsx
-            const newComponentPattern = /^packages\/core\/src\/([A-Z][A-Za-z]+)\/XDS\1\.tsx$/;
+            // Find new component directories:
+            //   packages/core/src/<Name>/XDS<Name>.tsx  (current convention)
+            //   packages/core/src/<Name>/<Name>.tsx      (post XDS-prefix migration, P2380608025)
+            const newComponentPattern = /^packages\/core\/src\/([A-Z][A-Za-z]+)\/(?:XDS)?\1\.tsx$/;
             const newComponents = new Set();
 
             for (const file of files) {

--- a/scripts/check-sync.js
+++ b/scripts/check-sync.js
@@ -29,7 +29,31 @@ function addViolation(type, file, message) {
   violations.push({type, file, message});
 }
 
-// Get all component directories (dirs with at least one XDS*.tsx file)
+// A component source file is `XDS{Name}.tsx` today, or the bare `{Name}.tsx`
+// after the XDS-prefix migration (P2380608025, P4). Match both, excluding
+// tests, `use*` hooks, and `*Context.*` files. As in component discovery, a
+// BARE-named file is only treated as a component when a sibling doc exists
+// (`{Name}.doc.mjs` or `XDS{Name}.doc.mjs`) — otherwise internal PascalCase
+// helpers (OverlayScrim.tsx, PowerSearchEditPopover.tsx, ...) would be
+// misclassified. Prefixed files keep their existing behavior.
+// Mirrors packages/cli/src/lib/component-discovery.mjs (inlined; CommonJS).
+function isComponentSourceFile(fileName, dirPath) {
+  if (!fileName.endsWith('.tsx')) return false;
+  if (fileName.includes('.test.') || fileName.includes('Context.')) {
+    return false;
+  }
+  if (/^XDS[A-Z]\w+\.tsx$/.test(fileName)) return true;
+  if (/^[A-Z]\w+\.tsx$/.test(fileName)) {
+    const base = fileName.slice(0, -'.tsx'.length);
+    return (
+      fs.existsSync(path.join(dirPath, `${base}.doc.mjs`)) ||
+      fs.existsSync(path.join(dirPath, `XDS${base}.doc.mjs`))
+    );
+  }
+  return false;
+}
+
+// Get all component directories (dirs with at least one component source file)
 const componentDirs = fs
   .readdirSync(CORE_SRC, {withFileTypes: true})
   .filter((d) => d.isDirectory())
@@ -38,10 +62,7 @@ const componentDirs = fs
     const dirPath = path.join(CORE_SRC, name);
     return fs
       .readdirSync(dirPath)
-      .some(
-        (f) =>
-          f.startsWith('XDS') && f.endsWith('.tsx') && !f.includes('.test.'),
-      );
+      .some((f) => isComponentSourceFile(f, dirPath));
   });
 
 for (const comp of componentDirs) {
@@ -60,9 +81,7 @@ for (const comp of componentDirs) {
   }
 
   // --- Check 2 & 3: SYNC references ---
-  const xdsFiles = files.filter(
-    (f) => f.startsWith('XDS') && f.endsWith('.tsx') && !f.includes('.test.'),
-  );
+  const xdsFiles = files.filter((f) => isComponentSourceFile(f, dirPath));
 
   for (const xdsFile of xdsFiles) {
     const filePath = path.join(dirPath, xdsFile);


### PR DESCRIPTION
## Summary

**P3b (checks, CI & GitHub surfaces)** for the XDS → Astryx prefix migration (paste P2380608025). Makes the CI/check surfaces that locate component source files recognize both the current `XDS{Name}.tsx` convention and the post-migration bare `{Name}.tsx` form, so P4's renames don't silently break them.

## Changes

- **`check-sync.js`** — the SYNC-comment night watch runs in `check:repo` on *every commit*, and matched `XDS*.tsx` to find component dirs/files. Now matches both prefixed and bare, using the **same doc-gate as discovery** (P3) so internal PascalCase helpers (`OverlayScrim.tsx`, `PowerSearchEditPopover.tsx`) aren't misclassified. Verified **byte-identical output** on the real tree before/after my change, and after a simulated `XDSButton.tsx → Button.tsx` rename.
- **`analyze-pr.js`** — `getPropsCount()` found the main component file via the `XDS` prefix. Now prefers the directory-named file (`XDS{Name}.tsx` or `{Name}.tsx`) and falls back to any component file (excluding tests/Context). Verified it resolves `Button → Button.tsx` post-rename and still picks `XDSOverlay.tsx` (not `OverlayScrim.tsx`).
- **`hardening-issue.yml`** — the new-component detection regex now accepts an optional prefix: `/^packages\/core\/src\/([A-Z][A-Za-z]+)\/(?:XDS)?\1\.tsx$/`.

## Deliberately left unchanged (correct through the compat window, per P0)

- **canary publish filter** `startsWith('@xds/')` — package scope stays `@xds/*` until P10
- **`generate-pr-comment.js`** `@xds/core` bundle row — same
- **`accessibility-audit.js`** — already strips `XDS` optionally (`/^XDS/i`), so it's prefix-tolerant; no change
- **`check-package-boundaries.js`** `XDSCommon*` — a *separate* package-boundary convention, not the component prefix
- **`analyze-pr.js` export-name filters** (`startsWith('XDS')` on exported *symbols*) — P4 keeps `XDS*` symbol names, and P1's bare aliases coexist, so every component is still captured

## Test plan

- `pnpm check:repo` (check-sync + package-boundaries + compat-aliases) passes
- check-sync: real-tree output identical across base / my change / simulated rename (all `✅ All SYNC comments are clean.`)
- analyze-pr mainFile resolution smoke-tested against the real tree in both prefixed and renamed states

These scripts are git-diff/PR-context driven (no unit-test harness exists), so verification is via real-tree simulation rather than new unit tests.

## Note

`check-sync.js` and `analyze-pr.js` were already prettier-dirty on the base branch; I left the pre-existing formatting untouched so the diff stays minimal (my added lines follow the existing style).