### PR TITLE
feat(cli): file-based codemod API and /codemod export

### DIFF
--- a/.changeset/file-based-codemods.md
+++ b/.changeset/file-based-codemods.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[feat] File-based codemod API (createCodemod/createConfigCodemod) with the @astryxdesign/cli/codemod export and integration codemod discovery in upgrade.
+
+@ejhammond

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -51,6 +51,10 @@
       "types": "./src/types/template-api.d.ts",
       "import": "./src/template.mjs"
     },
+    "./codemod": {
+      "types": "./src/types/codemod.d.ts",
+      "import": "./src/codemod.mjs"
+    },
     "./xle": {
       "types": "./src/lib/xle/browser.d.ts",
       "import": "./src/lib/xle/browser.mjs"

--- a/packages/cli/src/codemod.mjs
+++ b/packages/cli/src/codemod.mjs
@@ -1,0 +1,82 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Public file-based codemod-authoring API.
+ *
+ * Integrations (and core) author codemods as standalone modules that
+ * default-export a `createCodemod(...)` or `createConfigCodemod(...)` result.
+ * These helpers validate the definition at authoring time and stamp a `type`
+ * discriminator (`'code'` | `'config'`) consumed by integration codemod
+ * discovery during `astryx upgrade`.
+ */
+
+import {z} from 'zod';
+
+const Fn = z.custom(value => typeof value === 'function', {
+  message: 'Expected a function',
+});
+
+const CodemodSchema = z
+  .object({
+    title: z.string(),
+    description: z.string().optional(),
+    isOptional: z.boolean().optional().default(false),
+    fileExtensions: z.array(z.string()).optional(),
+    transform: Fn,
+  })
+  .strict();
+
+const ConfigCodemodSchema = z
+  .object({
+    title: z.string(),
+    description: z.string().optional(),
+    isOptional: z.boolean().optional().default(false),
+    transform: Fn,
+  })
+  .strict();
+
+/**
+ * @param {string} label
+ * @param {import('zod').ZodError} error
+ */
+function formatZodError(label, error) {
+  const issues = error.issues
+    .map(issue => {
+      const path = issue.path.length ? issue.path.join('.') : '(root)';
+      return `${path}: ${issue.message}`;
+    })
+    .join('; ');
+  return `${label} is invalid: ${issues}`;
+}
+
+/**
+ * Define a file-transforming codemod.
+ *
+ * @template {import('./types/codemod').AstryxCodemodDef} T
+ * @param {T} def
+ * @returns {import('./types/codemod').AstryxCodemod}
+ */
+export function createCodemod(def) {
+  const result = CodemodSchema.safeParse(def);
+  if (!result.success) {
+    throw new Error(formatZodError('createCodemod definition', result.error));
+  }
+  return {...result.data, type: 'code'};
+}
+
+/**
+ * Define a codemod that targets the consumer's astryx.config.* file.
+ *
+ * @template {import('./types/codemod').AstryxConfigCodemodDef} T
+ * @param {T} def
+ * @returns {import('./types/codemod').AstryxConfigCodemod}
+ */
+export function createConfigCodemod(def) {
+  const result = ConfigCodemodSchema.safeParse(def);
+  if (!result.success) {
+    throw new Error(
+      formatZodError('createConfigCodemod definition', result.error),
+    );
+  }
+  return {...result.data, type: 'config'};
+}

--- a/packages/cli/src/codemod.test.mjs
+++ b/packages/cli/src/codemod.test.mjs
@@ -1,0 +1,87 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {describe, expect, it} from 'vitest';
+import {createCodemod, createConfigCodemod} from './codemod.mjs';
+
+describe('createCodemod', () => {
+  it('returns the definition stamped with type: code and isOptional default', () => {
+    const transform = file => file.source;
+    const result = createCodemod({title: 'Drop foo', transform});
+    expect(result.type).toBe('code');
+    expect(result.title).toBe('Drop foo');
+    expect(result.transform).toBe(transform);
+    expect(result.isOptional).toBe(false);
+  });
+
+  it('preserves description, fileExtensions, and explicit isOptional', () => {
+    const result = createCodemod({
+      title: 'Rename',
+      description: 'renames things',
+      isOptional: true,
+      fileExtensions: ['.tsx'],
+      transform: () => null,
+    });
+    expect(result.description).toBe('renames things');
+    expect(result.isOptional).toBe(true);
+    expect(result.fileExtensions).toEqual(['.tsx']);
+  });
+
+  it('throws when title is missing', () => {
+    expect(() => createCodemod({transform: () => null})).toThrow(/title/i);
+  });
+
+  it('throws when transform is missing', () => {
+    expect(() => createCodemod({title: 'x'})).toThrow(/transform/i);
+  });
+
+  it('throws when transform is not a function', () => {
+    expect(() => createCodemod({title: 'x', transform: 'nope'})).toThrow(
+      /transform/i,
+    );
+  });
+
+  it('throws on unknown keys', () => {
+    expect(() =>
+      createCodemod({title: 'x', transform: () => null, bogus: true}),
+    ).toThrow();
+  });
+});
+
+describe('createConfigCodemod', () => {
+  it('returns the definition stamped with type: config', () => {
+    const transform = file => file.source;
+    const result = createConfigCodemod({title: 'Config bump', transform});
+    expect(result.type).toBe('config');
+    expect(result.isOptional).toBe(false);
+    expect(result.transform).toBe(transform);
+  });
+
+  it('throws when title is missing', () => {
+    expect(() => createConfigCodemod({transform: () => null})).toThrow(
+      /title/i,
+    );
+  });
+
+  it('throws when transform is missing or not a function', () => {
+    expect(() => createConfigCodemod({title: 'x'})).toThrow(/transform/i);
+    expect(() =>
+      createConfigCodemod({title: 'x', transform: 42}),
+    ).toThrow(/transform/i);
+  });
+
+  it('rejects fileExtensions (config codemods target astryx.config.* only)', () => {
+    expect(() =>
+      createConfigCodemod({
+        title: 'x',
+        transform: () => null,
+        fileExtensions: ['.ts'],
+      }),
+    ).toThrow();
+  });
+
+  it('throws on unknown keys', () => {
+    expect(() =>
+      createConfigCodemod({title: 'x', transform: () => null, bogus: 1}),
+    ).toThrow();
+  });
+});

--- a/packages/cli/src/codemods/integration-discovery.mjs
+++ b/packages/cli/src/codemods/integration-discovery.mjs
@@ -1,0 +1,213 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Integration codemod discovery.
+ *
+ * Integrations may declare a `codemods` directory in their manifest. The
+ * directory layout is version-folder-first:
+ *
+ *   <codemodsRoot>/<version>/<id>.<ext>
+ *
+ * where `<version>` is the immediate folder name (e.g. "0.2.0") and `<id>` is
+ * the codemod module's relative path under that version folder WITHOUT its
+ * extension (kebab-case; may include nested segments like "config/rename").
+ * Each module DEFAULT-EXPORTS a `createCodemod` / `createConfigCodemod`
+ * result.
+ *
+ * Version selection mirrors the core registry's getTransformsBetween(from,to):
+ * a codemod under folder X runs when upgrading to include X.
+ *
+ * Strictness: any broken discovery (bad/missing default export, schema
+ * invalid, duplicate id) is a hard error so the upgrade fails loudly rather
+ * than silently skipping migrations.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {pathToFileURL} from 'node:url';
+import {createJiti} from 'jiti';
+import {semverCompare} from '../utils/semver.mjs';
+
+/** File extensions recognized as codemod modules. */
+const CODEMOD_EXTENSIONS = ['.ts', '.mjs', '.js'];
+
+let jitiInstance;
+function getJiti() {
+  if (!jitiInstance) {
+    jitiInstance = createJiti(import.meta.url);
+  }
+  return jitiInstance;
+}
+
+/**
+ * Import a codemod module. `.ts` is loaded via jiti; `.mjs`/`.js` via dynamic
+ * import.
+ * @param {string} file
+ */
+async function importCodemodModule(file) {
+  if (file.endsWith('.ts')) {
+    return await getJiti().import(file);
+  }
+  return await import(pathToFileURL(file).href);
+}
+
+/**
+ * Recursively collect codemod module files under a version folder. Returns
+ * entries of {id, file} where id is the extension-less relative path
+ * (POSIX-style) under `versionDir`.
+ * @param {string} versionDir
+ * @returns {Array<{id: string, file: string}>}
+ */
+function collectCodemodFiles(versionDir) {
+  const out = [];
+
+  /** @param {string} dir */
+  function walk(dir) {
+    const entries = fs.readdirSync(dir, {withFileTypes: true});
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name === 'node_modules' || entry.name === '.git') continue;
+        walk(full);
+        continue;
+      }
+      const ext = path.extname(entry.name);
+      if (!CODEMOD_EXTENSIONS.includes(ext)) continue;
+      const rel = path.relative(versionDir, full);
+      const id = rel.slice(0, rel.length - ext.length).split(path.sep).join('/');
+      out.push({id, file: full});
+    }
+  }
+
+  walk(versionDir);
+  return out.sort((a, b) => a.id.localeCompare(b.id));
+}
+
+/**
+ * Validate that a module's default export is a createCodemod/
+ * createConfigCodemod result.
+ * @param {unknown} mod
+ * @param {string} label
+ * @returns {import('../types/codemod').AstryxCodemod | import('../types/codemod').AstryxConfigCodemod}
+ */
+function validateCodemodExport(mod, label) {
+  const exported = mod?.default;
+  if (!exported || typeof exported !== 'object') {
+    throw new Error(
+      `${label} must default-export a createCodemod/createConfigCodemod result.`,
+    );
+  }
+  if (exported.type !== 'code' && exported.type !== 'config') {
+    throw new Error(
+      `${label} default export is not a valid codemod (expected createCodemod or createConfigCodemod result).`,
+    );
+  }
+  if (typeof exported.title !== 'string' || exported.title.length === 0) {
+    throw new Error(`${label} codemod is missing a title.`);
+  }
+  if (typeof exported.transform !== 'function') {
+    throw new Error(`${label} codemod is missing a transform function.`);
+  }
+  return exported;
+}
+
+/**
+ * Discover file-based codemods contributed by configured integrations.
+ *
+ * @param {Array<{name?: string, codemods?: string, __spec?: string}>} loadedIntegrations
+ * @returns {Promise<Map<string, Array<{id: string, type: 'code'|'config', codemod: object, package: string}>>>}
+ *   Map keyed by version string; each value is the list of discovered codemods
+ *   for that version (across all integrations).
+ */
+export async function discoverIntegrationCodemods(loadedIntegrations = []) {
+  /** @type {Map<string, Array<{id: string, type: string, codemod: object, package: string}>>} */
+  const byVersion = new Map();
+
+  for (const integration of loadedIntegrations ?? []) {
+    const root = integration?.codemods;
+    if (!root) continue;
+
+    const pkgLabel = integration.name ?? integration.__spec ?? 'integration';
+
+    if (!fs.existsSync(root) || !fs.statSync(root).isDirectory()) {
+      throw new Error(
+        `Integration "${pkgLabel}" declares a codemods directory that does not exist: ${root}`,
+      );
+    }
+
+    const versionFolders = fs
+      .readdirSync(root, {withFileTypes: true})
+      .filter(entry => entry.isDirectory())
+      .map(entry => entry.name);
+
+    // Track ids seen ACROSS versions within this package — duplicate id across
+    // versions within a package is a hard error (locked decision).
+    /** @type {Map<string, string>} id -> version */
+    const idToVersion = new Map();
+
+    for (const version of versionFolders) {
+      const versionDir = path.join(root, version);
+      const files = collectCodemodFiles(versionDir);
+
+      // Track ids within this package+version to catch same-version dupes.
+      const seenInVersion = new Set();
+
+      for (const {id, file} of files) {
+        const label = `Integration "${pkgLabel}" codemod ${version}/${id} (${file})`;
+
+        if (seenInVersion.has(id)) {
+          throw new Error(
+            `Integration "${pkgLabel}" has a duplicate codemod id "${id}" within version ${version}.`,
+          );
+        }
+        seenInVersion.add(id);
+
+        const priorVersion = idToVersion.get(id);
+        if (priorVersion != null && priorVersion !== version) {
+          throw new Error(
+            `Integration "${pkgLabel}" reuses codemod id "${id}" across versions ${priorVersion} and ${version}. Codemod ids must be unique within a package.`,
+          );
+        }
+        idToVersion.set(id, version);
+
+        const mod = await importCodemodModule(file);
+        const codemod = validateCodemodExport(mod, label);
+
+        const entry = {
+          id,
+          type: codemod.type,
+          codemod,
+          package: pkgLabel,
+        };
+        const list = byVersion.get(version);
+        if (list) {
+          list.push(entry);
+        } else {
+          byVersion.set(version, [entry]);
+        }
+      }
+    }
+  }
+
+  return byVersion;
+}
+
+/**
+ * Select discovered integration codemods that apply when upgrading from
+ * `from` (exclusive) to `to` (inclusive), ordered ascending by version.
+ *
+ * @param {Map<string, Array<object>>} byVersion
+ * @param {string} from
+ * @param {string} to
+ * @returns {Array<{version: string, codemods: Array<object>}>}
+ */
+export function selectIntegrationCodemods(byVersion, from, to) {
+  const versions = [...byVersion.keys()].sort(semverCompare);
+  const results = [];
+  for (const version of versions) {
+    if (semverCompare(version, from) > 0 && semverCompare(version, to) <= 0) {
+      results.push({version, codemods: byVersion.get(version)});
+    }
+  }
+  return results;
+}

