### PR TITLE
chore: update package.json keywords 'xds' -> 'astryx'

### DIFF
--- a/internal/eslint-plugin-astryx/package.json
+++ b/internal/eslint-plugin-astryx/package.json
@@ -5,7 +5,13 @@
   "main": "index.js",
   "type": "module",
   "description": "ESLint plugin for Astryx design system token enforcement",
-  "keywords": ["eslint", "eslint-plugin", "xds", "design-system", "stylex"],
+  "keywords": [
+    "eslint",
+    "eslint-plugin",
+    "astryx",
+    "design-system",
+    "stylex"
+  ],
   "peerDependencies": {
     "eslint": ">=9.0.0"
   }

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@astryxdesign/build",
   "version": "0.1.0",
-  "description": "Build plugins for XDS source builds — babel, PostCSS, and Vite integrations",
+  "description": "Build plugins for XDS source builds \u2014 babel, PostCSS, and Vite integrations",
   "author": "Meta Open Source",
   "license": "MIT",
   "homepage": "https://github.com/facebook/astryx#readme",
@@ -14,7 +14,7 @@
     "url": "https://github.com/facebook/astryx/issues"
   },
   "keywords": [
-    "xds",
+    "astryx",
     "postcss",
     "stylex",
     "css-layers",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/facebook/astryx/issues"
   },
   "keywords": [
-    "xds",
+    "astryx",
     "cli",
     "design-system",
     "init",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/facebook/astryx/issues"
   },
   "keywords": [
-    "xds",
+    "astryx",
     "design-system",
     "react",
     "components",

--- a/packages/lab/package.json
+++ b/packages/lab/package.json
@@ -2,7 +2,7 @@
   "name": "@astryxdesign/lab",
   "version": "0.1.0",
   "private": true,
-  "description": "Experimental XDS components — not published, available in storybook and sandbox for testing",
+  "description": "Experimental XDS components \u2014 not published, available in storybook and sandbox for testing",
   "author": "Meta Open Source",
   "license": "MIT",
   "homepage": "https://github.com/facebook/astryx#readme",
@@ -15,7 +15,7 @@
     "url": "https://github.com/facebook/astryx/issues"
   },
   "keywords": [
-    "xds",
+    "astryx",
     "lab",
     "experimental",
     "design-system"

--- a/packages/themes/butter/package.json
+++ b/packages/themes/butter/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/facebook/astryx/issues"
   },
   "keywords": [
-    "xds",
+    "astryx",
     "theme",
     "design-system",
     "lucide",

--- a/packages/themes/chocolate/package.json
+++ b/packages/themes/chocolate/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "displayName": "Chocolate Theme",
   "private": false,
-  "description": "Warm chocolate theme for Astryx — rich brown palette with Fraunces headings, Albert Sans body, and Lucide icons",
+  "description": "Warm chocolate theme for Astryx \u2014 rich brown palette with Fraunces headings, Albert Sans body, and Lucide icons",
   "author": "Meta Open Source",
   "license": "MIT",
   "homepage": "https://github.com/facebook/astryx#readme",
@@ -16,7 +16,7 @@
     "url": "https://github.com/facebook/astryx/issues"
   },
   "keywords": [
-    "xds",
+    "astryx",
     "theme",
     "design-system",
     "lucide",

--- a/packages/themes/gothic/package.json
+++ b/packages/themes/gothic/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/facebook/astryx/issues"
   },
   "keywords": [
-    "xds",
+    "astryx",
     "theme",
     "design-system",
     "lucide",

--- a/packages/themes/matcha/package.json
+++ b/packages/themes/matcha/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/facebook/astryx/issues"
   },
   "keywords": [
-    "xds",
+    "astryx",
     "theme",
     "design-system",
     "lucide",

--- a/packages/themes/neutral/package.json
+++ b/packages/themes/neutral/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/facebook/astryx/issues"
   },
   "keywords": [
-    "xds",
+    "astryx",
     "theme",
     "design-system",
     "lucide",

--- a/packages/themes/stone/package.json
+++ b/packages/themes/stone/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/facebook/astryx/issues"
   },
   "keywords": [
-    "xds",
+    "astryx",
     "theme",
     "design-system",
     "lucide",

--- a/packages/themes/y2k/package.json
+++ b/packages/themes/y2k/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/facebook/astryx/issues"
   },
   "keywords": [
-    "xds",
+    "astryx",
     "theme",
     "design-system",
     "lucide",

--- a/packages/vega/package.json
+++ b/packages/vega/package.json
@@ -2,7 +2,7 @@
   "name": "@astryxdesign/vega",
   "version": "0.0.14",
   "private": true,
-  "description": "XDS Vega wrapper — chart and data visualization components",
+  "description": "XDS Vega wrapper \u2014 chart and data visualization components",
   "author": "Meta Open Source",
   "license": "MIT",
   "homepage": "https://github.com/facebook/astryx#readme",
@@ -15,7 +15,7 @@
     "url": "https://github.com/facebook/astryx/issues"
   },
   "keywords": [
-    "xds",
+    "astryx",
     "vega",
     "charts",
     "data-visualization",


### PR DESCRIPTION
Knots: `scrub-pkg-keywords`. 13 package.json files had `"xds"` in their npm keywords array. Replaced with `"astryx"`. Cosmetic npm metadata — no functional or API change.