### PR TITLE
docs(cli): update theme docs to current theme set

### DIFF
--- a/.changeset/cli-theme-docs-current-set.md
+++ b/.changeset/cli-theme-docs-current-set.md
@@ -1,0 +1,13 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[docs] Update CLI theme docs to the current theme set
+@cixzhang
+
+Refreshes the `astryx docs theme`, `getting-started`, `styling`,
+`styling-libraries`, and `migration` reference docs to reflect the published
+themes: `neutral`, `butter`, `chocolate`, `gothic`, `matcha`, `stone`, and
+`y2k`. The removed `theme-default`, `theme-brutalist`, and `theme-daily`
+packages are dropped from the docs, and install/import examples now use
+`@astryxdesign/theme-neutral` as the recommended starting theme.

--- a/packages/cli/docs/getting-started.doc.mjs
+++ b/packages/cli/docs/getting-started.doc.mjs
@@ -21,7 +21,7 @@ export const docs = {
           type: 'code',
           lang: 'text',
           label: 'Paste this into your AI',
-          code: 'Install @astryxdesign/core, @astryxdesign/theme-default, and @astryxdesign/cli in this project. Run `npx astryx init` to set up agent docs. Read the generated files to learn the conventions.',
+          code: 'Install @astryxdesign/core, @astryxdesign/theme-neutral, and @astryxdesign/cli in this project. Run `npx astryx init` to set up agent docs. Read the generated files to learn the conventions.',
         },
       ],
     },
