### PR TITLE
fix(core): rebrand internal xds references to astryx (dual-emit stays source-only)

### DIFF
--- a/packages/core/src/AppShell/AppShell.test.tsx
+++ b/packages/core/src/AppShell/AppShell.test.tsx
@@ -56,9 +56,7 @@ function TestSideNav({children}: {children?: React.ReactNode}) {
   return (
     <SideNav>
       <SideNavSection title="Test" isHeaderHidden>
-        <SideNavItem
-          label={typeof children === 'string' ? children : 'Nav'}
-        />
+        <SideNavItem label={typeof children === 'string' ? children : 'Nav'} />
       </SideNavSection>
     </SideNav>
   );
@@ -193,7 +191,7 @@ describe('AppShell', () => {
     );
     const skipLink = screen.getByTestId('skip-to-content');
     expect(skipLink).toBeInTheDocument();
-    expect(skipLink).toHaveAttribute('href', '#xds-app-shell-main');
+    expect(skipLink).toHaveAttribute('href', '#astryx-app-shell-main');
     expect(skipLink.textContent).toBe('Skip to content');
   });
 
@@ -204,7 +202,7 @@ describe('AppShell', () => {
       </AppShell>,
     );
     const main = screen.getByRole('main');
-    expect(main).toHaveAttribute('id', 'xds-app-shell-main');
+    expect(main).toHaveAttribute('id', 'astryx-app-shell-main');
   });
 
   // ===========================================================================
