### PR TITLE
refactor(core): rename internal xdsThemeProps helper to themeProps

### DIFF
--- a/packages/core/src/AlertDialog/AlertDialog.tsx
+++ b/packages/core/src/AlertDialog/AlertDialog.tsx
@@ -27,7 +27,7 @@ import {Text} from '../Text/Text';
 import {Button, type ButtonVariant} from '../Button';
 import type {BaseProps} from '../BaseProps';
 import {mergeProps} from '../utils';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 export interface AlertDialogProps extends BaseProps<HTMLDialogElement> {
   ref?: React.Ref<HTMLDialogElement>;
@@ -151,7 +151,7 @@ export function AlertDialog({
       role="alertdialog"
       aria-labelledby={titleId}
       aria-describedby={descriptionId}
-      {...mergeProps(xdsThemeProps('alert-dialog'), {className, style})}
+      {...mergeProps(themeProps('alert-dialog'), {className, style})}
       xstyle={xstyle}
       data-testid={testId}>
       <Layout

--- a/packages/core/src/AppShell/AppShell.tsx
+++ b/packages/core/src/AppShell/AppShell.tsx
@@ -52,7 +52,7 @@ import type {BaseProps} from '../BaseProps';
 import {mergeProps, mergeRefs, isRenderable} from '../utils';
 import {useMediaQuery} from '../hooks/useMediaQuery';
 import {observeResize, unobserveResize} from '../utils/sharedResizeObserver';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 const HasActivity = typeof React.Activity !== 'undefined';
 const ActivityWrapper = HasActivity
@@ -667,7 +667,7 @@ export function AppShell({
       <div
         ref={headerRef}
         {...mergeProps(
-          xdsThemeProps('app-shell-header', {variant}),
+          themeProps('app-shell-header', {variant}),
           stylex.props(navAreaStyle, isAuto && styles.headerSticky),
         )}>
         {headerInner}
@@ -687,7 +687,7 @@ export function AppShell({
       padding={0}
       hasDivider={navHasDividers}
       isScrollable={isFill}
-      {...xdsThemeProps('app-shell-sidenav', {variant})}
+      {...themeProps('app-shell-sidenav', {variant})}
       xstyle={[
         navAreaStyle,
         isAuto && stickyBgStyle,
@@ -748,7 +748,7 @@ export function AppShell({
     shouldShowAutoToggle && !hasTopNav && hasSideNav ? (
       <div
         {...mergeProps(
-          xdsThemeProps('app-shell-header', {variant}),
+          themeProps('app-shell-header', {variant}),
           stylex.props(navAreaStyle, isAuto && styles.headerSticky),
         )}>
         <LayoutHeader padding={0} hasDivider={navHasDividers}>
@@ -771,7 +771,7 @@ export function AppShell({
         ref={mergeRefs(ref, shellRef)}
         data-testid={dataTestId}
         {...mergeProps(
-          xdsThemeProps('app-shell', {variant}),
+          themeProps('app-shell', {variant}),
           stylex.props(
             styles.root,
             variant === 'wash'

--- a/packages/core/src/AspectRatio/AspectRatio.tsx
+++ b/packages/core/src/AspectRatio/AspectRatio.tsx
@@ -19,7 +19,7 @@ import type {ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {BaseProps} from '../BaseProps';
 import {mergeProps} from '../utils';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 /**
  * The shape of the aspect ratio container.
@@ -123,7 +123,7 @@ export function AspectRatio({
     <div
       ref={ref}
       {...mergeProps(
-        xdsThemeProps('aspect-ratio', {shape}),
+        themeProps('aspect-ratio', {shape}),
         stylex.props(
           styles.container,
           shape === 'ellipse' && styles.ellipse,

--- a/packages/core/src/Avatar/Avatar.tsx
+++ b/packages/core/src/Avatar/Avatar.tsx
@@ -27,7 +27,7 @@ import {
 import {AvatarSizeContext} from './AvatarSizeContext';
 import {useAvatarGroup} from '../AvatarGroup/AvatarGroupContext';
 import {mergeProps} from '../utils';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 /**
  * The offset ratio for positioning elements on a circle's edge at 45°.
@@ -310,7 +310,7 @@ export function Avatar({
         aria-label={accessibleName}
         data-testid={testId}
         {...mergeProps(
-          xdsThemeProps('avatar', {size: resolvedSize}),
+          themeProps('avatar', {size: resolvedSize}),
           stylex.props(
             styles.wrapper,
             avatarGroup && groupStyles.ring,

--- a/packages/core/src/Avatar/AvatarStatusDot.tsx
+++ b/packages/core/src/Avatar/AvatarStatusDot.tsx
@@ -21,7 +21,7 @@ import * as stylex from '@stylexjs/stylex';
 import {colorVars, radiusVars} from '../theme/tokens.stylex';
 import {AvatarSizeContext} from './AvatarSizeContext';
 import {mergeProps} from '../utils';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 /**
  * Resolves the status dot size, border width, and icon size based on the
@@ -196,7 +196,7 @@ export function AvatarStatusDot({
       ref={ref}
       {...(label ? {role: 'img', 'aria-label': label} : undefined)}
       {...mergeProps(
-        xdsThemeProps('avatar-status-dot', {variant}),
+        themeProps('avatar-status-dot', {variant}),
         stylex.props(
           styles.dot,
           variantStyleMap[variant],

--- a/packages/core/src/AvatarGroup/AvatarGroup.tsx
+++ b/packages/core/src/AvatarGroup/AvatarGroup.tsx
@@ -24,7 +24,7 @@ import {resolveSize, type AvatarSize} from '../Avatar';
 import * as stylex from '@stylexjs/stylex';
 import {mergeProps} from '../utils';
 import {AvatarGroupContext} from './AvatarGroupContext';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 const OVERLAP_RATIO = 0.25;
 
@@ -99,7 +99,7 @@ export function AvatarGroup({
         aria-label={ariaLabel}
         data-testid={testId}
         {...mergeProps(
-          xdsThemeProps('avatar-group', {size}),
+          themeProps('avatar-group', {size}),
           stylex.props(styles.root, xstyle),
           className,
           style,

--- a/packages/core/src/AvatarGroup/AvatarGroupOverflow.tsx
+++ b/packages/core/src/AvatarGroup/AvatarGroupOverflow.tsx
@@ -24,7 +24,7 @@ import {
 import {mergeProps} from '../utils';
 import {useAvatarGroup} from './AvatarGroupContext';
 import type {BaseProps} from '../BaseProps';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 const BORDER_WIDTH = 2;
 const OVERFLOW_FONT_RATIO = 0.35;
@@ -148,7 +148,7 @@ export function AvatarGroupOverflow({
         onClick={onClick}
         aria-label={label}
         {...mergeProps(
-          xdsThemeProps('avatar-group-overflow'),
+          themeProps('avatar-group-overflow'),
           stylex.props(
             styles.base,
             styles.button,
@@ -171,7 +171,7 @@ export function AvatarGroupOverflow({
       ref={ref}
       aria-label={label}
       {...mergeProps(
-        xdsThemeProps('avatar-group-overflow'),
+        themeProps('avatar-group-overflow'),
         stylex.props(
           styles.base,
           styles.overlap,

--- a/packages/core/src/Badge/Badge.tsx
+++ b/packages/core/src/Badge/Badge.tsx
@@ -27,7 +27,7 @@ import {
   typeScaleVars,
 } from '../theme/tokens.stylex';
 import {mergeProps} from '../utils';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 /**
  * Base badge styles
@@ -198,7 +198,7 @@ export function Badge({
     <span
       ref={ref}
       {...mergeProps(
-        xdsThemeProps('badge', {variant}),
+        themeProps('badge', {variant}),
         stylex.props(styles.base, variants[variant], xstyle),
         className,
         style,

--- a/packages/core/src/Banner/Banner.tsx
+++ b/packages/core/src/Banner/Banner.tsx
@@ -10,8 +10,8 @@
  *
  * Visual structure:
  * - Root container: layout-only wrapper (flex column), no visual styling, no theme target
- * - Header area (xdsThemeProps 'banner'): colored status background with icon, title, description, actions, dismiss
- * - Content area (xdsThemeProps 'banner-content'): collapsible card background for additional content (children)
+ * - Header area (themeProps 'banner'): colored status background with icon, title, description, actions, dismiss
+ * - Content area (themeProps 'banner-content'): collapsible card background for additional content (children)
  * - No left border accent — color is expressed through the full header background
  * - Each visual area owns its own border-radius (no overflow:clip on the container)
  * - When children are provided, a collapse/expand toggle button appears in the end area
@@ -42,7 +42,7 @@ import {
 } from '../theme/tokens.stylex';
 import {mergeProps} from '../utils';
 import {edgeCompSlot} from '../Layout/edgeCompensation.stylex';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 // =============================================================================
 // Types
@@ -417,7 +417,7 @@ export function Banner({
       {/* Header: colored status background — primary theme target ('banner') */}
       <div
         {...mergeProps(
-          xdsThemeProps('banner', {container, status}),
+          themeProps('banner', {container, status}),
           stylex.props(
             styles.header,
             isSingleLine && styles.headerCentered,
@@ -430,7 +430,7 @@ export function Banner({
         )}>
         <div
           {...mergeProps(
-            xdsThemeProps('banner-icon', {status}),
+            themeProps('banner-icon', {status}),
             stylex.props(styles.iconWrapper),
           )}
           aria-hidden="true">
@@ -491,7 +491,7 @@ export function Banner({
       {showContent && (
         <div
           {...mergeProps(
-            xdsThemeProps('banner-content', {container, status}),
+            themeProps('banner-content', {container, status}),
             stylex.props(styles.contentArea, isCard && styles.contentAreaCard),
           )}>
           {children}

--- a/packages/core/src/Blockquote/Blockquote.tsx
+++ b/packages/core/src/Blockquote/Blockquote.tsx
@@ -20,7 +20,7 @@ import type {BaseProps} from '../BaseProps';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars, spacingVars, typeScaleVars} from '../theme/tokens.stylex';
 import {mergeProps} from '../utils';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 export interface BlockquoteProps extends BaseProps<HTMLQuoteElement> {
   /** Ref forwarded to the root <blockquote> element */
@@ -78,7 +78,7 @@ export function Blockquote({
     <blockquote
       ref={ref}
       {...mergeProps(
-        xdsThemeProps('blockquote'),
+        themeProps('blockquote'),
         stylex.props(styles.root, xstyle),
         className,
         style,

--- a/packages/core/src/Breadcrumbs/BreadcrumbItem.tsx
+++ b/packages/core/src/Breadcrumbs/BreadcrumbItem.tsx
@@ -30,7 +30,7 @@ import {useLinkComponent} from '../Link/useLinkComponent';
 import type {LinkComponentType} from '../Link/types';
 import {mergeProps, mergeRefs} from '../utils';
 import type {BaseProps} from '../BaseProps';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 // =============================================================================
 // Props
@@ -231,7 +231,7 @@ export function BreadcrumbItem({
       <li
         ref={mergeRefs(ref, liRef)}
         {...mergeProps(
-          xdsThemeProps('breadcrumb-item'),
+          themeProps('breadcrumb-item'),
           stylex.props(
             itemStyles.root,
             isSupporting ? itemStyles.supportingSize : itemStyles.defaultSize,
@@ -265,7 +265,7 @@ export function BreadcrumbItem({
     <li
       ref={mergeRefs(ref, liRef)}
       {...mergeProps(
-        xdsThemeProps('breadcrumb-item'),
+        themeProps('breadcrumb-item'),
         stylex.props(
           itemStyles.root,
           isSupporting ? itemStyles.supportingSize : itemStyles.defaultSize,

--- a/packages/core/src/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/core/src/Breadcrumbs/Breadcrumbs.tsx
@@ -21,7 +21,7 @@ import * as stylex from '@stylexjs/stylex';
 import {spacingVars} from '../theme/tokens.stylex';
 import {mergeProps} from '../utils';
 import type {BaseProps} from '../BaseProps';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 // =============================================================================
 // Variant type
@@ -165,7 +165,7 @@ export function Breadcrumbs({
         ref={ref}
         aria-label={label}
         {...mergeProps(
-          xdsThemeProps('breadcrumbs', {variant}),
+          themeProps('breadcrumbs', {variant}),
           stylex.props(navStyles.root, xstyle),
           className,
           style,

--- a/packages/core/src/Button/Button.tsx
+++ b/packages/core/src/Button/Button.tsx
@@ -41,7 +41,7 @@ import {useButtonGroup} from '../ButtonGroup/ButtonGroupContext';
 import {mergeProps} from '../utils';
 import {useLinkComponent} from '../Link/useLinkComponent';
 import type {LinkComponentType} from '../Link/types';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 /**
  * Base button styles
@@ -588,7 +588,7 @@ export function Button({
   );
 
   const sharedMergedProps = mergeProps(
-    xdsThemeProps('button', {variant, size}),
+    themeProps('button', {variant, size}),
     sharedStylexProps,
     className,
     style,

--- a/packages/core/src/ButtonGroup/ButtonGroup.tsx
+++ b/packages/core/src/ButtonGroup/ButtonGroup.tsx
@@ -29,7 +29,7 @@ import {mergeProps, mergeRefs} from '../utils';
 import type {BaseProps} from '../BaseProps';
 import {ButtonGroupContext} from './ButtonGroupContext';
 import type {ButtonGroupOrientation} from './ButtonGroupContext';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 // =============================================================================
 // Props
@@ -145,7 +145,7 @@ export function ButtonGroup({
           aria-disabled={isDisabled || undefined}
           data-testid={testId}
           {...mergeProps(
-            xdsThemeProps('button-group', {size, orientation}),
+            themeProps('button-group', {size, orientation}),
             stylex.props(
               styles.group,
               orientation === 'vertical' && styles.vertical,

--- a/packages/core/src/Calendar/Calendar.tsx
+++ b/packages/core/src/Calendar/Calendar.tsx
@@ -72,7 +72,7 @@ import {
 
 export type {ISODateString, DayOfWeek, DateRange} from '../utils/dateTypes';
 import type {ISODateString, DayOfWeek, DateRange} from '../utils/dateTypes';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 /** Imperative handle for Calendar handleRef */
 
@@ -398,7 +398,7 @@ export function Calendar({ref, ...props}: CalendarProps) {
     <div
       ref={ref}
       {...mergeProps(
-        xdsThemeProps('calendar', {mode}),
+        themeProps('calendar', {mode}),
         stylex.props(calendarStyles.calendar, xstyle),
         className,
         style,
@@ -874,7 +874,7 @@ function DayCell({
         onMouseEnter={() => !state.effectivelyDisabled && onDayHover(date)}
         onMouseLeave={() => onDayHover(null)}
         {...mergeProps(
-          xdsThemeProps('calendar-day', {
+          themeProps('calendar-day', {
             selected: endpoint ? 'selected' : null,
             today: state.isToday ? 'today' : null,
             disabled: state.effectivelyDisabled ? 'disabled' : null,

--- a/packages/core/src/Card/Card.tsx
+++ b/packages/core/src/Card/Card.tsx
@@ -30,7 +30,7 @@ import {
 import type {SizeValue, SpacingStep} from '../utils/types';
 import {mergeProps} from '../utils';
 import type {BaseProps} from '../BaseProps';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 // =============================================================================
 // Variant type
@@ -262,7 +262,7 @@ export function Card({
     <div
       ref={ref}
       {...mergeProps(
-        xdsThemeProps('card', {variant}),
+        themeProps('card', {variant}),
         stylex.props(
           styles.card,
           variantStyles[variant],

--- a/packages/core/src/Carousel/Carousel.tsx
+++ b/packages/core/src/Carousel/Carousel.tsx
@@ -33,7 +33,7 @@ import {useScrollOverflow} from '../hooks/useScrollOverflow';
 import type {BaseProps} from '../BaseProps';
 import {mergeProps, mergeRefs} from '../utils';
 import type {SpacingStep} from '../utils/types';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 export interface CarouselProps extends BaseProps<HTMLDivElement> {
   ref?: React.Ref<HTMLDivElement>;
@@ -325,7 +325,7 @@ export function Carousel({
       aria-label={ariaLabel}
       aria-roledescription="carousel"
       {...mergeProps(
-        xdsThemeProps('carousel'),
+        themeProps('carousel'),
         stylex.props(styles.root, xstyle),
         className,
         style,

--- a/packages/core/src/Center/Center.tsx
+++ b/packages/core/src/Center/Center.tsx
@@ -20,7 +20,7 @@ import type {BaseProps} from '../BaseProps';
 import * as stylex from '@stylexjs/stylex';
 import type {SizeValue} from '../utils/types';
 import {mergeProps} from '../utils';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 const styles = stylex.create({
   base: {
@@ -110,7 +110,7 @@ export function Center({
   ...props
 }: CenterProps) {
   const stylexProps = mergeProps(
-    xdsThemeProps('center', {axis}),
+    themeProps('center', {axis}),
     stylex.props(
       isInline ? styles.inline : styles.base,
       (axis === 'both' || axis === 'vertical') && styles.alignItemsCenter,

--- a/packages/core/src/Chat/ChatComposer.tsx
+++ b/packages/core/src/Chat/ChatComposer.tsx
@@ -48,7 +48,7 @@ import {Icon} from '../Icon';
 import {ChatComposerInput} from './ChatComposerInput';
 import {ChatComposerContext} from './ChatContext';
 import {ChatSendButton} from './ChatSendButton';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 // =============================================================================
 // Types
@@ -384,7 +384,7 @@ export function ChatComposer(props: ChatComposerProps) {
       <div
         ref={ref}
         {...mergeProps(
-          xdsThemeProps('chat-composer', {density}),
+          themeProps('chat-composer', {density}),
           stylex.props(styles.root, isDisabled && styles.rootDisabled),
           className,
           style,

--- a/packages/core/src/Chat/ChatComposerDrawer.tsx
+++ b/packages/core/src/Chat/ChatComposerDrawer.tsx
@@ -29,7 +29,7 @@ import {
 import {Badge} from '../Badge';
 import {mergeProps} from '../utils';
 import type {BaseProps} from '../BaseProps';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 export interface ChatComposerDrawerProps extends BaseProps<HTMLDivElement> {
   ref?: React.Ref<HTMLDivElement>;
@@ -250,7 +250,7 @@ export function ChatComposerDrawer({
       ref={ref}
       data-testid={testId}
       {...mergeProps(
-        xdsThemeProps('chat-composer-drawer', {
+        themeProps('chat-composer-drawer', {
           collapsed: isCollapsed ? 'collapsed' : null,
         }),
         stylex.props(styles.root, xstyle),

--- a/packages/core/src/Chat/ChatComposerInput.tsx
+++ b/packages/core/src/Chat/ChatComposerInput.tsx
@@ -55,7 +55,7 @@ import {
 } from './useChatPasteAsToken';
 import {Badge, type BadgeProps} from '../Badge';
 import {useChatComposerContext} from './ChatContext';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 // =============================================================================
 // Types
@@ -619,7 +619,7 @@ export function ChatComposerInput(props: ChatComposerInputProps) {
     <div
       ref={ref}
       {...mergeProps(
-        xdsThemeProps('chat-composer-input'),
+        themeProps('chat-composer-input'),
         stylex.props(styles.root, isDisabled && styles.disabled, xstyle),
         className,
         style,

--- a/packages/core/src/Chat/ChatLayout.tsx
+++ b/packages/core/src/Chat/ChatLayout.tsx
@@ -31,7 +31,7 @@ import {useChatStreamScroll} from './useChatStreamScroll';
 import {useChatNewMessages} from './useChatNewMessages';
 import {ChatLayoutScrollButton} from './ChatLayoutScrollButton';
 import {ChatLayoutContext} from './ChatContext';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 // =============================================================================
 // Types
@@ -330,7 +330,7 @@ export function ChatLayout({
         ref={mergeRefs(ref, rootRef)}
         data-testid={testId}
         {...mergeProps(
-          xdsThemeProps('chat-layout', {density}),
+          themeProps('chat-layout', {density}),
           stylex.props(
             styles.root,
             isSelfScrolling && styles.rootScrollable,

--- a/packages/core/src/Chat/ChatMessage.tsx
+++ b/packages/core/src/Chat/ChatMessage.tsx
@@ -35,7 +35,7 @@ import {
 } from './ChatContext';
 import {mergeProps} from '../utils';
 import type {BaseProps} from '../BaseProps';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 export interface ChatMessageProps extends BaseProps<HTMLElement> {
   ref?: React.Ref<HTMLElement>;
@@ -221,7 +221,7 @@ export function ChatMessage({
         aria-label={!hasName ? `Message from ${sender}` : undefined}
         aria-labelledby={hasName ? nameId : undefined}
         {...mergeProps(
-          xdsThemeProps('chat-message', {sender, density}),
+          themeProps('chat-message', {sender, density}),
           stylex.props(
             styles.root,
             rootAlignment,

--- a/packages/core/src/Chat/ChatMessageBubble.tsx
+++ b/packages/core/src/Chat/ChatMessageBubble.tsx
@@ -37,7 +37,7 @@ import {
 import {useChatMessageContext} from './ChatContext';
 import {mergeProps} from '../utils';
 import type {BaseProps} from '../BaseProps';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 export type ChatMessageBubbleVariant = 'filled' | 'ghost';
 
@@ -277,7 +277,7 @@ export function ChatMessageBubble({
         ref={ref}
         data-testid={testId}
         {...mergeProps(
-          xdsThemeProps('chat-message-bubble', {sender, variant, density}),
+          themeProps('chat-message-bubble', {sender, variant, density}),
           stylex.props(
             styles.content,
             density === 'compact' && styles.radiusCompact,

--- a/packages/core/src/Chat/ChatMessageList.tsx
+++ b/packages/core/src/Chat/ChatMessageList.tsx
@@ -34,7 +34,7 @@ import {mergeProps} from '../utils';
 import {Spinner} from '../Spinner';
 import type {BaseProps} from '../BaseProps';
 import type {SpacingStep} from '../utils/types';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 export interface ChatMessageListProps extends BaseProps<HTMLDivElement> {
   /** Ref forwarded to the root element */
@@ -255,7 +255,7 @@ export function ChatMessageList({
         tabIndex={0}
         data-testid={testId}
         {...mergeProps(
-          xdsThemeProps('chat-message-list', {density}),
+          themeProps('chat-message-list', {density}),
           stylex.props(styles.root, xstyle),
           className,
           style,

--- a/packages/core/src/Chat/ChatMessageMetadata.tsx
+++ b/packages/core/src/Chat/ChatMessageMetadata.tsx
@@ -25,7 +25,7 @@ import {Icon} from '../Icon';
 import type {IconName} from '../Icon/globalIconRegistry';
 import {mergeProps} from '../utils';
 import type {BaseProps} from '../BaseProps';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 export type ChatMessageStatus =
   | 'sending'
@@ -134,7 +134,7 @@ export function ChatMessageMetadata({
     <div
       ref={ref}
       {...mergeProps(
-        xdsThemeProps('chat-message-metadata'),
+        themeProps('chat-message-metadata'),
         stylex.props(
           styles.meta,
           sender === 'user' ? styles.metaUser : styles.metaAssistant,

--- a/packages/core/src/Chat/ChatSendButton.tsx
+++ b/packages/core/src/Chat/ChatSendButton.tsx
@@ -24,7 +24,7 @@ import {getIcon} from '../Icon/globalIconRegistry';
 import {useChatComposerContext} from './ChatContext';
 
 import type {BaseProps} from '../BaseProps';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 // =============================================================================
 // Types
@@ -105,7 +105,7 @@ export function ChatSendButton(props: ChatSendButtonProps): ReactNode {
       isIconOnly
       isDisabled={!isStopShown && isDisabled}
       onClick={isStopShown ? onStop : handleSend}
-      {...xdsThemeProps('chat-send-button')}
+      {...themeProps('chat-send-button')}
       xstyle={[styles.root, xstyle]}
     />
   );

--- a/packages/core/src/Chat/ChatSystemMessage.tsx
+++ b/packages/core/src/Chat/ChatSystemMessage.tsx
@@ -31,7 +31,7 @@ import {
 import {mergeProps} from '../utils';
 import {Divider} from '../Divider';
 import type {BaseProps} from '../BaseProps';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 export type ChatSystemMessageVariant = 'default' | 'divider';
 
@@ -130,7 +130,7 @@ export function ChatSystemMessage({
         role="status"
         data-testid={testId}
         {...mergeProps(
-          xdsThemeProps('chat-system-message', {variant}),
+          themeProps('chat-system-message', {variant}),
           stylex.props(styles.dividerWrap, xstyle),
           className,
           styleProp,
@@ -146,7 +146,7 @@ export function ChatSystemMessage({
       role="status"
       data-testid={testId}
       {...mergeProps(
-        xdsThemeProps('chat-system-message', {variant}),
+        themeProps('chat-system-message', {variant}),
         stylex.props(styles.root, xstyle),
         className,
         styleProp,

--- a/packages/core/src/Chat/ChatTokenizedText.tsx
+++ b/packages/core/src/Chat/ChatTokenizedText.tsx
@@ -23,7 +23,7 @@ import {Badge} from '../Badge';
 import type {ChatComposerToken} from './ChatComposerInput';
 import {mergeProps} from '../utils';
 import type {BaseProps} from '../BaseProps';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 // =============================================================================
 // Styles
@@ -97,7 +97,7 @@ export function ChatTokenizedText({
       <span
         ref={ref}
         {...mergeProps(
-          xdsThemeProps('chat-tokenized-text'),
+          themeProps('chat-tokenized-text'),
           stylex.props(styles.root),
         )}>
         {children ?? ''}
@@ -110,7 +110,7 @@ export function ChatTokenizedText({
     <span
       ref={ref}
       {...mergeProps(
-        xdsThemeProps('chat-tokenized-text'),
+        themeProps('chat-tokenized-text'),
         stylex.props(styles.root),
       )}>
       {parts}

--- a/packages/core/src/Chat/ChatToolCalls.tsx
+++ b/packages/core/src/Chat/ChatToolCalls.tsx
@@ -35,7 +35,7 @@ import {getKey, mergeProps} from '../utils';
 import {Badge} from '../Badge';
 import {Icon, type IconName} from '../Icon';
 import {Spinner} from '../Spinner';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 // =============================================================================
 // Types
@@ -518,7 +518,7 @@ export function ChatToolCalls(props: ChatToolCallsProps) {
       <div
         ref={ref}
         {...mergeProps(
-          xdsThemeProps('chat-tool-calls'),
+          themeProps('chat-tool-calls'),
           stylex.props(styles.root, xstyle),
           className,
           style,
@@ -537,7 +537,7 @@ export function ChatToolCalls(props: ChatToolCallsProps) {
     <div
       ref={ref}
       {...mergeProps(
-        xdsThemeProps('chat-tool-calls'),
+        themeProps('chat-tool-calls'),
         stylex.props(styles.root, xstyle),
         className,
         style,

--- a/packages/core/src/Chat/useTriggerMenu.tsx
+++ b/packages/core/src/Chat/useTriggerMenu.tsx
@@ -39,7 +39,7 @@ import {
 } from '../theme/tokens.stylex';
 import {mergeProps, groupItems} from '../utils';
 import type {SearchableItem} from '../Typeahead/types';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 import type {
   ChatComposerTrigger,
   ChatComposerToken,
@@ -684,7 +684,7 @@ export function useTriggerMenu(
         role="listbox"
         aria-label={trigger?.menuLabel ?? 'Suggestions'}
         {...mergeProps(
-          xdsThemeProps('trigger-menu'),
+          themeProps('trigger-menu'),
           stylex.props(styles.dropdown),
         )}>
         {listContent}

--- a/packages/core/src/CheckboxInput/CheckboxInput.tsx
+++ b/packages/core/src/CheckboxInput/CheckboxInput.tsx
@@ -46,7 +46,7 @@ import type {InputStatus} from '../Field/types';
 import {Spinner} from '../Spinner';
 import {mergeProps, mergeRefs} from '../utils';
 import {checkboxScope} from './checkbox.markers.stylex';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 const styles = stylex.create({
   container: {
@@ -401,7 +401,7 @@ export function CheckboxInput({
   return (
     <div
       {...mergeProps(
-        xdsThemeProps('checkbox-input', {size}),
+        themeProps('checkbox-input', {size}),
         stylex.props(width != null && dynamicWidthStyles.width(width), xstyle),
         className,
         style,
@@ -450,7 +450,7 @@ export function CheckboxInput({
           <div
             aria-hidden="true"
             {...mergeProps(
-              xdsThemeProps('checkbox', {
+              themeProps('checkbox', {
                 size,
                 checked: isChecked
                   ? 'checked'

--- a/packages/core/src/CheckboxList/CheckboxList.tsx
+++ b/packages/core/src/CheckboxList/CheckboxList.tsx
@@ -31,7 +31,7 @@ import type {InputStatus} from '../Field/types';
 import {List} from '../List/List';
 import type {ListDensity} from '../List/ListContext';
 import {mergeProps} from '../utils';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 import {
   CheckboxListContext,
   type CheckboxListContextValue,
@@ -224,7 +224,7 @@ export function CheckboxList({
       statusVariant="detached"
       width={width}
       xstyle={xstyle}
-      {...mergeProps(xdsThemeProps('checkbox-list'), {className, style})}>
+      {...mergeProps(themeProps('checkbox-list'), {className, style})}>
       <CheckboxListContext value={contextValue}>
         <List density={density} hasDividers={hasDividers}>
           {children}

--- a/packages/core/src/Citation/Citation.tsx
+++ b/packages/core/src/Citation/Citation.tsx
@@ -27,7 +27,7 @@ import {
 } from '../theme/tokens.stylex';
 import {mergeProps} from '../utils';
 import type {BaseProps} from '../BaseProps';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 export interface CitationSource {
   title?: string;
@@ -173,7 +173,7 @@ export function Citation({
         data-testid={testId}
         {...linkProps}
         {...mergeProps(
-          xdsThemeProps('citation', {variant}),
+          themeProps('citation', {variant}),
           stylex.props(
             styles.number,
             href != null && styles.numberHover,
@@ -196,7 +196,7 @@ export function Citation({
       data-testid={testId}
       {...linkProps}
       {...mergeProps(
-        xdsThemeProps('citation', {variant}),
+        themeProps('citation', {variant}),
         stylex.props(
           styles.label,
           icon != null && styles.labelWithIcon,

--- a/packages/core/src/ClickableCard/ClickableCard.tsx
+++ b/packages/core/src/ClickableCard/ClickableCard.tsx
@@ -39,7 +39,7 @@ import type {CardVariant} from '../Card/Card';
 import {useClickableContainer} from '../hooks/useClickableContainer';
 import type {BaseProps} from '../BaseProps';
 import {useLinkComponent} from '../Link/useLinkComponent';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 // =============================================================================
 // Styles — only the interactive layer, Card handles everything else
@@ -256,7 +256,7 @@ export function ClickableCard({
       maxWidth={maxWidth}
       padding={padding}
       variant={variant}
-      {...mergeProps(xdsThemeProps('clickable-card', {variant}), {
+      {...mergeProps(themeProps('clickable-card', {variant}), {
         className: classNameProp,
         style,
       })}

--- a/packages/core/src/Code/Code.tsx
+++ b/packages/core/src/Code/Code.tsx
@@ -25,7 +25,7 @@ import {
 } from '../theme/tokens.stylex';
 import {mergeProps} from '../utils';
 import type {BaseProps} from '../BaseProps';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 const styles = stylex.create({
   base: {
@@ -74,7 +74,7 @@ export function Code({
     <code
       ref={ref}
       {...mergeProps(
-        xdsThemeProps('code'),
+        themeProps('code'),
         stylex.props(styles.base, xstyle),
         className,
         style,

--- a/packages/core/src/CodeBlock/CodeBlock.tsx
+++ b/packages/core/src/CodeBlock/CodeBlock.tsx
@@ -42,7 +42,7 @@ import {
 import type {SyntaxToken, TokenLine} from './tokenizer';
 import {ensureHighlightStyles} from './highlightStyles';
 import {applyHighlightRangesChunked} from './highlightRanges';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 // ---------------------------------------------------------------------------
 // Styles
@@ -776,7 +776,7 @@ export function CodeBlock({
     <pre
       ref={ref}
       {...mergeProps(
-        xdsThemeProps('codeblock', {size, language, container}),
+        themeProps('codeblock', {size, language, container}),
         stylex.props(
           styles.root,
           dynamicStyles.width(widthProp),

--- a/packages/core/src/Collapsible/Collapsible.tsx
+++ b/packages/core/src/Collapsible/Collapsible.tsx
@@ -36,7 +36,7 @@ import {useCollapsible} from './useCollapsible';
 import {getIcon} from '../Icon/globalIconRegistry';
 import {mergeProps} from '../utils';
 import type {BaseProps} from '../BaseProps';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 const styles = stylex.create({
   root: {
@@ -198,7 +198,7 @@ export function Collapsible({
     <div
       ref={ref}
       {...mergeProps(
-        xdsThemeProps('collapsible'),
+        themeProps('collapsible'),
         stylex.props(styles.root, xstyle),
         className,
         style,

--- a/packages/core/src/CommandPalette/CommandPaletteFooter.tsx
+++ b/packages/core/src/CommandPalette/CommandPaletteFooter.tsx
@@ -23,7 +23,7 @@ import {
   typographyVars,
 } from '../theme/tokens.stylex';
 import {Kbd} from '../Kbd';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 const styles = stylex.create({
   footer: {
@@ -89,7 +89,7 @@ export function CommandPaletteFooter({
     <div
       ref={ref}
       {...mergeProps(
-        xdsThemeProps('command-palette-footer'),
+        themeProps('command-palette-footer'),
         stylex.props(styles.footer, xstyle),
         className,
         style,

--- a/packages/core/src/CommandPalette/CommandPaletteGroup.tsx
+++ b/packages/core/src/CommandPalette/CommandPaletteGroup.tsx
@@ -16,7 +16,7 @@ import type {ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {BaseProps} from '../BaseProps';
 import {mergeProps} from '../utils';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 import {
   colorVars,
   spacingVars,
@@ -84,7 +84,7 @@ export function CommandPaletteGroup({
       role="group"
       aria-label={heading}
       {...mergeProps(
-        xdsThemeProps('command-palette-group'),
+        themeProps('command-palette-group'),
         stylex.props(styles.group, xstyle),
         className,
         style,

--- a/packages/core/src/CommandPalette/CommandPaletteInput.tsx
+++ b/packages/core/src/CommandPalette/CommandPaletteInput.tsx
@@ -26,7 +26,7 @@ import {
 import {useCommandPaletteContext} from './CommandPaletteContext';
 import {useDialogContext} from '../Dialog/DialogContext';
 import type {BaseProps} from '../BaseProps';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 const styles = stylex.create({
   wrapper: {
@@ -193,7 +193,7 @@ export function CommandPaletteInput({
   return (
     <div
       {...mergeProps(
-        xdsThemeProps('command-palette-input'),
+        themeProps('command-palette-input'),
         stylex.props(styles.wrapper, xstyle),
       )}>
       <span {...stylex.props(styles.icon)}>

--- a/packages/core/src/CommandPalette/CommandPaletteItem.tsx
+++ b/packages/core/src/CommandPalette/CommandPaletteItem.tsx
@@ -24,7 +24,7 @@ import {
 } from '../theme/tokens.stylex';
 import {useCommandPaletteContext} from './CommandPaletteContext';
 import {useDialogContext} from '../Dialog/DialogContext';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 const HOVER_HOVER = '@media (hover: hover)';
 
@@ -194,7 +194,7 @@ export function CommandPaletteItem({
       onClick={handleClick}
       onMouseEnter={handleMouseEnter}
       {...mergeProps(
-        xdsThemeProps('command-palette-item'),
+        themeProps('command-palette-item'),
         stylex.props(
           styles.item,
           !isDisabled && styles.itemHover,

--- a/packages/core/src/CommandPalette/CommandPaletteList.tsx
+++ b/packages/core/src/CommandPalette/CommandPaletteList.tsx
@@ -19,7 +19,7 @@ import type {BaseProps} from '../BaseProps';
 import {mergeProps} from '../utils';
 import {spacingVars} from '../theme/tokens.stylex';
 import {useCommandPaletteContext} from './CommandPaletteContext';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 const styles = stylex.create({
   list: {
@@ -88,7 +88,7 @@ export function CommandPaletteList({
       role="listbox"
       aria-label={label}
       {...mergeProps(
-        xdsThemeProps('command-palette-list'),
+        themeProps('command-palette-list'),
         stylex.props(styles.list, xstyle),
         className,
         style,

--- a/packages/core/src/ContextMenu/ContextMenu.tsx
+++ b/packages/core/src/ContextMenu/ContextMenu.tsx
@@ -53,7 +53,7 @@ import {
 } from '../theme/tokens.stylex';
 import {mergeProps} from '../utils';
 import type {BaseProps} from '../BaseProps';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 import type {
   DropdownMenuOption,
   DropdownMenuItemData,
@@ -297,7 +297,7 @@ export function ContextMenu({
           role="menu"
           onKeyDown={listKeyDown}
           {...mergeProps(
-            xdsThemeProps('context-menu'),
+            themeProps('context-menu'),
             stylex.props(styles.menu, xstyle),
             className,
             style,

--- a/packages/core/src/DateInput/DateInput.tsx
+++ b/packages/core/src/DateInput/DateInput.tsx
@@ -135,7 +135,7 @@ export type {
 import {mergeProps, mergeRefs} from '../utils';
 import type {BaseProps} from '../BaseProps';
 import type {SizeValue} from '../utils/types';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 export interface DateInputProps extends Omit<
   BaseProps,
@@ -516,7 +516,7 @@ export function DateInput({
         ref={popover.triggerRef}
         {...rest}
         {...mergeProps(
-          xdsThemeProps('date-input', {size, status: status?.type ?? null}),
+          themeProps('date-input', {size, status: status?.type ?? null}),
           stylex.props(
             inputWrapperStyles.base,
             sizeStyles[size],

--- a/packages/core/src/DateRangeInput/DateRangeInput.tsx
+++ b/packages/core/src/DateRangeInput/DateRangeInput.tsx
@@ -52,7 +52,7 @@ import {mergeProps} from '../utils';
 import type {BaseProps} from '../BaseProps';
 import type {SizeValue} from '../utils/types';
 import {useSize} from '../SizeContext/SizeContext';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 export type {DateRange} from '../Calendar';
 
@@ -490,7 +490,7 @@ export function DateRangeInput({
         ref={popover.triggerRef}
         {...rest}
         {...mergeProps(
-          xdsThemeProps('date-range-input', {
+          themeProps('date-range-input', {
             size,
             status: status?.type ?? null,
           }),

--- a/packages/core/src/DateTimeInput/DateTimeInput.tsx
+++ b/packages/core/src/DateTimeInput/DateTimeInput.tsx
@@ -78,7 +78,7 @@ import type {StyleXStyles} from '@stylexjs/stylex';
 import type {BaseProps} from '../BaseProps';
 import type {SizeValue} from '../utils/types';
 import {useSize} from '../SizeContext/SizeContext';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 export type ISODateTimeString = string & {
   readonly __brand: 'ISODateTimeString';
@@ -790,7 +790,7 @@ export function DateTimeInput({
       <div
         {...rest}
         {...mergeProps(
-          xdsThemeProps('date-time-input', {
+          themeProps('date-time-input', {
             size,
             status: status?.type ?? null,
           }),

--- a/packages/core/src/Dialog/Dialog.tsx
+++ b/packages/core/src/Dialog/Dialog.tsx
@@ -39,7 +39,7 @@ import {
 import type {SpacingStep} from '../utils/types';
 import {mergeProps, mergeRefs} from '../utils';
 import {DialogContext} from './DialogContext';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 /**
  * Calculate a directional translate offset for dialog entry animation.
@@ -505,7 +505,7 @@ export function Dialog({
     return (
       <div
         {...mergeProps(
-          xdsThemeProps('dialog', {variant}),
+          themeProps('dialog', {variant}),
           stylex.props(
             styles.inlineWrapper,
             !isFullscreen && dynamicStyles.sizing(width, maxHeight),
@@ -539,7 +539,7 @@ export function Dialog({
       aria-modal="true"
       role={purpose === 'required' ? 'alertdialog' : undefined}
       {...mergeProps(
-        xdsThemeProps('dialog', {variant}),
+        themeProps('dialog', {variant}),
         stylex.props(
           styles.dialog,
           isOpen && styles.open,

--- a/packages/core/src/Divider/Divider.tsx
+++ b/packages/core/src/Divider/Divider.tsx
@@ -26,7 +26,7 @@ import {
   borderVars,
 } from '../theme/tokens.stylex';
 import {mergeProps} from '../utils';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 /**
  * Extensible variant map for Divider.
@@ -197,7 +197,7 @@ export function Divider({
       role="separator"
       aria-orientation={orientation}
       {...mergeProps(
-        xdsThemeProps('divider', {variant, orientation}),
+        themeProps('divider', {variant, orientation}),
         stylex.props(
           isHorizontal ? baseStyles.horizontal : baseStyles.vertical,
           isFullBleed &&

--- a/packages/core/src/DropdownMenu/DropdownMenu.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenu.tsx
@@ -53,7 +53,7 @@ import {
 } from '../theme/tokens.stylex';
 import {mergeProps} from '../utils';
 import type {BaseProps} from '../BaseProps';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 const styles = stylex.create({
   dropdown: {
@@ -401,7 +401,7 @@ export function DropdownMenu({
           role="menu"
           onKeyDown={listKeyDown}
           {...mergeProps(
-            xdsThemeProps('dropdown-menu'),
+            themeProps('dropdown-menu'),
             stylex.props(styles.dropdown, xstyle),
             className,
             style,

--- a/packages/core/src/DropdownMenu/DropdownMenuItem.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenuItem.tsx
@@ -36,7 +36,7 @@ import {
 } from '../theme/tokens.stylex';
 import {mergeProps} from '../utils';
 import {useDropdownMenuContext} from './DropdownMenuContext';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 const menuItemStyles = stylex.create({
   root: {
@@ -161,7 +161,7 @@ export function DropdownMenuItem({
         isDisabled && menuItemStyles.disabled,
         xstyle,
       ]}
-      {...mergeProps(xdsThemeProps('dropdown-menu-item', {size: menuSize}), {
+      {...mergeProps(themeProps('dropdown-menu-item', {size: menuSize}), {
         className,
         style,
       })}

--- a/packages/core/src/EmptyState/EmptyState.tsx
+++ b/packages/core/src/EmptyState/EmptyState.tsx
@@ -24,7 +24,7 @@ import {
 } from '../theme/tokens.stylex';
 import type {BaseProps} from '../BaseProps';
 import {mergeProps} from '../utils';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 const styles = stylex.create({
   container: {
@@ -156,7 +156,7 @@ export function EmptyState({
       ref={ref}
       role="status"
       {...mergeProps(
-        xdsThemeProps('empty-state', {variant: isCompact ? 'compact' : null}),
+        themeProps('empty-state', {variant: isCompact ? 'compact' : null}),
         stylex.props(
           styles.container,
           isCompact && styles.containerCompact,

--- a/packages/core/src/Field/Field.tsx
+++ b/packages/core/src/Field/Field.tsx
@@ -27,7 +27,7 @@ import type {IconType} from '../Icon';
 import {mergeProps} from '../utils';
 import {FormLayoutContext} from '../FormLayout/FormLayoutContext';
 import {Text} from '../Text';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 const styles = stylex.create({
   container: {
@@ -236,7 +236,7 @@ export function Field({
       <div
         ref={ref}
         {...mergeProps(
-          xdsThemeProps('field', {layout: 'horizontal-labels'}),
+          themeProps('field', {layout: 'horizontal-labels'}),
           stylex.props(styles.horizontalLabels, xstyle),
           className,
           style,
@@ -264,7 +264,7 @@ export function Field({
     <div
       ref={ref}
       {...mergeProps(
-        xdsThemeProps('field'),
+        themeProps('field'),
         stylex.props(
           styles.container,
           !isLabelHidden && styles.containerGap,

--- a/packages/core/src/Field/FieldLabel.tsx
+++ b/packages/core/src/Field/FieldLabel.tsx
@@ -26,7 +26,7 @@ import {
 } from '../theme/tokens.stylex';
 import {Icon, renderIconSlot, type IconType} from '../Icon';
 import {Tooltip} from '../Tooltip';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 const styles = stylex.create({
   label: {
@@ -158,7 +158,7 @@ export function FieldLabel({
         ref={ref}
         htmlFor={inputID}
         {...mergeProps(
-          xdsThemeProps('field-label'),
+          themeProps('field-label'),
           stylex.props(
             styles.label,
             isDisabled && styles.labelDisabled,

--- a/packages/core/src/FieldStatus/FieldStatus.tsx
+++ b/packages/core/src/FieldStatus/FieldStatus.tsx
@@ -29,7 +29,7 @@ import {
 } from '../theme/tokens.stylex';
 import type {InputStatusType} from '../Field/types';
 import {useEntryAnimation} from '../hooks/useEntryAnimation';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 const styles = stylex.create({
   base: {
@@ -147,7 +147,7 @@ export function FieldStatus({
       aria-live={type === 'error' ? 'assertive' : 'polite'}
       {...rest}
       {...mergeProps(
-        xdsThemeProps('field-status', {type, variant}),
+        themeProps('field-status', {type, variant}),
         stylex.props(
           styles.base,
           entryStyle,

--- a/packages/core/src/FileInput/FileInput.tsx
+++ b/packages/core/src/FileInput/FileInput.tsx
@@ -52,7 +52,7 @@ export type {
 import {mergeProps, mergeRefs} from '../utils';
 import type {BaseProps} from '../BaseProps';
 import type {SizeValue} from '../utils/types';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 function formatFileSize(bytes: number): string {
   if (bytes < 1024) {
@@ -674,7 +674,7 @@ export function FileInput({
         aria-busy={isLoading || undefined}
         {...dragDropProps}
         {...mergeProps(
-          xdsThemeProps('file-input', {mode, status: status?.type ?? null}),
+          themeProps('file-input', {mode, status: status?.type ?? null}),
           stylex.props(
             isDropzone ? styles.dropzone : styles.compact,
             isDropzone && !isDisabled && styles.dropzoneHover,

--- a/packages/core/src/FormLayout/FormLayout.tsx
+++ b/packages/core/src/FormLayout/FormLayout.tsx
@@ -24,7 +24,7 @@ import {
   type FormLayoutDirection,
 } from './FormLayoutContext';
 import {mergeProps} from '../utils';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 // =============================================================================
 // Responsive breakpoint for horizontal-labels collapse
@@ -125,7 +125,7 @@ export function FormLayout({
       <div
         ref={ref}
         {...mergeProps(
-          xdsThemeProps('form-layout', {direction}),
+          themeProps('form-layout', {direction}),
           stylex.props(
             styles.base,
             direction === 'horizontal' && styles.horizontal,

--- a/packages/core/src/Grid/Grid.tsx
+++ b/packages/core/src/Grid/Grid.tsx
@@ -22,7 +22,7 @@ import {spacingVars} from '../theme/tokens.stylex';
 import type {SpacingStep} from '../utils/types';
 import type {SizeValue} from '../utils/types';
 import {mergeProps} from '../utils';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 /**
  * Grid alignment options for align-items and justify-items.
@@ -411,7 +411,7 @@ export function Grid({
     }),
   };
 
-  // For xdsThemeProps, extract numeric columns value for variant tracking
+  // For themeProps, extract numeric columns value for variant tracking
   const columnsVariant =
     typeof columns === 'number'
       ? columns
@@ -423,7 +423,7 @@ export function Grid({
     <div
       ref={ref}
       {...mergeProps(
-        xdsThemeProps('grid', {columns: columnsVariant, gap, align, justify}),
+        themeProps('grid', {columns: columnsVariant, gap, align, justify}),
         stylex.props(
           baseStyles.grid,
           gap != null && gapStyles[gap],

--- a/packages/core/src/Grid/GridSpan.tsx
+++ b/packages/core/src/Grid/GridSpan.tsx
@@ -17,7 +17,7 @@ import type {ReactNode} from 'react';
 import type {BaseProps} from '../BaseProps';
 import * as stylex from '@stylexjs/stylex';
 import {mergeProps} from '../utils';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 export interface GridSpanProps extends BaseProps<HTMLDivElement> {
   /** Ref forwarded to the root element */
@@ -89,7 +89,7 @@ export function GridSpan({
     <div
       ref={ref}
       {...mergeProps(
-        xdsThemeProps('grid-span'),
+        themeProps('grid-span'),
         stylex.props(baseStyles.span, xstyle),
         className,
         {...style, ...inlineStyle},

--- a/packages/core/src/Heading/Heading.tsx
+++ b/packages/core/src/Heading/Heading.tsx
@@ -44,7 +44,7 @@ import {useTruncation} from '../Text/useTruncation';
 import type {LayerPlacement} from '../Layer';
 import {mergeProps, mergeRefs} from '../utils';
 import type {BaseProps} from '../BaseProps';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 const LazyXDSTooltip = lazy(async () =>
   import('../Tooltip/Tooltip').then(mod => ({default: mod.Tooltip})),
@@ -249,7 +249,7 @@ export function Heading({
       <Component
         ref={mergeRefs(ref, truncation.ref, headingRef)}
         {...mergeProps(
-          xdsThemeProps('heading', {level, color, ...(type && {type})}),
+          themeProps('heading', {level, color, ...(type && {type})}),
           stylex.props(
             colorStyles[color],
             type ? sizeByTypeStyles[type] : sizeByLevelStyles[level],

--- a/packages/core/src/HoverCard/useHoverCard.tsx
+++ b/packages/core/src/HoverCard/useHoverCard.tsx
@@ -35,7 +35,7 @@ import {
   spacingVars,
 } from '../theme/tokens.stylex';
 import {mergeProps} from '../utils';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 const styles = stylex.create({
   // Base container styles passed to useLayer
@@ -459,7 +459,7 @@ export function useHoverCard(
       return layer.render(
         <div
           {...mergeProps(
-            xdsThemeProps('hovercard'),
+            themeProps('hovercard'),
             stylex.props(styles.content),
           )}
           onMouseEnter={() => {

--- a/packages/core/src/Icon/Icon.tsx
+++ b/packages/core/src/Icon/Icon.tsx
@@ -28,7 +28,7 @@ import {colorVars} from '../theme/tokens.stylex';
 import {getIcon} from './globalIconRegistry';
 import type {IconName} from './globalIconRegistry';
 import {mergeProps} from '../utils';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 // =============================================================================
 // Styles
@@ -241,7 +241,7 @@ export function Icon({
       ref={ref}
       aria-hidden="true"
       {...mergeProps(
-        xdsThemeProps('icon', {size, color}),
+        themeProps('icon', {size, color}),
         stylex.props(styles.root, colorStyles[color], sizeStyles[size]),
       )}
       {...props}
@@ -283,7 +283,7 @@ function IconFromRegistry({
     <span
       {...(spanProps as React.HTMLAttributes<HTMLSpanElement>)}
       {...mergeProps(
-        xdsThemeProps('icon', {size, color}),
+        themeProps('icon', {size, color}),
         stylex.props(styles.span, colorStyles[color], spanSizeStyles[size]),
       )}
       aria-hidden="true">

--- a/packages/core/src/InputGroup/InputGroup.tsx
+++ b/packages/core/src/InputGroup/InputGroup.tsx
@@ -28,7 +28,7 @@ import {SizeProvider, useSize} from '../SizeContext/SizeContext';
 import {mergeProps} from '../utils';
 import type {BaseProps} from '../BaseProps';
 import {InputGroupContext} from './InputGroupContext';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 export type InputGroupSize = 'sm' | 'md' | 'lg';
 
@@ -189,7 +189,7 @@ export function InputGroup({
             data-testid={testId}
             {...rest}
             {...mergeProps(
-              xdsThemeProps('input-group', {
+              themeProps('input-group', {
                 size,
                 status: status?.type ?? null,
               }),

--- a/packages/core/src/InputGroup/InputGroupText.tsx
+++ b/packages/core/src/InputGroup/InputGroupText.tsx
@@ -26,7 +26,7 @@ import {
   borderVars,
 } from '../theme/tokens.stylex';
 import {mergeProps} from '../utils';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 const styles = stylex.create({
   text: {
@@ -99,7 +99,7 @@ export function InputGroupText({
       ref={ref}
       {...rest}
       {...mergeProps(
-        xdsThemeProps('input-group-text'),
+        themeProps('input-group-text'),
         stylex.props(styles.text, xstyle),
         className,
         style,

--- a/packages/core/src/Item/Item.tsx
+++ b/packages/core/src/Item/Item.tsx
@@ -30,7 +30,7 @@ import type {BaseProps} from '../BaseProps';
 import {mergeProps} from '../utils';
 import {computeTargetAndRel} from '../Link/computeTargetAndRel';
 import {useLinkComponent} from '../Link/useLinkComponent';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 // =============================================================================
 // Types
@@ -474,7 +474,7 @@ export function Item({
       aria-disabled={isDisabled || undefined}
       {...restProps}
       {...mergeProps(
-        xdsThemeProps('item', {density, align}),
+        themeProps('item', {density, align}),
         stylex.props(
           styles.root,
           densityStyles[density],

--- a/packages/core/src/Kbd/Kbd.tsx
+++ b/packages/core/src/Kbd/Kbd.tsx
@@ -17,7 +17,7 @@ import React, {useSyncExternalStore} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {mergeProps} from '../utils';
 import type {BaseProps} from '../BaseProps';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 import {
   colorVars,
   spacingVars,
@@ -167,7 +167,7 @@ export function Kbd({
       ref={ref}
       {...rest}
       {...mergeProps(
-        xdsThemeProps('kbd'),
+        themeProps('kbd'),
         stylex.props(styles.wrapper, xstyle),
         className,
         style,

--- a/packages/core/src/Layer/useLayer.tsx
+++ b/packages/core/src/Layer/useLayer.tsx
@@ -71,7 +71,7 @@ export interface ContextRenderProps {
   xstyle?: StyleXStyles;
   /**
    * Additional CSS class name(s) for the popover container.
-   * Use with xdsThemeProps() for theme targeting when reflecting visual props.
+   * Use with themeProps() for theme targeting when reflecting visual props.
    */
   className?: string;
   /**
@@ -93,7 +93,7 @@ export interface FixedRenderProps {
   xstyle?: StyleXStyles;
   /**
    * Additional CSS class name(s) for the popover container.
-   * Use with xdsThemeProps() for theme targeting when reflecting visual props.
+   * Use with themeProps() for theme targeting when reflecting visual props.
    */
   className?: string;
   /**

--- a/packages/core/src/Layout/Layout.tsx
+++ b/packages/core/src/Layout/Layout.tsx
@@ -27,7 +27,7 @@ import {stackItem} from '../Stack/stackItem.stylex';
 import {mergeProps} from '../utils';
 import type {BaseProps} from '../BaseProps';
 import type {SpacingStep} from '../utils/types';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 import {
   layoutPaddingOuterXVarStyles,
   layoutPaddingOuterYVarStyles,
@@ -258,7 +258,7 @@ export function Layout({
       <div
         ref={ref}
         {...mergeProps(
-          xdsThemeProps('layout', {height}),
+          themeProps('layout', {height}),
           stylex.props(
             styles.layoutOuter,
             isFill ? styles.fill : styles.auto,

--- a/packages/core/src/Layout/LayoutContent.tsx
+++ b/packages/core/src/Layout/LayoutContent.tsx
@@ -23,7 +23,7 @@ import {spacingVars} from '../theme/tokens.stylex';
 import {LayoutSlotsContext} from './LayoutSlotsContext';
 import {mergeProps} from '../utils';
 import type {SpacingStep} from '../utils/types';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 import {
   paddingStyles,
   containerPaddingInlineVarStyles,
@@ -188,7 +188,7 @@ export function LayoutContent({
       role={role}
       aria-label={label}
       {...mergeProps(
-        xdsThemeProps('layout-content'),
+        themeProps('layout-content'),
         stylex.props(
           styles.content,
           // Outer padding on container edges (unless content is full bleed)

--- a/packages/core/src/Layout/LayoutFooter.tsx
+++ b/packages/core/src/Layout/LayoutFooter.tsx
@@ -23,7 +23,7 @@ import {LayoutDividerContext} from './LayoutDividerContext';
 import {colorVars, spacingVars} from '../theme/tokens.stylex';
 import {mergeProps} from '../utils';
 import type {SpacingStep} from '../utils/types';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 import {
   paddingStyles,
   containerPaddingInlineVarStyles,
@@ -159,7 +159,7 @@ export function LayoutFooter({
       aria-label={label}
       data-divider={resolvedHasDivider || undefined}
       {...mergeProps(
-        xdsThemeProps('layout-footer'),
+        themeProps('layout-footer'),
         stylex.props(
           styles.footer,
           dynamicStyles.sizing(height ?? null),

--- a/packages/core/src/Layout/LayoutHeader.tsx
+++ b/packages/core/src/Layout/LayoutHeader.tsx
@@ -23,7 +23,7 @@ import {LayoutDividerContext} from './LayoutDividerContext';
 import {colorVars, spacingVars} from '../theme/tokens.stylex';
 import {mergeProps} from '../utils';
 import type {SpacingStep} from '../utils/types';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 import {
   paddingStyles,
   containerPaddingInlineVarStyles,
@@ -159,7 +159,7 @@ export function LayoutHeader({
       aria-label={label}
       data-divider={resolvedHasDivider || undefined}
       {...mergeProps(
-        xdsThemeProps('layout-header'),
+        themeProps('layout-header'),
         stylex.props(
           styles.header,
           dynamicStyles.sizing(height ?? null),

--- a/packages/core/src/Layout/LayoutPanel.tsx
+++ b/packages/core/src/Layout/LayoutPanel.tsx
@@ -25,7 +25,7 @@ import {LayoutSlotsContext} from './LayoutSlotsContext';
 import {mergeProps} from '../utils';
 import type {SpacingStep} from '../utils/types';
 import type {ResizableProps} from '../Resizable/useResizable';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 import {
   paddingStyles,
   containerPaddingInlineVarStyles,
@@ -256,7 +256,7 @@ export function LayoutPanel({
       role={role}
       aria-label={label}
       {...mergeProps(
-        xdsThemeProps('layout-panel'),
+        themeProps('layout-panel'),
         stylex.props(
           styles.panel,
           dynamicStyles.sizing(effectiveWidth ?? null),

--- a/packages/core/src/Lightbox/Lightbox.tsx
+++ b/packages/core/src/Lightbox/Lightbox.tsx
@@ -32,7 +32,7 @@ import {useScrollLock} from '../hooks/useScrollLock';
 import {useIsomorphicLayoutEffect} from '../hooks/useIsomorphicLayoutEffect';
 import {mergeProps, mergeRefs} from '../utils';
 import type {BaseProps} from '../BaseProps';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 /**
  * Media type for lightbox items.
@@ -478,7 +478,7 @@ export function Lightbox({
       }}
       aria-label={currentItem.alt || 'Media viewer'}
       {...mergeProps(
-        xdsThemeProps('lightbox'),
+        themeProps('lightbox'),
         stylex.props(styles.dialog, xstyle),
         className,
         style,

--- a/packages/core/src/Link/Link.tsx
+++ b/packages/core/src/Link/Link.tsx
@@ -42,7 +42,7 @@ import type {LinkComponentType} from './types';
 import {mergeProps} from '../utils';
 import {computeTargetAndRel} from './computeTargetAndRel';
 import {useInteractiveRole} from '../hooks/useInteractiveRole';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 /**
  * Base link styles
@@ -318,7 +318,7 @@ export function Link({
         tabIndex={isDisabled ? -1 : undefined}
         disabled={isDisabled}
         {...mergeProps(
-          xdsThemeProps('link', {color}),
+          themeProps('link', {color}),
           stylex.props(
             styles.base,
             styles.buttonReset,
@@ -347,7 +347,7 @@ export function Link({
         aria-disabled={isDisabled || undefined}
         tabIndex={isDisabled ? -1 : undefined}
         {...mergeProps(
-          xdsThemeProps('link', {color}),
+          themeProps('link', {color}),
           stylex.props(
             styles.base,
             linkColorStyles[color],

--- a/packages/core/src/List/List.tsx
+++ b/packages/core/src/List/List.tsx
@@ -26,7 +26,7 @@ import {
   type ListMarkerStyle,
 } from './ListContext';
 import {mergeProps} from '../utils';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 export {
   type ListDensity,
@@ -170,7 +170,7 @@ export function List({
       {...(isOrdered && start != null && start !== 1 ? {start} : {})}
       {...(listStyle === 'none' && !isOrdered ? {role: 'list'} : {})}
       {...mergeProps(
-        xdsThemeProps('list', {density, listStyle}),
+        themeProps('list', {density, listStyle}),
         stylex.props(
           styles.list,
           hasDividers && styles.withDividers,

--- a/packages/core/src/List/ListItem.tsx
+++ b/packages/core/src/List/ListItem.tsx
@@ -31,7 +31,7 @@ import type {BaseProps} from '../BaseProps';
 import {ListContext} from './ListContext';
 import {mergeProps} from '../utils';
 import {Item} from '../Item';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 // =============================================================================
 // Types
@@ -251,7 +251,7 @@ export function ListItem({
         hasDividers && embeddedStyles.noRadius,
         xstyle,
       ]}
-      {...mergeProps(xdsThemeProps('list-item'), {className, style})}
+      {...mergeProps(themeProps('list-item'), {className, style})}
       {...restProps}
     />
   );

--- a/packages/core/src/Markdown/Markdown.tsx
+++ b/packages/core/src/Markdown/Markdown.tsx
@@ -55,7 +55,7 @@ import {
   trimStreamingArtifacts,
 } from './parser';
 import type {BlockNode, InlineNode, IncrementalState} from './parser';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 type SyncReactNode = Exclude<React.ReactNode, Promise<unknown>>;
 
@@ -1649,7 +1649,7 @@ export function Markdown({
         ref={ref}
         data-testid={testId}
         {...mergeProps(
-          xdsThemeProps('markdown', {density}),
+          themeProps('markdown', {density}),
           stylex.props(styles.root, styles.inlineRoot, xstyle),
           className,
           style,
@@ -1682,7 +1682,7 @@ export function Markdown({
       ref={ref as React.Ref<HTMLDivElement>}
       data-testid={testId}
       {...mergeProps(
-        xdsThemeProps('markdown', {density}),
+        themeProps('markdown', {density}),
         stylex.props(styles.root, xstyle),
         className,
         style,

--- a/packages/core/src/MetadataList/MetadataList.tsx
+++ b/packages/core/src/MetadataList/MetadataList.tsx
@@ -30,7 +30,7 @@ import {
 } from './MetadataListContext';
 import type {BaseProps} from '../BaseProps';
 import {mergeProps} from '../utils';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 // =============================================================================
 // Types
@@ -260,7 +260,7 @@ export function MetadataList({
         ref={ref}
         data-testid={testId}
         {...mergeProps(
-          xdsThemeProps('metadata-list', {
+          themeProps('metadata-list', {
             columns: String(columns),
             orientation,
           }),

--- a/packages/core/src/MetadataList/MetadataListItem.tsx
+++ b/packages/core/src/MetadataList/MetadataListItem.tsx
@@ -27,7 +27,7 @@ import {
 import {MetadataListContext} from './MetadataListContext';
 import type {BaseProps} from '../BaseProps';
 import {mergeProps} from '../utils';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 // =============================================================================
 // Types
@@ -166,7 +166,7 @@ export function MetadataListItem({
         ref={ref}
         data-testid={testId}
         {...mergeProps(
-          xdsThemeProps('metadata-list-item'),
+          themeProps('metadata-list-item'),
           stylex.props(styles.stackedWrapper, xstyle),
           className,
           style,
@@ -184,7 +184,7 @@ export function MetadataListItem({
         ref={ref}
         data-testid={testId ? `${testId}-label` : undefined}
         {...mergeProps(
-          xdsThemeProps('metadata-list-item'),
+          themeProps('metadata-list-item'),
           stylex.props(styles.label, xstyle),
           className,
           style,

--- a/packages/core/src/MobileNav/MobileNav.tsx
+++ b/packages/core/src/MobileNav/MobileNav.tsx
@@ -48,7 +48,7 @@ import {Heading} from '../Heading/Heading';
 import {useAppShellMobile} from '../AppShell/AppShellMobileContext';
 import {mergeProps, mergeRefs} from '../utils';
 import type {BaseProps} from '../BaseProps';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 // =============================================================================
 // Styles
@@ -399,7 +399,7 @@ export function MobileNav({
       onClick={handleDialogClick}
       onCancel={handleCancel}
       {...mergeProps(
-        xdsThemeProps('mobile-nav', {side: resolvedSide}),
+        themeProps('mobile-nav', {side: resolvedSide}),
         stylex.props(
           styles.dialog,
           isOpen && styles.open,

--- a/packages/core/src/MultiSelector/MultiSelector.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.tsx
@@ -68,7 +68,7 @@ import {mergeProps} from '../utils';
 import type {BaseProps} from '../BaseProps';
 import type {SizeValue} from '../utils/types';
 import {useSize} from '../SizeContext/SizeContext';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 // Sentinel value for the select-all item in keyboard navigation
 const SELECT_ALL_VALUE = '__xds_select_all__';
@@ -1124,7 +1124,7 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
         onClick={onTriggerClick}
         data-testid={testId}
         {...mergeProps(
-          xdsThemeProps('multi-selector', {size, status: status?.type ?? null}),
+          themeProps('multi-selector', {size, status: status?.type ?? null}),
           stylex.props(
             inputWrapperStyles.base,
             styles.triggerContainer,

--- a/packages/core/src/NavIcon/NavIcon.tsx
+++ b/packages/core/src/NavIcon/NavIcon.tsx
@@ -19,7 +19,7 @@ import type {BaseProps} from '../BaseProps';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars, sizeVars} from '../theme/tokens.stylex';
 import {mergeProps} from '../utils';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 /**
  * NavIcon styles
@@ -79,7 +79,7 @@ export function NavIcon({
     <span
       ref={ref}
       {...mergeProps(
-        xdsThemeProps('navicon'),
+        themeProps('navicon'),
         stylex.props(styles.base, xstyle),
         className,
         style,

--- a/packages/core/src/NavMenu/NavHeadingMenu.tsx
+++ b/packages/core/src/NavMenu/NavHeadingMenu.tsx
@@ -18,7 +18,7 @@ import {spacingVars} from '../theme/tokens.stylex';
 import {mergeProps, mergeRefs} from '../utils';
 import type {BaseProps} from '../BaseProps';
 import {useListFocus} from '../hooks/useListFocus';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 import {
   NavHeadingMenuContext,
   useNavHeadingCloseContext,
@@ -120,7 +120,7 @@ export function NavHeadingMenu({
         onKeyDown={handleKeyDown}
         data-testid={testId}
         {...mergeProps(
-          xdsThemeProps('nav-heading-menu', {size}),
+          themeProps('nav-heading-menu', {size}),
           stylex.props(styles.root, sizeStyles[size], xstyle),
           className,
           inlineStyle,

--- a/packages/core/src/NavMenu/NavHeadingMenuItem.tsx
+++ b/packages/core/src/NavMenu/NavHeadingMenuItem.tsx
@@ -27,7 +27,7 @@ import {mergeProps} from '../utils';
 import type {BaseProps} from '../BaseProps';
 import {useNavHeadingMenuContext} from './NavMenuContext';
 import {useLinkComponent} from '../Link/useLinkComponent';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 const styles = stylex.create({
   root: {
@@ -151,7 +151,7 @@ export function NavHeadingMenuItem({
       onClick={handleClick}
       data-testid={testId}
       {...mergeProps(
-        xdsThemeProps('nav-heading-menu-item', {size}),
+        themeProps('nav-heading-menu-item', {size}),
         stylex.props(
           styles.root,
           sizeStyles[size],

--- a/packages/core/src/NumberInput/NumberInput.tsx
+++ b/packages/core/src/NumberInput/NumberInput.tsx
@@ -131,7 +131,7 @@ export type {
 import {mergeProps, mergeRefs} from '../utils';
 import type {BaseProps} from '../BaseProps';
 import type {SizeValue} from '../utils/types';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 interface NumberInputPropsBase extends Omit<
   BaseProps,
@@ -526,7 +526,7 @@ export function NumberInput({
       onClick={handleWrapperClick}
       onMouseUp={handleWrapperMouseUp}
       {...mergeProps(
-        xdsThemeProps('number-input', {size, status: status?.type ?? null}),
+        themeProps('number-input', {size, status: status?.type ?? null}),
         stylex.props(
           inputWrapperStyles.base,
           styles.wrapper,

--- a/packages/core/src/Outline/Outline.tsx
+++ b/packages/core/src/Outline/Outline.tsx
@@ -36,7 +36,7 @@ import {mergeProps, mergeRefs} from '../utils';
 import type {BaseProps} from '../BaseProps';
 import {useScrollSpy} from './useScrollSpy';
 import type {OutlineItem} from './types';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 export type {OutlineItem} from './types';
 
@@ -281,7 +281,7 @@ export function Outline({
       aria-label={label}
       data-testid={testId}
       {...mergeProps(
-        xdsThemeProps('outline', {density}),
+        themeProps('outline', {density}),
         stylex.props(styles.root, xstyle),
         className,
         style,
@@ -297,7 +297,7 @@ export function Outline({
                 aria-current={isActive ? 'true' : undefined}
                 onClick={handleClick(item.id)}
                 {...mergeProps(
-                  xdsThemeProps('outline-item', {
+                  themeProps('outline-item', {
                     active: isActive ? 'active' : null,
                     level: item.level,
                   }),
@@ -323,7 +323,7 @@ export function Outline({
       </div>
       <span
         {...mergeProps(
-          xdsThemeProps('outline-indicator'),
+          themeProps('outline-indicator'),
           stylex.props(styles.indicator),
         )}
         aria-hidden="true"

--- a/packages/core/src/OverflowList/OverflowList.tsx
+++ b/packages/core/src/OverflowList/OverflowList.tsx
@@ -24,7 +24,7 @@ import * as stylex from '@stylexjs/stylex';
 import {mergeProps, mergeRefs} from '../utils';
 import {useOverflow} from '../hooks/useOverflow';
 import {spacingVars} from '../theme/tokens.stylex';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 const styles = stylex.create({
   container: {
@@ -246,7 +246,7 @@ export function OverflowList({
       <div
         ref={mergeRefs(ref, containerRef)}
         {...mergeProps(
-          xdsThemeProps('overflow-list'),
+          themeProps('overflow-list'),
           stylex.props(
             styles.container,
             gapStyles[gap],

--- a/packages/core/src/Overlay/Overlay.tsx
+++ b/packages/core/src/Overlay/Overlay.tsx
@@ -21,7 +21,7 @@ import {mergeProps, mergeRefs} from '../utils';
 import {useOverlay} from './useOverlay';
 import {useIsomorphicLayoutEffect} from '../hooks/useIsomorphicLayoutEffect';
 import {overlayScope, overlayContainerStyles} from './overlay.markers.stylex';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 import type {BaseProps} from '../BaseProps';
 import type {
   OverlayScrimMode,
@@ -115,7 +115,7 @@ export function Overlay({
     <div
       ref={mergeRefs(ref, overlay.containerRef)}
       {...mergeProps(
-        xdsThemeProps('overlay'),
+        themeProps('overlay'),
         stylex.props(overlayScope, overlayContainerStyles.root, xstyle),
         className,
         style,

--- a/packages/core/src/Overlay/OverlayScrim.tsx
+++ b/packages/core/src/Overlay/OverlayScrim.tsx
@@ -23,7 +23,7 @@ import {
 import {MediaTheme} from '../theme/MediaTheme';
 import {mergeProps} from '../utils';
 import {overlayScope} from './overlay.markers.stylex';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 // =============================================================================
 // Types (re-exported from index.ts for consumers)
@@ -276,7 +276,7 @@ export function OverlayScrim({
   return (
     <div
       {...mergeProps(
-        xdsThemeProps('overlay-scrim', {position}),
+        themeProps('overlay-scrim', {position}),
         stylex.props(
           styles.base,
           positionMap[position],

--- a/packages/core/src/Pagination/Pagination.tsx
+++ b/packages/core/src/Pagination/Pagination.tsx
@@ -36,7 +36,7 @@ import {Selector} from '../Selector';
 import {Text} from '../Text';
 import {mergeProps} from '../utils';
 import type {BaseProps} from '../BaseProps';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 // =============================================================================
 // Types
@@ -507,7 +507,7 @@ export function Pagination({
                 onClick={() => handlePageChange(i + 1)}
                 disabled={isDisabled}
                 {...mergeProps(
-                  xdsThemeProps('pagination-dot', {
+                  themeProps('pagination-dot', {
                     active: i + 1 === page ? 'active' : null,
                     size,
                   }),
@@ -536,7 +536,7 @@ export function Pagination({
       aria-label={label}
       data-testid={testId}
       {...mergeProps(
-        xdsThemeProps('pagination', {variant, size}),
+        themeProps('pagination', {variant, size}),
         stylex.props(styles.root, xstyle),
         className,
         style,

--- a/packages/core/src/Popover/Popover.tsx
+++ b/packages/core/src/Popover/Popover.tsx
@@ -32,7 +32,7 @@ import type {LayerAlignment, LayerPlacement} from '../Layer/useLayer';
 import {layerAnimations} from '../Layer/layerAnimations.stylex';
 import {spacingVars} from '../theme/tokens.stylex';
 import {InteractiveRoleContext} from '../InteractiveRoleContext/InteractiveRoleContext';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 // =============================================================================
 // Helpers
@@ -472,7 +472,7 @@ export function Popover({
           <div
             data-testid={testId}
             {...mergeProps(
-              xdsThemeProps('popover'),
+              themeProps('popover'),
               stylex.props(styles.contentPadding, xstyle),
               className,
               style,
@@ -508,7 +508,7 @@ export function Popover({
           <div
             data-testid={testId}
             {...mergeProps(
-              xdsThemeProps('popover'),
+              themeProps('popover'),
               stylex.props(styles.contentPadding, xstyle),
               className,
               style,
@@ -537,7 +537,7 @@ export function Popover({
         <div
           data-testid={testId}
           {...mergeProps(
-            xdsThemeProps('popover'),
+            themeProps('popover'),
             stylex.props(styles.contentPadding, xstyle),
             className,
             style,

--- a/packages/core/src/PowerSearch/PowerSearch.tsx
+++ b/packages/core/src/PowerSearch/PowerSearch.tsx
@@ -50,7 +50,7 @@ import {useInternalConfig} from './useInternalConfig';
 import {usePowerSearchSource} from './usePowerSearchSource';
 import {formatFilterValue} from './formatFilterValue';
 import {PowerSearchEditPopover} from './PowerSearchEditPopover';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 import type {
   PowerSearchConfig,
   PowerSearchFilter,
@@ -966,7 +966,7 @@ export function PowerSearch({
     <>
       <div
         ref={mergeRefs(ref, popover.triggerRef as React.Ref<HTMLDivElement>)}
-        {...xdsThemeProps('power-search')}>
+        {...themeProps('power-search')}>
         <Tokenizer
           handleRef={tokenizerRef}
           label={label}

--- a/packages/core/src/ProgressBar/ProgressBar.tsx
+++ b/packages/core/src/ProgressBar/ProgressBar.tsx
@@ -30,7 +30,7 @@ import {
 } from '../theme/tokens.stylex';
 import {mergeProps} from '../utils';
 import type {BaseProps} from '../BaseProps';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 /**
  * Extensible variant map for ProgressBar.
@@ -283,7 +283,7 @@ export function ProgressBar({
     <div
       ref={ref}
       {...mergeProps(
-        xdsThemeProps('progressbar', {variant}),
+        themeProps('progressbar', {variant}),
         stylex.props(styles.container, xstyle),
         className,
         style,
@@ -327,13 +327,13 @@ export function ProgressBar({
         aria-labelledby={labelId}
         aria-valuetext={isIndeterminate ? undefined : valueText}
         {...mergeProps(
-          xdsThemeProps('progressbar-track'),
+          themeProps('progressbar-track'),
           stylex.props(styles.track),
         )}>
         {isIndeterminate ? (
           <div
             {...mergeProps(
-              xdsThemeProps('progressbar-fill', {variant: fillVariant}),
+              themeProps('progressbar-fill', {variant: fillVariant}),
               stylex.props(
                 styles.indeterminateFill,
                 variantStyles[fillVariant],
@@ -343,7 +343,7 @@ export function ProgressBar({
         ) : (
           <div
             {...mergeProps(
-              xdsThemeProps('progressbar-fill', {variant: fillVariant}),
+              themeProps('progressbar-fill', {variant: fillVariant}),
               stylex.props(styles.fill, variantStyles[fillVariant]),
             )}
             style={{width: `${percentage}%`}}

--- a/packages/core/src/RadioList/RadioList.tsx
+++ b/packages/core/src/RadioList/RadioList.tsx
@@ -24,7 +24,7 @@ import type {InputStatus} from '../Field/types';
 import {mergeProps} from '../utils';
 import type {BaseProps} from '../BaseProps';
 import type {SizeValue} from '../utils/types';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 /**
  * Size of the radio controls, matching CheckboxInput sizes.
@@ -224,7 +224,7 @@ export function RadioList({
         aria-invalid={status?.type === 'error' ? true : undefined}
         aria-required={isRequired || undefined}
         {...mergeProps(
-          xdsThemeProps('radio-list', {orientation, size}),
+          themeProps('radio-list', {orientation, size}),
           stylex.props(
             styles.radiogroup,
             orientation === 'vertical' ? styles.vertical : styles.horizontal,

--- a/packages/core/src/RadioList/RadioListItem.tsx
+++ b/packages/core/src/RadioList/RadioListItem.tsx
@@ -32,7 +32,7 @@ import {RadioListContext} from './RadioList';
 import {mergeProps} from '../utils';
 import {radioScope} from './radio.markers.stylex';
 import {Item} from '../Item';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 const styles = stylex.create({
   container: {
@@ -259,7 +259,7 @@ export function RadioListItem({
       <div
         aria-hidden="true"
         {...mergeProps(
-          xdsThemeProps('radio', {
+          themeProps('radio', {
             size,
             checked: isChecked ? 'checked' : null,
             disabled: isDisabled ? 'disabled' : null,
@@ -275,7 +275,7 @@ export function RadioListItem({
         {isChecked && (
           <div
             {...mergeProps(
-              xdsThemeProps('radio-dot', {size}),
+              themeProps('radio-dot', {size}),
               stylex.props(styles.innerDot, dotSizeStyles[size]),
             )}
           />
@@ -299,7 +299,7 @@ export function RadioListItem({
       ref={ref}
       data-testid={dataTestId}
       {...mergeProps(
-        xdsThemeProps('radio-list-item'),
+        themeProps('radio-list-item'),
         stylex.props(styles.container, !isDisabled && radioScope),
       )}>
       <Item

--- a/packages/core/src/Resizable/ResizeHandle.tsx
+++ b/packages/core/src/Resizable/ResizeHandle.tsx
@@ -15,7 +15,7 @@
  * flips when the panel collapses to 0px so it stays accessible.
  *
  * Pill placement uses a single stylex dynamic style that accepts a direction
- * multiplier (-1 or 1). The pill element has its own xdsThemeProps
+ * multiplier (-1 or 1). The pill element has its own themeProps
  * ('resize-handle-pill') so themes can target size/shape directly.
  */
 
@@ -32,7 +32,7 @@ import {
 } from '../theme/tokens.stylex';
 import {mergeProps, mergeRefs} from '../utils';
 import type {ResizableProps} from './useResizable';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 const KEYBOARD_STEP = 10;
 const KEYBOARD_LARGE_STEP = 50;
@@ -487,7 +487,7 @@ export function ResizeHandle({
       onBlur={() => setIsFocused(false)}
       data-resizing={isDragging || undefined}
       {...mergeProps(
-        xdsThemeProps('resize-handle'),
+        themeProps('resize-handle'),
         stylex.props(
           styles.handle,
           isOverlay && styles.overlay,
@@ -534,7 +534,7 @@ export function ResizeHandle({
       {children ?? (
         <div
           {...mergeProps(
-            xdsThemeProps('resize-handle-pill'),
+            themeProps('resize-handle-pill'),
             stylex.props(
               styles.pill,
               isHorizontal ? styles.pillHorizontal : styles.pillVertical,

--- a/packages/core/src/Section/Section.tsx
+++ b/packages/core/src/Section/Section.tsx
@@ -32,7 +32,7 @@ import {
 } from '../Layout/padding.stylex';
 import type {SizeValue, SpacingStep} from '../utils/types';
 import {mergeProps} from '../utils';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 /**
  * Extensible variant map for Section.
@@ -268,7 +268,7 @@ export function Section({
       {...props}>
       <div
         {...mergeProps(
-          xdsThemeProps('section', {variant}),
+          themeProps('section', {variant}),
           stylex.props(
             nestedStyles.inner,
             ...container(

--- a/packages/core/src/SegmentedControl/SegmentedControl.tsx
+++ b/packages/core/src/SegmentedControl/SegmentedControl.tsx
@@ -26,7 +26,7 @@ import type {
 import {mergeProps, mergeRefs} from '../utils';
 import {useSize} from '../SizeContext/SizeContext';
 import type {BaseProps} from '../BaseProps';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 export interface SegmentedControlProps extends Omit<
   BaseProps<HTMLDivElement>,
@@ -206,7 +206,7 @@ export function SegmentedControl({
         aria-disabled={isDisabled || undefined}
         onKeyDown={handleKeyDown}
         {...mergeProps(
-          xdsThemeProps('segmented-control', {size}),
+          themeProps('segmented-control', {size}),
           stylex.props(
             styles.container,
             sizeStyles[size],

--- a/packages/core/src/SegmentedControl/SegmentedControlItem.tsx
+++ b/packages/core/src/SegmentedControl/SegmentedControlItem.tsx
@@ -31,7 +31,7 @@ import {useSegmentedControlContext} from './SegmentedControlContext';
 import type {SegmentedControlSize} from './SegmentedControlContext';
 import {mergeProps} from '../utils';
 import type {BaseProps} from '../BaseProps';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 export interface SegmentedControlItemProps extends BaseProps<HTMLButtonElement> {
   ref?: React.Ref<HTMLButtonElement>;
@@ -198,7 +198,7 @@ export function SegmentedControlItem({
       tabIndex={isSelected ? 0 : -1}
       onClick={handleClick}
       {...mergeProps(
-        xdsThemeProps('segmented-control-item', {
+        themeProps('segmented-control-item', {
           size,
           selected: isSelected ? 'selected' : null,
           disabled: isItemDisabled ? 'disabled' : null,

--- a/packages/core/src/SelectableCard/SelectableCard.tsx
+++ b/packages/core/src/SelectableCard/SelectableCard.tsx
@@ -42,7 +42,7 @@ import {Card} from '../Card/Card';
 import type {CardVariant} from '../Card/Card';
 import {useClickableContainer} from '../hooks/useClickableContainer';
 import type {BaseProps} from '../BaseProps';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 // =============================================================================
 // Styles — selection + interaction; Card handles the rest
@@ -329,7 +329,7 @@ export function SelectableCard({
       padding={padding}
       variant={variant}
       {...mergeProps(
-        xdsThemeProps('selectable-card', {
+        themeProps('selectable-card', {
           variant,
           selected: isSelected ? 'true' : 'false',
         }),

--- a/packages/core/src/Selector/Selector.tsx
+++ b/packages/core/src/Selector/Selector.tsx
@@ -65,7 +65,7 @@ import {mergeProps} from '../utils';
 import {useSize} from '../SizeContext/SizeContext';
 import type {BaseProps} from '../BaseProps';
 import type {SizeValue} from '../utils/types';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 const styles = stylex.create({
   // Trigger container — the enhanced click target wrapping the combobox button and clear button as siblings
@@ -873,7 +873,7 @@ export function Selector<T extends SelectorOptionType>(
         onClick={onTriggerClick}
         data-testid={testId}
         {...mergeProps(
-          xdsThemeProps('selector', {size, status: status?.type ?? null}),
+          themeProps('selector', {size, status: status?.type ?? null}),
           stylex.props(
             inputWrapperStyles.base,
             styles.triggerContainer,

--- a/packages/core/src/Selector/SelectorOption.tsx
+++ b/packages/core/src/Selector/SelectorOption.tsx
@@ -14,7 +14,7 @@ import type {StyleXStyles} from '@stylexjs/stylex';
 import {renderIconSlot, type IconType} from '../Icon';
 import {Item} from '../Item';
 import {mergeProps} from '../utils';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 const embeddedStyles = stylex.create({
   root: {
@@ -111,7 +111,7 @@ export function SelectorOption({
       description={description}
       endContent={endContent}
       xstyle={[embeddedStyles.root, xstyle]}
-      {...mergeProps(xdsThemeProps('selector-option'), {className, style})}
+      {...mergeProps(themeProps('selector-option'), {className, style})}
     />
   );
 }

--- a/packages/core/src/SideNav/SideNav.tsx
+++ b/packages/core/src/SideNav/SideNav.tsx
@@ -44,7 +44,7 @@ import {MobileNav} from '../MobileNav/MobileNav';
 import {useResizable} from '../Resizable/useResizable';
 import type {ResizableConfig} from '../Resizable/useResizable';
 import {ResizeHandle} from '../Resizable/ResizeHandle';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 // =============================================================================
 // Constants
@@ -427,7 +427,7 @@ export function SideNav({
       <div
         data-testid={testId}
         {...mergeProps(
-          xdsThemeProps('side-nav', {mode: 'topbar'}),
+          themeProps('side-nav', {mode: 'topbar'}),
           stylex.props(styles.topbar, xstyle),
           className,
           style,
@@ -503,7 +503,7 @@ export function SideNav({
       aria-label="Side navigation"
       data-testid={testId}
       {...mergeProps(
-        xdsThemeProps('side-nav'),
+        themeProps('side-nav'),
         stylex.props(styles.root, collapsed && styles.rootCollapsed, xstyle),
         className,
         resizableNavStyle,

--- a/packages/core/src/SideNav/SideNavHeading.tsx
+++ b/packages/core/src/SideNav/SideNavHeading.tsx
@@ -43,7 +43,7 @@ import {mergeProps, mergeRefs} from '../utils';
 import type {BaseProps} from '../BaseProps';
 import {useMenuHover} from '../hooks/useMenuHover';
 import {NavHeadingCloseContext} from '../NavMenu/NavMenuContext';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 // =============================================================================
 // Styles
@@ -392,7 +392,7 @@ export function SideNavHeading({
           aria-label={heading}
           data-testid={testId}
           {...mergeProps(
-            xdsThemeProps('side-nav-heading'),
+            themeProps('side-nav-heading'),
             stylex.props(navItemStyles.item, styles.rootCollapsed, xstyle),
             className,
             style,
@@ -411,7 +411,7 @@ export function SideNavHeading({
             {...popover.triggerProps}
             {...triggerProps}
             {...mergeProps(
-              xdsThemeProps('side-nav-heading'),
+              themeProps('side-nav-heading'),
               stylex.props(
                 navItemStyles.item,
                 styles.rootCollapsed,
@@ -473,7 +473,7 @@ export function SideNavHeading({
           ref={collapsedSetRef}
           data-testid={testId}
           {...mergeProps(
-            xdsThemeProps('side-nav-heading'),
+            themeProps('side-nav-heading'),
             stylex.props(styles.root, styles.rootCollapsed, xstyle),
             className,
             style,
@@ -571,7 +571,7 @@ export function SideNavHeading({
         href={headingHref}
         data-testid={testId}
         {...mergeProps(
-          xdsThemeProps('side-nav-heading'),
+          themeProps('side-nav-heading'),
           stylex.props(styles.root, styles.menuTrigger, xstyle),
           className,
           style,
@@ -594,7 +594,7 @@ export function SideNavHeading({
           data-testid={testId}
           {...triggerProps}
           {...mergeProps(
-            xdsThemeProps('side-nav-heading'),
+            themeProps('side-nav-heading'),
             stylex.props(styles.root, styles.menuTrigger, xstyle),
             className,
             style,
@@ -645,7 +645,7 @@ export function SideNavHeading({
           data-testid={testId}
           {...triggerProps}
           {...mergeProps(
-            xdsThemeProps('side-nav-heading'),
+            themeProps('side-nav-heading'),
             stylex.props(styles.root, xstyle),
             className,
             style,
@@ -701,7 +701,7 @@ export function SideNavHeading({
         ref={ref}
         data-testid={testId}
         {...mergeProps(
-          xdsThemeProps('side-nav-heading'),
+          themeProps('side-nav-heading'),
           stylex.props(styles.root, xstyle),
           className,
           style,
@@ -758,7 +758,7 @@ export function SideNavHeading({
       ref={ref}
       data-testid={testId}
       {...mergeProps(
-        xdsThemeProps('side-nav-heading'),
+        themeProps('side-nav-heading'),
         stylex.props(styles.root, xstyle),
         className,
         style,

--- a/packages/core/src/SideNav/SideNavItem.tsx
+++ b/packages/core/src/SideNav/SideNavItem.tsx
@@ -53,7 +53,7 @@ import {
 import {getIcon} from '../Icon/globalIconRegistry';
 import {useSideNavRenderMode} from './SideNavRenderContext';
 import {useAppShellMobile} from '../AppShell/AppShellMobileContext';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 // =============================================================================
 // Styles
@@ -482,7 +482,7 @@ export function SideNavItem({
 
     // Shared collapsed item styles — used by trigger, link, and button
     const collapsedItemStyles = mergeProps(
-      xdsThemeProps('side-nav-item', {
+      themeProps('side-nav-item', {
         size,
         selected: isSelected ? 'selected' : null,
       }),
@@ -583,7 +583,7 @@ export function SideNavItem({
   );
 
   const navItemStyleProps = mergeProps(
-    xdsThemeProps('side-nav-item', {
+    themeProps('side-nav-item', {
       size,
       selected: isSelected ? 'selected' : null,
     }),

--- a/packages/core/src/SideNav/SideNavSection.tsx
+++ b/packages/core/src/SideNav/SideNavSection.tsx
@@ -29,7 +29,7 @@ import {
 import {mergeProps} from '../utils';
 import type {BaseProps} from '../BaseProps';
 import {useSideNavCollapse} from './SideNavCollapseContext';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 // =============================================================================
 // Styles
 // =============================================================================
@@ -187,7 +187,7 @@ export function SideNavSection({
       aria-labelledby={titleId}
       data-testid={testId}
       {...mergeProps(
-        xdsThemeProps('side-nav-section'),
+        themeProps('side-nav-section'),
         stylex.props(styles.root, xstyle),
         className,
         style,

--- a/packages/core/src/Skeleton/Skeleton.tsx
+++ b/packages/core/src/Skeleton/Skeleton.tsx
@@ -19,7 +19,7 @@ import type {BaseProps} from '../BaseProps';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars, radiusVars, durationVars} from '../theme/tokens.stylex';
 import {mergeProps} from '../utils';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 // =============================================================================
 // Animation Timing Constants
@@ -182,7 +182,7 @@ export function Skeleton({
       ref={ref}
       data-testid={testId}
       {...mergeProps(
-        xdsThemeProps('skeleton'),
+        themeProps('skeleton'),
         stylex.props(
           styles.root,
           styles.animate,

--- a/packages/core/src/Slider/Slider.tsx
+++ b/packages/core/src/Slider/Slider.tsx
@@ -41,7 +41,7 @@ import type {InputStatus} from '../Field/types';
 import {mergeProps, mergeRefs} from '../utils';
 import type {BaseProps} from '../BaseProps';
 import type {SizeValue} from '../utils/types';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 // =============================================================================
 // Types
@@ -661,7 +661,7 @@ export function Slider({ref, ...props}: SliderProps) {
         aria-describedby={ariaDescribedBy}
         onKeyDown={e => handleKeyDown(thumbIndex, e)}
         {...mergeProps(
-          xdsThemeProps('slider-thumb', {
+          themeProps('slider-thumb', {
             orientation,
             disabled: isDisabled ? 'disabled' : null,
           }),
@@ -751,7 +751,7 @@ export function Slider({ref, ...props}: SliderProps) {
       style={style}>
       <div
         {...mergeProps(
-          xdsThemeProps('slider', {
+          themeProps('slider', {
             orientation,
             disabled: isDisabled ? 'disabled' : null,
           }),
@@ -775,7 +775,7 @@ export function Slider({ref, ...props}: SliderProps) {
           <div
             aria-hidden="true"
             {...mergeProps(
-              xdsThemeProps('slider-track', {orientation}),
+              themeProps('slider-track', {orientation}),
               stylex.props(
                 styles.track,
                 isHorizontal ? styles.trackHorizontal : styles.trackVertical,

--- a/packages/core/src/Spinner/Spinner.tsx
+++ b/packages/core/src/Spinner/Spinner.tsx
@@ -23,7 +23,7 @@ import {useTheme} from '../theme/useTheme';
 import type {BaseProps} from '../BaseProps';
 import {Text} from '../Text/Text';
 import {mergeProps} from '../utils';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 // =============================================================================
 // Constants
@@ -261,7 +261,7 @@ export function Spinner({
       data-testid={hasLabel ? undefined : testId}
       {...(hasLabel ? {} : restProps)}
       {...mergeProps(
-        hasLabel ? '' : xdsThemeProps('spinner', {size, shade}),
+        hasLabel ? '' : themeProps('spinner', {size, shade}),
         stylex.props(styles.spinner, !hasLabel && xstyle),
         hasLabel ? undefined : className,
         {...(hasLabel ? {} : style), width: frameSize, height: frameSize},
@@ -280,7 +280,7 @@ export function Spinner({
       data-testid={testId}
       {...restProps}
       {...mergeProps(
-        xdsThemeProps('spinner', {size, shade}),
+        themeProps('spinner', {size, shade}),
         stylex.props(styles.wrapper, xstyle),
         className,
         style,

--- a/packages/core/src/Stack/Stack.tsx
+++ b/packages/core/src/Stack/Stack.tsx
@@ -26,7 +26,7 @@ import {
 } from './stack.stylex';
 import type {SizeValue} from '../utils/types';
 import {mergeProps} from '../utils';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 /**
  * Alignment values accepted by Stack.
@@ -233,7 +233,7 @@ export function Stack({
     {
       ref: ref as Ref<Element>,
       ...mergeProps(
-        xdsThemeProps('stack', {direction, gap, wrap}),
+        themeProps('stack', {direction, gap, wrap}),
         stylexProps,
         className,
         {...style, ...sizingStyle},

--- a/packages/core/src/Stack/StackItem.tsx
+++ b/packages/core/src/Stack/StackItem.tsx
@@ -21,7 +21,7 @@ import {
   type StackItemSize,
 } from './stackItem.stylex';
 import {mergeProps} from '../utils';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 export interface StackItemProps extends BaseProps<HTMLElement> {
   /** Ref forwarded to the root element */
@@ -110,7 +110,7 @@ export function StackItem({
     {
       ref: ref as Ref<Element>,
       ...mergeProps(
-        xdsThemeProps('stack-item', {size}),
+        themeProps('stack-item', {size}),
         stylexProps,
         className,
         style,

--- a/packages/core/src/StatusDot/StatusDot.tsx
+++ b/packages/core/src/StatusDot/StatusDot.tsx
@@ -21,7 +21,7 @@ import {colorVars} from '../theme/tokens.stylex';
 import type {BaseProps} from '../BaseProps';
 import {Tooltip} from '../Tooltip/Tooltip';
 import {mergeProps} from '../utils';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 /**
  * Pulse animation keyframes
@@ -160,7 +160,7 @@ export function StatusDot({
       role="img"
       aria-label={label}
       {...mergeProps(
-        xdsThemeProps('statusdot', {variant}),
+        themeProps('statusdot', {variant}),
         stylex.props(
           styles.base,
           variants[variant],

--- a/packages/core/src/Switch/Switch.tsx
+++ b/packages/core/src/Switch/Switch.tsx
@@ -43,7 +43,7 @@ import {mergeProps} from '../utils';
 import {switchScope} from './switch.markers.stylex';
 import type {BaseProps} from '../BaseProps';
 import type {SizeValue} from '../utils/types';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 // Fixed dimensions: 40px width, 24px height, 16px thumb (off), 20px thumb (on)
 const SWITCH_WIDTH = 40;
@@ -396,7 +396,7 @@ export function Switch({
       <div
         aria-hidden="true"
         {...mergeProps(
-          xdsThemeProps('switch', {
+          themeProps('switch', {
             checked: isOn ? 'checked' : null,
             disabled: isDisabled ? 'disabled' : null,
           }),
@@ -410,7 +410,7 @@ export function Switch({
         )}>
         <div
           {...mergeProps(
-            xdsThemeProps('switch-thumb', {checked: isOn ? 'checked' : null}),
+            themeProps('switch-thumb', {checked: isOn ? 'checked' : null}),
             stylex.props(styles.thumb, isOn ? styles.thumbOn : styles.thumbOff),
           )}>
           {isBusy && <Spinner size="sm" />}
@@ -444,7 +444,7 @@ export function Switch({
   return (
     <div
       {...mergeProps(
-        xdsThemeProps('switch-field', {
+        themeProps('switch-field', {
           labelPosition: labelPosition !== 'end' ? labelPosition : undefined,
           labelSpacing: labelSpacing !== 'default' ? labelSpacing : undefined,
         }),

--- a/packages/core/src/TabList/Tab.tsx
+++ b/packages/core/src/TabList/Tab.tsx
@@ -36,7 +36,7 @@ import {useLinkComponent} from '../Link/useLinkComponent';
 import type {LinkComponentType} from '../Link/types';
 import {mergeProps} from '../utils';
 import {EDGE_COMP_ATTR} from '../Layout/edgeCompensation.stylex';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 export interface TabProps extends BaseProps<HTMLButtonElement> {
   /**
@@ -261,7 +261,7 @@ export function Tab({
     [EDGE_COMP_ATTR]: '',
     'aria-current': isSelected ? ('page' as const) : undefined,
     ...mergeProps(
-      xdsThemeProps('tab', {
+      themeProps('tab', {
         selected: isSelected ? 'selected' : null,
       }),
       stylex.props(
@@ -287,7 +287,7 @@ export function Tab({
   const indicatorElement = (
     <span
       {...mergeProps(
-        xdsThemeProps('tab-indicator', {
+        themeProps('tab-indicator', {
           selected: isSelected ? 'selected' : null,
         }),
         stylex.props(

--- a/packages/core/src/TabList/TabList.tsx
+++ b/packages/core/src/TabList/TabList.tsx
@@ -24,7 +24,7 @@ import type {TabListSize} from './TabListContext';
 import {useSize} from '../SizeContext/SizeContext';
 import {mergeProps} from '../utils';
 import {EDGE_COMP_ATTR} from '../Layout/edgeCompensation.stylex';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 export interface TabListProps extends Omit<
   BaseProps<HTMLElement>,
@@ -125,7 +125,7 @@ export function TabList({
         {...{[EDGE_COMP_ATTR]: ''}}
         {...restProps}
         {...mergeProps(
-          xdsThemeProps('tab-list', {size}),
+          themeProps('tab-list', {size}),
           stylex.props(
             styles.nav,
             layout === 'fill' && styles.fill,

--- a/packages/core/src/TabList/TabMenu.tsx
+++ b/packages/core/src/TabList/TabMenu.tsx
@@ -37,7 +37,7 @@ import type {TabListSize} from './TabListContext';
 import {tabScope} from './tab.markers.stylex';
 import {mergeProps, mergeRefs} from '../utils';
 import type {BaseProps} from '../BaseProps';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 export interface TabMenuOption {
   value: string;
@@ -308,7 +308,7 @@ export function TabMenu({
         aria-controls={menuId}
         onClick={handleToggle}
         {...mergeProps(
-          xdsThemeProps('tab-menu'),
+          themeProps('tab-menu'),
           stylex.props(
             styles.trigger,
             sizeStyles[size],
@@ -340,7 +340,7 @@ export function TabMenu({
         {hasSelectedOption && (
           <span
             {...mergeProps(
-              xdsThemeProps('tab-indicator', {selected: 'selected'}),
+              themeProps('tab-indicator', {selected: 'selected'}),
               stylex.props(styles.indicator, styles.indicatorSelected),
             )}
           />
@@ -354,7 +354,7 @@ export function TabMenu({
           aria-label={label}
           onKeyDown={handleListKeyDown}
           {...mergeProps(
-            xdsThemeProps('tab-menu-dropdown'),
+            themeProps('tab-menu-dropdown'),
             stylex.props(styles.dropdown),
           )}>
           <span role="presentation" {...stylex.props(styles.menuHeading)}>
@@ -376,7 +376,7 @@ export function TabMenu({
                   }
                 }}
                 {...mergeProps(
-                  xdsThemeProps('tab-menu-item'),
+                  themeProps('tab-menu-item'),
                   stylex.props(
                     styles.menuItem,
                     isSelected && styles.menuItemSelected,

--- a/packages/core/src/Table/BaseTable.tsx
+++ b/packages/core/src/Table/BaseTable.tsx
@@ -43,7 +43,7 @@ import {TableBody} from './TableBody';
 import {mergeProps} from '../utils';
 import {EmptyState} from '../EmptyState';
 import {Text} from '../Text';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 const styles = stylex.create({
   table: {
@@ -452,7 +452,7 @@ function BaseTableInner<T extends Record<string, unknown>>({
       ref={ref}
       {...tableRenderProps.htmlProps}
       {...mergeProps(
-        xdsThemeProps('base-table'),
+        themeProps('base-table'),
         stylex.props(...tableRenderProps.styles),
         tableRenderProps.htmlProps.className,
       )}

--- a/packages/core/src/Table/Table.tsx
+++ b/packages/core/src/Table/Table.tsx
@@ -23,7 +23,7 @@ import {BaseTable} from './BaseTable';
 import {TableContext} from './TableContext';
 import {useBaseTablePlugins} from './useBaseTablePlugins';
 import {mergeProps} from '../utils';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 import type {
   BaseTableProps,
   TableVerticalAlign,
@@ -135,7 +135,7 @@ function TableScrollWrapper({children}: {children: React.ReactNode}) {
   return (
     <div
       {...mergeProps(
-        xdsThemeProps('table-scroll-wrapper'),
+        themeProps('table-scroll-wrapper'),
         stylex.props(
           scrollWrapperStyles.base,
           scrollWrapperStyles.containerBleed,
@@ -156,7 +156,7 @@ function buildTableStylePlugin<
   return {
     transformTable(props: TableRenderProps): TableRenderProps {
       const existingClass = props.htmlProps.className ?? '';
-      const tableClass = xdsThemeProps('table').className;
+      const tableClass = themeProps('table').className;
       return {
         ...props,
         htmlProps: {

--- a/packages/core/src/Table/TableBody.tsx
+++ b/packages/core/src/Table/TableBody.tsx
@@ -6,7 +6,7 @@ import type {ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {BaseProps} from '../BaseProps';
 import {mergeProps} from '../utils';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 export interface TableBodyProps extends BaseProps<HTMLTableSectionElement> {
   ref?: React.Ref<HTMLTableSectionElement>;
@@ -17,7 +17,7 @@ export function TableBody({ref, children, xstyle}: TableBodyProps) {
   return (
     <tbody
       ref={ref}
-      {...mergeProps(xdsThemeProps('table-body'), stylex.props(xstyle))}>
+      {...mergeProps(themeProps('table-body'), stylex.props(xstyle))}>
       {children}
     </tbody>
   );

--- a/packages/core/src/Table/TableCell.tsx
+++ b/packages/core/src/Table/TableCell.tsx
@@ -36,7 +36,7 @@ import {
   mergeXStyle,
 } from './useTableCellStyles';
 import {mergeProps} from '../utils';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 /** Props for TableCell — thin `<td>` wrapper */
 export interface TableCellProps extends BaseProps<HTMLTableCellElement> {
@@ -148,7 +148,7 @@ export function TableCell({
         ref={ref}
         {...props}
         {...mergeProps(
-          xdsThemeProps('table-cell'),
+          themeProps('table-cell'),
           stylex.props(xstyle),
           incomingClassName,
           incomingStyle,
@@ -171,7 +171,7 @@ export function TableCell({
       ref={ref}
       {...props}
       {...mergeProps(
-        xdsThemeProps('table-cell'),
+        themeProps('table-cell'),
         stylex.props(...mergeXStyle(cellStyles, xstyle)),
         incomingClassName,
         incomingStyle,

--- a/packages/core/src/Table/TableFooter.tsx
+++ b/packages/core/src/Table/TableFooter.tsx
@@ -6,7 +6,7 @@ import type {ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {BaseProps} from '../BaseProps';
 import {mergeProps} from '../utils';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 export interface TableFooterProps extends BaseProps<HTMLTableSectionElement> {
   ref?: React.Ref<HTMLTableSectionElement>;
@@ -17,7 +17,7 @@ export function TableFooter({ref, children, xstyle}: TableFooterProps) {
   return (
     <tfoot
       ref={ref}
-      {...mergeProps(xdsThemeProps('table-footer'), stylex.props(xstyle))}>
+      {...mergeProps(themeProps('table-footer'), stylex.props(xstyle))}>
       {children}
     </tfoot>
   );

--- a/packages/core/src/Table/TableHeader.tsx
+++ b/packages/core/src/Table/TableHeader.tsx
@@ -6,7 +6,7 @@ import type {ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {BaseProps} from '../BaseProps';
 import {mergeProps} from '../utils';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 export interface TableHeaderProps extends BaseProps<HTMLTableSectionElement> {
   ref?: React.Ref<HTMLTableSectionElement>;
@@ -17,7 +17,7 @@ export function TableHeader({ref, children, xstyle}: TableHeaderProps) {
   return (
     <thead
       ref={ref}
-      {...mergeProps(xdsThemeProps('table-header'), stylex.props(xstyle))}>
+      {...mergeProps(themeProps('table-header'), stylex.props(xstyle))}>
       {children}
     </thead>
   );

--- a/packages/core/src/Table/TableHeaderCell.tsx
+++ b/packages/core/src/Table/TableHeaderCell.tsx
@@ -28,7 +28,7 @@ import type {StyleXStyles} from '../theme/types';
 import {overflowStyles, containerEdgeStyles} from './table.stylex';
 import {useTableContext, mergeXStyle} from './useTableCellStyles';
 import {mergeProps} from '../utils';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 /** Props for TableHeaderCell — `<th>` wrapper with context-aware styling */
 export interface TableHeaderCellProps extends BaseProps<HTMLTableCellElement> {
@@ -127,7 +127,7 @@ export function TableHeaderCell({
         ref={ref}
         {...props}
         {...mergeProps(
-          xdsThemeProps('table-header-cell'),
+          themeProps('table-header-cell'),
           stylex.props(xstyle),
           incomingClassName,
           incomingStyle,
@@ -158,7 +158,7 @@ export function TableHeaderCell({
       ref={ref}
       {...props}
       {...mergeProps(
-        xdsThemeProps('table-header-cell'),
+        themeProps('table-header-cell'),
         stylex.props(...mergeXStyle(cellStyles, xstyle)),
         incomingClassName,
         incomingStyle,

--- a/packages/core/src/Table/TableRow.tsx
+++ b/packages/core/src/Table/TableRow.tsx
@@ -22,7 +22,7 @@ import type {StyleXStyles} from '../theme/types';
 import {tableRowMarker} from './table.stylex';
 import {TableContext} from './TableContext';
 import {mergeProps} from '../utils';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 /** Props for TableRow — thin `<tr>` wrapper */
 export interface TableRowProps extends BaseProps<HTMLTableRowElement> {
@@ -104,7 +104,7 @@ export function TableRow({
         ref={ref}
         {...props}
         {...mergeProps(
-          xdsThemeProps('table-row'),
+          themeProps('table-row'),
           stylex.props(tableRowMarker, xstyle),
         )}>
         {children}
@@ -137,7 +137,7 @@ export function TableRow({
       ref={ref}
       {...props}
       {...mergeProps(
-        xdsThemeProps('table-row'),
+        themeProps('table-row'),
         stylex.props(tableRowMarker, ...rowStyles),
       )}>
       {children}

--- a/packages/core/src/Text/Text.tsx
+++ b/packages/core/src/Text/Text.tsx
@@ -48,7 +48,7 @@ import {useTruncation} from './useTruncation';
 import type {LayerPlacement} from '../Layer';
 import {mergeProps, mergeRefs} from '../utils';
 import type {BaseProps} from '../BaseProps';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 const LazyXDSTooltip = lazy(async () =>
   import('../Tooltip/Tooltip').then(mod => ({default: mod.Tooltip})),
@@ -254,7 +254,7 @@ export function Text({
       <Component
         ref={mergeRefs(ref, truncation.ref, textRef)}
         {...mergeProps(
-          xdsThemeProps('text', {type, color: resolvedColor}),
+          themeProps('text', {type, color: resolvedColor}),
           stylex.props(
             colorStyles[resolvedColor],
             sizeByTypeStyles[styleType],

--- a/packages/core/src/TextArea/TextArea.tsx
+++ b/packages/core/src/TextArea/TextArea.tsx
@@ -48,7 +48,7 @@ import type {BaseProps} from '../BaseProps';
 import type {SizeValue} from '../utils/types';
 import {useInputContainer} from '../hooks/useInputContainer';
 import {useSize} from '../SizeContext/SizeContext';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 const COUNTER_WARNING_THRESHOLD = 0.8;
 
@@ -385,7 +385,7 @@ export function TextArea({
         onClick={handleWrapperClick}
         onMouseUp={handleWrapperMouseUp}
         {...mergeProps(
-          xdsThemeProps('textarea', {size, status: status?.type ?? null}),
+          themeProps('textarea', {size, status: status?.type ?? null}),
           stylex.props(
             inputWrapperStyles.base,
             styles.wrapper,

--- a/packages/core/src/TextInput/TextInput.tsx
+++ b/packages/core/src/TextInput/TextInput.tsx
@@ -119,7 +119,7 @@ import {useInputContainer} from '../hooks/useInputContainer';
 import {useInputGroup} from '../InputGroup/InputGroupContext';
 import type {BaseProps} from '../BaseProps';
 import type {SizeValue} from '../utils/types';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 export type TextInputType = 'text' | 'password' | 'email';
 
@@ -340,7 +340,7 @@ export function TextInput({
       onClick={handleWrapperClick}
       onMouseUp={handleWrapperMouseUp}
       {...mergeProps(
-        xdsThemeProps('text-input', {size, status: status?.type ?? null}),
+        themeProps('text-input', {size, status: status?.type ?? null}),
         stylex.props(
           inputWrapperStyles.base,
           sizeStyles[size],

--- a/packages/core/src/Thumbnail/Thumbnail.tsx
+++ b/packages/core/src/Thumbnail/Thumbnail.tsx
@@ -39,7 +39,7 @@ import {MediaTheme} from '../theme/MediaTheme';
 import {useImageMode} from '../hooks/useImageMode';
 import type {BaseProps} from '../BaseProps';
 import {mergeProps} from '../utils';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 /** Sample the region behind the remove button (20px button, 4px inset, in 64px container). */
 const BUTTON_REGION = {x: 0.5, y: 0.06, width: 0.44, height: 0.44};
@@ -298,7 +298,7 @@ export function Thumbnail({
       data-testid={testId}
       aria-label={accessibleName}
       {...mergeProps(
-        xdsThemeProps('thumbnail'),
+        themeProps('thumbnail'),
         stylex.props(styles.root, isDisabled && styles.disabled, xstyle),
         className,
         style,

--- a/packages/core/src/TimeInput/TimeInput.tsx
+++ b/packages/core/src/TimeInput/TimeInput.tsx
@@ -63,7 +63,7 @@ import type {BaseProps} from '../BaseProps';
 import type {SizeValue} from '../utils/types';
 import {useSize} from '../SizeContext/SizeContext';
 import {useInputContainer} from '../hooks/useInputContainer';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 const styles = stylex.create({
   icon: {
@@ -535,7 +535,7 @@ export function TimeInput({
         onClick={handleWrapperClick}
         onMouseUp={handleWrapperMouseUp}
         {...mergeProps(
-          xdsThemeProps('time-input', {size, status: status?.type ?? null}),
+          themeProps('time-input', {size, status: status?.type ?? null}),
           stylex.props(
             inputWrapperStyles.base,
             sizeStyles[size],

--- a/packages/core/src/Timestamp/Timestamp.tsx
+++ b/packages/core/src/Timestamp/Timestamp.tsx
@@ -27,7 +27,7 @@ import type {
 } from '../theme/types';
 import {mergeProps, mergeRefs} from '../utils';
 import type {BaseProps} from '../BaseProps';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 const LazyXDSTooltip = lazy(async () =>
   import('../Tooltip/Tooltip').then(mod => ({default: mod.Tooltip})),
@@ -379,7 +379,7 @@ export function Timestamp({
   const showTooltip = hasTooltip && effectiveFormat === 'relative';
 
   const timestampProps = mergeProps(
-    xdsThemeProps('timestamp', {format: effectiveFormat}),
+    themeProps('timestamp', {format: effectiveFormat}),
     {className, style},
   );
 

--- a/packages/core/src/Toast/Toast.tsx
+++ b/packages/core/src/Toast/Toast.tsx
@@ -21,7 +21,7 @@ import {mergeProps} from '../utils';
 import {useTheme} from '../theme';
 import {MediaTheme} from '../theme/MediaTheme';
 import type {ToastType, ToastDismissReason} from './types';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 const styles = stylex.create({
   root: {
@@ -187,7 +187,7 @@ export function Toast({
       onFocusCapture={pauseTimer}
       onBlurCapture={resumeTimer}
       {...mergeProps(
-        xdsThemeProps('toast', {type}),
+        themeProps('toast', {type}),
         stylex.props(
           styles.root,
           isError ? styles.variantError : styles.variantDefault,

--- a/packages/core/src/ToggleButton/ToggleButton.tsx
+++ b/packages/core/src/ToggleButton/ToggleButton.tsx
@@ -27,7 +27,7 @@ import {colorVars, fontWeightVars} from '../theme/tokens.stylex';
 import {Button, type ButtonSize} from '../Button';
 import {useToggleButtonGroup} from './ToggleButtonGroup';
 import type {BaseProps} from '../BaseProps';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 // =============================================================================
 // Styles
@@ -294,7 +294,7 @@ export function ToggleButton({
       aria-pressed={isPressed}
       icon={resolvedIcon}
       tooltip={tooltip}
-      {...xdsThemeProps('toggle-button', {
+      {...themeProps('toggle-button', {
         isPressed: isPressed ? 'true' : 'false',
       })}
       xstyle={[isPressed ? pressedStyles.background : undefined, xstyle]}

--- a/packages/core/src/ToggleButton/ToggleButtonGroup.tsx
+++ b/packages/core/src/ToggleButton/ToggleButtonGroup.tsx
@@ -24,7 +24,7 @@ import {spacingVars} from '../theme/tokens.stylex';
 import type {ButtonSize} from '../Button';
 import {mergeProps} from '../utils';
 import type {StyleXStyles} from '@stylexjs/stylex';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 // =============================================================================
 // Context
@@ -231,7 +231,7 @@ export function ToggleButtonGroup(
         aria-label={label}
         data-testid={testId}
         {...mergeProps(
-          xdsThemeProps('toggle-button-group'),
+          themeProps('toggle-button-group'),
           stylex.props(
             styles.group,
             orientation === 'vertical' && styles.vertical,

--- a/packages/core/src/Token/Token.tsx
+++ b/packages/core/src/Token/Token.tsx
@@ -33,7 +33,7 @@ import {mergeProps} from '../utils';
 import {useLinkComponent} from '../Link/useLinkComponent';
 import {useInteractiveRole} from '../hooks/useInteractiveRole';
 import type {BaseProps} from '../BaseProps';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 // =============================================================================
 // Types
@@ -369,7 +369,7 @@ export function Token({
         aria-disabled={isDisabled || undefined}
         {...sharedProps}
         {...mergeProps(
-          xdsThemeProps('token', {color, size}),
+          themeProps('token', {color, size}),
           stylex.props(
             styles.base,
             sizeStyles[size],
@@ -401,7 +401,7 @@ export function Token({
         onClick={isDisabled ? undefined : handleContainerClick}
         {...sharedProps}
         {...mergeProps(
-          xdsThemeProps('token', {color, size}),
+          themeProps('token', {color, size}),
           stylex.props(
             styles.base,
             sizeStyles[size],
@@ -451,7 +451,7 @@ export function Token({
       ref={ref}
       {...sharedProps}
       {...mergeProps(
-        xdsThemeProps('token', {color, size}),
+        themeProps('token', {color, size}),
         stylex.props(
           styles.base,
           sizeStyles[size],

--- a/packages/core/src/Tokenizer/Tokenizer.tsx
+++ b/packages/core/src/Tokenizer/Tokenizer.tsx
@@ -50,7 +50,7 @@ import {
 } from '../theme/tokens.stylex';
 import type {SearchableItem, SearchSource} from '../Typeahead/types';
 import {mergeProps} from '../utils';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 // Re-export status types for convenience
 export type {
@@ -664,7 +664,7 @@ export function Tokenizer<T extends SearchableItem>({
       onBlurCapture={handleBlurCapture}
       data-testid={testId}
       {...mergeProps(
-        xdsThemeProps('tokenizer', {size, status: status?.type}),
+        themeProps('tokenizer', {size, status: status?.type}),
         stylex.props(
           inputWrapperStyles.base,
           styles.wrapper,
@@ -749,7 +749,7 @@ export function Tokenizer<T extends SearchableItem>({
           ref={placeholderRef}
           onClick={handleWrapperClick}
           {...mergeProps(
-            xdsThemeProps('tokenizer', {size, status: status?.type}),
+            themeProps('tokenizer', {size, status: status?.type}),
             stylex.props(
               inputWrapperStyles.base,
               styles.wrapper,

--- a/packages/core/src/Toolbar/Toolbar.tsx
+++ b/packages/core/src/Toolbar/Toolbar.tsx
@@ -28,7 +28,7 @@ import {Section} from '../Section/Section';
 import {useListFocus} from '../hooks/useListFocus';
 import {SizeProvider} from '../SizeContext/SizeContext';
 import {edgeCompSlot} from '../Layout/edgeCompensation.stylex';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 /**
  * Map SpacingStep values to spacingVars keys.
@@ -257,7 +257,7 @@ export function Toolbar({
           aria-orientation={orientation}
           onKeyDown={handleKeyDown}
           {...mergeProps(
-            xdsThemeProps('toolbar', {size}),
+            themeProps('toolbar', {size}),
             stylex.props(
               hasCenterContent ? styles.baseGrid : styles.baseFlex,
               orientation === 'vertical' && styles.vertical,

--- a/packages/core/src/Tooltip/useTooltip.tsx
+++ b/packages/core/src/Tooltip/useTooltip.tsx
@@ -28,7 +28,7 @@ import {
   type LayerPlacement,
 } from '../Layer/useLayer';
 import {layerAnimations} from '../Layer/layerAnimations.stylex';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 import {
   colorVars,
   radiusVars,
@@ -430,7 +430,7 @@ export function useTooltip(
         placement: renderPlacement,
         alignment: props?.alignment ?? alignment,
         xstyle: [popoverXstyle, layerAnimations[renderPlacement]],
-        className: xdsThemeProps('tooltip').className,
+        className: themeProps('tooltip').className,
       };
 
       return layer.render(

--- a/packages/core/src/TopNav/TopNav.tsx
+++ b/packages/core/src/TopNav/TopNav.tsx
@@ -28,7 +28,7 @@ import {Divider} from '../Divider/Divider';
 import {MobileNav} from '../MobileNav/MobileNav';
 import {MobileNavToggle} from '../MobileNav/MobileNavToggle';
 import {useAppShellMobile} from '../AppShell/AppShellMobileContext';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 /**
  * Base TopNav styles
@@ -205,7 +205,7 @@ export function TopNav({
         role="navigation"
         aria-label={label}
         {...mergeProps(
-          xdsThemeProps('top-nav', {mode: 'mobile-bar'}),
+          themeProps('top-nav', {mode: 'mobile-bar'}),
           stylex.props(styles.mobileBar, xstyle),
           className,
           style,
@@ -262,7 +262,7 @@ export function TopNav({
       role="navigation"
       aria-label={label}
       {...mergeProps(
-        xdsThemeProps('top-nav'),
+        themeProps('top-nav'),
         stylex.props(
           styles.base,
           hasCenterContent ? styles.baseGrid : styles.baseFlex,

--- a/packages/core/src/TopNav/TopNavHeading.tsx
+++ b/packages/core/src/TopNav/TopNavHeading.tsx
@@ -38,7 +38,7 @@ import {mergeProps, mergeRefs} from '../utils';
 import type {BaseProps} from '../BaseProps';
 import {useMenuHover} from '../hooks/useMenuHover';
 import {NavHeadingCloseContext} from '../NavMenu/NavMenuContext';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 // =============================================================================
 // Styles
@@ -427,7 +427,7 @@ export function TopNavHeading({
         href={headingHref}
         data-testid={testId}
         {...mergeProps(
-          xdsThemeProps('top-nav-heading'),
+          themeProps('top-nav-heading'),
           stylex.props(
             styles.root,
             !!headingHref && styles.menuTrigger,
@@ -450,7 +450,7 @@ export function TopNavHeading({
         href={headingHref}
         data-testid={testId}
         {...mergeProps(
-          xdsThemeProps('top-nav-heading'),
+          themeProps('top-nav-heading'),
           stylex.props(styles.root, styles.menuTrigger, xstyle),
           className,
           style,
@@ -473,7 +473,7 @@ export function TopNavHeading({
           data-testid={testId}
           {...triggerProps}
           {...mergeProps(
-            xdsThemeProps('top-nav-heading'),
+            themeProps('top-nav-heading'),
             stylex.props(styles.root, styles.menuTrigger, xstyle),
             className,
             style,
@@ -524,7 +524,7 @@ export function TopNavHeading({
           data-testid={testId}
           {...triggerProps}
           {...mergeProps(
-            xdsThemeProps('top-nav-heading'),
+            themeProps('top-nav-heading'),
             stylex.props(styles.root, xstyle),
             className,
             style,
@@ -585,7 +585,7 @@ export function TopNavHeading({
         ref={ref as React.Ref<HTMLDivElement>}
         data-testid={testId}
         {...mergeProps(
-          xdsThemeProps('top-nav-heading'),
+          themeProps('top-nav-heading'),
           stylex.props(styles.root, xstyle),
           className,
           style,
@@ -636,7 +636,7 @@ export function TopNavHeading({
       ref={ref as React.Ref<HTMLDivElement>}
       data-testid={testId}
       {...mergeProps(
-        xdsThemeProps('top-nav-heading'),
+        themeProps('top-nav-heading'),
         stylex.props(styles.root, xstyle),
         className,
         style,

--- a/packages/core/src/TopNav/TopNavItem.tsx
+++ b/packages/core/src/TopNav/TopNavItem.tsx
@@ -34,7 +34,7 @@ import {useTopNavRenderMode} from './TopNavRenderContext';
 import {navItemStyles, type NavItemSize} from '../NavItem/navItemStyles.stylex';
 import {mergeProps} from '../utils';
 import {useAppShellMobile} from '../AppShell/AppShellMobileContext';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 /**
  * NavItem styles with hover/selected states
@@ -216,7 +216,7 @@ export function TopNavItem({
         aria-disabled={isDisabled || undefined}
         tabIndex={isDisabled ? -1 : undefined}
         {...mergeProps(
-          xdsThemeProps('top-nav-item', {
+          themeProps('top-nav-item', {
             mode: 'drawer',
             selected: isSelected ? 'selected' : null,
           }),
@@ -251,7 +251,7 @@ export function TopNavItem({
       aria-disabled={isDisabled || undefined}
       tabIndex={isDisabled ? -1 : undefined}
       {...mergeProps(
-        xdsThemeProps('top-nav-item', {
+        themeProps('top-nav-item', {
           selected: isSelected ? 'selected' : null,
         }),
         stylex.props(

--- a/packages/core/src/TopNav/TopNavMegaMenu.tsx
+++ b/packages/core/src/TopNav/TopNavMegaMenu.tsx
@@ -50,7 +50,7 @@ import type {BaseProps} from '../BaseProps';
 import {navItemStyles} from '../NavItem/navItemStyles.stylex';
 import {useTopNavSlot} from './TopNavContext';
 import {useTopNavRenderMode} from './TopNavRenderContext';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 // =============================================================================
 // Styles
@@ -440,7 +440,7 @@ function DefaultMegaMenu({
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
         {...mergeProps(
-          xdsThemeProps('top-nav-mega-menu'),
+          themeProps('top-nav-mega-menu'),
           stylex.props(styles.trigger, popover.isOpen && styles.triggerOpen),
         )}>
         {label}
@@ -506,7 +506,7 @@ function DrawerMegaMenu({
         aria-expanded={isExpanded}
         aria-controls={`${menuId}-items`}
         {...mergeProps(
-          xdsThemeProps('top-nav-mega-menu', {mode: 'drawer'}),
+          themeProps('top-nav-mega-menu', {mode: 'drawer'}),
           stylex.props(navItemStyles.item, styles.drawerHeader),
         )}>
         {label}

--- a/packages/core/src/TopNav/TopNavMegaMenuFeaturedCard.tsx
+++ b/packages/core/src/TopNav/TopNavMegaMenuFeaturedCard.tsx
@@ -29,7 +29,7 @@ import {
 import {mergeProps} from '../utils';
 import type {BaseProps} from '../BaseProps';
 import {useLinkComponent} from '../Link/useLinkComponent';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 // =============================================================================
 // Styles
@@ -138,7 +138,7 @@ export function TopNavMegaMenuFeaturedCard({
     <div
       ref={ref}
       {...mergeProps(
-        xdsThemeProps('top-nav-mega-menu-featured-card'),
+        themeProps('top-nav-mega-menu-featured-card'),
         stylex.props(styles.root),
       )}>
       {image && (

--- a/packages/core/src/TopNav/TopNavMegaMenuItem.tsx
+++ b/packages/core/src/TopNav/TopNavMegaMenuItem.tsx
@@ -33,7 +33,7 @@ import {useTopNavRenderMode} from './TopNavRenderContext';
 import {mergeProps} from '../utils';
 import type {BaseProps} from '../BaseProps';
 import {useAppShellMobile} from '../AppShell/AppShellMobileContext';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 // =============================================================================
 // Styles
@@ -221,7 +221,7 @@ export function TopNavMegaMenuItem({
         onClick={handleDrawerClick}
         {...elementProps}
         {...mergeProps(
-          xdsThemeProps('top-nav-mega-menu-item', {mode: 'drawer'}),
+          themeProps('top-nav-mega-menu-item', {mode: 'drawer'}),
           stylex.props(navItemStyles.item, styles.drawerItem),
         )}>
         {icon && <div {...stylex.props(styles.drawerItemIcon)}>{icon}</div>}
@@ -248,7 +248,7 @@ export function TopNavMegaMenuItem({
       onClick={onClick}
       tabIndex={tabIndex}
       {...mergeProps(
-        xdsThemeProps('top-nav-mega-menu-item'),
+        themeProps('top-nav-mega-menu-item'),
         stylex.props(styles.desktop),
       )}>
       {icon && <div {...stylex.props(styles.desktopIcon)}>{icon}</div>}

--- a/packages/core/src/TopNav/TopNavMenu.tsx
+++ b/packages/core/src/TopNav/TopNavMenu.tsx
@@ -27,7 +27,7 @@ import {useTopNavSlot} from './TopNavContext';
 import {useTopNavRenderMode} from './TopNavRenderContext';
 import {useAppShellMobile} from '../AppShell/AppShellMobileContext';
 import {useLinkComponent} from '../Link/useLinkComponent';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 import {
   colorVars,
   spacingVars,
@@ -423,7 +423,7 @@ export function TopNavMenu({
         {...popover.triggerProps}
         {...triggerProps}
         {...mergeProps(
-          xdsThemeProps('top-nav-menu'),
+          themeProps('top-nav-menu'),
           stylex.props(styles.trigger, popover.isOpen && styles.triggerOpen),
         )}>
         {label}

--- a/packages/core/src/TreeList/TreeList.tsx
+++ b/packages/core/src/TreeList/TreeList.tsx
@@ -22,7 +22,7 @@ import {mergeProps} from '../utils';
 import type {BaseProps} from '../BaseProps';
 import {TreeListItem} from './TreeListItem';
 import type {TreeListItemData, TreeListDensity} from './TreeListTypes';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 // =============================================================================
 // Types
@@ -216,7 +216,7 @@ export function TreeList({
       ref={ref}
       data-testid={testId}
       {...mergeProps(
-        xdsThemeProps('tree-list', {density}),
+        themeProps('tree-list', {density}),
         stylex.props(styles.root, xstyle),
         className,
         style,

--- a/packages/core/src/TreeList/TreeListItem.tsx
+++ b/packages/core/src/TreeList/TreeListItem.tsx
@@ -29,7 +29,7 @@ import {mergeProps} from '../utils';
 import {useLinkComponent} from '../Link/useLinkComponent';
 import {TreeListBranches} from './TreeListBranches';
 import type {TreeListDensity} from './TreeListTypes';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 // =============================================================================
 // Styles
@@ -411,7 +411,7 @@ export function TreeListItem({
       <div {...stylex.props(styles.rowWrapper)}>
         <div
           {...mergeProps(
-            xdsThemeProps('tree-list-item', {
+            themeProps('tree-list-item', {
               density,
               selected: isSelected ? 'selected' : null,
               disabled: isDisabled ? 'disabled' : null,

--- a/packages/core/src/Typeahead/BaseTypeahead.tsx
+++ b/packages/core/src/Typeahead/BaseTypeahead.tsx
@@ -42,7 +42,7 @@ import {
 import {getKey, mergeProps, mergeRefs} from '../utils';
 import type {BaseProps} from '../BaseProps';
 import type {SearchableItem, SearchSource} from './types';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 // =============================================================================
 // Types
@@ -684,7 +684,7 @@ export const BaseTypeahead = function BaseTypeahead<
           role="listbox"
           aria-label="Search results"
           {...mergeProps(
-            xdsThemeProps('typeahead-dropdown'),
+            themeProps('typeahead-dropdown'),
             stylex.props(styles.dropdown),
           )}>
           {results.length === 0 && hasSearched ? (

--- a/packages/core/src/Typeahead/Typeahead.tsx
+++ b/packages/core/src/Typeahead/Typeahead.tsx
@@ -44,7 +44,7 @@ import {mergeProps} from '../utils';
 import type {BaseProps} from '../BaseProps';
 import type {SizeValue} from '../utils/types';
 import type {SearchableItem, SearchSource} from './types';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 export type {
   InputStatus as TypeaheadStatus,
@@ -376,7 +376,7 @@ export function Typeahead<T extends SearchableItem>({
         onClick={handleWrapperClick}
         onBlur={handleBlur}
         {...mergeProps(
-          xdsThemeProps('typeahead', {size, status: status?.type}),
+          themeProps('typeahead', {size, status: status?.type}),
           stylex.props(
             inputWrapperStyles.base,
             styles.wrapper,

--- a/packages/core/src/Typeahead/TypeaheadItem.tsx
+++ b/packages/core/src/Typeahead/TypeaheadItem.tsx
@@ -22,7 +22,7 @@ import {
 import type {SearchableItem} from './types';
 import type {BaseProps} from '../BaseProps';
 import {mergeProps} from '../utils';
-import {xdsThemeProps} from '../utils/xdsThemeProps';
+import {themeProps} from '../utils/themeProps';
 
 // =============================================================================
 // Types
@@ -142,7 +142,7 @@ export function TypeaheadItem<T extends SearchableItem>({
     <div
       ref={ref}
       {...mergeProps(
-        xdsThemeProps('typeahead-item'),
+        themeProps('typeahead-item'),
         stylex.props(styles.container, isDisabled && styles.disabled),
       )}>
       {icon}

--- a/packages/core/src/docs-types.ts
+++ b/packages/core/src/docs-types.ts
@@ -76,7 +76,7 @@ export interface PropDoc {
  * A theming target — a stable selector surface that `defineTheme` can target
  * via `@scope` selectors. Each component renders one or more stable `xds-*`
  * class names and reflects visual props/states as `data-*` attributes via
- * `xdsThemeProps()`, so themes and external CSS have an explicit prop-aware selector surface.
+ * `themeProps()`, so themes and external CSS have an explicit prop-aware selector surface.
  *
  * @example
  * ```
@@ -91,7 +91,7 @@ export interface ThemingTarget {
    *  e.g. `"astryx-button"`, `"astryx-avatar-status-dot"`, `"astryx-card"` */
   className: string;
   /** Visual prop names reflected on this element.
-   *  These are the props passed to `xdsThemeProps()` as the second argument.
+   *  These are the props passed to `themeProps()` as the second argument.
    *  Use these names to derive preferred data selectors: `variant` →
    *  `[data-variant="secondary"]`, `level` → `[data-level="2"]`. Legacy bare
    *  classes are still emitted for compatibility but should not be the primary
@@ -494,7 +494,7 @@ interface BaseDoc {
      *  `--layout-padding-*` tokens instead of emitting raw CSS. */
     container?: boolean;
     /** Selector targets rendered by this component.
-     *  Each entry corresponds to an `xdsThemeProps()` call in the source. */
+     *  Each entry corresponds to an `themeProps()` call in the source. */
     targets: ThemingTarget[];
     /** CSS custom properties exposed for theming. */
     vars?: ComponentVar[];

--- a/packages/core/src/naming.ts
+++ b/packages/core/src/naming.ts
@@ -27,7 +27,7 @@
  * - CSS custom properties: `--astryx-*` via {@link cssVarNamespace} / {@link cssVar}.
  * - CSS layers: `astryx-base` / `astryx-theme`.
  *
- * SYNC: packages/core/src/utils/xdsThemeProps.ts (consumes classPrefix)
+ * SYNC: packages/core/src/utils/themeProps.ts (consumes classPrefix)
  * SYNC: packages/core/src/utils/parseStyleKey.ts
  * SYNC: packages/cli/src/commands/build-theme.mjs (imports @astryxdesign/core/naming)
  */

--- a/packages/core/src/utils/mergeProps.ts
+++ b/packages/core/src/utils/mergeProps.ts
@@ -4,7 +4,7 @@
  * Merge xds-* props, stylex.props result, and optional consumer className/style.
  *
  * stylex.props() returns { className, style }. This merges the Astryx stable
- * class name plus any data-attribute reflection from `xdsThemeProps()` with the
+ * class name plus any data-attribute reflection from `themeProps()` with the
  * StyleX class name so both StyleX styles and the theme-targeting surface are
  * applied.
  *
@@ -13,9 +13,9 @@
  *
  * @example
  * ```tsx
- * // Root element with xdsThemeProps
+ * // Root element with themeProps
  * <div {...mergeProps(
- *   xdsThemeProps('button', { variant }),
+ *   themeProps('button', { variant }),
  *   stylex.props(styles.base, variants[variant]),
  *   className,
  *   style,
@@ -66,7 +66,7 @@ export function mergeProps(
   style?: React.CSSProperties,
 ): PropsObject {
   // Disambiguate: first arg is string → (xdsClass, stylexResult, className?, style?)
-  // first arg is object → merge arbitrary props (supports xdsThemeProps + data attrs).
+  // first arg is object → merge arbitrary props (supports themeProps + data attrs).
   if (typeof xdsClassOrStylexResult === 'string') {
     const xdsClass = xdsClassOrStylexResult;
     const stylexResult = (stylexResultOrClassName as PropsObject) ?? {

--- a/packages/core/src/utils/parseStyleKey.ts
+++ b/packages/core/src/utils/parseStyleKey.ts
@@ -6,11 +6,11 @@
  * Used by both defineTheme (CSS generation) and components (class name rendering)
  * to ensure the same convention is applied consistently.
  *
- * <!-- SYNC: packages/core/src/utils/xdsThemeProps.ts -->
+ * <!-- SYNC: packages/core/src/utils/themeProps.ts -->
  *
  * Emits the legacy class-selector suffix used by defineTheme/component override
  * generation today. Components also reflect the same prop values as data
- * attributes via `xdsThemeProps()` (`variant:secondary` renders both `.secondary`
+ * attributes via `themeProps()` (`variant:secondary` renders both `.secondary`
  * and `[data-variant="secondary"]` in the DOM), but generated theme CSS still
  * uses these class selectors until the selector contract migrates fully.
  *

--- a/packages/core/src/utils/themeProps.test.ts
+++ b/packages/core/src/utils/themeProps.test.ts
@@ -1,44 +1,44 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 import {describe, it, expect} from 'vitest';
-import {xdsThemeDataAttributes, xdsThemeProps} from './xdsThemeProps';
+import {themeDataAttributes, themeProps} from './themeProps';
 
-describe('xdsThemeProps', () => {
+describe('themeProps', () => {
   it('returns base class for component', () => {
-    expect(xdsThemeProps('card').className).toBe('astryx-card');
+    expect(themeProps('card').className).toBe('astryx-card');
   });
 
   it('adds variant classes', () => {
     expect(
-      xdsThemeProps('button', {variant: 'secondary', size: 'sm'}).className,
+      themeProps('button', {variant: 'secondary', size: 'sm'}).className,
     ).toBe('astryx-button secondary sm');
   });
 
   it('prefixes numeric values with prop name', () => {
-    expect(xdsThemeProps('heading', {level: 1}).className).toBe(
+    expect(themeProps('heading', {level: 1}).className).toBe(
       'astryx-heading level-1',
     );
   });
 
   it('skips null and undefined props', () => {
     expect(
-      xdsThemeProps('button', {variant: 'primary', size: undefined}).className,
+      themeProps('button', {variant: 'primary', size: undefined}).className,
     ).toBe('astryx-button primary');
   });
 
   it('works with no props', () => {
-    expect(xdsThemeProps('divider').className).toBe('astryx-divider');
+    expect(themeProps('divider').className).toBe('astryx-divider');
   });
 
   it('handles string numeric values', () => {
-    expect(xdsThemeProps('heading', {level: '3'}).className).toBe(
+    expect(themeProps('heading', {level: '3'}).className).toBe(
       'astryx-heading level-3',
     );
   });
 
   it('reflects visual props as data attributes', () => {
     expect(
-      xdsThemeDataAttributes({variant: 'secondary', size: 'sm', level: 2}),
+      themeDataAttributes({variant: 'secondary', size: 'sm', level: 2}),
     ).toEqual({
       'data-variant': 'secondary',
       'data-size': 'sm',
@@ -47,19 +47,19 @@ describe('xdsThemeProps', () => {
   });
 
   it('kebab-cases data attribute names', () => {
-    expect(xdsThemeDataAttributes({listStyle: 'ordered'})).toEqual({
+    expect(themeDataAttributes({listStyle: 'ordered'})).toEqual({
       'data-list-style': 'ordered',
     });
   });
 
   it('omits nullish data attributes', () => {
-    expect(xdsThemeDataAttributes({variant: 'primary', size: null})).toEqual({
+    expect(themeDataAttributes({variant: 'primary', size: null})).toEqual({
       'data-variant': 'primary',
     });
   });
 
   it('returns class and data attributes together', () => {
-    expect(xdsThemeProps('button', {variant: 'primary', size: 'sm'})).toEqual({
+    expect(themeProps('button', {variant: 'primary', size: 'sm'})).toEqual({
       className: 'astryx-button primary sm',
       'data-variant': 'primary',
       'data-size': 'sm',

--- a/packages/core/src/utils/themeProps.ts
+++ b/packages/core/src/utils/themeProps.ts
@@ -21,7 +21,7 @@ function classTokenForPropValue(prop: string, value: string): string {
  *
  * Every component renders a stable base class (`astryx-button`, `astryx-card`,
  * etc.) plus variant classes derived from visual props. Components also reflect
- * those visual props as data attributes via `xdsThemeProps()` (`data-variant`,
+ * those visual props as data attributes via `themeProps()` (`data-variant`,
  * `data-size`, `data-level`, etc.) so consumers target stable data-attribute
  * selectors rather than collision-prone bare class names.
  *
@@ -73,7 +73,7 @@ function buildClassName(component: string, props?: ClassProps): string {
  * literal prop values, including numeric values (`level: 1` → `data-level="1"`).
  * Nullish values are omitted.
  */
-export function xdsThemeDataAttributes(
+export function themeDataAttributes(
   props?: ClassProps,
 ): ThemeDataAttributes {
   const attrs: ThemeDataAttributes = {};
@@ -98,16 +98,16 @@ export function xdsThemeDataAttributes(
  * surface. For example:
  *
  * ```ts
- * xdsThemeProps('button', { variant: 'primary', size: 'sm' })
+ * themeProps('button', { variant: 'primary', size: 'sm' })
  * // → { className: 'astryx-button primary sm', data-variant: 'primary', data-size: 'sm' }
  * ```
  */
-export function xdsThemeProps(
+export function themeProps(
   component: string,
   props?: ClassProps,
 ): ThemeProps {
   return {
     className: buildClassName(component, props),
-    ...xdsThemeDataAttributes(props),
+    ...themeDataAttributes(props),
   };
 }

--- a/packages/lab/src/ChatReasoning/ChatReasoning.tsx
+++ b/packages/lab/src/ChatReasoning/ChatReasoning.tsx
@@ -28,7 +28,7 @@ import {
   easeVars,
 } from '@astryxdesign/core/theme/tokens.stylex';
 import {mergeProps} from '@astryxdesign/core/utils';
-import {xdsThemeProps} from '../../../core/src/utils/xdsThemeProps';
+import {themeProps} from '../../../core/src/utils/themeProps';
 
 // =============================================================================
 // Types
@@ -259,7 +259,7 @@ export function ChatReasoning(props: ChatReasoningProps) {
   return (
     <div
       {...mergeProps(
-        xdsThemeProps('chat-reasoning', {
+        themeProps('chat-reasoning', {
           expanded: isExpanded ? 'expanded' : null,
           streaming: isStreaming ? 'streaming' : null,
         }),

--- a/packages/lab/src/CircularProgress/CircularProgress.tsx
+++ b/packages/lab/src/CircularProgress/CircularProgress.tsx
@@ -29,7 +29,7 @@ import {
 } from '@astryxdesign/core/theme/tokens.stylex';
 import {mergeProps} from '@astryxdesign/core/utils';
 import type {BaseProps} from '@astryxdesign/core';
-import {xdsThemeProps} from '../../../core/src/utils/xdsThemeProps';
+import {themeProps} from '../../../core/src/utils/themeProps';
 
 /**
  * Extensible variant map for CircularProgress.
@@ -299,7 +299,7 @@ export function CircularProgress({
     <div
       ref={ref}
       {...mergeProps(
-        xdsThemeProps('circular-progress', {variant, size}),
+        themeProps('circular-progress', {variant, size}),
         stylex.props(styles.root, showLabel && styles.rootWithLabel, xstyle),
         className,
         style,
@@ -327,7 +327,7 @@ export function CircularProgress({
           )}>
           <circle
             {...mergeProps(
-              xdsThemeProps('circular-progress-track'),
+              themeProps('circular-progress-track'),
               stylex.props(styles.track, trackVariantStyles[variant]),
             )}
             cx={center}
@@ -338,7 +338,7 @@ export function CircularProgress({
           {isIndeterminate ? (
             <circle
               {...mergeProps(
-                xdsThemeProps('circular-progress-fill', {variant}),
+                themeProps('circular-progress-fill', {variant}),
                 stylex.props(styles.fillIndeterminate, variantStyles[variant]),
               )}
               cx={center}
@@ -349,7 +349,7 @@ export function CircularProgress({
           ) : (
             <circle
               {...mergeProps(
-                xdsThemeProps('circular-progress-fill', {variant}),
+                themeProps('circular-progress-fill', {variant}),
                 stylex.props(styles.fill, variantStyles[variant]),
               )}
               cx={center}

--- a/packages/lab/src/CodeEditor/CodeEditor.tsx
+++ b/packages/lab/src/CodeEditor/CodeEditor.tsx
@@ -33,7 +33,7 @@ import {
   SYNC_TOKENIZE_THRESHOLD,
 } from '@astryxdesign/core/CodeBlock';
 import type {TokenLine} from '@astryxdesign/core/CodeBlock';
-import {xdsThemeProps} from '../../../core/src/utils/xdsThemeProps';
+import {themeProps} from '../../../core/src/utils/themeProps';
 import {
   ensureHighlightStyles,
   applyHighlightRangesFlat,
@@ -417,7 +417,7 @@ export function CodeEditor({
     <div
       ref={ref}
       {...mergeProps(
-        xdsThemeProps('codeeditor', {size, language}),
+        themeProps('codeeditor', {size, language}),
         stylex.props(styles.root, focused && styles.rootFocused, xstyle),
         className,
         style,

--- a/packages/lab/src/SVGIcon/SVGIcon.tsx
+++ b/packages/lab/src/SVGIcon/SVGIcon.tsx
@@ -25,7 +25,7 @@ import {colorVars} from '@astryxdesign/core/theme/tokens.stylex';
 import {mergeProps} from '@astryxdesign/core/utils';
 import {iconVars} from './tokens.stylex';
 import {variations, opticalSize} from './variations.stylex';
-import {xdsThemeProps} from '../../../core/src/utils/xdsThemeProps';
+import {themeProps} from '../../../core/src/utils/themeProps';
 
 // =============================================================================
 // Types
@@ -368,7 +368,7 @@ export function SVGIcon({
       viewBox={viewBox}
       aria-hidden="true"
       {...mergeProps(
-        xdsThemeProps('svg-icon', {variation, size, color}),
+        themeProps('svg-icon', {variation, size, color}),
         stylex.props(
           styles.root,
           colorStyles[color],

--- a/packages/lab/src/Schedule/Schedule.tsx
+++ b/packages/lab/src/Schedule/Schedule.tsx
@@ -23,7 +23,7 @@ import {ScheduleContext} from './context';
 import {defaultSchedulePlugins} from './plugins';
 import {styles} from './shared';
 import {createZonedDateTime} from './zonedDateTime';
-import {xdsThemeProps} from '../../../core/src/utils/xdsThemeProps';
+import {themeProps} from '../../../core/src/utils/themeProps';
 import type {
   CalendarEvent,
   Instant,
@@ -265,7 +265,7 @@ export function Schedule({
     <div
       {...rest}
       {...mergeProps(
-        xdsThemeProps('schedule'),
+        themeProps('schedule'),
         stylex.props(styles.root, xstyle),
         className,
         style,

--- a/packages/lab/src/Stepper/Step.tsx
+++ b/packages/lab/src/Stepper/Step.tsx
@@ -31,7 +31,7 @@ import {
 import {mergeProps} from '@astryxdesign/core/utils';
 import type {BaseProps} from '@astryxdesign/core';
 import {useStepperContext} from './StepperContext';
-import {xdsThemeProps} from '../../../core/src/utils/xdsThemeProps';
+import {themeProps} from '../../../core/src/utils/themeProps';
 import type {StepStatus} from './StepStatus';
 
 /**
@@ -632,7 +632,7 @@ export function Step({
     ) : null;
 
   // Theme data attributes reflect progress + optional semantic status.
-  const themeProps = xdsThemeProps('step', {
+  const stepThemeProps = themeProps('step', {
     progress,
     status: status ?? undefined,
   });
@@ -643,7 +643,7 @@ export function Step({
       <li
         ref={ref}
         {...mergeProps(
-          themeProps,
+          stepThemeProps,
           stylex.props(styles.verticalRoot, xstyle),
           className,
           style,
@@ -654,7 +654,7 @@ export function Step({
         {/* 4px progress bar */}
         <div
           {...mergeProps(
-            xdsThemeProps('step-bar'),
+            themeProps('step-bar'),
             stylex.props(
               styles.verticalBar,
               statusBarStyle ??
@@ -702,7 +702,7 @@ export function Step({
     <li
       ref={ref}
       {...mergeProps(
-        themeProps,
+        stepThemeProps,
         stylex.props(styles.horizontalStep, xstyle),
         className,
         style,
@@ -713,7 +713,7 @@ export function Step({
       {/* 4px progress bar segment for this step */}
       <div
         {...mergeProps(
-          xdsThemeProps('step-bar'),
+          themeProps('step-bar'),
           stylex.props(
             styles.horizontalBar,
             statusBarStyle ??

--- a/packages/lab/src/Stepper/Stepper.tsx
+++ b/packages/lab/src/Stepper/Stepper.tsx
@@ -21,7 +21,7 @@ import * as stylex from '@stylexjs/stylex';
 
 import {mergeProps} from '@astryxdesign/core/utils';
 import type {BaseProps} from '@astryxdesign/core';
-import {xdsThemeProps} from '../../../core/src/utils/xdsThemeProps';
+import {themeProps} from '../../../core/src/utils/themeProps';
 import {
   StepperContext,
   type StepperOrientation,
@@ -137,7 +137,7 @@ export function Stepper({
         aria-label={label}
         {...rest}
         {...mergeProps(
-          xdsThemeProps('stepper', {orientation}),
+          themeProps('stepper', {orientation}),
           stylex.props(
             styles.root,
             orientation === 'horizontal' ? styles.horizontal : styles.vertical,


### PR DESCRIPTION
## Summary

Renames the internal `xdsThemeProps` helper (and `xdsThemeDataAttributes`) to `themeProps` / `themeDataAttributes`, scrubbing `xds` from one of the most widely-used internal identifiers.

## Context
`xdsThemeProps` builds each component's stable `astryx-*` class + reflected `data-*` attribute surface. It's **internal** — not exported from `@astryxdesign/core` or its package exports — so this is a safe rename with no consumer impact.

## Changes
- `utils/xdsThemeProps.ts` → `utils/themeProps.ts` (+ its test file).
- `xdsThemeProps` → `themeProps`, `xdsThemeDataAttributes` → `themeDataAttributes`.
- All **162 files**: call sites + import paths across `@astryxdesign/core` and the private `lab` package, plus the `naming.ts` `SYNC:` comment.

## Scope
Internal helper only — no public API, no package scope, no behavior change (same classes/attrs emitted). No changeset. `check:sync` + `check:package-boundaries` green; the renamed file/functions are consistent across all call sites and the cross-package lab imports.
