### PR TITLE
refactor(cli): use shared module-loader for codemod and template-doc loading

### DIFF
--- a/.changeset/dedupe-jiti-loaders.md
+++ b/.changeset/dedupe-jiti-loaders.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[chore] Integration codemod and template-doc loading now use the shared module-loader util instead of duplicating the jiti/import logic.
+
+@ejhammond

--- a/packages/cli/src/api/template.mjs
+++ b/packages/cli/src/api/template.mjs
@@ -6,8 +6,7 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import {pathToFileURL} from 'node:url';
-import {createJiti} from 'jiti';
+import {importUserModule} from '../lib/module-loader.mjs';
 import {CLI_ROOT, discoverExternalPackages} from '../utils/paths.mjs';
 import {
   assertWithin,
@@ -24,12 +23,6 @@ const CORE_PACKAGE = '@astryxdesign/core';
 /** Doc-file basename suffixes for integration templates, in precedence order. */
 const DOC_SUFFIXES = ['.doc.ts', '.doc.mjs', '.doc.js'];
 
-let jitiInstance;
-function getJiti() {
-  if (!jitiInstance) jitiInstance = createJiti(import.meta.url);
-  return jitiInstance;
-}
-
 /**
  * Load an integration template doc module. `.ts` is loaded via jiti; `.mjs`/
  * `.js` via dynamic import. The doc may be the default export (e.g.
@@ -38,9 +31,7 @@ function getJiti() {
  * @param {string} file
  */
 async function loadIntegrationDoc(file) {
-  const mod = file.endsWith('.ts')
-    ? await getJiti().import(file)
-    : await import(pathToFileURL(file).href);
+  const mod = await importUserModule(file);
   return mod.default ?? mod.doc ?? null;
 }
 

--- a/packages/cli/src/codemods/integration-discovery.mjs
+++ b/packages/cli/src/codemods/integration-discovery.mjs
@@ -24,32 +24,11 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import {pathToFileURL} from 'node:url';
-import {createJiti} from 'jiti';
+import {importUserModule} from '../lib/module-loader.mjs';
 import {semverCompare} from '../utils/semver.mjs';
 
 /** File extensions recognized as codemod modules. */
 const CODEMOD_EXTENSIONS = ['.ts', '.mjs', '.js'];
-
-let jitiInstance;
-function getJiti() {
-  if (!jitiInstance) {
-    jitiInstance = createJiti(import.meta.url);
-  }
-  return jitiInstance;
-}
-
-/**
- * Import a codemod module. `.ts` is loaded via jiti; `.mjs`/`.js` via dynamic
- * import.
- * @param {string} file
- */
-async function importCodemodModule(file) {
-  if (file.endsWith('.ts')) {
-    return await getJiti().import(file);
-  }
-  return await import(pathToFileURL(file).href);
-}
 
 /**
  * Recursively collect codemod module files under a version folder. Returns
@@ -170,7 +149,7 @@ export async function discoverIntegrationCodemods(loadedIntegrations = []) {
         }
         idToVersion.set(id, version);
 
-        const mod = await importCodemodModule(file);
+        const mod = await importUserModule(file);
         const codemod = validateCodemodExport(mod, label);
 
         const entry = {


### PR DESCRIPTION
Follow-on to the module-loader extraction. Routes the two remaining config-adjacent jiti/import call sites through the shared `module-loader.mjs` helper instead of duplicating the `.ts`-via-jiti / `.mjs`-via-dynamic-import logic:

- `codemods/integration-discovery.mjs` — integration codemod module loading now calls `importUserModule`.
- `api/template.mjs` — integration template-doc loading now calls `importUserModule` (keeping the `default ?? doc` unwrap).

`build-theme.mjs` is intentionally left as-is: it constructs jiti with custom options (`moduleCache: false`, `jsx: true`) and uses the `{ default: true }` import shortcut, so it doesn't fit the shared helper without widening its API.

No behavior change. After this, `createJiti`/`jitiInstance` exist only in `module-loader.mjs` (and the distinct `build-theme.mjs` case).
