### PR TITLE
docs(core): document TabList's layout prop

### DIFF
--- a/.changeset/tablist-layout-doc.md
+++ b/.changeset/tablist-layout-doc.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[docs] Document TabList's `layout` prop ('hug' | 'fill') for tab sizing, which was supported by the component but missing from the docsite properties tab
+@durvesh1992

--- a/packages/core/src/TabList/TabList.doc.mjs
+++ b/packages/core/src/TabList/TabList.doc.mjs
@@ -44,6 +44,12 @@ export const docs = {
       default: "'md'",
     },
     {
+      name: 'layout',
+      type: "'hug' | 'fill'",
+      description: "Layout mode for tab sizing. 'hug': each tab hugs its content width. 'fill': tabs stretch equally to fill the container width.",
+      default: "'hug'",
+    },
+    {
       name: 'hasDivider',
       type: 'boolean',
       description: 'Whether to show a bottom border divider under the tab list.',


### PR DESCRIPTION
## Summary

`TabList` has a public **`layout`** prop (`'hug' | 'fill'`, `@default 'hug'`) — `'hug'` makes each tab hug its content width, `'fill'` stretches tabs equally to fill the container — but it was missing from the docsite **properties tab**.

Found via the interface-vs-docs prop scan. Added after `size`.

## Testing
- Regenerated docsite data — `layout` now appears in the TabList component registry.

## Changeset
Included (`@astryxdesign/core` patch, docs).