### PR TITLE
fix(docsite): use Link trigger in HoverCard "Link Preview" example (#2728)

### DIFF
--- a/packages/cli/templates/blocks/components/HoverCard/HoverCardInteractiveContent.doc.mjs
+++ b/packages/cli/templates/blocks/components/HoverCard/HoverCardInteractiveContent.doc.mjs
@@ -10,5 +10,5 @@ export const doc = {
     'Shows a page summary when hovering a link: title, description, and URL. Use for documentation links, article references, or any URL where a preview helps the user decide whether to click.',
   isReady: true,
   aspectRatio: 16 / 9,
-  componentsUsed: ['HoverCard', 'Icon', 'Layout', 'Text'],
+  componentsUsed: ['HoverCard', 'Icon', 'Layout', 'Link', 'Text'],
 };

--- a/packages/cli/templates/blocks/components/HoverCard/HoverCardInteractiveContent.tsx
+++ b/packages/cli/templates/blocks/components/HoverCard/HoverCardInteractiveContent.tsx
@@ -5,12 +5,14 @@
 import {HoverCard} from '@astryxdesign/core/HoverCard';
 import {Icon} from '@astryxdesign/core/Icon';
 import {VStack, HStack} from '@astryxdesign/core/Layout';
+import {Link} from '@astryxdesign/core/Link';
 import {Text} from '@astryxdesign/core/Text';
 import {LinkIcon} from '@heroicons/react/24/outline';
 
 export default function HoverCardInteractiveContent() {
   return (
-    <Text type="body">Read more in the{' '}
+    <Text type="body">
+      Read more in the{' '}
       <HoverCard
         placement="below"
         content={
@@ -30,8 +32,11 @@ export default function HoverCardInteractiveContent() {
             </HStack>
           </VStack>
         }>
-        Getting Started Guide
-      </HoverCard>.
-          </Text>
+        <Link href="#" hasUnderline>
+          Getting Started Guide
+        </Link>
+      </HoverCard>
+      .
+    </Text>
   );
 }


### PR DESCRIPTION
## Summary

The "Link Preview" example on the HoverCard docsite page had no interactive trigger — the HoverCard child was a plain text string, leaving nothing visually distinct to hover over.

## Cause

The HoverCardInteractiveContent example passed "Getting Started Guide" as a plain text child to HoverCard. While HoverCard does wrap text-only children in a hoverable <span>, this gave no semantic link affordance — there was no underline, no cursor change, and nothing to signal to the user that the text was interactive. For a "Link Preview" pattern specifically, the trigger should be an actual link.

## Fix

Replaced the plain text child with <Link href="#" hasUnderline>Getting Started Guide</Link>. hasUnderline ensures the underline is always visible (not just on hover), making the trigger immediately discoverable. Updated componentsUsed in the doc to include 'Link' and propagated the change to all generated registry files.

Closes #2728 