### PR TITLE
refactor: rename xds-* runtime keys/events (sandbox + docsite)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,7 @@ e2e/playwright/.cache/
 internal/vibe-tests/results/
 
 # XDS agent docs (generated)
-.xds-docs/
+.astryx-docs/
 apps/sandbox/.next/
 apps/sandbox/out/
 apps/sandbox/next-env.d.ts

--- a/apps/docsite/src/app/playground/PlaygroundClient.tsx
+++ b/apps/docsite/src/app/playground/PlaygroundClient.tsx
@@ -296,7 +296,7 @@ export function PlaygroundClient({defaultIsMobile}: PlaygroundClientProps) {
     defaultSize: 440,
     minSizePx: 340,
     maxSizePx: 760,
-    autoSaveId: 'xds-playground-left-width',
+    autoSaveId: 'astryx-playground-left-width',
   });
 
   // Seed the preview mode once from the docsite's mode; afterward the toolbar

--- a/apps/sandbox/src/app/(fullscreen)/PreviewShell.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/PreviewShell.tsx
@@ -310,7 +310,7 @@ export function PreviewShell({children}: {children: React.ReactNode}) {
       return;
     }
     iframe.contentWindow.postMessage(
-      {type: 'xds-theme-sync', theme: themeName, mode},
+      {type: 'astryx-theme-sync', theme: themeName, mode},
       '*',
     );
   }, [themeName, mode]);

--- a/apps/sandbox/src/app/layout.tsx
+++ b/apps/sandbox/src/app/layout.tsx
@@ -27,12 +27,12 @@ export default function RootLayout({children}: {children: React.ReactNode}) {
             Runs before paint so the toolbar is never visible in embed contexts. */}
         <script
           dangerouslySetInnerHTML={{
-            __html: `try{if(window.self!==window.top)document.documentElement.classList.add('xds-embed')}catch(e){document.documentElement.classList.add('xds-embed')}`,
+            __html: `try{if(window.self!==window.top)document.documentElement.classList.add('astryx-embed')}catch(e){document.documentElement.classList.add('astryx-embed')}`,
           }}
         />
         <style
           dangerouslySetInnerHTML={{
-            __html: `html.xds-embed [data-preview-shell]{display:none!important}`,
+            __html: `html.astryx-embed [data-preview-shell]{display:none!important}`,
           }}
         />
       </head>

--- a/apps/sandbox/src/app/providers.tsx
+++ b/apps/sandbox/src/app/providers.tsx
@@ -59,8 +59,8 @@ const ThemeContext = createContext<ThemeContextValue>({
 
 export const useThemeControls = () => useContext(ThemeContext);
 
-const THEME_STORAGE_KEY = 'xds-sandbox-theme';
-const MODE_STORAGE_KEY = 'xds-sandbox-mode';
+const THEME_STORAGE_KEY = 'astryx-sandbox-theme';
+const MODE_STORAGE_KEY = 'astryx-sandbox-mode';
 
 /**
  * Reads theme/mode from URL search params when rendered inside an embed iframe.
@@ -155,7 +155,7 @@ export function Providers({children}: {children: React.ReactNode}) {
       return;
     }
     const handler = (event: MessageEvent) => {
-      if (event.data?.type === 'xds-theme-sync') {
+      if (event.data?.type === 'astryx-theme-sync') {
         const {theme: newTheme, mode: newMode} = event.data;
         if (newTheme && newTheme in themes) {
           setThemeName(newTheme);

--- a/internal/vibe-tests/.gitignore
+++ b/internal/vibe-tests/.gitignore
@@ -1,5 +1,5 @@
 # XDS agent docs (generated)
-.xds-docs/
+.astryx-docs/
 AGENTS.md
 
 # Baseline comparison docs (generated)

--- a/scripts/package-source.js
+++ b/scripts/package-source.js
@@ -270,7 +270,7 @@ node src/xds/setup.mjs
 
 This will:
 - Ask if you want to add XDS guidance to your AGENTS.md
-- Create a \`.xds-docs/\` folder with component documentation
+- Create a \`.astryx-docs/\` folder with component documentation
 
 ## Version
 


### PR DESCRIPTION
## Summary

Renames app-local runtime keys/events/classes off the `xds` name, in the sandbox and docsite (both private apps; all keys are self-contained).

## Changes
- **sandbox** (`apps/sandbox`):
  - localStorage keys `xds-sandbox-theme` / `xds-sandbox-mode` → `astryx-sandbox-*`
  - `xds-theme-sync` postMessage type → `astryx-theme-sync` (send in PreviewShell + recv in providers)
  - `xds-embed` html class → `astryx-embed` (set in layout + its inline `<style>` rule)
- **docsite** playground: `autoSaveId: 'xds-playground-left-width'` → `astryx-*`
- `.xds-docs/` → `.astryx-docs/` in `.gitignore` (×2) and the `package-source.js` doc string

## Notes
- The localStorage renames reset a saved theme/panel value **once** on first load — acceptable for internal dev apps.
- Out of scope: build-plugin internal `name:` fields (`xds-css-layer-order`, `xds-babel-plugin`, etc. — internal identifiers, separate sweep), codemod fixtures, and `@xds/*` package scope.

## Validation
`check:sync` + `check:package-boundaries` pass; postMessage send/recv and storage read/write are self-consistent. Relying on CI for full lint/typecheck/build.
