### PR TITLE
fix(docsite): brand component page titles (e.g. "Button · Astryx")

### DIFF
--- a/apps/docsite/src/app/(docs)/components/layout.tsx
+++ b/apps/docsite/src/app/(docs)/components/layout.tsx
@@ -9,13 +9,24 @@
 
 import type {Metadata} from 'next';
 import {pageMetadata} from '../../../lib/pageMetadata';
+import {SITE_NAME} from '../../../lib/siteConfig';
 
-export const metadata: Metadata = pageMetadata({
-  title: 'Components',
-  description:
-    'Browse every Astryx component with copy-ready examples for each variant, state, and pattern.',
-  path: '/components',
-});
+export const metadata: Metadata = {
+  ...pageMetadata({
+    title: 'Components',
+    description:
+      'Browse every Astryx component with copy-ready examples for each variant, state, and pattern.',
+    path: '/components',
+  }),
+  // Brand the per-component page titles (e.g. "Button · Astryx") so browser
+  // tabs are distinguishable. A plain string title at this layout segment was
+  // shadowing the root title template for the dynamic /components/[name] pages,
+  // so re-declare the template here; `default` titles the gallery index.
+  title: {
+    default: 'Components',
+    template: `%s · ${SITE_NAME}`,
+  },
+};
 
 export default function ComponentsLayout({
   children,


### PR DESCRIPTION
## Summary

Closes #2702.

Component detail pages rendered a bare `<title>` ("Button") instead of the branded `<Component> · Astryx` pattern that `/blog` and `/themes` already use — so several open component tabs were hard to tell apart.

Root cause: the plain-string `title: 'Components'` in `app/(docs)/components/layout.tsx` shadowed the root layout's title template for the dynamic `/components/[name]` pages. Re-declaring the template at that segment restores branded per-page titles, with `Components` kept as the gallery-index default.

`apps/docsite/src/app/(docs)/components/layout.tsx` — `title` is now `{ default: 'Components', template: '%s · Astryx' }`.

## Testing (verified against the running dev server's rendered `<title>`)
- `/components/Button` → **`Button · Astryx`**
- `/components/Timestamp` → `Timestamp · Astryx`
- `/components/Slider`, `Card`, `Icon`, `Kbd`, `Heading` → all branded
- `/components` (index) → `Components · Astryx` (no double suffix)

> Used the site's existing `· Astryx` convention (matching blog/themes) rather than the `| Astryx Design System` in the issue text, for consistency.

No changeset (docsite is a private package).