### PR TITLE
fix(storybook): set modern esbuild target for dev dependency pre-bundling

### DIFF
--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -44,9 +44,8 @@ const config: StorybookConfig = {
       ...config,
       build: {
         ...config.build,
-        // Storybook's generated story chunks use hook tuple destructuring.
-        // esbuild 0.28 cannot downlevel those chunks for Vite's default
-        // Safari 14 baseline, so match the modern preview CSS targets.
+        // esbuild will not downlevel syntax such as destructuring — target modern
+        // browsers only.
         target: viteBuildTargets,
       },
       optimizeDeps: {
@@ -55,6 +54,12 @@ const config: StorybookConfig = {
         // pre-bundled deps. The StyleX Babel plugin stalls on some XDS core
         // components, so the crawl never completes and deps are never served.
         holdUntilCrawlEnd: false,
+        esbuildOptions: {
+          ...config.optimizeDeps?.esbuildOptions,
+          // esbuild will not downlevel syntax such as destructuring — target modern
+          // browsers only.
+          target: viteBuildTargets,
+        },
       },
       plugins: [
         {


### PR DESCRIPTION
Esbuild does not downlevel syntax like array destructuring and will instead error out if targeting older browsers.

Storybook dev pre-bundles node_modules with esbuild, and would fail due to targeting old browsers.

Updated the browser target for esbuild for this step.