### PR TITLE
fix(templates): use Layout contentWidth in settings template instead of custom CSS

### DIFF
--- a/packages/cli/templates/pages/settings/page.tsx
+++ b/packages/cli/templates/pages/settings/page.tsx
@@ -22,19 +22,8 @@ import {Button} from '@xds/core/Button';
 import {Divider} from '@xds/core/Divider';
 import {CheckboxInput} from '@xds/core/CheckboxInput';
 import {Typeahead} from '@xds/core/Typeahead';
-import * as stylex from '@stylexjs/stylex';
 import {MagnifyingGlassIcon} from '@heroicons/react/24/outline';
 import type {SearchableItem, SearchSource} from '@xds/core/Typeahead';
-
-// Caps + centers the whole layout shell (header + sidebar + content). Layout
-// has no max-width prop for the outer shell — contentWidth only caps slot
-// content, not the sidebar/header. Tracked in #2625.
-const styles = stylex.create({
-  constrainedShell: {
-    maxWidth: 1440,
-    marginInline: 'auto',
-  },
-});
 
 const NAV_ITEMS = [
   'Profile',
@@ -77,14 +66,12 @@ export default function SettingsTemplate() {
   const [dataExport, setDataExport] = useState(false);
   const [adminMembers, setAdminMembers] = useState(false);
   const [twoFactor, setTwoFactor] = useState(false);
-  const [searchValue, setSearchValue] = useState<SearchableItem | null>(
-    null,
-  );
+  const [searchValue, setSearchValue] = useState<SearchableItem | null>(null);
 
   return (
     <Layout
       height="auto"
-      xstyle={styles.constrainedShell}
+      contentWidth={1440}
       header={
         <LayoutHeader hasDivider>
           <HStack vAlign="center">


### PR DESCRIPTION
## Summary

Replaces the settings page template's only piece of custom CSS — a hand-written `stylex.create` block that capped + centered the shell — with the built-in `Layout` `contentWidth` prop.

```diff
-import * as stylex from '@stylexjs/stylex';
-
-// Caps + centers the whole layout shell (header + sidebar + content). Layout
-// has no max-width prop for the outer shell — contentWidth only caps slot
-// content, not the sidebar/header. Tracked in #2625.
-const styles = stylex.create({
-  constrainedShell: { maxWidth: 1440, marginInline: 'auto' },
-});
-
     <Layout
       height="auto"
-      xstyle={styles.constrainedShell}
+      contentWidth={1440}
```

**No visual change.** `contentWidth` sets `--layout-content-width`, which `LayoutHeader`/`LayoutFooter` consume to constrain + center themselves alongside the middle row (`start` + `content` + `end`), with dividers staying full-bleed — exactly what the custom CSS did. The removed comment referenced #2625 ("Layout has no max-width prop for the outer shell"); that gap is already resolved, so the workaround is no longer needed.

## Template Grade: Settings Form

**Type**: page · **File**: `packages/cli/templates/pages/settings/page.tsx`
**Grade**: A (100/100) — was A (97/100)

| Category | Before | After | Max |
|----------|--------|-------|-----|
| Astryx Component Purity | 30 | 30 | 30 |
| Icon Purity | 15 | 15 | 15 |
| **Custom CSS** | **12** | **15** | 15 |
| Layout & Structure | 15 | 15 | 15 |
| Doc Metadata | 10 | 10 | 10 |
| Image Handling | 5 | 5 | 5 |
| Code Quality | 10 | 10 | 10 |
| **TOTAL** | **97** | **100** | **100** |

The only deduction was Custom CSS (2 style declarations with no Astryx alternative → 12/15). Routing it through `contentWidth` drops the count to zero, closing the gap with no tradeoff. Graded against the [Template Grading Rubric](https://github.com/facebookexperimental/xds/wiki/Contributing-Templates#template-grading-rubric).

## Test plan

- [x] `pnpm -F @xds/sandbox dev` → `/templates/settings/` compiles and returns 200
- [x] Shell still constrained to 1440px and centered (header + sidebar + content), dividers full-bleed
- [x] No `stylex` / `xstyle` / `className` remaining in the template (verified zero custom CSS)
- [ ] Confirm in the PR sandbox preview that desktop/tablet/mobile viewports render identically to before

Made with [Cursor](https://cursor.com)