### PR TITLE
docs(deslop): fix em-dashes + Button dense bestPractices parity

### DIFF
--- a/packages/core/src/AppShell/useAppShellMobile.doc.mjs
+++ b/packages/core/src/AppShell/useAppShellMobile.doc.mjs
@@ -16,7 +16,7 @@ export const docs = {
     'drawer state',
   ],
   params: [
-    // useAppShellMobile takes no arguments — it reads AppShell context.
+    // useAppShellMobile takes no arguments; it reads AppShell context.
   ],
   returns: [
     {

--- a/packages/core/src/Button/Button.doc.mjs
+++ b/packages/core/src/Button/Button.doc.mjs
@@ -18,7 +18,7 @@ export const docs = {
       {guidance: true, description: 'Write labels that describe the action ("Save changes", "Delete account", "Send invite"), not vague labels like "OK" or "Click here".'},
       {guidance: true, description: 'Show a loading state for actions that take time, like saving or submitting, so the user knows it is working.'},
       {guidance: true, description: 'Always provide a label for icon-only buttons so screen readers can announce what the button does. Add a tooltip for sighted users.'},
-      {guidance: true, description: 'For a dedicated icon-only button, use IconButton from \'@xds/core/IconButton\'. It is a separate component — not exported from \'@xds/core/Button\'.'},
+      {guidance: true, description: 'For a dedicated icon-only button, use IconButton from \'@xds/core/IconButton\'. It is a separate component, not exported from \'@xds/core/Button\'.'},
       {guidance: false, description: 'Place more than one primary button in the same view; this dilutes the visual hierarchy.'},
       {guidance: false, description: 'Use the destructive variant without a confirmation step for irreversible actions like deleting data.'},
       {guidance: false, description: 'Use a button for navigation. If it only takes the user to another page, use a link instead. Buttons are for actions like saving, deleting, or submitting.'},
@@ -102,7 +102,7 @@ export const docs = {
       name: 'children',
       type: 'ReactNode',
       description:
-        'Optional override for visible text. When provided, displayed instead of label — but label is still required (it provides the accessible name). For most cases, just use label alone: <Button label="Save" />.',
+        'Optional override for visible text. When provided, displayed instead of label, but label is still required (it provides the accessible name). For most cases, just use label alone: <Button label="Save" />.',
     },
     {
       name: 'endContent',
@@ -248,6 +248,7 @@ export const docsDense = {
       {guidance: true, description: 'Labels that describe the action: "Save changes" not "OK" or "Click here".'},
       {guidance: true, description: 'Show loading state for async actions so the user knows it is working.'},
       {guidance: true, description: 'Icon-only buttons need a label for screen readers and a tooltip for sighted users.'},
+      {guidance: true, description: 'For dedicated icon-only buttons, use IconButton from @xds/core/IconButton. Separate component, not exported from @xds/core/Button.'},
       {guidance: false, description: 'Multiple primary buttons in one view; dilutes hierarchy.'},
       {guidance: false, description: 'Destructive without confirmation for irreversible actions.'},
       {guidance: false, description: 'Button for navigation; use a link if it only takes the user to another page.'},

--- a/packages/core/src/Chat/ChatComposerInput.doc.mjs
+++ b/packages/core/src/Chat/ChatComposerInput.doc.mjs
@@ -89,7 +89,7 @@ export const docsZh = {
   displayName: 'Chat Composer Input',
   description: '聊天编写器的富文本输入。支持触发菜单（输入 @ 或 / 打开 typeahead）、内联标记徽章、ArrowUp/Down 消息历史回溯、粘贴/拖放文件处理，并在触控设备上将字体大小保持至少 16px 以避免 iOS 输入缩放。当需要普通文本区域以外的功能时，传入 ChatComposer 的 input 插槽。',
   propDescriptions: {
-    handleRef: '命令式句柄，用于编程式控制 — insertToken、insertText、focus 和 getValue。',
+    handleRef: '命令式句柄，用于编程式控制：insertToken、insertText、focus 和 getValue。',
     value: '受控输入值。与 onChange 配对实现双向绑定。',
     onChange: '输入值变更时调用。序列化字符串包含标记占位符。',
     placeholder: '输入为空时显示的占位文本。',

--- a/packages/core/src/Chat/ChatLayout.doc.mjs
+++ b/packages/core/src/Chat/ChatLayout.doc.mjs
@@ -113,8 +113,8 @@ export const docsZh = {
   displayName: 'Chat Layout',
   description: '完整聊天界面的布局外壳。消息在页面中自然流动，编写器固定在底部，带有毛玻璃效果。通过容器宽度自动适配密度。',
   propDescriptions: {
-    children: '消息内容 — 通常是 ChatMessageList。在页面中自然流动。',
-    composer: '编写器元素 — 通常是 ChatComposer。固定在底部，带有毛玻璃底座。',
+    children: '消息内容，通常是 ChatMessageList。在页面中自然流动。',
+    composer: '编写器元素，通常是 ChatComposer。固定在底部，带有毛玻璃底座。',
     emptyState: '子元素为空时显示的内容。',
     scrollButton: '编写器上方的滚动到底部按钮。默认使用 ChatLayoutScrollButton。传入 null 隐藏。',
     scrollRef: '外部滚动容器引用。提供时，自动滚动和滚动到底部将目标指向此元素。',

--- a/packages/core/src/Chat/ChatLayoutScrollButton.doc.mjs
+++ b/packages/core/src/Chat/ChatLayoutScrollButton.doc.mjs
@@ -36,7 +36,7 @@ export const docsZh = {
   description: '可组合的滚动到底部按钮。可见时淡入，提供标签时展开。',
   propDescriptions: {
     isVisible: '按钮是否可见。',
-    label: '可选标签 — 展开按钮（如"新消息"）。',
+    label: '可选标签，展开按钮（如"新消息"）。',
     onClick: '点击处理器。',
   },
 };

--- a/packages/core/src/Chat/ChatMessageMetadata.doc.mjs
+++ b/packages/core/src/Chat/ChatMessageMetadata.doc.mjs
@@ -49,8 +49,8 @@ export const docsZh = {
   displayName: 'Chat Message Metadata',
   description: '可组合的消息元数据行。渲染时间戳、页脚内容和发送状态。用户消息方向反转。',
   propDescriptions: {
-    timestamp: '时间戳内容 — 字符串或 Timestamp 组件。',
-    footer: '页脚内容 — 模型信息、反应按钮、复制按钮。',
+    timestamp: '时间戳内容，字符串或 Timestamp 组件。',
+    footer: '页脚内容：模型信息、反应按钮、复制按钮。',
     status: '消息发送状态。显示图标和标签。',
   },
 };

--- a/packages/core/src/Chat/ChatSystemMessage.doc.mjs
+++ b/packages/core/src/Chat/ChatSystemMessage.doc.mjs
@@ -42,8 +42,8 @@ export const docsZh = {
   displayName: 'Chat System Message',
   description: '居中的系统消息，用于日期分隔、成员变更和状态通知等非发送者内容。没有头像、对齐或气泡。使用 divider 变体做时间分隔，default 做内联状态更新。',
   propDescriptions: {
-    children: '系统消息内容 — 简短的事实性文本，如日期、加入/离开通知或状态变更。',
-    variant: "视觉变体。'default' 渲染居中文本。'divider' 通过 Divider 在两侧添加水平线 — 用于日期分隔和段落分隔。",
+    children: '系统消息内容，简短的事实性文本，如日期、加入/离开通知或状态变更。',
+    variant: "视觉变体。'default' 渲染居中文本。'divider' 通过 Divider 在两侧添加水平线，用于日期分隔和段落分隔。",
     icon: '增强消息类型辨识度的前置图标。使用 Icon 包裹以获得一致的尺寸。',
   },
 };

--- a/packages/core/src/Chat/ChatTokenizedText.doc.mjs
+++ b/packages/core/src/Chat/ChatTokenizedText.doc.mjs
@@ -30,7 +30,7 @@ export const docsZh = {
   description: '渲染带有标记模式的文本，将匹配的模式替换为内联 Badge 组件。在 ChatMessageBubble 内使用，将 @提及、#标签或 /命令显示为样式化徽章。未提供标记时以纯文本渲染，因此可以无条件使用。',
   propDescriptions: {
     children: '包含序列化标记值的纯文本消息。匹配标记值的模式将被替换为内联徽章组件。',
-    tokens: '标记定义 — 与触发器 onSelect 返回的类型相同。每个包含 value（匹配字符串）、label（显示文本）以及可选的 variant 和 icon。',
+    tokens: '标记定义，与触发器 onSelect 返回的类型相同。每个包含 value（匹配字符串）、label（显示文本）以及可选的 variant 和 icon。',
   },
 };
 

--- a/packages/core/src/Field/Field.doc.mjs
+++ b/packages/core/src/Field/Field.doc.mjs
@@ -105,7 +105,7 @@ export const docs = {
     {
       name: 'width',
       type: 'SizeValue',
-      description: 'Width of the field (number = pixels, string used as-is, e.g. "100%"). Sizes the whole field — label, control, and status — so they stay aligned. Prefer this over setting width via xstyle/className/style, which only size the inner control box.',
+      description: 'Width of the field (number = pixels, string used as-is, e.g. "100%"). Sizes the whole field (label, control, and status) so they stay aligned. Prefer this over setting width via xstyle/className/style, which only size the inner control box.',
     },
     {
       name: 'ref',

--- a/packages/core/src/Outline/Outline.doc.mjs
+++ b/packages/core/src/Outline/Outline.doc.mjs
@@ -115,7 +115,7 @@ import {Outline} from '@xds/core/Outline';
 function ControlledOutline() {
   const [activeId, setActiveId] = useState('overview');
 
-  // Providing activeId disables built-in scroll-spy — you own the active state.
+  // Providing activeId disables built-in scroll-spy; you own the active state.
   return (
     <Outline
       items={items}

--- a/packages/core/src/Toast/useToast.doc.mjs
+++ b/packages/core/src/Toast/useToast.doc.mjs
@@ -7,7 +7,7 @@ export const docs = {
   group: 'Toast',
   keywords: ['toast', 'notification', 'snackbar', 'alert', 'message', 'feedback', 'flash'],
   params: [
-    // useToast takes no arguments — returns a show function
+    // useToast takes no arguments; returns a show function
   ],
   returns: [
     {

--- a/packages/core/src/TopNav/TopNavHeading.doc.mjs
+++ b/packages/core/src/TopNav/TopNavHeading.doc.mjs
@@ -125,7 +125,7 @@ export const docsZh = {
     {
       name: 'href',
       type: 'string',
-      description: '已弃用 — 请使用 headingHref。点击时导航到的 URL。',
+      description: '已弃用，请使用 headingHref。点击时导航到的 URL。',
     },
     {
       name: 'superheading',

--- a/packages/core/src/TopNav/TopNavItem.doc.mjs
+++ b/packages/core/src/TopNav/TopNavItem.doc.mjs
@@ -69,7 +69,7 @@ export const docsZh = {
   name: 'TopNavItem',
   isHiddenFromOverview: true,
   displayName: 'Top Nav Item',
-  description: '用于 TopNav startContent 的导航链接项 — 渲染为具有悬停和选中状态的锚点。',
+  description: '用于 TopNav startContent 的导航链接项，渲染为具有悬停和选中状态的锚点。',
   props: [
     {
       name: 'label',

--- a/packages/core/src/TopNav/TopNavMegaMenu.doc.mjs
+++ b/packages/core/src/TopNav/TopNavMegaMenu.doc.mjs
@@ -76,12 +76,12 @@ export const docsZh = {
     {
       name: 'items',
       type: 'ReactNode',
-      description: '菜单项插槽 — 通常为 TopNavMegaMenuItem 组件，但接受任何 ReactNode。',
+      description: '菜单项插槽，通常为 TopNavMegaMenuItem 组件，但接受任何 ReactNode。',
     },
     {
       name: 'featured',
       type: 'ReactNode',
-      description: '特色内容插槽 — 桌面端显示在右侧面板，移动抽屉中显示在项目下方。',
+      description: '特色内容插槽，桌面端显示在右侧面板，移动抽屉中显示在项目下方。',
     },
     {
       name: 'delay',


### PR DESCRIPTION
## What

- Replace em-dashes with appropriate punctuation in 14 doc files:
  - English prose (Button, Field, AppShell, Toast, Outline): semicolons, commas, parentheses
  - CJK translations (Chat*, TopNav*): Chinese comma or colon instead of single em-dash
- Add missing 8th bestPractice to Button `docsDense` overlay (IconButton guidance entry added in #2955 but dense overlay was not updated, causing 8-vs-7 count mismatch)

CJK double em-dashes and numeric en-dashes left as-is (correct usage).

## Checklist
- [x] `pnpm --filter @xds/core typecheck:docs` passes
- [x] `npx tsc --project packages/cli/tsconfig.template-docs.json --noEmit` passes
- [x] CLI `--lang dense` output verified for Button (8 bestPractices, no duplicate required markers)
- [x] All edited files parse without error

---
*Night Watch \u2014 Doc Reviewer*