### PR TITLE
feat(lab): publish @astryxdesign/lab to the @canary dist-tag only

### DIFF
--- a/.changeset/lab-canary-publish-themeprops.md
+++ b/.changeset/lab-canary-publish-themeprops.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] Export `themeProps` (and its `ThemeProps`/`ClassProps`/`ClassValue`/`ThemeDataAttributes` types) from `@astryxdesign/core/utils`, so packages building on core can generate the stable astryx class + `data-*` attribute surface through the public API instead of reaching into core internals.
+
+@cixzhang

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "license": "MIT",
   "scripts": {
-    "build": "pnpm -F @astryxdesign/build build && pnpm -F @astryxdesign/core build && pnpm -F @astryxdesign/vega build && pnpm -F @astryxdesign/theme-neutral build && pnpm -F @astryxdesign/theme-matcha build && pnpm -F @astryxdesign/theme-stone build && pnpm -F @astryxdesign/theme-gothic build && pnpm -F @astryxdesign/theme-chocolate build && pnpm -F @astryxdesign/theme-y2k build && pnpm -F @astryxdesign/theme-butter build && pnpm bundle:cli-themes",
+    "build": "pnpm -F @astryxdesign/build build && pnpm -F @astryxdesign/core build && pnpm -F @astryxdesign/lab build && pnpm -F @astryxdesign/vega build && pnpm -F @astryxdesign/theme-neutral build && pnpm -F @astryxdesign/theme-matcha build && pnpm -F @astryxdesign/theme-stone build && pnpm -F @astryxdesign/theme-gothic build && pnpm -F @astryxdesign/theme-chocolate build && pnpm -F @astryxdesign/theme-y2k build && pnpm -F @astryxdesign/theme-butter build && pnpm bundle:cli-themes",
     "bundle:cli-themes": "node scripts/generate-cli-themes.mjs",
     "dev": "pnpm -F @astryxdesign/storybook dev",
     "test": "vitest run",

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -68,6 +68,13 @@ export {getKey, type Key, type KeyFallback} from './getKey';
 
 export {mergeProps} from './mergeProps';
 export {mergeRefs} from './mergeRefs';
+export {themeProps, themeDataAttributes} from './themeProps';
+export type {
+  ClassValue,
+  ClassProps,
+  ThemeDataAttributes,
+  ThemeProps,
+} from './themeProps';
 export {groupItems, getItemGroup} from './groupItems';
 export type {ItemGroup} from './groupItems';
 export {observeResize, unobserveResize} from './sharedResizeObserver';

--- a/packages/lab/README.md
+++ b/packages/lab/README.md
@@ -1,26 +1,47 @@
 # @astryxdesign/lab
 
-Experimental XDS components. This package is **not published**; it exists as a staging area for components being developed before graduating to `@astryxdesign/core`.
+Experimental Astryx components. This package is a staging area for components being developed before graduating to `@astryxdesign/core`. It ships to npm **only under the `@canary` dist-tag** — there is never a stable (`latest`) release.
 
 ## Purpose
 
 Components in lab:
 
 - Are importable in storybook and sandbox for testing
-- Can be iterated on freely without worrying about breaking consumers
+- Are publishable for early external testing via the `@canary` tag only
+- Can be iterated on freely without worrying about breaking stable consumers
 - Compose with `@astryxdesign/core` components (use the theme, follow naming conventions)
 - Graduate to `@astryxdesign/core` after thorough engineering review
 
 ## What's here vs what's in core
 
-**Lab:** Works, has basic props, maybe has stories. API might change. Not accessibility-hardened, not vibe-tested, not fully themed.
+**Lab:** Works, has basic props, maybe has stories. API might change. Not accessibility-hardened, not vibe-tested, not fully themed. **Canary-only — no stability promise.**
 
-**Core:** Full keyboard/a11y, hover guards, theming story, status states, spec compliance, vibe tested. Shipped to consumers.
+**Core:** Full keyboard/a11y, hover guards, theming story, status states, spec compliance, vibe tested. Shipped to consumers on `latest`.
 
 ## Usage
 
+Inside the monorepo (storybook/sandbox), imports resolve via pnpm workspaces:
+
 ```tsx
-import {XDSCodeEditor} from '@astryxdesign/lab';
+import {CodeEditor} from '@astryxdesign/lab';
 ```
 
-Since this is a workspace package (not published), imports resolve via pnpm workspaces in storybook and sandbox.
+### Trying lab components in your own project (canary)
+
+Lab is published **only** under the `@canary` dist-tag, so you must request that tag explicitly. There is no `latest` version to install.
+
+```bash
+npm install @astryxdesign/lab@canary @astryxdesign/core@canary
+```
+
+```tsx
+import {CodeEditor} from '@astryxdesign/lab';
+import '@astryxdesign/core/astryx.css';
+import '@astryxdesign/lab/lab.css';
+```
+
+> Canary builds track the latest commit on `main` (`0.x.y-canary.<sha>`). They can break between any two versions — pin an exact version if you need stability.
+
+## Why no stable release?
+
+`package.json` keeps `"private": true` plus an `"astryx": { "canaryOnly": true }` marker. The release workflow's stable (`latest`) job skips both private and `canaryOnly` packages, while the canary job strips `private` in its ephemeral CI checkout only (never in git) to publish the `@canary` tag. The committed `private: true` is npm's hard guarantee that no stable publish can ever happen — **do not remove it.**

--- a/packages/lab/babel-plugin-add-extensions.cjs
+++ b/packages/lab/babel-plugin-add-extensions.cjs
@@ -1,0 +1,61 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+/* eslint-disable @typescript-eslint/no-require-imports, no-undef */
+
+/**
+ * Babel plugin that appends .js to relative import/export paths.
+ *
+ * TypeScript source uses extensionless imports (e.g. './XDSButton').
+ * Node.js ESM requires explicit extensions for "type": "module" packages.
+ * This plugin rewrites them during compilation so no postbuild step is needed.
+ *
+ * Handles both file imports ('./XDSButton' → './XDSButton.js') and
+ * directory imports ('./domainTokens' → './domainTokens/index.js').
+ */
+const fs = require('fs');
+const nodePath = require('path');
+
+module.exports = function addExtensions() {
+  const SKIP = /\.(?:js|mjs|cjs|json|css)$/;
+
+  return {
+    visitor: {
+      'ImportDeclaration|ExportNamedDeclaration|ExportAllDeclaration'(
+        path,
+        state,
+      ) {
+        const source = path.node.source;
+        if (!source) return;
+        const value = source.value;
+
+        // Compat alias barrels self-re-export from `'.'` in source. Node ESM
+        // does not support directory imports in built output, so make the self
+        // reference explicit (`./index.js`) during compilation.
+        if (value === '.') {
+          source.value = './index.js';
+          return;
+        }
+        if (value === '..') {
+          source.value = '../index.js';
+          return;
+        }
+
+        if (!value.startsWith('./') && !value.startsWith('../')) return;
+        if (SKIP.test(value)) return;
+
+        const dir = nodePath.dirname(state.filename);
+        const asFile = nodePath.join(dir, value + '.ts');
+        const asTsx = nodePath.join(dir, value + '.tsx');
+        const asIndex = nodePath.join(dir, value, 'index.ts');
+        const asIndexTsx = nodePath.join(dir, value, 'index.tsx');
+
+        if (fs.existsSync(asFile) || fs.existsSync(asTsx)) {
+          source.value = value + '.js';
+        } else if (fs.existsSync(asIndex) || fs.existsSync(asIndexTsx)) {
+          source.value = value + '/index.js';
+        } else {
+          source.value = value + '.js';
+        }
+      },
+    },
+  };
+};

--- a/packages/lab/babel.config.js
+++ b/packages/lab/babel.config.js
@@ -1,0 +1,46 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file babel.config.js
+ * @input Uses @babel/preset-react, @babel/preset-typescript, the local
+ *   add-extensions plugin, and @stylexjs/babel-plugin
+ * @output Babel config for compiling lab src → dist (ESM .js with StyleX)
+ * @position Build config for @astryxdesign/lab
+ *
+ * Mirrors packages/core/babel.config.json, with one difference: lab consumes
+ * core's StyleX theme tokens (@astryxdesign/core/theme/tokens.stylex), a
+ * cross-package reference core never makes. The StyleX resolver therefore
+ * needs an alias to core's source and a monorepo-root rootDir.
+ *
+ * SYNC: When modified, update this header and /packages/lab/README.md
+ */
+
+/* global module, require, __dirname */
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const path = require('path');
+
+const rootDir = path.resolve(__dirname, '../..');
+
+module.exports = {
+  presets: [
+    ['@babel/preset-react', {runtime: 'automatic'}],
+    ['@babel/preset-typescript', {isTSX: true, allExtensions: true}],
+  ],
+  plugins: [
+    './babel-plugin-add-extensions.cjs',
+    [
+      '@stylexjs/babel-plugin',
+      {
+        dev: false,
+        runtimeInjection: false,
+        genConditionalClasses: true,
+        treeshakeCompensation: true,
+        aliases: {
+          '@astryxdesign/core/*': [path.join(rootDir, 'packages/core/src/*')],
+          '@astryxdesign/core': [path.join(rootDir, 'packages/core/src')],
+        },
+        unstable_moduleResolution: {type: 'commonJS', rootDir},
+      },
+    ],
+  ],
+};

--- a/packages/lab/package.json
+++ b/packages/lab/package.json
@@ -2,7 +2,7 @@
   "name": "@astryxdesign/lab",
   "version": "0.1.2",
   "private": true,
-  "description": "Experimental Astryx components \u2014 published to npm only under the @canary dist-tag for early testing; never released as a stable (latest) version.",
+  "description": "Experimental Astryx components — published to npm only under the @canary dist-tag for early testing; never released as a stable (latest) version.",
   "author": "Meta Open Source",
   "license": "MIT",
   "homepage": "https://github.com/facebook/astryx#readme",
@@ -22,7 +22,7 @@
   ],
   "astryx": {
     "canaryOnly": true,
-    "_comment": "Published ONLY to the @canary dist-tag (see .github/workflows/release.yml). Never published as a stable `latest` release. `private: true` is intentional and must stay \u2014 it is npm's hard guarantee against an accidental stable publish."
+    "_comment": "Published ONLY to the @canary dist-tag (see .github/workflows/release.yml). Never published as a stable `latest` release. `private: true` is intentional and must stay — it is npm's hard guarantee against an accidental stable publish."
   },
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/lab/package.json
+++ b/packages/lab/package.json
@@ -2,7 +2,7 @@
   "name": "@astryxdesign/lab",
   "version": "0.1.2",
   "private": true,
