### PR TITLE
fix(eslint-plugin): match bare component names after unprefixing

### DIFF
--- a/internal/eslint-plugin-astryx/README.md
+++ b/internal/eslint-plugin-astryx/README.md
@@ -89,10 +89,10 @@ A test file with intentional violations is provided:
 
 ```bash
 # Human mode - shows warnings
-pnpm lint packages/core/src/Badge/XDSBadge.test-violations.tsx
+pnpm lint packages/core/src/Badge/Badge.test-violations.tsx
 
 # Strict mode - shows errors
-pnpm lint:strict packages/core/src/Badge/XDSBadge.test-violations.tsx
+pnpm lint:strict packages/core/src/Badge/Badge.test-violations.tsx
 ```
 
 Expected output in strict mode:
@@ -156,9 +156,9 @@ Allowed hooks: `useId`, `useMemo`, `useCallback`, `useContext` (read-only).
 **Bad:**
 
 ```tsx
-// In XDSBadge.tsx
+// In Badge.tsx
 import {useState} from 'react';
-export function XDSBadge() {
+export function Badge() {
   const [x, setX] = useState(0); // ❌ Presentational components must not remember things
   return <span>{x}</span>;
 }
@@ -167,9 +167,9 @@ export function XDSBadge() {
 **Good:**
 
 ```tsx
-// In XDSBadge.tsx
+// In Badge.tsx
 import {useId, useContext} from 'react';
