### PR TITLE
fix(docsite): remove duplicate playground key in Skeleton doc

### DIFF
--- a/packages/core/src/Skeleton/Skeleton.doc.mjs
+++ b/packages/core/src/Skeleton/Skeleton.doc.mjs
@@ -7,15 +7,6 @@ export const docs = {
   displayName: 'Skeleton',
   category: 'Feedback & Status',
   keywords: ["skeleton","placeholder","loading","shimmer","pulse","loader","bone","ghost","preloader"],
-  playground: {
-    // width/height default to '100%', which collapses to nothing inside the
-    // centered properties-tab preview. Give the preview concrete dimensions
-    // so the skeleton is actually visible.
-    defaults: {
-      width: 200,
-      height: 24,
-    },
-  },
   props: [
     {
       name: 'width',


### PR DESCRIPTION
## Problem

`packages/core/src/Skeleton/Skeleton.doc.mjs` declares the `playground` key **twice** in the `docs` object. This fails the `typecheck:docs` gate with:

```
src/Skeleton/Skeleton.doc.mjs(46,3): error TS1117: An object literal cannot have multiple properties with the same name.
```

Because the `build` job runs `typecheck:docs` against the PR-merged-with-`main` tree, this breaks the **build check on every open PR**, not just one. (`main`'s own push only runs `test`, so the duplicate landed without the `build` gate catching it.)

The two blocks came from two separate fixes for the same Skeleton properties-tab preview issue — one added a `playground` block after `keywords`, the other after `props`. In JS, the later key wins, so the first block was already dead.

## Fix

Remove the dead earlier `playground` block and keep the later one (the effective `320 × 80` preview). No change to the rendered properties-tab preview.

## Verification

- `pnpm -F @astryxdesign/core typecheck:docs` → passes (was TS1117).
- `pnpm lint`, `sync-exports --check`, `generate-token-docs --check`, `check-changesets` → all clean.
- Docsite-internal only; no consumer-visible API change, so no changeset.
