### PR TITLE
docs(cli): add component-selection ladder to the agent cheat sheet

### DIFF
--- a/.changeset/agent-docs-selection-hierarchy.md
+++ b/.changeset/agent-docs-selection-hierarchy.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[docs] Add a component-selection ladder to the generated agent cheat sheet (`agent-docs`): guide LLM consumers to prefer the app's own components, then Astryx semantic components, then Astryx primitives, then a custom composition in `/components`, and only as a last resort a token-built custom component — cribbing behavior from the closest Astryx component instead of hand-rolling raw CSS (#3212)
+@durvesh1992

--- a/packages/cli/src/commands/agent-docs.mjs
+++ b/packages/cli/src/commands/agent-docs.mjs
@@ -177,6 +177,17 @@ export function generateCompressedIndex(version, {coreDir, runPrefix = getRunPre
   lines.push('3. `astryx component <Name>` — props + examples for every component you use.');
   lines.push('');
 
+  // Selection ladder — which component to reach for, and how to fall back to a
+  // custom one, so models reuse/compose instead of jamming an ill-fitting
+  // component or hand-rolling raw CSS in an arbitrary place.
+  lines.push('SELECT — choose in this order; only fall back when nothing above fits:');
+  lines.push("1. The app's own components — reuse what already exists in the project's /components.");
+  lines.push('2. Astryx semantic components/patterns — intent-named, higher-level (e.g. Chat, Dialog).');
+  lines.push('3. Astryx primitive/compositional components (Button, Card, Stack, ...).');
+  lines.push('4. Custom composition in /components, built from Astryx primitives — when no single component fits.');
+  lines.push('5. Last resort: custom in /components from CSS token primitives; crib hooks/behavior from the closest Astryx component (`astryx swizzle <Name>`) instead of hand-rolling.');
+  lines.push('');
+
   // Rules — the top error-preventers.
   lines.push('RULES:');
   lines.push('- No <div> — components do all layout/spacing. Full page → AppShell; sidebar nav → SideNav.');


### PR DESCRIPTION
## Summary

Closes #3212.

The generated agent docs (`agent-docs` → the `<!-- XDS:START -->` block in `AGENTS.md`/`CLAUDE.md`/`.cursorrules`) told models the **rules** and a **discovery workflow**, but gave no guidance on *which* component to reach for, in what order, or where/how to author a custom one. So when nothing fits exactly, models jam an ill-fitting component or hand-roll raw CSS in an arbitrary place.

Added a concise **SELECT** ladder between WORKFLOW and RULES, encoding the hierarchy from the issue:

1. The app's own components (reuse what's in `/components`)
2. Astryx semantic components/patterns (Chat, Dialog, …)
3. Astryx primitive/compositional components (Button, Card, Stack, …)
4. Custom composition in `/components` built from Astryx primitives
5. Last resort: custom in `/components` from CSS token primitives — cribbing hooks/behavior from the closest Astryx component (`astryx swizzle <Name>`) instead of hand-rolling.

Kept it terse to match the compressed cheat-sheet style.

## Testing
- Regenerated the index via `generateCompressedIndex` — the SELECT section renders correctly between WORKFLOW and RULES.
- `agent-docs` tests: **51/51 pass**.

## Notes
- Scoped to the high-leverage surface (the generated cheat sheet). The issue also mentions possibly mirroring this in the `working-with-ai` guide — happy to follow up there if you'd like.
- Wording is open to tweaks.

## Changeset
Included (`@astryxdesign/cli` patch, docs).