### PR TITLE
fix(core): remove doubled focus ring on Selector trigger

### DIFF
--- a/.changeset/fix-selector-double-focus-ring.md
+++ b/.changeset/fix-selector-double-focus-ring.md
@@ -1,0 +1,10 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Remove doubled focus ring on `Selector`. The inner combobox button drew
+its own `:focus-visible` outline on top of the wrapper's `:focus-within` ring,
+producing a stacked, rounded outline over the trigger after selecting an option
+or navigating with the keyboard. The button now defers to the wrapper's focus
+ring, matching `TextInput` and `NumberInput`.
+@cixzhang

--- a/packages/core/src/Selector/Selector.tsx
+++ b/packages/core/src/Selector/Selector.tsx
@@ -107,12 +107,11 @@ const styles = stylex.create({
     lineHeight: 'inherit',
     color: 'inherit',
     cursor: 'pointer',
-    outline: {
-      default: 'none',
-      ':focus-visible': `${borderVars['--border-width']} solid ${colorVars['--color-accent']}`,
-    },
-    outlineOffset: '0',
-    borderRadius: radiusVars['--radius-element'],
+    // The wrapper (inputWrapperStyles.base) renders the focus ring via
+    // :focus-within when this button is focused, matching TextInput/NumberInput.
+    // The button must not draw its own :focus-visible outline or the two stack
+    // into a doubled ring over the trigger.
+    outline: 'none',
   },
   triggerPlaceholder: {
     color: colorVars['--color-text-secondary'],


### PR DESCRIPTION
## Summary

Fixes #3083 — a doubled focus ring ("circle covering the dropdown selector") that appears on `Selector` after selecting an option or navigating with the keyboard.

## Root cause

`Selector`'s wrapper `<div>` already renders the focus indicator through the shared `inputWrapperStyles.base`: on `:focus-within` it draws an accent border plus an `inset 0 0 0 2px` ring. But the inner `<button role="combobox">` carried its **own** `:focus-visible` accent outline (rounded, via `borderRadius` + `outlineOffset`):

```js
outline: {
  default: 'none',
  ':focus-visible': `${borderVars['--border-width']} solid ${colorVars['--color-accent']}`,
},
outlineOffset: '0',
borderRadius: radiusVars['--radius-element'],
```

When focus lands on that button (clicking the chevron, pressing the arrow keys, etc.), **both** rings render at once — the wrapper's `:focus-within` border + inset shadow, and the button's own rounded outline stacked on top. That stacked rounded outline is the artifact in the repro.

The sibling input components establish the intended pattern: `TextInput` and `NumberInput` give their inner focusable element `outline: 'none'` and rely solely on the wrapper's `:focus-within` ring. `Selector` deviated from this.

## Fix

Remove the inner button's own `:focus-visible` outline (and the now-unused `outlineOffset`/`borderRadius`) so it defers to the wrapper's focus ring, exactly like the other input components. A single, consistent focus indicator now renders.

## Testing

- All 21 `Selector` unit tests pass
- `eslint` clean, `tsc --noEmit` clean
