### PR TITLE
refactor(vibe-tests): update report UI (drop xds target + fix broken imports)

### DIFF
--- a/internal/vibe-tests/app/src/report/CodeModal.tsx
+++ b/internal/vibe-tests/app/src/report/CodeModal.tsx
@@ -1,18 +1,18 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-import {XDSDialog} from '@astryxdesign/core/Dialog';
-import {XDSVStack} from '@astryxdesign/core/Stack';
-import {XDSText} from '@astryxdesign/core/Text';
-import {XDSHeading} from '@astryxdesign/core/Text';
-import {XDSButton} from '@astryxdesign/core/Button';
-import {XDSIcon} from '@astryxdesign/core/Icon';
+import {Dialog} from '@astryxdesign/core/Dialog';
+import {VStack} from '@astryxdesign/core/Stack';
+import {Text} from '@astryxdesign/core/Text';
+import {Heading} from '@astryxdesign/core/Text';
+import {Button} from '@astryxdesign/core/Button';
+import {Icon} from '@astryxdesign/core/Icon';
 import './report.css';
 
 interface CodeModalProps {
   isOpen: boolean;
   onHide: () => void;
   promptId: string;
-  target: 'xds' | 'baseline' | 'html';
+  target: 'astryx' | 'baseline' | 'html';
   code: string;
 }
 
@@ -24,34 +24,34 @@ export function CodeModal({
   code,
 }: CodeModalProps) {
   const targetLabel =
-    target === 'xds' ? 'XDS' : target === 'baseline' ? 'Baseline' : 'HTML';
+    target === 'astryx' ? 'Astryx' : target === 'baseline' ? 'Baseline' : 'HTML';
   const lineCount = code.split('\n').length;
 
   return (
-    <XDSDialog
+    <Dialog
       isOpen={isOpen}
       onHide={onHide}
       purpose="info"
       width={800}
       aria-label={`${targetLabel} code for ${promptId}`}>
       <div className="report-codeModal-header">
-        <XDSVStack gap={1}>
-          <XDSHeading level={3}>
+        <VStack gap={1}>
+          <Heading level={3}>
             {promptId} — {targetLabel}
-          </XDSHeading>
-          <XDSText type="supporting">{lineCount} lines</XDSText>
-        </XDSVStack>
-        <XDSButton
+          </Heading>
+          <Text type="supporting">{lineCount} lines</Text>
+        </VStack>
+        <Button
           variant="ghost"
           label="Close"
           tooltip="Close"
-          icon={<XDSIcon icon="close" color="inherit" />}
+          icon={<Icon icon="close" color="inherit" />}
           onClick={onHide}
         />
       </div>
       <div className="report-codeModal-content">
         <div className="report-codeModal-codeBlock">{code}</div>
       </div>
-    </XDSDialog>
+    </Dialog>
   );
 }

