### PR TITLE
fix(core): support multiple layers anchored to one element (anchor-name list)

### DIFF
--- a/.changeset/mega-menu-anchor-name-list.md
+++ b/.changeset/mega-menu-anchor-name-list.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] useLayer now treats `anchor-name` as a comma-separated list, so multiple layers can anchor to the same element (e.g. two TopNavMegaMenus in one nav) without clobbering each other's anchor. Previously the second menu lost its anchor and rendered over the nav.
+
+@ernesttien

--- a/packages/core/src/Layer/anchorName.test.ts
+++ b/packages/core/src/Layer/anchorName.test.ts
@@ -1,0 +1,146 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file anchorName.test.ts
+ * @input Uses vitest, anchorName utilities
+ * @output Unit tests for anchor-name list manipulation helpers
+ * @position Testing; validates anchorName.ts implementation
+ *
+ * SYNC: When anchorName.ts changes, update tests to match new behavior
+ */
+
+import {describe, it, expect} from 'vitest';
+import {
+  readAnchorNames,
+  writeAnchorNames,
+  addAnchorName,
+  removeAnchorName,
+} from './anchorName';
+
+function createMockElement(): HTMLElement {
+  const el = document.createElement('div');
+  return el;
+}
+
+describe('readAnchorNames', () => {
+  it('returns empty array for element with no anchor-name', () => {
+    const el = createMockElement();
+    expect(readAnchorNames(el)).toEqual([]);
+  });
+
+  it('reads a single anchor name', () => {
+    const el = createMockElement();
+    (el.style as unknown as Record<string, string>).anchorName = '--layer-1';
+    expect(readAnchorNames(el)).toEqual(['--layer-1']);
+  });
+
+  it('reads multiple comma-separated anchor names', () => {
+    const el = createMockElement();
+    (el.style as unknown as Record<string, string>).anchorName =
+      '--layer-1, --layer-2, --layer-3';
+    expect(readAnchorNames(el)).toEqual([
+      '--layer-1',
+      '--layer-2',
+      '--layer-3',
+    ]);
+  });
+
+  it('trims whitespace around names', () => {
+    const el = createMockElement();
+    (el.style as unknown as Record<string, string>).anchorName =
+      '  --layer-1 ,  --layer-2  ';
+    expect(readAnchorNames(el)).toEqual(['--layer-1', '--layer-2']);
+  });
+
+  it('returns empty array for empty string value', () => {
+    const el = createMockElement();
+    (el.style as unknown as Record<string, string>).anchorName = '';
+    expect(readAnchorNames(el)).toEqual([]);
+  });
+});
+
+describe('writeAnchorNames', () => {
+  it('writes names as comma-separated list', () => {
+    const el = createMockElement();
+    writeAnchorNames(el, ['--layer-1', '--layer-2']);
+    expect((el.style as unknown as Record<string, string>).anchorName).toBe(
+      '--layer-1, --layer-2',
+    );
+  });
+
+  it('writes empty string for empty array', () => {
+    const el = createMockElement();
+    writeAnchorNames(el, []);
+    expect((el.style as unknown as Record<string, string>).anchorName).toBe('');
+  });
+});
+
+describe('addAnchorName', () => {
+  it('adds name to element with no existing anchors', () => {
+    const el = createMockElement();
+    addAnchorName(el, '--layer-1');
+    expect((el.style as unknown as Record<string, string>).anchorName).toBe(
+      '--layer-1',
+    );
+  });
+
+  it('appends name to existing anchor list', () => {
+    const el = createMockElement();
+    (el.style as unknown as Record<string, string>).anchorName = '--layer-1';
+    addAnchorName(el, '--layer-2');
+    expect((el.style as unknown as Record<string, string>).anchorName).toBe(
+      '--layer-1, --layer-2',
+    );
+  });
+
+  it('does not duplicate an already-present name', () => {
+    const el = createMockElement();
+    (el.style as unknown as Record<string, string>).anchorName = '--layer-1';
+    addAnchorName(el, '--layer-1');
+    expect((el.style as unknown as Record<string, string>).anchorName).toBe(
+      '--layer-1',
+    );
+  });
+
+  it('supports multiple layers sharing one element', () => {
+    const el = createMockElement();
+    addAnchorName(el, '--menu-1');
+    addAnchorName(el, '--menu-2');
+    addAnchorName(el, '--menu-3');
+    expect(readAnchorNames(el)).toEqual(['--menu-1', '--menu-2', '--menu-3']);
+  });
+});
+
+describe('removeAnchorName', () => {
+  it('removes name from a multi-anchor list', () => {
+    const el = createMockElement();
+    (el.style as unknown as Record<string, string>).anchorName =
+      '--layer-1, --layer-2, --layer-3';
+    removeAnchorName(el, '--layer-2');
+    expect(readAnchorNames(el)).toEqual(['--layer-1', '--layer-3']);
+  });
+
+  it('removes the last remaining name, leaving empty string', () => {
+    const el = createMockElement();
+    (el.style as unknown as Record<string, string>).anchorName = '--layer-1';
+    removeAnchorName(el, '--layer-1');
+    expect((el.style as unknown as Record<string, string>).anchorName).toBe('');
+  });
+
+  it('is a no-op if name is not present', () => {
+    const el = createMockElement();
+    (el.style as unknown as Record<string, string>).anchorName =
+      '--layer-1, --layer-2';
+    removeAnchorName(el, '--layer-3');
+    expect(readAnchorNames(el)).toEqual(['--layer-1', '--layer-2']);
+  });
+
+  it('handles multiple add/remove cycles correctly', () => {
+    const el = createMockElement();
+    addAnchorName(el, '--menu-a');
+    addAnchorName(el, '--menu-b');
+    removeAnchorName(el, '--menu-a');
+    addAnchorName(el, '--menu-c');
+    expect(readAnchorNames(el)).toEqual(['--menu-b', '--menu-c']);
+  });
+});

