### PR TITLE
fix(NavMenu,Overlay): file headers, BaseProps, hover guard, export hygiene

### DIFF
--- a/packages/core/src/NavMenu/NavHeadingMenu.tsx
+++ b/packages/core/src/NavMenu/NavHeadingMenu.tsx
@@ -2,6 +2,16 @@
 
 'use client';
 
+/**
+ * @file NavHeadingMenu.tsx
+ * @input Uses React, StyleX, useListFocus, NavMenuContext
+ * @output Exports NavHeadingMenu component and NavHeadingMenuProps type
+ * @position Core implementation; consumed by index.ts
+ *
+ * SYNC: When modified, update:
+ * - /packages/core/src/NavMenu/index.ts
+ */
+
 import React, {useMemo, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {spacingVars} from '../theme/tokens.stylex';

--- a/packages/core/src/NavMenu/NavHeadingMenuItem.tsx
+++ b/packages/core/src/NavMenu/NavHeadingMenuItem.tsx
@@ -2,6 +2,16 @@
 
 'use client';
 
+/**
+ * @file NavHeadingMenuItem.tsx
+ * @input Uses React, StyleX, Icon, Text, NavMenuContext, useLinkComponent
+ * @output Exports NavHeadingMenuItem component and NavHeadingMenuItemProps type
+ * @position Core implementation; consumed by index.ts
+ *
+ * SYNC: When modified, update:
+ * - /packages/core/src/NavMenu/index.ts
+ */
+
 import React, {useCallback, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {renderIconSlot, type IconType} from '../Icon';
@@ -33,7 +43,9 @@ const styles = stylex.create({
     backgroundColor: {
       default: 'transparent',
       ':focus': colorVars['--color-overlay-hover'],
-      ':hover': colorVars['--color-overlay-hover'],
+      ':hover': {
+        '@media (hover: hover)': colorVars['--color-overlay-hover'],
+      },
     },
     border: 'none',
     cursor: 'pointer',

--- a/packages/core/src/NavMenu/NavMenuContext.tsx
+++ b/packages/core/src/NavMenu/NavMenuContext.tsx
@@ -2,6 +2,16 @@
 
 'use client';
 
+/**
+ * @file NavMenuContext.tsx
+ * @input Uses React createContext/use
+ * @output Exports NavHeadingCloseContext, NavHeadingMenuContext, and hooks
+ * @position Context providers; consumed by NavHeadingMenu and NavHeadingMenuItem
+ *
+ * SYNC: When modified, update:
+ * - /packages/core/src/NavMenu/index.ts
+ */
+
 import {createContext, use} from 'react';
 
 export type NavHeadingMenuSize = 'sm' | 'md' | 'lg';

--- a/packages/core/src/NavMenu/NavMenuItem.tsx
+++ b/packages/core/src/NavMenu/NavMenuItem.tsx
@@ -2,6 +2,13 @@
 
 'use client';
 
+/**
+ * @file NavMenuItem.tsx
+ * @input NavHeadingMenuItem
+ * @output Exports deprecated NavMenuItem alias
+ * @position Compatibility re-export; prefer NavHeadingMenuItem
+ */
+
 import {NavHeadingMenuItem} from './NavHeadingMenuItem';
 import type {NavHeadingMenuItemProps} from './NavHeadingMenuItem';
 

--- a/packages/core/src/Overlay/Overlay.tsx
+++ b/packages/core/src/Overlay/Overlay.tsx
@@ -17,12 +17,12 @@
 
 import type {ReactNode, Ref} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import type {StyleXStyles} from '@stylexjs/stylex';
 import {mergeProps, mergeRefs} from '../utils';
 import {useOverlay} from './useOverlay';
 import {useIsomorphicLayoutEffect} from '../hooks/useIsomorphicLayoutEffect';
 import {overlayScope, overlayContainerStyles} from './overlay.markers.stylex';
 import {xdsThemeProps} from '../utils/xdsThemeProps';
+import type {BaseProps} from '../BaseProps';
 import type {
   OverlayScrimMode,
   OverlayPosition,
@@ -30,7 +30,10 @@ import type {
   OverlayShowOn,
 } from './OverlayScrim';
 
-export interface OverlayProps {
+export interface OverlayProps extends Pick<
+  BaseProps<HTMLDivElement>,
+  'xstyle' | 'className' | 'style'
+> {
   /** Ref forwarded to the container element. */
   ref?: Ref<HTMLDivElement>;
   /** Base content (image, card, video, etc.). */
@@ -47,21 +50,6 @@ export interface OverlayProps {
   position?: OverlayPosition;
   /** @default "end" */
   align?: OverlayAlign;
-  /**
-   * StyleX styles for layout customization (margins, positioning, sizing).
-   * Must be a `stylex.create()` value — not an inline style object.
-   *
-   * @example
-   * ```
-   * const styles = stylex.create({ wrapper: { marginTop: 8 } });
-   * <Overlay xstyle={styles.wrapper} />
-   * ```
-   */
-  xstyle?: StyleXStyles;
-  /** CSS class name(s) appended to the root element. */
-  className?: string;
-  /** Inline styles. */
-  style?: React.CSSProperties;
 }
 
 /**

--- a/packages/core/src/Overlay/index.ts
+++ b/packages/core/src/Overlay/index.ts
@@ -1,5 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+'use client';
+
 /**
  * @file index.ts
  * @position Overlay barrel export
@@ -9,7 +11,11 @@ export {Overlay} from './Overlay';
 export type {OverlayProps} from './Overlay';
 
 export {useOverlay} from './useOverlay';
-export type {UseOverlayOptions, UseOverlayResult} from './useOverlay';
+export type {
+  UseOverlayOptions,
+  UseOverlayResult,
+  OverlayContainerProps,
+} from './useOverlay';
 
 export type {
   OverlayScrimMode,
@@ -31,6 +37,7 @@ export {
 } from '.';
 export type {
   OverlayAlign as XDSOverlayAlign,
+  OverlayContainerProps as XDSOverlayContainerProps,
   OverlayPosition as XDSOverlayPosition,
   OverlayProps as XDSOverlayProps,
   OverlayScrimMode as XDSOverlayScrimMode,


### PR DESCRIPTION
## Component Audit: NavMenu, Overlay, MultiSelector, Outline, OverflowList

Audited 5 components. MultiSelector, Outline, and OverflowList passed clean. Fixes for NavMenu and Overlay:

**NavMenu**
- Add `@file` headers to NavHeadingMenu.tsx, NavHeadingMenuItem.tsx, NavMenuContext.tsx, NavMenuItem.tsx
- Guard `:hover` background on NavHeadingMenuItem with `@media (hover: hover)` to prevent sticky hover on touch devices

**Overlay**
- `OverlayProps` now extends `Pick<BaseProps, 'xstyle' | 'className' | 'style'>` instead of re-declaring those props manually
- Add `'use client'` directive to Overlay/index.ts (re-exports hooks using client APIs)
- Export `OverlayContainerProps` type from index.ts (consumers need it when typing useOverlay results)
- Regenerate compat-aliases to include `XDSOverlayContainerProps`

**Needs Review**
- OverlayScrim uses a hardcoded `color-mix(in srgb, white 60%, transparent)` for the light scrim. Existing TODO says it needs a `--color-overlay-light` token. Not fixed here because it requires a token design decision.

Night Watch \u2014 Component Auditor