### PR TITLE
refactor(cli): unified module loading with validation at the load boundary

### DIFF
--- a/.changeset/unified-module-loading.md
+++ b/.changeset/unified-module-loading.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[refactor] Load and validate user-authored config, integration, codemod, and template modules through one shared module loader; create\* factories are now type-only and validation happens at load.
+
+@ejhammond

--- a/packages/cli/src/api/template.mjs
+++ b/packages/cli/src/api/template.mjs
@@ -6,7 +6,8 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import {importUserModule} from '../lib/module-loader.mjs';
+import {loadModuleWithSchema} from '../lib/module-loader.mjs';
+import {TemplateEnvelopeSchema} from '../template.mjs';
 import {CLI_ROOT, discoverExternalPackages} from '../utils/paths.mjs';
 import {
   assertWithin,
@@ -24,15 +25,18 @@ const CORE_PACKAGE = '@astryxdesign/core';
 const DOC_SUFFIXES = ['.doc.ts', '.doc.mjs', '.doc.js'];
 
 /**
- * Load an integration template doc module. `.ts` is loaded via jiti; `.mjs`/
- * `.js` via dynamic import. The doc may be the default export (e.g.
- * `export default createPageTemplate({...})`) or a named `doc` export.
+ * Load an integration template doc module and validate it against the template
+ * envelope at the load boundary. Default export only — `.ts` via jiti,
+ * `.mjs`/`.js` via dynamic import. Throws (caught by discovery) if the default
+ * export is missing or fails {@link TemplateEnvelopeSchema}. NOTE: the built-in
+ * core templates use `export const doc = {...}` and are loaded by a different
+ * function ({@link loadDocModule}) — this path is for INTEGRATION templates.
  *
  * @param {string} file
+ * @param {string} [label]
  */
-async function loadIntegrationDoc(file) {
-  const mod = await importUserModule(file);
-  return mod.default ?? mod.doc ?? null;
+async function loadIntegrationDoc(file, label) {
+  return loadModuleWithSchema(file, TemplateEnvelopeSchema, {label});
 }
 
 const TEMPLATES_DIR = path.join(CLI_ROOT, 'templates');
@@ -348,7 +352,7 @@ export async function discoverIntegrationTemplatesForOne(integration) {
 
     let doc;
     try {
-      doc = await loadIntegrationDoc(docPath);
+      doc = await loadIntegrationDoc(docPath, `Template "${id}"`);
     } catch (err) {
       errors.push({
         package: pkgLabel,
@@ -358,6 +362,9 @@ export async function discoverIntegrationTemplatesForOne(integration) {
       continue;
     }
 
+    // loadIntegrationDoc validates against the envelope (incl. a 'page'|'block'
+    // type) at the load boundary, so a valid doc always has a type. This guard
+    // stays as defense-in-depth.
     const type = doc?.type;
     if (type !== 'page' && type !== 'block') {
       errors.push({

--- a/packages/cli/src/api/validate-integration.mjs
+++ b/packages/cli/src/api/validate-integration.mjs
@@ -24,7 +24,6 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import {validateIntegration} from '../lib/config-schema.mjs';
 import {
   findManifestPaths,
   loadManifestObject,
@@ -71,32 +70,6 @@ function error(code, message) {
 /** @param {string} code @param {string} message @returns {Issue} */
 function warning(code, message) {
   return {code, severity: 'warning', message};
-}
-
-/**
- * Validate the manifest object against the integration schema. Schema failures
- * become a single `invalid_manifest` error issue.
- * @param {unknown} exported
- * @param {string} label
- * @param {Issue[]} issues
- * @returns {import('../types/integration').AstryxIntegration | null}
- */
-function validateManifestSchema(exported, label, issues) {
-  if (!exported || typeof exported !== 'object') {
-    issues.push(
-      error(
-        'invalid_manifest',
-        `${label} did not export an integration object.`,
-      ),
-    );
-    return null;
-  }
-  try {
-    return validateIntegration(exported, label);
-  } catch (err) {
-    issues.push(error('invalid_manifest', err.message));
-    return null;
-  }
 }
 
 /**
@@ -275,22 +248,20 @@ async function validateAtPackageDir(packageDir, identity) {
   const manifestFile = manifests[0];
   result.manifestFile = manifestFile;
 
-  let exported;
+  // loadManifestObject loads the default export and validates it against the
+  // integration schema (the shared load boundary). A missing default export or
+  // a schema failure throws; we convert either into a single invalid_manifest
+  // error issue so validate-integration stays exit-1-but-not-crash.
+  let manifest;
   try {
-    exported = await loadManifestObject(manifestFile);
-  } catch (err) {
-    issues.push(
-      error('invalid_manifest', `Failed to load manifest: ${err.message}`),
+    manifest = await loadManifestObject(
+      manifestFile,
+      `Integration manifest (${path.basename(manifestFile)})`,
     );
+  } catch (err) {
+    issues.push(error('invalid_manifest', err.message));
     return result;
   }
-
-  const manifest = validateManifestSchema(
-    exported,
-    `Integration manifest (${path.basename(manifestFile)})`,
-    issues,
-  );
-  if (!manifest) return result;
 
   const resolveRoot = value =>
     value == null ? undefined : path.resolve(packageDir, value);

--- a/packages/cli/src/codemod.mjs
+++ b/packages/cli/src/codemod.mjs
@@ -5,9 +5,12 @@
  *
  * Integrations (and core) author codemods as standalone modules that
  * default-export a `createCodemod(...)` or `createConfigCodemod(...)` result.
- * These helpers validate the definition at authoring time and stamp a `type`
- * discriminator (`'code'` | `'config'`) consumed by integration codemod
- * discovery during `astryx upgrade`.
+ * These helpers are intentionally tiny: they stamp a `type` discriminator
+ * (`'code'` | `'config'`) consumed by integration codemod discovery during
+ * `astryx upgrade`, and otherwise return the definition unchanged. They do NOT
+ * validate — validation happens at the load boundary, where discovery runs the
+ * module's default export through {@link CodemodEnvelopeSchema} (see
+ * `loadModuleWithSchema`). The exported schemas below ARE that contract.
  */
 
 import {z} from 'zod';
@@ -16,7 +19,12 @@ const Fn = z.custom(value => typeof value === 'function', {
   message: 'Expected a function',
 });
 
-const CodemodSchema = z
+/**
+ * Authoring shape for a file-transforming codemod (the `def` an author passes
+ * to {@link createCodemod}), before the `type` discriminator is stamped on.
+ * Exported so discovery can validate the stamped result against the envelope.
+ */
+export const CodemodSchema = z
   .object({
     title: z.string(),
     description: z.string().optional(),
@@ -26,7 +34,12 @@ const CodemodSchema = z
   })
   .strict();
 
-const ConfigCodemodSchema = z
+/**
+ * Authoring shape for a config-targeting codemod (the `def` an author passes to
+ * {@link createConfigCodemod}). Like {@link CodemodSchema} but without
+ * `fileExtensions`, which is only meaningful for code codemods.
+ */
+export const ConfigCodemodSchema = z
   .object({
     title: z.string(),
     description: z.string().optional(),
@@ -36,47 +49,45 @@ const ConfigCodemodSchema = z
   .strict();
 
 /**
- * @param {string} label
- * @param {import('zod').ZodError} error
+ * The metadata envelope discovery validates: a stamped codemod result. This is
+ * the LOAD-boundary contract — a hand-written plain object that matches this
+ * shape is accepted (discovery does not check "was it made by the factory",
+ * only the shape). A single discriminated union over the stamped `type`:
+ *   - `type: 'code'`  → may carry `fileExtensions`
+ *   - `type: 'config'` → no `fileExtensions`
  */
-function formatZodError(label, error) {
-  const issues = error.issues
-    .map(issue => {
-      const path = issue.path.length ? issue.path.join('.') : '(root)';
-      return `${path}: ${issue.message}`;
-    })
-    .join('; ');
-  return `${label} is invalid: ${issues}`;
-}
+export const CodemodEnvelopeSchema = z.discriminatedUnion('type', [
+  CodemodSchema.extend({type: z.literal('code')}),
+  ConfigCodemodSchema.extend({type: z.literal('config')}),
+]);
 
 /**
- * Define a file-transforming codemod.
+ * Define a file-transforming codemod. Stamp-only: returns the definition with
+ * `type: 'code'` injected. Validation happens at the load boundary.
  *
  * @template {import('./types/codemod').AstryxCodemodDef} T
  * @param {T} def
  * @returns {import('./types/codemod').AstryxCodemod}
  */
 export function createCodemod(def) {
-  const result = CodemodSchema.safeParse(def);
-  if (!result.success) {
-    throw new Error(formatZodError('createCodemod definition', result.error));
-  }
-  return {...result.data, type: 'code'};
+  return /** @type {import('./types/codemod').AstryxCodemod} */ ({
+    ...def,
+    type: 'code',
+  });
 }
 
 /**
- * Define a codemod that targets the consumer's astryx.config.* file.
+ * Define a codemod that targets the consumer's astryx.config.* file. Stamp-only:
+ * returns the definition with `type: 'config'` injected. Validation happens at
+ * the load boundary.
  *
  * @template {import('./types/codemod').AstryxConfigCodemodDef} T
  * @param {T} def
  * @returns {import('./types/codemod').AstryxConfigCodemod}
  */
 export function createConfigCodemod(def) {
-  const result = ConfigCodemodSchema.safeParse(def);
-  if (!result.success) {
-    throw new Error(
-      formatZodError('createConfigCodemod definition', result.error),
-    );
-  }
-  return {...result.data, type: 'config'};
+  return /** @type {import('./types/codemod').AstryxConfigCodemod} */ ({
+    ...def,
+    type: 'config',
+  });
 }

--- a/packages/cli/src/codemod.test.mjs
+++ b/packages/cli/src/codemod.test.mjs
@@ -1,16 +1,27 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 import {describe, expect, it} from 'vitest';
-import {createCodemod, createConfigCodemod} from './codemod.mjs';
+import {
+  createCodemod,
+  createConfigCodemod,
+  CodemodEnvelopeSchema,
+} from './codemod.mjs';
 
-describe('createCodemod', () => {
-  it('returns the definition stamped with type: code and isOptional default', () => {
+// createCodemod/createConfigCodemod are now stamp-only: they inject the `type`
+// discriminator and return the definition otherwise unchanged, performing NO
+// runtime validation. Validation happens at the LOAD boundary (discovery runs
+// the default export through CodemodEnvelopeSchema), so the rejection cases
+// that used to assert factory throws now assert the envelope schema rejects.
+
+describe('createCodemod (stamp-only)', () => {
+  it('stamps type: code and returns the def otherwise unchanged', () => {
     const transform = file => file.source;
     const result = createCodemod({title: 'Drop foo', transform});
     expect(result.type).toBe('code');
     expect(result.title).toBe('Drop foo');
     expect(result.transform).toBe(transform);
-    expect(result.isOptional).toBe(false);
+    // Stamp-only: it does NOT apply schema defaults (e.g. isOptional).
+    expect(result.isOptional).toBeUndefined();
   });
 
   it('preserves description, fileExtensions, and explicit isOptional', () => {
@@ -24,64 +35,100 @@ describe('createCodemod', () => {
     expect(result.description).toBe('renames things');
     expect(result.isOptional).toBe(true);
     expect(result.fileExtensions).toEqual(['.tsx']);
+    expect(result.type).toBe('code');
   });
 
-  it('throws when title is missing', () => {
-    expect(() => createCodemod({transform: () => null})).toThrow(/title/i);
-  });
-
-  it('throws when transform is missing', () => {
-    expect(() => createCodemod({title: 'x'})).toThrow(/transform/i);
-  });
-
-  it('throws when transform is not a function', () => {
-    expect(() => createCodemod({title: 'x', transform: 'nope'})).toThrow(
-      /transform/i,
-    );
-  });
-
-  it('throws on unknown keys', () => {
-    expect(() =>
-      createCodemod({title: 'x', transform: () => null, bogus: true}),
-    ).toThrow();
+  it('does NOT validate — returns an invalid def stamped, unchanged', () => {
+    const result = createCodemod({transform: () => null});
+    expect(result.type).toBe('code');
+    expect(result.title).toBeUndefined();
   });
 });
 
-describe('createConfigCodemod', () => {
-  it('returns the definition stamped with type: config', () => {
+describe('createConfigCodemod (stamp-only)', () => {
+  it('stamps type: config', () => {
     const transform = file => file.source;
     const result = createConfigCodemod({title: 'Config bump', transform});
     expect(result.type).toBe('config');
-    expect(result.isOptional).toBe(false);
     expect(result.transform).toBe(transform);
   });
+});
 
-  it('throws when title is missing', () => {
-    expect(() => createConfigCodemod({transform: () => null})).toThrow(
-      /title/i,
+describe('CodemodEnvelopeSchema (load-boundary validation)', () => {
+  it('accepts a stamped code codemod (incl. defaults)', () => {
+    const parsed = CodemodEnvelopeSchema.parse(
+      createCodemod({title: 'Drop foo', transform: () => null}),
     );
+    expect(parsed.type).toBe('code');
+    expect(parsed.isOptional).toBe(false); // schema default applied at load
   });
 
-  it('throws when transform is missing or not a function', () => {
-    expect(() => createConfigCodemod({title: 'x'})).toThrow(/transform/i);
+  it('accepts a PLAIN OBJECT envelope (no factory required)', () => {
+    const parsed = CodemodEnvelopeSchema.parse({
+      type: 'code',
+      title: 'Hand-written',
+      transform: () => null,
+    });
+    expect(parsed.title).toBe('Hand-written');
+  });
+
+  it('accepts a stamped config codemod', () => {
+    const parsed = CodemodEnvelopeSchema.parse(
+      createConfigCodemod({title: 'Bump', transform: () => null}),
+    );
+    expect(parsed.type).toBe('config');
+  });
+
+  it('rejects a missing title', () => {
     expect(() =>
-      createConfigCodemod({title: 'x', transform: 42}),
+      CodemodEnvelopeSchema.parse({type: 'code', transform: () => null}),
+    ).toThrow(/title/i);
+  });
+
+  it('rejects a missing transform', () => {
+    expect(() =>
+      CodemodEnvelopeSchema.parse({type: 'code', title: 'x'}),
     ).toThrow(/transform/i);
   });
 
-  it('rejects fileExtensions (config codemods target astryx.config.* only)', () => {
+  it('rejects a non-function transform', () => {
     expect(() =>
-      createConfigCodemod({
+      CodemodEnvelopeSchema.parse({type: 'code', title: 'x', transform: 'nope'}),
+    ).toThrow(/transform/i);
+  });
+
+  it('rejects a missing/invalid type discriminator', () => {
+    expect(() =>
+      CodemodEnvelopeSchema.parse({title: 'x', transform: () => null}),
+    ).toThrow();
+    expect(() =>
+      CodemodEnvelopeSchema.parse({
+        type: 'bogus',
         title: 'x',
         transform: () => null,
-        fileExtensions: ['.ts'],
       }),
     ).toThrow();
   });
 
-  it('throws on unknown keys', () => {
+  it('rejects unknown keys (strict)', () => {
     expect(() =>
-      createConfigCodemod({title: 'x', transform: () => null, bogus: 1}),
+      CodemodEnvelopeSchema.parse({
+        type: 'code',
+        title: 'x',
+        transform: () => null,
+        bogus: true,
+      }),
+    ).toThrow();
+  });
+
+  it('rejects fileExtensions on a config codemod', () => {
+    expect(() =>
+      CodemodEnvelopeSchema.parse({
+        type: 'config',
+        title: 'x',
+        transform: () => null,
+        fileExtensions: ['.ts'],
+      }),
     ).toThrow();
   });
 });

--- a/packages/cli/src/codemods/integration-discovery.mjs
+++ b/packages/cli/src/codemods/integration-discovery.mjs
@@ -11,8 +11,10 @@
  * where `<version>` is the immediate folder name (e.g. "0.2.0") and `<id>` is
  * the codemod module's relative path under that version folder WITHOUT its
  * extension (kebab-case; may include nested segments like "config/rename").
- * Each module DEFAULT-EXPORTS a `createCodemod` / `createConfigCodemod`
- * result.
+ * Each module DEFAULT-EXPORTS a codemod envelope — typically a `createCodemod`
+ * / `createConfigCodemod` result, though any plain object matching
+ * {@link CodemodEnvelopeSchema} is accepted. Validation happens here at the
+ * load boundary via `loadModuleWithSchema`, not in the factories.
  *
  * Version selection mirrors the core registry's getTransformsBetween(from,to):
  * a codemod under folder X runs when upgrading to include X.
@@ -24,7 +26,8 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import {importUserModule} from '../lib/module-loader.mjs';
+import {loadModuleWithSchema} from '../lib/module-loader.mjs';
+import {CodemodEnvelopeSchema} from '../codemod.mjs';
 import {semverCompare} from '../utils/semver.mjs';
 
 /** File extensions recognized as codemod modules. */
@@ -60,34 +63,6 @@ function collectCodemodFiles(versionDir) {
 
   walk(versionDir);
   return out.sort((a, b) => a.id.localeCompare(b.id));
-}
-
-/**
- * Validate that a module's default export is a createCodemod/
- * createConfigCodemod result.
- * @param {unknown} mod
- * @param {string} label
- * @returns {import('../types/codemod').AstryxCodemod | import('../types/codemod').AstryxConfigCodemod}
- */
-function validateCodemodExport(mod, label) {
-  const exported = mod?.default;
-  if (!exported || typeof exported !== 'object') {
-    throw new Error(
-      `${label} must default-export a createCodemod/createConfigCodemod result.`,
-    );
-  }
-  if (exported.type !== 'code' && exported.type !== 'config') {
-    throw new Error(
-      `${label} default export is not a valid codemod (expected createCodemod or createConfigCodemod result).`,
-    );
-  }
-  if (typeof exported.title !== 'string' || exported.title.length === 0) {
-    throw new Error(`${label} codemod is missing a title.`);
-  }
-  if (typeof exported.transform !== 'function') {
-    throw new Error(`${label} codemod is missing a transform function.`);
-  }
-  return exported;
 }
 
 /**
@@ -149,8 +124,9 @@ export async function discoverIntegrationCodemods(loadedIntegrations = []) {
         }
         idToVersion.set(id, version);
 
-        const mod = await importUserModule(file);
-        const codemod = validateCodemodExport(mod, label);
+        const codemod = await loadModuleWithSchema(file, CodemodEnvelopeSchema, {
+          label,
+        });
 
         const entry = {
           id,

--- a/packages/cli/src/codemods/integration-discovery.test.mjs
+++ b/packages/cli/src/codemods/integration-discovery.test.mjs
@@ -159,24 +159,60 @@ describe('integration codemod discovery', () => {
     ).toContain('consumer-new');
   });
 
-  it('fails discovery when a codemod has no valid default export', async () => {
+  it('fails discovery when a codemod has no default export', async () => {
     scaffold({
       '0.2.0/broken.mjs': `export const notDefault = 1;\n`,
     });
     const project = await Project.load(tmpDir);
+    // Validation now happens at the LOAD boundary (loadModuleWithSchema against
+    // CodemodEnvelopeSchema); a missing default export is a schema-invalid
+    // failure rather than the old bespoke "must default-export" message.
     await expect(
       discoverIntegrationCodemods(project.loadedIntegrations),
-    ).rejects.toThrow(/default-export/i);
+    ).rejects.toThrow(/is invalid/i);
   });
 
-  it('fails discovery when default export is not a codemod result', async () => {
+  it('fails discovery when default export is not a codemod envelope', async () => {
     scaffold({
       '0.2.0/bad.mjs': `export default { title: 'x', transform: () => null };\n`,
     });
     const project = await Project.load(tmpDir);
+    // No `type` discriminator -> fails the envelope schema at load.
     await expect(
       discoverIntegrationCodemods(project.loadedIntegrations),
-    ).rejects.toThrow(/not a valid codemod/i);
+    ).rejects.toThrow(/is invalid/i);
+  });
+
+  it('accepts a PLAIN OBJECT codemod envelope (no factory required)', async () => {
+    // Proves we dropped factory-identity coupling: a hand-written object that
+    // matches the envelope schema is accepted by discovery.
+    scaffold({
+      '0.2.0/hand-written.mjs': `
+        export default {
+          type: 'code',
+          title: 'Hand written',
+          transform: (file) => file.source,
+        };
+      `,
+    });
+    const project = await Project.load(tmpDir);
+    const byVersion = await discoverIntegrationCodemods(
+      project.loadedIntegrations,
+    );
+    const entry = byVersion.get('0.2.0')[0];
+    expect(entry.id).toBe('hand-written');
+    expect(entry.type).toBe('code');
+    expect(entry.codemod.isOptional).toBe(false); // schema default applied
+  });
+
+  it('rejects a malformed codemod envelope at load (missing transform)', async () => {
+    scaffold({
+      '0.2.0/no-transform.mjs': `export default { type: 'code', title: 'x' };\n`,
+    });
+    const project = await Project.load(tmpDir);
+    await expect(
+      discoverIntegrationCodemods(project.loadedIntegrations),
+    ).rejects.toThrow(/transform/i);
   });
 
   it('fails discovery on a duplicate id across versions within a package', async () => {

--- a/packages/cli/src/config.mjs
+++ b/packages/cli/src/config.mjs
@@ -1,19 +1,18 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-import {validateConfig} from './lib/config-schema.mjs';
-
 /**
  * Type-preserving helper for the Astryx config file.
  *
- * This is an intentionally tiny runtime identity function. Its value is the
- * exported TypeScript surface from `@astryxdesign/cli/config`, so config files
- * can get editor/type feedback without coupling to CLI internals.
+ * This is an intentionally tiny runtime identity function: it returns its
+ * argument unchanged. Its value is the exported TypeScript surface from
+ * `@astryxdesign/cli/config`, so config files get editor/type feedback without
+ * coupling to CLI internals. Validation is NOT performed here — it happens at
+ * the load boundary (see `loadModuleWithSchema` + `AstryxConfigSchema`).
  *
  * @template {import('./types/config').AstryxConfig} T
  * @param {T} config
  * @returns {T}
  */
 export function createConfig(config) {
-  validateConfig(config);
   return config;
 }

--- a/packages/cli/src/config.test.mjs
+++ b/packages/cli/src/config.test.mjs
@@ -3,54 +3,98 @@
 import {describe, expect, it} from 'vitest';
 import {createConfig} from './config.mjs';
 import {createIntegration} from './integration.mjs';
+import {
+  AstryxConfigSchema,
+  AstryxIntegrationSchema,
+} from './lib/config-schema.mjs';
 
-describe('createConfig', () => {
-  it('returns a valid minimal config unchanged', () => {
+// createConfig/createIntegration are now pure typed-identity helpers: they
+// return their argument unchanged and perform NO runtime validation. Validation
+// happens at the LOAD boundary (loadModuleWithSchema against the schemas below),
+// so the rejection cases that used to assert factory throws now assert the
+// schema rejects the same shapes.
+
+describe('createConfig (typed identity)', () => {
+  it('returns the config unchanged', () => {
     const config = {integrations: ['@acme/widgets']};
     expect(createConfig(config)).toBe(config);
     expect(createConfig({})).toEqual({});
+  });
+
+  it('does NOT validate — returns invalid shapes unchanged', () => {
+    const bogus = {packages: ['./libs']};
+    expect(createConfig(bogus)).toBe(bogus);
+    const badIntegrations = {integrations: '@acme/widgets'};
+    expect(createConfig(badIntegrations)).toBe(badIntegrations);
+  });
+});
+
+describe('AstryxConfigSchema (load-boundary validation)', () => {
+  it('accepts a valid minimal config', () => {
+    expect(AstryxConfigSchema.parse({})).toEqual({});
+    expect(
+      AstryxConfigSchema.parse({integrations: ['@acme/widgets']}),
+    ).toEqual({integrations: ['@acme/widgets']});
   });
 
   it('accepts hooks.postCodemod with a buildCommand function', () => {
     const config = {
       hooks: {postCodemod: [{name: 'format', buildCommand: () => null}]},
     };
-    expect(createConfig(config)).toBe(config);
+    expect(() => AstryxConfigSchema.parse(config)).not.toThrow();
   });
 
   it('rejects unknown keys (strict)', () => {
-    expect(() => createConfig({packages: ['./libs']})).toThrow(/packages/);
-  });
-
-  it('rejects a non-array integrations field', () => {
-    expect(() => createConfig({integrations: '@acme/widgets'})).toThrow(
-      /integrations/,
+    expect(() => AstryxConfigSchema.parse({packages: ['./libs']})).toThrow(
+      /packages|Unrecognized/,
     );
   });
 
+  it('rejects a non-array integrations field', () => {
+    expect(() =>
+      AstryxConfigSchema.parse({integrations: '@acme/widgets'}),
+    ).toThrow();
+  });
+
   it('rejects a non-URL issuesUrl', () => {
-    expect(() => createConfig({issuesUrl: 'not-a-url'})).toThrow(/issuesUrl/);
+    expect(() => AstryxConfigSchema.parse({issuesUrl: 'not-a-url'})).toThrow();
   });
 
   it('rejects a postCodemod hook without buildCommand', () => {
     expect(() =>
-      createConfig({hooks: {postCodemod: [{name: 'empty'}]}}),
-    ).toThrow(/buildCommand/);
+      AstryxConfigSchema.parse({hooks: {postCodemod: [{name: 'empty'}]}}),
+    ).toThrow();
   });
 });
 
-describe('createIntegration', () => {
-  it('returns a valid minimal integration unchanged', () => {
+describe('createIntegration (typed identity)', () => {
+  it('returns the integration unchanged', () => {
     const integration = {components: './src'};
     expect(createIntegration(integration)).toBe(integration);
     expect(createIntegration({})).toEqual({});
   });
 
+  it('does NOT validate — returns invalid shapes unchanged', () => {
+    const bogus = {name: '@acme/widgets'};
+    expect(createIntegration(bogus)).toBe(bogus);
+  });
+});
+
+describe('AstryxIntegrationSchema (load-boundary validation)', () => {
+  it('accepts a valid minimal integration', () => {
+    expect(AstryxIntegrationSchema.parse({components: './src'})).toEqual({
+      components: './src',
+    });
+    expect(AstryxIntegrationSchema.parse({})).toEqual({});
+  });
+
   it('rejects unknown keys (strict)', () => {
-    expect(() => createIntegration({name: '@acme/widgets'})).toThrow(/name/);
+    expect(() => AstryxIntegrationSchema.parse({name: '@acme/widgets'})).toThrow(
+      /name|Unrecognized/,
+    );
   });
 
   it('rejects a non-URL issuesUrl', () => {
-    expect(() => createIntegration({issuesUrl: 'nope'})).toThrow(/issuesUrl/);
+    expect(() => AstryxIntegrationSchema.parse({issuesUrl: 'nope'})).toThrow();
   });
 });

--- a/packages/cli/src/integration.mjs
+++ b/packages/cli/src/integration.mjs
@@ -1,19 +1,19 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-import {validateIntegration} from './lib/config-schema.mjs';
-
 /**
  * Type-preserving helper for an Astryx integration manifest.
  *
- * This is an intentionally tiny runtime identity function. Its value is the
- * exported TypeScript surface from `@astryxdesign/cli/integration`, so
- * manifests can get editor/type feedback without coupling to CLI internals.
+ * This is an intentionally tiny runtime identity function: it returns its
+ * argument unchanged. Its value is the exported TypeScript surface from
+ * `@astryxdesign/cli/integration`, so manifests get editor/type feedback
+ * without coupling to CLI internals. Validation is NOT performed here — it
+ * happens at the load boundary (see `loadModuleWithSchema` +
+ * `AstryxIntegrationSchema`).
  *
  * @template {import('./types/integration').AstryxIntegration} T
  * @param {T} integration
  * @returns {T}
  */
 export function createIntegration(integration) {
-  validateIntegration(integration);
   return integration;
 }

--- a/packages/cli/src/lib/config-schema.mjs
+++ b/packages/cli/src/lib/config-schema.mjs
@@ -57,10 +57,14 @@ export const AstryxIntegrationSchema = z
   .strict();
 
 /**
+ * Format a zod error into a single readable line, mirroring the issue-joining
+ * convention used across the CLI (path: message; path: message). Exported so
+ * the shared module loader and other validators stay in lockstep.
  * @param {string} label
  * @param {import('zod').ZodError} error
+ * @returns {string}
  */
-function formatZodError(label, error) {
+export function formatZodError(label, error) {
   const issues = error.issues
     .map(issue => {
       const path = issue.path.length ? issue.path.join('.') : '(root)';

--- a/packages/cli/src/lib/integrations.mjs
+++ b/packages/cli/src/lib/integrations.mjs
@@ -12,8 +12,8 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import {validateIntegration} from './config-schema.mjs';
-import {importUserModule, findPresentFiles} from './module-loader.mjs';
+import {AstryxIntegrationSchema} from './config-schema.mjs';
+import {loadModuleWithSchema, findPresentFiles} from './module-loader.mjs';
 
 /** Conventional manifest basenames, in load-precedence order. */
 export const MANIFEST_BASENAMES = [
@@ -34,14 +34,16 @@ export function findManifestPaths(dir) {
 }
 
 /**
- * Load a manifest module's exported object. `.ts` is loaded via jiti;
- * `.mjs`/`.js` via dynamic import. Exposed for validate-integration.
+ * Load and validate a manifest module's default export against the integration
+ * schema. Default export only — `.ts` is loaded via jiti; `.mjs`/`.js` via
+ * dynamic import. Throws if the default export is missing or invalid. Exposed
+ * for validate-integration.
  * @param {string} file absolute manifest path
- * @returns {Promise<unknown>} the exported integration object (or module)
+ * @param {string} [label] used in error messages
+ * @returns {Promise<import('../types/integration').AstryxIntegration>}
  */
-export async function loadManifestObject(file) {
-  const mod = await importUserModule(file);
-  return mod.default ?? mod.integration ?? mod;
+export async function loadManifestObject(file, label = 'integration manifest') {
+  return loadModuleWithSchema(file, AstryxIntegrationSchema, {label});
 }
 
 /**
@@ -104,12 +106,11 @@ export async function loadIntegrations(specs = [], {cwd = process.cwd()} = {}) {
     }
 
     const manifestFile = resolveManifestPath(packageDir, spec);
-    const mod = await importUserModule(manifestFile);
-    const exported = mod.default ?? mod.integration ?? mod;
-    if (!exported || typeof exported !== 'object') {
-      throw new Error(`Integration ${spec} did not export an object.`);
-    }
-    const manifest = validateIntegration(exported, `Integration ${spec}`);
+    const manifest = await loadModuleWithSchema(
+      manifestFile,
+      AstryxIntegrationSchema,
+      {label: `Integration ${spec}`},
+    );
 
     const resolveRoot = value =>
       value == null ? undefined : path.resolve(packageDir, value);

--- a/packages/cli/src/lib/module-loader.mjs
+++ b/packages/cli/src/lib/module-loader.mjs
@@ -8,12 +8,18 @@
  * import) and (b) find conventional files by basename in a fixed
  * load-precedence order. These helpers centralize that so the two callers stay
  * in lockstep.
+ *
+ * `loadModuleWithSchema` builds on these primitives to provide the single
+ * load/validation boundary shared by config, integration, codemod, and
+ * template discovery: import the module, take its default export, and validate
+ * it against the expected zod schema.
  */
 
 import * as path from 'node:path';
 import {pathToFileURL} from 'node:url';
 import * as fs from 'node:fs';
 import {createJiti} from 'jiti';
+import {formatZodError} from './config-schema.mjs';
 
 let jitiInstance;
 function getJiti() {
@@ -47,4 +53,28 @@ export function findPresentFiles(dir, basenames) {
   return basenames
     .filter(name => fs.existsSync(path.join(dir, name)))
     .map(name => path.join(dir, name));
+}
+
+/**
+ * Import a user-authored module, take its default export, and validate it
+ * against a zod schema. This is the single load/validation boundary for all
+ * user-authored modules (config, integration, codemod, template): execute the
+ * module, take the default export, validate it against the expected schema.
+ * Throws a clear, readable error if the default export is missing or fails
+ * validation.
+ *
+ * @template {import('zod').ZodType} S
+ * @param {string} file absolute path
+ * @param {S} schema
+ * @param {{label?: string}} [opts] label used in error messages
+ * @returns {Promise<import('zod').infer<S>>} parsed + typed value
+ */
+export async function loadModuleWithSchema(file, schema, {label} = {}) {
+  const mod = await importUserModule(file);
+  const exported = mod?.default;
+  const result = schema.safeParse(exported);
+  if (!result.success) {
+    throw new Error(formatZodError(label ?? file, result.error));
+  }
+  return result.data;
 }

--- a/packages/cli/src/lib/module-loader.test.mjs
+++ b/packages/cli/src/lib/module-loader.test.mjs
@@ -3,7 +3,12 @@
 import {afterEach, beforeEach, describe, expect, it} from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import {findPresentFiles, importUserModule} from './module-loader.mjs';
+import {z} from 'zod';
+import {
+  findPresentFiles,
+  importUserModule,
+  loadModuleWithSchema,
+} from './module-loader.mjs';
 
 let tmpDir;
 
@@ -55,5 +60,47 @@ describe('importUserModule', () => {
     const mod = await importUserModule(file);
     expect(mod.default).toEqual({answer: 42});
     expect(mod.named).toBe('hi');
+  });
+});
+
+describe('loadModuleWithSchema', () => {
+  // Temp module files live under a repo-local dir (not /tmp): Vite's dynamic
+  // import blocks /tmp, so we mirror the existing repo-local temp pattern.
+  const schema = z
+    .object({
+      name: z.string(),
+      count: z.number().optional(),
+    })
+    .strict();
+
+  it('returns the parsed default export when it satisfies the schema', async () => {
+    const file = path.join(tmpDir, 'valid.mjs');
+    fs.writeFileSync(file, `export default {name: 'ok', count: 3};\n`);
+    const value = await loadModuleWithSchema(file, schema, {label: 'thing'});
+    expect(value).toEqual({name: 'ok', count: 3});
+  });
+
+  it('throws a readable error when there is no default export', async () => {
+    const file = path.join(tmpDir, 'no-default.mjs');
+    fs.writeFileSync(file, `export const named = {name: 'x'};\n`);
+    await expect(
+      loadModuleWithSchema(file, schema, {label: 'thing'}),
+    ).rejects.toThrow(/thing is invalid/i);
+  });
+
+  it('throws a readable error when the default export fails the schema', async () => {
+    const file = path.join(tmpDir, 'invalid.mjs');
+    fs.writeFileSync(file, `export default {count: 'not-a-number'};\n`);
+    await expect(
+      loadModuleWithSchema(file, schema, {label: 'thing'}),
+    ).rejects.toThrow(/thing is invalid:.*name/i);
+  });
+
+  it('falls back to the file path in the message when no label is given', async () => {
+    const file = path.join(tmpDir, 'unlabeled.mjs');
+    fs.writeFileSync(file, `export default {bogus: true};\n`);
+    await expect(loadModuleWithSchema(file, schema)).rejects.toThrow(
+      new RegExp(`${path.basename(file)} is invalid`),
+    );
   });
 });

--- a/packages/cli/src/lib/project.mjs
+++ b/packages/cli/src/lib/project.mjs
@@ -32,8 +32,8 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import {importUserModule, findPresentFiles} from './module-loader.mjs';
-import {validateConfig} from './config-schema.mjs';
+import {findPresentFiles, loadModuleWithSchema} from './module-loader.mjs';
+import {AstryxConfigSchema} from './config-schema.mjs';
 import {loadIntegrations} from './integrations.mjs';
 import {
   CORE_PACKAGE,
@@ -180,9 +180,9 @@ export class Project {
     let loadedIntegrations = [];
 
     if (configPath) {
-      const mod = await importUserModule(configPath);
-      const rawConfig = mod.default ?? {};
-      config = validateConfig(rawConfig);
+      config = await loadModuleWithSchema(configPath, AstryxConfigSchema, {
+        label: 'astryx.config',
+      });
       const configDir = path.dirname(configPath);
       integrations = config.integrations ?? [];
       loadedIntegrations = await loadIntegrations(integrations, {

--- a/packages/cli/src/template.mjs
+++ b/packages/cli/src/template.mjs
@@ -4,10 +4,13 @@
  * @file Static template authoring API.
  *
  * Helpers for authoring Astryx page/block template docs. Like
- * `createConfig`/`createIntegration`, these are tiny runtime
- * validate-and-return helpers whose real value is the exported TypeScript
- * surface from `@astryxdesign/cli/template`. They inject the discriminant
- * `type` so a discovered doc always knows whether it is a page or a block.
+ * `createConfig`/`createIntegration`, these are tiny runtime identity helpers
+ * whose real value is the exported TypeScript surface from
+ * `@astryxdesign/cli/template`. They inject the discriminant `type` so a
+ * discovered doc always knows whether it is a page or a block. They do NOT
+ * validate — validation happens at the load boundary, where integration
+ * template discovery runs the module's default export through
+ * {@link TemplateEnvelopeSchema} (see `loadModuleWithSchema`).
  */
 
 import {z} from 'zod';
@@ -23,8 +26,9 @@ const PreviewSchema = z
  * Shared authored-template shape. `type` is injected by the create* helpers,
  * so authors never write it. Inline source/sourceFile are intentionally NOT
  * part of v1 — a template's source is the required same-stem sibling file.
+ * Exported so integration template discovery can validate the stamped result.
  */
-const BaseTemplateSchema = z
+export const BaseTemplateSchema = z
   .object({
     name: z.string().min(1, 'name is required'),
     description: z.string().min(1, 'description is required'),
@@ -35,46 +39,35 @@ const BaseTemplateSchema = z
   .strict();
 
 /**
- * @param {'page'|'block'} type
- * @param {unknown} def
- * @param {string} label
+ * The metadata envelope integration template discovery validates: a stamped
+ * template doc. This is the LOAD-boundary contract — a hand-written plain
+ * object that matches this shape is accepted (discovery does not check "was it
+ * made by the factory", only the shape).
  */
-function validateTemplate(type, def, label) {
-  const result = BaseTemplateSchema.safeParse(def);
-  if (!result.success) {
-    const issues = result.error.issues
-      .map(issue => {
-        const path = issue.path.length ? issue.path.join('.') : '(root)';
-        return `${path}: ${issue.message}`;
-      })
-      .join('; ');
-    throw new Error(`${label} is invalid: ${issues}`);
-  }
-  return {...result.data, type};
-}
+export const TemplateEnvelopeSchema = BaseTemplateSchema.extend({
+  type: z.enum(['page', 'block']),
+});
 
 /**
- * Author an Astryx page template doc.
+ * Author an Astryx page template doc. Stamp-only: returns the def with
+ * `type: 'page'` injected. Validation happens at the load boundary.
  *
  * @template {import('./types/template-api').AstryxPageTemplateInput} T
  * @param {T} def
  * @returns {T & {type: 'page'}}
  */
 export function createPageTemplate(def) {
-  return /** @type {T & {type: 'page'}} */ (
-    validateTemplate('page', def, 'page template')
-  );
+  return /** @type {T & {type: 'page'}} */ ({...def, type: 'page'});
 }
 
 /**
- * Author an Astryx block template doc.
+ * Author an Astryx block template doc. Stamp-only: returns the def with
+ * `type: 'block'` injected. Validation happens at the load boundary.
  *
  * @template {import('./types/template-api').AstryxBlockTemplateInput} T
  * @param {T} def
  * @returns {T & {type: 'block'}}
  */
 export function createBlockTemplate(def) {
-  return /** @type {T & {type: 'block'}} */ (
-    validateTemplate('block', def, 'block template')
-  );
+  return /** @type {T & {type: 'block'}} */ ({...def, type: 'block'});
 }

--- a/packages/cli/src/template.test.mjs
+++ b/packages/cli/src/template.test.mjs
@@ -1,9 +1,20 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 import {describe, it, expect} from 'vitest';
-import {createPageTemplate, createBlockTemplate} from './template.mjs';
+import {
+  createPageTemplate,
+  createBlockTemplate,
+  TemplateEnvelopeSchema,
+} from './template.mjs';
 
-describe('createPageTemplate', () => {
+// createPageTemplate/createBlockTemplate are now stamp-only: they inject the
+// `type` discriminant and return the def otherwise unchanged, with NO runtime
+// validation. Validation happens at the LOAD boundary (integration template
+// discovery runs the default export through TemplateEnvelopeSchema), so the
+// rejection cases that used to assert factory throws now assert the envelope
+// schema rejects the same shapes.
+
+describe('createPageTemplate (stamp-only)', () => {
   it('returns the def with type "page" injected', () => {
     const t = createPageTemplate({
       name: 'Landing',
@@ -30,34 +41,14 @@ describe('createPageTemplate', () => {
     expect(t.type).toBe('page');
   });
 
-  it('throws when name is missing', () => {
-    expect(() => createPageTemplate({description: 'x'})).toThrow(/name/);
-  });
-
-  it('throws when description is missing', () => {
-    expect(() => createPageTemplate({name: 'x'})).toThrow(/description/);
-  });
-
-  it('throws when name is an empty string', () => {
-    expect(() => createPageTemplate({name: '', description: 'x'})).toThrow(
-      /name/,
-    );
-  });
-
-  it('hard-errors on unknown keys', () => {
-    expect(() =>
-      createPageTemplate({name: 'x', description: 'y', source: './x.tsx'}),
-    ).toThrow();
-  });
-
-  it('rejects inline sourceFile (not supported in v1)', () => {
-    expect(() =>
-      createPageTemplate({name: 'x', description: 'y', sourceFile: './x.tsx'}),
-    ).toThrow();
+  it('does NOT validate — returns an invalid def stamped, unchanged', () => {
+    const t = createPageTemplate({description: 'x'});
+    expect(t.type).toBe('page');
+    expect(t.name).toBeUndefined();
   });
 });
 
-describe('createBlockTemplate', () => {
+describe('createBlockTemplate (stamp-only)', () => {
   it('returns the def with type "block" injected', () => {
     const t = createBlockTemplate({
       name: 'Hero',
@@ -66,15 +57,71 @@ describe('createBlockTemplate', () => {
     expect(t.type).toBe('block');
     expect(t.name).toBe('Hero');
   });
+});
 
-  it('throws when required fields are missing', () => {
-    expect(() => createBlockTemplate({name: 'Hero'})).toThrow(/description/);
-    expect(() => createBlockTemplate({description: 'x'})).toThrow(/name/);
+describe('TemplateEnvelopeSchema (load-boundary validation)', () => {
+  it('accepts a stamped page template', () => {
+    const parsed = TemplateEnvelopeSchema.parse(
+      createPageTemplate({name: 'Landing', description: 'A landing page.'}),
+    );
+    expect(parsed.type).toBe('page');
   });
 
-  it('hard-errors on unknown keys', () => {
+  it('accepts a PLAIN OBJECT envelope (no factory required)', () => {
+    const parsed = TemplateEnvelopeSchema.parse({
+      type: 'block',
+      name: 'Hero',
+      description: 'A hero block.',
+    });
+    expect(parsed.name).toBe('Hero');
+  });
+
+  it('rejects a missing name', () => {
     expect(() =>
-      createBlockTemplate({name: 'x', description: 'y', bogus: 1}),
+      TemplateEnvelopeSchema.parse({type: 'page', description: 'x'}),
+    ).toThrow(/name/);
+  });
+
+  it('rejects a missing description', () => {
+    expect(() =>
+      TemplateEnvelopeSchema.parse({type: 'page', name: 'x'}),
+    ).toThrow(/description/);
+  });
+
+  it('rejects an empty-string name', () => {
+    expect(() =>
+      TemplateEnvelopeSchema.parse({type: 'page', name: '', description: 'x'}),
+    ).toThrow(/name/);
+  });
+
+  it('rejects a missing/invalid type', () => {
+    expect(() =>
+      TemplateEnvelopeSchema.parse({name: 'x', description: 'y'}),
+    ).toThrow();
+    expect(() =>
+      TemplateEnvelopeSchema.parse({type: 'bogus', name: 'x', description: 'y'}),
+    ).toThrow();
+  });
+
+  it('rejects unknown keys (strict)', () => {
+    expect(() =>
+      TemplateEnvelopeSchema.parse({
+        type: 'page',
+        name: 'x',
+        description: 'y',
+        source: './x.tsx',
+      }),
+    ).toThrow();
+  });
+
+  it('rejects inline sourceFile (not supported in v1)', () => {
+    expect(() =>
+      TemplateEnvelopeSchema.parse({
+        type: 'page',
+        name: 'x',
+        description: 'y',
+        sourceFile: './x.tsx',
+      }),
     ).toThrow();
   });
 });


### PR DESCRIPTION
## What

Makes loading external user-authored JS **uniform** and moves validation to the **load boundary**.

Previously, four loaders each imported-and-picked-and-validated differently, and the `create*` factories *also* validated. This change:

1. Adds **one** shared `loadModuleWithSchema(file, schema, {label})` in `lib/module-loader.mjs` — "execute the module, take the default export, validate it against the expected schema."
2. Makes all four `create*` factories **pure typed identity** (stamp-only, no runtime validation). Their value is the exported TypeScript surface for editor DX.
3. Validates at the load/discovery boundary via the shared helper against an envelope schema.
4. Removes the bespoke "must be a createCodemod result" structural check in favor of schema validation.

Behavior stays equivalent — genuinely invalid inputs are still rejected, just at **load**, not in the factory.

## Envelope schemas (the load-boundary contract)

- **Config** → `AstryxConfigSchema` (unchanged; strict — unknown keys still rejected)
- **Integration** → `AstryxIntegrationSchema` (unchanged)
- **Codemod** → `CodemodEnvelopeSchema` — discriminated union over the stamped `type` (`'code'` may carry `fileExtensions`; `'config'` may not)
- **Template** → `TemplateEnvelopeSchema` — `BaseTemplateSchema` + `type: 'page' | 'block'`

A **plain object** matching an envelope is accepted regardless of how it was produced (no more factory-identity coupling).

## Migrated loaders

- `lib/project.mjs` `Project.load` → `loadModuleWithSchema(configPath, AstryxConfigSchema, {label: 'astryx.config'})` (strict config validation preserved)
- `lib/integrations.mjs` `loadManifestObject` + `loadIntegrations` → `loadModuleWithSchema(..., AstryxIntegrationSchema, ...)` (default-export only; dropped the `?? mod.integration ?? mod` fallback)
- `codemods/integration-discovery.mjs` → `loadModuleWithSchema(file, CodemodEnvelopeSchema, ...)` (replaces bespoke `validateCodemodExport`)
- `api/template.mjs` `loadIntegrationDoc` → `loadModuleWithSchema(file, TemplateEnvelopeSchema, ...)` (default-export only; dropped `?? mod.doc` fallback)

The built-in core `.doc.mjs` / `template.doc.mjs` loader (`loadDocModule` → `docModule.doc`) is **untouched**.

## Out of scope

No changes to the upgrade command ordering or dry-run (separate follow-up). Config strictness at load is not loosened.

## Test changes

- Factory tests that asserted factory-time throws are re-pointed: stamp/identity behavior is verified on the factory, and rejection cases now assert the **envelope schema** (or the **load path**) rejects.
- Codemod discovery tests asserting the old "must be a createCodemod result" message now assert the schema-validation message, plus a new test proving a **plain-object envelope** is accepted by discovery and a malformed one is rejected at load.
- New focused `loadModuleWithSchema` tests (valid default export passes; missing default export throws; schema mismatch throws with a readable message; hermetic repo-local temp module).

## Green gate

- `npx vitest run packages/cli` → **1596 passed (97 files)**
- `node scripts/sync-exports.js --check` → 0
- `./scripts/add-copyright.sh --check` → 0
- `pnpm -F @astryxdesign/cli typecheck:json-api` → 0
- `pnpm build` + `node scripts/verify-exports.mjs` → 0
- `npx eslint` on changed files → 0
- Smoke: `--help` OK; `component --list --json` valid envelope; `upgrade --list --json` lists codemods
- `node scripts/check-changesets.mjs` → 0
