### PR TITLE
docs(core): document Heading's justify prop

### DIFF
--- a/.changeset/heading-justify-prop-doc.md
+++ b/.changeset/heading-justify-prop-doc.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[docs] Document Heading's `justify` prop, which was supported by the component but missing from the docsite properties tab (#2847)
+@durvesh1992

--- a/packages/core/src/Text/Heading.doc.mjs
+++ b/packages/core/src/Text/Heading.doc.mjs
@@ -65,6 +65,12 @@ export const docs = {
       description: 'Text wrapping behavior.',
     },
     {
+      name: 'justify',
+      type: "'start' | 'center' | 'end'",
+      description: 'Text alignment (justification). Uses logical values (start/end) for i18n/RTL compatibility.',
+      default: "'start'",
+    },
+    {
       name: 'hasCapsize',
       type: 'boolean',
       description: 'Enable optical alignment using text-box-trim. Forces block display.',
@@ -146,6 +152,12 @@ export const docsZh = {
       description: '文本换行行为。',
     },
     {
+      name: 'justify',
+      type: "'start' | 'center' | 'end'",
+      description: '文本对齐（两端对齐）。使用逻辑值（start/end）以兼容 i18n/RTL。',
+      default: "'start'",
+    },
+    {
       name: 'hasCapsize',
       type: 'boolean',
       description: '使用 text-box-trim 启用光学对齐。强制块级显示。',
@@ -180,6 +192,7 @@ export const docsDense = {
     hasTruncateTooltip: "Tooltip for truncated text; true=default position, false=disabled, or a placement ('above' | 'below' | 'start' | 'end').",
     wordBreak: "Word break behavior; defaults 'break-all' for single-line, 'break-word' otherwise.",
     textWrap: 'Text wrapping behavior.',
+    justify: "Text alignment (justification); logical values 'start' | 'center' | 'end' for RTL.",
     hasCapsize: 'Optical alignment via text-box-trim; forces block display.',
     hasStrikethrough: 'Strikethrough text decoration.',
     id: 'HTML id attribute.',


### PR DESCRIPTION
## Summary

Closes #2847.

`Heading` supports a **`justify`** prop (`TextJustify`: `'start' | 'center' | 'end'`, default `'start'`) for text alignment, but it was missing from the docsite **properties tab**. The properties tab is driven by the `props` array in `packages/core/src/Text/Heading.doc.mjs`, and `justify` simply wasn't listed.

> Note: the issue called it "justification" (from the prop's JSDoc); the actual prop name is `justify`.

Added `justify` to all three doc exports (`docs`, `docsZh`, `docsDense`), positioned after `textWrap` to match the interface order.

## Testing
- Audited the full `HeadingProps` interface against the doc's prop list — `justify` was the **only** omission.
- Re-ran `generate-data.mjs` — `justify` now appears in the generated Heading component registry.

## Changeset
Included (`@astryxdesign/core` patch, docs) since `.doc.mjs` ships in `core/src`.