### PR TITLE
fix(AvatarGroup): forward rest props in AvatarGroupOverflow

### DIFF
--- a/.changeset/avatar-group-overflow-rest-props.md
+++ b/.changeset/avatar-group-overflow-rest-props.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] AvatarGroupOverflow now forwards rest props (data-_, aria-_, event handlers, id, role, tabIndex) to the rendered element, matching the behavior of Avatar and AvatarGroup.
+
+@cixzhang

--- a/packages/core/src/AvatarGroup/AvatarGroupOverflow.tsx
+++ b/packages/core/src/AvatarGroup/AvatarGroupOverflow.tsx
@@ -132,6 +132,7 @@ export function AvatarGroupOverflow({
   xstyle,
   className,
   style,
+  ...rest
 }: AvatarGroupOverflowProps): ReactNode {
   const group = useAvatarGroup();
   const numericSize = group?.numericSize ?? 36;
@@ -147,6 +148,7 @@ export function AvatarGroupOverflow({
         type="button"
         onClick={onClick}
         aria-label={label}
+        {...rest}
         {...mergeProps(
           themeProps('avatar-group-overflow'),
           stylex.props(
@@ -170,6 +172,7 @@ export function AvatarGroupOverflow({
     <span
       ref={ref}
       aria-label={label}
+      {...rest}
       {...mergeProps(
         themeProps('avatar-group-overflow'),
         stylex.props(


### PR DESCRIPTION
AvatarGroupOverflow destructured a fixed set of props without a rest spread, silently dropping BaseProps attributes that consumers pass (event handlers, aria-*, data-*, role, tabIndex, id). Avatar and AvatarGroup both forward rest props; this brings AvatarGroupOverflow into alignment.

The `...rest` spread is placed before the `mergeProps` result so that mergeProps-computed className/style take priority over any className/style in rest (which would be unusual but shouldn't clobber the component's own styling).

## Audited components (no other findings)

- AlertDialog
- AppShell
- AspectRatio
- Avatar
- AvatarGroup

## Notes

- Avatar uses an inline SVG for the default person icon (not `Icon` from the registry) because it needs proportional sizing (`size * 0.6`) that doesn't map to Icon's fixed size tiers. This is intentional.
- Avatar and AvatarGroup both manually declare `'data-testid'?: string` despite BaseProps covering it via the `data-*` index signature. This aids IDE discoverability and is fine.

Night Watch — Component Auditor
