### PR TITLE
refactor(build): rename xds-named exports to astryx

### DIFF
--- a/.changeset/build-astryx-exports.md
+++ b/.changeset/build-astryx-exports.md
@@ -1,0 +1,12 @@
+---
+'@astryxdesign/build': patch
+---
+
+[breaking] Rename `@xds/build` exports off the xds name
+@ejhammond
+
+The Vite integration's public exports are renamed: `xdsStylex` -> `astryxStylex`,
+and the option types `XDSVitePluginOptions` / `XDSVitePluginLegacyOptions` ->
+`AstryxVitePluginOptions` / `AstryxVitePluginLegacyOptions`. Update imports from
+`@xds/build/vite` accordingly. Internal plugin names and the babel wrapper are
+also rebranded. Part of removing `xds` naming from the public API.

--- a/apps/example-vite/README.md
+++ b/apps/example-vite/README.md
@@ -61,7 +61,7 @@ export default defineConfig({
   plugins: [
     // Declare CSS layer order so theme overrides beat component base styles.
     {
-      name: 'xds-css-layer-order',
+      name: 'astryx-css-layer-order',
       transformIndexHtml() {
         return [
           {

--- a/apps/example-vite/vite.config.ts
+++ b/apps/example-vite/vite.config.ts
@@ -2,8 +2,8 @@
 
 import {defineConfig} from 'vite';
 import react from '@vitejs/plugin-react';
-import {xdsStylex} from '@astryxdesign/build/vite';
+import {astryxStylex} from '@astryxdesign/build/vite';
 
 export default defineConfig({
-  plugins: [...xdsStylex(), react()],
+  plugins: [...astryxStylex(), react()],
 });

--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 import type {StorybookConfig} from '@storybook/react-vite';
-import {xdsStylex} from '@astryxdesign/build/vite';
+import {astryxStylex} from '@astryxdesign/build/vite';
 import path from 'path';
 import {fileURLToPath} from 'url';
 
@@ -58,7 +58,7 @@ const config: StorybookConfig = {
       },
       plugins: [
         {
-          name: 'xds-color-scheme',
+          name: 'astryx-color-scheme',
           transformIndexHtml() {
             return [
               {
@@ -70,7 +70,7 @@ const config: StorybookConfig = {
           },
         },
         ...filteredPlugins,
-        ...xdsStylex({
+        ...astryxStylex({
           stylexOptions: {
             dev: false,
             styleResolution: 'application-order',

--- a/packages/build/README.md
+++ b/packages/build/README.md
@@ -144,12 +144,12 @@ export default nextConfig;
 ## Vite Setup
 
 ```ts
-import {xdsStylex} from '@astryxdesign/build/vite';
+import {astryxStylex} from '@astryxdesign/build/vite';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [
-    ...xdsStylex({
+    ...astryxStylex({
       stylexOptions: {
         dev: process.env.NODE_ENV === 'development',
         runtimeInjection: false,

--- a/packages/build/src/babel.js
+++ b/packages/build/src/babel.js
@@ -18,7 +18,7 @@ const XDS_LIBRARY_PATTERNS = [
   'node_modules/@astryxdesign/',
 ];
 
-module.exports = function xdsBabelPlugin(api, options) {
+module.exports = function astryxBabelPlugin(api, options) {
   const stylexPlugin = require('@stylexjs/babel-plugin');
 
   const {
@@ -100,7 +100,7 @@ module.exports = function xdsBabelPlugin(api, options) {
   }
 
   return {
-    name: 'xds-babel-plugin',
+    name: 'astryx-babel-plugin',
     visitor,
   };
 };

--- a/packages/build/src/babel.test.mjs
+++ b/packages/build/src/babel.test.mjs
@@ -13,7 +13,7 @@ import {createRequire} from 'node:module';
 
 const require = createRequire(import.meta.url);
 const babel = require('@babel/core');
-const xdsBabelPlugin = require('./babel.js');
+const astryxBabelPlugin = require('./babel.js');
 
 const SOURCE = `
 import * as stylex from '@stylexjs/stylex';
@@ -36,7 +36,7 @@ function transformLibraryFile(libraryPrefix) {
     configFile: false,
     plugins: [
       [
-        xdsBabelPlugin,
+        astryxBabelPlugin,
         {
           ...(libraryPrefix ? {libraryPrefix} : {}),
           unstable_moduleResolution: {type: 'commonJS', rootDir: process.cwd()},

--- a/packages/build/src/vite.test.ts
+++ b/packages/build/src/vite.test.ts
@@ -8,12 +8,12 @@
  */
 
 import {describe, it, expect} from 'vitest';
-import {xdsStylex} from './vite';
+import {astryxStylex} from './vite';
 
 /** Pull the injected `@layer ...;` order statement out of the plugin set. */
-function getLayerOrder(plugins: ReturnType<typeof xdsStylex>): string {
-  const layerPlugin = plugins.find(p => p.name === 'xds-css-layer-order');
-  expect(layerPlugin, 'xds-css-layer-order plugin should exist').toBeTruthy();
+function getLayerOrder(plugins: ReturnType<typeof astryxStylex>): string {
+  const layerPlugin = plugins.find(p => p.name === 'astryx-css-layer-order');
+  expect(layerPlugin, 'astryx-css-layer-order plugin should exist').toBeTruthy();
   const transform = (layerPlugin as any).transformIndexHtml;
   const tags =
     typeof transform === 'function' ? transform() : transform.handler();
@@ -22,24 +22,24 @@ function getLayerOrder(plugins: ReturnType<typeof xdsStylex>): string {
   return styleTag.children as string;
 }
 
-describe('xdsStylex layer order (modern API)', () => {
+describe('astryxStylex layer order (modern API)', () => {
   it('uses the astryx-* layer names (theme layer is astryx-theme)', () => {
-    const order = getLayerOrder(xdsStylex());
+    const order = getLayerOrder(astryxStylex());
     expect(order).toBe('@layer reset, astryx-base, astryx-theme, product;');
   });
 
   it('honors configured library and product layer names', () => {
     const order = getLayerOrder(
-      xdsStylex({layers: {library: 'custom-base', product: 'app'}}),
+      astryxStylex({layers: {library: 'custom-base', product: 'app'}}),
     );
     // The theme layer stays astryx-theme regardless of other layer config.
     expect(order).toBe('@layer reset, custom-base, astryx-theme, app;');
   });
 });
 
-describe('xdsStylex layer order (legacy API)', () => {
+describe('astryxStylex layer order (legacy API)', () => {
   it('uses the astryx-* layer names (theme layer is astryx-theme)', () => {
-    const order = getLayerOrder(xdsStylex({stylexOptions: {}}));
+    const order = getLayerOrder(astryxStylex({stylexOptions: {}}));
     expect(order).toBe('@layer reset, astryx-base, astryx-theme, product;');
   });
 });

--- a/packages/build/src/vite.ts
+++ b/packages/build/src/vite.ts
@@ -24,9 +24,9 @@ export const LIGHTNINGCSS_TARGETS = {
 
 /**
  * Legacy options shape — kept for backward compatibility.
- * Prefer the zero-config form: xdsStylex()
+ * Prefer the zero-config form: astryxStylex()
  */
-export interface XDSVitePluginLegacyOptions {
+export interface AstryxVitePluginLegacyOptions {
   stylexOptions: Parameters<typeof stylex.vite>[0];
   libraryPattern?: string;
   /** StyleX atomic class-name prefix for XDS library styles. @default 'astryx' */
@@ -37,7 +37,7 @@ export interface XDSVitePluginLegacyOptions {
   };
 }
 
-export interface XDSVitePluginOptions {
+export interface AstryxVitePluginOptions {
   /**
    * Whether to enable dev mode for StyleX.
    * @default process.env.NODE_ENV !== 'production'
@@ -99,7 +99,7 @@ export interface XDSVitePluginOptions {
  * Provides sensible defaults for StyleX compilation with XDS.
  * Just spread into your plugins array:
  *
- *   plugins: [...xdsStylex(), react()]
+ *   plugins: [...astryxStylex(), react()]
  *
  * Handles:
  * - StyleX compilation with correct settings
@@ -109,15 +109,15 @@ export interface XDSVitePluginOptions {
  *
  * @param options — optional overrides
  */
-export function xdsStylex(
-  options: XDSVitePluginOptions | XDSVitePluginLegacyOptions = {},
+export function astryxStylex(
+  options: AstryxVitePluginOptions | AstryxVitePluginLegacyOptions = {},
 ): Plugin[] {
-  // Detect legacy API: xdsStylex({stylexOptions: {...}})
+  // Detect legacy API: astryxStylex({stylexOptions: {...}})
   if ('stylexOptions' in options && options.stylexOptions) {
-    return xdsStylexLegacy(options as XDSVitePluginLegacyOptions);
+    return astryxStylexLegacy(options as AstryxVitePluginLegacyOptions);
   }
 
-  const opts = options as XDSVitePluginOptions;
+  const opts = options as AstryxVitePluginOptions;
   const {
     dev = process.env.NODE_ENV !== 'production',
     rootDir = process.cwd(),
@@ -148,7 +148,7 @@ export function xdsStylex(
 
   // Inject our babel wrapper as a user plugin — it runs before the
   // unplugin's hardcoded StyleX instance and handles prefix routing.
-  const xdsBabelPlugin = path.resolve(__dirname, 'babel.js');
+  const astryxBabelPlugin = path.resolve(__dirname, 'babel.js');
 
   const basePlugin = stylex.vite({
     ...(stylexOptions as any),
@@ -156,7 +156,7 @@ export function xdsStylex(
     babelConfig: {
       plugins: [
         [
-          xdsBabelPlugin,
+          astryxBabelPlugin,
           {
             ...stylexOptions,
             libraryPrefix: stylexPrefix,
@@ -169,7 +169,7 @@ export function xdsStylex(
 
   // Layer order declaration plugin
   const layerOrderPlugin: Plugin = {
-    name: 'xds-css-layer-order',
+    name: 'astryx-css-layer-order',
     transformIndexHtml() {
       return [
         {
@@ -183,7 +183,7 @@ export function xdsStylex(
 
   // Config plugin — injects resolve.alias and optimizeDeps
   const configPlugin: Plugin = {
-    name: 'xds-config',
+    name: 'astryx-config',
     config(): UserConfig {
       // Discover all @astryxdesign/* packages to exclude from pre-bundling.
       // XDS ships as source that must be compiled by StyleX — pre-bundling
@@ -221,7 +221,7 @@ export function xdsStylex(
 
   // Split-layer interceptor plugin (dev server only)
   const splitLayerPlugin: Plugin = {
-    name: 'xds-split-layers',
+    name: 'astryx-split-layers',
     configureServer(server) {
       let stylexPlugin: any = null;
 
@@ -299,10 +299,10 @@ export function xdsStylex(
 }
 
 /**
- * Legacy implementation — handles the old xdsStylex({stylexOptions: {...}}) API.
+ * Legacy implementation — handles the old astryxStylex({stylexOptions: {...}}) API.
  * Used by Storybook and other existing configs.
  */
-function xdsStylexLegacy(options: XDSVitePluginLegacyOptions): Plugin[] {
+function astryxStylexLegacy(options: AstryxVitePluginLegacyOptions): Plugin[] {
   const {
     stylexOptions,
     libraryPattern = XDS_LIBRARY_PATTERN,
@@ -313,7 +313,7 @@ function xdsStylexLegacy(options: XDSVitePluginLegacyOptions): Plugin[] {
   const libraryLayer = layers.library ?? 'astryx-base';
   const productLayer = layers.product ?? 'product';
 
-  const xdsBabelPlugin = path.resolve(__dirname, 'babel.js');
+  const astryxBabelPlugin = path.resolve(__dirname, 'babel.js');
   const existingPlugins = (stylexOptions as any).babelConfig?.plugins ?? [];
 
   const basePlugin = stylex.vite({
@@ -323,7 +323,7 @@ function xdsStylexLegacy(options: XDSVitePluginLegacyOptions): Plugin[] {
       ...(stylexOptions as any).babelConfig,
       plugins: [
         [
-          xdsBabelPlugin,
+          astryxBabelPlugin,
           {
             ...(stylexOptions as any),
             libraryPrefix: stylexPrefix,
@@ -336,7 +336,7 @@ function xdsStylexLegacy(options: XDSVitePluginLegacyOptions): Plugin[] {
   });
 
   const layerOrderPlugin: Plugin = {
-    name: 'xds-css-layer-order',
+    name: 'astryx-css-layer-order',
     transformIndexHtml() {
       return [
         {
@@ -349,7 +349,7 @@ function xdsStylexLegacy(options: XDSVitePluginLegacyOptions): Plugin[] {
   };
 
   const splitLayerPlugin: Plugin = {
-    name: 'xds-split-layers',
+    name: 'astryx-split-layers',
     configureServer(server) {
       let stylexPlugin: any = null;
 


### PR DESCRIPTION
## Summary

Renames `@xds/build`'s `xds`-named identifiers to `astryx`, part of scrubbing `xds` from public identifiers.

## Public exports (breaking)
- `xdsStylex` → `astryxStylex` (the Vite plugin factory)
- `XDSVitePluginOptions` → `AstryxVitePluginOptions`
- `XDSVitePluginLegacyOptions` → `AstryxVitePluginLegacyOptions`

## Internal
- `xdsStylexLegacy`, `xdsBabelPlugin` function names
- Vite/babel plugin `name:` fields (`xds-css-layer-order`, `xds-config`, `xds-split-layers`, `xds-babel-plugin`) → `astryx-*`
- storybook's local `xds-color-scheme` plugin name → `astryx-color-scheme`

## Consumers updated
`apps/example-vite` and `apps/storybook` now import `astryxStylex` from `@xds/build/vite`.

## Scope
`@xds/build` identifiers + its in-repo consumers. The `@xds/*` package scope is untouched (separate task). Changeset: `[breaking]`, patch on `@xds/build`.
