### PR TITLE
feat(templates): add changeset for Shell page-template category

### DIFF
--- a/.changeset/shell-page-templates.md
+++ b/.changeset/shell-page-templates.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[feat] Add a Shell page-template category to the CLI: Top Nav, Side Nav, and Shell Nav app-shell scaffolds (#3245, #3246, #3247)
+
+@ernestt


### PR DESCRIPTION
## Summary

Adds the missing changeset for the new **Shell** page-template category in `@astryxdesign/cli`. The three Shell templates merged without a changeset, so they're currently absent from the changelog:

- **Top Nav** (#3245) — `Shell - Top Nav`
- **Side Nav** (#3246) — `Shell - Left Sidebar`
- **Shell Nav** (#3247) — `Shell - Top Nav + Left Sidebar`

Templates ship in the published CLI package (`packages/cli/templates/`), so this is a consumer-visible addition → `patch`. Contributor credit goes to @ernestt, who authored the templates.

## Test plan

- [x] `.changeset/shell-page-templates.md` has valid frontmatter (`@astryxdesign/cli: patch`).
- [x] All three template directories exist on `main` under `packages/cli/templates/pages/`.
