### PR TITLE
chore(oss): scrub internal references from source for OSS release

### DIFF
--- a/apps/docsite/src/app/playground/themeEditor/icons.tsx
+++ b/apps/docsite/src/app/playground/themeEditor/icons.tsx
@@ -2,7 +2,7 @@
 
 /**
  * Icon shim for the theme playground. The tool was authored against internal
- * `@nest/*` icon packages; the OSS docsite uses Lucide. Each export keeps the
+ * icon packages; the OSS docsite uses Lucide. Each export keeps the
  * original icon name (aliased to the closest Lucide icon) and renders at the
  * 16px size the editor expects, so the ported component code stays unchanged.
  */

--- a/apps/sandbox/src/app/(fullscreen)/pages/showcase-components/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/showcase-components/page.tsx
@@ -50,7 +50,7 @@ export default function ShowcaseComponentsPage() {
           <VStack gap={4}>
             <Heading level={2}>Build with XDS</Heading>
             <Text type="body" color="secondary">
-              Open source components for Nest and beyond
+              Open source components for the web and beyond
             </Text>
           </VStack>
           <HStack gap={2}>

--- a/apps/sandbox/src/app/(fullscreen)/pages/showcase-header/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/showcase-header/page.tsx
@@ -55,13 +55,13 @@ export default function ShowcaseHeaderPage() {
       <div {...stylex.props(styles.content)}>
         <div {...stylex.props(styles.badgeRow)}>
           <Badge label="Open Source" variant="info" />
-          <Badge label="Nest" variant="success" />
+          <Badge label="Astryx" variant="success" />
         </div>
 
         <div {...stylex.props(styles.titleRow)}>
           <Heading level={1}>XDS</Heading>
           <div {...stylex.props(styles.connector)} />
-          <Heading level={1}>Nest</Heading>
+          <Heading level={1}>Astryx</Heading>
         </div>
 
         <div {...stylex.props(styles.subtitle)}>

--- a/packages/cli/src/api/template.test.mjs
+++ b/packages/cli/src/api/template.test.mjs
@@ -14,7 +14,7 @@ describe('stripTemplateAssetRefs', () => {
 
   it('replaces a lookaside block-avatar image URL', () => {
     const src =
-      'src="https://lookaside.facebook.com/assets/vs_datakit_profile_photos_t66173184/VS-Design-Tools-Datakit-05.jpg"';
+      'src="https://lookaside.facebook.com/assets/xds_oss/avatar-profile-05.jpg"';
     const out = stripTemplateAssetRefs(src);
     expect(out).not.toContain('lookaside.facebook.com');
     expect(out).toContain('data:image/svg+xml,');

--- a/packages/cli/src/codemods/transforms/v0.0.15/__tests__/migrate-selector-children-to-render-option.test.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.15/__tests__/migrate-selector-children-to-render-option.test.mjs
@@ -89,8 +89,8 @@ describe('migrate-selector-children-to-render-option', () => {
     expect(output).toBe(input);
   });
 
-  it('does not touch legacy @nest/xds selector item children', async () => {
-    const input = `import {XDSSelector, XDSSelectorItem} from '@nest/xds';
+  it('does not touch legacy @acme/legacy selector item children', async () => {
+    const input = `import {XDSSelector, XDSSelectorItem} from '@acme/legacy';
 <XDSSelector label="Role" value={value} onChange={setValue}>
   <XDSSelectorItem label="Admin" value="admin" />
 </XDSSelector>`;

--- a/packages/cli/src/codemods/transforms/v0.0.15/migrate-selector-children-to-render-option.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.15/migrate-selector-children-to-render-option.mjs
@@ -16,7 +16,7 @@
  *
  * The transform is import-aware and only touches components imported from
  * @xds/core or @xds/core/{Selector,MultiSelector}. It intentionally skips
- * legacy @nest/xds selectors, where JSX children are selector items.
+ * legacy @acme/legacy selectors, where JSX children are selector items.
  */
 
 export const meta = {

--- a/packages/cli/templates/blocks/components/Avatar/AvatarFallbackChain.tsx
+++ b/packages/cli/templates/blocks/components/Avatar/AvatarFallbackChain.tsx
@@ -10,11 +10,7 @@ export default function AvatarFallbackChain() {
   return (
     <VStack gap={4}>
       <HStack gap={3} vAlign="center">
-        <Avatar
-          src="https://lookaside.facebook.com/assets/vs_datakit_profile_photos_t66173184/VS-Design-Tools-Datakit-60.jpg"
-          name="Carol Davis"
-          size="medium"
-        />
+        <Avatar name="Carol Davis" size="medium" />
         <Text type="supporting">Valid src</Text>
       </HStack>
       <HStack gap={3} vAlign="center">

--- a/packages/cli/templates/blocks/components/Avatar/AvatarGroup.tsx
+++ b/packages/cli/templates/blocks/components/Avatar/AvatarGroup.tsx
@@ -10,23 +10,18 @@ import {Text} from '@xds/core/Text';
 const USERS = [
   {
     name: 'Alex Daniels',
-    src: 'https://lookaside.facebook.com/assets/vs_datakit_profile_photos_t66173184/VS-Design-Tools-Datakit-05.jpg',
   },
   {
     name: 'Ann Smith',
-    src: 'https://lookaside.facebook.com/assets/vs_datakit_profile_photos_t66173184/VS-Design-Tools-Datakit-30.jpg',
   },
   {
     name: 'Carol Davis',
-    src: 'https://lookaside.facebook.com/assets/vs_datakit_profile_photos_t66173184/VS-Design-Tools-Datakit-60.jpg',
   },
   {
     name: 'Gina Wilson',
-    src: 'https://lookaside.facebook.com/assets/vs_datakit_profile_photos_t66173184/VS-Design-Tools-Datakit-98.jpg',
   },
   {
     name: 'Eve Park',
-    src: 'https://lookaside.facebook.com/assets/vs_datakit_profile_photos_t66173184/VS-Design-Tools-Datakit-125.jpg',
   },
 ];
 
@@ -39,7 +34,7 @@ export default function AvatarGroupBlock() {
         </Text>
         <AvatarGroup size="medium">
           {USERS.map(user => (
-            <Avatar key={user.name} src={user.src} name={user.name} />
+            <Avatar key={user.name} name={user.name} />
           ))}
           <AvatarGroupOverflow count={3} />
         </AvatarGroup>
@@ -50,7 +45,7 @@ export default function AvatarGroupBlock() {
         </Text>
         <AvatarGroup size="medium">
           {USERS.slice(0, 3).map(user => (
-            <Avatar key={user.name} src={user.src} name={user.name} />
+            <Avatar key={user.name} name={user.name} />
           ))}
           <AvatarGroupOverflow count={8} />
         </AvatarGroup>

--- a/packages/cli/templates/blocks/components/Avatar/AvatarShowcase.tsx
+++ b/packages/cli/templates/blocks/components/Avatar/AvatarShowcase.tsx
@@ -11,14 +11,9 @@ export default function AvatarShowcase() {
       <Avatar
         name="Ann Smith"
         size="large"
-        src="https://lookaside.facebook.com/assets/vs_datakit_profile_photos_t66173184/VS-Design-Tools-Datakit-30.jpg"
         status={<AvatarStatusDot variant="success" label="Online" />}
       />
-      <Avatar
-        name="Alex Daniels"
-        size="large"
-        src="https://lookaside.facebook.com/assets/vs_datakit_profile_photos_t66173184/VS-Design-Tools-Datakit-05.jpg"
-      />
+      <Avatar name="Alex Daniels" size="large" />
       <Avatar name="Sam Chen" size="large" />
       <Avatar
         name="Taylor Nguyen"

--- a/packages/cli/templates/blocks/components/Avatar/AvatarUserCard.tsx
+++ b/packages/cli/templates/blocks/components/Avatar/AvatarUserCard.tsx
@@ -11,19 +11,16 @@ const USERS = [
     name: 'Alex Daniels',
     role: 'Engineering Lead',
     variant: 'success' as const,
-    src: 'https://lookaside.facebook.com/assets/vs_datakit_profile_photos_t66173184/VS-Design-Tools-Datakit-05.jpg',
   },
   {
     name: 'Ann Smith',
     role: 'Product Designer',
     variant: 'neutral' as const,
-    src: 'https://lookaside.facebook.com/assets/vs_datakit_profile_photos_t66173184/VS-Design-Tools-Datakit-30.jpg',
   },
   {
     name: 'Carol Davis',
     role: 'Engineering Manager',
     variant: 'error' as const,
-    src: 'https://lookaside.facebook.com/assets/vs_datakit_profile_photos_t66173184/VS-Design-Tools-Datakit-60.jpg',
   },
 ];
 
@@ -31,13 +28,8 @@ export default function AvatarUserCard() {
   return (
     <Stack direction="vertical" gap={4}>
       {USERS.map(user => (
-        <Stack
-          key={user.name}
-          direction="horizontal"
-          gap={3}
-          vAlign="center">
+        <Stack key={user.name} direction="horizontal" gap={3} vAlign="center">
           <Avatar
-            src={user.src}
             name={user.name}
             size="medium"
             status={

--- a/packages/cli/templates/blocks/components/Avatar/AvatarWithImage.tsx
+++ b/packages/cli/templates/blocks/components/Avatar/AvatarWithImage.tsx
@@ -8,26 +8,10 @@ import {Stack} from '@xds/core/Layout';
 export default function AvatarWithImage() {
   return (
     <Stack direction="horizontal" gap={4} vAlign="center">
-      <Avatar
-        src="https://lookaside.facebook.com/assets/vs_datakit_profile_photos_t66173184/VS-Design-Tools-Datakit-05.jpg"
-        name="Alex Daniles"
-        size="tiny"
-      />
-      <Avatar
-        src="https://lookaside.facebook.com/assets/vs_datakit_profile_photos_t66173184/VS-Design-Tools-Datakit-30.jpg"
-        name="Ann Smith"
-        size="small"
-      />
-      <Avatar
-        src="https://lookaside.facebook.com/assets/vs_datakit_profile_photos_t66173184/VS-Design-Tools-Datakit-60.jpg"
-        name="Carol Davis"
-        size="medium"
-      />
-      <Avatar
-        src="https://lookaside.facebook.com/assets/vs_datakit_profile_photos_t66173184/VS-Design-Tools-Datakit-98.jpg"
-        name="Gina Wilson"
-        size="large"
-      />
+      <Avatar name="Alex Daniles" size="tiny" />
+      <Avatar name="Ann Smith" size="small" />
+      <Avatar name="Carol Davis" size="medium" />
+      <Avatar name="Gina Wilson" size="large" />
     </Stack>
   );
 }

--- a/packages/cli/templates/blocks/components/Avatar/AvatarWithStatus.tsx
+++ b/packages/cli/templates/blocks/components/Avatar/AvatarWithStatus.tsx
@@ -9,19 +9,16 @@ export default function AvatarWithStatus() {
   return (
     <Stack direction="horizontal" gap={4} vAlign="center">
       <Avatar
-        src="https://lookaside.facebook.com/assets/vs_datakit_profile_photos_t66173184/VS-Design-Tools-Datakit-05.jpg"
         name="Alex Daniels"
         size="large"
         status={<AvatarStatusDot variant="success" label="Online" />}
       />
       <Avatar
-        src="https://lookaside.facebook.com/assets/vs_datakit_profile_photos_t66173184/VS-Design-Tools-Datakit-30.jpg"
         name="Ann Smith"
         size="large"
         status={<AvatarStatusDot variant="neutral" label="Offline" />}
       />
       <Avatar
-        src="https://lookaside.facebook.com/assets/vs_datakit_profile_photos_t66173184/VS-Design-Tools-Datakit-60.jpg"
         name="Carol Davis"
         size="large"
         status={<AvatarStatusDot variant="error" label="Busy" />}

--- a/packages/cli/templates/blocks/components/AvatarGroup/AvatarGroupShowcase.tsx
+++ b/packages/cli/templates/blocks/components/AvatarGroup/AvatarGroupShowcase.tsx
@@ -9,27 +9,22 @@ import {Text} from '@xds/core/Text';
 const USERS = [
   {
     name: 'Alex Daniels',
-    src: 'https://lookaside.facebook.com/assets/vs_datakit_profile_photos_t66173184/VS-Design-Tools-Datakit-05.jpg',
     key: 'alex',
   },
   {
     name: 'Ann Smith',
-    src: 'https://lookaside.facebook.com/assets/vs_datakit_profile_photos_t66173184/VS-Design-Tools-Datakit-30.jpg',
     key: 'ann',
   },
   {
     name: 'Carol Davis',
-    src: 'https://lookaside.facebook.com/assets/vs_datakit_profile_photos_t66173184/VS-Design-Tools-Datakit-60.jpg',
     key: 'carol',
   },
   {
     name: 'Gina Wilson',
-    src: 'https://lookaside.facebook.com/assets/vs_datakit_profile_photos_t66173184/VS-Design-Tools-Datakit-98.jpg',
     key: 'gina',
   },
   {
     name: 'Eve Park',
-    src: 'https://lookaside.facebook.com/assets/vs_datakit_profile_photos_t66173184/VS-Design-Tools-Datakit-125.jpg',
     key: 'eve',
   },
 ];
@@ -43,7 +38,7 @@ export default function AvatarGroupShowcase() {
         </Text>
         <AvatarGroup size="medium">
           {USERS.map(u => (
-            <Avatar key={u.key} src={u.src} name={u.name} />
+            <Avatar key={u.key} name={u.name} />
           ))}
         </AvatarGroup>
       </Stack>
@@ -53,7 +48,7 @@ export default function AvatarGroupShowcase() {
         </Text>
         <AvatarGroup size="medium">
           {USERS.slice(0, 3).map(u => (
-            <Avatar key={u.key} src={u.src} name={u.name} />
+            <Avatar key={u.key} name={u.name} />
           ))}
           <AvatarGroupOverflow count={USERS.length - 3} />
         </AvatarGroup>

--- a/packages/cli/templates/blocks/components/AvatarGroupOverflow/AvatarGroupOverflowCustomText.tsx
+++ b/packages/cli/templates/blocks/components/AvatarGroupOverflow/AvatarGroupOverflowCustomText.tsx
@@ -9,15 +9,12 @@ import {Text} from '@xds/core/Text';
 const TEAM = [
   {
     name: 'Alex Daniels',
-    src: 'https://lookaside.facebook.com/assets/vs_datakit_profile_photos_t66173184/VS-Design-Tools-Datakit-05.jpg',
   },
   {
     name: 'Ann Smith',
-    src: 'https://lookaside.facebook.com/assets/vs_datakit_profile_photos_t66173184/VS-Design-Tools-Datakit-30.jpg',
   },
   {
     name: 'Carol Davis',
-    src: 'https://lookaside.facebook.com/assets/vs_datakit_profile_photos_t66173184/VS-Design-Tools-Datakit-60.jpg',
   },
 ];
 
@@ -29,7 +26,7 @@ export default function AvatarGroupOverflowCustomText() {
       </Text>
       <AvatarGroup size="medium">
         {TEAM.map(member => (
-          <Avatar key={member.name} src={member.src} name={member.name} />
+          <Avatar key={member.name} name={member.name} />
         ))}
         <AvatarGroupOverflow count={12}>12+</AvatarGroupOverflow>
       </AvatarGroup>

--- a/packages/cli/templates/blocks/components/AvatarGroupOverflow/AvatarGroupOverflowDefault.tsx
+++ b/packages/cli/templates/blocks/components/AvatarGroupOverflow/AvatarGroupOverflowDefault.tsx
@@ -9,15 +9,12 @@ import {Text} from '@xds/core/Text';
 const REVIEWERS = [
   {
     name: 'Alex Daniels',
-    src: 'https://lookaside.facebook.com/assets/vs_datakit_profile_photos_t66173184/VS-Design-Tools-Datakit-05.jpg',
   },
   {
     name: 'Ann Smith',
-    src: 'https://lookaside.facebook.com/assets/vs_datakit_profile_photos_t66173184/VS-Design-Tools-Datakit-30.jpg',
   },
   {
     name: 'Carol Davis',
-    src: 'https://lookaside.facebook.com/assets/vs_datakit_profile_photos_t66173184/VS-Design-Tools-Datakit-60.jpg',
   },
 ];
 
@@ -29,11 +26,7 @@ export default function AvatarGroupOverflowDefault() {
       </Text>
       <AvatarGroup size="medium">
         {REVIEWERS.map(reviewer => (
-          <Avatar
-            key={reviewer.name}
-            src={reviewer.src}
-            name={reviewer.name}
-          />
+          <Avatar key={reviewer.name} name={reviewer.name} />
         ))}
         <AvatarGroupOverflow count={2} />
       </AvatarGroup>

--- a/packages/cli/templates/blocks/components/AvatarGroupOverflow/AvatarGroupOverflowShowcase.tsx
+++ b/packages/cli/templates/blocks/components/AvatarGroupOverflow/AvatarGroupOverflowShowcase.tsx
@@ -9,15 +9,12 @@ import {Text} from '@xds/core/Text';
 const USERS = [
   {
     name: 'Alex Daniels',
-    src: 'https://lookaside.facebook.com/assets/vs_datakit_profile_photos_t66173184/VS-Design-Tools-Datakit-05.jpg',
   },
   {
     name: 'Ann Smith',
-    src: 'https://lookaside.facebook.com/assets/vs_datakit_profile_photos_t66173184/VS-Design-Tools-Datakit-30.jpg',
   },
   {
     name: 'Carol Davis',
-    src: 'https://lookaside.facebook.com/assets/vs_datakit_profile_photos_t66173184/VS-Design-Tools-Datakit-60.jpg',
   },
 ];
 
@@ -30,7 +27,7 @@ export default function AvatarGroupOverflowShowcase() {
         </Text>
         <AvatarGroup size="medium">
           {USERS.map(user => (
-            <Avatar key={user.name} src={user.src} name={user.name} />
+            <Avatar key={user.name} name={user.name} />
           ))}
           <AvatarGroupOverflow count={5} />
         </AvatarGroup>
@@ -41,7 +38,7 @@ export default function AvatarGroupOverflowShowcase() {
         </Text>
         <AvatarGroup size="medium">
           {USERS.slice(0, 2).map(user => (
-            <Avatar key={user.name} src={user.src} name={user.name} />
+            <Avatar key={user.name} name={user.name} />
           ))}
           <AvatarGroupOverflow count={12}>12+</AvatarGroupOverflow>
         </AvatarGroup>


### PR DESCRIPTION
## What

Pre-OSS-launch source cleanup — removes internal references from current `main` so nothing internal ships in the public release.

> **Scope note:** the `drop-xds-meta-prefix` codemod removal is handled separately in **#2970**. This PR covers the remaining source cleanup only (no overlap).

**1. CLI codemods — genericize `@nest` references**
- `migrate-selector-children-to-render-option`: the doc comment and one negative-test fixture referenced `@nest/xds`. Genericized to `@acme/legacy`. Behavior unchanged — the transform only ever touches `@xds/core` sources, so a non-core source is correctly skipped.
- Docsite theme-playground icon shim: genericized the `@nest/*` comment.

**2. Brand — remove "Nest"**
- `showcase-components`: "components for Nest and beyond" → brand-neutral.
- `showcase-header`: `Nest` badge/heading → `Astryx`.

**3. Avatar templates — drop internal-CDN image URLs**
- Block-template avatars pointed at `lookaside.facebook.com/.../vs_datakit_profile_photos_t66173184/...`; the `t66173184` task ID is an internal reference. Removed the `src` so `<Avatar>` falls back to initials (from `name`). Updated the `stripTemplateAssetRefs` test input to a task-ID-free path so it still validates the stripping behavior.

## Verification

- `git grep 'vs_datakit_profile_photos'` → 0 hits
- `git grep '@nest/'` in changed files → 0 hits
- `git grep` for `Nest` brand usages → 0 hits
- migrate-selector + template tests pass (16 tests); compat-aliases check passes.

This is the source-file half of the pre-launch cleanup. A separate git-history scrub (filter-repo) handles internal references that remain in old commit diffs.