### PR TITLE
feat(docsite): render the components feature card with live components (dark-mode aware)

### DIFF
--- a/apps/docsite/src/app/(site)/_landing/CliPreview.tsx
+++ b/apps/docsite/src/app/(site)/_landing/CliPreview.tsx
@@ -1,0 +1,127 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import {useState} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {Send, Check} from 'lucide-react';
+import {VStack, HStack} from '@astryxdesign/core/Layout';
+import {IconButton} from '@astryxdesign/core/IconButton';
+import {Text} from '@astryxdesign/core/Text';
+import {
+  colorVars,
+  spacingVars,
+  radiusVars,
+  shadowVars,
+} from '@astryxdesign/core/theme/tokens.stylex';
+
+// Live "chat composer" composition for the home page's CLI feature
+// card ("A design system that your agent can use"). This replaces the
+// former baked PNG (/feature-cli.png) which could not adapt to dark
+// mode — it stayed light on the dark surface. Rendering real, theme-
+// aware markup instead means the preview re-themes automatically via
+// the same light-dark() tokens every other component uses, so it
+// reads correctly in both light and dark.
+//
+// The composition mirrors the reference screenshot, top to bottom:
+//   1. muted helper text ("How can i help you today?")
+//   2. a single chat-input "pill": a rounded surface bar holding the
+//      message text + a circular send button (paper-plane icon)
+//
+// Why a hand-composed pill instead of <ChatComposer>: the reference is
+// a single-line input bar (text left, circular send button right).
+// ChatComposer is a multi-row layout shell — it renders the input and
+// the send button on separate rows and carries its own popover
+// surface + hover/focus shadows — so it neither matches the one-line
+// pill shape nor stays lightweight for a decorative preview. TextInput
+// can't hold a trailing button (it only exposes startIcon), so the
+// cleanest theme-aware match is a surface-token pill + the real
+// IconButton for the circular send affordance.
+//
+// The send button is decorative but kept as a genuine, interactive
+// IconButton (with minimal local "sent" state) rather than static
+// markup, mirroring ComponentsPreview — the preview still behaves like
+// a real component if poked.
+
+const styles = stylex.create({
+  // Outer frame. The card supplies the 40px inset padding around the
+  // preview (innerPaddingImageInset via the previewWrap), so this just
+  // stacks the helper text above the pill. maxWidth keeps the composer
+  // from stretching uncomfortably wide on the desktop bento card while
+  // staying fluid on narrow screens.
+  root: {
+    width: '100%',
+    maxWidth: 360,
+    marginInline: 'auto',
+  },
+  // Nudge the helper text in so it aligns with the pill's text rather
+  // than sitting flush against the pill's rounded left edge — matches
+  // the reference where the helper text is slightly inset.
+  helper: {
+    paddingInlineStart: spacingVars['--spacing-3'],
+  },
+  // The chat-input pill. Uses a surface token for the background so it
+  // inverts in dark mode (white in light, dark surface in dark), a
+  // full radius for the pill shape, and a soft shadow so it lifts off
+  // the card's pastel backdrop like the reference. Generous inline
+  // padding on the start (text) side; tighter on the end so the round
+  // send button sits in a balanced inset.
+  pill: {
+    width: '100%',
+    backgroundColor: colorVars['--color-background-surface'],
+    borderRadius: radiusVars['--radius-full'],
+    boxShadow: shadowVars['--shadow-low'],
+    paddingBlock: spacingVars['--spacing-2'],
+    paddingInlineStart: spacingVars['--spacing-5'],
+    paddingInlineEnd: spacingVars['--spacing-2'],
+  },
+  // Message text fills the row and truncates rather than wrapping so
+  // the pill keeps its single-line height on narrow cards.
+  message: {
+    minWidth: 0,
+    flex: 1,
+  },
+  // Circular send button — overrides IconButton's variant surface with
+  // the inverted token so it reads as the near-black filled circle in
+  // the reference (and flips to a light circle in dark mode, proving
+  // the whole preview is theme-aware). xstyle is applied last by
+  // Button, so these win over the variant's own colors.
+  sendButton: {
+    borderRadius: radiusVars['--radius-full'],
+    flexShrink: 0,
+    backgroundColor: colorVars['--color-background-inverted'],
+    color: colorVars['--color-background-surface'],
+  },
+});
+
+export function CliPreview() {
+  // Decorative state — the send button toggles a transient "sent" look
+  // so the preview is a real, pokeable component rather than static
+  // markup. It resets on its own so the reference composition is what
+  // the page shows at rest.
+  const [sent, setSent] = useState(false);
+
+  return (
+    <VStack gap={3} align="stretch" xstyle={styles.root}>
+      <Text type="supporting" color="secondary" xstyle={styles.helper}>
+        How can i help you today?
+      </Text>
+
+      <HStack gap={2} vAlign="center" hAlign="between" xstyle={styles.pill}>
+        <Text type="body" color="primary" maxLines={1} xstyle={styles.message}>
+          Can you create me a table page
+        </Text>
+        <IconButton
+          label={sent ? 'Message sent' : 'Send message'}
+          icon={sent ? <Check size={16} /> : <Send size={16} />}
+          size="md"
+          onClick={() => {
+            setSent(true);
+            window.setTimeout(() => setSent(false), 600);
+          }}
+          xstyle={styles.sendButton}
+        />
+      </HStack>
+    </VStack>
+  );
+}

