### PR TITLE
fix(docsite): use astryx-* classes for component chrome styling

### DIFF
--- a/.github/scripts/test-pr-enrichment.js
+++ b/.github/scripts/test-pr-enrichment.js
@@ -99,7 +99,7 @@ const mockA11y = {
           totalNodes: 3,
           stories: ['Default', 'WithSeconds'],
           nodes: [
-            { html: '<input type="text" class="xds-time-input">', target: ['.xds-time-input'] },
+            { html: '<input type="text" class="astryx-time-input">', target: ['.astryx-time-input'] },
           ],
         },
         {
@@ -113,7 +113,7 @@ const mockA11y = {
           totalNodes: 2,
           stories: ['Disabled'],
           nodes: [
-            { html: '<span class="xds-time-label">Hours</span>', target: ['.xds-time-label'] },
+            { html: '<span class="astryx-time-label">Hours</span>', target: ['.astryx-time-label'] },
           ],
         },
       ],
@@ -133,7 +133,7 @@ const mockA11y = {
           totalNodes: 5,
           stories: ['IconOnly', 'Loading', 'Minimal'],
           nodes: [
-            { html: '<button class="xds-button">', target: ['.xds-button'] },
+            { html: '<button class="astryx-button">', target: ['.astryx-button'] },
           ],
         },
       ],

