### PR TITLE
fix(button): use inherit shade for loading spinner contrast (#2717)

### DIFF
--- a/.changeset/button-loading-spinner-contrast.md
+++ b/.changeset/button-loading-spinner-contrast.md
@@ -1,0 +1,7 @@
+---
+'@xds/core': patch
+---
+
+`XDSButton` + `XDSSpinner`: fix poor loading-spinner contrast on themed variants (#2717). The button hardcoded the destructive/primary spinner to `shade="onMedia"` (white), which disappeared on themes that render destructive as a muted light-red fill (e.g. the neutral theme). It also hid the loading label by setting `color: transparent` on the button itself, which themed `color` overrides defeated — leaking the label through on destructive.
+
+`XDSSpinner` gains a `shade="inherit"` option that paints the ring from the inherited `currentColor` (with a translucent track), so it always matches the parent's resolved foreground regardless of theme or variant. `XDSButton` now uses `shade="inherit"` for all variants and hides its content via the content wrapper (not the button), so the spinner overlay inherits the true variant foreground while the label hides correctly.

--- a/packages/core/src/Button/XDSButton.test.tsx
+++ b/packages/core/src/Button/XDSButton.test.tsx
@@ -71,6 +71,26 @@ describe('XDSButton', () => {
     expect(button).toBeDisabled();
   });
 
+  it('renders the loading spinner with the inherit shade for every variant (#2717)', () => {
+    // The spinner must follow the button's resolved foreground color rather
+    // than a hardcoded white, so it keeps contrast on themed variants like the
+    // neutral theme's muted-red destructive button.
+    for (const variant of [
+      'primary',
+      'secondary',
+      'ghost',
+      'destructive',
+    ] as const) {
+      const {container, unmount} = render(
+        <XDSButton label="Submit" variant={variant} isLoading />,
+      );
+      const spinner = container.querySelector('.xds-spinner');
+      expect(spinner).not.toBeNull();
+      expect(spinner).toHaveAttribute('data-shade', 'inherit');
+      unmount();
+    }
+  });
+
   it('handles click events', async () => {
     const user = userEvent.setup();
     const handleClick = vi.fn();

--- a/packages/core/src/Button/XDSButton.tsx
+++ b/packages/core/src/Button/XDSButton.tsx
@@ -381,8 +381,10 @@ export interface XDSButtonProps extends XDSBaseProps<HTMLButtonElement> {
 }
 
 const loadingStyles = stylex.create({
-  loading: {
-    position: 'relative',
+  // Hide the button's own content while the spinner overlay is shown. Applied
+  // to the content wrapper (not the button) so the button keeps its variant
+  // foreground color, which the spinner inherits via shade="inherit" (#2717).
+  hiddenContent: {
     color: 'transparent',
   },
   spinnerOverlay: {
@@ -516,7 +518,6 @@ export function XDSButton({
   const isLoadingState = isLoading || isPending;
   const groupDisabled = buttonGroup?.isDisabled ?? false;
   const buttonDisabled = isDisabled || groupDisabled || isLoadingState;
-  const useLightSpinner = variant === 'primary' || variant === 'destructive';
   // isIconOnly prop is the source of truth for icon-only rendering.
   // When false (default), label is always rendered as visible text.
 
@@ -573,7 +574,6 @@ export function XDSButton({
     isIconOnly && styles.iconOnly,
     buttonDisabled && styles.disabled,
     useAriaDisabled && styles.ariaDisabled,
-    isLoadingState && loadingStyles.loading,
     renderAsLink && styles.link,
     !buttonGroup && styles.pressable,
     buttonGroup &&
@@ -601,14 +601,14 @@ export function XDSButton({
         <span
           {...stylex.props(loadingStyles.spinnerOverlay)}
           aria-hidden="true">
-          <XDSSpinner
-            size="sm"
-            shade={useLightSpinner ? 'onMedia' : 'default'}
-          />
+          <XDSSpinner size="sm" shade="inherit" />
         </span>
       )}
       <span
-        {...stylex.props(styles.contentWrapper)}
+        {...stylex.props(
+          styles.contentWrapper,
+          isLoadingState && loadingStyles.hiddenContent,
+        )}
         aria-hidden={isLoadingState || undefined}>
         {icon && (
           <span {...stylex.props(styles.iconWrapper, iconSizeStyles[size])}>

--- a/packages/core/src/Spinner/Spinner.doc.mjs
+++ b/packages/core/src/Spinner/Spinner.doc.mjs
@@ -16,7 +16,7 @@ export const docs = {
     },
     {
       name: 'shade',
-      type: "'default' | 'onMedia'",
+      type: "'default' | 'onMedia' | 'subtle' | 'inherit'",
       description: 'Color shade for light or dark backgrounds.',
       default: "'default'",
     },
@@ -69,7 +69,7 @@ export const docsZh = {
     },
     {
       name: 'shade',
-      type: "'default' | 'onMedia'",
+      type: "'default' | 'onMedia' | 'subtle' | 'inherit'",
       description: '浅色或深色背景的颜色色调。',
       default: "'default'",
     },

--- a/packages/core/src/Spinner/XDSSpinner.test.tsx
+++ b/packages/core/src/Spinner/XDSSpinner.test.tsx
@@ -44,6 +44,13 @@ describe('XDSSpinner', () => {
     expect(screen.getByTestId('spinner')).toBeInTheDocument();
   });
 
+  it('renders with shade inherit', () => {
+    render(<XDSSpinner shade="inherit" data-testid="spinner" />);
+    const spinner = screen.getByTestId('spinner');
+    expect(spinner).toBeInTheDocument();
+    expect(spinner).toHaveAttribute('data-shade', 'inherit');
+  });
+
   it('has role="status"', () => {
     render(<XDSSpinner data-testid="spinner" />);
     expect(screen.getByRole('status')).toBeInTheDocument();

--- a/packages/core/src/Spinner/XDSSpinner.tsx
+++ b/packages/core/src/Spinner/XDSSpinner.tsx
@@ -82,7 +82,7 @@ const styles = stylex.create({
 
 export type XDSSpinnerSize = keyof typeof SIZES;
 
-export type XDSSpinnerShade = 'default' | 'onMedia' | 'subtle';
+export type XDSSpinnerShade = 'default' | 'onMedia' | 'subtle' | 'inherit';
 
 export interface XDSSpinnerProps extends XDSBaseProps<HTMLSpanElement> {
   /** Ref forwarded to the root element */
@@ -101,6 +101,9 @@ export interface XDSSpinnerProps extends XDSBaseProps<HTMLSpanElement> {
    * - 'default': accent color on light backgrounds
    * - 'onMedia': white on dark/accent backgrounds
    * - 'subtle': secondary text color, less prominent — for inline use in lists
+   * - 'inherit': inherits the parent's `currentColor` (with a translucent
+   *   track) — use inside colored elements like buttons so the ring matches
+   *   the resolved foreground regardless of theme/variant
    * @default 'default'
    */
   shade?: XDSSpinnerShade;
@@ -173,19 +176,29 @@ export function XDSSpinner({
     // - default → accent ring on a track tuned to body luminance
     // - subtle  → secondary text color, less prominent
     // - onMedia → on-dark color, with a translucent track for photos/video
+    // - inherit → the inherited currentColor, so the ring matches the parent's
+    //   resolved foreground (e.g. a button's variant text color)
+    const inheritedColor =
+      shade === 'inherit' ? getComputedStyle(canvas).color : null;
     const activeColor =
-      shade === 'onMedia'
-        ? themeTokens['--color-on-dark']
-        : shade === 'subtle'
-          ? themeTokens['--color-text-secondary']
-          : themeTokens['--color-accent'];
+      shade === 'inherit'
+        ? (inheritedColor as string)
+        : shade === 'onMedia'
+          ? themeTokens['--color-on-dark']
+          : shade === 'subtle'
+            ? themeTokens['--color-text-secondary']
+            : themeTokens['--color-accent'];
     // Track derives from --color-on-dark for onMedia (with a 30% alpha so the
     // ring reads against arbitrary backgrounds) and from --color-track for the
-    // body-luminance shades. Both branches are fully theme-driven.
+    // body-luminance shades. For inherit, the track is the same currentColor
+    // drawn at reduced alpha via globalAlpha (see below). All branches are
+    // fully theme-driven.
     const backgroundColor =
-      shade === 'onMedia'
-        ? `${themeTokens['--color-on-dark']}4D`
-        : themeTokens['--color-track'];
+      shade === 'inherit'
+        ? (inheritedColor as string)
+        : shade === 'onMedia'
+          ? `${themeTokens['--color-on-dark']}4D`
+          : themeTokens['--color-track'];
 
     const radius = (diameter / 2) * pixelRatio;
     const lineWidth = border * pixelRatio;
@@ -202,11 +215,17 @@ export function XDSSpinner({
 
     const center = frameSize / 2;
 
-    // Background circle (full ring, faded)
+    // Background circle (full ring, faded). For the inherit shade the track is
+    // the same currentColor as the arc, so fade it via globalAlpha (the
+    // computed color is an opaque rgb() string with no alpha channel to tweak).
     context.beginPath();
     context.arc(center, center, radius, 0, 2 * Math.PI);
     context.strokeStyle = backgroundColor;
+    if (shade === 'inherit') {
+      context.globalAlpha = 0.3;
+    }
     context.stroke();
+    context.globalAlpha = 1;
 
     // Active arc (partial ring, colored)
     context.beginPath();


### PR DESCRIPTION
## Summary

Fixes #2717 — the destructive button's loading spinner had poor contrast (white spinner that disappears on the muted light-red destructive fill).

> **Note:** This PR was reworked after review. The original approach (removing the disabled opacity during loading) treated a symptom. Thanks to @cixzhang's screenshot, the real root cause turned out to be the spinner *color*, which is what the issue called out from the start.

### Root cause

Two coupled bugs, both visible on themes where `destructive` is a muted fill (e.g. the **neutral** theme: `--color-error-muted` bg + `--color-error` red text):

1. **Spinner color** — the button hardcoded `shade="onMedia"` (→ white) for primary/destructive:
   ```ts
   const useLightSpinner = variant === 'primary' || variant === 'destructive';
   <XDSSpinner shade={useLightSpinner ? 'onMedia' : 'default'} />
   ```
   White-on-light-red has almost no contrast. (It only looked fine on the default theme's *saturated* red.)

2. **Label leak** — the loading state hid the label with `color: transparent` on the `<button>` itself. Theme component overrides are emitted *above* the StyleX layer (they're designed to beat StyleX), so neutral's `.xds-button.destructive { color: var(--color-error) }` overrode `transparent` and the label showed through — uniquely on destructive.

### Fix

- **`XDSSpinner`**: add `shade="inherit"` — paints the ring from the inherited `currentColor` (with a translucent track via `globalAlpha`), so it always matches the parent's resolved foreground regardless of theme/variant.
- **`XDSButton`**: use `shade="inherit"` for all variants (drop `useLightSpinner`), and move the content-hiding `color: transparent` onto the **content wrapper** instead of the button. The spinner overlay is a *sibling* of the content wrapper, so it inherits the button's real variant foreground while the label still hides correctly.

### Why this is theme-correct

The spinner now derives its color from the same foreground the button resolves — no per-theme or per-variant hardcoding. Works for default (white on saturated red), neutral (red on muted red), and any future theme/variant.

### Variants verified

| variant | foreground | spinner color (inherit) |
| --- | --- | --- |
| primary | on-accent (white) | white on accent ✓ |
| secondary | text-primary | dark on neutral ✓ |
| ghost | text-primary | dark on transparent ✓ |
| destructive (default) | on-error (white) | white on saturated red ✓ |
| destructive (neutral) | error (red) | **red on muted red ✓** (the bug) |

### Tests

- `@xds/core`: **3140/3140 pass** (154 files), including:
  - new Button test asserting the loading spinner uses `shade="inherit"` for all four variants,
  - new Spinner test for the `inherit` shade.
- `@xds/core` typecheck: clean. ESLint: clean.
- Updated `Spinner.doc.mjs` (shade type) and added a `@xds/core` patch changeset.
