### PR TITLE
fix(codemods): don't rewrite ambiguous 'info' variant in context-blind paths

### DIFF
--- a/packages/cli/src/codemods/transforms/v0.0.14/__tests__/rename-status-variants.test.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.14/__tests__/rename-status-variants.test.mjs
@@ -95,16 +95,19 @@ const args = { variant: 'positive' };`;
     expect(output).not.toContain("'positive'");
   });
 
-  it('renames Storybook argType options arrays', async () => {
+  it('renames unambiguous values in Storybook argType options arrays but leaves ambiguous "info"', async () => {
     const input = `import { XDSStatusDot } from '@xds/core/StatusDot';
 const meta = { argTypes: { variant: { options: ['positive', 'negative', 'warning', 'info', 'neutral'] } } };`;
     const output = await applyTransform(input);
     expect(output).toContain("'success'");
     expect(output).toContain("'error'");
-    expect(output).toContain("'accent'");
     expect(output).not.toContain("'positive'");
     expect(output).not.toContain("'negative'");
-    expect(output).not.toContain("'info'");
+    // 'info' is ambiguous (valid on Badge etc.) and this is a context-blind
+    // path — the codemod cannot tell which component the options describe, so
+    // it is left for human review rather than risk rewriting a valid value.
+    expect(output).toContain("'info'");
+    expect(output).not.toContain("'accent'");
     // warning and neutral are unchanged
     expect(output).toContain("'warning'");
     expect(output).toContain("'neutral'");
@@ -115,6 +118,44 @@ const meta = { argTypes: { variant: { options: ['positive', 'negative', 'warning
     const output = await applyTransform(input);
     // XDSBadge is not in the target list
     expect(output).toContain('info');
+  });
+
+  it('does not rewrite Badge config "info" in a file that also imports a target (Icon)', async () => {
+    // Regression: a file may import a target component (e.g. XDSIcon) AND
+    // declare a typed config object for a NON-target component (Badge, whose
+    // BadgeVariantMap still has `info`). The context-blind object-property path
+    // must NOT rewrite that `info` to `accent` just because the file imports a
+    // target — `accent` is not a valid Badge variant. positive/negative stay
+    // renamed (no component keeps them), but info is preserved.
+    const input = `import { XDSIcon } from '@xds/core/Icon';
+import { XDSBadge, type XDSBadgeVariant } from '@xds/core/Badge';
+const PROGRESS_CONFIG: Record<string, {label: string; variant: XDSBadgeVariant}> = {
+  OPEN: {label: 'Open', variant: 'info'},
+  DONE: {label: 'Done', variant: 'positive'},
+  BLOCKED: {label: 'Blocked', variant: 'negative'},
+};`;
+    const output = await applyTransform(input);
+    // Ambiguous 'info' on a Badge config is left intact.
+    expect(output).toContain("variant: 'info'");
+    expect(output).not.toContain("'accent'");
+    // Unambiguous values are still migrated (no component retains them).
+    expect(output).toContain("variant: 'success'");
+    expect(output).toContain("variant: 'error'");
+    expect(output).not.toContain("'positive'");
+    expect(output).not.toContain("'negative'");
+  });
+
+  it('still renames "info" to "accent" on a direct target JSX attribute', async () => {
+    // The precise path (component is known) keeps the full mapping, including
+    // the ambiguous info -> accent, even when other components are imported.
+    const input = `import { XDSStatusDot } from '@xds/core/StatusDot';
+import { XDSBadge } from '@xds/core/Badge';
+const a = <XDSStatusDot variant="info" label="Status" />;
+const b = <XDSBadge variant="info" label="New" />;`;
+    const output = await applyTransform(input);
+    // StatusDot's info -> accent (precise), Badge's info stays.
+    expect(output).toContain("<XDSStatusDot variant='accent'");
+    expect(output).toContain('<XDSBadge variant="info"');
   });
 
   it('does not touch unrelated props on target components', async () => {

--- a/packages/cli/src/codemods/transforms/v0.0.14/rename-status-variants.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.14/rename-status-variants.mjs
@@ -23,7 +23,11 @@ export const meta = {
   title: 'Rename status variants positive/negative → success/error',
   description:
     'Renames `positive` to `success`, `negative` to `error`, and `info` to `accent` ' +
-    'on StatusDot, AvatarStatusDot, Icon, SVGIcon, and ProgressBar to align with token naming.',
+    'on StatusDot, AvatarStatusDot, Icon, SVGIcon, and ProgressBar to align with token naming. ' +
+    'The `info` -> `accent` rename is only applied to direct JSX attributes on these ' +
+    'components (where the component is known); in context-blind locations (object ' +
+    'properties, type unions) `info` is left untouched because it is a valid variant on ' +
+    'other components such as Badge.',
   pr: '#996',
 };
 
@@ -33,6 +37,21 @@ const RENAMES = new Map([
   ['negative', 'error'],
   ['info', 'accent'],
 ]);
+
+/**
+ * Ambiguous renames that are only safe when the target component is known.
+ *
+ * `info` is a VALID variant on non-target components (notably XDSBadge, whose
+ * BadgeVariantMap still has `info`). `positive`/`negative` are not retained by
+ * any component post-migration, so renaming them is always safe. Therefore the
+ * context-blind heuristic paths (object properties, type unions, and suffixed
+ * props on wrapper components) must NOT rewrite `info` — only the precise path,
+ * a direct JSX attribute on a known target component, may. Otherwise a
+ * `variant: 'info'` on an unrelated Badge config in a file that merely also
+ * imports e.g. XDSIcon gets wrongly rewritten to the invalid `accent`.
+ */
+const AMBIGUOUS_VALUES = new Set(['info']);
+
 
 /**
  * Components and which props are affected.
@@ -77,7 +96,7 @@ export default function transformer(file, api) {
    * Unwraps TSAsExpression (e.g. 'positive' as const) to reach the literal.
    * @returns {boolean} whether a rename occurred
    */
-  function renameValue(node) {
+  function renameValue(node, {precise = false} = {}) {
     if (!node) return false;
 
     // Unwrap TSAsExpression (e.g. 'positive' as const → StringLiteral)
@@ -90,6 +109,12 @@ export default function transformer(file, api) {
     const replacement = RENAMES.get(target.value);
     if (!replacement) return false;
 
+    // Ambiguous values (e.g. `info`) are only renamed in a precise context
+    // where the target component is known (a direct JSX attribute on a target).
+    // In context-blind paths they may belong to a component that legitimately
+    // keeps the value (e.g. Badge's `info`), so leave them untouched.
+    if (!precise && AMBIGUOUS_VALUES.has(target.value)) return false;
+
     target.value = replacement;
     if (target.raw) target.raw = undefined;
     return true;
@@ -98,12 +123,12 @@ export default function transformer(file, api) {
   /**
    * Rename elements in an array (handles TSAsExpression wrapping).
    */
-  function renameArrayElements(node) {
+  function renameArrayElements(node, {precise = false} = {}) {
     let arrayNode = node;
     if (arrayNode.type === 'TSAsExpression') arrayNode = arrayNode.expression;
     if (arrayNode.type !== 'ArrayExpression') return;
     arrayNode.elements.forEach((el) => {
-      if (renameValue(el)) hasChanges = true;
+      if (renameValue(el, {precise})) hasChanges = true;
     });
   }
 
@@ -137,10 +162,15 @@ export default function transformer(file, api) {
         if (!matchesPropName(attrName) || TARGET_PROP_NAMES.has(attrName)) return;
       }
 
+      // Only a direct JSX attribute on a target component is a precise context
+      // where the component (and thus the validity of `info`) is known. The
+      // wrapper/suffixed-prop case is a heuristic and must not touch ambiguous
+      // values.
+      const precise = isDirectTarget;
       const value = attr.value;
 
       // variant="positive" (string literal)
-      if (renameValue(value)) {
+      if (renameValue(value, {precise})) {
         hasChanges = true;
         return;
       }
@@ -151,15 +181,17 @@ export default function transformer(file, api) {
         value.type === 'JSXExpressionContainer' &&
         value.expression
       ) {
-        if (renameValue(value.expression)) {
+        if (renameValue(value.expression, {precise})) {
           hasChanges = true;
           return;
         }
 
         // variant={condition ? 'positive' : 'negative'} (ternary)
         if (value.expression.type === 'ConditionalExpression') {
-          if (renameValue(value.expression.consequent)) hasChanges = true;
-          if (renameValue(value.expression.alternate)) hasChanges = true;
+          if (renameValue(value.expression.consequent, {precise}))
+            hasChanges = true;
+          if (renameValue(value.expression.alternate, {precise}))
+            hasChanges = true;
         }
       }
     });


### PR DESCRIPTION
## Problem

The v0.0.14 `rename-status-variants` codemod maps `positive`→`success`, `negative`→`error`, `info`→`accent` on StatusDot/AvatarStatusDot/Icon/ProgressBar.

Its **object-property** and **type-union** passes (sections 2 & 3) fire whenever a file imports *any* target component, then rewrite every `variant`/`color` value they find — **without knowing which component that value belongs to.** That over-applies the `info`→`accent` rename, because `info` is a **valid** variant on non-target components (notably `Badge`, whose `BadgeVariantMap` still has `info`) — but `accent` is not.

So a Badge config in a file that *also* imports a target component:

```ts
import { Icon } from '@xds/core/Icon';            // a codemod target
import { Badge, type BadgeVariant } from '@xds/core/Badge';

