### PR TITLE
test: rename xds-* temp-dir prefixes to astryx-*

### DIFF
--- a/apps/docsite/src/__tests__/blog.test.ts
+++ b/apps/docsite/src/__tests__/blog.test.ts
@@ -192,7 +192,7 @@ describe('discoverPosts (temp fixtures)', () => {
   let dir: string;
 
   beforeEach(() => {
-    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'xds-blog-'));
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'astryx-blog-'));
   });
 
   afterEach(() => {

--- a/packages/cli/src/commands/agent-docs.path-safety.test.mjs
+++ b/packages/cli/src/commands/agent-docs.path-safety.test.mjs
@@ -20,7 +20,7 @@ import {PathSafetyError} from '../utils/path-safety.mjs';
 
 let tmpDir;
 beforeEach(() => {
-  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'xds-agent-docs-paths-'));
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'astryx-agent-docs-paths-'));
 });
 afterEach(() => {
   fs.rmSync(tmpDir, {recursive: true, force: true});

--- a/packages/cli/src/commands/agent-docs.test.mjs
+++ b/packages/cli/src/commands/agent-docs.test.mjs
@@ -20,7 +20,7 @@ import {
 let tmpDir;
 
 beforeEach(() => {
-  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'xds-agent-docs-test-'));
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'astryx-agent-docs-test-'));
 });
 
 afterEach(() => {

--- a/packages/cli/src/commands/build-theme.import-path.test.mjs
+++ b/packages/cli/src/commands/build-theme.import-path.test.mjs
@@ -70,7 +70,7 @@ beforeAll(() => {
 
 let tmpDir;
 beforeEach(() => {
-  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'xds-build-theme-import-path-'));
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'astryx-build-theme-import-path-'));
 });
 afterEach(() => {
   fs.rmSync(tmpDir, {recursive: true, force: true});

--- a/packages/cli/src/commands/build-theme.path-safety.test.mjs
+++ b/packages/cli/src/commands/build-theme.path-safety.test.mjs
@@ -54,7 +54,7 @@ function writeTheme(dir, name) {
 
 let tmpDir;
 beforeEach(() => {
-  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'xds-build-theme-paths-'));
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'astryx-build-theme-paths-'));
 });
 afterEach(() => {
   fs.rmSync(tmpDir, {recursive: true, force: true});

--- a/packages/cli/src/commands/build-theme.prose.test.mjs
+++ b/packages/cli/src/commands/build-theme.prose.test.mjs
@@ -82,7 +82,7 @@ beforeAll(() => {
 
 let tmpDir;
 beforeEach(() => {
-  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'xds-build-theme-prose-'));
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'astryx-build-theme-prose-'));
 });
 afterEach(() => {
   fs.rmSync(tmpDir, {recursive: true, force: true});

--- a/packages/cli/src/commands/component-package.test.mjs
+++ b/packages/cli/src/commands/component-package.test.mjs
@@ -65,7 +65,7 @@ export const docs = {
 }
 
 beforeEach(() => {
-  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'xds-pkg-test-'));
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'astryx-pkg-test-'));
   createFixture();
 });
 

--- a/packages/cli/src/commands/component.test.mjs
+++ b/packages/cli/src/commands/component.test.mjs
@@ -18,7 +18,7 @@ import {
 let tmpDir;
 
 beforeEach(() => {
-  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'xds-component-test-'));
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'astryx-component-test-'));
 });
 
 afterEach(() => {

--- a/packages/cli/src/commands/docs.test.mjs
+++ b/packages/cli/src/commands/docs.test.mjs
@@ -10,7 +10,7 @@ import {registerDocs} from './docs.mjs';
 let tmpDir;
 
 beforeEach(() => {
-  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'xds-docs-test-'));
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'astryx-docs-test-'));
   vi.spyOn(console, 'log').mockImplementation(() => {});
   vi.spyOn(console, 'error').mockImplementation(() => {});
 });

