### PR TITLE
fix(lab): rebrand internal SVG ids xds- → astryx-

### DIFF
--- a/packages/lab/src/Chart/XDSChart.tsx
+++ b/packages/lab/src/Chart/XDSChart.tsx
@@ -298,7 +298,7 @@ export function XDSChart({
           height={height}
           style={interactive ? {touchAction: 'none'} : undefined}>
           <defs>
-            <clipPath id="xds-chart-plot">
+            <clipPath id="astryx-chart-plot">
               <rect x={0} y={0} width={innerWidth} height={innerHeight} />
             </clipPath>
           </defs>

--- a/packages/lab/src/Sankey/XDSSankeyLink.tsx
+++ b/packages/lab/src/Sankey/XDSSankeyLink.tsx
@@ -116,7 +116,7 @@ export function XDSSankeyLink({
         } else if (mode.type === 'target') {
           fill = oklch(link.target.color, opacity);
         } else {
-          fill = `url(#xds-sankey-grad-${i})`;
+          fill = `url(#astryx-sankey-grad-${i})`;
         }
 
         return <path key={i} d={d} fill={fill} opacity={pathOpacity} />;
@@ -144,7 +144,7 @@ function GradientDef({
 
   return (
     <linearGradient
-      id={`xds-sankey-grad-${index}`}
+      id={`astryx-sankey-grad-${index}`}
       x1={sx}
       x2={tx}
       y1={0}


### PR DESCRIPTION
## Context

Continuing the internal-namespace sweep into the non-core packages. The three **private** (internal, unpublished) packages — `@xds/lab`, `@xds/vega`, `@xds/theme-brutalist` — can migrate the legacy `xds` namespace **directly** to `astryx` with no compat/dual-emit, since they have no external consumers to keep compatible.

## Findings

Only `@xds/lab` had internal `xds-` string references — three self-contained SVG element ids (definition + `url()` reference within the same component):

| File | Before | After |
|---|---|---|
| `Chart/XDSChart.tsx` | `<clipPath id="xds-chart-plot">` | `"astryx-chart-plot"` |
| `Sankey/XDSSankeyLink.tsx` | `id={`xds-sankey-grad-${i}`}` + `fill=`url(#xds-sankey-grad-${i})`` | `astryx-sankey-grad-${i}` |

These are pure internal machinery (not consumer-observable classes or data-attrs), so they flip outright rather than dual-emitting.

`@xds/vega` and `@xds/theme-brutalist` had **no** internal `xds-` / `data-xds-` / `--xds-` / `.xds-` references — nothing to change.

## Scope note

This is the **internal-string sweep only**. Lab's `XDS*`-prefixed component **API names** (`XDSChart`, `XDSSankeyLink`, …) are a separate, larger rename tracked independently (`xds-lab`) and are intentionally still prefixed for now.

## Test

`@xds/lab` Chart + Sankey tests pass (14). Lint clean. No test asserted the old ids.