### PR TITLE
docs(pages): update GitHub Pages URLs to facebook.github.io/astryx

### DIFF
--- a/.claude/commands/vibe-test.md
+++ b/.claude/commands/vibe-test.md
@@ -131,7 +131,7 @@ pnpm aggregate --iteration <xds-id>
 pnpm report:deploy --iteration <xds-id> --baseline <baseline-id> --html <html-id>
 ```
 
-Report URL: `https://facebookexperimental.github.io/xds/reports/<xds-id>/`
+Report URL: `https://facebook.github.io/astryx/reports/<xds-id>/`
 
 ### Step 7: Post results
 

--- a/apps/sandbox/README.md
+++ b/apps/sandbox/README.md
@@ -25,7 +25,7 @@ npx xds init --features agents
 The sandbox is a Next.js app configured for static export (`output: 'export'`). On PRs, the CI workflow builds it and deploys to GitHub Pages at a versioned URL:
 
 ```
-https://facebookexperimental.github.io/xds/{commit}/sandbox/
+https://facebook.github.io/astryx/{commit}/sandbox/
 ```
 
 ## Adding a new page

--- a/internal/vibe-tests/scripts/publish-report.sh
+++ b/internal/vibe-tests/scripts/publish-report.sh
@@ -22,7 +22,7 @@ if [ $# -lt 1 ]; then
   echo "Usage: $0 <xds-iteration> [baseline-iteration]"
   echo ""
   echo "Builds and deploys a vibe test report to GitHub Pages."
-  echo "Report URL: https://facebookexperimental.github.io/xds/reports/<xds-iteration>/"
+  echo "Report URL: https://facebook.github.io/astryx/reports/<xds-iteration>/"
   exit 1
 fi
 

--- a/internal/vibe-tests/src/post-design-results.py
+++ b/internal/vibe-tests/src/post-design-results.py
@@ -67,7 +67,7 @@ PROMPT_LABELS = {
 
 
 # GitHub Pages base URL for the XDS repo
-GH_PAGES_BASE = "https://studious-broccoli-o7e61n3.pages.github.io"
+GH_PAGES_BASE = "https://facebook.github.io/astryx"
 
 
 def img_url(iteration_id, filename):

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -57,7 +57,7 @@ npx xds gap-report                   # report a missing capability
 
 ## Resources
 
-- [Component Storybook](https://facebookexperimental.github.io/xds/)
+- [Component Storybook](https://facebook.github.io/astryx/)
 - [GitHub Repository](https://github.com/facebookexperimental/xds)
 
 ---


### PR DESCRIPTION
## Summary

Updates GitHub Pages URLs to the new repo's Pages site. Two related fixes:

1. **`studious-broccoli` codename → clean URL.** `post-design-results.py` hard-coded `https://studious-broccoli-o7e61n3.pages.github.io` — the opaque codename GitHub assigned to the (private) repo's Pages backing host. Replaced with the repo-aligned `https://facebook.github.io/astryx`, which 301-redirects to that same Pages site and survives future Pages re-provisioning.

2. **Stale old-org URLs → new.** Four refs still pointed at `https://facebookexperimental.github.io/xds/...`, which now returns **404** (the old org subpath no longer serves; `facebook.github.io/astryx` does). Updated to the new path.

## Files changed

| File | Old | New |
|---|---|---|
| `internal/vibe-tests/src/post-design-results.py` | `studious-broccoli-o7e61n3.pages.github.io` | `facebook.github.io/astryx` |
| `.claude/commands/vibe-test.md` | `facebookexperimental.github.io/xds` | `facebook.github.io/astryx` |
| `apps/sandbox/README.md` | `facebookexperimental.github.io/xds` | `facebook.github.io/astryx` |
| `internal/vibe-tests/scripts/publish-report.sh` | `facebookexperimental.github.io/xds` | `facebook.github.io/astryx` |
| `packages/core/README.md` | `facebookexperimental.github.io/xds` | `facebook.github.io/astryx` |

Base URL has no trailing slash, matching the existing convention in `apps/docsite/src/constants.ts` (`GITHUB_PAGES`).

## Scope note

This PR touches **only** GitHub Pages URLs. Repo-source links (`github.com/facebookexperimental/xds`, ~122 refs) are left alone — GitHub redirects them transparently and they aren't broken; that's a separate rename if desired.

## Caveat (pre-existing)

`facebook/astryx` Pages is currently **private**, so all these URLs redirect to GitHub login — design-judge images won't render for logged-out viewers. Unchanged by this PR.

## Test plan

- `python3 -m py_compile internal/vibe-tests/src/post-design-results.py` passes
- Verified zero remaining `studious-broccoli` / `facebookexperimental.github.io` refs in the tree
- `https://facebook.github.io/astryx/` returns 200 (301 → Pages host); old `facebookexperimental.github.io/xds/` returns 404