--- a/packages/cli/src/codemods/integration-discovery.test.mjs
+++ b/packages/cli/src/codemods/integration-discovery.test.mjs
@@ -1,0 +1,198 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {pathToFileURL} from 'node:url';
+import {loadConfig} from '../lib/config.mjs';
+import {
+  discoverIntegrationCodemods,
+  selectIntegrationCodemods,
+} from './integration-discovery.mjs';
+import {runIntegrationCodemods} from './integration-runner.mjs';
+
+let tmpDir;
+let originalCwd;
+
+/**
+ * Build a consumer project with an astryx.config.mjs that loads a single
+ * integration package, and the integration package itself (manifest +
+ * codemods dir). `codemodFiles` maps "<version>/<id>.mjs" -> file body.
+ */
+function scaffold(codemodFiles) {
+  fs.writeFileSync(
+    path.join(tmpDir, 'package.json'),
+    JSON.stringify({name: 'consumer'}),
+  );
+  fs.writeFileSync(
+    path.join(tmpDir, 'astryx.config.mjs'),
+    `export default { integrations: ['@acme/widgets'] };\n`,
+  );
+
+  const pkgDir = path.join(tmpDir, 'node_modules', '@acme', 'widgets');
+  fs.mkdirSync(pkgDir, {recursive: true});
+  fs.writeFileSync(
+    path.join(pkgDir, 'package.json'),
+    JSON.stringify({name: '@acme/widgets', version: '1.0.0'}),
+  );
+  fs.writeFileSync(
+    path.join(pkgDir, 'astryx.integration.mjs'),
+    `export default { codemods: './codemods' };\n`,
+  );
+
+  for (const [rel, body] of Object.entries(codemodFiles)) {
+    const full = path.join(pkgDir, 'codemods', rel);
+    fs.mkdirSync(path.dirname(full), {recursive: true});
+    fs.writeFileSync(full, body);
+  }
+  return pkgDir;
+}
+
+// Resolve the codemod helper module to an absolute file:// URL so codemod
+// modules in the temp package can import it without node_modules wiring.
+// vitest reports import.meta.url as an http:// URL, so derive the on-disk path
+// from the vitest cwd (the repo root) instead.
+const codemodModulePath = path.resolve(
+  process.cwd(),
+  'packages/cli/src/codemod.mjs',
+);
+const codemodModuleUrl = pathToFileURL(codemodModulePath).href;
+
+beforeEach(() => {
+  originalCwd = process.cwd();
+  tmpDir = fs.mkdtempSync(path.join(process.cwd(), '.astryx-codemod-test-'));
+  process.chdir(tmpDir);
+});
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  fs.rmSync(tmpDir, {recursive: true, force: true});
+});
+
+describe('integration codemod discovery', () => {
+  it('discovers a code codemod and runs it for an applicable --from', async () => {
+    scaffold({
+      '0.2.0/drop-foo.mjs': `
+        import {createCodemod} from ${JSON.stringify(codemodModuleUrl)};
+        export default createCodemod({
+          title: 'Drop foo',
+          transform: (file) => file.source.replace(/foo/g, 'bar'),
+        });
+      `,
+    });
+
+    const config = await loadConfig(tmpDir);
+    expect(config.loadedIntegrations).toHaveLength(1);
+
+    const byVersion = await discoverIntegrationCodemods(
+      config.loadedIntegrations,
+    );
+    expect([...byVersion.keys()]).toEqual(['0.2.0']);
+    const entry = byVersion.get('0.2.0')[0];
+    expect(entry.id).toBe('drop-foo');
+    expect(entry.type).toBe('code');
+    expect(entry.package).toBe('@acme/widgets');
+
+    // Selection: applies upgrading from 0.1.0 -> 0.2.0, not from 0.2.0 -> 0.2.0
+    expect(selectIntegrationCodemods(byVersion, '0.1.0', '0.2.0')).toHaveLength(
+      1,
+    );
+    expect(selectIntegrationCodemods(byVersion, '0.2.0', '0.2.0')).toHaveLength(
+      0,
+    );
+
+    // Run it against a source file.
+    const srcDir = path.join(tmpDir, 'src');
+    fs.mkdirSync(srcDir);
+    fs.writeFileSync(path.join(srcDir, 'a.ts'), 'const foo = 1;\n');
+
+    const jscodeshift = (await import('jscodeshift')).default;
+    const groups = selectIntegrationCodemods(byVersion, '0.1.0', '0.2.0');
+    const result = runIntegrationCodemods(groups, {
+      apply: true,
+      path: './src',
+      jscodeshift,
+      silent: true,
+    });
+    expect(result.errors).toHaveLength(0);
+    expect(result.totalFilesChanged).toBe(1);
+    expect(fs.readFileSync(path.join(srcDir, 'a.ts'), 'utf-8')).toContain(
+      'const bar = 1',
+    );
+  });
+
+  it('discovers and runs a config codemod against astryx.config.*', async () => {
+    scaffold({
+      '0.2.0/bump-config.mjs': `
+        import {createConfigCodemod} from ${JSON.stringify(codemodModuleUrl)};
+        export default createConfigCodemod({
+          title: 'Bump config',
+          transform: (file) => file.source.replace('consumer-old', 'consumer-new'),
+        });
+      `,
+    });
+    // Make the config file a transform target. (loadConfig only needs a valid
+    // default export; the marker string lives in a comment.)
+    fs.writeFileSync(
+      path.join(tmpDir, 'astryx.config.mjs'),
+      `// consumer-old\nexport default { integrations: ['@acme/widgets'] };\n`,
+    );
+
+    const config = await loadConfig(tmpDir);
+    const byVersion = await discoverIntegrationCodemods(
+      config.loadedIntegrations,
+    );
+    expect(byVersion.get('0.2.0')[0].type).toBe('config');
+
+    const jscodeshift = (await import('jscodeshift')).default;
+    const groups = selectIntegrationCodemods(byVersion, '0.1.0', '0.2.0');
+    const result = runIntegrationCodemods(groups, {
+      apply: true,
+      path: './src',
+      jscodeshift,
+      silent: true,
+    });
+    expect(result.errors).toHaveLength(0);
+    expect(result.totalFilesChanged).toBe(1);
+    expect(
+      fs.readFileSync(path.join(tmpDir, 'astryx.config.mjs'), 'utf-8'),
+    ).toContain('consumer-new');
+  });
+
+  it('fails discovery when a codemod has no valid default export', async () => {
+    scaffold({
+      '0.2.0/broken.mjs': `export const notDefault = 1;\n`,
+    });
+    const config = await loadConfig(tmpDir);
+    await expect(
+      discoverIntegrationCodemods(config.loadedIntegrations),
+    ).rejects.toThrow(/default-export/i);
+  });
+
+  it('fails discovery when default export is not a codemod result', async () => {
+    scaffold({
+      '0.2.0/bad.mjs': `export default { title: 'x', transform: () => null };\n`,
+    });
+    const config = await loadConfig(tmpDir);
+    await expect(
+      discoverIntegrationCodemods(config.loadedIntegrations),
+    ).rejects.toThrow(/not a valid codemod/i);
+  });
+
+  it('fails discovery on a duplicate id across versions within a package', async () => {
+    scaffold({
+      '0.2.0/dup.mjs': `
+        import {createCodemod} from ${JSON.stringify(codemodModuleUrl)};
+        export default createCodemod({title: 'a', transform: () => null});
+      `,
+      '0.3.0/dup.mjs': `
+        import {createCodemod} from ${JSON.stringify(codemodModuleUrl)};
+        export default createCodemod({title: 'b', transform: () => null});
+      `,
+    });
+    const config = await loadConfig(tmpDir);
+    await expect(
+      discoverIntegrationCodemods(config.loadedIntegrations),
+    ).rejects.toThrow(/across versions/i);
+  });
+});

