### PR TITLE
fix(Icon,InputGroup): forward rest props in string mode and InputGroupText

### DIFF
--- a/packages/core/src/Icon/XDSIcon.tsx
+++ b/packages/core/src/Icon/XDSIcon.tsx
@@ -224,7 +224,14 @@ export function XDSIcon({
 }: XDSIconProps) {
   // String mode: resolve from icon registry, wrap in styled span
   if (typeof icon === 'string') {
-    return <IconFromRegistry name={icon} color={color} size={size} />;
+    return (
+      <IconFromRegistry
+        name={icon}
+        color={color}
+        size={size}
+        spanProps={props}
+      />
+    );
   }
 
   // Component mode: render SVG component directly with ref forwarding
@@ -259,10 +266,12 @@ function IconFromRegistry({
   name,
   color,
   size,
+  spanProps,
 }: {
   name: XDSIconName;
   color: XDSIconColor;
   size: XDSIconSize;
+  spanProps?: Omit<SVGProps<SVGSVGElement>, 'ref' | 'color'>;
 }) {
   const resolvedIcon = getIcon(name);
 
@@ -272,6 +281,7 @@ function IconFromRegistry({
 
   return (
     <span
+      {...(spanProps as React.HTMLAttributes<HTMLSpanElement>)}
       {...mergeProps(
         xdsThemeProps('icon', {size, color}),
         stylex.props(styles.span, colorStyles[color], spanSizeStyles[size]),

--- a/packages/core/src/InputGroup/XDSInputGroupText.tsx
+++ b/packages/core/src/InputGroup/XDSInputGroupText.tsx
@@ -92,10 +92,12 @@ export function XDSInputGroupText({
   xstyle,
   className,
   style,
+  ...rest
 }: XDSInputGroupTextProps) {
   return (
     <div
       ref={ref}
+      {...rest}
       {...mergeProps(
         xdsThemeProps('input-group-text'),
         stylex.props(styles.text, xstyle),


### PR DESCRIPTION
## Summary

Two prop-forwarding bugs found during component audit:

**XDSIcon (string mode):** When `icon` is a semantic name string, the component rendered an internal `IconFromRegistry` but discarded all remaining props (`data-testid`, `className`, event handlers). Component mode forwarded these correctly. Now both paths forward rest props.

**XDSInputGroupText:** The interface extends `XDSBaseProps<HTMLDivElement>` (which includes `data-*`, `aria-*`, `id`, event handlers) but the implementation only destructured `ref`, `children`, `xstyle`, `className`, `style`. Everything else was silently dropped. Added `...rest` forwarding.

## Needs Review

**XDSInputGroup aria-describedby gap:** When a status message is rendered on the group, the `<div role="group">` container does not wire `aria-describedby` to the status message ID. The field renders the message visually, but assistive technology may not associate it with the group. This needs a design decision: should the group element itself carry `aria-describedby`, or should the context pass the ID to child inputs?

## Components Audited

- HStack (clean)
- Heading (clean)
- Icon (fixed)
- IconButton (clean)
- InputGroup (fixed)

Night Watch — Component Auditor