-  "description": "Experimental XDS components — not published, available in storybook and sandbox for testing",
+  "description": "Experimental Astryx components \u2014 published to npm only under the @canary dist-tag for early testing; never released as a stable (latest) version.",
   "author": "Meta Open Source",
   "license": "MIT",
   "homepage": "https://github.com/facebook/astryx#readme",
@@ -20,9 +20,41 @@
     "experimental",
     "design-system"
   ],
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "astryx": {
+    "canaryOnly": true,
+    "_comment": "Published ONLY to the @canary dist-tag (see .github/workflows/release.yml). Never published as a stable `latest` release. `private: true` is intentional and must stay \u2014 it is npm's hard guarantee against an accidental stable publish."
+  },
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "sideEffects": false,
+  "files": [
+    "dist",
+    "src",
+    "README.md",
+    "CHANGELOG.md"
+  ],
+  "exports": {
+    ".": {
+      "source": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./lab.css": {
+      "default": "./dist/lab.css"
+    }
+  },
+  "scripts": {
+    "prepack": "pnpm build",
+    "build": "rm -rf dist && pnpm build:esm && tsc --project tsconfig.build.json && pnpm build:css",
+    "build:esm": "babel src --out-dir dist --extensions '.ts,.tsx' --out-file-extension '.js' --ignore '**/*.test.ts,**/*.test.tsx,**/__tests__/**,**/*.perf.test.*,**/*.doc.mjs,**/*.d.ts,**/*.css,**/*.css.d.ts' --config-file ./babel.config.js",
+    "build:css": "node ../../scripts/build-css.mjs --package lab",
+    "dev": "babel src --watch --out-dir dist --extensions '.ts,.tsx' --out-file-extension '.js' --ignore '**/*.test.*,**/*.doc.mjs,**/*.d.ts,**/*.css*' --config-file ./babel.config.js",
+    "test": "vitest run --root ../..",
+    "test:watch": "vitest --root ../..",
+    "lint": "eslint src",
+    "typecheck": "tsc --project tsconfig.json --noEmit"
+  },
   "peerDependencies": {
     "@stylexjs/stylex": ">=0.10.0",
     "@astryxdesign/core": "0.1.2",

--- a/packages/lab/src/ChatReasoning/ChatReasoning.test.tsx
+++ b/packages/lab/src/ChatReasoning/ChatReasoning.test.tsx
@@ -1,5 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+import {describe, it, expect} from 'vitest';
 import {render, screen, fireEvent} from '@testing-library/react';
 import {ChatReasoning} from './ChatReasoning';
 
@@ -15,9 +16,7 @@ describe('ChatReasoning', () => {
 
   it('shows preview text when collapsed', () => {
     render(
-      <ChatReasoning>
-        Some reasoning text about constraints
-      </ChatReasoning>,
+      <ChatReasoning>Some reasoning text about constraints</ChatReasoning>,
     );
     expect(
       screen.getAllByText('Some reasoning text about constraints').length,

--- a/packages/lab/src/ChatReasoning/ChatReasoning.tsx
+++ b/packages/lab/src/ChatReasoning/ChatReasoning.tsx
@@ -28,7 +28,7 @@ import {
   easeVars,
 } from '@astryxdesign/core/theme/tokens.stylex';
 import {mergeProps} from '@astryxdesign/core/utils';
-import {themeProps} from '../../../core/src/utils/themeProps';
+import {themeProps} from '@astryxdesign/core/utils';
 
 // =============================================================================
 // Types

--- a/packages/lab/src/CircularProgress/CircularProgress.tsx
+++ b/packages/lab/src/CircularProgress/CircularProgress.tsx
@@ -29,7 +29,7 @@ import {
 } from '@astryxdesign/core/theme/tokens.stylex';
 import {mergeProps} from '@astryxdesign/core/utils';
 import type {BaseProps} from '@astryxdesign/core';
-import {themeProps} from '../../../core/src/utils/themeProps';
+import {themeProps} from '@astryxdesign/core/utils';
 
 /**
  * Extensible variant map for CircularProgress.

--- a/packages/lab/src/CodeEditor/CodeEditor.tsx
+++ b/packages/lab/src/CodeEditor/CodeEditor.tsx
@@ -33,7 +33,7 @@ import {
   SYNC_TOKENIZE_THRESHOLD,
 } from '@astryxdesign/core/CodeBlock';
 import type {TokenLine} from '@astryxdesign/core/CodeBlock';
-import {themeProps} from '../../../core/src/utils/themeProps';
+import {themeProps} from '@astryxdesign/core/utils';
 import {
   ensureHighlightStyles,
   applyHighlightRangesFlat,

--- a/packages/lab/src/SVGIcon/SVGIcon.tsx
+++ b/packages/lab/src/SVGIcon/SVGIcon.tsx
@@ -25,7 +25,7 @@ import {colorVars} from '@astryxdesign/core/theme/tokens.stylex';
 import {mergeProps} from '@astryxdesign/core/utils';
 import {iconVars} from './tokens.stylex';
 import {variations, opticalSize} from './variations.stylex';
-import {themeProps} from '../../../core/src/utils/themeProps';
+import {themeProps} from '@astryxdesign/core/utils';
 
 // =============================================================================
 // Types
@@ -80,10 +80,7 @@ export interface SVGIconDef {
   secondary?: IconShape[];
 }
 
-export interface SVGIconProps extends Omit<
-  SVGProps<SVGSVGElement>,
-  'color'
-> {
+export interface SVGIconProps extends Omit<SVGProps<SVGSVGElement>, 'color'> {
   /** The icon definition containing path data */
   icon: SVGIconDef;
   /**

--- a/packages/lab/src/Schedule/Schedule.test.tsx
+++ b/packages/lab/src/Schedule/Schedule.test.tsx
@@ -1,5 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+import {describe, it, expect, vi} from 'vitest';
 import {fireEvent, render, screen, waitFor} from '@testing-library/react';
 import {createEventFromISO} from './CalendarEvent';
 import {Schedule} from './Schedule';

--- a/packages/lab/src/Schedule/Schedule.tsx
+++ b/packages/lab/src/Schedule/Schedule.tsx
@@ -23,7 +23,7 @@ import {ScheduleContext} from './context';
 import {defaultSchedulePlugins} from './plugins';
 import {styles} from './shared';
 import {createZonedDateTime} from './zonedDateTime';
-import {themeProps} from '../../../core/src/utils/themeProps';
+import {themeProps} from '@astryxdesign/core/utils';
 import type {
   CalendarEvent,
   Instant,

--- a/packages/lab/src/Stepper/Step.tsx
+++ b/packages/lab/src/Stepper/Step.tsx
@@ -31,7 +31,7 @@ import {
 import {mergeProps} from '@astryxdesign/core/utils';
 import type {BaseProps} from '@astryxdesign/core';
 import {useStepperContext} from './StepperContext';
-import {themeProps} from '../../../core/src/utils/themeProps';
+import {themeProps} from '@astryxdesign/core/utils';
 import type {StepStatus} from './StepStatus';
 
 /**

--- a/packages/lab/src/Stepper/Stepper.tsx
+++ b/packages/lab/src/Stepper/Stepper.tsx
@@ -21,7 +21,7 @@ import * as stylex from '@stylexjs/stylex';
 
 import {mergeProps} from '@astryxdesign/core/utils';
 import type {BaseProps} from '@astryxdesign/core';
-import {themeProps} from '../../../core/src/utils/themeProps';
+import {themeProps} from '@astryxdesign/core/utils';
 import {
   StepperContext,
   type StepperOrientation,

--- a/packages/lab/src/index.ts
+++ b/packages/lab/src/index.ts
@@ -7,7 +7,9 @@
  * They're available in storybook and sandbox for testing and iteration.
  * Once vetted, components graduate to @astryxdesign/core.
  *
- * This package is never published to npm.
+ * This package is published to npm ONLY under the @canary dist-tag
+ * (npm install @astryxdesign/lab@canary). It is never released as a
+ * stable (latest) version.
  */
 
 // Code components — syntax highlighting domain

--- a/packages/lab/tsconfig.build.json
+++ b/packages/lab/tsconfig.build.json
@@ -1,0 +1,21 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "noEmit": false,
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "sourceMap": false
+  },
+  "include": ["src"],
+  "exclude": [
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.doc.mjs",
+    "src/**/__tests__/**",
+    "src/**/*.perf.test.ts",
+    "src/**/*.perf.test.tsx"
+  ]
+}

--- a/packages/lab/tsconfig.json
+++ b/packages/lab/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"]
+}

--- a/scripts/build-css.mjs
+++ b/scripts/build-css.mjs
@@ -3,17 +3,20 @@
 /**
  * @file build-css.mjs
  * Post-build script that extracts StyleX CSS from compiled source files
- * and outputs a combined astryx.css wrapped in @layer astryx-base.
+ * and outputs a combined stylesheet wrapped in @layer astryx-base.
  *
- * Usage: node scripts/build-css.mjs
+ * Usage:
+ *   node scripts/build-css.mjs                 # core  → packages/core/dist/astryx.css
+ *   node scripts/build-css.mjs --package lab   # lab   → packages/lab/dist/lab.css
  *
  * This script:
- * 1. Runs Babel with the StyleX plugin over all source files
+ * 1. Runs Babel with the StyleX plugin over the target package's source files
  * 2. Collects all StyleX rules
- * 3. Outputs a combined astryx.css with all rules in @layer astryx-base
+ * 3. Outputs a combined stylesheet with all rules in @layer astryx-base
  *
- * Dist consumers import the full stylesheet:
+ * Dist consumers import the full stylesheet, e.g.:
  *   import '@astryxdesign/core/astryx.css';
+ *   import '@astryxdesign/lab/lab.css';
  */
 
 import {transformAsync} from '@babel/core';
@@ -25,12 +28,48 @@ import {glob} from 'glob';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
-const CORE_SRC = path.resolve(ROOT, 'packages/core/src');
-const CORE_DIST = path.resolve(ROOT, 'packages/core/dist');
 
-async function collectStyleXCSS() {
+// Per-package build targets. Each entry defines where source lives, where the
+// stylesheet is written, and any StyleX module-resolution aliases needed for
+// cross-package theme-token imports (lab consumes @astryxdesign/core tokens).
+const TARGETS = {
+  core: {
+    src: path.resolve(ROOT, 'packages/core/src'),
+    dist: path.resolve(ROOT, 'packages/core/dist'),
+    outFile: 'astryx.css',
+    banner: 'Astryx Pre-compiled StyleX CSS — all components',
+    aliases: {},
+  },
+  lab: {
+    src: path.resolve(ROOT, 'packages/lab/src'),
+    dist: path.resolve(ROOT, 'packages/lab/dist'),
+    outFile: 'lab.css',
+    banner: 'Astryx Lab Pre-compiled StyleX CSS — experimental components',
+    // lab imports @astryxdesign/core/theme/tokens.stylex; point the resolver at
+    // core's source so the cross-package token reference resolves.
+    aliases: {
+      '@astryxdesign/core/*': [path.join(ROOT, 'packages/core/src/*')],
+      '@astryxdesign/core': [path.join(ROOT, 'packages/core/src')],
+    },
+  },
+};
+
+function parseTarget() {
+  const idx = process.argv.indexOf('--package');
+  const name = idx !== -1 ? process.argv[idx + 1] : 'core';
+  const target = TARGETS[name];
+  if (!target) {
+    console.error(
+      `Unknown --package "${name}". Valid: ${Object.keys(TARGETS).join(', ')}`,
+    );
+    process.exit(1);
+  }
+  return {name, ...target};
+}
+
+async function collectStyleXCSS(target) {
   const files = await glob('**/*.{ts,tsx}', {
-    cwd: CORE_SRC,
+    cwd: target.src,
     absolute: true,
     ignore: ['**/*.test.*', '**/*.d.ts', '**/node_modules/**'],
   });
@@ -62,6 +101,7 @@ async function collectStyleXCSS() {
               runtimeInjection: false,
               genConditionalClasses: true,
               treeshakeCompensation: true,
+              aliases: target.aliases,
               unstable_moduleResolution: {
                 type: 'commonJS',
                 rootDir: ROOT,
@@ -87,24 +127,25 @@ async function collectStyleXCSS() {
 }
 
 async function main() {
-  const allRules = await collectStyleXCSS();
+  const target = parseTarget();
+  const allRules = await collectStyleXCSS(target);
 
   if (allRules.length === 0) {
     console.error('No StyleX rules found!');
     process.exit(1);
   }
 
-  await fs.mkdir(CORE_DIST, {recursive: true});
+  await fs.mkdir(target.dist, {recursive: true});
 
   const combinedCSS = stylexBabelPlugin.processStylexRules(allRules, false);
 
-  const astryxPath = path.resolve(CORE_DIST, 'astryx.css');
-  const combinedFileContents = `/* Astryx Pre-compiled StyleX CSS — all components */\n/* Auto-generated. Do not edit manually. */\n\n@layer astryx-base {\n${combinedCSS
+  const outPath = path.resolve(target.dist, target.outFile);
+  const combinedFileContents = `/* ${target.banner} */\n/* Auto-generated. Do not edit manually. */\n\n@layer astryx-base {\n${combinedCSS
     .split('\n')
     .map(line => '  ' + line)
     .join('\n')}\n}\n`;
-  await fs.writeFile(astryxPath, combinedFileContents, 'utf8');
-  console.log(`astryx.css: ${(combinedCSS.length / 1024).toFixed(1)} KB`);
+  await fs.writeFile(outPath, combinedFileContents, 'utf8');
+  console.log(`${target.outFile}: ${(combinedCSS.length / 1024).toFixed(1)} KB`);
 }
 
 main().catch(err => {


### PR DESCRIPTION
## Summary

Make `@astryxdesign/lab` installable for early testing **without ever shipping a stable (`latest`) release**. Today lab has no build and is `private`, so the only way to try a lab component is to fork/vendor the source. This change gives lab a real build and publishes it **only under the `@canary` dist-tag**:

```bash
npm install @astryxdesign/lab@canary @astryxdesign/core@canary
```

## "Never a stable release" — three independent guarantees

1. **`private: true` stays in committed source** — npm hard-refuses to publish a private package, and changesets ignores it (no "Version Packages" bump is ever generated for lab).
2. **Stable publish job** additionally skips `astryx.canaryOnly` packages — so even an accidental `private: false` cannot leak lab onto `latest`.
3. **Canary job** is the only place that treats lab as publishable, and it strips `private` *only in the ephemeral CI checkout* — never in git.

A new `astryx.canaryOnly` marker in `package.json` is the explicit opt-in; it's a reusable convention for any future experimental package.

## What's in this change

- **Lab build**: babel ESM compile + `tsc` declarations + StyleX CSS extraction (`lab.css`, 542 rules). `scripts/build-css.mjs` is generalized to take a `--package` target; **core's output is byte-unchanged**.
- **Lab `package.json`**: adds `exports`, `files`, build scripts, and the `astryx.canaryOnly` marker. Keeps `private: true`.
- **`themeProps` through the public API**: 7 lab files reached into core *source* (`../../../core/src/utils/themeProps`) — a path that does not exist in an installed package, which would break any published lab. They now import from `@astryxdesign/core/utils`, and `themeProps` (+ its types) is exported from core's `utils` barrel.
- **Root build**: lab is added after core so CI builds it before publishing.

## ⚠️ One manual follow-up (workflow scope)

The matching change to `.github/workflows/release.yml` is **not in this branch** — the bot token used to push lacks `workflow` scope. The two gate edits (stable job: also skip `canaryOnly`; canary job: include `canaryOnly` and strip `private` in the ephemeral checkout) need to be applied to `release.yml` separately by a maintainer. The exact patch is provided by the PR author. **Until that workflow edit lands, the canary job will not publish lab.**

## Verification

- Full `pnpm build` passes with lab in the pipeline
- Lab tests pass in isolation (7 files, 107 tests)
- `npm pack` produces a complete tarball (`dist/index.js`, `index.d.ts`, `lab.css`, `src`)
- `check:sync`, `check:package-boundaries`, `sync-exports --check`, `verify-exports`, `check:changesets` all green

## Draft notes

Opening as draft for design sign-off on:
- the `astryx.canaryOnly` manifest convention, and
- the canary-only distribution policy for lab.
