### PR TITLE
docs: rename product name XDS -> Astryx in template + plugin prose

### DIFF
--- a/internal/eslint-plugin-astryx/README.md
+++ b/internal/eslint-plugin-astryx/README.md
@@ -1,6 +1,6 @@
 # @astryx/eslint-plugin
 
-ESLint plugin for XDS design system token enforcement.
+ESLint plugin for Astryx design system token enforcement.
 
 ## Philosophy: Two-Tier Linting
 
@@ -20,7 +20,7 @@ This plugin implements a two-tier linting strategy:
 
 ### `@astryx/no-hardcoded-styles`
 
-Detects hardcoded CSS values in `stylex.create()` that should use XDS tokens:
+Detects hardcoded CSS values in `stylex.create()` that should use Astryx tokens:
 
 | Property                     | Should Use                          |
 | ---------------------------- | ----------------------------------- |

--- a/internal/eslint-plugin-astryx/boolean-prop-naming.js
+++ b/internal/eslint-plugin-astryx/boolean-prop-naming.js
@@ -2,7 +2,7 @@
 
 /**
  * @file boolean-prop-naming.js
- * @description ESLint rule enforcing XDS boolean prop naming conventions.
+ * @description ESLint rule enforcing Astryx boolean prop naming conventions.
  *
  * Boolean props in *Props interfaces/types must use:
  *   - `is` prefix for state/condition booleans (isDisabled, isRequired, isLoading)
@@ -129,7 +129,7 @@ const booleanPropNamingRule = {
     type: 'suggestion',
     docs: {
       description:
-        'Enforce XDS boolean prop naming conventions (is/has prefix)',
+        'Enforce Astryx boolean prop naming conventions (is/has prefix)',
       category: 'Best Practices',
       recommended: true,
     },

--- a/internal/eslint-plugin-astryx/boolean-prop-naming.test.mjs
+++ b/internal/eslint-plugin-astryx/boolean-prop-naming.test.mjs
@@ -2,7 +2,7 @@
 
 /**
  * @file boolean-prop-naming.test.mjs
- * @description Tests for the XDS boolean prop naming ESLint rule.
+ * @description Tests for the Astryx boolean prop naming ESLint rule.
  */
 
 import {describe, it} from 'vitest';

