### PR TITLE
docs(tab): add selected icon example

### DIFF
--- a/packages/cli/templates/blocks/components/Tab/TabWithSelectedIcon.doc.mjs
+++ b/packages/cli/templates/blocks/components/Tab/TabWithSelectedIcon.doc.mjs
@@ -1,0 +1,13 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  exampleFor: 'Tab',
+  name: 'Tab — Selected Icon',
+  displayName: 'Tab — Selected Icon',
+  description: 'A tab that changes its icon when selected.',
+  isReady: true,
+  aspectRatio: 4 / 3,
+  componentsUsed: ['TabList', 'Tab'],
+};

--- a/packages/cli/templates/blocks/components/Tab/TabWithSelectedIcon.tsx
+++ b/packages/cli/templates/blocks/components/Tab/TabWithSelectedIcon.tsx
@@ -1,0 +1,39 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import {useState} from 'react';
+import {TabList, Tab} from '@astryxdesign/core/TabList';
+
+const StarIcon = (
+  <svg
+    viewBox="0 0 16 16"
+    fill="none"
+    stroke="currentColor"
+    width="100%"
+    height="100%">
+    <path d="m8 1.5 2 4.1 4.5.7-3.3 3.2.8 4.5-4-2.1L4 14l.8-4.5-3.3-3.2 4.5-.7L8 1.5Z" />
+  </svg>
+);
+
+const SelectedStarIcon = (
+  <svg viewBox="0 0 16 16" fill="currentColor" width="100%" height="100%">
+    <path d="m8 1.5 2 4.1 4.5.7-3.3 3.2.8 4.5-4-2.1L4 14l.8-4.5-3.3-3.2 4.5-.7L8 1.5Z" />
+  </svg>
+);
+
+export default function TabWithSelectedIcon() {
+  const [value, setValue] = useState('favorites');
+
+  return (
+    <TabList value={value} onChange={setValue}>
+      <Tab
+        value="favorites"
+        label="Favorites"
+        icon={StarIcon}
+        selectedIcon={SelectedStarIcon}
+      />
+      <Tab value="recent" label="Recent" />
+    </TabList>
+  );
+}


### PR DESCRIPTION
## Summary

Add a viewable code example to the `Tab` documentation page.

## Changes

- Add an interactive example showing `icon` and `selectedIcon`.
- Add matching block metadata so the docsite generator registers the example under `Tab`.
- Use only existing `Tab` and `TabList` APIs.

## Validation

- `pnpm build`
- Docsite data generation
- Docsite test suite: 206 tests passed
- Docsite TypeScript check
- ESLint
- Prettier
- Repository pre-commit checks

Fixes #2765
