### PR TITLE
chore(ci): upgrade Node 22 -> 24 across all workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: 'pnpm'
 
       - run: pnpm install --frozen-lockfile
@@ -118,7 +118,7 @@ jobs:
       - uses: actions/setup-node@v6
         if: needs.check-scope.outputs.docsite_only != 'true'
         with:
-          node-version: 22
+          node-version: 24
           cache: 'pnpm'
 
       - run: pnpm install --frozen-lockfile
@@ -172,7 +172,7 @@ jobs:
         if: needs.check-scope.outputs.docsite_only != 'true'
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -358,7 +358,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Download analysis artifact
         uses: actions/download-artifact@v8
@@ -435,7 +435,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: 'pnpm'
 
       - name: Download analysis artifact
@@ -482,7 +482,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Download analysis artifact
         uses: actions/download-artifact@v8

--- a/.github/workflows/cli-smoke-test.yml
+++ b/.github/workflows/cli-smoke-test.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: "pnpm"
 
       - run: pnpm install --frozen-lockfile

--- a/.github/workflows/codemod-verify.yml
+++ b/.github/workflows/codemod-verify.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: "pnpm"
 
       - run: pnpm install --frozen-lockfile

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,7 +55,7 @@ jobs:
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: 'pnpm'
 
       - run: pnpm install --frozen-lockfile
@@ -82,7 +82,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -294,7 +294,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org'
 
@@ -331,7 +331,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org'
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/setup-node@v6
         if: steps.scope.outputs.docsite_only != 'true'
         with:
-          node-version: 22
+          node-version: 24
           cache: 'pnpm'
 
       - run: pnpm install --frozen-lockfile

--- a/.github/workflows/redeploy-preview.yml
+++ b/.github/workflows/redeploy-preview.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: 'pnpm'
 
       - name: Install Vercel CLI

--- a/.github/workflows/vibe-screenshots.yml
+++ b/.github/workflows/vibe-screenshots.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -90,7 +90,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'pnpm'
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary

Standardizes CI on **Node 24** (active LTS), matching facebook/lexical. Bumps `node-version: 22 -> 24` in all 9 workflows (17 occurrences): `ci`, `deploy`, `lint`, `cli-smoke-test`, `codemod-verify`, `vercel-preview`, `vibe-screenshots`, `redeploy-preview`. No `engines`/`.nvmrc` pin exists, so workflows were the only source of truth.

## Why

Node 24 bundles **npm 11.x**, which natively supports **OIDC trusted publishing** (requires npm ≥ 11.5.1). Node 22 ships npm 10.x — the reason the first OIDC publish returned a misleading `404`. This is also why publishing works on Lexical (node 24) and didn't here (node 22).

Independent of #3044 (the explicit `npm install -g npm@latest` fix), which stays in place as belt-and-suspenders.

## Validation ("break nothing")

- All 13 workflow YAML files parse valid; diff is a pure 17/17 version bump, no other changes.
- **This PR's CI runs the full suite on Node 24** (ci.yml: test/lint/build, plus deploy's test) — the authoritative matrix in the real environment.
- Additional local smoke in a `node:24` linux container (install + test + build) — results in a comment.

Do not merge until all CI checks are green on Node 24.