### PR TITLE
feat(core): un-prefix migration Part 1/3 — foundation (compat layer + prefix-agnostic tooling)

### DIFF
--- a/.github/scripts/analyze-pr.js
+++ b/.github/scripts/analyze-pr.js
@@ -149,7 +149,20 @@ function getPropsCount(componentName) {
   const componentDir = path.join(process.cwd(), CORE_SRC, componentName);
   try {
     const files = fs.readdirSync(componentDir);
-    const mainFile = files.find(f => f.startsWith('XDS') && f.endsWith('.tsx'));
+    // The main component file is `XDS{Name}.tsx` today, or the bare `{Name}.tsx`
+    // after the XDS-prefix migration (P2380608025, P4). Prefer the file named
+    // after the component directory (prefixed or bare); otherwise fall back to
+    // any prefixed/PascalCase component file in the directory.
+    const mainFile =
+      [`XDS${componentName}.tsx`, `${componentName}.tsx`].find(f =>
+        files.includes(f),
+      ) ||
+      files.find(
+        f =>
+          (/^XDS[A-Z]\w+\.tsx$/.test(f) || /^[A-Z]\w+\.tsx$/.test(f)) &&
+          !f.includes('.test.') &&
+          !f.includes('Context.'),
+      );
 
     if (!mainFile) return null;
 

--- a/.github/workflows/hardening-issue.yml
+++ b/.github/workflows/hardening-issue.yml
@@ -37,8 +37,10 @@ jobs:
               { owner, repo, pull_number: pr.number }
             );
 
-            // Find new component directories: packages/core/src/<Name>/XDS<Name>.tsx
-            const newComponentPattern = /^packages\/core\/src\/([A-Z][A-Za-z]+)\/XDS\1\.tsx$/;
+            // Find new component directories:
+            //   packages/core/src/<Name>/XDS<Name>.tsx  (current convention)
+            //   packages/core/src/<Name>/<Name>.tsx      (post XDS-prefix migration, P2380608025)
+            const newComponentPattern = /^packages\/core\/src\/([A-Z][A-Za-z]+)\/(?:XDS)?\1\.tsx$/;
             const newComponents = new Set();
 
             for (const file of files) {

--- a/internal/vibe-tests/environments/project-astryx/README.md
+++ b/internal/vibe-tests/environments/project-astryx/README.md
@@ -1,0 +1,55 @@
+# Astryx
+
+This project uses Astryx (formerly XDS) components. Use the CLI to look up component props and usage before writing code:
+
+```bash
+npx astryx component --list              # list all available components
+npx astryx component Button              # look up props, variants, and usage
+npx astryx component IconButton          # each component has its own entry
+```
+
+If the CLI is not available, install dependencies first:
+
+```bash
+npm install --include=dev
+```
+
+Components use:
+
+- StyleX (`@stylexjs/stylex`) for styling
+- React 19
+
+## Styling with StyleX
+
+Custom styles must use `stylex.create()`. Plain objects are not valid:
+
+```tsx
+import stylex from '@stylexjs/stylex';
+
+const styles = stylex.create({
+  container: {
+    padding: 16,
+    backgroundColor: '#f5f5f5',
+  },
+});
+
+// Apply to components via the xstyle prop:
+<Card xstyle={styles.container}>...</Card>
+
+// Apply to HTML elements via stylex.props():
+<div {...stylex.props(styles.container)}>...</div>
+```
+
+**Important:** Never pass plain `{padding: '16px'}` objects to `xstyle`. Always use `stylex.create()`.
+
+## Import Pattern
+
+Each component is imported from its own subpath:
+
+```tsx
+import {Button} from '@xds/core/Button';
+import {IconButton} from '@xds/core/IconButton';
+import {Card} from '@xds/core/Card';
+import {Text, Heading} from '@xds/core/Text';
+import {useTheme} from '@xds/core/theme';
+```

--- a/internal/vibe-tests/environments/project-astryx/package.json
+++ b/internal/vibe-tests/environments/project-astryx/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "my-app",
+  "private": true,
+  "dependencies": {
+    "@xds/core": "*",
+    "@xds/theme-default": "*",
+    "@stylexjs/stylex": "^0.10",
+    "react": "^19",
+    "react-dom": "^19"
+  },
+  "devDependencies": {
+    "@xds/cli": "*"
+  }
+}

--- a/internal/vibe-tests/src/interactive.ts
+++ b/internal/vibe-tests/src/interactive.ts
@@ -755,12 +755,42 @@ function installAgentsDocs(): void {
   }
 }
 
