### PR TITLE
refactor: rename XDS_* env vars to ASTRYX_*

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -12,16 +12,16 @@ import xdsPlugin from "./internal/eslint-plugin-astryx/index.js";
  * XDS ESLint Configuration
  *
  * Two-tier linting philosophy:
- * - CI/Agents: Strict mode (errors) - Set XDS_STRICT_LINT=1 or CI=true
+ * - CI/Agents: Strict mode (errors) - Set ASTRYX_STRICT_LINT=1 or CI=true
  * - Humans: Recommended mode (warnings) - Default for local development
  *
  * Usage:
  *   pnpm lint                    # Human mode (warnings)
- *   XDS_STRICT_LINT=1 pnpm lint  # Strict mode (errors)
+ *   ASTRYX_STRICT_LINT=1 pnpm lint  # Strict mode (errors)
  *   CI=true pnpm lint            # Also triggers strict mode
  */
 
-const isStrictMode = process.env.XDS_STRICT_LINT === '1' || process.env.CI === 'true';
+const isStrictMode = process.env.ASTRYX_STRICT_LINT === '1' || process.env.CI === 'true';
 const xdsConfig = isStrictMode ? xdsPlugin.configs.strict : xdsPlugin.configs.recommended;
 const reactSeverity = isStrictMode ? 'error' : 'warn';
 

--- a/internal/eslint-plugin-astryx/README.md
+++ b/internal/eslint-plugin-astryx/README.md
@@ -9,7 +9,7 @@ This plugin implements a two-tier linting strategy:
 | Mode            | Audience  | Behavior            | Trigger                          |
 | --------------- | --------- | ------------------- | -------------------------------- |
 | **Recommended** | Humans    | Warnings only       | Default (local dev)              |
-| **Strict**      | Agents/CI | Errors (fail build) | `CI=true` or `XDS_STRICT_LINT=1` |
+| **Strict**      | Agents/CI | Errors (fail build) | `CI=true` or `ASTRYX_STRICT_LINT=1` |
 
 ### Why Two Tiers?
 
@@ -75,7 +75,7 @@ pnpm lint
 ```bash
 pnpm lint:strict
 # or
-XDS_STRICT_LINT=1 pnpm lint
+ASTRYX_STRICT_LINT=1 pnpm lint
 # or (automatic in GitHub Actions)
 CI=true pnpm lint
 
@@ -111,7 +111,7 @@ The plugin is configured in `eslint.config.js`:
 ```js
 import xdsPlugin from "./internal/eslint-plugin-astryx/index.js";
 
-const isStrictMode = process.env.XDS_STRICT_LINT === '1' || process.env.CI === 'true';
+const isStrictMode = process.env.ASTRYX_STRICT_LINT === '1' || process.env.CI === 'true';
 const xdsConfig = isStrictMode ? xdsPlugin.configs.strict : xdsPlugin.configs.recommended;
 
 // Applied to core package files

