### PR TITLE
fix(cli): make `npx astryx` work when installed as a real package

### DIFF
--- a/.changeset/cli-bin-symlink-resolution.md
+++ b/.changeset/cli-bin-symlink-resolution.md
@@ -1,0 +1,13 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[fix] `npx astryx` now works when the CLI is installed as a real npm package.
+The bin imported its `../src/*` modules relative to the invoked path, so running
+through the `node_modules/.bin/astryx` symlink made them resolve outside the
+package (`ERR_MODULE_NOT_FOUND: .../node_modules/src/...`) on Node versions that
+don't realpath the bin entry. It now resolves siblings via the bin's real path
+(realpath of `import.meta.url`), working whether invoked via symlink, copy, or
+Windows shim. Also fixes the non-interactive `init`/`theme` error to say
+`astryx <command>` instead of the stale `xds <command>`.
+@josephfarina

--- a/packages/cli/bin/astryx.mjs
+++ b/packages/cli/bin/astryx.mjs
@@ -12,10 +12,25 @@
 //
 // `node-version.mjs` is intentionally dependency-free so it loads on the
 // unsupported runtimes this guard protects against.
-import {
-  isNodeVersionSupported,
-  unsupportedNodeMessage,
-} from '../src/lib/node-version.mjs';
+//
+// Sibling `src/` modules are resolved by this bin's REAL path. When the CLI is
+// installed as a package, `npx astryx` runs this file through the
+// `node_modules/.bin/astryx` symlink, and some Node versions resolve relative
+// specifiers from the symlink's directory (→ `node_modules/src/...`) rather
+// than the real package — breaking bare `../src/...` imports with a cryptic
+// ERR_MODULE_NOT_FOUND. realpath-ing `import.meta.url` makes these imports
+// resolve correctly however the bin is invoked (symlink, copy, or Windows
+// shim). Uses only built-ins, so the version gate below still runs first.
+import {fileURLToPath, pathToFileURL} from 'node:url';
+import {realpathSync} from 'node:fs';
+import {dirname, join} from 'node:path';
+
+const binDir = dirname(realpathSync(fileURLToPath(import.meta.url)));
+const importSrc = rel =>
+  import(pathToFileURL(join(binDir, '..', 'src', rel)).href);
+
+const {isNodeVersionSupported, unsupportedNodeMessage} =
+  await importSrc('lib/node-version.mjs');
 
 if (!isNodeVersionSupported(process.versions.node)) {
   const msg = unsupportedNodeMessage(process.versions.node);
@@ -39,9 +54,9 @@ if (!isNodeVersionSupported(process.versions.node)) {
 
 // Imports that transitively load `styleText` must happen AFTER the gate above,
 // so they are dynamically imported here rather than at the top of the module.
-const {program} = await import('../src/index.mjs');
-const {isJsonMode, toErrorEnvelope} = await import('../src/lib/json.mjs');
-const {handleCommanderError} = await import('../src/lib/json-shim.mjs');
+const {program} = await importSrc('index.mjs');
+const {isJsonMode, toErrorEnvelope} = await importSrc('lib/json.mjs');
+const {handleCommanderError} = await importSrc('lib/json-shim.mjs');
 
 /**
  * Top-level error boundary (contract guarantee #4): an uncaught throw must

--- a/packages/cli/src/utils/interactive.mjs
+++ b/packages/cli/src/utils/interactive.mjs
@@ -60,7 +60,7 @@ export function isInteractive({
  */
 export function requireInteractive({command, hint, json = false} = {}, env) {
   if (isInteractive(env)) return;
-  const name = command ? `xds ${command}` : 'this command';
+  const name = command ? `astryx ${command}` : 'this command';
   console.error(
     `Error: \`${name}\` with no flags is interactive and requires a TTY.`,
   );

--- a/packages/cli/src/utils/interactive.test.mjs
+++ b/packages/cli/src/utils/interactive.test.mjs
@@ -64,5 +64,7 @@ describe('requireInteractive', () => {
     const output = err.mock.calls.map(c => c.join(' ')).join('\n');
     expect(output).toMatch(/requires a TTY/i);
     expect(output).toMatch(/astryx theme <preset>/);
+    expect(output).toMatch(/`astryx theme`/);
+    expect(output).not.toMatch(/\bxds\b/);
   });
 });


### PR DESCRIPTION
## Why

`npx astryx <cmd>` — the documented entry point — **throws on a normal install**:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../node_modules/src/lib/node-version.mjs'
imported from .../node_modules/.bin/astryx
```

`bin/astryx.mjs` imports its siblings with bare relative specifiers (`../src/...`). When the CLI is installed as a package and run via the `node_modules/.bin/astryx` symlink, Node (on versions that don't realpath the bin entry — reproduced on Node 25) resolves those relative to the symlink's directory → `node_modules/src/...`, which doesn't exist. This was masked in our own dogfooding because we directory-linked the package (which happens to resolve), so it only bites real consumers who `npm install @astryxdesign/cli`.

## What

- Resolve sibling `src/` modules via the bin's **real path** (`realpath(import.meta.url)`) instead of bare relative imports. Works whether the bin is invoked via symlink, a plain copy, or a Windows shim. The Node-version preflight gate still runs first (built-ins only, then the dependency-free `node-version.mjs`).
- Drop the stale `xds <command>` branding in the non-interactive `init`/`theme` error → `astryx <command>`.

## Test plan

- [x] **Proved against a real tarball install**: `npm pack` the CLI, install the `.tgz` into a fresh project, and `npx astryx component --list` / `init --all` — both fail before this change, both pass after.
- [x] `interactive.test.mjs` updated with a regression guard (`/\bxds\b/` must not appear); 6/6 pass.
- [x] `node --check bin/astryx.mjs`; ESLint clean.
- [x] Full CLI suite: 1412/1414 pass. The 2 failures (`import-hint-correctness` for `Theme`/`Layout --detail brief`) are **pre-existing on `main`** (verified by re-running with these changes stashed) and unrelated to this PR.

Made with [Cursor](https://cursor.com)