### PR TITLE
fix(cli): clarify SpacingStep and Button label in docs

### DIFF
--- a/packages/core/src/Button/Button.doc.mjs
+++ b/packages/core/src/Button/Button.doc.mjs
@@ -101,7 +101,7 @@ export const docs = {
       name: 'children',
       type: 'ReactNode',
       description:
-        'Optional visible content. When provided, rendered instead of label as the visible text.',
+        'Optional override for visible text. When provided, displayed instead of label — but label is still required (it provides the accessible name). For most cases, just use label alone: <XDSButton label="Save" />.',
     },
     {
       name: 'endContent',
@@ -198,7 +198,7 @@ export const docsZh = {
       default: 'false',
     },
     {name: 'icon', type: 'ReactNode', description: '图标元素。仅提供 icon 而不提供 children 时，按钮渲染为正方形的纯图标按钮。'},
-    {name: 'children', type: 'ReactNode', description: '按钮内容。与 icon 同时提供时，文本渲染在图标旁边。'},
+    {name: 'children', type: 'ReactNode', description: '可选的可见内容覆盖；label 仍然是必需的（用于无障碍名称）。大多数情况使用 <XDSButton label="Save" />。'},
     {
       name: 'endContent',
       type: 'ReactElement<XDSIconProps> | ReactElement<XDSBadgeProps>',
@@ -264,7 +264,7 @@ export const docsDense = {
     isLoading: 'shows spinner+disables interaction; announces via live region',
     icon: 'icon element rendered before label text',
     isIconOnly: 'when true, renders square icon-only button; label becomes aria-label',
-    children: 'optional visible content; rendered instead of label when provided',
+    children: 'optional visible override; label is still required for a11y. Prefer <XDSButton label="Save" /> over using children',
     endContent: 'trailing icon/badge after label; ignored when isIconOnly; color inherited',
     tooltip: 'tooltip on hover',
     onClick: 'standard click handler; fires before clickAction',

--- a/packages/core/src/Stack/Stack.doc.mjs
+++ b/packages/core/src/Stack/Stack.doc.mjs
@@ -26,7 +26,7 @@ export const docs = {
           name: 'gap',
           type: 'SpacingStep',
           description:
-            'Numeric spacing step controlling the gap between items: 0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10.',
+            'Spacing step (number literal): 0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10. Pass as a JSX number expression e.g. gap={4}, NOT a string like gap="4".',
         },
         {
           name: 'width',
@@ -94,7 +94,7 @@ export const docs = {
           name: 'gap',
           type: 'SpacingStep',
           description:
-            'Numeric spacing step controlling the gap between items: 0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10.',
+            'Spacing step (number literal): 0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10. Pass as a JSX number expression e.g. gap={4}, NOT a string like gap="4".',
         },
         {
           name: 'width',
@@ -214,7 +214,7 @@ export const docsZh = {
           name: 'gap',
           type: 'SpacingStep',
           description:
-            '控制元素间距的数值间距步进：0、0.5、1、1.5、2、3、4、5、6、8、10。',
+            '间距步进（数字字面量）：0、0.5、1、1.5、2、3、4、5、6、8、10。在 JSX 中使用数字表达式 e.g. gap={4}，不要使用字符串 gap="4"。',
         },
         {
           name: 'width',
@@ -283,7 +283,7 @@ export const docsZh = {
           name: 'gap',
           type: 'SpacingStep',
           description:
-            '控制元素间距的数值间距步进：0、0.5、1、1.5、2、3、4、5、6、8、10。',
+            '间距步进（数字字面量）：0、0.5、1、1.5、2、3、4、5、6、8、10。在 JSX 中使用数字表达式 e.g. gap={4}，不要使用字符串 gap="4"。',
         },
         {
           name: 'width',
@@ -399,7 +399,7 @@ export const docsDense = {
       displayName: 'H Stack',
       description: 'Horizontal stack; left-to-right, polymorphic rendering.',
       propDescriptions: {
-        gap: 'Numeric spacing step for gap: 0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10.',
+        gap: 'Number literal spacing step: 0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10. Use gap={4} not gap="4".',
         width: "Width of container. Numbers=pixels, strings=as-is (e.g. '100%').",
         height: "Height of container. Numbers=pixels, strings=as-is (e.g. '100%').",
         hAlign: 'Horizontal (main-axis) alignment.',
@@ -418,7 +418,7 @@ export const docsDense = {
       displayName: 'V Stack',
       description: 'Vertical stack; top-to-bottom, polymorphic rendering.',
       propDescriptions: {
-        gap: 'Numeric spacing step for gap: 0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10.',
+        gap: 'Number literal spacing step: 0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10. Use gap={4} not gap="4".',
         width: "Width of container. Numbers=pixels, strings=as-is (e.g. '100%').",
         height: "Height of container. Numbers=pixels, strings=as-is (e.g. '100%').",
         hAlign: 'Horizontal (cross-axis) alignment.',


### PR DESCRIPTION
## What

Fixes CLI documentation issues identified by the nightly vibe test.

## Why

The vibe test nightly (issue #2937) showed agents making systematic errors:
- **SpacingStep**: 10/10 XDS prompts failed with `Type 'string' is not assignable to type 'SpacingStep'`. Agents wrote `gap="4"` (string) instead of `gap={4}` (number literal).
- **Button label**: Agents wrote `<XDSButton>Save</XDSButton>` without the required `label` prop, misled by the `children` description implying it replaces label.

## Changes

### Stack.doc.mjs
- Updated `gap` description in HStack, VStack (en, zh, dense) from "Numeric spacing step..." to explicitly state: "Pass as a JSX number expression e.g. gap={4}, NOT a string like gap=\"4\"."

### Button.doc.mjs
- Updated `children` description (en, zh, dense) to clarify: "label is still required (it provides the accessible name). For most cases, just use label alone: \<XDSButton label=\"Save\" /\>."

## Verification

- [x] `npx xds component HStack` now shows explicit JSX syntax guidance
- [x] `npx xds component Button` clarifies label is always required
- [x] TypeScript types unchanged — docs now match actual type requirements

Vibe Test Debugger