### PR TITLE
feat(cli): warn when a configured integration has validation issues

### DIFF
--- a/.changeset/integration-issue-warning.md
+++ b/.changeset/integration-issue-warning.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[feat] component, template, and upgrade now print a one-line non-blocking warning when a configured integration has validation issues, pointing to validate-integration.
+
+@ejhammond

--- a/packages/cli/src/api/validate-integration.mjs
+++ b/packages/cli/src/api/validate-integration.mjs
@@ -200,6 +200,39 @@ async function runContributionChecks(integration, issues) {
 }
 
 /**
+ * Validate an already-LOADED integration (as produced by
+ * `loadIntegrations` in lib/integrations.mjs — absolute contribution roots
+ * plus identity) and return its issues. This is the reuse seam for everyday
+ * commands that have already loaded the configured integrations and want the
+ * SAME validators that `validate-integration` runs, without re-resolving the
+ * manifest from disk.
+ *
+ * The manifest schema is intentionally NOT re-validated here: `loadIntegrations`
+ * already validated it (and throws otherwise), so by the time a command holds a
+ * loaded integration the manifest is known-good. We re-run the on-disk
+ * contribution checks (roots + codemods/templates/components) because those can
+ * regress independently of the manifest (a deleted directory, a broken template).
+ *
+ * @param {object} loaded loaded-integration-shaped object
+ * @returns {Promise<Issue[]>}
+ */
+export async function validateLoadedIntegration(loaded) {
+  /** @type {Issue[]} */
+  const issues = [];
+  if (!loaded || typeof loaded !== 'object') return issues;
+  checkRoots(
+    {
+      components: loaded.components,
+      templates: loaded.templates,
+      codemods: loaded.codemods,
+    },
+    issues,
+  );
+  await runContributionChecks(loaded, issues);
+  return issues;
+}
+
+/**
  * Validate a single integration given its package directory and identity.
  * Shared core for the local and installed entry points.
  * @param {string} packageDir
@@ -261,27 +294,22 @@ async function validateAtPackageDir(packageDir, identity) {
 
   const resolveRoot = value =>
     value == null ? undefined : path.resolve(packageDir, value);
-  const resolved = {
-    components: resolveRoot(manifest.components),
-    templates: resolveRoot(manifest.templates),
-    codemods: resolveRoot(manifest.codemods),
-  };
-
-  checkRoots(resolved, issues);
 
   const loaded = {
     name: identity.name,
     version: identity.version,
-    components: resolved.components,
-    templates: resolved.templates,
-    codemods: resolved.codemods,
+    components: resolveRoot(manifest.components),
+    templates: resolveRoot(manifest.templates),
+    codemods: resolveRoot(manifest.codemods),
     issuesUrl: manifest.issuesUrl,
     __spec: identity.name,
     __packageDir: packageDir,
     __manifestFile: manifestFile,
   };
 
-  await runContributionChecks(loaded, issues);
+  // Roots + contribution checks are shared with validateLoadedIntegration so
+  // the everyday-command nudge runs the exact same validators.
+  issues.push(...(await validateLoadedIntegration(loaded)));
 
   return result;
 }

--- a/packages/cli/src/commands/component/index.mjs
+++ b/packages/cli/src/commands/component/index.mjs
@@ -24,6 +24,8 @@ import {cliError} from '../../lib/cli-error.mjs';
 import {ERROR_CODES} from '../../lib/error-codes.mjs';
 import {component as componentApi} from '../../api/component.mjs';
 import {findRelatedBlocks} from '../../api/template.mjs';
+import {loadConfig} from '../../lib/config.mjs';
+import {warnOnIntegrationIssues} from '../../lib/integration-warnings.mjs';
 
 export function registerComponent(program) {
   program
@@ -53,6 +55,16 @@ export function registerComponent(program) {
       if (!validDetails.includes(detail)) {
         cliError(`Invalid --detail value "${detail}". Valid levels: ${validDetails.join(', ')}`, {code: ERROR_CODES.ERR_INVALID_DETAIL});
         return;
+      }
+
+      // Non-blocking nudge: if any configured integration has validation
+      // issues, print one compact line to stderr pointing at
+      // validate-integration. Best-effort; suppressed in --json mode.
+      try {
+        const config = await loadConfig(process.cwd());
+        await warnOnIntegrationIssues(config.loadedIntegrations, {json});
+      } catch {
+        // Never let the nudge break the command.
       }
 
       let result;

--- a/packages/cli/src/commands/template.mjs
+++ b/packages/cli/src/commands/template.mjs
@@ -12,6 +12,8 @@ import {jsonOut, humanLog} from '../lib/json.mjs';
 import {cliError} from '../lib/cli-error.mjs';
 import {ERROR_CODES} from '../lib/error-codes.mjs';
 import {template as templateApi} from '../api/template.mjs';
+import {loadConfig} from '../lib/config.mjs';
+import {warnOnIntegrationIssues} from '../lib/integration-warnings.mjs';
 
 export {discoverTemplates, listTemplates} from '../api/template.mjs';
 
@@ -34,6 +36,16 @@ export function registerTemplate(program) {
     .option('-f, --overwrite', 'Overwrite existing files without prompting')
     .action(async (name, targetPath, options) => {
       const json = program.opts().json || false;
+
+      // Non-blocking nudge: if any configured integration has validation
+      // issues, print one compact line to stderr pointing at
+      // validate-integration. Best-effort; suppressed in --json mode.
+      try {
+        const config = await loadConfig(process.cwd());
+        await warnOnIntegrationIssues(config.loadedIntegrations, {json});
+      } catch {
+        // Never let the nudge break the command.
+      }
 
       // Pre-flight overwrite check (only when we'd actually copy a file).
       // The API resolves the destination; we need to mirror its logic

--- a/packages/cli/src/commands/upgrade.mjs
+++ b/packages/cli/src/commands/upgrade.mjs
@@ -43,6 +43,7 @@ import {isValidSemver, semverGte} from '../utils/semver.mjs';
 import {jsonOut, jsonError} from '../lib/json.mjs';
 import {loadConfig} from '../lib/config.mjs';
 import {loadIntegrations} from '../lib/integrations.mjs';
+import {warnOnIntegrationIssues} from '../lib/integration-warnings.mjs';
 import {ERROR_CODES} from '../lib/error-codes.mjs';
 
 const execFileAsync = promisify(execFile);
@@ -272,6 +273,16 @@ export function registerUpgrade(program) {
         p.log.info(
           `Integrations: ${integrations.map(i => i.name ?? i.__spec).join(', ')}`,
         );
+      }
+
+      // Non-blocking nudge: if any configured integration has validation
+      // issues, print one compact line to stderr pointing at
+      // validate-integration. Best-effort; suppressed in --json mode. The
+      // integrations are already loaded above, so this is cheap.
+      try {
+        await warnOnIntegrationIssues(integrations, {json});
+      } catch {
+        // Never let the nudge break the upgrade.
       }
 
       if (!options.force && semverGte(currentVersion, targetVersion)) {

--- a/packages/cli/src/lib/integration-warnings.mjs
+++ b/packages/cli/src/lib/integration-warnings.mjs
@@ -1,0 +1,62 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Compact, non-blocking integration-issue nudge for everyday commands.
+ *
+ * When a CONFIGURED integration (from loadConfig's `loadedIntegrations`) has
+ * validation issues, the everyday commands (component / template / upgrade)
+ * should print ONE compact, non-blocking line per integration telling the user
+ * to run `validate-integration` — instead of silently skipping broken
+ * contributions or spamming per-contribution diagnostics.
+ *
+ * Design constraints (all enforced here):
+ *   - Reuses the validate-integration validators (validateLoadedIntegration);
+ *     no validation logic is duplicated.
+ *   - Writes to STDERR only, so it never corrupts a --json stdout envelope.
+ *   - Suppressed entirely in --json mode.
+ *   - Best-effort: never throws, never changes the exit code. Broken
+ *     contributions are still skipped downstream exactly as before; this only
+ *     ADDS a one-line nudge.
+ */
+
+import {validateLoadedIntegration} from '../api/validate-integration.mjs';
+
+/**
+ * For each configured (already-loaded) integration, compute its issues using
+ * the shared validate-integration validators and, if any exist, print exactly
+ * ONE line per integration to stderr:
+ *
+ *   Warning: <pkg> has N integration issue(s). Run: astryx validate-integration <pkg>
+ *
+ * @param {Array<object>} loadedIntegrations integrations from loadConfig
+ * @param {{json?: boolean}} [options]
+ * @returns {Promise<void>}
+ */
+export async function warnOnIntegrationIssues(loadedIntegrations, {json = false} = {}) {
+  try {
+    // Cheap guard: only do work when integrations are actually configured.
+    if (json) return;
+    if (!Array.isArray(loadedIntegrations) || loadedIntegrations.length === 0) {
+      return;
+    }
+    for (const integration of loadedIntegrations) {
+      if (!integration || typeof integration !== 'object') continue;
+      let issues;
+      try {
+        issues = await validateLoadedIntegration(integration);
+      } catch {
+        // Best-effort: a validator throwing must not break the host command.
+        continue;
+      }
+      if (!Array.isArray(issues) || issues.length === 0) continue;
+      const pkg = integration.name ?? integration.__spec ?? '(integration)';
+      // Stderr only — keeps stdout (and any --json envelope) clean.
+      console.error(
+        `Warning: ${pkg} has ${issues.length} integration issue(s). ` +
+          `Run: astryx validate-integration ${pkg}`,
+      );
+    }
+  } catch {
+    // Never throw, never change the exit code.
+  }
+}

