### PR TITLE
docs(storybook): scrub xds references from stories + config

### DIFF
--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -52,7 +52,7 @@ const config: StorybookConfig = {
       optimizeDeps: {
         ...config.optimizeDeps,
         // Vite waits for all module transforms to finish before committing
-        // pre-bundled deps. The StyleX Babel plugin stalls on some XDS core
+        // pre-bundled deps. The StyleX Babel plugin stalls on some Astryx core
         // components, so the crawl never completes and deps are never served.
         holdUntilCrawlEnd: false,
       },

--- a/apps/storybook/.storybook/preview.tsx
+++ b/apps/storybook/.storybook/preview.tsx
@@ -19,7 +19,7 @@ const themes = {
 };
 
 /**
- * Decorator that wraps all stories in the XDS Theme provider.
+ * Decorator that wraps all stories in the Astryx Theme provider.
  *
  * Sets `color-scheme` on the document root so that CSS `light-dark()`
  * resolves correctly at every level of the page — not just inside the
@@ -29,7 +29,7 @@ const themes = {
  */
 const withTheme: Decorator = (Story, context) => {
   // Get theme selection from toolbar
-  const themeKey = (context.globals?.xdsTheme || 'neutral') as string;
+  const themeKey = (context.globals?.astryxTheme || 'neutral') as string;
   const mode = context.globals?.colorMode === 'dark' ? 'dark' : 'light';
 
   // Sync color-scheme to the document root so light-dark() works
@@ -83,8 +83,8 @@ const preview: Preview = {
     layout: 'fullscreen',
   },
   globalTypes: {
-    xdsTheme: {
-      description: 'XDS Theme',
+    astryxTheme: {
+      description: 'Astryx Theme',
       toolbar: {
         title: 'Theme',
         icon: 'paintbrush',
@@ -111,7 +111,7 @@ const preview: Preview = {
     },
   },
   initialGlobals: {
-    xdsTheme: 'neutral',
+    astryxTheme: 'neutral',
     colorMode: 'light',
   },
   decorators: [withTheme],

--- a/apps/storybook/stories/Chat.stories.tsx
+++ b/apps/storybook/stories/Chat.stories.tsx
@@ -518,7 +518,7 @@ export const MultiBubble: StoryObj = {
                 status="delivered"
               />
             }>
-            Link: github.com/xds/pull/1180
+            Link: github.com/facebook/astryx/pull/1180
           </ChatMessageBubble>
         </ChatMessage>
         <ChatMessage

--- a/apps/storybook/stories/ChatAutoScroll.stories.tsx
+++ b/apps/storybook/stories/ChatAutoScroll.stories.tsx
@@ -4,7 +4,7 @@
  * Demonstrates the auto-scroll behavior difference between streaming text
  * and discrete block additions (tool calls, custom elements).
  *
- * Issue: https://github.com/facebookexperimental/xds/issues/2282
+ * Issue: https://github.com/facebook/astryx/issues/2282
  *
  * The auto-scroll system (useChatStreamScroll + useChatNewMessages)
  * relies on ResizeObserver detecting content height changes. This story
@@ -114,7 +114,7 @@ const TOOL_CALLS_SEQUENCE: ChatToolCallItem[][] = [
       target: 'packages/core/src/Chat/useChatStreamScroll.ts',
       status: 'complete',
       duration: '42ms',
-      node: 'xds',
+      node: 'astryx',
     },
   ],
   [
@@ -124,7 +124,7 @@ const TOOL_CALLS_SEQUENCE: ChatToolCallItem[][] = [
       target: 'yarn test --filter Chat',
       status: 'complete',
       duration: '4.2s',
-      node: 'xds',
+      node: 'astryx',
     },
   ],
   [
@@ -134,7 +134,7 @@ const TOOL_CALLS_SEQUENCE: ChatToolCallItem[][] = [
       target: 'ChatLayout.tsx',
       status: 'complete',
       duration: '95ms',
-      node: 'xds',
+      node: 'astryx',
       additions: 12,
       deletions: 3,
       resultDetail: (
@@ -152,7 +152,7 @@ const TOOL_CALLS_SEQUENCE: ChatToolCallItem[][] = [
       target: 'yarn test',
       status: 'complete',
       duration: '8.1s',
-      node: 'xds',
+      node: 'astryx',
       resultDetail: (
         <CodeBlock
           code={`$ yarn test\n✓ 142 tests passed (18 suites)\n\nTest Suites: 18 passed, 18 total\nTests:       142 passed, 142 total\nTime:        8.1s`}
@@ -168,7 +168,7 @@ const TOOL_CALLS_SEQUENCE: ChatToolCallItem[][] = [
       target: 'packages/core/src/Chat/useChatNewMessages.ts',
       status: 'complete',
       duration: '38ms',
-      node: 'xds',
+      node: 'astryx',
     },
   ],
 ];
@@ -471,7 +471,7 @@ export const RapidToolCalls: StoryObj = {
                 name: toolNames[idx] ?? 'read',
                 target: targets[idx],
                 status: 'running',
-                node: 'xds',
+                node: 'astryx',
               },
             ],
           },
@@ -491,7 +491,7 @@ export const RapidToolCalls: StoryObj = {
                         target: targets[idx],
                         status: 'complete' as const,
                         duration: `${(Math.random() * 3 + 0.1).toFixed(1)}s`,
-                        node: 'xds',
+                        node: 'astryx',
                       },
                     ],
                   }
@@ -633,7 +633,7 @@ export const MixedStreamAndTools: StoryObj = {
                     name: 'edit',
                     target: 'Button.tsx',
                     status: 'running',
-                    node: 'xds',
+                    node: 'astryx',
                   },
                 ],
               },
@@ -652,7 +652,7 @@ export const MixedStreamAndTools: StoryObj = {
                             target: 'Button.tsx',
                             status: 'complete',
                             duration: '92ms',
-                            node: 'xds',
+                            node: 'astryx',
                             additions: 4,
                             deletions: 2,
                             resultDetail: (
@@ -683,7 +683,7 @@ export const MixedStreamAndTools: StoryObj = {
                         name: 'bash',
                         target: 'yarn test --filter Button',
                         status: 'running',
-                        node: 'xds',
+                        node: 'astryx',
                       },
                     ],
                   },
@@ -702,7 +702,7 @@ export const MixedStreamAndTools: StoryObj = {
                                 target: 'yarn test --filter Button',
                                 status: 'complete',
                                 duration: '3.8s',
-                                node: 'xds',
+                                node: 'astryx',
                                 resultDetail: (
                                   <CodeBlock
                                     code={`✓ 24 tests passed\n\nTest Suites: 3 passed, 3 total\nTests:       24 passed, 24 total`}

--- a/apps/storybook/stories/ChatComposerInput.stories.tsx
+++ b/apps/storybook/stories/ChatComposerInput.stories.tsx
@@ -128,7 +128,7 @@ export const CustomPlaceholder: Story = {
     <ChatComposer
       onSubmit={v => alert(v)}
       input={
-        <ChatComposerInput placeholder="Ask me anything about XDS..." />
+        <ChatComposerInput placeholder="Ask me anything about Astryx..." />
       }
     />
   ),

--- a/apps/storybook/stories/ChatLayout.stories.tsx
+++ b/apps/storybook/stories/ChatLayout.stories.tsx
@@ -142,7 +142,7 @@ const SEED_MESSAGES: Message[] = [
         target: 'Button.tsx',
         status: 'complete',
         duration: '45ms',
-        node: 'xds',
+        node: 'astryx',
       },
       {
         key: '2',
@@ -150,7 +150,7 @@ const SEED_MESSAGES: Message[] = [
         target: 'Button.tsx',
         status: 'complete',
         duration: '120ms',
-        node: 'xds',
+        node: 'astryx',
         additions: 8,
         deletions: 2,
         resultDetail: (
@@ -166,7 +166,7 @@ const SEED_MESSAGES: Message[] = [
         target: 'yarn test',
         status: 'complete',
         duration: '6.1s',
-        node: 'xds',
+        node: 'astryx',
         resultDetail: (
           <CodeBlock
             code={`$ yarn test\n✓ 24 tests passed (3 suites)`}
@@ -369,7 +369,7 @@ export const FullAIChat: StoryObj = {
                 target: 'Card.tsx',
                 status: 'complete',
                 duration: '35ms',
-                node: 'xds',
+                node: 'astryx',
               },
               {
                 key: 'e1',
@@ -377,7 +377,7 @@ export const FullAIChat: StoryObj = {
                 target: 'Card.tsx',
                 status: 'complete',
                 duration: '90ms',
-                node: 'xds',
+                node: 'astryx',
                 additions: 1,
                 deletions: 1,
               },
@@ -387,7 +387,7 @@ export const FullAIChat: StoryObj = {
                 target: 'yarn test --filter Card',
                 status: 'complete',
                 duration: '3.2s',
-                node: 'xds',
+                node: 'astryx',
               },
             ],
           );

--- a/apps/storybook/stories/CodeBlock.stories.tsx
+++ b/apps/storybook/stories/CodeBlock.stories.tsx
@@ -157,7 +157,7 @@ export const HTML: Story = {
   <body>
     <main id="app">
       <h1>Hello, World!</h1>
-      <p class="subtitle">Welcome to XDS.</p>
+      <p class="subtitle">Welcome to Astryx.</p>
     </main>
     <script src="app.js"></script>
   </body>

--- a/apps/storybook/stories/Collapsible.stories.tsx
+++ b/apps/storybook/stories/Collapsible.stories.tsx
@@ -85,9 +85,9 @@ export const MultipleMode: Story = {
     <CollapsibleGroup type="multiple" defaultValue={['faq1', 'faq3']}>
       <VStack gap={2}>
         <Card>
-          <Collapsible trigger="What is XDS?" value="faq1">
+          <Collapsible trigger="What is Astryx?" value="faq1">
             <p {...stylex.props(styles.text)}>
-              XDS is a design system for building internal tools and products.
+              Astryx is a design system for building internal tools and products.
             </p>
           </Collapsible>
         </Card>
@@ -101,7 +101,7 @@ export const MultipleMode: Story = {
         <Card>
           <Collapsible trigger="Is it open source?" value="faq3">
             <p {...stylex.props(styles.text)}>
-              Yes! XDS is open source and available on GitHub.
+              Yes! Astryx is open source and available on GitHub.
             </p>
           </Collapsible>
         </Card>

--- a/apps/storybook/stories/Field.stories.tsx
+++ b/apps/storybook/stories/Field.stories.tsx
@@ -13,7 +13,7 @@ import {
   typographyVars,
 } from '@astryxdesign/core/theme/tokens.stylex';
 
-// A minimal native input styled to match XDS aesthetics —
+// A minimal native input styled to match Astryx aesthetics —
 // demonstrating that Field wraps any custom or native input.
 const inputStyles = stylex.create({
   root: {

--- a/apps/storybook/stories/FormLayout.stories.tsx
+++ b/apps/storybook/stories/FormLayout.stories.tsx
@@ -106,7 +106,7 @@ export const HorizontalLabels: Story = {
   },
 };
 
-// ─── Mixed: XDS inputs + Field-wrapped custom controls ─────────────────
+// ─── Mixed: Astryx inputs + Field-wrapped custom controls ─────────────────
 
 const checkboxStyles = stylex.create({
   group: {

--- a/apps/storybook/stories/Item.stories.tsx
+++ b/apps/storybook/stories/Item.stories.tsx
@@ -219,7 +219,7 @@ export const SearchResults: Story = {
         startContent={<Icon icon={MagnifyingGlassIcon} size="sm" />}
         label={
           <>
-            XDS <b>Button</b> Component
+            Astryx <b>Button</b> Component
           </>
         }
         description="Primary interactive element for triggering actions..."
@@ -230,7 +230,7 @@ export const SearchResults: Story = {
         startContent={<Icon icon={MagnifyingGlassIcon} size="sm" />}
         label={
           <>
-            XDS <b>Button</b>Group
+            Astryx <b>Button</b>Group
           </>
         }
         description="Groups related buttons into a single connected control..."

--- a/apps/storybook/stories/Layer.stories.tsx
+++ b/apps/storybook/stories/Layer.stories.tsx
@@ -10,11 +10,11 @@ import {Text} from '@astryxdesign/core/Text';
 
 const styles = stylex.create({
   popoverContent: {
-    backgroundColor: 'var(--xds-color-surface-raised)',
+    backgroundColor: 'var(--color-background-surface)',
     borderRadius: 8,
     padding: 16,
     boxShadow: '0 4px 12px rgba(0,0,0,0.15)',
-    border: '1px solid var(--xds-color-border-default)',
+    border: '1px solid var(--color-border-default)',
   },
   demoArea: {
     display: 'flex',
@@ -120,7 +120,7 @@ function FixedModeDemo() {
       style={{
         position: 'relative',
         minHeight: 300,
-        border: '1px dashed var(--xds-color-border-default)',
+        border: '1px dashed var(--color-border-default)',
         borderRadius: 8,
         cursor: 'crosshair',
       }}

--- a/apps/storybook/stories/Layout.stories.tsx
+++ b/apps/storybook/stories/Layout.stories.tsx
@@ -169,7 +169,7 @@ const meta: Meta<typeof Layout> = {
     docs: {
       description: {
         component: `
-The XDS Layout System provides a structured way to build page and component layouts.
+The Astryx Layout System provides a structured way to build page and component layouts.
 
 **Components:**
 - \`Card\` - Card container with shadow

--- a/apps/storybook/stories/Link.stories.tsx
+++ b/apps/storybook/stories/Link.stories.tsx
@@ -130,7 +130,7 @@ export const InlineWithText: Story = {
   render: () => (
     <Text type="body">
       Read the <Link href="/docs">documentation</Link> for more
-      information about using XDS components.
+      information about using Astryx components.
     </Text>
   ),
 };

--- a/apps/storybook/stories/Markdown.stories.tsx
+++ b/apps/storybook/stories/Markdown.stories.tsx
@@ -38,7 +38,7 @@ const SAMPLE_MD = [
   '',
   '## Features',
   '',
-  '- Headings mapped to XDS type scale',
+  '- Headings mapped to Astryx type scale',
   '- **Bold**, *italic*, and ~~strikethrough~~ text',
   '- [Links](https://example.com) with external detection',
   '- Inline `code` and fenced code blocks',

--- a/apps/storybook/stories/MetadataList.stories.tsx
+++ b/apps/storybook/stories/MetadataList.stories.tsx
@@ -51,7 +51,7 @@ export const MultiColumn: Story = {
       <MetadataListItem label="Tags">
         <span style={{display: 'flex', gap: 4}}>
           <Token label="component" />
-          <Token label="xds" />
+          <Token label="astryx" />
         </span>
       </MetadataListItem>
       <MetadataListItem label="Priority">Tier 1</MetadataListItem>
@@ -93,7 +93,7 @@ export const StackedLabelsSingleColumn: Story = {
       <MetadataListItem label="Tags">
         <span style={{display: 'flex', gap: 4}}>
           <Token label="component" />
-          <Token label="xds" />
+          <Token label="astryx" />
         </span>
       </MetadataListItem>
     </MetadataList>
@@ -165,7 +165,7 @@ export const WithIcons: Story = {
         icon={<Icon icon={TagIcon} size="sm" />}>
         <span style={{display: 'flex', gap: 4}}>
           <Token label="component" />
-          <Token label="xds" />
+          <Token label="astryx" />
         </span>
       </MetadataListItem>
     </MetadataList>

--- a/apps/storybook/stories/Outline.stories.tsx
+++ b/apps/storybook/stories/Outline.stories.tsx
@@ -48,7 +48,7 @@ const outlineItems: OutlineItem[] = [
 const markdownContent = [
   '## Overview',
   '',
-  'XDS gives teams a consistent foundation for internal product surfaces.',
+  'Astryx gives teams a consistent foundation for internal product surfaces.',
   '',
   '## Installation',
   '',
@@ -123,7 +123,7 @@ export const WithDocument: Story = {
         <section>
           <h2 id="overview">Overview</h2>
           <p>
-            XDS components provide consistent interaction, styling, and theme
+            Astryx components provide consistent interaction, styling, and theme
             behavior for internal tools.
           </p>
         </section>
@@ -147,8 +147,8 @@ export const WithDocument: Story = {
           </p>
           <h3 id="component-overrides">Component overrides</h3>
           <p>
-            Component overrides target the stable XDS selector surface emitted
-            by each component: xds-* classes plus data-* prop reflections.
+            Component overrides target the stable Astryx selector surface emitted
+            by each component: astryx-* classes plus data-* prop reflections.
           </p>
         </section>
         <section>

--- a/apps/storybook/stories/Overlay.stories.tsx
+++ b/apps/storybook/stories/Overlay.stories.tsx
@@ -251,7 +251,7 @@ export const VideoThumbnail: Story = {
             <Text weight="bold" size="lg">
               ▶
             </Text>
-            <Text weight="bold">Introduction to XDS</Text>
+            <Text weight="bold">Introduction to Astryx</Text>
           </VStack>
         }>
         <AspectRatio ratio={16 / 9}>

--- a/apps/storybook/stories/SankeyChart.stories.tsx
+++ b/apps/storybook/stories/SankeyChart.stories.tsx
@@ -262,7 +262,7 @@ export const ManyColumns: Story = {
 
 // --- Business Funnel: blue main flow, gray exits ---
 
-// oklch approximations of XDS data tokens:
+// oklch approximations of Astryx data tokens:
 // blue categorical: #0171E3 ≈ oklch(0.55 0.19 255)
 // blue-3: #2694FE ≈ oklch(0.65 0.17 250)
 // gray-4: #5D6C7B ≈ oklch(0.50 0.02 240)

--- a/apps/storybook/stories/VegaLiteRanges.stories.tsx
+++ b/apps/storybook/stories/VegaLiteRanges.stories.tsx
@@ -299,7 +299,7 @@ const weatherHeatmapSpec: AnySpec = {
 };
 
 // ---------------------------------------------------------------------------
-// Themed wrapper — resolves XDS tokens into a Vega-Lite config
+// Themed wrapper — resolves Astryx tokens into a Vega-Lite config
 // ---------------------------------------------------------------------------
 
 function ThemedVegaChart(props: React.ComponentProps<typeof VegaChart>) {

--- a/apps/storybook/stories/XIFSpec.stories.tsx
+++ b/apps/storybook/stories/XIFSpec.stories.tsx
@@ -78,7 +78,7 @@ export const SpecExamples: StoryObj = {
     <Stack direction="vertical" gap={3}>
       <Heading level={3}>XIF Spec Examples</Heading>
       <Text type="supporting">
-        Icons defined using the XDS Icon Format specification. Each demonstrates
+        Icons defined using the Astryx Icon Format specification. Each demonstrates
         a different capability: stroke-only, two-layer knockout, composable
         slots, animation declarations, personality overrides, and bold geometry
         overrides.


### PR DESCRIPTION
Knots: `scrub-storybook`. 21 files across storybook:
- `xdsTheme` global → `astryxTheme`; display label 'XDS Theme' → 'Astryx Theme'
- Mock data `node: 'xds'` → `'astryx'` across 10+ story files
- `var(--xds-color-*)` → proper token names
- Stale GitHub URLs → `facebook/astryx`
- Product-name prose + demo labels

Left alone: picsum.photos URL seeds (`seed/xds-travel` — opaque image seeds, not branding) and files renamed in #3125.