### PR TITLE
feat(vibe-tests): add project-astryx target for unprefixed name validation

### DIFF
--- a/internal/vibe-tests/environments/project-astryx/README.md
+++ b/internal/vibe-tests/environments/project-astryx/README.md
@@ -1,0 +1,55 @@
+# Astryx
+
+This project uses Astryx (formerly XDS) components. Use the CLI to look up component props and usage before writing code:
+
+```bash
+npx astryx component --list              # list all available components
+npx astryx component Button              # look up props, variants, and usage
+npx astryx component IconButton          # each component has its own entry
+```
+
+If the CLI is not available, install dependencies first:
+
+```bash
+npm install --include=dev
+```
+
+Components use:
+
+- StyleX (`@stylexjs/stylex`) for styling
+- React 19
+
+## Styling with StyleX
+
+Custom styles must use `stylex.create()`. Plain objects are not valid:
+
+```tsx
+import stylex from '@stylexjs/stylex';
+
+const styles = stylex.create({
+  container: {
+    padding: 16,
+    backgroundColor: '#f5f5f5',
+  },
+});
+
+// Apply to components via the xstyle prop:
+<Card xstyle={styles.container}>...</Card>
+
+// Apply to HTML elements via stylex.props():
+<div {...stylex.props(styles.container)}>...</div>
+```
+
+**Important:** Never pass plain `{padding: '16px'}` objects to `xstyle`. Always use `stylex.create()`.
+
+## Import Pattern
+
+Each component is imported from its own subpath:
+
+```tsx
+import {Button} from '@xds/core/Button';
+import {IconButton} from '@xds/core/IconButton';
+import {Card} from '@xds/core/Card';
+import {Text, Heading} from '@xds/core/Text';
+import {useTheme} from '@xds/core/theme';
+```

--- a/internal/vibe-tests/environments/project-astryx/package.json
+++ b/internal/vibe-tests/environments/project-astryx/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "my-app",
+  "private": true,
+  "dependencies": {
+    "@xds/core": "*",
+    "@xds/theme-default": "*",
+    "@stylexjs/stylex": "^0.10",
+    "react": "^19",
+    "react-dom": "^19"
+  },
+  "devDependencies": {
+    "@xds/cli": "*"
+  }
+}

--- a/internal/vibe-tests/src/interactive.ts
+++ b/internal/vibe-tests/src/interactive.ts
@@ -755,12 +755,42 @@ function installAgentsDocs(): void {
   }
 }
 
