### PR TITLE
docs: update stale xds references to astryx in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,7 @@ pnpm --version   # 10.x.x
 ```bash
 # Clone the repo
 git clone https://github.com/facebook/astryx.git
-cd xds
+cd astryx
 
 # Install dependencies
 pnpm install
@@ -124,7 +124,7 @@ pnpm dev
 ## Project Structure
 
 ```
-xds/
+astryx/
 ├── apps/
 │   ├── storybook/      # Component playground (localhost:6006)
 │   └── sandbox/        # Development testing


### PR DESCRIPTION
The repo was renamed from xds to astryx, but CONTRIBUTING.md still told contributors to cd into xds.