--- a/packages/cli/src/commands/doctor.test.mjs
+++ b/packages/cli/src/commands/doctor.test.mjs
@@ -26,7 +26,7 @@ let logCalls;
 let exitCode;
 
 beforeEach(() => {
-  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'xds-doctor-test-'));
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'astryx-doctor-test-'));
   logCalls = [];
   exitCode = undefined;
   vi.spyOn(console, 'log').mockImplementation((...args) => {

--- a/packages/cli/src/commands/external-showcase.test.mjs
+++ b/packages/cli/src/commands/external-showcase.test.mjs
@@ -78,7 +78,7 @@ export const doc = {
 }
 
 beforeEach(() => {
-  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'xds-showcase-test-'));
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'astryx-showcase-test-'));
   createFixture();
 });
 

--- a/packages/cli/src/commands/interactive-guard.test.mjs
+++ b/packages/cli/src/commands/interactive-guard.test.mjs
@@ -35,7 +35,7 @@ function runCli(args) {
 }
 
 beforeEach(() => {
-  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'xds-interactive-guard-'));
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'astryx-interactive-guard-'));
 });
 
 afterEach(() => {

--- a/packages/cli/src/commands/json-contract.test.mjs
+++ b/packages/cli/src/commands/json-contract.test.mjs
@@ -53,7 +53,7 @@ function parseJson(stdout) {
 let tmpDir;
 
 beforeEach(() => {
-  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'xds-json-contract-'));
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'astryx-json-contract-'));
 });
 
 afterEach(() => {

--- a/packages/cli/src/commands/swizzle-gap-safety.test.mjs
+++ b/packages/cli/src/commands/swizzle-gap-safety.test.mjs
@@ -36,7 +36,7 @@ let markerFile;
 let baseEnv;
 
 beforeAll(() => {
-  shimDir = fs.mkdtempSync(path.join(os.tmpdir(), 'xds-gh-shim-'));
+  shimDir = fs.mkdtempSync(path.join(os.tmpdir(), 'astryx-gh-shim-'));
   markerFile = path.join(shimDir, 'gh-issue-create-was-called.marker');
 
   // Sabotaged `gh` shim. Records ONLY `gh issue create` invocations to the

--- a/packages/cli/src/commands/swizzle.path-safety.test.mjs
+++ b/packages/cli/src/commands/swizzle.path-safety.test.mjs
@@ -58,7 +58,7 @@ function runCli(args, cwd) {
 
 let tmpDir;
 beforeEach(() => {
-  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'xds-swizzle-paths-'));
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'astryx-swizzle-paths-'));
 });
 afterEach(() => {
   fs.rmSync(tmpDir, {recursive: true, force: true});

--- a/packages/cli/src/commands/template.path-safety.test.mjs
+++ b/packages/cli/src/commands/template.path-safety.test.mjs
@@ -17,7 +17,7 @@ let tmpDir;
 let templateApi;
 
 beforeEach(async () => {
-  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'xds-template-paths-'));
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'astryx-template-paths-'));
   templateApi = (await import('../api/template.mjs')).template;
 });
 afterEach(() => {

--- a/packages/cli/src/commands/template.test.mjs
+++ b/packages/cli/src/commands/template.test.mjs
@@ -12,7 +12,7 @@ import * as os from 'node:os';
 let tmpDir;
 
 beforeEach(() => {
-  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'xds-template-test-'));
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'astryx-template-test-'));
 });
 
 afterEach(() => {

--- a/packages/cli/src/commands/upgrade.test.mjs
+++ b/packages/cli/src/commands/upgrade.test.mjs
@@ -14,7 +14,7 @@ let stdoutCalls;
 let exitCode;
 
 beforeEach(() => {
-  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'xds-upgrade-test-'));
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'astryx-upgrade-test-'));
   originalCwd = process.cwd();
   process.chdir(tmpDir);
   logCalls = [];

--- a/packages/cli/src/utils/package-manager.test.mjs
+++ b/packages/cli/src/utils/package-manager.test.mjs
@@ -18,7 +18,7 @@ afterEach(() => {
 });
 
 function makeTmpDir() {
-  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'xds-pm-test-'));
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'astryx-pm-test-'));
   return tmpDir;
 }
 

