### PR TITLE
fix(ci): deploy.yml references removed default theme → neutral

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -171,11 +171,11 @@ jobs:
           mkdir -p deploy/assets
           cp packages/core/dist/astryx.css deploy/assets/astryx.css
           cp packages/core/src/reset.css deploy/assets/reset.css
-          cp packages/themes/default/dist/theme.css deploy/assets/theme.css
+          cp packages/themes/neutral/dist/theme.css deploy/assets/theme.css
 
           cat > deploy/index.html << 'LANDING_EOF'
           <!DOCTYPE html>
-          <html lang="en" data-astryx-theme="default">
+          <html lang="en" data-astryx-theme="neutral">
           <head>
             <meta charset="UTF-8">
             <meta name="viewport" content="width=device-width, initial-scale=1.0">


### PR DESCRIPTION
## What

The `default` theme package was removed and migrated to `theme-neutral`, but the landing-page build step in `.github/workflows/deploy.yml` still referenced the deleted `default` theme in two places. This broke the deploy/publish pipeline with:

```
cp: cannot stat 'packages/themes/default/dist/theme.css': No such file or directory
```

## Changes

In the **Prepare deployment** step:

1. `cp packages/themes/default/dist/theme.css …` → `packages/themes/neutral/dist/theme.css`
2. Landing page `<html … data-astryx-theme="default">` → `data-astryx-theme="neutral"`

## Why neutral is a safe drop-in

- `theme-neutral` produces the same `dist/theme.css` output (`astryx theme build … -o dist/theme.css`), with a matching `./theme.css` export.
- The root `build` script already builds `@astryxdesign/theme-neutral` (run in the `Build core package` step **before** this `cp`), so `packages/themes/neutral/dist/theme.css` exists when the copy runs.

Surgical, two-line fix. No other `themes/default` / `data-astryx-theme="default"` references remain in the workflow.
