### PR TITLE
fix(core): render current time as "just now" in Timestamp

### DIFF
--- a/.changeset/timestamp-current-time-future-phrase.md
+++ b/.changeset/timestamp-current-time-future-phrase.md
@@ -2,12 +2,6 @@
 '@astryxdesign/core': patch
 ---
 
-[fix] Stop `Timestamp` from rendering "in a few seconds" for a time that is
-"right now". The component captures its `now` reference at render time, so a
-value equal to the current instant can land a fraction of a second in the
-future relative to that baseline and round to a tiny negative delta. That tiny
-negative delta was treated as a future date and formatted as "in a few
-seconds". Values at (or a hair before/after) the present now read as "just
-now".
+[fix] `Timestamp` now renders the current time as "now" instead of "in a few seconds" (#3099).
 
 @cixzhang

--- a/.changeset/timestamp-current-time-future-phrase.md
+++ b/.changeset/timestamp-current-time-future-phrase.md
@@ -2,6 +2,6 @@
 '@astryxdesign/core': patch
 ---
 
-[fix] `Timestamp` now renders the current time as "now" instead of "in a few seconds" (#3099).
+[fix] `Timestamp` now renders the current time (and small clock skew up to ~30s in the future) as "now" instead of "in a few seconds" (#3099).
 
-@cixzhang
+@cixzhang @durvesh1992

--- a/.changeset/timestamp-current-time-future-phrase.md
+++ b/.changeset/timestamp-current-time-future-phrase.md
@@ -1,0 +1,13 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Stop `Timestamp` from rendering "in a few seconds" for a time that is
+"right now". The component captures its `now` reference at render time, so a
+value equal to the current instant can land a fraction of a second in the
+future relative to that baseline and round to a tiny negative delta. That tiny
+negative delta was treated as a future date and formatted as "in a few
+seconds". Values at (or a hair before/after) the present now read as "just
+now".
+
+@cixzhang

--- a/packages/core/src/Timestamp/Timestamp.test.tsx
+++ b/packages/core/src/Timestamp/Timestamp.test.tsx
@@ -248,6 +248,24 @@ describe('Timestamp', () => {
     expect(screen.getByText('in 1 hour')).toBeInTheDocument();
   });
 
+  it('renders "now" for a value a few seconds in the future (clock skew)', () => {
+    // Beyond the sub-second render lag but still within the skew tolerance: a
+    // value ~20s ahead of our clock is almost always skew (the value's clock
+    // running fast), not a genuine future event, so it should read as the
+    // present rather than "in a few seconds".
+    const twentySecondsFromNow = Date.now() / 1000 + 20;
+    render(<Timestamp value={twentySecondsFromNow} format="relative" />);
+    expect(screen.queryByText(/^in /)).not.toBeInTheDocument();
+    expect(screen.getByText('now')).toBeInTheDocument();
+  });
+
+  it('renders a genuine near-future time beyond the skew tolerance', () => {
+    // Past the skew window — this is a real upcoming time, not clock drift.
+    const fortyFiveSecondsFromNow = Date.now() / 1000 + 45;
+    render(<Timestamp value={fortyFiveSecondsFromNow} format="relative" />);
+    expect(screen.getByText('in a few seconds')).toBeInTheDocument();
+  });
+
   // --- Long-ago relative ---
 
   it('renders months ago for dates older than 30 days', () => {

--- a/packages/core/src/Timestamp/Timestamp.test.tsx
+++ b/packages/core/src/Timestamp/Timestamp.test.tsx
@@ -33,30 +33,30 @@ describe('Timestamp', () => {
     expect(screen.getByText('2 hours ago')).toBeInTheDocument();
   });
 
-  it('renders "just now" for very recent times', () => {
+  it('renders "now" for very recent times', () => {
     const fiveSecondsAgo = Date.now() / 1000 - 5;
     render(<Timestamp value={fiveSecondsAgo} format="relative" />);
-    expect(screen.getByText('just now')).toBeInTheDocument();
+    expect(screen.getByText('now')).toBeInTheDocument();
   });
 
-  it('renders "just now" for the current instant (not a future phrase)', () => {
+  it('renders "now" for the current instant (not a future phrase)', () => {
     // A value equal to "right now". Because the internal `now` baseline is
     // captured at render time, it can lag the value by a fraction of a second,
     // producing a tiny negative delta that must not be treated as the future.
     render(<Timestamp value={Date.now() / 1000} format="relative" />);
     expect(screen.queryByText(/^in /)).not.toBeInTheDocument();
-    expect(screen.getByText('just now')).toBeInTheDocument();
+    expect(screen.getByText('now')).toBeInTheDocument();
   });
 
-  it('renders "just now" for a value a hair in the future (clock skew)', () => {
+  it('renders "now" for a value a hair in the future (clock skew)', () => {
     // Real-world clock / captured-now skew can make a current-ish value land a
     // fraction of a second in the future relative to the component's internal
-    // `now`. This must read as the present ("just now"), never "in a few
+    // `now`. This must read as the present ("now"), never "in a few
     // seconds". Regression test for the right-now -> future-phrase bug.
     const aHairInTheFuture = Date.now() / 1000 + 0.6;
     render(<Timestamp value={aHairInTheFuture} format="relative" />);
     expect(screen.queryByText(/^in /)).not.toBeInTheDocument();
-    expect(screen.getByText('just now')).toBeInTheDocument();
+    expect(screen.getByText('now')).toBeInTheDocument();
   });
 
   it('renders "yesterday" for times ~1 day ago', () => {
@@ -209,7 +209,7 @@ describe('Timestamp', () => {
   it('live updates relative time', () => {
     const now = Date.now() / 1000;
     render(<Timestamp value={now - 5} format="relative" isLive />);
-    expect(screen.getByText('just now')).toBeInTheDocument();
+    expect(screen.getByText('now')).toBeInTheDocument();
 
     act(() => {
       vi.advanceTimersByTime(30_000);

--- a/packages/core/src/Timestamp/Timestamp.test.tsx
+++ b/packages/core/src/Timestamp/Timestamp.test.tsx
@@ -39,6 +39,26 @@ describe('Timestamp', () => {
     expect(screen.getByText('just now')).toBeInTheDocument();
   });
 
+  it('renders "just now" for the current instant (not a future phrase)', () => {
+    // A value equal to "right now". Because the internal `now` baseline is
+    // captured at render time, it can lag the value by a fraction of a second,
+    // producing a tiny negative delta that must not be treated as the future.
+    render(<Timestamp value={Date.now() / 1000} format="relative" />);
+    expect(screen.queryByText(/^in /)).not.toBeInTheDocument();
+    expect(screen.getByText('just now')).toBeInTheDocument();
+  });
+
+  it('renders "just now" for a value a hair in the future (clock skew)', () => {
+    // Real-world clock / captured-now skew can make a current-ish value land a
+    // fraction of a second in the future relative to the component's internal
+    // `now`. This must read as the present ("just now"), never "in a few
+    // seconds". Regression test for the right-now -> future-phrase bug.
+    const aHairInTheFuture = Date.now() / 1000 + 0.6;
+    render(<Timestamp value={aHairInTheFuture} format="relative" />);
+    expect(screen.queryByText(/^in /)).not.toBeInTheDocument();
+    expect(screen.getByText('just now')).toBeInTheDocument();
+  });
+
   it('renders "yesterday" for times ~1 day ago', () => {
     const yesterday = Date.now() / 1000 - 100000;
     render(<Timestamp value={yesterday} format="relative" />);
@@ -49,11 +69,7 @@ describe('Timestamp', () => {
 
   it('renders date format', () => {
     render(
-      <Timestamp
-        value="2026-02-19T17:00:00Z"
-        format="date"
-        data-testid="ts"
-      />,
+      <Timestamp value="2026-02-19T17:00:00Z" format="date" data-testid="ts" />,
     );
     const el = screen.getByTestId('ts');
     expect(el.textContent).toContain('2026');
@@ -77,11 +93,7 @@ describe('Timestamp', () => {
 
   it('renders time format', () => {
     render(
-      <Timestamp
-        value="2026-02-19T17:00:00Z"
-        format="time"
-        data-testid="ts"
-      />,
+      <Timestamp value="2026-02-19T17:00:00Z" format="time" data-testid="ts" />,
     );
     const el = screen.getByTestId('ts');
     // Should contain time but not year
@@ -210,11 +222,7 @@ describe('Timestamp', () => {
   it('forwards ref', () => {
     const ref = {current: null as HTMLTimeElement | null};
     render(
-      <Timestamp
-        ref={ref}
-        value="2026-03-25T10:00:00Z"
-        format="date_time"
-      />,
+      <Timestamp ref={ref} value="2026-03-25T10:00:00Z" format="date_time" />,
     );
     expect(ref.current).toBeInstanceOf(HTMLTimeElement);
   });

--- a/packages/core/src/Timestamp/Timestamp.tsx
+++ b/packages/core/src/Timestamp/Timestamp.tsx
@@ -49,7 +49,7 @@ export interface TimestampProps extends BaseProps<HTMLTimeElement> {
   value: string | number;
   /**
    * Display format.
-   * - `'relative'`: "2 hours ago", "yesterday", "just now"
+   * - `'relative'`: "2 hours ago", "yesterday", "now"
    * - `'auto'`: Relative for recent times, `date_time` for older
    * - `'date'`: "Mar 21, 2025"
    * - `'date_time'`: "Mar 21, 2025, 2:51 PM"
@@ -145,13 +145,13 @@ function parseValue(value: string | number): Date {
 function getRelativeTimeString(date: Date, now: Date): string {
   const diffSeconds = Math.round((now.getTime() - date.getTime()) / 1000);
 
-  // Treat values at (or a hair before/after) the present as "just now". The
+  // Treat values at (or a hair before/after) the present as "now". The
   // internal `now` reference is captured at render time, so it can lag the
   // real clock; a value equal to "right now" can land a fraction of a second
   // in the future and round to a small negative delta. Without this clamp,
   // such values fall into the future branch and render "in a few seconds".
   if (Math.abs(diffSeconds) < 10) {
-    return 'just now';
+    return 'now';
   }
 
   if (diffSeconds < 0) {

--- a/packages/core/src/Timestamp/Timestamp.tsx
+++ b/packages/core/src/Timestamp/Timestamp.tsx
@@ -133,6 +133,18 @@ const YEAR = 365 * DAY;
 /** Default auto threshold: 7 days in seconds */
 const DEFAULT_AUTO_THRESHOLD = 7 * DAY;
 
+/**
+ * Tolerance (in seconds) for treating a *future* timestamp as the present.
+ * A value only a handful of seconds ahead of our reference clock is almost
+ * always clock skew — the displayed `now` lagging the real clock, or the value
+ * being produced on a slightly faster clock — not a genuine future event, so
+ * it reads as "now" rather than a confusing "in a few seconds". The future
+ * side gets a wider window than the past (which only needs to absorb the
+ * sub-second render-time lag) because future drift is far more likely to be
+ * skew than real.
+ */
+const FUTURE_SKEW_TOLERANCE = 30;
+
 function parseValue(value: string | number): Date {
   if (typeof value === 'number') {
     // Heuristic: if the number is less than 1e12, treat as seconds; otherwise ms.
@@ -157,6 +169,13 @@ function getRelativeTimeString(date: Date, now: Date): string {
   if (diffSeconds < 0) {
     // Future dates
     const absDiff = Math.abs(diffSeconds);
+    // A value only a few seconds ahead of our clock is almost always skew, not
+    // a genuine future event — render it as the present rather than a
+    // confusing "in a few seconds". Wider than the past window above on
+    // purpose (see FUTURE_SKEW_TOLERANCE).
+    if (absDiff <= FUTURE_SKEW_TOLERANCE) {
+      return 'now';
+    }
     if (absDiff < MINUTE) {
       return 'in a few seconds';
     }

--- a/packages/core/src/Timestamp/Timestamp.tsx
+++ b/packages/core/src/Timestamp/Timestamp.tsx
@@ -19,12 +19,7 @@
 import {useEffect, useRef, useState, lazy, Suspense} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {Text} from '../Text';
-import type {
-  TextType,
-  TextSize,
-  TextColor,
-  TextWeight,
-} from '../theme/types';
+import type {TextType, TextSize, TextColor, TextWeight} from '../theme/types';
 import {mergeProps, mergeRefs} from '../utils';
 import type {BaseProps} from '../BaseProps';
 import {themeProps} from '../utils/themeProps';
@@ -150,6 +145,15 @@ function parseValue(value: string | number): Date {
 function getRelativeTimeString(date: Date, now: Date): string {
   const diffSeconds = Math.round((now.getTime() - date.getTime()) / 1000);
 
+  // Treat values at (or a hair before/after) the present as "just now". The
+  // internal `now` reference is captured at render time, so it can lag the
+  // real clock; a value equal to "right now" can land a fraction of a second
+  // in the future and round to a small negative delta. Without this clamp,
+  // such values fall into the future branch and render "in a few seconds".
+  if (Math.abs(diffSeconds) < 10) {
+    return 'just now';
+  }
+
   if (diffSeconds < 0) {
     // Future dates
     const absDiff = Math.abs(diffSeconds);
@@ -176,9 +180,6 @@ function getRelativeTimeString(date: Date, now: Date): string {
     return `in ${years} ${years === 1 ? 'year' : 'years'}`;
   }
 
-  if (diffSeconds < 10) {
-    return 'just now';
-  }
   if (diffSeconds < MINUTE) {
     return `${diffSeconds} seconds ago`;
   }


### PR DESCRIPTION
## Bug

`Timestamp` renders **"in a few seconds"** for a time that is "right now". In a UI
where an action sets a timestamp to the current instant, the label flips to a
future phrase instead of reading "just now". Closes #3099.

## Reproduction (failing test, now passing)

Added a regression test that renders `Timestamp` with a value at/near the
present and asserts it never shows a future phrase:

```tsx
it('renders "just now" for a value a hair in the future (clock skew)', () => {
  const aHairInTheFuture = Date.now() / 1000 + 0.6;
  render(<Timestamp value={aHairInTheFuture} format="relative" />);
  expect(screen.queryByText(/^in /)).not.toBeInTheDocument();
  expect(screen.getByText('just now')).toBeInTheDocument();
});
```

**Before the fix** this rendered `in a few seconds` and the test failed.
**After the fix** it renders `just now` and all 25 Timestamp tests pass.

## Root cause

The relative-time formatter computes `diffSeconds = round((now - value) / 1000)`,
where `now` is captured once at render time. A value equal to the current
instant can land a fraction of a second **in the future** relative to that
captured baseline, rounding to a tiny negative `diffSeconds`. The very first
branch treated any negative delta as a future date and, for sub-minute deltas,
returned `"in a few seconds"`.

## Fix

Clamp deltas within the existing "just now" window (`|diffSeconds| < 10s`) to
`"just now"` before the future/past branching. This makes the present and
near-present read correctly regardless of sub-second skew between the value and
the captured `now`, and removes the now-redundant past-side `< 10s` check.

A patch changeset is included.
