### PR TITLE
fix(markdown): parse ordered lists using the ) delimiter

### DIFF
--- a/.changeset/markdown-ordered-list-paren-delimiter.md
+++ b/.changeset/markdown-ordered-list-paren-delimiter.md
@@ -1,0 +1,9 @@
+---
+'@xds/core': patch
+---
+
+[fix] Markdown: parse ordered lists using the `)` marker delimiter, not just `.` (#2994)
+
+CommonMark 5.2 allows an ordered-list marker to end in `.` or `)` (e.g. `1)`), but the parser only matched `\d+\. `, so `1) First` lists rendered as literal paragraph text. Lists now capture their delimiter — a `.` → `)` change starts a new list, including across streamed chunks — and paragraph interruption follows CommonMark (only a marker value of 1, including zero-padded like `01.`, may interrupt).
+
+@lexs

--- a/packages/core/src/Markdown/incremental.test.ts
+++ b/packages/core/src/Markdown/incremental.test.ts
@@ -41,6 +41,25 @@ describe('parseMarkdownIncremental', () => {
     }
   });
 
+  it('joins loose ) ordered list across streamed chunks', () => {
+    const text = '1) apple\n\n1) banana\n\n1) cherry\n';
+    const {final} = simulateStreaming(text, 5);
+    expect(final).toHaveLength(1);
+    if (final[0].type === 'list') {
+      expect(final[0].items).toHaveLength(3);
+      expect(final[0].delimiter).toBe(')');
+    }
+  });
+
+  it('does not merge ordered lists with different delimiters across chunks', () => {
+    // A change of delimiter (. -> )) starts a new list (CommonMark 5.2), so
+    // the streamed result must match the full parse and stay two lists.
+    const text = '1. First\n\n2) Second\n';
+    const {final} = simulateStreaming(text, 4);
+    expect(final).toEqual(parseMarkdown(text));
+    expect(final.filter(b => b.type === 'list')).toHaveLength(2);
+  });
+
   it('handles empty input', () => {
     const state = createIncrementalState();
     const result = parseMarkdownIncremental('', state);

--- a/packages/core/src/Markdown/parser.test.ts
+++ b/packages/core/src/Markdown/parser.test.ts
@@ -262,6 +262,65 @@ describe('parseMarkdown', () => {
     }
   });
 
+  it('parses an ordered list using the ) delimiter (CommonMark 5.2)', () => {
+    const result = parseMarkdown('1) First\n2) Second\n3) Third');
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe('list');
+    if (result[0].type === 'list') {
+      expect(result[0].ordered).toBe(true);
+      expect(result[0].start).toBe(1);
+      expect(result[0].items).toHaveLength(3);
+    }
+  });
+
+  it('parses a ) ordered list with a custom start number', () => {
+    const result = parseMarkdown('3) three\n4) four');
+    expect(result[0].type).toBe('list');
+    if (result[0].type === 'list') {
+      expect(result[0].ordered).toBe(true);
+      expect(result[0].start).toBe(3);
+      expect(result[0].items).toHaveLength(2);
+    }
+  });
+
+  it('starts a new list when the ordered delimiter changes', () => {
+    // CommonMark: changing the marker delimiter (. -> )) begins a new list.
+    const result = parseMarkdown('1. First\n2) Second');
+    const lists = result.filter(b => b.type === 'list');
+    expect(lists).toHaveLength(2);
+    if (lists[0].type === 'list' && lists[1].type === 'list') {
+      expect(lists[0].items).toHaveLength(1);
+      expect(lists[1].items).toHaveLength(1);
+      expect(lists[1].start).toBe(2);
+    }
+  });
+
+  it('only lets a marker value of 1 interrupt a paragraph', () => {
+    // CommonMark 5.2: an ordered list interrupts a paragraph only when it
+    // starts at 1 (for either delimiter). A `2)`/`2.` line is lazy paragraph
+    // text.
+    const two = parseMarkdown('Intro\n2) second step');
+    expect(two).toHaveLength(1);
+    expect(two[0].type).toBe('paragraph');
+
+    const one = parseMarkdown('Intro\n1) first step');
+    expect(one.map(b => b.type)).toEqual(['paragraph', 'list']);
+  });
+
+  it('treats a zero-padded value-1 marker as interrupting a paragraph', () => {
+    // The interruption rule is by numeric value, so `01.` / `001)` (value 1)
+    // still start a list, while `0)` (value 0) does not.
+    expect(parseMarkdown('Intro\n01. first').map(b => b.type)).toEqual([
+      'paragraph',
+      'list',
+    ]);
+    expect(parseMarkdown('Intro\n001) first').map(b => b.type)).toEqual([
+      'paragraph',
+      'list',
+    ]);
+    expect(parseMarkdown('Intro\n0) zero')).toHaveLength(1);
+  });
+
   it('joins blank-line-separated same-style items into one loose list', () => {
     // CommonMark §5.3 loose-list: blank lines between items of the same
     // style/indent still form a single list. LLM output very commonly uses

--- a/packages/core/src/Markdown/parser.ts
+++ b/packages/core/src/Markdown/parser.ts
@@ -31,6 +31,8 @@ export type BlockNode =
       type: 'list';
       ordered: boolean;
       start?: number;
+      /** Ordered-list marker delimiter ('.' or ')'). Undefined for bullets. */
+      delimiter?: '.' | ')';
       loose?: boolean;
       items: ListItemNode[];
     }
@@ -769,7 +771,7 @@ function isBlockStart(line: string): boolean {
   if (/^ {0,9}[-*+] /.test(line)) {
     return true;
   }
-  if (/^ {0,9}\d+\. /.test(line)) {
+  if (/^ {0,9}0*1[.)] /.test(line)) {
     return true;
   }
   if (line.includes('|')) {
@@ -867,18 +869,25 @@ function parseList(
 ): {node: BlockNode; nextIndex: number} {
   const items: ListItemNode[] = [];
   const baseIndent = getIndent(lines[startIndex]);
+  // Ordered lists may use either '.' or ')' as the marker delimiter
+  // (CommonMark 5.2). Capture which one this list starts with so its items
+  // must all share it — a change of delimiter starts a new list.
+  const orderedStart = ordered
+    ? lines[startIndex].match(/^ *(\d+)([.)]) /)
+    : null;
+  const delim = orderedStart ? orderedStart[2] : '.';
+  const escDelim = `\\${delim}`;
   const itemPattern = ordered
-    ? new RegExp(`^ {${baseIndent}}\\d+\\. `)
+    ? new RegExp(`^ {${baseIndent}}\\d+${escDelim} `)
     : new RegExp(`^ {${baseIndent}}[-*+] `);
 
-  const startMatch = ordered ? lines[startIndex].match(/^ *(\d+)\./) : null;
-  const start = startMatch ? parseInt(startMatch[1], 10) : undefined;
+  const start = orderedStart ? parseInt(orderedStart[1], 10) : undefined;
 
   let loose = false;
   let index = startIndex;
   while (index < lines.length && itemPattern.test(lines[index])) {
     const content = ordered
-      ? lines[index].replace(/^ *\d+\. /, '')
+      ? lines[index].replace(new RegExp(`^ *\\d+${escDelim} `), '')
       : lines[index].replace(/^ *[-*+] /, '');
 
     const taskMatch = content.match(/^\[([ xX])\] (.*)/);
@@ -931,7 +940,14 @@ function parseList(
     }
   }
   return {
-    node: {type: 'list', ordered, start, loose: loose || undefined, items},
+    node: {
+      type: 'list',
+      ordered,
+      start,
+      delimiter: ordered ? (delim as '.' | ')') : undefined,
+      loose: loose || undefined,
+      items,
+    },
     nextIndex: index,
   };
 }
@@ -1048,7 +1064,7 @@ function parseMarkdownImpl(input: string, opts: ResolvedOptions): BlockNode[] {
     }
 
     // --- Ordered list ---
-    if (/^ {0,9}\d+\. /.test(line)) {
+    if (/^ {0,9}\d+[.)] /.test(line)) {
       const listResult = parseList(lines, index, true, opts);
       blocks.push(listResult.node);
       index = listResult.nextIndex;
@@ -1311,7 +1327,7 @@ function trimUnsettledStructural(text: string): string {
     }
 
     // Bare list marker with no content: "- " or "1. " (just whitespace after marker)
-    if (/^ {0,9}[-*+] $/.test(last) || /^ {0,9}\d+\. $/.test(last)) {
+    if (/^ {0,9}[-*+] $/.test(last) || /^ {0,9}\d+[.)] $/.test(last)) {
       lines.pop();
       continue;
     }
@@ -1371,12 +1387,14 @@ function mergeSettledBlocks(
   if (
     prevLast.type === 'list' &&
     deltaFirst.type === 'list' &&
-    prevLast.ordered === deltaFirst.ordered
+    prevLast.ordered === deltaFirst.ordered &&
+    prevLast.delimiter === deltaFirst.delimiter
   ) {
     const merged: BlockNode = {
       type: 'list',
       ordered: prevLast.ordered,
       start: prevLast.start,
+      delimiter: prevLast.delimiter,
       loose: true,
       items: [...prevLast.items, ...deltaFirst.items],
     };


### PR DESCRIPTION
## Summary

CommonMark 5.2 allows an ordered-list marker to end in either `.` or `)` (e.g. `1)`), but the Markdown parser only matched `\d+\. `. As a result `1) First` lists were never recognized and rendered as a literal paragraph (`1) First 2) Second …`). This makes `)`-delimited ordered lists parse the same as `.`-delimited ones.

- Block detection and `parseList` recognize `N)` markers.
- A list captures the delimiter of its first item; items must share it, so a change of delimiter (`.` → `)`) starts a new list (per spec) — including across streamed chunks. The list node now carries `delimiter` and the incremental merge only joins same-delimiter lists, so streamed output matches the full parse.
- Paragraph interruption follows CommonMark: only a marker value of `1` (`0*1[.)]`, including zero-padded like `01.`) may interrupt a paragraph (previously any `N.` did).

## Repro

`1) a` / `2) b` / `3) c` previously produced **no `<ol>`** (rendered as a paragraph); markdown-it / CommonMark produce a proper ordered list. Now matches.

## Test plan

- `vitest run packages/core/src/Markdown` — **219 pass** (added `)` parser cases, delimiter-change split, streaming delimiter preservation, and paragraph-interruption rules incl. zero-padded).
- `tsc -p packages/core` + eslint on changed files: clean.
- Changeset included (`@xds/core` patch).

_Reviewed with codex before submitting._
