### PR TITLE
fix(core/Chat): adopt field content present at mount instead of wiping it

### DIFF
--- a/.changeset/chat-composer-adopt-prehydration-input.md
+++ b/.changeset/chat-composer-adopt-prehydration-input.md
@@ -1,0 +1,7 @@
+---
+'@xds/core': patch
+---
+
+fix(core/Chat): adopt field content present at mount instead of wiping it
+
+`ChatComposerInput`'s controlled-value sync effect overwrote the field with `controlledValue` on mount, discarding any text already in the contentEditable — e.g. typed into the server-rendered composer before hydration attached `onChange`, or filled by the browser. It now adopts that content on the first sync by emitting it through `onChange` (so it becomes the controlled value) instead of erasing it, and marks the field with `suppressHydrationWarning` so React doesn't clobber pre-hydration input. Post-mount behavior is unchanged: an empty `controlledValue` against a non-empty field is still treated as a deliberate external clear.

--- a/packages/core/src/Chat/ChatComposerInput.test.tsx
+++ b/packages/core/src/Chat/ChatComposerInput.test.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 import {describe, it, expect, vi, afterEach} from 'vitest';
+import {useLayoutEffect, useRef} from 'react';
 import {render, screen, fireEvent} from '@testing-library/react';
 import {ChatComposerInput} from './ChatComposerInput';
 import type {
@@ -220,6 +221,36 @@ describe('ChatComposerInput', () => {
       rerender(<ChatComposerInput value="hello" onChange={onChange} />);
       expect(textbox.textContent).toBe('hello');
     });
+
+    it('adopts field content present at mount instead of wiping it', () => {
+      // The mount sync must adopt content already in the field -- e.g. text
+      // typed into the server-rendered composer before hydration attached
+      // `onChange`, or browser autofill -- by emitting it via `onChange`, not
+      // wiping it. Seed the field from a parent layout effect, which runs
+      // before the composer's passive sync effect, to mimic that pre-existing
+      // content.
+      const onChange = vi.fn();
+      function Harness() {
+        const hostRef = useRef<HTMLDivElement>(null);
+        useLayoutEffect(() => {
+          const field = hostRef.current?.querySelector('[role="textbox"]');
+          if (field) {
+            field.textContent = 'typed before hydration';
+          }
+        }, []);
+        return (
+          <div ref={hostRef}>
+            <ChatComposerInput value="" onChange={onChange} />
+          </div>
+        );
+      }
+      render(<Harness />);
+
+      expect(onChange).toHaveBeenCalledWith('typed before hydration');
+      expect(screen.getByRole('textbox').textContent).toBe(
+        'typed before hydration',
+      );
+    });
   });
 
   describe('file handling', () => {
@@ -345,7 +376,9 @@ describe('ChatComposerInput', () => {
         },
       });
 
-      expect(textbox.querySelector('[data-astryx-token]')).not.toBeInTheDocument();
+      expect(
+        textbox.querySelector('[data-astryx-token]'),
+      ).not.toBeInTheDocument();
       expect(textbox.textContent).toBe(long);
     });
   });

--- a/packages/core/src/Chat/ChatComposerInput.tsx
+++ b/packages/core/src/Chat/ChatComposerInput.tsx
@@ -43,10 +43,7 @@ import {
 } from '../theme/tokens.stylex';
 import {mergeProps} from '../utils';
 import {useTriggerMenu} from './useTriggerMenu';
