### PR TITLE
docs(cli): make Toolbar Table Filter use real controls and enrich Toolbar playground

### DIFF
--- a/.changeset/toolbar-table-filter-and-playground.md
+++ b/.changeset/toolbar-table-filter-and-playground.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/cli': patch
+'@astryxdesign/core': patch
+---
+
+[docs] Make the Toolbar "Table Filter" example use real Selector controls for its Status and Priority filters instead of buttons styled to look like dropdowns, and add meaningful playground defaults plus richer slot options (buttons, icon buttons, tabs, segmented controls, selectors) to the Toolbar docs (#2877).
+@cixzhang

--- a/packages/cli/templates/blocks/components/Toolbar/ToolbarTableFilter.doc.mjs
+++ b/packages/cli/templates/blocks/components/Toolbar/ToolbarTableFilter.doc.mjs
@@ -7,8 +7,8 @@ export const doc = {
   name: 'Toolbar — Table Filter',
   displayName: 'Toolbar — Table Filter',
   description:
-    'A compact toolbar with a search input, filter buttons, and an overflow menu. Use above a data table to let users search, filter, and access view options.',
+    'A compact toolbar with a search input, Status and Priority filter selectors, and an overflow menu. Use above a data table to let users search, filter, and access view options.',
   isReady: true,
   aspectRatio: 16 / 9,
-  componentsUsed: ['Toolbar', 'Button', 'Icon', 'TextInput', 'MoreMenu', 'Layout', 'Table'],
+  componentsUsed: ['Toolbar', 'Selector', 'TextInput', 'MoreMenu', 'Layout', 'Table'],
 };

--- a/packages/cli/templates/blocks/components/Toolbar/ToolbarTableFilter.tsx
+++ b/packages/cli/templates/blocks/components/Toolbar/ToolbarTableFilter.tsx
@@ -2,19 +2,20 @@
 
 'use client';
 
+import {useState} from 'react';
 import {Toolbar} from '@astryxdesign/core/Toolbar';
-import {Button} from '@astryxdesign/core/Button';
-import {Icon} from '@astryxdesign/core/Icon';
+import {Selector} from '@astryxdesign/core/Selector';
 import {TextInput} from '@astryxdesign/core/TextInput';
 import {MoreMenu} from '@astryxdesign/core/MoreMenu';
 import {Stack} from '@astryxdesign/core/Layout';
 import {Table} from '@astryxdesign/core/Table';
-import {
-  MagnifyingGlassIcon,
-  ChevronDownIcon,
-} from '@heroicons/react/24/outline';
+import {MagnifyingGlassIcon} from '@heroicons/react/24/outline';
 
 export default function ToolbarTableFilter() {
+  const [search, setSearch] = useState('');
+  const [status, setStatus] = useState<string | null>(null);
+  const [priority, setPriority] = useState<string | null>(null);
+
   return (
     <Stack direction="vertical" style={{width: '100%'}}>
       <Toolbar
@@ -27,19 +28,27 @@ export default function ToolbarTableFilter() {
               label="Search"
               isLabelHidden
               placeholder="Search..."
-              value=""
-              onChange={() => {}}
+              value={search}
+              onChange={setSearch}
               startIcon={MagnifyingGlassIcon}
             />
-            <Button
+            <Selector
               label="Status"
-              variant="secondary"
-              endContent={<Icon icon={ChevronDownIcon} />}
+              isLabelHidden
+              placeholder="Status"
+              hasClear
+              value={status}
+              onChange={setStatus}
+              options={['Open', 'In progress', 'Done']}
             />
-            <Button
+            <Selector
               label="Priority"
-              variant="secondary"
-              endContent={<Icon icon={ChevronDownIcon} />}
+              isLabelHidden
+              placeholder="Priority"
+              hasClear
+              value={priority}
+              onChange={setPriority}
+              options={['High', 'Medium', 'Low']}
             />
           </>
         }

--- a/packages/core/src/Toolbar/Toolbar.doc.mjs
+++ b/packages/core/src/Toolbar/Toolbar.doc.mjs
@@ -7,6 +7,25 @@ export const docs = {
   displayName: 'Toolbar',
   category: 'Action',
   keywords: ['toolbar', 'nav', 'bar', 'actions', 'buttonbar', 'header', 'footer', 'action-bar', 'control-bar'],
+  playground: {
+    defaults: {
+      label: 'Table actions',
+      size: 'sm',
+      dividers: ['bottom'],
+      startContent: {
+        __element: 'TabList',
+        props: {value: 'overview'},
+        children: [
+          {__element: 'Tab', props: {label: 'Overview', value: 'overview'}},
+          {__element: 'Tab', props: {label: 'Activity', value: 'activity'}},
+        ],
+      },
+      endContent: [
+        {__element: 'Selector', props: {label: 'Status', isLabelHidden: true, placeholder: 'Status', size: 'sm', options: ['Open', 'In progress', 'Done']}},
+        {__element: 'Button', props: {label: 'New item', variant: 'primary', size: 'sm'}},
+      ],
+    },
+  },
   theming: {
     targets: [
       {className: 'astryx-toolbar', states: ['size']},
@@ -29,21 +48,62 @@ export const docs = {
           name: 'startContent',
           type: 'ReactNode',
           description: 'Content aligned to the start (left in LTR).',
-          slotElements: [{__element: 'Icon', props: {icon: 'check', size: 'sm'}}],
+          slotElements: [
+            {__element: 'Text', props: {type: 'body', weight: 'bold'}, children: 'Title'},
+            {__element: 'Button', props: {label: 'Back', variant: 'ghost', size: 'sm'}},
+            {__element: 'IconButton', props: {label: 'Filter', icon: {__element: 'Icon', props: {icon: 'check', size: 'sm'}}, variant: 'ghost', size: 'sm'}},
+            {
+              __element: 'TabList',
+              props: {value: 'overview'},
+              children: [
+                {__element: 'Tab', props: {label: 'Overview', value: 'overview'}},
+                {__element: 'Tab', props: {label: 'Activity', value: 'activity'}},
+              ],
+            },
+            {
+              __element: 'SegmentedControl',
+              props: {label: 'View', value: 'list'},
+              children: [
+                {__element: 'SegmentedControlItem', props: {label: 'List', value: 'list'}},
+                {__element: 'SegmentedControlItem', props: {label: 'Grid', value: 'grid'}},
+              ],
+            },
+            {__element: 'Selector', props: {label: 'Status', isLabelHidden: true, placeholder: 'Status', size: 'sm', options: ['Open', 'In progress', 'Done']}},
+          ],
         },
         {
           name: 'centerContent',
           type: 'ReactNode',
           description:
             'Centered content. Switches layout to CSS grid (1fr auto 1fr).',
-          slotElements: [{__element: 'Text', props: {type: 'body', weight: 'bold'}, children: 'Center'}],
+          slotElements: [
+            {__element: 'Text', props: {type: 'body', weight: 'bold'}, children: 'Center'},
+            {
+              __element: 'SegmentedControl',
+              props: {label: 'View', value: 'list'},
+              children: [
+                {__element: 'SegmentedControlItem', props: {label: 'List', value: 'list'}},
+                {__element: 'SegmentedControlItem', props: {label: 'Grid', value: 'grid'}},
+              ],
+            },
+            {
+              __element: 'TabList',
+              props: {value: 'overview'},
+              children: [
+                {__element: 'Tab', props: {label: 'Overview', value: 'overview'}},
+                {__element: 'Tab', props: {label: 'Activity', value: 'activity'}},
+              ],
+            },
+          ],
         },
         {
           name: 'endContent',
           type: 'ReactNode',
           description: 'Content aligned to the end (right in LTR).',
           slotElements: [
-            {__element: 'Icon', props: {icon: 'chevronDown', size: 'sm'}},
+            {__element: 'Button', props: {label: 'Save', variant: 'primary', size: 'sm'}},
+            {__element: 'IconButton', props: {label: 'More', icon: {__element: 'Icon', props: {icon: 'chevronDown', size: 'sm'}}, variant: 'ghost', size: 'sm'}},
+            {__element: 'Selector', props: {label: 'Sort', isLabelHidden: true, placeholder: 'Sort by', size: 'sm', options: ['Newest', 'Oldest', 'A–Z']}},
             {__element: 'Badge', props: {label: '3'}},
           ],
         },


### PR DESCRIPTION
## Summary

Fixes two related Toolbar documentation/example fidelity issues so the docs demonstrate honest, real controls and the Toolbar playground starts in a meaningful state.

### BB-003 — Toolbar "Table Filter" example used fake filter controls
The `Toolbar — Table Filter` block example rendered its **Status** and **Priority** filters as plain secondary `Button`s with a chevron icon, styled to look like dropdowns but doing nothing — semantically misleading for an example meant to teach correct composition.

**Fix:** replace those buttons with real `Selector` controls (hidden label, placeholder, clearable, controlled value), matching how sibling examples compose filter selectors. Updated the example description and `componentsUsed` accordingly.

### BB-004 — Toolbar playground started too empty
`Toolbar.doc.mjs` had no `playground.defaults` and only narrow `slotElements` (Icon / Text / Icon+Badge), so the playground opened nearly empty and under-represented what a Toolbar can hold.

**Fix:** add `playground.defaults` (a labeled toolbar with a TabList in `startContent` and a Selector + primary Button in `endContent`) and expand the slot options across `startContent` / `centerContent` / `endContent` to include text, button, icon button, tab list, segmented control, and selector descriptors.

## Root cause
Example/doc content drift: the example faked a dropdown with a button instead of using the system's `Selector`, and the Toolbar doc never defined playground defaults, so the generated registry carried `playground: null`.

## Checks (provable)
- **BB-004:** ran the docsite codegen (`generate-data.mjs`). Before: the Toolbar entry emitted `"playground": null`. After: it emits a populated `playground.defaults` plus the expanded `slotElements` (Button, IconButton, TabList, SegmentedControl, Selector, Text, Badge) — codegen completes without errors. Component-doc typecheck (`typecheck:docs`) passes.
- **BB-003:** the rewritten example typechecks clean against the real `@astryxdesign/core` component APIs (verified `Selector`'s clearable signature — nullable `value`/`onChange`, `options`, `placeholder`, `isLabelHidden`). The CLI template-docs typecheck (`typecheck:template-docs`) passes and the block flows through the block registry with the updated description.

Refs #2877 (BB-003, BB-004); related #2008