--- a/packages/core/src/Layer/anchorName.ts
+++ b/packages/core/src/Layer/anchorName.ts
@@ -1,0 +1,46 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file anchorName.ts
+ * @input HTMLElement with CSS anchor-name property
+ * @output Helpers for managing comma-separated anchor-name lists
+ * @position Utility; used by useLayer for multi-anchor support
+ *
+ * SYNC: When modified, update:
+ * - /packages/core/src/Layer/useLayer.tsx (imports from here)
+ */
+
+/**
+ * CSS `anchor-name` is a comma-separated list, so multiple layers can anchor to
+ * the same element (e.g. several TopNavMegaMenus anchored to one <nav>). These
+ * helpers add/remove a single layer's anchor id without clobbering the others —
+ * overwriting the whole property would break every sibling layer's positioning.
+ */
+
+export function readAnchorNames(el: HTMLElement): string[] {
+  const value =
+    (el.style as unknown as Record<string, string>).anchorName ?? '';
+  return value
+    .split(',')
+    .map(name => name.trim())
+    .filter(Boolean);
+}
+
+export function writeAnchorNames(el: HTMLElement, names: string[]): void {
+  (el.style as unknown as Record<string, string>).anchorName = names.join(', ');
+}
+
+export function addAnchorName(el: HTMLElement, name: string): void {
+  const names = readAnchorNames(el);
+  if (!names.includes(name)) {
+    names.push(name);
+    writeAnchorNames(el, names);
+  }
+}
+
+export function removeAnchorName(el: HTMLElement, name: string): void {
+  writeAnchorNames(
+    el,
+    readAnchorNames(el).filter(existing => existing !== name),
+  );
+}

