### PR TITLE
docs(dense): restore bestPractices parity for useLayer

### DIFF
--- a/packages/core/src/Layer/useLayer.doc.mjs
+++ b/packages/core/src/Layer/useLayer.doc.mjs
@@ -145,6 +145,11 @@ export const docsDense = {
         description: 'Build on Popover/HoverCard/Tooltip for common overlay patterns.',
       },
       {
+        guidance: true,
+        description:
+          'Rely on the Popover API top layer to escape clipping/stacking: render inline (no portal) to inherit the trigger theme cascade and natural focus order. Use `as: "span"` when the layer must be valid in inline contexts like a paragraph.',
+      },
+      {
         guidance: false,
         description:
           'Implement ARIA directly in Layer unless you own full accessibility behavior.',


### PR DESCRIPTION
## What

The `docsDense` overlay for `useLayer` listed 3 bestPractices while the
English `docs` listed 4. The missing guidance was the third English
bullet about the Popover API top layer (render inline, no portal, so it
inherits the trigger theme cascade and focus order; use `as: "span"` for
inline contexts). Because the loader falls back per-field, dense CLI
output silently dropped that guidance.

Added a compressed version at the matching position with `guidance: true`,
restoring 1:1 count and order parity. No other bullets changed.

## Checklist
- [x] `pnpm --filter @astryxdesign/core typecheck:docs` passes
- [x] `npx tsc --project packages/cli/tsconfig.template-docs.json --noEmit` passes
- [x] `node .github/scripts/api-cli-parity-test.mjs --no-baseline` passes (307/307)
- [x] CLI component tests pass (70/70)
- [x] `astryx component useLayer --lang dense` shows all 4 bestPractices, correct Do/Don't flags

---
Night Watch — Doc Reviewer