### PR TITLE
refactor(cli): use login-split cover image in two-column form template

### DIFF
--- a/packages/cli/templates/pages/form-two-column/page.tsx
+++ b/packages/cli/templates/pages/form-two-column/page.tsx
@@ -18,9 +18,10 @@ import {Link} from '@astryxdesign/core/Link';
 import {Divider} from '@astryxdesign/core/Divider';
 import {Card} from '@astryxdesign/core/Card';
 import {Selector} from '@astryxdesign/core/Selector';
+import {radiusVars} from '@astryxdesign/core/theme/tokens.stylex';
 
 const ILLUSTRATION_URL =
-  'https://lookaside.facebook.com/assets/astryx/light-working-vertical-1.png';
+  'https://lookaside.facebook.com/assets/astryx/light-working-vertical-2.png';
 
 // ─────────────────────────────────────────────────────────────
 // Constants
@@ -56,8 +57,11 @@ const CONTACT_COLUMNS = [
 // ─────────────────────────────────────────────────────────────
 
 // The only custom styling is fitting the cover photo inside its AspectRatio
-// box (cover, not contain — it's a photograph, so crop it to fill the frame).
-// No objectFit prop on AspectRatio, and there's no Image primitive (#2582).
+// box (cover, not contain — it's a photograph, so crop it to fill the frame)
+// and rounding its corners. borderRadius needs overflow:clip so the cover crop
+// is masked to the rounded edge. Tracks --radius-container so it matches the
+// form Card in the same row. No objectFit/radius prop on AspectRatio, and
+// there's no Image primitive (#2582).
 const styles = stylex.create({
   page: {
     minHeight: '100%',
@@ -66,6 +70,8 @@ const styles = stylex.create({
     width: '100%',
     height: '100%',
     objectFit: 'cover',
+    borderRadius: radiusVars['--radius-container'],
+    overflow: 'hidden',
   },
 });
 

--- a/packages/cli/templates/pages/form-two-column/page.tsx
+++ b/packages/cli/templates/pages/form-two-column/page.tsx
@@ -23,10 +23,6 @@ import {radiusVars} from '@astryxdesign/core/theme/tokens.stylex';
 const ILLUSTRATION_URL =
   'https://lookaside.facebook.com/assets/astryx/light-working-vertical-2.png';
 
-// ─────────────────────────────────────────────────────────────
-// Constants
-// ─────────────────────────────────────────────────────────────
-
 const INQUIRY_REASONS = [
   'New business',
   'General inquiry',
@@ -52,16 +48,9 @@ const CONTACT_COLUMNS = [
   {label: 'Press & partnerships', email: 'press@company.com'},
 ];
 
-// ─────────────────────────────────────────────────────────────
-// Styles
-// ─────────────────────────────────────────────────────────────
-
-// The only custom styling is fitting the cover photo inside its AspectRatio
-// box (cover, not contain — it's a photograph, so crop it to fill the frame)
-// and rounding its corners. borderRadius needs overflow:clip so the cover crop
-// is masked to the rounded edge. Tracks --radius-container so it matches the
-// form Card in the same row. No objectFit/radius prop on AspectRatio, and
-// there's no Image primitive (#2582).
+// AspectRatio has no objectFit/radius prop and there's no Image primitive
+// (#2582), so the cover photo is styled directly. overflow:hidden masks the
+// cover crop to the rounded corners.
 const styles = stylex.create({
   page: {
     minHeight: '100%',
@@ -74,10 +63,6 @@ const styles = stylex.create({
     overflow: 'hidden',
   },
 });
-
-// ─────────────────────────────────────────────────────────────
-// Page
-// ─────────────────────────────────────────────────────────────
 
 /**
  * Form (Two-column) — marketing contact form template.
@@ -113,9 +98,8 @@ export default function FormTwoColumnPage() {
     <Center xstyle={styles.page}>
       <Section maxWidth={1100} width="100%" padding={10} variant="transparent">
         <VStack gap={10}>
-          {/* ── Top: two-column, stacks to one column below ~520px ── */}
+          {/* Two-column; stacks to one column below ~520px. */}
           <Grid columns={{minWidth: 320}} align="center" gap={10}>
-            {/* Left: headline + description + illustration */}
             <VStack gap={6}>
               <VStack gap={3}>
                 <Text type="display-1" as="h1">
@@ -135,7 +119,6 @@ export default function FormTwoColumnPage() {
               </AspectRatio>
             </VStack>
 
-            {/* Right: form on a card */}
             <Card padding={8}>
               <VStack gap={4}>
                 <Text type="label">Your details</Text>
@@ -238,7 +221,7 @@ export default function FormTwoColumnPage() {
             </Card>
           </Grid>
 
-          {/* ── Bottom: contact strip (stacks below ~440px) ── */}
+          {/* Contact strip; stacks below ~440px. */}
           <VStack gap={6}>
             <Divider />
             <Grid columns={{minWidth: 200}} gap={6}>

--- a/packages/cli/templates/pages/form-two-column/page.tsx
+++ b/packages/cli/templates/pages/form-two-column/page.tsx
@@ -20,7 +20,7 @@ import {Card} from '@astryxdesign/core/Card';
 import {Selector} from '@astryxdesign/core/Selector';
 
 const ILLUSTRATION_URL =
-  'https://lookaside.facebook.com/assets/astryx/illustration-horizontal-1.png';
+  'https://lookaside.facebook.com/assets/astryx/light-working-vertical-1.png';
 
 // ─────────────────────────────────────────────────────────────
 // Constants
@@ -55,8 +55,8 @@ const CONTACT_COLUMNS = [
 // Styles
 // ─────────────────────────────────────────────────────────────
 
-// The only custom styling is fitting the illustration inside its AspectRatio
-// box without distortion (contain, not cover — it's line art, don't crop it).
+// The only custom styling is fitting the cover photo inside its AspectRatio
+// box (cover, not contain — it's a photograph, so crop it to fill the frame).
 // No objectFit prop on AspectRatio, and there's no Image primitive (#2582).
 const styles = stylex.create({
   page: {
@@ -65,7 +65,7 @@ const styles = stylex.create({
   illustrationImg: {
     width: '100%',
     height: '100%',
-    objectFit: 'contain',
+    objectFit: 'cover',
   },
 });
 
@@ -105,11 +105,7 @@ export default function FormTwoColumnPage() {
 
   return (
     <Center xstyle={styles.page}>
-      <Section
-        maxWidth={1100}
-        width="100%"
-        padding={10}
-        variant="transparent">
+      <Section maxWidth={1100} width="100%" padding={10} variant="transparent">
         <VStack gap={10}>
           {/* ── Top: two-column, stacks to one column below ~520px ── */}
           <Grid columns={{minWidth: 320}} align="center" gap={10}>
@@ -127,7 +123,7 @@ export default function FormTwoColumnPage() {
               <AspectRatio ratio={4 / 3}>
                 <img
                   src={ILLUSTRATION_URL}
-                  alt="Person with a laptop and a lightbulb idea"
+                  alt="Two people working at a desk"
                   {...stylex.props(styles.illustrationImg)}
                 />
               </AspectRatio>
@@ -188,9 +184,7 @@ export default function FormTwoColumnPage() {
                 </Grid>
 
                 <VStack gap={2}>
-                  <Text type="label">
-                    What are you reaching out about?
-                  </Text>
+                  <Text type="label">What are you reaching out about?</Text>
                   <HStack gap={2} wrap="wrap">
                     {INQUIRY_REASONS.map(reason => (
                       <Token


### PR DESCRIPTION
## Summary
- Swap the **Two-column Form** template's image (`packages/cli/templates/pages/form-two-column/page.tsx`) to use the same cover photo as the **Login Split** template (`light-working-vertical-1.png`).
- Change `objectFit` from `contain` to `cover` since the new asset is a photograph (which should fill the frame) rather than the previous line-art illustration (which needed letterboxing).
- Update the image `alt` text to "Two people working at a desk" to match the new photo, consistent with Login Split.

## Test plan
- [ ] Render the Two-column Form template (`astryx template form-two-column`) and confirm the left column shows the login-split cover photo, cropped to fill its 4:3 `AspectRatio` box without distortion.
- [ ] Verify the photo matches the Login Split template's cover image.
- [ ] Confirm responsive stacking (<520px) and the rest of the form layout are unaffected.

Made with [Cursor](https://cursor.com)