--- a/packages/cli/src/codemods/integration-runner.mjs
+++ b/packages/cli/src/codemods/integration-runner.mjs
@@ -1,0 +1,251 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Runner for file-based integration codemods.
+ *
+ * Integration codemods authored with `createCodemod` / `createConfigCodemod`
+ * use the file-based contract `(file, api) => string | null | undefined`.
+ * Config codemods target the consumer's astryx.config.* file; code codemods
+ * are applied to source files discovered under `--path`, filtered by each
+ * codemod's `fileExtensions`.
+ *
+ * Both kinds reuse the shared output validation from runner.mjs and fail the
+ * upgrade if a transform throws (strictness contract).
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as p from '@clack/prompts';
+import {findConfigPath} from '../lib/config.mjs';
+import {fixDirectiveCorruption, validateOutput} from './runner.mjs';
+
+const DEFAULT_CODE_EXTENSIONS = ['.tsx', '.ts', '.jsx', '.js', '.mjs', '.cjs'];
+const PARSEABLE_EXTENSIONS = ['.tsx', '.ts', '.jsx', '.js', '.mjs', '.cjs'];
+
+/**
+ * Recursively find candidate source files in a directory.
+ * @param {string} dir
+ * @returns {string[]}
+ */
+function findSourceFiles(dir) {
+  const results = [];
+  function walk(currentDir) {
+    let entries;
+    try {
+      entries = fs.readdirSync(currentDir, {withFileTypes: true});
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const fullPath = path.join(currentDir, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name === 'node_modules' || entry.name === '.git') continue;
+        walk(fullPath);
+      } else {
+        results.push(fullPath);
+      }
+    }
+  }
+  walk(dir);
+  return results.sort();
+}
+
+function makeLog(silent) {
+  return silent
+    ? {step() {}, info() {}, success() {}, warn() {}, error() {}, message() {}}
+    : p.log;
+}
+
+/**
+ * Apply a config codemod to the consumer's astryx.config.* file.
+ *
+ * @param {object} entry discovered codemod entry {id, codemod, package}
+ * @param {{apply: boolean, log: object, jscodeshift: Function}} ctx
+ * @returns {{filesChanged: number, writtenFiles: string[], errors: Array}}
+ */
+function runConfigCodemod(entry, {apply, log, jscodeshift}) {
+  const {codemod, id, package: pkg} = entry;
+  const name = `${pkg}:${id}`;
+  const configPath = findConfigPath(process.cwd());
+  if (!configPath) {
+    log.info(`  ${codemod.title} — no astryx.config.* found; skipping.`);
+    return {filesChanged: 0, writtenFiles: [], errors: []};
+  }
+
+  const relativePath = path.relative(process.cwd(), configPath);
+  try {
+    const source = fs.readFileSync(configPath, 'utf-8');
+    const ext = path.extname(configPath);
+    const parser = ext === '.tsx' || ext === '.ts' ? 'tsx' : 'babel';
+    const j = jscodeshift.withParser(parser);
+    const api = {jscodeshift: j, stats: () => {}, report: () => {}};
+    let result = codemod.transform({source, path: configPath}, api);
+
+    if (result == null || result === source) {
+      return {filesChanged: 0, writtenFiles: [], errors: []};
+    }
+
+    result = fixDirectiveCorruption(result);
+    const validation = validateOutput(result, source, j, {
+      parse: PARSEABLE_EXTENSIONS.includes(ext),
+    });
+    if (!validation.valid) {
+      log.error(`    ✗ ${relativePath} — ${validation.reason}`);
+      return {
+        filesChanged: 0,
+        writtenFiles: [],
+        errors: [{file: relativePath, codemod: name, error: validation.reason}],
+      };
+    }
+
+    if (apply) {
+      fs.writeFileSync(configPath, result, 'utf-8');
+      log.success(`    ✓ ${relativePath}`);
+    } else {
+      log.warn(`    ~ ${relativePath} (would change)`);
+    }
+    return {filesChanged: 1, writtenFiles: apply ? [configPath] : [], errors: []};
+  } catch (err) {
+    log.error(`    ✗ ${relativePath} — ${err.message}`);
+    return {
+      filesChanged: 0,
+      writtenFiles: [],
+      errors: [{file: relativePath, codemod: name, error: err.message}],
+    };
+  }
+}
+
+/**
+ * Apply a code codemod to discovered source files.
+ *
+ * @param {object} entry discovered codemod entry {id, codemod, package}
+ * @param {string[]} files
+ * @param {{apply: boolean, log: object, jscodeshift: Function}} ctx
+ * @returns {{filesChanged: number, writtenFiles: string[], errors: Array}}
+ */
+function runCodeCodemod(entry, files, {apply, log, jscodeshift}) {
+  const {codemod, id, package: pkg} = entry;
+  const name = `${pkg}:${id}`;
+  const extensions = new Set(codemod.fileExtensions ?? DEFAULT_CODE_EXTENSIONS);
+
+  let filesChanged = 0;
+  const writtenFiles = [];
+  const errors = [];
+
+  for (const filePath of files) {
+    const ext = path.extname(filePath);
+    if (!extensions.has(ext)) continue;
+
+    const relativePath = path.relative(process.cwd(), filePath);
+    try {
+      const source = fs.readFileSync(filePath, 'utf-8');
+      const parser = ext === '.tsx' || ext === '.ts' ? 'tsx' : 'babel';
+      const j = jscodeshift.withParser(parser);
+      const api = {jscodeshift: j, stats: () => {}, report: () => {}};
+      let result = codemod.transform({source, path: filePath}, api);
+
+      if (result == null || result === source) continue;
+
+      result = fixDirectiveCorruption(result);
+      const validation = validateOutput(result, source, j, {
+        parse: PARSEABLE_EXTENSIONS.includes(ext),
+      });
+      if (!validation.valid) {
+        log.error(`    ✗ ${relativePath} — ${validation.reason}`);
+        errors.push({file: relativePath, codemod: name, error: validation.reason});
+        continue;
+      }
+
+      filesChanged++;
+      if (apply) {
+        fs.writeFileSync(filePath, result, 'utf-8');
+        writtenFiles.push(filePath);
+        log.success(`    ✓ ${relativePath}`);
+      } else {
+        log.warn(`    ~ ${relativePath} (would change)`);
+      }
+    } catch (err) {
+      log.error(`    ✗ ${relativePath} — ${err.message}`);
+      errors.push({file: relativePath, codemod: name, error: err.message});
+    }
+  }
+
+  return {filesChanged, writtenFiles, errors};
+}
+
+/**
+ * Run file-based integration codemods, version-ordered. Config codemods run
+ * first (targeting astryx.config.*), then code codemods (source globbing).
+ *
+ * Optional codemods (isOptional) are skipped unless explicitly requested via
+ * `codemod` (matched against the codemod id).
+ *
+ * @param {Array<{version: string, codemods: Array<object>}>} versionGroups
+ * @param {object} options
+ * @param {boolean} options.apply
+ * @param {string} options.path source directory to scan
+ * @param {string} [options.codemod] run only this codemod id
+ * @param {Function} options.jscodeshift
+ * @param {boolean} [options.silent]
+ * @returns {{totalFilesChanged: number, totalTransformsApplied: number, writtenFiles: string[], errors: Array, skippedOptional: Array}}
+ */
+export function runIntegrationCodemods(
+  versionGroups,
+  {apply, path: srcPath, codemod, jscodeshift, silent = false},
+) {
+  const log = makeLog(silent);
+
+  let totalFilesChanged = 0;
+  let totalTransformsApplied = 0;
+  const writtenFiles = [];
+  const errors = [];
+  const skippedOptional = [];
+
+  // Flatten and split by type, preserving version ordering.
+  const configEntries = [];
+  const codeEntries = [];
+  for (const {version, codemods} of versionGroups) {
+    for (const entry of codemods) {
+      const withVersion = {...entry, version};
+      if (entry.codemod.isOptional && !codemod) {
+        skippedOptional.push(withVersion);
+        continue;
+      }
+      if (codemod && entry.id !== codemod) continue;
+      if (entry.type === 'config') configEntries.push(withVersion);
+      else codeEntries.push(withVersion);
+    }
+  }
+
+  // Config codemods first.
+  for (const entry of configEntries) {
+    log.info(`  ${entry.codemod.title} (v${entry.version}, ${entry.package})`);
+    const r = runConfigCodemod(entry, {apply, log, jscodeshift});
+    totalFilesChanged += r.filesChanged;
+    totalTransformsApplied += r.filesChanged;
+    writtenFiles.push(...r.writtenFiles);
+    errors.push(...r.errors);
+  }
+
+  // Then code codemods (only scan the tree if there are any).
+  if (codeEntries.length > 0) {
+    const resolvedPath = path.resolve(srcPath);
+    const files = fs.existsSync(resolvedPath) ? findSourceFiles(resolvedPath) : [];
+    for (const entry of codeEntries) {
+      log.info(`  ${entry.codemod.title} (v${entry.version}, ${entry.package})`);
+      const r = runCodeCodemod(entry, files, {apply, log, jscodeshift});
+      totalFilesChanged += r.filesChanged;
+      totalTransformsApplied += r.filesChanged;
+      writtenFiles.push(...r.writtenFiles);
+      errors.push(...r.errors);
+    }
+  }
+
+  return {
+    totalFilesChanged,
+    totalTransformsApplied,
+    writtenFiles,
+    errors,
+    skippedOptional,
+  };
+}

