### PR TITLE
fix(cli): make template --skeleton extractors prefix-agnostic

### DIFF
--- a/packages/cli/src/api/template.mjs
+++ b/packages/cli/src/api/template.mjs
@@ -247,9 +247,19 @@ const UBIQUITOUS = new Set([
 
 function extractComponents(pagePath) {
   const src = fs.readFileSync(pagePath, 'utf-8');
+  // Match JSX opening tags, e.g. `<Section` or the legacy `<XDSSection`.
+  // Templates author bare component names post un-prefix migration
+  // (P2380608025), so the `XDS` prefix is optional. Anchoring on the `<`
+  // JSX-tag boundary keeps this precise (avoids matching imports/comments/
+  // identifiers) while remaining prefix-agnostic.
+  const tagRegex = /<(XDS)?([A-Z]\w+)/g;
+  const matches = [];
+  let m;
+  while ((m = tagRegex.exec(src)) !== null) {
+    matches.push(m[2]);
+  }
   return [...new Set(
-    (src.match(/XDS[A-Z]\w+/g) || [])
-      .map(n => n.replace(/^XDS/, ''))
+    matches
       .filter(n => !['Theme', 'ThemeProvider'].includes(n))
       .filter(n => !UBIQUITOUS.has(n))
       .map(n => n.replace(/(Item|Section|Header|Content|Footer|Panel|Heading|CollapseButton|Column|Sortable|Selection|Group|Source)$/, ''))
@@ -284,9 +294,14 @@ function extractSkeleton(source) {
       continue;
     }
 
-    const openMatch = t.match(/^<(XDS\w+)/);
+    // Match a JSX opening tag, e.g. `<Section` or the legacy `<XDSSection`.
+    // The `XDS` prefix is optional (templates author bare names post
+    // un-prefix migration P2380608025). `tagName` is the full authored name
+    // (used for the self-closing lookahead); `comp` is the bare display name.
+    const openMatch = t.match(/^<((XDS)?([A-Z]\w+))/);
     if (openMatch && !t.startsWith('</')) {
-      const comp = openMatch[1].replace(/^XDS/, '');
+      const tagName = openMatch[1];
+      const comp = openMatch[3];
       let tagText = '';
       for (let j = i; j < Math.min(i + 12, lines.length); j++) {
         tagText += ' ' + lines[j];
@@ -306,7 +321,7 @@ function extractSkeleton(source) {
       const hasSpatialProps = props.length > 0;
       const propStr = hasSpatialProps ? ' ' + props.join(' ') : '';
       const isVStack = comp === 'VStack' || comp === 'HStack';
-      const isSelfClosing = tagText.match(new RegExp('<' + openMatch[1] + '[^>]*/>', 's'));
+      const isSelfClosing = tagText.match(new RegExp('<' + tagName + '[^>]*/>', 's'));
 
       if (isVStack && !hasSpatialProps) continue;
 
@@ -322,9 +337,9 @@ function extractSkeleton(source) {
       continue;
     }
 
-    const closeMatch = t.match(/^<\/(XDS\w+)>/);
+    const closeMatch = t.match(/^<\/(XDS)?([A-Z]\w+)>/);
     if (closeMatch) {
-      const comp = closeMatch[1].replace(/^XDS/, '');
+      const comp = closeMatch[2];
       if (depthStack.length > 0 && depthStack[depthStack.length - 1] === comp) {
         depthStack.pop();
         depth = Math.max(0, depth - 1);

--- a/packages/cli/src/api/template.test.mjs
+++ b/packages/cli/src/api/template.test.mjs
@@ -1,7 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 import {describe, it, expect} from 'vitest';
-import {stripTemplateAssetRefs} from './template.mjs';
+import {stripTemplateAssetRefs, template} from './template.mjs';
 
 describe('stripTemplateAssetRefs', () => {
   it('replaces a lookaside xds_oss image URL with an inline data URI', () => {
@@ -52,5 +52,27 @@ describe('stripTemplateAssetRefs', () => {
     const src = "import x from './local.png'; const y = '/public/logo.svg';";
     const out = stripTemplateAssetRefs(src);
     expect(out).toBe(src);
+  });
+});
+
+describe('template --skeleton component extraction (prefix-agnostic)', () => {
+  // Regression guard: templates author bare component names post un-prefix
+  // migration (P2380608025). The extractors previously matched only the
+  // `XDS`-prefixed form, so `--skeleton` returned an empty components list and
+  // an empty skeleton body for bare templates.
+  it('extracts components and a skeleton from a bare-named template', async () => {
+    const result = await template('contact-form', {skeleton: true});
+
+    expect(result.type).toBe('template.skeleton');
+    expect(Array.isArray(result.data.components)).toBe(true);
+    expect(result.data.components.length).toBeGreaterThan(0);
+    // The contact-form template composes a Card + form inputs.
+    expect(result.data.components).toContain('Card');
+    expect(result.data.components).toContain('TextInput');
+
+    // Skeleton body is non-empty and uses bare component tags (no XDS prefix).
+    expect(result.data.skeleton.trim().length).toBeGreaterThan(0);
+    expect(result.data.skeleton).toMatch(/<[A-Z]\w+/);
+    expect(result.data.skeleton).not.toContain('<XDS');
   });
 });


### PR DESCRIPTION
## Problem

The un-prefix migration (P5b, #2898) rewrote all 600+ CLI page/block templates to use **bare** component names (`<Section>` instead of `<XDSSection>`). But the two extractors in `template.mjs` still matched only the `XDS`-prefixed form:

- `extractComponents`: `src.match(/XDS[A-Z]\w+/g)`
- `extractSkeleton`: `/^<(XDS\w+)/` and `/^<\/(XDS\w+)>/`

So on the integration branch, `xds template <name> --skeleton` returns an **empty** `# Components:` list and an **empty skeleton body** for every template. This is exactly what the vibe-test agents hit — multiple naive runs reported `contact-form --skeleton` came back empty and unhelpful, forcing them to dump the full template instead.

## Reproduction (before)

```
$ xds template contact-form --skeleton

# contact-form — Marketing lead-capture form...
# Components:        ← empty
                     ← no skeleton body
```

## Fix

Match JSX opening/closing tags with an **optional** `XDS` prefix. Anchoring on the `<` tag boundary also makes `extractComponents` *more precise* than before — it previously grepped every `XDS...` substring anywhere in the file (imports, comments, types); the tag anchor restricts to actual JSX usage. All existing filters (`UBIQUITOUS`, suffix-stripping, dedup) are unchanged.

## After

```
# Components: Banner, Card, Center, CheckboxInput, Divider, Grid, RadioList, Selector, TextArea, TextInput, Token

<Center>
  <VStack width="100%">
    <Section maxWidth={800} padding={6} variant="section">
      ...
```

## Test

Adds a regression test exercising the public `template()` API with `{skeleton: true}` against the bare-named `contact-form` template (asserts non-empty components list + bare-tag skeleton body). Full `template.test.mjs` suite green (7 tests).

## Out of scope

A pre-existing cosmetic issue — Grid `columns={{minWidth:240}}` renders as `columns="{minWidth:"` in the skeleton — is unrelated to the prefix (it stems from the `propRegex` and affects prefixed templates identically). Left for a separate fix.

## CI note

This targets `xds-unprefix-integration`; CI doesn't auto-run on integration-branch PRs. Validated locally: `template.test.mjs` 7/7 pass, and `contact-form --skeleton` verified by hand.