### PR TITLE
fix(playground): prevent derived color scale from overriding custom accent color

### DIFF
--- a/apps/docsite/src/__tests__/theme-helpers.test.ts
+++ b/apps/docsite/src/__tests__/theme-helpers.test.ts
@@ -1,0 +1,36 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {describe, it, expect} from 'vitest';
+import {getExpandedColorScale} from '../app/playground/themeEditor/helpers';
+
+describe('theme editor helpers - getExpandedColorScale', () => {
+  it('omits --color-accent from output to prevent overriding user picker selection', () => {
+    const scale = getExpandedColorScale('#0064E0');
+    expect(scale).not.toHaveProperty('--color-accent');
+  });
+
+  it('correctly generates other derived semantic color tokens', () => {
+    const scale = getExpandedColorScale('#0064E0');
+    const expectedKeys = [
+      '--color-accent-muted',
+      '--color-neutral',
+      '--color-background-surface',
+      '--color-background-body',
+      '--color-text-primary',
+      '--color-text-secondary',
+      '--shadow-inset-hover',
+      '--shadow-inset-selected',
+    ];
+    for (const key of expectedKeys) {
+      expect(scale).toHaveProperty(key);
+      expect(typeof scale[key]).toBe('string');
+    }
+  });
+
+  it('properly falls back on invalid hex accent color', () => {
+    const scale = getExpandedColorScale('invalid-hex');
+    // Should fall back to black, which produces valid tokens
+    expect(scale).toHaveProperty('--color-neutral');
+    expect(typeof scale['--color-neutral']).toBe('string');
+  });
+});

--- a/apps/docsite/src/app/playground/themeEditor/ThemeEditor.tsx
+++ b/apps/docsite/src/app/playground/themeEditor/ThemeEditor.tsx
@@ -226,6 +226,8 @@ export function ThemeEditor({
 
   const handleExpandColorScale = useCallback((accentHex: string) => {
     const derived = expandColorScale({accent: accentHex});
+    // Do not override the user's custom picker selection for `--color-accent` itself
+    delete derived['--color-accent'];
     let hex = accentHex.replace('#', '');
     // Normalize 3-char short hex (e.g. "f00") to 6-char ("ff0000")
     if (hex.length === 3) {

--- a/apps/docsite/src/app/playground/themeEditor/ThemeEditor.tsx
+++ b/apps/docsite/src/app/playground/themeEditor/ThemeEditor.tsx
@@ -48,6 +48,7 @@ import {
   buildComponentOverrides,
   buildSpacingScale,
   mergeComponentStyleMaps,
+  getExpandedColorScale,
 } from './helpers';
 
 const s = stylex.create({
@@ -225,25 +226,7 @@ export function ThemeEditor({
   }, []);
 
   const handleExpandColorScale = useCallback((accentHex: string) => {
-    const derived = expandColorScale({accent: accentHex});
-    // Do not override the user's custom picker selection for `--color-accent` itself
-    delete derived['--color-accent'];
-    let hex = accentHex.replace('#', '');
-    // Normalize 3-char short hex (e.g. "f00") to 6-char ("ff0000")
-    if (hex.length === 3) {
-      hex = hex[0] + hex[0] + hex[1] + hex[1] + hex[2] + hex[2];
-    }
-    // Guard against invalid hex — fall back to black
-    if (hex.length !== 6 || !/^[0-9a-fA-F]{6}$/.test(hex)) {
-      hex = '000000';
-    }
-    const r = parseInt(hex.slice(0, 2), 16);
-    const g = parseInt(hex.slice(2, 4), 16);
-    const b = parseInt(hex.slice(4, 6), 16);
-    derived['--shadow-inset-hover'] =
-      `inset 0px 0px 0px 2px rgba(${r}, ${g}, ${b}, 0.3)`;
-    derived['--shadow-inset-selected'] =
-      `inset 0px 0px 0px 2px rgba(${r}, ${g}, ${b}, 0.5)`;
+    const derived = getExpandedColorScale(accentHex);
     setTokens(prev => ({...prev, ...derived}));
   }, []);
 

--- a/apps/docsite/src/app/playground/themeEditor/helpers.ts
+++ b/apps/docsite/src/app/playground/themeEditor/helpers.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 import {COMPONENT_VAR_TO_OVERRIDE, COMPONENT_VAR_NAMES} from './constants';
+import {expandColorScale} from '@astryxdesign/core/theme';
 
 export function parseLightDark(
   value: string,
@@ -237,4 +238,27 @@ export function generateThemeCode(
 
   lines.push('});');
   return lines.join('\n');
+}
+
+export function getExpandedColorScale(accentHex: string): Record<string, string> {
+  const derived = expandColorScale({accent: accentHex}) as Record<string, string>;
+  // Do not override the user's custom picker selection for `--color-accent` itself
+  delete derived['--color-accent'];
+  let hex = accentHex.replace('#', '');
+  // Normalize 3-char short hex (e.g. "f00") to 6-char ("ff0000")
+  if (hex.length === 3) {
+    hex = hex[0] + hex[0] + hex[1] + hex[1] + hex[2] + hex[2];
+  }
+  // Guard against invalid hex — fall back to black
+  if (hex.length !== 6 || !/^[0-9a-fA-F]{6}$/.test(hex)) {
+    hex = '000000';
+  }
+  const r = parseInt(hex.slice(0, 2), 16);
+  const g = parseInt(hex.slice(2, 4), 16);
+  const b = parseInt(hex.slice(4, 6), 16);
+  derived['--shadow-inset-hover'] =
+    `inset 0px 0px 0px 2px rgba(${r}, ${g}, ${b}, 0.3)`;
+  derived['--shadow-inset-selected'] =
+    `inset 0px 0px 0px 2px rgba(${r}, ${g}, ${b}, 0.5)`;
+  return derived;
 }


### PR DESCRIPTION
### Summary
This PR fixes a bug in the playground theme editor where toggling "Create from accent" and selecting/typing an accent color causes the input to get "stuck" or automatically shift to a different, derived color (the tone-40/tone-80 HCT tone variant).

### Cause
When "Create from accent" is active, changing `--color-accent` calls `onExpandColorScale(hex)` to derive all semantic scale tokens. However, the derived scale includes a generated `--color-accent` token value (`light-dark(P[40], P[80])`). When merged back into the React state batch, this derived value overrides the exact custom accent color the user selected or typed in the color swatch.

### Fix
Deleted `--color-accent` from the `derived` token object in `handleExpandColorScale` (inside `ThemeEditor.tsx`) before merging it into the token state. This preserves the user's custom accent color selection while successfully generating all other neutral and semantic color tokens from it.

### Verification
* **Manual Check:** Verified in the playground with "Create from accent" active that entering any custom hex values (like `#ff0000 100%`) correctly saves and updates without jumping/reverting.
* **Build Check:** Ran `npx pnpm build` in the docsite to verify compilation is successful with no errors.

Closes #3238
