### PR TITLE
fix(docsite): let blog article body text fill the article column

### DIFF
--- a/apps/docsite/src/components/blog/BlogArticle.tsx
+++ b/apps/docsite/src/components/blog/BlogArticle.tsx
@@ -94,7 +94,9 @@ export function BlogArticle({post}: BlogArticleProps) {
           />
         )}
 
-        <Markdown headingLevelStart={2}>{post.body}</Markdown>
+        <Markdown headingLevelStart={2} contentWidth="100%">
+          {post.body}
+        </Markdown>
 
         {post.tags.length > 0 ? (
           <HStack gap={1} xstyle={styles.tagRow}>
@@ -110,10 +112,6 @@ export function BlogArticle({post}: BlogArticleProps) {
             <Heading level={2} type="display-3">
               Related
             </Heading>
-            {/* minWidth caps this at 2 columns within the ~752px article
-                column; 'fit' lets a lone card stretch to fill when it wraps to
-                one column (an explicit `max` would cap track width at 50% and
-                prevent the fill). */}
             <Grid columns={{minWidth: 280, repeat: 'fill'}} gap={2}>
               {post.relatedDocs.map(doc => (
                 <ClickableCard


### PR DESCRIPTION
## Summary

- The blog article body text was capped at `680px` by the `Markdown` component's `contentWidth` default, leaving the prose visibly narrower than the surrounding `800px` article frame (cover image, title, etc.).
- Set `contentWidth="100%"` on the article's `<Markdown>` so paragraphs, headings, lists, and blockquotes fill the full article column. Tables and code blocks were already full-width (they ignore `contentWidth`), so they're unaffected.
- The overall article layout (800px frame, centered) is unchanged — only the body text width changed.
- Removed a stale `Grid` comment that referenced a `fit` mode the code no longer uses.

## Test plan

- [ ] Visit `/blog/introducing-astryx` and confirm the body paragraphs line up flush with the cover image / article edges (no extra inset).
- [ ] Confirm the title, byline, cover image, tags, and "Related" cards are unchanged.
- [ ] `pnpm -F @astryxdesign/docsite typecheck` passes.

Made with [Cursor](https://cursor.com)