### PR TITLE
docs(core): document Text's justify prop

### DIFF
--- a/.changeset/text-justify-prop-doc.md
+++ b/.changeset/text-justify-prop-doc.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[docs] Document Text's `justify` prop, which was supported by the component but missing from the docsite properties tab (same omission previously fixed for Heading) (#2847-adjacent)
+@durvesh1992

--- a/packages/core/src/Text/Text.doc.mjs
+++ b/packages/core/src/Text/Text.doc.mjs
@@ -83,6 +83,12 @@ export const docs = {
       description: 'Text wrapping behavior.',
     },
     {
+      name: 'justify',
+      type: "'start' | 'center' | 'end'",
+      description: 'Text alignment (justification). Uses logical values (start/end) for i18n/RTL compatibility.',
+      default: "'start'",
+    },
+    {
       name: 'hasCapsize',
       type: 'boolean',
       description: 'Enable optical alignment using text-box-trim. Forces block display.',


### PR DESCRIPTION
## Summary

`Text` supports a **`justify`** prop (`TextJustify`: `'start' | 'center' | 'end'`, default `'start'`) but it was missing from the docsite **properties tab** — the exact same omission I fixed for its sibling `Heading` in #3176.

Found by scanning component interfaces against their `.doc.mjs` prop lists. Added `justify` to `Text`'s doc props (after `textWrap`, matching interface order).

## Testing
- Regenerated docsite data — `justify` now appears in the Text component registry.

## Note
The same scan surfaced other props missing from various components' docs (e.g. Link's `type/size/weight/color/display`, several `width` props). Those need per-prop judgment (some omissions are intentional for advanced/system props), so I'm keeping this PR scoped to the unambiguous `justify` case that mirrors the already-reviewed Heading fix. Happy to follow up on others if useful.

## Changeset
Included (`@astryxdesign/core` patch, docs).