### PR TITLE
chore(examples): use ESM in Next.js example apps

### DIFF
--- a/apps/example-nextjs-tailwind/package.json
+++ b/apps/example-nextjs-tailwind/package.json
@@ -2,6 +2,7 @@
   "name": "@astryxdesign/example-nextjs-tailwind",
   "version": "0.0.1",
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/apps/example-nextjs/package.json
+++ b/apps/example-nextjs/package.json
@@ -2,6 +2,7 @@
   "name": "@astryxdesign/example-nextjs",
   "version": "0.0.1",
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
## What

Make the Next.js example apps use ESM instead of CommonJS by adding
`"type": "module"` to their `package.json`, matching the Vite example apps
which already declare `"type": "module"`.

| App | Before | After |
| --- | --- | --- |
| `example-vite` | ESM | ESM (unchanged) |
| `example-vite-tailwind` | ESM | ESM (unchanged) |
| `example-nextjs` | CJS | **ESM** |
| `example-nextjs-tailwind` | CJS | **ESM** |
| `example-nextjs-source` | CJS | CJS (see below) |
| `example-nextjs-stylex` | CJS | CJS (see below) |

## Why `-source` and `-stylex` stay CommonJS

These two apps use a custom Babel config. Next.js's Babel loader only loads
`babel.config.js` via `require()` and explicitly rejects `.mjs`/`.cjs` config
files. Declaring `"type": "module"` therefore breaks the build two ways:

- A `.mjs`/`.cjs` babel config → `The Next.js Babel loader does not support .mjs or .cjs config files.`
- A `babel.config.js` with CommonJS syntax under `"type": "module"` → `require is not defined in ES module scope`

So these apps cannot adopt ESM without dropping their custom Babel setup. Left
as-is intentionally.

## Verification

- `example-nextjs-tailwind` — `next build` passes (`✓ Compiled successfully`).
- `example-nextjs` — Babel/ESM layer compiles successfully; the build surfaces a
  pre-existing, unrelated type error (`TextInput` missing `value` prop) that also
  fails on `main`.
