### PR TITLE
feat(layout): standardize sizing props (Tiers 1–2 of #3223)

### DIFF
--- a/.changeset/standard-layout-props.md
+++ b/.changeset/standard-layout-props.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] Standardize layout component sizing props. Add `maxWidth`/`minHeight` to `Stack`, `Grid`, and `Center` (matching `Section`/`Card`), migrate `Layout`/`LayoutHeader`/`LayoutFooter`/`LayoutPanel` sizing to the shared `SizeValue` type, and drop redundant `xstyle`/`className`/`style` re-declarations on `Stack`, `StackItem`, and `Layout`. No runtime behavior change.
+@cixzhang

--- a/packages/core/src/Center/Center.doc.mjs
+++ b/packages/core/src/Center/Center.doc.mjs
@@ -18,13 +18,23 @@ export const docs = {
     },
     {
       name: 'width',
-      type: 'number | string',
+      type: 'SizeValue',
       description: 'Container width (px or CSS value).',
     },
     {
       name: 'height',
-      type: 'number | string',
+      type: 'SizeValue',
       description: 'Container height (px or CSS value).',
+    },
+    {
+      name: 'maxWidth',
+      type: 'SizeValue',
+      description: 'Maximum container width (px or CSS value).',
+    },
+    {
+      name: 'minHeight',
+      type: 'SizeValue',
+      description: 'Minimum container height (px or CSS value).',
     },
     {
       name: 'isInline',

--- a/packages/core/src/Center/Center.tsx
+++ b/packages/core/src/Center/Center.tsx
@@ -39,14 +39,20 @@ const styles = stylex.create({
 
 // Dynamic styles for sizing props
 const dynamicStyles = stylex.create({
-  sizing: (width: SizeValue | null, height: SizeValue | null) => ({
+  sizing: (
+    width: SizeValue | null,
+    height: SizeValue | null,
+    maxWidth: SizeValue | null,
+    minHeight: SizeValue | null,
+  ) => ({
     width,
     height,
+    maxWidth,
+    minHeight,
   }),
 });
 
 export type CenterAxis = 'both' | 'horizontal' | 'vertical';
-
 
 export interface CenterProps extends BaseProps<HTMLDivElement> {
   /** Ref forwarded to the root element */
@@ -71,6 +77,18 @@ export interface CenterProps extends BaseProps<HTMLDivElement> {
    * Numbers are treated as pixels, strings are used as-is (e.g., '100%').
    */
   height?: SizeValue;
+
+  /**
+   * Maximum width of the container.
+   * Numbers are treated as pixels, strings are used as-is (e.g., '100%').
+   */
+  maxWidth?: SizeValue;
+
+  /**
+   * Minimum height of the container.
+   * Numbers are treated as pixels, strings are used as-is (e.g., '100%').
+   */
+  minHeight?: SizeValue;
 
   /**
    * Whether to make the container inline-flex (useful for text/icons).
@@ -101,6 +119,8 @@ export function Center({
   axis = 'both',
   width,
   height,
+  maxWidth,
+  minHeight,
   isInline = false,
   children,
   xstyle,
@@ -115,7 +135,12 @@ export function Center({
       isInline ? styles.inline : styles.base,
       (axis === 'both' || axis === 'vertical') && styles.alignItemsCenter,
       (axis === 'both' || axis === 'horizontal') && styles.justifyContentCenter,
-      dynamicStyles.sizing(width ?? null, height ?? null),
+      dynamicStyles.sizing(
+        width ?? null,
+        height ?? null,
+        maxWidth ?? null,
+        minHeight ?? null,
+      ),
       xstyle,
     ),
     className,

--- a/packages/core/src/Grid/Grid.doc.mjs
+++ b/packages/core/src/Grid/Grid.doc.mjs
@@ -39,13 +39,23 @@ export const docs = {
     },
     {
       name: 'width',
-      type: 'number | string',
-      description: 'Container width.',
+      type: 'SizeValue',
+      description: 'Container width. Numbers are treated as pixels, strings are used as-is.',
     },
     {
       name: 'height',
-      type: 'number | string',
-      description: 'Container height.',
+      type: 'SizeValue',
+      description: 'Container height. Numbers are treated as pixels, strings are used as-is.',
+    },
+    {
+      name: 'maxWidth',
+      type: 'SizeValue',
+      description: 'Maximum container width. Numbers are treated as pixels, strings are used as-is.',
+    },
+    {
+      name: 'minHeight',
+      type: 'SizeValue',
+      description: 'Minimum container height. Numbers are treated as pixels, strings are used as-is.',
     },
     {
       name: 'gap',

--- a/packages/core/src/Grid/Grid.tsx
+++ b/packages/core/src/Grid/Grid.tsx
@@ -84,6 +84,18 @@ export interface GridProps extends BaseProps<HTMLDivElement> {
   height?: SizeValue;
 
   /**
+   * Maximum width of the grid container.
+   * Numbers are treated as pixels, strings are used as-is (e.g., '100%').
+   */
+  maxWidth?: SizeValue;
+
+  /**
+   * Minimum height of the grid container.
+   * Numbers are treated as pixels, strings are used as-is (e.g., '100%').
+   */
+  minHeight?: SizeValue;
+
+  /**
    * Spacing between all grid items (both row and column).
    * Accepts numeric spacing steps: 0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10.
    */
@@ -346,6 +358,8 @@ export function Grid({
   rowHeight,
   width,
   height,
+  maxWidth,
+  minHeight,
   gap,
   rowGap,
   columnGap,
@@ -408,6 +422,12 @@ export function Grid({
     }),
     ...(height != null && {
       height: typeof height === 'number' ? `${height}px` : height,
+    }),
+    ...(maxWidth != null && {
+      maxWidth: typeof maxWidth === 'number' ? `${maxWidth}px` : maxWidth,
+    }),
+    ...(minHeight != null && {
+      minHeight: typeof minHeight === 'number' ? `${minHeight}px` : minHeight,
     }),
   };
 

--- a/packages/core/src/Layout/Layout.tsx
+++ b/packages/core/src/Layout/Layout.tsx
@@ -26,7 +26,7 @@ import {stack} from '../Stack/stack.stylex';
 import {stackItem} from '../Stack/stackItem.stylex';
 import {mergeProps} from '../utils';
 import type {BaseProps} from '../BaseProps';
-import type {SpacingStep} from '../utils/types';
+import type {SizeValue, SpacingStep} from '../utils/types';
 import {themeProps} from '../utils/themeProps';
 import {
   layoutPaddingOuterXVarStyles,
@@ -76,12 +76,12 @@ const styles = stylex.create({
 });
 
 const dynamicStyles = stylex.create({
-  contentWidthVar: (width: number) => ({
-    '--layout-content-width': `${width}px`,
+  contentWidthVar: (width: SizeValue) => ({
+    '--layout-content-width': typeof width === 'number' ? `${width}px` : width,
   }),
-  contentWidth: (width: number) => ({
+  contentWidth: (width: SizeValue) => ({
     width: '100%',
-    maxWidth: width,
+    maxWidth: typeof width === 'number' ? `${width}px` : width,
     marginInline: 'auto',
   }),
 });
@@ -102,11 +102,12 @@ export interface LayoutProps extends Omit<BaseProps, 'content'> {
    * panels). Dividers remain full-bleed. Content is centered with
    * `margin-inline: auto` when narrower than the available space.
    *
-   * Accepts any pixel value. Common page widths from internal patterns:
+   * Numbers are treated as pixels, strings are used as-is (e.g., '60ch').
+   * Common page widths:
    * - `640` — forms, settings, text-focused pages
    * - `960` — content pages, component demos, wider layouts
    */
-  contentWidth?: number;
+  contentWidth?: SizeValue;
 
   /**
    * End panel slot (right in LTR, left in RTL).
@@ -148,15 +149,6 @@ export interface LayoutProps extends Omit<BaseProps, 'content'> {
    * When not set, nested layouts inherit from their parent context.
    */
   defaultHasDividers?: boolean;
-
-  /**
-   * CSS class name(s) appended to the root element.
-   */
-  className?: string;
-  /**
-   * Inline styles to apply to the root element.
-   */
-  style?: React.CSSProperties;
 
   /**
    * Children are a shorthand for the `content` slot:

--- a/packages/core/src/Layout/LayoutFooter.doc.mjs
+++ b/packages/core/src/Layout/LayoutFooter.doc.mjs
@@ -22,8 +22,8 @@ export const docs = {
     },
     {
       name: 'height',
-      type: 'number | string',
-      description: 'Footer height.',
+      type: 'SizeValue',
+      description: 'Footer height. Numbers are treated as pixels, strings are used as-is.',
     },
     {
       name: 'label',
@@ -57,8 +57,8 @@ export const docsZh = {
     },
     {
       name: 'height',
-      type: 'number | string',
-      description: '页脚高度。',
+      type: 'SizeValue',
+      description: '页脚高度。数字类型会被解释为像素值，字符串类型按原样使用。',
     },
     {
       name: 'label',

--- a/packages/core/src/Layout/LayoutFooter.tsx
+++ b/packages/core/src/Layout/LayoutFooter.tsx
@@ -22,7 +22,7 @@ import * as stylex from '@stylexjs/stylex';
 import {LayoutDividerContext} from './LayoutDividerContext';
 import {colorVars, spacingVars} from '../theme/tokens.stylex';
 import {mergeProps} from '../utils';
-import type {SpacingStep} from '../utils/types';
+import type {SizeValue, SpacingStep} from '../utils/types';
 import {themeProps} from '../utils/themeProps';
 import {
   paddingStyles,
@@ -71,7 +71,7 @@ const styles = stylex.create({
 
 // Dynamic styles for sizing props
 const dynamicStyles = stylex.create({
-  sizing: (height: number | string | null) => ({
+  sizing: (height: SizeValue | null) => ({
     height,
   }),
 });
@@ -95,7 +95,7 @@ export interface LayoutFooterProps extends BaseProps<HTMLDivElement> {
    * Height of the footer.
    * Numbers are treated as pixels, strings are used as-is.
    */
-  height?: number | string;
+  height?: SizeValue;
 
   /**
    * Internal padding of the footer using the spacing scale.

--- a/packages/core/src/Layout/LayoutHeader.doc.mjs
+++ b/packages/core/src/Layout/LayoutHeader.doc.mjs
@@ -22,8 +22,8 @@ export const docs = {
     },
     {
       name: 'height',
-      type: 'number | string',
-      description: 'Header height.',
+      type: 'SizeValue',
+      description: 'Header height. Numbers are treated as pixels, strings are used as-is.',
     },
     {
       name: 'label',
@@ -57,8 +57,8 @@ export const docsZh = {
     },
     {
       name: 'height',
-      type: 'number | string',
-      description: '页眉高度。',
+      type: 'SizeValue',
+      description: '页眉高度。数字类型会被解释为像素值，字符串类型按原样使用。',
     },
     {
       name: 'label',

--- a/packages/core/src/Layout/LayoutHeader.tsx
+++ b/packages/core/src/Layout/LayoutHeader.tsx
@@ -22,7 +22,7 @@ import * as stylex from '@stylexjs/stylex';
 import {LayoutDividerContext} from './LayoutDividerContext';
 import {colorVars, spacingVars} from '../theme/tokens.stylex';
 import {mergeProps} from '../utils';
-import type {SpacingStep} from '../utils/types';
+import type {SizeValue, SpacingStep} from '../utils/types';
 import {themeProps} from '../utils/themeProps';
 import {
   paddingStyles,
@@ -71,7 +71,7 @@ const styles = stylex.create({
 
 // Dynamic styles for sizing props
 const dynamicStyles = stylex.create({
-  sizing: (height: number | string | null) => ({
+  sizing: (height: SizeValue | null) => ({
     height,
   }),
 });
@@ -95,7 +95,7 @@ export interface LayoutHeaderProps extends BaseProps<HTMLDivElement> {
    * Height of the header.
    * Numbers are treated as pixels, strings are used as-is.
    */
-  height?: number | string;
+  height?: SizeValue;
 
   /**
    * Internal padding of the header using the spacing scale.

--- a/packages/core/src/Layout/LayoutPanel.tsx
+++ b/packages/core/src/Layout/LayoutPanel.tsx
@@ -23,7 +23,7 @@ import {colorVars, spacingVars} from '../theme/tokens.stylex';
 import {LayoutAreaContext} from './LayoutAreaContext';
 import {LayoutSlotsContext} from './LayoutSlotsContext';
 import {mergeProps} from '../utils';
-import type {SpacingStep} from '../utils/types';
+import type {SizeValue, SpacingStep} from '../utils/types';
 import type {ResizableProps} from '../Resizable/useResizable';
 import {themeProps} from '../utils/themeProps';
 import {
@@ -102,7 +102,7 @@ const styles = stylex.create({
 
 // Dynamic styles for sizing props
 const dynamicStyles = stylex.create({
-  sizing: (width: number | string | null) => ({
+  sizing: (width: SizeValue | null) => ({
     width,
   }),
 });
@@ -158,7 +158,7 @@ export interface LayoutPanelProps extends BaseProps<HTMLDivElement> {
    * Numbers are treated as pixels, strings are used as-is.
    * When `resizable` is provided, this is ignored — the hook controls width.
    */
-  width?: number | string;
+  width?: SizeValue;
 
   /**
    * Resize props from `useResizable()`. When provided, the panel width

--- a/packages/core/src/Stack/Stack.doc.mjs
+++ b/packages/core/src/Stack/Stack.doc.mjs
@@ -39,6 +39,16 @@ export const docs = {
           description: "Height of the stack container. Numbers are treated as pixels, strings are used as-is (e.g., '100%').",
         },
         {
+          name: 'maxWidth',
+          type: 'SizeValue',
+          description: "Maximum width of the stack container. Numbers are treated as pixels, strings are used as-is (e.g., '100%').",
+        },
+        {
+          name: 'minHeight',
+          type: 'SizeValue',
+          description: "Minimum height of the stack container. Numbers are treated as pixels, strings are used as-is (e.g., '100%').",
+        },
+        {
           name: 'hAlign',
           type: "'start' | 'center' | 'end' | 'between' | 'around' | 'evenly'",
           description: 'Horizontal (main-axis) alignment of items.',
@@ -105,6 +115,16 @@ export const docs = {
           name: 'height',
           type: 'SizeValue',
           description: "Height of the stack container. Numbers are treated as pixels, strings are used as-is (e.g., '100%').",
+        },
+        {
+          name: 'maxWidth',
+          type: 'SizeValue',
+          description: "Maximum width of the stack container. Numbers are treated as pixels, strings are used as-is (e.g., '100%').",
+        },
+        {
+          name: 'minHeight',
+          type: 'SizeValue',
+          description: "Minimum height of the stack container. Numbers are treated as pixels, strings are used as-is (e.g., '100%').",
         },
         {
           name: 'hAlign',

--- a/packages/core/src/Stack/Stack.tsx
+++ b/packages/core/src/Stack/Stack.tsx
@@ -15,7 +15,6 @@
 import {createElement, type ElementType, type ReactNode, type Ref} from 'react';
 import type {BaseProps} from '../BaseProps';
 import * as stylex from '@stylexjs/stylex';
-import type {StyleXStyles} from '@stylexjs/stylex';
 import {
   stack,
   type StackCrossAlignment,
@@ -39,7 +38,6 @@ import {themeProps} from '../utils/themeProps';
  *   `'start' | 'center' | 'end' | 'stretch'`
  */
 export type StackAlignment = StackMainAlignment | StackCrossAlignment;
-
 
 export interface StackProps extends BaseProps<HTMLElement> {
   /** Ref forwarded to the root element */
@@ -101,6 +99,18 @@ export interface StackProps extends BaseProps<HTMLElement> {
   height?: SizeValue;
 
   /**
+   * Maximum width of the stack container.
+   * Numbers are treated as pixels, strings are used as-is (e.g., '100%').
+   */
+  maxWidth?: SizeValue;
+
+  /**
+   * Minimum height of the stack container.
+   * Numbers are treated as pixels, strings are used as-is (e.g., '100%').
+   */
+  minHeight?: SizeValue;
+
+  /**
    * Spacing between items.
    * Accepts numeric spacing steps: 0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10.
    */
@@ -120,28 +130,6 @@ export interface StackProps extends BaseProps<HTMLElement> {
    * @default 'div'
    */
   as?: ElementType;
-
-  /**
-   * StyleX styles created via `stylex.create()`. Merged with the component's
-   * base styles inside a single `stylex.props()` call for optimal deduplication.
-   *
-   * @example
-   * ```
-   * const overrides = stylex.create({ root: { marginBottom: 8 } });
-   * <Component xstyle={overrides.root} />
-   * ```
-   */
-  xstyle?: StyleXStyles;
-  /**
-   * CSS class name(s) appended to the root element.
-   * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
-   */
-  className?: string;
-  /**
-   * Inline styles to apply to the root element. Spread after StyleX
-   * inline styles, so these values take priority.
-   */
-  style?: React.CSSProperties;
 
   /**
    * Content to render inside the stack.
@@ -182,6 +170,8 @@ export function Stack({
   gap,
   width,
   height,
+  maxWidth,
+  minHeight,
   wrap,
   as: element = 'div',
   xstyle,
@@ -225,6 +215,12 @@ export function Stack({
     }),
     ...(height != null && {
       height: typeof height === 'number' ? `${height}px` : height,
+    }),
+    ...(maxWidth != null && {
+      maxWidth: typeof maxWidth === 'number' ? `${maxWidth}px` : maxWidth,
+    }),
+    ...(minHeight != null && {
+      minHeight: typeof minHeight === 'number' ? `${minHeight}px` : minHeight,
     }),
   };
 

--- a/packages/core/src/Stack/StackItem.tsx
+++ b/packages/core/src/Stack/StackItem.tsx
@@ -14,7 +14,6 @@
 import {createElement, type ElementType, type ReactNode, type Ref} from 'react';
 import type {BaseProps} from '../BaseProps';
 import * as stylex from '@stylexjs/stylex';
-import type {StyleXStyles} from '@stylexjs/stylex';
 import {
   stackItem,
   type StackItemCrossAlignSelf,
@@ -46,28 +45,6 @@ export interface StackItemProps extends BaseProps<HTMLElement> {
    * @default 'div'
    */
   as?: ElementType;
-
-  /**
-   * StyleX styles created via `stylex.create()`. Merged with the component's
-   * base styles inside a single `stylex.props()` call for optimal deduplication.
-   *
-   * @example
-   * ```
-   * const overrides = stylex.create({ root: { marginBottom: 8 } });
-   * <Component xstyle={overrides.root} />
-   * ```
-   */
-  xstyle?: StyleXStyles;
-  /**
-   * CSS class name(s) appended to the root element.
-   * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
-   */
-  className?: string;
-  /**
-   * Inline styles to apply to the root element. Spread after StyleX
-   * inline styles, so these values take priority.
-   */
-  style?: React.CSSProperties;
 
   /**
    * Content to render inside the stack item.


### PR DESCRIPTION
## What

First implementation step toward a standard layout prop set (#3223). Tiers 1 and 2: safe, mechanical changes with no runtime behavior change.

**Tier 1 — consistency / cleanup**
- Remove redundant `xstyle` / `className` / `style` re-declarations on `Stack`, `StackItem`, and `Layout`. These already come from the shared base props; re-declaring them is noise (the Component Auditor flags it). The components still destructure and forward them — only the duplicated interface declarations are removed.
- Migrate layout-area sizing props to the shared `SizeValue` type:
  - `LayoutHeader.height`, `LayoutFooter.height`, `LayoutPanel.width`: `number | string` → `SizeValue`
  - `Layout.contentWidth`: `number` → `SizeValue` (now also accepts CSS strings like `'60ch'`)

**Tier 2 — complete the sizing set**
- Add `maxWidth` and `minHeight` to `Stack`, `Grid`, and `Center`, matching the sizing set already on `Section` and `Card`. `HStack`/`VStack` inherit these automatically (they extend `StackProps`).

## Why

The layout components each grew their own vocabulary for the same concerns. This aligns the easy ones first:
- One sizing type (`SizeValue`) across all layout containers instead of ad-hoc `number | string` / px-only `number`.
- The de-facto sizing set (`width`/`height`/`maxWidth`/`minHeight`, as on `Section`/`Card`) now applies to `Stack`/`Grid`/`Center` too — so consumers don't drop to custom CSS for a max-width or min-height.
- No more duplicated escape-hatch declarations to keep in sync.

Tier E (capability props — `overflow`, flex `grow`/`shrink`/`basis`, `isSticky`, page surface, shell `maxWidth`) is intentionally **out of scope** here and will land incrementally, each closing its linked issue.

## How

- `SizeValue` coercion follows each component's existing pattern (inline-style number→px for `Stack`/`Grid`; StyleX dynamic-style function for `Center`; pass-through for `Layout*`, where StyleX already appends `px` to numbers).
- `.doc.mjs` updated for the new props and the `SizeValue` type alignment on `Grid`/`Center`.
- Changeset included.

## Validation

- `pnpm -F @astryxdesign/core build` ✓ (Babel + tsc + CSS + UMD)
- `pnpm -F @astryxdesign/core typecheck` and `typecheck:docs` ✓
- `pnpm -F @astryxdesign/docsite generate && test` ✓ (190/190)
- `node scripts/sync-exports.js --check` ✓
- eslint on changed files ✓
- Layout component tests pass (`Stack`, `StackItem`, `Grid`, `Center`, `Layout`, `FormLayout`)

Closes part of #3223 (Tiers 1–2).
