### PR TITLE
docs(core): document Section's paddingBlock prop

### DIFF
--- a/.changeset/section-paddingblock-doc.md
+++ b/.changeset/section-paddingblock-doc.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[docs] Document Section's `paddingBlock` prop (block-axis padding override), which was supported by the component but missing from the docsite properties tab
+@durvesh1992

--- a/packages/core/src/Section/Section.doc.mjs
+++ b/packages/core/src/Section/Section.doc.mjs
@@ -54,6 +54,11 @@ export const docs = {
       default: '4',
     },
     {
+      name: 'paddingBlock',
+      type: 'SpacingStep',
+      description: 'Block (vertical) padding override. Overrides only the block-axis padding while preserving inline padding from `padding` or the container theme default. Accepts the spacing scale (0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10).',
+    },
+    {
       name: 'xstyle',
       type: 'StyleXStyles',
       description: 'StyleX styles for layout customization (margins, positioning, sizing). Must be a stylex.create() value, not an inline style object.',
@@ -131,6 +136,11 @@ export const docsZh = {
       default: '4',
     },
     {
+      name: 'paddingBlock',
+      type: 'SpacingStep',
+      description: '块（垂直）方向内边距覆盖。仅覆盖块轴内边距，同时保留来自 padding 或容器主题默认值的行内内边距。使用间距比例（0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10）。',
+    },
+    {
       name: 'xstyle',
       type: 'StyleXStyles',
       description: '用于布局自定义的 StyleX 样式（外边距、定位、尺寸）。必须是 stylex.create() 的值，不能是内联样式对象。',
@@ -182,6 +192,7 @@ export const docsDense = {
     children: 'Content rendered inside section.',
     dividers: 'Which sides of section have divider borders.',
     padding: 'Internal padding via spacing scale; 0 for edge-to-edge content.',
+    paddingBlock: 'Block-axis padding override; preserves inline padding from padding/theme.',
     xstyle: 'StyleX styles for layout customization; must be stylex.create() value.',
   },
 };


### PR DESCRIPTION
## Summary

`Section` has a public **`paddingBlock`** prop (`SpacingStep`) that overrides only the block (vertical) axis padding while preserving inline padding from `padding` or the container theme default — but it was missing from the docsite **properties tab**.

Found via the interface-vs-docs prop scan. Added to the EN + ZH prop lists and the dense `propDescriptions`.

## Testing
- Regenerated docsite data — `paddingBlock` now appears in the Section component registry.

## Changeset
Included (`@astryxdesign/core` patch, docs).