### PR TITLE
docs: clarify Node and Corepack setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ This file covers local development setup.
 
 ### Node.js
 
-Install Node.js v22+ using one of these methods:
+Install Node.js v22 LTS using one of these methods:
 
 **Via nvm (recommended):**
 
@@ -35,14 +35,15 @@ Download and install from https://nodejs.org
 Astryx uses [pnpm](https://pnpm.io/) as its package manager (declared in
 the `packageManager` and `devEngines.packageManager` fields of
 `package.json`). The easiest way to install it is via
-[Corepack](https://nodejs.org/api/corepack.html), which ships
-with Node.js:
+[Corepack](https://nodejs.org/api/corepack.html):
 
 ```bash
 corepack enable
 ```
 
 This makes the `pnpm` command available with the exact version Astryx pins.
+Corepack ships with Node.js 22, but not with current Node.js 25+ releases. If
+`corepack` is missing, switch to Node 22 LTS or install pnpm directly.
 Alternatively, install pnpm directly:
 
 ```bash
@@ -53,7 +54,7 @@ npm install -g pnpm@10
 brew install pnpm
 
 # Via standalone installer (no npm or Node.js required)
-curl -fsSL https://get.pnpm.io/install.sh | env PNPM_VERSION=10.33.4 sh -
+curl -fsSL https://get.pnpm.io/install.sh | env PNPM_VERSION=10.34.1 sh -
 
 # Via GitHub releases (single binary, no dependencies)
 # https://github.com/pnpm/pnpm/releases/latest
@@ -391,6 +392,51 @@ yet" — open the PR as a draft and mark it ready for review when it's done.
 - Export types alongside components
 
 ## Troubleshooting
+
+### Setup Issues
+
+**`pnpm: command not found`**
+
+Enable Corepack on Node 22 LTS:
+
+```bash
+corepack enable
+```
+
+If Corepack is not available, install pnpm directly using one of the commands
+above, then run `pnpm --version`.
+
+**`corepack: command not found`**
+
+Make sure you are using Node 22 LTS:
+
+```bash
+nvm install 22
+nvm use 22
+```
+
+Node 25+ does not include Corepack. If you need to stay on Node 25+, install
+pnpm directly instead.
+
+**Unexpected Node.js version**
+
+Check the active version before installing dependencies:
+
+```bash
+node --version
+```
+
+Use `nvm use 22` if your shell selected a different version, such as the latest
+`stable` release.
+
+**CLI path issues**
+
+If `astryx` is not found in a consuming app, add the package script shown in the
+root `README.md` and run it through your package manager:
+
+```bash
+pnpm astryx -- component --list
+```
 
 ### pnpm Installation Issues
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ This file covers local development setup.
 
 ### Node.js
 
-Install Node.js v22 LTS using one of these methods:
+Install Node.js 22+ from an active LTS line using one of these methods:
 
 **Via nvm (recommended):**
 
@@ -34,17 +34,7 @@ Download and install from https://nodejs.org
 
 Astryx uses [pnpm](https://pnpm.io/) as its package manager (declared in
 the `packageManager` and `devEngines.packageManager` fields of
-`package.json`). The easiest way to install it is via
-[Corepack](https://nodejs.org/api/corepack.html):
-
-```bash
-corepack enable
-```
-
-This makes the `pnpm` command available with the exact version Astryx pins.
-Corepack ships with Node.js 22, but not with current Node.js 25+ releases. If
-`corepack` is missing, switch to Node 22 LTS or install pnpm directly.
-Alternatively, install pnpm directly:
+`package.json`). You can install pnpm directly:
 
 ```bash
 # Via npm
@@ -60,10 +50,26 @@ curl -fsSL https://get.pnpm.io/install.sh | env PNPM_VERSION=10.34.1 sh -
 # https://github.com/pnpm/pnpm/releases/latest
 ```
 
+Or use [Corepack](https://nodejs.org/api/corepack.html) to install the exact
+pnpm version Astryx pins:
+
+```bash
+corepack enable
+```
+
+Corepack ships with Node.js 22 and 24, but current Node.js 25+ releases no
+longer bundle it. If `corepack` is missing and you want the auto-pinning path,
+install Corepack manually first:
+
+```bash
+npm install -g corepack
+corepack enable
+```
+
 Verify installation:
 
 ```bash
-node --version   # v22.x.x
+node --version   # v22.x.x or v24.x.x
 pnpm --version   # 10.x.x
 ```
 
@@ -397,26 +403,29 @@ yet" — open the PR as a draft and mark it ready for review when it's done.
 
 **`pnpm: command not found`**
 
-Enable Corepack on Node 22 LTS:
+Install pnpm directly:
+
+```bash
+npm install -g pnpm@10
+```
+
+Or enable Corepack if you want to use the repository's pinned pnpm version:
 
 ```bash
 corepack enable
 ```
 
-If Corepack is not available, install pnpm directly using one of the commands
-above, then run `pnpm --version`.
-
 **`corepack: command not found`**
 
-Make sure you are using Node 22 LTS:
+Install Corepack manually, then enable it:
 
 ```bash
-nvm install 22
-nvm use 22
+npm install -g corepack
+corepack enable
 ```
 
-Node 25+ does not include Corepack. If you need to stay on Node 25+, install
-pnpm directly instead.
+Node 25+ does not include Corepack. You can either install Corepack manually or
+install pnpm directly.
 
 **Unexpected Node.js version**
 
@@ -426,8 +435,8 @@ Check the active version before installing dependencies:
 node --version
 ```
 
-Use `nvm use 22` if your shell selected a different version, such as the latest
-`stable` release.
+Use an active LTS line such as 22 or 24 if your shell selected a different
+version, such as a non-LTS `stable` release.
 
 **CLI path issues**
 

--- a/README.md
+++ b/README.md
@@ -95,12 +95,17 @@ Battle-tested design solutions for common interactions and workflows: table page
 
 We welcome contributions! See **[CONTRIBUTING.md](CONTRIBUTING.md)** for the full guide.
 
-Quick start for contributors: this repo uses **pnpm 10** via [Corepack](https://nodejs.org/api/corepack.html). Enable it once and the right pnpm version installs automatically:
+Quick start for contributors: this repo uses **Node 22 LTS** and **pnpm 10**.
+With Node 22, enable [Corepack](https://nodejs.org/api/corepack.html) once and
+the right pnpm version installs automatically:
 
 ```bash
 corepack enable
 pnpm install
 ```
+
+If `corepack` is missing, switch to Node 22 LTS or install pnpm directly; see
+the troubleshooting notes in [CONTRIBUTING.md](CONTRIBUTING.md#troubleshooting).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -95,17 +95,19 @@ Battle-tested design solutions for common interactions and workflows: table page
 
 We welcome contributions! See **[CONTRIBUTING.md](CONTRIBUTING.md)** for the full guide.
 
-Quick start for contributors: this repo uses **Node 22 LTS** and **pnpm 10**.
-With Node 22, enable [Corepack](https://nodejs.org/api/corepack.html) once and
-the right pnpm version installs automatically:
+Quick start for contributors: this repo uses **Node 22+ on an active LTS line**
+and **pnpm 10**. Install pnpm directly, or enable
+[Corepack](https://nodejs.org/api/corepack.html) once so the pinned pnpm version
+installs automatically:
 
 ```bash
 corepack enable
 pnpm install
 ```
 
-If `corepack` is missing, switch to Node 22 LTS or install pnpm directly; see
-the troubleshooting notes in [CONTRIBUTING.md](CONTRIBUTING.md#troubleshooting).
+If `corepack` is missing, install pnpm directly or install Corepack manually;
+see the troubleshooting notes in
+[CONTRIBUTING.md](CONTRIBUTING.md#troubleshooting).
 
 ## License
 


### PR DESCRIPTION
## Summary
- clarify that contributors should use Node 22 LTS for Corepack-based setup
- document the Node 25+ Corepack absence and direct pnpm fallback
- add setup troubleshooting entries for missing pnpm, missing Corepack, Node version drift, and CLI path issues
- update the standalone pnpm installer example to the repo's pinned pnpm version

## Verification
- git diff --check

Fixes #3270
Fixes #3288