### PR TITLE
feat(cli): validate-integration command

### DIFF
--- a/.changeset/validate-integration.md
+++ b/.changeset/validate-integration.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[feat] Add the validate-integration command and integration issue model for checking an Astryx integration package's manifest and contributions.
+
+@ejhammond

--- a/packages/cli/src/api/template.mjs
+++ b/packages/cli/src/api/template.mjs
@@ -312,63 +312,84 @@ async function discoverIntegrationTemplates(cwd = process.cwd()) {
   }
 
   for (const integration of loadedIntegrations) {
-    const root = integration.templates;
-    if (!root || !fs.existsSync(root)) continue;
+    const result = await discoverIntegrationTemplatesForOne(integration);
+    templates.push(...result.templates);
+    errors.push(...result.errors);
+  }
 
-    for (const docPath of findIntegrationDocFiles(root)) {
-      const suffix = matchedDocSuffix(docPath);
-      const id = path
-        .relative(root, docPath)
-        .slice(0, -suffix.length)
-        .split(path.sep)
-        .join('/');
+  return {templates, errors};
+}
 
-      const sourcePath = docPath.slice(0, -suffix.length) + '.tsx';
-      if (!fs.existsSync(sourcePath)) {
-        errors.push({
-          package: integration.name,
-          template: id,
-          message: `Template "${id}" is missing its same-stem source file ${path.basename(sourcePath)}.`,
-        });
-        continue;
-      }
+/**
+ * Discover the templates contributed by a SINGLE integration. Same per-template
+ * rules as {@link discoverIntegrationTemplates} (same-stem source required,
+ * page|block type required); broken templates are recorded in `errors` rather
+ * than thrown. Exposed for `validate-integration`.
+ *
+ * @param {{name?: string, __spec?: string, templates?: string}} integration
+ * @returns {Promise<{templates: object[], errors: {package: string, template?: string, message: string}[]}>}
+ */
+export async function discoverIntegrationTemplatesForOne(integration) {
+  const templates = [];
+  const errors = [];
 
-      let doc;
-      try {
-        doc = await loadIntegrationDoc(docPath);
-      } catch (err) {
-        errors.push({
-          package: integration.name,
-          template: id,
-          message: `Template "${id}" failed to load: ${err.message}`,
-        });
-        continue;
-      }
+  const root = integration?.templates;
+  const pkgLabel = integration?.name ?? integration?.__spec ?? 'integration';
+  if (!root || !fs.existsSync(root)) return {templates, errors};
 
-      const type = doc?.type;
-      if (type !== 'page' && type !== 'block') {
-        errors.push({
-          package: integration.name,
-          template: id,
-          message: `Template "${id}" is missing a "type" of "page" or "block". Author it with createPageTemplate/createBlockTemplate.`,
-        });
-        continue;
-      }
+  for (const docPath of findIntegrationDocFiles(root)) {
+    const suffix = matchedDocSuffix(docPath);
+    const id = path
+      .relative(root, docPath)
+      .slice(0, -suffix.length)
+      .split(path.sep)
+      .join('/');
 
-      templates.push({
-        type,
-        dirName: id,
-        name: doc?.name || id,
-        description: doc?.description || '',
-        category: doc?.category || '',
-        isReady: true,
-        scaffold: false,
-        componentsUsed: doc?.componentsUsed ?? [],
-        filePath: sourcePath,
-        docPath,
-        package: integration.name,
+    const sourcePath = docPath.slice(0, -suffix.length) + '.tsx';
+    if (!fs.existsSync(sourcePath)) {
+      errors.push({
+        package: pkgLabel,
+        template: id,
+        message: `Template "${id}" is missing its same-stem source file ${path.basename(sourcePath)}.`,
       });
+      continue;
     }
+
+    let doc;
+    try {
+      doc = await loadIntegrationDoc(docPath);
+    } catch (err) {
+      errors.push({
+        package: pkgLabel,
+        template: id,
+        message: `Template "${id}" failed to load: ${err.message}`,
+      });
+      continue;
+    }
+
+    const type = doc?.type;
+    if (type !== 'page' && type !== 'block') {
+      errors.push({
+        package: pkgLabel,
+        template: id,
+        message: `Template "${id}" is missing a "type" of "page" or "block". Author it with createPageTemplate/createBlockTemplate.`,
+      });
+      continue;
+    }
+
+    templates.push({
+      type,
+      dirName: id,
+      name: doc?.name || id,
+      description: doc?.description || '',
+      category: doc?.category || '',
+      isReady: true,
+      scaffold: false,
+      componentsUsed: doc?.componentsUsed ?? [],
+      filePath: sourcePath,
+      docPath,
+      package: pkgLabel,
+    });
   }
 
   return {templates, errors};

--- a/packages/cli/src/api/validate-integration.mjs
+++ b/packages/cli/src/api/validate-integration.mjs
@@ -1,0 +1,371 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Programmatic API for `astryx validate-integration`.
+ *
+ * Validates exactly ONE integration package at a time and reports findings
+ * using the AstryxIntegrationIssue model
+ * ({ code, severity: 'warning'|'error', message }; see
+ * types/integration.d.ts). Two entry points:
+ *
+ *   - validateLocalIntegration(cwd)  — the package rooted at `cwd` (nearest
+ *     package.json + sibling astryx.integration.{ts,mjs,js}).
+ *   - validateInstalledIntegration(spec, cwd) — an installed package resolved
+ *     from `cwd`/node_modules.
+ *
+ * Both return a { found, name, version, manifestFile, issues } result. `found`
+ * is false only for the no-manifest local case, which is guidance (not an
+ * error) so `validate-integration` can stay exit-0 in a non-integration dir.
+ *
+ * Validators are intentionally small and independent so more checks can be
+ * appended without reshaping the result. Issue `code`s are stable public
+ * strings.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {validateIntegration} from '../lib/config-schema.mjs';
+import {
+  findManifestPaths,
+  loadManifestObject,
+  resolvePackageDir,
+} from '../lib/integrations.mjs';
+import {discoverIntegrationCodemods} from '../codemods/integration-discovery.mjs';
+import {discoverIntegrationTemplatesForOne} from './template.mjs';
+import * as componentDiscovery from '../lib/component-discovery.mjs';
+
+/**
+ * @typedef {import('../types/integration').AstryxIntegrationIssue} Issue
+ */
+
+/**
+ * @typedef {Object} ValidateResult
+ * @property {boolean} found Whether an integration manifest was located.
+ * @property {string} [name] Integration package name (from package.json).
+ * @property {string} [version] Integration package version.
+ * @property {string} [manifestFile] Absolute path to the loaded manifest.
+ * @property {Issue[]} issues
+ */
+
+/**
+ * Find the nearest package.json starting from `cwd` and walking up.
+ * @param {string} cwd
+ * @returns {string | null} absolute path to the package.json, or null.
+ */
+function findNearestPackageJson(cwd) {
+  let dir = path.resolve(cwd);
+  for (;;) {
+    const candidate = path.join(dir, 'package.json');
+    if (fs.existsSync(candidate)) return candidate;
+    const parent = path.dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+/** @param {string} code @param {string} message @returns {Issue} */
+function error(code, message) {
+  return {code, severity: 'error', message};
+}
+
+/** @param {string} code @param {string} message @returns {Issue} */
+function warning(code, message) {
+  return {code, severity: 'warning', message};
+}
+
+/**
+ * Validate the manifest object against the integration schema. Schema failures
+ * become a single `invalid_manifest` error issue.
+ * @param {unknown} exported
+ * @param {string} label
+ * @param {Issue[]} issues
+ * @returns {import('../types/integration').AstryxIntegration | null}
+ */
+function validateManifestSchema(exported, label, issues) {
+  if (!exported || typeof exported !== 'object') {
+    issues.push(
+      error(
+        'invalid_manifest',
+        `${label} did not export an integration object.`,
+      ),
+    );
+    return null;
+  }
+  try {
+    return validateIntegration(exported, label);
+  } catch (err) {
+    issues.push(error('invalid_manifest', err.message));
+    return null;
+  }
+}
+
+/**
+ * Verify each declared contribution root exists on disk. A declared-but-missing
+ * root is a `missing_root` error.
+ * @param {{components?: string, templates?: string, codemods?: string}} resolved
+ *   absolute resolved roots (undefined when not declared)
+ * @param {Issue[]} issues
+ */
+function checkRoots(resolved, issues) {
+  for (const kind of ['components', 'templates', 'codemods']) {
+    const root = resolved[kind];
+    if (root == null) continue;
+    if (!fs.existsSync(root)) {
+      issues.push(
+        error(
+          'missing_root',
+          `Declared ${kind} root does not exist on disk: ${root}`,
+        ),
+      );
+    }
+  }
+}
+
+/**
+ * Validate the integration's codemods via the landed discovery. Discovery is
+ * strict (throws on bad export / duplicate id); we convert any throw into an
+ * `invalid_codemod` error.
+ * @param {object} integration loaded-integration-shaped object
+ * @param {Issue[]} issues
+ */
+async function checkCodemods(integration, issues) {
+  if (!integration.codemods || !fs.existsSync(integration.codemods)) return;
+  try {
+    await discoverIntegrationCodemods([integration]);
+  } catch (err) {
+    issues.push(error('invalid_codemod', err.message));
+  }
+}
+
+/**
+ * Validate the integration's templates via the landed discovery. Per-template
+ * problems are reported as `invalid_template` errors.
+ * @param {object} integration loaded-integration-shaped object
+ * @param {Issue[]} issues
+ */
+async function checkTemplates(integration, issues) {
+  if (!integration.templates || !fs.existsSync(integration.templates)) return;
+  try {
+    const {errors} = await discoverIntegrationTemplatesForOne(integration);
+    for (const e of errors) {
+      issues.push(error('invalid_template', e.message));
+    }
+  } catch (err) {
+    issues.push(error('invalid_template', err.message));
+  }
+}
+
+/**
+ * Validate the integration's components via the landed ownership discovery.
+ * Feature-detected: if the component-ownership export isn't present in this
+ * build (sibling PR not yet merged), component validation is skipped rather
+ * than hard-failing.
+ *
+ * `discoverIntegrationComponents` returns ownership records and does not throw
+ * on a missing same-stem source — it records `sourcePath: null`. We surface
+ * each such record as an `invalid_component` error.
+ * @param {object} integration loaded-integration-shaped object
+ * @param {Issue[]} issues
+ */
+async function checkComponents(integration, issues) {
+  if (!integration.components || !fs.existsSync(integration.components)) return;
+  const discover = componentDiscovery.discoverIntegrationComponents;
+  if (typeof discover !== 'function') return; // feature not present yet
+  try {
+    const records = (await discover(integration)) ?? [];
+    for (const record of records) {
+      if (record?.sourcePath == null) {
+        issues.push(
+          error(
+            'invalid_component',
+            `Component "${record?.name}" is missing its same-stem source file ${record?.name}.tsx.`,
+          ),
+        );
+      }
+    }
+  } catch (err) {
+    issues.push(error('invalid_component', err.message));
+  }
+}
+
+/**
+ * Run every contribution validator against a loaded-integration-shaped object.
+ * @param {object} integration
+ * @param {Issue[]} issues
+ */
+async function runContributionChecks(integration, issues) {
+  await checkCodemods(integration, issues);
+  await checkTemplates(integration, issues);
+  await checkComponents(integration, issues);
+}
+
+/**
+ * Validate a single integration given its package directory and identity.
+ * Shared core for the local and installed entry points.
+ * @param {string} packageDir
+ * @param {{name: string, version?: string}} identity
+ * @returns {Promise<ValidateResult>}
+ */
+async function validateAtPackageDir(packageDir, identity) {
+  /** @type {Issue[]} */
+  const issues = [];
+  const result = {
+    found: true,
+    name: identity.name,
+    version: identity.version,
+    manifestFile: undefined,
+    issues,
+  };
+
+  const manifests = findManifestPaths(packageDir);
+  if (manifests.length === 0) {
+    issues.push(
+      error(
+        'missing_manifest',
+        `No astryx.integration.{ts,mjs,js} found next to package.json in ${packageDir}.`,
+      ),
+    );
+    return result;
+  }
+  if (manifests.length > 1) {
+    issues.push(
+      error(
+        'multiple_manifests',
+        `Multiple root manifests present (${manifests
+          .map(m => path.basename(m))
+          .join(', ')}). Keep exactly one.`,
+      ),
+    );
+    return result;
+  }
+
+  const manifestFile = manifests[0];
+  result.manifestFile = manifestFile;
+
+  let exported;
+  try {
+    exported = await loadManifestObject(manifestFile);
+  } catch (err) {
+    issues.push(
+      error('invalid_manifest', `Failed to load manifest: ${err.message}`),
+    );
+    return result;
+  }
+
+  const manifest = validateManifestSchema(
+    exported,
+    `Integration manifest (${path.basename(manifestFile)})`,
+    issues,
+  );
+  if (!manifest) return result;
+
+  const resolveRoot = value =>
+    value == null ? undefined : path.resolve(packageDir, value);
+  const resolved = {
+    components: resolveRoot(manifest.components),
+    templates: resolveRoot(manifest.templates),
+    codemods: resolveRoot(manifest.codemods),
+  };
+
+  checkRoots(resolved, issues);
+
+  const loaded = {
+    name: identity.name,
+    version: identity.version,
+    components: resolved.components,
+    templates: resolved.templates,
+    codemods: resolved.codemods,
+    issuesUrl: manifest.issuesUrl,
+    __spec: identity.name,
+    __packageDir: packageDir,
+    __manifestFile: manifestFile,
+  };
+
+  await runContributionChecks(loaded, issues);
+
+  return result;
+}
+
+/**
+ * Validate the LOCAL integration package rooted at `cwd`: nearest package.json
+ * + a single sibling astryx.integration.{ts,mjs,js}. A missing manifest yields
+ * `found: false` (guidance, not an error) so callers stay exit-0.
+ * @param {string} [cwd]
+ * @returns {Promise<ValidateResult>}
+ */
+export async function validateLocalIntegration(cwd = process.cwd()) {
+  const pkgJsonPath = findNearestPackageJson(cwd);
+  if (!pkgJsonPath) {
+    return {found: false, issues: []};
+  }
+  const packageDir = path.dirname(pkgJsonPath);
+
+  const manifests = findManifestPaths(packageDir);
+  if (manifests.length === 0) {
+    // No manifest next to package.json — guidance, not an error.
+    return {found: false, issues: []};
+  }
+
+  let pkg = {};
+  try {
+    pkg = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf-8'));
+  } catch {
+    // Identity falls back to undefined; the manifest checks still run.
+  }
+
+  return validateAtPackageDir(packageDir, {
+    name: pkg.name ?? '(local package)',
+    version: pkg.version,
+  });
+}
+
+/**
+ * Validate an INSTALLED integration package resolved from `cwd`/node_modules.
+ * @param {string} spec package name
+ * @param {string} [cwd]
+ * @returns {Promise<ValidateResult>}
+ */
+export async function validateInstalledIntegration(spec, cwd = process.cwd()) {
+  const packageDir = resolvePackageDir(spec, cwd);
+  const pkgJsonPath = path.join(packageDir, 'package.json');
+
+  let pkg;
+  try {
+    pkg = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf-8'));
+  } catch {
+    return {
+      found: true,
+      name: spec,
+      version: undefined,
+      issues: [
+        error(
+          'package_not_found',
+          `Could not find installed integration package "${spec}" at ${pkgJsonPath}. Install it first.`,
+        ),
+      ],
+    };
+  }
+
+  return validateAtPackageDir(packageDir, {
+    name: pkg.name ?? spec,
+    version: pkg.version,
+  });
+}
+
+/**
+ * Summarize issues by severity.
+ * @param {Issue[]} issues
+ * @returns {{errors: number, warnings: number}}
+ */
+export function summarizeIssues(issues) {
+  let errors = 0;
+  let warnings = 0;
+  for (const issue of issues) {
+    if (issue.severity === 'error') errors += 1;
+    else if (issue.severity === 'warning') warnings += 1;
+  }
+  return {errors, warnings};
+}
+
+// Re-export issue constructors for callers/tests that want them.
+export {error as integrationError, warning as integrationWarning};

--- a/packages/cli/src/api/validate-integration.test.mjs
+++ b/packages/cli/src/api/validate-integration.test.mjs
@@ -1,0 +1,222 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Hermetic tests for the validate-integration API.
+ *
+ * Each test stands up a temp integration package and exercises the public
+ * validate API directly. Temp dirs live UNDER the repo root (process.cwd())
+ * so node_modules-style paths are within Vite's allowed fs roots; we never
+ * load configs from /tmp.
+ */
+
+import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {pathToFileURL} from 'node:url';
+import {
+  validateLocalIntegration,
+  validateInstalledIntegration,
+  summarizeIssues,
+} from './validate-integration.mjs';
+
+let tmpDir;
+
+// Absolute file:// URL to the codemod helper so codemod modules in the temp
+// package can import createCodemod without node_modules wiring.
+const codemodModuleUrl = pathToFileURL(
+  path.resolve(process.cwd(), 'packages/cli/src/codemod.mjs'),
+).href;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(process.cwd(), '.astryx-validate-it-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, {recursive: true, force: true});
+});
+
+/**
+ * Create an integration package directory with a package.json + manifest.
+ * @param {string} dir
+ * @param {{name?: string, version?: string, manifest: string, manifestExt?: string}} opts
+ */
+function writePackage(dir, {name = '@acme/widgets', version = '1.0.0', manifest, manifestExt = 'mjs'}) {
+  fs.mkdirSync(dir, {recursive: true});
+  fs.writeFileSync(
+    path.join(dir, 'package.json'),
+    JSON.stringify({name, version}),
+  );
+  fs.writeFileSync(path.join(dir, `astryx.integration.${manifestExt}`), manifest);
+}
+
+/** Find issues by code. */
+function byCode(issues, code) {
+  return issues.filter(i => i.code === code);
+}
+
+describe('validate-integration API', () => {
+  it('reports no errors for a valid integration with a codemod', async () => {
+    const pkgDir = path.join(tmpDir, 'pkg');
+    writePackage(pkgDir, {
+      manifest: `export default { codemods: './codemods' };\n`,
+    });
+    const cmDir = path.join(pkgDir, 'codemods', '0.2.0');
+    fs.mkdirSync(cmDir, {recursive: true});
+    fs.writeFileSync(
+      path.join(cmDir, 'drop-foo.mjs'),
+      `import {createCodemod} from ${JSON.stringify(codemodModuleUrl)};\n` +
+        `export default createCodemod({ title: 'Drop foo', transform: (file) => file.source });\n`,
+    );
+
+    const result = await validateLocalIntegration(pkgDir);
+    expect(result.found).toBe(true);
+    expect(result.name).toBe('@acme/widgets');
+    expect(result.version).toBe('1.0.0');
+    const {errors} = summarizeIssues(result.issues);
+    expect(errors).toBe(0);
+  });
+
+  it('flags an unknown manifest key as invalid_manifest error', async () => {
+    const pkgDir = path.join(tmpDir, 'pkg');
+    writePackage(pkgDir, {
+      manifest: `export default { components: './c', bogus: true };\n`,
+    });
+    const result = await validateLocalIntegration(pkgDir);
+    const manifestIssues = byCode(result.issues, 'invalid_manifest');
+    expect(manifestIssues).toHaveLength(1);
+    expect(manifestIssues[0].severity).toBe('error');
+  });
+
+  it('flags a declared-but-missing root as missing_root error', async () => {
+    const pkgDir = path.join(tmpDir, 'pkg');
+    writePackage(pkgDir, {
+      manifest: `export default { templates: './nope' };\n`,
+    });
+    const result = await validateLocalIntegration(pkgDir);
+    const rootIssues = byCode(result.issues, 'missing_root');
+    expect(rootIssues).toHaveLength(1);
+    expect(rootIssues[0].severity).toBe('error');
+    expect(summarizeIssues(result.issues).errors).toBeGreaterThan(0);
+  });
+
+  it('flags multiple manifests as multiple_manifests error', async () => {
+    const pkgDir = path.join(tmpDir, 'pkg');
+    writePackage(pkgDir, {manifest: `export default {};\n`});
+    fs.writeFileSync(path.join(pkgDir, 'astryx.integration.js'), 'export default {};\n');
+    const result = await validateLocalIntegration(pkgDir);
+    expect(byCode(result.issues, 'multiple_manifests')).toHaveLength(1);
+  });
+
+  it('returns found:false (guidance) when no manifest is present', async () => {
+    const pkgDir = path.join(tmpDir, 'pkg');
+    fs.mkdirSync(pkgDir, {recursive: true});
+    fs.writeFileSync(
+      path.join(pkgDir, 'package.json'),
+      JSON.stringify({name: 'plain'}),
+    );
+    const result = await validateLocalIntegration(pkgDir);
+    expect(result.found).toBe(false);
+    expect(result.issues).toEqual([]);
+  });
+
+  it('flags a broken codemod as invalid_codemod error', async () => {
+    const pkgDir = path.join(tmpDir, 'pkg');
+    writePackage(pkgDir, {
+      manifest: `export default { codemods: './codemods' };\n`,
+    });
+    const cmDir = path.join(pkgDir, 'codemods', '0.2.0');
+    fs.mkdirSync(cmDir, {recursive: true});
+    // Missing default export → discovery throws → invalid_codemod.
+    fs.writeFileSync(path.join(cmDir, 'broken.mjs'), `export const nope = 1;\n`);
+
+    const result = await validateLocalIntegration(pkgDir);
+    expect(byCode(result.issues, 'invalid_codemod')).toHaveLength(1);
+  });
+
+  it('flags a broken template as invalid_template error', async () => {
+    const pkgDir = path.join(tmpDir, 'pkg');
+    writePackage(pkgDir, {
+      manifest: `export default { templates: './templates' };\n`,
+    });
+    const tplDir = path.join(pkgDir, 'templates');
+    fs.mkdirSync(tplDir, {recursive: true});
+    // Doc with no same-stem source file.
+    fs.writeFileSync(
+      path.join(tplDir, 'dash.doc.mjs'),
+      `export default { type: 'page', name: 'Dash' };\n`,
+    );
+
+    const result = await validateLocalIntegration(pkgDir);
+    expect(byCode(result.issues, 'invalid_template')).toHaveLength(1);
+  });
+
+  it('validates an installed package resolved from node_modules', async () => {
+    const consumer = path.join(tmpDir, 'consumer');
+    fs.mkdirSync(consumer, {recursive: true});
+    fs.writeFileSync(
+      path.join(consumer, 'package.json'),
+      JSON.stringify({name: 'consumer'}),
+    );
+    const pkgDir = path.join(consumer, 'node_modules', '@acme', 'widgets');
+    writePackage(pkgDir, {
+      name: '@acme/widgets',
+      version: '2.0.0',
+      manifest: `export default { templates: './gone' };\n`,
+    });
+
+    const result = await validateInstalledIntegration('@acme/widgets', consumer);
+    expect(result.found).toBe(true);
+    expect(result.name).toBe('@acme/widgets');
+    expect(result.version).toBe('2.0.0');
+    expect(byCode(result.issues, 'missing_root')).toHaveLength(1);
+  });
+
+  it('flags a non-installed package as package_not_found error', async () => {
+    const consumer = path.join(tmpDir, 'consumer');
+    fs.mkdirSync(consumer, {recursive: true});
+    fs.writeFileSync(
+      path.join(consumer, 'package.json'),
+      JSON.stringify({name: 'consumer'}),
+    );
+    const result = await validateInstalledIntegration('@acme/nope', consumer);
+    expect(byCode(result.issues, 'package_not_found')).toHaveLength(1);
+  });
+
+  it('reports no errors for a valid component (doc + same-stem source)', async () => {
+    const pkgDir = path.join(tmpDir, 'pkg');
+    writePackage(pkgDir, {
+      manifest: `export default { components: './components' };\n`,
+    });
+    const cDir = path.join(pkgDir, 'components');
+    fs.mkdirSync(cDir, {recursive: true});
+    fs.writeFileSync(
+      path.join(cDir, 'Widget.doc.mjs'),
+      `export default { name: 'Widget' };\n`,
+    );
+    fs.writeFileSync(
+      path.join(cDir, 'Widget.tsx'),
+      `export function Widget() { return null; }\n`,
+    );
+
+    const result = await validateLocalIntegration(pkgDir);
+    expect(byCode(result.issues, 'invalid_component')).toHaveLength(0);
+    expect(summarizeIssues(result.issues).errors).toBe(0);
+  });
+
+  it('flags a component doc missing its same-stem source as invalid_component', async () => {
+    const pkgDir = path.join(tmpDir, 'pkg');
+    writePackage(pkgDir, {
+      manifest: `export default { components: './components' };\n`,
+    });
+    const cDir = path.join(pkgDir, 'components');
+    fs.mkdirSync(cDir, {recursive: true});
+    // Doc with no sibling Widget.tsx.
+    fs.writeFileSync(
+      path.join(cDir, 'Widget.doc.mjs'),
+      `export default { name: 'Widget' };\n`,
+    );
+
+    const result = await validateLocalIntegration(pkgDir);
+    expect(byCode(result.issues, 'invalid_component')).toHaveLength(1);
+  });
+});

--- a/packages/cli/src/commands/validate-integration.mjs
+++ b/packages/cli/src/commands/validate-integration.mjs
@@ -1,0 +1,110 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file `astryx validate-integration` command — validate ONE integration
+ * package's manifest and contributions and report findings using the
+ * AstryxIntegrationIssue model.
+ *
+ *   astryx validate-integration            validate the local package (cwd)
+ *   astryx validate-integration <pkg>      validate an installed package
+ *
+ * Exit code is the contract: 0 when there are no severity:'error' issues
+ * (warnings are fine), 1 when any error issue is present — so it works as a CI
+ * gate. The no-arg + no-local-manifest case prints guidance and exits 0 (not
+ * an integration package is not a failure).
+ */
+
+import {jsonOut, humanLog} from '../lib/json.mjs';
+import {
+  validateLocalIntegration,
+  validateInstalledIntegration,
+  summarizeIssues,
+} from '../api/validate-integration.mjs';
+
+/**
+ * Render a validation result for humans.
+ * @param {import('../api/validate-integration.mjs').ValidateResult} result
+ */
+function printHuman(result) {
+  const label =
+    result.version != null
+      ? `${result.name}@${result.version}`
+      : result.name;
+  humanLog(`Validating integration: ${label}`);
+
+  if (result.issues.length === 0) {
+    humanLog('\n\u2713 No issues found.');
+    return;
+  }
+
+  humanLog('');
+  for (const issue of result.issues) {
+    humanLog(`  ${issue.severity} ${issue.code}: ${issue.message}`);
+  }
+
+  const {errors, warnings} = summarizeIssues(result.issues);
+  humanLog(
+    `\n${result.issues.length} issue(s): ${errors} error(s), ${warnings} warning(s)`,
+  );
+}
+
+const NO_MANIFEST_GUIDANCE =
+  'No astryx.integration.* found next to package.json. ' +
+  'To validate an installed integration: astryx validate-integration <package>';
+
+/**
+ * Register the `astryx validate-integration` command.
+ * @param {import('commander').Command} program
+ */
+export function registerValidateIntegration(program) {
+  program
+    .command('validate-integration [package]')
+    .description(
+      'Validate an Astryx integration package (manifest + contributions)',
+    )
+    .addHelpText(
+      'after',
+      '\nWith no argument, validates the integration package rooted at the\n' +
+        'current directory. Pass a package name to validate an installed\n' +
+        'integration resolved from ./node_modules.\n\n' +
+        'Exit code:\n' +
+        '  0  no error issues (warnings are allowed) — safe as a CI gate\n' +
+        '  1  one or more error issues\n',
+    )
+    .action(async pkg => {
+      const json = program.opts().json || false;
+
+      const result = pkg
+        ? await validateInstalledIntegration(pkg)
+        : await validateLocalIntegration();
+
+      // No-arg + no local manifest: guidance, not an error.
+      if (!result.found) {
+        if (json) {
+          jsonOut('integration.validate', {
+            name: null,
+            version: null,
+            issues: [],
+          });
+        } else {
+          humanLog(NO_MANIFEST_GUIDANCE);
+        }
+        return;
+      }
+
+      if (json) {
+        jsonOut('integration.validate', {
+          name: result.name ?? null,
+          version: result.version ?? null,
+          issues: result.issues,
+        });
+      } else {
+        printHuman(result);
+      }
+
+      const {errors} = summarizeIssues(result.issues);
+      if (errors > 0) {
+        process.exitCode = 1;
+      }
+    });
+}

--- a/packages/cli/src/commands/validate-integration.test.mjs
+++ b/packages/cli/src/commands/validate-integration.test.mjs
@@ -1,0 +1,124 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Command-level tests for `astryx validate-integration` — envelope shape
+ * and the no-manifest guidance path.
+ */
+
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {Command} from 'commander';
+
+import {registerValidateIntegration} from './validate-integration.mjs';
+
+let tmpDir;
+let logCalls;
+let prevCwd;
+let prevExit;
+
+beforeEach(() => {
+  // Temp dir under the repo root so manifest/node_modules paths are within
+  // Vite's allowed fs roots.
+  tmpDir = fs.mkdtempSync(path.join(process.cwd(), '.astryx-validate-cmd-'));
+  logCalls = [];
+  vi.spyOn(console, 'log').mockImplementation((...args) => {
+    logCalls.push(args.join(' '));
+  });
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+  prevCwd = process.cwd();
+  prevExit = process.exitCode;
+  process.exitCode = undefined;
+});
+
+afterEach(() => {
+  process.chdir(prevCwd);
+  process.exitCode = prevExit;
+  fs.rmSync(tmpDir, {recursive: true, force: true});
+  vi.restoreAllMocks();
+});
+
+function createProgram() {
+  const program = new Command();
+  program.exitOverride();
+  program.option('--json', 'Output as typed JSON');
+  registerValidateIntegration(program);
+  return program;
+}
+
+describe('validate-integration — command', () => {
+  it('--json emits an integration.validate envelope for a valid package', async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({name: '@acme/widgets', version: '1.2.3'}),
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, 'astryx.integration.mjs'),
+      'export default {};\n',
+    );
+    process.chdir(tmpDir);
+
+    const program = createProgram();
+    await program.parseAsync(['node', 'astryx', '--json', 'validate-integration']);
+
+    const parsed = JSON.parse(logCalls.join('\n'));
+    expect(parsed.apiVersion).toBe(1);
+    expect(parsed.type).toBe('integration.validate');
+    expect(parsed.data.name).toBe('@acme/widgets');
+    expect(parsed.data.version).toBe('1.2.3');
+    expect(Array.isArray(parsed.data.issues)).toBe(true);
+    expect(parsed.data.issues).toHaveLength(0);
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it('--json envelope carries issues and sets exit 1 on errors', async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({name: '@acme/bad', version: '1.0.0'}),
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, 'astryx.integration.mjs'),
+      'export default { templates: "./gone" };\n',
+    );
+    process.chdir(tmpDir);
+
+    const program = createProgram();
+    await program.parseAsync(['node', 'astryx', '--json', 'validate-integration']);
+
+    const parsed = JSON.parse(logCalls.join('\n'));
+    expect(parsed.type).toBe('integration.validate');
+    expect(parsed.data.issues.some(i => i.code === 'missing_root')).toBe(true);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('no-arg + no manifest prints guidance and stays exit 0', async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({name: 'plain'}),
+    );
+    process.chdir(tmpDir);
+
+    const program = createProgram();
+    await program.parseAsync(['node', 'astryx', 'validate-integration']);
+
+    const out = logCalls.join('\n');
+    expect(out).toContain('No astryx.integration.* found next to package.json');
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it('--json with no manifest yields a null-identity envelope', async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({name: 'plain'}),
+    );
+    process.chdir(tmpDir);
+
+    const program = createProgram();
+    await program.parseAsync(['node', 'astryx', '--json', 'validate-integration']);
+
+    const parsed = JSON.parse(logCalls.join('\n'));
+    expect(parsed.type).toBe('integration.validate');
+    expect(parsed.data.name).toBeNull();
+    expect(parsed.data.issues).toEqual([]);
+  });
+});

