### PR TITLE
feat(cli): add drop-xds-prefix-imports codemod (P2)

### DIFF
--- a/packages/cli/src/codemods/transforms/v0.0.15/__tests__/drop-xds-prefix-imports.test.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.15/__tests__/drop-xds-prefix-imports.test.mjs
@@ -1,0 +1,124 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {describe, it, expect} from 'vitest';
+
+async function applyTransform(source) {
+  const {default: transform} = await import('../drop-xds-prefix-imports.mjs');
+  const jscodeshift = (await import('jscodeshift')).default;
+  const j = jscodeshift.withParser('tsx');
+  const api = {jscodeshift: j, stats: () => {}, report: () => {}};
+  const file = {source, path: 'test.tsx'};
+  const result = transform(file, api);
+  return result ?? source;
+}
+
+describe('drop-xds-prefix-imports', () => {
+  it('renames a named import + its JSX usage', async () => {
+    const input = [
+      `import {XDSButton} from '@xds/core';`,
+      `export const App = () => <XDSButton label="Hi" />;`,
+    ].join('\n');
+    const output = await applyTransform(input);
+    expect(output).toContain(`import {Button} from '@xds/core';`);
+    expect(output).toContain('<Button label="Hi" />');
+    expect(output).not.toContain('XDSButton');
+  });
+
+  it('renames subpath imports and keeps the source path', async () => {
+    const input = `import {XDSButton} from '@xds/core/Button';`;
+    const output = await applyTransform(input);
+    expect(output).toContain('Button');
+    // The subpath dir is NOT renamed by this codemod.
+    expect(output).toContain(`from '@xds/core/Button'`);
+    expect(output).not.toContain('XDSButton');
+  });
+
+  it('renames hooks (useXDS -> use)', async () => {
+    const input = [
+      `import {useXDSTheme} from '@xds/core';`,
+      `const t = useXDSTheme();`,
+    ].join('\n');
+    const output = await applyTransform(input);
+    expect(output).toContain('import {useTheme}');
+    expect(output).toContain('const t = useTheme();');
+    expect(output).not.toContain('useXDSTheme');
+  });
+
+  it('renames type-only imports and type references', async () => {
+    const input = [
+      `import type {XDSButtonProps} from '@xds/core';`,
+      `type Props = XDSButtonProps & {extra: true};`,
+    ].join('\n');
+    const output = await applyTransform(input);
+    expect(output).toContain('ButtonProps');
+    expect(output).not.toContain('XDSButtonProps');
+  });
+
+  it('rewrites the imported name but keeps a custom local alias', async () => {
+    const input = [
+      `import {XDSButton as Btn} from '@xds/core';`,
+      `export const App = () => <Btn />;`,
+    ].join('\n');
+    const output = await applyTransform(input);
+    expect(output).toContain('Button as Btn');
+    expect(output).toContain('<Btn />');
+    expect(output).not.toContain('XDSButton');
+  });
+
+  it('does NOT touch identifiers that are not imported from @xds/core', async () => {
+    const input = [
+      `import {XDSButton} from '@my/other-lib';`,
+      `const XDSCustomThing = 1;`,
+      `export const App = () => <XDSButton />;`,
+    ].join('\n');
+    const output = await applyTransform(input);
+    // Neither the third-party import nor the local symbol should change.
+    expect(output).toContain(`import {XDSButton} from '@my/other-lib';`);
+    expect(output).toContain('const XDSCustomThing = 1;');
+    expect(output).toContain('<XDSButton />');
+  });
+
+  it('does NOT touch strings that merely start with XDS', async () => {
+    const input = [
+      `import {XDSButton} from '@xds/core';`,
+      `const label = 'XDSButton is great';`,
+      `export const App = () => <XDSButton label={label} />;`,
+    ].join('\n');
+    const output = await applyTransform(input);
+    expect(output).toContain(`'XDSButton is great'`);
+    expect(output).toContain('<Button label={label} />');
+  });
+
+  it('handles multiple specifiers and a mix of components, hooks, and types', async () => {
+    const input = [
+      `import {XDSButton, XDSCard, useXDSToast} from '@xds/core';`,
+      `import type {XDSCardProps} from '@xds/core';`,
+      `export function App() {`,
+      `  const toast = useXDSToast();`,
+      `  const p: XDSCardProps = {};`,
+      `  return <XDSCard><XDSButton /></XDSCard>;`,
+      `}`,
+    ].join('\n');
+    const output = await applyTransform(input);
+    expect(output).toContain('import {Button, Card, useToast}');
+    expect(output).toContain('CardProps');
+    expect(output).toContain('const toast = useToast();');
+    expect(output).toContain('<Card><Button /></Card>');
+    expect(output).not.toContain('XDS');
+  });
+
+  it('rewrites re-exports from @xds/core', async () => {
+    const input = `export {XDSButton} from '@xds/core/Button';`;
+    const output = await applyTransform(input);
+    expect(output).toContain('Button');
+    expect(output).toContain(`from '@xds/core/Button'`);
+    expect(output).not.toContain('XDSButton');
+  });
+
+  it('returns source unchanged when there is nothing to rename', async () => {
+    const input = `import {useState} from 'react';\nconst x = 1;`;
+    const output = await applyTransform(input);
+    expect(output).toContain(`import {useState} from 'react';`);
+    expect(output).toContain('const x = 1;');
+  });
+});

