### PR TITLE
refactor(vibe-tests): update pipeline files (drop xds target)

### DIFF
--- a/internal/vibe-tests/src/build-previews.ts
+++ b/internal/vibe-tests/src/build-previews.ts
@@ -154,7 +154,7 @@ function createEntryFile(
   const entryPath = path.join(tmpDir, 'entry.tsx');
 
   // For XDS and XDS+Tailwind targets, wrap in theme provider and import reset
-  if (target === 'xds' || target === 'xds-tailwind') {
+  if (target === 'astryx' || target === 'xds-tailwind') {
     const tailwindImport =
       target === 'xds-tailwind'
         ? `\nimport '${path.join(REPO_ROOT, 'packages/core/src/tailwind-theme.css').replace(/\\/g, '/')}';`
@@ -296,7 +296,7 @@ function createViteConfig(tmpDir: string, target: string): string {
   // type casts). We use a pre-transform plugin to strip TypeScript type
   // assertions before StyleX processes the file.
   const plugins =
-    target === 'xds' || target === 'xds-tailwind'
+    target === 'astryx' || target === 'xds-tailwind'
       ? `
     {
       name: 'stylex-inline-vars',
@@ -368,7 +368,7 @@ function createViteConfig(tmpDir: string, target: string): string {
     viteSingleFile(),`;
 
   const imports =
-    target === 'xds' || target === 'xds-tailwind'
+    target === 'astryx' || target === 'xds-tailwind'
       ? `import stylex from '@stylexjs/unplugin';
 import react from '@vitejs/plugin-react';
 import {viteSingleFile} from 'vite-plugin-singlefile';`
@@ -389,7 +389,7 @@ import {viteSingleFile} from 'vite-plugin-singlefile';`;
     },`;
 
   const aliases =
-    target === 'xds' || target === 'xds-tailwind'
+    target === 'astryx' || target === 'xds-tailwind'
       ? xdsAliases
       : target === 'baseline'
         ? `
@@ -533,7 +533,6 @@ type BuildErrors = Record<string, TscResult>;
  */
 function getTsconfigForTarget(target: string): string {
   switch (target) {
-    case 'xds':
     case 'xds-tailwind':
     case 'astryx':
       return path.join(VIBE_DIR, 'tsconfig.xds.json');
@@ -699,7 +698,7 @@ async function main() {
     }
 
     const iterManifest = readJson<{config?: {target?: string}}>(manifestPath);
-    const target = iterManifest.config?.target ?? 'xds';
+    const target = iterManifest.config?.target ?? 'astryx';
     const codeDir = path.join(iterDir, 'results');
 
     if (!fs.existsSync(codeDir)) {
@@ -733,7 +732,7 @@ async function main() {
       console.log(`  📄 ${promptId} (${target})...`);
 
       // Auto-fix missing XDS imports before building
-      if (target === 'xds' || target === 'xds-tailwind') {
+      if (target === 'astryx' || target === 'xds-tailwind') {
         const autoImported = fixMissingXDSImports(componentPath);
         if (autoImported.length > 0) {
           console.log(`  ⚡ Auto-imported: ${autoImported.join(', ')}`);
@@ -748,7 +747,7 @@ async function main() {
       const ok = buildPreview(componentPath, target, promptId, previewPath);
       if (ok) {
         // Post-build validation: ensure no unresolved XDS references
-        if (target === 'xds' || target === 'xds-tailwind') {
+        if (target === 'astryx' || target === 'xds-tailwind') {
           const unresolved = validatePreviewHtml(previewPath);
           if (unresolved.length > 0) {
             console.error(

--- a/internal/vibe-tests/src/fix-imports.ts
+++ b/internal/vibe-tests/src/fix-imports.ts
@@ -103,10 +103,10 @@ function main() {
     }
 
     const iterManifest = readJson<{config?: {target?: string}}>(manifestPath);
-    const target = iterManifest.config?.target ?? 'xds';
+    const target = iterManifest.config?.target ?? 'astryx';
 
     // Only XDS targets need import fixing
-    if (target !== 'xds') {
+    if (target !== 'astryx') {
       console.log(`  ⏭ ${iterationId} is ${target}, skipping`);
       continue;
     }

--- a/internal/vibe-tests/src/screenshot.ts
+++ b/internal/vibe-tests/src/screenshot.ts
@@ -51,12 +51,12 @@ function parseArgs(): {iteration: string; prompt?: string} {
 
 function generatePreviewCode(
   componentPath: string,
-  target: 'xds' | 'baseline' | 'xds-tailwind',
+  target: 'astryx' | 'baseline' | 'xds-tailwind',
 ): string {
   const relPath = path.relative(path.join(APP_DIR, 'src'), componentPath);
   const importPath = relPath.replace(/\.tsx$/, '').replace(/\\/g, '/');
 
-  if (target === 'xds' || target === 'xds-tailwind') {
+  if (target === 'astryx' || target === 'xds-tailwind') {
     // XDS+Tailwind uses the same XDS wrapper but also imports Tailwind CSS
     const tailwindImport =
       target === 'xds-tailwind' ? `\nimport '../tailwind.css';` : '';
@@ -108,7 +108,7 @@ async function main() {
     prompts: Array<{id: string; category: string}>;
   }>(manifestPath);
 
-  const target = manifest.config.target as 'xds' | 'baseline' | 'xds-tailwind';
+  const target = manifest.config.target as 'astryx' | 'baseline' | 'xds-tailwind';
 
   // Determine which prompts to screenshot
   let promptIds = manifest.prompts.map(p => p.id);

--- a/internal/vibe-tests/src/setup-environment.mjs
+++ b/internal/vibe-tests/src/setup-environment.mjs
@@ -13,7 +13,7 @@
  *
  * Usage (from setup-nightly.mjs):
  *   import {createAgentProject} from './setup-environment.mjs';
- *   const projectDir = createAgentProject('xds', iterDir, 'fwc-1');
+ *   const projectDir = createAgentProject('astryx', iterDir, 'fwc-1');
  */
 
 import * as fs from 'node:fs';
@@ -38,7 +38,7 @@ function copyFile(src, dest) {
  * Create an isolated project directory for a single agent.
  * Returns the absolute path to the project directory.
  *
- * @param {'xds' | 'xds-tailwind' | 'baseline' | 'html'} target
+ * @param {'astryx' | 'xds-tailwind' | 'baseline' | 'html'} target
  * @param {string} iterDir - The iteration results directory
  * @param {string} promptId - The prompt ID (used to name the clone)
  */
@@ -47,7 +47,7 @@ export function createAgentProject(target, iterDir, promptId) {
   ensureDir(projectDir);
 
   const templateMap = {
-    xds: 'project-xds',
+    astryx: 'project-astryx',
     'xds-tailwind': 'project-xds-tailwind',
     baseline: 'project-baseline',
     html: 'project-html',
@@ -61,7 +61,7 @@ export function createAgentProject(target, iterDir, promptId) {
     copyFile(path.join(templateDir, file), path.join(projectDir, file));
   }
 
-  if (target === 'xds' || target === 'xds-tailwind') {
+  if (target === 'astryx' || target === 'xds-tailwind') {
     // Symlink node_modules/@astryxdesign/core → packages/core
     const coreLink = path.join(projectDir, 'node_modules', '@astryxdesign', 'core');
     ensureDir(path.dirname(coreLink));


### PR DESCRIPTION
Knots: `scrub-vibe-pipeline`. Depends on #3109 (`scrub-vibe-types`).

Updates the 4 pipeline files to use `'astryx'` instead of `'xds'` as the target:
- `build-previews.ts`: 6 condition sites + switch case + default
- `fix-imports.ts`: default + guard condition
- `screenshot.ts`: type unions + condition
- `setup-environment.mjs`: templateMap + JSDoc + condition

`xds-tailwind` refs kept (separate `scrub-xds-tailwind` task). 4 files, -17/+16 lines.