### PR TITLE
fix(ci): gate canary publish on @astryxdesign scope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       # docsite `generate` runs `xds theme build`, which imports the compiled
-      # @xds/core/theme entry (dist/theme/index.js). Build core first so that
+      # @astryxdesign/core/theme entry (dist/theme/index.js). Build core first so that
       # entry exists — otherwise generate fails with "Cannot find module".
       - name: Build core package
         run: pnpm -F @astryxdesign/core build
@@ -209,7 +209,7 @@ jobs:
         with:
           path: apps/sandbox/.next/cache
           # No restore-keys fallback — see deploy.yml for the full rationale.
-          # The Next.js module cache bakes in @xds/core's resolved export graph,
+          # The Next.js module cache bakes in @astryxdesign/core's resolved export graph,
           # so a loose fallback can restore a cache built against a different
           # export shape and silently produce wrong builds (broke #2941's
           # post-merge deploy). A changed key yields a cold (safe) rebuild.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -99,15 +99,15 @@ jobs:
         with:
           path: apps/sandbox/.next/cache
           # IMPORTANT: no restore-keys fallback. The key is pinned to the
-          # @xds/core dist hash because the Next.js module cache bakes in the
-          # resolved export graph of @xds/core. A loose restore-keys fallback
+          # @astryxdesign/core dist hash because the Next.js module cache bakes in the
+          # resolved export graph of @astryxdesign/core. A loose restore-keys fallback
           # (e.g. "nextjs-sandbox-<lock>-") would let a build restore a cache
           # produced against a DIFFERENT export shape. That is exactly what
           # broke the post-merge deploy of the XDS un-prefix migration (#2941):
           # the migration changed core's exports (bare names, new subpaths), the
           # exact key missed, and restore-keys fell back to a pre-migration
           # cache whose compiled modules still expected XDS*-prefixed exports —
-          # producing "'Text' is not exported from '@xds/core/Text'" and
+          # producing "'Text' is not exported from '@astryxdesign/core/Text'" and
           # "Element type is invalid ... undefined" prerender failures.
           # A changed key now yields a COLD cache (safe rebuild) instead of a
           # poisoned warm one.
@@ -268,7 +268,7 @@ jobs:
           force_orphan: true
           destination_dir: .
 
-  # Publish @xds/* packages to Metaccio (Meta's internal npm registry).
+  # Publish @astryxdesign/* packages to Metaccio (Meta's internal npm registry).
   # Runs in parallel with deploy — both gate on test passing.
   # changeset publish checks each package: if the version in package.json
   # is not yet on the registry, it publishes. Already-published versions
@@ -314,7 +314,7 @@ jobs:
 
   # Publish canary versions to Metaccio on every push to main.
   # The @canary dist-tag always points to the latest main commit:
-  #   npm install @xds/core@canary --registry https://registry.facebook.net
+  #   npm install @astryxdesign/core@canary --registry https://registry.facebook.net
   canary:
     name: Publish canary to Metaccio
     needs: test
@@ -362,12 +362,12 @@ jobs:
             node -e "
               const fs = require('fs');
               const p = JSON.parse(fs.readFileSync('$pkg','utf8'));
-              if (p.private || !p.name?.startsWith('@xds/')) process.exit(0);
+              if (p.private || !p.name?.startsWith('@astryxdesign/')) process.exit(0);
               p.version = '${CANARY_VERSION}';
               for (const dt of ['dependencies','peerDependencies','devDependencies']) {
                 if (!p[dt]) continue;
                 for (const [k,v] of Object.entries(p[dt])) {
-                  if (k.startsWith('@xds/')) p[dt][k] = '${CANARY_VERSION}';
+                  if (k.startsWith('@astryxdesign/')) p[dt][k] = '${CANARY_VERSION}';
                 }
               }
               fs.writeFileSync('$pkg', JSON.stringify(p, null, 2) + '\n');
@@ -378,7 +378,7 @@ jobs:
           # Publish each package with --tag canary
           for pkg_dir in packages/* packages/themes/*; do
             [ -f "$pkg_dir/package.json" ] || continue
-            IS_PUBLISHABLE=$(node -p "const p=require('./$pkg_dir/package.json'); !p.private && p.name?.startsWith('@xds/') ? 'yes' : 'no'")
+            IS_PUBLISHABLE=$(node -p "const p=require('./$pkg_dir/package.json'); !p.private && p.name?.startsWith('@astryxdesign/') ? 'yes' : 'no'")
             if [ "$IS_PUBLISHABLE" = "yes" ]; then
               NAME=$(node -p "require('./$pkg_dir/package.json').name")
               echo "Publishing ${NAME}@${CANARY_VERSION}"
@@ -386,4 +386,4 @@ jobs:
             fi
           done
 
-          echo "Canary published: npm install @xds/core@${CANARY_VERSION} --registry https://registry.facebook.net"
+          echo "Canary published: npm install @astryxdesign/core@${CANARY_VERSION} --registry https://registry.facebook.net"


### PR DESCRIPTION
## Summary

Fixes a publish bug introduced by the npm-scope rename (#3008). Packages moved to `@astryxdesign/*`, but the **canary publish** job in `deploy.yml` still gated on `name.startsWith('@xds/')` — so it now matches **nothing**:

- **Version stamping** (`if (p.private || !p.name?.startsWith('@xds/')) process.exit(0)`) → every package early-exits, no version written.
- **Dependency version rewrite** (`if (k.startsWith('@xds/'))`) → never matches, intra-repo dep versions not bumped.
- **`IS_PUBLISHABLE`** (`startsWith('@xds/') ? 'yes' : 'no'`) → always `no`, **zero packages published**.

## Fix
Point all three gates at `@astryxdesign/`. Also refreshed the `@xds/core` mentions in `deploy.yml` / `ci.yml` comments + the final `echo` install hint for accuracy.

## Scope
CI config only — no package or source changes, no changeset. The build/runtime `node_modules/@astryxdesign/` scope scans were already handled by #3008; this was the one missed gate.
