### PR TITLE
fix(core): clamp Calendar numberOfMonths to 1|2 at runtime

### DIFF
--- a/.changeset/calendar-number-of-months-clamp.md
+++ b/.changeset/calendar-number-of-months-clamp.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Calendar / DateInput / DateTimeInput: defensively clamp `numberOfMonths` to its `1 | 2` type at runtime. Out-of-range values (e.g. `0` rendered nothing, `1000` locked the page up in `Array.from({length})`) fall back to a single month. DateInput and DateTimeInput inherit the guard since they forward the prop to `<Calendar>` (#2704)
+@durvesh1992

--- a/packages/core/src/Calendar/Calendar.test.tsx
+++ b/packages/core/src/Calendar/Calendar.test.tsx
@@ -215,6 +215,33 @@ describe('Calendar', () => {
     expect(screen.getByText(/February 2026.*March 2026/)).toBeInTheDocument();
   });
 
+  it('clamps out-of-range numberOfMonths to a single month', () => {
+    // 1000 would otherwise try to render 1000 month grids and lock the page up.
+    render(
+      <Calendar
+        numberOfMonths={1000 as unknown as 1 | 2}
+        focusDate="2026-01-01"
+      />,
+    );
+
+    // Only the focused month renders — no second month, no range separator.
+    expect(screen.getByText('January 2026')).toBeInTheDocument();
+    expect(screen.queryByText(/February 2026/)).not.toBeInTheDocument();
+  });
+
+  it('clamps numberOfMonths={0} to a single month', () => {
+    render(
+      <Calendar
+        numberOfMonths={0 as unknown as 1 | 2}
+        focusDate="2026-01-01"
+      />,
+    );
+
+    // 0 previously rendered no months at all; now falls back to one.
+    expect(screen.getByText('January 2026')).toBeInTheDocument();
+    expect(screen.getAllByRole('gridcell').length).toBeGreaterThan(0);
+  });
+
   // ─── Display Options ─────────────────────────────────────────
 
   it('shows week numbers when hasWeekNumbers is true', () => {

--- a/packages/core/src/Calendar/Calendar.tsx
+++ b/packages/core/src/Calendar/Calendar.tsx
@@ -203,7 +203,7 @@ export function Calendar({ref, ...props}: CalendarProps) {
     value,
     defaultValue,
     onChange,
-    numberOfMonths = 1,
+    numberOfMonths: numberOfMonthsProp = 1,
     min,
     max,
     dateConstraints,
@@ -222,6 +222,11 @@ export function Calendar({ref, ...props}: CalendarProps) {
   // Normalize `weekStartsOn` (number or three-letter day name) to a numeric
   // DayOfWeek so all downstream date math keeps working with an index.
   const weekStartsOn = normalizeDayOfWeek(weekStartsOnProp);
+
+  // `numberOfMonths` is typed `1 | 2`; defensively clamp anything else that
+  // slips through at runtime to 1 so `Array.from({length})` can't render an
+  // absurd number of month grids (e.g. `numberOfMonths={1000}`).
+  const numberOfMonths = numberOfMonthsProp === 2 ? 2 : 1;
 
   // Today's date (memoized)
   const today = useMemo(() => plainDateToday(), []);


### PR DESCRIPTION
## Summary

`numberOfMonths` on `Calendar` (and the `DateInput` / `DateTimeInput` that forward to it) is typed `1 | 2`, but nothing enforced that at runtime. A free-form caller — or the docsite Properties control — could pass `0` (renders no months) or `1000` (locks the page up trying to render 1000 month grids in `Array.from({length: numberOfMonths})`).

This clamps the value to the supported union in `Calendar`: anything that isn't exactly `2` falls back to `1`, with a dev-only `console.warn` when an out-of-range value is passed. `DateInput` and `DateTimeInput` inherit the guard for free since they forward the prop straight to `<Calendar>`.

Note: the docsite should also render a 1/2 toggle instead of a free-form number input for small-literal-union props (item 3 in the issue) — that's a separate docsite-side change and not included here.

## Test plan
- Added unit tests: `numberOfMonths={1000}` and `={0}` both render exactly one month and emit the dev warning.
- Existing multi-month tests (`={2}`) still pass — 32/32 Calendar tests green.

Closes #2704