### PR TITLE
chore: enforce pnpm via preinstall guard

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,8 +33,10 @@ Download and install from https://nodejs.org
 ### pnpm
 
 Astryx uses [pnpm](https://pnpm.io/) as its package manager (declared in
-the `packageManager` field of `package.json`). The easiest way to install
-it is via [Corepack](https://nodejs.org/api/corepack.html), which ships
+the `packageManager` field of `package.json`, and enforced by a
+`preinstall` script — running `npm install` or `yarn install` will fail
+fast with a clear message). The easiest way to install it is via
+[Corepack](https://nodejs.org/api/corepack.html), which ships
 with Node.js:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ corepack enable
 pnpm install
 ```
 
+> Running `npm install` or `yarn install` will fail fast — the repo enforces pnpm via a `preinstall` script.
+
 ## License
 
 MIT

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "license": "MIT",
   "scripts": {
+    "preinstall": "npx -y only-allow pnpm",
     "build": "pnpm -F @astryxdesign/build build && pnpm -F @astryxdesign/core build && pnpm -F @astryxdesign/vega build && pnpm -F @astryxdesign/theme-neutral build && pnpm -F @astryxdesign/theme-matcha build && pnpm -F @astryxdesign/theme-stone build && pnpm -F @astryxdesign/theme-gothic build && pnpm -F @astryxdesign/theme-chocolate build && pnpm -F @astryxdesign/theme-y2k build && pnpm -F @astryxdesign/theme-butter build && pnpm bundle:cli-themes",
     "bundle:cli-themes": "node scripts/generate-cli-themes.mjs",
     "dev": "pnpm -F @astryxdesign/storybook dev",


### PR DESCRIPTION
## What

Adds a root `preinstall` script that runs [`only-allow pnpm`](https://github.com/pnpm/only-allow), so attempts to install with `npm` or `yarn` fail fast with a clear message instead of producing a broken `node_modules` (or an `ERESOLVE` dependency-tree error, which is the surface symptom today).

## Why

The repo already declares `packageManager: pnpm@10.34.1` in `package.json`, but that field is purely advisory — `npm` and `yarn` ignore it.

Recent example: a contributor on Windows ran `npm install` against the latest branch and hit `ERESOLVE` from a peer-dep conflict between `@modelcontextprotocol/sdk` and `mcp-handler` in `apps/docsite`. pnpm tolerates that conflict; npm rejects it. The user-visible error blames the deps, but the real issue is that we shouldn't be running npm in the first place.

With this PR, running npm/yarn fails immediately with the standard `only-allow` message:

```
Use "pnpm install" for installation in this project.
```

## How

- `package.json`: `"preinstall": "npx -y only-allow pnpm"`
- README + CONTRIBUTING: one-line note that the guard exists

`npx -y` keeps the implementation registry-only — no new entry in `devDependencies`, no lockfile churn. (If we want to avoid even the registry fetch, we could inline a small Node script — happy to switch if preferred.)

## Notes

- pnpm itself sets `npm_config_user_agent` so the guard is a no-op when invoked correctly.
- This does **not** address how someone gets pnpm in the first place — that's the README/Corepack docs question, which I'm splitting out into a separate PR for discussion (Node v25 no longer ships Corepack by default).

## Testing

Tested locally by running `npm install` against a minimal package.json carrying just the `preinstall` script — the script fires and the install aborts non-zero before any deps are resolved.
