### PR TITLE
fix(ci): skip preview/comment jobs on fork PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,8 +277,14 @@ jobs:
   # Uses a per-PR concurrency group so multiple PRs deploy in parallel.
   # Instead of peaceiris/actions-gh-pages (which can conflict with main's
   # force-push), we do a manual git push with retry-on-conflict.
+  # Fork PRs run with a read-only GITHUB_TOKEN, so the `git push origin gh-pages`
+  # below would 403. Skip on forks (neutral, not failing). A maintainer can deploy
+  # a trusted fork PR's preview manually via the Re-deploy Preview workflow.
   deploy-preview:
-    if: github.event_name == 'pull_request' && needs.check-scope.outputs.docsite_only != 'true'
+    if: >-
+      github.event_name == 'pull_request' &&
+      needs.check-scope.outputs.docsite_only != 'true' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     needs: [build, check-scope]
     runs-on: ubuntu-latest
     permissions:
@@ -344,8 +350,14 @@ jobs:
 
   # Post PR comment with preview links + analysis as soon as build finishes
   # Does NOT wait for test or a11y — those update the comment later
+  # Posting a comment needs `pull-requests: write`, which fork PRs don't get
+  # (their GITHUB_TOKEN is read-only). Skip on forks so the check stays neutral
+  # instead of failing. The analysis artifact is still uploaded by `build`.
   pr-comment:
-    if: github.event_name == 'pull_request' && needs.check-scope.outputs.docsite_only != 'true'
+    if: >-
+      github.event_name == 'pull_request' &&
+      needs.check-scope.outputs.docsite_only != 'true' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     needs: [build, check-scope]
     runs-on: ubuntu-latest
     permissions:
@@ -467,10 +479,15 @@ jobs:
           path: a11y-report.json
           retention-days: 1
 
-  # Update PR comment with a11y results once they're ready
+  # Update PR comment with a11y results once they're ready.
+  # Skipped on fork PRs for the same read-only-token reason as pr-comment.
   pr-comment-update:
     needs: [build, check-components, pr-a11y]
-    if: always() && github.event_name == 'pull_request' && needs.build.result == 'success' && needs.check-components.outputs.has_components == 'true'
+    if: >-
+      always() && github.event_name == 'pull_request' &&
+      needs.build.result == 'success' &&
+      needs.check-components.outputs.has_components == 'true' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -26,6 +26,12 @@ concurrency:
 
 jobs:
   deploy-preview:
+    # Fork PRs don't receive repository secrets, so VERCEL_TOKEN/ORG/PROJECT are
+    # empty and `vercel pull` fails. Their GITHUB_TOKEN is also read-only, so the
+    # PR comment can't post either. Skip on forks (neutral, not failing); the
+    # Vercel GitHub App still posts its own "authorize this preview" comment, and
+    # a maintainer can authorize the deploy from the Vercel dashboard.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Problem

Several CI checks fail on **every PR opened from a fork** (e.g. #3117 from `maladr0it/astryx`):

- **`CI / deploy-preview`** — pushes the built Storybook/Sandbox to `gh-pages`, which needs `contents: write`.
- **`CI / pr-comment`** (and `pr-comment-update`) — post/update the analysis comment, which needs `pull-requests: write`.
- **`Vercel Preview / deploy-preview`** — runs `vercel pull`, which needs the `VERCEL_TOKEN` / `VERCEL_ORG_ID` / `VERCEL_PROJECT_ID` secrets.

On `pull_request` events from a fork, GitHub intentionally hands the workflow a **read-only `GITHUB_TOKEN`** and **withholds repository secrets** — regardless of the `permissions:` blocks. So these jobs can never succeed from a fork and show up as red ❌ on the PR, even though the actual merge gates (`build`, `lint`, `test`, `docsite-test`) all pass.

## Fix

Guard each of those jobs with a head-repo-equals-base-repo check:

```yaml
if: github.event.pull_request.head.repo.full_name == github.repository
```

- Same-repo PRs and the merge queue: unchanged — jobs still run.
- Fork PRs: jobs are **skipped** (neutral, not failing), so the fork PR no longer shows spurious failures.

Maintainers who want a preview for a trusted fork PR can still trigger the existing **Re-deploy Preview** `workflow_dispatch`, and the Vercel GitHub App continues to post its own "authorize this preview" comment for forks.

## Notes

- The separate **`Vercel`** status (the Vercel GitHub App's "Authorization required to deploy") is controlled by the Vercel project's *Git* settings, not by these workflow files, so it's out of scope here.
