### PR TITLE
[ci] Adopt shared Internal Registry dependency-check

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 5
     labels:
       - "dependencies"

--- a/.github/workflows/internal-registry.yml
+++ b/.github/workflows/internal-registry.yml
@@ -1,0 +1,25 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+name: Internal Registry
+
+# Verifies every pinned dependency is available from the registry before it can
+# break a build. Mark the merge_group run ("Internal Registry / dependency-check")
+# as a REQUIRED status check to gate landing; fork PRs are skipped and enforced
+# by that required merge_group run.
+
+on:
+  pull_request:
+    branches: ["main"]
+  merge_group:
+
+permissions: {}
+
+jobs:
+  dependency-check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: facebook/lexical/.github/actions/internal-registry/dependency-check@internal-registry-dependency-check-v1


### PR DESCRIPTION
## What

Adopts the shared **Internal Registry dependency-check** — the CI gate that verifies every pinned dependency is available from the internal registry before it can break a build inside Meta.

- New `.github/workflows/internal-registry.yml` (`name: Internal Registry`, job `dependency-check`) that consumes the reusable composite action hosted in **facebook/lexical**, pinned to `@internal-registry-dependency-check-v1`.
- 7-day Dependabot cooldown on npm updates so bumps don't propose a version still inside the registry's availability window.

## Why this shape

The check logic lives once (the composite action in facebook/lexical); each repo just adds a thin standalone workflow + a cooldown line. The required-check context is identical across repos: **`Internal Registry / dependency-check`**.

- **No registry-side change** — `facebook/astryx` is already onboarded.
- **Fork PRs**: can't mint OIDC, so they pass with a notice and are enforced by the required `merge_group` run (trusted context).

## Activation

- [ ] Mark **`Internal Registry / dependency-check`** as a required status check for the merge queue.