--- a/packages/cli/src/lib/integration-warnings.test.mjs
+++ b/packages/cli/src/lib/integration-warnings.test.mjs
@@ -1,0 +1,102 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Hermetic tests for the compact integration-issue nudge.
+ *
+ * Builds loaded-integration-shaped objects (as produced by
+ * lib/integrations.mjs) with absolute contribution roots under the repo root
+ * (process.cwd()) so any node_modules-style path stays within Vite's allowed
+ * fs roots. We never load configs from /tmp. The helper is exercised directly;
+ * stderr is captured to assert exactly one warning line per broken integration
+ * and zero output in --json mode / for clean integrations.
+ */
+
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {warnOnIntegrationIssues} from './integration-warnings.mjs';
+
+let tmpDir;
+let errSpy;
+let errLines;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(process.cwd(), '.astryx-warn-it-'));
+  errLines = [];
+  errSpy = vi.spyOn(console, 'error').mockImplementation((...args) => {
+    errLines.push(args.join(' '));
+  });
+});
+
+afterEach(() => {
+  errSpy.mockRestore();
+  fs.rmSync(tmpDir, {recursive: true, force: true});
+});
+
+/**
+ * Build a loaded-integration-shaped object. Roots are absolute (mirrors
+ * loadIntegrations' resolveRoot).
+ */
+function loaded({name = '@acme/widgets', components, templates, codemods} = {}) {
+  return {
+    name,
+    version: '1.0.0',
+    components: components == null ? undefined : path.join(tmpDir, components),
+    templates: templates == null ? undefined : path.join(tmpDir, templates),
+    codemods: codemods == null ? undefined : path.join(tmpDir, codemods),
+    __spec: name,
+    __packageDir: tmpDir,
+  };
+}
+
+describe('warnOnIntegrationIssues', () => {
+  it('emits exactly one stderr line for an integration with issues', async () => {
+    // Declared components root that does not exist on disk → missing_root.
+    const integration = loaded({components: 'does-not-exist'});
+    await warnOnIntegrationIssues([integration], {json: false});
+
+    expect(errLines).toHaveLength(1);
+    expect(errLines[0]).toBe(
+      'Warning: @acme/widgets has 1 integration issue(s). ' +
+        'Run: astryx validate-integration @acme/widgets',
+    );
+  });
+
+  it('emits nothing in --json mode (keeps stdout/JSON clean)', async () => {
+    const integration = loaded({components: 'does-not-exist'});
+    await warnOnIntegrationIssues([integration], {json: true});
+    expect(errLines).toHaveLength(0);
+  });
+
+  it('emits nothing for an integration with no issues', async () => {
+    // Existing components root with no broken contributions → no issues.
+    const componentsRoot = path.join(tmpDir, 'components');
+    fs.mkdirSync(componentsRoot, {recursive: true});
+    const integration = loaded({components: 'components'});
+    await warnOnIntegrationIssues([integration], {json: false});
+    expect(errLines).toHaveLength(0);
+  });
+
+  it('emits nothing when there are no configured integrations', async () => {
+    await warnOnIntegrationIssues([], {json: false});
+    await warnOnIntegrationIssues(undefined, {json: false});
+    expect(errLines).toHaveLength(0);
+  });
+
+  it('emits one line per broken integration', async () => {
+    const a = loaded({name: '@acme/a', components: 'missing-a'});
+    const b = loaded({name: '@acme/b', templates: 'missing-b'});
+    await warnOnIntegrationIssues([a, b], {json: false});
+    expect(errLines).toHaveLength(2);
+    expect(errLines[0]).toContain('@acme/a');
+    expect(errLines[1]).toContain('@acme/b');
+  });
+
+  it('never throws and never emits when a validator misbehaves', async () => {
+    // A non-object entry must be skipped silently.
+    await expect(
+      warnOnIntegrationIssues([null, 'nope', 42], {json: false}),
+    ).resolves.toBeUndefined();
+    expect(errLines).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a compact, **non-blocking** nudge: when a *configured* integration (from `loadConfig`'s `loadedIntegrations`) has validation issues, the everyday commands — `component`, `template`, and `upgrade` — now print exactly **one line per integration** to **stderr**:

```
Warning: <pkg> has N integration issue(s). Run: astryx validate-integration <pkg>
```

…instead of silently skipping broken contributions or spamming per-contribution diagnostics.

## How it reuses the validators (no duplication)

- `src/api/validate-integration.mjs` now exports `validateLoadedIntegration(loaded)`, which runs the **same** root + contribution validators (`checkRoots` + codemods/templates/components) against an already-loaded integration shaped like `loadIntegrations`' output. `validateAtPackageDir` was refactored to call it, so the local/installed `validate-integration` paths and the nudge share one code path.
- A small shared helper `src/lib/integration-warnings.mjs` (`warnOnIntegrationIssues(loadedIntegrations, { json })`) computes issues per integration and emits the one-liner.

## Safety

- **stderr only** — never corrupts a `--json` stdout envelope.
- **Suppressed in `--json` mode** entirely.
- **Never throws, never changes the exit code** (best-effort, wrapped in try/catch at both the helper and call sites).
- Broken contributions are still skipped downstream exactly as before; this only **adds** a one-line nudge. Cheap: only runs validators when integrations are configured.

## Tests

New hermetic `integration-warnings.test.mjs` (fixtures under repo root, never `/tmp`): a configured integration with an issue → exactly one stderr line; `--json` mode → no output; clean integration → no output; one line per broken integration; no-config and misbehaving-input cases stay silent and never throw. Full `packages/cli` suite green (1561 tests).

@ejhammond
