### PR TITLE
Fix HoverCard SSR hydration stability

### DIFF
--- a/packages/core/src/HoverCard/HoverCard.test.tsx
+++ b/packages/core/src/HoverCard/HoverCard.test.tsx
@@ -2,7 +2,7 @@
 
 /**
  * @file HoverCard.test.tsx
- * @input Uses vitest, @testing-library/react, HoverCard component
+ * @input Uses vitest, @testing-library/react, React SSR/hydration APIs, HoverCard component
  * @output Unit tests for HoverCard component behavior
  * @position Testing; validates HoverCard.tsx implementation
  *
@@ -11,6 +11,9 @@
 
 import {describe, it, expect, vi, beforeAll, afterAll} from 'vitest';
 import {render, screen, fireEvent, waitFor} from '@testing-library/react';
+import {act} from 'react';
+import {hydrateRoot} from 'react-dom/client';
+import {renderToString} from 'react-dom/server';
 import {HoverCard} from './HoverCard';
 
 // Store original matches to restore later
@@ -71,6 +74,51 @@ describe('HoverCard', () => {
 
     expect(trigger.parentElement?.tagName).toBe('SPAN');
     expect(paragraph?.querySelector('div')).toBeNull();
+  });
+
+  it('hydrates without rendering the portaled layer on the first client render', async () => {
+    const ui = (
+      <HoverCard
+        content={<div>Hover content</div>}
+        placement="above"
+        alignment="center">
+        <a href="https://example.com">Example</a>
+      </HoverCard>
+    );
+    const html = renderToString(ui);
+    const container = document.createElement('div');
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    let root: ReturnType<typeof hydrateRoot> | null = null;
+
+    expect(html).toContain('Example');
+    expect(html).not.toContain('Hover content');
+    expect(html).not.toContain('popover=');
+
+    container.innerHTML = html;
+    document.body.appendChild(container);
+
+    try {
+      await act(async () => {
+        root = hydrateRoot(container, ui);
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('Hover content').closest('[popover]'),
+        ).not.toBeNull();
+      });
+
+      const hydrationErrors = errorSpy.mock.calls.filter(call =>
+        call.some(arg => /hydration|hydrated|did not match/i.test(String(arg))),
+      );
+      expect(hydrationErrors).toHaveLength(0);
+    } finally {
+      errorSpy.mockRestore();
+      await act(async () => {
+        root?.unmount();
+      });
+      container.remove();
+    }
   });
 
   it('does not show content initially', () => {
@@ -186,6 +234,39 @@ describe('HoverCard', () => {
       await waitFor(() => {
         expect(HTMLElement.prototype.showPopover).toHaveBeenCalled();
       });
+    });
+
+    it('shows hover card after SSR hydration when isDefaultOpen is true', async () => {
+      vi.mocked(HTMLElement.prototype.showPopover).mockClear();
+
+      const ui = (
+        <HoverCard
+          content={<span>Hydrated default open card</span>}
+          isDefaultOpen>
+          <button type="button">Trigger</button>
+        </HoverCard>
+      );
+      const html = renderToString(ui);
+      const container = document.createElement('div');
+      let root: ReturnType<typeof hydrateRoot> | null = null;
+
+      container.innerHTML = html;
+      document.body.appendChild(container);
+
+      try {
+        await act(async () => {
+          root = hydrateRoot(container, ui);
+        });
+
+        await waitFor(() => {
+          expect(HTMLElement.prototype.showPopover).toHaveBeenCalled();
+        });
+      } finally {
+        await act(async () => {
+          root?.unmount();
+        });
+        container.remove();
+      }
     });
 
     it('calls onOpenChange(true) on mount when isDefaultOpen is true', async () => {

--- a/packages/core/src/HoverCard/HoverCard.tsx
+++ b/packages/core/src/HoverCard/HoverCard.tsx
@@ -4,7 +4,7 @@
 
 /**
  * @file HoverCard.tsx
- * @input Uses React, ReactDOM createPortal, useHoverCard hook
+ * @input Uses React, useSyncExternalStore, ReactDOM createPortal, useHoverCard hook
  * @output Exports HoverCard component for hover/focus triggered layers
  * @position Layer component; uses inline-safe trigger wrapper and portals floating layer
  *
@@ -18,6 +18,7 @@
 import React, {
   useCallback,
   useRef,
+  useSyncExternalStore,
   type ReactElement,
   type ReactNode,
 } from 'react';
@@ -45,6 +46,22 @@ const styles = stylex.create({
     textUnderlineOffset: spacingVars['--spacing-0-5'],
   },
 });
+
+const subscribeToHydration = () => () => {};
+const getHydratedSnapshot = () => true;
+const getServerSnapshot = () => false;
+
+/**
+ * Returns false during SSR and the first hydration render, then true for
+ * browser-only renders after hydration completes.
+ */
+function useHasHydrated(): boolean {
+  return useSyncExternalStore(
+    subscribeToHydration,
+    getHydratedSnapshot,
+    getServerSnapshot,
+  );
+}
 
 export interface HoverCardProps extends Pick<
   BaseProps,
