### PR TITLE
fix(core): increase trailing padding on ChatLayoutScrollButton label

### DIFF
--- a/.changeset/chatlayoutscrollbutton-label-padding.md
+++ b/.changeset/chatlayoutscrollbutton-label-padding.md
@@ -1,0 +1,13 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Increase trailing padding on `ChatLayoutScrollButton` when a label is shown
+@cixzhang
+
+With a label (e.g. "New messages"), the chevron icon sits on the leading edge
+and the text on the trailing edge. The symmetric inline padding left the label
+text cramped against the pill's rounded corner. The trailing inline padding is
+now widened when a label is present, giving the text comfortable breathing room
+from the rounded edge. The icon-only (collapsed) state is unchanged and stays
+balanced.

--- a/packages/core/src/Chat/ChatLayoutScrollButton.tsx
+++ b/packages/core/src/Chat/ChatLayoutScrollButton.tsx
@@ -90,6 +90,12 @@ const styles = stylex.create({
     whiteSpace: 'nowrap',
     paddingInline: spacingVars['--spacing-2'],
   },
+  // When a label is shown, the icon sits on the leading edge and the text on
+  // the trailing edge. Symmetric padding leaves the text cramped against the
+  // pill's rounded edge, so give the trailing side extra breathing room.
+  buttonWithLabel: {
+    paddingInlineEnd: spacingVars['--spacing-3'],
+  },
 });
 
 // =============================================================================
@@ -130,7 +136,7 @@ export function ChatLayoutScrollButton({
           variant="ghost"
           size="md"
           onClick={onClick}
-          xstyle={styles.button}>
+          xstyle={[styles.button, label ? styles.buttonWithLabel : null]}>
           {label ?? undefined}
         </Button>
       </div>


### PR DESCRIPTION
## What

Fixes #3086.

When `ChatLayoutScrollButton` shows a text label (e.g. "New messages"), the trailing inline padding was too tight — the last character of the label sat well into the curve of the rounded pill, looking cramped compared with other labeled controls.

## Why

The button applied symmetric inline padding (`--spacing-2` on both sides). With a label, the chevron icon sits on the leading edge and the text on the trailing edge, so the text needs more clearance from the pill's rounded corner than the icon does.

## How

- Added a `buttonWithLabel` style that widens the trailing inline padding (`paddingInlineEnd: --spacing-3`) and applied it only when a `label` is present.
- The icon-only (collapsed) state is unchanged and keeps its balanced symmetric padding.

## Testing

- `pnpm -F @astryxdesign/core typecheck`, `typecheck:docs`, and storybook typecheck pass.
- `pnpm -F @astryxdesign/core build` compiles the new StyleX rule cleanly.
- All Chat component tests pass (119/119).
- ESLint clean; sync-exports, token-docs, and changeset checks pass.
- Added a patch changeset for `@astryxdesign/core`.
