### PR TITLE
fix(core): center XDSSpinner in icon-only button loading state

### DIFF
--- a/.changeset/icon-button-spinner-centering.md
+++ b/.changeset/icon-button-spinner-centering.md
@@ -1,0 +1,5 @@
+---
+'@xds/core': patch
+---
+
+Fix `XDSSpinner` rendering off-center inside the icon-only `XDSButton` loading state. The spinner canvas now pins its CSS layout size to its logical dimensions instead of deriving it from the device pixel ratio, so it no longer overflows its `overflow: hidden` wrapper and clips asymmetrically at fractional device pixel ratios. The button loading overlay and the spinner wrapper also use `display: grid` + `place-items: center` for sub-pixel-stable centering.

--- a/packages/core/src/Button/XDSButton.tsx
+++ b/packages/core/src/Button/XDSButton.tsx
@@ -393,9 +393,8 @@ const loadingStyles = stylex.create({
     left: 0,
     right: 0,
     bottom: 0,
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
+    display: 'grid',
+    placeItems: 'center',
   },
 });
 

--- a/packages/core/src/Spinner/XDSSpinner.tsx
+++ b/packages/core/src/Spinner/XDSSpinner.tsx
@@ -62,7 +62,8 @@ const styles = stylex.create({
     gap: spacingVars['--spacing-2'],
   },
   spinner: {
-    display: 'inline-block',
+    display: 'inline-grid',
+    placeItems: 'center',
     overflow: 'hidden',
     verticalAlign: 'middle',
   },
@@ -200,12 +201,16 @@ export function XDSSpinner({
           ? `${themeTokens['--color-on-dark']}4D`
           : themeTokens['--color-track'];
 
-    const radius = (diameter / 2) * pixelRatio;
-    const lineWidth = border * pixelRatio;
-    // Ensure even frame size so center is always on a whole pixel (prevents rotation jitter)
-    const rawFrameSize = Math.ceil((radius + lineWidth) * 2);
+    const cssSize = diameter + border * 2;
+
+    // Round to an even number of device pixels so the center stays on a whole
+    // pixel (avoids rotation jitter); keep CSS size pinned to cssSize (#2732).
+    const rawFrameSize = Math.round(cssSize * pixelRatio);
     const frameSize = rawFrameSize + (rawFrameSize % 2);
-    const cssSize = frameSize / pixelRatio;
+
+    const scale = frameSize / cssSize;
+    const radius = (diameter / 2) * scale;
+    const lineWidth = border * scale;
 
     canvas.height = canvas.width = frameSize;
     canvas.style.width = canvas.style.height = cssSize + 'px';


### PR DESCRIPTION
## Summary

Fixes #2732 — the loading spinner in icon-only `XDSButton` rendered offset toward the top-left instead of centered.

## Root cause

`XDSSpinner` sized its canvas **backing store** from `window.devicePixelRatio` and then set the canvas **CSS layout size** to `frameSize / pixelRatio`. At fractional pixel ratios (e.g. DPR 1.5) this produced a non-integer CSS size — `14.67px` for `size="sm"` — while the wrapping `<span>` is fixed at the logical `14px` and has `overflow: hidden`. The 0.67px overflow was clipped asymmetrically from the bottom-right, shifting the visible ring up-left.

This was most visible in icon-only buttons because the spinner is the only content in a square `aspect-ratio: 1/1` box, so any offset reads as obviously off-center.

## Fix

- **`XDSSpinner.tsx`** — Pin the canvas CSS layout size to the logical dimensions (`diameter + border*2`) so it always exactly fills its wrapper — no fractional overflow, no asymmetric clipping. The backing store still scales by DPR (rounded to an even device-pixel count for crisp, jitter-free rendering), and the draw `scale` is derived from `backingSize / cssSize` so the ring geometry stays perfectly centered at every DPR.
- **`XDSSpinner.tsx`** — Spinner wrapper span now uses `display: inline-grid` + `place-items: center` so the canvas is centered defensively even if sizes ever diverge.
- **`XDSButton.tsx`** — `loadingStyles.spinnerOverlay` switched from `inline-flex` to `display: grid` + `place-items: center` for sub-pixel-stable centering inside the icon-only aspect-ratio box.

## Verification

| Gate | Result |
| --- | --- |
| `pnpm -F @xds/core build` | ✅ pass |
| Button + Spinner tests (`vitest run`) | ✅ 40/40 pass |
| `pnpm -F @xds/core lint` | ✅ clean |
| `pnpm -F @xds/core typecheck` | ✅ clean |
| `node scripts/sync-exports.js --check` | ✅ up to date |
| Visual harness across sm/md/lg @ DPR 1 / 1.25 / 1.5 / 2 / 2.5 | ✅ centered on crosshair |

A standalone HTML harness reproducing the canvas geometry confirmed that the old path clips off-center at fractional DPRs while the new path lands exactly on the button center for all sizes.

A `@xds/core` patch changeset is included.

## Status

Fix complete and all local CI gates green. Opening as a draft for review.
