### PR TITLE
fix(core): use solid fill for default info status icon (#2678)

### DIFF
--- a/.changeset/info-icon-solid-fill.md
+++ b/.changeset/info-icon-solid-fill.md
@@ -1,0 +1,5 @@
+---
+'@xds/core': patch
+---
+
+The default `info` status icon now uses a solid fill (matching `success`, `error`, and `warning`) instead of a 1.5px outline. Status icons in XDSBanner and elsewhere now render consistently as filled glyphs for better color visibility at small sizes.

--- a/packages/core/src/Icon/defaultIcons.tsx
+++ b/packages/core/src/Icon/defaultIcons.tsx
@@ -16,7 +16,7 @@
  * - Use currentColor for stroke/fill (inherits from parent)
  * - Are aria-hidden (decorative by default)
  * - Use stroke-based rendering with 1.5px stroke width (matching heroicons outline style)
- * - Status icons (checkCircle, xCircle, warning) use solid fills for better color visibility
+ * - Status icons (checkCircle, xCircle, warning, info) use solid fills for better color visibility
  *
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/Icon/globalIconRegistry.tsx (XDSIconName type if names change)
@@ -40,7 +40,7 @@ const svgProps = {
 
 /**
  * Props for solid/filled SVG icons.
- * Status icons (checkCircle, xCircle, warning) use solid fills for better
+ * Status icons (checkCircle, xCircle, warning, info) use solid fills for better
  * color visibility at small sizes, matching the heroicons solid style
  * used by themes.
  */
@@ -122,12 +122,14 @@ export const defaultIcons: XDSIconRegistry = {
     </svg>
   ),
 
-  /** ⓘ — information */
+  /** ⓘ — information (solid fill for status visibility) */
   info: (
-    <svg {...svgProps}>
-      <circle cx="12" cy="12" r="9" />
-      <path d="M12 11v5" />
-      <circle cx="12" cy="8" r="0.5" fill="currentColor" stroke="none" />
+    <svg {...solidSvgProps}>
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M12 3a9 9 0 100 18 9 9 0 000-18zm0 4a1 1 0 100 2 1 1 0 000-2zm-.75 3.75a.75.75 0 011.5 0v5.5a.75.75 0 01-1.5 0v-5.5z"
+      />
     </svg>
   ),
 


### PR DESCRIPTION
## Summary

Fixes #2678 — the default `info` status icon was rendered as a 1.5px **outline** (`svgProps`) while `success`, `error`, and `warning` all use **solid fills** (`solidSvgProps`). This made `info` look visually inconsistent in `XDSBanner` and other status surfaces.

## Change

In `packages/core/src/Icon/defaultIcons.tsx`:
- Replace the `info` icon to use `solidSvgProps` with a solid filled circle and a cut-out "i" glyph (dot + stem) via `fillRule`/`clipRule`, matching the style of the other status icons.
- Update the file header so the SYNC list reads `(checkCircle, xCircle, warning, info)`.

Before: outlined circle + line + dot. After: solid filled circle with an "i" cut out — consistent with success/error/warning.

## Testing

- `vitest run packages/core/src/Icon` → **26 passed**
- `pnpm -F @xds/core build` → success (Babel + StyleX)
- `eslint packages/core/src/Icon/defaultIcons.tsx` → clean
- `node scripts/sync-exports.js --check` → up to date
- pre-commit SYNC + package-boundary checks → clean

A `@xds/core` patch changeset is included.
