### PR TITLE
fix(docsite): keep Properties preview border framed, tidy Examples divider

### DIFF
--- a/apps/docsite/src/components/component-detail/ComponentDetailClient.tsx
+++ b/apps/docsite/src/components/component-detail/ComponentDetailClient.tsx
@@ -12,7 +12,6 @@ import {Card} from '@astryxdesign/core/Card';
 import {Divider} from '@astryxdesign/core';
 import {CodeExampleBlock} from '../CodeExampleBlock';
 import {TabList, Tab} from '@astryxdesign/core/TabList';
-import {useMediaQuery} from '@astryxdesign/core/hooks';
 import {ShowcasePreview} from './ShowcasePreview';
 import {ComponentPreviewTheme} from './ComponentPreviewTheme';
 import {BestPractices} from './BestPractices';
@@ -33,6 +32,19 @@ import {trackNavigate} from '../../lib/analytics';
 const styles = stylex.create({
   section: {
     marginInline: 'auto',
+  },
+  previewStage: {
+    position: 'sticky',
+    top: 44,
+    zIndex: 10,
+    backgroundColor: 'var(--color-background-page)',
+    backdropFilter: 'blur(16px)',
+    maxHeight: {default: 400, '@media (max-width: 768px)': 250},
+    overflow: 'auto',
+    borderWidth: 'var(--border-width, 1px)',
+    borderStyle: 'solid',
+    borderColor: 'var(--color-border-emphasized)',
+    borderRadius: 'var(--radius-container)',
   },
 });
 
@@ -91,7 +103,6 @@ function OverviewContent({
 
       {(exampleRegistry[comp.name] || []).length > 0 && (
         <>
-          <Divider />
           <VStack gap={4}>
             <Heading level={2} type="display-3">
               Examples
@@ -124,7 +135,6 @@ function ComponentDetailInner({
   const isHook = comp.params != null;
   const hasShowcase = comp.name in showcaseRegistry;
   const hasPlayground = !isHook;
-  const isMobile = useMediaQuery('(max-width: 768px)');
 
   const tab = searchParams.get('tab') ?? 'overview';
   const setTab = (value: string) => {
@@ -184,16 +194,7 @@ function ComponentDetailInner({
 
             {tab === 'properties' && (
               <VStack gap={4}>
-                <div
-                  style={{
-                    position: 'sticky',
-                    top: 44,
-                    zIndex: 10,
-                    backgroundColor: 'var(--color-background-page)',
-                    backdropFilter: 'blur(16px)',
-                    maxHeight: isMobile ? 250 : 400,
-                    overflow: 'auto',
-                  }}>
+                <div {...stylex.props(styles.previewStage)}>
                   <InteractivePreviewStage
                     name={comp.name}
                     state={state}
@@ -201,6 +202,7 @@ function ComponentDetailInner({
                     playground={comp.playground}
                     missingRequiredProps={missingRequiredProps}
                     onPropChange={setProp}
+                    embedded
                     canControlOpenState={
                       comp.props.some(prop => prop.name === 'isOpen') &&
                       comp.props.some(prop => prop.name === 'onOpenChange')

--- a/apps/docsite/src/components/component-detail/InteractivePreview.tsx
+++ b/apps/docsite/src/components/component-detail/InteractivePreview.tsx
@@ -11,6 +11,7 @@ import {
   Component,
   type ReactNode,
 } from 'react';
+import * as stylex from '@stylexjs/stylex';
 import {getComponent, resolveValue} from './resolveElements';
 import {Button} from '@astryxdesign/core/Button';
 import {Card} from '@astryxdesign/core/Card';
@@ -33,6 +34,17 @@ import type {
 } from '../../generated/componentRegistry';
 
 export type {KnobProp} from './interactiveState';
+
+const styles = stylex.create({
+  card: {
+    width: '100%',
+    position: 'relative',
+  },
+  // Flattens the Card corners when embedded in an already-framed container.
+  flat: {
+    borderRadius: 0,
+  },
+});
 
 class PreviewErrorBoundary extends Component<
   {children: ReactNode; resetKeys: unknown[]},
@@ -193,6 +205,7 @@ export function InteractivePreviewStage({
   missingRequiredProps = [],
   onPropChange,
   canControlOpenState = false,
+  embedded = false,
 }: {
   name: string;
   state: Record<string, unknown>;
@@ -201,6 +214,7 @@ export function InteractivePreviewStage({
   missingRequiredProps?: string[];
   onPropChange?: (propName: string, value: unknown) => void;
   canControlOpenState?: boolean;
+  embedded?: boolean;
 }) {
   const [showCode, setShowCode] = useState(false);
   const Component = getComponent(name);
@@ -242,7 +256,7 @@ export function InteractivePreviewStage({
   if (missingRequiredProps.length > 0) {
     return (
       <ComponentPreviewTheme>
-        <Card variant="muted" padding={0}>
+        <Card variant="muted" padding={0} xstyle={embedded && styles.flat}>
           <Center style={{minHeight: 200, width: '100%'}}>
             <VStack
               gap={1}
@@ -268,7 +282,7 @@ export function InteractivePreviewStage({
   if (!Component) {
     return (
       <ComponentPreviewTheme>
-        <Card variant="muted" padding={0}>
+        <Card variant="muted" padding={0} xstyle={embedded && styles.flat}>
           <Center style={{minHeight: 200, width: '100%'}}>
             <VStack
               gap={1}
@@ -297,7 +311,7 @@ export function InteractivePreviewStage({
       <Card
         variant="muted"
         padding={0}
-        style={{width: '100%', position: 'relative'}}>
+        xstyle={[styles.card, embedded && styles.flat]}>
         <div
           style={{
             position: 'absolute',


### PR DESCRIPTION
## Summary

Two polish fixes to the docsite component detail pages (e.g. `/components/Button`, `/components/Token`).

### 1. Fix disappearing preview border on the Properties tab
On the Properties tab, the live preview sits in a sticky `overflow: auto` / `max-height` container. The border was on the inner `Card`, so when the preview was taller than the container the Card's **top and bottom borders scrolled out of the overflow window and vanished** (left/right stayed). Fixed by:
- Moving the border + radius onto the **scroll container** itself (a border on the scrolling element doesn't scroll away).
- Adding an `embedded` flag to `InteractivePreviewStage` that flattens the inner Card's `border-radius` so it sits flush inside the frame.

### 2. Remove the divider above "Examples"
Dropped the `<Divider />` that sat directly above the "Examples" section on the overview — the heading provides enough separation.

> Note: an earlier revision of this PR also simplified the header subtitle (dropping the package version and module name). That change has been reverted — the subtitle remains the original `@astryxdesign/core v0.0.15 · Button`.

## Changes
- `apps/docsite/src/components/component-detail/ComponentDetailClient.tsx` — border/radius on the Properties scroll container; pass `embedded`; removed the Examples divider.
- `apps/docsite/src/components/component-detail/InteractivePreview.tsx` — new `embedded` prop flattens the Card corners when framed.

## Test plan
- [x] `/components/Token?tab=properties` — border stays framed while scrolling the property-heavy preview
- [x] `/components/Button` — no divider above the Examples section
- [x] `/components/Button` header still renders `@astryxdesign/core v0.0.15 · Button` (unchanged)
- [x] `eslint` on all changed files — clean
- [x] Pre-commit checks (`check:repo`, `check:changesets`) pass

## Notes
- Docsite-only change (`apps/docsite` is private/unpublished), so no changeset is needed.