### PR TITLE
fix(core): Kbd uses --color-border-emphasized for its border

### DIFF
--- a/.changeset/kbd-border-emphasized.md
+++ b/.changeset/kbd-border-emphasized.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Kbd: use the `--color-border-emphasized` token for its bottom border instead of `--color-border` (#2850)
+@durvesh1992

--- a/packages/core/src/Kbd/Kbd.tsx
+++ b/packages/core/src/Kbd/Kbd.tsx
@@ -45,7 +45,7 @@ const styles = stylex.create({
     backgroundColor: colorVars['--color-neutral'],
     borderBottomWidth: '2px',
     borderBottomStyle: 'solid',
-    borderBottomColor: colorVars['--color-border'],
+    borderBottomColor: colorVars['--color-border-emphasized'],
     color: colorVars['--color-text-secondary'],
     fontFamily: typographyVars['--font-family-body'],
     fontSize: typeScaleVars['--text-supporting-size'],
@@ -146,14 +146,7 @@ export interface KbdProps extends BaseProps<HTMLSpanElement> {
  * <Kbd keys="mod+k" />
  * ```
  */
-export function Kbd({
-  keys,
-  ref,
-  xstyle,
-  className,
-  style,
-  ...rest
-}: KbdProps) {
+export function Kbd({keys, ref, xstyle, className, style, ...rest}: KbdProps) {
   const isMac = useSyncExternalStore(
     subscribeToPlatformChanges,
     detectMac,


### PR DESCRIPTION
## Summary

Closes #2850.

`Kbd` rendered its 2px bottom border with the `--color-border` token, which is too subtle for the raised-key affordance and can be nearly invisible on muted backgrounds. Switch the `borderBottomColor` to `--color-border-emphasized` so the key edge reads clearly across themes.

`packages/core/src/Kbd/Kbd.tsx` — one token reference changed.

## Testing
- `pnpm -F @astryxdesign/core test Kbd` — 12/12 pass (no color/snapshot assertions, so no test updates needed).
- `node scripts/check-changesets.mjs` — changeset valid (patch).

## Changeset
Included (`@astryxdesign/core` patch) since this touches a published package.