### PR TITLE
docs(cli): replace removed `agent-docs` command with `init --features agents`

### DIFF
--- a/packages/cli/docs/working-with-ai.doc.mjs
+++ b/packages/cli/docs/working-with-ai.doc.mjs
@@ -34,11 +34,11 @@ export const docs = {
           type: 'code',
           lang: 'text',
           label: 'Paste this into your AI',
-          code: 'Install @astryxdesign/cli and run `npx astryx agent-docs` to set up your Astryx context. Read the generated file.',
+          code: 'Install @astryxdesign/cli and run `npx astryx init --features agents` to set up your Astryx context. Read the generated file.',
         },
         {
           type: 'prose',
-          text: 'That\'s it. The agent-docs command generates everything your AI needs (component index, behavioral rules, CLI reference) pulled from your installed version. After a version bump, run it again to update in place.',
+          text: 'That\'s it. The `init --features agents` command generates everything your AI needs (component index, behavioral rules, CLI reference) pulled from your installed version. After a version bump, run it again to update in place.',
         },
         {
           type: 'prose',
@@ -48,9 +48,9 @@ export const docs = {
           type: 'code',
           lang: 'bash',
           label: 'Manual options',
-          code: `npx astryx agent-docs --agent claude    # CLAUDE.md
-npx astryx agent-docs --agent cursor    # .cursorrules
-npx astryx agent-docs --agent codex     # AGENTS.md (Copilot, Codex, etc.)`,
+          code: `npx astryx init --features agents --agent claude    # CLAUDE.md
+npx astryx init --features agents --agent cursor    # .cursorrules
+npx astryx init --features agents --agent codex     # AGENTS.md (Copilot, Codex, etc.)`,
         },
       ],
     },
@@ -88,7 +88,7 @@ npx astryx agent-docs --agent codex     # AGENTS.md (Copilot, Codex, etc.)`,
           lang: 'bash',
           label: 'Install as a Cursor user rule',
           code: `mkdir -p ~/.cursor/rules
-npx astryx agent-docs --agent-docs-path ~/.cursor/rules/xds.mdc`,
+npx astryx init --features agents --agent-docs-path ~/.cursor/rules/xds.mdc`,
         },
       ],
     },

--- a/packages/cli/src/commands/upgrade.mjs
+++ b/packages/cli/src/commands/upgrade.mjs
@@ -438,7 +438,7 @@ export function registerUpgrade(program) {
         } catch {
           if (!json) {
             p.log.warn(
-              `Could not update agent docs. Run \`${getRunPrefix()} astryx agent-docs\` to update manually.`,
+              `Could not update agent docs. Run \`${getRunPrefix()} astryx init --features agents\` to update manually.`,
             );
           }
         }


### PR DESCRIPTION
## What

The `agent-docs` CLI command was removed — it's now folded into `init` behind the `--features agents` flag. Several user-facing references still pointed at the old, non-existent command. This updates them all to the current syntax.

## Changes

**`packages/cli/docs/working-with-ai.doc.mjs`** (Working with AI guide):
- Quick Start "paste into your AI" snippet: `npx astryx agent-docs` → `npx astryx init --features agents`
- Prose describing what the command generates
- Manual per-agent options (`--agent claude/cursor/codex`)
- Cursor user-rule install (`--agent-docs-path`)

**`packages/cli/src/commands/upgrade.mjs`**:
- Fallback warning shown when agent docs can't be auto-updated during `upgrade` now suggests `astryx init --features agents` instead of the removed command.

The `--agent` and `--agent-docs-path` flags carried over to `init` unchanged, so only the base command changed. One reference in the guide ("Checking Your Setup") already used the correct `init --features agents` form — this brings the rest in line.

## Notes

Docs/content-only change. No package behavior changes, so no changeset. The `.doc.mjs` is consumed by the docsite generator at build time; verified it imports and parses cleanly.
