### PR TITLE
fix(core): make HoverCard SSR-hydration-safe

### DIFF
--- a/.changeset/hovercard-ssr-hydration.md
+++ b/.changeset/hovercard-ssr-hydration.md
@@ -1,0 +1,14 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Make `HoverCard` SSR-hydration-safe. When rendered inside a Server-Side
+Rendered framework (e.g. Next.js App Router), `HoverCard` emitted its portaled
+popover layer on the first client render even though the server could not
+render a portal, producing markup the server never sent and triggering a React
+hydration mismatch. The portal is now deferred until after hydration so the
+server output and the first client render match. `useLayer` records open intent
+even when the popover element has not mounted yet and replays the open once it
+attaches, so `isDefaultOpen` still opens the card after hydration.
+
+@ShanHuangNet

--- a/packages/core/src/HoverCard/HoverCard.test.tsx
+++ b/packages/core/src/HoverCard/HoverCard.test.tsx
@@ -2,7 +2,7 @@
 
 /**
  * @file HoverCard.test.tsx
- * @input Uses vitest, @testing-library/react, HoverCard component
+ * @input Uses vitest, @testing-library/react, React SSR/hydration APIs, HoverCard component
  * @output Unit tests for HoverCard component behavior
  * @position Testing; validates HoverCard.tsx implementation
  *
@@ -11,6 +11,9 @@
 
 import {describe, it, expect, vi, beforeAll, afterAll} from 'vitest';
 import {render, screen, fireEvent, waitFor} from '@testing-library/react';
+import {act} from 'react';
+import {hydrateRoot} from 'react-dom/client';
+import {renderToString} from 'react-dom/server';
 import {HoverCard} from './HoverCard';
 
 // Store original matches to restore later
@@ -172,6 +175,112 @@ describe('HoverCard', () => {
     const wrapper = screen.getByText('Just text, no element');
     expect(wrapper.tagName).toBe('SPAN');
     expect(wrapper).toHaveAttribute('aria-describedby');
+  });
+
+  describe('SSR / hydration', () => {
+    it('does not emit the portaled popover in server-rendered markup', () => {
+      const html = renderToString(
+        <HoverCard
+          content={<div>Hover content</div>}
+          placement="above"
+          alignment="center">
+          <a href="https://example.com">Example</a>
+        </HoverCard>,
+      );
+
+      // The trigger renders on the server...
+      expect(html).toContain('Example');
+      // ...but the portaled popover layer must not, since the server cannot
+      // create a portal and emitting it would mismatch the first client render.
+      expect(html).not.toContain('Hover content');
+      expect(html).not.toContain('popover=');
+    });
+
+    it('hydrates without a mismatch and mounts the popover after hydration', async () => {
+      const ui = (
+        <HoverCard
+          content={<div>Hover content</div>}
+          placement="above"
+          alignment="center">
+          <a href="https://example.com">Example</a>
+        </HoverCard>
+      );
+
+      const html = renderToString(ui);
+      const container = document.createElement('div');
+      container.innerHTML = html;
+      document.body.appendChild(container);
+
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      let root: ReturnType<typeof hydrateRoot> | null = null;
+
+      try {
+        await act(async () => {
+          root = hydrateRoot(container, ui);
+        });
+
+        // After hydration commits, the deferred portal attaches the layer.
+        await waitFor(() => {
+          expect(
+            screen.getByText('Hover content').closest('[popover]'),
+          ).not.toBeNull();
+        });
+
+        // No hydration mismatch should have been reported.
+        const hydrationErrors = errorSpy.mock.calls.filter(call =>
+          call.some(arg =>
+            /hydrat|did not match|server (?:rendered|html)/i.test(String(arg)),
+          ),
+        );
+        expect(hydrationErrors).toEqual([]);
+      } finally {
+        errorSpy.mockRestore();
+        await act(async () => {
+          root?.unmount();
+        });
+        container.remove();
+      }
+    });
+
+    it('opens the popover after hydration when isDefaultOpen is true', async () => {
+      vi.mocked(HTMLElement.prototype.showPopover).mockClear();
+
+      const ui = (
+        <HoverCard
+          content={<span>Hydrated default open card</span>}
+          isDefaultOpen>
+          <button type="button">Trigger</button>
+        </HoverCard>
+      );
+
+      const html = renderToString(ui);
+      const container = document.createElement('div');
+      container.innerHTML = html;
+      document.body.appendChild(container);
+
+      // The default-open layer is still deferred on the server render.
+      expect(html).not.toContain('Hydrated default open card');
+      expect(html).not.toContain('popover=');
+
+      let root: ReturnType<typeof hydrateRoot> | null = null;
+
+      try {
+        await act(async () => {
+          root = hydrateRoot(container, ui);
+        });
+
+        // useLayer should replay the pending open onto the freshly-attached
+        // popover element once it mounts after hydration.
+        await waitFor(() => {
+          expect(HTMLElement.prototype.showPopover).toHaveBeenCalled();
+        });
+      } finally {
+        await act(async () => {
+          root?.unmount();
+        });
+        container.remove();
+      }
+    });
   });
 
   describe('isDefaultOpen', () => {

--- a/packages/core/src/HoverCard/HoverCard.tsx
+++ b/packages/core/src/HoverCard/HoverCard.tsx
@@ -4,7 +4,7 @@
 
 /**
  * @file HoverCard.tsx
- * @input Uses React, ReactDOM createPortal, useHoverCard hook
+ * @input Uses React, useSyncExternalStore, ReactDOM createPortal, useHoverCard hook
  * @output Exports HoverCard component for hover/focus triggered layers
  * @position Layer component; uses inline-safe trigger wrapper and portals floating layer
  *
@@ -18,6 +18,7 @@
 import React, {
   useCallback,
   useRef,
+  useSyncExternalStore,
   type ReactElement,
   type ReactNode,
 } from 'react';
@@ -45,6 +46,33 @@ const styles = stylex.create({
     textUnderlineOffset: spacingVars['--spacing-0-5'],
   },
 });
+
+// useSyncExternalStore primitives for hydration detection. The store never
+// changes, so the subscribe callback is a no-op. The server snapshot is
+// `false` and the client snapshot is `true`, which makes React render the
+// `false` value during SSR and the initial hydration pass, then switch to
+// `true` only after hydration commits.
+const subscribeToHydration = () => () => {};
+const getHydratedSnapshot = () => true;
+const getServerSnapshot = () => false;
+
+/**
+ * Returns `false` during SSR and the first (hydrating) client render, then
+ * `true` on the subsequent browser-only render once hydration has committed.
+ *
+ * The portaled popover layer must not be emitted until after hydration: the
+ * server cannot render a portal, so emitting it on the first client render
+ * produces markup the server never sent and React reports a hydration
+ * mismatch. Gating the portal on this flag keeps the SSR output and the first
+ * client render identical.
+ */
+function useHasHydrated(): boolean {
+  return useSyncExternalStore(
+    subscribeToHydration,
+    getHydratedSnapshot,
+    getServerSnapshot,
+  );
+}
 
 export interface HoverCardProps extends Pick<
   BaseProps,
