### PR TITLE
docs(core): document Link type="inherit" for inline links

### DIFF
--- a/.changeset/link-type-inherit-docs.md
+++ b/.changeset/link-type-inherit-docs.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[docs] Link: document `type="inherit"` for inline links. The value was already supported (forwarded to `Text`, which renders `font-size`/`line-height: inherit`), but undocumented — clarified the `type` prop JSDoc, added an inline-link example, and added regression tests covering the inherit/default-body behavior (#2927)
+@durvesh1992

--- a/packages/core/src/Link/Link.test.tsx
+++ b/packages/core/src/Link/Link.test.tsx
@@ -120,6 +120,24 @@ describe('Link', () => {
     expect(screen.getByRole('link')).toBeInTheDocument();
   });
 
+  it('defaults the inner text type to body', () => {
+    render(<Link href="/test">Body link</Link>);
+    expect(screen.getByText('Body link')).toHaveClass('astryx-text', 'body');
+  });
+
+  it('forwards type="inherit" so the link adopts the surrounding text type', () => {
+    render(
+      <Link href="/test" type="inherit">
+        Inline link
+      </Link>,
+    );
+    // The inner Text renders with the `inherit` type, so font-size/line-height
+    // inherit from the surrounding text rather than imposing the body type.
+    const text = screen.getByText('Inline link');
+    expect(text).toHaveClass('astryx-text', 'inherit');
+    expect(text).not.toHaveClass('body');
+  });
+
   it('applies hasUnderline style when true', () => {
     render(
       <Link href="/test" hasUnderline>

--- a/packages/core/src/Link/Link.tsx
+++ b/packages/core/src/Link/Link.tsx
@@ -203,6 +203,10 @@ export interface LinkProps extends BaseProps<
   isStandalone?: boolean;
   /**
    * Semantic text type for Text. Determines base typography.
+   *
+   * Use `type="inherit"` for inline links inside an existing `Text` element so
+   * the link adopts the surrounding text's size and line-height instead of
+   * imposing its own (e.g. a link within a `large` paragraph).
    * @default 'body'
    */
   type?: TextType;
@@ -248,6 +252,11 @@ export interface LinkProps extends BaseProps<
  * <Link href="/settings" color="secondary">Settings</Link>
  * <Link href="/privacy" hasUnderline>Privacy Policy</Link>
  * <Link label="Close dialog" href="/home"><Icon icon="x" /></Link>
+ *
+ * // Inline link inside text — inherits the surrounding type/size:
+ * <Text type="large">
+ *   Read our <Link href="/terms" type="inherit">terms</Link> first.
+ * </Text>
  * ```
  */
 export function Link({


### PR DESCRIPTION
## Summary

Closes #2927, which asks for `Link` to support `type="inherit"` so inline links can adopt the surrounding text's styling.

On inspection, this **already works**: `Link`'s `type` prop is typed `TextType`, which includes `'inherit'`, and `Link` forwards `type` straight to the inner `<Text>`. `Text` maps `type="inherit"` to `font-size: inherit; line-height: inherit`, and `Link`'s base `<a>` already inherits font properties — so a link inside a `Text` block adopts that block's type through the normal inheritance chain.

What was missing was **documentation and test coverage**, so the capability wasn't discoverable. This PR:
- Clarifies the `type` prop JSDoc to call out `type="inherit"` for inline links.
- Adds an inline-link `@example` (`<Text type="large">… <Link type="inherit">…</Link></Text>`).
- Adds regression tests: `type="inherit"` renders the inner Text with the `inherit` type (not `body`), and the default remains `body`.

No runtime/behavior change — docs + tests only.

## Test plan
- 28/28 Link tests pass, including the two new ones asserting the forwarded `inherit` class and the default `body` class.

Closes #2927