### PR TITLE
  fix(docsite): add examples for DateTimeInput and DateRangeInput (# 2724)

### DIFF
--- a/packages/cli/templates/blocks/components/DateRangeInput/DateRangeInputWithPresets.doc.mjs
+++ b/packages/cli/templates/blocks/components/DateRangeInput/DateRangeInputWithPresets.doc.mjs
@@ -1,0 +1,14 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  exampleFor: 'DateRangeInput',
+  name: 'DateRangeInput — With Presets',
+  displayName: 'DateRangeInput — With Presets',
+  description:
+    'Date range picker with quick-select presets for common periods. Use for analytics dashboards, report filters, or any context where users frequently select standard time windows.',
+  isReady: true,
+  aspectRatio: 4 / 3,
+  componentsUsed: ['DateRangeInput', 'Layout', 'Text'],
+};

--- a/packages/cli/templates/blocks/components/DateRangeInput/DateRangeInputWithPresets.tsx
+++ b/packages/cli/templates/blocks/components/DateRangeInput/DateRangeInputWithPresets.tsx
@@ -1,0 +1,46 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import {useState} from 'react';
+import {DateRangeInput} from '@astryxdesign/core/DateRangeInput';
+import type {DateRange} from '@astryxdesign/core/DateRangeInput';
+import type {ISODateString} from '@astryxdesign/core/Calendar';
+import {Stack} from '@astryxdesign/core/Layout';
+import {Text} from '@astryxdesign/core/Text';
+
+function daysAgo(n: number): ISODateString {
+  const d = new Date();
+  d.setDate(d.getDate() - n);
+  return d.toISOString().slice(0, 10) as ISODateString;
+}
+
+function today(): ISODateString {
+  return new Date().toISOString().slice(0, 10) as ISODateString;
+}
+
+const presets = [
+  {label: 'Last 7 days', getRange: () => ({start: daysAgo(7), end: today()})},
+  {label: 'Last 14 days', getRange: () => ({start: daysAgo(14), end: today()})},
+  {label: 'Last 30 days', getRange: () => ({start: daysAgo(30), end: today()})},
+  {label: 'Last 90 days', getRange: () => ({start: daysAgo(90), end: today()})},
+];
+
+export default function DateRangeInputWithPresets() {
+  const [range, setRange] = useState<DateRange | null>(null);
+
+  return (
+    <Stack direction="vertical" gap={4} width="100%" style={{maxWidth: 400}}>
+      <Text type="supporting" color="secondary">
+        {range ? `${range.start} → ${range.end}` : 'No range selected'}
+      </Text>
+      <DateRangeInput
+        label="Report period"
+        description="Use a preset or pick a custom range"
+        value={range}
+        onChange={setRange}
+        presets={presets}
+      />
+    </Stack>
+  );
+}

--- a/packages/cli/templates/blocks/components/DateRangeInput/DateRangeInputWithValidation.doc.mjs
+++ b/packages/cli/templates/blocks/components/DateRangeInput/DateRangeInputWithValidation.doc.mjs
@@ -1,0 +1,14 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  exampleFor: 'DateRangeInput',
+  name: 'DateRangeInput — Validation',
+  displayName: 'DateRangeInput — Validation',
+  description:
+    'Date range input in all three status states: error, warning, and success. Use to surface booking conflicts, flag high-demand periods, or confirm an available range.',
+  isReady: true,
+  aspectRatio: 4 / 3,
+  componentsUsed: ['DateRangeInput', 'Layout'],
+};

--- a/packages/cli/templates/blocks/components/DateRangeInput/DateRangeInputWithValidation.tsx
+++ b/packages/cli/templates/blocks/components/DateRangeInput/DateRangeInputWithValidation.tsx
@@ -1,0 +1,52 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import {useState} from 'react';
+import {DateRangeInput} from '@astryxdesign/core/DateRangeInput';
+import type {DateRange} from '@astryxdesign/core/DateRangeInput';
+import {Stack} from '@astryxdesign/core/Layout';
+
+export default function DateRangeInputWithValidation() {
+  const [errorRange, setErrorRange] = useState<DateRange | null>({
+    start: '2026-01-01',
+    end: '2026-01-31',
+  });
+  const [warningRange, setWarningRange] = useState<DateRange | null>({
+    start: '2026-06-01',
+    end: '2026-06-30',
+  });
+  const [successRange, setSuccessRange] = useState<DateRange | null>({
+    start: '2026-03-01',
+    end: '2026-03-31',
+  });
+
+  return (
+    <Stack direction="vertical" gap={4} width="100%" style={{maxWidth: 400}}>
+      <DateRangeInput
+        label="Booking period"
+        value={errorRange}
+        onChange={setErrorRange}
+        status={{
+          type: 'error',
+          message: 'Selected dates are no longer available',
+        }}
+      />
+      <DateRangeInput
+        label="Preferred period"
+        value={warningRange}
+        onChange={setWarningRange}
+        status={{
+          type: 'warning',
+          message: 'High demand — limited availability',
+        }}
+      />
+      <DateRangeInput
+        label="Confirmed period"
+        value={successRange}
+        onChange={setSuccessRange}
+        status={{type: 'success', message: 'Dates confirmed and available'}}
+      />
+    </Stack>
+  );
+}