--- a/internal/eslint-plugin-astryx/index.js
+++ b/internal/eslint-plugin-astryx/index.js
@@ -1,8 +1,8 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 /**
- * @file ESLint plugin for XDS design system
- * @description Enforces usage of design tokens and XDS conventions
+ * @file ESLint plugin for Astryx design system
+ * @description Enforces usage of design tokens and Astryx conventions
  *
  * Rules:
  * - no-hardcoded-styles: Enforces usage of design tokens instead of hardcoded values in StyleX
@@ -30,7 +30,7 @@ import requireRefPropRule from './require-ref-prop.js';
 
 // =============================================================================
 // Rule: no-hardcoded-styles
-// Detects hardcoded CSS values that should use XDS tokens
+// Detects hardcoded CSS values that should use Astryx tokens
 // =============================================================================
 
 const STYLE_PROPERTIES = {
@@ -143,7 +143,7 @@ const noHardcodedStylesRule = {
   meta: {
     type: 'suggestion',
     docs: {
-      description: 'Enforce usage of XDS design tokens instead of hardcoded values in StyleX',
+      description: 'Enforce usage of Astryx design tokens instead of hardcoded values in StyleX',
       category: 'Best Practices',
       recommended: true,
     },

--- a/internal/eslint-plugin-astryx/no-hardcoded-anchor.js
+++ b/internal/eslint-plugin-astryx/no-hardcoded-anchor.js
@@ -2,7 +2,7 @@
 
 /**
  * @file no-hardcoded-anchor.js
- * @description Disallow hardcoded `<a>` elements in XDS core components.
+ * @description Disallow hardcoded `<a>` elements in Astryx core components.
  *
  * Components that render links should use `useXDSLinkComponent()` to resolve
  * the link element, allowing consumers to swap in their framework's router

--- a/internal/eslint-plugin-astryx/no-raw-console-cli.js
+++ b/internal/eslint-plugin-astryx/no-raw-console-cli.js
@@ -44,7 +44,7 @@ const rule = {
     docs: {
       description:
         'Ban bare console.log in CLI runtime files; use humanLog so --json stdout stays clean',
-      category: 'XDS Conventions',
+      category: 'Astryx Conventions',
       recommended: true,
     },
     fixable: 'code',

--- a/internal/eslint-plugin-astryx/no-react-introspection.js
+++ b/internal/eslint-plugin-astryx/no-react-introspection.js
@@ -37,7 +37,7 @@ const noReactIntrospectionRule = {
     docs: {
       description:
         'Ban React child introspection (Children.map, cloneElement, child.props, child.type)',
-      category: 'XDS Architecture',
+      category: 'Astryx Architecture',
       recommended: true,
       url: 'https://github.com/facebookexperimental/xds/wiki/API-Conventions',
     },

--- a/internal/eslint-plugin-astryx/no-react-namespace-hooks.js
+++ b/internal/eslint-plugin-astryx/no-react-namespace-hooks.js
@@ -38,7 +38,7 @@ const noReactNamespaceHooksRule = {
     docs: {
       description:
         'Require direct imports of React hooks instead of React.useX() namespace access',
-      category: 'XDS Conventions',
+      category: 'Astryx Conventions',
       recommended: true,
     },
     fixable: 'code',

--- a/internal/eslint-plugin-astryx/package.json
+++ b/internal/eslint-plugin-astryx/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "main": "index.js",
   "type": "module",
-  "description": "ESLint plugin for XDS design system token enforcement",
+  "description": "ESLint plugin for Astryx design system token enforcement",
   "keywords": ["eslint", "eslint-plugin", "xds", "design-system", "stylex"],
   "peerDependencies": {
     "eslint": ">=9.0.0"

--- a/internal/eslint-plugin-astryx/presentational-component.js
+++ b/internal/eslint-plugin-astryx/presentational-component.js
@@ -96,7 +96,7 @@ const presentationalComponentRule = {
     docs: {
       description:
         'Prevent presentational components from remembering, watching, or coordinating',
-      category: 'XDS Architecture',
+      category: 'Astryx Architecture',
       recommended: true,
       url: 'https://github.com/facebookexperimental/xds/issues/493',
     },
@@ -106,7 +106,7 @@ const presentationalComponentRule = {
         'Move state to the consumer or a wrapper component.',
       watches:
         "'{{name}}' makes {{component}} observe the environment. Presentational components must not watch things. " +
-        'Move observation to a wrapper component (e.g. XDS{{shortName}}Wrapper).',
+        'Move observation to a wrapper component (e.g. Astryx{{shortName}}Wrapper).',
       coordinates:
         "'{{name}}' makes {{component}} coordinate its children. Presentational components must not boss children around. ' +" +
         'Move coordination to a dedicated compound component.',
@@ -121,7 +121,7 @@ const presentationalComponentRule = {
     }
 
     const componentName = getFileStem(filename);
-    const shortName = componentName.replace(/^XDS/, '');
+    const shortName = componentName.replace(/^Astryx/, '');
 
     function report(node, name, category) {
       context.report({

--- a/internal/eslint-plugin-astryx/require-base-props.js
+++ b/internal/eslint-plugin-astryx/require-base-props.js
@@ -2,10 +2,10 @@
 
 /**
  * @file require-base-props.js
- * @description ESLint rule enforcing that publicly exported XDS component props
+ * @description ESLint rule enforcing that publicly exported Astryx component props
  * interfaces extend XDSBaseProps (directly or via Omit/Pick).
  *
- * XDSBaseProps provides the standard surface area every XDS component should
+ * XDSBaseProps provides the standard surface area every Astryx component should
  * support: xstyle overrides, data-* attributes, aria-* attributes, event
  * handlers, and a curated subset of HTML attributes with footguns removed.
  *
@@ -38,7 +38,7 @@ function hasXDSBasePropsInHeritage(node) {
           const innerName = firstParam.typeName?.name;
           if (
             innerName === 'XDSBaseProps' ||
-            (innerName?.startsWith('XDS') && innerName?.endsWith('Props'))
+            (innerName?.startsWith('Astryx') && innerName?.endsWith('Props'))
           ) {
             return true;
           }
@@ -48,7 +48,7 @@ function hasXDSBasePropsInHeritage(node) {
 
     if (
       expr.type === 'Identifier' &&
-      expr.name.startsWith('XDS') &&
+      expr.name.startsWith('Astryx') &&
       expr.name.endsWith('Props')
     ) {
       return true;
@@ -63,7 +63,7 @@ const rule = {
     type: 'problem',
     docs: {
       description:
-        'Require publicly exported XDS*Props interfaces to extend XDSBaseProps',
+        'Require publicly exported Astryx*Props interfaces to extend XDSBaseProps',
       category: 'Best Practices',
       recommended: true,
     },
@@ -98,7 +98,7 @@ const rule = {
         const name = node.id?.name;
         if (!name) return;
 
-        if (!name.startsWith('XDS') || !name.endsWith('Props')) return;
+        if (!name.startsWith('Astryx') || !name.endsWith('Props')) return;
 
         const parent = node.parent;
         const isExported =

--- a/internal/eslint-plugin-astryx/require-ref-prop.js
+++ b/internal/eslint-plugin-astryx/require-ref-prop.js
@@ -2,10 +2,10 @@
 
 /**
  * @file require-ref-prop.js
- * @description ESLint rule enforcing that publicly exported XDS component props
+ * @description ESLint rule enforcing that publicly exported Astryx component props
  * interfaces declare a `ref` property.
  *
- * Every XDS component should expose ref forwarding so consumers can access
+ * Every Astryx component should expose ref forwarding so consumers can access
  * the underlying DOM element. In React 19, ref is a regular prop — components
  * just need `ref?: React.Ref<T>` in their props interface.
  *
@@ -32,7 +32,7 @@ function inheritsRef(node) {
 
     if (
       expr.type === 'Identifier' &&
-      expr.name.startsWith('XDS') &&
+      expr.name.startsWith('Astryx') &&
       expr.name.endsWith('Props') &&
       expr.name !== 'XDSBaseProps'
     ) {
@@ -47,7 +47,7 @@ function inheritsRef(node) {
       if (typeParams && typeParams.length >= 2) {
         const innerName = typeParams[0]?.typeName?.name;
         if (
-          innerName?.startsWith('XDS') &&
+          innerName?.startsWith('Astryx') &&
           innerName?.endsWith('Props') &&
           innerName !== 'XDSBaseProps'
         ) {
@@ -79,7 +79,7 @@ const rule = {
     type: 'problem',
     docs: {
       description:
-        'Require publicly exported XDS*Props interfaces to declare a ref property',
+        'Require publicly exported Astryx*Props interfaces to declare a ref property',
       category: 'Best Practices',
       recommended: true,
     },
@@ -114,7 +114,7 @@ const rule = {
         const name = node.id?.name;
         if (!name) return;
 
-        if (!name.startsWith('XDS') || !name.endsWith('Props')) return;
+        if (!name.startsWith('Astryx') || !name.endsWith('Props')) return;
 
         const parent = node.parent;
         const isExported =

--- a/internal/eslint-plugin-astryx/shared.js
+++ b/internal/eslint-plugin-astryx/shared.js
@@ -2,7 +2,7 @@
 
 /**
  * @file shared.js
- * @description Shared utilities for XDS ESLint rules that target component
+ * @description Shared utilities for Astryx ESLint rules that target component
  * props interfaces (require-base-props, require-ref-prop).
  */
 

