### PR TITLE
docs(cli): add LinkProvider example block

### DIFF
--- a/.changeset/linkprovider-example-block.md
+++ b/.changeset/linkprovider-example-block.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[docs] Add a LinkProvider example block showing how to swap in a framework router link (e.g. Next.js Link) for client-side routing (#2733)
+@cixzhang

--- a/packages/cli/templates/blocks/components/LinkProvider/LinkProviderCustomLink.doc.mjs
+++ b/packages/cli/templates/blocks/components/LinkProvider/LinkProviderCustomLink.doc.mjs
@@ -1,0 +1,14 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  exampleFor: 'LinkProvider',
+  name: 'Link Provider — Custom Link Component',
+  displayName: 'Link Provider — Custom Link Component',
+  description:
+    'Routes every Astryx link through a custom component that intercepts the click — the hook frameworks like Next.js use for client-side navigation. Click the link to see the custom handler fire instead of a full-page load.',
+  isReady: true,
+  aspectRatio: 4 / 3,
+  componentsUsed: ['LinkProvider', 'Link'],
+};

--- a/packages/cli/templates/blocks/components/LinkProvider/LinkProviderCustomLink.tsx
+++ b/packages/cli/templates/blocks/components/LinkProvider/LinkProviderCustomLink.tsx
@@ -1,0 +1,43 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import type {AnchorHTMLAttributes} from 'react';
+import {Link, LinkProvider} from '@astryxdesign/core/Link';
+
+/**
+ * A stand-in for a framework router link (e.g. Next.js `Link` or React
+ * Router `Link`). Instead of letting the browser do a full-page navigation,
+ * it intercepts the click and hands the destination to a custom handler —
+ * the same hook real routers use for client-side navigation. Here it just
+ * announces the target so the behavior swap is observable in the preview.
+ */
+function RouterLink({
+  href,
+  onClick,
+  children,
+  ...props
+}: AnchorHTMLAttributes<HTMLAnchorElement>) {
+  return (
+    <a
+      href={href}
+      onClick={e => {
+        e.preventDefault();
+        onClick?.(e);
+        alert(`RouterLink intercepted navigation to: ${href}`);
+      }}
+      {...props}>
+      {children}
+    </a>
+  );
+}
+
+export default function LinkProviderCustomLink() {
+  return (
+    <LinkProvider component={RouterLink}>
+      <Link href="/dashboard" isStandalone>
+        Go to dashboard
+      </Link>
+    </LinkProvider>
+  );
+}

--- a/packages/core/src/Link/LinkProvider.tsx
+++ b/packages/core/src/Link/LinkProvider.tsx
@@ -23,6 +23,7 @@
  * - /packages/core/src/Link/index.ts
  * - /packages/core/src/Link/Link.doc.mjs
  * - /packages/cli/templates/blocks/components/Link/ (showcase blocks)
+ * - /packages/cli/templates/blocks/components/LinkProvider/ (example blocks)
  */
 
 import {useMemo, type ReactNode} from 'react';


### PR DESCRIPTION
## What

Adds a non-showcase **example block** for `LinkProvider` (`LinkProviderCustomLink`), addressing the first item in the utility-component docsite tracking issue: *"Needs at least one example block demonstrating how it works (e.g. wrapping an app with a custom link component)."*

The example wraps a single `Link` in `LinkProvider` and supplies a stand-in `RouterLink` (a placeholder for a framework router link such as Next.js `Link`). Instead of styling, the custom component demonstrates the **behavioral** reason to swap link components: it calls `e.preventDefault()` and runs a custom handler on click — the exact hook real routers use for client-side navigation — rather than triggering a full-page load. Clicking the link in the preview fires the handler so the swap is observable.

## Why

`LinkProvider` previously had no example block on its docsite page — only a props table. This gives consumers a concrete, copy-pasteable pattern for the primary use case: intercepting navigation for client-side routing.

## Notes

- This is an **example block**, not a showcase (`isShowcase` intentionally omitted) — `LinkProvider` is a utility/provider and doesn't need a hero showcase.
- Block auto-discovers via the templates directory scan and registers under `exampleFor: 'LinkProvider'`; the docsite example registry renders it under the component's **Examples** section.
- Updated the `SYNC:` comment in `LinkProvider.tsx` to point at the new example-block directory.

## Validation

- `typecheck:template-docs` — passes (exit 0)
- docsite `generate` — block registered (385 examples / 122 components)
- docsite `test` — 189/189 passing
- eslint clean on the new block; copyright headers present

Part of #2733
