### PR TITLE
docs(dense): remove duplicate (required) markers in Layer and Resizable

### DIFF
--- a/packages/core/src/Layer/Layer.doc.mjs
+++ b/packages/core/src/Layer/Layer.doc.mjs
@@ -89,7 +89,7 @@ export const docsDense = {
       name: 'LayerProvider',
       description: 'App-level provider for toast/layer systems.',
       propDescriptions: {
-        children: 'application subtree using shared layer context **(required)**',
+        children: 'application subtree using shared layer context',
         toast: 'toast viewport config: position, maxVisible, inset',
       },
     },

--- a/packages/core/src/Resizable/Resizable.doc.mjs
+++ b/packages/core/src/Resizable/Resizable.doc.mjs
@@ -226,7 +226,7 @@ export const docsDense = {
         isAlwaysVisible: 'show pill grip at rest instead of only on hover. Use when discoverability important',
         pillPlacement: 'which side of divider pill sits on. auto = content side (derived from isReversed), flips when collapsed; start = left/top, end = right/bottom, center = centered on divider',
         label: 'accessible label for separator',
-        resizable: 'resize props from useResizable: connects handle to panel **(required)**',
+        resizable: 'resize props from useResizable: connects handle to panel',
       },
     },
   ],


### PR DESCRIPTION
## What

The CLI renderer auto-appends `**(required)**` from the English `required: true` field. The `docsDense` overlay text for Layer (children prop) and Resizable (resizable prop) also contained a literal `(required)`, causing double rendering:

```
| children | ReactNode | — | application subtree using shared layer context **(required)** **(required)** |
```

Removed the literal markers from the overlay text so the renderer's single auto-appended marker is the only one shown.

## Checklist
- [x] `pnpm --filter @xds/core typecheck:docs` passes
- [x] `npx tsc --project packages/cli/tsconfig.template-docs.json --noEmit` passes
- [x] CLI `--lang dense` output verified (single `(required)` for both components)

---
*Night Watch -- Doc Reviewer*