### PR TITLE
chore(assets): migrate demo imagery from xds_oss to astryx asset set

### DIFF
--- a/apps/docsite/src/app/(site)/_landing/hero/heroThemeContent.ts
+++ b/apps/docsite/src/app/(site)/_landing/hero/heroThemeContent.ts
@@ -24,7 +24,7 @@ const ASTRYX = 'astryx';
 // Shared XDS asset CDN. The per-theme reel cards pull the same product photos
 // the /themes showcase uses (see themeShowcaseContent.ts) so the hero and the
 // gallery stay in sync.
-const XDS_CDN = 'https://lookaside.facebook.com/assets/astryx';
+const IMAGE_CDN = 'https://lookaside.facebook.com/assets/astryx';
 
 export interface HeroThemeContent {
   /** Product card (image + title/description + price). */
@@ -158,18 +158,18 @@ const CONTENT_BY_THEME: Record<string, HeroThemeContent> = {
   },
   '@xds/theme-butter': {
     product: {
-      image: `${XDS_CDN}/Butter-Croissant.png`,
+      image: `${IMAGE_CDN}/Butter-Croissant.png`,
       title: 'Butter croissant',
       description: 'Flaky, laminated layers baked golden each morning.',
       price: '$6',
     },
     feature: {
-      image: `${XDS_CDN}/Butter-Waffle.png`,
+      image: `${IMAGE_CDN}/Butter-Waffle.png`,
       title: 'Belgian waffle',
       price: '$8',
     },
     mini: {
-      image: `${XDS_CDN}/Butter-Pancake.png`,
+      image: `${IMAGE_CDN}/Butter-Pancake.png`,
       title: 'Buttermilk pancakes',
       description: 'Stacked tall with melting butter.',
     },
@@ -179,18 +179,18 @@ const CONTENT_BY_THEME: Record<string, HeroThemeContent> = {
   },
   '@xds/theme-matcha': {
     product: {
-      image: `${XDS_CDN}/matcha-product-1.png`,
+      image: `${IMAGE_CDN}/matcha-product-1.png`,
       title: 'Iced matcha latte',
       description: 'Stone-ground ceremonial matcha over cold milk.',
       price: '$6',
     },
     feature: {
-      image: `${XDS_CDN}/matcha-product-2.png`,
+      image: `${IMAGE_CDN}/matcha-product-2.png`,
       title: 'Strawberry matcha',
       price: '$7',
     },
     mini: {
-      image: `${XDS_CDN}/matcha-product-4.png`,
+      image: `${IMAGE_CDN}/matcha-product-4.png`,
       title: 'Ube matcha',
       description: 'Ube and cream matcha.',
     },
@@ -205,18 +205,18 @@ const CONTENT_BY_THEME: Record<string, HeroThemeContent> = {
   },
   '@xds/theme-gothic': {
     product: {
-      image: `${XDS_CDN}/Gothic-1.png`,
+      image: `${IMAGE_CDN}/Gothic-1.png`,
       title: 'Dried sea holly',
       description: 'A single preserved thistle stem with a steely bloom.',
       price: '$24',
     },
     feature: {
-      image: `${XDS_CDN}/Gothic-2.png`,
+      image: `${IMAGE_CDN}/Gothic-2.png`,
       title: 'Garden rose',
       price: '$18',
     },
     mini: {
-      image: `${XDS_CDN}/Gothic-3.png`,
+      image: `${IMAGE_CDN}/Gothic-3.png`,
       title: 'Lilac ranunculus',
       description: 'Layered petals in a soft mauve.',
     },
@@ -226,18 +226,18 @@ const CONTENT_BY_THEME: Record<string, HeroThemeContent> = {
   },
   '@xds/theme-y2k': {
     product: {
-      image: `${XDS_CDN}/Y2K-Phone.png`,
+      image: `${IMAGE_CDN}/Y2K-Phone.png`,
       title: 'Holo flip phone',
       description: 'Iridescent clamshell with a rainbow screen.',
       price: '$18',
     },
     feature: {
-      image: `${XDS_CDN}/Y2K-Star.png`,
+      image: `${IMAGE_CDN}/Y2K-Star.png`,
       title: 'Glow star set',
       price: '$12',
     },
     mini: {
-      image: `${XDS_CDN}/Y2K-Butterfly.png`,
+      image: `${IMAGE_CDN}/Y2K-Butterfly.png`,
       title: 'Glitter butterfly',
       description: 'Sparkly stick-on in pastel chrome.',
     },

--- a/apps/docsite/src/app/(site)/_landing/hero/heroThemeContent.ts
+++ b/apps/docsite/src/app/(site)/_landing/hero/heroThemeContent.ts
@@ -24,7 +24,7 @@ const ASTRYX = 'astryx';
 // Shared XDS asset CDN. The per-theme reel cards pull the same product photos
 // the /themes showcase uses (see themeShowcaseContent.ts) so the hero and the
 // gallery stay in sync.
-const XDS_CDN = 'https://lookaside.facebook.com/assets/xds_oss';
+const XDS_CDN = 'https://lookaside.facebook.com/assets/astryx';
 
 export interface HeroThemeContent {
   /** Product card (image + title/description + price). */

--- a/apps/docsite/src/components/ThemePackagePage.tsx
+++ b/apps/docsite/src/components/ThemePackagePage.tsx
@@ -36,7 +36,7 @@ const THEME_SHOWCASE_SOURCE =
 
 // CDN host for the per-theme picker banners (same host as the showcase
 // product photos), so the artwork can be updated without a code change.
-const PICKER_CDN = 'https://lookaside.facebook.com/assets/xds_oss';
+const PICKER_CDN = 'https://lookaside.facebook.com/assets/astryx';
 
 // Gallery order — themes are listed in the same canonical visual-
 // closeness order used elsewhere (most restrained → most expressive).

--- a/apps/docsite/src/components/themeShowcaseContent.ts
+++ b/apps/docsite/src/components/themeShowcaseContent.ts
@@ -24,7 +24,7 @@ export interface ThemeShowcaseContent {
   inventory: InventoryRow[];
 }
 
-const XDS_CDN = 'https://lookaside.facebook.com/assets/xds_oss';
+const XDS_CDN = 'https://lookaside.facebook.com/assets/astryx';
 
 // Matcha café — matcha-drink photos.
 const MATCHA_IMAGES: Record<string, string> = {

--- a/apps/docsite/src/components/themeShowcaseContent.ts
+++ b/apps/docsite/src/components/themeShowcaseContent.ts
@@ -24,16 +24,16 @@ export interface ThemeShowcaseContent {
   inventory: InventoryRow[];
 }
 
-const XDS_CDN = 'https://lookaside.facebook.com/assets/astryx';
+const IMAGE_CDN = 'https://lookaside.facebook.com/assets/astryx';
 
 // Matcha café — matcha-drink photos.
 const MATCHA_IMAGES: Record<string, string> = {
-  watch: `${XDS_CDN}/matcha-product-1.png`,
-  headphones: `${XDS_CDN}/matcha-product-2.png`,
-  backpack: `${XDS_CDN}/matcha-product-3.png`,
-  wallet: `${XDS_CDN}/matcha-product-5.png`,
-  tumbler: `${XDS_CDN}/matcha-product-4.png`,
-  throw_: `${XDS_CDN}/matcha-product-6.png`,
+  watch: `${IMAGE_CDN}/matcha-product-1.png`,
+  headphones: `${IMAGE_CDN}/matcha-product-2.png`,
+  backpack: `${IMAGE_CDN}/matcha-product-3.png`,
+  wallet: `${IMAGE_CDN}/matcha-product-5.png`,
+  tumbler: `${IMAGE_CDN}/matcha-product-4.png`,
+  throw_: `${IMAGE_CDN}/matcha-product-6.png`,
 };
 
 const MATCHA_CONTENT: ThemeShowcaseContent = {
@@ -131,12 +131,12 @@ const MATCHA_CONTENT: ThemeShowcaseContent = {
 // Butter bakery — butter/breakfast photos. Only five Butter assets exist, so
 // the croissant is reused for the sixth slot.
 const BUTTER_IMAGES: Record<string, string> = {
-  watch: `${XDS_CDN}/Butter-Croissant.png`,
-  headphones: `${XDS_CDN}/Butter-Pancake.png`,
-  backpack: `${XDS_CDN}/Butter-Waffle.png`,
-  wallet: `${XDS_CDN}/Butter-Toast.png`,
-  tumbler: `${XDS_CDN}/Butter-Stick.png`,
-  throw_: `${XDS_CDN}/Butter-Croissant.png`,
+  watch: `${IMAGE_CDN}/Butter-Croissant.png`,
+  headphones: `${IMAGE_CDN}/Butter-Pancake.png`,
+  backpack: `${IMAGE_CDN}/Butter-Waffle.png`,
+  wallet: `${IMAGE_CDN}/Butter-Toast.png`,
+  tumbler: `${IMAGE_CDN}/Butter-Stick.png`,
+  throw_: `${IMAGE_CDN}/Butter-Croissant.png`,
 };
 
 const BUTTER_CONTENT: ThemeShowcaseContent = {
@@ -233,12 +233,12 @@ const BUTTER_CONTENT: ThemeShowcaseContent = {
 
 // Stone homeware — stoneware photos on stone plinths.
 const STONE_IMAGES: Record<string, string> = {
-  watch: `${XDS_CDN}/Stone-bowl.png`,
-  headphones: `${XDS_CDN}/Stone-cup.png`,
-  backpack: `${XDS_CDN}/Stone-plate.png`,
-  wallet: `${XDS_CDN}/Stone-servingbowl.png`,
-  tumbler: `${XDS_CDN}/Stone-teapot.png`,
-  throw_: `${XDS_CDN}/Stone-vase.png`,
+  watch: `${IMAGE_CDN}/Stone-bowl.png`,
+  headphones: `${IMAGE_CDN}/Stone-cup.png`,
+  backpack: `${IMAGE_CDN}/Stone-plate.png`,
+  wallet: `${IMAGE_CDN}/Stone-servingbowl.png`,
+  tumbler: `${IMAGE_CDN}/Stone-teapot.png`,
+  throw_: `${IMAGE_CDN}/Stone-vase.png`,
 };
 
 const STONE_CONTENT: ThemeShowcaseContent = {
@@ -335,12 +335,12 @@ const STONE_CONTENT: ThemeShowcaseContent = {
 
 // Y2K trinkets — iridescent/holo objects.
 const Y2K_IMAGES: Record<string, string> = {
-  watch: `${XDS_CDN}/Y2K-Phone.png`,
-  headphones: `${XDS_CDN}/Y2K-Star.png`,
-  backpack: `${XDS_CDN}/Y2K-Butterfly.png`,
-  wallet: `${XDS_CDN}/Y2K-Heart.png`,
-  tumbler: `${XDS_CDN}/Y2K-Flower.png`,
-  throw_: `${XDS_CDN}/Y2K-Couch.png`,
+  watch: `${IMAGE_CDN}/Y2K-Phone.png`,
+  headphones: `${IMAGE_CDN}/Y2K-Star.png`,
+  backpack: `${IMAGE_CDN}/Y2K-Butterfly.png`,
+  wallet: `${IMAGE_CDN}/Y2K-Heart.png`,
+  tumbler: `${IMAGE_CDN}/Y2K-Flower.png`,
+  throw_: `${IMAGE_CDN}/Y2K-Couch.png`,
 };
 
 const Y2K_CONTENT: ThemeShowcaseContent = {
@@ -437,12 +437,12 @@ const Y2K_CONTENT: ThemeShowcaseContent = {
 
 // Gothic botanicals — moody single-stem floral photos.
 const GOTHIC_IMAGES: Record<string, string> = {
-  watch: `${XDS_CDN}/Gothic-1.png`,
-  headphones: `${XDS_CDN}/Gothic-2.png`,
-  backpack: `${XDS_CDN}/Gothic-3.png`,
-  wallet: `${XDS_CDN}/Gothic-4.png`,
-  tumbler: `${XDS_CDN}/Gothic-5.png`,
-  throw_: `${XDS_CDN}/Gothic-6.png`,
+  watch: `${IMAGE_CDN}/Gothic-1.png`,
+  headphones: `${IMAGE_CDN}/Gothic-2.png`,
+  backpack: `${IMAGE_CDN}/Gothic-3.png`,
+  wallet: `${IMAGE_CDN}/Gothic-4.png`,
+  tumbler: `${IMAGE_CDN}/Gothic-5.png`,
+  throw_: `${IMAGE_CDN}/Gothic-6.png`,
 };
 
 const GOTHIC_CONTENT: ThemeShowcaseContent = {

--- a/packages/cli/src/api/template.test.mjs
+++ b/packages/cli/src/api/template.test.mjs
@@ -4,9 +4,9 @@ import {describe, it, expect} from 'vitest';
 import {stripTemplateAssetRefs, template} from './template.mjs';
 
 describe('stripTemplateAssetRefs', () => {
-  it('replaces a lookaside xds_oss image URL with an inline data URI', () => {
+  it('replaces a lookaside astryx image URL with an inline data URI', () => {
     const src =
-      "const hero = 'https://lookaside.facebook.com/assets/xds_oss/colorful-home-horizontal-1.png';";
+      "const hero = 'https://lookaside.facebook.com/assets/astryx/colorful-home-horizontal-1.png';";
     const out = stripTemplateAssetRefs(src);
     expect(out).not.toContain('lookaside.facebook.com');
     expect(out).toContain('data:image/svg+xml,');
@@ -14,7 +14,7 @@ describe('stripTemplateAssetRefs', () => {
 
   it('replaces a lookaside block-avatar image URL', () => {
     const src =
-      'src="https://lookaside.facebook.com/assets/xds_oss/avatar-profile-05.jpg"';
+      'src="https://lookaside.facebook.com/assets/astryx/avatar-profile-05.jpg"';
     const out = stripTemplateAssetRefs(src);
     expect(out).not.toContain('lookaside.facebook.com');
     expect(out).toContain('data:image/svg+xml,');
@@ -22,9 +22,9 @@ describe('stripTemplateAssetRefs', () => {
 
   it('replaces every lookaside reference, not just the first', () => {
     const src = [
-      "'https://lookaside.facebook.com/assets/xds_oss/colorful-home-horizontal-1.png'",
-      "'https://lookaside.facebook.com/assets/xds_oss/illustrative-horizontal-3.jpg'",
-      "'https://lookaside.facebook.com/assets/xds_oss/moody-scene-horizontal-1.png'",
+      "'https://lookaside.facebook.com/assets/astryx/colorful-home-horizontal-1.png'",
+      "'https://lookaside.facebook.com/assets/astryx/illustrative-horizontal-3.png'",
+      "'https://lookaside.facebook.com/assets/astryx/moody-scene-horizontal-1.png'",
     ].join('\n');
     const out = stripTemplateAssetRefs(src);
     expect(out).not.toContain('lookaside.facebook.com');
@@ -33,7 +33,7 @@ describe('stripTemplateAssetRefs', () => {
 
   it('preserves surrounding source structure', () => {
     const src =
-      "const data = [{src: 'https://lookaside.facebook.com/assets/xds_oss/x.png', alt: 'X'}];";
+      "const data = [{src: 'https://lookaside.facebook.com/assets/astryx/x.png', alt: 'X'}];";
     const out = stripTemplateAssetRefs(src);
     expect(out).toContain("alt: 'X'");
     expect(out).toContain('const data = [{src:');

--- a/packages/cli/templates/blocks/components/AspectRatio/AspectRatioCircleImage.tsx
+++ b/packages/cli/templates/blocks/components/AspectRatio/AspectRatioCircleImage.tsx
@@ -10,7 +10,7 @@ export default function AspectRatioCircleImage() {
     <Center width={300}>
       <AspectRatio ratio={1} shape="ellipse">
         <img
-          src="https://lookaside.facebook.com/assets/xds_oss/light-home-square-1.png"
+          src="https://lookaside.facebook.com/assets/astryx/light-home-square-1.png"
           alt="Circular image"
           style={{
             width: '100%',

--- a/packages/cli/templates/blocks/components/AspectRatio/AspectRatioImageGallery.tsx
+++ b/packages/cli/templates/blocks/components/AspectRatio/AspectRatioImageGallery.tsx
@@ -27,7 +27,7 @@ export default function AspectRatioImageGallery() {
         {images.map(({id, alt}) => (
           <AspectRatio key={id} ratio={4 / 3}>
             <img
-              src="https://lookaside.facebook.com/assets/xds_oss/illustrative-horizontal-1.jpg"
+              src="https://lookaside.facebook.com/assets/astryx/illustrative-horizontal-1.png"
               alt={alt}
               style={{
                 width: '100%',

--- a/packages/cli/templates/blocks/components/AspectRatio/AspectRatioShowcase.tsx
+++ b/packages/cli/templates/blocks/components/AspectRatio/AspectRatioShowcase.tsx
@@ -27,19 +27,19 @@ const items = [
   {
     ratio: 1,
     label: '1 : 1',
-    src: 'https://lookaside.facebook.com/assets/xds_oss/light-home-square-1.png',
+    src: 'https://lookaside.facebook.com/assets/astryx/light-home-square-1.png',
     alt: '1:1 square',
   },
   {
     ratio: 4 / 3,
     label: '4 : 3',
-    src: 'https://lookaside.facebook.com/assets/xds_oss/illustrative-horizontal-1.jpg',
+    src: 'https://lookaside.facebook.com/assets/astryx/illustrative-horizontal-1.png',
     alt: '4:3 standard',
   },
   {
     ratio: 16 / 9,
     label: '16 : 9',
-    src: 'https://lookaside.facebook.com/assets/xds_oss/light-scene-horizontal-1.png',
+    src: 'https://lookaside.facebook.com/assets/astryx/light-scene-horizontal-1.png',
     alt: '16:9 widescreen',
   },
 ];

--- a/packages/cli/templates/blocks/components/AspectRatio/AspectRatioSquareImage.tsx
+++ b/packages/cli/templates/blocks/components/AspectRatio/AspectRatioSquareImage.tsx
@@ -10,7 +10,7 @@ export default function AspectRatioSquareImage() {
     <Center width={300}>
       <AspectRatio ratio={1}>
         <img
-          src="https://lookaside.facebook.com/assets/xds_oss/light-home-square-1.png"
+          src="https://lookaside.facebook.com/assets/astryx/light-home-square-1.png"
           alt="1:1 square"
           style={{
             width: '100%',

--- a/packages/cli/templates/blocks/components/AspectRatio/AspectRatioWidescreen.tsx
+++ b/packages/cli/templates/blocks/components/AspectRatio/AspectRatioWidescreen.tsx
@@ -10,7 +10,7 @@ export default function AspectRatioWidescreen() {
     <Center width={600}>
       <AspectRatio ratio={16 / 9}>
         <img
-          src="https://lookaside.facebook.com/assets/xds_oss/light-scene-horizontal-1.png"
+          src="https://lookaside.facebook.com/assets/astryx/light-scene-horizontal-1.png"
           alt="16:9 widescreen"
           style={{
             width: '100%',

--- a/packages/cli/templates/blocks/components/Avatar/AvatarFallbackChain.tsx
+++ b/packages/cli/templates/blocks/components/Avatar/AvatarFallbackChain.tsx
@@ -20,7 +20,7 @@ export default function AvatarFallbackChain() {
       <HStack gap={3} vAlign="center">
         <Avatar
           src="https://lookaside.facebook.com/assets/astryx/does-not-exist-primary.jpg"
-          fallbackSrc="https://lookaside.facebook.com/assets/astryx/illustration-horizontal-2.png"
+          fallbackSrc="https://lookaside.facebook.com/assets/astryx/DATA-Ami-Pena.png"
           name="Invalid User"
           size="medium"
         />

--- a/packages/cli/templates/blocks/components/Avatar/AvatarFallbackChain.tsx
+++ b/packages/cli/templates/blocks/components/Avatar/AvatarFallbackChain.tsx
@@ -11,7 +11,7 @@ export default function AvatarFallbackChain() {
     <VStack gap={4}>
       <HStack gap={3} vAlign="center">
         <Avatar
-          src="https://lookaside.facebook.com/assets/xds_oss/DATA-Daniela-Gimenez.png"
+          src="https://lookaside.facebook.com/assets/astryx/DATA-Daniela-Gimenez.png"
           name="Daniela Gimenez"
           size="medium"
         />
@@ -19,8 +19,8 @@ export default function AvatarFallbackChain() {
       </HStack>
       <HStack gap={3} vAlign="center">
         <Avatar
-          src="https://lookaside.facebook.com/assets/xds_oss/does-not-exist-primary.jpg"
-          fallbackSrc="https://lookaside.facebook.com/assets/xds_oss/illustration-horizontal-2.png"
+          src="https://lookaside.facebook.com/assets/astryx/does-not-exist-primary.jpg"
+          fallbackSrc="https://lookaside.facebook.com/assets/astryx/illustration-horizontal-2.png"
           name="Invalid User"
           size="medium"
         />
@@ -28,8 +28,8 @@ export default function AvatarFallbackChain() {
       </HStack>
       <HStack gap={3} vAlign="center">
         <Avatar
-          src="https://lookaside.facebook.com/assets/xds_oss/does-not-exist-primary.jpg"
-          fallbackSrc="https://lookaside.facebook.com/assets/xds_oss/does-not-exist-fallback.jpg"
+          src="https://lookaside.facebook.com/assets/astryx/does-not-exist-primary.jpg"
+          fallbackSrc="https://lookaside.facebook.com/assets/astryx/does-not-exist-fallback.jpg"
           name="Test User"
           size="medium"
         />
@@ -37,7 +37,7 @@ export default function AvatarFallbackChain() {
       </HStack>
       <HStack gap={3} vAlign="center">
         <Avatar
-          src="https://lookaside.facebook.com/assets/xds_oss/does-not-exist-primary.jpg"
+          src="https://lookaside.facebook.com/assets/astryx/does-not-exist-primary.jpg"
           size="medium"
         />
         <Text type="supporting">All invalid, no name</Text>

--- a/packages/cli/templates/blocks/components/Avatar/AvatarGroup.tsx
+++ b/packages/cli/templates/blocks/components/Avatar/AvatarGroup.tsx
@@ -7,7 +7,7 @@ import {AvatarGroup, AvatarGroupOverflow} from '@xds/core/AvatarGroup';
 import {Stack} from '@xds/core/Layout';
 import {Text} from '@xds/core/Text';
 
-const CDN = 'https://lookaside.facebook.com/assets/xds_oss';
+const CDN = 'https://lookaside.facebook.com/assets/astryx';
 
 const USERS = [
   {

--- a/packages/cli/templates/blocks/components/Avatar/AvatarShowcase.tsx
+++ b/packages/cli/templates/blocks/components/Avatar/AvatarShowcase.tsx
@@ -5,7 +5,7 @@
 import {Avatar, AvatarStatusDot} from '@xds/core/Avatar';
 import {Stack} from '@xds/core/Layout';
 
-const CDN = 'https://lookaside.facebook.com/assets/xds_oss';
+const CDN = 'https://lookaside.facebook.com/assets/astryx';
 
 export default function AvatarShowcase() {
   return (

--- a/packages/cli/templates/blocks/components/Avatar/AvatarUserCard.tsx
+++ b/packages/cli/templates/blocks/components/Avatar/AvatarUserCard.tsx
@@ -6,7 +6,7 @@ import {Avatar, AvatarStatusDot} from '@xds/core/Avatar';
 import {Stack} from '@xds/core/Layout';
 import {Text} from '@xds/core/Text';
 
-const CDN = 'https://lookaside.facebook.com/assets/xds_oss';
+const CDN = 'https://lookaside.facebook.com/assets/astryx';
 
 const USERS = [
   {

--- a/packages/cli/templates/blocks/components/Avatar/AvatarWithImage.tsx
+++ b/packages/cli/templates/blocks/components/Avatar/AvatarWithImage.tsx
@@ -5,7 +5,7 @@
 import {Avatar} from '@xds/core/Avatar';
 import {Stack} from '@xds/core/Layout';
 
-const CDN = 'https://lookaside.facebook.com/assets/xds_oss';
+const CDN = 'https://lookaside.facebook.com/assets/astryx';
 
 export default function AvatarWithImage() {
   return (

--- a/packages/cli/templates/blocks/components/Avatar/AvatarWithStatus.tsx
+++ b/packages/cli/templates/blocks/components/Avatar/AvatarWithStatus.tsx
@@ -5,7 +5,7 @@
 import {Avatar, AvatarStatusDot} from '@xds/core/Avatar';
 import {Stack} from '@xds/core/Layout';
 
-const CDN = 'https://lookaside.facebook.com/assets/xds_oss';
+const CDN = 'https://lookaside.facebook.com/assets/astryx';
 
 export default function AvatarWithStatus() {
   return (

--- a/packages/cli/templates/blocks/components/ChatComposerDrawer/ChatComposerDrawerAttachments.tsx
+++ b/packages/cli/templates/blocks/components/ChatComposerDrawer/ChatComposerDrawerAttachments.tsx
@@ -11,31 +11,31 @@ import {Stack} from '@xds/core/Layout';
 const IMAGE_ATTACHMENTS = [
   {
     id: '1',
-    src: 'https://lookaside.facebook.com/assets/xds_oss/illustrative-vertical-1.jpg',
+    src: 'https://lookaside.facebook.com/assets/astryx/illustrative-vertical-1.png',
     alt: 'River through a valley',
     label: 'valley.jpg',
   },
   {
     id: '2',
-    src: 'https://lookaside.facebook.com/assets/xds_oss/illustrative-vertical-2.jpg',
+    src: 'https://lookaside.facebook.com/assets/astryx/illustrative-vertical-2.png',
     alt: 'Foggy mountain peak',
     label: 'mountain.jpg',
   },
   {
     id: '3',
-    src: 'https://lookaside.facebook.com/assets/xds_oss/illustrative-vertical-3.jpg',
+    src: 'https://lookaside.facebook.com/assets/astryx/illustrative-vertical-3.png',
     alt: 'Golden retriever puppy',
     label: 'puppy.jpg',
   },
   {
     id: '4',
-    src: 'https://lookaside.facebook.com/assets/xds_oss/illustrative-vertical-4.jpg',
+    src: 'https://lookaside.facebook.com/assets/astryx/illustrative-vertical-4.png',
     alt: 'Bridge at sunset',
     label: 'bridge.jpg',
   },
   {
     id: '5',
-    src: 'https://lookaside.facebook.com/assets/xds_oss/illustrative-vertical-5.jpg',
+    src: 'https://lookaside.facebook.com/assets/astryx/illustrative-vertical-5.png',
     alt: 'Lakeside at dusk',
     label: 'lakeside.jpg',
   },

--- a/packages/cli/templates/blocks/components/MediaTheme/MediaThemeImageOverlay.tsx
+++ b/packages/cli/templates/blocks/components/MediaTheme/MediaThemeImageOverlay.tsx
@@ -9,9 +9,9 @@ import {Section} from '@xds/core/Section';
 import {Stack} from '@xds/core/Layout';
 import {Text} from '@xds/core/Text';
 
-// light-scene-horizontal-1 from xds_oss asset set
+// light-scene-horizontal-1 from astryx asset set
 const LANDSCAPE_IMAGE_URL =
-  'https://lookaside.facebook.com/assets/xds_oss/light-scene-horizontal-1.png';
+  'https://lookaside.facebook.com/assets/astryx/light-scene-horizontal-1.png';
 
 export default function MediaThemeImageOverlay() {
   return (

--- a/packages/cli/templates/blocks/components/MediaTheme/MediaThemeImageOverlay.tsx
+++ b/packages/cli/templates/blocks/components/MediaTheme/MediaThemeImageOverlay.tsx
@@ -9,7 +9,6 @@ import {Section} from '@xds/core/Section';
 import {Stack} from '@xds/core/Layout';
 import {Text} from '@xds/core/Text';
 
-// light-scene-horizontal-1 from astryx asset set
 const LANDSCAPE_IMAGE_URL =
   'https://lookaside.facebook.com/assets/astryx/light-scene-horizontal-1.png';
 

--- a/packages/cli/templates/blocks/components/MediaTheme/MediaThemeLightScrim.tsx
+++ b/packages/cli/templates/blocks/components/MediaTheme/MediaThemeLightScrim.tsx
@@ -9,9 +9,9 @@ import {Section} from '@xds/core/Section';
 import {Stack} from '@xds/core/Layout';
 import {Text} from '@xds/core/Text';
 
-// light-home-square-1 from xds_oss asset set
+// light-home-square-1 from astryx asset set
 const BRIGHT_ROOM_IMAGE_URL =
-  'https://lookaside.facebook.com/assets/xds_oss/light-home-square-1.png';
+  'https://lookaside.facebook.com/assets/astryx/light-home-square-1.png';
 
 export default function MediaThemeLightScrim() {
   return (

--- a/packages/cli/templates/blocks/components/MediaTheme/MediaThemeLightScrim.tsx
+++ b/packages/cli/templates/blocks/components/MediaTheme/MediaThemeLightScrim.tsx
@@ -9,7 +9,6 @@ import {Section} from '@xds/core/Section';
 import {Stack} from '@xds/core/Layout';
 import {Text} from '@xds/core/Text';
 
-// light-home-square-1 from astryx asset set
 const BRIGHT_ROOM_IMAGE_URL =
   'https://lookaside.facebook.com/assets/astryx/light-home-square-1.png';
 

--- a/packages/cli/templates/blocks/components/MediaTheme/MediaThemeShowcase.tsx
+++ b/packages/cli/templates/blocks/components/MediaTheme/MediaThemeShowcase.tsx
@@ -10,9 +10,9 @@ import {Button} from '@xds/core/Button';
 import {Badge} from '@xds/core/Badge';
 import {Icon} from '@xds/core/Icon';
 
-// light-scene-horizontal-1 from xds_oss asset set
+// light-scene-horizontal-1 from astryx asset set
 const SHOWCASE_IMAGE_URL =
-  'https://lookaside.facebook.com/assets/xds_oss/light-scene-horizontal-1.png';
+  'https://lookaside.facebook.com/assets/astryx/light-scene-horizontal-1.png';
 
 export default function MediaThemeShowcase() {
   return (

--- a/packages/cli/templates/blocks/components/MediaTheme/MediaThemeShowcase.tsx
+++ b/packages/cli/templates/blocks/components/MediaTheme/MediaThemeShowcase.tsx
@@ -10,7 +10,6 @@ import {Button} from '@xds/core/Button';
 import {Badge} from '@xds/core/Badge';
 import {Icon} from '@xds/core/Icon';
 
-// light-scene-horizontal-1 from astryx asset set
 const SHOWCASE_IMAGE_URL =
   'https://lookaside.facebook.com/assets/astryx/light-scene-horizontal-1.png';
 

--- a/packages/cli/templates/blocks/components/Overlay/OverlayBottomStrip.tsx
+++ b/packages/cli/templates/blocks/components/Overlay/OverlayBottomStrip.tsx
@@ -41,7 +41,7 @@ export default function OverlayBottomStrip() {
       }>
       <AspectRatio ratio={16 / 9} xstyle={styles.frame}>
         <img
-          src="https://lookaside.facebook.com/assets/xds_oss/illustrative-horizontal-1.jpg"
+          src="https://lookaside.facebook.com/assets/astryx/illustrative-horizontal-1.png"
           alt="Product highlight preview"
           {...stylex.props(styles.image)}
         />

--- a/packages/cli/templates/blocks/components/Overlay/OverlayHoverReveal.tsx
+++ b/packages/cli/templates/blocks/components/Overlay/OverlayHoverReveal.tsx
@@ -29,7 +29,7 @@ export default function OverlayHoverReveal() {
       content={<Button label="Quick view" variant="secondary" size="sm" />}>
       <AspectRatio ratio={16 / 9} xstyle={styles.frame}>
         <img
-          src="https://lookaside.facebook.com/assets/xds_oss/light-working-horizontal-1.png"
+          src="https://lookaside.facebook.com/assets/astryx/light-working-horizontal-1.png"
           alt="Workspace preview"
           {...stylex.props(styles.image)}
         />

--- a/packages/cli/templates/blocks/components/Overlay/OverlayShowcase.tsx
+++ b/packages/cli/templates/blocks/components/Overlay/OverlayShowcase.tsx
@@ -40,7 +40,7 @@ export default function OverlayShowcase() {
       }>
       <AspectRatio ratio={16 / 9} xstyle={styles.frame}>
         <img
-          src="https://lookaside.facebook.com/assets/xds_oss/light-scene-horizontal-1.png"
+          src="https://lookaside.facebook.com/assets/astryx/light-scene-horizontal-1.png"
           alt="Abstract landscape"
           {...stylex.props(styles.image)}
         />

--- a/packages/cli/templates/blocks/components/Thumbnail/ThumbnailDisabled.tsx
+++ b/packages/cli/templates/blocks/components/Thumbnail/ThumbnailDisabled.tsx
@@ -15,7 +15,7 @@ export default function ThumbnailDisabled() {
         </Text>
         <Stack direction="horizontal" gap={3} vAlign="center">
           <Thumbnail
-            src="https://lookaside.facebook.com/assets/xds_oss/moody-scene-vertical-2.png"
+            src="https://lookaside.facebook.com/assets/astryx/moody-scene-vertical-2.png"
             alt="Bright landscape"
             label="landscape.jpg"
             onRemove={() => {}}
@@ -29,7 +29,7 @@ export default function ThumbnailDisabled() {
         </Text>
         <Stack direction="horizontal" gap={3} vAlign="center">
           <Thumbnail
-            src="https://lookaside.facebook.com/assets/xds_oss/moody-scene-vertical-2.png"
+            src="https://lookaside.facebook.com/assets/astryx/moody-scene-vertical-2.png"
             alt="Bright landscape"
             label="landscape.jpg"
             onRemove={() => {}}

--- a/packages/cli/templates/blocks/components/Thumbnail/ThumbnailGallery.tsx
+++ b/packages/cli/templates/blocks/components/Thumbnail/ThumbnailGallery.tsx
@@ -8,10 +8,10 @@ import {Stack} from '@xds/core/Layout';
 import {Text} from '@xds/core/Text';
 
 const ATTACHMENTS = [
-  {id: 1, src: 'https://lookaside.facebook.com/assets/xds_oss/illustrative-vertical-1.jpg', alt: 'River through a valley', label: 'valley.jpg'},
-  {id: 2, src: 'https://lookaside.facebook.com/assets/xds_oss/illustrative-vertical-2.jpg', alt: 'Foggy mountain peak', label: 'mountain.jpg'},
-  {id: 3, src: 'https://lookaside.facebook.com/assets/xds_oss/illustrative-vertical-3.jpg', alt: 'Golden retriever puppy', label: 'puppy.jpg'},
-  {id: 4, src: 'https://lookaside.facebook.com/assets/xds_oss/illustrative-vertical-4.jpg', alt: 'Bridge at sunset', label: 'bridge.jpg'},
+  {id: 1, src: 'https://lookaside.facebook.com/assets/astryx/illustrative-vertical-1.png', alt: 'River through a valley', label: 'valley.jpg'},
+  {id: 2, src: 'https://lookaside.facebook.com/assets/astryx/illustrative-vertical-2.png', alt: 'Foggy mountain peak', label: 'mountain.jpg'},
+  {id: 3, src: 'https://lookaside.facebook.com/assets/astryx/illustrative-vertical-3.png', alt: 'Golden retriever puppy', label: 'puppy.jpg'},
+  {id: 4, src: 'https://lookaside.facebook.com/assets/astryx/illustrative-vertical-4.png', alt: 'Bridge at sunset', label: 'bridge.jpg'},
 ];
 
 export default function ThumbnailGallery() {

--- a/packages/cli/templates/blocks/components/Thumbnail/ThumbnailRemovable.tsx
+++ b/packages/cli/templates/blocks/components/Thumbnail/ThumbnailRemovable.tsx
@@ -8,9 +8,9 @@ import {Stack} from '@xds/core/Layout';
 import {Text} from '@xds/core/Text';
 
 const IMAGES = [
-  {id: 1, src: 'https://lookaside.facebook.com/assets/xds_oss/moody-scene-vertical-1.png', alt: 'Dark cityscape at night', label: 'dark-city.jpg'},
-  {id: 2, src: 'https://lookaside.facebook.com/assets/xds_oss/moody-scene-vertical-2.png', alt: 'Bright snowy landscape', label: 'snow.jpg'},
-  {id: 3, src: 'https://lookaside.facebook.com/assets/xds_oss/moody-home-vertical-1.png', alt: 'Warm sunset over mountains', label: 'sunset.jpg'},
+  {id: 1, src: 'https://lookaside.facebook.com/assets/astryx/moody-scene-vertical-1.png', alt: 'Dark cityscape at night', label: 'dark-city.jpg'},
+  {id: 2, src: 'https://lookaside.facebook.com/assets/astryx/moody-scene-vertical-2.png', alt: 'Bright snowy landscape', label: 'snow.jpg'},
+  {id: 3, src: 'https://lookaside.facebook.com/assets/astryx/moody-home-vertical-1.png', alt: 'Warm sunset over mountains', label: 'sunset.jpg'},
 ];
 
 export default function ThumbnailRemovable() {

--- a/packages/cli/templates/blocks/components/Thumbnail/ThumbnailShowcase.tsx
+++ b/packages/cli/templates/blocks/components/Thumbnail/ThumbnailShowcase.tsx
@@ -7,7 +7,7 @@ import {Thumbnail} from '@xds/core/Thumbnail';
 export default function ThumbnailShowcase() {
   return (
     <Thumbnail
-      src="https://lookaside.facebook.com/assets/xds_oss/moody-scene-vertical-2.png"
+      src="https://lookaside.facebook.com/assets/astryx/moody-scene-vertical-2.png"
       alt="Sample image"
       label="photo.jpg"
     />

--- a/packages/cli/templates/blocks/components/Thumbnail/ThumbnailStates.tsx
+++ b/packages/cli/templates/blocks/components/Thumbnail/ThumbnailStates.tsx
@@ -28,7 +28,7 @@ export default function ThumbnailStates() {
           </Stack>
           <Stack direction="vertical" gap={1} hAlign="center">
             <Thumbnail
-              src="https://lookaside.facebook.com/assets/xds_oss/moody-home-vertical-1.png"
+              src="https://lookaside.facebook.com/assets/astryx/moody-home-vertical-1.png"
               alt="Mountain landscape"
               isLoading
               label="landscape.jpg"
@@ -39,7 +39,7 @@ export default function ThumbnailStates() {
           </Stack>
           <Stack direction="vertical" gap={1} hAlign="center">
             <Thumbnail
-              src="https://lookaside.facebook.com/assets/xds_oss/moody-home-vertical-1.png"
+              src="https://lookaside.facebook.com/assets/astryx/moody-home-vertical-1.png"
               alt="Mountain landscape"
               label="landscape.jpg"
             />

--- a/packages/cli/templates/blocks/components/TopNav/TopNavMegaMenu.tsx
+++ b/packages/cli/templates/blocks/components/TopNav/TopNavMegaMenu.tsx
@@ -75,7 +75,7 @@ export default function TopNavMegaMenuBlock() {
               <TopNavMegaMenuFeaturedCard
                 title="What's new in v4.0"
                 description="AI-powered analytics and real-time collaboration."
-                image="https://lookaside.facebook.com/assets/xds_oss/light-working-horizontal-1.png"
+                image="https://lookaside.facebook.com/assets/astryx/light-working-horizontal-1.png"
                 imageAlt="Team collaboration"
                 linkLabel="Read the announcement"
                 linkHref="#announcement"

--- a/packages/cli/templates/pages/centered-hero/page.tsx
+++ b/packages/cli/templates/pages/centered-hero/page.tsx
@@ -17,7 +17,7 @@ import {Section} from '@xds/core/Section';
 import {ArrowRightIcon} from '@heroicons/react/20/solid';
 
 const IMAGE_URL =
-  'https://lookaside.facebook.com/assets/xds_oss/light-scene-horizontal-1.png';
+  'https://lookaside.facebook.com/assets/astryx/light-scene-horizontal-1.png';
 
 const styles = stylex.create({
   heroImage: {

--- a/packages/cli/templates/pages/classic-gallery/page.tsx
+++ b/packages/cli/templates/pages/classic-gallery/page.tsx
@@ -50,52 +50,52 @@ interface GalleryImage {
 
 const GALLERY_IMAGES: GalleryImage[] = [
   {
-    src: 'https://lookaside.facebook.com/assets/xds_oss/moody-scene-horizontal-1.png',
+    src: 'https://lookaside.facebook.com/assets/astryx/moody-scene-horizontal-1.png',
     alt: 'Moody scene landscape',
     category: 'scene',
   },
   {
-    src: 'https://lookaside.facebook.com/assets/xds_oss/moody-lifestyle-vertical-1.png',
+    src: 'https://lookaside.facebook.com/assets/astryx/moody-lifestyle-vertical-1.png',
     alt: 'Moody lifestyle portrait',
     category: 'lifestyle',
   },
   {
-    src: 'https://lookaside.facebook.com/assets/xds_oss/moody-home-vertical-1.png',
+    src: 'https://lookaside.facebook.com/assets/astryx/moody-home-vertical-1.png',
     alt: 'Moody home interior',
     category: 'home',
   },
   {
-    src: 'https://lookaside.facebook.com/assets/xds_oss/moody-scene-horizontal-2.png',
+    src: 'https://lookaside.facebook.com/assets/astryx/moody-scene-horizontal-2.png',
     alt: 'Moody scene vista',
     category: 'scene',
   },
   {
-    src: 'https://lookaside.facebook.com/assets/xds_oss/moody-lifestyle-vertical-2.png',
+    src: 'https://lookaside.facebook.com/assets/astryx/moody-lifestyle-vertical-2.png',
     alt: 'Moody lifestyle scene',
     category: 'lifestyle',
   },
   {
-    src: 'https://lookaside.facebook.com/assets/xds_oss/moody-lifestyle-horizontal-1.png',
+    src: 'https://lookaside.facebook.com/assets/astryx/moody-lifestyle-horizontal-1.png',
     alt: 'Moody lifestyle horizontal',
     category: 'lifestyle',
   },
   {
-    src: 'https://lookaside.facebook.com/assets/xds_oss/moody-scene-vertical-1.png',
+    src: 'https://lookaside.facebook.com/assets/astryx/moody-scene-vertical-1.png',
     alt: 'Moody scene vertical',
     category: 'scene',
   },
   {
-    src: 'https://lookaside.facebook.com/assets/xds_oss/moody-home-vertical-2.png',
+    src: 'https://lookaside.facebook.com/assets/astryx/moody-home-vertical-2.png',
     alt: 'Moody home vertical',
     category: 'home',
   },
   {
-    src: 'https://lookaside.facebook.com/assets/xds_oss/moody-home-horizontal-1.png',
+    src: 'https://lookaside.facebook.com/assets/astryx/moody-home-horizontal-1.png',
     alt: 'Moody home horizontal',
     category: 'home',
   },
   {
-    src: 'https://lookaside.facebook.com/assets/xds_oss/moody-scene-vertical-2.png',
+    src: 'https://lookaside.facebook.com/assets/astryx/moody-scene-vertical-2.png',
     alt: 'Moody scene vertical',
     category: 'scene',
   },

--- a/packages/cli/templates/pages/detail-page/page.tsx
+++ b/packages/cli/templates/pages/detail-page/page.tsx
@@ -63,14 +63,14 @@ const pageStyles = stylex.create({
 });
 
 // ─── Product data ───────────────────────────────────────────────────────────
-// Light product photography from the xds_oss asset set (ceramics collection)
-// Source: meta assets.file list -s xds_oss -g light-product-{1..5}
+// Light product photography from the astryx asset set (ceramics collection)
+// Source: meta assets.file list -s astryx -g light-product-{1..5}
 const PRODUCT_IMAGES = [
-  'https://lookaside.facebook.com/assets/xds_oss/light-product-1.png',
-  'https://lookaside.facebook.com/assets/xds_oss/light-product-2.png',
-  'https://lookaside.facebook.com/assets/xds_oss/light-product-3.png',
-  'https://lookaside.facebook.com/assets/xds_oss/light-product-4.png',
-  'https://lookaside.facebook.com/assets/xds_oss/light-product-5.png',
+  'https://lookaside.facebook.com/assets/astryx/light-product-1.png',
+  'https://lookaside.facebook.com/assets/astryx/light-product-2.png',
+  'https://lookaside.facebook.com/assets/astryx/light-product-3.png',
+  'https://lookaside.facebook.com/assets/astryx/light-product-4.png',
+  'https://lookaside.facebook.com/assets/astryx/light-product-5.png',
 ];
 
 const PRODUCTS = [

--- a/packages/cli/templates/pages/detail-page/page.tsx
+++ b/packages/cli/templates/pages/detail-page/page.tsx
@@ -63,8 +63,6 @@ const pageStyles = stylex.create({
 });
 
 // ─── Product data ───────────────────────────────────────────────────────────
-// Light product photography from the astryx asset set (ceramics collection)
-// Source: meta assets.file list -s astryx -g light-product-{1..5}
 const PRODUCT_IMAGES = [
   'https://lookaside.facebook.com/assets/astryx/light-product-1.png',
   'https://lookaside.facebook.com/assets/astryx/light-product-2.png',

--- a/packages/cli/templates/pages/form-two-column/page.tsx
+++ b/packages/cli/templates/pages/form-two-column/page.tsx
@@ -20,7 +20,7 @@ import {Card} from '@xds/core/Card';
 import {Selector} from '@xds/core/Selector';
 
 const ILLUSTRATION_URL =
-  'https://lookaside.facebook.com/assets/xds_oss/illustration-horizontal-1.png';
+  'https://lookaside.facebook.com/assets/astryx/illustration-horizontal-1.png';
 
 // ─────────────────────────────────────────────────────────────
 // Constants

--- a/packages/cli/templates/pages/gallery-hero/page.tsx
+++ b/packages/cli/templates/pages/gallery-hero/page.tsx
@@ -18,15 +18,15 @@ import {ArrowRightIcon} from '@heroicons/react/20/solid';
 
 const IMAGES = [
   {
-    src: 'https://lookaside.facebook.com/assets/xds_oss/colorful-home-horizontal-1.png',
+    src: 'https://lookaside.facebook.com/assets/astryx/colorful-home-horizontal-1.png',
     alt: 'Colorful home interior with vibrant decor',
   },
   {
-    src: 'https://lookaside.facebook.com/assets/xds_oss/colorful-lifestyle-horizontal-1.png',
+    src: 'https://lookaside.facebook.com/assets/astryx/colorful-lifestyle-horizontal-1.png',
     alt: 'Colorful lifestyle portrait with natural lighting',
   },
   {
-    src: 'https://lookaside.facebook.com/assets/xds_oss/colorful-lifestyle-horizontal-2.png',
+    src: 'https://lookaside.facebook.com/assets/astryx/colorful-lifestyle-horizontal-2.png',
     alt: 'Colorful lifestyle scene with warm tones',
   },
 ];

--- a/packages/cli/templates/pages/library/page.tsx
+++ b/packages/cli/templates/pages/library/page.tsx
@@ -38,7 +38,7 @@ const ITEMS: LibraryItem[] = [
     category: 'Layout',
     type: 'Component',
     imageUrl:
-      'https://lookaside.facebook.com/assets/xds_oss/colorful-home-horizontal-1.png',
+      'https://lookaside.facebook.com/assets/astryx/colorful-home-horizontal-1.png',
   },
   {
     id: '2',
@@ -48,7 +48,7 @@ const ITEMS: LibraryItem[] = [
     category: 'Layout',
     type: 'Component',
     imageUrl:
-      'https://lookaside.facebook.com/assets/xds_oss/illustrative-horizontal-3.jpg',
+      'https://lookaside.facebook.com/assets/astryx/illustrative-horizontal-3.png',
   },
   {
     id: '3',
@@ -58,7 +58,7 @@ const ITEMS: LibraryItem[] = [
     category: 'Layout',
     type: 'Component',
     imageUrl:
-      'https://lookaside.facebook.com/assets/xds_oss/light-working-horizontal-2.png',
+      'https://lookaside.facebook.com/assets/astryx/light-working-horizontal-2.png',
   },
   {
     id: '4',
@@ -67,7 +67,7 @@ const ITEMS: LibraryItem[] = [
     category: 'Layout',
     type: 'Utility',
     imageUrl:
-      'https://lookaside.facebook.com/assets/xds_oss/moody-scene-horizontal-1.png',
+      'https://lookaside.facebook.com/assets/astryx/moody-scene-horizontal-1.png',
   },
   {
     id: '5',
@@ -76,7 +76,7 @@ const ITEMS: LibraryItem[] = [
     category: 'Layout',
     type: 'Pattern',
     imageUrl:
-      'https://lookaside.facebook.com/assets/xds_oss/colorful-lifestyle-horizontal-2.png',
+      'https://lookaside.facebook.com/assets/astryx/colorful-lifestyle-horizontal-2.png',
   },
   {
     id: '6',
@@ -85,7 +85,7 @@ const ITEMS: LibraryItem[] = [
     category: 'Layout',
     type: 'Component',
     imageUrl:
-      'https://lookaside.facebook.com/assets/xds_oss/light-scene-horizontal-1.png',
+      'https://lookaside.facebook.com/assets/astryx/light-scene-horizontal-1.png',
   },
   {
     id: '7',
@@ -95,7 +95,7 @@ const ITEMS: LibraryItem[] = [
     category: 'Forms',
     type: 'Component',
     imageUrl:
-      'https://lookaside.facebook.com/assets/xds_oss/moody-working-horizontal-1.png',
+      'https://lookaside.facebook.com/assets/astryx/moody-working-horizontal-1.png',
   },
   {
     id: '8',
@@ -104,7 +104,7 @@ const ITEMS: LibraryItem[] = [
     category: 'Forms',
     type: 'Component',
     imageUrl:
-      'https://lookaside.facebook.com/assets/xds_oss/colorful-working-horizontal-3.png',
+      'https://lookaside.facebook.com/assets/astryx/colorful-working-horizontal-3.png',
   },
   {
     id: '9',
@@ -113,7 +113,7 @@ const ITEMS: LibraryItem[] = [
     category: 'Forms',
     type: 'Component',
     imageUrl:
-      'https://lookaside.facebook.com/assets/xds_oss/illustrative-horizontal-1.jpg',
+      'https://lookaside.facebook.com/assets/astryx/illustrative-horizontal-1.png',
   },
   {
     id: '10',
@@ -122,7 +122,7 @@ const ITEMS: LibraryItem[] = [
     category: 'Forms',
     type: 'Component',
     imageUrl:
-      'https://lookaside.facebook.com/assets/xds_oss/light-home-horizontal-1.png',
+      'https://lookaside.facebook.com/assets/astryx/light-home-horizontal-1.png',
   },
   {
     id: '11',
@@ -131,7 +131,7 @@ const ITEMS: LibraryItem[] = [
     category: 'Forms',
     type: 'Component',
     imageUrl:
-      'https://lookaside.facebook.com/assets/xds_oss/moody-home-horizontal-2.png',
+      'https://lookaside.facebook.com/assets/astryx/moody-home-horizontal-2.png',
   },
   {
     id: '12',
@@ -141,7 +141,7 @@ const ITEMS: LibraryItem[] = [
     category: 'Forms',
     type: 'Component',
     imageUrl:
-      'https://lookaside.facebook.com/assets/xds_oss/colorful-product-1.png',
+      'https://lookaside.facebook.com/assets/astryx/colorful-product-1.png',
   },
   {
     id: '13',
@@ -151,7 +151,7 @@ const ITEMS: LibraryItem[] = [
     category: 'Navigation',
     type: 'Component',
     imageUrl:
-      'https://lookaside.facebook.com/assets/xds_oss/illustrative-horizontal-5.jpg',
+      'https://lookaside.facebook.com/assets/astryx/illustrative-horizontal-5.png',
   },
   {
     id: '14',
@@ -160,7 +160,7 @@ const ITEMS: LibraryItem[] = [
     category: 'Navigation',
     type: 'Pattern',
     imageUrl:
-      'https://lookaside.facebook.com/assets/xds_oss/light-working-horizontal-1.png',
+      'https://lookaside.facebook.com/assets/astryx/light-working-horizontal-1.png',
   },
   {
     id: '15',
@@ -170,7 +170,7 @@ const ITEMS: LibraryItem[] = [
     category: 'Navigation',
     type: 'Pattern',
     imageUrl:
-      'https://lookaside.facebook.com/assets/xds_oss/moody-lifestyle-horizontal-1.png',
+      'https://lookaside.facebook.com/assets/astryx/moody-lifestyle-horizontal-1.png',
   },
   {
     id: '16',
@@ -179,7 +179,7 @@ const ITEMS: LibraryItem[] = [
     category: 'Navigation',
     type: 'Component',
     imageUrl:
-      'https://lookaside.facebook.com/assets/xds_oss/colorful-home-horizontal-2.png',
+      'https://lookaside.facebook.com/assets/astryx/colorful-home-horizontal-2.png',
   },
   {
     id: '17',
@@ -189,7 +189,7 @@ const ITEMS: LibraryItem[] = [
     category: 'Navigation',
     type: 'Component',
     imageUrl:
-      'https://lookaside.facebook.com/assets/xds_oss/colorful-working-horizontal-1.png',
+      'https://lookaside.facebook.com/assets/astryx/colorful-working-horizontal-1.png',
   },
   {
     id: '18',
@@ -199,7 +199,7 @@ const ITEMS: LibraryItem[] = [
     category: 'Navigation',
     type: 'Pattern',
     imageUrl:
-      'https://lookaside.facebook.com/assets/xds_oss/light-working-horizontal-3.png',
+      'https://lookaside.facebook.com/assets/astryx/light-working-horizontal-3.png',
   },
   {
     id: '19',
@@ -209,7 +209,7 @@ const ITEMS: LibraryItem[] = [
     category: 'Feedback',
     type: 'Component',
     imageUrl:
-      'https://lookaside.facebook.com/assets/xds_oss/moody-working-horizontal-2.png',
+      'https://lookaside.facebook.com/assets/astryx/moody-working-horizontal-2.png',
   },
   {
     id: '20',
@@ -219,7 +219,7 @@ const ITEMS: LibraryItem[] = [
     category: 'Feedback',
     type: 'Component',
     imageUrl:
-      'https://lookaside.facebook.com/assets/xds_oss/illustrative-horizontal-2.jpg',
+      'https://lookaside.facebook.com/assets/astryx/illustrative-horizontal-2.png',
   },
   {
     id: '21',
@@ -228,7 +228,7 @@ const ITEMS: LibraryItem[] = [
     category: 'Feedback',
     type: 'Component',
     imageUrl:
-      'https://lookaside.facebook.com/assets/xds_oss/colorful-lifestyle-horizontal-1.png',
+      'https://lookaside.facebook.com/assets/astryx/colorful-lifestyle-horizontal-1.png',
   },
   {
     id: '22',
@@ -237,7 +237,7 @@ const ITEMS: LibraryItem[] = [
     category: 'Feedback',
     type: 'Component',
     imageUrl:
-      'https://lookaside.facebook.com/assets/xds_oss/light-lifestyle-horizontal-1.png',
+      'https://lookaside.facebook.com/assets/astryx/light-lifestyle-horizontal-1.png',
   },
   {
     id: '23',
@@ -247,7 +247,7 @@ const ITEMS: LibraryItem[] = [
     category: 'Feedback',
     type: 'Component',
     imageUrl:
-      'https://lookaside.facebook.com/assets/xds_oss/moody-home-horizontal-1.png',
+      'https://lookaside.facebook.com/assets/astryx/moody-home-horizontal-1.png',
   },
   {
     id: '24',
@@ -257,7 +257,7 @@ const ITEMS: LibraryItem[] = [
     category: 'Feedback',
     type: 'Component',
     imageUrl:
-      'https://lookaside.facebook.com/assets/xds_oss/colorful-working-horizontal-2.png',
+      'https://lookaside.facebook.com/assets/astryx/colorful-working-horizontal-2.png',
   },
   {
     id: '25',
@@ -267,7 +267,7 @@ const ITEMS: LibraryItem[] = [
     category: 'Data',
     type: 'Component',
     imageUrl:
-      'https://lookaside.facebook.com/assets/xds_oss/illustrative-horizontal-4.jpg',
+      'https://lookaside.facebook.com/assets/astryx/illustrative-horizontal-4.png',
   },
   {
     id: '26',
@@ -277,7 +277,7 @@ const ITEMS: LibraryItem[] = [
     category: 'Data',
     type: 'Component',
     imageUrl:
-      'https://lookaside.facebook.com/assets/xds_oss/light-working-horizontal-4.png',
+      'https://lookaside.facebook.com/assets/astryx/light-working-horizontal-4.png',
   },
   {
     id: '27',
@@ -287,7 +287,7 @@ const ITEMS: LibraryItem[] = [
     category: 'Data',
     type: 'Utility',
     imageUrl:
-      'https://lookaside.facebook.com/assets/xds_oss/moody-lifestyle-horizontal-2.png',
+      'https://lookaside.facebook.com/assets/astryx/moody-lifestyle-horizontal-2.png',
   },
   {
     id: '28',
@@ -296,7 +296,7 @@ const ITEMS: LibraryItem[] = [
     category: 'Data',
     type: 'Component',
     imageUrl:
-      'https://lookaside.facebook.com/assets/xds_oss/moody-scene-horizontal-2.png',
+      'https://lookaside.facebook.com/assets/astryx/moody-scene-horizontal-2.png',
   },
   {
     id: '29',
@@ -306,7 +306,7 @@ const ITEMS: LibraryItem[] = [
     category: 'Data',
     type: 'Pattern',
     imageUrl:
-      'https://lookaside.facebook.com/assets/xds_oss/colorful-product-2.png',
+      'https://lookaside.facebook.com/assets/astryx/colorful-product-2.png',
   },
   {
     id: '30',
@@ -316,7 +316,7 @@ const ITEMS: LibraryItem[] = [
     category: 'Data',
     type: 'Component',
     imageUrl:
-      'https://lookaside.facebook.com/assets/xds_oss/moody-working-horizontal-3.png',
+      'https://lookaside.facebook.com/assets/astryx/moody-working-horizontal-3.png',
   },
 ];
 

--- a/packages/cli/templates/pages/login-split/page.tsx
+++ b/packages/cli/templates/pages/login-split/page.tsx
@@ -19,15 +19,15 @@ import {Link} from '@xds/core/Link';
 import {Divider} from '@xds/core/Divider';
 import {colorVars, spacingVars} from '@xds/core/theme/tokens.stylex';
 
-// light-working-vertical-1 from xds_oss asset set
+// light-working-vertical-1 from astryx asset set
 const COVER_IMAGE_URL =
-  'https://lookaside.facebook.com/assets/xds_oss/light-working-vertical-1.png';
-// AppleLogo from xds_oss asset set
+  'https://lookaside.facebook.com/assets/astryx/light-working-vertical-1.png';
+// AppleLogo from astryx asset set
 const APPLE_LOGO_URL =
-  'https://lookaside.facebook.com/assets/xds_oss/AppleLogo.png';
-// GoogleLogo from xds_oss asset set
+  'https://lookaside.facebook.com/assets/astryx/AppleLogo.png';
+// GoogleLogo from astryx asset set
 const GOOGLE_LOGO_URL =
-  'https://lookaside.facebook.com/assets/xds_oss/GoogleLogo.png';
+  'https://lookaside.facebook.com/assets/astryx/GoogleLogo.png';
 
 // Grid emits minmax(MIN, 1fr) where MIN is a hard floor, so MIN plus the
 // grid inset and page padding must fit the narrowest phone or the column is

--- a/packages/cli/templates/pages/login-split/page.tsx
+++ b/packages/cli/templates/pages/login-split/page.tsx
@@ -19,13 +19,10 @@ import {Link} from '@xds/core/Link';
 import {Divider} from '@xds/core/Divider';
 import {colorVars, spacingVars} from '@xds/core/theme/tokens.stylex';
 
-// light-working-vertical-1 from astryx asset set
 const COVER_IMAGE_URL =
   'https://lookaside.facebook.com/assets/astryx/light-working-vertical-1.png';
-// AppleLogo from astryx asset set
 const APPLE_LOGO_URL =
   'https://lookaside.facebook.com/assets/astryx/AppleLogo.png';
-// GoogleLogo from astryx asset set
 const GOOGLE_LOGO_URL =
   'https://lookaside.facebook.com/assets/astryx/GoogleLogo.png';
 

--- a/packages/cli/templates/pages/login-sso/page.tsx
+++ b/packages/cli/templates/pages/login-sso/page.tsx
@@ -22,7 +22,7 @@ import {spacingVars} from '@xds/core/theme/tokens.stylex';
 // Styles
 // ---------------------------------------------------------------------------
 
-const BG_URL = 'https://lookaside.facebook.com/assets/xds_oss/building.jpg';
+const BG_URL = 'https://lookaside.facebook.com/assets/astryx/building.png';
 
 const styles = stylex.create({
   page: {

--- a/packages/cli/templates/pages/mixed-gallery/page.tsx
+++ b/packages/cli/templates/pages/mixed-gallery/page.tsx
@@ -61,23 +61,23 @@ interface GalleryImage {
 // All landscape photos so the uniform 3:2 / 3:1 tiles crop cleanly.
 const IMAGES: GalleryImage[] = [
   {
-    src: 'https://lookaside.facebook.com/assets/xds_oss/illustrative-horizontal-1.jpg',
+    src: 'https://lookaside.facebook.com/assets/astryx/illustrative-horizontal-1.png',
     title: 'Going places',
   },
   {
-    src: 'https://lookaside.facebook.com/assets/xds_oss/light-home-horizontal-1.png',
+    src: 'https://lookaside.facebook.com/assets/astryx/light-home-horizontal-1.png',
     title: 'Making memories',
   },
   {
-    src: 'https://lookaside.facebook.com/assets/xds_oss/light-lifestyle-horizontal-1.png',
+    src: 'https://lookaside.facebook.com/assets/astryx/light-lifestyle-horizontal-1.png',
     title: 'Being free',
   },
   {
-    src: 'https://lookaside.facebook.com/assets/xds_oss/light-working-horizontal-2.png',
+    src: 'https://lookaside.facebook.com/assets/astryx/light-working-horizontal-2.png',
     title: 'Getting it done',
   },
   {
-    src: 'https://lookaside.facebook.com/assets/xds_oss/light-scene-horizontal-1.png',
+    src: 'https://lookaside.facebook.com/assets/astryx/light-scene-horizontal-1.png',
     title: 'Finding calm',
   },
 ];

--- a/packages/cli/templates/pages/payment-form/page.tsx
+++ b/packages/cli/templates/pages/payment-form/page.tsx
@@ -117,9 +117,9 @@ const US_STATES = [
 // Product photos from the local template-assets set (committed to the
 // docsite; the CLI swaps these for an inline placeholder on scaffold).
 const ITEM_IMAGES: Record<string, {src: string}> = {
-  '1': {src: 'https://lookaside.facebook.com/assets/xds_oss/light-product-1.png'},
-  '2': {src: 'https://lookaside.facebook.com/assets/xds_oss/light-product-4.png'},
-  '3': {src: 'https://lookaside.facebook.com/assets/xds_oss/light-product-5.png'},
+  '1': {src: 'https://lookaside.facebook.com/assets/astryx/light-product-1.png'},
+  '2': {src: 'https://lookaside.facebook.com/assets/astryx/light-product-4.png'},
+  '3': {src: 'https://lookaside.facebook.com/assets/astryx/light-product-5.png'},
 };
 
 const ORDER_ITEMS = [

--- a/packages/cli/templates/pages/product-detail/page.tsx
+++ b/packages/cli/templates/pages/product-detail/page.tsx
@@ -79,24 +79,24 @@ function StarRating({rating, count}: {rating: number; count: number}) {
 }
 
 // ─── Image URLs ─────────────────────────────────────────────────────────────
-// Light product photography from the xds_oss asset set (ceramics collection)
-// Source: meta assets.file list -s xds_oss -g light-product-{1..5}
+// Light product photography from the astryx asset set (ceramics collection)
+// Source: meta assets.file list -s astryx -g light-product-{1..5}
 // IMAGES[0] = fallback hero; IMAGES[1..6] = thumbnails (first is selected by default)
 const IMAGES = [
   // light-product-1 (fallback hero)
-  'https://lookaside.facebook.com/assets/xds_oss/light-product-1.png',
+  'https://lookaside.facebook.com/assets/astryx/light-product-1.png',
   // light-product-1 (thumbnail 1)
-  'https://lookaside.facebook.com/assets/xds_oss/light-product-1.png',
+  'https://lookaside.facebook.com/assets/astryx/light-product-1.png',
   // light-product-2
-  'https://lookaside.facebook.com/assets/xds_oss/light-product-2.png',
+  'https://lookaside.facebook.com/assets/astryx/light-product-2.png',
   // light-product-3
-  'https://lookaside.facebook.com/assets/xds_oss/light-product-3.png',
+  'https://lookaside.facebook.com/assets/astryx/light-product-3.png',
   // light-product-4
-  'https://lookaside.facebook.com/assets/xds_oss/light-product-4.png',
+  'https://lookaside.facebook.com/assets/astryx/light-product-4.png',
   // light-product-5
-  'https://lookaside.facebook.com/assets/xds_oss/light-product-5.png',
+  'https://lookaside.facebook.com/assets/astryx/light-product-5.png',
   // light-product-3 (gallery variety)
-  'https://lookaside.facebook.com/assets/xds_oss/light-product-3.png',
+  'https://lookaside.facebook.com/assets/astryx/light-product-3.png',
 ];
 
 // ─── Product Data ───────────────────────────────────────────────────────────

--- a/packages/cli/templates/pages/product-detail/page.tsx
+++ b/packages/cli/templates/pages/product-detail/page.tsx
@@ -79,23 +79,14 @@ function StarRating({rating, count}: {rating: number; count: number}) {
 }
 
 // ─── Image URLs ─────────────────────────────────────────────────────────────
-// Light product photography from the astryx asset set (ceramics collection)
-// Source: meta assets.file list -s astryx -g light-product-{1..5}
 // IMAGES[0] = fallback hero; IMAGES[1..6] = thumbnails (first is selected by default)
 const IMAGES = [
-  // light-product-1 (fallback hero)
   'https://lookaside.facebook.com/assets/astryx/light-product-1.png',
-  // light-product-1 (thumbnail 1)
   'https://lookaside.facebook.com/assets/astryx/light-product-1.png',
-  // light-product-2
   'https://lookaside.facebook.com/assets/astryx/light-product-2.png',
-  // light-product-3
   'https://lookaside.facebook.com/assets/astryx/light-product-3.png',
-  // light-product-4
   'https://lookaside.facebook.com/assets/astryx/light-product-4.png',
-  // light-product-5
   'https://lookaside.facebook.com/assets/astryx/light-product-5.png',
-  // light-product-3 (gallery variety)
   'https://lookaside.facebook.com/assets/astryx/light-product-3.png',
 ];
 

--- a/packages/cli/templates/pages/product-gallery/page.tsx
+++ b/packages/cli/templates/pages/product-gallery/page.tsx
@@ -42,7 +42,7 @@ const PRODUCTS: Product[] = [
       "Sometimes all it takes is one small thing to turn your whole day around. That's what good design is for.",
     price: 75.0,
     image:
-      'https://lookaside.facebook.com/assets/xds_oss/illustrative-horizontal-1.jpg',
+      'https://lookaside.facebook.com/assets/astryx/illustrative-horizontal-1.png',
   },
   {
     id: 2,
@@ -51,7 +51,7 @@ const PRODUCTS: Product[] = [
       "Sometimes all it takes is one small thing to turn your whole day around. That's what good design is for.",
     price: 80.0,
     image:
-      'https://lookaside.facebook.com/assets/xds_oss/illustrative-vertical-1.jpg',
+      'https://lookaside.facebook.com/assets/astryx/illustrative-vertical-1.png',
   },
   {
     id: 3,
@@ -60,7 +60,7 @@ const PRODUCTS: Product[] = [
       "Sometimes all it takes is one small thing to turn your whole day around. That's what good design is for.",
     price: 75.0,
     image:
-      'https://lookaside.facebook.com/assets/xds_oss/illustrative-horizontal-3.jpg',
+      'https://lookaside.facebook.com/assets/astryx/illustrative-horizontal-3.png',
   },
   {
     id: 4,
@@ -69,7 +69,7 @@ const PRODUCTS: Product[] = [
       "Sometimes all it takes is one small thing to turn your whole day around. That's what good design is for.",
     price: 75.0,
     image:
-      'https://lookaside.facebook.com/assets/xds_oss/illustrative-horizontal-4.jpg',
+      'https://lookaside.facebook.com/assets/astryx/illustrative-horizontal-4.png',
   },
   {
     id: 5,
@@ -78,7 +78,7 @@ const PRODUCTS: Product[] = [
       "Sometimes all it takes is one small thing to turn your whole day around. That's what good design is for.",
     price: 60.0,
     image:
-      'https://lookaside.facebook.com/assets/xds_oss/illustrative-horizontal-5.jpg',
+      'https://lookaside.facebook.com/assets/astryx/illustrative-horizontal-5.png',
   },
   {
     id: 6,
@@ -87,7 +87,7 @@ const PRODUCTS: Product[] = [
       "Sometimes all it takes is one small thing to turn your whole day around. That's what good design is for.",
     price: 80.0,
     image:
-      'https://lookaside.facebook.com/assets/xds_oss/illustrative-horizontal-2.jpg',
+      'https://lookaside.facebook.com/assets/astryx/illustrative-horizontal-2.png',
   },
 ];
 

--- a/packages/cli/templates/pages/side-gallery/page.tsx
+++ b/packages/cli/templates/pages/side-gallery/page.tsx
@@ -30,44 +30,44 @@ const styles = stylex.create({
 });
 
 // ─── Image Data ─────────────────────────────────────────────────────────────
-// From the xds_oss asset set (colorful home + lifestyle collection)
-// Source: meta assets.file list -s xds_oss -g <name>
+// From the astryx asset set (colorful home + lifestyle collection)
+// Source: meta assets.file list -s astryx -g <name>
 
 const IMAGES = [
   {
-    src: 'https://lookaside.facebook.com/assets/xds_oss/colorful-lifestyle-vertical-3.png',
+    src: 'https://lookaside.facebook.com/assets/astryx/colorful-lifestyle-vertical-3.png',
     alt: 'Colorful lifestyle scene',
   },
   {
-    src: 'https://lookaside.facebook.com/assets/xds_oss/colorful-lifestyle-horizontal-1.png',
+    src: 'https://lookaside.facebook.com/assets/astryx/colorful-lifestyle-horizontal-1.png',
     alt: 'Colorful lifestyle horizontal',
   },
   {
-    src: 'https://lookaside.facebook.com/assets/xds_oss/colorful-lifestyle-vertical-1.png',
+    src: 'https://lookaside.facebook.com/assets/astryx/colorful-lifestyle-vertical-1.png',
     alt: 'Colorful lifestyle vertical',
   },
   {
-    src: 'https://lookaside.facebook.com/assets/xds_oss/colorful-home-vertical-2.png',
+    src: 'https://lookaside.facebook.com/assets/astryx/colorful-home-vertical-2.png',
     alt: 'Colorful home interior',
   },
   {
-    src: 'https://lookaside.facebook.com/assets/xds_oss/colorful-home-vertical-3.png',
+    src: 'https://lookaside.facebook.com/assets/astryx/colorful-home-vertical-3.png',
     alt: 'Colorful home scene',
   },
   {
-    src: 'https://lookaside.facebook.com/assets/xds_oss/colorful-home-vertical-1.png',
+    src: 'https://lookaside.facebook.com/assets/astryx/colorful-home-vertical-1.png',
     alt: 'Colorful home vertical',
   },
   {
-    src: 'https://lookaside.facebook.com/assets/xds_oss/colorful-lifestyle-horizontal-2.png',
+    src: 'https://lookaside.facebook.com/assets/astryx/colorful-lifestyle-horizontal-2.png',
     alt: 'Colorful lifestyle wide',
   },
   {
-    src: 'https://lookaside.facebook.com/assets/xds_oss/colorful-lifestyle-vertical-2.png',
+    src: 'https://lookaside.facebook.com/assets/astryx/colorful-lifestyle-vertical-2.png',
     alt: 'Colorful lifestyle detail',
   },
   {
-    src: 'https://lookaside.facebook.com/assets/xds_oss/colorful-lifestyle-vertical-4.png',
+    src: 'https://lookaside.facebook.com/assets/astryx/colorful-lifestyle-vertical-4.png',
     alt: 'Colorful lifestyle portrait',
   },
 ];

--- a/packages/cli/templates/pages/side-gallery/page.tsx
+++ b/packages/cli/templates/pages/side-gallery/page.tsx
@@ -30,8 +30,6 @@ const styles = stylex.create({
 });
 
 // ─── Image Data ─────────────────────────────────────────────────────────────
-// From the astryx asset set (colorful home + lifestyle collection)
-// Source: meta assets.file list -s astryx -g <name>
 
 const IMAGES = [
   {

--- a/packages/cli/templates/pages/table-page-chart/page.tsx
+++ b/packages/cli/templates/pages/table-page-chart/page.tsx
@@ -52,37 +52,37 @@ const PRODUCTS = [
   {
     name: 'Ceremonial Matcha Latte',
     category: 'Matcha' as ProductCategory,
-    image: 'https://lookaside.facebook.com/assets/xds_oss/matcha-product-1.png',
+    image: 'https://lookaside.facebook.com/assets/astryx/matcha-product-1.png',
     price: 6,
   },
   {
     name: 'Oat Milk Cappuccino',
     category: 'Coffee' as ProductCategory,
-    image: 'https://lookaside.facebook.com/assets/xds_oss/matcha-product-2.png',
+    image: 'https://lookaside.facebook.com/assets/astryx/matcha-product-2.png',
     price: 5,
   },
   {
     name: 'Jasmine Green Tea',
     category: 'Tea' as ProductCategory,
-    image: 'https://lookaside.facebook.com/assets/xds_oss/matcha-product-3.png',
+    image: 'https://lookaside.facebook.com/assets/astryx/matcha-product-3.png',
     price: 4,
   },
   {
     name: 'Mango Matcha Smoothie',
     category: 'Smoothie' as ProductCategory,
-    image: 'https://lookaside.facebook.com/assets/xds_oss/matcha-product-4.png',
+    image: 'https://lookaside.facebook.com/assets/astryx/matcha-product-4.png',
     price: 8,
   },
   {
     name: 'Hojicha Latte',
     category: 'Specialty' as ProductCategory,
-    image: 'https://lookaside.facebook.com/assets/xds_oss/matcha-product-5.png',
+    image: 'https://lookaside.facebook.com/assets/astryx/matcha-product-5.png',
     price: 7,
   },
   {
     name: 'Iced Yuzu Matcha',
     category: 'Matcha' as ProductCategory,
-    image: 'https://lookaside.facebook.com/assets/xds_oss/matcha-product-6.png',
+    image: 'https://lookaside.facebook.com/assets/astryx/matcha-product-6.png',
     price: 7,
   },
 ];

--- a/packages/cli/templates/pages/theme-showcase/page.tsx
+++ b/packages/cli/templates/pages/theme-showcase/page.tsx
@@ -290,9 +290,9 @@ const DEFAULT_PRODUCTS: ProductSpec[] = [
   },
 ];
 
-// Neutral product photos, served from the shared xds_oss asset CDN so the
+// Neutral product photos, served from the shared astryx asset CDN so the
 // scaffolded template renders real imagery without needing local public assets.
-const NEUTRAL_CDN = 'https://lookaside.facebook.com/assets/xds_oss';
+const NEUTRAL_CDN = 'https://lookaside.facebook.com/assets/astryx';
 const DEFAULT_IMAGES: Record<string, string> = {
   watch: `${NEUTRAL_CDN}/Neutral-Watch.png`,
   headphones: `${NEUTRAL_CDN}/Neutral-Headphones.png`,


### PR DESCRIPTION
## Summary

Migrates **all** demo image references in templates, blocks, and the docsite from the **`xds_oss`** asset set to the **`astryx`** asset set (both on the same `lookaside.facebook.com` CDN). This is a URL-only migration — the set segment is swapped and rendering behavior is preserved.

- **43 files** updated (`assets/xds_oss/...` → `assets/astryx/...`), covering every reference style: inline URLs, `XDS_CDN`/`PICKER_CDN`/`NEUTRAL_CDN`/`CDN` constants, comments, and the `template.test.mjs` fixture string.
- **Extension fixes (`.jpg` → `.png`, 26 refs):** `astryx` is PNG-only. The `illustrative-*` family and `building` were `.jpg` in `xds_oss` but exist as `.png` in `astryx`, so those URLs were updated to keep resolving.
- **One image substitution (to preserve behavior):** `AvatarFallbackChain`'s "Invalid src, valid fallbackSrc" row used `illustration-horizontal-2` as its `fallbackSrc`, but that asset doesn't exist in `astryx` (404). A pure URL swap would have made that demo row fall through to initials (i.e. behave like the "both invalid" row). To keep the demo intact, the `fallbackSrc` now points at `DATA-Ami-Pena.png` — a real person photo in `astryx` — so the row still shows a working image fallback.
- **Redundant comments removed:** comments that merely restated the filename already in the adjacent URL, plus internal `meta assets.file list` source notes. Intent-bearing comments (array layout, why a remote CDN is used) were kept.
- Intentional `does-not-exist-*` fallback demos were rehosted to `astryx` as well (they're meant to 404, so this is cosmetic).
- The CLI template asset-stripping logic keys off the `lookaside.facebook.com` host (not the set name), so scaffolding behavior is unchanged.

## Test plan

- [x] All migrated asset URLs expected to resolve return HTTP 200 on the `astryx` CDN (intentional `does-not-exist-*` demos excepted)
- [x] `vitest run packages/cli/src/api/template.test.mjs` — 7/7 pass
- [x] `eslint` on all changed files — clean
- [x] `check:sync` — clean
- [x] `check:changesets` — passes (no changeset added; demo-asset swap with no consumer-facing behavior change)
- [ ] Visual spot-check of template/block previews + docsite theme showcase rendering with `astryx` imagery