### PR TITLE
[DO NOT MERGE] ci: upgrade npm to >=11.5.1 in publish jobs for OIDC

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -304,6 +304,13 @@ jobs:
       - name: Build all packages
         run: pnpm build
 
+      # pnpm publish delegates the upload to the runner's npm, and OIDC trusted
+      # publishing only exists in npm >= 11.5.1. Node 22 bundles npm 10.x, so we
+      # upgrade explicitly — otherwise the publish runs unauthenticated and the
+      # registry returns a misleading 404.
+      - name: Ensure npm supports OIDC trusted publishing
+        run: npm install -g npm@latest
+
       - name: Publish changed packages
         # Pure OIDC trusted publishing — no NPM_TOKEN. pnpm -r publish skips
         # already-published versions, filters private packages, and rewrites
@@ -340,6 +347,10 @@ jobs:
 
       - name: Build all packages
         run: pnpm build
+
+      # OIDC trusted publishing requires npm >= 11.5.1 (Node 22 bundles npm 10.x).
+      - name: Ensure npm supports OIDC trusted publishing
+        run: npm install -g npm@latest
 
       - name: Publish canary versions
         # Pure OIDC trusted publishing — no NPM_TOKEN.


### PR DESCRIPTION
## Problem

The first OIDC publish (after #3043) failed with a misleading error:

```
npm notice Publishing to https://registry.npmjs.org/ with tag latest and public access
npm error code E404
npm error 404 Not Found - PUT https://registry.npmjs.org/@astryxdesign%2fbuild
npm error 404  '@astryxdesign/build@0.0.15' is not in this registry.
```

A `404` on a publish `PUT` is npm's signal for a **failed/absent auth** — the publish ran without an OIDC credential, so the registry hid the (existing) package as "not in this registry".

## Root cause

`pnpm publish` delegates the actual upload to the runner's **`npm`**, and npm OIDC trusted publishing only exists in **npm ≥ 11.5.1**. Our jobs run `node-version: 22`, and **Node 22 bundles npm 10.9.x** — so no OIDC exchange happened and the publish was unauthenticated.

This is exactly why it works on facebook/lexical and not here: Lexical's publish job runs **`node 24.x`** (npm 11.x). Same pnpm (10.34.1), same `pnpm publish --provenance`, same trust config — only the Node/npm version differed.

## Fix

Add an explicit `npm install -g npm@latest` step before the publish in both the `publish` and `canary` jobs, guaranteeing npm ≥ 11.5.1 regardless of the Node image's bundled npm.

## Notes
- Trusted publishers for all 12 `@astryxdesign/*` packages are already configured (`facebook` / `astryx` / `deploy.yml`), verified via `npm trust list`.
- No token involved — still pure OIDC.