### PR TITLE
fix(cli): run core codemods before loading config in upgrade (with dry-run guidance)

### DIFF
--- a/.changeset/upgrade-config-codemod-ordering.md
+++ b/.changeset/upgrade-config-codemod-ordering.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[fix] upgrade now runs core codemods before loading config, so a config codemod can repair an otherwise-invalid config; dry-run reports a fixable config and suggests the command to apply it.
+
+@ejhammond

--- a/packages/cli/src/commands/upgrade.config-ordering.test.mjs
+++ b/packages/cli/src/commands/upgrade.config-ordering.test.mjs
@@ -1,0 +1,273 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Upgrade config-codemod-ordering tests.
+ *
+ * Verifies that CORE codemods run BEFORE the consumer's config is loaded, so a
+ * config codemod (v0.1.3 migrate-layout-components, meta.codemodType==='config')
+ * can repair an otherwise-invalid config that strict `Project.load` would reject.
+ *
+ * Like the integration-policy tests, these scaffold a real consumer project
+ * (package.json + astryx.config.mjs) under a REPO-LOCAL temp dir (so Vite
+ * permits dynamic import of the config module — it blocks /tmp) and chdir in.
+ *
+ * Cases:
+ *   1. dry-run, legacy layout.components, v0.1.3 config codemod in range →
+ *      does NOT abort; reports "fixable, re-run with --apply" + the suggested
+ *      `--codemod ... --apply` command; exit 0; integrations skipped.
+ *   2. --apply, same config → core config codemod writes the repaired config,
+ *      then config loads strictly OK and the upgrade completes; on-disk config
+ *      is migrated to experimental.xle.components.
+ *   3. dry-run, config genuinely invalid (integrations: 5) with NO pending
+ *      config codemod → still ABORTS (exit nonzero).
+ *   4. happy path (valid config, no config codemod) → unchanged behavior.
+ */
+
+import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {Command} from 'commander';
+import {registerUpgrade} from './upgrade.mjs';
+
+let tmpDir;
+let originalCwd;
+let logCalls;
+let stdoutCalls;
+let exitCode;
+
+beforeEach(() => {
+  originalCwd = process.cwd();
+  // Repo-local temp dir: under cwd so Vite allows the astryx.config import.
+  tmpDir = fs.mkdtempSync(path.join(process.cwd(), '.astryx-upgrade-order-'));
+  process.chdir(tmpDir);
+  logCalls = [];
+  stdoutCalls = [];
+  exitCode = undefined;
+  vi.spyOn(console, 'log').mockImplementation((...a) => logCalls.push(a.join(' ')));
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+  vi.spyOn(process.stdout, 'write').mockImplementation(chunk => {
+    stdoutCalls.push(typeof chunk === 'string' ? chunk : chunk.toString());
+    return true;
+  });
+  vi.spyOn(process, 'exit').mockImplementation(code => {
+    exitCode = code;
+    throw new Error(`__exit ${code}`);
+  });
+});
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  fs.rmSync(tmpDir, {recursive: true, force: true});
+  vi.restoreAllMocks();
+});
+
+function writePkg() {
+  fs.writeFileSync(
+    path.join(tmpDir, 'package.json'),
+    JSON.stringify({name: 'consumer'}),
+  );
+}
+
+function writeInstalledCore(version) {
+  const dir = path.join(tmpDir, 'node_modules', '@astryxdesign', 'core');
+  fs.mkdirSync(dir, {recursive: true});
+  fs.writeFileSync(
+    path.join(dir, 'package.json'),
+    JSON.stringify({name: '@astryxdesign/core', version}),
+  );
+}
+
+function writeConfig(body) {
+  fs.writeFileSync(path.join(tmpDir, 'astryx.config.mjs'), body);
+}
+
+function writeSource() {
+  fs.mkdirSync(path.join(tmpDir, 'src'), {recursive: true});
+  fs.writeFileSync(path.join(tmpDir, 'src', 'index.ts'), 'const foo = 1;\n');
+}
+
+const LEGACY_CONFIG = `export default {
+  layout: {
+    components: {
+      KpiCard: '@/components/KpiCard',
+    },
+  },
+};
+`;
+
+function createProgram() {
+  const program = new Command();
+  program.exitOverride();
+  program.option('--json', 'Output as typed JSON');
+  registerUpgrade(program);
+  return program;
+}
+
+async function runJson(args) {
+  const program = createProgram();
+  try {
+    await program.parseAsync(['node', 'astryx', ...args]);
+  } catch (err) {
+    if (!String(err?.message || '').startsWith('__exit')) throw err;
+  }
+  for (let i = logCalls.length - 1; i >= 0; i--) {
+    const line = logCalls[i];
+    if (line.startsWith('{')) {
+      try {
+        return JSON.parse(line);
+      } catch {
+        // keep looking
+      }
+    }
+  }
+  return null;
+}
+
+async function runHuman(args) {
+  const program = createProgram();
+  try {
+    await program.parseAsync(['node', 'astryx', ...args]);
+  } catch (err) {
+    if (!String(err?.message || '').startsWith('__exit')) throw err;
+  }
+  return stdoutCalls.join('') + '\n' + logCalls.join('\n');
+}
+
+describe('upgrade — core codemods run before config load', () => {
+  it('dry-run: legacy layout.components is reported as fixable, not an abort', async () => {
+    // 0.1.2 -> 0.1.3 brings the migrate-layout-components config codemod.
+    writePkg();
+    writeInstalledCore('0.1.3');
+    writeConfig(LEGACY_CONFIG);
+    writeSource();
+
+    const result = await runJson([
+      '--json',
+      'upgrade',
+      '--from',
+      '0.1.2',
+      '--path',
+      'src',
+    ]);
+
+    expect(result).not.toBeNull();
+    // Did NOT abort with a config-validation error.
+    expect(result.error).toBeUndefined();
+    expect(exitCode).not.toBe(1);
+    // Reported as the fixable case with the suggested apply command.
+    expect(result.type).toBe('upgrade.status');
+    expect(result.data.status).toBe('config_fixable');
+    expect(result.data.configCodemods).toContain(
+      'migrate-layout-components-to-experimental',
+    );
+    expect(result.data.suggestedCommand).toBe(
+      'astryx upgrade --from 0.1.2 --codemod migrate-layout-components-to-experimental --apply',
+    );
+    expect(result.data.message).toMatch(/--apply/);
+    // Integrations skipped for the preview.
+    expect(result.data.note).toMatch(/--apply run/i);
+    // Dry-run did not write the config.
+    const onDisk = fs.readFileSync(
+      path.join(tmpDir, 'astryx.config.mjs'),
+      'utf-8',
+    );
+    expect(onDisk).toContain('layout');
+    expect(onDisk).not.toContain('experimental');
+  });
+
+  it('human dry-run prints the fixable guidance + suggested command', async () => {
+    writePkg();
+    writeInstalledCore('0.1.3');
+    writeConfig(LEGACY_CONFIG);
+    writeSource();
+
+    const out = await runHuman(['upgrade', '--from', '0.1.2', '--path', 'src']);
+    expect(out).toMatch(/fails strict validation/i);
+    expect(out).toContain(
+      'astryx upgrade --from 0.1.2 --codemod migrate-layout-components-to-experimental --apply',
+    );
+    expect(exitCode).not.toBe(1);
+  });
+
+  it('--apply: core config codemod repairs the config, then the upgrade completes', async () => {
+    writePkg();
+    writeInstalledCore('0.1.3');
+    writeConfig(LEGACY_CONFIG);
+    writeSource();
+
+    const result = await runJson([
+      '--json',
+      'upgrade',
+      '--from',
+      '0.1.2',
+      '--path',
+      'src',
+      '--apply',
+    ]);
+
+    expect(result).not.toBeNull();
+    expect(result.error).toBeUndefined();
+    expect(exitCode).not.toBe(1);
+    expect(result.type).toBe('upgrade.run');
+    expect(result.data.filesChanged).toBeGreaterThan(0);
+
+    // The on-disk config was migrated to experimental.xle.components.
+    const onDisk = fs.readFileSync(
+      path.join(tmpDir, 'astryx.config.mjs'),
+      'utf-8',
+    );
+    expect(onDisk).toContain('experimental');
+    expect(onDisk).toContain('xle');
+    expect(onDisk).toMatch(
+      /KpiCard:\s*\{\s*from:\s*['"]@\/components\/KpiCard['"]/,
+    );
+    expect(onDisk).not.toMatch(/layout\s*:/);
+  });
+
+  it('dry-run: a genuinely invalid config with NO fixing codemod still aborts', async () => {
+    writePkg();
+    writeInstalledCore('0.1.3');
+    // `integrations: 5` is invalid AND no config codemod in 0.1.2->0.1.3 fixes it.
+    writeConfig(`export default { integrations: 5 };\n`);
+    writeSource();
+
+    const result = await runJson([
+      '--json',
+      'upgrade',
+      '--from',
+      '0.1.2',
+      '--path',
+      'src',
+    ]);
+
+    expect(result).not.toBeNull();
+    // Aborts with a config-validation error (not the fixable status).
+    expect(result.error).toBeTruthy();
+    expect(result.type).not.toBe('upgrade.status');
+    expect(exitCode).toBe(1);
+  });
+
+  it('happy path: valid config with no config codemod behaves normally', async () => {
+    writePkg();
+    writeInstalledCore('0.1.3');
+    // A valid, already-migrated config; no relocation needed.
+    writeConfig(`export default { integrations: [] };\n`);
+    writeSource();
+
+    const result = await runJson([
+      '--json',
+      'upgrade',
+      '--from',
+      '0.1.2',
+      '--path',
+      'src',
+      '--apply',
+    ]);
+
+    expect(result).not.toBeNull();
+    expect(result.error).toBeUndefined();
+    expect(exitCode).not.toBe(1);
+    // Completed as a run (the config codemod is a no-op on an already-migrated config).
+    expect(result.type).toBe('upgrade.run');
+  });
+});

--- a/packages/cli/src/commands/upgrade.mjs
+++ b/packages/cli/src/commands/upgrade.mjs
@@ -254,66 +254,20 @@ export function registerUpgrade(program) {
         );
       }
 
-      let integrations;
-      let postCodemodHooks;
-      let integrationCodemodsByVersion;
-      try {
-        const project = await Project.load(process.cwd());
-        postCodemodHooks = project.config.hooks?.postCodemod ?? [];
-        const integrationSpecs = uniqueFiles([
-          ...(project.integrations ?? []),
-          ...(options.integration ?? []),
-        ]);
-        integrations = await loadIntegrations(integrationSpecs);
-        // Discover file-based integration codemods up front, PER integration.
-        // A broken integration (bad export, invalid schema, duplicate id,
-        // missing root) is a DEFINITION error: skip that integration's
-        // codemods and warn (below), rather than hard-failing the upgrade.
-        // This reverses the previous hard-fail-on-broken-integration policy.
-        // An EXECUTION-time failure (a transform throwing) is handled later by
-        // the codemod-error gate, which still aborts the upgrade.
-        integrationCodemodsByVersion = new Map();
-        for (const integration of integrations) {
-          if (!integration?.codemods) continue;
-          try {
-            const byVersion = await discoverIntegrationCodemods([integration]);
-            for (const [version, list] of byVersion) {
-              const existing = integrationCodemodsByVersion.get(version);
-              if (existing) existing.push(...list);
-              else integrationCodemodsByVersion.set(version, [...list]);
-            }
-          } catch {
-            // Skip this integration's codemods; the validate-integration nudge
-            // below surfaces the underlying issue. Best-effort, non-blocking.
-          }
-        }
-      } catch (err) {
-        if (json)
-          return jsonError(
-            err.message,
-            undefined,
-            ERROR_CODES.ERR_INVALID_ARGUMENT,
-          );
-        p.log.error(err.message);
-        p.outro('Aborted');
-        process.exitCode = 1;
-        return;
-      }
-      if (!json && integrations.length > 0) {
-        p.log.info(
-          `Integrations: ${integrations.map(i => i.name ?? i.__spec).join(', ')}`,
-        );
-      }
-
-      // Non-blocking nudge: if any configured integration has validation
-      // issues, print one compact line to stderr pointing at
-      // validate-integration. Best-effort; suppressed in --json mode. The
-      // integrations are already loaded above, so this is cheap.
-      try {
-        await warnOnIntegrationIssues(integrations, {json});
-      } catch {
-        // Never let the nudge break the upgrade.
-      }
+      // ───────────────────────────────────────────────────────────────────
+      // PIPELINE ORDERING
+      //
+      // CORE codemods run BEFORE the consumer's config is loaded. `Project.load`
+      // STRICT-validates astryx.config.* and THROWS on unknown keys — but a core
+      // CONFIG codemod (e.g. v0.1.3 migrate-layout-components, signalled by
+      // `meta.codemodType === 'config'`) is precisely what repairs an otherwise
+      // -invalid config. Loading first created a chicken-and-egg: the config was
+      // rejected before the codemod that would fix it ever ran. Core codemods
+      // read files directly (config codemods via runConfigCodemod read
+      // astryx.config.*; code codemods scan --path), so they do NOT need the
+      // loaded config. We run them here, then load config, then sequence the
+      // integration codemods (which DO require a valid loaded config).
+      // ───────────────────────────────────────────────────────────────────
 
       if (!options.force && semverGte(currentVersion, targetVersion)) {
         if (json) {
@@ -329,33 +283,28 @@ export function registerUpgrade(program) {
         return;
       }
 
-      // Resolve transforms. Core built-in codemods come from the registry;
-      // file-based integration codemods are discovered separately and run
-      // alongside them, ordered by version.
+      // Resolve CORE transforms from the registry. These do not need the loaded
+      // config. Integration codemods are discovered later, AFTER the config
+      // loads successfully (they require a valid config to resolve).
       const versionManifests = [
         ...(await getTransformsBetween(currentVersion, targetVersion)),
       ];
-      const integrationVersionGroups = selectIntegrationCodemods(
-        integrationCodemodsByVersion,
-        currentVersion,
-        targetVersion,
-      );
-      const hasIntegrationCodemods = integrationVersionGroups.some(
-        g => g.codemods.length > 0,
-      );
 
-      if (versionManifests.length === 0 && !hasIntegrationCodemods) {
-        if (json) {
-          return jsonOut('upgrade.status', {
-            status: 'no_codemods',
-            from: currentVersion,
-            to: targetVersion,
-          });
+      // Does the selected core set include >=1 CONFIG codemod? A config codemod
+      // is the established convention `meta.codemodType === 'config'` (see
+      // `toUnifiedEntry` in runner.mjs). This drives the graceful dry-run catch
+      // around `Project.load` below: a fixable config error is only "expected"
+      // when a pending core config codemod would repair it.
+      const coreConfigCodemodNames = [];
+      for (const {transforms} of versionManifests) {
+        for (const t of transforms) {
+          if (options.codemod && t.name !== options.codemod) continue;
+          if (t.meta?.codemodType === 'config') {
+            coreConfigCodemodNames.push(t.name);
+          }
         }
-        p.log.success('No codemods available for this version range.');
-        p.outro('Done');
-        return;
       }
+      const hasCoreConfigCodemod = coreConfigCodemodNames.length > 0;
 
       // Codemods explicitly excluded via --skip-codemod, matched by the same
       // identifier the run loop uses (core transform `t.name`, integration
@@ -363,7 +312,8 @@ export function registerUpgrade(program) {
       // execution time.
       const skipCodemods = new Set(options.skipCodemod ?? []);
 
-      // Count transforms (optional codemods only count when explicitly requested)
+      // Count CORE transforms (optional codemods only count when explicitly
+      // requested). Integration counts are added after discovery below.
       let totalTransforms = 0;
       let totalOptional = 0;
       for (const {transforms} of versionManifests) {
@@ -377,6 +327,159 @@ export function registerUpgrade(program) {
           }
         }
       }
+
+      // Ensure jscodeshift is available before running any codemod.
+      const ready = await ensureJscodeshift({
+        installDeps: options.installDeps,
+        silent: json,
+      });
+      if (!ready) {
+        if (json)
+          return jsonError(
+            'jscodeshift is required but could not be installed.',
+            undefined,
+            ERROR_CODES.ERR_DEP_MISSING,
+          );
+        p.outro('Aborted');
+        process.exitCode = 1;
+        return;
+      }
+
+      // STEP 3 — Run CORE codemods FIRST (before loading config). In --apply,
+      // core config codemods WRITE the repaired config to disk; in dry-run they
+      // only PREVIEW. This is what makes the v0.1.3 config codemod reachable on
+      // a config that the strict loader would otherwise reject.
+      const codemodResult = await runCodemods(versionManifests, {
+        apply: options.apply,
+        path: options.path,
+        codemod: options.codemod,
+        skipCodemods,
+        silent: json,
+      });
+
+      // STEP 4 — Load the consumer's config (STRICT validation; unchanged). On
+      // --apply this now sees the repaired config the core codemod just wrote.
+      // We need `hooks.postCodemod` and the configured integration specs from
+      // here. Wrap in a graceful dry-run catch (see below).
+      // Assigned inside the try below; every catch branch returns, so these
+      // are always set before any later read.
+      let integrations;
+      let postCodemodHooks;
+      let integrationVersionGroups;
+      try {
+        const project = await Project.load(process.cwd());
+        postCodemodHooks = project.config.hooks?.postCodemod ?? [];
+        const integrationSpecs = uniqueFiles([
+          ...(project.integrations ?? []),
+          ...(options.integration ?? []),
+        ]);
+        integrations = await loadIntegrations(integrationSpecs);
+      } catch (err) {
+        // GRACEFUL DRY-RUN CATCH. A config that fails strict validation is the
+        // EXPECTED, fixable case ONLY when we are in dry-run AND a pending core
+        // config codemod just PREVIEWED a change to the config — i.e. the very
+        // codemod that would repair it. (Merely having a config codemod in the
+        // range is not enough: it may be a no-op on this config, in which case
+        // the validation error is genuine and we must abort. A config codemod
+        // that THREW reports zero would-change files, so it also fails this
+        // gate and aborts below — preserving the strictness contract.) This is
+        // the reason this PR reorders the pipeline.
+        const codemodWouldFixConfig =
+          hasCoreConfigCodemod && (codemodResult?.totalFilesChanged ?? 0) > 0;
+        if (!options.apply && codemodWouldFixConfig) {
+          const codemodFlags = coreConfigCodemodNames
+            .map(name => `--codemod ${name}`)
+            .join(' ');
+          const suggestedCommand = `astryx upgrade --from ${currentVersion} ${codemodFlags} --apply`;
+          const guidance =
+            'Your astryx.config currently fails strict validation, but a pending ' +
+            'config codemod would repair it. This dry run previewed the fix without ' +
+            'writing. Re-run with --apply to apply it, or run just the config codemod(s) ' +
+            'now:';
+          if (json) {
+            return jsonOut('upgrade.status', {
+              status: 'config_fixable',
+              from: currentVersion,
+              to: targetVersion,
+              configError: err.message,
+              configCodemods: coreConfigCodemodNames,
+              suggestedCommand,
+              message: guidance,
+              note: 'Integrations are skipped in this preview; they will be processed on the --apply run.',
+            });
+          }
+          p.log.warn(guidance);
+          p.log.info(`  ${suggestedCommand}`);
+          p.log.info(
+            'Integrations are skipped in this preview; they will be processed on the --apply run.',
+          );
+          p.outro('Dry run complete');
+          return;
+        }
+        // Genuine config error (apply mode, OR dry-run with no pending core
+        // config codemod that would fix it): abort as before.
+        if (json)
+          return jsonError(
+            err.message,
+            undefined,
+            ERROR_CODES.ERR_INVALID_ARGUMENT,
+          );
+        p.log.error(err.message);
+        p.outro('Aborted');
+        process.exitCode = 1;
+        return;
+      }
+
+      if (!json && integrations.length > 0) {
+        p.log.info(
+          `Integrations: ${integrations.map(i => i.name ?? i.__spec).join(', ')}`,
+        );
+      }
+
+      // Non-blocking nudge: if any configured integration has validation
+      // issues, print one compact line to stderr pointing at
+      // validate-integration. Best-effort; suppressed in --json mode. This
+      // depends on integrations being loaded, so it lives after the successful
+      // config load (it is skipped on the graceful dry-run path above, where
+      // integrations were never loaded).
+      try {
+        await warnOnIntegrationIssues(integrations, {json});
+      } catch {
+        // Never let the nudge break the upgrade.
+      }
+
+      // STEP 5 — Discover + run INTEGRATION codemods (only reached on a
+      // successful config load). A broken integration (bad export, invalid
+      // schema, duplicate id, missing root) is a DEFINITION error: skip that
+      // integration's codemods and warn (via the nudge above), rather than
+      // hard-failing the upgrade. An EXECUTION-time failure (a transform
+      // throwing) is handled later by the codemod-error gate, which still
+      // aborts the upgrade.
+      const integrationCodemodsByVersion = new Map();
+      for (const integration of integrations) {
+        if (!integration?.codemods) continue;
+        try {
+          const byVersion = await discoverIntegrationCodemods([integration]);
+          for (const [version, list] of byVersion) {
+            const existing = integrationCodemodsByVersion.get(version);
+            if (existing) existing.push(...list);
+            else integrationCodemodsByVersion.set(version, [...list]);
+          }
+        } catch {
+          // Skip this integration's codemods; the validate-integration nudge
+          // above surfaces the underlying issue. Best-effort, non-blocking.
+        }
+      }
+      integrationVersionGroups = selectIntegrationCodemods(
+        integrationCodemodsByVersion,
+        currentVersion,
+        targetVersion,
+      );
+      const hasIntegrationCodemods = integrationVersionGroups.some(
+        g => g.codemods.length > 0,
+      );
+
+      // Add integration transforms to the run counts.
       for (const {codemods} of integrationVersionGroups) {
         for (const c of codemods) {
           if (options.codemod && c.id !== options.codemod) continue;
@@ -389,6 +492,21 @@ export function registerUpgrade(program) {
         }
       }
 
+      // No codemods at all for this range (neither core nor integration).
+      if (versionManifests.length === 0 && !hasIntegrationCodemods) {
+        if (json) {
+          return jsonOut('upgrade.status', {
+            status: 'no_codemods',
+            from: currentVersion,
+            to: targetVersion,
+          });
+        }
+        p.log.success('No codemods available for this version range.');
+        p.outro('Done');
+        return;
+      }
+
+      // A named `--codemod` that matched nothing (across core + integration).
       if (totalTransforms === 0 && totalOptional === 0) {
         const msg = `Codemod "${options.codemod}" not found. Use --list to see available codemods.`;
         if (json)
@@ -417,32 +535,6 @@ export function registerUpgrade(program) {
         agentDocsRefreshed: false,
       };
 
-      // Ensure jscodeshift is available
-      const ready = await ensureJscodeshift({
-        installDeps: options.installDeps,
-        silent: json,
-      });
-      if (!ready) {
-        if (json)
-          return jsonError(
-            'jscodeshift is required but could not be installed.',
-            undefined,
-            ERROR_CODES.ERR_DEP_MISSING,
-          );
-        p.outro('Aborted');
-        process.exitCode = 1;
-        return;
-      }
-
-      // Run codemods
-      const codemodResult = await runCodemods(versionManifests, {
-        apply: options.apply,
-        path: options.path,
-        codemod: options.codemod,
-        skipCodemods,
-        silent: json,
-      });
-
       // Run file-based integration codemods alongside the core registry
       // codemods (config codemods first, then code codemods), ordered by
       // version. Their results are merged into the receipt below.
@@ -459,6 +551,7 @@ export function registerUpgrade(program) {
           silent: json,
         });
       }
+
 
       // Merge core + integration codemod results into a single accounting so
       // hooks, receipts, and error gating see both.

--- a/packages/cli/src/types/upgrade.d.ts
+++ b/packages/cli/src/types/upgrade.d.ts
@@ -7,6 +7,7 @@
  * ------------------------------------------------------------------
  * xds --json upgrade --list                 -> upgrade.list
  * xds --json upgrade [--apply]              -> upgrade.run
+ * xds --json upgrade (status short-circuit) -> upgrade.status
  * (version detection failure)               -> CLIError
  */
 
@@ -32,4 +33,32 @@ export interface UpgradeRunResponse {
     depsUpdated: string[];
     agentDocsRefreshed: boolean;
   };
+}
+
+/**
+ * xds --json upgrade — short-circuit status results.
+ *
+ * - `up_to_date`: `--from` is >= installed target and `--force` was not passed.
+ * - `no_codemods`: no codemods (core or integration) apply to the range.
+ * - `config_fixable`: DRY-RUN ONLY. The consumer's astryx.config currently
+ *   fails strict validation, but a pending core CONFIG codemod (in the selected
+ *   range) would repair it. The dry run previews the fix without writing and
+ *   reports the exact command to apply it; integrations are skipped for the
+ *   preview (they will be processed on the `--apply` run).
+ */
+export interface UpgradeStatusResponse {
+  type: 'upgrade.status';
+  data:
+    | {status: 'up_to_date'; from: string; to: string}
+    | {status: 'no_codemods'; from: string; to: string}
+    | {
+        status: 'config_fixable';
+        from: string;
+        to: string;
+        configError: string;
+        configCodemods: string[];
+        suggestedCommand: string;
+        message: string;
+        note: string;
+      };
 }


### PR DESCRIPTION
## Problem

`astryx upgrade` called `Project.load(process.cwd())` **up front**, before running any codemods. `Project.load` strict-validates `astryx.config.*` (unknown keys rejected) and **throws** on failure. This created a chicken-and-egg:

A consumer whose config still has the legacy `layout.components` key — exactly what the v0.1.3 codemod `migrate-layout-components-to-experimental` exists to fix — gets their config rejected at load, so the upgrade aborts and the codemod that would repair it never runs.

## Fix

Reorder the upgrade pipeline so **core codemods run before the config is loaded**:

1. version detect (unchanged)
2. up-to-date check (unchanged)
3. **resolve + run CORE codemods** (registry `getTransformsBetween` → `runCodemods`). Config codemods read `astryx.config.*` directly via `runConfigCodemod`; code codemods scan `--path`. Neither needs the loaded config. In `--apply` the config codemod **writes** the repaired config; in dry-run it only **previews**.
4. **load config** via `Project.load` (strict validation unchanged), now wrapped in a graceful dry-run catch:
   - **dry-run + a pending core config codemod actually previewed a change** → don't abort. Report that the config currently fails validation but a pending config codemod would fix it, print the exact `astryx upgrade --from <from> --codemod <name> --apply` command to repair it, and finish the dry-run cleanly (exit 0). Integrations are skipped for the preview and noted as deferred to the `--apply` run.
   - **otherwise** (apply mode, or dry-run with no config codemod that would fix it — including a no-op or throwing codemod) → genuine config error, abort as before.
5. discover + run **integration** codemods (only on a successful config load); the integration-issue nudge moves here too.
6. postCodemod hooks + agent-docs refresh (unchanged, still last).

Config strictness is **not** loosened. The codemod-execution-error gate still aborts on a throwing transform.

## Tests

New `upgrade.config-ordering.test.mjs` (repo-local temp project + chdir):
- dry-run with legacy `layout.components` → reports the fixable status + suggested `--codemod ... --apply` command; exit 0; config not written; integrations skipped.
- `--apply` with the same config → core config codemod rewrites it to `experimental.xle.components`, strict load then succeeds, upgrade completes.
- dry-run with a genuinely invalid config (`integrations: 5`) and no fixing codemod → still aborts (exit nonzero).
- happy path (valid config, no config codemod) → unchanged.

All existing upgrade/runner/integration tests stay green.

## Before / after (manual smoke)

Config `export default { layout: { components: { KpiCard: '@/components/KpiCard' } } }`:

- `astryx upgrade --from 0.1.2` (dry-run): previews the fix, prints the fixable-config guidance + suggested command, exit 0 (no crash on the legacy key).
- `astryx upgrade --from 0.1.2 --apply`: rewrites the config to `experimental.xle.components`, completes.
