### PR TITLE
fix(docsite): prevent home hero showing through on overscroll

### DIFF
--- a/apps/docsite/src/app/globals.css
+++ b/apps/docsite/src/app/globals.css
@@ -12,10 +12,8 @@
    reset, astryx-base, astryx-theme so product styles always win. */
 @stylex;
 
-/* Disable rubber-band overscroll. The home hero's pin-and-cover layers
-   (hero band, nav backdrop, aurora glow, floating cards) are position:fixed,
-   so an elastic bounce past the top/bottom exposes them behind the footer.
-   The (site) layout scrolls the document (AppShell height="auto"). */
+/* Disable overscroll bounce so the home hero's position:fixed layers can't
+   show through past the top/bottom of the page. */
 html {
   overscroll-behavior-y: none;
 }

--- a/apps/docsite/src/app/globals.css
+++ b/apps/docsite/src/app/globals.css
@@ -12,6 +12,14 @@
    reset, astryx-base, astryx-theme so product styles always win. */
 @stylex;
 
+/* Disable rubber-band overscroll. The home hero's pin-and-cover layers
+   (hero band, nav backdrop, aurora glow, floating cards) are position:fixed,
+   so an elastic bounce past the top/bottom exposes them behind the footer.
+   The (site) layout scrolls the document (AppShell height="auto"). */
+html {
+  overscroll-behavior-y: none;
+}
+
 /* Marketing-only custom properties for the docsite home page. These are
    NOT XDS theming tokens — they're docsite-specific values that back the
    landing page's bento feature cards + section rhythm — so they live here


### PR DESCRIPTION
## Summary

- On the docsite home page, scrolling to the very bottom and over-scrolling (rubber-band) revealed the hero content behind the footer — "the header showing through in the back."
- Root cause: the home hero uses a **pin-and-cover** effect where the hero band (wordmark, headline, CTAs), the nav backdrop strip, the aurora glow, and the floating cards are all `position: fixed`, and the showcase surface scrolls up over them. Those fixed layers stay pinned to the viewport for the entire page, so the elastic overscroll at the top/bottom lifts the in-flow content and exposes them behind the footer.
- Fix: set `overscroll-behavior-y: none` on the document scroller. The `(site)` layout uses `AppShell height="auto"`, so `html` owns the scroll. This removes the rubber-band bounce so the fixed layers can never be revealed.

This is a docsite-only change (`@astryxdesign/docsite` is private/ignored for releases), so no changeset is included.

## Test plan

- [ ] Run the docsite locally (`pnpm -F @astryxdesign/docsite dev`) and open the home page.
- [ ] Scroll to the very bottom and attempt to over-scroll/rubber-band past the footer — the page no longer bounces and the pinned hero (wordmark, cards, nav strip) no longer shows through behind the footer.
- [ ] Do the same at the very top (over-scroll upward) — no fixed layers exposed.
- [ ] Confirm normal scrolling, the hero pin-and-cover transition, anchor-link jumps, and the footer are all unaffected.

## Notes

`overscroll-behavior` reliably stops the bounce on desktop browsers (where this was reported). On iOS Safari the document-level rubber-band can still occur in some cases; if we want it bulletproof there, the alternative is bounding the fixed hero layers to the hero region (larger change to the tuned pin-and-cover).

Made with [Cursor](https://cursor.com)