### PR TITLE
fix(cli): correct theme import path in init next-steps

### DIFF
--- a/packages/cli/src/commands/init.mjs
+++ b/packages/cli/src/commands/init.mjs
@@ -246,7 +246,7 @@ export function registerInit(program) {
       humanLog('  Next steps:');
       humanLog("    1. Import components: import { XDSButton } from '@xds/core'");
       humanLog('    2. Optionally add a theme:');
-      humanLog("       import { defaultTheme } from '@xds/theme/default'");
+      humanLog("       import { defaultTheme } from '@xds/theme-default'");
       humanLog('       <XDSTheme theme={defaultTheme}>...</XDSTheme>');
       humanLog(`    3. ${run} xds --help for all commands`);
       humanLog('');


### PR DESCRIPTION
## Problem

The `xds init` command's "Next steps" output instructs users to import the default theme from `@xds/theme/default` (slash):

```
2. Optionally add a theme:
   import { defaultTheme } from '@xds/theme/default'
   <XDSTheme theme={defaultTheme}>...</XDSTheme>
```

But the published package is **`@xds/theme-default`** (hyphen). The slash form does not resolve to a real package, so anyone copy-pasting the suggested import hits a module-not-found error on their very first theming step.

## Fix

One-line change in `packages/cli/src/commands/init.mjs` — use the hyphenated package name.

This aligns with **every other** theme-import reference across the CLI:
- `docs/theme.doc.mjs`, `docs/migration.doc.mjs`, `docs/styling*.doc.mjs`, `docs/getting-started.doc.mjs` — all use `@xds/theme-default`
- `.claude/commands/create-theme.md` (authoritative theming doc) uses `@xds/theme-default`
- the example apps (`apps/example-nextjs/*`) import `from '@xds/theme-default'` / `'@xds/theme-default/built'`

`init.mjs` was the lone outlier with the broken slash form.

## How it was found

Surfaced during the XDS un-prefix migration vibe-test battery: multiple independent AI agents following the docs tripped on `@xds/theme-default` path resolution. Investigation traced one genuine user-facing instance to the CLI init output (the other slash references are inside the vibe-tests harness, which self-consistently aliases the slash form to source in its own tsconfig + vite config — those are intentional and out of scope here).

## Test plan

- No test asserts on this exact string, so no test changes required.
- Verified the corrected import (`@xds/theme-default` → `defaultTheme`) matches the package's `.` export (`packages/themes/default/src/source.ts` exports `defaultTheme`).