--- a/apps/docsite/src/app/(site)/_landing/FeaturesShowcase.tsx
+++ b/apps/docsite/src/app/(site)/_landing/FeaturesShowcase.tsx
@@ -113,7 +113,7 @@ const styles = stylex.create({
   // All cards use Card padding={0} and apply their own padding
   // via the innerPadding* styles below. This is intentional: Card's
   // `padding={N}` prop wires its `padding-bottom` through a
-  // (0,5,0)-specificity selector (`.xds-card-XXX:not(#\#):not(#\#)
+  // (0,5,0)-specificity selector (`.astryx-card-XXX:not(#\#):not(#\#)
   // :not(#\#):not(#\#)`) which beats any xstyle override at (0,1,0).
   // The CSS variable indirection ALSO doesn't work because the card
   // sets `padding-bottom: var(--spacing-N)` directly (not via the
@@ -123,7 +123,7 @@ const styles = stylex.create({
 
   // All four card variants share the same pastel backdrop, pulled
   // from a marketing-only theme token (defined in astryxTheme.ts as
-  // `--xds-marketing-feature-card-bg`). Sourcing the color from the
+  // `--astryx-marketing-feature-card-bg`). Sourcing the color from the
   // theme keeps the bento palette tunable in one place and avoids
   // baking literal hex values into the component. We do NOT use
   // Card's `variant="blue"` here because that token (--color-
@@ -136,7 +136,7 @@ const styles = stylex.create({
   // is stretched by the grid to match the tallest sibling column.
   cardTall: {
     flex: 1,
-    backgroundColor: 'var(--xds-marketing-feature-card-bg)',
+    backgroundColor: 'var(--astryx-marketing-feature-card-bg)',
     overflow: 'hidden',
   },
   // Regular image card — natural (content) height. Used for an image
@@ -150,7 +150,7 @@ const styles = stylex.create({
   card: {
     height: 'auto',
     overflow: 'hidden',
-    backgroundColor: 'var(--xds-marketing-feature-card-bg)',
+    backgroundColor: 'var(--astryx-marketing-feature-card-bg)',
   },
   // Flex variant of `card` — image card that grows to fill its
   // column's leftover height so a column with a short text-only
@@ -159,14 +159,14 @@ const styles = stylex.create({
   cardFlex: {
     flex: 1,
     overflow: 'hidden',
-    backgroundColor: 'var(--xds-marketing-feature-card-bg)',
+    backgroundColor: 'var(--astryx-marketing-feature-card-bg)',
   },
   // Text-only feature card variant — no image, so overflow hidden
   // keeps the card contour tidy at the rounded corners.
   cardTextOnly: {
     height: 'auto',
     overflow: 'hidden',
-    backgroundColor: 'var(--xds-marketing-feature-card-bg)',
+    backgroundColor: 'var(--astryx-marketing-feature-card-bg)',
   },
   // Padding for image cards: --spacing-10 (40px) on top + sides +
   // 0 on bottom so the image wrapper inside sits flush at the

--- a/apps/docsite/src/app/(site)/page.tsx
+++ b/apps/docsite/src/app/(site)/page.tsx
@@ -116,10 +116,10 @@ const styles = stylex.create({
     borderTopLeftRadius: 'var(--radius-page)',
     borderTopRightRadius: 'var(--radius-page)',
     backgroundColor: 'var(--color-background-surface)',
-    paddingBlockStart: 'var(--xds-marketing-section-gap)',
+    paddingBlockStart: 'var(--astryx-marketing-section-gap)',
     paddingBlockEnd: spacingVars['--spacing-12'],
     paddingInline: spacingVars['--spacing-6'],
-    gap: 'var(--xds-marketing-section-gap)',
+    gap: 'var(--astryx-marketing-section-gap)',
   },
 });
 

--- a/apps/docsite/src/app/globals.css
+++ b/apps/docsite/src/app/globals.css
@@ -30,12 +30,12 @@
 
   /* Feature card backdrop. Soft pastel blue in light mode, deep navy in
      dark mode. Consumed by FeaturesShowcase's bento cards via
-     `backgroundColor: var(--xds-marketing-feature-card-bg)`. Picked
+     `backgroundColor: var(--astryx-marketing-feature-card-bg)`. Picked
      specifically because the stock --color-background-blue is a
      20%-alpha saturated wash that prints too vivid against the showcase's
      white surface; this gives the cards a soft pastel band the eye reads
      as a single related group. */
-  --xds-marketing-feature-card-bg: light-dark(#e6f0ff, #1a2333);
+  --astryx-marketing-feature-card-bg: light-dark(#e6f0ff, #1a2333);
 
   /* Marketing-section vertical rhythm. The XDS spacing scale tops out at
      --spacing-12 = 48px, which is fine for in-app density but too tight
@@ -43,7 +43,7 @@
      home-page sections (hero ↔ features ↔ about ↔ discover) and the
      page's first paddingBlockStart so the rhythm reads as deliberate
      marketing pacing rather than a maxed-out spacing step. */
-  --xds-marketing-section-gap: 100px;
+  --astryx-marketing-section-gap: 100px;
 }
 
 /* AppShell sets a sticky top nav but its main content area sits at the same
@@ -56,7 +56,7 @@
    The --appshell-header-height variable is seeded at :root (above) and then
    re-set by the AppShell once it measures the rendered header. The literal
    fallbacks below only apply if the :root seed is ever missing. */
-body:not(:has([data-playground-page])) #xds-app-shell-main {
+body:not(:has([data-playground-page])) #astryx-app-shell-main {
   scroll-padding-top: var(--appshell-header-height, 64px);
   padding-top: var(--appshell-header-height, 64px);
 }
@@ -66,30 +66,30 @@ body:not(:has([data-playground-page])) #xds-app-shell-main {
    `top: var(--appshell-header-height, 0px)` rule, and the extra padding
    here would introduce a visible cream-colored gap between the nav and
    the hero. scroll-padding-top is kept for anchor-link scrolling. */
-body:has([data-home-page]) #xds-app-shell-main {
+body:has([data-home-page]) #astryx-app-shell-main {
   padding-top: 0;
 }
 
 /* Translucent top nav — frosted glass effect.
 
-   The :where(:not(.xds-app-shell .xds-app-shell *)) guard scopes every frost
+   The :where(:not(.astryx-app-shell .astryx-app-shell *)) guard scopes every frost
    rule to the OUTERMOST AppShell only: any nav inside a *nested* AppShell
-   (component examples, templates) matches `.xds-app-shell .xds-app-shell *`
+   (component examples, templates) matches `.astryx-app-shell .astryx-app-shell *`
    — it has two AppShell ancestors — and is therefore excluded, so it keeps
    its own solid navAreaStyle background and stays seamless with its sidenav.
 
    The guard lives inside :where() so it adds ZERO specificity. The frost
-   subject stays at (0,1,0) — identical to a bare `.xds-top-nav` — so the
+   subject stays at (0,1,0) — identical to a bare `.astryx-top-nav` — so the
    home-page, nav-mode, and theme-preview overrides below keep winning exactly
    as they did before. (Putting the :not() on the outer shell instead, as in
-   `.xds-app-shell:not(...) > .xds-layout .xds-top-nav`, does NOT work: the
+   `.astryx-app-shell:not(...) > .astryx-layout .astryx-top-nav`, does NOT work: the
    nested nav is still an unrestricted descendant of the outer layout.) */
-.xds-layout-header:where(:not(.xds-app-shell .xds-app-shell *)),
-:has(> .xds-layout-header):where(:not(.xds-app-shell .xds-app-shell *)) {
+.astryx-layout-header:where(:not(.astryx-app-shell .astryx-app-shell *)),
+:has(> .astryx-layout-header):where(:not(.astryx-app-shell .astryx-app-shell *)) {
   background: transparent !important;
 }
 
-.xds-top-nav:where(:not(.xds-app-shell .xds-app-shell *)) {
+.astryx-top-nav:where(:not(.astryx-app-shell .astryx-app-shell *)) {
   background: color-mix(in srgb, var(--color-background-surface) 80%, transparent);
   backdrop-filter: blur(12px);
   transition: background 300ms ease;
@@ -99,15 +99,15 @@ body:has([data-home-page]) #xds-app-shell-main {
    navBackdrop band rendered behind it (inside the hero reel's themed scope)
    shows through and retints the nav strip with the ACTIVE theme's body color.
    Without this the nav would paint Astryx's default body color and never
-   follow the reel. The backdrop-filter blur from the .xds-top-nav rule above
+   follow the reel. The backdrop-filter blur from the .astryx-top-nav rule above
    is preserved. */
-body:has([data-home-page]) .xds-top-nav:where(:not(.xds-app-shell .xds-app-shell *)) {
+body:has([data-home-page]) .astryx-top-nav:where(:not(.astryx-app-shell .astryx-app-shell *)) {
   background: transparent;
 }
 
 /* When the home page IntersectionObserver detects the theming showcase has
    reached the top, switch the nav back to a surface-tinted frosted bar. */
-body[data-nav-mode='surface'] .xds-top-nav:where(:not(.xds-app-shell .xds-app-shell *)) {
+body[data-nav-mode='surface'] .astryx-top-nav:where(:not(.astryx-app-shell .astryx-app-shell *)) {
   background: color-mix(in srgb, var(--color-background-surface) 80%, transparent);
 }
 
@@ -120,13 +120,13 @@ body[data-hero-dark] {
 /* Dark hero slide: switch the transparent nav's text to that light ink. Skipped
    in surface mode (scrolled past the hero onto the white showcase). */
 body[data-hero-dark]:not([data-nav-mode='surface'])
-  .xds-top-nav:where(:not(.xds-app-shell .xds-app-shell *)) {
+  .astryx-top-nav:where(:not(.astryx-app-shell .astryx-app-shell *)) {
   color: var(--hero-on-dark);
 }
 body[data-hero-dark]:not([data-nav-mode='surface'])
-  .xds-top-nav:where(:not(.xds-app-shell .xds-app-shell *)) a,
+  .astryx-top-nav:where(:not(.astryx-app-shell .astryx-app-shell *)) a,
 body[data-hero-dark]:not([data-nav-mode='surface'])
-  .xds-top-nav:where(:not(.xds-app-shell .xds-app-shell *)) button {
+  .astryx-top-nav:where(:not(.astryx-app-shell .astryx-app-shell *)) button {
   color: var(--hero-on-dark);
 }
 
@@ -135,7 +135,7 @@ body[data-hero-dark]:not([data-nav-mode='surface'])
    static light nav ink — otherwise it's light-on-light and vanishes in dark
    mode. Higher specificity than the blanket a/button rule above. */
 body[data-hero-dark]:not([data-nav-mode='surface'])
-  .xds-top-nav:where(:not(.xds-app-shell .xds-app-shell *)) [data-variant='primary'] {
+  .astryx-top-nav:where(:not(.astryx-app-shell .astryx-app-shell *)) [data-variant='primary'] {
   color: var(--color-on-accent);
 }
 
@@ -144,28 +144,28 @@ body[data-hero-dark]:not([data-nav-mode='surface'])
    variant="dots" ships with chevrons by default; the hero wants a minimal
    indicator-only treatment. Scoped to [data-home-page] so other
    XDSPagination instances across the site stay untouched. */
-[data-home-page] .xds-pagination button[aria-label='Go to previous page'],
-[data-home-page] .xds-pagination button[aria-label='Go to next page'] {
+[data-home-page] .astryx-pagination button[aria-label='Go to previous page'],
+[data-home-page] .astryx-pagination button[aria-label='Go to next page'] {
   display: none;
 }
 
 /* On dark hero slides the dots render in Astryx, whose --color-accent is a
    near-black ink — invisible on the dark backdrop, so the active dot and the
    keyboard focus ring disappear. Repaint both with the light hero ink. */
-body[data-hero-dark] [data-home-page] .xds-pagination-dot.active {
+body[data-hero-dark] [data-home-page] .astryx-pagination-dot.active {
   background-color: var(--hero-on-dark);
 }
-body[data-hero-dark] [data-home-page] .xds-pagination-dot:focus-visible {
+body[data-hero-dark] [data-home-page] .astryx-pagination-dot:focus-visible {
   outline-color: var(--hero-on-dark);
 }
 
 /* The /themes/<name> dedicated page renders a faux app top nav INSIDE
-   its preview surface. The global `.xds-top-nav` rule above gives it a
+   its preview surface. The global `.astryx-top-nav` rule above gives it a
    surface-tinted frosted background, which leaks through and makes the
    preview's nav look distinct from its themed body. Scope it back to
    the theme's body color so the preview reads as one continuous app
    surface. */
-[data-theme-preview='true'] .xds-top-nav {
+[data-theme-preview='true'] .astryx-top-nav {
   background: var(--color-background-body);
   backdrop-filter: none;
 }

--- a/apps/docsite/src/components/ThemePackagePage.tsx
+++ b/apps/docsite/src/components/ThemePackagePage.tsx
@@ -334,7 +334,7 @@ const styles = stylex.create({
     // (distressed display), and themes without a display family
     // override fall back to their heading font (Outfit, system,
     // etc.). The Text below uses type="display-3" so the
-    // .xds-text.display-3 selector in each theme's @scope'd CSS (legacy class
+    // .astryx-text.display-3 selector in each theme's @scope'd CSS (legacy class
     // selector; text also emits data-type="display-3")
     // applies the right family per card.
     fontSize: 24,

--- a/apps/docsite/src/components/ThemeShowcaseTile.tsx
+++ b/apps/docsite/src/components/ThemeShowcaseTile.tsx
@@ -222,7 +222,7 @@ const styles = stylex.create({
   // Each typography sample sizes itself uniformly via a wrapper
   // class. The actual font family + weight comes from the underlying
   // Text / span using the theme's own typography tokens (or, for
-  // Display, the theme-scoped .xds-text.display-3 rule (legacy class selector;
+  // Display, the theme-scoped .astryx-text.display-3 rule (legacy class selector;
   // text also emits data-type="display-3") which themes
   // like Gothic use to swap in a signature display family).
   typeAa: {
@@ -476,7 +476,7 @@ export function ThemeShowcaseTile({
                   display / heading / body / mono font with the role as
                   label. The Display sample uses Text type="display-3"
                   so themes that scope a custom display family to the
-                  .xds-text.display-3 selector (legacy class selector; e.g. Gothic →
+                  .astryx-text.display-3 selector (legacy class selector; e.g. Gothic →
                   Manufacturing Consent) flow through cleanly. */}
               <HStack gap={3}>
                 <VStack gap={0.5} xstyle={styles.typeSample}>


### PR DESCRIPTION
## Summary

Fixes a visual regression introduced by the compat-layer removal (#3001): custom docsite CSS still targeted the old `xds-*` component classes, which no longer render (components emit `astryx-*` now). This chrome styling silently stopped applying.

## Changes
- **`apps/docsite/src/app/globals.css`** — the live `.xds-app-shell`, `.xds-top-nav`, `.xds-layout-header`, `.xds-pagination`, `.xds-pagination-dot` selectors and the `#xds-app-shell-main` id selector → `astryx-*`. (Core's `AppShell` now emits `id="astryx-app-shell-main"`.)
- Renamed the **docsite-local** `--xds-marketing-*` custom properties (defined in `globals.css`, consumed in `FeaturesShowcase.tsx` / `page.tsx`) → `--astryx-marketing-*`.
- Updated `.xds-text.display-3` comments (ThemePackagePage, ThemeShowcaseTile) and the FeaturesShowcase `.xds-card` comment for accuracy.
- **`.github/scripts/test-pr-enrichment.js`** — a11y mock fixtures use `astryx-*` classes.

## Scope
No package-scope (`@xds/*`) changes — that rename is tracked separately. This is part of the broader effort to scrub remaining `xds` references now that the compat layer is gone.

## Validation
- `node_modules` not available in the sandbox; relying on CI for lint/typecheck/build/docsite-test.
- Verified: zero `.xds-*` class/id selectors or `--xds-marketing-*` vars remain in the docsite; var define/consume sites stay consistent.