--- a/packages/cli/src/codemods/transforms/v0.0.15/drop-xds-prefix-imports.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.15/drop-xds-prefix-imports.mjs
@@ -1,0 +1,170 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Codemod: Drop the `XDS` prefix from @xds/core imports and their usages
+ *
+ * Part of the XDS-prefix migration (P2380608025). Rewrites consumer code from
+ * the prefixed names to the bare compatibility aliases shipped in P1:
+ *
+ *   XDSButton      -> Button
+ *   XDSButtonProps -> ButtonProps
+ *   useXDSTheme    -> useTheme
+ *   useXDSToast    -> useToast
+ *
+ * Safety: this codemod ONLY renames identifiers that are imported from
+ * `@xds/core` (bare or subpath, e.g. `@xds/core/Button`). It tracks the local
+ * binding introduced by each import and renames that binding plus its
+ * references -- so a consumer's own unrelated `XDSWhatever` symbol, or a string
+ * that merely starts with "XDS", is never touched.
+ *
+ * Handles:
+ * 1. Named import specifiers:   import {XDSButton} from '@xds/core'
+ *    -> import {Button} from '@xds/core'   (and aliased imports)
+ * 2. All references to the imported binding (JSX, type positions, values)
+ * 3. Re-exports from @xds/core: export {XDSButton} from '@xds/core/Button'
+ *
+ * Does NOT touch:
+ * - import source paths (`@xds/core/Button` stays -- subpath dirs are unchanged
+ *   by the prefix migration)
+ * - identifiers not bound to an @xds/core import
+ * - the `XDSBaseProps`-style names only when they are NOT imported from core
+ */
+
+export const meta = {
+  title: 'Drop XDS prefix from @xds/core imports (XDSButton -> Button)',
+  description:
+    'Rewrites @xds/core imports and their usages from the prefixed names ' +
+    '(XDSButton, useXDSTheme, XDSButtonProps) to the bare compatibility ' +
+    'aliases (Button, useTheme, ButtonProps). Only renames bindings imported ' +
+    'from @xds/core, leaving unrelated identifiers untouched.',
+  pr: '#2880',
+};
+
+const XDS_CORE_SOURCE = /^@xds\/core(\/.*)?$/;
+
+/**
+ * Compute the bare (unprefixed) name for an XDS-prefixed identifier.
+ * Returns null if the name is not XDS-prefixed in a renameable way.
+ */
+function bareName(name) {
+  if (name.startsWith('useXDS') && name.length > 'useXDS'.length) {
+    return 'use' + name.slice('useXDS'.length);
+  }
+  if (
+    name.startsWith('XDS') &&
+    name.length > 3 &&
+    name[3] === name[3].toUpperCase() &&
+    name[3] !== name[3].toLowerCase() // next char is an uppercase letter
+  ) {
+    return name.slice(3);
+  }
+  return null;
+}
+
+export default function transformer(file, api) {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+  let hasChanges = false;
+
+  // Map of localName -> newLocalName for bindings we will rename. We only
+  // rename when the LOCAL binding is the prefixed name (i.e. not aliased to
+  // something custom). Aliased imports like `XDSButton as Btn` keep their
+  // local alias and only the imported name is rewritten.
+  const localRenames = new Map();
+
+  // 1. Rewrite import specifiers from @xds/core
+  root.find(j.ImportDeclaration).forEach(path => {
+    const source = path.node.source.value;
+    if (typeof source !== 'string' || !XDS_CORE_SOURCE.test(source)) return;
+
+    for (const spec of path.node.specifiers || []) {
+      if (spec.type !== 'ImportSpecifier') continue; // skip default/namespace
+      const importedName = spec.imported.name;
+      const bare = bareName(importedName);
+      if (!bare) continue;
+
+      const localName = spec.local.name;
+      const wasAliased = localName !== importedName;
+
+      // Rewrite the imported name to the bare alias.
+      spec.imported.name = bare;
+
+      if (wasAliased) {
+        // `import {XDSButton as Btn}` -> `import {Button as Btn}`.
+        // Local binding unchanged, so no usage rewrites needed.
+        hasChanges = true;
+      } else {
+        // `import {XDSButton}` -> `import {Button}`. The local binding is the
+        // prefixed name; rename it and all its references.
+        spec.local.name = bare;
+        localRenames.set(importedName, bare);
+        hasChanges = true;
+      }
+    }
+  });
+
+  // 2. Rewrite re-exports from @xds/core
+  root.find(j.ExportNamedDeclaration).forEach(path => {
+    if (!path.node.source) return;
+    const source = path.node.source.value;
+    if (typeof source !== 'string' || !XDS_CORE_SOURCE.test(source)) return;
+
+    for (const spec of path.node.specifiers || []) {
+      if (spec.type !== 'ExportSpecifier') continue;
+      const localName = spec.local.name;
+      const bare = bareName(localName);
+      if (!bare) continue;
+      spec.local.name = bare;
+      // If the export was `export {XDSButton}` (exported name == local),
+      // also update the exported name; if it was `export {XDSButton as Foo}`,
+      // keep the public exported name `Foo`.
+      if (spec.exported.name === localName) {
+        spec.exported.name = bare;
+      }
+      hasChanges = true;
+    }
+  });
+
+  if (localRenames.size === 0) {
+    return hasChanges ? root.toSource() : undefined;
+  }
+
+  // 3. Rename references to renamed local bindings
+  // Identifiers (type refs, value refs, etc.)
+  root.find(j.Identifier).forEach(path => {
+    const newName = localRenames.get(path.node.name);
+    if (!newName) return;
+    // Skip object property keys like `{ XDSButton: ... }` (not a reference to
+    // the binding) and member expression properties like `foo.XDSButton`.
+    const parent = path.parent.node;
+    if (
+      (parent.type === 'ObjectProperty' || parent.type === 'Property') &&
+      parent.key === path.node &&
+      !parent.computed
+    ) {
+      return;
+    }
+    if (
+      parent.type === 'MemberExpression' &&
+      parent.property === path.node &&
+      !parent.computed
+    ) {
+      return;
+    }
+    // Don't double-rewrite the import specifier we already handled.
+    if (parent.type === 'ImportSpecifier') return;
+    path.node.name = newName;
+    hasChanges = true;
+  });
+
+  // JSX element names: <XDSButton> -> <Button>
+  root.find(j.JSXIdentifier).forEach(path => {
+    const newName = localRenames.get(path.node.name);
+    if (newName) {
+      path.node.name = newName;
+      hasChanges = true;
+    }
+  });
+
+  return hasChanges ? root.toSource() : undefined;
+}

