### PR TITLE
fix(vibe-tests): repair report build (core dist .js + esnext target)

### DIFF
--- a/internal/vibe-tests/app/vite.config.report.ts
+++ b/internal/vibe-tests/app/vite.config.report.ts
@@ -38,6 +38,12 @@ const lightningcssTargets = {
 export default defineConfig({
   plugins: [react(), viteSingleFile()],
   build: {
+    // The bundled @astryxdesign/core (Babel output) uses modern syntax that
+    // esbuild can't downlevel to the default es2020 target (destructuring in
+    // certain positions). The report is an internal artifact viewed in current
+    // browsers, so target esnext and skip downleveling. CSS targets stay modern
+    // below to preserve native light-dark().
+    target: 'esnext',
     rollupOptions: {
       input: path.resolve(__dirname, 'index.report.html'),
     },
@@ -76,21 +82,27 @@ export default defineConfig({
       // Core subpath imports → dist (bypasses "source" condition in exports map)
       {
         find: /^@astryxdesign\/core\/(.+)$/,
-        replacement: path.resolve(repoRoot, 'packages/core/dist/$1/index.mjs'),
+        replacement: path.resolve(repoRoot, 'packages/core/dist/$1/index.js'),
       },
       // Core root import
       {
         find: '@astryxdesign/core',
-        replacement: path.resolve(repoRoot, 'packages/core/dist/index.mjs'),
+        replacement: path.resolve(repoRoot, 'packages/core/dist/index.js'),
       },
       // Theme: resolve to source (no StyleX usage, just defineTheme + icons).
       {
         find: '@astryxdesign/theme-neutral',
-        replacement: path.resolve(repoRoot, 'packages/themes/neutral/src/source.ts'),
+        replacement: path.resolve(
+          repoRoot,
+          'packages/themes/neutral/src/source.ts',
+        ),
       },
       {
         find: '@astryxdesign/theme/neutral',
-        replacement: path.resolve(repoRoot, 'packages/themes/neutral/src/source.ts'),
+        replacement: path.resolve(
+          repoRoot,
+          'packages/themes/neutral/src/source.ts',
+        ),
       },
     ],
   },


### PR DESCRIPTION
## What

Repairs the nightly vibe-test **report build** (`build-report.ts`, invoked by
`deploy-report.ts` Step 5), which has been failing since early June — independent of
the recent target rename.

## Why

Two stacked breakages in `internal/vibe-tests/app/vite.config.report.ts`:

1. **Module resolution.** The config aliased `@astryxdesign/core` subpath and root
   imports to `dist/**/index.**mjs**`, but core's build emits `.js` (its `build:esm`
   step uses `--out-file-extension '.js'` since the switch to the Babel CLI). Vite
   could not load the modules → `Could not load .../dist/theme/index.mjs (ENOENT)`.
2. **Transpile target.** After resolution is fixed, esbuild fails to transpile the
   bundled core to Vite's default `es2020` target — `Transforming destructuring … is
   not supported yet` (135 errors) — because no `build.target` is set.

The daily Night Watch logs corroborate the timeline: the report deployed fine on
2026-06-20, then began failing ("Report deploy: Failed — build-report.ts error") on
2026-06-22, shortly after core moved to `.js` output.

## Changes

- Point the core aliases at `dist/**/index.js` (matching what core actually builds).
- Set `build.target: 'esnext'` so esbuild doesn't downlevel core's modern Babel output.
  The report is an internal artifact viewed in current browsers; CSS targets stay modern
  (lightningcss, chrome 123) to preserve native `light-dark()`.

No component source or public types touched. `@astryxdesign/vibe-tests` is a private
(unpublished) package, so no changeset.

## Verification

- `build-report.ts` now produces a self-contained 4-target `report.html` (~510 KB) — the
  rendered HTML includes the Astryx, Astryx+TW, Baseline, and HTML columns/data.
- `deploy-report.ts --dry-run` completes end to end ("Report built but not deployed").
- `eslint` clean; repo pre-commit gates (sync, package-boundaries, changesets,
  demo-media) all pass.