+/**
+ * Install AGENTS.md for the Astryx (unprefixed) target.
+ * Same as XDS docs but with bare component names (Button not XDSButton).
+ * This validates that agents perform equally well with unprefixed names.
+ */
+function installAstryxDocs(): void {
+  // First generate the standard XDS AGENTS.md
+  installAgentsDocs();
+
+  const vibeTestsDir = path.join(__dirname, '..');
+  const agentsMdPath = path.join(vibeTestsDir, 'AGENTS.md');
+
+  if (!fs.existsSync(agentsMdPath)) return;
+
+  // Post-process: strip XDS prefix from component/hook names
+  let content = fs.readFileSync(agentsMdPath, 'utf-8');
+
+  // XDSButton -> Button, XDSCard -> Card, etc. (PascalCase after XDS)
+  content = content.replace(/\bXDS([A-Z][a-zA-Z]*)/g, '$1');
+  // useXDSTheme -> useTheme, useXDSToast -> useToast
+  content = content.replace(/\buseXDS([A-Z][a-zA-Z]*)/g, 'use$1');
+  // Update the header/branding
+  content = content.replace(/\bXDS\b/g, 'Astryx');
+  content = content.replace(/`xds /g, '`astryx ');
+  content = content.replace(/npx xds /g, 'npx astryx ');
+
+  fs.writeFileSync(agentsMdPath, content);
+  console.log('✓ Post-processed AGENTS.md for Astryx (bare component names)');
+}
+
 interface InteractiveConfig {
   sample?: number;
   holdout?: boolean;
   persona: 'naive' | 'experienced' | 'adversarial';
   degradation?: boolean; // Enable degradation curve testing
-  target: 'xds' | 'baseline' | 'html'; // Target design system
+  target: 'xds' | 'baseline' | 'html' | 'astryx'; // Target design system
 }
 
 interface AgentTask {
@@ -970,6 +1000,11 @@ function generateSubagentPrompt(
       experienced: `Use only plain HTML elements and inline CSS. `,
       adversarial: `I know React component libraries exist but I want raw HTML/CSS. `,
     },
+    astryx: {
+      naive: '', // No special framing - same library, bare names
+      experienced: `Use Astryx components from @xds/core. `,
+      adversarial: `I'm used to Tailwind/baseline patterns but need to use your design system. `,
+    },
   };
 
   const framing = personaFraming[config.target]?.[config.persona] || '';
@@ -1064,7 +1099,7 @@ async function main() {
   const targetIndex = args.indexOf('--target');
   const target =
     targetIndex !== -1
-      ? (args[targetIndex + 1] as 'xds' | 'baseline' | 'html')
+      ? (args[targetIndex + 1] as 'xds' | 'baseline' | 'html' | 'astryx')
       : 'xds';
   const promptsIndex = args.indexOf('--prompts');
   const promptIds =
@@ -1088,6 +1123,8 @@ async function main() {
   // Install target-specific documentation for retrieval-led approach
   if (target === 'xds') {
     installAgentsDocs();
+  } else if (target === 'astryx') {
+    installAstryxDocs();
   } else if (target === 'baseline') {
     installBaselineDocs();
   } else if (target === 'html') {
@@ -1150,7 +1187,7 @@ async function main() {
     console.log(`Skill doc: ${skillDocOverride}`);
   }
   console.log(
-    `Mode: ${target === 'xds' ? 'AGENTS.md' : target === 'baseline' ? 'AGENTS.baseline.md' : 'AGENTS.html.md'} (retrieval-led)`,
+    `Mode: ${target === 'xds' || target === 'astryx' ? 'AGENTS.md' : target === 'baseline' ? 'AGENTS.baseline.md' : 'AGENTS.html.md'} (retrieval-led)`,
   );
   console.log(
     `Protocol: ${degradation ? 'Degradation (10-turn curve)' : 'One-shot'}`,


### PR DESCRIPTION
## Summary

Adds an **`astryx` target** to the vibe-test harness for validating that agents perform equally well with bare (unprefixed) component names. Same library, same code, same prompts — only the **naming presentation to the agent** differs.

`project-astryx` is the **long-term replacement**; `project-xds` will be deleted before the integration branch merges to main (once we confirm equivalent or better scores).

## What's new

### `environments/project-astryx/`
- **README.md** — shows bare imports (`import {Button} from '@xds/core/Button'`) and the `astryx` CLI (`npx astryx component Button`). Notes that the package is still `@xds/core` during the migration.
- **package.json** — identical deps to `project-xds` (the bare names resolve via the P1 compat aliases already merged).

### `interactive.ts` additions
- Register `astryx` in the target type union + CLI arg parsing.
- Add `personaFraming` entry for `astryx` (experienced mode says "Use Astryx components from @xds/core (import {Button} not {XDSButton})").
- Add `installAstryxDocs()`: generates the standard `AGENTS.md` via `xds init`, then post-processes to strip `XDS` prefixes (`XDSButton` → `Button`, `useXDSTheme` → `useTheme`, branding `XDS` → `Astryx`).

## Running the comparison

```bash
cd internal/vibe-tests

# 1. Run prompts against astryx (records prompt IDs)
pnpm interactive --target astryx --persona naive --sample 5

# 2. Reuse same prompts for the prefixed baseline
pnpm interactive --target xds --persona naive --prompts <comma-separated-ids>

# 3. Compare
pnpm compare:md
```

If bare-name scores are equivalent or better → the compat layer is validated for agent use, and `project-astryx` becomes the canonical environment.

## Knots
Task: `kt-tn6g` (Vibe test: validate unprefixed names)