### PR TITLE
feat(blocks): restore Avatar example photos with OSS people images

### DIFF
--- a/packages/cli/templates/blocks/components/Avatar/AvatarFallbackChain.tsx
+++ b/packages/cli/templates/blocks/components/Avatar/AvatarFallbackChain.tsx
@@ -10,7 +10,11 @@ export default function AvatarFallbackChain() {
   return (
     <VStack gap={4}>
       <HStack gap={3} vAlign="center">
-        <Avatar name="Carol Davis" size="medium" />
+        <Avatar
+          src="https://lookaside.facebook.com/assets/xds_oss/DATA-Daniela-Gimenez.png"
+          name="Daniela Gimenez"
+          size="medium"
+        />
         <Text type="supporting">Valid src</Text>
       </HStack>
       <HStack gap={3} vAlign="center">

--- a/packages/cli/templates/blocks/components/Avatar/AvatarGroup.tsx
+++ b/packages/cli/templates/blocks/components/Avatar/AvatarGroup.tsx
@@ -7,21 +7,28 @@ import {AvatarGroup, AvatarGroupOverflow} from '@xds/core/AvatarGroup';
 import {Stack} from '@xds/core/Layout';
 import {Text} from '@xds/core/Text';
 
+const CDN = 'https://lookaside.facebook.com/assets/xds_oss';
+
 const USERS = [
   {
-    name: 'Alex Daniels',
+    name: 'Ami Pena',
+    src: `${CDN}/DATA-Ami-Pena.png`,
   },
   {
-    name: 'Ann Smith',
+    name: 'Drew Young',
+    src: `${CDN}/DATA-Drew-Young.png`,
   },
   {
-    name: 'Carol Davis',
+    name: 'Gabriela Fernandez',
+    src: `${CDN}/DATA-Gabriela-Fernandez.png`,
   },
   {
-    name: 'Gina Wilson',
+    name: 'Jihoo Song',
+    src: `${CDN}/DATA-Jihoo-Song.png`,
   },
   {
-    name: 'Eve Park',
+    name: 'Nam Tran',
+    src: `${CDN}/DATA-Nam-Tran.png`,
   },
 ];
 
@@ -34,7 +41,7 @@ export default function AvatarGroupBlock() {
         </Text>
         <AvatarGroup size="medium">
           {USERS.map(user => (
-            <Avatar key={user.name} name={user.name} />
+            <Avatar key={user.name} src={user.src} name={user.name} />
           ))}
           <AvatarGroupOverflow count={3} />
         </AvatarGroup>
@@ -45,7 +52,7 @@ export default function AvatarGroupBlock() {
         </Text>
         <AvatarGroup size="medium">
           {USERS.slice(0, 3).map(user => (
-            <Avatar key={user.name} name={user.name} />
+            <Avatar key={user.name} src={user.src} name={user.name} />
           ))}
           <AvatarGroupOverflow count={8} />
         </AvatarGroup>

--- a/packages/cli/templates/blocks/components/Avatar/AvatarShowcase.tsx
+++ b/packages/cli/templates/blocks/components/Avatar/AvatarShowcase.tsx
@@ -5,18 +5,30 @@
 import {Avatar, AvatarStatusDot} from '@xds/core/Avatar';
 import {Stack} from '@xds/core/Layout';
 
+const CDN = 'https://lookaside.facebook.com/assets/xds_oss';
+
 export default function AvatarShowcase() {
   return (
     <Stack direction="horizontal" gap={4} vAlign="center">
       <Avatar
-        name="Ann Smith"
+        src={`${CDN}/DATA-Ana-Thomas.png`}
+        name="Ana Thomas"
         size="large"
         status={<AvatarStatusDot variant="success" label="Online" />}
       />
-      <Avatar name="Alex Daniels" size="large" />
-      <Avatar name="Sam Chen" size="large" />
       <Avatar
-        name="Taylor Nguyen"
+        src={`${CDN}/DATA-Drew-Young.png`}
+        name="Drew Young"
+        size="large"
+      />
+      <Avatar
+        src={`${CDN}/DATA-Jihoo-Song.png`}
+        name="Jihoo Song"
+        size="large"
+      />
+      <Avatar
+        src={`${CDN}/DATA-Nam-Tran.png`}
+        name="Nam Tran"
         size="large"
         status={<AvatarStatusDot variant="error" label="Online" />}
       />

--- a/packages/cli/templates/blocks/components/Avatar/AvatarUserCard.tsx
+++ b/packages/cli/templates/blocks/components/Avatar/AvatarUserCard.tsx
@@ -6,19 +6,24 @@ import {Avatar, AvatarStatusDot} from '@xds/core/Avatar';
 import {Stack} from '@xds/core/Layout';
 import {Text} from '@xds/core/Text';
 
+const CDN = 'https://lookaside.facebook.com/assets/xds_oss';
+
 const USERS = [
   {
-    name: 'Alex Daniels',
+    name: 'Itai Jordaan',
+    src: `${CDN}/DATA-Itai-Jordaan.png`,
     role: 'Engineering Lead',
     variant: 'success' as const,
   },
   {
-    name: 'Ann Smith',
+    name: 'Margot Schroder',
+    src: `${CDN}/DATA-Margot-Schroder.png`,
     role: 'Product Designer',
     variant: 'neutral' as const,
   },
   {
-    name: 'Carol Davis',
+    name: 'Daniela Gimenez',
+    src: `${CDN}/DATA-Daniela-Gimenez.png`,
     role: 'Engineering Manager',
     variant: 'error' as const,
   },
@@ -30,6 +35,7 @@ export default function AvatarUserCard() {
       {USERS.map(user => (
         <Stack key={user.name} direction="horizontal" gap={3} vAlign="center">
           <Avatar
+            src={user.src}
             name={user.name}
             size="medium"
             status={

--- a/packages/cli/templates/blocks/components/Avatar/AvatarWithImage.tsx
+++ b/packages/cli/templates/blocks/components/Avatar/AvatarWithImage.tsx
@@ -5,13 +5,27 @@
 import {Avatar} from '@xds/core/Avatar';
 import {Stack} from '@xds/core/Layout';
 
+const CDN = 'https://lookaside.facebook.com/assets/xds_oss';
+
 export default function AvatarWithImage() {
   return (
     <Stack direction="horizontal" gap={4} vAlign="center">
-      <Avatar name="Alex Daniles" size="tiny" />
-      <Avatar name="Ann Smith" size="small" />
-      <Avatar name="Carol Davis" size="medium" />
-      <Avatar name="Gina Wilson" size="large" />
+      <Avatar src={`${CDN}/DATA-Ami-Pena.png`} name="Ami Pena" size="tiny" />
+      <Avatar
+        src={`${CDN}/DATA-Ana-Thomas.png`}
+        name="Ana Thomas"
+        size="small"
+      />
+      <Avatar
+        src={`${CDN}/DATA-Daniela-Gimenez.png`}
+        name="Daniela Gimenez"
+        size="medium"
+      />
+      <Avatar
+        src={`${CDN}/DATA-Gabriela-Fernandez.png`}
+        name="Gabriela Fernandez"
+        size="large"
+      />
     </Stack>
   );
 }

--- a/packages/cli/templates/blocks/components/Avatar/AvatarWithStatus.tsx
+++ b/packages/cli/templates/blocks/components/Avatar/AvatarWithStatus.tsx
@@ -5,21 +5,26 @@
 import {Avatar, AvatarStatusDot} from '@xds/core/Avatar';
 import {Stack} from '@xds/core/Layout';
 
+const CDN = 'https://lookaside.facebook.com/assets/xds_oss';
+
 export default function AvatarWithStatus() {
   return (
     <Stack direction="horizontal" gap={4} vAlign="center">
       <Avatar
-        name="Alex Daniels"
+        src={`${CDN}/DATA-Itai-Jordaan.png`}
+        name="Itai Jordaan"
         size="large"
         status={<AvatarStatusDot variant="success" label="Online" />}
       />
       <Avatar
-        name="Ann Smith"
+        src={`${CDN}/DATA-Margot-Schroder.png`}
+        name="Margot Schroder"
         size="large"
         status={<AvatarStatusDot variant="neutral" label="Offline" />}
       />
       <Avatar
-        name="Carol Davis"
+        src={`${CDN}/DATA-Pablo-Morales.png`}
+        name="Pablo Morales"
         size="large"
         status={<AvatarStatusDot variant="error" label="Busy" />}
       />


### PR DESCRIPTION
## Summary

The Avatar block examples lost their profile photos in the OSS scrub (#2968) — the images had pointed at an internal CDN path (`.../vs_datakit_profile_photos_t66173184/...`), so removing them left every Avatar example showing **initials only**.

This restores real photos using the public **`xds_oss` CDN** people set (`lookaside.facebook.com/assets/xds_oss/DATA-*.png`, all verified reachable) across all six Avatar blocks, and updates the displayed names to match each photo's person:

| Block | People |
|---|---|
| `AvatarShowcase` | Ana Thomas, Drew Young, Jihoo Song, Nam Tran |
| `AvatarWithImage` | Ami Pena, Ana Thomas, Daniela Gimenez, Gabriela Fernandez |
| `AvatarWithStatus` | Itai Jordaan, Margot Schroder, Pablo Morales |
| `AvatarUserCard` | Itai Jordaan, Margot Schroder, Daniela Gimenez |
| `AvatarGroup` | Ami Pena, Drew Young, Gabriela Fernandez, Jihoo Song, Nam Tran |
| `AvatarFallbackChain` | Daniela Gimenez (only the "Valid src" row) |

The `AvatarFallbackChain` demo intentionally keeps its `does-not-exist` URLs to show the fallback chain — only its "Valid src" example gets a real photo.

## Test plan

- [ ] Run the docsite (`pnpm -F @xds/docsite dev`) and open `/components/Avatar`.
- [ ] The main showcase shows four photos with status dots (Ana Thomas, Drew Young, Jihoo Song, Nam Tran).
- [ ] Avatar Group, Avatar Status Dot, and the other example blocks show profile photos (not just initials).
- [ ] `AvatarFallbackChain` still demonstrates the fallback chain (valid photo → initials → icon) with its intentional broken URLs.
- [ ] Photos load from the `xds_oss` CDN; initials remain the correct fallback if an image fails.

> Note: avatar photos render as initials in sandboxed/headless environments that block the external CDN, but the `DATA-*.png` URLs all return 200 and display in a normal browser.

Made with [Cursor](https://cursor.com)