### PR TITLE
fix(cli): standalone page templates fill the viewport (100dvh, not 100%)

### DIFF
--- a/.changeset/template-full-height.md
+++ b/.changeset/template-full-height.md
@@ -1,0 +1,14 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[fix] Standalone page templates fill the viewport (`100dvh`, not `100%`)
+
+The login family (`login`, `login-card`, `login-sso`, `login-split`),
+`form-two-column`, and `theme-showcase` painted their page background with
+`minHeight: '100%'`, which collapses to content height unless the consumer sets
+`html`/`body`/`#root` height — leaving an unpainted band below the content when
+scaffolded into a plain app. Switched to `100dvh` so a standalone page fills the
+viewport on its own. (`ai-chat-landing` keeps `100%`: it fills a `Layout`
+content area that already has height.)
+@joeyfarina

--- a/packages/cli/templates/pages/form-two-column/page.tsx
+++ b/packages/cli/templates/pages/form-two-column/page.tsx
@@ -50,7 +50,7 @@ const CONTACT_COLUMNS = [
 // (#2582), so the cover photo is styled directly. overflow:hidden masks the
 // cover crop to the rounded corners.
 const pageStyle: CSSProperties = {
-  minHeight: '100%',
+  minHeight: '100dvh',
 };
 const illustrationImg: CSSProperties = {
   width: '100%',

--- a/packages/cli/templates/pages/login-card/page.tsx
+++ b/packages/cli/templates/pages/login-card/page.tsx
@@ -56,7 +56,7 @@ const GoogleIcon = (props: React.SVGProps<SVGSVGElement>) => (
 
 // Standalone auth page paints its own body background (no host shell).
 const pageStyle: CSSProperties = {
-  minHeight: '100%',
+  minHeight: '100dvh',
   backgroundColor: 'var(--color-background-body)',
   padding: 'var(--spacing-6)',
 };

--- a/packages/cli/templates/pages/login-split/page.tsx
+++ b/packages/cli/templates/pages/login-split/page.tsx
@@ -35,7 +35,7 @@ const COLUMN_MIN_WIDTH = 240;
 // minHeight:100% fills the host so the centered card never leaves an unpainted
 // band; padding keeps it off the surface edges.
 const pageStyle: CSSProperties = {
-  minHeight: '100%',
+  minHeight: '100dvh',
   backgroundColor: 'var(--color-background-body)',
   padding: 'var(--spacing-6)',
 };

--- a/packages/cli/templates/pages/login-sso/page.tsx
+++ b/packages/cli/templates/pages/login-sso/page.tsx
@@ -23,7 +23,7 @@ import {Avatar} from '@astryxdesign/core/Avatar';
 const BG_URL = 'https://lookaside.facebook.com/assets/astryx/building.png';
 
 const pageStyle: CSSProperties = {
-  minHeight: '100%',
+  minHeight: '100dvh',
   backgroundImage: `url(${BG_URL})`,
   backgroundSize: 'cover',
   backgroundPosition: 'center',

--- a/packages/cli/templates/pages/login/page.tsx
+++ b/packages/cli/templates/pages/login/page.tsx
@@ -15,7 +15,7 @@ import {CubeIcon} from '@heroicons/react/24/outline';
 
 // Standalone auth page paints its own body background (no host shell).
 const pageStyle: CSSProperties = {
-  minHeight: '100%',
+  minHeight: '100dvh',
   backgroundColor: 'var(--color-background-body)',
   padding: 'var(--spacing-6)',
 };

--- a/packages/cli/templates/pages/theme-showcase/page.tsx
+++ b/packages/cli/templates/pages/theme-showcase/page.tsx
@@ -324,7 +324,7 @@ export function ThemeShowcaseStore({
   return (
     <div
       style={{
-        minHeight: '100%',
+        minHeight: '100dvh',
         backgroundColor: 'var(--color-background-body)',
       }}>
       <StorePreview images={images} products={products} isMobile={isMobile} />


### PR DESCRIPTION
## Summary
Six standalone page templates painted their page background with `minHeight: '100%'`:
`login`, `login-card`, `login-sso`, `login-split`, `form-two-column`, and `theme-showcase`.
`100%` only resolves against an ancestor with an explicit height, but the reset sets no
`height` on `html`/`body`/`#root` — so when scaffolded into a plain app the background
**collapses to content height**, leaving an unpainted band below the content (a visible
grey-then-white split on short pages like login). Switched these to `100dvh` so a
standalone page fills the viewport on its own.

`ai-chat-landing` intentionally keeps `100%` — its `minHeight` is on content inside a
`<Layout>` that already has height, so `100%` is correct there.

## Why
Surfaced by vibe-testing: an agent scaffolded `login-card` faithfully and shipped a
half-painted page (typecheck + build both pass — a runtime/layout bug the gates can't
see). The `minHeight: '100%'` came straight from the template, so it propagated to every
page built from the login family.

## Test plan
- [ ] Scaffold `login-card` into a plain Vite app and confirm the themed background now
      fills the viewport (no white band) on a short viewport.
- [ ] `ai-chat-landing` still renders correctly (unchanged).
- [ ] `pnpm check:changesets` passes.


Made with [Cursor](https://cursor.com)