--- a/internal/vibe-tests/app/src/report/CompareView.tsx
+++ b/internal/vibe-tests/app/src/report/CompareView.tsx
@@ -1,12 +1,12 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-import {XDSCard} from '@astryxdesign/core/Card';
-import {XDSVStack} from '@astryxdesign/core/Stack';
-import {XDSText} from '@astryxdesign/core/Text';
-import {XDSHeading} from '@astryxdesign/core/Text';
-import {XDSBadge} from '@astryxdesign/core/Badge';
-import {XDSTable} from '@astryxdesign/core/Table';
-import type {XDSTableColumn} from '@astryxdesign/core/Table';
+import {Card} from '@astryxdesign/core/Card';
+import {VStack} from '@astryxdesign/core/Stack';
+import {Text} from '@astryxdesign/core/Text';
+import {Heading} from '@astryxdesign/core/Text';
+import {Badge} from '@astryxdesign/core/Badge';
+import {Table} from '@astryxdesign/core/Table';
+import type {TableColumn} from '@astryxdesign/core/Table';
 import type {
   UniversalComparison,
   UniversalDimension,
@@ -29,7 +29,7 @@ interface CompareViewProps {
 interface DimRow extends Record<string, unknown> {
   id: string;
   dimension: string;
-  xdsScore: number;
+  astryxScore: number;
   baselineScore: number;
   htmlScore?: number;
   xdsTailwindScore?: number;
@@ -40,7 +40,7 @@ interface DimRow extends Record<string, unknown> {
 interface CatRow extends Record<string, unknown> {
   id: string;
   category: string;
-  xdsOverall: number;
+  astryxOverall: number;
   baselineOverall: number;
   htmlOverall?: number;
   xdsTailwindOverall?: number;
@@ -50,7 +50,7 @@ interface CatRow extends Record<string, unknown> {
 interface CostRow extends Record<string, unknown> {
   id: string;
   metric: string;
-  xds: string;
+  astryx: string;
   baseline: string;
   html?: string;
   xdsTailwind?: string;
@@ -58,14 +58,14 @@ interface CostRow extends Record<string, unknown> {
 }
 
 function costWinner(
-  xdsVal: number,
+  astryxVal: number,
   baseVal: number,
   lowerIsBetter: boolean,
   htmlVal?: number,
   twVal?: number,
 ): WinnerType {
   const entries: [WinnerType, number][] = [
-    ['xds', xdsVal],
+    ['astryx', astryxVal],
     ['baseline', baseVal],
   ];
   if (htmlVal != null) {
@@ -89,7 +89,7 @@ function winnerBadgeVariant(
   w: string,
 ): 'success' | 'error' | 'warning' | 'neutral' | 'info' {
   switch (w) {
-    case 'xds':
+    case 'astryx':
       return 'success';
     case 'baseline':
       return 'error';
@@ -104,8 +104,8 @@ function winnerBadgeVariant(
 
 function winnerLabel(w: string): string {
   switch (w) {
-    case 'xds':
-      return 'XDS';
+    case 'astryx':
+      return 'Astryx';
     case 'baseline':
       return 'Baseline';
     case 'html':
@@ -128,12 +128,12 @@ function deltaClassName(delta: number): string {
 }
 
 function CostComparisonSection({
-  xdsCost,
+  astryxCost,
   baselineCost,
   htmlCost,
   xdsTailwindCost,
 }: {
-  xdsCost: CostMetrics;
+  astryxCost: CostMetrics;
   baselineCost: CostMetrics;
   htmlCost?: CostMetrics;
   xdsTailwindCost?: CostMetrics;
@@ -141,7 +141,7 @@ function CostComparisonSection({
   const isThreeWay = !!htmlCost;
   const isFourWay = !!xdsTailwindCost;
   const hasDuration =
-    xdsCost.avgDurationMs > 0 || baselineCost.avgDurationMs > 0;
+    astryxCost.avgDurationMs > 0 || baselineCost.avgDurationMs > 0;
 
   const costData: CostRow[] = [
     ...(hasDuration
@@ -149,7 +149,7 @@ function CostComparisonSection({
           {
             id: 'duration',
             metric: 'Avg Duration',
-            xds: `${(xdsCost.avgDurationMs / 1000).toFixed(1)}s`,
+            astryx: `${(astryxCost.avgDurationMs / 1000).toFixed(1)}s`,
             baseline: `${(baselineCost.avgDurationMs / 1000).toFixed(1)}s`,
             ...(isThreeWay
               ? {html: `${((htmlCost?.avgDurationMs ?? 0) / 1000).toFixed(1)}s`}
@@ -160,7 +160,7 @@ function CostComparisonSection({
                 }
               : {}),
             winner: costWinner(
-              xdsCost.avgDurationMs,
+              astryxCost.avgDurationMs,
               baselineCost.avgDurationMs,
               true,
               htmlCost?.avgDurationMs,
@@ -172,7 +172,7 @@ function CostComparisonSection({
     {
       id: 'input-tokens',
       metric: 'Input Tokens',
-      xds: `~${xdsCost.estimatedInputTokens.toLocaleString()}`,
+      astryx: `~${astryxCost.estimatedInputTokens.toLocaleString()}`,
       baseline: `~${baselineCost.estimatedInputTokens.toLocaleString()}`,
       ...(isThreeWay
         ? {html: `~${htmlCost?.estimatedInputTokens.toLocaleString()}`}
@@ -183,7 +183,7 @@ function CostComparisonSection({
           }
         : {}),
       winner: costWinner(
-        xdsCost.estimatedInputTokens,
+        astryxCost.estimatedInputTokens,
         baselineCost.estimatedInputTokens,
         true,
         htmlCost?.estimatedInputTokens,
@@ -193,7 +193,7 @@ function CostComparisonSection({
     {
       id: 'output-tokens',
       metric: 'Output Tokens',
-      xds: `~${xdsCost.estimatedOutputTokens.toLocaleString()}`,
+      astryx: `~${astryxCost.estimatedOutputTokens.toLocaleString()}`,
       baseline: `~${baselineCost.estimatedOutputTokens.toLocaleString()}`,
       ...(isThreeWay
         ? {html: `~${htmlCost?.estimatedOutputTokens.toLocaleString()}`}
@@ -204,7 +204,7 @@ function CostComparisonSection({
           }
         : {}),
       winner: costWinner(
-        xdsCost.estimatedOutputTokens,
+        astryxCost.estimatedOutputTokens,
         baselineCost.estimatedOutputTokens,
         true,
         htmlCost?.estimatedOutputTokens,
@@ -214,7 +214,7 @@ function CostComparisonSection({
     {
       id: 'total-tokens',
       metric: 'Total Tokens',
-      xds: `~${(xdsCost.estimatedInputTokens + xdsCost.estimatedOutputTokens).toLocaleString()}`,
+      astryx: `~${(astryxCost.estimatedInputTokens + astryxCost.estimatedOutputTokens).toLocaleString()}`,
       baseline: `~${(baselineCost.estimatedInputTokens + baselineCost.estimatedOutputTokens).toLocaleString()}`,
       ...(isThreeWay
         ? {
@@ -227,7 +227,7 @@ function CostComparisonSection({
           }
         : {}),
       winner: costWinner(
-        xdsCost.estimatedInputTokens + xdsCost.estimatedOutputTokens,
+        astryxCost.estimatedInputTokens + astryxCost.estimatedOutputTokens,
         baselineCost.estimatedInputTokens + baselineCost.estimatedOutputTokens,
         true,
         htmlCost
@@ -242,14 +242,14 @@ function CostComparisonSection({
     {
       id: 'output-lines',
       metric: 'Avg Output Lines',
-      xds: String(xdsCost.avgOutputLines),
+      astryx: String(astryxCost.avgOutputLines),
       baseline: String(baselineCost.avgOutputLines),
       ...(isThreeWay ? {html: String(htmlCost?.avgOutputLines)} : {}),
       ...(isFourWay
         ? {xdsTailwind: String(xdsTailwindCost?.avgOutputLines)}
         : {}),
       winner: costWinner(
-        xdsCost.avgOutputLines,
+        astryxCost.avgOutputLines,
         baselineCost.avgOutputLines,
         true,
         htmlCost?.avgOutputLines,
@@ -259,7 +259,7 @@ function CostComparisonSection({
     {
       id: 'docs-read',
       metric: 'Avg Docs Read',
-      xds: String(xdsCost.avgDocsRead),
+      astryx: String(astryxCost.avgDocsRead),
       baseline: String(baselineCost.avgDocsRead),
       ...(isThreeWay ? {html: String(htmlCost?.avgDocsRead)} : {}),
       ...(isFourWay ? {xdsTailwind: String(xdsTailwindCost?.avgDocsRead)} : {}),
@@ -267,17 +267,17 @@ function CostComparisonSection({
     },
   ];
 
-  const costColumns: XDSTableColumn<CostRow>[] = [
+  const costColumns: TableColumn<CostRow>[] = [
     {key: 'metric', header: 'Metric'},
     {
-      key: 'xds',
-      header: 'XDS',
-      renderCell: row => <XDSText type="body">{row.xds}</XDSText>,
+      key: 'astryx',
+      header: 'Astryx',
+      renderCell: row => <Text type="body">{row.astryx}</Text>,
     },
     {
       key: 'baseline',
       header: 'Baseline',
-      renderCell: row => <XDSText type="body">{row.baseline}</XDSText>,
+      renderCell: row => <Text type="body">{row.baseline}</Text>,
     },
     ...(isThreeWay
       ? [
@@ -285,9 +285,9 @@ function CostComparisonSection({
             key: 'html' as const,
             header: 'HTML',
             renderCell: (row: CostRow) => (
-              <XDSText type="body">{row.html ?? '—'}</XDSText>
+              <Text type="body">{row.html ?? '—'}</Text>
             ),
-          } satisfies XDSTableColumn<CostRow>,
+          } satisfies TableColumn<CostRow>,
         ]
       : []),
     ...(isFourWay
@@ -296,16 +296,16 @@ function CostComparisonSection({
             key: 'xdsTailwind' as const,
             header: 'XDS+TW',
             renderCell: (row: CostRow) => (
-              <XDSText type="body">{row.xdsTailwind ?? '—'}</XDSText>
+              <Text type="body">{row.xdsTailwind ?? '—'}</Text>
             ),
-          } satisfies XDSTableColumn<CostRow>,
+          } satisfies TableColumn<CostRow>,
         ]
       : []),
     {
       key: 'winner',
       header: 'Lower Cost',
       renderCell: row => (
-        <XDSBadge
+        <Badge
           variant={winnerBadgeVariant(row.winner)}
           label={row.winner === 'tie' ? '—' : winnerLabel(row.winner)}
         />
@@ -314,7 +314,7 @@ function CostComparisonSection({
   ];
 
   return (
-    <XDSTable<CostRow>
+    <Table<CostRow>
       data={costData}
       columns={costColumns}
       idKey="id"
@@ -329,15 +329,15 @@ export function CompareView({comparison}: CompareViewProps) {
   const isThreeWay = !!html;
   const isFourWay = !!xdsTailwind;
 
-  let xdsWins = 0;
+  let astryxWins = 0;
   let baselineWins = 0;
   let htmlWins = 0;
   let xdsTailwindWins = 0;
   let ties = 0;
   for (const dim of ALL_DIMENSIONS) {
     const w = winners[dim];
-    if (w === 'xds') {
-      xdsWins++;
+    if (w === 'astryx') {
+      astryxWins++;
     } else if (w === 'baseline') {
       baselineWins++;
     } else if (w === 'html') {
@@ -350,32 +350,32 @@ export function CompareView({comparison}: CompareViewProps) {
   }
 
   const dimData: DimRow[] = ALL_DIMENSIONS.filter(
-    dim => xds.averages[dim] != null || baseline.averages[dim] != null,
+    dim => astryx.averages[dim] != null || baseline.averages[dim] != null,
   ).map(dim => ({
     id: dim,
     dimension: DIMENSION_LABELS[dim],
-    xdsScore: xds.averages[dim] ?? 0,
+    astryxScore: astryx.averages[dim] ?? 0,
     baselineScore: baseline.averages[dim] ?? 0,
     ...(isThreeWay ? {htmlScore: html?.averages[dim] ?? 0} : {}),
     ...(isFourWay ? {xdsTailwindScore: xdsTailwind?.averages[dim] ?? 0} : {}),
-    delta: (xds.averages[dim] ?? 0) - (baseline.averages[dim] ?? 0),
+    delta: (astryx.averages[dim] ?? 0) - (baseline.averages[dim] ?? 0),
     winner: winners[dim],
   }));
 
-  const dimColumns: XDSTableColumn<DimRow>[] = [
+  const dimColumns: TableColumn<DimRow>[] = [
     {key: 'dimension', header: 'Dimension'},
     {
-      key: 'xdsScore',
-      header: 'XDS',
+      key: 'astryxScore',
+      header: 'Astryx',
       renderCell: row => (
-        <XDSText type="body">{formatScore(row.xdsScore)}</XDSText>
+        <Text type="body">{formatScore(row.astryxScore)}</Text>
       ),
     },
     {
       key: 'baselineScore',
       header: 'Baseline',
       renderCell: row => (
-        <XDSText type="body">{formatScore(row.baselineScore)}</XDSText>
+        <Text type="body">{formatScore(row.baselineScore)}</Text>
       ),
     },
     ...(isThreeWay
@@ -384,11 +384,11 @@ export function CompareView({comparison}: CompareViewProps) {
             key: 'htmlScore' as const,
             header: 'HTML',
             renderCell: (row: DimRow) => (
-              <XDSText type="body">
+              <Text type="body">
                 {row.htmlScore != null ? formatScore(row.htmlScore) : '—'}
-              </XDSText>
+              </Text>
             ),
-          } satisfies XDSTableColumn<DimRow>,
+          } satisfies TableColumn<DimRow>,
         ]
       : []),
     ...(isFourWay
@@ -397,30 +397,30 @@ export function CompareView({comparison}: CompareViewProps) {
             key: 'xdsTailwindScore' as const,
             header: 'XDS+TW',
             renderCell: (row: DimRow) => (
-              <XDSText type="body">
+              <Text type="body">
                 {row.xdsTailwindScore != null
                   ? formatScore(row.xdsTailwindScore)
                   : '—'}
-              </XDSText>
+              </Text>
             ),
-          } satisfies XDSTableColumn<DimRow>,
+          } satisfies TableColumn<DimRow>,
         ]
       : []),
     {
       key: 'delta',
-      header: 'Delta (XDS−Base)',
+      header: 'Delta (Astryx−Base)',
       renderCell: row => (
-        <XDSText type="body" className={deltaClassName(row.delta)}>
+        <Text type="body" className={deltaClassName(row.delta)}>
           {row.delta > 0 ? '+' : ''}
           {formatScore(row.delta)}
-        </XDSText>
+        </Text>
       ),
     },
     {
       key: 'winner',
       header: 'Winner',
       renderCell: row => (
-        <XDSBadge
+        <Badge
           variant={winnerBadgeVariant(row.winner)}
           label={winnerLabel(row.winner)}
         />
@@ -429,14 +429,14 @@ export function CompareView({comparison}: CompareViewProps) {
   ];
 
   const allCategories = new Set([
-    ...Object.keys(xds.byCategory),
+    ...Object.keys(astryx.byCategory),
     ...Object.keys(baseline.byCategory),
     ...(html ? Object.keys(html.byCategory) : []),
     ...(xdsTailwind ? Object.keys(xdsTailwind.byCategory) : []),
   ]);
 
   const catData: CatRow[] = [...allCategories].map(cat => {
-    const xdsCat = xds.byCategory[cat] ?? {};
+    const astryxCat = astryx.byCategory[cat] ?? {};
     const baseCat = baseline.byCategory[cat] ?? {};
     const htmlInit = {};
     const htmlCat =
@@ -445,9 +445,9 @@ export function CompareView({comparison}: CompareViewProps) {
     const twCat =
       xdsTailwind?.byCategory[cat] ??
       (twInit as Record<UniversalDimension, number>);
-    const xdsAvg =
+    const astryxAvg =
       CODE_DIMENSIONS.reduce(
-        (s, d) => s + ((xdsCat[d as UniversalDimension] as number) ?? 0),
+        (s, d) => s + ((astryxCat[d as UniversalDimension] as number) ?? 0),
         0,
       ) / CODE_DIMENSIONS.length;
     const baseAvg =
@@ -470,28 +470,28 @@ export function CompareView({comparison}: CompareViewProps) {
     return {
       id: cat,
       category: cat,
-      xdsOverall: xdsAvg,
+      astryxOverall: astryxAvg,
       baselineOverall: baseAvg,
       ...(htmlAvg != null ? {htmlOverall: htmlAvg} : {}),
       ...(twAvg != null ? {xdsTailwindOverall: twAvg} : {}),
-      delta: xdsAvg - baseAvg,
+      delta: astryxAvg - baseAvg,
     };
   });
 
-  const catColumns: XDSTableColumn<CatRow>[] = [
+  const catColumns: TableColumn<CatRow>[] = [
     {key: 'category', header: 'Category'},
     {
-      key: 'xdsOverall',
-      header: 'XDS',
+      key: 'astryxOverall',
+      header: 'Astryx',
       renderCell: row => (
-        <XDSText type="body">{formatScore(row.xdsOverall)}</XDSText>
+        <Text type="body">{formatScore(row.astryxOverall)}</Text>
       ),
     },
     {
       key: 'baselineOverall',
       header: 'Baseline',
       renderCell: row => (
-        <XDSText type="body">{formatScore(row.baselineOverall)}</XDSText>
+        <Text type="body">{formatScore(row.baselineOverall)}</Text>
       ),
     },
     ...(isThreeWay
@@ -500,11 +500,11 @@ export function CompareView({comparison}: CompareViewProps) {
             key: 'htmlOverall' as const,
             header: 'HTML',
             renderCell: (row: CatRow) => (
-              <XDSText type="body">
+              <Text type="body">
                 {row.htmlOverall != null ? formatScore(row.htmlOverall) : '—'}
-              </XDSText>
+              </Text>
             ),
-          } satisfies XDSTableColumn<CatRow>,
+          } satisfies TableColumn<CatRow>,
         ]
       : []),
     ...(isFourWay
@@ -513,23 +513,23 @@ export function CompareView({comparison}: CompareViewProps) {
             key: 'xdsTailwindOverall' as const,
             header: 'XDS+TW',
             renderCell: (row: CatRow) => (
-              <XDSText type="body">
+              <Text type="body">
                 {row.xdsTailwindOverall != null
                   ? formatScore(row.xdsTailwindOverall)
                   : '—'}
-              </XDSText>
+              </Text>
             ),
-          } satisfies XDSTableColumn<CatRow>,
+          } satisfies TableColumn<CatRow>,
         ]
       : []),
     {
       key: 'delta',
-      header: 'Delta (XDS−Base)',
+      header: 'Delta (Astryx−Base)',
       renderCell: row => (
-        <XDSText type="body" className={deltaClassName(row.delta)}>
+        <Text type="body" className={deltaClassName(row.delta)}>
           {row.delta > 0 ? '+' : ''}
           {formatScore(row.delta)}
-        </XDSText>
+        </Text>
       ),
     },
   ];
@@ -544,99 +544,99 @@ export function CompareView({comparison}: CompareViewProps) {
         : 'report-compare-summaryGrid';
 
   return (
-    <XDSVStack gap={4}>
+    <VStack gap={4}>
       <div className={summaryGridClass}>
-        <XDSCard>
+        <Card>
           <div className="report-compare-winCard">
-            <XDSVStack gap={2}>
-              <XDSText type="label">XDS Wins</XDSText>
-              <XDSHeading level={2}>
-                <span className="report-color-positive">{xdsWins}</span>
-              </XDSHeading>
-            </XDSVStack>
+            <VStack gap={2}>
+              <Text type="label">Astryx Wins</Text>
+              <Heading level={2}>
+                <span className="report-color-positive">{astryxWins}</span>
+              </Heading>
+            </VStack>
           </div>
-        </XDSCard>
-        <XDSCard>
+        </Card>
+        <Card>
           <div className="report-compare-winCard">
-            <XDSVStack gap={2}>
-              <XDSText type="label">Baseline Wins</XDSText>
-              <XDSHeading level={2}>
+            <VStack gap={2}>
+              <Text type="label">Baseline Wins</Text>
+              <Heading level={2}>
                 <span className="report-color-negative">{baselineWins}</span>
-              </XDSHeading>
-            </XDSVStack>
+              </Heading>
+            </VStack>
           </div>
-        </XDSCard>
+        </Card>
         {isThreeWay && (
-          <XDSCard>
+          <Card>
             <div className="report-compare-winCard">
-              <XDSVStack gap={2}>
-                <XDSText type="label">HTML Wins</XDSText>
-                <XDSHeading level={2}>
+              <VStack gap={2}>
+                <Text type="label">HTML Wins</Text>
+                <Heading level={2}>
                   <span className="report-color-warning">{htmlWins}</span>
-                </XDSHeading>
-              </XDSVStack>
+                </Heading>
+              </VStack>
             </div>
-          </XDSCard>
+          </Card>
         )}
         {isFourWay && (
-          <XDSCard>
+          <Card>
             <div className="report-compare-winCard">
-              <XDSVStack gap={2}>
-                <XDSText type="label">XDS+TW Wins</XDSText>
-                <XDSHeading level={2}>
+              <VStack gap={2}>
+                <Text type="label">XDS+TW Wins</Text>
+                <Heading level={2}>
                   <span className="report-color-info">{xdsTailwindWins}</span>
-                </XDSHeading>
-              </XDSVStack>
+                </Heading>
+              </VStack>
             </div>
-          </XDSCard>
+          </Card>
         )}
-        <XDSCard>
+        <Card>
           <div className="report-compare-winCard">
-            <XDSVStack gap={2}>
-              <XDSText type="label">Ties</XDSText>
-              <XDSHeading level={2}>
+            <VStack gap={2}>
+              <Text type="label">Ties</Text>
+              <Heading level={2}>
                 <span className="report-color-neutral">{ties}</span>
-              </XDSHeading>
-            </XDSVStack>
+              </Heading>
+            </VStack>
           </div>
-        </XDSCard>
+        </Card>
       </div>
 
-      <XDSVStack gap={3}>
-        <XDSHeading level={3}>Dimension Comparison</XDSHeading>
-        <XDSTable<DimRow>
+      <VStack gap={3}>
+        <Heading level={3}>Dimension Comparison</Heading>
+        <Table<DimRow>
           data={dimData}
           columns={dimColumns}
           idKey="id"
           density="balanced"
           dividers="rows"
         />
-      </XDSVStack>
+      </VStack>
 
       {catData.length > 0 && (
-        <XDSVStack gap={3}>
-          <XDSHeading level={3}>Category Breakdown</XDSHeading>
-          <XDSTable<CatRow>
+        <VStack gap={3}>
+          <Heading level={3}>Category Breakdown</Heading>
+          <Table<CatRow>
             data={catData}
             columns={catColumns}
             idKey="id"
             density="balanced"
             dividers="rows"
           />
-        </XDSVStack>
+        </VStack>
       )}
 
-      {xds.cost && baseline.cost && (
-        <XDSVStack gap={3}>
-          <XDSHeading level={3}>Cost Comparison</XDSHeading>
+      {astryx.cost && baseline.cost && (
+        <VStack gap={3}>
+          <Heading level={3}>Cost Comparison</Heading>
           <CostComparisonSection
-            xdsCost={xds.cost}
+            astryxCost={astryx.cost}
             baselineCost={baseline.cost}
             htmlCost={html?.cost}
             xdsTailwindCost={xdsTailwind?.cost}
           />
-        </XDSVStack>
+        </VStack>
       )}
-    </XDSVStack>
+    </VStack>
   );
 }

--- a/internal/vibe-tests/app/src/report/DimensionTable.tsx
+++ b/internal/vibe-tests/app/src/report/DimensionTable.tsx
@@ -1,10 +1,10 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-import {XDSTable} from '@astryxdesign/core/Table';
-import {XDSStatusDot} from '@astryxdesign/core/StatusDot';
-import {XDSHStack} from '@astryxdesign/core/Stack';
-import {XDSText} from '@astryxdesign/core/Text';
-import type {XDSTableColumn} from '@astryxdesign/core/Table';
+import {Table} from '@astryxdesign/core/Table';
+import {StatusDot} from '@astryxdesign/core/StatusDot';
+import {HStack} from '@astryxdesign/core/Stack';
+import {Text} from '@astryxdesign/core/Text';
+import type {TableColumn} from '@astryxdesign/core/Table';
 import type {UniversalScore} from './types';
 import {
   ALL_DIMENSIONS,
@@ -32,14 +32,14 @@ interface RowData extends Record<string, unknown> {
 
 function ScoreCell({score}: {score: number}) {
   return (
-    <XDSHStack gap={1} hAlign="center">
-      <XDSStatusDot
+    <HStack gap={1} hAlign="center">
+      <StatusDot
         variant={scoreToStatusVariant(score)}
         label={`Score: ${formatScore(score)}`}
         size="sm"
       />
-      <XDSText type="body">{formatScore(score)}</XDSText>
-    </XDSHStack>
+      <Text type="body">{formatScore(score)}</Text>
+    </HStack>
   );
 }
 
@@ -56,14 +56,14 @@ export function DimensionTable({byPrompt}: DimensionTableProps) {
     overall: computeOverall(score),
   }));
 
-  const columns: XDSTableColumn<RowData>[] = [
+  const columns: TableColumn<RowData>[] = [
     {
       key: 'promptId',
       header: 'Prompt',
-      renderCell: row => <XDSText type="body">{row.promptId}</XDSText>,
+      renderCell: row => <Text type="body">{row.promptId}</Text>,
     },
     ...ALL_DIMENSIONS.map(
-      (dim): XDSTableColumn<RowData> => ({
+      (dim): TableColumn<RowData> => ({
         key: dim,
         header: DIMENSION_LABELS[dim],
         renderCell: row => <ScoreCell score={row[dim] as number} />,
@@ -77,7 +77,7 @@ export function DimensionTable({byPrompt}: DimensionTableProps) {
   ];
 
   return (
-    <XDSTable<RowData>
+    <Table<RowData>
       data={data}
       columns={columns}
       idKey="id"

--- a/internal/vibe-tests/app/src/report/PromptDetailCard.tsx
+++ b/internal/vibe-tests/app/src/report/PromptDetailCard.tsx
@@ -1,13 +1,13 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-import {XDSCard} from '@astryxdesign/core/Card';
-import {XDSVStack} from '@astryxdesign/core/Stack';
-import {XDSText} from '@astryxdesign/core/Text';
-import {XDSHeading} from '@astryxdesign/core/Text';
-import {XDSStatusDot} from '@astryxdesign/core/StatusDot';
-import {XDSBadge} from '@astryxdesign/core/Badge';
-import {XDSButton} from '@astryxdesign/core/Button';
-import {XDSDivider} from '@astryxdesign/core/Divider';
+import {Card} from '@astryxdesign/core/Card';
+import {VStack} from '@astryxdesign/core/Stack';
+import {Text} from '@astryxdesign/core/Text';
+import {Heading} from '@astryxdesign/core/Text';
+import {StatusDot} from '@astryxdesign/core/StatusDot';
+import {Badge} from '@astryxdesign/core/Badge';
+import {Button} from '@astryxdesign/core/Button';
+import {Divider} from '@astryxdesign/core/Divider';
 import type {UniversalScore} from './types';
 import {
   ALL_DIMENSIONS,
@@ -20,14 +20,14 @@ import './report.css';
 function ScoreItem({label, score}: {label: string; score: number}) {
   return (
     <div className="report-promptDetail-scoreItem">
-      <XDSStatusDot
+      <StatusDot
         variant={scoreToStatusVariant(score)}
         label={`${label}: ${score}`}
         size="sm"
       />
-      <XDSText type="supporting">
+      <Text type="supporting">
         {label} {score}
-      </XDSText>
+      </Text>
     </div>
   );
 }
@@ -35,8 +35,8 @@ function ScoreItem({label, score}: {label: string; score: number}) {
 function ScoreSummary({label, score}: {label: string; score: UniversalScore}) {
   return (
     <div className="report-promptDetail-scoreBlock">
-      <XDSVStack gap={2}>
-        <XDSText type="label">{label}</XDSText>
+      <VStack gap={2}>
+        <Text type="label">{label}</Text>
         <div className="report-promptDetail-scoreGrid">
           {ALL_DIMENSIONS.filter(dim => score[dim] != null).map(dim => (
             <ScoreItem
@@ -47,7 +47,7 @@ function ScoreSummary({label, score}: {label: string; score: UniversalScore}) {
           ))}
           <ScoreItem label="Overall" score={computeOverall(score)} />
         </div>
-      </XDSVStack>
+      </VStack>
     </div>
   );
 }
@@ -62,14 +62,14 @@ function Findings({score}: {score: UniversalScore}) {
   );
 
   if (allFindings.length === 0) {
-    return <XDSText type="supporting">No issues found.</XDSText>;
+    return <Text type="supporting">No issues found.</Text>;
   }
 
   return (
     <div className="report-promptDetail-findingsGrid">
       {allFindings.map((f, i) => (
         <>
-          <XDSBadge
+          <Badge
             key={`badge-${i}`}
             variant={
               f.severity === 'critical'
@@ -80,9 +80,9 @@ function Findings({score}: {score: UniversalScore}) {
             }
             label={f.severity ?? 'info'}
           />
-          <XDSText key={`text-${i}`} type="body">
+          <Text key={`text-${i}`} type="body">
             <strong>{f.dimension}</strong> — {f.detail}
-          </XDSText>
+          </Text>
         </>
       ))}
     </div>
@@ -93,7 +93,7 @@ interface PromptDetailCardProps {
   promptId: string;
   /** The actual prompt text shown to the agent */
   promptText?: string;
-  xdsScore?: UniversalScore;
+  astryxScore?: UniversalScore;
   baselineScore?: UniversalScore;
   htmlScore?: UniversalScore;
   xdsTailwindScore?: UniversalScore;
@@ -102,14 +102,14 @@ interface PromptDetailCardProps {
   hasHtmlCode: boolean;
   hasXdsTailwindCode: boolean;
   onViewCode: (target: 'xds' | 'baseline' | 'html' | 'xds-tailwind') => void;
-  /** Relative preview URLs keyed by target (e.g. { xds: "previews/sd-1/xds.html" }) */
+  /** Relative preview URLs keyed by target (e.g. { astryx: "previews/sd-1/astryx.html" }) */
   previewUrls?: Record<string, string>;
 }
 
 export function PromptDetailCard({
   promptId,
   promptText,
-  xdsScore,
+  astryxScore,
   baselineScore,
   htmlScore,
   xdsTailwindScore,
@@ -121,7 +121,7 @@ export function PromptDetailCard({
   previewUrls,
 }: PromptDetailCardProps) {
   const hasAnyPreview =
-    previewUrls?.xds ||
+    previewUrls?.astryx ||
     previewUrls?.baseline ||
     previewUrls?.html ||
     previewUrls?.['xds-tailwind'];
@@ -130,7 +130,7 @@ export function PromptDetailCard({
 
   // Count how many score blocks we have
   const scoreCount = [
-    xdsScore,
+    astryxScore,
     baselineScore,
     htmlScore,
     xdsTailwindScore,
@@ -145,29 +145,29 @@ export function PromptDetailCard({
           : 'report-promptDetail-scoresRowSingle';
 
   return (
-    <XDSCard>
+    <Card>
       <div className="report-promptDetail-card">
-        <XDSVStack gap={3}>
+        <VStack gap={3}>
           {/* Header: prompt ID, prompt text, and buttons */}
           <div className="report-promptDetail-header">
-            <XDSHeading level={4}>{promptId}</XDSHeading>
+            <Heading level={4}>{promptId}</Heading>
             {promptText && (
-              <XDSText type="body" className="report-promptDetail-promptText">
+              <Text type="body" className="report-promptDetail-promptText">
                 {promptText}
-              </XDSText>
+              </Text>
             )}
             {(hasAnyPreview || hasAnyCode) && (
               <div className="report-promptDetail-buttonRow">
-                {previewUrls?.xds && (
-                  <XDSButton
+                {previewUrls?.astryx && (
+                  <Button
                     variant="secondary"
                     size="sm"
-                    onClick={() => window.open(previewUrls.xds, '_blank')}
-                    label="XDS Preview"
+                    onClick={() => window.open(previewUrls.astryx, '_blank')}
+                    label="Astryx Preview"
                   />
                 )}
                 {previewUrls?.baseline && (
-                  <XDSButton
+                  <Button
                     variant="secondary"
                     size="sm"
                     onClick={() => window.open(previewUrls.baseline, '_blank')}
@@ -175,7 +175,7 @@ export function PromptDetailCard({
                   />
                 )}
                 {previewUrls?.html && (
-                  <XDSButton
+                  <Button
                     variant="secondary"
                     size="sm"
                     onClick={() => window.open(previewUrls.html, '_blank')}
@@ -183,7 +183,7 @@ export function PromptDetailCard({
                   />
                 )}
                 {previewUrls?.['xds-tailwind'] && (
-                  <XDSButton
+                  <Button
                     variant="secondary"
                     size="sm"
                     onClick={() =>
@@ -193,15 +193,15 @@ export function PromptDetailCard({
                   />
                 )}
                 {hasXdsCode && (
-                  <XDSButton
+                  <Button
                     variant="ghost"
                     size="sm"
-                    onClick={() => onViewCode('xds')}
-                    label="XDS Code"
+                    onClick={() => onViewCode('astryx')}
+                    label="Astryx Code"
                   />
                 )}
                 {hasBaselineCode && (
-                  <XDSButton
+                  <Button
                     variant="ghost"
                     size="sm"
                     onClick={() => onViewCode('baseline')}
@@ -209,7 +209,7 @@ export function PromptDetailCard({
                   />
                 )}
                 {hasHtmlCode && (
-                  <XDSButton
+                  <Button
                     variant="ghost"
                     size="sm"
                     onClick={() => onViewCode('html')}
@@ -217,7 +217,7 @@ export function PromptDetailCard({
                   />
                 )}
                 {hasXdsTailwindCode && (
-                  <XDSButton
+                  <Button
                     variant="ghost"
                     size="sm"
                     onClick={() => onViewCode('xds-tailwind')}
@@ -229,9 +229,9 @@ export function PromptDetailCard({
           </div>
 
           {/* Score summaries in constrained grid */}
-          {(xdsScore || baselineScore || htmlScore || xdsTailwindScore) && (
+          {(astryxScore || baselineScore || htmlScore || xdsTailwindScore) && (
             <div className={scoresClassName}>
-              {xdsScore && <ScoreSummary label="XDS" score={xdsScore} />}
+              {astryxScore && <ScoreSummary label="Astryx" score={astryxScore} />}
               {baselineScore && (
                 <ScoreSummary label="Baseline" score={baselineScore} />
               )}
@@ -243,24 +243,24 @@ export function PromptDetailCard({
           )}
 
           {/* Findings */}
-          {xdsScore && (
+          {astryxScore && (
             <>
-              <XDSDivider />
+              <Divider />
               <div className="report-promptDetail-section">
                 <div className="report-promptDetail-sectionLabel">
-                  <XDSText type="label">XDS Findings</XDSText>
+                  <Text type="label">Astryx Findings</Text>
                 </div>
-                <Findings score={xdsScore} />
+                <Findings score={astryxScore} />
               </div>
             </>
           )}
 
           {baselineScore && (
             <>
-              <XDSDivider />
+              <Divider />
               <div className="report-promptDetail-section">
                 <div className="report-promptDetail-sectionLabel">
-                  <XDSText type="label">Baseline Findings</XDSText>
+                  <Text type="label">Baseline Findings</Text>
                 </div>
                 <Findings score={baselineScore} />
               </div>
@@ -269,10 +269,10 @@ export function PromptDetailCard({
 
           {htmlScore && (
             <>
-              <XDSDivider />
+              <Divider />
               <div className="report-promptDetail-section">
                 <div className="report-promptDetail-sectionLabel">
-                  <XDSText type="label">HTML Findings</XDSText>
+                  <Text type="label">HTML Findings</Text>
                 </div>
                 <Findings score={htmlScore} />
               </div>
@@ -281,17 +281,17 @@ export function PromptDetailCard({
 
           {xdsTailwindScore && (
             <>
-              <XDSDivider />
+              <Divider />
               <div className="report-promptDetail-section">
                 <div className="report-promptDetail-sectionLabel">
-                  <XDSText type="label">XDS+TW Findings</XDSText>
+                  <Text type="label">XDS+TW Findings</Text>
                 </div>
                 <Findings score={xdsTailwindScore} />
               </div>
             </>
           )}
-        </XDSVStack>
+        </VStack>
       </div>
-    </XDSCard>
+    </Card>
   );
 }

--- a/internal/vibe-tests/app/src/report/Report.tsx
+++ b/internal/vibe-tests/app/src/report/Report.tsx
@@ -1,15 +1,15 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 import {useState} from 'react';
-import {XDSTheme} from '@astryxdesign/core/theme';
-import {XDSVStack} from '@astryxdesign/core/Stack';
-import {XDSHStack} from '@astryxdesign/core/Stack';
-import {XDSText} from '@astryxdesign/core/Text';
-import {XDSHeading} from '@astryxdesign/core/Text';
-import {XDSTabList} from '@astryxdesign/core/TabList';
-import {XDSTab} from '@astryxdesign/core/TabList';
-import {XDSCard} from '@astryxdesign/core/Card';
-import {XDSButton} from '@astryxdesign/core/Button';
+import {Theme} from '@astryxdesign/core/theme';
+import {VStack} from '@astryxdesign/core/Stack';
+import {HStack} from '@astryxdesign/core/Stack';
+import {Text} from '@astryxdesign/core/Text';
+import {Heading} from '@astryxdesign/core/Text';
+import {TabList} from '@astryxdesign/core/TabList';
+import {Tab} from '@astryxdesign/core/TabList';
+import {Card} from '@astryxdesign/core/Card';
+import {Button} from '@astryxdesign/core/Button';
 import {neutralTheme} from '@astryxdesign/theme-neutral';
 import type {ReportData} from './types';
 import {ALL_DIMENSIONS, DIMENSION_LABELS} from './utils';
@@ -24,10 +24,10 @@ import './report.css';
 function MetricValue({label, value}: {label: string; value: string}) {
   return (
     <div className="report-metricItem">
-      <XDSVStack gap={1}>
-        <XDSText type="label">{label}</XDSText>
-        <XDSHeading level={3}>{value}</XDSHeading>
-      </XDSVStack>
+      <VStack gap={1}>
+        <Text type="label">{label}</Text>
+        <Heading level={3}>{value}</Heading>
+      </VStack>
     </div>
   );
 }
@@ -59,10 +59,10 @@ function EfficiencyMetricsCard({
     metrics.length;
 
   return (
-    <XDSCard>
+    <Card>
       <div className="report-metricsCard">
-        <XDSVStack gap={2}>
-          <XDSHeading level={4}>Efficiency Metrics</XDSHeading>
+        <VStack gap={2}>
+          <Heading level={4}>Efficiency Metrics</Heading>
           <div className="report-metricsGrid">
             <MetricValue
               label="Decisions / Element"
@@ -81,9 +81,9 @@ function EfficiencyMetricsCard({
               value={`${(avgBoilerplate * 100).toFixed(1)}%`}
             />
           </div>
-        </XDSVStack>
+        </VStack>
       </div>
-    </XDSCard>
+    </Card>
   );
 }
 
@@ -108,10 +108,10 @@ function MaintainabilityMetricsCard({
   const darkModeCount = metrics.filter(m => m?.darkModeSupport).length;
 
   return (
-    <XDSCard>
+    <Card>
       <div className="report-metricsCard">
-        <XDSVStack gap={2}>
-          <XDSHeading level={4}>Maintainability Metrics</XDSHeading>
+        <VStack gap={2}>
+          <Heading level={4}>Maintainability Metrics</Heading>
           <div className="report-metricsGrid">
             <MetricValue
               label="Semantic Ratio"
@@ -123,9 +123,9 @@ function MaintainabilityMetricsCard({
               value={`${darkModeCount}/${entries.length}`}
             />
           </div>
-        </XDSVStack>
+        </VStack>
       </div>
-    </XDSCard>
+    </Card>
   );
 }
 
@@ -135,10 +135,10 @@ function CostMetricsCard({cost}: {cost: ReportData['universal']['cost']}) {
   }
 
   return (
-    <XDSCard>
+    <Card>
       <div className="report-metricsCard">
-        <XDSVStack gap={2}>
-          <XDSHeading level={4}>Cost</XDSHeading>
+        <VStack gap={2}>
+          <Heading level={4}>Cost</Heading>
           <div className="report-metricsGrid">
             {cost.avgDurationMs > 0 && (
               <MetricValue
@@ -160,9 +160,9 @@ function CostMetricsCard({cost}: {cost: ReportData['universal']['cost']}) {
               value={`~${cost.estimatedOutputTokens.toLocaleString()}`}
             />
           </div>
-        </XDSVStack>
+        </VStack>
       </div>
-    </XDSCard>
+    </Card>
   );
 }
 
@@ -181,68 +181,68 @@ export function Report() {
 
   if (!data) {
     return (
-      <XDSTheme theme={neutralTheme} mode={themeMode}>
+      <Theme theme={neutralTheme} mode={themeMode}>
         <div className="report-root">
           <div className="report-container">
             <div className="report-emptyState">
-              <XDSVStack gap={4}>
-                <XDSHeading level={2}>No Report Data</XDSHeading>
-                <XDSText type="body">
+              <VStack gap={4}>
+                <Heading level={2}>No Report Data</Heading>
+                <Text type="body">
                   No report data found. Run the vibe test harness to generate a
                   report.
-                </XDSText>
-              </XDSVStack>
+                </Text>
+              </VStack>
             </div>
           </div>
         </div>
-      </XDSTheme>
+      </Theme>
     );
   }
 
   const {universal, comparison, screenshots} = data;
 
   return (
-    <XDSTheme theme={neutralTheme} mode={themeMode}>
+    <Theme theme={neutralTheme} mode={themeMode}>
       <div className="report-root">
         <div className="report-container">
-          <XDSVStack gap={5}>
+          <VStack gap={5}>
             {/* Header */}
             <div className="report-header">
-              <XDSHStack gap={4} hAlign="between" vAlign="center">
-                <XDSVStack gap={1}>
-                  <XDSHeading level={1}>Vibe Test Report</XDSHeading>
+              <HStack gap={4} hAlign="between" vAlign="center">
+                <VStack gap={1}>
+                  <Heading level={1}>Vibe Test Report</Heading>
                   {data.target && (
-                    <XDSText type="supporting">Target: {data.target}</XDSText>
+                    <Text type="supporting">Target: {data.target}</Text>
                   )}
                   {data.iterationId && (
-                    <XDSText type="supporting">
+                    <Text type="supporting">
                       Iteration: {data.iterationId}
-                    </XDSText>
+                    </Text>
                   )}
-                </XDSVStack>
-                <XDSButton
+                </VStack>
+                <Button
                   variant="secondary"
                   onClick={() =>
                     setThemeMode(m => (m === 'light' ? 'dark' : 'light'))
                   }
                   label={themeMode === 'light' ? '🌙 Dark' : '☀️ Light'}
                 />
-              </XDSHStack>
+              </HStack>
             </div>
 
             {/* Tabs */}
-            <XDSTabList value={activeTab} onChange={setActiveTab} hasDivider>
-              <XDSTab value="overview" label="Overview" />
-              <XDSTab value="byPrompt" label="By Prompt" />
+            <TabList value={activeTab} onChange={setActiveTab} hasDivider>
+              <Tab value="overview" label="Overview" />
+              <Tab value="byPrompt" label="By Prompt" />
               {hasScreenshots && (
-                <XDSTab value="screenshots" label="Screenshots" />
+                <Tab value="screenshots" label="Screenshots" />
               )}
-            </XDSTabList>
+            </TabList>
 
             {/* Tab Content */}
             <div className="report-tabContent">
               {activeTab === 'overview' && (
-                <XDSVStack gap={4}>
+                <VStack gap={4}>
                   {/* Overall score */}
                   <ScoreCard
                     label="Overall Score"
@@ -268,8 +268,8 @@ export function Report() {
                   )}
 
                   {/* Dimension scores grid */}
-                  <XDSVStack gap={3}>
-                    <XDSHeading level={3}>Dimensions</XDSHeading>
+                  <VStack gap={3}>
+                    <Heading level={3}>Dimensions</Heading>
                     <div className="report-scoreGrid">
                       {ALL_DIMENSIONS.filter(
                         dim => universal.averages[dim] != null,
@@ -283,7 +283,7 @@ export function Report() {
                         />
                       ))}
                     </div>
-                  </XDSVStack>
+                  </VStack>
 
                   {/* Sub-metrics */}
                   <EfficiencyMetricsCard byPrompt={universal.byPrompt} />
@@ -292,10 +292,10 @@ export function Report() {
 
                   {/* Comparison view */}
                   {comparison && (
-                    <XDSVStack gap={3}>
-                      <XDSHeading level={3}>
+                    <VStack gap={3}>
+                      <Heading level={3}>
                         {[
-                          'XDS',
+                          'Astryx',
                           'Baseline',
                           comparison.html ? 'HTML' : null,
                           comparison.xdsTailwind ? 'XDS+TW' : null,
@@ -303,26 +303,26 @@ export function Report() {
                           .filter(Boolean)
                           .join(' vs ')}{' '}
                         Comparison
-                      </XDSHeading>
+                      </Heading>
                       <CompareView comparison={comparison} />
-                    </XDSVStack>
+                    </VStack>
                   )}
-                </XDSVStack>
+                </VStack>
               )}
 
               {activeTab === 'byPrompt' && (
-                <XDSVStack gap={4}>
+                <VStack gap={4}>
                   <DimensionTable byPrompt={universal.byPrompt} />
 
                   {/* Per-prompt detail cards */}
-                  <XDSVStack gap={3}>
-                    <XDSHeading level={3}>Prompt Details</XDSHeading>
+                  <VStack gap={3}>
+                    <Heading level={3}>Prompt Details</Heading>
                     {Object.keys(universal.byPrompt).map(promptId => (
                       <PromptDetailCard
                         key={promptId}
                         promptId={promptId}
                         promptText={data.prompts?.[promptId]}
-                        xdsScore={universal.byPrompt[promptId]}
+                        astryxScore={universal.byPrompt[promptId]}
                         baselineScore={comparison?.baseline.byPrompt[promptId]}
                         htmlScore={comparison?.html?.byPrompt[promptId]}
                         xdsTailwindScore={
@@ -338,15 +338,15 @@ export function Report() {
                         previewUrls={data.previews?.[promptId]}
                       />
                     ))}
-                  </XDSVStack>
-                </XDSVStack>
+                  </VStack>
+                </VStack>
               )}
 
               {/* Code modal */}
               {codeModal &&
                 (() => {
                   const code =
-                    codeModal.target === 'xds'
+                    codeModal.target === 'astryx'
                       ? data.sourceCode?.[codeModal.promptId]
                       : codeModal.target === 'baseline'
                         ? data.baselineSourceCode?.[codeModal.promptId]
@@ -368,9 +368,9 @@ export function Report() {
                 <ScreenshotGallery screenshots={screenshots} />
               )}
             </div>
-          </XDSVStack>
+          </VStack>
         </div>
       </div>
-    </XDSTheme>
+    </Theme>
   );
 }

--- a/internal/vibe-tests/app/src/report/ScoreCard.tsx
+++ b/internal/vibe-tests/app/src/report/ScoreCard.tsx
@@ -1,11 +1,11 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-import {XDSCard} from '@astryxdesign/core/Card';
-import {XDSVStack} from '@astryxdesign/core/Stack';
-import {XDSHStack} from '@astryxdesign/core/Stack';
-import {XDSText} from '@astryxdesign/core/Text';
-import {XDSHeading} from '@astryxdesign/core/Text';
-import {XDSProgressBar} from '@astryxdesign/core/ProgressBar';
+import {Card} from '@astryxdesign/core/Card';
+import {VStack} from '@astryxdesign/core/Stack';
+import {HStack} from '@astryxdesign/core/Stack';
+import {Text} from '@astryxdesign/core/Text';
+import {Heading} from '@astryxdesign/core/Text';
+import {ProgressBar} from '@astryxdesign/core/ProgressBar';
 import {formatScore, scoreToProgressVariant} from './utils';
 import './report.css';
 
@@ -35,21 +35,21 @@ export function ScoreCard({
   const delta = compareScore != null ? score - compareScore : undefined;
 
   return (
-    <XDSCard>
+    <Card>
       <div className="report-scoreCard-card">
-        <XDSVStack gap={2}>
-          <XDSText type="label">{label}</XDSText>
-          <XDSHStack gap={2} hAlign="center">
-            <XDSHeading level={2}>{formatScore(score)}</XDSHeading>
+        <VStack gap={2}>
+          <Text type="label">{label}</Text>
+          <HStack gap={2} hAlign="center">
+            <Heading level={2}>{formatScore(score)}</Heading>
             {delta != null && (
-              <XDSText type="supporting" className={deltaClassName(delta)}>
+              <Text type="supporting" className={deltaClassName(delta)}>
                 {delta > 0 ? '+' : ''}
                 {formatScore(delta)}
                 {compareLabel ? ` vs ${compareLabel}` : ''}
-              </XDSText>
+              </Text>
             )}
-          </XDSHStack>
-          <XDSProgressBar
+          </HStack>
+          <ProgressBar
             label={label}
             isLabelHidden
             value={score}
@@ -57,8 +57,8 @@ export function ScoreCard({
             variant={scoreToProgressVariant(score)}
             size="sm"
           />
-        </XDSVStack>
+        </VStack>
       </div>
-    </XDSCard>
+    </Card>
   );
 }

--- a/internal/vibe-tests/app/src/report/ScreenshotGallery.tsx
+++ b/internal/vibe-tests/app/src/report/ScreenshotGallery.tsx
@@ -1,9 +1,9 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 import {useState} from 'react';
-import {XDSCard} from '@astryxdesign/core/Card';
-import {XDSVStack} from '@astryxdesign/core/Stack';
-import {XDSText} from '@astryxdesign/core/Text';
+import {Card} from '@astryxdesign/core/Card';
+import {VStack} from '@astryxdesign/core/Stack';
+import {Text} from '@astryxdesign/core/Text';
 import './report.css';
 
 interface ScreenshotGalleryProps {
@@ -51,8 +51,8 @@ export function ScreenshotGallery({screenshots}: ScreenshotGalleryProps) {
     <>
       <div className="report-gallery-grid">
         {items.map(item => (
-          <XDSCard key={item.filename}>
-            <XDSVStack gap={0}>
+          <Card key={item.filename}>
+            <VStack gap={0}>
               <img
                 className="report-gallery-image"
                 src={item.src}
@@ -60,16 +60,16 @@ export function ScreenshotGallery({screenshots}: ScreenshotGalleryProps) {
                 onClick={() => setEnlarged(item.src)}
               />
               <div className="report-gallery-cardContent">
-                <XDSVStack gap={1}>
-                  <XDSText type="label">{item.promptId}</XDSText>
+                <VStack gap={1}>
+                  <Text type="label">{item.promptId}</Text>
                   <div className="report-gallery-meta">
-                    <XDSText type="supporting">{item.viewport}</XDSText>
-                    <XDSText type="supporting">{item.theme}</XDSText>
+                    <Text type="supporting">{item.viewport}</Text>
+                    <Text type="supporting">{item.theme}</Text>
                   </div>
-                </XDSVStack>
+                </VStack>
               </div>
-            </XDSVStack>
-          </XDSCard>
+            </VStack>
+          </Card>
         ))}
       </div>
       {enlarged && (

--- a/internal/vibe-tests/app/src/report/report.css
+++ b/internal/vibe-tests/app/src/report/report.css
@@ -4,7 +4,7 @@
  * Report-specific styles.
  *
  * Plain CSS replacement for StyleX styles previously used in report components.
- * Uses XDS CSS custom properties (defined in astryx.css) directly.
+ * Uses Astryx CSS custom properties (defined in astryx.css) directly.
  */
 
 /* === CodeModal === */


### PR DESCRIPTION
Knots: `scrub-vibe-report`. Depends on #3114 (`scrub-vibe-compare`).

Updates the entire report UI layer (7 files, 317+317 lines):
- Data keys/vars: `xds` → `astryx` (scores, costs, categories, winner checks)
- Display labels: `'XDS'` → `'Astryx'` (column headers, button labels, section titles)
- Type unions: `'xds'` → `'astryx'`
- **Fixed already-broken component imports**: all report files used `XDSText`/`XDSCard`/etc. from `@astryxdesign/core` — those aliases were removed in #3001, so these imports were dead. Renamed to bare `Text`/`Card`/etc.
- `report.css` comment

Keeps `XDS+TW` / `xdsTailwind` (separate variant, tracked in `scrub-xds-tailwind`).