### PR TITLE
refactor(cli): rename XDSError class to AstryxError

### DIFF
--- a/.changeset/cli-astryx-error.md
+++ b/.changeset/cli-astryx-error.md
@@ -1,0 +1,11 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[breaking] Rename the exported `XDSError` class to `AstryxError`
+@ejhammond
+
+The CLI's programmatic API error class is renamed `XDSError` -> `AstryxError`
+(exported from `@xds/cli` + declared in its types). Consumers that catch or
+reference `XDSError` from the CLI's API should switch to `AstryxError`. Part of
+removing `xds` naming from the public API.

--- a/packages/cli/CONTRIBUTING.md
+++ b/packages/cli/CONTRIBUTING.md
@@ -21,12 +21,12 @@ Both paths run identical code. The CLI handler just adds argument parsing and ou
 ```
 src/
   api/                         # Programmatic API (exported as @astryxdesign/cli/api)
-    index.mjs                  # barrel: component, docs, discover, template, XDSError
+    index.mjs                  # barrel: component, docs, discover, template, AstryxError
     component.mjs              # component(name?, opts?) → { type, data }
     docs.mjs                   # docs(topic?, section?, opts?) → { type, data }
     discover.mjs               # discover(query?, opts?) → { type, data }
     template.mjs               # template(name?, opts?) → { type, data }
-    error.mjs                  # XDSError class (carries .suggestions)
+    error.mjs                  # AstryxError class (carries .suggestions)
   commands/                    # CLI wrappers (thin: parse args → call API → format output)
     component/index.mjs        # calls api/component.mjs
     docs.mjs                   # calls api/docs.mjs
@@ -42,7 +42,7 @@ src/
     json.mjs                   # jsonOut(type, data), jsonError(msg) — internal
     parse.mjs                  # parseResponse, isError, assertResponse — consumer
   types/
-    api.d.ts                   # API function signatures + XDSError
+    api.d.ts                   # API function signatures + AstryxError
     base.d.ts                  # CLIError, CLIResult<T>, CLIAnyResponse, CLIResponseType
     component.d.ts             # ComponentListResponse, ComponentDetailResponse, ...
     discover.d.ts              # DiscoverListResponse, ...
@@ -67,11 +67,11 @@ src/
 
 ### 1. Write the API function
 
-Add a file in `src/api/` with all the logic. It returns `{ type, data }` on success and throws `XDSError` on failure. The CLI handler should have zero logic — just arg parsing and text formatting:
+Add a file in `src/api/` with all the logic. It returns `{ type, data }` on success and throws `AstryxError` on failure. The CLI handler should have zero logic — just arg parsing and text formatting:
 
 ```javascript
 // src/api/my-command.mjs
