### PR TITLE
fix(cli): use bare component names in CLI doc/usage examples

### DIFF
--- a/packages/cli/src/commands/build-theme.mjs
+++ b/packages/cli/src/commands/build-theme.mjs
@@ -1221,18 +1221,18 @@ Install in your app:
   import { ${exportName} } from '${importPrefix}${baseName}';
   import '${importPrefix}${baseName}.css';
 
-  <XDSTheme theme={${exportName}}>
+  <Theme theme={${exportName}}>
     <App />
-  </XDSTheme>
+  </Theme>
 
 Or with a <link> tag:
 
   import { ${exportName} } from '${importPrefix}${baseName}';
 
   <link rel="stylesheet" href="${importPrefix}${baseName}.css" />
-  <XDSTheme theme={${exportName}}>
+  <Theme theme={${exportName}}>
     <App />
-  </XDSTheme>
+  </Theme>
 `);
 
       // Print font declaration warnings (derived from typography roles)

--- a/packages/cli/src/commands/component/index.mjs
+++ b/packages/cli/src/commands/component/index.mjs
@@ -107,7 +107,7 @@ export function registerComponent(program) {
               }
             }
             humanLog('');
-            humanLog(`Import from the path shown (e.g. import {XDSButton} from '@xds/core/Button')`);
+            humanLog(`Import from the path shown (e.g. import {Button} from '@xds/core/Button')`);
             humanLog(`Usage: ${run} xds component <name>`);
             humanLog('');
           }
@@ -130,7 +130,7 @@ export function registerComponent(program) {
             }
             humanLog('');
           }
-          humanLog(`Import from the path shown (e.g. import {XDSButton} from '@xds/core/Button')`);
+          humanLog(`Import from the path shown (e.g. import {Button} from '@xds/core/Button')`);
           humanLog(`Usage: ${run} xds component <name>`);
           humanLog('');
           break;

--- a/packages/cli/src/commands/init.mjs
+++ b/packages/cli/src/commands/init.mjs
@@ -244,10 +244,10 @@ export function registerInit(program) {
 
       humanLog('');
       humanLog('  Next steps:');
-      humanLog("    1. Import components: import { XDSButton } from '@xds/core'");
+      humanLog("    1. Import components: import { Button } from '@xds/core'");
       humanLog('    2. Optionally add a theme:');
       humanLog("       import { defaultTheme } from '@xds/theme-default'");
-      humanLog('       <XDSTheme theme={defaultTheme}>...</XDSTheme>');
+      humanLog('       <Theme theme={defaultTheme}>...</Theme>');
       humanLog(`    3. ${run} xds --help for all commands`);
       humanLog('');
     });


### PR DESCRIPTION
## Problem

The CLI still printed **XDS-prefixed** names in several user-facing example strings, even though bare names are now canonical (the `XDS*` names are deletable compat aliases). Anyone reading the CLI docs/output sees the old prefixed style:

```
$ xds component --list
  ...
  Import from the path shown (e.g. import {XDSButton} from '@xds/core/Button')
```

## Fix

Update the rendered examples to bare names (doc/example output only — no API or behavior change):

| Surface | Before | After |
|---|---|---|
| `xds component` / `--list` footer | `import {XDSButton} from '@xds/core/Button'` | `import {Button} from '@xds/core/Button'` |
| `xds init` next-steps | `import { XDSButton } from '@xds/core'` | `import { Button } from '@xds/core'` |
| `xds init` next-steps | `<XDSTheme theme={defaultTheme}>` | `<Theme theme={defaultTheme}>` |
| `xds theme build` install hint | `<XDSTheme theme={...}>` | `<Theme theme={...}>` |

`xds swizzle`'s explicit "`xds swizzle XDSButton` (XDS prefix also works)" hint is **intentionally left** — it documents that the compat alias still resolves.

## Scope

These are the only XDS-prefixed strings in CLI-*rendered* output. The remaining `XDS*` references in `packages/cli/src` are intentional: codemod test fixtures (they test the prefix→bare transform), the internal `XDSError` class, and code comments about legacy compat.

## Test

All 722 `packages/cli/src/commands` tests pass. Verified the live output (`xds component --list`, `xds docs`, `xds agent-docs`) is now prefix-free.