### PR TITLE
fix(core): prevent DateInput crash on incomplete/leading-zero input

### DIFF
--- a/.changeset/dateinput-incomplete-input-crash.md
+++ b/.changeset/dateinput-incomplete-input-crash.md
@@ -1,0 +1,12 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Prevent `DateInput` from crashing the page while typing an incomplete
+date. Typing a leading `0` or `1` (e.g. starting to enter `01` for January)
+could coerce the in-progress value into an invalid date with a year of `0`,
+which then threw a `RangeError` and crashed the surrounding page. Partial,
+not-yet-complete input is now treated as incomplete instead of being parsed
+into a date, so the field stays usable as you type.
+
+@cixzhang

--- a/packages/core/src/DateInput/DateInput.test.tsx
+++ b/packages/core/src/DateInput/DateInput.test.tsx
@@ -21,19 +21,13 @@ describe('DateInput', () => {
 
   it('renders with placeholder', () => {
     render(
-      <DateInput
-        label="Date"
-        onChange={() => {}}
-        placeholder="Pick a date"
-      />,
+      <DateInput label="Date" onChange={() => {}} placeholder="Pick a date" />,
     );
     expect(screen.getByPlaceholderText('Pick a date')).toBeInTheDocument();
   });
 
   it('displays formatted date when value is provided', () => {
-    render(
-      <DateInput label="Date" value="2026-01-25" onChange={() => {}} />,
-    );
+    render(<DateInput label="Date" value="2026-01-25" onChange={() => {}} />);
     expect(screen.getByDisplayValue('January 25, 2026')).toBeInTheDocument();
   });
 
@@ -118,9 +112,7 @@ describe('DateInput', () => {
 
   it('reverts to previous value on blur when input is invalid', async () => {
     const onChange = vi.fn();
-    render(
-      <DateInput label="Date" value="2026-01-25" onChange={onChange} />,
-    );
+    render(<DateInput label="Date" value="2026-01-25" onChange={onChange} />);
 
     const input = screen.getByRole('combobox');
     fireEvent.change(input, {target: {value: 'not a date'}});
@@ -299,9 +291,7 @@ describe('DateInput', () => {
   // --- P1: Tab order: calendar button first, then input ---
 
   it('renders calendar button before input in DOM order', () => {
-    const {container} = render(
-      <DateInput label="Date" onChange={() => {}} />,
-    );
+    const {container} = render(<DateInput label="Date" onChange={() => {}} />);
     const input = container.querySelector('input');
     const button = container.querySelector('button');
     // Calendar button should come before input in the DOM
@@ -389,9 +379,7 @@ describe('DateInput', () => {
 
   it('calls onChange with undefined when input is cleared and blurred', () => {
     const onChange = vi.fn();
-    render(
-      <DateInput label="Date" value="2026-01-25" onChange={onChange} />,
-    );
+    render(<DateInput label="Date" value="2026-01-25" onChange={onChange} />);
 
     const input = screen.getByRole('combobox');
     fireEvent.change(input, {target: {value: ''}});
@@ -476,9 +464,7 @@ describe('DateInput', () => {
     });
 
     it('does not show clear button when hasClear is false', () => {
-      render(
-        <DateInput label="Date" value="2026-01-15" onChange={() => {}} />,
-      );
+      render(<DateInput label="Date" value="2026-01-15" onChange={() => {}} />);
       expect(
         screen.queryByRole('button', {name: 'Clear Date'}),
       ).not.toBeInTheDocument();
@@ -511,6 +497,68 @@ describe('DateInput', () => {
       );
       fireEvent.click(screen.getByRole('button', {name: 'Clear Date'}));
       expect(onChange).toHaveBeenCalledWith(undefined);
+    });
+  });
+
+  // --- Regression: in-progress / leading-zero input must not crash ---
+
+  describe('incomplete typed input', () => {
+    it('does not crash or fire onChange when first digit typed is 0', () => {
+      const onChange = vi.fn();
+      render(<DateInput label="Date" onChange={onChange} />);
+
+      const input = screen.getByRole('combobox');
+      // Typing a leading "0" (e.g. starting "01" for January) must be treated
+      // as incomplete input, not coerced into an (invalid) date that crashes.
+      expect(() =>
+        fireEvent.change(input, {target: {value: '0'}}),
+      ).not.toThrow();
+
+      expect(onChange).not.toHaveBeenCalled();
+      expect(input).toHaveValue('0');
+    });
+
+    it('does not crash or fire onChange when first digit typed is 1', () => {
+      const onChange = vi.fn();
+      render(<DateInput label="Date" onChange={onChange} />);
+
+      const input = screen.getByRole('combobox');
+      expect(() =>
+        fireEvent.change(input, {target: {value: '1'}}),
+      ).not.toThrow();
+
+      expect(onChange).not.toHaveBeenCalled();
+      expect(input).toHaveValue('1');
+    });
+
+    it('does not crash while progressively typing a numeric date', () => {
+      const onChange = vi.fn();
+      render(<DateInput label="Date" onChange={onChange} />);
+
+      const input = screen.getByRole('combobox');
+      // Simulate keystroke-by-keystroke entry of "01/15/2026". The leading
+      // single-digit keystrokes must not crash (the original bug).
+      for (const partial of ['0', '01', '01/', '01/1', '01/15', '01/15/']) {
+        expect(() =>
+          fireEvent.change(input, {target: {value: partial}}),
+        ).not.toThrow();
+      }
+
+      // Completing the date commits it without error.
+      expect(() =>
+        fireEvent.change(input, {target: {value: '01/15/2026'}}),
+      ).not.toThrow();
+      expect(onChange).toHaveBeenCalledWith('2026-01-15');
+    });
+
+    it('does not crash on blur after typing an incomplete value', () => {
+      const onChange = vi.fn();
+      render(<DateInput label="Date" onChange={onChange} />);
+
+      const input = screen.getByRole('combobox');
+      fireEvent.change(input, {target: {value: '0'}});
+      expect(() => fireEvent.blur(input)).not.toThrow();
+      expect(onChange).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/core/src/utils/dateParser.test.ts
+++ b/packages/core/src/utils/dateParser.test.ts
@@ -320,5 +320,31 @@ describe('parseDateInput', () => {
     it('rejects mixed separators', () => {
       expect(parseDateInput('1/25.2026')).toBeNull();
     });
+
+    it('treats a single typed digit as incomplete, not a date', () => {
+      // A user starting to type a month (e.g. "0" or "1" for January) should
+      // not produce a date. Native Date parsing would otherwise coerce these
+      // into arbitrary dates (and a year of 0 in some engines).
+      expect(parseDateInput('0')).toBeNull();
+      expect(parseDateInput('1')).toBeNull();
+    });
+
+    it('treats bare numeric input as incomplete, not a date', () => {
+      expect(parseDateInput('00')).toBeNull();
+      expect(parseDateInput('01')).toBeNull();
+      expect(parseDateInput('12')).toBeNull();
+      expect(parseDateInput('2026')).toBeNull();
+    });
+
+    it('never returns an out-of-range date for partial input', () => {
+      // Regression: partial input must never yield a date with year < 1,
+      // which would throw when later re-parsed and crash the page.
+      for (const input of ['0', '1', '01', '00', '9', '99']) {
+        const result = parseDateInput(input);
+        if (result !== null) {
+          expect(result.year).toBeGreaterThanOrEqual(1);
+        }
+      }
+    });
   });
 });

--- a/packages/core/src/utils/dateParser.ts
+++ b/packages/core/src/utils/dateParser.ts
@@ -124,10 +124,24 @@ export function parseDateInput(input: string): PlainDate | null {
     return parseNumericDate(+first, +second, currentYear);
   }
 
-  // 6. Fall back to native Date parsing for other formats
+  // 6. Fall back to native Date parsing for other formats.
+  //
+  // Skip bare numeric input (e.g. "0", "1", "01", "2026"). These are
+  // in-progress values a user is still typing, not complete dates. Native
+  // `Date` parsing coerces them into arbitrary dates ("0" -> year 2000 in V8,
+  // year 0 in some engines), which is both surprising and — when the year
+  // resolves to 0 — produces an out-of-range date that throws downstream.
+  // Treat them as not-yet-a-valid-date instead.
+  if (/^\d+$/.test(trimmed)) {
+    return null;
+  }
+
   const parsed = new Date(trimmed);
   if (!isNaN(parsed.getTime())) {
-    return plainDateFromDate(parsed);
+    const fromDate = plainDateFromDate(parsed);
+    // Validate the result so we never return an out-of-range date (e.g. a
+    // year of 0), which would throw when later re-parsed.
+    return tryCreatePlainDate(fromDate.year, fromDate.month, fromDate.day);
   }
 
   return null;


### PR DESCRIPTION
## Summary

Fixes #3104.

Typing a leading `0` or `1` into `DateInput` (e.g. starting to enter `01` for January) could crash the entire page with:

```
RangeError: year must be a positive integer, got 0
```

### Cause

`parseDateInput` falls back to the native `Date` constructor for inputs that don't match its explicit format patterns. A single in-progress digit like `"0"` or `"1"` is happily "parsed" by `new Date(...)` into an arbitrary date, and the result was passed straight to `plainDateFromDate` without validation. In some engines (e.g. Safari) `new Date("0")` resolves to a year of `0`; that out-of-range value then threw when the date was re-parsed downstream while rendering, taking down the whole page. In V8 the same input silently produced a surprising year-2000 date the user never typed.

### Fix

`parseDateInput` now treats a partial value as not-yet-a-valid-date rather than coercing it:

- Bare numeric input (`"0"`, `"1"`, `"01"`, `"2026"`, …) returns `null` — it's an in-progress value, not a complete date.
- The native-`Date` fallback validates its result through the same range checks used everywhere else, so it can never return an out-of-range date (e.g. year `0`) that would throw later.

The field now stays usable as you type, and incomplete input never crashes the page.

### Tests

- `dateParser.test.ts`: single digits, bare numbers, and partial input return `null` and never yield an out-of-range year.
- `DateInput.test.tsx`: typing a leading `0` / `1`, progressively typing a full date, and blurring on incomplete input no longer throw and don't fire spurious `onChange` calls.

Patch changeset included for `@astryxdesign/core`.