--- a/packages/cli/src/index.mjs
+++ b/packages/cli/src/index.mjs
@@ -64,6 +64,7 @@ export const JSON_SUPPORTED = new Set([
   'upgrade',
   'manifest',
   'doctor',
+  'validate-integration',
   'layout expand',
   'layout check',
   'layout grammar',
@@ -255,6 +256,11 @@ const commands = [
   {name: 'search', path: './commands/search.mjs', register: 'registerSearch'},
   {name: 'build', path: './commands/build.mjs', register: 'registerBuild'},
   {name: 'doctor', path: './commands/doctor.mjs', register: 'registerDoctor'},
+  {
+    name: 'validate-integration',
+    path: './commands/validate-integration.mjs',
+    register: 'registerValidateIntegration',
+  },
 ];
 
 for (const cmd of commands) {

--- a/packages/cli/src/lib/integrations.mjs
+++ b/packages/cli/src/lib/integrations.mjs
@@ -17,11 +17,35 @@ import {createJiti} from 'jiti';
 import {validateIntegration} from './config-schema.mjs';
 
 /** Conventional manifest basenames, in load-precedence order. */
-const MANIFEST_BASENAMES = [
+export const MANIFEST_BASENAMES = [
   'astryx.integration.ts',
   'astryx.integration.mjs',
   'astryx.integration.js',
 ];
+
+/**
+ * Return the conventional root manifest paths present in `dir`, in
+ * load-precedence order. Unlike {@link resolveManifestPath} this never throws —
+ * callers (e.g. validate-integration) decide how to treat zero / multiple.
+ * @param {string} dir
+ * @returns {string[]} absolute manifest paths
+ */
+export function findManifestPaths(dir) {
+  return MANIFEST_BASENAMES.filter(name =>
+    fs.existsSync(path.join(dir, name)),
+  ).map(name => path.join(dir, name));
+}
+
+/**
+ * Load a manifest module's exported object. `.ts` is loaded via jiti;
+ * `.mjs`/`.js` via dynamic import. Exposed for validate-integration.
+ * @param {string} file absolute manifest path
+ * @returns {Promise<unknown>} the exported integration object (or module)
+ */
+export async function loadManifestObject(file) {
+  const mod = await importManifest(file);
+  return mod.default ?? mod.integration ?? mod;
+}
 
 let jitiInstance;
 function getJiti() {

--- a/packages/cli/src/lib/manifest.mjs
+++ b/packages/cli/src/lib/manifest.mjs
@@ -64,6 +64,7 @@ export const RESPONSE_TYPES = {
   upgrade: ['upgrade.list', 'upgrade.status', 'upgrade.run'],
   manifest: ['manifest'],
   doctor: ['doctor'],
+  'validate-integration': ['integration.validate'],
   'layout expand': ['layout.expand'],
   'layout check': ['layout.check'],
   'layout grammar': ['layout.grammar'],
@@ -87,6 +88,10 @@ const EXAMPLES = {
   upgrade: ['astryx upgrade --json'],
   manifest: ['astryx manifest --json', 'astryx --json'],
   doctor: ['astryx doctor', 'astryx doctor --json'],
+  'validate-integration': [
+    'astryx validate-integration',
+    'astryx validate-integration @acme/widgets --json',
+  ],
   init: ['astryx init'],
   'layout expand': [`astryx layout expand 'V[g6] > C{card-callout}*4' ./src/Page.tsx`],
   'layout check': [`astryx layout check 'A[cp6] > L > LC > S[p6]' --json`],

--- a/packages/cli/src/types/base.d.ts
+++ b/packages/cli/src/types/base.d.ts
@@ -47,6 +47,7 @@ import type {SearchResponse} from './search';
 import type {ErrorCode} from './error-codes';
 import type {ManifestResponse} from './manifest';
 import type {DoctorResponse} from './doctor';
+import type {ValidateIntegrationResponse} from './validate-integration';
 
 /**
  * Structured error. Check `'error' in result` to discriminate.
@@ -100,7 +101,8 @@ export type CLIAnyResponse =
   | UpgradeRunResponse
   | SearchResponse
   | ManifestResponse
-  | DoctorResponse;
+  | DoctorResponse
+  | ValidateIntegrationResponse;
 
 /** Union of all type discriminator string literals. */
 export type CLIResponseType = CLIAnyResponse['type'];

--- a/packages/cli/src/types/validate-integration.d.ts
+++ b/packages/cli/src/types/validate-integration.d.ts
@@ -1,0 +1,24 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * validate-integration command JSON responses.
+ *
+ * Invocation                              -> type discriminator
+ * ------------------------------------------------------------
+ * astryx --json validate-integration       -> integration.validate
+ * astryx --json validate-integration <pkg> -> integration.validate
+ */
+
+import type {AstryxIntegrationIssue} from './integration';
+
+/** astryx --json validate-integration [package] */
+export interface ValidateIntegrationResponse {
+  type: 'integration.validate';
+  data: {
+    /** Integration package name, or null when no manifest was located. */
+    name: string | null;
+    /** Integration package version, or null when unavailable. */
+    version: string | null;
+    issues: AstryxIntegrationIssue[];
+  };
+}


### PR DESCRIPTION
Adds `astryx validate-integration` — validate ONE Astryx integration package at a time and report findings using the `AstryxIntegrationIssue` model (`{ code, severity, message }`).

## Usage
- `astryx validate-integration` — validate the local package at the current root (nearest `package.json` + a single sibling `astryx.integration.{ts,mjs,js}`).
- `astryx validate-integration <pkg>` — validate an installed package resolved from `./node_modules`.
- `--json` emits a typed `integration.validate` envelope.

## Checks (stable issue codes)
- `missing_manifest` / `multiple_manifests` — manifest presence (no-arg + no local manifest prints guidance and exits 0).
- `invalid_manifest` — schema validation (unknown keys, bad `issuesUrl`, wrong types).
- `missing_root` — a declared `components`/`templates`/`codemods` root that doesn't exist on disk.
- `invalid_codemod` / `invalid_template` / `invalid_component` — broken contributions, surfaced via the existing discovery helpers.

Exit code is the contract: `0` when there are no error-severity issues (warnings allowed), `1` otherwise — usable as a CI gate.

## Notes
- Reuses the landed integration schema, resolution, and codemod/template/component discovery; a small per-integration template-discovery helper is extracted from the existing config-driven path (behavior unchanged).
- Tests are hermetic (temp packages under `node_modules`); cover valid integrations, unknown manifest key, missing root, multiple manifests, broken codemod/template/component, installed-package resolution, and the `--json` envelope shape.

Targets `xds-unprefix-integration`; rebased on the merged component-ownership work so component validation is wired up.
