### PR TITLE
fix(cli): align `init` theme instructions with built-theme recommendation

### DIFF
--- a/.changeset/fix-cli-init-theme-instructions.md
+++ b/.changeset/fix-cli-init-theme-instructions.md
@@ -1,0 +1,8 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[fix] align `astryx init` theme instructions with the runtime built-theme recommendation (#3080)
+@cixzhang
+
+`astryx init` now points users at the pre-built theme path (`@astryxdesign/theme-neutral/built` + `theme.css`) and the base CSS imports, matching the runtime `<Theme>` console guidance, instead of the slower runtime style-injection import that left apps unstyled.

--- a/packages/cli/src/commands/init.mjs
+++ b/packages/cli/src/commands/init.mjs
@@ -29,6 +29,37 @@ import {requireInteractive} from '../utils/interactive.mjs';
 const VALID_FEATURES = ['agents', 'theme', 'template'];
 const run = getRunPrefix();
 
+/**
+ * Build the "Next steps" lines printed at the end of `astryx init`.
+ *
+ * Theme guidance must match the runtime recommendation emitted by core's
+ * <Theme> component (packages/core/src/theme/Theme.tsx): the pre-built theme
+ * path (`/built` import + `theme.css`) plus the base CSS import, so users
+ * don't end up with an unstyled app or the slower runtime style-injection
+ * path. See https://github.com/facebook/astryx/issues/3080.
+ *
+ * Exported for testing.
+ *
+ * @param {string} runPrefix package-manager run prefix (e.g. `npx`)
+ * @returns {string[]} ordered list of human-facing lines
+ */
+export function getNextSteps(runPrefix) {
+  return [
+    '',
+    '  Next steps:',
+    "    1. Import base styles: import '@astryxdesign/core/reset.css'",
+    "       and import '@astryxdesign/core/astryx.css'",
+    "    2. Import components: import { Button } from '@astryxdesign/core'",
+    '    3. Optionally add a theme (use the pre-built path for performance):',
+    "       import { neutralTheme } from '@astryxdesign/theme-neutral/built'",
+    "       import '@astryxdesign/theme-neutral/theme.css'",
+    '       <Theme theme={neutralTheme}>...</Theme>',
+    `       For custom themes, run \`${runPrefix} astryx theme build <file>\` to generate the built artifacts.`,
+    `    4. ${runPrefix} astryx --help for all commands`,
+    '',
+  ];
+}
+
 function isCancel(value) {
   if (p.isCancel(value)) {
     p.cancel('Setup cancelled.');
@@ -250,13 +281,8 @@ export function registerInit(program) {
       // Outro
       p.outro('Design system initialized!');
 
-      humanLog('');
-      humanLog('  Next steps:');
-      humanLog("    1. Import components: import { Button } from '@astryxdesign/core'");
-      humanLog('    2. Optionally add a theme:');
-      humanLog("       import { neutralTheme } from '@astryxdesign/theme-neutral'");
-      humanLog('       <Theme theme={neutralTheme}>...</Theme>');
-      humanLog(`    3. ${run} astryx --help for all commands`);
-      humanLog('');
+      for (const line of getNextSteps(run)) {
+        humanLog(line);
+      }
     });
 }

--- a/packages/cli/src/commands/init.next-steps.test.mjs
+++ b/packages/cli/src/commands/init.next-steps.test.mjs
@@ -1,0 +1,46 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Regression test for `astryx init` "Next steps" theme guidance.
+ *
+ * The init command previously steered users toward the slower runtime
+ * style-injection path:
+ *
+ *   import { neutralTheme } from '@astryxdesign/theme-neutral'
+ *   <Theme theme={neutralTheme}>...</Theme>
+ *
+ * ...which contradicted the runtime console warning emitted by core's
+ * <Theme> component (packages/core/src/theme/Theme.tsx) recommending the
+ * pre-built path, and left users with an unstyled app because the base CSS
+ * imports were never mentioned (facebook/astryx#3080).
+ *
+ * These assertions lock in the corrected guidance: base CSS imports, the
+ * pre-built (`/built` + `theme.css`) theme path, and the custom-theme build
+ * command.
+ */
+
+import {describe, it, expect} from 'vitest';
+import {getNextSteps} from './init.mjs';
+
+describe('init Next steps theme guidance', () => {
+  const text = getNextSteps('npx').join('\n');
+
+  it('mentions the base CSS imports so the app is not left unstyled', () => {
+    expect(text).toContain("'@astryxdesign/core/reset.css'");
+    expect(text).toContain("'@astryxdesign/core/astryx.css'");
+  });
+
+  it('uses the pre-built theme path matching the runtime recommendation', () => {
+    expect(text).toContain("'@astryxdesign/theme-neutral/built'");
+    expect(text).toContain("'@astryxdesign/theme-neutral/theme.css'");
+  });
+
+  it('mentions building custom themes via `astryx theme build`', () => {
+    expect(text).toContain('astryx theme build <file>');
+  });
+
+  it('does not steer users to the runtime style-injection import', () => {
+    // The bare source import (no `/built`) is the slow runtime-injection path.
+    expect(text).not.toContain("from '@astryxdesign/theme-neutral'");
+  });
+});


### PR DESCRIPTION
## Bug

`astryx init`'s "Next steps" steered users to the runtime style-injection theme import, contradicting the runtime guidance and leaving the app unstyled:

```
2. Optionally add a theme:
   import { neutralTheme } from '@astryxdesign/theme-neutral'
   <Theme theme={neutralTheme}>...</Theme>
```

But at runtime, core's `<Theme>` warns this is the slower path and recommends the pre-built one:

```
[Astryx] Theme "neutral" is using runtime style injection. For better performance, use the pre-built theme:

  import {neutralTheme} from '@astryxdesign/theme-neutral/built';
  import '@astryxdesign/theme-neutral/theme.css';

For custom themes, run `npx astryx theme build <file>` to generate the built artifacts.
```

The reporter also observed **no theme applied until the CSS file was added** — `init` never mentioned the base CSS imports (`@astryxdesign/core/reset.css` + `@astryxdesign/core/astryx.css`), so the app rendered unstyled.

## Root cause

The init "Next steps" string was authored independently of the runtime `<Theme>` recommendation (`packages/core/src/theme/Theme.tsx`) and drifted from it. It used the bare source import (runtime injection) and omitted both `theme.css` and the base CSS imports.

## Fix

- Emit the **pre-built theme path** (`@astryxdesign/theme-neutral/built` + `import '@astryxdesign/theme-neutral/theme.css'`) — matches the runtime warning.
- Add the **base CSS imports** (`core/reset.css` + `core/astryx.css`) so the app isn't left unstyled.
- Mention `astryx theme build <file>` for custom themes.
- Extract the lines into an exported `getNextSteps(runPrefix)` so the guidance is unit-testable.

## Before / after

**Before**
```
2. Optionally add a theme:
   import { neutralTheme } from '@astryxdesign/theme-neutral'
   <Theme theme={neutralTheme}>...</Theme>
```

**After**
```
1. Import base styles: import '@astryxdesign/core/reset.css'
   and import '@astryxdesign/core/astryx.css'
2. Import components: import { Button } from '@astryxdesign/core'
3. Optionally add a theme (use the pre-built path for performance):
   import { neutralTheme } from '@astryxdesign/theme-neutral/built'
   import '@astryxdesign/theme-neutral/theme.css'
   <Theme theme={neutralTheme}>...</Theme>
   For custom themes, run `npx astryx theme build <file>` to generate the built artifacts.
```

## Test

New regression test `packages/cli/src/commands/init.next-steps.test.mjs` asserts the corrected guidance (base CSS imports, `/built` + `theme.css`, `theme build`) and that the bare runtime-injection import is gone. Red against the old string, green after the fix.

```
npx vitest run packages/cli/src/commands/init.next-steps.test.mjs
```

Closes #3080
