### PR TITLE
test: update component test labels from xds-* to astryx-*

### DIFF
--- a/packages/core/src/Badge/Badge.test.tsx
+++ b/packages/core/src/Badge/Badge.test.tsx
@@ -48,7 +48,7 @@ describe('Badge', () => {
     }
   });
 
-  it('applies xds class name with non-semantic variant', () => {
+  it('applies astryx class name with non-semantic variant', () => {
     const {container} = render(<Badge variant="purple" label="Tag" />);
     const root = container.firstElementChild!;
     expect(root.className).toContain('astryx-badge');
@@ -74,7 +74,7 @@ describe('Badge', () => {
     expect(screen.getByTestId('custom-badge')).toBeInTheDocument();
   });
 
-  it('renders xds-* class names for theme targeting', () => {
+  it('renders astryx-* class names for theme targeting', () => {
     const {container} = render(<Badge variant="success" label="Active" />);
     const root = container.firstElementChild!;
     expect(root.className).toContain('astryx-badge');

--- a/packages/core/src/Blockquote/Blockquote.test.tsx
+++ b/packages/core/src/Blockquote/Blockquote.test.tsx
@@ -22,7 +22,7 @@ describe('Blockquote', () => {
     expect(element).toHaveTextContent('A quoted statement.');
   });
 
-  it('renders xds-* class name for theme targeting', () => {
+  it('renders astryx-* class name for theme targeting', () => {
     render(<Blockquote data-testid="bq">Quote</Blockquote>);
     const element = screen.getByTestId('bq');
     expect(element.className).toContain('astryx-blockquote');

--- a/packages/core/src/Button/Button.test.tsx
+++ b/packages/core/src/Button/Button.test.tsx
@@ -207,7 +207,7 @@ describe('Button', () => {
     expect(button).toHaveAttribute('aria-busy', 'true');
   });
 
-  it('renders xds-* classes and data attributes for theme targeting', () => {
+  it('renders astryx-* classes and data attributes for theme targeting', () => {
     render(<Button label="Test" variant="secondary" size="sm" />);
     const button = screen.getByRole('button');
     expect(button.className).toContain('astryx-button');

--- a/packages/core/src/Card/Card.test.tsx
+++ b/packages/core/src/Card/Card.test.tsx
@@ -10,7 +10,7 @@ describe('Card', () => {
     expect(getByText('Hello')).toBeInTheDocument();
   });
 
-  it('renders xds-* class names for theme targeting', () => {
+  it('renders astryx-* class names for theme targeting', () => {
     const {container} = render(<Card>Content</Card>);
     const root = container.firstElementChild!;
     expect(root.className).toContain('astryx-card');

--- a/packages/core/src/Carousel/Carousel.test.tsx
+++ b/packages/core/src/Carousel/Carousel.test.tsx
@@ -47,7 +47,7 @@ describe('Carousel', () => {
     expect(screen.getByTestId('my-carousel')).toBeInTheDocument();
   });
 
-  it('has correct xds class name', () => {
+  it('has correct astryx class name', () => {
     render(
       <Carousel data-testid="cls-test">
         <div>Item</div>

--- a/packages/core/src/Chat/ChatComposerInput.test.tsx
+++ b/packages/core/src/Chat/ChatComposerInput.test.tsx
@@ -562,8 +562,8 @@ describe('ChatComposerInput', () => {
     });
   });
 
-  describe('xds class names', () => {
-    it('has xds-chat-composer-input class', () => {
+  describe('astryx class names', () => {
+    it('has astryx-chat-composer-input class', () => {
       const {container} = render(<ChatComposerInput />);
       expect(
         container.querySelector('.astryx-chat-composer-input'),

--- a/packages/core/src/Divider/Divider.test.tsx
+++ b/packages/core/src/Divider/Divider.test.tsx
@@ -100,7 +100,7 @@ describe('Divider', () => {
     expect(screen.getByText('Vertical')).toBeInTheDocument();
   });
 
-  it('renders xds-* class names for theme targeting', () => {
+  it('renders astryx-* class names for theme targeting', () => {
     render(
       <Divider
         variant="strong"

--- a/packages/core/src/Heading/Heading.test.tsx
+++ b/packages/core/src/Heading/Heading.test.tsx
@@ -189,7 +189,7 @@ describe('Heading', () => {
     });
   });
 
-  it('renders xds-* classes and data attributes for theme targeting', () => {
+  it('renders astryx-* classes and data attributes for theme targeting', () => {
     render(
       <Heading level={2} color="secondary">
         Themed Heading

--- a/packages/core/src/Kbd/Kbd.test.tsx
+++ b/packages/core/src/Kbd/Kbd.test.tsx
@@ -90,7 +90,7 @@ describe('Kbd', () => {
     expect(screen.getByText('K')).toBeInTheDocument();
   });
 
-  it('renders xds-* class names for theme targeting', () => {
+  it('renders astryx-* class names for theme targeting', () => {
     const {container} = render(<Kbd keys="k" />);
     const wrapper = container.firstChild as HTMLElement;
     expect(wrapper.className).toContain('astryx-kbd');

--- a/packages/core/src/Link/Link.test.tsx
+++ b/packages/core/src/Link/Link.test.tsx
@@ -282,7 +282,7 @@ describe('Link', () => {
     expect(link).not.toHaveAttribute('data-another-link');
   });
 
-  it('renders xds-* class names for theme targeting', () => {
+  it('renders astryx-* class names for theme targeting', () => {
     render(
       <Link href="/test" color="secondary">
         Themed Link

--- a/packages/core/src/Markdown/Markdown.test.tsx
+++ b/packages/core/src/Markdown/Markdown.test.tsx
@@ -11,7 +11,7 @@ describe('Markdown', () => {
     expect(screen.getByRole('document')).toBeInTheDocument();
   });
 
-  it('renders xds-markdown class name', () => {
+  it('renders astryx-markdown class name', () => {
     const {container} = render(<Markdown>Hello</Markdown>);
     expect(container.firstElementChild!.className).toContain('astryx-markdown');
   });

--- a/packages/core/src/MoreMenu/MoreMenu.test.tsx
+++ b/packages/core/src/MoreMenu/MoreMenu.test.tsx
@@ -192,7 +192,7 @@ describe('MoreMenu', () => {
     expect(button.tagName).toBe('BUTTON');
   });
 
-  it('renders xds-more-menu class on dropdown panel for theme targeting', () => {
+  it('renders astryx-more-menu class on dropdown panel for theme targeting', () => {
     render(<MoreMenu items={defaultItems} />);
     const menu = screen.getByRole('menu', {hidden: true});
     expect(menu.className).toContain('astryx-more-menu');

--- a/packages/core/src/Section/Section.test.tsx
+++ b/packages/core/src/Section/Section.test.tsx
@@ -102,13 +102,13 @@ describe('Section', () => {
     expect(ref.current).toBeInstanceOf(HTMLDivElement);
   });
 
-  it('renders xds-* class names for theme targeting', () => {
+  it('renders astryx-* class names for theme targeting', () => {
     const {container} = render(<Section>Content</Section>);
     const inner = container.firstElementChild!.firstElementChild!;
     expect(inner.className).toContain('astryx-section');
   });
 
-  it('renders variant in xds class names', () => {
+  it('renders variant in astryx class names', () => {
     const {container} = render(
       <Section variant="muted">Content</Section>,
     );
@@ -157,7 +157,7 @@ describe('Section', () => {
     expect(screen.getByTestId('custom-section')).toBeInTheDocument();
   });
 
-  it('propagates explicit padding to nested sections via --xds-section-padding', () => {
+  it('propagates explicit padding to nested sections via --astryx-section-padding', () => {
     const {container} = render(
       <Section padding={6}>
         <Section data-testid="inner">Inner</Section>

--- a/packages/core/src/Text/Text.test.tsx
+++ b/packages/core/src/Text/Text.test.tsx
@@ -191,7 +191,7 @@ describe('Text', () => {
     });
   });
 
-  it('renders xds-* class names for theme targeting', () => {
+  it('renders astryx-* class names for theme targeting', () => {
     render(<Text type="body">Themed Text</Text>);
     const element = screen.getByText('Themed Text');
     expect(element.className).toContain('astryx-text');

--- a/packages/core/src/TreeList/TreeList.test.tsx
+++ b/packages/core/src/TreeList/TreeList.test.tsx
@@ -312,7 +312,7 @@ describe('TreeList', () => {
   // xds class name
   // ===========================================================================
 
-  it('applies xds-tree-list class name', () => {
+  it('applies astryx-tree-list class name', () => {
     render(<TreeList items={simpleItems} data-testid="tree" />);
     const root = screen.getByTestId('tree');
     expect(root.className).toContain('astryx-tree-list');


### PR DESCRIPTION
## Summary

Cosmetic test-label cleanup: the `it()` / `describe()` description strings in core component tests still read "renders **xds-\*** class names" / "applies **xds** class", but the assertions inside were already updated to `astryx-*` during the compat-layer removal. This aligns the human-readable labels with what the tests actually check.

## Scope
- 15 core component test files — **description strings only** (`it('renders astryx-* class names …')`, etc.).
- No assertions, selectors, or code changed — purely the label text.

## Excluded (owned elsewhere / intentional)
- `xdsThemeProps.test` and `tokens.test` `describe()` labels — those identifiers are renamed in their own open PRs (#3031, #3026).
- Intentional legacy-behavior labels — `agent-docs` "XDS markers", component-discovery "XDS{name}.tsx" — describe real `XDS`-prefix backward-compat and stay accurate.

No changeset (test labels only).
