### PR TITLE
feat(cli): add rebrand-xds-css-namespace codemod (P2)

### DIFF
--- a/packages/cli/src/codemods/transforms/v0.0.15/__tests__/rebrand-xds-css-namespace.test.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.15/__tests__/rebrand-xds-css-namespace.test.mjs
@@ -1,0 +1,78 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {describe, it, expect} from 'vitest';
+
+async function applyTransform(source) {
+  const {default: transform} = await import('../rebrand-xds-css-namespace.mjs');
+  const file = {source, path: 'test.css'};
+  const result = transform(file);
+  return result ?? source;
+}
+
+describe('rebrand-xds-css-namespace', () => {
+  it('rewrites .xds-* class selectors to .astryx-*', async () => {
+    const out = await applyTransform('.xds-button { color: red; }');
+    expect(out).toBe('.astryx-button { color: red; }');
+  });
+
+  it('rewrites data-xds-* attribute selectors', async () => {
+    const out = await applyTransform(
+      '[data-xds-theme="dark"] .xds-card { padding: 0; }',
+    );
+    expect(out).toBe('[data-astryx-theme="dark"] .astryx-card { padding: 0; }');
+  });
+
+  it('rewrites data-xds-* attributes in JSX/markup', async () => {
+    const out = await applyTransform('<div data-xds-media="dark" />');
+    expect(out).toBe('<div data-astryx-media="dark" />');
+  });
+
+  it('rewrites data-xds-* in getAttribute string args', async () => {
+    const out = await applyTransform("el.getAttribute('data-xds-theme')");
+    expect(out).toBe("el.getAttribute('data-astryx-theme')");
+  });
+
+  it('rewrites bare xds-* class tokens in className strings', async () => {
+    const out = await applyTransform('className="xds-button primary"');
+    expect(out).toBe('className="astryx-button primary"');
+  });
+
+  it('PRESERVES @layer xds-base / xds-theme (layer names stay through compat)', async () => {
+    const src = '@layer reset, xds-base, xds-theme, product;';
+    const out = await applyTransform(src);
+    expect(out).toBe(src);
+  });
+
+  it('PRESERVES --xds-* custom properties', async () => {
+    const src = '.my-card { --xds-card-padding: 24px; }';
+    const out = await applyTransform(src);
+    // The class selector `.my-card` is untouched and the --xds- var is left as-is
+    // (var migration is a separate, human-reviewed step).
+    expect(out).toBe(src);
+  });
+
+  it('does not rebrand --xds-* even when xds-base layer is nearby', async () => {
+    const src =
+      '@layer xds-theme {\n  .my-thing { --xds-card-padding: 8px; }\n}';
+    const out = await applyTransform(src);
+    expect(out).toBe(src);
+  });
+
+  it('rewrites a realistic consumer override block', async () => {
+    const src = [
+      '[data-xds-theme="brand"] .xds-button[data-variant="primary"] {',
+      '  background: hotpink;',
+      '}',
+    ].join('\n');
+    const out = await applyTransform(src);
+    expect(out).toContain('[data-astryx-theme="brand"]');
+    expect(out).toContain('.astryx-button[data-variant="primary"]');
+    expect(out).not.toContain('xds-');
+  });
+
+  it('returns source unchanged when nothing matches', async () => {
+    const src = '.my-button { color: blue; }';
+    const out = await applyTransform(src);
+    expect(out).toBe(src);
+  });
+});

--- a/packages/cli/src/codemods/transforms/v0.0.15/index.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.15/index.mjs
@@ -34,6 +34,10 @@ import dropXdsPrefixImports, {
   meta as dropXdsPrefixImportsMeta,
 } from './drop-xds-prefix-imports.mjs';
 
