### PR TITLE
feat(docsite): add Google Search Console site verification meta tag

### DIFF
--- a/apps/docsite/src/app/layout.tsx
+++ b/apps/docsite/src/app/layout.tsx
@@ -39,6 +39,9 @@ export const metadata: Metadata = {
   icons: {
     icon: '/favicon.svg',
   },
+  verification: {
+    google: '2R11kontqme-N-8WuDSR0MZ1YVbKX3IQg3OM08UO_e0',
+  },
   openGraph: {
     type: 'website',
     siteName: SITE_NAME,


### PR DESCRIPTION
Adds the Google Search Console site verification meta tag to the docsite so the domain can be verified for Search Console.

Uses Next.js's `metadata.verification.google` field, which renders the standard tag in the first `<head>`:

```html
<meta name="google-site-verification" content="2R11kontqme-N-8WuDSR0MZ1YVbKX3IQg3OM08UO_e0" />
```

This keeps the verification token in the same typed `metadata` export as the rest of the site's head config, rather than hand-writing a `<meta>` tag.
