### PR TITLE
fix(cli): align error-code type declarations with runtime codes

### DIFF
--- a/.changeset/error-codes-drift.md
+++ b/.changeset/error-codes-drift.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[fix] Align the CLI error-code type declarations with the runtime error codes (add the missing ERR_AMBIGUOUS_TEMPLATE declaration).
+
+@ejhammond

--- a/packages/cli/src/types/error-codes.d.ts
+++ b/packages/cli/src/types/error-codes.d.ts
@@ -25,7 +25,9 @@ export type ErrorCode =
   | 'ERR_UNKNOWN_SECTION'
   | 'ERR_UNKNOWN_CATEGORY'
   | 'ERR_UNKNOWN_TEMPLATE'
+  | 'ERR_AMBIGUOUS_TEMPLATE'
   | 'ERR_AMBIGUOUS_COMPONENT'
+  | 'ERR_UNKNOWN_THEME'
   | 'ERR_UNKNOWN_PACKAGE'
   | 'ERR_UNKNOWN_AGENT'
   | 'ERR_UNKNOWN_FEATURE'
@@ -45,7 +47,9 @@ export type ErrorCode =
   | 'ERR_VERSION_DETECT'
   | 'ERR_INVALID_VERSION'
   | 'ERR_DEP_MISSING'
-  | 'ERR_GH_CLI';
+  | 'ERR_GH_CLI'
+  | 'ERR_LAYOUT_PARSE'
+  | 'ERR_LAYOUT_INVALID';
 
 /** The frozen runtime map of all error codes (keys === values). */
 export declare const ERROR_CODES: Readonly<Record<ErrorCode, ErrorCode>>;


### PR DESCRIPTION
The CLI's runtime error codes (`packages/cli/src/lib/error-codes.mjs`) and their
TypeScript declaration (`packages/cli/src/types/error-codes.d.ts`) had drifted: several
codes existed at runtime but were missing from the `.d.ts` union.

This aligns the declaration with the runtime so every runtime error code has a matching
type declaration (and vice-versa). Codes added to the `.d.ts`:

- `ERR_AMBIGUOUS_TEMPLATE`
- `ERR_UNKNOWN_THEME`
- `ERR_LAYOUT_PARSE`
- `ERR_LAYOUT_INVALID`

Append/align-only — no existing codes were renamed, removed, or restructured. New entries
are placed to match the file's existing grouping. No orphans (codes in the `.d.ts` absent
from the runtime) were found.

Verified: `typecheck:json-api`, `sync-exports --check`, copyright check, full `packages/cli`
test suite, ESLint, and the changeset gate all pass.
