### PR TITLE
docs(build): remove internal reference from ./vite plugin JSDoc

### DIFF
--- a/packages/build/src/vite.ts
+++ b/packages/build/src/vite.ts
@@ -79,7 +79,7 @@ export interface AstryxVitePluginOptions {
    * build uses a distinct prefix so library and product atoms never collide
    * across layers.
    *
-   * Configurable to support the Astryx-prefix migration (P2380608025): a consumer
+   * Configurable to support the Astryx-prefix migration: a consumer
    * can rebrand the library atom prefix to `astryx` before the final cutover.
    * Defaults to `xds` so existing consumers are unaffected.
    *


### PR DESCRIPTION
## What

A JSDoc comment on the `stylexPrefix` option in the Vite plugin source (`packages/build/src/vite.ts`) carried an internal project reference that should not appear in a public/published source file. This removes that reference while preserving the explanation of what the option is for.

## Why

`packages/build/src/vite.ts` is part of a published package, so its JSDoc can surface in consumers' `.d.ts` files and editor tooltips. The internal reference has no meaning to external consumers and does not belong on a public source surface.

## Details

- **Comment text only.** No code, types, defaults, or runtime behavior changed.
- The comment still explains that the prefix is configurable to support the Astryx-prefix migration so a consumer can rebrand the library atom prefix before the final cutover.
- No behavior or API impact; no consumer-visible change, so no changeset is needed.
