### PR TITLE
docs: stop listing @astryxdesign/vega as a published package

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,9 @@ Then follow the [setup guide](packages/core/README.md#quick-start) to import sty
 | [`@astryxdesign/core`](packages/core)      | Components, theme system, and utilities                                                                                       | [README](packages/core/README.md)  |
 | [`@astryxdesign/cli`](packages/cli)        | CLI tooling: component docs, templates, scaffolding, themes, and codemods                                                     | [README](packages/cli/README.md)   |
 | [`@astryxdesign/build`](packages/build)    | Build plugins for StyleX source builds                                                                                        | [README](packages/build/README.md) |
-| [`@astryxdesign/vega`](packages/vega)      | Vega/Vega-Lite chart wrapper                                                                                                  | [README](packages/vega/README.md)  |
 | [`@astryxdesign/theme-*`](packages/themes) | Ten ready-made, fully customizable themes (default, neutral, daily, butter, chocolate, matcha, stone, gothic, brutalist, y2k) | [README](packages/themes)          |
 
-> `@astryxdesign/lab` hosts experimental components for testing in Storybook and the sandbox; it is not published.
+> `@astryxdesign/lab` (experimental components) and `@astryxdesign/vega` (Vega/Vega-Lite chart wrapper) are used internally for Storybook and the sandbox; they are not yet published to npm.
 
 ## Features
 
@@ -95,7 +94,7 @@ Battle-tested design solutions for common interactions and workflows: table page
 | Directory   | Purpose                                                     |
 | ----------- | ----------------------------------------------------------- |
 | `apps/`     | Example apps, the docsite, and Storybook                    |
-| `packages/` | Published packages: core, cli, build, vega, themes          |
+| `packages/` | Published packages: core, cli, build, themes                |
 | `internal/` | Internal tooling: test utilities, eslint plugin, vibe tests |
 
 ## Contributing

--- a/packages/README.md
+++ b/packages/README.md
@@ -9,6 +9,6 @@ Published npm packages for the XDS design system.
 | `core/` | `@astryxdesign/core` | Core UI components, theme system, and utilities |
 | `cli/` | `@astryxdesign/cli` | CLI tooling: component docs, templates, scaffolding, codemods |
 | `build/` | `@astryxdesign/build` | Build plugins for StyleX source builds (Babel, PostCSS, Vite) |
-| `vega/` | `@astryxdesign/vega` | Vega/Vega-Lite chart wrapper |
 | `themes/` | `@astryxdesign/theme-*` | Visual themes (default, neutral, daily, brutalist, meta, whatsapp) |
+| `vega/` | `@astryxdesign/vega` | Vega/Vega-Lite chart wrapper (not published) |
 | `lab/` | — | Experimental components (not published) |


### PR DESCRIPTION
## Problem

`@astryxdesign/vega` is marked `"private": true` and is not published to npm, but it was listed alongside the published packages in both `README.md` and `packages/README.md`. A user following the docs to `npm install @astryxdesign/vega` (or visiting the package link) hits a 404.

## Fix

- Remove `@astryxdesign/vega` from the published-packages table in the root `README.md`, and group it with `@astryxdesign/lab` in the existing "used internally, not yet published" note.
- Drop `vega` from the `packages/` "Published packages" structure line.
- In `packages/README.md`, mark the `vega/` row as `(not published)`, matching how `lab/` is already annotated.

Docs-only change; no package or code behavior is affected.
