### PR TITLE
docs(cli): move "ToggleButton — Group" example to the ToggleButtonGroup page

### DIFF
--- a/.changeset/togglebutton-group-example-page.md
+++ b/.changeset/togglebutton-group-example-page.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[docs] Move the "ToggleButton — Group" example to the ToggleButtonGroup page, where it belongs (it demonstrates grouped toggle behavior) (#2842)
+@durvesh1992

--- a/packages/cli/templates/blocks/components/ToggleButton/ToggleButtonGroup.doc.mjs
+++ b/packages/cli/templates/blocks/components/ToggleButton/ToggleButtonGroup.doc.mjs
@@ -3,7 +3,7 @@
 /** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   type: 'block',
-  exampleFor: 'ToggleButton',
+  exampleFor: 'ToggleButtonGroup',
   name: 'ToggleButton — Group',
   displayName: 'ToggleButton — Group',
   description: 'Toggle button groups in single-select and multi-select modes. Single selection acts as a view mode switcher; multiple selection forms a formatting toolbar.',


### PR DESCRIPTION
## Summary

Closes #2842.

The **"ToggleButton — Group"** example demonstrates grouped toggle behavior (it renders `ToggleButtonGroup`), but it was tagged `exampleFor: 'ToggleButton'`, so it showed on the `ToggleButton` page instead of `ToggleButtonGroup`. Retargeted `exampleFor` to `'ToggleButtonGroup'`.

## Testing
- Re-ran `generate-data.mjs` — the example now appears under the `'ToggleButtonGroup'` key in the generated example registry (previously under `'ToggleButton'`).

## Changeset
Included (`@astryxdesign/cli` patch, docs) since the example block ships in `cli/templates`.