--- a/packages/cli/templates/blocks/components/DateTimeInput/DateTimeInputWithValidation.doc.mjs
+++ b/packages/cli/templates/blocks/components/DateTimeInput/DateTimeInputWithValidation.doc.mjs
@@ -1,0 +1,14 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  exampleFor: 'DateTimeInput',
+  name: 'DateTimeInput — Validation',
+  displayName: 'DateTimeInput — Validation',
+  description:
+    'DateTimeInput in all three status states: error, warning, and success. Use to surface scheduling conflicts, caution the user about edge cases, or confirm a valid datetime.',
+  isReady: true,
+  aspectRatio: 4 / 3,
+  componentsUsed: ['DateTimeInput', 'Layout'],
+};

--- a/packages/cli/templates/blocks/components/DateTimeInput/DateTimeInputWithValidation.tsx
+++ b/packages/cli/templates/blocks/components/DateTimeInput/DateTimeInputWithValidation.tsx
@@ -1,0 +1,43 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import {useState} from 'react';
+import {DateTimeInput} from '@astryxdesign/core/DateTimeInput';
+import type {ISODateTimeString} from '@astryxdesign/core/DateTimeInput';
+import {Stack} from '@astryxdesign/core/Layout';
+
+export default function DateTimeInputWithValidation() {
+  const [errorVal, setErrorVal] = useState<ISODateTimeString | undefined>(
+    '2026-01-25T09:00' as ISODateTimeString,
+  );
+  const [warningVal, setWarningVal] = useState<ISODateTimeString | undefined>(
+    '2026-12-25T14:00' as ISODateTimeString,
+  );
+  const [successVal, setSuccessVal] = useState<ISODateTimeString | undefined>(
+    '2026-03-10T10:30' as ISODateTimeString,
+  );
+
+  return (
+    <Stack direction="vertical" gap={4} width="100%" style={{maxWidth: 400}}>
+      <DateTimeInput
+        label="Meeting time"
+        value={errorVal}
+        onChange={setErrorVal}
+        status={{type: 'error', message: 'This time slot is already booked'}}
+      />
+      <DateTimeInput
+        label="Preferred time"
+        value={warningVal}
+        onChange={setWarningVal}
+        status={{type: 'warning', message: 'This falls outside business hours'}}
+      />
+      <DateTimeInput
+        label="Start time"
+        value={successVal}
+        onChange={setSuccessVal}
+        status={{type: 'success', message: 'Time confirmed'}}
+      />
+    </Stack>
+  );
+}


### PR DESCRIPTION
## Summary

This PR fixes missing example blocks on the DateTimeInput and DateRangeInput docsite pages, which left both components with empty Examples sections and no "Open in playground" link.

## Cause

Both components only had a showcase block (isShowcase: true), which populates the component thumbnail/hero. Showcases are not picked up as Examples — those require separate block files with isShowcase omitted or false. With no example blocks registered under exampleFor: 'DateTimeInput' / exampleFor: 'DateRangeInput', the Examples section on each page was empty and the playground link never appeared.

## Fix

Added new example blocks under packages/cli/templates/blocks/components/:

- DateTimeInputWithValidation — Shows DateTimeInput in all three status states (error, warning, success) with a meeting scheduling scenario.
- DateRangeInputWithValidation — Shows DateRangeInput in all three status states with a booking conflict scenario.
- DateRangeInputWithPresets — Shows DateRangeInput with four common analytics presets (Last 7 / 14 / 30 / 90 days) and a live selected-range display.

Closes #2724 
Closes #2709