### PR TITLE
refactor(vega): rename XDSVegaChart to VegaChart

### DIFF
--- a/apps/storybook/stories/VegaChart.stories.tsx
+++ b/apps/storybook/stories/VegaChart.stories.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 import type {Meta, StoryObj} from '@storybook/react';
-import {XDSVegaChart} from '@astryxdesign/vega';
+import {VegaChart} from '@astryxdesign/vega';
 import type {AnySpec} from '@astryxdesign/vega';
 
 /**
@@ -73,9 +73,9 @@ const radialPlotSpec: AnySpec = {
   ],
 };
 
-const meta: Meta<typeof XDSVegaChart> = {
+const meta: Meta<typeof VegaChart> = {
   title: 'Vega/VegaChart',
-  component: XDSVegaChart,
+  component: VegaChart,
   tags: ['autodocs'],
   parameters: {
     layout: 'centered',
@@ -84,7 +84,7 @@ const meta: Meta<typeof XDSVegaChart> = {
 };
 
 export default meta;
-type Story = StoryObj<typeof XDSVegaChart>;
+type Story = StoryObj<typeof VegaChart>;
 
 export const RadialPlot: Story = {
   name: 'Radial Plot',

--- a/apps/storybook/stories/VegaLiteRanges.stories.tsx
+++ b/apps/storybook/stories/VegaLiteRanges.stories.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 import type {Meta, StoryObj} from '@storybook/react';
-import {XDSVegaChart, buildVegaLiteConfig} from '@astryxdesign/vega';
+import {VegaChart, buildVegaLiteConfig} from '@astryxdesign/vega';
 import type {AnySpec} from '@astryxdesign/vega';
 import {useTheme} from '@astryxdesign/core';
 
@@ -302,19 +302,19 @@ const weatherHeatmapSpec: AnySpec = {
 // Themed wrapper — resolves XDS tokens into a Vega-Lite config
 // ---------------------------------------------------------------------------
 
-function ThemedVegaChart(props: React.ComponentProps<typeof XDSVegaChart>) {
+function ThemedVegaChart(props: React.ComponentProps<typeof VegaChart>) {
   const {token} = useTheme();
   const config = buildVegaLiteConfig(token);
-  return <XDSVegaChart {...props} compileOptions={{config}} />;
+  return <VegaChart {...props} compileOptions={{config}} />;
 }
 
 // ---------------------------------------------------------------------------
 // Storybook meta
 // ---------------------------------------------------------------------------
 
-const meta: Meta<typeof XDSVegaChart> = {
-  title: 'Vega/XDSVegaChart',
-  component: XDSVegaChart,
+const meta: Meta<typeof VegaChart> = {
+  title: 'Vega/VegaChart',
+  component: VegaChart,
   tags: ['autodocs'],
   parameters: {
     layout: 'padded',
@@ -322,7 +322,7 @@ const meta: Meta<typeof XDSVegaChart> = {
 };
 
 export default meta;
-type Story = StoryObj<typeof XDSVegaChart>;
+type Story = StoryObj<typeof VegaChart>;
 
 export const StocksLineChart: Story = {
   name: 'Range: Category - Stocks Line Chart',

--- a/packages/vega/README.md
+++ b/packages/vega/README.md
@@ -14,7 +14,7 @@ Renders [Vega](https://vega.github.io/vega/) and [Vega-Lite](https://vega.github
 | `tsconfig.json` | Config | TypeScript compiler config (extends root) |
 | `tsup.config.ts` | Config | Build config: CJS + ESM + `.d.ts` outputs |
 | `src/index.ts` | Barrel | Public API surface |
-| `src/XDSVegaChart.tsx` | Component | Inspects `$schema`, compiles or renders, owns View lifecycle |
+| `src/VegaChart.tsx` | Component | Inspects `$schema`, compiles or renders, owns View lifecycle |
 | `src/schema.ts` | Utility | Parses and validates Vega/Vega-Lite `$schema` URLs |
 | `src/types.ts` | Types | Shared TypeScript types for this package |
 
@@ -29,9 +29,9 @@ pnpm add @astryxdesign/vega vega vega-lite
 ### Vega-Lite spec (compiled automatically)
 
 ```tsx
-import {XDSVegaChart} from '@astryxdesign/vega';
+import {VegaChart} from '@astryxdesign/vega';
 
-<XDSVegaChart
+<VegaChart
   spec={{
     $schema: 'https://vega.github.io/schema/vega-lite/v5.json',
     mark: 'bar',
@@ -47,7 +47,7 @@ import {XDSVegaChart} from '@astryxdesign/vega';
 ### Vega spec (rendered directly, no compilation)
 
 ```tsx
-<XDSVegaChart
+<VegaChart
   spec={{
     $schema: 'https://vega.github.io/schema/vega/v5.json',
     marks: [...],
@@ -58,7 +58,7 @@ import {XDSVegaChart} from '@astryxdesign/vega';
 ### Full configuration
 
 ```tsx
-<XDSVegaChart
+<VegaChart
   spec={spec}
   parseConfig={{background: '#1a1a1a'}}
   parseOptions={{ast: true}}
@@ -80,7 +80,7 @@ import {XDSVegaChart} from '@astryxdesign/vega';
 
 ## API
 
-### `<XDSVegaChart>`
+### `<VegaChart>`
 
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
@@ -129,7 +129,7 @@ import {XDSVegaChart} from '@astryxdesign/vega';
 To update data dynamically after render, use `onReady` to get the live View and drive it yourself:
 
 ```tsx
-<XDSVegaChart
+<VegaChart
   spec={spec}
   data={{table: [{category: 'A', value: 28}, {category: 'B', value: 55}]}}
   onReady={view => {
@@ -148,7 +148,7 @@ Parses and validates a Vega `$schema` URL. Returns:
 
 ## Schema validation
 
-`XDSVegaChart` validates `spec.$schema` before doing any work. It will call `onError` (and render nothing) if:
+`VegaChart` validates `spec.$schema` before doing any work. It will call `onError` (and render nothing) if:
 
 - `$schema` is missing or not a string
 - The URL doesn't match the expected format (`schema/{library}/{version}.json`)

--- a/packages/vega/src/VegaChart.tsx
+++ b/packages/vega/src/VegaChart.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 /**
- * @file XDSVegaChart.tsx
+ * @file VegaChart.tsx
  * @input A Vega or Vega-Lite spec (distinguished by $schema), parse config/options, view options, and data
  * @output A React component that renders the spec via the Vega runtime
  * @position Primary component in @astryxdesign/vega; owns the Vega View lifecycle
@@ -13,10 +13,10 @@ import React, {useEffect, useRef} from 'react';
 import {parse, View} from 'vega';
 import {compile} from 'vega-lite';
 import {parseSchema} from './schema';
-import type {XDSVegaChartProps, VegaSpec, VegaLiteSpec} from './types';
+import type {VegaChartProps, VegaSpec, VegaLiteSpec} from './types';
 
 /**
- * `XDSVegaChart` renders a Vega or Vega-Lite specification using the Vega runtime.
+ * `VegaChart` renders a Vega or Vega-Lite specification using the Vega runtime.
  *
  * The component inspects `spec.$schema` to determine how to handle the spec:
  * - `vega-lite` schema -> compiled to Vega via `vega-lite`'s `compile()`, then rendered
@@ -46,10 +46,10 @@ import type {XDSVegaChartProps, VegaSpec, VegaLiteSpec} from './types';
  *
  * @example
  * ```
- * import {XDSVegaChart} from '@astryxdesign/vega';
+ * import {VegaChart} from '@astryxdesign/vega';
  *
  * // Vega-Lite spec -- compiled automatically
- * <XDSVegaChart
+ * <VegaChart
  *   spec={{
  *     $schema: 'https://vega.github.io/schema/vega-lite/v5.json',
  *     mark: 'bar',
@@ -63,14 +63,14 @@ import type {XDSVegaChartProps, VegaSpec, VegaLiteSpec} from './types';
  * />
  *
  * // Vega spec -- rendered directly
- * <XDSVegaChart
+ * <VegaChart
  *   spec={{$schema: 'https://vega.github.io/schema/vega/v5.json', marks: []}}
  *   parseConfig={{background: '#1a1a1a'}}
  *   viewOptions={{logLevel: 1, tooltip: myTooltipHandler}}
  * />
  * ```
  */
