### PR TITLE
fix(docs): show default icons in icon table

### DIFF
--- a/apps/docsite/src/components/docs/TableBlock.tsx
+++ b/apps/docsite/src/components/docs/TableBlock.tsx
@@ -7,7 +7,7 @@ import {Text} from '@astryxdesign/core/Text';
 import {Table, pixel, type TableColumn} from '@astryxdesign/core/Table';
 import {Card} from '@astryxdesign/core/Card';
 import {HStack} from '@astryxdesign/core/Layout';
-import {Icon} from '@astryxdesign/core/Icon';
+import {Icon, getIconRegistry} from '@astryxdesign/core/Icon';
 import type {IconName} from '@astryxdesign/core/Icon';
 import {renderInlineMarkdown} from './inlineMarkdown';
 
@@ -17,37 +17,12 @@ const styles = stylex.create({
   iconNameText: {minWidth: 0},
 });
 
-const SEMANTIC_ICON_NAMES = new Set<IconName>([
-  'close',
-  'chevronDown',
-  'chevronLeft',
-  'chevronRight',
-  'check',
-  'success',
-  'error',
-  'warning',
-  'info',
-  'calendar',
-  'clock',
-  'externalLink',
-  'menu',
-  'moreHorizontal',
-  'search',
-  'arrowUp',
-  'arrowDown',
-  'arrowsUpDown',
-  'funnel',
-  'eyeSlash',
-  'viewColumns',
-  'copy',
-  'checkDouble',
-  'wrench',
-  'stop',
-  'microphone',
-]);
+const semanticIconNames = new Set<IconName>(
+  Object.keys(getIconRegistry()) as IconName[],
+);
 
 function isIconName(value: string): value is IconName {
-  return SEMANTIC_ICON_NAMES.has(value as IconName);
+  return semanticIconNames.has(value as IconName);
 }
 
 function renderCellContent(value: string, header: string) {

--- a/apps/docsite/src/components/docs/TableBlock.tsx
+++ b/apps/docsite/src/components/docs/TableBlock.tsx
@@ -2,10 +2,68 @@
 
 'use client';
 
+import * as stylex from '@stylexjs/stylex';
 import {Text} from '@astryxdesign/core/Text';
-import {Table} from '@astryxdesign/core/Table';
+import {Table, pixel, type TableColumn} from '@astryxdesign/core/Table';
 import {Card} from '@astryxdesign/core/Card';
+import {HStack} from '@astryxdesign/core/Layout';
+import {Icon} from '@astryxdesign/core/Icon';
+import type {IconName} from '@astryxdesign/core/Icon';
 import {renderInlineMarkdown} from './inlineMarkdown';
+
+const styles = stylex.create({
+  tableCard: {maxWidth: 'var(--docs-table-max-width)'},
+  iconNameCell: {minWidth: 0},
+  iconNameText: {minWidth: 0},
+});
+
+const SEMANTIC_ICON_NAMES = new Set<IconName>([
+  'close',
+  'chevronDown',
+  'chevronLeft',
+  'chevronRight',
+  'check',
+  'success',
+  'error',
+  'warning',
+  'info',
+  'calendar',
+  'clock',
+  'externalLink',
+  'menu',
+  'moreHorizontal',
+  'search',
+  'arrowUp',
+  'arrowDown',
+  'arrowsUpDown',
+  'funnel',
+  'eyeSlash',
+  'viewColumns',
+  'copy',
+  'checkDouble',
+  'wrench',
+  'stop',
+  'microphone',
+]);
+
+function isIconName(value: string): value is IconName {
+  return SEMANTIC_ICON_NAMES.has(value as IconName);
+}
+
+function renderCellContent(value: string, header: string) {
+  if (header === 'Name' && isIconName(value)) {
+    return (
+      <HStack gap={2} align="center" xstyle={styles.iconNameCell}>
+        <Icon icon={value} size="sm" color="secondary" />
+        <Text type="code" maxLines={1} xstyle={styles.iconNameText}>
+          {value}
+        </Text>
+      </HStack>
+    );
+  }
+
+  return <Text>{renderInlineMarkdown(value)}</Text>;
+}
 
 export function TableBlock({
   headers,
@@ -22,16 +80,16 @@ export function TableBlock({
     return obj;
   });
 
-  const columns = headers.map(h => ({
+  const columns: TableColumn<Record<string, unknown>>[] = headers.map(h => ({
     key: h,
     header: h,
-    renderCell: (item: Record<string, unknown>) => (
-      <Text>{renderInlineMarkdown(item[h] as string)}</Text>
-    ),
+    width: h === 'Name' ? pixel(220) : undefined,
+    renderCell: (item: Record<string, unknown>) =>
+      renderCellContent((item[h] as string) ?? '', h),
   }));
 
   return (
-    <Card>
+    <Card xstyle={styles.tableCard}>
       <Table
         data={data}
         columns={columns}


### PR DESCRIPTION
## Summary
- Render semantic icon previews next to icon names in docs tables
- Derive valid semantic icon names from `getIconRegistry()` so previews track the same registry used by `Icon`
- Preserve existing markdown rendering for other docs table cells

## Test plan
- pnpm -F @astryxdesign/core build
- pnpm -F @astryxdesign/docsite generate
- pnpm -F @astryxdesign/docsite test
- pnpm exec eslint apps/docsite/src/components/docs/TableBlock.tsx

Note: `pnpm -F @astryxdesign/docsite build` reached Next.js production compilation locally but was killed by the sandbox. GitHub/Vercel build checks are the source of truth for the full production build.
