### PR TITLE
fix(docsite): make 'Open in Playground' a real link

### DIFF
--- a/apps/docsite/src/components/PlaygroundButton.tsx
+++ b/apps/docsite/src/components/PlaygroundButton.tsx
@@ -16,14 +16,8 @@ export function PlaygroundButton({
 }: PlaygroundButtonProps) {
   const href = buildPlaygroundHref(source);
 
-  return (
-    <Button
-      label={label}
-      variant="secondary"
-      size="sm"
-      onClick={() => {
-        window.location.href = href;
-      }}
-    />
-  );
+  // Render a real anchor (Button renders as <a> when given href) so
+  // right-click / Cmd-click / middle-click "open in new tab" work, instead
+  // of an onClick that hard-navigates the current tab.
+  return <Button label={label} variant="secondary" size="sm" href={href} />;
 }

--- a/apps/docsite/src/components/component-detail/ExampleBlock.tsx
+++ b/apps/docsite/src/components/component-detail/ExampleBlock.tsx
@@ -107,9 +107,12 @@ export function ExampleBlock({entry, componentName}: ExampleBlockProps) {
                 label="Open in Playground"
                 variant="ghost"
                 size="sm"
+                // Real anchor (Button renders <a> with href) so right-click /
+                // Cmd-click / middle-click "open in new tab" work. onClick stays
+                // for analytics; the href handles navigation natively.
+                href={buildPlaygroundHref(entry.source)}
                 onClick={() => {
                   trackOpenPlayground({page: 'components', item: entry.name});
-                  window.location.href = buildPlaygroundHref(entry.source);
                 }}
               />
             )}


### PR DESCRIPTION
## Summary

Closes #2701.

The **Open in Playground** control on component example blocks rendered a `<button>` with an `onClick` that hard-set `window.location.href` — so right-click / Cmd-click / middle-click "open in new tab" did nothing, and it always opened in the same tab.

Fix: pass `href` to `Button` (which renders a real `<a>` when given `href`) so native link behaviors work. In `ExampleBlock`, `onClick` is kept solely for the `trackOpenPlayground` analytics call; navigation is now the anchor's `href`. Also applied the same fix to the (currently unused) `PlaygroundButton` helper, which had the identical pattern.

## Testing (verified against the running dev server)
- `/components/Button` example blocks now render **`<a href="/playground#code=…">`** (4 anchors), **0** `<button>` for this control.
- Normal click still navigates; Cmd/right/middle-click now offer "open in new tab".

> Per the issue, left the default as same-tab navigation (a real link) rather than forcing `target="_blank"` — modifier-click now covers new-tab. Happy to add `target="_blank"` if you'd prefer new-tab by default.

No changeset (docsite is a private package).