### PR TITLE
fix(docsite): preload carousel theme fonts/images to remove first-visit jank

### DIFF
--- a/apps/docsite/src/app/(site)/_landing/hero/HeroThemeReel.tsx
+++ b/apps/docsite/src/app/(site)/_landing/hero/HeroThemeReel.tsx
@@ -29,7 +29,12 @@ import {Text} from '@astryxdesign/core/Text';
 import {Pagination} from '@astryxdesign/core/Pagination';
 import {useMediaQuery} from '@astryxdesign/core/hooks';
 import {useThemeMode} from '../../../providers';
-import {HERO_THEME_SLIDES, type HeroThemeSlide} from './heroThemeContent';
+import {
+  HERO_THEME_SLIDES,
+  REEL_FONT_SPECIFIERS,
+  REEL_IMAGE_SRCS,
+  type HeroThemeSlide,
+} from './heroThemeContent';
 import {AstryxLogo} from '../../../../components/logos';
 import {HeroFloatingCards} from './HeroFloatingCards';
 
@@ -245,6 +250,47 @@ export function HeroReelProvider({children}: {children: ReactNode}) {
     const onVisibility = () => setPaused(document.hidden);
     document.addEventListener('visibilitychange', onVisibility);
     return () => document.removeEventListener('visibilitychange', onVisibility);
+  }, []);
+
+  // Warm the reel's per-theme assets once, after first paint, so first-time
+  // visitors don't see fonts flash (FOUT) and product photos pop in as the reel
+  // auto-advances. The @font-face rules ship in the docsite's Google Fonts
+  // <link>, but a family's woff2 is only fetched when a glyph using it first
+  // paints — and the remote card photos aren't fetched until their slide
+  // renders; both happen mid-swap on a cold cache. Kicking the fetches off here
+  // (off the critical path, scoped to just the reel's ~9 fonts and photos) gets
+  // them into cache before the first 4.5s advance without touching initial LCP.
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    // Defer to idle time so warming never competes with first paint / LCP.
+    const schedule =
+      window.requestIdleCallback?.bind(window) ??
+      ((cb: () => void) => window.setTimeout(cb, 200));
+    const cancel =
+      window.cancelIdleCallback?.bind(window) ?? window.clearTimeout;
+
+    const handle = schedule(() => {
+      // Fonts: ask the CSS Font Loading API to load each reel family. This pulls
+      // the woff2 the @font-face rule points at without us hardcoding gstatic's
+      // hashed URLs (which rotate). Failures (e.g. a family not in the sheet)
+      // are non-fatal — the slide just paints its fallback as it does today.
+      if (typeof document !== 'undefined' && document.fonts?.load) {
+        for (const spec of REEL_FONT_SPECIFIERS) {
+          document.fonts.load(spec).catch(() => {});
+        }
+      }
+      // Images: prime the browser cache with the reel's product photos so they
+      // are decoded by the time their slide swaps in.
+      for (const src of REEL_IMAGE_SRCS) {
+        const img = new Image();
+        img.decoding = 'async';
+        img.src = src;
+      }
+    });
+
+    return () => cancel(handle as never);
   }, []);
 
   const value = useMemo<HeroReelState>(

--- a/apps/docsite/src/app/(site)/_landing/hero/heroThemeContent.ts
+++ b/apps/docsite/src/app/(site)/_landing/hero/heroThemeContent.ts
@@ -313,7 +313,9 @@ function wordmarkColorFor(name: string): string {
 }
 
 // Dark-first themes (rendered in dark mode; hero text/nav go light).
-const DARK_THEMES: ReadonlySet<string> = new Set<string>(['@astryxdesign/theme-gothic']);
+const DARK_THEMES: ReadonlySet<string> = new Set<string>([
+  '@astryxdesign/theme-gothic',
+]);
 
 // Per-theme aurora blob palettes (categorical background tokens, on-brand hues).
 const AURORA_BY_THEME: Record<string, HeroAuroraPalette> = {
@@ -358,6 +360,45 @@ const DEFAULT_AURORA: HeroAuroraPalette = {
   right: 'var(--color-background-pink)',
 };
 
+// The custom (web) font families each reel theme paints with — body, heading,
+// and the marketing-scale display family. Listed here so the hero can warm them
+// before the first auto-advance (the @font-face rules ship in the docsite's
+// Google Fonts <link>, but the browser only fetches a family's woff2 once a
+// glyph using it first paints — i.e. when the reel swaps to that slide, which
+// is the visible FOUT first-time visitors hit). System/fallback stacks
+// (-apple-system, Georgia, …) are intentionally omitted: they need no fetch.
+//
+// Keep in sync with the typography.{body,heading} families + display overrides
+// in each theme package (packages/themes/<name>/src/<name>Theme.ts).
+const REEL_FONT_FAMILIES: ReadonlyArray<string> = [
+  // Astryx (docsite brand)
+  'Figtree',
+  // Matcha (DM Sans body + Playwrite US Trad heading)
+  'DM Sans',
+  'Playwrite US Trad',
+  // Butter (Outfit body/heading + Sarina display)
+  'Outfit',
+  'Sarina',
+  // Gothic (Fustat body/heading + Manufacturing Consent display)
+  'Fustat',
+  'Manufacturing Consent',
+  // Y2K (Poppins body/heading + Crimson Text display)
+  'Poppins',
+  'Crimson Text',
+];
+
+/**
+ * `document.fonts.load()` specifiers for the reel's custom families. A short
+ * representative string is enough to pull the right woff2 — the API loads the
+ * whole face that would render those glyphs. We warm a normal and a bold-ish
+ * weight since the cards mix body and heading weights.
+ */
+export const REEL_FONT_SPECIFIERS: ReadonlyArray<string> =
+  REEL_FONT_FAMILIES.flatMap(family => [
+    `400 1rem "${family}"`,
+    `600 1rem "${family}"`,
+  ]);
+
 // Ordered slides from REEL_THEMES; unresolved (uninstalled) themes are skipped.
 export const HERO_THEME_SLIDES: ReadonlyArray<HeroThemeSlide> = REEL_THEMES.map(
   name => {
@@ -376,3 +417,21 @@ export const HERO_THEME_SLIDES: ReadonlyArray<HeroThemeSlide> = REEL_THEMES.map(
       : null;
   },
 ).filter((s): s is HeroThemeSlide => s !== null);
+
+/**
+ * Every product photo the reel cards reference, deduped and in slide order. The
+ * cards use plain <img> (no next/image priority), so on a fresh visit a slide's
+ * remote CDN photos aren't fetched until that slide renders — they pop in as
+ * the reel advances. The hero warms this list on mount so the images are in the
+ * browser cache before the first auto-advance. Scoped to just the reel's photos
+ * (3 per slide) so it doesn't bloat the rest of the landing page's initial load.
+ */
+export const REEL_IMAGE_SRCS: ReadonlyArray<string> = Array.from(
+  new Set(
+    HERO_THEME_SLIDES.flatMap(slide => [
+      slide.content.product.image,
+      slide.content.feature.image,
+      slide.content.mini.image,
+    ]),
+  ),
+);


### PR DESCRIPTION
## Problem

First-time visitors see visible jank in the home hero reel: as it auto-advances
between themes every 4.5s, fonts flash/reflow (FOUT) and product photos pop in
as they load. Returning visitors don't see it because the assets are already in
cache.

## Root cause

The reel cycles through five themes (Astryx, Matcha, Butter, Gothic, Y2K). Each
slide paints with its own Google Font and pulls three product photos:

| Slide  | Fonts (body / heading / display)            |
| ------ | ------------------------------------------- |
| Astryx | Figtree                                     |
| Matcha | DM Sans / Playwrite US Trad                 |
| Butter | Outfit + Sarina (display)                   |
| Gothic | Fustat + Manufacturing Consent (display)    |
| Y2K    | Poppins + Crimson Text (display)            |

The `@font-face` rules for all of these ship up front in the shared Google Fonts
`<link>` in `layout.tsx`, but a browser only downloads a family's `woff2` once a
glyph using it **first paints** — i.e. when the reel swaps to that slide. The
card product photos (plain `<img>`, no `next/image` priority) likewise aren't
fetched until their slide renders. On a cold cache both happen mid-swap, which
is exactly the flash/pop first-time visitors reported.

## Fix

Warm the reel's per-theme assets once, after first paint, scoped to exactly the
~9 font families and the reel's product photos:

- **Fonts** via the CSS Font Loading API (`document.fonts.load`), which pulls the
  `woff2` the existing `@font-face` rule points at — no need to hardcode
  gstatic's rotating hashed URLs. Only the reel's custom families are warmed;
  system/fallback stacks (`-apple-system`, `Georgia`, …) are skipped since they
  need no fetch.
- **Images** via `new Image()` to prime the browser cache so each slide's photos
  are decoded before that slide swaps in.

Both are deferred to `requestIdleCallback` (with a `setTimeout` fallback) so the
warming never competes with first paint / LCP, and all failures are non-fatal —
a slide just paints its fallback exactly as it does today.

The asset lists live in `heroThemeContent.ts` next to the slide definitions
(the single source of truth for the reel), with a note to keep the font list in
sync with each theme package's typography config.

## Tradeoff

The landing page now eagerly fetches ~9 web-font faces and the reel's product
photos shortly after load instead of lazily on each swap. This is the same set
of bytes the reel was always going to request within the first ~20s — it's just
pulled forward into idle time so they're ready at the first swap. Initial LCP is
untouched (warming is deferred to idle and the fetches are async/non-blocking).

## Verification

- `pnpm -F @astryxdesign/core build` ✓
- `pnpm -F @astryxdesign/docsite generate && pnpm -F @astryxdesign/docsite test` ✓ (168 tests) — the CI `docsite-test` gate
- `pnpm -F @astryxdesign/docsite build` compiles successfully; the reel still renders/cycles
