### PR TITLE
docs(cli): make Slider/Selector/MultiSelector showcases interactive

### DIFF
--- a/.changeset/interactive-showcases.md
+++ b/.changeset/interactive-showcases.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[docs] Wire local state into the Slider, Selector, and MultiSelector showcase examples so they are interactive — they were controlled components with a static value and a no-op/missing onChange, so the docsite previews appeared frozen (#3187, #3188, #3189)
+@durvesh1992

--- a/packages/cli/templates/blocks/components/MultiSelector/MultiSelectorShowcase.tsx
+++ b/packages/cli/templates/blocks/components/MultiSelector/MultiSelectorShowcase.tsx
@@ -1,15 +1,19 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+'use client';
+
+import {useState} from 'react';
 import {MultiSelector} from '@astryxdesign/core/MultiSelector';
 
 export default function MultiSelectorShowcase() {
+  const [value, setValue] = useState<string[]>([]);
   return (
     <div style={{width: 300}}>
       <MultiSelector
         label="Columns"
         options={['Name', 'Email', 'Role', 'Status', 'Created']}
-        value={[]}
-        onChange={() => {}}
+        value={value}
+        onChange={setValue}
         placeholder="Select columns..."
       />
     </div>

--- a/packages/cli/templates/blocks/components/Selector/SelectorShowcase.tsx
+++ b/packages/cli/templates/blocks/components/Selector/SelectorShowcase.tsx
@@ -2,16 +2,19 @@
 
 'use client';
 
+import {useState} from 'react';
 import {Selector} from '@astryxdesign/core/Selector';
 
 export default function SelectorShowcase() {
+  const [value, setValue] = useState<string | undefined>();
   return (
     <Selector
       style={{width: 300}}
       label="Fruit"
       options={['Apple', 'Banana', 'Orange', 'Mango', 'Pineapple']}
       placeholder="Select a fruit..."
-      onChange={() => {}}
+      value={value}
+      onChange={setValue}
     />
   );
 }


### PR DESCRIPTION
## Summary

Closes #3187. Closes #3188. Closes #3189.

The Slider, Selector, and MultiSelector **showcase** blocks rendered controlled components with a static `value` and a no-op/missing `onChange`, so the docsite previews appeared frozen — dragging the slider or picking an option did nothing. Wired local `useState` + `onChange` in each, mirroring the existing examples that already do this (`SliderWithMarks`, `SelectorWithSections`, `MultiSelectorColumnVisibilitySelector`).

- `Slider/SliderShowcase.tsx` — `useState(50)` + `onChange`
- `Selector/SelectorShowcase.tsx` — `useState<string | undefined>()` + `value`/`onChange`
- `MultiSelector/MultiSelectorShowcase.tsx` — `useState<string[]>([])` + `onChange`; added `'use client'` (now uses state)

## Testing
- Regenerated docsite data — all three blocks parse and copy cleanly.
- Patterns are identical to existing stateful examples in the same folders (which compile), so the controlled-state wiring is type-correct.

> I can't launch a browser locally to click-test the previews, but this is the exact state-wiring the issues request; a quick visual confirm on the preview is welcome.

## Changeset
Included (`@astryxdesign/cli` patch) — showcase blocks ship in `cli/templates`.