### PR TITLE
feat(cli): static template API and /template export

### DIFF
--- a/.changeset/static-template-api.md
+++ b/.changeset/static-template-api.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[feat] Static template authoring API (createPageTemplate/createBlockTemplate) with the @astryxdesign/cli/template export and type-driven, package-scoped template discovery.
+
+@ejhammond

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -47,6 +47,10 @@
       "types": "./src/types/integration.d.ts",
       "import": "./src/integration.mjs"
     },
+    "./template": {
+      "types": "./src/types/template-api.d.ts",
+      "import": "./src/template.mjs"
+    },
     "./xle": {
       "types": "./src/lib/xle/browser.d.ts",
       "import": "./src/lib/xle/browser.mjs"

--- a/packages/cli/src/api/template-integration.test.mjs
+++ b/packages/cli/src/api/template-integration.test.mjs
@@ -1,0 +1,225 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Integration-provided template discovery (same-stem + type-driven).
+ *
+ * These tests stand up a temp consumer project with an astryx.config and an
+ * installed integration package that contributes templates, then exercise the
+ * public `template()` API to verify discovery, package/type scoping, ambiguity
+ * errors, and copy-to-dir naming.
+ */
+
+import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {template} from './template.mjs';
+
+let tmpDir;
+let originalCwd;
+
+/** Absolute path to the CLI package so integrations can import /template. */
+const CLI_PKG = path.resolve(import.meta.dirname, '..', '..');
+
+function makeConsumer() {
+  const dir = fs.mkdtempSync(
+    path.join(process.cwd(), '.astryx-template-it-'),
+  );
+  fs.writeFileSync(
+    path.join(dir, 'package.json'),
+    JSON.stringify({name: 'consumer'}),
+  );
+  fs.writeFileSync(
+    path.join(dir, 'astryx.config.mjs'),
+    `export default { integrations: ['@acme/widgets'] };\n`,
+  );
+  return dir;
+}
+
+/**
+ * Install an @acme/widgets integration package that declares a templates root.
+ * @returns the package dir.
+ */
+function installWidgets(consumerDir) {
+  const pkgDir = path.join(consumerDir, 'node_modules', '@acme', 'widgets');
+  fs.mkdirSync(pkgDir, {recursive: true});
+  fs.writeFileSync(
+    path.join(pkgDir, 'package.json'),
+    JSON.stringify({name: '@acme/widgets', version: '2.0.0'}),
+  );
+  fs.writeFileSync(
+    path.join(pkgDir, 'astryx.integration.mjs'),
+    `export default { templates: './templates' };\n`,
+  );
+  fs.mkdirSync(path.join(pkgDir, 'templates'));
+  return pkgDir;
+}
+
+/** Write a template doc + same-stem source under the templates root. */
+function writeTemplate(pkgDir, id, {kind, body, withSource = true}) {
+  const docPath = path.join(pkgDir, 'templates', `${id}.doc.mjs`);
+  fs.mkdirSync(path.dirname(docPath), {recursive: true});
+  const create = kind === 'page' ? 'createPageTemplate' : 'createBlockTemplate';
+  fs.writeFileSync(
+    docPath,
+    body ??
+      `import {${create}} from '${CLI_PKG}/src/template.mjs';\n` +
+        `export default ${create}({name: '${id} name', description: '${id} desc'});\n`,
+  );
+  if (withSource) {
+    fs.writeFileSync(
+      path.join(pkgDir, 'templates', `${id}.tsx`),
+      `export default function ${id.replace(/[^a-zA-Z0-9]/g, '')}() { return null; }\n`,
+    );
+  }
+}
+
+beforeEach(() => {
+  originalCwd = process.cwd();
+  tmpDir = makeConsumer();
+  process.chdir(tmpDir);
+});
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  fs.rmSync(tmpDir, {recursive: true, force: true});
+});
+
+describe('integration template discovery', () => {
+  it('discovers and lists an integration template with package + type', async () => {
+    const pkgDir = installWidgets(tmpDir);
+    writeTemplate(pkgDir, 'pricing', {kind: 'page'});
+
+    const result = await template(undefined, {list: true, cwd: tmpDir});
+    expect(result.type).toBe('template.list');
+    const entry = result.data.find(t => t.id === 'pricing');
+    expect(entry).toBeTruthy();
+    expect(entry.type).toBe('page');
+    expect(entry.package).toBe('@acme/widgets');
+    expect(entry.name).toBe('pricing name');
+    expect(entry.description).toBe('pricing desc');
+  });
+
+  it('lists nested-id templates (kebab path under root)', async () => {
+    const pkgDir = installWidgets(tmpDir);
+    writeTemplate(pkgDir, 'marketing/hero', {kind: 'block'});
+
+    const result = await template(undefined, {list: true, cwd: tmpDir});
+    const entry = result.data.find(t => t.id === 'marketing/hero');
+    expect(entry).toBeTruthy();
+    expect(entry.type).toBe('block');
+    expect(entry.package).toBe('@acme/widgets');
+  });
+
+  it('always reports core templates under @astryxdesign/core', async () => {
+    const result = await template(undefined, {list: true, cwd: tmpDir});
+    const core = result.data.filter(t => t.package === '@astryxdesign/core');
+    expect(core.length).toBeGreaterThan(0);
+  });
+
+  it('--package narrows the listing', async () => {
+    const pkgDir = installWidgets(tmpDir);
+    writeTemplate(pkgDir, 'pricing', {kind: 'page'});
+
+    const result = await template(undefined, {
+      list: true,
+      package: '@acme/widgets',
+      cwd: tmpDir,
+    });
+    expect(result.data.length).toBe(1);
+    expect(result.data[0].id).toBe('pricing');
+  });
+
+  it('skips a template whose same-stem source is missing', async () => {
+    const pkgDir = installWidgets(tmpDir);
+    writeTemplate(pkgDir, 'orphan', {kind: 'page', withSource: false});
+
+    const result = await template(undefined, {list: true, cwd: tmpDir});
+    expect(result.data.find(t => t.id === 'orphan')).toBeUndefined();
+  });
+
+  it('skips a raw doc that is missing a type', async () => {
+    const pkgDir = installWidgets(tmpDir);
+    writeTemplate(pkgDir, 'untyped', {
+      kind: 'page',
+      body: `export default {name: 'Untyped', description: 'no type'};\n`,
+    });
+
+    const result = await template(undefined, {list: true, cwd: tmpDir});
+    expect(result.data.find(t => t.id === 'untyped')).toBeUndefined();
+  });
+
+  it('errors with candidates when an id is ambiguous across type/package', async () => {
+    const pkgDir = installWidgets(tmpDir);
+    // Same id "hero" as both a page and a block within the integration.
+    writeTemplate(pkgDir, 'hero', {kind: 'page'});
+    // Add a sibling block doc with the same stem in a different file is not
+    // possible (same file). Instead install a second package with a "hero".
+    const pkg2 = path.join(tmpDir, 'node_modules', '@acme', 'extra');
+    fs.mkdirSync(path.join(pkg2, 'templates'), {recursive: true});
+    fs.writeFileSync(
+      path.join(pkg2, 'package.json'),
+      JSON.stringify({name: '@acme/extra', version: '1.0.0'}),
+    );
+    fs.writeFileSync(
+      path.join(pkg2, 'astryx.integration.mjs'),
+      `export default { templates: './templates' };\n`,
+    );
+    fs.writeFileSync(
+      path.join(pkg2, 'templates', 'hero.doc.mjs'),
+      `import {createBlockTemplate} from '${CLI_PKG}/src/template.mjs';\n` +
+        `export default createBlockTemplate({name: 'Hero block', description: 'b'});\n`,
+    );
+    fs.writeFileSync(
+      path.join(pkg2, 'templates', 'hero.tsx'),
+      `export default function Hero() { return null; }\n`,
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, 'astryx.config.mjs'),
+      `export default { integrations: ['@acme/widgets', '@acme/extra'] };\n`,
+    );
+
+    await expect(
+      template('hero', {targetPath: './out', cwd: tmpDir}),
+    ).rejects.toMatchObject({code: 'ERR_AMBIGUOUS_TEMPLATE'});
+  });
+
+  it('--type and --package narrow an ambiguous id to a single match', async () => {
+    const pkgDir = installWidgets(tmpDir);
+    writeTemplate(pkgDir, 'pricing', {kind: 'page'});
+
+    const result = await template('pricing', {
+      type: 'page',
+      package: '@acme/widgets',
+      show: true,
+      cwd: tmpDir,
+    });
+    expect(result.type).toBe('template.show');
+    expect(result.data.type).toBe('page');
+  });
+
+  it('copies a page template into a directory as page.tsx', async () => {
+    const pkgDir = installWidgets(tmpDir);
+    writeTemplate(pkgDir, 'pricing', {kind: 'page'});
+
+    const result = await template('pricing', {
+      targetPath: './dest',
+      cwd: tmpDir,
+    });
+    expect(result.type).toBe('template.copy');
+    expect(result.data.fileName).toBe('page.tsx');
+    expect(fs.existsSync(path.join(tmpDir, 'dest', 'page.tsx'))).toBe(true);
+  });
+
+  it('copies a block template into a directory as <id-basename>.tsx', async () => {
+    const pkgDir = installWidgets(tmpDir);
+    writeTemplate(pkgDir, 'marketing/hero', {kind: 'block'});
+
+    const result = await template('marketing/hero', {
+      targetPath: './dest',
+      cwd: tmpDir,
+    });
+    expect(result.type).toBe('template.copy');
+    expect(result.data.fileName).toBe('hero.tsx');
+    expect(fs.existsSync(path.join(tmpDir, 'dest', 'hero.tsx'))).toBe(true);
+  });
+});

