### PR TITLE
fix(cli): correct Breadcrumbs and Theme docs from vibe test 2026-06-18

### DIFF
--- a/packages/core/src/Breadcrumbs/Breadcrumbs.doc.mjs
+++ b/packages/core/src/Breadcrumbs/Breadcrumbs.doc.mjs
@@ -86,6 +86,7 @@ export const docs = {
   components: [
     {
       name: 'XDSBreadcrumbItem',
+      displayName: 'Breadcrumb Item',
       description: 'Individual breadcrumb item. Renders as a link when href is provided, or as plain text for the current page.',
       props: [
         {

--- a/packages/core/src/Breadcrumbs/Breadcrumbs.doc.mjs
+++ b/packages/core/src/Breadcrumbs/Breadcrumbs.doc.mjs
@@ -84,7 +84,44 @@ export const docs = {
     },
   ],
   components: [
-    {name: 'XDSBreadcrumbItem'},
+    {
+      name: 'XDSBreadcrumbItem',
+      description: 'Individual breadcrumb item. Renders as a link when href is provided, or as plain text for the current page.',
+      props: [
+        {
+          name: 'children',
+          type: 'ReactNode',
+          description: 'Label content for the breadcrumb item.',
+          required: true,
+        },
+        {
+          name: 'href',
+          type: 'string',
+          description: 'URL the breadcrumb links to; omit for non-navigable items.',
+        },
+        {
+          name: 'onClick',
+          type: '(e: MouseEvent) => void',
+          description: 'Click handler for the breadcrumb item.',
+        },
+        {
+          name: 'isCurrent',
+          type: 'boolean',
+          description: 'Marks this item as the current page, applying aria-current="page".',
+          default: 'false',
+        },
+        {
+          name: 'startIcon',
+          type: 'ReactNode',
+          description: 'Icon rendered before the item label.',
+        },
+        {
+          name: 'as',
+          type: 'XDSLinkComponentType',
+          description: 'Custom link component to render instead of <a>. Overrides the provider-level default from XDSLinkProvider. Only applies to non-current items.',
+        },
+      ],
+    },
   ],
 };
 

--- a/packages/core/src/theme/XDSTheme.doc.mjs
+++ b/packages/core/src/theme/XDSTheme.doc.mjs
@@ -39,7 +39,7 @@ export const docs = {
   },
   usage: {
     description:
-      'Wraps a subtree with a specific XDS theme. For static production themes, use `npx xds theme build` and import the generated CSS plus built theme object for first-paint and SSR performance. Use runtime `defineTheme()` when themes are dynamic or for prototyping.',
+      'Wraps a subtree with a specific XDS theme. For static production themes, use `npx xds theme build` and import the generated CSS plus built theme object for first-paint and SSR performance. Use runtime `defineTheme()` when themes are dynamic or for prototyping.\n\n`defineTheme` accepts a `tokens` object whose keys are CSS custom property names (always prefixed with `--`). Common token names include `--color-accent`, `--color-background-surface`, `--color-background-body`, `--color-text-primary`, `--color-text-secondary`, `--radius-container`, `--spacing-1` through `--spacing-6`. Values can be a string (same for light/dark) or a `[light, dark]` tuple.\n\nExample:\n```ts\nimport {defineTheme} from \'@xds/core/theme\';\nconst myTheme = defineTheme({\n  name: \'ocean\',\n  tokens: {\n    \'--color-accent\': [\'#0077B6\', \'#48CAE4\'],\n    \'--color-background-surface\': [\'#F0F8FF\', \'#0A1628\'],\n    \'--color-text-primary\': [\'#0A1317\', \'#FFFFFF\'],\n    \'--radius-container\': \'16px\',\n  },\n});\n```',
     bestPractices: [
       {
         guidance: true,
@@ -50,6 +50,11 @@ export const docs = {
         guidance: true,
         description:
           'Use runtime themes when the theme is created or edited in the browser, such as theme editors, user branding, or prototypes.',
+      },
+      {
+        guidance: true,
+        description:
+          'Token names always start with `--` (e.g. `--color-accent`, `--color-background-surface`). Do not omit the prefix.',
       },
       {
         guidance: false,
@@ -85,7 +90,7 @@ export const docs = {
 export const docsDense = {
   usage: {
     description:
-      'Wraps subtree w/ specific XDS theme. For static production themes, use `npx xds theme build` + generated CSS + built theme object for first-paint/SSR performance. Use runtime `defineTheme()` for dynamic themes or prototyping.',
+      'Wraps subtree w/ specific XDS theme. For static production themes, use `npx xds theme build` + generated CSS + built theme object for first-paint/SSR performance. Use runtime `defineTheme()` for dynamic themes or prototyping. Token names always start with `--` (e.g. `--color-accent`, `--color-background-surface`).',
     bestPractices: [
       {
         guidance: true,
@@ -96,6 +101,11 @@ export const docsDense = {
         guidance: true,
         description:
           'Use runtime themes when theme is created/edited in browser, e.g. theme editor, user branding, prototype.',
+      },
+      {
+        guidance: true,
+        description:
+          'Token names always start with `--` (e.g. `--color-accent`, `--color-background-surface`). Do not omit the prefix.',
       },
       {
         guidance: false,


### PR DESCRIPTION
## What

Fixes CLI documentation issues identified by the nightly vibe test.

## Why

The vibe test nightly (issue #2913) showed agents making errors because CLI output was misleading:

1. **XDSBreadcrumbItem** — `npx xds component Breadcrumbs` rendered the sub-component section as "undefined" with no props table. Agents guessed `label` and `href` as props instead of using `children` (the correct required prop).
2. **defineTheme tokens** — The Theme doc had no example showing valid token names. Agents used `'color-background'` instead of the required `'--color-background-surface'` format (CSS custom property names with `--` prefix).

## Changes

- **`packages/core/src/Breadcrumbs/Breadcrumbs.doc.mjs`**: Inlined XDSBreadcrumbItem description and props in the `components` array so the CLI output correctly shows `children` (required), `href`, `isCurrent`, `startIcon`, `onClick`, and `as` props.
- **`packages/core/src/theme/XDSTheme.doc.mjs`**: Added `defineTheme` usage example with valid token names (`--color-accent`, `--color-background-surface`, etc.) and a best practice noting the `--` prefix requirement.

## Verification

- [x] `pnpm xds component Breadcrumbs` now shows XDSBreadcrumbItem with full props table
- [x] `pnpm xds component Theme` now shows defineTheme example with correct token format
- [x] TypeScript types match documentation
- [x] Repo sync check passes

Vibe Test Debugger