### PR TITLE
feat(field): add width prop to field-based components (#2755)

### DIFF
--- a/.changeset/field-width-prop.md
+++ b/.changeset/field-width-prop.md
@@ -1,0 +1,11 @@
+---
+'@xds/core': minor
+---
+
+Add a `width` prop to field-based components so they can size predictably. `width` (a `SizeValue` — numbers are pixels, strings like `'100%'` are used as-is) is applied to the outer `XDSField` container, so the whole field — label, control, and status — sizes together and stays aligned.
+
+Previously the only way to size these components was `xstyle`/`className`/`style`, which land on the inner control box: setting `width: '100%'` there stretched the bordered input but left the label and status at their natural width (issue #2755). `width` targets the right element and avoids that mismatch.
+
+This is additive and backward compatible — `xstyle`/`className`/`style` continue to target the inner control box exactly as before.
+
+Affected: `XDSTextInput`, `XDSTextArea`, `XDSNumberInput`, `XDSDateInput`, `XDSDateRangeInput`, `XDSDateTimeInput`, `XDSTimeInput`, `XDSFileInput`, `XDSSelector`, `XDSMultiSelector`, `XDSTypeahead`, `XDSTokenizer`, `XDSSlider`, `XDSCheckboxInput`, `XDSCheckboxList`, `XDSRadioList`, `XDSSwitch`, and `XDSField` itself.

--- a/packages/core/src/CheckboxInput/XDSCheckboxInput.tsx
+++ b/packages/core/src/CheckboxInput/XDSCheckboxInput.tsx
@@ -38,6 +38,7 @@ import {
   borderVars,
 } from '../theme/tokens.stylex';
 import type {XDSBaseProps} from '../XDSBaseProps';
+import type {SizeValue} from '../utils/types';
 import {XDSFieldLabel} from '../Field/XDSFieldLabel';
 import {XDSFieldStatus} from '../FieldStatus/XDSFieldStatus';
 import type {XDSIconType} from '../Icon';
@@ -280,6 +281,12 @@ export interface XDSCheckboxInputProps extends Omit<XDSBaseProps, 'onChange'> {
    */
   isRequired?: boolean;
   /**
+   * Width of the field. Numbers are treated as pixels, strings are used as-is
+   * (e.g. `'100%'`). Sizes the whole field (label, control, and status) so they
+   * stay aligned, unlike setting width via `xstyle`/`className`/`style`.
+   */
+  width?: SizeValue;
+  /**
    * The size of the checkbox.
    * - 'sm': Compact size (28px row height)
    * - 'md': Default size (36px row height)
@@ -304,6 +311,11 @@ export interface XDSCheckboxInputProps extends Omit<XDSBaseProps, 'onChange'> {
    */
   status?: XDSInputStatus;
 }
+
+// Dynamic field width (number -> px, string used as-is).
+const dynamicWidthStyles = stylex.create({
+  width: (width: SizeValue | null) => ({width}),
+});
 
 /**
  * A checkbox input component for toggling boolean values.
@@ -340,6 +352,7 @@ export function XDSCheckboxInput({
   onBlur,
   labelIcon,
   status,
+  width,
   xstyle,
   className,
   style,
@@ -383,7 +396,7 @@ export function XDSCheckboxInput({
     <div
       {...mergeProps(
         xdsThemeProps('checkbox-input', {size}),
-        stylex.props(xstyle),
+        stylex.props(width != null && dynamicWidthStyles.width(width), xstyle),
         className,
         style,
       )}>

--- a/packages/core/src/CheckboxList/XDSCheckboxList.tsx
+++ b/packages/core/src/CheckboxList/XDSCheckboxList.tsx
@@ -25,6 +25,7 @@ import {
   type ReactNode,
 } from 'react';
 import type {XDSBaseProps} from '../XDSBaseProps';
+import type {SizeValue} from '../utils/types';
 import {XDSField} from '../Field/XDSField';
 import type {XDSInputStatus} from '../Field/types';
 import {XDSList} from '../List/XDSList';
@@ -106,6 +107,12 @@ export interface XDSCheckboxListProps extends Omit<
    */
   isReadOnly?: boolean;
   /**
+   * Width of the field. Numbers are treated as pixels, strings are used as-is
+   * (e.g. `'100%'`). Sizes the whole field (label, control, and status) so they
+   * stay aligned, unlike setting width via `xstyle`/`className`/`style`.
+   */
+  width?: SizeValue;
+  /**
    * Checkbox list items to render.
    */
   children: ReactNode;
@@ -144,6 +151,7 @@ export function XDSCheckboxList({
   isReadOnly = false,
   children,
   ref,
+  width,
   xstyle,
   className,
   style,
@@ -210,6 +218,7 @@ export function XDSCheckboxList({
           : undefined
       }
       statusVariant="detached"
+      width={width}
       xstyle={xstyle}
       {...mergeProps(xdsThemeProps('checkbox-list'), {className, style})}>
       <XDSCheckboxListContext value={contextValue}>

--- a/packages/core/src/DateInput/XDSDateInput.tsx
+++ b/packages/core/src/DateInput/XDSDateInput.tsx
@@ -134,6 +134,7 @@ export type {
 } from '../Field';
 import {mergeProps, mergeRefs} from '../utils';
 import type {XDSBaseProps} from '../XDSBaseProps';
+import type {SizeValue} from '../utils/types';
 import {xdsThemeProps} from '../utils/xdsThemeProps';
 
 export interface XDSDateInputProps extends Omit<
@@ -235,6 +236,12 @@ export interface XDSDateInputProps extends Omit<
   status?: XDSInputStatus;
 
   /**
+   * Width of the field. Numbers are treated as pixels, strings are used as-is
+   * (e.g. `'100%'`). Sizes the whole field (label, control, and status) so they
+   * stay aligned, unlike setting width via `xstyle`/`className`/`style`.
+   */
+  width?: SizeValue;
+  /**
    * Tooltip text to display in an info icon at the end of the label.
    */
   labelTooltip?: string;
@@ -285,6 +292,7 @@ export function XDSDateInput({
   labelTooltip,
   hasClear = false,
   numberOfMonths = 1,
+  width,
   xstyle,
   className,
   style,
@@ -502,7 +510,8 @@ export function XDSDateInput({
             }
           : undefined
       }
-      labelTooltip={labelTooltip}>
+      labelTooltip={labelTooltip}
+      width={width}>
       <div
         ref={popover.triggerRef}
         {...rest}

--- a/packages/core/src/DateRangeInput/XDSDateRangeInput.tsx
+++ b/packages/core/src/DateRangeInput/XDSDateRangeInput.tsx
@@ -50,6 +50,7 @@ import {XDSCalendar, type ISODateString, type DateRange} from '../Calendar';
 import {useXDSPopover} from '../Popover';
 import {mergeProps} from '../utils';
 import type {XDSBaseProps} from '../XDSBaseProps';
+import type {SizeValue} from '../utils/types';
 import {useXDSSize} from '../SizeContext/XDSSizeContext';
 import {xdsThemeProps} from '../utils/xdsThemeProps';
 
@@ -306,6 +307,12 @@ export interface XDSDateRangeInputProps extends Omit<
   status?: XDSInputStatus;
 
   /**
+   * Width of the field. Numbers are treated as pixels, strings are used as-is
+   * (e.g. `'100%'`). Sizes the whole field (label, control, and status) so they
+   * stay aligned, unlike setting width via `xstyle`/`className`/`style`.
+   */
+  width?: SizeValue;
+  /**
    * Tooltip text to display in an info icon at the end of the label.
    */
   labelTooltip?: string;
@@ -354,6 +361,7 @@ export function XDSDateRangeInput({
   status,
   labelTooltip,
   numberOfMonths = 2,
+  width,
   xstyle,
   className,
   style,
@@ -476,7 +484,8 @@ export function XDSDateRangeInput({
             }
           : undefined
       }
-      labelTooltip={labelTooltip}>
+      labelTooltip={labelTooltip}
+      width={width}>
       <div
         ref={popover.triggerRef}
         {...rest}

--- a/packages/core/src/DateTimeInput/XDSDateTimeInput.tsx
+++ b/packages/core/src/DateTimeInput/XDSDateTimeInput.tsx
@@ -76,6 +76,7 @@ import {
 } from '../utils/plainDate';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import type {XDSBaseProps} from '../XDSBaseProps';
+import type {SizeValue} from '../utils/types';
 import {useXDSSize} from '../SizeContext/XDSSizeContext';
 import {xdsThemeProps} from '../utils/xdsThemeProps';
 
@@ -294,6 +295,12 @@ export interface XDSDateTimeInputProps extends Omit<
   status?: XDSInputStatus;
 
   /**
+   * Width of the field. Numbers are treated as pixels, strings are used as-is
+   * (e.g. `'100%'`). Sizes the whole field (label, control, and status) so they
+   * stay aligned, unlike setting width via `xstyle`/`className`/`style`.
+   */
+  width?: SizeValue;
+  /**
    * Tooltip text to display in an info icon at the end of the label.
    */
   labelTooltip?: string;
@@ -382,6 +389,7 @@ export function XDSDateTimeInput({
   status,
   labelTooltip,
   numberOfMonths = 1,
+  width,
   xstyle,
   className,
   style,
@@ -777,7 +785,8 @@ export function XDSDateTimeInput({
           : undefined
       }
       labelTooltip={labelTooltip}
-      statusVariant="detached">
+      statusVariant="detached"
+      width={width}>
       <div
         {...rest}
         {...mergeProps(

--- a/packages/core/src/Field/Field.doc.mjs
+++ b/packages/core/src/Field/Field.doc.mjs
@@ -103,6 +103,11 @@ export const docs = {
       default: "'attached'",
     },
     {
+      name: 'width',
+      type: 'SizeValue',
+      description: 'Width of the field (number = pixels, string used as-is, e.g. "100%"). Sizes the whole field — label, control, and status — so they stay aligned. Prefer this over setting width via xstyle/className/style, which only size the inner control box.',
+    },
+    {
       name: 'ref',
       type: 'React.Ref<HTMLDivElement>',
       description: 'Ref forwarded to the root element.',

--- a/packages/core/src/Field/XDSField.test.tsx
+++ b/packages/core/src/Field/XDSField.test.tsx
@@ -264,6 +264,65 @@ describe('XDSField', () => {
     warnSpy.mockRestore();
   });
 
+  // ─── width prop (#2755) ───────────────────────────────────────────────
+
+  describe('width prop', () => {
+    it('applies a string width to the outer field root', () => {
+      render(
+        <XDSField
+          label="Name"
+          inputID="name-input"
+          width="100%"
+          data-testid="field">
+          <input id="name-input" data-testid="control" />
+        </XDSField>,
+      );
+      const field = screen.getByTestId('field');
+      // StyleX compiles the dynamic width to an inline CSS custom property.
+      expect(field.getAttribute('style')).toContain('100%');
+      expect(field.className).toContain('dynamicStyles.width');
+    });
+
+    it('applies a numeric width (treated as pixels)', () => {
+      render(
+        <XDSField
+          label="Name"
+          inputID="name-input"
+          width={240}
+          data-testid="field">
+          <input id="name-input" />
+        </XDSField>,
+      );
+      const field = screen.getByTestId('field');
+      expect(field.getAttribute('style')).toContain('240');
+    });
+
+    it('does not size the inner control element', () => {
+      render(
+        <XDSField
+          label="Name"
+          inputID="name-input"
+          width="100%"
+          data-testid="field">
+          <input id="name-input" data-testid="control" />
+        </XDSField>,
+      );
+      const control = screen.getByTestId('control');
+      // The width var lives on the field root, not the control itself.
+      expect(control.getAttribute('style') ?? '').not.toContain('100%');
+    });
+
+    it('omits width styling when the prop is not provided', () => {
+      render(
+        <XDSField label="Name" inputID="name-input" data-testid="field">
+          <input id="name-input" />
+        </XDSField>,
+      );
+      const field = screen.getByTestId('field');
+      expect(field.className).not.toContain('dynamicStyles.width');
+    });
+  });
+
   // ─── Horizontal-labels context ────────────────────────────────────────
 
   describe('horizontal-labels layout', () => {

--- a/packages/core/src/Field/XDSField.tsx
+++ b/packages/core/src/Field/XDSField.tsx
@@ -19,6 +19,7 @@
 import {type ReactNode, use} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {XDSBaseProps} from '../XDSBaseProps';
+import type {SizeValue} from '../utils/types';
 import {XDSFieldLabel} from './XDSFieldLabel';
 import {XDSFieldStatus} from '../FieldStatus/XDSFieldStatus';
 import {spacingVars, borderVars} from '../theme/tokens.stylex';
@@ -51,6 +52,14 @@ const styles = stylex.create({
     isolation: 'isolate',
   },
 });
+
+// Dynamic style for the consumer-controlled field width. Numbers are treated
+// as pixels by StyleX; strings (e.g. '100%') are used as-is.
+const dynamicStyles = stylex.create({
+  width: (width: SizeValue | null) => ({width}),
+});
+
+export type {SizeValue} from '../utils/types';
 
 export type XDSFieldStatusType = 'warning' | 'error' | 'success';
 
@@ -133,6 +142,14 @@ export interface XDSFieldProps extends Omit<
    */
   statusVariant?: 'attached' | 'detached';
   /**
+   * Width of the field. Numbers are treated as pixels, strings are used as-is
+   * (e.g. `'100%'`). Sizes the whole field — label, control, and status — so
+   * the control and its surrounding chrome stay aligned. Prefer this over
+   * setting `width` via `xstyle`/`className`/`style`, which only size the inner
+   * control box and leave the label and status at their natural width.
+   */
+  width?: SizeValue;
+  /**
    * The input or control to render inside the field.
    */
   children: ReactNode;
@@ -163,6 +180,7 @@ export function XDSField({
   status,
   labelTooltip,
   statusVariant = 'attached',
+  width,
   xstyle,
   children,
   className,
@@ -250,6 +268,7 @@ export function XDSField({
         stylex.props(
           styles.container,
           !isLabelHidden && styles.containerGap,
+          width != null && dynamicStyles.width(width),
           xstyle,
         ),
         className,

--- a/packages/core/src/FileInput/XDSFileInput.tsx
+++ b/packages/core/src/FileInput/XDSFileInput.tsx
@@ -51,6 +51,7 @@ export type {
 } from '../Field';
 import {mergeProps, mergeRefs} from '../utils';
 import type {XDSBaseProps} from '../XDSBaseProps';
+import type {SizeValue} from '../utils/types';
 import {xdsThemeProps} from '../utils/xdsThemeProps';
 
 function formatFileSize(bytes: number): string {
@@ -355,6 +356,12 @@ export interface XDSFileInputProps extends Omit<
    */
   isOptional?: boolean;
   /**
+   * Width of the field. Numbers are treated as pixels, strings are used as-is
+   * (e.g. `'100%'`). Sizes the whole field (label, control, and status) so they
+   * stay aligned, unlike setting width via `xstyle`/`className`/`style`.
+   */
+  width?: SizeValue;
+  /**
    * Tooltip text to display in an info icon at the end of the label.
    */
   labelTooltip?: string;
@@ -387,6 +394,7 @@ export function XDSFileInput({
   mode = 'input',
   isOptional = false,
   labelTooltip,
+  width,
   xstyle,
   className,
   style,
@@ -655,7 +663,8 @@ export function XDSFileInput({
             }
           : undefined
       }
-      labelTooltip={labelTooltip}>
+      labelTooltip={labelTooltip}
+      width={width}>
       <div
         role="button"
         tabIndex={isDisabled ? -1 : 0}

--- a/packages/core/src/MultiSelector/XDSMultiSelector.tsx
+++ b/packages/core/src/MultiSelector/XDSMultiSelector.tsx
@@ -66,6 +66,7 @@ import {
 import {useMultiCombobox} from './hooks';
 import {mergeProps} from '../utils';
 import type {XDSBaseProps} from '../XDSBaseProps';
+import type {SizeValue} from '../utils/types';
 import {useXDSSize} from '../SizeContext/XDSSizeContext';
 import {xdsThemeProps} from '../utils/xdsThemeProps';
 
@@ -441,6 +442,12 @@ export interface XDSMultiSelectorProps<
   status?: XDSMultiSelectorStatus;
 
   /**
+   * Width of the field. Numbers are treated as pixels, strings are used as-is
+   * (e.g. `'100%'`). Sizes the whole field (label, control, and status) so they
+   * stay aligned, unlike setting width via `xstyle`/`className`/`style`.
+   */
+  width?: SizeValue;
+  /**
    * Tooltip text to display in an info icon at the end of the label.
    */
   labelTooltip?: string;
@@ -558,6 +565,7 @@ export function XDSMultiSelector<T extends XDSMultiSelectorOptionType>({
   renderOption,
   isDefaultOpen = false,
   'data-testid': testId,
+  width,
   xstyle,
   className,
   style,
@@ -1107,7 +1115,8 @@ export function XDSMultiSelector<T extends XDSMultiSelectorOptionType>({
             }
           : undefined
       }
-      labelTooltip={labelTooltip}>
+      labelTooltip={labelTooltip}
+      width={width}>
       <div
         ref={el => {
           popover.triggerRef(el);

--- a/packages/core/src/NumberInput/XDSNumberInput.tsx
+++ b/packages/core/src/NumberInput/XDSNumberInput.tsx
@@ -130,6 +130,7 @@ export type {
 } from '../Field';
 import {mergeProps, mergeRefs} from '../utils';
 import type {XDSBaseProps} from '../XDSBaseProps';
+import type {SizeValue} from '../utils/types';
 import {xdsThemeProps} from '../utils/xdsThemeProps';
 
 interface XDSNumberInputPropsBase extends Omit<
@@ -199,6 +200,12 @@ interface XDSNumberInputPropsBase extends Omit<
    * Placeholder text shown when the input is empty.
    */
   placeholder?: string;
+  /**
+   * Width of the field. Numbers are treated as pixels, strings are used as-is
+   * (e.g. `'100%'`). Sizes the whole field (label, control, and status) so they
+   * stay aligned, unlike setting width via `xstyle`/`className`/`style`.
+   */
+  width?: SizeValue;
   /**
    * Tooltip text to display in an info icon at the end of the label.
    */
@@ -360,6 +367,7 @@ export function XDSNumberInput({
   hasClear,
   onEnter,
   onKeyDown,
+  width,
   xstyle,
   className,
   style,
@@ -607,7 +615,8 @@ export function XDSNumberInput({
             }
           : undefined
       }
-      labelTooltip={labelTooltip}>
+      labelTooltip={labelTooltip}
+      width={width}>
       {inputWrapper}
     </XDSField>
   );

--- a/packages/core/src/RadioList/XDSRadioList.tsx
+++ b/packages/core/src/RadioList/XDSRadioList.tsx
@@ -23,6 +23,7 @@ import {XDSField} from '../Field/XDSField';
 import type {XDSInputStatus} from '../Field/types';
 import {mergeProps} from '../utils';
 import type {XDSBaseProps} from '../XDSBaseProps';
+import type {SizeValue} from '../utils/types';
 import {xdsThemeProps} from '../utils/xdsThemeProps';
 
 /**
@@ -117,6 +118,12 @@ export interface XDSRadioListProps extends Omit<
    */
   size?: XDSRadioListSize;
   /**
+   * Width of the field. Numbers are treated as pixels, strings are used as-is
+   * (e.g. `'100%'`). Sizes the whole field (label, control, and status) so they
+   * stay aligned, unlike setting width via `xstyle`/`className`/`style`.
+   */
+  width?: SizeValue;
+  /**
    * Tooltip text to display in an info icon at the end of the label.
    */
   labelTooltip?: string;
@@ -159,6 +166,7 @@ export function XDSRadioList({
   size = 'md',
   status,
   labelTooltip,
+  width,
   xstyle,
   className,
   style,
@@ -198,6 +206,7 @@ export function XDSRadioList({
       }
       labelTooltip={labelTooltip}
       statusVariant="detached"
+      width={width}
       xstyle={xstyle}
       className={className}
       style={style}>

--- a/packages/core/src/Selector/XDSSelector.tsx
+++ b/packages/core/src/Selector/XDSSelector.tsx
@@ -64,6 +64,7 @@ import {XDSSelectorOption} from './XDSSelectorOption';
 import {mergeProps} from '../utils';
 import {useXDSSize} from '../SizeContext/XDSSizeContext';
 import type {XDSBaseProps} from '../XDSBaseProps';
+import type {SizeValue} from '../utils/types';
 import {xdsThemeProps} from '../utils/xdsThemeProps';
 
 const styles = stylex.create({
@@ -405,6 +406,12 @@ interface XDSSelectorPropsBase<
   status?: XDSSelectorStatus;
 
   /**
+   * Width of the field. Numbers are treated as pixels, strings are used as-is
+   * (e.g. `'100%'`). Sizes the whole field (label, control, and status) so they
+   * stay aligned, unlike setting width via `xstyle`/`className`/`style`.
+   */
+  width?: SizeValue;
+  /**
    * Tooltip text to display in an info icon at the end of the label.
    */
   labelTooltip?: string;
@@ -539,6 +546,7 @@ export function XDSSelector<T extends XDSSelectorOptionType>(
     placement,
     isDefaultOpen = false,
     'data-testid': testId,
+    width,
     xstyle,
     className,
     style,
@@ -856,7 +864,8 @@ export function XDSSelector<T extends XDSSelectorOptionType>(
             }
           : undefined
       }
-      labelTooltip={labelTooltip}>
+      labelTooltip={labelTooltip}
+      width={width}>
       <div
         ref={el => {
           popover.triggerRef(el);

--- a/packages/core/src/Slider/XDSSlider.tsx
+++ b/packages/core/src/Slider/XDSSlider.tsx
@@ -40,6 +40,7 @@ import {XDSTooltip} from '../Tooltip/XDSTooltip';
 import type {XDSInputStatus} from '../Field/types';
 import {mergeProps, mergeRefs} from '../utils';
 import type {XDSBaseProps} from '../XDSBaseProps';
+import type {SizeValue} from '../utils/types';
 import {xdsThemeProps} from '../utils/xdsThemeProps';
 
 // =============================================================================
@@ -66,6 +67,12 @@ export interface XDSSliderBaseProps extends Omit<
   isRequired?: boolean;
   /** Status indicator for the slider. */
   status?: XDSInputStatus;
+  /**
+   * Width of the field. Numbers are treated as pixels, strings are used as-is
+   * (e.g. `'100%'`). Sizes the whole field (label, control, and status) so they
+   * stay aligned, unlike setting width via `xstyle`/`className`/`style`.
+   */
+  width?: SizeValue;
   /** Tooltip text to display in an info icon at the end of the label. */
   labelTooltip?: string;
   /** Minimum value. @default 0 */
@@ -335,6 +342,7 @@ export function XDSSlider({ref, ...props}: XDSSliderProps) {
     formatValue,
     valueDisplay = 'tooltip',
     marks,
+    width,
     xstyle,
     className,
     style,
@@ -737,6 +745,7 @@ export function XDSSlider({ref, ...props}: XDSSliderProps) {
       }
       labelTooltip={labelTooltip}
       statusVariant="detached"
+      width={width}
       xstyle={xstyle}
       className={className}
       style={style}>

--- a/packages/core/src/Switch/XDSSwitch.tsx
+++ b/packages/core/src/Switch/XDSSwitch.tsx
@@ -42,6 +42,7 @@ import {XDSSpinner} from '../Spinner';
 import {mergeProps} from '../utils';
 import {switchScope} from './switch.markers.stylex';
 import type {XDSBaseProps} from '../XDSBaseProps';
+import type {SizeValue} from '../utils/types';
 import {xdsThemeProps} from '../utils/xdsThemeProps';
 
 // Fixed dimensions: 40px width, 24px height, 16px thumb (off), 20px thumb (on)
@@ -259,6 +260,12 @@ export interface XDSSwitchProps extends Omit<XDSBaseProps, 'onChange'> {
    */
   labelIcon?: ReactNode | XDSIconType;
   /**
+   * Width of the field. Numbers are treated as pixels, strings are used as-is
+   * (e.g. `'100%'`). Sizes the whole field (label, control, and status) so they
+   * stay aligned, unlike setting width via `xstyle`/`className`/`style`.
+   */
+  width?: SizeValue;
+  /**
    * Tooltip text to display in an info icon at the end of the label.
    */
   labelTooltip?: string;
@@ -282,6 +289,11 @@ export interface XDSSwitchProps extends Omit<XDSBaseProps, 'onChange'> {
    */
   status?: XDSInputStatus;
 }
+
+// Dynamic field width (number -> px, string used as-is).
+const dynamicWidthStyles = stylex.create({
+  width: (width: SizeValue | null) => ({width}),
+});
 
 /**
  * A toggle switch component for boolean values.
@@ -319,6 +331,7 @@ export function XDSSwitch({
   labelPosition = 'end',
   labelSpacing = 'default',
   status,
+  width,
   xstyle,
   className,
   style,
@@ -435,7 +448,7 @@ export function XDSSwitch({
           labelPosition: labelPosition !== 'end' ? labelPosition : undefined,
           labelSpacing: labelSpacing !== 'default' ? labelSpacing : undefined,
         }),
-        stylex.props(xstyle),
+        stylex.props(width != null && dynamicWidthStyles.width(width), xstyle),
         className,
         style,
       )}>

--- a/packages/core/src/TextArea/XDSTextArea.tsx
+++ b/packages/core/src/TextArea/XDSTextArea.tsx
@@ -45,6 +45,7 @@ import {XDSIcon, renderIconSlot, type XDSIconType} from '../Icon';
 import {XDSSpinner} from '../Spinner';
 import {mergeProps, mergeRefs} from '../utils';
 import type {XDSBaseProps} from '../XDSBaseProps';
+import type {SizeValue} from '../utils/types';
 import {useInputContainer} from '../hooks/useInputContainer';
 import {useXDSSize} from '../SizeContext/XDSSizeContext';
 import {xdsThemeProps} from '../utils/xdsThemeProps';
@@ -205,6 +206,12 @@ export interface XDSTextAreaProps extends Omit<
    */
   status?: XDSTextAreaStatus;
   /**
+   * Width of the field. Numbers are treated as pixels, strings are used as-is
+   * (e.g. `'100%'`). Sizes the whole field (label, control, and status) so they
+   * stay aligned, unlike setting width via `xstyle`/`className`/`style`.
+   */
+  width?: SizeValue;
+  /**
    * Tooltip text to display in an info icon at the end of the label.
    */
   labelTooltip?: string;
@@ -288,6 +295,7 @@ export function XDSTextArea({
   htmlName,
   onFocus,
   onBlur,
+  width,
   xstyle,
   className,
   style,
@@ -370,7 +378,8 @@ export function XDSTextArea({
             }
           : undefined
       }
-      labelTooltip={labelTooltip}>
+      labelTooltip={labelTooltip}
+      width={width}>
       <div
         ref={containerRef}
         onClick={handleWrapperClick}

--- a/packages/core/src/TextInput/XDSTextInput.test.tsx
+++ b/packages/core/src/TextInput/XDSTextInput.test.tsx
@@ -499,4 +499,29 @@ describe('XDSTextInput', () => {
       expect(input).toHaveFocus();
     });
   });
+
+  describe('width prop (#2755)', () => {
+    it('sizes the outer field, not just the input wrapper', () => {
+      render(
+        <XDSTextInput label="Name" value="" onChange={() => {}} width="100%" />,
+      );
+      const input = screen.getByRole('textbox');
+      const inputWrapper = input.parentElement!;
+      // Field root is the labelled ancestor that owns the width.
+      const fieldRoot = input.closest('.xds-field') as HTMLElement;
+      expect(fieldRoot).toBeTruthy();
+      expect(fieldRoot.getAttribute('style')).toContain('100%');
+      // The inner control wrapper is not the element carrying the width.
+      expect(fieldRoot).not.toBe(inputWrapper);
+      expect(inputWrapper.getAttribute('style') ?? '').not.toContain('100%');
+    });
+
+    it('does not set width when the prop is omitted', () => {
+      render(<XDSTextInput label="Name" value="" onChange={() => {}} />);
+      const fieldRoot = screen
+        .getByRole('textbox')
+        .closest('.xds-field') as HTMLElement;
+      expect(fieldRoot.getAttribute('style') ?? '').not.toContain('100%');
+    });
+  });
 });

--- a/packages/core/src/TextInput/XDSTextInput.tsx
+++ b/packages/core/src/TextInput/XDSTextInput.tsx
@@ -118,6 +118,7 @@ import {useXDSSize} from '../SizeContext/XDSSizeContext';
 import {useInputContainer} from '../hooks/useInputContainer';
 import {useXDSInputGroup} from '../InputGroup/XDSInputGroupContext';
 import type {XDSBaseProps} from '../XDSBaseProps';
+import type {SizeValue} from '../utils/types';
 import {xdsThemeProps} from '../utils/xdsThemeProps';
 
 export type XDSTextInputType = 'text' | 'password' | 'email';
@@ -199,6 +200,12 @@ export interface XDSTextInputProps extends Omit<
    */
   placeholder?: string;
   /**
+   * Width of the field. Numbers are treated as pixels, strings are used as-is
+   * (e.g. `'100%'`). Sizes the whole field (label, control, and status) so they
+   * stay aligned, unlike setting width via `xstyle`/`className`/`style`.
+   */
+  width?: SizeValue;
+  /**
    * Tooltip text to display in an info icon at the end of the label.
    */
   labelTooltip?: string;
@@ -259,6 +266,7 @@ export function XDSTextInput({
   htmlName,
   onEnter,
   onKeyDown,
+  width,
   xstyle,
   className,
   style,
@@ -419,7 +427,8 @@ export function XDSTextInput({
             }
           : undefined
       }
-      labelTooltip={labelTooltip}>
+      labelTooltip={labelTooltip}
+      width={width}>
       {inputWrapper}
     </XDSField>
   );

--- a/packages/core/src/TimeInput/XDSTimeInput.tsx
+++ b/packages/core/src/TimeInput/XDSTimeInput.tsx
@@ -60,6 +60,7 @@ import {
   mergeRefs,
 } from '../utils';
 import type {XDSBaseProps} from '../XDSBaseProps';
+import type {SizeValue} from '../utils/types';
 import {useXDSSize} from '../SizeContext/XDSSizeContext';
 import {useInputContainer} from '../hooks/useInputContainer';
 import {xdsThemeProps} from '../utils/xdsThemeProps';
@@ -268,6 +269,12 @@ export interface XDSTimeInputProps extends Omit<
   status?: XDSInputStatus;
 
   /**
+   * Width of the field. Numbers are treated as pixels, strings are used as-is
+   * (e.g. `'100%'`). Sizes the whole field (label, control, and status) so they
+   * stay aligned, unlike setting width via `xstyle`/`className`/`style`.
+   */
+  width?: SizeValue;
+  /**
    * Tooltip text to display in an info icon at the end of the label.
    */
   labelTooltip?: string;
@@ -309,6 +316,7 @@ export function XDSTimeInput({
   size: sizeProp,
   status,
   labelTooltip,
+  width,
   xstyle,
   className,
   style,
@@ -520,7 +528,8 @@ export function XDSTimeInput({
             }
           : undefined
       }
-      labelTooltip={labelTooltip}>
+      labelTooltip={labelTooltip}
+      width={width}>
       <div
         ref={containerRef}
         onClick={handleWrapperClick}

--- a/packages/core/src/Tokenizer/XDSTokenizer.tsx
+++ b/packages/core/src/Tokenizer/XDSTokenizer.tsx
@@ -26,6 +26,7 @@ import React, {
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {XDSBaseProps} from '../XDSBaseProps';
+import type {SizeValue} from '../utils/types';
 import {XDSBaseTypeahead} from '../Typeahead/XDSBaseTypeahead';
 import {useXDSSize} from '../SizeContext/XDSSizeContext';
 import {
@@ -114,6 +115,12 @@ export interface XDSTokenizerProps<T extends XDSSearchableItem> extends Omit<
    * Accepts a ReactNode (e.g. `<XDSIcon icon={SearchIcon} />`) or an SVG icon component directly.
    */
   startIcon?: ReactNode | XDSIconType;
+  /**
+   * Width of the field. Numbers are treated as pixels, strings are used as-is
+   * (e.g. `'100%'`). Sizes the whole field (label, control, and status) so they
+   * stay aligned, unlike setting width via `xstyle`/`className`/`style`.
+   */
+  width?: SizeValue;
   /** Label tooltip. */
   labelTooltip?: string;
   /** Search source providing items. */
@@ -365,6 +372,7 @@ export function XDSTokenizer<T extends XDSSearchableItem>({
   onChangeQuery,
   onFocus,
   onBlur,
+  width,
   xstyle,
   className,
   style,
@@ -815,6 +823,7 @@ export function XDSTokenizer<T extends XDSSearchableItem>({
           : undefined
       }
       labelTooltip={labelTooltip}
+      width={width}
       xstyle={xstyle}
       className={className}
       style={style}>

--- a/packages/core/src/Typeahead/XDSTypeahead.tsx
+++ b/packages/core/src/Typeahead/XDSTypeahead.tsx
@@ -42,6 +42,7 @@ import {renderIconSlot, type XDSIconType} from '../Icon';
 import {spacingVars, sizeVars} from '../theme/tokens.stylex';
 import {mergeProps} from '../utils';
 import type {XDSBaseProps} from '../XDSBaseProps';
+import type {SizeValue} from '../utils/types';
 import type {XDSSearchableItem, XDSSearchSource} from './types';
 import {xdsThemeProps} from '../utils/xdsThemeProps';
 
@@ -74,6 +75,12 @@ export interface XDSTypeaheadProps<T extends XDSSearchableItem> extends Omit<
    * Accepts a ReactNode (e.g. `<XDSIcon icon={SearchIcon} />`) or an SVG icon component directly.
    */
   startIcon?: ReactNode | XDSIconType;
+  /**
+   * Width of the field. Numbers are treated as pixels, strings are used as-is
+   * (e.g. `'100%'`). Sizes the whole field (label, control, and status) so they
+   * stay aligned, unlike setting width via `xstyle`/`className`/`style`.
+   */
+  width?: SizeValue;
   /** Label tooltip. */
   labelTooltip?: string;
   /** Search source providing items. */
@@ -208,6 +215,7 @@ export function XDSTypeahead<T extends XDSSearchableItem>({
   debounceMs,
   onChangeQuery,
   onOpenChange,
+  width,
   xstyle,
   className,
   style,
@@ -358,6 +366,7 @@ export function XDSTypeahead<T extends XDSSearchableItem>({
           : undefined
       }
       labelTooltip={labelTooltip}
+      width={width}
       xstyle={xstyle}
       className={className}
       style={style}>


### PR DESCRIPTION
## Summary

Fixes #2755. Field-based inputs had no predictable way to size the whole field: setting `width="100%"` via `xstyle`/`className`/`style` only stretched the **inner control box**, leaving the label and status message at their natural width.

## Approach (revised after design review)

Rather than redirect open styling (`xstyle`/`className`/`style`) to the field container — which would be a silent breaking change and conflate three different styling channels — this adds a **typed `width?: SizeValue` prop**, matching the existing XDS convention for sizing layout components (`XDSCard`, `XDSStack`, `XDSGrid`, `XDSSection`, `XDSDialog`, `XDSPopover`).

- `width` is applied to the **outer `XDSField`** container, so the whole field (label + control + status) sizes together and stays aligned.
- Numbers are treated as pixels; strings (e.g. `'100%'`) are used as-is.
- `xstyle`/`className`/`style` **keep targeting the inner control box exactly as before** → fully backward compatible, no migration needed.

```tsx
<XDSTextInput label="Email" width="100%" />   // full-width field, label + status aligned
<XDSTextInput label="Zip"   width={120} />     // fixed 120px field
```

### Why a `width` prop and not open-style forwarding

- **No breaking change.** Redirecting `xstyle`/`className`/`style` to the field would silently move every existing border/background/padding override from the control box to the whole field. We can't grep consumers in a public DS.
- **Cross-library consistency.** `xstyle` (StyleX), `className` (Tailwind/CSS) and `style` (inline) are distinct channels; forwarding all three to the field would, e.g., make `className="border-2"` border the label too. Sizing deserves its own typed prop.
- **No desync footgun.** The inner control box is a flex child with no width of its own, so it already stretches to the field's content width. Sizing the field is the *only* place that can't desync; the old behavior (sizing the inner box) is exactly what left the label/status behind.

## Scope — consistent across all field-based components

`width` is added to `XDSField` and forwarded by: `XDSTextInput`, `XDSTextArea`, `XDSNumberInput`, `XDSDateInput`, `XDSDateRangeInput`, `XDSDateTimeInput`, `XDSTimeInput`, `XDSFileInput`, `XDSSelector`, `XDSMultiSelector`, `XDSTypeahead`, `XDSTokenizer`, `XDSSlider`, `XDSCheckboxList`, `XDSRadioList`. `XDSCheckboxInput` and `XDSSwitch` (which compose their own layout rather than `XDSField`) apply `width` to their root for the same API.

> In horizontal-labels form layout the field is `display:contents` and the parent grid owns width, so `width` is intentionally a no-op there.

## Tests

- `XDSField.test.tsx`: `width` (string + numeric) lands on the field root, never the inner control, and is absent when unset.
- `XDSTextInput.test.tsx`: end-to-end — `width` sizes the field root, not the input wrapper.
- All 18 affected suites pass locally (577 tests).
- `pnpm -F @xds/core build` (Babel + `tsc` typecheck + CSS) — clean.

Changeset: `minor`, additive/non-breaking.

Closes #2755.
