### PR TITLE
fix(docsite): bridge controlled component callbacks in interactive preview (#2716)

### DIFF
--- a/apps/docsite/src/__tests__/component-preview-state.test.ts
+++ b/apps/docsite/src/__tests__/component-preview-state.test.ts
@@ -111,4 +111,101 @@ describe('component detail preview state', () => {
 
     expect(onPropChange).toHaveBeenCalledWith('isOpen', false);
   });
+
+  it('bridges a controlled value/onChange pair so the preview updates', () => {
+    const knobs = pickPrimaryProps('Pagination', [
+      prop({name: 'page', type: 'number', required: true}),
+      prop({
+        name: 'onChange',
+        type: '(page: number) => void',
+        required: true,
+      }),
+      prop({name: 'totalItems', type: 'number'}),
+      prop({name: 'pageSize', type: 'number', default: '10'}),
+      prop({
+        name: 'onPageSizeChange',
+        type: '(pageSize: number) => void',
+      }),
+    ]);
+
+    const onPropChange = vi.fn();
+    const runtimeState = buildRuntimePreviewState(
+      {page: 1, totalItems: 100, pageSize: 10},
+      onPropChange,
+      {knobs},
+    );
+
+    // onChange's first param is `page`, which is a value prop → wired.
+    expect(runtimeState.onChange).toEqual(expect.any(Function));
+    (runtimeState.onChange as (page: number) => void)(3);
+    expect(onPropChange).toHaveBeenCalledWith('page', 3);
+
+    // onPageSizeChange's first param is `pageSize`, also a value prop → wired.
+    expect(runtimeState.onPageSizeChange).toEqual(expect.any(Function));
+    (runtimeState.onPageSizeChange as (pageSize: number) => void)(25);
+    expect(onPropChange).toHaveBeenCalledWith('pageSize', 25);
+  });
+
+  it('bridges a generic value/onChange pair', () => {
+    const knobs = pickPrimaryProps('Slider', [
+      prop({name: 'value', type: 'number', required: true}),
+      prop({
+        name: 'onChange',
+        type: '(value: number) => void',
+        required: true,
+      }),
+    ]);
+
+    const onPropChange = vi.fn();
+    const runtimeState = buildRuntimePreviewState({value: 10}, onPropChange, {
+      knobs,
+    });
+
+    (runtimeState.onChange as (value: number) => void)(42);
+    expect(onPropChange).toHaveBeenCalledWith('value', 42);
+  });
+
+  it('leaves callbacks alone when no matching value prop exists in state', () => {
+    const knobs = pickPrimaryProps('Button', [
+      prop({name: 'label', type: 'string'}),
+      prop({name: 'onClick', type: '(e: MouseEvent) => void'}),
+    ]);
+
+    const state = {label: 'Click me'};
+    const onPropChange = vi.fn();
+    const runtimeState = buildRuntimePreviewState(state, onPropChange, {knobs});
+
+    // No `e` value prop in state → callback not bridged; state returned as-is.
+    expect(runtimeState).toBe(state);
+    expect(runtimeState.onClick).toBeUndefined();
+  });
+
+  it('only bridges isOpen when the preview opts into controlling open state', () => {
+    const knobs = pickPrimaryProps('Popover', [
+      prop({name: 'isOpen', type: 'boolean', required: true}),
+      prop({
+        name: 'onOpenChange',
+        type: '(isOpen: boolean) => void',
+        required: true,
+      }),
+    ]);
+
+    const onPropChange = vi.fn();
+
+    const withoutOptIn = buildRuntimePreviewState(
+      {isOpen: true},
+      onPropChange,
+      {
+        knobs,
+      },
+    );
+    expect(withoutOptIn.onOpenChange).toBeUndefined();
+
+    const withOptIn = buildRuntimePreviewState({isOpen: true}, onPropChange, {
+      knobs,
+      canControlOpenState: true,
+    });
+    (withOptIn.onOpenChange as (isOpen: boolean) => void)(false);
+    expect(onPropChange).toHaveBeenCalledWith('isOpen', false);
+  });
 });

