### PR TITLE
feat(cli): move XLE app components to experimental.xle.components config

### DIFF
--- a/.changeset/xle-experimental-components.md
+++ b/.changeset/xle-experimental-components.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[feat] XLE app-component registration moved into validated config under experimental.xle.components (object form), replacing the unvalidated layout.components read.
+
+@ejhammond

--- a/packages/cli/src/api/layout.mjs
+++ b/packages/cli/src/api/layout.mjs
@@ -25,66 +25,14 @@ import {expand} from '../lib/xle/expand.mjs';
 import {toCompact, toOutline} from '../lib/xle/print.mjs';
 import {buildRegistry, ALIAS_TABLE} from '../lib/xle/registry.mjs';
 import {discoverTemplates, stripTemplateAssetRefs} from './template.mjs';
-import {findConfigPath} from '../lib/config.mjs';
-import {pathToFileURL} from 'node:url';
-import {createJiti} from 'jiti';
-
-let jitiInstance;
-function getJiti() {
-  if (!jitiInstance) jitiInstance = createJiti(import.meta.url);
-  return jitiInstance;
-}
-
-/**
- * Read the raw `layout.components` map from the app config, if present.
- *
- * The locked v1 config surface (validated by loadConfig) does not include the
- * XLE `layout.components` bridge, so this reads the raw default export directly
- * rather than going through schema validation. Best-effort: a missing/invalid
- * config yields an empty map.
- *
- * @param {string} cwd
- * @returns {Promise<Record<string, unknown>>}
- */
-async function readLayoutComponents(cwd) {
-  // Prefer a config directly in cwd (XLE callers pass the project dir as cwd);
-  // fall back to the sibling-of-nearest-package.json resolution.
-  const CONFIG_BASENAMES = [
-    'astryx.config.ts',
-    'astryx.config.mjs',
-    'astryx.config.js',
-  ];
-  let configPath = null;
-  for (const name of CONFIG_BASENAMES) {
-    const candidate = path.join(cwd, name);
-    if (fs.existsSync(candidate)) {
-      configPath = candidate;
-      break;
-    }
-  }
-  if (!configPath) {
-    try {
-      configPath = findConfigPath(cwd);
-    } catch {
-      return {};
-    }
-  }
-  if (!configPath) return {};
-  try {
-    const mod = configPath.endsWith('.ts')
-      ? await getJiti().import(configPath)
-      : await import(pathToFileURL(configPath).href);
-    return mod.default?.layout?.components ?? {};
-  } catch {
-    return {};
-  }
-}
+import {loadConfig} from '../lib/config.mjs';
 
 /**
  * The catalog a `{hint}` can resolve to: template blocks (spliced inline) plus
- * any app-registered local components from astryx.config.mjs `layout.components`
- * (imported by name). App components are how XLE reaches domain pieces — the
- * KpiCard/chart/drawer set that the @astryxdesign/core registry can't see.
+ * any app-registered local components from astryx.config.mjs
+ * `experimental.xle.components` (imported by name). App components are how XLE
+ * reaches domain pieces — the KpiCard/chart/drawer set that the
+ * @astryxdesign/core registry can't see.
  */
 async function loadBlocks(cwd) {
   const blocks = [];
@@ -95,19 +43,20 @@ async function loadBlocks(cwd) {
     // discovery is best-effort
   }
   try {
-    const components = await readLayoutComponents(cwd);
+    const config = await loadConfig(cwd);
+    const components = config.experimental?.xle?.components ?? {};
     for (const [name, spec] of Object.entries(components)) {
-      const importPath = typeof spec === 'string' ? spec : spec.from;
+      const importPath = spec.from;
       if (!importPath) continue;
       blocks.push({
         type: 'block',
         kind: 'component',
         dirName: name,
         name,
-        description: typeof spec === 'object' ? spec.description || '' : '',
+        description: spec.description ?? '',
         category: 'app',
         importPath,
-        isDefault: typeof spec === 'object' ? Boolean(spec.default) : false,
+        isDefault: Boolean(spec.default),
       });
     }
   } catch {
@@ -333,7 +282,7 @@ TEMPLATE REFERENCING  ({hint} pulls in real content — this is how XLE reaches 
   {kpi-card}                   standalone reference (no wrapper element) — place a component directly
   {kpi-card}*4                 repeat a reference; the definition/import is emitted once
   app components               register local ones in astryx.config.mjs to import them by name:
-                                 export default {layout: {components: {KpiCard: '@/components/KpiCard'}}}
+                                 export default {experimental: {xle: {components: {KpiCard: {from: '@/components/KpiCard'}}}}}
                                then {kpi-card} → import {KpiCard} + <KpiCard /> (kebab ↔ Pascal)
 
 STRUCTURE THE EXPANDER HANDLES

--- a/packages/cli/src/api/layout.test.mjs
+++ b/packages/cli/src/api/layout.test.mjs
@@ -196,11 +196,14 @@ describe('template referencing', () => {
 
   it('imports app-registered local components (the local-component bridge)', async () => {
     // Inside the workspace so @astryxdesign/core resolves; cleaned up after.
+    // A package.json beside the config makes loadConfig resolve it as the
+    // sibling-of-nearest-package.json (the standard config resolution).
     const cwd = mkdtempSync(join(process.cwd(), '.xle-imp-test-'));
     try {
+      writeFileSync(join(cwd, 'package.json'), '{"name": "xle-imp-fixture"}\n');
       writeFileSync(
         join(cwd, 'astryx.config.mjs'),
-        `export default {layout: {components: {KpiCard: '@/components/KpiCard', TimeRangePicker: {from: '@/components/TimeRangePicker'}}}};\n`,
+        `export default {experimental: {xle: {components: {KpiCard: {from: '@/components/KpiCard'}, TimeRangePicker: {from: '@/components/TimeRangePicker'}}}}};\n`,
       );
       const result = await layoutExpand('S[p6] > (G[c4 g4] > {kpi-card}*4) + {time-range-picker}', {
         name: 'Demo',

--- a/packages/cli/src/lib/config-schema.mjs
+++ b/packages/cli/src/lib/config-schema.mjs
@@ -15,6 +15,14 @@ export const PostCodemodHookSchema = z
   })
   .strict();
 
+export const XleComponentSchema = z
+  .object({
+    from: z.string(),
+    description: z.string().optional(),
+    default: z.boolean().optional(),
+  })
+  .strict();
+
 export const AstryxConfigSchema = z
   .object({
     integrations: z.array(z.string()).optional(),
@@ -22,6 +30,17 @@ export const AstryxConfigSchema = z
     hooks: z
       .object({
         postCodemod: z.array(PostCodemodHookSchema).optional(),
+      })
+      .strict()
+      .optional(),
+    experimental: z
+      .object({
+        xle: z
+          .object({
+            components: z.record(z.string(), XleComponentSchema).optional(),
+          })
+          .strict()
+          .optional(),
       })
       .strict()
       .optional(),

--- a/packages/cli/src/lib/config.mjs
+++ b/packages/cli/src/lib/config.mjs
@@ -80,7 +80,7 @@ async function importConfig(file) {
  * Returns an empty config when no config file is found.
  *
  * @param {string} [startDir]
- * @returns {Promise<{integrations: string[], issuesUrl?: string, hooks?: object, loadedIntegrations: object[]}>}
+ * @returns {Promise<{integrations: string[], issuesUrl?: string, hooks?: object, experimental?: object, loadedIntegrations: object[]}>}
  */
 export async function loadConfig(startDir = process.cwd()) {
   const configPath = findConfigPath(startDir);
@@ -102,6 +102,7 @@ export async function loadConfig(startDir = process.cwd()) {
     integrations,
     issuesUrl: config.issuesUrl,
     hooks: config.hooks,
+    experimental: config.experimental,
     loadedIntegrations,
   };
 }

--- a/packages/cli/src/lib/config.test.mjs
+++ b/packages/cli/src/lib/config.test.mjs
@@ -102,6 +102,68 @@ describe('loadConfig', () => {
     await expect(loadConfig(dir)).rejects.toThrow(/integrations/);
   });
 
+  it('exposes experimental.xle.components from the config', async () => {
+    const dir = makeRoot('experimental');
+    fs.writeFileSync(
+      path.join(dir, 'astryx.config.mjs'),
+      `export default {
+        experimental: {
+          xle: {
+            components: {
+              KpiCard: { from: '@/components/KpiCard' },
+              Chart: { from: '@/components/Chart', description: 'A chart', default: true },
+            },
+          },
+        },
+      };\n`,
+    );
+    const config = await loadConfig(dir);
+    expect(config.experimental.xle.components.KpiCard).toEqual({
+      from: '@/components/KpiCard',
+    });
+    expect(config.experimental.xle.components.Chart).toEqual({
+      from: '@/components/Chart',
+      description: 'A chart',
+      default: true,
+    });
+  });
+
+  it('rejects unknown keys under experimental (strict)', async () => {
+    const dir = makeRoot('exp-strict');
+    fs.writeFileSync(
+      path.join(dir, 'astryx.config.mjs'),
+      `export default { experimental: { bogus: true } };\n`,
+    );
+    await expect(loadConfig(dir)).rejects.toThrow(/bogus|Unrecognized/);
+  });
+
+  it('rejects unknown keys under experimental.xle (strict)', async () => {
+    const dir = makeRoot('exp-xle-strict');
+    fs.writeFileSync(
+      path.join(dir, 'astryx.config.mjs'),
+      `export default { experimental: { xle: { nope: 1 } } };\n`,
+    );
+    await expect(loadConfig(dir)).rejects.toThrow(/nope|Unrecognized/);
+  });
+
+  it('rejects a string shorthand for a component (object-only)', async () => {
+    const dir = makeRoot('exp-string');
+    fs.writeFileSync(
+      path.join(dir, 'astryx.config.mjs'),
+      `export default { experimental: { xle: { components: { Foo: './x' } } } };\n`,
+    );
+    await expect(loadConfig(dir)).rejects.toThrow(/components/);
+  });
+
+  it('rejects an unknown key under a component (strict)', async () => {
+    const dir = makeRoot('exp-comp-strict');
+    fs.writeFileSync(
+      path.join(dir, 'astryx.config.mjs'),
+      `export default { experimental: { xle: { components: { Foo: { from: './x', extra: 1 } } } } };\n`,
+    );
+    await expect(loadConfig(dir)).rejects.toThrow(/extra|Unrecognized/);
+  });
+
   it('rejects multiple config files at the same root', async () => {
     const dir = makeRoot('dupe');
     fs.writeFileSync(path.join(dir, 'astryx.config.mjs'), `export default {};\n`);

--- a/packages/cli/src/types/config.d.ts
+++ b/packages/cli/src/types/config.d.ts
@@ -31,6 +31,16 @@ export type PostCodemodHook = {
     | Promise<PostCodemodCommand | null | undefined>;
 };
 
+/** A component XLE layout expressions can reference by name via `{hint}`. */
+export interface XleComponent {
+  /** Import specifier the component is imported from, e.g. '@/components/KpiCard'. */
+  from: string;
+  /** Optional human description shown in tooling. */
+  description?: string;
+  /** Import as the module's default export instead of a named export. Defaults to false. */
+  default?: boolean;
+}
+
 /** User config exported from astryx.config.{ts,mjs,js}. */
 export interface AstryxConfig {
   /** Integration package names to load. */
@@ -40,6 +50,20 @@ export interface AstryxConfig {
   /** Lifecycle hooks. */
   hooks?: {
     postCodemod?: PostCodemodHook[];
+  };
+  /**
+   * EXPERIMENTAL — shape may change and is not part of the stable config
+   * contract. Provisional home for features still being proven out.
+   */
+  experimental?: {
+    /** Experimental XLE (layout expression) configuration. */
+    xle?: {
+      /**
+       * Register app-local components so XLE layout expressions can
+       * reference them by name via {hint}. Keyed by component name.
+       */
+      components?: Record<string, XleComponent>;
+    };
   };
 }
 


### PR DESCRIPTION
## Summary

Moves XLE app-component registration into the validated Astryx config under a new `experimental.xle.components` field, replacing the previous unvalidated raw-read of `layout.components`.

Authors register app-local components so XLE layout expressions can reference them by name via `{hint}`:

```js
export default {
  experimental: {
    xle: {
      components: {
        KpiCard: {from: '@/components/KpiCard'},
      },
    },
  },
};
```

`{kpi-card}` then expands to `import {KpiCard} from '@/components/KpiCard'` and `<KpiCard />`.

## What changed

- **Types**: added `experimental.xle.components` (`Record<string, XleComponent>`) to `AstryxConfig`, plus an exported `XleComponent` interface (`{ from, description?, default? }`).
- **Schema**: added a strict `XleComponentSchema` and the `experimental.xle.components` branch to the strict config schema. Unknown keys still error; the component shape is object-only (the old string shorthand now throws).
- **Loader**: `loadConfig` passes `experimental` through.
- **XLE**: removed the raw-read shim (and its special "config directly in cwd first" lookup). XLE now reads components via `loadConfig`, using the same standard sibling-of-nearest-`package.json` resolution as the rest of the CLI.
- Updated `layout grammar` help text to document the new config shape.

## Tests

- Migrated the app-component bridge test to the new `experimental.xle.components` object shape.
- Added config tests: valid passthrough; strict rejection of unknown keys under `experimental` / `experimental.xle` / a component; and the string shorthand now throwing.

Full CLI suite green (1560 tests).
