### PR TITLE
chore(build): drop configurable theme-layer opt-in (keep xds-theme until cutover)

### DIFF
--- a/packages/build/src/vite.test.ts
+++ b/packages/build/src/vite.test.ts
@@ -2,10 +2,11 @@
 
 /**
  * @file vite.test.ts
- * @description Verifies CSS layer-order injection in the XDS Vite plugin,
- *   including the configurable theme layer added for the XDS-prefix migration
- *   (P2380608025). Default theme layer is `xds-theme`; consumers may opt into
- *   a rebranded layer (e.g. `astryx-theme`) before final cutover.
+ * @description Verifies CSS layer-order injection in the XDS Vite plugin.
+ *   The theme layer name is intentionally NOT configurable — it stays
+ *   `xds-theme` for the whole compatibility window and is rebranded only at
+ *   the final cutover (XDS-prefix migration P2380608025), so consumers never
+ *   have to touch their `@layer` order line until then.
  */
 
 import {describe, it, expect} from 'vitest';
@@ -24,36 +25,23 @@ function getLayerOrder(plugins: ReturnType<typeof xdsStylex>): string {
 }
 
 describe('xdsStylex layer order (modern API)', () => {
-  it('defaults to the legacy xds-* layer names', () => {
+  it('uses the xds-* layer names (theme layer is xds-theme)', () => {
     const order = getLayerOrder(xdsStylex());
     expect(order).toBe('@layer reset, xds-base, xds-theme, product;');
   });
 
-  it('honors a configured theme layer (astryx-theme opt-in)', () => {
-    const order = getLayerOrder(xdsStylex({layers: {theme: 'astryx-theme'}}));
-    expect(order).toBe('@layer reset, xds-base, astryx-theme, product;');
-  });
-
-  it('honors all configured layer names together', () => {
+  it('honors configured library and product layer names', () => {
     const order = getLayerOrder(
-      xdsStylex({
-        layers: {library: 'astryx-base', theme: 'astryx-theme', product: 'app'},
-      }),
+      xdsStylex({layers: {library: 'astryx-base', product: 'app'}}),
     );
-    expect(order).toBe('@layer reset, astryx-base, astryx-theme, app;');
+    // The theme layer stays xds-theme regardless of other layer config.
+    expect(order).toBe('@layer reset, astryx-base, xds-theme, app;');
   });
 });
 
 describe('xdsStylex layer order (legacy API)', () => {
-  it('defaults to the legacy xds-* layer names', () => {
+  it('uses the xds-* layer names (theme layer is xds-theme)', () => {
     const order = getLayerOrder(xdsStylex({stylexOptions: {}}));
     expect(order).toBe('@layer reset, xds-base, xds-theme, product;');
-  });
-
-  it('honors a configured theme layer', () => {
-    const order = getLayerOrder(
-      xdsStylex({stylexOptions: {}, layers: {theme: 'astryx-theme'}}),
-    );
-    expect(order).toBe('@layer reset, xds-base, astryx-theme, product;');
   });
 });

--- a/packages/build/src/vite.ts
+++ b/packages/build/src/vite.ts
@@ -33,8 +33,6 @@ export interface XDSVitePluginLegacyOptions {
   stylexPrefix?: string;
   layers?: {
     library?: string;
-    /** Layer name for theme overrides @default 'xds-theme' */
-    theme?: string;
     product?: string;
   };
 }
@@ -64,15 +62,6 @@ export interface XDSVitePluginOptions {
   layers?: {
     /** Layer name for XDS library styles @default 'xds-base' */
     library?: string;
-    /**
-     * Layer name for XDS theme overrides @default 'xds-theme'
-     *
-     * Configurable to support the XDS-prefix migration (P2380608025): a
-     * consumer can opt into the rebranded `astryx-theme` layer before the
-     * final cutover by setting this (and the matching runtime theme-layer
-     * name). Defaults to `xds-theme` so existing consumers are unaffected.
-     */
-    theme?: string;
     /** Layer name for product styles @default 'product' */
     product?: string;
   };
@@ -140,7 +129,6 @@ export function xdsStylex(
   } = opts;
 
   const libraryLayer = layers.library ?? 'xds-base';
-  const themeLayer = layers.theme ?? 'xds-theme';
   const productLayer = layers.product ?? 'product';
 
   // Build StyleX options with sensible defaults
@@ -186,7 +174,7 @@ export function xdsStylex(
       return [
         {
           tag: 'style',
-          children: `@layer reset, ${libraryLayer}, ${themeLayer}, ${productLayer};`,
+          children: `@layer reset, ${libraryLayer}, xds-theme, ${productLayer};`,
           injectTo: 'head-prepend',
         },
       ];
@@ -323,7 +311,6 @@ function xdsStylexLegacy(options: XDSVitePluginLegacyOptions): Plugin[] {
   } = options;
 
   const libraryLayer = layers.library ?? 'xds-base';
-  const themeLayer = layers.theme ?? 'xds-theme';
   const productLayer = layers.product ?? 'product';
 
   const xdsBabelPlugin = path.resolve(__dirname, 'babel.js');
@@ -354,7 +341,7 @@ function xdsStylexLegacy(options: XDSVitePluginLegacyOptions): Plugin[] {
       return [
         {
           tag: 'style',
-          children: `@layer reset, ${libraryLayer}, ${themeLayer}, ${productLayer};`,
+          children: `@layer reset, ${libraryLayer}, xds-theme, ${productLayer};`,
           injectTo: 'head-prepend',
         },
       ];


### PR DESCRIPTION
## Summary

Removes the build-side `layers.theme` option added in #2866. **Decision (EJ):** consumers should *not* opt into the rebranded `astryx-theme` layer before the final cutover — keep cascade layers as `xds-*` until P10.

## Why

The opt-in only lets a consumer rename their cascade layer early, but the layer name is **functionally invisible** to them — it only affects their `@layer` order declaration. Opting in early means:
- editing their `@layer` order line **twice** (opt-in now, again at cutover),
- plus runtime `setThemeLayerName()` setup,
- all of which gets **torn down at P10** when they move to `@astryx/core` (which uses `astryx` layers natively).

Throwaway config for zero functional gain. If the consumer side were a one-line swap it'd be different, but it requires setup/config we'd just clean up later.

There was also a latent footgun: the build option alone (`layers.theme: 'astryx-theme'`) without the matching **runtime** layer name (the never-merged #2880) would desync the declared layer order from the runtime-injected layer — a cascade split-brain. Removing both halves eliminates that.

## Changes

- `vite.ts` — remove `layers.theme` from both option interfaces; revert the layer-order injection to the hardcoded `xds-theme` in both the modern and legacy API paths.
- `vite.test.ts` — drop the theme-opt-in tests; keep coverage of the default `xds-theme` order and the still-configurable `library`/`product` layer names.
- **Preserves `stylexPrefix`** (#2881), which also lives in `vite.ts`.

## Scope / related

- The runtime counterpart **#2880** is being **closed unmerged** (it's the other half of this opt-in).
- The `--xds-*` var **inverted-fallback** (#2882) is **unaffected** — it's automatic dual-support requiring no consumer action.
- The `xds-*` → `astryx-*` layer rename still happens — **once**, at the P10 cutover.

## Test plan

- `@xds/build` builds cleanly (`pnpm --filter @xds/build build`).
- `vite.test.ts` — 3 tests pass (default `xds-theme` order for both APIs + configurable library/product). Prettier clean.