--- a/packages/cli/src/api/template.mjs
+++ b/packages/cli/src/api/template.mjs
@@ -6,6 +6,8 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import {pathToFileURL} from 'node:url';
+import {createJiti} from 'jiti';
 import {CLI_ROOT, discoverExternalPackages} from '../utils/paths.mjs';
 import {
   assertWithin,
@@ -14,6 +16,33 @@ import {
 } from '../utils/path-safety.mjs';
 import {AstryxError} from './error.mjs';
 import {ERROR_CODES} from '../lib/error-codes.mjs';
+import {loadConfig} from '../lib/config.mjs';
+
+/** Identity used for core (built-in) templates in package-scoped listings. */
+const CORE_PACKAGE = '@astryxdesign/core';
+
+/** Doc-file basename suffixes for integration templates, in precedence order. */
+const DOC_SUFFIXES = ['.doc.ts', '.doc.mjs', '.doc.js'];
+
+let jitiInstance;
+function getJiti() {
+  if (!jitiInstance) jitiInstance = createJiti(import.meta.url);
+  return jitiInstance;
+}
+
+/**
+ * Load an integration template doc module. `.ts` is loaded via jiti; `.mjs`/
+ * `.js` via dynamic import. The doc may be the default export (e.g.
+ * `export default createPageTemplate({...})`) or a named `doc` export.
+ *
+ * @param {string} file
+ */
+async function loadIntegrationDoc(file) {
+  const mod = file.endsWith('.ts')
+    ? await getJiti().import(file)
+    : await import(pathToFileURL(file).href);
+  return mod.default ?? mod.doc ?? null;
+}
 
 const TEMPLATES_DIR = path.join(CLI_ROOT, 'templates');
 const PAGES_DIR = path.join(TEMPLATES_DIR, 'pages');
@@ -189,12 +218,160 @@ async function discoverAllBlocks(cwd = process.cwd()) {
   return [...core, ...external];
 }
 
-async function discoverAll() {
-  const [pages, blocks] = await Promise.all([
+async function discoverAll(cwd = process.cwd()) {
+  const [pages, blocks, integration] = await Promise.all([
     discoverPages(),
-    discoverAllBlocks(),
+    discoverAllBlocks(cwd),
+    discoverIntegrationTemplates(cwd),
   ]);
-  return [...pages, ...blocks].sort((a, b) => a.name.localeCompare(b.name));
+  return [...pages, ...blocks, ...integration.templates].sort((a, b) =>
+    a.name.localeCompare(b.name),
+  );
+}
+
+/**
+ * Like {@link discoverAll} but also returns integration-template discovery
+ * errors (missing same-stem source, missing `type`, load failure). Use this
+ * when the caller wants to warn about malformed integration templates.
+ *
+ * @param {string} [cwd]
+ * @returns {Promise<{templates: object[], errors: {package: string, template?: string, message: string}[]}>}
+ */
+async function discoverAllWithErrors(cwd = process.cwd()) {
+  const [pages, blocks, integration] = await Promise.all([
+    discoverPages(),
+    discoverAllBlocks(cwd),
+    discoverIntegrationTemplates(cwd),
+  ]);
+  const templates = [...pages, ...blocks, ...integration.templates].sort(
+    (a, b) => a.name.localeCompare(b.name),
+  );
+  return {templates, errors: integration.errors};
+}
+
+export {discoverAllWithErrors};
+
+/**
+ * Recursively collect integration template doc files under `root`.
+ * Returns absolute paths to files ending in one of DOC_SUFFIXES.
+ *
+ * @param {string} root
+ * @returns {string[]}
+ */
+function findIntegrationDocFiles(root) {
+  const results = [];
+  if (!fs.existsSync(root)) return results;
+  const walk = dir => {
+    for (const entry of fs.readdirSync(dir, {withFileTypes: true})) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+      } else if (DOC_SUFFIXES.some(suffix => entry.name.endsWith(suffix))) {
+        results.push(full);
+      }
+    }
+  };
+  walk(root);
+  return results;
+}
+
+/**
+ * The doc-file suffix present on `file`, or null if none matches.
+ * @param {string} file
+ */
+function matchedDocSuffix(file) {
+  return DOC_SUFFIXES.find(suffix => file.endsWith(suffix)) ?? null;
+}
+
+/**
+ * Discover templates contributed by configured integrations.
+ *
+ * For each integration with a resolved `templates` root, every
+ * `<id>.doc.{ts,mjs,js}` file is a template whose id is its path relative to
+ * the templates root with the `.doc.*` suffix stripped (kebab-case, may be
+ * nested). The doc's `type` (page|block) decides scaffolding — there is no
+ * `/pages` vs `/blocks` requirement. A same-stem sibling source file
+ * (`<id>.tsx`) is required; a doc missing its source, or missing `type`, is
+ * an integration error and that template is skipped (recorded in `errors`).
+ *
+ * @param {string} [cwd]
+ * @returns {Promise<{templates: object[], errors: {package: string, template?: string, message: string}[]}>}
+ */
+async function discoverIntegrationTemplates(cwd = process.cwd()) {
+  const templates = [];
+  const errors = [];
+
+  let loadedIntegrations;
+  try {
+    const config = await loadConfig(cwd);
+    loadedIntegrations = config.loadedIntegrations ?? [];
+  } catch {
+    // Config load failures are surfaced elsewhere (discover/doctor); here we
+    // simply contribute no integration templates.
+    return {templates, errors};
+  }
+
+  for (const integration of loadedIntegrations) {
+    const root = integration.templates;
+    if (!root || !fs.existsSync(root)) continue;
+
+    for (const docPath of findIntegrationDocFiles(root)) {
+      const suffix = matchedDocSuffix(docPath);
+      const id = path
+        .relative(root, docPath)
+        .slice(0, -suffix.length)
+        .split(path.sep)
+        .join('/');
+
+      const sourcePath = docPath.slice(0, -suffix.length) + '.tsx';
+      if (!fs.existsSync(sourcePath)) {
+        errors.push({
+          package: integration.name,
+          template: id,
+          message: `Template "${id}" is missing its same-stem source file ${path.basename(sourcePath)}.`,
+        });
+        continue;
+      }
+
+      let doc;
+      try {
+        doc = await loadIntegrationDoc(docPath);
+      } catch (err) {
+        errors.push({
+          package: integration.name,
+          template: id,
+          message: `Template "${id}" failed to load: ${err.message}`,
+        });
+        continue;
+      }
+
+      const type = doc?.type;
+      if (type !== 'page' && type !== 'block') {
+        errors.push({
+          package: integration.name,
+          template: id,
+          message: `Template "${id}" is missing a "type" of "page" or "block". Author it with createPageTemplate/createBlockTemplate.`,
+        });
+        continue;
+      }
+
+      templates.push({
+        type,
+        dirName: id,
+        name: doc?.name || id,
+        description: doc?.description || '',
+        category: doc?.category || '',
+        isReady: true,
+        scaffold: false,
+        componentsUsed: doc?.componentsUsed ?? [],
+        filePath: sourcePath,
+        docPath,
+        package: integration.name,
+      });
+    }
+  }
+
+  return {templates, errors};
 }
 
 export async function findRelatedBlocks(componentName, cwd) {
@@ -493,7 +670,8 @@ function extractSkeleton(source) {
  * @param {boolean} [options.list]
  * @param {boolean} [options.skeleton]
  * @param {boolean} [options.show]
- * @param {'page'|'block'} [options.type] - Filter list views by template kind.
+ * @param {'page'|'block'} [options.type] - Filter list views / narrow lookups by template kind.
+ * @param {string} [options.package] - Narrow lookups to a specific package (id-only matches across packages are ambiguous).
  * @param {string} [options.cwd]
  * @returns {Promise<{type: string, data: unknown}>}
  */
@@ -504,34 +682,65 @@ export async function template(name, options = {}) {
     show = false,
     targetPath,
     type,
+    package: packageFilter,
     cwd = process.cwd(),
   } = options;
-  const templates = await discoverAll();
+  const templates = await discoverAll(cwd);
+
+  /**
+   * Identity for a template in package-scoped views. Core (built-in)
+   * templates have no `package` field; report them under @astryxdesign/core.
+   * @param {{package?: string}} t
+   */
+  const pkgOf = t => t.package ?? CORE_PACKAGE;
 
   if (list || (!name && !skeleton)) {
     let filtered = templates;
-    if (type) filtered = templates.filter(t => t.type === type);
+    if (type) filtered = filtered.filter(t => t.type === type);
+    if (packageFilter) filtered = filtered.filter(t => pkgOf(t) === packageFilter);
     return {
       type: 'template.list',
       data: filtered.map(t => ({
-        name: t.dirName,
+        id: t.dirName,
+        name: t.name,
+        // `displayName` retained for back-compat with existing consumers.
         displayName: t.name,
         description: t.description,
+        type: t.type,
+        package: pkgOf(t),
+        category: t.category || undefined,
+        componentsUsed: t.componentsUsed ?? undefined,
         isReady: t.isReady,
         scaffold: t.scaffold ?? false,
-        type: t.type,
       })),
     };
   }
 
-  const match = templates.find(t => t.dirName === name);
-  if (name && !match) {
+  // Resolve `name` to a single template. The same id can appear across types
+  // and/or packages (e.g. a core "hero" page and an integration "hero"
+  // block); narrow with --type / --package.
+  let candidates = templates.filter(t => t.dirName === name);
+  if (type) candidates = candidates.filter(t => t.type === type);
+  if (packageFilter) candidates = candidates.filter(t => pkgOf(t) === packageFilter);
+
+  if (name && candidates.length === 0) {
     throw new AstryxError(
       `Unknown template "${name}"`,
       templates.map(t => ({name: t.dirName, reason: `${t.type} template`})),
       ERROR_CODES.ERR_UNKNOWN_TEMPLATE,
     );
   }
+  if (name && candidates.length > 1) {
+    throw new AstryxError(
+      `Template "${name}" is ambiguous — narrow it with --type and/or --package.`,
+      candidates.map(t => ({
+        name: t.dirName,
+        reason: `${t.type} template in ${pkgOf(t)}`,
+      })),
+      ERROR_CODES.ERR_AMBIGUOUS_TEMPLATE,
+    );
+  }
+  const match = candidates[0];
 
   if (skeleton) {
     if (!match) {

--- a/packages/cli/src/commands/template.mjs
+++ b/packages/cli/src/commands/template.mjs
@@ -29,6 +29,7 @@ export function registerTemplate(program) {
     .description('Inject a page or block template')
     .option('--list', 'List available templates')
     .option('--type <type>', 'Filter by template type: page or block')
+    .option('--package <pkg>', 'Narrow to templates from a specific package')
     .option('--skeleton', 'Show layout skeleton with spatial annotations (padding, gap, nesting)')
     .option('-f, --overwrite', 'Overwrite existing files without prompting')
     .action(async (name, targetPath, options) => {
@@ -72,6 +73,7 @@ export function registerTemplate(program) {
           list: options.list,
           skeleton: options.skeleton,
           type: options.type,
+          package: options.package,
           targetPath,
           cwd: process.cwd(),
         });
@@ -88,26 +90,28 @@ export function registerTemplate(program) {
         case 'template.list': {
           const pages = result.data.filter(t => t.type === 'page');
           const blocks = result.data.filter(t => t.type === 'block');
+          const renderEntry = t => {
+            const status = t.isReady ? '' : ' (WIP)';
+            const pkg =
+              t.package && t.package !== '@astryxdesign/core'
+                ? `  [${t.package}]`
+                : '';
+            humanLog(`  ${t.name}${status}${pkg}`);
+            if (t.description) humanLog(`    ${t.description}`);
+          };
           if (pages.length > 0) {
             humanLog('\nPage Templates:\n');
-            for (const t of pages) {
-              const status = t.isReady ? '' : ' (WIP)';
-              humanLog(`  ${t.name}${status}`);
-              if (t.description) humanLog(`    ${t.description}`);
-            }
+            for (const t of pages) renderEntry(t);
           }
           if (blocks.length > 0) {
             humanLog('\nBlock Templates:\n');
-            for (const t of blocks) {
-              const status = t.isReady ? '' : ' (WIP)';
-              humanLog(`  ${t.name}${status}`);
-              if (t.description) humanLog(`    ${t.description}`);
-            }
+            for (const t of blocks) renderEntry(t);
           }
           humanLog('\nUsage:');
-          humanLog('  astryx template <name> [target-path]   Scaffold page or block');
-          humanLog('  astryx template <name> --skeleton      Layout reference');
-          humanLog('  astryx template --list --type block    List only blocks\n');
+          humanLog('  astryx template <id> [target-path]     Scaffold page or block');
+          humanLog('  astryx template <id> --skeleton        Layout reference');
+          humanLog('  astryx template --list --type block    List only blocks');
+          humanLog('  astryx template --list --package <pkg> List from one package\n');
           break;
         }
 
@@ -148,7 +152,7 @@ async function detectTemplateCollision(name, targetPath) {
   const {discoverTemplates} = await import('../api/template.mjs');
   let templates;
   try {
-    templates = await discoverTemplates();
+    templates = await discoverTemplates(process.cwd());
   } catch {
     return null;
   }

--- a/packages/cli/src/lib/error-codes.mjs
+++ b/packages/cli/src/lib/error-codes.mjs
@@ -52,6 +52,7 @@
  *   | 'ERR_UNKNOWN_SECTION'
  *   | 'ERR_UNKNOWN_CATEGORY'
  *   | 'ERR_UNKNOWN_TEMPLATE'
+ *   | 'ERR_AMBIGUOUS_TEMPLATE'
  *   | 'ERR_UNKNOWN_THEME'
  *   | 'ERR_UNKNOWN_PACKAGE'
  *   | 'ERR_UNKNOWN_AGENT'
@@ -122,6 +123,8 @@ export const ERROR_CODES = Object.freeze({
   ERR_UNKNOWN_CATEGORY: 'ERR_UNKNOWN_CATEGORY',
   /** No template matched the requested name. */
   ERR_UNKNOWN_TEMPLATE: 'ERR_UNKNOWN_TEMPLATE',
+  /** A template id matched more than one template (narrow with --type/--package). */
+  ERR_AMBIGUOUS_TEMPLATE: 'ERR_AMBIGUOUS_TEMPLATE',
   /** No theme matched the requested slug (theme add). */
   ERR_UNKNOWN_THEME: 'ERR_UNKNOWN_THEME',
   /** No package matched the requested name (discover). */

--- a/packages/cli/src/template.mjs
+++ b/packages/cli/src/template.mjs
@@ -1,0 +1,80 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Static template authoring API.
+ *
+ * Helpers for authoring Astryx page/block template docs. Like
+ * `createConfig`/`createIntegration`, these are tiny runtime
+ * validate-and-return helpers whose real value is the exported TypeScript
+ * surface from `@astryxdesign/cli/template`. They inject the discriminant
+ * `type` so a discovered doc always knows whether it is a page or a block.
+ */
+
+import {z} from 'zod';
+
+const PreviewSchema = z
+  .object({
+    image: z.string().optional(),
+    aspectRatio: z.string().optional(),
+  })
+  .strict();
+
+/**
+ * Shared authored-template shape. `type` is injected by the create* helpers,
+ * so authors never write it. Inline source/sourceFile are intentionally NOT
+ * part of v1 — a template's source is the required same-stem sibling file.
+ */
+const BaseTemplateSchema = z
+  .object({
+    name: z.string().min(1, 'name is required'),
+    description: z.string().min(1, 'description is required'),
+    category: z.string().optional(),
+    componentsUsed: z.array(z.string()).optional(),
+    preview: PreviewSchema.optional(),
+  })
+  .strict();
+
+/**
+ * @param {'page'|'block'} type
+ * @param {unknown} def
+ * @param {string} label
+ */
+function validateTemplate(type, def, label) {
+  const result = BaseTemplateSchema.safeParse(def);
+  if (!result.success) {
+    const issues = result.error.issues
+      .map(issue => {
+        const path = issue.path.length ? issue.path.join('.') : '(root)';
+        return `${path}: ${issue.message}`;
+      })
+      .join('; ');
+    throw new Error(`${label} is invalid: ${issues}`);
+  }
+  return {...result.data, type};
+}
+
+/**
+ * Author an Astryx page template doc.
+ *
+ * @template {import('./types/template-api').AstryxPageTemplateInput} T
+ * @param {T} def
+ * @returns {T & {type: 'page'}}
+ */
+export function createPageTemplate(def) {
+  return /** @type {T & {type: 'page'}} */ (
+    validateTemplate('page', def, 'page template')
+  );
+}
+
+/**
+ * Author an Astryx block template doc.
+ *
+ * @template {import('./types/template-api').AstryxBlockTemplateInput} T
+ * @param {T} def
+ * @returns {T & {type: 'block'}}
+ */
+export function createBlockTemplate(def) {
+  return /** @type {T & {type: 'block'}} */ (
+    validateTemplate('block', def, 'block template')
+  );
+}

--- a/packages/cli/src/template.test.mjs
+++ b/packages/cli/src/template.test.mjs
@@ -1,0 +1,80 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {describe, it, expect} from 'vitest';
+import {createPageTemplate, createBlockTemplate} from './template.mjs';
+
+describe('createPageTemplate', () => {
+  it('returns the def with type "page" injected', () => {
+    const t = createPageTemplate({
+      name: 'Landing',
+      description: 'A landing page.',
+    });
+    expect(t).toEqual({
+      name: 'Landing',
+      description: 'A landing page.',
+      type: 'page',
+    });
+  });
+
+  it('preserves optional fields', () => {
+    const t = createPageTemplate({
+      name: 'Landing',
+      description: 'A landing page.',
+      category: 'Marketing',
+      componentsUsed: ['Button', 'Card'],
+      preview: {image: './preview.png', aspectRatio: '16 / 9'},
+    });
+    expect(t.category).toBe('Marketing');
+    expect(t.componentsUsed).toEqual(['Button', 'Card']);
+    expect(t.preview).toEqual({image: './preview.png', aspectRatio: '16 / 9'});
+    expect(t.type).toBe('page');
+  });
+
+  it('throws when name is missing', () => {
+    expect(() => createPageTemplate({description: 'x'})).toThrow(/name/);
+  });
+
+  it('throws when description is missing', () => {
+    expect(() => createPageTemplate({name: 'x'})).toThrow(/description/);
+  });
+
+  it('throws when name is an empty string', () => {
+    expect(() => createPageTemplate({name: '', description: 'x'})).toThrow(
+      /name/,
+    );
+  });
+
+  it('hard-errors on unknown keys', () => {
+    expect(() =>
+      createPageTemplate({name: 'x', description: 'y', source: './x.tsx'}),
+    ).toThrow();
+  });
+
+  it('rejects inline sourceFile (not supported in v1)', () => {
+    expect(() =>
+      createPageTemplate({name: 'x', description: 'y', sourceFile: './x.tsx'}),
+    ).toThrow();
+  });
+});
+
+describe('createBlockTemplate', () => {
+  it('returns the def with type "block" injected', () => {
+    const t = createBlockTemplate({
+      name: 'Hero',
+      description: 'A hero block.',
+    });
+    expect(t.type).toBe('block');
+    expect(t.name).toBe('Hero');
+  });
+
+  it('throws when required fields are missing', () => {
+    expect(() => createBlockTemplate({name: 'Hero'})).toThrow(/description/);
+    expect(() => createBlockTemplate({description: 'x'})).toThrow(/name/);
+  });
+
+  it('hard-errors on unknown keys', () => {
+    expect(() =>
+      createBlockTemplate({name: 'x', description: 'y', bogus: 1}),
+    ).toThrow();
+  });
+});

--- a/packages/cli/src/types/api.d.ts
+++ b/packages/cli/src/types/api.d.ts
@@ -137,6 +137,8 @@ export interface TemplateOptions {
   show?: boolean;
   /** Filter templates by kind: 'page' or 'block'. Only applies to list views. */
   type?: 'page' | 'block';
+  /** Narrow to templates from a specific package (id-only lookups across packages are ambiguous). */
+  package?: string;
   targetPath?: string;
   cwd?: string;
 }

--- a/packages/cli/src/types/template-api.d.ts
+++ b/packages/cli/src/types/template-api.d.ts
@@ -1,0 +1,54 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * Authoring surface for Astryx static templates, exported from
+ * `@astryxdesign/cli/template`.
+ *
+ * A template doc lives in a `<id>.doc.{ts,mjs,js}` file with a required
+ * same-stem sibling source file (`<id>.tsx`). The doc's `type` (page or
+ * block) — injected by the create* helpers — decides how the template is
+ * scaffolded; there is no `/pages` vs `/blocks` directory requirement.
+ */
+
+/** Optional preview metadata for a template (used by docs surfaces). */
+export interface AstryxTemplatePreview {
+  /** Path or URL to a preview image. */
+  image?: string;
+  /** CSS aspect-ratio hint for the preview, e.g. "16 / 9". */
+  aspectRatio?: string;
+}
+
+/** Fields common to page and block template docs (without the `type` tag). */
+export interface AstryxTemplateInput {
+  /** Human-readable template name. Required. */
+  name: string;
+  /** One-line description of what the template provides. Required. */
+  description: string;
+  /** Optional grouping/category label. */
+  category?: string;
+  /** Component display names the template composes. */
+  componentsUsed?: string[];
+  /** Optional preview metadata. */
+  preview?: AstryxTemplatePreview;
+}
+
+/** Input accepted by {@link createPageTemplate} (no `type` field). */
+export type AstryxPageTemplateInput = AstryxTemplateInput;
+/** Input accepted by {@link createBlockTemplate} (no `type` field). */
+export type AstryxBlockTemplateInput = AstryxTemplateInput;
+
+/** A validated page template doc. */
+export type AstryxPageTemplate = AstryxTemplateInput & {type: 'page'};
+/** A validated block template doc. */
+export type AstryxBlockTemplate = AstryxTemplateInput & {type: 'block'};
+
+/** A validated template doc (page or block). */
+export type AstryxTemplate = AstryxPageTemplate | AstryxBlockTemplate;
+
+export declare function createPageTemplate<T extends AstryxPageTemplateInput>(
+  def: T,
+): T & {type: 'page'};
+
+export declare function createBlockTemplate<T extends AstryxBlockTemplateInput>(
+  def: T,
+): T & {type: 'block'};

--- a/packages/cli/src/types/template.d.ts
+++ b/packages/cli/src/types/template.d.ts
@@ -21,12 +21,21 @@ export interface TemplateListResponse {
 }
 
 export interface TemplateListEntry {
+  /** Stable template id (relative path under the templates root, minus the .doc.* suffix). */
+  id: string;
   name: string;
+  /** @deprecated Alias of `name`, retained for back-compat. */
   displayName: string;
   description: string;
+  type: 'page' | 'block';
+  /** Owning package; core (built-in) templates report '@astryxdesign/core'. */
+  package: string;
+  /** Optional grouping/category label. */
+  category?: string;
+  /** Component display names the template composes. */
+  componentsUsed?: string[];
   isReady: boolean;
   scaffold?: boolean;
-  type: 'page' | 'block';
 }
 
 /** xds --json template <name> */


### PR DESCRIPTION
## Summary

Adds a static template authoring API and a `@astryxdesign/cli/template` export, plus type-driven, package-scoped discovery for integration-provided templates. Built-in template discovery, the `astryx template` command behavior, and existing tests are unchanged.

## What's in this PR

**Authoring helpers (`@astryxdesign/cli/template`)**
- `createPageTemplate(def)` / `createBlockTemplate(def)` — tiny validate-and-return helpers (zod-backed) that require `name` + `description`, hard-error on unknown keys, and inject the discriminant `type` (`page` | `block`). No inline `source`/`sourceFile` in v1 — a template's source is its required same-stem sibling file.
- New `./template` subpath export and `src/types/template-api.d.ts` (`AstryxTemplate`, `AstryxPageTemplate`, `AstryxBlockTemplate`, and the two create fns).

**Integration template discovery**
- For an integration's resolved `templates` root, a template id is the relative path under that root with the `.doc.*` suffix stripped (kebab-case, may be nested). A same-stem `<id>.tsx` source is required next to `<id>.doc.{ts,mjs,js}`.
- The doc's `type` decides page vs block — no `/pages` or `/blocks` directory requirement.
- A doc missing its same-stem source, or a raw doc missing `type`, is an integration error and that template is skipped.

**Command UX**
- `astryx template [id] [path]`, `--list`, `--type page|block`, `--package <pkg>`.
- An id that matches more than one template across type/package errors with the candidate list; `--type`/`--package` narrow it.
- JSON list entries always include `id`, `name`, `description`, `type`, and `package` (core templates report `@astryxdesign/core`), plus optional `category` / `componentsUsed`.
- Copy-to-dir: a directory target writes `page.tsx` for pages and `<id-basename>.tsx` for blocks; built-in behavior preserved.

## Testing
- Unit tests for `createPageTemplate` / `createBlockTemplate` validation.
- Integration tests with a temp integration package: discovery + listing with package/type, nested ids, missing-source skip, missing-type skip, ambiguity error, and copy-to-dir naming.
- Full `packages/cli` suite green (1504 tests). `sync-exports --check`, copyright check, `typecheck:json-api`, `typecheck:template-docs`, core build + `verify-exports`, and eslint on changed files all pass.
