### PR TITLE
docs(Dialog): remove duplicate (required) markers in prop descriptions

### DIFF
--- a/packages/core/src/Dialog/Dialog.doc.mjs
+++ b/packages/core/src/Dialog/Dialog.doc.mjs
@@ -40,13 +40,13 @@ export const docs = {
     {
       name: 'isOpen',
       type: 'boolean',
-      description: 'Whether the dialog is open (required).',
+      description: 'Whether the dialog is open.',
       required: true,
     },
     {
       name: 'onOpenChange',
       type: '(isOpen: boolean) => unknown',
-      description: 'Callback when dialog visibility changes (required).',
+      description: 'Callback when dialog visibility changes.',
       required: true,
     },
     {


### PR DESCRIPTION
## What

`Dialog`'s `isOpen` and `onOpenChange` prop descriptions ended with a literal `(required)` while also setting `required: true`. The CLI renderer auto-appends a `**(required)**` marker from `required: true`, so both the default and `--lang dense` output rendered the marker twice:

Before:
```
| `isOpen` | `boolean` | — | Whether the dialog is open (required). **(required)** |
```

After:
```
| `isOpen` | `boolean` | — | Whether the dialog is open. **(required)** |
```

This drops the redundant literal text and keeps `required: true` as the single source of the marker. The `children` prop was already correct. No other component had this pattern (verified with a repo-wide scan).

## Checklist
- [x] `pnpm --filter @astryxdesign/core typecheck:docs` passes
- [x] `npx tsc --project packages/cli/tsconfig.template-docs.json --noEmit` passes
- [x] CLI `component Dialog` output verified (single `(required)` marker)
- [x] CLI `component Dialog --lang dense` output verified (single `(required)` marker)
- [x] `api-cli-parity-test.mjs --no-baseline`: 307 pass, 0 fail

Night Watch — Doc Reviewer
