### PR TITLE
fix(docsite): extend article body readability to changelog, blog, component pages

### DIFF
--- a/apps/docsite/src/components/ChangelogView.tsx
+++ b/apps/docsite/src/components/ChangelogView.tsx
@@ -10,6 +10,7 @@ import {VStack} from '@astryxdesign/core/Layout';
 import {Section} from '@astryxdesign/core/Section';
 import {TabList, Tab} from '@astryxdesign/core/TabList';
 import {Carousel} from '@astryxdesign/core/Carousel';
+import {typeScaleVars} from '@astryxdesign/core/theme/tokens.stylex';
 import {GITHUB_REPO} from '../constants';
 import {layout} from '../layout.stylex';
 
@@ -61,6 +62,13 @@ interface ChangelogViewProps {
 const styles = stylex.create({
   section: {
     marginInline: 'auto',
+    // Match the docs article body treatment (16px / 1.75) from DocPageLayout.
+    // The release-notes body renders via Markdown, whose root reads these
+    // tokens; re-assigning them here scopes the larger/airier body to the
+    // changelog article only. The title (display-1), subtitle (large), and
+    // tab labels use different tokens, so they're unaffected.
+    [typeScaleVars['--text-body-size']]: '1rem', // 16px
+    [typeScaleVars['--text-body-leading']]: '1.75', // 28px line box
   },
 });
 
@@ -72,7 +80,10 @@ export function ChangelogView({
   const active = changelogs.find(c => c.pkg === activeTab);
 
   return (
-    <Section maxWidth={layout.proseMaxWidth} padding={6} xstyle={styles.section}>
+    <Section
+      maxWidth={layout.proseMaxWidth}
+      padding={6}
+      xstyle={styles.section}>
       <VStack gap={8}>
         <VStack gap={4}>
           <Heading level={1} type="display-1">

--- a/apps/docsite/src/components/blog/BlogArticle.tsx
+++ b/apps/docsite/src/components/blog/BlogArticle.tsx
@@ -17,6 +17,7 @@ import {Badge} from '@astryxdesign/core/Badge';
 import {Breadcrumbs, BreadcrumbItem} from '@astryxdesign/core/Breadcrumbs';
 import {Divider} from '@astryxdesign/core/Divider';
 import {ClickableCard} from '@astryxdesign/core/ClickableCard';
+import {typeScaleVars} from '@astryxdesign/core/theme/tokens.stylex';
 import type {BlogPost} from '../../lib/blog/schema';
 import {POST_TYPE_LABELS} from '../../lib/blog/schema';
 import {AuthorByline} from './AuthorByline';
@@ -25,6 +26,13 @@ import {layout} from '../../layout.stylex';
 const styles = stylex.create({
   section: {
     marginInline: 'auto',
+    // Match the docs article body treatment (16px / 1.75) from DocPageLayout.
+    // The post body renders via Markdown, whose root reads these tokens;
+    // re-assigning them here scopes the larger/airier body to the blog
+    // article only. The title (display-1) and subtitle/description (large)
+    // use different tokens, so they're unaffected.
+    [typeScaleVars['--text-body-size']]: '1rem', // 16px
+    [typeScaleVars['--text-body-leading']]: '1.75', // 28px line box
   },
   cover: {
     borderRadius: 'var(--radius-container)',

--- a/apps/docsite/src/components/component-detail/ComponentDetailClient.tsx
+++ b/apps/docsite/src/components/component-detail/ComponentDetailClient.tsx
@@ -10,6 +10,7 @@ import {VStack} from '@astryxdesign/core/Layout';
 import {Section} from '@astryxdesign/core/Section';
 import {Card} from '@astryxdesign/core/Card';
 import {Divider} from '@astryxdesign/core';
+import {typeScaleVars} from '@astryxdesign/core/theme/tokens.stylex';
 import {CodeExampleBlock} from '../CodeExampleBlock';
 import {TabList, Tab} from '@astryxdesign/core/TabList';
 import {ShowcasePreview} from './ShowcasePreview';
@@ -32,6 +33,16 @@ import {trackNavigate} from '../../lib/analytics';
 const styles = stylex.create({
   section: {
     marginInline: 'auto',
+  },
+  // Match the docs article body treatment (16px / 1.75) from DocPageLayout,
+  // scoped to the Overview prose only — the dense Properties props table keeps
+  // its compact body size. Live previews in the Overview are isolated inside
+  // ComponentPreviewTheme (a nested Theme that re-declares the type-scale
+  // tokens), so this override never leaks into them. The Usage/Examples
+  // descriptions (large) use different tokens and are unaffected.
+  overviewProse: {
+    [typeScaleVars['--text-body-size']]: '1rem', // 16px
+    [typeScaleVars['--text-body-leading']]: '1.75', // 28px line box
   },
   previewStage: {
     position: 'sticky',
@@ -66,7 +77,7 @@ function OverviewContent({
   const importPath = `import {${comp.moduleName}} from '${importFrom}'`;
 
   return (
-    <VStack gap={8}>
+    <VStack gap={8} xstyle={styles.overviewProse}>
       {hasShowcase && (
         <ComponentPreviewTheme>
           <Card variant="muted" padding={0}>


### PR DESCRIPTION
## Summary
Follow-up to #3085, which bumped docs article body text to **16px / 1.75** line-height (and semantic `<p>`) via `DocPageLayout`. A few article-style pages have their own `Section` wrapper and so missed the update: the **What's New (changelog)** page, **blog** posts, and **component doc** pages.

This re-assigns the body size/leading tokens (`--text-body-size` / `--text-body-leading`) on each page's container — exactly the mechanism #3085 used for `DocPageLayout`. The `Markdown` root and body-typed `Text` read these tokens, so the larger/airier body cascades to article prose only; titles (`display-1`) and subtitles (`large`) use different tokens and are unaffected.

## Changes
- **`ChangelogView.tsx`** — override on the `Section`. Release notes render via `Markdown`, which already emits semantic `<p>`.
- **`BlogArticle.tsx`** — override on the `Section`. Post body renders via `Markdown`.
- **`ComponentDetailClient.tsx`** — override **scoped to the Overview prose only** (`OverviewContent`'s `VStack`), not the page `Section`, so the dense **Properties** props table keeps its compact body size. Live previews are isolated inside `ComponentPreviewTheme` (a nested `Theme` that re-declares the type-scale tokens), so the override never leaks into them.

No `ProseBlock`-style change is needed on these pages — `Markdown` already renders paragraphs as `<p>`.

## Test plan
- [ ] `/changelog` — release-notes body is 16px with 1.75 line-height.
- [ ] `/blog/<slug>` — post body is 16px / 1.75.
- [ ] `/components/<Name>` **Overview** tab — prose body is 16px / 1.75; live previews unchanged.
- [ ] `/components/<Name>` **Properties** tab — props table body stays compact (unchanged).
- [ ] Titles (`display-1`) and subtitles (`large`) are unchanged on all three pages.

Made with [Cursor](https://cursor.com)