const PROGRESS_CONFIG: Record<string, {variant: BadgeVariant}> = {
  OPEN: { variant: 'info' },   // ← valid Badge variant
};
```

…got rewritten to `variant: 'accent'` — **not a valid Badge variant**, breaking the build. Hit in practice while upgrading `@nest/xds-meta` to the 0.0.14 canary (`HovercardTaskStatus.tsx`).

## Fix

`info` is **ambiguous** — only safe to rename when the target component is known. So it is now renamed **only in a precise context**: a direct JSX attribute on a known target component (section 1, `isDirectTarget`). In context-blind paths — object properties, type unions, and the suffixed-prop wrapper heuristic — the ambiguous `info` is left untouched for human review.

`positive`/`negative` are **not** retained by any component post-migration, so they keep renaming everywhere (no risk of a valid-value collision).

- `renameValue` / `renameArrayElements` take a `{precise}` flag; only direct-target JSX attributes pass `precise: true`.
- Updated the Storybook-options test: `info` is now preserved in that blind path (the codemod can't know the story's component — a stale option is cosmetic, a corrupted valid value is not).
- Added regression tests: the Badge-config false positive, and the still-correct precise StatusDot `info`→`accent`.

## Test

All 18 `rename-status-variants` tests pass (`vitest run rename-status-variants`).