### PR TITLE
docs(blog): set Astryx Design link to astryx.atmeta.com

### DIFF
--- a/apps/docsite/src/content/blog/posts/introducing-astryx.md
+++ b/apps/docsite/src/content/blog/posts/introducing-astryx.md
@@ -34,4 +34,4 @@ Astryx is built to end that trade-off. The system controls behavior, accessibili
 
 The way we build software is changing, and Astryx is designed for people and the agents building alongside them. Design systems have historically been designed for human consumption but as more code is written by agents, we have to rethink how design systems are structured and the role that they play. Astryx was built ground-up to be AI-operable, opposed to retrofitting existing design systems to play nicely with agent behaviors. It's an open source design system built for how we build in this new world.
 
-Astryx is in Beta and ready for you to build with today. Try it out at [Astryx Design](TODO_ASTRYX_DESIGN_URL) and on [GitHub](https://github.com/facebook/astryx).
+Astryx is in Beta and ready for you to build with today. Try it out at [Astryx Design](https://astryx.atmeta.com) and on [GitHub](https://github.com/facebook/astryx).


### PR DESCRIPTION
Follow-up to #2986. The previous PR merged with a placeholder URL for the **Astryx Design** link (`TODO_ASTRYX_DESIGN_URL`) — this swaps in the live URL.

## Change
- `/blog/introducing-astryx`: **Astryx Design** link → `https://astryx.atmeta.com`

## Why now
The placeholder is currently live on `main` (and deploys to the docsite). Worth landing before tomorrow's launch so the link works.