### PR TITLE
docs: remove em-dashes from doc prose and a duplicate (required) marker

### DIFF
--- a/packages/cli/docs/theme.doc.mjs
+++ b/packages/cli/docs/theme.doc.mjs
@@ -53,7 +53,7 @@ function App() {
         },
         {
           type: 'prose',
-          text: 'Each theme ships as its own npm package. Install the one you want, then wrap your app in `<Theme>` — the same pattern works for every theme; just swap the package and import name.',
+          text: 'Each theme ships as its own npm package. Install the one you want, then wrap your app in `<Theme>`. The same pattern works for every theme; just swap the package and import name.',
         },
         {
           type: 'prose',
@@ -261,7 +261,7 @@ const brandTheme = defineTheme({
       content: [
         {
           type: 'prose',
-          text: 'The `components` field in defineTheme uses semantic component keys and style keys — not raw CSS selectors. Use `base` for all instances, `variant:value` or `stateName` for specific props/states, and let the theme pipeline choose the underlying selector. For raw external CSS escape hatches, prefer the data-attribute selector surface documented in `astryx docs styling`.',
+          text: 'The `components` field in defineTheme uses semantic component keys and style keys, not raw CSS selectors. Use `base` for all instances, `variant:value` or `stateName` for specific props/states, and let the theme pipeline choose the underlying selector. For raw external CSS escape hatches, prefer the data-attribute selector surface documented in `astryx docs styling`.',
         },
         {
           type: 'code',

--- a/packages/cli/templates/blocks/components/LinkProvider/LinkProviderCustomLink.doc.mjs
+++ b/packages/cli/templates/blocks/components/LinkProvider/LinkProviderCustomLink.doc.mjs
@@ -7,7 +7,7 @@ export const doc = {
   name: 'Link Provider — Custom Link Component',
   displayName: 'Link Provider — Custom Link Component',
   description:
-    'Routes every Astryx link through a custom component that intercepts the click — the hook frameworks like Next.js use for client-side navigation. Click the link to see the custom handler fire instead of a full-page load.',
+    'Routes every Astryx link through a custom component that intercepts the click, the hook frameworks like Next.js use for client-side navigation. Click the link to see the custom handler fire instead of a full-page load.',
   isReady: true,
   aspectRatio: 4 / 3,
   componentsUsed: ['LinkProvider', 'Link'],

--- a/packages/cli/templates/blocks/components/Table/StickyColumnsHookUsage.doc.mjs
+++ b/packages/cli/templates/blocks/components/Table/StickyColumnsHookUsage.doc.mjs
@@ -7,7 +7,7 @@ export const doc = {
   name: 'useTableStickyColumns — Pinned Columns',
   displayName: 'useTableStickyColumns — Pinned Columns',
   description:
-    'A Table using useTableStickyColumns to pin the Name column to the start edge and Status to the end edge. Scroll horizontally — pinned columns stay in view with a soft shadow over the scrolling content.',
+    'A Table using useTableStickyColumns to pin the Name column to the start edge and Status to the end edge. Scroll horizontally; pinned columns stay in view with a soft shadow over the scrolling content.',
   isReady: true,
   aspectRatio: 16 / 9,
   componentsUsed: ['Table'],

--- a/packages/cli/templates/pages/shell-side-nav/template.doc.mjs
+++ b/packages/cli/templates/pages/shell-side-nav/template.doc.mjs
@@ -6,7 +6,7 @@ export const doc = {
   name: 'Side Nav',
   displayName: 'Side Nav',
   description:
-    'A side-nav app shell with a collapsible, resizable SideNav — new chat, search, library, and workspace-grouped conversations with status dots — over static grey-card conversation and composer placeholders.',
+    'A side-nav app shell with a collapsible, resizable SideNav (new chat, search, library, and workspace-grouped conversations with status dots) over static grey-card conversation and composer placeholders.',
   isReady: true,
   category: 'Shell - Left Sidebar',
 };

--- a/packages/cli/templates/pages/shell-top-nav/template.doc.mjs
+++ b/packages/cli/templates/pages/shell-top-nav/template.doc.mjs
@@ -6,7 +6,7 @@ export const doc = {
   name: 'Top Nav',
   displayName: 'Top Nav',
   description:
-    'A top-nav app shell with a centered TopNav — Shop and Brands mega menus (a 2x4 item grid plus a featured card each), Sale/Service links, and a Checkout button — over static grey-card hero and category sections.',
+    'A top-nav app shell with a centered TopNav (Shop and Brands mega menus with a 2x4 item grid plus a featured card each, Sale/Service links, and a Checkout button) over static grey-card hero and category sections.',
   isReady: true,
   category: 'Shell - Top Nav',
 };

--- a/packages/core/src/Table/useTableColumnResize.doc.mjs
+++ b/packages/core/src/Table/useTableColumnResize.doc.mjs
@@ -19,7 +19,7 @@ export const docs = {
       name: 'onColumnResizeEnd',
       type: '(updates: Record<string, number>) => void',
       description:
-        'Called when a resize completes (pointerup / Enter). Receives a map of every column key whose width changed — merge it into your columnWidths state.',
+        'Called when a resize completes (pointerup / Enter). Receives a map of every column key whose width changed; merge it into your columnWidths state.',
     },
     {
       name: 'minWidth',
@@ -37,7 +37,7 @@ export const docs = {
       name: 'columns',
       type: 'TableColumn<T>[]',
       description:
-        'Column definitions — needed to derive per-column min widths and detect proportional vs pixel columns for neighbor/last-column resize behavior.',
+        'Column definitions, needed to derive per-column min widths and detect proportional vs pixel columns for neighbor/last-column resize behavior.',
     },
   ],
 };
@@ -91,6 +91,6 @@ export const docsDense = {
     minWidth: 'Global min column width (px) during resize.',
     maxWidth: 'Global max column width (px) during resize. Default Infinity.',
     columns:
-      'Column defs — derive per-column mins + proportional/pixel detection for neighbor/last-column behavior.',
+      'Column defs: derive per-column mins + proportional/pixel detection for neighbor/last-column behavior.',
   },
 };

--- a/packages/core/src/Table/useTableStickyColumns.doc.mjs
+++ b/packages/core/src/Table/useTableStickyColumns.doc.mjs
@@ -13,13 +13,13 @@ export const docs = {
       name: 'startKeys',
       type: 'string[]',
       description:
-        'Column keys pinned to the start (inline-start / left in LTR) edge — the contiguous run from the first column through the last listed key.',
+        'Column keys pinned to the start (inline-start / left in LTR) edge: the contiguous run from the first column through the last listed key.',
     },
     {
       name: 'endKeys',
       type: 'string[]',
       description:
-        'Column keys pinned to the end (inline-end / right in LTR) edge — the contiguous run from the first listed key through the last column.',
+        'Column keys pinned to the end (inline-end / right in LTR) edge: the contiguous run from the first listed key through the last column.',
     },
   ],
 };

--- a/packages/lab/src/CircularProgress/CircularProgress.doc.mjs
+++ b/packages/lab/src/CircularProgress/CircularProgress.doc.mjs
@@ -22,7 +22,7 @@ export const docs = {
     {
       name: 'label',
       type: 'string',
-      description: 'Accessible label for screen readers (required).',
+      description: 'Accessible label for screen readers.',
       required: true,
     },
     {
@@ -164,7 +164,7 @@ export const docsDense = {
   propDescriptions: {
     value: 'Current value. Omit for indeterminate spinning animation.',
     max: 'Maximum value.',
-    label: 'Accessible label for screen readers (required).',
+    label: 'Accessible label for screen readers.',
     isLabelHidden: 'Visually hide label (remains accessible). Defaults to true.',
     children: 'Center content: percentage, icon, or custom.',
     size: 'Ring diameter (32px, 48px, 64px).',


### PR DESCRIPTION
## Summary

Removes em-dashes from documentation prose and clears a duplicate `(required)` marker, following the Doc Reviewer check 17 (AI-slop prose) rubric. Found by a full re-scan of all 789 `.doc.mjs` files after the cron refresh; these are pre-existing tells, not new content.

## Changes (8 files, prose only)

**Em-dash recasts** (colon / semicolon / comma / parentheses per the right punctuation):
- `Table/useTableColumnResize.doc.mjs` (3) and `Table/useTableStickyColumns.doc.mjs` (2) hook param/return descriptions
- `cli/docs/theme.doc.mjs` (2) guide prose
- `LinkProvider/LinkProviderCustomLink.doc.mjs` and `Table/StickyColumnsHookUsage.doc.mjs` block descriptions
- `pages/shell-side-nav` and `pages/shell-top-nav` template descriptions (parenthetical asides)

**Duplicate `(required)` marker:**
- `lab/CircularProgress/CircularProgress.doc.mjs` `label` description (English + dense overlay) had a literal `(required)` while the prop already sets `required: true`. Removed the literal text so the marker renders once.

## What is intentionally left alone

- Chinese `——` and the `必填` marker in `docsZh` (correct CJK punctuation, exempt)
- `Component — Variant` `name`/`displayName` labels (naming convention, exempt)
- Numeric en-dash ranges (`2-4`, `h1-h6`, etc.)
- Em-dashes inside `//` and `/* */` code comments and demo UI copy

## Validation

- `pnpm --filter @astryxdesign/core typecheck:docs`: pass
- `npx tsc --project packages/cli/tsconfig.template-docs.json --noEmit`: pass
- `node .github/scripts/api-cli-parity-test.mjs --no-baseline`: 307 pass / 0 fail
- All 8 files parse as ESM; theme docs render verified clean (no em-dash, single `(required)`)

Night Watch — Doc Reviewer
