### PR TITLE
fix(example-vite): remove dead unplugin dep blocking external npm install

### DIFF
--- a/apps/example-vite/package.json
+++ b/apps/example-vite/package.json
@@ -13,8 +13,7 @@
     "@astryxdesign/core": "*",
     "@astryxdesign/theme-default": "*",
     "react": "^19.2.7",
-    "react-dom": "^19.2.7",
-    "unplugin": "^3.0.0"
+    "react-dom": "^19.2.7"
   },
   "devDependencies": {
     "@stylexjs/unplugin": "^0.19.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -370,9 +370,6 @@ importers:
       react-dom:
         specifier: ^19.2.7
         version: 19.2.7(react@19.2.7)
-      unplugin:
-        specifier: ^3.0.0
-        version: 3.0.0
     devDependencies:
       '@astryxdesign/build':
         specifier: '*'


### PR DESCRIPTION
## What

Remove the dead `unplugin@^3.0.0` top-level dep from `apps/example-vite/package.json`.

## Why

No source file imports `unplugin` directly. It was added in #1295 as a peer-dep workaround when `vite.config.ts` imported `@stylexjs/unplugin` directly. #1460 then consolidated all of that plumbing into `xdsStylex()` from `@astryxdesign/build/vite` and the top-level dep became dead — it was just missed in the cleanup. #2340 (dependabot) later bumped it `2.3.11 → 3.0.0`, which now conflicts with `@stylexjs/unplugin@0.19`'s `unplugin@^2` peer.

`pnpm` tolerates the conflict thanks to loose peer-dep resolution in the monorepo, so the symptom is invisible during normal development. But external consumers following [`Testing-Example-Apps`](https://github.com/facebook/astryx/wiki/Testing-Example-Apps) hit a hard `ERESOLVE` under `npm install`:

```
npm error code ERESOLVE
npm error While resolving: @astryxdesign/example-vite@0.0.1
npm error Found: unplugin@3.2.0
npm error   unplugin@"^3.0.0" from the root project
npm error
npm error Could not resolve dependency:
npm error peer unplugin@"^2.3.11" from @stylexjs/unplugin@0.19.0
```

## How

Deleted the dead dep entry. Verified `unplugin` is not imported anywhere in `apps/example-vite/` source.

## Test plan

- Pack the three publishable deps (`@astryxdesign/core`, `@astryxdesign/theme-default`, `@astryxdesign/build`) and `npm install` against the example outside the monorepo per the wiki guide — install completes cleanly and `vite build && vite preview` succeeds. Previously failed with the `ERESOLVE` above.
- In-monorepo `pnpm install && pnpm -F @astryxdesign/example-vite build` is unaffected.

## Notes

The example app remains private (`"private": true`), so no changeset is needed (`check:changesets` clean).