### PR TITLE
feat(cli): component package ownership and source discovery

### DIFF
--- a/.changeset/component-ownership.md
+++ b/.changeset/component-ownership.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[feat] Component discovery is now package-ownership aware: --package scoping, source resolution for integration components, and package-qualified JSON listings.
+
+@ejhammond

--- a/packages/cli/src/api/component.mjs
+++ b/packages/cli/src/api/component.mjs
@@ -11,17 +11,47 @@ import * as fs from 'node:fs';
 import {ERROR_CODES} from '../lib/error-codes.mjs';
 import {findCoreDir, discoverExternalPackages} from '../utils/paths.mjs';
 import {
+  CORE_PACKAGE,
   discoverComponents,
   discoverExternalComponentsGrouped,
+  discoverIntegrationComponents,
   findComponentReadme,
   findComponentSource,
   findExternalComponentDoc,
+  findIntegrationComponentDoc,
+  findIntegrationComponentSource,
   resolveImportPath,
 } from '../lib/component-discovery.mjs';
+import {loadConfig} from '../lib/config.mjs';
 import {loadDocs} from '../lib/component-loader.mjs';
 import {searchComponents} from '../lib/string-utils.mjs';
 import {AstryxError} from './error.mjs';
 import {findShowcase, findRelatedBlocks} from './template.mjs';