-import {XDSError} from './error.mjs';
+import {AstryxError} from './error.mjs';
 
 export async function myCommand(name, options = {}) {
   if (!name) {
@@ -80,7 +80,7 @@ export async function myCommand(name, options = {}) {
 
   const item = findItem(name);
   if (!item) {
-    throw new XDSError(`Item "${name}" not found`, suggestions);
+    throw new AstryxError(`Item "${name}" not found`, suggestions);
   }
 
   return {type: 'my-command.detail', data: item};

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -97,7 +97,7 @@ The `code` field is a **stable, machine-readable identifier**. Branch on it,
 never on the human-readable `error` string, which changes freely as we improve
 wording. Every error envelope carries a `code` (falling back to `ERR_UNKNOWN`
 when no more specific code applies). The same `code` is exposed on thrown
-`XDSError` instances from the programmatic API, so both surfaces agree.
+`AstryxError` instances from the programmatic API, so both surfaces agree.
 
 Codes are **append-only**: once shipped, a code's meaning never changes and a
 code is never removed. New error conditions get new codes.
@@ -225,7 +225,7 @@ For the standalone manifest envelope (`type: "manifest"`), use `xds manifest --j
 The same logic that powers `xds --json` is available as importable, type-safe functions:
 
 ```typescript
-import {component, docs, discover, template, hook, search, XDSError} from '@astryxdesign/cli/api';
+import {component, docs, discover, template, hook, search, AstryxError} from '@astryxdesign/cli/api';
 
 // Same result as: xds --json component Button
 const btn = await component('Button');
@@ -244,7 +244,7 @@ principles.data.title; // 'XDS Principles'
 const useMediaQuery = await hook('useMediaQuery');
 useMediaQuery.data.params; // typed as HookParamDoc[]
 
-// Errors throw XDSError with a stable .code and optional .suggestions
+// Errors throw AstryxError with a stable .code and optional .suggestions
 try {
   await component('Buttn');
 } catch (e) {

--- a/packages/cli/src/api/component.mjs
+++ b/packages/cli/src/api/component.mjs
@@ -20,7 +20,7 @@ import {
 } from '../lib/component-discovery.mjs';
 import {loadDocs} from '../lib/component-loader.mjs';
 import {searchComponents} from '../lib/string-utils.mjs';
-import {XDSError} from './error.mjs';
+import {AstryxError} from './error.mjs';
 import {findShowcase, findRelatedBlocks} from './template.mjs';
 
 /**
@@ -76,7 +76,7 @@ export async function component(name, options = {}) {
 
   const coreDir = findCoreDir(cwd);
   if (!coreDir) {
-    throw new XDSError('Could not find @astryxdesign/core package', undefined, ERROR_CODES.ERR_CORE_NOT_FOUND);
+    throw new AstryxError('Could not find @astryxdesign/core package', undefined, ERROR_CODES.ERR_CORE_NOT_FOUND);
   }
 
   // ── List mode ──────────────────────────────────────────────────
@@ -89,7 +89,7 @@ export async function component(name, options = {}) {
         ([key]) => key.toLowerCase() === category.toLowerCase(),
       );
       if (!match) {
-        throw new XDSError(
+        throw new AstryxError(
           `Unknown category "${category}"`,
           Object.keys(components).map(k => ({name: k, reason: 'valid category'})),
           ERROR_CODES.ERR_UNKNOWN_CATEGORY,
@@ -218,13 +218,13 @@ export async function component(name, options = {}) {
   if (packageScope) {
     const ext = resolveExternalPackage(packageScope, cwd);
     if (!ext) {
-      throw new XDSError(`External package "${packageScope}" not found`, undefined, ERROR_CODES.ERR_UNKNOWN_PACKAGE);
+      throw new AstryxError(`External package "${packageScope}" not found`, undefined, ERROR_CODES.ERR_UNKNOWN_PACKAGE);
     }
 
     if (showcase) {
       const match = await findShowcase(dirName, cwd, {package: packageScope});
       if (!match) {
-        throw new XDSError(`No showcase found for "${name}" in package "${packageScope}"`, undefined, ERROR_CODES.ERR_NO_SHOWCASE);
+        throw new AstryxError(`No showcase found for "${name}" in package "${packageScope}"`, undefined, ERROR_CODES.ERR_NO_SHOWCASE);
       }
       return {
         type: 'component.detail.showcase',
@@ -246,13 +246,13 @@ export async function component(name, options = {}) {
       }
       return {type: 'component.detail', data: docs};
     }
-    throw new XDSError(`No component "${name}" in package "${packageScope}"`, undefined, ERROR_CODES.ERR_UNKNOWN_COMPONENT);
+    throw new AstryxError(`No component "${name}" in package "${packageScope}"`, undefined, ERROR_CODES.ERR_UNKNOWN_COMPONENT);
   }
 
   if (source) {
     const sourcePath = findComponentSource(coreDir, dirName);
     if (!sourcePath) {
-      throw new XDSError(`Source for "${name}" not found`, undefined, ERROR_CODES.ERR_NO_SOURCE);
+      throw new AstryxError(`Source for "${name}" not found`, undefined, ERROR_CODES.ERR_NO_SOURCE);
     }
     return {type: 'component.detail.source', data: {component: dirName, source: fs.readFileSync(sourcePath, 'utf-8')}};
   }
@@ -260,7 +260,7 @@ export async function component(name, options = {}) {
   if (showcase) {
     const match = await findShowcase(dirName, cwd);
     if (!match) {
-      throw new XDSError(`No showcase found for "${name}"`, undefined, ERROR_CODES.ERR_NO_SHOWCASE);
+      throw new AstryxError(`No showcase found for "${name}"`, undefined, ERROR_CODES.ERR_NO_SHOWCASE);
     }
     return {
       type: 'component.detail.showcase',
@@ -303,19 +303,19 @@ export async function component(name, options = {}) {
         const threshold = Math.max(topScore - 20, 1);
         const candidates = results.filter(r => r.score >= threshold).slice(0, 5);
         if (candidates.length < 2) candidates.push(...results.slice(candidates.length, 2));
-        throw new XDSError(
+        throw new AstryxError(
           `No component named "${name}"`,
           candidates.map(c => ({name: c.name, reason: c.reason})),
           ERROR_CODES.ERR_UNKNOWN_COMPONENT,
         );
       }
     } else {
-      throw new XDSError(`No component named "${name}"`, undefined, ERROR_CODES.ERR_UNKNOWN_COMPONENT);
+      throw new AstryxError(`No component named "${name}"`, undefined, ERROR_CODES.ERR_UNKNOWN_COMPONENT);
     }
   }
 
   if (!readmePath || !readmePath.endsWith('.doc.mjs')) {
-    throw new XDSError(`No .doc.mjs found for "${resolvedName}". The component needs a typed doc file.`, undefined, ERROR_CODES.ERR_NO_DOC);
+    throw new AstryxError(`No .doc.mjs found for "${resolvedName}". The component needs a typed doc file.`, undefined, ERROR_CODES.ERR_NO_DOC);
   }
 
   const docs = await loadDocs(readmePath, {zh, dense, lang});

--- a/packages/cli/src/api/discover.mjs
+++ b/packages/cli/src/api/discover.mjs
@@ -8,7 +8,7 @@ import {loadConfig} from '../lib/config.mjs';
 import {scanAllPackages, findComponentInPackages} from '../lib/package-scanner.mjs';
 import {loadDocs} from '../lib/component-loader.mjs';
 import {levenshteinDistance} from '../lib/string-utils.mjs';
-import {XDSError} from './error.mjs';
+import {AstryxError} from './error.mjs';
 import {ERROR_CODES} from '../lib/error-codes.mjs';
 
 function validateDocs(docs) {
@@ -66,7 +66,7 @@ export async function discover(query, options = {}) {
 
     const pkg = packages.find(p => p.name === query);
     if (!pkg) {
-      throw new XDSError(
+      throw new AstryxError(
         `Package "${query}" not found`,
         packages.map(p => ({name: p.name, reason: 'available package'})),
         ERROR_CODES.ERR_UNKNOWN_PACKAGE,
@@ -116,19 +116,19 @@ export async function discover(query, options = {}) {
     .slice(0, 5);
 
   if (fuzzyMatches.length > 0) {
-    throw new XDSError(
+    throw new AstryxError(
       `"${query}" not found`,
       fuzzyMatches.map(m => ({name: m.pkg.name + '/' + m.comp, reason: 'similar name'})),
       ERROR_CODES.ERR_NOT_FOUND,
     );
   }
 
-  throw new XDSError(`"${query}" not found in any package`, undefined, ERROR_CODES.ERR_NOT_FOUND);
+  throw new AstryxError(`"${query}" not found in any package`, undefined, ERROR_CODES.ERR_NOT_FOUND);
 }
 
 async function resolveComponentDocs(packages, compName, pkgName, {lang, zh}) {
   const pkg = packages.find(p => p.name === pkgName);
-  if (!pkg) throw new XDSError(`Package "${pkgName}" not found`, undefined, ERROR_CODES.ERR_UNKNOWN_PACKAGE);
+  if (!pkg) throw new AstryxError(`Package "${pkgName}" not found`, undefined, ERROR_CODES.ERR_UNKNOWN_PACKAGE);
 
   const result = findComponentInPackages([pkg], compName);
   if (!result) {
@@ -142,7 +142,7 @@ async function resolveComponentDocs(packages, compName, pkgName, {lang, zh}) {
         .sort((a, b) => a.distance - b.distance)
         .slice(0, 5)
         .map(m => m.name);
-    throw new XDSError(
+    throw new AstryxError(
       `Component "${compName}" not found in ${pkgName}`,
       suggestions.map(s => ({name: s, reason: 'similar name'})),
       ERROR_CODES.ERR_UNKNOWN_COMPONENT,
@@ -157,9 +157,9 @@ async function loadAndValidate(result, {lang, zh}) {
   try {
     docs = await loadDocs(result.docPath, {zh, lang});
   } catch (e) {
-    throw new XDSError(`Failed to load docs for ${result.componentName}: ${e.message}`, undefined, ERROR_CODES.ERR_INVALID_DOC);
+    throw new AstryxError(`Failed to load docs for ${result.componentName}: ${e.message}`, undefined, ERROR_CODES.ERR_INVALID_DOC);
   }
   const err = validateDocs(docs);
-  if (err) throw new XDSError(`Invalid docs for ${result.componentName}: ${err}`, undefined, ERROR_CODES.ERR_INVALID_DOC);
+  if (err) throw new AstryxError(`Invalid docs for ${result.componentName}: ${err}`, undefined, ERROR_CODES.ERR_INVALID_DOC);
   return {type: 'discover.detail.doc', data: docs};
 }

--- a/packages/cli/src/api/docs.mjs
+++ b/packages/cli/src/api/docs.mjs
@@ -8,7 +8,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import {pathToFileURL} from 'node:url';
 import {CLI_ROOT} from '../utils/paths.mjs';
-import {XDSError} from './error.mjs';
+import {AstryxError} from './error.mjs';
 import {ERROR_CODES} from '../lib/error-codes.mjs';
 
 const DOCS_DIR = path.join(CLI_ROOT, 'docs');
@@ -136,7 +136,7 @@ export async function docs(topic, section, options = {}) {
 
   const normalized = topic.toLowerCase();
   if (!topics[normalized]) {
-    throw new XDSError(
+    throw new AstryxError(
       `Unknown topic "${topic}"`,
       Object.keys(topics).map(t => ({name: t, reason: 'available topic'})),
       ERROR_CODES.ERR_UNKNOWN_TOPIC,
@@ -149,7 +149,7 @@ export async function docs(topic, section, options = {}) {
     const normalizedSection = section.toLowerCase();
     const match = docsData.sections.find(s => s.title.toLowerCase().includes(normalizedSection));
     if (!match) {
-      throw new XDSError(
+      throw new AstryxError(
         `Section "${section}" not found in "${topic}"`,
         docsData.sections.map(s => ({name: s.title, reason: 'available section'})),
         ERROR_CODES.ERR_UNKNOWN_SECTION,

--- a/packages/cli/src/api/error.mjs
+++ b/packages/cli/src/api/error.mjs
@@ -3,9 +3,9 @@
 /**
  * @file API error class — carries structured error info matching CLIError shape.
  *
- * `XDSError` is what the API layer throws. Alongside the human-readable
+ * `AstryxError` is what the API layer throws. Alongside the human-readable
  * message and optional `suggestions`, it carries a stable machine-readable
- * `code` (see ../lib/error-codes.mjs). When the CLI catches an XDSError and
+ * `code` (see ../lib/error-codes.mjs). When the CLI catches an AstryxError and
  * routes it through `cliError`, it propagates `e.code` so the JSON error
  * envelope's `code` field matches the API contract exactly. The code defaults
  * to `ERR_UNKNOWN` so older throw sites still produce a valid envelope.
@@ -13,7 +13,7 @@
 
 import {ERROR_CODES} from '../lib/error-codes.mjs';
 
-export class XDSError extends Error {
+export class AstryxError extends Error {
   /** @type {Array<{name: string, reason: string}> | undefined} */
   suggestions;
 
@@ -31,7 +31,7 @@ export class XDSError extends Error {
    */
   constructor(message, suggestions, code) {
     super(message);
-    this.name = 'XDSError';
+    this.name = 'AstryxError';
     this.code = code || ERROR_CODES.ERR_UNKNOWN;
     if (suggestions?.length) this.suggestions = suggestions;
   }

--- a/packages/cli/src/api/hook.mjs
+++ b/packages/cli/src/api/hook.mjs
@@ -11,7 +11,7 @@ import {findCoreDir} from '../utils/paths.mjs';
 import {discoverHooks, findHookDoc, getAllHookNames} from '../lib/hook-discovery.mjs';
 import {loadDocs} from '../lib/component-loader.mjs';
 import {levenshteinDistance} from '../lib/string-utils.mjs';
-import {XDSError} from './error.mjs';
+import {AstryxError} from './error.mjs';
 import {ERROR_CODES} from '../lib/error-codes.mjs';
 
 /**
@@ -46,7 +46,7 @@ export async function hook(name, options = {}) {
 
   const coreDir = findCoreDir(cwd);
   if (!coreDir) {
-    throw new XDSError('Could not find @astryxdesign/core package', undefined, ERROR_CODES.ERR_CORE_NOT_FOUND);
+    throw new AstryxError('Could not find @astryxdesign/core package', undefined, ERROR_CODES.ERR_CORE_NOT_FOUND);
   }
 
   // ── List mode ──────────────────────────────────────────────────
@@ -59,7 +59,7 @@ export async function hook(name, options = {}) {
         ([key]) => key.toLowerCase() === category.toLowerCase(),
       );
       if (!match) {
-        throw new XDSError(
+        throw new AstryxError(
           `Unknown category "${category}"`,
           Object.keys(hooks).map(k => ({name: k, reason: 'valid category'})),
           ERROR_CODES.ERR_UNKNOWN_CATEGORY,
@@ -179,7 +179,7 @@ export async function hook(name, options = {}) {
       .slice(0, 5)
       .map(m => ({name: m.name, reason: `similar name (distance ${m.distance})`}));
 
-    throw new XDSError(
+    throw new AstryxError(
       `No hook named "${name}"`,
       suggestions,
       ERROR_CODES.ERR_UNKNOWN_HOOK,

--- a/packages/cli/src/api/index.mjs
+++ b/packages/cli/src/api/index.mjs
@@ -4,10 +4,10 @@
  * @file Programmatic API for the XDS CLI.
  *
  * Every function returns the same { type, data } envelope that `xds --json` outputs.
- * Errors throw XDSError (with optional .suggestions).
+ * Errors throw AstryxError (with optional .suggestions).
  *
  * @example
- * import { component, docs, hook, XDSError } from '@astryxdesign/cli/api';
+ * import { component, docs, hook, AstryxError } from '@astryxdesign/cli/api';
  *
  * const result = await component('Button');
  * // { type: 'component.detail', data: { name: 'Button', ... } }
@@ -26,4 +26,4 @@ export {template} from './template.mjs';
 export {hook} from './hook.mjs';
 export {search} from './search.mjs';
 export {doctor} from './doctor.mjs';
-export {XDSError} from './error.mjs';
+export {AstryxError} from './error.mjs';

--- a/packages/cli/src/api/search.mjs
+++ b/packages/cli/src/api/search.mjs
@@ -42,7 +42,7 @@ import {
 import {discoverHooks, findHookDoc} from '../lib/hook-discovery.mjs';
 import {levenshteinDistance} from '../lib/string-utils.mjs';
 import {discoverTemplates} from './template.mjs';
-import {XDSError} from './error.mjs';
+import {AstryxError} from './error.mjs';
 
 const DOCS_DIR = path.join(CLI_ROOT, 'docs');
 
@@ -312,13 +312,13 @@ export async function search(query, options = {}) {
   const {cwd = process.cwd(), type, limit = 20} = options;
 
   if (!query || !String(query).trim()) {
-    throw new XDSError('A search query is required', [
+    throw new AstryxError('A search query is required', [
       {name: 'xds search button', reason: 'example'},
     ]);
   }
 
   if (type && !SEARCH_DOMAINS.includes(type)) {
-    throw new XDSError(
+    throw new AstryxError(
       `Unknown --type "${type}"`,
       SEARCH_DOMAINS.map(d => ({name: d, reason: 'valid type'})),
     );
@@ -328,7 +328,7 @@ export async function search(query, options = {}) {
 
   const coreDir = findCoreDir(cwd);
   if (!coreDir) {
-    throw new XDSError('Could not find @astryxdesign/core package');
+    throw new AstryxError('Could not find @astryxdesign/core package');
   }
 
   // Gather candidates from each requested domain in parallel.

--- a/packages/cli/src/api/template.mjs
+++ b/packages/cli/src/api/template.mjs
@@ -8,7 +8,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import {CLI_ROOT, discoverExternalPackages} from '../utils/paths.mjs';
 import {assertWithin, isFilePathArg, PathSafetyError} from '../utils/path-safety.mjs';
-import {XDSError} from './error.mjs';
+import {AstryxError} from './error.mjs';
 import {ERROR_CODES} from '../lib/error-codes.mjs';
 import {loadConfig} from '../lib/config.mjs';
 
@@ -389,7 +389,7 @@ export async function getTemplateById(id, options = {}) {
 
   const getter = config.template?.get;
   if (typeof getter !== 'function') {
-    throw new XDSError(
+    throw new AstryxError(
       'Template fetching by ID is not configured.\n' +
         'Add a template.get function to xds.config.mjs:\n\n' +
         '  export default {\n' +
@@ -407,11 +407,11 @@ export async function getTemplateById(id, options = {}) {
     source = await getter(id);
   } catch (err) {
     const detail = err instanceof Error ? err.message : String(err);
-    throw new XDSError(`template.get("${id}") threw an error: ${detail}`, undefined, ERROR_CODES.ERR_TEMPLATE_GET);
+    throw new AstryxError(`template.get("${id}") threw an error: ${detail}`, undefined, ERROR_CODES.ERR_TEMPLATE_GET);
   }
 
   if (source == null) {
-    throw new XDSError(
+    throw new AstryxError(
       `template.get("${id}") returned ${source} — no template found for that ID`,
       undefined,
       ERROR_CODES.ERR_TEMPLATE_GET,
@@ -419,7 +419,7 @@ export async function getTemplateById(id, options = {}) {
   }
 
   if (typeof source !== 'string') {
-    throw new XDSError(
+    throw new AstryxError(
       `template.get("${id}") must return a string, got ${typeof source}`,
       undefined,
       ERROR_CODES.ERR_TEMPLATE_GET,
@@ -427,7 +427,7 @@ export async function getTemplateById(id, options = {}) {
   }
 
   if (source.trim() === '') {
-    throw new XDSError(
+    throw new AstryxError(
       `template.get("${id}") returned an empty string`,
       undefined,
       ERROR_CODES.ERR_TEMPLATE_GET,
@@ -470,7 +470,7 @@ export async function template(name, options = {}) {
 
   const match = templates.find(t => t.dirName === name);
   if (name && !match) {
-    throw new XDSError(
+    throw new AstryxError(
       `Unknown template "${name}"`,
       templates.map(t => ({name: t.dirName, reason: `${t.type} template`})),
       ERROR_CODES.ERR_UNKNOWN_TEMPLATE,
@@ -479,14 +479,14 @@ export async function template(name, options = {}) {
 
   if (skeleton) {
     if (!match) {
-      throw new XDSError(
+      throw new AstryxError(
         'Specify a template name for --skeleton',
         templates.map(t => ({name: t.dirName, reason: `${t.type} template`})),
         ERROR_CODES.ERR_UNKNOWN_TEMPLATE,
       );
     }
     if (!fs.existsSync(match.filePath)) {
-      throw new XDSError(`No source file found for template "${name}"`, undefined, ERROR_CODES.ERR_NO_SOURCE);
+      throw new AstryxError(`No source file found for template "${name}"`, undefined, ERROR_CODES.ERR_NO_SOURCE);
     }
     const src = fs.readFileSync(match.filePath, 'utf-8');
     return {
@@ -501,7 +501,7 @@ export async function template(name, options = {}) {
   }
 
   if (!fs.existsSync(match.filePath)) {
-    throw new XDSError(`No source file found for template "${name}"`, undefined, ERROR_CODES.ERR_NO_SOURCE);
+    throw new AstryxError(`No source file found for template "${name}"`, undefined, ERROR_CODES.ERR_NO_SOURCE);
   }
 
   if (show || !targetPath) {
@@ -528,7 +528,7 @@ export async function template(name, options = {}) {
     });
   } catch (err) {
     if (err instanceof PathSafetyError) {
-      throw new XDSError(err.message, undefined, ERROR_CODES.ERR_PATH_TRAVERSAL);
+      throw new AstryxError(err.message, undefined, ERROR_CODES.ERR_PATH_TRAVERSAL);
     }
     throw err;
   }

--- a/packages/cli/src/lib/error-codes.mjs
+++ b/packages/cli/src/lib/error-codes.mjs
@@ -12,7 +12,7 @@
  * named X" is brittle and silently breaks the moment we reword it.
  *
  * The `code` field is the stable contract. Every error — whether raised by a
- * command, the API layer (`XDSError`), or Commander's own parse machinery —
+ * command, the API layer (`AstryxError`), or Commander's own parse machinery —
  * carries one of the identifiers below. Codes are append-only: once shipped,
  * a code's meaning never changes and the code is never removed. The message
  * may change freely; the code never does.
@@ -26,7 +26,7 @@
  *
  *   import {ERROR_CODES} from './error-codes.mjs';
  *   cliError('No component named "Buton"', {code: ERROR_CODES.ERR_UNKNOWN_COMPONENT});
- *   throw new XDSError('No component named "Buton"', suggestions, ERROR_CODES.ERR_UNKNOWN_COMPONENT);
+ *   throw new AstryxError('No component named "Buton"', suggestions, ERROR_CODES.ERR_UNKNOWN_COMPONENT);
  *
  * Consumers read `envelope.code` and compare against the published list in
  * packages/cli/README.md.

--- a/packages/cli/src/lib/json.mjs
+++ b/packages/cli/src/lib/json.mjs
@@ -107,7 +107,7 @@ export function jsonOut(type, data, meta) {
  * shape.
  *
  * The `code` is resolved in priority order: an explicit `code` argument,
- * then a `code` property carried on a thrown Error/XDSError, then the
+ * then a `code` property carried on a thrown Error/AstryxError, then the
  * generic `ERR_UNKNOWN` fallback. It always appears on the envelope so
  * consumers can branch on it unconditionally.
  *

--- a/packages/cli/src/types/api.d.ts
+++ b/packages/cli/src/types/api.d.ts
@@ -4,7 +4,7 @@
  * Programmatic API types for @astryxdesign/cli/api.
  *
  * Every function returns the same { type, data } envelope as `xds --json`.
- * Errors throw XDSError.
+ * Errors throw AstryxError.
  */
 
 import type {
@@ -47,7 +47,7 @@ import type {ErrorCode} from './error-codes';
 import type {DoctorResponse} from './doctor';
 
 /** Structured API error with a stable machine-readable code. */
-export declare class XDSError extends Error {
+export declare class AstryxError extends Error {
   /** Stable error code; consumers branch on this, never the message. */
   code: ErrorCode;
   suggestions?: Array<{name: string; reason: string}>;

--- a/packages/cli/src/types/error-codes.d.ts
+++ b/packages/cli/src/types/error-codes.d.ts
@@ -2,7 +2,7 @@
 
 /**
  * Stable, machine-readable error codes carried on every CLI error envelope
- * and every thrown XDSError. Consumers should branch on these — never on the
+ * and every thrown AstryxError. Consumers should branch on these — never on the
  * human-readable `error` string, which can change at any time.
  *
  * Append-only: a code's meaning never changes and codes are never removed.


### PR DESCRIPTION
## Summary

Renames the CLI's exported error class `XDSError` → `AstryxError`, part of scrubbing `xds` from public identifiers.

## Changes
- `api/error.mjs` class definition + `api/index.mjs` re-export + `types/api.d.ts` declaration.
- All 63 references across `@xds/cli`: throw sites (component/discover/docs/hook/search/template APIs), error-codes + json plumbing, tests, and docs.

## Consumer impact
Programmatic consumers that catch/reference `XDSError` from `@xds/cli`'s API should switch to `AstryxError`. Self-contained to `@xds/cli` — no other `xds` categories touched. Changeset: `[breaking]`, patch on `@xds/cli`.
