### PR TITLE
fix(docsite): give Skeleton properties-tab example explicit dimensions

### DIFF
--- a/.changeset/skeleton-docsite-dims.md
+++ b/.changeset/skeleton-docsite-dims.md
@@ -1,0 +1,13 @@
+---
+'@astryxdesign/core': patch
+---
+
+[docs] Give the `Skeleton` properties-tab example explicit dimensions so it is visible
+
+The `Skeleton` doc had no `playground` config, so the interactive
+properties-tab preview fell back to the prop defaults of `width: '100%'` /
+`height: '100%'`. With no sized parent, the skeleton collapsed to a zero-size
+(invisible) element. The doc now sets a `playground.defaults` of
+`width: 320` / `height: 80` so the shimmer placeholder renders visibly.
+
+@cixzhang

--- a/packages/core/src/Skeleton/Skeleton.doc.mjs
+++ b/packages/core/src/Skeleton/Skeleton.doc.mjs
@@ -33,7 +33,17 @@ export const docs = {
         'Index for staggered animation timing. For element at index n, animation starts at DELAY_TIME + (STAGGER_TIME × n).',
       default: '0',
     },
-  ],  theming: {
+  ],
+  playground: {
+    // Skeleton width/height default to '100%', which collapses to a zero-size
+    // (invisible) element in the properties-tab preview. Give the example
+    // explicit pixel dimensions so the shimmer placeholder is visible.
+    defaults: {
+      width: 320,
+      height: 80,
+    },
+  },
+  theming: {
     targets: [
       {className: 'astryx-skeleton'},
     ],


### PR DESCRIPTION
## Bug

On the docsite, the `Skeleton` example on the **properties tab** renders with no visible content — the preview area looks empty. (#2875)

## Root cause

`Skeleton.doc.mjs` had **no `playground` config**, so the interactive properties-tab preview fell back to the prop defaults documented for `width` / `height`, both `'100%'`. Inside the preview container the skeleton has no intrinsic size and no sized parent, so it collapses to a zero-size (invisible) element.

## Fix

Add a `playground.defaults` to the Skeleton doc with explicit pixel dimensions so the shimmer placeholder renders at a sensible, visible size:

```js
playground: {
  defaults: {
    width: 320,
    height: 80,
  },
},
```

## Before / After

- **Before:** the generated component registry entry for `Skeleton` had `"playground": null`; the preview rendered a zero-height element.
- **After:** the registry entry carries `playground.defaults` `{ width: 320, height: 80 }`, so the properties-tab preview shows a visible 320×80 skeleton.

## Validation

- `pnpm -F @astryxdesign/core build` → green
- `pnpm -F @astryxdesign/docsite generate` → green; the regenerated `componentRegistry` now contains the Skeleton playground dimensions
- `pnpm -F @astryxdesign/docsite test` → 187 passed
- `node scripts/check-changesets.mjs` → valid (patch changeset added)

Minimal, example-config-only change — no component runtime behavior changes.

Closes #2875