+
+/**
+ * Load the configured integrations for `cwd`, swallowing any config errors so
+ * component discovery never hard-fails on a malformed/absent integration. An
+ * empty list means "core only".
+ * @param {string} cwd
+ * @returns {Promise<Array<{name: string, components?: string, issuesUrl?: string}>>}
+ */
+async function loadIntegrationsSafely(cwd) {
+  try {
+    const config = await loadConfig(cwd);
+    return config.loadedIntegrations ?? [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Resolve a loaded integration by package name.
+ * @param {Array<{name: string}>} loadedIntegrations
+ * @param {string} packageName
+ */
+function findLoadedIntegration(loadedIntegrations, packageName) {
+  return loadedIntegrations.find(i => i.name === packageName) ?? null;
+}
 
 /**
  * Resolve an external package by name from the discovered externals list.
@@ -131,8 +161,13 @@ export async function component(name, options = {}) {
         return {type: 'component.full', data: {[match[0]]: entries}};
       }
 
-      // Default: brief — names only
-      return {type: 'component.list', data: {[match[0]]: match[1]}};
+      // Default: brief — package-qualified object list for the category.
+      // Pre-1.0 JSON contract: members are {name, package} objects, not bare
+      // strings, so consumers can disambiguate ownership.
+      return {
+        type: 'component.list',
+        data: {[match[0]]: match[1].map(n => ({name: n, package: CORE_PACKAGE}))},
+      };
     }
 
     // All components — merge core + external packages with grouped subcategories
@@ -179,43 +214,181 @@ export async function component(name, options = {}) {
       return {type: 'component.full', data: result};
     }
 
-    // Default: brief — names only (with externals merged in)
+    // Default: brief — package-qualified object list (core + integrations).
+    // Pre-1.0 JSON contract: each group's members are {name, package} objects.
+    /** @type {Record<string, Array<{name: string, package: string}>>} */
+    const listData = {};
+    for (const [cat, comps] of Object.entries(components)) {
+      listData[cat] = comps.map(n => ({name: n, package: CORE_PACKAGE}));
+    }
+
+    // Integration components (authoritative source: loadedIntegrations).
+    const loadedIntegrations = await loadIntegrationsSafely(cwd);
+    const seenIntegration = new Set();
+    for (const integration of loadedIntegrations) {
+      seenIntegration.add(integration.name);
+      const owned = discoverIntegrationComponents(integration);
+      // Group integration components by their doc `group`, falling back to the
+      // package name. Keys are package-qualified so they never collide with
+      // core groups or each other.
+      /** @type {Map<string, Array<{name: string, package: string}>>} */
+      const byGroup = new Map();
+      for (const rec of owned) {
+        const groupLabel = rec.group ?? integration.name;
+        const key = `${groupLabel} (${integration.name})`;
+        if (!byGroup.has(key)) byGroup.set(key, []);
+        byGroup.get(key).push({name: rec.name, package: integration.name});
+      }
+      for (const [key, members] of byGroup) {
+        members.sort((a, b) => a.name.localeCompare(b.name));
+        listData[key] = members;
+      }
+    }
+
+    // Back-compat: node_modules-scanned external packages (pkg.astryx.docs)
+    // that are NOT configured integrations. Preserves existing discovery for
+    // consumers that haven't adopted the config-integration flow.
     const externals = discoverExternalPackages(cwd);
     for (const ext of externals) {
+      if (seenIntegration.has(ext.name)) continue;
       const grouped = discoverExternalComponentsGrouped(ext.docsDir);
       const groupKeys = Object.keys(grouped);
       if (groupKeys.length === 0) continue;
 
-      // If the package has subcategories (groups), emit each as a separate key.
-      // If no groups exist, fall back to the flat list under one key.
       const hasGroups = groupKeys.some(
         k => grouped[k].length > 1 || grouped[k][0] !== k,
       );
 
       if (hasGroups) {
         for (const [group, members] of Object.entries(grouped)) {
-          components[`${group} (${ext.name})`] = members;
+          listData[`${group} (${ext.name})`] = members.map(n => ({
+            name: n,
+            package: ext.name,
+          }));
         }
       } else {
-        // All ungrouped — single flat list under the package category
         const allComps = Object.values(grouped).flat().sort();
         if (allComps.length > 0) {
-          components[`${ext.category} (${ext.name})`] = allComps;
+          listData[`${ext.category} (${ext.name})`] = allComps.map(n => ({
+            name: n,
+            package: ext.name,
+          }));
         }
       }
     }
-    return {type: 'component.list', data: components};
+    return {type: 'component.list', data: listData};
   }
 
   // ── Single component ───────────────────────────────────────────
 
   const dirName = name.replace(/^XDS/, '');
 
+  // Ownership-aware resolution. Build the set of OWNER packages that provide a
+  // component with this name across core + every loaded integration. This is
+  // what lets the CLI disambiguate by package and expose the owner's source +
+  // issuesUrl (the inputs the future integration-component swizzle needs).
+  const loadedIntegrations = await loadIntegrationsSafely(cwd);
+  const coreDocPath = findComponentReadme(coreDir, dirName);
+  /**
+   * @type {Array<{
+   *   package: string,
+   *   docPath: string,
+   *   sourcePath: string|null,
+   *   issuesUrl: string|undefined,
+   *   integration: object|null,
+   * }>}
+   */
+  const owners = [];
+  if (coreDocPath) {
+    owners.push({
+      package: CORE_PACKAGE,
+      docPath: coreDocPath,
+      sourcePath: findComponentSource(coreDir, dirName),
+      issuesUrl: undefined,
+      integration: null,
+    });
+  }
+  for (const integration of loadedIntegrations) {
+    const docPath = findIntegrationComponentDoc(integration, dirName);
+    if (!docPath) continue;
+    owners.push({
+      package: integration.name,
+      docPath,
+      sourcePath: findIntegrationComponentSource(integration, dirName),
+      issuesUrl: integration.issuesUrl,
+      integration,
+    });
+  }
+
+  /**
+   * Augment a loaded `component.detail` doc with ownership metadata. Adds
+   * `package`, the resolved `import` specifier, and `sourceAvailable` (whether
+   * a swizzleable source file exists for the owner). Existing doc fields
+   * (name, usage, props, …) are preserved.
+   * @param {object} docs
+   * @param {{package: string, sourcePath: string|null}} owner
+   * @param {string} componentName
+   */
+  function withOwnership(docs, owner, componentName) {
+    const importSpec =
+      owner.package === CORE_PACKAGE
+        ? resolveImportPath(coreDir, componentName)
+        : `${owner.package}/${componentName}`;
+    return {
+      ...docs,
+      package: owner.package,
+      import: importSpec,
+      sourceAvailable: owner.sourcePath != null,
+    };
+  }
+
   // When scoped to a specific package, search that package first.
   // This is critical for components that exist in both core and an external
   // package (e.g. AppShell, Button, SideNav) — the package scope ensures
   // the external package's docs are returned, not core's.
   if (packageScope) {
+    // Core scope: resolve from core directly.
+    if (packageScope === CORE_PACKAGE) {
+      const owner = owners.find(o => o.package === CORE_PACKAGE);
+      if (!owner) {
+        throw new AstryxError(`No component "${name}" in package "${packageScope}"`, undefined, ERROR_CODES.ERR_UNKNOWN_COMPONENT);
+      }
+      if (source) {
+        if (!owner.sourcePath) {
+          throw new AstryxError(`Source for "${name}" not found`, undefined, ERROR_CODES.ERR_NO_SOURCE);
+        }
+        return {type: 'component.detail.source', data: {component: dirName, source: fs.readFileSync(owner.sourcePath, 'utf-8')}};
+      }
+      const docs = await loadDocs(owner.docPath, {zh, dense, lang});
+      if (props) {
+        const p = docs.props || (docs.components ? docs.components.flatMap(c => c.props || []) : []);
+        return {type: 'component.detail.props', data: p};
+      }
+      return {type: 'component.detail', data: withOwnership(docs, owner, dirName)};
+    }
+
+    // Integration scope (authoritative): resolve from the loaded integration.
+    const integration = findLoadedIntegration(loadedIntegrations, packageScope);
+    if (integration) {
+      const owner = owners.find(o => o.package === packageScope);
+      if (!owner) {
+        throw new AstryxError(`No component "${name}" in package "${packageScope}"`, undefined, ERROR_CODES.ERR_UNKNOWN_COMPONENT);
+      }
+      if (source) {
+        if (!owner.sourcePath) {
+          throw new AstryxError(`Source for "${name}" not found in package "${packageScope}"`, undefined, ERROR_CODES.ERR_NO_SOURCE);
+        }
+        return {type: 'component.detail.source', data: {component: dirName, source: fs.readFileSync(owner.sourcePath, 'utf-8')}};
+      }
+      const docs = await loadDocs(owner.docPath, {zh, dense, lang});
+      if (props) {
+        const p = docs.props || (docs.components ? docs.components.flatMap(c => c.props || []) : []);
+        return {type: 'component.detail.props', data: p};
+      }
+      return {type: 'component.detail', data: withOwnership(docs, owner, dirName)};
+    }
+
+    // Legacy fallback: node_modules `pkg.astryx.docs` external package.
     const ext = resolveExternalPackage(packageScope, cwd);
     if (!ext) {
       throw new AstryxError(`External package "${packageScope}" not found`, undefined, ERROR_CODES.ERR_UNKNOWN_PACKAGE);
@@ -244,9 +417,47 @@ export async function component(name, options = {}) {
         const p = docs.props || (docs.components ? docs.components.flatMap(c => c.props || []) : []);
         return {type: 'component.detail.props', data: p};
       }
-      return {type: 'component.detail', data: docs};
+      return {
+        type: 'component.detail',
+        data: withOwnership(docs, {package: ext.name, sourcePath: null}, dirName),
+      };
     }
     throw new AstryxError(`No component "${name}" in package "${packageScope}"`, undefined, ERROR_CODES.ERR_UNKNOWN_COMPONENT);
+  }
+
+  // Ambiguity: when the name is owned by MORE THAN ONE package (core and/or
+  // integrations) and the caller did not scope with --package, refuse to guess.
+  // NOTE: legacy `pkg.astryx.docs` externals are intentionally NOT part of this
+  // ambiguity set — they retain their historical core-first fallback below so
+  // existing consumers (and tests) keep working. Only config-driven integration
+  // ownership participates here.
+  if (owners.length > 1) {
+    throw new AstryxError(
+      `Component "${dirName}" is provided by multiple packages. Re-run with --package <pkg> to choose one.`,
+      owners.map(o => ({name: o.package, reason: 'provides this component'})),
+      ERROR_CODES.ERR_UNKNOWN_COMPONENT,
+    );
+  }
+
+  // Single non-core owner (an integration provides it, core does not) — resolve
+  // from that integration so the integration component is authoritative.
+  if (owners.length === 1 && owners[0].package !== CORE_PACKAGE) {
+    const owner = owners[0];
+    if (source) {
+      if (!owner.sourcePath) {
+        throw new AstryxError(`Source for "${name}" not found`, undefined, ERROR_CODES.ERR_NO_SOURCE);
+      }
+      return {type: 'component.detail.source', data: {component: dirName, source: fs.readFileSync(owner.sourcePath, 'utf-8')}};
+    }
+    if (showcase) {
+      throw new AstryxError(`No showcase found for "${name}"`, undefined, ERROR_CODES.ERR_NO_SHOWCASE);
+    }
+    const docs = await loadDocs(owner.docPath, {zh, dense, lang});
+    if (props) {
+      const p = docs.props || (docs.components ? docs.components.flatMap(c => c.props || []) : []);
+      return {type: 'component.detail.props', data: p};
+    }
+    return {type: 'component.detail', data: withOwnership(docs, owner, dirName)};
   }
 
   if (source) {
@@ -274,6 +485,10 @@ export async function component(name, options = {}) {
 
   let readmePath = findComponentReadme(coreDir, dirName);
   let resolvedName = dirName;
+  // Track the resolving owner so the detail payload can carry ownership info.
+  // Defaults to core; the legacy-external fallback below may reassign it.
+  let resolvedOwnerPackage = CORE_PACKAGE;
+  let resolvedSourcePath = readmePath ? findComponentSource(coreDir, dirName) : null;
 
   if (!readmePath) {
     const externals = discoverExternalPackages(cwd);
@@ -281,6 +496,8 @@ export async function component(name, options = {}) {
       const extDocPath = findExternalComponentDoc(ext.docsDir, dirName);
       if (extDocPath) {
         readmePath = extDocPath;
+        resolvedOwnerPackage = ext.name;
+        resolvedSourcePath = null;
         break;
       }
     }
@@ -299,6 +516,8 @@ export async function component(name, options = {}) {
       if (topScore >= 90 && topTied.length === 1 && gap >= 20) {
         resolvedName = topTied[0].name;
         readmePath = findComponentReadme(coreDir, resolvedName);
+        resolvedOwnerPackage = CORE_PACKAGE;
+        resolvedSourcePath = findComponentSource(coreDir, resolvedName);
       } else {
         const threshold = Math.max(topScore - 20, 1);
         const candidates = results.filter(r => r.score >= threshold).slice(0, 5);
@@ -382,7 +601,14 @@ export async function component(name, options = {}) {
     if (props) {
       return {type: 'component.detail.props', data: matchingComponent.props || []};
     }
-    return {type: 'component.detail', data: scoped};
+    return {
+      type: 'component.detail',
+      data: withOwnership(
+        scoped,
+        {package: resolvedOwnerPackage, sourcePath: resolvedSourcePath},
+        dirName,
+      ),
+    };
   }
 
   if (props) {
@@ -390,5 +616,12 @@ export async function component(name, options = {}) {
     return {type: 'component.detail.props', data: p};
   }
 
-  return {type: 'component.detail', data: docs};
+  return {
+    type: 'component.detail',
+    data: withOwnership(
+      docs,
+      {package: resolvedOwnerPackage, sourcePath: resolvedSourcePath},
+      resolvedName,
+    ),
+  };
 }

--- a/packages/cli/src/commands/component-ownership.test.mjs
+++ b/packages/cli/src/commands/component-ownership.test.mjs
@@ -1,0 +1,227 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import {
+  discoverIntegrationComponents,
+  discoverOwnedComponents,
+  findIntegrationComponentDoc,
+  findIntegrationComponentSource,
+  CORE_PACKAGE,
+} from '../lib/component-discovery.mjs';
+
+// The api `component()` reads integrations via loadConfig(). In the vitest
+// environment, Vite's `server.fs.allow` only permits loading modules from
+// under `node_modules`, so a real astryx.config.mjs at a tmp root cannot be
+// imported. We therefore mock loadConfig to return resolved `loadedIntegrations`
+// (exactly the shape lib/integrations.mjs produces) while keeping the
+// integration's `components` dir on disk under node_modules so its `.doc.mjs`
+// files load normally.
+const loadConfigMock = vi.fn();
+vi.mock('../lib/config.mjs', () => ({
+  loadConfig: (...args) => loadConfigMock(...args),
+}));
+
+// Import the api AFTER the mock is registered.
+const {component} = await import('../api/component.mjs');
+
+let tmpDir;
+
+const INTEGRATION_NAME = '@test/meta';
+const INTEGRATION_ISSUES = 'https://example.com/meta/issues';
+
+/**
+ * Build a consumer fixture:
+ * - packages/core symlinked to the real @astryxdesign/core (loadDocs source)
+ * - node_modules/@test/meta with a `components` dir using the same-stem
+ *   source/doc convention (MetaAppShell.tsx + MetaAppShell.doc.mjs)
+ * Returns the absolute `components` dir so the loadConfig mock can hand back a
+ * resolved integration entry.
+ */
+function createFixture({withSource = true, extraComponent = null} = {}) {
+  const realCoreDir = path.resolve(import.meta.dirname, '..', '..', '..', 'core');
+  const coreDir = path.join(tmpDir, 'packages', 'core');
+  fs.mkdirSync(path.dirname(coreDir), {recursive: true});
+  fs.symlinkSync(realCoreDir, coreDir);
+
+  const intDir = path.join(tmpDir, 'node_modules', '@test', 'meta');
+  const compDir = path.join(intDir, 'components');
+  fs.mkdirSync(compDir, {recursive: true});
+  fs.writeFileSync(
+    path.join(intDir, 'package.json'),
+    JSON.stringify({name: INTEGRATION_NAME, version: '1.2.3'}),
+  );
+  fs.writeFileSync(
+    path.join(compDir, 'MetaAppShell.doc.mjs'),
+    `export const docs = {\n  name: 'MetaAppShell',\n  usage: { description: 'Meta-flavored app shell.' },\n  props: [{ name: 'title', type: 'string', description: 'Header title' }],\n};\n`,
+  );
+  if (withSource) {
+    fs.writeFileSync(
+      path.join(compDir, 'MetaAppShell.tsx'),
+      "'use client';\nexport function MetaAppShell() { return null; }\n",
+    );
+  }
+  if (extraComponent) {
+    fs.writeFileSync(
+      path.join(compDir, `${extraComponent}.doc.mjs`),
+      `export const docs = {\n  name: '${extraComponent}',\n  usage: { description: '${extraComponent} from meta.' },\n};\n`,
+    );
+    fs.writeFileSync(
+      path.join(compDir, `${extraComponent}.tsx`),
+      `export function ${extraComponent}() { return null; }\n`,
+    );
+  }
+
+  const integration = {
+    name: INTEGRATION_NAME,
+    version: '1.2.3',
+    components: compDir,
+    templates: undefined,
+    codemods: undefined,
+    issuesUrl: INTEGRATION_ISSUES,
+  };
+  loadConfigMock.mockResolvedValue({
+    integrations: [INTEGRATION_NAME],
+    loadedIntegrations: [integration],
+  });
+  return {coreDir, intDir, compDir, integration};
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'astryx-ownership-'));
+  loadConfigMock.mockReset();
+  // Default: no integrations (core only).
+  loadConfigMock.mockResolvedValue({integrations: [], loadedIntegrations: []});
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, {recursive: true, force: true});
+});
+
+describe('discoverIntegrationComponents (ownership records)', () => {
+  it('records name, package, sourcePath, and issuesUrl for same-stem components', () => {
+    const {integration, compDir} = createFixture();
+    const records = discoverIntegrationComponents(integration);
+    expect(records).toHaveLength(1);
+    const rec = records[0];
+    expect(rec.name).toBe('MetaAppShell');
+    expect(rec.package).toBe(INTEGRATION_NAME);
+    expect(rec.issuesUrl).toBe(INTEGRATION_ISSUES);
+    expect(rec.sourcePath).toBe(path.join(compDir, 'MetaAppShell.tsx'));
+    expect(fs.existsSync(rec.sourcePath)).toBe(true);
+  });
+
+  it('records sourcePath: null when the integration ships docs without source', () => {
+    const {integration} = createFixture({withSource: false});
+    const [rec] = discoverIntegrationComponents(integration);
+    expect(rec.sourcePath).toBeNull();
+  });
+});
+
+describe('discoverOwnedComponents (core + integrations)', () => {
+  it('marks core components with the core package and integration components with their owner', () => {
+    const {coreDir, integration} = createFixture();
+    const records = discoverOwnedComponents(coreDir, [integration]);
+    const core = records.find(r => r.package === CORE_PACKAGE);
+    expect(core).toBeTruthy();
+    expect(core.issuesUrl).toBeUndefined();
+    const meta = records.find(r => r.name === 'MetaAppShell');
+    expect(meta.package).toBe(INTEGRATION_NAME);
+    expect(meta.issuesUrl).toBe(INTEGRATION_ISSUES);
+    expect(meta.sourcePath).toContain('MetaAppShell.tsx');
+  });
+});
+
+describe('findIntegrationComponentDoc / Source', () => {
+  it('finds doc + source by name', () => {
+    const {integration} = createFixture();
+    expect(findIntegrationComponentDoc(integration, 'MetaAppShell')).toContain('MetaAppShell.doc.mjs');
+    expect(findIntegrationComponentSource(integration, 'MetaAppShell')).toContain('MetaAppShell.tsx');
+  });
+
+  it('returns null source when none present', () => {
+    const {integration} = createFixture({withSource: false});
+    expect(findIntegrationComponentSource(integration, 'MetaAppShell')).toBeNull();
+  });
+});
+
+describe('component() — integration ownership via config', () => {
+  it('discovers a config integration component by package ownership (detail)', async () => {
+    createFixture();
+    const result = await component('MetaAppShell', {cwd: tmpDir});
+    expect(result.type).toBe('component.detail');
+    expect(result.data.name).toBe('MetaAppShell');
+    expect(result.data.package).toBe(INTEGRATION_NAME);
+    expect(result.data.sourceAvailable).toBe(true);
+    expect(result.data.import).toBe(`${INTEGRATION_NAME}/MetaAppShell`);
+  });
+
+  it('--package resolves the integration component', async () => {
+    createFixture();
+    const result = await component('MetaAppShell', {cwd: tmpDir, package: INTEGRATION_NAME});
+    expect(result.type).toBe('component.detail');
+    expect(result.data.package).toBe(INTEGRATION_NAME);
+  });
+
+  it('--source returns the integration source when available', async () => {
+    createFixture();
+    const result = await component('MetaAppShell', {cwd: tmpDir, source: true});
+    expect(result.type).toBe('component.detail.source');
+    expect(result.data.component).toBe('MetaAppShell');
+    expect(result.data.source).toContain('MetaAppShell');
+  });
+
+  it('--source throws ERR_NO_SOURCE when the integration ships no source', async () => {
+    createFixture({withSource: false});
+    await expect(
+      component('MetaAppShell', {cwd: tmpDir, source: true}),
+    ).rejects.toMatchObject({code: 'ERR_NO_SOURCE'});
+  });
+
+  it('errors with candidate packages when a name is ambiguous (core + integration)', async () => {
+    // 'AppShell' exists in core; add a same-named integration component.
+    createFixture({extraComponent: 'AppShell'});
+    let caught;
+    try {
+      await component('AppShell', {cwd: tmpDir});
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeTruthy();
+    expect(caught.code).toBe('ERR_UNKNOWN_COMPONENT');
+    const pkgs = (caught.suggestions ?? []).map(s => s.name);
+    expect(pkgs).toContain(CORE_PACKAGE);
+    expect(pkgs).toContain(INTEGRATION_NAME);
+  });
+
+  it('--package disambiguates an ambiguous name to core', async () => {
+    createFixture({extraComponent: 'AppShell'});
+    const result = await component('AppShell', {cwd: tmpDir, package: CORE_PACKAGE});
+    expect(result.type).toBe('component.detail');
+    expect(result.data.package).toBe(CORE_PACKAGE);
+  });
+
+  it('--package disambiguates an ambiguous name to the integration', async () => {
+    createFixture({extraComponent: 'AppShell'});
+    const result = await component('AppShell', {cwd: tmpDir, package: INTEGRATION_NAME});
+    expect(result.type).toBe('component.detail');
+    expect(result.data.package).toBe(INTEGRATION_NAME);
+  });
+
+  it('JSON list includes integration components as {name, package} objects', async () => {
+    createFixture();
+    const result = await component(undefined, {cwd: tmpDir, list: true});
+    expect(result.type).toBe('component.list');
+    const allEntries = Object.values(result.data).flat();
+    for (const entry of allEntries) {
+      expect(typeof entry.name).toBe('string');
+      expect(typeof entry.package).toBe('string');
+    }
+    const meta = allEntries.find(e => e.name === 'MetaAppShell');
+    expect(meta).toBeTruthy();
+    expect(meta.package).toBe(INTEGRATION_NAME);
+    expect(allEntries.some(e => e.package === CORE_PACKAGE)).toBe(true);
+  });
+});

--- a/packages/cli/src/commands/component/index.mjs
+++ b/packages/cli/src/commands/component/index.mjs
@@ -82,27 +82,49 @@ export function registerComponent(program) {
 
       switch (result.type) {
         case 'component.list': {
-          // --detail brief (default for list views) — names with import paths.
+          // --detail brief (default for list views). The API now returns
+          // package-qualified entries ({name, package}); the human view omits
+          // the core package label for readability but ALWAYS shows the package
+          // for integration components (and whenever names collide).
+          const CORE_PKG = '@astryxdesign/core';
+          // Names that appear under more than one package across the whole
+          // listing — these must always be package-qualified to disambiguate.
+          const nameCounts = new Map();
+          for (const items of Object.values(result.data)) {
+            for (const item of items) {
+              const set = nameCounts.get(item.name) ?? new Set();
+              set.add(item.package);
+              nameCounts.set(item.name, set);
+            }
+          }
+          const isCollision = n => (nameCounts.get(n)?.size ?? 0) > 1;
+          const pkgSuffix = item => {
+            if (item.package !== CORE_PKG) return `  [${item.package}]`;
+            if (isCollision(item.name)) return `  [${item.package}]`;
+            return '';
+          };
+
           if (options.category) {
             const [cat, comps] = Object.entries(result.data)[0];
             humanLog(`\n${cat}:`);
-            for (const comp of comps) {
-              const importPath = resolveImportPath(coreDir, comp);
-              humanLog(`  ${comp}  ← ${importPath}`);
+            for (const item of comps) {
+              const importPath = resolveImportPath(coreDir, item.name);
+              humanLog(`  ${item.name}  ← ${importPath}${pkgSuffix(item)}`);
             }
             humanLog('');
           } else {
             humanLog('');
             for (const [key, comps] of Object.entries(result.data)) {
-              const isUngrouped = comps.length === 1 && comps[0] === key;
+              const isUngrouped = comps.length === 1 && comps[0]?.name === key;
               if (isUngrouped) {
-                const importPath = resolveImportPath(coreDir, key);
-                humanLog(`${key}  ← ${importPath}`);
+                const item = comps[0];
+                const importPath = resolveImportPath(coreDir, item.name);
+                humanLog(`${item.name}  ← ${importPath}${pkgSuffix(item)}`);
               } else {
                 humanLog(`${key} (group)`);
-                for (const comp of comps) {
-                  const importPath = resolveImportPath(coreDir, comp);
-                  humanLog(`  ${comp}  ← ${importPath}`);
+                for (const item of comps) {
+                  const importPath = resolveImportPath(coreDir, item.name);
+                  humanLog(`  ${item.name}  ← ${importPath}${pkgSuffix(item)}`);
                 }
               }
             }

--- a/packages/cli/src/lib/component-discovery.mjs
+++ b/packages/cli/src/lib/component-discovery.mjs
@@ -9,6 +9,12 @@ import * as path from 'node:path';
 
 const SKIP_DIRS = new Set(['hooks', 'utils', '__tests__', 'node_modules']);
 
+/** The owner package name for built-in (core) components. */
+export const CORE_PACKAGE = '@astryxdesign/core';
+
+/** Conventional doc-file suffixes for integration components (same-stem). */
+const INTEGRATION_DOC_SUFFIXES = ['.doc.ts', '.doc.mjs', '.doc.js'];
+
 // Component source files are named `XDS{Name}.tsx` today. The XDS-prefix
 // migration (P2380608025, P4) renames them to the bare `{Name}.tsx` form, so
 // discovery must recognize BOTH. The `XDS` prefix has historically doubled as
@@ -473,6 +479,177 @@ export function findExternalComponentDoc(docsDir, name) {
   }
 
   return scanDir(docsDir);
+}
+
+// ── Integration component discovery (ownership-aware) ────────────────
+//
+// Integration packages contribute a `components` root (resolved absolute path
+// in `loadedIntegrations`, see lib/integrations.mjs). Each component uses a
+// same-stem source/doc convention — e.g. `MetaAppShell.tsx` next to
+// `MetaAppShell.doc.{ts,mjs,js}`. The doc file is authoritative for discovery;
+// the sibling `.tsx` (if present) is the swizzleable source.
+//
+// Each discovered component is recorded with its OWNER package (the
+// integration's package name) and the owner's `issuesUrl` so downstream
+// commands — and the future integration-component swizzle — can disambiguate
+// by package and route source/issues correctly.
+
+/**
+ * Given an integration component doc path, return the sibling component source
+ * (`{Name}.tsx`) if one exists, else null.
+ *
+ * @param {string} docPath absolute path to a `{Name}.doc.{ts,mjs,js}` file
+ * @returns {string|null}
+ */
+function integrationSourceForDoc(docPath) {
+  const dir = path.dirname(docPath);
+  const base = path.basename(docPath).replace(/\.doc\.(ts|mjs|js)$/, '');
+  const candidate = path.join(dir, `${base}.tsx`);
+  return fs.existsSync(candidate) ? candidate : null;
+}
+
+/**
+ * Discover ownership records for the components contributed by a single loaded
+ * integration. Scans the integration's resolved `components` dir for same-stem
+ * doc files and records each with owner package + issuesUrl + sourcePath.
+ *
+ * @param {{name: string, components?: string, issuesUrl?: string}} integration
+ *   a single entry from `loadedIntegrations` (lib/integrations.mjs)
+ * @returns {Array<{name: string, package: string, docPath: string, sourcePath: string|null, issuesUrl: string|undefined, group: string|null}>}
+ */
+export function discoverIntegrationComponents(integration) {
+  const componentsDir = integration?.components;
+  if (!componentsDir || !fs.existsSync(componentsDir)) return [];
+
+  /** @type {Map<string, {name: string, package: string, docPath: string, sourcePath: string|null, issuesUrl: string|undefined, group: string|null}>} */
+  const byName = new Map();
+
+  function scanDir(dirPath) {
+    const entries = fs.readdirSync(dirPath, {withFileTypes: true});
+    for (const entry of entries) {
+      if (entry.name === 'node_modules' || entry.name === '__tests__') continue;
+      const fullPath = path.join(dirPath, entry.name);
+      if (entry.isDirectory()) {
+        scanDir(fullPath);
+        continue;
+      }
+      const suffix = INTEGRATION_DOC_SUFFIXES.find(s => entry.name.endsWith(s));
+      if (!suffix) continue;
+      const name = entry.name.slice(0, -suffix.length);
+      const {group, hidden} = readDocMeta(fullPath);
+      if (hidden) continue;
+      // First doc wins per name (precedence matches INTEGRATION_DOC_SUFFIXES).
+      if (byName.has(name)) continue;
+      byName.set(name, {
+        name,
+        package: integration.name,
+        docPath: fullPath,
+        sourcePath: integrationSourceForDoc(fullPath),
+        issuesUrl: integration.issuesUrl,
+        group: group ?? null,
+      });
+    }
+  }
+
+  scanDir(componentsDir);
+  return [...byName.values()];
+}
+
+/**
+ * Find an integration component's doc file by name within a loaded
+ * integration's resolved `components` dir. Honors the same-stem convention
+ * (`{Name}.doc.{ts,mjs,js}`), preferring `.ts` → `.mjs` → `.js`.
+ *
+ * @param {{components?: string}} integration
+ * @param {string} name bare component name (no `XDS`/`Astryx` prefix)
+ * @returns {string|null}
+ */
+export function findIntegrationComponentDoc(integration, name) {
+  const componentsDir = integration?.components;
+  if (!componentsDir || !fs.existsSync(componentsDir)) return null;
+
+  function scanDir(dirPath) {
+    const entries = fs.readdirSync(dirPath, {withFileTypes: true});
+    // Exact same-stem match (precedence order) first in this dir.
+    for (const suffix of INTEGRATION_DOC_SUFFIXES) {
+      const candidate = path.join(dirPath, `${name}${suffix}`);
+      if (fs.existsSync(candidate)) return candidate;
+    }
+    for (const entry of entries) {
+      if (entry.name === 'node_modules' || entry.name === '__tests__') continue;
+      if (entry.isDirectory()) {
+        const found = scanDir(path.join(dirPath, entry.name));
+        if (found) return found;
+      }
+    }
+    return null;
+  }
+
+  return scanDir(componentsDir);
+}
+
+/**
+ * Find an integration component's swizzleable source file (`{Name}.tsx`) by
+ * name within a loaded integration's resolved `components` dir. Returns null
+ * when the integration ships docs without source.
+ *
+ * @param {{components?: string}} integration
+ * @param {string} name bare component name
+ * @returns {string|null}
+ */
+export function findIntegrationComponentSource(integration, name) {
+  const docPath = findIntegrationComponentDoc(integration, name);
+  if (!docPath) return null;
+  return integrationSourceForDoc(docPath);
+}
+
+/**
+ * Build a flat list of ownership records for ALL discoverable components —
+ * core (built-in) plus every loaded integration. This is the authoritative
+ * source for package-aware listing and disambiguation.
+ *
+ * Core records carry `package: '@astryxdesign/core'`, `issuesUrl: undefined`
+ * (the default core issues URL), and the resolved `.tsx` source via
+ * findComponentSource(). Integration records carry their owner package name,
+ * the manifest `issuesUrl`, and the same-stem `.tsx` source if present.
+ *
+ * @param {string} coreDir
+ * @param {Array<{name: string, components?: string, issuesUrl?: string}>} [loadedIntegrations]
+ * @returns {Array<{name: string, package: string, group: string|null, docPath: string|null, sourcePath: string|null, issuesUrl: string|undefined}>}
+ */
+export function discoverOwnedComponents(coreDir, loadedIntegrations = []) {
+  /** @type {Array<{name: string, package: string, group: string|null, docPath: string|null, sourcePath: string|null, issuesUrl: string|undefined}>} */
+  const records = [];
+
+  // Core components — derive group from discoverComponents (grouped record).
+  const grouped = discoverComponents(coreDir);
+  /** @type {Map<string, string|null>} name → group */
+  const coreGroup = new Map();
+  for (const [key, members] of Object.entries(grouped)) {
+    const isUngrouped = members.length === 1 && members[0] === key;
+    for (const name of members) {
+      coreGroup.set(name, isUngrouped ? null : key);
+    }
+  }
+  for (const [name, group] of coreGroup) {
+    records.push({
+      name,
+      package: CORE_PACKAGE,
+      group,
+      docPath: findComponentReadme(coreDir, name),
+      sourcePath: findComponentSource(coreDir, name),
+      issuesUrl: undefined,
+    });
+  }
+
+  // Integration components.
+  for (const integration of loadedIntegrations) {
+    for (const rec of discoverIntegrationComponents(integration)) {
+      records.push(rec);
+    }
+  }
+
+  return records;
 }
 
 // ── Legacy markdown-parsing functions ────────────────────────────────

--- a/packages/cli/src/types/component.d.ts
+++ b/packages/cli/src/types/component.d.ts
@@ -28,7 +28,18 @@ import type {ComponentDoc, PropDoc} from '../../../core/src/docs-types';
 /** xds --json component [--list] [--category X] [--detail brief] */
 export interface ComponentListResponse {
   type: 'component.list';
-  data: Record<string, string[]>;
+  data: Record<string, ComponentListEntry[]>;
+}
+
+/**
+ * A single entry in a `component.list` group. Pre-1.0 the list moved from bare
+ * strings to package-qualified objects so consumers can disambiguate ownership
+ * (core vs. an integration package).
+ */
+export interface ComponentListEntry {
+  name: string;
+  /** Owner package, e.g. '@astryxdesign/core' or '@acme/astryx-meta'. */
+  package: string;
 }
 
 /** xds --json component --list --detail compact */
@@ -52,7 +63,21 @@ export interface ComponentFullResponse {
 /** xds --json component <name> */
 export interface ComponentDetailResponse {
   type: 'component.detail';
-  data: ComponentDoc;
+  data: ComponentDoc & ComponentOwnership;
+}
+
+/**
+ * Ownership metadata attached to every `component.detail` payload. Exposes the
+ * owner package, the import specifier, and whether a swizzleable source file is
+ * available — the inputs the integration-component swizzle (a later PR) needs.
+ */
+export interface ComponentOwnership {
+  /** Owner package, e.g. '@astryxdesign/core' or an integration package name. */
+  package: string;
+  /** Import specifier for the component (e.g. '@astryxdesign/core/Button'). */
+  import: string;
+  /** Whether a component source file exists for `--source` / swizzle. */
+  sourceAvailable: boolean;
 }
 
 /** xds --json component <name> --props */


### PR DESCRIPTION
## Summary

Make component discovery **ownership-aware** so commands can disambiguate by package and expose source for integration components. This sets up the integration-component swizzle (a later PR).

Each discovered component now carries an ownership record: `{ name, package, docPath, sourcePath, issuesUrl, group }`.
- **Core** components → `package: '@astryxdesign/core'`, `issuesUrl: undefined`.
- **Integration** components → owner package name (from `loadedIntegrations`), the manifest `issuesUrl`, and the same-stem `.tsx` source if present.

### Discovery (`lib/component-discovery.mjs`)
- `discoverIntegrationComponents(integration)` — scans the integration's resolved `components` dir for same-stem doc files (`Name.doc.{ts,mjs,js}`) and records owner package + issuesUrl + sibling `Name.tsx` source.
- `findIntegrationComponentDoc` / `findIntegrationComponentSource` — by-name resolution honoring the same-stem convention.
- `discoverOwnedComponents(coreDir, loadedIntegrations)` — authoritative flat list across core + integrations.
- Core discovery is unchanged (compat preserved).

### Command UX (`api/component.mjs`, `commands/component/index.mjs`)
- `astryx component <Name> [--package <pkg>]`.
- Ambiguous name across multiple packages (core and/or integrations) with no `--package` ⇒ error listing the providing packages and asking for `--package`. No core-first fallback when integration ownership collides. (Legacy `pkg.astryx.docs` externals keep their historical core-first behavior so existing consumers/tests don't regress.)
- `--source` resolves integration source when available; `ERR_NO_SOURCE` otherwise.
- **JSON (pre-1.0 breaking):** `component.list` members move from `string[]` to `{ name, package }` objects. Detail payloads gain `package`, `import`, and `sourceAvailable`.
- Human list omits the core label for readability but always shows the package for integration components and on name collisions.

### Types
- `ComponentListEntry`, updated `ComponentListResponse`, and `ComponentOwnership` (added to `ComponentDetailResponse`) in `types/component.d.ts`. `typecheck:json-api` and the api-contract assert both pass.

### Downstream swizzle readiness
The ownership record explicitly exposes `{ package, sourcePath, issuesUrl }` — exactly the inputs the future integration-component swizzle will need to route source and issues correctly.

## Tests
New `component-ownership.test.mjs` (13 tests): integration ownership records (package/source/issuesUrl), `discoverOwnedComponents`, by-name doc/source resolution, `--package` resolution, `--source` integration source + `ERR_NO_SOURCE`, ambiguous-name error with candidate packages, and the new object-shape JSON list. Existing component tests updated/preserved for the new shape.

## Green gate
- `packages/cli` vitest — **1497 passed, 0 failed**
- `sync-exports --check` — 0
- `add-copyright --check` — 0
- `typecheck:json-api` — 0
- core build + `verify-exports` — 0 (all 10 packages resolve)
- eslint changed files — 0
- `astryx --help`, `component --help`, `component --list --json` emit the new `{name, package}` object shape
- `check-changesets` — 0

## Changeset
`@astryxdesign/cli`: patch — `[feat]` … @ejhammond