--- a/apps/docsite/src/app/(site)/_landing/CliPreview.tsx
+++ b/apps/docsite/src/app/(site)/_landing/CliPreview.tsx
@@ -15,57 +15,15 @@ import {
   shadowVars,
 } from '@astryxdesign/core/theme/tokens.stylex';
 
-// Live "chat composer" composition for the home page's CLI feature
-// card ("A design system that your agent can use"). This replaces the
-// former baked PNG (/feature-cli.png) which could not adapt to dark
-// mode — it stayed light on the dark surface. Rendering real, theme-
-// aware markup instead means the preview re-themes automatically via
-// the same light-dark() tokens every other component uses, so it
-// reads correctly in both light and dark.
-//
-// The composition mirrors the reference screenshot, top to bottom:
-//   1. muted helper text ("How can i help you today?")
-//   2. a single chat-input "pill": a rounded surface bar holding the
-//      message text + a circular send button (paper-plane icon)
-//
-// Why a hand-composed pill instead of <ChatComposer>: the reference is
-// a single-line input bar (text left, circular send button right).
-// ChatComposer is a multi-row layout shell — it renders the input and
-// the send button on separate rows and carries its own popover
-// surface + hover/focus shadows — so it neither matches the one-line
-// pill shape nor stays lightweight for a decorative preview. TextInput
-// can't hold a trailing button (it only exposes startIcon), so the
-// cleanest theme-aware match is a surface-token pill + the real
-// IconButton for the circular send affordance.
-//
-// The send button is decorative but kept as a genuine, interactive
-// IconButton (with minimal local "sent" state) rather than static
-// markup, mirroring ComponentsPreview — the preview still behaves like
-// a real component if poked.
-
 const styles = stylex.create({
-  // Outer frame. The card supplies the 40px inset padding around the
-  // preview (innerPaddingImageInset via the previewWrap), so this just
-  // stacks the helper text above the pill. maxWidth keeps the composer
-  // from stretching uncomfortably wide on the desktop bento card while
-  // staying fluid on narrow screens.
   root: {
     width: '100%',
     maxWidth: 360,
     marginInline: 'auto',
   },
-  // Nudge the helper text in so it aligns with the pill's text rather
-  // than sitting flush against the pill's rounded left edge — matches
-  // the reference where the helper text is slightly inset.
   helper: {
     paddingInlineStart: spacingVars['--spacing-3'],
   },
-  // The chat-input pill. Uses a surface token for the background so it
-  // inverts in dark mode (white in light, dark surface in dark), a
-  // full radius for the pill shape, and a soft shadow so it lifts off
-  // the card's pastel backdrop like the reference. Generous inline
-  // padding on the start (text) side; tighter on the end so the round
-  // send button sits in a balanced inset.
   pill: {
     width: '100%',
     backgroundColor: colorVars['--color-background-surface'],
@@ -75,17 +33,10 @@ const styles = stylex.create({
     paddingInlineStart: spacingVars['--spacing-5'],
     paddingInlineEnd: spacingVars['--spacing-2'],
   },
-  // Message text fills the row and truncates rather than wrapping so
-  // the pill keeps its single-line height on narrow cards.
   message: {
     minWidth: 0,
     flex: 1,
   },
-  // Circular send button — overrides IconButton's variant surface with
-  // the inverted token so it reads as the near-black filled circle in
-  // the reference (and flips to a light circle in dark mode, proving
-  // the whole preview is theme-aware). xstyle is applied last by
-  // Button, so these win over the variant's own colors.
   sendButton: {
     borderRadius: radiusVars['--radius-full'],
     flexShrink: 0,
@@ -95,10 +46,6 @@ const styles = stylex.create({
 });
 
 export function CliPreview() {
-  // Decorative state — the send button toggles a transient "sent" look
-  // so the preview is a real, pokeable component rather than static
-  // markup. It resets on its own so the reference composition is what
-  // the page shows at rest.
   const [sent, setSent] = useState(false);
 
   return (

--- a/apps/docsite/src/app/(site)/_landing/ComponentsPreview.tsx
+++ b/apps/docsite/src/app/(site)/_landing/ComponentsPreview.tsx
@@ -15,47 +15,17 @@ import {Switch} from '@astryxdesign/core/Switch';
 import {TextInput} from '@astryxdesign/core/TextInput';
 import {spacingVars} from '@astryxdesign/core/theme/tokens.stylex';
 
-// Live "sampler" composition for the home page's "Over N components"
-// feature card. This replaces the former baked PNG
-// (/feature-components.png) which could not adapt to dark mode — it
-// stayed light on the dark surface. Rendering the real XDS components
-// instead means the preview re-themes automatically via the same
-// light-dark() tokens every other component uses, so it reads
-// correctly in both light and dark.
-//
-// The composition mirrors the original screenshot, top to bottom:
-//   1. two Badges (orange + blue) + a bare radio, checkbox, and switch
-//   2. a Secondary and a Primary button
-//   3. a search TextInput (leading search icon, clear button)
-//
-// Everything is decorative, so the controls carry hidden labels and
-// fixed "checked"/"on"/"selected" states. They keep minimal local
-// state so they remain genuine, interactive components (not static
-// markup) — the preview still behaves like the real thing if poked.
-
 const styles = stylex.create({
-  // Outer frame. The card supplies the 40px inset padding around the
-  // preview (innerPaddingImageInset), so this just stacks the three
-  // rows with even spacing and centers them in the available space.
-  // maxWidth keeps the sampler from stretching uncomfortably wide on
-  // the desktop bento card while staying fluid on narrow screens.
   root: {
     width: '100%',
     maxWidth: 360,
     marginInline: 'auto',
   },
-  // Row 1: badges + form controls, distributed evenly across the full
-  // row width (hAlign="evenly" → space-evenly). The small gap is just a
-  // min spacing for the wrap case; rowGap adds vertical spacing if the
-  // row wraps on a very narrow card so nothing clips.
   controlsRow: {
     rowGap: spacingVars['--spacing-3'],
   },
 });
 
-// Full-width buttons so each fills its equal-width Grid cell and the
-// pair reads as a balanced Secondary | Primary row like the reference.
-// (Button sizes to content by default.)
 const buttonStyles = stylex.create({
   fill: {
     width: '100%',
@@ -63,10 +33,6 @@ const buttonStyles = stylex.create({
 });
 
 export function ComponentsPreview() {
-  // Decorative state — seeded to the "active" look shown in the
-  // reference (checkbox checked, switch on). They stay interactive so
-  // the sampler is a real, pokeable component rather than a static
-  // mock.
   const [checked, setChecked] = useState(true);
   const [on, setOn] = useState(true);
   const [search, setSearch] = useState('');
@@ -87,9 +53,6 @@ export function ComponentsPreview() {
           size="md"
           value=""
           onChange={() => {}}>
-          {/* Empty label keeps just the bare radio circle (unselected,
-              since the group value never matches) to match the
-              reference's label-less control trio. */}
           <RadioListItem label="" value="sample" />
         </RadioList>
         <CheckboxInput

--- a/apps/docsite/src/app/(site)/_landing/ComponentsPreview.tsx
+++ b/apps/docsite/src/app/(site)/_landing/ComponentsPreview.tsx
@@ -44,9 +44,10 @@ const styles = stylex.create({
     maxWidth: 360,
     marginInline: 'auto',
   },
-  // Row 1: badges + form controls, evenly spaced. The HStack handles
-  // the row gap + center cross-alignment; rowGap here only adds vertical
-  // spacing if the row wraps on a very narrow card so nothing clips.
+  // Row 1: badges + form controls, distributed evenly across the full
+  // row width (hAlign="evenly" → space-evenly). The small gap is just a
+  // min spacing for the wrap case; rowGap adds vertical spacing if the
+  // row wraps on a very narrow card so nothing clips.
   controlsRow: {
     rowGap: spacingVars['--spacing-3'],
   },
@@ -73,8 +74,8 @@ export function ComponentsPreview() {
   return (
     <VStack gap={4} align="stretch" xstyle={styles.root}>
       <HStack
-        gap={3}
-        hAlign="start"
+        gap={2}
+        hAlign="evenly"
         vAlign="center"
         wrap="wrap"
         xstyle={styles.controlsRow}>

--- a/apps/docsite/src/app/(site)/_landing/ComponentsPreview.tsx
+++ b/apps/docsite/src/app/(site)/_landing/ComponentsPreview.tsx
@@ -44,17 +44,11 @@ const styles = stylex.create({
     maxWidth: 360,
     marginInline: 'auto',
   },
-  // Row 1: badges + form controls. The HStack handles the row gap +
-  // center cross-alignment; rowGap here only adds vertical spacing if
-  // the row wraps on a very narrow card so nothing clips.
+  // Row 1: badges + form controls, evenly spaced. The HStack handles
+  // the row gap + center cross-alignment; rowGap here only adds vertical
+  // spacing if the row wraps on a very narrow card so nothing clips.
   controlsRow: {
     rowGap: spacingVars['--spacing-3'],
-  },
-  // Pushes the form-control trio to the right edge so the badges sit
-  // left and the controls sit right, matching the reference's spread.
-  controlsSpacer: {
-    flex: 1,
-    minWidth: spacingVars['--spacing-2'],
   },
 });
 
@@ -86,7 +80,6 @@ export function ComponentsPreview() {
         xstyle={styles.controlsRow}>
         <Badge variant="orange" label="Badge" />
         <Badge variant="blue" label="Badge" />
-        <span {...stylex.props(styles.controlsSpacer)} />
         <RadioList
           label="Sample option"
           isLabelHidden

--- a/apps/docsite/src/app/(site)/_landing/ComponentsPreview.tsx
+++ b/apps/docsite/src/app/(site)/_landing/ComponentsPreview.tsx
@@ -84,7 +84,7 @@ export function ComponentsPreview() {
         <RadioList
           label="Sample option"
           isLabelHidden
-          size="sm"
+          size="md"
           value=""
           onChange={() => {}}>
           {/* Empty label keeps just the bare radio circle (unselected,
@@ -95,7 +95,7 @@ export function ComponentsPreview() {
         <CheckboxInput
           label="Sample checkbox"
           isLabelHidden
-          size="sm"
+          size="md"
           value={checked}
           onChange={setChecked}
         />

--- a/apps/docsite/src/app/(site)/_landing/ComponentsPreview.tsx
+++ b/apps/docsite/src/app/(site)/_landing/ComponentsPreview.tsx
@@ -1,0 +1,136 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import {useState} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {Search} from 'lucide-react';
+import {VStack, HStack} from '@astryxdesign/core/Layout';
+import {Grid} from '@astryxdesign/core/Grid';
+import {Badge} from '@astryxdesign/core/Badge';
+import {Button} from '@astryxdesign/core/Button';
+import {CheckboxInput} from '@astryxdesign/core/CheckboxInput';
+import {RadioList, RadioListItem} from '@astryxdesign/core/RadioList';
+import {Switch} from '@astryxdesign/core/Switch';
+import {TextInput} from '@astryxdesign/core/TextInput';
+import {spacingVars} from '@astryxdesign/core/theme/tokens.stylex';
+
+// Live "sampler" composition for the home page's "Over N components"
+// feature card. This replaces the former baked PNG
+// (/feature-components.png) which could not adapt to dark mode — it
+// stayed light on the dark surface. Rendering the real XDS components
+// instead means the preview re-themes automatically via the same
+// light-dark() tokens every other component uses, so it reads
+// correctly in both light and dark.
+//
+// The composition mirrors the original screenshot, top to bottom:
+//   1. two Badges (orange + blue) + a bare radio, checkbox, and switch
+//   2. a Secondary and a Primary button
+//   3. a search TextInput (leading search icon, clear button)
+//
+// Everything is decorative, so the controls carry hidden labels and
+// fixed "checked"/"on"/"selected" states. They keep minimal local
+// state so they remain genuine, interactive components (not static
+// markup) — the preview still behaves like the real thing if poked.
+
+const styles = stylex.create({
+  // Outer frame. The card supplies the 40px inset padding around the
+  // preview (innerPaddingImageInset), so this just stacks the three
+  // rows with even spacing and centers them in the available space.
+  // maxWidth keeps the sampler from stretching uncomfortably wide on
+  // the desktop bento card while staying fluid on narrow screens.
+  root: {
+    width: '100%',
+    maxWidth: 360,
+    marginInline: 'auto',
+  },
+  // Row 1: badges + form controls. The HStack handles the row gap +
+  // center cross-alignment; rowGap here only adds vertical spacing if
+  // the row wraps on a very narrow card so nothing clips.
+  controlsRow: {
+    rowGap: spacingVars['--spacing-3'],
+  },
+  // Pushes the form-control trio to the right edge so the badges sit
+  // left and the controls sit right, matching the reference's spread.
+  controlsSpacer: {
+    flex: 1,
+    minWidth: spacingVars['--spacing-2'],
+  },
+});
+
+// Full-width buttons so each fills its equal-width Grid cell and the
+// pair reads as a balanced Secondary | Primary row like the reference.
+// (Button sizes to content by default.)
+const buttonStyles = stylex.create({
+  fill: {
+    width: '100%',
+  },
+});
+
+export function ComponentsPreview() {
+  // Decorative state — seeded to the "active" look shown in the
+  // reference (checkbox checked, switch on). They stay interactive so
+  // the sampler is a real, pokeable component rather than a static
+  // mock.
+  const [checked, setChecked] = useState(true);
+  const [on, setOn] = useState(true);
+  const [search, setSearch] = useState('');
+
+  return (
+    <VStack gap={4} align="stretch" xstyle={styles.root}>
+      <HStack
+        gap={3}
+        hAlign="start"
+        vAlign="center"
+        wrap="wrap"
+        xstyle={styles.controlsRow}>
+        <Badge variant="orange" label="Badge" />
+        <Badge variant="blue" label="Badge" />
+        <span {...stylex.props(styles.controlsSpacer)} />
+        <RadioList
+          label="Sample option"
+          isLabelHidden
+          size="sm"
+          value=""
+          onChange={() => {}}>
+          {/* Empty label keeps just the bare radio circle (unselected,
+              since the group value never matches) to match the
+              reference's label-less control trio. */}
+          <RadioListItem label="" value="sample" />
+        </RadioList>
+        <CheckboxInput
+          label="Sample checkbox"
+          isLabelHidden
+          size="sm"
+          value={checked}
+          onChange={setChecked}
+        />
+        <Switch
+          label="Sample switch"
+          isLabelHidden
+          value={on}
+          onChange={setOn}
+        />
+      </HStack>
+
+      <Grid columns={2} gap={3}>
+        <Button
+          variant="secondary"
+          label="Secondary"
+          xstyle={buttonStyles.fill}
+        />
+        <Button variant="primary" label="Primary" xstyle={buttonStyles.fill} />
+      </Grid>
+
+      <TextInput
+        label="Search components"
+        isLabelHidden
+        placeholder="Search..."
+        value={search}
+        onChange={setSearch}
+        startIcon={Search}
+        hasClear
+      />
+    </VStack>
+  );
+}

--- a/apps/docsite/src/app/(site)/_landing/FeaturesShowcase.tsx
+++ b/apps/docsite/src/app/(site)/_landing/FeaturesShowcase.tsx
@@ -12,6 +12,7 @@ import {spacingVars} from '@astryxdesign/core/theme/tokens.stylex';
 import {components} from '../../../generated/componentRegistry';
 import {layout} from '../../../layout.stylex';
 import {ComponentsPreview} from './ComponentsPreview';
+import {CliPreview} from './CliPreview';
 
 // Count of public @astryxdesign/core components (excluding hooks and hidden entries).
 // Sourced from the generated registry so the number stays accurate as the
@@ -384,10 +385,10 @@ const features: Record<string, Feature> = {
     description:
       'Scaffold projects, browse templates, generate themes, and get agent-ready docs from the command line or MCP.',
     href: '/docs/cli',
-    image: {
-      src: '/feature-cli.png',
-      alt: 'AI prompt input asking "Can you create me a table page" with a send button',
-    },
+    // Live, theme-aware chat composer instead of a baked PNG — the old
+    // /feature-cli.png stayed light on the dark surface; CliPreview
+    // re-themes for dark mode.
+    preview: <CliPreview />,
   },
 };
 
@@ -609,7 +610,7 @@ export function FeaturesShowcase() {
         </VStack>
         <VStack gap={8} width="100%" height="100%" xstyle={styles.column}>
           <FeatureCard feature={features.components} isFlex insetImage />
-          <FeatureCard feature={features.cli} smallImage />
+          <FeatureCard feature={features.cli} />
         </VStack>
         <VStack gap={8} width="100%" height="100%" xstyle={styles.column}>
           <FeatureCard feature={features.templates} isTall />

--- a/apps/docsite/src/app/(site)/_landing/FeaturesShowcase.tsx
+++ b/apps/docsite/src/app/(site)/_landing/FeaturesShowcase.tsx
@@ -275,14 +275,7 @@ const styles = stylex.create({
     maxWidth: '100%',
     overflow: 'hidden',
   },
-  // Wrapper for the live components preview (the "Over N components"
-  // card). Mirrors imageWrapInset's inset/framed treatment so the
-  // sampler sits where the old PNG did: marginTop:auto pushes it to
-  // the bottom of the card's content stack, paddingTop keeps the same
-  // 40px gap below the "Explore" link, and alignSelf:stretch lets the
-  // centered HStack span the inner width so its content centers
-  // horizontally. No negative inline margins (unlike the full-bleed
-  // wrappers) — the preview stays inside the card's inset padding.
+  // Inset wrapper for a live preview node, pinned to the card's bottom.
   previewWrap: {
     marginTop: 'auto',
     paddingTop: spacingVars['--spacing-10'],
@@ -333,14 +326,7 @@ type Feature = {
     src: string;
     alt: string;
   };
-  /**
-   * Optional live preview node rendered below the description in place
-   * of an image. Used by the "components" card to render real XDS
-   * components (instead of a baked PNG) so the sampler is theme-aware
-   * and adapts to dark mode. When set, it is framed with the same
-   * inset treatment as an `insetImage` card. Takes precedence over
-   * `image` when both happen to be present.
-   */
+  /** Live, theme-aware preview node rendered in place of an image. */
   preview?: ReactNode;
 };
 
@@ -441,11 +427,6 @@ function FeatureCard({
 }) {
   const hasImage = feature.image != null;
   const hasPreview = feature.preview != null;
-  // A card has "media" if it renders either a baked image or a live
-  // preview node below the text. Both get the same card/padding
-  // treatment (an inset/framed media block), so the layout matches
-  // whether the components card uses the old PNG or the new live
-  // sampler.
   const hasMedia = hasImage || hasPreview;
   // Style precedence:
   //   1. isTall   → cardTall (right-column dominant card)
@@ -492,10 +473,7 @@ function FeatureCard({
           Explore →
         </Link>
         {hasPreview ? (
-          // Live preview (real XDS components) framed with the same
-          // inset wrapper an insetImage card uses, so the sampler sits
-          // in the card exactly where the old PNG did — but theme-aware.
-          // vAlign="center" + hAlign="center" centers the sampler in
+          // vAlign="center" + hAlign="center" centers the preview in
           // the card's leftover vertical+horizontal space.
           <HStack hAlign="center" vAlign="center" xstyle={styles.previewWrap}>
             {feature.preview}

--- a/apps/docsite/src/app/(site)/_landing/FeaturesShowcase.tsx
+++ b/apps/docsite/src/app/(site)/_landing/FeaturesShowcase.tsx
@@ -472,7 +472,7 @@ function FeatureCard({
         height="100%"
         xstyle={
           hasMedia
-            ? insetImage
+            ? insetImage || hasPreview
               ? styles.innerPaddingImageInset
               : styles.innerPaddingImage
             : styles.innerPaddingText

--- a/apps/docsite/src/app/(site)/_landing/FeaturesShowcase.tsx
+++ b/apps/docsite/src/app/(site)/_landing/FeaturesShowcase.tsx
@@ -2,6 +2,7 @@
 
 'use client';
 
+import type {ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {Card} from '@astryxdesign/core/Card';
 import {VStack, HStack} from '@astryxdesign/core/Layout';
@@ -10,6 +11,7 @@ import {Link} from '@astryxdesign/core/Link';
 import {spacingVars} from '@astryxdesign/core/theme/tokens.stylex';
 import {components} from '../../../generated/componentRegistry';
 import {layout} from '../../../layout.stylex';
+import {ComponentsPreview} from './ComponentsPreview';
 
 // Count of public @astryxdesign/core components (excluding hooks and hidden entries).
 // Sourced from the generated registry so the number stays accurate as the
@@ -272,6 +274,22 @@ const styles = stylex.create({
     maxWidth: '100%',
     overflow: 'hidden',
   },
+  // Wrapper for the live components preview (the "Over N components"
+  // card). Mirrors imageWrapInset's inset/framed treatment so the
+  // sampler sits where the old PNG did: marginTop:auto pushes it to
+  // the bottom of the card's content stack, paddingTop keeps the same
+  // 40px gap below the "Explore" link, and alignSelf:stretch lets the
+  // centered HStack span the inner width so its content centers
+  // horizontally. No negative inline margins (unlike the full-bleed
+  // wrappers) — the preview stays inside the card's inset padding.
+  previewWrap: {
+    marginTop: 'auto',
+    paddingTop: spacingVars['--spacing-10'],
+    alignSelf: 'stretch',
+    width: '100%',
+    minWidth: 0,
+    maxWidth: '100%',
+  },
   // Default image: full-bleed to the card width (no max-width cap) so
   // it spans edge-to-edge. height:auto preserves natural aspect ratio.
   // display:block kills the inline baseline gap so there's no mystery
@@ -314,6 +332,15 @@ type Feature = {
     src: string;
     alt: string;
   };
+  /**
+   * Optional live preview node rendered below the description in place
+   * of an image. Used by the "components" card to render real XDS
+   * components (instead of a baked PNG) so the sampler is theme-aware
+   * and adapts to dark mode. When set, it is framed with the same
+   * inset treatment as an `insetImage` card. Takes precedence over
+   * `image` when both happen to be present.
+   */
+  preview?: ReactNode;
 };
 
 // Looked up by slot key in the JSX below so each card's position in
@@ -327,10 +354,10 @@ const features: Record<string, Feature> = {
     description:
       'Accessible and themeable React components with built-in spacing, dark mode, and flexible styling.',
     href: '/components',
-    image: {
-      src: '/feature-components.png',
-      alt: 'Sample XDS components — Badges, radio, checkbox, switch, Secondary and Primary buttons, and a search input',
-    },
+    // Live, theme-aware sampler of real XDS components instead of a
+    // baked PNG — the old /feature-components.png stayed light on the
+    // dark surface; ComponentsPreview re-themes for dark mode.
+    preview: <ComponentsPreview />,
   },
   themes: {
     title: 'Themes that fit your brand',
@@ -339,7 +366,7 @@ const features: Record<string, Feature> = {
     href: '/themes',
     image: {
       src: '/feature-brand.png',
-      alt: 'A product landing page styled with the Butter theme, shown alongside the theme\'s color swatches and type sample',
+      alt: "A product landing page styled with the Butter theme, shown alongside the theme's color swatches and type sample",
     },
   },
   templates: {
@@ -412,17 +439,24 @@ function FeatureCard({
   smallImage?: boolean;
 }) {
   const hasImage = feature.image != null;
+  const hasPreview = feature.preview != null;
+  // A card has "media" if it renders either a baked image or a live
+  // preview node below the text. Both get the same card/padding
+  // treatment (an inset/framed media block), so the layout matches
+  // whether the components card uses the old PNG or the new live
+  // sampler.
+  const hasMedia = hasImage || hasPreview;
   // Style precedence:
   //   1. isTall   → cardTall (right-column dominant card)
-  //   2. isFlex   → cardFlex (grow-to-fill image card)
-  //   3. hasImage → card     (natural-height image card)
+  //   2. isFlex   → cardFlex (grow-to-fill media card)
+  //   3. hasMedia → card     (natural-height media card)
   //   4. else     → cardTextOnly (shrink-to-content text-only card)
   // Only one of these applies at a time.
   const cardStyle = isTall
     ? styles.cardTall
     : isFlex
       ? styles.cardFlex
-      : hasImage
+      : hasMedia
         ? styles.card
         : styles.cardTextOnly;
 
@@ -436,7 +470,7 @@ function FeatureCard({
         align="start"
         height="100%"
         xstyle={
-          hasImage
+          hasMedia
             ? insetImage
               ? styles.innerPaddingImageInset
               : styles.innerPaddingImage
@@ -456,42 +490,54 @@ function FeatureCard({
           xstyle={styles.exploreLink}>
           Explore →
         </Link>
-        {hasImage && feature.image && (
-          // HStack handles the flex+direction+alignment chrome;
-          // marginTop/padding/overflow/sizing live in the xstyle.
-          // No width prop: the wrapper's width is set in the xstyle to
-          // calc(100% + 2×40px) so it can exceed the inset parent and
-          // bleed the image to the card edges (a width="100%" prop here
-          // would win over the xstyle and clamp it back to the inset).
-          <HStack
-            hAlign={isTall || smallImage ? 'center' : 'start'}
-            xstyle={
-              isTall
-                ? styles.imageWrapTall
-                : insetImage
-                  ? styles.imageWrapInset
-                  : centerImage
-                    ? styles.imageWrapCentered
-                    : styles.imageWrap
-            }>
-            {/* Decorative image — kept as a raw <img> because @astryxdesign/core
+        {hasPreview ? (
+          // Live preview (real XDS components) framed with the same
+          // inset wrapper an insetImage card uses, so the sampler sits
+          // in the card exactly where the old PNG did — but theme-aware.
+          // vAlign="center" + hAlign="center" centers the sampler in
+          // the card's leftover vertical+horizontal space.
+          <HStack hAlign="center" vAlign="center" xstyle={styles.previewWrap}>
+            {feature.preview}
+          </HStack>
+        ) : (
+          hasImage &&
+          feature.image && (
+            // HStack handles the flex+direction+alignment chrome;
+            // marginTop/padding/overflow/sizing live in the xstyle.
+            // No width prop: the wrapper's width is set in the xstyle to
+            // calc(100% + 2×40px) so it can exceed the inset parent and
+            // bleed the image to the card edges (a width="100%" prop here
+            // would win over the xstyle and clamp it back to the inset).
+            <HStack
+              hAlign={isTall || smallImage ? 'center' : 'start'}
+              xstyle={
+                isTall
+                  ? styles.imageWrapTall
+                  : insetImage
+                    ? styles.imageWrapInset
+                    : centerImage
+                      ? styles.imageWrapCentered
+                      : styles.imageWrap
+              }>
+              {/* Decorative image — kept as a raw <img> because @astryxdesign/core
                 does not export a dedicated Image primitive (Thumbnail
                 is a chat/attachment chrome, not a fit-to-container
                 marketing image). Sizing + display:block come from the
                 featureImage / featureImageTall / featureImageSmall
                 xstyles below. */}
-            <img
-              src={feature.image.src}
-              alt={feature.image.alt}
-              {...stylex.props(
-                isTall
-                  ? styles.featureImageTall
-                  : smallImage
-                    ? styles.featureImageSmall
-                    : styles.featureImage,
-              )}
-            />
-          </HStack>
+              <img
+                src={feature.image.src}
+                alt={feature.image.alt}
+                {...stylex.props(
+                  isTall
+                    ? styles.featureImageTall
+                    : smallImage
+                      ? styles.featureImageSmall
+                      : styles.featureImage,
+                )}
+              />
+            </HStack>
+          )
         )}
       </VStack>
     </Card>
@@ -562,12 +608,7 @@ export function FeaturesShowcase() {
           <FeatureCard feature={features.themes} isFlex centerImage />
         </VStack>
         <VStack gap={8} width="100%" height="100%" xstyle={styles.column}>
-          <FeatureCard
-            feature={features.components}
-            isFlex
-            insetImage
-            smallImage
-          />
+          <FeatureCard feature={features.components} isFlex insetImage />
           <FeatureCard feature={features.cli} smallImage />
         </VStack>
         <VStack gap={8} width="100%" height="100%" xstyle={styles.column}>


### PR DESCRIPTION
## Summary

The home page (`/`) "Features" bento has an **"Over N components"** card whose preview was a baked PNG (`/feature-components.png`). Because it was a static image, it **did not adapt to dark mode** — it stayed light on the dark surface.

This PR replaces that image with a **live, theme-aware sampler** rendered from real XDS components, so the preview re-themes automatically (via `light-dark()` tokens) and reads correctly in both light and dark mode. The rest of the card (heading, description, "Explore →") is unchanged, and the other three image cards (Themes, Templates, CLI) are untouched.

### What changed
- **New** `apps/docsite/src/app/(site)/_landing/ComponentsPreview.tsx` — a `'use client'` component reproducing the original composition, top to bottom:
  1. Two `Badge`s (`variant="orange"` + `variant="blue"`), then a bare radio (`RadioList`/`RadioListItem`), a checked `CheckboxInput`, and an "on" `Switch`.
  2. A `Button variant="secondary"` ("Secondary") + `Button variant="primary"` ("Primary"), in a 2-col `Grid`.
  3. A search `TextInput` with `startIcon={Search}` (lucide-react) + `hasClear`, placeholder `"Search..."`.
  - Layout via `VStack`/`HStack`/`Grid` + StyleX using theme tokens (`spacingVars`); **no hardcoded colors, no inline styles** — colors come from each component's own variant/token, which is what makes it dark-mode aware.
- **Modified** `FeaturesShowcase.tsx` — the `Feature` type + `FeatureCard` now accept an optional `preview?: ReactNode` rendered in place of the image, reusing the inset/framed treatment so spacing matches the old image. `features.components` now sets `preview: <ComponentsPreview />` and drops its `image`. The orphaned `public/feature-components.png` is left in place (now unused).

### Components + variants used
| Component | Variant / props |
|---|---|
| `Badge` | `variant="orange"`, `variant="blue"` |
| `Button` | `variant="secondary"`, `variant="primary"` |
| `CheckboxInput` | `value` (checked), `size="sm"`, `isLabelHidden` |
| `RadioList` / `RadioListItem` | unselected (group `value` never matches the item), `size="sm"`, `isLabelHidden` |
| `Switch` | `value` (on), `isLabelHidden` |
| `TextInput` | `startIcon={Search}`, `hasClear`, `placeholder="Search…"`, `isLabelHidden` |

## Screenshots

Captured locally with Playwright against the docsite dev server, emulating `colorScheme: 'light'` and `'dark'` (the docsite defers to the OS scheme via `light-dark()` tokens). Images are attached in a follow-up PR comment.

- **Light:** card has a light pastel surface, dark text, orange/blue badges, dark "Primary" button.
- **Dark:** the same card renders natively dark — text, badges, controls, buttons, and the search input all invert and stay legible. In the full-section dark shot the **other three (still-image) cards remain light/baked**, which is exactly the problem this PR fixes for the components card.

## Test plan
- [x] `pnpm -F @astryxdesign/docsite typecheck` — clean (no errors).
- [x] `eslint` on the two changed files — clean.
- [x] Docsite dev server compiles `/` with no runtime errors.
- [x] Playwright screenshots of the card in **light** and **dark** confirm it's legible and theme-aware in both.
- [x] Other three feature cards (Themes, Templates, CLI) still render their images unchanged.
- [ ] Reviewer: visually confirm the card on the deployed/preview build in both OS color schemes.