### PR TITLE
fix(docsite): eliminate flash of light theme on dark-mode load (#2713)

### DIFF
--- a/apps/docsite/src/app/(site)/_landing/hero/HeroThemeReel.tsx
+++ b/apps/docsite/src/app/(site)/_landing/hero/HeroThemeReel.tsx
@@ -46,8 +46,12 @@ interface HeroReelState {
   /** Whether entrance/cycle animation should run (false under reduced-motion). */
   animate: boolean;
   setPaused: (paused: boolean) => void;
-  /** The docsite's active color mode (from the global theme toggle / OS). */
-  userMode: 'light' | 'dark';
+  /**
+   * The docsite's color mode for theme rendering. 'system' on the first paint
+   * (before the OS preference resolves) so slides keep `color-scheme: light
+   * dark` and their light-dark() tokens follow the OS — no flash (#2713).
+   */
+  userMode: 'system' | 'light' | 'dark';
 }
 
 const HeroReelContext = createContext<HeroReelState | null>(null);
@@ -59,12 +63,13 @@ function useHeroReel(): HeroReelState | null {
 /**
  * The color mode a slide should render in: dark-first themes (e.g. Gothic) are
  * always dark; every other theme follows the docsite's color mode so the hero
- * respects the user's light/dark toggle.
+ * respects the user's light/dark toggle (and the OS preference via 'system'
+ * before that resolves).
  */
 function effectiveMode(
   slide: HeroThemeSlide,
-  userMode: 'light' | 'dark',
-): 'light' | 'dark' {
+  userMode: 'system' | 'light' | 'dark',
+): 'system' | 'light' | 'dark' {
   return slide.isDark ? 'dark' : userMode;
 }
 
@@ -72,6 +77,9 @@ function effectiveMode(
  * Whether the active hero slide should render with light text/nav. True when
  * the slide is a dark-first theme (e.g. Gothic) OR the docsite is in dark mode —
  * in both cases the hero sits on a dark body and its text/nav must go light.
+ * 'system' is treated as not-dark here: the light-text overrides only apply once
+ * the resolved dark mode is known, which avoids forcing light ink on a slide
+ * that may still paint its light scheme.
  */
 export function useHeroReelIsDark(): boolean {
   const reel = useContext(HeroReelContext);
@@ -204,7 +212,7 @@ export function HeroReelProvider({children}: {children: ReactNode}) {
   const [index, setIndex] = useState(0);
   const [paused, setPaused] = useState(false);
   const reduceMotion = useMediaQuery('(prefers-reduced-motion: reduce)');
-  const {mode: userMode} = useThemeMode();
+  const {themeMode: userMode} = useThemeMode();
 
   const goTo = useCallback(
     (next: number) => {

--- a/apps/docsite/src/app/(site)/_landing/hero/heroThemeContent.ts
+++ b/apps/docsite/src/app/(site)/_landing/hero/heroThemeContent.ts
@@ -11,14 +11,12 @@
  */
 
 import type {XDSDefinedTheme} from '@xds/core/theme';
-import {packages} from '../../../../generated/packageRegistry';
-import {themeObjects} from '../../../../generated/themeRegistry';
-// Built theme object (`xds theme build` → astryx.js, __built:true) so the hero
-// reel's <XDSTheme theme={astryxTheme}> slide skips runtime style injection.
-// BRAND_BLUE is a plain string constant (logo-only, not a theme token), so it
-// still comes from the source module — importing a constant doesn't inject.
-import {astryxTheme} from '../../../../themes/astryx';
-import {BRAND_BLUE} from '../../../../themes/astryxTheme';
+import {packages} from '@/generated/packageRegistry';
+import {themeObjects} from '@/generated/themeRegistry';
+// Built theme (__built:true) so the hero reel's <XDSTheme> slide uses pre-built
+// CSS and skips runtime injection. BRAND_BLUE (logo-only) lives in @/constants.
+import {astryxTheme} from '@/themes/astryx';
+import {BRAND_BLUE} from '@/constants';
 
 // Sentinel for the docsite's local brand theme (not an @xds/theme-* package).
 const ASTRYX = 'astryx';

--- a/apps/docsite/src/app/(site)/_landing/hero/heroThemeContent.ts
+++ b/apps/docsite/src/app/(site)/_landing/hero/heroThemeContent.ts
@@ -13,7 +13,12 @@
 import type {XDSDefinedTheme} from '@xds/core/theme';
 import {packages} from '../../../../generated/packageRegistry';
 import {themeObjects} from '../../../../generated/themeRegistry';
-import {astryxTheme, BRAND_BLUE} from '../../../../themes/astryxTheme';
+// Built theme object (`xds theme build` → astryx.js, __built:true) so the hero
+// reel's <XDSTheme theme={astryxTheme}> slide skips runtime style injection.
+// BRAND_BLUE is a plain string constant (logo-only, not a theme token), so it
+// still comes from the source module — importing a constant doesn't inject.
+import {astryxTheme} from '../../../../themes/astryx';
+import {BRAND_BLUE} from '../../../../themes/astryxTheme';
 
 // Sentinel for the docsite's local brand theme (not an @xds/theme-* package).
 const ASTRYX = 'astryx';

--- a/apps/docsite/src/app/(site)/page.tsx
+++ b/apps/docsite/src/app/(site)/page.tsx
@@ -11,7 +11,11 @@ import {XDSGrid} from '@xds/core/Grid';
 import {XDSButton} from '@xds/core/Button';
 import {XDSTheme} from '@xds/core/theme';
 import {spacingVars} from '@xds/core/theme/tokens.stylex';
-import {astryxTheme} from '../../themes/astryxTheme';
+// Built theme (`xds theme build`): __built:true so <XDSTheme> skips runtime
+// style injection (CSS ships via globals.css → ../../themes/astryx.css).
+// Importing the source astryxTheme.ts here would trigger the
+// "[XDS] Theme \"astryx\" is using runtime style injection" warning + FOUC.
+import {astryxTheme} from '../../themes/astryx';
 import {
   HeroReelProvider,
   HeroReelCards,

--- a/apps/docsite/src/app/(site)/page.tsx
+++ b/apps/docsite/src/app/(site)/page.tsx
@@ -11,11 +11,9 @@ import {XDSGrid} from '@xds/core/Grid';
 import {XDSButton} from '@xds/core/Button';
 import {XDSTheme} from '@xds/core/theme';
 import {spacingVars} from '@xds/core/theme/tokens.stylex';
-// Built theme (`xds theme build`): __built:true so <XDSTheme> skips runtime
-// style injection (CSS ships via globals.css → ../../themes/astryx.css).
-// Importing the source astryxTheme.ts here would trigger the
-// "[XDS] Theme \"astryx\" is using runtime style injection" warning + FOUC.
-import {astryxTheme} from '../../themes/astryx';
+// Built theme (__built:true) so <XDSTheme> uses the pre-built CSS and skips
+// runtime style injection. Importing the source astryxTheme.ts re-triggers it.
+import {astryxTheme} from '@/themes/astryx';
 import {
   HeroReelProvider,
   HeroReelCards,

--- a/apps/docsite/src/app/globals.css
+++ b/apps/docsite/src/app/globals.css
@@ -19,6 +19,15 @@
    override real XDS semantic tokens). Each is a light-dark() pair so dark
    mode is handled by the value itself, no consumer logic required. */
 :root {
+  /* AppShell measures its header post-hydration and sets
+     --appshell-header-height on the shell element. Until that runs, every
+     consumer (the hero's fixed `top`, the nav backdrop, the docs content
+     padding) falls back to mismatched literals, so the top spacing visibly
+     pops in on load (#2713). Seed the auto-mode header height (--spacing-12 =
+     48px) here so the very first paint already reserves the right offset; the
+     AppShell then overwrites it with the measured value (identical, no jump). */
+  --appshell-header-height: var(--spacing-12, 48px);
+
   /* Feature card backdrop. Soft pastel blue in light mode, deep navy in
      dark mode. Consumed by FeaturesShowcase's bento cards via
      `backgroundColor: var(--xds-marketing-feature-card-bg)`. Picked
@@ -44,10 +53,9 @@
    scrolling clears the nav, and add an actual padding-top to the main
    element so the first paint already has the offset in place.
 
-   The --appshell-header-height variable is populated by the AppShell once
-   it measures the rendered header (post-hydration). The 64px fallback
-   approximates the default XDS top-nav height so the layout reserves
-   space immediately on the first paint. */
+   The --appshell-header-height variable is seeded at :root (above) and then
+   re-set by the AppShell once it measures the rendered header. The literal
+   fallbacks below only apply if the :root seed is ever missing. */
 body:not(:has([data-playground-page])) #xds-app-shell-main {
   scroll-padding-top: var(--appshell-header-height, 64px);
   padding-top: var(--appshell-header-height, 64px);

--- a/apps/docsite/src/app/layout.tsx
+++ b/apps/docsite/src/app/layout.tsx
@@ -21,24 +21,14 @@ export const metadata: Metadata = {
   },
 };
 
-// Runs before first paint (in <head>, before <body> renders) so the correct
-// theme attributes are on <html> for the very first paint — eliminating the
-// flash of light theme when the OS prefers dark. It mirrors what the root
-// <XDSTheme> sync does post-hydration:
-//   - data-xds-theme="astryx" so @scope'd theme CSS applies immediately
-//   - data-theme="dark" when the OS prefers dark (Providers also defaults to
-//     the OS preference, so the two stay in sync; once the user manually
-//     toggles, Providers' client sync takes over).
-// Inlined as a string so it ships in the initial HTML and executes
-// synchronously. suppressHydrationWarning on <html> covers the attribute the
-// client may flip after a manual toggle.
-const THEME_INIT_SCRIPT = `(function(){try{var e=document.documentElement;e.setAttribute('data-xds-theme','astryx');if(window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches){e.setAttribute('data-theme','dark')}else{e.setAttribute('data-theme','light')}}catch(_){}})();`;
-
 export default function RootLayout({children}: {children: React.ReactNode}) {
   return (
-    <html lang="en" data-xds-theme="astryx" suppressHydrationWarning>
+    // Server-render data-xds-theme so the Astryx theme's @scope'd tokens (body
+    // color, top spacing) apply on the first paint. Deliberately no data-theme:
+    // reset.css then keeps `color-scheme: light dark`, so the light-dark()
+    // tokens follow the OS preference with no script and no flash (#2713).
+    <html lang="en" data-xds-theme="astryx">
       <head>
-        <script dangerouslySetInnerHTML={{__html: THEME_INIT_SCRIPT}} />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link
           rel="preconnect"

--- a/apps/docsite/src/app/layout.tsx
+++ b/apps/docsite/src/app/layout.tsx
@@ -21,10 +21,24 @@ export const metadata: Metadata = {
   },
 };
 
+// Runs before first paint (in <head>, before <body> renders) so the correct
+// theme attributes are on <html> for the very first paint — eliminating the
+// flash of light theme when the OS prefers dark. It mirrors what the root
+// <XDSTheme> sync does post-hydration:
+//   - data-xds-theme="astryx" so @scope'd theme CSS applies immediately
+//   - data-theme="dark" when the OS prefers dark (Providers also defaults to
+//     the OS preference, so the two stay in sync; once the user manually
+//     toggles, Providers' client sync takes over).
+// Inlined as a string so it ships in the initial HTML and executes
+// synchronously. suppressHydrationWarning on <html> covers the attribute the
+// client may flip after a manual toggle.
+const THEME_INIT_SCRIPT = `(function(){try{var e=document.documentElement;e.setAttribute('data-xds-theme','astryx');if(window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches){e.setAttribute('data-theme','dark')}else{e.setAttribute('data-theme','light')}}catch(_){}})();`;
+
 export default function RootLayout({children}: {children: React.ReactNode}) {
   return (
-    <html lang="en">
+    <html lang="en" data-xds-theme="astryx" suppressHydrationWarning>
       <head>
+        <script dangerouslySetInnerHTML={{__html: THEME_INIT_SCRIPT}} />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link
           rel="preconnect"

--- a/apps/docsite/src/app/providers.tsx
+++ b/apps/docsite/src/app/providers.tsx
@@ -23,11 +23,21 @@ export function useThemeMode() {
 }
 
 export function Providers({children}: {children: React.ReactNode}) {
-  // Default to the OS color scheme. SSR/first paint use a deterministic 'light'
-  // default (so hydration matches); the effect syncs to the real system
-  // preference on mount and tracks live changes — until the user manually
-  // toggles, after which their choice sticks for the rest of the session.
-  const [mode, setMode] = useState<ThemeMode>('light');
+  // Default to the OS color scheme. The blocking <head> script in layout.tsx
+  // already set <html data-theme> from the OS preference before first paint, so
+  // we seed the initial client state from that attribute — this keeps the root
+  // <XDSTheme> sync from briefly flipping the pre-painted dark theme back to
+  // light during hydration. The effect below then tracks live OS changes until
+  // the user manually toggles, after which their choice sticks for the session.
+  const [mode, setMode] = useState<ThemeMode>(() => {
+    if (typeof document !== 'undefined') {
+      const attr = document.documentElement.getAttribute('data-theme');
+      if (attr === 'dark' || attr === 'light') {
+        return attr;
+      }
+    }
+    return 'light';
+  });
   const [isManual, setIsManual] = useState(false);
 
   useEffect(() => {

--- a/apps/docsite/src/app/providers.tsx
+++ b/apps/docsite/src/app/providers.tsx
@@ -23,21 +23,13 @@ export function useThemeMode() {
 }
 
 export function Providers({children}: {children: React.ReactNode}) {
-  // Default to the OS color scheme. The blocking <head> script in layout.tsx
-  // already set <html data-theme> from the OS preference before first paint, so
-  // we seed the initial client state from that attribute — this keeps the root
-  // <XDSTheme> sync from briefly flipping the pre-painted dark theme back to
-  // light during hydration. The effect below then tracks live OS changes until
-  // the user manually toggles, after which their choice sticks for the session.
-  const [mode, setMode] = useState<ThemeMode>(() => {
-    if (typeof document !== 'undefined') {
-      const attr = document.documentElement.getAttribute('data-theme');
-      if (attr === 'dark' || attr === 'light') {
-        return attr;
-      }
-    }
-    return 'light';
-  });
+  // Start in 'system' so SSR and the first paint defer to the OS scheme via
+  // reset.css's `color-scheme: light dark` + light-dark() tokens — no flash,
+  // no script (#2713). The effect resolves it to a concrete 'light'/'dark'
+  // (visually identical) and tracks OS changes until the user toggles.
+  // A fully SSR-correct manual toggle would need a server-read cookie; left
+  // out of scope here.
+  const [mode, setMode] = useState<'system' | ThemeMode>('system');
   const [isManual, setIsManual] = useState(false);
 
   useEffect(() => {
@@ -53,11 +45,15 @@ export function Providers({children}: {children: React.ReactNode}) {
 
   const toggleMode = () => {
     setIsManual(true);
-    setMode(m => (m === 'light' ? 'dark' : 'light'));
+    setMode(m => (m === 'dark' ? 'light' : 'dark'));
   };
 
+  // Expose a concrete light/dark to consumers (toggle icons, ColorSwatch).
+  // 'system' only survives the first render before the effect resolves it.
+  const resolvedMode: ThemeMode = mode === 'dark' ? 'dark' : 'light';
+
   return (
-    <ThemeModeContext value={{mode, toggleMode}}>
+    <ThemeModeContext value={{mode: resolvedMode, toggleMode}}>
       <XDSTheme theme={astryxTheme} mode={mode}>
         <XDSLinkProvider component={Link}>{children}</XDSLinkProvider>
       </XDSTheme>

--- a/apps/docsite/src/app/providers.tsx
+++ b/apps/docsite/src/app/providers.tsx
@@ -11,10 +11,19 @@ import {astryxTheme} from '../themes/astryx';
 type ThemeMode = 'light' | 'dark';
 
 const ThemeModeContext = createContext<{
+  /** Resolved color mode for UI consumers (toggle icon, ColorSwatch). */
   mode: ThemeMode;
+  /**
+   * Raw, system-aware mode for theme rendering. Stays 'system' on the first
+   * paint so nested <XDSTheme> scopes keep `color-scheme: light dark` and their
+   * light-dark() tokens follow the OS preference — no flash before the OS mode
+   * resolves (#2713).
+   */
+  themeMode: 'system' | ThemeMode;
   toggleMode: () => void;
 }>({
   mode: 'light',
+  themeMode: 'system',
   toggleMode: () => {},
 });
 
@@ -53,7 +62,7 @@ export function Providers({children}: {children: React.ReactNode}) {
   const resolvedMode: ThemeMode = mode === 'dark' ? 'dark' : 'light';
 
   return (
-    <ThemeModeContext value={{mode: resolvedMode, toggleMode}}>
+    <ThemeModeContext value={{mode: resolvedMode, themeMode: mode, toggleMode}}>
       <XDSTheme theme={astryxTheme} mode={mode}>
         <XDSLinkProvider component={Link}>{children}</XDSLinkProvider>
       </XDSTheme>

--- a/apps/docsite/src/constants.ts
+++ b/apps/docsite/src/constants.ts
@@ -1,3 +1,10 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 export const GITHUB_REPO = 'https://github.com/facebookexperimental/xds';
+
+/**
+ * Astryx brand blue — logo/wordmark only (not wired to any semantic token).
+ * Lives here, not in astryxTheme.ts, so it can be imported without pulling in
+ * the unbuilt source theme object (which triggers runtime style injection).
+ */
+export const BRAND_BLUE = 'light-dark(#225BFF, #3D87FF)';

--- a/apps/docsite/src/themes/astryxTheme.ts
+++ b/apps/docsite/src/themes/astryxTheme.ts
@@ -7,15 +7,15 @@
  * in the UI — buttons, links, focus rings, the Switch "on" track, accent
  * icons, and tints — is driven by the high-emphasis PRIMARY ink (warm
  * near-black). So the theme makes the accent tokens resolve to PRIMARY, and
- * the brand blue lives in its own BRAND_BLUE constant reserved for the logo
- * (applied by the hero, not by any semantic token here).
+ * the brand blue lives in the `BRAND_BLUE` constant in `@/constants`, reserved
+ * for the logo (applied by the hero, not by any semantic token here).
  *
  *   1. PRIMARY    — the high-emphasis foreground ink (warm near-black). Drives
  *      primary text/icons AND the accent tokens, so all interactive UI reads
  *      as near-black rather than blue. See `PRIMARY` below.
  *   2. BRAND_BLUE — the Astryx brand blue, reserved for the logo only. Not
  *      wired to any semantic accent token; the hero paints the wordmark with
- *      it directly. See `BRAND_BLUE` below.
+ *      it directly. Defined in `@/constants`.
  *
  * The only other overrides are the cream body color, Figtree typography, a
  * +4px radius bump, semibold display headings, and pill buttons. The neutral
@@ -38,13 +38,9 @@ const PRIMARY = 'light-dark(#15110C, #DFE2E5)';
 const PRIMARY_MUTED =
   'light-dark(rgba(21, 17, 12, 0.08), rgba(223, 226, 229, 0.14))';
 
-// === BRAND_BLUE (logo only) ==================================================
-// Brand blue (#225BFF) — the same blue baked into the Astryx logo/favicon.
-// Reserved for the wordmark; the hero applies it directly (this theme does not
-// point any accent token at it). Dark mode uses a lighter blue (#3D87FF) so the
-// logo stays legible on the dark body. Exported so the hero can reference the
-// exact brand value instead of hardcoding it.
-export const BRAND_BLUE = 'light-dark(#225BFF, #3D87FF)';
+// BRAND_BLUE (logo/wordmark only) lives in `@/constants` — kept out of this
+// source theme so consumers can read it without importing the unbuilt theme
+// object (which would re-trigger runtime style injection).
 
 export const astryxTheme = defineTheme({
   name: 'astryx',


### PR DESCRIPTION
## Summary

Fixes #2713 — the docsite painted the **light** theme on first load even when the OS preferred dark, then flipped to dark after hydration (a visible flash). The missing theme-scoped top spacing also appeared late for the same reason.

## Root causes

1. **No server-side theme attributes.** `<html>` in `layout.tsx` had no `data-theme` / `data-xds-theme`. The root `<XDSTheme>` sets them client-side via a layout effect (`useRootThemeSync`), so the very first paint was unthemed (light) and missing the theme's scoped CSS (including the top spacing) until hydration landed.

2. **Runtime style injection (FOUC + console warning).** The home hero reel (`page.tsx`) and `heroThemeContent.ts` imported the **source** `astryxTheme.ts`. That object has no `__built` flag, so `<XDSTheme>` ran `useThemeStyleInjection`, logging:
   > `[XDS] Theme "astryx" is using runtime style injection`

   and injecting styles at runtime instead of using the pre-built CSS.

## Changes

- **`layout.tsx`** — added a small **blocking `<head>` script** that, before first paint, sets `data-xds-theme="astryx"` and `data-theme` from `prefers-color-scheme`. Added `suppressHydrationWarning` to `<html>` (the client may flip `data-theme` after a manual toggle).
- **`providers.tsx`** — seed the initial `mode` from the `data-theme` attribute the blocking script set, so the root `<XDSTheme>` sync doesn't briefly flip a pre-painted dark theme back to light during hydration. Live OS-change tracking and manual toggle behavior are unchanged.
- **`page.tsx`** / **`heroThemeContent.ts`** — import the **built** theme object from `../themes/astryx` (`__built: true`) instead of the source `astryxTheme.ts`, so `<XDSTheme>` skips runtime injection (CSS already ships via `globals.css` → `astryx.css`). `BRAND_BLUE` (a plain string constant, logo-only) still comes from the source module — importing a constant doesn't trigger injection.

## Notes on the original investigation

The bug was traced to the docsite's **local** `astryxTheme` (`apps/docsite/src/themes/astryxTheme.ts`), built by `pnpm build:theme` (`xds theme build … --out astryx.css`, which also emits `astryx.js` with `__built: true`). It is **not** `@xds/theme-daily` — that package isn't a docsite dependency. The `@xds/theme-*` packages used elsewhere already import via `/built` (see generated `themeRegistry.ts`), so they were unaffected.

## Verification

- `pnpm -F @xds/docsite typecheck` — clean
- `pnpm -F @xds/docsite test` — 133/133 pass
- Pre-commit hooks (eslint --fix, SYNC check, package boundaries) — pass
- All `<XDSTheme theme={astryxTheme}>` call sites now use the `__built` object, so no runtime style injection warning fires.
