### PR TITLE
docs(core): document List.start and CheckboxInput.isReadOnly props

### DIFF
--- a/.changeset/doc-missing-props-list-checkbox.md
+++ b/.changeset/doc-missing-props-list-checkbox.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[docs] Document two public props missing from the docsite properties tab: List's `start` (ordered-list counter start) and CheckboxInput's `isReadOnly`
+@durvesh1992

--- a/packages/core/src/CheckboxInput/CheckboxInput.doc.mjs
+++ b/packages/core/src/CheckboxInput/CheckboxInput.doc.mjs
@@ -64,6 +64,13 @@ export const docs = {
       default: 'false',
     },
     {
+      name: 'isReadOnly',
+      type: 'boolean',
+      description:
+        'Whether the checkbox is read-only. Displays the current state at full opacity but prevents interaction. Unlike `isDisabled`, read-only checkboxes are not visually dimmed.',
+      default: 'false',
+    },
+    {
       name: 'isOptional',
       type: 'boolean',
       description: 'Whether the field is optional. Mutually exclusive with isRequired.',
@@ -156,6 +163,7 @@ export const docsZh = {
     },
     {name: 'isLoading', type: 'boolean', description: '复选框是否处于加载状态。显示旋转器并阻止交互。', default: 'false'},
     {name: 'isDisabled', type: 'boolean', description: '复选框是否禁用。', default: 'false'},
+    {name: 'isReadOnly', type: 'boolean', description: '复选框是否为只读。以完整不透明度显示当前状态但阻止交互。与 isDisabled 不同，只读复选框不会变暗。', default: 'false'},
     {name: 'isOptional', type: 'boolean', description: '字段是否可选。与 isRequired 互斥。', default: 'false'},
     {name: 'isRequired', type: 'boolean', description: '复选框是否必填。与 isOptional 互斥。', default: 'false'},
     {name: 'size', type: "'sm' | 'md'", description: '复选框尺寸。sm 用于紧凑布局，md 为默认。', default: "'md'"},

--- a/packages/core/src/List/List.doc.mjs
+++ b/packages/core/src/List/List.doc.mjs
@@ -62,6 +62,13 @@ export const docs = {
       default: "'none'",
     },
     {
+      name: 'start',
+      type: 'number',
+      description:
+        "Starting number for ordered lists (listStyle='decimal'). Sets the CSS counter to begin at this value.",
+      default: '1',
+    },
+    {
       name: 'xstyle',
       type: 'StyleXStyles',
       description: 'StyleX styles for layout customization (margins, positioning, sizing). Must be a stylex.create() value: not an inline style object like style={{}}.',


### PR DESCRIPTION
## Summary

Two public props that were missing from the docsite **properties tab** (same class as the approved Heading/Text `justify` and ToggleButton `isIconOnly` fixes):

- **`List.start`** — `number`, `@default 1`: starting number for ordered lists (`listStyle='decimal'`).
- **`CheckboxInput.isReadOnly`** — `boolean`, `@default false`: read-only state (full opacity, no interaction; unlike `isDisabled` it isn't dimmed). Added to EN + ZH doc prop lists.

Found via the interface-vs-docs prop scan.

## Testing
- Regenerated docsite data — both props now appear in the component registry.

## Changeset
Included (`@astryxdesign/core` patch, docs).