### PR TITLE
fix(core): Timestamp shows 'just now' for near-future clock skew

### DIFF
--- a/.changeset/timestamp-clock-skew-just-now.md
+++ b/.changeset/timestamp-clock-skew-just-now.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Timestamp: render "just now" instead of "in a few seconds" for a value that is only a few seconds in the future, which is almost always clock skew rather than a genuine future event (#3099)
+@durvesh1992

--- a/packages/core/src/Timestamp/Timestamp.test.tsx
+++ b/packages/core/src/Timestamp/Timestamp.test.tsx
@@ -49,11 +49,7 @@ describe('Timestamp', () => {
 
   it('renders date format', () => {
     render(
-      <Timestamp
-        value="2026-02-19T17:00:00Z"
-        format="date"
-        data-testid="ts"
-      />,
+      <Timestamp value="2026-02-19T17:00:00Z" format="date" data-testid="ts" />,
     );
     const el = screen.getByTestId('ts');
     expect(el.textContent).toContain('2026');
@@ -77,11 +73,7 @@ describe('Timestamp', () => {
 
   it('renders time format', () => {
     render(
-      <Timestamp
-        value="2026-02-19T17:00:00Z"
-        format="time"
-        data-testid="ts"
-      />,
+      <Timestamp value="2026-02-19T17:00:00Z" format="time" data-testid="ts" />,
     );
     const el = screen.getByTestId('ts');
     // Should contain time but not year
@@ -210,11 +202,7 @@ describe('Timestamp', () => {
   it('forwards ref', () => {
     const ref = {current: null as HTMLTimeElement | null};
     render(
-      <Timestamp
-        ref={ref}
-        value="2026-03-25T10:00:00Z"
-        format="date_time"
-      />,
+      <Timestamp ref={ref} value="2026-03-25T10:00:00Z" format="date_time" />,
     );
     expect(ref.current).toBeInstanceOf(HTMLTimeElement);
   });
@@ -238,6 +226,20 @@ describe('Timestamp', () => {
     const oneHourFromNow = Date.now() / 1000 + 3600;
     render(<Timestamp value={oneHourFromNow} format="relative" />);
     expect(screen.getByText('in 1 hour')).toBeInTheDocument();
+  });
+
+  it('renders "just now" for a value a few seconds in the future (clock skew)', () => {
+    // Simulates the value's clock being slightly ahead of our reference clock,
+    // e.g. when a timestamp is set to "right now" while the displayed `now` lags.
+    const fiveSecondsFromNow = Date.now() / 1000 + 5;
+    render(<Timestamp value={fiveSecondsFromNow} format="relative" />);
+    expect(screen.getByText('just now')).toBeInTheDocument();
+  });
+
+  it('still renders a genuine near-future time beyond the skew tolerance', () => {
+    const fortyFiveSecondsFromNow = Date.now() / 1000 + 45;
+    render(<Timestamp value={fortyFiveSecondsFromNow} format="relative" />);
+    expect(screen.getByText('in a few seconds')).toBeInTheDocument();
   });
 
   // --- Long-ago relative ---

--- a/packages/core/src/Timestamp/Timestamp.tsx
+++ b/packages/core/src/Timestamp/Timestamp.tsx
@@ -19,12 +19,7 @@
 import {useEffect, useRef, useState, lazy, Suspense} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {Text} from '../Text';
-import type {
-  TextType,
-  TextSize,
-  TextColor,
-  TextWeight,
-} from '../theme/types';
+import type {TextType, TextSize, TextColor, TextWeight} from '../theme/types';
 import {mergeProps, mergeRefs} from '../utils';
 import type {BaseProps} from '../BaseProps';
 import {themeProps} from '../utils/themeProps';
@@ -135,6 +130,16 @@ const DAY = 86400;
 const MONTH = 30 * DAY;
 const YEAR = 365 * DAY;
 
+/**
+ * Tolerance (in seconds) for treating a "future" timestamp as the present.
+ * A value only a handful of seconds ahead of our reference clock is virtually
+ * always clock skew — the displayed `now` lagging the real clock, or the value
+ * being produced on a slightly faster clock — not a genuine future event.
+ * These render as "just now" instead of a confusing "in a few seconds" for
+ * what is effectively the current time.
+ */
+const CLOCK_SKEW_TOLERANCE = 30;
+
 /** Default auto threshold: 7 days in seconds */
 const DEFAULT_AUTO_THRESHOLD = 7 * DAY;
 
@@ -153,6 +158,10 @@ function getRelativeTimeString(date: Date, now: Date): string {
   if (diffSeconds < 0) {
     // Future dates
     const absDiff = Math.abs(diffSeconds);
+    if (absDiff <= CLOCK_SKEW_TOLERANCE) {
+      // Effectively "now" — small skew between the value and our clock.
+      return 'just now';
+    }
     if (absDiff < MINUTE) {
       return 'in a few seconds';
     }


### PR DESCRIPTION
## Summary

Closes #3099.

When a `Timestamp` value is set to the current time but the component's internal `now` reference lags the real clock, the diff goes slightly negative and the relative formatter returned **"in a few seconds"** for what is effectively the present. This is confusing in UIs that update a timestamp on an action (the reported repro: clicking an action that sets the timestamp to "right now").

Treat a value within a small clock-skew tolerance (`CLOCK_SKEW_TOLERANCE = 30s`) in the future as **"just now"**. Genuine near-future times beyond the tolerance still render "in a few seconds", and all larger future ranges ("in 1 hour", etc.) are unchanged.

`packages/core/src/Timestamp/Timestamp.tsx` — add the tolerance constant and short-circuit in `getRelativeTimeString`.

## Testing
- `pnpm -F @astryxdesign/core test Timestamp` — **25/25 pass** (23 existing + 2 new).
- New tests: a value +5s in the future → "just now"; a value +45s → still "in a few seconds" (tolerance boundary preserved).

## Changeset
Included (`@astryxdesign/core` patch).