### PR TITLE
refactor(vibe-tests): rename TargetName 'xds' -> 'astryx' + schema field

### DIFF
--- a/internal/vibe-tests/src/types.ts
+++ b/internal/vibe-tests/src/types.ts
@@ -317,10 +317,10 @@ export interface UniversalAggregate {
   cost?: CostMetrics;
 }
 
-export type TargetName = 'xds' | 'xds-tailwind' | 'baseline' | 'html';
+export type TargetName = 'astryx' | 'xds-tailwind' | 'baseline' | 'html';
 
 export interface UniversalComparison {
-  xds: UniversalAggregate;
+  astryx: UniversalAggregate;
   baseline: UniversalAggregate;
   html?: UniversalAggregate;
   xdsTailwind?: UniversalAggregate;
@@ -328,7 +328,7 @@ export interface UniversalComparison {
   byPrompt: Record<
     string,
     {
-      xds: UniversalScore;
+      astryx: UniversalScore;
       baseline: UniversalScore;
       html?: UniversalScore;
       xdsTailwind?: UniversalScore;


### PR DESCRIPTION
Root schema change for removing the `xds` vibe-test target (Knots: `scrub-vibe-types`).

## Changes (1 file: `internal/vibe-tests/src/types.ts`)
- `TargetName` union: `'xds'` → `'astryx'` (keeps `'xds-tailwind'` — separate task)
- `UniversalComparison` interface: `xds:` field → `astryx:` (both aggregate-level and per-prompt)

## Why land this alone
CI doesn't typecheck vibe-tests (`pnpm -F @astryxdesign/vibe-tests typecheck` isn't in any workflow). The downstream consumers (interactive.ts, universal-compare.ts, report UI) are fixed in subsequent PRs tracked in Knots — this unblocks those tasks by establishing the correct schema first.

## Dependency graph
```
scrub-vibe-types (this PR)
    ↓ blocks
scrub-vibe-runner + scrub-vibe-pipeline + scrub-vibe-compare
    ↓ blocks
scrub-vibe-report → scrub-vibe-cleanup → scrub-xds-tailwind
```