### PR TITLE
fix(core): never render <p> by default; render <div> for composition safety

### DIFF
--- a/.changeset/no-default-paragraph-element.md
+++ b/.changeset/no-default-paragraph-element.md
@@ -2,30 +2,5 @@
 '@astryxdesign/core': patch
 ---
 
-[fix] Core components no longer render a `<p>` element by default
+[fix] Core components (`Banner`, `EmptyState`, `Markdown`) no longer render a `<p>` by default — they render `<div>` (appearance unchanged). This avoids hydration mismatches when block content lands in a `<p>`. `Markdown` paragraphs use `role="paragraph"`; pass `components={{paragraph: 'p'}}` to opt back into `<p>`.
 @cixzhang
-
-`<p>` is phrasing-content-only in HTML — it cannot legally contain block-level
-children (`<div>`, popovers/layers, block images, etc.). When block content
-lands inside a `<p>`, the HTML parser reparents it and closes the `<p>` early,
-so server-rendered markup and the hydrated DOM disagree and React reports a
-hydration mismatch. Because components accept arbitrary content into their text
-slots, any component that emits a `<p>` can be handed block content and break.
-
-Affected components now render `<div>` (styled to preserve the previous
-appearance — margins and typography were already set explicitly, so the visual
-result is unchanged):
-
-- `Banner` — `title` and `description` slots.
-- `EmptyState` — `description` slot.
-- `Markdown` — rendered paragraphs and image blocks. A markdown paragraph maps
-  to a block `<div role="paragraph">` rather than `<p>`; the role re-exposes
-  paragraph semantics to assistive tech without the `<p>` composition hazard,
-  and spacing already comes from tokens. Pass `components={{paragraph: 'p'}}`
-  to render a real `<p>` element instead.
-
-`Text` is unaffected — it already defaults to `<span>` and keeps `as="p"` as an
-opt-in. No public API changes: this only changes the default rendered element.
-Consumers who relied on a `<p>` tag (for example CSS selectors targeting `p`
-inside these components) should update their selectors or opt in to `<p>` where
-an override exists.

--- a/.changeset/no-default-paragraph-element.md
+++ b/.changeset/no-default-paragraph-element.md
@@ -1,0 +1,29 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Core components no longer render a `<p>` element by default
+@cixzhang
+
+`<p>` is phrasing-content-only in HTML — it cannot legally contain block-level
+children (`<div>`, popovers/layers, block images, etc.). When block content
+lands inside a `<p>`, the HTML parser reparents it and closes the `<p>` early,
+so server-rendered markup and the hydrated DOM disagree and React reports a
+hydration mismatch. Because components accept arbitrary content into their text
+slots, any component that emits a `<p>` can be handed block content and break.
+
+Affected components now render `<div>` (styled to preserve the previous
+appearance — margins and typography were already set explicitly, so the visual
+result is unchanged):
+
+- `Banner` — `title` and `description` slots.
+- `EmptyState` — `description` slot.
+- `Markdown` — rendered paragraphs and image blocks. A markdown paragraph maps
+  to a block `<div>` rather than `<p>`; spacing already comes from tokens. Pass
+  `components={{paragraph: 'p'}}` to opt back into `<p>` semantics.
+
+`Text` is unaffected — it already defaults to `<span>` and keeps `as="p"` as an
+opt-in. No public API changes: this only changes the default rendered element.
+Consumers who relied on a `<p>` tag (for example CSS selectors targeting `p`
+inside these components) should update their selectors or opt in to `<p>` where
+an override exists.

--- a/.changeset/no-default-paragraph-element.md
+++ b/.changeset/no-default-paragraph-element.md
@@ -19,8 +19,10 @@ result is unchanged):
 - `Banner` — `title` and `description` slots.
 - `EmptyState` — `description` slot.
 - `Markdown` — rendered paragraphs and image blocks. A markdown paragraph maps
