### PR TITLE
fix(cli): add anti-pattern guidance for Text and Icon docs

### DIFF
--- a/packages/core/src/Icon/Icon.doc.mjs
+++ b/packages/core/src/Icon/Icon.doc.mjs
@@ -11,7 +11,7 @@ export const docs = {
     {
       name: 'icon',
       type: 'XDSIconName | ComponentType<SVGProps>',
-      description: 'Semantic icon name or SVG component. Run `npx xds docs icons` for valid names.',
+      description: 'Semantic icon name or SVG component. Run `npx xds docs icons` for valid names. Note: this prop is called `icon`, not `name`.',
       required: true,
     },
     {
@@ -43,6 +43,7 @@ export const docs = {
       { guidance: false, description: 'Resize icons with arbitrary pixel values; use the provided size props.' },
       { guidance: false, description: 'Mix icon styles (e.g. outline and filled) within the same context.' },
       { guidance: false, description: 'Render raw SVG elements; always wrap in Icon for consistent sizing and color.' },
+      { guidance: false, description: 'Pass a `name` prop \u2014 XDSIcon uses `icon` (not `name`) to specify which icon to render.' },
     ],
   },
 };
@@ -87,6 +88,7 @@ export const docsZh = {
       { guidance: false, description: 'Resize icons with arbitrary pixel values; use the provided size props.' },
       { guidance: false, description: 'Mix icon styles (e.g. outline and filled) within the same context.' },
       { guidance: false, description: 'Render raw SVG elements; always wrap in Icon for consistent sizing and color.' },
+      { guidance: false, description: 'Pass a `name` prop \u2014 XDSIcon uses `icon` (not `name`) to specify which icon to render.' },
     ],
   },
 };
@@ -106,6 +108,7 @@ export const docsDense = {
       { guidance: false, description: 'Resize icons with arbitrary pixel values; use the provided size props.' },
       { guidance: false, description: 'Mix icon styles (e.g. outline and filled) within the same context.' },
       { guidance: false, description: 'Render raw SVG elements; always wrap in Icon for consistent sizing and color.' },
+      { guidance: false, description: '`name` prop \u2014 does not exist. Use `icon` to specify which icon to render.' },
     ],
   },
   propDescriptions: {

--- a/packages/core/src/Text/Text.doc.mjs
+++ b/packages/core/src/Text/Text.doc.mjs
@@ -23,8 +23,8 @@ export const docs = {
   props: [
     {
       name: 'type',
-      type: "'body' | 'large' | 'label' | 'supporting' | 'code'",
-      description: 'Semantic text type. Determines size, weight, and line-height from the theme.',
+      type: "'body' | 'large' | 'label' | 'supporting' | 'code' | 'display-1' | 'display-2' | 'display-3'",
+      description: 'Semantic text type. Determines size, weight, and line-height from the theme. Note: this prop is called `type`, not `variant`.',
       default: "'body'",
     },
     {
@@ -125,6 +125,8 @@ export const docs = {
       { guidance: false, description: 'Override size and weight when a semantic type already matches \u2014 extra overrides fight the theme and break when themes change.' },
       { guidance: false, description: 'Skip heading levels in the document outline \u2014 go h1 then h2 then h3, never h1 then h3.' },
       { guidance: false, description: 'Use raw HTML tags like <p>, <h1>\u2013<h6>, or <span> for text \u2014 XDSText and XDSHeading apply the correct theme tokens automatically.' },
+      { guidance: false, description: 'Pass a `variant` prop \u2014 XDSText does not have a `variant` prop. Use `type` for semantic styling (body, label, large, supporting, code) or use XDSHeading for headings.' },
+      { guidance: false, description: 'Use XDSText for headings \u2014 use XDSHeading with a `level` prop (1\u20136) for section titles and headings.' },
     ],
   },
 };
@@ -142,6 +144,8 @@ export const docsZh = {
       { guidance: false, description: 'Override size and weight when a semantic type already matches \u2014 extra overrides fight the theme and break when themes change.' },
       { guidance: false, description: 'Skip heading levels in the document outline \u2014 go h1 then h2 then h3, never h1 then h3.' },
       { guidance: false, description: 'Use raw HTML tags like <p>, <h1>\u2013<h6>, or <span> for text \u2014 XDSText and XDSHeading apply the correct theme tokens automatically.' },
+      { guidance: false, description: 'Pass a `variant` prop \u2014 XDSText does not have a `variant` prop. Use `type` for semantic styling (body, label, large, supporting, code) or use XDSHeading for headings.' },
+      { guidance: false, description: 'Use XDSText for headings \u2014 use XDSHeading with a `level` prop (1\u20136) for section titles and headings.' },
     ],
   },
 };
@@ -160,6 +164,7 @@ export const docsDense = {
       { guidance: false, description: 'Override size/weight when a semantic type already matches.' },
       { guidance: false, description: 'Skip heading levels \u2014 sequential h1 \u2192 h2 \u2192 h3.' },
       { guidance: false, description: 'Raw <p>/<h1>/<span> \u2014 use XDSText/XDSHeading for theme tokens.' },
+      { guidance: false, description: '`variant` prop \u2014 does not exist. Use `type` for text styling or XDSHeading for headings.' },
     ],
   },
 };


### PR DESCRIPTION
## What

Adds explicit "Don't" guidance to Text and Icon CLI docs to prevent common prop name confusion.

## Why

The vibe test nightly (issue #2886) showed agents consistently using:
- `variant` prop on XDSText (does not exist — should use `type`)
- `name` prop on XDSIcon (does not exist — should use `icon`)
- XDSText for headings (should use XDSHeading)

Even though the docs correctly list the right prop names, agents default to familiar patterns from other design systems (MUI, Chakra). Explicit anti-patterns in the "Don't" list directly address this.

Also fixed the XDSText `type` prop documentation to include `display-1`, `display-2`, and `display-3` values that were missing from the documented union type.

## Changes

- `packages/core/src/Text/Text.doc.mjs`: Added "Don't use variant" and "Don't use XDSText for headings" guidance; expanded `type` prop union to include display types
- `packages/core/src/Icon/Icon.doc.mjs`: Added "Don't use name" guidance; clarified `icon` prop description

## Verification

- [x] `node packages/cli/bin/xds.mjs component Text` now shows anti-pattern guidance
- [x] `node packages/cli/bin/xds.mjs component Icon` now shows anti-pattern guidance  
- [x] TypeScript types match documentation (display-1/2/3 are valid XDSTextType values)
- [x] Build passes
- [x] Doc files load without errors

Vibe Test Debugger