@@ -36,7 +36,7 @@ export const docs = {
           type: 'code',
           lang: 'bash',
           label: 'Terminal',
-          code: `npm install @astryxdesign/core @astryxdesign/theme-default @astryxdesign/cli`,
+          code: `npm install @astryxdesign/core @astryxdesign/theme-neutral @astryxdesign/cli`,
         },
         {
           type: 'prose',
@@ -63,11 +63,11 @@ export const docs = {
           label: 'globals.css',
           code: `@import '@astryxdesign/core/reset.css';
 @import '@astryxdesign/core/astryx.css';
-@import '@astryxdesign/theme-default/theme.css';`,
+@import '@astryxdesign/theme-neutral/theme.css';`,
         },
         {
           type: 'prose',
-          text: 'Available themes: @astryxdesign/theme-default (blue accent), @astryxdesign/theme-neutral (grayscale), @astryxdesign/theme-brutalist (zero radius, monospace). See `npx astryx docs theme` for the full theming guide.',
+          text: 'Available themes: @astryxdesign/theme-neutral (muted minimal, a good starting point), @astryxdesign/theme-butter, @astryxdesign/theme-chocolate, @astryxdesign/theme-gothic (dark-only), @astryxdesign/theme-matcha, @astryxdesign/theme-stone, and @astryxdesign/theme-y2k. See `npx astryx docs theme` for the full theming guide.',
         },
       ],
     },

--- a/packages/cli/docs/migration.doc.mjs
+++ b/packages/cli/docs/migration.doc.mjs
@@ -91,15 +91,15 @@ npx astryx component Button --json`,
           lang: 'tsx',
           label: 'Root provider with explicit mode',
           code: `import {Theme} from '@astryxdesign/core/theme';
-import {defaultTheme} from '@astryxdesign/theme-default/built';
+import {neutralTheme} from '@astryxdesign/theme-neutral/built';
 import {useState} from 'react';
-import '@astryxdesign/theme-default/theme.css';
+import '@astryxdesign/theme-neutral/theme.css';
 
 export function AppRoot({children}: {children: React.ReactNode}) {
   const [mode, setMode] = useState<'system' | 'light' | 'dark'>('system');
 
   return (
-    <Theme theme={defaultTheme} mode={mode}>
+    <Theme theme={neutralTheme} mode={mode}>
       <SettingsContext.Provider value={{mode, setMode}}>
         {children}
       </SettingsContext.Provider>
@@ -121,7 +121,7 @@ export function AppRoot({children}: {children: React.ReactNode}) {
 @import "tailwindcss/preflight.css" layer(base);
 @import "@astryxdesign/core/reset.css";
 @import "@astryxdesign/core/astryx.css";
-@import "@astryxdesign/theme-default/theme.css";
+@import "@astryxdesign/theme-neutral/theme.css";
 @import "@astryxdesign/core/tailwind-theme.css";
 @import "tailwindcss/utilities.css" layer(utilities);`,
         },

--- a/packages/cli/docs/styling-libraries.doc.mjs
+++ b/packages/cli/docs/styling-libraries.doc.mjs
@@ -162,7 +162,7 @@ const styles = stylex.create({
 @import "tailwindcss/preflight.css" layer(base);
 @import "@astryxdesign/core/reset.css";
 @import "@astryxdesign/core/astryx.css";
-@import "@astryxdesign/theme-default/theme.css";
+@import "@astryxdesign/theme-neutral/theme.css";
 @import "@astryxdesign/core/tailwind-theme.css";
 @import "tailwindcss/utilities.css" layer(utilities);`,
         },
@@ -374,9 +374,9 @@ tokens: {
           lang: 'ts',
           label: 'Resolve tokens without React context',
           code: `import {resolveThemeTokens} from '@astryxdesign/core/theme/tokens';
-import {defaultTheme} from '@astryxdesign/theme-default';
+import {neutralTheme} from '@astryxdesign/theme-neutral';
 
-const tokens = resolveThemeTokens(defaultTheme, {mode: 'light'});
+const tokens = resolveThemeTokens(neutralTheme, {mode: 'light'});
 
 const chartOptions = {
   textColor: tokens['--color-text-primary'],

--- a/packages/cli/docs/styling.doc.mjs
+++ b/packages/cli/docs/styling.doc.mjs
@@ -104,7 +104,7 @@ const overrides = stylex.create({
 @import "tailwindcss/preflight.css" layer(base);
 @import "@astryxdesign/core/reset.css";
 @import "@astryxdesign/core/astryx.css";
-@import "@astryxdesign/theme-default/theme.css";
+@import "@astryxdesign/theme-neutral/theme.css";
 @import "@astryxdesign/core/tailwind-theme.css";
 @import "tailwindcss/utilities.css" layer(utilities);`,
         },

--- a/packages/cli/docs/theme.doc.dense.mjs
+++ b/packages/cli/docs/theme.doc.dense.mjs
@@ -6,7 +6,7 @@ export const docsDense = {
   description: 'Theme provider, custom themes, light/dark, component overrides',
   sections: [
     { title: 'Quick Start', content: [null, null, { type: 'prose', text: 'default import = runtime injection. /built import = pre-compiled CSS (pair with theme.css).' }] },
-    { title: 'Themes', content: [null, { type: 'prose', text: '@astryxdesign/theme-{name} = source (runtime). @astryxdesign/theme-{name}/built = optimized (+ theme.css).' }] },
+    { title: 'Themes', content: [null, { type: 'prose', text: 'published: neutral (start here), butter, chocolate, gothic (dark-only), matcha, stone, y2k. @astryxdesign/theme-{name} = source (runtime). @astryxdesign/theme-{name}/built = optimized (+ theme.css).' }] },
     { title: 'Props', content: [null] },
     { title: 'Custom Theme', content: [{ type: 'prose', text: 'CLI wizard or manual defineTheme. only override tokens that differ.' }, null] },
     { title: 'defineTheme', content: [{ type: 'prose', text: 'scale configs (color, typography, radius, motion) + explicit token overrides + component overrides. color derives full palette from accent hex via HCT.' }, null, null] },

--- a/packages/cli/docs/theme.doc.mjs
+++ b/packages/cli/docs/theme.doc.mjs
@@ -19,11 +19,11 @@ export const docs = {
           lang: 'tsx',
           label: 'Basic theme setup (runtime injection)',
           code: `import {Theme} from '@astryxdesign/core';
-import {defaultTheme} from '@astryxdesign/theme-default';
+import {neutralTheme} from '@astryxdesign/theme-neutral';
 
 function App() {
   return (
-    <Theme theme={defaultTheme}>
+    <Theme theme={neutralTheme}>
       <YourApp />
     </Theme>
   );
@@ -34,12 +34,12 @@ function App() {
           lang: 'tsx',
           label: 'Optimized setup (pre-built CSS)',
           code: `import {Theme} from '@astryxdesign/core';
-import {defaultTheme} from '@astryxdesign/theme-default/built';
-import '@astryxdesign/theme-default/theme.css';
+import {neutralTheme} from '@astryxdesign/theme-neutral/built';
+import '@astryxdesign/theme-neutral/theme.css';
 
 function App() {
   return (
-    <Theme theme={defaultTheme}>
+    <Theme theme={neutralTheme}>
       <YourApp />
     </Theme>
   );
@@ -60,19 +60,39 @@ function App() {
           headers: ['Theme', 'Import', 'Description'],
           rows: [
             [
-              'Default',
-              "import {defaultTheme} from '@astryxdesign/theme-default'",
-              'Blue accent, system fonts, light/dark',
-            ],
-            [
               'Neutral',
               "import {neutralTheme} from '@astryxdesign/theme-neutral'",
-              'Grayscale, shadcn-inspired',
+              'Muted, minimal aesthetic with system fonts. A good starting point.',
             ],
             [
-              'Brutalist',
-              "import {brutalistTheme} from '@astryxdesign/theme-brutalist'",
-              'Zero radius, monospace, heavy borders',
+              'Butter',
+              "import {butterTheme} from '@astryxdesign/theme-butter'",
+              'Golden, buttery surfaces with blue accents; Sarina + Outfit type.',
+            ],
+            [
+              'Chocolate',
+              "import {chocolateTheme} from '@astryxdesign/theme-chocolate'",
+              'Warm brown tones and cozy beige; Fraunces + Albert Sans type.',
+            ],
+            [
+              'Gothic',
+              "import {gothicTheme} from '@astryxdesign/theme-gothic'",
+              'Dark-only atmospheric theme; deep blue-gray surfaces, distressed display type.',
+            ],
+            [
+              'Matcha',
+              "import {matchaTheme} from '@astryxdesign/theme-matcha'",
+              'Earthy green theme with Figtree typography.',
+            ],
+            [
+              'Stone',
+              "import {stoneTheme} from '@astryxdesign/theme-stone'",
+              'Warm stone and slate tones; Montserrat + Figtree type.',
+            ],
+            [
+              'Y2K',
+              "import {y2kTheme} from '@astryxdesign/theme-y2k'",
+              'Playful Y2K pop; periwinkle body, holographic accents, Poppins + Crimson Text.',
             ],
           ],
         },
@@ -194,14 +214,14 @@ const myTheme = defineTheme({
         {
           type: 'code',
           lang: 'tsx',
-          label: 'Extending the default theme',
+          label: 'Extending the neutral theme',
           code: `import {defineTheme} from '@astryxdesign/core/theme';
-import {defaultTheme} from '@astryxdesign/theme-default';
+import {neutralTheme} from '@astryxdesign/theme-neutral';
 import {myIcons} from './icons';
 
 const brandTheme = defineTheme({
   name: 'brand',
-  extends: defaultTheme,
+  extends: neutralTheme,
   icons: myIcons,
   tokens: {
     '--color-accent': ['#7B61FF', '#9B85FF'],
@@ -525,9 +545,9 @@ const pandaOrEmotionTheme = {
           lang: 'ts',
           label: 'Resolve token values without a hook',
           code: `import {resolveThemeTokens} from '@astryxdesign/core/theme/tokens';
-import {defaultTheme} from '@astryxdesign/theme-default';
+import {neutralTheme} from '@astryxdesign/theme-neutral';
 
-const lightTokens = resolveThemeTokens(defaultTheme, {mode: 'light'});
+const lightTokens = resolveThemeTokens(neutralTheme, {mode: 'light'});
 const chartTheme = {
   textColor: lightTokens['--color-text-primary'],
   seriesColor: lightTokens['--color-data-categorical-blue'],

--- a/packages/cli/docs/theme.doc.zh.mjs
+++ b/packages/cli/docs/theme.doc.zh.mjs
@@ -6,7 +6,7 @@ export const docsZh = {
   description: 'Theme 提供者、自定义主题、亮/暗模式和组件样式覆盖。',
   sections: [
     { title: '快速开始', content: [null, null, { type: 'prose', text: '默认导入使用运行时样式注入。/built 导入使用预编译 CSS（需配合 theme.css）。' }] },
-    { title: '可用主题', content: [null, { type: 'prose', text: '@astryxdesign/theme-{name} = 源码版（运行时注入）。@astryxdesign/theme-{name}/built = 优化版（配合 theme.css）。' }] },
+    { title: '可用主题', content: [null, { type: 'prose', text: '已发布主题：neutral（推荐起点）、butter、chocolate、gothic（仅暗色）、matcha、stone、y2k。@astryxdesign/theme-{name} = 源码版（运行时注入）。@astryxdesign/theme-{name}/built = 优化版（配合 theme.css）。' }] },
     { title: 'Theme 属性', content: [null] },
     { title: '创建自定义主题', content: [{ type: 'prose', text: '使用 CLI 向导（推荐）或手动 defineTheme。只覆盖与默认值不同的令牌。' }, null] },
     { title: 'defineTheme', content: [{ type: 'prose', text: '支持比例配置（typography、radius、motion）+ 显式令牌覆盖 + 组件覆盖。' }, null, null] },


### PR DESCRIPTION
## What

Updates the CLI reference docs to match the current set of published themes. The theme docs had drifted: they advertised `default`, `neutral`, and `brutalist`, but the published theme set is now seven themes. This refreshes every CLI doc that enumerates, imports, or installs a theme.

**Current theme set (7):** `neutral`, `butter`, `chocolate`, `gothic` (dark-only), `matcha`, `stone`, `y2k`.

## Why

The old docs pointed users at `@astryxdesign/theme-default` and `@astryxdesign/theme-brutalist`, which are being removed. Following those examples would leave users installing/importing packages that no longer exist. The docs now use **`@astryxdesign/theme-neutral`** as the recommended starting theme in install and import examples (the closest replacement for the old default: muted, minimal, system fonts).

## Changes

- `packages/cli/docs/theme.doc.mjs` — rebuilt the "Available Themes" table to list all 7 themes with accurate imports/descriptions; switched Quick Start, "Extending a Theme", and token-utility examples from `defaultTheme` to `neutralTheme`.
- `packages/cli/docs/theme.doc.dense.mjs` — added the published theme list to the Themes section.
- `packages/cli/docs/theme.doc.zh.mjs` — added the published theme list (Chinese) to 可用主题.
- `packages/cli/docs/getting-started.doc.mjs` — updated install command, AI setup prompt, theme CSS import, and the "Available themes" line to the current set.
- `packages/cli/docs/styling.doc.mjs`, `styling-libraries.doc.mjs`, `migration.doc.mjs` — switched stale `theme-default` import/CSS examples to `theme-neutral`.
- Added a `[docs]` changeset for `@astryxdesign/cli`.

`ThemeApply.doc.mjs` (and the other `templates/blocks/components/Theme/*.doc.mjs`) only list `componentsUsed` and don't enumerate themes, so they needed no change.

## ⚠️ Merge ordering

These docs describe the **end state after** the `theme-default`, `theme-brutalist`, and `theme-daily` packages are removed. As of this writing those theme packages still exist in `packages/themes/` and their removal PRs are being landed separately. **Merge this after the theme-removal PRs land** so the docs don't reference themes that exist while also dropping ones that don't.

## Verification

- All edited `.doc.mjs` files import cleanly as ES modules.
- `typecheck:template-docs` passes.
- `check:changesets` passes (changeset has a `[docs]` category + contributor credit).
- No remaining references to `theme-default`, `theme-brutalist`, or `theme-daily` in `packages/cli/docs/`.
- CLI command examples use `astryx` (post CLI rename), not `xds`.

## Note

`@astryxdesign/theme-neutral` was chosen as the recommended starting theme to replace the removed `theme-default`. If the team prefers a different default starting theme, the install/import examples can be repointed.