-  to a block `<div>` rather than `<p>`; spacing already comes from tokens. Pass
-  `components={{paragraph: 'p'}}` to opt back into `<p>` semantics.
+  to a block `<div role="paragraph">` rather than `<p>`; the role re-exposes
+  paragraph semantics to assistive tech without the `<p>` composition hazard,
+  and spacing already comes from tokens. Pass `components={{paragraph: 'p'}}`
+  to render a real `<p>` element instead.
 
 `Text` is unaffected — it already defaults to `<span>` and keeps `as="p"` as an
 opt-in. No public API changes: this only changes the default rendered element.

--- a/internal/eslint-plugin-astryx/index.js
+++ b/internal/eslint-plugin-astryx/index.js
@@ -8,6 +8,7 @@
  * - no-hardcoded-styles: Enforces usage of design tokens instead of hardcoded values in StyleX
  * - boolean-prop-naming: Enforces is/has prefix on boolean props in *Props interfaces
  * - docblock-example-format: Enforces @example blocks use ``` fenced code on a separate line
+ * - no-raw-paragraph: Disallows components from rendering a <p> by default (render <div> so any content composes)
  *
  * Philosophy: Strict for agents (CI), lenient for humans (local dev)
  * - "strict" config: All rules as errors - use in CI/agent environments
@@ -21,6 +22,7 @@ import noStylexNullOverrideRule from './no-stylex-null-override.js';
 import noReactIntrospectionRule from './no-react-introspection.js';
 import noClassnameClobberRule from './no-classname-clobber.js';
 import noHardcodedAnchorRule from './no-hardcoded-anchor.js';
+import noRawParagraphRule from './no-raw-paragraph.js';
 import noBorderShorthandRule from './no-border-shorthand.js';
 import noReactNamespaceHooksRule from './no-react-namespace-hooks.js';
 import copyrightHeaderRule from './copyright-header.js';
@@ -234,6 +236,7 @@ const plugin = {
     'no-react-introspection': noReactIntrospectionRule,
     'no-classname-clobber': noClassnameClobberRule,
     'no-hardcoded-anchor': noHardcodedAnchorRule,
+    'no-raw-paragraph': noRawParagraphRule,
     'no-border-shorthand': noBorderShorthandRule,
     'no-react-namespace-hooks': noReactNamespaceHooksRule,
     'require-base-props': requireBasePropsRule,
@@ -258,6 +261,7 @@ plugin.configs.strict = {
     '@astryx/no-react-introspection': 'error',
     '@astryx/no-classname-clobber': 'error',
     '@astryx/no-hardcoded-anchor': 'error',
+    '@astryx/no-raw-paragraph': 'error',
     '@astryx/no-border-shorthand': 'error',
     '@astryx/no-react-namespace-hooks': 'error',
     '@astryx/require-base-props': 'error',
@@ -280,6 +284,7 @@ plugin.configs.recommended = {
     '@astryx/no-react-introspection': 'error',
     '@astryx/no-classname-clobber': 'error',
     '@astryx/no-hardcoded-anchor': 'warn',
+    '@astryx/no-raw-paragraph': 'warn',
     '@astryx/no-border-shorthand': 'warn',
     '@astryx/no-react-namespace-hooks': 'error',
     '@astryx/require-base-props': 'warn',

--- a/internal/eslint-plugin-astryx/no-raw-paragraph.js
+++ b/internal/eslint-plugin-astryx/no-raw-paragraph.js
@@ -1,0 +1,146 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file no-raw-paragraph.js
+ * @description Disallow Astryx components from rendering a `<p>` by default.
+ *
+ * `<p>` is phrasing-content-only in HTML: it cannot legally contain
+ * block-level children (`<div>`, layers, popovers, images-as-blocks, etc.).
+ * When a block element ends up inside a `<p>`, the HTML parser silently
+ * reparents it and closes the `<p>` early. Server-rendered markup and the
+ * browser-parsed DOM then disagree, producing React hydration mismatches.
+ *
+ * Astryx components accept arbitrary `ReactNode` content into their slots, so
+ * any component that emits a `<p>` can be handed block content and break. The
+ * enforceable fix on our side: Astryx's own components never emit a `<p>` by
+ * default. They render `<div>` (styled to preserve appearance) instead, which
+ * can contain anything. Consumers who genuinely want paragraph semantics opt
+ * in explicitly (a raw `<p>` they own, or a component override such as
+ * Markdown's `components={{paragraph: 'p'}}`), and they own the composition
+ * consequences.
+ *
+ * This rule flags two patterns in Astryx source:
+ *   1. A raw `<p>` JSX element.
+ *   2. An element-type prop whose DEFAULT resolves to `'p'`, e.g.
+ *      `as: Component = 'p'` or `const Tag = as ?? 'p'`.
+ *
+ * It does NOT forbid `'p'` as an opt-in value (e.g. `as="p"` passed by a
+ * consumer, or `'p'` appearing in an `as?: ... | 'p' | ...` union type) — only
+ * Astryx defaulting to `<p>` on its own.
+ *
+ * Bad:
+ *   <p {...stylex.props(styles.description)}>{description}</p>
+ *   function Text({as: Component = 'p'}) { ... }
+ *
+ * Good:
+ *   <div {...stylex.props(styles.description)}>{description}</div>
+ *   function Text({as: Component = 'div'}) { ... }   // 'p' still allowed via prop
+ */
+
+const rule = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Disallow Astryx components from rendering a <p> by default — render <div> so any content composes without hydration mismatches',
+      category: 'Best Practices',
+      recommended: true,
+    },
+    messages: {
+      rawParagraph:
+        'Astryx components must not render a <p> by default. <p> cannot contain ' +
+        'block-level children, so block content nested inside it triggers React ' +
+        'hydration mismatches. Render <div> instead (style margin/line-height to ' +
+        'preserve appearance). Consumers who want paragraph semantics can opt in.',
+      defaultParagraph:
+        'Element-type prop defaults to "p". Astryx components must not default to ' +
+        'rendering a <p> (it cannot contain block children — see hydration mismatch). ' +
+        'Default to "div" and keep "p" as an opt-in value consumers can pass.',
+    },
+    schema: [],
+  },
+  create(context) {
+    const filename = context.filename;
+
+    // Skip non-source files.
+    if (filename.includes('.test.') || filename.includes('.stories.')) {
+      return {};
+    }
+
+    /**
+     * Is this assignment pattern an element-type prop (`as` / `component`)
+     * that defaults to the literal 'p'?
+     */
+    function isElementTypeDefaultToP(pattern) {
+      if (pattern.type !== 'AssignmentPattern') {
+        return false;
+      }
+      // Default value must be the string literal 'p'.
+      const right = pattern.right;
+      if (right?.type !== 'Literal' || right.value !== 'p') {
+        return false;
+      }
+      // Left side names an element-type prop. Covers both:
+      //   {as = 'p'}            -> Identifier 'as'
+      //   {as: Component = 'p'} -> handled at the Property level (see below)
+      const left = pattern.left;
+      if (left?.type === 'Identifier') {
+        return /^(as|component|tag|element)$/i.test(left.name);
+      }
+      return false;
+    }
+
+    return {
+      JSXOpeningElement(node) {
+        if (node.name?.type === 'JSXIdentifier' && node.name.name === 'p') {
+          context.report({node, messageId: 'rawParagraph'});
+        }
+      },
+
+      // `{as = 'p'}` — shorthand destructured prop with default.
+      AssignmentPattern(node) {
+        if (isElementTypeDefaultToP(node)) {
+          context.report({node, messageId: 'defaultParagraph'});
+        }
+      },
+
+      // `{as: Component = 'p'}` — renamed destructured prop with default.
+      Property(node) {
+        if (
+          node.value?.type === 'AssignmentPattern' &&
+          node.value.right?.type === 'Literal' &&
+          node.value.right.value === 'p'
+        ) {
+          const key = node.key;
+          const keyName =
+            key?.type === 'Identifier'
+              ? key.name
+              : key?.type === 'Literal'
+                ? String(key.value)
+                : '';
+          if (/^(as|component|tag|element)$/i.test(keyName)) {
+            context.report({
+              node: node.value.right,
+              messageId: 'defaultParagraph',
+            });
+          }
+        }
+      },
+
+      // `const Tag = as ?? 'p'` / `as || 'p'` — defaulting via fallback expr.
+      LogicalExpression(node) {
+        if (
+          (node.operator === '??' || node.operator === '||') &&
+          node.right?.type === 'Literal' &&
+          node.right.value === 'p' &&
+          node.left?.type === 'Identifier' &&
+          /^(as|component|tag|element)$/i.test(node.left.name)
+        ) {
+          context.report({node: node.right, messageId: 'defaultParagraph'});
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/internal/eslint-plugin-astryx/no-raw-paragraph.test.mjs
+++ b/internal/eslint-plugin-astryx/no-raw-paragraph.test.mjs
@@ -1,0 +1,74 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file no-raw-paragraph.test.mjs
+ * @description Tests for the no-raw-paragraph ESLint rule.
+ */
+
+import {describe, it} from 'vitest';
+import {RuleTester} from 'eslint';
+import tseslint from 'typescript-eslint';
+import noRawParagraphRule from './no-raw-paragraph.js';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parser: tseslint.parser,
+    parserOptions: {
+      ecmaFeatures: {jsx: true},
+    },
+  },
+});
+
+describe('no-raw-paragraph', () => {
+  it('passes the RuleTester', () => {
+    ruleTester.run('no-raw-paragraph', noRawParagraphRule, {
+      valid: [
+        // <div> is the compositional default we want.
+        {code: '<div>{children}</div>'},
+        // Other phrasing/block elements are unaffected.
+        {code: '<span>{text}</span>'},
+        {code: '<section>{children}</section>'},
+        // `as` defaulting to 'div' is correct.
+        {code: 'function C({as: Component = "div"}) { return <Component/>; }'},
+        {code: 'function C({as = "div"}) { return null; }'},
+        // 'p' as an opt-in value (not a default) is allowed: it appears only
+        // in the type union, never as the default the component renders.
+        {code: 'const Tag = as ?? "div";'},
+        {code: 'const Tag = as || "div";'},
+        // A consumer passing as="p" is their choice — not flagged here (this
+        // rule guards Astryx source defaults, not prop usage call sites).
+        {code: '<Text as="p">{text}</Text>'},
+      ],
+      invalid: [
+        // Raw <p> JSX.
+        {
+          code: '<p {...props}>{children}</p>',
+          errors: [{messageId: 'rawParagraph'}],
+        },
+        {
+          code: '<p>text</p>',
+          errors: [{messageId: 'rawParagraph'}],
+        },
+        // `as` prop defaulting to 'p' (renamed).
+        {
+          code: 'function C({as: Component = "p"}) { return <Component/>; }',
+          errors: [{messageId: 'defaultParagraph'}],
+        },
+        // `as` prop defaulting to 'p' (shorthand).
+        {
+          code: 'function C({as = "p"}) { return null; }',
+          errors: [{messageId: 'defaultParagraph'}],
+        },
+        // Defaulting via nullish/or fallback expression.
+        {
+          code: 'const Tag = as ?? "p";',
+          errors: [{messageId: 'defaultParagraph'}],
+        },
+        {
+          code: 'const Tag = as || "p";',
+          errors: [{messageId: 'defaultParagraph'}],
+        },
+      ],
+    });
+  });
+});

--- a/packages/core/src/Banner/Banner.test.tsx
+++ b/packages/core/src/Banner/Banner.test.tsx
@@ -76,11 +76,22 @@ describe('Banner', () => {
     expect(screen.getByText('This is a description')).toBeInTheDocument();
   });
 
+  it('renders title and description as <div> (never <p>) for composition safety', () => {
+    const {container} = render(
+      <Banner status="info" title="Title" description="Description" />,
+    );
+    // Block content can be nested inside Banner text slots without tripping
+    // the phrasing-content trap that <p> imposes, so neither slot is a <p>.
+    expect(container.querySelector('p')).toBeNull();
+    expect(screen.getByText('Title').tagName).toBe('DIV');
+    expect(screen.getByText('Description').tagName).toBe('DIV');
+  });
+
   it('does not render description when not provided', () => {
-    const {container} = render(<Banner status="info" title="Title Only" />);
-    // Only one <p> for the title, no description
-    const paragraphs = container.querySelectorAll('p');
-    expect(paragraphs).toHaveLength(1);
+    render(<Banner status="info" title="Title Only" />);
+    // Title renders; no description text is present.
+    expect(screen.getByText('Title Only')).toBeInTheDocument();
+    expect(screen.queryByText('This is a description')).not.toBeInTheDocument();
   });
 
   it('renders dismiss button when isDismissable', () => {
@@ -158,9 +169,7 @@ describe('Banner', () => {
   });
 
   it('renders card container by default', () => {
-    const {container} = render(
-      <Banner status="info" title="Card Container" />,
-    );
+    const {container} = render(<Banner status="info" title="Card Container" />);
     const root = container.firstElementChild;
     expect(root).toBeInTheDocument();
   });

--- a/packages/core/src/Banner/Banner.tsx
+++ b/packages/core/src/Banner/Banner.tsx
@@ -16,6 +16,13 @@
  * - Each visual area owns its own border-radius (no overflow:clip on the container)
  * - When children are provided, a collapse/expand toggle button appears in the end area
  *
+ * Title and description render as <div> (not <p>): they accept arbitrary
+ * ReactNode content, and <p> cannot legally contain block-level children
+ * (the HTML parser reparents them, desyncing SSR markup from the hydrated
+ * DOM). Using <div> keeps these slots composable with any content. Their
+ * StyleX styles set margin: 0 and explicit typography, so the rendered
+ * appearance is identical to the previous <p>.
+ *
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/Banner/Banner.doc.mjs (props table, features, implementation notes)
  * - /packages/core/src/Banner/Banner.test.tsx (tests for new/changed behavior)
@@ -441,9 +448,9 @@ export function Banner({
           )}
         </div>
         <div {...stylex.props(styles.headerContent)}>
-          <p {...stylex.props(styles.title)}>{title}</p>
+          <div {...stylex.props(styles.title)}>{title}</div>
           {description != null && (
-            <p {...stylex.props(styles.description)}>{description}</p>
+            <div {...stylex.props(styles.description)}>{description}</div>
           )}
         </div>
         {showEndArea && (

--- a/packages/core/src/EmptyState/EmptyState.test.tsx
+++ b/packages/core/src/EmptyState/EmptyState.test.tsx
@@ -45,11 +45,13 @@ describe('EmptyState', () => {
       />,
     );
     expect(screen.getByText('Try adjusting your search.')).toBeInTheDocument();
+    // Description renders as <div> (never <p>) so block content composes safely.
+    expect(screen.getByText('Try adjusting your search.').tagName).toBe('DIV');
   });
 
   it('does not render description when not provided', () => {
-    const {container} = render(<EmptyState title="No results" />);
-    expect(container.querySelector('p')).not.toBeInTheDocument();
+    render(<EmptyState title="No results" />);
+    expect(screen.queryByText('Try adjusting your search.')).toBeNull();
   });
 
   it('renders with icon', () => {

--- a/packages/core/src/EmptyState/EmptyState.tsx
+++ b/packages/core/src/EmptyState/EmptyState.tsx
@@ -174,13 +174,17 @@ export function EmptyState({
           title,
         )}
         {description != null && (
-          <p
+          // Rendered as <div> (not <p>): description accepts ReactNode and a
+          // <p> cannot legally contain block children, which causes hydration
+          // mismatches. The StyleX style sets margin: 0, so appearance is
+          // unchanged.
+          <div
             {...stylex.props(
               styles.description,
               isCompact && styles.descriptionCompact,
             )}>
             {description}
-          </p>
+          </div>
         )}
       </div>
       {actions != null && (

--- a/packages/core/src/Markdown/Markdown.test.tsx
+++ b/packages/core/src/Markdown/Markdown.test.tsx
@@ -22,9 +22,13 @@ describe('Markdown', () => {
     expect(screen.getByText('Heading 2').tagName).toBe('H2');
   });
 
-  it('renders paragraphs', () => {
+  it('renders paragraphs as block <div> (never <p>) for composition safety', () => {
     render(<Markdown>{'Hello world'}</Markdown>);
-    expect(screen.getByText('Hello world').tagName).toBe('P');
+    // Markdown paragraphs render as <div> so block-level inline content
+    // (images, custom inline components) never trips the phrasing-content
+    // trap that a <p> would impose. Consumers who want <p> semantics can
+    // pass `components={{paragraph: 'p'}}`.
+    expect(screen.getByText('Hello world').tagName).toBe('DIV');
   });
 
   it('renders inline display without block wrappers', () => {
@@ -201,9 +205,7 @@ describe('Markdown', () => {
   });
 
   it('shows streaming cursor when isStreaming is true', () => {
-    const {container} = render(
-      <Markdown isStreaming>{'Hello'}</Markdown>,
-    );
+    const {container} = render(<Markdown isStreaming>{'Hello'}</Markdown>);
     // Streaming mode parses incrementally but no cursor element
     expect(container.querySelector('[role="document"]')).toBeInTheDocument();
   });
@@ -243,9 +245,7 @@ describe('Markdown', () => {
 
   it('sanitizes data: URLs in images', () => {
     const {container} = render(
-      <Markdown>
-        {'![xss](data:text/html,<script>alert(1)</script>)'}
-      </Markdown>,
+      <Markdown>{'![xss](data:text/html,<script>alert(1)</script>)'}</Markdown>,
     );
     const img = container.querySelector('img');
     expect(img).toBeNull();
@@ -435,9 +435,7 @@ describe('inlinePlugins', () => {
       },
     };
     const {container} = render(
-      <Markdown inlinePlugins={[plugin]}>
-        {'See TAG:important here'}
-      </Markdown>,
+      <Markdown inlinePlugins={[plugin]}>{'See TAG:important here'}</Markdown>,
     );
     const tag = container.querySelector('[data-testid="tag-match"]');
     expect(tag).toBeInTheDocument();
@@ -446,9 +444,7 @@ describe('inlinePlugins', () => {
 
   it('renders identically when no inlinePlugins are provided', () => {
     const withPlugins = render(
-      <Markdown inlinePlugins={[]}>
-        {'Hello **world** and `code`'}
-      </Markdown>,
+      <Markdown inlinePlugins={[]}>{'Hello **world** and `code`'}</Markdown>,
     );
     const withoutPlugins = render(
       <Markdown>{'Hello **world** and `code`'}</Markdown>,
@@ -481,9 +477,7 @@ describe('inlinePlugins', () => {
 
     it('renders bare https URLs as links when autolink="gfm"', () => {
       const {container} = render(
-        <Markdown autolink="gfm">
-          {'see https://example.com here'}
-        </Markdown>,
+        <Markdown autolink="gfm">{'see https://example.com here'}</Markdown>,
       );
       const link = container.querySelector('a');
       expect(link).not.toBeNull();
@@ -503,9 +497,7 @@ describe('inlinePlugins', () => {
 
     it('renders bare emails with mailto: href', () => {
       const {container} = render(
-        <Markdown autolink="gfm">
-          {'ping user@example.com please'}
-        </Markdown>,
+        <Markdown autolink="gfm">{'ping user@example.com please'}</Markdown>,
       );
       const link = container.querySelector('a');
       expect(link).not.toBeNull();
@@ -515,9 +507,7 @@ describe('inlinePlugins', () => {
 
     it('does not autolink URLs inside code spans', () => {
       const {container} = render(
-        <Markdown autolink="gfm">
-          {'try `https://example.com` here'}
-        </Markdown>,
+        <Markdown autolink="gfm">{'try `https://example.com` here'}</Markdown>,
       );
       expect(container.querySelector('a')).toBeNull();
       expect(container.querySelector('code')).not.toBeNull();
