### PR TITLE
fix(docsite): wrap context-dependent sub-components in interactive preview (#2766)

### DIFF
--- a/apps/docsite/scripts/generate-data.mjs
+++ b/apps/docsite/scripts/generate-data.mjs
@@ -766,7 +766,11 @@ export interface ElementDescriptor {
 }
 
 export interface PlaygroundConfig {
-  defaults: Record<string, unknown>;
+  defaults?: Record<string, unknown>;
+  wrapper?: {
+    component: string;
+    props?: Record<string, unknown>;
+  };
 }
 
 export const components: Record<string, ComponentEntry[]> = ${JSON.stringify(allComponents, null, 2)};

--- a/apps/docsite/src/components/component-detail/ComponentDetailClient.tsx
+++ b/apps/docsite/src/components/component-detail/ComponentDetailClient.tsx
@@ -200,6 +200,7 @@ function ComponentDetailInner({
                     name={comp.name}
                     state={state}
                     knobs={knobs}
+                    playground={comp.playground}
                     missingRequiredProps={missingRequiredProps}
                     onPropChange={setProp}
                     canControlOpenState={

--- a/apps/docsite/src/components/component-detail/InteractivePreview.tsx
+++ b/apps/docsite/src/components/component-detail/InteractivePreview.tsx
@@ -189,6 +189,7 @@ export function InteractivePreviewStage({
   name,
   state,
   knobs,
+  playground,
   missingRequiredProps = [],
   onPropChange,
   canControlOpenState = false,
@@ -196,6 +197,7 @@ export function InteractivePreviewStage({
   name: string;
   state: Record<string, unknown>;
   knobs?: KnobProp[];
+  playground?: PlaygroundConfig | null;
   missingRequiredProps?: string[];
   onPropChange?: (propName: string, value: unknown) => void;
   canControlOpenState?: boolean;
@@ -211,6 +213,30 @@ export function InteractivePreviewStage({
         }),
       ) as Record<string, unknown>,
     [state, onPropChange, canControlOpenState, knobs],
+  );
+
+  // Sub-components that need a parent context provider declare it via
+  // `playground.wrapper`; wrap the previewed component in that parent.
+  const wrapper = playground?.wrapper ?? null;
+  const WrapperComponent = wrapper ? getXDSComponent(wrapper.component) : null;
+  const wrapperProps = useMemo(() => {
+    const resolved = wrapper?.props
+      ? (resolveValue(wrapper.props) as Record<string, unknown>)
+      : {};
+    // Wrapper parents require an onChange that can't be serialized; no-op it.
+    if (!('onChange' in resolved)) {
+      resolved.onChange = () => {};
+    }
+    return resolved;
+  }, [wrapper]);
+  const renderPreview = useCallback(
+    (rendered: ReactNode): ReactNode => {
+      if (wrapper && WrapperComponent) {
+        return createElement(WrapperComponent, wrapperProps, rendered);
+      }
+      return rendered;
+    },
+    [wrapper, WrapperComponent, wrapperProps],
   );
 
   if (missingRequiredProps.length > 0) {
@@ -311,8 +337,9 @@ export function InteractivePreviewStage({
               width: '100%',
               padding: 'var(--spacing-4)',
             }}>
-            <PreviewErrorBoundary resetKeys={[Component, runtimeState]}>
-              {createElement(Component, runtimeState)}
+            <PreviewErrorBoundary
+              resetKeys={[Component, runtimeState, WrapperComponent]}>
+              {renderPreview(createElement(Component, runtimeState))}
             </PreviewErrorBoundary>
           </XDSCenter>
         )}

--- a/packages/core/src/RadioList/RadioListItem.doc.mjs
+++ b/packages/core/src/RadioList/RadioListItem.doc.mjs
@@ -8,6 +8,14 @@ export const docs = {
   displayName: 'Radio List Item',
   isHiddenFromOverview: true,
   description: 'Individual radio item with label, description, and content slots.',
+  // XDSRadioListItem requires XDSRadioList context; wrap it so the preview doesn't throw.
+  playground: {
+    defaults: {value: 'option-1', label: 'Option'},
+    wrapper: {
+      component: 'XDSRadioList',
+      props: {value: 'option-1', label: 'Radio list'},
+    },
+  },
   props: [
     {
       name: 'label',

--- a/packages/core/src/SegmentedControl/SegmentedControlItem.doc.mjs
+++ b/packages/core/src/SegmentedControl/SegmentedControlItem.doc.mjs
@@ -8,6 +8,14 @@ export const docs = {
   displayName: 'Segmented Control Item',
   isHiddenFromOverview: true,
   description: 'Individual segment item rendering as a radio button within the segmented control.',
+  // XDSSegmentedControlItem requires XDSSegmentedControl context; wrap it so the preview doesn't throw.
+  playground: {
+    defaults: {value: 'item-1', label: 'Item'},
+    wrapper: {
+      component: 'XDSSegmentedControl',
+      props: {value: 'item-1', label: 'Segmented control'},
+    },
+  },
   props: [
     {
       name: 'value',

--- a/packages/core/src/TabList/Tab.doc.mjs
+++ b/packages/core/src/TabList/Tab.doc.mjs
@@ -9,6 +9,11 @@ export const docs = {
   isHiddenFromOverview: true,
   description:
     'Individual tab item that renders as a button or an anchor link, with selected-state styling and optional icons.',
+  // XDSTab requires XDSTabList context; wrap it so the preview doesn't throw.
+  playground: {
+    defaults: {value: 'tab-1', label: 'Tab'},
+    wrapper: {component: 'XDSTabList', props: {value: 'tab-1'}},
+  },
   props: [
     {
       name: 'value',

--- a/packages/core/src/docs-types.ts
+++ b/packages/core/src/docs-types.ts
@@ -389,7 +389,24 @@ export interface ElementDescriptor {
 export interface PlaygroundConfig {
   /** Initial prop values for the playground preview.
    *  Keys are prop names. Values are primitives or ElementDescriptors. */
-  defaults: Record<string, unknown>;
+  defaults?: Record<string, unknown>;
+  /** Required parent wrapper for sub-components that depend on a parent
+   *  context provider (e.g. `XDSTab` calls `useXDSTabListContext()` and throws
+   *  standalone). The preview wraps the component in this parent before
+   *  rendering, injecting it as `children`. Provide any props the wrapper
+   *  requires (e.g. a matching `value`).
+   *
+   *  @example
+   *  ```
+   *  playground: {wrapper: {component: 'XDSTabList', props: {value: 'tab-1'}}}
+   *  ```
+   */
+  wrapper?: {
+    /** Parent component name as exported from `@xds/core`, e.g. `'XDSTabList'`. */
+    component: string;
+    /** Props for the wrapper. The previewed sub-component becomes its `children`. */
+    props?: Record<string, unknown>;
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #2766. Sub-components like `XDSTab` call `useXDSTabListContext()` and **throw** when the docsite's interactive preview renders them standalone via `createElement(Component, state)`. `PreviewErrorBoundary` catches the error and shows "Render error" instead of a working preview.

This adds a mechanism for a sub-component's doc to declare the **required parent wrapper** for its preview.

## Changes

- **`playground.wrapper` config** — `{ component: string, props?: Record<string, unknown> }`. Added to:
  - the authoring type in `packages/core/src/docs-types.ts` (with JSDoc + example)
  - the generated registry type in `apps/docsite/scripts/generate-data.mjs`
  - `defaults` is now optional, since a wrapper-only playground config is valid.
- **`InteractivePreviewStage`** — when `playground.wrapper` is present, resolves the parent component from `@xds/core` and wraps the previewed component in it via `createElement(Wrapper, props, child)` before rendering. The wrapper is added to the error-boundary `resetKeys`.
  - Injects a no-op `onChange` when the wrapper doesn't supply one — `XDSTabList` / `XDSSegmentedControl` / `XDSRadioList` all require it, and functions can't survive the JSON serialization of the generated registry.
- **Doc declarations** for the affected sub-components:
  - `Tab.doc.mjs` → `wrapper: { component: 'XDSTabList', props: { value: 'tab-1' } }`
  - `SegmentedControlItem.doc.mjs` → `wrapper: { component: 'XDSSegmentedControl', props: { value: 'item-1', label: 'Segmented control' } }`
  - `RadioListItem.doc.mjs` → `wrapper: { component: 'XDSRadioList', props: { value: 'option-1', label: 'Radio list' } }`
  - Each also sets matching `defaults` (`value`/`label`) so the previewed item renders in its selected state.

## Testing

- `pnpm -F @xds/docsite test` — **all 133 tests pass** (includes the preview-state, resolve-elements, and prop-controls suites that exercise this code path).
- ESLint clean on all changed source files.
- `@xds/core` builds successfully; registry regenerates and carries the `wrapper` config through (verified in generated `componentRegistry.ts`).
- Affected core component test suites (TabList / RadioList / SegmentedControl) run separately as a sanity check — these doc/docsite changes don't touch component runtime behavior.

## Notes

- The generated registries under `apps/docsite/src/generated/` are gitignored build artifacts and are not part of this diff.
