### PR TITLE
fix(docsite): Blog styling fixes

### DIFF
--- a/apps/docsite/src/app/(docs)/components/page.tsx
+++ b/apps/docsite/src/app/(docs)/components/page.tsx
@@ -134,7 +134,7 @@ export default function ComponentsGalleryPage() {
       <VStack gap={10}>
         <VStack gap={4} hAlign="center">
           <VStack gap={2} style={{alignItems: 'center'}}>
-            <Text type="display-2" xstyle={styles.heroTitle}>
+            <Text type="display-1" xstyle={styles.heroTitle}>
               Browse the library
             </Text>
             <Text type="body" color="secondary" xstyle={styles.heroTitle}>
@@ -172,11 +172,7 @@ export default function ComponentsGalleryPage() {
                 </VStack>
               </VStack>
             }>
-            <Button
-              variant="primary"
-              size="lg"
-              label="Install core library"
-            />
+            <Button variant="primary" size="lg" label="Install core library" />
           </Popover>
         </VStack>
 

--- a/apps/docsite/src/app/(site)/community/page.tsx
+++ b/apps/docsite/src/app/(site)/community/page.tsx
@@ -85,11 +85,6 @@ const styles = stylex.create({
     maxWidth: 1200,
     width: '100%',
     marginInline: 'auto',
-    // Add the same section gap as bottom padding so the
-    // Resources → footer break feels like another section gap
-    // (96px) rather than abruptly hitting the footer with only
-    // the Section's 24px padding underneath.
-    paddingBlockEnd: 'calc(var(--spacing-12) * 2)',
   },
   // Hero group — wraps the "Build with us" hero row + the wall
   // card below it as one unit inside the section stack. Tight

--- a/apps/docsite/src/app/(site)/templates/page.tsx
+++ b/apps/docsite/src/app/(site)/templates/page.tsx
@@ -203,7 +203,7 @@ export default function TemplatesPage() {
         {/* Header */}
         <VStack gap={6} align="stretch">
           <VStack gap={2}>
-            <Heading level={1} type="display-2" justify="center">
+            <Heading level={1} type="display-1" justify="center">
               Templates
             </Heading>
             <Text type="body" color="secondary" justify="center">
@@ -216,20 +216,13 @@ export default function TemplatesPage() {
             onChange={value => setActiveCategory(value ?? 'All')}
             xstyle={styles.categoryFilter}>
             {categories.map(category => (
-              <ToggleButton
-                key={category}
-                label={category}
-                value={category}
-              />
+              <ToggleButton key={category} label={category} value={category} />
             ))}
           </ToggleButtonGroup>
         </VStack>
 
         {/* Body */}
-        <Grid
-          columns={{minWidth: isMobile ? 280 : 420}}
-          gap={4}
-          width="100%">
+        <Grid columns={{minWidth: isMobile ? 280 : 420}} gap={4} width="100%">
           {filteredItems.map(item => {
             const templateContent = <TemplateThumbnail slug={item.slug} />;
 

--- a/apps/docsite/src/components/ChangelogView.tsx
+++ b/apps/docsite/src/components/ChangelogView.tsx
@@ -10,7 +10,6 @@ import {VStack} from '@xds/core/Layout';
 import {Section} from '@xds/core/Section';
 import {TabList, Tab} from '@xds/core/TabList';
 import {Carousel} from '@xds/core/Carousel';
-import {spacingVars} from '@xds/core/theme/tokens.stylex';
 import {GITHUB_REPO} from '../constants';
 
 function linkifyPRs(markdown: string): string {
@@ -61,7 +60,6 @@ interface ChangelogViewProps {
 const styles = stylex.create({
   section: {
     marginInline: 'auto',
-    paddingBottom: `calc(${spacingVars['--spacing-12']} * 2)`,
   },
 });
 

--- a/apps/docsite/src/components/SiteFooter.tsx
+++ b/apps/docsite/src/components/SiteFooter.tsx
@@ -21,10 +21,10 @@ import {
 } from './logos';
 
 const styles = stylex.create({
-  mobileFooterLinks: {
-    maxWidth: 320,
+  siteFooter: {
+    paddingTop: 'calc(var(--spacing-12) * 2)',
   },
-  logo: {
+  astryxLogo: {
     height: 18,
     width: 'auto',
     display: 'block',
@@ -40,6 +40,9 @@ const styles = stylex.create({
     width: 'auto',
     display: 'block',
     color: 'var(--color-icon-secondary)',
+  },
+  mobileFooterLinks: {
+    maxWidth: 320,
   },
 });
 
@@ -139,7 +142,11 @@ export function SiteFooter() {
   const copyright = `\u00A9${year} Meta Platforms, Inc.`;
 
   const astryxLogo = (
-    <AstryxLogo role="img" aria-label="Astryx" {...stylex.props(styles.logo)} />
+    <AstryxLogo
+      role="img"
+      aria-label="Astryx"
+      {...stylex.props(styles.astryxLogo)}
+    />
   );
 
   const metaOpenSourceLink = (
@@ -158,7 +165,7 @@ export function SiteFooter() {
     // On narrow viewports the horizontal rows can't fit side by side, so we
     // stack the three regions vertically and let the link lists wrap.
     return (
-      <Section role="contentinfo" padding={6}>
+      <Section role="contentinfo" padding={6} xstyle={styles.siteFooter}>
         <VStack gap={6}>
           <VStack gap={6} hAlign="center">
             {astryxLogo}
@@ -192,7 +199,7 @@ export function SiteFooter() {
   }
 
   return (
-    <Section role="contentinfo" padding={6}>
+    <Section role="contentinfo" padding={6} xstyle={styles.siteFooter}>
       <VStack gap={4}>
         <Grid columns={5} align="center">
           {astryxLogo}

--- a/apps/docsite/src/components/blog/AuthorByline.tsx
+++ b/apps/docsite/src/components/blog/AuthorByline.tsx
@@ -13,9 +13,9 @@
  */
 
 import * as stylex from '@stylexjs/stylex';
-import {XDSAvatar} from '@xds/core/Avatar';
-import {XDSText} from '@xds/core/Text';
-import {XDSHStack} from '@xds/core/Layout';
+import {Avatar} from '@xds/core/Avatar';
+import {Text} from '@xds/core/Text';
+import {HStack} from '@xds/core/Layout';
 import {resolveAuthor} from '../../content/blog/authors';
 
 export function formatDate(iso: string): string {
@@ -62,48 +62,48 @@ export function AuthorByline({
   const names = resolved.map(a => a.name).join(', ');
 
   return (
-    <XDSHStack gap={2} align="center">
-      <XDSHStack gap={0} align="center">
+    <HStack gap={2} align="center">
+      <HStack gap={0} align="center">
         {resolved.map(author => (
-          <XDSAvatar
+          <Avatar
             key={author.key}
             src={author.avatar}
             name={author.name}
             size={avatarSize}
           />
         ))}
-      </XDSHStack>
-      <XDSHStack gap={1} align="center">
-        <XDSText type="supporting" color="secondary">
+      </HStack>
+      <HStack gap={1} align="center">
+        <Text type="supporting" color="secondary">
           {names}
-        </XDSText>
-        <XDSText type="supporting" color="secondary" xstyle={styles.dot}>
+        </Text>
+        <Text type="supporting" color="secondary" xstyle={styles.dot}>
           ·
-        </XDSText>
-        <XDSText type="supporting" color="secondary">
+        </Text>
+        <Text type="supporting" color="secondary">
           {formatDate(date)}
-        </XDSText>
+        </Text>
         {variant === 'full' && updatedAt ? (
           <>
-            <XDSText type="supporting" color="secondary" xstyle={styles.dot}>
+            <Text type="supporting" color="secondary" xstyle={styles.dot}>
               ·
-            </XDSText>
-            <XDSText type="supporting" color="secondary">
+            </Text>
+            <Text type="supporting" color="secondary">
               Updated {formatDate(updatedAt)}
-            </XDSText>
+            </Text>
           </>
         ) : null}
         {readingTimeMinutes ? (
           <>
-            <XDSText type="supporting" color="secondary" xstyle={styles.dot}>
+            <Text type="supporting" color="secondary" xstyle={styles.dot}>
               ·
-            </XDSText>
-            <XDSText type="supporting" color="secondary">
+            </Text>
+            <Text type="supporting" color="secondary">
               {readingTimeMinutes} min read
-            </XDSText>
+            </Text>
           </>
         ) : null}
-      </XDSHStack>
-    </XDSHStack>
+      </HStack>
+    </HStack>
   );
 }

--- a/apps/docsite/src/components/blog/AuthorByline.tsx
+++ b/apps/docsite/src/components/blog/AuthorByline.tsx
@@ -16,6 +16,7 @@ import * as stylex from '@stylexjs/stylex';
 import {Avatar} from '@xds/core/Avatar';
 import {Text} from '@xds/core/Text';
 import {HStack} from '@xds/core/Layout';
+import {Divider} from '@xds/core/Divider';
 import {resolveAuthor} from '../../content/blog/authors';
 
 export function formatDate(iso: string): string {
@@ -36,8 +37,8 @@ const styles = stylex.create({
   names: {
     display: 'inline',
   },
-  dot: {
-    opacity: 0.5,
+  divider: {
+    height: '0.75em',
   },
 });
 
@@ -48,6 +49,8 @@ export interface AuthorBylineProps {
   readingTimeMinutes?: number;
   /** 'compact' for cards, 'full' for article headers. */
   variant?: 'compact' | 'full';
+  /** Optional class on the root row (e.g. for parent-driven hover styling). */
+  className?: string;
 }
 
 export function AuthorByline({
@@ -56,38 +59,34 @@ export function AuthorByline({
   updatedAt,
   readingTimeMinutes,
   variant = 'compact',
+  className,
 }: AuthorBylineProps) {
   const resolved = authors.map(resolveAuthor);
-  const avatarSize = variant === 'full' ? 'small' : 'tiny';
   const names = resolved.map(a => a.name).join(', ');
 
   return (
-    <HStack gap={2} align="center">
+    <HStack gap={2} align="center" className={className}>
       <HStack gap={0} align="center">
         {resolved.map(author => (
           <Avatar
             key={author.key}
             src={author.avatar}
             name={author.name}
-            size={avatarSize}
+            size="tiny"
           />
         ))}
       </HStack>
-      <HStack gap={1} align="center">
+      <HStack gap={2} align="center">
         <Text type="supporting" color="secondary">
           {names}
         </Text>
-        <Text type="supporting" color="secondary" xstyle={styles.dot}>
-          ·
-        </Text>
+        <Divider orientation="vertical" xstyle={styles.divider} />
         <Text type="supporting" color="secondary">
           {formatDate(date)}
         </Text>
         {variant === 'full' && updatedAt ? (
           <>
-            <Text type="supporting" color="secondary" xstyle={styles.dot}>
-              ·
-            </Text>
+            <Divider orientation="vertical" xstyle={styles.divider} />
             <Text type="supporting" color="secondary">
               Updated {formatDate(updatedAt)}
             </Text>
@@ -95,9 +94,7 @@ export function AuthorByline({
         ) : null}
         {readingTimeMinutes ? (
           <>
-            <Text type="supporting" color="secondary" xstyle={styles.dot}>
-              ·
-            </Text>
+            <Divider orientation="vertical" xstyle={styles.divider} />
             <Text type="supporting" color="secondary">
               {readingTimeMinutes} min read
             </Text>

--- a/apps/docsite/src/components/blog/BlogArticle.tsx
+++ b/apps/docsite/src/components/blog/BlogArticle.tsx
@@ -4,9 +4,10 @@
  * @file BlogArticle.tsx
  *
  * Article layout matching the docs page typography: a centered, readable column
- * (maxWidth 800) with a display-1 title, large regular-weight dek, byline, a
- * neutral cover placeholder, the prose body (rendered via Markdown), optional
- * curated related-doc links, and a link back to the blog index. No sidebar.
+ * (maxWidth 800) with a breadcrumb trail (Blog / post type), a display-1 title,
+ * large regular-weight dek, byline, a neutral cover placeholder, the prose body
+ * (rendered via Markdown), optional curated related-doc links, and a link back to
+ * the blog index. No sidebar.
  *
  * @input  post (BlogPost)
  * @output The full article view
@@ -17,8 +18,11 @@ import * as stylex from '@stylexjs/stylex';
 import {Markdown} from '@xds/core/Markdown';
 import {Text, Heading} from '@xds/core/Text';
 import {VStack, HStack} from '@xds/core/Layout';
+import {Grid} from '@xds/core/Grid';
+import {Icon} from '@xds/core/Icon';
 import {Section} from '@xds/core/Section';
 import {Badge} from '@xds/core/Badge';
+import {Breadcrumbs, BreadcrumbItem} from '@xds/core/Breadcrumbs';
 import {Divider} from '@xds/core/Divider';
 import {Link} from '@xds/core/Link';
 import {ClickableCard} from '@xds/core/ClickableCard';
@@ -60,12 +64,12 @@ export function BlogArticle({post}: BlogArticleProps) {
       <VStack gap={10}>
         {/* Header — matches the docs page treatment */}
         <VStack gap={4}>
-          <Link href="/blog" label="Back to blog">
-            ← Blog
-          </Link>
-          <HStack gap={1} align="center" xstyle={styles.tagRow}>
-            <Badge label={POST_TYPE_LABELS[post.type]} variant="neutral" />
-          </HStack>
+          <Breadcrumbs>
+            <BreadcrumbItem href="/blog">Blog</BreadcrumbItem>
+            <BreadcrumbItem isCurrent>
+              {POST_TYPE_LABELS[post.type]}
+            </BreadcrumbItem>
+          </Breadcrumbs>
           <Heading level={1} type="display-1">
             {post.title}
           </Heading>
@@ -104,33 +108,36 @@ export function BlogArticle({post}: BlogArticleProps) {
           </HStack>
         ) : null}
 
-        {/* Related docs — clickable cards, not styled links */}
+        {/* Related content */}
         {post.relatedDocs && post.relatedDocs.length > 0 ? (
-          <VStack gap={4}>
+          <VStack gap={6}>
             <Divider />
             <Heading level={2} type="display-3">
               Related
             </Heading>
-            <VStack gap={2}>
+            {/* minWidth caps this at 2 columns within the ~752px article
+                column; 'fit' lets a lone card stretch to fill when it wraps to
+                one column (an explicit `max` would cap track width at 50% and
+                prevent the fill). */}
+            <Grid columns={{minWidth: 280, repeat: 'fill'}} gap={2}>
               {post.relatedDocs.map(doc => (
                 <ClickableCard
                   key={doc.href}
                   href={doc.href}
                   label={doc.title}
+                  padding={3}
                   variant="muted">
-                  <Text type="body" weight="medium">
-                    {doc.title}
-                  </Text>
+                  <HStack justify="between" align="center" gap={2}>
+                    <Text type="body" weight="medium">
+                      {doc.title}
+                    </Text>
+                    <Icon icon="chevronRight" size="sm" color="secondary" />
+                  </HStack>
                 </ClickableCard>
               ))}
-            </VStack>
+            </Grid>
           </VStack>
         ) : null}
-
-        <Divider />
-        <Link href="/blog" label="Back to all posts">
-          ← Back to all posts
-        </Link>
       </VStack>
     </Section>
   );

--- a/apps/docsite/src/components/blog/BlogArticle.tsx
+++ b/apps/docsite/src/components/blog/BlogArticle.tsx
@@ -24,7 +24,6 @@ import {Section} from '@xds/core/Section';
 import {Badge} from '@xds/core/Badge';
 import {Breadcrumbs, BreadcrumbItem} from '@xds/core/Breadcrumbs';
 import {Divider} from '@xds/core/Divider';
-import {Link} from '@xds/core/Link';
 import {ClickableCard} from '@xds/core/ClickableCard';
 import type {BlogPost} from '../../lib/blog/schema';
 import {POST_TYPE_LABELS} from '../../lib/blog/schema';

--- a/apps/docsite/src/components/blog/BlogArticle.tsx
+++ b/apps/docsite/src/components/blog/BlogArticle.tsx
@@ -5,7 +5,7 @@
  *
  * Article layout matching the docs page typography: a centered, readable column
  * (maxWidth 800) with a display-1 title, large regular-weight dek, byline, a
- * neutral cover placeholder, the prose body (rendered via XDSMarkdown), optional
+ * neutral cover placeholder, the prose body (rendered via Markdown), optional
  * curated related-doc links, and a link back to the blog index. No sidebar.
  *
  * @input  post (BlogPost)
@@ -14,15 +14,14 @@
  */
 
 import * as stylex from '@stylexjs/stylex';
-import {XDSMarkdown} from '@xds/core/Markdown';
-import {XDSText, XDSHeading} from '@xds/core/Text';
-import {XDSVStack, XDSHStack} from '@xds/core/Layout';
-import {XDSSection} from '@xds/core/Section';
-import {XDSBadge} from '@xds/core/Badge';
-import {XDSDivider} from '@xds/core/Divider';
-import {XDSLink} from '@xds/core/Link';
-import {XDSClickableCard} from '@xds/core/ClickableCard';
-import {spacingVars} from '@xds/core/theme/tokens.stylex';
+import {Markdown} from '@xds/core/Markdown';
+import {Text, Heading} from '@xds/core/Text';
+import {VStack, HStack} from '@xds/core/Layout';
+import {Section} from '@xds/core/Section';
+import {Badge} from '@xds/core/Badge';
+import {Divider} from '@xds/core/Divider';
+import {Link} from '@xds/core/Link';
+import {ClickableCard} from '@xds/core/ClickableCard';
 import type {BlogPost} from '../../lib/blog/schema';
 import {POST_TYPE_LABELS} from '../../lib/blog/schema';
 import {AuthorByline} from './AuthorByline';
@@ -30,7 +29,6 @@ import {AuthorByline} from './AuthorByline';
 const styles = stylex.create({
   section: {
     marginInline: 'auto',
-    paddingBottom: `calc(${spacingVars['--spacing-12']} * 2)`,
   },
   // Neutral cover placeholder (cover generator deferred). Calm, theme-driven.
   cover: {
@@ -58,22 +56,22 @@ export interface BlogArticleProps {
 
 export function BlogArticle({post}: BlogArticleProps) {
   return (
-    <XDSSection maxWidth={800} padding={6} xstyle={styles.section}>
-      <XDSVStack gap={10}>
+    <Section maxWidth={800} padding={6} xstyle={styles.section}>
+      <VStack gap={10}>
         {/* Header — matches the docs page treatment */}
-        <XDSVStack gap={4}>
-          <XDSLink href="/blog" label="Back to blog">
+        <VStack gap={4}>
+          <Link href="/blog" label="Back to blog">
             ← Blog
-          </XDSLink>
-          <XDSHStack gap={1} align="center" xstyle={styles.tagRow}>
-            <XDSBadge label={POST_TYPE_LABELS[post.type]} variant="neutral" />
-          </XDSHStack>
-          <XDSHeading level={1} type="display-1">
+          </Link>
+          <HStack gap={1} align="center" xstyle={styles.tagRow}>
+            <Badge label={POST_TYPE_LABELS[post.type]} variant="neutral" />
+          </HStack>
+          <Heading level={1} type="display-1">
             {post.title}
-          </XDSHeading>
-          <XDSText type="large" weight="normal" color="secondary">
+          </Heading>
+          <Text type="large" weight="normal" color="secondary">
             {post.description}
-          </XDSText>
+          </Text>
           <AuthorByline
             authors={post.authors}
             date={post.date}
@@ -81,8 +79,8 @@ export function BlogArticle({post}: BlogArticleProps) {
             readingTimeMinutes={post.readingTimeMinutes}
             variant="full"
           />
-          <XDSDivider />
-        </XDSVStack>
+          <Divider />
+        </VStack>
 
         {/* Cover — custom image when provided, else a neutral placeholder */}
         {post.coverImage ? (
@@ -96,44 +94,44 @@ export function BlogArticle({post}: BlogArticleProps) {
         )}
 
         {/* Body */}
-        <XDSMarkdown headingLevelStart={2}>{post.body}</XDSMarkdown>
+        <Markdown headingLevelStart={2}>{post.body}</Markdown>
 
         {post.tags.length > 0 ? (
-          <XDSHStack gap={1} xstyle={styles.tagRow}>
+          <HStack gap={1} xstyle={styles.tagRow}>
             {post.tags.map(tag => (
-              <XDSBadge key={tag} label={tag} variant="neutral" />
+              <Badge key={tag} label={tag} variant="neutral" />
             ))}
-          </XDSHStack>
+          </HStack>
         ) : null}
 
         {/* Related docs — clickable cards, not styled links */}
         {post.relatedDocs && post.relatedDocs.length > 0 ? (
-          <XDSVStack gap={4}>
-            <XDSDivider />
-            <XDSHeading level={2} type="display-3">
+          <VStack gap={4}>
+            <Divider />
+            <Heading level={2} type="display-3">
               Related
-            </XDSHeading>
-            <XDSVStack gap={2}>
+            </Heading>
+            <VStack gap={2}>
               {post.relatedDocs.map(doc => (
-                <XDSClickableCard
+                <ClickableCard
                   key={doc.href}
                   href={doc.href}
                   label={doc.title}
                   variant="muted">
-                  <XDSText type="body" weight="medium">
+                  <Text type="body" weight="medium">
                     {doc.title}
-                  </XDSText>
-                </XDSClickableCard>
+                  </Text>
+                </ClickableCard>
               ))}
-            </XDSVStack>
-          </XDSVStack>
+            </VStack>
+          </VStack>
         ) : null}
 
-        <XDSDivider />
-        <XDSLink href="/blog" label="Back to all posts">
+        <Divider />
+        <Link href="/blog" label="Back to all posts">
           ← Back to all posts
-        </XDSLink>
-      </XDSVStack>
-    </XDSSection>
+        </Link>
+      </VStack>
+    </Section>
   );
 }

--- a/apps/docsite/src/components/blog/BlogCard.module.css
+++ b/apps/docsite/src/components/blog/BlogCard.module.css
@@ -1,0 +1,29 @@
+/* Copyright (c) Meta Platforms, Inc. and affiliates. */
+
+/*
+ * Hover affordances for BlogCard, driven by the card Link's :hover. Plain
+ * descendant selectors — no StyleX marker/ancestor machinery needed. Theme
+ * tokens (--color-*, --duration-*, --ease-*) are real CSS custom properties.
+ */
+
+.cover::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background-color: transparent;
+  transition: background-color var(--duration-fast) var(--ease-standard);
+}
+
+@media (hover: hover) {
+  /* Subtle currentColor tint over the cover, mirroring ClickableCard. */
+  .card:hover .cover::after {
+    background-color: color-mix(in srgb, currentColor 5%, transparent);
+  }
+
+  /* Promote secondary text to the primary text color on hover. */
+  .card:hover .description,
+  .card:hover .byline * {
+    color: var(--color-text-primary);
+  }
+}

--- a/apps/docsite/src/components/blog/BlogCard.tsx
+++ b/apps/docsite/src/components/blog/BlogCard.tsx
@@ -3,10 +3,11 @@
 /**
  * @file BlogCard.tsx
  *
- * A blog index card built on ClickableCard: a neutral
- * cover placeholder on top, then type badge, title, description excerpt,
- * byline, and tag chips. The whole card navigates to the post; nested elements
- * (tags, author links) remain independently interactive.
+ * A blog index card built on Link: a neutral
+ * cover placeholder on top, then title, description excerpt, byline, and a
+ * chip row whose first badge is the post type followed by tag chips. The whole
+ * card navigates to the post; nested elements (tags, author links) remain
+ * independently interactive.
  *
  * The `feature` variant gives the latest post a larger treatment. This is
  * derived from sort order by the index page — never from per-post metadata.
@@ -20,32 +21,40 @@ import * as stylex from '@stylexjs/stylex';
 import {Text, Heading} from '@xds/core/Text';
 import {VStack, HStack} from '@xds/core/Layout';
 import {Badge} from '@xds/core/Badge';
-import {ClickableCard} from '@xds/core/ClickableCard';
+import {Link} from '@xds/core/Link';
+import {AspectRatio} from '@xds/core/AspectRatio';
 import type {BlogPost} from '../../lib/blog/schema';
 import {POST_TYPE_LABELS} from '../../lib/blog/schema';
 import {AuthorByline} from './AuthorByline';
+import css from './BlogCard.module.css';
 
 const styles = stylex.create({
   card: {
+    display: 'block',
+    width: '100%',
     height: '100%',
+    color: 'inherit',
+    textDecoration: {
+      default: 'none',
+      ':hover': 'none',
+    },
   },
   inner: {
     height: '100%',
   },
   // Neutral cover placeholder (cover generator deferred). Calm, theme-driven.
-  cover: (feature: boolean) => ({
-    width: '100%',
-    aspectRatio: feature ? '16 / 7' : '16 / 9',
+  // Hover tint lives in BlogCard.module.css (.cover::after).
+  cover: {
     borderRadius: 'var(--radius-container)',
     backgroundColor: 'var(--color-background-muted)',
     border: '1px solid var(--color-border)',
-  }),
+    overflow: 'hidden',
+  },
   coverImg: {
     width: '100%',
     height: '100%',
     objectFit: 'cover',
     display: 'block',
-    borderRadius: 'var(--radius-container)',
   },
   excerpt: {
     display: '-webkit-box',
@@ -53,7 +62,7 @@ const styles = stylex.create({
     WebkitBoxOrient: 'vertical',
     overflow: 'hidden',
   },
-  tagRow: {
+  postTags: {
     flexWrap: 'wrap',
   },
 });
@@ -65,28 +74,33 @@ export interface BlogCardProps {
 
 export function BlogCard({post, feature = false}: BlogCardProps) {
   return (
-    <ClickableCard
+    <Link
       href={`/blog/${post.slug}`}
       label={post.title}
-      padding={4}
-      xstyle={styles.card}>
+      color="inherit"
+      display="block"
+      xstyle={styles.card}
+      className={css.card}>
       <VStack gap={3} xstyle={styles.inner}>
-        {post.coverImage ? (
-          <img
-            src={post.coverImage}
-            alt={post.coverAlt ?? ''}
-            {...stylex.props(styles.cover(feature), styles.coverImg)}
-          />
-        ) : (
-          <div {...stylex.props(styles.cover(feature))} aria-hidden="true" />
-        )}
-        <VStack gap={2}>
-          <HStack gap={1} align="center" xstyle={styles.tagRow}>
-            <Badge label={POST_TYPE_LABELS[post.type]} variant="neutral" />
-          </HStack>
+        <AspectRatio ratio={16 / 9} xstyle={styles.cover} className={css.cover}>
+          {post.coverImage ? (
+            <img
+              src={post.coverImage}
+              alt={post.coverAlt ?? ''}
+              {...stylex.props(styles.coverImg)}
+            />
+          ) : (
+            <div aria-hidden="true" />
+          )}
+        </AspectRatio>
+        <VStack gap={3}>
           <VStack gap={1}>
-            <Heading level={feature ? 2 : 3}>{post.title}</Heading>
-            <Text type="body" color="secondary" xstyle={styles.excerpt}>
+            <Heading level={feature ? 1 : 3}>{post.title}</Heading>
+            <Text
+              type="body"
+              color="secondary"
+              xstyle={styles.excerpt}
+              className={css.description}>
               {post.description}
             </Text>
           </VStack>
@@ -95,16 +109,16 @@ export function BlogCard({post, feature = false}: BlogCardProps) {
             date={post.date}
             readingTimeMinutes={post.readingTimeMinutes}
             variant="compact"
+            className={css.byline}
           />
-          {post.tags.length > 0 ? (
-            <HStack gap={1} xstyle={styles.tagRow}>
-              {post.tags.map(tag => (
-                <Badge key={tag} label={tag} variant="neutral" />
-              ))}
-            </HStack>
-          ) : null}
+          <HStack gap={1} xstyle={styles.postTags}>
+            <Badge label={POST_TYPE_LABELS[post.type]} variant="cyan" />
+            {post.tags.map(tag => (
+              <Badge key={tag} label={tag} variant="neutral" />
+            ))}
+          </HStack>
         </VStack>
       </VStack>
-    </ClickableCard>
+    </Link>
   );
 }

--- a/apps/docsite/src/components/blog/BlogCard.tsx
+++ b/apps/docsite/src/components/blog/BlogCard.tsx
@@ -3,7 +3,7 @@
 /**
  * @file BlogCard.tsx
  *
- * A blog index card built on XDSClickableCard: a neutral
+ * A blog index card built on ClickableCard: a neutral
  * cover placeholder on top, then type badge, title, description excerpt,
  * byline, and tag chips. The whole card navigates to the post; nested elements
  * (tags, author links) remain independently interactive.
@@ -17,10 +17,10 @@
  */
 
 import * as stylex from '@stylexjs/stylex';
-import {XDSText, XDSHeading} from '@xds/core/Text';
-import {XDSVStack, XDSHStack} from '@xds/core/Layout';
-import {XDSBadge} from '@xds/core/Badge';
-import {XDSClickableCard} from '@xds/core/ClickableCard';
+import {Text, Heading} from '@xds/core/Text';
+import {VStack, HStack} from '@xds/core/Layout';
+import {Badge} from '@xds/core/Badge';
+import {ClickableCard} from '@xds/core/ClickableCard';
 import type {BlogPost} from '../../lib/blog/schema';
 import {POST_TYPE_LABELS} from '../../lib/blog/schema';
 import {AuthorByline} from './AuthorByline';
@@ -65,12 +65,12 @@ export interface BlogCardProps {
 
 export function BlogCard({post, feature = false}: BlogCardProps) {
   return (
-    <XDSClickableCard
+    <ClickableCard
       href={`/blog/${post.slug}`}
       label={post.title}
       padding={4}
       xstyle={styles.card}>
-      <XDSVStack gap={3} xstyle={styles.inner}>
+      <VStack gap={3} xstyle={styles.inner}>
         {post.coverImage ? (
           <img
             src={post.coverImage}
@@ -80,16 +80,16 @@ export function BlogCard({post, feature = false}: BlogCardProps) {
         ) : (
           <div {...stylex.props(styles.cover(feature))} aria-hidden="true" />
         )}
-        <XDSVStack gap={2}>
-          <XDSHStack gap={1} align="center" xstyle={styles.tagRow}>
-            <XDSBadge label={POST_TYPE_LABELS[post.type]} variant="neutral" />
-          </XDSHStack>
-          <XDSVStack gap={1}>
-            <XDSHeading level={feature ? 2 : 3}>{post.title}</XDSHeading>
-            <XDSText type="body" color="secondary" xstyle={styles.excerpt}>
+        <VStack gap={2}>
+          <HStack gap={1} align="center" xstyle={styles.tagRow}>
+            <Badge label={POST_TYPE_LABELS[post.type]} variant="neutral" />
+          </HStack>
+          <VStack gap={1}>
+            <Heading level={feature ? 2 : 3}>{post.title}</Heading>
+            <Text type="body" color="secondary" xstyle={styles.excerpt}>
               {post.description}
-            </XDSText>
-          </XDSVStack>
+            </Text>
+          </VStack>
           <AuthorByline
             authors={post.authors}
             date={post.date}
@@ -97,14 +97,14 @@ export function BlogCard({post, feature = false}: BlogCardProps) {
             variant="compact"
           />
           {post.tags.length > 0 ? (
-            <XDSHStack gap={1} xstyle={styles.tagRow}>
+            <HStack gap={1} xstyle={styles.tagRow}>
               {post.tags.map(tag => (
-                <XDSBadge key={tag} label={tag} variant="neutral" />
+                <Badge key={tag} label={tag} variant="neutral" />
               ))}
-            </XDSHStack>
+            </HStack>
           ) : null}
-        </XDSVStack>
-      </XDSVStack>
-    </XDSClickableCard>
+        </VStack>
+      </VStack>
+    </ClickableCard>
   );
 }

--- a/apps/docsite/src/components/blog/BlogIndex.tsx
+++ b/apps/docsite/src/components/blog/BlogIndex.tsx
@@ -23,23 +23,16 @@ import {Text, Heading} from '@xds/core/Text';
 import {VStack} from '@xds/core/Layout';
 import {Section} from '@xds/core/Section';
 import {Grid} from '@xds/core/Grid';
-import {Carousel} from '@xds/core/Carousel';
-import {TabList, Tab} from '@xds/core/TabList';
+import {ToggleButton, ToggleButtonGroup} from '@xds/core/ToggleButton';
+import {EmptyState} from '@xds/core/EmptyState';
 import type {BlogPost, BlogPostType} from '../../lib/blog/schema';
 import {POST_TYPE_LABELS} from '../../lib/blog/schema';
 import {BlogCard} from './BlogCard';
 
 const styles = stylex.create({
-  header: {
-    maxWidth: 720,
-    marginInline: 'auto',
-  },
-  filterRow: {
-    marginBottom: 4,
-  },
-  empty: {
-    paddingBlock: 48,
-    textAlign: 'center',
+  typeFilter: {
+    flexWrap: 'wrap',
+    justifyContent: 'center',
   },
 });
 
@@ -73,55 +66,51 @@ export function BlogIndex({posts, availableTypes}: BlogIndexProps) {
   const restPosts = showFeature ? filtered.slice(1) : filtered;
 
   return (
-    <Section maxWidth={1200} padding={6} style={{marginInline: 'auto'}}>
-      <VStack gap={6}>
-        <VStack gap={4} xstyle={styles.header}>
+    <Section maxWidth={800} padding={6} style={{marginInline: 'auto'}}>
+      <VStack gap={10}>
+        {/* Header */}
+        <VStack gap={2}>
           <Heading level={1} type="display-1" justify="center">
             Blog
           </Heading>
-          <Text type="large" weight="normal" color="secondary" justify="center">
-            Notes on building Astryx — releases, guides, stories, and
-            perspectives on designing a system for humans and agents.
+          <Text weight="normal" color="secondary" justify="center">
+            Releases, guides, and stories on building Astryx for humans and
+            agents.
           </Text>
         </VStack>
 
         {availableTypes.length > 1 ? (
-          <Carousel gap={0}>
-            <TabList
-              value={activeType}
-              onChange={v => setActiveType(v as 'all' | BlogPostType)}
-              size="md"
-              xstyle={styles.filterRow}>
-              <Tab value="all" label={`All (${counts.all})`} />
-              {availableTypes.map(t => (
-                <Tab
-                  key={t}
-                  value={t}
-                  label={`${POST_TYPE_LABELS[t]} (${counts[t]})`}
-                />
-              ))}
-            </TabList>
-          </Carousel>
+          <ToggleButtonGroup
+            label="Filter posts by type"
+            value={activeType}
+            onChange={value =>
+              setActiveType((value as 'all' | BlogPostType) ?? 'all')
+            }
+            xstyle={styles.typeFilter}>
+            <ToggleButton value="all" label={`All (${counts.all})`} />
+            {availableTypes.map(t => (
+              <ToggleButton
+                key={t}
+                value={t}
+                label={`${POST_TYPE_LABELS[t]} (${counts[t]})`}
+              />
+            ))}
+          </ToggleButtonGroup>
         ) : null}
 
         {filtered.length === 0 ? (
-          <div {...stylex.props(styles.empty)}>
-            <Text type="body" color="secondary">
-              No posts yet. Check back soon.
-            </Text>
-          </div>
+          <EmptyState
+            title="No posts yet"
+            description="Check back soon for releases, guides, and stories."
+          />
         ) : (
-          <VStack gap={6}>
-            {featurePost ? (
-              <Grid columns={1} gap={4}>
-                <BlogCard post={featurePost} feature />
-              </Grid>
-            ) : null}
+          <VStack gap={10}>
+            {featurePost ? <BlogCard post={featurePost} feature /> : null}
             {restPosts.length > 0 ? (
               <Grid
                 columns={{minWidth: 320, repeat: 'fill'}}
-                gap={4}
-                rowGap={6}>
+                gap={5}
+                rowGap={10}>
                 {restPosts.map(post => (
                   <BlogCard key={post.slug} post={post} />
                 ))}

--- a/apps/docsite/src/components/blog/BlogIndex.tsx
+++ b/apps/docsite/src/components/blog/BlogIndex.tsx
@@ -19,12 +19,12 @@
 
 import {useState, useMemo} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {XDSText, XDSHeading} from '@xds/core/Text';
-import {XDSVStack} from '@xds/core/Layout';
-import {XDSSection} from '@xds/core/Section';
-import {XDSGrid} from '@xds/core/Grid';
-import {XDSCarousel} from '@xds/core/Carousel';
-import {XDSTabList, XDSTab} from '@xds/core/TabList';
+import {Text, Heading} from '@xds/core/Text';
+import {VStack} from '@xds/core/Layout';
+import {Section} from '@xds/core/Section';
+import {Grid} from '@xds/core/Grid';
+import {Carousel} from '@xds/core/Carousel';
+import {TabList, Tab} from '@xds/core/TabList';
 import type {BlogPost, BlogPostType} from '../../lib/blog/schema';
 import {POST_TYPE_LABELS} from '../../lib/blog/schema';
 import {BlogCard} from './BlogCard';
@@ -32,6 +32,7 @@ import {BlogCard} from './BlogCard';
 const styles = stylex.create({
   header: {
     maxWidth: 720,
+    marginInline: 'auto',
   },
   filterRow: {
     marginBottom: 4,
@@ -72,63 +73,63 @@ export function BlogIndex({posts, availableTypes}: BlogIndexProps) {
   const restPosts = showFeature ? filtered.slice(1) : filtered;
 
   return (
-    <XDSSection maxWidth={1100} padding={6}>
-      <XDSVStack gap={6}>
-        <XDSVStack gap={4} xstyle={styles.header}>
-          <XDSHeading level={1} type="display-1">
+    <Section maxWidth={1200} padding={6} style={{marginInline: 'auto'}}>
+      <VStack gap={6}>
+        <VStack gap={4} xstyle={styles.header}>
+          <Heading level={1} type="display-1" justify="center">
             Blog
-          </XDSHeading>
-          <XDSText type="large" weight="normal" color="secondary">
+          </Heading>
+          <Text type="large" weight="normal" color="secondary" justify="center">
             Notes on building Astryx — releases, guides, stories, and
             perspectives on designing a system for humans and agents.
-          </XDSText>
-        </XDSVStack>
+          </Text>
+        </VStack>
 
         {availableTypes.length > 1 ? (
-          <XDSCarousel gap={0}>
-            <XDSTabList
+          <Carousel gap={0}>
+            <TabList
               value={activeType}
               onChange={v => setActiveType(v as 'all' | BlogPostType)}
               size="md"
               xstyle={styles.filterRow}>
-              <XDSTab value="all" label={`All (${counts.all})`} />
+              <Tab value="all" label={`All (${counts.all})`} />
               {availableTypes.map(t => (
-                <XDSTab
+                <Tab
                   key={t}
                   value={t}
                   label={`${POST_TYPE_LABELS[t]} (${counts[t]})`}
                 />
               ))}
-            </XDSTabList>
-          </XDSCarousel>
+            </TabList>
+          </Carousel>
         ) : null}
 
         {filtered.length === 0 ? (
           <div {...stylex.props(styles.empty)}>
-            <XDSText type="body" color="secondary">
+            <Text type="body" color="secondary">
               No posts yet. Check back soon.
-            </XDSText>
+            </Text>
           </div>
         ) : (
-          <XDSVStack gap={6}>
+          <VStack gap={6}>
             {featurePost ? (
-              <XDSGrid columns={1} gap={4}>
+              <Grid columns={1} gap={4}>
                 <BlogCard post={featurePost} feature />
-              </XDSGrid>
+              </Grid>
             ) : null}
             {restPosts.length > 0 ? (
-              <XDSGrid
+              <Grid
                 columns={{minWidth: 320, repeat: 'fill'}}
                 gap={4}
                 rowGap={6}>
                 {restPosts.map(post => (
                   <BlogCard key={post.slug} post={post} />
                 ))}
-              </XDSGrid>
+              </Grid>
             ) : null}
-          </XDSVStack>
+          </VStack>
         )}
-      </XDSVStack>
-    </XDSSection>
+      </VStack>
+    </Section>
   );
 }

--- a/apps/docsite/src/components/component-detail/ComponentDetailClient.tsx
+++ b/apps/docsite/src/components/component-detail/ComponentDetailClient.tsx
@@ -28,13 +28,11 @@ import type {ComponentEntry} from '../../generated/componentRegistry';
 import type {BlockEntry} from '../../generated/blockRegistry';
 import {showcaseRegistry} from '../../generated/showcaseRegistry';
 import {exampleRegistry} from '../../generated/exampleRegistry';
-import {spacingVars} from '@xds/core/theme/tokens.stylex';
 import {trackNavigate} from '../../lib/analytics';
 
 const styles = stylex.create({
   section: {
     marginInline: 'auto',
-    paddingBottom: `calc(${spacingVars['--spacing-12']} * 2)`,
   },
 });
 

--- a/apps/docsite/src/components/docs/DocPageLayout.tsx
+++ b/apps/docsite/src/components/docs/DocPageLayout.tsx
@@ -13,12 +13,9 @@ import {Text, Heading} from '@xds/core/Text';
 import {VStack} from '@xds/core/Layout';
 import {Section} from '@xds/core/Section';
 import {Divider} from '@xds/core/Divider';
-import {spacingVars} from '@xds/core/theme/tokens.stylex';
-
 const styles = stylex.create({
   section: {
     marginInline: 'auto',
-    paddingBottom: `calc(${spacingVars['--spacing-12']} * 2)`,
   },
 });
 

--- a/apps/docsite/src/content/blog/posts/introducing-astryx.md
+++ b/apps/docsite/src/content/blog/posts/introducing-astryx.md
@@ -20,7 +20,7 @@ Open source is how the best ideas in our industry travel. The tools we reach for
 
 We're excited to introduce Astryx by Meta, an open source design system that's AI fluent and fully customizable without dependencies. It's a complete, production-ready (and growing) toolkit with 150+ accessible components, brand-level theming, dark mode, ready-to-ship templates, and a CLI – all as one cohesive system, built on React and StyleX.
 
-Astryx isn't new. It's matured within Meta for the last eight years and powers over 13,000 apps, shaped by the designers, engineers, and product teams who depend on it every day. What's new is that it's now yours, too.
+Astryx has matured within Meta for the last eight years and powers over 13,000 apps. It's shaped by the designers, engineers, and product teams who depend on it every day and now, it's yours, too.
 
 ## Start anywhere, change anything, and ship faster
 
@@ -32,4 +32,4 @@ Astryx is built to end that trade-off. The system controls behavior, accessibili
 
 The way we build software is changing, and Astryx is designed for people and the agents building alongside them. Design systems have historically been designed for human consumption but as more code is written by agents, we have to rethink how design systems are structured and the role that they play. Astryx was built ground-up to be AI-operable, opposed to retrofitting existing design systems to play nicely with agent behaviors. It's an open source design system built for how we build in this new world.
 
-Astryx is in Beta and ready for you to build with today. Try it out at [astryxdesign.com](https://astryxdesign.com) and on [GitHub](https://github.com/facebookexperimental/xds).
+Astryx is in Beta and ready for you to build with today. Try it out at [Astryx Design](TODO_ASTRYX_DESIGN_URL) and on [GitHub](https://github.com/facebook/astryx).


### PR DESCRIPTION
- Added styling fixes for the blog pages.
- Added extra spacing above footer into the SiteFooter component (no longer added to the end of the content on each page).
- Aligned title styling for all pages with large titles (Components, Templates, and Blog).