### PR TITLE
refactor(cli): extract shared module-loader util for config + integration loading

### DIFF
--- a/.changeset/module-loader-extract.md
+++ b/.changeset/module-loader-extract.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[chore] Extract the shared module-loading + conventional-file-discovery helpers used by config and integration loading into one internal util (no behavior change).
+
+@ejhammond

--- a/packages/cli/src/lib/config.mjs
+++ b/packages/cli/src/lib/config.mjs
@@ -11,10 +11,9 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import {pathToFileURL} from 'node:url';
-import {createJiti} from 'jiti';
 import {loadIntegrations} from './integrations.mjs';
 import {validateConfig} from './config-schema.mjs';
+import {importUserModule, findPresentFiles} from './module-loader.mjs';
 
 /** Conventional config basenames, in load-precedence order. */
 const CONFIG_BASENAMES = [
@@ -22,14 +21,6 @@ const CONFIG_BASENAMES = [
   'astryx.config.mjs',
   'astryx.config.js',
 ];
-
-let jitiInstance;
-function getJiti() {
-  if (!jitiInstance) {
-    jitiInstance = createJiti(import.meta.url);
-  }
-  return jitiInstance;
-}
 
 /**
  * Find the directory of the nearest package.json walking up from startDir.
@@ -53,26 +44,15 @@ function findPackageRoot(startDir) {
  */
 export function findConfigPath(startDir = process.cwd()) {
   const root = findPackageRoot(startDir) ?? startDir;
-  const present = CONFIG_BASENAMES.filter(name =>
-    fs.existsSync(path.join(root, name)),
-  );
+  const present = findPresentFiles(root, CONFIG_BASENAMES);
   if (present.length > 1) {
     throw new Error(
-      `Multiple Astryx config files found in ${root} (${present.join(', ')}). Keep exactly one.`,
+      `Multiple Astryx config files found in ${root} (${present
+        .map(file => path.basename(file))
+        .join(', ')}). Keep exactly one.`,
     );
   }
-  return present.length === 1 ? path.join(root, present[0]) : null;
-}
-
-/**
- * Load a config module. `.ts` is loaded via jiti; `.mjs`/`.js` via dynamic
- * import.
- */
-async function importConfig(file) {
-  if (file.endsWith('.ts')) {
-    return await getJiti().import(file);
-  }
-  return await import(pathToFileURL(file).href);
+  return present.length === 1 ? present[0] : null;
 }
 
 /**
@@ -88,7 +68,7 @@ export async function loadConfig(startDir = process.cwd()) {
     return {integrations: [], loadedIntegrations: []};
   }
 
-  const mod = await importConfig(configPath);
+  const mod = await importUserModule(configPath);
   const rawConfig = mod.default ?? {};
   const config = validateConfig(rawConfig);
 

--- a/packages/cli/src/lib/integrations.mjs
+++ b/packages/cli/src/lib/integrations.mjs
@@ -12,9 +12,8 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import {pathToFileURL} from 'node:url';
-import {createJiti} from 'jiti';
 import {validateIntegration} from './config-schema.mjs';
+import {importUserModule, findPresentFiles} from './module-loader.mjs';
 
 /** Conventional manifest basenames, in load-precedence order. */
 export const MANIFEST_BASENAMES = [
@@ -31,9 +30,7 @@ export const MANIFEST_BASENAMES = [
  * @returns {string[]} absolute manifest paths
  */
 export function findManifestPaths(dir) {
-  return MANIFEST_BASENAMES.filter(name =>
-    fs.existsSync(path.join(dir, name)),
-  ).map(name => path.join(dir, name));
+  return findPresentFiles(dir, MANIFEST_BASENAMES);
 }
 
 /**
@@ -43,16 +40,8 @@ export function findManifestPaths(dir) {
  * @returns {Promise<unknown>} the exported integration object (or module)
  */
 export async function loadManifestObject(file) {
-  const mod = await importManifest(file);
+  const mod = await importUserModule(file);
   return mod.default ?? mod.integration ?? mod;
-}
-
-let jitiInstance;
-function getJiti() {
-  if (!jitiInstance) {
-    jitiInstance = createJiti(import.meta.url);
-  }
-  return jitiInstance;
 }
 
 /**
@@ -73,9 +62,7 @@ export function resolvePackageDir(packageName, cwd = process.cwd()) {
  * @returns {string} absolute manifest path
  */
 function resolveManifestPath(packageDir, spec) {
-  const present = MANIFEST_BASENAMES.filter(name =>
-    fs.existsSync(path.join(packageDir, name)),
-  );
+  const present = findPresentFiles(packageDir, MANIFEST_BASENAMES);
   if (present.length === 0) {
     throw new Error(
       `Integration package "${spec}" has no conventional root manifest. Add one of: ${MANIFEST_BASENAMES.join(', ')} next to its package.json.`,
@@ -83,22 +70,12 @@ function resolveManifestPath(packageDir, spec) {
   }
   if (present.length > 1) {
     throw new Error(
-      `Integration package "${spec}" has multiple root manifests (${present.join(', ')}). Keep exactly one.`,
+      `Integration package "${spec}" has multiple root manifests (${present
+        .map(file => path.basename(file))
+        .join(', ')}). Keep exactly one.`,
     );
   }
-  return path.join(packageDir, present[0]);
-}
-
-/**
- * Load a manifest module. `.ts` is loaded via jiti; `.mjs`/`.js` via dynamic
- * import.
- * @param {string} file
- */
-async function importManifest(file) {
-  if (file.endsWith('.ts')) {
-    return await getJiti().import(file);
-  }
-  return await import(pathToFileURL(file).href);
+  return present[0];
 }
 
 /**
@@ -127,7 +104,7 @@ export async function loadIntegrations(specs = [], {cwd = process.cwd()} = {}) {
     }
 
     const manifestFile = resolveManifestPath(packageDir, spec);
-    const mod = await importManifest(manifestFile);
+    const mod = await importUserModule(manifestFile);
     const exported = mod.default ?? mod.integration ?? mod;
     if (!exported || typeof exported !== 'object') {
       throw new Error(`Integration ${spec} did not export an object.`);

--- a/packages/cli/src/lib/module-loader.mjs
+++ b/packages/cli/src/lib/module-loader.mjs
@@ -1,0 +1,50 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Shared module-loading + conventional-file-discovery primitives.
+ *
+ * Both config loading and integration loading need to (a) import a
+ * user-authored module (`.ts` via jiti, `.mjs`/`.js` via native dynamic
+ * import) and (b) find conventional files by basename in a fixed
+ * load-precedence order. These helpers centralize that so the two callers stay
+ * in lockstep.
+ */
+
+import * as path from 'node:path';
+import {pathToFileURL} from 'node:url';
+import * as fs from 'node:fs';
+import {createJiti} from 'jiti';
+
+let jitiInstance;
+function getJiti() {
+  if (!jitiInstance) {
+    jitiInstance = createJiti(import.meta.url);
+  }
+  return jitiInstance;
+}
+
+/**
+ * Import a user-authored module. `.ts` is loaded via jiti; `.mjs`/`.js` via
+ * native dynamic import (file:// URL). Returns the full module namespace.
+ * @param {string} file absolute path
+ * @returns {Promise<Record<string, unknown>>}
+ */
+export async function importUserModule(file) {
+  if (file.endsWith('.ts')) {
+    return await getJiti().import(file);
+  }
+  return await import(pathToFileURL(file).href);
+}
+
+/**
+ * Return the conventional files (by basename, in the given precedence order)
+ * that exist directly in `dir`, as absolute paths. Never throws.
+ * @param {string} dir
+ * @param {string[]} basenames precedence-ordered
+ * @returns {string[]} absolute paths of present files, in basenames order
+ */
+export function findPresentFiles(dir, basenames) {
+  return basenames
+    .filter(name => fs.existsSync(path.join(dir, name)))
+    .map(name => path.join(dir, name));
+}

--- a/packages/cli/src/lib/module-loader.test.mjs
+++ b/packages/cli/src/lib/module-loader.test.mjs
@@ -1,0 +1,59 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {findPresentFiles, importUserModule} from './module-loader.mjs';
+
+let tmpDir;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(process.cwd(), '.astryx-module-loader-test-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, {recursive: true, force: true});
+});
+
+describe('findPresentFiles', () => {
+  const basenames = ['a.ts', 'b.mjs', 'c.js'];
+
+  it('returns [] when none of the basenames are present', () => {
+    expect(findPresentFiles(tmpDir, basenames)).toEqual([]);
+  });
+
+  it('returns only the present files, in basenames precedence order', () => {
+    // Create out of order to prove the result follows `basenames`, not disk order.
+    fs.writeFileSync(path.join(tmpDir, 'c.js'), '');
+    fs.writeFileSync(path.join(tmpDir, 'a.ts'), '');
+    const present = findPresentFiles(tmpDir, basenames);
+    expect(present.map(p => path.basename(p))).toEqual(['a.ts', 'c.js']);
+  });
+
+  it('returns absolute paths joined to the given directory', () => {
+    fs.writeFileSync(path.join(tmpDir, 'b.mjs'), '');
+    const present = findPresentFiles(tmpDir, basenames);
+    expect(present).toEqual([path.join(tmpDir, 'b.mjs')]);
+    expect(path.isAbsolute(present[0])).toBe(true);
+  });
+
+  it('does not match files in nested subdirectories', () => {
+    const nested = path.join(tmpDir, 'nested');
+    fs.mkdirSync(nested);
+    fs.writeFileSync(path.join(nested, 'a.ts'), '');
+    expect(findPresentFiles(tmpDir, basenames)).toEqual([]);
+  });
+});
+
+describe('importUserModule', () => {
+  it('imports a .mjs file and returns its module namespace', async () => {
+    const file = path.join(tmpDir, 'mod.mjs');
+    fs.writeFileSync(
+      file,
+      `export default {answer: 42};\nexport const named = 'hi';\n`,
+    );
+    const mod = await importUserModule(file);
+    expect(mod.default).toEqual({answer: 42});
+    expect(mod.named).toBe('hi');
+  });
+});


### PR DESCRIPTION
Pure internal refactor — no behavior change, no public API/CLI/JSON change.

Config loading (`config.mjs`) and integration loading (`integrations.mjs`) each
duplicated two primitives:

- a jiti singleton plus a "import a user module (`.ts` via jiti, else native
  dynamic import of a `file://` URL)" helper, and
- a "find conventional files by basename in load-precedence order" filter.

This extracts both into a single tiny internal util,
`packages/cli/src/lib/module-loader.mjs`, exporting `importUserModule(file)` and
`findPresentFiles(dir, basenames)`, and routes both callers through it.

Behavior-identical: all error message strings (multiple config files, missing /
multiple root manifests) and all public return shapes and signatures are
preserved. Existing `config.test.mjs` and `integrations.test.mjs` pass unchanged;
new unit tests cover `findPresentFiles` and `importUserModule`.
