### PR TITLE
refactor: scrub xds refs from sandbox + rename withXDS -> withAstryx

### DIFF
--- a/.changeset/build-with-astryx.md
+++ b/.changeset/build-with-astryx.md
@@ -1,0 +1,11 @@
+---
+'@astryxdesign/build': patch
+---
+
+[breaking] Rename Next.js helper `withXDS` to `withAstryx`
+@ejhammond
+
+The Next.js configuration wrapper is renamed `withXDS` -> `withAstryx`
+(exported from `@astryxdesign/build/next`). Update your `next.config.mjs`:
+`import {withAstryx} from '@astryxdesign/build/next'`. Part of removing xds
+naming from the public API.

--- a/apps/example-nextjs-source/next.config.mjs
+++ b/apps/example-nextjs-source/next.config.mjs
@@ -1,4 +1,4 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-import {withXDS} from '@astryxdesign/build/next';
-export default withXDS({});
+import {withAstryx} from '@astryxdesign/build/next';
+export default withAstryx({});

--- a/apps/sandbox/README.md
+++ b/apps/sandbox/README.md
@@ -1,6 +1,6 @@
 # /apps/sandbox
 
-XDS component sandbox for designer exploration and vibe testing. Deployed alongside Storybook on every PR.
+Astryx component sandbox for designer exploration and vibe testing. Deployed alongside Storybook on every PR.
 
 <!-- SYNC: When files in this directory change, update this document. -->
 