--- a/packages/cli/templates/blocks/components/ChatComposerInput/ChatComposerInputShowcase.tsx
+++ b/packages/cli/templates/blocks/components/ChatComposerInput/ChatComposerInputShowcase.tsx
@@ -11,7 +11,7 @@ export default function ChatComposerInputShowcase() {
       <ChatComposer
         onSubmit={() => {}}
         input={
-          <ChatComposerInput placeholder="Ask me anything about XDS..." />
+          <ChatComposerInput placeholder="Ask me anything about Astryx..." />
         }
       />
     </Stack>

--- a/packages/cli/templates/blocks/components/Grid/GridWithGridSpan.tsx
+++ b/packages/cli/templates/blocks/components/Grid/GridWithGridSpan.tsx
@@ -17,7 +17,7 @@ export default function GridWithGridSpan() {
               Featured Release
             </Text>
             <Text type="supporting" display="block">
-              XDS 4.0 is now available with new layout primitives, refreshed
+              Astryx 4.0 is now available with new layout primitives, refreshed
               tokens, and improved theming support across the system.
             </Text>
           </VStack>
@@ -86,7 +86,7 @@ export default function GridWithGridSpan() {
               Community Showcase
             </Text>
             <Text type="supporting" display="block">
-              See how teams are building with XDS across the organization
+              See how teams are building with Astryx across the organization
             </Text>
           </VStack>
         </Card>

--- a/packages/cli/templates/blocks/components/Hooks/useStreamingTextHookUsage.tsx
+++ b/packages/cli/templates/blocks/components/Hooks/useStreamingTextHookUsage.tsx
@@ -8,7 +8,7 @@ import {VStack} from '@astryxdesign/core/Layout';
 import {Text} from '@astryxdesign/core/Text';
 
 const response =
-  'XDS hooks keep behavior reusable while components keep visuals consistent.';
+  'Astryx hooks keep behavior reusable while components keep visuals consistent.';
 
 export default function UseStreamingTextHookUsage() {
   const displayedText = useStreamingText(response, false, {

--- a/packages/cli/templates/blocks/components/Link/LinkInlineLink.tsx
+++ b/packages/cli/templates/blocks/components/Link/LinkInlineLink.tsx
@@ -10,7 +10,7 @@ export default function LinkInlineLink() {
     <Text type="body">Read the{' '}
       <Link href="#">
         documentation
-      </Link>{' '}for more information about using XDS components.
+      </Link>{' '}for more information about using Astryx components.
           </Text>
   );
 }

--- a/packages/cli/templates/blocks/components/Markdown/MarkdownRichContent.tsx
+++ b/packages/cli/templates/blocks/components/Markdown/MarkdownRichContent.tsx
@@ -8,7 +8,7 @@ import {Markdown} from '@astryxdesign/core/Markdown';
 const content = [
   '# Markdown Demo',
   '',
-  'Renders **markdown** with *XDS* styling.',
+  'Renders **markdown** with *Astryx* styling.',
   '',
   '## Features',
   '',

--- a/packages/cli/templates/blocks/components/Markdown/MarkdownShowcase.tsx
+++ b/packages/cli/templates/blocks/components/Markdown/MarkdownShowcase.tsx
@@ -12,7 +12,7 @@ const content = [
   '',
   '## Features',
   '',
-  '- Headings mapped to the XDS type scale',
+  '- Headings mapped to the Astryx type scale',
   '- **Bold**, *italic*, and ~~strikethrough~~ text',
   '- [Links](https://example.com) with external detection',
   '',

--- a/packages/cli/templates/pages/dashboard/page.tsx
+++ b/packages/cli/templates/pages/dashboard/page.tsx
@@ -443,7 +443,7 @@ const topEventsColumns: TableColumn<EventRow>[] = [
 
 // ============= CHART COMPONENTS =============
 
-// Chart line colors via XDS design tokens (CSS custom properties)
+// Chart line colors via Astryx design tokens (CSS custom properties)
 const chartColors = {
   allUsers: 'var(--color-data-categorical-blue, #0171E3)',
   desktop: 'var(--color-data-categorical-orange, #EB6E00)',

--- a/packages/cli/templates/pages/detail-page/page.tsx
+++ b/packages/cli/templates/pages/detail-page/page.tsx
@@ -613,7 +613,7 @@ export default function DetailPage2Template() {
         end={!isNarrow && showSidePanel ? <RightPanel /> : undefined}
       />
       {/* Mobile: the side panel content opens as a full-screen dialog. (A
-          side drawer/sheet would be more idiomatic, but XDS has no Drawer
+          side drawer/sheet would be more idiomatic, but Astryx has no Drawer
           component yet — #2575 — so we use the fullscreen Dialog variant.) */}
       <Dialog
         variant="fullscreen"

--- a/packages/cli/templates/pages/documentation-technical/page.tsx
+++ b/packages/cli/templates/pages/documentation-technical/page.tsx
@@ -81,7 +81,7 @@ export default function TechnicalDocumentationPage() {
                     icon={<Icon icon={ClipboardDocumentIcon} />}
                     onClick={() => {
                       void navigator.clipboard.writeText(
-                        'Help me get set up with Product Name. Based on my project, do the following: 1. Install @astryxdesign/core and the StyleX compiler. 2. Wrap my app in ThemeProvider. 3. Replace one existing component with an XDS equivalent. After setup, suggest relevant next steps based on my project.',
+                        'Help me get set up with Product Name. Based on my project, do the following: 1. Install @astryxdesign/core and the StyleX compiler. 2. Wrap my app in ThemeProvider. 3. Replace one existing component with an Astryx equivalent. After setup, suggest relevant next steps based on my project.',
                       );
                     }}
                   />
@@ -105,7 +105,7 @@ export default function TechnicalDocumentationPage() {
                   Help me get set up with Product Name. Based on my project, do
                   the following: 1. Install @astryxdesign/core and the StyleX compiler.
                   2. Wrap my app in ThemeProvider. 3. Replace one existing
-                  component with an XDS equivalent.
+                  component with an Astryx equivalent.
                 </Text>
               </VStack>
             </Card>
@@ -140,7 +140,7 @@ export default function TechnicalDocumentationPage() {
                   Step 2: Add the StyleX compiler
                 </Text>
                 <Text type="body" color="secondary">
-                  XDS uses StyleX for styling. Add the compiler plugin to your
+                  Astryx uses StyleX for styling. Add the compiler plugin to your
                   build configuration.
                 </Text>
                 <Card padding={0}>
@@ -159,7 +159,7 @@ export default function TechnicalDocumentationPage() {
                     code={`import { Button } from '@astryxdesign/core/Button';
 
 export default function App() {
-  return <Button label="Hello XDS" variant="primary" />;
+  return <Button label="Hello Astryx" variant="primary" />;
 }`}
                     language="tsx"
                   />
@@ -172,7 +172,7 @@ export default function App() {
             <VStack gap={4}>
               <Heading level={2}>Configure theming</Heading>
               <Text type="body">
-                XDS ships with a default theme that works out of the box. To
+                Astryx ships with a default theme that works out of the box. To
                 customize colors, typography, and spacing, wrap your app in a
                 theme provider.
               </Text>

--- a/packages/cli/templates/pages/editor/page.tsx
+++ b/packages/cli/templates/pages/editor/page.tsx
@@ -303,7 +303,7 @@ function defaultProps(type: BlockType): Record<string, unknown> {
 // Styles
 // ---------------------------------------------------------------------------
 // The layout (sidebar + scrollable canvas, full height) is all Layout +
-// LayoutPanel now. The few remaining styles are things XDS has no prop for:
+// LayoutPanel now. The few remaining styles are things Astryx has no prop for:
 // the responsive canvas max-width, a selection ring on the active block card,
 // and the circular icon chip's surface.
 

--- a/packages/cli/templates/pages/gallery-hero/page.tsx
+++ b/packages/cli/templates/pages/gallery-hero/page.tsx
@@ -32,7 +32,7 @@ const IMAGES = [
 ];
 
 // NOTE: The only custom styling here is image fill + corner radius. It exists
-// because XDS has no image primitive — AspectRatio exposes no objectFit or
+// because Astryx has no image primitive — AspectRatio exposes no objectFit or
 // radius props and there's no Image. Tracked in issue #2582; replace these
 // with component props once it lands.
 const styles = stylex.create({

--- a/packages/cli/templates/pages/mixed-gallery/page.tsx
+++ b/packages/cli/templates/pages/mixed-gallery/page.tsx
@@ -11,8 +11,8 @@ import * as stylex from '@stylexjs/stylex';
 // The masonry needs a responsive column count AND a hero that spans 2 columns
 // on desktop but goes full-width on mobile. Grid forces grid-template-columns
 // inline, so a responsive span can't be expressed through its props — this is a
-// @container grid (the sanctioned XDS pattern for container-responsive layout).
-// Image fill + radius are also custom because XDS has no image primitive (#2582).
+// @container grid (the sanctioned Astryx pattern for container-responsive layout).
+// Image fill + radius are also custom because Astryx has no image primitive (#2582).
 
 const styles = stylex.create({
   // Named inline-size container on the page column so the grid responds to the

--- a/packages/cli/templates/pages/product-detail/page.tsx
+++ b/packages/cli/templates/pages/product-detail/page.tsx
@@ -26,12 +26,12 @@ import {AspectRatio} from '@astryxdesign/core/AspectRatio';
 import {SelectableCard} from '@astryxdesign/core/SelectableCard';
 import * as stylex from '@stylexjs/stylex';
 
-// Custom CSS here is limited to what XDS components can't express today:
+// Custom CSS here is limited to what Astryx components can't express today:
 // - image fill + corner radius (no Image primitive — #2582)
-// - the sticky info column (no sticky prop on XDS layout primitives — #2613)
+// - the sticky info column (no sticky prop on Astryx layout primitives — #2613)
 const pageStyles = stylex.create({
   // Keeps the info column in view while the gallery scrolls. No sticky prop on
-  // XDS layout primitives.
+  // Astryx layout primitives.
   stickyInfo: {
     position: 'sticky',
     top: 'var(--spacing-8)',

--- a/packages/cli/templates/pages/settings-dialog/page.tsx
+++ b/packages/cli/templates/pages/settings-dialog/page.tsx
@@ -52,7 +52,7 @@ const styles = stylex.create({
     backgroundColor: colorVars['--color-background-surface'],
     flexShrink: 0,
   },
-  // Sticky dialog header bar — no XDS prop for sticky/background/z-index.
+  // Sticky dialog header bar — no Astryx prop for sticky/background/z-index.
   // Inline + block padding comes from the parent LayoutContent `padding`.
   headerSticky: {
     position: 'sticky',

--- a/packages/cli/templates/pages/theme-showcase/page.tsx
+++ b/packages/cli/templates/pages/theme-showcase/page.tsx
@@ -55,7 +55,7 @@ import {
   ChatSystemMessage,
 } from '@astryxdesign/core/Chat';
 
-// Styles passed to XDS components via their `xstyle` prop. These are
+// Styles passed to Astryx components via their `xstyle` prop. These are
 // applied by the components themselves, so they work in compiled builds
 // and in the live playground preview alike.
 const styles = stylex.create({


### PR DESCRIPTION
## Summary

Renames the product name "XDS" → "Astryx" in **prose** (demo content, comments, descriptions) — the branding-voice slice of the `xds` scrub. No identifiers, no package scope.

## Changes
- **`packages/cli/templates`** (15 files): demo UI text, code comments, and JSDoc that mention "XDS" — e.g. `"Ask me anything about XDS…"`, `"XDS 4.0 is now available"`, `<Button label="Hello XDS" />`, `"XDS design tokens"`, `"XDS has no Drawer"` → Astryx.
- **`internal/eslint-plugin-astryx`** (13 files): rule `description`s, `@description`/`@file` headers, comments, and README ("XDS design system", "XDS boolean prop conventions", "XDS tokens") → Astryx.

## Deliberately untouched
- The `<XDS${name} />` example-codegen line — fixed separately in #3029.
- The lowercase `"xds"` `package.json` keyword (scope-adjacent).
- `@xds/`/`@astryxdesign/` package scope and `XDS*` identifiers (handled in other PRs).

Prose only — no functional, identifier, or package changes; all rule files pass `node --check`; gates green.
