### PR TITLE
fix(ci): deploy copies theme.css from neutral, not deleted default

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -171,7 +171,7 @@ jobs:
           mkdir -p deploy/assets
           cp packages/core/dist/astryx.css deploy/assets/astryx.css
           cp packages/core/src/reset.css deploy/assets/reset.css
-          cp packages/themes/default/dist/theme.css deploy/assets/theme.css
+          cp packages/themes/neutral/dist/theme.css deploy/assets/theme.css
 
           cat > deploy/index.html << 'LANDING_EOF'
           <!DOCTYPE html>


### PR DESCRIPTION
## Problem

The gh-pages `deploy` job fails on **every push** with:
```
cp: cannot stat 'packages/themes/default/dist/theme.css': No such file or directory
```
(e.g. run 28127794134).

## Cause

#3059 removed `packages/themes/default` (migrated default→neutral), but the `deploy` job's "Prepare deployment" step still hardcoded `cp packages/themes/default/dist/theme.css …`. That path no longer exists.

## Fix

Repoint the copy to the surviving `neutral` theme:
```diff
- cp packages/themes/default/dist/theme.css deploy/assets/theme.css
+ cp packages/themes/neutral/dist/theme.css deploy/assets/theme.css
```

## Scope / notes
- **Website (`deploy`) job only.** The npm `publish`/`canary` jobs are independent (`needs: test`) and were unaffected — `0.1.0` published fine on the failing run.
- Follow-up (separate PR): the release-workflow split will also de-hardcode the theme CSS copy so a future theme rename can't break this again.