### PR TITLE
docs(core): document Table's verticalAlign and textOverflow props

### DIFF
--- a/.changeset/table-verticalalign-textoverflow-doc.md
+++ b/.changeset/table-verticalalign-textoverflow-doc.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[docs] Document Table's `verticalAlign` and `textOverflow` props, which were supported by the component but missing from the docsite properties tab
+@durvesh1992

--- a/packages/core/src/Table/Table.doc.mjs
+++ b/packages/core/src/Table/Table.doc.mjs
@@ -72,6 +72,18 @@ export const docs = {
       default: 'false',
     },
     {
+      name: 'verticalAlign',
+      type: "'middle' | 'top' | 'bottom'",
+      description: 'Vertical alignment for body row cells. Controls `vertical-align` on the `<td>` elements.',
+      default: "'middle'",
+    },
+    {
+      name: 'textOverflow',
+      type: "'wrap' | 'truncate'",
+      description: "How body cell text behaves when it exceeds the column width. 'wrap' lets text wrap and the row grow taller; 'truncate' clips with an ellipsis (default-rendered cells show a tooltip on hover when truncated). Header cells always truncate.",
+      default: "'wrap'",
+    },
+    {
       name: 'plugins',
       type: 'Record<string, TablePlugin<T>>',
       description: 'Named plugins that extend table behavior via the transform pipeline. Converted to an ordered array internally.',


### PR DESCRIPTION
## Summary

Two public `Table` props (both with JSDoc + `@default` + examples) were missing from the docsite **properties tab**:

- **`verticalAlign`** — `'middle' | 'top' | 'bottom'` (`@default 'middle'`): vertical alignment for body row cells (`vertical-align` on `<td>`).
- **`textOverflow`** — `'wrap' | 'truncate'` (`@default 'wrap'`): how body cell text behaves past the column width (wrap vs ellipsis-with-tooltip).

Found via the interface-vs-docs prop scan.

## Testing
- Regenerated docsite data — both props now appear in the Table component registry.

## Changeset
Included (`@astryxdesign/core` patch, docs).