### PR TITLE
feat(build): expose configurable StyleX library prefix (P3c, part 3)

### DIFF
--- a/packages/build/src/babel.test.mjs
+++ b/packages/build/src/babel.test.mjs
@@ -1,0 +1,74 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file babel.test.mjs
+ * @description Verifies that the XDS babel wrapper applies the configured
+ *   library StyleX class-name prefix to XDS library files. Part of the
+ *   XDS-prefix migration (P2380608025): the prefix defaults to `xds` and is
+ *   configurable to `astryx` so the library atom prefix can be rebranded
+ *   before the final cutover.
+ */
+
+import {describe, it, expect} from 'vitest';
+import {createRequire} from 'node:module';
+
+const require = createRequire(import.meta.url);
+const babel = require('@babel/core');
+const xdsBabelPlugin = require('./babel.js');
+
+const SOURCE = `
+import * as stylex from '@stylexjs/stylex';
+export const styles = stylex.create({
+  box: {color: 'red'},
+});
+`;
+
+/**
+ * Transform a StyleX source through the XDS babel wrapper as if it were a
+ * library file, returning the emitted code. `libraryPrefix` controls the
+ * atomic class-name prefix for library files.
+ */
+function transformLibraryFile(libraryPrefix) {
+  const result = babel.transformSync(SOURCE, {
+    // A path matching one of the library patterns so the wrapper routes it
+    // through the library plugin instance.
+    filename: 'node_modules/@xds/core/src/Box/XDSBox.tsx',
+    babelrc: false,
+    configFile: false,
+    plugins: [
+      [
+        xdsBabelPlugin,
+        {
+          ...(libraryPrefix ? {libraryPrefix} : {}),
+          unstable_moduleResolution: {type: 'commonJS', rootDir: process.cwd()},
+        },
+      ],
+    ],
+  });
+  return result?.code ?? '';
+}
+
+/** Extract the StyleX atomic class names referenced in the emitted code. */
+function atomicClasses(code) {
+  // StyleX emits atoms like "xds1a2b3c" / "astryx1a2b3c" in the compiled output.
+  return code.match(/\b(?:xds|astryx)[a-z0-9]{4,}\b/g) ?? [];
+}
+
+describe('xds babel wrapper -- library StyleX prefix', () => {
+  it('defaults library atoms to the `xds` prefix', () => {
+    const code = transformLibraryFile(undefined);
+    const atoms = atomicClasses(code);
+    expect(atoms.length).toBeGreaterThan(0);
+    expect(atoms.every(c => c.startsWith('xds'))).toBe(true);
+  });
+
+  it('uses the configured `astryx` prefix for library atoms', () => {
+    const code = transformLibraryFile('astryx');
+    const atoms = atomicClasses(code);
+    expect(atoms.length).toBeGreaterThan(0);
+    expect(atoms.every(c => c.startsWith('astryx'))).toBe(true);
+    expect(
+      atoms.some(c => c.startsWith('xds') && !c.startsWith('astryx')),
+    ).toBe(false);
+  });
+});

--- a/packages/build/src/vite.ts
+++ b/packages/build/src/vite.ts
@@ -29,6 +29,8 @@ export const LIGHTNINGCSS_TARGETS = {
 export interface XDSVitePluginLegacyOptions {
   stylexOptions: Parameters<typeof stylex.vite>[0];
   libraryPattern?: string;
+  /** StyleX atomic class-name prefix for XDS library styles. @default 'xds' */
+  stylexPrefix?: string;
   layers?: {
     library?: string;
     /** Layer name for theme overrides @default 'xds-theme' */
@@ -84,6 +86,19 @@ export interface XDSVitePluginOptions {
   lightningcssTargets?: Record<string, number>;
 
   /**
+   * StyleX atomic class-name prefix for XDS *library* styles. The product
+   * build uses a distinct prefix so library and product atoms never collide
+   * across layers.
+   *
+   * Configurable to support the XDS-prefix migration (P2380608025): a consumer
+   * can rebrand the library atom prefix to `astryx` before the final cutover.
+   * Defaults to `xds` so existing consumers are unaffected.
+   *
+   * @default 'xds'
+   */
+  stylexPrefix?: string;
+
+  /**
    * Extra StyleX options to merge.
    */
   stylexOverrides?: Record<string, unknown>;
@@ -120,6 +135,7 @@ export function xdsStylex(
     libraryPattern = XDS_LIBRARY_PATTERN,
     layers = {},
     lightningcssTargets,
+    stylexPrefix = 'xds',
     stylexOverrides = {},
   } = opts;
 
@@ -155,6 +171,7 @@ export function xdsStylex(
           xdsBabelPlugin,
           {
             ...stylexOptions,
+            libraryPrefix: stylexPrefix,
             babelConfig: undefined,
           },
         ],
@@ -301,6 +318,7 @@ function xdsStylexLegacy(options: XDSVitePluginLegacyOptions): Plugin[] {
   const {
     stylexOptions,
     libraryPattern = XDS_LIBRARY_PATTERN,
+    stylexPrefix = 'xds',
     layers = {},
   } = options;
 
@@ -321,6 +339,7 @@ function xdsStylexLegacy(options: XDSVitePluginLegacyOptions): Plugin[] {
           xdsBabelPlugin,
           {
             ...(stylexOptions as any),
+            libraryPrefix: stylexPrefix,
             babelConfig: undefined,
           },
         ],


### PR DESCRIPTION
## Summary

Third P3c build-pipeline piece for the XDS → Astryx prefix migration (paste P2380608025). Exposes the **StyleX atomic library prefix** as a configurable option on `xdsStylex()`.

## Context

`@xds/build`'s babel wrapper (`babel.js`) compiles XDS library files with a distinct StyleX `classNamePrefix` (`xds`) from product files (`x`), so atomic classes never collide across cascade layers. `babel.js` already accepted a `libraryPrefix` option — but the modern `xdsStylex()` Vite entry never threaded it, so library atoms were stuck at `xds`.

## Change

Add a `stylexPrefix` option to `xdsStylex()` (both modern and legacy APIs), defaulting to `xds`, threaded into the babel wrapper as `libraryPrefix`. A consumer can now rebrand library atoms to `astryx` before the final cutover.

This completes the configurable-build trio for opting into the rebranded namespace early:
- `layers.library` (already existed)
- `layers.theme` (#2866)
- **`stylexPrefix`** (this PR)

Internal-only surface (`@xds/build` is `private`); default unchanged, so existing consumers are unaffected.

## Test plan

- New `babel.test.mjs`: runs the XDS babel wrapper through `@babel/core` on a real StyleX source and asserts library atoms are `xds`-prefixed by default and `astryx`-prefixed when `libraryPrefix: 'astryx'` is set. This is a genuine end-to-end StyleX compile, not a mock.
- `vite.test.ts` (5) + `babel.test.mjs` (2) pass; `@xds/build` builds cleanly.

## P3c status after this

The **build-pipeline configurability** for P3c is now complete (layers + StyleX prefix + runtime theme layer in #2880). The one remaining P3c piece is the `--xds-*` **CSS custom-property inverted-fallback codegen** (`container.stylex.ts` / `generateThemeRules.ts`), which needs careful validation of StyleX's build-time static analysis of `stylex.create()` template literals — that lands as its own PR.