### PR TITLE
docs: rebrand XDS → Astryx in README and root docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,13 +1,13 @@
-# Contributing to XDS
+# Contributing to Astryx
 
-For the full contribution process — what we accept, how to propose new components, and how API decisions are made — read the **[Contributing wiki](https://github.com/facebookexperimental/xds/wiki/Contributing)**.
+For the full contribution process — what we accept, how to propose new components, and how API decisions are made — read the **[Contributing wiki](https://github.com/facebook/astryx/wiki/Contributing)**.
 
 Key pages:
 
-- **[API Conventions](https://github.com/facebookexperimental/xds/wiki/API-Conventions)** — naming, prop patterns, composition rules (read before submitting an RFC)
-- **[Specification Protocol](https://github.com/facebookexperimental/xds/wiki/Component-Specification-Protocol)** — the 9-phase process for new components
-- **[API Arbitration](https://github.com/facebookexperimental/xds/wiki/API-Arbitration)** — how we resolve API design questions
-- **[Contributing with AI](https://github.com/facebookexperimental/xds/wiki/Contributing-with-AI-Assistants)** — safe zones, spec protocol, and working with AI tools
+- **[API Conventions](https://github.com/facebook/astryx/wiki/API-Conventions)** — naming, prop patterns, composition rules (read before submitting an RFC)
+- **[Specification Protocol](https://github.com/facebook/astryx/wiki/Component-Specification-Protocol)** — the 9-phase process for new components
+- **[API Arbitration](https://github.com/facebook/astryx/wiki/API-Arbitration)** — how we resolve API design questions
+- **[Contributing with AI](https://github.com/facebook/astryx/wiki/Contributing-with-AI-Assistants)** — safe zones, spec protocol, and working with AI tools
 
 This file covers local development setup.
 
@@ -32,7 +32,7 @@ Download and install from https://nodejs.org
 
 ### pnpm
 
-XDS uses [pnpm](https://pnpm.io/) as its package manager (declared in
+Astryx uses [pnpm](https://pnpm.io/) as its package manager (declared in
 the `packageManager` field of `package.json`). The easiest way to install
 it is via [Corepack](https://nodejs.org/api/corepack.html), which ships
 with Node.js:
@@ -41,7 +41,7 @@ with Node.js:
 corepack enable
 ```
 
-This makes the `pnpm` command available with the exact version XDS pins.
+This makes the `pnpm` command available with the exact version Astryx pins.
 Alternatively, install pnpm directly:
 
 ```bash
@@ -69,7 +69,7 @@ pnpm --version   # 10.x.x
 
 ```bash
 # Clone the repo
-git clone https://github.com/facebookexperimental/xds.git
+git clone https://github.com/facebook/astryx.git
 cd xds
 
 # Install dependencies
@@ -289,7 +289,7 @@ src/Button/
 
 ## Versioning & Releases
 
-We use [Changesets](https://github.com/changesets/changesets) for versioning, with a thin XDS layer on top so changelogs stay categorized, contributor-attributed, and aligned with our pre-1.0 conventions.
+We use [Changesets](https://github.com/changesets/changesets) for versioning, with a thin Astryx layer on top so changelogs stay categorized, contributor-attributed, and aligned with our pre-1.0 conventions.
 
 ### Adding a Changeset
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 <!-- SYNC CONTRACT: Architecture changes require documentation updates. -->
 
-# XDS
+# Astryx
 
 A design system for building internal tools and products.
 
 ## Overview
 
-XDS is an open source design system born from years of building internal tools at scale in Meta's monorepo. It provides foundations, components, and patterns that work together to deliver consistent, accessible interfaces.
+Astryx is an open source design system born from years of building internal tools at scale in Meta's monorepo. It provides foundations, components, and patterns that work together to deliver consistent, accessible interfaces.
 
-**What makes XDS different:**
+**What makes Astryx different:**
 
 - **Open internals:** All primitives are exported and composable, not hidden. Build exactly what you need.
 - **Plugin architecture:** Transform and extend components through a unified plugin system

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,11 +2,11 @@
 
 ## Reporting a Vulnerability
 
-The XDS team takes security seriously. If you discover a security issue,
+The Astryx team takes security seriously. If you discover a security issue,
 please bring it to our attention right away.
 
 **Please do not file a public issue.** Public issues are visible to anyone, and
-disclosing a vulnerability before it is fixed puts XDS users at risk.
+disclosing a vulnerability before it is fixed puts Astryx users at risk.
 
 ### Meta Bug Bounty
 


### PR DESCRIPTION
## What

Rebrands the user-facing **XDS → Astryx** name in the repo's root documentation, matching the rename already reflected in the repo path (`facebook/astryx`) and the live wiki.

## Changes

- **README.md** — title `# XDS` → `# Astryx` and overview/marketing prose
- **CONTRIBUTING.md** — title, prose mentions, and stale repo URLs (`facebookexperimental/xds` → `facebook/astryx`, including the clone URL and all wiki links)
- **SECURITY.md** — brand prose

## Intentionally NOT changed

These are still the real published/code identifiers and would break things if renamed now:

- `@xds/*` package names (`@xds/core`, `@xds/cli`, `@xds/theme-default`, …)
- The `xds` CLI bin and the `xds` npm script in install instructions
- The `xds` npm workspace root name in `package.json`

Line counts are unchanged across all three files — these are pure string substitutions, no content moved or lost.

## Companion work

The full **wiki** rebrand (XDS→Astryx React identifiers, DOM/CSS `xds-*`→`astryx-*`, naming-guidance rewrites, repo URLs) has already been pushed directly to the wiki repo (`facebook/astryx.wiki`), since GitHub wikis don't take PRs. This PR covers only the code-repo root docs.
