### PR TITLE
refactor(core): unprefix DateRangeInput's preset type

### DIFF
--- a/packages/core/src/DateRangeInput/DateRangeInput.doc.mjs
+++ b/packages/core/src/DateRangeInput/DateRangeInput.doc.mjs
@@ -22,7 +22,7 @@ export const docs = {
     { name: 'min', type: 'ISODateString', description: 'Minimum selectable date.' },
     { name: 'max', type: 'ISODateString', description: 'Maximum selectable date.' },
     { name: 'dateConstraints', type: 'Array<(date: Date) => boolean>', description: 'Custom constraint functions to disable specific dates.' },
-    { name: 'presets', type: 'Array<XDSDateRangePreset>', description: 'Preset ranges shown as quick-select options beside the calendar.' },
+    { name: 'presets', type: 'Array<DateRangePreset>', description: 'Preset ranges shown as quick-select options beside the calendar.' },
     { name: 'hasClear', type: 'boolean', description: 'Shows a clear button when a range is selected.', default: 'true' },
     { name: 'placeholder', type: 'string', description: 'Placeholder text when no range is selected.', default: "'Select date range'" },
     { name: 'size', type: "'sm' | 'md' | 'lg'", description: 'Size of the trigger.', default: "'md'" },

--- a/packages/core/src/DateRangeInput/XDSDateRangeInput.tsx
+++ b/packages/core/src/DateRangeInput/XDSDateRangeInput.tsx
@@ -55,7 +55,7 @@ import {xdsThemeProps} from '../utils/xdsThemeProps';
 
 export type {DateRange as XDSDateRange} from '../Calendar';
 
-export interface XDSDateRangePreset {
+export interface DateRangePreset {
   label: string;
   getRange: () => DateRange;
 }
@@ -280,7 +280,7 @@ export interface XDSDateRangeInputProps extends Omit<
   /**
    * Preset date ranges shown as quick-select options beside the calendar.
    */
-  presets?: ReadonlyArray<XDSDateRangePreset>;
+  presets?: ReadonlyArray<DateRangePreset>;
 
   /**
    * Whether to show a clear button when a range is selected.
@@ -438,7 +438,7 @@ export function XDSDateRangeInput({
   );
 
   const handlePresetClick = useCallback(
-    (preset: XDSDateRangePreset) => {
+    (preset: DateRangePreset) => {
       fireChange(preset.getRange());
       popover.hide();
     },

--- a/packages/core/src/DateRangeInput/index.ts
+++ b/packages/core/src/DateRangeInput/index.ts
@@ -16,5 +16,5 @@ export type {
   XDSDateRangeInputStatus,
   XDSDateRangeInputStatusType,
   XDSDateRange,
-  XDSDateRangePreset,
+  DateRangePreset,
 } from './XDSDateRangeInput';


### PR DESCRIPTION
## What

Renames the calendar range-picker's preset type `XDSDateRangePreset` → `DateRangePreset`, aligning it with the other bare date types (`DateRange`, `ISODateString`, `DayOfWeek`, `PlainDate`).

## Depends on #2925

This is **stacked on #2925** (PowerSearch `*FilterPreset` rename). PowerSearch previously exported an unrelated bare `DateRangePreset`; #2925 renames it to `DateRangeFilterPreset`, freeing the bare `DateRangePreset` name at the root `@xds/core` barrel. Without #2925, this rename would hit TS2308 (the collision in #2923).

**Merge #2925 first.** (The diff here will simplify once #2925 lands and this rebases onto main.)

## Changes

- `XDSDateRangeInput.tsx`: `interface DateRangePreset` (was `XDSDateRangePreset`) + internal usages
- `index.ts` barrel + `DateRangeInput.doc.mjs` prop type → bare name

## Validation

- `@xds/core` `tsc` typecheck: **clean** (confirms the root-barrel collision is resolved)
- Build: success (460 files)
- Tests: **123/123** pass across DateRangeInput + PowerSearch

## Related

- #2925 (prerequisite — frees the name)
- #2923 (the collision, now resolvable)
- #2922 (unprefixes the sibling `DateRange` value type)