### PR TITLE
docs(templates): use astryx in demo content (file tree + example codegen)

### DIFF
--- a/packages/cli/templates/pages/documentation-design/page.tsx
+++ b/packages/cli/templates/pages/documentation-design/page.tsx
@@ -483,7 +483,7 @@ function getComponentDocs(key: string) {
       {
         title: `Basic ${name}`,
         description: `A simple example of the ${name} component with default settings.`,
-        code: `<XDS${name} />`,
+        code: `<${name} />`,
       },
     ],
   };

--- a/packages/cli/templates/pages/file-explorer/page.tsx
+++ b/packages/cli/templates/pages/file-explorer/page.tsx
@@ -187,19 +187,19 @@ const FILESYSTEM: FileSystemItem[] = [
     ],
   },
   {
-    id: 'xds',
-    name: 'xds',
+    id: 'astryx',
+    name: 'astryx',
     type: 'folder',
     children: [
-      {id: 'xds-readme', name: 'README.md', type: 'file'},
-      {id: 'xds-pkg', name: 'package.json', type: 'file'},
+      {id: 'astryx-readme', name: 'README.md', type: 'file'},
+      {id: 'astryx-pkg', name: 'package.json', type: 'file'},
       {
-        id: 'xds-packages',
+        id: 'astryx-packages',
         name: 'packages',
         type: 'folder',
         children: [
           {
-            id: 'xds-core',
+            id: 'astryx-core',
             name: 'core',
             type: 'folder',
             children: [
@@ -216,7 +216,7 @@ const FILESYSTEM: FileSystemItem[] = [
             ],
           },
           {
-            id: 'xds-cli',
+            id: 'astryx-cli',
             name: 'cli',
             type: 'folder',
             children: [{id: 'cli-index', name: 'index.ts', type: 'file'}],
@@ -224,7 +224,7 @@ const FILESYSTEM: FileSystemItem[] = [
         ],
       },
       {
-        id: 'xds-apps',
+        id: 'astryx-apps',
         name: 'apps',
         type: 'folder',
         children: [


### PR DESCRIPTION
## Summary

Two demo-correctness fixes in shipped `@astryxdesign/cli` page templates, part of the `xds` scrub.

## Changes
- **`documentation-design/page.tsx`** — the example-code generator emitted `` `<XDS${name} />` `` (e.g. `<XDSButton />`), which no longer exists after unprefixing. Now emits `` `<${name} />` `` so the generated demo references the real bare component name.
- **`file-explorer/page.tsx`** — the mock monorepo file tree was rooted at `name: 'xds'` with `xds-*` node ids; renamed to `'astryx'` / `astryx-*` to reflect the repo. (Node ids aren't cross-referenced by selection state, so the rename is self-consistent.)

## Scope
Shipped template content only. The product-name "XDS" in other template **prose** (e.g. "about XDS…", "XDS design tokens") is a separate branding pass. No package or functional code changes.
