### PR TITLE
fix(templates): point RFC template at facebook/astryx and use an existing label

### DIFF
--- a/.github/ISSUE_TEMPLATE/rfc.yml
+++ b/.github/ISSUE_TEMPLATE/rfc.yml
@@ -3,16 +3,16 @@
 name: "RFC: Component or Feature Proposal"
 description: Propose a new component, feature, or significant API change for XDS.
 title: "[RFC] "
-labels: ["rfc"]
+labels: ["enhancement"]
 body:
   - type: markdown
     attributes:
       value: |
         ## Before you submit
 
-        An RFC is a **problem statement and demand signal** — not a design proposal we evaluate as-written. Read the [contributing guide](https://github.com/facebookexperimental/xds/wiki/Contributing) before submitting.
+        An RFC is a **problem statement and demand signal** — not a design proposal we evaluate as-written. Read the [contributing guide](https://github.com/facebook/astryx/wiki/Contributing) before submitting.
 
-        After acceptance, either of us drives the [specification protocol](https://github.com/facebookexperimental/xds/wiki/Component-Specification-Protocol) — you can front-load research and API exploration in this RFC at your own risk if we haven't responded yet.
+        After acceptance, either of us drives the [specification protocol](https://github.com/facebook/astryx/wiki/Component-Specification-Protocol) — you can front-load research and API exploration in this RFC at your own risk if we haven't responded yet.
 
         **Response time:** We aim to respond within 1 week — either accepting, requesting more information, or declining with rationale.
 
@@ -91,9 +91,9 @@ body:
     attributes:
       label: Pre-submission Checklist
       options:
-        - label: I have read the [Contributing guide](https://github.com/facebookexperimental/xds/wiki/Contributing)
+        - label: I have read the [Contributing guide](https://github.com/facebook/astryx/wiki/Contributing)
           required: true
-        - label: I have read the [API Conventions](https://github.com/facebookexperimental/xds/wiki/API-Conventions)
+        - label: I have read the [API Conventions](https://github.com/facebook/astryx/wiki/API-Conventions)
           required: true
         - label: I have checked that existing XDS components cannot compose to solve this
           required: true


### PR DESCRIPTION
## Summary

The RFC issue template (`.github/ISSUE_TEMPLATE/rfc.yml`) had two maintenance problems that affected contributors filing RFCs.

### Bug

1. **Stale namespace in wiki links.** The template linked Contributing, Component-Specification-Protocol, and API-Conventions docs under the old `facebookexperimental/xds` namespace instead of the current `facebook/astryx`. These only worked via redirect.
2. **Non-existent label.** The template declared `labels: ["rfc"]`, but the repo has no `rfc` label, so filing via `gh issue create --label rfc` failed:
   ```text
   could not add label: 'rfc' not found
   ```

### Reproduction (before — fails)

```sh
# (a) stale namespace references present
grep -n "facebookexperimental/xds" .github/ISSUE_TEMPLATE/rfc.yml
# -> 4 matches (lines 13, 15, 94, 96)

# (b) declared label is absent from the repo
grep "^labels:" .github/ISSUE_TEMPLATE/rfc.yml          # -> labels: ["rfc"]
gh label list --repo facebook/astryx --limit 100 | grep -x rfc   # -> (no match)
```

### Root cause

The template was authored before the `facebookexperimental/xds` → `facebook/astryx` rename and was never updated, and it referenced an `rfc` label that was never created in the repo.

### Fix

- Rewrite the three wiki links to the current `facebook/astryx` namespace.
- Switch the declared label from the non-existent `rfc` to the existing `enhancement` label. This matches the sibling template `bug.yml`, which declares the existing `bug` label, and `enhancement` ("New feature or request") is the closest fit for an RFC proposing a new component/feature/API.

### Verification (after — passes)

```sh
grep -n "facebookexperimental/xds" .github/ISSUE_TEMPLATE/rfc.yml   # -> no matches
grep "^labels:" .github/ISSUE_TEMPLATE/rfc.yml                      # -> labels: ["enhancement"]
gh label list --repo facebook/astryx --limit 100 | grep -x enhancement  # -> enhancement (exists)
```

No changeset is needed — this is an issue-template-only change and touches no publishable package.

Closes #3123