--- a/packages/cli/src/commands/upgrade.mjs
+++ b/packages/cli/src/commands/upgrade.mjs
@@ -32,6 +32,11 @@ import * as p from '@clack/prompts';
 import {ensureJscodeshift} from '../codemods/ensure-jscodeshift.mjs';
 import {getTransformsBetween, latestVersion} from '../codemods/registry.mjs';
 import {runCodemods} from '../codemods/runner.mjs';
+import {
+  discoverIntegrationCodemods,
+  selectIntegrationCodemods,
+} from '../codemods/integration-discovery.mjs';
+import {runIntegrationCodemods} from '../codemods/integration-runner.mjs';
 import {installAgentDocs, discoverAgentDocs} from './agent-docs.mjs';
 import {getRunPrefix} from '../utils/package-manager.mjs';
 import {isValidSemver, semverGte} from '../utils/semver.mjs';
@@ -237,6 +242,7 @@ export function registerUpgrade(program) {
 
       let integrations;
       let postCodemodHooks;
+      let integrationCodemodsByVersion;
       try {
         const config = await loadConfig(process.cwd());
         postCodemodHooks = config.hooks?.postCodemod ?? [];
@@ -245,6 +251,11 @@ export function registerUpgrade(program) {
           ...(options.integration ?? []),
         ]);
         integrations = await loadIntegrations(integrationSpecs);
+        // Discover file-based integration codemods up front. A broken
+        // integration (bad export, invalid schema, duplicate id) is a hard
+        // error here so the upgrade fails before mutating any files.
+        integrationCodemodsByVersion =
+          await discoverIntegrationCodemods(integrations);
       } catch (err) {
         if (json)
           return jsonError(
@@ -277,13 +288,22 @@ export function registerUpgrade(program) {
         return;
       }
 
-      // Resolve transforms. Integrations no longer contribute codemods here;
-      // file-based integration codemod discovery is a later change.
+      // Resolve transforms. Core built-in codemods come from the registry;
+      // file-based integration codemods are discovered separately and run
+      // alongside them, ordered by version.
       const versionManifests = [
         ...(await getTransformsBetween(currentVersion, targetVersion)),
       ];
+      const integrationVersionGroups = selectIntegrationCodemods(
+        integrationCodemodsByVersion,
+        currentVersion,
+        targetVersion,
+      );
+      const hasIntegrationCodemods = integrationVersionGroups.some(
+        g => g.codemods.length > 0,
+      );
 
-      if (versionManifests.length === 0) {
+      if (versionManifests.length === 0 && !hasIntegrationCodemods) {
         if (json) {
           return jsonOut('upgrade.status', {
             status: 'no_codemods',
@@ -303,6 +323,16 @@ export function registerUpgrade(program) {
         for (const t of transforms) {
           if (options.codemod && t.name !== options.codemod) continue;
           if (t.optional && !options.codemod) {
+            totalOptional++;
+          } else {
+            totalTransforms++;
+          }
+        }
+      }
+      for (const {codemods} of integrationVersionGroups) {
+        for (const c of codemods) {
+          if (options.codemod && c.id !== options.codemod) continue;
+          if (c.codemod.isOptional && !options.codemod) {
             totalOptional++;
           } else {
             totalTransforms++;
@@ -363,15 +393,46 @@ export function registerUpgrade(program) {
         silent: json,
       });
 
+      // Run file-based integration codemods alongside the core registry
+      // codemods (config codemods first, then code codemods), ordered by
+      // version. Their results are merged into the receipt below.
+      let integrationResult = null;
+      if (hasIntegrationCodemods) {
+        if (!json) p.log.step('Applying integration codemods...');
+        const jscodeshift = (await import('jscodeshift')).default;
+        integrationResult = runIntegrationCodemods(integrationVersionGroups, {
+          apply: options.apply,
+          path: options.path,
+          codemod: options.codemod,
+          jscodeshift,
+          silent: json,
+        });
+      }
+
+      // Merge core + integration codemod results into a single accounting so
+      // hooks, receipts, and error gating see both.
+      const mergedFilesChanged =
+        (codemodResult?.totalFilesChanged ?? 0) +
+        (integrationResult?.totalFilesChanged ?? 0);
+      const mergedTransformsApplied =
+        (codemodResult?.totalTransformsApplied ?? 0) +
+        (integrationResult?.totalTransformsApplied ?? 0);
+      const mergedWrittenFiles = [
+        ...(codemodResult?.writtenFiles ?? []),
+        ...(integrationResult?.writtenFiles ?? []),
+      ];
+      const mergedErrors = [
+        ...(codemodResult?.errors ?? []),
+        ...(integrationResult?.errors ?? []),
+      ];
+
       // Post-codemod hooks come from the app config (config.hooks.postCodemod).
       // They run only when codemods actually changed files. In apply mode the
       // commands execute (nonzero exit fails the upgrade); in dry-run mode we
       // only preview the resolved command (a buildCommand throw still fails).
-      const changedFileCount = codemodResult?.totalFilesChanged ?? 0;
+      const changedFileCount = mergedFilesChanged;
       if (postCodemodHooks.length > 0 && changedFileCount > 0) {
-        const absoluteChangedFiles = uniqueFiles(
-          codemodResult?.writtenFiles ?? [],
-        );
+        const absoluteChangedFiles = uniqueFiles(mergedWrittenFiles);
         const files = absoluteChangedFiles.map(file =>
           path.relative(process.cwd(), file),
         );
@@ -420,11 +481,9 @@ export function registerUpgrade(program) {
         }
       }
 
-      if (codemodResult && typeof codemodResult === 'object') {
-        receipt.filesChanged = codemodResult.totalFilesChanged ?? 0;
-        receipt.transformsApplied = codemodResult.totalTransformsApplied ?? 0;
-        receipt.errors = codemodResult.errors ?? [];
-      }
+      receipt.filesChanged = mergedFilesChanged;
+      receipt.transformsApplied = mergedTransformsApplied;
+      receipt.errors = mergedErrors;
 
       if (receipt.errors?.length > 0) {
         const msg = `Upgrade completed with ${receipt.errors.length} codemod error${receipt.errors.length === 1 ? '' : 's'}.`;

--- a/packages/cli/src/types/codemod.d.ts
+++ b/packages/cli/src/types/codemod.d.ts
@@ -1,0 +1,81 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * Public type surface for the file-based codemod-authoring API exported from
+ * `@astryxdesign/cli/codemod`.
+ */
+
+/** A single source file presented to a codemod's transform. */
+export interface AstryxCodemodFile {
+  /** Absolute path to the file being transformed. */
+  path: string;
+  /** The current source contents of the file. */
+  source: string;
+}
+
+/** Helpers and context passed to a codemod's transform as the second argument. */
+export interface AstryxCodemodApi {
+  /** A jscodeshift instance configured with a parser for the file. */
+  jscodeshift: unknown;
+  /** Report a statistic (no-op-friendly; provided for jscodeshift parity). */
+  stats: (...args: unknown[]) => void;
+  /** Report progress (no-op-friendly; provided for jscodeshift parity). */
+  report: (...args: unknown[]) => void;
+}
+
+/**
+ * A codemod's transform. Return the new source to rewrite the file, or
+ * `null`/`undefined` to leave the file unchanged.
+ */
+export type AstryxCodemodTransform = (
+  file: AstryxCodemodFile,
+  api: AstryxCodemodApi,
+) => string | null | undefined;
+
+/** Definition accepted by {@link createCodemod}. */
+export interface AstryxCodemodDef {
+  /** Short, human-readable title shown in upgrade output. */
+  title: string;
+  /** Optional longer description. */
+  description?: string;
+  /** When true, the codemod runs only when explicitly requested. */
+  isOptional?: boolean;
+  /** File extensions this codemod applies to (e.g. ['.tsx', '.ts']). */
+  fileExtensions?: string[];
+  /** The transform function. */
+  transform: AstryxCodemodTransform;
+}
+
+/** Result of {@link createCodemod}. */
+export interface AstryxCodemod extends AstryxCodemodDef {
+  isOptional: boolean;
+  type: 'code';
+}
+
+/** Definition accepted by {@link createConfigCodemod}. */
+export interface AstryxConfigCodemodDef {
+  /** Short, human-readable title shown in upgrade output. */
+  title: string;
+  /** Optional longer description. */
+  description?: string;
+  /** When true, the codemod runs only when explicitly requested. */
+  isOptional?: boolean;
+  /** The transform function applied to the astryx.config.* file. */
+  transform: AstryxCodemodTransform;
+}
+
+/** Result of {@link createConfigCodemod}. */
+export interface AstryxConfigCodemod extends AstryxConfigCodemodDef {
+  isOptional: boolean;
+  type: 'config';
+}
+
+/** Define a file-transforming codemod. */
+export declare function createCodemod<T extends AstryxCodemodDef>(
+  def: T,
+): AstryxCodemod;
+
+/** Define a codemod that targets the consumer's astryx.config.* file. */
+export declare function createConfigCodemod<T extends AstryxConfigCodemodDef>(
+  def: T,
+): AstryxConfigCodemod;


### PR DESCRIPTION
## What

Adds the public file-based codemod-authoring API and wires integration-contributed codemods into `astryx upgrade`.

- **`@astryxdesign/cli/codemod`** — new export with `createCodemod` / `createConfigCodemod` helpers (zod-validated; unknown keys rejected; `transform` required and must be a function; config codemods reject `fileExtensions`). Result objects carry a `type` discriminator (`'code'` | `'config'`).
- **Integration codemod discovery** — an integration's resolved `codemods` directory (`<root>/<version>/<id>.<ext>`) is enumerated, each module's default export validated, and codemods are keyed by version. Duplicate ids within a version or across versions in a package are hard errors.
- **Upgrade integration** — discovered codemods run alongside the core registry codemods, ordered by version: config codemods first (applied to `astryx.config.*`), then code codemods (source globbing + per-codemod `fileExtensions`). Core built-in codemods are unchanged. Broken discovery or a throwing transform fails the upgrade rather than silently skipping.

## Types

`src/types/codemod.d.ts` adds `AstryxCodemod`, `AstryxConfigCodemod`, `AstryxCodemodFile`, `AstryxCodemodApi`, and the helper declarations. The transform contract is `(file, api) => string | null | undefined`.

## Tests

- Unit: helper validation (title/transform required, transform must be a function, unknown keys rejected, `isOptional` defaults to false, config codemods reject `fileExtensions`).
- Integration: hermetic temp integration package wired through `loadConfig` → discovery → run; asserts discovery + version selection + execution, plus that a broken/invalid default export or a cross-version duplicate id fails discovery.
