### PR TITLE
feat(core): add plugin-contributed context menus to Table

### DIFF
--- a/.changeset/table-context-menu.md
+++ b/.changeset/table-context-menu.md
@@ -3,19 +3,23 @@
 ---
 
 [feat] Add a plugin-contributed right-click context-menu system to `Table`.
-Right-clicking a column header shows a menu of actions aggregated from every
-enabled plugin (instead of the browser's generic menu).
+Right-clicking a column header or a row shows a menu of actions aggregated from
+every enabled plugin (instead of the browser's generic menu).
 
 - New `TableContextAction` type and an optional `contextMenuActions` field on
   `HeaderCellRenderProps` / `BodyCellRenderProps`. Plugins append their actions
   inside the existing `transformHeaderCell` / `transformBodyCell` transforms;
-  the table concatenates them across plugins (never overridden) and renders one
-  menu per header cell, built on the `ContextMenu` component. Actions group with
-  dividers and show a checkmark for the active item; when none are contributed,
-  the native browser menu passes through.
+  the table concatenates them across plugins (never overridden), the same way
+  `styles` are merged.
+- The cell components (`TableHeaderCell` / `TableCell`) own the menu wrapper and
+  render it around their own content via the `ContextMenuActions` prop, so the
+  cell controls how the wrapper interacts with padding / content sizing — and
+  row menus work without invalid `<tr>` nesting. Actions group with dividers and
+  show a checkmark for the active item; when none are contributed, the native
+  browser menu passes through.
 - First contributor: `useTableSortable` adds "Sort ascending / Sort descending
   / Clear sort" on sortable headers.
 
-(Header menus only for now; row-menu rendering is a follow-up pending
-`asChild`/Slot support for valid `<tr>` nesting.)
+Built on the `ContextMenu` component. Other plugins opt in by setting
+`contextMenuActions` in their cell transforms — no core changes needed.
 @humbertovirtudes

--- a/.changeset/table-context-menu.md
+++ b/.changeset/table-context-menu.md
@@ -17,6 +17,11 @@ every enabled plugin (instead of the browser's generic menu).
   row menus work without invalid `<tr>` nesting. Actions group with dividers and
   show a checkmark for the active item; when none are contributed, the native
   browser menu passes through.
+- `contextMenuActions` accepts either an array or a getter
+  (`() => TableContextAction[]`); the getter is resolved lazily when the menu
+  opens, so plugins with state-derived actions don't build arrays on every
+  render. `useTableSortable` uses a getter so its checked/clear state always
+  reflects the latest sort.
 - First contributor: `useTableSortable` adds "Sort ascending / Sort descending
   / Clear sort" on sortable headers.
 

--- a/.changeset/table-context-menu.md
+++ b/.changeset/table-context-menu.md
@@ -6,17 +6,16 @@
 Right-clicking a column header shows a menu of actions aggregated from every
 enabled plugin (instead of the browser's generic menu).
 
-- New `TableContextAction` type and two optional, backward-compatible
-  `TablePlugin` methods: `getHeaderContextActions(column, columnIndex)` and
-  `getRowContextActions(item, rowIndex)`.
-- Plugins *contribute* actions; the table aggregates them into one menu per
-  header cell (built on the `ContextMenu` component). Actions group with
-  dividers and show a checkmark for the active item. When no plugin contributes
-  actions, the native browser menu passes through.
+- New `TableContextAction` type and an optional `contextMenuActions` field on
+  `HeaderCellRenderProps` / `BodyCellRenderProps`. Plugins append their actions
+  inside the existing `transformHeaderCell` / `transformBodyCell` transforms;
+  the table concatenates them across plugins (never overridden) and renders one
+  menu per header cell, built on the `ContextMenu` component. Actions group with
+  dividers and show a checkmark for the active item; when none are contributed,
+  the native browser menu passes through.
 - First contributor: `useTableSortable` adds "Sort ascending / Sort descending
   / Clear sort" on sortable headers.
 
-Other plugins can opt in by implementing the same two methods — no core changes
-needed. (Header menus only for now; row-menu rendering is a follow-up pending
+(Header menus only for now; row-menu rendering is a follow-up pending
 `asChild`/Slot support for valid `<tr>` nesting.)
 @humbertovirtudes

--- a/.changeset/table-context-menu.md
+++ b/.changeset/table-context-menu.md
@@ -1,0 +1,22 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] Add a plugin-contributed right-click context-menu system to `Table`.
+Right-clicking a column header shows a menu of actions aggregated from every
+enabled plugin (instead of the browser's generic menu).
+
+- New `TableContextAction` type and two optional, backward-compatible
+  `TablePlugin` methods: `getHeaderContextActions(column, columnIndex)` and
+  `getRowContextActions(item, rowIndex)`.
+- Plugins *contribute* actions; the table aggregates them into one menu per
+  header cell (built on the `ContextMenu` component). Actions group with
+  dividers and show a checkmark for the active item. When no plugin contributes
+  actions, the native browser menu passes through.
+- First contributor: `useTableSortable` adds "Sort ascending / Sort descending
+  / Clear sort" on sortable headers.
+
+Other plugins can opt in by implementing the same two methods — no core changes
+needed. (Header menus only for now; row-menu rendering is a follow-up pending
+`asChild`/Slot support for valid `<tr>` nesting.)
+@humbertovirtudes

--- a/packages/core/src/Table/BaseTable.tsx
+++ b/packages/core/src/Table/BaseTable.tsx
@@ -45,7 +45,6 @@ import {mergeProps} from '../utils';
 import {EmptyState} from '../EmptyState';
 import {Text} from '../Text';
 import {themeProps} from '../utils/themeProps';
-import {wrapInTableContextMenu} from './tableContextMenu';
 
 const styles = stylex.create({
   table: {
@@ -206,6 +205,7 @@ function TableRowInner<T extends Record<string, unknown>>({
       <CellComponent
         key={col.key}
         {...cellRenderProps.htmlProps}
+        contextMenuActions={cellRenderProps.contextMenuActions}
         xstyle={cellRenderProps.styles}>
         {content}
       </CellComponent>
@@ -428,21 +428,14 @@ function BaseTableInner<T extends Record<string, unknown>>({
       resolvedContent
     );
 
-    // Right-click context menu: plugins append actions to
-    // `contextMenuActions` in transformHeaderCell; wrap the content in a menu.
-    // No-op (native menu) when none.
-    const headerCellContent = wrapInTableContextMenu(
-      headerInner,
-      cellRenderProps.contextMenuActions ?? [],
-    );
-
     return (
       <HeaderCellComponent
         key={col.key}
         {...mergedHtmlProps}
         {...headerTitleProp}
+        contextMenuActions={cellRenderProps.contextMenuActions}
         xstyle={cellRenderProps.styles}>
-        {headerCellContent}
+        {headerInner}
       </HeaderCellComponent>
     );
   });

--- a/packages/core/src/Table/BaseTable.tsx
+++ b/packages/core/src/Table/BaseTable.tsx
@@ -45,10 +45,7 @@ import {mergeProps} from '../utils';
 import {EmptyState} from '../EmptyState';
 import {Text} from '../Text';
 import {themeProps} from '../utils/themeProps';
-import {
-  collectHeaderContextActions,
-  wrapInTableContextMenu,
-} from './tableContextMenu';
+import {wrapInTableContextMenu} from './tableContextMenu';
 
 const styles = stylex.create({
   table: {
@@ -431,11 +428,12 @@ function BaseTableInner<T extends Record<string, unknown>>({
       resolvedContent
     );
 
-    // Right-click context menu: aggregate actions contributed by every plugin
-    // for this header and wrap the content. No-op (native menu) when none.
+    // Right-click context menu: plugins append actions to
+    // `contextMenuActions` in transformHeaderCell; wrap the content in a menu.
+    // No-op (native menu) when none.
     const headerCellContent = wrapInTableContextMenu(
       headerInner,
-      collectHeaderContextActions(plugins, col, columnIndex),
+      cellRenderProps.contextMenuActions ?? [],
     );
 
     return (

--- a/packages/core/src/Table/BaseTable.tsx
+++ b/packages/core/src/Table/BaseTable.tsx
@@ -45,6 +45,10 @@ import {mergeProps} from '../utils';
 import {EmptyState} from '../EmptyState';
 import {Text} from '../Text';
 import {themeProps} from '../utils/themeProps';
+import {
+  collectHeaderContextActions,
+  wrapInTableContextMenu,
+} from './tableContextMenu';
 
 const styles = stylex.create({
   table: {
@@ -409,29 +413,38 @@ function BaseTableInner<T extends Record<string, unknown>>({
     const hasSlots =
       before != null || after != null || overlay != null || below != null;
 
+    const headerInner = hasSlots ? (
+      <>
+        {before}
+        {after != null ? (
+          <div {...stylex.props(styles.headerLabelRow)}>
+            {resolvedContent}
+            {after}
+          </div>
+        ) : (
+          resolvedContent
+        )}
+        {overlay}
+        {below}
+      </>
+    ) : (
+      resolvedContent
+    );
+
+    // Right-click context menu: aggregate actions contributed by every plugin
+    // for this header and wrap the content. No-op (native menu) when none.
+    const headerCellContent = wrapInTableContextMenu(
+      headerInner,
+      collectHeaderContextActions(plugins, col, columnIndex),
+    );
+
     return (
       <HeaderCellComponent
         key={col.key}
         {...mergedHtmlProps}
         {...headerTitleProp}
         xstyle={cellRenderProps.styles}>
-        {hasSlots ? (
-          <>
-            {before}
-            {after != null ? (
-              <div {...stylex.props(styles.headerLabelRow)}>
-                {resolvedContent}
-                {after}
-              </div>
-            ) : (
-              resolvedContent
-            )}
-            {overlay}
-            {below}
-          </>
-        ) : (
-          resolvedContent
-        )}
+        {headerCellContent}
       </HeaderCellComponent>
     );
   });

--- a/packages/core/src/Table/TableCell.tsx
+++ b/packages/core/src/Table/TableCell.tsx
@@ -24,7 +24,7 @@ import {
   typeScaleVars,
 } from '../theme/tokens.stylex';
 import type {StyleXStyles} from '../theme/types';
-import type {TableContextAction} from './types';
+import type {TableContextActions} from './types';
 import {wrapInTableContextMenu} from './tableContextMenu';
 import {
   overflowStyles,
@@ -63,7 +63,7 @@ export interface TableCellProps extends BaseProps<HTMLTableCellElement> {
    * The cell owns the wrapper so it controls how the menu interacts with its
    * padding / content. Empty or undefined renders no menu.
    */
-  contextMenuActions?: TableContextAction[];
+  contextMenuActions?: TableContextActions;
 }
 
 const densityStyles = stylex.create({
@@ -166,7 +166,7 @@ export function TableCell({
 
   // The cell owns the context-menu wrapper so it controls how the menu
   // interacts with its padding / content. No-op when no actions.
-  const content = wrapInTableContextMenu(children, contextMenuActions ?? []);
+  const content = wrapInTableContextMenu(children, contextMenuActions);
 
   return (
     <td

--- a/packages/core/src/Table/TableCell.tsx
+++ b/packages/core/src/Table/TableCell.tsx
@@ -24,6 +24,8 @@ import {
   typeScaleVars,
 } from '../theme/tokens.stylex';
 import type {StyleXStyles} from '../theme/types';
+import type {TableContextAction} from './types';
+import {wrapInTableContextMenu} from './tableContextMenu';
 import {
   overflowStyles,
   wrapStyles,
@@ -56,6 +58,12 @@ export interface TableCellProps extends BaseProps<HTMLTableCellElement> {
    * Must be a `stylex.create()` value — not an inline style object.
    */
   xstyle?: StyleXStyles | StyleXStyles[];
+  /**
+   * Right-click actions rendered as a context menu around the cell content.
+   * The cell owns the wrapper so it controls how the menu interacts with its
+   * padding / content. Empty or undefined renders no menu.
+   */
+  contextMenuActions?: TableContextAction[];
 }
 
 const densityStyles = stylex.create({
@@ -138,33 +146,27 @@ export function TableCell({
   ref,
   className: incomingClassName,
   style: incomingStyle,
+  contextMenuActions,
   ...props
 }: TableCellProps) {
   const ctx = useTableContext();
 
-  if (!ctx) {
-    return (
-      <td
-        ref={ref}
-        {...props}
-        {...mergeProps(
-          themeProps('table-cell'),
-          stylex.props(xstyle),
-          incomingClassName,
-          incomingStyle,
-        )}>
-        {children}
-      </td>
-    );
-  }
+  // Standalone (no table context) renders plain, with no density/divider styles.
+  const cellStyles: StyleXStyles[] = ctx
+    ? [
+        densityStyles[ctx.density],
+        ctx.textOverflow === 'truncate'
+          ? overflowStyles.cell
+          : wrapStyles.cell,
+        containerEdgeStyles[ctx.density],
+        verticalAlignStyles[ctx.verticalAlign],
+        ...buildDividerStyles(ctx, dividerRowStyles.cell, dividerColumnStyles.cell),
+      ]
+    : [];
 
-  const cellStyles: StyleXStyles[] = [
-    densityStyles[ctx.density],
-    ctx.textOverflow === 'truncate' ? overflowStyles.cell : wrapStyles.cell,
-    containerEdgeStyles[ctx.density],
-    verticalAlignStyles[ctx.verticalAlign],
-    ...buildDividerStyles(ctx, dividerRowStyles.cell, dividerColumnStyles.cell),
-  ];
+  // The cell owns the context-menu wrapper so it controls how the menu
+  // interacts with its padding / content. No-op when no actions.
+  const content = wrapInTableContextMenu(children, contextMenuActions ?? []);
 
   return (
     <td
@@ -176,7 +178,7 @@ export function TableCell({
         incomingClassName,
         incomingStyle,
       )}>
-      {children}
+      {content}
     </td>
   );
 }

--- a/packages/core/src/Table/TableHeaderCell.tsx
+++ b/packages/core/src/Table/TableHeaderCell.tsx
@@ -25,8 +25,10 @@ import {
   borderVars,
 } from '../theme/tokens.stylex';
 import type {StyleXStyles} from '../theme/types';
+import type {TableContextAction} from './types';
 import {overflowStyles, containerEdgeStyles} from './table.stylex';
 import {useTableContext, mergeXStyle} from './useTableCellStyles';
+import {wrapInTableContextMenu} from './tableContextMenu';
 import {mergeProps} from '../utils';
 import {themeProps} from '../utils/themeProps';
 
@@ -42,6 +44,12 @@ export interface TableHeaderCellProps extends BaseProps<HTMLTableCellElement> {
    * Must be a `stylex.create()` value — not an inline style object.
    */
   xstyle?: StyleXStyles | StyleXStyles[];
+  /**
+   * Right-click actions rendered as a context menu around the cell content.
+   * The cell owns the wrapper so it controls how the menu interacts with its
+   * padding / content. Empty or undefined renders no menu.
+   */
+  contextMenuActions?: TableContextAction[];
 }
 
 const densityStyles = stylex.create({
@@ -117,41 +125,32 @@ export function TableHeaderCell({
   ref,
   className: incomingClassName,
   style: incomingStyle,
+  contextMenuActions,
   ...props
 }: TableHeaderCellProps) {
   const ctx = useTableContext();
 
-  if (!ctx) {
-    return (
-      <th
-        ref={ref}
-        {...props}
-        {...mergeProps(
-          themeProps('table-header-cell'),
-          stylex.props(xstyle),
-          incomingClassName,
-          incomingStyle,
-        )}>
-        {children}
-      </th>
-    );
-  }
-
   // Header cells always get the bottom divider (separates header from body).
-  // Column dividers use the shared buildDividerStyles — but only for
-  // the column axis, since the row divider is the headerDividerStyles.
-  const cellStyles: StyleXStyles[] = [
-    headerStyles.cell,
-    densityStyles[ctx.density],
-    headerDividerStyles.cell,
-    overflowStyles.cell,
-    containerEdgeStyles[ctx.density],
-  ];
-
-  // Only add column dividers from the shared builder
-  if (ctx.dividers === 'columns' || ctx.dividers === 'grid') {
-    cellStyles.push(dividerColumnStyles.cell);
+  // When used standalone (no table context) the cell renders plain, with no
+  // density/divider styles.
+  const cellStyles: StyleXStyles[] = [];
+  if (ctx) {
+    cellStyles.push(
+      headerStyles.cell,
+      densityStyles[ctx.density],
+      headerDividerStyles.cell,
+      overflowStyles.cell,
+      containerEdgeStyles[ctx.density],
+    );
+    // Column dividers come from the shared builder (column axis only).
+    if (ctx.dividers === 'columns' || ctx.dividers === 'grid') {
+      cellStyles.push(dividerColumnStyles.cell);
+    }
   }
+
+  // The cell owns the context-menu wrapper so it controls how the menu
+  // interacts with its padding / content. No-op when no actions.
+  const content = wrapInTableContextMenu(children, contextMenuActions ?? []);
 
   return (
     <th
@@ -163,7 +162,7 @@ export function TableHeaderCell({
         incomingClassName,
         incomingStyle,
       )}>
-      {children}
+      {content}
     </th>
   );
 }

--- a/packages/core/src/Table/TableHeaderCell.tsx
+++ b/packages/core/src/Table/TableHeaderCell.tsx
@@ -25,7 +25,7 @@ import {
   borderVars,
 } from '../theme/tokens.stylex';
 import type {StyleXStyles} from '../theme/types';
-import type {TableContextAction} from './types';
+import type {TableContextActions} from './types';
 import {overflowStyles, containerEdgeStyles} from './table.stylex';
 import {useTableContext, mergeXStyle} from './useTableCellStyles';
 import {wrapInTableContextMenu} from './tableContextMenu';
@@ -49,7 +49,7 @@ export interface TableHeaderCellProps extends BaseProps<HTMLTableCellElement> {
    * The cell owns the wrapper so it controls how the menu interacts with its
    * padding / content. Empty or undefined renders no menu.
    */
-  contextMenuActions?: TableContextAction[];
+  contextMenuActions?: TableContextActions;
 }
 
 const densityStyles = stylex.create({
@@ -150,7 +150,7 @@ export function TableHeaderCell({
 
   // The cell owns the context-menu wrapper so it controls how the menu
   // interacts with its padding / content. No-op when no actions.
-  const content = wrapInTableContextMenu(children, contextMenuActions ?? []);
+  const content = wrapInTableContextMenu(children, contextMenuActions);
 
   return (
     <th

--- a/packages/core/src/Table/index.ts
+++ b/packages/core/src/Table/index.ts
@@ -50,6 +50,7 @@ export type {
   PixelWidth,
   TablePlugin,
   TableContextAction,
+  TableContextActions,
   TableRenderProps,
   HeaderRowRenderProps,
   HeaderCellRenderProps,

--- a/packages/core/src/Table/index.ts
+++ b/packages/core/src/Table/index.ts
@@ -49,6 +49,7 @@ export type {
   ProportionalWidth,
   PixelWidth,
   TablePlugin,
+  TableContextAction,
   TableRenderProps,
   HeaderRowRenderProps,
   HeaderCellRenderProps,

--- a/packages/core/src/Table/index.ts
+++ b/packages/core/src/Table/index.ts
@@ -28,6 +28,7 @@ export {useTableColumnSettings} from './plugins/columnSettings';
 export {useTableColumnSettingsState} from './plugins/columnSettings';
 export {useTableColumnResize} from './plugins/columnResize';
 export {useTableStickyColumns} from './plugins/stickyColumns';
+export {resolveContextActions} from './tableContextMenu';
 export {
   useTableFiltering,
   useTableFilterState,

--- a/packages/core/src/Table/plugins/sortable/useTableSortable.test.tsx
+++ b/packages/core/src/Table/plugins/sortable/useTableSortable.test.tsx
@@ -7,8 +7,8 @@
  * @position Testing; validates sortable plugin implementation
  */
 
-import {describe, it, expect, vi} from 'vitest';
-import {render, screen} from '@testing-library/react';
+import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {render, screen, fireEvent} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {useState} from 'react';
 import {Table} from '../../Table';
@@ -618,5 +618,94 @@ describe('useTableSortable', () => {
         'sorted descending',
       );
     });
+  });
+});
+
+// =============================================================================
+// Context-menu actions (colocated with the sortable plugin)
+// =============================================================================
+
+describe('useTableSortable — context menu actions', () => {
+  // jsdom doesn't implement the Popover API; mock it so the menu can "open"
+  // and its items become queryable (as hidden).
+  beforeEach(() => {
+    HTMLElement.prototype.showPopover = vi.fn(function (this: HTMLElement) {
+      this.setAttribute('popover-open', '');
+      const event = new Event('toggle', {bubbles: false});
+      Object.defineProperty(event, 'newState', {value: 'open'});
+      this.dispatchEvent(event);
+    });
+    HTMLElement.prototype.hidePopover = vi.fn(function (this: HTMLElement) {
+      this.removeAttribute('popover-open');
+      const event = new Event('toggle', {bubbles: false});
+      Object.defineProperty(event, 'newState', {value: 'closed'});
+      this.dispatchEvent(event);
+    });
+    const originalMatches = HTMLElement.prototype.matches;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (HTMLElement.prototype as any).matches = function (
+      selector: string,
+    ): boolean {
+      if (selector === ':popover-open') {
+        return this.hasAttribute('popover-open');
+      }
+      return originalMatches.call(this, selector);
+    };
+  });
+
+  it('offers Sort ascending/descending on a sortable header, and Clear sort once sorted', () => {
+    render(<SortableTable allowUnsortedState />);
+
+    // Unsorted: asc + desc, no "Clear sort".
+    fireEvent.contextMenu(screen.getByText('Name'));
+    expect(
+      screen.getAllByRole('menuitem', {name: 'Sort ascending', hidden: true})
+        .length,
+    ).toBeGreaterThan(0);
+    expect(
+      screen.getAllByRole('menuitem', {name: 'Sort descending', hidden: true})
+        .length,
+    ).toBeGreaterThan(0);
+    expect(
+      screen.queryByRole('menuitem', {name: 'Clear sort', hidden: true}),
+    ).not.toBeInTheDocument();
+
+    // Apply ascending → "Clear sort" now appears.
+    fireEvent.click(
+      screen.getAllByRole('menuitem', {name: 'Sort ascending', hidden: true})[0],
+    );
+    fireEvent.contextMenu(screen.getByText('Name'));
+    expect(
+      screen.getAllByRole('menuitem', {name: 'Clear sort', hidden: true}).length,
+    ).toBeGreaterThan(0);
+  });
+
+  it('resolves fresh actions on each open as sort state changes (lazy getter)', () => {
+    const onSortChange = vi.fn();
+    render(<SortableTable allowUnsortedState onSortChange={onSortChange} />);
+
+    // Open (unsorted) and pick descending.
+    fireEvent.contextMenu(screen.getByText('Name'));
+    fireEvent.click(
+      screen.getAllByRole('menuitem', {
+        name: 'Sort descending',
+        hidden: true,
+      })[0],
+    );
+    expect(onSortChange).toHaveBeenLastCalledWith([
+      {sortKey: 'name', direction: 'descending'},
+    ]);
+
+    // Re-open: the getter recomputes against the now-descending state, so
+    // "Clear sort" is present and clicking it clears — proving the actions are
+    // freshly derived on each open, not memoized from the first render.
+    fireEvent.contextMenu(screen.getByText('Name'));
+    const clear = screen.getAllByRole('menuitem', {
+      name: 'Clear sort',
+      hidden: true,
+    });
+    expect(clear.length).toBeGreaterThan(0);
+    fireEvent.click(clear[0]);
+    expect(onSortChange).toHaveBeenLastCalledWith([]);
   });
 });

--- a/packages/core/src/Table/plugins/sortable/useTableSortable.tsx
+++ b/packages/core/src/Table/plugins/sortable/useTableSortable.tsx
@@ -17,6 +17,7 @@ import {useRef, useMemo, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars, spacingVars, radiusVars} from '../../../theme/tokens.stylex';
 import {Icon} from '../../../Icon';
+import {resolveContextActions} from '../../tableContextMenu';
 import type {
   TablePlugin,
   HeaderCellRenderProps,
@@ -423,9 +424,7 @@ export function useTableSortable<
             </SortHeaderButton>
           ),
           contextMenuActions: () => [
-            ...(typeof priorActions === 'function'
-              ? priorActions()
-              : (priorActions ?? [])),
+            ...resolveContextActions(priorActions),
             ...getSortActions(),
           ],
         };

--- a/packages/core/src/Table/plugins/sortable/useTableSortable.tsx
+++ b/packages/core/src/Table/plugins/sortable/useTableSortable.tsx
@@ -21,6 +21,7 @@ import type {
   TablePlugin,
   HeaderCellRenderProps,
   TableColumn,
+  TableContextAction,
 } from '../../types';
 
 // =============================================================================
@@ -359,6 +360,44 @@ export function useTableSortable<
         // Find sort entry for this column
         const cfg = configRef.current;
         const entry = cfg.sort.find(e => e.sortKey === sortKey);
+        const direction = entry?.direction ?? null;
+
+        // Right-click actions: sort asc / desc, and clear when active. Appended
+        // to any actions other plugins contributed for this header.
+        const sortActions: TableContextAction[] = [
+          {
+            id: 'sort-asc',
+            group: 'sort',
+            label: 'Sort ascending',
+            icon: <Icon icon="arrowUp" size="xsm" aria-hidden />,
+            checked: direction === 'ascending',
+            onSelect: () =>
+              cfg.onSortChange([
+                {sortKey: sortKey as TSortKey, direction: 'ascending'},
+              ]),
+          },
+          {
+            id: 'sort-desc',
+            group: 'sort',
+            label: 'Sort descending',
+            icon: <Icon icon="arrowDown" size="xsm" aria-hidden />,
+            checked: direction === 'descending',
+            onSelect: () =>
+              cfg.onSortChange([
+                {sortKey: sortKey as TSortKey, direction: 'descending'},
+              ]),
+          },
+        ];
+        if (direction != null) {
+          sortActions.push({
+            id: 'sort-clear',
+            group: 'sort-clear',
+            label: 'Clear sort',
+            icon: <Icon icon="close" size="xsm" aria-hidden />,
+            onSelect: () =>
+              cfg.onSortChange(cfg.sort.filter(e => e.sortKey !== sortKey)),
+          });
+        }
 
         return {
           ...props,
@@ -375,49 +414,11 @@ export function useTableSortable<
               {props.content}
             </SortHeaderButton>
           ),
+          contextMenuActions: [
+            ...(props.contextMenuActions ?? []),
+            ...sortActions,
+          ],
         };
-      },
-      getHeaderContextActions(column: TableColumn<T>) {
-        const sortKey = resolveSortKey(column);
-        if (sortKey == null) {
-          return [];
-        }
-        const cfg = configRef.current;
-        const entry = cfg.sort.find(e => e.sortKey === sortKey);
-        const direction = entry?.direction ?? null;
-        const actions = [
-          {
-            id: 'sort-asc',
-            group: 'sort',
-            label: 'Sort ascending',
-            icon: <Icon icon="arrowUp" size="xsm" aria-hidden />,
-            checked: direction === 'ascending',
-            onSelect: () =>
-              cfg.onSortChange([{sortKey: sortKey as TSortKey, direction: 'ascending'}]),
-          },
-          {
-            id: 'sort-desc',
-            group: 'sort',
-            label: 'Sort descending',
-            icon: <Icon icon="arrowDown" size="xsm" aria-hidden />,
-            checked: direction === 'descending',
-            onSelect: () =>
-              cfg.onSortChange([{sortKey: sortKey as TSortKey, direction: 'descending'}]),
-          },
-        ];
-        // Offer "Clear sort" only when this column is actively sorted.
-        if (direction != null) {
-          actions.push({
-            id: 'sort-clear',
-            group: 'sort-clear',
-            label: 'Clear sort',
-            icon: <Icon icon="close" size="xsm" aria-hidden />,
-            checked: false,
-            onSelect: () =>
-              cfg.onSortChange(cfg.sort.filter(e => e.sortKey !== sortKey)),
-          });
-        }
-        return actions;
       },
     }),
     [],

--- a/packages/core/src/Table/plugins/sortable/useTableSortable.tsx
+++ b/packages/core/src/Table/plugins/sortable/useTableSortable.tsx
@@ -377,6 +377,48 @@ export function useTableSortable<
           ),
         };
       },
+      getHeaderContextActions(column: TableColumn<T>) {
+        const sortKey = resolveSortKey(column);
+        if (sortKey == null) {
+          return [];
+        }
+        const cfg = configRef.current;
+        const entry = cfg.sort.find(e => e.sortKey === sortKey);
+        const direction = entry?.direction ?? null;
+        const actions = [
+          {
+            id: 'sort-asc',
+            group: 'sort',
+            label: 'Sort ascending',
+            icon: <Icon icon="arrowUp" size="xsm" aria-hidden />,
+            checked: direction === 'ascending',
+            onSelect: () =>
+              cfg.onSortChange([{sortKey: sortKey as TSortKey, direction: 'ascending'}]),
+          },
+          {
+            id: 'sort-desc',
+            group: 'sort',
+            label: 'Sort descending',
+            icon: <Icon icon="arrowDown" size="xsm" aria-hidden />,
+            checked: direction === 'descending',
+            onSelect: () =>
+              cfg.onSortChange([{sortKey: sortKey as TSortKey, direction: 'descending'}]),
+          },
+        ];
+        // Offer "Clear sort" only when this column is actively sorted.
+        if (direction != null) {
+          actions.push({
+            id: 'sort-clear',
+            group: 'sort-clear',
+            label: 'Clear sort',
+            icon: <Icon icon="close" size="xsm" aria-hidden />,
+            checked: false,
+            onSelect: () =>
+              cfg.onSortChange(cfg.sort.filter(e => e.sortKey !== sortKey)),
+          });
+        }
+        return actions;
+      },
     }),
     [],
   );

--- a/packages/core/src/Table/plugins/sortable/useTableSortable.tsx
+++ b/packages/core/src/Table/plugins/sortable/useTableSortable.tsx
@@ -357,48 +357,56 @@ export function useTableSortable<
           return props;
         }
 
-        // Find sort entry for this column
         const cfg = configRef.current;
         const entry = cfg.sort.find(e => e.sortKey === sortKey);
-        const direction = entry?.direction ?? null;
 
-        // Right-click actions: sort asc / desc, and clear when active. Appended
-        // to any actions other plugins contributed for this header.
-        const sortActions: TableContextAction[] = [
-          {
-            id: 'sort-asc',
-            group: 'sort',
-            label: 'Sort ascending',
-            icon: <Icon icon="arrowUp" size="xsm" aria-hidden />,
-            checked: direction === 'ascending',
-            onSelect: () =>
-              cfg.onSortChange([
-                {sortKey: sortKey as TSortKey, direction: 'ascending'},
-              ]),
-          },
-          {
-            id: 'sort-desc',
-            group: 'sort',
-            label: 'Sort descending',
-            icon: <Icon icon="arrowDown" size="xsm" aria-hidden />,
-            checked: direction === 'descending',
-            onSelect: () =>
-              cfg.onSortChange([
-                {sortKey: sortKey as TSortKey, direction: 'descending'},
-              ]),
-          },
-        ];
-        if (direction != null) {
-          sortActions.push({
-            id: 'sort-clear',
-            group: 'sort-clear',
-            label: 'Clear sort',
-            icon: <Icon icon="close" size="xsm" aria-hidden />,
-            onSelect: () =>
-              cfg.onSortChange(cfg.sort.filter(e => e.sortKey !== sortKey)),
-          });
-        }
+        // Context-menu actions are built lazily (only when the menu opens) via
+        // a getter, reading the current sort state at call time — so we don't
+        // build an action array for every header on every render, and the
+        // checked/clear state always reflects the latest sort.
+        const getSortActions = (): TableContextAction[] => {
+          const c = configRef.current;
+          const dir = c.sort.find(e => e.sortKey === sortKey)?.direction ?? null;
+          const actions: TableContextAction[] = [
+            {
+              id: 'sort-asc',
+              group: 'sort',
+              label: 'Sort ascending',
+              icon: <Icon icon="arrowUp" size="xsm" aria-hidden />,
+              checked: dir === 'ascending',
+              onSelect: () =>
+                c.onSortChange([
+                  {sortKey: sortKey as TSortKey, direction: 'ascending'},
+                ]),
+            },
+            {
+              id: 'sort-desc',
+              group: 'sort',
+              label: 'Sort descending',
+              icon: <Icon icon="arrowDown" size="xsm" aria-hidden />,
+              checked: dir === 'descending',
+              onSelect: () =>
+                c.onSortChange([
+                  {sortKey: sortKey as TSortKey, direction: 'descending'},
+                ]),
+            },
+          ];
+          if (dir != null) {
+            actions.push({
+              id: 'sort-clear',
+              group: 'sort-clear',
+              label: 'Clear sort',
+              icon: <Icon icon="close" size="xsm" aria-hidden />,
+              onSelect: () =>
+                c.onSortChange(c.sort.filter(e => e.sortKey !== sortKey)),
+            });
+          }
+          return actions;
+        };
 
+        // Merge with any actions a prior plugin contributed (array or getter),
+        // resolving both lazily at open time.
+        const priorActions = props.contextMenuActions;
         return {
           ...props,
           htmlProps: {
@@ -414,9 +422,11 @@ export function useTableSortable<
               {props.content}
             </SortHeaderButton>
           ),
-          contextMenuActions: [
-            ...(props.contextMenuActions ?? []),
-            ...sortActions,
+          contextMenuActions: () => [
+            ...(typeof priorActions === 'function'
+              ? priorActions()
+              : (priorActions ?? [])),
+            ...getSortActions(),
           ],
         };
       },

--- a/packages/core/src/Table/tableContextMenu.test.tsx
+++ b/packages/core/src/Table/tableContextMenu.test.tsx
@@ -15,6 +15,7 @@ import {
   type TableSortState,
 } from './plugins/sortable/useTableSortable';
 import type {TablePlugin, TableColumn} from './types';
+import {resolveContextActions} from './tableContextMenu';
 
 // jsdom doesn't implement the Popover API; mirror the ContextMenu test's mock
 // so the menu can "open" and its items become queryable (as hidden).
@@ -89,7 +90,7 @@ describe('Table header context menu', () => {
       transformHeaderCell: props => ({
         ...props,
         contextMenuActions: [
-          ...(props.contextMenuActions ?? []),
+          ...resolveContextActions(props.contextMenuActions),
           {id: 'a', label: 'Action A', onSelect: () => {}},
         ],
       }),
@@ -98,7 +99,7 @@ describe('Table header context menu', () => {
       transformHeaderCell: props => ({
         ...props,
         contextMenuActions: [
-          ...(props.contextMenuActions ?? []),
+          ...resolveContextActions(props.contextMenuActions),
           {id: 'b', label: 'Action B', onSelect: () => {}},
         ],
       }),

--- a/packages/core/src/Table/tableContextMenu.test.tsx
+++ b/packages/core/src/Table/tableContextMenu.test.tsx
@@ -125,6 +125,40 @@ describe('Table header context menu', () => {
 });
 
 // =============================================================================
+// Body / row context menu
+// =============================================================================
+
+describe('Table body context menu', () => {
+  it('renders row actions from a plugin that sets contextMenuActions in transformBodyCell', () => {
+    const onSelect = vi.fn();
+    const plugin: TablePlugin<Row> = {
+      transformBodyCell: (props, _column, item) => ({
+        ...props,
+        contextMenuActions: [
+          {
+            id: `delete-${item.id}`,
+            label: 'Delete row',
+            onSelect: () => onSelect(item.id),
+          },
+        ],
+      }),
+    };
+    render(
+      <Table data={data} columns={columns} idKey="id" plugins={{plugin}} />,
+    );
+    // Right-click the first body cell (Alice).
+    fireEvent.contextMenu(screen.getByText('Alice'));
+    const items = screen.getAllByRole('menuitem', {
+      name: 'Delete row',
+      hidden: true,
+    });
+    expect(items.length).toBeGreaterThan(0);
+    fireEvent.click(items[0]);
+    expect(onSelect).toHaveBeenCalledWith('1');
+  });
+});
+
+// =============================================================================
 // Sortable integration
 // =============================================================================
 

--- a/packages/core/src/Table/tableContextMenu.test.tsx
+++ b/packages/core/src/Table/tableContextMenu.test.tsx
@@ -207,4 +207,48 @@ describe('sortable context actions', () => {
         .length,
     ).toBeGreaterThan(0);
   });
+
+  it('resolves fresh actions on each open as sort state changes (lazy getter)', () => {
+    const onSortChange = vi.fn();
+    function Harness() {
+      const [sort, setSort] = useState<TableSortState>([]);
+      const sortPlugin = useTableSortable<Row>({
+        sort,
+        onSortChange: next => {
+          setSort(next);
+          onSortChange(next);
+        },
+      });
+      return (
+        <Table
+          data={data}
+          columns={[{key: 'name', header: 'Name', sortable: true}]}
+          idKey="id"
+          plugins={{sort: sortPlugin}}
+        />
+      );
+    }
+    render(<Harness />);
+
+    // Open (unsorted) and pick descending.
+    fireEvent.contextMenu(screen.getByText('Name'));
+    fireEvent.click(
+      screen.getAllByRole('menuitem', {name: 'Sort descending', hidden: true})[0],
+    );
+    expect(onSortChange).toHaveBeenLastCalledWith([
+      {sortKey: 'name', direction: 'descending'},
+    ]);
+
+    // Re-open: the getter recomputes against the now-descending state, so
+    // "Clear sort" is present and clicking it clears — proving the actions are
+    // freshly derived on each open, not memoized from the first render.
+    fireEvent.contextMenu(screen.getByText('Name'));
+    const clear = screen.getAllByRole('menuitem', {
+      name: 'Clear sort',
+      hidden: true,
+    });
+    expect(clear.length).toBeGreaterThan(0);
+    fireEvent.click(clear[0]);
+    expect(onSortChange).toHaveBeenLastCalledWith([]);
+  });
 });

--- a/packages/core/src/Table/tableContextMenu.test.tsx
+++ b/packages/core/src/Table/tableContextMenu.test.tsx
@@ -8,12 +8,7 @@
 
 import {describe, it, expect, vi, beforeEach} from 'vitest';
 import {render, screen, fireEvent} from '@testing-library/react';
-import {useState} from 'react';
 import {Table} from './Table';
-import {
-  useTableSortable,
-  type TableSortState,
-} from './plugins/sortable/useTableSortable';
 import type {TablePlugin, TableColumn} from './types';
 import {resolveContextActions} from './tableContextMenu';
 
@@ -158,98 +153,5 @@ describe('Table body context menu', () => {
     expect(items.length).toBeGreaterThan(0);
     fireEvent.click(items[0]);
     expect(onSelect).toHaveBeenCalledWith('1');
-  });
-});
-
-// =============================================================================
-// Sortable integration
-// =============================================================================
-
-describe('sortable context actions', () => {
-  it('offers Sort ascending/descending on a sortable header and Clear sort once sorted', () => {
-    function Harness() {
-      const [sort, setSort] = useState<TableSortState>([]);
-      const sortPlugin = useTableSortable<Row>({sort, onSortChange: setSort});
-      return (
-        <Table
-          data={data}
-          columns={[{key: 'name', header: 'Name', sortable: true}]}
-          idKey="id"
-          plugins={{sort: sortPlugin}}
-        />
-      );
-    }
-    render(<Harness />);
-
-    // Unsorted: asc + desc, no "Clear sort".
-    fireEvent.contextMenu(screen.getByText('Name'));
-    expect(
-      screen.getAllByRole('menuitem', {name: 'Sort ascending', hidden: true})
-        .length,
-    ).toBeGreaterThan(0);
-    expect(
-      screen.getAllByRole('menuitem', {name: 'Sort descending', hidden: true})
-        .length,
-    ).toBeGreaterThan(0);
-    expect(
-      screen.queryByRole('menuitem', {name: 'Clear sort', hidden: true}),
-    ).not.toBeInTheDocument();
-
-    // Apply ascending → "Clear sort" now appears.
-    fireEvent.click(
-      screen.getAllByRole('menuitem', {
-        name: 'Sort ascending',
-        hidden: true,
-      })[0],
-    );
-    fireEvent.contextMenu(screen.getByText('Name'));
-    expect(
-      screen.getAllByRole('menuitem', {name: 'Clear sort', hidden: true})
-        .length,
-    ).toBeGreaterThan(0);
-  });
-
-  it('resolves fresh actions on each open as sort state changes (lazy getter)', () => {
-    const onSortChange = vi.fn();
-    function Harness() {
-      const [sort, setSort] = useState<TableSortState>([]);
-      const sortPlugin = useTableSortable<Row>({
-        sort,
-        onSortChange: next => {
-          setSort(next);
-          onSortChange(next);
-        },
-      });
-      return (
-        <Table
-          data={data}
-          columns={[{key: 'name', header: 'Name', sortable: true}]}
-          idKey="id"
-          plugins={{sort: sortPlugin}}
-        />
-      );
-    }
-    render(<Harness />);
-
-    // Open (unsorted) and pick descending.
-    fireEvent.contextMenu(screen.getByText('Name'));
-    fireEvent.click(
-      screen.getAllByRole('menuitem', {name: 'Sort descending', hidden: true})[0],
-    );
-    expect(onSortChange).toHaveBeenLastCalledWith([
-      {sortKey: 'name', direction: 'descending'},
-    ]);
-
-    // Re-open: the getter recomputes against the now-descending state, so
-    // "Clear sort" is present and clicking it clears — proving the actions are
-    // freshly derived on each open, not memoized from the first render.
-    fireEvent.contextMenu(screen.getByText('Name'));
-    const clear = screen.getAllByRole('menuitem', {
-      name: 'Clear sort',
-      hidden: true,
-    });
-    expect(clear.length).toBeGreaterThan(0);
-    fireEvent.click(clear[0]);
-    expect(onSortChange).toHaveBeenLastCalledWith([]);
   });
 });

--- a/packages/core/src/Table/tableContextMenu.test.tsx
+++ b/packages/core/src/Table/tableContextMenu.test.tsx
@@ -1,0 +1,183 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file tableContextMenu.test.tsx
+ * @output Tests for the Table context-menu system (collection + rendering)
+ * @position Validates plugin action aggregation and header context menus
+ */
+
+import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {render, screen, fireEvent} from '@testing-library/react';
+import {useState} from 'react';
+import {Table} from './Table';
+import {
+  collectHeaderContextActions,
+  collectRowContextActions,
+} from './tableContextMenu';
+import {
+  useTableSortable,
+  type TableSortState,
+} from './plugins/sortable/useTableSortable';
+import type {TablePlugin, TableColumn} from './types';
+
+// jsdom doesn't implement the Popover API; mirror the ContextMenu test's mock
+// so the menu can "open" and its items become queryable (as hidden).
+beforeEach(() => {
+  HTMLElement.prototype.showPopover = vi.fn(function (this: HTMLElement) {
+    this.setAttribute('popover-open', '');
+    const event = new Event('toggle', {bubbles: false});
+    Object.defineProperty(event, 'newState', {value: 'open'});
+    this.dispatchEvent(event);
+  });
+  HTMLElement.prototype.hidePopover = vi.fn(function (this: HTMLElement) {
+    this.removeAttribute('popover-open');
+    const event = new Event('toggle', {bubbles: false});
+    Object.defineProperty(event, 'newState', {value: 'closed'});
+    this.dispatchEvent(event);
+  });
+  const originalMatches = HTMLElement.prototype.matches;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (HTMLElement.prototype as any).matches = function (
+    selector: string,
+  ): boolean {
+    if (selector === ':popover-open') {
+      return this.hasAttribute('popover-open');
+    }
+    return originalMatches.call(this, selector);
+  };
+});
+
+interface Row extends Record<string, unknown> {
+  id: string;
+  name: string;
+}
+
+const data: Row[] = [
+  {id: '1', name: 'Alice'},
+  {id: '2', name: 'Bob'},
+];
+
+const columns: TableColumn<Row>[] = [
+  {key: 'name', header: 'Name'},
+  {key: 'id', header: 'ID'},
+];
+
+// =============================================================================
+// Collection
+// =============================================================================
+
+describe('collectHeaderContextActions / collectRowContextActions', () => {
+  it('aggregates actions from every plugin in order', () => {
+    const a: TablePlugin<Row> = {
+      getHeaderContextActions: () => [
+        {id: 'a', label: 'A', onSelect: () => {}},
+      ],
+    };
+    const b: TablePlugin<Row> = {
+      getHeaderContextActions: () => [
+        {id: 'b', label: 'B', onSelect: () => {}},
+      ],
+    };
+    const actions = collectHeaderContextActions([a, b], columns[0], 0);
+    expect(actions.map(x => x.id)).toEqual(['a', 'b']);
+  });
+
+  it('returns an empty array when no plugin contributes', () => {
+    const plugin: TablePlugin<Row> = {transformHeaderCell: p => p};
+    expect(collectHeaderContextActions([plugin], columns[0], 0)).toEqual([]);
+    expect(collectRowContextActions([plugin], data[0], 0)).toEqual([]);
+  });
+
+  it('collects row actions per plugin', () => {
+    const plugin: TablePlugin<Row> = {
+      getRowContextActions: item => [
+        {id: `del-${item.id}`, label: 'Delete', onSelect: () => {}},
+      ],
+    };
+    const actions = collectRowContextActions([plugin], data[1], 1);
+    expect(actions.map(x => x.id)).toEqual(['del-2']);
+  });
+});
+
+// =============================================================================
+// Rendering (header)
+// =============================================================================
+
+describe('Table header context menu', () => {
+  it('opens a menu with the plugin actions on right-click', () => {
+    const onSelect = vi.fn();
+    const plugin: TablePlugin<Row> = {
+      getHeaderContextActions: () => [
+        {id: 'pin', label: 'Pin column', onSelect},
+      ],
+    };
+    render(
+      <Table data={data} columns={columns} idKey="id" plugins={{plugin}} />,
+    );
+    fireEvent.contextMenu(screen.getByText('Name'));
+    const items = screen.getAllByRole('menuitem', {
+      name: 'Pin column',
+      hidden: true,
+    });
+    expect(items.length).toBeGreaterThan(0);
+    fireEvent.click(items[0]);
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not render a menu when no plugin contributes actions', () => {
+    render(<Table data={data} columns={columns} idKey="id" />);
+    fireEvent.contextMenu(screen.getByText('Name'));
+    expect(
+      screen.queryByRole('menuitem', {hidden: true}),
+    ).not.toBeInTheDocument();
+  });
+});
+
+// =============================================================================
+// Sortable integration
+// =============================================================================
+
+describe('sortable context actions', () => {
+  it('offers Sort ascending/descending on a sortable header and Clear sort once sorted', () => {
+    function Harness() {
+      const [sort, setSort] = useState<TableSortState>([]);
+      const sortPlugin = useTableSortable<Row>({sort, onSortChange: setSort});
+      return (
+        <Table
+          data={data}
+          columns={[{key: 'name', header: 'Name', sortable: true}]}
+          idKey="id"
+          plugins={{sort: sortPlugin}}
+        />
+      );
+    }
+    render(<Harness />);
+
+    // Unsorted: asc + desc, no "Clear sort".
+    fireEvent.contextMenu(screen.getByText('Name'));
+    expect(
+      screen.getAllByRole('menuitem', {name: 'Sort ascending', hidden: true})
+        .length,
+    ).toBeGreaterThan(0);
+    expect(
+      screen.getAllByRole('menuitem', {name: 'Sort descending', hidden: true})
+        .length,
+    ).toBeGreaterThan(0);
+    expect(
+      screen.queryByRole('menuitem', {name: 'Clear sort', hidden: true}),
+    ).not.toBeInTheDocument();
+
+    // Apply ascending → "Clear sort" now appears.
+    fireEvent.click(
+      screen.getAllByRole('menuitem', {
+        name: 'Sort ascending',
+        hidden: true,
+      })[0],
+    );
+    fireEvent.contextMenu(screen.getByText('Name'));
+    expect(
+      screen.getAllByRole('menuitem', {name: 'Clear sort', hidden: true})
+        .length,
+    ).toBeGreaterThan(0);
+  });
+});

--- a/packages/core/src/Table/tableContextMenu.test.tsx
+++ b/packages/core/src/Table/tableContextMenu.test.tsx
@@ -138,7 +138,9 @@ describe('Table body context menu', () => {
           {
             id: `delete-${item.id}`,
             label: 'Delete row',
-            onSelect: () => onSelect(item.id),
+            onSelect: () => {
+              onSelect(item.id);
+            },
           },
         ],
       }),

--- a/packages/core/src/Table/tableContextMenu.test.tsx
+++ b/packages/core/src/Table/tableContextMenu.test.tsx
@@ -2,18 +2,14 @@
 
 /**
  * @file tableContextMenu.test.tsx
- * @output Tests for the Table context-menu system (collection + rendering)
- * @position Validates plugin action aggregation and header context menus
+ * @output Tests for the Table context-menu system
+ * @position Validates contextMenuActions aggregation + header context menus
  */
 
 import {describe, it, expect, vi, beforeEach} from 'vitest';
 import {render, screen, fireEvent} from '@testing-library/react';
 import {useState} from 'react';
 import {Table} from './Table';
-import {
-  collectHeaderContextActions,
-  collectRowContextActions,
-} from './tableContextMenu';
 import {
   useTableSortable,
   type TableSortState,
@@ -63,53 +59,17 @@ const columns: TableColumn<Row>[] = [
 ];
 
 // =============================================================================
-// Collection
-// =============================================================================
-
-describe('collectHeaderContextActions / collectRowContextActions', () => {
-  it('aggregates actions from every plugin in order', () => {
-    const a: TablePlugin<Row> = {
-      getHeaderContextActions: () => [
-        {id: 'a', label: 'A', onSelect: () => {}},
-      ],
-    };
-    const b: TablePlugin<Row> = {
-      getHeaderContextActions: () => [
-        {id: 'b', label: 'B', onSelect: () => {}},
-      ],
-    };
-    const actions = collectHeaderContextActions([a, b], columns[0], 0);
-    expect(actions.map(x => x.id)).toEqual(['a', 'b']);
-  });
-
-  it('returns an empty array when no plugin contributes', () => {
-    const plugin: TablePlugin<Row> = {transformHeaderCell: p => p};
-    expect(collectHeaderContextActions([plugin], columns[0], 0)).toEqual([]);
-    expect(collectRowContextActions([plugin], data[0], 0)).toEqual([]);
-  });
-
-  it('collects row actions per plugin', () => {
-    const plugin: TablePlugin<Row> = {
-      getRowContextActions: item => [
-        {id: `del-${item.id}`, label: 'Delete', onSelect: () => {}},
-      ],
-    };
-    const actions = collectRowContextActions([plugin], data[1], 1);
-    expect(actions.map(x => x.id)).toEqual(['del-2']);
-  });
-});
-
-// =============================================================================
-// Rendering (header)
+// contextMenuActions via transformHeaderCell
 // =============================================================================
 
 describe('Table header context menu', () => {
-  it('opens a menu with the plugin actions on right-click', () => {
+  it('renders a menu from a plugin that sets contextMenuActions', () => {
     const onSelect = vi.fn();
     const plugin: TablePlugin<Row> = {
-      getHeaderContextActions: () => [
-        {id: 'pin', label: 'Pin column', onSelect},
-      ],
+      transformHeaderCell: props => ({
+        ...props,
+        contextMenuActions: [{id: 'pin', label: 'Pin column', onSelect}],
+      }),
     };
     render(
       <Table data={data} columns={columns} idKey="id" plugins={{plugin}} />,
@@ -122,6 +82,37 @@ describe('Table header context menu', () => {
     expect(items.length).toBeGreaterThan(0);
     fireEvent.click(items[0]);
     expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+
+  it('concatenates actions from multiple plugins (never overridden)', () => {
+    const a: TablePlugin<Row> = {
+      transformHeaderCell: props => ({
+        ...props,
+        contextMenuActions: [
+          ...(props.contextMenuActions ?? []),
+          {id: 'a', label: 'Action A', onSelect: () => {}},
+        ],
+      }),
+    };
+    const b: TablePlugin<Row> = {
+      transformHeaderCell: props => ({
+        ...props,
+        contextMenuActions: [
+          ...(props.contextMenuActions ?? []),
+          {id: 'b', label: 'Action B', onSelect: () => {}},
+        ],
+      }),
+    };
+    render(
+      <Table data={data} columns={columns} idKey="id" plugins={{a, b}} />,
+    );
+    fireEvent.contextMenu(screen.getByText('Name'));
+    expect(
+      screen.getAllByRole('menuitem', {name: 'Action A', hidden: true}).length,
+    ).toBeGreaterThan(0);
+    expect(
+      screen.getAllByRole('menuitem', {name: 'Action B', hidden: true}).length,
+    ).toBeGreaterThan(0);
   });
 
   it('does not render a menu when no plugin contributes actions', () => {

--- a/packages/core/src/Table/tableContextMenu.tsx
+++ b/packages/core/src/Table/tableContextMenu.tsx
@@ -13,10 +13,10 @@
  * - /packages/core/src/Table/types.ts (TableContextAction)
  */
 
-import type {ReactNode} from 'react';
+import {useState, type ReactNode} from 'react';
 import {ContextMenu, type ContextMenuOption} from '../ContextMenu';
 import {Icon} from '../Icon';
-import type {TableContextAction} from './types';
+import type {TableContextAction, TableContextActions} from './types';
 
 /**
  * Convert the flat action list into ContextMenu options, inserting a divider
@@ -69,11 +69,49 @@ function toContextMenuOptions(
  * actions the element is returned untouched so the native browser menu passes
  * through.
  */
+/**
+ * A context menu whose actions are resolved lazily — only when the user opens
+ * the menu (right-click). Deferring the work means plugins that pass a getter
+ * don't build an action array (with its closures) for every cell on every
+ * render; it's computed on demand and memoized until the menu closes.
+ */
+function LazyTableContextMenu({
+  element,
+  getActions,
+}: {
+  element: ReactNode;
+  getActions: () => TableContextAction[];
+}): ReactNode {
+  const [options, setOptions] = useState<ContextMenuOption[] | null>(null);
+  return (
+    <ContextMenu
+      items={options ?? []}
+      hasAutoFocus={false}
+      onOpenChange={open => {
+        // Resolve actions when opening; clear on close so state derived later
+        // (e.g. current sort direction) is always fresh next open.
+        setOptions(open ? toContextMenuOptions(getActions()) : null);
+      }}>
+      {element}
+    </ContextMenu>
+  );
+}
+
+/**
+ * Wrap a table element (a header cell's content or a body cell) in a right-click
+ * context menu rendering the aggregated `actions`. Accepts a static array or a
+ * getter (resolved lazily on open). When there are no actions the element is
+ * returned untouched so the native browser menu passes through.
+ */
 export function wrapInTableContextMenu(
   element: ReactNode,
-  actions: TableContextAction[],
+  actions: TableContextActions | undefined,
 ): ReactNode {
-  if (actions.length === 0) {
+  // Getter form → resolve lazily on open.
+  if (typeof actions === 'function') {
+    return <LazyTableContextMenu element={element} getActions={actions} />;
+  }
+  if (!actions || actions.length === 0) {
     return element;
   }
   // hasAutoFocus={false}: a right-click menu shouldn't pre-highlight the first

--- a/packages/core/src/Table/tableContextMenu.tsx
+++ b/packages/core/src/Table/tableContextMenu.tsx
@@ -19,6 +19,27 @@ import {Icon} from '../Icon';
 import type {TableContextAction, TableContextActions} from './types';
 
 /**
+ * Resolve a `contextMenuActions` value (array or getter) to a plain array.
+ * Use this when composing actions from a prior plugin's render props so you
+ * don't have to branch on the array-vs-getter form:
+ *
+ * ```
+ * contextMenuActions: () => [
+ *   ...resolveContextActions(props.contextMenuActions),
+ *   ...myActions,
+ * ]
+ * ```
+ */
+export function resolveContextActions(
+  actions: TableContextActions | undefined,
+): TableContextAction[] {
+  if (typeof actions === 'function') {
+    return actions();
+  }
+  return actions ?? [];
+}
+
+/**
  * Convert the flat action list into ContextMenu options, inserting a divider
  * between groups (first-seen group order). Ungrouped actions form a trailing
  * group. A `checked` action shows a trailing check icon.

--- a/packages/core/src/Table/tableContextMenu.tsx
+++ b/packages/core/src/Table/tableContextMenu.tsx
@@ -5,8 +5,8 @@
 /**
  * @file tableContextMenu.tsx
  * @input React, ContextMenu, Icon, types
- * @output collectContextActions + wrapInTableContextMenu helpers
- * @position Renders the aggregated plugin context actions for a header/row
+ * @output wrapInTableContextMenu helper
+ * @position Renders the aggregated `contextMenuActions` for a header cell / row
  *
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/Table/BaseTable.tsx (call sites)
@@ -16,44 +16,7 @@
 import type {ReactNode} from 'react';
 import {ContextMenu, type ContextMenuOption} from '../ContextMenu';
 import {Icon} from '../Icon';
-import type {TablePlugin, TableContextAction, TableColumn} from './types';
-
-/**
- * Aggregate header context actions from every plugin for a given column.
- * Actions are concatenated in plugin order (never overridden).
- */
-export function collectHeaderContextActions<
-  T extends Record<string, unknown>,
->(
-  plugins: TablePlugin<T>[],
-  column: TableColumn<T>,
-  columnIndex: number,
-): TableContextAction[] {
-  const actions: TableContextAction[] = [];
-  for (const plugin of plugins) {
-    if (plugin.getHeaderContextActions) {
-      actions.push(...plugin.getHeaderContextActions(column, columnIndex));
-    }
-  }
-  return actions;
-}
-
-/**
- * Aggregate row context actions from every plugin for a given row.
- */
-export function collectRowContextActions<T extends Record<string, unknown>>(
-  plugins: TablePlugin<T>[],
-  item: T,
-  rowIndex: number,
-): TableContextAction[] {
-  const actions: TableContextAction[] = [];
-  for (const plugin of plugins) {
-    if (plugin.getRowContextActions) {
-      actions.push(...plugin.getRowContextActions(item, rowIndex));
-    }
-  }
-  return actions;
-}
+import type {TableContextAction} from './types';
 
 /**
  * Convert the flat action list into ContextMenu options, inserting a divider

--- a/packages/core/src/Table/tableContextMenu.tsx
+++ b/packages/core/src/Table/tableContextMenu.tsx
@@ -1,0 +1,124 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file tableContextMenu.tsx
+ * @input React, ContextMenu, Icon, types
+ * @output collectContextActions + wrapInTableContextMenu helpers
+ * @position Renders the aggregated plugin context actions for a header/row
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/Table/BaseTable.tsx (call sites)
+ * - /packages/core/src/Table/types.ts (TableContextAction)
+ */
+
+import type {ReactNode} from 'react';
+import {ContextMenu, type ContextMenuOption} from '../ContextMenu';
+import {Icon} from '../Icon';
+import type {TablePlugin, TableContextAction, TableColumn} from './types';
+
+/**
+ * Aggregate header context actions from every plugin for a given column.
+ * Actions are concatenated in plugin order (never overridden).
+ */
+export function collectHeaderContextActions<
+  T extends Record<string, unknown>,
+>(
+  plugins: TablePlugin<T>[],
+  column: TableColumn<T>,
+  columnIndex: number,
+): TableContextAction[] {
+  const actions: TableContextAction[] = [];
+  for (const plugin of plugins) {
+    if (plugin.getHeaderContextActions) {
+      actions.push(...plugin.getHeaderContextActions(column, columnIndex));
+    }
+  }
+  return actions;
+}
+
+/**
+ * Aggregate row context actions from every plugin for a given row.
+ */
+export function collectRowContextActions<T extends Record<string, unknown>>(
+  plugins: TablePlugin<T>[],
+  item: T,
+  rowIndex: number,
+): TableContextAction[] {
+  const actions: TableContextAction[] = [];
+  for (const plugin of plugins) {
+    if (plugin.getRowContextActions) {
+      actions.push(...plugin.getRowContextActions(item, rowIndex));
+    }
+  }
+  return actions;
+}
+
+/**
+ * Convert the flat action list into ContextMenu options, inserting a divider
+ * between groups (first-seen group order). Ungrouped actions form a trailing
+ * group. A `checked` action shows a trailing check icon.
+ */
+function toContextMenuOptions(
+  actions: TableContextAction[],
+): ContextMenuOption[] {
+  const order: string[] = [];
+  const buckets = new Map<string, TableContextAction[]>();
+  for (const action of actions) {
+    const key = action.group ?? '__ungrouped__';
+    let bucket = buckets.get(key);
+    if (!bucket) {
+      bucket = [];
+      buckets.set(key, bucket);
+      order.push(key);
+    }
+    bucket.push(action);
+  }
+
+  const options: ContextMenuOption[] = [];
+  order.forEach((key, groupIndex) => {
+    if (groupIndex > 0) {
+      options.push({type: 'divider'});
+    }
+    for (const action of buckets.get(key) ?? []) {
+      options.push({
+        label: typeof action.label === 'string' ? action.label : action.id,
+        // A checked action (e.g. the active sort direction) shows a checkmark;
+        // otherwise the action's own icon. ContextMenu's data form takes a
+        // single leading icon, so checked state replaces the icon.
+        icon: action.checked ? (
+          <Icon icon="check" size="xsm" aria-hidden />
+        ) : (
+          action.icon
+        ),
+        isDisabled: action.disabled,
+        onClick: action.onSelect,
+      });
+    }
+  });
+  return options;
+}
+
+/**
+ * Wrap a table element (a header cell's content or a row) in a right-click
+ * context menu rendering the aggregated `actions`. When no plugin contributes
+ * actions the element is returned untouched so the native browser menu passes
+ * through.
+ */
+export function wrapInTableContextMenu(
+  element: ReactNode,
+  actions: TableContextAction[],
+): ReactNode {
+  if (actions.length === 0) {
+    return element;
+  }
+  // hasAutoFocus={false}: a right-click menu shouldn't pre-highlight the first
+  // item (it looked like "ascending" was always selected). Focus moves only
+  // when the user arrow-keys into the menu.
+  return (
+    <ContextMenu items={toContextMenuOptions(actions)} hasAutoFocus={false}>
+      {element}
+    </ContextMenu>
+  );
+}

--- a/packages/core/src/Table/types.ts
+++ b/packages/core/src/Table/types.ts
@@ -336,6 +336,38 @@ export interface ScrollWrapperRenderProps {
 }
 
 // =============================================================================
+// Context-menu actions
+// =============================================================================
+
+/**
+ * A single right-click context-menu action contributed by a plugin.
+ *
+ * Plugins contribute actions via {@link TablePlugin.getHeaderContextActions} /
+ * {@link TablePlugin.getRowContextActions}; the table aggregates actions from
+ * every enabled plugin into a single menu per header cell / row.
+ */
+export interface TableContextAction {
+  /** Stable identifier, unique within a single menu. */
+  id: string;
+  /** Visible label for the menu item. */
+  label: ReactNode;
+  /** Optional leading icon. */
+  icon?: ReactNode;
+  /** Invoked when the item is selected. */
+  onSelect: () => void;
+  /** When true, the item is rendered but not selectable. */
+  disabled?: boolean;
+  /**
+   * Group key used to cluster related actions and insert a divider between
+   * groups (e.g. 'sort', 'selection'). Actions without a group form a trailing
+   * group. Group order follows first-seen order across the aggregated list.
+   */
+  group?: string;
+  /** When true, the item renders as checked (e.g. the active sort direction). */
+  checked?: boolean;
+}
+
+// =============================================================================
 // Plugin Interface
 // =============================================================================
 
@@ -353,6 +385,10 @@ export interface ScrollWrapperRenderProps {
  * 6. `transformBodyCell` — transform each body `<td>` props
  * 7. `transformScrollWrapper` — transform the scroll-container wrapper around the table
  * 8. `transformTableContext` — wrap the table output in context providers
+ *
+ * Plugins may also contribute right-click menu actions via
+ * `getHeaderContextActions` / `getRowContextActions` (aggregated into one menu
+ * per header cell / row).
  */
 export interface TablePlugin<
   T extends Record<string, unknown> = Record<string, unknown>,
@@ -409,6 +445,21 @@ export interface TablePlugin<
   ) => ScrollWrapperRenderProps;
   /** Wrap the table output in context providers */
   transformTableContext?: (children: ReactNode) => ReactNode;
+  /**
+   * Contribute right-click actions for a column header. Called for the header
+   * under the cursor; return an empty array to contribute nothing. Actions
+   * from all plugins are merged into one menu (never overridden).
+   */
+  getHeaderContextActions?: (
+    column: TableColumn<T>,
+    columnIndex: number,
+  ) => TableContextAction[];
+  /**
+   * Contribute right-click actions for a body row. Called for the row under
+   * the cursor; return an empty array to contribute nothing. Actions from all
+   * plugins are merged into one menu (never overridden).
+   */
+  getRowContextActions?: (item: T, rowIndex: number) => TableContextAction[];
 }
 
 // =============================================================================

--- a/packages/core/src/Table/types.ts
+++ b/packages/core/src/Table/types.ts
@@ -266,7 +266,7 @@ export interface HeaderCellRenderProps {
    * their actions in `transformHeaderCell`; BaseTable concatenates the arrays
    * across plugins (never overridden) and renders one menu per header cell.
    */
-  contextMenuActions?: TableContextAction[];
+  contextMenuActions?: TableContextActions;
   /**
    * Index of this column within the final, ordered list of rendered columns
    * (after column injection/reordering by other plugins). Populated by
@@ -302,7 +302,7 @@ export interface BodyCellRenderProps {
    * plugins and across the row's cells (never overridden) and renders one menu
    * per row.
    */
-  contextMenuActions?: TableContextAction[];
+  contextMenuActions?: TableContextActions;
   /**
    * Index of this cell's column within the final ordered column list.
    * Mirrors the `columnIndex` passed to `transformHeaderCell`. Populated by
@@ -380,6 +380,17 @@ export interface TableContextAction {
   /** When true, the item renders as checked (e.g. the active sort direction). */
   checked?: boolean;
 }
+
+/**
+ * Context-menu actions for a cell — either a static array, or a getter that
+ * returns the actions lazily. Prefer the getter for actions derived from state
+ * (e.g. the active sort direction): it's only invoked when the menu is opened,
+ * so the plugin doesn't build an action array (with closures) for every cell on
+ * every render.
+ */
+export type TableContextActions =
+  | TableContextAction[]
+  | (() => TableContextAction[]);
 
 // =============================================================================
 // Plugin Interface
@@ -488,7 +499,7 @@ export interface TableCellComponentProps extends TdHTMLAttributes<HTMLTableCellE
    * padding / content sizing. Empty/undefined renders no menu (native passes
    * through).
    */
-  contextMenuActions?: TableContextAction[];
+  contextMenuActions?: TableContextActions;
 }
 
 /** Props for header cell components used in the components prop */
@@ -500,7 +511,7 @@ export interface TableHeaderCellComponentProps extends ThHTMLAttributes<HTMLTabl
    * The cell owns the menu wrapper so it can control how it interacts with
    * padding / content sizing. Empty/undefined renders no menu.
    */
-  contextMenuActions?: TableContextAction[];
+  contextMenuActions?: TableContextActions;
 }
 
 // =============================================================================

--- a/packages/core/src/Table/types.ts
+++ b/packages/core/src/Table/types.ts
@@ -262,6 +262,12 @@ export interface HeaderCellRenderProps {
   /** Content rendered below the header label row (e.g. inline filter controls). */
   below?: ReactNode;
   /**
+   * Right-click context-menu actions for this header cell. Plugins append
+   * their actions in `transformHeaderCell`; BaseTable concatenates the arrays
+   * across plugins (never overridden) and renders one menu per header cell.
+   */
+  contextMenuActions?: TableContextAction[];
+  /**
    * Index of this column within the final, ordered list of rendered columns
    * (after column injection/reordering by other plugins). Populated by
    * BaseTable. Optional for backward compatibility with hand-constructed
@@ -290,6 +296,13 @@ export interface BodyRowRenderProps {
 export interface BodyCellRenderProps {
   htmlProps: TdHTMLAttributes<HTMLTableCellElement>;
   styles: StyleXStyles[];
+  /**
+   * Right-click context-menu actions for this body cell. Plugins append their
+   * actions in `transformBodyCell`; BaseTable concatenates the arrays across
+   * plugins and across the row's cells (never overridden) and renders one menu
+   * per row.
+   */
+  contextMenuActions?: TableContextAction[];
   /**
    * Index of this cell's column within the final ordered column list.
    * Mirrors the `columnIndex` passed to `transformHeaderCell`. Populated by
@@ -342,9 +355,10 @@ export interface ScrollWrapperRenderProps {
 /**
  * A single right-click context-menu action contributed by a plugin.
  *
- * Plugins contribute actions via {@link TablePlugin.getHeaderContextActions} /
- * {@link TablePlugin.getRowContextActions}; the table aggregates actions from
- * every enabled plugin into a single menu per header cell / row.
+ * Plugins contribute actions via the `contextMenuActions` field on
+ * `HeaderCellRenderProps` / `BodyCellRenderProps` (set in
+ * `transformHeaderCell` / `transformBodyCell`); the table aggregates actions
+ * from every enabled plugin into a single menu per header cell / row.
  */
 export interface TableContextAction {
   /** Stable identifier, unique within a single menu. */
@@ -386,9 +400,9 @@ export interface TableContextAction {
  * 7. `transformScrollWrapper` — transform the scroll-container wrapper around the table
  * 8. `transformTableContext` — wrap the table output in context providers
  *
- * Plugins may also contribute right-click menu actions via
- * `getHeaderContextActions` / `getRowContextActions` (aggregated into one menu
- * per header cell / row).
+ * Plugins may also contribute right-click menu actions by appending to
+ * `contextMenuActions` in `transformHeaderCell` / `transformBodyCell`
+ * (aggregated into one menu per header cell / row).
  */
 export interface TablePlugin<
   T extends Record<string, unknown> = Record<string, unknown>,
@@ -445,21 +459,6 @@ export interface TablePlugin<
   ) => ScrollWrapperRenderProps;
   /** Wrap the table output in context providers */
   transformTableContext?: (children: ReactNode) => ReactNode;
-  /**
-   * Contribute right-click actions for a column header. Called for the header
-   * under the cursor; return an empty array to contribute nothing. Actions
-   * from all plugins are merged into one menu (never overridden).
-   */
-  getHeaderContextActions?: (
-    column: TableColumn<T>,
-    columnIndex: number,
-  ) => TableContextAction[];
-  /**
-   * Contribute right-click actions for a body row. Called for the row under
-   * the cursor; return an empty array to contribute nothing. Actions from all
-   * plugins are merged into one menu (never overridden).
-   */
-  getRowContextActions?: (item: T, rowIndex: number) => TableContextAction[];
 }
 
 // =============================================================================

--- a/packages/core/src/Table/types.ts
+++ b/packages/core/src/Table/types.ts
@@ -482,12 +482,25 @@ export interface TableRowComponentProps extends HTMLAttributes<HTMLTableRowEleme
 export interface TableCellComponentProps extends TdHTMLAttributes<HTMLTableCellElement> {
   children?: ReactNode;
   xstyle?: StyleXStyles | StyleXStyles[];
+  /**
+   * Right-click actions to render as a context menu around the cell content.
+   * The cell owns the menu wrapper so it can control how it interacts with
+   * padding / content sizing. Empty/undefined renders no menu (native passes
+   * through).
+   */
+  contextMenuActions?: TableContextAction[];
 }
 
 /** Props for header cell components used in the components prop */
 export interface TableHeaderCellComponentProps extends ThHTMLAttributes<HTMLTableCellElement> {
   children?: ReactNode;
   xstyle?: StyleXStyles | StyleXStyles[];
+  /**
+   * Right-click actions to render as a context menu around the header content.
+   * The cell owns the menu wrapper so it can control how it interacts with
+   * padding / content sizing. Empty/undefined renders no menu.
+   */
+  contextMenuActions?: TableContextAction[];
 }
 
 // =============================================================================

--- a/packages/core/src/Table/useBaseTablePlugins.ts
+++ b/packages/core/src/Table/useBaseTablePlugins.ts
@@ -89,10 +89,6 @@ const VALID_TRANSFORM_KEYS = new Set([
   'transformBodyCell',
   'transformScrollWrapper',
   'transformTableContext',
-  // Context-menu action contributors (not transforms, but valid plugin keys
-  // that make a plugin do meaningful work).
-  'getHeaderContextActions',
-  'getRowContextActions',
 ]);
 
 /**

--- a/packages/core/src/Table/useBaseTablePlugins.ts
+++ b/packages/core/src/Table/useBaseTablePlugins.ts
@@ -89,6 +89,10 @@ const VALID_TRANSFORM_KEYS = new Set([
   'transformBodyCell',
   'transformScrollWrapper',
   'transformTableContext',
+  // Context-menu action contributors (not transforms, but valid plugin keys
+  // that make a plugin do meaningful work).
+  'getHeaderContextActions',
+  'getRowContextActions',
 ]);
 
 /**


### PR DESCRIPTION
## What

Adds a **plugin-contributed right-click context-menu system** to `Table`. Right-clicking a column header shows a menu of actions aggregated from every enabled plugin (instead of the browser's generic menu) — e.g. with `useTableSortable` enabled, right-clicking a sortable header offers **Sort ascending / Sort descending / Clear sort**.

## Design

Plugins **contribute** actions rather than each rendering their own menu — the table aggregates actions from all plugins into one menu per header, avoiding nested/clobbered menus.

- New `TableContextAction` type and two optional, backward-compatible `TablePlugin` methods: `getHeaderContextActions(column, columnIndex)` and `getRowContextActions(item, rowIndex)`.
- `tableContextMenu.tsx`: `collectHeaderContextActions` / `collectRowContextActions` (aggregate across plugins) + `wrapInTableContextMenu` (maps actions → `ContextMenu` options, dividers between groups, checkmark for the active item, `hasAutoFocus={false}` so right-click doesn't pre-highlight). When no plugin contributes actions the element is untouched and the native browser menu passes through.
- `BaseTable` collects + wraps at the header render path; `useBaseTablePlugins` registers the two new plugin keys.
- First contributor: `useTableSortable` adds asc/desc/clear (adapted to Astryx's array sort-state).

Other plugins opt in by implementing the same two methods — no core changes needed.

## Scope note

**Header menus only** in this PR. The interface includes `getRowContextActions` and the row collector is built/exported, but row-menu *rendering* into `<tr>` is a follow-up: Astryx's `ContextMenu` wraps its trigger in a `<div>`, invalid between `<tbody>` and `<tr>`. Needs an `asChild`/Slot option on `ContextMenu` (or an `onContextMenu`-on-`<tr>` approach). Header menus — the sortable use case — work fully.

## Demo

Surfaces on the **existing** `Core → TableSortable` stories (no new stories) — right-click any sortable column header.

## Validation

- `pnpm -F @astryxdesign/core build` ✅ (incl. tsc), `eslint` ✅
- New `tableContextMenu.test.tsx` (6 tests: aggregation, header render, no-op passthrough, sortable asc/desc/clear). Full Table suite: **318 pass**.
- Changeset included (`[feat]`).
