### PR TITLE
docs: remove em-dashes and curly quote from doc prose

### DIFF
--- a/packages/core/src/Layer/useLayer.doc.mjs
+++ b/packages/core/src/Layer/useLayer.doc.mjs
@@ -78,7 +78,7 @@ export const docs = {
       name: 'render',
       type: '(children: ReactNode, props: ContextRenderProps | FixedRenderProps) => ReactNode',
       description:
-        'Render function for the popover element. Pass placement/alignment in context mode or x/y in fixed mode. In context mode, pass `as: "span"` to render an inline-safe layer (e.g. inside a paragraph). The layer renders inline in the React tree — the Popover API promotes it to the top layer when shown, so it escapes ancestor clipping and stacking without a portal.',
+        'Render function for the popover element. Pass placement/alignment in context mode or x/y in fixed mode. In context mode, pass `as: "span"` to render an inline-safe layer (e.g. inside a paragraph). The layer renders inline in the React tree; the Popover API promotes it to the top layer when shown, so it escapes ancestor clipping and stacking without a portal.',
     },
   ],
   usage: {
@@ -98,7 +98,7 @@ export const docs = {
       {
         guidance: true,
         description:
-          'Rely on the Popover API top layer to escape ancestor clipping and stacking — render the layer inline (no portal) so it inherits the trigger\u2019s theme cascade and keeps a natural focus order. Use `as: "span"` when the layer must be valid inside inline contexts like a paragraph.',
+          'Rely on the Popover API top layer to escape ancestor clipping and stacking: render the layer inline (no portal) so it inherits the trigger\'s theme cascade and keeps a natural focus order. Use `as: "span"` when the layer must be valid inside inline contexts like a paragraph.',
       },
       {
         guidance: false,

--- a/packages/core/src/Layout/Layout.doc.mjs
+++ b/packages/core/src/Layout/Layout.doc.mjs
@@ -30,7 +30,7 @@ export const docs = {
       name: 'content',
       type: 'ReactNode',
       description:
-        'Main content area (center). Children passed to `<Layout>` render here too — `<Layout>{main}</Layout>` is shorthand for `<Layout content={main} />`.',
+        'Main content area (center). Children passed to `<Layout>` render here too: `<Layout>{main}</Layout>` is shorthand for `<Layout content={main} />`.',
       slotElements: [
         {
           __element: 'LayoutContent',

--- a/packages/core/src/Toolbar/Toolbar.doc.mjs
+++ b/packages/core/src/Toolbar/Toolbar.doc.mjs
@@ -51,7 +51,7 @@ export const docs = {
           name: 'size',
           type: "'sm' | 'md' | 'lg'",
           description:
-            'Size of the toolbar. Controls minimum height and coordinates with Button, TextInput, TabList, and Selector — children inherit this size as their default via SizeContext.',
+            'Size of the toolbar. Controls minimum height and coordinates with Button, TextInput, TabList, and Selector; children inherit this size as their default via SizeContext.',
           default: "'md'",
         },
         {


### PR DESCRIPTION
## What

Removes 5 AI-slop typographic tells from English doc strings:

- **useLayer.doc.mjs** (line 81): em-dash replaced with semicolon in `render` param description
- **useLayer.doc.mjs** (line 101): em-dash replaced with colon + curly apostrophe (`\u2019`) replaced with straight quote in bestPractices entry
- **Layout.doc.mjs** (line 33): em-dash replaced with colon in `content` prop description
- **Toolbar.doc.mjs** (line 54): em-dash replaced with semicolon in `size` prop description

CJK double em-dashes and numeric en-dash ranges were left alone.

## Checklist
- [x] `pnpm --filter @astryxdesign/core typecheck:docs` passes
- [x] `npx tsc --project packages/cli/tsconfig.template-docs.json --noEmit` passes
- [x] All three modified files parse cleanly
- [x] CLI `--lang dense` output verified for useLayer, Layout, Toolbar

---
*Night Watch -- Doc Reviewer*