### PR TITLE
feat(docsite): live theme + template previews on landing feature cards

### DIFF
--- a/apps/docsite/src/app/(site)/_landing/CliPreview.tsx
+++ b/apps/docsite/src/app/(site)/_landing/CliPreview.tsx
@@ -2,9 +2,8 @@
 
 'use client';
 
-import {useState} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {Send, Check} from 'lucide-react';
+import {Send} from 'lucide-react';
 import {VStack, HStack} from '@astryxdesign/core/Layout';
 import {IconButton} from '@astryxdesign/core/IconButton';
 import {Text} from '@astryxdesign/core/Text';
@@ -20,6 +19,8 @@ const styles = stylex.create({
     width: '100%',
     maxWidth: 360,
     marginInline: 'auto',
+    // Decorative preview — never interactive.
+    pointerEvents: 'none',
   },
   helper: {
     paddingInlineStart: spacingVars['--spacing-3'],
@@ -46,10 +47,8 @@ const styles = stylex.create({
 });
 
 export function CliPreview() {
-  const [sent, setSent] = useState(false);
-
   return (
-    <VStack gap={3} align="stretch" xstyle={styles.root}>
+    <VStack gap={3} align="stretch" xstyle={styles.root} inert>
       <Text type="supporting" color="secondary" xstyle={styles.helper}>
         How can i help you today?
       </Text>
@@ -59,13 +58,9 @@ export function CliPreview() {
           Can you create me a table page
         </Text>
         <IconButton
-          label={sent ? 'Message sent' : 'Send message'}
-          icon={sent ? <Check size={16} /> : <Send size={16} />}
+          label="Send message"
+          icon={<Send size={16} />}
           size="md"
-          onClick={() => {
-            setSent(true);
-            window.setTimeout(() => setSent(false), 600);
-          }}
           xstyle={styles.sendButton}
         />
       </HStack>

--- a/apps/docsite/src/app/(site)/_landing/ComponentsPreview.tsx
+++ b/apps/docsite/src/app/(site)/_landing/ComponentsPreview.tsx
@@ -20,6 +20,8 @@ const styles = stylex.create({
     width: '100%',
     maxWidth: 360,
     marginInline: 'auto',
+    // Decorative preview — never interactive.
+    pointerEvents: 'none',
   },
   controlsRow: {
     rowGap: spacingVars['--spacing-3'],
@@ -38,7 +40,7 @@ export function ComponentsPreview() {
   const [search, setSearch] = useState('');
 
   return (
-    <VStack gap={4} align="stretch" xstyle={styles.root}>
+    <VStack gap={4} align="stretch" xstyle={styles.root} inert>
       <HStack
         gap={2}
         hAlign="evenly"

--- a/apps/docsite/src/app/(site)/_landing/FeaturesShowcase.tsx
+++ b/apps/docsite/src/app/(site)/_landing/FeaturesShowcase.tsx
@@ -368,9 +368,8 @@ const features: Record<string, Feature> = {
     description:
       'Fully customizable themes ready for use. Make it yours without starting from scratch.',
     href: '/themes',
-    // Live Butter-themed faux landing + static Butter swatches/"Aa" instead of
-    // the old /feature-brand.png — the PNG stayed light on the dark surface;
-    // ThemesPreview's left panel re-themes for dark mode via the Butter scope.
+    // Live Butter-themed store preview + swatches/"Aa" instead of the old
+    // /feature-brand.png, so it re-themes for dark mode (the PNG stayed light).
     preview: <ThemesPreview />,
   },
   templates: {
@@ -378,10 +377,9 @@ const features: Record<string, Feature> = {
     description:
       'Production-ready templates for common pages, just plug in your content.',
     href: '/templates',
-    // Live scaled-down renders of the same real page templates the old
-    // /feature-templates.png collage showed (storefront, IDE, payment, login,
-    // product detail, AI chat, gallery) — re-themes for dark mode and stays in
-    // sync with the actual templates instead of a baked screenshot.
+    // Live scaled-down renders of real page templates instead of the baked
+    // /feature-templates.png, so they re-theme for dark mode and stay in sync
+    // with the actual templates.
     preview: <TemplatesPreview />,
   },
   cli: {

--- a/apps/docsite/src/app/(site)/_landing/FeaturesShowcase.tsx
+++ b/apps/docsite/src/app/(site)/_landing/FeaturesShowcase.tsx
@@ -13,6 +13,8 @@ import {components} from '../../../generated/componentRegistry';
 import {layout} from '../../../layout.stylex';
 import {ComponentsPreview} from './ComponentsPreview';
 import {CliPreview} from './CliPreview';
+import {ThemesPreview} from './ThemesPreview';
+import {TemplatesPreview} from './TemplatesPreview';
 
 // Count of public @astryxdesign/core components (excluding hooks and hidden entries).
 // Sourced from the generated registry so the number stays accurate as the
@@ -57,9 +59,12 @@ const styles = stylex.create({
     maxWidth: layout.contentMaxWidth,
     display: 'grid',
     gap: spacingVars['--spacing-8'],
+    // minmax(0, 1fr) (not 1fr) so a card with wide content — e.g. the Themes
+    // preview's left-bleed — can't blow out its column; all three stay equal.
     gridTemplateColumns: {
       default: '1fr',
-      '@media (min-width: 1024px)': '1fr 1fr 1fr',
+      '@media (min-width: 1024px)':
+        'minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr)',
     },
     minHeight: {
       default: 0,
@@ -275,8 +280,20 @@ const styles = stylex.create({
     maxWidth: '100%',
     overflow: 'hidden',
   },
-  // Inset wrapper for a live preview node, pinned to the card's bottom.
+  // Inset wrapper for a live preview node. A fixed top gap (not marginTop:auto)
+  // keeps the space under "Explore" consistent across preview cards; any extra
+  // card height falls below the framed preview rather than above it.
   previewWrap: {
+    paddingTop: spacingVars['--spacing-10'],
+    alignSelf: 'stretch',
+    width: '100%',
+    minWidth: 0,
+    maxWidth: '100%',
+  },
+  // Bottom-anchored preview wrapper. marginTop:auto pushes the preview to the
+  // bottom of the card's content column so any extra card height opens up ABOVE
+  // it (used by the Themes card so its store preview sits flush at the bottom).
+  previewWrapBottom: {
     marginTop: 'auto',
     paddingTop: spacingVars['--spacing-10'],
     alignSelf: 'stretch',
@@ -351,20 +368,21 @@ const features: Record<string, Feature> = {
     description:
       'Fully customizable themes ready for use. Make it yours without starting from scratch.',
     href: '/themes',
-    image: {
-      src: '/feature-brand.png',
-      alt: "A product landing page styled with the Butter theme, shown alongside the theme's color swatches and type sample",
-    },
+    // Live Butter-themed faux landing + static Butter swatches/"Aa" instead of
+    // the old /feature-brand.png — the PNG stayed light on the dark surface;
+    // ThemesPreview's left panel re-themes for dark mode via the Butter scope.
+    preview: <ThemesPreview />,
   },
   templates: {
     title: 'Ready to ship templates',
     description:
       'Production-ready templates for common pages, just plug in your content.',
     href: '/templates',
-    image: {
-      src: '/feature-templates.png',
-      alt: 'A scattered collage of ready-to-use page templates — product gallery, code editor, checkout summary, login, product detail, and AI chat',
-    },
+    // Live scaled-down renders of the same real page templates the old
+    // /feature-templates.png collage showed (storefront, IDE, payment, login,
+    // product detail, AI chat, gallery) — re-themes for dark mode and stays in
+    // sync with the actual templates instead of a baked screenshot.
+    preview: <TemplatesPreview />,
   },
   cli: {
     title: 'A design system that your agent can use',
@@ -385,6 +403,7 @@ function FeatureCard({
   insetImage = false,
   centerImage = false,
   smallImage = false,
+  bottomPreview = false,
 }: {
   feature: Feature;
   /**
@@ -424,6 +443,12 @@ function FeatureCard({
    * the full card width.
    */
   smallImage?: boolean;
+  /**
+   * When true, a live preview is pinned to the bottom of the card (extra
+   * card height opens above it) instead of sitting just under "Explore".
+   * Used by the Themes card. Ignored for image cards.
+   */
+  bottomPreview?: boolean;
 }) {
   const hasImage = feature.image != null;
   const hasPreview = feature.preview != null;
@@ -474,8 +499,14 @@ function FeatureCard({
         </Link>
         {hasPreview ? (
           // vAlign="center" + hAlign="center" centers the preview in
-          // the card's leftover vertical+horizontal space.
-          <HStack hAlign="center" vAlign="center" xstyle={styles.previewWrap}>
+          // the card's leftover horizontal space; bottomPreview pins it to the
+          // bottom of the card instead of the fixed top gap.
+          <HStack
+            hAlign="center"
+            vAlign="center"
+            xstyle={
+              bottomPreview ? styles.previewWrapBottom : styles.previewWrap
+            }>
             {feature.preview}
           </HStack>
         ) : (
@@ -584,14 +615,14 @@ export function FeaturesShowcase() {
             owns only the responsive display switch. */}
         <VStack gap={8} width="100%" height="100%" xstyle={styles.column}>
           <HeadingBlock />
-          <FeatureCard feature={features.themes} isFlex centerImage />
+          <FeatureCard feature={features.themes} isFlex bottomPreview />
         </VStack>
         <VStack gap={8} width="100%" height="100%" xstyle={styles.column}>
           <FeatureCard feature={features.components} isFlex insetImage />
           <FeatureCard feature={features.cli} />
         </VStack>
         <VStack gap={8} width="100%" height="100%" xstyle={styles.column}>
-          <FeatureCard feature={features.templates} isTall />
+          <FeatureCard feature={features.templates} isTall bottomPreview />
         </VStack>
       </div>
     </VStack>

--- a/apps/docsite/src/app/(site)/_landing/TemplatesPreview.tsx
+++ b/apps/docsite/src/app/(site)/_landing/TemplatesPreview.tsx
@@ -51,12 +51,11 @@ const styles = stylex.create({
     // Decorative — never interactive (TemplateThumbnail is already inert).
     pointerEvents: 'none',
   },
-  // Narrow card: a vertical stack of 2-per-row groups (each row offset/bled).
-  // Wide card: a single 3-column grid (the row wrappers dissolve via
-  // display:contents below, so all 6 tiles flow into these 3 columns → 2 lines).
+  // Narrow card: a flex-column stack of 2-per-row groups (each row offset/bled).
+  // Wide card: a single 3-column grid — the row wrappers dissolve via
+  // display:contents below, so all 6 tiles flow into these 3 columns → 2 lines.
+  // (The unused flex/grid properties for each mode are ignored.)
   root: {
-    // flex column (stack of rows) on a narrow card; grid (3 per line) on a wide
-    // card. The unused properties for each mode are simply ignored.
     display: {
       default: 'flex',
       [WIDE_CARD]: 'grid',

--- a/apps/docsite/src/app/(site)/_landing/TemplatesPreview.tsx
+++ b/apps/docsite/src/app/(site)/_landing/TemplatesPreview.tsx
@@ -1,0 +1,155 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import * as stylex from '@stylexjs/stylex';
+import {
+  spacingVars,
+  radiusVars,
+  shadowVars,
+} from '@astryxdesign/core/theme/tokens.stylex';
+import {TemplateThumbnail} from '../../../components/TemplateThumbnail';
+
+// A representative set of the real page templates (storefront, IDE, payment,
+// login, settings, AI chat, product detail). Live scaled-down renders via
+// TemplateThumbnail so they re-theme for dark mode. Grouped into rows; the
+// middle row holds three so the centered (login) template sits in the middle.
+const TEMPLATE_ROWS: string[][] = [
+  ['product-gallery', 'ide'],
+  ['payment-form', 'login-split', 'settings-sidebar'],
+  ['ai-chat-landing', 'product-detail'],
+];
+
+// On small screens the rows flow into a single 3-column grid; 7 templates would
+// leave a lone 7th tile, so this one is dropped there to keep a clean 3 + 3.
+const HIDE_ON_SMALL = 'product-detail';
+
+// Desktop width each template renders at before being shrunk to fit — a desktop
+// width shows the WHOLE page composition (nav + hero + content), not a zoomed-in
+// top-left corner.
+const RENDER_WIDTH = 1100;
+// Uniform tile aspect ratio so every block is the same height (and, in a 2-col
+// grid, the same width). Slightly taller than 16/10 to show a bit more of each
+// page.
+const TILE_RATIO = '16/11.5';
+
+// The bento column is narrow even on wide screens (3-column desktop grid), so
+// the 50%-wider, staggered, bleeding 2-per-row layout only makes sense there.
+// Once the card itself is wide — the single-column stack on small screens — the
+// rows dissolve into a single 3-per-line grid so the tiles aren't huge and use
+// the width better. Keyed to the CARD width via a container query, not viewport.
+const WIDE_CARD = '@container templatesPreview (min-width: 400px)';
+
+const styles = stylex.create({
+  // Query container — a plain wrapper whose width the layout below responds to.
+  // (A container can't respond to its OWN @container query, so the responsive
+  // layout must live on a descendant, not on this element.)
+  container: {
+    containerType: 'inline-size',
+    containerName: 'templatesPreview',
+    width: '100%',
+    // Decorative — never interactive (TemplateThumbnail is already inert).
+    pointerEvents: 'none',
+  },
+  // Narrow card: a vertical stack of 2-per-row groups (each row offset/bled).
+  // Wide card: a single 3-column grid (the row wrappers dissolve via
+  // display:contents below, so all 6 tiles flow into these 3 columns → 2 lines).
+  root: {
+    // flex column (stack of rows) on a narrow card; grid (3 per line) on a wide
+    // card. The unused properties for each mode are simply ignored.
+    display: {
+      default: 'flex',
+      [WIDE_CARD]: 'grid',
+    },
+    flexDirection: 'column',
+    gridTemplateColumns: {
+      default: 'none',
+      [WIDE_CARD]: 'repeat(3, 1fr)',
+    },
+    gap: spacingVars['--spacing-5'],
+    width: '100%',
+  },
+  // Narrow card: each row is a uniform grid, centered so the extra width bleeds
+  // evenly off both edges (clipped by the card's overflow). Wide card: the row
+  // wrapper dissolves (display:contents) so its tiles flow into the root's
+  // 3-column grid. Width/offset is set per column-count below so EVERY tile is
+  // the same size regardless of how many are in the row.
+  row: {
+    display: {
+      default: 'grid',
+      [WIDE_CARD]: 'contents',
+    },
+    gap: spacingVars['--spacing-5'],
+  },
+  // 2-up row: 150% wide → each tile ≈ 75% of the card. Centered.
+  cols2: {
+    gridTemplateColumns: '1fr 1fr',
+    width: '150%',
+    marginInline: '-25%',
+  },
+  // 3-up row: 225% wide so each tile is the SAME ~75%-of-card size as the 2-up
+  // rows (3 × 75% = 225%). Centered, so the middle tile is fully visible and the
+  // outer two bleed off the edges (clipped) — matching the others' tile size.
+  cols3: {
+    gridTemplateColumns: 'repeat(3, 1fr)',
+    width: '225%',
+    marginInline: '-62.5%',
+  },
+  // Frame each thumbnail with a subtle border + clip and an elevation shadow so
+  // each scaled page reads as a tidy, lifted card tile rather than a flat render.
+  tile: {
+    borderRadius: radiusVars['--radius-inner'],
+    overflow: 'hidden',
+    borderWidth: '1px',
+    borderStyle: 'solid',
+    borderColor: 'var(--color-border)',
+    backgroundColor: 'var(--color-background-surface)',
+    boxShadow: shadowVars['--shadow-med'],
+  },
+  // Hidden on a wide card (small screens): with 7 templates the dissolved
+  // 3-column grid would leave a lone 7th tile (3 + 3 + 1), so one tile drops out
+  // to keep a clean 3 + 3. It still shows in the narrow-card desktop layout.
+  hideOnWide: {
+    display: {
+      default: 'block',
+      [WIDE_CARD]: 'none',
+    },
+  },
+});
+
+export function TemplatesPreview() {
+  return (
+    <div {...stylex.props(styles.container)} inert>
+      <div {...stylex.props(styles.root)}>
+        {TEMPLATE_ROWS.map((row, rowIndex) => (
+          <div
+            key={rowIndex}
+            {...stylex.props(
+              styles.row,
+              row.length === 3 ? styles.cols3 : styles.cols2,
+            )}>
+            {row.map(slug => (
+              <div
+                key={slug}
+                {...stylex.props(
+                  styles.tile,
+                  slug === HIDE_ON_SMALL && styles.hideOnWide,
+                )}>
+                {/* borderRadius="0" so the thumbnail fills the tile's rounded
+                    corners flush — the tile already rounds + clips, so the
+                    thumbnail's own --radius-container would otherwise nest a
+                    second, mismatched radius. */}
+                <TemplateThumbnail
+                  slug={slug}
+                  aspectRatio={TILE_RATIO}
+                  renderWidth={RENDER_WIDTH}
+                  borderRadius="0"
+                />
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/docsite/src/app/(site)/_landing/ThemesPreview.tsx
+++ b/apps/docsite/src/app/(site)/_landing/ThemesPreview.tsx
@@ -30,18 +30,14 @@ const butterTheme = themeObjects['@astryxdesign/theme-butter'];
 // stays in sync with the themes page.
 const butterContent = getThemeShowcaseContent('butter');
 
-// The swatches + "Aa" wordmark read the Butter theme's CSS vars directly (the
-// rail is wrapped in a Butter <Theme> scope below), instead of hardcoded hex —
-// brand --color-accent, the yellow categorical background, and the creamy
-// --color-background-body — so they stay in sync with the theme and follow
-// light/dark like the rest of the preview.
+// Swatch + "Aa" colors as Butter theme tokens (resolved via the Butter <Theme>
+// scope around the rail below) rather than hardcoded hex, so they stay in sync.
 const BUTTER_BLUE = 'var(--color-accent)';
 const BUTTER_YELLOW = 'var(--color-background-yellow)';
 const BUTTER_CREAM = 'var(--color-background-body)';
 
-// Butter's signature display cursive (theme scopes it to text display roles via
-// type:display-*); set explicitly for the static "Aa" since it sits outside the
-// Butter <Theme> scope.
+// Butter's signature display cursive — the theme only applies it to display-role
+// text, so the "Aa" sets the family explicitly.
 const BUTTER_SCRIPT = 'Sarina, "Brush Script MT", "Snell Roundhand", cursive';
 
 // The store template's natural (pre-scale) render width and the layout height
@@ -146,8 +142,7 @@ const styles = stylex.create({
     transform: `scale(calc(min(${STORE_MAX}px, calc(100cqw - ${RAIL_RESERVE}px)) / ${STORE_RENDER_WIDTH + 4}px))`,
     transformOrigin: 'top left',
   },
-  // Static Butter palette swatches + script wordmark, stacked vertically on the
-  // right and left-aligned (the swatches and the "Aa" share a common left edge).
+  // Butter swatches + script wordmark, stacked vertically and left-aligned.
   rail: {
     flexShrink: 0,
     flexDirection: 'column',
@@ -189,11 +184,9 @@ const FORCE_DESKTOP_MOBILE_CONTEXT: AppShellMobileContextValue = {
   hasAutoToggle: false,
 };
 
-// Live, theme-aware replacement for the old /feature-brand.png. The LEFT panel
-// reuses the real /themes showcase (ThemeShowcaseStore + Butter content) inside
-// the Butter <Theme> scope — real themed surfaces, so it's dark-mode correct
-// and stays in sync with the themes page. The RIGHT rail keeps the reference's
-// static Butter swatches + script "Aa".
+// Live, theme-aware replacement for the old /feature-brand.png: the real /themes
+// ThemeShowcaseStore (Butter content) on the left + Butter swatches & script "Aa"
+// on the right, both in a Butter <Theme> scope so they're dark-mode correct.
 export function ThemesPreview() {
   // Follow the docsite light/dark toggle so the Butter preview switches modes
   // (keeps Butter's palette; 'system' defers to the OS before the toggle).

--- a/apps/docsite/src/app/(site)/_landing/ThemesPreview.tsx
+++ b/apps/docsite/src/app/(site)/_landing/ThemesPreview.tsx
@@ -30,13 +30,14 @@ const butterTheme = themeObjects['@astryxdesign/theme-butter'];
 // stays in sync with the themes page.
 const butterContent = getThemeShowcaseContent('butter');
 
-// Butter's literal palette for the STATIC swatches + "Aa" wordmark (rendered
-// outside the themed scope, so they can't read tokens). Values mirror
-// packages/themes/butter/src/butterTheme.ts: brand --color-accent, the yellow
-// categorical background, and the creamy --color-background-body.
-const BUTTER_BLUE = '#225BFF';
-const BUTTER_YELLOW = '#feee7b';
-const BUTTER_CREAM = '#FDFBE4';
+// The swatches + "Aa" wordmark read the Butter theme's CSS vars directly (the
+// rail is wrapped in a Butter <Theme> scope below), instead of hardcoded hex —
+// brand --color-accent, the yellow categorical background, and the creamy
+// --color-background-body — so they stay in sync with the theme and follow
+// light/dark like the rest of the preview.
+const BUTTER_BLUE = 'var(--color-accent)';
+const BUTTER_YELLOW = 'var(--color-background-yellow)';
+const BUTTER_CREAM = 'var(--color-background-body)';
 
 // Butter's signature display cursive (theme scopes it to text display roles via
 // type:display-*); set explicitly for the static "Aa" since it sits outside the
@@ -215,20 +216,24 @@ export function ThemesPreview() {
           </Theme>
         </Card>
 
-        <HStack gap={2} xstyle={styles.rail}>
-          <div
-            {...stylex.props(styles.swatch, swatchColors.fill(BUTTER_BLUE))}
-          />
-          <div
-            {...stylex.props(styles.swatch, swatchColors.fill(BUTTER_YELLOW))}
-          />
-          <div
-            {...stylex.props(styles.swatch, swatchColors.fill(BUTTER_CREAM))}
-          />
-          <span {...stylex.props(styles.railWordmark)} aria-hidden="true">
-            Aa
-          </span>
-        </HStack>
+        {/* Butter <Theme> scope (display:contents, no layout box) so the
+            swatches/"Aa" resolve the Butter --color-* tokens directly. */}
+        <Theme theme={butterTheme} mode={themeMode}>
+          <HStack gap={2} xstyle={styles.rail}>
+            <div
+              {...stylex.props(styles.swatch, swatchColors.fill(BUTTER_BLUE))}
+            />
+            <div
+              {...stylex.props(styles.swatch, swatchColors.fill(BUTTER_YELLOW))}
+            />
+            <div
+              {...stylex.props(styles.swatch, swatchColors.fill(BUTTER_CREAM))}
+            />
+            <span {...stylex.props(styles.railWordmark)} aria-hidden="true">
+              Aa
+            </span>
+          </HStack>
+        </Theme>
       </div>
     </div>
   );

--- a/apps/docsite/src/app/(site)/_landing/ThemesPreview.tsx
+++ b/apps/docsite/src/app/(site)/_landing/ThemesPreview.tsx
@@ -1,0 +1,235 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import * as stylex from '@stylexjs/stylex';
+import {
+  AppShellMobileContext,
+  type AppShellMobileContextValue,
+} from '@astryxdesign/core/AppShell';
+import {Card} from '@astryxdesign/core/Card';
+import {HStack} from '@astryxdesign/core/Layout';
+import {Theme} from '@astryxdesign/core/theme';
+import {
+  radiusVars,
+  shadowVars,
+  spacingVars,
+} from '@astryxdesign/core/theme/tokens.stylex';
+import {ThemeShowcaseStore} from '../../../../../../packages/cli/templates/pages/theme-showcase/page';
+import {getThemeShowcaseContent} from '../../../components/themeShowcaseContent';
+import {themeObjects} from '../../../generated/themeRegistry';
+import {useThemeMode} from '../../providers';
+
+// Built Butter theme (__built:true) — same registry the hero reel + /themes
+// page pull from, so the left preview renders pre-built CSS with no runtime
+// injection.
+const butterTheme = themeObjects['@astryxdesign/theme-butter'];
+
+// Butter's bespoke showcase content (breakfast products + inventory) — the
+// same source of truth the /themes page feeds ThemeShowcaseStore, so this card
+// stays in sync with the themes page.
+const butterContent = getThemeShowcaseContent('butter');
+
+// Butter's literal palette for the STATIC swatches + "Aa" wordmark (rendered
+// outside the themed scope, so they can't read tokens). Values mirror
+// packages/themes/butter/src/butterTheme.ts: brand --color-accent, the yellow
+// categorical background, and the creamy --color-background-body.
+const BUTTER_BLUE = '#225BFF';
+const BUTTER_YELLOW = '#feee7b';
+const BUTTER_CREAM = '#FDFBE4';
+
+// Butter's signature display cursive (theme scopes it to text display roles via
+// type:display-*); set explicitly for the static "Aa" since it sits outside the
+// Butter <Theme> scope.
+const BUTTER_SCRIPT = 'Sarina, "Brush Script MT", "Snell Roundhand", cursive';
+
+// The store template's natural (pre-scale) render width and the layout height
+// at which the first section ends — just below the 3 product cards (the cards'
+// bottom sits at ~748px; +20px leaves a clean gap before the crop). The window
+// uses this ratio so it always crops right under the products (showing the full
+// nav + hero + product cards) regardless of how big the store is scaled.
+const STORE_RENDER_WIDTH = 1000;
+const STORE_CROP_HEIGHT = 768;
+// Max width of the store window on wide cards (the scaled-down desktop store).
+// Larger than the card's content box so the store bleeds symmetrically into the
+// card's inset (see container) — this gives the preview more height (taller)
+// while staying centered.
+const STORE_MAX = 360;
+// Horizontal space reserved beside the store for the swatches/"Aa" rail (gap +
+// rail width + breathing room). The fluid store width subtracts this from the
+// available width so the rail always stays inside the card with comfortable
+// clearance — the cursive "Aa" slants/overhangs past its box, so the reserve is
+// generous enough that it never touches the card's right edge, even in the
+// narrow 3-column grid.
+const RAIL_RESERVE = 72;
+// Extra left shift beyond the inset cancellation (applied only when the card is
+// narrow — the 3-column desktop grid) — pushes the composition further left so
+// the store bleeds PAST the card's left edge (the card's overflow:hidden clips
+// it), giving the off-canvas, anchored-left look. On a wide single-column card
+// (small screens) the composition is centered instead (no shift).
+const SHIFT_LEFT = 40;
+// Container-width threshold separating the narrow 3-column-grid card (left-
+// anchored + shifted) from the wide single-column card (centered). The 3-column
+// cards measure ~300-380px of container width; the single-column card is wider.
+const WIDE_CARD = '@container themesPreview (min-width: 400px)';
+
+const styles = stylex.create({
+  // Container so the store + rail size FLUIDLY off the card's width, not the
+  // viewport. The bento column is narrow even on wide screens (the 3-column
+  // desktop grid), so a viewport media query can't tell when the card is tight.
+  // Symmetric bleed: reclaims BOTH of the card's insets (--spacing-10 = 40px
+  // each) so the store can be bigger. flexShrink 0 keeps the widened box from
+  // being collapsed by the parent flex (previewWrap is an HStack).
+  container: {
+    containerType: 'inline-size',
+    containerName: 'themesPreview',
+    flexShrink: 0,
+    width: `calc(100% + 2 * ${spacingVars['--spacing-10']})`,
+    marginInline: `calc(-1 * ${spacingVars['--spacing-10']})`,
+  },
+  // Horizontal composition: themed store preview + static swatches/"Aa" rail.
+  // Narrow card (3-column grid): left-anchored and shifted further left so the
+  // store bleeds past the card's left edge (off-canvas look). Wide single-column
+  // card (small screens): centered as a group (the original layout).
+  root: {
+    display: 'flex',
+    flexDirection: 'row',
+    // Top-align so the store starts right under "Explore" (matching the gap on
+    // the other cards) rather than being vertically centered.
+    alignItems: 'flex-start',
+    justifyContent: {
+      default: 'flex-start',
+      [WIDE_CARD]: 'center',
+    },
+    // Push past the card's left edge only on narrow cards; none when centered.
+    marginInlineStart: {
+      default: `calc(-1 * ${SHIFT_LEFT}px)`,
+      [WIDE_CARD]: 0,
+    },
+    gap: spacingVars['--spacing-4'],
+    width: '100%',
+  },
+  // Window around the scaled store (no border — transparent Card), rounded on
+  // all corners with an elevation shadow so the store preview lifts off the
+  // card. Width is FLUID: it fills the available width minus the space reserved
+  // for the rail (RAIL_RESERVE), capped at STORE_MAX. So the store shrinks on
+  // narrow cards and the swatches/"Aa" rail always stays inside.
+  showcaseCard: {
+    flexShrink: 0,
+    minWidth: 0,
+    width: `min(${STORE_MAX}px, calc(100cqw - ${RAIL_RESERVE}px))`,
+    overflow: 'hidden',
+    borderRadius: radiusVars['--radius-inner'],
+    boxShadow: shadowVars['--shadow-med'],
+  },
+  // Clipping viewport — its aspect ratio crops the scaled store right under the
+  // 3 product cards (showing the full nav + hero + products), cropping out the
+  // cream gap and the Checkout / Studio AI sections below. The ratio is the
+  // store's natural render width : crop height, so the crop point stays constant
+  // as the store scales fluidly with the card width.
+  scaleViewport: {
+    width: '100%',
+    aspectRatio: `${STORE_RENDER_WIDTH} / ${STORE_CROP_HEIGHT}`,
+    overflow: 'hidden',
+    // Decorative preview — never interactive (also inert on scaleInner).
+    pointerEvents: 'none',
+  },
+  // Render the store at its natural desktop width then scale it down to fit the
+  // fluid window. The scale is the window width / (render width + 4px slack),
+  // computed from the same fluid expression, so the store always fills the
+  // window with a hair to spare — no right-clip, no gutter — at any card width.
+  // calc() dividing a length by a length yields the unitless number scale()
+  // requires.
+  scaleInner: {
+    width: STORE_RENDER_WIDTH,
+    transform: `scale(calc(min(${STORE_MAX}px, calc(100cqw - ${RAIL_RESERVE}px)) / ${STORE_RENDER_WIDTH + 4}px))`,
+    transformOrigin: 'top left',
+  },
+  // Static Butter palette swatches + script wordmark, stacked vertically on the
+  // right and left-aligned (the swatches and the "Aa" share a common left edge).
+  rail: {
+    flexShrink: 0,
+    flexDirection: 'column',
+    alignItems: 'flex-start',
+  },
+  swatch: {
+    width: 22,
+    height: 22,
+    borderRadius: radiusVars['--radius-full'],
+    borderWidth: '1px',
+    borderStyle: 'solid',
+    // Subtle outline so the cream swatch stays visible on the card's pastel bg.
+    borderColor: 'rgba(29, 28, 17, 0.12)',
+  },
+  railWordmark: {
+    fontFamily: BUTTER_SCRIPT,
+    fontSize: 24,
+    lineHeight: 1,
+    color: BUTTER_BLUE,
+  },
+});
+
+const swatchColors = stylex.create({
+  fill: (color: string) => ({backgroundColor: color}),
+});
+
+// The store template's internal responsive grids read useAppShellMobile(), which
+// reflects the DOCSITE's viewport. Since the store is rendered at a fixed 1000px
+// desktop width and scaled down to a miniature, we force isMobile:false so its
+// product grid keeps the 3-column desktop layout on small screens (otherwise it
+// collapses to a single full-width product, ignoring the miniature's scale).
+const FORCE_DESKTOP_MOBILE_CONTEXT: AppShellMobileContextValue = {
+  isMobile: false,
+  isMobileNavOpen: false,
+  toggleMobileNav: () => {},
+  openMobileNav: () => {},
+  closeMobileNav: () => {},
+  isMobileNavEnabled: false,
+  hasAutoToggle: false,
+};
+
+// Live, theme-aware replacement for the old /feature-brand.png. The LEFT panel
+// reuses the real /themes showcase (ThemeShowcaseStore + Butter content) inside
+// the Butter <Theme> scope — real themed surfaces, so it's dark-mode correct
+// and stays in sync with the themes page. The RIGHT rail keeps the reference's
+// static Butter swatches + script "Aa".
+export function ThemesPreview() {
+  // Follow the docsite light/dark toggle so the Butter preview switches modes
+  // (keeps Butter's palette; 'system' defers to the OS before the toggle).
+  const {themeMode} = useThemeMode();
+  return (
+    <div {...stylex.props(styles.container)}>
+      <div {...stylex.props(styles.root)}>
+        <Card variant="transparent" padding={0} xstyle={styles.showcaseCard}>
+          <Theme theme={butterTheme} mode={themeMode}>
+            <div
+              {...stylex.props(styles.scaleViewport)}
+              data-themes-card-preview>
+              <div {...stylex.props(styles.scaleInner)} inert>
+                <AppShellMobileContext.Provider
+                  value={FORCE_DESKTOP_MOBILE_CONTEXT}>
+                  <ThemeShowcaseStore {...butterContent} />
+                </AppShellMobileContext.Provider>
+              </div>
+            </div>
+          </Theme>
+        </Card>
+
+        <HStack gap={2} xstyle={styles.rail}>
+          <div
+            {...stylex.props(styles.swatch, swatchColors.fill(BUTTER_BLUE))}
+          />
+          <div
+            {...stylex.props(styles.swatch, swatchColors.fill(BUTTER_YELLOW))}
+          />
+          <div
+            {...stylex.props(styles.swatch, swatchColors.fill(BUTTER_CREAM))}
+          />
+          <span {...stylex.props(styles.railWordmark)} aria-hidden="true">
+            Aa
+          </span>
+        </HStack>
+      </div>
+    </div>
+  );
+}

--- a/apps/docsite/src/app/globals.css
+++ b/apps/docsite/src/app/globals.css
@@ -176,3 +176,17 @@ body[data-hero-dark] [data-home-page] .astryx-pagination-dot:focus-visible {
   backdrop-filter: none;
 }
 
+/* The home page's Themes feature card embeds the theme-showcase store. The
+   home-page nav rules above (transparent nav / frosted bar) target every
+   `.astryx-top-nav` on the page and leak into this embedded preview, leaving
+   its nav transparent so a mismatched band shows through. Pin the embedded
+   preview's nav (and its header wrapper) to the themed body color so it reads
+   as one continuous surface. !important + the data-attribute scope beat the
+   home-page overrides without affecting the real top nav. */
+[data-themes-card-preview] .astryx-top-nav,
+[data-themes-card-preview] .astryx-layout-header,
+[data-themes-card-preview] :has(> .astryx-layout-header) {
+  background: var(--color-background-body) !important;
+  backdrop-filter: none !important;
+}
+

--- a/apps/docsite/src/components/TemplateThumbnail.tsx
+++ b/apps/docsite/src/components/TemplateThumbnail.tsx
@@ -2,13 +2,7 @@
 
 'use client';
 
-import {
-  Suspense,
-  useRef,
-  useState,
-  useEffect,
-  useCallback,
-} from 'react';
+import {Suspense, useRef, useState, useEffect, useCallback} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {Skeleton} from '@astryxdesign/core/Skeleton';
 import {Theme} from '@astryxdesign/core/theme';
@@ -35,7 +29,6 @@ const styles = stylex.create({
     position: 'absolute' as const,
     top: 0,
     left: 0,
-    height: `${100 / FIXED_SCALE}%`,
     transformOrigin: 'top left',
     pointerEvents: 'none' as const,
     overflow: 'hidden',
@@ -54,17 +47,46 @@ const styles = stylex.create({
   },
 });
 
-export function TemplateThumbnail({slug}: {slug: string}) {
+export function TemplateThumbnail({
+  slug,
+  aspectRatio,
+  renderWidth: fixedRenderWidth,
+  borderRadius,
+}: {
+  slug: string;
+  /** Crop window aspect ratio (CSS aspect-ratio). Defaults to '16/10'. */
+  aspectRatio?: string;
+  /**
+   * Width (px) to render the template at before scaling it to fit the tile.
+   * Default (undefined) renders at 2× the tile width (scale 0.5) — a zoomed-in
+   * slice. Pass a desktop width (e.g. 1100) to render the FULL page composition
+   * and shrink it to fit, so the whole page shows rather than a top-left corner.
+   */
+  renderWidth?: number;
+  /**
+   * Override the container's corner radius (CSS border-radius). Pass '0' when the
+   * thumbnail is already framed/clipped by a rounded parent, so the default
+   * --radius-container doesn't nest a second, mismatched radius inside it.
+   */
+  borderRadius?: string;
+}) {
   const {mode} = useThemeMode();
   const containerRef = useRef<HTMLDivElement>(null);
-  const [renderWidth, setRenderWidth] = useState(0);
+  const [tileWidth, setTileWidth] = useState(0);
   const [isVisible, setIsVisible] = useState(false);
 
   const updateWidth = useCallback(() => {
     if (containerRef.current) {
-      setRenderWidth(containerRef.current.offsetWidth / FIXED_SCALE);
+      setTileWidth(containerRef.current.offsetWidth);
     }
   }, []);
+
+  // Render width: a fixed desktop width (full-page miniature) when provided,
+  // else 2× the tile width (the legacy zoomed-in slice).
+  const renderWidth =
+    fixedRenderWidth != null ? fixedRenderWidth : tileWidth / FIXED_SCALE;
+  // Scale so the rendered width fits the tile width.
+  const scale = renderWidth > 0 ? tileWidth / renderWidth : FIXED_SCALE;
 
   // Intersection observer: track visibility for Activity mode
   useEffect(() => {
@@ -99,11 +121,26 @@ export function TemplateThumbnail({slug}: {slug: string}) {
   }
 
   return (
-    <div ref={containerRef} {...stylex.props(styles.container)} inert>
-      {renderWidth > 0 && isVisible && (
+    <div
+      ref={containerRef}
+      {...stylex.props(styles.container)}
+      style={
+        aspectRatio || borderRadius
+          ? {
+              ...(aspectRatio ? {aspectRatio} : {}),
+              ...(borderRadius ? {borderRadius} : {}),
+            }
+          : undefined
+      }
+      inert>
+      {tileWidth > 0 && isVisible && (
         <div
           {...stylex.props(styles.scaler)}
-          style={{width: renderWidth, transform: `scale(${FIXED_SCALE})`}}>
+          style={{
+            width: renderWidth,
+            height: `${100 / scale}%`,
+            transform: `scale(${scale})`,
+          }}>
           <Suspense
             fallback={
               <div {...stylex.props(styles.skeleton)}>


### PR DESCRIPTION
## Summary

Replaces the two baked PNGs on the home page **Features** bento (`/feature-brand.png`, `/feature-templates.png`) with **live, dark-mode-aware previews** built from the real components/templates.

- **Themes card** (`ThemesPreview`): renders the real `/themes` `ThemeShowcaseStore` (Butter theme + content) in a `<Theme>` scope, fluidly scaled to a miniature cropped to the first section (nav + hero + product cards). An `AppShellMobileContext` override forces the store's desktop grid so it doesn't collapse inside the scaled tile. Static Butter swatches + script "Aa" rail. Left-anchored/bled on the narrow 3-column card, centered on the wide single-column card, bottom-anchored, with an elevation shadow.
- **Templates card** (`TemplatesPreview`): a grid of live, scaled-down real page templates via `TemplateThumbnail`, framed as elevated tiles. Narrow desktop card → 2-up rows (the middle row is 3-up with the login template centered), uniform tile size. Wide single-column card → dissolves into a **3-per-line × 2-row** grid (one template dropped to avoid an orphan).
- **`TemplateThumbnail`**: adds optional `aspectRatio`, `renderWidth` (full-page miniature vs. the legacy zoomed-in slice), and `borderRadius` props. Defaults preserve existing `/templates` usage.
- **Components / CLI previews**: marked `inert` + `pointer-events: none` (decorative, non-interactive).
- **globals.css**: scopes the embedded theme-showcase nav to the themed body color so the home-page nav overrides don't leak a mismatched band into the preview.

Both previews are responsive via **container queries** (keyed to the card width, not the viewport), so they look right in the narrow 3-column bento and the wide single-column stack.

## Test plan

- [ ] `/` home page renders; Themes + Templates feature cards show live previews (light + dark mode).
- [ ] Resize narrow: Themes preview stays centered & uncramped; Templates collapses to 3-per-line × 2 rows (no huge tiles, no orphan).
- [ ] `/themes` page still renders correctly (shared `TemplateThumbnail` change is backward-compatible).
- [ ] `/templates` page thumbnails unchanged.
- [ ] No nested-radius artifact on template tiles; elevation shadows present.
- [ ] ESLint clean; StyleX capability scan confirms all used features (`@container`, `aspect-ratio`, `calc()`, grid/flex) are supported.

🤖 Generated with [Cursor](https://cursor.com)

Made with [Cursor](https://cursor.com)