### PR TITLE
fix(vibe-tests): rebrand --xds-* vars to --astryx-* in astryx agent docs

### DIFF
--- a/internal/vibe-tests/src/interactive.ts
+++ b/internal/vibe-tests/src/interactive.ts
@@ -780,6 +780,10 @@ function installAstryxDocs(): void {
   content = content.replace(/\bXDS\b/g, 'Astryx');
   content = content.replace(/`xds /g, '`astryx ');
   content = content.replace(/npx xds /g, 'npx astryx ');
+  // CSS custom properties: docs should reference the new --astryx-* names
+  // (the library still handles --xds-* via inverted fallback, but we don't
+  // recommend the legacy names in forward-facing docs)
+  content = content.replace(/--xds-/g, '--astryx-');
 
   fs.writeFileSync(agentsMdPath, content);
   console.log('✓ Post-processed AGENTS.md for Astryx (bare component names)');


### PR DESCRIPTION
Docs should recommend the new `--astryx-*` custom property names, not the legacy `--xds-*` ones. The library still handles `--xds-*` at runtime via the inverted fallback, but forward-facing docs should point at the canonical names.

One-line addition to the `installAstryxDocs()` post-processing.