### PR TITLE
fix(example-nextjs): make TextInput controlled to fix typecheck on nextjs example app

### DIFF
--- a/apps/example-nextjs/src/app/page.tsx
+++ b/apps/example-nextjs/src/app/page.tsx
@@ -2,6 +2,7 @@
 
 'use client';
 
+import {useState} from 'react';
 import {VStack, HStack} from '@astryxdesign/core/Layout';
 import {Button} from '@astryxdesign/core/Button';
 import {Text, Heading} from '@astryxdesign/core/Text';
@@ -10,6 +11,7 @@ import {Badge} from '@astryxdesign/core/Badge';
 import {Divider} from '@astryxdesign/core';
 
 export default function Home() {
+  const [email, setEmail] = useState('');
   return (
     <main
       style={{
@@ -65,7 +67,12 @@ export default function Home() {
           {/* Text Input */}
           <VStack gap={3}>
             <Heading level={2}>Text Input</Heading>
-            <TextInput label="Email address" placeholder="you@example.com" />
+            <TextInput
+              label="Email address"
+              placeholder="you@example.com"
+              value={email}
+              onChange={setEmail}
+            />
           </VStack>
 
           <Divider />


### PR DESCRIPTION
## Fix example-nextjs: TextInput missing required `value` prop

### Problem
`apps/example-nextjs/src/app/page.tsx` fails to typecheck:

```
./src/app/page.tsx:68:14
Type error: Property 'value' is missing in type
'{ label: string; placeholder: string; }' but required in type 'TextInputProps'.
```

### Root cause
`TextInput` is **controlled-only** by design — `TextInputProps.value` is required, and `defaultValue` is explicitly omitted (`Omit<BaseProps, 'onChange' | 'defaultValue'>`); the component derives its displayed value straight from the prop via `useOptimistic(value)` with no internal state fallback. The `example-nextjs` page rendered `TextInput` with no `value`, so it never compiled. Every sibling example (`example-nextjs-stylex`, `-source`, `-tailwind`) already uses the controlled pattern — this app just wasn't updated when `TextInput` became controlled-only.

### Fix
Make the input controlled, matching the sibling examples:
- `import {useState} from 'react';`
- `const [email, setEmail] = useState('');`
- `value={email} onChange={setEmail}` on the `TextInput`

`onChange` is `(value: string, e) => void`, so `setEmail` can be passed directly. This is the only component drift in the file.

### Testing
- Typecheck passes on `example-nextjs`.
- Verified no other required-prop/enum drift in the file (Button/Badge/Heading/Text/VStack/HStack/Divider all validate).

### Context
Found while testing the example apps as external npm consumers (per the `Testing-Example-Apps` wiki). The same effort surfaced two related issues handled separately: a dead/conflicting `unplugin@^3.0.0` dep in `example-vite` (npm `ERESOLVE`, masked by pnpm), and several wiki staleness bugs (`@xds/` → `@astryxdesign/` namespace, `--pack-destination` creating a directory, and a missing `@astryxdesign/build` packing step).
<img width="1310" height="854" alt="localhost_3000_" src="https://github.com/user-attachments/assets/145a3fdf-367c-4c0a-b83d-2ee0a3b32ccc" />
<img width="1310" height="854" alt="localhost_3000_ (1)" src="https://github.com/user-attachments/assets/f29caf68-b06c-40ab-873d-368d340a49c5" />