@@ -309,9 +307,7 @@ describe('AppShell', () => {
     render(
       <AppShell
         topNav={
-          <TopNav
-            label="Navigation"
-            heading={<TopNavHeading heading="App" />}>
+          <TopNav label="Navigation" heading={<TopNavHeading heading="App" />}>
             <TopNavItem label="Home" href="/" />
           </TopNav>
         }
@@ -458,9 +454,7 @@ describe('AppShell', () => {
     vi.stubGlobal('matchMedia', vi.fn().mockReturnValue(mockMql));
 
     const {container} = render(
-      <AppShell
-        sideNav={<TestSideNav />}
-        mobileNav={{defaultIsMobile: true}}>
+      <AppShell sideNav={<TestSideNav />} mobileNav={{defaultIsMobile: true}}>
         <div>Content</div>
       </AppShell>,
     );

--- a/packages/core/src/AppShell/AppShell.tsx
+++ b/packages/core/src/AppShell/AppShell.tsx
@@ -76,7 +76,7 @@ const BREAKPOINT_VALUES: Record<AppShellBreakpoint, number> = {
   none: 0,
 };
 
-const MAIN_CONTENT_ID = 'xds-app-shell-main';
+const MAIN_CONTENT_ID = 'astryx-app-shell-main';
 
 // =============================================================================
 // Types
@@ -645,9 +645,7 @@ export function AppShell({
   const topNavContent = hasTopNav ? (
     isBelowBreakpoint && !mobileNavDisabled && mobileNavReactNode == null ? (
       <TopNavMobileContentContext value={mobileContentValue}>
-        <TopNavRenderContext value="mobile-bar">
-          {topNav}
-        </TopNavRenderContext>
+        <TopNavRenderContext value="mobile-bar">{topNav}</TopNavRenderContext>
       </TopNavMobileContentContext>
     ) : (
       topNav

--- a/packages/core/src/Chat/useChatDictation.ts
+++ b/packages/core/src/Chat/useChatDictation.ts
@@ -345,7 +345,7 @@ export function useChatDictation(
       return active as HTMLDivElement;
     }
     return document.querySelector<HTMLDivElement>(
-      '.xds-chat-composer-input [contenteditable="true"], [role="textbox"][contenteditable="true"]',
+      '.astryx-chat-composer-input [contenteditable="true"], [role="textbox"][contenteditable="true"]',
     );
   }, []);
 

--- a/packages/core/src/Chat/useChatNewMessages.ts
+++ b/packages/core/src/Chat/useChatNewMessages.ts
@@ -9,7 +9,7 @@
  * @position Utility hook — used by ChatLayout, also usable standalone
  *
  * Observes a content element via ResizeObserver and tracks the last
- * .xds-chat-message element. When a new message appears (last element
+ * .astryx-chat-message element. When a new message appears (last element
  * changes), flags hasNewMessages if the scroll is unlocked.
  *
  * Also calls onResize on every content height change so the scroll
@@ -83,7 +83,7 @@ export function useChatNewMessages({
     observeResize(el, () => {
       onResizeRef.current?.();
 
-      const messages = el.getElementsByClassName('xds-chat-message');
+      const messages = el.getElementsByClassName('astryx-chat-message');
       const last = messages.length > 0 ? messages[messages.length - 1] : null;
 
       if (last && last !== lastMessageRef.current) {

--- a/packages/core/src/Chat/useChatStreamScroll.ts
+++ b/packages/core/src/Chat/useChatStreamScroll.ts
@@ -208,7 +208,7 @@ export function useChatStreamScroll({
     if (!container) {
       return;
     }
-    const messages = container.getElementsByClassName('xds-chat-message');
+    const messages = container.getElementsByClassName('astryx-chat-message');
     const last = messages[messages.length - 1];
     if (last instanceof HTMLElement) {
       scrollToMessage(last);

--- a/packages/core/src/CodeBlock/highlightRanges.test.ts
+++ b/packages/core/src/CodeBlock/highlightRanges.test.ts
@@ -59,7 +59,7 @@ describe('applyHighlightRangesChunked', () => {
 
     const cleanup = applyHighlightRangesChunked(codeEl, tokenLines);
 
-    const kwHighlight = mockHighlightsMap.get('xds-keyword');
+    const kwHighlight = mockHighlightsMap.get('astryx-keyword');
     expect(kwHighlight).toBeDefined();
     expect(kwHighlight!.size).toBe(2);
 
@@ -77,7 +77,7 @@ describe('applyHighlightRangesChunked', () => {
 
     const cleanup = applyHighlightRangesChunked(codeEl, tokenLines);
 
-    const kwHighlight = mockHighlightsMap.get('xds-keyword');
+    const kwHighlight = mockHighlightsMap.get('astryx-keyword');
     expect(kwHighlight).toBeDefined();
     expect(kwHighlight!.size).toBe(1);
 
@@ -99,8 +99,8 @@ describe('applyHighlightRangesChunked', () => {
 
     const cleanup = applyHighlightRangesChunked(codeEl, tokenLines);
 
-    const kwHighlight = mockHighlightsMap.get('xds-keyword');
-    const numHighlight = mockHighlightsMap.get('xds-number');
+    const kwHighlight = mockHighlightsMap.get('astryx-keyword');
+    const numHighlight = mockHighlightsMap.get('astryx-number');
     expect(kwHighlight!.size).toBe(1);
     expect(numHighlight!.size).toBe(1);
 

--- a/packages/core/src/CodeBlock/highlightRanges.ts
+++ b/packages/core/src/CodeBlock/highlightRanges.ts
@@ -64,10 +64,10 @@ function ensureDynamicHighlightType(tokenType: string): void {
     }
   }
 
-  const name = `xds-${tokenType}`;
+  const name = `astryx-${tokenType}`;
   const colorVar = `var(--color-syntax-${tokenType}, currentColor)`;
   dynamicStyleSheet.insertRule(
-    `.xds-codeblock code::highlight(${name}), .xds-codeeditor code::highlight(${name}) { color: ${colorVar}; }`,
+    `.astryx-codeblock code::highlight(${name}), .xds-codeblock code::highlight(${name}), .astryx-codeeditor code::highlight(${name}), .xds-codeeditor code::highlight(${name}) { color: ${colorVar}; }`,
   );
 }
 
@@ -90,7 +90,7 @@ function createHighlightResolver(): (tokenType: string) => Highlight {
 
     ensureDynamicHighlightType(tokenType);
 
-    const name = `xds-${tokenType}`;
+    const name = `astryx-${tokenType}`;
     highlight = CSS.highlights.get(name);
     if (!highlight) {
       highlight = new Highlight();

--- a/packages/core/src/CodeBlock/highlightStyles.ts
+++ b/packages/core/src/CodeBlock/highlightStyles.ts
@@ -30,32 +30,58 @@ const FALLBACK_TOKENS = `:root {\n${Object.entries(syntaxTokenDefaults)
 const HIGHLIGHT_STYLES = `
 ${FALLBACK_TOKENS}
 
-.xds-codeblock code::highlight(xds-keyword),
-.xds-codeeditor code::highlight(xds-keyword)     { color: var(--color-syntax-keyword); }
-.xds-codeblock code::highlight(xds-string),
-.xds-codeeditor code::highlight(xds-string)      { color: var(--color-syntax-string); }
-.xds-codeblock code::highlight(xds-comment),
-.xds-codeeditor code::highlight(xds-comment)     { color: var(--color-syntax-comment); }
-.xds-codeblock code::highlight(xds-number),
-.xds-codeeditor code::highlight(xds-number)      { color: var(--color-syntax-number); }
-.xds-codeblock code::highlight(xds-function),
-.xds-codeeditor code::highlight(xds-function)    { color: var(--color-syntax-function); }
-.xds-codeblock code::highlight(xds-type),
-.xds-codeeditor code::highlight(xds-type)        { color: var(--color-syntax-type); }
-.xds-codeblock code::highlight(xds-tag),
-.xds-codeeditor code::highlight(xds-tag)         { color: var(--color-syntax-tag); }
-.xds-codeblock code::highlight(xds-attribute),
-.xds-codeeditor code::highlight(xds-attribute)   { color: var(--color-syntax-attribute); }
-.xds-codeblock code::highlight(xds-property),
-.xds-codeeditor code::highlight(xds-property)    { color: var(--color-syntax-property); }
-.xds-codeblock code::highlight(xds-operator),
-.xds-codeeditor code::highlight(xds-operator)    { color: var(--color-syntax-operator); }
-.xds-codeblock code::highlight(xds-constant),
-.xds-codeeditor code::highlight(xds-constant)    { color: var(--color-syntax-constant); }
-.xds-codeblock code::highlight(xds-punctuation),
-.xds-codeeditor code::highlight(xds-punctuation) { color: var(--color-syntax-punctuation); }
-.xds-codeblock code::highlight(xds-variable),
-.xds-codeeditor code::highlight(xds-variable)    { color: var(--color-syntax-variable); }
+.astryx-codeblock code::highlight(astryx-keyword),
+.xds-codeblock code::highlight(astryx-keyword),
+.astryx-codeeditor code::highlight(astryx-keyword),
+.xds-codeeditor code::highlight(astryx-keyword) { color: var(--color-syntax-keyword); }
+.astryx-codeblock code::highlight(astryx-string),
+.xds-codeblock code::highlight(astryx-string),
+.astryx-codeeditor code::highlight(astryx-string),
+.xds-codeeditor code::highlight(astryx-string) { color: var(--color-syntax-string); }
+.astryx-codeblock code::highlight(astryx-comment),
+.xds-codeblock code::highlight(astryx-comment),
+.astryx-codeeditor code::highlight(astryx-comment),
+.xds-codeeditor code::highlight(astryx-comment) { color: var(--color-syntax-comment); }
+.astryx-codeblock code::highlight(astryx-number),
+.xds-codeblock code::highlight(astryx-number),
+.astryx-codeeditor code::highlight(astryx-number),
+.xds-codeeditor code::highlight(astryx-number) { color: var(--color-syntax-number); }
+.astryx-codeblock code::highlight(astryx-function),
+.xds-codeblock code::highlight(astryx-function),
+.astryx-codeeditor code::highlight(astryx-function),
+.xds-codeeditor code::highlight(astryx-function) { color: var(--color-syntax-function); }
+.astryx-codeblock code::highlight(astryx-type),
+.xds-codeblock code::highlight(astryx-type),
+.astryx-codeeditor code::highlight(astryx-type),
+.xds-codeeditor code::highlight(astryx-type) { color: var(--color-syntax-type); }
+.astryx-codeblock code::highlight(astryx-tag),
+.xds-codeblock code::highlight(astryx-tag),
+.astryx-codeeditor code::highlight(astryx-tag),
+.xds-codeeditor code::highlight(astryx-tag) { color: var(--color-syntax-tag); }
+.astryx-codeblock code::highlight(astryx-attribute),
+.xds-codeblock code::highlight(astryx-attribute),
+.astryx-codeeditor code::highlight(astryx-attribute),
+.xds-codeeditor code::highlight(astryx-attribute) { color: var(--color-syntax-attribute); }
+.astryx-codeblock code::highlight(astryx-property),
+.xds-codeblock code::highlight(astryx-property),
+.astryx-codeeditor code::highlight(astryx-property),
+.xds-codeeditor code::highlight(astryx-property) { color: var(--color-syntax-property); }
+.astryx-codeblock code::highlight(astryx-operator),
+.xds-codeblock code::highlight(astryx-operator),
+.astryx-codeeditor code::highlight(astryx-operator),
+.xds-codeeditor code::highlight(astryx-operator) { color: var(--color-syntax-operator); }
+.astryx-codeblock code::highlight(astryx-constant),
+.xds-codeblock code::highlight(astryx-constant),
+.astryx-codeeditor code::highlight(astryx-constant),
+.xds-codeeditor code::highlight(astryx-constant) { color: var(--color-syntax-constant); }
+.astryx-codeblock code::highlight(astryx-punctuation),
+.xds-codeblock code::highlight(astryx-punctuation),
+.astryx-codeeditor code::highlight(astryx-punctuation),
+.xds-codeeditor code::highlight(astryx-punctuation) { color: var(--color-syntax-punctuation); }
+.astryx-codeblock code::highlight(astryx-variable),
+.xds-codeblock code::highlight(astryx-variable),
+.astryx-codeeditor code::highlight(astryx-variable),
+.xds-codeeditor code::highlight(astryx-variable) { color: var(--color-syntax-variable); }
 
 /* Span-based fallback classes — used when highlightMode='spans' or
    when the CSS Custom Highlight API is not available.
@@ -98,7 +124,7 @@ export function ensureHighlightStyles(): void {
 
 /**
  * Token types that map to highlight names.
- * Used to create CSS.highlights entries with `xds-` prefix.
+ * Used to create CSS.highlights entries with the `astryx-` prefix.
  */
 export const TOKEN_TYPES = [
   'keyword',

--- a/packages/core/src/Layer/useLayer.tsx
+++ b/packages/core/src/Layer/useLayer.tsx
@@ -278,7 +278,7 @@ export function useLayer(
 ): ContextLayerReturn | FixedLayerReturn {
   const {mode, onShow, onHide, lightDismiss = false} = options;
   const id = useId();
-  const anchorId = `--xds-layer-${id.replace(/:/g, '')}`;
+  const anchorId = `--astryx-layer-${id.replace(/:/g, '')}`;
 
   const [isOpen, setIsOpen] = useState(false);
   const popoverRef = useRef<HTMLElement | null>(null);

--- a/packages/core/src/Layout/LayoutContent.tsx
+++ b/packages/core/src/Layout/LayoutContent.tsx
@@ -44,14 +44,16 @@ const styles = stylex.create({
     paddingBlockStart: {
       default: `var(--layout-padding-inner-y, ${spacingVars['--spacing-4']})`,
       // When header has no divider, collapse top padding for seamless visual flow
-      [stylex.when.ancestor(':has(> .xds-layout-header:not([data-divider]))')]:
-        0,
+      [stylex.when.ancestor(
+        ':has(> .astryx-layout-header:not([data-divider]))',
+      )]: 0,
     },
     paddingBlockEnd: {
       default: `var(--layout-padding-inner-y, ${spacingVars['--spacing-4']})`,
       // When footer has no divider, collapse bottom padding for seamless visual flow
-      [stylex.when.ancestor(':has(> .xds-layout-footer:not([data-divider]))')]:
-        0,
+      [stylex.when.ancestor(
+        ':has(> .astryx-layout-footer:not([data-divider]))',
+      )]: 0,
     },
     // Publish container padding vars for bleed children (Table, Divider, etc.)
     '--container-padding-inline-start': `var(--layout-padding-inner-x, ${spacingVars['--spacing-4']})`,

--- a/packages/core/src/Layout/padding.stylex.ts
+++ b/packages/core/src/Layout/padding.stylex.ts
@@ -280,15 +280,15 @@ export const paddingBlockStyles = stylex.create({
  * useThemeDefault inherit the parent's padding instead of the theme default.
  */
 export const sectionPaddingPropagationStyles = stylex.create({
-  0: {'--xds-section-padding': spacingVars['--spacing-0']},
-  0.5: {'--xds-section-padding': spacingVars['--spacing-0-5']},
-  1: {'--xds-section-padding': spacingVars['--spacing-1']},
-  1.5: {'--xds-section-padding': spacingVars['--spacing-1-5']},
-  2: {'--xds-section-padding': spacingVars['--spacing-2']},
-  3: {'--xds-section-padding': spacingVars['--spacing-3']},
-  4: {'--xds-section-padding': spacingVars['--spacing-4']},
-  5: {'--xds-section-padding': spacingVars['--spacing-5']},
-  6: {'--xds-section-padding': spacingVars['--spacing-6']},
-  8: {'--xds-section-padding': spacingVars['--spacing-8']},
-  10: {'--xds-section-padding': spacingVars['--spacing-10']},
+  0: {'--astryx-section-padding': spacingVars['--spacing-0']},
+  0.5: {'--astryx-section-padding': spacingVars['--spacing-0-5']},
+  1: {'--astryx-section-padding': spacingVars['--spacing-1']},
+  1.5: {'--astryx-section-padding': spacingVars['--spacing-1-5']},
+  2: {'--astryx-section-padding': spacingVars['--spacing-2']},
+  3: {'--astryx-section-padding': spacingVars['--spacing-3']},
+  4: {'--astryx-section-padding': spacingVars['--spacing-4']},
+  5: {'--astryx-section-padding': spacingVars['--spacing-5']},
+  6: {'--astryx-section-padding': spacingVars['--spacing-6']},
+  8: {'--astryx-section-padding': spacingVars['--spacing-8']},
+  10: {'--astryx-section-padding': spacingVars['--spacing-10']},
 });

--- a/packages/core/src/List/List.tsx
+++ b/packages/core/src/List/List.tsx
@@ -105,7 +105,7 @@ const styles = stylex.create({
     gap: 0,
   },
   withCounter: {
-    counterReset: 'xds-list',
+    counterReset: 'astryx-list',
   },
   header: {
     marginBottom: spacingVars['--spacing-2'],
@@ -114,7 +114,7 @@ const styles = stylex.create({
 
 const dynamicStyles = stylex.create({
   counterStart: (value: number) => ({
-    counterReset: `xds-list ${value}`,
+    counterReset: `astryx-list ${value}`,
   }),
 });
 

--- a/packages/core/src/List/ListItem.tsx
+++ b/packages/core/src/List/ListItem.tsx
@@ -111,7 +111,7 @@ export interface ListItemProps extends BaseProps<HTMLLIElement> {
 
 const styles = stylex.create({
   withCounter: {
-    counterIncrement: 'xds-list',
+    counterIncrement: 'astryx-list',
   },
   withDivider: {
     borderBlockEndWidth: borderVars['--border-width'],
@@ -164,7 +164,7 @@ const markerStyles = stylex.create({
     lineHeight: typeScaleVars['--text-body-leading'],
     width: spacingVars['--spacing-4'],
     '::before': {
-      content: 'counter(xds-list) "."',
+      content: 'counter(astryx-list) "."',
     },
   },
 });

--- a/packages/core/src/Resizable/ResizeHandle.tsx
+++ b/packages/core/src/Resizable/ResizeHandle.tsx
@@ -155,7 +155,7 @@ const styles = stylex.create({
     cursor: 'row-resize',
   },
 
-  // Pill base — themes target .xds-resize-handle-pill for size/shape.
+  // Pill base — themes target .astryx-resize-handle-pill for size/shape.
   pill: {
     position: 'absolute',
     zIndex: 2,
@@ -289,7 +289,7 @@ export interface ResizeHandleProps extends Omit<
  * divider line with a wider invisible hit area and optional pill grip indicator.
  * Supports keyboard resizing via arrow keys and WAI-ARIA separator role.
  *
- * The pill element uses class `xds-resize-handle-pill` for theme targeting.
+ * The pill element uses class `astryx-resize-handle-pill` for theme targeting.
  *
  * @example
  * ```
@@ -528,7 +528,7 @@ export function ResizeHandle({
         }}
         onKeyDown={handleKeyDown}
       />
-      {/* Pill grip indicator — themed via .xds-resize-handle-pill */}
+      {/* Pill grip indicator — themed via .astryx-resize-handle-pill */}
       {children ?? (
         <div
           {...mergeProps(

--- a/packages/core/src/Resizable/useResizable.ts
+++ b/packages/core/src/Resizable/useResizable.ts
@@ -106,7 +106,11 @@ export interface ResizableProps {
 
 const DEFAULT_MIN = 50;
 const DEFAULT_COLLAPSED_SIZE = 40;
-const STORAGE_PREFIX = 'xds-resizable:';
+const STORAGE_PREFIX = 'astryx-resizable:';
+// Legacy key prefix read during the compat window so persisted panel sizes
+// survive the xds -> astryx rename. Read-only fallback; we always write the
+// new prefix. Removed at final cutover.
+const LEGACY_STORAGE_PREFIX = 'xds-resizable:';
 
 // =============================================================================
 // Helpers
@@ -143,7 +147,9 @@ function loadPersistedSize(key: string): number | null {
     return null;
   }
   try {
-    const raw = localStorage.getItem(STORAGE_PREFIX + key);
+    const raw =
+      localStorage.getItem(STORAGE_PREFIX + key) ??
+      localStorage.getItem(LEGACY_STORAGE_PREFIX + key);
     if (raw != null) {
       const parsed = JSON.parse(raw);
       if (typeof parsed === 'number') {
@@ -188,9 +194,7 @@ function resolveDefaultSize(defaultSize: number | string | undefined): number {
 // Single-region hook
 // =============================================================================
 
-function useSingleResizable(
-  config: UseResizableSingleConfig,
-): ResizableRegion {
+function useSingleResizable(config: UseResizableSingleConfig): ResizableRegion {
   const {
     defaultSize,
     minSizePx = DEFAULT_MIN,
@@ -365,9 +369,7 @@ function useMultiResizable(
 // Public API
 // =============================================================================
 
-export function useResizable(
-  config: UseResizableSingleConfig,
-): ResizableRegion;
+export function useResizable(config: UseResizableSingleConfig): ResizableRegion;
 export function useResizable(
   config: UseResizableMultiConfig,
 ): Record<string, ResizableRegion>;

--- a/packages/core/src/SideNav/SideNav.test.tsx
+++ b/packages/core/src/SideNav/SideNav.test.tsx
@@ -203,11 +203,7 @@ describe('SideNavHeading', () => {
 
   it('uses custom link component from as prop', () => {
     render(
-      <SideNavHeading
-        heading="My App"
-        headingHref="/home"
-        as={CustomLink}
-      />,
+      <SideNavHeading heading="My App" headingHref="/home" as={CustomLink} />,
     );
     const link = screen.getByRole('link');
     expect(link).toHaveAttribute('data-custom-link');
@@ -239,9 +235,7 @@ describe('SideNavHeading', () => {
   });
 
   it('shows chevron when menu is provided', () => {
-    render(
-      <SideNavHeading heading="My App" menu={<div>Menu content</div>} />,
-    );
+    render(<SideNavHeading heading="My App" menu={<div>Menu content</div>} />);
     // The chevron SVG should be rendered
     const button = screen.getByRole('button');
     expect(button).toBeInTheDocument();
@@ -584,9 +578,7 @@ describe('SideNavItem', () => {
   });
 
   it('renders custom component when as and href are provided', () => {
-    render(
-      <SideNavItem label="Dashboard" href="/dashboard" as={CustomLink} />,
-    );
+    render(<SideNavItem label="Dashboard" href="/dashboard" as={CustomLink} />);
     const link = screen.getByRole('link');
     expect(link).toHaveAttribute('data-custom-link');
     expect(link).toHaveAttribute('href', '/dashboard');
@@ -703,13 +695,15 @@ describe('SideNavSection', () => {
 describe('SideNav resizable', () => {
   it('renders drag handle when resizable', () => {
     render(<SideNav resizable>Content</SideNav>);
-    expect(screen.getByTestId('xds-sidenav-resize-handle')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('astryx-sidenav-resize-handle'),
+    ).toBeInTheDocument();
   });
 
   it('does not render drag handle without resizable', () => {
     render(<SideNav>Content</SideNav>);
     expect(
-      screen.queryByTestId('xds-sidenav-resize-handle'),
+      screen.queryByTestId('astryx-sidenav-resize-handle'),
     ).not.toBeInTheDocument();
   });
 
@@ -722,18 +716,16 @@ describe('SideNav resizable', () => {
       </SideNav>,
     );
     expect(
-      screen.queryByTestId('xds-sidenav-resize-handle'),
+      screen.queryByTestId('astryx-sidenav-resize-handle'),
     ).not.toBeInTheDocument();
   });
 
   it('calls onWidthChange after drag', () => {
     const handleWidthChange = vi.fn();
     render(
-      <SideNav resizable={{onWidthChange: handleWidthChange}}>
-        Content
-      </SideNav>,
+      <SideNav resizable={{onWidthChange: handleWidthChange}}>Content</SideNav>,
     );
-    const handle = screen.getByTestId('xds-sidenav-resize-handle');
+    const handle = screen.getByTestId('astryx-sidenav-resize-handle');
     // The pointer event handler is on the hit area child inside the handle.
     const hitArea = handle.firstElementChild as HTMLElement;
 
@@ -819,9 +811,7 @@ function renderExpanded(ui: React.ReactElement) {
 
 describe('SideNavItem (collapsed)', () => {
   it('hides items without icons when collapsed', () => {
-    const {container} = renderCollapsed(
-      <SideNavItem label="No Icon Item" />,
-    );
+    const {container} = renderCollapsed(<SideNavItem label="No Icon Item" />);
     expect(screen.queryByText('No Icon Item')).not.toBeInTheDocument();
     expect(container.querySelector('[data-xds="side-nav-item"]')).toBeNull();
   });

--- a/packages/core/src/SideNav/SideNav.tsx
+++ b/packages/core/src/SideNav/SideNav.tsx
@@ -559,7 +559,7 @@ export function SideNav({
     <div {...stylex.props(styles.resizableContainer)}>
       {navElement}
       <ResizeHandle
-        data-testid="xds-sidenav-resize-handle"
+        data-testid="astryx-sidenav-resize-handle"
         direction="horizontal"
         position="overlay"
         pillPlacement="end"

--- a/packages/core/src/SideNav/SideNavHeading.tsx
+++ b/packages/core/src/SideNav/SideNavHeading.tsx
@@ -57,7 +57,7 @@ const styles = stylex.create({
     minHeight: spacingVars['--spacing-8'],
     paddingInlineStart: {
       default: spacingVars['--spacing-2'],
-      ':has(.xds-navicon)': 0,
+      ':has(.astryx-navicon)': 0,
     },
     paddingInlineEnd: spacingVars['--spacing-2'],
     paddingBlock: 0,
@@ -198,7 +198,7 @@ const styles = stylex.create({
     minHeight: spacingVars['--spacing-8'],
     paddingInlineStart: {
       default: spacingVars['--spacing-2'],
-      ':has(.xds-navicon)': 0,
+      ':has(.astryx-navicon)': 0,
     },
     paddingInlineEnd: spacingVars['--spacing-2'],
     paddingBlock: 0,

--- a/packages/core/src/Text/Text.tsx
+++ b/packages/core/src/Text/Text.tsx
@@ -175,7 +175,7 @@ const defaultColorByType: Record<string, TextColor> = {
 /**
  * Resolve the StyleX style key for a text type.
  * Custom (theme-defined) types fall back to 'body' for baseline StyleX styles;
- * their visual treatment comes from theme CSS overrides (.xds-text.<type>).
+ * their visual treatment comes from theme CSS overrides (.astryx-text.<type>).
  */
 function resolveStyleType(type: TextType): BuiltinTextType {
   if (type in sizeByTypeStyles) {

--- a/packages/core/src/Text/text.stylex.ts
+++ b/packages/core/src/Text/text.stylex.ts
@@ -100,7 +100,7 @@ export const defaultWeightByTypeStyles = stylex.create({
 // Baseline Size/Leading by Type (from type-scale tokens)
 //
 // These ensure Text renders with correct sizing even without a theme.
-// Theme component overrides (.xds-text.body { ... } today, plus data-type
+// Theme component overrides (.astryx-text.body { ... } today, plus data-type
 // reflection on rendered text elements) win when present
 // because they have higher specificity via @scope.
 // =============================================================================

--- a/packages/core/src/Toast/useToast.tsx
+++ b/packages/core/src/Toast/useToast.tsx
@@ -102,7 +102,7 @@ function getFallbackContext(): ToastContextValue {
 
 let toastIdCounter = 0;
 function generateToastId(): string {
-  return `xds-toast-${++toastIdCounter}`;
+  return `astryx-toast-${++toastIdCounter}`;
 }
 
 /**

--- a/packages/core/src/TopNav/TopNavHeading.tsx
+++ b/packages/core/src/TopNav/TopNavHeading.tsx
@@ -52,7 +52,7 @@ const styles = stylex.create({
     minHeight: spacingVars['--spacing-8'],
     paddingInlineStart: {
       default: spacingVars['--spacing-2'],
-      ':has(.xds-navicon)': 0,
+      ':has(.astryx-navicon)': 0,
     },
     paddingInlineEnd: spacingVars['--spacing-2'],
     paddingBlock: 0,
@@ -172,7 +172,7 @@ const styles = stylex.create({
     minHeight: spacingVars['--spacing-8'],
     paddingInlineStart: {
       default: spacingVars['--spacing-2'],
-      ':has(.xds-navicon)': 0,
+      ':has(.astryx-navicon)': 0,
     },
     paddingInlineEnd: spacingVars['--spacing-2'],
     paddingBlock: 0,

--- a/packages/core/src/theme/Theme.tsx
+++ b/packages/core/src/theme/Theme.tsx
@@ -114,7 +114,7 @@ function useThemeStyleInjection(theme: DefinedTheme): void {
       return;
     }
 
-    const themeKey = `xds-theme-${theme.name}`;
+    const themeKey = `astryx-theme-${theme.name}`;
     if (injectedThemes.has(themeKey)) {
       return;
     }

--- a/packages/core/src/theme/derivedVarRegistry.test.ts
+++ b/packages/core/src/theme/derivedVarRegistry.test.ts
@@ -65,7 +65,7 @@ const STRUCTURAL_VARS = new Set([
   '--indicator-width',
   '--table-resize-height',
   '--separator-display',
-  '--xds-section-padding',
+  '--astryx-section-padding',
 ]);
 
 /**

--- a/packages/core/src/theme/generateThemeRules.ts
+++ b/packages/core/src/theme/generateThemeRules.ts
@@ -18,7 +18,13 @@
 import type {DefinedTheme} from './defineTheme';
 import {parseStyleKey} from '../utils/parseStyleKey';
 import {getDerivedVars} from './derivedVarRegistry';
-import {cssVar, classPrefix, legacyClassPrefix, dataAttrNamespace, legacyDataAttrNamespace} from '../naming';
+import {
+  cssVar,
+  classPrefix,
+  legacyClassPrefix,
+  dataAttrNamespace,
+  legacyDataAttrNamespace,
+} from '../naming';
 
 /**
  * Dual-prefix theme @scope selectors (XDS-prefix migration P2380608025).
@@ -456,13 +462,19 @@ function generateColorOverrides(
   if (touchesText || touchesHeading || touchesLink) {
     for (const [colorName, colorValue] of Object.entries(TEXT_COLOR_MAP)) {
       if (touchesText) {
-        parts.push(`  .xds-text.${colorName} { color: ${colorValue}; }`);
+        parts.push(
+          `  ${componentClassSelector('text', `.${colorName}`)} { color: ${colorValue}; }`,
+        );
       }
       if (touchesHeading) {
-        parts.push(`  .xds-heading.${colorName} { color: ${colorValue}; }`);
+        parts.push(
+          `  ${componentClassSelector('heading', `.${colorName}`)} { color: ${colorValue}; }`,
+        );
       }
       if (touchesLink) {
-        parts.push(`  .xds-link.${colorName} { color: ${colorValue}; }`);
+        parts.push(
+          `  ${componentClassSelector('link', `.${colorName}`)} { color: ${colorValue}; }`,
+        );
       }
     }
   }
@@ -478,9 +490,7 @@ function generateColorOverrides(
  * Component rules (tokens, .xds-* overrides) are intentional theme overrides
  * that need to beat StyleX — they stay in xds-theme (above StyleX layers).
  */
-export function generateThemeRulesSplit(
-  theme: DefinedTheme,
-): ThemeRulesSplit {
+export function generateThemeRulesSplit(theme: DefinedTheme): ThemeRulesSplit {
   const allRules = generateThemeRules(theme);
 
   const prose: string[] = [];

--- a/packages/core/src/theme/types.ts
+++ b/packages/core/src/theme/types.ts
@@ -112,7 +112,7 @@ export type BuiltinTextType =
  *
  * Themes can define custom text types via component overrides in defineTheme.
  * Custom types render with `body` baseline styles and receive their visual
- * treatment from theme CSS (`.xds-text.<custom-type> { ... }`).
+ * treatment from theme CSS (`.astryx-text.<custom-type> { ... }`).
  *
  * To add type-safe custom types, use module augmentation:
  * ```ts
@@ -130,9 +130,7 @@ export type BuiltinTextType =
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface CustomTextTypes {}
 
-export type TextType =
-  | BuiltinTextType
-  | (keyof CustomTextTypes & string);
+export type TextType = BuiltinTextType | (keyof CustomTextTypes & string);
 
 /**
  * Text size scale for Text size prop override


### PR DESCRIPTION
## Principle

The consumer-observable DOM/CSS surface (component classes, data-attrs, CSS-var override knobs) **dual-emits** `astryx` + `xds` during the compat window. Everything **else** — internal identifiers, the library's own DOM queries, generated theme CSS, and doc/comments — should reference the new `astryx` namespace **directly**. This sweep fixes the stragglers that still used `xds` internally.

## Internal identifiers rebranded (self-contained, no external contract)

| Surface | Before | After |
|---|---|---|
| AppShell skip-nav id | `xds-app-shell-main` | `astryx-app-shell-main` |
| Layer anchor-name | `--xds-layer-*` | `--astryx-layer-*` |
| Theme dedup key (internal Set, not DOM) | `xds-theme-${name}` | `astryx-theme-${name}` |
| Toast id key | `xds-toast-*` | `astryx-toast-*` |
| List CSS counter (writer+reader) | `xds-list` | `astryx-list` |
| CodeBlock highlight-API registry names (JS+CSS lockstep) | `xds-<tok>` | `astryx-<tok>` |
| SideNav resize-handle `data-testid` (+test) | `xds-…` | `astryx-…` |
| Resizable localStorage prefix | `xds-resizable:` | `astryx-resizable:` **+ legacy-read fallback** so persisted sizes survive |
| Internal section-padding var **write** | `--xds-section-padding` | `--astryx-section-padding` |

The Resizable change keeps a read-only fallback to the old key; the section-padding read chain keeps its inverted `var(--xds-, var(--astryx-, default))` order, so consumer `--xds-` overrides still win.

## Library's own DOM queries / cross-component selectors

Retargeted to the new `astryx` class (still matches dual-emit):
- `getElementsByClassName('astryx-chat-message')`, dictation `.astryx-chat-composer-input`
- LayoutContent `:has(.astryx-layout-header/footer)`, heading `:has(.astryx-navicon)`
- CodeBlock `.astryx-codeblock`/`.astryx-codeeditor` base-class selectors (dual-prefixed)

## Generated theme CSS

`generateThemeRules`'s `.xds-text`/`.xds-heading`/`.xds-link` color overrides now go through the existing `componentClassSelector()` **dual-prefix helper** instead of hardcoding `.xds-`. Doc-comments referencing `.xds-*` theme targets updated to `.astryx-*`.

## Untouched (deliberately)

`data-xds-theme`/`data-xds-media` (public DOM contract — dual-emit), the `var(--xds-, var(--astryx-, …))` read fallbacks, `@layer xds-base`/`xds-theme` (renamed only at final cutover), the **"XDS" design-system proper noun**, and the `naming.ts` helpers / `LEGACY_*` constants.

## Test

All **3164** `packages/core` tests pass. `@xds/core build` green (both `xds.css` and `astryx.css` emit). Coordinated changes verified: JS↔CSS highlight names match, counter writer/reader match, the 3 affected test files (AppShell href, highlightRanges registry names, derivedVarRegistry structural-var allowlist) updated and passing.