### PR TITLE
docs(dense): fix bestPractices count parity for Selector and MultiSelector

### DIFF
--- a/packages/core/src/MultiSelector/MultiSelector.doc.mjs
+++ b/packages/core/src/MultiSelector/MultiSelector.doc.mjs
@@ -246,6 +246,11 @@ export const docsZh = {
       {
         guidance: true,
         description:
+          'Use renderOption for custom option rows; the checkbox affordance remains owned by XDSMultiSelector.',
+      },
+      {
+        guidance: true,
+        description:
           'Enable select-all when most users will want all or nearly all options selected.',
       },
       {
@@ -277,6 +282,11 @@ export const docsDense = {
         guidance: true,
         description:
           'Enable search filtering when the list exceeds ~15 options.',
+      },
+      {
+        guidance: true,
+        description:
+          'renderOption for custom rows; checkbox affordance stays owned by XDSMultiSelector.',
       },
       {
         guidance: true,

--- a/packages/core/src/Selector/Selector.doc.mjs
+++ b/packages/core/src/Selector/Selector.doc.mjs
@@ -227,6 +227,11 @@ export const docsZh = {
       {
         guidance: true,
         description:
+          'Use renderOption for custom option rows. Do not pass XDSSelectorOption directly as JSX children.',
+      },
+      {
+        guidance: true,
+        description:
           'Set a meaningful placeholder that hints at the expected selection (e.g. "Choose a country" not "Select...").',
       },
       {
@@ -305,6 +310,11 @@ export const docsDense = {
         guidance: true,
         description:
           'Use sections and dividers to organize options when the list exceeds ~8 items.',
+      },
+      {
+        guidance: true,
+        description:
+          'renderOption for custom rows; do not pass XDSSelectorOption as JSX children.',
       },
       {
         guidance: true,


### PR DESCRIPTION
## What

Selector and MultiSelector both had a bestPractices count mismatch between their English docs and their docsZh/docsDense overlays. Both overlays were missing the `renderOption` guidance entry (E2), causing:
- Selector: 9 English vs 8 dense/zh
- MultiSelector: 6 English vs 5 dense/zh

The CLI silently falls back to English for the missing position, so dense users got an uncompressed bullet mixed in.

## Fix

Added the missing bestPractice at the correct position (index 2) in both docsZh and docsDense for each component.

## Validation
- `pnpm --filter @xds/core typecheck:docs` passes
- `npx tsc --project packages/cli/tsconfig.template-docs.json --noEmit` passes
- `node .github/scripts/api-cli-parity-test.mjs --no-baseline` passes (322/322)
- Dense audit bullet drift: 0 (was 2)
- Rendered output verified: `xds component Selector --lang dense` and `xds component MultiSelector --lang dense` both show correct count

---
*Night Watch -- Doc Reviewer*