### PR TITLE
fix(ci): pin Next.js sandbox cache key, drop poisoning restore-keys fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,10 +208,12 @@ jobs:
         uses: actions/cache@v5
         with:
           path: apps/sandbox/.next/cache
+          # No restore-keys fallback — see deploy.yml for the full rationale.
+          # The Next.js module cache bakes in @xds/core's resolved export graph,
+          # so a loose fallback can restore a cache built against a different
+          # export shape and silently produce wrong builds (broke #2941's
+          # post-merge deploy). A changed key yields a cold (safe) rebuild.
           key: nextjs-sandbox-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('packages/core/dist/**') }}
-          restore-keys: |
-            nextjs-sandbox-${{ hashFiles('pnpm-lock.yaml') }}-
-            nextjs-sandbox-
 
       - name: Build Storybook
         if: needs.check-scope.outputs.docsite_only != 'true'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -98,10 +98,20 @@ jobs:
         uses: actions/cache@v5
         with:
           path: apps/sandbox/.next/cache
+          # IMPORTANT: no restore-keys fallback. The key is pinned to the
+          # @xds/core dist hash because the Next.js module cache bakes in the
+          # resolved export graph of @xds/core. A loose restore-keys fallback
+          # (e.g. "nextjs-sandbox-<lock>-") would let a build restore a cache
+          # produced against a DIFFERENT export shape. That is exactly what
+          # broke the post-merge deploy of the XDS un-prefix migration (#2941):
+          # the migration changed core's exports (bare names, new subpaths), the
+          # exact key missed, and restore-keys fell back to a pre-migration
+          # cache whose compiled modules still expected XDS*-prefixed exports —
+          # producing "'Text' is not exported from '@xds/core/Text'" and
+          # "Element type is invalid ... undefined" prerender failures.
+          # A changed key now yields a COLD cache (safe rebuild) instead of a
+          # poisoned warm one.
           key: nextjs-sandbox-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('packages/core/dist/**') }}
-          restore-keys: |
-            nextjs-sandbox-${{ hashFiles('pnpm-lock.yaml') }}-
-            nextjs-sandbox-
 
       - name: Build Sandbox
         run: pnpm -F @xds/sandbox build


### PR DESCRIPTION
## Problem

The post-merge `deploy` job for the XDS un-prefix migration (#2941) failed at **Build Sandbox** with:
- `Attempted import error: 'Text' is not exported from '@xds/core/Text'` (theme-showcase)
- `Error: Element type is invalid ... got: undefined` prerendering `/pages/butter-palette`

…even though the **same commit's PR CI build passed** (byte-identical tree).

## Root cause: poisoned Next.js build cache via `restore-keys` fallback

`apps/sandbox/.next/cache` bakes in the **resolved export graph of `@xds/core`**. The cache key correctly included `hashFiles('packages/core/dist/**')`, but the loose `restore-keys` fallback defeated it:

```yaml
key: nextjs-sandbox-<lock>-<core/dist>
restore-keys: |
  nextjs-sandbox-<lock>-     # ← matches ANY core/dist (any export shape)
  nextjs-sandbox-            # ← matches ANYTHING
```

Sequence:
1. #2941 changed core's exports (bare names canonical + new `./astryx.css`, `./naming` subpaths) → new `packages/core/dist/**` hash → new cache key.
2. On `main`, the **exact** key missed. GitHub Actions caches are ref-scoped: the post-migration caches existed only on `refs/pull/2941/merge`, unreadable from `main`.
3. `restore-keys` fell back to a **pre-migration `main` cache** (built ~6h earlier) whose compiled Next modules still expected `XDS*`-prefixed exports.
4. `next build` reused those stale modules against the new bare-name source → the import/prerender failures above.
5. The PR build passed because its PR-scoped cache was built **post-migration** and was internally consistent.

(Confirmed empirically: deleting the stale `main`-ref `nextjs-sandbox-*` caches and re-running the deploy builds clean.)

## Fix

Remove the `restore-keys` fallback in both `deploy.yml` and `ci.yml`. The key still keys on the lock + core dist hashes, so a change now yields a **cold** cache (a correct, slightly slower rebuild) instead of a **poisoned warm** one.

## Risk

Low. Worst case is a one-time cold Next build whenever `pnpm-lock.yaml` or `@xds/core` dist changes — which is exactly when reusing the cache is unsafe.