### PR TITLE
feat(core): underline Markdown links by default

### DIFF
--- a/.changeset/markdown-link-underline.md
+++ b/.changeset/markdown-link-underline.md
@@ -1,0 +1,8 @@
+---
+'@xds/core': patch
+---
+
+[feat] Underline links by default in the Markdown component
+@kentonquatman
+
+Markdown links now render with a persistent underline instead of only underlining on hover, making links clearly distinguishable from surrounding text and improving accessibility. The accent color is unchanged.

--- a/packages/core/src/Markdown/Markdown.tsx
+++ b/packages/core/src/Markdown/Markdown.tsx
@@ -399,10 +399,7 @@ const styles = stylex.create({
   },
   link: {
     color: colorVars['--color-text-accent'],
-    textDecoration: {
-      default: 'none',
-      ':hover': {'@media (hover: hover)': 'underline'},
-    },
+    textDecoration: 'underline',
   },
 });
 


### PR DESCRIPTION
## Summary

Markdown links now render with a **persistent underline** instead of underlining only on hover.

## Why

Links previously had `textDecoration: none` by default and only underlined on `:hover`. That makes them hard to distinguish from surrounding text — especially on touch devices where there is no hover state. Underlining by default improves link affordance and accessibility. The accent color is unchanged.

## Change

`packages/core/src/Markdown/Markdown.tsx` — the `link` style:

```diff
 link: {
   color: colorVars['--color-text-accent'],
-  textDecoration: {
-    default: 'none',
-    ':hover': {'@media (hover: hover)': 'underline'},
-  },
+  textDecoration: 'underline',
 },
```

## Scope / blast radius

This is the shared core `Markdown` component, so the change applies everywhere Markdown is rendered (docs, blog, AI response templates, CLI blocks, etc.). That is intentional — links should be consistently underlined system-wide.

## Verification

- `pnpm -F @xds/core test src/Markdown` → 212 passed
- `pnpm -F @xds/core typecheck` → clean
- `pnpm -F @xds/core build` → success

Includes a patch changeset for `@xds/core`.