--- a/packages/cli/src/utils/path-safety.test.mjs
+++ b/packages/cli/src/utils/path-safety.test.mjs
@@ -13,7 +13,7 @@ import {
 
 let tmpDir;
 beforeEach(() => {
-  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'xds-path-safety-'));
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'astryx-path-safety-'));
 });
 afterEach(() => {
   fs.rmSync(tmpDir, {recursive: true, force: true});

--- a/packages/cli/src/utils/paths.test.mjs
+++ b/packages/cli/src/utils/paths.test.mjs
@@ -9,7 +9,7 @@ import {findCoreDir, findProjectRoot, listComponents, discoverExternalPackages} 
 let tmpDir;
 
 function makeTmpDir() {
-  return fs.mkdtempSync(path.join(os.tmpdir(), 'xds-paths-test-'));
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'astryx-paths-test-'));
 }
 
 beforeEach(() => {
@@ -69,12 +69,12 @@ describe('findProjectRoot', () => {
 describe('discoverExternalPackages', () => {
   it('finds packages with an "astryx" field in package.json', () => {
     const nm = path.join(tmpDir, 'node_modules');
-    const extDir = path.join(nm, 'xds-charts');
+    const extDir = path.join(nm, 'astryx-charts');
     fs.mkdirSync(extDir, {recursive: true});
     fs.writeFileSync(
       path.join(extDir, 'package.json'),
       JSON.stringify({
-        name: 'xds-charts',
+        name: 'astryx-charts',
         astryx: {docs: './src', category: 'Data Viz'},
       }),
     );
@@ -82,7 +82,7 @@ describe('discoverExternalPackages', () => {
     const result = discoverExternalPackages(tmpDir);
     expect(result).toEqual([
       {
-        name: 'xds-charts',
+        name: 'astryx-charts',
         category: 'Data Viz',
         docsDir: path.join(extDir, 'src'),
         blocksDir: null,
@@ -92,7 +92,7 @@ describe('discoverExternalPackages', () => {
 
   it('handles scoped packages (@org/pkg)', () => {
     const nm = path.join(tmpDir, 'node_modules');
-    const scopedDir = path.join(nm, '@acme', 'xds-widgets');
+    const scopedDir = path.join(nm, '@acme', 'astryx-widgets');
     fs.mkdirSync(scopedDir, {recursive: true});
     fs.writeFileSync(
       path.join(scopedDir, 'package.json'),
@@ -165,12 +165,12 @@ describe('discoverExternalPackages', () => {
 
   it('walks up directories to find node_modules', () => {
     const nm = path.join(tmpDir, 'node_modules');
-    const extDir = path.join(nm, 'xds-ext');
+    const extDir = path.join(nm, 'astryx-ext');
     fs.mkdirSync(extDir, {recursive: true});
     fs.writeFileSync(
       path.join(extDir, 'package.json'),
       JSON.stringify({
-        name: 'xds-ext',
+        name: 'astryx-ext',
         astryx: {docs: './src'},
       }),
     );
@@ -180,7 +180,7 @@ describe('discoverExternalPackages', () => {
 
     const result = discoverExternalPackages(nested);
     expect(result).toHaveLength(1);
-    expect(result[0].name).toBe('xds-ext');
+    expect(result[0].name).toBe('astryx-ext');
   });
 
   it('handles invalid JSON in package.json gracefully', () => {

--- a/packages/cli/src/utils/update-check.test.mjs
+++ b/packages/cli/src/utils/update-check.test.mjs
@@ -14,7 +14,7 @@ let tmpDir;
 const originalEnv = {};
 
 beforeEach(() => {
-  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'xds-update-check-'));
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'astryx-update-check-'));
   // Save and clear env
   originalEnv.ASTRYX_LATEST_VERSION = process.env.ASTRYX_LATEST_VERSION;
   delete process.env.ASTRYX_LATEST_VERSION;


### PR DESCRIPTION
Knots: `scrub-test-tempdirs`. Cosmetic: 22 test files use `mkdtempSync('xds-<name>-')` as temp-dir prefixes. Zero functional impact — just identifies the tmp dir on disk. Renamed to `'astryx-*'` for consistency.