### PR TITLE
docs(cli): make Typeahead/Tokenizer/FileInput showcases interactive

### DIFF
--- a/.changeset/interactive-showcases-3.md
+++ b/.changeset/interactive-showcases-3.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[docs] Wire local state into the Typeahead, Tokenizer, and FileInput showcase examples (static value + no-op onChange → frozen previews). Completes the interactive-showcase fixes started for Slider/Selector/MultiSelector (#3187-#3189) and the input/tab batch
+@durvesh1992

--- a/packages/cli/templates/blocks/components/FileInput/FileInputShowcase.tsx
+++ b/packages/cli/templates/blocks/components/FileInput/FileInputShowcase.tsx
@@ -2,15 +2,17 @@
 
 'use client';
 
+import {useState} from 'react';
 import {FileInput} from '@astryxdesign/core/FileInput';
 
 export default function FileInputShowcase() {
+  const [value, setValue] = useState<File | File[] | null>(null);
   return (
     <div style={{width: 350}}>
       <FileInput
         label="Upload file"
-        value={null}
-        onChange={() => {}}
+        value={value}
+        onChange={setValue}
         placeholder="Drag files here or click to browse"
       />
     </div>

--- a/packages/cli/templates/blocks/components/Tokenizer/TokenizerShowcase.tsx
+++ b/packages/cli/templates/blocks/components/Tokenizer/TokenizerShowcase.tsx
@@ -2,8 +2,9 @@
 
 'use client';
 
+import {useState} from 'react';
 import {Tokenizer} from '@astryxdesign/core/Tokenizer';
-import type {SearchSource} from '@astryxdesign/core/Typeahead';
+import type {SearchableItem, SearchSource} from '@astryxdesign/core/Typeahead';
 
 const source: SearchSource = {
   search: () => [],
@@ -11,16 +12,17 @@ const source: SearchSource = {
 };
 
 export default function TokenizerShowcase() {
+  const [value, setValue] = useState<SearchableItem[]>([
+    {id: '1', label: 'Design'},
+    {id: '2', label: 'Engineering'},
+  ]);
   return (
     <Tokenizer
       label="Tags"
       placeholder="Search..."
       searchSource={source}
-      value={[
-        {id: '1', label: 'Design'},
-        {id: '2', label: 'Engineering'},
-      ]}
-      onChange={() => {}}
+      value={value}
+      onChange={setValue}
       style={{width: 400}}
     />
   );

--- a/packages/cli/templates/blocks/components/Typeahead/TypeaheadShowcase.tsx
+++ b/packages/cli/templates/blocks/components/Typeahead/TypeaheadShowcase.tsx
@@ -1,5 +1,8 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+'use client';
+
+import {useState} from 'react';
 import {Typeahead} from '@astryxdesign/core/Typeahead';
 import type {SearchableItem, SearchSource} from '@astryxdesign/core/Typeahead';
 
@@ -21,14 +24,15 @@ const fruitSource: SearchSource = {
 };
 
 export default function TypeaheadShowcase() {
+  const [value, setValue] = useState<SearchableItem | null>(null);
   return (
     <div style={{width: 320}}>
       <Typeahead
         label="Fruit"
         placeholder="Search fruits..."
         searchSource={fruitSource}
-        value={null}
-        onChange={() => {}}
+        value={value}
+        onChange={setValue}
       />
     </div>
   );


### PR DESCRIPTION
## Summary

Completes the frozen-showcase fixes (after #3199 and #3200). These three showcase blocks rendered controlled components with a static `value` and a no-op `onChange`, so their docsite previews were frozen. Wired local state:

- **Typeahead** — `useState<SearchableItem | null>(null)` (+ `'use client'`)
- **Tokenizer** — `useState<SearchableItem[]>([...])` (onChange's `(items, change)` signature accepts the `setState` setter)
- **FileInput** — `useState<File | File[] | null>(null)`

## Testing
- Each wiring is type-checked against the component's `value`/`onChange` signatures (Typeahead `(item: T | null) => void`, Tokenizer `(items: T[], change) => void`, FileInput `(files: File | File[] | null) => void`).
- Regenerated docsite data — all parse/copy cleanly.

> Browser can't launch in my environment, so verified at the type/regen level; a visual confirm on the preview is welcome.

## Changeset
Included (`@astryxdesign/cli` patch).