### PR TITLE
docs(SelectableCard): replace em-dash with comma in block copy

### DIFF
--- a/packages/core/src/SelectableCard/SelectableCard.doc.mjs
+++ b/packages/core/src/SelectableCard/SelectableCard.doc.mjs
@@ -46,7 +46,7 @@ export const docs = {
         props: {gap: 1},
         children: [
           {__element: 'XDSHeading', props: {level: 3}, children: 'Pro plan'},
-          {__element: 'XDSText', props: {type: 'body'}, children: '$29/month — unlimited projects and priority support.'},
+          {__element: 'XDSText', props: {type: 'body'}, children: '$29/month, unlimited projects and priority support.'},
         ],
       },
     },


### PR DESCRIPTION
## What

The pricing copy in the SelectableCard block template used an em-dash:
`'$29/month — unlimited projects and priority support.'`. Recast with a
comma to match the prose style guide (check 17 / A1). Prose only, no
meaning change, no other edits to the file.

## Checklist
- [x] `pnpm --filter @astryxdesign/core typecheck:docs` passes
- [x] `npx tsc --project packages/cli/tsconfig.template-docs.json --noEmit` passes
- [x] `.doc.mjs` parse-checked
- [x] CLI `component SelectableCard` renders clean

---
Night Watch — Doc Reviewer