-export function XDSVegaChart({
+export function VegaChart({
   spec,
   data,
   compileOptions,
@@ -83,7 +83,7 @@ export function XDSVegaChart({
   onReady,
   onError,
   ...props
-}: XDSVegaChartProps) {
+}: VegaChartProps) {
   const containerRef = useRef<HTMLDivElement>(null);
 
   // Keep callbacks in refs so they don't need to be in the dep array.
@@ -180,4 +180,4 @@ export function XDSVegaChart({
   );
 }
 
-XDSVegaChart.displayName = 'XDSVegaChart';
+VegaChart.displayName = 'VegaChart';

--- a/packages/vega/src/index.ts
+++ b/packages/vega/src/index.ts
@@ -18,7 +18,7 @@
  * SYNC: When modified, update /packages/vega/README.md
  */
 
-export {XDSVegaChart} from './XDSVegaChart';
+export {VegaChart} from './VegaChart';
 export {parseSchema} from './schema';
 export {
   buildVegaLiteConfig,
@@ -29,7 +29,7 @@ export {
   TITLE_OFFSET,
 } from './vegaLiteConfig';
 export type {
-  XDSVegaChartProps,
+  VegaChartProps,
   AnySpec,
   ViewData,
   VegaSpec,

--- a/packages/vega/src/schema.ts
+++ b/packages/vega/src/schema.ts
@@ -4,7 +4,7 @@
  * @file schema.ts
  * @input A spec object (Vega or Vega-Lite)
  * @output The resolved schema kind: 'vega', 'vega-lite', or an error
- * @position Utility; consumed by XDSVegaChart to decide whether to compile
+ * @position Utility; consumed by VegaChart to decide whether to compile
  *
  * SYNC: When modified, update /packages/vega/README.md
  */

--- a/packages/vega/src/types.ts
+++ b/packages/vega/src/types.ts
@@ -45,7 +45,7 @@ export interface CompileOptions {
 }
 
 /**
- * A spec accepted by `<XDSVegaChart>`. Must include a `$schema` field --
+ * A spec accepted by `<VegaChart>`. Must include a `$schema` field --
  * the component uses it to decide whether to compile (Vega-Lite) or
  * render directly (Vega).
  */
@@ -86,7 +86,7 @@ export interface ParseOptions {
 export type ViewData = Record<string, unknown[]>;
 
 /**
- * Props for the `<XDSVegaChart>` component.
+ * Props for the `<VegaChart>` component.
  *
  * Extends `React.HTMLAttributes<HTMLDivElement>` (minus `contentEditable`,
  * `dangerouslySetInnerHTML`) for full DOM event passthrough — drag, pointer,
@@ -96,7 +96,7 @@ export type ViewData = Record<string, unknown[]>;
  * because `@astryxdesign/vega` does not depend on StyleX. Use `className` or `style`
  * for layout overrides instead.
  */
-export interface XDSVegaChartProps extends Omit<
+export interface VegaChartProps extends Omit<
   React.HTMLAttributes<HTMLDivElement>,
   | 'contentEditable'
   | 'dangerouslySetInnerHTML'

--- a/packages/vega/src/vegaLiteConfig.ts
+++ b/packages/vega/src/vegaLiteConfig.ts
@@ -4,7 +4,7 @@
  * @file vegaLiteConfig.ts
  * @input XDS theme tokens via useXDSTheme
  * @output Predefined Vega-Lite Config object for XDS-themed charts
- * @position Utility module; consumed by XDSVegaChart and exported standalone
+ * @position Utility module; consumed by VegaChart and exported standalone
  *
  * Ported from the internal XDS data-viz config — structural config only.
  * Colors are wired through XDS data tokens (see domainTokens/dataTokens.ts).


### PR DESCRIPTION
## Summary

Renames `@xds/vega`'s chart component off the `xds` prefix: `XDSVegaChart` → `VegaChart` (and `XDSVegaChartProps` → `VegaChartProps`).

## Changes
- File `src/XDSVegaChart.tsx` → `src/VegaChart.tsx`; `index.ts` export; `displayName`.
- `XDSVegaChartProps` → `VegaChartProps` (types.ts + export).
- Storybook stories (imports, `Meta`/`StoryObj` types, story titles `Vega/VegaChart`).
- README + doc-comment references.

## Scope
`@xds/vega` is a **private** package (no changeset). The `@xds/vega` package *scope* is unchanged — separate task.
