### PR TITLE
fix(core): align Tokenizer/PowerSearch end content with field padding

### DIFF
--- a/.changeset/tokenizer-endsection-padding.md
+++ b/.changeset/tokenizer-endsection-padding.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Tokenizer/PowerSearch: align end content (clear button, resultCount) with the field's inline padding instead of hugging the border (~3px). It now uses spacing-2 (8px) to match the text/start-icon inset (#2849)
+@durvesh1992

--- a/packages/core/src/Tokenizer/Tokenizer.tsx
+++ b/packages/core/src/Tokenizer/Tokenizer.tsx
@@ -222,7 +222,10 @@ const styles = stylex.create({
   },
   endSection: {
     position: 'absolute',
-    insetInlineEnd: `calc(${spacingVars['--spacing-1']} - 1px)`,
+    // Match the field's inline padding (inputWrapperStyles.base uses
+    // spacing-2) so end content (clear button, resultCount) lines up with
+    // the text/start-icon inset instead of hugging the border at ~3px.
+    insetInlineEnd: spacingVars['--spacing-2'],
     display: 'flex',
     alignItems: 'center',
     gap: spacingVars['--spacing-2'],


### PR DESCRIPTION
## Summary

Closes #2849.

In `PowerSearch`, the `resultCount` (and the Tokenizer clear button / any `endContent`) sat ~3px from the field's right edge instead of matching the field padding.

Root cause: the Tokenizer `endSection` used `insetInlineEnd: calc(spacing-1 - 1px)` = **3px**, while the field's content padding (`inputWrapperStyles.base` → `paddingInline: spacing-2` = **8px**) and the restored text/start-icon insets (`startIconWithTokens`, `inputCompact`) all resolve to **8px**. So end content was misaligned with the text in both the token and non-token states.

Fix: set `endSection.insetInlineEnd` to `--spacing-2` (8px) so end content lines up with the field's inline padding.

## Testing
- `pnpm -F @astryxdesign/core test Tokenizer PowerSearch` — **148/148 pass**.
- Reasoning verified against `inputStyles.stylex.ts` (base `paddingInline: spacing-2`) and the existing start-side restoration styles, which target the same 8px inset.

## Changeset
Included (`@astryxdesign/core` patch).