@@ -525,9 +515,7 @@ describe('inlinePlugins', () => {
 
     it('does not autolink URLs inside code blocks', () => {
       const {container} = render(
-        <Markdown autolink="gfm">
-          {'```\nhttps://example.com\n```'}
-        </Markdown>,
+        <Markdown autolink="gfm">{'```\nhttps://example.com\n```'}</Markdown>,
       );
       expect(container.querySelector('a')).toBeNull();
       expect(container.querySelector('pre')).not.toBeNull();

--- a/packages/core/src/Markdown/Markdown.test.tsx
+++ b/packages/core/src/Markdown/Markdown.test.tsx
@@ -26,9 +26,12 @@ describe('Markdown', () => {
     render(<Markdown>{'Hello world'}</Markdown>);
     // Markdown paragraphs render as <div> so block-level inline content
     // (images, custom inline components) never trips the phrasing-content
-    // trap that a <p> would impose. Consumers who want <p> semantics can
-    // pass `components={{paragraph: 'p'}}`.
-    expect(screen.getByText('Hello world').tagName).toBe('DIV');
+    // trap that a <p> would impose. role="paragraph" re-exposes the paragraph
+    // role to assistive tech without the <p> hazard. Consumers who want a real
+    // <p> element can pass `components={{paragraph: 'p'}}`.
+    const para = screen.getByText('Hello world');
+    expect(para.tagName).toBe('DIV');
+    expect(para).toHaveAttribute('role', 'paragraph');
   });
 
   it('renders inline display without block wrappers', () => {

--- a/packages/core/src/Markdown/Markdown.tsx
+++ b/packages/core/src/Markdown/Markdown.tsx
@@ -1113,8 +1113,14 @@ function renderBlock(
       if (ParagraphComp) {
         return <ParagraphComp key={index}>{paraChildren}</ParagraphComp>;
       }
+      // Markdown paragraphs render as <div>, not <p>: inline content can
+      // include block-level nodes (images, custom inline components), and a
+      // <p> would reparent them, desyncing SSR markup from the hydrated DOM.
+      // Block spacing comes from token-based StyleX margins, so the rendered
+      // appearance is unchanged. Consumers who want <p> semantics can pass
+      // components={{paragraph: 'p'}}.
       return (
-        <p
+        <div
           key={index}
           {...stylex.props(
             spacing,
@@ -1128,7 +1134,7 @@ function renderBlock(
             isLast && styles.noMarginBlockEnd,
           )}>
           {paraChildren}
-        </p>
+        </div>
       );
     }
     case 'codeblock': {
@@ -1487,7 +1493,7 @@ function renderBlock(
       const safeSrc = sanitizeUrl(node.src);
       if (safeSrc == null) {
         return (
-          <p
+          <div
             key={index}
             {...stylex.props(
               spacing,
@@ -1495,11 +1501,11 @@ function renderBlock(
               isLast && styles.noMarginBlockEnd,
             )}>
             [{node.alt}]
-          </p>
+          </div>
         );
       }
       return (
-        <p
+        <div
           key={index}
           {...stylex.props(
             spacing,
@@ -1507,7 +1513,7 @@ function renderBlock(
             isLast && styles.noMarginBlockEnd,
           )}>
           <img src={safeSrc} alt={node.alt} {...stylex.props(styles.image)} />
-        </p>
+        </div>
       );
     }
   }

--- a/packages/core/src/Markdown/Markdown.tsx
+++ b/packages/core/src/Markdown/Markdown.tsx
@@ -1117,11 +1117,15 @@ function renderBlock(
       // include block-level nodes (images, custom inline components), and a
       // <p> would reparent them, desyncing SSR markup from the hydrated DOM.
       // Block spacing comes from token-based StyleX margins, so the rendered
-      // appearance is unchanged. Consumers who want <p> semantics can pass
-      // components={{paragraph: 'p'}}.
+      // appearance is unchanged. role="paragraph" re-exposes the paragraph
+      // role in the accessibility tree (a pure ARIA hint — it does not trigger
+      // the parser's block-child reparenting) so prose semantics are preserved
+      // without the <p> composition hazard. Consumers who want a real <p>
+      // element can still pass components={{paragraph: 'p'}}.
       return (
         <div
           key={index}
+          role="paragraph"
           {...stylex.props(
             spacing,
             contentWidthValue != null


### PR DESCRIPTION
## Summary

Core components no longer render a `<p>` element by default — they render `<div>` (styled to preserve appearance) instead. This guarantees compositional compatibility: any XDS component can be nested inside an XDS text/content slot without tripping the HTML phrasing-content trap.

`<p>` is phrasing-content-only in HTML and cannot legally contain block-level children (`<div>`, popovers/layers, block images, etc.). When block content lands inside a `<p>`, the parser reparents it and closes the `<p>` early, so server-rendered markup and the hydrated DOM disagree and React reports a hydration mismatch (see #3107). Because these components accept arbitrary `ReactNode` content, any `<p>` they emit can be handed block content and break.

## Changes

Default rendered element changed from `<p>` to `<div>`:

| Component | Slot |
| --- | --- |
| `Banner` | `title`, `description` |
| `EmptyState` | `description` |
| `Markdown` | rendered paragraphs (as `<div role="paragraph">`), image blocks |

Appearance is unchanged — `Banner`/`EmptyState` styles already set `margin: 0` with explicit typography, and `Markdown` drives block spacing from tokens (not UA `<p>` margins). `<div>` is block-level like `<p>`, so flow and layout are identical.

Escape hatches preserved:
- `Text` is **unaffected** — it already defaults to `<span>` and keeps `as="p"` as an opt-in.
- `Markdown` keeps `components={{paragraph: 'p'}}` to render a real `<p>` element.

## Enforcement

Adds a new `@astryx/eslint-plugin` rule, **`no-raw-paragraph`**, that flags in source (skips tests/stories):
- raw `<p>` JSX elements;
- element-type props (`as`/`component`/`tag`/`element`) **defaulting** to `'p'` (`{as = 'p'}`, `{as: C = 'p'}`, `as ?? 'p'`, `as || 'p'`).

It does **not** flag `'p'` as an opt-in value (e.g. `as="p"` call sites or `'p'` in a type union) — only XDS components *defaulting* to `<p>`. Wired into the `strict` (error) and `recommended` (warn) configs, with colocated tests.

## Accessibility

`<p>` carries paragraph semantics for assistive tech; a bare `<div>` does not.

- **`Banner` / `EmptyState`** are UI chrome (status messages, empty-state copy), not prose — paragraph semantics add no navigation value, so a plain `<div>` is appropriate.
- **`Markdown`** is rendered prose, where paragraph semantics matter. Its text paragraphs render as **`<div role="paragraph">`**: `role` re-exposes the paragraph role in the accessibility tree as a pure ARIA hint, so it preserves the semantic *without* triggering the parser's block-child reparenting that caused the hydration hazard. (Note: support for the `paragraph` role as a screen-reader navigation target is limited today; consumers who need fully-supported paragraph semantics can render a real `<p>` via `components={{paragraph: 'p'}}`.) The role is applied only to text paragraphs — image-block `<div>`s are image containers, not paragraphs, and are left without it.

## Compatibility

No public API changes — only the default rendered element changes. Consumers relying on a `<p>` tag (e.g. CSS selectors targeting `p` inside these components) should update their selectors or opt in to `<p>` where an override exists. A codemod is not warranted: there is no consumer source API to rewrite, and the runtime DOM/CSS impact can't be mechanically fixed; the changeset documents the selector caveat and the Markdown opt-in as migration guidance.

## Testing

- Updated colocated tests for `Banner`, `EmptyState`, `Markdown` (retargeted `<p>`-counting assertions to text/`<div>` checks; added "never `<p>`" locks and a `role="paragraph"` assertion for Markdown).
- New `no-raw-paragraph` rule tests (valid + invalid cases).
- Full suite green: 4811 tests passing. Typecheck (core, docs, template-docs, storybook), lint, build, and all repo check gates pass.