--- a/apps/docsite/src/components/component-detail/ComponentDetailClient.tsx
+++ b/apps/docsite/src/components/component-detail/ComponentDetailClient.tsx
@@ -199,6 +199,7 @@ function ComponentDetailInner({
                   <InteractivePreviewStage
                     name={comp.name}
                     state={state}
+                    knobs={knobs}
                     missingRequiredProps={missingRequiredProps}
                     onPropChange={setProp}
                     canControlOpenState={

--- a/apps/docsite/src/components/component-detail/InteractivePreview.tsx
+++ b/apps/docsite/src/components/component-detail/InteractivePreview.tsx
@@ -25,6 +25,7 @@ import {
   buildRuntimePreviewState,
   getMissingRequiredProps,
   pickPrimaryProps,
+  type KnobProp,
 } from './interactiveState';
 import type {
   PropDoc,
@@ -187,12 +188,14 @@ export function useInteractiveState(
 export function InteractivePreviewStage({
   name,
   state,
+  knobs,
   missingRequiredProps = [],
   onPropChange,
   canControlOpenState = false,
 }: {
   name: string;
   state: Record<string, unknown>;
+  knobs?: KnobProp[];
   missingRequiredProps?: string[];
   onPropChange?: (propName: string, value: unknown) => void;
   canControlOpenState?: boolean;
@@ -202,9 +205,12 @@ export function InteractivePreviewStage({
   const runtimeState = useMemo(
     () =>
       resolveValue(
-        buildRuntimePreviewState(state, onPropChange, {canControlOpenState}),
+        buildRuntimePreviewState(state, onPropChange, {
+          canControlOpenState,
+          knobs,
+        }),
       ) as Record<string, unknown>,
-    [state, onPropChange, canControlOpenState],
+    [state, onPropChange, canControlOpenState, knobs],
   );
 
   if (missingRequiredProps.length > 0) {

--- a/apps/docsite/src/components/component-detail/interactiveState.ts
+++ b/apps/docsite/src/components/component-detail/interactiveState.ts
@@ -208,15 +208,10 @@ export function getMissingRequiredProps(
 }
 
 /**
- * Extracts the name of a controlled callback's first parameter from a
- * stringified callback type, e.g. `(page: number) => void` → `page`,
- * `(value: string, e: ChangeEvent) => void` → `value`. Returns `null` when the
- * signature has no named leading parameter (event-only handlers like
- * `(e: MouseEvent) => void` are intentionally matched by name too — the bridge
- * only fires when a state prop of that name exists).
+ * Returns the name of a callback's first parameter from its stringified type,
+ * e.g. `(page: number) => void` → `page`. Returns `null` for unnamed params.
  */
 function getCallbackTargetProp(type: string): string | null {
-  // Grab the first parameter group of the arrow signature.
   const match = /^\s*\(\s*([^):,]+)/.exec(type);
   if (!match) {
     return null;
@@ -226,17 +221,11 @@ function getCallbackTargetProp(type: string): string | null {
 }
 
 /**
- * Bridges controlled-component callbacks back into playground state so the
- * preview reflects user interaction (e.g. clicking a Pagination page, toggling
- * a Switch). For every callback prop whose first parameter name matches an
- * existing value prop in `state` (page/onChange, value/onChange,
- * pageSize/onPageSizeChange, isOpen/onOpenChange, …), the noop callback is
- * replaced with one that updates that value prop.
- *
- * `knobs` provides the parsed control descriptors and original prop types used
- * to identify callback props and their controlled target. `canControlOpenState`
- * preserves the prior, explicit isOpen/onOpenChange behavior for overlay
- * components whose preview opts into controlling open state.
+ * Wires controlled-component change handlers back into playground state so the
+ * preview reflects interaction (clicking a Pagination page, etc.). A callback
+ * whose first parameter names a value prop in `state` (page/onChange,
+ * value/onChange, pageSize/onPageSizeChange) replaces its noop with one that
+ * updates that prop. isOpen/onOpenChange stays gated behind canControlOpenState.
  */
 export function buildRuntimePreviewState(
   state: Record<string, unknown>,
@@ -254,10 +243,8 @@ export function buildRuntimePreviewState(
     if (control.kind !== 'callback') {
       continue;
     }
-    // Only bridge change handlers (onChange, onPageSizeChange, onOpenChange, …)
-    // — not side-effect callbacks like `changeAction` or one-off events like
-    // `onClick`/`onSubmit`. These are the handlers paired with a controlled
-    // value prop.
+    // Only change handlers — not side-effect callbacks (changeAction) or
+    // one-off events (onClick).
     if (!/^on[A-Z].*Change$/.test(row.name) && row.name !== 'onChange') {
       continue;
     }
@@ -265,8 +252,6 @@ export function buildRuntimePreviewState(
     if (target == null || !(target in state)) {
       continue;
     }
-    // isOpen/onOpenChange stays gated behind the explicit opt-in so overlay
-    // previews that should not auto-close keep their prior behavior.
     if (target === 'isOpen' && options?.canControlOpenState !== true) {
       continue;
     }
@@ -274,8 +259,7 @@ export function buildRuntimePreviewState(
     changed = true;
   }
 
-  // Preserve legacy behavior when knobs aren't supplied: still bridge a
-  // controllable isOpen/onOpenChange pair.
+  // Fallback when knobs aren't supplied: bridge a controllable isOpen pair.
   if (
     !changed &&
     options?.canControlOpenState === true &&

--- a/apps/docsite/src/components/component-detail/interactiveState.ts
+++ b/apps/docsite/src/components/component-detail/interactiveState.ts
@@ -207,21 +207,83 @@ export function getMissingRequiredProps(
     .map(({row}) => row.name);
 }
 
+/**
+ * Extracts the name of a controlled callback's first parameter from a
+ * stringified callback type, e.g. `(page: number) => void` → `page`,
+ * `(value: string, e: ChangeEvent) => void` → `value`. Returns `null` when the
+ * signature has no named leading parameter (event-only handlers like
+ * `(e: MouseEvent) => void` are intentionally matched by name too — the bridge
+ * only fires when a state prop of that name exists).
+ */
+function getCallbackTargetProp(type: string): string | null {
+  // Grab the first parameter group of the arrow signature.
+  const match = /^\s*\(\s*([^):,]+)/.exec(type);
+  if (!match) {
+    return null;
+  }
+  const name = match[1].trim().replace(/\?$/, '');
+  return /^[A-Za-z_$][\w$]*$/.test(name) ? name : null;
+}
+
+/**
+ * Bridges controlled-component callbacks back into playground state so the
+ * preview reflects user interaction (e.g. clicking a Pagination page, toggling
+ * a Switch). For every callback prop whose first parameter name matches an
+ * existing value prop in `state` (page/onChange, value/onChange,
+ * pageSize/onPageSizeChange, isOpen/onOpenChange, …), the noop callback is
+ * replaced with one that updates that value prop.
+ *
+ * `knobs` provides the parsed control descriptors and original prop types used
+ * to identify callback props and their controlled target. `canControlOpenState`
+ * preserves the prior, explicit isOpen/onOpenChange behavior for overlay
+ * components whose preview opts into controlling open state.
+ */
 export function buildRuntimePreviewState(
   state: Record<string, unknown>,
   onPropChange?: (propName: string, value: unknown) => void,
-  options?: {canControlOpenState?: boolean},
+  options?: {canControlOpenState?: boolean; knobs?: KnobProp[]},
 ): Record<string, unknown> {
-  if (
-    onPropChange == null ||
-    options?.canControlOpenState !== true ||
-    typeof state.isOpen !== 'boolean'
-  ) {
+  if (onPropChange == null) {
     return state;
   }
 
-  return {
-    ...state,
-    onOpenChange: (isOpen: boolean) => onPropChange('isOpen', isOpen),
-  };
+  const next: Record<string, unknown> = {...state};
+  let changed = false;
+
+  for (const {row, control} of options?.knobs ?? []) {
+    if (control.kind !== 'callback') {
+      continue;
+    }
+    // Only bridge change handlers (onChange, onPageSizeChange, onOpenChange, …)
+    // — not side-effect callbacks like `changeAction` or one-off events like
+    // `onClick`/`onSubmit`. These are the handlers paired with a controlled
+    // value prop.
+    if (!/^on[A-Z].*Change$/.test(row.name) && row.name !== 'onChange') {
+      continue;
+    }
+    const target = getCallbackTargetProp(row.type);
+    if (target == null || !(target in state)) {
+      continue;
+    }
+    // isOpen/onOpenChange stays gated behind the explicit opt-in so overlay
+    // previews that should not auto-close keep their prior behavior.
+    if (target === 'isOpen' && options?.canControlOpenState !== true) {
+      continue;
+    }
+    next[row.name] = (value: unknown) => onPropChange(target, value);
+    changed = true;
+  }
+
+  // Preserve legacy behavior when knobs aren't supplied: still bridge a
+  // controllable isOpen/onOpenChange pair.
+  if (
+    !changed &&
+    options?.canControlOpenState === true &&
+    typeof state.isOpen === 'boolean'
+  ) {
+    next.onOpenChange = (isOpen: boolean) => onPropChange('isOpen', isOpen);
+    return next;
+  }
+
+  return changed ? next : state;
 }

--- a/packages/core/src/Pagination/Pagination.doc.mjs
+++ b/packages/core/src/Pagination/Pagination.doc.mjs
@@ -107,6 +107,14 @@ export const docs = {
       {className: 'xds-pagination-dot', visualProps: ['size'], states: ['active']},
     ],
   },
+  playground: {
+    defaults: {
+      page: 1,
+      totalItems: 100,
+      pageSize: 10,
+      variant: 'pages',
+    },
+  },
   usage: {
     description:
       'Pagination lets users step through pages of content. Place it below a table, list, or card grid so users can move forward and backward through results. Pick a variant to match the context: numbered pages for data tables, a count for large lists, compact for tight spaces, or dots for carousels.',


### PR DESCRIPTION
## Summary

Fixes #2716. The docsite's interactive **Properties** preview rendered controlled components with **noop callbacks**, so user interaction never updated the preview. For Pagination, `onChange` was `() => {}`, so clicking pages (and toggling variants on the controlled component) did nothing.

## Root cause

`apps/docsite/src/components/component-detail/interactiveState.ts` generated `() => {}` for every `callback` prop and `buildRuntimePreviewState` only bridged a single hard-coded pair (`isOpen` / `onOpenChange`). Controlled value/onChange pairs like `page`/`onChange` were never wired back into playground state.

## Fix

`buildRuntimePreviewState` now bridges **controlled-component change handlers** generically:

- For each `callback` prop named `onChange` or `on{Prop}Change`, it parses the **first parameter name** from the callback's type signature (`(page: number) => void` → `page`).
- If a value prop of that name exists in state, the noop callback is replaced with one that calls `onPropChange(targetProp, value)` — so the preview re-renders on interaction.
- This generalizes the prior behavior to `page`/`onChange`, `value`/`onChange`, `pageSize`/`onPageSizeChange`, etc.
- The `isOpen`/`onOpenChange` pair stays gated behind the explicit `canControlOpenState` opt-in, preserving overlay behavior.
- Side-effect callbacks (`changeAction`) and one-off events (`onClick`) are intentionally **not** bridged.

`knobs` are now threaded through `InteractivePreviewStage` so the bridge can see each prop's parsed control + type.

Also added a `playground` config to `Pagination.doc.mjs` (`page: 1, totalItems: 100, pageSize: 10, variant: 'pages'`) so the preview starts on a real page with a known total instead of the auto-generated `page: 0`.

## Testing

- `pnpm -F @xds/docsite test` → **137 passed** (5 new cases in `component-preview-state.test.ts` covering page/onChange, generic value/onChange, pageSize/onPageSizeChange, the no-matching-prop case, and the isOpen opt-in gate).
- `pnpm -F @xds/core typecheck:docs` → clean.
- `eslint` on changed files → clean.
- Docsite `tsc --noEmit` → no errors in changed files (only pre-existing `@xds/theme-*/built` missing-module errors that require building theme packages, unrelated to this change).

## Manual verification

With the playground defaults, the Pagination preview now updates `page` when clicking page buttons / prev / next, and updates `pageSize` via the size selector, because the bridged `onChange`/`onPageSizeChange` feed back into playground state.
