### PR TITLE
docs: fix stale XDS*-alias references in published docs

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -198,7 +198,7 @@ Shape:
         "options": [{"flag": "--props", "type": "boolean", "description": "Print only the props table"}],
         "json": true,
         "responseTypes": ["component.list", "component.detail", "component.detail.props", "…"],
-        "examples": ["xds component XDSButton --props --json"]
+        "examples": ["xds component Button --props --json"]
       }
       // …one entry per command; subcommands (e.g. `theme build`) nest under `subcommands`
     ],

--- a/packages/cli/docs/principles.doc.dense.mjs
+++ b/packages/cli/docs/principles.doc.dense.mjs
@@ -6,9 +6,9 @@ export const docsDense = {
   description: 'core design principles + rules for the design system',
   sections: [
     { title: 'Philosophy', content: [{ type: 'list', items: ['components over primitives', 'semantic tokens over hardcoded values', 'theme-agnostic code', 'open internals'] }] },
-    { title: 'Rules', content: [{ type: 'list', items: ['use components', 'StyleX or Tailwind for styling', 'semantic tokens only', 'CSS vars for colors', 'controlled form inputs', 'useXDSLinkComponent() for navigation'] }] },
+    { title: 'Rules', content: [{ type: 'list', items: ['use components', 'StyleX or Tailwind for styling', 'semantic tokens only', 'CSS vars for colors', 'controlled form inputs', 'useLinkComponent() for navigation'] }] },
     { title: 'Styling', content: [{ type: 'prose', text: 'xstyle prop for component overrides. StyleX or Tailwind for layout. See astryx docs styling.' }] },
-    { title: 'Anti-Patterns', content: [{ type: 'list', items: ['no inline styles on raw elements', 'no hardcoded colors — use tokens or Tailwind semantic classes', 'no hardcoded spacing', 'no hardcoded <a> — use useXDSLinkComponent()', 'read docs before inventing props'] }] },
+    { title: 'Anti-Patterns', content: [{ type: 'list', items: ['no inline styles on raw elements', 'no hardcoded colors — use tokens or Tailwind semantic classes', 'no hardcoded spacing', 'no hardcoded <a> — use useLinkComponent()', 'read docs before inventing props'] }] },
     { title: 'Tokens', content: [{ type: 'prose', text: 'run npx astryx docs tokens for full reference' }] },
   ],
 };

--- a/packages/cli/docs/principles.doc.zh.mjs
+++ b/packages/cli/docs/principles.doc.zh.mjs
@@ -6,9 +6,9 @@ export const docsZh = {
   description: 'XDS 核心设计原则和规则。',
   sections: [
     { title: '设计哲学', content: [{ type: 'list', items: ['组件优于原始元素 — 优先使用 XDS 组件', '语义化令牌优于硬编码值', '主题无关的代码 — 深色模式自动生效', '开放的内部机制 — 所有基础组件均可导出和组合'] }] },
-    { title: '规则', content: [{ type: 'list', items: ['所有支持的场景都使用 XDS 组件', '使用 StyleX 或 Tailwind 进行样式设置', '使用语义化令牌，不使用硬编码值', '使用 CSS 变量设置颜色，不使用十六进制值', '表单输入为受控组件（value + onChange）', '使用 useXDSLinkComponent() 进行导航'] }] },
+    { title: '规则', content: [{ type: 'list', items: ['所有支持的场景都使用 XDS 组件', '使用 StyleX 或 Tailwind 进行样式设置', '使用语义化令牌，不使用硬编码值', '使用 CSS 变量设置颜色，不使用十六进制值', '表单输入为受控组件（value + onChange）', '使用 useLinkComponent() 进行导航'] }] },
     { title: '样式方法', content: [{ type: 'prose', text: '组件覆盖使用 xstyle 属性。布局使用 StyleX 或 Tailwind。详见 astryx docs styling。' }] },
-    { title: '反模式', content: [{ type: 'list', items: ['不要在原始元素上使用内联样式', '不要硬编码颜色 — 使用令牌或 Tailwind 语义类', '不要硬编码间距', '不要硬编码 <a> 元素 — 使用 useXDSLinkComponent()', '不要自创属性。先阅读组件文档'] }] },
+    { title: '反模式', content: [{ type: 'list', items: ['不要在原始元素上使用内联样式', '不要硬编码颜色 — 使用令牌或 Tailwind 语义类', '不要硬编码间距', '不要硬编码 <a> 元素 — 使用 useLinkComponent()', '不要自创属性。先阅读组件文档'] }] },
     { title: '设计令牌', content: [{ type: 'prose', text: '运行 npx astryx docs tokens 查看完整参考' }] },
   ],
 };

