### PR TITLE
fix(checkbox-list): add visual loading feedback for isLoading

### DIFF
--- a/.changeset/checkbox-list-loading-visual.md
+++ b/.changeset/checkbox-list-loading-visual.md
@@ -1,0 +1,5 @@
+---
+'@xds/core': patch
+---
+
+`XDSCheckboxList` now gives visual feedback while loading. When `isLoading` is set (or a `changeAction` promise is pending), items are dimmed (reduced opacity) in addition to the existing `aria-busy` and blocked interaction. Previously the loading state was only conveyed to assistive tech, with no visible change. JSDoc and component docs were corrected to match the implemented behavior.

--- a/apps/storybook/stories/CheckboxList.stories.tsx
+++ b/apps/storybook/stories/CheckboxList.stories.tsx
@@ -219,6 +219,24 @@ export const Disabled: Story = {
   },
 };
 
+export const Loading: Story = {
+  render: args => {
+    const [value, setValue] = useState<string[]>(['email']);
+    const {value: _value, onChange: _onChange, ...restArgs} = args;
+    return (
+      <XDSCheckboxList {...restArgs} value={value} onChange={setValue}>
+        <XDSCheckboxListItem label="Email" value="email" />
+        <XDSCheckboxListItem label="SMS" value="sms" />
+        <XDSCheckboxListItem label="Push notification" value="push" />
+      </XDSCheckboxList>
+    );
+  },
+  args: {
+    label: 'Notification preferences',
+    isLoading: true,
+  },
+};
+
 export const DisabledItem: Story = {
   render: args => {
     const [value, setValue] = useState<string[]>([]);

--- a/packages/core/src/CheckboxList/CheckboxList.doc.mjs
+++ b/packages/core/src/CheckboxList/CheckboxList.doc.mjs
@@ -50,7 +50,8 @@ export const docs = {
     {
       name: 'isLoading',
       type: 'boolean',
-      description: 'External loading state.',
+      description:
+        'External loading state. Dims items (reduced opacity), marks them aria-busy, and blocks interaction.',
       default: 'false',
     },
     {

--- a/packages/core/src/CheckboxList/XDSCheckboxList.test.tsx
+++ b/packages/core/src/CheckboxList/XDSCheckboxList.test.tsx
@@ -419,6 +419,54 @@ describe('XDSCheckboxListItem ARIA props', () => {
     expect(item).not.toHaveAttribute('aria-busy');
   });
 
+  it('marks items aria-busy when isLoading is set', () => {
+    render(
+      <XDSCheckboxList
+        label="Prefs"
+        value={['a']}
+        onChange={() => {}}
+        isLoading>
+        <XDSCheckboxListItem label="Option A" value="a" />
+      </XDSCheckboxList>,
+    );
+    const item = screen.getByRole('listitem');
+    expect(item).toHaveAttribute('aria-busy', 'true');
+  });
+
+  it('dims items visually when isLoading is set', () => {
+    const {rerender} = render(
+      <XDSCheckboxList label="Prefs" value={['a']} onChange={() => {}}>
+        <XDSCheckboxListItem label="Option A" value="a" />
+      </XDSCheckboxList>,
+    );
+    const idleClass = screen.getByRole('listitem').getAttribute('class');
+
+    rerender(
+      <XDSCheckboxList
+        label="Prefs"
+        value={['a']}
+        onChange={() => {}}
+        isLoading>
+        <XDSCheckboxListItem label="Option A" value="a" />
+      </XDSCheckboxList>,
+    );
+    const busyClass = screen.getByRole('listitem').getAttribute('class');
+
+    // Loading applies an additional style class for the dimmed appearance.
+    expect(busyClass).not.toBe(idleClass);
+  });
+
+  it('does not toggle when isLoading is set', async () => {
+    const onChange = vi.fn();
+    render(
+      <XDSCheckboxList label="Prefs" value={[]} onChange={onChange} isLoading>
+        <XDSCheckboxListItem label="Option A" value="a" />
+      </XDSCheckboxList>,
+    );
+    fireEvent.click(screen.getByRole('checkbox'));
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
   it('forwards arbitrary aria attributes to the list item DOM element', () => {
     render(
       <XDSList>

--- a/packages/core/src/CheckboxList/XDSCheckboxList.test.tsx
+++ b/packages/core/src/CheckboxList/XDSCheckboxList.test.tsx
@@ -456,7 +456,7 @@ describe('XDSCheckboxListItem ARIA props', () => {
     expect(busyClass).not.toBe(idleClass);
   });
 
-  it('does not toggle when isLoading is set', async () => {
+  it('does not toggle when isLoading is set', () => {
     const onChange = vi.fn();
     render(
       <XDSCheckboxList label="Prefs" value={[]} onChange={onChange} isLoading>

--- a/packages/core/src/CheckboxList/XDSCheckboxList.tsx
+++ b/packages/core/src/CheckboxList/XDSCheckboxList.tsx
@@ -72,11 +72,14 @@ export interface XDSCheckboxListProps extends Omit<
   onChange?: (values: string[]) => void;
   /**
    * Async action on change. Fires after onChange.
-   * While pending, items show reduced opacity and aria-busy.
+   * While the returned promise is pending, items are dimmed (reduced
+   * opacity) and marked `aria-busy`, and interaction is blocked.
    */
   changeAction?: (values: string[]) => void | Promise<void>;
   /**
    * Whether the checkbox group is in an external loading state.
+   * While loading, items are dimmed (reduced opacity) and marked
+   * `aria-busy`, and interaction is blocked.
    * @default false
    */
   isLoading?: boolean;

--- a/packages/core/src/CheckboxList/XDSCheckboxListItem.tsx
+++ b/packages/core/src/CheckboxList/XDSCheckboxListItem.tsx
@@ -34,6 +34,14 @@ const styles = stylex.create({
   selected: {
     backgroundColor: colorVars['--color-accent-muted'],
   },
+  // Visual feedback while the parent group is in a loading/pending state.
+  // Mirrors the disabled-content dimming (opacity 0.5) used across XDS
+  // (e.g. XDSItem `disabledContent`) so loading reads as "temporarily
+  // inactive" without permanently disabling the control.
+  busy: {
+    opacity: 0.5,
+    cursor: 'progress',
+  },
 });
 
 // =============================================================================
@@ -190,6 +198,10 @@ export function XDSCheckboxListItem({
             !effectiveDisabled &&
             !effectiveReadOnly &&
             styles.selected,
+          // Dim the item while the group is busy (loading / pending async
+          // change) to give visual feedback that interaction is blocked.
+          // Skipped when already disabled, which provides its own dimming.
+          isBusy && !effectiveDisabled && styles.busy,
           xstyle,
         ] as StyleXStyles
       }

--- a/packages/core/src/CheckboxList/XDSCheckboxListItem.tsx
+++ b/packages/core/src/CheckboxList/XDSCheckboxListItem.tsx
@@ -34,10 +34,7 @@ const styles = stylex.create({
   selected: {
     backgroundColor: colorVars['--color-accent-muted'],
   },
-  // Visual feedback while the parent group is in a loading/pending state.
-  // Mirrors the disabled-content dimming (opacity 0.5) used across XDS
-  // (e.g. XDSItem `disabledContent`) so loading reads as "temporarily
-  // inactive" without permanently disabling the control.
+  // Loading/pending state: dim like disabled content (opacity 0.5).
   busy: {
     opacity: 0.5,
     cursor: 'progress',
@@ -198,9 +195,7 @@ export function XDSCheckboxListItem({
             !effectiveDisabled &&
             !effectiveReadOnly &&
             styles.selected,
-          // Dim the item while the group is busy (loading / pending async
-          // change) to give visual feedback that interaction is blocked.
-          // Skipped when already disabled, which provides its own dimming.
+          // Dim while busy; disabled items already dim themselves.
           isBusy && !effectiveDisabled && styles.busy,
           xstyle,
         ] as StyleXStyles


### PR DESCRIPTION
## Summary

Fixes #2688 — the `isLoading` prop on `XDSCheckboxList` was accepted and partially wired up (it set `aria-busy` and blocked interaction) but gave **no visual feedback**. The JSDoc even claimed "items show reduced opacity," which was never implemented.

## Changes

- **`XDSCheckboxListItem.tsx`**: Added a `busy` style (`opacity: 0.5`, `cursor: progress`) applied when the group `isBusy` and the item isn't already disabled. The `0.5` opacity matches the existing disabled-content dimming used across XDS (`XDSItem`, `XDSCheckboxInput`, `XDSRadioListItem`, etc.) for visual consistency.
- **`XDSCheckboxList.tsx`**: Corrected the `isLoading` and `changeAction` JSDoc to accurately describe the behavior (dimmed items + `aria-busy` + blocked interaction).
- **`CheckboxList.doc.mjs`**: Updated the `isLoading` prop description to match.
- **`CheckboxList.stories.tsx`**: Added a `Loading` story for visual verification.
- **Tests**: Added coverage for `aria-busy` when `isLoading` is set, the visual dimming class, and that interaction stays blocked while loading.
- Added a changeset (`@xds/core` patch).

## Approach note

I matched the existing **disabled dimming pattern** (opacity reduction) rather than adding a spinner. A spinner per-item would be visually noisy for a list, and the group-wide dim + `aria-busy` is the established pattern for "temporarily inactive" controls in XDS. Happy to switch to a spinner/skeleton if the team prefers — open to feedback.

## Testing

- `vitest run packages/core/src/CheckboxList/XDSCheckboxList.test.tsx` → 32/32 pass
- `pnpm -F @xds/core typecheck` → clean
- `eslint` on changed files → clean
- pre-commit SYNC + package-boundary checks → clean