--- a/packages/cli/src/codemods/transforms/v0.0.15/index.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.15/index.mjs
@@ -30,6 +30,10 @@ import migrateThemeSelectorsToDataAttrs, {
   meta as migrateThemeSelectorsToDataAttrsMeta,
 } from './migrate-theme-selectors-to-data-attrs.mjs';
 
+import dropXdsPrefixImports, {
+  meta as dropXdsPrefixImportsMeta,
+} from './drop-xds-prefix-imports.mjs';
+
 export default [
   {
     name: 'rename-date-picker-to-input',
@@ -60,6 +64,15 @@ export default [
     name: 'migrate-theme-selectors-to-data-attrs',
     transform: migrateThemeSelectorsToDataAttrs,
     meta: migrateThemeSelectorsToDataAttrsMeta,
+    optional: true,
+  },
+  {
+    // XDS-prefix migration (P2380608025). Optional + not tied to a version
+    // bump: consumers run it explicitly during their migration, e.g.
+    //   xds upgrade --codemod drop-xds-prefix-imports --codemod-only --apply
+    name: 'drop-xds-prefix-imports',
+    transform: dropXdsPrefixImports,
+    meta: dropXdsPrefixImportsMeta,
     optional: true,
   },
 ];


### PR DESCRIPTION
## Summary

**P2 (codemods)** for the XDS → Astryx prefix migration (paste P2380608025). Adds the first migration codemod: rewrites consumer code from the prefixed `@xds/core` names to the bare compatibility aliases shipped in P1.

```
XDSButton      -> Button
XDSButtonProps -> ButtonProps
useXDSTheme    -> useTheme
```

This is what the P9 per-app consumer migration runs to flip product code to the bare names.

## Safety is the design

A blanket "strip XDS from every identifier" would be dangerous (consumer's own `XDSFoo`, a third-party `XDSButton`, strings starting with `"XDS"`). Instead the codemod is **scoped to `@xds/core` imports only**: it tracks the local binding each `@xds/core` import introduces and renames *that binding* plus its references (imports, JSX, type positions, re-exports).

Explicitly **not** touched:
- a consumer's own unrelated `XDSWhatever` symbol
- `XDSButton` imported from another library
- strings that merely start with `"XDS"`
- import source paths (`@xds/core/Button` stays — subpath dirs are unchanged by the prefix migration; only React identifiers drop the prefix)

Aliased imports (`import {XDSButton as Btn}`) keep the custom local alias and only rewrite the imported name (`import {Button as Btn}`).

## Registration

Registered in the v0.0.15 manifest as `optional: true` — mirroring the existing optional `migrate-theme-selectors-to-data-attrs`. Being optional, it does **not** run on a routine `xds upgrade`; consumers invoke it explicitly:

```
xds upgrade --codemod drop-xds-prefix-imports --codemod-only --apply
```

The `--codemod <name>` path searches all version manifests and runs just the named transform, skipping version detection — exactly the standalone-migration use case.

## Test plan

- **10 new tests** covering: named imports + JSX usage, subpath imports (source path preserved), `useXDS*` hooks, type-only imports + type refs, aliased imports, multi-specifier mixes, re-exports, no-op files, and the three safety cases (third-party import / local symbol / XDS-prefixed string all untouched).
- Verified the codemod is discoverable via the registry as optional.
- Full `v0.0.15` codemod suite + `json-contract` + `upgrade` suites pass (58 tests).

## Scope note

This PR covers the **JS/TS identifier** codemod — the highest-value one (50k+ consumer subpath imports). The remaining P2 codemods (CSS `.xds-*` selectors/classes, `data-xds-*` attrs, CLI `<!-- XDS:START -->` doc markers) will follow as separate transforms; there's already a precedent for the CSS-selector style in `migrate-theme-selectors-to-data-attrs`.