### PR TITLE
docs(cli): update MCP server URL to astryx.meta.com

### DIFF
--- a/packages/cli/docs/working-with-ai.doc.mjs
+++ b/packages/cli/docs/working-with-ai.doc.mjs
@@ -183,7 +183,7 @@ npx astryx docs tokens --dense`,
   "mcpServers": {
     "xds": {
       "type": "url",
-      "url": "https://xds-sandbox.vercel.app/mcp"
+      "url": "https://astryx.meta.com/mcp"
     }
   }
 }`,


### PR DESCRIPTION
## Summary

Updates the MCP server URL referenced in the CLI's "Working with AI" documentation from the old Vercel sandbox domain to the production Astryx domain.

```diff
-      "url": "https://xds-sandbox.vercel.app/mcp"
+      "url": "https://astryx.meta.com/mcp"
```

## Context

This is the only reference to `xds-sandbox.vercel.app` in the repo. The remaining `xds-sandbox-*` strings (in `apps/sandbox/src/app/providers.tsx`) are localStorage keys, not links, so they are intentionally left unchanged.

## Test plan

- `docs working-with-ai` MCP config now points users at `https://astryx.meta.com/mcp`
- Verified the doc module imports cleanly and no other occurrences of the old URL remain