### PR TITLE
ci(deploy): run PR typecheck gates on push to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,6 +66,26 @@ jobs:
 
       - run: pnpm build
 
+      # Typecheck gates mirroring the PR `build` job in ci.yml. ci.yml only runs
+      # on pull_request/merge_group, so a typecheck error can land on main (its
+      # push only runs `pnpm test`) undetected — then break the `build` check on
+      # every open PR, which typechecks the PR merged with main (see #3197).
+      # Running them here closes that gap and blocks a broken deploy.
+      - name: Verify package exports
+        run: node scripts/verify-exports.mjs
+
+      - name: Typecheck component docs
+        run: pnpm -F @astryxdesign/core typecheck:docs
+
+      - name: Typecheck template docs
+        run: pnpm -F @astryxdesign/cli typecheck:template-docs
+
+      - name: Typecheck storybook
+        run: pnpm -F @astryxdesign/storybook typecheck
+
+      - name: Typecheck core (including tests)
+        run: pnpm -F @astryxdesign/core typecheck
+
   deploy:
     needs: test
     if: always() && !cancelled() && needs.test.result == 'success'


### PR DESCRIPTION
## Problem

The typecheck gates that catch errors like the one fixed in #3197 only run on **pull requests**, never on pushes to `main`.

- `ci.yml`'s `build` job runs `verify-exports`, `typecheck:docs`, `typecheck:template-docs`, the storybook typecheck, and the core typecheck — but it triggers only on `pull_request` and `merge_group`.
- A **push to `main`** runs `deploy.yml` (plus `lint.yml`/`prune-branches.yml`). `deploy.yml`'s `test` job only ran `pnpm test` + `pnpm build` — **no typecheck gates**.

So a typecheck error (e.g. a duplicate `playground` key) can land on `main` undetected, then break the `build` check on **every open PR**, because that job typechecks the PR *merged with* `main`. As #3197 put it: "main's own push only runs test, so the duplicate landed without the build gate catching it."

## Fix

Add the same gate steps to `deploy.yml`'s `test` job so they run on push to `main`. Since `deploy` needs `test`, this closes the detection gap **and** blocks a broken deploy.

## Verification

Ran all five gates against current `main` — all pass, so this won't immediately red; it only prevents future breakage:

- `node scripts/verify-exports.mjs`
- `pnpm -F @astryxdesign/core typecheck:docs`
- `pnpm -F @astryxdesign/cli typecheck:template-docs`
- `pnpm -F @astryxdesign/storybook typecheck`
- `pnpm -F @astryxdesign/core typecheck`

CI-workflow-only change; no consumer-visible API change, so no changeset.
