### PR TITLE
fix(core): re-open mobile nav drawer after close (#3091)

### DIFF
--- a/.changeset/mobile-nav-reopen.md
+++ b/.changeset/mobile-nav-reopen.md
@@ -1,0 +1,16 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Fix mobile nav drawer not re-opening after it is closed (#3091)
+@cixzhang
+
+The AppShell mobile drawer mounts `MobileNav` inside an `<Activity>` that
+switches to `mode="hidden"` when the drawer closes. On close, React runs the
+drawer effect's cleanup (with a stale `isOpen`) instead of re-running the
+effect with `isOpen=false`, so the deferred `dialog.close()` never fired and
+the native `<dialog>` was left `open` in the hidden subtree. The next open then
+skipped `showModal()` (the dialog was already open), so the drawer could be
+opened and closed once but never re-opened. The effect cleanup now closes the
+dialog if it is still open, keeping the native dialog state in sync so a
+subsequent open cleanly calls `showModal()` again.

--- a/packages/core/src/MobileNav/MobileNav.tsx
+++ b/packages/core/src/MobileNav/MobileNav.tsx
@@ -363,8 +363,21 @@ export function MobileNav({
     return () => {
       if (closeTimeoutRef.current) {
         clearTimeout(closeTimeoutRef.current);
+        closeTimeoutRef.current = null;
       }
       document.documentElement.style.overflow = '';
+      // Close the native dialog on teardown if it's still open. Inside AppShell
+      // the drawer is mounted in an <Activity> that switches to mode="hidden"
+      // when the drawer closes; React then runs this cleanup (with a stale
+      // isOpen) instead of re-running the effect with isOpen=false, so the
+      // close branch above never fires. If we leave the <dialog> `open` here,
+      // showModal() is skipped on the next open (the dialog is already open in
+      // the hidden tree) and the drawer can never be re-opened. Closing it
+      // unconditionally on teardown keeps the native dialog state in sync so a
+      // subsequent open cleanly calls showModal() again.
+      if (dialog.open) {
+        dialog.close();
+      }
     };
   }, [isOpen, side]);
 

--- a/packages/core/src/MobileNav/MobileNavReopen.test.tsx
+++ b/packages/core/src/MobileNav/MobileNavReopen.test.tsx
@@ -1,0 +1,118 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file MobileNavReopen.test.tsx
+ * @input Uses vitest, @testing-library/react, AppShell + SideNav
+ * @output Regression test for mobile hamburger nav re-open after close
+ * @position Testing; validates the OOTB AppShell mobile drawer toggle cycle
+ *
+ * Repro for: mobile hamburger nav can be opened and closed once, but cannot
+ * be re-opened after closing.
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeAll,
+  beforeEach,
+  afterEach,
+} from 'vitest';
+import {render, screen, fireEvent, act} from '@testing-library/react';
+import {AppShell} from '../AppShell/AppShell';
+import {SideNav, SideNavItem, SideNavSection} from '../SideNav';
+
+beforeAll(() => {
+  HTMLDialogElement.prototype.showModal =
+    HTMLDialogElement.prototype.showModal ||
+    function (this: HTMLDialogElement) {
+      this.setAttribute('open', '');
+    };
+  HTMLDialogElement.prototype.close =
+    HTMLDialogElement.prototype.close ||
+    function (this: HTMLDialogElement) {
+      this.removeAttribute('open');
+    };
+});
+
+class MockResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+vi.stubGlobal('ResizeObserver', MockResizeObserver);
+
+function createMockMatchMedia(matches: boolean) {
+  return {
+    matches,
+    media: '',
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  };
+}
+
+beforeEach(() => {
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn().mockReturnValue(createMockMatchMedia(true)),
+  );
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function TestShell() {
+  return (
+    <AppShell
+      sideNav={
+        <SideNav>
+          <SideNavSection title="Test" isHeaderHidden>
+            <SideNavItem label="Home" />
+          </SideNavSection>
+        </SideNav>
+      }
+      mobileNav={{breakpoint: 'md'}}>
+      <div>Content</div>
+    </AppShell>
+  );
+}
+
+describe('Mobile nav re-open after close (uncontrolled OOTB)', () => {
+  it('can be opened, closed, then opened again', () => {
+    vi.useFakeTimers();
+    try {
+      render(<TestShell />);
+
+      const getDialog = () => screen.getAllByRole('dialog', {hidden: true})[0];
+      const openToggle = () =>
+        screen.getByRole('button', {name: /open navigation/i});
+
+      // 1. Open
+      fireEvent.click(openToggle());
+      expect(getDialog()).toHaveAttribute('open');
+
+      // 2. Close via the drawer's close button
+      fireEvent.click(screen.getByRole('button', {name: /close navigation/i}));
+      // Flush the delayed dialog.close() (slide-out transition)
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+      expect(getDialog()).not.toHaveAttribute('open');
+
+      // 3. Open AGAIN — this is the bug: it should re-open
+      fireEvent.click(openToggle());
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+      expect(getDialog()).toHaveAttribute('open');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});


### PR DESCRIPTION
## Bug

The mobile hamburger nav (AppShell OOTB drawer) can be opened and closed once, but after closing it cannot be re-opened. Reported on Chrome with a simulated mobile viewport.

Closes #3091

## Reproduction

Added a regression test (`packages/core/src/MobileNav/MobileNavReopen.test.tsx`) that renders an uncontrolled `AppShell` with a `SideNav` below the mobile breakpoint and drives the full cycle:

1. Click the hamburger toggle → the drawer `<dialog>` opens. ✅
2. Click the drawer's close button (+ flush the slide-out timer) → the dialog closes. ✅
3. Click the hamburger toggle **again** → the drawer should re-open.

Before this change, step 2 left the native `<dialog>` with its `open` attribute set and step 3 never re-opened it — the test failed. After the change the test passes.

## Root cause

The AppShell mobile drawer mounts `MobileNav` inside an `<Activity>` that switches to `mode="hidden"` when the drawer closes. On close, React runs the drawer effect's **cleanup** (with a stale `isOpen`) instead of re-running the effect with `isOpen=false`, so the deferred `dialog.close()` in the effect body never fired. The native `<dialog>` was left `open` in the now-hidden subtree. On the next open, the effect's `if (!dialog.open) dialog.showModal()` guard saw the dialog as already open and skipped `showModal()`, so the drawer never re-appeared — opened/closed once, then stuck.

## Fix

The drawer effect's cleanup now closes the `<dialog>` if it is still open. This keeps the native dialog state in sync whenever the effect tears down (including the `<Activity>` hide on close), so a subsequent open cleanly calls `showModal()` again. Minimal, scoped to `MobileNav.tsx`; all existing AppShell/MobileNav/SideNav/TopNav tests still pass (197 total).
