### PR TITLE
feat(docsite): pin component search bar to top of sidebar

### DIFF
--- a/apps/docsite/src/components/DocsShell.tsx
+++ b/apps/docsite/src/components/DocsShell.tsx
@@ -102,6 +102,18 @@ export function DocsShell({
   // navigation.
   const isOnComponentsRoute = pathname.startsWith('/components');
 
+  const componentSearch = (
+    <TextInput
+      label="Search components"
+      isLabelHidden
+      value={componentQuery}
+      onChange={setComponentQuery}
+      placeholder="Search components…"
+      startIcon={Search}
+      hasClear
+    />
+  );
+
   return (
     <AppShell
       variant="surface"
@@ -109,7 +121,7 @@ export function DocsShell({
       mobileNav={{defaultIsMobile}}
       topNav={<SharedTopNav />}
       sideNav={
-        <SideNav>
+        <SideNav topContent={isOnComponentsRoute ? componentSearch : undefined}>
           {!isOnComponentsRoute && (
             <>
               {/* Getting Started */}
@@ -182,16 +194,6 @@ export function DocsShell({
           {isOnComponentsRoute && (
             <>
               <SideNavSection title="Components" isHeaderHidden>
-                <TextInput
-                  label="Search components"
-                  isLabelHidden
-                  value={componentQuery}
-                  onChange={setComponentQuery}
-                  placeholder="Search components…"
-                  startIcon={Search}
-                  hasClear
-                  style={{marginBottom: 'var(--spacing-3)'}}
-                />
                 {!q && (
                   <SideNavItem
                     label="Overview"


### PR DESCRIPTION
## Summary

On the component docs pages (`/components/*`), the **"Search components" input** was rendered inside the scrollable nav section, so it scrolled out of view as soon as you moved down the (long) component list.

This moves the search input into `SideNav`'s sticky `topContent` zone so it stays **pinned to the top** of the sidebar while the component list scrolls beneath it.

## Implementation

`SideNav` already supports this natively: `topContent` renders in a `position: sticky; top: 0` zone, separate from the scrollable `children`. So the fix is just relocating the input:

- Extracted the `TextInput` into a `componentSearch` element.
- Passed it as `<SideNav topContent={isOnComponentsRoute ? componentSearch : undefined}>` (only on component routes — other routes keep no topContent).
- Removed the input from inside the scrollable `SideNavSection` (and its now-unneeded `marginBottom`, since the sticky zone handles spacing).

No changes to the `SideNav` component itself.

## Test plan
- [x] Verified rendered DOM: the search input now sits in SideNav's `position: sticky` top zone, with the component list (`Overview`, `Button`, …) in the separate scrollable region below.
- [x] `eslint` on the changed file — clean
- [x] Pre-commit checks (`check:repo`, `check:changesets`) pass
- [ ] Visual check: scroll the component list and confirm the search bar stays pinned (desktop + mobile drawer)

## Notes
- Docsite-only change (`apps/docsite` is private/unpublished), so no changeset is needed.
- Search behavior/filtering is unchanged — only its placement moved.

Made with [Cursor](https://cursor.com)