### PR TITLE
fix(cli): include jscodeshift runtime dependency

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -55,7 +55,8 @@
   "dependencies": {
     "@clack/prompts": "^1.5.1",
     "commander": "^12.1.0",
-    "jiti": "^2.7.0"
+    "jiti": "^2.7.0",
+    "jscodeshift": "^17.3.0"
   },
   "peerDependencies": {
     "@astryxdesign/core": "*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -727,6 +727,9 @@ importers:
       jiti:
         specifier: ^2.7.0
         version: 2.7.0
+      jscodeshift:
+        specifier: ^17.3.0
+        version: 17.3.0
     devDependencies:
       '@astryxdesign/core':
         specifier: '*'
@@ -1204,12 +1207,6 @@ packages:
 
   '@babel/plugin-transform-flow-strip-types@7.27.1':
     resolution: {integrity: sha512-G5eDKsu50udECw7DL2AcsysXiQyB7Nfg521t2OAJ4tbfTJ27doHLeF/vlI1NZGlLdbb/v+ibvtL1YBQqYOwJGg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-modules-commonjs@7.28.6':
-    resolution: {integrity: sha512-jppVbf8IV9iWWwWTQIxJMAJCWBuuKx71475wHwYytrRGQ2CWiDvYlADQno3tcYpS/T2UUWFQp3nVtYfK/YBQrA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -6421,14 +6418,6 @@ snapshots:
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/plugin-syntax-flow': 7.29.7(@babel/core@7.29.7)
 
-  '@babel/plugin-transform-modules-commonjs@7.28.6(@babel/core@7.29.7)':
-    dependencies:
-      '@babel/core': 7.29.7
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
-      '@babel/helper-plugin-utils': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/plugin-transform-modules-commonjs@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
@@ -6611,7 +6600,7 @@ snapshots:
       outdent: 0.5.0
       prettier: 3.8.4
       resolve-from: 5.0.0
-      semver: 7.8.0
+      semver: 7.8.5
 
   '@changesets/assemble-release-plan@6.0.10':
     dependencies:
@@ -6620,7 +6609,7 @@ snapshots:
       '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
       '@manypkg/get-packages': 1.1.3
-      semver: 7.8.0
+      semver: 7.8.5
 
   '@changesets/changelog-git@0.2.1':
     dependencies:
@@ -6677,7 +6666,7 @@ snapshots:
       '@changesets/types': 6.1.0
       '@manypkg/get-packages': 1.1.3
       picocolors: 1.1.1
-      semver: 7.8.0
+      semver: 7.8.5
 
   '@changesets/get-release-plan@4.0.16':
     dependencies:
@@ -9875,9 +9864,9 @@ snapshots:
   jscodeshift@17.3.0:
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/parser': 7.29.3
+      '@babel/parser': 7.29.7
       '@babel/plugin-transform-class-properties': 7.28.6(@babel/core@7.29.7)
-      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.7)
       '@babel/plugin-transform-nullish-coalescing-operator': 7.28.6(@babel/core@7.29.7)
       '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.29.7)
       '@babel/plugin-transform-private-methods': 7.28.6(@babel/core@7.29.7)
@@ -10647,7 +10636,7 @@ snapshots:
     dependencies:
       '@img/colour': 1.1.0
       detect-libc: 2.1.2
-      semver: 7.8.4
+      semver: 7.8.5
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.34.5
       '@img/sharp-darwin-x64': 0.34.5


### PR DESCRIPTION
## Summary

Adds `jscodeshift` as a runtime dependency of `@astryxdesign/cli`.

`astryx upgrade` codemods require `jscodeshift`. When consumers install the CLI and run upgrade codemods in environments where dynamic package installation is blocked or registry-scoped, the CLI can fail before codemods run. Making `jscodeshift` a direct CLI dependency keeps the Astryx upgrade command self-contained once `@astryxdesign/cli` is installed.

The legacy `xds` binary remains supported, but this change is for the Astryx CLI package and should be described in Astryx terms going forward.

## Test Plan

- `pnpm install`
- `pnpm -F @astryxdesign/cli typecheck:json-api`
- commit hook repo checks passed (`check:sync`, `check:package-boundaries`, `check:changesets`)