### PR TITLE
feat(docsite): split Value and Example into separate columns on Typography page

### DIFF
--- a/apps/docsite/src/components/tokens/FontTokenTables.tsx
+++ b/apps/docsite/src/components/tokens/FontTokenTables.tsx
@@ -3,7 +3,6 @@
 'use client';
 
 import * as stylex from '@stylexjs/stylex';
-import {HStack} from '@xds/core/Layout';
 import {Text} from '@xds/core/Text';
 import {Table, pixel, proportional} from '@xds/core/Table';
 import type {TokenTableProps} from './types';
@@ -16,17 +15,7 @@ const styles = stylex.create({
     overflow: 'hidden',
     whiteSpace: 'nowrap',
     textOverflow: 'ellipsis',
-    maxWidth: 200,
-  },
-  weightSwatch: {
-    flex: 1,
-    overflow: 'hidden',
-    whiteSpace: 'nowrap',
-    textOverflow: 'ellipsis',
-  },
-  valueLabel: {
-    flexShrink: 0,
-    width: 40,
+    display: 'block',
   },
 });
 
@@ -45,22 +34,23 @@ export function FontFamilyTokenTable({theme}: TokenTableProps) {
         {
           key: 'value',
           header: 'Value',
-          width: proportional(1, {minWidth: 300}),
+          width: pixel(200),
           renderCell: (item: Record<string, unknown>) => (
-            <HStack gap={3} vAlign="center">
-              <Text type="code" color="secondary">
-                {(item.value as string)?.split(',')[0]?.trim()}
-              </Text>
-              <span
-                {...stylex.props(styles.fontSample)}
-                style={{
-                  fontFamily: item.value as string,
-                  flex: 1,
-                  maxWidth: 'none',
-                }}>
-                {FONT_SAMPLE}
-              </span>
-            </HStack>
+            <Text type="code" color="secondary">
+              {(item.value as string)?.split(',')[0]?.trim()}
+            </Text>
+          ),
+        },
+        {
+          key: 'example',
+          header: 'Example',
+          width: proportional(1, {minWidth: 200}),
+          renderCell: (item: Record<string, unknown>) => (
+            <span
+              {...stylex.props(styles.fontSample)}
+              style={{fontFamily: item.value as string}}>
+              {FONT_SAMPLE}
+            </span>
           ),
         },
       ]}
@@ -86,18 +76,23 @@ export function FontWeightTokenTable({theme}: TokenTableProps) {
         {
           key: 'value',
           header: 'Value',
-          width: proportional(1, {minWidth: 300}),
+          width: pixel(200),
           renderCell: (item: Record<string, unknown>) => (
-            <HStack gap={3} vAlign="center">
-              <Text type="code" color="secondary">
-                {item.value as string}
-              </Text>
-              <span
-                {...stylex.props(styles.weightSwatch)}
-                style={{fontWeight: item.value as string}}>
-                {FONT_SAMPLE}
-              </span>
-            </HStack>
+            <Text type="code" color="secondary">
+              {item.value as string}
+            </Text>
+          ),
+        },
+        {
+          key: 'example',
+          header: 'Example',
+          width: proportional(1, {minWidth: 200}),
+          renderCell: (item: Record<string, unknown>) => (
+            <span
+              {...stylex.props(styles.fontSample)}
+              style={{fontWeight: item.value as string}}>
+              {FONT_SAMPLE}
+            </span>
           ),
         },
       ]}
@@ -123,22 +118,23 @@ export function FontSizeTokenTable({theme}: TokenTableProps) {
         {
           key: 'value',
           header: 'Value',
-          width: proportional(1, {minWidth: 300}),
+          width: pixel(200),
           renderCell: (item: Record<string, unknown>) => (
-            <HStack gap={3} vAlign="center">
-              <Text type="code" color="secondary">
-                {item.value as string}
-              </Text>
-              <span
-                {...stylex.props(styles.fontSample)}
-                style={{
-                  fontSize: item.value as string,
-                  flex: 1,
-                  maxWidth: 'none',
-                }}>
-                {FONT_SAMPLE}
-              </span>
-            </HStack>
+            <Text type="code" color="secondary">
+              {item.value as string}
+            </Text>
+          ),
+        },
+        {
+          key: 'example',
+          header: 'Example',
+          width: proportional(1, {minWidth: 200}),
+          renderCell: (item: Record<string, unknown>) => (
+            <span
+              {...stylex.props(styles.fontSample)}
+              style={{fontSize: item.value as string}}>
+              {FONT_SAMPLE}
+            </span>
           ),
         },
       ]}

--- a/apps/docsite/src/components/tokens/FontTokenTables.tsx
+++ b/apps/docsite/src/components/tokens/FontTokenTables.tsx
@@ -10,6 +10,20 @@ import {resolveToken, getTokensByPrefix} from './helpers';
 
 const FONT_SAMPLE = 'The quick brown fox jumps over the lazy dog';
 
+// Return the primary font family from a font stack, splitting on the first
+// top-level comma so a leading `var(--x, fallback)` (which contains its own
+// comma) isn't chopped mid-token.
+function primaryFamily(value: string): string {
+  let depth = 0;
+  for (let i = 0; i < value.length; i++) {
+    const ch = value[i];
+    if (ch === '(') {depth++;}
+    else if (ch === ')') {depth--;}
+    else if (ch === ',' && depth === 0) {return value.slice(0, i).trim();}
+  }
+  return value.trim();
+}
+
 const styles = stylex.create({
   fontSample: {
     overflow: 'hidden',
@@ -37,7 +51,7 @@ export function FontFamilyTokenTable({theme}: TokenTableProps) {
           width: pixel(200),
           renderCell: (item: Record<string, unknown>) => (
             <Text type="code" color="secondary">
-              {(item.value as string)?.split(',')[0]?.trim()}
+              {primaryFamily(item.value as string)}
             </Text>
           ),
         },


### PR DESCRIPTION
## Summary

On [`/docs/typography`](https://xds-sandbox.vercel.app/docs/typography), the Font Family, Font Size, and Font Weight tables packed **two different things into one "Value" column** — the token value (e.g. `var(--font-figtree`) and the rendered "quick brown fox" sample sat side by side in the same cell.

This splits that into two columns:
- **Value** — the code value, fixed-width and left-aligned so it stays scannable
- **Example** — the live sample rendered in the actual font / size / weight, filling the remaining space

Applied to all three tables in `FontTokenTables.tsx` for consistency. Also removes the now-unused `HStack` import and two dead styles (`weightSwatch`, `valueLabel`).

## Before / After

**Before** — value + example combined in one cell:

| Token | Value |
|---|---|
| `--font-family-body` | `var(--font-figtree`  The quick brown fox… |

**After** — separate columns:

| Token | Value | Example |
|---|---|---|
| `--font-family-body` | `var(--font-figtree` | The quick brown fox… |

## Test plan

- [x] `pnpm -F @xds/docsite dev` → `/docs/typography` compiles and returns 200
- [x] Verified via screenshot that Font Family, Font Size, and Font Weight tables each show three columns (Token / Value / Example)
- [x] Value column stays aligned while the Example column scales with the font size
- [x] No lint errors; unused `HStack` import and dead styles removed

Made with [Cursor](https://cursor.com)