### PR TITLE
fix(docsite): add example and usage guidance for BaseTypeahead (#2679)

### DIFF
--- a/packages/cli/templates/blocks/components/BaseTypeahead/BaseTypeaheadCustomSearch.doc.mjs
+++ b/packages/cli/templates/blocks/components/BaseTypeahead/BaseTypeaheadCustomSearch.doc.mjs
@@ -1,0 +1,14 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  exampleFor: 'BaseTypeahead',
+  name: 'BaseTypeahead — Custom Search Bar',
+  displayName: 'BaseTypeahead — Custom Search Bar',
+  description:
+    'BaseTypeahead embedded inside a custom-styled wrapper. The wrapper provides its own border and icon chrome; anchorRef positions the dropdown relative to it. Use this pattern when Typeahead\'s built-in field layout does not fit your composition.',
+  isReady: true,
+  aspectRatio: 16 / 9,
+  componentsUsed: ['BaseTypeahead', 'Icon', 'Layout', 'Text'],
+};

--- a/packages/cli/templates/blocks/components/BaseTypeahead/BaseTypeaheadCustomSearch.tsx
+++ b/packages/cli/templates/blocks/components/BaseTypeahead/BaseTypeaheadCustomSearch.tsx
@@ -1,0 +1,58 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import {useRef, useState} from 'react';
+import {BaseTypeahead, createStaticSource} from '@astryxdesign/core/Typeahead';
+import type {SearchableItem} from '@astryxdesign/core/Typeahead';
+import {Icon} from '@astryxdesign/core/Icon';
+import {HStack, VStack} from '@astryxdesign/core/Layout';
+import {Text} from '@astryxdesign/core/Text';
+import {MagnifyingGlassIcon} from '@heroicons/react/24/outline';
+
+const frameworks: SearchableItem[] = [
+  {id: 'react', label: 'React'},
+  {id: 'vue', label: 'Vue'},
+  {id: 'angular', label: 'Angular'},
+  {id: 'svelte', label: 'Svelte'},
+  {id: 'solid', label: 'SolidJS'},
+  {id: 'remix', label: 'Remix'},
+  {id: 'next', label: 'Next.js'},
+  {id: 'nuxt', label: 'Nuxt'},
+];
+
+const source = createStaticSource(frameworks);
+
+export default function BaseTypeaheadCustomSearch() {
+  const [value, setValue] = useState<SearchableItem | null>(null);
+  const wrapperRef = useRef<HTMLElement>(null);
+
+  return (
+    <VStack gap={3} style={{width: 320}}>
+      <HStack
+        ref={wrapperRef}
+        gap={2}
+        vAlign="center"
+        style={{
+          border: '1px solid var(--color-border)',
+          borderRadius: 'var(--radius-control)',
+          padding: '6px 10px',
+          background: 'var(--color-surface)',
+        }}>
+        <Icon icon={MagnifyingGlassIcon} size="sm" color="secondary" />
+        <BaseTypeahead
+          searchSource={source}
+          value={value}
+          onChange={setValue}
+          anchorRef={wrapperRef}
+          placeholder="Search frameworks…"
+          hasEntriesOnFocus
+          debounceMs={0}
+        />
+      </HStack>
+      <Text type="supporting" color="secondary">
+        {value != null ? `Selected: ${value.label}` : 'No selection'}
+      </Text>
+    </VStack>
+  );
+}

--- a/packages/core/src/Typeahead/BaseTypeahead.doc.mjs
+++ b/packages/core/src/Typeahead/BaseTypeahead.doc.mjs
@@ -8,7 +8,6 @@ export const docs = {
   displayName: 'Base Typeahead',
   isHiddenFromOverview: true,
   description: 'Unstyled combobox engine providing input, search, keyboard navigation, and dropdown. No wrapper div, no border styling, no token rendering. Used by Typeahead and Tokenizer for custom compositions.',
-  relatedComponents: ['Typeahead', 'Tokenizer'],
   usage: {
     description: 'Unstyled combobox engine providing input, search, keyboard navigation, and dropdown. No wrapper div, no border styling, no token rendering. Used by Typeahead and Tokenizer for custom compositions.',
     bestPractices: [

--- a/packages/core/src/Typeahead/BaseTypeahead.doc.mjs
+++ b/packages/core/src/Typeahead/BaseTypeahead.doc.mjs
@@ -8,6 +8,17 @@ export const docs = {
   displayName: 'Base Typeahead',
   isHiddenFromOverview: true,
   description: 'Unstyled combobox engine providing input, search, keyboard navigation, and dropdown. No wrapper div, no border styling, no token rendering. Used by Typeahead and Tokenizer for custom compositions.',
+  relatedComponents: ['Typeahead', 'Tokenizer'],
+  usage: {
+    description: 'Unstyled combobox engine providing input, search, keyboard navigation, and dropdown. No wrapper div, no border styling, no token rendering. Used by Typeahead and Tokenizer for custom compositions.',
+    bestPractices: [
+      { guidance: true, description: 'Use Typeahead or Tokenizer for standard fields — they wrap BaseTypeahead with the wrapper div, border styling, and token rendering it intentionally omits.' },
+      { guidance: true, description: 'Provide your own wrapper div with border and layout when composing directly — BaseTypeahead renders no visual chrome of its own.' },
+      { guidance: true, description: 'Pass anchorRef pointing to your wrapper so the dropdown positions against your custom input chrome, not just the bare input element.' },
+      { guidance: false, description: 'Expect a wrapper div, border, or token rendering — BaseTypeahead is an engine only; all visual chrome is the caller\'s responsibility.' },
+      { guidance: false, description: 'Use BaseTypeahead when Typeahead or Tokenizer would suffice — the extra wrapper and styling work is only justified for truly custom compositions.' },
+    ],
+  },
   props: [
     {
       name: 'searchSource',


### PR DESCRIPTION
## Summary

The BaseTypeahead docsite page had no meaningful example and no usage guidance, leaving an empty Examples section and no playground link. It was also unclear whether the component was intended for direct use or was a primitive backing higher-level components.

## Cause

BaseTypeahead had no usage section in its doc and no example blocks registered under exampleFor: 'BaseTypeahead'. The component is a headless primitive (subComponentOf: 'Typeahead', isHiddenFromOverview: true) used internally by Typeahead and Tokenizer, so no examples were ever authored for it. Without guidance, the page silently showed nothing.

## Fix

- Added a usage section to BaseTypeahead.doc.mjs with a description matching the existing component description, 3 Do / 2 Don't best practices aligned to its "no wrapper, no border, no token rendering" nature, and relatedComponents: ['Typeahead', 'Tokenizer'] to surface links to the correct higher-level components.
- Added a BaseTypeaheadCustomSearch example block showing BaseTypeahead embedded inside a custom-styled HStack wrapper with its own border and search icon, demonstrating the anchorRef pattern and createStaticSource — the exact composition use case the component is designed for.


Closes #2679 