--- a/packages/cli/docs/theme.doc.dense.mjs
+++ b/packages/cli/docs/theme.doc.dense.mjs
@@ -3,7 +3,7 @@
 /** @type {import('../../core/src/docs-types').ReferenceTranslationDoc} */
 
 export const docsDense = {
-  description: 'XDSTheme provider, custom themes, light/dark, component overrides',
+  description: 'Theme provider, custom themes, light/dark, component overrides',
   sections: [
     { title: 'Quick Start', content: [null, null, { type: 'prose', text: 'default import = runtime injection. /built import = pre-compiled CSS (pair with theme.css).' }] },
     { title: 'Themes', content: [null, { type: 'prose', text: '@astryxdesign/theme-{name} = source (runtime). @astryxdesign/theme-{name}/built = optimized (+ theme.css).' }] },
@@ -15,7 +15,7 @@ export const docsDense = {
     { title: 'Build for Production', content: [{ type: 'prose', text: 'npx astryx theme build compiles defineTheme to static CSS. outputs .css + .js (__built:true) + .d.ts.' }, null, null, null, null] },
     { title: 'Runtime vs Built', content: [{ type: 'prose', text: 'runtime: useInsertionEffect injects styles client-side. built: static CSS on first paint. USE /built + theme.css FOR SSR.' }, null, null, null] },
     { title: 'Light/Dark', content: [{ type: 'prose', text: 'light-dark() in token values via [light, dark] tuples. mode=system follows OS.' }, null, null] },
-    { title: 'Nesting', content: [{ type: 'prose', text: 'wrap sections in separate <XDSTheme> providers' }, null] },
-    { title: 'useXDSTheme', content: [null, { type: 'prose', text: 'read-only. manage state at app level.' }] },
+    { title: 'Nesting', content: [{ type: 'prose', text: 'wrap sections in separate <Theme> providers' }, null] },
+    { title: 'useTheme', content: [null, { type: 'prose', text: 'read-only. manage state at app level.' }] },
   ],
 };

--- a/packages/cli/docs/theme.doc.zh.mjs
+++ b/packages/cli/docs/theme.doc.zh.mjs
@@ -3,17 +3,17 @@
 /** @type {import('../../core/src/docs-types').ReferenceTranslationDoc} */
 
 export const docsZh = {
-  description: 'XDSTheme 提供者、自定义主题、亮/暗模式和组件样式覆盖。',
+  description: 'Theme 提供者、自定义主题、亮/暗模式和组件样式覆盖。',
   sections: [
     { title: '快速开始', content: [null, null, { type: 'prose', text: '默认导入使用运行时样式注入。/built 导入使用预编译 CSS（需配合 theme.css）。' }] },
     { title: '可用主题', content: [null, { type: 'prose', text: '@astryxdesign/theme-{name} = 源码版（运行时注入）。@astryxdesign/theme-{name}/built = 优化版（配合 theme.css）。' }] },
-    { title: 'XDSTheme 属性', content: [null] },
+    { title: 'Theme 属性', content: [null] },
     { title: '创建自定义主题', content: [{ type: 'prose', text: '使用 CLI 向导（推荐）或手动 defineTheme。只覆盖与默认值不同的令牌。' }, null] },
     { title: 'defineTheme', content: [{ type: 'prose', text: '支持比例配置（typography、radius、motion）+ 显式令牌覆盖 + 组件覆盖。' }, null, null] },
     { title: '生产构建', content: [{ type: 'prose', text: 'npx astryx theme build 将 defineTheme 编译为静态 CSS。输出 .css + .js（__built:true）+ .d.ts。' }, null, null, null, null] },
     { title: '运行时 vs 构建', content: [{ type: 'prose', text: '运行时：useInsertionEffect 在客户端注入样式。构建：静态 CSS 在首次渲染时就存在。SSR 应用请使用 /built + theme.css。' }, null, null, null] },
-    { title: '亮/暗模式', content: [{ type: 'prose', text: "令牌值使用 [light, dark] 元组实现自动模式切换。XDSTheme 上 mode='system'（默认）跟随系统偏好。" }, null, null] },
-    { title: '嵌套主题', content: [{ type: 'prose', text: '将不同部分包裹在独立的 <XDSTheme> 提供者中。' }, null] },
-    { title: 'useXDSTheme 钩子', content: [null, { type: 'prose', text: '这是只读的。要更改主题/模式，在应用层管理状态并传递给 <XDSTheme>。' }] },
+    { title: '亮/暗模式', content: [{ type: 'prose', text: "令牌值使用 [light, dark] 元组实现自动模式切换。Theme 上 mode='system'（默认）跟随系统偏好。" }, null, null] },
+    { title: '嵌套主题', content: [{ type: 'prose', text: '将不同部分包裹在独立的 <Theme> 提供者中。' }, null] },
+    { title: 'useTheme 钩子', content: [null, { type: 'prose', text: '这是只读的。要更改主题/模式，在应用层管理状态并传递给 <Theme>。' }] },
   ],
 };

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -36,7 +36,7 @@ The CLI (`@astryxdesign/cli`) provides additional tooling:
 npx xds --help                       # full listing of all commands
 npx xds component Button             # full docs + related block templates
 npx xds docs                         # reference docs (principles, tokens, theming, styling)
-npx xds docs theme                   # theming guide (XDSTheme, defineTheme, light/dark)
+npx xds docs theme                   # theming guide (Theme, defineTheme, light/dark)
 npx xds docs tokens                  # spacing, color, radius, typography token reference
 npx xds init                         # initialize XDS in your project
 npx xds theme build                  # build theme CSS for production
@@ -120,15 +120,15 @@ Spacing references `var(--spacing-1)` as the base unit, so `p-4` = 16px, matchin
 'use client';
 
 import Link from 'next/link';
-import {XDSTheme} from '@astryxdesign/core/theme';
-import {XDSLinkProvider} from '@astryxdesign/core/Link';
+import {Theme} from '@astryxdesign/core/theme';
+import {LinkProvider} from '@astryxdesign/core/Link';
 import {defaultTheme} from '@astryxdesign/theme-default/built';
 
 export function Providers({children}: {children: React.ReactNode}) {
   return (
-    <XDSTheme theme={defaultTheme}>
-      <XDSLinkProvider component={Link}>{children}</XDSLinkProvider>
-    </XDSTheme>
+    <Theme theme={defaultTheme}>
+      <LinkProvider component={Link}>{children}</LinkProvider>
+    </Theme>
   );
 }
 ```
@@ -153,10 +153,10 @@ export default function RootLayout({children}: {children: React.ReactNode}) {
 That's it. Start using components:
 
 ```tsx
-import {XDSButton} from '@astryxdesign/core/Button';
+import {Button} from '@astryxdesign/core/Button';
 
 export default function Page() {
-  return <XDSButton label="Hello XDS" variant="primary" />;
+  return <Button label="Hello XDS" variant="primary" />;
 }
 ```
 

--- a/packages/core/docs.mjs
+++ b/packages/core/docs.mjs
@@ -255,7 +255,7 @@ const HOOK_CATEGORY_MAP = {
   useScrollOverflow: 'Layout',
   useScrollLock: 'Layout',
   useEntryAnimation: 'Animation',
-  useXDSStreamingText: 'Streaming',
+  useStreamingText: 'Streaming',
   useImageMode: 'Media',
   useClickableContainer: 'Interaction',
   useInputContainer: 'Interaction',


### PR DESCRIPTION
## Summary

Fixes stale references to the removed `XDS*` compat aliases in **published docs**. After #3001 dropped those aliases, these doc examples no longer resolve.

## Changes
- **core README**: `<XDSTheme>` / `<XDSLinkProvider>` / `XDSButton` imports + usage → `Theme` / `LinkProvider` / `Button`.
- **cli docs** (`principles` + `theme`, en/zh/dense): `XDSTheme`, `useXDSTheme`, `useXDSLinkComponent` → `Theme`, `useTheme`, `useLinkComponent`.
- **core/docs.mjs**: `useXDSStreamingText` → `useStreamingText`.

## Deliberately preserved
- `resolveXDSThemeTokens`, `resolveXDSThemeToken`, `xdsTokenVar` — these are **still current** `@xds/core` exports (not removed aliases). Any rename of those is a separate task.
- `@xds/*` package scope and the `npx xds` command — separate PRs.
- Product-name "XDS" in prose (e.g. "Hello XDS") — left as-is.

Doc-only; no changeset. This is the published-doc slice of the stale-reference cleanup; internal test fixtures (vibe-tests, eslint-plugin) are a separate careful pass.
