### PR TITLE
fix(cli): generate bare type imports in theme build

### DIFF
--- a/.changeset/cli-generated-types-astryx.md
+++ b/.changeset/cli-generated-types-astryx.md
@@ -1,0 +1,11 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[fix] `theme build` generates valid bare type imports (IconRegistry/DefinedTheme)
+@ejhammond
+
+`astryx theme build` emitted `.d.ts` files importing `XDSIconRegistry` /
+`XDSDefinedTheme` from `@xds/core`, but those aliases were removed — the
+generated types failed to resolve. Generate `IconRegistry` / `DefinedTheme`
+(the bare names `@xds/core` now exports) instead.

--- a/packages/cli/src/commands/build-theme.mjs
+++ b/packages/cli/src/commands/build-theme.mjs
@@ -250,7 +250,7 @@ const THEME_SCOPE_TO = `[data-astryx-theme]`;
 
 /**
  * Import a theme module using jiti and find the defineTheme() result.
- * Returns the resolved XDSDefinedTheme object.
+ * Returns the resolved DefinedTheme object.
  */
 async function importThemeModule(filePath) {
   const jiti = createJiti(import.meta.url, {
@@ -417,12 +417,12 @@ ${iconReExport}`;
  */
 function generateBuiltTypes(themeDef, iconInfo) {
   const iconType = iconInfo
-    ? `import type { XDSIconRegistry } from '@astryxdesign/core/Icon';
-export declare const ${iconInfo.exportName}: XDSIconRegistry;
+    ? `import type { IconRegistry } from '@astryxdesign/core/Icon';
+export declare const ${iconInfo.exportName}: IconRegistry;
 `
     : '';
-  return `import type { XDSDefinedTheme } from '@astryxdesign/core/theme';
-${iconType}export declare const ${toIdentifier(themeDef.name)}Theme: XDSDefinedTheme;
+  return `import type { DefinedTheme } from '@astryxdesign/core/theme';
+${iconType}export declare const ${toIdentifier(themeDef.name)}Theme: DefinedTheme;
 `;
 }
 


### PR DESCRIPTION
## Summary

Fixes a real bug from the compat-layer removal (#3001): `astryx theme build` generates `.d.ts` files that import **`XDSIconRegistry`** / **`XDSDefinedTheme`** from `@xds/core` — but those aliases were removed, so the generated types fail to resolve for consumers building themes.

## Fix
`build-theme.mjs` now generates imports for the **bare** names `@xds/core` actually exports:
- `XDSIconRegistry` → `IconRegistry`
- `XDSDefinedTheme` → `DefinedTheme`

Plus the matching stale JSDoc reference.

## Notes
- Codemod legacy-detection references to `XDSIconRegistry` (in `icon-name-deprecations`) are intentionally kept — they heuristically detect icon-registry files by old *or* new name.
- Changeset: `[fix]`, patch on `@xds/cli`.
