### PR TITLE
fix(cli): stop rendering 'undefined' for bare sub-component doc entries

### DIFF
--- a/packages/cli/src/lib/component-format.mjs
+++ b/packages/cli/src/lib/component-format.mjs
@@ -37,6 +37,30 @@ function formatPropsTable(props) {
 }
 
 /**
+ * Render a sub-component block (the `### Name` sections under "## Components").
+ *
+ * Sub-components are sometimes declared as a bare reference, e.g.
+ * `{name: 'XDSRadioListItem'}`, with their description/props documented in
+ * their own `.doc.mjs`. Without guarding, `comp.description` is `undefined`
+ * and was being printed literally as the string "undefined". Emit the
+ * description only when present, and when there are no inline props point the
+ * reader at the sub-component's own docs instead of a blank/`undefined` block.
+ */
+function formatSubComponent(comp) {
+  const out = [`### ${comp.name}\n`];
+  if (comp.description) {
+    out.push(comp.description + '\n');
+  }
+  const table = formatPropsTable(comp.props);
+  if (table) {
+    out.push(table + '\n');
+  } else {
+    out.push(`See \`xds component ${comp.name}\` for props and usage.\n`);
+  }
+  return out;
+}
+
+/**
  * Get the variant values for a given theming target, extracting them from
  * the visualProps and the variant prop in the component's props list.
  * Returns an array of variant strings from the `variant` prop type,
@@ -162,9 +186,7 @@ export function formatFull(docs, options = {}) {
   if ('components' in docs) {
     sections.push('## Components\n');
     for (const comp of docs.components) {
-      sections.push(`### ${comp.name}\n`);
-      sections.push(comp.description + '\n');
-      sections.push(formatPropsTable(comp.props) + '\n');
+      sections.push(...formatSubComponent(comp));
       if (comp.examples?.length) {
         for (const ex of comp.examples) {
           if (ex.label) sections.push(`#### ${ex.label}\n`);
@@ -317,9 +339,7 @@ export function formatCompact(docs, componentName, importHint) {
 
   if ('components' in docs) {
     for (const comp of docs.components) {
-      sections.push(`### ${comp.name}\n`);
-      sections.push(comp.description + '\n');
-      sections.push(formatPropsTable(comp.props) + '\n');
+      sections.push(...formatSubComponent(comp));
     }
   }
 

--- a/packages/cli/src/lib/component-format.test.mjs
+++ b/packages/cli/src/lib/component-format.test.mjs
@@ -1,0 +1,53 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {describe, it, expect} from 'vitest';
+import {formatFull} from './component-format.mjs';
+
+describe('formatFull sub-component rendering', () => {
+  // Regression guard: sub-components are sometimes declared as a bare
+  // reference, e.g. {name: 'XDSRadioListItem'}, with props/description in
+  // their own .doc.mjs. Previously `comp.description` was undefined and got
+  // printed as the literal string "undefined", and the props area was blank.
+  it('does not print "undefined" for a bare {name} sub-component', () => {
+    const docs = {
+      name: 'RadioList',
+      description: 'Radio group container.',
+      components: [{name: 'XDSRadioListItem'}],
+    };
+    const out = formatFull(docs);
+
+    expect(out).toContain('### XDSRadioListItem');
+    expect(out).not.toContain('undefined');
+    // Points the reader at the sub-component's own docs instead of a blank.
+    expect(out).toContain('xds component XDSRadioListItem');
+  });
+
+  it('renders a full props table for a sub-component that has inline props', () => {
+    const docs = {
+      name: 'ButtonGroup',
+      description: 'Groups buttons.',
+      components: [
+        {
+          name: 'XDSButtonGroup',
+          description: 'Connected button styling.',
+          props: [
+            {
+              name: 'label',
+              type: 'string',
+              description: 'Accessible label.',
+              required: true,
+            },
+          ],
+        },
+      ],
+    };
+    const out = formatFull(docs);
+
+    expect(out).toContain('### XDSButtonGroup');
+    expect(out).toContain('Connected button styling.');
+    expect(out).toContain('| `label` |');
+    expect(out).not.toContain('undefined');
+    // With real props, it should NOT emit the "see docs" pointer.
+    expect(out).not.toContain('xds component XDSButtonGroup');
+  });
+});


### PR DESCRIPTION
## Problem

In `xds component <Name>`, multi-component docs render each sub-component as a `### Name` block. Sub-components are frequently declared as a **bare reference** — e.g. `{name: 'XDSRadioListItem'}` — with their actual description/props documented in their own `.doc.mjs`. The formatter did:

```js
sections.push(comp.description + '\n');        // undefined + '\n' => the string "undefined"
sections.push(formatPropsTable(comp.props));   // '' (already handled)
```

So any bare sub-component rendered a literal **`undefined`** with no props:

```
### XDSRadioListItem
undefined
```

This affects **26 component docs** (Text→XDSHeading, RadioList→XDSRadioListItem, Table→XDSTableRow/Cell, SideNav, Dialog, Avatar, …) and was flagged by vibe-test agents who read the `Text` and `RadioList` docs and saw `XDSHeading`/`XDSRadioListItem` render as `undefined`.

## Fix

A small `formatSubComponent()` helper that:
- emits the description **only when present** (no more `undefined`), and
- when there are no inline props, points the reader at the sub-component's own docs (`See \`xds component <Name>\``) instead of a blank block.

Used at both `formatFull` multi-component render sites. Sub-components that **do** carry inline props/description (e.g. `XDSButtonGroup`) are unchanged — they still render the full description + props table.

## After

```
### XDSRadioListItem

See `xds component XDSRadioListItem` for props and usage.
```

## Test

New `component-format.test.mjs` covers both paths:
- bare `{name}` reference → pointer, no `undefined`
- sub-component with inline props → full table, no pointer

Full CLI lib + component test suites green (146 tests).