### PR TITLE
fix(core): add missing displayName, export, and escape hatches

### DIFF
--- a/packages/core/src/Link/XDSLinkProvider.tsx
+++ b/packages/core/src/Link/XDSLinkProvider.tsx
@@ -55,3 +55,5 @@ export function XDSLinkProvider({component, children}: XDSLinkProviderProps) {
   const value = useMemo(() => ({component}), [component]);
   return <XDSLinkContext value={value}>{children}</XDSLinkContext>;
 }
+
+XDSLinkProvider.displayName = 'XDSLinkProvider';

--- a/packages/core/src/MoreMenu/XDSMoreMenu.tsx
+++ b/packages/core/src/MoreMenu/XDSMoreMenu.tsx
@@ -24,8 +24,12 @@ import {XDSDropdownMenu} from '../DropdownMenu/XDSDropdownMenu';
 import {useXDSSize} from '../SizeContext/XDSSizeContext';
 import type {XDSDropdownMenuOption} from '../DropdownMenu';
 import type {XDSButtonVariant, XDSButtonSize} from '../Button';
+import type {XDSBaseProps} from '../XDSBaseProps';
 
-export interface XDSMoreMenuProps {
+export interface XDSMoreMenuProps extends Pick<
+  XDSBaseProps,
+  'xstyle' | 'className' | 'style'
+> {
   /** Ref forwarded to the trigger button */
   ref?: React.Ref<HTMLButtonElement>;
 
@@ -112,6 +116,9 @@ export function XDSMoreMenu({
   isMenuOpen,
   onOpenChange,
   hasAutoFocus,
+  xstyle,
+  className: classNameProp,
+  style,
   'data-testid': testId,
   ref,
 }: XDSMoreMenuProps) {
@@ -120,7 +127,11 @@ export function XDSMoreMenu({
 
   return (
     <XDSDropdownMenu
-      className="xds-more-menu"
+      className={
+        classNameProp ? `xds-more-menu ${classNameProp}` : 'xds-more-menu'
+      }
+      xstyle={xstyle}
+      style={style}
       isMenuOpen={isMenuOpen}
       onOpenChange={onOpenChange}
       button={{

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -90,6 +90,7 @@ export * from './Dialog';
 export * from './ContextMenu';
 export * from './DropdownMenu';
 export * from './MoreMenu';
+export * from './InteractiveRoleContext';
 export * from './SizeContext';
 export * from './Toolbar';
 export * from './TopNav';


### PR DESCRIPTION
Fixes found during component audit of InteractiveRoleContext, Item, Layer, Link, and MoreMenu.

**Changes:**

1. **XDSLinkProvider**: Add `displayName` (was missing, unlike XDSLayerProvider and other providers).

2. **InteractiveRoleContext**: Export from `src/index.ts`. It has a package.json entry point and is consumer-facing (used in Storybook examples), matching the SizeContext pattern.

3. **XDSMoreMenu**: Accept `xstyle`, `className`, and `style` via `Pick<XDSBaseProps, ...>`. As a thin wrapper around XDSDropdownMenu, it uses Pick rather than full extension to avoid exposing irrelevant DOM props.

**Components audited (no issues):**
- InteractiveRoleContext: clean (context-only, no visual code)
- Item: clean (tokens, xdsThemeProps, BaseProps, displayName all correct)
- Layer: clean (provider, hook, animations all follow conventions)
- Link: clean (tokens, xdsThemeProps, BaseProps, displayName all correct)

Night Watch \u2014 Component Auditor