### PR TITLE
feat(docsite): add 'Use this theme' install block on /themes

### DIFF
--- a/apps/docsite/src/components/ThemeInstallBlock.tsx
+++ b/apps/docsite/src/components/ThemeInstallBlock.tsx
@@ -2,18 +2,12 @@
 
 'use client';
 
-import * as stylex from '@stylexjs/stylex';
 import {VStack} from '@astryxdesign/core/Layout';
 import {Heading, Text} from '@astryxdesign/core/Text';
 import {Link} from '@astryxdesign/core/Link';
 import {Section} from '@astryxdesign/core/Section';
 import {CodeExampleBlock} from './CodeExampleBlock';
 import {packages} from '../generated/packageRegistry';
-
-const styles = stylex.create({
-  // CodeBlock defaults to fit-content; force full-width inside the Section.
-  code: {width: '100%'},
-});
 
 // Strip "Theme: " prefix and " Theme" suffix from the registered displayName
 // so headings read as the brand wordmark ("Y2K") rather than "Theme: Y2K Theme".
@@ -68,14 +62,14 @@ import {${importName}} from '${packageName}';
           language="bash"
           hasCopyButton
           isWrapped
-          xstyle={styles.code}
+          width="100%"
         />
         <CodeExampleBlock
           code={importCode}
           language="tsx"
           hasCopyButton
           isWrapped
-          xstyle={styles.code}
+          width="100%"
         />
       </VStack>
     </Section>

--- a/apps/docsite/src/components/ThemeInstallBlock.tsx
+++ b/apps/docsite/src/components/ThemeInstallBlock.tsx
@@ -2,41 +2,15 @@
 
 'use client';
 
-import * as stylex from '@stylexjs/stylex';
 import {VStack} from '@astryxdesign/core/Layout';
 import {Heading, Text} from '@astryxdesign/core/Text';
-import {Card} from '@astryxdesign/core/Card';
 import {Link} from '@astryxdesign/core/Link';
 import {CodeExampleBlock} from './CodeExampleBlock';
-import {layout} from '../layout.stylex';
 
-// Theme packages export a single named theme object: `<slug>Theme` (e.g.
-// `y2kTheme`, `neutralTheme`). The export name is derived from the package
-// slug rather than read from the registry — every theme in the workspace
-// follows this convention, and threading the import name through
-// generate-data.mjs would add a registry field for one consumer.
+// Theme packages export `<slug>Theme` — y2kTheme, neutralTheme, etc.
 function importNameForSlug(slug: string): string {
   return `${slug.replace(/-([a-z])/g, (_, c) => c.toUpperCase())}Theme`;
 }
