### PR TITLE
fix(vibe-tests): map astryx target to xds tsconfig for type checking

### DIFF
--- a/internal/vibe-tests/src/build-previews.ts
+++ b/internal/vibe-tests/src/build-previews.ts
@@ -538,6 +538,7 @@ function getTsconfigForTarget(target: string): string {
   switch (target) {
     case 'xds':
     case 'xds-tailwind':
+    case 'astryx':
       return path.join(VIBE_DIR, 'tsconfig.xds.json');
     case 'baseline':
       return path.join(VIBE_DIR, 'tsconfig.baseline.json');

--- a/packages/core/src/DateRangeInput/index.ts
+++ b/packages/core/src/DateRangeInput/index.ts
@@ -33,5 +33,7 @@ export type {
   XDSDateRangeInputSize as DateRangeInputSize,
   XDSDateRangeInputStatus as DateRangeInputStatus,
   XDSDateRangeInputStatusType as DateRangeInputStatusType,
+  XDSDateRange as DateRange,
+  XDSDateRangePreset as DateRangePreset,
 } from '.';
 // <compat-aliases:end>


### PR DESCRIPTION
One-line fix: add `'astryx'` to the tsconfig target switch so the astryx vibe-test results typecheck against `@xds/core` types (same as the xds target). Without this, astryx falls through to the HTML tsconfig which has no core path mappings.