### PR TITLE
feat(docsite): improve the Shape tokens page (bigger swatches + separate Value/Example columns)

### DIFF
--- a/apps/docsite/src/components/tokens/ShapeTokenTable.tsx
+++ b/apps/docsite/src/components/tokens/ShapeTokenTable.tsx
@@ -10,10 +10,6 @@ import type {TokenTableProps} from './types';
 import {resolveToken, getTokensByPrefix} from './helpers';
 
 const styles = stylex.create({
-  // 96px so the border-radius cap (half the smallest side = 48px) sits clearly
-  // above the largest non-pill radius (--radius-page, up to 32px in some
-  // themes). On the old 32px box every token >=16px clamped to the same
-  // fully-rounded shape, so --radius-container/page/full looked identical.
   radiusBox: {
     width: 96,
     height: 96,

--- a/apps/docsite/src/components/tokens/ShapeTokenTable.tsx
+++ b/apps/docsite/src/components/tokens/ShapeTokenTable.tsx
@@ -10,15 +10,19 @@ import type {TokenTableProps} from './types';
 import {resolveToken, getTokensByPrefix} from './helpers';
 
 const styles = stylex.create({
+  // 96px so the border-radius cap (half the smallest side = 48px) sits clearly
+  // above the largest non-pill radius (--radius-page, up to 32px in some
+  // themes). On the old 32px box every token >=16px clamped to the same
+  // fully-rounded shape, so --radius-container/page/full looked identical.
   radiusBox: {
-    width: 32,
-    height: 32,
+    width: 96,
+    height: 96,
     backgroundColor: 'var(--color-accent-muted)',
     border: '2px solid var(--color-accent)',
     flexShrink: 0,
   },
   borderLine: {
-    width: 32,
+    width: 96,
     height: 0,
     borderBottomStyle: 'solid',
     borderBottomColor: 'var(--color-border-emphasized)',

--- a/apps/docsite/src/components/tokens/ShapeTokenTable.tsx
+++ b/apps/docsite/src/components/tokens/ShapeTokenTable.tsx
@@ -3,9 +3,9 @@
 'use client';
 
 import * as stylex from '@stylexjs/stylex';
-import {VStack, HStack} from '@xds/core/Layout';
+import {VStack} from '@xds/core/Layout';
 import {Text, Heading} from '@xds/core/Text';
-import {Table, pixel} from '@xds/core/Table';
+import {Table, pixel, proportional} from '@xds/core/Table';
 import type {TokenTableProps} from './types';
 import {resolveToken, getTokensByPrefix} from './helpers';
 
@@ -41,16 +41,22 @@ export function RadiusTokenTable({theme}: TokenTableProps) {
         {
           key: 'value',
           header: 'Value',
+          width: pixel(200),
           renderCell: (item: Record<string, unknown>) => (
-            <HStack gap={2} vAlign="center">
-              <div
-                {...stylex.props(styles.radiusBox)}
-                style={{borderRadius: item.value as string}}
-              />
-              <Text type="code" color="secondary">
-                {item.value as string}
-              </Text>
-            </HStack>
+            <Text type="code" color="secondary">
+              {item.value as string}
+            </Text>
+          ),
+        },
+        {
+          key: 'example',
+          header: 'Example',
+          width: proportional(1, {minWidth: 120}),
+          renderCell: (item: Record<string, unknown>) => (
+            <div
+              {...stylex.props(styles.radiusBox)}
+              style={{borderRadius: item.value as string}}
+            />
           ),
         },
       ]}
@@ -80,16 +86,22 @@ export function BorderTokenTable({theme}: TokenTableProps) {
         {
           key: 'value',
           header: 'Value',
+          width: pixel(200),
           renderCell: (item: Record<string, unknown>) => (
-            <HStack gap={2} vAlign="center">
-              <div
-                {...stylex.props(styles.borderLine)}
-                style={{borderBottomWidth: item.value as string}}
-              />
-              <Text type="code" color="secondary">
-                {item.value as string}
-              </Text>
-            </HStack>
+            <Text type="code" color="secondary">
+              {item.value as string}
+            </Text>
+          ),
+        },
+        {
+          key: 'example',
+          header: 'Example',
+          width: proportional(1, {minWidth: 120}),
+          renderCell: (item: Record<string, unknown>) => (
+            <div
+              {...stylex.props(styles.borderLine)}
+              style={{borderBottomWidth: item.value as string}}
+            />
           ),
         },
       ]}

--- a/apps/sandbox/src/app/(sandbox)/pages/doc-preview/token-tables/ShapeTokenTable.tsx
+++ b/apps/sandbox/src/app/(sandbox)/pages/doc-preview/token-tables/ShapeTokenTable.tsx
@@ -10,10 +10,6 @@ import type {TokenTableProps} from './types';
 import {resolveToken, getTokensByPrefix} from './helpers';
 
 const styles = stylex.create({
-  // 96px so the border-radius cap (half the smallest side = 48px) sits clearly
-  // above the largest non-pill radius (--radius-page, up to 32px in some
-  // themes). On the old 32px box every token >=16px clamped to the same
-  // fully-rounded shape, so --radius-container/page/full looked identical.
   radiusBox: {
     width: 96,
     height: 96,

--- a/apps/sandbox/src/app/(sandbox)/pages/doc-preview/token-tables/ShapeTokenTable.tsx
+++ b/apps/sandbox/src/app/(sandbox)/pages/doc-preview/token-tables/ShapeTokenTable.tsx
@@ -10,15 +10,19 @@ import type {TokenTableProps} from './types';
 import {resolveToken, getTokensByPrefix} from './helpers';
 
 const styles = stylex.create({
+  // 96px so the border-radius cap (half the smallest side = 48px) sits clearly
+  // above the largest non-pill radius (--radius-page, up to 32px in some
+  // themes). On the old 32px box every token >=16px clamped to the same
+  // fully-rounded shape, so --radius-container/page/full looked identical.
   radiusBox: {
-    width: 32,
-    height: 32,
+    width: 96,
+    height: 96,
     backgroundColor: 'var(--color-accent-muted)',
     border: '2px solid var(--color-accent)',
     flexShrink: 0,
   },
   borderLine: {
-    width: 32,
+    width: 96,
     height: 0,
     borderBottomStyle: 'solid',
     borderBottomColor: 'var(--color-border-emphasized)',

--- a/apps/sandbox/src/app/(sandbox)/pages/doc-preview/token-tables/ShapeTokenTable.tsx
+++ b/apps/sandbox/src/app/(sandbox)/pages/doc-preview/token-tables/ShapeTokenTable.tsx
@@ -3,7 +3,7 @@
 'use client';
 
 import * as stylex from '@stylexjs/stylex';
-import {VStack, HStack} from '@xds/core/Layout';
+import {VStack} from '@xds/core/Layout';
 import {Text, Heading} from '@xds/core/Text';
 import {Table} from '@xds/core/Table';
 import type {TokenTableProps} from './types';
@@ -65,15 +65,19 @@ function RadiusTokenTable({theme}: TokenTableProps) {
           key: 'value',
           header: 'Value',
           renderCell: (item: Record<string, unknown>) => (
-            <HStack gap={2} align="center">
-              <div
-                {...stylex.props(styles.radiusBox)}
-                style={{borderRadius: item.value as string}}
-              />
-              <Text type="code" color="secondary">
-                {item.value as string}
-              </Text>
-            </HStack>
+            <Text type="code" color="secondary">
+              {item.value as string}
+            </Text>
+          ),
+        },
+        {
+          key: 'example',
+          header: 'Example',
+          renderCell: (item: Record<string, unknown>) => (
+            <div
+              {...stylex.props(styles.radiusBox)}
+              style={{borderRadius: item.value as string}}
+            />
           ),
         },
       ]}
@@ -104,15 +108,19 @@ function BorderTokenTable({theme}: TokenTableProps) {
           key: 'value',
           header: 'Value',
           renderCell: (item: Record<string, unknown>) => (
-            <HStack gap={2} align="center">
-              <div
-                {...stylex.props(styles.borderLine)}
-                style={{borderBottomWidth: item.value as string}}
-              />
-              <Text type="code" color="secondary">
-                {item.value as string}
-              </Text>
-            </HStack>
+            <Text type="code" color="secondary">
+              {item.value as string}
+            </Text>
+          ),
+        },
+        {
+          key: 'example',
+          header: 'Example',
+          renderCell: (item: Record<string, unknown>) => (
+            <div
+              {...stylex.props(styles.borderLine)}
+              style={{borderBottomWidth: item.value as string}}
+            />
           ),
         },
       ]}


### PR DESCRIPTION
## Summary

Two improvements to the radius/border previews on [`/docs/shape`](https://xds-sandbox.vercel.app/docs/shape):

### 1. Enlarge the radius preview swatches (32px → 96px)
The swatch was **32×32px**, and `border-radius` is capped at half the smallest side (**16px**). So every token at or above 16px — `--radius-container`, `--radius-page`, `--radius-chat`, `--radius-full` — rendered as the same fully-rounded shape. Bumping the swatch to **96×96px** raises the cap to 48px, so each step of the scale reads as a distinct shape while `--radius-full` stays a circle.

### 2. Split "Value" and "Example" into separate columns
The Radius and Border tables packed the token value and the preview swatch into a single "Value" cell. Now split into a dedicated **Value** column (the code value) and an **Example** column (the rendered swatch) — matching the same treatment on the Typography page (#3002).

| Token | Value | Example |
|---|---|---|
| `--radius-element` | 12px | ▢ (rounded square) |
| `--radius-page` | 32px | ▢ (more rounded) |
| `--radius-full` | 9999px | ● (circle) |

Applied to both copies of `ShapeTokenTable` (docsite + sandbox doc-preview) for parity. Also removed the now-unused `HStack` import.

## Test plan

- [x] `pnpm -F @xds/docsite dev` → `/docs/shape` compiles and returns 200
- [x] All 7 radius swatches are visually distinct (none → inner → element → container → page → chat → full)
- [x] Radius and Border tables show three columns: Token / Value / Example
- [x] `--radius-full` still renders as a circle; `--radius-page`/`--radius-chat` read as rounded squares
- [x] No lint errors
- [ ] Confirm in the PR preview across a couple of themes (radius multipliers differ per theme)