@@ -12,7 +12,7 @@ Before writing any code, install dependencies:
 npm install
 ```
 
-This automatically generates `AGENTS.md` with the XDS component index via `astryx init --features agents`. **Read `AGENTS.md` for all XDS component documentation**: it contains CLI commands to browse components, tokens, themes, and design rules.
+This automatically generates `AGENTS.md` with the Astryx component index via `astryx init --features agents`. **Read `AGENTS.md` for all Astryx component documentation**: it contains CLI commands to browse components, tokens, themes, and design rules.
 
 If `AGENTS.md` is missing, regenerate it:
 

--- a/apps/sandbox/next.config.mjs
+++ b/apps/sandbox/next.config.mjs
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-import {withXDS} from '@astryxdesign/build/next';
+import {withAstryx} from '@astryxdesign/build/next';
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
@@ -34,4 +34,4 @@ const nextConfig = {
   },
 };
 
-export default withXDS(nextConfig);
+export default withAstryx(nextConfig);

--- a/apps/sandbox/scripts/generate-changelog.js
+++ b/apps/sandbox/scripts/generate-changelog.js
@@ -14,7 +14,7 @@ const REPO_ROOT = path.resolve(__dirname, '..', '..', '..');
 const OUT_DIR = path.resolve(__dirname, '..', 'src', 'generated');
 const OUT_FILE = path.join(OUT_DIR, 'changelogRegistry.ts');
 
-const GITHUB_REPO = 'facebookexperimental/xds';
+const GITHUB_REPO = 'facebook/astryx';
 
 const CHANGELOG_SOURCES = [
   {pkg: '@astryxdesign/core', file: 'packages/core/CHANGELOG.md'},

--- a/apps/sandbox/scripts/generate-cli-registry.mjs
+++ b/apps/sandbox/scripts/generate-cli-registry.mjs
@@ -27,7 +27,7 @@ const CLI_PKG = JSON.parse(
 
 const program = new Command();
 program
-  .name('xds')
+  .name('astryx')
   .description(CLI_PKG.description)
   .version(CLI_PKG.version)
   .option('--zh', 'Output docs in Chinese Simplified')

--- a/apps/sandbox/src/app/(fullscreen)/pages/doc-discover/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/doc-discover/page.tsx
@@ -41,7 +41,7 @@ const ITEMS: DiscoverItem[] = [
     description:
       'Full-featured data table with sorting, filtering, pagination, and row selection.',
     category: 'Components',
-    author: 'XDS Core',
+    author: 'Astryx Core',
     downloads: '12.4k',
     tags: ['table', 'data', 'filtering'],
   },
@@ -50,7 +50,7 @@ const ITEMS: DiscoverItem[] = [
     description:
       'Declarative form composition with built-in validation and error handling.',
     category: 'Patterns',
-    author: 'XDS Core',
+    author: 'Astryx Core',
     downloads: '8.2k',
     tags: ['form', 'validation', 'input'],
   },
@@ -59,16 +59,16 @@ const ITEMS: DiscoverItem[] = [
     description:
       'Pre-built dashboard template with sidebar nav, stats cards, and chart areas.',
     category: 'Templates',
-    author: 'XDS Team',
+    author: 'Astryx Team',
     downloads: '6.7k',
     tags: ['dashboard', 'layout', 'analytics'],
   },
   {
     name: 'Theme Editor',
     description:
-      'Visual editor for customizing and previewing XDS design tokens in real-time.',
+      'Visual editor for customizing and previewing Astryx design tokens in real-time.',
     category: 'Tools',
-    author: 'XDS Team',
+    author: 'Astryx Team',
     downloads: '3.1k',
     tags: ['theme', 'tokens', 'preview'],
   },
@@ -77,7 +77,7 @@ const ITEMS: DiscoverItem[] = [
     description:
       'App shell with sidebar, top nav, breadcrumbs, and responsive collapse.',
     category: 'Components',
-    author: 'XDS Core',
+    author: 'Astryx Core',
     downloads: '9.8k',
     tags: ['navigation', 'shell', 'layout'],
   },
@@ -86,7 +86,7 @@ const ITEMS: DiscoverItem[] = [
     description:
       'Keyboard-driven command palette for quick actions and search.',
     category: 'Components',
-    author: 'XDS Labs',
+    author: 'Astryx Labs',
     downloads: '4.5k',
     tags: ['search', 'keyboard', 'shortcuts'],
   },
@@ -95,7 +95,7 @@ const ITEMS: DiscoverItem[] = [
     description:
       'Complete authentication flow with login, registration, and password reset pages.',
     category: 'Templates',
-    author: 'XDS Team',
+    author: 'Astryx Team',
     downloads: '5.3k',
     tags: ['auth', 'login', 'security'],
   },
@@ -104,7 +104,7 @@ const ITEMS: DiscoverItem[] = [
     description:
       'Create-Read-Update-Delete pattern with modals, toasts, and confirmation dialogs.',
     category: 'Patterns',
-    author: 'XDS Core',
+    author: 'Astryx Core',
     downloads: '7.1k',
     tags: ['crud', 'modal', 'data'],
   },
@@ -113,7 +113,7 @@ const ITEMS: DiscoverItem[] = [
     description:
       'AI-powered tool for testing component usage and validating design system adherence.',
     category: 'Tools',
-    author: 'XDS Labs',
+    author: 'Astryx Labs',
     downloads: '2.8k',
     tags: ['ai', 'testing', 'quality'],
   },
@@ -122,7 +122,7 @@ const ITEMS: DiscoverItem[] = [
     description:
       'Full-width dropdown navigation menu with sections, icons, and featured content.',
     category: 'Components',
-    author: 'XDS Core',
+    author: 'Astryx Core',
     downloads: '5.9k',
     tags: ['navigation', 'menu', 'dropdown'],
   },
@@ -131,7 +131,7 @@ const ITEMS: DiscoverItem[] = [
     description:
       'Settings template with tabbed sections, form fields, and save/cancel actions.',
     category: 'Templates',
-    author: 'XDS Team',
+    author: 'Astryx Team',
     downloads: '4.0k',
     tags: ['settings', 'form', 'tabs'],
   },
@@ -140,7 +140,7 @@ const ITEMS: DiscoverItem[] = [
     description:
       'Reusable empty state patterns with illustrations, CTAs, and guidance text.',
     category: 'Patterns',
-    author: 'XDS Core',
+    author: 'Astryx Core',
     downloads: '3.6k',
     tags: ['empty', 'placeholder', 'onboarding'],
   },

--- a/apps/sandbox/src/app/(fullscreen)/pages/doc-docs/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/doc-docs/page.tsx
@@ -353,7 +353,7 @@ export default function DocDocsPage() {
                 letterSpacing: '-0.03em',
                 color: 'var(--color-text-primary, #1a1a1a)',
               }}>
-              XDS
+              Astryx
             </span>
             <span
               style={{

--- a/apps/sandbox/src/app/(fullscreen)/pages/doc-home/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/doc-home/page.tsx
@@ -55,7 +55,7 @@ export default function DocHomePage() {
             <Heading level={1}>Endless templates for your ideas</Heading>
             <Text type="large" color="secondary">
               Explore production-ready templates, patterns, and components built
-              with XDS.
+              with Astryx.
             </Text>
           </div>
 

--- a/apps/sandbox/src/app/(fullscreen)/pages/doc-nav/DocTopNav.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/doc-nav/DocTopNav.tsx
@@ -19,7 +19,7 @@ export default function DocTopNav() {
     <TopNav
       label="Documentation navigation"
       heading={
-        <TopNavHeading heading="XDS" href="/pages/doc-home/" as={Link} />
+        <TopNavHeading heading="Astryx" href="/pages/doc-home/" as={Link} />
       }
       centerContent={
         <>

--- a/apps/sandbox/src/app/(fullscreen)/pages/documentation/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/documentation/page.tsx
@@ -881,7 +881,7 @@ export default function DocumentationPage() {
             padding: '16px 24px 8px',
             flexShrink: 0,
           }}>
-          <span style={{fontWeight: 700, fontSize: 18}}>XDS</span>
+          <span style={{fontWeight: 700, fontSize: 18}}>Astryx</span>
         </div>
 
         {/* Nav */}
@@ -952,15 +952,15 @@ export default function DocumentationPage() {
               }}>
               <div style={{flex: 1, minWidth: 0}}>
                 <Text type="supporting" color="secondary">
-                  XDS Design System
+                  Astryx Design System
                 </Text>
                 <div style={{marginTop: 8}}>
                   <Text type="display-1">Web overview</Text>
                 </div>
                 <div style={{marginTop: 16}}>
                   <Text type="large" color="secondary">
-                    XDS Web React is an open-source UI library created by the
-                    XDS Design Team to help developers quickly build beautiful,
+                    Astryx Web React is an open-source UI library created by the
+                    Astryx Design Team to help developers quickly build beautiful,
                     accessible products.
                   </Text>
                 </div>

--- a/apps/sandbox/src/app/(fullscreen)/pages/showcase-components/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/showcase-components/page.tsx
@@ -48,7 +48,7 @@ export default function ShowcaseComponentsPage() {
             justifyContent: 'space-between',
           }}>
           <VStack gap={4}>
-            <Heading level={2}>Build with XDS</Heading>
+            <Heading level={2}>Build with Astryx</Heading>
             <Text type="body" color="secondary">
               Open source components for the web and beyond
             </Text>
@@ -167,7 +167,7 @@ export default function ShowcaseComponentsPage() {
               <Avatar name="+3" />
             </HStack>
             <Text type="supporting" color="secondary">
-              XDS Core Team
+              Astryx Core Team
             </Text>
           </VStack>
         </div>

--- a/apps/sandbox/src/app/(fullscreen)/pages/showcase-header/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/showcase-header/page.tsx
@@ -59,7 +59,7 @@ export default function ShowcaseHeaderPage() {
         </div>
 
         <div {...stylex.props(styles.titleRow)}>
-          <Heading level={1}>XDS</Heading>
+          <Heading level={1}>Astryx</Heading>
           <div {...stylex.props(styles.connector)} />
           <Heading level={1}>Astryx</Heading>
         </div>

--- a/apps/sandbox/src/app/(sandbox)/page.tsx
+++ b/apps/sandbox/src/app/(sandbox)/page.tsx
@@ -83,7 +83,7 @@ export default function Home() {
     <Layout
       header={
         <LayoutHeader hasDivider padding={6}>
-          <Heading level={1}>XDS Sandbox</Heading>
+          <Heading level={1}>Astryx Sandbox</Heading>
         </LayoutHeader>
       }
       content={

--- a/apps/sandbox/src/app/(sandbox)/pages/example/page.tsx
+++ b/apps/sandbox/src/app/(sandbox)/pages/example/page.tsx
@@ -38,7 +38,7 @@ export default function ExamplePage() {
         <VStack gap={2}>
           <Heading level={1}>Example Page</Heading>
           <Text type="body" color="secondary">
-            A scaffold showing common XDS components. Copy this file to create
+            A scaffold showing common Astryx components. Copy this file to create
             new pages.
           </Text>
         </VStack>

--- a/apps/sandbox/src/app/(sandbox)/pages/motion-examples/page.tsx
+++ b/apps/sandbox/src/app/(sandbox)/pages/motion-examples/page.tsx
@@ -584,7 +584,7 @@ export default function MotionExamplesPage() {
       <VStack gap={2}>
         <Heading level={1}>Motion Examples</Heading>
         <Text type="body" color="secondary">
-          How XDS components apply duration and easing tokens. Each section
+          How Astryx components apply duration and easing tokens. Each section
           calls out which tokens drive the motion so you can see the scale in
           action.
         </Text>

--- a/apps/sandbox/src/app/(sandbox)/pages/polymorphic-link/page.tsx
+++ b/apps/sandbox/src/app/(sandbox)/pages/polymorphic-link/page.tsx
@@ -118,7 +118,7 @@ export default function PolymorphicLinkPage() {
         <VStack gap={2}>
           <Heading level={1}>Polymorphic Link</Heading>
           <Text type="body" color="secondary">
-            XDS components that render links can use a custom link component
+            Astryx components that render links can use a custom link component
             instead of native {'<a>'}. Set it globally via LinkProvider or
             per-component via the{' '}
             <Text type="body" weight="bold">

--- a/apps/sandbox/src/app/(sandbox)/pages/table-overview/page.tsx
+++ b/apps/sandbox/src/app/(sandbox)/pages/table-overview/page.tsx
@@ -47,7 +47,7 @@ interface ReviewRow extends Record<string, unknown> {
 const waitingForAWhile: ReviewRow[] = [
   {
     id: '1',
-    title: '[xds][FilterTokenList]: Promote out of beta',
+    title: '[astryx][FilterTokenList]: Promote out of beta',
     prId: 'PR-1042',
     lines: 3,
     reviewTime: '<20sec review',
@@ -63,7 +63,7 @@ const waitingForAWhile: ReviewRow[] = [
   },
   {
     id: '2',
-    title: '[xds][Table] Fix column resize regression on Safari',
+    title: '[astryx][Table] Fix column resize regression on Safari',
     prId: 'PR-1038',
     lines: 47,
     reviewTime: '~3min review',
@@ -79,7 +79,7 @@ const waitingForAWhile: ReviewRow[] = [
 const needsCodeReview: ReviewRow[] = [
   {
     id: '3',
-    title: '[xds][Avatar] Add AvatarStatusDot size scaling',
+    title: '[astryx][Avatar] Add AvatarStatusDot size scaling',
     prId: 'PR-1055',
     lines: 128,
     reviewTime: '~8min review',
@@ -96,7 +96,7 @@ const needsCodeReview: ReviewRow[] = [
   },
   {
     id: '4',
-    title: '[xds][Badge] Introduce error variant with icon slot',
+    title: '[astryx][Badge] Introduce error variant with icon slot',
     prId: 'PR-1061',
     lines: 52,
     reviewTime: '~2min review',
@@ -109,7 +109,7 @@ const needsCodeReview: ReviewRow[] = [
   },
   {
     id: '5',
-    title: '[xds][Collapsible] Animate height transitions with CSS',
+    title: '[astryx][Collapsible] Animate height transitions with CSS',
     prId: 'PR-1063',
     lines: 210,
     reviewTime: '~12min review',
@@ -125,7 +125,7 @@ const needsCodeReview: ReviewRow[] = [
   },
   {
     id: '6',
-    title: '[xds][TextInput] Add clearable prop with trailing icon',
+    title: '[astryx][TextInput] Add clearable prop with trailing icon',
     prId: 'PR-1067',
     lines: 34,
     reviewTime: '<1min review',
@@ -138,7 +138,7 @@ const needsCodeReview: ReviewRow[] = [
   },
   {
     id: '7',
-    title: '[xds][Layout] Support sticky header in LayoutHeader',
+    title: '[astryx][Layout] Support sticky header in LayoutHeader',
     prId: 'PR-1070',
     lines: 89,
     reviewTime: '~5min review',
@@ -157,7 +157,7 @@ const needsCodeReview: ReviewRow[] = [
 const acceptedAndReady: ReviewRow[] = [
   {
     id: '8',
-    title: '[xds][StatusDot] Add isPulsing animation support',
+    title: '[astryx][StatusDot] Add isPulsing animation support',
     prId: 'PR-1048',
     lines: 22,
     reviewTime: '<30sec review',
@@ -173,7 +173,7 @@ const acceptedAndReady: ReviewRow[] = [
   },
   {
     id: '9',
-    title: '[xds][Card] Add isFullBleed prop for edge-to-edge content',
+    title: '[astryx][Card] Add isFullBleed prop for edge-to-edge content',
     prId: 'PR-1051',
     lines: 15,
     reviewTime: '<20sec review',

--- a/apps/sandbox/src/app/layout.tsx
+++ b/apps/sandbox/src/app/layout.tsx
@@ -5,8 +5,8 @@ import './globals.css';
 import {Providers} from './providers';
 
 export const metadata: Metadata = {
-  title: 'XDS Sandbox',
-  description: 'XDS component testing sandbox',
+  title: 'Astryx Sandbox',
+  description: 'Astryx component testing sandbox',
 };
 
 export default function RootLayout({children}: {children: React.ReactNode}) {

--- a/apps/sandbox/src/app/sandboxPages.ts
+++ b/apps/sandbox/src/app/sandboxPages.ts
@@ -54,7 +54,7 @@ export const categories: SandboxCategory[] = [
       {
         name: 'Card Examples',
         href: '/pages/example-cards/',
-        description: 'XDS components showcased in realistic card compositions',
+        description: 'Astryx components showcased in realistic card compositions',
       },
       {
         name: 'Table Overview',
@@ -103,7 +103,7 @@ export const categories: SandboxCategory[] = [
     label: 'Templates',
     slug: 'templates',
     description:
-      'Full-page application templates — dashboards, forms, and data views built with XDS.',
+      'Full-page application templates — dashboards, forms, and data views built with Astryx.',
     pages: [
       ...autoDiscoveredTemplates.map(t => ({
         name: t.name,
@@ -158,7 +158,7 @@ export const categories: SandboxCategory[] = [
   {
     label: 'Tools',
     slug: 'tools',
-    description: 'Interactive tools for building and exploring XDS components.',
+    description: 'Interactive tools for building and exploring Astryx components.',
     pages: [
       {
         name: 'CodeBlock Perf',

--- a/apps/sandbox/src/components/ThemePalettePreview.tsx
+++ b/apps/sandbox/src/components/ThemePalettePreview.tsx
@@ -300,7 +300,7 @@ export interface CoreSwatch {
 }
 
 export interface ThemePalettePreviewProps {
-  /** The XDS theme object */
+  /** The Astryx theme object */
   theme: DefinedTheme;
   /** Theme display name for the page title */
   title: string;

--- a/apps/sandbox/src/components/themePreview/ThemeAuditDrawer.tsx
+++ b/apps/sandbox/src/components/themePreview/ThemeAuditDrawer.tsx
@@ -25,9 +25,9 @@
 import {useEffect, useMemo, useReducer, useRef, useState} from 'react';
 import type {DefinedTheme} from '@astryxdesign/core/theme';
 
-// XDS components — used in the editor popover, export dialog, and the
+// Astryx components — used in the editor popover, export dialog, and the
 // row trigger so the audit drawer's interactive surfaces stay
-// consistent with the rest of XDS instead of a hand-rolled clone of
+// consistent with the rest of Astryx instead of a hand-rolled clone of
 // each one.
 import {Popover} from '@astryxdesign/core/Popover';
 import {TabList, Tab} from '@astryxdesign/core/TabList';
@@ -343,7 +343,7 @@ const S = {
   // present (even when default === current) so the row geometry is
   // consistent and you can sanity-check the original value at a glance.
   //
-  // When the token has no XDS default (theme-only addition), the caller
+  // When the token has no Astryx default (theme-only addition), the caller
   // passes `transparent` and we lay a faint diagonal-stripe pattern on
   // top so the empty slot reads as "no default exists" rather than a
   // glitched render.
@@ -492,7 +492,7 @@ export function ThemeAuditDrawer({
   };
 
   // Pre-bucket tokens into the docsite categories. We pass the *union*
-  // of every color token the audit knows about (theme-defined + XDS
+  // of every color token the audit knows about (theme-defined + Astryx
   // defaults) so anything not covered by the curated categories falls
   // into the trailing "Other Colors" / "Syntax Highlighting" buckets
   // instead of being silently hidden.
@@ -699,7 +699,7 @@ function ColorRow({
     ? composeAlphaHex(activeHexBase, activeAlpha)
     : '';
 
-  // Resolve the XDS-default value for this token in the active mode.
+  // Resolve the Astryx-default value for this token in the active mode.
   // Always rendered as the leftmost square so the row geometry is
   // consistent across the table, even when default === current. The
   // default's own alpha is layered back on so the comparison swatch
@@ -763,8 +763,8 @@ function ColorRow({
           style={S.originalSwatch(defaultHexWithAlpha ?? 'transparent')}
           title={
             defaultHexWithAlpha
-              ? `Original (XDS default): ${formatHexWithAlpha(defaultHexBase ?? '#000000', defaultAlpha)}`
-              : 'No XDS default — token added by theme'
+              ? `Original (Astryx default): ${formatHexWithAlpha(defaultHexBase ?? '#000000', defaultAlpha)}`
+              : 'No Astryx default — token added by theme'
           }
           aria-label={
             defaultHexWithAlpha

--- a/apps/sandbox/src/components/themePreview/themeAudit.ts
+++ b/apps/sandbox/src/components/themePreview/themeAudit.ts
@@ -6,7 +6,7 @@
  * Two questions this module answers, both painful to eyeball from raw
  * theme source files:
  *
- *   1. "Which tokens did this theme actually change vs the XDS defaults?"
+ *   1. "Which tokens did this theme actually change vs the Astryx defaults?"
  *      — diff `theme.tokens` against `xdsTokenDefaults` and bucket each
  *        entry as unchanged / overridden / new.
  *

--- a/packages/build/src/next.js
+++ b/packages/build/src/next.js
@@ -8,8 +8,8 @@
  * Next.js configuration helper for Astryx source builds.
  *
  * Usage in next.config.mjs:
- *   import {withXDS} from '@astryxdesign/build/next';
- *   export default withXDS({
+ *   import {withAstryx} from '@astryxdesign/build/next';
+ *   export default withAstryx({
  *     // your normal next config
  *   });
  */
@@ -19,15 +19,15 @@
  * - Adds transpilePackages for @astryxdesign/* packages
  * - Sets conditionNames to resolve source exports
  */
-function withXDS(nextConfig = {}) {
-  const xdsPackages = [
+function withAstryx(nextConfig = {}) {
+  const astryxPackages = [
     '@astryxdesign/core',
     '@astryxdesign/theme-neutral',
     '@astryxdesign/lab',
   ];
 
   const existingTranspile = nextConfig.transpilePackages || [];
-  const merged = Array.from(new Set([...existingTranspile, ...xdsPackages]));
+  const merged = Array.from(new Set([...existingTranspile, ...astryxPackages]));
 
   const existingWebpack = nextConfig.webpack;
 
@@ -60,4 +60,4 @@ function withXDS(nextConfig = {}) {
   };
 }
 
-module.exports = {withXDS};
+module.exports = {withAstryx};


### PR DESCRIPTION
Knots: `scrub-sandbox-misc`.

**Sandbox app** (23 files): demo page content (`'XDS Core'`/`'XDS Team'` → Astryx), product-name prose, stale GitHub URLs, mock data task titles, README.

**`@astryxdesign/build` public export**: `withXDS` → `withAstryx` (the Next.js configuration wrapper from `@astryxdesign/build/next`). Changeset: `[breaking]` patch.

**Consumers**: `apps/sandbox` + `apps/example-nextjs-source` `next.config.mjs`.

Left alone: `xdsTokenDefaults` (still a real `@astryxdesign/core` export — separate rename task).