### PR TITLE
fix(build): ship TypeScript declarations for the ./vite export

### DIFF
--- a/.changeset/build-vite-declarations.md
+++ b/.changeset/build-vite-declarations.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/build': patch
+---
+
+[fix] ship TypeScript declarations for the `@astryxdesign/build/vite` export
+@benjipeng

--- a/packages/build/build.mjs
+++ b/packages/build/build.mjs
@@ -10,6 +10,7 @@
  */
 import {buildSync} from 'esbuild';
 import {readFileSync, writeFileSync} from 'fs';
+import {execSync} from 'node:child_process';
 
 buildSync({
   entryPoints: ['src/vite.ts'],
@@ -39,3 +40,8 @@ content = content.replaceAll(
 writeFileSync('dist/vite.mjs', content);
 
 console.log('Built dist/vite.mjs');
+
+// Emit TypeScript declarations for the ./vite export. esbuild cannot generate
+// them, so run tsc (declaration-only) — the same pattern the theme packages use.
+execSync('tsc --project tsconfig.build.json', {stdio: 'inherit'});
+console.log('Built dist/vite.d.ts');

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -25,7 +25,10 @@
     ".": "./src/config.js",
     "./babel": "./src/babel.js",
     "./postcss": "./src/index.js",
-    "./vite": "./dist/vite.mjs",
+    "./vite": {
+      "types": "./dist/vite.d.ts",
+      "import": "./dist/vite.mjs"
+    },
     "./next": "./src/next.js"
   },
   "files": [

--- a/packages/build/tsconfig.build.json
+++ b/packages/build/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "skipLibCheck": true,
+    "target": "es2022",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/vite.ts"]
+}


### PR DESCRIPTION
## TL;DR

`@astryxdesign/build/vite` ships JS but no `.d.ts`, so every TypeScript consumer hand-writes an ambient `declare module` shim. This emits `dist/vite.d.ts` and adds a `types` condition to the export — completing the typings half of the ask in #2240. Four-file change, no new deps, changeset included.

## Problem

The `./vite` export points at built JS only:

```jsonc
"./vite": "./dist/vite.mjs"
```

There's no `types` condition and no `dist/vite.d.ts`. So under `moduleResolution: bundler`/`node16`:

```ts
import { astryxStylex } from '@astryxdesign/build/vite';
//                            ^ Could not find a declaration file for module
```

…and consumers fall back to a hand-maintained shim. #2240 asked for the Vite export to *ship at all* — that landed; this is the missing declarations.

## Fix

- **`build.mjs`** — after the esbuild step, emit declarations via `tsc --project tsconfig.build.json` (esbuild can't generate `.d.ts`). Same pattern the theme packages already use.
- **`tsconfig.build.json`** (new) — declaration-only emit of `src/vite.ts` → `dist/vite.d.ts`.
- **`package.json`** — give `./vite` a `types` condition. `files` already includes `dist`, so the `.d.ts` ships. No new deps: `shamefully-hoist=true` keeps `typescript`/`@types/node`/`vite`/`@stylexjs/*` resolvable from the root.

## Verification

Built the package against a flat/hoisted `node_modules` (matching the repo's `.npmrc`):

```
$ node build.mjs
Built dist/vite.mjs
Built dist/vite.d.ts
```

`dist/vite.d.ts` carries full types for `astryxStylex()`, `AstryxVitePluginOptions`, `AstryxVitePluginLegacyOptions`, and `LIGHTNINGCSS_TARGETS`; consuming `@astryxdesign/build/vite` then resolves with no shim.
