### PR TITLE
fix(deploy): include repo name in sandbox base path for GitHub Pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,6 +231,7 @@ jobs:
 
           echo "short_hash=${SHORT_HASH}" >> $GITHUB_OUTPUT
           echo "pr_number=${PR_NUMBER}" >> $GITHUB_OUTPUT
+          echo "sandbox_base_path=/${REPO_NAME}/pr/${PR_NUMBER}/sandbox" >> $GITHUB_OUTPUT
           echo "storybook_url=https://${REPO_OWNER}.github.io/${REPO_NAME}/pr/${PR_NUMBER}/" >> $GITHUB_OUTPUT
           echo "sandbox_url=https://${REPO_OWNER}.github.io/${REPO_NAME}/pr/${PR_NUMBER}/sandbox/" >> $GITHUB_OUTPUT
 
@@ -238,7 +239,10 @@ jobs:
         if: needs.check-scope.outputs.docsite_only != 'true' && github.event_name == 'pull_request'
         run: pnpm -F @astryxdesign/sandbox build
         env:
-          SANDBOX_BASE_PATH: /pr/${{ steps.urls.outputs.pr_number }}/sandbox
+          # Must match the deployed Pages path (<owner>.github.io/<repo>/pr/<n>/sandbox).
+          # Built without the /<repo> prefix, the sandbox's root-absolute asset URLs
+          # drop that segment and 404 — breaking all styles/JS on the preview.
+          SANDBOX_BASE_PATH: ${{ steps.urls.outputs.sandbox_base_path }}
           NODE_OPTIONS: '--max-old-space-size=8192'
 
       - name: Upload Storybook artifact

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -118,7 +118,11 @@ jobs:
       - name: Build Sandbox
         run: pnpm -F @astryxdesign/sandbox build
         env:
-          SANDBOX_BASE_PATH: /sandbox
+          # GitHub Pages serves this project at <owner>.github.io/<repo>/, so the
+          # sandbox must be built with the repo name as a base path prefix —
+          # otherwise its root-absolute asset URLs (/sandbox/_next/...) drop the
+          # /<repo> segment and 404. Derived from the repo name so it survives renames.
+          SANDBOX_BASE_PATH: /${{ github.event.repository.name }}/sandbox
           NODE_OPTIONS: '--max-old-space-size=4096'
 
       - name: Preserve PR previews and reports from gh-pages
@@ -153,7 +157,7 @@ jobs:
           mkdir -p deploy/storybook
           cp -r apps/storybook/dist/* deploy/storybook/
 
-          # Stable sandbox (built with basePath=/sandbox)
+          # Stable sandbox (built with basePath=/<repo>/sandbox)
           if [ -d "apps/sandbox/out" ]; then
             mkdir -p deploy/sandbox
             cp -r apps/sandbox/out/* deploy/sandbox/

--- a/.github/workflows/redeploy-preview.yml
+++ b/.github/workflows/redeploy-preview.yml
@@ -67,7 +67,10 @@ jobs:
 
       - name: Build Sandbox
         env:
-          SANDBOX_BASE_PATH: /pr/${{ github.event.inputs.pr_number }}/sandbox
+          # GitHub Pages serves at <owner>.github.io/<repo>/, so the sandbox base
+          # path must include the repo name — otherwise root-absolute asset URLs
+          # drop the /<repo> segment and 404, breaking the preview's styles/JS.
+          SANDBOX_BASE_PATH: /${{ github.event.repository.name }}/pr/${{ github.event.inputs.pr_number }}/sandbox
         run: pnpm -F @astryxdesign/sandbox build
 
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
## What

The GitHub Pages sandbox (both the stable `/sandbox/` and PR previews) renders **completely unstyled** with no client-side hydration — all CSS and JS 404.

## Root cause

GitHub Pages serves this project at `<owner>.github.io/<repo>/`, but the sandbox is built with:

- `SANDBOX_BASE_PATH=/sandbox` (deploy)
- `SANDBOX_BASE_PATH=/pr/<n>/sandbox` (PR previews)

These omit the `/<repo>` segment. The sandbox emits **root-absolute** asset URLs like `/sandbox/_next/static/...`. In the browser those resolve against the origin and drop the `/<repo>` prefix, so the request becomes `<owner>.github.io/sandbox/_next/...` → **404**. Result: no styles, no hydration.

Mirroring the deployed site at its real host layout and watching the access log confirms it: serving at `/<repo>/.../sandbox/`, **70 of 71 asset requests 404** (only the HTML loads). Storybook is unaffected because it uses **relative** asset paths (`./sb-manager/...`).

This surfaced after the repo rename — Pages now lives under `/astryx/`, while the base paths were never updated to include the project segment.

## Fix

Prefix `SANDBOX_BASE_PATH` with the repo name in all three workflows that build the sandbox:

| Workflow | Before | After |
| --- | --- | --- |
| `deploy.yml` | `/sandbox` | `/${repo}/sandbox` |
| `ci.yml` | `/pr/<n>/sandbox` | `/${repo}/pr/<n>/sandbox` |
| `redeploy-preview.yml` | `/pr/<n>/sandbox` | `/${repo}/pr/<n>/sandbox` |

Derived from `github.event.repository.name` (already used in `ci.yml` for the preview URLs), so it stays correct through future renames.

## Verification

Built the sandbox locally with `SANDBOX_BASE_PATH=/astryx/pr/9999/sandbox`:

- **36 / 36** root-absolute `_next` asset references now carry the `/astryx/pr/9999/sandbox` prefix; **zero** unprefixed.
- Served the build at the real host layout (`/astryx/pr/9999/sandbox/`): **176 assets load 200**, only favicon 404s.
- Page renders fully styled (sidebar, cards, typography, themes) with working hydration.
