### PR TITLE
fix(docs): correct Toolbar and MoreMenu prop docs to match component APIs

### DIFF
--- a/packages/core/src/MoreMenu/MoreMenu.doc.mjs
+++ b/packages/core/src/MoreMenu/MoreMenu.doc.mjs
@@ -54,12 +54,6 @@ export const docs = {
       default: 'true',
     },
     {
-      name: 'children',
-      type: '(item: DropdownMenuItemData) => ReactNode',
-      description:
-        'Custom render function for items. Only called for selectable items (not dividers/sections).',
-    },
-    {
       name: 'xstyle',
       type: 'StyleXStyles',
       description:
@@ -140,12 +134,6 @@ export const docsZh = {
       default: 'true',
     },
     {
-      name: 'children',
-      type: '(item: DropdownMenuItemData) => ReactNode',
-      description:
-        '自定义项目渲染函数。仅对可选择的项目调用（不包括分割线/分组）。',
-    },
-    {
       name: 'xstyle',
       type: 'StyleXStyles',
       description:
@@ -189,7 +177,6 @@ export const docsDense = {
     icon: 'Override default three-dot icon. Accepts any ReactNode.',
     isDisabled: 'Whether menu trigger disabled.',
     hasAutoFocus: 'Auto-focus first item on open; false for showcases.',
-    children: 'Custom render function for selectable items (not dividers/sections).',
     xstyle:
       'StyleX styles for layout customization (margins, positioning, sizing). Must be stylex.create() value.',
   },

--- a/packages/core/src/Toolbar/Toolbar.doc.mjs
+++ b/packages/core/src/Toolbar/Toolbar.doc.mjs
@@ -9,7 +9,7 @@ export const docs = {
   keywords: ['toolbar', 'nav', 'bar', 'actions', 'buttonbar', 'header', 'footer', 'action-bar', 'control-bar'],
   theming: {
     targets: [
-      {className: 'astryx-toolbar', states: ['density']},
+      {className: 'astryx-toolbar', states: ['size']},
     ],
   },
   components: [
@@ -48,10 +48,11 @@ export const docs = {
           ],
         },
         {
-          name: 'density',
-          type: "'compact' | 'default'",
-          description: 'Toolbar density. Controls minimum height.',
-          default: "'default'",
+          name: 'size',
+          type: "'sm' | 'md' | 'lg'",
+          description:
+            'Size of the toolbar. Controls minimum height and coordinates with Button, TextInput, TabList, and Selector — children inherit this size as their default via SizeContext.',
+          default: "'md'",
         },
         {
           name: 'gap',
@@ -107,7 +108,7 @@ export const docsZh = {
         startContent: '起始内容（LTR 中靠左对齐）。',
         centerContent: '居中内容。切换为 CSS grid（1fr auto 1fr）。',
         endContent: '结束内容（LTR 中靠右对齐）。',
-        density: '工具栏密度。控制最小高度。',
+        size: '工具栏尺寸。控制最小高度，子组件通过 SizeContext 继承此尺寸作为默认值。',
         gap: '插槽内项目间距。',
         orientation: '键盘导航方向。控制方向键方向。',
         variant: '传递给 Section 的视觉变体。',
@@ -156,7 +157,7 @@ export const docsDense = {
         startContent: 'Start-aligned content.',
         centerContent: 'Centered content; switches to 3-col grid.',
         endContent: 'End-aligned content.',
-        density: 'Toolbar density; controls min-height.',
+        size: 'Toolbar size; controls min-height + cascades to children via SizeContext.',
         gap: 'Gap between slot items.',
         orientation: 'Keyboard nav direction.',
         variant: 'Visual variant for Section.',


### PR DESCRIPTION
## Summary

Corrects two component docs (`{Name}.doc.mjs`) that documented props which do
not exist on the actual components. These structured docs feed the agent-facing
CLI output (`astryx component <Name>`) and the docsite prop tables, so an
incorrect entry steers code generation toward props the component rejects.

### Root cause / trigger

While investigating a report that generated code passed `isActive` to
`TopNavItem` (which threw, since `TopNavItem` only accepts `isSelected`), I
swept every `*.doc.mjs` against its component's real TypeScript prop interface.
The `TopNavItem`/`isActive` case turned out to be a generation error, not a doc
bug — the component, its doc, the templates, and the stories all consistently
use `isSelected`, with no `isActive` anywhere. But the sweep surfaced two
genuine doc-vs-API mismatches:

### 1. Toolbar — documented `density`, real prop is `size`

`Toolbar.doc.mjs` documented a `density` prop (`'compact' | 'default'`) that the
component does not have. The real prop is `size` (`'sm' | 'md' | 'lg'`, default
`'md'`), which the docs omitted entirely. The component reflects this as
`data-size` via `themeProps('toolbar', { size })`, but the theming target listed
`states: ['density']`.

- Replaced the `density` prop entry with `size` (correct type, values, default,
  and description) in `docs`, `docsZh`, and `docsDense`.
- Corrected the theming state from `['density']` to `['size']` so it matches the
  emitted `data-size` attribute.

### 2. MoreMenu — documented a non-existent `children` render prop

`MoreMenu.doc.mjs` documented a `children` render-function prop
(`(item) => ReactNode`). `MoreMenuProps` does not declare `children`, and the
component never forwards one — it passes only the `items` data array through to
`DropdownMenu`. Removed the `children` entry from `docs`, `docsZh`, and
`docsDense`.

## Sweep result

A systematic comparison of all 187 `*.doc.mjs` files against their components'
real prop interfaces found only these two genuine mismatches. All other
candidates were verified as accurate (props inherited via `extends`/`Omit`/
`Pick`, documented under sub-component entries, or sourced from companion option
types such as `useToast` options).

## Verification

- `pnpm -F @astryxdesign/core typecheck:docs` — passes
- `pnpm -F @astryxdesign/cli typecheck:template-docs` — passes
- `astryx component Toolbar` now shows `size` and `data-size`; `astryx component
  MoreMenu` no longer lists `children`.
- No example snippets, stories, or templates referenced the removed props, so no
  usage code needed changes.
