### PR TITLE
refactor(build): default StyleX library atomic prefix to astryx

### DIFF
--- a/.changeset/build-astryx-atomic-prefix.md
+++ b/.changeset/build-astryx-atomic-prefix.md
@@ -1,0 +1,13 @@
+---
+'@xds/build': patch
+---
+
+[breaking] Default the StyleX library atomic-class prefix to `astryx` (was `xds`)
+@ejhammond
+
+`@xds/build`'s babel/Vite integrations now emit library atomic classes as
+`.astryx78zum5` by default instead of `.xds78zum5` (the `libraryPrefix` /
+`stylexPrefix` option default flips `xds` -> `astryx`). This is an opaque,
+StyleX-generated namespace — consumers don't target these classes directly —
+but it completes the removal of `xds` naming from build output. Consumers that
+explicitly configured `libraryPrefix`/`stylexPrefix` are unaffected.

--- a/apps/example-nextjs-source/README.md
+++ b/apps/example-nextjs-source/README.md
@@ -20,7 +20,7 @@ Reference application for compiling **@xds/core** from raw TypeScript + StyleX s
 
 This creates completely independent class namespaces:
 
-- `.xds78zum5 { display: flex }` in `@layer astryx-base`
+- `.astryx78zum5 { display: flex }` in `@layer astryx-base`
 - `.x78zum5 { display: flex }` in `@layer product`
 
 Theme sits between them in `@layer astryx-theme`, so:

--- a/packages/build/README.md
+++ b/packages/build/README.md
@@ -3,7 +3,7 @@
 Build plugins for XDS source builds. Provides babel, PostCSS, and Vite integrations that compile XDS library and product code with separate class name prefixes, which enables independent CSS layers:
 
 ```
-reset < astryx-base (library, xds prefix) < astryx-theme < product (app, x prefix)
+reset < astryx-base (library, astryx prefix) < astryx-theme < product (app, x prefix)
 ```
 
 ## Why?
@@ -12,7 +12,7 @@ StyleX generates atomic CSS: same declaration = same class name. Without separat
 
 `@xds/build` solves this by:
 
-1. Compiling XDS library code with `xds` prefix (`.xds78zum5`)
+1. Compiling XDS library code with `astryx` prefix (`.astryx78zum5`)
 2. Compiling product code with default `x` prefix (`.x78zum5`)
 3. Placing each group in its own CSS `@layer`
 
