### PR TITLE
chore(lint): rename internal ESLint namespace @xds/* -> @astryx/*

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -137,10 +137,10 @@ export default tseslint.config(
     files: ["**/*.{ts,tsx}"],
     ignores: ["**/*.d.ts", "**/dist/**"],
     plugins: {
-      '@xds': xdsPlugin,
+      '@astryx': xdsPlugin,
     },
     rules: {
-      '@xds/copyright-header': 'error',
+      '@astryx/copyright-header': 'error',
     },
   },
   // XDS design token enforcement - applies to core package (excluding theme files)
@@ -152,7 +152,7 @@ export default tseslint.config(
       ...xdsConfig.rules,
       // Temporarily allow Children.* in files that need architectural fixes.
       // Tracked: OverflowList, MetadataList, Carousel need data-driven APIs.
-      '@xds/no-react-introspection': ['error', {
+      '@astryx/no-react-introspection': ['error', {
         allowFiles: [
           'OverflowList/OverflowList',
           'MetadataList/MetadataList',
@@ -163,7 +163,7 @@ export default tseslint.config(
   },
   // React bug-prevention rules - applies to core package
   // Uses @eslint-react for bugs that TypeScript alone cannot catch.
-  // Children.*/cloneElement are already covered by @xds/no-react-introspection.
+  // Children.*/cloneElement are already covered by @astryx/no-react-introspection.
   {
     files: ["packages/core/src/**/*.{ts,tsx}"],
     plugins: {
@@ -288,11 +288,11 @@ export default tseslint.config(
   // CLI runtime (.mjs). The CLI ships as ESM Node modules and was never linted
   // (the global **/*.mjs ignore swallowed it; see #2468). This block gives the
   // .mjs sources a Node language environment and enforces the JSON-stdout
-  // contract (#2467) at author time via @xds/no-raw-console-cli.
+  // contract (#2467) at author time via @astryx/no-raw-console-cli.
   {
     files: ["packages/cli/src/**/*.mjs", "packages/cli/bin/**/*.mjs"],
     plugins: {
-      '@xds': xdsPlugin,
+      '@astryx': xdsPlugin,
     },
     languageOptions: {
       sourceType: "module",
@@ -330,7 +330,7 @@ export default tseslint.config(
       }],
       // Bare console.log corrupts --json stdout. Route human chatter through
       // humanLog(); console.error/console.warn (stderr) stay allowed.
-      "@xds/no-raw-console-cli": "error",
+      "@astryx/no-raw-console-cli": "error",
     },
   },
   // Copyright header for CLI .mjs sources (the main copyright block only
@@ -338,10 +338,10 @@ export default tseslint.config(
   {
     files: ["packages/cli/src/**/*.mjs", "packages/cli/bin/**/*.mjs"],
     plugins: {
-      '@xds': xdsPlugin,
+      '@astryx': xdsPlugin,
     },
     rules: {
-      '@xds/copyright-header': 'error',
+      '@astryx/copyright-header': 'error',
     },
   },
   // CLI tests — relax author-ergonomics rules (test files emit freely and may
@@ -349,7 +349,7 @@ export default tseslint.config(
   {
     files: ["packages/cli/**/*.test.mjs"],
     rules: {
-      "@xds/no-raw-console-cli": "off",
+      "@astryx/no-raw-console-cli": "off",
       "@typescript-eslint/no-unused-vars": "off",
     },
   },

--- a/internal/eslint-plugin-astryx/README.md
+++ b/internal/eslint-plugin-astryx/README.md
@@ -1,4 +1,4 @@
-# @xds/eslint-plugin
+# @astryx/eslint-plugin
 
 ESLint plugin for XDS design system token enforcement.
 
@@ -18,7 +18,7 @@ This plugin implements a two-tier linting strategy:
 
 ## Rules
 
-### `@xds/no-hardcoded-styles`
+### `@astryx/no-hardcoded-styles`
 
 Detects hardcoded CSS values in `stylex.create()` that should use XDS tokens:
 
@@ -54,7 +54,7 @@ const styles = stylex.create({
 });
 ```
 
-### `@xds/require-letter-spacing`
+### `@astryx/require-letter-spacing`
 
 Recommends adding `letterSpacing` when `fontSize` is defined (common design pattern for badges, labels).
 
@@ -98,9 +98,9 @@ pnpm lint:strict packages/core/src/Badge/XDSBadge.test-violations.tsx
 Expected output in strict mode:
 
 ```
-  12:15  error  Use textSizeVars token instead of hardcoded fontSize  @xds/no-hardcoded-styles
-  17:16  error  Use fontWeightVars token instead of hardcoded fontWeight  @xds/no-hardcoded-styles
-  22:12  error  Use colorVars token instead of hardcoded color  @xds/no-hardcoded-styles
+  12:15  error  Use textSizeVars token instead of hardcoded fontSize  @astryx/no-hardcoded-styles
+  17:16  error  Use fontWeightVars token instead of hardcoded fontWeight  @astryx/no-hardcoded-styles
+  22:12  error  Use colorVars token instead of hardcoded color  @astryx/no-hardcoded-styles
   ...
 ```
 
@@ -129,16 +129,16 @@ If a property legitimately needs a hardcoded value:
 // In eslint.config.js
 {
   files: ["packages/core/src/**/*.{ts,tsx}"],
-  plugins: { '@xds': xdsPlugin },
+  plugins: { '@astryx': xdsPlugin },
   rules: {
-    '@xds/no-hardcoded-styles': ['warn', {
+    '@astryx/no-hardcoded-styles': ['warn', {
       ignore: ['lineHeight']  // Allow hardcoded lineHeight
     }],
   },
 }
 ```
 
-### `@xds/presentational-component`
+### `@astryx/presentational-component`
 
 Enforces that presentational components remain server-component compatible by preventing:
 

--- a/internal/eslint-plugin-astryx/index.js
+++ b/internal/eslint-plugin-astryx/index.js
@@ -222,7 +222,7 @@ const noHardcodedStylesRule = {
 
 const plugin = {
   meta: {
-    name: '@xds/eslint-plugin',
+    name: '@astryx/eslint-plugin',
     version: '0.0.1',
   },
   rules: {
@@ -247,44 +247,44 @@ const plugin = {
 // Strict config - for agents/CI (all errors)
 plugin.configs.strict = {
   plugins: {
-    '@xds': plugin,
+    '@astryx': plugin,
   },
   rules: {
-    '@xds/no-hardcoded-styles': 'error',
-    '@xds/boolean-prop-naming': 'error',
-    '@xds/presentational-component': 'error',
-    '@xds/docblock-example-format': 'error',
-    '@xds/no-stylex-null-override': 'error',
-    '@xds/no-react-introspection': 'error',
-    '@xds/no-classname-clobber': 'error',
-    '@xds/no-hardcoded-anchor': 'error',
-    '@xds/no-border-shorthand': 'error',
-    '@xds/no-react-namespace-hooks': 'error',
-    '@xds/require-base-props': 'error',
-    '@xds/require-ref-prop': 'error',
-    '@xds/copyright-header': 'error',
+    '@astryx/no-hardcoded-styles': 'error',
+    '@astryx/boolean-prop-naming': 'error',
+    '@astryx/presentational-component': 'error',
+    '@astryx/docblock-example-format': 'error',
+    '@astryx/no-stylex-null-override': 'error',
+    '@astryx/no-react-introspection': 'error',
+    '@astryx/no-classname-clobber': 'error',
+    '@astryx/no-hardcoded-anchor': 'error',
+    '@astryx/no-border-shorthand': 'error',
+    '@astryx/no-react-namespace-hooks': 'error',
+    '@astryx/require-base-props': 'error',
+    '@astryx/require-ref-prop': 'error',
+    '@astryx/copyright-header': 'error',
   },
 };
 
 // Recommended config - for humans (all warnings)
 plugin.configs.recommended = {
   plugins: {
-    '@xds': plugin,
+    '@astryx': plugin,
   },
   rules: {
-    '@xds/no-hardcoded-styles': 'warn',
-    '@xds/boolean-prop-naming': 'warn',
-    '@xds/presentational-component': 'error',
-    '@xds/docblock-example-format': 'warn',
-    '@xds/no-stylex-null-override': 'warn',
-    '@xds/no-react-introspection': 'error',
-    '@xds/no-classname-clobber': 'error',
-    '@xds/no-hardcoded-anchor': 'warn',
-    '@xds/no-border-shorthand': 'warn',
-    '@xds/no-react-namespace-hooks': 'error',
-    '@xds/require-base-props': 'warn',
-    '@xds/require-ref-prop': 'warn',
-    '@xds/copyright-header': 'error',
+    '@astryx/no-hardcoded-styles': 'warn',
+    '@astryx/boolean-prop-naming': 'warn',
+    '@astryx/presentational-component': 'error',
+    '@astryx/docblock-example-format': 'warn',
+    '@astryx/no-stylex-null-override': 'warn',
+    '@astryx/no-react-introspection': 'error',
+    '@astryx/no-classname-clobber': 'error',
+    '@astryx/no-hardcoded-anchor': 'warn',
+    '@astryx/no-border-shorthand': 'warn',
+    '@astryx/no-react-namespace-hooks': 'error',
+    '@astryx/require-base-props': 'warn',
+    '@astryx/require-ref-prop': 'warn',
+    '@astryx/copyright-header': 'error',
   },
 };
 

--- a/internal/eslint-plugin-astryx/package.json
+++ b/internal/eslint-plugin-astryx/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@xds/eslint-plugin",
+  "name": "@astryx/eslint-plugin",
   "version": "0.0.1",
   "private": true,
   "main": "index.js",

--- a/packages/core/src/Carousel/Carousel.tsx
+++ b/packages/core/src/Carousel/Carousel.tsx
@@ -98,10 +98,10 @@ const styles = stylex.create({
     alignItems: 'center',
     overflowX: 'auto',
     overflowY: 'hidden',
-    /* eslint-disable @xds/no-hardcoded-styles -- 1px bleed for tab indicator; no token at this size */
+    /* eslint-disable @astryx/no-hardcoded-styles -- 1px bleed for tab indicator; no token at this size */
     paddingBottom: '1px',
     marginBottom: '-1px',
-    /* eslint-enable @xds/no-hardcoded-styles */
+    /* eslint-enable @astryx/no-hardcoded-styles */
     overscrollBehaviorX: 'contain',
     scrollBehavior: {
       default: 'smooth',

--- a/packages/core/src/Resizable/useResizable.ts
+++ b/packages/core/src/Resizable/useResizable.ts
@@ -85,7 +85,7 @@ export interface ResizableRegion {
 
 export interface ResizableProps {
   _size: number;
-  // eslint-disable-next-line @xds/boolean-prop-naming
+  // eslint-disable-next-line @astryx/boolean-prop-naming
   _isCollapsed: boolean;
   _onResizeStart: () => void;
   _onResizeMove: (delta: number) => void;
@@ -95,7 +95,7 @@ export interface ResizableProps {
   _snaps: number[];
   _collapsedSize: number;
   /** Whether the region supports collapsing. */
-  // eslint-disable-next-line @xds/boolean-prop-naming
+  // eslint-disable-next-line @astryx/boolean-prop-naming
   _collapsible: boolean;
   _isResizableProps: true;
 }

--- a/packages/core/src/Table/plugins/sortable/useTableSortable.tsx
+++ b/packages/core/src/Table/plugins/sortable/useTableSortable.tsx
@@ -147,7 +147,7 @@ const sortStyles = stylex.create({
   },
   rank: {
     fontSize: 10,
-    // eslint-disable-next-line @xds/no-hardcoded-styles -- no token for lineHeight:1 (tight badge)
+    // eslint-disable-next-line @astryx/no-hardcoded-styles -- no token for lineHeight:1 (tight badge)
     lineHeight: '1',
     color: colorVars['--color-accent'],
   },


### PR DESCRIPTION
## Rename internal ESLint namespace `@xds/*` → `@astryx/*`

Companion to the package-scope rename (#3008), but **fully independent** — this only touches internal lint tooling and has **zero consumer/package impact**.

### What changed (7 files)
- `eslint.config.js`: plugin registration `'@xds'` → `'@astryx'`
- `internal/eslint-plugin-xds/`: plugin meta `name` + all 13 rule ids → `@astryx/*`
- `@xds/eslint-plugin` package name → `@astryx/eslint-plugin` (private; imported by relative path, so no dependents to update)
- The 3 `@xds/*` `eslint-disable` comments in `packages/core` → `@astryx/*`

### Why separate from #3008
The `@xds` ESLint **namespace** and the `@xds` **package scope** are two different things that happen to share a prefix. #3008 moves packages to `@astryxdesign`; this moves the internal lint namespace to `@astryx`. Keeping them apart avoids cross-contaminating a 1,200-file rename with a 7-file one, and lets each land/revert independently.

### Validation
- ✅ `eslint --print-config` shows all **13 rules active under `@astryx/*`**, zero under `@xds/*`
- ✅ `eslint` runs clean on the affected files (disable comments resolve correctly)

### Note
The directory `internal/eslint-plugin-xds/` keeps its name — purely cosmetic; the registered namespace is what matters. Can be renamed later if desired.
