### PR TITLE
fix(docsite): restore Icon and Skeleton properties-tab previews

### DIFF
--- a/.changeset/docsite-icon-skeleton-properties-preview.md
+++ b/.changeset/docsite-icon-skeleton-properties-preview.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[docs] Restore the Icon and Skeleton properties-tab previews on the docsite. Icon now seeds a default `icon` (it was a required, non-generatable prop), and Skeleton renders with concrete preview dimensions instead of collapsing at `100%` (#2848, #2875)
+@durvesh1992

--- a/apps/docsite/src/__tests__/component-preview-state.test.ts
+++ b/apps/docsite/src/__tests__/component-preview-state.test.ts
@@ -94,6 +94,43 @@ describe('component detail preview state', () => {
     expect(getMissingRequiredProps(knobs, state)).toEqual(['config']);
   });
 
+  it("satisfies Icon's required, non-generatable icon prop via playground defaults", () => {
+    const knobs = pickPrimaryProps('Icon', [
+      prop({
+        name: 'icon',
+        type: 'IconName | ComponentType<SVGProps>',
+        required: true,
+      }),
+    ]);
+
+    // Without a playground default the required icon prop cannot be generated.
+    expect(getMissingRequiredProps(knobs, buildInitialState(knobs))).toEqual([
+      'icon',
+    ]);
+
+    // The doc's playground default seeds a valid semantic name.
+    const state = buildInitialState(knobs, {defaults: {icon: 'search'}});
+    expect(state.icon).toBe('search');
+    expect(getMissingRequiredProps(knobs, state)).toEqual([]);
+  });
+
+  it('gives Skeleton concrete preview dimensions via playground defaults', () => {
+    const knobs = pickPrimaryProps('Skeleton', [
+      prop({name: 'width', type: 'number | string', default: "'100%'"}),
+      prop({name: 'height', type: 'number | string', default: "'100%'"}),
+    ]);
+
+    // Doc defaults alone would render at 100% (collapses in the centered preview).
+    expect(buildInitialState(knobs).width).toBe('100%');
+
+    // Playground defaults override with visible pixel dimensions.
+    const state = buildInitialState(knobs, {
+      defaults: {width: 200, height: 24},
+    });
+    expect(state.width).toBe(200);
+    expect(state.height).toBe(24);
+  });
+
   it('wires controlled open previews back to their isOpen prop', () => {
     const onPropChange = vi.fn();
     const runtimeState = buildRuntimePreviewState(

--- a/packages/core/src/Icon/Icon.doc.mjs
+++ b/packages/core/src/Icon/Icon.doc.mjs
@@ -7,6 +7,14 @@ export const docs = {
   displayName: 'Icon',
   category: 'Content',
   keywords: ["icon","svg","glyph","symbol","pictogram","graphic","vector"],
+  playground: {
+    // `icon` is required and its type can't be auto-generated, so the
+    // properties-tab preview showed "Missing: icon". Seed a valid semantic
+    // icon name so the interactive preview renders.
+    defaults: {
+      icon: 'search',
+    },
+  },
   props: [
     {
       name: 'icon',

--- a/packages/core/src/Skeleton/Skeleton.doc.mjs
+++ b/packages/core/src/Skeleton/Skeleton.doc.mjs
@@ -7,6 +7,15 @@ export const docs = {
   displayName: 'Skeleton',
   category: 'Feedback & Status',
   keywords: ["skeleton","placeholder","loading","shimmer","pulse","loader","bone","ghost","preloader"],
+  playground: {
+    // width/height default to '100%', which collapses to nothing inside the
+    // centered properties-tab preview. Give the preview concrete dimensions
+    // so the skeleton is actually visible.
+    defaults: {
+      width: 200,
+      height: 24,
+    },
+  },
   props: [
     {
       name: 'width',


### PR DESCRIPTION
## Summary

Closes #2848. Closes #2875.

Two components rendered a broken **properties-tab** interactive preview on the docsite. Both are fixed by adding `playground.defaults` to their `.doc.mjs`:

- **Icon (#2848):** `icon` is required and its type (`IconName | ComponentType<SVGProps>`) can't be auto-generated, so the tab showed *"Interactive preview needs required props … Missing: icon"*. Seed a valid semantic name (`icon: 'search'`).
- **Skeleton (#2875):** `width`/`height` default to `'100%'`, which collapses to nothing inside the centered preview. Provide concrete pixel dimensions (`200 × 24`).

## Testing
- Extended `component-preview-state.test.ts` — **10/10 pass**. The Icon test asserts the prop is genuinely *Missing* without the default and satisfied with it; the Skeleton test asserts the playground default overrides the `100%` doc default.
- Re-ran `generate-data.mjs` — both `.doc.mjs` files parse and the registry rebuilds cleanly.

## Changeset
Included (`@astryxdesign/core` patch, docs) since `.doc.mjs` files ship in `core/src`.