### PR TITLE
fix(core): add bare DateRange/DateRangePreset aliases to DateRangeInput

### DIFF
--- a/packages/core/src/DateRangeInput/index.ts
+++ b/packages/core/src/DateRangeInput/index.ts
@@ -33,5 +33,7 @@ export type {
   XDSDateRangeInputSize as DateRangeInputSize,
   XDSDateRangeInputStatus as DateRangeInputStatus,
   XDSDateRangeInputStatusType as DateRangeInputStatusType,
+  XDSDateRange as DateRange,
+  XDSDateRangePreset as DateRangePreset,
 } from '.';
 // <compat-aliases:end>


### PR DESCRIPTION
Fixes the import-path inconsistency the vibe-test surfaced: agents importing from `@xds/core/DateRangeInput` couldn't find bare `DateRange` (only `XDSDateRange` was there). The generator correctly skipped it (global collision pre-pass), but at the subpath level it's needed for ergonomics. Manually added.