### PR TITLE
feat(docsite): add command palette shortcut

### DIFF
--- a/apps/docsite/src/__tests__/search-palette.test.ts
+++ b/apps/docsite/src/__tests__/search-palette.test.ts
@@ -65,4 +65,14 @@ describe('SearchPalette data', () => {
       '/components/DropdownMenu',
     );
   });
+
+  it('finds AppShell when searching for app shell with a space', () => {
+    const items = buildItems();
+    const appShell = items.find(item => item.id === '/components/AppShell');
+    expect(appShell?.label).toBe('App Shell');
+
+    expect(searchItems('app shell').map(item => item.id)).toContain(
+      '/components/AppShell',
+    );
+  });
 });

--- a/apps/docsite/src/components/SharedTopNav.tsx
+++ b/apps/docsite/src/components/SharedTopNav.tsx
@@ -2,7 +2,7 @@
 
 'use client';
 
-import {useState} from 'react';
+import {useEffect, useState} from 'react';
 import {usePathname} from 'next/navigation';
 import {TopNav, TopNavHeading, TopNavItem} from '@astryxdesign/core/TopNav';
 import {Button} from '@astryxdesign/core/Button';
@@ -39,6 +39,27 @@ export function SharedTopNav() {
   const [isSearchOpen, setIsSearchOpen] = useState(false);
   const pathname = usePathname();
   const {mode, toggleMode} = useThemeMode();
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented) {
+        return;
+      }
+      if (
+        (event.metaKey || event.ctrlKey) &&
+        !event.shiftKey &&
+        !event.altKey &&
+        event.key.toLowerCase() === 'k'
+      ) {
+        event.preventDefault();
+        trackSearch({target: 'open'});
+        setIsSearchOpen(true);
+      }
+    };
+
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, []);
 
   // Determine active nav item
   const getActiveItem = () => {

--- a/apps/docsite/src/components/searchPaletteData.ts
+++ b/apps/docsite/src/components/searchPaletteData.ts
@@ -29,8 +29,19 @@ function uniqueKeywords(keywords: Array<string | null | undefined>): string[] {
   return [...new Set(keywords.filter((kw): kw is string => Boolean(kw)))];
 }
 
+function splitWords(value: string): string {
+  return value.replace(/([a-z0-9])([A-Z])/g, '$1 $2').replace(/[_-]+/g, ' ');
+}
+
 export function getSearchItemKeywords(item: SearchItem): string[] {
-  return [item.auxiliaryData.group, ...item.auxiliaryData.keywords];
+  return [
+    item.auxiliaryData.group,
+    splitWords(item.label),
+    ...item.auxiliaryData.keywords.flatMap(keyword => [
+      keyword,
+      splitWords(keyword),
+    ]),
+  ];
 }
 
 export function buildSearchPaletteItems({
@@ -73,7 +84,9 @@ export function buildSearchPaletteItems({
     // Neutral as the default seed; users browse to the specific
     // theme they want via the sidebar picker.
     items.push({
-      id: isTheme ? '/themes' : `/docs/${pkg.name.replace('@astryxdesign/', '')}`,
+      id: isTheme
+        ? '/themes'
+        : `/docs/${pkg.name.replace('@astryxdesign/', '')}`,
       label: pkg.displayName,
       auxiliaryData: {
         group: 'Package',


### PR DESCRIPTION
## Summary
- wire Cmd/Ctrl+K to open the docsite search palette from the public/marketing nav
- expand search keywords with split PascalCase terms so `app shell` matches the App Shell component
- add regression coverage for AppShell spaced search

## Test plan
- `pnpm -F @astryxdesign/docsite test -- --run src/__tests__/search-palette.test.ts`
- `pnpm exec eslint apps/docsite/src/components/SharedTopNav.tsx apps/docsite/src/components/searchPaletteData.ts apps/docsite/src/__tests__/search-palette.test.ts --cache=false`

## Notes
- `pnpm -F @astryxdesign/docsite typecheck` currently fails because theme package `/built` modules are not built in the fresh worktree.