-import {
-  useChatComposerTokens,
-  isCustomToken,
-} from './useChatComposerTokens';
+import {useChatComposerTokens, isCustomToken} from './useChatComposerTokens';
 import {ensureCaretInside, insertTextAtCursor} from './chatComposerSelection';
 import {ChatPastedTextToken} from './ChatPastedTextToken';
 import {
@@ -322,6 +319,14 @@ export function ChatComposerInput(props: ChatComposerInputProps) {
   // a later external set back to the same string is never
   // incorrectly skipped.
   const pendingEchoValueRef = useRef<string | undefined>(undefined);
+  // Set once the mount-time sync has run; gates the one-shot adoption of
+  // content already present in the field (see the sync effect below).
+  const didInitRef = useRef(false);
+  // Latest `onChange` in a ref so the mount-time adoption can call it without
+  // adding `onChange` to the sync effect's deps -- that would re-run the effect
+  // on every parent render and risk clobbering in-flight input.
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
 
   // Stable refs for imperative handle callbacks (avoid re-creating handle on every render)
   const insertTokenRef = useRef<
@@ -351,6 +356,24 @@ export function ChatComposerInput(props: ChatComposerInputProps) {
     if (controlledValue === undefined || !editableRef.current) {
       return;
     }
+    const editable = editableRef.current;
+    // First mount sync: adopt content already in the field that the controlled
+    // value hasn't captured -- e.g. text typed into the server-rendered
+    // composer before hydration attached `onChange`, or browser autofill.
+    // Hand it to the parent via `onChange` so it becomes the controlled value,
+    // instead of the resync below wiping it. Mount-only: afterwards an empty
+    // `controlledValue` against a non-empty field is a deliberate external
+    // clear, which must still apply.
+    if (!didInitRef.current) {
+      didInitRef.current = true;
+      const existing = serialize(editable);
+      if (existing !== '' && existing !== controlledValue) {
+        pendingEchoValueRef.current = existing;
+        setIsEmpty(false);
+        onChangeRef.current?.(existing);
+        return;
+      }
+    }
     // Skip exactly one echo of our most recent `onChange` emission:
     // the DOM is already authoritative for that value, and the user
     // may have typed more characters between the emit and this
@@ -360,7 +383,6 @@ export function ChatComposerInput(props: ChatComposerInputProps) {
       pendingEchoValueRef.current = undefined;
       return;
     }
-    const editable = editableRef.current;
     if (serialize(editable) !== controlledValue) {
       // Genuine external override — invalidate any stale pending
       // echo before we rewrite the DOM.
@@ -637,6 +659,7 @@ export function ChatComposerInput(props: ChatComposerInputProps) {
         aria-label={label}
         contentEditable={!isDisabled}
         suppressContentEditableWarning
+        suppressHydrationWarning
         onInput={handleInput}
         onKeyDown={handleKeyDown}
         onPaste={handlePaste}
@@ -680,11 +703,7 @@ ChatComposerInput.displayName = 'ChatComposerInput';
 // Token element helper (for custom rendering in stories/consumers)
 // =============================================================================
 
-export function ChatComposerTokenElement({
-  token,
-}: {
-  token: ChatComposerToken;
-}) {
+export function ChatComposerTokenElement({token}: {token: ChatComposerToken}) {
   return (
     <span
       data-astryx-token=""
@@ -694,11 +713,7 @@ export function ChatComposerTokenElement({
       {isCustomToken(token) ? (
         token.render()
       ) : (
-        <Badge
-          label={token.label}
-          variant={token.variant}
-          icon={token.icon}
-        />
+        <Badge label={token.label} variant={token.variant} icon={token.icon} />
       )}
     </span>
   );


### PR DESCRIPTION
## Problem

`ChatComposerInput` silently drops text that's already in the field when it first mounts. Its controlled-value sync effect runs once on mount and, if the DOM doesn't match `controlledValue`, overwrites the field via `editable.textContent = controlledValue`. When the field already holds content the parent hasn't seen yet, that content is destroyed. This happens when:

- a user types into the server-rendered composer before hydration has attached `onChange` (the controlled value is still `''`, so the mount sync wipes what they typed), or
- the browser autofills the field.

## Fix

- **Adopt-on-mount.** On the first sync, if the field already contains content the controlled value hasn't captured, emit it through `onChange` (so it becomes the controlled value) instead of erasing it. This is mount-only — afterwards an empty `controlledValue` against a non-empty field is still treated as a deliberate external clear, so programmatic clears keep working.
- **`suppressHydrationWarning`** on the contentEditable so React leaves pre-hydration input in place rather than reconciling it away.

No change to the existing controlled-sync behavior (echo-skip, external overrides, caret restore on programmatic set) — only the previously-destructive mount case is now non-destructive.

## Test

Adds a regression test: content present in the field when the composer's sync effect first runs is emitted via `onChange` and left in the DOM, rather than wiped.

- `pnpm -F @xds/core test` (Chat suite) — 120 passing, including the new case
- `eslint` + `tsc --noEmit` clean
