### PR TITLE
refactor: drop XDS_ prefix from internal library-pattern constants

### DIFF
--- a/internal/vibe-tests/src/generate-a11y-manifest.ts
+++ b/internal/vibe-tests/src/generate-a11y-manifest.ts
@@ -19,7 +19,7 @@ import path from 'path';
 
 const VIBE_TESTS_DIR = path.join(import.meta.dirname, '..');
 const MANIFESTS_DIR = path.join(VIBE_TESTS_DIR, 'a11y-manifests');
-const XDS_CORE_DIR = path.join(
+const CORE_DIR = path.join(
   VIBE_TESTS_DIR,
   '..',
   '..',
@@ -198,7 +198,7 @@ function generateXDSManifest(): A11yManifest {
     return readmes;
   };
 
-  const readmePaths = findReadmes(XDS_CORE_DIR);
+  const readmePaths = findReadmes(CORE_DIR);
   console.log(`Found ${readmePaths.length} XDS component README files`);
 
   for (const readmePath of readmePaths) {

--- a/packages/build/src/babel.js
+++ b/packages/build/src/babel.js
@@ -11,7 +11,7 @@
  * Library files get 'astryx' prefix (.astryx78zum5), product files get 'x' (.x78zum5).
  */
 
-const XDS_LIBRARY_PATTERNS = [
+const LIBRARY_PATTERNS = [
   'packages/core/',
   'packages/themes/',
   'packages/lab/',
@@ -22,7 +22,7 @@ module.exports = function xdsBabelPlugin(api, options) {
   const stylexPlugin = require('@stylexjs/babel-plugin');
 
   const {
-    libraryPatterns = XDS_LIBRARY_PATTERNS,
+    libraryPatterns = LIBRARY_PATTERNS,
     libraryPrefix = 'astryx',
     classNamePrefix = 'x',
     ...stylexOptions

--- a/packages/build/src/index.js
+++ b/packages/build/src/index.js
@@ -26,8 +26,8 @@ const globParent = require('glob-parent');
 
 const PLUGIN_NAME = '@astryxdesign/postcss-plugin';
 
-const XDS_LIBRARY_GLOB = 'node_modules/@astryxdesign/**/*.{ts,tsx}';
-const XDS_LIBRARY_PATTERNS = ['node_modules/@astryxdesign/', 'packages/core/', 'packages/themes/'];
+const LIBRARY_GLOB = 'node_modules/@astryxdesign/**/*.{ts,tsx}';
+const LIBRARY_PATTERNS = ['node_modules/@astryxdesign/', 'packages/core/', 'packages/themes/'];
 const STYLEX_IMPORT_SOURCE = '@stylexjs/stylex';
 
 function parseDependency(fileOrGlob, cwd) {
@@ -84,12 +84,12 @@ function createPlugin() {
     // Class name prefix for library styles (product keeps default 'x')
     libraryPrefix = 'astryx',
     extraInclude = [],
-    libraryPatterns = XDS_LIBRARY_PATTERNS,
+    libraryPatterns = LIBRARY_PATTERNS,
     exclude = [],
   }) => {
     const include = [
       `${appDir}/**/*.{js,jsx,ts,tsx}`,
-      XDS_LIBRARY_GLOB,
+      LIBRARY_GLOB,
       ...extraInclude,
     ];
 

--- a/packages/build/src/vite.ts
+++ b/packages/build/src/vite.ts
@@ -8,7 +8,7 @@ import {fileURLToPath} from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-const XDS_LIBRARY_PATTERN = 'node_modules/@astryxdesign/';
+const LIBRARY_PATTERN = 'node_modules/@astryxdesign/';
 const STYLEX_CSS_PATH = '/virtual:stylex.css';
 
 /**
@@ -121,7 +121,7 @@ export function xdsStylex(
   const {
     dev = process.env.NODE_ENV !== 'production',
     rootDir = process.cwd(),
-    libraryPattern = XDS_LIBRARY_PATTERN,
+    libraryPattern = LIBRARY_PATTERN,
     layers = {},
     lightningcssTargets,
     stylexPrefix = 'astryx',
@@ -305,7 +305,7 @@ export function xdsStylex(
 function xdsStylexLegacy(options: XDSVitePluginLegacyOptions): Plugin[] {
   const {
     stylexOptions,
-    libraryPattern = XDS_LIBRARY_PATTERN,
+    libraryPattern = LIBRARY_PATTERN,
     stylexPrefix = 'astryx',
     layers = {},
   } = options;


### PR DESCRIPTION
## Summary

Drops the `XDS_` prefix from internal (non-exported) JS constants — the last cosmetic internal-identifier slice of the scrub.

## Changes
- `@xds/build`: `XDS_LIBRARY_PATTERNS` → `LIBRARY_PATTERNS`, `XDS_LIBRARY_GLOB` → `LIBRARY_GLOB`, `XDS_LIBRARY_PATTERN` → `LIBRARY_PATTERN` (`babel.js`, `index.js`, `vite.ts`).
- `vibe-tests`: `XDS_CORE_DIR` → `CORE_DIR`.

None of these are exported — purely internal names. No public API change, no changeset.

## Deliberately left
- `XDS_MARKER_START`/`XDS_MARKER_END` — their **values** (`<!-- XDS:START -->` / `<!-- XDS:END -->`) are the agent-docs marker contract written into consumers' AGENTS.md files; renaming would break idempotent re-runs.
- Codemod consts `XDS_CORE_SOURCE` (`/^@xds\/core/` regex) and `XDS_LAYOUT_ELEMENTS` — intentional legacy-name targeting in transforms.

Verified self-consistent (def + all refs) and all files pass `node --check`; gates green.