@@ -182,6 +210,7 @@ export function HoverCard({
 }: HoverCardProps): ReactElement {
   const wrapperRef = useRef<HTMLSpanElement>(null);
   const textOnly = isTextOnly(children);
+  const hasHydrated = useHasHydrated();
 
   // Determine if hover indication should be shown
   const showHoverIndication =
@@ -245,8 +274,13 @@ export function HoverCard({
     };
   }, [textOnly, hoverCard.ref, hoverCard.describedBy]);
 
+  // Defer the portaled popover until after hydration. The portal can only be
+  // created in the browser, so rendering it on the first client pass would add
+  // DOM the server never produced and trip React's hydration check. After
+  // hydration the popover mounts and useLayer replays any pending open state
+  // (e.g. isDefaultOpen) onto the freshly-attached element.
   const renderedHoverCard =
-    typeof document !== 'undefined'
+    hasHydrated && typeof document !== 'undefined'
       ? createPortal(
           hoverCard.renderHoverCard(content, {xstyle, className, style}),
           document.body,

--- a/packages/core/src/Layer/useLayer.doc.mjs
+++ b/packages/core/src/Layer/useLayer.doc.mjs
@@ -57,7 +57,8 @@ export const docs = {
     {
       name: 'show',
       type: '() => void',
-      description: 'Imperatively show the layer.',
+      description:
+        'Imperatively show the layer. Open intent is recorded even if the popover element has not mounted yet, and the open is replayed when it attaches.',
     },
     {
       name: 'hide',
@@ -83,7 +84,7 @@ export const docs = {
   ],
   usage: {
     description:
-      'Core positioning hook for rendering overlay content using CSS Anchor Positioning and the Popover API. Use it as the foundation for custom popovers, hover cards, tooltips, and fixed-position layers when higher-level components are not enough.',
+      'Core positioning hook for rendering overlay content using CSS Anchor Positioning and the Popover API. Use it as the foundation for custom popovers, hover cards, tooltips, and fixed-position layers when higher-level components are not enough. Open state is tracked even when the popover element mounts later, so layers that defer their DOM until after hydration stay in sync.',
     bestPractices: [
       {
         guidance: true,
@@ -121,7 +122,7 @@ export const docsDense = {
   returnDescriptions: {
     ref: 'trigger ref for context mode; undefined in fixed mode.',
     anchorId: 'CSS anchor name.',
-    show: 'show layer.',
+    show: 'show layer; open intent is replayed if the popover DOM attaches later.',
     hide: 'hide layer.',
     isOpen: 'whether layer is open.',
     id: 'unique ARIA id.',

--- a/packages/core/src/Layer/useLayer.tsx
+++ b/packages/core/src/Layer/useLayer.tsx
@@ -5,7 +5,7 @@
 /**
  * @file useLayer.tsx
  * @input Uses React hooks, Popover API, CSS anchor positioning, typography tokens
- * @output Exports useLayer hook for layer positioning and visibility
+ * @output Exports useLayer hook for layer positioning, visibility, and deferred DOM-open sync
  * @position Core layer utility; used by useHoverCard, useTooltip, etc.
  *
  * SYNC: When modified, update:
@@ -290,8 +290,12 @@ export function useLayer(
   const isOpenRef = useRef(false);
 
   const show = useCallback(() => {
-    if (popoverRef.current && !isOpenRef.current) {
-      popoverRef.current.showPopover();
+    if (!isOpenRef.current) {
+      // The popover element may not be attached yet — e.g. when the layer is
+      // portaled only after hydration, an isDefaultOpen request can fire before
+      // the DOM node mounts. Record the open intent regardless; the ref
+      // callback replays showPopover() once the element attaches.
+      popoverRef.current?.showPopover();
       isOpenRef.current = true;
       setIsOpen(true);
       onShow?.();
@@ -352,9 +356,21 @@ export function useLayer(
   // Ref callback for popover element — sets up toggle listener
   const popoverRefCallback = useCallback(
     (el: HTMLElement | null) => {
+      // Detach from the previous element so we don't leak a toggle listener
+      // when the popover node is swapped (e.g. deferred portal mount).
+      if (popoverRef.current) {
+        popoverRef.current.removeEventListener('toggle', handleToggle);
+      }
+
       popoverRef.current = el;
       if (el) {
         el.addEventListener('toggle', handleToggle);
+        // Replay a pending open: show() may have run before the popover DOM
+        // node attached (deferred/portaled layers, isDefaultOpen). If the
+        // layer is logically open but the element isn't, open it now.
+        if (isOpenRef.current && !el.matches(':popover-open')) {
+          el.showPopover();
+        }
       }
     },
     [handleToggle],


### PR DESCRIPTION
## Summary

Fixes #3107.

`HoverCard` produced a React hydration mismatch when rendered inside a Client
Component in a Next.js App Router page (SSR enabled). The server tree and the
first client tree differed inside `HoverCard`: the client rendered an extra
portaled popover (`<div popover="manual" style={{ positionAnchor, positionArea,
positionTryFallbacks }}>`) that the server never produced.

## Cause

`HoverCard` portals its floating popover layer into `document.body`. The portal
was gated only on `typeof document !== 'undefined'`, which is `false` during SSR
but `true` on the very first client render. So the server emitted no popover
markup while the first client render immediately emitted the portaled popover —
the two renders disagreed and React reported a hydration mismatch. This matches
the reporter's workaround, where gating the card behind a `useSyncExternalStore`
`hasMounted` flag removed the error.

## Fix

- Defer the portaled popover until **after** hydration using a
  `useSyncExternalStore`-based hydration flag (server snapshot `false`, client
  snapshot `true`). The SSR output and the first client render are now identical
  — neither includes the portal — and the popover mounts on the next
  browser-only render, so there is nothing for hydration to mismatch.
- Make `useLayer` resilient to the popover element mounting later: `show()` now
  records open intent even when the popover DOM node has not attached yet, and
  the popover ref callback replays `showPopover()` once the element attaches
  (and detaches the previous element's `toggle` listener). This keeps
  `isDefaultOpen` working — the card opens after hydration once the deferred
  popover mounts.
- Document the deferred-open behavior on `useLayer`.

## Tests

Added SSR/hydration regression coverage to `HoverCard.test.tsx`:

- server-rendered markup does not contain the portaled popover;
- hydrating with `renderToString` + `hydrateRoot` reports no hydration errors
  and the popover mounts after hydration;
- `isDefaultOpen` opens the popover after hydration once the deferred layer
  attaches.

## Validation

- `pnpm vitest run packages/core/src/HoverCard/HoverCard.test.tsx packages/core/src/Popover/Popover.test.tsx` — pass
- `pnpm vitest run packages/core/src/HoverCard packages/core/src/Popover packages/core/src/Tooltip` — pass
- `pnpm -F @astryxdesign/core typecheck` — pass
- `pnpm -F @astryxdesign/core typecheck:docs` — pass
- `pnpm -F @astryxdesign/core lint` — pass
- `pnpm -F @astryxdesign/core build` — pass
- `node scripts/sync-exports.js --check` / `node scripts/generate-token-docs.mjs --check` / `node scripts/check-sync.js` — clean

A patch changeset for `@astryxdesign/core` is included.
