### PR TITLE
fix: clean up stale 'xds' references in user-facing CLI output and console warnings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,7 +131,7 @@ xds/
 │
 ├── packages/
 │   ├── core/           # Core components (Button, Input, etc.)
-│   ├── cli/            # CLI tooling (npx xds)
+│   ├── cli/            # CLI tooling (npx astryx)
 │   ├── lab/            # Experimental components (not yet stable)
 │   └── themes/         # Theme presets (default, neutral, daily, and more)
 │

--- a/packages/cli/src/commands/init.mjs
+++ b/packages/cli/src/commands/init.mjs
@@ -248,7 +248,7 @@ export function registerInit(program) {
       humanLog('    2. Optionally add a theme:');
       humanLog("       import { neutralTheme } from '@astryxdesign/theme-neutral'");
       humanLog('       <Theme theme={neutralTheme}>...</Theme>');
-      humanLog(`    3. ${run} xds --help for all commands`);
+      humanLog(`    3. ${run} astryx --help for all commands`);
       humanLog('');
     });
 }

--- a/packages/cli/src/utils/package-manager.mjs
+++ b/packages/cli/src/utils/package-manager.mjs
@@ -4,7 +4,7 @@
  * @file Detect the project's package manager from lockfiles.
  *
  * Returns the correct command prefix for running package binaries
- * (e.g. 'npx xds', 'yarn xds', 'pnpm exec xds').
+ * (e.g. 'npx astryx', 'yarn astryx', 'pnpm exec astryx').
  */
 
 import * as fs from 'node:fs';

--- a/packages/core/src/theme/Theme.tsx
+++ b/packages/core/src/theme/Theme.tsx
@@ -123,7 +123,7 @@ function useThemeStyleInjection(theme: DefinedTheme): void {
     if (!warnedThemes.has(theme.name)) {
       warnedThemes.add(theme.name);
       console.warn(
-        `[XDS] Theme "${theme.name}" is using runtime style injection. ` +
+        `[Astryx] Theme "${theme.name}" is using runtime style injection. ` +
           `For better performance, use the pre-built theme:\n\n` +
           `  import {${theme.name}Theme} from '@astryxdesign/theme-${theme.name}/built';\n` +
           `  import '@astryxdesign/theme-${theme.name}/theme.css';\n\n` +

--- a/packages/core/src/theme/syntax/defineSyntaxTheme.ts
+++ b/packages/core/src/theme/syntax/defineSyntaxTheme.ts
@@ -134,7 +134,7 @@ export function defineSyntaxTheme(input: SyntaxThemeInput): SyntaxThemeDefinitio
   const missing = ALL_SYNTAX_KEYS.filter(key => !(key in input.tokens));
   if (missing.length > 0) {
     console.warn(
-      '[XDS] defineSyntaxTheme("' + input.name + '"): missing tokens: ' +
+      '[Astryx] defineSyntaxTheme("' + input.name + '"): missing tokens: ' +
         missing.join(', ') + '. All 14 syntax tokens are required.',
     );
   }


### PR DESCRIPTION
## What

After the unprefix migration (`xds` → `astryx`), a few stale references to the old name were still showing up in user-facing surfaces:

### CLI `init` outro

The final "Next steps" output of `npx astryx init` told users to run:

```
3. npx xds --help for all commands
```

But the `xds` bin no longer exists, so users hit:

```
npm error could not determine executable to run
```

### `@astryx/core` console warnings

Two runtime `console.warn()` messages still used `[XDS]` as the log prefix:

```
[XDS] Theme "neutral" is using runtime style injection. ...
[XDS] defineSyntaxTheme("..."): missing tokens: ...
```

## Changes

**CLI / docs (commit 1):**
- `packages/cli/src/commands/init.mjs` — `npx xds --help` → `npx astryx --help`
- `CONTRIBUTING.md` — repo-tree comment
- `packages/cli/src/utils/package-manager.mjs` — code comment example

**Core console warnings (commit 2):**
- `packages/core/src/theme/Theme.tsx` — runtime-style-injection perf hint, `[XDS]` → `[Astryx]`
- `packages/core/src/theme/syntax/defineSyntaxTheme.ts` — missing-tokens warn, `[XDS]` → `[Astryx]`

Brand-cased `[Astryx]` chosen to match the original `[XDS]` casing and the README's branding ("Astryx"); other `@astryx/core` console warnings either bracket the component name (`[Table]`) or use a `Component:` prefix, but those are component-scoped — these two are package-scoped, so they keep the brand-prefix style.

The `packages/cli/CHANGELOG.md` entry that mentions the old `xds` name is historical (it documents the rename itself) and is left intact.

## Test plan

Visual / static — these are user-facing strings. No tests assert on the prefix `[XDS]` (verified with `rg`).