### PR TITLE
fix(core): use rimraf instead of `rm -rf` in build script for Windows support

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -622,7 +622,7 @@
   ],
   "scripts": {
     "prepack": "pnpm build",
-    "build": "rm -rf dist && pnpm build:esm && tsc --project tsconfig.build.json && pnpm build:css && pnpm build:umd",
+    "build": "rimraf dist && pnpm build:esm && tsc --project tsconfig.build.json && pnpm build:css && pnpm build:umd",
     "build:esm": "babel src --out-dir dist --extensions '.ts,.tsx' --out-file-extension '.js' --ignore '**/*.test.ts,**/*.test.tsx,**/__tests__/**,**/*.perf.test.*,**/*.doc.mjs,**/*.d.ts,**/*.css,**/*.css.d.ts' --config-file ./babel.config.json",
     "build:css": "node ../../scripts/build-css.mjs",
     "build:umd": "node ../../scripts/build-umd.mjs",
@@ -648,6 +648,7 @@
     "@stylexjs/babel-plugin": "^0.19.0",
     "@testing-library/dom": "^10.0.0",
     "@testing-library/jest-dom": "^6.6.0",
-    "@testing-library/react": "^16.3.2"
+    "@testing-library/react": "^16.3.2",
+    "rimraf": "^6.0.1"
   }
 }


### PR DESCRIPTION
## What

Replace `rm -rf dist` with `rimraf dist` in `packages/core`'s `build` script, and add `rimraf` as a devDependency.

## Why

The `build` script in `@astryxdesign/core` currently starts with `rm -rf dist`, which fails on Windows cmd/PowerShell:

```
> @astryxdesign/core@0.1.1 build C:\Users\alex-\dev\astryx\packages\core
> rm -rf dist && pnpm build:esm && tsc --project tsconfig.build.json && pnpm build:css && pnpm build:umd

'rm' is not recognized as an internal or external command,
operable program or batch file.
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  @astryxdesign/core@0.1.1 build
```

This is the **only** `rm -rf` in any package script across the entire repo, so it's a one-line fix:

```bash
$ rg -nE 'rm -rf' --type=json packages apps
packages/core/package.json:625:    "build": "rm -rf dist && pnpm build:esm && ..."
```

## How

- `packages/core/package.json`:
  - `rm -rf dist` → `rimraf dist`
  - Add `"rimraf": "^6.0.1"` to `devDependencies`

## Testing

- `pnpm -F @astryxdesign/core build` on macOS still produces the same `dist/` output (verified locally).
- Windows path would now invoke the `rimraf` JS binary instead of relying on a POSIX `rm`.

## Notes

`rimraf` is the npm-ecosystem standard for cross-platform recursive delete (~50KB, no runtime deps relevant to the build). Alternatives considered:
- Inline `node -e "require('fs').rmSync(...)"` — works but ugly, and quote-escaping varies across cmd.exe/PowerShell/sh.
- Move the clean into the existing JS build scripts (`scripts/build-css.mjs` etc.) — bigger surface area for a small problem.
