### PR TITLE
fix(docsite): wrap long lines in docs code blocks

### DIFF
--- a/apps/docsite/src/components/docs/CodeBlock.tsx
+++ b/apps/docsite/src/components/docs/CodeBlock.tsx
@@ -31,6 +31,7 @@ export function CodeBlockRenderer({
         code={code}
         language={lang}
         hasCopyButton
+        isWrapped
         xstyle={styles.root}
       />
     </VStack>


### PR DESCRIPTION
## Summary

Long code lines in docs pages currently overflow horizontally (`white-space: pre`), so you have to scroll sideways to read the full content.

The XDS `CodeBlock` component already supports soft-wrapping via the `isWrapped` prop (toggles `white-space: pre-wrap` + `overflow-wrap: break-word`), but the docs content renderer never passed it. This change passes `isWrapped` in `CodeBlockRenderer` so docs code blocks wrap and the entire content is readable without horizontal scrolling.

## Scope

- Affects **docs prose/content code blocks** (the markdown-rendered ones).
- Does **not** change live component example previews elsewhere, nor the `CodeBlock` component default.

## Notes

- `isWrapped` uses `word-break: break-all`, so very long unbreakable tokens (URLs, hashes) break mid-character — existing component behavior.

🤖 Opened by Navi on behalf of @cindyxz