### PR TITLE
feat(docsite): add custom 404 page with header and footer

### DIFF
--- a/apps/docsite/src/__tests__/mcp-server.test.ts
+++ b/apps/docsite/src/__tests__/mcp-server.test.ts
@@ -20,7 +20,7 @@ import type {DocTopic} from '../generated/docsRegistry';
 import type {TemplateEntry} from '../generated/templateRegistry';
 
 // ── Replicate MCP server logic for testing ─────────────────────────────
-// These mirror the runtime logic in apps/docsite/src/app/[transport]/route.ts
+// These mirror the runtime logic in apps/docsite/src/app/mcp/route.ts
 // without importing the Next.js route handler directly.
 
 const allComponents: ComponentEntry[] = Object.values(components).flat();
@@ -58,19 +58,35 @@ function resolveKeywords(query: string): string[] {
 function score(text: string, query: string): number {
   const lower = text.toLowerCase();
   const queryLower = query.toLowerCase();
-  if (lower === queryLower) {return 100;}
-  if (lower.startsWith(queryLower)) {return 90;}
-  if (lower.includes(queryLower)) {return 85;}
+  if (lower === queryLower) {
+    return 100;
+  }
+  if (lower.startsWith(queryLower)) {
+    return 90;
+  }
+  if (lower.includes(queryLower)) {
+    return 85;
+  }
   const words = queryLower.split(/\s+/).filter(w => w.length > 1);
-  if (words.length === 0) {return 0;}
+  if (words.length === 0) {
+    return 0;
+  }
   let matched = 0;
   for (const word of words) {
-    if (lower.includes(word)) {matched++;}
+    if (lower.includes(word)) {
+      matched++;
+    }
   }
   const ratio = matched / words.length;
-  if (ratio === 1) {return 75;}
-  if (ratio >= 0.5) {return 50;}
-  if (ratio > 0) {return 30;}
+  if (ratio === 1) {
+    return 75;
+  }
+  if (ratio >= 0.5) {
+    return 50;
+  }
+  if (ratio > 0) {
+    return 30;
+  }
   return 0;
 }
 
@@ -254,7 +270,7 @@ describe('MCP search simulation', () => {
 describe('MCP branding', () => {
   it('route file uses Astryx (XDS) in tool descriptions', async () => {
     const fs = await import('node:fs');
-    const routePath = new URL('../app/[transport]/route.ts', import.meta.url);
+    const routePath = new URL('../app/mcp/route.ts', import.meta.url);
     const source = fs.readFileSync(routePath, 'utf-8');
     expect(source).toContain('Search Astryx (XDS) design system');
     expect(source).toContain('Astryx (XDS) component');
@@ -265,7 +281,7 @@ describe('MCP branding', () => {
 
   it('route file does not contain hardcoded ALIASES map', async () => {
     const fs = await import('node:fs');
-    const routePath = new URL('../app/[transport]/route.ts', import.meta.url);
+    const routePath = new URL('../app/mcp/route.ts', import.meta.url);
     const source = fs.readFileSync(routePath, 'utf-8');
     expect(source).not.toContain('const ALIASES');
     expect(source).toContain('keywordIndex');

--- a/apps/docsite/src/app/[transport]/route.ts
+++ b/apps/docsite/src/app/[transport]/route.ts
@@ -588,3 +588,16 @@ const handler = createMcpHandler(
 );
 
 export {handler as GET, handler as POST, handler as DELETE};
+
+// This catch-all `[transport]` segment exists for the MCP handler, which only
+// serves the `mcp`, `sse`, and `message` transports. Without constraining it,
+// the segment greedily matches every single-segment path (e.g. `/foo`), and
+// mcp-handler responds with a bare "Not found" — bypassing Next's not-found
+// boundary so users never see the styled 404 page. Pinning the valid params
+// and disabling dynamic params makes any other single-segment path fall
+// through to `app/not-found.tsx`. The MCP transports remain dynamic (the
+// handler reads the request body), so this only gates routing, not caching.
+export const dynamicParams = false;
+export function generateStaticParams() {
+  return [{transport: 'mcp'}, {transport: 'sse'}, {transport: 'message'}];
+}

--- a/apps/docsite/src/app/[transport]/route.ts
+++ b/apps/docsite/src/app/[transport]/route.ts
@@ -589,14 +589,8 @@ const handler = createMcpHandler(
 
 export {handler as GET, handler as POST, handler as DELETE};
 
-// This catch-all `[transport]` segment exists for the MCP handler, which only
-// serves the `mcp`, `sse`, and `message` transports. Without constraining it,
-// the segment greedily matches every single-segment path (e.g. `/foo`), and
-// mcp-handler responds with a bare "Not found" — bypassing Next's not-found
-// boundary so users never see the styled 404 page. Pinning the valid params
-// and disabling dynamic params makes any other single-segment path fall
-// through to `app/not-found.tsx`. The MCP transports remain dynamic (the
-// handler reads the request body), so this only gates routing, not caching.
+// Constrain the MCP catch-all to its real transports so other single-segment
+// paths fall through to the not-found page instead of mcp-handler's bare 404.
 export const dynamicParams = false;
 export function generateStaticParams() {
   return [{transport: 'mcp'}, {transport: 'sse'}, {transport: 'message'}];

--- a/apps/docsite/src/app/mcp/route.ts
+++ b/apps/docsite/src/app/mcp/route.ts
@@ -588,10 +588,3 @@ const handler = createMcpHandler(
 );
 
 export {handler as GET, handler as POST, handler as DELETE};
-
-// Constrain the MCP catch-all to its real transports so other single-segment
-// paths fall through to the not-found page instead of mcp-handler's bare 404.
-export const dynamicParams = false;
-export function generateStaticParams() {
-  return [{transport: 'mcp'}, {transport: 'sse'}, {transport: 'message'}];
-}

--- a/apps/docsite/src/app/not-found.module.css
+++ b/apps/docsite/src/app/not-found.module.css
@@ -1,9 +1,5 @@
 /* Copyright (c) Meta Platforms, Inc. and affiliates. */
 
-/* The AppShell (height="fill") gives the main content area a definite height
-   equal to the viewport minus the sticky header. Make this shell a full-height
-   flex column so the centered content fills the available space and the
-   <SiteFooter /> pins to the bottom. */
 .shell {
   display: flex;
   flex-direction: column;
@@ -12,10 +8,6 @@
   width: 100%;
 }
 
-/* Grow to fill the leftover height between the top of the content area and the
-   footer. XDSCenter already centers its children on both axes via flexbox;
-   flex: 1 makes the centering region expand so the 404 message sits in the
-   true vertical middle of the space. */
 .content {
   flex: 1 1 auto;
   width: 100%;

--- a/apps/docsite/src/app/not-found.module.css
+++ b/apps/docsite/src/app/not-found.module.css
@@ -1,0 +1,23 @@
+/* Copyright (c) Meta Platforms, Inc. and affiliates. */
+
+/* Mirror of (site)/layout.module.css: make the not-found shell a flex column
+   so <SiteFooter /> pins to the bottom of the viewport and the 404 message
+   fills the space between the header and footer.
+
+   The min-height subtracts the AppShell header height (set as a CSS var by
+   the AppShell once it measures the rendered header, falling back to 64px on
+   first paint per the convention used in globals.css). */
+.shell {
+  display: flex;
+  flex-direction: column;
+  min-height: calc(100vh - var(--appshell-header-height, 64px));
+  width: 100%;
+}
+
+/* Grow to fill the leftover height between header and footer. XDSCenter
+   already centers its content on both axes via flexbox; this just makes the
+   centering region expand so the 404 message sits in the vertical middle. */
+.main {
+  flex: 1 0 auto;
+  width: 100%;
+}

--- a/apps/docsite/src/app/not-found.module.css
+++ b/apps/docsite/src/app/not-found.module.css
@@ -1,23 +1,22 @@
 /* Copyright (c) Meta Platforms, Inc. and affiliates. */
 
-/* Mirror of (site)/layout.module.css: make the not-found shell a flex column
-   so <SiteFooter /> pins to the bottom of the viewport and the 404 message
-   fills the space between the header and footer.
-
-   The min-height subtracts the AppShell header height (set as a CSS var by
-   the AppShell once it measures the rendered header, falling back to 64px on
-   first paint per the convention used in globals.css). */
+/* The AppShell (height="fill") gives the main content area a definite height
+   equal to the viewport minus the sticky header. Make this shell a full-height
+   flex column so the centered content fills the available space and the
+   <SiteFooter /> pins to the bottom. */
 .shell {
   display: flex;
   flex-direction: column;
-  min-height: calc(100vh - var(--appshell-header-height, 64px));
+  min-height: 100%;
+  height: 100%;
   width: 100%;
 }
 
-/* Grow to fill the leftover height between header and footer. XDSCenter
-   already centers its content on both axes via flexbox; this just makes the
-   centering region expand so the 404 message sits in the vertical middle. */
-.main {
-  flex: 1 0 auto;
+/* Grow to fill the leftover height between the top of the content area and the
+   footer. XDSCenter already centers its children on both axes via flexbox;
+   flex: 1 makes the centering region expand so the 404 message sits in the
+   true vertical middle of the space. */
+.content {
+  flex: 1 1 auto;
   width: 100%;
 }

--- a/apps/docsite/src/app/not-found.tsx
+++ b/apps/docsite/src/app/not-found.tsx
@@ -9,12 +9,6 @@ import {SharedTopNav} from '../components/SharedTopNav';
 import {SiteFooter} from '../components/SiteFooter';
 import styles from './not-found.module.css';
 
-// Global App Router not-found boundary. It is rendered inside the root layout
-// (app/layout.tsx) only — the (site) route-group layout that provides
-// <SharedTopNav /> and <SiteFooter /> does NOT wrap it. So we reconstruct the
-// same shell here. height="fill" makes the shell exactly one viewport tall:
-// the header pins to the top, the footer to the bottom, and the centered 404
-// message fills the space between them.
 export default async function NotFound() {
   const headersList = await headers();
   const ua = headersList.get('user-agent') ?? '';

--- a/apps/docsite/src/app/not-found.tsx
+++ b/apps/docsite/src/app/not-found.tsx
@@ -9,11 +9,12 @@ import {SharedTopNav} from '../components/SharedTopNav';
 import {SiteFooter} from '../components/SiteFooter';
 import styles from './not-found.module.css';
 
-// This is the global App Router not-found boundary. It is rendered inside the
-// root layout (app/layout.tsx) only — the (site) route-group layout that
-// normally provides <SharedTopNav /> and <SiteFooter /> does NOT wrap it. So
-// we reconstruct the same shell here to keep the 404 on-brand, with the
-// message centered in the space between the header and footer.
+// Global App Router not-found boundary. It is rendered inside the root layout
+// (app/layout.tsx) only — the (site) route-group layout that provides
+// <SharedTopNav /> and <SiteFooter /> does NOT wrap it. So we reconstruct the
+// same shell here. height="fill" makes the shell exactly one viewport tall:
+// the header pins to the top, the footer to the bottom, and the centered 404
+// message fills the space between them.
 export default async function NotFound() {
   const headersList = await headers();
   const ua = headersList.get('user-agent') ?? '';
@@ -22,17 +23,17 @@ export default async function NotFound() {
   return (
     <XDSAppShell
       variant="surface"
-      height="auto"
+      height="fill"
       mobileNav={{defaultIsMobile}}
       topNav={<SharedTopNav />}>
       <div className={styles.shell}>
-        <div className={styles.main}>
+        <div className={styles.content}>
           <XDSCenter axis="both" height="100%">
             <XDSVStack gap={2} hAlign="center">
               <XDSHeading level={1} type="display-1">
                 404
               </XDSHeading>
-              <XDSText type="large" color="secondary">
+              <XDSText type="body" color="secondary">
                 This page could not be found.
               </XDSText>
             </XDSVStack>

--- a/apps/docsite/src/app/not-found.tsx
+++ b/apps/docsite/src/app/not-found.tsx
@@ -1,0 +1,45 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {headers} from 'next/headers';
+import {XDSAppShell} from '@xds/core/AppShell';
+import {XDSCenter} from '@xds/core/Center';
+import {XDSVStack} from '@xds/core/Layout';
+import {XDSHeading, XDSText} from '@xds/core/Text';
+import {SharedTopNav} from '../components/SharedTopNav';
+import {SiteFooter} from '../components/SiteFooter';
+import styles from './not-found.module.css';
+
+// This is the global App Router not-found boundary. It is rendered inside the
+// root layout (app/layout.tsx) only — the (site) route-group layout that
+// normally provides <SharedTopNav /> and <SiteFooter /> does NOT wrap it. So
+// we reconstruct the same shell here to keep the 404 on-brand, with the
+// message centered in the space between the header and footer.
+export default async function NotFound() {
+  const headersList = await headers();
+  const ua = headersList.get('user-agent') ?? '';
+  const defaultIsMobile = /mobile|android|iphone|ipad/i.test(ua);
+
+  return (
+    <XDSAppShell
+      variant="surface"
+      height="auto"
+      mobileNav={{defaultIsMobile}}
+      topNav={<SharedTopNav />}>
+      <div className={styles.shell}>
+        <div className={styles.main}>
+          <XDSCenter axis="both" height="100%">
+            <XDSVStack gap={2} hAlign="center">
+              <XDSHeading level={1} type="display-1">
+                404
+              </XDSHeading>
+              <XDSText type="large" color="secondary">
+                This page could not be found.
+              </XDSText>
+            </XDSVStack>
+          </XDSCenter>
+        </div>
+        <SiteFooter />
+      </div>
+    </XDSAppShell>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a custom 404 page to the docsite so invalid URLs render an on-brand page — the XDS header and footer with the "404 / This page could not be found." message centered between them — instead of Next.js's bare default.

## Changes

### 1. Invalid URLs now reach the 404 page (production-correct)

The root-level `[transport]` route (the MCP server handler) was a catch-all dynamic segment that matched **every** single-segment path (e.g. `/random`), and `mcp-handler` returned a bare plain-text `Not found`.

The MCP server only serves `/mcp` (SSE is disabled, and `/mcp` is the only advertised endpoint), so the dynamic `[transport]` segment was unnecessarily greedy. This moves the handler to a **static `app/mcp/route.ts`**. Non-MCP paths now match no route handler and fall through to `not-found.tsx`.

> Note: an earlier attempt used `dynamicParams = false` + `generateStaticParams` on the catch-all. That worked in `next dev` but **not** in a production build — Next still invokes a Route Handler for any matching path regardless of `dynamicParams`. The static-route move is verified against a real production build.

### 2. Content centered with the footer pinned to the bottom

`XDSAppShell height="fill"` (a definite `100dvh` root) with a full-height flex column: `shell` (`height: 100%`, flex column) → `content` (`flex: 1`) wrapping `XDSCenter` (centers both axes) → `SiteFooter`. The message sits in the middle of the available space; the footer pins to the bottom.

### 3. Subheading uses the default (non-bold) weight

`XDSText type="large"` is semibold; switched to `type="body"` (normal weight) with `color="secondary"`.

## Files

- `app/not-found.tsx` — the not-found boundary: `XDSAppShell` + `SharedTopNav` + centered `404`/message + `SiteFooter`.
- `app/not-found.module.css` — full-height flex column.
- `app/mcp/route.ts` — MCP handler moved here from `app/[transport]/route.ts` (static path, no longer a catch-all).
- `__tests__/mcp-server.test.ts` — updated route path references.

## Testing

- `pnpm typecheck` — clean.
- `pnpm -F @xds/docsite test` — 131/131 pass (incl. MCP server tests).
- **Production build** (`next build` + `next start`), verified live:
  - `/random`, `/foobar`, `/404`, `/nonsense`, deep paths → **HTTP 404 with the full styled shell** ✅
  - `POST /mcp` → MCP `initialize` + `tools/list` (returns `search` + `get`) ✅