### PR TITLE
ci: split stable npm release into a dedicated dispatched workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,9 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
-# Deploy Storybook + Sandbox to GitHub Pages, publish packages to public npm,
-# and publish @canary dist-tag from latest main.
-# Only runs on push to main — simple and sequential: sync → test → deploy + publish + canary
+# Deploy Storybook + Sandbox to GitHub Pages, and publish @canary prereleases
+# from latest main. Stable npm releases live in release.yml (manually dispatched)
+# so they don't share this workflow's pages-deploy concurrency.
+# Only runs on push to main — simple and sequential: sync → test → deploy + canary
 #
 # Deployment layout on gh-pages:
 #   /storybook/    — stable Storybook (always latest main)
@@ -267,48 +268,6 @@ jobs:
           keep_files: false
           force_orphan: true
           destination_dir: .
-
-  # Publish @astryxdesign/* packages to the public npm registry.
-  # Runs in parallel with deploy — both gate on test passing.
-  # Auth is npm OIDC trusted publishing (no NPM_TOKEN): the id-token: write
-  # permission lets pnpm fetch a short-lived OIDC token, and each package
-  # trusts this workflow (deploy.yml) on npmjs.com.
-  # pnpm -r publish publishes every non-private workspace package whose
-  # version is not yet on the registry; already-published versions are
-  # skipped (npm 409 Conflict → no-op) and workspace: deps are rewritten.
-  publish:
-    name: Publish to npm
-    needs: test
-    if: always() && !cancelled() && needs.test.result == 'success'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write # required for npm OIDC trusted publishing + provenance
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: 'pnpm'
-          registry-url: 'https://registry.npmjs.org'
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Build all packages
-        run: pnpm build
-
-      - name: Publish changed packages
-        # Pure OIDC trusted publishing — no NPM_TOKEN. pnpm -r publish skips
-        # already-published versions, filters private packages, and rewrites
-        # workspace: deps to real versions before upload.
-        run: pnpm -r publish --tag latest --provenance --access public --no-git-checks
 
   # Publish canary versions to the public npm registry on every push to main.
   # The @canary dist-tag always points to the latest main commit:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,89 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+# Publish the stable @astryxdesign/* packages to the public npm registry
+# (`latest` dist-tag), via npm OIDC trusted publishing — no NPM_TOKEN.
+#
+# Manually dispatched (Actions → Release → Run workflow). The release flow is:
+#   1. Land the changesets "Version Packages" PR on main (`pnpm version-packages`
+#      → PR → merge). This bumps versions; it never touches the registry.
+#   2. Run this workflow to publish the bumped versions.
+#
+# Why a separate workflow (not a job in deploy.yml):
+#   - deploy.yml uses the `pages-deploy` concurrency group, which cancels queued
+#     runs on a busy main — that repeatedly starved the npm publish. This
+#     workflow has its own non-cancelling concurrency, so a release never gets
+#     dropped.
+#   - It checks out the exact ref being released and publishes per package, so
+#     the published tarball matches the released commit and carries provenance.
+#
+# Publishing is version-gated and idempotent: any package whose version is
+# already on the registry is skipped, so re-running (or a `dry-run` first) is
+# safe. Provenance requires a PUBLIC repo (facebook/astryx is public).
+name: Release
+run-name: Release (${{ github.sha }})
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: 'Build and resolve what would publish, but do not publish'
+        type: boolean
+        default: false
+
+permissions: {}
+
+concurrency:
+  group: npm-release
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # npm OIDC trusted publishing + provenance
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24 # bundles npm >= 11.5.1, required for OIDC publishing
+          cache: 'pnpm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build all packages
+        run: pnpm build
+
+      - name: Publish changed packages
+        env:
+          DRY_RUN: ${{ inputs.dry-run }}
+        run: |
+          set -eu
+          published=0
+          for pkg_dir in packages/* packages/themes/*; do
+            [ -f "$pkg_dir/package.json" ] || continue
+            IS_PUBLISHABLE=$(node -p "const p=require('./$pkg_dir/package.json'); !p.private && p.name?.startsWith('@astryxdesign/') ? 'yes' : 'no'")
+            [ "$IS_PUBLISHABLE" = "yes" ] || continue
+            NAME=$(node -p "require('./$pkg_dir/package.json').name")
+            VERSION=$(node -p "require('./$pkg_dir/package.json').version")
+            if npm view "$NAME@$VERSION" version --registry https://registry.npmjs.org >/dev/null 2>&1; then
+              echo "Skipping $NAME@$VERSION (already on registry)"
+              continue
+            fi
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "[dry-run] Would publish $NAME@$VERSION"
+              continue
+            fi
+            echo "Publishing $NAME@$VERSION"
+            pnpm publish "./$pkg_dir" --tag latest --provenance --access public --no-git-checks
+            published=$((published + 1))
+          done
+          echo "Published $published package(s)."


### PR DESCRIPTION
## Summary

Moves stable npm publishing out of `deploy.yml` into a new `release.yml`, modeled on facebook/lexical's manually-dispatched release workflow. Keeps it minimal — no changesets bot, no drift cron, no reusable-workflow indirection.

## Why

Today the `publish` job lives inside `deploy.yml` under the `pages-deploy` concurrency group (`cancel-in-progress: false`). On a busy `main` that **cancels queued Deploy runs**, which repeatedly **starved the npm publish** — and when a run *did* survive, the `publish` job checks out the *triggering* commit (`GITHUB_SHA`), so it could publish from a different commit than the release. Bundling release with the website deploy also made releases invisible/unpredictable in the Actions UI.

## Changes

**`release.yml` (new)** — Lexical-style:
- `workflow_dispatch` only — run it after landing the changesets "Version Packages" PR.
- Own concurrency group `npm-release` with `cancel-in-progress: false` → **a release is never dropped/starved**.
- Per-package `pnpm publish --provenance` on **node 24** (npm ≥ 11.5.1), OIDC, **no `NPM_TOKEN`**.
- **Version-gated + idempotent** (skips versions already on the registry); `dry-run` input.
- The per-package form **actually emits provenance** — `pnpm -r publish` silently dropped `--provenance`.

**`deploy.yml`** — drop the `publish` job; it now only deploys the website + publishes canaries. (Canary left here for now — throwaway prerelease; can move to a nightly schedule later.)

## Behavior change (the new convention)
After this lands, **a version bump no longer auto-publishes on push.** The release flow becomes:
1. Land the "Version Packages" PR (bumps versions).
2. **Actions → Release → Run workflow** → publishes the bumped versions with provenance.

This is deterministic (one run per release, from the right commit), can't be starved, and surfaces as a clearly-named **"Release"** run.

## Supersedes
- **#3050** (`[DO NOT LAND]` per-package provenance in `deploy.yml`) — this PR moves that logic into `release.yml` instead. Will close it.

## Test plan
- Both workflows valid YAML; `release.yml` publish step passes `bash -n`.
- `deploy.yml` jobs now: `sync-exports, test, deploy, canary` (no `publish`).
- Independent of #3070 (deploy theme.css fix) — different lines.