+/**
+ * Install AGENTS.md for the Astryx (unprefixed) target.
+ * Same as XDS docs but with bare component names (Button not XDSButton).
+ * This validates that agents perform equally well with unprefixed names.
+ */
+function installAstryxDocs(): void {
+  // First generate the standard XDS AGENTS.md
+  installAgentsDocs();
+
+  const vibeTestsDir = path.join(__dirname, '..');
+  const agentsMdPath = path.join(vibeTestsDir, 'AGENTS.md');
+
+  if (!fs.existsSync(agentsMdPath)) return;
+
+  // Post-process: strip XDS prefix from component/hook names
+  let content = fs.readFileSync(agentsMdPath, 'utf-8');
+
+  // XDSButton -> Button, XDSCard -> Card, etc. (PascalCase after XDS)
+  content = content.replace(/\bXDS([A-Z][a-zA-Z]*)/g, '$1');
+  // useXDSTheme -> useTheme, useXDSToast -> useToast
+  content = content.replace(/\buseXDS([A-Z][a-zA-Z]*)/g, 'use$1');
+  // Update the header/branding
+  content = content.replace(/\bXDS\b/g, 'Astryx');
+  content = content.replace(/`xds /g, '`astryx ');
+  content = content.replace(/npx xds /g, 'npx astryx ');
+
+  fs.writeFileSync(agentsMdPath, content);
+  console.log('✓ Post-processed AGENTS.md for Astryx (bare component names)');
+}
+
 interface InteractiveConfig {
   sample?: number;
   holdout?: boolean;
   persona: 'naive' | 'experienced' | 'adversarial';
   degradation?: boolean; // Enable degradation curve testing
-  target: 'xds' | 'baseline' | 'html'; // Target design system
+  target: 'xds' | 'baseline' | 'html' | 'astryx'; // Target design system
 }
 
 interface AgentTask {
@@ -970,6 +1000,11 @@ function generateSubagentPrompt(
       experienced: `Use only plain HTML elements and inline CSS. `,
       adversarial: `I know React component libraries exist but I want raw HTML/CSS. `,
     },
+    astryx: {
+      naive: '', // No special framing - same library, bare names
+      experienced: `Use Astryx components from @xds/core. `,
+      adversarial: `I'm used to Tailwind/baseline patterns but need to use your design system. `,
+    },
   };
 
   const framing = personaFraming[config.target]?.[config.persona] || '';
@@ -1064,7 +1099,7 @@ async function main() {
   const targetIndex = args.indexOf('--target');
   const target =
     targetIndex !== -1
-      ? (args[targetIndex + 1] as 'xds' | 'baseline' | 'html')
+      ? (args[targetIndex + 1] as 'xds' | 'baseline' | 'html' | 'astryx')
       : 'xds';
   const promptsIndex = args.indexOf('--prompts');
   const promptIds =
@@ -1088,6 +1123,8 @@ async function main() {
   // Install target-specific documentation for retrieval-led approach
   if (target === 'xds') {
     installAgentsDocs();
+  } else if (target === 'astryx') {
+    installAstryxDocs();
   } else if (target === 'baseline') {
     installBaselineDocs();
   } else if (target === 'html') {
@@ -1150,7 +1187,7 @@ async function main() {
     console.log(`Skill doc: ${skillDocOverride}`);
   }
   console.log(
-    `Mode: ${target === 'xds' ? 'AGENTS.md' : target === 'baseline' ? 'AGENTS.baseline.md' : 'AGENTS.html.md'} (retrieval-led)`,
+    `Mode: ${target === 'xds' || target === 'astryx' ? 'AGENTS.md' : target === 'baseline' ? 'AGENTS.baseline.md' : 'AGENTS.html.md'} (retrieval-led)`,
   );
   console.log(
     `Protocol: ${degradation ? 'Degradation (10-turn curve)' : 'One-shot'}`,

--- a/internal/vibe-tests/src/interactive.ts
+++ b/internal/vibe-tests/src/interactive.ts
@@ -780,6 +780,10 @@ function installAstryxDocs(): void {
   content = content.replace(/\bXDS\b/g, 'Astryx');
   content = content.replace(/`xds /g, '`astryx ');
   content = content.replace(/npx xds /g, 'npx astryx ');
+  // CSS custom properties: docs should reference the new --astryx-* names
+  // (the library still handles --xds-* via inverted fallback, but we don't
+  // recommend the legacy names in forward-facing docs)
+  content = content.replace(/--xds-/g, '--astryx-');
 
   fs.writeFileSync(agentsMdPath, content);
   console.log('✓ Post-processed AGENTS.md for Astryx (bare component names)');

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test:watch": "vitest",
     "test:coverage": "vitest --coverage",
     "check:package-boundaries": "node scripts/check-package-boundaries.js",
-    "check:repo": "pnpm check:sync && pnpm check:package-boundaries",
+    "check:repo": "pnpm check:sync && pnpm check:package-boundaries && pnpm compat:aliases:check",
     "check:sync": "node scripts/check-sync.js",
     "lint": "pnpm check:repo && eslint . --cache",
     "lint:strict": "pnpm check:repo && XDS_STRICT_LINT=1 eslint . --cache",
@@ -27,7 +27,9 @@
     "release": "pnpm build && changeset publish",
     "prepare": "husky install",
     "dev:sandbox": "pnpm -F @xds/core build && pnpm -F @xds/sandbox dev",
-    "dev:sandbox:source": "XDS_SOURCE=1 pnpm -F @xds/sandbox dev"
+    "dev:sandbox:source": "XDS_SOURCE=1 pnpm -F @xds/sandbox dev",
+    "compat:aliases": "node scripts/generate-compat-aliases.mjs",
+    "compat:aliases:check": "node scripts/generate-compat-aliases.mjs --check"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.11.3",

--- a/packages/build/src/babel.test.mjs
+++ b/packages/build/src/babel.test.mjs
@@ -1,0 +1,74 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file babel.test.mjs
+ * @description Verifies that the XDS babel wrapper applies the configured
+ *   library StyleX class-name prefix to XDS library files. Part of the
+ *   XDS-prefix migration (P2380608025): the prefix defaults to `xds` and is
+ *   configurable to `astryx` so the library atom prefix can be rebranded
+ *   before the final cutover.
+ */
+
+import {describe, it, expect} from 'vitest';
+import {createRequire} from 'node:module';
+
+const require = createRequire(import.meta.url);
+const babel = require('@babel/core');
+const xdsBabelPlugin = require('./babel.js');
+
+const SOURCE = `
+import * as stylex from '@stylexjs/stylex';
+export const styles = stylex.create({
+  box: {color: 'red'},
+});
+`;
+
+/**
+ * Transform a StyleX source through the XDS babel wrapper as if it were a
+ * library file, returning the emitted code. `libraryPrefix` controls the
+ * atomic class-name prefix for library files.
+ */
+function transformLibraryFile(libraryPrefix) {
+  const result = babel.transformSync(SOURCE, {
+    // A path matching one of the library patterns so the wrapper routes it
+    // through the library plugin instance.
+    filename: 'node_modules/@xds/core/src/Box/XDSBox.tsx',
+    babelrc: false,
+    configFile: false,
+    plugins: [
+      [
+        xdsBabelPlugin,
+        {
+          ...(libraryPrefix ? {libraryPrefix} : {}),
+          unstable_moduleResolution: {type: 'commonJS', rootDir: process.cwd()},
+        },
+      ],
+    ],
+  });
+  return result?.code ?? '';
+}
+
+/** Extract the StyleX atomic class names referenced in the emitted code. */
+function atomicClasses(code) {
+  // StyleX emits atoms like "xds1a2b3c" / "astryx1a2b3c" in the compiled output.
+  return code.match(/\b(?:xds|astryx)[a-z0-9]{4,}\b/g) ?? [];
+}
+
+describe('xds babel wrapper -- library StyleX prefix', () => {
+  it('defaults library atoms to the `xds` prefix', () => {
+    const code = transformLibraryFile(undefined);
+    const atoms = atomicClasses(code);
+    expect(atoms.length).toBeGreaterThan(0);
+    expect(atoms.every(c => c.startsWith('xds'))).toBe(true);
+  });
+
+  it('uses the configured `astryx` prefix for library atoms', () => {
+    const code = transformLibraryFile('astryx');
+    const atoms = atomicClasses(code);
+    expect(atoms.length).toBeGreaterThan(0);
+    expect(atoms.every(c => c.startsWith('astryx'))).toBe(true);
+    expect(
+      atoms.some(c => c.startsWith('xds') && !c.startsWith('astryx')),
+    ).toBe(false);
+  });
+});

--- a/packages/build/src/vite.test.ts
+++ b/packages/build/src/vite.test.ts
@@ -2,10 +2,11 @@
 
 /**
  * @file vite.test.ts
- * @description Verifies CSS layer-order injection in the XDS Vite plugin,
- *   including the configurable theme layer added for the XDS-prefix migration
- *   (P2380608025). Default theme layer is `xds-theme`; consumers may opt into
- *   a rebranded layer (e.g. `astryx-theme`) before final cutover.
+ * @description Verifies CSS layer-order injection in the XDS Vite plugin.
+ *   The theme layer name is intentionally NOT configurable — it stays
+ *   `xds-theme` for the whole compatibility window and is rebranded only at
+ *   the final cutover (XDS-prefix migration P2380608025), so consumers never
+ *   have to touch their `@layer` order line until then.
  */
 
 import {describe, it, expect} from 'vitest';
@@ -24,36 +25,23 @@ function getLayerOrder(plugins: ReturnType<typeof xdsStylex>): string {
 }
 
 describe('xdsStylex layer order (modern API)', () => {
-  it('defaults to the legacy xds-* layer names', () => {
+  it('uses the xds-* layer names (theme layer is xds-theme)', () => {
     const order = getLayerOrder(xdsStylex());
     expect(order).toBe('@layer reset, xds-base, xds-theme, product;');
   });
 
-  it('honors a configured theme layer (astryx-theme opt-in)', () => {
-    const order = getLayerOrder(xdsStylex({layers: {theme: 'astryx-theme'}}));
-    expect(order).toBe('@layer reset, xds-base, astryx-theme, product;');
-  });
-
-  it('honors all configured layer names together', () => {
+  it('honors configured library and product layer names', () => {
     const order = getLayerOrder(
-      xdsStylex({
-        layers: {library: 'astryx-base', theme: 'astryx-theme', product: 'app'},
-      }),
+      xdsStylex({layers: {library: 'astryx-base', product: 'app'}}),
     );
-    expect(order).toBe('@layer reset, astryx-base, astryx-theme, app;');
+    // The theme layer stays xds-theme regardless of other layer config.
+    expect(order).toBe('@layer reset, astryx-base, xds-theme, app;');
   });
 });
 
 describe('xdsStylex layer order (legacy API)', () => {
-  it('defaults to the legacy xds-* layer names', () => {
+  it('uses the xds-* layer names (theme layer is xds-theme)', () => {
     const order = getLayerOrder(xdsStylex({stylexOptions: {}}));
     expect(order).toBe('@layer reset, xds-base, xds-theme, product;');
-  });
-
-  it('honors a configured theme layer', () => {
-    const order = getLayerOrder(
-      xdsStylex({stylexOptions: {}, layers: {theme: 'astryx-theme'}}),
-    );
-    expect(order).toBe('@layer reset, xds-base, astryx-theme, product;');
   });
 });

--- a/packages/build/src/vite.test.ts
+++ b/packages/build/src/vite.test.ts
@@ -1,0 +1,59 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file vite.test.ts
+ * @description Verifies CSS layer-order injection in the XDS Vite plugin,
+ *   including the configurable theme layer added for the XDS-prefix migration
+ *   (P2380608025). Default theme layer is `xds-theme`; consumers may opt into
+ *   a rebranded layer (e.g. `astryx-theme`) before final cutover.
+ */
+
+import {describe, it, expect} from 'vitest';
+import {xdsStylex} from './vite';
+
+/** Pull the injected `@layer ...;` order statement out of the plugin set. */
+function getLayerOrder(plugins: ReturnType<typeof xdsStylex>): string {
+  const layerPlugin = plugins.find(p => p.name === 'xds-css-layer-order');
+  expect(layerPlugin, 'xds-css-layer-order plugin should exist').toBeTruthy();
+  const transform = (layerPlugin as any).transformIndexHtml;
+  const tags =
+    typeof transform === 'function' ? transform() : transform.handler();
+  const styleTag = tags.find((t: any) => t.tag === 'style');
+  expect(styleTag, 'a <style> tag should be injected').toBeTruthy();
+  return styleTag.children as string;
+}
+
+describe('xdsStylex layer order (modern API)', () => {
+  it('defaults to the legacy xds-* layer names', () => {
+    const order = getLayerOrder(xdsStylex());
+    expect(order).toBe('@layer reset, xds-base, xds-theme, product;');
+  });
+
+  it('honors a configured theme layer (astryx-theme opt-in)', () => {
+    const order = getLayerOrder(xdsStylex({layers: {theme: 'astryx-theme'}}));
+    expect(order).toBe('@layer reset, xds-base, astryx-theme, product;');
+  });
+
+  it('honors all configured layer names together', () => {
+    const order = getLayerOrder(
+      xdsStylex({
+        layers: {library: 'astryx-base', theme: 'astryx-theme', product: 'app'},
+      }),
+    );
+    expect(order).toBe('@layer reset, astryx-base, astryx-theme, app;');
+  });
+});
+
+describe('xdsStylex layer order (legacy API)', () => {
+  it('defaults to the legacy xds-* layer names', () => {
+    const order = getLayerOrder(xdsStylex({stylexOptions: {}}));
+    expect(order).toBe('@layer reset, xds-base, xds-theme, product;');
+  });
+
+  it('honors a configured theme layer', () => {
+    const order = getLayerOrder(
+      xdsStylex({stylexOptions: {}, layers: {theme: 'astryx-theme'}}),
+    );
+    expect(order).toBe('@layer reset, xds-base, astryx-theme, product;');
+  });
+});

--- a/packages/build/src/vite.ts
+++ b/packages/build/src/vite.ts
@@ -29,6 +29,8 @@ export const LIGHTNINGCSS_TARGETS = {
 export interface XDSVitePluginLegacyOptions {
   stylexOptions: Parameters<typeof stylex.vite>[0];
   libraryPattern?: string;
+  /** StyleX atomic class-name prefix for XDS library styles. @default 'xds' */
+  stylexPrefix?: string;
   layers?: {
     library?: string;
     /** Layer name for theme overrides @default 'xds-theme' */
@@ -84,6 +86,19 @@ export interface XDSVitePluginOptions {
   lightningcssTargets?: Record<string, number>;
 
   /**
+   * StyleX atomic class-name prefix for XDS *library* styles. The product
+   * build uses a distinct prefix so library and product atoms never collide
+   * across layers.
+   *
+   * Configurable to support the XDS-prefix migration (P2380608025): a consumer
+   * can rebrand the library atom prefix to `astryx` before the final cutover.
+   * Defaults to `xds` so existing consumers are unaffected.
+   *
+   * @default 'xds'
+   */
+  stylexPrefix?: string;
+
+  /**
    * Extra StyleX options to merge.
    */
   stylexOverrides?: Record<string, unknown>;
@@ -120,6 +135,7 @@ export function xdsStylex(
     libraryPattern = XDS_LIBRARY_PATTERN,
     layers = {},
     lightningcssTargets,
+    stylexPrefix = 'xds',
     stylexOverrides = {},
   } = opts;
 
@@ -155,6 +171,7 @@ export function xdsStylex(
           xdsBabelPlugin,
           {
             ...stylexOptions,
+            libraryPrefix: stylexPrefix,
             babelConfig: undefined,
           },
         ],
@@ -301,6 +318,7 @@ function xdsStylexLegacy(options: XDSVitePluginLegacyOptions): Plugin[] {
   const {
     stylexOptions,
     libraryPattern = XDS_LIBRARY_PATTERN,
+    stylexPrefix = 'xds',
     layers = {},
   } = options;
 
@@ -321,6 +339,7 @@ function xdsStylexLegacy(options: XDSVitePluginLegacyOptions): Plugin[] {
           xdsBabelPlugin,
           {
             ...(stylexOptions as any),
+            libraryPrefix: stylexPrefix,
             babelConfig: undefined,
           },
         ],

--- a/packages/build/src/vite.ts
+++ b/packages/build/src/vite.ts
@@ -31,6 +31,8 @@ export interface XDSVitePluginLegacyOptions {
   libraryPattern?: string;
   layers?: {
     library?: string;
+    /** Layer name for theme overrides @default 'xds-theme' */
+    theme?: string;
     product?: string;
   };
 }
@@ -60,6 +62,15 @@ export interface XDSVitePluginOptions {
   layers?: {
     /** Layer name for XDS library styles @default 'xds-base' */
     library?: string;
+    /**
+     * Layer name for XDS theme overrides @default 'xds-theme'
+     *
+     * Configurable to support the XDS-prefix migration (P2380608025): a
+     * consumer can opt into the rebranded `astryx-theme` layer before the
+     * final cutover by setting this (and the matching runtime theme-layer
+     * name). Defaults to `xds-theme` so existing consumers are unaffected.
+     */
+    theme?: string;
     /** Layer name for product styles @default 'product' */
     product?: string;
   };
@@ -113,6 +124,7 @@ export function xdsStylex(
   } = opts;
 
   const libraryLayer = layers.library ?? 'xds-base';
+  const themeLayer = layers.theme ?? 'xds-theme';
   const productLayer = layers.product ?? 'product';
 
   // Build StyleX options with sensible defaults
@@ -157,7 +169,7 @@ export function xdsStylex(
       return [
         {
           tag: 'style',
-          children: `@layer reset, ${libraryLayer}, xds-theme, ${productLayer};`,
+          children: `@layer reset, ${libraryLayer}, ${themeLayer}, ${productLayer};`,
           injectTo: 'head-prepend',
         },
       ];
@@ -293,6 +305,7 @@ function xdsStylexLegacy(options: XDSVitePluginLegacyOptions): Plugin[] {
   } = options;
 
   const libraryLayer = layers.library ?? 'xds-base';
+  const themeLayer = layers.theme ?? 'xds-theme';
   const productLayer = layers.product ?? 'product';
 
   const xdsBabelPlugin = path.resolve(__dirname, 'babel.js');
@@ -322,7 +335,7 @@ function xdsStylexLegacy(options: XDSVitePluginLegacyOptions): Plugin[] {
       return [
         {
           tag: 'style',
-          children: `@layer reset, ${libraryLayer}, xds-theme, ${productLayer};`,
+          children: `@layer reset, ${libraryLayer}, ${themeLayer}, ${productLayer};`,
           injectTo: 'head-prepend',
         },
       ];

--- a/packages/build/src/vite.ts
+++ b/packages/build/src/vite.ts
@@ -33,8 +33,6 @@ export interface XDSVitePluginLegacyOptions {
   stylexPrefix?: string;
   layers?: {
     library?: string;
-    /** Layer name for theme overrides @default 'xds-theme' */
-    theme?: string;
     product?: string;
   };
 }
@@ -64,15 +62,6 @@ export interface XDSVitePluginOptions {
   layers?: {
     /** Layer name for XDS library styles @default 'xds-base' */
     library?: string;
-    /**
-     * Layer name for XDS theme overrides @default 'xds-theme'
-     *
-     * Configurable to support the XDS-prefix migration (P2380608025): a
-     * consumer can opt into the rebranded `astryx-theme` layer before the
-     * final cutover by setting this (and the matching runtime theme-layer
-     * name). Defaults to `xds-theme` so existing consumers are unaffected.
-     */
-    theme?: string;
     /** Layer name for product styles @default 'product' */
     product?: string;
   };
@@ -140,7 +129,6 @@ export function xdsStylex(
   } = opts;
 
   const libraryLayer = layers.library ?? 'xds-base';
-  const themeLayer = layers.theme ?? 'xds-theme';
   const productLayer = layers.product ?? 'product';
 
   // Build StyleX options with sensible defaults
@@ -186,7 +174,7 @@ export function xdsStylex(
       return [
         {
           tag: 'style',
-          children: `@layer reset, ${libraryLayer}, ${themeLayer}, ${productLayer};`,
+          children: `@layer reset, ${libraryLayer}, xds-theme, ${productLayer};`,
           injectTo: 'head-prepend',
         },
       ];
@@ -323,7 +311,6 @@ function xdsStylexLegacy(options: XDSVitePluginLegacyOptions): Plugin[] {
   } = options;
 
   const libraryLayer = layers.library ?? 'xds-base';
-  const themeLayer = layers.theme ?? 'xds-theme';
   const productLayer = layers.product ?? 'product';
 
   const xdsBabelPlugin = path.resolve(__dirname, 'babel.js');
@@ -354,7 +341,7 @@ function xdsStylexLegacy(options: XDSVitePluginLegacyOptions): Plugin[] {
       return [
         {
           tag: 'style',
-          children: `@layer reset, ${libraryLayer}, ${themeLayer}, ${productLayer};`,
+          children: `@layer reset, ${libraryLayer}, xds-theme, ${productLayer};`,
           injectTo: 'head-prepend',
         },
       ];

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,7 +26,8 @@
   ],
   "type": "module",
   "bin": {
-    "xds": "./bin/xds.mjs"
+    "xds": "./bin/xds.mjs",
+    "astryx": "./bin/xds.mjs"
   },
   "exports": {
     ".": "./bin/xds.mjs",

--- a/packages/cli/src/codemods/transforms/v0.0.15/__tests__/drop-xds-prefix-imports.test.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.15/__tests__/drop-xds-prefix-imports.test.mjs
@@ -1,0 +1,124 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {describe, it, expect} from 'vitest';
+
+async function applyTransform(source) {
+  const {default: transform} = await import('../drop-xds-prefix-imports.mjs');
+  const jscodeshift = (await import('jscodeshift')).default;
+  const j = jscodeshift.withParser('tsx');
+  const api = {jscodeshift: j, stats: () => {}, report: () => {}};
+  const file = {source, path: 'test.tsx'};
+  const result = transform(file, api);
+  return result ?? source;
+}
+
+describe('drop-xds-prefix-imports', () => {
+  it('renames a named import + its JSX usage', async () => {
+    const input = [
+      `import {XDSButton} from '@xds/core';`,
+      `export const App = () => <XDSButton label="Hi" />;`,
+    ].join('\n');
+    const output = await applyTransform(input);
+    expect(output).toContain(`import {Button} from '@xds/core';`);
+    expect(output).toContain('<Button label="Hi" />');
+    expect(output).not.toContain('XDSButton');
+  });
+
+  it('renames subpath imports and keeps the source path', async () => {
+    const input = `import {XDSButton} from '@xds/core/Button';`;
+    const output = await applyTransform(input);
+    expect(output).toContain('Button');
+    // The subpath dir is NOT renamed by this codemod.
+    expect(output).toContain(`from '@xds/core/Button'`);
+    expect(output).not.toContain('XDSButton');
+  });
+
+  it('renames hooks (useXDS -> use)', async () => {
+    const input = [
+      `import {useXDSTheme} from '@xds/core';`,
+      `const t = useXDSTheme();`,
+    ].join('\n');
+    const output = await applyTransform(input);
+    expect(output).toContain('import {useTheme}');
+    expect(output).toContain('const t = useTheme();');
+    expect(output).not.toContain('useXDSTheme');
+  });
+
+  it('renames type-only imports and type references', async () => {
+    const input = [
+      `import type {XDSButtonProps} from '@xds/core';`,
+      `type Props = XDSButtonProps & {extra: true};`,
+    ].join('\n');
+    const output = await applyTransform(input);
+    expect(output).toContain('ButtonProps');
+    expect(output).not.toContain('XDSButtonProps');
+  });
+
+  it('rewrites the imported name but keeps a custom local alias', async () => {
+    const input = [
+      `import {XDSButton as Btn} from '@xds/core';`,
+      `export const App = () => <Btn />;`,
+    ].join('\n');
+    const output = await applyTransform(input);
+    expect(output).toContain('Button as Btn');
+    expect(output).toContain('<Btn />');
+    expect(output).not.toContain('XDSButton');
+  });
+
+  it('does NOT touch identifiers that are not imported from @xds/core', async () => {
+    const input = [
+      `import {XDSButton} from '@my/other-lib';`,
+      `const XDSCustomThing = 1;`,
+      `export const App = () => <XDSButton />;`,
+    ].join('\n');
+    const output = await applyTransform(input);
+    // Neither the third-party import nor the local symbol should change.
+    expect(output).toContain(`import {XDSButton} from '@my/other-lib';`);
+    expect(output).toContain('const XDSCustomThing = 1;');
+    expect(output).toContain('<XDSButton />');
+  });
+
+  it('does NOT touch strings that merely start with XDS', async () => {
+    const input = [
+      `import {XDSButton} from '@xds/core';`,
+      `const label = 'XDSButton is great';`,
+      `export const App = () => <XDSButton label={label} />;`,
+    ].join('\n');
+    const output = await applyTransform(input);
+    expect(output).toContain(`'XDSButton is great'`);
+    expect(output).toContain('<Button label={label} />');
+  });
+
+  it('handles multiple specifiers and a mix of components, hooks, and types', async () => {
+    const input = [
+      `import {XDSButton, XDSCard, useXDSToast} from '@xds/core';`,
+      `import type {XDSCardProps} from '@xds/core';`,
+      `export function App() {`,
+      `  const toast = useXDSToast();`,
+      `  const p: XDSCardProps = {};`,
+      `  return <XDSCard><XDSButton /></XDSCard>;`,
+      `}`,
+    ].join('\n');
+    const output = await applyTransform(input);
+    expect(output).toContain('import {Button, Card, useToast}');
+    expect(output).toContain('CardProps');
+    expect(output).toContain('const toast = useToast();');
+    expect(output).toContain('<Card><Button /></Card>');
+    expect(output).not.toContain('XDS');
+  });
+
+  it('rewrites re-exports from @xds/core', async () => {
+    const input = `export {XDSButton} from '@xds/core/Button';`;
+    const output = await applyTransform(input);
+    expect(output).toContain('Button');
+    expect(output).toContain(`from '@xds/core/Button'`);
+    expect(output).not.toContain('XDSButton');
+  });
+
+  it('returns source unchanged when there is nothing to rename', async () => {
+    const input = `import {useState} from 'react';\nconst x = 1;`;
+    const output = await applyTransform(input);
+    expect(output).toContain(`import {useState} from 'react';`);
+    expect(output).toContain('const x = 1;');
+  });
+});

--- a/packages/cli/src/codemods/transforms/v0.0.15/drop-xds-prefix-imports.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.15/drop-xds-prefix-imports.mjs
@@ -1,0 +1,170 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Codemod: Drop the `XDS` prefix from @xds/core imports and their usages
+ *
+ * Part of the XDS-prefix migration (P2380608025). Rewrites consumer code from
+ * the prefixed names to the bare compatibility aliases shipped in P1:
+ *
+ *   XDSButton      -> Button
+ *   XDSButtonProps -> ButtonProps
+ *   useXDSTheme    -> useTheme
+ *   useXDSToast    -> useToast
+ *
+ * Safety: this codemod ONLY renames identifiers that are imported from
+ * `@xds/core` (bare or subpath, e.g. `@xds/core/Button`). It tracks the local
+ * binding introduced by each import and renames that binding plus its
+ * references -- so a consumer's own unrelated `XDSWhatever` symbol, or a string
+ * that merely starts with "XDS", is never touched.
+ *
+ * Handles:
+ * 1. Named import specifiers:   import {XDSButton} from '@xds/core'
+ *    -> import {Button} from '@xds/core'   (and aliased imports)
+ * 2. All references to the imported binding (JSX, type positions, values)
+ * 3. Re-exports from @xds/core: export {XDSButton} from '@xds/core/Button'
+ *
+ * Does NOT touch:
+ * - import source paths (`@xds/core/Button` stays -- subpath dirs are unchanged
+ *   by the prefix migration)
+ * - identifiers not bound to an @xds/core import
+ * - the `XDSBaseProps`-style names only when they are NOT imported from core
+ */
+
+export const meta = {
+  title: 'Drop XDS prefix from @xds/core imports (XDSButton -> Button)',
+  description:
+    'Rewrites @xds/core imports and their usages from the prefixed names ' +
+    '(XDSButton, useXDSTheme, XDSButtonProps) to the bare compatibility ' +
+    'aliases (Button, useTheme, ButtonProps). Only renames bindings imported ' +
+    'from @xds/core, leaving unrelated identifiers untouched.',
+  pr: '#2880',
+};
+
+const XDS_CORE_SOURCE = /^@xds\/core(\/.*)?$/;
+
+/**
+ * Compute the bare (unprefixed) name for an XDS-prefixed identifier.
+ * Returns null if the name is not XDS-prefixed in a renameable way.
+ */
+function bareName(name) {
+  if (name.startsWith('useXDS') && name.length > 'useXDS'.length) {
+    return 'use' + name.slice('useXDS'.length);
+  }
+  if (
+    name.startsWith('XDS') &&
+    name.length > 3 &&
+    name[3] === name[3].toUpperCase() &&
+    name[3] !== name[3].toLowerCase() // next char is an uppercase letter
+  ) {
+    return name.slice(3);
+  }
+  return null;
+}
+
+export default function transformer(file, api) {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+  let hasChanges = false;
+
+  // Map of localName -> newLocalName for bindings we will rename. We only
+  // rename when the LOCAL binding is the prefixed name (i.e. not aliased to
+  // something custom). Aliased imports like `XDSButton as Btn` keep their
+  // local alias and only the imported name is rewritten.
+  const localRenames = new Map();
+
+  // 1. Rewrite import specifiers from @xds/core
+  root.find(j.ImportDeclaration).forEach(path => {
+    const source = path.node.source.value;
+    if (typeof source !== 'string' || !XDS_CORE_SOURCE.test(source)) return;
+
+    for (const spec of path.node.specifiers || []) {
+      if (spec.type !== 'ImportSpecifier') continue; // skip default/namespace
+      const importedName = spec.imported.name;
+      const bare = bareName(importedName);
+      if (!bare) continue;
+
+      const localName = spec.local.name;
+      const wasAliased = localName !== importedName;
+
+      // Rewrite the imported name to the bare alias.
+      spec.imported.name = bare;
+
+      if (wasAliased) {
+        // `import {XDSButton as Btn}` -> `import {Button as Btn}`.
+        // Local binding unchanged, so no usage rewrites needed.
+        hasChanges = true;
+      } else {
+        // `import {XDSButton}` -> `import {Button}`. The local binding is the
+        // prefixed name; rename it and all its references.
+        spec.local.name = bare;
+        localRenames.set(importedName, bare);
+        hasChanges = true;
+      }
+    }
+  });
+
+  // 2. Rewrite re-exports from @xds/core
+  root.find(j.ExportNamedDeclaration).forEach(path => {
+    if (!path.node.source) return;
+    const source = path.node.source.value;
+    if (typeof source !== 'string' || !XDS_CORE_SOURCE.test(source)) return;
+
+    for (const spec of path.node.specifiers || []) {
+      if (spec.type !== 'ExportSpecifier') continue;
+      const localName = spec.local.name;
+      const bare = bareName(localName);
+      if (!bare) continue;
+      spec.local.name = bare;
+      // If the export was `export {XDSButton}` (exported name == local),
+      // also update the exported name; if it was `export {XDSButton as Foo}`,
+      // keep the public exported name `Foo`.
+      if (spec.exported.name === localName) {
+        spec.exported.name = bare;
+      }
+      hasChanges = true;
+    }
+  });
+
+  if (localRenames.size === 0) {
+    return hasChanges ? root.toSource() : undefined;
+  }
+
+  // 3. Rename references to renamed local bindings
+  // Identifiers (type refs, value refs, etc.)
+  root.find(j.Identifier).forEach(path => {
+    const newName = localRenames.get(path.node.name);
+    if (!newName) return;
+    // Skip object property keys like `{ XDSButton: ... }` (not a reference to
+    // the binding) and member expression properties like `foo.XDSButton`.
+    const parent = path.parent.node;
+    if (
+      (parent.type === 'ObjectProperty' || parent.type === 'Property') &&
+      parent.key === path.node &&
+      !parent.computed
+    ) {
+      return;
+    }
+    if (
+      parent.type === 'MemberExpression' &&
+      parent.property === path.node &&
+      !parent.computed
+    ) {
+      return;
+    }
+    // Don't double-rewrite the import specifier we already handled.
+    if (parent.type === 'ImportSpecifier') return;
+    path.node.name = newName;
+    hasChanges = true;
+  });
+
+  // JSX element names: <XDSButton> -> <Button>
+  root.find(j.JSXIdentifier).forEach(path => {
+    const newName = localRenames.get(path.node.name);
+    if (newName) {
+      path.node.name = newName;
+      hasChanges = true;
+    }
+  });
+
+  return hasChanges ? root.toSource() : undefined;
+}

--- a/packages/cli/src/codemods/transforms/v0.0.15/index.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.15/index.mjs
@@ -34,6 +34,10 @@ import migrateSelectorChildrenToRenderOption, {
   meta as migrateSelectorChildrenToRenderOptionMeta,
 } from './migrate-selector-children-to-render-option.mjs';
 
+import dropXdsPrefixImports, {
+  meta as dropXdsPrefixImportsMeta,
+} from './drop-xds-prefix-imports.mjs';
+
 export default [
   {
     name: 'rename-date-picker-to-input',
@@ -70,5 +74,14 @@ export default [
     name: 'migrate-selector-children-to-render-option',
     transform: migrateSelectorChildrenToRenderOption,
     meta: migrateSelectorChildrenToRenderOptionMeta,
+  },
+  {
+    // XDS-prefix migration (P2380608025). Optional + not tied to a version
+    // bump: consumers run it explicitly during their migration, e.g.
+    //   xds upgrade --codemod drop-xds-prefix-imports --codemod-only --apply
+    name: 'drop-xds-prefix-imports',
+    transform: dropXdsPrefixImports,
+    meta: dropXdsPrefixImportsMeta,
+    optional: true,
   },
 ];

--- a/packages/cli/src/commands/build-theme.mjs
+++ b/packages/cli/src/commands/build-theme.mjs
@@ -343,7 +343,12 @@ function parsePadding(props) {
 }
 
 function expandContainerPadding(component, parsed) {
-  const prefix = `--xds-${component}-padding`;
+  // Emit the rebranded --astryx-<component>-padding tokens. The component reads
+  // them via an inverted fallback (var(--xds-*, var(--astryx-*, default))) so a
+  // legacy --xds-* override still wins during compat (XDS-prefix migration
+  // P2380608025). Keep the `astryx` literal in sync with packages/core/src/naming.ts
+  // (NAMESPACE) and the primary path in generateThemeRules.ts.
+  const prefix = `--astryx-${component}-padding`;
   const tokens = [];
 
   // Resolve effective inline values (inlineStart/End override inline)

--- a/packages/cli/src/commands/component.test.mjs
+++ b/packages/cli/src/commands/component.test.mjs
@@ -33,13 +33,19 @@ describe('discoverComponents', () => {
     const buttonDir = path.join(srcDir, 'Button');
     fs.mkdirSync(buttonDir, {recursive: true});
     fs.writeFileSync(path.join(buttonDir, 'XDSButton.tsx'), '');
-    fs.writeFileSync(path.join(buttonDir, 'Button.doc.mjs'), "export const docs = {\n  name: 'Button',\n  group: 'Buttons',\n};");
+    fs.writeFileSync(
+      path.join(buttonDir, 'Button.doc.mjs'),
+      "export const docs = {\n  name: 'Button',\n  group: 'Buttons',\n};",
+    );
 
     // IconButton with group: 'Buttons'
     const iconBtnDir = path.join(srcDir, 'IconButton');
     fs.mkdirSync(iconBtnDir, {recursive: true});
     fs.writeFileSync(path.join(iconBtnDir, 'XDSIconButton.tsx'), '');
-    fs.writeFileSync(path.join(iconBtnDir, 'IconButton.doc.mjs'), "export const docs = {\n  name: 'IconButton',\n  group: 'Buttons',\n};");
+    fs.writeFileSync(
+      path.join(iconBtnDir, 'IconButton.doc.mjs'),
+      "export const docs = {\n  name: 'IconButton',\n  group: 'Buttons',\n};",
+    );
 
     // Avatar with no group
     const avatarDir = path.join(srcDir, 'Avatar');
@@ -83,7 +89,10 @@ describe('discoverComponents', () => {
     const middleDir = path.join(srcDir, 'Middle');
     fs.mkdirSync(middleDir, {recursive: true});
     fs.writeFileSync(path.join(middleDir, 'XDSMiddle.tsx'), '');
-    fs.writeFileSync(path.join(middleDir, 'Middle.doc.mjs'), "export const docs = {\n  name: 'Middle',\n  group: 'Inputs',\n};");
+    fs.writeFileSync(
+      path.join(middleDir, 'Middle.doc.mjs'),
+      "export const docs = {\n  name: 'Middle',\n  group: 'Inputs',\n};",
+    );
 
     const result = discoverComponents(tmpDir);
     const keys = Object.keys(result);
@@ -129,6 +138,86 @@ describe('discoverComponents', () => {
     const result = discoverComponents(tmpDir);
     expect(result).toEqual({});
   });
+
+  // XDS-prefix migration (P2380608025, P4): source files are renamed from
+  // `XDS{Name}.tsx` to the bare `{Name}.tsx`. Discovery must find both.
+  it('discovers components from bare {Name}.tsx files (post-rename)', () => {
+    const srcDir = path.join(tmpDir, 'src');
+    const buttonDir = path.join(srcDir, 'Button');
+    fs.mkdirSync(buttonDir, {recursive: true});
+    // Bare component file (no XDS prefix) + its doc
+    fs.writeFileSync(path.join(buttonDir, 'Button.tsx'), '');
+    fs.writeFileSync(
+      path.join(buttonDir, 'Button.doc.mjs'),
+      "export const docs = {name: 'Button'};",
+    );
+
+    const result = discoverComponents(tmpDir);
+    expect(result).toEqual({Button: ['Button']});
+  });
+
+  it('discovers a mix of prefixed and bare component files', () => {
+    const srcDir = path.join(tmpDir, 'src');
+
+    const buttonDir = path.join(srcDir, 'Button');
+    fs.mkdirSync(buttonDir, {recursive: true});
+    fs.writeFileSync(path.join(buttonDir, 'Button.tsx'), ''); // bare
+    fs.writeFileSync(
+      path.join(buttonDir, 'Button.doc.mjs'),
+      "export const docs = {name: 'Button'};",
+    );
+
+    const cardDir = path.join(srcDir, 'Card');
+    fs.mkdirSync(cardDir, {recursive: true});
+    fs.writeFileSync(path.join(cardDir, 'XDSCard.tsx'), ''); // prefixed
+    fs.writeFileSync(
+      path.join(cardDir, 'Card.doc.mjs'),
+      "export const docs = {name: 'Card'};",
+    );
+
+    const result = discoverComponents(tmpDir);
+    expect(result).toEqual({Button: ['Button'], Card: ['Card']});
+  });
+
+  it('does not surface bare PascalCase helper files without a doc', () => {
+    const srcDir = path.join(tmpDir, 'src');
+    const overlayDir = path.join(srcDir, 'Overlay');
+    fs.mkdirSync(overlayDir, {recursive: true});
+    // Real component (documented) + an internal PascalCase helper (no doc).
+    fs.writeFileSync(path.join(overlayDir, 'Overlay.tsx'), '');
+    fs.writeFileSync(path.join(overlayDir, 'OverlayScrim.tsx'), '');
+    fs.writeFileSync(
+      path.join(overlayDir, 'Overlay.doc.mjs'),
+      "export const docs = {name: 'Overlay'};",
+    );
+
+    const result = discoverComponents(tmpDir);
+    // OverlayScrim has no doc, so it must NOT be surfaced as a component.
+    expect(result).toEqual({Overlay: ['Overlay']});
+  });
+
+  it('finds the source file for both prefixed and bare names', () => {
+    const srcDir = path.join(tmpDir, 'src');
+
+    const buttonDir = path.join(srcDir, 'Button');
+    fs.mkdirSync(buttonDir, {recursive: true});
+    fs.writeFileSync(path.join(buttonDir, 'Button.tsx'), '// bare');
+    fs.writeFileSync(
+      path.join(buttonDir, 'Button.doc.mjs'),
+      "export const docs = {name: 'Button'};",
+    );
+
+    const cardDir = path.join(srcDir, 'Card');
+    fs.mkdirSync(cardDir, {recursive: true});
+    fs.writeFileSync(path.join(cardDir, 'XDSCard.tsx'), '// prefixed');
+
+    expect(findComponentSource(tmpDir, 'Button')).toBe(
+      path.join(buttonDir, 'Button.tsx'),
+    );
+    expect(findComponentSource(tmpDir, 'Card')).toBe(
+      path.join(cardDir, 'XDSCard.tsx'),
+    );
+  });
 });
 
 describe('findComponentReadme', () => {
@@ -136,7 +225,10 @@ describe('findComponentReadme', () => {
     const srcDir = path.join(tmpDir, 'src');
     const compDir = path.join(srcDir, 'Button');
     fs.mkdirSync(compDir, {recursive: true});
-    fs.writeFileSync(path.join(compDir, 'Button.doc.mjs'), 'export const docs = {}');
+    fs.writeFileSync(
+      path.join(compDir, 'Button.doc.mjs'),
+      'export const docs = {}',
+    );
 
     const result = findComponentReadme(tmpDir, 'Button');
     expect(result).toBe(path.join(compDir, 'Button.doc.mjs'));
@@ -146,7 +238,10 @@ describe('findComponentReadme', () => {
     const srcDir = path.join(tmpDir, 'src');
     const nestedDir = path.join(srcDir, 'Layout', 'Container');
     fs.mkdirSync(nestedDir, {recursive: true});
-    fs.writeFileSync(path.join(nestedDir, 'Container.doc.mjs'), 'export const docs = {}');
+    fs.writeFileSync(
+      path.join(nestedDir, 'Container.doc.mjs'),
+      'export const docs = {}',
+    );
 
     const result = findComponentReadme(tmpDir, 'Container');
     expect(result).toBe(path.join(nestedDir, 'Container.doc.mjs'));
@@ -157,7 +252,10 @@ describe('findComponentReadme', () => {
     const stackDir = path.join(srcDir, 'Stack');
     fs.mkdirSync(stackDir, {recursive: true});
     fs.writeFileSync(path.join(stackDir, 'XDSStackItem.tsx'), '');
-    fs.writeFileSync(path.join(stackDir, 'Stack.doc.mjs'), 'export const docs = {}');
+    fs.writeFileSync(
+      path.join(stackDir, 'Stack.doc.mjs'),
+      'export const docs = {}',
+    );
 
     const result = findComponentReadme(tmpDir, 'StackItem');
     expect(result).toBe(path.join(stackDir, 'Stack.doc.mjs'));
@@ -361,25 +459,31 @@ describe('discoverExternalComponentsGrouped', () => {
     // AppShell with group
     const shellDir = path.join(docsDir, 'AppShell');
     fs.mkdirSync(shellDir, {recursive: true});
-    fs.writeFileSync(path.join(shellDir, 'AppShell.doc.mjs'),
-      "export const docs = {\n  name: 'AppShell',\n  group: 'App Chrome',\n};");
+    fs.writeFileSync(
+      path.join(shellDir, 'AppShell.doc.mjs'),
+      "export const docs = {\n  name: 'AppShell',\n  group: 'App Chrome',\n};",
+    );
 
     // SideNav with same group
     const navDir = path.join(docsDir, 'SideNav');
     fs.mkdirSync(navDir, {recursive: true});
-    fs.writeFileSync(path.join(navDir, 'SideNav.doc.mjs'),
-      "export const docs = {\n  name: 'SideNav',\n  group: 'App Chrome',\n};");
+    fs.writeFileSync(
+      path.join(navDir, 'SideNav.doc.mjs'),
+      "export const docs = {\n  name: 'SideNav',\n  group: 'App Chrome',\n};",
+    );
 
     // Diff with no group
     const diffDir = path.join(docsDir, 'Diff');
     fs.mkdirSync(diffDir, {recursive: true});
-    fs.writeFileSync(path.join(diffDir, 'Diff.doc.mjs'),
-      "export const docs = {\n  name: 'Diff',\n};");
+    fs.writeFileSync(
+      path.join(diffDir, 'Diff.doc.mjs'),
+      "export const docs = {\n  name: 'Diff',\n};",
+    );
 
     const result = discoverExternalComponentsGrouped(docsDir);
     expect(result).toEqual({
       'App Chrome': ['AppShell', 'SideNav'],
-      'Diff': ['Diff'],
+      Diff: ['Diff'],
     });
   });
 
@@ -392,14 +496,18 @@ describe('discoverExternalComponentsGrouped', () => {
     const docsDir = path.join(tmpDir, 'src');
     const compDir = path.join(docsDir, 'Internal');
     fs.mkdirSync(compDir, {recursive: true});
-    fs.writeFileSync(path.join(compDir, 'Internal.doc.mjs'),
-      "export const docs = {\n  name: 'Internal',\n  hidden: true,\n};");
+    fs.writeFileSync(
+      path.join(compDir, 'Internal.doc.mjs'),
+      "export const docs = {\n  name: 'Internal',\n  hidden: true,\n};",
+    );
 
-    fs.writeFileSync(path.join(docsDir, 'Visible.doc.mjs'),
-      "export const docs = {\n  name: 'Visible',\n};");
+    fs.writeFileSync(
+      path.join(docsDir, 'Visible.doc.mjs'),
+      "export const docs = {\n  name: 'Visible',\n};",
+    );
 
     const result = discoverExternalComponentsGrouped(docsDir);
-    expect(result).toEqual({'Visible': ['Visible']});
+    expect(result).toEqual({Visible: ['Visible']});
   });
 
   it('sorts groups and ungrouped alphabetically', () => {
@@ -407,18 +515,24 @@ describe('discoverExternalComponentsGrouped', () => {
 
     const zDir = path.join(docsDir, 'Zebra');
     fs.mkdirSync(zDir, {recursive: true});
-    fs.writeFileSync(path.join(zDir, 'Zebra.doc.mjs'),
-      "export const docs = {\n  name: 'Zebra',\n  group: 'Animals',\n};");
+    fs.writeFileSync(
+      path.join(zDir, 'Zebra.doc.mjs'),
+      "export const docs = {\n  name: 'Zebra',\n  group: 'Animals',\n};",
+    );
 
     const aDir = path.join(docsDir, 'Alpha');
     fs.mkdirSync(aDir, {recursive: true});
-    fs.writeFileSync(path.join(aDir, 'Alpha.doc.mjs'),
-      "export const docs = {\n  name: 'Alpha',\n};");
+    fs.writeFileSync(
+      path.join(aDir, 'Alpha.doc.mjs'),
+      "export const docs = {\n  name: 'Alpha',\n};",
+    );
 
     const bDir = path.join(docsDir, 'Bear');
     fs.mkdirSync(bDir, {recursive: true});
-    fs.writeFileSync(path.join(bDir, 'Bear.doc.mjs'),
-      "export const docs = {\n  name: 'Bear',\n  group: 'Animals',\n};");
+    fs.writeFileSync(
+      path.join(bDir, 'Bear.doc.mjs'),
+      "export const docs = {\n  name: 'Bear',\n  group: 'Animals',\n};",
+    );
 
     const result = discoverExternalComponentsGrouped(docsDir);
     const keys = Object.keys(result);
@@ -474,30 +588,44 @@ describe('findExternalComponentDoc', () => {
   });
 });
 
-
 describe('searchComponents', () => {
   it('finds Collapsible when searching "accordion"', async () => {
-    const {searchComponents, discoverComponents} = await import('./component/index.mjs');
+    const {searchComponents, discoverComponents} =
+      await import('./component/index.mjs');
     const components = discoverComponents('packages/core');
-    const results = await searchComponents('accordion', 'packages/core', components);
+    const results = await searchComponents(
+      'accordion',
+      'packages/core',
+      components,
+    );
     expect(results.length).toBeGreaterThan(0);
     expect(results[0].name).toBe('Collapsible');
     expect(results[0].score).toBe(90);
   });
 
   it('finds Dialog when searching "modal"', async () => {
-    const {searchComponents, discoverComponents} = await import('./component/index.mjs');
+    const {searchComponents, discoverComponents} =
+      await import('./component/index.mjs');
     const components = discoverComponents('packages/core');
-    const results = await searchComponents('modal', 'packages/core', components);
+    const results = await searchComponents(
+      'modal',
+      'packages/core',
+      components,
+    );
     const dialog = results.find(r => r.name === 'Dialog');
     expect(dialog).toBeDefined();
     expect(dialog.score).toBe(90);
   });
 
   it('returns multiple matches for ambiguous terms like "select"', async () => {
-    const {searchComponents, discoverComponents} = await import('./component/index.mjs');
+    const {searchComponents, discoverComponents} =
+      await import('./component/index.mjs');
     const components = discoverComponents('packages/core');
-    const results = await searchComponents('select', 'packages/core', components);
+    const results = await searchComponents(
+      'select',
+      'packages/core',
+      components,
+    );
     const top90 = results.filter(r => r.score === 90);
     expect(top90.length).toBeGreaterThan(1);
     const names = top90.map(r => r.name);
@@ -505,17 +633,27 @@ describe('searchComponents', () => {
   });
 
   it('finds exact name matches with score 100', async () => {
-    const {searchComponents, discoverComponents} = await import('./component/index.mjs');
+    const {searchComponents, discoverComponents} =
+      await import('./component/index.mjs');
     const components = discoverComponents('packages/core');
-    const results = await searchComponents('Button', 'packages/core', components);
+    const results = await searchComponents(
+      'Button',
+      'packages/core',
+      components,
+    );
     expect(results[0].name).toBe('Button');
     expect(results[0].score).toBe(100);
   });
 
   it('returns empty array for complete gibberish', async () => {
-    const {searchComponents, discoverComponents} = await import('./component/index.mjs');
+    const {searchComponents, discoverComponents} =
+      await import('./component/index.mjs');
     const components = discoverComponents('packages/core');
-    const results = await searchComponents('zzzzzzzzzzz', 'packages/core', components);
+    const results = await searchComponents(
+      'zzzzzzzzzzz',
+      'packages/core',
+      components,
+    );
     expect(results.length).toBe(0);
   });
 });

--- a/packages/cli/src/lib/component-discovery.mjs
+++ b/packages/cli/src/lib/component-discovery.mjs
@@ -9,6 +9,58 @@ import * as path from 'node:path';
 
 const SKIP_DIRS = new Set(['hooks', 'utils', '__tests__', 'node_modules']);
 
+// Component source files are named `XDS{Name}.tsx` today. The XDS-prefix
+// migration (P2380608025, P4) renames them to the bare `{Name}.tsx` form, so
+// discovery must recognize BOTH. The `XDS` prefix has historically doubled as
+// a "this is a top-level component" marker, so naively matching all PascalCase
+// `.tsx` files would surface internal helpers that happen to be PascalCase
+// (`OverlayScrim.tsx`, `PowerSearchEditPopover.tsx`, ...). To avoid that
+// regression, a BARE-named file is only treated as a component when a matching
+// doc file exists for it (`{Name}.doc.mjs` or `XDS{Name}.doc.mjs` in the same
+// directory). Prefixed `XDS{Name}.tsx` files keep their existing behavior.
+const PREFIXED_COMPONENT_FILE_RE = /^XDS[A-Z]\w+\.tsx$/;
+const BARE_COMPONENT_FILE_RE = /^[A-Z]\w+\.tsx$/;
+
+/**
+ * Whether a filename looks like a component source file, excluding tests,
+ * Context files, and (implicitly, via the uppercase-first match) `use*` hooks.
+ *
+ * Recognizes both the current `XDSButton.tsx` form and the post-migration
+ * bare `Button.tsx` form. Bare matches additionally require a sibling doc file
+ * so internal PascalCase helpers are not misclassified as components.
+ *
+ * @param {string} fileName
+ * @param {string} dirPath — directory containing the file (for the bare-name doc check)
+ * @returns {boolean}
+ */
+function isComponentSourceFile(fileName, dirPath) {
+  if (fileName.includes('.test.') || fileName.includes('Context.')) {
+    return false;
+  }
+  if (PREFIXED_COMPONENT_FILE_RE.test(fileName)) {
+    return true;
+  }
+  if (BARE_COMPONENT_FILE_RE.test(fileName)) {
+    const base = fileName.replace(/\.tsx$/, '');
+    return (
+      fs.existsSync(path.join(dirPath, `${base}.doc.mjs`)) ||
+      fs.existsSync(path.join(dirPath, `XDS${base}.doc.mjs`))
+    );
+  }
+  return false;
+}
+
+/**
+ * Strip the optional `XDS` prefix and `.tsx` suffix to get the bare component
+ * name. Works for both `XDSButton.tsx` and `Button.tsx`.
+ *
+ * @param {string} fileName
+ * @returns {string}
+ */
+function componentNameFromFile(fileName) {
+  return fileName.replace(/^XDS/, '').replace(/\.tsx$/, '');
+}
+
 // Matches the top-level `group: 'GroupName'` field in a .doc.mjs file.
 // Only matches at shallow indentation (≤ 4 spaces from line start) to avoid
 // picking up nested `group:` fields inside prop descriptions.
@@ -64,11 +116,7 @@ export function discoverComponents(coreDir) {
     for (const entry of entries) {
       if (entry.isDirectory()) {
         results.push(...collectXDSFiles(path.join(dirPath, entry.name)));
-      } else if (
-        /^XDS[A-Z]\w+\.tsx$/.test(entry.name) &&
-        !entry.name.includes('.test.') &&
-        !entry.name.includes('Context.')
-      ) {
+      } else if (isComponentSourceFile(entry.name, dirPath)) {
         results.push(entry.name);
       }
     }
@@ -96,7 +144,7 @@ export function discoverComponents(coreDir) {
     if (hidden) continue;
 
     for (const fileName of xdsFiles) {
-      const componentName = fileName.replace(/^XDS/, '').replace(/\.tsx$/, '');
+      const componentName = componentNameFromFile(fileName);
       if (hiddenComponents.has(componentName)) continue;
 
       // Check for a per-component doc file that overrides the directory group
@@ -222,15 +270,21 @@ export function findComponentReadme(coreDir, name) {
  */
 export function findComponentSource(coreDir, name) {
   const srcDir = path.join(coreDir, 'src');
-  const xdsName = `XDS${name}.tsx`;
+  // Try the prefixed form (`XDSButton.tsx`) first since that is the current
+  // on-disk convention, then the bare form (`Button.tsx`) that the XDS-prefix
+  // migration (P4) renames to. Listing the prefixed name first keeps behavior
+  // identical until files are actually renamed.
+  const candidateFiles = [`XDS${name}.tsx`, `${name}.tsx`];
 
   function searchDir(dirPath) {
     if (!fs.existsSync(dirPath)) return null;
     const entries = fs.readdirSync(dirPath, {withFileTypes: true});
 
-    // Check for exact match first
-    const exact = path.join(dirPath, xdsName);
-    if (fs.existsSync(exact)) return exact;
+    // Check for an exact match (prefixed or bare) first
+    for (const candidate of candidateFiles) {
+      const exact = path.join(dirPath, candidate);
+      if (fs.existsSync(exact)) return exact;
+    }
 
     // Recurse into subdirectories
     for (const entry of entries) {

--- a/packages/core/docs.mjs
+++ b/packages/core/docs.mjs
@@ -81,10 +81,12 @@ function findDocByComponent(name) {
 }
 
 function hasXDSFile(dir, name) {
-  const target = `XDS${name}.tsx`;
+  // Match the current `XDS{Name}.tsx` convention and the post-migration bare
+  // `{Name}.tsx` form (XDS-prefix migration P2380608025, P4).
+  const targets = [`XDS${name}.tsx`, `${name}.tsx`];
   try {
     for (const f of fs.readdirSync(dir, {withFileTypes: true})) {
-      if (f.name === target) return true;
+      if (targets.includes(f.name)) return true;
       if (f.isDirectory() && hasXDSFile(path.join(dir, f.name), name)) return true;
     }
   } catch {}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -51,6 +51,11 @@
       "types": "./src/tailwind-theme.css.d.ts",
       "default": "./src/tailwind-theme.css"
     },
+    "./naming": {
+      "source": "./src/naming.ts",
+      "types": "./dist/naming.d.ts",
+      "default": "./dist/naming.js"
+    },
     "./theme/tokens": {
       "source": "./src/theme/tokens.ts",
       "types": "./dist/theme/tokens.d.ts",

--- a/packages/core/src/AlertDialog/index.ts
+++ b/packages/core/src/AlertDialog/index.ts
@@ -7,3 +7,19 @@ export type {XDSAlertDialogProps} from './XDSAlertDialog';
 
 export {useXDSImperativeAlertDialog} from './useXDSImperativeAlertDialog';
 export type {XDSImperativeAlertDialogReturn} from './useXDSImperativeAlertDialog';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSAlertDialog as AlertDialog,
+  useXDSImperativeAlertDialog as useImperativeAlertDialog,
+} from '.';
+export type {
+  XDSAlertDialogProps as AlertDialogProps,
+  XDSImperativeAlertDialogReturn as ImperativeAlertDialogReturn,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/AppShell/index.ts
+++ b/packages/core/src/AppShell/index.ts
@@ -24,3 +24,24 @@ export {
   XDSAppShellMobileContext,
 } from './XDSAppShellMobileContext';
 export type {XDSAppShellMobileContextValue} from './XDSAppShellMobileContext';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSAppShell as AppShell,
+  XDSAppShellMobileContext as AppShellMobileContext,
+  useXDSAppShellMobile as useAppShellMobile,
+} from '.';
+export type {
+  XDSAppShellBreakpoint as AppShellBreakpoint,
+  XDSAppShellMobileContextValue as AppShellMobileContextValue,
+  XDSAppShellProps as AppShellProps,
+  XDSAppShellVariant as AppShellVariant,
+  XDSAppShellVariantMap as AppShellVariantMap,
+  XDSMobileNavConfig as MobileNavConfig,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/AspectRatio/index.ts
+++ b/packages/core/src/AspectRatio/index.ts
@@ -13,3 +13,18 @@
 
 export {XDSAspectRatio} from './XDSAspectRatio';
 export type {XDSAspectRatioProps, XDSAspectRatioShape} from './XDSAspectRatio';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSAspectRatio as AspectRatio,
+} from '.';
+export type {
+  XDSAspectRatioProps as AspectRatioProps,
+  XDSAspectRatioShape as AspectRatioShape,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Avatar/index.ts
+++ b/packages/core/src/Avatar/index.ts
@@ -19,3 +19,22 @@ export type {
   XDSAvatarStatusDotVariant,
   XDSAvatarStatusDotVariantMap,
 } from './XDSAvatarStatusDot';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSAvatar as Avatar,
+  XDSAvatarStatusDot as AvatarStatusDot,
+} from '.';
+export type {
+  XDSAvatarProps as AvatarProps,
+  XDSAvatarSize as AvatarSize,
+  XDSAvatarStatusDotProps as AvatarStatusDotProps,
+  XDSAvatarStatusDotVariant as AvatarStatusDotVariant,
+  XDSAvatarStatusDotVariantMap as AvatarStatusDotVariantMap,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/AvatarGroup/index.ts
+++ b/packages/core/src/AvatarGroup/index.ts
@@ -18,3 +18,21 @@ export type {XDSAvatarGroupOverflowProps} from './XDSAvatarGroupOverflow';
 
 export {useXDSAvatarGroup} from './XDSAvatarGroupContext';
 export type {XDSAvatarGroupContextValue} from './XDSAvatarGroupContext';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSAvatarGroup as AvatarGroup,
+  XDSAvatarGroupOverflow as AvatarGroupOverflow,
+  useXDSAvatarGroup as useAvatarGroup,
+} from '.';
+export type {
+  XDSAvatarGroupContextValue as AvatarGroupContextValue,
+  XDSAvatarGroupOverflowProps as AvatarGroupOverflowProps,
+  XDSAvatarGroupProps as AvatarGroupProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Badge/index.ts
+++ b/packages/core/src/Badge/index.ts
@@ -17,3 +17,19 @@ export type {
   XDSBadgeVariant,
   XDSBadgeVariantMap,
 } from './XDSBadge';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSBadge as Badge,
+} from '.';
+export type {
+  XDSBadgeProps as BadgeProps,
+  XDSBadgeVariant as BadgeVariant,
+  XDSBadgeVariantMap as BadgeVariantMap,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Banner/index.ts
+++ b/packages/core/src/Banner/index.ts
@@ -19,3 +19,21 @@ export type {
   XDSBannerContainer,
   XDSBannerContainerMap,
 } from './XDSBanner';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSBanner as Banner,
+} from '.';
+export type {
+  XDSBannerContainer as BannerContainer,
+  XDSBannerContainerMap as BannerContainerMap,
+  XDSBannerProps as BannerProps,
+  XDSBannerStatus as BannerStatus,
+  XDSBannerStatusMap as BannerStatusMap,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Blockquote/index.ts
+++ b/packages/core/src/Blockquote/index.ts
@@ -13,3 +13,17 @@
 
 export {XDSBlockquote} from './XDSBlockquote';
 export type {XDSBlockquoteProps} from './XDSBlockquote';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSBlockquote as Blockquote,
+} from '.';
+export type {
+  XDSBlockquoteProps as BlockquoteProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Breadcrumbs/index.ts
+++ b/packages/core/src/Breadcrumbs/index.ts
@@ -14,3 +14,21 @@ export type {
 } from './XDSBreadcrumbs';
 export {XDSBreadcrumbItem} from './XDSBreadcrumbItem';
 export type {XDSBreadcrumbItemProps} from './XDSBreadcrumbItem';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSBreadcrumbItem as BreadcrumbItem,
+  XDSBreadcrumbs as Breadcrumbs,
+} from '.';
+export type {
+  XDSBreadcrumbItemProps as BreadcrumbItemProps,
+  XDSBreadcrumbsProps as BreadcrumbsProps,
+  XDSBreadcrumbsVariant as BreadcrumbsVariant,
+  XDSBreadcrumbsVariantMap as BreadcrumbsVariantMap,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Button/index.ts
+++ b/packages/core/src/Button/index.ts
@@ -18,3 +18,20 @@ export type {
   XDSButtonSize,
 } from './XDSButton';
 export type {XDSButtonVariantMap} from './XDSButton';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSButton as Button,
+} from '.';
+export type {
+  XDSButtonProps as ButtonProps,
+  XDSButtonSize as ButtonSize,
+  XDSButtonVariant as ButtonVariant,
+  XDSButtonVariantMap as ButtonVariantMap,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/ButtonGroup/index.ts
+++ b/packages/core/src/ButtonGroup/index.ts
@@ -17,3 +17,20 @@ export type {
   XDSButtonGroupOrientation,
   XDSButtonGroupContextValue,
 } from './XDSButtonGroupContext';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSButtonGroup as ButtonGroup,
+  useXDSButtonGroup as useButtonGroup,
+} from '.';
+export type {
+  XDSButtonGroupContextValue as ButtonGroupContextValue,
+  XDSButtonGroupOrientation as ButtonGroupOrientation,
+  XDSButtonGroupProps as ButtonGroupProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Calendar/index.ts
+++ b/packages/core/src/Calendar/index.ts
@@ -49,3 +49,17 @@ export {
 
 // Re-export theme styles for customization
 
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSCalendar as Calendar,
+} from '.';
+export type {
+  XDSCalendarHandle as CalendarHandle,
+  XDSCalendarProps as CalendarProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Card/index.ts
+++ b/packages/core/src/Card/index.ts
@@ -13,3 +13,18 @@
 
 export {XDSCard} from './XDSCard';
 export type {XDSCardProps, XDSCardVariant, SizeValue} from './XDSCard';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSCard as Card,
+} from '.';
+export type {
+  XDSCardProps as CardProps,
+  XDSCardVariant as CardVariant,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Carousel/index.ts
+++ b/packages/core/src/Carousel/index.ts
@@ -11,3 +11,17 @@
 
 export {XDSCarousel} from './XDSCarousel';
 export type {XDSCarouselProps} from './XDSCarousel';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSCarousel as Carousel,
+} from '.';
+export type {
+  XDSCarouselProps as CarouselProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Center/index.ts
+++ b/packages/core/src/Center/index.ts
@@ -13,3 +13,17 @@
 
 export {XDSCenter} from './XDSCenter';
 export type {XDSCenterProps, XDSCenterAxis, CenterAxis} from './XDSCenter';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSCenter as Center,
+} from '.';
+export type {
+  XDSCenterProps as CenterProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Chat/index.ts
+++ b/packages/core/src/Chat/index.ts
@@ -111,3 +111,63 @@ export type {
 
 export {XDSChatDictationButton} from './XDSChatDictationButton';
 export type {XDSChatDictationButtonProps} from './XDSChatDictationButton';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSChatComposer as ChatComposer,
+  XDSChatComposerDrawer as ChatComposerDrawer,
+  XDSChatComposerInput as ChatComposerInput,
+  XDSChatComposerTokenElement as ChatComposerTokenElement,
+  XDSChatDictationButton as ChatDictationButton,
+  XDSChatLayout as ChatLayout,
+  XDSChatLayoutScrollButton as ChatLayoutScrollButton,
+  XDSChatMessage as ChatMessage,
+  XDSChatMessageBubble as ChatMessageBubble,
+  XDSChatMessageList as ChatMessageList,
+  XDSChatMessageMetadata as ChatMessageMetadata,
+  XDSChatSendButton as ChatSendButton,
+  XDSChatSystemMessage as ChatSystemMessage,
+  XDSChatTokenizedText as ChatTokenizedText,
+  XDSChatToolCalls as ChatToolCalls,
+  useXDSChatComposerTokens as useChatComposerTokens,
+  useXDSChatDictation as useChatDictation,
+  useXDSChatLayoutContext as useChatLayoutContext,
+  useXDSChatNewMessages as useChatNewMessages,
+  useXDSChatPasteAsToken as useChatPasteAsToken,
+  useXDSChatStreamScroll as useChatStreamScroll,
+} from '.';
+export type {
+  XDSChatComposerDensity as ChatComposerDensity,
+  XDSChatComposerDrawerProps as ChatComposerDrawerProps,
+  XDSChatComposerInputHandle as ChatComposerInputHandle,
+  XDSChatComposerInputProps as ChatComposerInputProps,
+  XDSChatComposerProps as ChatComposerProps,
+  XDSChatComposerStatus as ChatComposerStatus,
+  XDSChatComposerToken as ChatComposerToken,
+  XDSChatComposerTrigger as ChatComposerTrigger,
+  XDSChatComposerTriggerItem as ChatComposerTriggerItem,
+  XDSChatDensity as ChatDensity,
+  XDSChatDictationButtonProps as ChatDictationButtonProps,
+  XDSChatLayoutProps as ChatLayoutProps,
+  XDSChatLayoutScrollButtonProps as ChatLayoutScrollButtonProps,
+  XDSChatMessageBubbleProps as ChatMessageBubbleProps,
+  XDSChatMessageBubbleVariant as ChatMessageBubbleVariant,
+  XDSChatMessageListProps as ChatMessageListProps,
+  XDSChatMessageMetadataProps as ChatMessageMetadataProps,
+  XDSChatMessageProps as ChatMessageProps,
+  XDSChatMessageSender as ChatMessageSender,
+  XDSChatMessageStatus as ChatMessageStatus,
+  XDSChatSendButtonProps as ChatSendButtonProps,
+  XDSChatSystemMessageProps as ChatSystemMessageProps,
+  XDSChatSystemMessageVariant as ChatSystemMessageVariant,
+  XDSChatTokenizedTextProps as ChatTokenizedTextProps,
+  XDSChatToolCallItem as ChatToolCallItem,
+  XDSChatToolCallStatus as ChatToolCallStatus,
+  XDSChatToolCallsProps as ChatToolCallsProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/CheckboxInput/index.ts
+++ b/packages/core/src/CheckboxInput/index.ts
@@ -16,3 +16,18 @@ export type {
   XDSCheckboxInputProps,
   XDSCheckboxInputSize,
 } from './XDSCheckboxInput';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSCheckboxInput as CheckboxInput,
+} from '.';
+export type {
+  XDSCheckboxInputProps as CheckboxInputProps,
+  XDSCheckboxInputSize as CheckboxInputSize,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/CheckboxList/index.ts
+++ b/packages/core/src/CheckboxList/index.ts
@@ -15,3 +15,19 @@ export {XDSCheckboxList} from './XDSCheckboxList';
 export type {XDSCheckboxListProps} from './XDSCheckboxList';
 export {XDSCheckboxListItem} from './XDSCheckboxListItem';
 export type {XDSCheckboxListItemProps} from './XDSCheckboxListItem';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSCheckboxList as CheckboxList,
+  XDSCheckboxListItem as CheckboxListItem,
+} from '.';
+export type {
+  XDSCheckboxListItemProps as CheckboxListItemProps,
+  XDSCheckboxListProps as CheckboxListProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Citation/index.ts
+++ b/packages/core/src/Citation/index.ts
@@ -11,3 +11,18 @@
 
 export {XDSCitation} from './XDSCitation';
 export type {XDSCitationProps, XDSCitationSource} from './XDSCitation';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSCitation as Citation,
+} from '.';
+export type {
+  XDSCitationProps as CitationProps,
+  XDSCitationSource as CitationSource,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/ClickableCard/index.ts
+++ b/packages/core/src/ClickableCard/index.ts
@@ -13,3 +13,17 @@
 
 export {XDSClickableCard} from './XDSClickableCard';
 export type {XDSClickableCardProps} from './XDSClickableCard';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSClickableCard as ClickableCard,
+} from '.';
+export type {
+  XDSClickableCardProps as ClickableCardProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Code/index.ts
+++ b/packages/core/src/Code/index.ts
@@ -8,3 +8,17 @@
  */
 
 export {XDSCode, type XDSCodeProps} from './XDSCode';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSCode as Code,
+} from '.';
+export type {
+  XDSCodeProps as CodeProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/CodeBlock/index.ts
+++ b/packages/core/src/CodeBlock/index.ts
@@ -33,3 +33,19 @@ export {
   cleanupRanges,
 } from './highlightRanges';
 export {ensureHighlightStyles, TOKEN_TYPES} from './highlightStyles';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSCode as Code,
+  XDSCodeBlock as CodeBlock,
+} from '.';
+export type {
+  XDSCodeBlockProps as CodeBlockProps,
+  XDSCodeProps as CodeProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Collapsible/index.ts
+++ b/packages/core/src/Collapsible/index.ts
@@ -23,3 +23,21 @@ export type {
   UseXDSCollapsibleOptions,
   UseXDSCollapsibleReturn,
 } from './useXDSCollapsible';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSCollapsible as Collapsible,
+  XDSCollapsibleGroup as CollapsibleGroup,
+  useXDSCollapsible as useCollapsible,
+} from '.';
+export type {
+  XDSCollapsibleConfig as CollapsibleConfig,
+  XDSCollapsibleGroupProps as CollapsibleGroupProps,
+  XDSCollapsibleProps as CollapsibleProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/CommandPalette/index.ts
+++ b/packages/core/src/CommandPalette/index.ts
@@ -34,3 +34,29 @@ export type {XDSCommandPaletteEmptyProps} from './XDSCommandPaletteEmpty';
 
 export {useCommandPaletteContext} from './CommandPaletteContext';
 export type {CommandPaletteContextValue} from './CommandPaletteContext';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSCommandPalette as CommandPalette,
+  XDSCommandPaletteEmpty as CommandPaletteEmpty,
+  XDSCommandPaletteFooter as CommandPaletteFooter,
+  XDSCommandPaletteGroup as CommandPaletteGroup,
+  XDSCommandPaletteInput as CommandPaletteInput,
+  XDSCommandPaletteItem as CommandPaletteItem,
+  XDSCommandPaletteList as CommandPaletteList,
+} from '.';
+export type {
+  XDSCommandPaletteEmptyProps as CommandPaletteEmptyProps,
+  XDSCommandPaletteFooterProps as CommandPaletteFooterProps,
+  XDSCommandPaletteGroupProps as CommandPaletteGroupProps,
+  XDSCommandPaletteInputProps as CommandPaletteInputProps,
+  XDSCommandPaletteItemProps as CommandPaletteItemProps,
+  XDSCommandPaletteListProps as CommandPaletteListProps,
+  XDSCommandPaletteProps as CommandPaletteProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/ContextMenu/index.ts
+++ b/packages/core/src/ContextMenu/index.ts
@@ -20,3 +20,23 @@ export {
   XDSDropdownMenuItem as XDSContextMenuItem,
   type XDSDropdownMenuItemProps as XDSContextMenuItemProps,
 } from '../DropdownMenu/XDSDropdownMenuItem';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSContextMenu as ContextMenu,
+  XDSContextMenuItem as ContextMenuItem,
+} from '.';
+export type {
+  XDSContextMenuDivider as ContextMenuDivider,
+  XDSContextMenuItemData as ContextMenuItemData,
+  XDSContextMenuItemProps as ContextMenuItemProps,
+  XDSContextMenuOption as ContextMenuOption,
+  XDSContextMenuProps as ContextMenuProps,
+  XDSContextMenuSection as ContextMenuSection,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/DateInput/index.ts
+++ b/packages/core/src/DateInput/index.ts
@@ -16,3 +16,20 @@ export type {
   XDSDateInputStatus,
   XDSDateInputStatusType,
 } from './XDSDateInput';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSDateInput as DateInput,
+} from '.';
+export type {
+  XDSDateInputProps as DateInputProps,
+  XDSDateInputSize as DateInputSize,
+  XDSDateInputStatus as DateInputStatus,
+  XDSDateInputStatusType as DateInputStatusType,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/DateRangeInput/index.ts
+++ b/packages/core/src/DateRangeInput/index.ts
@@ -18,3 +18,20 @@ export type {
   DateRange,
   DateRangePreset,
 } from './XDSDateRangeInput';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSDateRangeInput as DateRangeInput,
+} from '.';
+export type {
+  XDSDateRangeInputProps as DateRangeInputProps,
+  XDSDateRangeInputSize as DateRangeInputSize,
+  XDSDateRangeInputStatus as DateRangeInputStatus,
+  XDSDateRangeInputStatusType as DateRangeInputStatusType,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/DateTimeInput/index.ts
+++ b/packages/core/src/DateTimeInput/index.ts
@@ -18,3 +18,21 @@ export type {
   XDSDateTimeInputStatusType,
   ISODateTimeString,
 } from './XDSDateTimeInput';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSDateTimeInput as DateTimeInput,
+} from '.';
+export type {
+  XDSDateTimeInputHourFormat as DateTimeInputHourFormat,
+  XDSDateTimeInputProps as DateTimeInputProps,
+  XDSDateTimeInputSize as DateTimeInputSize,
+  XDSDateTimeInputStatus as DateTimeInputStatus,
+  XDSDateTimeInputStatusType as DateTimeInputStatusType,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Dialog/index.ts
+++ b/packages/core/src/Dialog/index.ts
@@ -25,3 +25,25 @@ export type {XDSDialogHeaderProps} from './XDSDialogHeader';
 
 export {useXDSImperativeDialog} from './useXDSImperativeDialog';
 export type {XDSImperativeDialogReturn} from './useXDSImperativeDialog';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSDialog as Dialog,
+  XDSDialogHeader as DialogHeader,
+  useXDSImperativeDialog as useImperativeDialog,
+} from '.';
+export type {
+  XDSDialogHeaderProps as DialogHeaderProps,
+  XDSDialogPosition as DialogPosition,
+  XDSDialogProps as DialogProps,
+  XDSDialogPurpose as DialogPurpose,
+  XDSDialogVariant as DialogVariant,
+  XDSDialogVariantMap as DialogVariantMap,
+  XDSImperativeDialogReturn as ImperativeDialogReturn,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Divider/index.ts
+++ b/packages/core/src/Divider/index.ts
@@ -17,3 +17,19 @@ export type {
   XDSDividerVariant,
   XDSDividerVariantMap,
 } from './XDSDivider';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSDivider as Divider,
+} from '.';
+export type {
+  XDSDividerProps as DividerProps,
+  XDSDividerVariant as DividerVariant,
+  XDSDividerVariantMap as DividerVariantMap,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/DropdownMenu/index.ts
+++ b/packages/core/src/DropdownMenu/index.ts
@@ -22,3 +22,24 @@ export {
   XDSDropdownMenuItem,
   type XDSDropdownMenuItemProps,
 } from './XDSDropdownMenuItem';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSDropdownMenu as DropdownMenu,
+  XDSDropdownMenuItem as DropdownMenuItem,
+} from '.';
+export type {
+  XDSDropdownMenuButtonProps as DropdownMenuButtonProps,
+  XDSDropdownMenuDivider as DropdownMenuDivider,
+  XDSDropdownMenuItemData as DropdownMenuItemData,
+  XDSDropdownMenuItemProps as DropdownMenuItemProps,
+  XDSDropdownMenuOption as DropdownMenuOption,
+  XDSDropdownMenuProps as DropdownMenuProps,
+  XDSDropdownMenuSection as DropdownMenuSection,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/EmptyState/index.ts
+++ b/packages/core/src/EmptyState/index.ts
@@ -6,3 +6,17 @@
 
 export {XDSEmptyState} from './XDSEmptyState';
 export type {XDSEmptyStateProps} from './XDSEmptyState';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSEmptyState as EmptyState,
+} from '.';
+export type {
+  XDSEmptyStateProps as EmptyStateProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Field/index.ts
+++ b/packages/core/src/Field/index.ts
@@ -40,3 +40,29 @@ export {
 
 // Shared input components
 export {XDSInputClearButton} from './XDSInputClearButton';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSField as Field,
+  XDSFieldLabel as FieldLabel,
+  XDSFieldStatus as FieldStatus,
+  XDSInputClearButton as InputClearButton,
+} from '.';
+export type {
+  XDSFieldLabelProps as FieldLabelProps,
+  XDSFieldProps as FieldProps,
+  XDSFieldStatusInput as FieldStatusInput,
+  XDSFieldStatusProps as FieldStatusProps,
+  XDSFieldStatusType as FieldStatusType,
+  XDSFieldStatusVariant as FieldStatusVariant,
+  XDSFieldStatusVariantMap as FieldStatusVariantMap,
+  XDSInputSize as InputSize,
+  XDSInputStatus as InputStatus,
+  XDSInputStatusType as InputStatusType,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/FieldStatus/index.ts
+++ b/packages/core/src/FieldStatus/index.ts
@@ -15,3 +15,19 @@ export type {
   XDSFieldStatusVariant,
   XDSFieldStatusVariantMap,
 } from './XDSFieldStatus';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSFieldStatus as FieldStatus,
+} from '.';
+export type {
+  XDSFieldStatusProps as FieldStatusProps,
+  XDSFieldStatusVariant as FieldStatusVariant,
+  XDSFieldStatusVariantMap as FieldStatusVariantMap,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/FileInput/index.ts
+++ b/packages/core/src/FileInput/index.ts
@@ -17,3 +17,19 @@ export type {
   XDSFileInputStatus,
   XDSFileInputStatusType,
 } from './XDSFileInput';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSFileInput as FileInput,
+} from '.';
+export type {
+  XDSFileInputProps as FileInputProps,
+  XDSFileInputStatus as FileInputStatus,
+  XDSFileInputStatusType as FileInputStatusType,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/FormLayout/index.ts
+++ b/packages/core/src/FormLayout/index.ts
@@ -15,3 +15,19 @@ export {XDSFormLayout} from './XDSFormLayout';
 export type {XDSFormLayoutProps} from './XDSFormLayout';
 export type {XDSFormLayoutDirection} from './XDSFormLayoutContext';
 export {XDSFormLayoutContext} from './XDSFormLayoutContext';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSFormLayout as FormLayout,
+  XDSFormLayoutContext as FormLayoutContext,
+} from '.';
+export type {
+  XDSFormLayoutDirection as FormLayoutDirection,
+  XDSFormLayoutProps as FormLayoutProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Grid/index.ts
+++ b/packages/core/src/Grid/index.ts
@@ -16,3 +16,20 @@ export type {XDSGridProps, XDSGridColumns, GridAlignment} from './XDSGrid';
 
 export {XDSGridSpan} from './XDSGridSpan';
 export type {XDSGridSpanProps} from './XDSGridSpan';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSGrid as Grid,
+  XDSGridSpan as GridSpan,
+} from '.';
+export type {
+  XDSGridColumns as GridColumns,
+  XDSGridProps as GridProps,
+  XDSGridSpanProps as GridSpanProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/HStack/index.ts
+++ b/packages/core/src/HStack/index.ts
@@ -8,3 +8,17 @@
  */
 
 export {XDSHStack, type XDSHStackProps} from './XDSHStack';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSHStack as HStack,
+} from '.';
+export type {
+  XDSHStackProps as HStackProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Heading/index.ts
+++ b/packages/core/src/Heading/index.ts
@@ -13,3 +13,18 @@ export {
   type XDSHeadingLevel,
   type XDSHeadingType,
 } from './XDSHeading';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSHeading as Heading,
+} from '.';
+export type {
+  XDSHeadingProps as HeadingProps,
+  XDSHeadingType as HeadingType,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/HoverCard/index.ts
+++ b/packages/core/src/HoverCard/index.ts
@@ -22,3 +22,20 @@ export type {
 // HoverCard component
 export {XDSHoverCard} from './XDSHoverCard';
 export type {XDSHoverCardProps} from './XDSHoverCard';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSHoverCard as HoverCard,
+  useXDSHoverCard as useHoverCard,
+} from '.';
+export type {
+  XDSHoverCardOptions as HoverCardOptions,
+  XDSHoverCardProps as HoverCardProps,
+  XDSHoverCardReturn as HoverCardReturn,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Icon/index.ts
+++ b/packages/core/src/Icon/index.ts
@@ -27,3 +27,22 @@ export {
   resetIcons,
 } from './globalIconRegistry';
 export type {XDSIconName, XDSIconRegistry} from './globalIconRegistry';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSIcon as Icon,
+} from '.';
+export type {
+  XDSIconColor as IconColor,
+  XDSIconName as IconName,
+  XDSIconProps as IconProps,
+  XDSIconRegistry as IconRegistry,
+  XDSIconSize as IconSize,
+  XDSIconType as IconType,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/IconButton/index.ts
+++ b/packages/core/src/IconButton/index.ts
@@ -13,3 +13,17 @@
 
 export {XDSIconButton} from './XDSIconButton';
 export type {XDSIconButtonProps} from './XDSIconButton';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSIconButton as IconButton,
+} from '.';
+export type {
+  XDSIconButtonProps as IconButtonProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/InputGroup/index.ts
+++ b/packages/core/src/InputGroup/index.ts
@@ -16,3 +16,21 @@ export {XDSInputGroupText} from './XDSInputGroupText';
 export type {XDSInputGroupTextProps} from './XDSInputGroupText';
 
 export {useXDSInputGroup} from './XDSInputGroupContext';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSInputGroup as InputGroup,
+  XDSInputGroupText as InputGroupText,
+  useXDSInputGroup as useInputGroup,
+} from '.';
+export type {
+  XDSInputGroupProps as InputGroupProps,
+  XDSInputGroupSize as InputGroupSize,
+  XDSInputGroupTextProps as InputGroupTextProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/InteractiveRoleContext/index.ts
+++ b/packages/core/src/InteractiveRoleContext/index.ts
@@ -13,3 +13,15 @@ export {
   XDSInteractiveRoleContext,
   useXDSInteractiveRoleContext,
 } from './XDSInteractiveRoleContext';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSInteractiveRoleContext as InteractiveRoleContext,
+  useXDSInteractiveRoleContext as useInteractiveRoleContext,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Item/index.ts
+++ b/packages/core/src/Item/index.ts
@@ -11,3 +11,19 @@
 
 export {XDSItem} from './XDSItem';
 export type {XDSItemProps, XDSItemAlign, XDSItemDensity} from './XDSItem';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSItem as Item,
+} from '.';
+export type {
+  XDSItemAlign as ItemAlign,
+  XDSItemDensity as ItemDensity,
+  XDSItemProps as ItemProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Kbd/index.ts
+++ b/packages/core/src/Kbd/index.ts
@@ -9,3 +9,17 @@
 
 export {XDSKbd} from './XDSKbd';
 export type {XDSKbdProps} from './XDSKbd';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSKbd as Kbd,
+} from '.';
+export type {
+  XDSKbdProps as KbdProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Layer/index.ts
+++ b/packages/core/src/Layer/index.ts
@@ -63,3 +63,34 @@ export type {
   XDSTooltipReturn,
   XDSTooltipProps,
 } from '../Tooltip';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSHoverCard as HoverCard,
+  XDSLayerContext as LayerContext,
+  XDSLayerProvider as LayerProvider,
+  XDSPopover as Popover,
+  XDSTooltip as Tooltip,
+  useXDSHoverCard as useHoverCard,
+  useXDSLayer as useLayer,
+  useXDSLayerContext as useLayerContext,
+  useXDSPopover as usePopover,
+  useXDSTooltip as useTooltip,
+} from '.';
+export type {
+  XDSHoverCardOptions as HoverCardOptions,
+  XDSHoverCardProps as HoverCardProps,
+  XDSHoverCardReturn as HoverCardReturn,
+  XDSLayerContextValue as LayerContextValue,
+  XDSLayerProviderProps as LayerProviderProps,
+  XDSPopoverProps as PopoverProps,
+  XDSTooltipOptions as TooltipOptions,
+  XDSTooltipProps as TooltipProps,
+  XDSTooltipReturn as TooltipReturn,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Layout/container.stylex.ts
+++ b/packages/core/src/Layout/container.stylex.ts
@@ -9,19 +9,24 @@
  * ## Public API for themes
  *
  * Themes set `padding` on container component overrides. The theme build
- * pipeline expands this to component-scoped CSS custom properties:
+ * pipeline expands this to component-scoped CSS custom properties. As part of
+ * the XDS-prefix migration (P2380608025), the pipeline now emits the rebranded
+ * `--astryx-*` tokens, while the component reads them via an inverted fallback
+ * chain so a legacy `--xds-*` override set by existing consumer code still wins
+ * during the compat window:
  *
- *   --xds-card-padding            (shorthand — all sides)
- *   --xds-card-padding-inline     (horizontal)
- *   --xds-card-padding-block-start
- *   --xds-card-padding-block-end
+ *   --astryx-card-padding            (shorthand — all sides; emitted)
+ *   --astryx-card-padding-inline     (horizontal)
+ *   --astryx-card-padding-block-start
+ *   --astryx-card-padding-block-end
  *
- * Same pattern for section (--xds-section-padding-*) and dialog
- * (--xds-dialog-padding-*).
+ * Read order per level: `var(--xds-…, var(--astryx-…, <next level>))` — legacy
+ * `--xds-*` wins, then `--astryx-*`, terminating at `--spacing-4`. Same pattern
+ * for section and dialog.
  *
  * ```ts
  * components: {
- *   card: { base: { padding: '20px' } },          // → --xds-card-padding: 20px
+ *   card: { base: { padding: '20px' } },          // → --astryx-card-padding: 20px
  *   section: { base: { padding: '12px 20px' } },  // → directional tokens
  *   dialog: { base: { padding: '16px' } },
  * }
@@ -70,14 +75,16 @@ const baseStyles = stylex.create({
  * Component-scoped padding tokens.
  *
  * Each container component (card, section, dialog) has public CSS custom
- * properties that themes can set:
+ * properties that themes can set. The pipeline emits the rebranded `--astryx-*`
+ * names; the component reads `var(--xds-…, var(--astryx-…, …))` so legacy
+ * `--xds-*` overrides still win during the compat window (P2380608025):
  *
- *   --xds-card-padding          (shorthand — all sides)
- *   --xds-card-padding-inline
- *   --xds-card-padding-inline-start
- *   --xds-card-padding-inline-end
- *   --xds-card-padding-block-start
- *   --xds-card-padding-block-end
+ *   --astryx-card-padding          (shorthand — all sides)
+ *   --astryx-card-padding-inline
+ *   --astryx-card-padding-inline-start
+ *   --astryx-card-padding-inline-end
+ *   --astryx-card-padding-block-start
+ *   --astryx-card-padding-block-end
  *
  * The theme build pipeline maps `padding: '20px'` on a container component
  * to these tokens. The component reads them with var() fallbacks to --spacing-4.
@@ -88,84 +95,119 @@ const baseStyles = stylex.create({
  * the theme CSS sets the token value and the component picks it up via
  * CSS custom property cascade — no layer competition.
  */
+const SP4 = spacingVars['--spacing-4'];
+
+// Card padding chains (XDS-prefix migration P2380608025): legacy --xds-* wins,
+// then --astryx-*, then the next specificity level, terminating at --spacing-4.
+// Built as chained const strings (no function calls) so StyleX can statically
+// analyze them; see naming.ts for the prefix policy.
+const cardShorthand = `var(--xds-card-padding, var(--astryx-card-padding, ${SP4}))`;
+const cardInline = `var(--xds-card-padding-inline, var(--astryx-card-padding-inline, ${cardShorthand}))`;
+const cardInlineStart = `var(--xds-card-padding-inline-start, var(--astryx-card-padding-inline-start, ${cardInline}))`;
+const cardInlineEnd = `var(--xds-card-padding-inline-end, var(--astryx-card-padding-inline-end, ${cardInline}))`;
+const cardBlockStart = `var(--xds-card-padding-block-start, var(--astryx-card-padding-block-start, ${cardShorthand}))`;
+const cardBlockEnd = `var(--xds-card-padding-block-end, var(--astryx-card-padding-block-end, ${cardShorthand}))`;
+
+// Section padding chains (XDS-prefix migration P2380608025): legacy --xds-* wins,
+// then --astryx-*, then the next specificity level, terminating at --spacing-4.
+// Built as chained const strings (no function calls) so StyleX can statically
+// analyze them; see naming.ts for the prefix policy.
+const sectionShorthand = `var(--xds-section-padding, var(--astryx-section-padding, ${SP4}))`;
+const sectionInline = `var(--xds-section-padding-inline, var(--astryx-section-padding-inline, ${sectionShorthand}))`;
+const sectionInlineStart = `var(--xds-section-padding-inline-start, var(--astryx-section-padding-inline-start, ${sectionInline}))`;
+const sectionInlineEnd = `var(--xds-section-padding-inline-end, var(--astryx-section-padding-inline-end, ${sectionInline}))`;
+const sectionBlockStart = `var(--xds-section-padding-block-start, var(--astryx-section-padding-block-start, ${sectionShorthand}))`;
+const sectionBlockEnd = `var(--xds-section-padding-block-end, var(--astryx-section-padding-block-end, ${sectionShorthand}))`;
+
+// Dialog padding chains (XDS-prefix migration P2380608025): legacy --xds-* wins,
+// then --astryx-*, then the next specificity level, terminating at --spacing-4.
+// Built as chained const strings (no function calls) so StyleX can statically
+// analyze them; see naming.ts for the prefix policy.
+const dialogShorthand = `var(--xds-dialog-padding, var(--astryx-dialog-padding, ${SP4}))`;
+const dialogInline = `var(--xds-dialog-padding-inline, var(--astryx-dialog-padding-inline, ${dialogShorthand}))`;
+const dialogInlineStart = `var(--xds-dialog-padding-inline-start, var(--astryx-dialog-padding-inline-start, ${dialogInline}))`;
+const dialogInlineEnd = `var(--xds-dialog-padding-inline-end, var(--astryx-dialog-padding-inline-end, ${dialogInline}))`;
+const dialogBlockStart = `var(--xds-dialog-padding-block-start, var(--astryx-dialog-padding-block-start, ${dialogShorthand}))`;
+const dialogBlockEnd = `var(--xds-dialog-padding-block-end, var(--astryx-dialog-padding-block-end, ${dialogShorthand}))`;
+
 const cardDefaultPaddingStyles = stylex.create({
   containerPaddingInlineStart: {
-    '--container-padding-inline-start': `var(--xds-card-padding-inline-start, var(--xds-card-padding-inline, var(--xds-card-padding, ${spacingVars['--spacing-4']})))`,
+    '--container-padding-inline-start': cardInlineStart,
   },
   containerPaddingInlineEnd: {
-    '--container-padding-inline-end': `var(--xds-card-padding-inline-end, var(--xds-card-padding-inline, var(--xds-card-padding, ${spacingVars['--spacing-4']})))`,
+    '--container-padding-inline-end': cardInlineEnd,
   },
   containerPaddingBlockStart: {
-    '--container-padding-block-start': `var(--xds-card-padding-block-start, var(--xds-card-padding, ${spacingVars['--spacing-4']}))`,
+    '--container-padding-block-start': cardBlockStart,
   },
   containerPaddingBlockEnd: {
-    '--container-padding-block-end': `var(--xds-card-padding-block-end, var(--xds-card-padding, ${spacingVars['--spacing-4']}))`,
+    '--container-padding-block-end': cardBlockEnd,
   },
   layoutPaddingOuterX: {
-    '--layout-padding-outer-x': `var(--xds-card-padding-inline-start, var(--xds-card-padding-inline, var(--xds-card-padding, ${spacingVars['--spacing-4']})))`,
+    '--layout-padding-outer-x': cardInlineStart,
   },
   layoutPaddingOuterY: {
-    '--layout-padding-outer-y': `var(--xds-card-padding-block-start, var(--xds-card-padding, ${spacingVars['--spacing-4']}))`,
+    '--layout-padding-outer-y': cardBlockStart,
   },
   layoutPaddingInnerX: {
-    '--layout-padding-inner-x': `var(--xds-card-padding-inline-start, var(--xds-card-padding-inline, var(--xds-card-padding, ${spacingVars['--spacing-4']})))`,
+    '--layout-padding-inner-x': cardInlineStart,
   },
   layoutPaddingInnerY: {
-    '--layout-padding-inner-y': `var(--xds-card-padding-block-start, var(--xds-card-padding, ${spacingVars['--spacing-4']}))`,
+    '--layout-padding-inner-y': cardBlockStart,
   },
 });
 
 const sectionDefaultPaddingStyles = stylex.create({
   containerPaddingInlineStart: {
-    '--container-padding-inline-start': `var(--xds-section-padding-inline-start, var(--xds-section-padding-inline, var(--xds-section-padding, ${spacingVars['--spacing-4']})))`,
+    '--container-padding-inline-start': sectionInlineStart,
   },
   containerPaddingInlineEnd: {
-    '--container-padding-inline-end': `var(--xds-section-padding-inline-end, var(--xds-section-padding-inline, var(--xds-section-padding, ${spacingVars['--spacing-4']})))`,
+    '--container-padding-inline-end': sectionInlineEnd,
   },
   containerPaddingBlockStart: {
-    '--container-padding-block-start': `var(--xds-section-padding-block-start, var(--xds-section-padding, ${spacingVars['--spacing-4']}))`,
+    '--container-padding-block-start': sectionBlockStart,
   },
   containerPaddingBlockEnd: {
-    '--container-padding-block-end': `var(--xds-section-padding-block-end, var(--xds-section-padding, ${spacingVars['--spacing-4']}))`,
+    '--container-padding-block-end': sectionBlockEnd,
   },
   layoutPaddingOuterX: {
-    '--layout-padding-outer-x': `var(--xds-section-padding-inline-start, var(--xds-section-padding-inline, var(--xds-section-padding, ${spacingVars['--spacing-4']})))`,
+    '--layout-padding-outer-x': sectionInlineStart,
   },
   layoutPaddingOuterY: {
-    '--layout-padding-outer-y': `var(--xds-section-padding-block-start, var(--xds-section-padding, ${spacingVars['--spacing-4']}))`,
+    '--layout-padding-outer-y': sectionBlockStart,
   },
   layoutPaddingInnerX: {
-    '--layout-padding-inner-x': `var(--xds-section-padding-inline-start, var(--xds-section-padding-inline, var(--xds-section-padding, ${spacingVars['--spacing-4']})))`,
+    '--layout-padding-inner-x': sectionInlineStart,
   },
   layoutPaddingInnerY: {
-    '--layout-padding-inner-y': `var(--xds-section-padding-block-start, var(--xds-section-padding, ${spacingVars['--spacing-4']}))`,
+    '--layout-padding-inner-y': sectionBlockStart,
   },
 });
 
 const dialogDefaultPaddingStyles = stylex.create({
   containerPaddingInlineStart: {
-    '--container-padding-inline-start': `var(--xds-dialog-padding-inline-start, var(--xds-dialog-padding-inline, var(--xds-dialog-padding, ${spacingVars['--spacing-4']})))`,
+    '--container-padding-inline-start': dialogInlineStart,
   },
   containerPaddingInlineEnd: {
-    '--container-padding-inline-end': `var(--xds-dialog-padding-inline-end, var(--xds-dialog-padding-inline, var(--xds-dialog-padding, ${spacingVars['--spacing-4']})))`,
+    '--container-padding-inline-end': dialogInlineEnd,
   },
   containerPaddingBlockStart: {
-    '--container-padding-block-start': `var(--xds-dialog-padding-block-start, var(--xds-dialog-padding, ${spacingVars['--spacing-4']}))`,
+    '--container-padding-block-start': dialogBlockStart,
   },
   containerPaddingBlockEnd: {
-    '--container-padding-block-end': `var(--xds-dialog-padding-block-end, var(--xds-dialog-padding, ${spacingVars['--spacing-4']}))`,
+    '--container-padding-block-end': dialogBlockEnd,
   },
   layoutPaddingOuterX: {
-    '--layout-padding-outer-x': `var(--xds-dialog-padding-inline-start, var(--xds-dialog-padding-inline, var(--xds-dialog-padding, ${spacingVars['--spacing-4']})))`,
+    '--layout-padding-outer-x': dialogInlineStart,
   },
   layoutPaddingOuterY: {
-    '--layout-padding-outer-y': `var(--xds-dialog-padding-block-start, var(--xds-dialog-padding, ${spacingVars['--spacing-4']}))`,
+    '--layout-padding-outer-y': dialogBlockStart,
   },
   layoutPaddingInnerX: {
-    '--layout-padding-inner-x': `var(--xds-dialog-padding-inline-start, var(--xds-dialog-padding-inline, var(--xds-dialog-padding, ${spacingVars['--spacing-4']})))`,
+    '--layout-padding-inner-x': dialogInlineStart,
   },
   layoutPaddingInnerY: {
-    '--layout-padding-inner-y': `var(--xds-dialog-padding-block-start, var(--xds-dialog-padding, ${spacingVars['--spacing-4']}))`,
+    '--layout-padding-inner-y': dialogBlockStart,
   },
 });
 

--- a/packages/core/src/Layout/index.ts
+++ b/packages/core/src/Layout/index.ts
@@ -81,3 +81,41 @@ export type {LayoutArea} from './XDSLayoutAreaContext';
 
 export {XDSLayoutDividerContext} from './XDSLayoutDividerContext';
 export type {LayoutDividerContextValue} from './XDSLayoutDividerContext';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSCard as Card,
+  XDSHStack as HStack,
+  XDSLayout as Layout,
+  XDSLayoutAreaContext as LayoutAreaContext,
+  XDSLayoutContent as LayoutContent,
+  XDSLayoutDividerContext as LayoutDividerContext,
+  XDSLayoutFooter as LayoutFooter,
+  XDSLayoutHeader as LayoutHeader,
+  XDSLayoutPanel as LayoutPanel,
+  XDSSection as Section,
+  XDSStack as Stack,
+  XDSStackItem as StackItem,
+  XDSVStack as VStack,
+} from '.';
+export type {
+  XDSCardProps as CardProps,
+  XDSHStackProps as HStackProps,
+  XDSLayoutContentProps as LayoutContentProps,
+  XDSLayoutFooterProps as LayoutFooterProps,
+  XDSLayoutHeaderProps as LayoutHeaderProps,
+  XDSLayoutHeight as LayoutHeight,
+  XDSLayoutPanelProps as LayoutPanelProps,
+  XDSLayoutProps as LayoutProps,
+  XDSSectionProps as SectionProps,
+  XDSSectionVariant as SectionVariant,
+  XDSStackItemProps as StackItemProps,
+  XDSStackProps as StackProps,
+  XDSVStackProps as VStackProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Lightbox/index.ts
+++ b/packages/core/src/Lightbox/index.ts
@@ -21,3 +21,20 @@ export type {
   UseXDSLightboxOptions,
   UseXDSLightboxReturn,
 } from './useXDSLightbox';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSLightbox as Lightbox,
+  useXDSLightbox as useLightbox,
+} from '.';
+export type {
+  XDSLightboxMedia as LightboxMedia,
+  XDSLightboxMediaType as LightboxMediaType,
+  XDSLightboxProps as LightboxProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Link/index.ts
+++ b/packages/core/src/Link/index.ts
@@ -23,3 +23,22 @@ export type {XDSLinkComponentType} from './types';
 
 export {useXDSLinkify} from './useXDSLinkify';
 export type {LinkifyPattern, UseXDSLinkifyOptions} from './useXDSLinkify';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSLink as Link,
+  XDSLinkProvider as LinkProvider,
+  useXDSLinkComponent as useLinkComponent,
+  useXDSLinkify as useLinkify,
+} from '.';
+export type {
+  XDSLinkComponentType as LinkComponentType,
+  XDSLinkProps as LinkProps,
+  XDSLinkProviderProps as LinkProviderProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/List/index.ts
+++ b/packages/core/src/List/index.ts
@@ -15,3 +15,21 @@ export {XDSList} from './XDSList';
 export type {XDSListProps, XDSListStyle, XDSListDensity} from './XDSList';
 export {XDSListItem} from './XDSListItem';
 export type {XDSListItemProps} from './XDSListItem';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSList as List,
+  XDSListItem as ListItem,
+} from '.';
+export type {
+  XDSListDensity as ListDensity,
+  XDSListItemProps as ListItemProps,
+  XDSListProps as ListProps,
+  XDSListStyle as ListStyle,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Markdown/index.ts
+++ b/packages/core/src/Markdown/index.ts
@@ -9,7 +9,12 @@
  */
 
 export {XDSMarkdown} from './XDSMarkdown';
-export type {XDSMarkdownProps, XDSMarkdownSource, XDSMarkdownComponents, MarkdownInlinePlugin} from './XDSMarkdown';
+export type {
+  XDSMarkdownProps,
+  XDSMarkdownSource,
+  XDSMarkdownComponents,
+  MarkdownInlinePlugin,
+} from './XDSMarkdown';
 
 export {
   parseMarkdown,
@@ -25,3 +30,19 @@ export type {
   TableAlignment,
   IncrementalState as IncrementalParseState,
 } from './parser';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSMarkdown as Markdown,
+} from '.';
+export type {
+  XDSMarkdownComponents as MarkdownComponents,
+  XDSMarkdownProps as MarkdownProps,
+  XDSMarkdownSource as MarkdownSource,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/MetadataList/index.ts
+++ b/packages/core/src/MetadataList/index.ts
@@ -19,3 +19,21 @@ export type {
 export {XDSMetadataListItem} from './XDSMetadataListItem';
 export type {XDSMetadataListItemProps} from './XDSMetadataListItem';
 export type {XDSMetadataListLabelConfig} from './XDSMetadataListContext';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSMetadataList as MetadataList,
+  XDSMetadataListItem as MetadataListItem,
+} from '.';
+export type {
+  XDSMetadataListColumns as MetadataListColumns,
+  XDSMetadataListItemProps as MetadataListItemProps,
+  XDSMetadataListLabelConfig as MetadataListLabelConfig,
+  XDSMetadataListProps as MetadataListProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/MobileNav/index.ts
+++ b/packages/core/src/MobileNav/index.ts
@@ -13,3 +13,19 @@ export {XDSMobileNav} from './XDSMobileNav';
 export type {XDSMobileNavProps} from './XDSMobileNav';
 export {XDSMobileNavToggle} from './XDSMobileNavToggle';
 export type {XDSMobileNavToggleProps} from './XDSMobileNavToggle';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSMobileNav as MobileNav,
+  XDSMobileNavToggle as MobileNavToggle,
+} from '.';
+export type {
+  XDSMobileNavProps as MobileNavProps,
+  XDSMobileNavToggleProps as MobileNavToggleProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/MoreMenu/index.ts
+++ b/packages/core/src/MoreMenu/index.ts
@@ -9,3 +9,17 @@
  */
 
 export {XDSMoreMenu, type XDSMoreMenuProps} from './XDSMoreMenu';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSMoreMenu as MoreMenu,
+} from '.';
+export type {
+  XDSMoreMenuProps as MoreMenuProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/MultiSelector/index.ts
+++ b/packages/core/src/MultiSelector/index.ts
@@ -22,3 +22,24 @@ export type {
   XDSMultiSelectorStatus,
 } from './types';
 export {useMultiCombobox} from './hooks';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSMultiSelector as MultiSelector,
+} from '.';
+export type {
+  XDSMultiSelectorDivider as MultiSelectorDivider,
+  XDSMultiSelectorOptionData as MultiSelectorOptionData,
+  XDSMultiSelectorOptionType as MultiSelectorOptionType,
+  XDSMultiSelectorProps as MultiSelectorProps,
+  XDSMultiSelectorSection as MultiSelectorSection,
+  XDSMultiSelectorSize as MultiSelectorSize,
+  XDSMultiSelectorStatus as MultiSelectorStatus,
+  XDSMultiSelectorStatusType as MultiSelectorStatusType,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/NavIcon/index.ts
+++ b/packages/core/src/NavIcon/index.ts
@@ -11,3 +11,17 @@
 
 export {XDSNavIcon} from './XDSNavIcon';
 export type {XDSNavIconProps} from './XDSNavIcon';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSNavIcon as NavIcon,
+} from '.';
+export type {
+  XDSNavIconProps as NavIconProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/NavMenu/index.ts
+++ b/packages/core/src/NavMenu/index.ts
@@ -20,3 +20,28 @@ export type {
 // Backward compat — use XDSNavHeadingMenuItem instead.
 export {XDSNavMenuItem} from './XDSNavMenuItem';
 export type {XDSNavMenuItemProps} from './XDSNavMenuItem';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSNavHeadingCloseContext as NavHeadingCloseContext,
+  XDSNavHeadingMenu as NavHeadingMenu,
+  XDSNavHeadingMenuContext as NavHeadingMenuContext,
+  XDSNavHeadingMenuItem as NavHeadingMenuItem,
+  XDSNavMenuItem as NavMenuItem,
+  useXDSNavHeadingCloseContext as useNavHeadingCloseContext,
+  useXDSNavHeadingMenuContext as useNavHeadingMenuContext,
+} from '.';
+export type {
+  XDSNavHeadingCloseContextValue as NavHeadingCloseContextValue,
+  XDSNavHeadingMenuContextValue as NavHeadingMenuContextValue,
+  XDSNavHeadingMenuItemProps as NavHeadingMenuItemProps,
+  XDSNavHeadingMenuProps as NavHeadingMenuProps,
+  XDSNavHeadingMenuSize as NavHeadingMenuSize,
+  XDSNavMenuItemProps as NavMenuItemProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/NumberInput/index.ts
+++ b/packages/core/src/NumberInput/index.ts
@@ -18,3 +18,20 @@ export type {
   XDSNumberInputStatus,
   XDSNumberInputStatusType,
 } from './XDSNumberInput';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSNumberInput as NumberInput,
+} from '.';
+export type {
+  XDSNumberInputProps as NumberInputProps,
+  XDSNumberInputSize as NumberInputSize,
+  XDSNumberInputStatus as NumberInputStatus,
+  XDSNumberInputStatusType as NumberInputStatusType,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Outline/index.ts
+++ b/packages/core/src/Outline/index.ts
@@ -17,3 +17,17 @@ export type {OutlineItem} from './types';
 export {parseOutlineFromMarkdown} from './parseOutlineFromMarkdown';
 export {useOutlineFromMarkdown} from './useOutlineFromMarkdown';
 export {useOutlineFromDOM} from './useOutlineFromDOM';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSOutline as Outline,
+} from '.';
+export type {
+  XDSOutlineProps as OutlineProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/OverflowList/index.ts
+++ b/packages/core/src/OverflowList/index.ts
@@ -8,3 +8,18 @@
 
 export {XDSOverflowList} from './XDSOverflowList';
 export type {XDSOverflowListProps, XDSOverflowItem} from './XDSOverflowList';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSOverflowList as OverflowList,
+} from '.';
+export type {
+  XDSOverflowItem as OverflowItem,
+  XDSOverflowListProps as OverflowListProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Overlay/index.ts
+++ b/packages/core/src/Overlay/index.ts
@@ -17,3 +17,18 @@ export type {
   OverlayAlign,
   OverlayShowOn,
 } from './OverlayScrim';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSOverlay as Overlay,
+  useXDSOverlay as useOverlay,
+} from '.';
+export type {
+  XDSOverlayProps as OverlayProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Pagination/index.ts
+++ b/packages/core/src/Pagination/index.ts
@@ -16,3 +16,20 @@ export type {
   XDSPaginationVariantMap,
   XDSPaginationSize,
 } from './XDSPagination';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSPagination as Pagination,
+} from '.';
+export type {
+  XDSPaginationProps as PaginationProps,
+  XDSPaginationSize as PaginationSize,
+  XDSPaginationVariant as PaginationVariant,
+  XDSPaginationVariantMap as PaginationVariantMap,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Popover/index.ts
+++ b/packages/core/src/Popover/index.ts
@@ -18,3 +18,18 @@ export type {UseXDSPopoverOptions, UseXDSPopoverReturn} from './useXDSPopover';
 // Popover component
 export {XDSPopover} from './XDSPopover';
 export type {XDSPopoverProps, PopoverTriggerRenderProps} from './XDSPopover';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSPopover as Popover,
+  useXDSPopover as usePopover,
+} from '.';
+export type {
+  XDSPopoverProps as PopoverProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/PowerSearch/index.ts
+++ b/packages/core/src/PowerSearch/index.ts
@@ -84,3 +84,22 @@ export type {
   PowerSearchComponentOverride,
   XDSPowerSearchComponents,
 } from './types';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSPowerSearch as PowerSearch,
+  XDSPowerSearchFilterEditor as PowerSearchFilterEditor,
+  XDSPowerSearchToken as PowerSearchToken,
+} from '.';
+export type {
+  XDSPowerSearchComponents as PowerSearchComponents,
+  XDSPowerSearchHandle as PowerSearchHandle,
+  XDSPowerSearchProps as PowerSearchProps,
+  XDSPowerSearchSize as PowerSearchSize,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/ProgressBar/index.ts
+++ b/packages/core/src/ProgressBar/index.ts
@@ -12,3 +12,19 @@ export type {
   XDSProgressBarVariant,
   XDSProgressBarVariantMap,
 } from './XDSProgressBar';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSProgressBar as ProgressBar,
+} from '.';
+export type {
+  XDSProgressBarProps as ProgressBarProps,
+  XDSProgressBarVariant as ProgressBarVariant,
+  XDSProgressBarVariantMap as ProgressBarVariantMap,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/README.md
+++ b/packages/core/src/README.md
@@ -4,8 +4,9 @@ Source code for core UI components.
 
 <!-- SYNC: When files in this directory change, update this document. -->
 
-| File/Directory | Role      | Purpose                                                             |
-| -------------- | --------- | ------------------------------------------------------------------- |
-| `index.ts`     | Entry     | Package entry point; re-exports public components, hooks, and types |
-| `reset.css`    | Styles    | Base CSS reset for consistent cross-browser defaults                |
-| `Button/`      | Component | Button component with variants and loading states                   |
+| File/Directory | Role      | Purpose                                                                                                                                         |
+| -------------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `index.ts`     | Entry     | Package entry point; re-exports public components, hooks, and types                                                                             |
+| `naming.ts`    | Utility   | Centralized namespace-prefix constants/helpers (CSS classes, data attrs, CSS vars) — single source of truth for the XDS→Astryx prefix migration |
+| `reset.css`    | Styles    | Base CSS reset for consistent cross-browser defaults                                                                                            |
+| `Button/`      | Component | Button component with variants and loading states                                                                                               |

--- a/packages/core/src/RadioList/index.ts
+++ b/packages/core/src/RadioList/index.ts
@@ -19,3 +19,22 @@ export type {
 } from './XDSRadioList';
 export {XDSRadioListItem} from './XDSRadioListItem';
 export type {XDSRadioListItemProps} from './XDSRadioListItem';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSRadioList as RadioList,
+  XDSRadioListContext as RadioListContext,
+  XDSRadioListItem as RadioListItem,
+} from '.';
+export type {
+  XDSRadioListContextValue as RadioListContextValue,
+  XDSRadioListItemProps as RadioListItemProps,
+  XDSRadioListProps as RadioListProps,
+  XDSRadioListSize as RadioListSize,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Resizable/index.ts
+++ b/packages/core/src/Resizable/index.ts
@@ -21,3 +21,19 @@ export type {
 
 export {XDSResizeHandle} from './XDSResizeHandle';
 export type {XDSResizeHandleProps} from './XDSResizeHandle';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSResizeHandle as ResizeHandle,
+  useXDSResizable as useResizable,
+} from '.';
+export type {
+  XDSResizableConfig as ResizableConfig,
+  XDSResizeHandleProps as ResizeHandleProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Section/index.ts
+++ b/packages/core/src/Section/index.ts
@@ -17,3 +17,19 @@ export type {
   XDSSectionVariant,
   XDSSectionVariantMap,
 } from './XDSSection';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSSection as Section,
+} from '.';
+export type {
+  XDSSectionProps as SectionProps,
+  XDSSectionVariant as SectionVariant,
+  XDSSectionVariantMap as SectionVariantMap,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/SegmentedControl/index.ts
+++ b/packages/core/src/SegmentedControl/index.ts
@@ -17,4 +17,25 @@ export type {XDSSegmentedControlProps} from './XDSSegmentedControl';
 export {XDSSegmentedControlItem} from './XDSSegmentedControlItem';
 export type {XDSSegmentedControlItemProps} from './XDSSegmentedControlItem';
 
-export type {XDSSegmentedControlSize, XDSSegmentedControlLayout} from './XDSSegmentedControlContext';
+export type {
+  XDSSegmentedControlSize,
+  XDSSegmentedControlLayout,
+} from './XDSSegmentedControlContext';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSSegmentedControl as SegmentedControl,
+  XDSSegmentedControlItem as SegmentedControlItem,
+} from '.';
+export type {
+  XDSSegmentedControlItemProps as SegmentedControlItemProps,
+  XDSSegmentedControlLayout as SegmentedControlLayout,
+  XDSSegmentedControlProps as SegmentedControlProps,
+  XDSSegmentedControlSize as SegmentedControlSize,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/SelectableCard/index.ts
+++ b/packages/core/src/SelectableCard/index.ts
@@ -2,3 +2,17 @@
 
 export {XDSSelectableCard} from './XDSSelectableCard';
 export type {XDSSelectableCardProps} from './XDSSelectableCard';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSSelectableCard as SelectableCard,
+} from '.';
+export type {
+  XDSSelectableCardProps as SelectableCardProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Selector/index.ts
+++ b/packages/core/src/Selector/index.ts
@@ -23,3 +23,25 @@ export type {
   XDSSelectorSection,
 } from './types';
 export {useCombobox, useSelectedItemOffset} from './hooks';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSSelector as Selector,
+  XDSSelectorOption as SelectorOption,
+} from '.';
+export type {
+  XDSSelectorDivider as SelectorDivider,
+  XDSSelectorOptionData as SelectorOptionData,
+  XDSSelectorOptionType as SelectorOptionType,
+  XDSSelectorProps as SelectorProps,
+  XDSSelectorSection as SelectorSection,
+  XDSSelectorSize as SelectorSize,
+  XDSSelectorStatus as SelectorStatus,
+  XDSSelectorStatusType as SelectorStatusType,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/SideNav/index.ts
+++ b/packages/core/src/SideNav/index.ts
@@ -37,3 +37,31 @@ export {
   useXDSSideNavRenderMode,
 } from './XDSSideNavRenderContext';
 export type {XDSSideNavRenderMode} from './XDSSideNavRenderContext';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSSideNav as SideNav,
+  XDSSideNavCollapseButton as SideNavCollapseButton,
+  XDSSideNavHeading as SideNavHeading,
+  XDSSideNavItem as SideNavItem,
+  XDSSideNavRenderContext as SideNavRenderContext,
+  XDSSideNavSection as SideNavSection,
+  useXDSSideNavCollapse as useSideNavCollapse,
+  useXDSSideNavRenderMode as useSideNavRenderMode,
+} from '.';
+export type {
+  XDSSideNavCollapseButtonProps as SideNavCollapseButtonProps,
+  XDSSideNavCollapseState as SideNavCollapseState,
+  XDSSideNavHeadingProps as SideNavHeadingProps,
+  XDSSideNavImperativeCollapseHandle as SideNavImperativeCollapseHandle,
+  XDSSideNavItemProps as SideNavItemProps,
+  XDSSideNavProps as SideNavProps,
+  XDSSideNavRenderMode as SideNavRenderMode,
+  XDSSideNavSectionProps as SideNavSectionProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/SizeContext/index.ts
+++ b/packages/core/src/SizeContext/index.ts
@@ -13,3 +13,19 @@ export {
   useXDSSize,
   type XDSElementSize,
 } from './XDSSizeContext';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSSizeContext as SizeContext,
+  XDSSizeProvider as SizeProvider,
+  useXDSSize as useSize,
+} from '.';
+export type {
+  XDSElementSize as ElementSize,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Skeleton/index.ts
+++ b/packages/core/src/Skeleton/index.ts
@@ -13,3 +13,18 @@
 
 export {XDSSkeleton} from './XDSSkeleton';
 export type {XDSSkeletonProps, XDSSkeletonRadius} from './XDSSkeleton';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSSkeleton as Skeleton,
+} from '.';
+export type {
+  XDSSkeletonProps as SkeletonProps,
+  XDSSkeletonRadius as SkeletonRadius,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Slider/index.ts
+++ b/packages/core/src/Slider/index.ts
@@ -18,3 +18,20 @@ export type {
   XDSSliderSingleProps,
   XDSSliderRangeProps,
 } from './XDSSlider';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSSlider as Slider,
+} from '.';
+export type {
+  XDSSliderBaseProps as SliderBaseProps,
+  XDSSliderProps as SliderProps,
+  XDSSliderRangeProps as SliderRangeProps,
+  XDSSliderSingleProps as SliderSingleProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Spinner/index.ts
+++ b/packages/core/src/Spinner/index.ts
@@ -17,3 +17,19 @@ export type {
   XDSSpinnerSize,
   XDSSpinnerShade,
 } from './XDSSpinner';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSSpinner as Spinner,
+} from '.';
+export type {
+  XDSSpinnerProps as SpinnerProps,
+  XDSSpinnerShade as SpinnerShade,
+  XDSSpinnerSize as SpinnerSize,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Stack/index.ts
+++ b/packages/core/src/Stack/index.ts
@@ -24,3 +24,23 @@ export {XDSVStack, type XDSVStackProps} from '../VStack';
 
 export {XDSStackItem} from './XDSStackItem';
 export type {XDSStackItemProps} from './XDSStackItem';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSHStack as HStack,
+  XDSStack as Stack,
+  XDSStackItem as StackItem,
+  XDSVStack as VStack,
+} from '.';
+export type {
+  XDSHStackProps as HStackProps,
+  XDSStackItemProps as StackItemProps,
+  XDSStackProps as StackProps,
+  XDSVStackProps as VStackProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/StatusDot/index.ts
+++ b/packages/core/src/StatusDot/index.ts
@@ -15,3 +15,19 @@ export type {
   XDSStatusDotVariant,
   XDSStatusDotVariantMap,
 } from './XDSStatusDot';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSStatusDot as StatusDot,
+} from '.';
+export type {
+  XDSStatusDotProps as StatusDotProps,
+  XDSStatusDotVariant as StatusDotVariant,
+  XDSStatusDotVariantMap as StatusDotVariantMap,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Switch/index.ts
+++ b/packages/core/src/Switch/index.ts
@@ -17,3 +17,19 @@ export type {
   XDSSwitchLabelPosition,
   XDSSwitchLabelSpacing,
 } from './XDSSwitch';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSSwitch as Switch,
+} from '.';
+export type {
+  XDSSwitchLabelPosition as SwitchLabelPosition,
+  XDSSwitchLabelSpacing as SwitchLabelSpacing,
+  XDSSwitchProps as SwitchProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/TabList/index.ts
+++ b/packages/core/src/TabList/index.ts
@@ -22,3 +22,25 @@ export type {XDSTabMenuProps, XDSTabMenuOption} from './XDSTabMenu';
 
 export {useXDSTabListContext} from './XDSTabListContext';
 export type {XDSTabListSize, XDSTabListLayout} from './XDSTabListContext';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSTab as Tab,
+  XDSTabList as TabList,
+  XDSTabMenu as TabMenu,
+  useXDSTabListContext as useTabListContext,
+} from '.';
+export type {
+  XDSTabListLayout as TabListLayout,
+  XDSTabListProps as TabListProps,
+  XDSTabListSize as TabListSize,
+  XDSTabMenuOption as TabMenuOption,
+  XDSTabMenuProps as TabMenuProps,
+  XDSTabProps as TabProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Table/index.ts
+++ b/packages/core/src/Table/index.ts
@@ -100,3 +100,59 @@ export type {
   XDSTableFilterValue,
   XDSTableFilterFieldRef,
 } from './plugins/filtering';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSTable as Table,
+  XDSTableBody as TableBody,
+  XDSTableCell as TableCell,
+  XDSTableContext as TableContext,
+  XDSTableFooter as TableFooter,
+  XDSTableHeader as TableHeader,
+  XDSTableHeaderCell as TableHeaderCell,
+  XDSTableRow as TableRow,
+  useXDSBaseTablePlugins as useBaseTablePlugins,
+  useXDSTableColumnResize as useTableColumnResize,
+  useXDSTableColumnSettings as useTableColumnSettings,
+  useXDSTableColumnSettingsState as useTableColumnSettingsState,
+  useXDSTableFilterState as useTableFilterState,
+  useXDSTableFiltering as useTableFiltering,
+  useXDSTablePagination as useTablePagination,
+  useXDSTableSelection as useTableSelection,
+  useXDSTableSelectionState as useTableSelectionState,
+  useXDSTableSortable as useTableSortable,
+  useXDSTableSortableState as useTableSortableState,
+} from '.';
+export type {
+  XDSBaseTableProps as BaseTableProps,
+  XDSColumnSettingsOption as ColumnSettingsOption,
+  XDSTableBodyProps as TableBodyProps,
+  XDSTableCellProps as TableCellProps,
+  XDSTableColumn as TableColumn,
+  XDSTableColumnAlign as TableColumnAlign,
+  XDSTableContextValue as TableContextValue,
+  XDSTableDensity as TableDensity,
+  XDSTableDividers as TableDividers,
+  XDSTableFilterFieldRef as TableFilterFieldRef,
+  XDSTableFilterState as TableFilterState,
+  XDSTableFilterValue as TableFilterValue,
+  XDSTableFilterVariant as TableFilterVariant,
+  XDSTableFooterProps as TableFooterProps,
+  XDSTableHeaderCellProps as TableHeaderCellProps,
+  XDSTableHeaderProps as TableHeaderProps,
+  XDSTableProps as TableProps,
+  XDSTableRowProps as TableRowProps,
+  XDSTableSortComparator as TableSortComparator,
+  XDSTableSortDirection as TableSortDirection,
+  XDSTableSortEntry as TableSortEntry,
+  XDSTableSortState as TableSortState,
+  XDSTableSortableColumnConfig as TableSortableColumnConfig,
+  XDSTableTextOverflow as TableTextOverflow,
+  XDSTableVerticalAlign as TableVerticalAlign,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Text/index.ts
+++ b/packages/core/src/Text/index.ts
@@ -38,3 +38,29 @@ export {
   type UseTruncationOptions,
   type UseTruncationReturn,
 } from './useTruncation';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSHeading as Heading,
+  XDSText as Text,
+} from '.';
+export type {
+  XDSHeadingProps as HeadingProps,
+  XDSHeadingType as HeadingType,
+  XDSTextColor as TextColor,
+  XDSTextDisplay as TextDisplay,
+  XDSTextJustify as TextJustify,
+  XDSTextProps as TextProps,
+  XDSTextSize as TextSize,
+  XDSTextType as TextType,
+  XDSTextWeight as TextWeight,
+  XDSTextWrap as TextWrap,
+  XDSTextXStyleAllowed as TextXStyleAllowed,
+  XDSWordBreak as WordBreak,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/TextArea/index.ts
+++ b/packages/core/src/TextArea/index.ts
@@ -18,3 +18,20 @@ export type {
   XDSTextAreaStatusType,
   XDSTextAreaSize,
 } from './XDSTextArea';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSTextArea as TextArea,
+} from '.';
+export type {
+  XDSTextAreaProps as TextAreaProps,
+  XDSTextAreaSize as TextAreaSize,
+  XDSTextAreaStatus as TextAreaStatus,
+  XDSTextAreaStatusType as TextAreaStatusType,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/TextInput/index.ts
+++ b/packages/core/src/TextInput/index.ts
@@ -19,3 +19,21 @@ export type {
   XDSTextInputStatus,
   XDSTextInputStatusType,
 } from './XDSTextInput';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSTextInput as TextInput,
+} from '.';
+export type {
+  XDSTextInputProps as TextInputProps,
+  XDSTextInputSize as TextInputSize,
+  XDSTextInputStatus as TextInputStatus,
+  XDSTextInputStatusType as TextInputStatusType,
+  XDSTextInputType as TextInputType,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Thumbnail/index.ts
+++ b/packages/core/src/Thumbnail/index.ts
@@ -8,3 +8,17 @@
 
 export {XDSThumbnail} from './XDSThumbnail';
 export type {XDSThumbnailProps} from './XDSThumbnail';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSThumbnail as Thumbnail,
+} from '.';
+export type {
+  XDSThumbnailProps as ThumbnailProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/TimeInput/index.ts
+++ b/packages/core/src/TimeInput/index.ts
@@ -20,3 +20,21 @@ export type {
   XDSTimeInputStatusType,
 } from './XDSTimeInput';
 export type {ISOTimeString} from '../utils';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSTimeInput as TimeInput,
+} from '.';
+export type {
+  XDSTimeInputHourFormat as TimeInputHourFormat,
+  XDSTimeInputProps as TimeInputProps,
+  XDSTimeInputSize as TimeInputSize,
+  XDSTimeInputStatus as TimeInputStatus,
+  XDSTimeInputStatusType as TimeInputStatusType,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Timestamp/index.ts
+++ b/packages/core/src/Timestamp/index.ts
@@ -13,3 +13,18 @@
 
 export {XDSTimestamp} from './XDSTimestamp';
 export type {XDSTimestampProps, XDSTimestampFormat} from './XDSTimestamp';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSTimestamp as Timestamp,
+} from '.';
+export type {
+  XDSTimestampFormat as TimestampFormat,
+  XDSTimestampProps as TimestampProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Toast/index.ts
+++ b/packages/core/src/Toast/index.ts
@@ -21,3 +21,27 @@ export type {XDSToastViewportProps} from './XDSToastViewport';
 // Exported for inline rendering in previews and documentation
 export {XDSToast} from './XDSToast';
 export type {XDSToastProps} from './XDSToast';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSToast as Toast,
+  XDSToastViewport as ToastViewport,
+  useXDSToast as useToast,
+} from '.';
+export type {
+  XDSShowToastFn as ShowToastFn,
+  XDSToastCollisionBehavior as ToastCollisionBehavior,
+  XDSToastDismissFn as ToastDismissFn,
+  XDSToastDismissReason as ToastDismissReason,
+  XDSToastOptions as ToastOptions,
+  XDSToastPosition as ToastPosition,
+  XDSToastProps as ToastProps,
+  XDSToastType as ToastType,
+  XDSToastViewportProps as ToastViewportProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/ToggleButton/index.ts
+++ b/packages/core/src/ToggleButton/index.ts
@@ -18,3 +18,21 @@ export type {
   XDSToggleButtonGroupSingleProps,
   XDSToggleButtonGroupMultipleProps,
 } from './XDSToggleButtonGroup';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSToggleButton as ToggleButton,
+  XDSToggleButtonGroup as ToggleButtonGroup,
+} from '.';
+export type {
+  XDSToggleButtonGroupMultipleProps as ToggleButtonGroupMultipleProps,
+  XDSToggleButtonGroupProps as ToggleButtonGroupProps,
+  XDSToggleButtonGroupSingleProps as ToggleButtonGroupSingleProps,
+  XDSToggleButtonProps as ToggleButtonProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Token/index.ts
+++ b/packages/core/src/Token/index.ts
@@ -13,3 +13,16 @@
 
 export {XDSToken} from './XDSToken';
 export type {XDSTokenProps, XDSTokenColor, XDSTokenSize} from './XDSToken';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export type {
+  XDSTokenColor as TokenColor,
+  XDSTokenProps as TokenProps,
+  XDSTokenSize as TokenSize,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Tokenizer/index.ts
+++ b/packages/core/src/Tokenizer/index.ts
@@ -21,3 +21,23 @@ export type {
   XDSTokenizerStatus,
   XDSTokenizerStatusType,
 } from './XDSTokenizer';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSTokenizer as Tokenizer,
+} from '.';
+export type {
+  XDSTokenizerChange as TokenizerChange,
+  XDSTokenizerHandle as TokenizerHandle,
+  XDSTokenizerOverflowBehavior as TokenizerOverflowBehavior,
+  XDSTokenizerProps as TokenizerProps,
+  XDSTokenizerSize as TokenizerSize,
+  XDSTokenizerStatus as TokenizerStatus,
+  XDSTokenizerStatusType as TokenizerStatusType,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Toolbar/index.ts
+++ b/packages/core/src/Toolbar/index.ts
@@ -13,3 +13,18 @@
 
 export {XDSToolbar} from './XDSToolbar';
 export type {XDSToolbarProps, XDSToolbarSize} from './XDSToolbar';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSToolbar as Toolbar,
+} from '.';
+export type {
+  XDSToolbarProps as ToolbarProps,
+  XDSToolbarSize as ToolbarSize,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Tooltip/index.ts
+++ b/packages/core/src/Tooltip/index.ts
@@ -22,3 +22,20 @@ export type {
 // Tooltip component
 export {XDSTooltip} from './XDSTooltip';
 export type {XDSTooltipProps} from './XDSTooltip';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSTooltip as Tooltip,
+  useXDSTooltip as useTooltip,
+} from '.';
+export type {
+  XDSTooltipOptions as TooltipOptions,
+  XDSTooltipProps as TooltipProps,
+  XDSTooltipReturn as TooltipReturn,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/TopNav/index.ts
+++ b/packages/core/src/TopNav/index.ts
@@ -37,3 +37,33 @@ export {
   useXDSTopNavRenderMode,
 } from './XDSTopNavRenderContext';
 export type {XDSTopNavRenderMode} from './XDSTopNavRenderContext';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSTopNav as TopNav,
+  XDSTopNavHeading as TopNavHeading,
+  XDSTopNavItem as TopNavItem,
+  XDSTopNavMegaMenu as TopNavMegaMenu,
+  XDSTopNavMegaMenuFeaturedCard as TopNavMegaMenuFeaturedCard,
+  XDSTopNavMegaMenuItem as TopNavMegaMenuItem,
+  XDSTopNavMenu as TopNavMenu,
+  XDSTopNavRenderContext as TopNavRenderContext,
+  useXDSTopNavRenderMode as useTopNavRenderMode,
+} from '.';
+export type {
+  XDSTopNavHeadingProps as TopNavHeadingProps,
+  XDSTopNavItemProps as TopNavItemProps,
+  XDSTopNavMegaMenuFeaturedCardProps as TopNavMegaMenuFeaturedCardProps,
+  XDSTopNavMegaMenuItemProps as TopNavMegaMenuItemProps,
+  XDSTopNavMegaMenuProps as TopNavMegaMenuProps,
+  XDSTopNavMenuItemData as TopNavMenuItemData,
+  XDSTopNavMenuProps as TopNavMenuProps,
+  XDSTopNavProps as TopNavProps,
+  XDSTopNavRenderMode as TopNavRenderMode,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/TreeList/index.ts
+++ b/packages/core/src/TreeList/index.ts
@@ -14,3 +14,19 @@
 export {XDSTreeList} from './XDSTreeList';
 export type {XDSTreeListProps, XDSTreeListDensity} from './XDSTreeList';
 export type {XDSTreeListItemData} from './XDSTreeListTypes';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSTreeList as TreeList,
+} from '.';
+export type {
+  XDSTreeListDensity as TreeListDensity,
+  XDSTreeListItemData as TreeListItemData,
+  XDSTreeListProps as TreeListProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/Typeahead/index.ts
+++ b/packages/core/src/Typeahead/index.ts
@@ -34,3 +34,26 @@ export type {
 // Typeahead item
 export {XDSTypeaheadItem} from './XDSTypeaheadItem';
 export type {XDSTypeaheadItemProps} from './XDSTypeaheadItem';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSBaseTypeahead as BaseTypeahead,
+  XDSTypeahead as Typeahead,
+  XDSTypeaheadItem as TypeaheadItem,
+} from '.';
+export type {
+  XDSBaseTypeaheadProps as BaseTypeaheadProps,
+  XDSSearchSource as SearchSource,
+  XDSSearchableItem as SearchableItem,
+  XDSTypeaheadItemProps as TypeaheadItemProps,
+  XDSTypeaheadProps as TypeaheadProps,
+  XDSTypeaheadSize as TypeaheadSize,
+  XDSTypeaheadStatus as TypeaheadStatus,
+  XDSTypeaheadStatusType as TypeaheadStatusType,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/VStack/index.ts
+++ b/packages/core/src/VStack/index.ts
@@ -8,3 +8,17 @@
  */
 
 export {XDSVStack, type XDSVStackProps} from './XDSVStack';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSVStack as VStack,
+} from '.';
+export type {
+  XDSVStackProps as VStackProps,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/compat-aliases.test.tsx
+++ b/packages/core/src/compat-aliases.test.tsx
@@ -1,0 +1,65 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file compat-aliases.test.tsx
+ * @description Verifies the XDS-prefix migration compatibility layer: bare
+ *   (unprefixed) aliases resolve to the SAME runtime values and TS types as
+ *   the prefixed XDS* exports, and the module-augmentation interface alias is
+ *   still augmentable. See P2380608025.
+ */
+
+import {describe, it, expect, expectTypeOf} from 'vitest';
+import * as Core from './index';
+import {Button, XDSButton, Card, XDSCard, useXDSTheme, useTheme} from './index';
+import type {
+  ButtonProps,
+  XDSButtonProps,
+  ButtonVariant,
+  XDSButtonVariant,
+} from './index';
+
+describe('compat aliases: runtime value identity', () => {
+  it('bare component aliases are the SAME value as the prefixed exports', () => {
+    expect(Button).toBe(XDSButton);
+    expect(Card).toBe(XDSCard);
+  });
+
+  it('bare hook aliases are the SAME value as the prefixed hooks', () => {
+    expect(useTheme).toBe(useXDSTheme);
+  });
+
+  it('a representative spread of bare aliases are exported from the root barrel', () => {
+    for (const name of [
+      'Button',
+      'Card',
+      'Text',
+      'Heading',
+      'Dialog',
+      'Table',
+      'Theme',
+      'useTheme',
+    ]) {
+      expect(Core, `@xds/core should export bare "${name}"`).toHaveProperty(
+        name,
+      );
+    }
+  });
+
+  it('keeps the prefixed exports working unchanged', () => {
+    for (const name of ['XDSButton', 'XDSCard', 'XDSTheme', 'useXDSTheme']) {
+      expect(Core, `@xds/core should still export "${name}"`).toHaveProperty(
+        name,
+      );
+    }
+  });
+});
+
+describe('compat aliases: type identity', () => {
+  it('bare prop type alias equals the prefixed prop type', () => {
+    expectTypeOf<ButtonProps>().toEqualTypeOf<XDSButtonProps>();
+  });
+
+  it('bare variant union alias equals the prefixed union', () => {
+    expectTypeOf<ButtonVariant>().toEqualTypeOf<XDSButtonVariant>();
+  });
+});

--- a/packages/core/src/hooks/index.ts
+++ b/packages/core/src/hooks/index.ts
@@ -55,3 +55,18 @@ export type {
   XDSInteractiveRole,
   UseXDSInteractiveRoleOptions,
 } from './useXDSInteractiveRole';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  useXDSInteractiveRole as useInteractiveRole,
+  useXDSStreamingText as useStreamingText,
+} from '.';
+export type {
+  XDSInteractiveRole as InteractiveRole,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/naming.test.ts
+++ b/packages/core/src/naming.test.ts
@@ -1,0 +1,69 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {describe, it, expect} from 'vitest';
+import {
+  LEGACY_NAMESPACE,
+  NAMESPACE,
+  classPrefix,
+  legacyClassPrefix,
+  dataAttrNamespace,
+  legacyDataAttrNamespace,
+  cssVarNamespace,
+  legacyCssVarNamespace,
+  stableClassName,
+  legacyStableClassName,
+  dataAttr,
+  legacyDataAttr,
+  cssVar,
+  legacyCssVar,
+} from './naming';
+
+describe('naming constants', () => {
+  it('exposes the legacy and new namespace prefixes', () => {
+    expect(LEGACY_NAMESPACE).toBe('xds');
+    expect(NAMESPACE).toBe('astryx');
+  });
+
+  it('derives per-surface prefixes from the namespaces', () => {
+    expect(classPrefix).toBe('astryx');
+    expect(legacyClassPrefix).toBe('xds');
+    expect(dataAttrNamespace).toBe('astryx');
+    expect(legacyDataAttrNamespace).toBe('xds');
+    expect(cssVarNamespace).toBe('astryx');
+    expect(legacyCssVarNamespace).toBe('xds');
+  });
+});
+
+describe('stableClassName', () => {
+  it('builds new-namespace class tokens', () => {
+    expect(stableClassName('button')).toBe('astryx-button');
+    expect(stableClassName('card')).toBe('astryx-card');
+  });
+
+  it('builds legacy class tokens preserving the current contract', () => {
+    expect(legacyStableClassName('button')).toBe('xds-button');
+    expect(legacyStableClassName('card')).toBe('xds-card');
+  });
+});
+
+describe('dataAttr', () => {
+  it('builds new-namespace data attribute names', () => {
+    expect(dataAttr('theme')).toBe('data-astryx-theme');
+    expect(dataAttr('media')).toBe('data-astryx-media');
+  });
+
+  it('builds legacy data attribute names', () => {
+    expect(legacyDataAttr('theme')).toBe('data-xds-theme');
+    expect(legacyDataAttr('media')).toBe('data-xds-media');
+  });
+});
+
+describe('cssVar', () => {
+  it('builds new-namespace custom property names', () => {
+    expect(cssVar('card-padding')).toBe('--astryx-card-padding');
+  });
+
+  it('builds legacy custom property names', () => {
+    expect(legacyCssVar('card-padding')).toBe('--xds-card-padding');
+  });
+});

--- a/packages/core/src/naming.ts
+++ b/packages/core/src/naming.ts
@@ -1,0 +1,137 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file naming.ts
+ * @input None (pure constants/helpers)
+ * @output Centralized namespace-prefix constants and helpers for all
+ *   externally-observable XDS name surfaces: CSS classes, data attributes,
+ *   CSS custom properties, and CSS layer names.
+ * @position Single source of truth consumed by the runtime (components,
+ *   theme generation) AND by build/CLI tooling (build-theme.mjs, discovery)
+ *   via the `@xds/core/naming` subpath export.
+ *
+ * ## Why this module exists
+ *
+ * The literal string `xds` is part of several externally-observable contracts
+ * (`.xds-button` classes, `data-xds-theme` attributes, `--xds-card-padding`
+ * custom properties, `@layer xds-base`). Historically each of these was
+ * hardcoded independently across the runtime, the theme build pipeline, and
+ * discovery tooling, kept in sync only by `<!-- SYNC: ... -->` comments.
+ *
+ * The XDS-prefix migration (see P2380608025) removes the `XDS` prefix from
+ * React identifiers and rebrands the DOM/CSS namespace `xds` -> `astryx`.
+ * Centralizing the prefix here means the dual-emit compatibility layer and the
+ * eventual cutover flip in ONE place instead of hundreds of literals.
+ *
+ * ## Surfaces and their migration policy (locked in P0)
+ *
+ * - CSS classes (`xds-button` -> `astryx-button`): REBRAND. Dual-emit during
+ *   compat via {@link classPrefix} / {@link stableClassName}.
+ * - data attributes (`data-xds-*` -> `data-astryx-*`): REBRAND. Only 3 of 15
+ *   are consumer-observable and dual-emitted; the rest rename outright.
+ * - CSS custom properties (`--xds-card-padding` -> `--astryx-card-padding`):
+ *   REBRAND with an inverted read fallback so legacy overrides win during compat.
+ * - CSS layers (`xds-base` / `xds-theme`): UNCHANGED through the compat window
+ *   (a CSS layer cannot be aliased); renamed only at final cutover.
+ *
+ * SYNC: packages/core/src/utils/xdsThemeProps.ts (consumes classPrefix)
+ * SYNC: packages/core/src/utils/parseStyleKey.ts
+ * SYNC: packages/cli/src/commands/build-theme.mjs (imports @xds/core/naming)
+ */
+
+/**
+ * The current (legacy) DOM/CSS namespace prefix.
+ *
+ * This is the prefix that ships TODAY and that all existing consumer code
+ * targets (`.xds-button`, `data-xds-theme`, `--xds-card-padding`). It remains
+ * the emitted prefix until the new prefix is introduced behind the compat
+ * layer, and remains a *compat* prefix (dual-emitted / fallback-read) until the
+ * final cutover removes it.
+ */
+export const LEGACY_NAMESPACE = 'xds';
+
+/**
+ * The new DOM/CSS namespace prefix introduced by the un-prefix migration.
+ *
+ * During the compatibility window the library emits BOTH {@link NAMESPACE} and
+ * {@link LEGACY_NAMESPACE} forms for consumer-observable surfaces (classes,
+ * theme/media data attributes). At final cutover the legacy form is removed.
+ */
+export const NAMESPACE = 'astryx';
+
+/**
+ * Class-name prefix for stable component classes, WITHOUT the trailing dash.
+ *
+ * Use {@link stableClassName} to build a full class token rather than
+ * concatenating this directly.
+ */
+export const classPrefix = NAMESPACE;
+
+/** Legacy class-name prefix (compat). */
+export const legacyClassPrefix = LEGACY_NAMESPACE;
+
+/**
+ * data-attribute namespace segment (the part between `data-` and the rest).
+ * e.g. `dataAttrNamespace` = 'astryx' -> `data-astryx-theme`.
+ */
+export const dataAttrNamespace = NAMESPACE;
+
+/** Legacy data-attribute namespace segment (compat). */
+export const legacyDataAttrNamespace = LEGACY_NAMESPACE;
+
+/**
+ * CSS custom-property namespace segment.
+ * e.g. `--astryx-card-padding`.
+ */
+export const cssVarNamespace = NAMESPACE;
+
+/** Legacy CSS custom-property namespace segment (compat). */
+export const legacyCssVarNamespace = LEGACY_NAMESPACE;
+
+/**
+ * Build a stable component class token, e.g. `stableClassName('button')`
+ * -> `'astryx-button'`.
+ */
+export function stableClassName(component: string): string {
+  return `${classPrefix}-${component}`;
+}
+
+/**
+ * Build the legacy stable component class token (compat), e.g.
+ * `legacyStableClassName('button')` -> `'xds-button'`.
+ */
+export function legacyStableClassName(component: string): string {
+  return `${legacyClassPrefix}-${component}`;
+}
+
+/**
+ * Build a `data-*` attribute name in the current namespace, e.g.
+ * `dataAttr('theme')` -> `'data-astryx-theme'`.
+ */
+export function dataAttr(name: string): `data-${string}` {
+  return `data-${dataAttrNamespace}-${name}`;
+}
+
+/**
+ * Build a legacy `data-*` attribute name (compat), e.g.
+ * `legacyDataAttr('theme')` -> `'data-xds-theme'`.
+ */
+export function legacyDataAttr(name: string): `data-${string}` {
+  return `data-${legacyDataAttrNamespace}-${name}`;
+}
+
+/**
+ * Build a CSS custom-property name in the current namespace, e.g.
+ * `cssVar('card-padding')` -> `'--astryx-card-padding'`.
+ */
+export function cssVar(name: string): string {
+  return `--${cssVarNamespace}-${name}`;
+}
+
+/**
+ * Build a legacy CSS custom-property name (compat), e.g.
+ * `legacyCssVar('card-padding')` -> `'--xds-card-padding'`.
+ */
+export function legacyCssVar(name: string): string {
+  return `--${legacyCssVarNamespace}-${name}`;
+}

--- a/packages/core/src/theme/defineTheme.test.ts
+++ b/packages/core/src/theme/defineTheme.test.ts
@@ -825,10 +825,10 @@ describe('container padding mapping', () => {
     // Should NOT emit raw padding property (only the scoped token)
     expect(css).not.toMatch(/[^-]padding: 20px/);
     // Should emit component-scoped shorthand token
-    expect(css).toContain('--xds-card-padding: 20px');
+    expect(css).toContain('--astryx-card-padding: 20px');
     // Should NOT emit directional tokens (shorthand covers all sides)
-    expect(css).not.toContain('--xds-card-padding-inline');
-    expect(css).not.toContain('--xds-card-padding-block-start');
+    expect(css).not.toContain('--astryx-card-padding-inline');
+    expect(css).not.toContain('--astryx-card-padding-block-start');
   });
 
   it('maps asymmetric padding to directional tokens', () => {
@@ -841,11 +841,11 @@ describe('container padding mapping', () => {
       },
     });
     const css = generateThemeCSSFlat(theme);
-    expect(css).toContain('--xds-card-padding-inline: 20px');
-    expect(css).toContain('--xds-card-padding-block-start: 16px');
-    expect(css).toContain('--xds-card-padding-block-end: 16px');
+    expect(css).toContain('--astryx-card-padding-inline: 20px');
+    expect(css).toContain('--astryx-card-padding-block-start: 16px');
+    expect(css).toContain('--astryx-card-padding-block-end: 16px');
     // Should NOT emit shorthand (sides differ)
-    expect(css).not.toMatch(/--xds-card-padding:[^-]/);
+    expect(css).not.toMatch(/--astryx-card-padding:[^-]/);
   });
 
   it('maps paddingBlock and paddingInline separately', () => {
@@ -858,9 +858,9 @@ describe('container padding mapping', () => {
       },
     });
     const css = generateThemeCSSFlat(theme);
-    expect(css).toContain('--xds-card-padding-inline: 16px');
-    expect(css).toContain('--xds-card-padding-block-start: 24px');
-    expect(css).toContain('--xds-card-padding-block-end: 24px');
+    expect(css).toContain('--astryx-card-padding-inline: 16px');
+    expect(css).toContain('--astryx-card-padding-block-start: 24px');
+    expect(css).toContain('--astryx-card-padding-block-end: 24px');
   });
 
   it('works for section and dialog too', () => {
@@ -877,10 +877,10 @@ describe('container padding mapping', () => {
     });
     const css = generateThemeCSSFlat(theme);
     // Section — uniform → shorthand
-    expect(css).toContain('--xds-section-padding: 12px');
+    expect(css).toContain('--astryx-section-padding: 12px');
     // Dialog — asymmetric → directional
-    expect(css).toContain('--xds-dialog-padding-inline: 32px');
-    expect(css).toContain('--xds-dialog-padding-block-start: 24px');
+    expect(css).toContain('--astryx-dialog-padding-inline: 32px');
+    expect(css).toContain('--astryx-dialog-padding-block-start: 24px');
   });
 
   it('does NOT map padding on non-container components', () => {
@@ -916,7 +916,7 @@ describe('container padding mapping', () => {
     expect(css).toContain('--_card-radius: 16px');
     expect(css).toContain('background-color: white');
     // Padding is mapped to component-scoped token
-    expect(css).toContain('--xds-card-padding: 20px');
+    expect(css).toContain('--astryx-card-padding: 20px');
     expect(css).not.toMatch(/[^-]padding: 20px/);
   });
 
@@ -930,9 +930,9 @@ describe('container padding mapping', () => {
       },
     });
     const css = generateThemeCSSFlat(theme);
-    expect(css).toContain('--xds-card-padding-block-start: 16px');
-    expect(css).toContain('--xds-card-padding-block-end: 12px');
-    expect(css).toContain('--xds-card-padding-inline: 20px');
+    expect(css).toContain('--astryx-card-padding-block-start: 16px');
+    expect(css).toContain('--astryx-card-padding-block-end: 12px');
+    expect(css).toContain('--astryx-card-padding-inline: 20px');
   });
 
   it('maps paddingBlock shorthand with two values', () => {
@@ -945,8 +945,8 @@ describe('container padding mapping', () => {
       },
     });
     const css = generateThemeCSSFlat(theme);
-    expect(css).toContain('--xds-card-padding-block-start: 16px');
-    expect(css).toContain('--xds-card-padding-block-end: 24px');
+    expect(css).toContain('--astryx-card-padding-block-start: 16px');
+    expect(css).toContain('--astryx-card-padding-block-end: 24px');
   });
 
   it('maps paddingInline shorthand with two values', () => {
@@ -959,8 +959,8 @@ describe('container padding mapping', () => {
       },
     });
     const css = generateThemeCSSFlat(theme);
-    expect(css).toContain('--xds-card-padding-inline-start: 12px');
-    expect(css).toContain('--xds-card-padding-inline-end: 20px');
+    expect(css).toContain('--astryx-card-padding-inline-start: 12px');
+    expect(css).toContain('--astryx-card-padding-inline-end: 20px');
   });
 
   it('maps paddingBlockStart alone', () => {
@@ -973,9 +973,9 @@ describe('container padding mapping', () => {
       },
     });
     const css = generateThemeCSSFlat(theme);
-    expect(css).toContain('--xds-card-padding-block-start: 32px');
-    expect(css).not.toContain('--xds-card-padding-block-end');
-    expect(css).not.toContain('--xds-card-padding-inline');
+    expect(css).toContain('--astryx-card-padding-block-start: 32px');
+    expect(css).not.toContain('--astryx-card-padding-block-end');
+    expect(css).not.toContain('--astryx-card-padding-inline');
   });
 
   it('maps paddingInlineStart and paddingInlineEnd separately', () => {
@@ -988,8 +988,8 @@ describe('container padding mapping', () => {
       },
     });
     const css = generateThemeCSSFlat(theme);
-    expect(css).toContain('--xds-card-padding-inline-start: 8px');
-    expect(css).toContain('--xds-card-padding-inline-end: 24px');
+    expect(css).toContain('--astryx-card-padding-inline-start: 8px');
+    expect(css).toContain('--astryx-card-padding-inline-end: 24px');
   });
 });
 

--- a/packages/core/src/theme/generateThemeRules.test.ts
+++ b/packages/core/src/theme/generateThemeRules.test.ts
@@ -321,8 +321,8 @@ describe('derived var expansion', () => {
     const rules = generateThemeRules(theme);
     const rule = rules.find(r => r.includes('.xds-card'));
     expect(rule).toBeDefined();
-    // Container expansion emits --xds-card-padding token
-    expect(rule).toContain('--xds-card-padding: 20px');
+    // Container expansion emits --astryx-card-padding token
+    expect(rule).toContain('--astryx-card-padding: 20px');
   });
 
   it('handles variant-specific derived vars', () => {
@@ -372,7 +372,7 @@ describe('brutalist-style derived expansion', () => {
     const rules = generateThemeRules(theme);
     const rule = rules.find(r => r.includes('.xds-card'));
     expect(rule).toBeDefined();
-    expect(rule).toContain('--xds-card-padding: 24px');
+    expect(rule).toContain('--astryx-card-padding: 24px');
   });
 
   it('dropdown-menu borderRadius + padding emit both derived vars', () => {

--- a/packages/core/src/theme/generateThemeRules.ts
+++ b/packages/core/src/theme/generateThemeRules.ts
@@ -18,6 +18,7 @@
 import type {XDSDefinedTheme} from './defineTheme';
 import {parseStyleKey} from '../utils/parseStyleKey';
 import {getDerivedVars} from './derivedVarRegistry';
+import {cssVar} from '../naming';
 
 // =============================================================================
 // Types
@@ -144,12 +145,16 @@ function parsePadding(props: [string, string][]): ParsedPadding {
 /**
  * Expand parsed padding into component-scoped public tokens.
  *
- * Emits --xds-<component>-padding (shorthand) and directional overrides:
- *   --xds-card-padding: 20px
- *   --xds-card-padding-inline: 20px
- *   --xds-card-padding-block-start: 20px
- *   --xds-card-padding-block-end: 20px
+ * Emits the rebranded --astryx-<component>-padding tokens (shorthand +
+ * directional overrides), e.g.:
+ *   --astryx-card-padding: 20px
+ *   --astryx-card-padding-inline: 20px
+ *   --astryx-card-padding-block-start: 20px
+ *   --astryx-card-padding-block-end: 20px
  *
+ * The component reads these with an inverted fallback chain
+ * (var(--xds-*, var(--astryx-*, default))) so a legacy --xds-* override set by
+ * existing consumer code still wins during the compat window (P2380608025).
  * The container.stylex.ts default styles read these via var() fallbacks,
  * so the theme CSS sets the value and the component picks it up through
  * CSS custom property cascade — no layer competition with StyleX output.
@@ -158,7 +163,7 @@ function expandContainerPadding(
   component: string,
   parsed: ParsedPadding,
 ): [string, string][] {
-  const prefix = `--xds-${component}-padding`;
+  const prefix = cssVar(`${component}-padding`);
   const tokens: [string, string][] = [];
 
   // Resolve effective inline values (inlineStart/End override inline)

--- a/packages/core/src/theme/index.ts
+++ b/packages/core/src/theme/index.ts
@@ -159,3 +159,40 @@ export type {
   TypographyRole,
   FontWeight,
 } from './types';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export {
+  XDSMediaTheme as MediaTheme,
+  XDSTheme as Theme,
+  XDSThemeContext as ThemeContext,
+  useXDSSyntaxTheme as useSyntaxTheme,
+  useXDSTheme as useTheme,
+} from '.';
+export type {
+  XDSBuiltinTextType as BuiltinTextType,
+  XDSColorScaleConfig as ColorScaleConfig,
+  XDSComponentStyleMap as ComponentStyleMap,
+  XDSCoreTokenName as CoreTokenName,
+  XDSCustomTextTypes as CustomTextTypes,
+  XDSDefineThemeInput as DefineThemeInput,
+  XDSDefinedTheme as DefinedTheme,
+  XDSMediaThemeProps as MediaThemeProps,
+  XDSMotionScaleConfig as MotionScaleConfig,
+  XDSRadiusScaleConfig as RadiusScaleConfig,
+  XDSResolvedThemeMode as ResolvedThemeMode,
+  XDSStyleOverrides as StyleOverrides,
+  XDSTextColor as TextColor,
+  XDSTextSize as TextSize,
+  XDSTextType as TextType,
+  XDSTextWeight as TextWeight,
+  XDSThemeContextValue as ThemeContextValue,
+  XDSTokenName as TokenName,
+  XDSTokenValue as TokenValue,
+  XDSTypeScaleConfig as TypeScaleConfig,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -72,3 +72,15 @@ export {groupItems, getItemGroup} from './groupItems';
 export type {ItemGroup} from './groupItems';
 export {observeResize, unobserveResize} from './sharedResizeObserver';
 export {isRenderable} from './isRenderable';
+
+
+// <compat-aliases:start> — generated, do not edit by hand
+// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).
+// Prefixed names above remain canonical + module-augmentation targets.
+// These bare re-exports reference the SAME values/types.
+// Regenerate: node scripts/generate-compat-aliases.mjs
+export type {
+  XDSKey as Key,
+  XDSKeyFallback as KeyFallback,
+} from '.';
+// <compat-aliases:end>

--- a/packages/core/src/utils/xdsThemeProps.ts
+++ b/packages/core/src/utils/xdsThemeProps.ts
@@ -1,5 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+import {legacyStableClassName} from '../naming';
+
 export type XDSClassValue = string | number | undefined | null;
 export type XDSClassProps = Record<string, XDSClassValue>;
 export type XDSThemeDataAttributes = Record<
@@ -26,6 +28,10 @@ function classTokenForPropValue(prop: string, value: string): string {
  * `data-size`, `data-level`, etc.) so consumers can migrate CSS selectors
  * away from collision-prone bare class names while old selectors keep working.
  *
+ * The `xds-`/`astryx-` prefix comes from the centralized naming module
+ * (`packages/core/src/naming.ts`) so the prefix migration flips in one place.
+ *
+ * <!-- SYNC: packages/core/src/naming.ts (namespace prefix source of truth) -->
  * <!-- SYNC: packages/cli/src/commands/build-theme.mjs (parseStyleKey + selector generation) -->
  * <!-- SYNC: packages/core/src/utils/parseStyleKey.ts -->
  *
@@ -50,7 +56,7 @@ function classTokenForPropValue(prop: string, value: string): string {
  * ```
  */
 function legacyClassName(component: string, props?: XDSClassProps): string {
-  const classes = [`xds-${component}`];
+  const classes = [legacyStableClassName(component)];
 
   if (props) {
     for (const [prop, value] of Object.entries(props)) {

--- a/scripts/check-sync.js
+++ b/scripts/check-sync.js
@@ -29,7 +29,31 @@ function addViolation(type, file, message) {
   violations.push({type, file, message});
 }
 
-// Get all component directories (dirs with at least one XDS*.tsx file)
+// A component source file is `XDS{Name}.tsx` today, or the bare `{Name}.tsx`
+// after the XDS-prefix migration (P2380608025, P4). Match both, excluding
+// tests, `use*` hooks, and `*Context.*` files. As in component discovery, a
+// BARE-named file is only treated as a component when a sibling doc exists
+// (`{Name}.doc.mjs` or `XDS{Name}.doc.mjs`) — otherwise internal PascalCase
+// helpers (OverlayScrim.tsx, PowerSearchEditPopover.tsx, ...) would be
+// misclassified. Prefixed files keep their existing behavior.
+// Mirrors packages/cli/src/lib/component-discovery.mjs (inlined; CommonJS).
+function isComponentSourceFile(fileName, dirPath) {
+  if (!fileName.endsWith('.tsx')) return false;
+  if (fileName.includes('.test.') || fileName.includes('Context.')) {
+    return false;
+  }
+  if (/^XDS[A-Z]\w+\.tsx$/.test(fileName)) return true;
+  if (/^[A-Z]\w+\.tsx$/.test(fileName)) {
+    const base = fileName.slice(0, -'.tsx'.length);
+    return (
+      fs.existsSync(path.join(dirPath, `${base}.doc.mjs`)) ||
+      fs.existsSync(path.join(dirPath, `XDS${base}.doc.mjs`))
+    );
+  }
+  return false;
+}
+
+// Get all component directories (dirs with at least one component source file)
 const componentDirs = fs
   .readdirSync(CORE_SRC, {withFileTypes: true})
   .filter((d) => d.isDirectory())
@@ -38,10 +62,7 @@ const componentDirs = fs
     const dirPath = path.join(CORE_SRC, name);
     return fs
       .readdirSync(dirPath)
-      .some(
-        (f) =>
-          f.startsWith('XDS') && f.endsWith('.tsx') && !f.includes('.test.'),
-      );
+      .some((f) => isComponentSourceFile(f, dirPath));
   });
 
 for (const comp of componentDirs) {
@@ -60,9 +81,7 @@ for (const comp of componentDirs) {
   }
 
   // --- Check 2 & 3: SYNC references ---
-  const xdsFiles = files.filter(
-    (f) => f.startsWith('XDS') && f.endsWith('.tsx') && !f.includes('.test.'),
-  );
+  const xdsFiles = files.filter((f) => isComponentSourceFile(f, dirPath));
 
   for (const xdsFile of xdsFiles) {
     const filePath = path.join(dirPath, xdsFile);

--- a/scripts/generate-compat-aliases.mjs
+++ b/scripts/generate-compat-aliases.mjs
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+/**
+ * @file generate-compat-aliases.mjs
+ * @description Codegen for the XDS-prefix migration compatibility layer
+ *   (P2380608025). Appends unprefixed alias re-exports alongside the
+ *   existing XDS* exports in component barrel files (index.ts).
+ *
+ *   Idempotent: strips the old generated block, re-generates from scratch.
+ *   Skips aliases whose bare name already exists in the barrel.
+ *
+ *   Usage:
+ *     node scripts/generate-compat-aliases.mjs           # write in place
+ *     node scripts/generate-compat-aliases.mjs --check   # exit 1 if stale
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SRC = path.resolve(__dirname, '../packages/core/src');
+const MARKER_START = '// <compat-aliases:start> — generated, do not edit by hand';
+const MARKER_END = '// <compat-aliases:end>';
+
+/** Strip block + line comments from TS source. */
+function stripComments(txt) {
+  return txt.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*/g, '');
+}
+
+/**
+ * Parse all export statements from a barrel file into structured entries.
+ * Returns [{name, alias?, source, isType}] where `name` is the imported
+ * identifier, `alias` is the exported name (if renamed), and `source` is
+ * the module specifier string.
+ */
+function parseExportEntries(txt) {
+  const clean = stripComments(txt);
+  const entries = [];
+  // Matches: export [type] { ... } from '...'
+  // Also inline: export { X, type Y } from '...'
+  const re = /export\s+(type\s+)?\{([^}]*)\}\s*from\s*['"]([^'"]+)['"]/g;
+  let m;
+  while ((m = re.exec(clean))) {
+    const blockIsType = Boolean(m[1]);
+    const specifiers = m[2];
+    const source = m[3];
+    for (let part of specifiers.split(',')) {
+      part = part.trim();
+      if (!part) continue;
+      let isType = blockIsType;
+      if (part.startsWith('type ')) {
+        isType = true;
+        part = part.slice(5).trim();
+      }
+      let name, alias;
+      if (part.includes(' as ')) {
+        [name, alias] = part.split(/\s+as\s+/);
+      } else {
+        name = part;
+        alias = part;
+      }
+      entries.push({name: name.trim(), alias: alias.trim(), source, isType});
+    }
+  }
+  return entries;
+}
+
+/** Compute the bare (unprefixed) name for an XDS* or useXDS* identifier. */
+function bareName(id) {
+  if (id.startsWith('useXDS')) return 'use' + id.slice(6);
+  if (id.startsWith('XDS')) return id.slice(3);
+  return null;
+}
+
+/**
+ * Pre-pass: collect bare (non-XDS) names already exported by ANY barrel.
+ * The root barrel uses `export *`, so a generated bare alias that duplicates
+ * an existing bare export elsewhere causes TS2308 ambiguity. We skip those.
+ */
+function collectExistingBareNames() {
+  const bare = new Set();
+  for (const entry of fs.readdirSync(SRC, {withFileTypes: true})) {
+    if (!entry.isDirectory()) continue;
+    const idx = path.join(SRC, entry.name, 'index.ts');
+    if (!fs.existsSync(idx)) continue;
+    let raw = fs.readFileSync(idx, 'utf8');
+    // Only look at the human-authored part (strip any generated block) so we
+    // don't treat previously-generated aliases as "existing".
+    if (raw.includes(MARKER_START)) raw = raw.slice(0, raw.indexOf(MARKER_START));
+    for (const e of parseExportEntries(raw)) {
+      if (!e.alias.startsWith('XDS') && !e.alias.startsWith('useXDS')) {
+        bare.add(e.alias);
+      }
+    }
+  }
+  return bare;
+}
+
+const EXISTING_BARE = collectExistingBareNames();
+
+function generateBlock(filePath) {
+  const raw = fs.readFileSync(filePath, 'utf8');
+  // Strip any previous generated block to make this idempotent.
+  const base = raw.includes(MARKER_START)
+    ? raw.slice(0, raw.indexOf(MARKER_START)).replace(/\n+$/, '\n')
+    : raw.replace(/\n+$/, '\n');
+
+  const entries = parseExportEntries(base);
+  // Collect all currently-exported names (the alias/exported-as side)
+  const existingNames = new Set(entries.map(e => e.alias));
+
+  // Build alias specifiers. Every alias re-exports from the barrel itself
+  // ('.') rather than the original source module: by the time this block runs,
+  // the prefixed name is already exported by this barrel, and re-exporting from
+  // '.' avoids the renamed-re-export problem (e.g. `X as XDSFoo from './src'`
+  // where './src' has no member named `XDSFoo`).
+  const valueSpecs = [];
+  const typeSpecs = [];
+
+  for (const entry of entries) {
+    const exported = entry.alias;
+    const bare = bareName(exported);
+    if (!bare) continue;
+    if (existingNames.has(bare)) continue; // skip if bare already exported in THIS barrel
+    if (EXISTING_BARE.has(bare)) continue; // skip if bare already exported by ANY barrel (root export * ambiguity)
+    const spec = `${exported} as ${bare}`;
+    (entry.isType ? typeSpecs : valueSpecs).push(spec);
+  }
+
+  // De-dup (a barrel may export the same prefixed name more than once).
+  const uniqValue = [...new Set(valueSpecs)].sort();
+  const uniqType = [...new Set(typeSpecs)].sort();
+  if (uniqValue.length === 0 && uniqType.length === 0) return {base, block: null};
+
+  const lines = [
+    '',
+    MARKER_START,
+    '// Unprefixed compatibility aliases (XDS-prefix migration P2380608025).',
+    '// Prefixed names above remain canonical + module-augmentation targets.',
+    '// These bare re-exports reference the SAME values/types.',
+    '// Regenerate: node scripts/generate-compat-aliases.mjs',
+  ];
+  if (uniqValue.length) {
+    lines.push('export {');
+    for (const v of uniqValue) lines.push(`  ${v},`);
+    lines.push("} from '.';");
+  }
+  if (uniqType.length) {
+    lines.push('export type {');
+    for (const t of uniqType) lines.push(`  ${t},`);
+    lines.push("} from '.';");
+  }
+  lines.push(MARKER_END);
+  return {base, block: lines.join('\n') + '\n'};
+}
+
+// Main
+const check = process.argv.includes('--check');
+let updated = 0;
+let stale = 0;
+
+for (const entry of fs.readdirSync(SRC, {withFileTypes: true})) {
+  if (!entry.isDirectory()) continue;
+  const idx = path.join(SRC, entry.name, 'index.ts');
+  if (!fs.existsSync(idx)) continue;
+
+  const {base, block} = generateBlock(idx);
+  const desired = block ? base + '\n' + block : base;
+
+  const current = fs.readFileSync(idx, 'utf8');
+  if (desired !== current) {
+    if (check) {
+      stale++;
+      console.error(`  stale: ${entry.name}/index.ts`);
+    } else {
+      fs.writeFileSync(idx, desired);
+      updated++;
+    }
+  }
+}
+
+if (check) {
+  if (stale) {
+    console.error(`\n${stale} barrel(s) have stale compat aliases.`);
+    console.error('Run: node scripts/generate-compat-aliases.mjs');
+    process.exit(1);
+  }
+  console.log('✓ Compat aliases up to date');
+} else {
+  console.log(`✓ Compat aliases: ${updated} barrel(s) updated`);
+}

--- a/scripts/sync-exports.js
+++ b/scripts/sync-exports.js
@@ -62,6 +62,11 @@ const STATIC_EXPORTS = {
     types: './src/tailwind-theme.css.d.ts',
     default: './src/tailwind-theme.css',
   },
+  './naming': {
+    source: './src/naming.ts',
+    types: './dist/naming.d.ts',
+    default: './dist/naming.js',
+  },
   './theme/tokens': {
     source: './src/theme/tokens.ts',
     types: './dist/theme/tokens.d.ts',
@@ -222,7 +227,7 @@ function main() {
 
   const dirs = discoverExportDirs();
   console.log(
-    `✓ Synced ${Object.keys(newExports).length} exports (${dirs.length} components/modules)`
+    `✓ Synced ${Object.keys(newExports).length} exports (${dirs.length} components/modules)`,
   );
 }
 


### PR DESCRIPTION
## XDS un-prefix migration — Part 1 of 3: Foundation (additive, no renames)

Recreates the foundational, **purely additive** commits of the un-prefix migration directly on top of current `main`. Nothing is renamed or removed here — this layer adds the compatibility surface and prefix-agnostic tooling that the later parts build on, so it's safe to land independently and early.

### What's included
- **Naming module** (#2861) — centralized prefix helpers for the migration
- **P1 compat layer** (#2864) — unprefixed alias re-exports alongside existing `XDS*` exports (regenerated for current `main`, so it picks up `XDSKey`/`XDSKeyFallback` added since the integration branch froze)
- **`drop-xds-prefix-imports` codemod** (#2879) — opt-in, consumer-run
- **Prefix-agnostic CLI/CI/build** (#2867, #2878, #2881, #2888) — component discovery, checks, configurable StyleX library prefix + theme-layer name
- **Padding-var rebrand with inverted-fallback compat** (#2882)
- **Vibe-test astryx target** (#2892, #2894)

### Why recreated (vs. cherry-picked from the integration branch)
`main` advanced ~50 commits since the integration branch last synced. These commits are recreated on current `main`, and the compat layer is **regenerated** (not replayed) so it reflects today's exports rather than a frozen snapshot.

### Validation (local)
- ✅ `pnpm -F @xds/core build` (Babel + tsc + CSS)
- ✅ `pnpm -F @xds/core typecheck` — 0 errors
- ✅ `pnpm check:repo` (sync-exports, compat-aliases, package boundaries)
- ✅ token-docs sync

### Stack
1. **Part 1 — Foundation** ← this PR
2. Part 2 — Bare names in CLI output / docs / templates
3. Part 3 — Source rename (P4) + snapshots/tests (P5/P6)

Part of the un-prefix migration recreation onto current `main`.