--- a/packages/core/src/Layer/useLayer.tsx
+++ b/packages/core/src/Layer/useLayer.tsx
@@ -23,6 +23,7 @@ import React, {
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
+import {addAnchorName, removeAnchorName} from './anchorName';
 import {typographyVars} from '../theme/tokens.stylex';
 
 const styles = stylex.create({
@@ -268,40 +269,6 @@ function getPositionArea(
     return `${cssPlacement} span-top`;
   }
   return `${cssPlacement} center`;
-}
-
-/**
- * CSS `anchor-name` is a comma-separated list, so multiple layers can anchor to
- * the same element (e.g. several TopNavMegaMenus anchored to one <nav>). These
- * helpers add/remove a single layer's anchor id without clobbering the others —
- * overwriting the whole property would break every sibling layer's positioning.
- */
-function readAnchorNames(el: HTMLElement): string[] {
-  const value =
-    (el.style as unknown as Record<string, string>).anchorName ?? '';
-  return value
-    .split(',')
-    .map(name => name.trim())
-    .filter(Boolean);
-}
-
-function writeAnchorNames(el: HTMLElement, names: string[]): void {
-  (el.style as unknown as Record<string, string>).anchorName = names.join(', ');
-}
-
-function addAnchorName(el: HTMLElement, name: string): void {
-  const names = readAnchorNames(el);
-  if (!names.includes(name)) {
-    names.push(name);
-    writeAnchorNames(el, names);
-  }
-}
-
-function removeAnchorName(el: HTMLElement, name: string): void {
-  writeAnchorNames(
-    el,
-    readAnchorNames(el).filter(existing => existing !== name),
-  );
 }
 
 /**

--- a/packages/core/src/Layer/useLayer.tsx
+++ b/packages/core/src/Layer/useLayer.tsx
@@ -271,6 +271,40 @@ function getPositionArea(
 }
 
 /**
+ * CSS `anchor-name` is a comma-separated list, so multiple layers can anchor to
+ * the same element (e.g. several TopNavMegaMenus anchored to one <nav>). These
+ * helpers add/remove a single layer's anchor id without clobbering the others —
+ * overwriting the whole property would break every sibling layer's positioning.
+ */
+function readAnchorNames(el: HTMLElement): string[] {
+  const value =
+    (el.style as unknown as Record<string, string>).anchorName ?? '';
+  return value
+    .split(',')
+    .map(name => name.trim())
+    .filter(Boolean);
+}
+
+function writeAnchorNames(el: HTMLElement, names: string[]): void {
+  (el.style as unknown as Record<string, string>).anchorName = names.join(', ');
+}
+
+function addAnchorName(el: HTMLElement, name: string): void {
+  const names = readAnchorNames(el);
+  if (!names.includes(name)) {
+    names.push(name);
+    writeAnchorNames(el, names);
+  }
+}
+
+function removeAnchorName(el: HTMLElement, name: string): void {
+  writeAnchorNames(
+    el,
+    readAnchorNames(el).filter(existing => existing !== name),
+  );
+}
+
+/**
  * Core layer hook that handles popover behavior and positioning.
  *
  * Supports two positioning modes with type-safe render props:
@@ -324,16 +358,14 @@ export function useLayer(
   const ref: RefCallback<HTMLElement> | undefined =
     mode === 'context'
       ? (el: HTMLElement | null) => {
-          // Cleanup previous element
-          if (triggerRef.current) {
-            (
-              triggerRef.current.style as unknown as Record<string, string>
-            ).anchorName = '';
+          // Remove only THIS layer's anchor name from the previous element so
+          // other layers sharing the same trigger keep their anchors.
+          if (triggerRef.current && triggerRef.current !== el) {
+            removeAnchorName(triggerRef.current, anchorId);
           }
 
           if (el) {
-            (el.style as unknown as Record<string, string>).anchorName =
-              anchorId;
+            addAnchorName(el, anchorId);
           }
 
           triggerRef.current = el;


### PR DESCRIPTION
## Problem

`useLayer` is the core hook behind every popover/menu in Astryx. It positions a layer relative to its trigger using CSS anchor positioning: the trigger element gets an `anchor-name`, and the floating layer references it via `position-anchor`.

The ref callback set the trigger's `anchor-name` to a single id and cleared the whole property on cleanup:

```ts
(el.style).anchorName = anchorId;   // set
(triggerRef.current.style).anchorName = '';  // cleanup
```

CSS `anchor-name` is actually a **comma-separated list** — an element can expose several anchors at once. `TopNavMegaMenu` anchors its panel to the shared `<nav>` element (not to each trigger button), so when a nav contains **two** mega menus, both layers write `anchor-name` on the same `<nav>`. The second one overwrites the first, and the cleanup wipes the property entirely.

The menu that loses its anchor falls back to the viewport origin and renders on top of the nav. Hovering between the two triggers makes the panels flash and jump as anchors get clobbered and restored.

Reproes outside Astryx too (e.g. https://moonveil.ai/), since it's the standard CSS anchor pitfall.

Fixes #3190

## Solution

Treat `anchor-name` as the list it is. Added small helpers (`readAnchorNames` / `writeAnchorNames` / `addAnchorName` / `removeAnchorName`) and changed the ref callback to **append** this layer's `anchorId` and **remove only its own** id on cleanup, leaving any sibling layers' anchors intact.

Now multiple layers can share one anchor element and each keeps a stable, correct position.

## Test plan

- [x] Two `TopNavMegaMenu`s in one `TopNav`: both panels open at the same offset below the nav; switching between them no longer flashes/jumps (verified in browser).
- [x] Existing single-anchor popovers/menus/tooltips unaffected (only the cleanup/set path changed; single-layer behavior is identical).
- [x] `pnpm check:repo` + lint/format pass; patch changeset added for `@astryxdesign/core`.

Made with [Cursor](https://cursor.com)