-export function XDSBadge({label}) {
+export function Badge({label}) {
   const id = useId(); // ✅ useId is RSC-compatible
   const theme = useContext(ThemeContext); // ✅ Reading context is fine
   return <span id={id}>{label}</span>;
@@ -178,7 +178,7 @@ export function XDSBadge({label}) {
 
 **What to do when you need state/effects:**
 
-- Move the behavior to a wrapper component (e.g. `XDSTextTruncation` wraps `XDSText`)
+- Move the behavior to a wrapper component (e.g. `TextTruncation` wraps `Text`)
 - Make state controlled via props (consumer owns the state)
 - If the component legitimately needs client behavior, remove it from the presentational list
 

--- a/internal/eslint-plugin-astryx/boolean-prop-naming.js
+++ b/internal/eslint-plugin-astryx/boolean-prop-naming.js
@@ -2,7 +2,7 @@
 
 /**
  * @file boolean-prop-naming.js
- * @description ESLint rule enforcing Astryx boolean prop naming conventions.
+ * @description ESLint rule enforcing boolean prop naming conventions.
  *
  * Boolean props in *Props interfaces/types must use:
  *   - `is` prefix for state/condition booleans (isDisabled, isRequired, isLoading)
@@ -103,7 +103,7 @@ function isPureBooleanType(typeAnnotation) {
 function getEnclosingPropsName(node) {
   let current = node.parent;
   while (current) {
-    // Interface declaration: `interface XDSButtonProps { ... }`
+    // Interface declaration: `interface ButtonProps { ... }`
     if (current.type === 'TSInterfaceDeclaration') {
       const name = current.id?.name;
       if (name && name.endsWith('Props')) {
@@ -111,7 +111,7 @@ function getEnclosingPropsName(node) {
       }
       return null;
     }
-    // Type alias: `type XDSButtonProps = { ... }`
+    // Type alias: `type ButtonProps = { ... }`
     if (current.type === 'TSTypeAliasDeclaration') {
       const name = current.id?.name;
       if (name && name.endsWith('Props')) {
@@ -129,7 +129,7 @@ const booleanPropNamingRule = {
     type: 'suggestion',
     docs: {
       description:
-        'Enforce Astryx boolean prop naming conventions (is/has prefix)',
+        'Enforce boolean prop naming conventions (is/has prefix)',
       category: 'Best Practices',
       recommended: true,
     },

--- a/internal/eslint-plugin-astryx/boolean-prop-naming.test.mjs
+++ b/internal/eslint-plugin-astryx/boolean-prop-naming.test.mjs
@@ -26,7 +26,7 @@ describe('boolean-prop-naming', () => {
         // ✅ Correct "is" prefix
         {
           code: `
-            interface XDSButtonProps {
+            interface ButtonProps {
               isDisabled?: boolean;
             }
           `,
@@ -34,7 +34,7 @@ describe('boolean-prop-naming', () => {
         // ✅ Correct "has" prefix
         {
           code: `
-            interface XDSTextInputProps {
+            interface TextInputProps {
               hasAutoFocus?: boolean;
             }
           `,
@@ -42,7 +42,7 @@ describe('boolean-prop-naming', () => {
         // ✅ Correct "initialIs" prefix
         {
           code: `
-            interface XDSDialogProps {
+            interface DialogProps {
               initialIsOpen?: boolean;
             }
           `,
@@ -50,7 +50,7 @@ describe('boolean-prop-naming', () => {
         // ✅ Correct "initialHas" prefix
         {
           code: `
-            interface XDSSelectorProps {
+            interface SelectorProps {
               initialHasSelection?: boolean;
             }
           `,
@@ -58,7 +58,7 @@ describe('boolean-prop-naming', () => {
         // ✅ Correct "defaultIs" prefix
         {
           code: `
-            interface XDSCollapsibleProps {
+            interface CollapsibleProps {
               defaultIsOpen?: boolean;
             }
           `,
@@ -66,7 +66,7 @@ describe('boolean-prop-naming', () => {
         // ✅ Correct "defaultHas" prefix
         {
           code: `
-            interface XDSSelectorProps {
+            interface SelectorProps {
               defaultHasSelection?: boolean;
             }
           `,
@@ -74,7 +74,7 @@ describe('boolean-prop-naming', () => {
         // ✅ Correct "defaultIs" prefix — expanded
         {
           code: `
-            interface XDSBannerProps {
+            interface BannerProps {
               defaultIsExpanded?: boolean;
             }
           `,
@@ -82,7 +82,7 @@ describe('boolean-prop-naming', () => {
         // ✅ Non-boolean prop — should be ignored
         {
           code: `
-            interface XDSButtonProps {
+            interface ButtonProps {
               label: string;
               size?: 'sm' | 'md' | 'lg';
             }
@@ -108,7 +108,7 @@ describe('boolean-prop-naming', () => {
         // ✅ Union type with boolean — should be ignored (not purely boolean)
         {
           code: `
-            interface XDSHeadingProps {
+            interface HeadingProps {
               truncateTooltip?: boolean | string;
             }
           `,
@@ -116,7 +116,7 @@ describe('boolean-prop-naming', () => {
         // ✅ aria-* props — excluded
         {
           code: `
-            interface XDSButtonProps {
+            interface ButtonProps {
               'aria-pressed'?: boolean;
             }
           `,
@@ -124,7 +124,7 @@ describe('boolean-prop-naming', () => {
         // ✅ data-* props — excluded
         {
           code: `
-            interface XDSButtonProps {
+            interface ButtonProps {
               'data-active'?: boolean;
             }
           `,
@@ -132,7 +132,7 @@ describe('boolean-prop-naming', () => {
         // ✅ value prop — excluded (controlled component pattern)
         {
           code: `
-            interface XDSSwitchProps {
+            interface SwitchProps {
               value: boolean;
             }
           `,
@@ -140,7 +140,7 @@ describe('boolean-prop-naming', () => {
         // ✅ defaultValue prop — excluded
         {
           code: `
-            interface XDSToggleProps {
+            interface ToggleProps {
               defaultValue?: boolean;
             }
           `,
@@ -148,7 +148,7 @@ describe('boolean-prop-naming', () => {
         // ✅ Type alias with Props suffix — correct naming
         {
           code: `
-            type XDSCardProps = {
+            type CardProps = {
               isFullBleed?: boolean;
             };
           `,
@@ -156,7 +156,7 @@ describe('boolean-prop-naming', () => {
         // ✅ Multiple valid props
         {
           code: `
-            interface XDSFieldProps {
+            interface FieldProps {
               isLabelHidden?: boolean;
               isOptional?: boolean;
               isRequired?: boolean;
@@ -171,7 +171,7 @@ describe('boolean-prop-naming', () => {
         // ❌ Missing prefix — should suggest "isDisabled"
         {
           code: `
-            interface XDSButtonProps {
+            interface ButtonProps {
               disabled?: boolean;
             }
           `,
@@ -180,7 +180,7 @@ describe('boolean-prop-naming', () => {
               messageId: 'invalidBooleanPropName',
               data: {
                 name: 'disabled',
-                interfaceName: 'XDSButtonProps',
+                interfaceName: 'ButtonProps',
                 suggestion: 'isDisabled',
               },
             },
@@ -189,7 +189,7 @@ describe('boolean-prop-naming', () => {
         // ❌ Missing prefix — should suggest "isLoading"
         {
           code: `
-            interface XDSButtonProps {
+            interface ButtonProps {
               loading?: boolean;
             }
           `,
@@ -198,7 +198,7 @@ describe('boolean-prop-naming', () => {
               messageId: 'invalidBooleanPropName',
               data: {
                 name: 'loading',
-                interfaceName: 'XDSButtonProps',
+                interfaceName: 'ButtonProps',
                 suggestion: 'isLoading',
               },
             },
@@ -207,7 +207,7 @@ describe('boolean-prop-naming', () => {
         // ❌ Missing prefix — should suggest "isInline"
         {
           code: `
-            interface XDSCenterProps {
+            interface CenterProps {
               inline?: boolean;
             }
           `,
@@ -216,7 +216,7 @@ describe('boolean-prop-naming', () => {
               messageId: 'invalidBooleanPropName',
               data: {
                 name: 'inline',
-                interfaceName: 'XDSCenterProps',
+                interfaceName: 'CenterProps',
                 suggestion: 'isInline',
               },
             },
@@ -225,7 +225,7 @@ describe('boolean-prop-naming', () => {
         // ❌ Missing prefix — should suggest "isStandalone"
         {
           code: `
-            interface XDSLinkProps {
+            interface LinkProps {
               standalone?: boolean;
             }
           `,
@@ -234,7 +234,7 @@ describe('boolean-prop-naming', () => {
               messageId: 'invalidBooleanPropName',
               data: {
                 name: 'standalone',
-                interfaceName: 'XDSLinkProps',
+                interfaceName: 'LinkProps',
                 suggestion: 'isStandalone',
               },
             },
@@ -243,7 +243,7 @@ describe('boolean-prop-naming', () => {
         // ❌ Missing prefix in type alias
         {
           code: `
-            type XDSTableProps = {
+            type TableProps = {
               striped?: boolean;
             };
           `,
@@ -252,7 +252,7 @@ describe('boolean-prop-naming', () => {
               messageId: 'invalidBooleanPropName',
               data: {
                 name: 'striped',
-                interfaceName: 'XDSTableProps',
+                interfaceName: 'TableProps',
                 suggestion: 'isStriped',
               },
             },
@@ -261,7 +261,7 @@ describe('boolean-prop-naming', () => {
         // ❌ "required" should suggest "isRequired"
         {
           code: `
-            interface XDSFieldProps {
+            interface FieldProps {
               required?: boolean;
             }
           `,
@@ -270,7 +270,7 @@ describe('boolean-prop-naming', () => {
               messageId: 'invalidBooleanPropName',
               data: {
                 name: 'required',
-                interfaceName: 'XDSFieldProps',
+                interfaceName: 'FieldProps',
                 suggestion: 'isRequired',
               },
             },
@@ -279,7 +279,7 @@ describe('boolean-prop-naming', () => {
         // ❌ "checked" should suggest "isChecked"
         {
           code: `
-            interface XDSCheckboxProps {
+            interface CheckboxProps {
               checked?: boolean;
             }
           `,
@@ -288,7 +288,7 @@ describe('boolean-prop-naming', () => {
               messageId: 'invalidBooleanPropName',
               data: {
                 name: 'checked',
-                interfaceName: 'XDSCheckboxProps',
+                interfaceName: 'CheckboxProps',
                 suggestion: 'isChecked',
               },
             },
@@ -297,7 +297,7 @@ describe('boolean-prop-naming', () => {
         // ❌ Multiple violations in one interface
         {
           code: `
-            interface XDSTableProps {
+            interface TableProps {
               striped?: boolean;
               hover?: boolean;
             }
@@ -307,7 +307,7 @@ describe('boolean-prop-naming', () => {
               messageId: 'invalidBooleanPropName',
               data: {
                 name: 'striped',
-                interfaceName: 'XDSTableProps',
+                interfaceName: 'TableProps',
                 suggestion: 'isStriped',
               },
             },
@@ -315,7 +315,7 @@ describe('boolean-prop-naming', () => {
               messageId: 'invalidBooleanPropName',
               data: {
                 name: 'hover',
-                interfaceName: 'XDSTableProps',
+                interfaceName: 'TableProps',
                 suggestion: 'hasHover',
               },
             },
@@ -324,7 +324,7 @@ describe('boolean-prop-naming', () => {
         // ❌ Unknown prop gets generic "is" prefix suggestion
         {
           code: `
-            interface XDSWidgetProps {
+            interface WidgetProps {
               active?: boolean;
             }
           `,
@@ -333,7 +333,7 @@ describe('boolean-prop-naming', () => {
               messageId: 'invalidBooleanPropName',
               data: {
                 name: 'active',
-                interfaceName: 'XDSWidgetProps',
+                interfaceName: 'WidgetProps',
                 suggestion: 'isActive',
               },
             },

--- a/internal/eslint-plugin-astryx/docblock-example-format.js
+++ b/internal/eslint-plugin-astryx/docblock-example-format.js
@@ -7,13 +7,13 @@
  * Valid:
  *   @example
  *   ```
- *   <XDSButton label="Click" />
+ *   <Button label="Click" />
  *   ```
  *
  * Invalid:
- *   @example <XDSButton label="Click" />
+ *   @example <Button label="Click" />
  *   @example
- *   <XDSButton label="Click" />
+ *   <Button label="Click" />
  */
 
 /**

--- a/internal/eslint-plugin-astryx/no-hardcoded-anchor.js
+++ b/internal/eslint-plugin-astryx/no-hardcoded-anchor.js
@@ -4,29 +4,29 @@
  * @file no-hardcoded-anchor.js
  * @description Disallow hardcoded `<a>` elements in Astryx core components.
  *
- * Components that render links should use `useXDSLinkComponent()` to resolve
+ * Components that render links should use `useLinkComponent()` to resolve
  * the link element, allowing consumers to swap in their framework's router
- * (Next.js Link, React Router Link, etc.) via `XDSLinkProvider`.
+ * (Next.js Link, React Router Link, etc.) via `LinkProvider`.
  *
  * This rule catches `<a>` JSX elements and suggests using the link provider
  * pattern instead. It allows `<a>` in a few known cases:
  * - Test files (*.test.tsx)
- * - The Link infrastructure itself (XDSLink.tsx, XDSLinkProvider.tsx)
+ * - The Link infrastructure itself (Link.tsx, LinkProvider.tsx)
  * - In-page anchors (href starting with #)
  *
  * Bad:
  *   <a href={href} className={styles.link}>{children}</a>
  *
  * Good:
- *   const LinkComponent = useXDSLinkComponent();
+ *   const LinkComponent = useLinkComponent();
  *   <LinkComponent href={href} className={styles.link}>{children}</LinkComponent>
  */
 
 const ALLOWED_FILES = [
-  'XDSLink.tsx',
-  'XDSLinkProvider.tsx',
-  'XDSLinkContext.ts',
-  'useXDSLinkComponent.ts',
+  'Link.tsx',
+  'LinkProvider.tsx',
+  'LinkContext.ts',
+  'useLinkComponent.ts',
   'types.ts',
 ];
 
@@ -35,15 +35,15 @@ const rule = {
     type: 'suggestion',
     docs: {
       description:
-        'Disallow hardcoded <a> elements — use useXDSLinkComponent() for router integration',
+        'Disallow hardcoded <a> elements — use useLinkComponent() for router integration',
       category: 'Best Practices',
       recommended: true,
     },
     messages: {
       hardcodedAnchor:
-        'Hardcoded <a> element. Use `useXDSLinkComponent()` to resolve the link component, ' +
-        'so consumers can swap in their framework router via XDSLinkProvider. ' +
-        'See: packages/core/src/Link/useXDSLinkComponent.ts',
+        'Hardcoded <a> element. Use `useLinkComponent()` to resolve the link component, ' +
+        'so consumers can swap in their framework router via LinkProvider. ' +
+        'See: packages/core/src/Link/useLinkComponent.ts',
     },
     schema: [],
   },

--- a/internal/eslint-plugin-astryx/presentational-component.js
+++ b/internal/eslint-plugin-astryx/presentational-component.js
@@ -21,24 +21,24 @@
  * It never remembers, watches, or coordinates on its own.
  */
 const PRESENTATIONAL_COMPONENTS = new Set([
-  'XDSAspectRatio',
-  'XDSBadge',
-  'XDSCard',
-  'XDSCenter',
-  'XDSDivider',
-  'XDSEmptyState',
-  'XDSField',
-  'XDSFormLayout',
-  'XDSGrid',
-  'XDSLayout',
-  'XDSLink',
-  'XDSNavIcon',
-  'XDSProgressBar',
-  'XDSSection',
-  'XDSSkeleton',
-  'XDSStack',
-  'XDSStatusDot',
-  'XDSToken',
+  'AspectRatio',
+  'Badge',
+  'Card',
+  'Center',
+  'Divider',
+  'EmptyState',
+  'Field',
+  'FormLayout',
+  'Grid',
+  'Layout',
+  'Link',
+  'NavIcon',
+  'ProgressBar',
+  'Section',
+  'Skeleton',
+  'Stack',
+  'StatusDot',
+  'Token',
 ]);
 
 /**
@@ -106,7 +106,7 @@ const presentationalComponentRule = {
         'Move state to the consumer or a wrapper component.',
       watches:
         "'{{name}}' makes {{component}} observe the environment. Presentational components must not watch things. " +
-        'Move observation to a wrapper component (e.g. Astryx{{shortName}}Wrapper).',
+        'Move observation to a wrapper component (e.g. {{shortName}}Wrapper).',
       coordinates:
         "'{{name}}' makes {{component}} coordinate its children. Presentational components must not boss children around. ' +" +
         'Move coordination to a dedicated compound component.',
@@ -121,7 +121,7 @@ const presentationalComponentRule = {
     }
 
     const componentName = getFileStem(filename);
-    const shortName = componentName.replace(/^Astryx/, '');
+    const shortName = componentName;
 
     function report(node, name, category) {
       context.report({

--- a/internal/eslint-plugin-astryx/presentational-component.test.mjs
+++ b/internal/eslint-plugin-astryx/presentational-component.test.mjs
@@ -24,18 +24,18 @@ ruleTester.run('presentational-component', presentationalComponentRule, {
     {
       code: `
         import {useState} from 'react';
-        export function XDSButton() {
+        export function Button() {
           const [x, setX] = useState(0);
           return <button>{x}</button>;
         }
       `,
-      filename: 'packages/core/src/Button/XDSButton.tsx',
+      filename: 'packages/core/src/Button/Button.tsx',
     },
     // Presentational component — allowed hooks (useId, useMemo, useCallback, useContext)
     {
       code: `
         import {useId, useMemo, useCallback, useContext} from 'react';
-        export function XDSBadge({label}) {
+        export function Badge({label}) {
           const id = useId();
           const style = useMemo(() => ({}), []);
           const handler = useCallback(() => {}, []);
@@ -43,28 +43,28 @@ ruleTester.run('presentational-component', presentationalComponentRule, {
           return <span id={id}>{label}</span>;
         }
       `,
-      filename: 'packages/core/src/Badge/XDSBadge.tsx',
+      filename: 'packages/core/src/Badge/Badge.tsx',
     },
     // Presentational component — no hooks at all
     {
       code: `
-        export function XDSStatusDot({color}) {
+        export function StatusDot({color}) {
           return <span style={{backgroundColor: color}} />;
         }
       `,
-      filename: 'packages/core/src/StatusDot/XDSStatusDot.tsx',
+      filename: 'packages/core/src/StatusDot/StatusDot.tsx',
     },
     // File not in presentational list — anything goes
     {
       code: `
         import {useState, useEffect, createContext} from 'react';
-        export function XDSTable() {
+        export function Table() {
           const [data, setData] = useState([]);
           useEffect(() => {}, []);
           return <table />;
         }
       `,
-      filename: 'packages/core/src/Table/XDSTable.tsx',
+      filename: 'packages/core/src/Table/Table.tsx',
     },
   ],
   invalid: [
@@ -72,71 +72,71 @@ ruleTester.run('presentational-component', presentationalComponentRule, {
     {
       code: `
         import {useState} from 'react';
-        export function XDSBadge() {
+        export function Badge() {
           const [x, setX] = useState(0);
           return <span>{x}</span>;
         }
       `,
-      filename: 'packages/core/src/Badge/XDSBadge.tsx',
+      filename: 'packages/core/src/Badge/Badge.tsx',
       errors: [{messageId: 'remembers'}],
     },
     // useReducer in presentational component
     {
       code: `
         import {useReducer} from 'react';
-        export function XDSCard() {
+        export function Card() {
           const [state, dispatch] = useReducer(reducer, {});
           return <div>{state.value}</div>;
         }
       `,
-      filename: 'packages/core/src/Card/XDSCard.tsx',
+      filename: 'packages/core/src/Card/Card.tsx',
       errors: [{messageId: 'remembers'}],
     },
     // useTransition in presentational component
     {
       code: `
         import {useTransition} from 'react';
-        export function XDSToken() {
+        export function Token() {
           const [isPending, startTransition] = useTransition();
           return <span>{isPending ? 'loading' : 'done'}</span>;
         }
       `,
-      filename: 'packages/core/src/Token/XDSToken.tsx',
+      filename: 'packages/core/src/Token/Token.tsx',
       errors: [{messageId: 'remembers'}],
     },
     // useEffect in presentational component
     {
       code: `
         import {useEffect} from 'react';
-        export function XDSDivider() {
+        export function Divider() {
           useEffect(() => console.log('mounted'), []);
           return <hr />;
         }
       `,
-      filename: 'packages/core/src/Divider/XDSDivider.tsx',
+      filename: 'packages/core/src/Divider/Divider.tsx',
       errors: [{messageId: 'watches'}],
     },
     // useRef in presentational component
     {
       code: `
         import {useRef} from 'react';
-        export function XDSGrid() {
+        export function Grid() {
           const ref = useRef(null);
           return <div ref={ref} />;
         }
       `,
-      filename: 'packages/core/src/Grid/XDSGrid.tsx',
+      filename: 'packages/core/src/Grid/Grid.tsx',
       errors: [{messageId: 'watches'}],
     },
     // ResizeObserver in presentational component
     {
       code: `
-        export function XDSStack() {
+        export function Stack() {
           const observer = new ResizeObserver(() => {});
           return <div />;
         }
       `,
-      filename: 'packages/core/src/Stack/XDSStack.tsx',
+      filename: 'packages/core/src/Stack/Stack.tsx',
       errors: [{messageId: 'watches'}],
     },
     // createContext in presentational component
@@ -144,23 +144,23 @@ ruleTester.run('presentational-component', presentationalComponentRule, {
       code: `
         import {createContext} from 'react';
         const MyContext = createContext(null);
-        export function XDSSection() {
+        export function Section() {
           return <MyContext.Provider value={{}}><div /></MyContext.Provider>;
         }
       `,
-      filename: 'packages/core/src/Section/XDSSection.tsx',
+      filename: 'packages/core/src/Section/Section.tsx',
       errors: [{messageId: 'coordinates'}],
     },
     // React.useState form
     {
       code: `
         import React from 'react';
-        export function XDSCenter() {
+        export function Center() {
           const [x, setX] = React.useState(0);
           return <div>{x}</div>;
         }
       `,
-      filename: 'packages/core/src/Center/XDSCenter.tsx',
+      filename: 'packages/core/src/Center/Center.tsx',
       errors: [{messageId: 'remembers'}],
     },
   ],

--- a/internal/eslint-plugin-astryx/require-base-props.js
+++ b/internal/eslint-plugin-astryx/require-base-props.js
@@ -2,10 +2,10 @@
 
 /**
  * @file require-base-props.js
- * @description ESLint rule enforcing that publicly exported Astryx component props
- * interfaces extend XDSBaseProps (directly or via Omit/Pick).
+ * @description ESLint rule enforcing that publicly exported component props
+ * interfaces extend BaseProps (directly or via Omit/Pick).
  *
- * XDSBaseProps provides the standard surface area every Astryx component should
+ * BaseProps provides the standard surface area every component should
  * support: xstyle overrides, data-* attributes, aria-* attributes, event
  * handlers, and a curated subset of HTML attributes with footguns removed.
  *
@@ -15,7 +15,7 @@
 
 import {COMPONENT_RULE_ALLOWED, isPubliclyExported} from './shared.js';
 
-function hasXDSBasePropsInHeritage(node) {
+function hasBasePropsInHeritage(node) {
   if (!node.extends || node.extends.length === 0) {
     return false;
   }
@@ -23,7 +23,7 @@ function hasXDSBasePropsInHeritage(node) {
   for (const heritage of node.extends) {
     const expr = heritage.expression;
 
-    if (expr.type === 'Identifier' && expr.name === 'XDSBaseProps') {
+    if (expr.type === 'Identifier' && expr.name === 'BaseProps') {
       return true;
     }
 
@@ -37,8 +37,8 @@ function hasXDSBasePropsInHeritage(node) {
         if (firstParam.type === 'TSTypeReference') {
           const innerName = firstParam.typeName?.name;
           if (
-            innerName === 'XDSBaseProps' ||
-            (innerName?.startsWith('Astryx') && innerName?.endsWith('Props'))
+            innerName === 'BaseProps' ||
+            innerName?.endsWith('Props')
           ) {
             return true;
           }
@@ -48,7 +48,6 @@ function hasXDSBasePropsInHeritage(node) {
 
     if (
       expr.type === 'Identifier' &&
-      expr.name.startsWith('Astryx') &&
       expr.name.endsWith('Props')
     ) {
       return true;
@@ -63,13 +62,13 @@ const rule = {
     type: 'problem',
     docs: {
       description:
-        'Require publicly exported Astryx*Props interfaces to extend XDSBaseProps',
+        'Require publicly exported *Props interfaces to extend BaseProps',
       category: 'Best Practices',
       recommended: true,
     },
     messages: {
       missingBaseProps:
-        '"{{name}}" should extend XDSBaseProps to inherit xstyle, data-*, aria-*, and standard HTML attribute support.',
+        '"{{name}}" should extend BaseProps to inherit xstyle, data-*, aria-*, and standard HTML attribute support.',
     },
     schema: [
       {
@@ -98,7 +97,10 @@ const rule = {
         const name = node.id?.name;
         if (!name) return;
 
-        if (!name.startsWith('Astryx') || !name.endsWith('Props')) return;
+        if (!name.endsWith('Props')) return;
+        // Render-callback prop bags (e.g. TableRenderProps) end in 'Props' but
+        // are not component props — they describe render-function arguments.
+        if (name.endsWith('RenderProps')) return;
 
         const parent = node.parent;
         const isExported =
@@ -110,7 +112,7 @@ const rule = {
 
         if (!isPubliclyExported(name, context.filename)) return;
 
-        if (hasXDSBasePropsInHeritage(node)) return;
+        if (hasBasePropsInHeritage(node)) return;
 
         context.report({
           node: node.id,

--- a/internal/eslint-plugin-astryx/require-ref-prop.js
+++ b/internal/eslint-plugin-astryx/require-ref-prop.js
@@ -2,10 +2,10 @@
 
 /**
  * @file require-ref-prop.js
- * @description ESLint rule enforcing that publicly exported Astryx component props
+ * @description ESLint rule enforcing that publicly exported component props
  * interfaces declare a `ref` property.
  *
- * Every Astryx component should expose ref forwarding so consumers can access
+ * Every component should expose ref forwarding so consumers can access
  * the underlying DOM element. In React 19, ref is a regular prop — components
  * just need `ref?: React.Ref<T>` in their props interface.
  *
@@ -32,9 +32,8 @@ function inheritsRef(node) {
 
     if (
       expr.type === 'Identifier' &&
-      expr.name.startsWith('Astryx') &&
       expr.name.endsWith('Props') &&
-      expr.name !== 'XDSBaseProps'
+      expr.name !== 'BaseProps'
     ) {
       return true;
     }
@@ -47,9 +46,8 @@ function inheritsRef(node) {
       if (typeParams && typeParams.length >= 2) {
         const innerName = typeParams[0]?.typeName?.name;
         if (
-          innerName?.startsWith('Astryx') &&
           innerName?.endsWith('Props') &&
-          innerName !== 'XDSBaseProps'
+          innerName !== 'BaseProps'
         ) {
           if (!isRefOmitted(typeParams[1])) {
             return true;
@@ -79,7 +77,7 @@ const rule = {
     type: 'problem',
     docs: {
       description:
-        'Require publicly exported Astryx*Props interfaces to declare a ref property',
+        'Require publicly exported *Props interfaces to declare a ref property',
       category: 'Best Practices',
       recommended: true,
     },
@@ -114,7 +112,9 @@ const rule = {
         const name = node.id?.name;
         if (!name) return;
 
-        if (!name.startsWith('Astryx') || !name.endsWith('Props')) return;
+        if (!name.endsWith('Props')) return;
+        // Render-callback prop bags (e.g. TableRenderProps) are not component props.
+        if (name.endsWith('RenderProps')) return;
 
         const parent = node.parent;
         const isExported =

--- a/internal/eslint-plugin-astryx/shared.js
+++ b/internal/eslint-plugin-astryx/shared.js
@@ -15,23 +15,27 @@ import {dirname, join} from 'path';
  * different type shape (SVG, provider, overlay).
  */
 export const COMPONENT_RULE_ALLOWED = new Set([
-  // XDSBaseProps is the base type itself
-  'XDSBaseProps',
+  // BaseProps is the base type itself
+  'BaseProps',
   // SVG components extend SVGProps, not HTMLAttributes
-  'XDSIconProps',
-  'XDSSVGIconProps',
+  'IconProps',
+  'SVGIconProps',
   // Overlay/layer components — no meaningful root DOM element
-  'XDSTooltipProps',
-  'XDSPopoverProps',
-  'XDSHoverCardProps',
-  'XDSOverlayProps',
+  'TooltipProps',
+  'PopoverProps',
+  'HoverCardProps',
+  'OverlayProps',
   // System-managed, not directly rendered by consumers
-  'XDSToastProps',
-  'XDSToastViewportProps',
+  'ToastProps',
+  'ToastViewportProps',
   // Provider components — render no DOM element
-  'XDSLayerProviderProps',
-  'XDSLinkProviderProps',
-  'XDSMediaThemeProps',
+  'LayerProviderProps',
+  'LinkProviderProps',
+  'MediaThemeProps',
+  // Hook return-value / editor-config prop bags — not DOM-component props
+  'OverlayContainerProps',
+  'PowerSearchEditorProps',
+  'ResizableProps',
 ]);
 
 const barrelCache = new Map();


### PR DESCRIPTION
## Summary

Fixes the internal ESLint plugin's rules, which silently broke after the component unprefixing. The rules keyed their allowlists / matchers on `XDS*`-prefixed names, but core is now bare (`Badge`, `BaseProps`, `Link.tsx`, …) — so the matching no longer fired.

## Functional fixes
- **`presentational-component`**: `PRESENTATIONAL_COMPONENTS` set `XDS*` → bare (rule now matches `Badge`, `Card`, … again).
- **`shared`**: `COMPONENT_RULE_ALLOWED` set (`XDSBaseProps`, `XDSIconProps`, `XDSTooltipProps`, … → bare).
- **`require-base-props` / `require-ref-prop`**: dropped the `startsWith('XDS')` gate (component props are bare `*Props` now) and match `BaseProps` instead of `XDSBaseProps`.
- **`no-hardcoded-anchor`**: `ALLOWED_FILES` skip-list `XDSLink.tsx`/`XDSLinkProvider.tsx`/`useXDSLinkComponent.ts` → `Link.tsx`/`LinkProvider.tsx`/`useLinkComponent.ts`, so the Link infrastructure files are correctly exempt.

## Also
- `boolean-prop-naming` illustrative comments + rule **test fixtures** (`XDS*Props` → `*Props`) and the plugin README/docblock examples, so they exercise the real (bare) surface.

## Scope
Product-name "XDS" in rule descriptions/categories left as-is (prose branding decision). Internal package — no changeset. All rule files pass `node --check`; `check:sync` + `check:package-boundaries` green.
