### PR TITLE
fix(docsite): repair footer copyright, add GitHub Pages link, responsive layout

### DIFF
--- a/apps/docsite/src/components/SiteFooter.tsx
+++ b/apps/docsite/src/components/SiteFooter.tsx
@@ -1,5 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+'use client';
+
 import * as stylex from '@stylexjs/stylex';
 import {spacingVars} from '@xds/core/theme/tokens.stylex';
 import {Text} from '@xds/core/Text';
@@ -9,7 +11,8 @@ import {HStack, VStack} from '@xds/core/Layout';
 import {Grid, GridSpan} from '@xds/core/Grid';
 import {Card} from '@xds/core/Card';
 import {Section} from '@xds/core/Section';
-import {GITHUB_REPO} from '../constants';
+import {useAppShellMobile} from '@xds/core/AppShell';
+import {GITHUB_REPO, GITHUB_PAGES} from '../constants';
 import {
   AstryxLogo,
   GitHubLogo,
@@ -55,6 +58,7 @@ const FOOTER_LINKS: ReadonlyArray<{
   {label: 'Templates', href: '/templates'},
   {label: 'Themes', href: '/themes'},
   {label: 'Playground', href: '/playground'},
+  {label: 'GitHub Pages', href: GITHUB_PAGES, isExternal: true},
 ];
 
 const SOCIAL_LINKS: ReadonlyArray<{
@@ -72,81 +76,151 @@ const LEGAL_LINKS: ReadonlyArray<{label: string; href: string}> = [
   {label: 'Privacy policy', href: 'https://opensource.fb.com/legal/privacy'},
 ];
 
+function NavLinks() {
+  return (
+    <>
+      {FOOTER_LINKS.map(item => (
+        <Link
+          key={item.label}
+          href={item.href}
+          type="supporting"
+          color="secondary"
+          isStandalone
+          target={item.isExternal ? '_blank' : undefined}>
+          {item.label}
+        </Link>
+      ))}
+    </>
+  );
+}
+
+function SocialButtons() {
+  return (
+    <>
+      {SOCIAL_LINKS.map(social => (
+        <Button
+          key={social.label}
+          label={social.label}
+          tooltip={social.label}
+          variant="secondary"
+          isIconOnly
+          icon={
+            <social.Icon
+              aria-hidden="true"
+              {...stylex.props(styles.socialIcon)}
+            />
+          }
+          href={social.href}
+        />
+      ))}
+    </>
+  );
+}
+
+function LegalLinks() {
+  return (
+    <>
+      {LEGAL_LINKS.map(link => (
+        <Link
+          key={link.label}
+          href={link.href}
+          type="supporting"
+          color="secondary"
+          isStandalone
+          target="_blank">
+          {link.label}
+        </Link>
+      ))}
+    </>
+  );
+}
+
 export function SiteFooter() {
+  const {isMobile} = useAppShellMobile();
   const year = new Date().getFullYear();
+
+  // The regex compliance check requires the year to immediately follow the
+  // copyright mark — `©{year}`, no separating space. See PR description.
+  const copyright = `\u00A9${year} Meta Platforms, Inc.`;
+
+  const astryxLogo = (
+    <AstryxLogo role="img" aria-label="Astryx" {...stylex.props(styles.logo)} />
+  );
+
+  const metaOpenSourceLink = (
+    <Link
+      href="https://opensource.fb.com"
+      label="Meta Open Source"
+      target="_blank">
+      <MetaOpenSourceLogo
+        aria-hidden="true"
+        {...stylex.props(styles.metaOpenSourceLogo)}
+      />
+    </Link>
+  );
+
+  if (isMobile) {
+    // On narrow viewports the horizontal rows can't fit side by side, so we
+    // stack the three regions vertically and let the link lists wrap.
+    return (
+      <Section role="contentinfo" padding={4}>
+        <VStack gap={4}>
+          <VStack gap={3} hAlign="start" xstyle={styles.footerLinks}>
+            {astryxLogo}
+            <HStack gap={4} wrap="wrap" align="center">
+              <NavLinks />
+            </HStack>
+            <HStack gap={2} wrap="wrap" align="center">
+              <SocialButtons />
+            </HStack>
+          </VStack>
+
+          <Card variant="muted">
+            <VStack gap={3} hAlign="start">
+              {metaOpenSourceLink}
+              <VStack gap={2} hAlign="start">
+                <LegalLinks />
+              </VStack>
+              <Text type="supporting" color="secondary">
+                {copyright}
+              </Text>
+            </VStack>
+          </Card>
+        </VStack>
+      </Section>
+    );
+  }
 
   return (
     <Section role="contentinfo" padding={4}>
       <VStack gap={4}>
         <Grid columns={5} xstyle={styles.footerLinks} align="center">
-          <AstryxLogo
-            role="img"
-            aria-label="Astryx"
-            {...stylex.props(styles.logo)}
-          />
+          {astryxLogo}
           <GridSpan columns={3}>
-            <HStack gap={4} align="center" hAlign="center">
-              {FOOTER_LINKS.map(item => (
-                <Link
-                  key={item.label}
-                  href={item.href}
-                  type="supporting"
-                  color="secondary"
-                  isStandalone
-                  target={item.isExternal ? '_blank' : undefined}>
-                  {item.label}
-                </Link>
-              ))}
+            <HStack gap={4} wrap="wrap" align="center" hAlign="center">
+              <NavLinks />
             </HStack>
           </GridSpan>
           <HStack gap={2} align="center" justify="end">
-            {SOCIAL_LINKS.map(social => (
-              <Button
-                key={social.label}
-                label={social.label}
-                tooltip={social.label}
-                variant="secondary"
-                isIconOnly
-                icon={
-                  <social.Icon
-                    aria-hidden="true"
-                    {...stylex.props(styles.socialIcon)}
-                  />
-                }
-                href={social.href}
-              />
-            ))}
+            <SocialButtons />
           </HStack>
         </Grid>
 
         <Card variant="muted">
           <Grid columns={4} align="center">
-            <Link
-              href="https://opensource.fb.com"
-              label="Meta Open Source"
-              target="_blank">
-              <MetaOpenSourceLogo
-                aria-hidden="true"
-                {...stylex.props(styles.metaOpenSourceLogo)}
-              />
-            </Link>
+            {metaOpenSourceLink}
             <GridSpan columns={2}>
-              <HStack gap={4} align="center" hAlign="center" width="100%">
-                {LEGAL_LINKS.map(link => (
-                  <Link
-                    key={link.label}
-                    href={link.href}
-                    type="supporting"
-                    color="secondary"
-                    isStandalone
-                    target="_blank">
-                    {link.label}
-                  </Link>
-                ))}
+              <HStack
+                gap={4}
+                wrap="wrap"
+                align="center"
+                hAlign="center"
+                width="100%">
+                <LegalLinks />
               </HStack>
             </GridSpan>
             <Text type="supporting" color="secondary" justify="end">
-              &copy; {year} Meta Platforms, Inc.
+              {copyright}
             </Text>
           </Grid>
         </Card>

--- a/apps/docsite/src/constants.ts
+++ b/apps/docsite/src/constants.ts
@@ -3,6 +3,14 @@
 export const GITHUB_REPO = 'https://github.com/facebookexperimental/xds';
 
 /**
+ * Public GitHub Pages deployment for the site (Storybook, sandbox, and the
+ * landing page). Distinct from GITHUB_REPO, which points at the source repo.
+ * See .github/workflows/deploy.yml — the site is published to gh-pages with
+ * no CNAME, so it resolves to the org's github.io subpath.
+ */
+export const GITHUB_PAGES = 'https://facebookexperimental.github.io/xds/';
+
+/**
  * Astryx brand blue — logo/wordmark only (not wired to any semantic token).
  * Lives here, not in astryxTheme.ts, so it can be imported without pulling in
  * the unbuilt source theme object (which triggers runtime style injection).


### PR DESCRIPTION
## What

Fixes three issues with the docsite footer (`apps/docsite/src/components/SiteFooter.tsx`):

1. **Copyright was failing the required compliance regex.** The footer rendered `© {year} Meta Platforms, Inc.` — with a space between the copyright mark and the year. The required pattern is:

   ```
   /(Copyright|©|Copyright\s+©)(20[0-9]{2},?)\s+Meta Platforms,\s+Inc/
   ```

   The capture groups are adjacent: `(…©…)(20[0-9]{2})`. There is **no** `\s` allowed between the mark and the year, so `© 2026` never matched. Now it renders `©{year}` (no space), which matches.

2. **Missing GitHub Pages link.** Added a "GitHub Pages" entry to the footer nav pointing at the published site (`https://facebookexperimental.github.io/xds/`, exposed as a new `GITHUB_PAGES` constant). This is distinct from `GITHUB_REPO` (the source repo).

3. **Poor responsiveness on mobile.** The nav row, social row, and legal/copyright row were fixed `Grid` layouts that overflowed and collided on narrow screens (see before screenshots). The footer now uses `useAppShellMobile()` to switch to a vertical stack below the `md` (768px) breakpoint, and the link lists `wrap`.

## How

- `©{year}` is built explicitly (`\u00A9${year}`) with a comment explaining the no-space requirement so a future "tidy-up" doesn't reintroduce the space.
- Footer markup factored into small `NavLinks` / `SocialButtons` / `LegalLinks` helpers so the desktop (`Grid`) and mobile (`VStack`) branches share the same link definitions.
- `SiteFooter` is now a client component (`'use client'`) because `useAppShellMobile()` reads context. `isMobile` is seeded from `defaultIsMobile` (UA-derived, already threaded through every layout's `AppShell mobileNav` config), so SSR and first client render agree — no hydration mismatch.
- `Grid` sets `grid-template-columns` via an inline style, which a `@media` `xstyle` override can't beat — so the responsive collapse branches on `isMobile` rather than fighting Grid with CSS.
- `apps/docsite` is `private`, so no changeset is added.

## Note on the Docusaurus comparison

The hint was that `docusaurus.io` "passes" this regex while also having a space after the `©`. Worth flagging: against this *exact* regex, a literal `Copyright © 2026 …` string would **also fail** (same adjacency rule — the year must immediately follow the mark). So if Docusaurus passes the upstream checker, that checker is almost certainly normalizing/stripping whitespace before matching, or matching a different rendered string. This PR makes XDS pass the regex as written, rather than relying on that normalization.

## Testing

- `tsc --noEmit` on `apps/docsite`: no errors in `SiteFooter.tsx` / `constants.ts` (remaining errors are pre-existing, from unbuilt `@xds/theme-*` packages on a fresh worktree).
- Pre-commit hooks (eslint, prettier, sync/boundary/compat checks) all pass.
- Regex verified against the rendered string: `©2026 Meta Platforms, Inc.` → matches.