@@ -179,7 +179,7 @@ export default defineConfig({
 
 ### Babel plugin (`@xds/build/babel`)
 
-Wraps `@stylexjs/babel-plugin` with two internal instances: one with `classNamePrefix: 'xds'` for library files, one with default `'x'` for product files. Routes each file to the correct instance based on its path.
+Wraps `@stylexjs/babel-plugin` with two internal instances: one with `classNamePrefix: 'astryx'` for library files, one with default `'x'` for product files. Routes each file to the correct instance based on its path.
 
 Library patterns (configurable):
 
@@ -215,8 +215,8 @@ Wraps `@stylexjs/unplugin` and intercepts the dev CSS endpoint (`/virtual:stylex
       'node_modules/@xds/',
     ],
 
-    // Class name prefix for library styles (default: 'xds')
-    libraryPrefix: 'xds',
+    // Class name prefix for library styles (default: 'astryx')
+    libraryPrefix: 'astryx',
 
     // Class name prefix for product styles (default: 'x')
     classNamePrefix: 'x',
@@ -232,7 +232,7 @@ Wraps `@stylexjs/unplugin` and intercepts the dev CSS endpoint (`/virtual:stylex
 '@xds/build/postcss': {
   appDir: 'src',           // Your app source directory
   babelPlugins: [...],     // StyleX babel plugin config
-  libraryPrefix: 'xds',   // Prefix for library CSS (default: 'xds')
+  libraryPrefix: 'astryx',   // Prefix for library CSS (default: 'astryx')
   extraInclude: [...],     // Additional glob patterns
   layers: {                // Layer names (defaults shown)
     library: 'astryx-base',

--- a/packages/build/src/babel.js
+++ b/packages/build/src/babel.js
@@ -8,7 +8,7 @@
  * Babel plugin that delegates to @stylexjs/babel-plugin with a
  * different classNamePrefix for XDS library files vs product files.
  *
- * Library files get 'xds' prefix (.xds78zum5), product files get 'x' (.x78zum5).
+ * Library files get 'astryx' prefix (.astryx78zum5), product files get 'x' (.x78zum5).
  */
 
 const XDS_LIBRARY_PATTERNS = [
@@ -23,7 +23,7 @@ module.exports = function xdsBabelPlugin(api, options) {
 
   const {
     libraryPatterns = XDS_LIBRARY_PATTERNS,
-    libraryPrefix = 'xds',
+    libraryPrefix = 'astryx',
     classNamePrefix = 'x',
     ...stylexOptions
   } = options;

--- a/packages/build/src/babel.test.mjs
+++ b/packages/build/src/babel.test.mjs
@@ -4,8 +4,7 @@
  * @file babel.test.mjs
  * @description Verifies that the XDS babel wrapper applies the configured
  *   library StyleX class-name prefix to XDS library files. Part of the
- *   XDS-prefix migration (P2380608025): the prefix defaults to `xds` and is
- *   configurable to `astryx` so the library atom prefix can be rebranded
+ *   the library atom prefix defaults to `astryx` and is configurable
  *   before the final cutover.
  */
 
@@ -51,24 +50,24 @@ function transformLibraryFile(libraryPrefix) {
 /** Extract the StyleX atomic class names referenced in the emitted code. */
 function atomicClasses(code) {
   // StyleX emits atoms like "xds1a2b3c" / "astryx1a2b3c" in the compiled output.
-  return code.match(/\b(?:xds|astryx)[a-z0-9]{4,}\b/g) ?? [];
+  return code.match(/\b(?:xds|astryx|lib)[a-z0-9]{4,}\b/g) ?? [];
 }
 
 describe('xds babel wrapper -- library StyleX prefix', () => {
-  it('defaults library atoms to the `xds` prefix', () => {
+  it('defaults library atoms to the `astryx` prefix', () => {
     const code = transformLibraryFile(undefined);
-    const atoms = atomicClasses(code);
-    expect(atoms.length).toBeGreaterThan(0);
-    expect(atoms.every(c => c.startsWith('xds'))).toBe(true);
-  });
-
-  it('uses the configured `astryx` prefix for library atoms', () => {
-    const code = transformLibraryFile('astryx');
     const atoms = atomicClasses(code);
     expect(atoms.length).toBeGreaterThan(0);
     expect(atoms.every(c => c.startsWith('astryx'))).toBe(true);
     expect(
       atoms.some(c => c.startsWith('xds') && !c.startsWith('astryx')),
     ).toBe(false);
+  });
+
+  it('uses a configured custom prefix for library atoms', () => {
+    const code = transformLibraryFile('lib');
+    const atoms = atomicClasses(code);
+    expect(atoms.length).toBeGreaterThan(0);
+    expect(atoms.every(c => c.startsWith('lib'))).toBe(true);
   });
 });

--- a/packages/build/src/index.js
+++ b/packages/build/src/index.js
@@ -9,7 +9,7 @@
  * XDS library source and product code in two separate passes with
  * different class name prefixes, then outputs them in separate layers:
  *
- *   reset < astryx-base (library, prefix: 'xds') < astryx-theme < product (prefix: 'x')
+ *   reset < astryx-base (library, prefix: 'astryx') < astryx-theme < product (prefix: 'x')
  *
  * The separate prefixes ensure atomic classes don't collide between
  * layers, which would break theme overrides.
@@ -82,7 +82,7 @@ function createPlugin() {
       product: 'product',
     },
     // Class name prefix for library styles (product keeps default 'x')
-    libraryPrefix = 'xds',
+    libraryPrefix = 'astryx',
     extraInclude = [],
     libraryPatterns = XDS_LIBRARY_PATTERNS,
     exclude = [],

--- a/packages/build/src/vite.ts
+++ b/packages/build/src/vite.ts
@@ -29,7 +29,7 @@ export const LIGHTNINGCSS_TARGETS = {
 export interface XDSVitePluginLegacyOptions {
   stylexOptions: Parameters<typeof stylex.vite>[0];
   libraryPattern?: string;
-  /** StyleX atomic class-name prefix for XDS library styles. @default 'xds' */
+  /** StyleX atomic class-name prefix for XDS library styles. @default 'astryx' */
   stylexPrefix?: string;
   layers?: {
     library?: string;
@@ -83,7 +83,7 @@ export interface XDSVitePluginOptions {
    * can rebrand the library atom prefix to `astryx` before the final cutover.
    * Defaults to `xds` so existing consumers are unaffected.
    *
-   * @default 'xds'
+   * @default 'astryx'
    */
   stylexPrefix?: string;
 
@@ -124,7 +124,7 @@ export function xdsStylex(
     libraryPattern = XDS_LIBRARY_PATTERN,
     layers = {},
     lightningcssTargets,
-    stylexPrefix = 'xds',
+    stylexPrefix = 'astryx',
     stylexOverrides = {},
   } = opts;
 
@@ -306,7 +306,7 @@ function xdsStylexLegacy(options: XDSVitePluginLegacyOptions): Plugin[] {
   const {
     stylexOptions,
     libraryPattern = XDS_LIBRARY_PATTERN,
-    stylexPrefix = 'xds',
+    stylexPrefix = 'astryx',
     layers = {},
   } = options;
 


### PR DESCRIPTION
## Summary

Removes `xds` from `@xds/build`'s StyleX output: the library atomic-class prefix default flips `xds` → `astryx` (`.xds78zum5` → `.astryx78zum5`). Part of the broader `xds`-scrub now that the compat layer is gone (#3001).

## Context

`@xds/build` compiles StyleX with two prefixes to avoid atomic-class collisions between **library** code (`libraryPrefix`, default was `xds`) and **product** code (`classNamePrefix`, `x`). This flips the library default to `astryx`, keeping it distinct from the product `x` prefix.

## Changes
- `babel.js` / `index.js` — `libraryPrefix` default `'xds'` → `'astryx'` (+ comments).
- `vite.ts` — `stylexPrefix` default `'xds'` → `'astryx'` (dev + build paths, + jsdoc `@default`).
- `babel.test.mjs` — default test now asserts `astryx`; added a test for an explicitly-configured custom prefix.
- `packages/build/README.md` + example README — doc references (`.astryx78zum5`).

## Notes
- **Opaque namespace** — consumers don't target these atomic classes directly, so impact is minimal. Consumers who explicitly set `libraryPrefix`/`stylexPrefix` are unaffected.
- The pre-built `@xds/core/astryx.css` uses StyleX's default `x` atomic prefix (set by `build-css.mjs`, not this option) — unchanged and unaffected.
- No `@xds/*` package-scope changes (tracked separately).
- Changeset: `[breaking]`, patch bump on `@xds/build`.