--- a/internal/vibe-tests/scripts/publish-report.sh
+++ b/internal/vibe-tests/scripts/publish-report.sh
@@ -26,21 +26,21 @@ if [ $# -lt 1 ]; then
   exit 1
 fi
 
-XDS_ITER="$1"
+ASTRYX_ITER="$1"
 BASELINE_ITER="${2:-}"
 
-ARGS="--iteration $XDS_ITER"
+ARGS="--iteration $ASTRYX_ITER"
 if [ -n "$BASELINE_ITER" ]; then
   ARGS="$ARGS --baseline $BASELINE_ITER"
 fi
 
 echo ""
 echo "📊 Publishing vibe test report"
-echo "   XDS iteration:      $XDS_ITER"
+echo "   XDS iteration:      $ASTRYX_ITER"
 if [ -n "$BASELINE_ITER" ]; then
   echo "   Baseline iteration: $BASELINE_ITER"
 fi
-echo "   Deploy to:          reports/$XDS_ITER/"
+echo "   Deploy to:          reports/$ASTRYX_ITER/"
 echo ""
 
 cd "$VIBE_DIR"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "check:changesets": "node scripts/check-changesets.mjs",
     "check:sync": "node scripts/check-sync.js",
     "lint": "pnpm check:repo && eslint . --cache",
-    "lint:strict": "pnpm check:repo && XDS_STRICT_LINT=1 eslint . --cache",
+    "lint:strict": "pnpm check:repo && ASTRYX_STRICT_LINT=1 eslint . --cache",
     "storybook": "pnpm -F @xds/storybook dev",
     "storybook:build": "pnpm -F @xds/storybook build",
     "docs": "pnpm -F @xds/docs dev",
@@ -30,7 +30,7 @@
     "release": "pnpm build && changeset publish",
     "prepare": "husky install",
     "dev:sandbox": "pnpm -F @xds/core build && pnpm -F @xds/sandbox dev",
-    "dev:sandbox:source": "XDS_SOURCE=1 pnpm -F @xds/sandbox dev"
+    "dev:sandbox:source": "ASTRYX_SOURCE=1 pnpm -F @xds/sandbox dev"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.11.3",

--- a/packages/cli/src/api/doctor.mjs
+++ b/packages/cli/src/api/doctor.mjs
@@ -124,14 +124,14 @@ function findThemePackages(cwd) {
 }
 
 /**
- * Detect whether a theme appears to be wired up via the XDS_THEME env var or
+ * Detect whether a theme appears to be wired up via the ASTRYX_THEME env var or
  * an `xds.theme` field in the nearest package.json. Config-based wiring is
  * handled by the caller (ctx.configTheme). This only inspects static signals.
  * @param {string} cwd
  * @returns {{wired: boolean, source: string|null}}
  */
 function detectThemeWiring(cwd) {
-  if (process.env.XDS_THEME) return {wired: true, source: 'XDS_THEME env var'};
+  if (process.env.ASTRYX_THEME) return {wired: true, source: 'ASTRYX_THEME env var'};
   const nm = findNodeModules(cwd);
   const projectDir = nm ? path.dirname(nm) : cwd;
   const pkg = readPkg(path.join(projectDir, 'package.json'));
@@ -251,7 +251,7 @@ export function checkThemes(ctx) {
       label: 'Theme packages',
       status: 'warn',
       message: `Theme package(s) installed (${names}) but no theme appears wired.`,
-      fix: 'Wire a theme via the `xds.theme` field in package.json, the XDS_THEME env var, or your xds.config.mjs.',
+      fix: 'Wire a theme via the `astryx.theme` field in package.json, the ASTRYX_THEME env var, or your xds.config.mjs.',
     };
   }
 

--- a/packages/cli/src/commands/doctor.test.mjs
+++ b/packages/cli/src/commands/doctor.test.mjs
@@ -38,7 +38,7 @@ beforeEach(() => {
 afterEach(() => {
   fs.rmSync(tmpDir, {recursive: true, force: true});
   vi.restoreAllMocks();
-  delete process.env.XDS_THEME;
+  delete process.env.ASTRYX_THEME;
 });
 
 /** Make a minimal node_modules/@xds/core in tmpDir with the given version. */

--- a/packages/cli/src/commands/gap-report.mjs
+++ b/packages/cli/src/commands/gap-report.mjs
@@ -236,7 +236,7 @@ export function registerGapReport(program) {
     .addHelpText(
       'after',
       '\nSafety:\n' +
-        '  Set XDS_GAP_REPORT=off to disable gap reporting entirely.\n' +
+        '  Set ASTRYX_GAP_REPORT=off to disable gap reporting entirely.\n' +
         '  In non-interactive mode (CI, piped stdout, --json), gap-report is\n' +
         '  dry-run by default. Pass --commit to actually file an issue.\n' +
         '  In interactive mode, you will always be shown a confirmation prompt.\n',
@@ -256,7 +256,7 @@ export function registerGapReport(program) {
       if (!config.enabled) {
         if (json) return jsonError('Gap reporting is disabled', undefined, ERROR_CODES.ERR_GAP_REPORT_FAILED);
         humanLog(
-          `Gap reporting is disabled (XDS_GAP_REPORT=off or xds.config.mjs).\n` +
+          `Gap reporting is disabled (ASTRYX_GAP_REPORT=off or xds.config.mjs).\n` +
             `Run \`${getRunPrefix()} xds gap-report setup\` to configure.`,
         );
         return;

--- a/packages/cli/src/commands/gap-report.test.mjs
+++ b/packages/cli/src/commands/gap-report.test.mjs
@@ -3,7 +3,7 @@
 /**
  * Tests for gap-report safety gates: dry-run-by-default in non-interactive
  * mode, --commit required to actually file, --no-report suppression in swizzle,
- * and XDS_GAP_REPORT=off honored everywhere.
+ * and ASTRYX_GAP_REPORT=off honored everywhere.
  *
  * Regression cases for issues #2370 and #2371: real gap-report issues filed
  * unintentionally in CI/non-TTY runs.
@@ -77,19 +77,19 @@ describe('formatPreview', () => {
   });
 });
 
-describe('XDS_GAP_REPORT=off env var', () => {
+describe('ASTRYX_GAP_REPORT=off env var', () => {
   let originalEnv;
   beforeEach(() => {
-    originalEnv = process.env.XDS_GAP_REPORT;
+    originalEnv = process.env.ASTRYX_GAP_REPORT;
   });
   afterEach(() => {
-    if (originalEnv === undefined) delete process.env.XDS_GAP_REPORT;
-    else process.env.XDS_GAP_REPORT = originalEnv;
+    if (originalEnv === undefined) delete process.env.ASTRYX_GAP_REPORT;
+    else process.env.ASTRYX_GAP_REPORT = originalEnv;
     vi.resetModules();
   });
 
   it('disables gap reporting when set to "off"', async () => {
-    process.env.XDS_GAP_REPORT = 'off';
+    process.env.ASTRYX_GAP_REPORT = 'off';
     vi.resetModules();
     const {loadGapReportConfig, createGapReport} = await import(
       '../utils/github.mjs'
@@ -106,12 +106,12 @@ describe('XDS_GAP_REPORT=off env var', () => {
   });
 
   it('also accepts "false" and "0" as disable values', async () => {
-    process.env.XDS_GAP_REPORT = 'false';
+    process.env.ASTRYX_GAP_REPORT = 'false';
     vi.resetModules();
     let mod = await import('../utils/github.mjs');
     expect(mod.loadGapReportConfig().enabled).toBe(false);
 
-    process.env.XDS_GAP_REPORT = '0';
+    process.env.ASTRYX_GAP_REPORT = '0';
     vi.resetModules();
     mod = await import('../utils/github.mjs');
     expect(mod.loadGapReportConfig().enabled).toBe(false);
@@ -121,13 +121,13 @@ describe('XDS_GAP_REPORT=off env var', () => {
 describe('buildGapReportPreview', () => {
   let originalEnv;
   beforeEach(() => {
-    originalEnv = process.env.XDS_GAP_REPORT;
+    originalEnv = process.env.ASTRYX_GAP_REPORT;
     // Force github mode (default) for these tests.
-    delete process.env.XDS_GAP_REPORT;
+    delete process.env.ASTRYX_GAP_REPORT;
   });
   afterEach(() => {
-    if (originalEnv === undefined) delete process.env.XDS_GAP_REPORT;
-    else process.env.XDS_GAP_REPORT = originalEnv;
+    if (originalEnv === undefined) delete process.env.ASTRYX_GAP_REPORT;
+    else process.env.ASTRYX_GAP_REPORT = originalEnv;
   });
 
   it('renders title and body without invoking gh', async () => {
@@ -149,7 +149,7 @@ describe('buildGapReportPreview', () => {
   });
 
   it('reports disabled mode when env var is off', async () => {
-    process.env.XDS_GAP_REPORT = 'off';
+    process.env.ASTRYX_GAP_REPORT = 'off';
     vi.resetModules();
     const {buildGapReportPreview} = await import('../utils/github.mjs');
     const preview = buildGapReportPreview({

--- a/packages/cli/src/commands/swizzle-gap-safety.test.mjs
+++ b/packages/cli/src/commands/swizzle-gap-safety.test.mjs
@@ -7,7 +7,7 @@
  * defend in depth:
  *
  *   1. We spawn the CLI in a non-TTY pipe → triggers the dry-run gate.
- *   2. We set XDS_GAP_REPORT=off as an extra belt-and-suspenders for tests
+ *   2. We set ASTRYX_GAP_REPORT=off as an extra belt-and-suspenders for tests
  *      that would otherwise risk filing.
  *   3. We unset GH_TOKEN so that any unexpected `gh` invocation fails fast.
  *   4. We put a sabotaged `gh` shim earlier on PATH that blocks real
@@ -133,7 +133,7 @@ describe('gap-report: dry-run by default in non-interactive mode', () => {
     expect(parsed.data.wouldFile).toBe(true);
   });
 
-  it('XDS_GAP_REPORT=off → no gh call, even with --commit flag', () => {
+  it('ASTRYX_GAP_REPORT=off → no gh call, even with --commit flag', () => {
     const r = runXds(
       [
         'gap-report',
@@ -145,7 +145,7 @@ describe('gap-report: dry-run by default in non-interactive mode', () => {
         'should be disabled',
         '--commit',
       ],
-      {env: {XDS_GAP_REPORT: 'off'}},
+      {env: {ASTRYX_GAP_REPORT: 'off'}},
     );
     // Should exit 0 with a "disabled" message; never calls gh.
     expect(r.ghWasCalled).toBe(false);
@@ -168,7 +168,7 @@ describe('gap-report: dry-run by default in non-interactive mode', () => {
         'commit flag should engage filing',
         '--commit',
       ],
-      {env: {XDS_GAP_REPORT: ''}}, // re-enable feature; shim will block real call
+      {env: {ASTRYX_GAP_REPORT: ''}}, // re-enable feature; shim will block real call
     );
     expect(r.ghWasCalled).toBe(true);
     expect(r.ghCallArgs).toContain('issue');
@@ -246,13 +246,13 @@ describe('swizzle --gap respects safety gates', () => {
         '--no-report',
         '--commit',
       ],
-      {env: {XDS_GAP_REPORT: ''}},
+      {env: {ASTRYX_GAP_REPORT: ''}},
     );
     expect(r.ghWasCalled).toBe(false);
     expect(r.status).toBe(0);
   });
 
-  it('swizzle --gap with XDS_GAP_REPORT=off → no gh call', () => {
+  it('swizzle --gap with ASTRYX_GAP_REPORT=off → no gh call', () => {
     const r = runXds(
       [
         'swizzle',
@@ -265,7 +265,7 @@ describe('swizzle --gap respects safety gates', () => {
         'other',
         '--commit',
       ],
-      {env: {XDS_GAP_REPORT: 'off'}},
+      {env: {ASTRYX_GAP_REPORT: 'off'}},
     );
     expect(r.ghWasCalled).toBe(false);
     expect(r.status).toBe(0);

--- a/packages/cli/src/lib/resolve-theme.mjs
+++ b/packages/cli/src/lib/resolve-theme.mjs
@@ -4,7 +4,7 @@
  * @file Theme resolution — resolve a theme from config or environment
  *
  * Resolution sources (in priority order):
- * 1. XDS_THEME environment variable
+ * 1. ASTRYX_THEME environment variable
  * 2. xds.theme field in package.json
  *
  * Resolution strategy for the value:
@@ -84,7 +84,7 @@ function extractTheme(mod) {
  */
 export function resolveTheme(cwd = process.cwd()) {
   // 1. Determine theme specifier
-  let specifier = process.env.XDS_THEME || null;
+  let specifier = process.env.ASTRYX_THEME || null;
 
   if (!specifier) {
     // Read from package.json

--- a/packages/cli/src/utils/github.mjs
+++ b/packages/cli/src/utils/github.mjs
@@ -11,8 +11,8 @@
  *   gapReport: { command: './scripts/report-gap.sh' } — run custom script (receives JSON on stdin)
  *
  * Or via environment variable:
- *   XDS_GAP_REPORT=off                              — disable entirely
- *   XDS_GAP_REPORT=./scripts/report-gap.sh          — run custom script
+ *   ASTRYX_GAP_REPORT=off                              — disable entirely
+ *   ASTRYX_GAP_REPORT=./scripts/report-gap.sh          — run custom script
  */
 
 import {execFileSync} from 'node:child_process';
@@ -46,7 +46,7 @@ export const GAP_CATEGORIES = [
  */
 export function loadGapReportConfig() {
   // 1. Check environment variable
-  const envVar = process.env.XDS_GAP_REPORT;
+  const envVar = process.env.ASTRYX_GAP_REPORT;
   if (envVar) {
     if (envVar === 'off' || envVar === 'false' || envVar === '0') {
       return {enabled: false};

--- a/packages/cli/src/utils/update-check.mjs
+++ b/packages/cli/src/utils/update-check.mjs
@@ -4,12 +4,12 @@
  * @file Check for newer @xds/core versions via local signals.
  *
  * Resolution order:
- * 1. $XDS_LATEST_VERSION env var (set by previous CLI invocation)
+ * 1. $ASTRYX_LATEST_VERSION env var (set by previous CLI invocation)
  * 2. xds.versionFile in consumer's package.json (e.g. ../../libs/xds-common/LATEST_VERSION)
  * 3. If neither: no hint (no network calls from this module)
  *
  * When a newer version is detected, returns a hint string for CLI output.
- * Also sets $XDS_LATEST_VERSION for subsequent commands in the same shell.
+ * Also sets $ASTRYX_LATEST_VERSION for subsequent commands in the same shell.
  */
 
 import * as fs from 'node:fs';
@@ -25,7 +25,7 @@ import {semverGt} from './semver.mjs';
  */
 export function getLatestVersion(cwd = process.cwd()) {
   // 1. Check env var (fastest — set by previous CLI run)
-  const envVersion = process.env.XDS_LATEST_VERSION;
+  const envVersion = process.env.ASTRYX_LATEST_VERSION;
   if (envVersion && /^\d+\.\d+\.\d+/.test(envVersion)) {
     return envVersion;
   }
@@ -79,7 +79,7 @@ export function getInstalledVersion(cwd = process.cwd()) {
 
 /**
  * Check for available updates and return a hint string if one exists.
- * Also sets $XDS_LATEST_VERSION env var for subsequent commands.
+ * Also sets $ASTRYX_LATEST_VERSION env var for subsequent commands.
  *
  * @param {string} [cwd] - Project directory
  * @returns {string|null} FYI hint string, or null if up to date / unknown
@@ -89,7 +89,7 @@ export function checkForUpdate(cwd = process.cwd()) {
   if (!latest) return null;
 
   // Persist for subsequent commands in this shell session
-  process.env.XDS_LATEST_VERSION = latest;
+  process.env.ASTRYX_LATEST_VERSION = latest;
 
   const installed = getInstalledVersion(cwd);
   if (!installed) return null;

--- a/packages/cli/src/utils/update-check.test.mjs
+++ b/packages/cli/src/utils/update-check.test.mjs
@@ -16,28 +16,28 @@ const originalEnv = {};
 beforeEach(() => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'xds-update-check-'));
   // Save and clear env
-  originalEnv.XDS_LATEST_VERSION = process.env.XDS_LATEST_VERSION;
-  delete process.env.XDS_LATEST_VERSION;
+  originalEnv.ASTRYX_LATEST_VERSION = process.env.ASTRYX_LATEST_VERSION;
+  delete process.env.ASTRYX_LATEST_VERSION;
 });
 
 afterEach(() => {
   fs.rmSync(tmpDir, {recursive: true, force: true});
   // Restore env
-  if (originalEnv.XDS_LATEST_VERSION !== undefined) {
-    process.env.XDS_LATEST_VERSION = originalEnv.XDS_LATEST_VERSION;
+  if (originalEnv.ASTRYX_LATEST_VERSION !== undefined) {
+    process.env.ASTRYX_LATEST_VERSION = originalEnv.ASTRYX_LATEST_VERSION;
   } else {
-    delete process.env.XDS_LATEST_VERSION;
+    delete process.env.ASTRYX_LATEST_VERSION;
   }
 });
 
 describe('getLatestVersion', () => {
-  it('reads from XDS_LATEST_VERSION env var', () => {
-    process.env.XDS_LATEST_VERSION = '0.0.8';
+  it('reads from ASTRYX_LATEST_VERSION env var', () => {
+    process.env.ASTRYX_LATEST_VERSION = '0.0.8';
     expect(getLatestVersion(tmpDir)).toBe('0.0.8');
   });
 
   it('ignores invalid env var values', () => {
-    process.env.XDS_LATEST_VERSION = 'not-a-version';
+    process.env.ASTRYX_LATEST_VERSION = 'not-a-version';
     expect(getLatestVersion(tmpDir)).toBeNull();
   });
 
@@ -69,7 +69,7 @@ describe('getLatestVersion', () => {
   });
 
   it('env var takes priority over versionFile', () => {
-    process.env.XDS_LATEST_VERSION = '1.0.0';
+    process.env.ASTRYX_LATEST_VERSION = '1.0.0';
     const versionFilePath = path.join(tmpDir, 'LATEST_VERSION');
     fs.writeFileSync(versionFilePath, '0.0.9\n');
     fs.writeFileSync(
@@ -109,7 +109,7 @@ describe('getInstalledVersion', () => {
 
 describe('checkForUpdate', () => {
   it('returns hint when newer version is available', () => {
-    process.env.XDS_LATEST_VERSION = '0.0.8';
+    process.env.ASTRYX_LATEST_VERSION = '0.0.8';
     fs.writeFileSync(
       path.join(tmpDir, 'package.json'),
       JSON.stringify({dependencies: {'@xds/core': '^0.0.7'}}),
@@ -122,7 +122,7 @@ describe('checkForUpdate', () => {
   });
 
   it('returns null when up to date', () => {
-    process.env.XDS_LATEST_VERSION = '0.0.7';
+    process.env.ASTRYX_LATEST_VERSION = '0.0.7';
     fs.writeFileSync(
       path.join(tmpDir, 'package.json'),
       JSON.stringify({dependencies: {'@xds/core': '^0.0.7'}}),
@@ -152,7 +152,7 @@ describe('checkForUpdate', () => {
     );
 
     checkForUpdate(tmpDir);
-    expect(process.env.XDS_LATEST_VERSION).toBe('0.0.8');
+    expect(process.env.ASTRYX_LATEST_VERSION).toBe('0.0.8');
   });
 
   it('reads from versionFile and produces hint', () => {
@@ -175,7 +175,7 @@ describe('checkForUpdate', () => {
     // Regression: with string compare, '0.0.20' > '0.0.5' is false because
     // '2' < '5' lexicographically. Users on 0.0.5 would never be told that
     // 0.0.20 is available.
-    process.env.XDS_LATEST_VERSION = '0.0.20';
+    process.env.ASTRYX_LATEST_VERSION = '0.0.20';
     fs.writeFileSync(
       path.join(tmpDir, 'package.json'),
       JSON.stringify({dependencies: {'@xds/core': '^0.0.5'}}),
@@ -188,7 +188,7 @@ describe('checkForUpdate', () => {
   it('does not suggest an upgrade when latest < installed (semver)', () => {
     // The mirror-image bug: '0.0.9' > '0.0.10' is true under string compare,
     // so a stale env hint of 0.0.9 would falsely claim it's "newer" than 0.0.10.
-    process.env.XDS_LATEST_VERSION = '0.0.9';
+    process.env.ASTRYX_LATEST_VERSION = '0.0.9';
     fs.writeFileSync(
       path.join(tmpDir, 'package.json'),
       JSON.stringify({dependencies: {'@xds/core': '^0.0.10'}}),


### PR DESCRIPTION
## Summary

Renames the runtime env-var contract from `XDS_*` to `ASTRYX_*`, part of scrubbing remaining `xds` naming.

## Renamed
| Old | New | Used by |
|---|---|---|
| `XDS_THEME` | `ASTRYX_THEME` | theme resolution (`resolve-theme`, `doctor`) |
| `XDS_GAP_REPORT` | `ASTRYX_GAP_REPORT` | gap-report enable/disable toggle |
| `XDS_LATEST_VERSION` | `ASTRYX_LATEST_VERSION` | update-check version cache |
| `XDS_STRICT_LINT` | `ASTRYX_STRICT_LINT` | eslint strict mode (+ `lint:strict` script) |
| `XDS_SOURCE` | `ASTRYX_SOURCE` | sandbox source-dev script |
| `XDS_ITER` | `ASTRYX_ITER` | vibe-tests publish script |

Updated all `process.env` reads, `package.json` scripts, the shell setter, `eslint.config.js`, and CLI commands/tests/docs.

## Also
Fixed a stale post-#3001 reference: `doctor`'s theme-wiring hint said to use the `xds.theme` package.json field, but the CLI now reads `astryx.theme` (changed in #3001).

## Out of scope (separate tasks)
- Internal `XDS_*` **JS constants** (`XDS_LIBRARY_PATTERNS`, `XDS_MARKER_*`, `XDS_CORE_DIR`, `XDS_LAYOUT_ELEMENTS`, `XDS_CORE_SOURCE`) — these are local identifiers, not env vars.
- The `xds.config.mjs` **config-file name** — a separate consumer-facing surface.
- `@xds/*` package scope.

## Validation
`check:sync` + `check:package-boundaries` pass locally; relying on CI for full lint/typecheck/test. No published-package API surface changes (no changeset needed).
