### PR TITLE
docs(cli): rename misleading DateInput "Date Range" example

### DIFF
--- a/.changeset/dateinput-example-rename.md
+++ b/.changeset/dateinput-example-rename.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[docs] Rename the DateInput "Date Range" example to "Min/Max Constraints" — it demos a single input constrained to a min/max window, not a date-range picker (#2692)
+@durvesh1992

--- a/packages/cli/templates/blocks/components/DateInput/DateInputDateRange.doc.mjs
+++ b/packages/cli/templates/blocks/components/DateInput/DateInputDateRange.doc.mjs
@@ -4,8 +4,8 @@
 export const doc = {
   type: 'block',
   exampleFor: 'DateInput',
-  name: 'DateInput — Date Range',
-  displayName: 'DateInput — Date Range',
+  name: 'DateInput — Min/Max Constraints',
+  displayName: 'DateInput — Min/Max Constraints',
   description:
     'Date input constrained to a min/max window. Use when only certain dates are valid, like booking availability or a fiscal quarter.',
   isReady: true,


### PR DESCRIPTION
## Summary

Closes #2692.

The DateInput example titled **"Date Range"** reads like a date-range picker, but it actually demos a **single DateInput constrained to a min/max window**. Renamed to **"Min/Max Constraints"** so the name matches the example (the description already says "constrained to a min/max window").

`packages/cli/templates/blocks/components/DateInput/DateInputDateRange.doc.mjs` — `name` + `displayName` only.

## Changeset
Included (`@astryxdesign/cli` patch, docs) — the example ships in `cli/templates`.