-
-const styles = stylex.create({
-  // Caps the install block at the same width as the showcase card below
-  // it so the two surfaces line up visually instead of the install
-  // block running edge-to-edge while the showcase is centered.
-  block: {
-    width: '100%',
-    maxWidth: layout.contentMaxWidth,
-    marginInline: 'auto',
-  },
-  card: {
-    padding: 'var(--spacing-4)',
-  },
-  // Keep heading + lede tight; the code blocks below provide the
-  // visual breathing room.
-  heading: {
-    margin: 0,
-  },
-});
 
 interface ThemeInstallBlockProps {
   /** Full npm package name, e.g. `@astryxdesign/theme-y2k`. */
@@ -46,12 +20,9 @@ interface ThemeInstallBlockProps {
 }
 
 /**
- * Inline "Use this theme" affordance shown above the themed preview on the
- * /themes explorer. Surfaces the two-step path — `npm install` and the
- * matching `import` — so visitors can copy both without hunting through the
- * separate /docs/theme guide. Renders the code inline (rather than behind a
- * popover) because the report on issue #3082 was specifically that the
- * install instructions weren't discoverable on the theme preview itself.
+ * "Use this theme" snippet shown below the themed preview on /themes —
+ * `npm install` + the matching import so visitors can copy both without
+ * leaving the page.
  */
 export function ThemeInstallBlock({
   packageName,
@@ -66,37 +37,23 @@ import {${importName}} from '${packageName}';
 <Theme theme={${importName}}>{/* your app */}</Theme>`;
 
   return (
-    <div {...stylex.props(styles.block)}>
-      <Card padding={0} xstyle={styles.card}>
-        <VStack gap={3}>
-          <VStack gap={1}>
-            <Heading level={2} xstyle={styles.heading}>
-              Use the {themeLabel} theme
-            </Heading>
-            <Text type="body" color="secondary">
-              Install the package, then wrap your app in {'<Theme>'}. See the{' '}
-              <Link
-                type="body"
-                color="secondary"
-                href="/docs/theme"
-                hasUnderline>
-                Theme System guide
-              </Link>{' '}
-              for SSR, light/dark mode, and customization.
-            </Text>
-          </VStack>
-          <Card padding={0}>
-            <CodeExampleBlock
-              code={installCode}
-              language="bash"
-              hasCopyButton
-            />
-          </Card>
-          <Card padding={0}>
-            <CodeExampleBlock code={importCode} language="tsx" hasCopyButton />
-          </Card>
-        </VStack>
-      </Card>
-    </div>
+    <VStack gap={3}>
+      <VStack gap={1}>
+        <Heading level={2}>Use the {themeLabel} theme</Heading>
+        <Text type="body" color="secondary">
+          Install the package, then wrap your app in {'<Theme>'}. See the{' '}
+          <Link
+            type="body"
+            color="secondary"
+            href="/docs/theme"
+            hasUnderline>
+            Theme System guide
+          </Link>{' '}
+          for SSR, light/dark mode, and customization.
+        </Text>
+      </VStack>
+      <CodeExampleBlock code={installCode} language="bash" hasCopyButton />
+      <CodeExampleBlock code={importCode} language="tsx" hasCopyButton />
+    </VStack>
   );
 }

--- a/apps/docsite/src/components/ThemeInstallBlock.tsx
+++ b/apps/docsite/src/components/ThemeInstallBlock.tsx
@@ -1,0 +1,102 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import * as stylex from '@stylexjs/stylex';
+import {VStack} from '@astryxdesign/core/Layout';
+import {Heading, Text} from '@astryxdesign/core/Text';
+import {Card} from '@astryxdesign/core/Card';
+import {Link} from '@astryxdesign/core/Link';
+import {CodeExampleBlock} from './CodeExampleBlock';
+import {layout} from '../layout.stylex';
+
+// Theme packages export a single named theme object: `<slug>Theme` (e.g.
+// `y2kTheme`, `neutralTheme`). The export name is derived from the package
+// slug rather than read from the registry — every theme in the workspace
+// follows this convention, and threading the import name through
+// generate-data.mjs would add a registry field for one consumer.
+function importNameForSlug(slug: string): string {
+  return `${slug.replace(/-([a-z])/g, (_, c) => c.toUpperCase())}Theme`;
+}
+
+const styles = stylex.create({
+  // Caps the install block at the same width as the showcase card below
+  // it so the two surfaces line up visually instead of the install
+  // block running edge-to-edge while the showcase is centered.
+  block: {
+    width: '100%',
+    maxWidth: layout.contentMaxWidth,
+    marginInline: 'auto',
+  },
+  card: {
+    padding: 'var(--spacing-4)',
+  },
+  // Keep heading + lede tight; the code blocks below provide the
+  // visual breathing room.
+  heading: {
+    margin: 0,
+  },
+});
+
+interface ThemeInstallBlockProps {
+  /** Full npm package name, e.g. `@astryxdesign/theme-y2k`. */
+  packageName: string;
+  /** Friendly wordmark, e.g. `Y2K`. */
+  themeLabel: string;
+}
+
+/**
+ * Inline "Use this theme" affordance shown above the themed preview on the
+ * /themes explorer. Surfaces the two-step path — `npm install` and the
+ * matching `import` — so visitors can copy both without hunting through the
+ * separate /docs/theme guide. Renders the code inline (rather than behind a
+ * popover) because the report on issue #3082 was specifically that the
+ * install instructions weren't discoverable on the theme preview itself.
+ */
+export function ThemeInstallBlock({
+  packageName,
+  themeLabel,
+}: ThemeInstallBlockProps) {
+  const slug = packageName.replace(/^@astryxdesign\/theme-/, '');
+  const importName = importNameForSlug(slug);
+  const installCode = `npm install ${packageName}`;
+  const importCode = `import {Theme} from '@astryxdesign/core';
+import {${importName}} from '${packageName}';
+
+<Theme theme={${importName}}>{/* your app */}</Theme>`;
+
+  return (
+    <div {...stylex.props(styles.block)}>
+      <Card padding={0} xstyle={styles.card}>
+        <VStack gap={3}>
+          <VStack gap={1}>
+            <Heading level={2} xstyle={styles.heading}>
+              Use the {themeLabel} theme
+            </Heading>
+            <Text type="body" color="secondary">
+              Install the package, then wrap your app in {'<Theme>'}. See the{' '}
+              <Link
+                type="body"
+                color="secondary"
+                href="/docs/theme"
+                hasUnderline>
+                Theme System guide
+              </Link>{' '}
+              for SSR, light/dark mode, and customization.
+            </Text>
+          </VStack>
+          <Card padding={0}>
+            <CodeExampleBlock
+              code={installCode}
+              language="bash"
+              hasCopyButton
+            />
+          </Card>
+          <Card padding={0}>
+            <CodeExampleBlock code={importCode} language="tsx" hasCopyButton />
+          </Card>
+        </VStack>
+      </Card>
+    </div>
+  );
+}

--- a/apps/docsite/src/components/ThemeInstallBlock.tsx
+++ b/apps/docsite/src/components/ThemeInstallBlock.tsx
@@ -2,21 +2,28 @@
 
 'use client';
 
+import * as stylex from '@stylexjs/stylex';
 import {VStack} from '@astryxdesign/core/Layout';
 import {Heading, Text} from '@astryxdesign/core/Text';
 import {Link} from '@astryxdesign/core/Link';
+import {Section} from '@astryxdesign/core/Section';
 import {CodeExampleBlock} from './CodeExampleBlock';
+import {packages} from '../generated/packageRegistry';
 
-// Theme packages export `<slug>Theme` — y2kTheme, neutralTheme, etc.
-function importNameForSlug(slug: string): string {
-  return `${slug.replace(/-([a-z])/g, (_, c) => c.toUpperCase())}Theme`;
+const styles = stylex.create({
+  // CodeBlock defaults to fit-content; force full-width inside the Section.
+  code: {width: '100%'},
+});
+
+// Strip "Theme: " prefix and " Theme" suffix from the registered displayName
+// so headings read as the brand wordmark ("Y2K") rather than "Theme: Y2K Theme".
+function brandLabel(displayName: string): string {
+  return displayName.replace(/^Theme:\s*/, '').replace(/\s*Theme$/, '');
 }
 
 interface ThemeInstallBlockProps {
   /** Full npm package name, e.g. `@astryxdesign/theme-y2k`. */
   packageName: string;
-  /** Friendly wordmark, e.g. `Y2K`. */
-  themeLabel: string;
 }
 
 /**
@@ -24,12 +31,13 @@ interface ThemeInstallBlockProps {
  * `npm install` + the matching import so visitors can copy both without
  * leaving the page.
  */
-export function ThemeInstallBlock({
-  packageName,
-  themeLabel,
-}: ThemeInstallBlockProps) {
+export function ThemeInstallBlock({packageName}: ThemeInstallBlockProps) {
+  const pkg = packages.find(p => p.name === packageName);
+  const themeLabel = pkg
+    ? brandLabel(pkg.displayName) || pkg.displayName
+    : '';
   const slug = packageName.replace(/^@astryxdesign\/theme-/, '');
-  const importName = importNameForSlug(slug);
+  const importName = `${slug}Theme`;
   const installCode = `npm install ${packageName}`;
   const importCode = `import {Theme} from '@astryxdesign/core';
 import {${importName}} from '${packageName}';
@@ -37,23 +45,39 @@ import {${importName}} from '${packageName}';
 <Theme theme={${importName}}>{/* your app */}</Theme>`;
 
   return (
-    <VStack gap={3}>
-      <VStack gap={1}>
-        <Heading level={2}>Use the {themeLabel} theme</Heading>
-        <Text type="body" color="secondary">
-          Install the package, then wrap your app in {'<Theme>'}. See the{' '}
-          <Link
-            type="body"
-            color="secondary"
-            href="/docs/theme"
-            hasUnderline>
-            Theme System guide
-          </Link>{' '}
-          for SSR, light/dark mode, and customization.
-        </Text>
+    <Section>
+      <VStack gap={4}>
+        <VStack gap={1}>
+          <Heading level={2} type="display-3">
+            Use the {themeLabel} theme
+          </Heading>
+          <Text type="body" color="secondary">
+            Install the package, then wrap your app in {'<Theme>'}. See the{' '}
+            <Link
+              type="body"
+              color="secondary"
+              href="/docs/theme"
+              hasUnderline>
+              Theme System guide
+            </Link>{' '}
+            for SSR, light/dark mode, and customization.
+          </Text>
+        </VStack>
+        <CodeExampleBlock
+          code={installCode}
+          language="bash"
+          hasCopyButton
+          isWrapped
+          xstyle={styles.code}
+        />
+        <CodeExampleBlock
+          code={importCode}
+          language="tsx"
+          hasCopyButton
+          isWrapped
+          xstyle={styles.code}
+        />
       </VStack>
-      <CodeExampleBlock code={installCode} language="bash" hasCopyButton />
-      <CodeExampleBlock code={importCode} language="tsx" hasCopyButton />
-    </VStack>
+    </Section>
   );
 }

--- a/apps/docsite/src/components/ThemePackagePage.tsx
+++ b/apps/docsite/src/components/ThemePackagePage.tsx
@@ -443,14 +443,17 @@ const styles = stylex.create({
   showcaseCard: {
     overflow: 'hidden',
   },
-  // Caps the showcase at the site's wide-content width and centers it
-  // so it doesn't run edge-to-edge on very wide screens. overflow:hidden
-  // clips template content that exceeds the width on mobile (e.g.
-  // inventory filter rows, tables).
-  showcaseBlock: {
+  // Width cap + centering applied to the right column's main content
+  // blocks (showcase, install snippet, etc.) so they don't run
+  // edge-to-edge on very wide screens.
+  contentBlock: {
     width: '100%',
     maxWidth: layout.contentMaxWidth,
     marginInline: 'auto',
+  },
+  // Showcase-only: clips template content that overflows on mobile
+  // (inventory rows, tables) to the card's rounded corners.
+  showcaseClip: {
     overflow: 'hidden',
     borderRadius: 'var(--radius-container)',
   },
@@ -972,7 +975,7 @@ export function ThemePackagePage({packageName, theme}: ThemePackagePageProps) {
             own backgrounds (top nav, sections) to the card's radius.
             LinkProvider keeps demo href="#" clicks from scrolling the
             page to the top (see PreviewAnchor). */}
-        <div {...stylex.props(styles.showcaseBlock)}>
+        <div {...stylex.props(styles.contentBlock, styles.showcaseClip)}>
           <Card padding={0} xstyle={styles.showcaseCard}>
             <Theme theme={selectedTheme} mode={mode}>
               <LinkProvider component={PreviewAnchor}>
@@ -993,7 +996,9 @@ export function ThemePackagePage({packageName, theme}: ThemePackagePageProps) {
             so the themed preview leads (it's the reason the visitor came
             here); the install snippet acts as the natural next step
             after they've decided they like what they see. */}
-        <ThemeInstallBlock packageName={selectedPkgName} />
+        <div {...stylex.props(styles.contentBlock)}>
+          <ThemeInstallBlock packageName={selectedPkgName} />
+        </div>
       </div>
     </div>
   );

--- a/apps/docsite/src/components/ThemePackagePage.tsx
+++ b/apps/docsite/src/components/ThemePackagePage.tsx
@@ -24,6 +24,7 @@ import {useMediaQuery} from '@astryxdesign/core/hooks';
 import {ThemeShowcaseStore} from '../../../../packages/cli/templates/pages/theme-showcase/page';
 import {getThemeShowcaseContent} from './themeShowcaseContent';
 import {buildPlaygroundHref} from './playgroundLink';
+import {ThemeInstallBlock} from './ThemeInstallBlock';
 import {packages} from '../generated/packageRegistry';
 import {layout} from '../layout.stylex';
 import {themeObjects} from '../generated/themeRegistry';
@@ -659,6 +660,14 @@ export function ThemePackagePage({packageName, theme}: ThemePackagePageProps) {
   // registry drifts).
   const selectedTheme = themeObjects[selectedPkgName] ?? theme;
 
+  // Friendly wordmark for the selected theme — used by the install
+  // block heading ("Use the Y2K theme") so users see the brand name
+  // they just clicked, not the package slug.
+  const selectedLabel = useMemo(() => {
+    const pkg = themePackages.find(p => p.name === selectedPkgName);
+    return pkg ? themeLabel(pkg.displayName) || pkg.displayName : '';
+  }, [themePackages, selectedPkgName]);
+
   // Mobile dropdown options — mirror the sidebar list. Value is the
   // full @astryxdesign/theme-<slug> package name (matches state), label is
   // the friendly brand wordmark ("Neutral", "Butter").
@@ -963,6 +972,16 @@ export function ThemePackagePage({packageName, theme}: ThemePackagePageProps) {
             );
           })}
         </Carousel>
+
+        {/* Install block — inline "Use this theme" affordance with the
+            two-step install + import snippet. Sits above the showcase
+            so the answer to "how do I use this in my app?" is visible
+            on the same surface as the preview, without forcing the
+            visitor to navigate to /docs/theme. */}
+        <ThemeInstallBlock
+          packageName={selectedPkgName}
+          themeLabel={selectedLabel}
+        />
 
         {/* Themed preview — the theme-showcase template rendered with
             the selected theme, wrapped in a bordered, rounded card so

--- a/apps/docsite/src/components/ThemePackagePage.tsx
+++ b/apps/docsite/src/components/ThemePackagePage.tsx
@@ -973,16 +973,6 @@ export function ThemePackagePage({packageName, theme}: ThemePackagePageProps) {
           })}
         </Carousel>
 
-        {/* Install block — inline "Use this theme" affordance with the
-            two-step install + import snippet. Sits above the showcase
-            so the answer to "how do I use this in my app?" is visible
-            on the same surface as the preview, without forcing the
-            visitor to navigate to /docs/theme. */}
-        <ThemeInstallBlock
-          packageName={selectedPkgName}
-          themeLabel={selectedLabel}
-        />
-
         {/* Themed preview — the theme-showcase template rendered with
             the selected theme, wrapped in a bordered, rounded card so
             it reads as a contained app surface against the docsite
@@ -1005,6 +995,16 @@ export function ThemePackagePage({packageName, theme}: ThemePackagePageProps) {
             </Theme>
           </Card>
         </div>
+
+        {/* Install block — inline "Use this theme" affordance with the
+            two-step install + import snippet. Sits BELOW the showcase
+            so the themed preview leads (it's the reason the visitor came
+            here); the install snippet acts as the natural next step
+            after they've decided they like what they see. */}
+        <ThemeInstallBlock
+          packageName={selectedPkgName}
+          themeLabel={selectedLabel}
+        />
       </div>
     </div>
   );

--- a/apps/docsite/src/components/ThemePackagePage.tsx
+++ b/apps/docsite/src/components/ThemePackagePage.tsx
@@ -660,14 +660,6 @@ export function ThemePackagePage({packageName, theme}: ThemePackagePageProps) {
   // registry drifts).
   const selectedTheme = themeObjects[selectedPkgName] ?? theme;
 
-  // Friendly wordmark for the selected theme — used by the install
-  // block heading ("Use the Y2K theme") so users see the brand name
-  // they just clicked, not the package slug.
-  const selectedLabel = useMemo(() => {
-    const pkg = themePackages.find(p => p.name === selectedPkgName);
-    return pkg ? themeLabel(pkg.displayName) || pkg.displayName : '';
-  }, [themePackages, selectedPkgName]);
-
   // Mobile dropdown options — mirror the sidebar list. Value is the
   // full @astryxdesign/theme-<slug> package name (matches state), label is
   // the friendly brand wordmark ("Neutral", "Butter").
@@ -1001,10 +993,7 @@ export function ThemePackagePage({packageName, theme}: ThemePackagePageProps) {
             so the themed preview leads (it's the reason the visitor came
             here); the install snippet acts as the natural next step
             after they've decided they like what they see. */}
-        <ThemeInstallBlock
-          packageName={selectedPkgName}
-          themeLabel={selectedLabel}
-        />
+        <ThemeInstallBlock packageName={selectedPkgName} />
       </div>
     </div>
   );


### PR DESCRIPTION
Closes #3082 (themes-page half).

The `/themes` explorer renders a themed preview but doesn't tell visitors how to actually use the theme in their app — they had to navigate to `/docs/theme` to find the install + import pattern.

Adds a "Use the {Theme} theme" block below the themed preview with two copyable snippets:

```
npm install @astryxdesign/theme-<slug>
```

```tsx
import {Theme} from '@astryxdesign/core';
import {<slug>Theme} from '@astryxdesign/theme-<slug>';

<Theme theme={<slug>Theme}>{/* your app */}</Theme>
```

Both update reactively as the picker changes. Links out to `/docs/theme` for the longer SSR / dark mode / customization story.

Sibling PRs: #3094 adds the install step to `/docs/theme` itself; #3140 fixes the showcase preview's demo links.
