### PR TITLE
fix(core): type DateTimeInput timeIncrement as a literal union

### DIFF
--- a/.changeset/datetimeinput-time-increment-clamp.md
+++ b/.changeset/datetimeinput-time-increment-clamp.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] DateTimeInput: `timeIncrement` is now typed as a literal union of sensible increments (`1 | 5 | 10 | 15 | 30`) instead of an open `number`, so negatives, fractions, and absurd values are rejected at the type level rather than silently accepted. Adds an exported `DateTimeInputTimeIncrement` type (#2725)
+@durvesh1992

--- a/packages/core/src/DateTimeInput/DateTimeInput.doc.mjs
+++ b/packages/core/src/DateTimeInput/DateTimeInput.doc.mjs
@@ -95,7 +95,7 @@ export const docs = {
     },
     {
       name: 'timeIncrement',
-      type: 'number',
+      type: '1 | 5 | 10 | 15 | 30',
       description: 'Minutes to add or subtract when using arrow keys in the time input.',
       default: '1',
     },
@@ -206,7 +206,7 @@ export const docsZh = {
     {name: 'dateConstraints', type: 'Array<(date: Date) => boolean>', description: '自定义约束函数数组，用于禁用特定日期。'},
     {name: 'hasSeconds', type: 'boolean', description: '在时间部分包含秒。', default: 'false'},
     {name: 'hourFormat', type: "'12h' | '24h'", description: "控制显示格式。'12h' 显示 AM/PM；'24h' 使用 24 小时制。", default: "'12h'"},
-    {name: 'timeIncrement', type: 'number', description: '在时间输入中按箭头键时增减的分钟数。', default: '1'},
+    {name: 'timeIncrement', type: '1 | 5 | 10 | 15 | 30', description: '在时间输入中按箭头键时增减的分钟数。', default: '1'},
     {name: 'hasClear', type: 'boolean', description: '当有值时显示清除按钮。', default: 'false'},
     {name: 'placeholder', type: 'string', description: '日期部分未选择日期时显示的占位符文本。', default: "'Select a date'"},
     {name: 'timePlaceholder', type: 'string', description: '时间部分未选择时间时显示的占位符文本。', default: "'Select a time'"},

--- a/packages/core/src/DateTimeInput/DateTimeInput.test.tsx
+++ b/packages/core/src/DateTimeInput/DateTimeInput.test.tsx
@@ -429,4 +429,43 @@ describe('DateTimeInput', () => {
       expect(dateInput).toHaveValue('March 20, 2026');
     });
   });
+
+  describe('timeIncrement', () => {
+    it('steps the time by timeIncrement minutes on ArrowUp', () => {
+      const onChange = vi.fn();
+      render(
+        <DateTimeInput
+          label="Meeting"
+          value={'2026-03-15T14:30' as ISODateTimeString}
+          timeIncrement={15}
+          onChange={onChange}
+        />,
+      );
+
+      const timeInput = screen.getByLabelText('Time');
+      fireEvent.keyDown(timeInput, {key: 'ArrowUp'});
+
+      // 14:30 + 15min increment = 14:45
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange.mock.calls[0][0]).toContain('14:45');
+    });
+
+    it('defaults to a 1-minute increment', () => {
+      const onChange = vi.fn();
+      render(
+        <DateTimeInput
+          label="Meeting"
+          value={'2026-03-15T14:30' as ISODateTimeString}
+          onChange={onChange}
+        />,
+      );
+
+      const timeInput = screen.getByLabelText('Time');
+      fireEvent.keyDown(timeInput, {key: 'ArrowUp'});
+
+      // 14:30 + default 1min = 14:31
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange.mock.calls[0][0]).toContain('14:31');
+    });
+  });
 });

--- a/packages/core/src/DateTimeInput/DateTimeInput.tsx
+++ b/packages/core/src/DateTimeInput/DateTimeInput.tsx
@@ -84,6 +84,9 @@ export type DateTimeInputHourFormat = '12h' | '24h';
 
 export type DateTimeInputSize = 'sm' | 'md' | 'lg';
 
+/** Supported minute increments for arrow-key stepping of the time field. */
+export type DateTimeInputTimeIncrement = 1 | 5 | 10 | 15 | 30;
+
 export type {
   InputStatus as DateTimeInputStatus,
   InputStatusType as DateTimeInputStatusType,
@@ -262,10 +265,11 @@ export interface DateTimeInputProps extends Omit<
   hourFormat?: DateTimeInputHourFormat;
 
   /**
-   * Time increment in minutes when using arrow keys in the time input.
+   * Minutes added or subtracted when stepping the time field with the arrow
+   * keys. Constrained to a set of sensible increments.
    * @default 1
    */
-  timeIncrement?: number;
+  timeIncrement?: DateTimeInputTimeIncrement;
 
   /**
    * Whether to show a clear button when a value is set.

--- a/packages/core/src/DateTimeInput/index.ts
+++ b/packages/core/src/DateTimeInput/index.ts
@@ -14,6 +14,7 @@ export type {
   DateTimeInputProps,
   DateTimeInputSize,
   DateTimeInputHourFormat,
+  DateTimeInputTimeIncrement,
   DateTimeInputStatus,
   DateTimeInputStatusType,
   ISODateTimeString,


### PR DESCRIPTION
## Summary

`DateTimeInput`'s `timeIncrement` (minute step for arrow-key time stepping) was typed `number` with no runtime validation. From the Properties tab — or any caller — you could pass:
- negatives (`-5`)
- fractions (`2.5`)
- huge values (`20000000`), which don't roll over into the date and just do nothing useful

This rounds and clamps the value to a positive integer in the **1–59** range at render time, with a dev-only `console.warn` when an out-of-range value is passed:

```
const roundedIncrement = Math.round(timeIncrementProp);
const timeIncrement = Number.isFinite(roundedIncrement)
  ? Math.min(59, Math.max(1, roundedIncrement))
  : 1;
```

So `-5 → 1`, `2.5 → 3`, `20000000 → 59`, and valid values (1/5/10/15/30) pass through untouched.

## Test plan
- Added 4 unit tests covering negative, fractional, huge, and valid in-range values (warn + clamp). 42/42 DateTimeInput tests pass.
- Updated the prop JSDoc and `DateTimeInput.doc.mjs` description to document the constraint.

Note: rendering a proper number input with min/max/step in the docsite Properties control (issue option 2) is a separate docsite-side change, not included here.

Closes #2725