### PR TITLE
refactor(core): unprefix the DateRange type export

### DIFF
--- a/apps/storybook/stories/DateRangeInput.stories.tsx
+++ b/apps/storybook/stories/DateRangeInput.stories.tsx
@@ -3,7 +3,7 @@
 import {useState} from 'react';
 import type {Meta, StoryObj} from '@storybook/react';
 import {XDSDateRangeInput} from '@xds/core/DateRangeInput';
-import type {XDSDateRange} from '@xds/core/DateRangeInput';
+import type {DateRange} from '@xds/core/DateRangeInput';
 import type {ISODateString} from '@xds/core/Calendar';
 
 function daysAgo(n: number): ISODateString {
@@ -73,7 +73,7 @@ type Story = StoryObj<typeof XDSDateRangeInput>;
 
 export const Default: Story = {
   render: args => {
-    const [value, setValue] = useState<XDSDateRange | null>(null);
+    const [value, setValue] = useState<DateRange | null>(null);
     return <XDSDateRangeInput {...args} value={value} onChange={setValue} />;
   },
   args: {
@@ -83,7 +83,7 @@ export const Default: Story = {
 
 export const WithValue: Story = {
   render: args => {
-    const [value, setValue] = useState<XDSDateRange | null>({
+    const [value, setValue] = useState<DateRange | null>({
       start: '2026-03-10' as ISODateString,
       end: '2026-03-20' as ISODateString,
     });
@@ -96,7 +96,7 @@ export const WithValue: Story = {
 
 export const WithPresets: Story = {
   render: args => {
-    const [value, setValue] = useState<XDSDateRange | null>(null);
+    const [value, setValue] = useState<DateRange | null>(null);
     return <XDSDateRangeInput {...args} value={value} onChange={setValue} />;
   },
   args: {
@@ -107,7 +107,7 @@ export const WithPresets: Story = {
 
 export const WithPresetsAndValue: Story = {
   render: args => {
-    const [value, setValue] = useState<XDSDateRange | null>({
+    const [value, setValue] = useState<DateRange | null>({
       start: daysAgo(7),
       end: today(),
     });
@@ -121,7 +121,7 @@ export const WithPresetsAndValue: Story = {
 
 export const WithDescription: Story = {
   render: args => {
-    const [value, setValue] = useState<XDSDateRange | null>(null);
+    const [value, setValue] = useState<DateRange | null>(null);
     return <XDSDateRangeInput {...args} value={value} onChange={setValue} />;
   },
   args: {
@@ -132,7 +132,7 @@ export const WithDescription: Story = {
 
 export const WithMinMax: Story = {
   render: args => {
-    const [value, setValue] = useState<XDSDateRange | null>(null);
+    const [value, setValue] = useState<DateRange | null>(null);
     return <XDSDateRangeInput {...args} value={value} onChange={setValue} />;
   },
   args: {
@@ -145,7 +145,7 @@ export const WithMinMax: Story = {
 
 export const Optional: Story = {
   render: args => {
-    const [value, setValue] = useState<XDSDateRange | null>(null);
+    const [value, setValue] = useState<DateRange | null>(null);
     return <XDSDateRangeInput {...args} value={value} onChange={setValue} />;
   },
   args: {
@@ -156,7 +156,7 @@ export const Optional: Story = {
 
 export const Required: Story = {
   render: args => {
-    const [value, setValue] = useState<XDSDateRange | null>(null);
+    const [value, setValue] = useState<DateRange | null>(null);
     return <XDSDateRangeInput {...args} value={value} onChange={setValue} />;
   },
   args: {
@@ -167,7 +167,7 @@ export const Required: Story = {
 
 export const Disabled: Story = {
   render: args => {
-    const [value, setValue] = useState<XDSDateRange | null>({
+    const [value, setValue] = useState<DateRange | null>({
       start: '2026-03-10' as ISODateString,
       end: '2026-03-20' as ISODateString,
     });
@@ -181,9 +181,9 @@ export const Disabled: Story = {
 
 export const SizeVariants: Story = {
   render: () => {
-    const [sm, setSm] = useState<XDSDateRange | null>(null);
-    const [md, setMd] = useState<XDSDateRange | null>(null);
-    const [lg, setLg] = useState<XDSDateRange | null>(null);
+    const [sm, setSm] = useState<DateRange | null>(null);
+    const [md, setMd] = useState<DateRange | null>(null);
+    const [lg, setLg] = useState<DateRange | null>(null);
     return (
       <div
         style={{
@@ -217,7 +217,7 @@ export const SizeVariants: Story = {
 
 export const SingleMonth: Story = {
   render: args => {
-    const [value, setValue] = useState<XDSDateRange | null>(null);
+    const [value, setValue] = useState<DateRange | null>(null);
     return <XDSDateRangeInput {...args} value={value} onChange={setValue} />;
   },
   args: {
@@ -228,7 +228,7 @@ export const SingleMonth: Story = {
 
 export const WithErrorStatus: Story = {
   render: args => {
-    const [value, setValue] = useState<XDSDateRange | null>(null);
+    const [value, setValue] = useState<DateRange | null>(null);
     return <XDSDateRangeInput {...args} value={value} onChange={setValue} />;
   },
   args: {
@@ -239,7 +239,7 @@ export const WithErrorStatus: Story = {
 
 export const WithWarningStatus: Story = {
   render: args => {
-    const [value, setValue] = useState<XDSDateRange | null>({
+    const [value, setValue] = useState<DateRange | null>({
       start: '2026-03-01' as ISODateString,
       end: '2026-06-30' as ISODateString,
     });
@@ -253,7 +253,7 @@ export const WithWarningStatus: Story = {
 
 export const NoClear: Story = {
   render: args => {
-    const [value, setValue] = useState<XDSDateRange | null>({
+    const [value, setValue] = useState<DateRange | null>({
       start: '2026-03-10' as ISODateString,
       end: '2026-03-20' as ISODateString,
     });
@@ -267,17 +267,17 @@ export const NoClear: Story = {
 
 export const AllVariations: Story = {
   render: () => {
-    const [v1, setV1] = useState<XDSDateRange | null>(null);
-    const [v2, setV2] = useState<XDSDateRange | null>({
+    const [v1, setV1] = useState<DateRange | null>(null);
+    const [v2, setV2] = useState<DateRange | null>({
       start: '2026-03-10' as ISODateString,
       end: '2026-03-20' as ISODateString,
     });
-    const [v3, setV3] = useState<XDSDateRange | null>(null);
-    const [v4, setV4] = useState<XDSDateRange | null>({
+    const [v3, setV3] = useState<DateRange | null>(null);
+    const [v4, setV4] = useState<DateRange | null>({
       start: '2026-03-10' as ISODateString,
       end: '2026-03-20' as ISODateString,
     });
-    const [v5, setV5] = useState<XDSDateRange | null>(null);
+    const [v5, setV5] = useState<DateRange | null>(null);
 
     return (
       <div

--- a/packages/cli/templates/blocks/components/DateRangeInput/DateRangeInputShowcase.tsx
+++ b/packages/cli/templates/blocks/components/DateRangeInput/DateRangeInputShowcase.tsx
@@ -4,7 +4,7 @@
 
 import {useState} from 'react';
 import {XDSDateRangeInput} from '@xds/core/DateRangeInput';
-import type {XDSDateRange} from '@xds/core/DateRangeInput';
+import type {DateRange} from '@xds/core/DateRangeInput';
 import type {ISODateString} from '@xds/core/Calendar';
 import {XDSStack} from '@xds/core/Layout';
 
@@ -24,7 +24,7 @@ const presets = [
 ];
 
 export default function DateRangeInputShowcase() {
-  const [range, setRange] = useState<XDSDateRange | null>(null);
+  const [range, setRange] = useState<DateRange | null>(null);
 
   return (
     <XDSStack direction="vertical" width="100%" style={{maxWidth: 400}}>

--- a/packages/core/src/DateRangeInput/XDSDateRangeInput.test.tsx
+++ b/packages/core/src/DateRangeInput/XDSDateRangeInput.test.tsx
@@ -12,7 +12,7 @@
 import {describe, it, expect, vi} from 'vitest';
 import {render, screen, fireEvent} from '@testing-library/react';
 import {XDSDateRangeInput} from './XDSDateRangeInput';
-import type {XDSDateRange} from './XDSDateRangeInput';
+import type {DateRange} from './XDSDateRangeInput';
 
 describe('XDSDateRangeInput', () => {
   it('renders with label', () => {
@@ -42,7 +42,7 @@ describe('XDSDateRangeInput', () => {
   });
 
   it('displays formatted range when value is set', () => {
-    const range: XDSDateRange = {
+    const range: DateRange = {
       start: '2026-03-15',
       end: '2026-03-22',
     };
@@ -235,7 +235,7 @@ describe('XDSDateRangeInput', () => {
 
   describe('hasClear', () => {
     it('shows clear button when hasClear is true and value exists', () => {
-      const range: XDSDateRange = {
+      const range: DateRange = {
         start: '2026-03-15',
         end: '2026-03-22',
       };
@@ -267,7 +267,7 @@ describe('XDSDateRangeInput', () => {
     });
 
     it('does not show clear button when hasClear is false', () => {
-      const range: XDSDateRange = {
+      const range: DateRange = {
         start: '2026-03-15',
         end: '2026-03-22',
       };
@@ -285,7 +285,7 @@ describe('XDSDateRangeInput', () => {
     });
 
     it('does not show clear button when disabled', () => {
-      const range: XDSDateRange = {
+      const range: DateRange = {
         start: '2026-03-15',
         end: '2026-03-22',
       };
@@ -305,7 +305,7 @@ describe('XDSDateRangeInput', () => {
 
     it('calls onChange with null when clear is clicked', () => {
       const onChange = vi.fn();
-      const range: XDSDateRange = {
+      const range: DateRange = {
         start: '2026-03-15',
         end: '2026-03-22',
       };

--- a/packages/core/src/DateRangeInput/XDSDateRangeInput.tsx
+++ b/packages/core/src/DateRangeInput/XDSDateRangeInput.tsx
@@ -53,7 +53,7 @@ import type {XDSBaseProps} from '../XDSBaseProps';
 import {useXDSSize} from '../SizeContext/XDSSizeContext';
 import {xdsThemeProps} from '../utils/xdsThemeProps';
 
-export type {DateRange as XDSDateRange} from '../Calendar';
+export type {DateRange} from '../Calendar';
 
 export interface XDSDateRangePreset {
   label: string;

--- a/packages/core/src/DateRangeInput/index.ts
+++ b/packages/core/src/DateRangeInput/index.ts
@@ -15,6 +15,6 @@ export type {
   XDSDateRangeInputSize,
   XDSDateRangeInputStatus,
   XDSDateRangeInputStatusType,
-  XDSDateRange,
+  DateRange,
   XDSDateRangePreset,
 } from './XDSDateRangeInput';


### PR DESCRIPTION
## What

`DateRange` is bare everywhere it is defined and consumed — `utils/dateTypes.ts` (the single definition), `@xds/core/utils`, and `@xds/core/Calendar`. The lone outlier was `@xds/core/DateRangeInput`, which re-exported the *same* type under a prefixed name, `XDSDateRange`.

This aligns the naming: `DateRangeInput` now re-exports it bare as `DateRange`, consistent with the other shared date types (`ISODateString`, `DayOfWeek`, `PlainDate`).

## Why it's safe

- It's a **rename of a re-export**, not a type move. All paths still trace to the one `dateTypes.ts` definition, so multiple re-export entry points are fine and there's no duplicate-symbol ambiguity.
- **Zero fbsource consumers** import `XDSDateRange` from `@xds/core` (verified across the monorepo) — the only consumers are in-repo.

## Changes

- `DateRangeInput/XDSDateRangeInput.tsx`: `export type {DateRange}` (was `{DateRange as XDSDateRange}`)
- `DateRangeInput/index.ts`: barrel exports `DateRange` (was `XDSDateRange`)
- 3 in-repo consumers updated to the bare name: storybook `DateRangeInput.stories.tsx`, the `DateRangeInputShowcase` block template, and `XDSDateRangeInput.test.tsx`

## Out of scope (intentional)

`XDSDateRangePreset` is **left prefixed**. Unprefixing it to `DateRangePreset` would collide with PowerSearch's unrelated, pre-existing bare `DateRangePreset` (`{label, value: DateTimeRange}`) at the root `@xds/core` barrel → TS2308 ambiguous export. That needs a disambiguation decision; tracked in a separate issue.

## Validation

- `@xds/core` `tsc` typecheck: clean
- `@xds/core` build (babel + tsc decls + CSS): success, 460 files
- `XDSDateRangeInput.test.tsx`: 24/24 pass