### PR TITLE
docs(cli): fix Card example titles and add playground defaults

### DIFF
--- a/.changeset/card-example-titles-and-playground-defaults.md
+++ b/.changeset/card-example-titles-and-playground-defaults.md
@@ -4,3 +4,5 @@
 ---
 
 [docs] Rename the ClickableCard and SelectableCard examples to follow the "Component — Variant" title convention (`Clickable Card — Nested Button`, `Selectable Card — Multi-select`), and add playground defaults to both card docs so their docsite previews show realistic card content (#2877)
+
+@cixzhang

--- a/.changeset/card-example-titles-and-playground-defaults.md
+++ b/.changeset/card-example-titles-and-playground-defaults.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/cli': patch
+'@astryxdesign/core': patch
+---
+
+[docs] Rename the ClickableCard and SelectableCard examples to follow the "Component — Variant" title convention (`Clickable Card — Nested Button`, `Selectable Card — Multi-select`), and add playground defaults to both card docs so their docsite previews show realistic card content (#2877)

--- a/apps/docsite/src/__tests__/data-extraction.test.ts
+++ b/apps/docsite/src/__tests__/data-extraction.test.ts
@@ -337,8 +337,7 @@ describe('componentRegistry', () => {
     // rather than by a name prefix.
     const hooks = core.filter(
       c =>
-        /^use[A-Z]/.test(c.name) &&
-        (exampleRegistry[c.name]?.length ?? 0) > 0,
+        /^use[A-Z]/.test(c.name) && (exampleRegistry[c.name]?.length ?? 0) > 0,
     );
     expect(hooks.length).toBeGreaterThan(15);
     expect(hooks.map(h => h.name)).toContain('useTheme');
@@ -666,7 +665,9 @@ describe('themeRegistry', () => {
   });
 
   it('has no entries for non-theme packages', () => {
-    const nonTheme = packages.filter(p => !p.name.startsWith('@astryxdesign/theme-'));
+    const nonTheme = packages.filter(
+      p => !p.name.startsWith('@astryxdesign/theme-'),
+    );
     for (const pkg of nonTheme) {
       expect(registrySource).not.toContain(`'${pkg.name}':`);
     }
@@ -807,5 +808,70 @@ describe('exampleRegistry', () => {
       .flat()
       .reduce((max, e) => Math.max(max, e.description.length), 0);
     expect(longest).toBeGreaterThan(200);
+  });
+});
+
+// ── Block example title convention (Component — Variant) ─────────────────
+// Example block `displayName`s should read like "Component — Variant" using an
+// em-dash separator, not leak PascalCase/export-name wording. The Card example
+// titles previously rendered as "Clickable Card With Nested Button" and
+// "Selectable Card Multi".
+describe('block example title convention', () => {
+  const blocksDir = fileURLToPath(
+    new URL('../../../../packages/cli/templates/blocks', import.meta.url),
+  );
+
+  function displayNameOf(relPath: string): string | null {
+    const content = fs.readFileSync(`${blocksDir}/${relPath}`, 'utf-8');
+    const m = content.match(/displayName:\s*['"]([^'"]+)['"]/);
+    return m ? m[1] : null;
+  }
+
+  it('Card example titles use the em-dash variant convention', () => {
+    expect(
+      displayNameOf('components/Card/ClickableCardWithNestedButton.doc.mjs'),
+    ).toBe('Clickable Card — Nested Button');
+    expect(displayNameOf('components/Card/SelectableCardMulti.doc.mjs')).toBe(
+      'Selectable Card — Multi-select',
+    );
+  });
+});
+
+// ── Playground defaults for Card components (BB-006 / #2008) ──────────────
+// ClickableCard and SelectableCard playgrounds rendered empty because their
+// docs carried no `playground.defaults`. Defaults must flow into the generated
+// registry so previews demonstrate realistic card layouts.
+describe('Card playground defaults', () => {
+  function coreComponent(name: string) {
+    return Object.values(components)
+      .flat()
+      .find(c => c.name === name);
+  }
+
+  it('ClickableCard has playground defaults with label, href, and body content', () => {
+    const entry = coreComponent('ClickableCard');
+    expect(entry).toBeDefined();
+    const defaults = entry!.playground?.defaults as
+      | Record<string, unknown>
+      | undefined;
+    expect(defaults).toBeDefined();
+    expect(typeof defaults!.label).toBe('string');
+    expect(defaults!.href).toBeDefined();
+    // children is a resolved element descriptor, not empty.
+    expect(defaults!.children).toBeTruthy();
+    expect(typeof defaults!.children).toBe('object');
+  });
+
+  it('SelectableCard has playground defaults with label, selection state, and body content', () => {
+    const entry = coreComponent('SelectableCard');
+    expect(entry).toBeDefined();
+    const defaults = entry!.playground?.defaults as
+      | Record<string, unknown>
+      | undefined;
+    expect(defaults).toBeDefined();
+    expect(typeof defaults!.label).toBe('string');
+    expect(typeof defaults!.isSelected).toBe('boolean');
+    expect(defaults!.children).toBeTruthy();
+    expect(typeof defaults!.children).toBe('object');
   });
 });

--- a/packages/cli/templates/blocks/components/Card/ClickableCardWithNestedButton.doc.mjs
+++ b/packages/cli/templates/blocks/components/Card/ClickableCardWithNestedButton.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'block',
   exampleFor: 'ClickableCard',
   name: 'ClickableCardWithNestedButton',
-  displayName: 'Clickable Card With Nested Button',
+  displayName: 'Clickable Card — Nested Button',
   description:
     'A product card that navigates on click but has an independent "Add to cart" button inside.',
   isReady: true,

--- a/packages/cli/templates/blocks/components/Card/SelectableCardMulti.doc.mjs
+++ b/packages/cli/templates/blocks/components/Card/SelectableCardMulti.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'block',
   exampleFor: 'SelectableCard',
   name: 'SelectableCardMulti',
-  displayName: 'Selectable Card Multi',
+  displayName: 'Selectable Card — Multi-select',
   description:
     'Multi-select tag picker using color variant selectable cards with color-matched selection borders.',
   isReady: true,

--- a/packages/core/src/ClickableCard/ClickableCard.doc.mjs
+++ b/packages/core/src/ClickableCard/ClickableCard.doc.mjs
@@ -37,6 +37,21 @@ export const docs = {
     container: true,
     targets: [{className: 'astryx-clickable-card', visualProps: ['variant']}],
   },
+  playground: {
+    defaults: {
+      label: 'View product details',
+      href: '#',
+      padding: 4,
+      children: {
+        __element: 'XDSVStack',
+        props: {gap: 1},
+        children: [
+          {__element: 'XDSHeading', props: {level: 3}, children: 'Wireless Headphones'},
+          {__element: 'XDSText', props: {type: 'body'}, children: 'Noise-cancelling over-ear headphones with 30-hour battery life.'},
+        ],
+      },
+    },
+  },
 };
 
 /** @type {import('../docs-types').TranslationDoc} */

--- a/packages/core/src/SelectableCard/SelectableCard.doc.mjs
+++ b/packages/core/src/SelectableCard/SelectableCard.doc.mjs
@@ -36,6 +36,21 @@ export const docs = {
     container: true,
     targets: [{className: 'astryx-selectable-card', visualProps: ['selected']}],
   },
+  playground: {
+    defaults: {
+      label: 'Pro plan',
+      isSelected: true,
+      padding: 4,
+      children: {
+        __element: 'XDSVStack',
+        props: {gap: 1},
+        children: [
+          {__element: 'XDSHeading', props: {level: 3}, children: 'Pro plan'},
+          {__element: 'XDSText', props: {type: 'body'}, children: '$29/month — unlimited projects and priority support.'},
+        ],
+      },
+    },
+  },
 };
 
 /** @type {import('../docs-types').TranslationDoc} */


### PR DESCRIPTION
## Summary

Fixes two related Card documentation issues surfaced during a docs/preview review.

### 1. Card example titles (em-dash convention)

Two block examples used PascalCase/export-name wording for their `displayName`, so their docsite titles rendered malformed:

- `ClickableCardWithNestedButton` → `Clickable Card With Nested Button`
- `SelectableCardMulti` → `Selectable Card Multi`

The established convention is `Component — Variant` (em-dash), used by 368 of 516 block examples and by sibling Card blocks (`Card — Callout`, `Card — Variants`, `Card — Layout`, `Card — Simple`). Updated both to match:

- `Clickable Card — Nested Button`
- `Selectable Card — Multi-select`

### 2. Card playground defaults

`ClickableCard` and `SelectableCard` docs had no `playground.defaults`, and `children` is optional with no slot default, so the docsite playgrounds rendered nearly empty. Added `playground.defaults` (matching the existing config shape used by `Card`, `Button`, `Dialog`, etc.) so each preview shows a realistic card:

- **ClickableCard**: `label` + `href` + heading/body content.
- **SelectableCard**: `label` + `isSelected` selection state (auto-wired to `onChange` by the playground) + heading/body content.

## Root cause

- Title issue: the example metadata predates the `Component — Variant` naming convention and leaked the export name.
- Empty previews: these docs were never given `playground.defaults`, so the preview harness fell back to auto-generated state, which leaves optional `children` empty.

## Checks (red → green)

Added assertions to `apps/docsite/src/__tests__/data-extraction.test.ts`:

- A block-title check asserting the two Card examples use the em-dash variant titles.
- Two playground checks asserting the generated component registry now carries `playground.defaults` (label, href/selection state, and non-empty `children`) for both cards.

Verified against the data generated by `generate-data.mjs`:

- **Before** (unmodified docs): 3 failed (`expected 'Clickable Card With Nested Button' to be 'Clickable Card — Nested Button'`; playground defaults `undefined`).
- **After**: all pass; full `data-extraction.test.ts` suite green (76 passed).

Refs #2877 (BB-005, BB-006); related #2008