+import rebrandXdsCssNamespace, {
+  meta as rebrandXdsCssNamespaceMeta,
+} from './rebrand-xds-css-namespace.mjs';
+
 export default [
   {
     name: 'rename-date-picker-to-input',
@@ -73,6 +77,15 @@ export default [
     name: 'drop-xds-prefix-imports',
     transform: dropXdsPrefixImports,
     meta: dropXdsPrefixImportsMeta,
+    optional: true,
+  },
+  {
+    // XDS-prefix migration (P2380608025). Optional + not version-tied:
+    // consumers run it explicitly to rebrand override CSS/markup, e.g.
+    //   xds upgrade --codemod rebrand-xds-css-namespace --codemod-only --apply
+    name: 'rebrand-xds-css-namespace',
+    transform: rebrandXdsCssNamespace,
+    meta: rebrandXdsCssNamespaceMeta,
     optional: true,
   },
 ];

--- a/packages/cli/src/codemods/transforms/v0.0.15/rebrand-xds-css-namespace.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.15/rebrand-xds-css-namespace.mjs
@@ -1,0 +1,100 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Codemod: rebrand xds-* CSS classes and data-xds-* attributes to astryx-*
+ *
+ * Part of the XDS-prefix migration (P2380608025). Rewrites consumer override
+ * CSS (and inline className/selector strings) from the legacy `xds` DOM
+ * namespace to the rebranded `astryx` namespace:
+ *
+ *   .xds-button          -> .astryx-button
+ *   [data-xds-theme=...]  -> [data-astryx-theme=...]
+ *   data-xds-media        -> data-astryx-media   (attribute usage in JSX/JS)
+ *
+ * During the compat window the library dual-emits BOTH class names and BOTH
+ * theme/media data attributes, so a consumer can flip their selectors to the
+ * `astryx` form at any time and they keep matching.
+ *
+ * Deliberately DOES NOT touch (per the P0 decision):
+ * - CSS cascade-layer names `@layer xds-base` / `@layer xds-theme` -- a layer
+ *   cannot be aliased/dual-emitted, so layer names stay `xds-*` through the
+ *   entire compat window and are only rebranded at the final cutover. Rewriting
+ *   them here would desync a consumer from the library's emitted layer.
+ * - `--xds-*` custom properties -- those use an inverted read fallback and need
+ *   per-case human review (stale vs intentional), handled separately.
+ * - the bare token `xds` anywhere it is not immediately followed by `-<word>`
+ *   in a class/attribute position.
+ */
+
+export const meta = {
+  title: 'Rebrand xds-* CSS classes and data-xds-* attributes to astryx-*',
+  description:
+    'Rewrites consumer CSS/markup from the legacy `xds` DOM namespace to ' +
+    '`astryx`: `.xds-button` -> `.astryx-button`, `data-xds-theme` -> ' +
+    '`data-astryx-theme`. Leaves CSS @layer names (xds-base/xds-theme) and ' +
+    '--xds-* custom properties untouched.',
+  pr: '#2883',
+  fileExtensions: [
+    '.css',
+    '.scss',
+    '.sass',
+    '.less',
+    '.ts',
+    '.tsx',
+    '.js',
+    '.jsx',
+    '.mjs',
+    '.cjs',
+  ],
+};
+
+/**
+ * Rewrite `data-xds-<name>` attribute references to `data-astryx-<name>`.
+ * Matches the attribute in CSS selectors (`[data-xds-theme="x"]`), JSX
+ * (`data-xds-media="dark"`), and string args (`getAttribute('data-xds-theme')`).
+ */
+const DATA_ATTR_RE = /\bdata-xds-([a-z][a-z0-9-]*)/g;
+
+/**
+ * Rewrite `.xds-<name>` CLASS SELECTORS to `.astryx-<name>`. The leading dot
+ * ensures we only match class selectors, not `@layer xds-base`, the bare word
+ * `xds`, or `--xds-*` custom properties.
+ */
+const CLASS_SELECTOR_RE = /\.xds-([a-z][a-z0-9-]*)/g;
+
+/**
+ * Rewrite `xds-<name>` class tokens inside className/class string literals.
+ * Conservative: only fires for tokens with a word boundary on both sides that
+ * are NOT preceded by `-` (so `--xds-foo` custom props and `data-xds-foo` are
+ * not matched here -- those are handled by the dedicated patterns or skipped).
+ * Layer names `xds-base`/`xds-theme` are explicitly preserved.
+ */
+const LAYER_NAMES = new Set(['xds-base', 'xds-theme']);
+// Leading group captures the boundary char (start-of-string, whitespace, or a
+// string quote) so we don't match `--xds-foo` (preceded by `-`) or substrings.
+const CLASS_TOKEN_RE = new RegExp('(^|[\\s"\'`])xds-([a-z][a-z0-9-]*)', 'g');
+
+export function rebrandXdsNamespace(source) {
+  let out = source;
+
+  // 1. data-xds-* attributes (CSS, JSX, string args)
+  out = out.replace(DATA_ATTR_RE, (_full, name) => `data-astryx-${name}`);
+
+  // 2. .xds-* class selectors
+  out = out.replace(CLASS_SELECTOR_RE, (_full, name) => `.astryx-${name}`);
+
+  // 3. bare xds-* class tokens in className strings (e.g. "xds-button primary")
+  out = out.replace(CLASS_TOKEN_RE, (full, lead, name) => {
+    const token = `xds-${name}`;
+    // Preserve cascade-layer names -- they stay xds-* through compat.
+    if (LAYER_NAMES.has(token)) return full;
+    return `${lead}astryx-${name}`;
+  });
+
+  return out;
+}
+
+export default function transformer(file) {
+  const result = rebrandXdsNamespace(file.source);
+  return result === file.source ? undefined : result;
+}


### PR DESCRIPTION
## Summary

Second **P2 (codemods)** transform for the XDS → Astryx prefix migration (paste P2380608025). Rebrands consumer override CSS and markup from the legacy `xds` DOM namespace to `astryx`:

```
.xds-button           ->  .astryx-button
[data-xds-theme=...]  ->  [data-astryx-theme=...]
data-xds-media="dark"  ->  data-astryx-media="dark"   (JSX/markup)
className="xds-card"   ->  className="astryx-card"
```

Pairs with the JS-identifier codemod (#2879) — together they cover the consumer-side rewrites P9 runs per app.

> **Stacked on #2879** (`navi/feat/p2-codemods`) — this PR targets that branch so the diff shows only the CSS codemod. Both share the v0.0.15 manifest. Merge #2879 first (or retarget this to integration once #2879 lands).

## Safety boundaries (per P0)

During compat the library dual-emits both class names and the theme/media data attributes, so flipping selectors to `astryx` is always safe. The codemod **deliberately leaves untouched**:

- **`@layer xds-base` / `@layer xds-theme`** — a CSS layer can't be aliased or dual-emitted, so layer names stay `xds-*` through the whole compat window and only rebrand at final cutover. Rewriting them would desync the consumer from the library's emitted layer (the split-brain hazard).
- **`--xds-*` custom properties** — these use the inverted read fallback (#2882) and need per-case human review (stale vs intentional override), handled separately in P9.

## Implementation

String-based transform (CSS isn't JS-parseable), mirroring the existing `migrate-theme-selectors-to-data-attrs` codemod. Three patterns: `data-xds-*` attributes, `.xds-*` class selectors, and bare `xds-*` class tokens in `className` strings (with a `LAYER_NAMES` guard preserving `xds-base`/`xds-theme`).

Registered in v0.0.15 as `optional`; run via:
```
xds upgrade --codemod rebrand-xds-css-namespace --codemod-only --apply
```

## Test plan

- **10 tests**: class selectors, data-attr selectors, JSX attrs, `getAttribute` string args, `className` tokens, a realistic override block, and the safety cases (layer names + `--xds-*` vars preserved).
- 26 tests pass across both P2 codemods + the upgrade suite; manifest loads and both codemods are discoverable.