### PR TITLE
docs: add CommandPaletteEmpty preview

### DIFF
--- a/packages/cli/templates/blocks/components/CommandPaletteEmpty/CommandPaletteEmptyShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/CommandPaletteEmpty/CommandPaletteEmptyShowcase.doc.mjs
@@ -1,0 +1,15 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  exampleFor: 'CommandPaletteEmpty',
+  name: 'CommandPaletteEmpty',
+  displayName: 'Command Palette Empty',
+  description:
+    'Command palette empty state shown when no commands are available.',
+  isReady: true,
+  isShowcase: true,
+  aspectRatio: 4 / 3,
+  componentsUsed: ['CommandPalette', 'CommandPaletteEmpty', 'Text'],
+};

--- a/packages/cli/templates/blocks/components/CommandPaletteEmpty/CommandPaletteEmptyShowcase.tsx
+++ b/packages/cli/templates/blocks/components/CommandPaletteEmpty/CommandPaletteEmptyShowcase.tsx
@@ -1,0 +1,26 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import {useMemo} from 'react';
+import {CommandPalette} from '@astryxdesign/core/CommandPalette';
+import {Text} from '@astryxdesign/core/Text';
+import {createStaticSource} from '@astryxdesign/core/Typeahead';
+
+export default function CommandPaletteEmptyShowcase() {
+  const emptySource = useMemo(() => createStaticSource([]), []);
+
+  return (
+    <CommandPalette
+      isOpen
+      isInline
+      onOpenChange={() => {}}
+      searchSource={emptySource}
+      emptyBootstrapText={
+        <Text type="supporting" color="secondary">
+          No commands available yet
+        </Text>
+      }
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- Add a `CommandPaletteEmpty` showcase block so the component detail page renders the same top preview treatment as sibling Command Palette pages.
- The preview uses an inline `CommandPalette` with an empty static source to exercise the no-bootstrap-results empty state.

## Test plan
- `pnpm -F @astryxdesign/core build`
- `pnpm -F @astryxdesign/docsite generate`
- `pnpm -F @astryxdesign/docsite exec vitest run src/__tests__/data-extraction.test.ts`
- `pnpm -F @astryxdesign/docsite exec vitest run src/__tests__/data-extraction.test.ts src/__tests__/component-preview-state.test.ts`
- Verified locally at `/components/CommandPaletteEmpty` that the page renders the new preview.
