### PR TITLE
docs(dense): fix bestPractices count parity for Text

### DIFF
--- a/packages/core/src/Text/Text.doc.mjs
+++ b/packages/core/src/Text/Text.doc.mjs
@@ -165,6 +165,7 @@ export const docsDense = {
       { guidance: false, description: 'Skip heading levels \u2014 sequential h1 \u2192 h2 \u2192 h3.' },
       { guidance: false, description: 'Raw <p>/<h1>/<span> \u2014 use XDSText/XDSHeading for theme tokens.' },
       { guidance: false, description: '`variant` prop \u2014 does not exist. Use `type` for text styling or XDSHeading for headings.' },
+      { guidance: false, description: 'XDSText for headings: use XDSHeading with level (1\u20136).' },
     ],
   },
 };


### PR DESCRIPTION
## What

Text had 9 English bestPractices but only 8 dense entries. The 9th entry ("Use XDSText for headings: use XDSHeading with level 1-6") was missing from the dense overlay, causing a silent fallback to English for that bullet.

## Checklist
- [x] `pnpm --filter @xds/core typecheck:docs` passes
- [x] `npx tsc --project packages/cli/tsconfig.template-docs.json --noEmit` passes
- [x] CLI `--lang dense` output verified (no duplicate markers, consistent caps)

---
*Night Watch: Doc Reviewer*