### PR TITLE
fix(codemods): handle XDS type names in generic type-argument positions

### DIFF
--- a/packages/cli/src/codemods/transforms/v0.0.15/__tests__/drop-xds-prefix-imports.test.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.15/__tests__/drop-xds-prefix-imports.test.mjs
@@ -54,6 +54,19 @@ describe('drop-xds-prefix-imports', () => {
     expect(output).not.toContain('XDSButtonProps');
   });
 
+  it('renames type references in generic type-argument positions', async () => {
+    const input = [
+      `import {XDSTableColumn} from '@xds/core/Table';`,
+      `const cols = useMemo<XDSTableColumn<Issue>[]>(() => [], []);`,
+    ].join('\n');
+    const output = await applyTransform(input);
+    expect(output).toContain(`import {TableColumn} from '@xds/core/Table';`);
+    expect(output).toContain('useMemo<TableColumn<Issue>[]>');
+    // The unrelated generic argument `Issue` must be left alone.
+    expect(output).toContain('<Issue>');
+    expect(output).not.toContain('XDSTableColumn');
+  });
+
   it('rewrites the imported name but keeps a custom local alias', async () => {
     const input = [
       `import {XDSButton as Btn} from '@xds/core';`,

--- a/packages/cli/src/codemods/transforms/v0.0.15/drop-xds-prefix-imports.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.15/drop-xds-prefix-imports.mjs
@@ -20,7 +20,9 @@
  * Handles:
  * 1. Named import specifiers:   import {XDSButton} from '@xds/core'
  *    -> import {Button} from '@xds/core'   (and aliased imports)
- * 2. All references to the imported binding (JSX, type positions, values)
+ * 2. All references to the imported binding (JSX, type positions, values),
+ *    including type references in generic type-argument positions such as
+ *    `useMemo<XDSTableColumn<Issue>[]>(...)`
  * 3. Re-exports from @xds/core: export {XDSButton} from '@xds/core/Button'
  *
  * Does NOT touch:
@@ -165,6 +167,60 @@ export default function transformer(file, api) {
       hasChanges = true;
     }
   });
+
+  // 4. Rename TS type references in generic type-argument positions.
+  //
+  // `j.find(j.Identifier)` (and `j.find(j.TSTypeReference)`) do NOT visit
+  // identifiers nested inside generic type arguments with the tsx/babel parser
+  // -- e.g. the `XDSTableColumn` in `useMemo<XDSTableColumn<Issue>[]>(...)`.
+  // ast-types' traversal doesn't descend through the
+  // `TSTypeParameterInstantiation` / `TSArrayType` field path here, so those
+  // type references slip past steps 1-3 and produce dangling prefixed names.
+  //
+  // To cover every type-reference position regardless of how the parser nests
+  // it, walk the raw AST and rename any `TSTypeReference` whose `typeName` is a
+  // renamed binding. Renaming already-bare names is a no-op, so re-visiting a
+  // node the earlier passes handled is harmless.
+  const seenTypeNodes = new Set();
+  const renameTypeReferences = node => {
+    if (!node || typeof node !== 'object') return;
+    if (Array.isArray(node)) {
+      for (const child of node) renameTypeReferences(child);
+      return;
+    }
+    if (seenTypeNodes.has(node)) return;
+    seenTypeNodes.add(node);
+
+    if (
+      node.type === 'TSTypeReference' &&
+      node.typeName &&
+      node.typeName.type === 'Identifier'
+    ) {
+      const newName = localRenames.get(node.typeName.name);
+      if (newName && node.typeName.name !== newName) {
+        node.typeName.name = newName;
+        hasChanges = true;
+      }
+    }
+
+    for (const key of Object.keys(node)) {
+      // Skip position/metadata fields to avoid wasted traversal.
+      if (
+        key === 'loc' ||
+        key === 'start' ||
+        key === 'end' ||
+        key === 'range' ||
+        key === 'comments' ||
+        key === 'leadingComments' ||
+        key === 'trailingComments' ||
+        key === 'tokens'
+      ) {
+        continue;
+      }
+      renameTypeReferences(node[key]);
+    }
+  };
+  renameTypeReferences(root.get().node);
 
   return hasChanges ? root.toSource() : undefined;
 }


### PR DESCRIPTION
## What

Fixes the `drop-xds-prefix-imports` codemod to rename XDS-prefixed type names that appear in **generic type-argument positions**, e.g.:

```ts
useMemo<XDSTableColumn<Issue>[]>(() => [...], [])
```

Before this fix the import was renamed (`XDSTableColumn` → `TableColumn`) but the usage inside the generic `<...>` was left untouched, producing `TS2304: Cannot find name 'XDSTableColumn'` and a cascade of implicit-`any` errors.

## Why

With the `tsx`/babel parser, ast-types' traversal does **not** descend into the
`TSTypeParameterInstantiation` → `TSArrayType` → `TSTypeReference` field path.
As a result, neither `j.find(j.Identifier)` nor `j.find(j.TSTypeReference)` visits
the identifier nested inside a generic type argument, so those references slipped
past the existing rename passes. (Top-level type references like
`type Props = XDSButtonProps & {...}` *are* visited, which is why they already worked.)

## How

Added a final pass that walks the raw AST recursively and renames any
`TSTypeReference` whose `typeName` identifier is a renamed `@xds/core` binding.
This covers every type-reference position regardless of how the parser nests it.
Renaming an already-bare name is a no-op, so re-visiting nodes handled by earlier
passes is harmless. Only bindings tracked from an `@xds/core` import are renamed —
unrelated generic arguments (e.g. `Issue`) are left alone.

## Test plan

- Added a test case covering a generic type-argument usage:
  `useMemo<XDSTableColumn<Issue>[]>` → `useMemo<TableColumn<Issue>[]>` (and verifying
  the unrelated `Issue` argument is untouched).
- `npx vitest run drop-xds-prefix-imports` → 11/11 pass.
- Full codemod suite (`packages/cli/src/codemods`) → 465/465 pass, no regressions.
- `prettier --check` and `eslint` clean on the changed files.
