### PR TITLE
feat(core): make the runtime theme-layer name configurable (P3c, part 2)

### DIFF
--- a/packages/core/src/naming.test.ts
+++ b/packages/core/src/naming.test.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-import {describe, it, expect} from 'vitest';
+import {describe, it, expect, afterEach} from 'vitest';
 import {
   LEGACY_NAMESPACE,
   NAMESPACE,
@@ -16,6 +16,10 @@ import {
   legacyDataAttr,
   cssVar,
   legacyCssVar,
+  DEFAULT_THEME_LAYER,
+  ASTRYX_THEME_LAYER,
+  getThemeLayerName,
+  setThemeLayerName,
 } from './naming';
 
 describe('naming constants', () => {
@@ -65,5 +69,31 @@ describe('cssVar', () => {
 
   it('builds legacy custom property names', () => {
     expect(legacyCssVar('card-padding')).toBe('--xds-card-padding');
+  });
+});
+
+describe('theme layer name (configurable)', () => {
+  afterEach(() => {
+    // Restore the default so test ordering can't leak state.
+    setThemeLayerName(DEFAULT_THEME_LAYER);
+  });
+
+  it('exposes the legacy and rebranded layer constants', () => {
+    expect(DEFAULT_THEME_LAYER).toBe('xds-theme');
+    expect(ASTRYX_THEME_LAYER).toBe('astryx-theme');
+  });
+
+  it('defaults to xds-theme', () => {
+    expect(getThemeLayerName()).toBe('xds-theme');
+  });
+
+  it('can be set to the rebranded astryx-theme layer (opt-in)', () => {
+    setThemeLayerName(ASTRYX_THEME_LAYER);
+    expect(getThemeLayerName()).toBe('astryx-theme');
+  });
+
+  it('accepts an arbitrary custom layer name', () => {
+    setThemeLayerName('my-design-system-theme');
+    expect(getThemeLayerName()).toBe('my-design-system-theme');
   });
 });

--- a/packages/core/src/naming.ts
+++ b/packages/core/src/naming.ts
@@ -135,3 +135,49 @@ export function cssVar(name: string): string {
 export function legacyCssVar(name: string): string {
   return `--${legacyCssVarNamespace}-${name}`;
 }
+
+// ---------------------------------------------------------------------------
+// Runtime theme-layer name (configurable)
+//
+// `XDSTheme` injects component overrides into a CSS cascade layer at runtime.
+// Per the P0 decision, CSS layer names stay `xds-*` through the entire compat
+// window (a layer cannot be aliased or dual-emitted), and are only rebranded
+// to `astryx-*` at the final cutover (P10).
+//
+// To let a consumer adopt the rebranded `astryx-theme` layer BEFORE the
+// cutover, the layer name is configurable. It must agree with the build-side
+// `layers.theme` option of `@xds/build`'s Vite plugin — otherwise the declared
+// layer order and the runtime-injected layer disagree (split brain). Default
+// is `xds-theme`, so existing consumers are unaffected.
+// ---------------------------------------------------------------------------
+
+/** The default (legacy) runtime theme-override layer name. */
+export const DEFAULT_THEME_LAYER = `${LEGACY_NAMESPACE}-theme`;
+
+/** The rebranded runtime theme-override layer name (final cutover target). */
+export const ASTRYX_THEME_LAYER = `${NAMESPACE}-theme`;
+
+let themeLayerName = DEFAULT_THEME_LAYER;
+
+/**
+ * Get the CSS cascade-layer name that `XDSTheme` injects component overrides
+ * into. Defaults to `xds-theme`.
+ */
+export function getThemeLayerName(): string {
+  return themeLayerName;
+}
+
+/**
+ * Set the CSS cascade-layer name that `XDSTheme` injects component overrides
+ * into. Call once at app initialization, BEFORE any `XDSTheme` renders, and
+ * keep it in sync with `@xds/build`'s `layers.theme` option.
+ *
+ * @example
+ * ```ts
+ * import {setThemeLayerName, ASTRYX_THEME_LAYER} from '@xds/core/naming';
+ * setThemeLayerName(ASTRYX_THEME_LAYER); // opt into `astryx-theme`
+ * ```
+ */
+export function setThemeLayerName(name: string): void {
+  themeLayerName = name;
+}

--- a/packages/core/src/theme/XDSTheme.test.tsx
+++ b/packages/core/src/theme/XDSTheme.test.tsx
@@ -5,6 +5,11 @@ import {render, cleanup} from '@testing-library/react';
 import React from 'react';
 import {XDSTheme} from './XDSTheme';
 import {defineTheme} from './defineTheme';
+import {
+  setThemeLayerName,
+  DEFAULT_THEME_LAYER,
+  ASTRYX_THEME_LAYER,
+} from '../naming';
 
 const testTheme = defineTheme({
   name: 'test',
@@ -165,5 +170,55 @@ describe('XDSTheme', () => {
     const nestedWrapper = container.querySelector('[data-xds-theme="alt"]');
     expect(nestedWrapper).toBeTruthy();
     expect(nestedWrapper?.getAttribute('data-theme')).toBe('light');
+  });
+
+  // =========================================================================
+  // Configurable theme layer (XDS-prefix migration P2380608025)
+  // =========================================================================
+  describe('component-override layer name', () => {
+    /** Read the @layer name from the injected component-override <style>. */
+    function injectedLayerFor(themeName: string): string | null {
+      const style = document.head.querySelector(
+        `style[data-xds-theme="${themeName}"]`,
+      );
+      const text = style?.textContent ?? '';
+      const match = text.match(/@layer\s+([\w-]+)\s*\{/);
+      return match ? match[1] : null;
+    }
+
+    afterEach(() => {
+      setThemeLayerName(DEFAULT_THEME_LAYER);
+      // Remove injected theme <style> nodes so re-injection isn't deduped.
+      document.head
+        .querySelectorAll('style[data-xds-theme]')
+        .forEach(el => el.remove());
+    });
+
+    it('injects component overrides into xds-theme by default', () => {
+      const theme = defineTheme({
+        name: 'layer-default',
+        components: {button: {'variant:secondary': {backgroundColor: 'red'}}},
+      });
+      render(
+        <XDSTheme theme={theme}>
+          <span>x</span>
+        </XDSTheme>,
+      );
+      expect(injectedLayerFor('layer-default')).toBe('xds-theme');
+    });
+
+    it('injects into astryx-theme when configured (opt-in)', () => {
+      setThemeLayerName(ASTRYX_THEME_LAYER);
+      const theme = defineTheme({
+        name: 'layer-astryx',
+        components: {button: {'variant:secondary': {backgroundColor: 'red'}}},
+      });
+      render(
+        <XDSTheme theme={theme}>
+          <span>x</span>
+        </XDSTheme>,
+      );
+      expect(injectedLayerFor('layer-astryx')).toBe('astryx-theme');
+    });
   });
 });

--- a/packages/core/src/theme/XDSTheme.tsx
+++ b/packages/core/src/theme/XDSTheme.tsx
@@ -44,6 +44,7 @@ import {colorVars, typographyVars} from './tokens.stylex';
 import {registerIcons} from '../Icon/globalIconRegistry';
 import {generateThemeCSS, type XDSDefinedTheme} from './defineTheme';
 import {XDSThemeContext} from './useXDSTheme';
+import {getThemeLayerName} from '../naming';
 
 /**
  * XDSTheme provider props
@@ -146,13 +147,16 @@ function useThemeStyleInjection(theme: XDSDefinedTheme): void {
       document.head.appendChild(proseStyle);
     }
 
-    // Component overrides go into @layer xds-theme — above StyleX layers
-    // so themes can intentionally restyle components.
+    // Component overrides go into the theme layer (default `xds-theme`) --
+    // above StyleX layers so themes can intentionally restyle components. The
+    // layer name is configurable via setThemeLayerName() so consumers can opt
+    // into the rebranded `astryx-theme` layer before the final cutover; it must
+    // match @xds/build's `layers.theme` option.
     if (component) {
       const compStyle = document.createElement('style');
       compStyle.setAttribute('data-xds-theme', theme.name);
       compStyle.setAttribute('data-xds-id', id);
-      compStyle.textContent = `@layer xds-theme {\n${component}\n}`;
+      compStyle.textContent = `@layer ${getThemeLayerName()} {\n${component}\n}`;
       document.head.appendChild(compStyle);
     }
 


### PR DESCRIPTION
## Summary

Completes the **configurable theme-layer** capability for the XDS → Astryx prefix migration (paste P2380608025). PR #2866 made the **build-side** theme layer name configurable (`@xds/build` vite plugin `layers.theme`); this adds the matching **runtime** half.

## Why both halves are needed

`XDSTheme` injects component-override CSS into `@layer xds-theme` at runtime (`XDSTheme.tsx`). That layer name was hardcoded. If a consumer set the *build* layer order to use `astryx-theme` but the *runtime* still injected into `xds-theme`, the declared layer order and the injected layer would disagree — a cascade split-brain. Per P0, CSS layer names stay `xds-*` through the whole compat window and only rebrand at P10; this capability lets a consumer opt into `astryx-theme` **early and coherently**.

## Changes

- **`naming.ts`** — add `DEFAULT_THEME_LAYER` (`xds-theme`), `ASTRYX_THEME_LAYER` (`astryx-theme`), and `getThemeLayerName()` / `setThemeLayerName()`. Single source of truth, defaulting to `xds-theme` so existing consumers are unaffected.
- **`XDSTheme.tsx`** — read `getThemeLayerName()` instead of the hardcoded `@layer xds-theme`.

Consumer opt-in (must match `@xds/build`'s `layers.theme`):

```ts
import {setThemeLayerName, ASTRYX_THEME_LAYER} from '@xds/core/naming';
setThemeLayerName(ASTRYX_THEME_LAYER); // before any XDSTheme renders
```

## Test plan

- **4 new naming tests**: constants, default `xds-theme`, opt-in `astryx-theme`, arbitrary custom name.
- **2 new XDSTheme integration tests**: render a theme with a component override, assert the injected `<style data-xds-theme>` wraps in `@layer xds-theme` by default and `@layer astryx-theme` when configured.
- `tsc --noEmit` clean; full theme suite (234 tests) + naming (12) pass.

## Scope

This + #2866 complete the **theme-layer** portion of P3c. The remaining P3c pieces (StyleX atomic `libraryPrefix` xds→astryx, and the `--xds-*` var inverted-fallback codegen in `container.stylex.ts` / `generateThemeRules.ts`) will follow as separate PRs — the var-codegen one needs careful validation of StyleX's build-time static analysis of `stylex.create()` template literals.