### PR TITLE
fix(docsite): Docs link fix

### DIFF
--- a/apps/docsite/src/components/SharedTopNav.tsx
+++ b/apps/docsite/src/components/SharedTopNav.tsx
@@ -86,7 +86,7 @@ export function SharedTopNav() {
           <>
             <TopNavItem
               label="Docs"
-              href="/docs"
+              href="/docs/getting-started"
               isSelected={getActiveItem() === 'docs'}
             />
             <TopNavItem


### PR DESCRIPTION
Setting the `/docs` link in the navigation to `/docs/getting-started` to avoid the blank screen flash caused by the redirect.
`/docs` will still redirect to `/docs/getting-started` if anyone tries to access that URL.