@@ -182,6 +199,7 @@ export function HoverCard({
 }: HoverCardProps): ReactElement {
   const wrapperRef = useRef<HTMLSpanElement>(null);
   const textOnly = isTextOnly(children);
+  const hasHydrated = useHasHydrated();
 
   // Determine if hover indication should be shown
   const showHoverIndication =
@@ -246,7 +264,7 @@ export function HoverCard({
   }, [textOnly, hoverCard.ref, hoverCard.describedBy]);
 
   const renderedHoverCard =
-    typeof document !== 'undefined'
+    hasHydrated && typeof document !== 'undefined'
       ? createPortal(
           hoverCard.renderHoverCard(content, {xstyle, className, style}),
           document.body,

--- a/packages/core/src/Layer/useLayer.doc.mjs
+++ b/packages/core/src/Layer/useLayer.doc.mjs
@@ -57,7 +57,8 @@ export const docs = {
     {
       name: 'show',
       type: '() => void',
-      description: 'Imperatively show the layer.',
+      description:
+        'Imperatively show the layer. If the popover element has not mounted yet, the open request is replayed when it attaches.',
     },
     {
       name: 'hide',
@@ -72,7 +73,8 @@ export const docs = {
     {
       name: 'id',
       type: 'string',
-      description: 'Unique ID for aria-describedby or other ARIA relationships.',
+      description:
+        'Unique ID for aria-describedby or other ARIA relationships.',
     },
     {
       name: 'render',
@@ -83,7 +85,7 @@ export const docs = {
   ],
   usage: {
     description:
-      'Core positioning hook for rendering overlay content using CSS Anchor Positioning and the Popover API. Use it as the foundation for custom popovers, hover cards, tooltips, and fixed-position layers when higher-level components are not enough.',
+      'Core positioning hook for rendering overlay content using CSS Anchor Positioning and the Popover API. Use it as the foundation for custom popovers, hover cards, tooltips, and fixed-position layers when higher-level components are not enough. Open state is tracked even when the popover DOM element mounts later.',
     bestPractices: [
       {
         guidance: true,
@@ -111,7 +113,7 @@ export const docs = {
 /** @type {import('../docs-types').HookTranslationDoc} */
 export const docsDense = {
   description:
-    'Core positioning hook for overlay content via CSS Anchor Positioning + Popover API. Foundation for custom popovers, hover cards, tooltips, fixed-position layers.',
+    'Core positioning hook for overlay content via CSS Anchor Positioning + Popover API. Foundation for custom popovers, hover cards, tooltips, fixed-position layers. Open requests can be made before DOM attach.',
   paramDescriptions: {
     mode: 'positioning strategy: context = CSS anchor relative to trigger; fixed = explicit x/y coords',
     onShow: 'fires when layer becomes visible.',
@@ -121,7 +123,7 @@ export const docsDense = {
   returnDescriptions: {
     ref: 'trigger ref for context mode; undefined in fixed mode.',
     anchorId: 'CSS anchor name.',
-    show: 'show layer.',
+    show: 'show layer; replays if popover DOM attaches later.',
     hide: 'hide layer.',
     isOpen: 'whether layer is open.',
     id: 'unique ARIA id.',
@@ -129,15 +131,17 @@ export const docsDense = {
   },
   usage: {
     description:
-      'Core positioning hook for overlay content via CSS Anchor Positioning + Popover API. Foundation for custom popovers, hover cards, tooltips, fixed-position layers.',
+      'Core positioning hook for overlay content via CSS Anchor Positioning + Popover API. Foundation for custom popovers, hover cards, tooltips, fixed-position layers. Open state can be requested before the DOM node attaches.',
     bestPractices: [
       {
         guidance: true,
-        description: 'Use context mode for trigger-anchored overlays; fixed mode for explicit coordinates.',
+        description:
+          'Use context mode for trigger-anchored overlays; fixed mode for explicit coordinates.',
       },
       {
         guidance: true,
-        description: 'Build on Popover/HoverCard/Tooltip for common overlay patterns.',
+        description:
+          'Build on Popover/HoverCard/Tooltip for common overlay patterns.',
       },
       {
         guidance: false,

--- a/packages/core/src/Layer/useLayer.tsx
+++ b/packages/core/src/Layer/useLayer.tsx
@@ -5,7 +5,7 @@
 /**
  * @file useLayer.tsx
  * @input Uses React hooks, Popover API, CSS anchor positioning, typography tokens
- * @output Exports useLayer hook for layer positioning and visibility
+ * @output Exports useLayer hook for layer positioning, visibility, and deferred DOM-open sync
  * @position Core layer utility; used by useHoverCard, useTooltip, etc.
  *
  * SYNC: When modified, update:
@@ -290,8 +290,8 @@ export function useLayer(
   const isOpenRef = useRef(false);
 
   const show = useCallback(() => {
-    if (popoverRef.current && !isOpenRef.current) {
-      popoverRef.current.showPopover();
+    if (!isOpenRef.current) {
+      popoverRef.current?.showPopover();
       isOpenRef.current = true;
       setIsOpen(true);
       onShow?.();
@@ -352,9 +352,16 @@ export function useLayer(
   // Ref callback for popover element — sets up toggle listener
   const popoverRefCallback = useCallback(
     (el: HTMLElement | null) => {
+      if (popoverRef.current) {
+        popoverRef.current.removeEventListener('toggle', handleToggle);
+      }
+
       popoverRef.current = el;
       if (el) {
         el.addEventListener('toggle', handleToggle);
+        if (isOpenRef.current && !el.matches(':popover-open')) {
+          el.showPopover();
+        }
       }
     },
     [handleToggle],


### PR DESCRIPTION
## Summary
- defer HoverCard's portaled popover until after hydration so SSR and the first client render match
- let useLayer record open state before the popover DOM node attaches, then replay showPopover on attach
- add SSR/hydration regression coverage for HoverCard, including isDefaultOpen
- document deferred-open behavior in useLayer docs

## Validation
- pnpm vitest run packages/core/src/HoverCard/HoverCard.test.tsx packages/core/src/Popover/Popover.test.tsx
- pnpm -F @astryxdesign/core typecheck
- pnpm -F @astryxdesign/core typecheck:docs
- pnpm -F @astryxdesign/core lint
- pnpm check:sync
- git diff --check

## Notes
- Tried pnpm -F @astryxdesign/core test, but that script runs the repo-wide suite via --root ../.. and failed in unrelated CLI/theme/build-css tests. The touched HoverCard/Popover tests passed in that run.