### PR TITLE
feat(core): rebrand component padding vars with inverted-fallback compat (P3c, part 4 — final)

### DIFF
--- a/packages/cli/src/commands/build-theme.mjs
+++ b/packages/cli/src/commands/build-theme.mjs
@@ -343,7 +343,12 @@ function parsePadding(props) {
 }
 
 function expandContainerPadding(component, parsed) {
-  const prefix = `--xds-${component}-padding`;
+  // Emit the rebranded --astryx-<component>-padding tokens. The component reads
+  // them via an inverted fallback (var(--xds-*, var(--astryx-*, default))) so a
+  // legacy --xds-* override still wins during compat (XDS-prefix migration
+  // P2380608025). Keep the `astryx` literal in sync with packages/core/src/naming.ts
+  // (NAMESPACE) and the primary path in generateThemeRules.ts.
+  const prefix = `--astryx-${component}-padding`;
   const tokens = [];
 
   // Resolve effective inline values (inlineStart/End override inline)

--- a/packages/core/src/Layout/container.stylex.ts
+++ b/packages/core/src/Layout/container.stylex.ts
@@ -9,19 +9,24 @@
  * ## Public API for themes
  *
  * Themes set `padding` on container component overrides. The theme build
- * pipeline expands this to component-scoped CSS custom properties:
+ * pipeline expands this to component-scoped CSS custom properties. As part of
+ * the XDS-prefix migration (P2380608025), the pipeline now emits the rebranded
+ * `--astryx-*` tokens, while the component reads them via an inverted fallback
+ * chain so a legacy `--xds-*` override set by existing consumer code still wins
+ * during the compat window:
  *
- *   --xds-card-padding            (shorthand — all sides)
- *   --xds-card-padding-inline     (horizontal)
- *   --xds-card-padding-block-start
- *   --xds-card-padding-block-end
+ *   --astryx-card-padding            (shorthand — all sides; emitted)
+ *   --astryx-card-padding-inline     (horizontal)
+ *   --astryx-card-padding-block-start
+ *   --astryx-card-padding-block-end
  *
- * Same pattern for section (--xds-section-padding-*) and dialog
- * (--xds-dialog-padding-*).
+ * Read order per level: `var(--xds-…, var(--astryx-…, <next level>))` — legacy
+ * `--xds-*` wins, then `--astryx-*`, terminating at `--spacing-4`. Same pattern
+ * for section and dialog.
  *
  * ```ts
  * components: {
- *   card: { base: { padding: '20px' } },          // → --xds-card-padding: 20px
+ *   card: { base: { padding: '20px' } },          // → --astryx-card-padding: 20px
  *   section: { base: { padding: '12px 20px' } },  // → directional tokens
  *   dialog: { base: { padding: '16px' } },
  * }
@@ -70,14 +75,16 @@ const baseStyles = stylex.create({
  * Component-scoped padding tokens.
  *
  * Each container component (card, section, dialog) has public CSS custom
- * properties that themes can set:
+ * properties that themes can set. The pipeline emits the rebranded `--astryx-*`
+ * names; the component reads `var(--xds-…, var(--astryx-…, …))` so legacy
+ * `--xds-*` overrides still win during the compat window (P2380608025):
  *
- *   --xds-card-padding          (shorthand — all sides)
- *   --xds-card-padding-inline
- *   --xds-card-padding-inline-start
- *   --xds-card-padding-inline-end
- *   --xds-card-padding-block-start
- *   --xds-card-padding-block-end
+ *   --astryx-card-padding          (shorthand — all sides)
+ *   --astryx-card-padding-inline
+ *   --astryx-card-padding-inline-start
+ *   --astryx-card-padding-inline-end
+ *   --astryx-card-padding-block-start
+ *   --astryx-card-padding-block-end
  *
  * The theme build pipeline maps `padding: '20px'` on a container component
  * to these tokens. The component reads them with var() fallbacks to --spacing-4.
@@ -88,84 +95,119 @@ const baseStyles = stylex.create({
  * the theme CSS sets the token value and the component picks it up via
  * CSS custom property cascade — no layer competition.
  */
+const SP4 = spacingVars['--spacing-4'];
+
+// Card padding chains (XDS-prefix migration P2380608025): legacy --xds-* wins,
+// then --astryx-*, then the next specificity level, terminating at --spacing-4.
+// Built as chained const strings (no function calls) so StyleX can statically
+// analyze them; see naming.ts for the prefix policy.
+const cardShorthand = `var(--xds-card-padding, var(--astryx-card-padding, ${SP4}))`;
+const cardInline = `var(--xds-card-padding-inline, var(--astryx-card-padding-inline, ${cardShorthand}))`;
+const cardInlineStart = `var(--xds-card-padding-inline-start, var(--astryx-card-padding-inline-start, ${cardInline}))`;
+const cardInlineEnd = `var(--xds-card-padding-inline-end, var(--astryx-card-padding-inline-end, ${cardInline}))`;
+const cardBlockStart = `var(--xds-card-padding-block-start, var(--astryx-card-padding-block-start, ${cardShorthand}))`;
+const cardBlockEnd = `var(--xds-card-padding-block-end, var(--astryx-card-padding-block-end, ${cardShorthand}))`;
+
+// Section padding chains (XDS-prefix migration P2380608025): legacy --xds-* wins,
+// then --astryx-*, then the next specificity level, terminating at --spacing-4.
+// Built as chained const strings (no function calls) so StyleX can statically
+// analyze them; see naming.ts for the prefix policy.
+const sectionShorthand = `var(--xds-section-padding, var(--astryx-section-padding, ${SP4}))`;
+const sectionInline = `var(--xds-section-padding-inline, var(--astryx-section-padding-inline, ${sectionShorthand}))`;
+const sectionInlineStart = `var(--xds-section-padding-inline-start, var(--astryx-section-padding-inline-start, ${sectionInline}))`;
+const sectionInlineEnd = `var(--xds-section-padding-inline-end, var(--astryx-section-padding-inline-end, ${sectionInline}))`;
+const sectionBlockStart = `var(--xds-section-padding-block-start, var(--astryx-section-padding-block-start, ${sectionShorthand}))`;
+const sectionBlockEnd = `var(--xds-section-padding-block-end, var(--astryx-section-padding-block-end, ${sectionShorthand}))`;
+
+// Dialog padding chains (XDS-prefix migration P2380608025): legacy --xds-* wins,
+// then --astryx-*, then the next specificity level, terminating at --spacing-4.
+// Built as chained const strings (no function calls) so StyleX can statically
+// analyze them; see naming.ts for the prefix policy.
+const dialogShorthand = `var(--xds-dialog-padding, var(--astryx-dialog-padding, ${SP4}))`;
+const dialogInline = `var(--xds-dialog-padding-inline, var(--astryx-dialog-padding-inline, ${dialogShorthand}))`;
+const dialogInlineStart = `var(--xds-dialog-padding-inline-start, var(--astryx-dialog-padding-inline-start, ${dialogInline}))`;
+const dialogInlineEnd = `var(--xds-dialog-padding-inline-end, var(--astryx-dialog-padding-inline-end, ${dialogInline}))`;
+const dialogBlockStart = `var(--xds-dialog-padding-block-start, var(--astryx-dialog-padding-block-start, ${dialogShorthand}))`;
+const dialogBlockEnd = `var(--xds-dialog-padding-block-end, var(--astryx-dialog-padding-block-end, ${dialogShorthand}))`;
+
 const cardDefaultPaddingStyles = stylex.create({
   containerPaddingInlineStart: {
-    '--container-padding-inline-start': `var(--xds-card-padding-inline-start, var(--xds-card-padding-inline, var(--xds-card-padding, ${spacingVars['--spacing-4']})))`,
+    '--container-padding-inline-start': cardInlineStart,
   },
   containerPaddingInlineEnd: {
-    '--container-padding-inline-end': `var(--xds-card-padding-inline-end, var(--xds-card-padding-inline, var(--xds-card-padding, ${spacingVars['--spacing-4']})))`,
+    '--container-padding-inline-end': cardInlineEnd,
   },
   containerPaddingBlockStart: {
-    '--container-padding-block-start': `var(--xds-card-padding-block-start, var(--xds-card-padding, ${spacingVars['--spacing-4']}))`,
+    '--container-padding-block-start': cardBlockStart,
   },
   containerPaddingBlockEnd: {
-    '--container-padding-block-end': `var(--xds-card-padding-block-end, var(--xds-card-padding, ${spacingVars['--spacing-4']}))`,
+    '--container-padding-block-end': cardBlockEnd,
   },
   layoutPaddingOuterX: {
-    '--layout-padding-outer-x': `var(--xds-card-padding-inline-start, var(--xds-card-padding-inline, var(--xds-card-padding, ${spacingVars['--spacing-4']})))`,
+    '--layout-padding-outer-x': cardInlineStart,
   },
   layoutPaddingOuterY: {
-    '--layout-padding-outer-y': `var(--xds-card-padding-block-start, var(--xds-card-padding, ${spacingVars['--spacing-4']}))`,
+    '--layout-padding-outer-y': cardBlockStart,
   },
   layoutPaddingInnerX: {
-    '--layout-padding-inner-x': `var(--xds-card-padding-inline-start, var(--xds-card-padding-inline, var(--xds-card-padding, ${spacingVars['--spacing-4']})))`,
+    '--layout-padding-inner-x': cardInlineStart,
   },
   layoutPaddingInnerY: {
-    '--layout-padding-inner-y': `var(--xds-card-padding-block-start, var(--xds-card-padding, ${spacingVars['--spacing-4']}))`,
+    '--layout-padding-inner-y': cardBlockStart,
   },
 });
 
 const sectionDefaultPaddingStyles = stylex.create({
   containerPaddingInlineStart: {
-    '--container-padding-inline-start': `var(--xds-section-padding-inline-start, var(--xds-section-padding-inline, var(--xds-section-padding, ${spacingVars['--spacing-4']})))`,
+    '--container-padding-inline-start': sectionInlineStart,
   },
   containerPaddingInlineEnd: {
-    '--container-padding-inline-end': `var(--xds-section-padding-inline-end, var(--xds-section-padding-inline, var(--xds-section-padding, ${spacingVars['--spacing-4']})))`,
+    '--container-padding-inline-end': sectionInlineEnd,
   },
   containerPaddingBlockStart: {
-    '--container-padding-block-start': `var(--xds-section-padding-block-start, var(--xds-section-padding, ${spacingVars['--spacing-4']}))`,
+    '--container-padding-block-start': sectionBlockStart,
   },
   containerPaddingBlockEnd: {
-    '--container-padding-block-end': `var(--xds-section-padding-block-end, var(--xds-section-padding, ${spacingVars['--spacing-4']}))`,
+    '--container-padding-block-end': sectionBlockEnd,
   },
   layoutPaddingOuterX: {
-    '--layout-padding-outer-x': `var(--xds-section-padding-inline-start, var(--xds-section-padding-inline, var(--xds-section-padding, ${spacingVars['--spacing-4']})))`,
+    '--layout-padding-outer-x': sectionInlineStart,
   },
   layoutPaddingOuterY: {
-    '--layout-padding-outer-y': `var(--xds-section-padding-block-start, var(--xds-section-padding, ${spacingVars['--spacing-4']}))`,
+    '--layout-padding-outer-y': sectionBlockStart,
   },
   layoutPaddingInnerX: {
-    '--layout-padding-inner-x': `var(--xds-section-padding-inline-start, var(--xds-section-padding-inline, var(--xds-section-padding, ${spacingVars['--spacing-4']})))`,
+    '--layout-padding-inner-x': sectionInlineStart,
   },
   layoutPaddingInnerY: {
-    '--layout-padding-inner-y': `var(--xds-section-padding-block-start, var(--xds-section-padding, ${spacingVars['--spacing-4']}))`,
+    '--layout-padding-inner-y': sectionBlockStart,
   },
 });
 
 const dialogDefaultPaddingStyles = stylex.create({
   containerPaddingInlineStart: {
-    '--container-padding-inline-start': `var(--xds-dialog-padding-inline-start, var(--xds-dialog-padding-inline, var(--xds-dialog-padding, ${spacingVars['--spacing-4']})))`,
+    '--container-padding-inline-start': dialogInlineStart,
   },
   containerPaddingInlineEnd: {
-    '--container-padding-inline-end': `var(--xds-dialog-padding-inline-end, var(--xds-dialog-padding-inline, var(--xds-dialog-padding, ${spacingVars['--spacing-4']})))`,
+    '--container-padding-inline-end': dialogInlineEnd,
   },
   containerPaddingBlockStart: {
-    '--container-padding-block-start': `var(--xds-dialog-padding-block-start, var(--xds-dialog-padding, ${spacingVars['--spacing-4']}))`,
+    '--container-padding-block-start': dialogBlockStart,
   },
   containerPaddingBlockEnd: {
-    '--container-padding-block-end': `var(--xds-dialog-padding-block-end, var(--xds-dialog-padding, ${spacingVars['--spacing-4']}))`,
+    '--container-padding-block-end': dialogBlockEnd,
   },
   layoutPaddingOuterX: {
-    '--layout-padding-outer-x': `var(--xds-dialog-padding-inline-start, var(--xds-dialog-padding-inline, var(--xds-dialog-padding, ${spacingVars['--spacing-4']})))`,
+    '--layout-padding-outer-x': dialogInlineStart,
   },
   layoutPaddingOuterY: {
-    '--layout-padding-outer-y': `var(--xds-dialog-padding-block-start, var(--xds-dialog-padding, ${spacingVars['--spacing-4']}))`,
+    '--layout-padding-outer-y': dialogBlockStart,
   },
   layoutPaddingInnerX: {
-    '--layout-padding-inner-x': `var(--xds-dialog-padding-inline-start, var(--xds-dialog-padding-inline, var(--xds-dialog-padding, ${spacingVars['--spacing-4']})))`,
+    '--layout-padding-inner-x': dialogInlineStart,
   },
   layoutPaddingInnerY: {
-    '--layout-padding-inner-y': `var(--xds-dialog-padding-block-start, var(--xds-dialog-padding, ${spacingVars['--spacing-4']}))`,
+    '--layout-padding-inner-y': dialogBlockStart,
   },
 });
 

--- a/packages/core/src/theme/defineTheme.test.ts
+++ b/packages/core/src/theme/defineTheme.test.ts
@@ -825,10 +825,10 @@ describe('container padding mapping', () => {
     // Should NOT emit raw padding property (only the scoped token)
     expect(css).not.toMatch(/[^-]padding: 20px/);
     // Should emit component-scoped shorthand token
-    expect(css).toContain('--xds-card-padding: 20px');
+    expect(css).toContain('--astryx-card-padding: 20px');
     // Should NOT emit directional tokens (shorthand covers all sides)
-    expect(css).not.toContain('--xds-card-padding-inline');
-    expect(css).not.toContain('--xds-card-padding-block-start');
+    expect(css).not.toContain('--astryx-card-padding-inline');
+    expect(css).not.toContain('--astryx-card-padding-block-start');
   });
 
   it('maps asymmetric padding to directional tokens', () => {
@@ -841,11 +841,11 @@ describe('container padding mapping', () => {
       },
     });
     const css = generateThemeCSSFlat(theme);
-    expect(css).toContain('--xds-card-padding-inline: 20px');
-    expect(css).toContain('--xds-card-padding-block-start: 16px');
-    expect(css).toContain('--xds-card-padding-block-end: 16px');
+    expect(css).toContain('--astryx-card-padding-inline: 20px');
+    expect(css).toContain('--astryx-card-padding-block-start: 16px');
+    expect(css).toContain('--astryx-card-padding-block-end: 16px');
     // Should NOT emit shorthand (sides differ)
-    expect(css).not.toMatch(/--xds-card-padding:[^-]/);
+    expect(css).not.toMatch(/--astryx-card-padding:[^-]/);
   });
 
   it('maps paddingBlock and paddingInline separately', () => {
@@ -858,9 +858,9 @@ describe('container padding mapping', () => {
       },
     });
     const css = generateThemeCSSFlat(theme);
-    expect(css).toContain('--xds-card-padding-inline: 16px');
-    expect(css).toContain('--xds-card-padding-block-start: 24px');
-    expect(css).toContain('--xds-card-padding-block-end: 24px');
+    expect(css).toContain('--astryx-card-padding-inline: 16px');
+    expect(css).toContain('--astryx-card-padding-block-start: 24px');
+    expect(css).toContain('--astryx-card-padding-block-end: 24px');
   });
 
   it('works for section and dialog too', () => {
@@ -877,10 +877,10 @@ describe('container padding mapping', () => {
     });
     const css = generateThemeCSSFlat(theme);
     // Section — uniform → shorthand
-    expect(css).toContain('--xds-section-padding: 12px');
+    expect(css).toContain('--astryx-section-padding: 12px');
     // Dialog — asymmetric → directional
-    expect(css).toContain('--xds-dialog-padding-inline: 32px');
-    expect(css).toContain('--xds-dialog-padding-block-start: 24px');
+    expect(css).toContain('--astryx-dialog-padding-inline: 32px');
+    expect(css).toContain('--astryx-dialog-padding-block-start: 24px');
   });
 
   it('does NOT map padding on non-container components', () => {
@@ -916,7 +916,7 @@ describe('container padding mapping', () => {
     expect(css).toContain('--_card-radius: 16px');
     expect(css).toContain('background-color: white');
     // Padding is mapped to component-scoped token
-    expect(css).toContain('--xds-card-padding: 20px');
+    expect(css).toContain('--astryx-card-padding: 20px');
     expect(css).not.toMatch(/[^-]padding: 20px/);
   });
 
@@ -930,9 +930,9 @@ describe('container padding mapping', () => {
       },
     });
     const css = generateThemeCSSFlat(theme);
-    expect(css).toContain('--xds-card-padding-block-start: 16px');
-    expect(css).toContain('--xds-card-padding-block-end: 12px');
-    expect(css).toContain('--xds-card-padding-inline: 20px');
+    expect(css).toContain('--astryx-card-padding-block-start: 16px');
+    expect(css).toContain('--astryx-card-padding-block-end: 12px');
+    expect(css).toContain('--astryx-card-padding-inline: 20px');
   });
 
   it('maps paddingBlock shorthand with two values', () => {
@@ -945,8 +945,8 @@ describe('container padding mapping', () => {
       },
     });
     const css = generateThemeCSSFlat(theme);
-    expect(css).toContain('--xds-card-padding-block-start: 16px');
-    expect(css).toContain('--xds-card-padding-block-end: 24px');
+    expect(css).toContain('--astryx-card-padding-block-start: 16px');
+    expect(css).toContain('--astryx-card-padding-block-end: 24px');
   });
 
   it('maps paddingInline shorthand with two values', () => {
@@ -959,8 +959,8 @@ describe('container padding mapping', () => {
       },
     });
     const css = generateThemeCSSFlat(theme);
-    expect(css).toContain('--xds-card-padding-inline-start: 12px');
-    expect(css).toContain('--xds-card-padding-inline-end: 20px');
+    expect(css).toContain('--astryx-card-padding-inline-start: 12px');
+    expect(css).toContain('--astryx-card-padding-inline-end: 20px');
   });
 
   it('maps paddingBlockStart alone', () => {
@@ -973,9 +973,9 @@ describe('container padding mapping', () => {
       },
     });
     const css = generateThemeCSSFlat(theme);
-    expect(css).toContain('--xds-card-padding-block-start: 32px');
-    expect(css).not.toContain('--xds-card-padding-block-end');
-    expect(css).not.toContain('--xds-card-padding-inline');
+    expect(css).toContain('--astryx-card-padding-block-start: 32px');
+    expect(css).not.toContain('--astryx-card-padding-block-end');
+    expect(css).not.toContain('--astryx-card-padding-inline');
   });
 
   it('maps paddingInlineStart and paddingInlineEnd separately', () => {
@@ -988,8 +988,8 @@ describe('container padding mapping', () => {
       },
     });
     const css = generateThemeCSSFlat(theme);
-    expect(css).toContain('--xds-card-padding-inline-start: 8px');
-    expect(css).toContain('--xds-card-padding-inline-end: 24px');
+    expect(css).toContain('--astryx-card-padding-inline-start: 8px');
+    expect(css).toContain('--astryx-card-padding-inline-end: 24px');
   });
 });
 

--- a/packages/core/src/theme/generateThemeRules.test.ts
+++ b/packages/core/src/theme/generateThemeRules.test.ts
@@ -321,8 +321,8 @@ describe('derived var expansion', () => {
     const rules = generateThemeRules(theme);
     const rule = rules.find(r => r.includes('.xds-card'));
     expect(rule).toBeDefined();
-    // Container expansion emits --xds-card-padding token
-    expect(rule).toContain('--xds-card-padding: 20px');
+    // Container expansion emits --astryx-card-padding token
+    expect(rule).toContain('--astryx-card-padding: 20px');
   });
 
   it('handles variant-specific derived vars', () => {
@@ -372,7 +372,7 @@ describe('brutalist-style derived expansion', () => {
     const rules = generateThemeRules(theme);
     const rule = rules.find(r => r.includes('.xds-card'));
     expect(rule).toBeDefined();
-    expect(rule).toContain('--xds-card-padding: 24px');
+    expect(rule).toContain('--astryx-card-padding: 24px');
   });
 
   it('dropdown-menu borderRadius + padding emit both derived vars', () => {

--- a/packages/core/src/theme/generateThemeRules.ts
+++ b/packages/core/src/theme/generateThemeRules.ts
@@ -18,6 +18,7 @@
 import type {XDSDefinedTheme} from './defineTheme';
 import {parseStyleKey} from '../utils/parseStyleKey';
 import {getDerivedVars} from './derivedVarRegistry';
+import {cssVar} from '../naming';
 
 // =============================================================================
 // Types
@@ -144,12 +145,16 @@ function parsePadding(props: [string, string][]): ParsedPadding {
 /**
  * Expand parsed padding into component-scoped public tokens.
  *
- * Emits --xds-<component>-padding (shorthand) and directional overrides:
- *   --xds-card-padding: 20px
- *   --xds-card-padding-inline: 20px
- *   --xds-card-padding-block-start: 20px
- *   --xds-card-padding-block-end: 20px
+ * Emits the rebranded --astryx-<component>-padding tokens (shorthand +
+ * directional overrides), e.g.:
+ *   --astryx-card-padding: 20px
+ *   --astryx-card-padding-inline: 20px
+ *   --astryx-card-padding-block-start: 20px
+ *   --astryx-card-padding-block-end: 20px
  *
+ * The component reads these with an inverted fallback chain
+ * (var(--xds-*, var(--astryx-*, default))) so a legacy --xds-* override set by
+ * existing consumer code still wins during the compat window (P2380608025).
  * The container.stylex.ts default styles read these via var() fallbacks,
  * so the theme CSS sets the value and the component picks it up through
  * CSS custom property cascade — no layer competition with StyleX output.
@@ -158,7 +163,7 @@ function expandContainerPadding(
   component: string,
   parsed: ParsedPadding,
 ): [string, string][] {
-  const prefix = `--xds-${component}-padding`;
+  const prefix = cssVar(`${component}-padding`);
   const tokens: [string, string][] = [];
 
   // Resolve effective inline values (inlineStart/End override inline)


### PR DESCRIPTION
## Summary

The **final P3c piece**: migrates the `--xds-*` CSS custom properties for component padding (card/section/dialog). Per the P0 decision, the theme pipeline now **emits** the rebranded `--astryx-*` defaults, while components **read** them through an *inverted* fallback so a legacy `--xds-*` override set by existing consumer code still wins during the compat window (P2380608025).

## The inverted-fallback chain

Read order per specificity level (in `container.stylex.ts`):

```
var(--xds-<v>, var(--astryx-<v>, <next level>))   ... terminating at --spacing-4
```

The built `xds.css` confirms it — e.g. card inline-start compiles to:

```css
var(--xds-card-padding-inline-start, var(--astryx-card-padding-inline-start,
  var(--xds-card-padding-inline, var(--astryx-card-padding-inline,
    var(--xds-card-padding, var(--astryx-card-padding, var(--spacing-4)))))))
```

Legacy `--xds-*` wins → then `--astryx-*` → then next level. Specificity-outer, per P0's "consumers use one prefix or the other" assumption.

## The StyleX constraint (the hard part)

`stylex.create()` **rejects function calls** in value resolution (`Unsupported expression: FunctionDeclaration`) — verified empirically, including a module-level `const` built *by* a function. So a DRY helper is impossible. The chains are instead precomputed as **chained module-level `const` strings** (pure string concatenation, no functions) and interpolated into `stylex.create()`, which StyleX statically analyzes correctly. Validated end-to-end: the built `xds.css` contains all 24 inverted chains (3 components × 8 properties).

## Changes

- **`container.stylex.ts`** (read side): card/section/dialog padding chains rebuilt as chained consts with the inverted `--xds`-then-`--astryx` fallback; doc headers updated.
- **`generateThemeRules.ts`** (write side, runtime): emit `--astryx-<component>-padding` via `cssVar()` from `naming.ts` (was hardcoded `--xds-`).
- **`build-theme.mjs`** (write side, CLI fallback): `expandContainerPadding` emits `--astryx-` too, kept in sync with the core primary path (SYNC note added).
- **tests**: updated padding-var emit assertions in `defineTheme.test.ts` / `generateThemeRules.test.ts` to `--astryx-*`. **CSS classes, data-attrs, and layer names are unchanged** (only the padding vars rebranded, per P0).

## Test plan

- `@xds/core` builds (full StyleX compile) cleanly; the inverted chain is present in `dist/xds.css`.
- 271 theme/Layout/Card/Section tests pass; `tsc --noEmit` clean.

## P3c complete

This finishes **P3c** — all four parts: configurable layers (#2866), runtime theme layer (#2880), StyleX prefix (#2881), and now the var inverted-fallback codegen.