### PR TITLE
P6: tests & snapshots green after P4 rename + dual-emit

### DIFF
--- a/packages/cli/src/commands/agent-docs.test.mjs
+++ b/packages/cli/src/commands/agent-docs.test.mjs
@@ -31,7 +31,7 @@ afterEach(() => {
 describe('generateCompressedIndex', () => {
   it('includes the version number', () => {
     const result = generateCompressedIndex('1.2.3');
-    expect(result).toContain('XDS v1.2.3');
+    expect(result).toContain('Astryx v1.2.3');
     expect(result).toContain('<!-- XDS:START -->');
     expect(result).toContain('<!-- XDS:END -->');
   });
@@ -39,7 +39,7 @@ describe('generateCompressedIndex', () => {
   it('includes theme nudge rule', () => {
     const result = generateCompressedIndex('1.0.0');
     expect(result).toMatch(/xds theme/);
-    expect(result).toMatch(/never override --xds-color/);
+    expect(result).toMatch(/never override --astryx-color/);
   });
 
   it('includes upgrade command and migration rule', () => {
@@ -158,7 +158,7 @@ describe('injectAgentsMd', () => {
     const content = fs.readFileSync(path.join(tmpDir, 'AGENTS.md'), 'utf-8');
     expect(content).toContain('# AGENTS.md');
     expect(content).toContain('<!-- XDS:START -->');
-    expect(content).toContain('XDS v1.0.0');
+    expect(content).toContain('Astryx v1.0.0');
     expect(content).toContain('<!-- XDS:END -->');
   });
 
@@ -178,7 +178,7 @@ More stuff.
     injectAgentsMd(tmpDir, '2.0.0');
 
     const content = fs.readFileSync(path.join(tmpDir, 'AGENTS.md'), 'utf-8');
-    expect(content).toContain('XDS v2.0.0');
+    expect(content).toContain('Astryx v2.0.0');
     expect(content).not.toContain('old content');
     expect(content).toContain('Some content.');
     expect(content).toContain('More stuff.');
@@ -196,7 +196,7 @@ Existing agent docs.
     const content = fs.readFileSync(path.join(tmpDir, 'AGENTS.md'), 'utf-8');
     expect(content).toContain('Existing agent docs.');
     expect(content).toContain('<!-- XDS:START -->');
-    expect(content).toContain('XDS v1.0.0');
+    expect(content).toContain('Astryx v1.0.0');
   });
 });
 
@@ -211,7 +211,7 @@ describe('injectClaudeMd', () => {
     expect(content).toContain('# Claude Config');
     expect(content).toContain('Existing rules.');
     expect(content).toContain('<!-- XDS:START -->');
-    expect(content).toContain('XDS v1.0.0');
+    expect(content).toContain('Astryx v1.0.0');
   });
 
   it('does not create CLAUDE.md when it does not exist', () => {
@@ -235,7 +235,7 @@ Other rules.
     injectClaudeMd(tmpDir, '2.0.0');
 
     const content = fs.readFileSync(path.join(tmpDir, 'CLAUDE.md'), 'utf-8');
-    expect(content).toContain('XDS v2.0.0');
+    expect(content).toContain('Astryx v2.0.0');
     expect(content).not.toContain('old content');
     expect(content).toContain('Other rules.');
   });
@@ -425,7 +425,7 @@ describe('installAgentDocs', () => {
 
     expect(written).toEqual(['CLAUDE.md']);
     const content = fs.readFileSync(path.join(tmpDir, 'CLAUDE.md'), 'utf-8');
-    expect(content).toContain('XDS v2.0.0');
+    expect(content).toContain('Astryx v2.0.0');
     expect(content).not.toContain('PLACEHOLDER_STALE_CONTENT');
     expect(content).toContain('Other rules.');
   });

--- a/packages/core/src/CodeBlock/index.ts
+++ b/packages/core/src/CodeBlock/index.ts
@@ -42,12 +42,14 @@ export {ensureHighlightStyles, TOKEN_TYPES} from './highlightStyles';
 // augmentable (consumer `declare module` augmentations of XDS* flow through).
 // Regenerate: node scripts/generate-compat-aliases.mjs
 export {
+  Code as XDSCode,
   CodeBlock as XDSCodeBlock,
   SYNC_TOKENIZE_THRESHOLD as XDSSYNC_TOKENIZE_THRESHOLD,
   TOKEN_TYPES as XDSTOKEN_TYPES,
 } from '.';
 export type {
   CodeBlockProps as XDSCodeBlockProps,
+  CodeProps as XDSCodeProps,
   SyntaxToken as XDSSyntaxToken,
   TokenLine as XDSTokenLine,
 } from '.';

--- a/packages/core/src/ContextMenu/index.ts
+++ b/packages/core/src/ContextMenu/index.ts
@@ -30,10 +30,12 @@ export {
 // Regenerate: node scripts/generate-compat-aliases.mjs
 export {
   ContextMenu as XDSContextMenu,
+  ContextMenuItem as XDSContextMenuItem,
 } from '.';
 export type {
   ContextMenuDivider as XDSContextMenuDivider,
   ContextMenuItemData as XDSContextMenuItemData,
+  ContextMenuItemProps as XDSContextMenuItemProps,
   ContextMenuOption as XDSContextMenuOption,
   ContextMenuProps as XDSContextMenuProps,
   ContextMenuSection as XDSContextMenuSection,

--- a/packages/core/src/Field/index.ts
+++ b/packages/core/src/Field/index.ts
@@ -51,13 +51,17 @@ export {InputClearButton} from './InputClearButton';
 export {
   Field as XDSField,
   FieldLabel as XDSFieldLabel,
+  FieldStatus as XDSFieldStatus,
   InputClearButton as XDSInputClearButton,
 } from '.';
 export type {
   FieldLabelProps as XDSFieldLabelProps,
   FieldProps as XDSFieldProps,
   FieldStatusInput as XDSFieldStatusInput,
+  FieldStatusProps as XDSFieldStatusProps,
   FieldStatusType as XDSFieldStatusType,
+  FieldStatusVariant as XDSFieldStatusVariant,
+  FieldStatusVariantMap as XDSFieldStatusVariantMap,
   InputSize as XDSInputSize,
   InputStatus as XDSInputStatus,
   InputStatusType as XDSInputStatusType,

--- a/packages/core/src/Layer/index.ts
+++ b/packages/core/src/Layer/index.ts
@@ -72,10 +72,16 @@ export type {
 // augmentable (consumer `declare module` augmentations of XDS* flow through).
 // Regenerate: node scripts/generate-compat-aliases.mjs
 export {
+  HoverCard as XDSHoverCard,
   LayerContext as XDSLayerContext,
   LayerProvider as XDSLayerProvider,
+  Popover as XDSPopover,
+  Tooltip as XDSTooltip,
+  useHoverCard as useXDSHoverCard,
   useLayer as useXDSLayer,
   useLayerContext as useXDSLayerContext,
+  usePopover as useXDSPopover,
+  useTooltip as useXDSTooltip,
 } from '.';
 export type {
   ContextLayerOptions as XDSContextLayerOptions,
@@ -84,10 +90,21 @@ export type {
   FixedLayerOptions as XDSFixedLayerOptions,
   FixedLayerReturn as XDSFixedLayerReturn,
   FixedRenderProps as XDSFixedRenderProps,
+  HoverCardFocusTrigger as XDSHoverCardFocusTrigger,
+  HoverCardOptions as XDSHoverCardOptions,
+  HoverCardProps as XDSHoverCardProps,
+  HoverCardReturn as XDSHoverCardReturn,
   LayerAlignment as XDSLayerAlignment,
   LayerContextValue as XDSLayerContextValue,
   LayerPlacement as XDSLayerPlacement,
   LayerProviderProps as XDSLayerProviderProps,
   LayerToastConfig as XDSLayerToastConfig,
+  PopoverProps as XDSPopoverProps,
+  TooltipFocusTrigger as XDSTooltipFocusTrigger,
+  TooltipOptions as XDSTooltipOptions,
+  TooltipProps as XDSTooltipProps,
+  TooltipReturn as XDSTooltipReturn,
+  UsePopoverOptions as XDSUsePopoverOptions,
+  UsePopoverReturn as XDSUsePopoverReturn,
 } from '.';
 // <compat-aliases:end>

--- a/packages/core/src/Layout/index.ts
+++ b/packages/core/src/Layout/index.ts
@@ -89,7 +89,9 @@ export type {LayoutDividerContextValue} from './LayoutDividerContext';
 // augmentable (consumer `declare module` augmentations of XDS* flow through).
 // Regenerate: node scripts/generate-compat-aliases.mjs
 export {
+  Card as XDSCard,
   EDGE_COMP_ATTR as XDSEDGE_COMP_ATTR,
+  HStack as XDSHStack,
   Layout as XDSLayout,
   LayoutAreaContext as XDSLayoutAreaContext,
   LayoutContent as XDSLayoutContent,
@@ -97,10 +99,16 @@ export {
   LayoutFooter as XDSLayoutFooter,
   LayoutHeader as XDSLayoutHeader,
   LayoutPanel as XDSLayoutPanel,
+  Section as XDSSection,
+  Stack as XDSStack,
+  StackItem as XDSStackItem,
+  VStack as XDSVStack,
 } from '.';
 export type {
+  CardProps as XDSCardProps,
   ContainerComponent as XDSContainerComponent,
   ContainerOptions as XDSContainerOptions,
+  HStackProps as XDSHStackProps,
   LayoutArea as XDSLayoutArea,
   LayoutContentProps as XDSLayoutContentProps,
   LayoutDividerContextValue as XDSLayoutDividerContextValue,
@@ -109,6 +117,22 @@ export type {
   LayoutHeight as XDSLayoutHeight,
   LayoutPanelProps as XDSLayoutPanelProps,
   LayoutProps as XDSLayoutProps,
+  SectionProps as XDSSectionProps,
+  SectionVariant as XDSSectionVariant,
+  SizeValue as XDSSizeValue,
+  SpacingStep as XDSSpacingStep,
   SpacingToken as XDSSpacingToken,
+  StackAlignment as XDSStackAlignment,
+  StackCrossAlignment as XDSStackCrossAlignment,
+  StackDirection as XDSStackDirection,
+  StackItemCrossAlignSelf as XDSStackItemCrossAlignSelf,
+  StackItemOptions as XDSStackItemOptions,
+  StackItemProps as XDSStackItemProps,
+  StackItemSize as XDSStackItemSize,
+  StackMainAlignment as XDSStackMainAlignment,
+  StackOptions as XDSStackOptions,
+  StackProps as XDSStackProps,
+  StackWrap as XDSStackWrap,
+  VStackProps as XDSVStackProps,
 } from '.';
 // <compat-aliases:end>

--- a/packages/core/src/Stack/index.ts
+++ b/packages/core/src/Stack/index.ts
@@ -32,12 +32,16 @@ export type {StackItemProps} from './StackItem';
 // augmentable (consumer `declare module` augmentations of XDS* flow through).
 // Regenerate: node scripts/generate-compat-aliases.mjs
 export {
+  HStack as XDSHStack,
   Stack as XDSStack,
   StackItem as XDSStackItem,
+  VStack as XDSVStack,
 } from '.';
 export type {
+  HStackProps as XDSHStackProps,
   StackAlignment as XDSStackAlignment,
   StackItemProps as XDSStackItemProps,
   StackProps as XDSStackProps,
+  VStackProps as XDSVStackProps,
 } from '.';
 // <compat-aliases:end>

--- a/packages/core/src/Text/index.ts
+++ b/packages/core/src/Text/index.ts
@@ -47,14 +47,26 @@ export {
 // augmentable (consumer `declare module` augmentations of XDS* flow through).
 // Regenerate: node scripts/generate-compat-aliases.mjs
 export {
+  Heading as XDSHeading,
   Text as XDSText,
   useTruncation as useXDSTruncation,
 } from '.';
 export type {
+  HeadingLevel as XDSHeadingLevel,
+  HeadingProps as XDSHeadingProps,
+  HeadingType as XDSHeadingType,
+  ProseElement as XDSProseElement,
+  TextColor as XDSTextColor,
+  TextDisplay as XDSTextDisplay,
+  TextJustify as XDSTextJustify,
   TextProps as XDSTextProps,
   TextSize as XDSTextSize,
   TextType as XDSTextType,
+  TextWeight as XDSTextWeight,
+  TextWrap as XDSTextWrap,
+  TextXStyleAllowed as XDSTextXStyleAllowed,
   UseTruncationOptions as XDSUseTruncationOptions,
   UseTruncationReturn as XDSUseTruncationReturn,
+  WordBreak as XDSWordBreak,
 } from '.';
 // <compat-aliases:end>

--- a/packages/core/src/TimeInput/index.ts
+++ b/packages/core/src/TimeInput/index.ts
@@ -32,6 +32,7 @@ export {
   TimeInput as XDSTimeInput,
 } from '.';
 export type {
+  ISOTimeString as XDSISOTimeString,
   TimeInputHourFormat as XDSTimeInputHourFormat,
   TimeInputProps as XDSTimeInputProps,
   TimeInputSize as XDSTimeInputSize,

--- a/scripts/generate-compat-aliases.mjs
+++ b/scripts/generate-compat-aliases.mjs
@@ -128,12 +128,6 @@ function generateBlock(filePath) {
     const exported = entry.alias;
     const prefixed = prefixedName(exported);
     if (!prefixed) continue;
-    // Skip re-exports from a SIBLING module (e.g. Text re-exporting
-    // '../Heading'): the owning barrel (Heading) already emits that alias, so
-    // emitting it here too would duplicate it at the root `export *` barrel
-    // (TS2308). Only emit aliases for names this barrel canonically owns
-    // (sources like './X' or with no path), not '../X'.
-    if (entry.source.startsWith('../')) continue;
     if (existingNames.has(prefixed)) continue; // skip if prefixed already exported in THIS barrel
     if (EXISTING_PREFIXED.has(prefixed)) continue; // skip if prefixed already exported by ANY barrel (root export * ambiguity)
     const spec = `${exported} as ${prefixed}`;

--- a/scripts/sync-exports.js
+++ b/scripts/sync-exports.js
@@ -58,6 +58,10 @@ const STATIC_EXPORTS = {
     types: './src/xds.css.d.ts',
     default: './dist/xds.css',
   },
+  './astryx.css': {
+    types: './src/astryx.css.d.ts',
+    default: './dist/astryx.css',
+  },
   './tailwind-theme.css': {
     types: './src/tailwind-theme.css.d.ts',
     default: './src/tailwind-theme.css',


### PR DESCRIPTION
## What

Completes **P6** — full test suite + checks green across the repo after the P4 rename and dual-emit landed.

## Fixes

1. **Compat generator: removed an over-broad sibling-reexport guard** (introduced during the P4 inversion). It skipped emitting `XDS*` aliases for *any* name re-exported from a sibling module, which dropped legitimate compat aliases consumers import via convenience subpaths — e.g. `import {XDSHStack} from '@xds/core/Stack'` (Stack re-exports HStack from `../HStack`) resolved to `undefined`, breaking 12 `@xds/lab` Schedule tests. The root-duplicate it was meant to prevent is handled by the `HeadingLevel`→`HeadingTag` disambiguation + the existing `EXISTING_PREFIXED` guard. 8 barrels restored their aliases.

2. **`sync-exports.js`: added `./astryx.css`** to the canonical export set (P4 part 5 added the package export but not the check's expected set).

3. **`agent-docs.test.mjs`: 8 assertions updated** for pre-existing branding drift the full-CI pass surfaced — generator emits `Astryx v${version}` (P5a) and `--astryx-color-*` (P3c), tests still asserted `XDS v` / `--xds-color`. The `<!-- XDS:START/END -->` markers + `injectXdsBlock` fixtures stay `XDS` (generator still uses those marker names).

Note: `.xds-*` class and `[data-xds-*]` assertions across component tests **did not need changes** — they use `toContain`/`toHaveClass`/`querySelector`, which still match since the dual-emit keeps `xds-*` alongside `astryx-*`.

## Validation (full CI green)

- **Full repo vitest: 4754/4754 pass** (254 files)
- `@xds/core` tsc: clean
- `check:repo` gates: compat-aliases ✓, exports-sync ✓, token-docs ✓
- Build: `@xds/core` (xds.css + astryx.css emit), docsite generate+test 168/168

CI doesn't auto-run on integration PRs; validated locally as above.