### PR TITLE
feat(docsite): refresh home hero theme reel content + fixes

### DIFF
--- a/apps/docsite/src/app/(site)/_landing/DiscoverShowcase.tsx
+++ b/apps/docsite/src/app/(site)/_landing/DiscoverShowcase.tsx
@@ -46,6 +46,12 @@ const styles = stylex.create({
     position: 'relative',
     width: '100%',
     zIndex: 1,
+    // Locally retint the `muted` surface to the page body color so this CTA
+    // card blends into the body (reads as a content group shaped by padding +
+    // corners, not a colored surface). Scoped to this card only — overriding
+    // --color-background-muted theme-wide would also recolor code blocks,
+    // table rows, sliders, etc. that rely on the default subtle muted tint.
+    '--color-background-muted': 'var(--color-background-body)',
     // 96px / 80px — beyond --spacing-12 (48px), so expressed as
     // calc() over spacing tokens (2× spacing-12, 2× spacing-10)
     // rather than as literals so the rhythm scales with any
@@ -255,7 +261,7 @@ export function DiscoverShowcase() {
             spread ? styles.floatBottomRightEnd : styles.floatBottomRightStart,
           )}
         />
-        <Card variant="gray" padding={0} xstyle={styles.card}>
+        <Card variant="muted" padding={0} xstyle={styles.card}>
           <VStack gap={6} align="center" xstyle={styles.cardContent}>
             <VStack gap={6} align="center">
               <Heading level={2} type="display-1" color="primary">

--- a/apps/docsite/src/app/(site)/_landing/hero/HeroThemeReel.tsx
+++ b/apps/docsite/src/app/(site)/_landing/hero/HeroThemeReel.tsx
@@ -124,17 +124,23 @@ const styles = stylex.create({
     zIndex: 0,
   },
   // Per-slide body fill behind the hero (resolves to the active theme's body
-  // color). Covers the band + a page-radius extra so the color sits behind the
-  // showcase's rounded top corners (no cream notch on dark themes like Gothic).
+  // color). Covers the band + an extra strip so the color sits behind the
+  // showcase's rounded top corners (no notch showing the docsite body color).
+  //
+  // The extra MUST match the showcase overlay's corner radius, which is the
+  // docsite (Astryx) --radius-page = 32px. We can't read --radius-page here
+  // because this fill renders inside <XDSTheme theme={active}>, where the
+  // active theme overrides it — e.g. Y2K sets --radius-page: 0, which left the
+  // fill 32px short and exposed the docsite body color in the rounded corners.
+  // Hence a fixed 32px tied to the overlay radius rather than the theme token.
   themeFill: {
     position: 'absolute',
     top: 0,
     left: 0,
     right: 0,
     height: {
-      default:
-        'calc(var(--hero-content-height, 760px) + var(--radius-page, 24px))',
-      '@media (min-width: 1024px)': 'calc(760px + var(--radius-page, 24px))',
+      default: 'calc(var(--hero-content-height, 760px) + 32px)',
+      '@media (min-width: 1024px)': 'calc(760px + 32px)',
     },
     backgroundColor: 'var(--color-background-body)',
     pointerEvents: 'none',
@@ -163,7 +169,7 @@ const styles = stylex.create({
     width: 'min(1200px, 100vw)',
     height: 1050,
     pointerEvents: 'none',
-    opacity: 0.5,
+    opacity: 0.7,
     transition: 'background-image 800ms ease',
     filter: 'blur(60px)',
     backgroundImage:

--- a/apps/docsite/src/app/(site)/_landing/hero/heroThemeContent.ts
+++ b/apps/docsite/src/app/(site)/_landing/hero/heroThemeContent.ts
@@ -21,6 +21,11 @@ import {BRAND_BLUE} from '@/constants';
 // Sentinel for the docsite's local brand theme (not an @xds/theme-* package).
 const ASTRYX = 'astryx';
 
+// Shared XDS asset CDN. The per-theme reel cards pull the same product photos
+// the /themes showcase uses (see themeShowcaseContent.ts) so the hero and the
+// gallery stay in sync.
+const XDS_CDN = 'https://lookaside.facebook.com/assets/xds_oss';
+
 export interface HeroThemeContent {
   /** Product card (image + title/description + price). */
   product: {
@@ -89,9 +94,8 @@ export interface HeroThemeSlide {
 // The curated reel — these themes, in this order. Edit here to add/remove.
 const REEL_THEMES: ReadonlyArray<string> = [
   ASTRYX,
-  '@xds/theme-neutral',
-  '@xds/theme-butter',
   '@xds/theme-matcha',
+  '@xds/theme-butter',
   '@xds/theme-gothic',
   '@xds/theme-y2k',
 ];
@@ -99,23 +103,23 @@ const REEL_THEMES: ReadonlyArray<string> = [
 // Per-theme card content, keyed by theme name (or the ASTRYX sentinel).
 const CONTENT_BY_THEME: Record<string, HeroThemeContent> = {
   [ASTRYX]: {
+    // Product photos reuse the Neutral theme's image set (watch / headphones /
+    // backpack) now that Neutral is no longer a standalone reel slide.
     product: {
-      image: '/neutral/preview-headphones.png',
-      title: 'Studio headphones',
-      description: 'Quiet, considered sound for deep focus.',
-      price: '$180',
+      image: '/neutral/preview-watch.png',
+      title: 'Minimalist watch',
+      description: 'Clean design, everyday durability.',
+      price: '$240',
     },
     feature: {
-      image:
-        'https://lookaside.facebook.com/assets/xds_oss/light-product-1.png',
-      title: 'Ceramic mug',
-      price: '$32',
+      image: '/neutral/preview-headphones.png',
+      title: 'Wireless headphones',
+      price: '$180',
     },
     mini: {
-      image:
-        'https://lookaside.facebook.com/assets/xds_oss/light-product-1.png',
-      title: 'Speckled mug',
-      description: 'Hand-thrown stoneware.',
+      image: '/neutral/preview-backpack.png',
+      title: 'Canvas backpack',
+      description: 'Water-resistant.',
     },
     pills: {leading: 'Limited time', trailing: 'Free shipping'},
     chatPrompt: 'How can I help?',
@@ -154,21 +158,20 @@ const CONTENT_BY_THEME: Record<string, HeroThemeContent> = {
   },
   '@xds/theme-butter': {
     product: {
-      image:
-        'https://lookaside.facebook.com/assets/xds_oss/light-product-1.png',
-      title: 'Speckled mug',
-      description: 'Warm stoneware for slow mornings.',
-      price: '$32',
+      image: `${XDS_CDN}/Butter-Croissant.png`,
+      title: 'Butter croissant',
+      description: 'Flaky, laminated layers baked golden each morning.',
+      price: '$6',
     },
     feature: {
-      image: '/theme-butter-preview.png',
-      title: 'Buttermilk waffles',
-      price: '$14',
+      image: `${XDS_CDN}/Butter-Waffle.png`,
+      title: 'Belgian waffle',
+      price: '$8',
     },
     mini: {
-      image: '/theme-butter-preview.png',
-      title: 'Maple waffles',
-      description: 'Served warm.',
+      image: `${XDS_CDN}/Butter-Pancake.png`,
+      title: 'Buttermilk pancakes',
+      description: 'Stacked tall with melting butter.',
     },
     pills: {leading: 'Limited time', trailing: 'Free shipping'},
     chatPrompt: 'How can I help?',
@@ -176,21 +179,18 @@ const CONTENT_BY_THEME: Record<string, HeroThemeContent> = {
   },
   '@xds/theme-matcha': {
     product: {
-      image:
-        'https://lookaside.facebook.com/assets/xds_oss/matcha-product-1.png',
-      title: 'Sweet vanilla matcha',
-      description: 'Vanilla matcha with whole milk or oat milk.',
+      image: `${XDS_CDN}/matcha-product-1.png`,
+      title: 'Iced matcha latte',
+      description: 'Stone-ground ceremonial matcha over cold milk.',
       price: '$6',
     },
     feature: {
-      image:
-        'https://lookaside.facebook.com/assets/xds_oss/matcha-product-4.png',
-      title: 'Ube matcha',
+      image: `${XDS_CDN}/matcha-product-2.png`,
+      title: 'Strawberry matcha',
       price: '$7',
     },
     mini: {
-      image:
-        'https://lookaside.facebook.com/assets/xds_oss/matcha-product-4.png',
+      image: `${XDS_CDN}/matcha-product-4.png`,
       title: 'Ube matcha',
       description: 'Ube and cream matcha.',
     },
@@ -205,20 +205,20 @@ const CONTENT_BY_THEME: Record<string, HeroThemeContent> = {
   },
   '@xds/theme-gothic': {
     product: {
-      image: '/theme-gothic-preview.png',
-      title: 'Onyx pendant',
-      description: 'Blackened silver with a matte finish.',
-      price: '$96',
+      image: `${XDS_CDN}/Gothic-1.png`,
+      title: 'Dried sea holly',
+      description: 'A single preserved thistle stem with a steely bloom.',
+      price: '$24',
     },
     feature: {
-      image: '/theme-gothic-preview.png',
-      title: 'Midnight cuff',
-      price: '$120',
+      image: `${XDS_CDN}/Gothic-2.png`,
+      title: 'Garden rose',
+      price: '$18',
     },
     mini: {
-      image: '/theme-gothic-preview.png',
-      title: 'Raven ring',
-      description: 'Hand-forged band.',
+      image: `${XDS_CDN}/Gothic-3.png`,
+      title: 'Lilac ranunculus',
+      description: 'Layered petals in a soft mauve.',
     },
     pills: {leading: 'Limited time', trailing: 'Free shipping'},
     chatPrompt: 'How can I help?',
@@ -226,23 +226,20 @@ const CONTENT_BY_THEME: Record<string, HeroThemeContent> = {
   },
   '@xds/theme-y2k': {
     product: {
-      image:
-        'https://lookaside.facebook.com/assets/xds_oss/colorful-product-2.png',
-      title: 'Bubbly charm',
-      description: 'A glossy little throwback keepsake.',
+      image: `${XDS_CDN}/Y2K-Phone.png`,
+      title: 'Holo flip phone',
+      description: 'Iridescent clamshell with a rainbow screen.',
       price: '$18',
     },
     feature: {
-      image:
-        'https://lookaside.facebook.com/assets/xds_oss/colorful-product-1.png',
-      title: 'Puppy keychain',
+      image: `${XDS_CDN}/Y2K-Star.png`,
+      title: 'Glow star set',
       price: '$12',
     },
     mini: {
-      image:
-        'https://lookaside.facebook.com/assets/xds_oss/colorful-product-1.png',
-      title: 'Puppy keychain',
-      description: 'Plush + chrome ring.',
+      image: `${XDS_CDN}/Y2K-Butterfly.png`,
+      title: 'Glitter butterfly',
+      description: 'Sparkly stick-on in pastel chrome.',
     },
     pills: {leading: 'Limited time', trailing: 'Free shipping'},
     chatPrompt: 'How can I help?',


### PR DESCRIPTION
## Summary

Updates the docsite landing-page **home hero theme reel** and fixes two related visual issues.

**Hero reel (`heroThemeContent.ts`)**
- Point the **Butter, Matcha, Gothic, Y2K** hero cards at their latest theme-matched CDN product photos, so the hero stays in sync with the `/themes` showcase (previously they used older/generic images).
- **Remove Neutral** from the reel and reorder to **Astryx → Matcha → Butter → Gothic → Y2K**.
- The **Astryx** slide now reuses the Neutral product image set (minimalist watch / wireless headphones / canvas backpack).

**Aurora glow (`HeroThemeReel.tsx`)**
- Bump the glow `opacity` from `0.5` → `0.7` so the per-slide blobs read with a bit more color (kept the original `--color-background-*` aurora hues).

**Discover CTA card (`DiscoverShowcase.tsx`)**
- Restore the "Discover the full Astryx design system" card to the page **body color**. It had regressed to a flat gray after the Astryx gray-token override was removed upstream. Fixed by switching the card to `variant="muted"` with a **card-scoped** `--color-background-muted` override (so it blends into the body without recoloring the many other components that use the default muted tint).

**Y2K hero seam fix (`HeroThemeReel.tsx`)**
- The per-slide body fill extended its coverage by `var(--radius-page)` to sit behind the showcase's rounded top corners. Since that fill renders inside `<XDSTheme theme={active}>`, on **Y2K** it resolved to Y2K's `--radius-page: 0`, leaving the fill 32px short and exposing the docsite body color in the rounded corners. Now uses a fixed `32px` (matching the overlay's corner radius), which is robust for any radius-0 theme.

## Test plan

- [ ] Run the docsite (`pnpm -F @xds/docsite dev`) and open `/`.
- [ ] Hero reel cycles through **5** themes in order: Astryx → Matcha → Butter → Gothic → Y2K (no Neutral).
- [ ] Astryx slide shows watch / headphones / backpack; Butter/Matcha/Gothic/Y2K show their theme-matched product photos.
- [ ] Aurora blobs read with adequate color on each slide (not washed out).
- [ ] The "Discover the full Astryx design system" CTA card uses the cream body color (blends in), not flat gray.
- [ ] On the **Y2K** slide, the rounded top corners of the next section sit over the Y2K periwinkle body color — no notch of the wrong body color.
- [ ] Light/dark mode both look correct.

Made with [Cursor](https://cursor.com)