### PR TITLE
fix(core): remove redundant React HTMLAttributes popover augmentation

### DIFF
--- a/packages/core/src/Layer/useXDSLayer.tsx
+++ b/packages/core/src/Layer/useXDSLayer.tsx
@@ -25,14 +25,6 @@ import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import {typographyVars} from '../theme/tokens.stylex';
 
-// Extend React's HTMLAttributes to include popover API attributes
-declare module 'react' {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  interface HTMLAttributes<T> {
-    popover?: 'auto' | 'manual' | 'hint' | '';
-  }
-}
-
 const styles = stylex.create({
   // Base reset for all layers
   base: {


### PR DESCRIPTION
## What

Removes the `declare module 'react'` augmentation in `useXDSLayer.tsx` that added `popover` to `HTMLAttributes<T>`.

## Why

`@types/react@19.2.x` (currently pinned at `19.2.17`) already declares these on `HTMLAttributes<T>`:

```ts
popover?: "" | "auto" | "manual" | "hint" | undefined;
popoverTargetAction?: "toggle" | "show" | "hide" | undefined;
popoverTarget?: string | undefined;
```

The local augmentation added `popover?: 'auto' | 'manual' | 'hint' | ''` — the **same member with the same values**. Since TS merges identical interface members, this was a no-op. It was presumably needed on an older `@types/react` where the Popover API typings (notably the `hint` value) hadn't landed yet, and was never cleaned up after the version bump.

`popover` on the hook's internal layer element now resolves to the upstream definition.

## Verification

- `pnpm -F @xds/core typecheck` → clean (exit 0); the two `popover={lightDismiss ? 'auto' : 'manual'}` callsites still typecheck.
- `eslint` on the file → clean.
