### PR TITLE
docs(core): document ToggleButton's isIconOnly prop

### DIFF
--- a/.changeset/togglebutton-isicononly-doc.md
+++ b/.changeset/togglebutton-isicononly-doc.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[docs] Document ToggleButton's `isIconOnly` prop, which was a supported public prop but missing from the docsite properties tab
+@durvesh1992

--- a/packages/core/src/ToggleButton/ToggleButton.doc.mjs
+++ b/packages/core/src/ToggleButton/ToggleButton.doc.mjs
@@ -75,6 +75,12 @@ export const docs = {
       ],
     },
     {
+      name: 'isIconOnly',
+      type: 'boolean',
+      description: 'When true, renders as a square icon-only button with `label` as the aria-label and an automatic tooltip from the label.',
+      default: 'false',
+    },
+    {
       name: 'pressedIcon',
       type: 'ReactNode',
       description: 'Icon shown when pressed. Falls back to icon if not provided.',


### PR DESCRIPTION
## Summary

`ToggleButton` has a public **`isIconOnly`** prop (`boolean`, `@default false`) — "renders as a square icon-only button with `label` as the aria-label and an automatic tooltip" — but it was missing from the docsite **properties tab**.

Found via the interface-vs-docs prop scan (same class as the approved Heading `justify` #3176 and Text `justify` #3203). Added `isIconOnly` to `ToggleButton`'s doc props.

## Testing
- Regenerated docsite data — `isIconOnly` now appears in the ToggleButton component registry.

## Changeset
Included (`@astryxdesign/core` patch, docs).