### PR TITLE
fix(core): tokenize SelectableCard transitions, add className to ResizeHandle

### DIFF
--- a/packages/core/src/Resizable/ResizeHandle.tsx
+++ b/packages/core/src/Resizable/ResizeHandle.tsx
@@ -213,7 +213,7 @@ const dynamicStyles = stylex.create({
 
 export interface ResizeHandleProps extends Omit<
   BaseProps<HTMLDivElement>,
-  'style' | 'className'
+  'style'
 > {
   ref?: React.Ref<HTMLDivElement>;
 
@@ -311,6 +311,7 @@ export function ResizeHandle({
   resizable,
   children,
   xstyle,
+  className,
   ref,
   ...props
 }: ResizeHandleProps) {
@@ -507,6 +508,7 @@ export function ResizeHandle({
           isDisabled && styles.disabled,
           xstyle,
         ),
+        className,
       )}
       {...props}>
       {/* Wider invisible hit area for pointer interaction */}

--- a/packages/core/src/SelectableCard/SelectableCard.tsx
+++ b/packages/core/src/SelectableCard/SelectableCard.tsx
@@ -35,7 +35,7 @@ import {
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
-import {colorVars} from '../theme/tokens.stylex';
+import {colorVars, durationVars, easeVars} from '../theme/tokens.stylex';
 import type {SizeValue, SpacingStep} from '../utils/types';
 import {mergeProps, mergeRefs} from '../utils';
 import {Card} from '../Card/Card';
@@ -52,7 +52,9 @@ const styles = stylex.create({
   interactive: {
     position: 'relative',
     cursor: 'pointer',
-    transition: 'box-shadow 0.15s ease, border-color 0.15s ease',
+    transitionProperty: 'box-shadow, border-color',
+    transitionDuration: durationVars['--duration-fast'],
+    transitionTimingFunction: easeVars['--ease-standard'],
     outlineOffset: '2px',
   },
   focusWithin: {
@@ -70,7 +72,9 @@ const styles = stylex.create({
       inset: 0,
       borderRadius: 'inherit',
       pointerEvents: 'none',
-      transition: 'background-color 0.15s ease',
+      transitionProperty: 'background-color',
+      transitionDuration: durationVars['--duration-fast'],
+      transitionTimingFunction: easeVars['--ease-standard'],
       backgroundColor: 'transparent',
     },
     ':active::after': {


### PR DESCRIPTION
## Component Audit (2026-06-21)

Components audited: Resizable, SelectableCard, SizeContext, Skeleton, TextInput

### Fixes

**SelectableCard** -- hardcoded transition values replaced with design tokens:
- `transition: 'box-shadow 0.15s ease, border-color 0.15s ease'` replaced with
  `transitionProperty` + `durationVars['--duration-fast']` + `easeVars['--ease-standard']`
- Same for the overlay `::after` background-color transition
- Themes can now control animation timing for this component

**ResizeHandle** -- missing className escape hatch:
- `className` was explicitly omitted from BaseProps via `Omit<BaseProps, 'style' | 'className'>`
- Added `className` back (still omits `style` since inline style could break handle positioning)
- `className` is properly merged via `mergeProps` alongside xdsThemeProps and stylex output

### No issues found

- **Resizable/useResizable**: tokens, naming, structure, exports all clean
- **SizeContext**: context utility, naming and exports correct
- **Skeleton**: tokens (uses colorVars, radiusVars, durationVars), structure, exports clean
- **TextInput**: full input consistency (label, value, onChange, status shape, a11y wiring, data-autofocus), tokens, structure all correct

Night Watch -- Component Auditor